### PR TITLE
Item dictionary

### DIFF
--- a/common/net/minecraftforge/common/Configuration.java
+++ b/common/net/minecraftforge/common/Configuration.java
@@ -183,9 +183,12 @@ public class Configuration
     public Property getItem(String key, int defaultID) { return getItem(CATEGORY_ITEM, key, defaultID, null); }
     public Property getItem(String key, int defaultID, String comment) { return getItem(CATEGORY_ITEM, key, defaultID, comment); }
     public Property getItem(String category, String key, int defaultID) { return getItem(category, key, defaultID, null); }
-
-    public Property getItem(String category, String key, int defaultID, String comment)
+    public Property getItem(String category, String key, int defaultID, String comment) { return getItem(category, key, defaultID, comment, false); }
+    
+    public Property getItem(String category, String key, int defaultID, String comment, boolean useShift)
     {
+        final int ITEM_SHIFT = (useShift ? Configuration.ITEM_SHIFT : 0);
+        
         Property prop = get(category, key, -1, comment);
         int defaultShift = defaultID + ITEM_SHIFT;
 

--- a/common/net/minecraftforge/common/ForgeDummyContainer.java
+++ b/common/net/minecraftforge/common/ForgeDummyContainer.java
@@ -15,6 +15,7 @@ import net.minecraftforge.common.network.ForgeConnectionHandler;
 import net.minecraftforge.common.network.ForgeNetworkHandler;
 import net.minecraftforge.common.network.ForgePacketHandler;
 import net.minecraftforge.common.network.ForgeTinyPacketHandler;
+import net.minecraftforge.itemdict.ItemDictionary;
 import net.minecraftforge.server.command.ForgeCommand;
 
 import com.google.common.eventbus.EventBus;
@@ -29,6 +30,7 @@ import cpw.mods.fml.common.Loader;
 import cpw.mods.fml.common.ModMetadata;
 import cpw.mods.fml.common.WorldAccessContainer;
 import cpw.mods.fml.common.event.FMLConstructionEvent;
+import cpw.mods.fml.common.event.FMLInitializationEvent;
 import cpw.mods.fml.common.event.FMLPostInitializationEvent;
 import cpw.mods.fml.common.event.FMLPreInitializationEvent;
 import cpw.mods.fml.common.event.FMLServerStartingEvent;
@@ -51,6 +53,8 @@ public class ForgeDummyContainer extends DummyModContainer implements WorldAcces
     public static boolean disableStitchedFileSaving = false;
     public static boolean forceDuplicateFluidBlockCrash = true;
     public static boolean fullBoundingBoxLadders = false;
+    
+    private LoadController loadController;
 
     public ForgeDummyContainer()
     {
@@ -149,6 +153,7 @@ public class ForgeDummyContainer extends DummyModContainer implements WorldAcces
     public boolean registerBus(EventBus bus, LoadController controller)
     {
         bus.register(this);
+        this.loadController = controller;
         return true;
     }
 
@@ -171,6 +176,16 @@ public class ForgeDummyContainer extends DummyModContainer implements WorldAcces
     public void preInit(FMLPreInitializationEvent evt)
     {
         ForgeChunkManager.captureConfig(evt.getModConfigurationDirectory());
+    }
+    
+    @Subscribe
+    public void init(FMLInitializationEvent evt)
+    {
+        try {
+            ItemDictionary.createItems();
+        } catch(Throwable t) {
+            loadController.errorOccurred(this, t);
+        }
     }
 
     @Subscribe

--- a/common/net/minecraftforge/itemdict/ItemDictionary.java
+++ b/common/net/minecraftforge/itemdict/ItemDictionary.java
@@ -1,0 +1,187 @@
+package net.minecraftforge.itemdict;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.Random;
+import java.util.Set;
+import java.util.TreeMap;
+
+import com.google.common.base.Joiner;
+
+import net.minecraft.block.Block;
+import net.minecraft.item.Item;
+import net.minecraftforge.common.Configuration;
+import net.minecraftforge.common.Property;
+
+import cpw.mods.fml.common.Loader;
+import cpw.mods.fml.common.ModContainer;
+
+/**
+ * This is like the ore dictionary, but only one item will be created for each
+ * entry.
+ * 
+ * To use the item dictionary, call ItemDictionary.register during pre-init if
+ * you want to add a possible item or block.
+ * 
+ * Then during init, call ItemDictionary.getItem/getBlock to find the item or
+ * block that was actually used.
+ */
+public class ItemDictionary {
+    public static interface Factory {
+        public void create(int id);
+    }
+
+    private static class ItemDictItem {
+        Map<String, Factory> alternatives = new TreeMap<String, Factory>();
+        Object object;
+    }
+
+    private static Map<String, ItemDictItem> items = new TreeMap<String, ItemDictItem>();
+    private static Map<String, ItemDictItem> blocks = new TreeMap<String, ItemDictItem>();
+
+    /**
+     * Returns an item from the item dictionary.
+     * 
+     * @param itemName
+     *            The item name.
+     * @return The item, or null if no such item was registered.
+     */
+    public static Item getItem(String itemName)
+    {
+        if (!finalized) throw new IllegalStateException("Not finalized yet");
+        ItemDictItem dictItem = items.get(itemName);
+        return dictItem == null ? null : (Item) dictItem.object;
+    }
+
+    /**
+     * Returns a block from the item dictionary.
+     * 
+     * @param itemName
+     *            The item name.
+     * @return The block, or null if no such block was registered.
+     */
+    public static Block getBlock(String itemName)
+    {
+        if (!finalized) throw new IllegalStateException("Not finalized yet");
+        ItemDictItem dictItem = blocks.get(itemName);
+        return dictItem == null ? null : (Block) dictItem.object;
+    }
+
+    /**
+     * Registers an item/block alternative.
+     * 
+     * @param mod
+     *            The mod making the registration.
+     * @param itemName
+     *            The name of the item.
+     * @param isBlock
+     *            True to register a block, false for an item.
+     * @param factory
+     *            The factory object used to actually create the block or item,
+     *            if this alternative is chosen.
+     */
+    public static void register(Object mod, String itemName, boolean isBlock, Factory factory)
+    {
+        register(mod, null, itemName, isBlock, factory);
+    }
+
+    /**
+     * Registers an item/block alternative.
+     * 
+     * @param mod
+     *            The mod making the registration.
+     * @param suffix
+     *            A suffix which is used in the alternative name, to allow a
+     *            single mod to provide multiple alternatives.
+     * @param itemName
+     *            The name of the item.
+     * @param isBlock
+     *            True to register a block, false for an item.
+     * @param factory
+     *            The factory object used to actually create the block or item,
+     *            if this alternative is chosen.
+     */
+    public static void register(Object mod, String suffix, String itemName, boolean isBlock, Factory factory)
+    {
+        ModContainer modContainer = Loader.instance().getModObjectList().inverse().get(mod);
+        if (modContainer == null) throw new IllegalArgumentException("Not a valid mod object");
+
+        String modID = modContainer.getModId();
+        String optionName = (suffix == null ? modID : modID + "-" + suffix);
+
+        Map<String, ItemDictItem> itemMap = (isBlock ? blocks : items);
+
+        ItemDictItem entry = itemMap.get(itemName);
+        if (entry == null)
+        {
+            entry = new ItemDictItem();
+            itemMap.put(itemName, entry);
+        }
+
+        if (entry.alternatives.containsKey(optionName)) throw new IllegalStateException("Option " + optionName + " already exists for item " + itemName);
+
+        entry.alternatives.put(optionName, factory);
+    }
+
+    private static boolean finalized = false;
+
+    public static void createItems()
+    {
+        if (finalized) throw new IllegalStateException("Already finalized");
+
+        File configFile = new File(Loader.instance().getConfigDir(), "forge-item-dictionary.cfg");
+        Configuration config = new Configuration(configFile);
+
+        for (Map.Entry<String, ItemDictItem> entry : items.entrySet())
+            createItem(entry.getKey(), entry.getValue(), false, config);
+        for (Map.Entry<String, ItemDictItem> entry : blocks.entrySet())
+            createItem(entry.getKey(), entry.getValue(), true, config);
+
+        if (config.hasChanged()) config.save();
+
+        finalized = true;
+    }
+
+    private static void createItem(String itemName, ItemDictItem item, boolean isBlock, Configuration config)
+    {
+        String comment = "Available choices: " + Joiner.on(", ").join(item.alternatives.keySet());
+
+        int id;
+        if (isBlock)
+            id = config.getBlock(itemName + ".id", 3000).getInt();
+        else
+            id = config.getItem(Configuration.CATEGORY_ITEM, itemName + ".id", 20000, null, false).getInt();
+
+        String defaultChoice = item.alternatives.keySet().iterator().next();
+        Property choiceProperty = config.get(isBlock ? Configuration.CATEGORY_BLOCK : Configuration.CATEGORY_ITEM, itemName + ".alt", defaultChoice, comment);
+        String choice = choiceProperty.getString();
+
+        if (!item.alternatives.containsKey(choice))
+        {
+            choice = chooseRandom(item.alternatives.keySet());
+            choiceProperty.set(choice);
+        }
+
+        Factory factory = item.alternatives.get(choice);
+
+        factory.create(id);
+
+        if (isBlock)
+            item.object = Block.blocksList[id];
+        else
+            item.object = Item.itemsList[id];
+
+        if (item.object == null)
+            throw new RuntimeException("THIS IS A PROBLEM WITH THE MOD '" + choice + "'! " + (isBlock ? "Block" : "Item") + " '" + itemName
+                    + "' was not correctly created at ID " + id + ". Factory instance: " + factory);
+    }
+
+    private static String chooseRandom(Collection<String> strings)
+    {
+        List<String> list = new ArrayList<String>(strings);
+        return list.get(new Random().nextInt(list.size()));
+    }
+}


### PR DESCRIPTION
This works like the ore dictionary, but only one item (or block) will be created for each name.
For example, if 5 mods register "ingotCopper", only one of them will be called upon to create the item for ingotCopper. A config file can be used to select which mod's copper is used - by default it's the first alphabetically.

If you are using, say, Forestry copper, and you remove Forestry, it will automatically switch to a different type of copper and keep the same ID.

(as an example, Resonant Rise has 7 types of steel, 6 types of copper, 6 types of tin, 7 types of bronze, 4 types of silver, and 3 types of lead)
