### PR TITLE
New callback to allow a ridden entity to specify whether the rider entity uses a sitting position or not

### DIFF
--- a/forge/patches/minecraft/net/minecraft/src/Entity.java.patch
+++ b/forge/patches/minecraft/net/minecraft/src/Entity.java.patch
@@ -53,3 +53,22 @@
          this.readEntityFromNBT(par1NBTTagCompound);
      }
  
+@@ -1714,8 +1739,17 @@
+     */
+    public boolean isRiding()
+    {
+-        return this.ridingEntity != null || this.getFlag(2);
++        return (this.ridingEntity != null && this.ridingEntity.shouldRiderSit()) || this.getFlag(2);
+    }
++
++   /**
++    * Forge: Return false to prevent an entity that is mounted to this entity from playing the 'sitting' animation.
++    * Client-side only as it only deals with the model rendering.
++    */
++   public boolean shouldRiderSit()
++   {
++        return true;
++   }
+
+    /**
+     * Returns if this entity is sneaking.


### PR DESCRIPTION
This is a client-side model related code change only.
