### PR TITLE
Allow all leaves to be recoloured using event

### DIFF
--- a/common/net/minecraftforge/event/terraingen/BiomeEvent.java
+++ b/common/net/minecraftforge/event/terraingen/BiomeEvent.java
@@ -2,6 +2,7 @@ package net.minecraftforge.event.terraingen;
 
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
+import net.minecraft.block.Block;
 import net.minecraft.world.biome.BiomeDecorator;
 import net.minecraft.world.biome.BiomeGenBase;
 import net.minecraftforge.event.*;
@@ -100,14 +101,26 @@ public class BiomeEvent extends Event
     }
     
     /**
-     * This event is fired when a biome is queried for its grass color. 
+     * This event is fired when a biome is queried for its foliage color. 
      */
     @SideOnly(Side.CLIENT)
     public static class GetFoliageColor extends BiomeColor
     {
+        public final int blockId;
+        public final int metadata;
+        
+        public GetFoliageColor(BiomeGenBase biome, int original, int blockId, int metadata)
+        {
+            super(biome, original);
+            this.blockId = blockId;
+            this.metadata = metadata;
+        }
+        
         public GetFoliageColor(BiomeGenBase biome, int original)
         {
             super(biome, original);
+            this.blockId = Block.leaves.blockID;
+            this.metadata = 0;
         }
     }
     

--- a/patches/minecraft/net/minecraft/block/BlockLeaves.java.patch
+++ b/patches/minecraft/net/minecraft/block/BlockLeaves.java.patch
@@ -20,7 +20,34 @@
  {
      public static final String[] LEAF_TYPES = new String[] {"oak", "spruce", "birch", "jungle"};
      public static final String[][] field_94396_b = new String[][] {{"leaves", "leaves_spruce", "leaves", "leaves_jungle"}, {"leaves_opaque", "leaves_spruce_opaque", "leaves_opaque", "leaves_jungle_opaque"}};
-@@ -107,10 +111,9 @@
+@@ -60,16 +64,7 @@
+     {
+         int l = par1IBlockAccess.getBlockMetadata(par2, par3, par4);
+ 
+-        if ((l & 3) == 1)
+-        {
+-            return ColorizerFoliage.getFoliageColorPine();
+-        }
+-        else if ((l & 3) == 2)
+-        {
+-            return ColorizerFoliage.getFoliageColorBirch();
+-        }
+-        else
+-        {
++        { // Forge leave here for indentation
+             int i1 = 0;
+             int j1 = 0;
+             int k1 = 0;
+@@ -78,7 +73,7 @@
+             {
+                 for (int i2 = -1; i2 <= 1; ++i2)
+                 {
+-                    int j2 = par1IBlockAccess.getBiomeGenForCoords(par2 + i2, par4 + l1).getBiomeFoliageColor();
++                    int j2 = par1IBlockAccess.getBiomeGenForCoords(par2 + i2, par4 + l1).getBiomeFoliageColor(this.blockID, l);
+                     i1 += (j2 & 16711680) >> 16;
+                     j1 += (j2 & 65280) >> 8;
+                     k1 += j2 & 255;
+@@ -107,10 +102,9 @@
                      {
                          int j2 = par1World.getBlockId(par2 + k1, par3 + l1, par4 + i2);
  
@@ -33,7 +60,7 @@
                          }
                      }
                  }
-@@ -156,11 +159,13 @@
+@@ -156,11 +150,13 @@
                              {
                                  k2 = par1World.getBlockId(par2 + l1, par3 + i2, par4 + j2);
  
@@ -49,7 +76,7 @@
                                  {
                                      this.adjacentTreeBlocks[(l1 + k1) * j1 + (i2 + k1) * b1 + j2 + k1] = -2;
                                  }
-@@ -325,15 +330,7 @@
+@@ -325,15 +321,7 @@
       */
      public void harvestBlock(World par1World, EntityPlayer par2EntityPlayer, int par3, int par4, int par5, int par6)
      {
@@ -66,7 +93,7 @@
      }
  
      /**
-@@ -414,4 +411,30 @@
+@@ -414,4 +402,30 @@
              }
          }
      }

--- a/patches/minecraft/net/minecraft/world/biome/BiomeGenBase.java.patch
+++ b/patches/minecraft/net/minecraft/world/biome/BiomeGenBase.java.patch
@@ -30,7 +30,7 @@
      }
  
      @SideOnly(Side.CLIENT)
-@@ -384,6 +387,38 @@
+@@ -384,6 +387,65 @@
      {
          double d0 = (double)MathHelper.clamp_float(this.getFloatTemperature(), 0.0F, 1.0F);
          double d1 = (double)MathHelper.clamp_float(this.getFloatRainfall(), 0.0F, 1.0F);
@@ -61,11 +61,38 @@
 +        return event.newColor;
 +    }
 +    
-+
 +    @SideOnly(Side.CLIENT)
 +    public int getModdedBiomeFoliageColor(int original)
 +    {
-+        BiomeEvent.GetFoliageColor event = new BiomeEvent.GetFoliageColor(this, original);
++        BiomeEvent.GetFoliageColor event = new BiomeEvent.GetFoliageColor(this, original, Block.leaves.blockID, 0);
++        MinecraftForge.EVENT_BUS.post(event);
++        return event.newColor;
++    }
++    
++    @SideOnly(Side.CLIENT)
++    public int getBiomeFoliageColor(int blockId, int metadata)
++    {
++        if (Block.leaves.blockID == blockId)
++        {
++            if (metadata == 1)
++            {
++                return getModdedBiomeFoliageColor(ColorizerFoliage.getFoliageColorPine(), blockId, metadata);
++            }
++            if (metadata == 2)
++            {
++                return getModdedBiomeFoliageColor(ColorizerFoliage.getFoliageColorBirch(), blockId, metadata);
++            }
++        }
++        
++        double d0 = (double)MathHelper.clamp_float(this.getFloatTemperature(), 0.0F, 1.0F);
++        double d1 = (double)MathHelper.clamp_float(this.getFloatRainfall(), 0.0F, 1.0F);
++        return getModdedBiomeFoliageColor(ColorizerFoliage.getFoliageColor(d0, d1), blockId, metadata);
++    }
++    
++    @SideOnly(Side.CLIENT)
++    public int getModdedBiomeFoliageColor(int original, int blockId, int metadata)
++    {
++        BiomeEvent.GetFoliageColor event = new BiomeEvent.GetFoliageColor(this, original, blockId, metadata);
 +        MinecraftForge.EVENT_BUS.post(event);
 +        return event.newColor;
      }


### PR DESCRIPTION
Modifies the GetFoliageColor event to add an identifier for different types of leaves. Standard identifiers are oak, spruce, birch and jungle. Tested and appears to be working.

Sample code:

``` java
    @ForgeSubscribe
    public void onFoliageColor(BiomeEvent.GetFoliageColor event) {
        if (event.identifier.equalsIgnoreCase("oak")) {
            event.newColor = 0xFF0000;
        }
        if (event.identifier.equalsIgnoreCase("spruce")) {
            event.newColor = 0xFF00;
        }
        if (event.identifier.equalsIgnoreCase("birch")) {
            event.newColor = 0xFF;
        }
        if (event.identifier.equalsIgnoreCase("jungle")) {
            event.newColor = 0xFF8800;
        }
    }
```
