### PR TITLE
WorldProvider additions

### DIFF
--- a/patches/common/net/minecraft/src/MapData.java.patch
+++ b/patches/common/net/minecraft/src/MapData.java.patch
@@ -1,0 +1,11 @@
+--- ../src_base/common/net/minecraft/src/MapData.java
++++ ../src_work/common/net/minecraft/src/MapData.java
+@@ -167,7 +167,7 @@
+             par8 += par8 < 0.0D ? -8.0D : 8.0D;
+             var15 = (byte)((int)(par8 * 16.0D / 360.0D));
+ 
+-            if (this.dimension < 0)
++            if (par2World.provider.shouldMapSpin())
+             {
+                 int var17 = (int)(par2World.getWorldInfo().getWorldTime() / 10L);
+                 var15 = (byte)(var17 * var17 * 34187121 + var17 * 121 >> 15 & 15);

--- a/patches/common/net/minecraft/src/ServerConfigurationManager.java.patch
+++ b/patches/common/net/minecraft/src/ServerConfigurationManager.java.patch
@@ -8,20 +8,24 @@
  
  public abstract class ServerConfigurationManager
  {
-@@ -296,6 +297,12 @@
+@@ -296,6 +297,16 @@
       */
      public EntityPlayerMP respawnPlayer(EntityPlayerMP par1EntityPlayerMP, int par2, boolean par3)
      {
 +        World world = mcServer.worldServerForDimension(par2);
-+        if (world == null || !world.provider.canRespawnHere())
++        if (world == null)
 +        {
 +            par2 = 0;
++        }
++        else if (!world.provider.canRespawnHere())
++        {
++            par2 = world.provider.getRespawnDimensionID();
 +        }
 +
          par1EntityPlayerMP.getServerForPlayer().getEntityTracker().removeAllTrackingPlayers(par1EntityPlayerMP);
          par1EntityPlayerMP.getServerForPlayer().getEntityTracker().removeEntityFromAllTrackingPlayers(par1EntityPlayerMP);
          par1EntityPlayerMP.getServerForPlayer().getPlayerManager().removePlayer(par1EntityPlayerMP);
-@@ -318,6 +325,7 @@
+@@ -318,6 +329,7 @@
          EntityPlayerMP var7 = new EntityPlayerMP(this.mcServer, this.mcServer.worldServerForDimension(par1EntityPlayerMP.dimension), par1EntityPlayerMP.username, (ItemInWorldManager)var6);
          var7.playerNetServerHandler = par1EntityPlayerMP.playerNetServerHandler;
          var7.clonePlayer(par1EntityPlayerMP, par3);
@@ -29,7 +33,7 @@
          var7.entityId = par1EntityPlayerMP.entityId;
          WorldServer var8 = this.mcServer.worldServerForDimension(par1EntityPlayerMP.dimension);
          this.func_72381_a(var7, par1EntityPlayerMP, var8);
-@@ -361,14 +369,20 @@
+@@ -361,14 +373,20 @@
  
      public void transferPlayerToDimension(EntityPlayerMP par1EntityPlayerMP, int par2)
      {
@@ -51,7 +55,7 @@
          this.func_72375_a(par1EntityPlayerMP, var4);
          par1EntityPlayerMP.playerNetServerHandler.setPlayerLocation(par1EntityPlayerMP.posX, par1EntityPlayerMP.posY, par1EntityPlayerMP.posZ, par1EntityPlayerMP.rotationYaw, par1EntityPlayerMP.rotationPitch);
          par1EntityPlayerMP.theItemInWorldManager.setWorld(var5);
-@@ -389,38 +403,23 @@
+@@ -389,38 +407,23 @@
       */
      public void transferEntityToWorld(Entity par1Entity, int par2, WorldServer par3WorldServer, WorldServer par4WorldServer)
      {
@@ -101,7 +105,7 @@
          {
              ChunkCoordinates var18;
  
-@@ -457,7 +456,7 @@
+@@ -457,7 +460,7 @@
                  par4WorldServer.spawnEntityInWorld(par1Entity);
                  par1Entity.setLocationAndAngles(var5, par1Entity.posY, var7, par1Entity.rotationYaw, par1Entity.rotationPitch);
                  par4WorldServer.updateEntityWithOptionalForce(par1Entity, false);

--- a/patches/common/net/minecraft/src/WorldProvider.java.patch
+++ b/patches/common/net/minecraft/src/WorldProvider.java.patch
@@ -17,7 +17,7 @@
      }
  
      @SideOnly(Side.CLIENT)
-@@ -256,4 +258,238 @@
+@@ -256,4 +258,258 @@
       * Returns the dimension's name, e.g. "The End", "Nether", or "Overworld".
       */
      public abstract String getDimensionName();
@@ -124,6 +124,26 @@
 +        }
 +
 +        return var5;
++    }
++
++    /**
++     * The dimension ID in which the player will respawn after death.
++     * If canRespawnHere() returns false, the player will be transferred to the dimension associated with this ID.
++     * If canRespawnHere() returns true, the player will respawn in the current dimension as usual.
++     *
++     * @return The ID of the dimension to respawn in
++     */
++    public int getRespawnDimensionID()
++    {
++        return 0;
++    }
++
++    /**
++     * Whether to spin the player icon on maps in this dimension.
++     */
++    public boolean shouldMapSpin()
++    {
++        return dimensionId < 0;
 +    }
 +
 +    /*======================================= Start Moved From World =========================================*/


### PR DESCRIPTION
Added two methods to improve the functionality of WorldProvider.

Firstly, the provider can now specify the dimension for the player to respawn in, assuming canRespawnHere returns false. At the moment, if it returns false the player will always respawn in the Overworld.

Secondly, the provider can specify whether or not maps should spin in the dimension, which is currently determined by whether the dimension's ID is negative.

I need both of these changes to avoid editing base classes in my mod.
