### PR TITLE
Unregister WorldProvider

### DIFF
--- a/common/net/minecraftforge/common/DimensionManager.java
+++ b/common/net/minecraftforge/common/DimensionManager.java
@@ -100,6 +100,18 @@ public class DimensionManager
         }
         dimensions.remove(id);
     }
+    
+    /**
+     * For unregistering a provider if the provider for a dimension needs to be overwritten
+     */
+    public static void unregisterProvider(int id)
+    {
+        if (!providers.containsKey(id))
+        {
+            throw new IllegalArgumentException(String.format("Failed to unregister provider for id %d; No provider registered", id));
+        }
+        providers.remove(id);
+    }
 
     public static int getProviderType(int dim)
     {


### PR DESCRIPTION
Added a method to dimension manager to allow a provider to be unregistered from DimensionManager so that the provider for a dimension can be overwritten. 

A recent bug fix in DimensionManager made it so that I can no longer overwrite the vanilla world provider for TFC. This should allow for a clean removal of the provider.
