### PR TITLE
Custom village spawn biomes - Removed final modifier

### DIFF
--- a/common/forge_at.cfg
+++ b/common/forge_at.cfg
@@ -84,3 +84,5 @@ default ib.a(IIZ)Lic; # PlayerManager/func_72690_a getOrCreateChunkWatcher
 # World
 public-f xe.C # World/field_72982_D villageCollectionObj
 public xe.H # World/field_72993_I activeChunkSet
+# MapGenVillage
+public-f aea.e # MapGenVillage.villageSpawnBiomes


### PR DESCRIPTION
Removed final modifier of MapGenVillage.villageSpawnBiomes to allow the addition of custom village spawn biomes.
