### PR TITLE
Added BlockPlaceEvent which fires before placing a block.

### DIFF
--- a/common/net/minecraftforge/common/BlockSnapshot.java
+++ b/common/net/minecraftforge/common/BlockSnapshot.java
@@ -1,0 +1,146 @@
+package net.minecraftforge.common;
+
+
+import java.util.List;
+
+import net.minecraft.block.Block;
+import net.minecraft.nbt.NBTTagCompound;
+import net.minecraft.tileentity.TileEntity;
+import net.minecraft.world.World;
+import net.minecraft.world.chunk.Chunk;
+
+public class BlockSnapshot {
+    public final World world;
+    public final int x;
+    public final int y;
+    public final int z;
+    public final int blockID;
+    public final int meta;
+    private final NBTTagCompound nbt;
+
+    public BlockSnapshot(World world, int x, int y, int z, int meta) {
+        this.world = world;
+        this.x = x;
+        this.y = y;
+        this.z = z;
+        this.blockID = world.getBlockId(x, y, z);
+        this.meta = meta;
+        TileEntity te = world.getBlockTileEntity(x, y, z);
+        if (te != null)
+        {
+            nbt = new NBTTagCompound();
+            te.writeToNBT(nbt);
+        }
+        else nbt = null;
+    }
+
+    public Block getBlock() {
+        return Block.blocksList[world.getBlockId(x, y, z)];
+    }
+
+    public TileEntity getTileEntity() {
+        if (nbt != null)
+            return TileEntity.createAndLoadEntity(nbt);
+        else return null;
+    }
+
+    public boolean restore() {
+        return restore(false);
+    }
+
+    public boolean restore(boolean force) {
+        return restore(force, true);
+    }
+
+    public boolean restore(boolean force, boolean applyPhysics) {
+        Block block = getBlock();
+
+        if (block != Block.blocksList[blockID] || world.getBlockMetadata(x & 15, y, z & 15) != meta) {
+            if (force) {
+                world.setBlock(x, y, z, blockID, meta, applyPhysics ? 3 : 2);
+            } else {
+                return false;
+            }
+        }
+
+        world.setBlockMetadataWithNotify(x, y, z, meta, applyPhysics ? 3 : 2);
+        world.markBlockForUpdate(x, y, z);
+        if (nbt != null)
+        {
+            TileEntity te = world.getBlockTileEntity(x, y, z);
+            if (te != null)
+            {
+                te.readFromNBT(nbt);
+            }
+        }
+
+        return true;
+    }
+
+    public boolean restoreToLocation(World world, int x, int y, int z, boolean force, boolean applyPhysics) {
+        Block block = getBlock();
+
+        if (block != Block.blocksList[blockID] || world.getBlockMetadata(x & 15, y, z & 15) != meta) {
+            if (force) {
+                world.setBlock(x, y, z, blockID, meta, applyPhysics ? 3 : 2);
+            } else {
+                return false;
+            }
+        }
+
+        world.setBlockMetadataWithNotify(x, y, z, meta, applyPhysics ? 3 : 2);
+        world.markBlockForUpdate(x, y, z);
+        if (nbt != null)
+        {
+            TileEntity te = world.getBlockTileEntity(x, y, z);
+            if (te != null)
+            {
+                te.readFromNBT(nbt);
+            }
+        }
+
+        return true;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (obj == null) {
+            return false;
+        }
+        if (getClass() != obj.getClass()) {
+            return false;
+        }
+        final BlockSnapshot other = (BlockSnapshot) obj;
+        if (this.world != other.world && (this.world == null || !this.world.equals(other.world))) {
+            return false;
+        }
+        if (this.x != other.x) {
+            return false;
+        }
+        if (this.y != other.y) {
+            return false;
+        }
+        if (this.z != other.z) {
+            return false;
+        }
+        if (this.blockID != other.blockID) {
+            return false;
+        }
+        if (this.meta != other.meta) {
+            return false;
+        }
+        return true;
+    }
+
+    @Override
+    public int hashCode() {
+        int hash = 7;
+        hash = 73 * hash + (this.world != null ? this.world.hashCode() : 0);
+        hash = 73 * hash + this.x;
+        hash = 73 * hash + this.y;
+        hash = 73 * hash + this.z;
+        hash = 73 * hash + this.blockID;
+        hash = 73 * hash + this.meta;
+        return hash;
+    }
+}

--- a/common/net/minecraftforge/event/block/BlockEvent.java
+++ b/common/net/minecraftforge/event/block/BlockEvent.java
@@ -1,0 +1,35 @@
+package net.minecraftforge.event.block;
+
+import net.minecraft.block.Block;
+import net.minecraft.world.World;
+import net.minecraftforge.event.Cancelable;
+import net.minecraftforge.event.Event;
+import net.minecraftforge.event.world.ChunkWatchEvent;
+
+/**
+ * Represents a block related event.
+ */
+public abstract class BlockEvent extends Event 
+{
+    /** Reference to the World object which can never be null. */
+    public final World world;
+    /** Reference to the Block object. */
+    public final Block block;
+    /** Block metadata */
+    public final int meta;
+    /** x coord where the block event took place. */
+    public final int x;
+    /** y coord where the block event took place. */
+    public final int y;
+    /** z coord where the block event took place. */
+    public final int z;
+    public BlockEvent(World world, int x, int y, int z, int meta, Block block) {
+        super();
+        this.world = world;
+        this.block = block;
+        this.meta = meta;
+        this.x = x;
+        this.y = y;
+        this.z = z;
+    }
+}

--- a/common/net/minecraftforge/event/block/BlockPlaceEvent.java
+++ b/common/net/minecraftforge/event/block/BlockPlaceEvent.java
@@ -1,0 +1,40 @@
+package net.minecraftforge.event.block;
+
+import net.minecraft.block.Block;
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.item.ItemBlock;
+import net.minecraft.item.ItemStack;
+import net.minecraft.world.World;
+import net.minecraftforge.common.BlockSnapshot;
+import net.minecraftforge.event.Cancelable;
+import net.minecraftforge.event.Event;
+
+/**
+ * Called when a block is placed by a player.
+ *
+ * If a Block Place event is cancelled, the block will not be placed.
+ */
+@Cancelable
+public class BlockPlaceEvent extends BlockEvent {
+
+    public final EntityPlayer player;
+    public final ItemStack itemstack;
+    public final int side;
+    public final int clickedX;
+    public final int clickedY;
+    public final int clickedZ;
+    public final int meta;
+    public final BlockSnapshot blocksnapshot;
+
+    public BlockPlaceEvent(ItemStack stack, EntityPlayer player, World world, int x, int y, int z, int side, int meta, int clickedX, int clickedY, int clickedZ, BlockSnapshot blocksnapshot) {
+        super(world, x, y, z, meta, blocksnapshot.getBlock());
+        this.side = side;
+        this.clickedX = clickedX;
+        this.clickedY = clickedY;
+        this.clickedZ = clickedZ;
+        this.meta = meta;
+        this.player = player;
+        this.itemstack = stack;
+        this.blocksnapshot = blocksnapshot;
+    }
+}

