### PR TITLE
EntityLivingRenderer Hook suggestion

### DIFF
--- a/forge/forge_client/src/net/minecraft/src/forge/ForgeHooksClient.java
+++ b/forge/forge_client/src/net/minecraft/src/forge/ForgeHooksClient.java
@@ -8,10 +8,13 @@ package net.minecraft.src.forge;
 import net.minecraft.client.Minecraft;
 import net.minecraft.src.Block;
 import net.minecraft.src.Entity;
+import net.minecraft.src.EntityLiving;
 import net.minecraft.src.Item;
 import net.minecraft.src.ModLoader;
+import net.minecraft.src.ModelBase;
 import net.minecraft.src.Packet100OpenWindow;
 import net.minecraft.src.RenderBlocks;
+import net.minecraft.src.RenderLiving;
 import net.minecraft.src.SoundPoolEntry;
 import net.minecraft.src.Tessellator;
 import net.minecraft.src.RenderGlobal;
@@ -644,4 +647,34 @@ public class ForgeHooksClient
             }
         }
     }
+    
+    public static boolean overrideRenderLivingRender(RenderLiving renderer, ModelBase mainModel, ModelBase renderPassModel, EntityLiving entity)
+    {
+        for (IRenderLivingHandler handler : renderLivingHandlers)
+        {
+            if (handler.overrideRender(renderer, mainModel, renderPassModel, entity))
+            {
+                return true;
+            }
+        }
+        return false;
+    }
+    
+    public static void onPostRenderLivingRender(RenderLiving renderer, ModelBase mainModel, ModelBase renderPassModel, EntityLiving entity)
+    {
+        for (IRenderLivingHandler handler : renderLivingHandlers)
+        {
+            handler.postRender(renderer, mainModel, renderPassModel, entity);
+        }
+    }
+    
+    public static void onPostRenderLivingRenderPasses(RenderLiving renderer, ModelBase mainModel, ModelBase renderPassModel, EntityLiving entity)
+    {
+        for (IRenderLivingHandler handler : renderLivingHandlers)
+        {
+            handler.postRenderPasses(renderer, mainModel, renderPassModel, entity);
+        }
+    }
+
+    public static LinkedList<IRenderLivingHandler> renderLivingHandlers = new LinkedList<IRenderLivingHandler>();
 }

--- a/forge/forge_client/src/net/minecraft/src/forge/IRenderLivingHandler.java
+++ b/forge/forge_client/src/net/minecraft/src/forge/IRenderLivingHandler.java
@@ -1,0 +1,47 @@
+package net.minecraft.src.forge;
+
+import net.minecraft.src.EntityLiving;
+import net.minecraft.src.ModelBase;
+import net.minecraft.src.RenderLiving;
+
+public interface IRenderLivingHandler
+{
+    /**
+     * Called before an EntityLiving's Rendering is done. You can use this to prevent Minecraft from rendering an
+     * EntityLiving, and then using postRender for Rendering it yourself however you want it.
+     * Prevents subsequent Renderpasses and equipped Items, also the 'Damage' state from being rendered.
+     * GLTranslation, Color, Light and Animation considerations are already done here.
+     * 
+     * @param renderer Instance of RenderLiving for Entity Type
+     * @param mainModel EntityLiving Main Model
+     * @param renderPassModel EntityLiving Render Pass Model (eg Pig Saddle, Dragon Addons) is null on most Entities
+     * @param entity EntityLiving being rendererd
+     * @return false to let the main Renderer do it's thing, true to prevent the EntityLiving from being rendered at all
+     */
+    public boolean overrideRender(RenderLiving renderer, ModelBase mainModel, ModelBase renderPassModel, EntityLiving entity);
+    
+    /**
+     * Called immediatly after an EntityLiving's main Rendering was done (also when overridden).
+     * If you want to replace an Entities Renderer on the fly, this is the place.
+     * Also, if you want to overlay an EntityLiving with another texture or FX.
+     * The GLTranslation, Color, Light and Animation considerations are already done here, so
+     * all you have to do is call a render method. RenderPasses (if present) take place after this.
+     * 
+     * @param renderer Instance of RenderLiving for Entity Type
+     * @param mainModel EntityLiving Main Model
+     * @param renderPassModel EntityLiving Render Pass Model (eg Pig Saddle, Dragon Addons) is null on most Entities
+     * @param entity EntityLiving being rendererd
+     */
+    public void postRender(RenderLiving renderer, ModelBase mainModel, ModelBase renderPassModel, EntityLiving entity);
+    
+    /**
+     * Called after an EntityLiving's RenderPasses have completed (also when overridden),
+     * if you wish to do your own additional RenderPasses.
+     * 
+     * @param renderer Instance of RenderLiving for Entity Type
+     * @param mainModel EntityLiving Main Model
+     * @param renderPassModel EntityLiving Render Pass Model (eg Pig Saddle, Dragon Addons) is null on most Entities
+     * @param entity EntityLiving being rendererd
+     */
+    public void postRenderPasses(RenderLiving renderer, ModelBase mainModel, ModelBase renderPassModel, EntityLiving entity);
+}

