### PR TITLE
Added an event that can be used for modifying the join/leave messages

### DIFF
--- a/patches/minecraft/net/minecraft/network/NetServerHandler.java.patch
+++ b/patches/minecraft/net/minecraft/network/NetServerHandler.java.patch
@@ -15,6 +15,15 @@
  public class NetServerHandler extends NetHandler
  {
      /** The underlying network manager for this server handler. */
+@@ -162,7 +170,7 @@
+             this.playerEntity.mountEntityAndWakeUp();
+             this.sendPacketToPlayer(new Packet255KickDisconnect(par1Str));
+             this.netManager.serverShutdown();
+-            this.mcServer.getConfigurationManager().sendChatMsg(ChatMessageComponent.createFromTranslationWithSubstitutions("multiplayer.player.left", new Object[] {this.playerEntity.getTranslatedEntityName()}).setColor(EnumChatFormatting.YELLOW));
++            ForgeHooks.sendLeaveMessage(this.playerEntity);
+             this.mcServer.getConfigurationManager().playerLoggedOut(this.playerEntity);
+             this.connectionClosed = true;
+         }
 @@ -223,6 +231,11 @@
                          this.playerEntity.ridingEntity.updateRiderPosition();
                      }
@@ -127,6 +136,15 @@
              {
                  this.playerEntity.theItemInWorldManager.activateBlockOrUseItem(this.playerEntity, worldserver, itemstack, i, j, k, l, par1Packet15Place.getXOffset(), par1Packet15Place.getYOffset(), par1Packet15Place.getZOffset());
              }
+@@ -584,7 +622,7 @@
+     public void handleErrorMessage(String par1Str, Object[] par2ArrayOfObj)
+     {
+         this.mcServer.getLogAgent().logInfo(this.playerEntity.getCommandSenderName() + " lost connection: " + par1Str);
+-        this.mcServer.getConfigurationManager().sendChatMsg(ChatMessageComponent.createFromTranslationWithSubstitutions("multiplayer.player.left", new Object[] {this.playerEntity.getTranslatedEntityName()}).setColor(EnumChatFormatting.YELLOW));
++        ForgeHooks.sendLeaveMessage(this.playerEntity);
+         this.mcServer.getConfigurationManager().playerLoggedOut(this.playerEntity);
+         this.connectionClosed = true;
+ 
 @@ -698,6 +736,8 @@
                      }
  

--- a/patches/minecraft/net/minecraft/server/management/ServerConfigurationManager.java.patch
+++ b/patches/minecraft/net/minecraft/server/management/ServerConfigurationManager.java.patch
@@ -1,6 +1,6 @@
 --- ../src-base/minecraft/net/minecraft/server/management/ServerConfigurationManager.java
 +++ ../src-work/minecraft/net/minecraft/server/management/ServerConfigurationManager.java
-@@ -52,11 +52,15 @@
+@@ -52,11 +52,16 @@
  import net.minecraft.util.EnumChatFormatting;
  import net.minecraft.util.MathHelper;
  import net.minecraft.world.EnumGameType;
@@ -12,11 +12,21 @@
  import net.minecraft.world.storage.IPlayerFileData;
  
 +import net.minecraftforge.common.DimensionManager;
