### PR TITLE
Performance improvements, bug fixes and simplification.

### DIFF
--- a/client/net/minecraftforge/client/ForgeHooksClient.java
+++ b/client/net/minecraftforge/client/ForgeHooksClient.java
@@ -402,7 +402,7 @@ public class ForgeHooksClient
             System.out.println(msg);
             if (Tessellator.class.getPackage() != null)
             {
-                if (Tessellator.class.getPackage().equals("net.minecraft.src"))
+                if (Tessellator.class.getPackage().getName().equals("net.minecraft.src"))
                 {
                     Minecraft mc = FMLClientHandler.instance().getClient();
                     if (mc.ingameGUI != null)

--- a/common/net/minecraftforge/common/ChestGenHooks.java
+++ b/common/net/minecraftforge/common/ChestGenHooks.java
@@ -67,12 +67,13 @@ public class ChestGenHooks
         addDungeonLoot(d, new ItemStack(Item.gunpowder),       100, 1, 4);
         addDungeonLoot(d, new ItemStack(Item.silk),            100, 1, 4);
         addDungeonLoot(d, new ItemStack(Item.bucketEmpty),     100, 1, 1);
-        addDungeonLoot(d, new ItemStack(Item.appleGold),       001, 1, 1);
-        addDungeonLoot(d, new ItemStack(Item.redstone),        050, 1, 4);
-        addDungeonLoot(d, new ItemStack(Item.record13),        005, 1, 1);
-        addDungeonLoot(d, new ItemStack(Item.recordCat),       005, 1, 1);
+        addDungeonLoot(d, new ItemStack(Item.appleGold),         1, 1, 1);
+        addDungeonLoot(d, new ItemStack(Item.redstone),         50, 1, 4);
+        addDungeonLoot(d, new ItemStack(Item.record13),          5, 1, 1);
+        addDungeonLoot(d, new ItemStack(Item.recordCat),         5, 1, 1);
         addDungeonLoot(d, new ItemStack(Item.dyePowder, 1, 3), 100, 1, 1);
         addDungeonLoot(d, book,                                100, 1, 1);
+        hasInit = true;
     }
     
     static void addDungeonLoot(ChestGenHooks dungeon, ItemStack item, int weight, int min, int max)
@@ -159,10 +160,7 @@ public class ChestGenHooks
     public ChestGenHooks(String category, WeightedRandomChestContent[] items, int min, int max)
     {
         this(category);
-        for (WeightedRandomChestContent item : items)
-        {
-            contents.add(item);
-        }
+        Collections.addAll(contents, items);
         countMin = min;
         countMax = max;
     }

--- a/common/net/minecraftforge/common/DimensionManager.java
+++ b/common/net/minecraftforge/common/DimensionManager.java
@@ -3,6 +3,7 @@ package net.minecraftforge.common;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.BitSet;
+import java.util.Collection;
 import java.util.Hashtable;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -46,7 +47,7 @@ public class DimensionManager
 
     public static boolean registerProviderType(int id, Class<? extends WorldProvider> provider, boolean keepLoaded)
     {
-        if (providers.containsValue(id))
+        if (providers.contains(id))
         {
             return false;
         }
@@ -67,6 +68,7 @@ public class DimensionManager
         registerDimension( 0,  0);
         registerDimension(-1, -1);
         registerDimension( 1,  1);
+        hasInit = true;
     }
 
     public static void registerDimension(int id, int providerType)
@@ -147,7 +149,7 @@ public class DimensionManager
             tmp.add(entry.getValue());
         }
 
-        MinecraftServer.getServer().worldServers = tmp.toArray(new WorldServer[0]);
+        MinecraftServer.getServer().worldServers = tmp.toArray(new WorldServer[tmp.size()]);
     }
 
     public static void initDimension(int dim) {
@@ -183,7 +185,8 @@ public class DimensionManager
 
     public static WorldServer[] getWorlds()
     {
-        return worlds.values().toArray(new WorldServer[0]);
+        Collection<WorldServer> var = worlds.values();
+        return var.toArray(new WorldServer[var.size()]);
     }
 
     public static boolean shouldLoadSpawn(int dim)

--- a/common/net/minecraftforge/common/DungeonHooks.java
+++ b/common/net/minecraftforge/common/DungeonHooks.java
@@ -95,11 +95,7 @@ public class DungeonHooks
         @Override
         public boolean equals(Object target)
         {
-            if (target instanceof DungeonMob)
-            {
-                return this.type.equals(((DungeonMob)target).type);
-            }
-            return false;
+            return target instanceof DungeonMob && this.type.equals(((DungeonMob) target).type);
         }
     }
 

