### PR TITLE
Adds cloud height to WorldType

### DIFF
--- a/patches/minecraft/net/minecraft/world/WorldProvider.java.patch
+++ b/patches/minecraft/net/minecraft/world/WorldProvider.java.patch
@@ -33,6 +33,15 @@
      }
  
      @SideOnly(Side.CLIENT)
+@@ -209,7 +216,7 @@
+      */
+     public float getCloudHeight()
+     {
+-        return 128.0F;
++        return this.terrainType.getCloudHeight();
+     }
+ 
+     @SideOnly(Side.CLIENT)
 @@ -268,4 +275,277 @@
       * Returns the dimension's name, e.g. "The End", "Nether", or "Overworld".
       */

--- a/patches/minecraft/net/minecraft/world/WorldType.java.patch
+++ b/patches/minecraft/net/minecraft/world/WorldType.java.patch
@@ -10,7 +10,7 @@
  import net.minecraft.world.*;
  import net.minecraft.world.gen.*;
  import net.minecraft.world.biome.*;
-@@ -224,4 +227,37 @@
+@@ -224,4 +227,47 @@
       * Called when 'Create New World' button is pressed before starting game
       */
      public void onGUICreateWorldPress() { }
@@ -46,5 +46,15 @@
 +    public boolean isCustomizable()
 +    {
 +        return this == FLAT;
++    }
++    
++    @SideOnly(Side.CLIENT)
++
++    /**
++     * the y level at which clouds are rendered.
++     */
++    public float getCloudHeight()
++    {
++        return 128.0F;
 +    }
  }


### PR DESCRIPTION
Adds the ability to adjust cloud height from WorldType and thus removes the need to replace Overworld WorldProvider.
