### PR TITLE
Extend forge's recipe classes

### DIFF
--- a/common/net/minecraftforge/crafting/ForgeRecipeUtils.java
+++ b/common/net/minecraftforge/crafting/ForgeRecipeUtils.java
@@ -1,0 +1,90 @@
+package net.minecraftforge.crafting;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import net.minecraft.item.ItemStack;
+
+public class ForgeRecipeUtils {
+
+    public static boolean itemMatches(ItemStack target, ItemStack input)
+    {
+        return itemMatches(target, input, false);
+    }
+
+    public static boolean itemMatches(ItemStack target, ItemStack input, boolean strict)
+    {
+        if (input == null && target != null || input != null && target == null)
+        {
+            return false;
+        }
+        return target.itemID == input.itemID && (target.getItemDamage() == -1 && !strict || target.getItemDamage() == input.getItemDamage());
+    }
+
+    public static boolean itemMatches(ArrayList targets, ItemStack input)
+    {
+        return itemMatches(targets, input, false);
+    }
+
+    public static boolean itemMatches(ArrayList targets, ItemStack input, boolean strict)
+    {
+        if (input == null && targets != null && targets.size() > 0 || input != null && (targets == null || targets.size() == 0))
+        {
+            return false;
+        }
+        if (input == null && (targets == null || targets.size() == 0))
+        {
+            return true;
+        }
+        for (Object target : targets)
+        {
+            if (target instanceof ItemStack && itemMatches((ItemStack)target, input, strict))
+            {
+                return true;
+            }
+            else if(target instanceof ICraftingMaterial && ((ICraftingMaterial)target).itemMatches(input))
+            {
+                return true;
+            }
+        }
+        return false;
+    }
+    
+    public static ArrayList<ItemStack> expandArray(ArrayList items)
+    {
+        Map<List, ItemStack> tmp = new HashMap<List, ItemStack>();
+        for(Object item : items)
+        {
+            if(item instanceof ItemStack)
+            {
+                tmp.put(Arrays.asList(((ItemStack)item).itemID, ((ItemStack)item).getItemDamage()), ((ItemStack)item).copy());
+            }
+            else if(item instanceof ICraftingMaterial)
+            {
+                for(ItemStack subitem : ((ICraftingMaterial)item).getItems())
+                {
+                    tmp.put(Arrays.asList(subitem.itemID, subitem.getItemDamage()), subitem);
+                }
+            }
+        }
+        
+        return new ArrayList<ItemStack>(tmp.values());
+    }
+    
+    public static boolean isValidItemList(Collection items)
+    {
+        for(Object item : items)
+        {
+            if(!(item instanceof ItemStack || item instanceof ICraftingMaterial))
+            {
+                return false;
+            }
+        }
+        
+        return true;
+    }
+}

--- a/common/net/minecraftforge/crafting/ICraftingMaterial.java
+++ b/common/net/minecraftforge/crafting/ICraftingMaterial.java
@@ -1,0 +1,24 @@
+package net.minecraftforge.crafting;
+
+import java.util.ArrayList;
+
+import net.minecraft.item.ItemStack;
+
+public interface ICraftingMaterial {
+
+    /**
+     * Checks whether the argument ItemStack matches this instance.
+     * 
+     * @param other
+     *            ItemStack to compare.
+     * @return Returns true if the argument is one of the items that this instance represents.
+     */
+    boolean itemMatches(ItemStack other);
+
+    /**
+     * Makes a list of ItemStacks that this instance represents.
+     * 
+     * @return
+     */
+    ArrayList<ItemStack> getItems();
+}

--- a/common/net/minecraftforge/crafting/IRecipeExtractable.java
+++ b/common/net/minecraftforge/crafting/IRecipeExtractable.java
@@ -1,0 +1,27 @@
+package net.minecraftforge.crafting;
+
+import java.util.ArrayList;
+
+import net.minecraft.item.crafting.IRecipe;
+
+public interface IRecipeExtractable extends IRecipe{
+
+    /**
+     * Gets the copy of the raw input and output. The output items should be
+     * assigned into the last element.
+     * 
+     * @return Raw recipe.
+     * 
+     */
+    public Object[] getRawRecipe();
+
+    /**
+     * Gets a list of recipes which this instance can process. All elements of
+     * recipe should be instances of ItemStack or ArrayList&lt;ItemStack&gt;. The
+     * length of each recipe should be getRecipeSize() + 1, and the output item
+     * should be assigned into the last element.
+     * 
+     * @return The list of possible recipes.
+     */
+    public ArrayList<Object[]> getPossibleRecipes();
+}

