### PR TITLE
Forge Additions: Conditional Recipe

### DIFF
--- a/common/net/minecraftforge/common/ForgeHooks.java
+++ b/common/net/minecraftforge/common/ForgeHooks.java
@@ -1,30 +1,35 @@
 package net.minecraftforge.common;
 
-import java.util.*;
-import java.util.Map.Entry;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
 
-import com.google.common.collect.ArrayListMultimap;
-import com.google.common.collect.ListMultimap;
-
-import cpw.mods.fml.common.FMLLog;
-import cpw.mods.fml.common.Loader;
+import com.google.common.collect.Maps;
 
 import net.minecraft.block.Block;
+import net.minecraft.entity.Entity;
 import net.minecraft.entity.EntityLiving;
 import net.minecraft.entity.item.EntityItem;
 import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.inventory.InventoryCrafting;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemArmor;
 import net.minecraft.item.ItemAxe;
 import net.minecraft.item.ItemPickaxe;
 import net.minecraft.item.ItemSpade;
 import net.minecraft.item.ItemStack;
+import net.minecraft.item.crafting.IRecipe;
 import net.minecraft.util.DamageSource;
 import net.minecraft.util.EnumMovingObjectType;
 import net.minecraft.util.MovingObjectPosition;
 import net.minecraft.util.WeightedRandom;
 import net.minecraft.util.WeightedRandomItem;
 import net.minecraft.world.World;
+import net.minecraftforge.craft.condition.BaseCondition;
+import net.minecraftforge.craft.condition.logic.ConditionLogicAND;
 import net.minecraftforge.event.ForgeEventFactory;
 import net.minecraftforge.event.entity.item.ItemTossEvent;
 import net.minecraftforge.event.entity.living.*;
@@ -385,5 +390,38 @@ public class ForgeHooks
 
         player.joinEntityItemWithWorld(event.entityItem);
         return event.entityItem;
+    }
+    
+    private static Map<IRecipe, BaseCondition> _recipeConditional = Maps.newHashMap();
+    
+    /**
+     * Set the Craft Condition for the Recipe.
+     * It Overwrite the Condition if exists.
+     * 
+     * @param recipe The Craft Recipe
+     * @param condition Condition to Match
+     */
+    public static void setCraftCondition(IRecipe recipe, BaseCondition condition)
+    {
+        _recipeConditional.put(recipe, condition);
+    }
+    
+    /**
+     * Add Craft Condition to the Recipe.
+     * 
+     * @param recipe The Craft Recipe
+     * @param condition Condition to Match
+     */
+    public static void addCraftCondition(IRecipe recipe, BaseCondition condition)
+    {
+        if (_recipeConditional.get(recipe) == null)
+            _recipeConditional.put(recipe, condition);
+        else
+            _recipeConditional.put(recipe, ConditionLogicAND.compare(condition, _recipeConditional.get(recipe)));
+    }
+    
+    public static boolean canCraft(IRecipe recipe, InventoryCrafting inventory, Entity crafter, World world, int x, int y, int z)
+    {
+        return !_recipeConditional.containsKey(recipe) || _recipeConditional.get(recipe).isVerified(inventory, crafter, world, x, y, z);
     }
 }

--- a/common/net/minecraftforge/craft/condition/BaseCondition.java
+++ b/common/net/minecraftforge/craft/condition/BaseCondition.java
@@ -1,0 +1,10 @@
+package net.minecraftforge.craft.condition;
+
+import net.minecraft.entity.Entity;
+import net.minecraft.inventory.InventoryCrafting;
+import net.minecraft.world.World;
+
+public abstract class BaseCondition
+{
+	public abstract boolean isVerified(InventoryCrafting inventory, Entity crafter, World world, int x, int y, int z);
+}

--- a/common/net/minecraftforge/craft/condition/ConditionException.java
+++ b/common/net/minecraftforge/craft/condition/ConditionException.java
@@ -1,0 +1,16 @@
+package net.minecraftforge.craft.condition;
+
+public class ConditionException extends RuntimeException
+{
+    private static final long serialVersionUID = 1761896151351608878L;
+    
+    public ConditionException(Throwable cause)
+    {
+        super(cause);
+    }
+    
+    public ConditionException(String cause)
+    {
+        super(cause);
+    }
+}

