### PR TITLE
Added PlayerModelRotationEvent. Allows modders to change player model rotation

### DIFF
--- a/client/net/minecraftforge/client/ForgeHooksClient.java
+++ b/client/net/minecraftforge/client/ForgeHooksClient.java
@@ -19,12 +19,14 @@ import net.minecraft.src.Item;
 import net.minecraft.src.ItemBlock;
 import net.minecraft.src.ItemStack;
 import net.minecraft.src.MathHelper;
+import net.minecraft.src.ModelBiped;
 import net.minecraft.src.MovingObjectPosition;
 import net.minecraft.src.RenderBlocks;
 import net.minecraft.src.RenderEngine;
 import net.minecraft.src.RenderGlobal;
 import net.minecraft.src.Tessellator;
 import net.minecraftforge.client.event.DrawBlockHighlightEvent;
+import net.minecraftforge.client.event.PlayerModelRotationEvent;
 import net.minecraftforge.client.event.RenderWorldLastEvent;
 import net.minecraftforge.client.event.TextureLoadEvent;
 import net.minecraftforge.common.IArmorTextureProvider;
@@ -387,6 +389,11 @@ public class ForgeHooksClient
     public static void onTextureLoad(String texture, ITexturePack pack)
     {
         MinecraftForge.EVENT_BUS.post(new TextureLoadEvent(texture, pack));
+    }
+    
+    public static void onRotatePlayerModel(EntityPlayer player, ModelBiped biped, float par3, float par4, float par5, float par6, float par7, float par8)
+    {
+    	MinecraftForge.EVENT_BUS.post(new PlayerModelRotationEvent(player, biped, par3, par4, par5, par6, par7, par8));
     }
 
     /**

--- a/client/net/minecraftforge/client/event/PlayerModelRotationEvent.java
+++ b/client/net/minecraftforge/client/event/PlayerModelRotationEvent.java
@@ -1,0 +1,29 @@
+package net.minecraftforge.client.event;
+
+import net.minecraft.src.EntityPlayer;
+import net.minecraft.src.ModelBiped;
+import net.minecraftforge.event.Event;
+
+public class PlayerModelRotationEvent extends Event
+{
+	public EntityPlayer currentPlayer;
+	public ModelBiped model;
+	public float ticks;
+	public float legSwing;
+	public float legYaw;
+	public float bodyRotation;
+	public float headYaw;
+	public float headPitch;
+	
+	public PlayerModelRotationEvent(EntityPlayer currentPlayer, ModelBiped model, float par2, float par3, float par4, float par5, float par6, float par7)
+	{
+		this.currentPlayer = currentPlayer;
+		this.model = model;
+		this.ticks = par2;
+		this.legSwing = par3;
+		this.legYaw = par4;
+		this.bodyRotation = par5;
+		this.headYaw = par6;
+		this.headPitch = par7;
+	}
+}

--- a/patches/minecraft/net/minecraft/src/ModelBiped.java.patch
+++ b/patches/minecraft/net/minecraft/src/ModelBiped.java.patch
@@ -1,0 +1,14 @@
+--- ../src_base/minecraft/net/minecraft/src/ModelBiped.java
++++ ../src_work/minecraft/net/minecraft/src/ModelBiped.java
+@@ -228,6 +228,11 @@
+             this.bipedRightArm.rotateAngleX += MathHelper.sin(par3 * 0.067F) * 0.05F;
+             this.bipedLeftArm.rotateAngleX -= MathHelper.sin(par3 * 0.067F) * 0.05F;
+         }
++		
++		if (par7Entity instanceof EntityPlayer)
++		{
++			ForgeHooksClient.onRotatePlayerModel((EntityPlayer)par7Entity, this, par1, par2, par3, par4, par5, par6);
++		}
+     }
+ 
+     /**


### PR DESCRIPTION
Same as #222, but condensed to one commit. Also checks if entity to rotate is a player before calling event now.

Why?
So I (and probably some other people) don't need a whole new dependency just to change the angle of the player's arms when they're using a custom item.
