### PR TITLE
Added a proper system for FurnaceRecipes

### DIFF
--- a/common/net/minecraftforge/StandardFurnaceRecipe.java
+++ b/common/net/minecraftforge/StandardFurnaceRecipe.java
@@ -1,0 +1,75 @@
+package net.minecraftforge;
+
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.item.ItemStack;
+import net.minecraftforge.common.IFurnaceRecipe;
+
+public class StandardFurnaceRecipe implements IFurnaceRecipe {
+
+    private final int itemId;
+    private final float experience;
+    private final ItemStack result;
+    private final int smeltTime;
+    
+    public StandardFurnaceRecipe(int itemId, float experience, ItemStack result)
+    {
+        this(itemId, experience, result, 200);
+    }
+    
+    public StandardFurnaceRecipe(int itemId, float experience, ItemStack result, int smeltTime)
+    {
+        this.itemId = itemId;
+        this.experience = experience;
+        this.result = result;
+        this.smeltTime = smeltTime;
+    }
+
+    @Override
+    public boolean matches(ItemStack smeltedItem)
+    {
+        return smeltedItem.itemID == itemId;
+    }
+
+    @Override
+    public ItemStack getResult(ItemStack smeltedItem)
+    {
+        return result;
+    }
+
+    @Override
+    public float getExperience(ItemStack smeltedItem, EntityPlayer player)
+    {
+        return experience;
+    }
+
+    @Override
+    public int getSmeltTime(ItemStack smeltedItem)
+    {
+        return smeltTime;
+    }
+    
+    public static class WithMeta extends StandardFurnaceRecipe {
+
+        private final int meta;
+        
+        public WithMeta(int itemId, int meta, float experience, ItemStack result)
+        {
+            super(itemId, experience, result);
+            this.meta = meta;
+        }
+        
+        public WithMeta(int itemId, int meta, float experience, ItemStack result, int smeltTime)
+        {
+            super(itemId, experience, result, smeltTime);
+            this.meta = meta;
+        }
+
+        @Override
+        public boolean matches(ItemStack smeltedItem)
+        {
+            return super.matches(smeltedItem) && smeltedItem.getItemDamage() == meta;
+        }
+        
+    }
+
+}

--- a/common/net/minecraftforge/common/IFurnaceRecipe.java
+++ b/common/net/minecraftforge/common/IFurnaceRecipe.java
@@ -1,0 +1,17 @@
+package net.minecraftforge.common;
+
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.item.ItemStack;
+import net.minecraft.tileentity.TileEntityFurnace;
+
+public interface IFurnaceRecipe {
+
+    boolean matches(ItemStack smeltedItem);
+    
+    ItemStack getResult(ItemStack smeltedItem);
+    
+    float getExperience(ItemStack smeltedItem, EntityPlayer player);
+    
+    int getSmeltTime(ItemStack smeltedItem);
+    
+}

