### PR TITLE
Filler uses normal constructor, fixed loop bug

### DIFF
--- a/common/net/minecraftforge/common/MinecraftForge.java
+++ b/common/net/minecraftforge/common/MinecraftForge.java
@@ -173,9 +173,7 @@ public class MinecraftForge
        Block filler = null;
        try 
        {
-           Constructor ctr = Block.class.getDeclaredConstructor(int.class, Material.class);
-           ctr.setAccessible(true);
-           filler = (Block)ctr.newInstance(256, Material.air);
+           filler = new Block(256,Material.air);
        }
        catch (Exception e)
        {
@@ -186,7 +184,7 @@ public class MinecraftForge
 
        for (int x = 256; x < 4096; x++)
        {
-           if (Item.itemsList[x - 256] != null)
+           if (Item.itemsList[x] != null)
            {
                Block.blocksList[x] = filler;
            }


### PR DESCRIPTION
Now the filler doesn't use reflection to get the constructor, and I fixed a bug with the filler loop.

I kept the try block around the filler creation just in case.

The bug was that the filler loop was using x - 256 to check if the Item was null: Which meant for slot 390 (Which isn't used in vanilla minecraft), it would check to see if slot 134 was empty, and since that slot wouldn't be empty (There's a block there) it create a filler block at 390 when it shouldn't. The bugfix was, of course, removing the - 256, which is only to be used when you want to create an Item at a specific slot.
