### PR TITLE
Fix Hash of ContainerKey

### DIFF
--- a/src/main/java/net/minecraftforge/fluids/FluidContainerRegistry.java
+++ b/src/main/java/net/minecraftforge/fluids/FluidContainerRegistry.java
@@ -63,8 +63,9 @@ public abstract class FluidContainerRegistry
             if(!(obj instanceof ContainerKey))
             	return false;
             ContainerKey key = (ContainerKey) obj;
+            boolean bothFluidsNull = fluid != null && key.fluid != null;
             boolean itemStacksEqual = ItemStack.areItemStacksEqual(container, key.container) && ItemStack.areItemStackTagsEqual(container, key.container);
-            boolean fluidsEqual = fluid != null && key.fluid ? fluid.isFluidStackIdentical(key.fluid) && FluidStack.areFluidStackTagsEqual(fluid, key.fluid) : true;
+            boolean fluidsEqual = bothFluidsNull ? fluid.isFluidStackIdentical(key.fluid) && FluidStack.areFluidStackTagsEqual(fluid, key.fluid) : bothFluidsNull;
             return itemStacksEqual && fluidsEqual;
         }
     }


### PR DESCRIPTION
ItemStacks don't have a persistant HashCode, so I made it use the ItemDamage and the hashCode of the Item (which is static) 

fixes this:
https://github.com/MinecraftForge/MinecraftForge/issues/962
