### PR TITLE
Improved IConnectRedstone

### DIFF
--- a/forge/patches/minecraft/net/minecraft/src/BlockRedstoneWire.java.patch
+++ b/forge/patches/minecraft/net/minecraft/src/BlockRedstoneWire.java.patch
@@ -18,6 +18,42 @@
      }
  
      /**
+@@ -459 +484 @@
++			 boolean normalCubeIMinus = this.blockAccess.isBlockNormalCube(par2 - 1, par3, par4);
++ 		     boolean normalCubeIPlus = this.blockAccess.isBlockNormalCube(par2 + 1, par3, par4);
++		 	 boolean normalCubeKMinus = this.blockAccess.isBlockNormalCube(par2, par3, par4 - 1);
++		 	 boolean normalCubeKPlus = this.blockAccess.isBlockNormalCube(par2, par3, par4 + 1);
++			 boolean var6 = isPoweredOrRepeater(par1IBlockAccess, par2 - 1, par3, par4, 1) || !normalCubeIMinus && isPoweredOrRepeater(par1IBlockAccess, par2 - 1, par3 - 1, par4, -1);
++            boolean var7 = isPoweredOrRepeater(par1IBlockAccess, par2 + 1, par3, par4, 3) || !normalCubeIPlus && isPoweredOrRepeater(par1IBlockAccess, par2 + 1, par3 - 1, par4, -2);
++            boolean var8 = isPoweredOrRepeater(par1IBlockAccess, par2, par3, par4 - 1, 2) || !normalCubeKMinus && isPoweredOrRepeater(par1IBlockAccess, par2, par3 - 1, par4 - 1, -3);
++            boolean var9 = isPoweredOrRepeater(par1IBlockAccess, par2, par3, par4 + 1, 0) || !normalCubeKPlus && isPoweredOrRepeater(par1IBlockAccess, par2, par3 - 1, par4 + 1, -4);
+-			 boolean var6 = isPoweredOrRepeater(par1IBlockAccess, par2 - 1, par3, par4, 1) || !par1IBlockAccess.isBlockNormalCube(par2 - 1, par3, par4) && isPoweredOrRepeater(par1IBlockAccess, par2 - 1, par3 - 1, par4, -1);
+-            boolean var7 = isPoweredOrRepeater(par1IBlockAccess, par2 + 1, par3, par4, 3) || !par1IBlockAccess.isBlockNormalCube(par2 + 1, par3, par4) && isPoweredOrRepeater(par1IBlockAccess, par2 + 1, par3 - 1, par4, -1);
+-            boolean var8 = isPoweredOrRepeater(par1IBlockAccess, par2, par3, par4 - 1, 2) || !par1IBlockAccess.isBlockNormalCube(par2, par3, par4 - 1) && isPoweredOrRepeater(par1IBlockAccess, par2, par3 - 1, par4 - 1, -1);
+-            boolean var9 = isPoweredOrRepeater(par1IBlockAccess, par2, par3, par4 + 1, 0) || !par1IBlockAccess.isBlockNormalCube(par2, par3, par4 + 1) && isPoweredOrRepeater(par1IBlockAccess, par2, par3 - 1, par4 + 1, -1);
+
+            if (!par1IBlockAccess.isBlockNormalCube(par2, par3 + 1, par4))
+            {
++                if (normalCubeIMinus && isPoweredOrRepeater(par1IBlockAccess, par2 - 1, par3 + 1, par4, -5))
+-                if (par1IBlockAccess.isBlockNormalCube(par2 - 1, par3, par4) && isPoweredOrRepeater(par1IBlockAccess, par2 - 1, par3 + 1, par4, -1))
+                {
+                    var6 = true;
+                }
++                if (normalCubeIPlus && isPoweredOrRepeater(par1IBlockAccess, par2 + 1, par3 + 1, par4, -6))
+-                if (par1IBlockAccess.isBlockNormalCube(par2 + 1, par3, par4) && isPoweredOrRepeater(par1IBlockAccess, par2 + 1, par3 + 1, par4, -1))
+                {
+                    var7 = true;
+                }
++                if (normalCubeKMinus && isPoweredOrRepeater(par1IBlockAccess, par2 + 1, par3 + 1, par4, -7))
+-                if (par1IBlockAccess.isBlockNormalCube(par2, par3, par4 - 1) && isPoweredOrRepeater(par1IBlockAccess, par2, par3 + 1, par4 - 1, -1))
+                {
+                    var8 = true;
+                }
++                if (normalCubeKPlus && isPoweredOrRepeater(par1IBlockAccess, par2 + 1, par3 + 1, par4, -8))
+-                if (par1IBlockAccess.isBlockNormalCube(par2, par3, par4 + 1) && isPoweredOrRepeater(par1IBlockAccess, par2, par3 + 1, par4 + 1, -1))
+                {
+                    var9 = true;
+                }
 @@ -548,6 +550,10 @@
          }
          else if (var5 != Block.redstoneRepeaterIdle.blockID && var5 != Block.redstoneRepeaterActive.blockID)
@@ -26,6 +62,7 @@
 +            {
 +                return ((IConnectRedstone)Block.blocksList[var5]).canConnectRedstone(par0IBlockAccess, par1, par2, par3, par4);
 +            }
-             return Block.blocksList[var5].canProvidePower() && par4 != -1;
+-             return Block.blocksList[var5].canProvidePower() && par4 != -1;
++			  return Block.blocksList[var5].canProvidePower() && par4 < 0;
          }
          else

--- a/forge/patches/minecraft/net/minecraft/src/RenderBlocks.java.patch
+++ b/forge/patches/minecraft/net/minecraft/src/RenderBlocks.java.patch
@@ -66,6 +66,53 @@
              {
                  var20 = (double)par2 + 0.5D + 0.5D;
                  var22 = (double)par2 + 0.5D - 0.5D;
+@@ -1598 +1634 @@
+			double var15 = (double)((float)var13 / 256.0F);
+			double var17 = (double)(((float)var13 + 15.99F) / 256.0F);
+			double var19 = (double)((float)var14 / 256.0F);
+			double var21 = (double)(((float)var14 + 15.99F) / 256.0F);
++			boolean normalCubeIMinus = this.blockAccess.isBlockNormalCube(par2 - 1, par3, par4);
++			boolean normalCubeIPlus = this.blockAccess.isBlockNormalCube(par2 + 1, par3, par4);
++			boolean normalCubeKMinus = this.blockAccess.isBlockNormalCube(par2, par3, par4 - 1);
++			boolean normalCubeKPlus = this.blockAccess.isBlockNormalCube(par2, par3, par4 + 1);
++			boolean var23 = BlockRedstoneWire.isPowerProviderOrWire(this.blockAccess, par2 - 1, par3, par4, 1) || !normalCubeIMinus && BlockRedstoneWire.isPowerProviderOrWire(this.blockAccess, par2 - 1, par3 - 1, par4, -1);
++			boolean var24 = BlockRedstoneWire.isPowerProviderOrWire(this.blockAccess, par2 + 1, par3, par4, 3) || !normalCubeIPlus && BlockRedstoneWire.isPowerProviderOrWire(this.blockAccess, par2 + 1, par3 - 1, par4, -2);
++			boolean var25 = BlockRedstoneWire.isPowerProviderOrWire(this.blockAccess, par2, par3, par4 - 1, 2) || !normalCubeKMinus && BlockRedstoneWire.isPowerProviderOrWire(this.blockAccess, par2, par3 - 1, par4 - 1, -3);
++			boolean var26 = BlockRedstoneWire.isPowerProviderOrWire(this.blockAccess, par2, par3, par4 + 1, 0) || !normalCubeKPlus && BlockRedstoneWire.isPowerProviderOrWire(this.blockAccess, par2, par3 - 1, par4 + 1, -4);
+-			boolean var23 = BlockRedstoneWire.isPowerProviderOrWire(this.blockAccess, par2 - 1, par3, par4, 1) || !this.blockAccess.isBlockNormalCube(par2 - 1, par3, par4) && BlockRedstoneWire.isPowerProviderOrWire(this.blockAccess, par2 - 1, par3 - 1, par4, -1);
+-			boolean var24 = BlockRedstoneWire.isPowerProviderOrWire(this.blockAccess, par2 + 1, par3, par4, 3) || !this.blockAccess.isBlockNormalCube(par2 + 1, par3, par4) && BlockRedstoneWire.isPowerProviderOrWire(this.blockAccess, par2 + 1, par3 - 1, par4, -1);
+-			boolean var25 = BlockRedstoneWire.isPowerProviderOrWire(this.blockAccess, par2, par3, par4 - 1, 2) || !this.blockAccess.isBlockNormalCube(par2, par3, par4 - 1) && BlockRedstoneWire.isPowerProviderOrWire(this.blockAccess, par2, par3 - 1, par4 - 1, -1);
+-			boolean var26 = BlockRedstoneWire.isPowerProviderOrWire(this.blockAccess, par2, par3, par4 + 1, 0) || !this.blockAccess.isBlockNormalCube(par2, par3, par4 + 1) && BlockRedstoneWire.isPowerProviderOrWire(this.blockAccess, par2, par3 - 1, par4 + 1, -1);
+
+			if (!this.blockAccess.isBlockNormalCube(par2, par3 + 1, par4))
+			{
++				if (normalCubeIMinus && BlockRedstoneWire.isPowerProviderOrWire(this.blockAccess, par2 - 1, par3 + 1, par4, -5))
+-				if (this.blockAccess.isBlockNormalCube(par2 - 1, par3, par4) && BlockRedstoneWire.isPowerProviderOrWire(this.blockAccess, par2 - 1, par3 + 1, par4, -1))
+				{
+					var23 = true;
+				}
++				if (normalCubeIPlus && BlockRedstoneWire.isPowerProviderOrWire(this.blockAccess, par2 - 1, par3 + 1, par4, -6))
+-				if (this.blockAccess.isBlockNormalCube(par2 + 1, par3, par4) && BlockRedstoneWire.isPowerProviderOrWire(this.blockAccess, par2 + 1, par3 + 1, par4, -1))
+				{
+					var24 = true;
+				}
++				if (normalCubeKMinus && BlockRedstoneWire.isPowerProviderOrWire(this.blockAccess, par2 - 1, par3 + 1, par4, -7))
+-				if (this.blockAccess.isBlockNormalCube(par2, par3, par4 - 1) && BlockRedstoneWire.isPowerProviderOrWire(this.blockAccess, par2, par3 + 1, par4 - 1, -1))
+				{
+					var25 = true;
+				}
++				if (normalCubeKPlus && BlockRedstoneWire.isPowerProviderOrWire(this.blockAccess, par2 - 1, par3 + 1, par4, -8))
+-				if (this.blockAccess.isBlockNormalCube(par2, par3, par4 + 1) && BlockRedstoneWire.isPowerProviderOrWire(this.blockAccess, par2, par3 + 1, par4 + 1, -1))
+				{
+					var26 = true;
+				}
+			}
+
+			float var27 = (float)(par2 + 0);
+			float var28 = (float)(par2 + 1);
+			float var29 = (float)(par4 + 0);
+			float var30 = (float)(par4 + 1);
+			byte var31 = 0;
 @@ -3610,7 +3609,7 @@
              var27 = par1Block.getBlockTexture(this.blockAccess, par2, par3, par4, 2);
              this.renderEastFace(par1Block, (double)par2, (double)par3, (double)par4, var27);


### PR DESCRIPTION
This change allows Blocks implementing IConnectRedstone to determine direction of redstone even if it's below or above it.
I used numbers from -1 to -8 to represent the directions so that -1 starts below ones and -5 starts above ones.
