### PR TITLE
Fix for ListenerList performance issue.

### DIFF
--- a/common/net/minecraftforge/event/ListenerList.java
+++ b/common/net/minecraftforge/event/ListenerList.java
@@ -185,6 +185,11 @@ public class ListenerList
          */
         private void buildCache()
         {        
+            if(parent != null && parent.shouldRebuild())
+            {
+                parent.buildCache();
+            }
+            
             ArrayList<IEventListener> ret = new ArrayList<IEventListener>();
             for (EventPriority value : EventPriority.values())
             {


### PR DESCRIPTION
Force parent ListenerListInsts to rebuild.

Without this change, it is possible (and, in fact, nearly guaranteed) for lists to rebuild endlessly if a parent list is marked as needing a rebuild but never actually read. This change forces the parent list(s) to rebuild as well, resulting in a significant performance increase and smoother framerate due to greatly reduced GC activity.

I don't have exact numbers, but before the change my framerate frequently dropped to single digits, with it it usually remained above 10.
