### PR TITLE
Refactored BiomeManager stronghold add/remove methods to support new MapGenStronghold dynamic biome changes.

### DIFF
--- a/patches/minecraft/net/minecraft/world/chunk/Chunk.java.patch
+++ b/patches/minecraft/net/minecraft/world/chunk/Chunk.java.patch
@@ -154,7 +154,7 @@
          p_150812_4_.field_145849_e = this.zPosition * 16 + p_150812_3_;
  
 -        if (this.func_150810_a(p_150812_1_, p_150812_2_, p_150812_3_) instanceof ITileEntityProvider)
-+        int metadata = getBlockMetadata( p_150812_4_.field_145851_c, p_150812_4_.field_145848_d, p_150812_4_.field_145849_e);
++        int metadata = getBlockMetadata(p_150812_1_, p_150812_2_, p_150812_3_);
 +        if (this.func_150810_a(p_150812_1_, p_150812_2_, p_150812_3_).hasTileEntity(metadata))
          {
              if (this.field_150816_i.containsKey(chunkposition))

--- a/patches/minecraft/net/minecraft/world/gen/ChunkProviderEnd.java.patch
+++ b/patches/minecraft/net/minecraft/world/gen/ChunkProviderEnd.java.patch
@@ -16,13 +16,13 @@
          this.noiseGen4 = new NoiseGeneratorOctaves(this.endRNG, 10);
          this.noiseGen5 = new NoiseGeneratorOctaves(this.endRNG, 16);
 +
-+        NoiseGeneratorOctaves[] noiseGens = {noiseGen1, noiseGen2, noiseGen3, noiseGen4, noiseGen5};
++        NoiseGenerator[] noiseGens = {noiseGen1, noiseGen2, noiseGen3, noiseGen4, noiseGen5};
 +        noiseGens = TerrainGen.getModdedNoiseGenerators(par1World, this.endRNG, noiseGens);
-+        this.noiseGen1 = noiseGens[0];
-+        this.noiseGen2 = noiseGens[1];
-+        this.noiseGen3 = noiseGens[2];
-+        this.noiseGen4 = noiseGens[3];
-+        this.noiseGen5 = noiseGens[4];
++        this.noiseGen1 = (NoiseGeneratorOctaves)noiseGens[0];
++        this.noiseGen2 = (NoiseGeneratorOctaves)noiseGens[1];
++        this.noiseGen3 = (NoiseGeneratorOctaves)noiseGens[2];
++        this.noiseGen4 = (NoiseGeneratorOctaves)noiseGens[3];
++        this.noiseGen5 = (NoiseGeneratorOctaves)noiseGens[4];
      }
  
      public void func_147420_a(int p_147420_1_, int p_147420_2_, Block[] p_147420_3_, BiomeGenBase[] p_147420_4_)

--- a/patches/minecraft/net/minecraft/world/gen/ChunkProviderGenerate.java.patch
+++ b/patches/minecraft/net/minecraft/world/gen/ChunkProviderGenerate.java.patch
@@ -34,15 +34,15 @@
              }
          }
 +
-+        NoiseGeneratorOctaves[] noiseGens = {field_147431_j, field_147432_k, field_147429_l, field_147430_m, noiseGen5, noiseGen6, mobSpawnerNoise};
++        NoiseGenerator[] noiseGens = {field_147431_j, field_147432_k, field_147429_l, field_147430_m, noiseGen5, noiseGen6, mobSpawnerNoise};
 +        noiseGens = TerrainGen.getModdedNoiseGenerators(par1World, this.rand, noiseGens);
-+        this.field_147431_j = noiseGens[0];
-+        this.field_147432_k = noiseGens[1];
-+        this.field_147429_l = noiseGens[2];
-+        this.field_147430_m = noiseGens[3];
-+        this.noiseGen5 = noiseGens[4];
-+        this.noiseGen6 = noiseGens[5];
-+        this.mobSpawnerNoise = noiseGens[6];
++        this.field_147431_j = (NoiseGeneratorOctaves)noiseGens[0];
++        this.field_147432_k = (NoiseGeneratorOctaves)noiseGens[1];
++        this.field_147429_l = (NoiseGeneratorOctaves)noiseGens[2];
++        this.field_147430_m = (NoiseGeneratorPerlin)noiseGens[3];
++        this.noiseGen5 = (NoiseGeneratorOctaves)noiseGens[4];
++        this.noiseGen6 = (NoiseGeneratorOctaves)noiseGens[5];
++        this.mobSpawnerNoise = (NoiseGeneratorOctaves)noiseGens[6];
      }
  
      public void func_147424_a(int p_147424_1_, int p_147424_2_, Block[] p_147424_3_)