--- a/common/net/minecraftforge/common/ForgeChunkManager.java
+++ b/common/net/minecraftforge/common/ForgeChunkManager.java
@@ -391,7 +391,7 @@ public class ForgeChunkManager
 
     static void loadWorld(World world)
     {
-        ArrayListMultimap<String, Ticket> newTickets = ArrayListMultimap.<String, Ticket>create();
+        ArrayListMultimap<String, Ticket> newTickets = ArrayListMultimap.create();
         tickets.put(world, newTickets);
 
         forcedChunks.put(world, ImmutableSetMultimap.<ChunkCoordIntPair,Ticket>of());
@@ -408,7 +408,7 @@ public class ForgeChunkManager
 
         if (chunkLoaderData.exists() && chunkLoaderData.isFile())
         {
-            ArrayListMultimap<String, Ticket> loadedTickets = ArrayListMultimap.<String, Ticket>create();
+            ArrayListMultimap<String, Ticket> loadedTickets = ArrayListMultimap.create();
             Map<String,ListMultimap<String,Ticket>> playerLoadedTickets = Maps.newHashMap();
             NBTTagCompound forcedChunkData;
             try

--- a/common/net/minecraftforge/common/ForgeHooks.java
+++ b/common/net/minecraftforge/common/ForgeHooks.java
@@ -94,7 +94,7 @@ public class ForgeHooks
             return player.canHarvestBlock(block);
         }
 
-        List info = (List)toolClasses.get(stack.getItem());
+        List info = toolClasses.get(stack.getItem());
         if (info == null)
         {
             return player.canHarvestBlock(block);
@@ -104,7 +104,7 @@ public class ForgeHooks
         String toolClass = (String)tmp[0];
         int harvestLevel = (Integer)tmp[1];
 
-        Integer blockHarvestLevel = (Integer)toolHarvestLevels.get(Arrays.asList(block, metadata, toolClass));
+        Integer blockHarvestLevel = toolHarvestLevels.get(Arrays.asList(block, metadata, toolClass));
         if (blockHarvestLevel == null)
         {
             return player.canHarvestBlock(block);
@@ -120,14 +120,14 @@ public class ForgeHooks
     public static boolean canToolHarvestBlock(Block block, int metadata, ItemStack stack)
     {
         if (stack == null) return false;
-        List info = (List)toolClasses.get(stack.getItem());
+        List info = toolClasses.get(stack.getItem());
         if (info == null) return false;
 
         Object[] tmp = info.toArray();
         String toolClass = (String)tmp[0];
         int harvestLevel = (Integer)tmp[1];
 
-        Integer blockHarvestLevel = (Integer)toolHarvestLevels.get(Arrays.asList(block, metadata, toolClass));
+        Integer blockHarvestLevel = toolHarvestLevels.get(Arrays.asList(block, metadata, toolClass));
         return !(blockHarvestLevel == null || blockHarvestLevel > harvestLevel);
     }
 
@@ -153,12 +153,8 @@ public class ForgeHooks
 
     public static boolean isToolEffective(ItemStack stack, Block block, int metadata)
     {
-        List toolClass = (List)toolClasses.get(stack.getItem());
-        if (toolClass == null)
-        {
-            return false;
-        }
-        return toolEffectiveness.contains(Arrays.asList(block, metadata, (String)toolClass.get(0)));
+        List toolClass = toolClasses.get(stack.getItem());
+        return toolClass != null && toolEffectiveness.contains(Arrays.asList(block, metadata, toolClass.get(0)));
     }
 
     static void initTools()

--- a/common/net/minecraftforge/common/ForgeInternalHandler.java
+++ b/common/net/minecraftforge/common/ForgeInternalHandler.java
@@ -32,7 +32,7 @@ public class ForgeInternalHandler
         Entity entity = event.entity;
         if (entity.getClass().equals(EntityItem.class))
         {
-            ItemStack stack = ((EntityItem)entity).getDataWatcher().getWatchableObjectItemStack(10);
+            ItemStack stack = entity.getDataWatcher().getWatchableObjectItemStack(10);
 
             if (stack == null)
             {

--- a/common/net/minecraftforge/common/ISpecialArmor.java
+++ b/common/net/minecraftforge/common/ISpecialArmor.java
@@ -124,7 +124,7 @@ public interface ISpecialArmor
             }
             if (dmgVals.size() > 0)
             {
-                ArmorProperties[] props = dmgVals.toArray(new ArmorProperties[0]);
+                ArmorProperties[] props = dmgVals.toArray(new ArmorProperties[dmgVals.size()]);
                 StandardizeList(props, damage);
                 int level = props[0].Priority;
                 double ratio = 0;
@@ -262,7 +262,7 @@ public interface ISpecialArmor
                             total -= armor[y].AbsorbRatio;
                             if (damage * armor[y].AbsorbRatio > armor[y].AbsorbMax)
                             {
-                                armor[y].AbsorbRatio = (double)armor[y].AbsorbMax / (double)damage;
+                                armor[y].AbsorbRatio = (double)armor[y].AbsorbMax / damage;
                             }
                             total += armor[y].AbsorbRatio;
                         }

--- a/common/net/minecraftforge/common/MinecraftForge.java
+++ b/common/net/minecraftforge/common/MinecraftForge.java
@@ -150,7 +150,7 @@ public class MinecraftForge
    {
        ForgeHooks.initTools();
        List key = Arrays.asList(block, metadata, toolClass);
-       Integer harvestLevel = (Integer)ForgeHooks.toolHarvestLevels.get(key);
+       Integer harvestLevel = ForgeHooks.toolHarvestLevels.get(key);
        if(harvestLevel == null)
        {
            return -1;
@@ -200,10 +200,7 @@ public class MinecraftForge
        }
 
        boolean[] temp = new boolean[4096];
-       for (int x = 0; x < EntityEnderman.carriableBlocks.length; x++)
-       {
-           temp[x] = EntityEnderman.carriableBlocks[x];
-       }
+       System.arraycopy(EntityEnderman.carriableBlocks, 0, temp, 0, EntityEnderman.carriableBlocks.length);
        EntityEnderman.carriableBlocks = temp;
 
        EVENT_BUS.register(INTERNAL_HANDLER);

--- a/common/net/minecraftforge/event/ListenerList.java
+++ b/common/net/minecraftforge/event/ListenerList.java
@@ -195,7 +195,7 @@ public class ListenerList
             {
                 ret.addAll(getListeners(value));
             }
-            listeners = ret.toArray(new IEventListener[0]);
+            listeners = ret.toArray(new IEventListener[ret.size()]);
             rebuild = false;
         }
         

--- a/common/net/minecraftforge/event/terraingen/ChunkProviderEvent.java
+++ b/common/net/minecraftforge/event/terraingen/ChunkProviderEvent.java
@@ -63,7 +63,7 @@ public class ChunkProviderEvent extends Event
             this.posY = posY;
             this.posZ = posZ;
             this.sizeX = sizeX;
-            this.sizeY = sizeX;
+            this.sizeY = sizeY;
             this.sizeZ = sizeZ;
         }
        

--- a/common/net/minecraftforge/liquids/LiquidContainerRegistry.java
+++ b/common/net/minecraftforge/liquids/LiquidContainerRegistry.java
@@ -79,10 +79,7 @@ public class LiquidContainerRegistry {
             return false;
         }
         LiquidContainerData ret = mapLiquidFromFilledItem.get(Arrays.asList(filledContainer.itemID, filledContainer.getItemDamage()));
-        if (ret != null) {
-            return ret.stillLiquid.isLiquidEqual(liquid);
-        }
-        return false;
+        return ret != null && ret.stillLiquid.isLiquidEqual(liquid);
     }
 
     public static boolean isBucket(ItemStack container) {
@@ -96,10 +93,7 @@ public class LiquidContainerRegistry {
         }
 
         LiquidContainerData ret = mapLiquidFromFilledItem.get(Arrays.asList(container.itemID, container.getItemDamage()));
-        if (ret != null) {
-            return ret.container.isItemEqual(EMPTY_BUCKET);
-        }
-        return false;
+        return ret != null && ret.container.isItemEqual(EMPTY_BUCKET);
     }
 
     public static boolean isContainer(ItemStack container) {
@@ -109,30 +103,21 @@ public class LiquidContainerRegistry {
 
     public static boolean isEmptyContainer(ItemStack emptyContainer) {
 
-        if (emptyContainer == null) {
-            return false;
-        }
-        return setContainerValidation.contains(Arrays.asList(emptyContainer.itemID, emptyContainer.getItemDamage()));
+        return emptyContainer != null && setContainerValidation.contains(Arrays.asList(emptyContainer.itemID, emptyContainer.getItemDamage()));
     }
 
     public static boolean isFilledContainer(ItemStack filledContainer) {
 
-        if (filledContainer == null) {
-            return false;
-        }
-        return getLiquidForFilledItem(filledContainer) != null;
+        return filledContainer != null && getLiquidForFilledItem(filledContainer) != null;
     }
 
     public static boolean isLiquid(ItemStack item) {
 
-        if (item == null) {
-            return false;
-        }
-        return setLiquidValidation.contains(Arrays.asList(item.itemID, item.getItemDamage()));
+        return item != null && setLiquidValidation.contains(Arrays.asList(item.itemID, item.getItemDamage()));
     }
 
     public static LiquidContainerData[] getRegisteredLiquidContainerData() {
 
-        return liquids.toArray(new LiquidContainerData[0]);
+        return liquids.toArray(new LiquidContainerData[liquids.size()]);
     }
 }

--- a/common/net/minecraftforge/liquids/LiquidStack.java
+++ b/common/net/minecraftforge/liquids/LiquidStack.java
@@ -60,10 +60,7 @@ public class LiquidStack {
 	 * @return true if this LiquidStack contains the same liquid as the one passed in.
 	 */
 	public boolean isLiquidEqual(LiquidStack other) {
-		if(other == null)
-			return false;
-
-		return itemID == other.itemID && itemMeta == other.itemMeta;
+		return other != null && itemID == other.itemID && itemMeta == other.itemMeta;
 	}
 
 	/**
@@ -71,10 +68,7 @@ public class LiquidStack {
 	 * @return true if this LiquidStack contains the other liquid (liquids are equal and amount >= other.amount).
 	 */
 	public boolean containsLiquid(LiquidStack other) {
-		if(!isLiquidEqual(other))
-			return false;
-
-		return amount >= other.amount;
+		return isLiquidEqual(other) && amount >= other.amount;
 	}
 
 	/**
@@ -82,10 +76,7 @@ public class LiquidStack {
 	 * @return true if this LiquidStack contains the same liquid as the one passed in.
 	 */
 	public boolean isLiquidEqual(ItemStack other) {
-		if(other == null)
-			return false;
-
-		return itemID == other.itemID && itemMeta == other.getItemDamage();
+		return other != null && itemID == other.itemID && itemMeta == other.getItemDamage();
 	}
 
 	/**

--- a/common/net/minecraftforge/oredict/OreDictionary.java
+++ b/common/net/minecraftforge/oredict/OreDictionary.java
@@ -6,6 +6,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Set;
 
 import net.minecraft.block.Block;
 import net.minecraft.item.Item;
@@ -81,7 +82,8 @@ public class OreDictionary
         }
         hasInit = true;
 
-        ItemStack[] replaceStacks = replacements.keySet().toArray(new ItemStack[0]);
+        Set<ItemStack> var = replacements.keySet();
+        ItemStack[] replaceStacks = var.toArray(new ItemStack[var.size()]);
 
         // Ignore recipes for the following items
         ItemStack[] exclusions = new ItemStack[]
@@ -121,7 +123,7 @@ public class OreDictionary
                     continue;
                 }
 
-                if(containsMatch(true, (ItemStack[])recipe.recipeItems.toArray(new ItemStack[0]), replaceStacks))
+                if(containsMatch(true, (ItemStack[])recipe.recipeItems.toArray(new ItemStack[recipe.recipeItems.size()]), replaceStacks))
                 {
                     recipesToRemove.add((IRecipe)obj);
                     IRecipe newRecipe = new ShapelessOreRecipe(recipe, replacements);
@@ -217,7 +219,8 @@ public class OreDictionary
      */
     public static String[] getOreNames()
     {
-        return oreIDs.keySet().toArray(new String[0]);
+        Set<String> var = oreIDs.keySet();
+        return var.toArray(new String[var.size()]);
     }
     
     /**

--- a/common/net/minecraftforge/oredict/ShapedOreRecipe.java
+++ b/common/net/minecraftforge/oredict/ShapedOreRecipe.java
@@ -87,7 +87,6 @@ public class ShapedOreRecipe implements IRecipe
         {
             Character chr = (Character)recipe[idx];
             Object in = recipe[idx + 1];
-            Object val = null;
 
             if (in instanceof ItemStack)
             {


### PR DESCRIPTION
- Corrected uses of .toArray() to avoid instantiating two arrays
- Use Collections.addAll when adding an array to a collection
- Correct dungeonloot chances for golden apples, redstone and records. Were accidentally made octal, 050 =/= 50
- Actually set hasInit = true when used (Maybe this should be a static block, instead of init method?)
- Removed type parameters where they can be inferred
- Removed some redundant casts
- Use System.arraycopy() instead of manually copying the enderman carriable block list
- Simplified logic in liquid APIs imported from BC.
- Correct InitNoiseField event to actually set sizeY
- Removed unnecessary local variable val from ShapedOreRecipe constructor
- ForgeHooksClient now actually displays the texture preloading warning, previously used .equals() incorrectly.
- Fixed DimensionManager.registerProviderType()'s duplicate key check - it would never return true, checking if the values contained a key!

Signed-off-by: Ross Allan rallanpcl@gmail.com
