### PR TITLE
Bonemeal handler fix

### DIFF
--- a/patches/common/net/minecraft/src/ItemDye.java.patch
+++ b/patches/common/net/minecraft/src/ItemDye.java.patch
@@ -17,7 +17,7 @@
                  var11 = par3World.getBlockId(par4, par5, par6);
 +
 +                BonemealEvent event = new BonemealEvent(par2EntityPlayer, par3World, var11, par4, par5, par6);
-+                if (!MinecraftForge.EVENT_BUS.post(event))
++                if (MinecraftForge.EVENT_BUS.post(event))
 +                {
 +                    return false;
 +                }


### PR DESCRIPTION
Fixed bug where default bonemeal behavior wouldn't trigger (i.e. on grass, saplings, etc).
