### PR TITLE
* IAnvilRecipe (IRecipe-style Anvil Recipes)

### DIFF
--- a/patches/minecraft/net/minecraft/inventory/ContainerRepair.java.patch
+++ b/patches/minecraft/net/minecraft/inventory/ContainerRepair.java.patch
@@ -1,39 +1,23 @@
 --- ../src-base/minecraft/net/minecraft/inventory/ContainerRepair.java
 +++ ../src-work/minecraft/net/minecraft/inventory/ContainerRepair.java
-@@ -2,8 +2,10 @@
- 
- import cpw.mods.fml.relauncher.Side;
- import cpw.mods.fml.relauncher.SideOnly;
-+
- import java.util.Iterator;
- import java.util.Map;
-+
- import net.minecraft.enchantment.Enchantment;
- import net.minecraft.enchantment.EnchantmentHelper;
- import net.minecraft.entity.player.EntityPlayer;
-@@ -12,6 +14,8 @@
+@@ -12,6 +12,7 @@
  import net.minecraft.init.Items;
  import net.minecraft.item.ItemStack;
  import net.minecraft.world.World;
 +import net.minecraftforge.common.AnvilRecipes;
-+
  import org.apache.commons.lang3.StringUtils;
  import org.apache.logging.log4j.LogManager;
  import org.apache.logging.log4j.Logger;
-@@ -74,26 +78,45 @@
+@@ -74,6 +75,24 @@
                      par1EntityPlayer.addExperienceLevel(-ContainerRepair.this.maximumCost);
                  }
  
--                ContainerRepair.this.inputSlots.setInventorySlotContents(0, (ItemStack)null);
--
--                if (ContainerRepair.this.stackSizeToBeUsedInRepair > 0)
 +                // IAnvilRecipe Implementation
 +                boolean renaming = false;
 +                if(!StringUtils.isBlank(ContainerRepair.this.repairedItemName) && (!ContainerRepair.this.repairedItemName.equals(ContainerRepair.this.inputSlots.getStackInSlot(0).getDisplayName())))
 +                    renaming = true;
 +                if(AnvilRecipes.getInstance().getRepairResult(ContainerRepair.this.inputSlots.getStackInSlot(0), ContainerRepair.this.inputSlots.getStackInSlot(1), renaming, ContainerRepair.this.theWorld) != null)
-                 {
--                    ItemStack itemstack1 = ContainerRepair.this.inputSlots.getStackInSlot(1);
++                {
 +                    AnvilRecipes.getInstance().repair(ContainerRepair.this.inputSlots.getStackInSlot(0), ContainerRepair.this.inputSlots.getStackInSlot(1), par2ItemStack, renaming, ContainerRepair.this.theWorld);
 +                    
 +                    if(ContainerRepair.this.inputSlots.getStackInSlot(0).stackSize <= 0)
@@ -46,38 +30,18 @@
 +                }
 +                else
 +                {
-+                    ContainerRepair.this.inputSlots.setInventorySlotContents(0, (ItemStack)null);
+                 ContainerRepair.this.inputSlots.setInventorySlotContents(0, (ItemStack)null);
  
--                    if (itemstack1 != null && itemstack1.stackSize > ContainerRepair.this.stackSizeToBeUsedInRepair)
-+                    if (ContainerRepair.this.stackSizeToBeUsedInRepair > 0)
-                     {
--                        itemstack1.stackSize -= ContainerRepair.this.stackSizeToBeUsedInRepair;
--                        ContainerRepair.this.inputSlots.setInventorySlotContents(1, itemstack1);
-+                        ItemStack itemstack1 = ContainerRepair.this.inputSlots.getStackInSlot(1);
-+    
-+                        if (itemstack1 != null && itemstack1.stackSize > ContainerRepair.this.stackSizeToBeUsedInRepair)
-+                        {
-+                            itemstack1.stackSize -= ContainerRepair.this.stackSizeToBeUsedInRepair;
-+                            ContainerRepair.this.inputSlots.setInventorySlotContents(1, itemstack1);
-+                        }
-+                        else
-+                        {
-+                            ContainerRepair.this.inputSlots.setInventorySlotContents(1, (ItemStack)null);
-+                        }
-                     }
-                     else
-                     {
-                         ContainerRepair.this.inputSlots.setInventorySlotContents(1, (ItemStack)null);
-                     }
+                 if (ContainerRepair.this.stackSizeToBeUsedInRepair > 0)
+@@ -94,6 +113,7 @@
+                 {
+                     ContainerRepair.this.inputSlots.setInventorySlotContents(1, (ItemStack)null);
                  }
--                else
--                {
--                    ContainerRepair.this.inputSlots.setInventorySlotContents(1, (ItemStack)null);
--                }
++                }
  
                  ContainerRepair.this.maximumCost = 0;
  
-@@ -177,9 +200,26 @@
+@@ -177,6 +197,23 @@
              int l1;
              Iterator iterator1;
              Enchantment enchantment;
@@ -100,12 +64,8 @@
 +            }
  
              if (itemstack2 != null)
