### PR TITLE
A quick fix for BlockPane blocks.

### DIFF
--- a/patches/common/net/minecraft/src/BlockPane.java.patch
+++ b/patches/common/net/minecraft/src/BlockPane.java.patch
@@ -1,0 +1,24 @@
+--- ../src_base/common/net/minecraft/src/BlockPane.java
++++ ../src_work/common/net/minecraft/src/BlockPane.java
+@@ -2,6 +2,7 @@
+ 
+ import cpw.mods.fml.common.Side;
+ import cpw.mods.fml.common.asm.SideOnly;
++import java.util.ArrayList;
+ import java.util.List;
+ import java.util.Random;
+ 
+@@ -193,9 +194,10 @@
+      * Gets passed in the blockID of the block adjacent and supposed to return true if its allowed to connect to the
+      * type of blockID passed in. Args: blockID
+      */
+-    public final boolean canThisPaneConnectToThisBlockID(int par1)
+-    {
+-        return Block.opaqueCubeLookup[par1] || par1 == this.blockID || par1 == Block.glass.blockID;
++    public static List ConnectableBlockIDs = new ArrayList();
++    public boolean canThisPaneConnectToThisBlockID(int par1)
++    {
++        return Block.opaqueCubeLookup[par1] || par1 == this.blockID || par1 == Block.glass.blockID || ConnectableBlockIDs.contains(par1);
+     }
+ 
+     /**


### PR DESCRIPTION
A couple of minor changes so mod blocks can force panes and fences to
connect to them, and removed final so blocks that extend blockpane can
choose for themselves what to connect to.
