### PR TITLE
Gave INetworkManager Access to the socket

### DIFF
--- a/patches/minecraft/net/minecraft/network/INetworkManager.java.patch
+++ b/patches/minecraft/net/minecraft/network/INetworkManager.java.patch
@@ -1,0 +1,9 @@
+--- ../src_base/minecraft/net/minecraft/network/INetworkManager.java
++++ ../src_work/minecraft/net/minecraft/network/INetworkManager.java
+@@ -53,4 +53,6 @@
+ 
+     @SideOnly(Side.CLIENT)
+     void closeConnections();
++
++	Socket getSocket();
+ }

--- a/patches/minecraft/net/minecraft/network/MemoryConnection.java.patch
+++ b/patches/minecraft/net/minecraft/network/MemoryConnection.java.patch
@@ -1,0 +1,15 @@
+--- ../src_base/minecraft/net/minecraft/network/MemoryConnection.java
++++ ../src_work/minecraft/net/minecraft/network/MemoryConnection.java
+@@ -176,4 +176,12 @@
+             this.readPacketCache.add(par1Packet);
+         }
+     }
++    
++    /**
++     * Returns the socket for this paired connection.
++     */
++    public Socket getSocket() 
++	{
++		return this.pairedConnection.getSocket();
++	}
+ }


### PR DESCRIPTION
This patch (if made correctly) gives the INetworkManager the getSocket() method which return the current socket for the pairedConnection.