--- a/common/net/minecraftforge/craft/condition/entity/ConditionEntityInsideArea.java
+++ b/common/net/minecraftforge/craft/condition/entity/ConditionEntityInsideArea.java
@@ -1,0 +1,70 @@
+package net.minecraftforge.craft.condition.entity;
+
+import net.minecraft.entity.Entity;
+import net.minecraft.inventory.InventoryCrafting;
+import net.minecraft.world.World;
+import net.minecraftforge.craft.condition.BaseCondition;
+
+public class ConditionEntityInsideArea extends BaseCondition
+{
+	private enum AreaType
+	{
+		AREA_X, AREA_Y, AREA_Z, AREA_XZ, AREA_XYZ
+	}
+	
+	private final AreaType _areaType;
+	private final int[] _coordinates;
+	
+	private ConditionEntityInsideArea(AreaType areaType, int... coordinates)
+	{
+		_areaType = areaType;
+		_coordinates = coordinates;
+	}
+	
+	public static ConditionEntityInsideArea isBetweenX(int minX, int maxX)
+	{
+		return new ConditionEntityInsideArea(AreaType.AREA_X, minX, maxX);
+	}
+	
+	public static ConditionEntityInsideArea isBetweenY(int minY, int maxY)
+	{
+		return new ConditionEntityInsideArea(AreaType.AREA_Y, minY, maxY);
+	}
+	
+	public static ConditionEntityInsideArea isBetweenZ(int minZ, int maxZ)
+	{
+		return new ConditionEntityInsideArea(AreaType.AREA_Z, minZ, maxZ);
+	}
+	
+	public static ConditionEntityInsideArea isBetweenXZ(int minX, int minZ, int maxX, int maxZ)
+	{
+		return new ConditionEntityInsideArea(AreaType.AREA_XZ, minX, minZ, maxX, maxZ);
+	}
+	
+	public static ConditionEntityInsideArea isBetweenXYZ(int minX, int minY, int minZ, int maxX, int maxY, int maxZ)
+	{
+		return new ConditionEntityInsideArea(AreaType.AREA_XYZ, minX, minY, minZ, maxX, maxY, maxZ);
+	}
+
+	@Override
+	public boolean isVerified(InventoryCrafting inventory, Entity crafter, World world, int x, int y, int z)
+	{
+		switch (_areaType)
+		{
+			case AREA_X:
+				return _coordinates[0] <= crafter.posX && crafter.posX <= _coordinates[1];
+			case AREA_Y:
+				return _coordinates[0] <= crafter.posY && crafter.posY <= _coordinates[1];
+			case AREA_Z:
+				return _coordinates[0] <= crafter.posZ && crafter.posZ <= _coordinates[1];
+			case AREA_XZ:
+				return _coordinates[0] <= crafter.posX && crafter.posX <= _coordinates[2]
+				&& _coordinates[1] <= crafter.posZ && crafter.posZ <= _coordinates[3];
+			case AREA_XYZ:
+				return _coordinates[0] <= crafter.posX && crafter.posX <= _coordinates[3]
+				&& _coordinates[1] <= crafter.posY && crafter.posY <= _coordinates[4]
+				&& _coordinates[2] <= crafter.posZ && crafter.posZ <= _coordinates[5];
+		}
+		return false;
+	}
+}

--- a/common/net/minecraftforge/craft/condition/entity/ConditionEntityInsideBiome.java
+++ b/common/net/minecraftforge/craft/condition/entity/ConditionEntityInsideBiome.java
@@ -1,0 +1,30 @@
+package net.minecraftforge.craft.condition.entity;
+
+import net.minecraft.entity.Entity;
+import net.minecraft.inventory.InventoryCrafting;
+import net.minecraft.world.World;
+import net.minecraftforge.craft.condition.BaseCondition;
+import net.minecraftforge.craft.condition.ConditionException;
+
+public class ConditionEntityInsideBiome extends BaseCondition
+{
+    private final String _biomeName;
+    
+	private ConditionEntityInsideBiome(String biomeName)
+	{
+		_biomeName = biomeName;
+	}
+	
+	public static ConditionEntityInsideBiome isInside(String biomeName)
+	{
+	    if (biomeName == null)
+            throw new ConditionException("Biome Name can't be NULL");
+		return new ConditionEntityInsideBiome(biomeName);
+	}
+
+	@Override
+	public boolean isVerified(InventoryCrafting inventory, Entity crafter, World world, int x, int y, int z)
+	{
+		return crafter.worldObj.getBiomeGenForCoords((int)crafter.posX, (int)crafter.posZ).biomeName.equalsIgnoreCase(_biomeName);
+	}
+}

