### PR TITLE
Custom world (level.dat) and chunk data

### DIFF
--- a/forge/patches/minecraft/net/minecraft/src/AnvilChunkLoader.java.patch
+++ b/forge/patches/minecraft/net/minecraft/src/AnvilChunkLoader.java.patch
@@ -19,9 +19,28 @@
      }
 @@ -103,6 +106,7 @@
              var3.setTag("Level", var4);
-             this.writeChunkToNBT(par2Chunk, par1World, var4);
+             this.func_48445_a(par2Chunk, par1World, var4);
              this.func_48446_a(par2Chunk.getChunkCoordIntPair(), var3);
 +            ForgeHooks.onChunkSaveData(par1World, par2Chunk, var3);
          }
          catch (Exception var5)
          {
+@@ -286,6 +290,8 @@
+ 
+             par3NBTTagCompound.setTag("TileTicks", var11);
+         }
++        
++        par3NBTTagCompound.setCompoundTag("ForgeData", par1Chunk.customChunkData);
+     }
+ 
+     private Chunk func_48444_a(World par1World, NBTTagCompound par2NBTTagCompound)
+@@ -371,6 +377,9 @@
+                 }
+             }
+         }
++        
++        if (par2NBTTagCompound.hasKey("ForgeData")) var5.customChunkData = par2NBTTagCompound.getCompoundTag("ForgeData");
++        else var5.customChunkData = new NBTTagCompound("ForgeData");
+ 
+         return var5;
+     }

