### PR TITLE
Take player strength into account, even if they can't actually harvest a block.

### DIFF
--- a/common/net/minecraftforge/common/ForgeHooks.java
+++ b/common/net/minecraftforge/common/ForgeHooks.java
@@ -112,7 +112,7 @@ public class ForgeHooks
 
         if (!canHarvestBlock(block, player, metadata))
         {
-            return 1.0F / hardness / 100F;
+            return player.getCurrentPlayerStrVsBlock(block, metadata) / hardness / 100F;
         }
         else
         {


### PR DESCRIPTION
This means that breaking blocks while swimming/flying/etc and relevant enchants work as intended.

Also fixes #188 (should get closed automatically on merge)
