### PR TITLE
Added support for cancelling input polling.

### DIFF
--- a/client/net/minecraftforge/client/event/PollInputEvent.java
+++ b/client/net/minecraftforge/client/event/PollInputEvent.java
@@ -1,0 +1,10 @@
+package net.minecraftforge.client.event;
+
+import net.minecraftforge.event.Cancelable;
+import net.minecraftforge.event.Event;
+
+@Cancelable
+public class PollInputEvent extends Event
+{
+    
+}

--- a/patches/minecraft/net/minecraft/client/Minecraft.java.patch
+++ b/patches/minecraft/net/minecraft/client/Minecraft.java.patch
@@ -1,16 +1,18 @@
 --- ../src_base/minecraft/net/minecraft/client/Minecraft.java
 +++ ../src_work/minecraft/net/minecraft/client/Minecraft.java
-@@ -124,6 +124,9 @@
+@@ -124,6 +124,11 @@
  import net.minecraft.src.WorldInfo;
  import net.minecraft.src.WorldRenderer;
  import net.minecraft.src.WorldSettings;
++import net.minecraftforge.client.event.PollInputEvent;
 +import net.minecraftforge.common.ForgeHooks;
++import net.minecraftforge.common.MinecraftForge;
 +import net.minecraftforge.event.ForgeEventFactory;
 +import net.minecraftforge.event.entity.player.PlayerInteractEvent.Action;
  
  import org.lwjgl.LWJGLException;
  import org.lwjgl.Sys;
-@@ -1260,7 +1263,7 @@
+@@ -1260,7 +1265,7 @@
  
                  if (this.thePlayer.canCurrentToolHarvestBlock(var3, var4, var5))
                  {
@@ -19,7 +21,7 @@
                      this.thePlayer.swingItem();
                  }
              }
