### PR TITLE
Rendering fix for Semi-Transparent, Non-Liquid Blocks

### DIFF
--- a/client/net/minecraftforge/client/renderer/TessellatorState.java
+++ b/client/net/minecraftforge/client/renderer/TessellatorState.java
@@ -1,0 +1,35 @@
+package net.minecraftforge.client.renderer;
+
+public class TessellatorState {
+	private int[] mRawBuffer;
+	private int mRawBufferIndex;
+	private int mRawBufferSize;
+	
+	private int mVertexCount;
+	
+	private boolean mHasTexture;
+	private boolean mHasBrightness;
+	private boolean mHasNormal;
+	private boolean mHasColor;
+	
+	public TessellatorState(int[] buffer, int bufferIndex, int bufferSize, int vertexCount, boolean hasTexture, boolean hasBrightness, boolean hasNormal, boolean hasColor)
+	{
+		mRawBuffer = buffer;
+		mRawBufferIndex = bufferIndex;
+		mRawBufferSize = bufferSize;
+		mVertexCount = vertexCount;
+		mHasTexture = hasTexture;
+		mHasBrightness = hasBrightness;
+		mHasNormal = hasNormal;
+		mHasColor = hasColor;
+	}
+	
+	public int[] getRawBuffer() { return mRawBuffer; }
+	public int getRawBufferIndex() { return mRawBufferIndex; }
+	public int getRawBufferSize() { return mRawBufferSize; }
+	public int getVertexCount() { return mVertexCount; }
+	public boolean getHasTexture() { return mHasTexture; }
+	public boolean getHasBrightness() { return mHasBrightness; }
+	public boolean getHasNormal() { return mHasNormal; }
+	public boolean getHasColor() { return mHasColor; }
+}

--- a/client/net/minecraftforge/client/renderer/TriComparator.java
+++ b/client/net/minecraftforge/client/renderer/TriComparator.java
@@ -1,0 +1,51 @@
+package net.minecraftforge.client.renderer;
+
+import java.util.Comparator;
+
+public class TriComparator implements Comparator<Integer> {
+	private float mPlayerX;
+	private float mPlayerY;
+	private float mPlayerZ;
+	
+	private int[] mBuffer;
+	
+	public TriComparator(int[] buffer, float playerX, float playerY, float playerZ)
+	{
+		mBuffer = buffer;
+		mPlayerX = playerX;
+		mPlayerY = playerY;
+		mPlayerZ = playerZ;
+	}
+
+	@Override
+	public int compare(Integer left, Integer right) {
+		float leftVert1X = Float.intBitsToFloat(mBuffer[left]) - mPlayerX;
+		float leftVert1Y = Float.intBitsToFloat(mBuffer[left+1]) - mPlayerY;
+		float leftVert1Z = Float.intBitsToFloat(mBuffer[left+2]) - mPlayerZ;
+		float leftVert2X = Float.intBitsToFloat(mBuffer[left+8]) - mPlayerX;
+		float leftVert2Y = Float.intBitsToFloat(mBuffer[left+9]) - mPlayerY;
+		float leftVert2Z = Float.intBitsToFloat(mBuffer[left+10]) - mPlayerZ;
+		float leftVert3X = Float.intBitsToFloat(mBuffer[left+16]) - mPlayerX;
+		float leftVert3Y = Float.intBitsToFloat(mBuffer[left+17]) - mPlayerY;
+		float leftVert3Z = Float.intBitsToFloat(mBuffer[left+18]) - mPlayerZ;
+		
+		float rightVert1X = Float.intBitsToFloat(mBuffer[right]) - mPlayerX;
+		float rightVert1Y = Float.intBitsToFloat(mBuffer[right+1]) - mPlayerY;
+		float rightVert1Z = Float.intBitsToFloat(mBuffer[right+2]) - mPlayerZ;
+		float rightVert2X = Float.intBitsToFloat(mBuffer[right+8]) - mPlayerX;
+		float rightVert2Y = Float.intBitsToFloat(mBuffer[right+9]) - mPlayerY;
+		float rightVert2Z = Float.intBitsToFloat(mBuffer[right+10]) - mPlayerZ;
+		float rightVert3X = Float.intBitsToFloat(mBuffer[right+16]) - mPlayerX;
+		float rightVert3Y = Float.intBitsToFloat(mBuffer[right+17]) - mPlayerY;
+		float rightVert3Z = Float.intBitsToFloat(mBuffer[right+18]) - mPlayerZ;
+		
+		float leftScore = leftVert1X * leftVert1X + leftVert1Y * leftVert1Y + leftVert1Z * leftVert1Z + 
+				leftVert2X * leftVert2X + leftVert2Y * leftVert2Y + leftVert2Z * leftVert2Z + 
+				leftVert3X * leftVert3X + leftVert3Y * leftVert3Y + leftVert3Z * leftVert3Z;
+		float rightScore = rightVert1X * rightVert1X + rightVert1Y * rightVert1Y + rightVert1Z * rightVert1Z + 
+				rightVert2X * rightVert2X + rightVert2Y * rightVert2Y + rightVert2Z * rightVert2Z + 
+				rightVert3X * rightVert3X + rightVert3Y * rightVert3Y + rightVert3Z * rightVert3Z;
+		
+		return Float.compare(rightScore, leftScore);
+	}
+}

