### PR TITLE
Fix unregistering of event listener

### DIFF
--- a/common/net/minecraftforge/event/ListenerList.java
+++ b/common/net/minecraftforge/event/ListenerList.java
@@ -210,9 +210,9 @@ public class ListenerList
             for(ArrayList<IEventListener> list : priorities)
             {
                 if (list.remove(listener))
-				{
-					rebuild = true;
-				}
+                {
+                    rebuild = true;
+                }
             }
         }
     }


### PR DESCRIPTION
Fix from forums (http://www.minecraftforge.net/forum/index.php/topic,7855.msg40208.html#msg40208) for unregistering of event listeners not working properly because listener caches are not rebuild after removing a listener.
