### PR TITLE
Fixes comparison for items in creative inventory

### DIFF
--- a/patches/minecraft/net/minecraft/client/gui/inventory/GuiContainerCreative.java.patch
+++ b/patches/minecraft/net/minecraft/client/gui/inventory/GuiContainerCreative.java.patch
@@ -9,6 +9,15 @@
  
      public GuiContainerCreative(EntityPlayer par1EntityPlayer)
      {
+@@ -137,7 +139,7 @@
+                     return;
+                 }
+ 
+-                if (var7 != null && var8 != null && var7.isItemEqual(var8))
++                if (var7 != null && var8 != null && var7.isItemEqual(var8) && ItemStack.areItemStackTagsEqual(var7, var8))
+                 {
+                     if (par3 == 0)
+                     {
 @@ -229,6 +231,13 @@
              this.setCurrentCreativeTab(CreativeTabs.creativeTabArray[var1]);
              this.field_82324_x = new CreativeCrafting(this.mc);


### PR DESCRIPTION
Fixes bug in native dealing with comparisons between items in creative
inventory, specifically when a held item is 'dropped' onto an item, it
should destroy if the target is not a source and increment if it is.
Only adds a check for NBT discrepancies between the two items.
