### PR TITLE
Added ItemTooltipEvent

### DIFF
--- a/common/net/minecraftforge/event/ForgeEventFactory.java
+++ b/common/net/minecraftforge/event/ForgeEventFactory.java
@@ -15,6 +15,7 @@ import net.minecraftforge.event.Event.Result;
 import net.minecraftforge.event.entity.living.LivingPackSizeEvent;
 import net.minecraftforge.event.entity.living.LivingSpawnEvent;
 import net.minecraftforge.event.entity.living.LivingSpawnEvent.AllowDespawn;
+import net.minecraftforge.event.entity.player.ItemTooltipEvent;
 import net.minecraftforge.event.entity.player.PlayerDestroyItemEvent;
 import net.minecraftforge.event.entity.player.PlayerEvent;
 import net.minecraftforge.event.entity.player.PlayerInteractEvent;
@@ -98,5 +99,12 @@ public class ForgeEventFactory
         BlockEvent.HarvestDropsEvent event = new BlockEvent.HarvestDropsEvent(x, y, z, world, block, meta, fortune, dropChance, drops, player, silkTouch);
         MinecraftForge.EVENT_BUS.post(event);
         return event.dropChance;
+    }
+    
+    public static ItemTooltipEvent onItemTooltip(ItemStack itemStack, EntityPlayer entityPlayer, List<String> toolTip, boolean showAdvancedItemTooltips)
+    {
+        ItemTooltipEvent event = new ItemTooltipEvent(itemStack, entityPlayer, toolTip, showAdvancedItemTooltips);
+        MinecraftForge.EVENT_BUS.post(event);
+        return event;
     }
 }

--- a/common/net/minecraftforge/event/entity/player/ItemTooltipEvent.java
+++ b/common/net/minecraftforge/event/entity/player/ItemTooltipEvent.java
@@ -1,0 +1,32 @@
+package net.minecraftforge.event.entity.player;
+
+import java.util.List;
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.item.ItemStack;
+
+public class ItemTooltipEvent extends PlayerEvent
+{
+    /**
+     * Whether the advanced information on item tooltips is being shown, toggled by F3+H.
+     */
+    public final boolean showAdvancedItemTooltips;
+    /**
+     * The {@link ItemStack} with the tooltip.
+     */
+    public final ItemStack itemStack;
+    /**
+     * The {@link ItemStack} tooltip.
+     */
+    public final List<String> toolTip;
+
+    /**
+     * This event is fired in {@link ItemStack#getTooltip(EntityPlayer, boolean)}, which in turn is called from it's respective GUIContainer.
+     */
+    public ItemTooltipEvent(ItemStack itemStack, EntityPlayer entityPlayer, List<String> toolTip, boolean showAdvancedItemTooltips)
+    {
+        super(entityPlayer);
+        this.itemStack = itemStack;
+        this.toolTip = toolTip;
+        this.showAdvancedItemTooltips = showAdvancedItemTooltips;
+    }
+}

--- a/patches/minecraft/net/minecraft/item/ItemStack.java.patch
+++ b/patches/minecraft/net/minecraft/item/ItemStack.java.patch
@@ -1,6 +1,14 @@
 --- ../src_base/minecraft/net/minecraft/item/ItemStack.java
 +++ ../src_work/minecraft/net/minecraft/item/ItemStack.java
-@@ -252,7 +252,9 @@
+@@ -29,6 +29,7 @@
+ import net.minecraft.util.Icon;
+ import net.minecraft.util.StatCollector;
+ import net.minecraft.world.World;
++import net.minecraftforge.event.ForgeEventFactory;
+ 
+ public final class ItemStack
+ {
+@@ -252,7 +253,9 @@
       */
      public boolean isItemDamaged()
      {
@@ -11,7 +19,7 @@
      }
  
      /**
-@@ -260,6 +262,10 @@
+@@ -260,6 +263,10 @@
       */
      public int getItemDamageForDisplay()
      {
@@ -22,7 +30,7 @@
          return this.itemDamage;
      }
  
-@@ -268,6 +274,10 @@
+@@ -268,6 +275,10 @@
       */
      public int getItemDamage()
      {
@@ -33,7 +41,7 @@
          return this.itemDamage;
      }
  
-@@ -276,6 +286,12 @@
+@@ -276,6 +287,12 @@
       */
      public void setItemDamage(int par1)
      {
@@ -46,7 +54,7 @@
          this.itemDamage = par1;
  
          if (this.itemDamage < 0)
-@@ -289,7 +305,7 @@
+@@ -289,7 +306,7 @@
       */
      public int getMaxDamage()
      {
@@ -55,7 +63,7 @@
      }
  
      /**
-@@ -327,8 +343,8 @@
+@@ -327,8 +344,8 @@
                  }
              }
  
@@ -66,7 +74,7 @@
          }
      }
  
-@@ -396,7 +412,7 @@
+@@ -396,7 +413,7 @@
       */
      public boolean canHarvestBlock(Block par1Block)
      {
@@ -75,7 +83,12 @@
      }
  
      public boolean func_111282_a(EntityPlayer par1EntityPlayer, EntityLivingBase par2EntityLivingBase)
-@@ -737,10 +753,16 @@
+@@ -733,14 +750,21 @@
+         {
+             arraylist.add("Durability: " + (this.getMaxDamage() - this.getItemDamageForDisplay()) + " / " + this.getMaxDamage());
+         }
++        ForgeEventFactory.onItemTooltip(this, par1EntityPlayer, arraylist, par2);
+ 
          return arraylist;
      }
  


### PR DESCRIPTION
This event is fired at the end of ItemStack.getTooltip(EntityPlayer,
boolean), which in turn is called from it's respective GUIContainer. It
allows an itemstack's tooltip to be changed depending on the player,
itemstack or whether the advanced information on item tooltips is being
shown, toggled by F3+H.
