### PR TITLE
Add cancellable LivingDespawnEvent for despawnEntity()

### DIFF
--- a/common/net/minecraftforge/event/ForgeEventFactory.java
+++ b/common/net/minecraftforge/event/ForgeEventFactory.java
@@ -11,6 +11,7 @@ import net.minecraft.world.World;
 import net.minecraft.world.WorldServer;
 import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.event.Event.Result;
+import net.minecraftforge.event.entity.living.LivingDespawnEvent;
 import net.minecraftforge.event.entity.living.LivingSpawnEvent;
 import net.minecraftforge.event.entity.player.PlayerDestroyItemEvent;
 import net.minecraftforge.event.entity.player.PlayerEvent;
@@ -66,5 +67,10 @@ public class ForgeEventFactory
             return null;
         }
         return event.list;
+    }
+    
+    public static boolean canEntityDespawn(EntityLiving entity, boolean canDespawn)
+    {
+        return !MinecraftForge.EVENT_BUS.post(new LivingDespawnEvent(entity, canDespawn));
     }
 }

--- a/common/net/minecraftforge/event/entity/living/LivingDespawnEvent.java
+++ b/common/net/minecraftforge/event/entity/living/LivingDespawnEvent.java
@@ -1,0 +1,23 @@
+package net.minecraftforge.event.entity.living;
+
+import net.minecraft.entity.EntityLiving;
+import net.minecraftforge.event.Cancelable;
+
+/**
+ * Fired before the entity is checked for despawning
+ * Cancelling will cause entity to not despawn
+ */
+@Cancelable
+public class LivingDespawnEvent extends LivingEvent {
+
+    /**
+     * Whether this Entity would usually Despawn
+     */
+    public final boolean canDespawn;
+
+    public LivingDespawnEvent(EntityLiving entity, boolean canDespawn)
+    {
+        super(entity);
+        this.canDespawn = canDespawn;
+    }
+}

--- a/patches/minecraft/net/minecraft/entity/EntityLiving.java.patch
+++ b/patches/minecraft/net/minecraft/entity/EntityLiving.java.patch
@@ -8,19 +8,20 @@
  import net.minecraft.entity.passive.EntityWolf;
  import net.minecraft.entity.player.EntityPlayer;
  import net.minecraft.entity.projectile.EntityArrow;
-@@ -50,6 +51,11 @@
+@@ -50,6 +51,12 @@
  import net.minecraft.world.World;
  import net.minecraft.world.WorldServer;
  
 +import net.minecraftforge.common.ForgeHooks;
 +import net.minecraftforge.common.MinecraftForge;
