### PR TITLE
OreDictionary additions + ItemStack maxDamage hook

### DIFF
--- a/common/net/minecraftforge/oredict/OreDictionary.java
+++ b/common/net/minecraftforge/oredict/OreDictionary.java
@@ -49,6 +49,12 @@ public class OreDictionary
             registerOre("stickWood",   Item.stick);
             registerOre("treeSapling", new ItemStack(Block.sapling, 1, WILDCARD_VALUE));
             registerOre("treeLeaves",  new ItemStack(Block.leaves, 1, WILDCARD_VALUE));
+            registerOre("oreGold", Block.oreGold);
+            registerOre("oreIron", Block.oreIron);
+            registerOre("oreLapis", Block.oreLapis);
+            registerOre("oreDiamond", Block.oreDiamond);
+            registerOre("oreRedstone", Block.oreRedstone);
+            registerOre("oreEmerald", Block.oreEmerald);
         }
 
         // Build our list of items to replace with ore tags

--- a/patches/minecraft/net/minecraft/item/Item.java.patch
+++ b/patches/minecraft/net/minecraft/item/Item.java.patch
@@ -60,7 +60,7 @@
          Vec3 vec31 = vec3.addVector((double)f7 * d3, (double)f6 * d3, (double)f8 * d3);
          return par1World.rayTraceBlocks_do_do(vec3, vec31, par3, !par3);
      }
-@@ -720,4 +736,480 @@
+@@ -720,4 +736,491 @@
      {
          StatList.initStats();
      }
@@ -514,6 +514,17 @@
 +    public int getItemDamageFromStackForDisplay(ItemStack stack)
 +    {
 +        return stack.itemDamage;
++    }
++    
++    /**
++     * Return the maxDamage for this ItemStack. Defaults to the maxDamage field in this item, but can be overridden here for other sources such as NBT.
++     *
++     * @param stack The itemstack that is damaged
++     * @return the damage value
++     */
++    public int getItemMaxDamageFromStack(ItemStack stack)
++    {
++        return maxDamage;
 +    }
 +
 +    /**

--- a/patches/minecraft/net/minecraft/item/ItemStack.java.patch
+++ b/patches/minecraft/net/minecraft/item/ItemStack.java.patch
@@ -41,6 +41,15 @@
      }
  
      /**
+@@ -286,7 +281,7 @@
+      */
+     public int getMaxDamage()
+     {
+-        return Item.itemsList[this.itemID].getMaxDamage();
++        return this.getItem().getItemMaxDamageFromStack(this);
+     }
+ 
+     public boolean func_96631_a(int par1, Random par2Random)
 @@ -382,7 +377,7 @@
       */
      public int getDamageVsEntity(Entity par1Entity)


### PR DESCRIPTION
-Add vanilla Ores to the Ore Dictionary. No recipe replacement required.
-Add NBT-sensitive getMaxDamage() for ItemStack.

Signed-off-by: King Lemming kinglemming@gmail.com
