### PR TITLE
Check if block is air instead of just ID zero when growing from stem block.

### DIFF
--- a/patches/minecraft/net/minecraft/block/BlockStem.java.patch
+++ b/patches/minecraft/net/minecraft/block/BlockStem.java.patch
@@ -24,7 +24,7 @@
  
 -                    if (par1World.getBlockId(j1, par3, k1) == 0 && (l1 == Block.tilledField.blockID || l1 == Block.dirt.blockID || l1 == Block.grass.blockID))
 +                    boolean isSoil = (blocksList[l1] != null && blocksList[l1].canSustainPlant(par1World, j1, par3 - 1, k1, ForgeDirection.UP, this));
-+                    if (par1World.getBlockId(j1, par3, k1) == 0 && (isSoil || l1 == Block.dirt.blockID || l1 == Block.grass.blockID))
++                    if (par1World.isAirBlock(j1, par3, k1) && (isSoil || l1 == Block.dirt.blockID || l1 == Block.grass.blockID))
                      {
                          par1World.setBlock(j1, par3, k1, this.fruitType.blockID);
                      }


### PR DESCRIPTION
Checks if adjacent block is air instead of ID zero. 

This fixes obvious problems when blocks are considered air to players, but aren't ID zero.
