### PR TITLE
Enchantment table hook

### DIFF
--- a/common/net/minecraftforge/common/ForgeHooks.java
+++ b/common/net/minecraftforge/common/ForgeHooks.java
@@ -370,4 +370,23 @@ public class ForgeHooks
         player.joinEntityItemWithWorld(event.entityItem);
         return event.entityItem;
     }
+    
+    public static boolean givesEnchantPower(World world, int x, int y, int z)
+    {
+        if (world.isAirBlock(x, y, z))
+        {
+            return false;
+        }
+        
+        Block block = Block.blocksList[world.getBlockId(x, y, z)];
+        
+        if (block == null)
+        {
+            return false;
+        }
+        else
+        {
+            return block.givesEnchantPower(world, x, y, z);
+        }
+    }
 }

--- a/patches/minecraft/net/minecraft/block/Block.java.patch
+++ b/patches/minecraft/net/minecraft/block/Block.java.patch
@@ -155,7 +155,7 @@
      }
  
      /**
-@@ -1435,4 +1455,881 @@
+@@ -1435,4 +1455,895 @@
          canBlockGrass[0] = true;
          StatList.initBreakableStats();
      }
@@ -1035,5 +1035,19 @@
 +    public ForgeDirection[] getValidRotations(World worldObj, int x, int y, int z)
 +    {
 +        return RotationHelper.getValidVanillaBlockRotations(this);
++    }
++    
++    /**
++     * Determines if this block can give enchanting power to an enchanting table.
++     * 
++     * @param world The world
++     * @param x X position
++     * @param y Y position
++     * @param z Z potition
++     * @return True, supply enchanting power to the table.
++     */
++    public boolean givesEnchantPower(World world, int x, int y, int z)
++    {
++        return blockID == bookShelf.blockID;
 +    }
  }

--- a/patches/minecraft/net/minecraft/inventory/ContainerEnchantment.java.patch
+++ b/patches/minecraft/net/minecraft/inventory/ContainerEnchantment.java.patch
@@ -1,0 +1,51 @@
+--- ../src_base/minecraft/net/minecraft/inventory/ContainerEnchantment.java
++++ ../src_work/minecraft/net/minecraft/inventory/ContainerEnchantment.java
+@@ -12,6 +12,7 @@
+ import net.minecraft.item.Item;
+ import net.minecraft.item.ItemStack;
+ import net.minecraft.world.World;
++import net.minecraftforge.common.ForgeHooks;
+ 
+ public class ContainerEnchantment extends Container
+ {
+@@ -116,34 +117,34 @@
+                         {
+                             if ((j != 0 || k != 0) && this.worldPointer.isAirBlock(this.posX + k, this.posY, this.posZ + j) && this.worldPointer.isAirBlock(this.posX + k, this.posY + 1, this.posZ + j))
+                             {
+-                                if (this.worldPointer.getBlockId(this.posX + k * 2, this.posY, this.posZ + j * 2) == Block.bookShelf.blockID)
++                                if (ForgeHooks.givesEnchantPower(worldPointer, this.posX + k * 2, this.posY, this.posZ + j * 2))
+                                 {
+                                     ++i;
+                                 }
+ 
+-                                if (this.worldPointer.getBlockId(this.posX + k * 2, this.posY + 1, this.posZ + j * 2) == Block.bookShelf.blockID)
++                                if (ForgeHooks.givesEnchantPower(worldPointer, this.posX + k * 2, this.posY + 1, this.posZ + j * 2))
+                                 {
+                                     ++i;
+                                 }
+ 
+                                 if (k != 0 && j != 0)
+                                 {
+-                                    if (this.worldPointer.getBlockId(this.posX + k * 2, this.posY, this.posZ + j) == Block.bookShelf.blockID)
++                                    if (ForgeHooks.givesEnchantPower(worldPointer, this.posX + k * 2, this.posY, this.posZ + j))
+                                     {
+                                         ++i;
+                                     }
+ 
+-                                    if (this.worldPointer.getBlockId(this.posX + k * 2, this.posY + 1, this.posZ + j) == Block.bookShelf.blockID)
++                                    if (ForgeHooks.givesEnchantPower(worldPointer, this.posX + k * 2, this.posY + 1, this.posZ + j))
+                                     {
+                                         ++i;
+                                     }
+ 
+-                                    if (this.worldPointer.getBlockId(this.posX + k, this.posY, this.posZ + j * 2) == Block.bookShelf.blockID)
++                                    if (ForgeHooks.givesEnchantPower(worldPointer, this.posX + k, this.posY, this.posZ + j * 2))
+                                     {
+                                         ++i;
+                                     }
+ 
+-                                    if (this.worldPointer.getBlockId(this.posX + k, this.posY + 1, this.posZ + j * 2) == Block.bookShelf.blockID)
++                                    if (ForgeHooks.givesEnchantPower(worldPointer, this.posX + k, this.posY + 1, this.posZ + j * 2))
+                                     {
+                                         ++i;
+                                     }


### PR DESCRIPTION
Adds a small method in Block.java to specify i the block can supply an Enchantment Table with enchanting power.

This replaces the hard-coded ID check for Bookshelves.
