### PR TITLE
Allow access to a world's save directory

### DIFF
--- a/common/forge_at.cfg
+++ b/common/forge_at.cfg
@@ -63,3 +63,7 @@ public ahi.a(Lahi;)I # getNAdjacentTiles
 public og.a(Lnj;)V # joinEntityItemWithWorld
 #EntityPlayerMP
 public atg.a(Lnj;)V # joinEntityItemWithWorld
+# SaveHandler
+public aeb.b()Ljava/io/File; # getSaveDirectory
+# World
+public up.z # saveHandler


### PR DESCRIPTION
Unlocking World.saveHandler and SaveHandler.getSaveDirectory to allow mods to access a world's save directory without reflection.

Mods that will benefit from it are a project of mine, CodeChickenCore, RedPower, ComputerCraft and Portal Gun.
