### PR TITLE
Added getBlock to ItemBlock

### DIFF
--- a/patches/minecraft/net/minecraft/item/ItemBlock.java.patch
+++ b/patches/minecraft/net/minecraft/item/ItemBlock.java.patch
@@ -63,4 +63,8 @@
 +
 +       return true;
 +    }
++    
++    public Block getBlock(){
++       return field_150939_a;
++    }
  }


### PR DESCRIPTION
field_150939_a is protected, therefore it becomes a pain to find out what Block the ItemBlock is for.
