### PR TITLE
Pass arguments to install.sh and install.cmd to install.py

### DIFF
--- a/install/install.cmd
+++ b/install/install.cmd
@@ -1,3 +1,3 @@
 @echo off
-.\fml\python\python_fml install.py
+.\fml\python\python_fml install.py %*
 pause

--- a/install/install.sh
+++ b/install/install.sh
@@ -1,2 +1,2 @@
 #!/bin/bash
-python install.py
+python install.py "$@"


### PR DESCRIPTION
Without this, any arguments passed to `install.sh` (and `install.cmd`) would be discarded rather than given to `install.py`, and so `install.py` had to be invoked manually in order to use arguments.