--            {
-+            {                
-                 flag = itemstack2.getItem() == Items.enchanted_book && Items.enchanted_book.func_92110_g(itemstack2).tagCount() > 0;
- 
-                 if (itemstack1.isItemStackDamageable() && itemstack1.getItem().getIsRepairable(itemstack, itemstack2))
-@@ -383,6 +423,8 @@
+             {
+@@ -383,6 +420,8 @@
                  k2 = Math.max(1, k2 / 2);
              }
  

--- a/patches/minecraft/net/minecraft/inventory/ContainerRepair.java.patch
+++ b/patches/minecraft/net/minecraft/inventory/ContainerRepair.java.patch
@@ -1,6 +1,111 @@
 --- ../src-base/minecraft/net/minecraft/inventory/ContainerRepair.java
 +++ ../src-work/minecraft/net/minecraft/inventory/ContainerRepair.java
-@@ -383,6 +383,8 @@
+@@ -2,8 +2,10 @@
+ 
+ import cpw.mods.fml.relauncher.Side;
+ import cpw.mods.fml.relauncher.SideOnly;
++
+ import java.util.Iterator;
+ import java.util.Map;
++
+ import net.minecraft.enchantment.Enchantment;
+ import net.minecraft.enchantment.EnchantmentHelper;
+ import net.minecraft.entity.player.EntityPlayer;
+@@ -12,6 +14,8 @@
+ import net.minecraft.init.Items;
+ import net.minecraft.item.ItemStack;
+ import net.minecraft.world.World;
++import net.minecraftforge.common.AnvilRecipes;
++
+ import org.apache.commons.lang3.StringUtils;
+ import org.apache.logging.log4j.LogManager;
+ import org.apache.logging.log4j.Logger;
+@@ -74,26 +78,45 @@
+                     par1EntityPlayer.addExperienceLevel(-ContainerRepair.this.maximumCost);
+                 }
+ 
+-                ContainerRepair.this.inputSlots.setInventorySlotContents(0, (ItemStack)null);
+-
+-                if (ContainerRepair.this.stackSizeToBeUsedInRepair > 0)
++                // IAnvilRecipe Implementation
++                boolean renaming = false;
++                if(!StringUtils.isBlank(ContainerRepair.this.repairedItemName) && (!ContainerRepair.this.repairedItemName.equals(ContainerRepair.this.inputSlots.getStackInSlot(0).getDisplayName())))
++                    renaming = true;
++                if(AnvilRecipes.getInstance().getRepairResult(ContainerRepair.this.inputSlots.getStackInSlot(0), ContainerRepair.this.inputSlots.getStackInSlot(1), renaming, ContainerRepair.this.theWorld) != null)
+                 {
+-                    ItemStack itemstack1 = ContainerRepair.this.inputSlots.getStackInSlot(1);
++                    AnvilRecipes.getInstance().repair(ContainerRepair.this.inputSlots.getStackInSlot(0), ContainerRepair.this.inputSlots.getStackInSlot(1), par2ItemStack, renaming, ContainerRepair.this.theWorld);
++                    
++                    if(ContainerRepair.this.inputSlots.getStackInSlot(0).stackSize <= 0)
++                        ContainerRepair.this.inputSlots.setInventorySlotContents(0, (ItemStack)null);  
++                    if(ContainerRepair.this.inputSlots.getStackInSlot(1).stackSize <= 0)
++                        ContainerRepair.this.inputSlots.setInventorySlotContents(1, (ItemStack)null);
++                    
++                    if(renaming)
++                        par2ItemStack.setStackDisplayName(ContainerRepair.this.repairedItemName);
++                }
++                else
++                {
++                    ContainerRepair.this.inputSlots.setInventorySlotContents(0, (ItemStack)null);
+ 
+-                    if (itemstack1 != null && itemstack1.stackSize > ContainerRepair.this.stackSizeToBeUsedInRepair)
++                    if (ContainerRepair.this.stackSizeToBeUsedInRepair > 0)
+                     {
+-                        itemstack1.stackSize -= ContainerRepair.this.stackSizeToBeUsedInRepair;
+-                        ContainerRepair.this.inputSlots.setInventorySlotContents(1, itemstack1);
++                        ItemStack itemstack1 = ContainerRepair.this.inputSlots.getStackInSlot(1);
++    
++                        if (itemstack1 != null && itemstack1.stackSize > ContainerRepair.this.stackSizeToBeUsedInRepair)
++                        {
++                            itemstack1.stackSize -= ContainerRepair.this.stackSizeToBeUsedInRepair;
++                            ContainerRepair.this.inputSlots.setInventorySlotContents(1, itemstack1);
++                        }
++                        else
++                        {
++                            ContainerRepair.this.inputSlots.setInventorySlotContents(1, (ItemStack)null);
++                        }
+                     }
+                     else
+                     {
+                         ContainerRepair.this.inputSlots.setInventorySlotContents(1, (ItemStack)null);
+                     }
+                 }
+-                else
+-                {
+-                    ContainerRepair.this.inputSlots.setInventorySlotContents(1, (ItemStack)null);
+-                }
+ 
+                 ContainerRepair.this.maximumCost = 0;
+ 
+@@ -177,9 +200,26 @@
+             int l1;
+             Iterator iterator1;
+             Enchantment enchantment;
++            
++            // IAnvilRecipe Implementation
++            boolean renaming = false;
++            if(!StringUtils.isBlank(this.repairedItemName) && (!this.repairedItemName.equals(itemstack.getDisplayName())))
++                renaming = true;
++                
++            this.outputSlot.setInventorySlotContents(0, AnvilRecipes.getInstance().getRepairResult(itemstack1, itemstack2, renaming, theWorld));
++            if(this.outputSlot.getStackInSlot(0) != null)
++            {
++                // Processing an IAnvilRecipe
++                this.stackSizeToBeUsedInRepair = 0;
++                this.maximumCost = AnvilRecipes.getInstance().getRepairCost(itemstack1, itemstack2, renaming, theWorld);
++                if(renaming)
++                    this.outputSlot.getStackInSlot(0).setStackDisplayName(this.repairedItemName);
++                this.detectAndSendChanges();
++                return;
++            }
+ 
+             if (itemstack2 != null)
+-            {
++            {                
+                 flag = itemstack2.getItem() == Items.enchanted_book && Items.enchanted_book.func_92110_g(itemstack2).tagCount() > 0;
+ 
+                 if (itemstack1.isItemStackDamageable() && itemstack1.getItem().getIsRepairable(itemstack, itemstack2))
+@@ -383,6 +423,8 @@
                  k2 = Math.max(1, k2 / 2);
              }
  

--- a/src/main/java/net/minecraftforge/common/AnvilRecipes.java
+++ b/src/main/java/net/minecraftforge/common/AnvilRecipes.java
@@ -29,6 +29,12 @@ public class AnvilRecipes {
         anvilRecipes.add(fRecipe);
     }
     
+    public void removeRepair(IAnvilRecipe fRecipe)
+    {
+        if(anvilRecipes.contains(fRecipe))
+            anvilRecipes.remove(fRecipe);
+    }
+    
     public ItemStack getRepairResult(ItemStack inputSlot1, ItemStack inputSlot2, boolean renaming, World world)
     {
         for(IAnvilRecipe recipe : anvilRecipes)
@@ -54,7 +60,10 @@ public class AnvilRecipes {
         for(IAnvilRecipe recipe : anvilRecipes)
         {
             if(recipe.matches(inputSlot1, inputSlot2, renaming, world))
+            {
                 recipe.getOutput(inputSlot1, inputSlot2, output, renaming, world);
+                return;
+            }
         }
     }
 }

--- a/src/main/java/net/minecraftforge/common/AnvilRecipes.java
+++ b/src/main/java/net/minecraftforge/common/AnvilRecipes.java
@@ -1,0 +1,60 @@
+package net.minecraftforge.common;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import net.minecraft.item.ItemStack;
+import net.minecraft.world.World;
+
+public class AnvilRecipes {
+    private static final AnvilRecipes instance = new AnvilRecipes();
+    
+    private List<IAnvilRecipe> anvilRecipes = new ArrayList<IAnvilRecipe>();
+
+    public static final AnvilRecipes getInstance()
+    {
+        return instance;
+    }
+    
+    public interface IAnvilRecipe
+    {
+        boolean matches(ItemStack inputSlot1, ItemStack inputSlot2, boolean renaming, World world);
+        ItemStack getResult(ItemStack inputSlot1, ItemStack inputSlot2, boolean renaming, World world);
+        int getCost(ItemStack inputSlot1, ItemStack inputSlot2, boolean renaming, World world);
+        void getOutput(ItemStack inputSlot1, ItemStack inputSlot2, ItemStack output, boolean renaming, World world);
+    }
+    
+    public void addRepair(IAnvilRecipe fRecipe)
+    {
+        anvilRecipes.add(fRecipe);
+    }
+    
+    public ItemStack getRepairResult(ItemStack inputSlot1, ItemStack inputSlot2, boolean renaming, World world)
+    {
+        for(IAnvilRecipe recipe : anvilRecipes)
+        {
+            if(recipe.matches(inputSlot1, inputSlot2, renaming, world))
+                return recipe.getResult(inputSlot1, inputSlot2, renaming, world);
+        }
+        return null;
+    }
+    
+    public int getRepairCost(ItemStack inputSlot1, ItemStack inputSlot2, boolean renaming, World world)
+    {
+        for(IAnvilRecipe recipe : anvilRecipes)
+        {
+            if(recipe.matches(inputSlot1, inputSlot2, renaming, world))
+                return recipe.getCost(inputSlot1, inputSlot2, renaming, world);
+        }
+        return 0;
+    }
+    
+    public void repair(ItemStack inputSlot1, ItemStack inputSlot2, ItemStack output, boolean renaming, World world)
+    {
+        for(IAnvilRecipe recipe : anvilRecipes)
+        {
+            if(recipe.matches(inputSlot1, inputSlot2, renaming, world))
+                recipe.getOutput(inputSlot1, inputSlot2, output, renaming, world);
+        }
+    }
+}


### PR DESCRIPTION
Currently, outside of specifying repair materials, there is no way to create recipes for use in anvils.  This allows for that creation, as well as allowing modders to specify separate visual (displayed in the anvil GUI) and actual (the item pulled from the anvil upon "repairing") results.

Modders can specify level cost and output, with the getOutput() method allowing IAnvilRecipe's to modify all ItemStacks in the anvil to be edited when the "repair" is completed to create the final output.

Adding a repair handler: AnvilRecipes.addRepair(IAnvilRecipe myHandler);

IAnvilRecipe.matches: Returns a boolean true if the given ItemStacks are able to be handled using this handler.
IAnvilRecipe.getResult: Returns an ItemStack that will be displayed in the anvil GUI.
IAnvilRecipe.getCost: Returns an int that corresponds to the experience levels required for the repair
IAnvilRecipe.getOutput: Exposes all 3 ItemStacks to be altered when the repair is completed (player removes the result from the output slot.