### PR TITLE
Add equals method

### DIFF
--- a/src/main/java/net/minecraftforge/fluids/FluidContainerRegistry.java
+++ b/src/main/java/net/minecraftforge/fluids/FluidContainerRegistry.java
@@ -1,4 +1,3 @@
-
 package net.minecraftforge.fluids;
 
 import java.util.Arrays;
@@ -53,6 +52,10 @@ public abstract class FluidContainerRegistry
             if (fluid != null)
                 code = 31*code + fluid.fluidID;
             return code;
+        }
+        @Override
+        public boolean equals(Object o){
+            return o != null && o.hashCode() == hashCode();
         }
     }
 


### PR DESCRIPTION
Because HashMaps use that, if the hashcode is the same (what we want), hashCode only puts objects in the same bucket, equals is used to compare them finally. This will make the FluidContainerRegistry finally work as expected.

Null check is probably obsolete since the HashMap shouldnt contain null, added it although. Didn't use instanceof since it would be a waste of resources.
