### PR TITLE
Fix for BiomeDictionary.getTypesForBiome throwing a ClassCastException when called.

### DIFF
--- a/common/net/minecraftforge/common/BiomeDictionary.java
+++ b/common/net/minecraftforge/common/BiomeDictionary.java
@@ -98,7 +98,7 @@ public class BiomeDictionary
     {
         if(typeInfoList[type.ordinal()] != null)
         {
-            return (BiomeGenBase[])typeInfoList[type.ordinal()].toArray();
+            return (BiomeGenBase[])typeInfoList[type.ordinal()].toArray(new BiomeGenBase[0]);
         }
 
         return new BiomeGenBase[0];


### PR DESCRIPTION
Attempting to fetch the BiomeDictionary types linked to a specific biome with BiomeDictionary.getTypesForBiome throws a ClassCastException. 
