### PR TITLE
Moved initVanillaEntries to init because otherwise the OreRegisterEvent doesn't fire for them or fires too soon

### DIFF
--- a/common/net/minecraftforge/common/ForgeDummyContainer.java
+++ b/common/net/minecraftforge/common/ForgeDummyContainer.java
@@ -178,6 +178,12 @@ public class ForgeDummyContainer extends DummyModContainer implements WorldAcces
     {
         ForgeChunkManager.captureConfig(evt.getModConfigurationDirectory());
     }
+    
+    @Subscribe
+    public void init(FMLInitializationEvent evt)
+    {
+        OreDictionary.initVanillaEntries();
+    }
 
     @Subscribe
     public void postInit(FMLPostInitializationEvent evt)

--- a/common/net/minecraftforge/oredict/OreDictionary.java
+++ b/common/net/minecraftforge/oredict/OreDictionary.java
@@ -31,10 +31,6 @@ public class OreDictionary
      */
     public static final int WILDCARD_VALUE = Short.MAX_VALUE;
 
-    static {
-        initVanillaEntries();
-    }
-
     public static void initVanillaEntries()
     {
         if (!hasInit)
@@ -58,6 +54,8 @@ public class OreDictionary
             registerOre("oreQuartz", Block.oreNetherQuartz);
             registerOre("stone", Block.stone);
             registerOre("cobblestone", Block.cobblestone);
+            registerOre("glass", Block.glass);
+            registerOre("slimeball", Item.slimeBall);
         }
 
         // Build our list of items to replace with ore tags


### PR DESCRIPTION
Moved initVanillaEntries to init because otherwise the OreRegisterEvent doesn't fire for them or fires too soon before any mod can register an event listener and added glass and slimeballs to the ore dictionary