++import net.minecraftforge.common.ForgeHooks;
 +
  public abstract class ServerConfigurationManager
  {
      private static final SimpleDateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd \'at\' HH:mm:ss z");
-@@ -392,13 +396,23 @@
+@@ -128,7 +133,7 @@
+         netserverhandler.sendPacketToPlayer(new Packet16BlockItemSwitch(par2EntityPlayerMP.inventory.currentItem));
+         this.func_96456_a((ServerScoreboard)worldserver.getScoreboard(), par2EntityPlayerMP);
+         this.updateTimeAndWeatherForPlayer(par2EntityPlayerMP, worldserver);
+-        this.sendChatMsg(ChatMessageComponent.createFromTranslationWithSubstitutions("multiplayer.player.joined", new Object[] {par2EntityPlayerMP.getTranslatedEntityName()}).setColor(EnumChatFormatting.YELLOW));
++        ForgeHooks.sendJoinMessage(par2EntityPlayerMP);
+         this.playerLoggedIn(par2EntityPlayerMP);
+         netserverhandler.setPlayerLocation(par2EntityPlayerMP.posX, par2EntityPlayerMP.posY, par2EntityPlayerMP.posZ, par2EntityPlayerMP.rotationYaw, par2EntityPlayerMP.rotationPitch);
+         this.mcServer.getNetworkThread().addPlayer(netserverhandler);
+@@ -392,13 +397,23 @@
       */
      public EntityPlayerMP respawnPlayer(EntityPlayerMP par1EntityPlayerMP, int par2, boolean par3)
      {
@@ -42,7 +52,7 @@
          par1EntityPlayerMP.dimension = par2;
          Object object;
  
-@@ -414,6 +428,7 @@
+@@ -414,6 +429,7 @@
          EntityPlayerMP entityplayermp1 = new EntityPlayerMP(this.mcServer, this.mcServer.worldServerForDimension(par1EntityPlayerMP.dimension), par1EntityPlayerMP.getCommandSenderName(), (ItemInWorldManager)object);
          entityplayermp1.playerNetServerHandler = par1EntityPlayerMP.playerNetServerHandler;
          entityplayermp1.clonePlayer(par1EntityPlayerMP, par3);
@@ -50,7 +60,7 @@
          entityplayermp1.entityId = par1EntityPlayerMP.entityId;
          WorldServer worldserver = this.mcServer.worldServerForDimension(par1EntityPlayerMP.dimension);
          this.func_72381_a(entityplayermp1, par1EntityPlayerMP, worldserver);
-@@ -458,6 +473,11 @@
+@@ -458,6 +474,11 @@
  
      public void transferPlayerToDimension(EntityPlayerMP par1EntityPlayerMP, int par2)
      {
@@ -62,7 +72,7 @@
          int j = par1EntityPlayerMP.dimension;
          WorldServer worldserver = this.mcServer.worldServerForDimension(par1EntityPlayerMP.dimension);
          par1EntityPlayerMP.dimension = par2;
-@@ -465,7 +485,7 @@
+@@ -465,7 +486,7 @@
          par1EntityPlayerMP.playerNetServerHandler.sendPacketToPlayer(new Packet9Respawn(par1EntityPlayerMP.dimension, (byte)par1EntityPlayerMP.worldObj.difficultySetting, worldserver1.getWorldInfo().getTerrainType(), worldserver1.getHeight(), par1EntityPlayerMP.theItemInWorldManager.getGameType()));
          worldserver.removePlayerEntityDangerously(par1EntityPlayerMP);
          par1EntityPlayerMP.isDead = false;
@@ -71,7 +81,7 @@
          this.func_72375_a(par1EntityPlayerMP, worldserver);
          par1EntityPlayerMP.playerNetServerHandler.setPlayerLocation(par1EntityPlayerMP.posX, par1EntityPlayerMP.posY, par1EntityPlayerMP.posZ, par1EntityPlayerMP.rotationYaw, par1EntityPlayerMP.rotationPitch);
          par1EntityPlayerMP.theItemInWorldManager.setWorld(worldserver1);
-@@ -487,39 +507,24 @@
+@@ -487,39 +508,24 @@
       */
      public void transferEntityToWorld(Entity par1Entity, int par2, WorldServer par3WorldServer, WorldServer par4WorldServer)
      {
@@ -122,7 +132,7 @@
              ChunkCoordinates chunkcoordinates;
  
              if (par2 == 1)
-@@ -555,7 +560,7 @@
+@@ -555,7 +561,7 @@
                  par4WorldServer.spawnEntityInWorld(par1Entity);
                  par1Entity.setLocationAndAngles(d0, par1Entity.posY, d1, par1Entity.rotationYaw, par1Entity.rotationPitch);
                  par4WorldServer.updateEntityWithOptionalForce(par1Entity, false);

--- a/src/main/java/net/minecraftforge/common/ForgeHooks.java
+++ b/src/main/java/net/minecraftforge/common/ForgeHooks.java
@@ -24,10 +24,12 @@ import net.minecraft.item.ItemSword;
 import net.minecraft.network.NetServerHandler;
 import net.minecraft.network.packet.Packet;
 import net.minecraft.network.packet.Packet53BlockChange;
+import net.minecraft.server.MinecraftServer;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.AxisAlignedBB;
 import net.minecraft.util.ChatMessageComponent;
 import net.minecraft.util.DamageSource;
+import net.minecraft.util.EnumChatFormatting;
 import net.minecraft.util.EnumMovingObjectType;
 import net.minecraft.util.MathHelper;
 import net.minecraft.util.MovingObjectPosition;
@@ -47,6 +49,7 @@ import net.minecraftforge.event.entity.living.LivingEvent.LivingUpdateEvent;
 import net.minecraftforge.event.entity.living.LivingFallEvent;
 import net.minecraftforge.event.entity.living.LivingHurtEvent;
 import net.minecraftforge.event.entity.living.LivingSetAttackTargetEvent;
+import net.minecraftforge.event.entity.player.PlayerMessageEvent;
 import net.minecraftforge.event.entity.player.PlayerOpenContainerEvent;
 import net.minecraftforge.event.world.BlockEvent;
 
@@ -496,5 +499,21 @@ public class ForgeHooks
             }
         }
         return event;
+    }
+    
+    public static void sendJoinMessage(EntityPlayer player)
+    {
+        ChatMessageComponent message = ChatMessageComponent.createFromTranslationWithSubstitutions("multiplayer.player.joined", player.getTranslatedEntityName()).setColor(EnumChatFormatting.YELLOW);
+        PlayerMessageEvent event = new PlayerMessageEvent.JoinServer(player, message);
+        if(MinecraftForge.EVENT_BUS.post(event)) return;
+        MinecraftServer.getServer().getConfigurationManager().sendChatMsg(event.message);
+    }
+    
+    public static void sendLeaveMessage(EntityPlayer player)
+    {
+        ChatMessageComponent message = ChatMessageComponent.createFromTranslationWithSubstitutions("multiplayer.player.left", player.getTranslatedEntityName()).setColor(EnumChatFormatting.YELLOW);
+        PlayerMessageEvent event = new PlayerMessageEvent.LeaveServer(player, message);
+        if(MinecraftForge.EVENT_BUS.post(event)) return;
+        MinecraftServer.getServer().getConfigurationManager().sendChatMsg(event.message);
     }
 }

