### PR TITLE
Add more render options

### DIFF
--- a/client/net/minecraftforge/client/GuiIngameForge.java
+++ b/client/net/minecraftforge/client/GuiIngameForge.java
@@ -68,7 +68,7 @@ public class GuiIngameForge extends GuiIngame
     public static boolean renderObjective = true;
     public static boolean renderVignette = true;
     public static boolean renderSleepFade = true;
-    public static boolean renderToolHighlight = true
+    public static boolean renderDebugText = true
     public static boolean renderToolTips = true;
     public static boolean renderMusicOverlay = true;
     public static boolean renderChat = true;
@@ -136,8 +136,8 @@ public class GuiIngameForge extends GuiIngame
 
         if (renderExperiance) renderExperience(width, height);
         if (renderSleepFade) renderSleepFade(width, height);
-        if (renderToolHighlight) renderToolHightlight(width, height);
-        if (renderToolTips) renderHUDText(width, height);
+        if (renderToolTips) renderToolHightlight(width, height);
+        if (renderDebugText) renderHUDText(width, height);
         if (renderMusicOverlay) renderRecordOverlay(width, height, partialTicks);
 
         ScoreObjective objective = mc.theWorld.getScoreboard().func_96539_a(1);


### PR DESCRIPTION
Adds ability to disable vignette, sleepfade, toolhighlight, tooltips, music overlay, chat and playerlist.

Makes the functionality actually useful, mods like Advanced HUD could greatly benefit from this, as they could switch to an event-based system rather than completely replacing mc.ingameGUI with themselves.
