### PR TITLE
add IMultiBlockInventory

### DIFF
--- a/common/net/minecraftforge/common/IMultiBlockInventory.java
+++ b/common/net/minecraftforge/common/IMultiBlockInventory.java
@@ -1,0 +1,23 @@
+package net.minecraftforge.common;
+
+import net.minecraft.inventory.IInventory;
+
+/**
+ * This enables transport mods to access the full inventory
+ * of a multiblock chest that doesn't extend TileEntityChest.
+ *
+ * Allowing for chests of custom shapes and sizes without loosing
+ * automation support, or requiring a connection to every TileEntity.
+ */
+public interface IMultiBlockInventory extends IInventory
+{
+    /**
+     * Returns the IInventory representing this blocks storage.
+     * 
+     * If it's currently not a multiblock chest just return the blocks TileEntity,
+     * Otherwise return an IInventory instance that is aware of all TileEntities needed.
+     * 
+     * See TileEntityChest for a usage example.
+     */
+    IInventory getMultiBlockInventory();
+}

--- a/patches/minecraft/net/minecraft/tileentity/TileEntityChest.java.patch
+++ b/patches/minecraft/net/minecraft/tileentity/TileEntityChest.java.patch
@@ -1,0 +1,30 @@
+--- ../src_base/minecraft/net/minecraft/tileentity/TileEntityChest.java
++++ ../src_work/minecraft/net/minecraft/tileentity/TileEntityChest.java
+@@ -12,8 +12,9 @@
+ import net.minecraft.nbt.NBTTagCompound;
+ import net.minecraft.nbt.NBTTagList;
+ import net.minecraft.util.AxisAlignedBB;
+-
+-public class TileEntityChest extends TileEntity implements IInventory
++import net.minecraftforge.common.IMultiBlockInventory;
++
++public class TileEntityChest extends TileEntity implements IInventory, IMultiBlockInventory
+ {
+     private ItemStack[] chestContents = new ItemStack[36];
+ 
+@@ -507,4 +508,15 @@
+ 
+         return this.field_94046_i;
+     }
++
++    @Override
++    public IInventory getMultiBlockInventory()
++    {
++        checkForAdjacentChests();
++        TileEntityChest chest2 = (this.adjacentChestXNeg != null) ? this.adjacentChestXNeg : (this.adjacentChestXPos != null) ? this.adjacentChestXPos : (this.adjacentChestZNeg != null) ? this.adjacentChestZNeg : (this.adjacentChestZPosition != null) ? this.adjacentChestZPosition : null;
++        if (chest2 != null) {
++            return new InventoryLargeChest("", this, chest2);
++        }
++        return this;
++    }
+ }


### PR DESCRIPTION
This enables transport mods (like BuildCraft) to access the full
inventory of a multiblock chest that doesn't extend TileEntityChest.

Allowing for chests of custom shapes and sizes without loosing
automation support, or requiring a connection to every TileEntity.
