### PR TITLE
Biome Tag System

### DIFF
--- a/common/net/minecraftforge/common/BiomeDictionary.java
+++ b/common/net/minecraftforge/common/BiomeDictionary.java
@@ -71,7 +71,7 @@ public class BiomeDictionary
     {   
         if(BiomeGenBase.biomeList[biome.biomeID] != null)
         {
-        	for(Type type : types)
+            for(Type type : types)
             {
                 if(typeInfoList[type.ordinal()] == null)
                 {


### PR DESCRIPTION
An issue with biome adding mods which is becoming increasingly annoying for players, is that many mod authors that add biome specific world generation or mobs in their mods, for the most part, hard code them to work with vanilla biomes only. This becomes a huge problem when it's difficult to even find a vanilla biome, let alone a specific one, when biome mods are installed.

A simple solution to this problem is a tag system for biomes that allows mod authors to set up their world generators, or mobs to generate or spawn in biomes that have been registered with a specific tag such as "FOREST", or "FROZEN". I wrote such a system a few months ago, which I've been using with my own mods, and have made available to anyone who wants to use it. Since then, I've had requests from mod authors and players alike to try and get it, or at least similar functionality, into Forge, where other mod authors will be more comfortable using it.

Aside from the tags, it also includes a rule based system to classify biomes that have not already been registered with it when information is requested on them (You can opt out of this by registering a biome as type "NULL"). And additionally, the ability to register IWorldGenerators for specific biomes, or biome types (tags) to speed up chunk generation a little bit.
