### PR TITLE
Separate EQUIPPED and EQUIPPED_FIRST_PERSON Item Render Types

### DIFF
--- a/client/net/minecraftforge/client/ForgeHooksClient.java
+++ b/client/net/minecraftforge/client/ForgeHooksClient.java
@@ -1,26 +1,18 @@
 package net.minecraftforge.client;
 
-import java.util.HashMap;
+import static net.minecraftforge.client.IItemRenderer.ItemRenderType.ENTITY;
+import static net.minecraftforge.client.IItemRenderer.ItemRenderType.EQUIPPED;
+import static net.minecraftforge.client.IItemRenderer.ItemRenderType.INVENTORY;
+import static net.minecraftforge.client.IItemRenderer.ItemRendererHelper.BLOCK_3D;
+import static net.minecraftforge.client.IItemRenderer.ItemRendererHelper.ENTITY_BOBBING;
+import static net.minecraftforge.client.IItemRenderer.ItemRendererHelper.ENTITY_ROTATION;
+import static net.minecraftforge.client.IItemRenderer.ItemRendererHelper.EQUIPPED_BLOCK;
+import static net.minecraftforge.client.IItemRenderer.ItemRendererHelper.INVENTORY_BLOCK;
+
 import java.util.Random;
-import java.util.TreeSet;
 
-import org.lwjgl.opengl.GL11;
-import org.lwjgl.opengl.GL12;
-
-import cpw.mods.fml.client.FMLClientHandler;
-
-import net.minecraft.client.Minecraft;
 import net.minecraft.block.Block;
-import net.minecraft.entity.item.EntityItem;
-import net.minecraft.entity.Entity;
-import net.minecraft.entity.EntityLiving;
-import net.minecraft.entity.player.EntityPlayer;
-import net.minecraft.client.texturepacks.ITexturePack;
-import net.minecraft.item.Item;
-import net.minecraft.item.ItemBlock;
-import net.minecraft.item.ItemStack;
-import net.minecraft.util.MathHelper;
-import net.minecraft.util.MovingObjectPosition;
+import net.minecraft.client.Minecraft;
 import net.minecraft.client.model.ModelBiped;
 import net.minecraft.client.renderer.RenderBlocks;
 import net.minecraft.client.renderer.RenderEngine;
@@ -28,14 +20,28 @@ import net.minecraft.client.renderer.RenderGlobal;
 import net.minecraft.client.renderer.Tessellator;
 import net.minecraft.client.renderer.entity.RenderItem;
 import net.minecraft.client.renderer.texture.TextureMap;
+import net.minecraft.client.texturepacks.ITexturePack;
+import net.minecraft.entity.Entity;
+import net.minecraft.entity.EntityLiving;
+import net.minecraft.entity.item.EntityItem;
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.item.Item;
+import net.minecraft.item.ItemBlock;
+import net.minecraft.item.ItemStack;
+import net.minecraft.util.MathHelper;
+import net.minecraft.util.MovingObjectPosition;
+import net.minecraftforge.client.IItemRenderer.ItemRenderType;
 import net.minecraftforge.client.event.DrawBlockHighlightEvent;
 import net.minecraftforge.client.event.RenderWorldLastEvent;
 import net.minecraftforge.client.event.TextureLoadEvent;
 import net.minecraftforge.client.event.TextureStitchEvent;
 import net.minecraftforge.common.IArmorTextureProvider;
 import net.minecraftforge.common.MinecraftForge;
-import static net.minecraftforge.client.IItemRenderer.ItemRenderType.*;
-import static net.minecraftforge.client.IItemRenderer.ItemRendererHelper.*;
+
+import org.lwjgl.opengl.GL11;
+import org.lwjgl.opengl.GL12;
+
+import cpw.mods.fml.client.FMLClientHandler;
 
 public class ForgeHooksClient
 {
@@ -177,13 +183,13 @@ public class ForgeHooksClient
         return true;
     }
 
