### PR TITLE
Made Item Constructor public instead of private

### DIFF
--- a/common/forge_at.cfg
+++ b/common/forge_at.cfg
@@ -57,6 +57,7 @@ public amr.c #FD:BlockLeavesBase/field_72131_c #graphicsLevel
 # Item
 public uk.e(I)Luk; #MD:Item/func_77656_e #setMaxDamage
 public-f uk.f(Lum;)I #MD:Item/func_77650_f #getIconIndex
+public uk.<init>(I)V #MD:Item/<init>(I) #Constructor
 # RailLogic
 public all #CL:RailLogic
 public all.a(Lall;)I #MD:RailLogic/func_73650_a #getNAdjacentTiles


### PR DESCRIPTION
Since ITextureProvider was merged in to Item, Item is still not directly useable outside of the 'net.minecraft.src' package since its constructor is protected.
Obviously using the 'net.minecraft.src' package is not recommended, and creating a worthless class to make the constructor private is something that will be repeated in a vast amount of mods, it is better to mark it public.