--- a/forge/patches/minecraft/net/minecraft/src/Chunk.java.patch
+++ b/forge/patches/minecraft/net/minecraft/src/Chunk.java.patch
@@ -9,7 +9,19 @@
  public class Chunk
  {
      /**
-@@ -120,7 +122,9 @@
+@@ -78,6 +80,11 @@
+      */
+     private int queuedLightChecks;
+     boolean field_35846_u;
++    
++    /**
++     * FORGE: Custom chunk data 
++     */
++    public NBTTagCompound customChunkData;
+ 
+     public Chunk(World par1World, int par2, int par3)
+     {
+@@ -120,7 +127,9 @@
              {
                  for (int var8 = 0; var8 < var5; ++var8)
                  {
@@ -20,7 +32,7 @@
  
                      if (var9 != 0)
                      {
-@@ -139,6 +143,48 @@
+@@ -139,6 +148,48 @@
      }
  
      /**
@@ -69,7 +81,7 @@
       * Checks whether the chunk is at the X/Z location specified
       */
      public boolean isAtLocation(int par1, int par2)
-@@ -505,7 +551,7 @@
+@@ -505,7 +556,7 @@
       */
      public int getBlockID(int par1, int par2, int par3)
      {
@@ -78,7 +90,7 @@
          {
              return 0;
          }
-@@ -521,7 +567,7 @@
+@@ -521,7 +572,7 @@
       */
      public int getBlockMetadata(int par1, int par2, int par3)
      {
@@ -87,7 +99,7 @@
          {
              return 0;
          }
-@@ -561,6 +607,11 @@
+@@ -561,6 +612,11 @@
          }
          else
          {
@@ -99,7 +111,7 @@
              ExtendedBlockStorage var9 = this.storageArrays[par2 >> 4];
              boolean var10 = false;
  
-@@ -585,7 +636,7 @@
+@@ -585,7 +641,7 @@
                  {
                      Block.blocksList[var8].onBlockRemoval(this.worldObj, var11, par2, var12);
                  }
@@ -108,7 +120,7 @@
                  {
                      this.worldObj.removeBlockTileEntity(var11, par2, var12);
                  }
-@@ -629,32 +680,23 @@
+@@ -629,32 +685,23 @@
                          Block.blocksList[par4].onBlockAdded(this.worldObj, var11, par2, var12);
                      }
  
@@ -144,7 +156,7 @@
                  this.isModified = true;
                  return true;
              }
-@@ -666,7 +708,7 @@
+@@ -666,7 +713,7 @@
       */
      public boolean setBlockMetadata(int par1, int par2, int par3, int par4)
      {
@@ -153,7 +165,7 @@
  
          if (var5 == null)
          {
-@@ -686,7 +728,7 @@
+@@ -686,7 +733,7 @@
                  var5.setExtBlockMetadata(par1, par2 & 15, par3, par4);
                  int var7 = var5.getExtBlockID(par1, par2 & 15, par3);
  
@@ -162,7 +174,7 @@
                  {
                      TileEntity var8 = this.getChunkBlockTileEntity(par1, par2, par3);
  
-@@ -707,7 +749,7 @@
+@@ -707,7 +754,7 @@
       */
      public int getSavedLightValue(EnumSkyBlock par1EnumSkyBlock, int par2, int par3, int par4)
      {
@@ -171,7 +183,7 @@
          return var5 == null ? par1EnumSkyBlock.defaultLightValue : (par1EnumSkyBlock == EnumSkyBlock.Sky ? var5.getExtSkylightValue(par2, par3 & 15, par4) : (par1EnumSkyBlock == EnumSkyBlock.Block ? var5.getExtBlocklightValue(par2, par3 & 15, par4) : par1EnumSkyBlock.defaultLightValue));
      }
  
-@@ -717,6 +759,11 @@
+@@ -717,6 +764,11 @@
       */
      public void setLightValue(EnumSkyBlock par1EnumSkyBlock, int par2, int par3, int par4, int par5)
      {
@@ -183,7 +195,7 @@
          ExtendedBlockStorage var6 = this.storageArrays[par3 >> 4];
  
          if (var6 == null)
-@@ -750,7 +797,7 @@
+@@ -750,7 +802,7 @@
       */
      public int getBlockLightValue(int par1, int par2, int par3, int par4)
      {
@@ -192,7 +204,7 @@
  
          if (var5 == null)
          {
-@@ -852,34 +899,33 @@
+@@ -852,34 +904,33 @@
      {
          ChunkPosition var4 = new ChunkPosition(par1, par2, par3);
          TileEntity var5 = (TileEntity)this.chunkTileEntityMap.get(var4);
@@ -238,7 +250,7 @@
      }
  
      /**
-@@ -894,7 +940,7 @@
+@@ -894,7 +945,7 @@
  
          if (this.isChunkLoaded)
          {
@@ -247,7 +259,7 @@
          }
      }
  
-@@ -909,8 +955,14 @@
+@@ -909,8 +960,14 @@
          par4TileEntity.yCoord = par2;
          par4TileEntity.zCoord = this.zPosition * 16 + par3;
  
@@ -263,7 +275,7 @@
              par4TileEntity.validate();
              this.chunkTileEntityMap.put(var5, par4TileEntity);
          }
-@@ -946,6 +998,7 @@
+@@ -946,6 +1003,7 @@
          {
              this.worldObj.addLoadedEntities(this.entityLists[var1]);
          }
@@ -271,7 +283,7 @@
      }
  
      /**
-@@ -966,6 +1019,7 @@
+@@ -966,6 +1024,7 @@
          {
              this.worldObj.unloadEntities(this.entityLists[var3]);
          }
@@ -279,7 +291,7 @@
      }
  
      /**
-@@ -982,8 +1036,8 @@
+@@ -982,8 +1041,8 @@
       */
      public void getEntitiesWithinAABBForEntity(Entity par1Entity, AxisAlignedBB par2AxisAlignedBB, List par3List)
      {
@@ -290,7 +302,7 @@
  
          if (var4 < 0)
          {
-@@ -1030,8 +1084,8 @@
+@@ -1030,8 +1089,8 @@
       */
      public void getEntitiesOfTypeWithinAAAB(Class par1Class, AxisAlignedBB par2AxisAlignedBB, List par3List)
      {
@@ -301,7 +313,7 @@
  
          if (var4 < 0)
          {
-@@ -1228,6 +1282,16 @@
+@@ -1228,6 +1287,16 @@
  
      public void func_48494_a(byte[] par1ArrayOfByte, int par2, int par3, boolean par4)
      {
@@ -318,7 +330,7 @@
          int var5 = 0;
          int var6;
  
-@@ -1324,12 +1388,26 @@
+@@ -1324,12 +1393,26 @@
          }
  
          this.generateHeightMap();
@@ -350,7 +362,7 @@
          }
      }
  
-@@ -1435,4 +1513,18 @@
+@@ -1434,4 +1517,18 @@
              }
          }
      }

--- a/forge/patches/minecraft/net/minecraft/src/WorldInfo.java.patch
+++ b/forge/patches/minecraft/net/minecraft/src/WorldInfo.java.patch
@@ -1,0 +1,56 @@
+--- ../src_base/minecraft/net/minecraft/src/WorldInfo.java	0000-00-00 00:00:00.000000000 -0000
++++ ../src_work/minecraft/net/minecraft/src/WorldInfo.java	0000-00-00 00:00:00.000000000 -0000
+@@ -2,6 +2,8 @@
+ 
+ import java.util.List;
+ 
++import net.minecraft.src.forge.ForgeHooks;
++
+ public class WorldInfo
+ {
+     /** Holds the seed of the currently world. */
+@@ -54,6 +56,11 @@
+ 
+     /** Hardcore mode flag */
+     private boolean hardcore;
++    
++    /**
++     * FORGE: Custom world data stored in level.dat
++     */
++    public NBTTagCompound customWorldData;
+ 
+     public WorldInfo(NBTTagCompound par1NBTTagCompound)
+     {
+@@ -107,6 +114,8 @@
+         this.thunderTime = par1NBTTagCompound.getInteger("thunderTime");
+         this.thundering = par1NBTTagCompound.getBoolean("thundering");
+         this.hardcore = par1NBTTagCompound.getBoolean("hardcore");
++        if (par1NBTTagCompound.hasKey("ForgeData")) this.customWorldData = par1NBTTagCompound.getCompoundTag("ForgeData");
++        else this.customWorldData = new NBTTagCompound("ForgeData");
+ 
+         if (par1NBTTagCompound.hasKey("Player"))
+         {
+@@ -125,6 +134,7 @@
+         this.levelName = par2Str;
+         this.hardcore = par1WorldSettings.getHardcoreEnabled();
+         this.terrainType = par1WorldSettings.getTerrainType();
++        this.customWorldData = new NBTTagCompound("ForgeData");
+     }
+ 
+     public WorldInfo(WorldInfo par1WorldInfo)
+@@ -150,6 +160,7 @@
+         this.thunderTime = par1WorldInfo.thunderTime;
+         this.thundering = par1WorldInfo.thundering;
+         this.hardcore = par1WorldInfo.hardcore;
++        this.customWorldData = par1WorldInfo.customWorldData;
+     }
+ 
+     /**
+@@ -206,6 +217,7 @@
+         par1NBTTagCompound.setInteger("thunderTime", this.thunderTime);
+         par1NBTTagCompound.setBoolean("thundering", this.thundering);
+         par1NBTTagCompound.setBoolean("hardcore", this.hardcore);
++        par1NBTTagCompound.setCompoundTag("ForgeData", customWorldData);
+ 
+         if (par2NBTTagCompound != null)
+         {

--- a/forge/patches/minecraft_server/net/minecraft/src/AnvilChunkLoader.java.patch
+++ b/forge/patches/minecraft_server/net/minecraft/src/AnvilChunkLoader.java.patch
@@ -19,9 +19,28 @@
      }
 @@ -103,6 +106,7 @@
              var3.setTag("Level", var4);
-             this.writeChunkToNBT(par2Chunk, par1World, var4);
+             this.func_48462_a(par2Chunk, par1World, var4);
              this.func_48463_a(par2Chunk.getChunkCoordIntPair(), var3);
 +            ForgeHooks.onChunkSaveData(par1World, par2Chunk, var3);
          }
          catch (Exception var5)
          {
+@@ -286,6 +290,8 @@
+ 
+             par3NBTTagCompound.setTag("TileTicks", var11);
+         }
++        
++        par3NBTTagCompound.setCompoundTag("ForgeData", par1Chunk.customChunkData);
+     }
+ 
+     private Chunk func_48465_a(World par1World, NBTTagCompound par2NBTTagCompound)
+@@ -371,6 +377,9 @@
+                 }
+             }
+         }
++        
++        if (par2NBTTagCompound.hasKey("ForgeData")) var5.customChunkData = par2NBTTagCompound.getCompoundTag("ForgeData");
++        else var5.customChunkData = new NBTTagCompound("ForgeData");
+ 
+         return var5;
+     }

--- a/forge/patches/minecraft_server/net/minecraft/src/Chunk.java.patch
+++ b/forge/patches/minecraft_server/net/minecraft/src/Chunk.java.patch
@@ -9,7 +9,19 @@
  public class Chunk
  {
      /**
-@@ -120,7 +122,9 @@
+@@ -78,6 +80,11 @@
+      */
+     private int queuedLightChecks;
+     boolean field_35638_u;
++    
++    /**
++     * FORGE: Custom chunk data 
++     */
++    public NBTTagCompound customChunkData;
+ 
+     public Chunk(World par1World, int par2, int par3)
+     {
+@@ -120,7 +127,9 @@
              {
                  for (int var8 = 0; var8 < var5; ++var8)
                  {
@@ -20,7 +32,7 @@
  
                      if (var9 != 0)
                      {
-@@ -139,6 +143,48 @@
+@@ -139,6 +148,48 @@
      }
  
      /**
@@ -69,7 +81,7 @@
       * Checks whether the chunk is at the X/Z location specified
       */
      public boolean isAtLocation(int par1, int par2)
-@@ -465,7 +511,7 @@
+@@ -465,7 +516,7 @@
       */
      public int getBlockID(int par1, int par2, int par3)
      {
@@ -78,7 +90,7 @@
          {
              return 0;
          }
-@@ -481,7 +527,7 @@
+@@ -481,7 +532,7 @@
       */
      public int getBlockMetadata(int par1, int par2, int par3)
      {
@@ -87,7 +99,7 @@
          {
              return 0;
          }
-@@ -521,6 +567,11 @@
+@@ -521,6 +572,11 @@
          }
          else
          {
@@ -99,7 +111,7 @@
              ExtendedBlockStorage var9 = this.storageArrays[par2 >> 4];
              boolean var10 = false;
  
-@@ -545,7 +596,7 @@
+@@ -545,7 +601,7 @@
                  {
                      Block.blocksList[var8].onBlockRemoval(this.worldObj, var11, par2, var12);
                  }
@@ -108,7 +120,7 @@
                  {
                      this.worldObj.removeBlockTileEntity(var11, par2, var12);
                  }
-@@ -589,32 +640,23 @@
+@@ -589,32 +645,23 @@
                          Block.blocksList[par4].onBlockAdded(this.worldObj, var11, par2, var12);
                      }
  
@@ -144,7 +156,7 @@
                  this.isModified = true;
                  return true;
              }
-@@ -626,7 +668,7 @@
+@@ -626,7 +673,7 @@
       */
      public boolean setBlockMetadata(int par1, int par2, int par3, int par4)
      {
@@ -153,7 +165,7 @@
  
          if (var5 == null)
          {
-@@ -646,7 +688,7 @@
+@@ -646,7 +693,7 @@
                  var5.setExtBlockMetadata(par1, par2 & 15, par3, par4);
                  int var7 = var5.getExtBlockID(par1, par2 & 15, par3);
  
@@ -162,7 +174,7 @@
                  {
                      TileEntity var8 = this.getChunkBlockTileEntity(par1, par2, par3);
  
-@@ -667,7 +709,7 @@
+@@ -667,7 +714,7 @@
       */
      public int getSavedLightValue(EnumSkyBlock par1EnumSkyBlock, int par2, int par3, int par4)
      {
@@ -171,7 +183,7 @@
          return var5 == null ? par1EnumSkyBlock.defaultLightValue : (par1EnumSkyBlock == EnumSkyBlock.Sky ? var5.getExtSkylightValue(par2, par3 & 15, par4) : (par1EnumSkyBlock == EnumSkyBlock.Block ? var5.getExtBlocklightValue(par2, par3 & 15, par4) : par1EnumSkyBlock.defaultLightValue));
      }
  
-@@ -677,6 +719,11 @@
+@@ -677,6 +724,11 @@
       */
      public void setLightValue(EnumSkyBlock par1EnumSkyBlock, int par2, int par3, int par4, int par5)
      {
@@ -183,7 +195,7 @@
          ExtendedBlockStorage var6 = this.storageArrays[par3 >> 4];
  
          if (var6 == null)
-@@ -710,7 +757,7 @@
+@@ -710,7 +762,7 @@
       */
      public int getBlockLightValue(int par1, int par2, int par3, int par4)
      {
@@ -192,7 +204,7 @@
  
          if (var5 == null)
          {
-@@ -812,34 +859,31 @@
+@@ -812,34 +864,31 @@
      {
          ChunkPosition var4 = new ChunkPosition(par1, par2, par3);
          TileEntity var5 = (TileEntity)this.chunkTileEntityMap.get(var4);
@@ -237,7 +249,7 @@
      }
  
      /**
-@@ -854,7 +898,7 @@
+@@ -854,7 +903,7 @@
  
          if (this.isChunkLoaded)
          {
@@ -246,7 +258,7 @@
          }
      }
  
-@@ -869,8 +913,14 @@
+@@ -869,8 +918,14 @@
          par4TileEntity.yCoord = par2;
          par4TileEntity.zCoord = this.zPosition * 16 + par3;
  
@@ -262,7 +274,7 @@
              par4TileEntity.validate();
              this.chunkTileEntityMap.put(var5, par4TileEntity);
          }
-@@ -906,6 +956,7 @@
+@@ -906,6 +961,7 @@
          {
              this.worldObj.addLoadedEntities(this.entityLists[var1]);
          }
@@ -270,7 +282,7 @@
      }
  
      /**
-@@ -926,6 +977,7 @@
+@@ -926,6 +982,7 @@
          {
              this.worldObj.unloadEntities(this.entityLists[var3]);
          }
@@ -278,7 +290,7 @@
      }
  
      /**
-@@ -942,8 +994,8 @@
+@@ -942,8 +999,8 @@
       */
      public void getEntitiesWithinAABBForEntity(Entity par1Entity, AxisAlignedBB par2AxisAlignedBB, List par3List)
      {
@@ -289,7 +301,7 @@
  
          if (var4 < 0)
          {
-@@ -990,8 +1042,8 @@
+@@ -990,8 +1047,8 @@
       */
      public void getEntitiesOfTypeWithinAAAB(Class par1Class, AxisAlignedBB par2AxisAlignedBB, List par3List)
      {
@@ -300,7 +312,7 @@
  
          if (var4 < 0)
          {
-@@ -1287,4 +1339,18 @@
+@@ -1287,4 +1344,18 @@
              }
          }
      }

--- a/forge/patches/minecraft_server/net/minecraft/src/WorldInfo.java.patch
+++ b/forge/patches/minecraft_server/net/minecraft/src/WorldInfo.java.patch
@@ -1,0 +1,56 @@
+--- ../src_base/minecraft_server/net/minecraft/src/WorldInfo.java	0000-00-00 00:00:00.000000000 -0000
++++ ../src_work/minecraft_server/net/minecraft/src/WorldInfo.java	0000-00-00 00:00:00.000000000 -0000
+@@ -2,6 +2,8 @@
+ 
+ import java.util.List;
+ 
++import net.minecraft.src.forge.ForgeHooks;
++
+ public class WorldInfo
+ {
+     /** Holds the seed of the currently world. */
+@@ -54,6 +56,11 @@
+ 
+     /** Hardcore mode flag */
+     private boolean hardcore;
++    
++    /**
++     * FORGE: Custom world data stored in level.dat
++     */
++    public NBTTagCompound customWorldData;
+ 
+     public WorldInfo(NBTTagCompound par1NBTTagCompound)
+     {
+@@ -107,6 +114,8 @@
+         this.thunderTime = par1NBTTagCompound.getInteger("thunderTime");
+         this.thundering = par1NBTTagCompound.getBoolean("thundering");
+         this.hardcore = par1NBTTagCompound.getBoolean("hardcore");
++        if (par1NBTTagCompound.hasKey("ForgeData")) this.customWorldData = par1NBTTagCompound.getCompoundTag("ForgeData");
++        else this.customWorldData = new NBTTagCompound("ForgeData");
+ 
+         if (par1NBTTagCompound.hasKey("Player"))
+         {
+@@ -125,6 +134,7 @@
+         this.levelName = par2Str;
+         this.hardcore = par1WorldSettings.getHardcoreEnabled();
+         this.terrainType = par1WorldSettings.getTerrainType();
++        this.customWorldData = new NBTTagCompound("ForgeData");
+     }
+ 
+     public WorldInfo(WorldInfo par1WorldInfo)
+@@ -150,6 +160,7 @@
+         this.thunderTime = par1WorldInfo.thunderTime;
+         this.thundering = par1WorldInfo.thundering;
+         this.hardcore = par1WorldInfo.hardcore;
++        this.customWorldData = par1WorldInfo.customWorldData;
+     }
+ 
+     /**
+@@ -206,6 +217,7 @@
+         par1NBTTagCompound.setInteger("thunderTime", this.thunderTime);
+         par1NBTTagCompound.setBoolean("thundering", this.thundering);
+         par1NBTTagCompound.setBoolean("hardcore", this.hardcore);
++        par1NBTTagCompound.setCompoundTag("ForgeData", customWorldData);
+ 
+         if (par2NBTTagCompound != null)
+         {


### PR DESCRIPTION
Allows writing and reading custom data in level.dat (WorldInfo) or in individual chunks (Chunk).

A possible usecase for chunk data is ThaumCraft, but I'm yet to contact Azanor.

Most likely not to apply automatically, since a MCP name in AnvilChunkLoader has changed, and this was done before client FML came out.