--- a/patches/minecraft/net/minecraft/client/renderer/EntityRenderer.java.patch
+++ b/patches/minecraft/net/minecraft/client/renderer/EntityRenderer.java.patch
@@ -1,5 +1,5 @@
---- ../src_base/minecraft/net/minecraft/client/renderer/EntityRenderer.java
-+++ ../src_work/minecraft/net/minecraft/client/renderer/EntityRenderer.java
+--- ../src_base/minecraft/net/minecraft/client/renderer/EntityRenderer.java 
++++ ../src_work/minecraft/net/minecraft/client/renderer/EntityRenderer.java 
 @@ -37,6 +37,11 @@
  import org.lwjgl.opengl.GLContext;
  import org.lwjgl.util.glu.GLU;
@@ -80,21 +80,70 @@
                      GL11.glEnable(GL11.GL_ALPHA_TEST);
                  }
              }
-@@ -1213,6 +1222,13 @@
+@@ -1166,7 +1175,10 @@
+             GL11.glDisable(GL11.GL_BLEND);
+             GL11.glEnable(GL11.GL_CULL_FACE);
+             GL11.glBlendFunc(GL11.GL_SRC_ALPHA, GL11.GL_ONE_MINUS_SRC_ALPHA);
+-            GL11.glDepthMask(true);
++            //This turns off depth writing- this was previously set to "on" for various reasons, but now
++            //that we have real transparency rendering in the following code, it needs to be turned off.
++            //we'll reactivate it when we're done with the transparency pass.
++            GL11.glDepthMask(false);
+             this.setupFog(0, par1);
+             GL11.glEnable(GL11.GL_BLEND);
+             GL11.glDisable(GL11.GL_CULL_FACE);
+@@ -1181,9 +1193,11 @@
+                     GL11.glShadeModel(GL11.GL_SMOOTH);
+                 }
+ 
+-                GL11.glColorMask(false, false, false, false);
+-                int l = renderglobal.sortAndRender(entityliving, 1, (double)par1);
+-
++                //Previously there was some code here that would turn off color buffer writing, render
++                //the transparency pass, turn back on color buffer writing, and re-render the pass.  This was done
++                //because previously, the transparency pass drawing was very bad and it was better to use that technique
++                //to prevent semi-transparent objects from being visible through each other.  The pass 1 rendering is
++                //better now, though, so the technique has been removed.
+                 if (this.mc.gameSettings.anaglyph)
+                 {
+                     if (anaglyphField == 0)
+@@ -1194,15 +1208,12 @@
+                     {
+                         GL11.glColorMask(true, false, false, true);
+                     }
++
++                    renderglobal.sortAndRender(entityliving, 1, (double)par1);
+                 }
+                 else
+                 {
+-                    GL11.glColorMask(true, true, true, true);
+-                }
+-
+-                if (l > 0)
+-                {
+-                    renderglobal.renderAllRenderLists(1, (double)par1);
++                    renderglobal.sortAndRender(entityliving, 1, (double)par1);
+                 }
+ 
+                 GL11.glShadeModel(GL11.GL_FLAT);
+@@ -1212,6 +1223,16 @@
+                 this.mc.mcProfiler.endStartSection("water");
                  renderglobal.sortAndRender(entityliving, 1, (double)par1);
              }
- 
++
++            //As promised, depth writing is now reactivated.
++            GL11.glDepthMask(true);
++
 +            RenderHelper.enableStandardItemLighting();
 +            this.mc.mcProfiler.endStartSection("entities");
 +            ForgeHooksClient.setRenderPass(1);
 +            renderglobal.renderEntities(entityliving.getPosition(par1), frustrum, par1);
 +            ForgeHooksClient.setRenderPass(-1);
 +            RenderHelper.disableStandardItemLighting();
-+
+ 
              GL11.glDepthMask(true);
              GL11.glEnable(GL11.GL_CULL_FACE);
