### PR TITLE
Exclude cobblestone slab recipe from ore dictification

### DIFF
--- a/src/main/java/net/minecraftforge/oredict/OreDictionary.java
+++ b/src/main/java/net/minecraftforge/oredict/OreDictionary.java
@@ -130,6 +130,7 @@ public class OreDictionary
             new ItemStack(Items.cookie),
             new ItemStack(Blocks.stonebrick),
             new ItemStack(Blocks.stone_slab),
+            new ItemStack(Blocks.stone_slab, 1, 3),
             new ItemStack(Blocks.stone_stairs),
             new ItemStack(Blocks.cobblestone_wall),
             new ItemStack(Blocks.oak_stairs),


### PR DESCRIPTION
The exclusion for the stone slab block is only excluding stone slabs (meta 0). For consistency, we should also exclude cobblestone slabs (meta 3).
