### PR TITLE
Furnace XP bug fix

### DIFF
--- a/patches/minecraft/net/minecraft/item/crafting/FurnaceRecipes.java.patch
+++ b/patches/minecraft/net/minecraft/item/crafting/FurnaceRecipes.java.patch
@@ -44,7 +44,7 @@
 +    public void addSmelting(int itemID, int metadata, ItemStack itemstack, float experience)
 +    {
 +        metaSmeltingList.put(Arrays.asList(itemID, metadata), itemstack);
-        metaExperience.put(Arrays.asList(itemstack.itemID, itemstack.getItemDamage()), experience);
++        metaExperience.put(Arrays.asList(itemstack.itemID, itemstack.getItemDamage()), experience);
 +    }
 +
 +    /**


### PR DESCRIPTION
I found a bug that would mess up experience rewards for furnace recipes added with metadata. The id and meta from the input item was being stored, but the experience look up uses the output item's id and meta.