-@@ -1326,7 +1329,8 @@
+@@ -1326,7 +1331,8 @@
                  {
                      int var8 = var3 != null ? var3.stackSize : 0;
  
@@ -29,7 +31,7 @@
                      {
                          var2 = false;
                          this.thePlayer.swingItem();
-@@ -1352,7 +1356,8 @@
+@@ -1352,7 +1358,8 @@
              {
                  ItemStack var9 = this.thePlayer.inventory.getCurrentItem();
  
@@ -39,7 +41,34 @@
                  {
                      this.entityRenderer.itemRenderer.func_78445_c();
                  }
-@@ -2026,6 +2031,18 @@
+@@ -1503,11 +1510,16 @@
+         CrashReport var2;
+         CrashReportCategory var3;
+ 
++        boolean cancelInputPolling = !MinecraftForge.EVENT_BUS.post(new PollInputEvent());
++        
+         if (this.currentScreen != null)
+         {
+             try
+             {
+-                this.currentScreen.handleInput();
++                if (!cancelInputPolling)
++                {
++                    this.currentScreen.handleInput();
++                }
+             }
+             catch (Throwable var6)
+             {
+@@ -1545,7 +1557,7 @@
+             }
+         }
+ 
+-        if (this.currentScreen == null || this.currentScreen.allowUserInput)
++        if (!cancelInputPolling && (this.currentScreen == null || this.currentScreen.allowUserInput))
+         {
+             this.mcProfiler.endStartSection("mouse");
+ 
+@@ -2026,6 +2038,18 @@
              if (this.theIntegratedServer != null)
              {
                  this.theIntegratedServer.initiateShutdown();
@@ -58,7 +87,7 @@
              }
  
              this.theIntegratedServer = null;
-@@ -2335,95 +2352,12 @@
+@@ -2335,95 +2359,12 @@
          if (this.objectMouseOver != null)
          {
              boolean var1 = this.thePlayer.capabilities.isCreativeMode;

--- a/patches/minecraft/net/minecraft/src/EntityRenderer.java.patch
+++ b/patches/minecraft/net/minecraft/src/EntityRenderer.java.patch
@@ -1,18 +1,19 @@
 --- ../src_base/minecraft/net/minecraft/src/EntityRenderer.java
 +++ ../src_work/minecraft/net/minecraft/src/EntityRenderer.java
-@@ -7,6 +7,11 @@
+@@ -7,6 +7,12 @@
  import java.util.List;
  import java.util.Random;
  import net.minecraft.client.Minecraft;
 +import net.minecraftforge.client.ForgeHooksClient;
 +import net.minecraftforge.client.event.DrawBlockHighlightEvent;
++import net.minecraftforge.client.event.PollInputEvent;
 +import net.minecraftforge.client.event.RenderWorldLastEvent;
 +import net.minecraftforge.common.MinecraftForge;
 +
  import org.lwjgl.input.Mouse;
  import org.lwjgl.opengl.Display;
  import org.lwjgl.opengl.GL11;
-@@ -309,8 +314,15 @@
+@@ -309,8 +315,15 @@
       */
      private void updateFovModifierHand()
      {
@@ -30,7 +31,7 @@
          this.fovModifierHandPrev = this.fovModifierHand;
          this.fovModifierHand += (this.fovMultiplierTemp - this.fovModifierHand) * 0.5F;
      }
-@@ -326,7 +338,7 @@
+@@ -326,7 +339,7 @@
          }
          else
          {
@@ -39,7 +40,7 @@
              float var4 = 70.0F;
  
              if (par2)
-@@ -413,15 +425,7 @@
+@@ -413,15 +426,7 @@
  
              if (!this.mc.gameSettings.debugCamEnable)
              {
@@ -56,7 +57,19 @@
                  GL11.glRotatef(var2.prevRotationYaw + (var2.rotationYaw - var2.prevRotationYaw) * par1 + 180.0F, 0.0F, -1.0F, 0.0F);
                  GL11.glRotatef(var2.prevRotationPitch + (var2.rotationPitch - var2.prevRotationPitch) * par1, -1.0F, 0.0F, 0.0F);
              }
-@@ -1112,8 +1116,11 @@
+@@ -930,6 +935,11 @@
+             int var17 = var15 - Mouse.getY() * var15 / this.mc.displayHeight - 1;
+             int var18 = func_78465_a(this.mc.gameSettings.limitFramerate);
+ 
++            if(MinecraftForge.EVENT_BUS.post(new PollInputEvent())) {
++                var16 = -1;
++                var17 = -1;
++            }
++            
+             if (this.mc.theWorld != null)
+             {
+                 this.mc.mcProfiler.startSection("level");
+@@ -1112,8 +1122,11 @@
                      var17 = (EntityPlayer)var4;
                      GL11.glDisable(GL11.GL_ALPHA_TEST);
                      this.mc.mcProfiler.endStartSection("outline");
@@ -70,7 +83,7 @@
                      GL11.glEnable(GL11.GL_ALPHA_TEST);
                  }
              }
-@@ -1177,15 +1184,18 @@
+@@ -1177,15 +1190,18 @@
                  var17 = (EntityPlayer)var4;
                  GL11.glDisable(GL11.GL_ALPHA_TEST);
                  this.mc.mcProfiler.endStartSection("outline");
@@ -92,7 +105,7 @@
              GL11.glDisable(GL11.GL_BLEND);
              this.mc.mcProfiler.endStartSection("weather");
              this.renderRainSnow(par1);
-@@ -1195,6 +1205,9 @@
+@@ -1195,6 +1211,9 @@
              {
                  this.func_82829_a(var5, par1);
              }

--- a/patches/minecraft/net/minecraft/src/GuiSlot.java.patch
+++ b/patches/minecraft/net/minecraft/src/GuiSlot.java.patch
@@ -1,6 +1,16 @@
 --- ../src_base/minecraft/net/minecraft/src/GuiSlot.java
 +++ ../src_work/minecraft/net/minecraft/src/GuiSlot.java
-@@ -67,6 +67,8 @@
+@@ -4,6 +4,9 @@
+ import cpw.mods.fml.common.asm.SideOnly;
+ import java.util.List;
+ import net.minecraft.client.Minecraft;
++import net.minecraftforge.client.event.PollInputEvent;
++import net.minecraftforge.common.MinecraftForge;
++
+ import org.lwjgl.input.Mouse;
+ import org.lwjgl.opengl.GL11;
+ 
+@@ -67,6 +70,8 @@
      private boolean showSelectionBox = true;
      private boolean field_77243_s;
      private int field_77242_t;
@@ -9,7 +19,16 @@
  
      public GuiSlot(Minecraft par1Minecraft, int par2, int par3, int par4, int par5, int par6)
      {
-@@ -331,16 +333,7 @@
+@@ -305,7 +310,7 @@
+         }
+         else
+         {
+-            while (!this.mc.gameSettings.field_85185_A && Mouse.next())
++            while (!MinecraftForge.EVENT_BUS.post(new PollInputEvent()) && !this.mc.gameSettings.field_85185_A && Mouse.next())
+             {
+                 int var16 = Mouse.getEventDWheel();
+ 
+@@ -331,16 +336,7 @@
          GL11.glDisable(GL11.GL_LIGHTING);
          GL11.glDisable(GL11.GL_FOG);
          Tessellator var18 = Tessellator.instance;
@@ -27,7 +46,7 @@
          var9 = this.width / 2 - 92 - 16;
          var10 = this.top + 4 - (int)this.amountScrolled;
  
-@@ -469,10 +462,10 @@
+@@ -469,10 +465,10 @@
      /**
       * Overlays the background to hide scrolled items
       */
@@ -40,7 +59,7 @@
          GL11.glColor4f(1.0F, 1.0F, 1.0F, 1.0F);
          float var6 = 32.0F;
          var5.startDrawingQuads();
-@@ -484,4 +477,18 @@
+@@ -484,4 +480,18 @@
          var5.addVertexWithUV(0.0D, (double)par1, 0.0D, 0.0D, (double)((float)par1 / var6));
          var5.draw();
      }


### PR DESCRIPTION
Multiple hooks were added:

Minecraft.java:
- currentScreen.handleInput() won't be called if PollInputEvent is cancelled.
- Mouse.next() won't be called nor processed if PollInputEvent is cancelled.

EntityRenderer.java:
- mouseX (var16) and mouseY (var17) will be set to -1 if PollInputEvent is cancelled.

GuiSlot.java:
- Mouse.next() won't be called nor processed if PollInputEvent is cancelled.
