### PR TITLE
Change water bottles to contain 250mB of liquid

### DIFF
--- a/common/net/minecraftforge/fluids/FluidContainerRegistry.java
+++ b/common/net/minecraftforge/fluids/FluidContainerRegistry.java
@@ -29,6 +29,7 @@ public abstract class FluidContainerRegistry
     private static Set<List> emptyContainers = new HashSet();
 
     public static final int BUCKET_VOLUME = 1000;
+    public static final int BOTTLE_VOLUME = BUCKET_VOLUME / 4;
     public static final ItemStack EMPTY_BUCKET = new ItemStack(Item.bucketEmpty);
     public static final ItemStack EMPTY_BOTTLE = new ItemStack(Item.glassBottle);
     private static final ItemStack NULL_EMPTYCONTAINER = new ItemStack(Item.bucketEmpty);
@@ -37,7 +38,7 @@ public abstract class FluidContainerRegistry
     {
         registerFluidContainer(FluidRegistry.WATER, new ItemStack(Item.bucketWater), EMPTY_BUCKET);
         registerFluidContainer(FluidRegistry.LAVA,  new ItemStack(Item.bucketLava),  EMPTY_BUCKET);
-        registerFluidContainer(FluidRegistry.WATER, new ItemStack(Item.potion),      EMPTY_BOTTLE);
+        registerFluidContainer(new FluidStack(FluidRegistry.WATER, BOTTLE_VOLUME), new ItemStack(Item.potion), EMPTY_BOTTLE);
     }
 
     private FluidContainerRegistry(){}


### PR DESCRIPTION
Looking at Vanilla, it should be a volume of 333mB, since one bucket of water placed in a cauldron equals 3 bottles of water. I'm suggesting 250mB because that's easier to work with. 4 bottles would be exactly one bucket. And the cauldron isn't a full block anyway so let's just say some of the water is lost when pouring it in.

I don't think this affects mods using bottles in a negative way at all. There shouldn't be a reason not to change it now, to set a sort of standard. Most mod bottles that are meant to store the liquid (thinking of creosote), can be stacked like empty ones, so one stack of 64 could hold up to 16 buckets worth of liquid. Not to mention mod bottles could contain any amount of liquid they want, this is only water bottles.

Earlier PR with a similar goal: #366

---

> **[copyboy:](https://github.com/MinecraftForge/MinecraftForge/pull/795#issuecomment-24896454)** It's not really about the amount the water in the bottle, it's more about setting the volume of the bottle to something that makes more sense. A standard that other mods can, but don't have to follow. [...]

---

> **[copyboy:](https://github.com/MinecraftForge/MinecraftForge/pull/795#issuecomment-25049732)** I wouldn't be opposed to 200mB, 125mB or 100mB (making sure a whole number of bottles equals a bucket of liquid) [...] I'd be much happier to change this regardless of the amount we set it to, than having it stay the way it is.
