### PR TITLE
Update MinecraftForge-License.txt

### DIFF
--- a/install/MinecraftForge-License.txt
+++ b/install/MinecraftForge-License.txt
@@ -46,8 +46,8 @@ decompiled version or the original source code, and to modify it.
 The user has the rights to derive code from Minecraft Forge, that is to say to
 write code that either extends Minecraft Forge class and interfaces, 
 instantiate the objects declared or calls the functions. This code is known as
-"derived" code, and can be licensed with conditions different from Minecraft
-Forge.
+"derived" code or "Mods", and can be licensed with conditions different from Minecraft
+Forge. 
 
 
 5. Distribution rights


### PR DESCRIPTION
I suggest this change to help mod developers have a chance in Legal problems with Mod Authors, The way I've read this was: "Mod authors have full control over how they license their mods and have the right to Copyright all the source". Please change if wrong.