--- a/common/net/minecraftforge/crafting/ShapedForgeRecipe.java
+++ b/common/net/minecraftforge/crafting/ShapedForgeRecipe.java
@@ -1,0 +1,360 @@
+package net.minecraftforge.crafting;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Map.Entry;
+
+import net.minecraft.block.Block;
+import net.minecraft.inventory.InventoryCrafting;
+import net.minecraft.item.Item;
+import net.minecraft.item.ItemStack;
+import net.minecraft.item.crafting.ShapedRecipes;
+import net.minecraft.world.World;
+import net.minecraftforge.crafting.tags.ItemFilledContainer;
+import net.minecraftforge.liquids.LiquidStack;
+
+public class ShapedForgeRecipe implements IRecipeExtractable {
+    // Added in for future ease of change, but hard coded for now.
+    private static final int MAX_CRAFT_GRID_WIDTH = 3;
+    private static final int MAX_CRAFT_GRID_HEIGHT = 3;
+
+    private ItemStack output = null;
+    private Object[] input = null;
+    private int width = 0;
+    private int height = 0;
+    private boolean mirrored = true;
+
+    public ShapedForgeRecipe(Block result, Object... recipe)
+    {
+        this(new ItemStack(result), recipe);
+    }
+
+    public ShapedForgeRecipe(Item result, Object... recipe)
+    {
+        this(new ItemStack(result), recipe);
+    }
+
+    public ShapedForgeRecipe(ItemStack result, Object... recipe)
+    {
+        output = result.copy();
+
+        String shape = "";
+        int idx = 0;
+
+        if (recipe[idx] instanceof Boolean)
+        {
+            mirrored = (Boolean) recipe[idx];
+            if (recipe[idx + 1] instanceof Object[])
+            {
+                recipe = (Object[]) recipe[idx + 1];
+            }
+            else
+            {
+                idx = 1;
+            }
+        }
+
+        if (recipe[idx] instanceof String[])
+        {
+            String[] parts = (String[]) recipe[idx++];
+
+            for (String s : parts)
+            {
+                width = s.length();
+                shape += s;
+            }
+
+            height = parts.length;
+        }
+        else
+        {
+            while (recipe[idx] instanceof String)
+            {
+                String s = (String) recipe[idx++];
+                shape += s;
+                width = s.length();
+                height++;
+            }
+        }
+
+        if (width * height != shape.length())
+        {
+            String ret = "Invalid shaped forge recipe: ";
+            for (Object tmp : recipe)
+            {
+                ret += tmp + ", ";
+            }
+            ret += output;
+            throw new RuntimeException(ret);
+        }
+
+        HashMap<Character, Object> itemMap = new HashMap<Character, Object>();
+
+        for (; idx < recipe.length; idx += 2)
+        {
+            Character chr = (Character) recipe[idx];
+            Object in = recipe[idx + 1];
+
+            if (in instanceof ItemStack)
+            {
+                itemMap.put(chr, ((ItemStack) in).copy());
+            }
+            else if (in instanceof Item)
+            {
+                itemMap.put(chr, new ItemStack((Item) in));
+            }
+            else if (in instanceof Block)
+            {
+                itemMap.put(chr, new ItemStack((Block) in, 1, -1));
+            }
+            else if (in instanceof LiquidStack)
+            {
+                itemMap.put(chr, new ItemFilledContainer((LiquidStack) in));
+            }
+            else if (in instanceof Collection && ForgeRecipeUtils.isValidItemList((Collection)in))
+            {
+                itemMap.put(chr, new ArrayList((Collection) in));
+            }
+            else if (in instanceof ICraftingMaterial)
+            {
+                itemMap.put(chr, in);
+            }
+            else
+            {
+                String ret = "Invalid shaped filling recipe: ";
+                for (Object tmp : recipe)
+                {
+                    ret += tmp + ", ";
+                }
+                ret += output;
+                throw new RuntimeException(ret);
+            }
+        }
+
+        input = new Object[width * height];
+        int x = 0;
+        for (char chr : shape.toCharArray())
+        {
+            input[x++] = itemMap.get(chr);
+        }
+    }
+
+    protected ShapedForgeRecipe(ShapedRecipes recipe, Map<ItemStack, Object> replacements)
+    {
+        output = recipe.getRecipeOutput();
+        width = recipe.recipeWidth;
+        height = recipe.recipeHeight;
+
+        input = new Object[recipe.recipeItems.length];
+
+        for (int i = 0; i < input.length; i++)
+        {
+            ItemStack ingred = recipe.recipeItems[i];
+
+            if (ingred == null)
+            {
+                continue;
+            }
+
+            input[i] = recipe.recipeItems[i];
+
+            for (Entry<ItemStack, Object> replace : replacements.entrySet())
+            {
+                if (ForgeRecipeUtils.itemMatches(replace.getKey(), ingred, true))
+                {
+                    Object value = replace.getValue();
+                    if (value instanceof ICraftingMaterial)
+                    {
+                        input[i] = value;
+                    }
+                    else if (value instanceof Collection && ForgeRecipeUtils.isValidItemList((Collection)value))
+                    {
+                        input[i] = new ArrayList((Collection) value);
+                    }
+                    else if (value instanceof LiquidStack)
+                    {
+                        input[i] = new ItemFilledContainer((LiquidStack) value);
+                    }
+                    break;
+                }
+            }
+        }
+    }
+
+    @Override
+    public ItemStack getCraftingResult(InventoryCrafting var1)
+    {
+        return output.copy();
+    }
+
+    @Override
+    public int getRecipeSize()
+    {
+        return input.length;
+    }
+
+    @Override
+    public ItemStack getRecipeOutput()
+    {
+        return output;
+    }
+
+    @Override
+    public boolean matches(InventoryCrafting inv, World world)
+    {
+        for (int x = 0; x <= MAX_CRAFT_GRID_WIDTH - width; x++)
+        {
+            for (int y = 0; y <= MAX_CRAFT_GRID_HEIGHT - height; ++y)
+            {
+                if (checkMatch(inv, x, y, true))
+                {
+                    return true;
+                }
+
+                if (mirrored && checkMatch(inv, x, y, false))
+                {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+
+    private boolean checkMatch(InventoryCrafting inv, int startX, int startY, boolean mirror)
+    {
+        for (int x = 0; x < MAX_CRAFT_GRID_WIDTH; x++)
+        {
+            for (int y = 0; y < MAX_CRAFT_GRID_HEIGHT; y++)
+            {
+                int subX = x - startX;
+                int subY = y - startY;
+                Object target = null;
+
+                if (subX >= 0 && subY >= 0 && subX < width && subY < height)
+                {
+                    if (mirror)
+                    {
+                        target = input[width - subX - 1 + subY * width];
+                    }
+                    else
+                    {
+                        target = input[subX + subY * width];
+                    }
+                }
+
+                ItemStack slot = inv.getStackInRowAndColumn(x, y);
+
+                if (target instanceof ItemStack)
+                {
+                    if (!ForgeRecipeUtils.itemMatches((ItemStack) target, slot))
+                    {
+                        return false;
+                    }
+                }
+                else if (target instanceof ArrayList)
+                {
+
+                    if (!ForgeRecipeUtils.itemMatches((ArrayList) target, slot))
+                    {
+                        return false;
+                    }
+                }
+                else if (target instanceof ICraftingMaterial)
+                {
+
+                    if (!((ICraftingMaterial) target).itemMatches(slot))
+                    {
+                        return false;
+                    }
+                }
+                else if (target == null && slot != null)
+                {
+                    return false;
+                }
+            }
+        }
+
+        return true;
+    }
+
+    public ShapedForgeRecipe setMirrored(boolean mirror)
+    {
+        mirrored = mirror;
+        return this;
+    }
+
+    @Override
+    public Object[] getRawRecipe()
+    {
+        Object[] recipe = null;
+        if (input != null)
+        {
+            recipe = new Object[getRecipeSize() + 1];
+            for (int i = 0; i < getRecipeSize(); ++i)
+            {
+                if (input[i] instanceof ItemStack)
+                {
+                    recipe[i] = ((ItemStack) input[i]).copy();
+                }
+                else if (input[i] instanceof ArrayList)
+                {
+                    ArrayList items = new ArrayList();
+                    for (Object item : (ArrayList) input[i])
+                    {
+                        if(item instanceof ItemStack)
+                        {
+                            items.add(((ItemStack)item).copy());
+                        }
+                        else
+                        {
+                            items.add(item);
+                        }
+                    }
+                    recipe[i] = items;
+                }
+                else
+                {
+                    recipe[i] = input[i];
+                }
+            }
+            recipe[recipe.length - 1] = output.copy();
+        }
+        return recipe;
+    }
+
+    @Override
+    public ArrayList<Object[]> getPossibleRecipes()
+    {
+        ArrayList<Object[]> result = new ArrayList<Object[]>();
+        Object[] recipe = null;
+        if (input != null && output != null)
+        {
+            recipe = new Object[getRecipeSize() + 1];
+            for (int i = 0; i < getRecipeSize(); ++i)
+            {
+                if (input[i] instanceof ItemStack)
+                {
+                    recipe[i] = ((ItemStack) input[i]).copy();
+                }
+                else if (input[i] instanceof ArrayList)
+                {
+                    recipe[i] = ForgeRecipeUtils.expandArray((ArrayList)input[i]);
+                }
+                else if (input[i] instanceof ICraftingMaterial)
+                {
+                    recipe[i] = ((ICraftingMaterial) input[i]).getItems();
+                }
+            }
+            recipe[recipe.length - 1] = output.copy();
+        }
+
+        if (recipe != null)
+        {
+            result.add(recipe);
+        }
+        return result;
+    }
+}

--- a/common/net/minecraftforge/crafting/ShapedLiquidFillingRecipe.java
+++ b/common/net/minecraftforge/crafting/ShapedLiquidFillingRecipe.java
@@ -1,0 +1,461 @@
+package net.minecraftforge.crafting;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Map.Entry;
+
+import net.minecraft.block.Block;
+import net.minecraft.inventory.InventoryCrafting;
+import net.minecraft.item.Item;
+import net.minecraft.item.ItemStack;
+import net.minecraft.item.crafting.ShapedRecipes;
+import net.minecraft.world.World;
+import net.minecraftforge.crafting.tags.ItemEmptyContainer;
+import net.minecraftforge.crafting.tags.ItemFilledContainer;
+import net.minecraftforge.liquids.LiquidContainerData;
+import net.minecraftforge.liquids.LiquidContainerRegistry;
+import net.minecraftforge.liquids.LiquidStack;
+
+public class ShapedLiquidFillingRecipe implements IRecipeExtractable {
+    // Added in for future ease of change, but hard coded for now.
+    private static final int MAX_CRAFT_GRID_WIDTH = 3;
+    private static final int MAX_CRAFT_GRID_HEIGHT = 3;
+
+    private LiquidStack output = null;
+    private Object[] input = null;
+    private int width = 0;
+    private int height = 0;
+    private boolean mirrored = true;
+    
+    // If this member is true, matching fails when there are same items in the input matrix and output result.
+    private boolean excludeSame = true;
+
+    public ShapedLiquidFillingRecipe(LiquidStack result, Object... recipe)
+    {
+        output = result.copy();
+
+        String shape = "";
+        int idx = 0;
+
+        if (recipe[idx] instanceof Boolean)
+        {
+            mirrored = (Boolean) recipe[idx];
+            if (recipe[idx + 1] instanceof Object[])
+            {
+                recipe = (Object[]) recipe[idx + 1];
+            }
+            else
+            {
+                idx = 1;
+            }
+        }
+
+        if (recipe[idx] instanceof String[])
+        {
+            String[] parts = (String[]) recipe[idx++];
+
+            for (String s : parts)
+            {
+                width = s.length();
+                shape += s;
+            }
+
+            height = parts.length;
+        }
+        else
+        {
+            while (recipe[idx] instanceof String)
+            {
+                String s = (String) recipe[idx++];
+                shape += s;
+                width = s.length();
+                height++;
+            }
+        }
+
+        if (width * height != shape.length())
+        {
+            String ret = "Invalid shaped filling recipe: ";
+            for (Object tmp : recipe)
+            {
+                ret += tmp + ", ";
+            }
+            ret += output;
+            throw new RuntimeException(ret);
+        }
+
+        HashMap<Character, Object> itemMap = new HashMap<Character, Object>();
+
+        for (; idx < recipe.length; idx += 2)
+        {
+            Character chr = (Character) recipe[idx];
+            Object in = recipe[idx + 1];
+
+            if (in instanceof ItemStack)
+            {
+                itemMap.put(chr, ((ItemStack) in).copy());
+            }
+            else if (in instanceof Item)
+            {
+                itemMap.put(chr, new ItemStack((Item) in));
+            }
+            else if (in instanceof Block)
+            {
+                itemMap.put(chr, new ItemStack((Block) in, 1, -1));
+            }
+            else if (in instanceof LiquidStack)
+            {
+                itemMap.put(chr, new ItemFilledContainer((LiquidStack) in));
+            }
+            else if (in instanceof Collection && ForgeRecipeUtils.isValidItemList((Collection)in))
+            {
+                itemMap.put(chr, new ArrayList((Collection) in));
+            }
+            else if (in instanceof ItemEmptyContainer || in instanceof ICraftingMaterial)
+            {
+                itemMap.put(chr, in);
+            }
+            else
+            {
+                String ret = "Invalid shaped filling recipe: ";
+                for (Object tmp : recipe)
+                {
+                    ret += tmp + ", ";
+                }
+                ret += output;
+                throw new RuntimeException(ret);
+            }
+        }
+
+        input = new Object[width * height];
+        int x = 0;
+        for (char chr : shape.toCharArray())
+        {
+            input[x++] = itemMap.get(chr);
+        }
+    }
+
+    protected ShapedLiquidFillingRecipe(ShapedRecipes recipe, Map<ItemStack, Object> replacements)
+    {
+        output = LiquidContainerRegistry.getLiquidForFilledItem(recipe.getRecipeOutput());
+        width = recipe.recipeWidth;
+        height = recipe.recipeHeight;
+
+        input = new Object[recipe.recipeItems.length];
+
+        for (int i = 0; i < input.length; i++)
+        {
+            ItemStack ingred = recipe.recipeItems[i];
+
+            if (ingred == null)
+            {
+                continue;
+            }
+
+            input[i] = recipe.recipeItems[i];
+
+            for (Entry<ItemStack, Object> replace : replacements.entrySet())
+            {
+                if (ForgeRecipeUtils.itemMatches(replace.getKey(), ingred, true))
+                {
+                    Object value = replace.getValue();
+                    if (value instanceof ItemEmptyContainer
+                            || value instanceof ICraftingMaterial)
+                    {
+                        input[i] = value;
+                    }
+                    else if (value instanceof Collection && ForgeRecipeUtils.isValidItemList((Collection)value))
+                    {
+                        input[i] = new ArrayList((Collection) value);
+                    }
+                    else if (value instanceof LiquidStack)
+                    {
+                        input[i] = new ItemFilledContainer((LiquidStack) value);
+                    }
+                    break;
+                }
+            }
+        }
+    }
+
+    @Override
+    public boolean matches(InventoryCrafting var1, World var2)
+    {
+        return getCraftingResult(var1) != null;
+    }
+
+    @Override
+    public ItemStack getCraftingResult(InventoryCrafting var1)
+    {
+        for (int x = 0; x <= MAX_CRAFT_GRID_WIDTH - width; x++)
+        {
+            for (int y = 0; y <= MAX_CRAFT_GRID_HEIGHT - height; ++y)
+            {
+                ItemStack result = checkResult(var1, x, y, true);
+                if (result != null)
+                {
+                    return result;
+                }
+
+                if (mirrored)
+                {
+                    result = checkResult(var1, x, y, false);
+                    if (result != null)
+                    {
+                        return result;
+                    }
+                }
+            }
+        }
+
+        return null;
+    }
+
+    private ItemStack checkResult(InventoryCrafting inv, int startX, int startY, boolean mirror)
+    {
+        ItemStack result = null;
+        ArrayList<ItemStack> foundMaterials = new ArrayList<ItemStack>();
+        for (int x = 0; x < MAX_CRAFT_GRID_WIDTH; x++)
+        {
+            for (int y = 0; y < MAX_CRAFT_GRID_HEIGHT; y++)
+            {
+                int subX = x - startX;
+                int subY = y - startY;
+                Object target = null;
+
+                if (subX >= 0 && subY >= 0 && subX < width && subY < height)
+                {
+                    if (mirror)
+                    {
+                        target = input[width - subX - 1 + subY * width];
+                    }
+                    else
+                    {
+                        target = input[subX + subY * width];
+                    }
+                }
+
+                ItemStack slot = inv.getStackInRowAndColumn(x, y);
+                boolean isMaterial = slot != null;
+
+                if (target instanceof ItemStack)
+                {
+                    if (!ForgeRecipeUtils.itemMatches((ItemStack) target, slot))
+                    {
+                        return null;
+                    }
+                }
+                else if (target instanceof ArrayList)
+                {
+
+                    if (!ForgeRecipeUtils.itemMatches((ArrayList) target, slot))
+                    {
+                        return null;
+                    }
+                }
+                else if (target instanceof ICraftingMaterial)
+                {
+
+                    if (!((ICraftingMaterial) target).itemMatches(slot))
+                    {
+                        return null;
+                    }
+                }
+                else if (target instanceof ItemEmptyContainer)
+                {
+                    ItemStack filled = ((ItemEmptyContainer) target).getFilledContainer(output, slot);
+                    if (filled == null)
+                    {
+                        return null;
+                    }
+                    else if (result == null)
+                    {
+                        result = filled;
+                    }
+                    else if (result.isItemEqual(filled) && result.stackSize < result.getMaxStackSize())
+                    {
+                        ++result.stackSize;
+                    }
+                    else
+                    {
+                        return null;
+                    }
+                    isMaterial = false;
+                }
+                else if (target == null && slot != null)
+                {
+                    return null;
+                }
+
+                if (isMaterial)
+                {
+                    foundMaterials.add(slot);
+                }
+            }
+        }
+
+        if (result != null && excludeSame)
+        {
+            for (ItemStack material : foundMaterials)
+            {
+                if (material.isItemEqual(result))
+                {
+                    return null;
+                }
+            }
+        }
+        return result;
+    }
+
+    @Override
+    public int getRecipeSize()
+    {
+        return width * height;
+    }
+
+    @Override
+    public ItemStack getRecipeOutput()
+    {
+        return null;
+    }
+
+    @Override
+    public Object[] getRawRecipe()
+    {
+        Object[] recipe = null;
+        if (input != null)
+        {
+            recipe = new Object[getRecipeSize() + 1];
+            for (int i = 0; i < getRecipeSize(); ++i)
+            {
+                if (input[i] instanceof ItemStack)
+                {
+                    recipe[i] = ((ItemStack) input[i]).copy();
+                }
+                else if (input[i] instanceof ArrayList)
+                {
+                    ArrayList items = new ArrayList();
+                    for (Object item : (ArrayList) input[i])
+                    {
+                        if(item instanceof ItemStack)
+                        {
+                            items.add(((ItemStack)item).copy());
+                        }
+                        else
+                        {
+                            items.add(item);
+                        }
+                    }
+                    recipe[i] = items;
+                }
+                else
+                {
+                    recipe[i] = input[i];
+                }
+            }
+            recipe[recipe.length - 1] = output.copy();
+        }
+        return recipe;
+    }
+
+    @Override
+    public ArrayList<Object[]> getPossibleRecipes()
+    {
+        ArrayList<Object[]> result = new ArrayList<Object[]>();
+        if (input == null || output == null)
+        {
+            return result;
+        }
+
+        ItemEmptyContainer container = null;
+        int stackSize = 0;
+        for (Object in : input)
+        {
+            if (in instanceof ItemEmptyContainer)
+            {
+                container = (ItemEmptyContainer) in;
+                ++stackSize;
+            }
+        }
+        if (stackSize == 0)
+        {
+            return result;
+        }
+
+        calcresult: for (LiquidContainerData data : container.getLiquidContainerData(output))
+        {
+            Object[] recipe = new Object[getRecipeSize() + 1];
+            ItemStack output = data.filled.copy();
+            if (output.getMaxStackSize() >= stackSize)
+            {
+                output.stackSize = stackSize;
+            }
+            else
+            {
+                continue;
+            }
+
+            for (int i = 0; i < getRecipeSize(); ++i)
+            {
+                if (input[i] instanceof ItemStack)
+                {
+                    recipe[i] = ((ItemStack) input[i]).copy();
+                }
+                else if (input[i] instanceof ArrayList)
+                {
+                    ArrayList<ItemStack> acceptable = new ArrayList<ItemStack>();
+                    for (ItemStack item : ForgeRecipeUtils.expandArray((ArrayList)input[i]))
+                    {
+                        if (!excludeSame || !item.isItemEqual(output))
+                        {
+                            acceptable.add(item);
+                        }
+                    }
+                    if (acceptable.size() == 0)
+                    {
+                        continue calcresult;
+                    }
+                    recipe[i] = acceptable;
+                }
+                else if (input[i] instanceof ICraftingMaterial)
+                {
+                    ArrayList<ItemStack> acceptable = new ArrayList<ItemStack>();
+                    for (ItemStack item : ((ICraftingMaterial) input[i]).getItems())
+                    {
+                        if (!excludeSame || !item.isItemEqual(output))
+                        {
+                            acceptable.add(item);
+                        }
+                    }
+                    if (acceptable.size() == 0)
+                    {
+                        continue calcresult;
+                    }
+                    recipe[i] = acceptable;
+                }
+                else if (input[i] instanceof ItemEmptyContainer)
+                {
+                    recipe[i] = data.container.copy();
+                }
+            }
+            recipe[recipe.length - 1] = output;
+            result.add(recipe);
+        }
+        return result;
+    }
+
+    public ShapedLiquidFillingRecipe setMirrored(boolean mirror)
+    {
+        mirrored = mirror;
+        return this;
+    }
+
+    public ShapedLiquidFillingRecipe setExcludeSame(boolean exclude)
+    {
+        excludeSame = exclude;
+        return this;
+    }
+
+}

--- a/common/net/minecraftforge/crafting/ShapelessForgeRecipe.java
+++ b/common/net/minecraftforge/crafting/ShapelessForgeRecipe.java
@@ -1,0 +1,250 @@
+package net.minecraftforge.crafting;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+
+import net.minecraft.block.Block;
+import net.minecraft.inventory.InventoryCrafting;
+import net.minecraft.item.Item;
+import net.minecraft.item.ItemStack;
+import net.minecraft.item.crafting.ShapelessRecipes;
+import net.minecraft.world.World;
+import net.minecraftforge.crafting.tags.ItemFilledContainer;
+import net.minecraftforge.liquids.LiquidStack;
+
+public class ShapelessForgeRecipe implements IRecipeExtractable {
+
+    private ItemStack output = null;
+    private ArrayList input = new ArrayList();
+
+    public ShapelessForgeRecipe(Block result, Object... recipe)
+    {
+        this(new ItemStack(result), recipe);
+    }
+
+    public ShapelessForgeRecipe(Item result, Object... recipe)
+    {
+        this(new ItemStack(result), recipe);
+    }
+
+    public ShapelessForgeRecipe(ItemStack result, Object... recipe)
+    {
+        output = result.copy();
+        for (Object in : recipe)
+        {
+            if (in instanceof ItemStack)
+            {
+                input.add(((ItemStack) in).copy());
+            }
+            else if (in instanceof Item)
+            {
+                input.add(new ItemStack((Item) in));
+            }
+            else if (in instanceof Block)
+            {
+                input.add(new ItemStack((Block) in));
+            }
+            else if (in instanceof LiquidStack)
+            {
+                input.add(new ItemFilledContainer((LiquidStack) in));
+            }
+            else if (in instanceof Collection && ForgeRecipeUtils.isValidItemList((Collection)in))
+            {
+                input.add(new ArrayList((Collection) in));
+            }
+            else if (in instanceof ICraftingMaterial)
+            {
+                input.add(in);
+            }
+            else
+            {
+                String ret = "Invalid shapeless forge recipe: ";
+                for (Object tmp : recipe)
+                {
+                    ret += tmp + ", ";
+                }
+                ret += output;
+                throw new RuntimeException(ret);
+            }
+        }
+    }
+
+    protected ShapelessForgeRecipe(ShapelessRecipes recipe, Map<ItemStack, Object> replacements)
+    {
+        output = recipe.getRecipeOutput();
+
+        for (ItemStack ingred : (List<ItemStack>) recipe.recipeItems)
+        {
+            Object finalObj = ingred;
+            for (Entry<ItemStack, Object> replace : replacements.entrySet())
+            {
+                if (ForgeRecipeUtils.itemMatches(replace.getKey(), ingred, true))
+                {
+                    Object value = replace.getValue();
+                    if (value instanceof ICraftingMaterial)
+                    {
+                        finalObj = value;
+                    }
+                    else if (value instanceof Collection && ForgeRecipeUtils.isValidItemList((Collection)value))
+                    {
+                        finalObj = new ArrayList((Collection) value);
+                    }
+                    else if (value instanceof LiquidStack)
+                    {
+                        finalObj = new ItemFilledContainer((LiquidStack) value);
+                    }
+                    break;
+                }
+            }
+            input.add(finalObj);
+        }
+    }
+
+    @Override
+    public boolean matches(InventoryCrafting var1, World var2)
+    {
+        ArrayList required = new ArrayList(input);
+
+        for (int x = 0; x < var1.getSizeInventory(); x++)
+        {
+            ItemStack slot = var1.getStackInSlot(x);
+
+            if (slot != null)
+            {
+                boolean inRecipe = false;
+                Iterator req = required.iterator();
+
+                while (req.hasNext())
+                {
+                    boolean match = false;
+
+                    Object next = req.next();
+
+                    if (next instanceof ItemStack)
+                    {
+                        match = ForgeRecipeUtils.itemMatches((ItemStack) next, slot);
+                    }
+                    else if (next instanceof ArrayList)
+                    {
+                        match = ForgeRecipeUtils.itemMatches((ArrayList) next, slot);
+                    }
+                    else if (next instanceof ICraftingMaterial)
+                    {
+
+                        match = ((ICraftingMaterial) next).itemMatches(slot);
+                    }
+
+                    if (match)
+                    {
+                        inRecipe = true;
+                        required.remove(next);
+                        break;
+                    }
+                }
+
+                if (!inRecipe)
+                {
+                    return false;
+                }
+            }
+        }
+
+        return required.isEmpty();
+    }
+
+    @Override
+    public ItemStack getCraftingResult(InventoryCrafting var1)
+    {
+        return output.copy();
+    }
+
+    @Override
+    public int getRecipeSize()
+    {
+        return input.size();
+    }
+
+    @Override
+    public ItemStack getRecipeOutput()
+    {
+        return output;
+    }
+
+    @Override
+    public Object[] getRawRecipe()
+    {
+        Object[] recipe = null;
+        if (input != null)
+        {
+            recipe = new Object[getRecipeSize() + 1];
+            for (int i = 0; i < getRecipeSize(); ++i)
+            {
+                Object in = input.get(i);
+                if (in instanceof ItemStack)
+                {
+                    recipe[i] = ((ItemStack) in).copy();
+                }
+                else if (in instanceof ArrayList)
+                {
+                    ArrayList items = new ArrayList();
+                    for (Object item : (ArrayList) in)
+                    {
+                        if(item instanceof ItemStack)
+                        {
+                            items.add(((ItemStack)item).copy());
+                        }
+                        else
+                        {
+                            items.add(item);
+                        }
+                    }
+                    recipe[i] = items;
+                }
+                else
+                {
+                    recipe[i] = in;
+                }
+            }
+            recipe[recipe.length - 1] = output.copy();
+        }
+        return recipe;
+    }
+
+    @Override
+    public ArrayList<Object[]> getPossibleRecipes()
+    {
+        Object[] recipe = null;
+        if (input != null)
+        {
+            recipe = new Object[getRecipeSize() + 1];
+            for (int i = 0; i < getRecipeSize(); ++i)
+            {
+                Object in = input.get(i);
+                if (in instanceof ItemStack)
+                {
+                    recipe[i] = ((ItemStack) in).copy();
+                }
+                else if (in instanceof ArrayList)
+                {
+                    recipe[i] = ForgeRecipeUtils.expandArray((ArrayList)in);
+                }
+                else if (in instanceof ICraftingMaterial)
+                {
+                    recipe[i] = ((ICraftingMaterial) in).getItems();
+                }
+            }
+            recipe[recipe.length - 1] = output.copy();
+        }
+
+        ArrayList<Object[]> result = new ArrayList<Object[]>();
+        if (recipe != null)
+        {
+            result.add(recipe);
+        }
+        return result;
+    }
+}

--- a/common/net/minecraftforge/crafting/ShapelessLiquidFillingRecipe.java
+++ b/common/net/minecraftforge/crafting/ShapelessLiquidFillingRecipe.java
@@ -1,0 +1,344 @@
+package net.minecraftforge.crafting;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+
+import net.minecraft.block.Block;
+import net.minecraft.inventory.InventoryCrafting;
+import net.minecraft.item.Item;
+import net.minecraft.item.ItemStack;
+import net.minecraft.item.crafting.ShapelessRecipes;
+import net.minecraft.world.World;
+import net.minecraftforge.crafting.tags.ItemEmptyContainer;
+import net.minecraftforge.crafting.tags.ItemFilledContainer;
+import net.minecraftforge.liquids.LiquidContainerData;
+import net.minecraftforge.liquids.LiquidContainerRegistry;
+import net.minecraftforge.liquids.LiquidStack;
+
+public class ShapelessLiquidFillingRecipe implements IRecipeExtractable {
+
+    private LiquidStack output = null;
+    private ArrayList input = new ArrayList();
+    
+    // If this member is true, matching fails when there are same items in the input matrix and output result.
+    private boolean excludeSame = true;
+
+    public ShapelessLiquidFillingRecipe(LiquidStack result, Object... recipe)
+    {
+        output = result.copy();
+        for (Object in : recipe)
+        {
+            if (in instanceof ItemStack)
+            {
+                input.add(((ItemStack) in).copy());
+            }
+            else if (in instanceof Item)
+            {
+                input.add(new ItemStack((Item) in));
+            }
+            else if (in instanceof Block)
+            {
+                input.add(new ItemStack((Block) in));
+            }
+            else if (in instanceof LiquidStack)
+            {
+                input.add(new ItemFilledContainer((LiquidStack) in));
+            }
+            else if (in instanceof Collection && ForgeRecipeUtils.isValidItemList((Collection)in))
+            {
+                input.add(new ArrayList((Collection) in));
+            }
+            else if (in instanceof ItemEmptyContainer || in instanceof ICraftingMaterial)
+            {
+                input.add(in);
+            }
+            else
+            {
+                String ret = "Invalid shapeless filling recipe: ";
+                for (Object tmp : recipe)
+                {
+                    ret += tmp + ", ";
+                }
+                ret += output;
+                throw new RuntimeException(ret);
+            }
+        }
+    }
+
+    protected ShapelessLiquidFillingRecipe(ShapelessRecipes recipe, Map<ItemStack, Object> replacements)
+    {
+        output = LiquidContainerRegistry.getLiquidForFilledItem(recipe.getRecipeOutput());
+
+        for (ItemStack ingred : (List<ItemStack>) recipe.recipeItems)
+        {
+            Object finalObj = ingred;
+            for (Entry<ItemStack, Object> replace : replacements.entrySet())
+            {
+                if (ForgeRecipeUtils.itemMatches(replace.getKey(), ingred, true))
+                {
+                    Object value = replace.getValue();
+                    if (value instanceof ItemEmptyContainer
+                            || value instanceof ICraftingMaterial)
+                    {
+                        finalObj = value;
+                    }
+                    else if (value instanceof Collection && ForgeRecipeUtils.isValidItemList((Collection)value))
+                    {
+                        finalObj = new ArrayList((Collection) value);
+                    }
+                    else if (value instanceof LiquidStack)
+                    {
+                        finalObj = new ItemFilledContainer((LiquidStack) value);
+                    }
+                    break;
+                }
+            }
+            input.add(finalObj);
+        }
+    }
+
+    @Override
+    public boolean matches(InventoryCrafting var1, World var2)
+    {
+        return getCraftingResult(var1) != null;
+    }
+
+    @Override
+    public ItemStack getCraftingResult(InventoryCrafting var1)
+    {
+        ArrayList required = new ArrayList(input);
+        ItemStack result = null;
+        ArrayList<ItemStack> foundMaterials = new ArrayList<ItemStack>();
+
+        for (int x = 0; x < var1.getSizeInventory(); x++)
+        {
+            ItemStack slot = var1.getStackInSlot(x);
+
+            if (slot != null)
+            {
+                boolean inRecipe = false;
+                Iterator req = required.iterator();
+
+                while (req.hasNext())
+                {
+                    boolean match = false;
+                    boolean isMaterial = true;
+
+                    Object next = req.next();
+
+                    if (next instanceof ItemStack)
+                    {
+                        match = ForgeRecipeUtils.itemMatches((ItemStack) next, slot);
+                    }
+                    else if (next instanceof ArrayList)
+                    {
+                        match = ForgeRecipeUtils.itemMatches((ArrayList) next, slot);
+                    }
+                    else if (next instanceof ICraftingMaterial)
+                    {
+
+                        match = ((ICraftingMaterial) next).itemMatches(slot);
+                    }
+                    else if (next instanceof ItemEmptyContainer)
+                    {
+
+                        ItemStack filled = ((ItemEmptyContainer) next).getFilledContainer(output, slot);
+                        if (filled != null)
+                        {
+                            if (result == null)
+                            {
+                                result = filled;
+                                match = true;
+                            }
+                            else if (result.isItemEqual(filled) && result.stackSize < result.getMaxStackSize())
+                            {
+                                ++result.stackSize;
+                                match = true;
+                            }
+                            isMaterial = false;
+                        }
+                    }
+
+                    if (match)
+                    {
+                        inRecipe = true;
+                        required.remove(next);
+                        break;
+                    }
+                }
+
+                if (!inRecipe)
+                {
+                    return null;
+                }
+            }
+        }
+
+        if (!required.isEmpty())
+        {
+            return null;
+        }
+
+        if (result != null && excludeSame)
+        {
+            for (ItemStack material : foundMaterials)
+            {
+                if (material.isItemEqual(result))
+                {
+                    return null;
+                }
+            }
+        }
+        return result;
+    }
+
+    @Override
+    public int getRecipeSize()
+    {
+        return input.size();
+    }
+
+    @Override
+    public ItemStack getRecipeOutput()
+    {
+        return null;
+    }
+
+    @Override
+    public Object[] getRawRecipe()
+    {
+        Object[] recipe = null;
+        if (input != null)
+        {
+            recipe = new Object[getRecipeSize() + 1];
+            for (int i = 0; i < getRecipeSize(); ++i)
+            {
+                Object in = input.get(i);
+                if (in instanceof ItemStack)
+                {
+                    recipe[i] = ((ItemStack) in).copy();
+                }
+                else if (in instanceof ArrayList)
+                {
+                    ArrayList items = new ArrayList();
+                    for (Object item : (ArrayList) in)
+                    {
+                        if(item instanceof ItemStack)
+                        {
+                            items.add(((ItemStack)item).copy());
+                        }
+                        else
+                        {
+                            items.add(item);
+                        }
+                    }
+                    recipe[i] = items;
+                }
+                else
+                {
+                    recipe[i] = in;
+                }
+            }
+            recipe[recipe.length - 1] = output.copy();
+        }
+        return recipe;
+    }
+
+    @Override
+    public ArrayList<Object[]> getPossibleRecipes()
+    {
+        ArrayList<Object[]> result = new ArrayList<Object[]>();
+        if (input == null || output == null)
+        {
+            return result;
+        }
+
+        ItemEmptyContainer container = null;
+        int stackSize = 0;
+        for (Object in : input)
+        {
+            if (in instanceof ItemEmptyContainer)
+            {
+                container = (ItemEmptyContainer) in;
+                ++stackSize;
+            }
+        }
+        if (stackSize == 0)
+        {
+            return result;
+        }
+
+        calcresult: for (LiquidContainerData data : container.getLiquidContainerData(output))
+        {
+            Object[] recipe = new Object[getRecipeSize() + 1];
+            ItemStack output = data.filled.copy();
+            if (output.getMaxStackSize() >= stackSize)
+            {
+                output.stackSize = stackSize;
+            }
+            else
+            {
+                continue;
+            }
+
+            for (int i = 0; i < getRecipeSize(); ++i)
+            {
+                Object in = input.get(i);
+
+                if (in instanceof ItemStack)
+                {
+                    recipe[i] = ((ItemStack) in).copy();
+                }
+                else if (in instanceof ArrayList)
+                {
+                    ArrayList<ItemStack> acceptable = new ArrayList<ItemStack>();
+                    for (ItemStack item : ForgeRecipeUtils.expandArray((ArrayList)in))
+                    {
+                        if (!excludeSame || !item.isItemEqual(output))
+                        {
+                            acceptable.add(item);
+                        }
+                    }
+                    if (acceptable.size() == 0)
+                    {
+                        continue calcresult;
+                    }
+                    recipe[i] = acceptable;
+                }
+                else if (in instanceof ICraftingMaterial)
+                {
+                    ArrayList<ItemStack> acceptable = new ArrayList<ItemStack>();
+                    for (ItemStack item : ((ICraftingMaterial) in).getItems())
+                    {
+                        if (!excludeSame || !item.isItemEqual(output))
+                        {
+                            acceptable.add(item);
+                        }
+                    }
+                    if (acceptable.size() == 0)
+                    {
+                        continue calcresult;
+                    }
+                    recipe[i] = acceptable;
+                }
+                else if (in instanceof ItemEmptyContainer)
+                {
+                    recipe[i] = data.container.copy();
+                }
+            }
+            recipe[recipe.length - 1] = output;
+            result.add(recipe);
+        }
+        return result;
+    }
+
+    public ShapelessLiquidFillingRecipe setExcludeSame(boolean exclude)
+    {
+        excludeSame = exclude;
+        return this;
+    }
+}

--- a/common/net/minecraftforge/crafting/tags/ItemEmptyContainer.java
+++ b/common/net/minecraftforge/crafting/tags/ItemEmptyContainer.java
@@ -1,0 +1,146 @@
+package net.minecraftforge.crafting.tags;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+
+import net.minecraft.item.ItemStack;
+import net.minecraftforge.liquids.LiquidContainerData;
+import net.minecraftforge.liquids.LiquidContainerRegistry;
+import net.minecraftforge.liquids.LiquidDictionary;
+import net.minecraftforge.liquids.LiquidStack;
+
+public class ItemEmptyContainer {
+    protected boolean exact;
+    protected ItemStack[] excludes;
+
+    public ItemEmptyContainer()
+    {
+        this(false);
+    }
+
+    public ItemEmptyContainer(boolean exact)
+    {
+        this(exact, null);
+    }
+
+    public ItemEmptyContainer(ItemStack[] excludes)
+    {
+        this(false, excludes);
+    }
+
+    public ItemEmptyContainer(boolean exact, ItemStack[] excludes)
+    {
+        this.exact = exact;
+        if (excludes != null)
+        {
+            this.excludes = new ItemStack[excludes.length];
+            for (int i = 0; i < excludes.length; ++i)
+            {
+                this.excludes[i] = excludes[i].copy();
+            }
+        }
+        else
+        {
+            this.excludes = null;
+        }
+    }
+
+    public ItemStack getFilledContainer(LiquidStack liquid, ItemStack container)
+    {
+        if(container == null) return null;
+        
+        if(excludes != null)
+        {
+            for(ItemStack item : excludes)
+            {
+                if (item.getItemDamage() == -1 && item.itemID == container.itemID || item.isItemEqual(container))
+                {
+                    return null;
+                }
+            }
+        }
+        
+        ItemStack filled = LiquidContainerRegistry.fillLiquidContainer(liquid, container);
+
+        if (filled != null)
+        {
+            if (!exact)
+            {
+                return filled;
+            }
+            else
+            {
+                LiquidStack filledLiquid = LiquidContainerRegistry.getLiquidForFilledItem(filled);
+                return filledLiquid.amount == liquid.amount ? filled : null;
+            }
+        }
+
+        return null;
+    }
+
+    public ArrayList<ItemStack> getFilledContainers(LiquidStack liquid)
+    {
+        ArrayList<ItemStack> result = new ArrayList<ItemStack>();
+
+        if(liquid == null) return result;
+        
+        for (LiquidContainerData data : LiquidContainerRegistry.getRegisteredLiquidContainerData())
+        {
+            if (data.stillLiquid.isLiquidEqual(liquid)
+                    && ((exact && data.stillLiquid.amount == liquid.amount) || (!exact && data.stillLiquid.amount <= liquid.amount)))
+            {
+                if (excludes != null)
+                {
+                    boolean include = true;;
+                    for (ItemStack item : excludes)
+                    {
+                        if ((item.getItemDamage() == -1 && item.itemID == data.container.itemID) || item.isItemEqual(data.container))
+                        {
+                            include = false;
+                        }
+                    }
+                    if (include) result.add(data.filled);
+                }
+                else
+                {
+                    result.add(data.filled);
+                }
+            }
+        }
+
+        return result;
+    }
+
+    public ArrayList<LiquidContainerData> getLiquidContainerData(LiquidStack liquid)
+    {
+        ArrayList<LiquidContainerData> result = new ArrayList<LiquidContainerData>();
+
+        if(liquid == null) return result;
+        
+        for (LiquidContainerData data : LiquidContainerRegistry.getRegisteredLiquidContainerData())
+        {
+            if (data.stillLiquid.isLiquidEqual(liquid)
+                    && ((exact && data.stillLiquid.amount == liquid.amount) || (!exact && data.stillLiquid.amount <= liquid.amount)))
+            {
+                if (excludes != null)
+                {
+                    boolean include = true;;
+                    for (ItemStack item : excludes)
+                    {
+                        if ((item.getItemDamage() == -1 && item.itemID == data.container.itemID) || item.isItemEqual(data.container))
+                        {
+                            include = false;
+                        }
+                    }
+                    if (include) result.add(data);
+                }
+                else
+                {
+                    result.add(data);
+                }
+            }
+        }
+
+        return result;
+    }
+}

--- a/common/net/minecraftforge/crafting/tags/ItemFilledContainer.java
+++ b/common/net/minecraftforge/crafting/tags/ItemFilledContainer.java
@@ -1,0 +1,155 @@
+package net.minecraftforge.crafting.tags;
+
+import java.util.ArrayList;
+
+import net.minecraft.block.Block;
+import net.minecraft.item.Item;
+import net.minecraft.item.ItemStack;
+import net.minecraftforge.crafting.ICraftingMaterial;
+import net.minecraftforge.liquids.LiquidContainerData;
+import net.minecraftforge.liquids.LiquidContainerRegistry;
+import net.minecraftforge.liquids.LiquidDictionary;
+import net.minecraftforge.liquids.LiquidStack;
+
+public class ItemFilledContainer implements ICraftingMaterial {
+
+    protected LiquidStack liquid;
+    protected String name;
+    protected int amount;
+    protected boolean exact;
+    protected ItemStack[] excludes;
+
+    public ItemFilledContainer(String name, int amount)
+    {
+        this(name, amount, false);
+    }
+
+    public ItemFilledContainer(String name, int amount, boolean exact)
+    {
+        this(name, amount, exact, null);
+    }
+
+    public ItemFilledContainer(String name, int amount, ItemStack[] excludes)
+    {
+        this(name, amount, false, excludes);
+    }
+
+    public ItemFilledContainer(String name, int amount, boolean exact, ItemStack[] excludes)
+    {
+        this(null, name, amount, exact, excludes);
+    }
+
+    public ItemFilledContainer(LiquidStack liquid)
+    {
+        this(liquid, false);
+    }
+
+    public ItemFilledContainer(LiquidStack liquid, boolean exact)
+    {
+        this(liquid, exact, null);
+    }
+
+    public ItemFilledContainer(LiquidStack liquid, ItemStack[] excludes)
+    {
+        this(liquid, false, excludes);
+    }
+
+    public ItemFilledContainer(LiquidStack liquid, boolean exact, ItemStack[] excludes)
+    {
+        this(liquid, null, liquid.amount, exact, excludes);
+    }
+
+    protected ItemFilledContainer(LiquidStack liquid, String name, int amount, boolean exact, ItemStack[] excludes)
+    {
+        this.liquid = liquid != null ? liquid.copy() : null;
+        this.name = name;
+        this.amount = amount;
+        this.exact = exact;
+        if(excludes != null){
+            this.excludes = new ItemStack[excludes.length];
+            for(int i = 0; i < excludes.length; ++i)
+            {
+                this.excludes[i] = excludes[i].copy();
+            }
+        }else{
+            this.excludes = null;
+        }
+    }
+
+    @Override
+    public boolean itemMatches(ItemStack other)
+    {
+        if(other == null) return false;
+        
+        if(excludes != null)
+        {
+            for(ItemStack item : excludes)
+            {
+                if (item.getItemDamage() == -1 && item.itemID == other.itemID || item.isItemEqual(other))
+                {
+                    return false;
+                }
+            }
+        }
+        
+        if (this.liquid == null && name != null)
+        {
+            this.liquid = LiquidDictionary.getLiquid(name, amount);
+        }
+
+        if (this.liquid == null)
+        {
+            return false;
+        }
+
+        LiquidStack liquid = LiquidContainerRegistry.getLiquidForFilledItem(other);
+
+        return liquid != null && (exact && liquid.amount == this.liquid.amount || !exact && liquid.amount >= this.liquid.amount);
+    }
+
+    @Override
+    public ArrayList<ItemStack> getItems()
+    {
+        ArrayList<ItemStack> result = new ArrayList<ItemStack>();
+
+        if (liquid == null && name != null)
+        {
+            liquid = LiquidDictionary.getLiquid(name, amount);
+        }
+
+        if (liquid == null)
+        {
+            return result;
+        }
+
+        for (LiquidContainerData data : LiquidContainerRegistry.getRegisteredLiquidContainerData())
+        {
+            if (data.stillLiquid.isLiquidEqual(liquid)
+                    && (exact && data.stillLiquid.amount == liquid.amount || !exact && data.stillLiquid.amount >= liquid.amount))
+            {
+                if (excludes != null)
+                {
+                    boolean include = true;
+                    for (ItemStack item : excludes)
+                    {
+                        if (item.getItemDamage() == -1 && item.itemID == data.filled.itemID || item.isItemEqual(data.filled))
+                        {
+                            include = false;
+                        }
+                    }
+                    if (include)
+                    {
+                        result.add(data.filled);
+                    }
+                }
+                else
+                {
+                    result.add(data.filled);
+                }
+            }
+        }
+
+        return result;
+    }
+
+}

--- a/common/net/minecraftforge/crafting/tags/ItemOre.java
+++ b/common/net/minecraftforge/crafting/tags/ItemOre.java
@@ -1,0 +1,43 @@
+package net.minecraftforge.crafting.tags;
+
+import java.util.ArrayList;
+
+import net.minecraft.item.ItemStack;
+import net.minecraftforge.crafting.ICraftingMaterial;
+import net.minecraftforge.oredict.OreDictionary;
+
+public class ItemOre implements ICraftingMaterial {
+
+    String name;
+
+    public ItemOre(String name)
+    {
+        this.name = name;
+    }
+
+    @Override
+    public boolean itemMatches(ItemStack other)
+    {
+        if (other == null) return false;
+        
+        ArrayList<ItemStack> items = OreDictionary.getOres(name);
+        if (items == null || items.isEmpty())
+        {
+            return false;
+        }
+        for (ItemStack item : items)
+        {
+            if (item.isItemEqual(other))
+            {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    @Override
+    public ArrayList<ItemStack> getItems()
+    {
+        return OreDictionary.getOres(name);
+    }
+}

--- a/common/net/minecraftforge/oredict/ShapedOreRecipe.java
+++ b/common/net/minecraftforge/oredict/ShapedOreRecipe.java
@@ -6,37 +6,35 @@ import java.util.Map;
 import java.util.Map.Entry;
 
 import net.minecraft.block.Block;
-import net.minecraft.item.crafting.IRecipe;
-import net.minecraft.inventory.InventoryCrafting;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraft.item.crafting.ShapedRecipes;
-import net.minecraft.world.World;
+import net.minecraftforge.crafting.ShapedForgeRecipe;
+import net.minecraftforge.crafting.tags.ItemOre;
 
-public class ShapedOreRecipe implements IRecipe 
+public class ShapedOreRecipe extends ShapedForgeRecipe
 {
-    //Added in for future ease of change, but hard coded for now.
-    private static final int MAX_CRAFT_GRID_WIDTH = 3;
-    private static final int MAX_CRAFT_GRID_HEIGHT = 3;
-    
-    private ItemStack output = null;
-    private Object[] input = null;
-    private int width = 0;
-    private int height = 0;
-    private boolean mirrored = true;
 
     public ShapedOreRecipe(Block     result, Object... recipe){ this(new ItemStack(result), recipe); }
     public ShapedOreRecipe(Item      result, Object... recipe){ this(new ItemStack(result), recipe); }
     public ShapedOreRecipe(ItemStack result, Object... recipe)
     {
-        output = result.copy();
+        super(result, convertInput(recipe));
+    }
+    
+    ShapedOreRecipe(ShapedRecipes recipe, Map<ItemStack, String> replacements)
+    {
+        super(recipe, convertInput(replacements));
+    }
 
-        String shape = "";
+    private static Object[] convertInput(Object[] recipe)
+    {
+        ArrayList result = new ArrayList();
         int idx = 0;
 
         if (recipe[idx] instanceof Boolean)
         {
-            mirrored = (Boolean)recipe[idx];
+            result.add(recipe[idx]);
             if (recipe[idx+1] instanceof Object[])
             {
                 recipe = (Object[])recipe[idx+1];
@@ -49,206 +47,40 @@ public class ShapedOreRecipe implements IRecipe
 
         if (recipe[idx] instanceof String[])
         {
-            String[] parts = ((String[])recipe[idx++]);
-
-            for (String s : parts)
-            {
-                width = s.length();
-                shape += s;
-            }
-            
-            height = parts.length;
+            result.add(recipe[idx++]);
         }
         else
         {
             while (recipe[idx] instanceof String)
             {
-                String s = (String)recipe[idx++];
-                shape += s;
-                width = s.length();
-                height++;
+                result.add(recipe[idx++]);
             }
         }
 
-        if (width * height != shape.length())
+        for (; idx < recipe.length; ++idx)
         {
-            String ret = "Invalid shaped ore recipe: ";
-            for (Object tmp :  recipe)
+            if (recipe[idx] instanceof String)
             {
-                ret += tmp + ", ";
-            }
-            ret += output;
-            throw new RuntimeException(ret);
-        }
-
-        HashMap<Character, Object> itemMap = new HashMap<Character, Object>();
-
-        for (; idx < recipe.length; idx += 2)
-        {
-            Character chr = (Character)recipe[idx];
-            Object in = recipe[idx + 1];
-
-            if (in instanceof ItemStack)
-            {
-                itemMap.put(chr, ((ItemStack)in).copy());
-            }
-            else if (in instanceof Item)
-            {
-                itemMap.put(chr, new ItemStack((Item)in));
-            }
-            else if (in instanceof Block)
-            {
-                itemMap.put(chr, new ItemStack((Block)in, 1, -1));
-            }
-            else if (in instanceof String)
-            {
-                itemMap.put(chr, OreDictionary.getOres((String)in));
+                result.add(new ItemOre((String)recipe[idx]));
             }
             else
             {
-                String ret = "Invalid shaped ore recipe: ";
-                for (Object tmp :  recipe)
-                {
-                    ret += tmp + ", ";
-                }
-                ret += output;
-                throw new RuntimeException(ret);
+                result.add(recipe[idx]);
             }
         }
 
-        input = new Object[width * height];
-        int x = 0;
-        for (char chr : shape.toCharArray())
-        {
-            input[x++] = itemMap.get(chr);   
-        }
-    }
-
-    ShapedOreRecipe(ShapedRecipes recipe, Map<ItemStack, String> replacements)
-    {
-        output = recipe.getRecipeOutput();
-        width = recipe.recipeWidth;
-        height = recipe.recipeHeight;
-
-        input = new Object[recipe.recipeItems.length];
-
-        for(int i = 0; i < input.length; i++)
-        {
-            ItemStack ingred = recipe.recipeItems[i];
-
-            if(ingred == null) continue;
-
-            input[i] = recipe.recipeItems[i];
-
-            for(Entry<ItemStack, String> replace : replacements.entrySet())
-            {
-                if(OreDictionary.itemMatches(replace.getKey(), ingred, true))
-                {
-                    input[i] = OreDictionary.getOres(replace.getValue());
-                    break;
-                }
-            }
-        }
-    }
-
-    @Override
-    public ItemStack getCraftingResult(InventoryCrafting var1){ return output.copy(); }
-
-    @Override
-    public int getRecipeSize(){ return input.length; }
-
-    @Override
-    public ItemStack getRecipeOutput(){ return output; }
-
-    @Override
-    public boolean matches(InventoryCrafting inv, World world)
-    {        
-        for (int x = 0; x <= MAX_CRAFT_GRID_WIDTH - width; x++)
-        {
-            for (int y = 0; y <= MAX_CRAFT_GRID_HEIGHT - height; ++y)
-            {
-                if (checkMatch(inv, x, y, true))
-                {
-                    return true;
-                }
-    
-                if (mirrored && checkMatch(inv, x, y, false))
-                {
-                    return true;
-                }
-            }
-        }
-    
-        return false;
+        return result.toArray();
     }
     
-    private boolean checkMatch(InventoryCrafting inv, int startX, int startY, boolean mirror)
+    private static Map<ItemStack, Object> convertInput(Map<ItemStack, String> replacements)
     {
-        for (int x = 0; x < MAX_CRAFT_GRID_WIDTH; x++)
+        Map<ItemStack, Object> converted = new HashMap<ItemStack, Object>();
+        
+        for(Entry<ItemStack, String> entry : replacements.entrySet())
         {
-            for (int y = 0; y < MAX_CRAFT_GRID_HEIGHT; y++)
-            {
-                int subX = x - startX;
-                int subY = y - startY;
-                Object target = null;
-
-                if (subX >= 0 && subY >= 0 && subX < width && subY < height)
-                {
-                    if (mirror)
-                    {
-                        target = input[width - subX - 1 + subY * width];
-                    }
-                    else
-                    {
-                        target = input[subX + subY * width];
-                    }
-                }
-
-                ItemStack slot = inv.getStackInRowAndColumn(x, y);
-                
-                if (target instanceof ItemStack)
-                {
-                    if (!checkItemEquals((ItemStack)target, slot))
-                    {
-                        return false;
-                    }
-                }
-                else if (target instanceof ArrayList)
-                {
-                    boolean matched = false;
-                    
-                    for (ItemStack item : (ArrayList<ItemStack>)target)
-                    {
-                        matched = matched || checkItemEquals(item, slot);
-                    }
-                    
-                    if (!matched)
-                    {
-                        return false;
-                    }
-                }
-                else if (target == null && slot != null)
-                {
-                    return false;
-                }
-            }
+            converted.put(entry.getKey(), new ItemOre(entry.getValue()));
         }
-
-        return true;
-    }
-
-    private boolean checkItemEquals(ItemStack target, ItemStack input)
-    {
-        if (input == null && target != null || input != null && target == null)
-        {
-            return false;
-        }
-        return (target.itemID == input.itemID && (target.getItemDamage() == -1 || target.getItemDamage() == input.getItemDamage()));
-    }
-
-    public ShapedOreRecipe setMirrored(boolean mirror)
-    {
-        mirrored = mirror;
-        return this;
+        
+        return converted;
     }
 }

--- a/common/net/minecraftforge/oredict/ShapelessOreRecipe.java
+++ b/common/net/minecraftforge/oredict/ShapelessOreRecipe.java
@@ -1,142 +1,58 @@
 package net.minecraftforge.oredict;
 
 import java.util.ArrayList;
-import java.util.Iterator;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Map.Entry;
-import java.util.List;
-
 import net.minecraft.block.Block;
-import net.minecraft.item.crafting.CraftingManager;
-import net.minecraft.item.crafting.IRecipe;
-import net.minecraft.inventory.InventoryCrafting;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraft.item.crafting.ShapelessRecipes;
-import net.minecraft.world.World;
+import net.minecraftforge.crafting.ShapelessForgeRecipe;
+import net.minecraftforge.crafting.tags.ItemOre;
 
-public class ShapelessOreRecipe implements IRecipe 
+public class ShapelessOreRecipe extends ShapelessForgeRecipe
 {
-    private ItemStack output = null;
-    private ArrayList input = new ArrayList();    
 
     public ShapelessOreRecipe(Block result, Object... recipe){ this(new ItemStack(result), recipe); }
     public ShapelessOreRecipe(Item  result, Object... recipe){ this(new ItemStack(result), recipe); }
     
     public ShapelessOreRecipe(ItemStack result, Object... recipe)
     {
-        output = result.copy();
+        super(result, convertInput(recipe));
+    }
+    
+    ShapelessOreRecipe(ShapelessRecipes recipe, Map<ItemStack, String> replacements)
+    {
+        super(recipe, convertInput(replacements));
+    }
+    
+    private static Object[] convertInput(Object[] recipe)
+    {
+        ArrayList result = new ArrayList();
         for (Object in : recipe)
         {
-            if (in instanceof ItemStack)
+            if (in instanceof String)
             {
-                input.add(((ItemStack)in).copy());
-            }
-            else if (in instanceof Item)
-            {
-                input.add(new ItemStack((Item)in));
-            }
-            else if (in instanceof Block)
-            {
-                input.add(new ItemStack((Block)in));
-            }
-            else if (in instanceof String)
-            {
-                input.add(OreDictionary.getOres((String)in));
+                result.add(new ItemOre((String)in));
             }
             else
             {
-                String ret = "Invalid shapeless ore recipe: ";
-                for (Object tmp :  recipe)
-                {
-                    ret += tmp + ", ";
-                }
-                ret += output;
-                throw new RuntimeException(ret);
+                result.add(in);
             }
         }
+        return result.toArray();
     }
 
-    ShapelessOreRecipe(ShapelessRecipes recipe, Map<ItemStack, String> replacements)
+    private static Map<ItemStack, Object> convertInput(Map<ItemStack, String> replacements)
     {
-        output = recipe.getRecipeOutput();
+        Map<ItemStack, Object> result = new HashMap<ItemStack, Object>();
 
-        for(ItemStack ingred : ((List<ItemStack>)recipe.recipeItems))
+        for(Entry<ItemStack, String> entry : replacements.entrySet())
         {
-            Object finalObj = ingred;
-            for(Entry<ItemStack, String> replace : replacements.entrySet())
-            {
-                if(OreDictionary.itemMatches(replace.getKey(), ingred, false))
-                {
-                    finalObj = OreDictionary.getOres(replace.getValue());
-                    break;
-                }
-            }
-            input.add(finalObj);
+            result.put(entry.getKey(), new ItemOre(entry.getValue()));
         }
-    }
-
-    @Override
-    public int getRecipeSize(){ return input.size(); }
-
-    @Override
-    public ItemStack getRecipeOutput(){ return output; }
-    
-    @Override
-    public ItemStack getCraftingResult(InventoryCrafting var1){ return output.copy(); }
-    
-    @Override
-    public boolean matches(InventoryCrafting var1, World world) 
-    {
-        ArrayList required = new ArrayList(input);
-
-        for (int x = 0; x < var1.getSizeInventory(); x++)
-        {
-            ItemStack slot = var1.getStackInSlot(x);
-
-            if (slot != null)
-            {
-                boolean inRecipe = false;
-                Iterator req = required.iterator();
-
-                while (req.hasNext())
-                {
-                    boolean match = false;
-                    
-                    Object next = req.next();
-                    
-                    if (next instanceof ItemStack)
-                    {
-                        match = checkItemEquals((ItemStack)next, slot);
-                    }
-                    else if (next instanceof ArrayList)
-                    {
-                        for (ItemStack item : (ArrayList<ItemStack>)next)
-                        {
-                            match = match || checkItemEquals(item, slot);
-                        }
-                    }
-
-                    if (match)
-                    {
-                        inRecipe = true;
-                        required.remove(next);
-                        break;
-                    }
-                }
-
-                if (!inRecipe)
-                {
-                    return false;
-                }
-            }
-        }
-
-        return required.isEmpty();
-    }
-    
-    private boolean checkItemEquals(ItemStack target, ItemStack input)
-    {
-        return (target.itemID == input.itemID && (target.getItemDamage() == -1 || target.getItemDamage() == input.getItemDamage()));
+        
+        return result;
     }
 }


### PR DESCRIPTION
- Treat LiquidStack as a filled container.
- Add methods to get recipe input.
  
  ```
  // Examples.
  LiquidStack liquidWater = new LiquidStack(Block.waterStill, LiquidContainerRegistry.BUCKET_VOLUME);
  IRecipe recipe;
  
  // Water + snawball -> ice
  recipe = new ShapelessForgeRecipe(Block.ice,
          liquidWater,
          Item.snowball);
  GameRegistry.addRecipe(recipe);
  
  // 3 cacti + empty container -> container filled with water.
  recipe = new ShapedLiquidFillingRecipe(
          liquidWater,
          "ccc",
          " b ",
          Character.valueOf('c'), Block.cactus,
          Character.valueOf('b'), new ItemEmptyContainer());
  GameRegistry.addRecipe(recipe);
  ```
