### PR TITLE
Vanilla hopper should obey the IInventory contract

### DIFF
--- a/patches/minecraft/net/minecraft/tileentity/TileEntityHopper.patch
+++ b/patches/minecraft/net/minecraft/tileentity/TileEntityHopper.patch
@@ -1,0 +1,38 @@
+--- ../src_base/minecraft/net/minecraft/tileentity/TileEntityHopper.java
++++ ../src_work/minecraft/net/minecraft/tileentity/TileEntityHopper.java
+@@ -449,17 +449,28 @@
+ 
+             if (itemstack1 == null)
+             {
++                int max = Math.min(par1ItemStack.getMaxStackSize(), par0IInventory.getInventoryStackLimit());
++                if (max >= par1ItemStack.stackSize)
++                {
+-                par0IInventory.setInventorySlotContents(par2, par1ItemStack);
+-                par1ItemStack = null;
++                    par0IInventory.setInventorySlotContents(par2, par1ItemStack);
++                    par1ItemStack = null;
++                }
++                else
++                {
++                    par0IInventory.setInventorySlotContents(par2, par1ItemStack.splitStack(max));
++                }
+                 flag = true;
+             }
+             else if (areItemStacksEqualItem(itemstack1, par1ItemStack))
+             {
+-                int k = par1ItemStack.getMaxStackSize() - itemstack1.stackSize;
+-                int l = Math.min(par1ItemStack.stackSize, k);
++                int max = Math.min(par1ItemStack.getMaxStackSize(), par0IInventory.getInventoryStackLimit());
++                if (max > itemstack1.stackSize)
++                {
++                    int l = Math.min(par1ItemStack.stackSize, max - itemstack1.stackSize);
+-                par1ItemStack.stackSize -= l;
+-                itemstack1.stackSize += l;
+-                flag = l > 0;
++                    par1ItemStack.stackSize -= l;
++                    itemstack1.stackSize += l;
++                    flag = l > 0;
++                }
+             }
+ 
+             if (flag)


### PR DESCRIPTION
`private static ItemStack func_102014_c(IInventory inventory, ItemStack stack, int slot, int side)` in TileEntityHopper now takes into account IInventory.getInventoryStackLimit() when inserting items
