### PR TITLE
Fixed localization for water and lava fluids

### DIFF
--- a/common/net/minecraftforge/fluids/Fluid.java
+++ b/common/net/minecraftforge/fluids/Fluid.java
@@ -106,6 +106,12 @@ public class Fluid
 
     public Fluid setUnlocalizedName(String unlocalizedName)
     {
+        this.unlocalizedName = "fluid." + unlocalizedName;
+        return this;
+    }
+
+    public Fluid setUnlocalizedNameWithoutPrefix(String unlocalizedName)
+    {
         this.unlocalizedName = unlocalizedName;
         return this;
     }

--- a/common/net/minecraftforge/fluids/FluidRegistry.java
+++ b/common/net/minecraftforge/fluids/FluidRegistry.java
@@ -25,8 +25,8 @@ public abstract class FluidRegistry
     static BiMap<String, Integer> fluidIDs = HashBiMap.create();
     static BiMap<Block, Fluid> fluidBlocks;
     
-    public static final Fluid WATER = new Fluid("water").setBlockID(Block.waterStill.blockID).setUnlocalizedName(Block.waterStill.getUnlocalizedName()+".name");
-    public static final Fluid LAVA = new Fluid("lava").setBlockID(Block.lavaStill.blockID).setLuminosity(15).setDensity(3000).setViscosity(6000).setTemperature(1300).setUnlocalizedName(Block.lavaStill.getUnlocalizedName()+".name");
+    public static final Fluid WATER = new Fluid("water").setBlockID(Block.waterStill.blockID).setUnlocalizedNameWithoutPrefix(Block.waterStill.getUnlocalizedName()+".name");
+    public static final Fluid LAVA = new Fluid("lava").setBlockID(Block.lavaStill.blockID).setLuminosity(15).setDensity(3000).setViscosity(6000).setTemperature(1300).setUnlocalizedNameWithoutPrefix(Block.lavaStill.getUnlocalizedName()+".name");
 
     public static int renderIdFluid = -1;
 


### PR DESCRIPTION
Currently FluidRegistry.WATER.getLocalizedName() return "fluid.tile.water" string instead of "Water"

Before: ![Before](http://i.imgur.com/89tVSHZ.png)

After: ![After](http://i.imgur.com/2YDv6n2.png)
