### PR TITLE
Allows modders to use a custom GuiSlot container background.

### DIFF
--- a/patches/minecraft/net/minecraft/src/GuiSlot.java.patch
+++ b/patches/minecraft/net/minecraft/src/GuiSlot.java.patch
@@ -1,0 +1,39 @@
+--- ../src_base/minecraft/net/minecraft/src/GuiSlot.java
++++ ../src_work/minecraft/net/minecraft/src/GuiSlot.java
+@@ -331,16 +331,7 @@
+         GL11.glDisable(GL11.GL_LIGHTING);
+         GL11.glDisable(GL11.GL_FOG);
+         Tessellator var18 = Tessellator.instance;
+-        GL11.glBindTexture(GL11.GL_TEXTURE_2D, this.mc.renderEngine.getTexture("/gui/background.png"));
+-        GL11.glColor4f(1.0F, 1.0F, 1.0F, 1.0F);
+-        float var17 = 32.0F;
+-        var18.startDrawingQuads();
+-        var18.setColorOpaque_I(2105376);
+-        var18.addVertexWithUV((double)this.left, (double)this.bottom, 0.0D, (double)((float)this.left / var17), (double)((float)(this.bottom + (int)this.amountScrolled) / var17));
+-        var18.addVertexWithUV((double)this.right, (double)this.bottom, 0.0D, (double)((float)this.right / var17), (double)((float)(this.bottom + (int)this.amountScrolled) / var17));
+-        var18.addVertexWithUV((double)this.right, (double)this.top, 0.0D, (double)((float)this.right / var17), (double)((float)(this.top + (int)this.amountScrolled) / var17));
+-        var18.addVertexWithUV((double)this.left, (double)this.top, 0.0D, (double)((float)this.left / var17), (double)((float)(this.top + (int)this.amountScrolled) / var17));
+-        var18.draw();
++        this.drawContainerBackground(var18);
+         var9 = this.width / 2 - 92 - 16;
+         var10 = this.top + 4 - (int)this.amountScrolled;
+ 
+@@ -484,4 +475,18 @@
+         var5.addVertexWithUV(0.0D, (double)par1, 0.0D, 0.0D, (double)((float)par1 / var6));
+         var5.draw();
+     }
++    
++    public void drawContainerBackground(Tessellator par1Tessellator)
++    {
++        GL11.glBindTexture(GL11.GL_TEXTURE_2D, this.mc.renderEngine.getTexture("/gui/background.png"));
++        GL11.glColor4f(1.0F, 1.0F, 1.0F, 1.0F);
++        float var2 = 32.0F;
++        par1Tessellator.startDrawingQuads();
++        par1Tessellator.setColorOpaque_I(2105376);
++        par1Tessellator.addVertexWithUV((double)this.left, (double)this.bottom, 0.0D, (double)((float)this.left / var2), (double)((float)(this.bottom + (int)this.amountScrolled) / var2));
++        par1Tessellator.addVertexWithUV((double)this.right, (double)this.bottom, 0.0D, (double)((float)this.right / var2), (double)((float)(this.bottom + (int)this.amountScrolled) / var2));
++        par1Tessellator.addVertexWithUV((double)this.right, (double)this.top, 0.0D, (double)((float)this.right / var2), (double)((float)(this.top + (int)this.amountScrolled) / var2));
++        par1Tessellator.addVertexWithUV((double)this.left, (double)this.top, 0.0D, (double)((float)this.left / var2), (double)((float)(this.top + (int)this.amountScrolled) / var2));
++        par1Tessellator.draw();
++    }
+ }


### PR DESCRIPTION
Example usage:

http://i.imgur.com/6CyTA.png

I understand this isn't a major addition into Forge, but would really help for the few people that want to change the background of a Slot GUI without editing base files.

If you would like anything changed let me know.
