### PR TITLE
Proper return for getRegisteredFluidContainerData

### DIFF
--- a/common/net/minecraftforge/fluids/FluidContainerRegistry.java
+++ b/common/net/minecraftforge/fluids/FluidContainerRegistry.java
@@ -1,4 +1,3 @@
-
 package net.minecraftforge.fluids;
 
 import java.util.Arrays;
@@ -212,7 +211,7 @@ public abstract class FluidContainerRegistry {
 
     public static FluidContainerData[] getRegisteredFluidContainerData() {
 
-        return (FluidContainerData[]) containerFluidMap.values().toArray();
+        return  containerFluidMap.values().toArray(new FluidContainerData[containerFluidMap.size()]);
     }
 
     /**


### PR DESCRIPTION
Without declaring a type in the toArray() via passing an instance of a FluidContainerData[] java has hicups with things such as for loops that are Object Based rather than index based.
Scenario: for(FluidContainerData data: getRegisteredFluidContainerData()) would crash due to inability to cast an Object to a FluidContainerData type.
