### PR TITLE
Add in fill method to IFluidBlock

### DIFF
--- a/common/net/minecraftforge/fluids/BlockFluidClassic.java
+++ b/common/net/minecraftforge/fluids/BlockFluidClassic.java
@@ -7,14 +7,11 @@ import net.minecraft.block.material.Material;
 import net.minecraft.world.IBlockAccess;
 import net.minecraft.world.World;
 
-/**
- * This is a fluid block implementation which emulates vanilla Minecraft fluid behavior.
+/** This is a fluid block implementation which emulates vanilla Minecraft fluid behavior.
  *
  * It is highly recommended that you use/extend this class for "classic" fluid blocks.
  *
- * @author King Lemming
- *
- */
+ * @author King Lemming */
 public class BlockFluidClassic extends BlockFluidBase
 {
     protected boolean[] isOptimalFlowDirection = new boolean[4];
@@ -91,21 +88,17 @@ public class BlockFluidClassic extends BlockFluidBase
         {
             int y2 = y - densityDir;
 
-            if (world.getBlockId(x,     y2, z    ) == blockID ||
-                world.getBlockId(x - 1, y2, z    ) == blockID ||
-                world.getBlockId(x + 1, y2, z    ) == blockID ||
-                world.getBlockId(x,     y2, z - 1) == blockID ||
-                world.getBlockId(x,     y2, z + 1) == blockID)
+            if (world.getBlockId(x, y2, z) == blockID || world.getBlockId(x - 1, y2, z) == blockID || world.getBlockId(x + 1, y2, z) == blockID || world.getBlockId(x, y2, z - 1) == blockID || world.getBlockId(x, y2, z + 1) == blockID)
             {
                 expQuanta = quantaPerBlock - 1;
             }
             else
             {
                 int maxQuanta = -100;
-                maxQuanta = getLargerQuanta(world, x - 1, y, z,     maxQuanta);
-                maxQuanta = getLargerQuanta(world, x + 1, y, z,     maxQuanta);
-                maxQuanta = getLargerQuanta(world, x,     y, z - 1, maxQuanta);
-                maxQuanta = getLargerQuanta(world, x,     y, z + 1, maxQuanta);
+                maxQuanta = getLargerQuanta(world, x - 1, y, z, maxQuanta);
+                maxQuanta = getLargerQuanta(world, x + 1, y, z, maxQuanta);
+                maxQuanta = getLargerQuanta(world, x, y, z - 1, maxQuanta);
+                maxQuanta = getLargerQuanta(world, x, y, z + 1, maxQuanta);
 
                 expQuanta = maxQuanta - 1;
             }
@@ -155,17 +148,20 @@ public class BlockFluidClassic extends BlockFluidBase
             }
             boolean flowTo[] = getOptimalFlowDirections(world, x, y, z);
 
-            if (flowTo[0]) flowIntoBlock(world, x - 1, y, z,     flowMeta);
-            if (flowTo[1]) flowIntoBlock(world, x + 1, y, z,     flowMeta);
-            if (flowTo[2]) flowIntoBlock(world, x,     y, z - 1, flowMeta);
-            if (flowTo[3]) flowIntoBlock(world, x,     y, z + 1, flowMeta);
+            if (flowTo[0])
+                flowIntoBlock(world, x - 1, y, z, flowMeta);
+            if (flowTo[1])
+                flowIntoBlock(world, x + 1, y, z, flowMeta);
+            if (flowTo[2])
+                flowIntoBlock(world, x, y, z - 1, flowMeta);
+            if (flowTo[3])
+                flowIntoBlock(world, x, y, z + 1, flowMeta);
         }
     }
 
     public boolean isFlowingVertically(IBlockAccess world, int x, int y, int z)
     {
-        return world.getBlockId(x, y + densityDir, z) == blockID ||
-            (world.getBlockId(x, y, z) == blockID && canFlowInto(world, x, y + densityDir, z));
+        return world.getBlockId(x, y + densityDir, z) == blockID || (world.getBlockId(x, y, z) == blockID && canFlowInto(world, x, y + densityDir, z));
     }
 
     public boolean isSourceBlock(IBlockAccess world, int x, int y, int z)
