### PR TITLE
Move chunk compression to the network thread in Packet 51 and 56

### DIFF
--- a/patches/minecraft/net/minecraft/network/packet/Packet51MapChunk.java.patch
+++ b/patches/minecraft/net/minecraft/network/packet/Packet51MapChunk.java.patch
@@ -1,16 +1,64 @@
 --- ../src_base/minecraft/net/minecraft/network/packet/Packet51MapChunk.java
 +++ ../src_work/minecraft/net/minecraft/network/packet/Packet51MapChunk.java
-@@ -103,6 +103,13 @@
+@@ -56,23 +56,17 @@
+         this.xCh = par1Chunk.xPosition;
+         this.zCh = par1Chunk.zPosition;
+         this.includeInitialize = par2;
+-        Packet51MapChunkData var4 = getMapChunkData(par1Chunk, par2, par3);
+-        Deflater var5 = new Deflater(-1);
+-        this.yChMax = var4.field_74581_c;
+-        this.yChMin = var4.field_74580_b;
+-
+-        try
+-        {
+-            this.field_73596_g = var4.field_74582_a;
+-            var5.setInput(var4.field_74582_a, 0, var4.field_74582_a.length);
+-            var5.finish();
+-            this.chunkData = new byte[var4.field_74582_a.length];
+-            this.tempLength = var5.deflate(this.chunkData);
+-        }
+-        finally
+-        {
+-            var5.end();
+-        }
++        
++        Packet51MapChunkData newChunkData = getMapChunkData(par1Chunk, par2, par3);
++        
++        yChMax = newChunkData.field_74581_c;
++        yChMin = newChunkData.field_74580_b;
++        field_73596_g = newChunkData.field_74582_a;
++        
++        // copy the uncompressed data, the compression will be done in writePacketData in the network thread
++        chunkData = new byte[newChunkData.field_74582_a.length];
++        
++        System.arraycopy(newChunkData.field_74582_a, 0, chunkData, 0, newChunkData.field_74582_a.length);
+     }
  
-         var3 = 12288 * var2;
- 
-+        int msb = 0; //BugFix: MC does not read the MSB array from the packet properly, causing issues for servers that use blocks > 256
-+        for (int x = 0; x < 16; x++)
+     /**
+@@ -131,6 +125,26 @@
+      */
+     public void writePacketData(DataOutputStream par1DataOutputStream) throws IOException
+     {
++        if (tempLength == 0) // just in case writePacketData gets called multiple times
 +        {
-+            msb += (yChMax >> x) & 1;
-+        }
-+        var3 += (2048 * msb);
++            Deflater deflater = new Deflater(Deflater.DEFAULT_COMPRESSION);
 +
-         if (this.includeInitialize)
-         {
-             var3 += 256;
++            try
++            {
++                deflater.setInput(chunkData, 0, chunkData.length);
++                deflater.finish();
++                
++                byte[] compressedChunkData = new byte[chunkData.length];
++                
++                tempLength = deflater.deflate(compressedChunkData);
++                chunkData = compressedChunkData;
++            }
++            finally
++            {
++                deflater.end();
++            }
++        }
++        
+         par1DataOutputStream.writeInt(this.xCh);
+         par1DataOutputStream.writeInt(this.zCh);
+         par1DataOutputStream.writeBoolean(this.includeInitialize);

--- a/patches/minecraft/net/minecraft/network/packet/Packet56MapChunks.java.patch
+++ b/patches/minecraft/net/minecraft/network/packet/Packet56MapChunks.java.patch
@@ -1,16 +1,138 @@
 --- ../src_base/minecraft/net/minecraft/network/packet/Packet56MapChunks.java
 +++ ../src_work/minecraft/net/minecraft/network/packet/Packet56MapChunks.java
-@@ -135,6 +135,13 @@
-                 var9 += 2048 * var7;
-             }
+@@ -5,6 +5,7 @@
+ import java.io.DataInputStream;
+ import java.io.DataOutputStream;
+ import java.io.IOException;
++import java.util.ArrayList;
+ import java.util.List;
+ import java.util.zip.DataFormatException;
+ import java.util.zip.Deflater;
+@@ -21,55 +22,50 @@
+     private byte[][] field_73584_f;
+     private int field_73585_g;
+     private boolean field_92024_h;
+-    private static byte[] field_73591_h = new byte[0];
++    private byte[] field_73591_h;
  
