### PR TITLE
Mods should be able to override the drawSlotInventory method

### DIFF
--- a/common/forge_at.cfg
+++ b/common/forge_at.cfg
@@ -102,3 +102,5 @@ public+f wk.b #FD:ShapedRecipes/field_77576_b #recipeWidth
 public+f wk.c #FD:ShapedRecipes/field_77577_c #recipeHeight
 # ShapelessRecipes
 public wl.b #FD:ShapelessRecipes/field_77579_b #recipeItems
+# GuiContainer
+protected auy.a(Lsq;)V #MD:GuiContainer/func_74192_a #drawSlotInventory


### PR DESCRIPTION
> Mods might want to be able to paint items in slots on a different way.
> 
> Closes #310

This would give mod developers the freedom to paint certain (or all) slots on their GuiContainer the way they want.

A practical use for this would be to have a tool that reveals the secret behind an item, 
so that the item's texture is by default something else, but when the item is placed on the Gui, it paints something else.
