### PR TITLE
Added DamageIndicatedItemComponent and DamageIndicatedItemFluidContainer

### DIFF
--- a/common/net/minecraftforge/fluids/DamageIndicatedItemFluidContainer.java
+++ b/common/net/minecraftforge/fluids/DamageIndicatedItemFluidContainer.java
@@ -1,0 +1,79 @@
+package net.minecraftforge.fluids;
+
+import java.util.List;
+
+import net.minecraft.creativetab.CreativeTabs;
+import net.minecraft.item.ItemStack;
+import net.minecraftforge.item.DamageIndicatedItemComponent;
+import cpw.mods.fml.relauncher.Side;
+import cpw.mods.fml.relauncher.SideOnly;
+
+/**
+ * This extension on {@link ItemFluidContainer} will show a damage indicator depending on how full
+ * the container is. This can be used to hold certain amounts of Fluids in an Item.
+ * When this item is available in a CreativeTab, it will add itself as a full and an empty container.
+ * 
+ * This container ONLY allows the fluid from the given type.
+ * 
+ * @author rubensworks
+ *
+ */
+public abstract class DamageIndicatedItemFluidContainer extends ItemFluidContainer {
+
+    private DamageIndicatedItemComponent component;
+    private Fluid fluid;
+    
+    /**
+     * Create a new DamageIndicatedItemFluidContainer.
+     * 
+     * @param itemID
+     *          The ID for this container.
+     * @param capacity
+     *          The capacity this container will have.
+     * @param fluid
+     *          The Fluid instance this container must hold.
+     */
+    public DamageIndicatedItemFluidContainer(int itemID, int capacity, Fluid fluid)
+    {
+        super(itemID, capacity);
+        this.fluid = fluid;
+        component = new DamageIndicatedItemComponent(this, this.capacity);
+    }
+    
+    @Override
+    public FluidStack drain(ItemStack container, int maxDrain, boolean doDrain)
+    {
+        FluidStack fluidStack = super.drain(container, maxDrain, doDrain);
+        int newAmount = getFluid(container) == null ? 0 : getFluid(container).amount;
+        component.updateAmount(container, newAmount);
+        return fluidStack;
+    }
+    
+    @Override
+    public int fill(ItemStack container, FluidStack resource, boolean doFill)
+    {
+        int filled = super.fill(container, resource, doFill);
+        component.updateAmount(container, getFluid(container).amount);
+        return filled;
+    }
+    
+    /**
+     * Make sure the full and empty container is available is the CreativeTab.
+     */
+    @SuppressWarnings({ "rawtypes", "unchecked" })
+    @Override
+    @SideOnly(Side.CLIENT)
+    public void getSubItems(int id, CreativeTabs tab, List itemList)
+    {
+        // Add the 'full' container.
+        ItemStack itemStackFull = new ItemStack(this, 1);
+        fill(itemStackFull, new FluidStack(fluid, component.capacity), true);
+        itemList.add(itemStackFull);
+        
+        // Add the 'empty' container.
+        ItemStack itemStackEmpty = new ItemStack(this, 1);
+        fill(itemStackEmpty, new FluidStack(fluid, 0), true);
+        itemList.add(itemStackEmpty);
+    }
+
+}

--- a/common/net/minecraftforge/item/DamageIndicatedItemComponent.java
+++ b/common/net/minecraftforge/item/DamageIndicatedItemComponent.java
@@ -1,0 +1,65 @@
+package net.minecraftforge.item;
+
+import net.minecraft.item.Item;
+import net.minecraft.item.ItemStack;
+
+/**
+ * A component that has to be added for classes that want to implement the DamageIndicator behaviour.
+ * 
+ * Items can add this component (Composite design-pattern) to any item that needs to have a damage
+ * indicator based on a custom value. Like for example the amount of energy left in an IC2 electrical
+ * wrench, or the amount of MJ's left in a redstone energy cell from Thermal Expansion.
+ * 
+ * See {@link DamageIndicatedItemFluidContainer} for an example.
+ * This could be for example an Item or an ItemFluidContainer.
+ * 
+ * @author rubensworks
+ *
+ */
+public class DamageIndicatedItemComponent{
+    
+    /**
+     * The item class on which the behaviour will be added.
+     */
+    public Item item;
+    /**
+     * The custom defined capacity this damage indicator must have.
+     */
+    public int capacity;
+
+    /**
+     * Create a new DamageIndicatedItemComponent
+     * 
+     * @param item
+     *          The item class on which the behaviour will be added.
+     * @param capacity
+     *          The custom defined capacity this damage indicator must have.
+     */
+    public DamageIndicatedItemComponent(Item item, int capacity)
+    {
+        this.item = item;
+        this.capacity = capacity;
+        item.setMaxStackSize(1);
+        item.setMaxDamage(102);
+        item.setNoRepair();
+    }
+    
+    /**
+     * Updates the amount of the given stack with the given amount depending on the predefined item.
+     * This method should be called whenever the contained amount of this container should be updated, 
+     * together with the damage indicator.
+     * 
+     * @param itemStack
+     *          The itemStack that will get an updated damage bar
+     * @param amount
+     *          The new amount this damage indicator must hold for the given itemStack.
+     */
+    public void updateAmount(ItemStack itemStack, int amount)
+    {
+        if(itemStack.getItem() == item && capacity > 0 && amount <= capacity)
+        {
+            item.setDamage(itemStack, 101 - ((amount * 100) / (capacity)));
+        }
+    }
+    
+}


### PR DESCRIPTION
The DamageIndicatedItemFluidContainer is an extension on the ItemFluidContainer and adds a damage indicator that shows how full the container is. This can be used to hold certain amounts of Fluids in an Item and immediately be able to see how full it is. When this item is available in a CreativeTab, it will add itself as a full and an empty container.

This pull request also contains a DamageIndicatedItemComponent to be able to reuse the damage-bar behavior to other (non-fluid container) items.
You can add this component (Composite design-pattern) to any item that needs to have a damage indicator based on a custom value that somehow cannot be stored in the damage value. Like for example the amount of energy left in an IC2 electrical wrench, or the amount of MJ's left in a redstone energy cell from Thermal Expansion.
This behavior is being used across different mods, so it should get a place within Forge itself.

Example of the damage bar (don't mind the github icon, just a temporary fluidcontainer):
![2013-10-22_16 04 26](https://f.cloud.github.com/assets/440384/1381679/cd2ecf5a-3b23-11e3-9047-1383ef5893d4.png)

Example of the CreativeTab:
![2013-10-22_16 04 36](https://f.cloud.github.com/assets/440384/1381687/f258bca0-3b23-11e3-9e54-658c2c9fd3ed.png)

Please let me know if I missed any of Forge's coding conventions.
