### PR TITLE
EntityLiving onAttacked Hook

### DIFF
--- a/forge/forge_common/net/minecraft/src/forge/ForgeHooks.java
+++ b/forge/forge_common/net/minecraft/src/forge/ForgeHooks.java
@@ -353,6 +353,15 @@ public class ForgeHooks
         return false;
     }
     static LinkedList<ISpecialMobSpawnHandler> specialMobSpawnHandlers = new LinkedList<ISpecialMobSpawnHandler>();
+	
+    public static void onEntityLivingAttacked(EntityLiving entity, DamageSource attack, int damage)
+    {
+        for (IEntityLivingAttackedHandler handler : attackedHandlers)
+        {
+            handler.onEntityLivingAttacked(entity, attack, damage);
+        }
+    }
+    static LinkedList<IEntityLivingAttackedHandler> attackedHandlers = new LinkedList<IEntityLivingAttackedHandler>();
 
     // Plant Management
     // ------------------------------------------------------------

--- a/forge/forge_common/net/minecraft/src/forge/IEntityLivingAttackedHandler.java
+++ b/forge/forge_common/net/minecraft/src/forge/IEntityLivingAttackedHandler.java
@@ -1,0 +1,23 @@
+/**
+ * This software is provided under the terms of the Minecraft Forge Public
+ * License v1.0.
+ */
+
+package net.minecraft.src.forge;
+
+import net.minecraft.src.EntityLiving;
+import net.minecraft.src.DamageSource;
+
+public interface IEntityLivingAttackedHandler
+{
+    /** 
+     * This is called when any EntityLiving takes damage from any DamageSource.
+     * In multiplayer, this is called by both the client and the server.
+     * 
+     * @param entity The entity being attacked
+     * @param attack DamageSource instance of the attack, contains attacking entity if exists
+	 * @param damage Unmitigated damage the attack would cause
+     * @return True to continue processing, false to cancel.
+     */
+    public boolean onEntityLivingAttacked(EntityLiving entity, DamageSource attack, int damage);
+}

--- a/forge/forge_common/net/minecraft/src/forge/MinecraftForge.java
+++ b/forge/forge_common/net/minecraft/src/forge/MinecraftForge.java
@@ -163,6 +163,15 @@ public class MinecraftForge
     {
         ForgeHooks.specialMobSpawnHandlers.add(handler);
     }
+	
+    /**
+     * Register a new EntityLiving Attack handler
+     * @param handler The handler to be registered
+     */
+    public static void registerEntityLivingAttackedHandler(IEntityLivingAttackedHandler handler)
+    {
+        ForgeHooks.attackedHandlers.add(handler);
+    }
 
     /**
      * This is not supposed to be called outside of Minecraft internals.

--- a/forge/patches/minecraft/net/minecraft/src/EntityLiving.java.patch
+++ b/forge/patches/minecraft/net/minecraft/src/EntityLiving.java.patch
@@ -9,7 +9,19 @@
  
      /** Number of ticks since this EntityLiving last produced its sound */
      private int livingSoundTime;
-@@ -1342,7 +1342,7 @@
+@@ -834,6 +834,11 @@
+      */
+     public boolean attackEntityFrom(DamageSource par1DamageSource, int par2)
+     {
++		if (ForgeHooks.onEntityLivingAttacked(this, par1DamageSource, par2))
++		{
++			return false;
++		}
++		
+         if (this.worldObj.isRemote)
+         {
+             return false;
+@@ -1342,7 +1347,7 @@
          int var2 = MathHelper.floor_double(this.boundingBox.minY);
          int var3 = MathHelper.floor_double(this.posZ);
          int var4 = this.worldObj.getBlockId(var1, var2, var3);

--- a/forge/patches/minecraft_server/net/minecraft/src/EntityLiving.java.patch
+++ b/forge/patches/minecraft_server/net/minecraft/src/EntityLiving.java.patch
@@ -9,7 +9,19 @@
  
      /** Number of ticks since this EntityLiving last produced its sound */
      private int livingSoundTime;
-@@ -1307,7 +1307,7 @@
+@@ -808,6 +808,11 @@
+      */
+     public boolean attackEntityFrom(DamageSource par1DamageSource, int par2)
+     {
++		if (ForgeHooks.onEntityLivingAttacked(this, par1DamageSource, par2))
++		{
++			return false;
++		}
++		
+         if (this.worldObj.isRemote)
+         {
+             return false;
+@@ -1307,7 +1312,7 @@
          int var2 = MathHelper.floor_double(this.boundingBox.minY);
          int var3 = MathHelper.floor_double(this.posZ);
          int var4 = this.worldObj.getBlockId(var1, var2, var3);


### PR DESCRIPTION
Adds a Forge Hook into EntityLiving.attackEntityFrom, prior to the multiplayer check/abort.

Useful for any number of Entity Interactions with each other or players.
