### PR TITLE
Let IChunkProvider allow or disallow mod generation

### DIFF
--- a/patches/minecraft/net/minecraft/world/chunk/IChunkProvider.java.patch
+++ b/patches/minecraft/net/minecraft/world/chunk/IChunkProvider.java.patch
@@ -1,0 +1,12 @@
+--- ../src_base/minecraft/net/minecraft/world/chunk/IChunkProvider.java
++++ ../src_work/minecraft/net/minecraft/world/chunk/IChunkProvider.java
+@@ -64,4 +64,9 @@
+     int getLoadedChunkCount();
+ 
+     void recreateStructures(int var1, int var2);
++
++    /**
++     * Returns whether the IChunkProvider allows mods to generate there using the IWorldGenerator interface.
++     */
++    boolean allowModGeneration();
+ }

--- a/patches/minecraft/net/minecraft/world/gen/ChunkProviderEnd.java.patch
+++ b/patches/minecraft/net/minecraft/world/gen/ChunkProviderEnd.java.patch
@@ -67,3 +67,17 @@
          BlockSand.fallInstantly = false;
      }
  
+@@ -412,4 +438,13 @@
+     }
+ 
+     public void recreateStructures(int par1, int par2) {}
++
++    /**
++     * Returns whether the IChunkProvider allows mods to generate there using the IWorldGenerator interface.
++     */
++    @Override
++    public boolean allowModGeneration()
++    {
++        return true;
++    }
+ }

--- a/patches/minecraft/net/minecraft/world/gen/ChunkProviderFlat.java.patch
+++ b/patches/minecraft/net/minecraft/world/gen/ChunkProviderFlat.java.patch
@@ -1,0 +1,16 @@
+--- ../src_base/minecraft/net/minecraft/world/gen/ChunkProviderFlat.java
++++ ../src_work/minecraft/net/minecraft/world/gen/ChunkProviderFlat.java
+@@ -314,4 +314,13 @@
+             var4.generate(this, this.worldObj, par1, par2, (byte[])null);
+         }
+     }
++
++    /**
++     * Returns whether the IChunkProvider allows mods to generate there using the IWorldGenerator interface.
++     */
++    @Override
++    public boolean allowModGeneration()
++    {
++        return true;
++    }
+ }

--- a/patches/minecraft/net/minecraft/world/gen/ChunkProviderGenerate.java.patch
+++ b/patches/minecraft/net/minecraft/world/gen/ChunkProviderGenerate.java.patch
@@ -126,3 +126,17 @@
  
          BlockSand.fallInstantly = false;
      }
+@@ -628,4 +669,13 @@
+             this.scatteredFeatureGenerator.generate(this, this.worldObj, par1, par2, (byte[])null);
+         }
+     }
++
++    /**
++     * Returns whether the IChunkProvider allows mods to generate there using the IWorldGenerator interface.
++     */
++    @Override
++    public boolean allowModGeneration()
++    {
++        return true;
++    }
+ }

--- a/patches/minecraft/net/minecraft/world/gen/ChunkProviderHell.java.patch
+++ b/patches/minecraft/net/minecraft/world/gen/ChunkProviderHell.java.patch
@@ -144,3 +144,17 @@
          BlockSand.fallInstantly = false;
      }
  
+@@ -572,4 +613,13 @@
+     {
+         this.genNetherBridge.generate(this, this.worldObj, par1, par2, (byte[])null);
+     }
++
++    /**
++     * Returns whether the IChunkProvider allows mods to generate there using the IWorldGenerator interface.
++     */
++    @Override
++    public boolean allowModGeneration()
++    {
++        return true;
++    }
+ }

--- a/patches/minecraft/net/minecraft/world/gen/ChunkProviderServer.java.patch
+++ b/patches/minecraft/net/minecraft/world/gen/ChunkProviderServer.java.patch
@@ -32,7 +32,19 @@
  
              if (var5 == null)
              {
-@@ -306,6 +313,11 @@
+@@ -249,7 +256,10 @@
+             if (this.currentChunkProvider != null)
+             {
+                 this.currentChunkProvider.populate(par1IChunkProvider, par2, par3);
+-                GameRegistry.generateWorld(par2, par3, worldObj, currentChunkProvider, par1IChunkProvider);
++                if (this.currentChunkProvider.allowModGeneration())
++                {
++                    GameRegistry.generateWorld(par2, par3, worldObj, currentChunkProvider, par1IChunkProvider);
++                }
+                 var4.setChunkModified();
+             }
+         }
+@@ -306,6 +316,11 @@
      {
          if (!this.worldObj.canNotSave)
          {
@@ -44,7 +56,7 @@
              for (int var1 = 0; var1 < 100; ++var1)
              {
                  if (!this.chunksToUnload.isEmpty())
-@@ -318,6 +330,11 @@
+@@ -318,6 +333,11 @@
                      this.chunksToUnload.remove(var2);
                      this.loadedChunkHashMap.remove(var2.longValue());
                      this.loadedChunks.remove(var3);


### PR DESCRIPTION
Added functionality to allow an IChunkProvider to determine whether mods should be able to generate there using the IWorldGenerator system.

Mods that add new dimensions will be able to take advantage of this functionality to effectively block other mods from populating their structures, trees, ores, etc. in that dimension.

The current implementation can be a little troublesome, because not all dimension modders (myself included) want other mods' features in their new dimension. Some dimensions are obviously more suited to this, but having the option to block it is incredibly helpful. 
