### PR TITLE
Added CommandPermissionEvent

### DIFF
--- a/common/net/minecraftforge/common/ForgeHooks.java
+++ b/common/net/minecraftforge/common/ForgeHooks.java
@@ -7,6 +7,8 @@ import java.util.HashSet;
 import java.util.List;
 
 import net.minecraft.block.Block;
+import net.minecraft.command.ICommand;
+import net.minecraft.command.ICommandSender;
 import net.minecraft.entity.EntityLiving;
 import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.entity.item.EntityItem;
@@ -27,6 +29,8 @@ import net.minecraft.util.MovingObjectPosition;
 import net.minecraft.util.WeightedRandom;
 import net.minecraft.util.WeightedRandomItem;
 import net.minecraft.world.World;
+import net.minecraftforge.event.CommandPermissionEvent;
+import net.minecraftforge.event.Event.Result;
 import net.minecraftforge.event.ForgeEventFactory;
 import net.minecraftforge.event.ServerChatEvent;
 import net.minecraftforge.event.entity.item.ItemTossEvent;
@@ -429,5 +433,22 @@ public class ForgeHooks
             return null;
         }
         return event.component;
+    }
+    
+    public static boolean onCommandPermissionEvent(ICommand command, ICommandSender sender, String[] parameters)
+    {
+        CommandPermissionEvent event = new CommandPermissionEvent(command, sender, parameters);
+        if (event.getResult() == Result.DEFAULT)
+        {
+            return command.canCommandSenderUseCommand(sender);
+        }
+        else if (event.getResult() == Result.ALLOW)
+        {
+            return true;
+        }
+        else
+        {
+            return false;
+        }
     }
 }

--- a/common/net/minecraftforge/event/CommandPermissionEvent.java
+++ b/common/net/minecraftforge/event/CommandPermissionEvent.java
@@ -1,0 +1,31 @@
+package net.minecraftforge.event;
+
+import net.minecraft.command.ICommand;
+import net.minecraft.command.ICommandSender;
+import net.minecraftforge.event.Event.HasResult;
+
+/**
+ * Determines if a command can be used by an {@link ICommandSender}.
+ * @author HoBoS_TaCo
+ */
+@HasResult
+public class CommandPermissionEvent extends Event
+{
+    public final ICommand command;
+    public final ICommandSender sender;
+    public final String[] parameters;
+    
+    /**
+     * Determines if a command can be used by an {@link ICommandSender}.
+     * @param command {@link ICommand} to be checked.
+     * @param sender Command user.
+     * @param parameters Command parameters following <i>ICommand.getCommandName()</i>
+     * @return ALLOW to allow, DENY to deny, DEFAULT for <i>ICommand.canCommandSenderUseCommand(ICommandSender sender)</i> to be used.
+     */
+    public CommandPermissionEvent(ICommand command, ICommandSender sender, String[] parameters)
+    {
+        this.command = command;
+        this.sender = sender;
+        this.parameters = parameters;
+    }
+}

--- a/patches/minecraft/net/minecraft/command/CommandHandler.java.patch
+++ b/patches/minecraft/net/minecraft/command/CommandHandler.java.patch
@@ -1,19 +1,25 @@
 --- ../src_base/minecraft/net/minecraft/command/CommandHandler.java
 +++ ../src_work/minecraft/net/minecraft/command/CommandHandler.java
-@@ -12,6 +12,9 @@
+@@ -8,9 +8,13 @@
+ import java.util.Map;
+ import java.util.Set;
+ import java.util.Map.Entry;
++
+ import net.minecraft.entity.player.EntityPlayerMP;
  import net.minecraft.util.ChatMessageComponent;
  import net.minecraft.util.EnumChatFormatting;
- 
++import net.minecraftforge.common.ForgeHooks;
 +import net.minecraftforge.common.MinecraftForge;
 +import net.minecraftforge.event.CommandEvent;
-+
+ 
  public class CommandHandler implements ICommandManager
  {
-     /** Map of Strings to the ICommand objects they represent */
-@@ -45,6 +48,16 @@
+@@ -43,8 +47,18 @@
+                 throw new CommandNotFoundException();
+             }
  
-             if (icommand.canCommandSenderUseCommand(par1ICommandSender))
-             {
++            if (ForgeHooks.onCommandPermissionEvent(icommand, par1ICommandSender, astring))
++            {
 +                CommandEvent event = new CommandEvent(icommand, par1ICommandSender, astring);
 +                if (MinecraftForge.EVENT_BUS.post(event))
 +                {


### PR DESCRIPTION
Added a CommandPermissionEvent. It's used for mods to check a command's permission, such as the vanilla commands, before CommandEvent is called or by doing it through commandMap, the hacky way.

It returns a result, ALLOW to allow the command to be used, DENY to deny use or DEFAULT for ICommand.canCommandSenderUseCommand(ICommandSender sender) to be used.
