### PR TITLE
Entity bounce fix for partial block collision.

### DIFF
--- a/patches/minecraft/net/minecraft/entity/Entity.java.patch
+++ b/patches/minecraft/net/minecraft/entity/Entity.java.patch
@@ -54,6 +54,15 @@
          }
  
          this.firstUpdate = false;
+@@ -850,7 +863,7 @@
+                 {
+                     double var40 = this.boundingBox.minY - (double)((int)this.boundingBox.minY);
+ 
+-                    if (var40 > 0.0D)
++                    if (var40 > 0.0D && !this.worldObj.isRemote)
+                     {
+                         this.ySize = (float)((double)this.ySize + var40 + 0.01D);
+                     }
 @@ -1513,6 +1526,15 @@
              par1NBTTagCompound.setInteger("Dimension", this.dimension);
              par1NBTTagCompound.setBoolean("Invulnerable", this.field_83001_bt);


### PR DESCRIPTION
Bounding box size update changed to run serverside only. This prevents a desync that causes player to briefly fall through blocks that have a Y collision size of increments less than 0.5 such as thin panels.

Previously if you made a block that had a Y size other than 1 or 0.5 and an entity attempted to walk up it, it would experience a very brief drop down to 0.5 or 0(depending on the block height), at which point the server would correct the entities height and they would be shot back up to the correct height. 

This change causes the bounding box size calculation to only occur serverside, thereby bypassing the desync that would normally occur.
