### PR TITLE
Adding hook for items to allow them to be held as bow and an event for player facing Enderman

### DIFF
--- a/common/net/minecraftforge/event/entity/living/EnderFacingEvent.java
+++ b/common/net/minecraftforge/event/entity/living/EnderFacingEvent.java
@@ -1,0 +1,24 @@
+package net.minecraftforge.event.entity.living;
+
+import net.minecraft.entity.EntityLiving;
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraftforge.event.Cancelable;
+
+/**
+ * An event which is fired whenever a player looks at an Enderman. It holds the Enderman (entityLiving)
+ * as well as the Player which looks at it )entityPlayer).
+ * Cancel the event to prevent the Enderman from going aggressive against the player.
+ * @author SanAndreas
+ *
+ */
+@Cancelable
+public class EnderFacingEvent extends LivingEvent {
+
+    public final EntityPlayer entityPlayer;
+    public EnderFacingEvent(EntityLiving entity, EntityPlayer player)
+    {
+        super(entity);
+        this.entityPlayer = player;
+    }
+
+}

--- a/patches/minecraft/net/minecraft/client/renderer/entity/RenderPlayer.java.patch
+++ b/patches/minecraft/net/minecraft/client/renderer/entity/RenderPlayer.java.patch
@@ -92,6 +92,15 @@
              {
                  f3 = 0.5F;
                  GL11.glTranslatef(0.0F, 0.1875F, -0.3125F);
+@@ -313,7 +330,7 @@
+                 GL11.glRotatef(45.0F, 0.0F, 1.0F, 0.0F);
+                 GL11.glScalef(-f3, -f3, f3);
+             }
+-            else if (itemstack1.itemID == Item.bow.itemID)
++            else if (Item.itemsList[itemstack1.itemID].renderAsBow(itemstack1, par1EntityPlayer))
+             {
+                 f3 = 0.625F;
+                 GL11.glTranslatef(0.0F, 0.125F, 0.3125F);
 @@ -361,7 +378,7 @@
  
              if (itemstack1.getItem().requiresMultipleRenderPasses())

--- a/patches/minecraft/net/minecraft/entity/monster/EntityEnderman.java.patch
+++ b/patches/minecraft/net/minecraft/entity/monster/EntityEnderman.java.patch
@@ -1,15 +1,31 @@
 --- ../src_base/minecraft/net/minecraft/entity/monster/EntityEnderman.java
 +++ ../src_work/minecraft/net/minecraft/entity/monster/EntityEnderman.java
-@@ -11,6 +11,8 @@
+@@ -11,6 +11,9 @@
  import net.minecraft.util.MathHelper;
  import net.minecraft.util.Vec3;
  import net.minecraft.world.World;
 +import net.minecraftforge.common.MinecraftForge;
++import net.minecraftforge.event.entity.living.EnderFacingEvent;
 +import net.minecraftforge.event.entity.living.EnderTeleportEvent;
  
  public class EntityEnderman extends EntityMob
  {
-@@ -264,12 +266,17 @@
+@@ -103,8 +106,12 @@
+     private boolean shouldAttackPlayer(EntityPlayer par1EntityPlayer)
+     {
+         ItemStack itemstack = par1EntityPlayer.inventory.armorInventory[3];
+-
+-        if (itemstack != null && itemstack.itemID == Block.pumpkin.blockID)
++        EnderFacingEvent event = new EnderFacingEvent(this, par1EntityPlayer);
++        if(MinecraftForge.EVENT_BUS.post(event))
++        {
++            return false;
++        }
++        else if (itemstack != null && itemstack.itemID == Block.pumpkin.blockID)
+         {
+             return false;
+         }
+@@ -264,12 +271,17 @@
       */
      protected boolean teleportTo(double par1, double par3, double par5)
      {
@@ -30,7 +46,7 @@
          boolean flag = false;
          int i = MathHelper.floor_double(this.posX);
          int j = MathHelper.floor_double(this.posY);
-@@ -439,7 +446,7 @@
+@@ -439,7 +451,7 @@
                      }
                  }
  

--- a/patches/minecraft/net/minecraft/item/Item.java.patch
+++ b/patches/minecraft/net/minecraft/item/Item.java.patch
@@ -60,7 +60,7 @@
          Vec3 vec31 = vec3.addVector((double)f7 * d3, (double)f6 * d3, (double)f8 * d3);
          return par1World.rayTraceBlocks_do_do(vec3, vec31, par3, !par3);
      }
-@@ -720,4 +736,491 @@
+@@ -720,4 +736,502 @@
      {
          StatList.initStats();
      }
@@ -550,5 +550,16 @@
 +        {
 +            stack.itemDamage = 0;
 +        }
++    }
++    
++    /**
++     * Determines if the ItemStack should be held as a bow in third-person-view.
++     * @param stack The ItemStack which should be rendered as bow
++     * @param player The player which holds the ItemStack
++     * @return if the ItemStack should render as a bow
++     */
++    @SideOnly(Side.CLIENT)
++    public boolean renderAsBow(ItemStack stack, EntityPlayer player) {
++        return stack.itemID == Item.bow.itemID;
 +    }
  }


### PR DESCRIPTION
The first hook allows modders to let one of their items (preferably a
custom bow) render /being held as a bow, without a need to make a custom
Item Renderer.
The second is an event which is triggered whenever a player is facing /
looking at an Enderman. It is useful as an event because modders are
able to check the circumstances for if the Enderman should get
aggressive towards the looking player, without needing to have an item /
block for it. It is cancellable, and if a modder cancels it, the Enderman won't get aggressive when looked at.
