### PR TITLE
Forge Permissions API

### DIFF
--- a/common/net/minecraftforge/common/MinecraftForge.java
+++ b/common/net/minecraftforge/common/MinecraftForge.java
@@ -32,11 +32,13 @@ public class MinecraftForge
      * This replaces every register*Handler() function in the old version of Forge.
      * TERRAIN_GEN_BUS for terrain gen events
      * ORE_GEN_BUS for ore gen events
+     * PERMISSIONS_BUS for permission events
      * EVENT_BUS for everything else
      */
     public static final EventBus EVENT_BUS = new EventBus();
     public static final EventBus TERRAIN_GEN_BUS = new EventBus();
     public static final EventBus ORE_GEN_BUS = new EventBus();
+    public static final EventBus PERMISSIONS_BUS = new EventBus();
 
     private static final ForgeInternalHandler INTERNAL_HANDLER = new ForgeInternalHandler();
 

--- a/common/net/minecraftforge/event/ForgeEventFactory.java
+++ b/common/net/minecraftforge/event/ForgeEventFactory.java
@@ -17,6 +17,8 @@ import net.minecraftforge.event.entity.player.PlayerDestroyItemEvent;
 import net.minecraftforge.event.entity.player.PlayerEvent;
 import net.minecraftforge.event.entity.player.PlayerInteractEvent;
 import net.minecraftforge.event.entity.player.PlayerInteractEvent.Action;
+import net.minecraftforge.event.entity.permissions.PermissionEvent;
+import net.minecraftforge.event.entity.permissions.LocatablePermissionEvent;
 import net.minecraftforge.event.world.WorldEvent;
 
 @SuppressWarnings("deprecation")
@@ -74,5 +76,19 @@ public class ForgeEventFactory
         LivingPackSizeEvent maxCanSpawnEvent = new LivingPackSizeEvent(entity);
         MinecraftForge.EVENT_BUS.post(maxCanSpawnEvent);
         return maxCanSpawnEvent.getResult() == Result.ALLOW ? maxCanSpawnEvent.maxPackSize : entity.getMaxSpawnedInChunk();
+    }
+
+    public static Result checkPermission(EntityPlayer player, String permission)
+    {
+        PermissionEvent event = new PermissionEvent(player, permission);
+        MinecraftForge.PERMISSIONS_BUS.post(event);
+        return event.getResult();
+    }
+	
+    public static Result checkPermission(EntityPlayer player, String permission, float x, float y, float z)
+    {
+        LocatablePermissionEvent event = new LocatablePermissionEvent(player, permission, x, y, z);
+        MinecraftForge.PERMISSIONS_BUS.post(event);
+        return event.getResult();
     }
 }

--- a/common/net/minecraftforge/event/permissions/LocatablePermissionEvent.java
+++ b/common/net/minecraftforge/event/permissions/LocatablePermissionEvent.java
@@ -1,0 +1,22 @@
+package net.minecraftforge.event.entity.permissions;
+
+import net.minecraft.block.Block;
+import net.minecraft.entity.Entity;
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraftforge.event.Event.HasResult;
+import net.minecraftforge.event.entity.player.PlayerEvent;
+
+@HasResult
+public class LocatablePermissionEvent extends PermissionEvent
+{
+    public final int x, y, z;
+    
+    public PlayerEvent(EntityPlayer player, String permission, int x, int y, int z)
+    {
+        super(player, permission);
+        this.x = x;
+        this.y = y;
+        this.z = z;
+    }
+    
+}

--- a/common/net/minecraftforge/event/permissions/PermissionEvent.java
+++ b/common/net/minecraftforge/event/permissions/PermissionEvent.java
@@ -1,0 +1,20 @@
+package net.minecraftforge.event.entity.permissions;
+
+import net.minecraft.block.Block;
+import net.minecraft.entity.Entity;
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraftforge.event.Event.HasResult;
+import net.minecraftforge.event.entity.player.PlayerEvent;
+
+@HasResult
+public class PermissionEvent extends PlayerEvent
+{
+    public final String permission;
+    
+    public PlayerEvent(EntityPlayer player, String permission)
+    {
+        super(player);
+        this.permission = permission;
+    }
+    
+}


### PR DESCRIPTION
A simple permissions api which allows mods to check for permissions and
permission providers to hook in and provide their results.

To check a permission, a mod simply calls

```
result=ForgeEventFactory.checkPermission(player, "some.permission");
```

If result is not DENY, the permission was granted.
The permission sytax should be similar to the one bukkit is using.

Permission providers can hook to the `MinecraftForge.PERMISSIONS_BUS` event bus and modify the result accordingly. 

Additionally, there is a LocatablePermissionEvent class for area-based permissions.
