### PR TITLE
Adds a more intelligent chunk constructor

### DIFF
--- a/patches/common/net/minecraft/src/Chunk.java.patch
+++ b/patches/common/net/minecraft/src/Chunk.java.patch
@@ -86,9 +86,9 @@
 +
 +        for (int y = 0; y < max; ++y)
 +        {
-+            for (int x = 0; x < 16; ++x)
++            for (int z = 0; z < 16; ++z)
 +            {
-+                for (int z = 0; z < 16; ++z)
++                for (int x = 0; x < 16; ++x)
 +                {
 +                    int idx = y << 8 | z << 4 | x;
 +                    int id = ids[idx] & 0xFFFFFF;


### PR DESCRIPTION
Adds a chunk constructor with full block id range, that's metadata
sensitive, has intelligent coord ordering, and which allows for
generation at greater heights than 127.

This, coupled with the ability to control how many ExtendedBlockStorage levels are in a chunk, would allow us to generate worlds with height > 256.  Whether the rest of Minecraft can handle that I'm unsure, but the chunk class itself would function without issue.
