### PR TITLE
Added custom EnumGameTypes

### DIFF
--- a/client/net/minecraftforge/client/EnumHelperClient.java
+++ b/client/net/minecraftforge/client/EnumHelperClient.java
@@ -17,9 +17,14 @@ public class EnumHelperClient extends EnumHelper
         {EnumRarity.class, int.class, String.class}
     };
     
+    /**
+     * To be removed in 1.7
+     * @see EnumHelper#addGameType(String, int, String)
+     */
+    @Deprecated
     public static EnumGameType addGameType(String name, int id, String displayName)
     {
-        return addEnum(EnumGameType.class, name, id, displayName);
+        return EnumHelper.addGameType(name, id, displayName);
     }
     
     public static EnumOptions addOptions(String name, String langName, boolean isSlider, boolean isToggle)

--- a/common/net/minecraftforge/common/EnumHelper.java
+++ b/common/net/minecraftforge/common/EnumHelper.java
@@ -18,6 +18,7 @@ import net.minecraft.item.EnumArmorMaterial;
 import net.minecraft.item.EnumToolMaterial;
 import net.minecraft.util.EnumArt;
 import net.minecraft.util.EnumMovingObjectType;
+import net.minecraft.world.EnumGameType;
 import net.minecraft.world.EnumSkyBlock;
 import net.minecraft.world.gen.structure.EnumDoor;
 import net.minecraftforge.classloading.FMLForgePlugin;
@@ -42,6 +43,7 @@ public class EnumHelper
         {EnumDoor.class},
         {EnumEnchantmentType.class},
         {EnumEntitySize.class},
+        {EnumGameType.class, int.class, String.class},
         {EnumMobType.class},
         {EnumMovingObjectType.class},
         {EnumSkyBlock.class, int.class},
