### PR TITLE
Add the ability to register chat commands that execute on client.

### DIFF
--- a/client/net/minecraftforge/client/MinecraftForgeClient.java
+++ b/client/net/minecraftforge/client/MinecraftForgeClient.java
@@ -7,16 +7,11 @@ package net.minecraftforge.client;
 
 import java.util.BitSet;
 
-import org.lwjgl.opengl.Display;
-
-import net.minecraft.block.Block;
-import net.minecraft.entity.Entity;
+import net.minecraft.command.ICommand;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
-import net.minecraft.client.renderer.RenderBlocks;
-import net.minecraft.world.World;
 import net.minecraftforge.client.IItemRenderer.ItemRenderType;
-import net.minecraftforge.common.MinecraftForge;
+import net.minecraftforge.client.command.ClientCommandHandler;
 
 public class MinecraftForgeClient
 {
@@ -88,5 +83,18 @@ public class MinecraftForgeClient
         {
             stencilBits.set(bit);
         }
+    }
+
+    public static ClientCommandHandler clientCommandHandler = new ClientCommandHandler();
+
+    /**
+     * Register a client-side command. This command is executed on the client
+     * and is never sent to server
+     * 
+     * @param command The command to register
+     */
+    public static void registerClientCommand(ICommand command)
+    {
+        clientCommandHandler.registerCommand(command);
     }
 }

--- a/client/net/minecraftforge/client/command/ClientCommandHandler.java
+++ b/client/net/minecraftforge/client/command/ClientCommandHandler.java
@@ -1,0 +1,122 @@
+package net.minecraftforge.client.command;
+
+import java.util.List;
+
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.gui.GuiChat;
+import net.minecraft.command.CommandException;
+import net.minecraft.command.CommandHandler;
+import net.minecraft.command.ICommand;
+import net.minecraft.command.ICommandSender;
+import net.minecraft.command.WrongUsageException;
+import net.minecraft.util.ChatMessageComponent;
+import net.minecraft.util.EnumChatFormatting;
+import net.minecraftforge.common.MinecraftForge;
+import net.minecraftforge.event.CommandEvent;
+import cpw.mods.fml.client.FMLClientHandler;
+
+/**
+ * The class that handles client-side chat commands. You should register any
+ * commands that you want handled on the client with this command handler.
+ * 
+ * If there is a command with the same name registered both on the server and
+ * client, the client takes precedence!
+ * 
+ * @author Lepko
+ * 
+ */
+public class ClientCommandHandler extends CommandHandler
+{
+
+    /**
+     * @return 1 if successfully executed, 0 if wrong usage, it doesn't exist or
+     *         it was canceled.
+     */
+    @Override
+    public int executeCommand(ICommandSender sender, String message)
+    {
+        message = message.trim();
+
+        if (message.startsWith("/"))
+        {
+            message = message.substring(1);
+        }
+
+        String[] args = message.split(" ");
+        String commandName = args[0];
+        System.arraycopy(args, 1, args, 0, args.length - 1);
+        ICommand icommand = (ICommand) getCommands().get(commandName);
+
+        try
+        {
+            if (icommand == null)
+            {
+                return 0;
+            }
+
+            if (icommand.canCommandSenderUseCommand(sender))
+            {
+                CommandEvent event = new CommandEvent(icommand, sender, args);
+                if (MinecraftForge.EVENT_BUS.post(event))
+                {
+                    if (event.exception != null)
+                    {
+                        throw event.exception;
+                    }
+                    return 0;
+                }
+
+                icommand.processCommand(sender, args);
+                return 1;
+            }
+            else
+            {
+                sender.sendChatToPlayer(ChatMessageComponent.func_111077_e("commands.generic.permission").func_111059_a(EnumChatFormatting.RED));
+            }
+        }
+        catch (WrongUsageException wue)
+        {
+            sender.sendChatToPlayer(ChatMessageComponent.func_111082_b("commands.generic.usage", new Object[] { ChatMessageComponent.func_111082_b(wue.getMessage(), wue.getErrorOjbects()) }).func_111059_a(EnumChatFormatting.RED));
+        }
+        catch (CommandException ce)
+        {
+            sender.sendChatToPlayer(ChatMessageComponent.func_111082_b(ce.getMessage(), ce.getErrorOjbects()).func_111059_a(EnumChatFormatting.RED));
+        }
+        catch (Throwable t)
+        {
+            sender.sendChatToPlayer(ChatMessageComponent.func_111077_e("commands.generic.exception").func_111059_a(EnumChatFormatting.RED));
+            t.printStackTrace();
+        }
+
+        return 0;
+    }
+
+    public void autoComplete(String leftOfCursor, String full)
+    {
+        latestAutoComplete = null;
+
+        if (leftOfCursor.charAt(0) == '/')
+        {
+            leftOfCursor = leftOfCursor.substring(1);
+
+            Minecraft mc = FMLClientHandler.instance().getClient();
+            if (mc.currentScreen instanceof GuiChat)
+            {
+                List<String> commands = getPossibleCommands(mc.thePlayer, leftOfCursor);
+                if (commands != null && !commands.isEmpty())
+                {
+                    if (leftOfCursor.indexOf(' ') == -1)
+                    {
+                        for (int i = 0; i < commands.size(); i++)
+                        {
+                            commands.set(i, EnumChatFormatting.GRAY + "/" + commands.get(i));
+                        }
+                    }
+                    latestAutoComplete = commands.toArray(new String[commands.size()]);
+                }
+            }
+        }
+    }
+
+    public String[] latestAutoComplete = null;
+}

