### PR TITLE
Add ability to WorldTypes to display the 'Customize' button and react to it.

### DIFF
--- a/patches/minecraft/net/minecraft/client/gui/GuiCreateWorld.java.patch
+++ b/patches/minecraft/net/minecraft/client/gui/GuiCreateWorld.java.patch
@@ -1,0 +1,22 @@
+--- ../src_base/minecraft/net/minecraft/client/gui/GuiCreateWorld.java
++++ ../src_work/minecraft/net/minecraft/client/gui/GuiCreateWorld.java
+@@ -375,7 +375,10 @@
+             }
+             else if (par1GuiButton.id == 8)
+             {
++                if (WorldType.worldTypes[this.worldTypeId] == WorldType.FLAT)
+                 this.mc.displayGuiScreen(new GuiCreateFlatWorld(this, this.field_82290_a));
++                else
++                    WorldType.worldTypes[this.worldTypeId].onCustomizeButton();
+             }
+         }
+     }
+@@ -393,7 +396,7 @@
+         this.buttonBonusItems.drawButton = this.moreOptions;
+         this.buttonWorldType.drawButton = this.moreOptions;
+         this.buttonAllowCommands.drawButton = this.moreOptions;
+-        this.buttonCustomize.drawButton = this.moreOptions && WorldType.worldTypes[this.worldTypeId] == WorldType.FLAT;
++        this.buttonCustomize.drawButton = this.moreOptions && (WorldType.worldTypes[this.worldTypeId] == WorldType.FLAT || WorldType.worldTypes[this.worldTypeId].isCustomizable());
+         StringTranslate var2;
+ 
+         if (this.moreOptions)

--- a/patches/minecraft/net/minecraft/world/WorldType.java.patch
+++ b/patches/minecraft/net/minecraft/world/WorldType.java.patch
@@ -1,6 +1,6 @@
 --- ../src_base/minecraft/net/minecraft/world/WorldType.java
 +++ ../src_work/minecraft/net/minecraft/world/WorldType.java
-@@ -224,4 +224,14 @@
+@@ -224,4 +224,28 @@
       * Called when 'Create New World' button is pressed before starting game
       */
      public void onGUICreateWorldPress() { }
@@ -13,5 +13,19 @@
 +    public int getSpawnFuzz()
 +    {
 +        return 20;
++    }
++
++    /**
++     * Called when the 'Customize' button is pressed on world creation GUI
++     */
++    public void onCustomizeButton() { }
++
++    /*
++     * Should world creation GUI show 'Customize' button for this world type?
++     * (vanilla FLAT wWorldType is hard coded to show the button in GuiCreateWorld)
++     */
++    public boolean isCustomizable()
++    {
++        return false;
 +    }
  }


### PR DESCRIPTION
Very small change to allow a custom WorldType to activate the "Customize" button and provide a hook to display its own gui in reponse to the button push.
