### PR TITLE
Made BlockCrops.getDrops call its super method

### DIFF
--- a/patches/minecraft/net/minecraft/block/BlockCrops.java.patch
+++ b/patches/minecraft/net/minecraft/block/BlockCrops.java.patch
@@ -61,7 +61,7 @@
 +    @Override
 +    public ArrayList<ItemStack> getDrops(World world, int x, int y, int z, int metadata, int fortune)
 +    {
-+        ArrayList<ItemStack> ret = new ArrayList<ItemStack>();
++        ArrayList<ItemStack> ret = super.getDrops(world, x, y, z, metadata, fortune);
 +
 +        if (metadata >= 7)
 +        {


### PR DESCRIPTION
This fixes issues with blocks extending BlockCrops only dropping their seeds and not their crop
