### PR TITLE
SlotCrafting fix for damageable container items

### DIFF
--- a/patches/common/net/minecraft/src/SlotCrafting.java.patch
+++ b/patches/common/net/minecraft/src/SlotCrafting.java.patch
@@ -19,7 +19,7 @@
 +                    if (var5.isItemStackDamageable() && var5.getItemDamage() > var5.getMaxDamage())
 +                    {
 +                        MinecraftForge.EVENT_BUS.post(new PlayerDestroyItemEvent(thePlayer, var5));
-+                        var4 = null;
++                        var5 = null;
 +                    }
  
 -                    if (!var4.getItem().doesContainerItemLeaveCraftingGrid(var4) || !this.thePlayer.inventory.addItemStackToInventory(var5))


### PR DESCRIPTION
Fixed logic in SlotCrafting when it comes to container items that can be used up in crafting
