### PR TITLE
Gives access to the container that was open

### DIFF
--- a/common/net/minecraftforge/event/entity/player/PlayerOpenContainerEvent.java
+++ b/common/net/minecraftforge/event/entity/player/PlayerOpenContainerEvent.java
@@ -9,6 +9,7 @@ public class PlayerOpenContainerEvent extends PlayerEvent
 {
 
     public final boolean canInteractWith;
+    public final Container openContainer;
 
     /**
      * This event is fired when a player attempts to view a container during
@@ -25,5 +26,6 @@ public class PlayerOpenContainerEvent extends PlayerEvent
     {
         super(player);
         this.canInteractWith = openContainer.canInteractWith(player);
+        this.openContainer = openContainer;
     }
 }


### PR DESCRIPTION
So that you'd be able to choose what to do according to the type of container (for example, allow the player to open chests but not brewing stands, for whatever reason)