--- a/forge/patches/minecraft/net/minecraft/src/RenderLiving.java.patch
+++ b/forge/patches/minecraft/net/minecraft/src/RenderLiving.java.patch
@@ -1,0 +1,59 @@
+--- ../src_base/minecraft/net/minecraft/src/RenderLiving.java	0000-00-00 00:00:00.000000000 -0000
++++ ../src_work/minecraft/net/minecraft/src/RenderLiving.java	0000-00-00 00:00:00.000000000 -0000
+@@ -3,6 +3,7 @@
+ import net.minecraft.client.Minecraft;
+ import org.lwjgl.opengl.GL11;
+ import org.lwjgl.opengl.GL12;
++import net.minecraft.src.forge.ForgeHooksClient;
+ 
+ public class RenderLiving extends Render
+ {
+@@ -95,8 +96,15 @@
+             }
+ 
+             GL11.glEnable(GL11.GL_ALPHA_TEST);
+-            this.mainModel.setLivingAnimations(par1EntityLiving, var16, var15, par9);
+-            this.renderModel(par1EntityLiving, var16, var15, var13, var11 - var10, var12, var14);
++			
++			boolean forgeOverride = ForgeHooksClient.overrideRenderLivingRender(this, mainModel, renderPassModel, par1EntityLiving);
++			
++			if (!forgeOverride)
++			{
++				this.mainModel.setLivingAnimations(par1EntityLiving, var16, var15, par9);
++				this.renderModel(par1EntityLiving, var16, var15, var13, var11 - var10, var12, var14);
++			}
++			ForgeHooksClient.onPostRenderLivingRender(this, mainModel, renderPassModel, par1EntityLiving);
+             float var19;
+             int var18;
+             float var20;
+@@ -106,7 +114,7 @@
+             {
+                 var18 = this.shouldRenderPass(par1EntityLiving, var17, par9);
+ 
+-                if (var18 > 0)
++                if (!forgeOverride && var18 > 0)
+                 {
+                     this.renderPassModel.setLivingAnimations(par1EntityLiving, var16, var15, par9);
+                     this.renderPassModel.render(par1EntityLiving, var16, var15, var13, var11 - var10, var12, var14);
+@@ -152,15 +160,19 @@
+                     GL11.glEnable(GL11.GL_ALPHA_TEST);
+                 }
+             }
++			ForgeHooksClient.onPostRenderLivingRenderPasses(this, mainModel, renderPassModel, par1EntityLiving);
+ 
+-            this.renderEquippedItems(par1EntityLiving, par9);
++			if (!forgeOverride)
++			{
++				this.renderEquippedItems(par1EntityLiving, par9);
++			}
+             float var26 = par1EntityLiving.getBrightness(par9);
+             var18 = this.getColorMultiplier(par1EntityLiving, var26, par9);
+             OpenGlHelper.setActiveTexture(OpenGlHelper.lightmapTexUnit);
+             GL11.glDisable(GL11.GL_TEXTURE_2D);
+             OpenGlHelper.setActiveTexture(OpenGlHelper.defaultTexUnit);
+ 
+-            if ((var18 >> 24 & 255) > 0 || par1EntityLiving.hurtTime > 0 || par1EntityLiving.deathTime > 0)
++            if (!forgeOverride && ((var18 >> 24 & 255) > 0 || par1EntityLiving.hurtTime > 0 || par1EntityLiving.deathTime > 0))
+             {
+                 GL11.glDisable(GL11.GL_TEXTURE_2D);
+                 GL11.glDisable(GL11.GL_ALPHA_TEST);


### PR DESCRIPTION
Allows for replacing an EntityLiving's Renderer on the fly, or just
adding something. Makes overlaying existing Entities with additional (even animated) textures possible.
