### PR TITLE
Change access of upper and lower chest fields of InventoryLargeChest to public.

### DIFF
--- a/common/forge_at.cfg
+++ b/common/forge_at.cfg
@@ -126,3 +126,6 @@ public yc.o #FD:World/field_73018_p #prevThunderingStrength
 public ayp.b(Llq;)V #MD:WorldClient/func_72847_b #releaseEntitySkin
 #WorldServer
 public in.b(Llq;)V #MD:WorldServer/func_72847_b #releaseEntitySkin
+# InventoryLargeChest
+public kz.c #FD:InventoryLargeChest/field_70478_c #lowerChest
+public kz.b #FD:InventoryLargeChest/field_70477_b #upperChest


### PR DESCRIPTION
Overriding equals and possibly hashcode to compare the two internal fields is a solution that would also suffice, however this is less intrusive.
