### PR TITLE
Fix check in getItem() to allow lowest item ID

### DIFF
--- a/common/net/minecraftforge/common/Configuration.java
+++ b/common/net/minecraftforge/common/Configuration.java
@@ -194,7 +194,7 @@ public class Configuration
                 FMLLog.warning("Config \"%s\" Category: \"%s\" Key: \"%s\" Default: %d", fileName, category, key, defaultID);
             }
 
-            if (Item.itemsList[defaultShift] == null && !configMarkers[defaultShift] && defaultShift > Block.blocksList.length)
+            if (Item.itemsList[defaultShift] == null && !configMarkers[defaultShift] && defaultShift >= Block.blocksList.length)
             {
                 prop.value = Integer.toString(defaultID);
                 configMarkers[defaultShift] = true;


### PR DESCRIPTION
Just a simple comparison fix to let users of Configuration.getItem() be able to use the lowest possible item ID of 3840 (shifted: 4096)
