### PR TITLE
Made some sleep-related fields public to allow fixing of sleeping bug in new dimensions

### DIFF
--- a/common/forge_at.cfg
+++ b/common/forge_at.cfg
@@ -66,6 +66,7 @@ public akw.a()I #MD:BlockBaseRailLogic/func_94505_a #getNAdjacentTiles
 # EntityPlayer
 public sk.a(Lrb;)V #MD:EntityPlayer/func_71012_a #joinEntityItemWithWorld
 public sk.h()V #MD:EntityPlayer/func_71053_j #closeScreen
+public sk.b #FD:EntityPlayer/field_71076_b #sleepTimer
 # EntityPlayerMP
 public bdp.a(Lrb;)V #MD:EntityClientPlayerMP/func_71012_a #joinEntityItemWithWorld
 # World Gen Chests Related
@@ -128,3 +129,4 @@ public zv.o #FD:World/field_73018_p #prevThunderingStrength
 public bdm.b(Lmp;)V #MD:WorldClient/func_72847_b #releaseEntitySkin
 #WorldServer
 public iz.b(Lmp;)V #MD:WorldServer/func_72847_b #releaseEntitySkin
+public iz.N #FD:WorldServer/field_73068_N #allPlayersSleeping


### PR DESCRIPTION
(I submitted a PR for this a while back which was accepted, but it somehow got undone in the 1.5 update, so here's the new one.)

Fields: EntityPlayer.sleepTimer and WorldServer.allPlayersSleeping

In new dimensions which allow player respawning, sleeping in beds doesn't fast forward time to day; it just sets the spawn point and kicks the player out of bed. This is to do with the way 'setting time' is handled in non-Overworld worlds.

The only way to get around this problem is to use reflection to access private fields, which is very costly being run every world tick. So what I've done here is made these fields public with the Forge access transformer.
