### PR TITLE
Added DamageIndicatedItemComponent and DamageIndicatedItemFluidContainer

### DIFF
--- a/patches/minecraft/net/minecraft/client/renderer/RenderBlocks.java.patch
+++ b/patches/minecraft/net/minecraft/client/renderer/RenderBlocks.java.patch
@@ -47,7 +47,7 @@
              float f1 = 0.2F;
              float f2 = 0.0625F;
 @@ -2378,7 +2381,7 @@
-                 d0 = d4;
+                 d0 = d5;
              }
  
 -            if (Block.fire.canBlockCatchFire(this.blockAccess, par2 - 1, par3, par4))
@@ -89,8 +89,8 @@
 -            if (Block.fire.canBlockCatchFire(this.blockAccess, par2, par3 + 1, par4))
 +            if (Block.fire.canBlockCatchFire(this.blockAccess, par2, par3 + 1, par4, DOWN))
              {
-                 d4 = (double)par2 + 0.5D + 0.5D;
-                 d5 = (double)par2 + 0.5D - 0.5D;
+                 d5 = (double)par2 + 0.5D + 0.5D;
+                 d6 = (double)par2 + 0.5D - 0.5D;
 @@ -3057,10 +3060,10 @@
          double d17 = (double)par2 + 0.5D + 0.0625D;
          double d18 = (double)par4 + 0.5D - 0.0625D;

--- a/patches/minecraft/net/minecraft/client/renderer/entity/RenderItem.java.patch
+++ b/patches/minecraft/net/minecraft/client/renderer/entity/RenderItem.java.patch
@@ -179,8 +179,8 @@
          int l = par3ItemStack.getItemDamage();
          Object object = par3ItemStack.getIconIndex();
 @@ -356,10 +349,10 @@
+         float f1;
          float f2;
-         int i1;
  
 -        if (par3ItemStack.getItemSpriteNumber() == 0 && RenderBlocks.renderItemIn3d(Block.blocksList[k].getRenderType()))
 +        Block block = (k < Block.blocksList.length ? Block.blocksList[k] : null);
@@ -206,8 +206,8 @@
 +                par2TextureManager.bindTexture(par3ItemStack.getItemSpriteNumber() == 0 ? TextureMap.locationBlocksTexture : TextureMap.locationItemsTexture);
 +                Icon icon = Item.itemsList[k].getIcon(par3ItemStack, j1);
                  int k1 = Item.itemsList[k].getColorFromItemStack(par3ItemStack, j1);
-                 f = (float)(k1 >> 16 & 255) / 255.0F;
-                 f1 = (float)(k1 >> 8 & 255) / 255.0F;
+                 f1 = (float)(k1 >> 16 & 255) / 255.0F;
+                 f2 = (float)(k1 >> 8 & 255) / 255.0F;
 @@ -402,6 +395,11 @@
                  }
  


### PR DESCRIPTION
Added a DamageIndicatedItemComponent to be used as a Component in de Composite design pattern to add a damage-bar to any desired Item. Also added a DamageIndicatedItemFluidContainer that implements this behavior.
The DamageIndicatedItemComponent is useful for items that have a damage-like behavior but don't want to use the basic damage feature, but something more complex. 
