### PR TITLE
Change when PlayerInteractEvent gets fired

### DIFF
--- a/patches/minecraft/net/minecraft/client/Minecraft.java.patch
+++ b/patches/minecraft/net/minecraft/client/Minecraft.java.patch
@@ -67,16 +67,20 @@
          }
  
          if (par1GuiScreen instanceof GuiMainMenu)
-@@ -1300,7 +1318,7 @@
- 
-                 if (this.thePlayer.isCurrentToolAdventureModeExempt(j, k, l))
-                 {
+@@ -1297,12 +1315,6 @@
+                 int k = this.objectMouseOver.blockY;
+                 int l = this.objectMouseOver.blockZ;
+                 this.playerController.onPlayerDamageBlock(j, k, l, this.objectMouseOver.sideHit);
+-
+-                if (this.thePlayer.isCurrentToolAdventureModeExempt(j, k, l))
+-                {
 -                    this.effectRenderer.addBlockHitEffects(j, k, l, this.objectMouseOver.sideHit);
-+                    this.effectRenderer.addBlockHitEffects(j, k, l, this.objectMouseOver);
-                     this.thePlayer.swingItem();
-                 }
+-                    this.thePlayer.swingItem();
+-                }
              }
-@@ -1366,7 +1384,8 @@
+             else
+             {
+@@ -1366,7 +1378,8 @@
                  {
                      int j1 = itemstack != null ? itemstack.stackSize : 0;
  
@@ -86,17 +90,17 @@
                      {
                          flag = false;
                          this.thePlayer.swingItem();
-@@ -1392,7 +1411,8 @@
+@@ -1392,7 +1405,8 @@
              {
                  ItemStack itemstack1 = this.thePlayer.inventory.getCurrentItem();
  
 -                if (itemstack1 != null && this.playerController.sendUseItem(this.thePlayer, this.theWorld, itemstack1))
 +                boolean result = !ForgeEventFactory.onPlayerInteract(thePlayer, Action.RIGHT_CLICK_AIR, 0, 0, 0, -1).isCanceled();
-+                if (result && itemstack1 != null && this.playerController.sendUseItem(this.thePlayer, this.theWorld, itemstack1))
++                if (this.playerController.sendUseItem(this.thePlayer, this.theWorld, itemstack1))
                  {
                      this.entityRenderer.itemRenderer.resetEquippedProgress2();
                  }
-@@ -1574,6 +1594,8 @@
+@@ -1574,6 +1588,8 @@
  
              while (Mouse.next())
              {
@@ -105,7 +109,7 @@
                  i = Mouse.getEventButton();
  
                  if (isRunningOnMac && i == 0 && (Keyboard.isKeyDown(29) || Keyboard.isKeyDown(157)))
-@@ -2046,6 +2068,11 @@
+@@ -2046,6 +2062,11 @@
      {
          this.statFileWriter.syncStats();
  
@@ -117,7 +121,7 @@
          if (par1WorldClient == null)
          {
              NetClientHandler netclienthandler = this.getNetHandler();
-@@ -2063,6 +2090,18 @@
+@@ -2063,6 +2084,18 @@
              if (this.theIntegratedServer != null)
              {
                  this.theIntegratedServer.initiateShutdown();
@@ -136,7 +140,7 @@
              }
  
              this.theIntegratedServer = null;
-@@ -2236,107 +2275,12 @@
+@@ -2236,107 +2269,12 @@
          if (this.objectMouseOver != null)
          {
              boolean flag = this.thePlayer.capabilities.isCreativeMode;
@@ -248,7 +252,7 @@
  
              if (flag)
              {
-@@ -2419,11 +2363,18 @@
+@@ -2419,11 +2357,18 @@
          par1PlayerUsageSnooper.addData("gl_max_texture_size", Integer.valueOf(getGLMaximumTextureSize()));
      }
  
@@ -267,7 +271,7 @@
          for (int i = 16384; i > 0; i >>= 1)
          {
              GL11.glTexImage2D(GL11.GL_PROXY_TEXTURE_2D, 0, GL11.GL_RGBA, i, i, 0, GL11.GL_RGBA, GL11.GL_UNSIGNED_BYTE, (ByteBuffer)null);
-@@ -2431,6 +2382,7 @@
+@@ -2431,6 +2376,7 @@
  
              if (j != 0)
              {

--- a/patches/minecraft/net/minecraft/client/multiplayer/PlayerControllerMP.java.patch
+++ b/patches/minecraft/net/minecraft/client/multiplayer/PlayerControllerMP.java.patch
@@ -1,30 +1,30 @@
 --- ../src_base/minecraft/net/minecraft/client/multiplayer/PlayerControllerMP.java
 +++ ../src_work/minecraft/net/minecraft/client/multiplayer/PlayerControllerMP.java
-@@ -22,6 +22,10 @@
+@@ -22,6 +22,13 @@
  import net.minecraft.world.EnumGameType;
  import net.minecraft.world.World;
  
-+import net.minecraftforge.common.ForgeHooks;
 +import net.minecraftforge.common.MinecraftForge;
++import net.minecraftforge.event.Event;
++import net.minecraftforge.event.ForgeEventFactory;
 +import net.minecraftforge.event.entity.player.PlayerDestroyItemEvent;
++import net.minecraftforge.event.entity.player.PlayerInteractEvent;
++import net.minecraftforge.event.entity.player.PlayerInteractEvent.Action;
 +
  @SideOnly(Side.CLIENT)
  public class PlayerControllerMP
  {
-@@ -125,6 +129,12 @@
+@@ -125,7 +132,8 @@
       */
      public boolean onPlayerDestroyBlock(int par1, int par2, int par3, int par4)
      {
+-        if (this.currentGameType.isAdventure() && !this.mc.thePlayer.isCurrentToolAdventureModeExempt(par1, par2, par3))
 +        ItemStack stack = mc.thePlayer.getCurrentEquippedItem();
 +        if (stack != null && stack.getItem() != null && stack.getItem().onBlockStartBreak(stack, par1, par2, par3, mc.thePlayer))
-+        {
-+            return false;
-+        }
-+
-         if (this.currentGameType.isAdventure() && !this.mc.thePlayer.isCurrentToolAdventureModeExempt(par1, par2, par3))
          {
              return false;
-@@ -146,7 +156,7 @@
+         }
+@@ -146,14 +154,12 @@
              {
                  worldclient.playAuxSFX(2001, par1, par2, par3, block.blockID + (worldclient.getBlockMetadata(par1, par2, par3) << 12));
                  int i1 = worldclient.getBlockMetadata(par1, par2, par3);
@@ -33,24 +33,167 @@
  
                  if (flag)
                  {
-@@ -347,8 +357,14 @@
+                     block.onBlockDestroyedByPlayer(worldclient, par1, par2, par3, i1);
+                 }
+-
+-                this.currentBlockY = -1;
+ 
+                 if (!this.currentGameType.isCreative())
+                 {
+@@ -180,39 +186,47 @@
+      */
+     public void clickBlock(int par1, int par2, int par3, int par4)
+     {
+-        if (!this.currentGameType.isAdventure() || this.mc.thePlayer.isCurrentToolAdventureModeExempt(par1, par2, par3))
+-        {
+-            if (this.currentGameType.isCreative())
+-            {
+-                this.netClientHandler.addToSendQueue(new Packet14BlockDig(0, par1, par2, par3, par4));
+-                clickBlockCreative(this.mc, this, par1, par2, par3, par4);
+-                this.blockHitDelay = 5;
+-            }
+-            else if (!this.isHittingBlock || !this.sameToolAndBlock(par1, par2, par3))
+-            {
+-                if (this.isHittingBlock)
+-                {
+-                    this.netClientHandler.addToSendQueue(new Packet14BlockDig(1, this.currentBlockX, this.currentBlockY, this.currentblockZ, par4));
+-                }
+-
+-                this.netClientHandler.addToSendQueue(new Packet14BlockDig(0, par1, par2, par3, par4));
+-                int i1 = this.mc.theWorld.getBlockId(par1, par2, par3);
+-
+-                if (i1 > 0 && this.curBlockDamageMP == 0.0F)
+-                {
+-                    Block.blocksList[i1].onBlockClicked(this.mc.theWorld, par1, par2, par3, this.mc.thePlayer);
+-                }
+-
+-                if (i1 > 0 && Block.blocksList[i1].getPlayerRelativeBlockHardness(this.mc.thePlayer, this.mc.thePlayer.worldObj, par1, par2, par3) >= 1.0F)
++        PlayerInteractEvent event = ForgeEventFactory.onPlayerInteract(this.mc.thePlayer, Action.LEFT_CLICK_BLOCK, par1, par2, par3, par4);
++
++        boolean canBreak = !this.currentGameType.isAdventure() || this.mc.thePlayer.isCurrentToolAdventureModeExempt(par1, par2, par3);
++        canBreak = event.useItem == Event.Result.DEFAULT ? canBreak : event.useItem == Event.Result.ALLOW;
++
++        if (!event.isCanceled() && (!this.isHittingBlock || !this.sameToolAndBlock(par1, par2, par3)))
++        {
++            if (this.isHittingBlock)
++            {
++                this.netClientHandler.addToSendQueue(new Packet14BlockDig(1, this.currentBlockX, this.currentBlockY, this.currentblockZ, par4));
++            }
++
++            this.netClientHandler.addToSendQueue(new Packet14BlockDig(0, par1, par2, par3, par4));
++            int i1 = this.mc.theWorld.getBlockId(par1, par2, par3);
++
++            boolean breakInstantly = i1 > 0 && Block.blocksList[i1].getPlayerRelativeBlockHardness(this.mc.thePlayer, this.mc.thePlayer.worldObj, par1, par2, par3) >= 1.0F;
++            breakInstantly = canBreak && (breakInstantly || this.currentGameType.isCreative());
++
++            if (!breakInstantly && i1 > 0 && this.curBlockDamageMP == 0.0F && event.useBlock != Event.Result.DENY)
++            {
++                Block.blocksList[i1].onBlockClicked(this.mc.theWorld, par1, par2, par3, this.mc.thePlayer);
++            }
++
++            if (canBreak)
++            {
++                this.currentBlockX = par1;
++                this.currentBlockY = par2;
++                this.currentblockZ = par3;
++
++                if (this.currentGameType.isCreative())
++                {
++                    clickBlockCreative(this.mc, this, par1, par2, par3, par4);
++                    this.blockHitDelay = 5;
++                }
++                else if (breakInstantly)
+                 {
+                     this.onPlayerDestroyBlock(par1, par2, par3, par4);
+                 }
+                 else
+                 {
+                     this.isHittingBlock = true;
+-                    this.currentBlockX = par1;
+-                    this.currentBlockY = par2;
+-                    this.currentblockZ = par3;
+                     this.field_85183_f = this.mc.thePlayer.getHeldItem();
+                     this.curBlockDamageMP = 0.0F;
+                     this.stepSoundTickCounter = 0.0F;
+@@ -220,6 +234,12 @@
+                 }
+             }
+         }
++
++        if (!canBreak)
++        {
++            this.resetBlockRemoving();
++            this.currentBlockY = -1;
++        }
+     }
+ 
+     /**
+@@ -247,6 +267,11 @@
+         if (this.blockHitDelay > 0)
+         {
+             --this.blockHitDelay;
++            return;
++        }
++        else if (this.currentBlockY == -1)
++        {
++            return;
+         }
+         else if (this.currentGameType.isCreative())
+         {
+@@ -293,6 +318,9 @@
+                 this.clickBlock(par1, par2, par3, par4);
+             }
+         }
++
++        this.mc.effectRenderer.addBlockHitEffects(par1, par2, par3, this.mc.objectMouseOver);
++        this.mc.thePlayer.swingItem();
+     }
+ 
+     /**
+@@ -341,14 +369,29 @@
+      */
+     public boolean onPlayerRightClick(EntityPlayer par1EntityPlayer, World par2World, ItemStack par3ItemStack, int par4, int par5, int par6, int par7, Vec3 par8Vec3)
+     {
++        PlayerInteractEvent event = ForgeEventFactory.onPlayerInteract(this.mc.thePlayer, Action.RIGHT_CLICK_BLOCK, par4, par5, par6, par7);
++        if (event.isCanceled())
++        {
++            return false;
++        }
++        
+         this.syncCurrentPlayItem();
+         float f = (float)par8Vec3.xCoord - (float)par4;
+         float f1 = (float)par8Vec3.yCoord - (float)par5;
          float f2 = (float)par8Vec3.zCoord - (float)par6;
          boolean flag = false;
          int i1;
 -
 -        if (!par1EntityPlayer.isSneaking() || par1EntityPlayer.getHeldItem() == null)
-+        if (par3ItemStack != null &&
++        if (event.useItem != Event.Result.DENY &&
++            par3ItemStack != null &&
 +            par3ItemStack.getItem() != null &&
 +            par3ItemStack.getItem().onItemUseFirst(par3ItemStack, par1EntityPlayer, par2World, par4, par5, par6, par7, f, f1, f2))
 +        {
 +                return true;
 +        }
 +
-+        if (!par1EntityPlayer.isSneaking() || (par1EntityPlayer.getHeldItem() == null || par1EntityPlayer.getHeldItem().getItem().shouldPassSneakingClickToBlock(par2World, par4, par5, par6)))
++        if (event.useBlock != Event.Result.DENY &&
++            !par1EntityPlayer.isSneaking() || (par1EntityPlayer.getHeldItem() == null ||
++            par1EntityPlayer.getHeldItem().getItem().shouldPassSneakingClickToBlock(par2World, par4, par5, par6)))
          {
              i1 = par2World.getBlockId(par4, par5, par6);
  
-@@ -389,7 +405,15 @@
+@@ -375,6 +418,10 @@
+             return true;
+         }
+         else if (par3ItemStack == null)
++        {
++            return false;
++        }
++        else if (event.useItem == Event.Result.DENY)
+         {
+             return false;
+         }
+@@ -389,7 +436,15 @@
          }
          else
          {
@@ -67,7 +210,28 @@
          }
      }
  
-@@ -411,9 +435,10 @@
+@@ -398,8 +453,20 @@
+      */
+     public boolean sendUseItem(EntityPlayer par1EntityPlayer, World par2World, ItemStack par3ItemStack)
+     {
++        PlayerInteractEvent event = ForgeEventFactory.onPlayerInteract(this.mc.thePlayer, Action.RIGHT_CLICK_AIR, 0, 0, 0, -1);
++        if (event.isCanceled())
++        {
++            return false;
++        }
++        
+         this.syncCurrentPlayItem();
+         this.netClientHandler.addToSendQueue(new Packet15Place(-1, -1, -1, 255, par1EntityPlayer.inventory.getCurrentItem(), 0.0F, 0.0F, 0.0F));
++        
++        if (par3ItemStack == null || event.useItem == Event.Result.DENY)
++        {
++            return false;
++        }
++        
+         int i = par3ItemStack.stackSize;
+         ItemStack itemstack1 = par3ItemStack.useItemRightClick(par2World, par1EntityPlayer);
+ 
+@@ -411,9 +478,10 @@
          {
              par1EntityPlayer.inventory.mainInventory[par1EntityPlayer.inventory.currentItem] = itemstack1;
  

--- a/patches/minecraft/net/minecraft/item/ItemInWorldManager.java.patch
+++ b/patches/minecraft/net/minecraft/item/ItemInWorldManager.java.patch
@@ -1,10 +1,9 @@
 --- ../src_base/minecraft/net/minecraft/item/ItemInWorldManager.java
 +++ ../src_work/minecraft/net/minecraft/item/ItemInWorldManager.java
-@@ -8,8 +8,19 @@
+@@ -8,8 +8,18 @@
  import net.minecraft.world.World;
  import net.minecraft.world.WorldServer;
  
-+import net.minecraftforge.common.ForgeHooks;
 +import net.minecraftforge.common.MinecraftForge;
 +import net.minecraftforge.event.Event;
 +import net.minecraftforge.event.ForgeEventFactory;
@@ -20,59 +19,110 @@
      /** The world object that this object is connected to. */
      public World theWorld;
  
-@@ -145,6 +156,13 @@
+@@ -143,43 +153,69 @@
+      */
+     public void onBlockClicked(int par1, int par2, int par3, int par4)
      {
-         if (!this.gameType.isAdventure() || this.thisPlayerMP.isCurrentToolAdventureModeExempt(par1, par2, par3))
-         {
-+            PlayerInteractEvent event = ForgeEventFactory.onPlayerInteract(thisPlayerMP, Action.LEFT_CLICK_BLOCK, par1, par2, par3, par4);
-+            if (event.isCanceled())
+-        if (!this.gameType.isAdventure() || this.thisPlayerMP.isCurrentToolAdventureModeExempt(par1, par2, par3))
+-        {
+-            if (this.isCreative())
+-            {
+-                if (!this.theWorld.extinguishFire((EntityPlayer)null, par1, par2, par3, par4))
+-                {
+-                    this.tryHarvestBlock(par1, par2, par3);
+-                }
++        PlayerInteractEvent event = ForgeEventFactory.onPlayerInteract(thisPlayerMP, Action.LEFT_CLICK_BLOCK, par1, par2, par3, par4);
++
++        boolean canBreak = !this.gameType.isAdventure() || this.thisPlayerMP.isCurrentToolAdventureModeExempt(par1, par2, par3);
++        canBreak = event.useItem == Event.Result.DEFAULT ? canBreak : event.useItem == Event.Result.ALLOW;
++
++        if (event.isCanceled())
++        {
++            thisPlayerMP.playerNetServerHandler.sendPacketToPlayer(new Packet53BlockChange(par1, par2, par3, theWorld));
++        }
++        else
++        {
++            this.initialDamage = this.curblockDamage;
++            float f = 1.0F;
++            int i1 = this.theWorld.getBlockId(par1, par2, par3);
++
++            Block block = Block.blocksList[i1];
++
++            if (block != null)
 +            {
-+                thisPlayerMP.playerNetServerHandler.sendPacketToPlayer(new Packet53BlockChange(par1, par2, par3, theWorld));
-+                return;
++                if (!this.isCreative() || !canBreak)
++                {
++                    f = block.getPlayerRelativeBlockHardness(thisPlayerMP, thisPlayerMP.worldObj, par1, par2, par3);
++                }
++                if (f < 1.0F && event.useBlock != Event.Result.DENY)
++                {
++                    block.onBlockClicked(theWorld, par1, par2, par3, thisPlayerMP);
++                }
++                if (event.useItem != Event.Result.DENY)
++                {
++                    theWorld.extinguishFire(thisPlayerMP, par1, par2, par3, par4);
++                }
++                else
++                {
++                    thisPlayerMP.playerNetServerHandler.sendPacketToPlayer(new Packet53BlockChange(par1, par2, par3, theWorld));
++                }
 +            }
 +
-             if (this.isCreative())
-             {
-                 if (!this.theWorld.extinguishFire((EntityPlayer)null, par1, par2, par3, par4))
-@@ -154,15 +172,33 @@
++            if (!canBreak)
++            {
++                if (f >= 1.0f)
++                {
++                    thisPlayerMP.playerNetServerHandler.sendPacketToPlayer(new Packet53BlockChange(par1, par2, par3, theWorld));
++                }
++            }
++            else if (i1 > 0 && f >= 1.0F)
++            {
++                this.tryHarvestBlock(par1, par2, par3);
              }
              else
              {
 -                this.theWorld.extinguishFire((EntityPlayer)null, par1, par2, par3, par4);
-                 this.initialDamage = this.curblockDamage;
-                 float f = 1.0F;
-                 int i1 = this.theWorld.getBlockId(par1, par2, par3);
- 
+-                this.initialDamage = this.curblockDamage;
+-                float f = 1.0F;
+-                int i1 = this.theWorld.getBlockId(par1, par2, par3);
+-
 -                if (i1 > 0)
 -                {
 -                    Block.blocksList[i1].onBlockClicked(this.theWorld, par1, par2, par3, this.thisPlayerMP);
 -                    f = Block.blocksList[i1].getPlayerRelativeBlockHardness(this.thisPlayerMP, this.thisPlayerMP.worldObj, par1, par2, par3);
-+                Block block = Block.blocksList[i1];
+-                }
+-
+-                if (i1 > 0 && f >= 1.0F)
+-                {
+-                    this.tryHarvestBlock(par1, par2, par3);
+-                }
+-                else
+-                {
+-                    this.isDestroyingBlock = true;
+-                    this.partiallyDestroyedBlockX = par1;
+-                    this.partiallyDestroyedBlockY = par2;
+-                    this.partiallyDestroyedBlockZ = par3;
+-                    int j1 = (int)(f * 10.0F);
+-                    this.theWorld.destroyBlockInWorldPartially(this.thisPlayerMP.entityId, par1, par2, par3, j1);
+-                    this.durabilityRemainingOnBlock = j1;
+-                }
+-            }
++                this.isDestroyingBlock = true;
++                this.partiallyDestroyedBlockX = par1;
++                this.partiallyDestroyedBlockY = par2;
++                this.partiallyDestroyedBlockZ = par3;
++                int j1 = (int)(f * 10.0F);
++                this.theWorld.destroyBlockInWorldPartially(this.thisPlayerMP.entityId, par1, par2, par3, j1);
++                this.durabilityRemainingOnBlock = j1;
++            }
++        }
 +
-+                if (block != null)
-+                {
-+                    if (event.useBlock != Event.Result.DENY)
-+                    {
-+                        block.onBlockClicked(theWorld, par1, par2, par3, thisPlayerMP);
-+                        theWorld.extinguishFire(thisPlayerMP, par1, par2, par3, par4);
-+                    }
-+                    else
-+                    {
-+                        thisPlayerMP.playerNetServerHandler.sendPacketToPlayer(new Packet53BlockChange(par1, par2, par3, theWorld));
-+                    }
-+                    f = block.getPlayerRelativeBlockHardness(thisPlayerMP, thisPlayerMP.worldObj, par1, par2, par3);
-+                }
-+
-+                if (event.useItem == Event.Result.DENY)
-+                {
-+                    if (f >= 1.0f)
-+                    {
-+                        thisPlayerMP.playerNetServerHandler.sendPacketToPlayer(new Packet53BlockChange(par1, par2, par3, theWorld));
-+                    }
-+                    return;
-                 }
++        if (!canBreak)
++        {
++            this.partiallyDestroyedBlockY = -1;
+         }
+     }
  
-                 if (i1 > 0 && f >= 1.0F)
 @@ -236,7 +272,7 @@
              block.onBlockHarvested(this.theWorld, par1, par2, par3, l, this.thisPlayerMP);
          }
@@ -82,8 +132,19 @@
  
          if (block != null && flag)
          {
-@@ -261,19 +297,30 @@
+@@ -251,29 +287,36 @@
+      */
+     public boolean tryHarvestBlock(int par1, int par2, int par3)
+     {
+-        if (this.gameType.isAdventure() && !this.thisPlayerMP.isCurrentToolAdventureModeExempt(par1, par2, par3))
++        if (this.gameType.isCreative() && this.thisPlayerMP.getHeldItem() != null && this.thisPlayerMP.getHeldItem().getItem() instanceof ItemSword)
+         {
+             return false;
          }
+-        else if (this.gameType.isCreative() && this.thisPlayerMP.getHeldItem() != null && this.thisPlayerMP.getHeldItem().getItem() instanceof ItemSword)
+-        {
+-            return false;
+-        }
          else
          {
 +            ItemStack stack = thisPlayerMP.getCurrentEquippedItem();
@@ -115,7 +176,7 @@
  
                  if (itemstack != null)
                  {
-@@ -285,6 +332,7 @@
+@@ -285,6 +328,7 @@
                      }
                  }
  
@@ -123,7 +184,7 @@
                  if (flag && flag1)
                  {
                      Block.blocksList[l].harvestBlock(this.theWorld, this.thisPlayerMP, par1, par2, par3, i1);
-@@ -325,6 +373,7 @@
+@@ -325,6 +369,7 @@
              if (itemstack1.stackSize == 0)
              {
                  par1EntityPlayer.inventory.mainInventory[par1EntityPlayer.inventory.currentItem] = null;
@@ -131,7 +192,7 @@
              }
  
              if (!par1EntityPlayer.isUsingItem())
-@@ -342,35 +391,56 @@
+@@ -342,35 +387,56 @@
       */
      public boolean activateBlockOrUseItem(EntityPlayer par1EntityPlayer, World par2World, ItemStack par3ItemStack, int par4, int par5, int par6, int par7, float par8, float par9, float par10)
      {
@@ -215,7 +276,7 @@
      }
  
      /**
-@@ -380,4 +450,13 @@
+@@ -380,4 +446,13 @@
      {
          this.theWorld = par1WorldServer;
      }

--- a/patches/minecraft/net/minecraft/network/NetServerHandler.java.patch
+++ b/patches/minecraft/net/minecraft/network/NetServerHandler.java.patch
@@ -103,20 +103,25 @@
                  {
                      return;
                  }
-@@ -502,7 +534,11 @@
-                 return;
-             }
+@@ -497,12 +529,11 @@
  
+         if (par1Packet15Place.getDirection() == 255)
+         {
+-            if (itemstack == null)
+-            {
+-                return;
+-            }
+-
 -            this.playerEntity.theItemInWorldManager.tryUseItem(this.playerEntity, worldserver, itemstack);
 +            PlayerInteractEvent event = ForgeEventFactory.onPlayerInteract(playerEntity, PlayerInteractEvent.Action.RIGHT_CLICK_AIR, 0, 0, 0, -1);
-+            if (event.useItem != Event.Result.DENY)
++            if (itemstack != null && event.useItem != Event.Result.DENY)
 +            {
 +                this.playerEntity.theItemInWorldManager.tryUseItem(this.playerEntity, worldserver, itemstack);
 +            }
          }
          else if (par1Packet15Place.getYPosition() >= this.mcServer.getBuildLimit() - 1 && (par1Packet15Place.getDirection() == 1 || par1Packet15Place.getYPosition() >= this.mcServer.getBuildLimit()))
          {
-@@ -511,7 +547,9 @@
+@@ -511,7 +542,9 @@
          }
          else
          {
@@ -127,7 +132,7 @@
              {
                  this.playerEntity.theItemInWorldManager.activateBlockOrUseItem(this.playerEntity, worldserver, itemstack, i, j, k, l, par1Packet15Place.getXOffset(), par1Packet15Place.getYOffset(), par1Packet15Place.getZOffset());
              }
-@@ -691,6 +729,8 @@
+@@ -691,6 +724,8 @@
                      }
  
                      ChatMessageComponent chatmessagecomponent = ChatMessageComponent.createFromTranslationWithSubstitutions("chat.type.text", new Object[] {this.playerEntity.getTranslatedEntityName(), s});
@@ -136,7 +141,7 @@
                      this.mcServer.getConfigurationManager().func_110459_a(chatmessagecomponent, false);
                  }
  
-@@ -838,7 +878,7 @@
+@@ -838,7 +873,7 @@
                      return;
                  }
  


### PR DESCRIPTION
I messed up when trying to update my last pull request (#715), and it was automatically "merged" / closed because there were no changes. This is it updated and resubmitted. The only difference is fixing an issue when block x or z is -1. Obviously those are valid block positions. Here's the old PR's comment:
- Cancelling the event on the client will not send a packet to the server, so no event will be fired on it.
- Left click block fires on client side.  
  - Setting useItem to DENY will prevent the block from being broken, but will still send a dig packet (block will still break in creative if server doesn't set it to DENY as well).
  - Setting useBlock to DENY will prevent the block's onBlockClicked method to be called.
- Setting useItem to ALLOW will allow blocks to be broken in adventure mode.
- onBlockClicked fires regardless of gamemode, as long as the block isn't broken instantly.
- Right click air, clicking without an item in hand will still send a packet to the server, causing a right click air event.

I believe these changes are for the better, they allow for more control over block breaking and interaction and generally make things more consistent - in my opinion. But depending on if and how people have used PlayerInteractEvent, they may have to rewrite some of their code to adjust for these changes.
