### PR TITLE
Entity sensitive isBlockReplaceable.

### DIFF
--- a/patches/common/net/minecraft/src/Block.java.patch
+++ b/patches/common/net/minecraft/src/Block.java.patch
@@ -201,6 +201,22 @@
 +     * Used in the player's placement code to make the block act like water, and lava.
 +     * 
 +     * @param world The current world
++     * @param player Entity trying to replace
++     * @param x X Position
++     * @param y Y position
++     * @param z Z position
++     * @return True if the block is replaceable by another block
++     */
++    public boolean isBlockReplaceableByEntity(World world, Entity entity, int x, int y, int z) 
++    {
++        return isBlockReplaceable(world, x, y, z);
++    }
++
++    /**
++     * Determines if a new block can be replace the space occupied by this one,
++     * Used in the player's placement code to make the block act like water, and lava.
++     * 
++     * @param world The current world
 +     * @param x X Position
 +     * @param y Y position
 +     * @param z Z position

--- a/patches/common/net/minecraft/src/ItemBlock.java.patch
+++ b/patches/common/net/minecraft/src/ItemBlock.java.patch
@@ -14,7 +14,8 @@
          }
 -        else if (var11 != Block.vine.blockID && var11 != Block.tallGrass.blockID && var11 != Block.deadBush.blockID)
 +        else if (var11 != Block.vine.blockID && var11 != Block.tallGrass.blockID && var11 != Block.deadBush.blockID
-+                && (Block.blocksList[var11] == null || !Block.blocksList[var11].isBlockReplaceable(par3World, par4, par5, par6)))
+-                && (Block.blocksList[var11] == null || !Block.blocksList[var11].isBlockReplaceable(par3World, par4, par5, par6)))
++                && (Block.blocksList[var11] == null || !Block.blocksList[var11].isBlockReplaceableByEntity(par3World, par2EntityPlayer, par4, par5, par6)))
          {
              if (par7 == 0)
              {
@@ -41,7 +42,8 @@
          }
 -        else if (var8 != Block.vine.blockID && var8 != Block.tallGrass.blockID && var8 != Block.deadBush.blockID)
 +        else if (var8 != Block.vine.blockID && var8 != Block.tallGrass.blockID && var8 != Block.deadBush.blockID
-+                && (Block.blocksList[var8] == null || !Block.blocksList[var8].isBlockReplaceable(par1World, par2, par3, par4)))
+-                && (Block.blocksList[var8] == null || !Block.blocksList[var8].isBlockReplaceable(par1World, par2, par3, par4)))
++                && (Block.blocksList[var8] == null || !Block.blocksList[var8].isBlockReplaceableByEntity(par1World, par6EntityPlayer, par2, par3, par4)))
          {
              if (par5 == 0)
              {

--- a/patches/common/net/minecraft/src/World.java.patch
+++ b/patches/common/net/minecraft/src/World.java.patch
@@ -589,7 +589,8 @@
 +                var9 = null;
 +            }
 +
-+            if (var9 != null && var9.isBlockReplaceable(this, par2, par3, par4))
+-            if (var9 != null && var9.isBlockReplaceable(this, par2, par3, par4))
++            if (var9 != null && var9.isBlockReplaceableByEntity(this, par7Entity, par2, par3, par4))
              {
                  var9 = null;
              }


### PR DESCRIPTION
Added Entity sensitive isBlockReplaceable.
This allows modder to specify can block be replaced on entity basis.
Allows to specify if certain block can replace another block via getting current item entity is holding.

I need this to my mod as it allows block that I added to replace itself, but not by other blocks.
