### PR TITLE
Allow to use ID for customCraftingMaterial

### DIFF
--- a/patches/minecraft/net/minecraft/item/EnumArmorMaterial.java.patch
+++ b/patches/minecraft/net/minecraft/item/EnumArmorMaterial.java.patch
@@ -6,7 +6,7 @@
      private int enchantability;
 +
 +    //Added by forge for custom Armor materials.
-+    public Item customCraftingMaterial = null;
++    public int customCraftingMaterialID = 0;
  
      private EnumArmorMaterial(int par3, int[] par4ArrayOfInteger, int par5)
      {
@@ -22,7 +22,7 @@
 +            case GOLD:    return Item.ingotGold.itemID;
 +            case IRON:    return Item.ingotIron.itemID;
 +            case DIAMOND: return Item.diamond.itemID;
-+            default:      return (customCraftingMaterial == null ? 0 : customCraftingMaterial.itemID);
++            default:      return customCraftingMaterialID;
 +        }
      }
  }

--- a/patches/minecraft/net/minecraft/item/EnumToolMaterial.java.patch
+++ b/patches/minecraft/net/minecraft/item/EnumToolMaterial.java.patch
@@ -6,7 +6,7 @@
      private final int enchantability;
 +
 +    //Added by forge for custom Armor materials.
-+    public Item customCraftingMaterial = null;
++    public int customCraftingMaterialID = 0;
  
      private EnumToolMaterial(int par3, int par4, float par5, int par6, int par7)
      {
@@ -22,7 +22,7 @@
 +            case GOLD:    return Item.ingotGold.itemID;
 +            case IRON:    return Item.ingotIron.itemID;
 +            case EMERALD: return Item.diamond.itemID;
-+            default:      return (customCraftingMaterial == null ? 0 : customCraftingMaterial.itemID);
++            default:      return customCraftingMaterialID;
 +        }
      }
  }


### PR DESCRIPTION
This patch allow to use net.minecraft.block.Block as custom crafting material
transparently.
For example, with current Forge, you can't use net.minecraft.block.Block.obsidian
as custom crafting material.
This impose you override 'getIsRepairable' in every item you want to be
repairable (if it's using a block as base material).

This patch changes existing Forge patches for minecraft:
- net.minecraft.item.EnumArmorMaterial.customCraftingMaterial (Item type)
  becomes net.minecraft.item.EnumArmorMaterial.customCraftingMaterialID
- net.minecraft.item.EnumToolMaterial.customCraftingMaterial (Item type)
  becomes net.minecraft.item.EnumToolMaterial.customCraftingMaterialID

With this patch applied you'll be able to use a Block as custom crafting
material (and Item too of course) by passing it blockID od itemID field.
