### PR TITLE
Fix Hash of ContainerKey

### DIFF
--- a/src/main/java/net/minecraftforge/fluids/FluidContainerRegistry.java
+++ b/src/main/java/net/minecraftforge/fluids/FluidContainerRegistry.java
@@ -47,7 +47,7 @@ public abstract class FluidContainerRegistry
         public int hashCode()
         {
             int code = 1;
-            code = 31*code + Item.hashCode();
+            code = 31*code + container.getItem().hashCode();
             code = 31*code + container.getItemDamage()
             if (fluid != null)
                 code = 31*code + fluid.fluidID;


### PR DESCRIPTION
ItemStacks don't have a persistant HashCode, so I made it use the ItemDamage, the ItemID and the hashcode of the nbttag (which seems to be persistant)

fixes this:
https://github.com/MinecraftForge/MinecraftForge/issues/962

(second commit also fixes NBTTag)
