### PR TITLE
EntityAnimal does not use the experienceValue of its Parent Class (yet)

### DIFF
--- a/patches/minecraft/net/minecraft/entity/passive/EntityAnimal.java.patch
+++ b/patches/minecraft/net/minecraft/entity/passive/EntityAnimal.java.patch
@@ -1,0 +1,15 @@
+18,21d17
+<     /**
+<      * This value is the Max Value to add to the experience Value per Random inside getExperiencePoints()
+<      */
+<     public int experienceValueAddition;
+32,33d27
+<         this.experienceValue = 1;
+<         this.experienceValueAddition = 3;
+324,327c318
+< 		 if(this.experienceValueAddition<=0)
+< 			return this.experienceValue;
+< 		 else
+<    	 	return this.experienceValue + this.worldObj.rand.nextInt(this.experienceValueAddition);
+---
+>         return 1 + this.worldObj.rand.nextInt(3);


### PR DESCRIPTION
I Also added a new variable experienceValueAddition that will mark the
Maximum random Value added to the experienceValue. You may set both
values to 0 to avoid XP Drops by the Animals.