--- a/common/net/minecraftforge/craft/condition/entity/ConditionEntityInsideDimension.java
+++ b/common/net/minecraftforge/craft/condition/entity/ConditionEntityInsideDimension.java
@@ -1,0 +1,27 @@
+package net.minecraftforge.craft.condition.entity;
+
+import net.minecraft.entity.Entity;
+import net.minecraft.inventory.InventoryCrafting;
+import net.minecraft.world.World;
+import net.minecraftforge.craft.condition.BaseCondition;
+
+public class ConditionEntityInsideDimension extends BaseCondition
+{
+    private final int _dimensionId;
+    
+	private ConditionEntityInsideDimension(int dimensionId)
+	{
+	    _dimensionId = dimensionId;
+	}
+	
+	public static ConditionEntityInsideDimension isInside(int dimensionId)
+	{
+		return new ConditionEntityInsideDimension(dimensionId);
+	}
+
+	@Override
+	public boolean isVerified(InventoryCrafting inventory, Entity crafter, World world, int x, int y, int z)
+	{
+		return crafter.worldObj.provider.dimensionId == _dimensionId;
+	}
+}

--- a/common/net/minecraftforge/craft/condition/entity/player/ConditionPlayerInventoryItem.java
+++ b/common/net/minecraftforge/craft/condition/entity/player/ConditionPlayerInventoryItem.java
@@ -1,0 +1,31 @@
+package net.minecraftforge.craft.condition.entity.player;
+
+import net.minecraft.entity.Entity;
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.inventory.InventoryCrafting;
+import net.minecraft.world.World;
+import net.minecraftforge.craft.condition.BaseCondition;
+
+public class ConditionPlayerInventoryItem extends BaseCondition
+{
+    private final int _itemId;
+    
+	private ConditionPlayerInventoryItem(int itemId)
+	{
+	    _itemId = itemId;
+	}
+	
+	public static ConditionPlayerInventoryItem haveItem(int itemId)
+	{
+		return new ConditionPlayerInventoryItem(itemId);
+	}
+
+	@Override
+	public boolean isVerified(InventoryCrafting inventory, Entity crafter, World world, int x, int y, int z)
+	{
+		if (crafter instanceof EntityPlayer)
+			return ((EntityPlayer)crafter).inventory.hasItem(_itemId);
+		return false;
+	}
+
+}

--- a/common/net/minecraftforge/craft/condition/entity/player/ConditionPlayerLevel.java
+++ b/common/net/minecraftforge/craft/condition/entity/player/ConditionPlayerLevel.java
@@ -1,0 +1,75 @@
+package net.minecraftforge.craft.condition.entity.player;
+
+import net.minecraft.entity.Entity;
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.inventory.InventoryCrafting;
+import net.minecraft.world.World;
+import net.minecraftforge.craft.condition.BaseCondition;
+
+public class ConditionPlayerLevel extends BaseCondition
+{
+	private enum ComparisionMode
+	{
+		EQUALS,
+		LESS,
+		MORE,
+		BETWEEN
+	}
+	
+	private final ComparisionMode _comparisionMode;
+	private final int[] _level;
+	
+	private ConditionPlayerLevel(ComparisionMode comparisionMode, int... level)
+	{
+		_comparisionMode = comparisionMode;
+		_level = level;
+	}
+	
+	public static ConditionPlayerLevel equals(int level)
+	{
+		return new ConditionPlayerLevel(ComparisionMode.EQUALS, level);
+	}
+	
+	public static ConditionPlayerLevel lessThan(int level)
+	{
+		return new ConditionPlayerLevel(ComparisionMode.LESS, level);
+	}
+	
+	public static ConditionPlayerLevel moreThan(int level)
+	{
+		return new ConditionPlayerLevel(ComparisionMode.MORE, level);
+	}
+	
+	public static ConditionPlayerLevel between(int minLevel, int maxLevel)
+	{
+	    if (minLevel == maxLevel)
+	        return ConditionPlayerLevel.equals(minLevel);
+	    
+	    if (minLevel > maxLevel)
+	        return new ConditionPlayerLevel(ComparisionMode.BETWEEN, maxLevel, minLevel);
+	    
+		return new ConditionPlayerLevel(ComparisionMode.BETWEEN, minLevel, maxLevel);
+	}
+
+	@Override
+	public boolean isVerified(InventoryCrafting inventory, Entity crafter, World world, int x, int y, int z)
+	{
+		if (!(crafter instanceof EntityPlayer))
+			return false;
+		
+		EntityPlayer player = (EntityPlayer)crafter;
+		
+		switch (_comparisionMode)
+		{
+			case EQUALS:
+				return player.experienceLevel == _level[0];
+			case LESS:
+				return player.experienceLevel < _level[0];
+			case MORE:
+				return player.experienceLevel > _level[0];
+			case BETWEEN:
+				return _level[0] <= player.experienceLevel && player.experienceLevel <= _level[1];
+		}
+		return false;
+	}
+}

