### PR TITLE
Modified BlockPistonBase to check correct maximum world height and post orientation event

### DIFF
--- a/common/net/minecraftforge/event/entity/block/BlockEvent.java
+++ b/common/net/minecraftforge/event/entity/block/BlockEvent.java
@@ -1,0 +1,19 @@
+package net.minecraftforge.event.entity.block;
+
+import net.minecraft.src.EntityLiving;
+import net.minecraft.src.World;
+import net.minecraftforge.event.entity.living.LivingEvent;
+
+public class BlockEvent extends LivingEvent
+{
+    public World world;
+    public int blockX, blockY, blockZ;
+    
+    public BlockEvent(World world, EntityLiving entity, int x, int y, int z) {
+        super(entity);
+        this.world = world;
+        this.blockX = x;
+        this.blockY = y;
+        this.blockZ = z;
+    }
+}

--- a/common/net/minecraftforge/event/entity/block/BlockOrientationEvent.java
+++ b/common/net/minecraftforge/event/entity/block/BlockOrientationEvent.java
@@ -1,0 +1,15 @@
+package net.minecraftforge.event.entity.block;
+
+import net.minecraft.src.EntityLiving;
+import net.minecraft.src.World;
+import net.minecraftforge.event.entity.EntityEvent;
+
+public class BlockOrientationEvent extends BlockPlacementEvent
+{
+    
+    public BlockOrientationEvent(World world, EntityLiving entity, int x, int y, int z)
+    {
+        super(world, entity, x, y, z);
+    }
+
+}

--- a/common/net/minecraftforge/event/entity/block/BlockPlacementEvent.java
+++ b/common/net/minecraftforge/event/entity/block/BlockPlacementEvent.java
@@ -1,0 +1,14 @@
+package net.minecraftforge.event.entity.block;
+
+import net.minecraft.src.EntityLiving;
+import net.minecraft.src.World;
+
+public class BlockPlacementEvent extends BlockEvent
+{
+
+    public BlockPlacementEvent(World world, EntityLiving entity, int x, int y, int z)
+    {
+        super(world, entity, x, y, z);
+    }
+
+}

--- a/patches/common/net/minecraft/src/BlockPistonBase.java.patch
+++ b/patches/common/net/minecraft/src/BlockPistonBase.java.patch
@@ -1,6 +1,61 @@
 --- ../src_base/common/net/minecraft/src/BlockPistonBase.java
 +++ ../src_work/common/net/minecraft/src/BlockPistonBase.java
-@@ -368,7 +368,7 @@
+@@ -3,6 +3,9 @@
+ import cpw.mods.fml.common.Side;
+ import cpw.mods.fml.common.asm.SideOnly;
+ import java.util.List;
++
++import net.minecraftforge.common.MinecraftForge;
++import net.minecraftforge.event.entity.block.BlockOrientationEvent;
+ 
+ public class BlockPistonBase extends Block
+ {
+@@ -310,31 +313,36 @@
+     {
+         return (par0 & 8) != 0;
+     }
+-
++    
+     /**
+      * gets the way this piston should face for that entity that placed it.
+      */
+     public static int determineOrientation(World par0World, int par1, int par2, int par3, EntityPlayer par4EntityPlayer)
+     {
+-        if (MathHelper.abs((float)par4EntityPlayer.posX - (float)par1) < 2.0F && MathHelper.abs((float)par4EntityPlayer.posZ - (float)par3) < 2.0F)
+-        {
+-            double var5 = par4EntityPlayer.posY + 1.82D - (double)par4EntityPlayer.yOffset;
+-
+-            if (var5 - (double)par2 > 2.0D)
++        BlockOrientationEvent event = new BlockOrientationEvent(par0World, par4EntityPlayer, par1, par2, par3);
++        
++        MinecraftForge.EVENT_BUS.post(event);
++        
++        if (MathHelper.abs((float)event.entityLiving.posX - (float)event.blockX) < 2.0F && MathHelper.abs((float)event.entityLiving.posZ - (float)event.blockZ) < 2.0F)
++        {
++            double var5 = event.entityLiving.posY + 1.82D - (double)event.entityLiving.yOffset;
++
++            if (var5 - (double)event.blockY > 2.0D)
+             {
+                 return 1;
+             }
+ 
+-            if ((double)par2 - var5 > 0.0D)
++            if ((double)event.blockY - var5 > 0.0D)
+             {
+                 return 0;
+             }
+         }
+ 
+-        int var7 = MathHelper.floor_double((double)(par4EntityPlayer.rotationYaw * 4.0F / 360.0F) + 0.5D) & 3;
++        int var7 = MathHelper.floor_double((double)(event.entityLiving.rotationYaw * 4.0F / 360.0F) + 0.5D) & 3;
+         return var7 == 0 ? 2 : (var7 == 1 ? 5 : (var7 == 2 ? 3 : (var7 == 3 ? 4 : 0)));
+     }
+ 
++
+     /**
+      * returns true if the piston can push the specified block
+      */
+@@ -368,7 +376,7 @@
                  return false;
              }
  
@@ -9,3 +64,21 @@
          }
      }
  
+@@ -386,7 +394,7 @@
+         {
+             if (var8 < 13)
+             {
+-                if (var6 <= 0 || var6 >= 255)
++                if (var6 <= 0 || var6 >= par0World.getHeight() - 1)
+                 {
+                     return false;
+                 }
+@@ -436,7 +444,7 @@
+ 
+             if (var9 < 13)
+             {
+-                if (var7 <= 0 || var7 >= 255)
++                if (var7 <= 0 || var7 >= par1World.getHeight() - 1)
+                 {
+                     return false;
+                 }


### PR DESCRIPTION
Modified BlockPistonBase
- tryExtend and canExtend methods modified
- changed the y >= 255 to y >= world.getHeight() - 1
- determineOrientation
  - posts a BlockOrientationEvent
  - this allows mods to register a handler
  - this will intercept the event that parses world, entity, x, y, z

Note: this will currently allow Pistons and Logs to work correctly in the LittleBlocksMod without the base edit.
