### PR TITLE
Add shorthand for tank.getLiquid.isLiquidEqual

### DIFF
--- a/common/net/minecraftforge/liquids/LiquidTank.java
+++ b/common/net/minecraftforge/liquids/LiquidTank.java
@@ -138,5 +138,9 @@ public class LiquidTank implements ILiquidTank {
     {
         this.tankPressure = pressure;
     }
+    
+    public boolean isLiquidEqual(LiquidStack other) {
+        return this.liquid.isLiquidEqual(other);
+    }
 
 }


### PR DESCRIPTION
When coding a special type of tank capable of storing several different types of liquid, I noticed that this combination seemed more verbose than necessary. After all, is there any way for a tank to store more than one type of liquid?