--- a/patches/minecraft/net/minecraft/item/ItemBed.java.patch
+++ b/patches/minecraft/net/minecraft/item/ItemBed.java.patch
@@ -1,0 +1,27 @@
+--- ../src_base/minecraft/net/minecraft/item/ItemBed.java
++++ ../src_work/minecraft/net/minecraft/item/ItemBed.java
+@@ -21,6 +21,7 @@
+      */
+     public boolean onItemUse(ItemStack par1ItemStack, EntityPlayer par2EntityPlayer, World par3World, int par4, int par5, int par6, int par7, float par8, float par9, float par10)
+     {
++        final int clickedX = par4, clickedY = par5, clickedZ = par6;
+         if (par3World.isRemote)
+         {
+             return true;
+@@ -61,7 +62,15 @@
+             {
+                 if (par3World.isAirBlock(par4, par5, par6) && par3World.isAirBlock(par4 + b0, par5, par6 + b1) && par3World.doesBlockHaveSolidTopSurface(par4, par5 - 1, par6) && par3World.doesBlockHaveSolidTopSurface(par4 + b0, par5 - 1, par6 + b1))
+                 {
+-                    par3World.setBlock(par4, par5, par6, blockbed.blockID, i1, 3);
++                    if (!par3World.isRemote)
++                    {
++                        ItemBlock itemblock = (ItemBlock)Item.itemsList[blockbed.blockID];
++                        if (!itemblock.placeBlockAt(par3World, par2EntityPlayer, null, par4, par5, par6, par7, blockbed.blockID, i1, clickedX, clickedY, clickedZ))
++                        {
++                            return false;
++                        }
++                    }
++                    else par3World.setBlock(par4, par5, par6, blockbed.blockID, i1, 3);
+ 
+                     if (par3World.getBlockId(par4, par5, par6) == blockbed.blockID)
+                     {

--- a/patches/minecraft/net/minecraft/item/ItemBlock.java.patch
+++ b/patches/minecraft/net/minecraft/item/ItemBlock.java.patch
@@ -1,6 +1,30 @@
 --- ../src_base/minecraft/net/minecraft/item/ItemBlock.java
 +++ ../src_work/minecraft/net/minecraft/item/ItemBlock.java
-@@ -64,7 +64,8 @@
+@@ -4,12 +4,16 @@
+ import cpw.mods.fml.relauncher.SideOnly;
+ import java.util.List;
+ import net.minecraft.block.Block;
++import net.minecraft.block.BlockContainer;
+ import net.minecraft.client.renderer.texture.IconRegister;
+ import net.minecraft.creativetab.CreativeTabs;
+ import net.minecraft.entity.Entity;
+ import net.minecraft.entity.player.EntityPlayer;
+ import net.minecraft.util.Icon;
+ import net.minecraft.world.World;
++import net.minecraftforge.common.BlockSnapshot;
++import net.minecraftforge.common.MinecraftForge;
++import net.minecraftforge.event.block.BlockPlaceEvent;
+ 
+ public class ItemBlock extends Item
+ {
+@@ -58,13 +62,15 @@
+      */
+     public boolean onItemUse(ItemStack par1ItemStack, EntityPlayer par2EntityPlayer, World par3World, int par4, int par5, int par6, int par7, float par8, float par9, float par10)
+     {
++        int clickedX = par4, clickedY = par5, clickedZ = par6;
+         int i1 = par3World.getBlockId(par4, par5, par6);
+ 
+         if (i1 == Block.snow.blockID && (par3World.getBlockMetadata(par4, par5, par6) & 7) < 1)
          {
              par7 = 1;
          }
@@ -10,7 +34,7 @@
          {
              if (par7 == 0)
              {
-@@ -115,14 +116,8 @@
+@@ -115,19 +121,7 @@
              int j1 = this.getMetadata(par1ItemStack.getItemDamage());
              int k1 = Block.blocksList[this.blockID].onBlockPlaced(par3World, par4, par5, par6, par7, par8, par9, par10, j1);
  
@@ -22,12 +46,16 @@
 -                    Block.blocksList[this.blockID].onPostBlockPlaced(par3World, par4, par5, par6, k1);
 -                }
 -
-+            if (placeBlockAt(par1ItemStack, par2EntityPlayer, par3World, par4, par5, par6, par7, par8, par9, par10, k1))
-+            {
-                 par3World.playSoundEffect((double)((float)par4 + 0.5F), (double)((float)par5 + 0.5F), (double)((float)par6 + 0.5F), block.stepSound.getPlaceSound(), (block.stepSound.getVolume() + 1.0F) / 2.0F, block.stepSound.getPitch() * 0.8F);
-                 --par1ItemStack.stackSize;
-             }
-@@ -148,7 +143,8 @@
+-                par3World.playSoundEffect((double)((float)par4 + 0.5F), (double)((float)par5 + 0.5F), (double)((float)par6 + 0.5F), block.stepSound.getPlaceSound(), (block.stepSound.getVolume() + 1.0F) / 2.0F, block.stepSound.getPitch() * 0.8F);
+-                --par1ItemStack.stackSize;
+-            }
+-
+-            return true;
++            return placeBlockAt(par3World, par2EntityPlayer, par1ItemStack, par4, par5, par6, par7, this.blockID, k1, clickedX, clickedY, clickedZ);
+         }
+         else
+         {
+@@ -148,7 +142,8 @@
          {
              par5 = 1;
          }
@@ -37,7 +65,7 @@
          {
              if (par5 == 0)
              {
-@@ -231,4 +227,28 @@
+@@ -231,4 +226,70 @@
              this.field_94588_b = par1IconRegister.registerIcon(s);
          }
      }
@@ -49,20 +77,62 @@
 +     * @param stack The item stack that was used to place the block. This can be changed inside the method.
 +     * @param player The player who is placing the block. Can be null if the block is not being placed by a player.
 +     * @param side The side the player (or machine) right-clicked on.
++     * @param id The block ID for item.
++     * @param metadata The block metadata.
++     * @param clickedX The x-coordinate for block that was right-clicked on.
++     * @param clickedY The y-coordinate for block that was right-clicked on.
++     * @param clickedZ The z-coordinate for block that was right-clicked on.
 +     */
-+    public boolean placeBlockAt(ItemStack stack, EntityPlayer player, World world, int x, int y, int z, int side, float hitX, float hitY, float hitZ, int metadata)
++    public boolean placeBlockAt(World world, EntityPlayer player, ItemStack stack, int x, int y, int z, int side, int id, int metadata, int clickedX, int clickedY, int clickedZ)
 +    {
-+       if (!world.setBlock(x, y, z, this.blockID, metadata, 3))
-+       {
-+           return false;
-+       }
++        if (!world.isRemote)
++        {
++            BlockSnapshot blocksnapshot = new BlockSnapshot(world, x, y, z, world.getBlockMetadata(x, y, z));
++            world.callingPlaceEvent = true;
++            world.setBlock(x, y, z, id, metadata, 2);
++            BlockPlaceEvent event = new BlockPlaceEvent(stack, player, world, x, y, z, side, metadata, clickedX, clickedY, clickedZ, blocksnapshot);
 +
-+       if (world.getBlockId(x, y, z) == this.blockID)
-+       {
-+           Block.blocksList[this.blockID].onBlockPlacedBy(world, x, y, z, player, stack);
-+           Block.blocksList[this.blockID].onPostBlockPlaced(world, x, y, z, metadata);
-+       }
++            if (event.isCanceled())
++            {
++                blocksnapshot.restore(true, false);
++                world.callingPlaceEvent = false;
++                return false;
++            }
 +
-+       return true;
++            world.callingPlaceEvent = false;
++            int newId = world.getBlockId(x, y, z);
++            int newData = world.getBlockMetadata(x, y, z);
++    
++            Block block = Block.blocksList[newId];
++    
++            if (block != null && !(block instanceof BlockContainer))   // Containers get placed automatically
++            {
++                block.onBlockAdded(world, x, y, z);
++            }
++    
++            world.notifyBlockChange(x, y, z, newId);
++    
++            // Skulls don't get block data applied to them
++            if (block != null && block != Block.skull)
++            {
++                block.onBlockPlacedBy(world, x, y, z, player, stack);
++                block.onPostBlockPlaced(world, x, y, z, newData);
++            }
++        }
++        else // standard method for client
++        {
++            if (!world.setBlock(x, y, z, id, metadata, 3))
++            {
++                return false;
++            }
++
++            if (world.getBlockId(x, y, z) == id)
++            {
++                Block.blocksList[id].onBlockPlacedBy(world, x, y, z, player, stack);
++                Block.blocksList[id].onPostBlockPlaced(world, x, y, z, metadata);
++            }
++        }
++
++        return true;
 +    }
  }

--- a/patches/minecraft/net/minecraft/item/ItemDoor.java.patch
+++ b/patches/minecraft/net/minecraft/item/ItemDoor.java.patch
@@ -1,0 +1,110 @@
+--- ../src_base/minecraft/net/minecraft/item/ItemDoor.java
++++ ../src_work/minecraft/net/minecraft/item/ItemDoor.java
+@@ -1,5 +1,7 @@
+ package net.minecraft.item;
+ 
++import net.minecraft.entity.player.EntityPlayerMP;
++import net.minecraft.network.packet.Packet53BlockChange;
+ import net.minecraft.block.Block;
+ import net.minecraft.block.material.Material;
+ import net.minecraft.creativetab.CreativeTabs;
+@@ -25,6 +27,7 @@
+      */
+     public boolean onItemUse(ItemStack par1ItemStack, EntityPlayer par2EntityPlayer, World par3World, int par4, int par5, int par6, int par7, float par8, float par9, float par10)
+     {
++        final int clickedX = par4, clickedY = par5, clickedZ = par6;
+         if (par7 != 1)
+         {
+             return false;
+@@ -52,7 +55,11 @@
+                 else
+                 {
+                     int i1 = MathHelper.floor_double((double)((par2EntityPlayer.rotationYaw + 180.0F) * 4.0F / 360.0F) - 0.5D) & 3;
+-                    placeDoorBlock(par3World, par4, par5, par6, i1, block);
++
++                    if (!place(par3World, par4, par5, par6, par7, i1, block, par2EntityPlayer, clickedX, clickedY, clickedZ))
++                    {
++                        return false;
++                    }
+                     --par1ItemStack.stackSize;
+                     return true;
+                 }
+@@ -66,33 +73,38 @@
+ 
+     public static void placeDoorBlock(World par0World, int par1, int par2, int par3, int par4, Block par5Block)
+     {
++        place(par0World, par1, par2, par3, 0, par4, par5Block, null, par1, par2, par3);
++    }
++
++    public static boolean place(World par0World, int par1, int par2, int par3, int par4, int par5, Block par6Block, EntityPlayer entityplayer, int clickedX, int clickedY, int clickedZ)
++    {
+         byte b0 = 0;
+         byte b1 = 0;
+ 
+-        if (par4 == 0)
++        if (par5 == 0)
+         {
+             b1 = 1;
+         }
+ 
+-        if (par4 == 1)
++        if (par5 == 1)
+         {
+             b0 = -1;
+         }
+ 
+-        if (par4 == 2)
++        if (par5 == 2)
+         {
+             b1 = -1;
+         }
+ 
+-        if (par4 == 3)
++        if (par5 == 3)
+         {
+             b0 = 1;
+         }
+ 
+         int i1 = (par0World.isBlockNormalCube(par1 - b0, par2, par3 - b1) ? 1 : 0) + (par0World.isBlockNormalCube(par1 - b0, par2 + 1, par3 - b1) ? 1 : 0);
+         int j1 = (par0World.isBlockNormalCube(par1 + b0, par2, par3 + b1) ? 1 : 0) + (par0World.isBlockNormalCube(par1 + b0, par2 + 1, par3 + b1) ? 1 : 0);
+-        boolean flag = par0World.getBlockId(par1 - b0, par2, par3 - b1) == par5Block.blockID || par0World.getBlockId(par1 - b0, par2 + 1, par3 - b1) == par5Block.blockID;
+-        boolean flag1 = par0World.getBlockId(par1 + b0, par2, par3 + b1) == par5Block.blockID || par0World.getBlockId(par1 + b0, par2 + 1, par3 + b1) == par5Block.blockID;
++        boolean flag = par0World.getBlockId(par1 - b0, par2, par3 - b1) == par6Block.blockID || par0World.getBlockId(par1 - b0, par2 + 1, par3 - b1) == par6Block.blockID;
++        boolean flag1 = par0World.getBlockId(par1 + b0, par2, par3 + b1) == par6Block.blockID || par0World.getBlockId(par1 + b0, par2 + 1, par3 + b1) == par6Block.blockID;
+         boolean flag2 = false;
+ 
+         if (flag && !flag1)
+@@ -104,9 +116,29 @@
+             flag2 = true;
+         }
+ 
+-        par0World.setBlock(par1, par2, par3, par5Block.blockID, par4, 2);
+-        par0World.setBlock(par1, par2 + 1, par3, par5Block.blockID, 8 | (flag2 ? 1 : 0), 2);
+-        par0World.notifyBlocksOfNeighborChange(par1, par2, par3, par5Block.blockID);
+-        par0World.notifyBlocksOfNeighborChange(par1, par2 + 1, par3, par5Block.blockID);
++        if (entityplayer != null && !par0World.isRemote)
++        {
++            ItemBlock itemblock = (ItemBlock)Item.itemsList[par6Block.blockID];
++            if (!itemblock.placeBlockAt(par0World, entityplayer, null, par1, par2, par3, par4, par6Block.blockID, par5, clickedX, clickedY, clickedZ))
++            {
++                ((EntityPlayerMP) entityplayer).playerNetServerHandler.sendPacketToPlayer(new Packet53BlockChange(par1, par2 + 1, par3, par0World));
++                return false;
++            }
++
++            if (par0World.getBlockId(par1, par2, par3) != par6Block.blockID)
++            {
++                ((EntityPlayerMP) entityplayer).playerNetServerHandler.sendPacketToPlayer(new Packet53BlockChange(par1, par2 + 1, par3, par0World));
++                return true;
++            }
++        }
++        else
++        {
++            par0World.setBlock(par1, par2, par3, par6Block.blockID, par5, 2);
++        }
++
++        par0World.setBlock(par1, par2 + 1, par3, par6Block.blockID, 8 | (flag2 ? 1 : 0), 2);
++        par0World.notifyBlocksOfNeighborChange(par1, par2, par3, par6Block.blockID);
++        par0World.notifyBlocksOfNeighborChange(par1, par2 + 1, par3, par6Block.blockID);
++        return true;
+     }
+ }

--- a/patches/minecraft/net/minecraft/item/ItemFlintAndSteel.java.patch
+++ b/patches/minecraft/net/minecraft/item/ItemFlintAndSteel.java.patch
@@ -1,6 +1,15 @@
 --- ../src_base/minecraft/net/minecraft/item/ItemFlintAndSteel.java
 +++ ../src_work/minecraft/net/minecraft/item/ItemFlintAndSteel.java
-@@ -57,9 +57,7 @@
+@@ -21,6 +21,8 @@
+      */
+     public boolean onItemUse(ItemStack par1ItemStack, EntityPlayer par2EntityPlayer, World par3World, int par4, int par5, int par6, int par7, float par8, float par9, float par10)
+     {
++        int clickedX = par4, clickedY = par5, clickedZ = par6; // CraftBukkit
++
+         if (par7 == 0)
+         {
+             --par5;
+@@ -57,12 +59,14 @@
          }
          else
          {
@@ -10,4 +19,12 @@
 +            if (par3World.isAirBlock(par4, par5, par6))
              {
                  par3World.playSoundEffect((double)par4 + 0.5D, (double)par5 + 0.5D, (double)par6 + 0.5D, "fire.ignite", 1.0F, itemRand.nextFloat() * 0.4F + 0.8F);
-                 par3World.setBlock(par4, par5, par6, Block.fire.blockID);
+-                par3World.setBlock(par4, par5, par6, Block.fire.blockID);
++                ItemBlock itemblock = (ItemBlock)Item.itemsList[Block.fire.blockID];
++                if (!itemblock.placeBlockAt(par3World, par2EntityPlayer, null, par4, par5, par6, par7, Block.fire.blockID, par3World.getBlockMetadata(par4, par5, par6), clickedX, clickedY, clickedZ))
++                {
++                    return false;
++                }
+             }
+ 
+             par1ItemStack.damageItem(1, par2EntityPlayer);

--- a/patches/minecraft/net/minecraft/item/ItemHoe.java.patch
+++ b/patches/minecraft/net/minecraft/item/ItemHoe.java.patch
@@ -10,7 +10,15 @@
  
  public class ItemHoe extends Item
  {
-@@ -32,10 +35,23 @@
+@@ -26,16 +29,30 @@
+      */
+     public boolean onItemUse(ItemStack par1ItemStack, EntityPlayer par2EntityPlayer, World par3World, int par4, int par5, int par6, int par7, float par8, float par9, float par10)
+     {
++        final int clickedX = par4, clickedY = par5, clickedZ = par6;
++
+         if (!par2EntityPlayer.canPlayerEdit(par4, par5, par6, par7, par1ItemStack))
+         {
+             return false;
          }
          else
          {
@@ -30,9 +38,29 @@
 -            int j1 = par3World.getBlockId(par4, par5 + 1, par6);
 +            boolean air = par3World.isAirBlock(par4, par5 + 1, par6);
  
--            if ((par7 == 0 || j1 != 0 || i1 != Block.grass.blockID) && i1 != Block.dirt.blockID)
-+            //Forge: Change 0 to air, also BugFix: parens mismatch causing you to be able to hoe dirt under dirt/grass
-+            if (par7 == 0 || !air || (i1 != Block.grass.blockID && i1 != Block.dirt.blockID))
+-            if (par7 != 0 && j1 == 0 && (i1 == Block.grass.blockID || i1 == Block.dirt.blockID))
++            if (par7 != 0 && air && (i1 == Block.grass.blockID || i1 == Block.dirt.blockID))
              {
-                 return false;
-             }
+                 Block block = Block.tilledField;
+                 par3World.playSoundEffect((double)((float)par4 + 0.5F), (double)((float)par5 + 0.5F), (double)((float)par6 + 0.5F), block.stepSound.getStepSound(), (block.stepSound.getVolume() + 1.0F) / 2.0F, block.stepSound.getPitch() * 0.8F);
+@@ -46,7 +63,19 @@
+                 }
+                 else
+                 {
+-                    par3World.setBlock(par4, par5, par6, block.blockID);
++                    // Hoes - blockface -1 for 'SELF'
++                    if (!par3World.isRemote)
++                    {
++                        ItemBlock itemblock = (ItemBlock)Item.itemsList[block.blockID];
++                        if (!itemblock.placeBlockAt(par3World, par2EntityPlayer, null, par4, par5, par6, par7, block.blockID, 0, clickedX, clickedY, clickedZ))
++                        {
++                            return false;
++                        }
++                    }
++                    else
++                    {
++                        par3World.setBlock(par4, par5, par6, block.blockID);
++                    }
+                     par1ItemStack.damageItem(1, par2EntityPlayer);
+                     return true;
+                 }

--- a/patches/minecraft/net/minecraft/item/ItemLilyPad.java.patch
+++ b/patches/minecraft/net/minecraft/item/ItemLilyPad.java.patch
@@ -1,0 +1,27 @@
+--- ../src_base/minecraft/net/minecraft/item/ItemLilyPad.java
++++ ../src_work/minecraft/net/minecraft/item/ItemLilyPad.java
+@@ -34,6 +34,7 @@
+                 int i = movingobjectposition.blockX;
+                 int j = movingobjectposition.blockY;
+                 int k = movingobjectposition.blockZ;
++                final int clickedX = i, clickedY = j, clickedZ = k;
+ 
+                 if (!par2World.canMineBlock(par3EntityPlayer, i, j, k))
+                 {
+@@ -47,7 +48,15 @@
+ 
+                 if (par2World.getBlockMaterial(i, j, k) == Material.water && par2World.getBlockMetadata(i, j, k) == 0 && par2World.isAirBlock(i, j + 1, k))
+                 {
+-                    par2World.setBlock(i, j + 1, k, Block.waterlily.blockID);
++                    if (!par2World.isRemote)
++                    {
++                        ItemBlock itemblock = (ItemBlock)Item.itemsList[Block.waterlily.blockID];
++                        if (!itemblock.placeBlockAt(par2World, par3EntityPlayer, null, i, j + 1, k, 0, Block.waterlily.blockID, 0, clickedX, clickedY, clickedZ))
++                        {
++                            return par1ItemStack;
++                        }
++                    }
++                    else par2World.setBlock(i, j + 1, k, Block.waterlily.blockID);
+ 
+                     if (!par3EntityPlayer.capabilities.isCreativeMode)
+                     {

--- a/patches/minecraft/net/minecraft/item/ItemRedstone.java.patch
+++ b/patches/minecraft/net/minecraft/item/ItemRedstone.java.patch
@@ -1,0 +1,33 @@
+--- ../src_base/minecraft/net/minecraft/item/ItemRedstone.java
++++ ../src_work/minecraft/net/minecraft/item/ItemRedstone.java
+@@ -19,6 +19,8 @@
+      */
+     public boolean onItemUse(ItemStack par1ItemStack, EntityPlayer par2EntityPlayer, World par3World, int par4, int par5, int par6, int par7, float par8, float par9, float par10)
+     {
++        final int clickedX = par4, clickedY = par5, clickedZ = par6;
++
+         if (par3World.getBlockId(par4, par5, par6) != Block.snow.blockID)
+         {
+             if (par7 == 0)
+@@ -65,8 +67,19 @@
+         {
+             if (Block.redstoneWire.canPlaceBlockAt(par3World, par4, par5, par6))
+             {
+-                --par1ItemStack.stackSize;
+-                par3World.setBlock(par4, par5, par6, Block.redstoneWire.blockID);
++                if (!par3World.isRemote)
++                {
++                    ItemBlock itemblock = (ItemBlock)Item.itemsList[Block.redstoneWire.blockID];
++                    if (!itemblock.placeBlockAt(par3World, par2EntityPlayer, par1ItemStack, par4, par5, par6, par7, Block.redstoneWire.blockID, 0, clickedX, clickedY, clickedZ))
++                    {
++                        return false;
++                    }
++                }
++                else
++                {
++                    --par1ItemStack.stackSize;
++                    par3World.setBlock(par4, par5, par6, Block.redstoneWire.blockID);
++                }
+             }
+ 
+             return true;

--- a/patches/minecraft/net/minecraft/item/ItemReed.java.patch
+++ b/patches/minecraft/net/minecraft/item/ItemReed.java.patch
@@ -1,0 +1,24 @@
+--- ../src_base/minecraft/net/minecraft/item/ItemReed.java
++++ ../src_work/minecraft/net/minecraft/item/ItemReed.java
+@@ -22,6 +22,7 @@
+      */
+     public boolean onItemUse(ItemStack par1ItemStack, EntityPlayer par2EntityPlayer, World par3World, int par4, int par5, int par6, int par7, float par8, float par9, float par10)
+     {
++        final int clickedX = par4, clickedY = par5, clickedZ = par6;
+         int i1 = par3World.getBlockId(par4, par5, par6);
+ 
+         if (i1 == Block.snow.blockID && (par3World.getBlockMetadata(par4, par5, par6) & 7) < 1)
+@@ -76,7 +77,12 @@
+                 Block block = Block.blocksList[this.spawnID];
+                 int j1 = block.onBlockPlaced(par3World, par4, par5, par6, par7, par8, par9, par10, 0);
+ 
+-                if (par3World.setBlock(par4, par5, par6, this.spawnID, j1, 3))
++                if (!par3World.isRemote)
++                {
++                    ItemBlock itemblock = (ItemBlock)Item.itemsList[this.spawnID];
++                    itemblock.placeBlockAt(par3World, par2EntityPlayer, par1ItemStack, par4, par5, par6, par7, this.spawnID, j1, clickedX, clickedY, clickedZ);
++                }
++                else if (par3World.setBlock(par4, par5, par6, this.spawnID, j1, 3))
+                 {
+                     if (par3World.getBlockId(par4, par5, par6) == this.spawnID)
+                     {

--- a/patches/minecraft/net/minecraft/item/ItemSeedFood.java.patch
+++ b/patches/minecraft/net/minecraft/item/ItemSeedFood.java.patch
@@ -15,7 +15,16 @@
  {
      /** Block ID of the crop this seed food should place. */
      private int cropId;
-@@ -31,8 +35,9 @@
+@@ -24,6 +28,8 @@
+      */
+     public boolean onItemUse(ItemStack par1ItemStack, EntityPlayer par2EntityPlayer, World par3World, int par4, int par5, int par6, int par7, float par8, float par9, float par10)
+     {
++        final int clickedX = par4, clickedY = par5, clickedZ = par6;
++
+         if (par7 != 1)
+         {
+             return false;
+@@ -31,10 +37,22 @@
          else if (par2EntityPlayer.canPlayerEdit(par4, par5, par6, par7, par1ItemStack) && par2EntityPlayer.canPlayerEdit(par4, par5 + 1, par6, par7, par1ItemStack))
          {
              int i1 = par3World.getBlockId(par4, par5, par6);
@@ -24,9 +33,23 @@
 -            if (i1 == this.soilId && par3World.isAirBlock(par4, par5 + 1, par6))
 +            if (soil != null && soil.canSustainPlant(par3World, par4, par5, par6, ForgeDirection.UP, this) && par3World.isAirBlock(par4, par5 + 1, par6))
              {
-                 par3World.setBlock(par4, par5 + 1, par6, this.cropId);
+-                par3World.setBlock(par4, par5 + 1, par6, this.cropId);
++                if (!par3World.isRemote)
++                {
++                    ItemBlock itemblock = (ItemBlock)Item.itemsList[this.cropId];
++                    if (!itemblock.placeBlockAt(par3World, par2EntityPlayer, null, par4, par5 + 1, par6, par7, this.cropId, 0, clickedX, clickedY, clickedZ))
++                    {
++                        return false;
++                    }
++                }
++                else 
++                {
++                    par3World.setBlock(par4, par5 + 1, par6, this.cropId);
++                }
                  --par1ItemStack.stackSize;
-@@ -48,4 +53,22 @@
+                 return true;
+             }
+@@ -48,4 +66,22 @@
              return false;
          }
      }

--- a/patches/minecraft/net/minecraft/item/ItemSeeds.java.patch
+++ b/patches/minecraft/net/minecraft/item/ItemSeeds.java.patch
@@ -17,7 +17,16 @@
  {
      /**
       * The type of block this seed turns into (wheat or pumpkin stems for instance)
-@@ -35,8 +40,9 @@
+@@ -28,6 +33,8 @@
+      */
+     public boolean onItemUse(ItemStack par1ItemStack, EntityPlayer par2EntityPlayer, World par3World, int par4, int par5, int par6, int par7, float par8, float par9, float par10)
+     {
++        final int clickedX = par4, clickedY = par5, clickedZ = par6;
++
+         if (par7 != 1)
+         {
+             return false;
+@@ -35,10 +42,22 @@
          else if (par2EntityPlayer.canPlayerEdit(par4, par5, par6, par7, par1ItemStack) && par2EntityPlayer.canPlayerEdit(par4, par5 + 1, par6, par7, par1ItemStack))
          {
              int i1 = par3World.getBlockId(par4, par5, par6);
@@ -26,9 +35,23 @@
 -            if (i1 == this.soilBlockID && par3World.isAirBlock(par4, par5 + 1, par6))
 +            if (soil != null && soil.canSustainPlant(par3World, par4, par5, par6, ForgeDirection.UP, this) && par3World.isAirBlock(par4, par5 + 1, par6))
              {
-                 par3World.setBlock(par4, par5 + 1, par6, this.blockType);
+-                par3World.setBlock(par4, par5 + 1, par6, this.blockType);
++                if (!par3World.isRemote)
++                {
++                    ItemBlock itemblock = (ItemBlock)Item.itemsList[this.blockType];
++                    if (!itemblock.placeBlockAt(par3World, par2EntityPlayer, null, par4, par5 + 1, par6, par7, this.blockType, 0, clickedX, clickedY, clickedZ))
++                    {
++                        return false;
++                    }
++                }
++                else
++                {
++                    par3World.setBlock(par4, par5 + 1, par6, this.blockType);
++                }
                  --par1ItemStack.stackSize;
-@@ -52,4 +58,22 @@
+                 return true;
+             }
+@@ -52,4 +71,22 @@
              return false;
          }
      }

--- a/patches/minecraft/net/minecraft/item/ItemSign.java.patch
+++ b/patches/minecraft/net/minecraft/item/ItemSign.java.patch
@@ -1,0 +1,40 @@
+--- ../src_base/minecraft/net/minecraft/item/ItemSign.java
++++ ../src_work/minecraft/net/minecraft/item/ItemSign.java
+@@ -22,6 +22,8 @@
+      */
+     public boolean onItemUse(ItemStack par1ItemStack, EntityPlayer par2EntityPlayer, World par3World, int par4, int par5, int par6, int par7, float par8, float par9, float par10)
+     {
++        final int clickedX = par4, clickedY = par5, clickedZ = par6;
++
+         if (par7 == 0)
+         {
+             return false;
+@@ -67,14 +69,28 @@
+             }
+             else
+             {
++                final Block block;
++
+                 if (par7 == 1)
+                 {
+                     int i1 = MathHelper.floor_double((double)((par2EntityPlayer.rotationYaw + 180.0F) * 16.0F / 360.0F) + 0.5D) & 15;
++                    block = Block.signPost;
++                    par7 = i1;
+                     par3World.setBlock(par4, par5, par6, Block.signPost.blockID, i1, 2);
+                 }
+                 else
+                 {
++                    block = Block.signWall;
+                     par3World.setBlock(par4, par5, par6, Block.signWall.blockID, par7, 2);
++                }
++
++                if (!par3World.isRemote)
++                {
++                    ItemBlock itemblock = (ItemBlock)Item.itemsList[block.blockID];
++                    if (!itemblock.placeBlockAt(par3World, par2EntityPlayer, null, par4, par5, par6, par7, block.blockID, par7, clickedX, clickedY, clickedZ))
++                    {
++                        return false;
++                    }
+                 }
+ 
+                 --par1ItemStack.stackSize;

--- a/patches/minecraft/net/minecraft/item/ItemSkull.java.patch
+++ b/patches/minecraft/net/minecraft/item/ItemSkull.java.patch
@@ -1,0 +1,29 @@
+--- ../src_base/minecraft/net/minecraft/item/ItemSkull.java
++++ ../src_work/minecraft/net/minecraft/item/ItemSkull.java
+@@ -36,6 +36,7 @@
+      */
+     public boolean onItemUse(ItemStack par1ItemStack, EntityPlayer par2EntityPlayer, World par3World, int par4, int par5, int par6, int par7, float par8, float par9, float par10)
+     {
++        final int clickedX = par4, clickedY = par5, clickedZ = par6;
+         if (par7 == 0)
+         {
+             return false;
+@@ -81,7 +82,17 @@
+             }
+             else
+             {
+-                par3World.setBlock(par4, par5, par6, Block.skull.blockID, par7, 2);
++                if (!par3World.isRemote)
++                {
++                    ItemBlock itemblock = (ItemBlock)Item.itemsList[Block.skull.blockID];
++                    if (!itemblock.placeBlockAt(par3World, par2EntityPlayer, null, par4, par5, par6, par7, Block.skull.blockID, par7, clickedX, clickedY, clickedZ))
++                    {
++                        return false;
++                    }
++
++                    par7 = par3World.getBlockMetadata(par4, par5, par6);
++                }
++                else par3World.setBlock(par4, par5, par6, Block.skull.blockID, par7, 2);
+                 int i1 = 0;
+ 
+                 if (par7 == 1)

--- a/patches/minecraft/net/minecraft/item/ItemSlab.java.patch
+++ b/patches/minecraft/net/minecraft/item/ItemSlab.java.patch
@@ -1,0 +1,69 @@
+--- ../src_base/minecraft/net/minecraft/item/ItemSlab.java
++++ ../src_work/minecraft/net/minecraft/item/ItemSlab.java
+@@ -61,6 +61,8 @@
+      */
+     public boolean onItemUse(ItemStack par1ItemStack, EntityPlayer par2EntityPlayer, World par3World, int par4, int par5, int par6, int par7, float par8, float par9, float par10)
+     {
++        final int clickedX = par4, clickedY = par5, clickedZ = par6;
++
+         if (this.isFullBlock)
+         {
+             return super.onItemUse(par1ItemStack, par2EntityPlayer, par3World, par4, par5, par6, par7, par8, par9, par10);
+@@ -82,10 +84,20 @@
+ 
+             if ((par7 == 1 && !flag || par7 == 0 && flag) && i1 == this.theHalfSlab.blockID && k1 == par1ItemStack.getItemDamage())
+             {
+-                if (par3World.checkNoEntityCollision(this.doubleSlab.getCollisionBoundingBoxFromPool(par3World, par4, par5, par6)) && par3World.setBlock(par4, par5, par6, this.doubleSlab.blockID, k1, 3))
+-                {
+-                    par3World.playSoundEffect((double)((float)par4 + 0.5F), (double)((float)par5 + 0.5F), (double)((float)par6 + 0.5F), this.doubleSlab.stepSound.getPlaceSound(), (this.doubleSlab.stepSound.getVolume() + 1.0F) / 2.0F, this.doubleSlab.stepSound.getPitch() * 0.8F);
+-                    --par1ItemStack.stackSize;
++                if (!par3World.isRemote)
++                {
++                    if (par3World.checkNoEntityCollision(this.doubleSlab.getCollisionBoundingBoxFromPool(par3World, par4, par5, par6)) && placeBlockAt(par3World, par2EntityPlayer, null, par4, par5, par6, par7, this.doubleSlab.blockID, k1, clickedX, clickedY, clickedZ))
++                    {
++                        --par1ItemStack.stackSize;
++                    }
++                }
++                else
++                {
++                    if (par3World.checkNoEntityCollision(this.doubleSlab.getCollisionBoundingBoxFromPool(par3World, par4, par5, par6)) && par3World.setBlock(par4, par5, par6, this.doubleSlab.blockID, k1, 3))
++                    {
++                        par3World.playSoundEffect((double)((float)par4 + 0.5F), (double)((float)par5 + 0.5F), (double)((float)par6 + 0.5F), this.doubleSlab.stepSound.getPlaceSound(), (this.doubleSlab.stepSound.getVolume() + 1.0F) / 2.0F, this.doubleSlab.stepSound.getPitch() * 0.8F);
++                        --par1ItemStack.stackSize;
++                    }
+                 }
+ 
+                 return true;
+@@ -158,6 +170,7 @@
+ 
+     private boolean func_77888_a(ItemStack par1ItemStack, EntityPlayer par2EntityPlayer, World par3World, int par4, int par5, int par6, int par7)
+     {
++        final int clickedX = par4, clickedY = par5, clickedZ = par6;
+         if (par7 == 0)
+         {
+             --par5;
+@@ -194,10 +207,20 @@
+ 
+         if (i1 == this.theHalfSlab.blockID && k1 == par1ItemStack.getItemDamage())
+         {
+-            if (par3World.checkNoEntityCollision(this.doubleSlab.getCollisionBoundingBoxFromPool(par3World, par4, par5, par6)) && par3World.setBlock(par4, par5, par6, this.doubleSlab.blockID, k1, 3))
+-            {
+-                par3World.playSoundEffect((double)((float)par4 + 0.5F), (double)((float)par5 + 0.5F), (double)((float)par6 + 0.5F), this.doubleSlab.stepSound.getPlaceSound(), (this.doubleSlab.stepSound.getVolume() + 1.0F) / 2.0F, this.doubleSlab.stepSound.getPitch() * 0.8F);
+-                --par1ItemStack.stackSize;
++            if (!par3World.isRemote)
++            {
++                if(par3World.checkNoEntityCollision(this.doubleSlab.getCollisionBoundingBoxFromPool(par3World, par4, par5, par6)) && placeBlockAt(par3World, par2EntityPlayer, null, par4, par5, par6, par7, this.doubleSlab.blockID, k1, clickedX, clickedY, clickedZ))
++                {
++                    --par1ItemStack.stackSize;
++                }
++            }
++            else
++            {
++                if (par3World.checkNoEntityCollision(this.doubleSlab.getCollisionBoundingBoxFromPool(par3World, par4, par5, par6)) && par3World.setBlock(par4, par5, par6, this.doubleSlab.blockID, k1, 3))
++                {
++                    par3World.playSoundEffect((double)((float)par4 + 0.5F), (double)((float)par5 + 0.5F), (double)((float)par6 + 0.5F), this.doubleSlab.stepSound.getPlaceSound(), (this.doubleSlab.stepSound.getVolume() + 1.0F) / 2.0F, this.doubleSlab.stepSound.getPitch() * 0.8F);
++                    --par1ItemStack.stackSize;
++                }
+             }
+ 
+             return true;

--- a/patches/minecraft/net/minecraft/world/World.java.patch
+++ b/patches/minecraft/net/minecraft/world/World.java.patch
@@ -7,7 +7,7 @@
  import cpw.mods.fml.relauncher.Side;
  import cpw.mods.fml.relauncher.SideOnly;
  import java.util.ArrayList;
-@@ -52,8 +53,32 @@
+@@ -53,8 +54,32 @@
  import net.minecraft.world.storage.MapStorage;
  import net.minecraft.world.storage.WorldInfo;
  
@@ -40,7 +40,14 @@
      /**
       * boolean; if true updates scheduled by scheduleBlockUpdate happen immediately
       */
-@@ -165,6 +190,11 @@
+@@ -161,11 +186,18 @@
+ 
+     /** This is set to true for client worlds, and false for server worlds. */
+     public boolean isRemote;
++    /** This is set to true during a BlockPlaceEvent, and false when complete. */
++    public boolean callingPlaceEvent;
+ 
+     /**
       * Gets the biome for a given set of x/z coordinates
       */
      public BiomeGenBase getBiomeGenForCoords(int par1, int par2)
@@ -52,7 +59,7 @@
      {
          if (this.blockExists(par1, 0, par2))
          {
-@@ -194,8 +224,15 @@
+@@ -194,8 +226,15 @@
          this.theProfiler = par5Profiler;
          this.worldInfo = new WorldInfo(par4WorldSettings, par2Str);
          this.provider = par3WorldProvider;
@@ -69,7 +76,7 @@
          VillageCollection villagecollection = (VillageCollection)this.mapStorage.loadData(VillageCollection.class, "villages");
  
          if (villagecollection == null)
-@@ -208,8 +245,10 @@
+@@ -208,8 +247,10 @@
              this.villageCollectionObj = villagecollection;
              this.villageCollectionObj.func_82566_a(this);
          }
@@ -82,8 +89,8 @@
          this.chunkProvider = this.createChunkProvider();
          this.calculateInitialSkylight();
          this.calculateInitialWeather();
-@@ -222,7 +261,7 @@
-         this.isRemote = false;
+@@ -221,7 +262,7 @@
+         this.lightUpdateBlockList = new int[32768];
          this.saveHandler = par1ISaveHandler;
          this.theProfiler = par5Profiler;
 -        this.mapStorage = new MapStorage(par1ISaveHandler);
@@ -91,7 +98,7 @@
          this.worldLogAgent = par6ILogAgent;
          this.worldInfo = par1ISaveHandler.loadWorldInfo();
  
-@@ -276,12 +315,20 @@
+@@ -275,12 +316,20 @@
              this.worldInfo.setServerInitialized(true);
          }
  
@@ -114,7 +121,7 @@
          }
          else
          {
-@@ -291,6 +338,19 @@
+@@ -290,6 +339,19 @@
  
          this.calculateInitialSkylight();
          this.calculateInitialWeather();
@@ -134,7 +141,7 @@
      }
  
      /**
-@@ -374,7 +434,8 @@
+@@ -373,7 +435,8 @@
       */
      public boolean isAirBlock(int par1, int par2, int par3)
      {
@@ -144,7 +151,7 @@
      }
  
      /**
-@@ -383,7 +444,8 @@
+@@ -382,7 +445,8 @@
      public boolean blockHasTileEntity(int par1, int par2, int par3)
      {
          int l = this.getBlockId(par1, par2, par3);
@@ -154,7 +161,7 @@
      }
  
      /**
-@@ -1158,7 +1220,7 @@
+@@ -1157,7 +1221,7 @@
       */
      public boolean isDaytime()
      {
@@ -163,7 +170,7 @@
      }
  
      /**
-@@ -1190,7 +1252,7 @@
+@@ -1189,7 +1253,7 @@
                  int l1 = this.getBlockMetadata(l, i1, j1);
                  Block block = Block.blocksList[k1];
  
@@ -172,7 +179,7 @@
                  {
                      MovingObjectPosition movingobjectposition = block.collisionRayTrace(this, l, i1, j1, par1Vec3, par2Vec3);
  
-@@ -1390,6 +1452,12 @@
+@@ -1389,6 +1453,12 @@
       */
      public void playSoundAtEntity(Entity par1Entity, String par2Str, float par3, float par4)
      {
@@ -185,7 +192,7 @@
          if (par1Entity != null && par2Str != null)
          {
              for (int i = 0; i < this.worldAccesses.size(); ++i)
-@@ -1404,6 +1472,12 @@
+@@ -1403,6 +1473,12 @@
       */
      public void playSoundToNearExcept(EntityPlayer par1EntityPlayer, String par2Str, float par3, float par4)
      {
@@ -198,7 +205,7 @@
          if (par1EntityPlayer != null && par2Str != null)
          {
              for (int i = 0; i < this.worldAccesses.size(); ++i)
-@@ -1490,6 +1564,11 @@
+@@ -1489,6 +1565,11 @@
                  EntityPlayer entityplayer = (EntityPlayer)par1Entity;
                  this.playerEntities.add(entityplayer);
                  this.updateAllPlayersSleepingFlag();
@@ -210,7 +217,7 @@
              }
  
              this.getChunkFromChunkCoords(i, j).addEntity(par1Entity);
-@@ -1736,6 +1815,12 @@
+@@ -1735,6 +1816,12 @@
       * Calculates the color for the skybox
       */
      public Vec3 getSkyColor(Entity par1Entity, float par2)
@@ -223,7 +230,7 @@
      {
          float f1 = this.getCelestialAngle(par2);
          float f2 = MathHelper.cos(f1 * (float)Math.PI * 2.0F) * 2.0F + 0.5F;
-@@ -1828,6 +1913,12 @@
+@@ -1833,6 +1920,12 @@
      @SideOnly(Side.CLIENT)
      public Vec3 getCloudColour(float par1)
      {
@@ -236,7 +243,7 @@
          float f1 = this.getCelestialAngle(par1);
          float f2 = MathHelper.cos(f1 * (float)Math.PI * 2.0F) * 2.0F + 0.5F;
  
-@@ -1899,6 +1990,8 @@
+@@ -1904,6 +1997,8 @@
      public int getTopSolidOrLiquidBlock(int par1, int par2)
      {
          Chunk chunk = this.getChunkFromBlockCoords(par1, par2);
@@ -245,7 +252,7 @@
          int k = chunk.getTopFilledSegment() + 15;
          par1 &= 15;
  
-@@ -1906,7 +1999,7 @@
+@@ -1911,7 +2006,7 @@
          {
              int l = chunk.getBlockID(par1, k, par2);
  
@@ -254,7 +261,7 @@
              {
                  return k + 1;
              }
-@@ -1921,6 +2014,12 @@
+@@ -1926,6 +2021,12 @@
       * How bright are stars in the sky
       */
      public float getStarBrightness(float par1)
@@ -267,7 +274,7 @@
      {
          float f1 = this.getCelestialAngle(par1);
          float f2 = 1.0F - (MathHelper.cos(f1 * (float)Math.PI * 2.0F) * 2.0F + 0.25F);
-@@ -1985,7 +2084,15 @@
+@@ -1990,7 +2091,15 @@
                      entity.func_85029_a(crashreportcategory);
                  }
  
@@ -284,7 +291,7 @@
              }
  
              if (entity.isDead)
-@@ -2047,7 +2154,16 @@
+@@ -2052,7 +2161,16 @@
                      crashreport = CrashReport.makeCrashReport(throwable1, "Ticking entity");
                      crashreportcategory = crashreport.makeCategory("Entity being ticked");
                      entity.func_85029_a(crashreportcategory);
@@ -302,7 +309,7 @@
                  }
              }
  
-@@ -2090,7 +2206,16 @@
+@@ -2095,7 +2213,16 @@
                      crashreport = CrashReport.makeCrashReport(throwable2, "Ticking tile entity");
                      crashreportcategory = crashreport.makeCategory("Tile entity being ticked");
                      tileentity.func_85027_a(crashreportcategory);
@@ -320,7 +327,7 @@
                  }
              }
  
-@@ -2104,7 +2229,7 @@
+@@ -2109,7 +2236,7 @@
  
                      if (chunk != null)
                      {
@@ -329,7 +336,7 @@
                      }
                  }
              }
-@@ -2113,6 +2238,10 @@
+@@ -2118,6 +2245,10 @@
  
          if (!this.entityRemoval.isEmpty())
          {
@@ -340,7 +347,7 @@
              this.loadedTileEntityList.removeAll(this.entityRemoval);
              this.entityRemoval.clear();
          }
-@@ -2133,18 +2262,18 @@
+@@ -2138,18 +2269,18 @@
                      {
                          this.loadedTileEntityList.add(tileentity1);
                      }
@@ -363,7 +370,7 @@
                  }
              }
  
-@@ -2157,13 +2286,13 @@
+@@ -2162,13 +2293,13 @@
  
      public void addTileEntity(Collection par1Collection)
      {
@@ -384,7 +391,7 @@
          }
      }
  
-@@ -2183,9 +2312,17 @@
+@@ -2188,9 +2319,17 @@
      {
          int i = MathHelper.floor_double(par1Entity.posX);
          int j = MathHelper.floor_double(par1Entity.posZ);
@@ -405,7 +412,7 @@
          {
              par1Entity.lastTickPosX = par1Entity.posX;
              par1Entity.lastTickPosY = par1Entity.posY;
-@@ -2418,6 +2555,14 @@
+@@ -2423,6 +2562,14 @@
                          {
                              return true;
                          }
@@ -420,7 +427,7 @@
                      }
                  }
              }
-@@ -2740,15 +2885,16 @@
+@@ -2745,15 +2892,16 @@
       */
      public void setBlockTileEntity(int par1, int par2, int par3, TileEntity par4TileEntity)
      {
@@ -446,7 +453,7 @@
                  while (iterator.hasNext())
                  {
                      TileEntity tileentity1 = (TileEntity)iterator.next();
-@@ -2759,19 +2905,18 @@
+@@ -2764,19 +2912,18 @@
                          iterator.remove();
                      }
                  }
@@ -475,7 +482,7 @@
          }
      }
  
-@@ -2780,27 +2925,10 @@
+@@ -2785,27 +2932,10 @@
       */
      public void removeBlockTileEntity(int par1, int par2, int par3)
      {
@@ -507,7 +514,7 @@
          }
      }
  
-@@ -2826,7 +2954,8 @@
+@@ -2831,7 +2961,8 @@
       */
      public boolean isBlockNormalCube(int par1, int par2, int par3)
      {
@@ -517,7 +524,7 @@
      }
  
      public boolean func_85174_u(int par1, int par2, int par3)
-@@ -2849,16 +2978,17 @@
+@@ -2854,16 +2985,17 @@
       */
      public boolean doesBlockHaveSolidTopSurface(int par1, int par2, int par3)
      {
@@ -537,7 +544,7 @@
          return par1Block == null ? false : (par1Block.blockMaterial.isOpaque() && par1Block.renderAsNormalBlock() ? true : (par1Block instanceof BlockStairs ? (par2 & 4) == 4 : (par1Block instanceof BlockHalfSlab ? (par2 & 8) == 8 : (par1Block instanceof BlockHopper ? true : (par1Block instanceof BlockSnow ? (par2 & 7) == 7 : false)))));
      }
  
-@@ -2875,7 +3005,7 @@
+@@ -2880,7 +3012,7 @@
              if (chunk != null && !chunk.isEmpty())
              {
                  Block block = Block.blocksList[this.getBlockId(par1, par2, par3)];
@@ -546,7 +553,7 @@
              }
              else
              {
-@@ -2906,8 +3036,7 @@
+@@ -2911,8 +3043,7 @@
       */
      public void setAllowedSpawnTypes(boolean par1, boolean par2)
      {
@@ -556,7 +563,7 @@
      }
  
      /**
-@@ -2923,6 +3052,11 @@
+@@ -2928,6 +3059,11 @@
       */
      private void calculateInitialWeather()
      {
@@ -568,7 +575,7 @@
          if (this.worldInfo.isRaining())
          {
              this.rainingStrength = 1.0F;
-@@ -2938,6 +3072,11 @@
+@@ -2943,6 +3079,11 @@
       * Updates all weather states.
       */
      protected void updateWeather()
@@ -580,7 +587,7 @@
      {
          if (!this.provider.hasNoSky)
          {
-@@ -3035,12 +3174,14 @@
+@@ -3040,12 +3181,14 @@
  
      public void toggleRain()
      {
@@ -596,7 +603,7 @@
          this.theProfiler.startSection("buildList");
          int i;
          EntityPlayer entityplayer;
-@@ -3147,6 +3288,11 @@
+@@ -3152,6 +3295,11 @@
       */
      public boolean canBlockFreeze(int par1, int par2, int par3, boolean par4)
      {
@@ -608,7 +615,7 @@
          BiomeGenBase biomegenbase = this.getBiomeGenForCoords(par1, par3);
          float f = biomegenbase.getFloatTemperature();
  
-@@ -3205,6 +3351,11 @@
+@@ -3210,6 +3358,11 @@
       */
      public boolean canSnowAt(int par1, int par2, int par3)
      {
@@ -620,7 +627,7 @@
          BiomeGenBase biomegenbase = this.getBiomeGenForCoords(par1, par3);
          float f = biomegenbase.getFloatTemperature();
  
-@@ -3248,10 +3399,12 @@
+@@ -3253,10 +3406,12 @@
          else
          {
              int l = this.getBlockId(par1, par2, par3);
@@ -637,7 +644,7 @@
              {
                  j1 = 1;
              }
-@@ -3347,7 +3500,9 @@
+@@ -3352,7 +3507,9 @@
                                      int j4 = i2 + Facing.offsetsXForSide[i4];
                                      int k4 = j2 + Facing.offsetsYForSide[i4];
                                      int l4 = k2 + Facing.offsetsZForSide[i4];
@@ -648,7 +655,7 @@
                                      i3 = this.getSavedLightValue(par1EnumSkyBlock, j4, k4, l4);
  
                                      if (i3 == l2 - i5 && i1 < this.lightUpdateBlockList.length)
-@@ -3450,10 +3605,10 @@
+@@ -3455,10 +3612,10 @@
      public List getEntitiesWithinAABBExcludingEntity(Entity par1Entity, AxisAlignedBB par2AxisAlignedBB, IEntitySelector par3IEntitySelector)
      {
          ArrayList arraylist = new ArrayList();
@@ -663,7 +670,7 @@
  
          for (int i1 = i; i1 <= j; ++i1)
          {
-@@ -3479,10 +3634,10 @@
+@@ -3484,10 +3641,10 @@
  
      public List selectEntitiesWithinAABB(Class par1Class, AxisAlignedBB par2AxisAlignedBB, IEntitySelector par3IEntitySelector)
      {
@@ -678,7 +685,7 @@
          ArrayList arraylist = new ArrayList();
  
          for (int i1 = i; i1 <= j; ++i1)
-@@ -3575,11 +3730,14 @@
+@@ -3580,11 +3737,14 @@
       */
      public void addLoadedEntities(List par1List)
      {
@@ -696,7 +703,7 @@
          }
      }
  
-@@ -3613,6 +3771,11 @@
+@@ -3618,6 +3778,11 @@
          else
          {
              if (block != null && (block == Block.waterMoving || block == Block.waterStill || block == Block.lavaMoving || block == Block.lavaStill || block == Block.fire || block.blockMaterial.isReplaceable()))
@@ -708,7 +715,7 @@
              {
                  block = null;
              }
-@@ -3907,7 +4070,7 @@
+@@ -3912,7 +4077,7 @@
       */
      public long getSeed()
      {
@@ -717,7 +724,7 @@
      }
  
      public long getTotalWorldTime()
-@@ -3917,7 +4080,7 @@
+@@ -3922,7 +4087,7 @@
  
      public long getWorldTime()
      {
@@ -726,7 +733,7 @@
      }
  
      /**
-@@ -3925,7 +4088,7 @@
+@@ -3930,7 +4095,7 @@
       */
      public void setWorldTime(long par1)
      {
@@ -735,7 +742,7 @@
      }
  
      /**
-@@ -3933,13 +4096,13 @@
+@@ -3938,13 +4103,13 @@
       */
      public ChunkCoordinates getSpawnPoint()
      {
@@ -751,7 +758,7 @@
      }
  
      @SideOnly(Side.CLIENT)
-@@ -3963,7 +4126,10 @@
+@@ -3968,7 +4133,10 @@
  
          if (!this.loadedEntityList.contains(par1Entity))
          {
@@ -763,7 +770,7 @@
          }
      }
  
-@@ -3971,6 +4137,11 @@
+@@ -3976,6 +4144,11 @@
       * Called when checking if a certain block can be mined or not. The 'spawn safe zone' check is located here.
       */
      public boolean canMineBlock(EntityPlayer par1EntityPlayer, int par2, int par3, int par4)
@@ -775,7 +782,7 @@
      {
          return true;
      }
-@@ -4091,8 +4262,7 @@
+@@ -4096,8 +4269,7 @@
       */
      public boolean isBlockHighHumidity(int par1, int par2, int par3)
      {
@@ -785,7 +792,7 @@
      }
  
      /**
-@@ -4167,7 +4337,7 @@
+@@ -4172,7 +4344,7 @@
       */
      public int getHeight()
      {
@@ -794,7 +801,7 @@
      }
  
      /**
-@@ -4175,7 +4345,7 @@
+@@ -4180,7 +4352,7 @@
       */
      public int getActualHeight()
      {
@@ -803,7 +810,7 @@
      }
  
      public IUpdatePlayerListBox func_82735_a(EntityMinecart par1EntityMinecart)
-@@ -4218,7 +4388,7 @@
+@@ -4223,7 +4395,7 @@
       */
      public double getHorizon()
      {
@@ -812,9 +819,9 @@
      }
  
      /**
-@@ -4321,4 +4491,115 @@
-     {
-         return this.worldLogAgent;
+@@ -4351,4 +4523,115 @@
+ 
+         return MathHelper.clamp_float(f, 0.0F, flag ? 1.5F : 1.0F);
      }
 +
 +    /**

--- a/patches/minecraft/net/minecraft/world/chunk/Chunk.java.patch
+++ b/patches/minecraft/net/minecraft/world/chunk/Chunk.java.patch
@@ -1,6 +1,14 @@
 --- ../src_base/minecraft/net/minecraft/world/chunk/Chunk.java
 +++ ../src_work/minecraft/net/minecraft/world/chunk/Chunk.java
-@@ -25,6 +25,10 @@
+@@ -10,6 +10,7 @@
+ import java.util.Map;
+ import java.util.Random;
+ import net.minecraft.block.Block;
++import net.minecraft.block.BlockContainer;
+ import net.minecraft.block.ITileEntityProvider;
+ import net.minecraft.block.material.Material;
+ import net.minecraft.command.IEntitySelector;
+@@ -25,6 +26,10 @@
  import net.minecraft.world.biome.WorldChunkManager;
  import net.minecraft.world.chunk.storage.ExtendedBlockStorage;
  
@@ -11,7 +19,7 @@
  public class Chunk
  {
      /**
-@@ -146,7 +150,9 @@
+@@ -138,7 +143,9 @@
              {
                  for (int j1 = 0; j1 < k; ++j1)
                  {
@@ -22,7 +30,7 @@
  
                      if (b0 != 0)
                      {
-@@ -165,6 +171,90 @@
+@@ -157,6 +164,90 @@
      }
  
      /**
@@ -113,7 +121,7 @@
       * Checks whether the chunk is at the X/Z location specified
       */
      public boolean isAtLocation(int par1, int par2)
-@@ -228,7 +318,7 @@
+@@ -220,7 +311,7 @@
                      {
                          int i1 = this.getBlockID(j, l - 1, k);
  
@@ -122,7 +130,7 @@
                          {
                              --l;
                              continue;
-@@ -534,7 +624,10 @@
+@@ -526,7 +617,10 @@
  
      public int getBlockLightOpacity(int par1, int par2, int par3)
      {
@@ -134,7 +142,7 @@
      }
  
      /**
-@@ -621,9 +714,13 @@
+@@ -613,9 +707,13 @@
                  {
                      Block.blocksList[l1].breakBlock(this.worldObj, j2, par2, k2, l1, i2);
                  }
@@ -151,7 +159,7 @@
                  }
              }
  
-@@ -641,7 +738,7 @@
+@@ -633,7 +731,7 @@
                  }
                  else
                  {
@@ -160,7 +168,14 @@
                      {
                          if (par2 >= k1)
                          {
-@@ -665,29 +762,21 @@
+@@ -652,34 +750,27 @@
+ 
+                 if (par4 != 0)
+                 {
+-                    if (!this.worldObj.isRemote)
++                    // Don't place while processing the BlockPlaceEvent, unless it's a BlockContainer
++                    if (!this.worldObj.isRemote && (!this.worldObj.callingPlaceEvent || (Block.blocksList[par4] instanceof BlockContainer)))
+                     {
                          Block.blocksList[par4].onBlockAdded(this.worldObj, j2, par2, k2);
                      }
  
@@ -169,7 +184,8 @@
                      {
                          tileentity = this.getChunkBlockTileEntity(par1, par2, par3);
  
-                         if (tileentity == null)
+-                        if (tileentity == null)
++                        if (tileentity == null && !this.worldObj.callingPlaceEvent) // Don't create a tile entity while processing the BlockPlaceEvent
                          {
 -                            tileentity = ((ITileEntityProvider)Block.blocksList[par4]).createNewTileEntity(this.worldObj);
 +                            tileentity = Block.blocksList[par4].createTileEntity(this.worldObj, par5);
@@ -193,7 +209,7 @@
                      }
                  }
  
-@@ -722,7 +811,7 @@
+@@ -714,7 +805,7 @@
                  extendedblockstorage.setExtBlockMetadata(par1, par2 & 15, par3, par4);
                  int j1 = extendedblockstorage.getExtBlockID(par1, par2 & 15, par3);
  
@@ -202,7 +218,7 @@
                  {
                      TileEntity tileentity = this.getChunkBlockTileEntity(par1, par2, par3);
  
-@@ -835,6 +924,7 @@
+@@ -827,6 +918,7 @@
              k = this.entityLists.length - 1;
          }
  
@@ -210,7 +226,7 @@
          par1Entity.addedToChunk = true;
          par1Entity.chunkCoordX = this.xPosition;
          par1Entity.chunkCoordY = k;
-@@ -884,33 +974,32 @@
+@@ -876,33 +968,32 @@
          ChunkPosition chunkposition = new ChunkPosition(par1, par2, par3);
          TileEntity tileentity = (TileEntity)this.chunkTileEntityMap.get(chunkposition);
  
@@ -255,7 +271,7 @@
      }
  
      /**
-@@ -925,7 +1014,7 @@
+@@ -917,7 +1008,7 @@
  
          if (this.isChunkLoaded)
          {
@@ -264,7 +280,7 @@
          }
      }
  
-@@ -940,7 +1029,8 @@
+@@ -932,7 +1023,8 @@
          par4TileEntity.yCoord = par2;
          par4TileEntity.zCoord = this.zPosition * 16 + par3;
  
@@ -274,15 +290,15 @@
          {
              if (this.chunkTileEntityMap.containsKey(chunkposition))
              {
-@@ -982,6 +1072,7 @@
-         {
+@@ -982,6 +1074,7 @@
+ 
              this.worldObj.addLoadedEntities(this.entityLists[i]);
          }
 +        MinecraftForge.EVENT_BUS.post(new ChunkEvent.Load(this));
      }
  
      /**
-@@ -1002,6 +1093,7 @@
+@@ -1002,6 +1095,7 @@
          {
              this.worldObj.unloadEntities(this.entityLists[i]);
          }
@@ -290,7 +306,7 @@
      }
  
      /**
-@@ -1018,8 +1110,8 @@
+@@ -1018,8 +1112,8 @@
       */
      public void getEntitiesWithinAABBForEntity(Entity par1Entity, AxisAlignedBB par2AxisAlignedBB, List par3List, IEntitySelector par4IEntitySelector)
      {
@@ -301,7 +317,7 @@
  
          if (i < 0)
          {
-@@ -1068,8 +1160,8 @@
+@@ -1068,8 +1162,8 @@
       */
      public void getEntitiesOfTypeWithinAAAB(Class par1Class, AxisAlignedBB par2AxisAlignedBB, List par3List, IEntitySelector par4IEntitySelector)
      {
@@ -312,7 +328,7 @@
  
          if (i < 0)
          {
-@@ -1252,6 +1344,15 @@
+@@ -1252,6 +1346,15 @@
       */
      public void fillChunk(byte[] par1ArrayOfByte, int par2, int par3, boolean par4)
      {
@@ -328,7 +344,7 @@
          int k = 0;
          boolean flag1 = !this.worldObj.provider.hasNoSky;
          int l;
-@@ -1352,12 +1453,26 @@
+@@ -1352,12 +1455,26 @@
          }
  
          this.generateHeightMap();
@@ -359,7 +375,7 @@
          }
      }
  
-@@ -1466,4 +1581,18 @@
+@@ -1466,4 +1583,18 @@
              }
          }
      }


### PR DESCRIPTION
To further improve protection, all block placements will trigger a BlockPlaceEvent with information about the block being placed. Any mod that overrides ItemBlock.placeBlockAt is responsible for implementing BlockPlaceEvent so protections are respected.

I have also added a new BlockSnapshot class which is based on CraftBukkit's BlockState but doesn't allow for modification after the snapshot is taken. This class provides a way to restore any location back to a previous
snapshot. By default, a BlockSnapshot is taken before all vanilla breaks/placements and sent via the event.

This implementation was based off the following commits by CraftBukkit :

https://github.com/Bukkit/CraftBukkit/commit/b39ef5e26f57029eebe2778c09c1757e6276b96b
https://github.com/Bukkit/CraftBukkit/commit/4aae8151825fef46dffc1bc9266730d3f493d9d6
https://github.com/Bukkit/CraftBukkit/commit/7b79da5c316aab18b5d82bc5b4c592c41567e343
https://github.com/Bukkit/CraftBukkit/commit/791ba7591a2853442fd2ba4245f9f4322fb1f001
https://github.com/Bukkit/CraftBukkit/commit/ed63bd525b36780e57d1576842e3d45f4bf5d55d
https://github.com/Bukkit/CraftBukkit/commit/c756ace0771b57b53ede0a1b6f82be760f1dd124
https://github.com/Bukkit/CraftBukkit/commit/f9b830267c104b7437393fed94c0e3d4d96d249e
