### PR TITLE
Add hooks to modify light levels just before rendering.

### DIFF
--- a/client/net/minecraftforge/client/ILightingHandler.java
+++ b/client/net/minecraftforge/client/ILightingHandler.java
@@ -1,0 +1,47 @@
+package net.minecraftforge.client;
+
+public interface ILightingHandler
+{
+    public enum LightingType {
+        Entity,
+        Block,
+    }
+
+	/**
+	 * Get's a value representing how important this value is.
+	 * 
+	 * Larger numbers represent higher priority and will execute later in the cycle.
+	 * 0 is taken to mean natural world lighting.
+	 * 
+	 * @return A value representing a 
+	 */
+	public int getLightingPriority();
+
+    /**
+     * Gets the light level of a block in the world.
+     * 
+     * This is used to modify the ambient light level of a block, usually provided by the sky.
+     *
+     * @param x The x position of the block.
+     * @param y The y position of the block.
+     * @param z The z position of the block.
+     * @param currentLight The current lighting level of the block.
+     * @param type The type of object requesting the light level. Most mods won't care about this.
+     * @return The light level of the block. Should be -1 if the mod doesn't wish to change this value.
+     */
+    public int getSkyLightLevel(int x, int y, int z, int currentLight, LightingType type);
+	
+    /**
+     * Gets the light level of a block in the world.
+     * 
+     * This is used to modify the light level of a block as affected by things like torches.
+     *
+     * @param x The x position of the block.
+     * @param y The y position of the block.
+     * @param z The z position of the block.
+     * @param currentLight The current lighting level of the block.
+     * @param type The type of object requesting the light level. Most mods won't care about this.
+     * @return The light level of the block. Should be -1 if the mod doesn't wish to change this value.
+     */
+    public int getBlockLightLevel(int x, int y, int z, int currentLight, LightingType type);
+}

