### PR TITLE
Fix BlockTrapDoor.disableValidation on server

### DIFF
--- a/forge/patches/minecraft_server/net/minecraft/src/BlockTrapDoor.java.patch
+++ b/forge/patches/minecraft_server/net/minecraft/src/BlockTrapDoor.java.patch
@@ -40,3 +40,14 @@
          }
      }
  
+@@ -280,6 +288,10 @@
+      */
+     private static boolean isValidSupportBlock(int par0)
+     {
++        if (disableValidation)
++        {
++            return true;
++        }
+         if (par0 <= 0)
+         {
+             return false;


### PR DESCRIPTION
BlockTrapDoor.disableValidation isn't checked on the server side (client is fine)
