### PR TITLE
Add RenderGameOverlayEvent.getType()

### DIFF
--- a/client/net/minecraftforge/client/event/RenderGameOverlayEvent.java
+++ b/client/net/minecraftforge/client/event/RenderGameOverlayEvent.java
@@ -52,6 +52,11 @@ public class RenderGameOverlayEvent extends Event
         this.mouseY = parent.mouseY;
         this.type = type;
     }
+    
+    public ElementType getType()
+    {
+    	return type;
+    }
 
     public static class Pre extends RenderGameOverlayEvent
     {


### PR DESCRIPTION
While this may seem useless, in scala, 'type' is a keyword, so the type field can't be accessed. This is a possible fix.