--- a/patches/minecraft/net/minecraft/client/Minecraft.java.patch
+++ b/patches/minecraft/net/minecraft/client/Minecraft.java.patch
@@ -1,11 +1,12 @@
 --- ../src_base/minecraft/net/minecraft/client/Minecraft.java
 +++ ../src_work/minecraft/net/minecraft/client/Minecraft.java
-@@ -136,6 +136,14 @@
+@@ -136,6 +136,15 @@
  
  import com.google.common.collect.MapDifference;
  
 +import net.minecraftforge.client.ForgeHooksClient;
 +import net.minecraftforge.client.GuiIngameForge;
++import net.minecraftforge.client.MinecraftForgeClient;
 +import net.minecraftforge.common.ForgeHooks;
 +import net.minecraftforge.common.MinecraftForge;
 +import net.minecraftforge.event.ForgeEventFactory;
@@ -15,7 +16,7 @@
  @SideOnly(Side.CLIENT)
  public class Minecraft implements IPlayerUsage
  {
-@@ -414,7 +422,7 @@
+@@ -414,7 +423,7 @@
  
          try
          {
@@ -24,7 +25,7 @@
          }
          catch (LWJGLException lwjglexception)
          {
-@@ -493,7 +501,7 @@
+@@ -493,7 +502,7 @@
          this.effectRenderer = new EffectRenderer(this.theWorld, this.renderEngine);
          FMLClientHandler.instance().finishMinecraftLoading();
          this.checkGLError("Post startup");
@@ -33,7 +34,7 @@
  
          if (this.serverName != null)
          {
-@@ -1296,7 +1304,7 @@
+@@ -1296,7 +1305,7 @@
  
                  if (this.thePlayer.canCurrentToolHarvestBlock(j, k, l))
                  {
@@ -42,7 +43,7 @@
                      this.thePlayer.swingItem();
                  }
              }
-@@ -1362,7 +1370,8 @@
+@@ -1362,7 +1371,8 @@
                  {
                      int j1 = itemstack != null ? itemstack.stackSize : 0;
  
@@ -52,7 +53,7 @@
                      {
                          flag = false;
                          this.thePlayer.swingItem();
-@@ -1388,7 +1397,8 @@
+@@ -1388,7 +1398,8 @@
              {
                  ItemStack itemstack1 = this.thePlayer.inventory.getCurrentItem();
  
@@ -62,7 +63,7 @@
                  {
                      this.entityRenderer.itemRenderer.resetEquippedProgress2();
                  }
-@@ -2036,6 +2046,11 @@
+@@ -2036,6 +2047,11 @@
      {
          this.statFileWriter.syncStats();
  
@@ -74,7 +75,7 @@
          if (par1WorldClient == null)
          {
              NetClientHandler netclienthandler = this.getNetHandler();
-@@ -2053,6 +2068,18 @@
+@@ -2053,6 +2069,18 @@
              if (this.theIntegratedServer != null)
              {
                  this.theIntegratedServer.initiateShutdown();
@@ -93,7 +94,16 @@
              }
  
              this.theIntegratedServer = null;
-@@ -2223,103 +2250,12 @@
+@@ -2212,7 +2240,7 @@
+      */
+     public boolean handleClientCommand(String par1Str)
+     {
+-        return false;
++        return MinecraftForgeClient.clientCommandHandler.executeCommand(thePlayer, par1Str) == 1;
+     }
+ 
+     /**
+@@ -2223,103 +2251,12 @@
          if (this.objectMouseOver != null)
          {
              boolean flag = this.thePlayer.capabilities.isCreativeMode;
@@ -201,7 +211,7 @@
  
              if (flag)
              {
-@@ -2401,11 +2337,18 @@
+@@ -2401,11 +2338,18 @@
          par1PlayerUsageSnooper.addData("gl_max_texture_size", Integer.valueOf(getGLMaximumTextureSize()));
      }
  
@@ -220,7 +230,7 @@
          for (int i = 16384; i > 0; i >>= 1)
          {
              GL11.glTexImage2D(GL11.GL_PROXY_TEXTURE_2D, 0, GL11.GL_RGBA, i, i, 0, GL11.GL_RGBA, GL11.GL_UNSIGNED_BYTE, (ByteBuffer)null);
-@@ -2413,6 +2356,7 @@
+@@ -2413,6 +2357,7 @@
  
              if (j != 0)
              {

--- a/patches/minecraft/net/minecraft/client/gui/GuiChat.java.patch
+++ b/patches/minecraft/net/minecraft/client/gui/GuiChat.java.patch
@@ -1,0 +1,54 @@
+--- ../src_base/minecraft/net/minecraft/client/gui/GuiChat.java
++++ ../src_work/minecraft/net/minecraft/client/gui/GuiChat.java
+@@ -7,8 +7,13 @@
+ import java.util.Iterator;
+ import java.util.List;
+ import net.minecraft.network.packet.Packet203AutoComplete;
++import net.minecraft.util.EnumChatFormatting;
++import net.minecraftforge.client.MinecraftForgeClient;
++
+ import org.lwjgl.input.Keyboard;
+ import org.lwjgl.input.Mouse;
++
++import com.google.common.collect.ObjectArrays;
+ 
+ @SideOnly(Side.CLIENT)
+ public class GuiChat extends GuiScreen
+@@ -268,20 +273,21 @@
+ 
+                 if (stringbuilder.length() > 0)
+                 {
+-                    stringbuilder.append(", ");
++                    stringbuilder.append(EnumChatFormatting.RESET + ", ");
+                 }
+             }
+ 
+             this.mc.ingameGUI.getChatGUI().printChatMessageWithOptionalDeletion(stringbuilder.toString(), 1);
+         }
+ 
+-        this.inputField.writeText((String)this.field_73904_o.get(this.field_73903_n++));
++        this.inputField.writeText(EnumChatFormatting.func_110646_a((String)this.field_73904_o.get(this.field_73903_n++)));
+     }
+ 
+     private void func_73893_a(String par1Str, String par2Str)
+     {
+         if (par1Str.length() >= 1)
+         {
++            MinecraftForgeClient.clientCommandHandler.autoComplete(par1Str, par2Str);
+             this.mc.thePlayer.sendQueue.addToSendQueue(new Packet203AutoComplete(par1Str));
+             this.field_73905_m = true;
+         }
+@@ -344,6 +350,13 @@
+             String[] astring1 = par1ArrayOfStr;
+             int i = par1ArrayOfStr.length;
+ 
++            String[] clientAutoComplete = MinecraftForgeClient.clientCommandHandler.latestAutoComplete;
++            if (clientAutoComplete != null)
++            {
++                astring1 = ObjectArrays.concat(clientAutoComplete, astring1, String.class);
++                i = astring1.length;
++            }
++            
+             for (int j = 0; j < i; ++j)
+             {
+                 String s = astring1[j];


### PR DESCRIPTION
_Resubmitted after screwing up #638_

Adds the ability to register chat commands that only execute on the client. Works with autocomplete.

Client commands are gray when shown in the autocomplete list (when you press tab)