--- a/patches/common/net/minecraft/src/ChunkCache.java.patch
+++ b/patches/common/net/minecraft/src/ChunkCache.java.patch
@@ -1,0 +1,20 @@
+--- ../src_base/common/net/minecraft/src/ChunkCache.java
++++ ../src_work/common/net/minecraft/src/ChunkCache.java
+@@ -1,5 +1,7 @@
+ package net.minecraft.src;
+ 
++import net.minecraftforge.client.ForgeHooksClient;
++import net.minecraftforge.client.ILightingHandler.LightingType;
+ import cpw.mods.fml.common.Side;
+ import cpw.mods.fml.common.asm.SideOnly;
+ 
+@@ -116,6 +118,9 @@
+     {
+         int var5 = this.getSkyBlockTypeBrightness(EnumSkyBlock.Sky, par1, par2, par3);
+         int var6 = this.getSkyBlockTypeBrightness(EnumSkyBlock.Block, par1, par2, par3);
++        
++        var5 = ForgeHooksClient.modifySkyLightLevel(par1, par2, par3, var5, LightingType.Block);
++        var6 = ForgeHooksClient.modifyBlockLightLevel(par1, par2, par3, var6, LightingType.Block);
+ 
+         if (var6 < par4)
+         {

--- a/patches/common/net/minecraft/src/World.java.patch
+++ b/patches/common/net/minecraft/src/World.java.patch
@@ -1,11 +1,13 @@
 --- ../src_base/common/net/minecraft/src/World.java
 +++ ../src_work/common/net/minecraft/src/World.java
-@@ -10,8 +10,27 @@
+@@ -10,8 +10,29 @@
  import java.util.Random;
  import java.util.Set;
  
 +import com.google.common.collect.SetMultimap;
 +
++import net.minecraftforge.client.ForgeHooksClient;
++import net.minecraftforge.client.ILightingHandler.LightingType;
 +import net.minecraftforge.common.ForgeChunkManager;
 +import net.minecraftforge.common.ForgeChunkManager.Ticket;
 +import net.minecraftforge.common.ForgeHooks;
@@ -28,7 +30,7 @@
      /**
       * boolean; if true updates scheduled by scheduleBlockUpdate happen immediately
       */
-@@ -132,6 +151,11 @@
+@@ -132,6 +153,11 @@
       * Gets the biome for a given set of x/z coordinates
       */
      public BiomeGenBase getBiomeGenForCoords(int par1, int par2)
@@ -40,7 +42,7 @@
      {
          if (this.blockExists(par1, 0, par2))
          {
-@@ -269,7 +293,8 @@
+@@ -269,7 +295,8 @@
       */
      public boolean isAirBlock(int par1, int par2, int par3)
      {
@@ -50,7 +52,7 @@
      }
  
      /**
-@@ -278,7 +303,8 @@
+@@ -278,7 +305,8 @@
      public boolean blockHasTileEntity(int par1, int par2, int par3)
      {
          int var4 = this.getBlockId(par1, par2, par3);
@@ -60,7 +62,17 @@
      }
  
      /**
-@@ -980,7 +1006,7 @@
+@@ -945,6 +973,9 @@
+         int var5 = this.getSkyBlockTypeBrightness(EnumSkyBlock.Sky, par1, par2, par3);
+         int var6 = this.getSkyBlockTypeBrightness(EnumSkyBlock.Block, par1, par2, par3);
+ 
++        var5 = ForgeHooksClient.modifySkyLightLevel(par1, par2, par3, var5, LightingType.Block);
++        var6 = ForgeHooksClient.modifyBlockLightLevel(par1, par2, par3, var6, LightingType.Block);
++
+         if (var6 < par4)
+         {
+             var6 = par4;
+@@ -980,7 +1011,7 @@
       */
      public boolean isDaytime()
      {
@@ -69,7 +81,7 @@
      }
  
      /**
-@@ -1012,7 +1038,7 @@
+@@ -1012,7 +1043,7 @@
                  int var12 = this.getBlockMetadata(var8, var9, var10);
                  Block var13 = Block.blocksList[var11];
  
@@ -78,7 +90,7 @@
                  {
                      MovingObjectPosition var14 = var13.collisionRayTrace(this, var8, var9, var10, par1Vec3, par2Vec3);
  
-@@ -1212,6 +1238,12 @@
+@@ -1212,6 +1243,12 @@
       */
      public void playSoundAtEntity(Entity par1Entity, String par2Str, float par3, float par4)
      {
@@ -91,7 +103,7 @@
          if (par1Entity != null && par2Str != null)
          {
              Iterator var5 = this.worldAccesses.iterator();
-@@ -1312,6 +1344,11 @@
+@@ -1312,6 +1349,11 @@
                  EntityPlayer var5 = (EntityPlayer)par1Entity;
                  this.playerEntities.add(var5);
                  this.updateAllPlayersSleepingFlag();
@@ -103,7 +115,7 @@
              }
  
              this.getChunkFromChunkCoords(var2, var3).addEntity(par1Entity);
-@@ -1563,6 +1600,12 @@
+@@ -1563,6 +1605,12 @@
       * Calculates the color for the skybox
       */
      public Vec3 getSkyColor(Entity par1Entity, float par2)
@@ -116,7 +128,7 @@
      {
          float var3 = this.getCelestialAngle(par2);
          float var4 = MathHelper.cos(var3 * (float)Math.PI * 2.0F) * 2.0F + 0.5F;
-@@ -1658,6 +1701,12 @@
+@@ -1658,6 +1706,12 @@
      @SideOnly(Side.CLIENT)
      public Vec3 drawClouds(float par1)
      {
@@ -129,7 +141,7 @@
          float var2 = this.getCelestialAngle(par1);
          float var3 = MathHelper.cos(var2 * (float)Math.PI * 2.0F) * 2.0F + 0.5F;
  
-@@ -1736,7 +1785,7 @@
+@@ -1736,7 +1790,7 @@
          {
              int var5 = var3.getBlockID(par1, var4, par2);
  
@@ -138,7 +150,7 @@
              {
                  return var4 + 1;
              }
-@@ -1751,6 +1800,12 @@
+@@ -1751,6 +1805,12 @@
       * How bright are stars in the sky
       */
      public float getStarBrightness(float par1)
@@ -151,7 +163,7 @@
      {
          float var2 = this.getCelestialAngle(par1);
          float var3 = 1.0F - (MathHelper.cos(var2 * (float)Math.PI * 2.0F) * 2.0F + 0.25F);
-@@ -1893,7 +1948,7 @@
+@@ -1893,7 +1953,7 @@
  
                      if (var8 != null)
                      {
@@ -160,7 +172,7 @@
                      }
                  }
              }
-@@ -1903,6 +1958,10 @@
+@@ -1903,6 +1963,10 @@
  
          if (!this.entityRemoval.isEmpty())
          {
@@ -171,7 +183,7 @@
              this.loadedTileEntityList.removeAll(this.entityRemoval);
              this.entityRemoval.clear();
          }
-@@ -1923,7 +1982,9 @@
+@@ -1923,7 +1987,9 @@
                      {
                          this.loadedTileEntityList.add(var9);
                      }
@@ -182,7 +194,7 @@
                      if (this.chunkExists(var9.xCoord >> 4, var9.zCoord >> 4))
                      {
                          Chunk var10 = this.getChunkFromChunkCoords(var9.xCoord >> 4, var9.zCoord >> 4);
-@@ -1933,8 +1994,6 @@
+@@ -1933,8 +1999,6 @@
                              var10.setChunkBlockTileEntity(var9.xCoord & 15, var9.yCoord, var9.zCoord & 15, var9);
                          }
                      }
@@ -191,7 +203,7 @@
                  }
              }
  
-@@ -1947,13 +2006,13 @@
+@@ -1947,13 +2011,13 @@
  
      public void addTileEntity(Collection par1Collection)
      {
@@ -212,7 +224,7 @@
          }
      }
  
-@@ -1973,9 +2032,17 @@
+@@ -1973,9 +2037,17 @@
      {
          int var3 = MathHelper.floor_double(par1Entity.posX);
          int var4 = MathHelper.floor_double(par1Entity.posZ);
@@ -233,7 +245,7 @@
          {
              par1Entity.lastTickPosX = par1Entity.posX;
              par1Entity.lastTickPosY = par1Entity.posY;
-@@ -2210,6 +2277,14 @@
+@@ -2210,6 +2282,14 @@
                          {
                              return true;
                          }
@@ -248,7 +260,7 @@
                      }
                  }
              }
-@@ -2516,25 +2591,21 @@
+@@ -2516,25 +2596,21 @@
       */
      public void setBlockTileEntity(int par1, int par2, int par3, TileEntity par4TileEntity)
      {
@@ -289,7 +301,7 @@
          }
      }
  
-@@ -2543,27 +2614,10 @@
+@@ -2543,27 +2619,10 @@
       */
      public void removeBlockTileEntity(int par1, int par2, int par3)
      {
@@ -321,7 +333,7 @@
          }
      }
  
