### PR TITLE
Lava/Water Collision Event

### DIFF
--- a/common/net/minecraftforge/event/world/LavaWaterCollisionEvent.java
+++ b/common/net/minecraftforge/event/world/LavaWaterCollisionEvent.java
@@ -1,0 +1,37 @@
+package net.minecraftforge.event.world;
+
+import net.minecraft.src.World;
+import net.minecraft.src.Block;
+
+@Cancelable
+@Event.HasResult
+public class LavaWaterCollisionEvent extends Event
+{
+    /**
+     * This event is fired when lava and water collide.
+     * By default this would create either cobblestone, stone or obsidian, depending on the circumstances.
+     * The block that would be created if the event were not handled is provided as the defaultBlock field.
+     * 
+     * You can cancel the event to prevent any processing, or set the result to ALLOW
+     * and mark the collision as handled.
+     * 
+     * An example of when this would be useful is a new dimension that adds a new stone block.
+     * By handling this event correctly, 'cobblestone generators' in the dimension would create the new stone,
+     * instead of cobblestone.
+     */
+
+    public final World world;
+    public final int x;
+    public final int y;
+    public final int z;
+    public final Block defaultResult;
+
+    public LavaWaterCollisionEvent(World world, int x, int y, int z, Block defaultResult)
+    {
+        this.world = world;
+        this.x = x;
+        this.y = y;
+        this.z = z;
+        this.defaultResult = defaultResult;
+    }
+}

--- a/patches/common/net/minecraft/src/BlockFlowing.java.patch
+++ b/patches/common/net/minecraft/src/BlockFlowing.java.patch
@@ -1,0 +1,25 @@
+--- ../src_base/common/net/minecraft/src/BlockFlowing.java
++++ ../src_work/common/net/minecraft/src/BlockFlowing.java
+@@ -1,5 +1,7 @@
+ package net.minecraft.src;
+ 
++import net.minecraftforge.common.MinecraftForge;
++import net.minecraftforge.event.LavaWaterCollisionEvent;
+ import java.util.Random;
+ 
+ public class BlockFlowing extends BlockFluid
+@@ -137,8 +139,12 @@
+         {
+             if (this.blockMaterial == Material.lava && par1World.getBlockMaterial(par2, par3 - 1, par4) == Material.water)
+             {
+-                par1World.setBlockWithNotify(par2, par3 - 1, par4, Block.stone.blockID);
+-                this.triggerLavaMixEffects(par1World, par2, par3 - 1, par4);
++                if (!MinecraftForge.EVENT_BUS.post(new LavaWaterCollisionEvent(par1World, par2, par3 - 1, par4, Block.stone)))
++                {
++                    par1World.setBlockWithNotify(par2, par3 - 1, par4, Block.stone.blockID);
++                    this.triggerLavaMixEffects(par1World, par2, par3 - 1, par4);
++                }
++
+                 return;
+             }
+ 

--- a/patches/common/net/minecraft/src/BlockFluid.java.patch
+++ b/patches/common/net/minecraft/src/BlockFluid.java.patch
@@ -1,0 +1,37 @@
+--- ../src_base/common/net/minecraft/src/BlockFluid.java
++++ ../src_work/common/net/minecraft/src/BlockFluid.java
+@@ -2,6 +2,8 @@
+ 
+ import cpw.mods.fml.common.Side;
+ import cpw.mods.fml.common.asm.SideOnly;
++import net.minecraftforge.common.MinecraftForge;
++import net.minecraftforge.event.LavaWaterCollisionEvent;
+ import java.util.Random;
+ 
+ public abstract class BlockFluid extends Block
+@@ -590,14 +592,20 @@
+ 
+                     if (var6 == 0)
+                     {
+-                        par1World.setBlockWithNotify(par2, par3, par4, Block.obsidian.blockID);
++                        if (!MinecraftForge.EVENT_BUS.post(new LavaWaterCollisionEvent(par1World, par2, par3, par4, Block.obsidian)))
++                        {
++                            par1World.setBlockWithNotify(par2, par3, par4, Block.obsidian.blockID);
++                            this.triggerLavaMixEffects(par1World, par2, par3, par4);
++                        }
+                     }
+                     else if (var6 <= 4)
+                     {
+-                        par1World.setBlockWithNotify(par2, par3, par4, Block.cobblestone.blockID);
+-                    }
+-
+-                    this.triggerLavaMixEffects(par1World, par2, par3, par4);
++                        if (!MinecraftForge.EVENT_BUS.post(new LavaWaterCollisionEvent(par1World, par2, par3, par4, Block.cobblestone)))
++                        {
++                            par1World.setBlockWithNotify(par2, par3, par4, Block.cobblestone.blockID);
++                            this.triggerLavaMixEffects(par1World, par2, par3, par4);
++                        }
++                    }
+                 }
+             }
+         }


### PR DESCRIPTION
Added an event fired when lava and water collide, which would ordinarily create either stone, cobblestone or obsidian, depending on the circumstances. 

By handling this event correctly you would be able, for example, to create your own block on a collision, or stop a block being created at all. 

An example of when this would be useful is for dimensions that add new stone blocks. Handling this event would allow 'cobblestone generators' in that dimension to produce the new stone, instead of cobblestone.

I need this functionality to avoid editing base classes in my mod.