-+//            int msb = 0; //BugFix: MC does not read the MSB array from the packet properly, causing issues for servers that use blocks > 256
-+//            for (int x = 0; x < 16; x++)
-+//            {
-+//                msb += (field_73588_b[var6] >> x) & 1;
-+//            }
-+//            var9 += (2048 * msb);
-+//
-             this.field_73584_f[var6] = new byte[var9];
-             System.arraycopy(var3, var5, this.field_73584_f[var6], 0, var9);
-             var5 += var9;
+     public Packet56MapChunks() {}
+ 
+     public Packet56MapChunks(List par1List)
+     {
+-        int var2 = par1List.size();
+-        this.field_73589_c = new int[var2];
+-        this.field_73586_d = new int[var2];
+-        this.field_73590_a = new int[var2];
+-        this.field_73588_b = new int[var2];
+-        this.field_73584_f = new byte[var2][];
+-        this.field_92024_h = !par1List.isEmpty() && !((Chunk)par1List.get(0)).worldObj.provider.hasNoSky;
+-        int var3 = 0;
+-
+-        for (int var4 = 0; var4 < var2; ++var4)
+-        {
+-            Chunk var5 = (Chunk)par1List.get(var4);
+-            Packet51MapChunkData var6 = Packet51MapChunk.getMapChunkData(var5, true, 65535);
+-
+-            if (field_73591_h.length < var3 + var6.field_74582_a.length)
+-            {
+-                byte[] var7 = new byte[var3 + var6.field_74582_a.length];
+-                System.arraycopy(field_73591_h, 0, var7, 0, field_73591_h.length);
+-                field_73591_h = var7;
+-            }
+-
+-            System.arraycopy(var6.field_74582_a, 0, field_73591_h, var3, var6.field_74582_a.length);
+-            var3 += var6.field_74582_a.length;
+-            this.field_73589_c[var4] = var5.xPosition;
+-            this.field_73586_d[var4] = var5.zPosition;
+-            this.field_73590_a[var4] = var6.field_74580_b;
+-            this.field_73588_b[var4] = var6.field_74581_c;
+-            this.field_73584_f[var4] = var6.field_74582_a;
+-        }
+-
+-        Deflater var11 = new Deflater(-1);
+-
+-        try
+-        {
+-            var11.setInput(field_73591_h, 0, var3);
+-            var11.finish();
+-            this.field_73587_e = new byte[var3];
+-            this.field_73585_g = var11.deflate(this.field_73587_e);
+-        }
+-        finally
+-        {
+-            var11.end();
+-        }
++        int chunkListSize = par1List.size();
++        field_73589_c = new int[chunkListSize];
++        field_73586_d = new int[chunkListSize];
++        field_73590_a = new int[chunkListSize];
++        field_73588_b = new int[chunkListSize];
++        field_73584_f = new byte[chunkListSize][];
++        field_92024_h = !par1List.isEmpty() && !((Chunk)par1List.get(0)).worldObj.provider.hasNoSky;
++        
++        List<Packet51MapChunkData> chunkDataList = new ArrayList<Packet51MapChunkData>(chunkListSize);
++        int totalLength = 0;
++        
++        // determine total data length, copy fixed length data
++        for (int i = 0; i < chunkListSize; i++)
++        {
++            Chunk chunk = (Chunk) par1List.get(i);
++            Packet51MapChunkData chunkData = Packet51MapChunk.getMapChunkData(chunk, true, 65535);
++            
++            chunkDataList.add(chunkData);
++            totalLength += chunkData.field_74582_a.length;
++            
++            field_73589_c[i] = chunk.xPosition;
++            field_73586_d[i] = chunk.zPosition;
++            field_73590_a[i] = chunkData.field_74580_b;
++            field_73588_b[i] = chunkData.field_74581_c;
++            field_73584_f[i] = chunkData.field_74582_a;
++        }
++        
++        field_73591_h = new byte[totalLength];
++        int offset = 0;
++        
++        // copy uncompressed chunk data
++        for (Packet51MapChunkData chunkData : chunkDataList)
++        {
++            System.arraycopy(chunkData.field_74582_a, 0, field_73591_h, offset, chunkData.field_74582_a.length);
++            offset += chunkData.field_74582_a.length;
++        }
++        
++        // compression moved to writePacketData
+     }
+ 
+     /**
+@@ -86,7 +82,7 @@
+         this.field_73588_b = new int[var2];
+         this.field_73584_f = new byte[var2][];
+ 
+-        if (field_73591_h.length < this.field_73585_g)
++        if (field_73591_h == null || field_73591_h.length < this.field_73585_g)
+         {
+             field_73591_h = new byte[this.field_73585_g];
+         }
+@@ -146,6 +142,23 @@
+      */
+     public void writePacketData(DataOutputStream par1DataOutputStream) throws IOException
+     {
++        if (field_73587_e == null) // just in case writePacketData gets called multiple times
++        {
++            Deflater deflater = new Deflater(Deflater.DEFAULT_COMPRESSION);
++
++            try
++            {
++                deflater.setInput(field_73591_h, 0, field_73591_h.length);
++                deflater.finish();
++                field_73587_e = new byte[field_73591_h.length];
++                field_73585_g = deflater.deflate(field_73587_e);
++            }
++            finally
++            {
++                deflater.end();
++            }
++        }
++        
+         par1DataOutputStream.writeShort(this.field_73589_c.length);
+         par1DataOutputStream.writeInt(this.field_73585_g);
+         par1DataOutputStream.writeBoolean(this.field_92024_h);


### PR DESCRIPTION
This will reduce the server load considerably by doing the chunk data compression in writePacketData, which will be run from the network thread.

The chunk compression can easily use 1/4th of the overall server thread CPU time if someone is exploring much, especially when moving quickly (e.g. with quantum leggings).
