### PR TITLE
New event: PlayerEvent.HarvestBlock

### DIFF
--- a/common/net/minecraftforge/event/ForgeEventFactory.java
+++ b/common/net/minecraftforge/event/ForgeEventFactory.java
@@ -2,6 +2,7 @@ package net.minecraftforge.event;
 import net.minecraft.src.*;
 import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.event.entity.player.*;
+import net.minecraftforge.event.entity.player.PlayerEvent.HarvestBlock;
 import net.minecraftforge.event.entity.player.PlayerInteractEvent.Action;
 
 public class ForgeEventFactory
@@ -29,5 +30,11 @@ public class ForgeEventFactory
     public static void onPlayerDestroyItem(EntityPlayer player, ItemStack stack)
     {
         MinecraftForge.EVENT_BUS.post(new PlayerDestroyItemEvent(player, stack));
+    }
+
+    public static void onBlockHarvested(World world, Block block, int x, int y, int z, int metadata, EntityPlayer player)
+    {
+        PlayerEvent.HarvestBlock event = new HarvestBlock(world, block, x, y, z, metadata, player);
+        MinecraftForge.EVENT_BUS.post(event);
     }
 }

--- a/common/net/minecraftforge/event/entity/player/PlayerEvent.java
+++ b/common/net/minecraftforge/event/entity/player/PlayerEvent.java
@@ -3,6 +3,7 @@ package net.minecraftforge.event.entity.player;
 import net.minecraft.src.Block;
 import net.minecraft.src.Entity;
 import net.minecraft.src.EntityPlayer;
+import net.minecraft.src.World;
 import net.minecraftforge.event.Cancelable;
 import net.minecraftforge.event.entity.living.LivingEvent;
 
@@ -25,6 +26,28 @@ public class PlayerEvent extends LivingEvent
             super(player);
             this.block = block;
             this.success = success;
+        }
+    }
+    
+    public static class HarvestBlock extends PlayerEvent
+    {
+        public final World world;
+        public final Block block;
+        public final int x;
+        public final int y;
+        public final int z;
+        public final int metadata;
+        public boolean success;
+
+        public HarvestBlock(World world, Block block, int x, int y, int z, int metadata, EntityPlayer player)
+        {
+            super(player);
+            this.world = world;
+            this.x = x;
+            this.y = y;
+            this.z = z;
+            this.metadata = metadata;
+            this.block = block;
         }
     }
 

--- a/patches/common/net/minecraft/src/ItemInWorldManager.java.patch
+++ b/patches/common/net/minecraft/src/ItemInWorldManager.java.patch
@@ -71,7 +71,11 @@
                  }
  
                  if (var6 > 0 && var5 >= 1.0F)
-@@ -225,7 +259,7 @@
+@@ -222,10 +256,11 @@
+ 
+         if (var4 != null)
+         {
++            ForgeEventFactory.onBlockHarvested(this.theWorld, var4, par1, par2, par3, var5, this.thisPlayerMP);
              var4.onBlockHarvested(this.theWorld, par1, par2, par3, var5, this.thisPlayerMP);
          }
  
@@ -80,7 +84,7 @@
  
          if (var4 != null && var6)
          {
-@@ -246,19 +280,30 @@
+@@ -246,19 +281,30 @@
          }
          else
          {
@@ -113,7 +117,7 @@
  
                  if (var7 != null)
                  {
-@@ -267,9 +312,11 @@
+@@ -267,9 +313,11 @@
                      if (var7.stackSize == 0)
                      {
                          this.thisPlayerMP.destroyCurrentEquippedItem();
@@ -125,7 +129,7 @@
                  if (var6 && var8)
                  {
                      Block.blocksList[var4].harvestBlock(this.theWorld, this.thisPlayerMP, par1, par2, par3, var5);
-@@ -310,6 +357,7 @@
+@@ -310,6 +358,7 @@
              if (var6.stackSize == 0)
              {
                  par1EntityPlayer.inventory.mainInventory[par1EntityPlayer.inventory.currentItem] = null;
@@ -133,7 +137,7 @@
              }
  
              if (!par1EntityPlayer.isUsingItem())
-@@ -327,29 +375,56 @@
+@@ -327,29 +376,56 @@
       */
      public boolean activateBlockOrUseItem(EntityPlayer par1EntityPlayer, World par2World, ItemStack par3ItemStack, int par4, int par5, int par6, int par7, float par8, float par9, float par10)
      {
@@ -212,7 +216,7 @@
      }
  
      /**
-@@ -359,4 +434,13 @@
+@@ -359,4 +435,13 @@
      {
          this.theWorld = par1WorldServer;
      }


### PR DESCRIPTION
Not intended to be a cancelable event.  A separate event that fires before item damage is applied should be created for the purpose of cancelling a block harvest attempt.

This event provides a hook that's called when a block has been committed to being broken by a player.  It provides the same parameters that are available in Block.onBlockHarvested(world, x, y, z, metadata, player).

This code is fully tested and behaves as expected.  This was originally submitted as #241, but I didn't have my dev env setup correctly and the patches were screwed up.  Everything should be good now.
