### PR TITLE
Change WorldServer.allPlayersSleeping to public, and remove the SideOnly annotation on EntityPlayer.getSleepTimer()

### DIFF
--- a/common/forge_at.cfg
+++ b/common/forge_at.cfg
@@ -126,3 +126,4 @@ public yc.o #FD:World/field_73018_p #prevThunderingStrength
 public ayp.b(Llq;)V #MD:WorldClient/func_72847_b #releaseEntitySkin
 #WorldServer
 public in.b(Llq;)V #MD:WorldServer/func_72847_b #releaseEntitySkin
+public in.N #FD:WorldServer/field_73068_P #allPlayersSleeping

--- a/patches/minecraft/net/minecraft/entity/player/EntityPlayer.java.patch
+++ b/patches/minecraft/net/minecraft/entity/player/EntityPlayer.java.patch
@@ -314,7 +314,15 @@
  
              switch (var2)
              {
-@@ -1846,7 +1953,7 @@
+@@ -1571,7 +1678,6 @@
+         return this.sleeping && this.sleepTimer >= 100;
+     }
+ 
+-    @SideOnly(Side.CLIENT)
+     public int getSleepTimer()
+     {
+         return this.sleepTimer;
+@@ -1846,7 +1952,7 @@
          {
              if (par1ItemStack.getItem().requiresMultipleRenderPasses())
              {
@@ -323,7 +331,7 @@
              }
  
              if (this.itemInUse != null && par1ItemStack.itemID == Item.bow.itemID)
-@@ -1868,6 +1975,7 @@
+@@ -1868,6 +1974,7 @@
                      return 101;
                  }
              }
@@ -331,7 +339,7 @@
          }
  
          return var3;
-@@ -2088,6 +2196,14 @@
+@@ -2088,6 +2195,14 @@
          }
  
          this.theInventoryEnderChest = par1EntityPlayer.theInventoryEnderChest;


### PR DESCRIPTION
In my new dimensions which allow player respawning, sleeping in beds doesn't fast forward time to day; it just sets the spawn point and kicks the player out of bed. This is to do with the way 'setting time' is handled in non-Overworld worlds.

I've fixed this in my mod, but it requires me to use reflection to gain access to a private field, and using reflection every world tick is very costly indeed. If the field were public, it would be immensely helpful.

Edit: The client-only annotation on EntityPlayer.getSleepTimer() is also a major stumbling block, since this makes it impossible to get the player's sleep timer on the server side without using reflection.
