### PR TITLE
Fixed Bug in EntityRenderer

### DIFF
--- a/forge/patches/minecraft/net/minecraft/src/EntityRenderer.java.patch
+++ b/forge/patches/minecraft/net/minecraft/src/EntityRenderer.java.patch
@@ -1,5 +1,5 @@
---- ../src_base/minecraft/net/minecraft/src/EntityRenderer.java	0000-00-00 00:00:00.000000000 -0000
-+++ ../src_work/minecraft/net/minecraft/src/EntityRenderer.java	0000-00-00 00:00:00.000000000 -0000
+--- ../src_base/minecraft/net/minecraft/src/EntityRenderer.java 2012-03-22 21:14:24.000000000 -0400
++++ ../src_work/minecraft/net/minecraft/src/EntityRenderer.java	2012-03-22 21:23:24.000000000 -0400
 @@ -5,6 +5,8 @@
  import java.util.List;
  import java.util.Random;
@@ -9,7 +9,30 @@
  import org.lwjgl.input.Mouse;
  import org.lwjgl.opengl.Display;
  import org.lwjgl.opengl.GL11;
-@@ -1106,8 +1108,11 @@
+@@ -287,8 +289,13 @@
+      */
+     private void updateFovModifierHand()
+     {
++    	if(mc.renderViewEntity instanceof EntityPlayerSP){               
+         EntityPlayerSP var1 = (EntityPlayerSP)this.mc.renderViewEntity;
+         this.fovMultiplierTemp = var1.getFOVMultiplier();
++    	}
++    	else{
++    	this.fovMultiplierTemp = mc.thePlayer.getFOVMultiplier();
++    	}
+         this.fovModifierHandPrev = this.fovModifierHand;
+         this.fovModifierHand += (this.fovMultiplierTemp - this.fovModifierHand) * 0.5F;
+     }
+@@ -304,7 +311,7 @@
+         }
+         else
+         {
+-            EntityPlayer var3 = (EntityPlayer)this.mc.renderViewEntity;
++            EntityLiving var3 = (EntityLiving)this.mc.renderViewEntity; //CHANGED
+             float var4 = 70.0F;
+ 
+             if (par2)
+@@ -1106,8 +1113,11 @@
                      var20 = (EntityPlayer)var4;
                      GL11.glDisable(GL11.GL_ALPHA_TEST);
                      Profiler.endStartSection("outline");
@@ -23,7 +46,7 @@
                      GL11.glEnable(GL11.GL_ALPHA_TEST);
                  }
              }
-@@ -1171,8 +1176,12 @@
+@@ -1171,8 +1181,12 @@
                  var20 = (EntityPlayer)var4;
                  GL11.glDisable(GL11.GL_ALPHA_TEST);
                  Profiler.endStartSection("outline");
@@ -38,7 +61,7 @@
                  GL11.glEnable(GL11.GL_ALPHA_TEST);
              }
  
-@@ -1196,6 +1205,9 @@
+@@ -1196,6 +1210,9 @@
                  this.setupFog(1, par1);
                  GL11.glPopMatrix();
              }


### PR DESCRIPTION
Fixed patch properly this time, ought to work perfectly. This will fix it so that the game doesn't crash when setting renderViewEntity to something other than an instance of EntityPlayerSP
