### PR TITLE
onBlockChange hook 

### DIFF
--- a/forge/forge_common/net/minecraft/src/forge/ForgeHooks.java
+++ b/forge/forge_common/net/minecraft/src/forge/ForgeHooks.java
@@ -168,7 +168,20 @@ public class ForgeHooks
         return cont;
     }
     static LinkedList<IPickupHandler> pickupHandlers = new LinkedList<IPickupHandler>();
-    
+
+    public static boolean onBlockChange(World w, int x, int y, int z, int blockID, int metadata)
+    {
+        for (IBlockChangeHandler handler : blockChangeHandlers)
+        {
+            if (!handler.onBlockChange(w, x, y, z, blockID, metadata))
+            {
+                return true;
+            }
+        }
+        return false;
+    }
+    static LinkedList<IBlockChangeHandler> blockChangeHandlers = new LinkedList<IBlockChangeHandler>();
+
     public static void addActiveChunks(World world, Set<ChunkCoordIntPair> chunkList)
     {
         for(IChunkLoadHandler loader : chunkLoadHandlers)

--- a/forge/forge_common/net/minecraft/src/forge/IBlockChangeHandler.java
+++ b/forge/forge_common/net/minecraft/src/forge/IBlockChangeHandler.java
@@ -1,0 +1,23 @@
+
+package net.minecraft.src.forge;
+
+import net.minecraft.src.World;
+
+public interface IBlockChangeHandler
+{
+
+    /**
+     * Raised when a block or a block's metadata is being altered You can
+     * prevent the block from changing by returning false
+     *
+     * @param w The world object where the block is being set
+     * @param x The x coordination on which the block is being set
+     * @param y The y coordination on which the block is being set
+     * @param z The z coordination on which the block is being set
+     * @param blockID The id of the new block (-1 if only the metadata was
+     * changed)
+     * @param metadata The new metadata for the block
+     * @return True if processing should continue.
+     */
+    public boolean onBlockChange(World w, int x, int y, int z, int blockID, int metadata);
+}

--- a/forge/forge_common/net/minecraft/src/forge/MinecraftForge.java
+++ b/forge/forge_common/net/minecraft/src/forge/MinecraftForge.java
@@ -121,6 +121,15 @@ public class MinecraftForge
     }
 
     /**
+     * Registers a new onBlockChange event handler
+     * @param handler The Handler to be registered
+     */
+    public static void registerSetBlockHandler(IBlockChangeHandler handler)
+    {
+        ForgeHooks.blockChangeHandlers.add(handler);
+    }
+    
+    /**
      * Register a new entity interact handler.
      * @param handler The Handler to be registered
      */

