### PR TITLE
Simple way to control the bottom position of the chat window.

### DIFF
--- a/client/net/minecraftforge/client/GuiIngameForge.java
+++ b/client/net/minecraftforge/client/GuiIngameForge.java
@@ -74,7 +74,6 @@ public class GuiIngameForge extends GuiIngame
 
     public static int left_height = 39;
     public static int right_height = 39;
-    public static int chat_bottom = 48;
 
     private ScaledResolution res = null;
     private FontRenderer fontrenderer = null;
@@ -724,12 +723,19 @@ public class GuiIngameForge extends GuiIngame
 
     protected void renderChat(int width, int height)
     {
-        GL11.glPushMatrix();
-        GL11.glTranslatef(0.0F, (float)(height - chat_bottom), 0.0F);
-        mc.mcProfiler.startSection("chat");
-        persistantChatGUI.drawChat(updateCounter);
-        mc.mcProfiler.endSection();
-        GL11.glPopMatrix();
+        int chatX = 0;
+        int chatY = 48;
+        RenderGameOverlayEvent.Chat event = new RenderGameOverlayEvent.Chat(eventParent, chatX, chatY);
+        if (!MinecraftForge.EVENT_BUS.post(event))
+        {
+            GL11.glPushMatrix();
+            GL11.glTranslatef((float)event.chatX, (float)(height - event.chatY), 0.0F);
+            mc.mcProfiler.startSection("chat");
+            persistantChatGUI.drawChat(updateCounter);
+            mc.mcProfiler.endSection();
+            GL11.glPopMatrix();
+        }
+        post(CHAT);
     }
 
     protected void renderPlayerList(int width, int height)

--- a/client/net/minecraftforge/client/event/RenderGameOverlayEvent.java
+++ b/client/net/minecraftforge/client/event/RenderGameOverlayEvent.java
@@ -24,7 +24,8 @@ public class RenderGameOverlayEvent extends Event
         EXPERIENCE,
         TEXT,
         HEALTHMOUNT,
-        JUMPBAR
+        JUMPBAR,
+        CHAT
     }
 
     public final float partialTicks;
@@ -32,6 +33,8 @@ public class RenderGameOverlayEvent extends Event
     public final int mouseX;
     public final int mouseY;
     public final ElementType type;
+    public int chatX;
+    public int chatY;
 
     public RenderGameOverlayEvent(float partialTicks, ScaledResolution resolution, int mouseX, int mouseY)
     {
@@ -77,6 +80,16 @@ public class RenderGameOverlayEvent extends Event
             super(parent, ElementType.TEXT);
             this.left = left;
             this.right = right;
+        }
+    }
+
+    public static class Chat extends Pre
+    {
+        public Chat(RenderGameOverlayEvent parent, int chatX, int chatY)
+        {
+            super(parent, ElementType.TEXT);
+            this.chatX = chatX;
+            this.chatY = chatY;
         }
     }
 }


### PR DESCRIPTION
There is no simple way to change the vertical position of the chat
window, which is needed if a custom health bar is used that has a
different size, like in TerraFirmaCraft mod. The chat window is being
rendered behind the health bar covering a part of the last sentence.
This small change would make things a lot easier.
