### PR TITLE
Fixed RenderWorldLastEvent never being called

### DIFF
--- a/patches/minecraft/net/minecraft/client/renderer/EntityRenderer.java.patch
+++ b/patches/minecraft/net/minecraft/client/renderer/EntityRenderer.java.patch
@@ -125,3 +125,13 @@
              GL11.glDepthMask(true);
              GL11.glEnable(GL11.GL_CULL_FACE);
              GL11.glDisable(GL11.GL_BLEND);
+@@ -1357,6 +1380,9 @@
+                 this.renderCloudsCheck(renderglobal, par1);
+             }
+ 
++            this.mc.mcProfiler.endStartSection("FRenderLast");
++            ForgeHooksClient.dispatchRenderLast(renderglobal, par1);
++            
+             this.mc.mcProfiler.endStartSection("hand");
+ 
+             if (this.cameraZoom == 1.0D)


### PR DESCRIPTION
This was an event used by my mod but I found out it was not being called
so I have re implemented it back into the EntityRenderer.java. I have
tested it in 1.7.2 and everything is now working normally
