### PR TITLE
Use python2 if possible for bash scripts

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,2 +1,6 @@
 #!/bin/bash
-python build.py "$@"
+PYTHON=python2
+if ! which "$PYTHON" >/dev/null; then
+	PYTHON=python
+fi
+$PYTHON build.py "$@"

--- a/install/install.sh
+++ b/install/install.sh
@@ -1,2 +1,6 @@
 #!/bin/bash
-python install.py
+PYTHON=python2
+if ! which "$PYTHON" >/dev/null; then
+	PYTHON=python
+fi
+$PYTHON install.py

--- a/setup.sh
+++ b/setup.sh
@@ -1,2 +1,6 @@
 #!/bin/bash
-python setup.py "$@"
+PYTHON=python2
+if ! which "$PYTHON" >/dev/null; then
+	PYTHON=python
+fi
+$PYTHON setup.py "$@"

--- a/update_patches.sh
+++ b/update_patches.sh
@@ -1,2 +1,6 @@
 #!/bin/bash
-python update_patches.py "$@"
+PYTHON=python2
+if ! which "$PYTHON" >/dev/null; then
+	PYTHON=python
+fi
+$PYTHON update_patches.py "$@"


### PR DESCRIPTION
Modern linux distributions have 'python' tied to python 3, which the scripts are not compatible with, these fixes should make sure the scripts try to find python2 first, and fall back to python if it doesn't exist.

Note I've seen pull request #392, but that one doesn't work on systems without python2, see below (python20 is used since I _do_ have python2):

```
[bartbes@archery /tmp]$ PYTHON=$(which python20 || which python || echo python)
[bartbes@archery /tmp]$ echo $PYTHON
python20 not found
/usr/bin/python
```

Compared to this version:

```
[bartbes@archery /tmp]$ PYTHON=python20; if ! which "$PYTHON" >/dev/null; then PYTHON=python; fi
[bartbes@archery /tmp]$ echo $PYTHON
python
```