-    public static void renderEquippedItem(IItemRenderer customRenderer, RenderBlocks renderBlocks, EntityLiving entity, ItemStack item)
+    public static void renderEquippedItem(ItemRenderType type, IItemRenderer customRenderer, RenderBlocks renderBlocks, EntityLiving entity, ItemStack item)
     {
-        if (customRenderer.shouldUseRenderHelper(EQUIPPED, item, EQUIPPED_BLOCK))
+        if (customRenderer.shouldUseRenderHelper(type, item, EQUIPPED_BLOCK))
         {
             GL11.glPushMatrix();
             GL11.glTranslatef(-0.5F, -0.5F, -0.5F);
-            customRenderer.renderItem(EQUIPPED, item, renderBlocks, entity);
+            customRenderer.renderItem(type, item, renderBlocks, entity);
             GL11.glPopMatrix();
         }
         else
@@ -195,7 +201,7 @@ public class ForgeHooksClient
             GL11.glRotatef(50.0F, 0.0F, 1.0F, 0.0F);
             GL11.glRotatef(335.0F, 0.0F, 0.0F, 1.0F);
             GL11.glTranslatef(-0.9375F, -0.0625F, 0.0F);
-            customRenderer.renderItem(EQUIPPED, item, renderBlocks, entity);
+            customRenderer.renderItem(type, item, renderBlocks, entity);
             GL11.glDisable(GL12.GL_RESCALE_NORMAL);
             GL11.glPopMatrix();
         }

