### PR TITLE
Added PlayerOpenContainerEvent and added ForgeHooks.canInteractWith

### DIFF
--- a/common/net/minecraftforge/common/ForgeHooks.java
+++ b/common/net/minecraftforge/common/ForgeHooks.java
@@ -11,6 +11,7 @@ import net.minecraft.entity.EntityLiving;
 import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.entity.item.EntityItem;
 import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.inventory.Container;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemArmor;
 import net.minecraft.item.ItemAxe;
@@ -27,6 +28,7 @@ import net.minecraft.util.MovingObjectPosition;
 import net.minecraft.util.WeightedRandom;
 import net.minecraft.util.WeightedRandomItem;
 import net.minecraft.world.World;
+import net.minecraftforge.event.Event;
 import net.minecraftforge.event.ForgeEventFactory;
 import net.minecraftforge.event.ServerChatEvent;
 import net.minecraftforge.event.entity.item.ItemTossEvent;
@@ -38,6 +40,7 @@ import net.minecraftforge.event.entity.living.LivingEvent.LivingUpdateEvent;
 import net.minecraftforge.event.entity.living.LivingFallEvent;
 import net.minecraftforge.event.entity.living.LivingHurtEvent;
 import net.minecraftforge.event.entity.living.LivingSetAttackTargetEvent;
+import net.minecraftforge.event.entity.player.PlayerOpenContainerEvent;
 
 public class ForgeHooks
 {
@@ -429,5 +432,12 @@ public class ForgeHooks
             return null;
         }
         return event.component;
+    }
+    
+    public static boolean canInteractWith(EntityPlayer player, Container openContainer)
+    {
+        PlayerOpenContainerEvent event = new PlayerOpenContainerEvent(player, openContainer);
+        MinecraftForge.EVENT_BUS.post(event);
+        return event.getResult() == Event.Result.DEFAULT ? event.canInteractWith : event.getResult() == Event.Result.ALLOW ? true : false;
     }
 }

--- a/common/net/minecraftforge/event/entity/player/PlayerOpenContainerEvent.java
+++ b/common/net/minecraftforge/event/entity/player/PlayerOpenContainerEvent.java
@@ -1,0 +1,29 @@
+package net.minecraftforge.event.entity.player;
+
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.inventory.Container;
+import net.minecraftforge.event.Event.HasResult;
+
+@HasResult
+public class PlayerOpenContainerEvent extends PlayerEvent
+{
+
+    public final boolean canInteractWith;
+
+    /**
+     * This event is fired when a player attempts to view a container during
+     * player tick.
+     * 
+     * setResult ALLOW to allow the container to stay open
+     * setResult DENY to force close the container (denying access)
+     * 
+     * DEFAULT is vanilla behaviour
+     * 
+     */
+
+    public PlayerOpenContainerEvent(EntityPlayer player, Container openContainer)
+    {
+        super(player);
+        this.canInteractWith = openContainer.canInteractWith(player);
+    }
+}

--- a/patches/minecraft/net/minecraft/entity/player/EntityPlayer.java.patch
+++ b/patches/minecraft/net/minecraft/entity/player/EntityPlayer.java.patch
@@ -64,6 +64,15 @@
                  if (this.itemInUseCount <= 25 && this.itemInUseCount % 4 == 0)
                  {
                      this.updateItemUse(itemstack, 5);
+@@ -321,7 +341,7 @@
+ 
+         super.onUpdate();
+ 
+-        if (!this.worldObj.isRemote && this.openContainer != null && !this.openContainer.canInteractWith(this))
++        if (!this.worldObj.isRemote && this.openContainer != null && !ForgeHooks.canInteractWith(this, this.openContainer))
+         {
+             this.closeScreen();
+             this.openContainer = this.inventoryContainer;
 @@ -429,7 +449,7 @@
                  vec31.rotateAroundX(-this.rotationPitch * (float)Math.PI / 180.0F);
                  vec31.rotateAroundY(-this.rotationYaw * (float)Math.PI / 180.0F);

--- a/patches/minecraft/net/minecraft/entity/player/EntityPlayerMP.java.patch
+++ b/patches/minecraft/net/minecraft/entity/player/EntityPlayerMP.java.patch
@@ -45,6 +45,15 @@
      /**
       * Called to update the entity's position/logic.
       */
+@@ -254,7 +247,7 @@
+         --this.initialInvulnerability;
+         this.openContainer.detectAndSendChanges();
+ 
+-        if (!this.worldObj.isRemote && !this.openContainer.canInteractWith(this))
++        if (!this.worldObj.isRemote && !ForgeHooks.canInteractWith(this, this.openContainer))
+         {
+             this.closeScreen();
+             this.openContainer = this.inventoryContainer;
 @@ -290,7 +283,10 @@
                  if (chunkcoordintpair != null && this.worldObj.blockExists(chunkcoordintpair.chunkXPos << 4, 0, chunkcoordintpair.chunkZPos << 4))
                  {


### PR DESCRIPTION
- Used to override the canInteractWith during player tick
- Event can be cancelled to DENY and force close the Container
- Use allowInteraction() to force Container to stay open/accessible
- Defaults to Vanilla behaviour in any other instance.

Required for LittleBlocks Mod and to Assist Gullivers Mod