--- a/common/net/minecraftforge/craft/condition/entity/player/ConditionPlayerUsername.java
+++ b/common/net/minecraftforge/craft/condition/entity/player/ConditionPlayerUsername.java
@@ -1,0 +1,41 @@
+package net.minecraftforge.craft.condition.entity.player;
+
+import net.minecraft.entity.Entity;
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.inventory.InventoryCrafting;
+import net.minecraft.world.World;
+import net.minecraftforge.craft.condition.BaseCondition;
+import net.minecraftforge.craft.condition.ConditionException;
+
+public class ConditionPlayerUsername extends BaseCondition
+{
+    private final String[] _usernames;
+    
+	private ConditionPlayerUsername(String[] usernames)
+	{
+		_usernames = usernames;
+	}
+	
+	public static ConditionPlayerUsername equals(String... usernames)
+	{
+	    for (String username : usernames)
+            if (username == null)
+                throw new ConditionException("Player Name can't be NULL");
+	    
+		return new ConditionPlayerUsername(usernames);
+	}
+
+	@Override
+	public boolean isVerified(InventoryCrafting inventory, Entity crafter, World world, int x, int y, int z)
+	{
+		if (crafter instanceof EntityPlayer)
+		{
+		    for (String username : _usernames)
+		    {
+		        if (username.equalsIgnoreCase(((EntityPlayer)crafter).username))
+		            return true;
+		    }
+		}
+		return false;
+	}
+}

--- a/common/net/minecraftforge/craft/condition/logic/ConditionLogicAND.java
+++ b/common/net/minecraftforge/craft/condition/logic/ConditionLogicAND.java
@@ -1,0 +1,43 @@
+package net.minecraftforge.craft.condition.logic;
+
+import net.minecraft.entity.Entity;
+import net.minecraft.inventory.InventoryCrafting;
+import net.minecraft.world.World;
+import net.minecraftforge.craft.condition.BaseCondition;
+import net.minecraftforge.craft.condition.ConditionException;
+
+public class ConditionLogicAND extends BaseCondition
+{
+    private final BaseCondition[] _conditions;
+    
+	private ConditionLogicAND(BaseCondition[] conditions)
+	{
+	    _conditions = conditions;
+	}
+	
+	public static ConditionLogicAND compare(BaseCondition... conditions)
+	{
+	    if (conditions.length == 0)
+	        throw new ConditionException("Missing Conditions");
+	    
+	    for (BaseCondition cond : conditions)
+	        if (cond == null)
+	            throw new ConditionException("Cannot Compare NULL");
+	    
+		return new ConditionLogicAND(conditions);
+	}
+
+	@Override
+	public boolean isVerified(InventoryCrafting inventory, Entity crafter, World world, int x, int y, int z)
+	{
+	    boolean firstCondition = _conditions[0].isVerified(inventory, crafter, world, x, y, z);
+	    
+		if (_conditions.length == 1 || !firstCondition)
+			return firstCondition;
+		
+		for (int i = 1; i < _conditions.length; i++)
+			if (!(firstCondition && _conditions[i].isVerified(inventory, crafter, world, x, y, z)))
+				return false;
+		return true;
+	}
+}

--- a/common/net/minecraftforge/craft/condition/logic/ConditionLogicNOT.java
+++ b/common/net/minecraftforge/craft/condition/logic/ConditionLogicNOT.java
@@ -1,0 +1,31 @@
+package net.minecraftforge.craft.condition.logic;
+
+import net.minecraft.entity.Entity;
+import net.minecraft.inventory.InventoryCrafting;
+import net.minecraft.world.World;
+import net.minecraftforge.craft.condition.BaseCondition;
+import net.minecraftforge.craft.condition.ConditionException;
+
+public class ConditionLogicNOT extends BaseCondition
+{
+    private final BaseCondition _condition;
+    
+	private ConditionLogicNOT(BaseCondition condition)
+	{
+	    _condition = condition;
+	}
+	
+	public static ConditionLogicNOT invert(BaseCondition condition)
+	{
+	    if (condition == null)
+            throw new ConditionException("Cannot Invert NULL");
+	    
+		return new ConditionLogicNOT(condition);
+	}
+
+	@Override
+	public boolean isVerified(InventoryCrafting inventory, Entity crafter, World world, int x, int y, int z)
+	{
+		return !_condition.isVerified(inventory, crafter, world, x, y, z);
+	}
+}