--- a/patches/minecraft/net/minecraft/inventory/SlotFurnace.java.patch
+++ b/patches/minecraft/net/minecraft/inventory/SlotFurnace.java.patch
@@ -5,7 +5,7 @@
          {
              int i = this.field_75228_b;
 -            float f = FurnaceRecipes.smelting().getExperience(par1ItemStack.itemID);
-+            float f = FurnaceRecipes.smelting().getExperience(par1ItemStack);
++            float f = FurnaceRecipes.smelting().getExperience(par1ItemStack, thePlayer);
              int j;
  
              if (f == 0.0F)

--- a/patches/minecraft/net/minecraft/item/crafting/FurnaceRecipes.java.patch
+++ b/patches/minecraft/net/minecraft/item/crafting/FurnaceRecipes.java.patch
@@ -1,94 +1,111 @@
 --- ../src_base/minecraft/net/minecraft/item/crafting/FurnaceRecipes.java
 +++ ../src_work/minecraft/net/minecraft/item/crafting/FurnaceRecipes.java
-@@ -1,6 +1,8 @@
+@@ -1,18 +1,24 @@
  package net.minecraft.item.crafting;
  
-+import java.util.Arrays;
++import java.util.Collections;
  import java.util.HashMap;
 +import java.util.List;
  import java.util.Map;
++
++import com.google.common.collect.Lists;
++
  import net.minecraft.block.Block;
++import net.minecraft.entity.player.EntityPlayer;
  import net.minecraft.item.Item;
-@@ -13,6 +15,8 @@
-     /** The list of smelting results. */
-     private Map smeltingList = new HashMap();
-     private Map experienceList = new HashMap();
-+    private HashMap<List<Integer>, ItemStack> metaSmeltingList = new HashMap<List<Integer>, ItemStack>();
-+    private HashMap<List<Integer>, Float> metaExperience = new HashMap<List<Integer>, Float>();
+ import net.minecraft.item.ItemStack;
++import net.minecraftforge.StandardFurnaceRecipe;
++import net.minecraftforge.common.IFurnaceRecipe;
+ 
+ public class FurnaceRecipes
+ {
+     private static final FurnaceRecipes smeltingBase = new FurnaceRecipes();
+ 
+-    /** The list of smelting results. */
+-    private Map smeltingList = new HashMap();
+-    private Map experienceList = new HashMap();
++    private List<IFurnaceRecipe> recipes = Lists.newLinkedList();
  
      /**
       * Used to call methods addSmelting and getSmeltingResult.
-@@ -57,7 +61,9 @@
+@@ -51,25 +57,75 @@
+      */
+     public void addSmelting(int par1, ItemStack par2ItemStack, float par3)
+     {
+-        this.smeltingList.put(Integer.valueOf(par1), par2ItemStack);
+-        this.experienceList.put(Integer.valueOf(par2ItemStack.itemID), Float.valueOf(par3));
++        addSmelting(new StandardFurnaceRecipe(par1, par3, par2ItemStack));
+     }
  
      /**
       * Returns the smelting result of an item.
-+     * Deprecated in favor of a metadata sensitive version
       */
-+    @Deprecated
++    @Deprecated // use getSmeltingResult(ItemStack)
      public ItemStack getSmeltingResult(int par1)
      {
-         return (ItemStack)this.smeltingList.get(Integer.valueOf(par1));
-@@ -68,8 +74,63 @@
-         return this.smeltingList;
-     }
- 
-+    @Deprecated //In favor of ItemStack sensitive version
-     public float getExperience(int par1)
-     {
-         return this.experienceList.containsKey(Integer.valueOf(par1)) ? ((Float)this.experienceList.get(Integer.valueOf(par1))).floatValue() : 0.0F;
-     }
-+
-+    /**
-+     * A metadata sensitive version of adding a furnace recipe.
-+     */
-+    public void addSmelting(int itemID, int metadata, ItemStack itemstack, float experience)
-+    {
-+        metaSmeltingList.put(Arrays.asList(itemID, metadata), itemstack);
-+        metaExperience.put(Arrays.asList(itemstack.itemID, itemstack.getItemDamage()), experience);
+-        return (ItemStack)this.smeltingList.get(Integer.valueOf(par1));
++        return getSmeltingResult(new ItemStack(par1, 1, 0));
 +    }
-+
-+    /**
-+     * Used to get the resulting ItemStack form a source ItemStack
-+     * @param item The Source ItemStack
-+     * @return The result ItemStack
-+     */
-+    public ItemStack getSmeltingResult(ItemStack item) 
++    
++    public ItemStack getSmeltingResult(ItemStack smeltingItem)
 +    {
-+        if (item == null)
-+        {
++        IFurnaceRecipe r = getRecipe(smeltingItem);
++        return r == null ? null : r.getResult(smeltingItem);
++    }
++    
++    private IFurnaceRecipe getRecipe(ItemStack smeltingItem)
++    {
++        if (smeltingItem == null) {
 +            return null;
 +        }
-+        ItemStack ret = (ItemStack)metaSmeltingList.get(Arrays.asList(item.itemID, item.getItemDamage()));
-+        if (ret != null) 
++        for (IFurnaceRecipe recipe : recipes)
 +        {
-+            return ret;
++            if (recipe.matches(smeltingItem))
++            {
++                return recipe;
++            }
 +        }
-+        return (ItemStack)smeltingList.get(Integer.valueOf(item.itemID));
++        return null;
 +    }
-+
-+    /**
-+     * Grabs the amount of base experience for this item to give when pulled from the furnace slot.
-+     */
-+    public float getExperience(ItemStack item)
++    
++    public float getExperience(ItemStack item, EntityPlayer player)
 +    {
-+        if (item == null || item.getItem() == null)
-+        {
-+            return 0;
-+        }
-+        float ret = item.getItem().getSmeltingExperience(item);
-+        if (ret < 0 && metaExperience.containsKey(Arrays.asList(item.itemID, item.getItemDamage())))
-+        {
-+            ret = metaExperience.get(Arrays.asList(item.itemID, item.getItemDamage()));
-+        }
-+        if (ret < 0 && experienceList.containsKey(item.itemID))
-+        {
-+            ret = ((Float)experienceList.get(item.itemID)).floatValue();
-+        }
-+        return (ret < 0 ? 0 : ret);
++        IFurnaceRecipe r = getRecipe(item);
++        return r == null ? 0 : r.getExperience(item, player);
 +    }
-+
-+    public Map<List<Integer>, ItemStack> getMetaSmeltingList()
++    
++    public void addSmelting(int itemID, int metadata, ItemStack itemstack, float experience)
 +    {
-+        return metaSmeltingList;
++        addSmelting(new StandardFurnaceRecipe.WithMeta(itemID, metadata, experience, itemstack));
 +    }
++    
++    public void addSmelting(IFurnaceRecipe recipe)
++    {
++        recipes.add(recipe);
++    }
++    
++    public List<IFurnaceRecipe> getRecipes()
++    {
++        return recipes;
++    }
++    
++    public int getSmeltTime(ItemStack smeltingItem)
++    {
++        IFurnaceRecipe r = getRecipe(smeltingItem);
++        return r == null ? 200 : r.getSmeltTime(smeltingItem);
+     }
+ 
++    @Deprecated // use getRecipes()
+     public Map getSmeltingList()
+     {
+-        return this.smeltingList;
++        return Collections.emptyMap();
+     }
+ 
++    @Deprecated // use getExperience(ItemStack)
+     public float getExperience(int par1)
+     {
+-        return this.experienceList.containsKey(Integer.valueOf(par1)) ? ((Float)this.experienceList.get(Integer.valueOf(par1))).floatValue() : 0.0F;
++        return 0;
+     }
  }

--- a/patches/minecraft/net/minecraft/tileentity/TileEntityFurnace.java.patch
+++ b/patches/minecraft/net/minecraft/tileentity/TileEntityFurnace.java.patch
@@ -17,7 +17,52 @@
  
  public class TileEntityFurnace extends TileEntity implements ISidedInventory
  {
-@@ -279,8 +282,7 @@
+@@ -30,6 +33,9 @@
+ 
+     /** The number of ticks that the furnace will keep burning */
+     public int furnaceBurnTime;
++    
++    private int currentItemSmeltTime = 200;
++    private ItemStack currentSmeltResult = null;
+ 
+     /**
+      * The number of ticks that a fresh copy of the currently-burning item would keep the furnace burning for
+@@ -119,6 +125,17 @@
+         {
+             par2ItemStack.stackSize = this.getInventoryStackLimit();
+         }
++        
++        if (par1 == 0)
++        {
++            updateSmeltingResults();
++        }
++    }
++    
++    private void updateSmeltingResults()
++    {
++        currentItemSmeltTime = FurnaceRecipes.smelting().getSmeltTime(furnaceItemStacks[0]);
++        currentSmeltResult = FurnaceRecipes.smelting().getSmeltingResult(furnaceItemStacks[0]);
+     }
+ 
+     /**
+@@ -174,6 +191,7 @@
+         {
+             this.field_94130_e = par1NBTTagCompound.getString("CustomName");
+         }
++        updateSmeltingResults();
+     }
+ 
+     /**
+@@ -222,7 +240,7 @@
+      */
+     public int getCookProgressScaled(int par1)
+     {
+-        return this.furnaceCookTime * par1 / 200;
++        return this.furnaceCookTime * par1 / currentItemSmeltTime;
+     }
+ 
+     @SideOnly(Side.CLIENT)
+@@ -279,8 +297,7 @@
  
                          if (this.furnaceItemStacks[1].stackSize == 0)
                          {
@@ -27,13 +72,22 @@
                          }
                      }
                  }
-@@ -326,8 +328,12 @@
+@@ -290,7 +307,7 @@
+             {
+                 ++this.furnaceCookTime;
+ 
+-                if (this.furnaceCookTime == 200)
++                if (this.furnaceCookTime == currentItemSmeltTime)
+                 {
+                     this.furnaceCookTime = 0;
+                     this.smeltItem();
+@@ -326,8 +343,12 @@
          }
          else
          {
 -            ItemStack itemstack = FurnaceRecipes.smelting().getSmeltingResult(this.furnaceItemStacks[0].getItem().itemID);
 -            return itemstack == null ? false : (this.furnaceItemStacks[2] == null ? true : (!this.furnaceItemStacks[2].isItemEqual(itemstack) ? false : (this.furnaceItemStacks[2].stackSize < this.getInventoryStackLimit() && this.furnaceItemStacks[2].stackSize < this.furnaceItemStacks[2].getMaxStackSize() ? true : this.furnaceItemStacks[2].stackSize < itemstack.getMaxStackSize())));
-+            ItemStack itemstack = FurnaceRecipes.smelting().getSmeltingResult(this.furnaceItemStacks[0]);
++            ItemStack itemstack = currentSmeltResult;
 +            if (itemstack == null) return false;
 +            if (this.furnaceItemStacks[2] == null) return true;
 +            if (!this.furnaceItemStacks[2].isItemEqual(itemstack)) return false;
@@ -42,12 +96,12 @@
          }
      }
  
-@@ -338,15 +344,15 @@
+@@ -338,15 +359,15 @@
      {
          if (this.canSmelt())
          {
 -            ItemStack itemstack = FurnaceRecipes.smelting().getSmeltingResult(this.furnaceItemStacks[0].getItem().itemID);
-+            ItemStack itemstack = FurnaceRecipes.smelting().getSmeltingResult(this.furnaceItemStacks[0]);
++            ItemStack itemstack = currentSmeltResult;
  
              if (this.furnaceItemStacks[2] == null)
              {
@@ -62,7 +116,15 @@
              }
  
              --this.furnaceItemStacks[0].stackSize;
-@@ -373,7 +379,7 @@
+@@ -355,6 +376,7 @@
+             {
+                 this.furnaceItemStacks[0] = null;
+             }
++            updateSmeltingResults();
+         }
+     }
+ 
+@@ -373,7 +395,7 @@
              int i = par0ItemStack.getItem().itemID;
              Item item = par0ItemStack.getItem();
  


### PR DESCRIPTION
Allows mods to further specify smeltingTime, per-player experience values or anything else they desire while still staying compatible with older versions by not changing the Method signatures in FurnaceRecipes.

Proper version of #615 I guess.
