### PR TITLE
TileEntityChestRenderer bugfix patch

### DIFF
--- a/patches/minecraft/net/minecraft/client/renderer/tileentity/TileEntityChestRenderer.java.patch
+++ b/patches/minecraft/net/minecraft/client/renderer/tileentity/TileEntityChestRenderer.java.patch
@@ -1,0 +1,15 @@
+--- ../src_base/minecraft/net/minecraft/client/renderer/tileentity/TileEntityChestRenderer.java
++++ ../src_work/minecraft/net/minecraft/client/renderer/tileentity/TileEntityChestRenderer.java
+@@ -50,7 +50,11 @@
+ 
+             if (var10 != null && var9 == 0)
+             {
+-                ((BlockChest)var10).unifyAdjacentChests(par1TileEntityChest.getWorldObj(), par1TileEntityChest.xCoord, par1TileEntityChest.yCoord, par1TileEntityChest.zCoord);
++                try
++                {
++                    ((BlockChest)var10).unifyAdjacentChests(par1TileEntityChest.getWorldObj(), par1TileEntityChest.xCoord, par1TileEntityChest.yCoord, par1TileEntityChest.zCoord);
++                }
++                catch (ClassCastException e) {}
+                 var9 = par1TileEntityChest.getBlockMetadata();
+             }
+ 


### PR DESCRIPTION
Fixed an unchecked cast to BlockChest that could sometimes cause a crash.

I kept experiencing this crash during generating structures in my mod, so I submitted this patch to fix it.

I believe the crash is caused by the renderer trying to render a chest when the world has not yet updated the blocks, and it attempts to cast an unrelated block (which should be a chest, but has not updated yet) to BlockChest.
