### PR TITLE
Allow getBlock compatibility with old maps

### DIFF
--- a/common/net/minecraftforge/common/Configuration.java
+++ b/common/net/minecraftforge/common/Configuration.java
@@ -143,7 +143,6 @@ public class Configuration
                     "mod authors should make sure there defaults are above 256 unless explicitly needed " +
                     "for terrain generation. Most ores do not need to be below 256.");
                 FMLLog.warning("Config \"%s\" Category: \"%s\" Key: \"%s\" Default: %d", fileName, category, key, defaultID);
-                defaultID = upper - 1;
             }
 
             if (Block.blocksList[defaultID] == null && !configMarkers[defaultID])


### PR DESCRIPTION
getBlock doesn't accept default IDs < 256 which will break old maps unless the user backed up the old configs as well, which is obviously not happening often enough and causes some major support overhead.

It's not suitable for us to change the default IDs until a sufficiently long migration time with working ID checking between world and config passed. The lack of RP2 updates caused users to stay on 1.2.5 until now.
