### PR TITLE
Add Item independent NBT saving for Liquids

### DIFF
--- a/common/net/minecraftforge/liquids/LiquidDictionary.java
+++ b/common/net/minecraftforge/liquids/LiquidDictionary.java
@@ -8,6 +8,8 @@ import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.event.Event;
 
 import com.google.common.collect.ImmutableMap;
+import java.util.Arrays;
+import java.util.List;
 
 /**
  * When creating liquids you should register them with this class.
@@ -18,6 +20,7 @@ public abstract class LiquidDictionary
 {
 
     private static Map<String, LiquidStack> liquids = new HashMap<String, LiquidStack>();
+    private static Map<List<Integer>, String> tags = new HashMap<List<Integer>, String>();
 
     /**
      * When creating liquids you should call this function.
@@ -37,6 +40,7 @@ public abstract class LiquidDictionary
             return existing.copy();
         }
         liquids.put(name, liquid.copy());
+        tags.put(Arrays.asList(liquid.itemID, liquid.itemMeta), name);
         MinecraftForge.EVENT_BUS.post(new LiquidRegisterEvent(name, liquid));
         return liquid;
     }
@@ -60,6 +64,20 @@ public abstract class LiquidDictionary
         liquid = liquid.copy();
         liquid.amount = amount;
         return liquid;
+    }
+    
+    /**
+     * Returns the name matching the liquid,
+     * if such a liquid exists.
+     *
+     * Can return null.
+     *
+     * @param liquid the LiquidStack
+     * @return String a unique tag for the liquid
+     */
+    public static String getLiquidName(LiquidStack liquid)
+    {
+        return tags.get(Arrays.asList(liquid.itemID, liquid.itemMeta));
     }
 
     /**

--- a/common/net/minecraftforge/liquids/LiquidStack.java
+++ b/common/net/minecraftforge/liquids/LiquidStack.java
@@ -30,6 +30,12 @@ public class LiquidStack
 
     public NBTTagCompound writeToNBT(NBTTagCompound nbt)
     {
+        String liquidName = LiquidDictionary.getLiquidName(this);
+        if (liquidName != null)
+        {
+            nbt.setString("liquidName", liquidName);
+        }
+
         nbt.setShort("Id", (short)itemID);
         nbt.setInteger("Amount", amount);
         nbt.setShort("Meta", (short)itemMeta);
@@ -41,6 +47,17 @@ public class LiquidStack
         itemID = nbt.getShort("Id");
         amount = nbt.getInteger("Amount");
         itemMeta = nbt.getShort("Meta");
+
+        if (nbt.hasKey("liquidName"))
+        {
+            String liquidName = nbt.getString("liquidName");
+            LiquidStack liquid = LiquidDictionary.getLiquid(liquidName, 0);
+            if (liquid != null)
+            {
+                itemID = liquid.itemID;
+                itemMeta = liquid.itemMeta;
+            }
+        }        
     }
 
     /**


### PR DESCRIPTION
This simple PR will allow users to add/remove mods that take advantage of the LiquidDictionary without the associated issues that currently plague the LiquidDictionary.

Typically users are forced to break all their pipes/tanks/machines to get rid of the old liquid item. With this change, that should no longer become necessary in most cases. Existing liquids will self-convert to the new liquid item on world save/load.

Of course this assumes that mods are actually using the LiquidStack nbt functions.

This change should be 100% backwards compatible and has been tested to work.
