### PR TITLE
small change to prevent mcProfiler breakage due to recent Forge commit

### DIFF
--- a/patches/minecraft/net/minecraft/client/renderer/RenderGlobal.java.patch
+++ b/patches/minecraft/net/minecraft/client/renderer/RenderGlobal.java.patch
@@ -38,9 +38,9 @@
 -            TileEntityRenderer.staticPlayerY = var4.lastTickPosY + (var4.posY - var4.lastTickPosY) * (double)par3;
 -            TileEntityRenderer.staticPlayerZ = var4.lastTickPosZ + (var4.posZ - var4.lastTickPosZ) * (double)par3;
 +            List var5 = this.theWorld.getLoadedEntityList();
++            this.theWorld.theProfiler.startSection("prepare");
 +            if(pass == 0)
 +            {
-+                this.theWorld.theProfiler.startSection("prepare");
 +                TileEntityRenderer.instance.cacheActiveRenderInfo(this.theWorld, this.renderEngine, this.mc.fontRenderer, this.mc.renderViewEntity, par3);
 +                RenderManager.instance.cacheActiveRenderInfo(this.theWorld, this.renderEngine, this.mc.fontRenderer, this.mc.renderViewEntity, this.mc.gameSettings, par3);
 +                this.countEntitiesTotal = 0;


### PR DESCRIPTION
....patch

call this.theWorld.theProfiler.startSection("prepare"); for passes other than 0.  EntityRenderer.renderWorld() now calls RenderGlobal.renderEntities() twice (for transparency - see https://github.com/MinecraftForge/MinecraftForge/blob/master/patches/minecraft/net/minecraft/client/renderer/EntityRenderer.java.patch section -1194,6 +1203,13 ).

On the second pass, that startSection() is not called, while the endSection() at the end of the method is called.  This unbalances the mcProfiler stack.  

Without that startSection, the endSection at the end kills off one more level than it should, prematurely ending profiler section "level".  this.mc.mcProfiler.endStartSection("gui"); in EntityRenderer.updateCameraAndRender() now replaces "gameRenderer" with "gui" (with "root" as the next one down the stack) instead of replacing "level" with "gui" and leaving "gameRenderer" the next one down the stack.

This change keeps mcProfiler balanced.
