### PR TITLE
Moved the PotionBrewedEvent to be posted before the removal of the input item

### DIFF
--- a/src/main/resources/forge_at.cfg
+++ b/src/main/resources/forge_at.cfg
@@ -162,6 +162,8 @@ public net.minecraft.world.gen.structure.StructureStrongholdPieces$Stronghold
 # Packets
 public net.minecraft.network.play.server.S23PacketBlockChange field_148883_d # Block
 public net.minecraft.network.play.server.S23PacketBlockChange field_148884_e # Metadata
+# RenderBlocks
+public net.minecraft.client.renderer.RenderBlocks *
 # WorldType
 public-f net.minecraft.world.WorldType field_77139_a #worldTypes
 # DamageSource


### PR DESCRIPTION
This allows for determining the input itemstack for brewing in the case of the stack size being one. Previously the input itemstack would be null in this case when interacting with it.
