### PR TITLE
Fix worldgen doubleshifting in ModLoaderMP until SDK fixes it.

### DIFF
--- a/forge/patches/minecraft_server/net/minecraft/src/ModLoader.java.patch
+++ b/forge/patches/minecraft_server/net/minecraft/src/ModLoader.java.patch
@@ -105,6 +105,20 @@
              Iterator var3 = inGameHooks.entrySet().iterator();
  
              while (var3.hasNext())
+@@ -863,11 +889,11 @@
+ 
+             if (var0 instanceof ChunkProviderGenerate)
+             {
+-                var10.generateSurface(var3, var4, var1 << 4, var2 << 4);
++                var10.generateSurface(var3, var4, var1, var2);
+             }
+             else if (var0 instanceof ChunkProviderHell)
+             {
+-                var10.generateNether(var3, var4, var1 << 4, var2 << 4);
++                var10.generateNether(var3, var4, var1, var2);
+             }
+         }
+     }
 @@ -1111,6 +1137,12 @@
          }
      }


### PR DESCRIPTION
This means mods can generate surface and nether in SMP again. It's doubleshifting the chunk coords, so worlds end up with zeros everywhere. It's a bug in MLMP, but would be helpful to everyone generating world, including forge mods.