++import net.minecraftforge.event.ForgeEventFactory;
 +import net.minecraftforge.event.entity.living.*;
 +import static net.minecraftforge.event.entity.living.LivingEvent.*;
 +
  public abstract class EntityLiving extends Entity
  {
      /**
-@@ -398,6 +404,7 @@
+@@ -398,6 +405,7 @@
      public void setAttackTarget(EntityLiving par1EntityLiving)
      {
          this.attackTarget = par1EntityLiving;
@@ -28,7 +29,7 @@
      }
  
      /**
-@@ -494,6 +501,7 @@
+@@ -494,6 +502,7 @@
      {
          this.entityLivingToAttack = par1EntityLiving;
          this.revengeTimer = this.entityLivingToAttack != null ? 100 : 0;
@@ -36,7 +37,7 @@
      }
  
      protected void entityInit()
-@@ -805,6 +813,11 @@
+@@ -805,6 +814,11 @@
       */
      public void onUpdate()
      {
@@ -48,7 +49,7 @@
          super.onUpdate();
  
          if (!this.worldObj.isRemote)
-@@ -990,6 +1003,11 @@
+@@ -990,6 +1004,11 @@
       */
      public boolean attackEntityFrom(DamageSource par1DamageSource, int par2)
      {
@@ -60,7 +61,7 @@
          if (this.isEntityInvulnerable())
          {
              return false;
-@@ -1227,6 +1245,11 @@
+@@ -1227,6 +1246,11 @@
      {
          if (!this.isEntityInvulnerable())
          {
@@ -72,7 +73,7 @@
              par2 = this.applyArmorCalculations(par1DamageSource, par2);
              par2 = this.applyPotionDamageCalculations(par1DamageSource, par2);
              int j = this.getHealth();
-@@ -1293,6 +1316,11 @@
+@@ -1293,6 +1317,11 @@
       */
      public void onDeath(DamageSource par1DamageSource)
      {
@@ -84,7 +85,7 @@
          Entity entity = par1DamageSource.getEntity();
          EntityLiving entityliving = this.func_94060_bK();
  
-@@ -1317,6 +1345,10 @@
+@@ -1317,6 +1346,10 @@
                  i = EnchantmentHelper.getLootingModifier((EntityLiving)entity);
              }
  
@@ -95,7 +96,7 @@
              if (!this.isChild() && this.worldObj.getGameRules().getGameRuleBooleanValue("doMobLoot"))
              {
                  this.dropFewItems(this.recentlyHit > 0, i);
-@@ -1324,7 +1356,7 @@
+@@ -1324,7 +1357,7 @@
  
                  if (this.recentlyHit > 0)
                  {
@@ -104,7 +105,7 @@
  
                      if (j < 5)
                      {
-@@ -1332,6 +1364,16 @@
+@@ -1332,6 +1365,16 @@
                      }
                  }
              }
@@ -121,7 +122,7 @@
          }
  
          this.worldObj.setEntityState(this, (byte)3);
-@@ -1376,6 +1418,12 @@
+@@ -1376,6 +1419,12 @@
       */
      protected void fall(float par1)
      {
@@ -134,7 +135,7 @@
          super.fall(par1);
          int i = MathHelper.ceiling_float_int(par1 - 3.0F);
  
-@@ -1578,7 +1626,7 @@
+@@ -1578,7 +1627,7 @@
          int j = MathHelper.floor_double(this.boundingBox.minY);
          int k = MathHelper.floor_double(this.posZ);
          int l = this.worldObj.getBlockId(i, j, k);
@@ -143,7 +144,7 @@
      }
  
      /**
-@@ -2000,6 +2048,7 @@
+@@ -2000,6 +2049,7 @@
          }
  
          this.isAirBorne = true;
@@ -151,7 +152,31 @@
      }
  
      /**
-@@ -2552,8 +2601,6 @@
+@@ -2047,7 +2097,10 @@
+     {
+         ++this.entityAge;
+         this.worldObj.theProfiler.startSection("checkDespawn");
+-        this.despawnEntity();
++        if (ForgeEventFactory.canEntityDespawn(this, canDespawn()))
++        {
++            this.despawnEntity();
++        }
+         this.worldObj.theProfiler.endSection();
+         this.worldObj.theProfiler.startSection("sensing");
+         this.senses.clearSensingCache();
+@@ -2083,7 +2136,10 @@
+     protected void updateEntityActionState()
+     {
+         ++this.entityAge;
+-        this.despawnEntity();
++        if (ForgeEventFactory.canEntityDespawn(this, canDespawn()))
++        {
++            this.despawnEntity();
++        }
+         this.moveStrafing = 0.0F;
+         this.moveForward = 0.0F;
+         float f = 8.0F;
+@@ -2552,8 +2608,6 @@
          return this.getCreatureAttribute() == EnumCreatureAttribute.UNDEAD;
      }
  
@@ -160,7 +185,7 @@
      /**
       * Remove the speified potion effect from this entity.
       */
-@@ -3077,4 +3124,42 @@
+@@ -3077,4 +3131,42 @@
      {
          this.canPickUpLoot = par1;
      }


### PR DESCRIPTION
Allows for circumventing entity despawning. Cancelling will cause Entity not to despawn.

Use Cases:
- Cancel despawning; forcing persistence
- Injecting alternative despawning algorithms; i.e. despawn in low light levels, when on a block, inside an area
