### PR TITLE
Add needed null check in SlotCrafting

### DIFF
--- a/patches/minecraft/net/minecraft/inventory/SlotCrafting.java.patch
+++ b/patches/minecraft/net/minecraft/inventory/SlotCrafting.java.patch
@@ -19,7 +19,7 @@
 +                    ItemStack itemstack2 = itemstack1.getItem().getContainerItemStack(itemstack1);
  
 -                    if (!itemstack1.getItem().doesContainerItemLeaveCraftingGrid(itemstack1) || !this.thePlayer.inventory.addItemStackToInventory(itemstack2))
-+                    if (itemstack2.isItemStackDamageable() && itemstack2.getItemDamage() > itemstack2.getMaxDamage())
++                    if (itemstack2 != null && itemstack2.isItemStackDamageable() && itemstack2.getItemDamage() > itemstack2.getMaxDamage())
 +                    {
 +                        MinecraftForge.EVENT_BUS.post(new PlayerDestroyItemEvent(thePlayer, itemstack2));
 +                        itemstack2 = null;


### PR DESCRIPTION
Previously, this patch didn't check to see if the returned container item was null, resulting in a crash.  This follows intended functionality by first checking to make sure that the returned container item is not null.
