### PR TITLE
Fixed an Issue with Creative tab not updating properly

### DIFF
--- a/patches/minecraft/net/minecraft/src/GuiContainerCreative.java.patch
+++ b/patches/minecraft/net/minecraft/src/GuiContainerCreative.java.patch
@@ -183,7 +183,7 @@
          itemRenderer.renderItemIntoGUI(this.fontRenderer, this.mc.renderEngine, var10, var7, var8);
          itemRenderer.renderItemOverlayIntoGUI(this.fontRenderer, this.mc.renderEngine, var10, var7, var8);
          GL11.glDisable(GL11.GL_LIGHTING);
-@@ -729,6 +801,15 @@
+@@ -729,6 +801,17 @@
          {
              this.mc.displayGuiScreen(new GuiStats(this, this.mc.statFileWriter));
          }
@@ -191,10 +191,12 @@
 +        if (par1GuiButton.id == 101)
 +        {
 +            tabPage = Math.max(tabPage - 1, 0);
++            func_74227_b(CreativeTabs.creativeTabArray[tabPage * 12]);
 +        }
 +        else if (par1GuiButton.id == 102)
 +        {
 +            tabPage = Math.min(tabPage + 1, maxPages);
++            func_74227_b(CreativeTabs.creativeTabArray[tabPage * 12]);
 +        }
      }
  


### PR DESCRIPTION
When you changed the page, the inventory of the last selected tab are still visible and the scroll bar on the right disappeared.

Now when u select a previous or next page, it automatically selects the first tab in that page.
