### PR TITLE
Fixes stencil bits not existing in Minecraft's framebuffer causing stencil test to not work.

### DIFF
--- a/patches/minecraft/net/minecraft/client/shader/Framebuffer.java.patch
+++ b/patches/minecraft/net/minecraft/client/shader/Framebuffer.java.patch
@@ -1,0 +1,21 @@
+--- ../src-base/minecraft/net/minecraft/client/shader/Framebuffer.java
++++ ../src-work/minecraft/net/minecraft/client/shader/Framebuffer.java
+@@ -6,6 +6,7 @@
+ import net.minecraft.client.renderer.OpenGlHelper;
+ import net.minecraft.client.renderer.Tessellator;
+ import net.minecraft.client.renderer.texture.TextureUtil;
++import net.minecraftforge.client.MinecraftForgeClient;
+ import org.lwjgl.opengl.EXTFramebufferObject;
+ import org.lwjgl.opengl.GL11;
+ 
+@@ -118,8 +119,8 @@
+             if (this.useDepth)
+             {
+                 EXTFramebufferObject.glBindRenderbufferEXT(36161, this.depthBuffer);
+-                EXTFramebufferObject.glRenderbufferStorageEXT(36161, 33190, this.framebufferTextureWidth, this.framebufferTextureHeight);
+-                EXTFramebufferObject.glFramebufferRenderbufferEXT(36160, 36096, 36161, this.depthBuffer);
++                EXTFramebufferObject.glRenderbufferStorageEXT(36161, MinecraftForgeClient.getStencilBits() > 0 ? 35056 /* ARBFramebufferObject.GL_DEPTH24_STENCIL8 */ : 33190, this.framebufferTextureWidth, this.framebufferTextureHeight);
++                EXTFramebufferObject.glFramebufferRenderbufferEXT(36160, MinecraftForgeClient.getStencilBits() > 0 ? 33306 /* ARBFramebufferObject.GL_DEPTH_STENCIL_ATTACHMENT */ : 36096, 36161, this.depthBuffer);
+             }
+ 
+             this.framebufferClear();


### PR DESCRIPTION
Basically checking if there are reserved stencil bits in the Display (which Forge already checks for) then using the correct OpenGL constant to supply the correct render buffer.
