### PR TITLE
Enabled underscore characters as a valid tag character in Configuration files.

### DIFF
--- a/forge/forge_common/net/minecraft/src/forge/Configuration.java
+++ b/forge/forge_common/net/minecraft/src/forge/Configuration.java
@@ -204,7 +204,7 @@ public class Configuration
 
                     for (int i = 0; i < line.length() && !skip; ++i)
                     {
-                        if (Character.isLetterOrDigit(line.charAt(i)) || line.charAt(i) == '.')
+                        if (Character.isLetterOrDigit(line.charAt(i)) || line.charAt(i) == '.' || line.charAt(i) == '_')
                         {
                             if (nameStart == -1)
                             {


### PR DESCRIPTION
Namely I wanted to add this so I can use a Configuration file that has a category for each language. For example "en_US".
