### PR TITLE
Fix getArmorTexture by passing it the subtype

### DIFF
--- a/client/net/minecraftforge/client/ForgeHooksClient.java
+++ b/client/net/minecraftforge/client/ForgeHooksClient.java
@@ -54,9 +54,15 @@ public class ForgeHooksClient
         return FMLClientHandler.instance().getClient().renderEngine;
     }
 
+    @Deprecated
     public static String getArmorTexture(Entity entity, ItemStack armor, String _default, int slot, int layer, String type)
     {
-        String result = armor.getItem().getArmorTexture(armor, entity, slot, layer);
+        return getArmorTexture(entity, armor, _default, slot, type);
+    }
+
+    public static String getArmorTexture(Entity entity, ItemStack armor, String _default, int slot, String type)
+    {
+        String result = armor.getItem().getArmorTexture(armor, entity, slot, type);
         return result != null ? result : _default;
     }
 

--- a/patches/minecraft/net/minecraft/client/renderer/entity/RenderBiped.java.patch
+++ b/patches/minecraft/net/minecraft/client/renderer/entity/RenderBiped.java.patch
@@ -49,7 +49,7 @@
 +        String s1 = String.format("textures/models/armor/%s_layer_%d%s.png",
 +                bipedArmorFilenamePrefix[item.renderIndex], (slot == 2 ? 2 : 1), type == null ? "" : String.format("_%s", type));
 +
-+        s1 = ForgeHooksClient.getArmorTexture(entity, stack, s1, slot, (slot == 2 ? 2 : 1), type);
++        s1 = ForgeHooksClient.getArmorTexture(entity, stack, s1, slot, type);
 +        ResourceLocation resourcelocation = (ResourceLocation)field_110859_k.get(s1);
 +
 +        if (resourcelocation == null)

--- a/patches/minecraft/net/minecraft/item/Item.java.patch
+++ b/patches/minecraft/net/minecraft/item/Item.java.patch
@@ -66,7 +66,7 @@
          Vec3 vec31 = vec3.addVector((double)f7 * d3, (double)f6 * d3, (double)f8 * d3);
          return par1World.rayTraceBlocks_do_do(vec3, vec31, par3, !par3);
      }
-@@ -740,4 +755,514 @@
+@@ -740,4 +755,534 @@
      {
          StatList.initStats();
      }
@@ -428,6 +428,7 @@
 +    {
 +        return 0.0F; //getDamageVsEntity(par1Entity);
 +    }
++    
 +    /**
 +     * Called by RenderBiped and RenderPlayer to determine the armor texture that 
 +     * should be use for the currently equiped item.
@@ -441,9 +442,28 @@
 +     * @param layer The render layer, either 1 or 2, 2 is only used for CLOTH armor by default
 +     * @return Path of texture to bind, or null to use default
 +     */
++    @Deprecated //Replaced with more useful version below
 +    public String getArmorTexture(ItemStack stack, Entity entity, int slot, int layer)
 +    {
 +        return null;
++    }
++    
++    /**
++     * Called by RenderBiped and RenderPlayer to determine the armor texture that 
++     * should be use for the currently equiped item.
++     * This will only be called on instances of ItemArmor. 
++     * 
++     * Returning null from this function will use the default value.
++     * 
++     * @param stack ItemStack for the equpt armor
++     * @param entity The entity wearing the armor
++     * @param slot The slot the armor is in
++     * @param type The subtype, can be null or "overlay"
++     * @return Path of texture to bind, or null to use default
++     */
++    public String getArmorTexture(ItemStack stack, Entity entity, int slot, String type)
++    {
++        return getArmorTexture(stack, entity, slot, (slot == 2 ? 2 : 1));
 +    }
 +
 +


### PR DESCRIPTION
This fixes Item.getArmorTexture by getting rid of the useless layer argument (which could be mistaken for the render pass, but it's just 2 when the slot is the upper body armor slot, otherwise 1) and replacing it with the type argument that gets passed to RenderBiped.getArmorResource.

**edit:** Made some changes. The old getArmorTexture is now kept, but marked as deprecated.
