### PR TITLE
Add support for servers to register dimensions on client.

### DIFF
--- a/common/net/minecraftforge/common/DimensionManager.java
+++ b/common/net/minecraftforge/common/DimensionManager.java
@@ -145,6 +145,11 @@ public class DimensionManager
         dimensions.remove(id);
     }
 
+    public static boolean isDimensionRegistered(int dim)
+    {
+        return dimensions.containsKey(dim);
+    }
+
     public static int getProviderType(int dim)
     {
         if (!dimensions.containsKey(dim))

--- a/common/net/minecraftforge/common/network/DimensionRegisterPacket.java
+++ b/common/net/minecraftforge/common/network/DimensionRegisterPacket.java
@@ -1,0 +1,72 @@
+/**
+ * This software is provided under the terms of the Minecraft Forge Public
+ * License v1.0.
+ */
+
+package net.minecraftforge.common.network;
+
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.entity.player.EntityPlayerMP;
+import net.minecraft.network.INetworkManager;
+import net.minecraft.network.packet.NetHandler;
+import net.minecraftforge.common.DimensionManager;
+
+import com.google.common.io.ByteArrayDataInput;
+import com.google.common.io.ByteArrayDataOutput;
+import com.google.common.io.ByteStreams;
+
+/**
+ * This class offers the ability for servers to register dimensions on client.
+ */
+public class DimensionRegisterPacket extends ForgePacket
+{
+
+    /** The dimension ID to register on client */
+    public int dimensionId;
+    /** The provider ID to register with dimension on client */
+    public int providerId;
+
+    // nullary constructor required by ForgePacket.make()
+    public DimensionRegisterPacket() {}
+
+    public DimensionRegisterPacket(int dimensionId, int providerId)
+    {
+        this.dimensionId = dimensionId;
+        this.providerId = providerId;
+    }
+
+    @Override
+    public byte[] generatePacket(Object... data)
+    {
+        ByteArrayDataOutput dat = ByteStreams.newDataOutput();
+        dat.writeInt(this.dimensionId);
+        dat.writeInt(this.providerId);
+        return dat.toByteArray();
+    }
+
+    @Override
+    public ForgePacket consumePacket(byte[] data)
+    {
+        ByteArrayDataInput dat = ByteStreams.newDataInput(data);
+        dimensionId = dat.readInt();
+        providerId = dat.readInt();
+        return this;
+    }
+
+    @Override
+    public void execute(INetworkManager network, EntityPlayer player)
+    {
+        if (!(player instanceof EntityPlayerMP))
+        {
+            if (!DimensionManager.isDimensionRegistered(dimensionId))
+            {
+                DimensionManager.registerDimension(dimensionId, providerId);
+            }
+            if (player != null && player.worldObj != null)
+            {
+                player.worldObj.provider.dimensionId = dimensionId;
+            }
+        }
+    }
+
+}

--- a/common/net/minecraftforge/common/network/ForgePacket.java
+++ b/common/net/minecraftforge/common/network/ForgePacket.java
@@ -25,7 +25,10 @@ public abstract class ForgePacket
     public static final String CHANNEL_ID = "FORGE";
     enum Type
     {
-        FAKE_TEMP(ForgePacket.class);
+        /**
+         * Registers a dimension for a provider on client
+         */
+        REGISTERDIMENSION(DimensionRegisterPacket.class);
 
         private Class<? extends ForgePacket> packetType;
         private ConcurrentMap<INetworkManager, ForgePacket> partTracker;


### PR DESCRIPTION
In order to support multi-worlds such as MultiVerse, the server needs the
ability to register dimensions on client or many forge mods such as IC2
will not function correctly. This has been an issue for MCPC which
provides both Forge and Bukkit support to players. By adding the
DimensionRegisterPacket class, MCPC now has the ability to send the
required packet to client to register a dimension with DimensionManager.
