### PR TITLE
Add PotionEvents to allow custom ItemPotions to be brewed

### DIFF
--- a/common/net/minecraftforge/event/ForgeEventFactory.java
+++ b/common/net/minecraftforge/event/ForgeEventFactory.java
@@ -11,6 +11,7 @@ import net.minecraft.world.World;
 import net.minecraft.world.WorldServer;
 import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.event.Event.Result;
+import net.minecraftforge.event.brewing.PotionBrewingStackEvent.CanBrewEvent;
 import net.minecraftforge.event.entity.living.LivingPackSizeEvent;
 import net.minecraftforge.event.entity.living.LivingSpawnEvent;
 import net.minecraftforge.event.entity.player.PlayerDestroyItemEvent;
@@ -74,5 +75,12 @@ public class ForgeEventFactory
         LivingPackSizeEvent maxCanSpawnEvent = new LivingPackSizeEvent(entity);
         MinecraftForge.EVENT_BUS.post(maxCanSpawnEvent);
         return maxCanSpawnEvent.getResult() == Result.ALLOW ? maxCanSpawnEvent.maxPackSize : entity.getMaxSpawnedInChunk();
+    }
+    
+    public static Result isValidBrewingCombo(ItemStack brewingStack, ItemStack ingredient)
+    {
+        CanBrewEvent canSpawn = new CanBrewEvent(brewingStack, ingredient);
+        MinecraftForge.EVENT_BUS.post(canSpawn);
+        return canSpawn.getResult();
     }
 }

--- a/common/net/minecraftforge/event/brewing/PotionBrewedEvent.java
+++ b/common/net/minecraftforge/event/brewing/PotionBrewedEvent.java
@@ -1,7 +1,9 @@
 package net.minecraftforge.event.brewing;
 
 import net.minecraft.item.ItemStack;
+import net.minecraftforge.event.Cancelable;
 import net.minecraftforge.event.Event;
+import net.minecraftforge.event.Event.HasResult;
 
 public class PotionBrewedEvent extends Event
 {
@@ -12,5 +14,16 @@ public class PotionBrewedEvent extends Event
     public PotionBrewedEvent(ItemStack[] brewingStacks)
     {
         this.brewingStacks = brewingStacks;
+    }
+    
+    /**
+     * Called after the Potion Ingredient has been applied to all present
+     * Potions. Each index has the possibility to be null, so make sure you
+     * check.
+     */
+    @Cancelable
+    public static class BrewingConsumeEvent extends PotionBrewedEvent
+    {
+        public BrewingConsumeEvent(ItemStack[] brewingStacks) { super(brewingStacks); }
     }
 }

--- a/common/net/minecraftforge/event/brewing/PotionBrewingStackEvent.java
+++ b/common/net/minecraftforge/event/brewing/PotionBrewingStackEvent.java
@@ -1,0 +1,56 @@
+package net.minecraftforge.event.brewing;
+
+import net.minecraft.entity.EntityLiving;
+import net.minecraft.entity.player.EntityPlayerMP;
+import net.minecraft.item.ItemStack;
+import net.minecraft.world.ChunkCoordIntPair;
+import net.minecraftforge.event.Cancelable;
+import net.minecraftforge.event.Event;
+import net.minecraftforge.event.Event.HasResult;
+import net.minecraftforge.event.world.ChunkWatchEvent;
+
+public class PotionBrewingStackEvent extends Event {
+
+    public final ItemStack brewingStack;
+    public final ItemStack ingredient;
+
+    public PotionBrewingStackEvent(ItemStack brewingStack, ItemStack ingredient)
+    {
+        this.brewingStack = brewingStack;
+        this.ingredient = ingredient;
+    }
+
+    @Cancelable
+    public static class BrewingCraftEvent extends PotionBrewingStackEvent
+    {
+        /**
+         * Called once for each brewingStack before the Potion Ingredient is
+         * applied to the Potion being brewed
+         * 
+         * @param brewingStack
+         *            Itemstack representing the Potion to be brewed. Is
+         *            instance of ItemPotion and not null.
+         * @param ingredient
+         *            Itemstack representing ingredient to be brewed with
+         *            brewingStack.
+         */
+        public BrewingCraftEvent(ItemStack brewingStack, ItemStack ingredient) { super(brewingStack, ingredient); }
+    }
+    
+    @HasResult
+    public static class CanBrewEvent extends PotionBrewingStackEvent
+    {
+        /**
+         * Called once for each brewingStack before the Potion being brewed is
+         * tested to see if the Potion Ingredient is applicable
+         * 
+         * @param brewingStack
+         *            Itemstack representing the Potion to be brewed. Is
+         *            instance of ItemPotion and not null.
+         * @param ingredient
+         *            Itemstack representing ingredient to be brewed with
+         *            brewingStack.
+         */
+        public CanBrewEvent(ItemStack brewingStack, ItemStack ingredient) { super(brewingStack, ingredient); }
+    }
+}

--- a/patches/minecraft/net/minecraft/tileentity/TileEntityBrewingStand.java.patch
+++ b/patches/minecraft/net/minecraft/tileentity/TileEntityBrewingStand.java.patch
@@ -1,51 +1,85 @@
 --- ../src_base/minecraft/net/minecraft/tileentity/TileEntityBrewingStand.java
 +++ ../src_work/minecraft/net/minecraft/tileentity/TileEntityBrewingStand.java
