### PR TITLE
Added AnvilRepairUpdateEvent

### DIFF
--- a/common/net/minecraftforge/event/ForgeEventFactory.java
+++ b/common/net/minecraftforge/event/ForgeEventFactory.java
@@ -14,6 +14,7 @@ import net.minecraft.world.World;
 import net.minecraft.world.WorldServer;
 import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.event.Event.Result;
+import net.minecraftforge.event.anvil.AnvilRepairUpdateEvent;
 import net.minecraftforge.event.entity.living.LivingPackSizeEvent;
 import net.minecraftforge.event.entity.living.LivingSpawnEvent;
 import net.minecraftforge.event.entity.living.LivingSpawnEvent.AllowDespawn;
@@ -117,4 +118,11 @@ public class ForgeEventFactory
         MinecraftForge.EVENT_BUS.post(summonEvent);
         return summonEvent;
     }
+
+    public static AnvilRepairUpdateEvent anvilRepairUpdate(ItemStack itemstack1, ItemStack itemstack2, ItemStack outputstack, int baseCost) {
+        AnvilRepairUpdateEvent event = new AnvilRepairUpdateEvent(itemstack1, itemstack2, outputstack, baseCost);
+        MinecraftForge.EVENT_BUS.post(event);
+        return event;
+    }
+
 }

--- a/common/net/minecraftforge/event/anvil/AnvilRepairUpdateEvent.java
+++ b/common/net/minecraftforge/event/anvil/AnvilRepairUpdateEvent.java
@@ -22,12 +22,12 @@ public class AnvilRepairUpdateEvent extends Event
      *  Be sure to set result to allow if you are updating the item,
      *  or cancel the event if you want no output.
      */
-    public AnvilRepairUpdateEvent(ItemStack inputStack1, ItemStack inputStack2, ItemStack outputStack, int defaultCost) {
+    public AnvilRepairUpdateEvent(ItemStack inputStack1, ItemStack inputStack2, ItemStack outputStack, int baseCost) {
     	this.inputStack1 = inputStack1;
         this.inputStack2 = inputStack2;
 
         this.outputStack = outputStack;
-        this.maximumCost = defaultCost;
+        this.maximumCost = baseCost;
     }
 
 }

--- a/patches/minecraft/net/minecraft/inventory/ContainerRepair.java.patch
+++ b/patches/minecraft/net/minecraft/inventory/ContainerRepair.java.patch
@@ -1,33 +1,36 @@
 --- ../src_base/minecraft/net/minecraft/inventory/ContainerRepair.java
 +++ ../src_work/minecraft/net/minecraft/inventory/ContainerRepair.java
-@@ -2,8 +2,10 @@
+@@ -1,9 +1,8 @@
+ package net.minecraft.inventory;
  
- import cpw.mods.fml.relauncher.Side;
- import cpw.mods.fml.relauncher.SideOnly;
-+
+-import cpw.mods.fml.relauncher.Side;
+-import cpw.mods.fml.relauncher.SideOnly;
  import java.util.Iterator;
  import java.util.Map;
 +
  import net.minecraft.block.Block;
  import net.minecraft.enchantment.Enchantment;
  import net.minecraft.enchantment.EnchantmentHelper;
-@@ -13,6 +15,10 @@
+@@ -13,7 +12,14 @@
  import net.minecraft.item.ItemEnchantedBook;
  import net.minecraft.item.ItemStack;
  import net.minecraft.world.World;
-+import net.minecraftforge.common.MinecraftForge;
 +import net.minecraftforge.event.Event.Result;
++import net.minecraftforge.event.ForgeEventFactory;
 +import net.minecraftforge.event.anvil.AnvilRepairUpdateEvent;
 +
  import org.apache.commons.lang3.StringUtils;
++
++import cpw.mods.fml.relauncher.Side;
++import cpw.mods.fml.relauncher.SideOnly;
  
  public class ContainerRepair extends Container
-@@ -112,6 +118,22 @@
+ {
+@@ -112,6 +118,21 @@
  
              if (itemstack2 != null)
              {
-+                AnvilRepairUpdateEvent event = new AnvilRepairUpdateEvent(itemstack, itemstack2, itemstack1, k);
-+                MinecraftForge.EVENT_BUS.post(event);
++                AnvilRepairUpdateEvent event = ForgeEventFactory.anvilRepairUpdate(itemstack, itemstack1, itemstack2, k);
 +                Result result = event.getResult();
 +                if ( result == Result.DENY || event.outputStack == null )
 +                {
@@ -45,7 +48,7 @@
                  flag = itemstack2.itemID == Item.enchantedBook.itemID && Item.enchantedBook.func_92110_g(itemstack2).tagCount() > 0;
  
                  if (itemstack1.isItemStackDamageable() && Item.itemsList[itemstack1.itemID].getIsRepairable(itemstack, itemstack2))
-@@ -315,6 +337,11 @@
+@@ -315,6 +336,11 @@
                  k = Math.max(1, k / 2);
              }
  
@@ -57,7 +60,7 @@
              this.maximumCost = k + i;
  
              if (i <= 0)
-@@ -331,6 +358,7 @@
+@@ -331,6 +357,7 @@
              {
                  itemstack1 = null;
              }


### PR DESCRIPTION
This event fires when two items are placed into the anvil repair GUI.
If the event is left to DEFAULT, vanilla behavior occurs.
If the event is set to ALLOW, the modified event.outputStack will be
applied to the anvil GUI output item.
If the event is set to DENY, then the anvil GUI will not allow the
combination of items.

```
new file:   common/net/minecraftforge/event/anvil/AnvilRepairUpdateEvent.java
modified:   patches/minecraft/net/minecraft/inventory/ContainerRepair.java.patch
```
