### PR TITLE
Addition: ItemStack sensitive canHarvestBlock

### DIFF
--- a/patches/minecraft/net/minecraft/item/Item.java.patch
+++ b/patches/minecraft/net/minecraft/item/Item.java.patch
@@ -60,7 +60,7 @@
          Vec3 vec31 = vec3.addVector((double)f7 * d3, (double)f6 * d3, (double)f8 * d3);
          return par1World.rayTraceBlocks_do_do(vec3, vec31, par3, !par3);
      }
-@@ -720,4 +736,497 @@
+@@ -720,4 +736,508 @@
      {
          StatList.initStats();
      }
@@ -556,5 +556,16 @@
 +        {
 +            stack.itemDamage = 0;
 +        }
++    }
++    
++    /**
++     * ItemStack sensitive version of {@link #canHarvestBlock(Block)} 
++     * @param par1Block The block trying to harvest
++     * @param itemStack The itemstack used to harvest the block
++     * @return true if can harvest the block
++     */
++    public boolean canHarvestBlock(Block par1Block, ItemStack itemStack)
++    {
++        return canHarvestBlock(par1Block);  
 +    }
  }

--- a/patches/minecraft/net/minecraft/item/ItemStack.java.patch
+++ b/patches/minecraft/net/minecraft/item/ItemStack.java.patch
@@ -59,3 +59,12 @@
      }
  
      /**
+@@ -396,7 +391,7 @@
+      */
+     public boolean canHarvestBlock(Block par1Block)
+     {
+-        return Item.itemsList[this.itemID].canHarvestBlock(par1Block);
++        return Item.itemsList[this.itemID].canHarvestBlock(par1Block, this);
+     }
+ 
+     public boolean interactWith(EntityLiving par1EntityLiving)


### PR DESCRIPTION
Added the method canHarvestBlock(block, itemStack)

defaults to canHarvestBlock(block) result for redundancy.
