### PR TITLE
Move block-placing code from ItemBlock.onItemUse into another method

### DIFF
--- a/forge/patches/minecraft/net/minecraft/src/ItemBlock.java.patch
+++ b/forge/patches/minecraft/net/minecraft/src/ItemBlock.java.patch
@@ -10,3 +10,46 @@
          {
              if (par7 == 0)
              {
+@@ -81,14 +82,8 @@
+         {
+             Block var9 = Block.blocksList[this.blockID];
+ 
+-            if (par3World.setBlockAndMetadataWithNotify(par4, par5, par6, this.blockID, this.getMetadata(par1ItemStack.getItemDamage())))
++            if (placeBlockAt(par3World, par4, par5, par6, par1ItemStack, par2EntityPlayer, par7))
+             {
+-                if (par3World.getBlockId(par4, par5, par6) == this.blockID)
+-                {
+-                    Block.blocksList[this.blockID].onBlockPlaced(par3World, par4, par5, par6, par7);
+-                    Block.blocksList[this.blockID].onBlockPlacedBy(par3World, par4, par5, par6, par2EntityPlayer);
+-                }
+-
+                 par3World.playSoundEffect((double)((float)par4 + 0.5F), (double)((float)par5 + 0.5F), (double)((float)par6 + 0.5F), var9.stepSound.getStepSound(), (var9.stepSound.getVolume() + 1.0F) / 2.0F, var9.stepSound.getPitch() * 0.8F);
+                 --par1ItemStack.stackSize;
+             }
+@@ -110,4 +105,26 @@
+     {
+         return Block.blocksList[this.blockID].getBlockName();
+     }
++
++    /**
++     * Called to actually place the block, after the location is determined
++     * and all permission checks have been made.
++     * 
++     * @param stack The item stack that was used to place the block. This can be changed inside the method.
++     * @param player The player who is placing the block. Can be null if the block is not being placed by a player.
++     * @param side The side the player (or machine) right-clicked on.
++     */
++    public boolean placeBlockAt(World world, int x, int y, int z, ItemStack stack, EntityPlayer player, int side)
++    {
++    	if (!world.setBlockAndMetadataWithNotify(x, y, z, this.blockID, this.getMetadata(stack.getItemDamage())))
++    		return false;
++    	
++    	if (world.getBlockId(x, y, z) == this.blockID)
++        {
++            Block.blocksList[this.blockID].onBlockPlaced(world, x, y, z, side);
++            Block.blocksList[this.blockID].onBlockPlacedBy(world, x, y, z, player);
++        }
++    	
++    	return true;
++    }
+ }

--- a/forge/patches/minecraft_server/net/minecraft/src/ItemBlock.java.patch
+++ b/forge/patches/minecraft_server/net/minecraft/src/ItemBlock.java.patch
@@ -10,3 +10,46 @@
          {
              if (par7 == 0)
              {
+@@ -81,14 +82,8 @@
+         {
+             Block var9 = Block.blocksList[this.blockID];
+ 
+-            if (par3World.setBlockAndMetadataWithNotify(par4, par5, par6, this.blockID, this.getMetadata(par1ItemStack.getItemDamage())))
++            if (placeBlockAt(par3World, par4, par5, par6, par1ItemStack, par2EntityPlayer, par7))
+             {
+-                if (par3World.getBlockId(par4, par5, par6) == this.blockID)
+-                {
+-                    Block.blocksList[this.blockID].onBlockPlaced(par3World, par4, par5, par6, par7);
+-                    Block.blocksList[this.blockID].onBlockPlacedBy(par3World, par4, par5, par6, par2EntityPlayer);
+-                }
+-
+                 par3World.playSoundEffect((double)((float)par4 + 0.5F), (double)((float)par5 + 0.5F), (double)((float)par6 + 0.5F), var9.stepSound.getStepSound(), (var9.stepSound.getVolume() + 1.0F) / 2.0F, var9.stepSound.getPitch() * 0.8F);
+                 --par1ItemStack.stackSize;
+             }
+@@ -110,4 +105,26 @@
+     {
+         return Block.blocksList[this.blockID].getBlockName();
+     }
++
++    /**
++     * Called to actually place the block, after the location is determined
++     * and all permission checks have been made.
++     * 
++     * @param stack The item stack that was used to place the block. This can be changed inside the method.
++     * @param player The player who is placing the block. Can be null if the block is not being placed by a player.
++     * @param side The side the player (or machine) right-clicked on.
++     */
++    public boolean placeBlockAt(World world, int x, int y, int z, ItemStack stack, EntityPlayer player, int side)
++    {
++    	if (!world.setBlockAndMetadataWithNotify(x, y, z, this.blockID, this.getMetadata(stack.getItemDamage())))
++    		return false;
++    	
++    	if (world.getBlockId(x, y, z) == this.blockID)
++        {
++            Block.blocksList[this.blockID].onBlockPlaced(world, x, y, z, side);
++            Block.blocksList[this.blockID].onBlockPlacedBy(world, x, y, z, player);
++        }
++    	
++    	return true;
++    }
+ }


### PR DESCRIPTION
Allows mods to override placeBlockAt to place their block, instead of overriding onItemUse and copy-pasting the permission checks and position calculation.
