### PR TITLE
Change to RenderName in RenderPlayer.class

### DIFF
--- a/patches/minecraft/net/minecraft/src/RenderPlayer.java.patch
+++ b/patches/minecraft/net/minecraft/src/RenderPlayer.java.patch
@@ -1,8 +1,10 @@
 --- ../src_base/minecraft/net/minecraft/src/RenderPlayer.java
 +++ ../src_work/minecraft/net/minecraft/src/RenderPlayer.java
-@@ -3,6 +3,12 @@
- import cpw.mods.fml.common.Side;
- import cpw.mods.fml.common.asm.SideOnly;
+@@ -1,15 +1,25 @@
+ package net.minecraft.src;
+ 
++import cpw.mods.fml.common.Side;
++import cpw.mods.fml.common.asm.SideOnly;
  import net.minecraft.client.Minecraft;
 +import static net.minecraftforge.client.IItemRenderer.ItemRenderType.*;
 +import static net.minecraftforge.client.IItemRenderer.ItemRendererHelper.*;
@@ -12,8 +14,21 @@
 +
  import org.lwjgl.opengl.GL11;
  
- @SideOnly(Side.CLIENT)
-@@ -35,7 +41,7 @@
++@SideOnly(Side.CLIENT)
+ public class RenderPlayer extends RenderLiving
+ {
+     private ModelBiped modelBipedMain;
+     private ModelBiped modelArmorChestplate;
+     private ModelBiped modelArmor;
+-    private static final String[] armorFilenamePrefix = new String[] {"cloth", "chain", "iron", "diamond", "gold"};
+-
++    public static String[] armorFilenamePrefix = new String[] {"cloth", "chain", "iron", "diamond", "gold"};
++    public static float NameTagRenderRange = 64.0f;
++    public static float NameTagSneakRenderRange = 32.0f;
+     public RenderPlayer()
+     {
+         super(new ModelBiped(0.0F), 0.5F);
+@@ -32,7 +42,7 @@
              if (var5 instanceof ItemArmor)
              {
                  ItemArmor var6 = (ItemArmor)var5;
@@ -22,7 +37,16 @@
                  ModelBiped var7 = par2 == 2 ? this.modelArmor : this.modelArmorChestplate;
                  var7.bipedHead.showModel = par2 == 0;
                  var7.bipedHeadwear.showModel = par2 == 0;
-@@ -159,12 +165,14 @@
+@@ -98,7 +108,7 @@
+             float var8 = 1.6F;
+             float var9 = 0.016666668F * var8;
+             double var10 = par1EntityPlayer.getDistanceSqToEntity(this.renderManager.livingPlayer);
+-            float var12 = par1EntityPlayer.isSneaking() ? 32.0F : 64.0F;
++            float var12 = par1EntityPlayer.isSneaking() ? NameTagSneakRenderRange : NameTagRenderRange;
+ 
+             if (var10 < (double)(var12 * var12))
+             {
+@@ -156,12 +166,14 @@
          super.renderEquippedItems(par1EntityPlayer, par2);
          ItemStack var3 = par1EntityPlayer.inventory.armorItemInSlot(3);
  
@@ -31,16 +55,15 @@
          {
              GL11.glPushMatrix();
              this.modelBipedMain.bipedHead.postRender(0.0625F);
--
--            if (RenderBlocks.renderItemIn3d(Block.blocksList[var3.itemID].getRenderType()))
 +            IItemRenderer customRenderer = MinecraftForgeClient.getItemRenderer(var3, EQUIPPED);
 +            boolean is3D = (customRenderer != null && customRenderer.shouldUseRenderHelper(EQUIPPED, var3, BLOCK_3D));
-+
+ 
+-            if (RenderBlocks.renderItemIn3d(Block.blocksList[var3.itemID].getRenderType()))
 +            if (is3D || RenderBlocks.renderItemIn3d(Block.blocksList[var3.itemID].getRenderType()))
              {
                  float var4 = 0.625F;
                  GL11.glTranslatef(0.0F, -0.25F, 0.0F);
-@@ -266,7 +274,10 @@
+@@ -263,7 +275,10 @@
                  var20 = var21.getItemUseAction();
              }
  
@@ -52,7 +75,7 @@
              {
                  var6 = 0.5F;
                  GL11.glTranslatef(0.0F, 0.1875F, -0.3125F);
-@@ -319,7 +330,7 @@
+@@ -316,7 +331,7 @@
  
              if (var21.getItem().requiresMultipleRenderPasses())
              {


### PR DESCRIPTION
This change in the patch will will allow for the range by which the name renders at to be changed
from outside the class. Its nothing overly complex and is a really simple fix to controlling the render range for my my ComeCloser.  Which i wan't to make compatible with other mods that modify RenderPlayer.class without making a new class file per mod. With this change all other mods will have this change in the version of RenderPlayer.class

I made a request for this a while back but just now figured out how to make a patch file. Here is the original request thread on the forge forum http://www.minecraftforge.net/forum/index.php/topic,1406.0.html
