### PR TITLE
Restrictive inventory mechanism to fix the infinite xp issue

### DIFF
--- a/common/net/minecraftforge/common/IRestrictiveInventory.java
+++ b/common/net/minecraftforge/common/IRestrictiveInventory.java
@@ -1,0 +1,27 @@
+/**
+ * This software is provided under the terms of the Minecraft Forge Public
+ * License v1.0.
+ */
+
+package net.minecraftforge.common;
+
+import net.minecraft.src.IInventory;
+import net.minecraft.src.ItemStack;
+
+/**
+ * Allows the implementing inventory to veto on stacks beeing added to it. 
+ * 
+ * @author Xfel
+ */
+public interface IRestrictiveInventory extends IInventory {
+	
+	/**
+	 * Queries whether an item may be added.
+	 * 
+	 * @param slot the slot the item would be added to
+	 * @param item the item stack that would be added
+	 * @return <code>true</code> if the item is allowed, <code>false</code> otherwise
+	 */
+	boolean isItemValid(int slot, ItemStack item);
+	
+}

--- a/patches/common/net/minecraft/src/Slot.java.patch
+++ b/patches/common/net/minecraft/src/Slot.java.patch
@@ -1,0 +1,18 @@
+--- ../src_base/common/net/minecraft/src/Slot.java
++++ ../src_work/common/net/minecraft/src/Slot.java
+@@ -1,5 +1,6 @@
+ package net.minecraft.src;
+ 
++import net.minecraftforge.common.IRestrictiveInventory;
+ import cpw.mods.fml.common.Side;
+ import cpw.mods.fml.common.asm.SideOnly;
+ 
+@@ -71,6 +72,8 @@
+      */
+     public boolean isItemValid(ItemStack par1ItemStack)
+     {
++        if (inventory instanceof IRestrictiveInventory) 
++            return ((IRestrictiveInventory) inventory).isItemValid(slotIndex, par1ItemStack);
+         return true;
+     }
+ 

--- a/patches/common/net/minecraft/src/TileEntityBrewingStand.java.patch
+++ b/patches/common/net/minecraft/src/TileEntityBrewingStand.java.patch
@@ -1,18 +1,19 @@
 --- ../src_base/common/net/minecraft/src/TileEntityBrewingStand.java
 +++ ../src_work/common/net/minecraft/src/TileEntityBrewingStand.java
-@@ -4,7 +4,10 @@
+@@ -4,7 +4,11 @@
  import cpw.mods.fml.common.asm.SideOnly;
  import java.util.List;
  
 -public class TileEntityBrewingStand extends TileEntity implements IInventory
++import net.minecraftforge.common.IRestrictiveInventory;
 +import net.minecraftforge.common.ISidedInventory;
 +import net.minecraftforge.common.ForgeDirection;
 +
-+public class TileEntityBrewingStand extends TileEntity implements IInventory, ISidedInventory
++public class TileEntityBrewingStand extends TileEntity implements IInventory, ISidedInventory, IRestrictiveInventory
  {
      /** The itemstacks currently placed in the slots of the brewing stand */
      private ItemStack[] brewingItemStacks = new ItemStack[4];
-@@ -158,7 +161,7 @@
+@@ -158,7 +162,7 @@
  
              if (Item.itemsList[var1.itemID].hasContainerItem())
              {
@@ -21,7 +22,7 @@
              }
              else
              {
-@@ -325,4 +328,16 @@
+@@ -325,4 +329,24 @@
  
          return var1;
      }
@@ -36,5 +37,13 @@
 +    public int getSizeInventorySide(ForgeDirection side)
 +    {
 +        return (side == ForgeDirection.UP ? 1 : 3);
++    }
++    
++    @Override
++    public boolean isItemValid(int slot, ItemStack item)
++    {
++        if (slot == 3) 
++            return item != null ? Item.itemsList[item.itemID].isPotionIngredient() : false;
++        return SlotBrewingStandPotion.func_75243_a_(item);
 +    }
  }

--- a/patches/common/net/minecraft/src/TileEntityFurnace.java.patch
+++ b/patches/common/net/minecraft/src/TileEntityFurnace.java.patch
@@ -1,8 +1,9 @@
 --- ../src_base/common/net/minecraft/src/TileEntityFurnace.java
 +++ ../src_work/common/net/minecraft/src/TileEntityFurnace.java
-@@ -1,11 +1,13 @@
+@@ -1,11 +1,14 @@
  package net.minecraft.src;
  
++import net.minecraftforge.common.IRestrictiveInventory;
 +import net.minecraftforge.common.ISidedInventory;
 +import net.minecraftforge.common.ForgeDirection;
  import cpw.mods.fml.common.registry.GameRegistry;
@@ -11,11 +12,11 @@
  import cpw.mods.fml.common.asm.SideOnly;
  
 -public class TileEntityFurnace extends TileEntity implements IInventory
-+public class TileEntityFurnace extends TileEntity implements IInventory, ISidedInventory
++public class TileEntityFurnace extends TileEntity implements IInventory, ISidedInventory, IRestrictiveInventory
  {
      /**
       * The ItemStacks that hold the items currently being used in the furnace
-@@ -235,8 +237,7 @@
+@@ -235,8 +238,7 @@
  
                          if (this.furnaceItemStacks[1].stackSize == 0)
                          {
@@ -25,7 +26,7 @@
                          }
                      }
                  }
-@@ -282,8 +283,12 @@
+@@ -282,8 +284,12 @@
          }
          else
          {
@@ -40,7 +41,7 @@
          }
      }
  
-@@ -294,15 +299,15 @@
+@@ -294,15 +300,15 @@
      {
          if (this.canSmelt())
          {
@@ -60,7 +61,7 @@
              }
  
              --this.furnaceItemStacks[0].stackSize;
-@@ -329,7 +334,7 @@
+@@ -329,7 +335,7 @@
              int var1 = par0ItemStack.getItem().shiftedIndex;
              Item var2 = par0ItemStack.getItem();
  
@@ -69,7 +70,7 @@
              {
                  Block var3 = Block.blocksList[var1];
  
-@@ -374,4 +379,18 @@
+@@ -374,4 +380,24 @@
      public void openChest() {}
  
      public void closeChest() {}
@@ -86,5 +87,11 @@
 +    public int getSizeInventorySide(ForgeDirection side)
 +    {
 +        return 1;
++    }
++    
++    @Override
++    public boolean isItemValid(int slot, ItemStack item)
++    {
++        return slot != 2;
 +    }
  }


### PR DESCRIPTION
The new interface IRestrictiveInventory provides a way to ask an
inventory whether it allows a specified item stack in a given slot. As
the Slot class already has such a query, which returns tre by default, I
patched it to use the interface if available. I also implemented the
interface on TileEntityFurnace and TileEntityBrewingStand to match the
gui behaviour.

If properly respected by modders, this will solve the infinite xp issue
https://github.com/MinecraftForge/MinecraftForge/issues/161 
