### PR TITLE
Biome dictionary refactor

### DIFF
--- a/common/net/minecraftforge/common/BiomeDictionary.java
+++ b/common/net/minecraftforge/common/BiomeDictionary.java
@@ -84,31 +84,20 @@ public class BiomeDictionary
     }
 
     /**
-<<<<<<< HEAD
-     * Registers a biome with a set of biome types
-=======
      * Registers a biome with a set of biome types. DEPRECATED - use Collection based version
->>>>>>> Redesigned BiomeDictionary to increase performance, reduce memory resources and fix bugs:
      * 
      * @param biome the biome to be registered
      * @param type the set of types to register the biome
      * @return returns true if the biome was registered successfully
      */
-<<<<<<< HEAD
-=======
     @Deprecated
->>>>>>> Redesigned BiomeDictionary to increase performance, reduce memory resources and fix bugs:
     public static boolean registerBiomeType(BiomeGenBase biome, Type ... types)
     {
         return registerBiomeType(biome, Arrays.asList(types));
     }
     
     /**
-<<<<<<< HEAD
-     * Returns an array of biomes registered with a specific type
-=======
      * Returns an array of biomes registered with a specific type. DEPRECATED - use Collection based version see {@link getBiomeListForType()}
->>>>>>> Redesigned BiomeDictionary to increase performance, reduce memory resources and fix bugs:
      * 
      * @param type the Type to look for
      * @return an array of biomes of the specified type
@@ -149,19 +138,12 @@ public class BiomeDictionary
     }
 
     /**
-<<<<<<< HEAD
-     * Gets an array of Types that a specific biome is registered with
-=======
      * Gets an array of Types that a specific biome is registered with. DEPRECATED - use Collection based version {@link getTypesListForBiome()}
->>>>>>> Redesigned BiomeDictionary to increase performance, reduce memory resources and fix bugs:
      * 
      * @param biome the biome to check
      * @return the array of types
      */
-<<<<<<< HEAD
-=======
     @Deprecated
->>>>>>> Redesigned BiomeDictionary to increase performance, reduce memory resources and fix bugs:
     public static Type[] getTypesForBiome(BiomeGenBase biome)
     {
         return getTypesListForBiome(biome).toArray(new Type[0]);
@@ -251,11 +233,8 @@ public class BiomeDictionary
     {
         if (biome == null) return;
         
-<<<<<<< HEAD
-=======
         final EnumSet<Type> types = EnumSet.noneOf(Type.class);
         
->>>>>>> Redesigned BiomeDictionary to increase performance, reduce memory resources and fix bugs:
         if(biome.theBiomeDecorator.treesPerChunk >= 3)
         {
             if(biome.isHighHumidity() && biome.temperature >= 1.0F)


### PR DESCRIPTION
Redesigned BiomeDictionary to increase performance, reduce memory usage and fix bugs:
- Memory footprint reduced: Rather than an array of 256 private classes containing a List of pointers to enum values, implementation now uses a multimap containing EnumSets (implemented with bit fields). Quantity of EnumSets is reduced using sparse map rather than full 256 array.
- Performance is increased because EnumSet lookups are binary masks instead of array indexes
- isBiomeRegistered() always returned true because valid BiomeGenBase objects are always indexed in BiomegenBase.biomeList (see BiomegenBase constructor). This bug prevented best guess auto tagging of custom biomes because auto tagger (checkRegistration()) would not run if isBiomeRegistered() returned true--which it always did.

Public interface is maintained with additional support added for modern java collections. Array based and variable argument methods are deprecated.
