### PR TITLE
use a better lookup than a hash.

### DIFF
--- a/common/net/minecraftforge/oredict/OreDictionary.java
+++ b/common/net/minecraftforge/oredict/OreDictionary.java
@@ -22,7 +22,7 @@ public class OreDictionary
     private static boolean hasInit = false;
     private static int maxID = 0;
     private static HashMap<String, Integer> oreIDs = new HashMap<String, Integer>();
-    private static HashMap<Integer, ArrayList<ItemStack>> oreStacks = new HashMap<Integer, ArrayList<ItemStack>>();
+    private static ArrayList<ArrayList<ItemStack>> oreStacks = new ArrayList<ArrayList<ItemStack>>();
     
     static {
         initVanillaEntries();
@@ -152,7 +152,10 @@ public class OreDictionary
         {
             val = maxID++;
             oreIDs.put(name, val);
-            oreStacks.put(val, new ArrayList<ItemStack>());
+            oreStacks.ensureCapacity(val); // double the size of the array if needed; way less expensive than rebuilding the hashmap as it fills
+            while(oreStacks.size()<val) // trivially cheap operation, as we know that it is within the capacity of the array.
+                oreStacks.add(null);
+            oreStacks.set(val, new ArrayList<ItemStack>());
         }
         return val;
     }
@@ -187,8 +190,9 @@ public class OreDictionary
         if( itemStack == null )
             return -1;
 
-        for(int oreID : oreStacks.keySet())
+        for(int oreID = 0;oreID < oreStacks.size();oreID++)
         {
+        	if(oreStacks.get(oreID) != null) // never true because we start the ID at 0 and increment it each time; and things are never un-registered.
             for(ItemStack target : oreStacks.get(oreID))
             {
                 if(itemStack.itemID == target.itemID && (target.getItemDamage() == -1 || itemStack.getItemDamage() == target.getItemDamage()))
@@ -233,7 +237,7 @@ public class OreDictionary
         if (val == null)
         {
             val = new ArrayList<ItemStack>();
-            oreStacks.put(id, val);
+            oreStacks.set(id, val);
         }
         return val;
     }


### PR DESCRIPTION
with a perfect index function in val, there is no need to hash.
val is an incremented int, starting at 0, with every index up to the current max in use; there is no point in calculating a hash from the int then storing (with potential collisions) in a hashmap, when we can use the known int as a direct index to an array with 0 overhead, and 0 chance of collision.

Also, 
for(X x : hashMap.keySet())
hashmap.get(x) is quite poor and very slow code, and should be fixed, even if this PR is rejected.

much faster code (especially when hashing could be expensive) is:
for(Entry<X,Y> e: hashMap.EntrySet() )
e.getValue() 

In most java implementations hashMap does extra hashing of whatever key is passed to it, so Integer.HashValue() + another 20 or so extra HashMap.Hash() cpu operations is vastly more expensive than a simple member get.

This may resolve slow recipe lookups in various which are ore dictionary aware, and have to look up recipes every other tick. (ie, most crafting type blocks)
