### PR TITLE
Expose the EntityLiving's combat tracker

### DIFF
--- a/common/forge_at.cfg
+++ b/common/forge_at.cfg
@@ -96,6 +96,7 @@ public-f aab.A #FD:World/field_72982_D #villageCollectionObj
 public aab.G #FD:World/field_72993_I #activeChunkSet
 # EntityLiving
 public ng.be #FD:EntityLiving/field_70728_aV #experienceValue
+public ng.bt #FD:EntityLiving/field_94063_bt #combatTracker
 public ng.bp #FD:EntityLiving/field_70715_bh #targetTasks
 # GuiFlatPresets
 public axm.a(Ljava/lang/String;ILaav;Ljava/util/List;[Laei;)V #MD:GuiFlatPresets/func_82294_a


### PR DESCRIPTION
Allows for mods like ForgeIRC to have access to the new death messages for entities.
