### PR TITLE
Fix EventTransformer throwing an NPE when transforming a class that doesn't exist.

### DIFF
--- a/common/net/minecraftforge/transformers/EventTransformer.java
+++ b/common/net/minecraftforge/transformers/EventTransformer.java
@@ -22,7 +22,7 @@ public class EventTransformer implements IClassTransformer
     @Override
     public byte[] transform(String name, byte[] bytes)
     {
-        if (name.equals("net.minecraftforge.event.Event") || name.startsWith("net.minecraft.") || name.indexOf('.') == -1)
+        if (bytes == null || name.equals("net.minecraftforge.event.Event") || name.startsWith("net.minecraft.") || name.indexOf('.') == -1)
         {
             return bytes;
         }


### PR DESCRIPTION
All other transformers handle the case where the class being transformed doesn't exist, and bytes == null.
EventTransformer throws an NPE in this case, so most ClassNotFoundExceptions point at EventTransformer as a suspect. This PR fixes that.
