### PR TITLE
EntityPopulate terrain event called during chunk generation when entities are populated

### DIFF
--- a/common/net/minecraftforge/event/terraingen/PopulateChunkEvent.java
+++ b/common/net/minecraftforge/event/terraingen/PopulateChunkEvent.java
@@ -4,6 +4,7 @@ import java.util.Random;
 
 import net.minecraft.world.World;
 import net.minecraft.world.chunk.IChunkProvider;
+import net.minecraftforge.event.Cancelable;
 import net.minecraftforge.event.world.*;
 
 public class PopulateChunkEvent extends ChunkProviderEvent
@@ -59,6 +60,20 @@ public class PopulateChunkEvent extends ChunkProviderEvent
         {
             super(chunkProvider, world, rand, chunkX, chunkZ, hasVillageGenerated);
             this.type = type;
+        }
+    }
+    
+    /**
+     * This event is fired when a chunk is called to determine Entities to spawn
+     * during its generation.
+     * 
+     * You can set the result to DENY to prevent the default Entity spawning.
+     */
+    @Cancelable
+    public static class EntityPopulate extends PopulateChunkEvent {
+        public EntityPopulate(World world, Random rand, int chunkX, int chunkZ)
+        {
+            super(null, world, rand, chunkX, chunkZ, false);
         }
     }
 }

--- a/common/net/minecraftforge/event/terraingen/TerrainGen.java
+++ b/common/net/minecraftforge/event/terraingen/TerrainGen.java
@@ -37,6 +37,12 @@ public abstract class TerrainGen
         return event.getResult() != Result.DENY;
     }
     
+    public static boolean entityPopulate(World world, Random rand, int chunkX, int chunkZ)
+    {
+        PopulateChunkEvent.EntityPopulate event = new PopulateChunkEvent.EntityPopulate(world, rand, chunkX, chunkZ);
+        return MinecraftForge.TERRAIN_GEN_BUS.post(event);
+    }  
+    
     public static boolean decorate(World world, Random rand, int chunkX, int chunkZ, Decorate.EventType type)
     {
         Decorate event = new Decorate(world, rand, chunkX, chunkZ, type);

--- a/patches/minecraft/net/minecraft/world/SpawnerAnimals.java.patch
+++ b/patches/minecraft/net/minecraft/world/SpawnerAnimals.java.patch
@@ -8,18 +8,19 @@
  import java.util.HashMap;
  import java.util.Iterator;
  import java.util.List;
-@@ -17,6 +19,10 @@
+@@ -17,6 +19,11 @@
  import net.minecraft.world.biome.SpawnListEntry;
  import net.minecraft.world.chunk.Chunk;
  
 +import net.minecraftforge.common.MinecraftForge;
 +import net.minecraftforge.event.Event.Result;
 +import net.minecraftforge.event.ForgeEventFactory;
++import net.minecraftforge.event.terraingen.TerrainGen;
 +
  public final class SpawnerAnimals
  {
      /** The 17x17 area around the player where mobs can spawn */
-@@ -85,9 +91,12 @@
+@@ -85,9 +92,12 @@
              {
                  EnumCreatureType enumcreaturetype = aenumcreaturetype[j1];
  
@@ -33,7 +34,7 @@
                      label110:
  
                      while (iterator.hasNext())
-@@ -165,13 +174,17 @@
+@@ -165,13 +175,17 @@
  
                                                              entityliving.setLocationAndAngles((double)f, (double)f1, (double)f2, par1WorldServer.rand.nextFloat() * 360.0F, 0.0F);
  
@@ -55,7 +56,7 @@
                                                                  {
                                                                      continue label110;
                                                                  }
-@@ -217,7 +230,8 @@
+@@ -217,7 +231,8 @@
          else
          {
              int l = par1World.getBlockId(par2, par3 - 1, par4);
@@ -65,3 +66,14 @@
          }
      }
  
+@@ -226,6 +241,10 @@
+      */
+     public static void performWorldGenSpawning(World par0World, BiomeGenBase par1BiomeGenBase, int par2, int par3, int par4, int par5, Random par6Random)
+     {
++        if (TerrainGen.entityPopulate(par0World, par6Random, MathHelper.floor_float(par2 / 16f), MathHelper.floor_float(par3 / 16f)))
++        {
++            return;
++        }
+         List list = par1BiomeGenBase.getSpawnableList(EnumCreatureType.creature);
+ 
+         if (!list.isEmpty())


### PR DESCRIPTION
Essentially the same as other terrain events but specifically for entity generation. Provides better compatability with dimension mods than other terrain events, which are less likely to be called.
- Allows spawning of additional entities alongside regular chunk generation
- Allows supplanting of chunk spawning system
- Possible to do a doChunkSpawning gamerule