--- a/common/net/minecraftforge/craft/condition/logic/ConditionLogicOR.java
+++ b/common/net/minecraftforge/craft/condition/logic/ConditionLogicOR.java
@@ -1,0 +1,39 @@
+package net.minecraftforge.craft.condition.logic;
+
+import net.minecraft.entity.Entity;
+import net.minecraft.inventory.InventoryCrafting;
+import net.minecraft.world.World;
+import net.minecraftforge.craft.condition.BaseCondition;
+import net.minecraftforge.craft.condition.ConditionException;
+
+public class ConditionLogicOR extends BaseCondition
+{
+    private final BaseCondition[] _conditions;
+    
+	private ConditionLogicOR(BaseCondition[] conditions)
+	{
+		_conditions = conditions;
+	}
+	
+	public static ConditionLogicOR compare(BaseCondition... conditions)
+	{
+	    if (conditions.length == 0)
+            throw new ConditionException("Missing Conditions");
+        
+        for (BaseCondition cond : conditions)
+            if (cond == null)
+                throw new ConditionException("Cannot Compare NULL");
+        
+		return new ConditionLogicOR(conditions);
+	}
+
+	@Override
+	public boolean isVerified(InventoryCrafting inventory, Entity crafter, World world, int x, int y, int z)
+	{
+		for (BaseCondition cond : _conditions)
+			if (cond.isVerified(inventory, crafter, world, x, y, z))
+				return true;
+		
+		return false;
+	}
+}

--- a/common/net/minecraftforge/craft/condition/time/ConditionTime.java
+++ b/common/net/minecraftforge/craft/condition/time/ConditionTime.java
@@ -1,0 +1,145 @@
+package net.minecraftforge.craft.condition.time;
+
+import java.util.Calendar;
+
+import net.minecraft.entity.Entity;
+import net.minecraft.inventory.InventoryCrafting;
+import net.minecraft.world.World;
+import net.minecraftforge.craft.condition.BaseCondition;
+import net.minecraftforge.craft.condition.ConditionException;
+
+public class ConditionTime extends BaseCondition
+{
+	private final int _dateType;
+	private final int[] _time;
+	
+	private ConditionTime(int dateType, int... time)
+	{
+		_dateType = dateType;
+		_time = time;
+	}
+	
+	public static ConditionTime isYear(int year)
+	{
+		return new ConditionTime(Calendar.YEAR, year);
+	}
+	
+	public static ConditionTime betweenYear(int minYear, int maxYear)
+	{
+	    if (minYear == maxYear)
+	        return ConditionTime.isYear(minYear);
+	    
+		return new ConditionTime(Calendar.YEAR, minYear, maxYear);
+	}
+	
+	public static ConditionTime isMonth(int month)
+	{
+	    if (month < 1 || month > 12)
+	        throw new ConditionException("Month Must be Between January (1) and December (12)");
+		return new ConditionTime(Calendar.MONTH, month-1);
+	}
+	
+	public static ConditionTime betweenMonth(int minMonth, int maxMonth)
+	{
+	    if (minMonth == maxMonth)
+            return ConditionTime.isMonth(minMonth);
+	    
+	    if (minMonth < 1 || minMonth > 12 || maxMonth < 1 || maxMonth > 12)
+            throw new ConditionException("Month Must be Between January (1) and December (12)");
+	    
+		return new ConditionTime(Calendar.MONTH, minMonth-1, maxMonth-1);
+	}
+	
+	public static ConditionTime isDay(int day)
+	{
+	    if (day < 1 || day > 31)
+            throw new ConditionException("Day Must be Between 1 and 31");
+	    
+		return new ConditionTime(Calendar.DAY_OF_MONTH, day);
+	}
+	
+	public static ConditionTime betweenDay(int minDay, int maxDay)
+	{
+	    if (minDay == maxDay)
+            return ConditionTime.isDay(minDay);
+	    
+	    if (minDay < 1 || minDay > 31 || maxDay < 1 || maxDay > 31)
+            throw new ConditionException("Day Must be Between 1 and 31");
+        
+		return new ConditionTime(Calendar.DAY_OF_MONTH, minDay, maxDay);
+	}
+	
+	public static ConditionTime isWeekday(int weekday)
+	{
+	    if (weekday < 1 || weekday > 7)
+	        throw new ConditionException("Weekday Must be Between Sunday (1) and Saturday (7)"); 
+	    
+		return new ConditionTime(Calendar.DAY_OF_WEEK, weekday);
+	}
+	
+	public static ConditionTime betweenWeekday(int minWeekday, int maxWeekday)
+	{
+	    if (minWeekday == maxWeekday)
+            return ConditionTime.isWeekday(minWeekday);
+	    
+	    if (minWeekday < 1 || minWeekday > 7 || maxWeekday < 1 || maxWeekday > 7)
+            throw new ConditionException("Weekday Must be Between Sunday (1) and Saturday (7)");
+	    
+		return new ConditionTime(Calendar.DAY_OF_WEEK, minWeekday, maxWeekday);
+	}
+	
+	public static ConditionTime isHour(int hour)
+	{
+	    if (hour < 0 || hour > 23)
+	        throw new ConditionException("Hour Must be Between 0 and 23");
+	    
+		return new ConditionTime(Calendar.HOUR_OF_DAY, hour);
+	}
+	
+	public static ConditionTime betweenHour(int minHour, int maxHour)
+	{
+	    if (minHour == maxHour)
+            return ConditionTime.isHour(minHour);
+	    
+	    if (minHour < 0 || minHour > 23 || maxHour < 0 || maxHour > 23)
+            throw new ConditionException("Hour Must be Between 0 and 23");
+	    
+		return new ConditionTime(Calendar.HOUR_OF_DAY, minHour, maxHour);
+	}
+	
+	public static ConditionTime isMinute(int minute)
+	{
+	    if (minute < 0 || minute > 60)
+	        throw new ConditionException("Minute Must be Between 0 and 59");
+	    
+		return new ConditionTime(Calendar.MINUTE, minute);
+	}
+	
+	public static ConditionTime betweenMinute(int minMinute, int maxMinute)
+	{
+	    if (minMinute == maxMinute)
+            return ConditionTime.isMinute(minMinute);
+	    
+	    if (minMinute < 0 || minMinute > 60 || maxMinute < 0 || maxMinute > 60)
+            throw new ConditionException("Minute Must be Between 0 and 59");
+	    
+		return new ConditionTime(Calendar.MINUTE, minMinute, maxMinute);
+	}
+
+	@Override
+	public boolean isVerified(InventoryCrafting inventory, Entity crafter, World world, int x, int y, int z)
+	{
+		Calendar calendar = Calendar.getInstance();
+		
+		switch (_time.length)
+		{
+    		case 0:
+    		    return calendar.get(_dateType) == _time[0];
+    		case 1:
+    		    if (_time[0] < _time[1])
+                    return _time[0] <= calendar.get(_dateType) && calendar.get(_dateType) <= _time[1];
+                return calendar.get(_dateType) >= _time[0] || calendar.get(_dateType) <= _time[1];
+		}
+		return false;
+	}
+}

