### PR TITLE
Change startConversion in EntityZombie to public

### DIFF
--- a/common/forge_at.cfg
+++ b/common/forge_at.cfg
@@ -156,3 +156,5 @@ protected aww.* #FD:GuiIngame/* # All private -> protected
 protected aww.*() #MD:GuiIngame/* # All private -> protected
 #ItemStack
 default wm.e #FD:ItemStack/field_77991_e # make default access for itemDamage
+#EntityZombie
+public sj.a(I)V #MD:EntityZombie/func_82228_a #startConversion


### PR DESCRIPTION
Made startConversion public so everybody can use it.
I need this for my mod, so i don't have to create a core mod for such a small change.
