### PR TITLE
Metadata sensitive onBlockDestroyedByExplosion

### DIFF
--- a/patches/minecraft/net/minecraft/block/Block.java.patch
+++ b/patches/minecraft/net/minecraft/block/Block.java.patch
@@ -155,7 +155,7 @@
      }
  
      /**
-@@ -1435,4 +1455,881 @@
+@@ -1435,4 +1455,898 @@
          canBlockGrass[0] = true;
          StatList.initBreakableStats();
      }
@@ -721,6 +721,23 @@
 +    public float getExplosionResistance(Entity par1Entity, World world, int x, int y, int z, double explosionX, double explosionY, double explosionZ)
 +    {
 +        return getExplosionResistance(par1Entity);
++    }
++
++    /**
++     * Called when the block is destroyed by an explosion.
++     * Useful for allowing the block to take into account tile entities,
++     * metadata, etc. when exploded, before it is removed.
++     *
++     * @param world The current world
++     * @param x X Position
++     * @param y Y Position
++     * @param z Z Position
++     * @param Explosion The explosion instance affecting the block
++     */
++    public void onBlockExploded(World world, int x, int y, int z, Explosion explosion)
++    {
++        world.setBlockToAir(x, y, z);
++        onBlockDestroyedByExplosion(world, x, y, z, explosion);
 +    }
 +
 +    /**

--- a/patches/minecraft/net/minecraft/world/Explosion.java.patch
+++ b/patches/minecraft/net/minecraft/world/Explosion.java.patch
@@ -9,3 +9,13 @@
                                  f1 -= (f3 + 0.3F) * f2;
                              }
  
+@@ -222,8 +222,7 @@
+                         block.dropBlockAsItemWithChance(this.worldObj, i, j, k, this.worldObj.getBlockMetadata(i, j, k), 1.0F / this.explosionSize, 0);
+                     }
+ 
+-                    this.worldObj.setBlock(i, j, k, 0, 0, 3);
+-                    block.onBlockDestroyedByExplosion(this.worldObj, i, j, k, this);
++                    block.onBlockExploded(this.worldObj, i, j, k, this);
+                 }
+             }
+         }


### PR DESCRIPTION
An explosion removes the block before calling onBlockDestroyedByExplosion, meaning that it is impossible to get the metadata of the destroyed block. This PR overloads the standard Block.onBlockDestroyedByExplosion method with a new one that gives the block's metadata as one of its parameters. By default, this new method simply calls the old one, so standard explosion functionality will not be altered.
