### PR TITLE
Add the ability to add custom records with sound files in custom domains

### DIFF
--- a/patches/minecraft/net/minecraft/client/renderer/RenderGlobal.java.patch
+++ b/patches/minecraft/net/minecraft/client/renderer/RenderGlobal.java.patch
@@ -111,3 +111,17 @@
          double d0 = par2EntityPlayer.lastTickPosX + (par2EntityPlayer.posX - par2EntityPlayer.lastTickPosX) * (double)par3;
          double d1 = par2EntityPlayer.lastTickPosY + (par2EntityPlayer.posY - par2EntityPlayer.lastTickPosY) * (double)par3;
          double d2 = par2EntityPlayer.lastTickPosZ + (par2EntityPlayer.posZ - par2EntityPlayer.lastTickPosZ) * (double)par3;
+@@ -1837,11 +1871,12 @@
+ 
+         if (par1Str != null)
+         {
+-            ItemRecord itemrecord = ItemRecord.func_150926_b(par1Str);
++            ItemRecord itemrecord = ItemRecord.func_150926_b(par1Str.replace("records.", ""));
+ 
+             if (itemrecord != null)
+             {
+                 this.mc.ingameGUI.setRecordPlayingMessage(itemrecord.func_150927_i());
++                par1Str = itemrecord.getResourceDomain() + ":" + par1Str;
+             }
+ 
+             PositionedSoundRecord positionedsoundrecord = PositionedSoundRecord.func_147675_a(new ResourceLocation(par1Str), (float)par2, (float)par3, (float)par4);

--- a/patches/minecraft/net/minecraft/item/ItemRecord.java.patch
+++ b/patches/minecraft/net/minecraft/item/ItemRecord.java.patch
@@ -1,0 +1,13 @@
+--- ../src-base/minecraft/net/minecraft/item/ItemRecord.java
++++ ../src-work/minecraft/net/minecraft/item/ItemRecord.java
+@@ -81,4 +81,10 @@
+     {
+         return (ItemRecord)field_150928_b.get(p_150926_0_);
+     }
++    
++    @SideOnly(Side.CLIENT)
++    public String getResourceDomain() 
++    {
++        return "minecraft";
++    }
+ }


### PR DESCRIPTION
Also fixing the issue with the record playing message not appearing due to itemrecord being null at runtime

Without this, it is impossible to play a record. without putting it in the minecraft domain and hence it will throw an error:[Client thread/WARN]: Unable to play unknown soundEvent: minecraft:records.song (given that the name of the record is "song"
