### PR TITLE
Added support for common (java style) event listeners

### DIFF
--- a/common/net/minecraftforge/event/EventBus.java
+++ b/common/net/minecraftforge/event/EventBus.java
@@ -61,7 +61,30 @@ public class EventBus
             }
         }
     }
+    
+    public void register(Class<?> eventType, EventPriority priority, IEventListener listener)
+    {
+        try
+        {
+            Constructor<?> ctr = eventType.getConstructor();
+            ctr.setAccessible(true);
+            Event event = (Event)ctr.newInstance();
+            event.getListenerList().register(busID, priority, listener);
 
+            ArrayList<IEventListener> others = listeners.get(listener); 
+            if (others == null)
+            {
+                others = new ArrayList<IEventListener>();
+                listeners.put(listener, others);
+            }
+            others.add(listener);
+        }
+        catch (Exception e)
+        {
+            e.printStackTrace();
+        }
+    }
+    
     private void register(Class<?> eventType, Object target, Method method)
     {
         try


### PR DESCRIPTION
There seems to be no good reason for me to force modders to know at
compile time which events their mod should listen to at runtime. With
this minor change Forge offers the modders a higher degree of freedom
when implementing event handlers.
