### PR TITLE
Change BlockFluid.theIcon from private to protected

### DIFF
--- a/common/forge_at.cfg
+++ b/common/forge_at.cfg
@@ -146,3 +146,5 @@ public xu.m #FD:PotionHelper/field_77927_l #potionRequirements
 public xu.n #FD:PotionHelper/field_77928_m #potionAmplifiers
 #PotionEffect
 public ml.b #FD:PotionEffect/field_76460_b #duration
+#BlockFluid
+protected amy.a #FD:BlockFluid/field_94425_a #theIcon


### PR DESCRIPTION
Reason: For BC to avoid having to make a new Icon[] variable and saves an identical override of getBlockTextureFromSideAndMetadata just to return the different icon field
