### PR TITLE
Fixed is/setHandeled event method/field names

### DIFF
--- a/common/net/minecraftforge/event/entity/UseHoeEvent.java
+++ b/common/net/minecraftforge/event/entity/UseHoeEvent.java
@@ -16,7 +16,7 @@ public class UseHoeEvent extends PlayerEvent
     public final int y;
     public final int z;
     
-    private boolean handeled = false;
+    private boolean handled = false;
     
     public UseHoeEvent(EntityPlayer player, ItemStack current, World world, int x, int y, int z)
     {
@@ -28,13 +28,19 @@ public class UseHoeEvent extends PlayerEvent
         this.z = z;
     }
 
-    public boolean isHandeled()
+    public boolean isHandled()
     {
-        return handeled;
+        return handled;
     }
     
+    public void setHandled()
+    {
+        handled = true;
+    }
+    
+    @Deprecated
     public void setHandeled()
     {
-        handeled = true;
+        this.setHandled();
     }
 }

--- a/common/net/minecraftforge/event/entity/living/LivingSpecialSpawnEvent.java
+++ b/common/net/minecraftforge/event/entity/living/LivingSpecialSpawnEvent.java
@@ -9,7 +9,7 @@ public class LivingSpecialSpawnEvent extends LivingEvent
     public final float x;
     public final float y;
     public final float z;
-    private boolean handeled = false;
+    private boolean handled = false;
     
     public LivingSpecialSpawnEvent(EntityLiving entity, World world, float x, float y, float z)
     {
@@ -20,13 +20,19 @@ public class LivingSpecialSpawnEvent extends LivingEvent
         this.z = z;
     }
     
-    public void setHandeled()
+    public boolean isHandled()
     {
-        handeled = true;
+        return handled;
     }
     
-    public boolean isHandeled()
+    public void setHandled()
     {
-        return handeled;
+        handled = true;
+    }
+    
+    @Deprecated
+    public void setHandeled()
+    {
+        this.setHandled();
     }
 }

--- a/common/net/minecraftforge/event/entity/player/BonemealEvent.java
+++ b/common/net/minecraftforge/event/entity/player/BonemealEvent.java
@@ -12,7 +12,7 @@ public class BonemealEvent extends PlayerEvent
     public final int X;
     public final int Y;
     public final int Z;
-    private boolean handeled = false;
+    private boolean handled = false;
     
     public BonemealEvent(EntityPlayer player, World world, int id, int x, int y, int z)
     {
@@ -24,13 +24,19 @@ public class BonemealEvent extends PlayerEvent
         this.Z = z;
     }
     
-    public void setHandeled()
+    public boolean isHandled()
     {
-        handeled = true;
+        return handled;
     }
     
-    public boolean isHandeled()
+    public void setHandled()
     {
-        return handeled;
+        handled = true;
+    }
+    
+    @Deprecated
+    public void setHandeled()
+    {
+        this.setHandled();
     }
 }

--- a/common/net/minecraftforge/event/entity/player/FillBucketEvent.java
+++ b/common/net/minecraftforge/event/entity/player/FillBucketEvent.java
@@ -14,7 +14,7 @@ public class FillBucketEvent extends PlayerEvent
     public final MovingObjectPosition target;
     
     public ItemStack result;
-    private boolean handeled = false;
+    private boolean handled = false;
     
     public FillBucketEvent(EntityPlayer player, ItemStack current, World world, MovingObjectPosition target)
     {
@@ -24,13 +24,19 @@ public class FillBucketEvent extends PlayerEvent
         this.target = target;
     }
     
-    public boolean isHandeled()
+    public boolean isHandled()
     {
-        return handeled;
+        return handled;
     }
     
+    public void setHandled()
+    {
+        handled = true;
+    }
+    
+    @Deprecated
     public void setHandeled()
     {
-        handeled = true;
+        this.setHandled();
     }
 }

--- a/patches/common/net/minecraft/src/ItemBucket.java.patch
+++ b/patches/common/net/minecraft/src/ItemBucket.java.patch
@@ -18,7 +18,7 @@
 +                return par1ItemStack;
 +            }
 +
-+            if (event.isHandeled())
++            if (event.isHandled())
 +            {
 +                if (par3EntityPlayer.capabilities.isCreativeMode)
 +                {

--- a/patches/common/net/minecraft/src/ItemDye.java.patch
+++ b/patches/common/net/minecraft/src/ItemDye.java.patch
@@ -22,7 +22,7 @@
 +                    return false;
 +                }
 +
-+                if (event.isHandeled())
++                if (event.isHandled())
 +                {
 +                   if (!par3World.isRemote)
 +                    {

--- a/patches/common/net/minecraft/src/ItemHoe.java.patch
+++ b/patches/common/net/minecraft/src/ItemHoe.java.patch
@@ -17,7 +17,7 @@
 +            {
 +                return false;
 +            }
-+            if (event.isHandeled())
++            if (event.isHandled())
 +            {
 +                par1ItemStack.damageItem(1, par2EntityPlayer);
 +                return true;

--- a/patches/common/net/minecraft/src/SpawnerAnimals.java.patch
+++ b/patches/common/net/minecraft/src/SpawnerAnimals.java.patch
@@ -41,7 +41,7 @@
      {
 +        LivingSpecialSpawnEvent event = new LivingSpecialSpawnEvent(par0EntityLiving, par1World, par2, par3, par4);
 +        MinecraftForge.EVENT_BUS.post(event);
-+        if (event.isHandeled())
++        if (event.isHandled())
 +        {
 +            return;
 +        }


### PR DESCRIPTION
The spelling of these trips me up any time I code-search for "handled" so I finally got off my ass and fixed them.

Left in the `setHandeled()` methods, for backwards compatibility, so existing event code shouldn't break and set them `@Deprecated` so modders see warnings to fix it.
