### PR TITLE
Made canBeReplacedByLeaves default to whether a block isn't opaque rathe...

### DIFF
--- a/patches/minecraft/net/minecraft/block/Block.java.patch
+++ b/patches/minecraft/net/minecraft/block/Block.java.patch
@@ -688,7 +688,7 @@
 +     */
 +    public boolean canBeReplacedByLeaves(IBlockAccess world, int x, int y, int z)
 +    {
-+        return func_149730_j();
++        return !func_149730_j();
 +    }
 +
 +    /**

--- a/patches/minecraft/net/minecraft/world/gen/feature/WorldGenBigMushroom.java.patch
+++ b/patches/minecraft/net/minecraft/world/gen/feature/WorldGenBigMushroom.java.patch
@@ -14,7 +14,7 @@
                                  }
  
 -                                if ((j2 != 0 || par4 >= par4 + i1 - 1) && !par1World.func_147439_a(l2, k1, i2).func_149730_j())
-+                                if ((j2 != 0 || par4 >= par4 + i1 - 1) && !par1World.func_147439_a(l2, k1, i2).canBeReplacedByLeaves(par1World, l2, k1, i2))
++                                if ((j2 != 0 || par4 >= par4 + i1 - 1) && par1World.func_147439_a(l2, k1, i2).canBeReplacedByLeaves(par1World, l2, k1, i2))
                                  {
                                      this.func_150516_a(par1World, l2, k1, i2, Block.func_149729_e(Block.func_149682_b(Blocks.brown_mushroom_block) + l), j2);
                                  }

--- a/patches/minecraft/net/minecraft/world/gen/feature/WorldGenSwamp.java.patch
+++ b/patches/minecraft/net/minecraft/world/gen/feature/WorldGenSwamp.java.patch
@@ -39,7 +39,7 @@
                                  int j2 = i2 - par5;
  
 -                                if ((Math.abs(l1) != k1 || Math.abs(j2) != k1 || par2Random.nextInt(2) != 0 && j1 != 0) && !par1World.func_147439_a(l2, k2, i2).func_149730_j())
-+                                if ((Math.abs(l1) != k1 || Math.abs(j2) != k1 || par2Random.nextInt(2) != 0 && j1 != 0) && !par1World.func_147439_a(l2, k2, i2).canBeReplacedByLeaves(par1World, l2, k2, i2))
++                                if ((Math.abs(l1) != k1 || Math.abs(j2) != k1 || par2Random.nextInt(2) != 0 && j1 != 0) && par1World.func_147439_a(l2, k2, i2).canBeReplacedByLeaves(par1World, l2, k2, i2))
                                  {
                                      this.func_150515_a(par1World, l2, k2, i2, Blocks.leaves);
                                  }

--- a/patches/minecraft/net/minecraft/world/gen/feature/WorldGenTaiga1.java.patch
+++ b/patches/minecraft/net/minecraft/world/gen/feature/WorldGenTaiga1.java.patch
@@ -39,7 +39,7 @@
                                  int l2 = k2 - par5;
  
 -                                if ((Math.abs(j3) != i3 || Math.abs(l2) != i3 || i3 <= 0) && !par1World.func_147439_a(j2, i2, k2).func_149730_j())
-+                                if ((Math.abs(j3) != i3 || Math.abs(l2) != i3 || i3 <= 0) && !par1World.func_147439_a(j2, i2, k2).canBeReplacedByLeaves(par1World, j2, i2, k2))
++                                if ((Math.abs(j3) != i3 || Math.abs(l2) != i3 || i3 <= 0) && par1World.func_147439_a(j2, i2, k2).canBeReplacedByLeaves(par1World, j2, i2, k2))
                                  {
                                      this.func_150516_a(par1World, j2, i2, k2, Blocks.leaves, 1);
                                  }

--- a/patches/minecraft/net/minecraft/world/gen/feature/WorldGenTaiga2.java.patch
+++ b/patches/minecraft/net/minecraft/world/gen/feature/WorldGenTaiga2.java.patch
@@ -39,7 +39,7 @@
                                  int k3 = j3 - par5;
  
 -                                if ((Math.abs(i3) != l3 || Math.abs(k3) != l3 || l3 <= 0) && !par1World.func_147439_a(l2, k2, j3).func_149730_j())
-+                                if ((Math.abs(i3) != l3 || Math.abs(k3) != l3 || l3 <= 0) && !par1World.func_147439_a(l2, k2, j3).canBeReplacedByLeaves(par1World, l2, k2, j3))
++                                if ((Math.abs(i3) != l3 || Math.abs(k3) != l3 || l3 <= 0) && par1World.func_147439_a(l2, k2, j3).canBeReplacedByLeaves(par1World, l2, k2, j3))
                                  {
                                      this.func_150516_a(par1World, l2, k2, j3, Blocks.leaves, 1);
                                  }


### PR DESCRIPTION
...r than if it is, also uninverted the checks for canBeReplacedByLeaves in WorldGenBigMushroom, WorldGenSwamp, WorldGenTaiga1 and WorldGenTaiga2
