### PR TITLE
Add check that Entity saves to disk before saving entity to saved chunkloading data.

### DIFF
--- a/common/net/minecraftforge/common/ForgeChunkManager.java
+++ b/common/net/minecraftforge/common/ForgeChunkManager.java
@@ -744,7 +744,7 @@ public class ForgeChunkManager
                 {
                     ticket.setCompoundTag("ModData", tick.modData);
                 }
-                if (tick.ticketType == Type.ENTITY && tick.entity != null)
+                if (tick.ticketType == Type.ENTITY && tick.entity != null && tick.entity.addEntityID(new NBTTagCompound()))
                 {
                     ticket.setInteger("chunkX", MathHelper.floor_double(tick.entity.chunkCoordX));
                     ticket.setInteger("chunkZ", MathHelper.floor_double(tick.entity.chunkCoordZ));


### PR DESCRIPTION
Returning false to addEntityID prevents the entity from being saved (cred to LexManos)
Entities which do not save to disk but are chunkloaders causes errors the next time the world loads. This ought to fix it.
