### PR TITLE
Extend WorldGenMinable to allow metadata

### DIFF
--- a/forge/patches/minecraft/net/minecraft/src/WorldGenMinable.java.patch
+++ b/forge/patches/minecraft/net/minecraft/src/WorldGenMinable.java.patch
@@ -1,6 +1,29 @@
 --- ../src_base/minecraft/net/minecraft/src/WorldGenMinable.java	0000-00-00 00:00:00.000000000 -0000
 +++ ../src_work/minecraft/net/minecraft/src/WorldGenMinable.java	0000-00-00 00:00:00.000000000 -0000
-@@ -57,7 +57,8 @@
+@@ -6,6 +6,7 @@
+ {
+     /** The block ID of the ore to be placed using this generator. */
+     private int minableBlockId;
++    private int minableBlockMetadata;
+ 
+     /** The number of blocks to generate. */
+     private int numberOfBlocks;
+@@ -14,6 +15,14 @@
+     {
+         this.minableBlockId = par1;
+         this.numberOfBlocks = par2;
++        this.minableBlockMetadata = 0;
++    }
++
++    public WorldGenMinable(int par1, int par2, int par3)
++    {
++        this.minableBlockId = par1;
++        this.numberOfBlocks = par2;
++        this.minableBlockMetadata = par3;
+     }
+ 
+     public boolean generate(World par1World, Random par2Random, int par3, int par4, int par5)
+@@ -57,9 +66,10 @@
                              {
                                  double var45 = ((double)var44 + 0.5D - var24) / (var28 / 2.0D);
  
@@ -8,5 +31,8 @@
 +                                Block block = Block.blocksList[par1World.getBlockId(var38, var41, var44)];
 +                                if (var39 * var39 + var42 * var42 + var45 * var45 < 1.0D && (block != null && block.isGenMineableReplaceable(par1World, var38, var41, var44)))
                                  {
-                                     par1World.setBlock(var38, var41, var44, this.minableBlockId);
+-                                    par1World.setBlock(var38, var41, var44, this.minableBlockId);
++                                    par1World.setBlockAndMetadata(var38, var41, var44, this.minableBlockId, this.minableBlockMetadata);
                                  }
+                             }
+                         }

--- a/forge/patches/minecraft_server/net/minecraft/src/WorldGenMinable.java.patch
+++ b/forge/patches/minecraft_server/net/minecraft/src/WorldGenMinable.java.patch
@@ -1,6 +1,29 @@
 --- ../src_base/minecraft_server/net/minecraft/src/WorldGenMinable.java	0000-00-00 00:00:00.000000000 -0000
 +++ ../src_work/minecraft_server/net/minecraft/src/WorldGenMinable.java	0000-00-00 00:00:00.000000000 -0000
-@@ -57,7 +57,8 @@
+@@ -6,6 +6,7 @@
+ {
+     /** The block ID of the ore to be placed using this generator. */
+     private int minableBlockId;
++    private int minableBlockMetadata;
+ 
+     /** The number of blocks to generate. */
+     private int numberOfBlocks;
+@@ -14,6 +15,14 @@
+     {
+         this.minableBlockId = par1;
+         this.numberOfBlocks = par2;
++        this.minableBlockMetadata = 0;
++    }
++
++    public WorldGenMinable(int par1, int par2, int par3)
++    {
++        this.minableBlockId = par1;
++        this.numberOfBlocks = par2;
++        this.minableBlockMetadata = par3;
+     }
+ 
+     public boolean generate(World par1World, Random par2Random, int par3, int par4, int par5)
+@@ -57,9 +66,10 @@
                              {
                                  double var45 = ((double)var44 + 0.5D - var24) / (var28 / 2.0D);
  
@@ -8,5 +31,8 @@
 +                                Block block = Block.blocksList[par1World.getBlockId(var38, var41, var44)];
 +                                if (var39 * var39 + var42 * var42 + var45 * var45 < 1.0D && (block != null && block.isGenMineableReplaceable(par1World, var38, var41, var44)))
                                  {
-                                     par1World.setBlock(var38, var41, var44, this.minableBlockId);
+-                                    par1World.setBlock(var38, var41, var44, this.minableBlockId);
++                                	par1World.setBlockAndMetadata(var38, var41, var44, this.minableBlockId, this.minableBlockMetadata);
                                  }
+                             }
+                         }


### PR DESCRIPTION
While building my first mod (always nice, aint it?), I tried to put several ores in a single BlockID. I succeeded rather well, except for one place: WorldGenMinable. Now I have 2 options there:

1) copy/paste WorldGenMinable to my own mod, and add the metadata

or 2) ask if you guys want to patch up MCForge to allow it.

Sadly, I am setting up my env for all this, and I haven't figured out how I can make patches out of my changes for MCForge quickly, so I will just give you the rundown of what is needed (code works, compiles and gives the expected result).

All in WorldGenMinable.java:

```
    private int minableBlockId;
+    private int minableBlockMetadata;
```

(..)

```
    public WorldGenMinable(int par1, int par2)
    {
        this.minableBlockId = par1;
        this.numberOfBlocks = par2;
+        this.minableBlockMetadata = 0;
    }

+    public WorldGenMinable(int par1, int par2, int par3)
+    {
+        this.minableBlockId = par1;
+        this.numberOfBlocks = par2;
+        this.minableBlockMetadata = par3;
+    }
```

(..)

```
-par1World.setBlock(var38, var41, var44, this.minableBlockId);
+par1World.setBlockAndMetadata(var38, var41, var44, this.minableBlockId, this.minableBlockMetadata);
```

And then it is ready to accept metadata, meaning I only have to use 1 BlockID for all my ores, and no code duplication \o/. An other option of course would be to allow an ItemStack as first parameter, which some other functions do. As I am new to this coding style, it is hard for me to estimate which is more common, and which would be better.

It of course also might be that I am doing this completely wrong. In that case I would love to get some input how I should be doing it. Tnx once again!