-             GL11.glDisable(GL11.GL_BLEND);
-@@ -1222,15 +1238,18 @@
+@@ -1222,15 +1243,18 @@
                  entityplayer = (EntityPlayer)entityliving;
                  GL11.glDisable(GL11.GL_ALPHA_TEST);
                  this.mc.mcProfiler.endStartSection("outline");
@@ -116,7 +165,7 @@
              GL11.glDisable(GL11.GL_BLEND);
              this.mc.mcProfiler.endStartSection("weather");
              this.renderRainSnow(par1);
-@@ -1240,6 +1259,9 @@
+@@ -1240,6 +1264,9 @@
              {
                  this.renderCloudsCheck(renderglobal, par1);
              }

--- a/patches/minecraft/net/minecraft/client/renderer/RenderGlobal.java.patch
+++ b/patches/minecraft/net/minecraft/client/renderer/RenderGlobal.java.patch
@@ -1,5 +1,5 @@
---- ../src_base/minecraft/net/minecraft/client/renderer/RenderGlobal.java
-+++ ../src_work/minecraft/net/minecraft/client/renderer/RenderGlobal.java
+--- ../src_base/minecraft/net/minecraft/client/renderer/RenderGlobal.java 
++++ ../src_work/minecraft/net/minecraft/client/renderer/RenderGlobal.java 
 @@ -65,6 +65,9 @@
  import org.lwjgl.opengl.ARBOcclusionQuery;
  import org.lwjgl.opengl.GL11;
