### PR TITLE
Visibility Change for InventoryLargeChest fields

### DIFF
--- a/common/forge_at.cfg
+++ b/common/forge_at.cfg
@@ -156,3 +156,6 @@ protected aww.* #FD:GuiIngame/* # All private -> protected
 protected aww.*() #MD:GuiIngame/* # All private -> protected
 #ItemStack
 default wm.e #FD:ItemStack/field_77991_e # make default access for itemDamage
+# InventoryLargeChest
+public ls.c #FD:InventoryLargeChest/field_70478_c #lowerChest
+public ls.b #FD:InventoryLargeChest/field_70477_b #upperChest


### PR DESCRIPTION
Changes InventoryLargeChest.upper/lowerChest to public to allow
comparison of composite inventory.
