### PR TITLE
LivingCureEffects Event + Added .DS_Store to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+*.DS_Store
 /fml/
 /logs/
 /*.pyc

--- a/common/net/minecraftforge/event/entity/living/LivingCureEffects.java
+++ b/common/net/minecraftforge/event/entity/living/LivingCureEffects.java
@@ -1,0 +1,28 @@
+package net.minecraftforge.event.entity.living;
+
+import net.minecraft.src.EntityLiving;
+import net.minecraft.src.ItemStack;
+import net.minecraft.src.PotionEffect;
+import net.minecraftforge.event.Cancelable;
+
+@Cancelable
+public class LivingCureEffects extends LivingEvent
+{
+    public final EntityLiving entityLiving;
+    public final ItemStack curativeItem;
+    public final PotionEffect potionEffect;
+    
+    /**
+     * Cancel the cancellation of a PotionEffect often caused by drinking milk.
+     * @param entity The entity being cured.
+     * @param curativeItem The item used to cure the PotionEffect.
+     * @param potionEffect The PotionEffect being cured.
+     */
+    public LivingCureEffects(EntityLiving entity, ItemStack curativeItem, PotionEffect potionEffect)
+    {
+        super(entity);
+        this.entityLiving = entity;
+        this.curativeItem = curativeItem;
+        this.potionEffect = potionEffect;
+    }
+}

--- a/patches/common/net/minecraft/src/EntityLiving.java.patch
+++ b/patches/common/net/minecraft/src/EntityLiving.java.patch
@@ -151,7 +151,7 @@
      /**
       * Remove the speified potion effect from this entity.
       */
-@@ -2867,4 +2912,42 @@
+@@ -2867,4 +2912,46 @@
      {
          this.dataWatcher.updateObject(10, Byte.valueOf((byte)par1));
      }
@@ -173,11 +173,15 @@
 +        {
 +            Integer key = potionKey.next();
 +            PotionEffect effect = (PotionEffect)activePotionsMap.get(key);
-+
-+            if (effect.isCurativeItem(curativeItem))
++            
++            LivingCureEffects event = new LivingCureEffects(this, curativeItem, effect);
++            if (!MinecraftForge.EVENT_BUS.post(event))
 +            {
-+                potionKey.remove();
-+                onFinishedPotionEffect(effect);
++                if (effect.isCurativeItem(curativeItem))
++                {
++                    potionKey.remove();
++                    onFinishedPotionEffect(effect);
++                }
 +            }
 +        }
 +    }


### PR DESCRIPTION
Added a LivingCureEffects Event so milk couldn't remove my custom bleeding potion/effect.

Also added .DS_Store to .gitignore because Mac OSX creates .DS_Store files in every directory.