@@ -10,7 +10,66 @@
  @SideOnly(Side.CLIENT)
  public class RenderGlobal implements IWorldAccess
  {
-@@ -443,35 +446,47 @@
+@@ -199,6 +202,45 @@
+      * resorted)
+      */
+     double prevSortZ = -9999.0D;
++    
++    /**
++     * Previous X position when the last semi-transparency update occurred. We need to track transparency updates
++     * separately from render sorts, since they happen rather more often (when the player moves every 1 unit).
++     */
++    double prevTransparencyUpdateX = -9999.0D;
++    
++    /**
++     * Previous Y position when the last semi-transparency update occurred. We need to track transparency updates
++     * separately from render sorts, since they happen rather more often (when the player moves every 1 unit).
++     */
++    double prevTransparencyUpdateY = -9999.0D;
++    
++    /**
++     * Previous Z position when the last semi-transparency update occurred. We need to track transparency updates
++     * separately from render sorts, since they happen rather more often (when the player moves every 1 unit).
++     */
++    double prevTransparencyUpdateZ = -9999.0D;
++    
++    /**
++     * Previous viewpoint entity chunk X coordinate.  We track chunk coordinates now, because resorting renderers
++     * is no longer just an optimization- transparency will render incorrectly if the player changes chunks
++     * and we don't resort the renderers.
++     */
++    int prevChunkX = -999;
++    
++    /**
++     * Previous viewpoint entity chunk Y coordinate.  We track chunk coordinates now, because resorting renderers
++     * is no longer just an optimization- transparency will render incorrectly if the player changes chunks
++     * and we don't resort the renderers.
++     */
++    int prevChunkY = -999;
++    
++    /**
++     * Previous viewpoint entity chunk Z coordinate.  We track chunk coordinates now, because resorting renderers
++     * is no longer just an optimization- transparency will render incorrectly if the player changes chunks
++     * and we don't resort the renderers.
++     */
++    int prevChunkZ = -999;
+ 
+     /**
+      * The offset used to determine if a renderer is one of the sixteenth that are being updated this frame
+@@ -338,6 +380,12 @@
+         this.prevSortX = -9999.0D;
+         this.prevSortY = -9999.0D;
+         this.prevSortZ = -9999.0D;
++        this.prevTransparencyUpdateX = -9999.0D;
++        this.prevTransparencyUpdateY = -9999.0D;
++        this.prevTransparencyUpdateZ = -9999.0D;
++        this.prevChunkX = -999;
++        this.prevChunkY = -999;
++        this.prevChunkZ = -999;
+         RenderManager.instance.set(par1WorldClient);
+         this.theWorld = par1WorldClient;
+         this.globalRenderBlocks = new RenderBlocks(par1WorldClient);
+@@ -443,35 +491,47 @@
       */
      public void renderEntities(Vec3 par1Vec3, ICamera par2ICamera, float par3)
      {
@@ -71,7 +130,7 @@
                  ++this.countEntitiesRendered;
  
                  if (entity.isInRangeToRenderVec3D(par1Vec3))
-@@ -485,6 +500,7 @@
+@@ -485,6 +545,7 @@
              for (i = 0; i < list.size(); ++i)
              {
                  entity = (Entity)list.get(i);
@@ -79,7 +138,7 @@
  
                  if (entity.isInRangeToRenderVec3D(par1Vec3) && (entity.ignoreFrustumCheck || par2ICamera.isBoundingBoxInFrustum(entity.boundingBox) || entity.riddenByEntity == this.mc.thePlayer) && (entity != this.mc.renderViewEntity || this.mc.gameSettings.thirdPersonView != 0 || this.mc.renderViewEntity.isPlayerSleeping()) && this.theWorld.blockExists(MathHelper.floor_double(entity.posX), 0, MathHelper.floor_double(entity.posZ)))
                  {
-@@ -498,7 +514,11 @@
+@@ -498,7 +559,11 @@
  
              for (i = 0; i < this.tileEntities.size(); ++i)
              {
@@ -92,7 +151,78 @@
              }
  
              this.mc.entityRenderer.disableLightmap((double)par3);
-@@ -933,6 +953,12 @@
+@@ -653,14 +718,45 @@
+         double d5 = par1EntityLiving.posY - this.prevSortY;
+         double d6 = par1EntityLiving.posZ - this.prevSortZ;
+ 
+-        if (d4 * d4 + d5 * d5 + d6 * d6 > 16.0D)
++        //Resort when the viewpoint player changes chunks, not just when they move more than 4 blocks
++        //Reason for this: the subchunk first in the rendering order will render last, on top of everything else.
++        //So if you change chunks without moving 4 units since last reset, stuff from your old chunk
++        //will render on top of closer stuff in your new chunk unless you force a resort.
++        if ((this.prevChunkX != par1EntityLiving.chunkCoordX || this.prevChunkY != par1EntityLiving.chunkCoordY || this.prevChunkZ != par1EntityLiving.chunkCoordZ) || d4 * d4 + d5 * d5 + d6 * d6 > 16.0D)
+         {
+             this.prevSortX = par1EntityLiving.posX;
+             this.prevSortY = par1EntityLiving.posY;
+             this.prevSortZ = par1EntityLiving.posZ;
++            this.prevChunkX = par1EntityLiving.chunkCoordX;
++            this.prevChunkY = par1EntityLiving.chunkCoordY;
++            this.prevChunkZ = par1EntityLiving.chunkCoordZ;
++            
+             this.markRenderersForNewPosition(MathHelper.floor_double(par1EntityLiving.posX), MathHelper.floor_double(par1EntityLiving.posY), MathHelper.floor_double(par1EntityLiving.posZ));
+             Arrays.sort(this.sortedWorldRenderers, new EntitySorter(par1EntityLiving));
+-        }
++        } 
++        
++        //We track transparency updates separately, particularly since render resorts don't always force
++        //a rerender of nearby stuff, so it's just better to handle resorting totally separately.
++        double transparencyXDiff = par1EntityLiving.posX - this.prevTransparencyUpdateX;
++        double transparencyYDiff = par1EntityLiving.posY - this.prevTransparencyUpdateY;
++        double transparencyZDiff = par1EntityLiving.posZ - this.prevTransparencyUpdateZ;
++
++        if (transparencyXDiff * transparencyXDiff + transparencyYDiff * transparencyYDiff + transparencyZDiff * transparencyZDiff > 1.0D)
++        {
++            this.prevTransparencyUpdateX = par1EntityLiving.posX;
++            this.prevTransparencyUpdateY = par1EntityLiving.posY;
++            this.prevTransparencyUpdateZ = par1EntityLiving.posZ;
++            
++            //If you've moved a meter since the last time we did this, 
++            //rebuild transparency in your closest 27 subchunks (tends to be a 3x3x3 box of subchunks around the player)
++            for (int i = 0; i < 27; i++)
++            {
++                this.sortedWorldRenderers[i].rebuildTransparencyPass(par1EntityLiving);
++            }
++            
++            //Further away stuff doesn't have to be rebuilt as often and can be handled slowly by ordinary renderer resorts
++        }
++
+ 
+         RenderHelper.disableStandardItemLighting();
+         byte b0 = 0;
+@@ -818,7 +914,21 @@
+         this.glRenderLists.clear();
+         int l = 0;
+ 
+-        for (int i1 = par1; i1 < par2; ++i1)
++        //This renders subchunks in sorting order.  Only problem?  Minecraft likes to render in front-to-back order
++        //to cut down on pixel writes.  Well transparency has to be rendered in back-to-front to look right,
++        //so now we reverse this order in pass 1.
++        int start = par1;
++        int end = par2;
++        int step = 1;
++        
++        if (par3 == 1)
++        {
++            start = (this.sortedWorldRenderers.length-1)-par1;
++            end = (this.sortedWorldRenderers.length - 1)-par2;
++            step = -1;
++        }
++
++        for (int i1 = start; i1 != end; i1 += step)
+         {
+             if (par3 == 0)
+             {
+@@ -933,6 +1043,12 @@
       */
      public void renderSky(float par1)
      {
@@ -105,7 +235,7 @@
          if (this.mc.theWorld.provider.dimensionId == 1)
          {
              GL11.glDisable(GL11.GL_FOG);
-@@ -1171,6 +1197,13 @@
+@@ -1171,6 +1287,13 @@
  
      public void renderClouds(float par1)
      {
@@ -119,7 +249,7 @@
          if (this.mc.theWorld.provider.isSurfaceWorld())
          {
              if (this.mc.gameSettings.fancyGraphics)
-@@ -1599,6 +1632,11 @@
+@@ -1599,6 +1722,11 @@
      }
  
      public void drawBlockDamageTexture(Tessellator par1Tessellator, EntityPlayer par2EntityPlayer, float par3)

--- a/patches/minecraft/net/minecraft/client/renderer/Tessellator.java.patch
+++ b/patches/minecraft/net/minecraft/client/renderer/Tessellator.java.patch
@@ -1,15 +1,19 @@
---- ../src_base/minecraft/net/minecraft/client/renderer/Tessellator.java
-+++ ../src_work/minecraft/net/minecraft/client/renderer/Tessellator.java
-@@ -7,6 +7,8 @@
+--- ../src_base/minecraft/net/minecraft/client/renderer/Tessellator.java 
++++ ../src_work/minecraft/net/minecraft/client/renderer/Tessellator.java 
+@@ -7,6 +7,12 @@
  import java.nio.FloatBuffer;
  import java.nio.IntBuffer;
  import java.nio.ShortBuffer;
 +import java.util.Arrays;
++import java.util.PriorityQueue;
++
++import net.minecraftforge.client.renderer.TessellatorState;
++import net.minecraftforge.client.renderer.TriComparator;
 +
  import org.lwjgl.opengl.ARBVertexBufferObject;
  import org.lwjgl.opengl.GL11;
  import org.lwjgl.opengl.GLContext;
-@@ -14,6 +16,12 @@
+@@ -14,6 +20,12 @@
  @SideOnly(Side.CLIENT)
  public class Tessellator
  {
@@ -22,7 +26,7 @@
      /**
       * Boolean used to check whether quads should be drawn as two triangles. Initialized to false and never changed.
       */
-@@ -25,16 +33,16 @@
+@@ -25,16 +37,16 @@
      private static boolean tryVBO = false;
  
      /** The byte buffer used for GL allocation. */
@@ -43,7 +47,7 @@
  
      /** Raw integer array. */
      private int[] rawBuffer;
-@@ -110,10 +118,10 @@
+@@ -110,10 +122,10 @@
      public boolean isDrawing = false;
  
      /** Whether we are currently using VBO or not. */
@@ -56,7 +60,7 @@
  
      /**
       * The index of the last VBO used. This is used in round-robin fashion, sequentially, through the vboCount vertex
-@@ -122,25 +130,28 @@
+@@ -122,25 +134,28 @@
      private int vboIndex = 0;
  
      /** Number of vertex buffer objects allocated for use. */
@@ -98,7 +102,7 @@
          }
      }
  
-@@ -157,12 +168,23 @@
+@@ -157,12 +172,23 @@
          {
              this.isDrawing = false;
  
@@ -126,7 +130,7 @@
  
                  if (this.useVBO)
                  {
-@@ -248,11 +270,11 @@
+@@ -248,11 +274,11 @@
  
                  if (this.drawMode == 7 && convertQuadsToTriangles)
                  {
@@ -140,7 +144,7 @@
                  }
  
                  GL11.glDisableClientState(GL11.GL_VERTEX_ARRAY);
-@@ -278,6 +300,12 @@
+@@ -278,6 +304,12 @@
                  {
                      GL11.glDisableClientState(GL11.GL_NORMAL_ARRAY);
                  }
@@ -153,11 +157,90 @@
              }
  
              int i = this.rawBufferIndex * 4;
-@@ -442,6 +470,19 @@
+@@ -437,11 +469,98 @@
+     }
+ 
+     /**
++     *
++     * Sort the quads that have already been added to the tessellator instance before drawing. This is used when drawing
++     * pass 1 in order to sort quads from back to front for accurate semi-transparent block drawing.  This method returns
++     * a TessellatorState object with the current raw buffer, vertex caps, etc.  This can be restored later with
++     * restoreTesselatorState to resort and redraw when the player moves, without using a RenderBlocks to rebuild the
++     * quad list.
++     *
++     * @param playerX Viewpoint entity's current x position.
++     * @param playerY Viewpoint entity's current y position.
++     * @param playerZ Viewpoint entity's current Z position.
++     * @return The current state of the Tessellator instance.
++     */
++    public TessellatorState sortQuads(float playerX, float playerY, float playerZ)
++    {
++        //We need a cloned-off copy of the raw buffer, because the draw() method jacks with the internal rawBuffer
++        //and we want to be able to restore the buffer later.
++        int[] newBuffer = new int[this.rawBuffer.length];
++        //Priority queues are great because they implement the heapsort algorithm, which has a common case of
++        //nlog(n) and extremely reasonable memory requirements.  We use the TriComparator class to actually
++        //sort the quads.
++        PriorityQueue<Integer> queue = new PriorityQueue<Integer>(this.rawBuffer.length, new TriComparator(this.rawBuffer, playerX + (float)this.xOffset, playerY + (float)this.yOffset, playerZ + (float)this.zOffset));
++
++        int span = 32;
++        if (this.convertQuadsToTriangles)
++            span = 48;
++
++        //Add the rawbuffer index for each quad to the priority queue
++        for (int i = 0; i < this.rawBufferIndex; i += span)
++            queue.add(i);
++
++        //Then unload the priority queue and use it to sort the newBuffer[] from the rawBuffer[]
++        int newBufferIndex = 0;
++        while (!queue.isEmpty())
++        {
++            int index = queue.remove();
++
++            for (int i = 0; i < span; i++)
++            {
++                newBuffer[newBufferIndex+i] = this.rawBuffer[index+i];
++            }
++            newBufferIndex += span;
++        }
++
++        //Once we sort, copy back into the rawbuffer- the rawbuffer will go to the draw() command
++        //and the newBuffer will be stored in the TessellatorState to be used later.
++        for (int i = 0; i < this.rawBufferIndex; i++)
++        {
++            this.rawBuffer[i] = newBuffer[i];
++        }
++
++        return new TessellatorState(newBuffer, this.rawBufferIndex, this.rawBufferSize, this.vertexCount, this.hasTexture, this.hasBrightness, this.hasNormals, this.hasColor);
++    }
++
++    /**
++     *
++     * Restore the state of this Tessellator instance to where we were just before drawing the calling WorldRenderer's
++     * transparency pass.  We use this to resort and redraw the transparency pass while skipping a lot of processing,
++     * since we have to resort/redraw nearby chunk transparency passes pretty often.
++     *
++     * @param state The TessellatorState object returned for this renderer the last time we ran sortQuads()
++     */
++    public void restoreTessellatorState(TessellatorState state)
++    {
++        this.rawBuffer = state.getRawBuffer();
++        this.rawBufferIndex = state.getRawBufferIndex();
++        this.rawBufferSize = state.getRawBufferSize();
++        this.vertexCount = state.getVertexCount();
++        this.hasTexture = state.getHasTexture();
++        this.hasColor = state.getHasColor();
++        this.hasBrightness = state.getHasBrightness();
++        this.hasNormals = state.getHasNormal();
++    }
++
++    /**
+      * Adds a vertex with the specified x,y,z to the current draw call. It will trigger a draw() if the buffer gets
+      * full.
       */
      public void addVertex(double par1, double par3, double par5)
      {
-+        if (rawBufferIndex >= rawBufferSize - 32) 
++        if (rawBufferIndex >= rawBufferSize - 32)
 +        {
 +            if (rawBufferSize == 0)
 +            {
@@ -173,7 +256,7 @@
          ++this.addedVertices;
  
          if (this.drawMode == 7 && convertQuadsToTriangles && this.addedVertices % 4 == 0)
-@@ -500,12 +541,6 @@
+@@ -500,12 +619,6 @@
          this.rawBuffer[this.rawBufferIndex + 2] = Float.floatToRawIntBits((float)(par5 + this.zOffset));
          this.rawBufferIndex += 8;
          ++this.vertexCount;

--- a/patches/minecraft/net/minecraft/client/renderer/WorldRenderer.java.patch
+++ b/patches/minecraft/net/minecraft/client/renderer/WorldRenderer.java.patch
@@ -1,14 +1,30 @@
---- ../src_base/minecraft/net/minecraft/client/renderer/WorldRenderer.java
-+++ ../src_work/minecraft/net/minecraft/client/renderer/WorldRenderer.java
-@@ -17,13 +17,15 @@
+--- ../src_base/minecraft/net/minecraft/client/renderer/WorldRenderer.java 
++++ ../src_work/minecraft/net/minecraft/client/renderer/WorldRenderer.java 
+@@ -6,10 +6,12 @@
+ import java.util.HashSet;
+ import java.util.List;
+ import net.minecraft.block.Block;
++import net.minecraft.client.Minecraft;
+ import net.minecraft.client.renderer.culling.ICamera;
+ import net.minecraft.client.renderer.entity.RenderItem;
+ import net.minecraft.client.renderer.tileentity.TileEntityRenderer;
+ import net.minecraft.entity.Entity;
++import net.minecraft.entity.EntityLiving;
+ import net.minecraft.tileentity.TileEntity;
+ import net.minecraft.util.AxisAlignedBB;
+ import net.minecraft.world.ChunkCache;
+@@ -17,13 +19,18 @@
  import net.minecraft.world.chunk.Chunk;
  import org.lwjgl.opengl.GL11;
  
 +import net.minecraftforge.client.ForgeHooksClient;
++import net.minecraftforge.client.renderer.TessellatorState;
 +
  @SideOnly(Side.CLIENT)
  public class WorldRenderer
  {
++    private TessellatorState mTransparencyPassTessState = null;
++
      /** Reference to the World object. */
      public World worldObj;
      private int glRenderList = -1;
@@ -17,15 +33,30 @@
      public static int chunksUpdated = 0;
      public int posX;
      public int posY;
-@@ -192,15 +194,16 @@
-                                         GL11.glTranslatef(-8.0F, -8.0F, -8.0F);
-                                         GL11.glScalef(f, f, f);
-                                         GL11.glTranslatef(8.0F, 8.0F, 8.0F);
+@@ -166,6 +173,8 @@
+                 RenderBlocks renderblocks = new RenderBlocks(chunkcache);
+                 this.bytesDrawn = 0;
+ 
++                    this.mTransparencyPassTessState = null;
++
+                 for (int l1 = 0; l1 < 2; ++l1)
+                 {
+                     boolean flag = false;
+@@ -185,22 +194,15 @@
+                                     if (!flag2)
+                                     {
+                                         flag2 = true;
+-                                        GL11.glNewList(this.glRenderList + l1, GL11.GL_COMPILE);
+-                                        GL11.glPushMatrix();
+-                                        this.setupGLTranslation();
+-                                        float f = 1.000001F;
+-                                        GL11.glTranslatef(-8.0F, -8.0F, -8.0F);
+-                                        GL11.glScalef(f, f, f);
+-                                        GL11.glTranslatef(8.0F, 8.0F, 8.0F);
 -                                        tessellator.startDrawingQuads();
 -                                        tessellator.setTranslation((double)(-this.posX), (double)(-this.posY), (double)(-this.posZ));
-+                                        //ForgeHooksClient.beforeRenderPass(l1); Noop fo now, TODO: Event if anyone needs
-+                                        Tessellator.instance.startDrawingQuads();
-+                                        Tessellator.instance.setTranslation((double)(-this.posX), (double)(-this.posY), (double)(-this.posZ));
++                                        //The logic that used to be here was extracted to startRenderPass()
++                                        startRenderPass(l1);
                                      }
  
                                      Block block = Block.blocksList[l2];
@@ -37,7 +68,7 @@
                                          {
                                              TileEntity tileentity = chunkcache.getBlockTileEntity(k2, i2, j2);
  
-@@ -212,14 +215,15 @@
+@@ -212,14 +214,15 @@
  
                                          int i3 = block.getRenderBlockPass();
  
@@ -56,17 +87,100 @@
                                      }
                                  }
                              }
-@@ -228,10 +232,11 @@
+@@ -228,10 +231,9 @@
  
                      if (flag2)
                      {
 -                        this.bytesDrawn += tessellator.draw();
-+                        //ForgeHooksClient.afterRenderPass(l1); Noop fo now, TODO: Event if anyone needs
-+                        this.bytesDrawn += Tessellator.instance.draw();
-                         GL11.glPopMatrix();
-                         GL11.glEndList();
+-                        GL11.glPopMatrix();
+-                        GL11.glEndList();
 -                        tessellator.setTranslation(0.0D, 0.0D, 0.0D);
-+                        Tessellator.instance.setTranslation(0.0D, 0.0D, 0.0D);
++                        //The logic that used to be here was extracted to endRenderPass()
++                        EntityLiving player = Minecraft.getMinecraft().renderViewEntity;
++                        endRenderPass(l1, player);
                      }
                      else
                      {
+@@ -262,6 +264,74 @@
+     }
+ 
+     /**
++     *
++     * This logic was extracted from updateRenderer() so that it could also be used in rebuildTransparencyPass(), a
++     * new public method.  It preps a render pass to be drawn to the tessellator by a RenderBlocks instance.
++     *
++     * @param pass The index of the pass to be started rendering.
++     */
++    private void startRenderPass(int pass)
++    {
++        GL11.glNewList(this.glRenderList + pass, GL11.GL_COMPILE);
++        GL11.glPushMatrix();
++        this.setupGLTranslation();
++        float f = 1.000001F;
++        GL11.glTranslatef(-8.0F, -8.0F, -8.0F);
++        GL11.glScalef(f, f, f);
++        GL11.glTranslatef(8.0F, 8.0F, 8.0F);
++        // ForgeHooksClient.beforeRenderPass(pass); Noop fo now, TODO: Event if
++        Tessellator.instance.startDrawingQuads();
++        Tessellator.instance.setTranslation((double) (-this.posX), (double) (-this.posY), (double) (-this.posZ));
++    }
++
++    /**
++     *
++     * This lgoic was extracted from updateRenderer() so that it could also be used in rebuildTransparencyPass(), a
++     * new public method.  It flushes the rendered quads out to the Tesselator instance's draw() method.  It also
++     * now handles quad sorting.
++     *
++     * @param pass The index of the pass to be started rendering.
++     * @param viewpoint The viewpoint to be renderered from- we use this to establish a position to base the transparent object quad sorting off of
++     */
++    private void endRenderPass(int pass, EntityLiving viewpoint)
++    {
++        //ForgeHooksClient.afterRenderPass(pass); Noop fo now, TODO: Event if anyone needs
++
++        if (pass == 1) {
++            //If we're drawing the semi-transparent pass, we now need to sort all quads in the pass from back to front
++            //in order to allow closer objects to correctly blend over further-away objects
++            this.mTransparencyPassTessState = Tessellator.instance.sortQuads((float)viewpoint.posX, (float)viewpoint.posY, (float)viewpoint.posZ);
++        }
++
++        this.bytesDrawn += Tessellator.instance.draw();
++        GL11.glPopMatrix();
++        GL11.glEndList();
++        Tessellator.instance.setTranslation(0.0D, 0.0D, 0.0D);
++    }
++
++    /**
++     *
++     * A new public method that tries to rebuild quads for the transparency pass in the lightest-weight way possible.
++     * This method exists because in order to keep semi-transparent objects rendering properly, their quads need to be
++     * resorted rather often.  As a result, we tend to use this method to rebuild the transparency pass of nearby subchunks
++     * when the player moves even a fairly small amount.
++     *
++     * @param viewpoint The viewpoint entity to base the quad sorting off of.
++     */
++    public void rebuildTransparencyPass(EntityLiving viewpoint) {
++
++        if (this.mTransparencyPassTessState == null || this.skipRenderPass[1])
++            return;
++
++        startRenderPass(1);
++
++        // Retrieve the old rendered stuff
++        Tessellator.instance.restoreTessellatorState(this.mTransparencyPassTessState);
++
++        endRenderPass(1, viewpoint);
++    }
++
++    /**
+      * Returns the distance of this chunk renderer to the entity without performing the final normalizing square root,
+      * for performance reasons.
+      */
+@@ -285,6 +355,7 @@
+ 
+         this.isInFrustum = false;
+         this.isInitialized = false;
++        this.mTransparencyPassTessState = null;
+     }
+ 
+     public void stopRendering()


### PR DESCRIPTION
Hello, Minecraft has a fairly well-known bug detailed here:  https://mojang.atlassian.net/browse/MC-1379

Essentially, the problem is that semi-transparent render objects must be rendered back to front, and minecraft's current behavior is this:
- Semi-transparent quads are rendered in sub-chunk order, front to back.  Each sub-chunk renders its semi-transparent quads in arbitrary order.
- Particles, liquids, and clouds are each rendered in separate phases from semi-transparent blocks and from each other, in a fixed order.

This causes a number of problems detailed in the linked bug.  This task only fixes the following problems:
- When viewing a semi-transparent block in Fast graphics mode, arbitrary backfaces of the object are rendered or not rendered. 
- When looking through a semi-transparent block, other semi-transparent blocks in the same subchunk on Fast graphics mode will have arbitrary faces rendered or not rendered.
- When looking through a semi-transparent block, other semi-transparent blocks in other subchunks, or in the same subchunk on Fancy graphics mode, will not appear.

Mojang deals with this issue by using very few alpha-blended non-liquid blocks (glass, for instance, is not actually blended) and using very high opacity for those blocks which are alpha blended (such as ice).  

For modders who would like to provide basics such as MineFactory Reloaded's stained glass, this is a very serious issue that directly impacts the player experience and the ability of modders to be creative.

Thank you for reading all this, and please know that I am prepared to make any changes necessary to help this fit with Forge code and satisfy your coding standards.  I am very serious about this fix finding its way into player hands.  Thank you.