@@ -185,10 +181,18 @@ public class BlockFluidClassic extends BlockFluidBase
 
             switch (side)
             {
-                case 0: --x2; break;
-                case 1: ++x2; break;
-                case 2: --z2; break;
-                case 3: ++z2; break;
+                case 0:
+                    --x2;
+                    break;
+                case 1:
+                    ++x2;
+                    break;
+                case 2:
+                    --z2;
+                    break;
+                case 3:
+                    ++z2;
+                    break;
             }
 
             if (!canFlowInto(world, x2, y2, z2) || isSourceBlock(world, x2, y2, z2))
@@ -226,10 +230,7 @@ public class BlockFluidClassic extends BlockFluidBase
         int cost = 1000;
         for (int adjSide = 0; adjSide < 4; adjSide++)
         {
-            if ((adjSide == 0 && side == 1) ||
-                (adjSide == 1 && side == 0) ||
-                (adjSide == 2 && side == 3) ||
-                (adjSide == 3 && side == 2))
+            if ((adjSide == 0 && side == 1) || (adjSide == 1 && side == 0) || (adjSide == 2 && side == 3) || (adjSide == 3 && side == 2))
             {
                 continue;
             }
@@ -240,10 +241,18 @@ public class BlockFluidClassic extends BlockFluidBase
 
             switch (adjSide)
             {
-                case 0: --x2; break;
-                case 1: ++x2; break;
-                case 2: --z2; break;
-                case 3: ++z2; break;
+                case 0:
+                    --x2;
+                    break;
+                case 1:
+                    ++x2;
+                    break;
+                case 2:
+                    --z2;
+                    break;
+                case 3:
+                    ++z2;
+                    break;
             }
 
             if (!canFlowInto(world, x2, y2, z2) || isSourceBlock(world, x2, y2, z2))
@@ -272,7 +281,8 @@ public class BlockFluidClassic extends BlockFluidBase
 
     protected void flowIntoBlock(World world, int x, int y, int z, int meta)
     {
-        if (meta < 0) return;
+        if (meta < 0)
+            return;
         if (displaceIfPossible(world, x, y, z))
         {
             world.setBlock(x, y, z, this.blockID, meta, 3);
@@ -281,7 +291,8 @@ public class BlockFluidClassic extends BlockFluidBase
 
     protected boolean canFlowInto(IBlockAccess world, int x, int y, int z)
     {
-        if (world.isAirBlock(x, y, z)) return true;
+        if (world.isAirBlock(x, y, z))
+            return true;
 
         int bId = world.getBlockId(x, y, z);
         if (bId == blockID)
@@ -295,27 +306,24 @@ public class BlockFluidClassic extends BlockFluidBase
         }
 
         Material material = Block.blocksList[bId].blockMaterial;
-        if (material.blocksMovement()  ||
-            material == Material.water ||
-            material == Material.lava  ||
-            material == Material.portal)
+        if (material.blocksMovement() || material == Material.water || material == Material.lava || material == Material.portal)
         {
             return false;
         }
 
         int density = getDensity(world, x, y, z);
-        if (density == Integer.MAX_VALUE) 
+        if (density == Integer.MAX_VALUE)
         {
-             return true;
+            return true;
         }
-        
+
         if (this.density > density)
         {
             return true;
         }
         else
         {
-        	return false;
+            return false;
         }
     }
 
@@ -350,5 +358,27 @@ public class BlockFluidClassic extends BlockFluidBase
     public boolean canDrain(World world, int x, int y, int z)
     {
         return isSourceBlock(world, x, y, z);
+    }
+
+    @Override
+    public FluidStack fill(World world, int x, int y, int z, boolean doFill)
+    {
+        if (isSourceBlock(world, x, y, z))
+        {
+            return stack.copy();
+        }
+
+        if (doFill)
+        {
+            world.setBlockMetadataWithNotify(x, y, z, 15, 2);
+        }
+
+        return null;
+    }
+
+    @Override
+    public boolean canFill(World world, int x, int y, int z)
+    {
+        return !isSourceBlock(world, x, y, z);
     }
 }

--- a/common/net/minecraftforge/fluids/BlockFluidFinite.java
+++ b/common/net/minecraftforge/fluids/BlockFluidFinite.java
@@ -10,11 +10,11 @@ import net.minecraft.world.World;
 
 /**
  * This is a cellular-automata based finite fluid block implementation.
- * 
+ *
  * It is highly recommended that you use/extend this class for finite fluid blocks.
- * 
+ *
  * @author OvermindDL1, KingLemming
- * 
+ *
  */
 public class BlockFluidFinite extends BlockFluidBase
 {
@@ -317,6 +317,18 @@ public class BlockFluidFinite extends BlockFluidBase
 
     @Override
     public boolean canDrain(World world, int x, int y, int z)
+    {
+        return false;
+    }
+
+    @Override
+    public FluidStack fill(World world, int x, int y, int z, boolean doFill)
+    {
+        return null;
+    }
+
+    @Override
+    public boolean canFill(World world, int x, int y, int z)
     {
         return false;
     }

--- a/common/net/minecraftforge/fluids/IFluidBlock.java
+++ b/common/net/minecraftforge/fluids/IFluidBlock.java
@@ -4,11 +4,11 @@ import net.minecraft.world.World;
 
 /**
  * Implement this interface on Block classes which represent world-placeable Fluids.
- * 
+ *
  * NOTE: Using/extending the reference implementations {@link BlockFluidBase} is encouraged.
- * 
+ *
  * @author King Lemming
- * 
+ *
  */
 public interface IFluidBlock
 {
@@ -19,9 +19,9 @@ public interface IFluidBlock
 
     /**
      * Attempt to drain the block. This method should be called by devices such as pumps.
-     * 
+     *
      * NOTE: The block is intended to handle its own state changes.
-     * 
+     *
      * @param doDrain
      *            If false, the drain will only be simulated.
      * @return
@@ -31,20 +31,37 @@ public interface IFluidBlock
     /**
      * Check to see if a block can be drained. This method should be called by devices such as
      * pumps.
-     * 
-     * @param doDrain
-     *            If false, the drain will only be simulated.
-     * @return
+     *
+     * @return true if the block can be drained
      */
     boolean canDrain(World world, int x, int y, int z);
 
     /**
+     * Attempt to fill the block. This method should be called by devices such as pumps.
+     *
+     * NOTE: The block is intended to handle its own state changes.
+     *
+     * @param doFill
+     *            If false, the fill will only be simulated.
+     * @return
+     */
+    FluidStack fill(World world, int x, int y, int z, boolean doFill);
+
+    /**
+     * Check to see if a block can be filled. This method should be called by devices such as
+     * pumps.
+     *
+     * @return true if the block can be filled
+     */
+    boolean canFill(World world, int x, int y, int z);
+
+    /**
      * Returns the amount of a single block is filled. Value between 0 and 1.
      * 1 meaning the entire 1x1x1 cube is full, 0 meaning completely empty.
-     * 
-     * If the return value is negative. It will be treated as filling the block 
+     *
+     * If the return value is negative. It will be treated as filling the block
      * from the top down instead of bottom up.
-     * 
+     *
      * @return
      */
     float getFilledPercentage(World world, int x, int y, int z);


### PR DESCRIPTION
I've made a pull request for this before but since it been a while i'm remaking the request with fresh code. This way there should be less issues pulling in the code if it ever does. 

The idea behind this change to the IFluidBlock is too allow automation to fill a block in the same way it can drain a block. This way the code doesn't have to assume that the block's meta represents the volume of the fluid block. As well it allows blocks to control how they are filled in the case they don't save volume at all using metadata. This will be a very useful method for other things than automation. As item containers can start to use this method to correctly fill a block that can contain more than one bucket worth of fluid.  Another use would be blocks that can store fluid but are not fluids themselves. 

Also for those that are reading this the doFill and doDrain Boolean are not up for discussion as that seems to be a large issues with fluid methods. I'm am making this pull with the only idea of creating an easy way to let  automation understand how fluid blocks are filled. Without running into issues of mod incompatibility due to different methods by which volume is stored in a block. 
