### PR TITLE
getPickBlock (in Block) should have an EntitiyPlayer parameter.

### DIFF
--- a/common/net/minecraftforge/common/ForgeHooks.java
+++ b/common/net/minecraftforge/common/ForgeHooks.java
@@ -261,7 +261,7 @@ public class ForgeHooks
                 return false;
             }
 
-            result = var8.getPickBlock(target, world, x, y, z);
+            result = var8.getPickBlock(target, player, world, x, y, z);
         }
         else
         {

--- a/patches/minecraft/net/minecraft/block/Block.java.patch
+++ b/patches/minecraft/net/minecraft/block/Block.java.patch
@@ -165,7 +165,7 @@
      }
  
      /**
-@@ -1443,4 +1464,950 @@
+@@ -1443,4 +1464,956 @@
          canBlockGrass[0] = true;
          StatList.initBreakableStats();
      }
@@ -820,6 +820,12 @@
 +     * @param target The full target the player is looking at
 +     * @return A ItemStack to add to the player's inventory, Null if nothing should be added.
 +     */
++    public ItemStack getPickBlock(MovingObjectPosition target, EntityPlayer player,  World world, int x, int y, int z)
++    {
++        return getPickBlock(target, world, x, y, z);
++    }
++    
++    @Deprecated // See EntityPlayer sensitive one above.
 +    public ItemStack getPickBlock(MovingObjectPosition target, World world, int x, int y, int z)
 +    {
 +        int id = idPicked(world, x, y, z);


### PR DESCRIPTION
Adding an EntityPlayer parameter to the getPickBlock() method would be quite useful, especially for providing a different block when Shift-Picked.

I'd do a PR, but can't seem to get a Forge dev environment setup...
