### PR TITLE
Getter method for meta-sensitive smelting recipes

### DIFF
--- a/patches/minecraft/net/minecraft/item/crafting/FurnaceRecipes.java.patch
+++ b/patches/minecraft/net/minecraft/item/crafting/FurnaceRecipes.java.patch
@@ -28,9 +28,18 @@
      public ItemStack getSmeltingResult(int par1)
      {
          return (ItemStack)this.smeltingList.get(Integer.valueOf(par1));
-@@ -65,8 +71,58 @@
+@@ -65,8 +71,67 @@
          return this.smeltingList;
      }
++
++    /**
++     * Returns the list of meta-sensitive smelting recipies
++     */
++    public Map getMetaSmeltingList()
++    {
++        return this.metaSmeltingList;
++    }
++
  
 +    @Deprecated //In favor of ItemStack sensitive version
      public float getExperience(int par1)


### PR DESCRIPTION
Because you can get the meta-insensitive list, but not meta-sensitive one.