--- a/patches/minecraft/net/minecraft/world/gen/ChunkProviderHell.java.patch
+++ b/patches/minecraft/net/minecraft/world/gen/ChunkProviderHell.java.patch
@@ -32,15 +32,15 @@
          this.netherNoiseGen6 = new NoiseGeneratorOctaves(this.hellRNG, 10);
          this.netherNoiseGen7 = new NoiseGeneratorOctaves(this.hellRNG, 16);
 +
-+        NoiseGeneratorOctaves[] noiseGens = {netherNoiseGen1, netherNoiseGen2, netherNoiseGen3, slowsandGravelNoiseGen, netherrackExculsivityNoiseGen, netherNoiseGen6, netherNoiseGen7};
++        NoiseGenerator[] noiseGens = {netherNoiseGen1, netherNoiseGen2, netherNoiseGen3, slowsandGravelNoiseGen, netherrackExculsivityNoiseGen, netherNoiseGen6, netherNoiseGen7};
 +        noiseGens = TerrainGen.getModdedNoiseGenerators(par1World, this.hellRNG, noiseGens);
-+        this.netherNoiseGen1 = noiseGens[0];
-+        this.netherNoiseGen2 = noiseGens[1];
-+        this.netherNoiseGen3 = noiseGens[2];
-+        this.slowsandGravelNoiseGen = noiseGens[3];
-+        this.netherrackExculsivityNoiseGen = noiseGens[4];
-+        this.netherNoiseGen6 = noiseGens[5];
-+        this.netherNoiseGen7 = noiseGens[6];
++        this.netherNoiseGen1 = (NoiseGeneratorOctaves)noiseGens[0];
++        this.netherNoiseGen2 = (NoiseGeneratorOctaves)noiseGens[1];
++        this.netherNoiseGen3 = (NoiseGeneratorOctaves)noiseGens[2];
++        this.slowsandGravelNoiseGen = (NoiseGeneratorOctaves)noiseGens[3];
++        this.netherrackExculsivityNoiseGen = (NoiseGeneratorOctaves)noiseGens[4];
++        this.netherNoiseGen6 = (NoiseGeneratorOctaves)noiseGens[5];
++        this.netherNoiseGen7 = (NoiseGeneratorOctaves)noiseGens[6];
      }
  
      public void func_147419_a(int p_147419_1_, int p_147419_2_, Block[] p_147419_3_)

--- a/patches/minecraft/net/minecraft/world/gen/structure/MapGenStronghold.java.patch
+++ b/patches/minecraft/net/minecraft/world/gen/structure/MapGenStronghold.java.patch
@@ -1,0 +1,30 @@
+--- ../src-base/minecraft/net/minecraft/world/gen/structure/MapGenStronghold.java
++++ ../src-work/minecraft/net/minecraft/world/gen/structure/MapGenStronghold.java
+@@ -11,6 +11,7 @@
+ import net.minecraft.world.ChunkPosition;
+ import net.minecraft.world.World;
+ import net.minecraft.world.biome.BiomeGenBase;
++import net.minecraftforge.common.BiomeManager;
+ 
+ public class MapGenStronghold extends MapGenStructure
+ {
+@@ -35,11 +36,18 @@
+         {
+             BiomeGenBase biomegenbase = abiomegenbase[j];
+ 
+-            if (biomegenbase != null && biomegenbase.minHeight > 0.0F)
++            if (biomegenbase != null && biomegenbase.minHeight > 0.0F && !BiomeManager.strongHoldBiomesBlackList.contains(biomegenbase))
+             {
+                 this.field_151546_e.add(biomegenbase);
+             }
+         }
++        for (BiomeGenBase biome : BiomeManager.strongHoldBiomes)
++        {
++            if (!this.field_151546_e.contains(biome))
++            {
++                this.field_151546_e.add(biome);
++            }
++        }
+     }
+ 
+     public MapGenStronghold(Map par1Map)