--- a/common/net/minecraftforge/craft/condition/world/ConditionWorldTime.java
+++ b/common/net/minecraftforge/craft/condition/world/ConditionWorldTime.java
@@ -1,0 +1,67 @@
+package net.minecraftforge.craft.condition.world;
+
+import net.minecraft.entity.Entity;
+import net.minecraft.inventory.InventoryCrafting;
+import net.minecraft.world.World;
+import net.minecraftforge.craft.condition.BaseCondition;
+import net.minecraftforge.craft.condition.ConditionException;
+
+public class ConditionWorldTime extends BaseCondition
+{
+    private static final int MIN_TIME = 0;
+    private static final int MAX_TIME = 24000;
+    
+	private static final int DAWN = 0;
+	private static final int MIDDAY = 6000;
+	private static final int DUSK = 12000;
+	private static final int MIDNIGHT = 18000;
+	
+	private final int _minTime;
+	private final int _maxTime;
+	
+	private ConditionWorldTime(int minTime, int maxTime)
+	{
+	    _minTime = minTime;
+	    _maxTime = maxTime;
+	}
+
+	public static ConditionWorldTime isBetween(int minTime, int maxTime)
+	{
+	    if (minTime == maxTime)
+	        throw new ConditionException("Min Time and Max Time Must be Different");
+	    
+	    if (minTime < MIN_TIME || minTime > MAX_TIME || maxTime < MIN_TIME || maxTime > MAX_TIME)
+	        throw new ConditionException("Time Must be Between 0 and 24000");
+	    
+		return new ConditionWorldTime(minTime, maxTime);
+	}
+
+	public static ConditionWorldTime isMoring()
+	{
+		return ConditionWorldTime.isBetween(DAWN, MIDDAY);
+	}
+
+	public static ConditionWorldTime isAfternoon()
+	{
+		return ConditionWorldTime.isBetween(MIDDAY, DUSK);
+	}
+
+	public static ConditionWorldTime isEvening()
+	{
+		return ConditionWorldTime.isBetween(DUSK, MIDNIGHT);
+	}
+
+	public static ConditionWorldTime isNight()
+	{
+		return ConditionWorldTime.isBetween(MIDNIGHT, DAWN);
+	}
+
+	@Override
+	public boolean isVerified(InventoryCrafting inventory, Entity crafter, World world, int x, int y, int z)
+	{
+		if (_minTime < _maxTime)
+			return _minTime <= world.getWorldTime() && world.getWorldTime() <= _maxTime;
+		
+		return world.getWorldTime() >= _minTime || world.getWorldTime() <= _maxTime;
+	}
+}