-@@ -2589,7 +2643,8 @@
+@@ -2589,7 +2648,8 @@
       */
      public boolean isBlockNormalCube(int par1, int par2, int par3)
      {
@@ -331,7 +343,7 @@
      }
  
      /**
-@@ -2597,8 +2652,7 @@
+@@ -2597,8 +2657,7 @@
       */
      public boolean doesBlockHaveSolidTopSurface(int par1, int par2, int par3)
      {
@@ -341,7 +353,7 @@
      }
  
      /**
-@@ -2614,7 +2668,7 @@
+@@ -2614,7 +2673,7 @@
              if (var5 != null && !var5.isEmpty())
              {
                  Block var6 = Block.blocksList[this.getBlockId(par1, par2, par3)];
@@ -350,7 +362,7 @@
              }
              else
              {
-@@ -2645,8 +2699,7 @@
+@@ -2645,8 +2704,7 @@
       */
      public void setAllowedSpawnTypes(boolean par1, boolean par2)
      {
@@ -360,7 +372,7 @@
      }
  
      /**
-@@ -2662,6 +2715,11 @@
+@@ -2662,6 +2720,11 @@
       */
      private void calculateInitialWeather()
      {
@@ -372,7 +384,7 @@
          if (this.worldInfo.isRaining())
          {
              this.rainingStrength = 1.0F;
-@@ -2677,6 +2735,11 @@
+@@ -2677,6 +2740,11 @@
       * Updates all weather states.
       */
      protected void updateWeather()
@@ -384,7 +396,7 @@
      {
          if (!this.provider.hasNoSky)
          {
-@@ -2779,12 +2842,14 @@
+@@ -2779,12 +2847,14 @@
  
      public void toggleRain()
      {
@@ -400,7 +412,7 @@
          this.theProfiler.startSection("buildList");
          int var1;
          EntityPlayer var2;
-@@ -2891,6 +2956,11 @@
+@@ -2891,6 +2961,11 @@
       */
      public boolean canBlockFreeze(int par1, int par2, int par3, boolean par4)
      {
@@ -412,7 +424,7 @@
          BiomeGenBase var5 = this.getBiomeGenForCoords(par1, par3);
          float var6 = var5.getFloatTemperature();
  
-@@ -2948,6 +3018,11 @@
+@@ -2948,6 +3023,11 @@
       * Tests whether or not snow can be placed at a given location
       */
      public boolean canSnowAt(int par1, int par2, int par3)
@@ -424,7 +436,7 @@
      {
          BiomeGenBase var4 = this.getBiomeGenForCoords(par1, par3);
          float var5 = var4.getFloatTemperature();
-@@ -3041,7 +3116,7 @@
+@@ -3041,7 +3121,7 @@
  
      private int computeBlockLightValue(int par1, int par2, int par3, int par4, int par5, int par6)
      {
@@ -433,7 +445,7 @@
          int var8 = this.getSavedLightValue(EnumSkyBlock.Block, par2 - 1, par3, par4) - par6;
          int var9 = this.getSavedLightValue(EnumSkyBlock.Block, par2 + 1, par3, par4) - par6;
          int var10 = this.getSavedLightValue(EnumSkyBlock.Block, par2, par3 - 1, par4) - par6;
-@@ -3309,10 +3384,10 @@
+@@ -3309,10 +3389,10 @@
      public List getEntitiesWithinAABBExcludingEntity(Entity par1Entity, AxisAlignedBB par2AxisAlignedBB)
      {
          this.entitiesWithinAABBExcludingEntity.clear();
@@ -448,7 +460,7 @@
  
          for (int var7 = var3; var7 <= var4; ++var7)
          {
-@@ -3333,10 +3408,10 @@
+@@ -3333,10 +3413,10 @@
       */
      public List getEntitiesWithinAABB(Class par1Class, AxisAlignedBB par2AxisAlignedBB)
      {
@@ -463,7 +475,7 @@
          ArrayList var7 = new ArrayList();
  
          for (int var8 = var3; var8 <= var4; ++var8)
-@@ -3425,11 +3500,14 @@
+@@ -3425,11 +3505,14 @@
       */
      public void addLoadedEntities(List par1List)
      {
@@ -481,7 +493,7 @@
          }
      }
  
-@@ -3466,7 +3544,10 @@
+@@ -3466,7 +3549,10 @@
              {
                  var9 = null;
              }
@@ -493,7 +505,7 @@
              return par1 > 0 && var9 == null && var10.canPlaceBlockOnSide(this, par2, par3, par4, par6);
          }
      }
-@@ -3656,7 +3737,7 @@
+@@ -3656,7 +3742,7 @@
       */
      public void setWorldTime(long par1)
      {
@@ -502,7 +514,7 @@
      }
  
      /**
-@@ -3664,12 +3745,12 @@
+@@ -3664,12 +3750,12 @@
       */
      public long getSeed()
      {
@@ -517,7 +529,7 @@
      }
  
      /**
-@@ -3677,13 +3758,13 @@
+@@ -3677,13 +3763,13 @@
       */
      public ChunkCoordinates getSpawnPoint()
      {
@@ -533,7 +545,7 @@
      }
  
      @SideOnly(Side.CLIENT)
-@@ -3707,7 +3788,10 @@
+@@ -3707,7 +3793,10 @@
  
          if (!this.loadedEntityList.contains(par1Entity))
          {
@@ -545,7 +557,7 @@
          }
      }
  
-@@ -3715,6 +3799,11 @@
+@@ -3715,6 +3804,11 @@
       * Called when checking if a certain block can be mined or not. The 'spawn safe zone' check is located here.
       */
      public boolean canMineBlock(EntityPlayer par1EntityPlayer, int par2, int par3, int par4)
@@ -557,7 +569,7 @@
      {
          return true;
      }
-@@ -3827,8 +3916,7 @@
+@@ -3827,8 +3921,7 @@
       */
      public boolean isBlockHighHumidity(int par1, int par2, int par3)
      {
@@ -567,7 +579,7 @@
      }
  
      /**
-@@ -3882,7 +3970,7 @@
+@@ -3882,7 +3975,7 @@
       */
      public int getHeight()
      {
@@ -576,7 +588,7 @@
      }
  
      /**
-@@ -3890,7 +3978,7 @@
+@@ -3890,7 +3983,7 @@
       */
      public int getActualHeight()
      {
@@ -585,7 +597,7 @@
      }
  
      /**
-@@ -3936,7 +4024,7 @@
+@@ -3936,7 +4029,7 @@
       */
      public double getHorizon()
      {
@@ -594,7 +606,7 @@
      }
  
      /**
-@@ -3964,4 +4052,75 @@
+@@ -3964,4 +4057,75 @@
              var7.destroyBlockPartially(par1, par2, par3, par4, par5);
          }
      }


### PR DESCRIPTION
Research has provided the following in terms of performance:
- Light values for blocks are cached. No real persistent performance hit.
- Light values for entities are checked every frame, however there are significantly less of these than blocks. Anything that can be run for a block when a chunk loads shouldn't have issues with this limitation.

Clearly, anything that uses this hook will need to be pretty well optimised as it could be prone to lag spikes when chunks load. All lag is limited to the client as this is purely client side (totally limited to rendering code) so it should scale fine in SMP.

There is a (somewhat bad, for now) example client implementation available here: https://github.com/monoxide0184/Lanterns.

Relevant code is in `ClientProxy` and `*ZeroTorch`.
