### PR TITLE
Furnace XP bug fix (fixed)

### DIFF
--- a/patches/minecraft/net/minecraft/item/crafting/FurnaceRecipes.java.patch
+++ b/patches/minecraft/net/minecraft/item/crafting/FurnaceRecipes.java.patch
@@ -44,7 +44,7 @@
 +    public void addSmelting(int itemID, int metadata, ItemStack itemstack, float experience)
 +    {
 +        metaSmeltingList.put(Arrays.asList(itemID, metadata), itemstack);
-+        metaExperience.put(Arrays.asList(itemID, metadata), experience);
++        metaExperience.put(Arrays.asList(itemstack.itemID, itemstack.getItemDamage()), experience);
 +    }
 +
 +    /**


### PR DESCRIPTION
This fixes a bug where metadata sensitive experience rewards for furnace recipes were stored incorrectly. Before the input item's id and meta were stored, but the XP look up uses the output item's id and meta.

Sorry for the double PR, I was having trouble squashing my commits; now I'm using a proper Git setup (read: won't happen again).