--- a/client/net/minecraftforge/client/IItemRenderer.java
+++ b/client/net/minecraftforge/client/IItemRenderer.java
@@ -35,6 +35,19 @@ public interface IItemRenderer
         EQUIPPED, 
         
         /** 
+         * Called to render an item currently held in-hand by a living entity in
+         * first person. If rendering as a 3D block, the item will be rotated to a
+         * 45-degree angle. To render a 2D texture with some thickness, see
+         * net.minecraft.src.ItemRenderer. In either case, rendering should be done
+         * in local coordinates from (0,0,0)-(1,1,1).
+         * 
+         * Data parameters:
+         * RenderBlocks render - The RenderBlocks instance
+         * EntityLiving entity - The entity holding this item
+         */
+        EQUIPPED_FIRST_PERSON, 
+        
+        /** 
          * Called to render an item in a GUI inventory slot. If rendering as a 3D
          * block, the appropriate OpenGL translations and scaling have already been
          * applied, and the rendering should be done in local coordinates from

--- a/patches/minecraft/net/minecraft/client/renderer/ItemRenderer.java.patch
+++ b/patches/minecraft/net/minecraft/client/renderer/ItemRenderer.java.patch
@@ -1,6 +1,16 @@
 --- ../src_base/minecraft/net/minecraft/client/renderer/ItemRenderer.java
 +++ ../src_work/minecraft/net/minecraft/client/renderer/ItemRenderer.java
-@@ -14,6 +14,8 @@
+@@ -1,7 +1,7 @@
+ package net.minecraft.client.renderer;
+ 
+-import cpw.mods.fml.relauncher.Side;
+-import cpw.mods.fml.relauncher.SideOnly;
++import static net.minecraftforge.client.IItemRenderer.ItemRenderType.EQUIPPED_FIRST_PERSON;
++import static net.minecraftforge.client.IItemRenderer.ItemRenderType.FIRST_PERSON_MAP;
+ import net.minecraft.block.Block;
+ import net.minecraft.block.material.Material;
+ import net.minecraft.client.Minecraft;
+@@ -14,12 +14,22 @@
  import net.minecraft.entity.EntityLiving;
  import net.minecraft.item.EnumAction;
  import net.minecraft.item.Item;
@@ -9,20 +19,51 @@
  import net.minecraft.item.ItemStack;
  import net.minecraft.util.Icon;
  import net.minecraft.util.MathHelper;
-@@ -21,6 +23,12 @@
- import org.lwjgl.opengl.GL11;
- import org.lwjgl.opengl.GL12;
- 
+ import net.minecraft.world.storage.MapData;
 +import net.minecraftforge.client.ForgeHooksClient;
 +import net.minecraftforge.client.IItemRenderer;
++import net.minecraftforge.client.IItemRenderer.ItemRenderType;
 +import net.minecraftforge.client.MinecraftForgeClient;
-+import static net.minecraftforge.client.IItemRenderer.ItemRenderType.*;
-+import static net.minecraftforge.client.IItemRenderer.ItemRendererHelper.*;
 +
+ import org.lwjgl.opengl.GL11;
+ import org.lwjgl.opengl.GL12;
++
++import cpw.mods.fml.relauncher.Side;
++import cpw.mods.fml.relauncher.SideOnly;
+ 
  @SideOnly(Side.CLIENT)
  public class ItemRenderer
- {
-@@ -54,7 +62,20 @@
+@@ -47,6 +57,29 @@
+         this.mapItemRenderer = new MapItemRenderer(par1Minecraft.fontRenderer, par1Minecraft.gameSettings, par1Minecraft.renderEngine);
+     }
+ 
++    public void renderItem(EntityLiving par1EntityLiving, ItemStack par2ItemStack, int par3, IItemRenderer customRenderer, ItemRenderType type)
++    {
++        GL11.glPushMatrix();
++
++        Block block = null;
++        if (par2ItemStack.getItem() instanceof ItemBlock && par2ItemStack.itemID < Block.blocksList.length)
++        {
++            block = Block.blocksList[par2ItemStack.itemID];
++        }
++
++        if (customRenderer != null)
++        {
++            this.mc.renderEngine.bindTexture(par2ItemStack.getItemSpriteNumber() == 0 ? "/terrain.png" : "/gui/items.png");
++            ForgeHooksClient.renderEquippedItem(type, customRenderer, renderBlocksInstance, par1EntityLiving, par2ItemStack);
++        }
++        else
++        {
++        	this.renderItem(par1EntityLiving, par2ItemStack, par3);
++        }
++        
++        GL11.glPopMatrix();
++    }
++    
+     /**
+      * Renders the item stack for being in an entity's hand Args: itemStack
+      */
+@@ -54,7 +87,13 @@
      {
          GL11.glPushMatrix();
  
@@ -32,19 +73,12 @@
 +        {
 +            block = Block.blocksList[par2ItemStack.itemID];
 +        }
-+
-+        IItemRenderer customRenderer = MinecraftForgeClient.getItemRenderer(par2ItemStack, EQUIPPED);
 +        
-+        if (customRenderer != null)
-+        {
-+            this.mc.renderEngine.bindTexture(par2ItemStack.getItemSpriteNumber() == 0 ? "/terrain.png" : "/gui/items.png");
-+            ForgeHooksClient.renderEquippedItem(customRenderer, renderBlocksInstance, par1EntityLiving, par2ItemStack);
-+        }
-+        else if (block != null && par2ItemStack.getItemSpriteNumber() == 0 && RenderBlocks.renderItemIn3d(Block.blocksList[par2ItemStack.itemID].getRenderType()))
++        if (block != null && par2ItemStack.getItemSpriteNumber() == 0 && RenderBlocks.renderItemIn3d(Block.blocksList[par2ItemStack.itemID].getRenderType()))
          {
              this.mc.renderEngine.bindTexture("/terrain.png");
              this.renderBlocksInstance.renderBlockAsItem(Block.blocksList[par2ItemStack.itemID], par2ItemStack.getItemDamage(), 1.0F);
-@@ -272,7 +293,7 @@
+@@ -272,7 +311,7 @@
          Render render;
          RenderPlayer renderplayer;
  
@@ -53,7 +87,7 @@
          {
              GL11.glPushMatrix();
              f4 = 0.8F;
-@@ -340,11 +361,20 @@
+@@ -340,11 +379,20 @@
              tessellator.addVertexWithUV((double)(128 + b0), (double)(0 - b0), 0.0D, 1.0D, 0.0D);
              tessellator.addVertexWithUV((double)(0 - b0), (double)(0 - b0), 0.0D, 0.0D, 0.0D);
              tessellator.draw();
@@ -79,16 +113,22 @@
              }
  
              GL11.glPopMatrix();
-@@ -447,12 +477,15 @@
+@@ -444,19 +492,24 @@
+                 GL11.glRotatef(180.0F, 0.0F, 1.0F, 0.0F);
+             }
+ 
++            IItemRenderer customRenderer = MinecraftForgeClient.getItemRenderer(itemstack, EQUIPPED_FIRST_PERSON);
++            
              if (itemstack.getItem().requiresMultipleRenderPasses())
              {
-                 this.renderItem(entityclientplayermp, itemstack, 0);
+-                this.renderItem(entityclientplayermp, itemstack, 0);
 -                int i1 = Item.itemsList[itemstack.itemID].getColorFromItemStack(itemstack, 1);
 -                f10 = (float)(i1 >> 16 & 255) / 255.0F;
 -                f11 = (float)(i1 >> 8 & 255) / 255.0F;
 -                f12 = (float)(i1 & 255) / 255.0F;
 -                GL11.glColor4f(f3 * f10, f3 * f11, f3 * f12, 1.0F);
 -                this.renderItem(entityclientplayermp, itemstack, 1);
++                this.renderItem(entityclientplayermp, itemstack, 0, customRenderer, EQUIPPED_FIRST_PERSON);
 +                for (int x = 1; x < itemstack.getItem().getRenderPasses(itemstack.getItemDamage()); x++)
 +                {
 +                    int i1 = Item.itemsList[itemstack.itemID].getColorFromItemStack(itemstack, x);
@@ -96,8 +136,13 @@
 +                    f11 = (float)(i1 >> 8 & 255) / 255.0F;
 +                    f12 = (float)(i1 & 255) / 255.0F;
 +                    GL11.glColor4f(f3 * f10, f3 * f11, f3 * f12, 1.0F);
-+                    this.renderItem(entityclientplayermp, itemstack, x);
++                    this.renderItem(entityclientplayermp, itemstack, x, customRenderer, EQUIPPED_FIRST_PERSON);
 +                }
              }
              else
              {
+-                this.renderItem(entityclientplayermp, itemstack, 0);
++                this.renderItem(entityclientplayermp, itemstack, 0, customRenderer, EQUIPPED_FIRST_PERSON);
+             }
+ 
+             GL11.glPopMatrix();

--- a/patches/minecraft/net/minecraft/client/renderer/entity/RenderBiped.java.patch
+++ b/patches/minecraft/net/minecraft/client/renderer/entity/RenderBiped.java.patch
@@ -1,6 +1,6 @@
 --- ../src_base/minecraft/net/minecraft/client/renderer/entity/RenderBiped.java
 +++ ../src_work/minecraft/net/minecraft/client/renderer/entity/RenderBiped.java
-@@ -11,9 +11,15 @@
+@@ -11,9 +11,16 @@
  import net.minecraft.entity.EntityLiving;
  import net.minecraft.item.EnumArmorMaterial;
  import net.minecraft.item.Item;
@@ -9,6 +9,7 @@
  import net.minecraft.item.ItemStack;
  import org.lwjgl.opengl.GL11;
 +import static net.minecraftforge.client.IItemRenderer.ItemRenderType.EQUIPPED;
++import static net.minecraftforge.client.IItemRenderer.ItemRenderType.EQUIPPED_FIRST_PERSON;
 +import static net.minecraftforge.client.IItemRenderer.ItemRendererHelper.BLOCK_3D;
 +import net.minecraftforge.client.ForgeHooksClient;
 +import net.minecraftforge.client.IItemRenderer;
@@ -16,7 +17,7 @@
  
  @SideOnly(Side.CLIENT)
  public class RenderBiped extends RenderLiving
-@@ -59,7 +65,7 @@
+@@ -59,7 +66,7 @@
              if (item instanceof ItemArmor)
              {
                  ItemArmor itemarmor = (ItemArmor)item;
@@ -25,7 +26,7 @@
                  ModelBiped modelbiped = par2 == 2 ? this.field_82425_h : this.field_82423_g;
                  modelbiped.bipedHead.showModel = par2 == 0;
                  modelbiped.bipedHeadwear.showModel = par2 == 0;
-@@ -68,6 +74,7 @@
+@@ -68,6 +75,7 @@
                  modelbiped.bipedLeftArm.showModel = par2 == 1;
                  modelbiped.bipedRightLeg.showModel = par2 == 2 || par2 == 3;
                  modelbiped.bipedLeftLeg.showModel = par2 == 2 || par2 == 3;
@@ -33,7 +34,7 @@
                  this.setRenderPassModel(modelbiped);
  
                  if (modelbiped != null)
-@@ -87,9 +94,10 @@
+@@ -87,9 +95,10 @@
  
                  float f1 = 1.0F;
  
@@ -47,7 +48,7 @@
                      float f2 = (float)(j >> 16 & 255) / 255.0F;
                      float f3 = (float)(j >> 8 & 255) / 255.0F;
                      float f4 = (float)(j & 255) / 255.0F;
-@@ -128,7 +136,7 @@
+@@ -128,7 +137,7 @@
              if (item instanceof ItemArmor)
              {
                  ItemArmor itemarmor = (ItemArmor)item;
@@ -56,7 +57,7 @@
                  float f1 = 1.0F;
                  GL11.glColor3f(f1, f1, f1);
              }
-@@ -174,9 +182,12 @@
+@@ -174,9 +183,12 @@
              GL11.glPushMatrix();
              this.modelBipedMain.bipedHead.postRender(0.0625F);
  
@@ -72,7 +73,16 @@
                  {
                      f2 = 0.625F;
                      GL11.glTranslatef(0.0F, -0.25F, 0.0F);
-@@ -218,7 +229,10 @@
+@@ -184,7 +196,7 @@
+                     GL11.glScalef(f2, -f2, -f2);
+                 }
+ 
+-                this.renderManager.itemRenderer.renderItem(par1EntityLiving, itemstack1, 0);
++                this.renderManager.itemRenderer.renderItem(par1EntityLiving, itemstack1, 0, customRenderer, EQUIPPED);
+             }
+             else if (itemstack1.getItem().itemID == Item.skull.itemID)
+             {
+@@ -218,7 +230,10 @@
              this.modelBipedMain.bipedRightArm.postRender(0.0625F);
              GL11.glTranslatef(-0.0625F, 0.4375F, 0.0625F);
  
@@ -84,14 +94,19 @@
              {
                  f2 = 0.5F;
                  GL11.glTranslatef(0.0F, 0.1875F, -0.3125F);
-@@ -265,7 +279,10 @@
+@@ -261,11 +276,14 @@
+                 GL11.glRotatef(20.0F, 0.0F, 0.0F, 1.0F);
+             }
+ 
+-            this.renderManager.itemRenderer.renderItem(par1EntityLiving, itemstack, 0);
++            this.renderManager.itemRenderer.renderItem(par1EntityLiving, itemstack, 0, customRenderer, EQUIPPED);
  
              if (itemstack.getItem().requiresMultipleRenderPasses())
              {
 -                this.renderManager.itemRenderer.renderItem(par1EntityLiving, itemstack, 1);
 +                for (int x = 1; x < itemstack.getItem().getRenderPasses(itemstack.getItemDamage()); x++)
 +                {
-+                    this.renderManager.itemRenderer.renderItem(par1EntityLiving, itemstack, x);
++                    this.renderManager.itemRenderer.renderItem(par1EntityLiving, itemstack, x, customRenderer, EQUIPPED);
 +                }
              }
  

--- a/patches/minecraft/net/minecraft/client/renderer/entity/RenderPlayer.java.patch
+++ b/patches/minecraft/net/minecraft/client/renderer/entity/RenderPlayer.java.patch
@@ -79,6 +79,15 @@
                  {
                      f2 = 0.625F;
                      GL11.glTranslatef(0.0F, -0.25F, 0.0F);
+@@ -194,7 +207,7 @@
+                     GL11.glScalef(f2, -f2, -f2);
+                 }
+ 
+-                this.renderManager.itemRenderer.renderItem(par1EntityPlayer, itemstack, 0);
++                this.renderManager.itemRenderer.renderItem(par1EntityPlayer, itemstack, 0, customRenderer, EQUIPPED);
+             }
+             else if (itemstack.getItem().itemID == Item.skull.itemID)
+             {
 @@ -304,7 +317,10 @@
                  enumaction = itemstack1.getItemUseAction();
              }
@@ -91,7 +100,7 @@
              {
                  f3 = 0.5F;
                  GL11.glTranslatef(0.0F, 0.1875F, -0.3125F);
-@@ -361,7 +377,7 @@
+@@ -361,14 +377,14 @@
  
              if (itemstack1.getItem().requiresMultipleRenderPasses())
              {
@@ -100,3 +109,20 @@
                  {
                      int k = itemstack1.getItem().getColorFromItemStack(itemstack1, j);
                      f12 = (float)(k >> 16 & 255) / 255.0F;
+                     f11 = (float)(k >> 8 & 255) / 255.0F;
+                     f6 = (float)(k & 255) / 255.0F;
+                     GL11.glColor4f(f12, f11, f6, 1.0F);
+-                    this.renderManager.itemRenderer.renderItem(par1EntityPlayer, itemstack1, j);
++                    this.renderManager.itemRenderer.renderItem(par1EntityPlayer, itemstack1, j, customRenderer, EQUIPPED);
+                 }
+             }
+             else
+@@ -378,7 +394,7 @@
+                 f12 = (float)(j >> 8 & 255) / 255.0F;
+                 f11 = (float)(j & 255) / 255.0F;
+                 GL11.glColor4f(f4, f12, f11, 1.0F);
+-                this.renderManager.itemRenderer.renderItem(par1EntityPlayer, itemstack1, 0);
++                this.renderManager.itemRenderer.renderItem(par1EntityPlayer, itemstack1, 0, customRenderer, EQUIPPED);
+             }
+ 
+             GL11.glPopMatrix();


### PR DESCRIPTION
Since many items will have different rendering transformations from the held item to looking at another player holding it, I decided this would be handy to have.

Examples of why this is necessary:

Correct Third Person (before change):
http://i.imgur.com/YWwJvhl.png

Incorrect First Person (before change):
http://i.imgur.com/QWAY6NK.png

With the merge I, along with other modders, would be able to render differently from first to third person.

I've confirmed that this builds successfully and works using my ItemRenderer.
