### PR TITLE
Fix breaking despite cancel in creative mode for PlayerInteractEvent

### DIFF
--- a/common/net/minecraftforge/event/entity/player/PlayerInteractEvent.java
+++ b/common/net/minecraftforge/event/entity/player/PlayerInteractEvent.java
@@ -40,6 +40,7 @@ public class PlayerInteractEvent extends PlayerEvent
     @Override
     public void setCanceled(boolean cancel)
     {
+        super.setCanceled(cancel);
         useBlock = (cancel ? DENY : useBlock == DENY ? DEFAULT : useBlock);
         useItem = (cancel ? DENY : useItem == DENY ? DEFAULT : useItem);
     }


### PR DESCRIPTION
to allow for the total cancellation of the event.
