### PR TITLE
Fix ghost players who appear if they don't have the 4096 fix installed

### DIFF
--- a/forge/forge_server/src/net/minecraft/src/forge/PacketHandlerServer.java
+++ b/forge/forge_server/src/net/minecraft/src/forge/PacketHandlerServer.java
@@ -58,6 +58,7 @@ public class PacketHandlerServer extends PacketHandlerBase
         if (!pkt.has4096)
         {
             net.kickPlayer("Must have Forge build #136+ (4096 fix) to connect to this server");
+            return;
         }
         if (pkt.Mods.length == 0)
         {


### PR DESCRIPTION
The disconnect needs to be followed by a return - otherwise the game creates a ghost of the player without the 4096.