--- a/common/net/minecraftforge/event/entity/item/ItemCraftMatchEvent.java
+++ b/common/net/minecraftforge/event/entity/item/ItemCraftMatchEvent.java
@@ -1,0 +1,47 @@
+package net.minecraftforge.event.entity.item;
+
+import net.minecraft.entity.Entity;
+import net.minecraft.item.ItemStack;
+import net.minecraft.item.crafting.IRecipe;
+import net.minecraft.world.World;
+import net.minecraftforge.event.Cancelable;
+import net.minecraftforge.event.entity.EntityEvent;
+
+@Cancelable
+public class ItemCraftMatchEvent extends EntityEvent
+{
+	public final IRecipe recipe;
+	public final ItemStack result;
+	public final World world;
+	public final int x;
+	public final int y;
+	public final int z;
+
+	public ItemStack newResult;
+
+	/**
+	 * This Event is Called when an Entity put a valid
+	 * item combination into a craft table.
+	 * 
+	 * @param entity The Entity
+	 * @param recipe Matching Recipe
+	 * @param result Expected Recipe Result
+	 * @param world Event World Origin
+	 * @param x Event X Origin
+	 * @param y Event Y Origin
+	 * @param z Event Z Origin
+	 */
+	public ItemCraftMatchEvent(Entity entity, IRecipe recipe, ItemStack result, World world, int x, int y, int z)
+	{
+	    super(entity);
+
+	    this.recipe = recipe;
+	    this.result = result;
+	    this.world = world;
+	    this.x = x;
+	    this.y = y;
+	    this.z = z;
+	    this.newResult = result;
+	}
+}
+

--- a/patches/minecraft/net/minecraft/entity/passive/EntitySheep.java.patch
+++ b/patches/minecraft/net/minecraft/entity/passive/EntitySheep.java.patch
@@ -49,6 +49,15 @@
          return super.interact(par1EntityPlayer);
      }
  
