### PR TITLE
Forge Additions: Location/Meta Sensitive Strength vs Block

### DIFF
--- a/common/net/minecraftforge/common/ForgeHooks.java
+++ b/common/net/minecraftforge/common/ForgeHooks.java
@@ -142,12 +142,12 @@ public class ForgeHooks
 
         if (!canHarvestBlock(block, player, metadata))
         {
-            float speed = ForgeEventFactory.getBreakSpeed(player, block, metadata, 1.0f);
+            float speed = ForgeEventFactory.getBreakSpeed(player, block, world, x, y, z, metadata, 1.0f);
             return (speed < 0 ? 0 : speed) / hardness / 100F;
         }
         else
         {
-             return player.getCurrentPlayerStrVsBlock(block, metadata) / hardness / 30F;
+             return player.getCurrentPlayerStrVsBlock(block, world, x, y, z, metadata) / hardness / 30F;
         }
     }
 

--- a/common/net/minecraftforge/event/ForgeEventFactory.java
+++ b/common/net/minecraftforge/event/ForgeEventFactory.java
@@ -22,9 +22,16 @@ public class ForgeEventFactory
         return event.success;
     }
 
+    @Deprecated
     public static float getBreakSpeed(EntityPlayer player, Block block, int metadata, float original)
     {
         PlayerEvent.BreakSpeed event = new PlayerEvent.BreakSpeed(player, block, metadata, original);
+        return (MinecraftForge.EVENT_BUS.post(event) ? -1 : event.newSpeed);
+    }
+
+    public static float getBreakSpeed(EntityPlayer player, Block block, World world, int x, int y, int z, int metadata, float original)
+    {
+        PlayerEvent.BreakSpeed event = new PlayerEvent.BreakSpeed(player, block, world, x, y, z, metadata, original);
         return (MinecraftForge.EVENT_BUS.post(event) ? -1 : event.newSpeed);
     }
 

--- a/common/net/minecraftforge/event/entity/player/PlayerEvent.java
+++ b/common/net/minecraftforge/event/entity/player/PlayerEvent.java
@@ -3,6 +3,7 @@ package net.minecraftforge.event.entity.player;
 import net.minecraft.block.Block;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.world.World;
 import net.minecraftforge.event.Cancelable;
 import net.minecraftforge.event.entity.living.LivingEvent;
 
