### PR TITLE
Fixed issue with forward-slashes in texture names when registering icons, fixed custom item renderer retrieval.

### DIFF
--- a/patches/minecraft/net/minecraft/client/Minecraft.java.patch
+++ b/patches/minecraft/net/minecraft/client/Minecraft.java.patch
@@ -72,7 +72,7 @@
          if (p_147108_1_ instanceof GuiMainMenu)
          {
              this.gameSettings.showDebugInfo = false;
-@@ -1338,7 +1352,7 @@
+@@ -1337,7 +1351,7 @@
  
                      if (this.thePlayer.isCurrentToolAdventureModeExempt(i, j, k))
                      {
@@ -81,7 +81,7 @@
                          this.thePlayer.swingItem();
                      }
                  }
-@@ -1419,11 +1433,12 @@
+@@ -1418,11 +1432,12 @@
                      int j = this.objectMouseOver.blockY;
                      int k = this.objectMouseOver.blockZ;
  
@@ -96,7 +96,7 @@
                          {
                              flag = false;
                              this.thePlayer.swingItem();
-@@ -1450,7 +1465,8 @@
+@@ -1449,7 +1464,8 @@
          {
              ItemStack itemstack1 = this.thePlayer.inventory.getCurrentItem();
  
@@ -106,7 +106,7 @@
              {
                  this.entityRenderer.itemRenderer.resetEquippedProgress2();
              }
-@@ -1652,6 +1668,8 @@
+@@ -1651,6 +1667,8 @@
  
              while (Mouse.next())
              {
@@ -115,7 +115,7 @@
                  i = Mouse.getEventButton();
  
                  if (isRunningOnMac && i == 0 && (Keyboard.isKeyDown(29) || Keyboard.isKeyDown(157)))
-@@ -2121,6 +2139,11 @@
+@@ -2120,6 +2138,11 @@
      // JAVADOC METHOD $$ func_71353_a
      public void loadWorld(WorldClient par1WorldClient, String par2Str)
      {
@@ -127,7 +127,7 @@
          if (par1WorldClient == null)
          {
              NetHandlerPlayClient nethandlerplayclient = this.func_147114_u();
-@@ -2133,6 +2156,18 @@
+@@ -2132,6 +2155,18 @@
              if (this.theIntegratedServer != null)
              {
                  this.theIntegratedServer.initiateShutdown();
@@ -146,7 +146,7 @@
              }
  
              this.theIntegratedServer = null;
-@@ -2288,113 +2323,10 @@
+@@ -2287,113 +2322,10 @@
          if (this.objectMouseOver != null)
          {
              boolean flag = this.thePlayer.capabilities.isCreativeMode;
@@ -262,7 +262,7 @@
              if (flag)
              {
                  j = this.thePlayer.inventoryContainer.inventorySlots.size() - 9 + this.thePlayer.inventory.currentItem;
-@@ -2564,9 +2496,16 @@
+@@ -2563,9 +2495,16 @@
          par1PlayerUsageSnooper.addData("gl_max_texture_size", Integer.valueOf(getGLMaximumTextureSize()));
      }
  
@@ -279,7 +279,7 @@
          for (int i = 16384; i > 0; i >>= 1)
          {
              GL11.glTexImage2D(GL11.GL_PROXY_TEXTURE_2D, 0, GL11.GL_RGBA, i, i, 0, GL11.GL_RGBA, GL11.GL_UNSIGNED_BYTE, (ByteBuffer)null);
-@@ -2574,6 +2513,7 @@
+@@ -2573,6 +2512,7 @@
  
              if (j != 0)
              {

--- a/patches/minecraft/net/minecraft/client/renderer/texture/TextureMap.java.patch
+++ b/patches/minecraft/net/minecraft/client/renderer/texture/TextureMap.java.patch
@@ -48,6 +48,15 @@
      }
  
      private ResourceLocation func_147634_a(ResourceLocation p_147634_1_, int p_147634_2_)
+@@ -348,7 +363,7 @@
+         {
+             throw new IllegalArgumentException("Name cannot be null!");
+         }
+-        else if (par1Str.indexOf(47) == -1 && par1Str.indexOf(92) == -1)
++        else if (par1Str.indexOf(92) == -1) // Disable backslashes (\) in texture asset paths.
+         {
+             Object object = (TextureAtlasSprite)this.mapRegisteredSprites.get(par1Str);
+ 
 @@ -404,4 +419,37 @@
      {
          this.field_147637_k = p_147632_1_;

--- a/src/main/java/net/minecraftforge/client/MinecraftForgeClient.java
+++ b/src/main/java/net/minecraftforge/client/MinecraftForgeClient.java
@@ -40,7 +40,7 @@ public class MinecraftForgeClient
 
     public static IItemRenderer getItemRenderer(ItemStack item, ItemRenderType type)
     {
-        IItemRenderer renderer = customItemRenderers.get(item);
+        IItemRenderer renderer = customItemRenderers.get(item.getItem());
         if (renderer != null && renderer.handleRenderType(item, type))
         {
             return renderer;


### PR DESCRIPTION
Fixed MinecraftForgeClient for custom Item Renderer implementations. Removed check for forward-slashes (/) in texture asset locations (but left check for backslash in place).
