### PR TITLE
Fix isBlockReplaceable bug

### DIFF
--- a/forge/patches/minecraft/net/minecraft/src/Block.java.patch
+++ b/forge/patches/minecraft/net/minecraft/src/Block.java.patch
@@ -190,7 +190,7 @@
 +     */
 +    public boolean isBlockReplaceable(World world, int x, int y, int z) 
 +    {
-+	    return false;
++    	return (blockID == vine.blockID || blockID == tallGrass.blockID || blockID == deadBush.blockID);
 +    }
 +
 +    /**

--- a/forge/patches/minecraft/net/minecraft/src/ItemBlock.java.patch
+++ b/forge/patches/minecraft/net/minecraft/src/ItemBlock.java.patch
@@ -1,0 +1,11 @@
+--- ../src_base/minecraft/net/minecraft/src/ItemBlock.java	0000-00-00 00:00:00.000000000 -0000
++++ ../src_work/minecraft/net/minecraft/src/ItemBlock.java	0000-00-00 00:00:00.000000000 -0000
+@@ -32,7 +32,7 @@
+         {
+             par7 = 1;
+         }
+-        else if (var8 != Block.vine.blockID && var8 != Block.tallGrass.blockID && var8 != Block.deadBush.blockID)
++        else if (!Block.blocksList[var8].isBlockReplaceable(par3World, par4, par5, par6))
+         {
+             if (par7 == 0)
+             {

--- a/forge/patches/minecraft_server/net/minecraft/src/Block.java.patch
+++ b/forge/patches/minecraft_server/net/minecraft/src/Block.java.patch
@@ -173,7 +173,7 @@
 +     */
 +    public boolean isBlockReplaceable(World world, int x, int y, int z) 
 +    {
-+        return false;
++       	return (blockID == vine.blockID || blockID == tallGrass.blockID || blockID == deadBush.blockID);
 +    }
 +
 +    /**

--- a/forge/patches/minecraft_server/net/minecraft/src/ItemBlock.java.patch
+++ b/forge/patches/minecraft_server/net/minecraft/src/ItemBlock.java.patch
@@ -1,0 +1,11 @@
+--- ../src_base/minecraft_server/net/minecraft/src/ItemBlock.java	0000-00-00 00:00:00.000000000 -0000
++++ ../src_work/minecraft_server/net/minecraft/src/ItemBlock.java	0000-00-00 00:00:00.000000000 -0000
+@@ -32,7 +32,7 @@
+         {
+             par7 = 1;
+         }
+-        else if (var8 != Block.vine.blockID && var8 != Block.tallGrass.blockID && var8 != Block.deadBush.blockID)
++        else if (!Block.blocksList[var8].isBlockReplaceable(par3World, par4, par5, par6))
+         {
+             if (par7 == 0)
+             {


### PR DESCRIPTION
If a custom block overrides Block.isBlockReplaceable() so that it returns true, ItemBlock.onItemUse() misplaces the replacement block. The site of the replacement block is shifted so that it is placed adjacent to the face of the replaceable block targeted by the player, rather than replacing the replaceable block.  The result is illustrated in [this screenshot](http://i.imgur.com/3e64h.jpg).

This change properly implements the hook on vanilla blocks and makes ItemBlock.onItemUse() properly react to any block that implements this hook.

Changes are included for both client and server.