@@ -32,14 +33,28 @@ public class PlayerEvent extends LivingEvent
     public static class BreakSpeed extends PlayerEvent
     {
         public final Block block;
+        public final World world;
+        public final int x;
+        public final int y;
+        public final int z;
         public final int metadata;
         public final float originalSpeed;
         public float newSpeed = 0.0f;
 
+        @Deprecated
         public BreakSpeed(EntityPlayer player, Block block, int metadata, float original)
+        {
+            this(player, block, null, 0, 0, 0, metadata, original);
+        }
+        
+        public BreakSpeed(EntityPlayer player, Block block, World world, int x, int y, int z, int metadata, float original)
         {
             super(player);
             this.block = block;
+            this.world = world;
+            this.x = x;
+            this.y = y;
+            this.z = z;
             this.metadata = metadata;
             this.originalSpeed = original;
             this.newSpeed = original;

--- a/patches/minecraft/net/minecraft/entity/player/EntityPlayer.java.patch
+++ b/patches/minecraft/net/minecraft/entity/player/EntityPlayer.java.patch
@@ -106,7 +106,7 @@
      }
  
      /**
-@@ -738,23 +782,39 @@
+@@ -738,23 +782,45 @@
       */
      public void joinEntityItemWithWorld(EntityItem par1EntityItem)
      {
@@ -133,10 +133,16 @@
 +        return getCurrentPlayerStrVsBlock(par1Block, 0);
 +    }
 +
++    @Deprecated
 +    public float getCurrentPlayerStrVsBlock(Block par1Block, int meta)
 +    {
++        return getCurrentPlayerStrVsBlock(par1Block, null, 0, 0, 0, meta);
++    }
++    
++    public float getCurrentPlayerStrVsBlock(Block par1Block, World world, int x, int y, int z, int meta)
++    {
 +        ItemStack stack = inventory.getCurrentItem();
-+        float var2 = (stack == null ? 1.0F : stack.getItem().getStrVsBlock(stack, par1Block, meta));
++        float var2 = (stack == null ? 1.0F : stack.getItem().getStrVsBlock(stack, par1Block, world, x, y, z, meta));
          int var3 = EnchantmentHelper.getEfficiencyModifier(this);
          ItemStack var4 = this.inventory.getCurrentItem();
  
@@ -151,17 +157,17 @@
              {
                  var2 += var5 * 0.08F;
              }
-@@ -784,7 +844,8 @@
+@@ -784,7 +850,8 @@
              var2 /= 5.0F;
          }
  
 -        return var2;
-+        var2 = ForgeEventFactory.getBreakSpeed(this, par1Block, meta, var2);
++        var2 = ForgeEventFactory.getBreakSpeed(this, par1Block, worldObj, x, y, z, meta, var2);
 +        return (var2 < 0 ? 0 : var2);
      }
  
      /**
-@@ -792,7 +853,7 @@
+@@ -792,7 +859,7 @@
       */
      public boolean canHarvestBlock(Block par1Block)
      {
@@ -170,7 +176,7 @@
      }
  
      /**
-@@ -1079,12 +1140,22 @@
+@@ -1079,12 +1146,22 @@
      {
          if (!this.isEntityInvulnerable())
          {
@@ -194,7 +200,7 @@
              par2 = this.applyPotionDamageCalculations(par1DamageSource, par2);
              this.addExhaustion(par1DamageSource.getHungerDamage());
              this.health -= par2;
-@@ -1125,6 +1196,10 @@
+@@ -1125,6 +1202,10 @@
  
      public boolean interactWith(Entity par1Entity)
      {
@@ -205,7 +211,7 @@
          if (par1Entity.interact(this))
          {
              return true;
-@@ -1168,7 +1243,9 @@
+@@ -1168,7 +1249,9 @@
       */
      public void destroyCurrentEquippedItem()
      {
@@ -215,7 +221,7 @@
      }
  
      /**
-@@ -1185,6 +1262,15 @@
+@@ -1185,6 +1268,15 @@
       */
      public void attackTargetEntityWithCurrentItem(Entity par1Entity)
      {
@@ -231,7 +237,7 @@
          if (par1Entity.canAttackWithItem())
          {
              if (!par1Entity.func_85031_j(this))
-@@ -1348,6 +1434,12 @@
+@@ -1348,6 +1440,12 @@
       */
      public EnumStatus sleepInBedAt(int par1, int par2, int par3)
      {
@@ -244,7 +250,7 @@
          if (!this.worldObj.isRemote)
          {
              if (this.isPlayerSleeping() || !this.isEntityAlive())
-@@ -1387,6 +1479,11 @@
+@@ -1387,6 +1485,11 @@
          {
              int var9 = this.worldObj.getBlockMetadata(par1, par2, par3);
              int var5 = BlockBed.getDirection(var9);
@@ -256,7 +262,7 @@
              float var10 = 0.5F;
              float var7 = 0.5F;
  
-@@ -1457,10 +1554,12 @@
+@@ -1457,10 +1560,12 @@
          ChunkCoordinates var4 = this.playerLocation;
          ChunkCoordinates var5 = this.playerLocation;
  
@@ -273,7 +279,7 @@
  
              if (var5 == null)
              {
-@@ -1497,7 +1596,9 @@
+@@ -1497,7 +1602,9 @@
       */
      private boolean isInBed()
      {
@@ -284,7 +290,7 @@
      }
  
      /**
-@@ -1512,9 +1613,12 @@
+@@ -1512,9 +1619,12 @@
          var3.loadChunk(par1ChunkCoordinates.posX - 3 >> 4, par1ChunkCoordinates.posZ + 3 >> 4);
          var3.loadChunk(par1ChunkCoordinates.posX + 3 >> 4, par1ChunkCoordinates.posZ + 3 >> 4);
  
@@ -300,7 +306,7 @@
              return var8;
          }
          else
-@@ -1536,8 +1640,11 @@
+@@ -1536,8 +1646,11 @@
      {
          if (this.playerLocation != null)
          {
@@ -314,7 +320,7 @@
  
              switch (var2)
              {
-@@ -1846,7 +1953,7 @@
+@@ -1846,7 +1959,7 @@
          {
              if (par1ItemStack.getItem().requiresMultipleRenderPasses())
              {
@@ -323,7 +329,7 @@
              }
  
              if (this.itemInUse != null && par1ItemStack.itemID == Item.bow.itemID)
-@@ -1868,6 +1975,7 @@
+@@ -1868,6 +1981,7 @@
                      return 101;
                  }
              }
@@ -331,7 +337,7 @@
          }
  
          return var3;
-@@ -2088,6 +2196,14 @@
+@@ -2088,6 +2202,14 @@
          }
  
          this.theInventoryEnderChest = par1EntityPlayer.theInventoryEnderChest;

--- a/patches/minecraft/net/minecraft/item/Item.java.patch
+++ b/patches/minecraft/net/minecraft/item/Item.java.patch
@@ -57,7 +57,7 @@
          Vec3 var23 = var13.addVector((double)var18 * var21, (double)var17 * var21, (double)var20 * var21);
          return par1World.rayTraceBlocks_do_do(var13, var23, par3, !par3);
      }
-@@ -701,4 +716,304 @@
+@@ -701,4 +716,321 @@
      {
          StatList.initStats();
      }
@@ -103,9 +103,26 @@
 +     * @param metadata The items current metadata
 +     * @return The damage strength
 +     */
++    @Deprecated
 +    public float getStrVsBlock(ItemStack itemstack, Block block, int metadata)
 +    {
 +        return getStrVsBlock(itemstack, block);
++    }
++    
++    /**
++     * Location and Metadata-sensitive version of getStrVsBlock
++     * @param itemstack The Item Stack
++     * @param block The block the item is trying to break
++     * @param world The World
++     * @param x X Position
++     * @param y Y Position
++     * @param z Z Position
++     * @param metadata The items current metadata
++     * @return The damage strength
++     */
++    public float getStrVsBlock(ItemStack itemstack, Block block, World world, int x, int y, int z, int metadata)
++    {
++        return getStrVsBlock(itemstack, block, metadata);
 +    }
 +
 +    /**

--- a/patches/minecraft/net/minecraft/item/ItemTool.java.patch
+++ b/patches/minecraft/net/minecraft/item/ItemTool.java.patch
@@ -15,7 +15,7 @@
 +
 +    /** FORGE: Overridden to allow custom tool effectiveness */
 +    @Override
-+    public float getStrVsBlock(ItemStack stack, Block block, int meta) 
++    public float getStrVsBlock(ItemStack stack, Block block, World world, int x, int y, int z, int meta) 
 +    {
 +        if (ForgeHooks.isToolEffective(stack, block, meta))
 +        {


### PR DESCRIPTION
This patch add the support for Location/Meta Sensitive Item Strength vs
Block.
It adds the ability to give a different resistance based on TileEntity
data or environmental (ie. apply a bonus/malus based on world).