@@ -80,6 +82,10 @@ public class EnumHelper
     public static EnumEntitySize addEntitySize(String name)
     {
         return addEnum(EnumEntitySize.class, name);
+    }
+    public static EnumGameType addGameType(String name, int id, String displayName)
+    {
+        return addEnum(EnumGameType.class, name, id, displayName);
     }
     public static EnumMobType addMobType(String name)
     {

--- a/common/net/minecraftforge/common/GameTypeManager.java
+++ b/common/net/minecraftforge/common/GameTypeManager.java
@@ -1,0 +1,56 @@
+package net.minecraftforge.common;
+
+import java.util.List;
+import net.minecraft.world.EnumGameType;
+import com.google.common.collect.Lists;
+import cpw.mods.fml.relauncher.Side;
+import cpw.mods.fml.relauncher.SideOnly;
+
+public class GameTypeManager
+{
+    public static final List<EnumGameType> customGameTypes = Lists.newArrayList();
+
+    /**
+     * Used by EnumGameType.
+     * @see EnumGameType#getByID(int)
+     */
+    public static EnumGameType getCustomByID(int id)
+    {
+        for (EnumGameType customGameType : customGameTypes)
+        {
+            if (customGameType.getID() == id)
+            {
+                return customGameType;
+            }
+        }
+        
+        return EnumGameType.SURVIVAL;
+    }
+
+    /**
+     * Used by EnumGameType.
+     * @see EnumGameType#getByName(String)
+     */
+    @SideOnly(Side.CLIENT)
+    public static EnumGameType getCustomByName(String name)
+    {
+        for (EnumGameType customGameType : customGameTypes)
+        {
+            if (customGameType.getName().equals(name))
+            {
+                return customGameType;
+            }
+        }
+        
+        return EnumGameType.SURVIVAL;
+    }
+    
+    /**
+     * To be called sometime before the server is started or the Singleplayer button in clicked.
+     * @param gameType The custom EnumGameType to add.
+     */
+    public static void registerGameType(EnumGameType gameType)
+    {
+        customGameTypes.add(gameType);
+    }
+}

--- a/patches/minecraft/net/minecraft/client/gui/GuiCreateWorld.java.patch
+++ b/patches/minecraft/net/minecraft/client/gui/GuiCreateWorld.java.patch
@@ -1,6 +1,63 @@
 --- ../src_base/minecraft/net/minecraft/client/gui/GuiCreateWorld.java
 +++ ../src_work/minecraft/net/minecraft/client/gui/GuiCreateWorld.java
-@@ -376,7 +376,7 @@
+@@ -12,6 +12,7 @@
+ import net.minecraft.world.WorldType;
+ import net.minecraft.world.storage.ISaveFormat;
+ import net.minecraft.world.storage.WorldInfo;
++import net.minecraftforge.common.GameTypeManager;
+ import org.lwjgl.input.Keyboard;
+ 
+ @SideOnly(Side.CLIENT)
+@@ -76,6 +77,8 @@
+ 
+     /** Generator options to use when creating the world. */
+     public String generatorOptionsToUse = "";
++
++    public int customGameTypeIndex = 0;
+ 
+     /**
+      * If the world name is one of these, it'll be surrounded with underscores.
+@@ -321,16 +324,29 @@
+                 }
+                 else
+                 {
+-                    if (!this.commandsToggled)
+-                    {
+-                        this.commandsAllowed = false;
+-                    }
+-
+-                    this.gameMode = "survival";
+-                    this.updateButtonText();
+-                    this.buttonAllowCommands.enabled = true;
+-                    this.buttonBonusItems.enabled = true;
+-                    this.isHardcore = false;
++                    if (this.customGameTypeIndex == GameTypeManager.customGameTypes.size() || GameTypeManager.customGameTypes.size() == 0)
++                    {
++                        if (!this.commandsToggled)
++                        {
++                            this.commandsAllowed = false;
++                        }
++
++                        this.gameMode = "survival";
++                        this.updateButtonText();
++                        this.buttonAllowCommands.enabled = true;
++                        this.buttonBonusItems.enabled = true;
++                        this.isHardcore = false;
++                        customGameTypeIndex = 0;
++                    }
++                    else
++                    {
++                        this.gameMode = GameTypeManager.customGameTypes.get(customGameTypeIndex).getName();
++                        this.updateButtonText();
++                        this.buttonAllowCommands.enabled = true;
++                        this.buttonBonusItems.enabled = true;
++                        this.isHardcore = false;
++                        customGameTypeIndex++;
++                    }
+                 }
+ 
+                 this.updateButtonText();
+@@ -376,7 +392,7 @@
              }
              else if (par1GuiButton.id == 8)
              {
@@ -9,7 +66,7 @@
              }
          }
      }
-@@ -394,7 +394,7 @@
+@@ -394,7 +410,7 @@
          this.buttonBonusItems.drawButton = this.moreOptions;
          this.buttonWorldType.drawButton = this.moreOptions;
          this.buttonAllowCommands.drawButton = this.moreOptions;

--- a/patches/minecraft/net/minecraft/client/gui/GuiSelectWorld.java.patch
+++ b/patches/minecraft/net/minecraft/client/gui/GuiSelectWorld.java.patch
@@ -1,0 +1,19 @@
+--- ../src_base/minecraft/net/minecraft/client/gui/GuiSelectWorld.java
++++ ../src_work/minecraft/net/minecraft/client/gui/GuiSelectWorld.java
+@@ -16,6 +16,7 @@
+ import net.minecraft.world.storage.ISaveHandler;
+ import net.minecraft.world.storage.SaveFormatComparator;
+ import net.minecraft.world.storage.WorldInfo;
++import net.minecraftforge.common.GameTypeManager;
+ 
+ @SideOnly(Side.CLIENT)
+ public class GuiSelectWorld extends GuiScreen
+@@ -48,7 +49,7 @@
+     /**
+      * The game mode text that is displayed with each world on the world selection list.
+      */
+-    private String[] localizedGameModeText = new String[3];
++    private String[] localizedGameModeText = new String[3 + GameTypeManager.customGameTypes.size()];
+ 
+     /** set to true if you arein the process of deleteing a world/save */
+     private boolean deleting;

--- a/patches/minecraft/net/minecraft/client/gui/GuiWorldSlot.java.patch
+++ b/patches/minecraft/net/minecraft/client/gui/GuiWorldSlot.java.patch
@@ -1,0 +1,11 @@
+--- ../src_base/minecraft/net/minecraft/client/gui/GuiWorldSlot.java
++++ ../src_work/minecraft/net/minecraft/client/gui/GuiWorldSlot.java
+@@ -90,6 +90,8 @@
+         {
+             s2 = GuiSelectWorld.func_82314_j(this.parentWorldGui)[saveformatcomparator.getEnumGameType().getID()];
+ 
++            if (s2 == null) { s2 = I18n.getString("selectWorld.gameMode." + saveformatcomparator.getEnumGameType().getName()); }
++            
+             if (saveformatcomparator.isHardcoreModeEnabled())
+             {
+                 s2 = EnumChatFormatting.DARK_RED + I18n.getString("gameMode.hardcore") + EnumChatFormatting.RESET;

--- a/patches/minecraft/net/minecraft/client/multiplayer/PlayerControllerMP.java.patch
+++ b/patches/minecraft/net/minecraft/client/multiplayer/PlayerControllerMP.java.patch
@@ -11,6 +11,15 @@
  @SideOnly(Side.CLIENT)
  public class PlayerControllerMP
  {
+@@ -117,7 +121,7 @@
+ 
+     public boolean shouldDrawHUD()
+     {
+-        return this.currentGameType.isSurvivalOrAdventure();
++        return isNotCreative();
+     }
+ 
+     /**
 @@ -125,6 +129,12 @@
       */
      public boolean onPlayerDestroyBlock(int par1, int par2, int par3, int par4)
@@ -79,3 +88,12 @@
              }
  
              return true;
+@@ -487,7 +512,7 @@
+ 
+     public boolean func_78763_f()
+     {
+-        return this.currentGameType.isSurvivalOrAdventure();
++        return isNotCreative();
+     }
+ 
+     /**

--- a/patches/minecraft/net/minecraft/world/EnumGameType.java.patch
+++ b/patches/minecraft/net/minecraft/world/EnumGameType.java.patch
@@ -1,0 +1,27 @@
+--- ../src_base/minecraft/net/minecraft/world/EnumGameType.java
++++ ../src_work/minecraft/net/minecraft/world/EnumGameType.java
+@@ -3,6 +3,7 @@
+ import cpw.mods.fml.relauncher.Side;
+ import cpw.mods.fml.relauncher.SideOnly;
+ import net.minecraft.entity.player.PlayerCapabilities;
++import net.minecraftforge.common.GameTypeManager;
+ 
+ public enum EnumGameType
+ {
+@@ -101,7 +102,7 @@
+             }
+         }
+ 
+-        return SURVIVAL;
++        return GameTypeManager.getCustomByID(par0);
+     }
+ 
+     @SideOnly(Side.CLIENT)
+@@ -124,6 +125,6 @@
+             }
+         }
+ 
+-        return SURVIVAL;
++        return GameTypeManager.getCustomByName(par0Str);
+     }
+ }


### PR DESCRIPTION
These additions will allow custom EnumGameTypes to be added which also appear correctly in world select, world create and with the gamemode command.

All mods need to do is:

``` java
EnumGameType gameType = EnumHelper.addGameType("CUSTOM", "3", "customType");
LanguageRegistry.instance().addStringLocalization("gameMode.customType", "Custom Mode");
LanguageRegistry.instance().addStringLocalization("selectWorld.gameMode.customType", "Custom");
LanguageRegistry.instance().addStringLocalization("selectWorld.gameMode.customType.line1", "This is Custom Mode, it ");
LanguageRegistry.instance().addStringLocalization("selectWorld.gameMode.customType.line2", "is very fun.");
GameTypeManager.registerGameType(gameType);
```
- When mods implementing custom game types are removed worlds using these types automatically switch back to survival mode.
- `EnumHelperClient.addGameType(String, int, String)` was moved to EnumHelperClient as it's used on the server as well.
- PlayerControllerMP changes were due to the HUD not displaying on custom game modes.
