### PR TITLE
Move the RenderWorldLastEvent back to before renderHand like it was in 1.4

### DIFF
--- a/patches/minecraft/net/minecraft/client/renderer/EntityRenderer.java.patch
+++ b/patches/minecraft/net/minecraft/client/renderer/EntityRenderer.java.patch
@@ -116,13 +116,12 @@
              GL11.glDisable(GL11.GL_BLEND);
              this.mc.mcProfiler.endStartSection("weather");
              this.renderRainSnow(par1);
-@@ -1248,6 +1267,9 @@
-                 GL11.glClear(GL11.GL_DEPTH_BUFFER_BIT);
-                 this.renderHand(par1, j);
-             }
+             GL11.glDisable(GL11.GL_FOG);
+             this.renderCloudsCheck(renderglobal, par1);
 +
 +            this.mc.mcProfiler.endStartSection("FRenderLast");
 +            ForgeHooksClient.dispatchRenderLast(renderglobal, par1);
++            
+             this.mc.mcProfiler.endStartSection("hand");
  
-             if (!this.mc.gameSettings.anaglyph)
-             {
+             if (this.cameraZoom == 1.0D)


### PR DESCRIPTION
Having it after leaves a different transformation matrix setup. Note this is a World render last event, not a complete render last event. The hand rendering (which includes the ingame gui) is not part of the world.
