### PR TITLE
Fix: fortune modifier always passed as 0.

### DIFF
--- a/patches/minecraft/net/minecraft/block/Block.java.patch
+++ b/patches/minecraft/net/minecraft/block/Block.java.patch
@@ -486,7 +486,7 @@
 +        int count = quantityDropped(metadata, fortune, world.rand);
 +        for(int i = 0; i < count; i++)
 +        {
-+            int id = idDropped(metadata, world.rand, 0);
++            int id = idDropped(metadata, world.rand, fortune);
 +            if (id > 0)
 +            {
 +                ret.add(new ItemStack(id, 1, damageDropped(metadata)));


### PR DESCRIPTION
This fixes an issue that the fortune modifier is incorrectly passed to blocks such as gravel and sand. 
