### PR TITLE
Adds a WeatherRender in the style of SkyRender

### DIFF
--- a/patches/minecraft/net/minecraft/client/renderer/EntityRenderer.java.patch
+++ b/patches/minecraft/net/minecraft/client/renderer/EntityRenderer.java.patch
@@ -1,10 +1,11 @@
 --- ../src_base/minecraft/net/minecraft/client/renderer/EntityRenderer.java
 +++ ../src_work/minecraft/net/minecraft/client/renderer/EntityRenderer.java
-@@ -40,6 +40,11 @@
+@@ -40,6 +40,12 @@
  import org.lwjgl.opengl.GLContext;
  import org.lwjgl.util.glu.Project;
  
 +import net.minecraftforge.client.ForgeHooksClient;
++import net.minecraftforge.client.IRenderHandler;
 +import net.minecraftforge.client.event.DrawBlockHighlightEvent;
 +import net.minecraftforge.client.event.RenderWorldLastEvent;
 +import net.minecraftforge.common.MinecraftForge;
@@ -12,7 +13,7 @@
  @SideOnly(Side.CLIENT)
  public class EntityRenderer
  {
-@@ -319,7 +324,7 @@
+@@ -319,7 +325,7 @@
  
                              if (d3 < d2 || d2 == 0.0D)
                              {
@@ -21,7 +22,7 @@
                                  {
                                      if (d2 == 0.0D)
                                      {
-@@ -354,8 +359,15 @@
+@@ -354,8 +360,15 @@
       */
      private void updateFovModifierHand()
      {
@@ -39,7 +40,7 @@
          this.fovModifierHandPrev = this.fovModifierHand;
          this.fovModifierHand += (this.fovMultiplierTemp - this.fovModifierHand) * 0.5F;
  
-@@ -381,7 +393,7 @@
+@@ -381,7 +394,7 @@
          }
          else
          {
@@ -48,7 +49,7 @@
              float f1 = 70.0F;
  
              if (par2)
-@@ -468,15 +480,7 @@
+@@ -468,15 +481,7 @@
  
              if (!this.mc.gameSettings.debugCamEnable)
              {
@@ -65,7 +66,7 @@
                  GL11.glRotatef(entitylivingbase.prevRotationYaw + (entitylivingbase.rotationYaw - entitylivingbase.prevRotationYaw) * par1 + 180.0F, 0.0F, -1.0F, 0.0F);
                  GL11.glRotatef(entitylivingbase.prevRotationPitch + (entitylivingbase.rotationPitch - entitylivingbase.prevRotationPitch) * par1, -1.0F, 0.0F, 0.0F);
              }
-@@ -1152,7 +1156,10 @@
+@@ -1152,7 +1157,10 @@
              {
                  RenderHelper.enableStandardItemLighting();
                  this.mc.mcProfiler.endStartSection("entities");
@@ -76,7 +77,7 @@
                  this.enableLightmap((double)par1);
                  this.mc.mcProfiler.endStartSection("litParticles");
                  effectrenderer.renderLitParticles(entitylivingbase, par1);
-@@ -1161,13 +1168,17 @@
+@@ -1161,13 +1169,17 @@
                  this.mc.mcProfiler.endStartSection("particles");
                  effectrenderer.renderParticles(entitylivingbase, par1);
                  this.disableLightmap((double)par1);
@@ -95,7 +96,7 @@
                      GL11.glEnable(GL11.GL_ALPHA_TEST);
                  }
              }
-@@ -1222,6 +1233,17 @@
+@@ -1222,6 +1234,17 @@
                  renderglobal.sortAndRender(entitylivingbase, 1, (double)par1);
              }
  
@@ -113,7 +114,7 @@
              GL11.glDepthMask(true);
              GL11.glEnable(GL11.GL_CULL_FACE);
              GL11.glDisable(GL11.GL_BLEND);
-@@ -1231,14 +1253,17 @@
+@@ -1231,14 +1254,17 @@
                  entityplayer = (EntityPlayer)entitylivingbase;
                  GL11.glDisable(GL11.GL_ALPHA_TEST);
                  this.mc.mcProfiler.endStartSection("outline");
@@ -133,7 +134,7 @@
              GL11.glDisable(GL11.GL_BLEND);
              this.mc.mcProfiler.endStartSection("weather");
              this.renderRainSnow(par1);
-@@ -1248,6 +1273,20 @@
+@@ -1248,6 +1274,20 @@
              {
                  this.renderCloudsCheck(renderglobal, par1);
              }
@@ -154,3 +155,17 @@
  
              this.mc.mcProfiler.endStartSection("hand");
  
+@@ -1376,6 +1416,13 @@
+      */
+     protected void renderRainSnow(float par1)
+     {
++        IRenderHandler renderer = this.mc.theWorld.provider.getWeatherRenderer();
++        if (renderer != null)
++        {
++            renderer.render(par1, this.mc.theWorld, mc);
++            return;
++        }
++
+         float f1 = this.mc.theWorld.getRainStrength(par1);
+ 
+         if (f1 > 0.0F)

--- a/patches/minecraft/net/minecraft/world/WorldProvider.java.patch
+++ b/patches/minecraft/net/minecraft/world/WorldProvider.java.patch
@@ -42,7 +42,7 @@
      }
  
      @SideOnly(Side.CLIENT)
-@@ -268,4 +275,277 @@
+@@ -268,4 +275,290 @@
       * Returns the dimension's name, e.g. "The End", "Nether", or "Overworld".
       */
      public abstract String getDimensionName();
@@ -50,6 +50,7 @@
 +    /*======================================= Forge Start =========================================*/
 +    private IRenderHandler skyRenderer = null;
 +    private IRenderHandler cloudRenderer = null;
++    private IRenderHandler weatherRenderer = null;
 +    
 +    /**
 +     * Sets the providers current dimension ID, used in default getSaveFolder()
@@ -145,6 +146,18 @@
 +    public void setCloudRenderer(IRenderHandler renderer)
 +    {
 +        cloudRenderer = renderer;
++    }
++
++    @SideOnly(Side.CLIENT)
++    public IRenderHandler getWeatherRenderer()
++    {
++        return weatherRenderer;
++    }
++
++    @SideOnly(Side.CLIENT)
++    public void setWeatherRenderer(IRenderHandler renderer)
++    {
++    	weatherRenderer = renderer;
 +    }
 +
 +    public ChunkCoordinates getRandomizedSpawnPoint()


### PR DESCRIPTION
Adds a render handler override for weather to WorldProvider in the style
of the cloud and sky renderer overrides.  This enables control over how
rain/snow/weather in general is rendered.
