### PR TITLE
Add possibility to replace built-in world providers to DimensionManager

### DIFF
--- a/common/net/minecraftforge/common/DimensionManager.java
+++ b/common/net/minecraftforge/common/DimensionManager.java
@@ -40,7 +40,20 @@ public class DimensionManager
         spawnSettings.put(id, keepLoaded);
         return true;
     }
-
+    
+    public static boolean replaceProvider(int id, Class<? extends WorldProvider> provider, boolean keepLoaded)
+    {
+        MinecraftServer server=MinecraftServer.getServer();
+        if (server!=null)
+            if (server.isServerRunning())
+                return false;
+        
+        providers.put(id, provider);
+        spawnSettings.put(id, keepLoaded);
+        
+        return true;
+    }
+    
     public static void init()
     {
         if (hasInit)


### PR DESCRIPTION
For mods like SkyZone or non-existant yet superflat Nether/End. Hope it will be useful.