--- a/forge/patches/minecraft/net/minecraft/src/World.java.patch
+++ b/forge/patches/minecraft/net/minecraft/src/World.java.patch
@@ -70,7 +70,92 @@
      }
  
      /**
-@@ -1453,6 +1468,12 @@
+@@ -638,6 +653,15 @@
+      */
+     public boolean setBlockAndMetadata(int par1, int par2, int par3, int par4, int par5)
+     {
++        return setBlockAndMetadata(par1, par2, par3, par4, par5, true);
++    }
++
++    /**
++     * The triggerHook boolen is to be used from machines that don't want to
++     * trigger the onBlockChange forge hook
++     */
++    public boolean setBlockAndMetadata(int par1, int par2, int par3, int par4, int par5, boolean triggerHook)
++    {
+         if (par1 >= -30000000 && par3 >= -30000000 && par1 < 30000000 && par3 < 30000000)
+         {
+             if (par2 < 0)
+@@ -650,6 +674,11 @@
+             }
+             else
+             {
++                if (triggerHook && ForgeHooks.onBlockChange(this, par1, par2, par3, par4, par5))
++                {
++                    return false;
++                }
++
+                 Chunk var6 = this.getChunkFromChunkCoords(par1 >> 4, par3 >> 4);
+                 boolean var7 = var6.setBlockIDWithMetadata(par1 & 15, par2, par3 & 15, par4, par5);
+                 Profiler.startSection("checkLight");
+@@ -669,6 +698,15 @@
+      */
+     public boolean setBlock(int par1, int par2, int par3, int par4)
+     {
++        return setBlock(par1, par2, par3, par4, true);
++    }
++
++    /**
++     * The triggerHook boolen is to be used from machines that don't want to
++     * trigger the onBlockChange forge hook
++     */
++    public boolean setBlock(int par1, int par2, int par3, int par4, boolean triggerHook)
++    {
+         if (par1 >= -30000000 && par3 >= -30000000 && par1 < 30000000 && par3 < 30000000)
+         {
+             if (par2 < 0)
+@@ -681,6 +719,11 @@
+             }
+             else
+             {
++                if (triggerHook && ForgeHooks.onBlockChange(this, par1, par2, par3, par4, 0))
++                {
++                    return false;
++                }
++
+                 Chunk var5 = this.getChunkFromChunkCoords(par1 >> 4, par3 >> 4);
+                 boolean var6 = var5.setBlockID(par1 & 15, par2, par3 & 15, par4);
+                 Profiler.startSection("checkLight");
+@@ -758,6 +801,16 @@
+      */
+     public boolean setBlockMetadata(int par1, int par2, int par3, int par4)
+     {
++        return setBlockMetadata(par1, par2, par3, par4, true);
++    }
++
++    /**
++     * The triggerHook boolen is to be used from machines that don't want to
++     * trigger the onBlockChange forge hook
++     */
++
++    public boolean setBlockMetadata(int par1, int par2, int par3, int par4, boolean triggerHook)
++    {
+         if (par1 >= -30000000 && par3 >= -30000000 && par1 < 30000000 && par3 < 30000000)
+         {
+             if (par2 < 0)
+@@ -770,6 +823,11 @@
+             }
+             else
+             {
++                if (triggerHook && ForgeHooks.onBlockChange(this, par1, par2, par3, -1, par4))
++                {
++                    return false;
++                }
++
+                 Chunk var5 = this.getChunkFromChunkCoords(par1 >> 4, par3 >> 4);
+                 par1 &= 15;
+                 par3 &= 15;
+@@ -1453,6 +1511,12 @@
       */
      public void playSoundAtEntity(Entity par1Entity, String par2Str, float par3, float par4)
      {
@@ -83,7 +168,7 @@
          for (int var5 = 0; var5 < this.worldAccesses.size(); ++var5)
          {
              ((IWorldAccess)this.worldAccesses.get(var5)).playSound(par2Str, par1Entity.posX, par1Entity.posY - (double)par1Entity.yOffset, par1Entity.posZ, par3, par4);
-@@ -2068,7 +2089,7 @@
+@@ -2068,7 +2132,7 @@
  
                      if (var7 != null)
                      {
@@ -92,7 +177,7 @@
                      }
                  }
              }
-@@ -2078,6 +2099,10 @@
+@@ -2078,6 +2142,10 @@
  
          if (!this.entityRemoval.isEmpty())
          {
@@ -103,7 +188,7 @@
              this.loadedTileEntityList.removeAll(this.entityRemoval);
              this.entityRemoval.clear();
          }
-@@ -2098,18 +2123,18 @@
+@@ -2098,18 +2166,18 @@
                      {
                          this.loadedTileEntityList.add(var8);
                      }
@@ -126,18 +211,18 @@
                  }
              }
  
-@@ -2122,13 +2147,13 @@
+@@ -2122,13 +2190,13 @@
  
      public void addTileEntity(Collection par1Collection)
      {
 -        if (this.scanningTileEntities)
-+        List dest = scanningTileEntities ? addedTileEntityList : loadedTileEntityList;
-+        for(Object entity : par1Collection) 
-         {
+-        {
 -            this.addedTileEntityList.addAll(par1Collection);
 -        }
 -        else
--        {
++        List dest = scanningTileEntities ? addedTileEntityList : loadedTileEntityList;
++        for(Object entity : par1Collection) 
+         {
 -            this.loadedTileEntityList.addAll(par1Collection);
 +            if(((TileEntity)entity).canUpdate())
 +            {
@@ -146,7 +231,7 @@
          }
      }
  
-@@ -2150,7 +2175,7 @@
+@@ -2150,7 +2218,7 @@
          int var4 = MathHelper.floor_double(par1Entity.posZ);
          byte var5 = 32;
  
@@ -155,7 +240,7 @@
          {
              par1Entity.lastTickPosX = par1Entity.posX;
              par1Entity.lastTickPosY = par1Entity.posY;
-@@ -2327,7 +2352,14 @@
+@@ -2327,7 +2395,14 @@
                          if (var11 == Block.fire.blockID || var11 == Block.lavaMoving.blockID || var11 == Block.lavaStill.blockID)
                          {
                              return true;
@@ -171,7 +256,7 @@
                      }
                  }
              }
-@@ -2631,25 +2663,19 @@
+@@ -2631,25 +2706,19 @@
       */
      public void setBlockTileEntity(int par1, int par2, int par3, TileEntity par4TileEntity)
      {
@@ -209,7 +294,7 @@
          }
      }
  
-@@ -2658,27 +2684,10 @@
+@@ -2658,27 +2727,10 @@
       */
      public void removeBlockTileEntity(int par1, int par2, int par3)
      {
@@ -240,7 +325,7 @@
          }
      }
  
-@@ -2704,7 +2713,8 @@
+@@ -2704,7 +2756,8 @@
       */
      public boolean isBlockNormalCube(int par1, int par2, int par3)
      {
@@ -250,7 +335,7 @@
      }
  
      /**
-@@ -2720,7 +2730,7 @@
+@@ -2720,7 +2773,7 @@
              if (var5 != null && !var5.isEmpty())
              {
                  Block var6 = Block.blocksList[this.getBlockId(par1, par2, par3)];
@@ -259,7 +344,7 @@
              }
              else
              {
-@@ -2985,6 +2995,7 @@
+@@ -2985,6 +3038,7 @@
                  }
              }
          }
@@ -267,7 +352,7 @@
  
          Profiler.endSection();
  
-@@ -3308,7 +3319,7 @@
+@@ -3308,7 +3362,7 @@
  
      private int computeBlockLightValue(int par1, int par2, int par3, int par4, int par5, int par6)
      {
@@ -276,7 +361,7 @@
          int var8 = this.getSavedLightValue(EnumSkyBlock.Block, par2 - 1, par3, par4) - par6;
          int var9 = this.getSavedLightValue(EnumSkyBlock.Block, par2 + 1, par3, par4) - par6;
          int var10 = this.getSavedLightValue(EnumSkyBlock.Block, par2, par3 - 1, par4) - par6;
-@@ -3668,10 +3679,10 @@
+@@ -3668,10 +3722,10 @@
      public List getEntitiesWithinAABBExcludingEntity(Entity par1Entity, AxisAlignedBB par2AxisAlignedBB)
      {
          this.entitiesWithinAABBExcludingEntity.clear();
@@ -291,7 +376,7 @@
  
          for (int var7 = var3; var7 <= var4; ++var7)
          {
-@@ -3692,10 +3703,10 @@
+@@ -3692,10 +3746,10 @@
       */
      public List getEntitiesWithinAABB(Class par1Class, AxisAlignedBB par2AxisAlignedBB)
      {
@@ -306,7 +391,7 @@
          ArrayList var7 = new ArrayList();
  
          for (int var8 = var3; var8 <= var4; ++var8)
-@@ -3840,7 +3851,10 @@
+@@ -3840,7 +3894,10 @@
              {
                  var8 = null;
              }
@@ -318,7 +403,7 @@
              return par1 > 0 && var8 == null && var9.canPlaceBlockOnSide(this, par2, par3, par4, par6);
          }
      }
-@@ -4449,4 +4463,39 @@
+@@ -4449,4 +4506,39 @@
      {
          return this.worldInfo.getTerrainType() == WorldType.FLAT ? 0.0D : 63.0D;
      }

--- a/forge/patches/minecraft_server/net/minecraft/src/World.java.patch
+++ b/forge/patches/minecraft_server/net/minecraft/src/World.java.patch
@@ -53,7 +53,92 @@
      }
  
      /**
-@@ -1604,7 +1616,7 @@
+@@ -442,6 +454,15 @@
+      */
+     public boolean setBlockAndMetadata(int par1, int par2, int par3, int par4, int par5)
+     {
++        return setBlockAndMetadata(par1, par2, par3, par4, par5, true);
++    }
++
++    /**
++     * The triggerHook boolen is to be used from machines that don't want to
++     * trigger the onBlockChange forge hook
++     */
++    public boolean setBlockAndMetadata(int par1, int par2, int par3, int par4, int par5, boolean triggerHook)
++    {
+         if (par1 >= -30000000 && par3 >= -30000000 && par1 < 30000000 && par3 < 30000000)
+         {
+             if (par2 < 0)
+@@ -454,6 +475,11 @@
+             }
+             else
+             {
++                if (triggerHook && ForgeHooks.onBlockChange(this, par1, par2, par3, par4, par5))
++                {
++                    return false;
++                }
++
+                 Chunk var6 = this.getChunkFromChunkCoords(par1 >> 4, par3 >> 4);
+                 boolean var7 = var6.setBlockIDWithMetadata(par1 & 15, par2, par3 & 15, par4, par5);
+                 Profiler.startSection("checkLight");
+@@ -473,6 +499,15 @@
+      */
+     public boolean setBlock(int par1, int par2, int par3, int par4)
+     {
++        return setBlock(par1, par2, par3, par4, true);
++    }
++
++    /**
++     * The triggerHook boolen is to be used from machines that don't want to
++     * trigger the onBlockChange forge hook
++     */
++    public boolean setBlock(int par1, int par2, int par3, int par4, boolean triggerHook)
++    {
+         if (par1 >= -30000000 && par3 >= -30000000 && par1 < 30000000 && par3 < 30000000)
+         {
+             if (par2 < 0)
+@@ -485,6 +520,11 @@
+             }
+             else
+             {
++                if (triggerHook && ForgeHooks.onBlockChange(this, par1, par2, par3, par4, 0))
++                {
++                    return false;
++                }
++
+                 Chunk var5 = this.getChunkFromChunkCoords(par1 >> 4, par3 >> 4);
+                 boolean var6 = var5.setBlockID(par1 & 15, par2, par3 & 15, par4);
+                 Profiler.startSection("checkLight");
+@@ -562,6 +602,16 @@
+      */
+     public boolean setBlockMetadata(int par1, int par2, int par3, int par4)
+     {
++        return setBlockMetadata(par1, par2, par3, par4, true);
++    }
++
++    /**
++     * The triggerHook boolen is to be used from machines that don't want to
++     * trigger the onBlockChange forge hook
++     */
++
++    public boolean setBlockMetadata(int par1, int par2, int par3, int par4, boolean triggerHook)
++    {
+         if (par1 >= -30000000 && par3 >= -30000000 && par1 < 30000000 && par3 < 30000000)
+         {
+             if (par2 < 0)
+@@ -574,6 +624,11 @@
+             }
+             else
+             {
++                if (triggerHook && ForgeHooks.onBlockChange(this, par1, par2, par3, -1, par4))
++                {
++                    return false;
++                }
++
+                 Chunk var5 = this.getChunkFromChunkCoords(par1 >> 4, par3 >> 4);
+                 par1 &= 15;
+                 par3 &= 15;
+@@ -1604,7 +1659,7 @@
  
                      if (var7 != null)
                      {
@@ -62,7 +147,7 @@
                      }
                  }
              }
-@@ -1614,6 +1626,10 @@
+@@ -1614,6 +1669,10 @@
  
          if (!this.entityRemoval.isEmpty())
          {
@@ -73,7 +158,7 @@
              this.loadedTileEntityList.removeAll(this.entityRemoval);
              this.entityRemoval.clear();
          }
-@@ -1634,14 +1650,16 @@
+@@ -1634,14 +1693,16 @@
                      {
                          this.loadedTileEntityList.add(var8);
                      }
@@ -92,7 +177,7 @@
                          }
                      }
  
-@@ -1658,13 +1676,13 @@
+@@ -1658,13 +1719,13 @@
  
      public void addTileEntity(Collection par1Collection)
      {
@@ -112,7 +197,7 @@
          }
      }
  
-@@ -1686,7 +1704,7 @@
+@@ -1686,7 +1747,7 @@
          int var4 = MathHelper.floor_double(par1Entity.posZ);
          byte var5 = 32;
  
@@ -121,7 +206,7 @@
          {
              par1Entity.lastTickPosX = par1Entity.posX;
              par1Entity.lastTickPosY = par1Entity.posY;
-@@ -1909,6 +1927,13 @@
+@@ -1909,6 +1970,13 @@
                          if (var11 == Block.fire.blockID || var11 == Block.lavaMoving.blockID || var11 == Block.lavaStill.blockID)
                          {
                              return true;
@@ -135,7 +220,7 @@
                          }
                      }
                  }
-@@ -2192,25 +2217,21 @@
+@@ -2192,25 +2260,21 @@
       */
      public void setBlockTileEntity(int par1, int par2, int par3, TileEntity par4TileEntity)
      {
@@ -174,21 +259,21 @@
          }
      }
  
-@@ -2219,27 +2240,10 @@
+@@ -2219,27 +2283,10 @@
       */
      public void removeBlockTileEntity(int par1, int par2, int par3)
      {
 -        TileEntity var4 = this.getBlockTileEntity(par1, par2, par3);
 -
 -        if (var4 != null && this.scanningTileEntities)
-+        Chunk var5 = this.getChunkFromChunkCoords(par1 >> 4, par3 >> 4);
-+        if (var5 != null)
-         {
+-        {
 -            var4.invalidate();
 -            this.addedTileEntityList.remove(var4);
 -        }
 -        else
--        {
++        Chunk var5 = this.getChunkFromChunkCoords(par1 >> 4, par3 >> 4);
++        if (var5 != null)
+         {
 -            if (var4 != null)
 -            {
 -                this.addedTileEntityList.remove(var4);
@@ -205,7 +290,7 @@
          }
      }
  
-@@ -2265,7 +2269,8 @@
+@@ -2265,7 +2312,8 @@
       */
      public boolean isBlockNormalCube(int par1, int par2, int par3)
      {
@@ -215,7 +300,7 @@
      }
  
      /**
-@@ -2281,7 +2286,7 @@
+@@ -2281,7 +2329,7 @@
              if (var5 != null && !var5.isEmpty())
              {
                  Block var6 = Block.blocksList[this.getBlockId(par1, par2, par3)];
@@ -224,7 +309,7 @@
              }
              else
              {
-@@ -2540,6 +2545,7 @@
+@@ -2540,6 +2588,7 @@
                  }
              }
          }
@@ -232,7 +317,7 @@
  
          Profiler.endSection();
  
-@@ -2863,7 +2869,7 @@
+@@ -2863,7 +2912,7 @@
  
      private int computeBlockLightValue(int par1, int par2, int par3, int par4, int par5, int par6)
      {
@@ -241,7 +326,7 @@
          int var8 = this.getSavedLightValue(EnumSkyBlock.Block, par2 - 1, par3, par4) - par6;
          int var9 = this.getSavedLightValue(EnumSkyBlock.Block, par2 + 1, par3, par4) - par6;
          int var10 = this.getSavedLightValue(EnumSkyBlock.Block, par2, par3 - 1, par4) - par6;
-@@ -3196,10 +3202,10 @@
+@@ -3196,10 +3245,10 @@
      public List getEntitiesWithinAABBExcludingEntity(Entity par1Entity, AxisAlignedBB par2AxisAlignedBB)
      {
          this.entitiesWithinAABBExcludingEntity.clear();
@@ -256,7 +341,7 @@
  
          for (int var7 = var3; var7 <= var4; ++var7)
          {
-@@ -3220,10 +3226,10 @@
+@@ -3220,10 +3269,10 @@
       */
      public List getEntitiesWithinAABB(Class par1Class, AxisAlignedBB par2AxisAlignedBB)
      {
@@ -271,7 +356,7 @@
          ArrayList var7 = new ArrayList();
  
          for (int var8 = var3; var8 <= var4; ++var8)
-@@ -3349,6 +3355,11 @@
+@@ -3349,6 +3398,11 @@
              {
                  var8 = null;
              }
@@ -283,7 +368,7 @@
  
              return par1 > 0 && var8 == null && var9.canPlaceBlockOnSide(this, par2, par3, par4, par6);
          }
-@@ -3864,4 +3875,38 @@
+@@ -3864,4 +3918,38 @@
      {
          return this.getChunkProvider().findClosestStructure(this, par1Str, par2, par3, par4);
      }


### PR DESCRIPTION
A hook in world.setBlock, world.setBlockAndMetadata and world.setMetadata  allowing a class to be informed whenever a block changes. I wanted it to be a bit more general so I also added the ability to prevent the block from changing.

Heres a small example: https://gist.github.com/2695062 (outdated)
Note that it is just the simplest mod I could thing of that could use such a hook and it probably could be done a lot more efficiently. What it does is prevent the user (any user, unfortunately there is no way to know who is trying to place the block from these methods, which kind of limits it's usability) from placing tnt in a 100 radius from the spawn.

This hook should only be used to replace resource heavy functions that search a whole area for block changes (I should probably should have stated that in the Javadoc), such as Buildcraft's quarry that in order to choose which block to mine next searches the whole quarry area from the top till it finds a mineable block. In a default size mine (9x9) by average it does 9_9_32=2592 more iterations than what it needs.

There is also a call for "machines" like the buildcraft filler that places a lot of blocks really fast, to prevent the hook from triggering.
