### PR TITLE
Added a new event for putting items in items frames

### DIFF
--- a/common/net/minecraftforge/event/entity/item/PutItemInFrameEvent.java
+++ b/common/net/minecraftforge/event/entity/item/PutItemInFrameEvent.java
@@ -1,0 +1,32 @@
+package net.minecraftforge.event.entity.item;
+
+import net.minecraft.entity.item.EntityItemFrame;
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.item.ItemStack;
+import net.minecraftforge.event.Cancelable;
+import net.minecraftforge.event.entity.EntityEvent;
+
+/**
+ * Called right before an item is placed in an item frame. Cancel to prevent further processing (prevent the player from putting the item in).
+ */
+@Cancelable
+public class PutItemInFrameEvent extends EntityEvent
+{
+
+    public ItemStack item;
+    public EntityPlayer player;
+
+    /**
+     * Creates a new event for putting an item in an item frame.
+     *
+     * @param frame The EntityItemFrame instance.
+     * @param item The item stack that is about to be put in.
+     * @param player The player who tried to put the item in.
+     */
+    public PutItemInFrameEvent(EntityItemFrame frame, ItemStack item, EntityPlayer player)
+    {
+        super(frame);
+        this.item = item;
+        this.player = player;
+    }
+}

--- a/patches/minecraft/net/minecraft/entity/item/EntityItemFrame.patch
+++ b/patches/minecraft/net/minecraft/entity/item/EntityItemFrame.patch
@@ -1,0 +1,32 @@
+--- ../src_base/minecraft/net/minecraft/entity/item/EntityItemFrame.java
++++ ../src_work/minecraft/net/minecraft/entity/item/EntityItemFrame.java
+@@ -8,6 +8,8 @@
+ import net.minecraft.item.ItemStack;
+ import net.minecraft.nbt.NBTTagCompound;
+ import net.minecraft.world.World;
++import net.minecraftforge.common.MinecraftForge;
++import net.minecraftforge.event.entity.item.PutItemInFrameEvent;
+ 
+ public class EntityItemFrame extends EntityHanging
+ {
+@@ -145,9 +147,14 @@
+             if (itemstack != null && !this.worldObj.isRemote)
+             {
+-                this.setDisplayedItem(itemstack);
+-
+-                if (!par1EntityPlayer.capabilities.isCreativeMode && --itemstack.stackSize <= 0)
+-                {
+-                    par1EntityPlayer.inventory.setInventorySlotContents(par1EntityPlayer.inventory.currentItem, (ItemStack)null);
+-                }
++                PutItemInFrameEvent event = new PutItemInFrameEvent(this, itemstack, par1EntityPlayer);
++
++                if (!MinecraftForge.EVENT_BUS.post(event))
++                {
++                    this.setDisplayedItem(itemstack);
++
++                    if (!par1EntityPlayer.capabilities.isCreativeMode && --itemstack.stackSize <= 0)
++                    {
++                        par1EntityPlayer.inventory.setInventorySlotContents(par1EntityPlayer.inventory.currentItem, (ItemStack)null);
++                    }
++                }
+             }


### PR DESCRIPTION
Added a new event that is called before an item is displayed in an item frame. You can cancel the event to prevent the item from being placed and used up. Very handy for blocks rendered with TESRs when you just can't make them display properly because of, for example, rotation issues or misplacement issues.

(seems to say something like "fuzz 1" when applying the patch file, but it is tested and it works and nothing is wrong with the code)
