### PR TITLE
Allow block to determine whether the renderer should apply stair and half slab lighting fixes to it

### DIFF
--- a/patches/common/net/minecraft/src/Block.java.patch
+++ b/patches/common/net/minecraft/src/Block.java.patch
@@ -102,7 +102,7 @@
          {
              ItemStack var8 = this.createStackedBlock(par6);
  
-@@ -1249,4 +1255,797 @@
+@@ -1249,4 +1255,811 @@
          canBlockGrass[0] = true;
          StatList.initBreakableStats();
      }
@@ -120,6 +120,20 @@
 +    public int getLightValue(IBlockAccess world, int x, int y, int z) 
 +    {
 +        return lightValue[blockID];
++    }
++    
++    @SideOnly(Side.CLIENT)
++
++    /**
++     * Determines whether to apply stair and half slab lighting fixes to this block
++     * 
++     * @return true if lighting fixes should be applied
++     */
++    public boolean useHalfSlabStairLightingCalculations()
++    {
++        return blockID == stoneSingleSlab.blockID || blockID == woodSingleSlab.blockID || blockID == tilledField.blockID || blockID == stairCompactPlanks.blockID || blockID == stairCompactCobblestone.blockID
++                || blockID == stairsBrick.blockID || blockID == stairsStoneBrickSmooth.blockID || blockID == stairsNetherBrick.blockID || blockID == stairsSandStone.blockID || blockID == stairsWoodSpruce.blockID
++                || blockID == stairsWoodBirch.blockID || blockID == stairsWoodJungle.blockID;
 +    }
 +
 +    /**

--- a/patches/common/net/minecraft/src/ChunkCache.java.patch
+++ b/patches/common/net/minecraft/src/ChunkCache.java.patch
@@ -1,0 +1,11 @@
+--- ../src_base/common/net/minecraft/src/ChunkCache.java
++++ ../src_work/common/net/minecraft/src/ChunkCache.java
+@@ -162,7 +162,7 @@
+             {
+                 var5 = this.getBlockId(par1, par2, par3);
+ 
+-                if (var5 == Block.stoneSingleSlab.blockID || var5 == Block.woodSingleSlab.blockID || var5 == Block.tilledField.blockID || var5 == Block.stairCompactPlanks.blockID || var5 == Block.stairCompactCobblestone.blockID)
++                if (var5 != 0 && Block.blocksList[var5] != null && Block.blocksList[var5].useHalfSlabStairLightingCalculations())
+                 {
+                     var6 = this.getLightValueExt(par1, par2 + 1, par3, false);
+                     int var7 = this.getLightValueExt(par1 + 1, par2, par3, false);


### PR DESCRIPTION
This allows modded half slabs and stairs and their shadows to be rendered properly without having to decrease lightOpacity for the block.

Currently the only solution is to write a custom renderer to eliminate shadows on the block itself and to set the blocks LightOpacity to 0 to prevent shadows on adjacent blocks. _Side effect of this is that light shines through custom slabs and stairs..._
