### PR TITLE
Shaped Ore Recipe mirroring issue

### DIFF
--- a/common/net/minecraftforge/oredict/ShapedOreRecipe.java
+++ b/common/net/minecraftforge/oredict/ShapedOreRecipe.java
@@ -167,12 +167,12 @@ public class ShapedOreRecipe implements IRecipe
         {
             for (int y = 0; y <= MAX_CRAFT_GRID_HEIGHT - height; ++y)
             {
-                if (checkMatch(inv, x, y, true))
+                if (checkMatch(inv, x, y, false))
                 {
                     return true;
                 }
 
-                if (mirrored && checkMatch(inv, x, y, false))
+                if (mirrored && checkMatch(inv, x, y, true))
                 {
                     return true;
                 }


### PR DESCRIPTION
ShapedOreRecipe is mirrored regardless of the mirrored value, which instead disables the original non mirrored version of the recipe.

This makes it so it now checks the non-mirrored recipe first and than if mirrored == true also checks the mirrored version
