### PR TITLE
ForgeDirection rotation matrix fix

### DIFF
--- a/common/net/minecraftforge/common/ForgeDirection.java
+++ b/common/net/minecraftforge/common/ForgeDirection.java
@@ -33,15 +33,15 @@ public enum ForgeDirection
     public static final int[] OPPOSITES = {1, 0, 3, 2, 5, 4, 6};
     // Left hand rule rotation matrix for all possible axes of rotation
     public static final int[][] ROTATION_MATRIX = {
-    	{0, 1, 4, 5, 2, 3, 6},
-    	{0, 1, 5, 4, 3, 2, 6},
+        {0, 1, 4, 5, 3, 2, 6},
+    	{0, 1, 5, 4, 2, 3, 6},
     	{5, 4, 2, 3, 0, 1, 6},
     	{4, 5, 2, 3, 1, 0, 6},
-    	{2, 3, 0, 1, 4, 5, 6},
-    	{3, 2, 1, 0, 4, 5, 6},
+    	{2, 3, 1, 0, 4, 5, 6},
+    	{3, 2, 0, 1, 4, 5, 6},
     	{0, 1, 2, 3, 4, 5, 6},
     };
-
+    
     private ForgeDirection(int x, int y, int z)
     {
         offsetX = x;


### PR DESCRIPTION
Fixed a few incorrect values in the ForgeDirection rotation matrix. Now the rotation matrix consistently implements the left hand rule.
