### PR TITLE
Added new method for different maxStackSize for different Item subTypes

### DIFF
--- a/patches/minecraft/net/minecraft/item/Item.java.patch
+++ b/patches/minecraft/net/minecraft/item/Item.java.patch
@@ -600,4 +600,10 @@
 +    {
 +        return hasEffect(par1ItemStack) && (pass == 0 || itemID != Item.potion.itemID);
 +    }
+
++    /** ItemStack sensitive version for having different maxStackSize for each item subtype (it can be overridden for this) */
++    public int getItemStackLimit(ItemStack par1ItemStack)
++    {
++    	return this.getItemStackLimit();
++    }
  }


### PR DESCRIPTION
Added the new method getItemStackLimit(ItemStack par1ItemStack) which must be called by ItemStack#getMaxStackSize for having different maxStackSize values for each Item subType.
