### PR TITLE
Add SneakClick bypass to client

### DIFF
--- a/patches/minecraft/net/minecraft/client/multiplayer/PlayerControllerMP.java.patch
+++ b/patches/minecraft/net/minecraft/client/multiplayer/PlayerControllerMP.java.patch
@@ -33,19 +33,23 @@
  
                  if (flag)
                  {
-@@ -347,6 +357,12 @@
+@@ -347,8 +357,14 @@
          float f2 = (float)par8Vec3.zCoord - (float)par6;
          boolean flag = false;
          int i1;
+-
+-        if (!par1EntityPlayer.isSneaking() || par1EntityPlayer.getHeldItem() == null)
 +        if (par3ItemStack != null &&
 +            par3ItemStack.getItem() != null &&
 +            par3ItemStack.getItem().onItemUseFirst(par3ItemStack, par1EntityPlayer, par2World, par4, par5, par6, par7, f, f1, f2))
 +        {
 +                return true;
 +        }
- 
-         if (!par1EntityPlayer.isSneaking() || par1EntityPlayer.getHeldItem() == null)
++
++        if (!par1EntityPlayer.isSneaking() || (par1EntityPlayer.getHeldItem() == null || par1EntityPlayer.getHeldItem().getItem().shouldPassSneakingClickToBlock(par2World, par4, par5, par6)))
          {
+             i1 = par2World.getBlockId(par4, par5, par6);
+ 
 @@ -389,7 +405,15 @@
          }
          else


### PR DESCRIPTION
Currently the Item Sneak Bypass only occurs on the server side, not the client side. This prevents anything from doing item animations or client simulation on a sneak click.
