### PR TITLE
Added CanFill and Fill to IFluidBlock

### DIFF
--- a/common/net/minecraftforge/fluids/BlockFluidClassic.java
+++ b/common/net/minecraftforge/fluids/BlockFluidClassic.java
@@ -10,11 +10,11 @@ import net.minecraft.world.World;
 
 /**
  * This is a fluid block implementation which emulates vanilla Minecraft fluid behavior.
- * 
+ *
  * It is highly recommended that you use/extend this class for "classic" fluid blocks.
- * 
+ *
  * @author King Lemming
- * 
+ *
  */
 public class BlockFluidClassic extends BlockFluidBase
 {
@@ -92,8 +92,8 @@ public class BlockFluidClassic extends BlockFluidBase
         {
             int y2 = y - densityDir;
 
-            if (world.getBlockId(x,     y2, z    ) == blockID || 
-                world.getBlockId(x - 1, y2, z    ) == blockID || 
+            if (world.getBlockId(x,     y2, z    ) == blockID ||
+                world.getBlockId(x - 1, y2, z    ) == blockID ||
                 world.getBlockId(x + 1, y2, z    ) == blockID ||
                 world.getBlockId(x,     y2, z - 1) == blockID ||
                 world.getBlockId(x,     y2, z + 1) == blockID)
@@ -226,7 +226,7 @@ public class BlockFluidClassic extends BlockFluidBase
         int cost = 1000;
         for (int adjSide = 0; adjSide < 4; adjSide++)
         {
-            if ((adjSide == 0 && side == 1) || 
+            if ((adjSide == 0 && side == 1) ||
                 (adjSide == 1 && side == 0) ||
                 (adjSide == 2 && side == 3) ||
                 (adjSide == 3 && side == 2))
@@ -319,7 +319,7 @@ public class BlockFluidClassic extends BlockFluidBase
     @Override
     public FluidStack drain(World world, int x, int y, int z, boolean doDrain)
     {
-        if (!isSourceBlock(world, x, y, z))
+        if (!this.canDrain(world, x, y, z))
         {
             return null;
         }
@@ -336,5 +336,31 @@ public class BlockFluidClassic extends BlockFluidBase
     public boolean canDrain(World world, int x, int y, int z)
     {
         return isSourceBlock(world, x, y, z);
+    }
+
+    @Override
+    public int fill(World world, int x, int y, int z, FluidStack receivingStack, boolean doFill)
+    {
+        if(!this.canFill(world, x, y, z))
+        {
+            return 0;
+        }
+
+        if(receivingStack != null && receivingStack.amount >= FluidContainerRegistry.BUCKET_VOLUME)
+        {
+            if(doFill)
+            {
+                world.setBlockMetadataWithNotify(x, y, z, 0, 3);
+            }
+            return FluidContainerRegistry.BUCKET_VOLUME;
+        }
+
+        return 0;
+    }
+
+    @Override
+    public boolean canFill(World world, int x, int y, int z)
+    {
+        return !isSourceBlock(world, x, y, z);
     }
 }

--- a/common/net/minecraftforge/fluids/BlockFluidFinite.java
+++ b/common/net/minecraftforge/fluids/BlockFluidFinite.java
@@ -10,11 +10,11 @@ import net.minecraft.world.World;
 
 /**
  * This is a cellular-automata based finite fluid block implementation.
- * 
+ *
  * It is highly recommended that you use/extend this class for finite fluid blocks.
- * 
+ *
  * @author OvermindDL1, KingLemming
- * 
+ *
  */
 public class BlockFluidFinite extends BlockFluidBase
 {
@@ -313,5 +313,17 @@ public class BlockFluidFinite extends BlockFluidBase
     public boolean canDrain(World world, int x, int y, int z)
     {
         return false;
+    }
+
+    @Override
+    public int fill(World world, int x, int y, int z, FluidStack recievingStack, boolean doFill)
+    {
+        return 0;
+    }
+
+    @Override
+    public boolean canFill(World world, int x, int y, int z)
+    {
+       return false;
     }
 }

--- a/common/net/minecraftforge/fluids/IFluidBlock.java
+++ b/common/net/minecraftforge/fluids/IFluidBlock.java
@@ -18,23 +18,45 @@ public interface IFluidBlock
     Fluid getFluid();
 
     /**
-     * Attempt to drain the block. This method should be called by devices such as pumps.
+     * Attempts to drain the block. This method should be called by devices that 
+     * desire to drain the fluid block.
      * 
      * NOTE: The block is intended to handle its own state changes.
      * 
      * @param doDrain
-     *            If false, the drain will only be simulated.
+     *             If false, the draining of the block will only be simulated.
      * @return
      */
     FluidStack drain(World world, int x, int y, int z, boolean doDrain);
 
     /**
-     * Check to see if a block can be drained. This method should be called by devices such as
-     * pumps.
+     * Check to see if a block can be drained. This method should be called by 
+     * devices that try to drain the fluid block
      * 
-     * @param doDrain
-     *            If false, the drain will only be simulated.
      * @return
+     *             True if the block can be drained
      */
     boolean canDrain(World world, int x, int y, int z);
+    
+    /**
+    * Attempts to fill the block. This method should be called by devices that 
+    * desire to fill the fluid block.
+    *
+    * NOTE: The block is intended to handle its own state changes.
+    *
+    * @param doFill
+    *            If false, the filling of the block will only be simulated.
+    * @return
+    *            Amount of fluid that was filled into the block
+    */
+    int fill(World world, int x, int y, int z, FluidStack receivingStack, boolean doFill);
+
+   /**
+    * Check to see if a block can be filled. This method should be called by devices that desire to 
+    * fill the fluid block
+    *
+    * @return
+    *          True if the block can be filled
+    */
+   boolean canFill(World world, int x, int y, int z);
 }


### PR DESCRIPTION
Commit comment-
"Designed to be used by pump/machine style blocks that want to fill a
block. These two methods should be used to tell the machine that it can
or can't fill the block. As well adds the option of allowing the block
to define how it wants to be filled."

The reason for the change is to allow more control over how a block is filled by a machine. Currently my only way to automatically fill a block is to check for !sourceBlock. Then set the block and meta to the fill block if its not a source. This works for generic fluids that act like the classic fluid blocks. However, when i start to hit cases of were people have custom fluid block it starts to act up. 
