### PR TITLE
Added PreLoad world event for mods to initialize external data structures that require active worlds.

### DIFF
--- a/common/net/minecraftforge/common/DimensionManager.java
+++ b/common/net/minecraftforge/common/DimensionManager.java
@@ -153,6 +153,7 @@ public class DimensionManager
 
         WorldServer world = (dim == 0 ? overworld : new WorldServerMulti(mcServer, savehandler, overworld.getWorldInfo().getWorldName(), dim, worldSettings, overworld, mcServer.theProfiler));
         world.addWorldAccess(new WorldManager(mcServer, world));
+        MinecraftForge.EVENT_BUS.post(new WorldEvent.PreLoad(world));
         MinecraftForge.EVENT_BUS.post(new WorldEvent.Load(world));
         if (!mcServer.isSinglePlayer())
         {

--- a/common/net/minecraftforge/event/world/WorldEvent.java
+++ b/common/net/minecraftforge/event/world/WorldEvent.java
@@ -11,6 +11,14 @@ public class WorldEvent extends Event
     {
         this.world = world;
     }
+    
+    /**
+     * Do not do anything that will load a chunk during this event
+     */
+    public static class PreLoad extends WorldEvent
+    {
+        public PreLoad(World world) { super(world); }
+    }
 
     public static class Load extends WorldEvent
     {

--- a/patches/common/net/minecraft/server/MinecraftServer.java.patch
+++ b/patches/common/net/minecraft/server/MinecraftServer.java.patch
@@ -37,7 +37,7 @@
          ISaveHandler var7 = this.anvilConverterForAnvilFile.getSaveLoader(par1Str, true);
          WorldInfo var9 = var7.loadWorldInfo();
          WorldSettings var8;
-@@ -263,46 +266,23 @@
+@@ -263,46 +266,24 @@
              var8.enableBonusChest();
          }
  
@@ -88,6 +88,7 @@
 -        }
 -
 +
++            MinecraftForge.EVENT_BUS.post(new WorldEvent.PreLoad(world));
 +            MinecraftForge.EVENT_BUS.post(new WorldEvent.Load(world));
 +        }
 +
@@ -95,7 +96,7 @@
          this.setDifficultyForAllWorlds(this.getDifficulty());
          this.initialWorldChunkLoad();
      }
-@@ -431,7 +411,14 @@
+@@ -431,7 +412,14 @@
              for (int var1 = 0; var1 < this.worldServers.length; ++var1)
              {
                  WorldServer var2 = this.worldServers[var1];
@@ -110,7 +111,7 @@
              }
  
              if (this.usageSnooper != null && this.usageSnooper.isSnooperRunning())
-@@ -645,13 +632,15 @@
+@@ -645,13 +633,15 @@
          this.theProfiler.startSection("levels");
          int var1;
  
@@ -131,7 +132,7 @@
                  this.theProfiler.startSection(var4.getWorldInfo().getWorldName());
                  this.theProfiler.startSection("pools");
                  var4.getWorldVec3Pool().clear();
-@@ -698,9 +687,11 @@
+@@ -698,9 +688,11 @@
                  this.theProfiler.endSection();
              }
  
@@ -146,7 +147,7 @@
          this.theProfiler.endStartSection("connection");
          this.getNetworkThread().networkTick();
          this.theProfiler.endStartSection("players");
-@@ -754,7 +745,13 @@
+@@ -754,7 +746,13 @@
       */
      public WorldServer worldServerForDimension(int par1)
      {
@@ -161,7 +162,7 @@
      }
  
      @SideOnly(Side.SERVER)
-@@ -863,7 +860,7 @@
+@@ -863,7 +861,7 @@
  
      public String getServerModName()
      {
@@ -170,7 +171,7 @@
      }
  
      /**
-@@ -1125,6 +1122,7 @@
+@@ -1125,6 +1123,7 @@
  
              if (var2 != null)
              {

--- a/patches/minecraft/net/minecraft/src/IntegratedServer.java.patch
+++ b/patches/minecraft/net/minecraft/src/IntegratedServer.java.patch
@@ -10,7 +10,7 @@
  
  @SideOnly(Side.CLIENT)
  public class IntegratedServer extends MinecraftServer
-@@ -48,44 +51,22 @@
+@@ -48,44 +51,23 @@
      protected void loadAllWorlds(String par1Str, String par2Str, long par3, WorldType par5WorldType, String par6Str)
      {
          this.convertMapIfNeeded(par1Str);
@@ -59,6 +59,7 @@
 -            this.getConfigurationManager().setPlayerManager(this.worldServers);
 -        }
 -
++            MinecraftForge.EVENT_BUS.post(new WorldEvent.PreLoad(world));
 +            MinecraftForge.EVENT_BUS.post(new WorldEvent.Load(world));
 +        }
 +

--- a/patches/minecraft/net/minecraft/src/WorldClient.java.patch
+++ b/patches/minecraft/net/minecraft/src/WorldClient.java.patch
@@ -9,7 +9,7 @@
  
  @SideOnly(Side.CLIENT)
  public class WorldClient extends World
-@@ -38,8 +40,11 @@
+@@ -38,8 +40,12 @@
          super(new SaveHandlerMP(), "MpServer", WorldProvider.getProviderForDimension(par3), par2WorldSettings, par5Profiler);
          this.sendQueue = par1NetClientHandler;
          this.difficultySetting = par4;
@@ -18,11 +18,12 @@
 +        finishSetup();
          this.setSpawnLocation(8, 64, 8);
 -        this.mapStorage = par1NetClientHandler.mapStorage;
++        MinecraftForge.EVENT_BUS.post(new WorldEvent.PreLoad(this));
 +        MinecraftForge.EVENT_BUS.post(new WorldEvent.Load(this));
      }
  
      /**
-@@ -271,6 +276,12 @@
+@@ -271,6 +277,12 @@
       */
      protected void updateWeather()
      {


### PR DESCRIPTION
The need for this event arises from Forge and other mods loading chunks during the Load world event. This results in ChunkDataLoad events and  methods like TileEntity.validate() being called before a mod gets its turn on the event queue and said external data structures may not be initialized yet.