-@@ -11,6 +11,8 @@
+@@ -11,6 +11,12 @@
  import net.minecraft.nbt.NBTTagCompound;
  import net.minecraft.nbt.NBTTagList;
  import net.minecraft.potion.PotionHelper;
 +import net.minecraftforge.common.MinecraftForge;
++import net.minecraftforge.event.Event.Result;
++import net.minecraftforge.event.ForgeEventFactory;
 +import net.minecraftforge.event.brewing.PotionBrewedEvent;
++import net.minecraftforge.event.brewing.PotionBrewedEvent.BrewingConsumeEvent;
++import net.minecraftforge.event.brewing.PotionBrewingStackEvent.BrewingCraftEvent;
  
  public class TileEntityBrewingStand extends TileEntity implements ISidedInventory
  {
-@@ -122,7 +124,7 @@
+@@ -122,8 +128,14 @@
  
                  for (int i = 0; i < 3; ++i)
                  {
 -                    if (this.brewingItemStacks[i] != null && this.brewingItemStacks[i].itemID == Item.potion.itemID)
 +                    if (this.brewingItemStacks[i] != null && this.brewingItemStacks[i].getItem() instanceof ItemPotion)
                      {
++                        Result result = ForgeEventFactory.isValidBrewingCombo(brewingItemStacks[i], itemstack);
++                        if (result != Result.DEFAULT)
++                        {
++                            if(result == Result.ALLOW) flag = true;
++                            continue;
++                        }
                          int j = this.brewingItemStacks[i].getItemDamage();
                          int k = this.getPotionResult(j, itemstack);
-@@ -161,7 +163,7 @@
+ 
+@@ -161,8 +173,12 @@
  
              for (int i = 0; i < 3; ++i)
              {
 -                if (this.brewingItemStacks[i] != null && this.brewingItemStacks[i].itemID == Item.potion.itemID)
 +                if (this.brewingItemStacks[i] != null && this.brewingItemStacks[i].getItem() instanceof ItemPotion)
                  {
++                    if (MinecraftForge.EVENT_BUS.post(new BrewingCraftEvent(brewingItemStacks[i], itemstack)))
++                    {
++                        continue;
++                    }
                      int j = this.brewingItemStacks[i].getItemDamage();
                      int k = this.getPotionResult(j, itemstack);
-@@ -184,7 +186,7 @@
- 
-             if (Item.itemsList[itemstack.itemID].hasContainerItem())
-             {
--                this.brewingItemStacks[3] = new ItemStack(Item.itemsList[itemstack.itemID].getContainerItem());
-+                this.brewingItemStacks[3] = Item.itemsList[itemstack.itemID].getContainerItemStack(brewingItemStacks[3]);
-             }
-             else
-             {
-@@ -195,6 +197,8 @@
-                     this.brewingItemStacks[3] = null;
+                     List list = Item.potion.getEffects(j);
+@@ -182,19 +198,24 @@
                  }
              }
+ 
+-            if (Item.itemsList[itemstack.itemID].hasContainerItem())
+-            {
+-                this.brewingItemStacks[3] = new ItemStack(Item.itemsList[itemstack.itemID].getContainerItem());
+-            }
+-            else
+-            {
+-                --this.brewingItemStacks[3].stackSize;
+-
+-                if (this.brewingItemStacks[3].stackSize <= 0)
++            if (!MinecraftForge.EVENT_BUS.post(new BrewingConsumeEvent(brewingItemStacks)))
++            {
++                if (Item.itemsList[itemstack.itemID].hasContainerItem())
+                 {
+-                    this.brewingItemStacks[3] = null;
++                    this.brewingItemStacks[3] = Item.itemsList[itemstack.itemID].getContainerItemStack(brewingItemStacks[3]);
+                 }
+-            }
++                else
++                {
++                    --this.brewingItemStacks[3].stackSize;
++
++                    if (this.brewingItemStacks[3].stackSize <= 0)
++                    {
++                        this.brewingItemStacks[3] = null;
++                    }
++                }
++            }
 +            
 +            MinecraftForge.EVENT_BUS.post(new PotionBrewedEvent(brewingItemStacks));
          }
      }
  
-@@ -343,7 +347,7 @@
+@@ -343,7 +364,7 @@
       */
      public boolean isStackValidForSlot(int par1, ItemStack par2ItemStack)
      {


### PR DESCRIPTION
It is currently difficult to add ItemPotions as all the reference in TilEntityBrewingStand statically reference Potion instead of using the local ItemPotion instance. In lieu of replacing all those references (upon which these events would still hold value), the following events allow user desired brewing logic to be inserted. 
- CanBrewEvent - Result event. determines if brewingStack and ingredient are valid for brewing. Called once for each brewingStack. If any stacks are valid brewing stand will continue to process.
- BrewingCraftEvent - Cancellable event. Used for inserting alternative potion crafting. Called once for each brewingStack. Allows manually settings the changes to the brewingStack triggered by the ingredient.
- BrewingConsumeEvent - Cancellable event. Allows overriding of default ingredient consumption. Included mostly to be complete, if we are allowing the individual BrewingCrafts to be cancelled, we should allow the ingredient to not be consumed /  replaced with specifal contained / corrupted / or last multiple brewing operations.
