### PR TITLE
Allow items on ground to do stuff other then turn

### DIFF
--- a/patches/minecraft/net/minecraft/entity/item/EntityItem.java.patch
+++ b/patches/minecraft/net/minecraft/entity/item/EntityItem.java.patch
@@ -32,7 +32,18 @@
      }
  
      /**
-@@ -135,7 +146,29 @@
+@@ -82,6 +93,10 @@
+     {
+         super.onUpdate();
+ 
++        ItemStack stack = this.getDataWatcher().getWatchableObjectItemStack(10);
++        Item items = stack.getItem();
++        items.onEntityItemUpdate(this);
++        
+         if (this.delayBeforeCanPickup > 0)
+         {
+             --this.delayBeforeCanPickup;
+@@ -135,7 +150,29 @@
  
          ++this.age;
  
@@ -63,7 +74,7 @@
          {
              this.setDead();
          }
-@@ -263,6 +296,7 @@
+@@ -263,6 +300,7 @@
      {
          par1NBTTagCompound.setShort("Health", (short)((byte)this.health));
          par1NBTTagCompound.setShort("Age", (short)this.age);
@@ -71,7 +82,7 @@
  
          if (this.getEntityItem() != null)
          {
-@@ -280,10 +314,17 @@
+@@ -280,10 +318,17 @@
          NBTTagCompound var2 = par1NBTTagCompound.getCompoundTag("Item");
          this.func_92058_a(ItemStack.loadItemStackFromNBT(var2));
  
@@ -90,7 +101,7 @@
      }
  
      /**
-@@ -293,10 +334,22 @@
+@@ -293,10 +338,22 @@
      {
          if (!this.worldObj.isRemote)
          {

--- a/patches/minecraft/net/minecraft/item/Item.java.patch
+++ b/patches/minecraft/net/minecraft/item/Item.java.patch
@@ -1,6 +1,20 @@
 --- ../src_base/minecraft/net/minecraft/item/Item.java
 +++ ../src_work/minecraft/net/minecraft/item/Item.java
-@@ -13,6 +13,7 @@
+@@ -1,18 +1,18 @@
+ package net.minecraft.item;
+ 
+-import cpw.mods.fml.common.registry.GameData;
+-import cpw.mods.fml.relauncher.Side;
+-import cpw.mods.fml.relauncher.SideOnly;
+ import java.util.List;
+ import java.util.Random;
++
+ import net.minecraft.block.Block;
+ import net.minecraft.block.material.Material;
+ import net.minecraft.creativetab.CreativeTabs;
+ import net.minecraft.entity.Entity;
+ import net.minecraft.entity.EntityLiving;
++import net.minecraft.entity.item.EntityItem;
  import net.minecraft.entity.item.EntityItemFrame;
  import net.minecraft.entity.item.EntityPainting;
  import net.minecraft.entity.player.EntityPlayer;
@@ -8,17 +22,20 @@
  import net.minecraft.potion.Potion;
  import net.minecraft.potion.PotionHelper;
  import net.minecraft.stats.StatList;
-@@ -21,7 +22,9 @@
+@@ -21,7 +21,12 @@
  import net.minecraft.util.StatCollector;
  import net.minecraft.util.StringTranslate;
  import net.minecraft.util.Vec3;
 +import net.minecraft.util.WeightedRandomChestContent;
  import net.minecraft.world.World;
 +import net.minecraftforge.common.ChestGenHooks;
++import cpw.mods.fml.common.registry.GameData;
++import cpw.mods.fml.relauncher.Side;
++import cpw.mods.fml.relauncher.SideOnly;
  
  public class Item
  {
-@@ -230,18 +233,26 @@
+@@ -230,18 +235,26 @@
      /** full name of item from language file */
      private String itemName;
  
@@ -46,7 +63,7 @@
      }
  
      /**
-@@ -561,6 +572,7 @@
+@@ -561,6 +574,7 @@
  
      /**
       * Returns a string representing what this item does to a potion.
@@ -54,7 +71,7 @@
       */
      public String getPotionEffect()
      {
-@@ -569,6 +581,7 @@
+@@ -569,6 +583,7 @@
  
      /**
       * Returns true if this item serves as a potion ingredient (its ingredient information is not null).
@@ -62,7 +79,7 @@
       */
      public boolean isPotionIngredient()
      {
-@@ -627,6 +640,10 @@
+@@ -627,6 +642,10 @@
          float var18 = var15 * var16;
          float var20 = var14 * var16;
          double var21 = 5.0D;
@@ -73,7 +90,7 @@
          Vec3 var23 = var13.addVector((double)var18 * var21, (double)var17 * var21, (double)var20 * var21);
          return par1World.rayTraceBlocks_do_do(var13, var23, par3, !par3);
      }
-@@ -701,4 +718,362 @@
+@@ -701,4 +720,373 @@
      {
          StatList.initStats();
      }
@@ -392,6 +409,17 @@
 +    }
 +
 +    /**
++     * Called to tick EntityItem for items on the ground. Override to do something
++     * 
++     * @param entityItem
++     */
++    public void onEntityItemUpdate(EntityItem entityItem)
++    {
++     
++        
++    }
++
++    /**
 +     * Determines if the specific ItemStack can be placed in the specified armor slot.
 +     * 
 +     * @param stack The ItemStack
@@ -434,5 +462,5 @@
 +    {
 +        return getPotionEffect();
 +    }
-+
++  
  }


### PR DESCRIPTION
This allow you to add code to you item/block to be able to make it do stuff after its thrown, every item/block is run separately. 
