### PR TITLE
Fix shouldRiderSit() to properly determine if rider is sitting.

### DIFF
--- a/patches/common/net/minecraft/src/Entity.java.patch
+++ b/patches/common/net/minecraft/src/Entity.java.patch
@@ -73,7 +73,7 @@
      public boolean isRiding()
      {
 -        return this.ridingEntity != null || this.getFlag(2);
-+        return (this.ridingEntity != null && ridingEntity.shouldRiderSit()) || this.getFlag(2);
++        return (this.ridingEntity != null && ridingEntity.shouldRiderSit()) && this.getFlag(2);
      }
  
      /**


### PR DESCRIPTION
I noticed that the "shouldRiderSit()" method in Entity stopped working since around 1.4, here's a fix. Plain and simple.
