### PR TITLE
Prevent subsequent listeners from acting on a canceled event

### DIFF
--- a/common/net/minecraftforge/event/EventBus.java
+++ b/common/net/minecraftforge/event/EventBus.java
@@ -106,6 +106,8 @@ public class EventBus
         for (IEventListener listener : listeners)
         {
             listener.invoke(event);
+            if (event.isCancelable() && event.isCanceled())
+                return true;
         }
         return (event.isCancelable() ? event.isCanceled() : false);
     }


### PR DESCRIPTION
This change prevents a situation where one listener cancels an event and a subsequent listener is still able to act on the event (by failing to check the isCanceled() value).  An example of this could be if a mod is using the BreakEvent event of one block as a catalyst for taking other actions such as destroying an entire tree. My understanding is that only the original block break would be canceled and any other actions taken would still be allowed. Adding the check inside the loop prevents that sort of asshattery.
