### PR TITLE
Fire left click onPlayerInteract on client too

### DIFF
--- a/patches/minecraft/net/minecraft/client/multiplayer/PlayerControllerMP.java.patch
+++ b/patches/minecraft/net/minecraft/client/multiplayer/PlayerControllerMP.java.patch
@@ -1,17 +1,21 @@
 --- ../src_base/minecraft/net/minecraft/client/multiplayer/PlayerControllerMP.java
 +++ ../src_work/minecraft/net/minecraft/client/multiplayer/PlayerControllerMP.java
-@@ -22,6 +22,10 @@
+@@ -22,6 +22,14 @@
  import net.minecraft.world.EnumGameType;
  import net.minecraft.world.World;
  
 +import net.minecraftforge.common.ForgeHooks;
 +import net.minecraftforge.common.MinecraftForge;
++import net.minecraftforge.event.Event;
++import net.minecraftforge.event.ForgeEventFactory;
 +import net.minecraftforge.event.entity.player.PlayerDestroyItemEvent;
++import net.minecraftforge.event.entity.player.PlayerInteractEvent;
++import net.minecraftforge.event.entity.player.PlayerInteractEvent.Action;
 +
  @SideOnly(Side.CLIENT)
  public class PlayerControllerMP
  {
-@@ -125,6 +129,12 @@
+@@ -125,6 +133,12 @@
       */
      public boolean onPlayerDestroyBlock(int par1, int par2, int par3, int par4)
      {
@@ -24,7 +28,7 @@
          if (this.currentGameType.isAdventure() && !this.mc.thePlayer.isCurrentToolAdventureModeExempt(par1, par2, par3))
          {
              return false;
-@@ -146,7 +156,7 @@
+@@ -146,7 +160,7 @@
              {
                  worldclient.playAuxSFX(2001, par1, par2, par3, block.blockID + (worldclient.getBlockMetadata(par1, par2, par3) << 12));
                  int i1 = worldclient.getBlockMetadata(par1, par2, par3);
@@ -33,7 +37,94 @@
  
                  if (flag)
                  {
-@@ -347,6 +357,12 @@
+@@ -180,9 +194,20 @@
+      */
+     public void clickBlock(int par1, int par2, int par3, int par4)
+     {
+-        if (!this.currentGameType.isAdventure() || this.mc.thePlayer.isCurrentToolAdventureModeExempt(par1, par2, par3))
+-        {
+-            if (this.currentGameType.isCreative())
++        PlayerInteractEvent event = ForgeEventFactory.onPlayerInteract(this.mc.thePlayer, Action.LEFT_CLICK_BLOCK, par1, par2, par3, par4);
++        if (!event.isCanceled() && (!this.currentGameType.isAdventure() || this.mc.thePlayer.isCurrentToolAdventureModeExempt(par1, par2, par3)))
++        {
++            if (event.useItem == Event.Result.DENY)
++            {
++                this.netClientHandler.addToSendQueue(new Packet14BlockDig(0, par1, par2, par3, par4));
++                int blockId = this.mc.theWorld.getBlockId(par1, par2, par3);
++                if (blockId > 0 && event.useBlock != Event.Result.DENY)
++                {
++                    Block.blocksList[blockId].onBlockClicked(this.mc.theWorld, par1, par2, par3, this.mc.thePlayer);
++                }
++                resetBlockRemoving();
++            }
++            else if (this.currentGameType.isCreative())
+             {
+                 this.netClientHandler.addToSendQueue(new Packet14BlockDig(0, par1, par2, par3, par4));
+                 clickBlockCreative(this.mc, this, par1, par2, par3, par4);
+@@ -198,7 +223,7 @@
+                 this.netClientHandler.addToSendQueue(new Packet14BlockDig(0, par1, par2, par3, par4));
+                 int i1 = this.mc.theWorld.getBlockId(par1, par2, par3);
+ 
+-                if (i1 > 0 && this.curBlockDamageMP == 0.0F)
++                if (i1 > 0 && this.curBlockDamageMP == 0.0F && event.useBlock != Event.Result.DENY)
+                 {
+                     Block.blocksList[i1].onBlockClicked(this.mc.theWorld, par1, par2, par3, this.mc.thePlayer);
+                 }
+@@ -233,6 +258,9 @@
+         }
+ 
+         this.isHittingBlock = false;
++        this.currentBlockX = -1;
++        this.currentBlockY = -1;
++        this.currentblockZ = -1;
+         this.curBlockDamageMP = 0.0F;
+         this.mc.theWorld.destroyBlockInWorldPartially(this.mc.thePlayer.entityId, this.currentBlockX, this.currentBlockY, this.currentblockZ, -1);
+     }
+@@ -247,6 +275,10 @@
+         if (this.blockHitDelay > 0)
+         {
+             --this.blockHitDelay;
++        }
++        else if (this.currentBlockX == -1 || this.currentBlockY == -1 || this.currentblockZ == -1)
++        {
++            return;
+         }
+         else if (this.currentGameType.isCreative())
+         {
+@@ -263,6 +295,9 @@
+                 if (i1 == 0)
+                 {
+                     this.isHittingBlock = false;
++                    this.currentBlockX = -1;
++                    this.currentBlockY = -1;
++                    this.currentblockZ = -1;
+                     return;
+                 }
+ 
+@@ -279,6 +314,9 @@
+                 if (this.curBlockDamageMP >= 1.0F)
+                 {
+                     this.isHittingBlock = false;
++                    this.currentBlockX = -1;
++                    this.currentBlockY = -1;
++                    this.currentblockZ = -1;
+                     this.netClientHandler.addToSendQueue(new Packet14BlockDig(2, par1, par2, par3, par4));
+                     this.onPlayerDestroyBlock(par1, par2, par3, par4);
+                     this.curBlockDamageMP = 0.0F;
+@@ -293,6 +331,12 @@
+                 this.clickBlock(par1, par2, par3, par4);
+             }
+         }
++
++        if (this.mc.thePlayer.isCurrentToolAdventureModeExempt(par1, par2, par3))
++        {
++            this.mc.effectRenderer.addBlockHitEffects(par1, par2, par3, this.mc.objectMouseOver);
++            this.mc.thePlayer.swingItem();
++        }
+     }
+ 
+     /**
+@@ -347,6 +391,12 @@
          float f2 = (float)par8Vec3.zCoord - (float)par6;
          boolean flag = false;
          int i1;
@@ -46,7 +137,7 @@
  
          if (!par1EntityPlayer.isSneaking() || par1EntityPlayer.getHeldItem() == null)
          {
-@@ -389,7 +405,15 @@
+@@ -389,7 +439,15 @@
          }
          else
          {
@@ -63,7 +154,7 @@
          }
      }
  
-@@ -411,9 +435,10 @@
+@@ -411,9 +469,10 @@
          {
              par1EntityPlayer.inventory.mainInventory[par1EntityPlayer.inventory.currentItem] = itemstack1;
  

--- a/patches/minecraft/net/minecraft/item/ItemInWorldManager.java.patch
+++ b/patches/minecraft/net/minecraft/item/ItemInWorldManager.java.patch
@@ -20,21 +20,27 @@
      /** The world object that this object is connected to. */
      public World theWorld;
  
-@@ -145,6 +156,13 @@
+@@ -143,26 +154,52 @@
+      */
+     public void onBlockClicked(int par1, int par2, int par3, int par4)
      {
++        PlayerInteractEvent event = ForgeEventFactory.onPlayerInteract(thisPlayerMP, Action.LEFT_CLICK_BLOCK, par1, par2, par3, par4);
++        if (event.isCanceled())
++        {
++            thisPlayerMP.playerNetServerHandler.sendPacketToPlayer(new Packet53BlockChange(par1, par2, par3, theWorld));
++            return;
++        }
++
          if (!this.gameType.isAdventure() || this.thisPlayerMP.isCurrentToolAdventureModeExempt(par1, par2, par3))
          {
-+            PlayerInteractEvent event = ForgeEventFactory.onPlayerInteract(thisPlayerMP, Action.LEFT_CLICK_BLOCK, par1, par2, par3, par4);
-+            if (event.isCanceled())
-+            {
-+                thisPlayerMP.playerNetServerHandler.sendPacketToPlayer(new Packet53BlockChange(par1, par2, par3, theWorld));
-+                return;
-+            }
 +
              if (this.isCreative())
              {
-                 if (!this.theWorld.extinguishFire((EntityPlayer)null, par1, par2, par3, par4))
-@@ -154,15 +172,33 @@
+-                if (!this.theWorld.extinguishFire((EntityPlayer)null, par1, par2, par3, par4))
++                if ((event.useBlock == Event.Result.DENY || !this.theWorld.extinguishFire((EntityPlayer)null, par1, par2, par3, par4)) && event.useItem != Event.Result.DENY)
+                 {
+                     this.tryHarvestBlock(par1, par2, par3);
+                 }
              }
              else
              {
@@ -73,7 +79,7 @@
                  }
  
                  if (i1 > 0 && f >= 1.0F)
-@@ -236,7 +272,7 @@
+@@ -236,7 +273,7 @@
              block.onBlockHarvested(this.theWorld, par1, par2, par3, l, this.thisPlayerMP);
          }
  
@@ -82,7 +88,7 @@
  
          if (block != null && flag)
          {
-@@ -261,19 +297,30 @@
+@@ -261,19 +298,30 @@
          }
          else
          {
@@ -115,7 +121,7 @@
  
                  if (itemstack != null)
                  {
-@@ -285,6 +332,7 @@
+@@ -285,6 +333,7 @@
                      }
                  }
  
@@ -123,7 +129,7 @@
                  if (flag && flag1)
                  {
                      Block.blocksList[l].harvestBlock(this.theWorld, this.thisPlayerMP, par1, par2, par3, i1);
-@@ -325,6 +373,7 @@
+@@ -325,6 +374,7 @@
              if (itemstack1.stackSize == 0)
              {
                  par1EntityPlayer.inventory.mainInventory[par1EntityPlayer.inventory.currentItem] = null;
@@ -131,7 +137,7 @@
              }
  
              if (!par1EntityPlayer.isUsingItem())
-@@ -342,35 +391,56 @@
+@@ -342,35 +392,56 @@
       */
      public boolean activateBlockOrUseItem(EntityPlayer par1EntityPlayer, World par2World, ItemStack par3ItemStack, int par4, int par5, int par6, int par7, float par8, float par9, float par10)
      {
@@ -215,7 +221,7 @@
      }
  
      /**
-@@ -380,4 +450,13 @@
+@@ -380,4 +451,13 @@
      {
          this.theWorld = par1WorldServer;
      }


### PR DESCRIPTION
This is kind of a draft, but I'd love to get some feedback / opinions on these changes.

Until now, onPlayerInteract for LEFT_CLICK_BLOCK didn't fire on the client, and therefore there's no way of canceling it so trying to break a block would show no breaking animation. It works perfectly fine on the server, so blocks can for example be protected by doing this. However there's no way to make a block appear unbreakable, or make something different happen when a player clicks a block on the client by using the onPlayerInteract event.

I made these changes a day ago, so I'm not sure sure I can get everything together, but here's what this is supposed to change:
- **Server:** Left click fires in adventure mode, but currently no packet is sent from the client  
  _(Ideally, useItem = ALLOW would allow a block to be broken in adventure mode.)_
- **Server:** Block breaking can be cancelled in creative mode, as well as extinguishing fire.
- **Client:** Cancelling the event will prevent the block from being broken, and no packet will be sent to the server.
- **Client:** useItem = DENY will send a dig packet to the server, but won't start breaking the block (just like adventure mode).
- **Client:** useBlock = DENY will prevent onBlockClicked from being fired, like on the server.

It doesn't quite work with adventure mode, as it won't send a dig packet to the server. I'd like to hear your input on the changes before tinkering with it even more, possibly doing something nobody wants. I will update the PR along the way, until hopefully everyone's happy with it.
