### PR TITLE
Config: add newline between last property and first child category of categories.

### DIFF
--- a/common/net/minecraftforge/common/ConfigCategory.java
+++ b/common/net/minecraftforge/common/ConfigCategory.java
@@ -183,6 +183,11 @@ public class ConfigCategory implements Map<String, Property>
             }
         }
 
+        if (properties.size() > 0 && children.size() > 0)
+        {
+            out.write(NEW_LINE);
+        }
+
         for (ConfigCategory child : children)
         {
             child.write(out, indent + 1);


### PR DESCRIPTION
Changes

```
parent {
    # This is the last property of the parent category.
    # It becomes easy to miss this as it currently is.
    B:lastProperty=false
    ####################
    # child
    ####################

    child {
        ...
```

to

```
parent {
    # This is the last property of the parent category.
    # It becomes easy to miss this as it currently is.
    B:lastProperty=false

    ####################
    # child
    ####################

    child {
        ...
```
