### PR TITLE
ItemStack-sensitive fuel

### DIFF
--- a/forge/forge_client/src/net/minecraft/src/forge/ModLoaderFuelHandler.java
+++ b/forge/forge_client/src/net/minecraft/src/forge/ModLoaderFuelHandler.java
@@ -1,0 +1,23 @@
+/**
+ * This software is provided under the terms of the Minecraft Forge Public
+ * License v1.0.
+ */
+
+package net.minecraft.src.forge;
+
+import net.minecraft.src.ItemStack;
+import net.minecraft.src.ModLoader;
+
+public class ModLoaderFuelHandler implements IFuelHandler
+{
+	@Override
+	public int onUseFuel(ItemStack stack)
+	{
+		return ModLoader.addAllFuel(stack.itemID, stack.getItemDamage());
+	}
+	
+	static
+	{
+		MinecraftForge.registerFuelHandler(new ModLoaderFuelHandler());
+	}
+}

--- a/forge/forge_common/net/minecraft/src/forge/ForgeHooks.java
+++ b/forge/forge_common/net/minecraft/src/forge/ForgeHooks.java
@@ -322,6 +322,17 @@ public class ForgeHooks
         }
     }
     static LinkedList<ISaveEventHandler> saveHandlers = new LinkedList<ISaveEventHandler>();
+    
+    public static int onUseFuel(ItemStack stack)
+    {
+    	for (IFuelHandler handler : fuelHandlers)
+    	{
+    		int fv = handler.onUseFuel(stack);
+    		if (fv > 0) return fv;
+    	}
+    	return 0;
+    }
+    static LinkedList<IFuelHandler> fuelHandlers = new LinkedList<IFuelHandler>();
 
     // Plant Management
     // ------------------------------------------------------------

--- a/forge/forge_common/net/minecraft/src/forge/IFuelHandler.java
+++ b/forge/forge_common/net/minecraft/src/forge/IFuelHandler.java
@@ -1,0 +1,16 @@
+/**
+ * This software is provided under the terms of the Minecraft Forge Public
+ * License v1.0.
+ */
+
+package net.minecraft.src.forge;
+
+import net.minecraft.src.ItemStack;
+
+public interface IFuelHandler
+{
+    /** Called when a furnace gains fuel to get its burn time.
+     * @return fuel burn time in ticks or 0 to continue processing
+     */
+    public int onUseFuel(ItemStack stack);
+}

--- a/forge/forge_common/net/minecraft/src/forge/MinecraftForge.java
+++ b/forge/forge_common/net/minecraft/src/forge/MinecraftForge.java
@@ -137,6 +137,15 @@ public class MinecraftForge
     {
         ForgeHooks.saveHandlers.add(handler);
     }
