### PR TITLE
Attempt #2 at fixing multi-pass items

### DIFF
--- a/patches/minecraft/net/minecraft/client/renderer/ItemRenderer.java.patch
+++ b/patches/minecraft/net/minecraft/client/renderer/ItemRenderer.java.patch
@@ -20,7 +20,7 @@
  
  @SideOnly(Side.CLIENT)
  public class ItemRenderer
-@@ -54,27 +62,21 @@
+@@ -54,30 +62,24 @@
      {
          GL11.glPushMatrix();
  
@@ -56,10 +56,14 @@
 -            {
 -                GL11.glBindTexture(GL11.GL_TEXTURE_2D, this.mc.renderEngine.getTexture("/gui/items.png"));
 -            }
-+            GL11.glBindTexture(GL11.GL_TEXTURE_2D, this.mc.renderEngine.getTexture(par2ItemStack.getItem().getTextureFile()));
- 
+-
              Tessellator var5 = Tessellator.instance;
              int var6 = par1EntityLiving.getItemIcon(par2ItemStack, par3);
++            GL11.glBindTexture(GL11.GL_TEXTURE_2D, this.mc.renderEngine.getTexture(par2ItemStack.getItem().getTextureFile()));
++            
+             float var7 = ((float)(var6 % 16 * 16) + 0.0F) / 256.0F;
+             float var8 = ((float)(var6 % 16 * 16) + 15.99F) / 256.0F;
+             float var9 = ((float)(var6 / 16 * 16) + 0.0F) / 256.0F;
 @@ -279,8 +281,9 @@
          Render var24;
          RenderPlayer var26;

--- a/patches/minecraft/net/minecraft/client/renderer/entity/RenderItem.java.patch
+++ b/patches/minecraft/net/minecraft/client/renderer/entity/RenderItem.java.patch
@@ -90,14 +90,13 @@
 -                    this.loadTexture("/gui/items.png");
 -
 -                    for (var15 = 0; var15 <= 1; ++var15)
--                    {
 +
 +                    for (var15 = 0; var15 <= var10.getItem().getRenderPasses(var10.getItemDamage()); ++var15)
-+                    {
-+                        this.loadTexture(Item.itemsList[var10.itemID].getTextureFile());
+                     {
                          this.random.setSeed(187L);
 -                        var16 = var10.getItem().getIconFromDamageForRenderPass(var10.getItemDamage(), var15);
 +                        var16 = var10.getItem().getIconIndex(var10, var15);
++                        this.loadTexture(Item.itemsList[var10.itemID].getTextureFile());
                          var17 = 1.0F;
  
                          if (this.field_77024_a)
@@ -193,11 +192,11 @@
 -                for (var9 = 0; var9 <= 1; ++var9)
 -                {
 -                    var10 = Item.itemsList[var6].getIconFromDamageForRenderPass(var7, var9);
-+                par2RenderEngine.bindTexture(par2RenderEngine.getTexture(Item.itemsList[var6].getTextureFile()));
 +
 +                for (var9 = 0; var9 < Item.itemsList[var6].getRenderPasses(var7); ++var9)
 +                {
 +                    var10 = Item.itemsList[var6].getIconIndex(par3ItemStack, var9);
++                    par2RenderEngine.bindTexture(par2RenderEngine.getTexture(Item.itemsList[var6].getTextureFile()));
                      int var11 = Item.itemsList[var6].getColorFromItemStack(par3ItemStack, var9);
                      var12 = (float)(var11 >> 16 & 255) / 255.0F;
                      var13 = (float)(var11 >> 8 & 255) / 255.0F;


### PR DESCRIPTION
The first PR had edits in two places for inventory and in-world texture bind fixes, but only the in-world version made it. This PR contains the inventory fix and allows passes to set textures in the same pass.

The change is simple: the texture is bound after getIconIndex ( GL11.glBindTexture is moved down 2-3 lines), and can be used like so:

public String getTextureFile()
{
    return texture;
}

public int getIconIndex(ItemStack stack, int pass)
{
    if (pass == 0)
    {
        texture = texture1;
        ...
    }

```
if (pass == 1)
{
    texture = texture2;
    ...
}

if (pass == 2)
{
    texture = texture3;
    ...
}
```

}
