### PR TITLE
RenderGameOverlayEvent.Post ALL is not called in GuiIngameForge

### DIFF
--- a/client/net/minecraftforge/client/GuiIngameForge.java
+++ b/client/net/minecraftforge/client/GuiIngameForge.java
@@ -150,6 +150,8 @@ public class GuiIngameForge extends GuiIngame
         GL11.glColor4f(1.0F, 1.0F, 1.0F, 1.0F);
         GL11.glDisable(GL11.GL_LIGHTING);
         GL11.glEnable(GL11.GL_ALPHA_TEST);
+
+        post(ALL);
     }
 
     public ScaledResolution getResolution()


### PR DESCRIPTION
This PR is a small fix for GuiIngameForge. I added an call to the Post ALL RenderGameOverlayEvent, because this was missing.