+    
+    /**
+     * Register a new Fuel handler
+     * @param handler The handler to be registered
+     */
+    public static void registerFuelHandler(IFuelHandler handler)
+    {
+    	ForgeHooks.fuelHandlers.add(handler);
+    }
 
     /**
      * This is not supposed to be called outside of Minecraft internals.

--- a/forge/patches/minecraft/net/minecraft/src/TileEntityFurnace.java.patch
+++ b/forge/patches/minecraft/net/minecraft/src/TileEntityFurnace.java.patch
@@ -1,16 +1,17 @@
 --- ../src_base/minecraft/net/minecraft/src/TileEntityFurnace.java	0000-00-00 00:00:00.000000000 -0000
 +++ ../src_work/minecraft/net/minecraft/src/TileEntityFurnace.java	0000-00-00 00:00:00.000000000 -0000
-@@ -1,6 +1,8 @@
+@@ -1,6 +1,9 @@
  package net.minecraft.src;
  
 -public class TileEntityFurnace extends TileEntity implements IInventory
++import net.minecraft.src.forge.ForgeHooks;
 +import net.minecraft.src.forge.ISidedInventory;
 +
 +public class TileEntityFurnace extends TileEntity implements IInventory, ISidedInventory
  {
      /**
       * The ItemStacks that hold the items currently being used in the furnace
-@@ -279,8 +281,12 @@
+@@ -279,8 +282,12 @@
          }
          else
          {
@@ -25,7 +26,7 @@
          }
      }
  
-@@ -291,13 +297,13 @@
+@@ -291,13 +298,13 @@
      {
          if (this.canSmelt())
          {
@@ -41,7 +42,16 @@
              {
                  this.furnaceItemStacks[2].stackSize += var1.stackSize;
              }
-@@ -351,4 +357,18 @@
+@@ -331,7 +338,7 @@
+         else
+         {
+             int var1 = par1ItemStack.getItem().shiftedIndex;
+-            return var1 < 256 && Block.blocksList[var1].blockMaterial == Material.wood ? 300 : (var1 == Item.stick.shiftedIndex ? 100 : (var1 == Item.coal.shiftedIndex ? 1600 : (var1 == Item.bucketLava.shiftedIndex ? 20000 : (var1 == Block.sapling.blockID ? 100 : (var1 == Item.blazeRod.shiftedIndex ? 2400 : ModLoader.addAllFuel(par1ItemStack.itemID, par1ItemStack.getItemDamage()))))));
++            return var1 < 256 && Block.blocksList[var1].blockMaterial == Material.wood ? 300 : (var1 == Item.stick.shiftedIndex ? 100 : (var1 == Item.coal.shiftedIndex ? 1600 : (var1 == Item.bucketLava.shiftedIndex ? 20000 : (var1 == Block.sapling.blockID ? 100 : (var1 == Item.blazeRod.shiftedIndex ? 2400 : ForgeHooks.onUseFuel(par1ItemStack))))));
+         }
+     }
+ 
+@@ -351,4 +358,18 @@
      public void openChest() {}
  
      public void closeChest() {}

--- a/forge/patches/minecraft_server/net/minecraft/src/TileEntityFurnace.java.patch
+++ b/forge/patches/minecraft_server/net/minecraft/src/TileEntityFurnace.java.patch
@@ -1,17 +1,18 @@
 --- ../src_base/minecraft_server/net/minecraft/src/TileEntityFurnace.java	0000-00-00 00:00:00.000000000 -0000
 +++ ../src_work/minecraft_server/net/minecraft/src/TileEntityFurnace.java	0000-00-00 00:00:00.000000000 -0000
-@@ -2,7 +2,9 @@
+@@ -2,7 +2,10 @@
  
  import cpw.mods.fml.server.FMLServerHandler;
  
 -public class TileEntityFurnace extends TileEntity implements IInventory
++import net.minecraft.src.forge.ForgeHooks;
 +import net.minecraft.src.forge.ISidedInventory;
 +
 +public class TileEntityFurnace extends TileEntity implements IInventory, ISidedInventory
  {
      /**
       * The ItemStacks that hold the items currently being used in the furnace
-@@ -251,8 +253,12 @@
+@@ -251,8 +254,12 @@
          }
          else
          {
@@ -26,7 +27,7 @@
          }
      }
  
-@@ -263,13 +269,13 @@
+@@ -263,13 +270,13 @@
      {
          if (this.canSmelt())
          {
@@ -42,7 +43,16 @@
              {
                  ++this.furnaceItemStacks[2].stackSize;
              }
-@@ -316,4 +322,18 @@
+@@ -296,7 +303,7 @@
+         else
+         {
+             int var1 = par1ItemStack.getItem().shiftedIndex;
+-            return var1 < 256 && Block.blocksList[var1].blockMaterial == Material.wood ? 300 : (var1 == Item.stick.shiftedIndex ? 100 : (var1 == Item.coal.shiftedIndex ? 1600 : (var1 == Item.bucketLava.shiftedIndex ? 20000 : (var1 == Block.sapling.blockID ? 100 : (var1 == Item.blazeRod.shiftedIndex ? 2400 : FMLServerHandler.instance().fuelLookup(var1, par1ItemStack.getItemDamage()))))));
++            return var1 < 256 && Block.blocksList[var1].blockMaterial == Material.wood ? 300 : (var1 == Item.stick.shiftedIndex ? 100 : (var1 == Item.coal.shiftedIndex ? 1600 : (var1 == Item.bucketLava.shiftedIndex ? 20000 : (var1 == Block.sapling.blockID ? 100 : (var1 == Item.blazeRod.shiftedIndex ? 2400 : ForgeHooks.onUseFuel(par1ItemStack))))));
+         }
+     }
+ 
+@@ -316,4 +323,18 @@
      public void openChest() {}
  
      public void closeChest() {}


### PR DESCRIPTION
Requested by IC2 due to fuel cans using NBT data. Works as an improvement to ModLoader's addFuel, which is ID and metadata sensitive.

Most likely not to apply automatically server-side due to FML.
