### PR TITLE
fixed canEntitySpawn test in SpawnerAnimals.java

### DIFF
--- a/patches/minecraft/net/minecraft/world/SpawnerAnimals.java.patch
+++ b/patches/minecraft/net/minecraft/world/SpawnerAnimals.java.patch
@@ -36,7 +36,7 @@
  
 -                                                            if (var39.getCanSpawnHere())
 +                                                            Result canSpawn = ForgeEventFactory.canEntitySpawn(var39, par0WorldServer, var24, var25, var26);
-+                                                            if (canSpawn == Result.ALLOW || (canSpawn == Result.DEFAULT && var39.getCanSpawnHere()))
++                                                            if ((canSpawn == Result.ALLOW) || ((canSpawn == Result.DEFAULT) && var39.getCanSpawnHere()))
                                                              {
                                                                  ++var16;
                                                                  par0WorldServer.spawnEntityInWorld(var39);


### PR DESCRIPTION
EntitySpawn (subclass of EntitySpawnEvent) was not firing due to the way the result was being tested in the SpawnerAnimals.java patch.  This commit fixes the issue.
