### PR TITLE
List Config type error

### DIFF
--- a/common/net/minecraftforge/common/Configuration.java
+++ b/common/net/minecraftforge/common/Configuration.java
@@ -591,7 +591,9 @@ public class Configuration
                                     }
 
                                     tmpList = new ArrayList<String>();
-
+                                    
+                                    skip = true;
+                                    
                                     break;
 
                                 case '>':
@@ -616,7 +618,7 @@ public class Configuration
                     {
                         throw new RuntimeException(String.format("Unmatched quote in '%s:%d'", fileName, lineNum));
                     }
-                    else if (tmpList != null)
+                    else if (tmpList != null && !skip)
                     {
                         tmpList.add(line.trim());
                     }


### PR DESCRIPTION
idk what you did lex... but my testing before didn't reveal this thing..

anyways.. the actual definition line for List properties was being saved as the first line of the list. That caused errors when running MC for the second time because of a malformed list property.