--- a/src/main/java/net/minecraftforge/event/entity/player/PlayerMessageEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/player/PlayerMessageEvent.java
@@ -1,0 +1,43 @@
+package net.minecraftforge.event.entity.player;
+
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.util.ChatMessageComponent;
+import net.minecraftforge.event.Cancelable;
+
+/**
+ * This event is fired before the join or leave message is sent.
+ * It can be used to change the {@link ChatMessageComponent} that is sent to the client.
+ * 
+ * Note: Canceling one of these events does NOT prevent the player from logging in.
+ * It does prevent the message from being sent.
+ * 
+ * @author jk-5
+ */
+public class PlayerMessageEvent extends PlayerEvent
+{
+    public ChatMessageComponent message;
+    
+    public PlayerMessageEvent(EntityPlayer player, ChatMessageComponent message)
+    {
+        super(player);
+        this.message = message;
+    }
+    
+    @Cancelable
+    public static class JoinServer extends PlayerMessageEvent
+    {
+        public JoinServer(EntityPlayer player, ChatMessageComponent message)
+        {
+            super(player, message);
+        }
+    }
+    
+    @Cancelable
+    public static class LeaveServer extends PlayerMessageEvent
+    {
+        public LeaveServer(EntityPlayer player, ChatMessageComponent message)
+        {
+            super(player, message);
+        }
+    }
+}


### PR DESCRIPTION
Subscribe to either `PlayerMessageEvent.JoinServer` or `PlayerMessageEvent.LeaveServer`, and use the `message` field to modify the message, or cancel the event to not show any message.

It would be nice to have this in 1.6.4, but if you guys are too busy with the update, just let it wait till 1.7
