### PR TITLE
Load models from resource packs

### DIFF
--- a/client/net/minecraftforge/client/model/AdvancedModelLoader.java
+++ b/client/net/minecraftforge/client/model/AdvancedModelLoader.java
@@ -3,7 +3,7 @@ package net.minecraftforge.client.model;
 import java.util.Collection;
 import java.util.Map;
 
-import net.minecraft.client.resources.ResourceLocation;
+import net.minecraft.util.ResourceLocation;
 import net.minecraftforge.client.model.obj.ObjModelLoader;
 import net.minecraftforge.client.model.techne.TechneModelLoader;
 
@@ -15,72 +15,72 @@ import cpw.mods.fml.relauncher.SideOnly;
 
 /**
  * Common interface for advanced model loading from files, based on file suffix
- * Model support can be queried through the {@link #getSupportedSuffixes()} method.
- * Instances can be created by calling {@link #loadModel(String)} with a class-loadable-path
+ * Model support can be queried through the {@link #getSupportedSuffixes()}
+ * method. Instances can be created by calling {@link #loadModel(String)} with a
+ * class-loadable-path
  * 
  * @author cpw
  * 
  */
 @SideOnly(Side.CLIENT)
-public class AdvancedModelLoader
-{
-	private static Map<String, IModelCustomLoader>	instances	= Maps.newHashMap();
-	
-	/**
-	 * Register a new model handler
-	 * 
-	 * @param modelHandler
-	 *            The model handler to register
-	 */
-	public static void registerModelHandler(IModelCustomLoader modelHandler)
-	{
-		for (String suffix : modelHandler.getSuffixes())
-		{
-			instances.put(suffix, modelHandler);
-		}
-	}
-	
-	/**
-	 * Load the model from the supplied classpath resolvable resource name
-	 * 
-	 * @param resourceName
-	 *            The resource name
-	 * @return A model
-	 * @throws IllegalArgumentException
-	 *             if the resource name cannot be understood
-	 * @throws ModelFormatException
-	 *             if the underlying model handler cannot parse the model format
-	 */
-	public static IModelCustom loadModel(String resourceName) throws IllegalArgumentException, ModelFormatException
-	{
-		int i = resourceName.lastIndexOf('.');
-		int j = resourceName.lastIndexOf(':');
-		if (i == -1 || j == -1)
-		{
-			FMLLog.severe("The resource name %s is not valid", resourceName);
-			throw new IllegalArgumentException("The resource name is not valid");
-		}
-		String suffix = resourceName.substring(i + 1);
-		String modID = resourceName.substring(0, j);
-		IModelCustomLoader loader = instances.get(suffix);
-		if (loader == null)
-		{
-			FMLLog.severe("The resource name %s is not supported", resourceName);
-			throw new IllegalArgumentException("The resource name is not supported");
-		}
-		
-		ResourceLocation resource = new ResourceLocation(modID, resourceName.substring(j + 1));
-		return loader.loadInstance(resourceName, resource);
-	}
-	
-	public static Collection<String> getSupportedSuffixes()
-	{
-		return instances.keySet();
-	}
-	
-	static
-	{
-		registerModelHandler(new ObjModelLoader());
-		registerModelHandler(new TechneModelLoader());
-	}
+public class AdvancedModelLoader {
+    private static Map<String, IModelCustomLoader> instances = Maps.newHashMap();
+
+    /**
+     * Register a new model handler
+     * 
+     * @param modelHandler
+     *            The model handler to register
+     */
+    public static void registerModelHandler(IModelCustomLoader modelHandler)
+    {
+        for (String suffix : modelHandler.getSuffixes())
+        {
+            instances.put(suffix, modelHandler);
+        }
+    }
+
+    /**
+     * Load the model from the supplied classpath resolvable resource name
+     * 
+     * @param resourceName
+     *            The resource name
+     * @return A model
+     * @throws IllegalArgumentException
+     *             if the resource name cannot be understood
+     * @throws ModelFormatException
+     *             if the underlying model handler cannot parse the model format
+     */
+    public static IModelCustom loadModel(String resourceName) throws IllegalArgumentException, ModelFormatException
+    {
+        int i = resourceName.lastIndexOf('.');
+        int j = resourceName.lastIndexOf(':');
+        if (i == -1 || j == -1)
+        {
+            FMLLog.severe("The resource name %s is not valid", resourceName);
+            throw new IllegalArgumentException("The resource name is not valid");
+        }
+        String suffix = resourceName.substring(i + 1);
+        String modID = resourceName.substring(0, j);
+        IModelCustomLoader loader = instances.get(suffix);
+        if (loader == null)
+        {
+            FMLLog.severe("The resource name %s is not supported", resourceName);
+            throw new IllegalArgumentException("The resource name is not supported");
+        }
+
+        ResourceLocation resource = new ResourceLocation(modID, resourceName.substring(j + 1));
+        return loader.loadInstance(resourceName, resource);
+    }
+
+    public static Collection<String> getSupportedSuffixes()
+    {
+        return instances.keySet();
+    }
+
+    static
+    {
+        registerModelHandler(new ObjModelLoader());
+        registerModelHandler(new TechneModelLoader());
+    }
 }

--- a/client/net/minecraftforge/client/model/IModelCustom.java
+++ b/client/net/minecraftforge/client/model/IModelCustom.java
@@ -1,9 +1,9 @@
 package net.minecraftforge.client.model;
 
-
-
 public interface IModelCustom {
     String getType();
+
     void renderAll();
+
     void renderPart(String partName);
 }

--- a/client/net/minecraftforge/client/model/IModelCustomLoader.java
+++ b/client/net/minecraftforge/client/model/IModelCustomLoader.java
@@ -1,6 +1,6 @@
 package net.minecraftforge.client.model;
 
-import net.minecraft.client.resources.ResourceLocation;
+import net.minecraft.util.ResourceLocation;
 
 /**
  * Instances of this class act as factories for their model type
@@ -8,32 +8,31 @@ import net.minecraft.client.resources.ResourceLocation;
  * @author cpw
  * 
  */
-public interface IModelCustomLoader
-{
-	/**
-	 * Get the main type name for this loader
-	 * 
-	 * @return the type name
-	 */
-	String getType();
-	
-	/**
-	 * Get resource suffixes this model loader recognizes
-	 * 
-	 * @return a list of suffixes
-	 */
-	String[] getSuffixes();
-	
-	/**
-	 * Load a model instance from the supplied path
-	 * 
-	 * @param resourceName
-	 *            The resource name to load
-	 * @param resource
-	 *            The URL associated with the classloader resource
-	 * @return A model instance
-	 * @throws ModelFormatException
-	 *             if the model format is not correct
-	 */
-	IModelCustom loadInstance(String resourceName, ResourceLocation resource) throws ModelFormatException;
+public interface IModelCustomLoader {
+    /**
+     * Get the main type name for this loader
+     * 
+     * @return the type name
+     */
+    String getType();
+
+    /**
+     * Get resource suffixes this model loader recognizes
+     * 
+     * @return a list of suffixes
+     */
+    String[] getSuffixes();
+
+    /**
+     * Load a model instance from the supplied path
+     * 
+     * @param resourceName
+     *            The resource name to load
+     * @param resource
+     *            The URL associated with the classloader resource
+     * @return A model instance
+     * @throws ModelFormatException
+     *             if the model format is not correct
+     */
+    IModelCustom loadInstance(String resourceName, ResourceLocation resource) throws ModelFormatException;
 }

--- a/client/net/minecraftforge/client/model/ModelFormatException.java
+++ b/client/net/minecraftforge/client/model/ModelFormatException.java
@@ -2,9 +2,9 @@ package net.minecraftforge.client.model;
 
 /**
  * Thrown if there is a problem parsing the model
- *
+ * 
  * @author cpw
- *
+ * 
  */
 public class ModelFormatException extends RuntimeException {
 

--- a/client/net/minecraftforge/client/model/obj/Face.java
+++ b/client/net/minecraftforge/client/model/obj/Face.java
@@ -6,8 +6,7 @@ import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
 
 @SideOnly(Side.CLIENT)
-public class Face
-{
+public class Face {
 
     public Vertex[] vertices;
     public Vertex[] vertexNormals;

--- a/client/net/minecraftforge/client/model/obj/GroupObject.java
+++ b/client/net/minecraftforge/client/model/obj/GroupObject.java
@@ -7,8 +7,7 @@ import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
 
 @SideOnly(Side.CLIENT)
-public class GroupObject
-{
+public class GroupObject {
 
     public String name;
     public ArrayList<Face> faces = new ArrayList<Face>();

--- a/client/net/minecraftforge/client/model/obj/ObjModelLoader.java
+++ b/client/net/minecraftforge/client/model/obj/ObjModelLoader.java
@@ -1,31 +1,30 @@
 package net.minecraftforge.client.model.obj;
 
-import net.minecraft.client.resources.ResourceLocation;
+import net.minecraft.util.ResourceLocation;
 import net.minecraftforge.client.model.IModelCustom;
 import net.minecraftforge.client.model.IModelCustomLoader;
 import net.minecraftforge.client.model.ModelFormatException;
 
-public class ObjModelLoader implements IModelCustomLoader
-{
-	
-	@Override
-	public String getType()
-	{
-		return "OBJ model";
-	}
-	
-	private static final String[]	types	= { "obj" };
-	
-	@Override
-	public String[] getSuffixes()
-	{
-		return types;
-	}
-	
-	@Override
-	public IModelCustom loadInstance(String resourceName, ResourceLocation resource) throws ModelFormatException
-	{
-		return new WavefrontObject(resourceName, resource);
-	}
-	
+public class ObjModelLoader implements IModelCustomLoader {
+
+    @Override
+    public String getType()
+    {
+        return "OBJ model";
+    }
+
+    private static final String[] types = { "obj" };
+
+    @Override
+    public String[] getSuffixes()
+    {
+        return types;
+    }
+
+    @Override
+    public IModelCustom loadInstance(String resourceName, ResourceLocation resource) throws ModelFormatException
+    {
+        return new WavefrontObject(resourceName, resource);
+    }
+
 }

--- a/client/net/minecraftforge/client/model/obj/TextureCoordinate.java
+++ b/client/net/minecraftforge/client/model/obj/TextureCoordinate.java
@@ -4,8 +4,7 @@ import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
 
 @SideOnly(Side.CLIENT)
-public class TextureCoordinate
-{
+public class TextureCoordinate {
 
     public float u, v, w;
 

--- a/client/net/minecraftforge/client/model/obj/Vertex.java
+++ b/client/net/minecraftforge/client/model/obj/Vertex.java
@@ -4,8 +4,7 @@ import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
 
 @SideOnly(Side.CLIENT)
-public class Vertex
-{
+public class Vertex {
 
     public float x, y, z;
 

--- a/client/net/minecraftforge/client/model/obj/WavefrontObject.java
+++ b/client/net/minecraftforge/client/model/obj/WavefrontObject.java
@@ -11,7 +11,7 @@ import java.util.regex.Pattern;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.renderer.Tessellator;
 import net.minecraft.client.resources.Resource;
-import net.minecraft.client.resources.ResourceLocation;
+import net.minecraft.util.ResourceLocation;
 import net.minecraftforge.client.model.IModelCustom;
 import net.minecraftforge.client.model.ModelFormatException;
 
@@ -25,596 +25,597 @@ import cpw.mods.fml.relauncher.SideOnly;
  * http://en.wikipedia.org/wiki/Wavefront_.obj_file
  */
 @SideOnly(Side.CLIENT)
-public class WavefrontObject implements IModelCustom
-{
-	
-	private static Pattern				vertexPattern				= Pattern.compile("(v( (\\-){0,1}\\d+\\.\\d+){3,4} *\\n)|(v( (\\-){0,1}\\d+\\.\\d+){3,4} *$)");
-	private static Pattern				vertexNormalPattern			= Pattern.compile("(vn( (\\-){0,1}\\d+\\.\\d+){3,4} *\\n)|(vn( (\\-){0,1}\\d+\\.\\d+){3,4} *$)");
-	private static Pattern				textureCoordinatePattern	= Pattern.compile("(vt( (\\-){0,1}\\d+\\.\\d+){2,3} *\\n)|(vt( (\\-){0,1}\\d+\\.\\d+){2,3} *$)");
-	private static Pattern				face_V_VT_VN_Pattern		= Pattern.compile("(f( \\d+/\\d+/\\d+){3,4} *\\n)|(f( \\d+/\\d+/\\d+){3,4} *$)");
-	private static Pattern				face_V_VT_Pattern			= Pattern.compile("(f( \\d+/\\d+){3,4} *\\n)|(f( \\d+/\\d+){3,4} *$)");
-	private static Pattern				face_V_VN_Pattern			= Pattern.compile("(f( \\d+//\\d+){3,4} *\\n)|(f( \\d+//\\d+){3,4} *$)");
-	private static Pattern				face_V_Pattern				= Pattern.compile("(f( \\d+){3,4} *\\n)|(f( \\d+){3,4} *$)");
-	private static Pattern				groupObjectPattern			= Pattern.compile("([go]( [\\w\\d]+) *\\n)|([go]( [\\w\\d]+) *$)");
-	
-	private static Matcher				vertexMatcher, vertexNormalMatcher, textureCoordinateMatcher;
-	private static Matcher				face_V_VT_VN_Matcher, face_V_VT_Matcher, face_V_VN_Matcher, face_V_Matcher;
-	private static Matcher				groupObjectMatcher;
-	
-	public ArrayList<Vertex>			vertices					= new ArrayList<Vertex>();
-	public ArrayList<Vertex>			vertexNormals				= new ArrayList<Vertex>();
-	public ArrayList<TextureCoordinate>	textureCoordinates			= new ArrayList<TextureCoordinate>();
-	public ArrayList<GroupObject>		groupObjects				= new ArrayList<GroupObject>();
-	private GroupObject					currentGroupObject;
-	private String						fileName;
-	
-	public WavefrontObject(String fileName, ResourceLocation resource) throws ModelFormatException
-	{
-		this.fileName = fileName;
-		loadObjModel(resource);
-	}
-	
-	private void loadObjModel(ResourceLocation resLoc) throws ModelFormatException
-	{
-		BufferedReader reader = null;
-		InputStream inputStream = null;
-		
-		String currentLine = null;
-		int lineCount = 0;
-		
-		try
-		{
-			Resource res = Minecraft.getMinecraft().func_110442_L().func_110536_a(resLoc);
-			inputStream = res.func_110527_b();
-			reader = new BufferedReader(new InputStreamReader(inputStream));
-			
-			while ((currentLine = reader.readLine()) != null)
-			{
-				lineCount++;
-				currentLine = currentLine.replaceAll("\\s+", " ").trim();
-				
-				if (currentLine.startsWith("#") || currentLine.length() == 0)
-				{
-					continue;
-				}
-				else if (currentLine.startsWith("v "))
-				{
-					Vertex vertex = parseVertex(currentLine, lineCount);
-					if (vertex != null)
-					{
-						vertices.add(vertex);
-					}
-				}
-				else if (currentLine.startsWith("vn "))
-				{
-					Vertex vertex = parseVertexNormal(currentLine, lineCount);
-					if (vertex != null)
-					{
-						vertexNormals.add(vertex);
-					}
-				}
-				else if (currentLine.startsWith("vt "))
-				{
-					TextureCoordinate textureCoordinate = parseTextureCoordinate(currentLine, lineCount);
-					if (textureCoordinate != null)
-					{
-						textureCoordinates.add(textureCoordinate);
-					}
-				}
-				else if (currentLine.startsWith("f "))
-				{
-					
-					if (currentGroupObject == null)
-					{
-						currentGroupObject = new GroupObject("Default");
-					}
-					
-					Face face = parseFace(currentLine, lineCount);
-					
-					if (face != null)
-					{
-						currentGroupObject.faces.add(face);
-					}
-				}
-				else if (currentLine.startsWith("g ") | currentLine.startsWith("o "))
-				{
-					GroupObject group = parseGroupObject(currentLine, lineCount);
-					
-					if (group != null)
-					{
-						if (currentGroupObject != null)
-						{
-							groupObjects.add(currentGroupObject);
-						}
-					}
-					
-					currentGroupObject = group;
-				}
-			}
-			
-			groupObjects.add(currentGroupObject);
-		}
-		catch (IOException e)
-		{
-			throw new ModelFormatException("IO Exception reading model format", e);
-		}
-		finally
-		{
-			try
-			{
-				reader.close();
-			}
-			catch (IOException e)
-			{
-				// hush
-			}
-			
-			try
-			{
-				inputStream.close();
-			}
-			catch (IOException e)
-			{
-				// hush
-			}
-		}
-	}
-	
-	public void renderAll()
-	{
-		Tessellator tessellator = Tessellator.instance;
-		
-		if (currentGroupObject != null)
-		{
-			tessellator.startDrawing(currentGroupObject.glDrawingMode);
-		}
-		else
-		{
-			tessellator.startDrawing(GL11.GL_TRIANGLES);
-		}
-		
-		for (GroupObject groupObject : groupObjects)
-		{
-			groupObject.render(tessellator);
-		}
-		
-		tessellator.draw();
-	}
-	
-	public void renderOnly(String... groupNames)
-	{
-		for (GroupObject groupObject : groupObjects)
-		{
-			for (String groupName : groupNames)
-			{
-				if (groupName.equalsIgnoreCase(groupObject.name))
-				{
-					groupObject.render();
-				}
-			}
-		}
-	}
-	
-	public void renderPart(String partName)
-	{
-		for (GroupObject groupObject : groupObjects)
-		{
-			if (partName.equalsIgnoreCase(groupObject.name))
-			{
-				groupObject.render();
-			}
-		}
-	}
-	
-	public void renderAllExcept(String... excludedGroupNames)
-	{
-		for (GroupObject groupObject : groupObjects)
-		{
-			for (String excludedGroupName : excludedGroupNames)
-			{
-				if (!excludedGroupName.equalsIgnoreCase(groupObject.name))
-				{
-					groupObject.render();
-				}
-			}
-		}
-	}
-	
-	private Vertex parseVertex(String line, int lineCount) throws ModelFormatException
-	{
-		Vertex vertex = null;
-		
-		if (isValidVertexLine(line))
-		{
-			line = line.substring(line.indexOf(" ") + 1);
-			String[] tokens = line.split(" ");
-			
-			try
-			{
-				if (tokens.length == 2)
-				{
-					return new Vertex(Float.parseFloat(tokens[0]), Float.parseFloat(tokens[1]));
-				}
-				else if (tokens.length == 3)
-				{
-					return new Vertex(Float.parseFloat(tokens[0]), Float.parseFloat(tokens[1]), Float.parseFloat(tokens[2]));
-				}
-			}
-			catch (NumberFormatException e)
-			{
-				throw new ModelFormatException(String.format("Number formatting error at line %d", lineCount), e);
-			}
-		}
-		else
-		{
-			throw new ModelFormatException("Error parsing entry ('" + line + "'" + ", line " + lineCount + ") in file '" + fileName + "' - Incorrect format");
-		}
-		
-		return vertex;
-	}
-	
-	private Vertex parseVertexNormal(String line, int lineCount) throws ModelFormatException
-	{
-		Vertex vertexNormal = null;
-		
-		if (isValidVertexNormalLine(line))
-		{
-			line = line.substring(line.indexOf(" ") + 1);
-			String[] tokens = line.split(" ");
-			
-			try
-			{
-				if (tokens.length == 3)
-					return new Vertex(Float.parseFloat(tokens[0]), Float.parseFloat(tokens[1]), Float.parseFloat(tokens[2]));
-			}
-			catch (NumberFormatException e)
-			{
-				throw new ModelFormatException(String.format("Number formatting error at line %d", lineCount), e);
-			}
-		}
-		else
-		{
-			throw new ModelFormatException("Error parsing entry ('" + line + "'" + ", line " + lineCount + ") in file '" + fileName + "' - Incorrect format");
-		}
-		
-		return vertexNormal;
-	}
-	
-	private TextureCoordinate parseTextureCoordinate(String line, int lineCount) throws ModelFormatException
-	{
-		TextureCoordinate textureCoordinate = null;
-		
-		if (isValidTextureCoordinateLine(line))
-		{
-			line = line.substring(line.indexOf(" ") + 1);
-			String[] tokens = line.split(" ");
-			
-			try
-			{
-				if (tokens.length == 2)
-					return new TextureCoordinate(Float.parseFloat(tokens[0]), 1 - Float.parseFloat(tokens[1]));
-				else if (tokens.length == 3)
-					return new TextureCoordinate(Float.parseFloat(tokens[0]), 1 - Float.parseFloat(tokens[1]), Float.parseFloat(tokens[2]));
-			}
-			catch (NumberFormatException e)
-			{
-				throw new ModelFormatException(String.format("Number formatting error at line %d", lineCount), e);
-			}
-		}
-		else
-		{
-			throw new ModelFormatException("Error parsing entry ('" + line + "'" + ", line " + lineCount + ") in file '" + fileName + "' - Incorrect format");
-		}
-		
-		return textureCoordinate;
-	}
-	
-	private Face parseFace(String line, int lineCount) throws ModelFormatException
-	{
-		Face face = null;
-		
-		if (isValidFaceLine(line))
-		{
-			face = new Face();
-			
-			String trimmedLine = line.substring(line.indexOf(" ") + 1);
-			String[] tokens = trimmedLine.split(" ");
-			String[] subTokens = null;
-			
-			if (tokens.length == 3)
-			{
-				if (currentGroupObject.glDrawingMode == -1)
-				{
-					currentGroupObject.glDrawingMode = GL11.GL_TRIANGLES;
-				}
-				else if (currentGroupObject.glDrawingMode != GL11.GL_TRIANGLES)
-				{
-					throw new ModelFormatException("Error parsing entry ('" + line + "'" + ", line " + lineCount + ") in file '" + fileName + "' - Invalid number of points for face (expected 4, found " + tokens.length + ")");
-				}
-			}
-			else if (tokens.length == 4)
-			{
-				if (currentGroupObject.glDrawingMode == -1)
-				{
-					currentGroupObject.glDrawingMode = GL11.GL_QUADS;
-				}
-				else if (currentGroupObject.glDrawingMode != GL11.GL_QUADS)
-				{
-					throw new ModelFormatException("Error parsing entry ('" + line + "'" + ", line " + lineCount + ") in file '" + fileName + "' - Invalid number of points for face (expected 3, found " + tokens.length + ")");
-				}
-			}
-			
-			// f v1/vt1/vn1 v2/vt2/vn2 v3/vt3/vn3 ...
-			if (isValidFace_V_VT_VN_Line(line))
-			{
-				face.vertices = new Vertex[tokens.length];
-				face.textureCoordinates = new TextureCoordinate[tokens.length];
-				face.vertexNormals = new Vertex[tokens.length];
-				
-				for (int i = 0; i < tokens.length; ++i)
-				{
-					subTokens = tokens[i].split("/");
-					
-					face.vertices[i] = vertices.get(Integer.parseInt(subTokens[0]) - 1);
-					face.textureCoordinates[i] = textureCoordinates.get(Integer.parseInt(subTokens[1]) - 1);
-					face.vertexNormals[i] = vertexNormals.get(Integer.parseInt(subTokens[2]) - 1);
-				}
-				
-				face.faceNormal = face.calculateFaceNormal();
-			}
-			// f v1/vt1 v2/vt2 v3/vt3 ...
-			else if (isValidFace_V_VT_Line(line))
-			{
-				face.vertices = new Vertex[tokens.length];
-				face.textureCoordinates = new TextureCoordinate[tokens.length];
-				
-				for (int i = 0; i < tokens.length; ++i)
-				{
-					subTokens = tokens[i].split("/");
-					
-					face.vertices[i] = vertices.get(Integer.parseInt(subTokens[0]) - 1);
-					face.textureCoordinates[i] = textureCoordinates.get(Integer.parseInt(subTokens[1]) - 1);
-				}
-				
-				face.faceNormal = face.calculateFaceNormal();
-			}
-			// f v1//vn1 v2//vn2 v3//vn3 ...
-			else if (isValidFace_V_VN_Line(line))
-			{
-				face.vertices = new Vertex[tokens.length];
-				face.vertexNormals = new Vertex[tokens.length];
-				
-				for (int i = 0; i < tokens.length; ++i)
-				{
-					subTokens = tokens[i].split("//");
-					
-					face.vertices[i] = vertices.get(Integer.parseInt(subTokens[0]) - 1);
-					face.vertexNormals[i] = vertexNormals.get(Integer.parseInt(subTokens[1]) - 1);
-				}
-				
-				face.faceNormal = face.calculateFaceNormal();
-			}
-			// f v1 v2 v3 ...
-			else if (isValidFace_V_Line(line))
-			{
-				face.vertices = new Vertex[tokens.length];
-				
-				for (int i = 0; i < tokens.length; ++i)
-				{
-					face.vertices[i] = vertices.get(Integer.parseInt(tokens[i]) - 1);
-				}
-				
-				face.faceNormal = face.calculateFaceNormal();
-			}
-			else
-			{
-				throw new ModelFormatException("Error parsing entry ('" + line + "'" + ", line " + lineCount + ") in file '" + fileName + "' - Incorrect format");
-			}
-		}
-		else
-		{
-			throw new ModelFormatException("Error parsing entry ('" + line + "'" + ", line " + lineCount + ") in file '" + fileName + "' - Incorrect format");
-		}
-		
-		return face;
-	}
-	
-	private GroupObject parseGroupObject(String line, int lineCount) throws ModelFormatException
-	{
-		GroupObject group = null;
-		
-		if (isValidGroupObjectLine(line))
-		{
-			String trimmedLine = line.substring(line.indexOf(" ") + 1);
-			
-			if (trimmedLine.length() > 0)
-			{
-				group = new GroupObject(trimmedLine);
-			}
-		}
-		else
-		{
-			throw new ModelFormatException("Error parsing entry ('" + line + "'" + ", line " + lineCount + ") in file '" + fileName + "' - Incorrect format");
-		}
-		
-		return group;
-	}
-	
-	/***
-	 * Verifies that the given line from the model file is a valid vertex
-	 * 
-	 * @param line
-	 *            the line being validated
-	 * @return true if the line is a valid vertex, false otherwise
-	 */
-	private static boolean isValidVertexLine(String line)
-	{
-		if (vertexMatcher != null)
-		{
-			vertexMatcher.reset();
-		}
-		
-		vertexMatcher = vertexPattern.matcher(line);
-		return vertexMatcher.matches();
-	}
-	
-	/***
-	 * Verifies that the given line from the model file is a valid vertex normal
-	 * 
-	 * @param line
-	 *            the line being validated
-	 * @return true if the line is a valid vertex normal, false otherwise
-	 */
-	private static boolean isValidVertexNormalLine(String line)
-	{
-		if (vertexNormalMatcher != null)
-		{
-			vertexNormalMatcher.reset();
-		}
-		
-		vertexNormalMatcher = vertexNormalPattern.matcher(line);
-		return vertexNormalMatcher.matches();
-	}
-	
-	/***
-	 * Verifies that the given line from the model file is a valid texture
-	 * coordinate
-	 * 
-	 * @param line
-	 *            the line being validated
-	 * @return true if the line is a valid texture coordinate, false otherwise
-	 */
-	private static boolean isValidTextureCoordinateLine(String line)
-	{
-		if (textureCoordinateMatcher != null)
-		{
-			textureCoordinateMatcher.reset();
-		}
-		
-		textureCoordinateMatcher = textureCoordinatePattern.matcher(line);
-		return textureCoordinateMatcher.matches();
-	}
-	
-	/***
-	 * Verifies that the given line from the model file is a valid face that is
-	 * described by vertices, texture coordinates, and vertex normals
-	 * 
-	 * @param line
-	 *            the line being validated
-	 * @return true if the line is a valid face that matches the format
-	 *         "f v1/vt1/vn1 ..." (with a minimum of 3 points in the face, and a
-	 *         maximum of 4), false otherwise
-	 */
-	private static boolean isValidFace_V_VT_VN_Line(String line)
-	{
-		if (face_V_VT_VN_Matcher != null)
-		{
-			face_V_VT_VN_Matcher.reset();
-		}
-		
-		face_V_VT_VN_Matcher = face_V_VT_VN_Pattern.matcher(line);
-		return face_V_VT_VN_Matcher.matches();
-	}
-	
-	/***
-	 * Verifies that the given line from the model file is a valid face that is
-	 * described by vertices and texture coordinates
-	 * 
-	 * @param line
-	 *            the line being validated
-	 * @return true if the line is a valid face that matches the format
-	 *         "f v1/vt1 ..." (with a minimum of 3 points in the face, and a
-	 *         maximum of 4), false otherwise
-	 */
-	private static boolean isValidFace_V_VT_Line(String line)
-	{
-		if (face_V_VT_Matcher != null)
-		{
-			face_V_VT_Matcher.reset();
-		}
-		
-		face_V_VT_Matcher = face_V_VT_Pattern.matcher(line);
-		return face_V_VT_Matcher.matches();
-	}
-	
-	/***
-	 * Verifies that the given line from the model file is a valid face that is
-	 * described by vertices and vertex normals
-	 * 
-	 * @param line
-	 *            the line being validated
-	 * @return true if the line is a valid face that matches the format
-	 *         "f v1//vn1 ..." (with a minimum of 3 points in the face, and a
-	 *         maximum of 4), false otherwise
-	 */
-	private static boolean isValidFace_V_VN_Line(String line)
-	{
-		if (face_V_VN_Matcher != null)
-		{
-			face_V_VN_Matcher.reset();
-		}
-		
-		face_V_VN_Matcher = face_V_VN_Pattern.matcher(line);
-		return face_V_VN_Matcher.matches();
-	}
-	
-	/***
-	 * Verifies that the given line from the model file is a valid face that is
-	 * described by only vertices
-	 * 
-	 * @param line
-	 *            the line being validated
-	 * @return true if the line is a valid face that matches the format
-	 *         "f v1 ..." (with a minimum of 3 points in the face, and a maximum
-	 *         of 4), false otherwise
-	 */
-	private static boolean isValidFace_V_Line(String line)
-	{
-		if (face_V_Matcher != null)
-		{
-			face_V_Matcher.reset();
-		}
-		
-		face_V_Matcher = face_V_Pattern.matcher(line);
-		return face_V_Matcher.matches();
-	}
-	
-	/***
-	 * Verifies that the given line from the model file is a valid face of any
-	 * of the possible face formats
-	 * 
-	 * @param line
-	 *            the line being validated
-	 * @return true if the line is a valid face that matches any of the valid
-	 *         face formats, false otherwise
-	 */
-	private static boolean isValidFaceLine(String line)
-	{
-		return isValidFace_V_VT_VN_Line(line) || isValidFace_V_VT_Line(line) || isValidFace_V_VN_Line(line) || isValidFace_V_Line(line);
-	}
-	
-	/***
-	 * Verifies that the given line from the model file is a valid group (or
-	 * object)
-	 * 
-	 * @param line
-	 *            the line being validated
-	 * @return true if the line is a valid group (or object), false otherwise
-	 */
-	private static boolean isValidGroupObjectLine(String line)
-	{
-		if (groupObjectMatcher != null)
-		{
-			groupObjectMatcher.reset();
-		}
-		
-		groupObjectMatcher = groupObjectPattern.matcher(line);
-		return groupObjectMatcher.matches();
-	}
-	
-	@Override
-	public String getType()
-	{
-		return "obj";
-	}
+public class WavefrontObject implements IModelCustom {
+
+    private static Pattern vertexPattern = Pattern.compile("(v( (\\-){0,1}\\d+\\.\\d+){3,4} *\\n)|(v( (\\-){0,1}\\d+\\.\\d+){3,4} *$)");
+    private static Pattern vertexNormalPattern = Pattern.compile("(vn( (\\-){0,1}\\d+\\.\\d+){3,4} *\\n)|(vn( (\\-){0,1}\\d+\\.\\d+){3,4} *$)");
+    private static Pattern textureCoordinatePattern = Pattern.compile("(vt( (\\-){0,1}\\d+\\.\\d+){2,3} *\\n)|(vt( (\\-){0,1}\\d+\\.\\d+){2,3} *$)");
+    private static Pattern face_V_VT_VN_Pattern = Pattern.compile("(f( \\d+/\\d+/\\d+){3,4} *\\n)|(f( \\d+/\\d+/\\d+){3,4} *$)");
+    private static Pattern face_V_VT_Pattern = Pattern.compile("(f( \\d+/\\d+){3,4} *\\n)|(f( \\d+/\\d+){3,4} *$)");
+    private static Pattern face_V_VN_Pattern = Pattern.compile("(f( \\d+//\\d+){3,4} *\\n)|(f( \\d+//\\d+){3,4} *$)");
+    private static Pattern face_V_Pattern = Pattern.compile("(f( \\d+){3,4} *\\n)|(f( \\d+){3,4} *$)");
+    private static Pattern groupObjectPattern = Pattern.compile("([go]( [\\w\\d]+) *\\n)|([go]( [\\w\\d]+) *$)");
+
+    private static Matcher vertexMatcher, vertexNormalMatcher, textureCoordinateMatcher;
+    private static Matcher face_V_VT_VN_Matcher, face_V_VT_Matcher, face_V_VN_Matcher, face_V_Matcher;
+    private static Matcher groupObjectMatcher;
+
+    public ArrayList<Vertex> vertices = new ArrayList<Vertex>();
+    public ArrayList<Vertex> vertexNormals = new ArrayList<Vertex>();
+    public ArrayList<TextureCoordinate> textureCoordinates = new ArrayList<TextureCoordinate>();
+    public ArrayList<GroupObject> groupObjects = new ArrayList<GroupObject>();
+    private GroupObject currentGroupObject;
+    private String fileName;
+
+    public WavefrontObject(String fileName, ResourceLocation resource) throws ModelFormatException
+    {
+        this.fileName = fileName;
+        loadObjModel(resource);
+    }
+
+    private void loadObjModel(ResourceLocation resLoc) throws ModelFormatException
+    {
+        BufferedReader reader = null;
+        InputStream inputStream = null;
+
+        String currentLine = null;
+        int lineCount = 0;
+
+        try
+        {
+            Resource res = Minecraft.getMinecraft().func_110442_L().func_110536_a(resLoc);
+            inputStream = res.func_110527_b();
+            reader = new BufferedReader(new InputStreamReader(inputStream));
+
+            while ((currentLine = reader.readLine()) != null)
+            {
+                lineCount++;
+                currentLine = currentLine.replaceAll("\\s+", " ").trim();
+
+                if (currentLine.startsWith("#") || currentLine.length() == 0)
+                {
+                    continue;
+                }
+                else if (currentLine.startsWith("v "))
+                {
+                    Vertex vertex = parseVertex(currentLine, lineCount);
+                    if (vertex != null)
+                    {
+                        vertices.add(vertex);
+                    }
+                }
+                else if (currentLine.startsWith("vn "))
+                {
+                    Vertex vertex = parseVertexNormal(currentLine, lineCount);
+                    if (vertex != null)
+                    {
+                        vertexNormals.add(vertex);
+                    }
+                }
+                else if (currentLine.startsWith("vt "))
+                {
+                    TextureCoordinate textureCoordinate = parseTextureCoordinate(currentLine, lineCount);
+                    if (textureCoordinate != null)
+                    {
+                        textureCoordinates.add(textureCoordinate);
+                    }
+                }
+                else if (currentLine.startsWith("f "))
+                {
+
+                    if (currentGroupObject == null)
+                    {
+                        currentGroupObject = new GroupObject("Default");
+                    }
+
+                    Face face = parseFace(currentLine, lineCount);
+
+                    if (face != null)
+                    {
+                        currentGroupObject.faces.add(face);
+                    }
+                }
+                else if (currentLine.startsWith("g ") | currentLine.startsWith("o "))
+                {
+                    GroupObject group = parseGroupObject(currentLine, lineCount);
+
+                    if (group != null)
+                    {
+                        if (currentGroupObject != null)
+                        {
+                            groupObjects.add(currentGroupObject);
+                        }
+                    }
+
+                    currentGroupObject = group;
+                }
+            }
+
+            groupObjects.add(currentGroupObject);
+        }
+        catch (IOException e)
+        {
+            throw new ModelFormatException("IO Exception reading model format", e);
+        }
+        finally
+        {
+            try
+            {
+                reader.close();
+            }
+            catch (IOException e)
+            {
+                // hush
+            }
+
+            try
+            {
+                inputStream.close();
+            }
+            catch (IOException e)
+            {
+                // hush
+            }
+        }
+    }
+
+    public void renderAll()
+    {
+        Tessellator tessellator = Tessellator.instance;
+
+        if (currentGroupObject != null)
+        {
+            tessellator.startDrawing(currentGroupObject.glDrawingMode);
+        }
+        else
+        {
+            tessellator.startDrawing(GL11.GL_TRIANGLES);
+        }
+
+        for (GroupObject groupObject : groupObjects)
+        {
+            groupObject.render(tessellator);
+        }
+
+        tessellator.draw();
+    }
+
+    public void renderOnly(String... groupNames)
+    {
+        for (GroupObject groupObject : groupObjects)
+        {
+            for (String groupName : groupNames)
+            {
+                if (groupName.equalsIgnoreCase(groupObject.name))
+                {
+                    groupObject.render();
+                }
+            }
+        }
+    }
+
+    public void renderPart(String partName)
+    {
+        for (GroupObject groupObject : groupObjects)
+        {
+            if (partName.equalsIgnoreCase(groupObject.name))
+            {
+                groupObject.render();
+            }
+        }
+    }
+
+    public void renderAllExcept(String... excludedGroupNames)
+    {
+        for (GroupObject groupObject : groupObjects)
+        {
+            for (String excludedGroupName : excludedGroupNames)
+            {
+                if (!excludedGroupName.equalsIgnoreCase(groupObject.name))
+                {
+                    groupObject.render();
+                }
+            }
+        }
+    }
+
+    private Vertex parseVertex(String line, int lineCount) throws ModelFormatException
+    {
+        Vertex vertex = null;
+
+        if (isValidVertexLine(line))
+        {
+            line = line.substring(line.indexOf(" ") + 1);
+            String[] tokens = line.split(" ");
+
+            try
+            {
+                if (tokens.length == 2)
+                {
+                    return new Vertex(Float.parseFloat(tokens[0]), Float.parseFloat(tokens[1]));
+                }
+                else if (tokens.length == 3)
+                {
+                    return new Vertex(Float.parseFloat(tokens[0]), Float.parseFloat(tokens[1]), Float.parseFloat(tokens[2]));
+                }
+            }
+            catch (NumberFormatException e)
+            {
+                throw new ModelFormatException(String.format("Number formatting error at line %d", lineCount), e);
+            }
+        }
+        else
+        {
+            throw new ModelFormatException("Error parsing entry ('" + line + "'" + ", line " + lineCount + ") in file '" + fileName + "' - Incorrect format");
+        }
+
+        return vertex;
+    }
+
+    private Vertex parseVertexNormal(String line, int lineCount) throws ModelFormatException
+    {
+        Vertex vertexNormal = null;
+
+        if (isValidVertexNormalLine(line))
+        {
+            line = line.substring(line.indexOf(" ") + 1);
+            String[] tokens = line.split(" ");
+
+            try
+            {
+                if (tokens.length == 3) return new Vertex(Float.parseFloat(tokens[0]), Float.parseFloat(tokens[1]), Float.parseFloat(tokens[2]));
+            }
+            catch (NumberFormatException e)
+            {
+                throw new ModelFormatException(String.format("Number formatting error at line %d", lineCount), e);
+            }
+        }
+        else
+        {
+            throw new ModelFormatException("Error parsing entry ('" + line + "'" + ", line " + lineCount + ") in file '" + fileName + "' - Incorrect format");
+        }
+
+        return vertexNormal;
+    }
+
+    private TextureCoordinate parseTextureCoordinate(String line, int lineCount) throws ModelFormatException
+    {
+        TextureCoordinate textureCoordinate = null;
+
+        if (isValidTextureCoordinateLine(line))
+        {
+            line = line.substring(line.indexOf(" ") + 1);
+            String[] tokens = line.split(" ");
+
+            try
+            {
+                if (tokens.length == 2)
+                    return new TextureCoordinate(Float.parseFloat(tokens[0]), 1 - Float.parseFloat(tokens[1]));
+                else if (tokens.length == 3)
+                    return new TextureCoordinate(Float.parseFloat(tokens[0]), 1 - Float.parseFloat(tokens[1]), Float.parseFloat(tokens[2]));
+            }
+            catch (NumberFormatException e)
+            {
+                throw new ModelFormatException(String.format("Number formatting error at line %d", lineCount), e);
+            }
+        }
+        else
+        {
+            throw new ModelFormatException("Error parsing entry ('" + line + "'" + ", line " + lineCount + ") in file '" + fileName + "' - Incorrect format");
+        }
+
+        return textureCoordinate;
+    }
+
+    private Face parseFace(String line, int lineCount) throws ModelFormatException
+    {
+        Face face = null;
+
+        if (isValidFaceLine(line))
+        {
+            face = new Face();
+
+            String trimmedLine = line.substring(line.indexOf(" ") + 1);
+            String[] tokens = trimmedLine.split(" ");
+            String[] subTokens = null;
+
+            if (tokens.length == 3)
+            {
+                if (currentGroupObject.glDrawingMode == -1)
+                {
+                    currentGroupObject.glDrawingMode = GL11.GL_TRIANGLES;
+                }
+                else if (currentGroupObject.glDrawingMode != GL11.GL_TRIANGLES)
+                {
+                    throw new ModelFormatException("Error parsing entry ('" + line + "'" + ", line " + lineCount + ") in file '" + fileName
+                            + "' - Invalid number of points for face (expected 4, found " + tokens.length + ")");
+                }
+            }
+            else if (tokens.length == 4)
+            {
+                if (currentGroupObject.glDrawingMode == -1)
+                {
+                    currentGroupObject.glDrawingMode = GL11.GL_QUADS;
+                }
+                else if (currentGroupObject.glDrawingMode != GL11.GL_QUADS)
+                {
+                    throw new ModelFormatException("Error parsing entry ('" + line + "'" + ", line " + lineCount + ") in file '" + fileName
+                            + "' - Invalid number of points for face (expected 3, found " + tokens.length + ")");
+                }
+            }
+
+            // f v1/vt1/vn1 v2/vt2/vn2 v3/vt3/vn3 ...
+            if (isValidFace_V_VT_VN_Line(line))
+            {
+                face.vertices = new Vertex[tokens.length];
+                face.textureCoordinates = new TextureCoordinate[tokens.length];
+                face.vertexNormals = new Vertex[tokens.length];
+
+                for (int i = 0; i < tokens.length; ++i)
+                {
+                    subTokens = tokens[i].split("/");
+
+                    face.vertices[i] = vertices.get(Integer.parseInt(subTokens[0]) - 1);
+                    face.textureCoordinates[i] = textureCoordinates.get(Integer.parseInt(subTokens[1]) - 1);
+                    face.vertexNormals[i] = vertexNormals.get(Integer.parseInt(subTokens[2]) - 1);
+                }
+
+                face.faceNormal = face.calculateFaceNormal();
+            }
+            // f v1/vt1 v2/vt2 v3/vt3 ...
+            else if (isValidFace_V_VT_Line(line))
+            {
+                face.vertices = new Vertex[tokens.length];
+                face.textureCoordinates = new TextureCoordinate[tokens.length];
+
+                for (int i = 0; i < tokens.length; ++i)
+                {
+                    subTokens = tokens[i].split("/");
+
+                    face.vertices[i] = vertices.get(Integer.parseInt(subTokens[0]) - 1);
+                    face.textureCoordinates[i] = textureCoordinates.get(Integer.parseInt(subTokens[1]) - 1);
+                }
+
+                face.faceNormal = face.calculateFaceNormal();
+            }
+            // f v1//vn1 v2//vn2 v3//vn3 ...
+            else if (isValidFace_V_VN_Line(line))
+            {
+                face.vertices = new Vertex[tokens.length];
+                face.vertexNormals = new Vertex[tokens.length];
+
+                for (int i = 0; i < tokens.length; ++i)
+                {
+                    subTokens = tokens[i].split("//");
+
+                    face.vertices[i] = vertices.get(Integer.parseInt(subTokens[0]) - 1);
+                    face.vertexNormals[i] = vertexNormals.get(Integer.parseInt(subTokens[1]) - 1);
+                }
+
+                face.faceNormal = face.calculateFaceNormal();
+            }
+            // f v1 v2 v3 ...
+            else if (isValidFace_V_Line(line))
+            {
+                face.vertices = new Vertex[tokens.length];
+
+                for (int i = 0; i < tokens.length; ++i)
+                {
+                    face.vertices[i] = vertices.get(Integer.parseInt(tokens[i]) - 1);
+                }
+
+                face.faceNormal = face.calculateFaceNormal();
+            }
+            else
+            {
+                throw new ModelFormatException("Error parsing entry ('" + line + "'" + ", line " + lineCount + ") in file '" + fileName
+                        + "' - Incorrect format");
+            }
+        }
+        else
+        {
+            throw new ModelFormatException("Error parsing entry ('" + line + "'" + ", line " + lineCount + ") in file '" + fileName + "' - Incorrect format");
+        }
+
+        return face;
+    }
+
+    private GroupObject parseGroupObject(String line, int lineCount) throws ModelFormatException
+    {
+        GroupObject group = null;
+
+        if (isValidGroupObjectLine(line))
+        {
+            String trimmedLine = line.substring(line.indexOf(" ") + 1);
+
+            if (trimmedLine.length() > 0)
+            {
+                group = new GroupObject(trimmedLine);
+            }
+        }
+        else
+        {
+            throw new ModelFormatException("Error parsing entry ('" + line + "'" + ", line " + lineCount + ") in file '" + fileName + "' - Incorrect format");
+        }
+
+        return group;
+    }
+
+    /***
+     * Verifies that the given line from the model file is a valid vertex
+     * 
+     * @param line
+     *            the line being validated
+     * @return true if the line is a valid vertex, false otherwise
+     */
+    private static boolean isValidVertexLine(String line)
+    {
+        if (vertexMatcher != null)
+        {
+            vertexMatcher.reset();
+        }
+
+        vertexMatcher = vertexPattern.matcher(line);
+        return vertexMatcher.matches();
+    }
+
+    /***
+     * Verifies that the given line from the model file is a valid vertex normal
+     * 
+     * @param line
+     *            the line being validated
+     * @return true if the line is a valid vertex normal, false otherwise
+     */
+    private static boolean isValidVertexNormalLine(String line)
+    {
+        if (vertexNormalMatcher != null)
+        {
+            vertexNormalMatcher.reset();
+        }
+
+        vertexNormalMatcher = vertexNormalPattern.matcher(line);
+        return vertexNormalMatcher.matches();
+    }
+
+    /***
+     * Verifies that the given line from the model file is a valid texture
+     * coordinate
+     * 
+     * @param line
+     *            the line being validated
+     * @return true if the line is a valid texture coordinate, false otherwise
+     */
+    private static boolean isValidTextureCoordinateLine(String line)
+    {
+        if (textureCoordinateMatcher != null)
+        {
+            textureCoordinateMatcher.reset();
+        }
+
+        textureCoordinateMatcher = textureCoordinatePattern.matcher(line);
+        return textureCoordinateMatcher.matches();
+    }
+
+    /***
+     * Verifies that the given line from the model file is a valid face that is
+     * described by vertices, texture coordinates, and vertex normals
+     * 
+     * @param line
+     *            the line being validated
+     * @return true if the line is a valid face that matches the format
+     *         "f v1/vt1/vn1 ..." (with a minimum of 3 points in the face, and a
+     *         maximum of 4), false otherwise
+     */
+    private static boolean isValidFace_V_VT_VN_Line(String line)
+    {
+        if (face_V_VT_VN_Matcher != null)
+        {
+            face_V_VT_VN_Matcher.reset();
+        }
+
+        face_V_VT_VN_Matcher = face_V_VT_VN_Pattern.matcher(line);
+        return face_V_VT_VN_Matcher.matches();
+    }
+
+    /***
+     * Verifies that the given line from the model file is a valid face that is
+     * described by vertices and texture coordinates
+     * 
+     * @param line
+     *            the line being validated
+     * @return true if the line is a valid face that matches the format
+     *         "f v1/vt1 ..." (with a minimum of 3 points in the face, and a
+     *         maximum of 4), false otherwise
+     */
+    private static boolean isValidFace_V_VT_Line(String line)
+    {
+        if (face_V_VT_Matcher != null)
+        {
+            face_V_VT_Matcher.reset();
+        }
+
+        face_V_VT_Matcher = face_V_VT_Pattern.matcher(line);
+        return face_V_VT_Matcher.matches();
+    }
+
+    /***
+     * Verifies that the given line from the model file is a valid face that is
+     * described by vertices and vertex normals
+     * 
+     * @param line
+     *            the line being validated
+     * @return true if the line is a valid face that matches the format
+     *         "f v1//vn1 ..." (with a minimum of 3 points in the face, and a
+     *         maximum of 4), false otherwise
+     */
+    private static boolean isValidFace_V_VN_Line(String line)
+    {
+        if (face_V_VN_Matcher != null)
+        {
+            face_V_VN_Matcher.reset();
+        }
+
+        face_V_VN_Matcher = face_V_VN_Pattern.matcher(line);
+        return face_V_VN_Matcher.matches();
+    }
+
+    /***
+     * Verifies that the given line from the model file is a valid face that is
+     * described by only vertices
+     * 
+     * @param line
+     *            the line being validated
+     * @return true if the line is a valid face that matches the format
+     *         "f v1 ..." (with a minimum of 3 points in the face, and a maximum
+     *         of 4), false otherwise
+     */
+    private static boolean isValidFace_V_Line(String line)
+    {
+        if (face_V_Matcher != null)
+        {
+            face_V_Matcher.reset();
+        }
+
+        face_V_Matcher = face_V_Pattern.matcher(line);
+        return face_V_Matcher.matches();
+    }
+
+    /***
+     * Verifies that the given line from the model file is a valid face of any
+     * of the possible face formats
+     * 
+     * @param line
+     *            the line being validated
+     * @return true if the line is a valid face that matches any of the valid
+     *         face formats, false otherwise
+     */
+    private static boolean isValidFaceLine(String line)
+    {
+        return isValidFace_V_VT_VN_Line(line) || isValidFace_V_VT_Line(line) || isValidFace_V_VN_Line(line) || isValidFace_V_Line(line);
+    }
+
+    /***
+     * Verifies that the given line from the model file is a valid group (or
+     * object)
+     * 
+     * @param line
+     *            the line being validated
+     * @return true if the line is a valid group (or object), false otherwise
+     */
+    private static boolean isValidGroupObjectLine(String line)
+    {
+        if (groupObjectMatcher != null)
+        {
+            groupObjectMatcher.reset();
+        }
+
+        groupObjectMatcher = groupObjectPattern.matcher(line);
+        return groupObjectMatcher.matches();
+    }
+
+    @Override
+    public String getType()
+    {
+        return "obj";
+    }
 }

--- a/client/net/minecraftforge/client/model/techne/TechneModel.java
+++ b/client/net/minecraftforge/client/model/techne/TechneModel.java
@@ -19,7 +19,7 @@ import net.minecraft.client.Minecraft;
 import net.minecraft.client.model.ModelBase;
 import net.minecraft.client.model.ModelRenderer;
 import net.minecraft.client.resources.Resource;
-import net.minecraft.client.resources.ResourceLocation;
+import net.minecraft.util.ResourceLocation;
 import net.minecraftforge.client.model.IModelCustom;
 import net.minecraftforge.client.model.ModelFormatException;
 
@@ -37,260 +37,245 @@ import cpw.mods.fml.relauncher.SideOnly;
  * Techne model importer, based on iChun's Hats importer
  */
 @SideOnly(Side.CLIENT)
-public class TechneModel extends ModelBase implements IModelCustom
-{
-	public static final List<String>	cubeTypes		= Arrays.asList("d9e621f7-957f-4b77-b1ae-20dcd0da7751", "de81aa14-bd60-4228-8d8d-5238bcd3caaa");
-	
-	private String						fileName;
-	private Map<String, byte[]>			zipContents		= new HashMap<String, byte[]>();
-	
-	private Map<String, ModelRenderer>	parts			= new LinkedHashMap<String, ModelRenderer>();
-	private String						texture			= null;
-	private int							textureName;
-	private boolean						textureNameSet	= false;
-	
-	public TechneModel(String fileName, ResourceLocation resource) throws ModelFormatException
-	{
-		this.fileName = fileName;
-		loadTechneModel(resource);
-	}
-	
-	private void loadTechneModel(ResourceLocation resLoc) throws ModelFormatException
-	{
-		try
-		{
-			Resource res = Minecraft.getMinecraft().func_110442_L().func_110536_a(resLoc);
-			ZipInputStream zipInput = new ZipInputStream(res.func_110527_b());
-			
-			ZipEntry entry;
-			while ((entry = zipInput.getNextEntry()) != null)
-			{
-				byte[] data = new byte[(int) entry.getSize()];
-				// For some reason, using read(byte[]) makes reading stall upon reaching a 0x1E byte
-				int i = 0;
-				while (zipInput.available() > 0 && i < data.length)
-				{
-					data[i++] = (byte) zipInput.read();
-				}
-				zipContents.put(entry.getName(), data);
-			}
-			
-			byte[] modelXml = zipContents.get("model.xml");
-			if (modelXml == null)
-			{
-				throw new ModelFormatException("Model " + fileName + " contains no model.xml file");
-			}
-			
-			DocumentBuilderFactory documentBuilderFactory = DocumentBuilderFactory.newInstance();
-			DocumentBuilder documentBuilder = documentBuilderFactory.newDocumentBuilder();
-			Document document = documentBuilder.parse(new ByteArrayInputStream(modelXml));
-			
-			NodeList nodeListTechne = document.getElementsByTagName("Techne");
-			if (nodeListTechne.getLength() < 1)
-			{
-				throw new ModelFormatException("Model " + fileName + " contains no Techne tag");
-			}
-			
-			NodeList nodeListModel = document.getElementsByTagName("Model");
-			if (nodeListModel.getLength() < 1)
-			{
-				throw new ModelFormatException("Model " + fileName + " contains no Model tag");
-			}
-			
-			NamedNodeMap modelAttributes = nodeListModel.item(0).getAttributes();
-			if (modelAttributes == null)
-			{
-				throw new ModelFormatException("Model " + fileName + " contains a Model tag with no attributes");
-			}
-			
-			Node modelTexture = modelAttributes.getNamedItem("texture");
-			if (modelTexture != null)
-			{
-				texture = modelTexture.getTextContent();
-			}
-			
-			NodeList shapes = document.getElementsByTagName("Shape");
-			for (int i = 0; i < shapes.getLength(); i++)
-			{
-				Node shape = shapes.item(i);
-				NamedNodeMap shapeAttributes = shape.getAttributes();
-				if (shapeAttributes == null)
-				{
-					throw new ModelFormatException("Shape #" + (i + 1) + " in " + fileName + " has no attributes");
-				}
-				
-				Node name = shapeAttributes.getNamedItem("name");
-				String shapeName = null;
-				if (name != null)
-				{
-					shapeName = name.getNodeValue();
-				}
-				if (shapeName == null)
-				{
-					shapeName = "Shape #" + (i + 1);
-				}
-				
-				String shapeType = null;
-				Node type = shapeAttributes.getNamedItem("type");
-				if (type != null)
-				{
-					shapeType = type.getNodeValue();
-				}
-				if (shapeType != null && !cubeTypes.contains(shapeType))
-				{
-					FMLLog.warning("Model shape [" + shapeName + "] in " + fileName + " is not a cube, ignoring");
-					continue;
-				}
-				
-				try
-				{
-					boolean mirrored = false;
-					String[] offset = new String[3];
-					String[] position = new String[3];
-					String[] rotation = new String[3];
-					String[] size = new String[3];
-					String[] textureOffset = new String[2];
-					
-					NodeList shapeChildren = shape.getChildNodes();
-					for (int j = 0; j < shapeChildren.getLength(); j++)
-					{
-						Node shapeChild = shapeChildren.item(j);
-						
-						String shapeChildName = shapeChild.getNodeName();
-						String shapeChildValue = shapeChild.getTextContent();
-						if (shapeChildValue != null)
-						{
-							shapeChildValue = shapeChildValue.trim();
-							
-							if (shapeChildName.equals("IsMirrored"))
-							{
-								mirrored = !shapeChildValue.equals("False");
-							}
-							else if (shapeChildName.equals("Offset"))
-							{
-								offset = shapeChildValue.split(",");
-							}
-							else if (shapeChildName.equals("Position"))
-							{
-								position = shapeChildValue.split(",");
-							}
-							else if (shapeChildName.equals("Rotation"))
-							{
-								rotation = shapeChildValue.split(",");
-							}
-							else if (shapeChildName.equals("Size"))
-							{
-								size = shapeChildValue.split(",");
-							}
-							else if (shapeChildName.equals("TextureOffset"))
-							{
-								textureOffset = shapeChildValue.split(",");
-							}
-						}
-					}
-					
-					// That's what the ModelBase subclassing is needed for
-					ModelRenderer cube = new ModelRenderer(this, Integer.parseInt(textureOffset[0]), Integer.parseInt(textureOffset[1]));
-					cube.mirror = mirrored;
-					cube.addBox(Float.parseFloat(offset[0]), Float.parseFloat(offset[1]), Float.parseFloat(offset[2]), Integer.parseInt(size[0]), Integer.parseInt(size[1]), Integer.parseInt(size[2]));
-					cube.setRotationPoint(Float.parseFloat(position[0]), Float.parseFloat(position[1]) - 23.4F, Float.parseFloat(position[2]));
-					
-					cube.rotateAngleX = (float) Math.toRadians(Float.parseFloat(rotation[0]));
-					cube.rotateAngleY = (float) Math.toRadians(Float.parseFloat(rotation[1]));
-					cube.rotateAngleZ = (float) Math.toRadians(Float.parseFloat(rotation[2]));
-					
-					parts.put(shapeName, cube);
-				}
-				catch (NumberFormatException e)
-				{
-					FMLLog.warning("Model shape [" + shapeName + "] in " + fileName + " contains malformed integers within its data, ignoring");
-					e.printStackTrace();
-				}
-			}
-		}
-		catch (ZipException e)
-		{
-			throw new ModelFormatException("Model " + fileName + " is not a valid zip file");
-		}
-		catch (IOException e)
-		{
-			throw new ModelFormatException("Model " + fileName + " could not be read", e);
-		}
-		catch (ParserConfigurationException e)
-		{
-			// hush
-		}
-		catch (SAXException e)
-		{
-			throw new ModelFormatException("Model " + fileName + " contains invalid XML", e);
-		}
-	}
-	
-	private void bindTexture()
-	{
-		/*
-		 * TODO: Update to 1.6
-		 * if (texture != null)
-		 * {
-		 * if (!textureNameSet)
-		 * {
-		 * try
-		 * {
-		 * byte[] textureEntry = zipContents.get(texture);
-		 * if (textureEntry == null)
-		 * {
-		 * throw new ModelFormatException("Model " + fileName + " has no such texture " + texture);
-		 * }
-		 * 
-		 * BufferedImage image = ImageIO.read(new ByteArrayInputStream(textureEntry));
-		 * textureName = Minecraft.getMinecraft().renderEngine.allocateAndSetupTexture(image);
-		 * textureNameSet = true;
-		 * }
-		 * catch (ZipException e)
-		 * {
-		 * throw new ModelFormatException("Model " + fileName + " is not a valid zip file");
-		 * }
-		 * catch (IOException e)
-		 * {
-		 * throw new ModelFormatException("Texture for model " + fileName + " could not be read", e);
-		 * }
-		 * }
-		 * 
-		 * if (textureNameSet)
-		 * {
-		 * GL11.glBindTexture(GL11.GL_TEXTURE_2D, textureName);
-		 * Minecraft.getMinecraft().renderEngine.resetBoundTexture();
-		 * }
-		 * }
-		 */
-	}
-	
-	@Override
-	public String getType()
-	{
-		return "tcn";
-	}
-	
-	@Override
-	public void renderAll()
-	{
-		bindTexture();
-		
-		for (ModelRenderer part : parts.values())
-		{
-			part.renderWithRotation(1.0F);
-		}
-	}
-	
-	@Override
-	public void renderPart(String partName)
-	{
-		ModelRenderer part = parts.get(partName);
-		if (part != null)
-		{
-			bindTexture();
-			
-			part.renderWithRotation(1.0F);
-		}
-	}
+public class TechneModel extends ModelBase implements IModelCustom {
+    public static final List<String> cubeTypes = Arrays.asList("d9e621f7-957f-4b77-b1ae-20dcd0da7751", "de81aa14-bd60-4228-8d8d-5238bcd3caaa");
+
+    private String fileName;
+    private Map<String, byte[]> zipContents = new HashMap<String, byte[]>();
+
+    private Map<String, ModelRenderer> parts = new LinkedHashMap<String, ModelRenderer>();
+    private String texture = null;
+    private int textureName;
+    private boolean textureNameSet = false;
+
+    public TechneModel(String fileName, ResourceLocation resource) throws ModelFormatException
+    {
+        this.fileName = fileName;
+        loadTechneModel(resource);
+    }
+
+    private void loadTechneModel(ResourceLocation resLoc) throws ModelFormatException
+    {
+        try
+        {
+            Resource res = Minecraft.getMinecraft().func_110442_L().func_110536_a(resLoc);
+            ZipInputStream zipInput = new ZipInputStream(res.func_110527_b());
+
+            ZipEntry entry;
+            while ((entry = zipInput.getNextEntry()) != null)
+            {
+                byte[] data = new byte[(int) entry.getSize()];
+                // For some reason, using read(byte[]) makes reading stall upon
+                // reaching a 0x1E byte
+                int i = 0;
+                while (zipInput.available() > 0 && i < data.length)
+                {
+                    data[i++] = (byte) zipInput.read();
+                }
+                zipContents.put(entry.getName(), data);
+            }
+
+            byte[] modelXml = zipContents.get("model.xml");
+            if (modelXml == null)
+            {
+                throw new ModelFormatException("Model " + fileName + " contains no model.xml file");
+            }
+
+            DocumentBuilderFactory documentBuilderFactory = DocumentBuilderFactory.newInstance();
+            DocumentBuilder documentBuilder = documentBuilderFactory.newDocumentBuilder();
+            Document document = documentBuilder.parse(new ByteArrayInputStream(modelXml));
+
+            NodeList nodeListTechne = document.getElementsByTagName("Techne");
+            if (nodeListTechne.getLength() < 1)
+            {
+                throw new ModelFormatException("Model " + fileName + " contains no Techne tag");
+            }
+
+            NodeList nodeListModel = document.getElementsByTagName("Model");
+            if (nodeListModel.getLength() < 1)
+            {
+                throw new ModelFormatException("Model " + fileName + " contains no Model tag");
+            }
+
+            NamedNodeMap modelAttributes = nodeListModel.item(0).getAttributes();
+            if (modelAttributes == null)
+            {
+                throw new ModelFormatException("Model " + fileName + " contains a Model tag with no attributes");
+            }
+
+            Node modelTexture = modelAttributes.getNamedItem("texture");
+            if (modelTexture != null)
+            {
+                texture = modelTexture.getTextContent();
+            }
+
+            NodeList shapes = document.getElementsByTagName("Shape");
+            for (int i = 0; i < shapes.getLength(); i++)
+            {
+                Node shape = shapes.item(i);
+                NamedNodeMap shapeAttributes = shape.getAttributes();
+                if (shapeAttributes == null)
+                {
+                    throw new ModelFormatException("Shape #" + (i + 1) + " in " + fileName + " has no attributes");
+                }
+
+                Node name = shapeAttributes.getNamedItem("name");
+                String shapeName = null;
+                if (name != null)
+                {
+                    shapeName = name.getNodeValue();
+                }
+                if (shapeName == null)
+                {
+                    shapeName = "Shape #" + (i + 1);
+                }
+
+                String shapeType = null;
+                Node type = shapeAttributes.getNamedItem("type");
+                if (type != null)
+                {
+                    shapeType = type.getNodeValue();
+                }
+                if (shapeType != null && !cubeTypes.contains(shapeType))
+                {
+                    FMLLog.warning("Model shape [" + shapeName + "] in " + fileName + " is not a cube, ignoring");
+                    continue;
+                }
+
+                try
+                {
+                    boolean mirrored = false;
+                    String[] offset = new String[3];
+                    String[] position = new String[3];
+                    String[] rotation = new String[3];
+                    String[] size = new String[3];
+                    String[] textureOffset = new String[2];
+
+                    NodeList shapeChildren = shape.getChildNodes();
+                    for (int j = 0; j < shapeChildren.getLength(); j++)
+                    {
+                        Node shapeChild = shapeChildren.item(j);
+
+                        String shapeChildName = shapeChild.getNodeName();
+                        String shapeChildValue = shapeChild.getTextContent();
+                        if (shapeChildValue != null)
+                        {
+                            shapeChildValue = shapeChildValue.trim();
+
+                            if (shapeChildName.equals("IsMirrored"))
+                            {
+                                mirrored = !shapeChildValue.equals("False");
+                            }
+                            else if (shapeChildName.equals("Offset"))
+                            {
+                                offset = shapeChildValue.split(",");
+                            }
+                            else if (shapeChildName.equals("Position"))
+                            {
+                                position = shapeChildValue.split(",");
+                            }
+                            else if (shapeChildName.equals("Rotation"))
+                            {
+                                rotation = shapeChildValue.split(",");
+                            }
+                            else if (shapeChildName.equals("Size"))
+                            {
+                                size = shapeChildValue.split(",");
+                            }
+                            else if (shapeChildName.equals("TextureOffset"))
+                            {
+                                textureOffset = shapeChildValue.split(",");
+                            }
+                        }
+                    }
+
+                    // That's what the ModelBase subclassing is needed for
+                    ModelRenderer cube = new ModelRenderer(this, Integer.parseInt(textureOffset[0]), Integer.parseInt(textureOffset[1]));
+                    cube.mirror = mirrored;
+                    cube.addBox(Float.parseFloat(offset[0]), Float.parseFloat(offset[1]), Float.parseFloat(offset[2]), Integer.parseInt(size[0]),
+                            Integer.parseInt(size[1]), Integer.parseInt(size[2]));
+                    cube.setRotationPoint(Float.parseFloat(position[0]), Float.parseFloat(position[1]) - 23.4F, Float.parseFloat(position[2]));
+
+                    cube.rotateAngleX = (float) Math.toRadians(Float.parseFloat(rotation[0]));
+                    cube.rotateAngleY = (float) Math.toRadians(Float.parseFloat(rotation[1]));
+                    cube.rotateAngleZ = (float) Math.toRadians(Float.parseFloat(rotation[2]));
+
+                    parts.put(shapeName, cube);
+                }
+                catch (NumberFormatException e)
+                {
+                    FMLLog.warning("Model shape [" + shapeName + "] in " + fileName + " contains malformed integers within its data, ignoring");
+                    e.printStackTrace();
+                }
+            }
+        }
+        catch (ZipException e)
+        {
+            throw new ModelFormatException("Model " + fileName + " is not a valid zip file");
+        }
+        catch (IOException e)
+        {
+            throw new ModelFormatException("Model " + fileName + " could not be read", e);
+        }
+        catch (ParserConfigurationException e)
+        {
+            // hush
+        }
+        catch (SAXException e)
+        {
+            throw new ModelFormatException("Model " + fileName + " contains invalid XML", e);
+        }
+    }
+
+    private void bindTexture()
+    {
+        /*
+         * TODO: Update to 1.6 if (texture != null) { if (!textureNameSet) { try
+         * { byte[] textureEntry = zipContents.get(texture); if (textureEntry ==
+         * null) { throw new ModelFormatException("Model " + fileName +
+         * " has no such texture " + texture); }
+         * 
+         * BufferedImage image = ImageIO.read(new
+         * ByteArrayInputStream(textureEntry)); textureName =
+         * Minecraft.getMinecraft().renderEngine.allocateAndSetupTexture(image);
+         * textureNameSet = true; } catch (ZipException e) { throw new
+         * ModelFormatException("Model " + fileName +
+         * " is not a valid zip file"); } catch (IOException e) { throw new
+         * ModelFormatException("Texture for model " + fileName +
+         * " could not be read", e); } }
+         * 
+         * if (textureNameSet) { GL11.glBindTexture(GL11.GL_TEXTURE_2D,
+         * textureName);
+         * Minecraft.getMinecraft().renderEngine.resetBoundTexture(); } }
+         */
+    }
+
+    @Override
+    public String getType()
+    {
+        return "tcn";
+    }
+
+    @Override
+    public void renderAll()
+    {
+        bindTexture();
+
+        for (ModelRenderer part : parts.values())
+        {
+            part.renderWithRotation(1.0F);
+        }
+    }
+
+    @Override
+    public void renderPart(String partName)
+    {
+        ModelRenderer part = parts.get(partName);
+        if (part != null)
+        {
+            bindTexture();
+
+            part.renderWithRotation(1.0F);
+        }
+    }
 }

--- a/client/net/minecraftforge/client/model/techne/TechneModelLoader.java
+++ b/client/net/minecraftforge/client/model/techne/TechneModelLoader.java
@@ -1,31 +1,30 @@
 package net.minecraftforge.client.model.techne;
 
-import net.minecraft.client.resources.ResourceLocation;
+import net.minecraft.util.ResourceLocation;
 import net.minecraftforge.client.model.IModelCustom;
 import net.minecraftforge.client.model.IModelCustomLoader;
 import net.minecraftforge.client.model.ModelFormatException;
 
-public class TechneModelLoader implements IModelCustomLoader
-{
-	
-	@Override
-	public String getType()
-	{
-		return "Techne model";
-	}
-	
-	private static final String[]	types	= { "tcn" };
-	
-	@Override
-	public String[] getSuffixes()
-	{
-		return types;
-	}
-	
-	@Override
-	public IModelCustom loadInstance(String resourceName, ResourceLocation resource) throws ModelFormatException
-	{
-		return new TechneModel(resourceName, resource);
-	}
-	
+public class TechneModelLoader implements IModelCustomLoader {
+
+    @Override
+    public String getType()
+    {
+        return "Techne model";
+    }
+
+    private static final String[] types = { "tcn" };
+
+    @Override
+    public String[] getSuffixes()
+    {
+        return types;
+    }
+
+    @Override
+    public IModelCustom loadInstance(String resourceName, ResourceLocation resource) throws ModelFormatException
+    {
+        return new TechneModel(resourceName, resource);
+    }
+
 }


### PR DESCRIPTION
Models must now be loaded from resource packs using the standard reference. For example, to load a model named "assets/mymod/models/mymodel.obj", you would call AdvancedModelLoader.loadModel("mymod:models/mymodel.obj");

Models must be STREAMED IN when they are first used (call loadModel the first frame they are rendered, and store the model for later frames); they cannot be pre-loaded anymore due to packs not being loaded during the loading cycle.