+@@ -325,7 +307,7 @@
+         int var4 = this.func_90013_b(par2EntityAnimal);
+         this.field_90016_e.getStackInSlot(0).setItemDamage(var3);
+         this.field_90016_e.getStackInSlot(1).setItemDamage(var4);
+-        ItemStack var5 = CraftingManager.getInstance().findMatchingRecipe(this.field_90016_e, ((EntitySheep)par1EntityAnimal).worldObj);
++        ItemStack var5 = CraftingManager.getInstance().findMatchingRecipe(par1EntityAnimal, this.field_90016_e, par1EntityAnimal.worldObj, (int)par1EntityAnimal.posX, (int)par1EntityAnimal.posY, (int)par1EntityAnimal.posZ);
+         int var6;
+ 
+         if (var5 != null && var5.getItem().itemID == Item.dyePowder.itemID)
 @@ -349,4 +331,24 @@
      {
          return this.func_90015_b(par1EntityAgeable);

--- a/patches/minecraft/net/minecraft/inventory/ContainerPlayer.java.patch
+++ b/patches/minecraft/net/minecraft/inventory/ContainerPlayer.java.patch
@@ -1,0 +1,11 @@
+--- ../src_base/minecraft/net/minecraft/inventory/ContainerPlayer.java
++++ ../src_work/minecraft/net/minecraft/inventory/ContainerPlayer.java
+@@ -58,7 +58,7 @@
+      */
+     public void onCraftMatrixChanged(IInventory par1IInventory)
+     {
+-        this.craftResult.setInventorySlotContents(0, CraftingManager.getInstance().findMatchingRecipe(this.craftMatrix, this.thePlayer.worldObj));
++        this.craftResult.setInventorySlotContents(0, CraftingManager.getInstance().findMatchingRecipe(this.thePlayer, this.craftMatrix, this.thePlayer.worldObj, (int)this.thePlayer.posX, (int)this.thePlayer.posY, (int)this.thePlayer.posZ));
+     }
+ 
+     /**

--- a/patches/minecraft/net/minecraft/inventory/ContainerWorkbench.java.patch
+++ b/patches/minecraft/net/minecraft/inventory/ContainerWorkbench.java.patch
@@ -1,0 +1,27 @@
+--- ../src_base/minecraft/net/minecraft/inventory/ContainerWorkbench.java
++++ ../src_work/minecraft/net/minecraft/inventory/ContainerWorkbench.java
+@@ -16,6 +16,7 @@
+     private int posX;
+     private int posY;
+     private int posZ;
++    private EntityPlayer player;
+ 
+     public ContainerWorkbench(InventoryPlayer par1InventoryPlayer, World par2World, int par3, int par4, int par5)
+     {
+@@ -23,6 +24,7 @@
+         this.posX = par3;
+         this.posY = par4;
+         this.posZ = par5;
++        this.player = par1InventoryPlayer.player;
+         this.addSlotToContainer(new SlotCrafting(par1InventoryPlayer.player, this.craftMatrix, this.craftResult, 0, 124, 35));
+         int var6;
+         int var7;
+@@ -56,7 +58,7 @@
+      */
+     public void onCraftMatrixChanged(IInventory par1IInventory)
+     {
+-        this.craftResult.setInventorySlotContents(0, CraftingManager.getInstance().findMatchingRecipe(this.craftMatrix, this.worldObj));
++        this.craftResult.setInventorySlotContents(0, CraftingManager.getInstance().findMatchingRecipe(this.player, this.craftMatrix, this.worldObj, this.posX, this.posY, this.posZ));
+     }
+ 
+     /**

--- a/patches/minecraft/net/minecraft/item/crafting/CraftingManager.java.patch
+++ b/patches/minecraft/net/minecraft/item/crafting/CraftingManager.java.patch
@@ -1,6 +1,57 @@
 --- ../src_base/minecraft/net/minecraft/item/crafting/CraftingManager.java
 +++ ../src_work/minecraft/net/minecraft/item/crafting/CraftingManager.java
-@@ -269,7 +269,7 @@
+@@ -5,10 +5,14 @@
+ import java.util.HashMap;
+ import java.util.List;
+ import net.minecraft.block.Block;
++import net.minecraft.entity.Entity;
+ import net.minecraft.inventory.InventoryCrafting;
+ import net.minecraft.item.Item;
+ import net.minecraft.item.ItemStack;
+ import net.minecraft.world.World;
++import net.minecraftforge.common.ForgeHooks;
++import net.minecraftforge.common.MinecraftForge;
++import net.minecraftforge.event.entity.item.ItemCraftMatchEvent;
+ 
+ public class CraftingManager
+ {
+@@ -210,7 +214,13 @@
+         return var17;
+     }
+ 
++    @Deprecated
+     public void addShapelessRecipe(ItemStack par1ItemStack, Object ... par2ArrayOfObj)
++    {
++        addShapelessRecipe(par1ItemStack, par2ArrayOfObj);
++    }
++
++    public ShapelessRecipes addAndGetShapelessRecipe(ItemStack par1ItemStack, Object ... par2ArrayOfObj)
+     {
+         ArrayList var3 = new ArrayList();
+         Object[] var4 = par2ArrayOfObj;
+@@ -239,10 +249,18 @@
+             }
+         }
+ 
+-        this.recipes.add(new ShapelessRecipes(par1ItemStack, var3));
+-    }
+-
++        ShapelessRecipes recipe = new ShapelessRecipes(par1ItemStack, var3);
++        this.recipes.add(recipe);
++        return recipe;
++    }
++
++    @Deprecated
+     public ItemStack findMatchingRecipe(InventoryCrafting par1InventoryCrafting, World par2World)
++    {
++        return findMatchingRecipe(null, par1InventoryCrafting, par2World, 0, 0, 0);
++    }
++
++    public ItemStack findMatchingRecipe(Entity crafter, InventoryCrafting par1InventoryCrafting, World par2World, int x, int y, int z)
+     {
+         int var3 = 0;
+         ItemStack var4 = null;
+@@ -269,7 +287,7 @@
              }
          }
  
@@ -9,3 +60,19 @@
          {
              Item var11 = Item.itemsList[var4.itemID];
              int var13 = var11.getMaxDamage() - var4.getItemDamageForDisplay();
+@@ -292,7 +310,14 @@
+ 
+                 if (var12.matches(par1InventoryCrafting, par2World))
+                 {
+-                    return var12.getCraftingResult(par1InventoryCrafting);
++                    if (!ForgeHooks.canCraft(var12, par1InventoryCrafting, crafter, par2World, x, y, z))
++                        return null;
++
++                    ItemCraftMatchEvent event = new ItemCraftMatchEvent(crafter, var12, var12.getCraftingResult(par1InventoryCrafting), par2World, x, y, z);
++                    if (MinecraftForge.EVENT_BUS.post(event))
++                        return null;
++
++                    return event.newResult;
+                 }
+             }
+ 


### PR DESCRIPTION
This patch add the support for Conditional Recipes.
Conditional recipes can be used with a Forge Hook or Event.
The Hook is useful for "weekdays modders", which want something limited
but functional: you can use a default set of conditions like real and
minecraft world time, AOI Logical operators, location, player and
entity.
The Event is useful if you need "something more".