--- a/src/main/java/net/minecraftforge/common/BiomeManager.java
+++ b/src/main/java/net/minecraftforge/common/BiomeManager.java
@@ -16,6 +16,9 @@ import com.google.common.collect.Lists;
 
 public class BiomeManager
 {
+    public static ArrayList<BiomeGenBase> strongHoldBiomes = new ArrayList<BiomeGenBase>();
+    public static ArrayList<BiomeGenBase> strongHoldBiomesBlackList = new ArrayList<BiomeGenBase>();
+
     public static void addVillageBiome(BiomeGenBase biome, boolean canSpawn)
     {
         if (!MapGenVillage.villageSpawnBiomes.contains(biome))
@@ -38,17 +41,17 @@ public class BiomeManager
 
     public static void addStrongholdBiome(BiomeGenBase biome)
     {
-        if (!MapGenStronghold.field_151546_e.contains(biome))
+        if (!strongHoldBiomes.contains(biome))
         {
-            MapGenStronghold.field_151546_e.add(biome);
+            strongHoldBiomes.add(biome);
         }
     }
 
     public static void removeStrongholdBiome(BiomeGenBase biome)
     {
-        if (MapGenStronghold.field_151546_e.contains(biome))
+        if (!strongHoldBiomesBlackList.contains(biome))
         {
-            MapGenStronghold.field_151546_e.remove(biome);
+            strongHoldBiomesBlackList.add(biome);
         }
     }
 

--- a/src/main/java/net/minecraftforge/event/terraingen/InitNoiseGensEvent.java
+++ b/src/main/java/net/minecraftforge/event/terraingen/InitNoiseGensEvent.java
@@ -3,16 +3,16 @@ package net.minecraftforge.event.terraingen;
 import java.util.Random;
 
 import net.minecraft.world.World;
-import net.minecraft.world.gen.NoiseGeneratorOctaves;
+import net.minecraft.world.gen.NoiseGenerator;
 import net.minecraftforge.event.world.*;
 
 public class InitNoiseGensEvent extends WorldEvent
 {
     public final Random rand;
-    public final NoiseGeneratorOctaves[] originalNoiseGens;
-    public NoiseGeneratorOctaves[] newNoiseGens;
+    public final NoiseGenerator[] originalNoiseGens;
+    public NoiseGenerator[] newNoiseGens;
     
-    public InitNoiseGensEvent(World world, Random rand, NoiseGeneratorOctaves[] original)
+    public InitNoiseGensEvent(World world, Random rand, NoiseGenerator[] original)
     {
         super(world);
         this.rand = rand;

--- a/src/main/java/net/minecraftforge/event/terraingen/TerrainGen.java
+++ b/src/main/java/net/minecraftforge/event/terraingen/TerrainGen.java
@@ -7,7 +7,7 @@ import cpw.mods.fml.common.eventhandler.Event.*;
 import net.minecraft.world.World;
 import net.minecraft.world.chunk.IChunkProvider;
 import net.minecraft.world.gen.MapGenBase;
-import net.minecraft.world.gen.NoiseGeneratorOctaves;
+import net.minecraft.world.gen.NoiseGenerator;
 import net.minecraft.world.gen.feature.WorldGenerator;
 import net.minecraftforge.common.*;
 import net.minecraftforge.event.terraingen.DecorateBiomeEvent.*;
@@ -17,7 +17,7 @@ import net.minecraftforge.event.terraingen.PopulateChunkEvent.*;
 
 public abstract class TerrainGen
 {
-    public static NoiseGeneratorOctaves[] getModdedNoiseGenerators(World world, Random rand, NoiseGeneratorOctaves[] original)
+    public static NoiseGenerator[] getModdedNoiseGenerators(World world, Random rand, NoiseGenerator[] original)
     {
         InitNoiseGensEvent event = new InitNoiseGensEvent(world, rand, original);
         MinecraftForge.TERRAIN_GEN_BUS.post(event);


### PR DESCRIPTION
Changed InitNoiseGensEvent to pass a NoiseGenerator array instead of NoiseGeneratorOctaves due to new NoiseGeneratorPerlin in ChunkProviderGenerate.
Fixed worldgen crash caused by wrong metadata in Chunk patch.
