### PR TITLE
Edit getMaxStackSize method for ItemStack sensitive result

### DIFF
--- a/patches/minecraft/net/minecraft/item/ItemStack.java.patch
+++ b/patches/minecraft/net/minecraft/item/ItemStack.java.patch
@@ -91,5 +91,10 @@
 +    {
 +        return this.getItem().hasEffect(this, pass);
      }
+     
+    public int getMaxStackSize()
+    {
++        return this.getItem().getItemStackLimit(this);
+    }
  
      @SideOnly(Side.CLIENT)


### PR DESCRIPTION
ItemStack#getMaxStackSize now returns the ItemStack-sensitive result because it calls Item#getItemStackLimit which is already ItemStack sensitive. We can have custom MaxStackSize for each item subType now.
