### PR TITLE
Tile entity get behavior

### DIFF
--- a/patches/minecraft/net/minecraft/block/BlockBeacon.java.patch
+++ b/patches/minecraft/net/minecraft/block/BlockBeacon.java.patch
@@ -1,0 +1,28 @@
+--- ../src-base/minecraft/net/minecraft/block/BlockBeacon.java
++++ ../src-work/minecraft/net/minecraft/block/BlockBeacon.java
+@@ -10,6 +10,7 @@
+ import net.minecraft.item.ItemStack;
+ import net.minecraft.tileentity.TileEntity;
+ import net.minecraft.tileentity.TileEntityBeacon;
++import net.minecraft.util.Util;
+ import net.minecraft.world.World;
+ 
+ public class BlockBeacon extends BlockContainer
+@@ -38,7 +39,7 @@
+         }
+         else
+         {
+-            TileEntityBeacon tileentitybeacon = (TileEntityBeacon)p_149727_1_.getTileEntity(p_149727_2_, p_149727_3_, p_149727_4_);
++            TileEntityBeacon tileentitybeacon = Util.getTileBehavior(p_149727_1_, p_149727_2_, p_149727_3_, p_149727_4_, TileEntityBeacon.class);
+ 
+             if (tileentitybeacon != null)
+             {
+@@ -80,7 +81,7 @@
+ 
+         if (p_149689_6_.hasDisplayName())
+         {
+-            ((TileEntityBeacon)p_149689_1_.getTileEntity(p_149689_2_, p_149689_3_, p_149689_4_)).func_145999_a(p_149689_6_.getDisplayName());
++            p_149689_1_.getTileEntity(p_149689_2_, p_149689_3_, p_149689_4_).getBehavior(TileEntityBeacon.class).func_145999_a(p_149689_6_.getDisplayName());
+         }
+     }
+ }

--- a/patches/minecraft/net/minecraft/block/BlockBrewingStand.java.patch
+++ b/patches/minecraft/net/minecraft/block/BlockBrewingStand.java.patch
@@ -1,0 +1,36 @@
+--- ../src-base/minecraft/net/minecraft/block/BlockBrewingStand.java
++++ ../src-work/minecraft/net/minecraft/block/BlockBrewingStand.java
+@@ -2,8 +2,10 @@
+ 
+ import cpw.mods.fml.relauncher.Side;
+ import cpw.mods.fml.relauncher.SideOnly;
++
+ import java.util.List;
+ import java.util.Random;
++
+ import net.minecraft.block.material.Material;
+ import net.minecraft.client.renderer.texture.IIconRegister;
+ import net.minecraft.entity.Entity;
+@@ -19,6 +21,7 @@
+ import net.minecraft.tileentity.TileEntityBrewingStand;
+ import net.minecraft.util.AxisAlignedBB;
+ import net.minecraft.util.IIcon;
++import net.minecraft.util.Util;
+ import net.minecraft.world.World;
+ 
+ public class BlockBrewingStand extends BlockContainer
+@@ -103,12 +106,10 @@
+ 
+     public void breakBlock(World p_149749_1_, int p_149749_2_, int p_149749_3_, int p_149749_4_, Block p_149749_5_, int p_149749_6_)
+     {
+-        TileEntity tileentity = p_149749_1_.getTileEntity(p_149749_2_, p_149749_3_, p_149749_4_);
++        TileEntityBrewingStand tileentitybrewingstand = Util.getTileBehavior(p_149749_1_, p_149749_2_, p_149749_3_, p_149749_4_, TileEntityBrewingStand.class);
+ 
+-        if (tileentity instanceof TileEntityBrewingStand)
++        if (tileentitybrewingstand != null)
+         {
+-            TileEntityBrewingStand tileentitybrewingstand = (TileEntityBrewingStand)tileentity;
+-
+             for (int i1 = 0; i1 < tileentitybrewingstand.getSizeInventory(); ++i1)
+             {
+                 ItemStack itemstack = tileentitybrewingstand.getStackInSlot(i1);

--- a/patches/minecraft/net/minecraft/block/BlockBrewingStand.java.patch
+++ b/patches/minecraft/net/minecraft/block/BlockBrewingStand.java.patch
@@ -19,7 +19,23 @@
  import net.minecraft.world.World;
  
  public class BlockBrewingStand extends BlockContainer
-@@ -103,12 +106,10 @@
+@@ -81,7 +84,7 @@
+         }
+         else
+         {
+-            TileEntityBrewingStand tileentitybrewingstand = (TileEntityBrewingStand)p_149727_1_.getTileEntity(p_149727_2_, p_149727_3_, p_149727_4_);
++            TileEntityBrewingStand tileentitybrewingstand = Util.getTileBehavior(p_149727_1_, p_149727_2_, p_149727_3_, p_149727_4_, TileEntityBrewingStand.class);
+ 
+             if (tileentitybrewingstand != null)
+             {
+@@ -97,18 +100,16 @@
+     {
+         if (p_149689_6_.hasDisplayName())
+         {
+-            ((TileEntityBrewingStand)p_149689_1_.getTileEntity(p_149689_2_, p_149689_3_, p_149689_4_)).func_145937_a(p_149689_6_.getDisplayName());
++            p_149689_1_.getTileEntity(p_149689_2_, p_149689_3_, p_149689_4_).getBehavior(TileEntityBrewingStand.class).func_145937_a(p_149689_6_.getDisplayName());
+         }
+     }
  
      public void breakBlock(World p_149749_1_, int p_149749_2_, int p_149749_3_, int p_149749_4_, Block p_149749_5_, int p_149749_6_)
      {
@@ -34,3 +50,12 @@
              for (int i1 = 0; i1 < tileentitybrewingstand.getSizeInventory(); ++i1)
              {
                  ItemStack itemstack = tileentitybrewingstand.getStackInSlot(i1);
+@@ -174,7 +175,7 @@
+     // JAVADOC METHOD $$ func_149736_g
+     public int getComparatorInputOverride(World p_149736_1_, int p_149736_2_, int p_149736_3_, int p_149736_4_, int p_149736_5_)
+     {
+-        return Container.calcRedstoneFromInventory((IInventory)p_149736_1_.getTileEntity(p_149736_2_, p_149736_3_, p_149736_4_));
++        return Container.calcRedstoneFromInventory(Util.getTileBehavior(p_149736_1_, p_149736_2_, p_149736_3_, p_149736_4_, IInventory.class, p_149736_5_));
+     }
+ 
+     @SideOnly(Side.CLIENT)

--- a/patches/minecraft/net/minecraft/block/BlockChest.java.patch
+++ b/patches/minecraft/net/minecraft/block/BlockChest.java.patch
@@ -1,15 +1,37 @@
 --- ../src-base/minecraft/net/minecraft/block/BlockChest.java
 +++ ../src-work/minecraft/net/minecraft/block/BlockChest.java
-@@ -23,6 +23,8 @@
+@@ -2,8 +2,10 @@
+ 
+ import cpw.mods.fml.relauncher.Side;
+ import cpw.mods.fml.relauncher.SideOnly;
++
+ import java.util.Iterator;
+ import java.util.Random;
++
+ import net.minecraft.block.material.Material;
+ import net.minecraft.client.renderer.texture.IIconRegister;
+ import net.minecraft.creativetab.CreativeTabs;
+@@ -20,8 +22,10 @@
+ import net.minecraft.tileentity.TileEntityChest;
+ import net.minecraft.util.AxisAlignedBB;
+ import net.minecraft.util.MathHelper;
++import net.minecraft.util.Util;
  import net.minecraft.world.IBlockAccess;
  import net.minecraft.world.World;
- 
 +import static net.minecraftforge.common.util.ForgeDirection.*;
-+
+ 
  public class BlockChest extends BlockContainer
  {
-     private final Random field_149955_b = new Random();
-@@ -416,7 +418,7 @@
+@@ -344,7 +348,7 @@
+ 
+     public void breakBlock(World p_149749_1_, int p_149749_2_, int p_149749_3_, int p_149749_4_, Block p_149749_5_, int p_149749_6_)
+     {
+-        TileEntityChest tileentitychest = (TileEntityChest)p_149749_1_.getTileEntity(p_149749_2_, p_149749_3_, p_149749_4_);
++        TileEntityChest tileentitychest = Util.getTileBehavior(p_149749_1_, p_149749_2_, p_149749_3_, p_149749_4_, TileEntityChest.class);
+ 
+         if (tileentitychest != null)
+         {
+@@ -416,7 +420,7 @@
          {
              return null;
          }
@@ -18,7 +40,7 @@
          {
              return null;
          }
-@@ -424,19 +426,19 @@
+@@ -424,19 +428,19 @@
          {
              return null;
          }

--- a/patches/minecraft/net/minecraft/block/BlockChest.java.patch
+++ b/patches/minecraft/net/minecraft/block/BlockChest.java.patch
@@ -11,18 +11,37 @@
  import net.minecraft.block.material.Material;
  import net.minecraft.client.renderer.texture.IIconRegister;
  import net.minecraft.creativetab.CreativeTabs;
-@@ -20,8 +22,10 @@
+@@ -20,8 +22,11 @@
  import net.minecraft.tileentity.TileEntityChest;
  import net.minecraft.util.AxisAlignedBB;
  import net.minecraft.util.MathHelper;
 +import net.minecraft.util.Util;
  import net.minecraft.world.IBlockAccess;
  import net.minecraft.world.World;
++import net.minecraftforge.common.util.ForgeDirection;
 +import static net.minecraftforge.common.util.ForgeDirection.*;
  
  public class BlockChest extends BlockContainer
  {
-@@ -344,7 +348,7 @@
+@@ -178,7 +183,7 @@
+ 
+         if (p_149689_6_.hasDisplayName())
+         {
+-            ((TileEntityChest)p_149689_1_.getTileEntity(p_149689_2_, p_149689_3_, p_149689_4_)).func_145976_a(p_149689_6_.getDisplayName());
++            p_149689_1_.getTileEntity(p_149689_2_, p_149689_3_, p_149689_4_).getBehavior(TileEntityChest.class).func_145976_a(p_149689_6_.getDisplayName());
+         }
+     }
+ 
+@@ -334,7 +339,7 @@
+     public void onNeighborBlockChange(World p_149695_1_, int p_149695_2_, int p_149695_3_, int p_149695_4_, Block p_149695_5_)
+     {
+         super.onNeighborBlockChange(p_149695_1_, p_149695_2_, p_149695_3_, p_149695_4_, p_149695_5_);
+-        TileEntityChest tileentitychest = (TileEntityChest)p_149695_1_.getTileEntity(p_149695_2_, p_149695_3_, p_149695_4_);
++        TileEntityChest tileentitychest = Util.getTileBehavior(p_149695_1_, p_149695_2_, p_149695_3_, p_149695_4_, TileEntityChest.class);
+ 
+         if (tileentitychest != null)
+         {
+@@ -344,7 +349,7 @@
  
      public void breakBlock(World p_149749_1_, int p_149749_2_, int p_149749_3_, int p_149749_4_, Block p_149749_5_, int p_149749_6_)
      {
@@ -31,7 +50,7 @@
  
          if (tileentitychest != null)
          {
-@@ -416,7 +420,7 @@
+@@ -416,7 +421,7 @@
          {
              return null;
          }
@@ -40,7 +59,7 @@
          {
              return null;
          }
-@@ -424,19 +428,19 @@
+@@ -424,19 +429,19 @@
          {
              return null;
          }
@@ -64,3 +83,12 @@
          {
              return null;
          }
+@@ -487,7 +492,7 @@
+         }
+         else
+         {
+-            int i1 = ((TileEntityChest)p_149709_1_.getTileEntity(p_149709_2_, p_149709_3_, p_149709_4_)).numPlayersUsing;
++            int i1 = p_149709_1_.getTileEntity(p_149709_2_, p_149709_3_, p_149709_4_).getBehavior(TileEntityChest.class, ForgeDirection.getOrientation(p_149709_5_)).numPlayersUsing;
+             return MathHelper.clamp_int(i1, 0, 15);
+         }
+     }

--- a/patches/minecraft/net/minecraft/block/BlockCommandBlock.java.patch
+++ b/patches/minecraft/net/minecraft/block/BlockCommandBlock.java.patch
@@ -1,0 +1,33 @@
+--- ../src-base/minecraft/net/minecraft/block/BlockCommandBlock.java
++++ ../src-work/minecraft/net/minecraft/block/BlockCommandBlock.java
+@@ -1,6 +1,7 @@
+ package net.minecraft.block;
+ 
+ import java.util.Random;
++
+ import net.minecraft.block.material.Material;
+ import net.minecraft.command.server.CommandBlockLogic;
+ import net.minecraft.entity.EntityLivingBase;
+@@ -8,6 +9,7 @@
+ import net.minecraft.item.ItemStack;
+ import net.minecraft.tileentity.TileEntity;
+ import net.minecraft.tileentity.TileEntityCommandBlock;
++import net.minecraft.util.Util;
+ import net.minecraft.world.World;
+ 
+ public class BlockCommandBlock extends BlockContainer
+@@ -49,11 +51,11 @@
+     // JAVADOC METHOD $$ func_149674_a
+     public void updateTick(World p_149674_1_, int p_149674_2_, int p_149674_3_, int p_149674_4_, Random p_149674_5_)
+     {
+-        TileEntity tileentity = p_149674_1_.getTileEntity(p_149674_2_, p_149674_3_, p_149674_4_);
++        TileEntityCommandBlock tile = Util.getTileBehavior(p_149674_1_, p_149674_2_, p_149674_3_, p_149674_4_, TileEntityCommandBlock.class);
+ 
+-        if (tileentity != null && tileentity instanceof TileEntityCommandBlock)
++        if (tile != null)
+         {
+-            CommandBlockLogic commandblocklogic = ((TileEntityCommandBlock)tileentity).func_145993_a();
++            CommandBlockLogic commandblocklogic = ((TileEntityCommandBlock)tile).func_145993_a();
+             commandblocklogic.func_145755_a(p_149674_1_);
+             p_149674_1_.func_147453_f(p_149674_2_, p_149674_3_, p_149674_4_, this);
+         }

--- a/patches/minecraft/net/minecraft/block/BlockCommandBlock.java.patch
+++ b/patches/minecraft/net/minecraft/block/BlockCommandBlock.java.patch
@@ -8,15 +8,17 @@
  import net.minecraft.block.material.Material;
  import net.minecraft.command.server.CommandBlockLogic;
  import net.minecraft.entity.EntityLivingBase;
-@@ -8,6 +9,7 @@
+@@ -8,7 +9,9 @@
  import net.minecraft.item.ItemStack;
  import net.minecraft.tileentity.TileEntity;
  import net.minecraft.tileentity.TileEntityCommandBlock;
 +import net.minecraft.util.Util;
  import net.minecraft.world.World;
++import net.minecraftforge.common.util.ForgeDirection;
  
  public class BlockCommandBlock extends BlockContainer
-@@ -49,11 +51,11 @@
+ {
+@@ -49,11 +52,11 @@
      // JAVADOC METHOD $$ func_149674_a
      public void updateTick(World p_149674_1_, int p_149674_2_, int p_149674_3_, int p_149674_4_, Random p_149674_5_)
      {
@@ -31,3 +33,30 @@
              commandblocklogic.func_145755_a(p_149674_1_);
              p_149674_1_.func_147453_f(p_149674_2_, p_149674_3_, p_149674_4_, this);
          }
+@@ -68,7 +71,7 @@
+     // JAVADOC METHOD $$ func_149727_a
+     public boolean onBlockActivated(World p_149727_1_, int p_149727_2_, int p_149727_3_, int p_149727_4_, EntityPlayer p_149727_5_, int p_149727_6_, float p_149727_7_, float p_149727_8_, float p_149727_9_)
+     {
+-        TileEntityCommandBlock tileentitycommandblock = (TileEntityCommandBlock)p_149727_1_.getTileEntity(p_149727_2_, p_149727_3_, p_149727_4_);
++        TileEntityCommandBlock tileentitycommandblock = Util.getTileBehavior(p_149727_1_, p_149727_2_, p_149727_3_, p_149727_4_, TileEntityCommandBlock.class);
+ 
+         if (tileentitycommandblock != null)
+         {
+@@ -87,14 +90,14 @@
+     // JAVADOC METHOD $$ func_149736_g
+     public int getComparatorInputOverride(World p_149736_1_, int p_149736_2_, int p_149736_3_, int p_149736_4_, int p_149736_5_)
+     {
+-        TileEntity tileentity = p_149736_1_.getTileEntity(p_149736_2_, p_149736_3_, p_149736_4_);
+-        return tileentity != null && tileentity instanceof TileEntityCommandBlock ? ((TileEntityCommandBlock)tileentity).func_145993_a().func_145760_g() : 0;
++        TileEntityCommandBlock tileentity = Util.getTileBehavior(p_149736_1_, p_149736_2_, p_149736_3_, p_149736_4_, TileEntityCommandBlock.class, p_149736_5_);
++        return tileentity != null ? tileentity.func_145993_a().func_145760_g() : 0;
+     }
+ 
+     // JAVADOC METHOD $$ func_149689_a
+     public void onBlockPlacedBy(World p_149689_1_, int p_149689_2_, int p_149689_3_, int p_149689_4_, EntityLivingBase p_149689_5_, ItemStack p_149689_6_)
+     {
+-        TileEntityCommandBlock tileentitycommandblock = (TileEntityCommandBlock)p_149689_1_.getTileEntity(p_149689_2_, p_149689_3_, p_149689_4_);
++        TileEntityCommandBlock tileentitycommandblock = p_149689_1_.getTileEntity(p_149689_2_, p_149689_3_, p_149689_4_).getBehavior(TileEntityCommandBlock.class);
+ 
+         if (p_149689_6_.hasDisplayName())
+         {

--- a/patches/minecraft/net/minecraft/block/BlockDispenser.java.patch
+++ b/patches/minecraft/net/minecraft/block/BlockDispenser.java.patch
@@ -1,0 +1,29 @@
+--- ../src-base/minecraft/net/minecraft/block/BlockDispenser.java
++++ ../src-work/minecraft/net/minecraft/block/BlockDispenser.java
+@@ -2,7 +2,9 @@
+ 
+ import cpw.mods.fml.relauncher.Side;
+ import cpw.mods.fml.relauncher.SideOnly;
++
+ import java.util.Random;
++
+ import net.minecraft.block.material.Material;
+ import net.minecraft.client.renderer.texture.IIconRegister;
+ import net.minecraft.creativetab.CreativeTabs;
+@@ -24,6 +26,7 @@
+ import net.minecraft.util.IIcon;
+ import net.minecraft.util.IRegistry;
+ import net.minecraft.util.RegistryDefaulted;
++import net.minecraft.util.Util;
+ import net.minecraft.world.World;
+ 
+ public class BlockDispenser extends BlockContainer
+@@ -208,7 +211,7 @@
+ 
+     public void breakBlock(World p_149749_1_, int p_149749_2_, int p_149749_3_, int p_149749_4_, Block p_149749_5_, int p_149749_6_)
+     {
+-        TileEntityDispenser tileentitydispenser = (TileEntityDispenser)p_149749_1_.getTileEntity(p_149749_2_, p_149749_3_, p_149749_4_);
++        TileEntityDispenser tileentitydispenser = Util.getTileBehavior(p_149749_1_, p_149749_2_, p_149749_3_, p_149749_4_, TileEntityDispenser.class);
+ 
+         if (tileentitydispenser != null)
+         {

--- a/patches/minecraft/net/minecraft/block/BlockDispenser.java.patch
+++ b/patches/minecraft/net/minecraft/block/BlockDispenser.java.patch
@@ -10,15 +10,33 @@
  import net.minecraft.block.material.Material;
  import net.minecraft.client.renderer.texture.IIconRegister;
  import net.minecraft.creativetab.CreativeTabs;
-@@ -24,6 +26,7 @@
+@@ -24,7 +26,9 @@
  import net.minecraft.util.IIcon;
  import net.minecraft.util.IRegistry;
  import net.minecraft.util.RegistryDefaulted;
 +import net.minecraft.util.Util;
  import net.minecraft.world.World;
++import net.minecraftforge.common.util.ForgeDirection;
  
  public class BlockDispenser extends BlockContainer
-@@ -208,7 +211,7 @@
+ {
+@@ -118,7 +122,7 @@
+         }
+         else
+         {
+-            TileEntityDispenser tileentitydispenser = (TileEntityDispenser)p_149727_1_.getTileEntity(p_149727_2_, p_149727_3_, p_149727_4_);
++            TileEntityDispenser tileentitydispenser = Util.getTileBehavior(p_149727_1_, p_149727_2_, p_149727_3_, p_149727_4_, TileEntityDispenser.class);
+ 
+             if (tileentitydispenser != null)
+             {
+@@ -202,13 +206,13 @@
+ 
+         if (p_149689_6_.hasDisplayName())
+         {
+-            ((TileEntityDispenser)p_149689_1_.getTileEntity(p_149689_2_, p_149689_3_, p_149689_4_)).func_146018_a(p_149689_6_.getDisplayName());
++            p_149689_1_.getTileEntity(p_149689_2_, p_149689_3_, p_149689_4_).getBehavior(TileEntityDispenser.class).func_146018_a(p_149689_6_.getDisplayName());
+         }
+     }
  
      public void breakBlock(World p_149749_1_, int p_149749_2_, int p_149749_3_, int p_149749_4_, Block p_149749_5_, int p_149749_6_)
      {
@@ -27,3 +45,11 @@
  
          if (tileentitydispenser != null)
          {
+@@ -277,6 +281,6 @@
+     // JAVADOC METHOD $$ func_149736_g
+     public int getComparatorInputOverride(World p_149736_1_, int p_149736_2_, int p_149736_3_, int p_149736_4_, int p_149736_5_)
+     {
+-        return Container.calcRedstoneFromInventory((IInventory)p_149736_1_.getTileEntity(p_149736_2_, p_149736_3_, p_149736_4_));
++        return Container.calcRedstoneFromInventory(p_149736_1_.getTileEntity(p_149736_2_, p_149736_3_, p_149736_4_).getBehavior(IInventory.class, p_149736_5_));
+     }
+ }

--- a/patches/minecraft/net/minecraft/block/BlockEnchantmentTable.java.patch
+++ b/patches/minecraft/net/minecraft/block/BlockEnchantmentTable.java.patch
@@ -1,0 +1,38 @@
+--- ../src-base/minecraft/net/minecraft/block/BlockEnchantmentTable.java
++++ ../src-work/minecraft/net/minecraft/block/BlockEnchantmentTable.java
+@@ -2,7 +2,9 @@
+ 
+ import cpw.mods.fml.relauncher.Side;
+ import cpw.mods.fml.relauncher.SideOnly;
++
+ import java.util.Random;
++
+ import net.minecraft.block.material.Material;
+ import net.minecraft.client.renderer.texture.IIconRegister;
+ import net.minecraft.creativetab.CreativeTabs;
+@@ -13,6 +15,7 @@
+ import net.minecraft.tileentity.TileEntity;
+ import net.minecraft.tileentity.TileEntityEnchantmentTable;
+ import net.minecraft.util.IIcon;
++import net.minecraft.util.Util;
+ import net.minecraft.world.World;
+ 
+ public class BlockEnchantmentTable extends BlockContainer
+@@ -99,7 +102,7 @@
+         }
+         else
+         {
+-            TileEntityEnchantmentTable tileentityenchantmenttable = (TileEntityEnchantmentTable)p_149727_1_.getTileEntity(p_149727_2_, p_149727_3_, p_149727_4_);
++            TileEntityEnchantmentTable tileentityenchantmenttable = Util.getTileBehavior(p_149727_1_, p_149727_2_, p_149727_3_, p_149727_4_, TileEntityEnchantmentTable.class);
+             p_149727_5_.displayGUIEnchantment(p_149727_2_, p_149727_3_, p_149727_4_, tileentityenchantmenttable.func_145921_b() ? tileentityenchantmenttable.func_145919_a() : null);
+             return true;
+         }
+@@ -112,7 +115,7 @@
+ 
+         if (p_149689_6_.hasDisplayName())
+         {
+-            ((TileEntityEnchantmentTable)p_149689_1_.getTileEntity(p_149689_2_, p_149689_3_, p_149689_4_)).func_145920_a(p_149689_6_.getDisplayName());
++            p_149689_1_.getTileEntity(p_149689_2_, p_149689_3_, p_149689_4_).getBehavior(TileEntityEnchantmentTable.class).func_145920_a(p_149689_6_.getDisplayName());
+         }
+     }
+ 

--- a/patches/minecraft/net/minecraft/block/BlockEnderChest.java.patch
+++ b/patches/minecraft/net/minecraft/block/BlockEnderChest.java.patch
@@ -1,0 +1,29 @@
+--- ../src-base/minecraft/net/minecraft/block/BlockEnderChest.java
++++ ../src-work/minecraft/net/minecraft/block/BlockEnderChest.java
+@@ -2,7 +2,9 @@
+ 
+ import cpw.mods.fml.relauncher.Side;
+ import cpw.mods.fml.relauncher.SideOnly;
++
+ import java.util.Random;
++
+ import net.minecraft.block.material.Material;
+ import net.minecraft.client.renderer.texture.IIconRegister;
+ import net.minecraft.creativetab.CreativeTabs;
+@@ -15,6 +17,7 @@
+ import net.minecraft.tileentity.TileEntity;
+ import net.minecraft.tileentity.TileEntityEnderChest;
+ import net.minecraft.util.MathHelper;
++import net.minecraft.util.Util;
+ import net.minecraft.world.World;
+ 
+ public class BlockEnderChest extends BlockContainer
+@@ -96,7 +99,7 @@
+     public boolean onBlockActivated(World p_149727_1_, int p_149727_2_, int p_149727_3_, int p_149727_4_, EntityPlayer p_149727_5_, int p_149727_6_, float p_149727_7_, float p_149727_8_, float p_149727_9_)
+     {
+         InventoryEnderChest inventoryenderchest = p_149727_5_.getInventoryEnderChest();
+-        TileEntityEnderChest tileentityenderchest = (TileEntityEnderChest)p_149727_1_.getTileEntity(p_149727_2_, p_149727_3_, p_149727_4_);
++        TileEntityEnderChest tileentityenderchest = Util.getTileBehavior(p_149727_1_, p_149727_2_, p_149727_3_, p_149727_4_, TileEntityEnderChest.class);
+ 
+         if (inventoryenderchest != null && tileentityenderchest != null)
+         {

--- a/patches/minecraft/net/minecraft/block/BlockFlowerPot.java.patch
+++ b/patches/minecraft/net/minecraft/block/BlockFlowerPot.java.patch
@@ -1,0 +1,30 @@
+--- ../src-base/minecraft/net/minecraft/block/BlockFlowerPot.java
++++ ../src-work/minecraft/net/minecraft/block/BlockFlowerPot.java
+@@ -2,7 +2,9 @@
+ 
+ import cpw.mods.fml.relauncher.Side;
+ import cpw.mods.fml.relauncher.SideOnly;
++
+ import java.util.Random;
++
+ import net.minecraft.block.material.Material;
+ import net.minecraft.entity.player.EntityPlayer;
+ import net.minecraft.init.Blocks;
+@@ -12,6 +14,7 @@
+ import net.minecraft.item.ItemStack;
+ import net.minecraft.tileentity.TileEntity;
+ import net.minecraft.tileentity.TileEntityFlowerPot;
++import net.minecraft.util.Util;
+ import net.minecraft.world.World;
+ 
+ public class BlockFlowerPot extends BlockContainer
+@@ -193,8 +196,7 @@
+ 
+     private TileEntityFlowerPot func_149929_e(World p_149929_1_, int p_149929_2_, int p_149929_3_, int p_149929_4_)
+     {
+-        TileEntity tileentity = p_149929_1_.getTileEntity(p_149929_2_, p_149929_3_, p_149929_4_);
+-        return tileentity != null && tileentity instanceof TileEntityFlowerPot ? (TileEntityFlowerPot)tileentity : null;
++        return Util.getTileBehavior(p_149929_1_, p_149929_2_, p_149929_3_, p_149929_4_, TileEntityFlowerPot.class);
+     }
+ 
+     // JAVADOC METHOD $$ func_149915_a

--- a/patches/minecraft/net/minecraft/block/BlockFurnace.java.patch
+++ b/patches/minecraft/net/minecraft/block/BlockFurnace.java.patch
@@ -10,15 +10,35 @@
  import net.minecraft.block.material.Material;
  import net.minecraft.client.renderer.texture.IIconRegister;
  import net.minecraft.entity.EntityLivingBase;
-@@ -18,6 +20,7 @@
+@@ -18,7 +20,9 @@
  import net.minecraft.tileentity.TileEntityFurnace;
  import net.minecraft.util.IIcon;
  import net.minecraft.util.MathHelper;
 +import net.minecraft.util.Util;
  import net.minecraft.world.World;
++import net.minecraftforge.common.util.ForgeDirection;
  
  public class BlockFurnace extends BlockContainer
-@@ -185,7 +188,7 @@
+ {
+@@ -107,7 +111,7 @@
+         }
+         else
+         {
+-            TileEntityFurnace tileentityfurnace = (TileEntityFurnace)p_149727_1_.getTileEntity(p_149727_2_, p_149727_3_, p_149727_4_);
++            TileEntityFurnace tileentityfurnace = Util.getTileBehavior(p_149727_1_, p_149727_2_, p_149727_3_, p_149727_4_, TileEntityFurnace.class);
+ 
+             if (tileentityfurnace != null)
+             {
+@@ -177,7 +181,7 @@
+ 
+         if (p_149689_6_.hasDisplayName())
+         {
+-            ((TileEntityFurnace)p_149689_1_.getTileEntity(p_149689_2_, p_149689_3_, p_149689_4_)).func_145951_a(p_149689_6_.getDisplayName());
++            p_149689_1_.getTileEntity(p_149689_2_, p_149689_3_, p_149689_4_).getBehavior(TileEntityFurnace.class).func_145951_a(p_149689_6_.getDisplayName());
+         }
+     }
+ 
+@@ -185,7 +189,7 @@
      {
          if (!field_149934_M)
          {
@@ -27,3 +47,12 @@
  
              if (tileentityfurnace != null)
              {
+@@ -277,7 +281,7 @@
+     // JAVADOC METHOD $$ func_149736_g
+     public int getComparatorInputOverride(World p_149736_1_, int p_149736_2_, int p_149736_3_, int p_149736_4_, int p_149736_5_)
+     {
+-        return Container.calcRedstoneFromInventory((IInventory)p_149736_1_.getTileEntity(p_149736_2_, p_149736_3_, p_149736_4_));
++        return Container.calcRedstoneFromInventory(p_149736_1_.getTileEntity(p_149736_2_, p_149736_3_, p_149736_4_).getBehavior(IInventory.class, p_149736_5_));
+     }
+ 
+     // JAVADOC METHOD $$ func_149694_d

--- a/patches/minecraft/net/minecraft/block/BlockFurnace.java.patch
+++ b/patches/minecraft/net/minecraft/block/BlockFurnace.java.patch
@@ -1,0 +1,29 @@
+--- ../src-base/minecraft/net/minecraft/block/BlockFurnace.java
++++ ../src-work/minecraft/net/minecraft/block/BlockFurnace.java
+@@ -2,7 +2,9 @@
+ 
+ import cpw.mods.fml.relauncher.Side;
+ import cpw.mods.fml.relauncher.SideOnly;
++
+ import java.util.Random;
++
+ import net.minecraft.block.material.Material;
+ import net.minecraft.client.renderer.texture.IIconRegister;
+ import net.minecraft.entity.EntityLivingBase;
+@@ -18,6 +20,7 @@
+ import net.minecraft.tileentity.TileEntityFurnace;
+ import net.minecraft.util.IIcon;
+ import net.minecraft.util.MathHelper;
++import net.minecraft.util.Util;
+ import net.minecraft.world.World;
+ 
+ public class BlockFurnace extends BlockContainer
+@@ -185,7 +188,7 @@
+     {
+         if (!field_149934_M)
+         {
+-            TileEntityFurnace tileentityfurnace = (TileEntityFurnace)p_149749_1_.getTileEntity(p_149749_2_, p_149749_3_, p_149749_4_);
++            TileEntityFurnace tileentityfurnace = Util.getTileBehavior(p_149749_1_, p_149749_2_, p_149749_3_, p_149749_4_, TileEntityFurnace.class);
+ 
+             if (tileentityfurnace != null)
+             {

--- a/patches/minecraft/net/minecraft/block/BlockHopper.java.patch
+++ b/patches/minecraft/net/minecraft/block/BlockHopper.java.patch
@@ -1,0 +1,30 @@
+--- ../src-base/minecraft/net/minecraft/block/BlockHopper.java
++++ ../src-work/minecraft/net/minecraft/block/BlockHopper.java
+@@ -2,8 +2,10 @@
+ 
+ import cpw.mods.fml.relauncher.Side;
+ import cpw.mods.fml.relauncher.SideOnly;
++
+ import java.util.List;
+ import java.util.Random;
++
+ import net.minecraft.block.material.Material;
+ import net.minecraft.client.renderer.texture.IIconRegister;
+ import net.minecraft.creativetab.CreativeTabs;
+@@ -20,6 +22,7 @@
+ import net.minecraft.util.AxisAlignedBB;
+ import net.minecraft.util.Facing;
+ import net.minecraft.util.IIcon;
++import net.minecraft.util.Util;
+ import net.minecraft.world.IBlockAccess;
+ import net.minecraft.world.World;
+ 
+@@ -143,7 +146,7 @@
+ 
+     public void breakBlock(World p_149749_1_, int p_149749_2_, int p_149749_3_, int p_149749_4_, Block p_149749_5_, int p_149749_6_)
+     {
+-        TileEntityHopper tileentityhopper = (TileEntityHopper)p_149749_1_.getTileEntity(p_149749_2_, p_149749_3_, p_149749_4_);
++        TileEntityHopper tileentityhopper = Util.getTileBehavior(p_149749_1_, p_149749_2_, p_149749_3_, p_149749_4_, TileEntityHopper.class);
+ 
+         if (tileentityhopper != null)
+         {

--- a/patches/minecraft/net/minecraft/block/BlockHopper.java.patch
+++ b/patches/minecraft/net/minecraft/block/BlockHopper.java.patch
@@ -28,3 +28,12 @@
  
          if (tileentityhopper != null)
          {
+@@ -259,7 +262,7 @@
+ 
+     public static TileEntityHopper func_149920_e(IBlockAccess p_149920_0_, int p_149920_1_, int p_149920_2_, int p_149920_3_)
+     {
+-        return (TileEntityHopper)p_149920_0_.getTileEntity(p_149920_1_, p_149920_2_, p_149920_3_);
++        return Util.getTileBehavior(p_149920_0_, p_149920_1_, p_149920_2_, p_149920_3_, TileEntityHopper.class);
+     }
+ 
+     // JAVADOC METHOD $$ func_149702_O

--- a/patches/minecraft/net/minecraft/block/BlockJukebox.java.patch
+++ b/patches/minecraft/net/minecraft/block/BlockJukebox.java.patch
@@ -1,0 +1,39 @@
+--- ../src-base/minecraft/net/minecraft/block/BlockJukebox.java
++++ ../src-work/minecraft/net/minecraft/block/BlockJukebox.java
+@@ -13,7 +13,9 @@
+ import net.minecraft.nbt.NBTTagCompound;
+ import net.minecraft.tileentity.TileEntity;
+ import net.minecraft.util.IIcon;
++import net.minecraft.util.Util;
+ import net.minecraft.world.World;
++import net.minecraftforge.common.util.ForgeDirection;
+ 
+ public class BlockJukebox extends BlockContainer
+ {
+@@ -52,7 +54,7 @@
+     {
+         if (!p_149926_1_.isRemote)
+         {
+-            BlockJukebox.TileEntityJukebox tileentityjukebox = (BlockJukebox.TileEntityJukebox)p_149926_1_.getTileEntity(p_149926_2_, p_149926_3_, p_149926_4_);
++            BlockJukebox.TileEntityJukebox tileentityjukebox = Util.getTileBehavior(p_149926_1_, p_149926_2_, p_149926_3_, p_149926_4_, BlockJukebox.TileEntityJukebox.class);
+ 
+             if (tileentityjukebox != null)
+             {
+@@ -66,7 +68,7 @@
+     {
+         if (!p_149925_1_.isRemote)
+         {
+-            BlockJukebox.TileEntityJukebox tileentityjukebox = (BlockJukebox.TileEntityJukebox)p_149925_1_.getTileEntity(p_149925_2_, p_149925_3_, p_149925_4_);
++            BlockJukebox.TileEntityJukebox tileentityjukebox = Util.getTileBehavior(p_149925_1_, p_149925_2_, p_149925_3_, p_149925_4_, BlockJukebox.TileEntityJukebox.class);
+ 
+             if (tileentityjukebox != null)
+             {
+@@ -128,7 +130,7 @@
+     // JAVADOC METHOD $$ func_149736_g
+     public int getComparatorInputOverride(World p_149736_1_, int p_149736_2_, int p_149736_3_, int p_149736_4_, int p_149736_5_)
+     {
+-        ItemStack itemstack = ((BlockJukebox.TileEntityJukebox)p_149736_1_.getTileEntity(p_149736_2_, p_149736_3_, p_149736_4_)).func_145856_a();
++        ItemStack itemstack = p_149736_1_.getTileEntity(p_149736_2_, p_149736_3_, p_149736_4_).getBehavior(BlockJukebox.TileEntityJukebox.class, p_149736_5_).func_145856_a();
+         return itemstack == null ? 0 : Item.getIdFromItem(itemstack.getItem()) + 1 - Item.getIdFromItem(Items.record_13);
+     }
+ 

--- a/patches/minecraft/net/minecraft/block/BlockNote.java.patch
+++ b/patches/minecraft/net/minecraft/block/BlockNote.java.patch
@@ -1,0 +1,37 @@
+--- ../src-base/minecraft/net/minecraft/block/BlockNote.java
++++ ../src-work/minecraft/net/minecraft/block/BlockNote.java
+@@ -5,6 +5,7 @@
+ import net.minecraft.entity.player.EntityPlayer;
+ import net.minecraft.tileentity.TileEntity;
+ import net.minecraft.tileentity.TileEntityNote;
++import net.minecraft.util.Util;
+ import net.minecraft.world.World;
+ 
+ public class BlockNote extends BlockContainer
+@@ -21,7 +22,7 @@
+     public void onNeighborBlockChange(World p_149695_1_, int p_149695_2_, int p_149695_3_, int p_149695_4_, Block p_149695_5_)
+     {
+         boolean flag = p_149695_1_.isBlockIndirectlyGettingPowered(p_149695_2_, p_149695_3_, p_149695_4_);
+-        TileEntityNote tileentitynote = (TileEntityNote)p_149695_1_.getTileEntity(p_149695_2_, p_149695_3_, p_149695_4_);
++        TileEntityNote tileentitynote = Util.getTileBehavior(p_149695_1_, p_149695_2_, p_149695_3_, p_149695_4_, TileEntityNote.class);
+ 
+         if (tileentitynote != null && tileentitynote.previousRedstoneState != flag)
+         {
+@@ -43,7 +44,7 @@
+         }
+         else
+         {
+-            TileEntityNote tileentitynote = (TileEntityNote)p_149727_1_.getTileEntity(p_149727_2_, p_149727_3_, p_149727_4_);
++            TileEntityNote tileentitynote = Util.getTileBehavior(p_149727_1_, p_149727_2_, p_149727_3_, p_149727_4_, TileEntityNote.class);
+ 
+             if (tileentitynote != null)
+             {
+@@ -60,7 +61,7 @@
+     {
+         if (!p_149699_1_.isRemote)
+         {
+-            TileEntityNote tileentitynote = (TileEntityNote)p_149699_1_.getTileEntity(p_149699_2_, p_149699_3_, p_149699_4_);
++            TileEntityNote tileentitynote = Util.getTileBehavior(p_149699_1_, p_149699_2_, p_149699_3_, p_149699_4_, TileEntityNote.class);
+ 
+             if (tileentitynote != null)
+             {

--- a/patches/minecraft/net/minecraft/block/BlockPistonBase.java.patch
+++ b/patches/minecraft/net/minecraft/block/BlockPistonBase.java.patch
@@ -1,6 +1,16 @@
 --- ../src-base/minecraft/net/minecraft/block/BlockPistonBase.java
 +++ ../src-work/minecraft/net/minecraft/block/BlockPistonBase.java
-@@ -11,6 +11,7 @@
+@@ -2,7 +2,9 @@
+ 
+ import cpw.mods.fml.relauncher.Side;
+ import cpw.mods.fml.relauncher.SideOnly;
++
+ import java.util.List;
++
+ import net.minecraft.block.material.Material;
+ import net.minecraft.client.renderer.texture.IIconRegister;
+ import net.minecraft.creativetab.CreativeTabs;
+@@ -11,12 +13,14 @@
  import net.minecraft.entity.player.EntityPlayer;
  import net.minecraft.init.Blocks;
  import net.minecraft.item.ItemStack;
@@ -8,7 +18,36 @@
  import net.minecraft.tileentity.TileEntity;
  import net.minecraft.tileentity.TileEntityPiston;
  import net.minecraft.util.AxisAlignedBB;
-@@ -380,7 +381,8 @@
+ import net.minecraft.util.Facing;
+ import net.minecraft.util.IIcon;
+ import net.minecraft.util.MathHelper;
++import net.minecraft.util.Util;
+ import net.minecraft.world.IBlockAccess;
+ import net.minecraft.world.World;
+ 
+@@ -187,12 +191,16 @@
+         }
+         else if (p_149696_5_ == 1)
+         {
+-            TileEntity tileentity1 = p_149696_1_.getTileEntity(p_149696_2_ + Facing.offsetsXForSide[p_149696_6_], p_149696_3_ + Facing.offsetsYForSide[p_149696_6_], p_149696_4_ + Facing.offsetsZForSide[p_149696_6_]);
++            TileEntityPiston tileentity1 = Util.getTileBehavior(
++                p_149696_1_,
++                p_149696_2_ + Facing.offsetsXForSide[p_149696_6_],
++                p_149696_3_ + Facing.offsetsYForSide[p_149696_6_],
++                p_149696_4_ + Facing.offsetsZForSide[p_149696_6_],
++                TileEntityPiston.class
++            );
+ 
+-            if (tileentity1 instanceof TileEntityPiston)
+-            {
+-                ((TileEntityPiston)tileentity1).clearPistonTileEntity();
+-            }
++            if (tileentity1 != null)
++                tileentity1.clearPistonTileEntity();
+ 
+             p_149696_1_.setBlock(p_149696_2_, p_149696_3_, p_149696_4_, Blocks.piston_extension, p_149696_6_, 3);
+             p_149696_1_.setTileEntity(p_149696_2_, p_149696_3_, p_149696_4_, BlockPistonMoving.getTileEntity(this, p_149696_6_, p_149696_6_, false, true));
+@@ -380,7 +388,8 @@
                  return false;
              }
  
@@ -18,7 +57,7 @@
          }
      }
  
-@@ -396,14 +398,14 @@
+@@ -396,14 +405,14 @@
          {
              if (l1 < 13)
              {
@@ -35,7 +74,7 @@
                  {
                      if (!canPushBlock(block, p_150077_0_, i1, j1, k1, true))
                      {
-@@ -442,14 +444,14 @@
+@@ -442,14 +451,14 @@
          {
              if (l1 < 13)
              {
@@ -52,7 +91,7 @@
                  {
                      if (!canPushBlock(block, p_150079_1_, i1, j1, k1, true))
                      {
-@@ -470,7 +472,9 @@
+@@ -470,7 +479,9 @@
                          continue;
                      }
  

--- a/patches/minecraft/net/minecraft/block/BlockPistonMoving.java.patch
+++ b/patches/minecraft/net/minecraft/block/BlockPistonMoving.java.patch
@@ -1,0 +1,35 @@
+--- ../src-base/minecraft/net/minecraft/block/BlockPistonMoving.java
++++ ../src-work/minecraft/net/minecraft/block/BlockPistonMoving.java
+@@ -2,7 +2,9 @@
+ 
+ import cpw.mods.fml.relauncher.Side;
+ import cpw.mods.fml.relauncher.SideOnly;
++
+ import java.util.Random;
++
+ import net.minecraft.block.material.Material;
+ import net.minecraft.client.renderer.texture.IIconRegister;
+ import net.minecraft.entity.player.EntityPlayer;
+@@ -11,6 +13,7 @@
+ import net.minecraft.tileentity.TileEntityPiston;
+ import net.minecraft.util.AxisAlignedBB;
+ import net.minecraft.util.Facing;
++import net.minecraft.util.Util;
+ import net.minecraft.world.IBlockAccess;
+ import net.minecraft.world.World;
+ 
+@@ -35,11 +38,11 @@
+ 
+     public void breakBlock(World p_149749_1_, int p_149749_2_, int p_149749_3_, int p_149749_4_, Block p_149749_5_, int p_149749_6_)
+     {
+-        TileEntity tileentity = p_149749_1_.getTileEntity(p_149749_2_, p_149749_3_, p_149749_4_);
++        TileEntityPiston tilePiston = Util.getTileBehavior(p_149749_1_, p_149749_2_, p_149749_3_, p_149749_4_, TileEntityPiston.class);
+ 
+-        if (tileentity instanceof TileEntityPiston)
++        if (tilePiston != null)
+         {
+-            ((TileEntityPiston)tileentity).clearPistonTileEntity();
++            tilePiston.clearPistonTileEntity();
+         }
+         else
+         {

--- a/patches/minecraft/net/minecraft/block/BlockPistonMoving.java.patch
+++ b/patches/minecraft/net/minecraft/block/BlockPistonMoving.java.patch
@@ -33,3 +33,13 @@
          }
          else
          {
+@@ -228,8 +231,7 @@
+ 
+     private TileEntityPiston func_149963_e(IBlockAccess p_149963_1_, int p_149963_2_, int p_149963_3_, int p_149963_4_)
+     {
+-        TileEntity tileentity = p_149963_1_.getTileEntity(p_149963_2_, p_149963_3_, p_149963_4_);
+-        return tileentity instanceof TileEntityPiston ? (TileEntityPiston)tileentity : null;
++        return Util.getTileBehavior(p_149963_1_, p_149963_2_, p_149963_3_, p_149963_4_, TileEntityPiston.class);
+     }
+ 
+     // JAVADOC METHOD $$ func_149694_d

--- a/patches/minecraft/net/minecraft/block/BlockRedstoneComparator.java.patch
+++ b/patches/minecraft/net/minecraft/block/BlockRedstoneComparator.java.patch
@@ -1,6 +1,33 @@
 --- ../src-base/minecraft/net/minecraft/block/BlockRedstoneComparator.java
 +++ ../src-work/minecraft/net/minecraft/block/BlockRedstoneComparator.java
-@@ -237,4 +237,19 @@
+@@ -2,7 +2,9 @@
+ 
+ import cpw.mods.fml.relauncher.Side;
+ import cpw.mods.fml.relauncher.SideOnly;
++
+ import java.util.Random;
++
+ import net.minecraft.entity.player.EntityPlayer;
+ import net.minecraft.init.Blocks;
+ import net.minecraft.init.Items;
+@@ -11,6 +13,7 @@
+ import net.minecraft.tileentity.TileEntityComparator;
+ import net.minecraft.util.Direction;
+ import net.minecraft.util.IIcon;
++import net.minecraft.util.Util;
+ import net.minecraft.world.IBlockAccess;
+ import net.minecraft.world.World;
+ 
+@@ -135,7 +138,7 @@
+     // JAVADOC METHOD $$ func_149971_e
+     public TileEntityComparator getTileEntityComparator(IBlockAccess p_149971_1_, int p_149971_2_, int p_149971_3_, int p_149971_4_)
+     {
+-        return (TileEntityComparator)p_149971_1_.getTileEntity(p_149971_2_, p_149971_3_, p_149971_4_);
++        return Util.getTileBehavior(p_149971_1_, p_149971_2_, p_149971_3_, p_149971_4_, TileEntityComparator.class);
+     }
+ 
+     // JAVADOC METHOD $$ func_149727_a
+@@ -237,4 +240,19 @@
      {
          return new TileEntityComparator();
      }

--- a/patches/minecraft/net/minecraft/block/BlockSkull.java.patch
+++ b/patches/minecraft/net/minecraft/block/BlockSkull.java.patch
@@ -1,14 +1,37 @@
 --- ../src-base/minecraft/net/minecraft/block/BlockSkull.java
 +++ ../src-work/minecraft/net/minecraft/block/BlockSkull.java
-@@ -2,6 +2,7 @@
+@@ -2,8 +2,11 @@
  
  import cpw.mods.fml.relauncher.Side;
  import cpw.mods.fml.relauncher.SideOnly;
++
 +import java.util.ArrayList;
  import java.util.Iterator;
  import java.util.Random;
++
  import net.minecraft.block.material.Material;
-@@ -118,9 +119,6 @@
+ import net.minecraft.client.renderer.texture.IIconRegister;
+ import net.minecraft.entity.EntityLivingBase;
+@@ -21,6 +24,7 @@
+ import net.minecraft.util.AxisAlignedBB;
+ import net.minecraft.util.IIcon;
+ import net.minecraft.util.MathHelper;
++import net.minecraft.util.Util;
+ import net.minecraft.world.EnumDifficulty;
+ import net.minecraft.world.IBlockAccess;
+ import net.minecraft.world.World;
+@@ -108,8 +112,8 @@
+     // JAVADOC METHOD $$ func_149643_k
+     public int getDamageValue(World p_149643_1_, int p_149643_2_, int p_149643_3_, int p_149643_4_)
+     {
+-        TileEntity tileentity = p_149643_1_.getTileEntity(p_149643_2_, p_149643_3_, p_149643_4_);
+-        return tileentity != null && tileentity instanceof TileEntitySkull ? ((TileEntitySkull)tileentity).func_145904_a() : super.getDamageValue(p_149643_1_, p_149643_2_, p_149643_3_, p_149643_4_);
++        TileEntitySkull tile = Util.getTileBehavior(p_149643_1_, p_149643_2_, p_149643_3_, p_149643_4_, TileEntitySkull.class);
++        return tile != null ? tile.func_145904_a() : super.getDamageValue(p_149643_1_, p_149643_2_, p_149643_3_, p_149643_4_);
+     }
+ 
+     // JAVADOC METHOD $$ func_149692_a
+@@ -118,9 +122,6 @@
          return p_149692_1_;
      }
  
@@ -18,7 +41,7 @@
      // JAVADOC METHOD $$ func_149681_a
      public void onBlockHarvested(World p_149681_1_, int p_149681_2_, int p_149681_3_, int p_149681_4_, int p_149681_5_, EntityPlayer p_149681_6_)
      {
-@@ -130,29 +128,38 @@
+@@ -130,29 +131,38 @@
              p_149681_1_.setBlockMetadataWithNotify(p_149681_2_, p_149681_3_, p_149681_4_, p_149681_5_, 4);
          }
  
@@ -41,7 +64,8 @@
              if ((p_149749_6_ & 8) == 0)
              {
                  ItemStack itemstack = new ItemStack(Items.skull, 1, this.getDamageValue(p_149749_1_, p_149749_2_, p_149749_3_, p_149749_4_));
-                 TileEntitySkull tileentityskull = (TileEntitySkull)p_149749_1_.getTileEntity(p_149749_2_, p_149749_3_, p_149749_4_);
+-                TileEntitySkull tileentityskull = (TileEntitySkull)p_149749_1_.getTileEntity(p_149749_2_, p_149749_3_, p_149749_4_);
++                TileEntitySkull tileentityskull = Util.getTileBehavior(p_149749_1_, p_149749_2_, p_149749_3_, p_149749_4_, TileEntitySkull.class);
  
 +                if (tileentityskull == null) return ret;
 +
@@ -61,3 +85,14 @@
      }
  
      public Item getItemDropped(int p_149650_1_, Random p_149650_2_, int p_149650_3_)
+@@ -283,8 +293,8 @@
+         }
+         else
+         {
+-            TileEntity tileentity = p_149966_1_.getTileEntity(p_149966_2_, p_149966_3_, p_149966_4_);
+-            return tileentity != null && tileentity instanceof TileEntitySkull ? ((TileEntitySkull)tileentity).func_145904_a() == p_149966_5_ : false;
++            TileEntitySkull tileentity = Util.getTileBehavior(p_149966_1_, p_149966_2_, p_149966_3_, p_149966_4_, TileEntitySkull.class, p_149966_5_);
++            return tileentity != null ? tileentity.func_145904_a() == p_149966_5_ : false;
+         }
+     }
+ 

--- a/patches/minecraft/net/minecraft/client/Minecraft.java.patch
+++ b/patches/minecraft/net/minecraft/client/Minecraft.java.patch
@@ -72,7 +72,7 @@
          if (p_147108_1_ instanceof GuiMainMenu)
          {
              this.gameSettings.showDebugInfo = false;
-@@ -1341,7 +1355,7 @@
+@@ -1342,7 +1356,7 @@
  
                      if (this.thePlayer.isCurrentToolAdventureModeExempt(i, j, k))
                      {
@@ -81,7 +81,7 @@
                          this.thePlayer.swingItem();
                      }
                  }
-@@ -1422,11 +1436,12 @@
+@@ -1423,11 +1437,12 @@
                      int j = this.objectMouseOver.blockY;
                      int k = this.objectMouseOver.blockZ;
  
@@ -96,7 +96,7 @@
                          {
                              flag = false;
                              this.thePlayer.swingItem();
-@@ -1453,7 +1468,8 @@
+@@ -1454,7 +1469,8 @@
          {
              ItemStack itemstack1 = this.thePlayer.inventory.getCurrentItem();
  
@@ -106,7 +106,7 @@
              {
                  this.entityRenderer.itemRenderer.resetEquippedProgress2();
              }
-@@ -1655,6 +1671,8 @@
+@@ -1656,6 +1672,8 @@
  
              while (Mouse.next())
              {
@@ -115,7 +115,7 @@
                  i = Mouse.getEventButton();
  
                  if (isRunningOnMac && i == 0 && (Keyboard.isKeyDown(29) || Keyboard.isKeyDown(157)))
-@@ -2125,6 +2143,11 @@
+@@ -2126,6 +2144,11 @@
      // JAVADOC METHOD $$ func_71353_a
      public void loadWorld(WorldClient par1WorldClient, String par2Str)
      {
@@ -127,7 +127,7 @@
          if (par1WorldClient == null)
          {
              NetHandlerPlayClient nethandlerplayclient = this.getNetHandler();
-@@ -2137,6 +2160,18 @@
+@@ -2138,6 +2161,18 @@
              if (this.theIntegratedServer != null)
              {
                  this.theIntegratedServer.initiateShutdown();
@@ -146,7 +146,7 @@
              }
  
              this.theIntegratedServer = null;
-@@ -2292,113 +2327,10 @@
+@@ -2293,113 +2328,10 @@
          if (this.objectMouseOver != null)
          {
              boolean flag = this.thePlayer.capabilities.isCreativeMode;
@@ -262,7 +262,7 @@
              if (flag)
              {
                  j = this.thePlayer.inventoryContainer.inventorySlots.size() - 9 + this.thePlayer.inventory.currentItem;
-@@ -2568,9 +2500,16 @@
+@@ -2569,9 +2501,16 @@
          par1PlayerUsageSnooper.addData("gl_max_texture_size", Integer.valueOf(getGLMaximumTextureSize()));
      }
  
@@ -279,7 +279,7 @@
          for (int i = 16384; i > 0; i >>= 1)
          {
              GL11.glTexImage2D(GL11.GL_PROXY_TEXTURE_2D, 0, GL11.GL_RGBA, i, i, 0, GL11.GL_RGBA, GL11.GL_UNSIGNED_BYTE, (ByteBuffer)null);
-@@ -2578,6 +2517,7 @@
+@@ -2579,6 +2518,7 @@
  
              if (j != 0)
              {

--- a/patches/minecraft/net/minecraft/client/network/NetHandlerPlayClient.java.patch
+++ b/patches/minecraft/net/minecraft/client/network/NetHandlerPlayClient.java.patch
@@ -1,15 +1,47 @@
 --- ../src-base/minecraft/net/minecraft/client/network/NetHandlerPlayClient.java
 +++ ../src-work/minecraft/net/minecraft/client/network/NetHandlerPlayClient.java
-@@ -191,6 +191,8 @@
+@@ -1,12 +1,14 @@
+ package net.minecraft.client.network;
+ 
+ import com.google.common.base.Charsets;
++
+ import cpw.mods.fml.client.FMLClientHandler;
+ import cpw.mods.fml.relauncher.Side;
+ import cpw.mods.fml.relauncher.SideOnly;
+ import io.netty.buffer.ByteBuf;
+ import io.netty.buffer.Unpooled;
+ import io.netty.util.concurrent.GenericFutureListener;
++
+ import java.io.ByteArrayInputStream;
+ import java.io.DataInputStream;
+ import java.io.IOException;
+@@ -17,6 +19,7 @@
+ import java.util.Map;
+ import java.util.Random;
+ import java.util.Map.Entry;
++
+ import net.minecraft.block.Block;
+ import net.minecraft.client.ClientBrandRetriever;
+ import net.minecraft.client.Minecraft;
+@@ -183,6 +186,7 @@
+ import net.minecraft.util.ChunkCoordinates;
+ import net.minecraft.util.IChatComponent;
+ import net.minecraft.util.MathHelper;
++import net.minecraft.util.Util;
+ import net.minecraft.village.MerchantRecipeList;
+ import net.minecraft.world.Explosion;
+ import net.minecraft.world.WorldProviderSurface;
+@@ -191,6 +195,9 @@
  import net.minecraft.world.storage.ISaveHandler;
  import net.minecraft.world.storage.MapData;
  import net.minecraft.world.storage.MapStorage;
 +import net.minecraftforge.client.event.ClientChatReceivedEvent;
 +import net.minecraftforge.common.MinecraftForge;
++
  import org.apache.logging.log4j.LogManager;
  import org.apache.logging.log4j.Logger;
  
-@@ -706,7 +708,11 @@
+@@ -706,7 +713,11 @@
      // JAVADOC METHOD $$ func_147251_a
      public void handleChat(S02PacketChat p_147251_1_)
      {
@@ -22,7 +54,22 @@
      }
  
      // JAVADOC METHOD $$ func_147279_a
-@@ -1160,6 +1166,10 @@
+@@ -1105,12 +1116,10 @@
+ 
+         if (this.gameController.theWorld.blockExists(p_147248_1_.func_149346_c(), p_147248_1_.func_149345_d(), p_147248_1_.func_149344_e()))
+         {
+-            TileEntity tileentity = this.gameController.theWorld.getTileEntity(p_147248_1_.func_149346_c(), p_147248_1_.func_149345_d(), p_147248_1_.func_149344_e());
++            TileEntitySign tileentitysign = Util.getTileBehavior(this.gameController.theWorld, p_147248_1_.func_149346_c(), p_147248_1_.func_149345_d(), p_147248_1_.func_149344_e(), TileEntitySign.class);
+ 
+-            if (tileentity instanceof TileEntitySign)
++            if (tileentitysign != null)
+             {
+-                TileEntitySign tileentitysign = (TileEntitySign)tileentity;
+-
+                 if (tileentitysign.func_145914_a())
+                 {
+                     for (int i = 0; i < 4; ++i)
+@@ -1160,6 +1169,10 @@
                  {
                      tileentity.readFromNBT(p_147273_1_.func_148857_g());
                  }

--- a/patches/minecraft/net/minecraft/client/renderer/RenderBlocks.java.patch
+++ b/patches/minecraft/net/minecraft/client/renderer/RenderBlocks.java.patch
@@ -1,6 +1,14 @@
 --- ../src-base/minecraft/net/minecraft/client/renderer/RenderBlocks.java
 +++ ../src-work/minecraft/net/minecraft/client/renderer/RenderBlocks.java
-@@ -52,6 +52,8 @@
+@@ -46,12 +46,16 @@
+ import net.minecraft.util.Direction;
+ import net.minecraft.util.IIcon;
+ import net.minecraft.util.MathHelper;
++import net.minecraft.util.Util;
+ import net.minecraft.util.Vec3;
+ import net.minecraft.world.IBlockAccess;
+ import net.minecraft.world.World;
++
  import org.lwjgl.opengl.GL11;
  import org.lwjgl.opengl.GL12;
  
@@ -9,7 +17,7 @@
  @SideOnly(Side.CLIENT)
  public class RenderBlocks
  {
-@@ -414,9 +416,9 @@
+@@ -414,9 +418,9 @@
      public boolean renderBlockBed(Block p_147773_1_, int p_147773_2_, int p_147773_3_, int p_147773_4_)
      {
          Tessellator tessellator = Tessellator.instance;
@@ -22,7 +30,7 @@
          float f = 0.5F;
          float f1 = 1.0F;
          float f2 = 0.8F;
-@@ -425,6 +427,7 @@
+@@ -425,6 +429,7 @@
          tessellator.setBrightness(j1);
          tessellator.setColorOpaque_F(f, f, f);
          IIcon iicon = this.getBlockIcon(p_147773_1_, this.blockAccess, p_147773_2_, p_147773_3_, p_147773_4_, 0);
@@ -30,7 +38,7 @@
          double d0 = (double)iicon.getMinU();
          double d1 = (double)iicon.getMaxU();
          double d2 = (double)iicon.getMinV();
-@@ -441,6 +444,7 @@
+@@ -441,6 +446,7 @@
          tessellator.setBrightness(p_147773_1_.getMixedBrightnessForBlock(this.blockAccess, p_147773_2_, p_147773_3_ + 1, p_147773_4_));
          tessellator.setColorOpaque_F(f1, f1, f1);
          iicon = this.getBlockIcon(p_147773_1_, this.blockAccess, p_147773_2_, p_147773_3_, p_147773_4_, 1);
@@ -38,7 +46,24 @@
          d0 = (double)iicon.getMinU();
          d1 = (double)iicon.getMaxU();
          d2 = (double)iicon.getMinV();
-@@ -2135,7 +2139,7 @@
+@@ -694,12 +700,12 @@
+         this.renderFaceZPos(p_147752_1_, (double)p_147752_2_, (double)p_147752_3_, (double)((float)p_147752_4_ - 0.5F + f3), iicon);
+         this.renderFaceZNeg(p_147752_1_, (double)p_147752_2_, (double)p_147752_3_, (double)((float)p_147752_4_ + 0.5F - f3), iicon);
+         this.renderFaceYPos(p_147752_1_, (double)p_147752_2_, (double)((float)p_147752_3_ - 0.5F + f3 + 0.1875F), (double)p_147752_4_, this.getBlockIcon(Blocks.dirt));
+-        TileEntity tileentity = this.blockAccess.getTileEntity(p_147752_2_, p_147752_3_, p_147752_4_);
++        TileEntityFlowerPot tile = Util.getTileBehavior(blockAccess, p_147752_2_, p_147752_3_, p_147752_4_, TileEntityFlowerPot.class);
+ 
+-        if (tileentity != null && tileentity instanceof TileEntityFlowerPot)
++        if (tile != null)
+         {
+-            Item item = ((TileEntityFlowerPot)tileentity).getFlowerPotItem();
+-            int i1 = ((TileEntityFlowerPot)tileentity).getFlowerPotData();
++            Item item = tile.getFlowerPotItem();
++            int i1 = tile.getFlowerPotData();
+ 
+             if (item instanceof ItemBlock)
+             {
+@@ -2135,7 +2141,7 @@
          double d9;
          double d10;
  
@@ -47,7 +72,7 @@
          {
              float f2 = 0.2F;
              float f1 = 0.0625F;
-@@ -2155,7 +2159,7 @@
+@@ -2155,7 +2161,7 @@
                  d0 = d5;
              }
  
@@ -56,7 +81,7 @@
              {
                  tessellator.addVertexWithUV((double)((float)p_147801_2_ + f2), (double)((float)p_147801_3_ + f + f1), (double)(p_147801_4_ + 1), d2, d1);
                  tessellator.addVertexWithUV((double)(p_147801_2_ + 0), (double)((float)(p_147801_3_ + 0) + f1), (double)(p_147801_4_ + 1), d2, d3);
-@@ -2167,7 +2171,7 @@
+@@ -2167,7 +2173,7 @@
                  tessellator.addVertexWithUV((double)((float)p_147801_2_ + f2), (double)((float)p_147801_3_ + f + f1), (double)(p_147801_4_ + 1), d2, d1);
              }
  
@@ -65,7 +90,7 @@
              {
                  tessellator.addVertexWithUV((double)((float)(p_147801_2_ + 1) - f2), (double)((float)p_147801_3_ + f + f1), (double)(p_147801_4_ + 0), d0, d1);
                  tessellator.addVertexWithUV((double)(p_147801_2_ + 1 - 0), (double)((float)(p_147801_3_ + 0) + f1), (double)(p_147801_4_ + 0), d0, d3);
-@@ -2179,7 +2183,7 @@
+@@ -2179,7 +2185,7 @@
                  tessellator.addVertexWithUV((double)((float)(p_147801_2_ + 1) - f2), (double)((float)p_147801_3_ + f + f1), (double)(p_147801_4_ + 0), d0, d1);
              }
  
@@ -74,7 +99,7 @@
              {
                  tessellator.addVertexWithUV((double)(p_147801_2_ + 0), (double)((float)p_147801_3_ + f + f1), (double)((float)p_147801_4_ + f2), d2, d1);
                  tessellator.addVertexWithUV((double)(p_147801_2_ + 0), (double)((float)(p_147801_3_ + 0) + f1), (double)(p_147801_4_ + 0), d2, d3);
-@@ -2191,7 +2195,7 @@
+@@ -2191,7 +2197,7 @@
                  tessellator.addVertexWithUV((double)(p_147801_2_ + 0), (double)((float)p_147801_3_ + f + f1), (double)((float)p_147801_4_ + f2), d2, d1);
              }
  
@@ -83,7 +108,7 @@
              {
                  tessellator.addVertexWithUV((double)(p_147801_2_ + 1), (double)((float)p_147801_3_ + f + f1), (double)((float)(p_147801_4_ + 1) - f2), d0, d1);
                  tessellator.addVertexWithUV((double)(p_147801_2_ + 1), (double)((float)(p_147801_3_ + 0) + f1), (double)(p_147801_4_ + 1 - 0), d0, d3);
-@@ -2203,7 +2207,7 @@
+@@ -2203,7 +2209,7 @@
                  tessellator.addVertexWithUV((double)(p_147801_2_ + 1), (double)((float)p_147801_3_ + f + f1), (double)((float)(p_147801_4_ + 1) - f2), d0, d1);
              }
  
@@ -92,7 +117,7 @@
              {
                  d5 = (double)p_147801_2_ + 0.5D + 0.5D;
                  d6 = (double)p_147801_2_ + 0.5D - 0.5D;
-@@ -3217,10 +3221,10 @@
+@@ -3217,10 +3223,10 @@
          double d16 = (double)p_147767_2_ + 0.5D + 0.0625D;
          double d17 = (double)p_147767_4_ + 0.5D - 0.0625D;
          double d18 = (double)p_147767_4_ + 0.5D + 0.0625D;

--- a/patches/minecraft/net/minecraft/entity/ai/EntityAIOcelotSit.java.patch
+++ b/patches/minecraft/net/minecraft/entity/ai/EntityAIOcelotSit.java.patch
@@ -1,0 +1,19 @@
+--- ../src-base/minecraft/net/minecraft/entity/ai/EntityAIOcelotSit.java
++++ ../src-work/minecraft/net/minecraft/entity/ai/EntityAIOcelotSit.java
+@@ -5,6 +5,7 @@
+ import net.minecraft.entity.passive.EntityOcelot;
+ import net.minecraft.init.Blocks;
+ import net.minecraft.tileentity.TileEntityChest;
++import net.minecraft.util.Util;
+ import net.minecraft.world.World;
+ 
+ public class EntityAIOcelotSit extends EntityAIBase
+@@ -110,7 +111,7 @@
+ 
+         if (block == Blocks.chest)
+         {
+-            TileEntityChest tileentitychest = (TileEntityChest)p_151486_1_.getTileEntity(p_151486_2_, p_151486_3_, p_151486_4_);
++            TileEntityChest tileentitychest = Util.getTileBehavior(p_151486_1_, p_151486_2_, p_151486_3_, p_151486_4_, TileEntityChest.class);
+ 
+             if (tileentitychest.numPlayersUsing < 1)
+             {

--- a/patches/minecraft/net/minecraft/item/ItemSign.java.patch
+++ b/patches/minecraft/net/minecraft/item/ItemSign.java.patch
@@ -1,0 +1,19 @@
+--- ../src-base/minecraft/net/minecraft/item/ItemSign.java
++++ ../src-work/minecraft/net/minecraft/item/ItemSign.java
+@@ -5,6 +5,7 @@
+ import net.minecraft.init.Blocks;
+ import net.minecraft.tileentity.TileEntitySign;
+ import net.minecraft.util.MathHelper;
++import net.minecraft.util.Util;
+ import net.minecraft.world.World;
+ 
+ public class ItemSign extends Item
+@@ -80,7 +81,7 @@
+                 }
+ 
+                 --par1ItemStack.stackSize;
+-                TileEntitySign tileentitysign = (TileEntitySign)par3World.getTileEntity(par4, par5, par6);
++                TileEntitySign tileentitysign = Util.getTileBehavior(par3World, par4, par5, par6, TileEntitySign.class);
+ 
+                 if (tileentitysign != null)
+                 {

--- a/patches/minecraft/net/minecraft/item/ItemSkull.java.patch
+++ b/patches/minecraft/net/minecraft/item/ItemSkull.java.patch
@@ -1,0 +1,45 @@
+--- ../src-base/minecraft/net/minecraft/item/ItemSkull.java
++++ ../src-work/minecraft/net/minecraft/item/ItemSkull.java
+@@ -2,7 +2,9 @@
+ 
+ import cpw.mods.fml.relauncher.Side;
+ import cpw.mods.fml.relauncher.SideOnly;
++
+ import java.util.List;
++
+ import net.minecraft.block.BlockSkull;
+ import net.minecraft.client.renderer.texture.IIconRegister;
+ import net.minecraft.creativetab.CreativeTabs;
+@@ -13,6 +15,7 @@
+ import net.minecraft.util.IIcon;
+ import net.minecraft.util.MathHelper;
+ import net.minecraft.util.StatCollector;
++import net.minecraft.util.Util;
+ import net.minecraft.world.World;
+ 
+ public class ItemSkull extends Item
+@@ -86,9 +89,9 @@
+                     i1 = MathHelper.floor_double((double)(par2EntityPlayer.rotationYaw * 16.0F / 360.0F) + 0.5D) & 15;
+                 }
+ 
+-                TileEntity tileentity = par3World.getTileEntity(par4, par5, par6);
++                TileEntitySkull tileentity = Util.getTileBehavior(par3World, par4, par5, par6, TileEntitySkull.class);
+ 
+-                if (tileentity != null && tileentity instanceof TileEntitySkull)
++                if (tileentity != null)
+                 {
+                     String s = "";
+ 
+@@ -97,9 +100,9 @@
+                         s = par1ItemStack.getTagCompound().getString("SkullOwner");
+                     }
+ 
+-                    ((TileEntitySkull)tileentity).func_145905_a(par1ItemStack.getItemDamage(), s);
+-                    ((TileEntitySkull)tileentity).func_145903_a(i1);
+-                    ((BlockSkull)Blocks.skull).func_149965_a(par3World, par4, par5, par6, (TileEntitySkull)tileentity);
++                    tileentity.func_145905_a(par1ItemStack.getItemDamage(), s);
++                    tileentity.func_145903_a(i1);
++                    ((BlockSkull)Blocks.skull).func_149965_a(par3World, par4, par5, par6, tileentity);
+                 }
+ 
+                 --par1ItemStack.stackSize;

--- a/patches/minecraft/net/minecraft/network/NetHandlerPlayServer.java.patch
+++ b/patches/minecraft/net/minecraft/network/NetHandlerPlayServer.java.patch
@@ -1,6 +1,33 @@
 --- ../src-base/minecraft/net/minecraft/network/NetHandlerPlayServer.java
 +++ ../src-work/minecraft/net/minecraft/network/NetHandlerPlayServer.java
-@@ -85,6 +85,14 @@
+@@ -2,9 +2,11 @@
+ 
+ import com.google.common.base.Charsets;
+ import com.google.common.collect.Lists;
++
+ import io.netty.buffer.Unpooled;
+ import io.netty.util.concurrent.Future;
+ import io.netty.util.concurrent.GenericFutureListener;
++
+ import java.io.ByteArrayInputStream;
+ import java.io.DataInputStream;
+ import java.io.IOException;
+@@ -12,6 +14,7 @@
+ import java.util.Iterator;
+ import java.util.Random;
+ import java.util.concurrent.Callable;
++
+ import net.minecraft.block.material.Material;
+ import net.minecraft.command.server.CommandBlockLogic;
+ import net.minecraft.crash.CrashReport;
+@@ -80,11 +83,21 @@
+ import net.minecraft.util.IChatComponent;
+ import net.minecraft.util.IntHashMap;
+ import net.minecraft.util.ReportedException;
++import net.minecraft.util.Util;
+ import net.minecraft.world.WorldServer;
++
+ import org.apache.commons.lang3.StringUtils;
  import org.apache.logging.log4j.LogManager;
  import org.apache.logging.log4j.Logger;
  
@@ -15,7 +42,7 @@
  public class NetHandlerPlayServer implements INetHandlerPlayServer
  {
      private static final Logger logger = LogManager.getLogger();
-@@ -229,6 +237,11 @@
+@@ -229,6 +242,11 @@
                          this.playerEntity.ridingEntity.updateRiderPosition();
                      }
  
@@ -27,7 +54,7 @@
                      this.serverController.getConfigurationManager().updatePlayerPertinentChunks(this.playerEntity);
  
                      if (this.hasMoved)
-@@ -306,9 +319,10 @@
+@@ -306,9 +324,10 @@
                  d4 = d1 - this.playerEntity.posX;
                  double d5 = d2 - this.playerEntity.posY;
                  double d6 = d3 - this.playerEntity.posZ;
@@ -41,7 +68,7 @@
                  double d10 = d7 * d7 + d8 * d8 + d9 * d9;
  
                  if (d10 > 100.0D && (!this.serverController.isSinglePlayer() || !this.serverController.getServerOwner().equals(this.playerEntity.getCommandSenderName())))
-@@ -326,6 +340,11 @@
+@@ -326,6 +345,11 @@
                      this.playerEntity.jump();
                  }
  
@@ -53,7 +80,7 @@
                  this.playerEntity.moveEntity(d4, d5, d6);
                  this.playerEntity.onGround = p_147347_1_.func_149465_i();
                  this.playerEntity.addMovementStat(d4, d5, d6);
-@@ -348,10 +367,15 @@
+@@ -348,10 +372,15 @@
                      logger.warn(this.playerEntity.getCommandSenderName() + " moved wrongly!");
                  }
  
@@ -70,7 +97,7 @@
                  {
                      this.setPlayerLocation(this.lastPosX, this.lastPosY, this.lastPosZ, f1, f2);
                      return;
-@@ -359,7 +383,7 @@
+@@ -359,7 +388,7 @@
  
                  AxisAlignedBB axisalignedbb = this.playerEntity.boundingBox.copy().expand((double)f3, (double)f3, (double)f3).addCoord(0.0D, -0.55D, 0.0D);
  
@@ -79,7 +106,7 @@
                  {
                      if (d11 >= -0.03125D)
                      {
-@@ -378,6 +402,11 @@
+@@ -378,6 +407,11 @@
                      this.floatingTickCount = 0;
                  }
  
@@ -91,7 +118,7 @@
                  this.playerEntity.onGround = p_147347_1_.func_149465_i();
                  this.serverController.getConfigurationManager().updatePlayerPertinentChunks(this.playerEntity);
                  this.playerEntity.handleFalling(this.playerEntity.posY - d0, p_147347_1_.func_149465_i());
-@@ -448,7 +477,10 @@
+@@ -448,7 +482,10 @@
                  double d2 = this.playerEntity.posZ - ((double)k + 0.5D);
                  double d3 = d0 * d0 + d1 * d1 + d2 * d2;
  
@@ -103,7 +130,7 @@
                  {
                      return;
                  }
-@@ -510,7 +542,11 @@
+@@ -510,7 +547,11 @@
                  return;
              }
  
@@ -116,7 +143,7 @@
          }
          else if (p_147346_1_.func_149571_d() >= this.serverController.getBuildLimit() - 1 && (p_147346_1_.func_149568_f() == 1 || p_147346_1_.func_149571_d() >= this.serverController.getBuildLimit()))
          {
-@@ -521,7 +557,9 @@
+@@ -521,7 +562,9 @@
          }
          else
          {
@@ -127,7 +154,7 @@
              {
                  this.playerEntity.theItemInWorldManager.activateBlockOrUseItem(this.playerEntity, worldserver, itemstack, i, j, k, l, p_147346_1_.func_149573_h(), p_147346_1_.func_149569_i(), p_147346_1_.func_149575_j());
              }
-@@ -690,6 +728,8 @@
+@@ -690,6 +733,8 @@
              else
              {
                  ChatComponentTranslation chatcomponenttranslation1 = new ChatComponentTranslation("chat.type.text", new Object[] {this.playerEntity.func_145748_c_(), s});
@@ -136,7 +163,7 @@
                  this.serverController.getConfigurationManager().sendChatMsgImpl(chatcomponenttranslation1, false);
              }
  
-@@ -831,7 +871,7 @@
+@@ -831,7 +876,7 @@
                          return;
                      }
  
@@ -145,3 +172,53 @@
                  }
  
                  break;
+@@ -950,13 +995,11 @@
+ 
+         if (worldserver.blockExists(p_147343_1_.func_149588_c(), p_147343_1_.func_149586_d(), p_147343_1_.func_149585_e()))
+         {
+-            TileEntity tileentity = worldserver.getTileEntity(p_147343_1_.func_149588_c(), p_147343_1_.func_149586_d(), p_147343_1_.func_149585_e());
++            TileEntitySign tile = Util.getTileBehavior(worldserver, p_147343_1_.func_149588_c(), p_147343_1_.func_149586_d(), p_147343_1_.func_149585_e(), TileEntitySign.class);
+ 
+-            if (tileentity instanceof TileEntitySign)
++            if (tile != null)
+             {
+-                TileEntitySign tileentitysign = (TileEntitySign)tileentity;
+-
+-                if (!tileentitysign.func_145914_a() || tileentitysign.func_145911_b() != this.playerEntity)
++                if (!tile.func_145914_a() || tile.func_145911_b() != this.playerEntity)
+                 {
+                     this.serverController.logWarning("Player " + this.playerEntity.getCommandSenderName() + " just tried to change non-editable sign");
+                     return;
+@@ -991,14 +1034,13 @@
+                 }
+             }
+ 
+-            if (tileentity instanceof TileEntitySign)
++            if (tile != null)
+             {
+                 j = p_147343_1_.func_149588_c();
+                 int k = p_147343_1_.func_149586_d();
+                 i = p_147343_1_.func_149585_e();
+-                TileEntitySign tileentitysign1 = (TileEntitySign)tileentity;
+-                System.arraycopy(p_147343_1_.func_149589_f(), 0, tileentitysign1.signText, 0, 4);
+-                tileentitysign1.markDirty();
++                System.arraycopy(p_147343_1_.func_149589_f(), 0, tile.signText, 0, 4);
++                tile.markDirty();
+                 worldserver.markBlockForUpdate(j, k, i);
+             }
+         }
+@@ -1140,11 +1182,11 @@
+ 
+                         if (b0 == 0)
+                         {
+-                            TileEntity tileentity = this.playerEntity.worldObj.getTileEntity(packetbuffer.readInt(), packetbuffer.readInt(), packetbuffer.readInt());
++                            TileEntityCommandBlock tile = Util.getTileBehavior(this.playerEntity.worldObj, packetbuffer.readInt(), packetbuffer.readInt(), packetbuffer.readInt(), TileEntityCommandBlock.class);
+ 
+-                            if (tileentity instanceof TileEntityCommandBlock)
++                            if (tile != null)
+                             {
+-                                commandblocklogic = ((TileEntityCommandBlock)tileentity).func_145993_a();
++                                commandblocklogic = tile.func_145993_a();
+                             }
+                         }
+                         else if (b0 == 1)

--- a/patches/minecraft/net/minecraft/tileentity/TileEntity.java.patch
+++ b/patches/minecraft/net/minecraft/tileentity/TileEntity.java.patch
@@ -1,6 +1,14 @@
 --- ../src-base/minecraft/net/minecraft/tileentity/TileEntity.java
 +++ ../src-work/minecraft/net/minecraft/tileentity/TileEntity.java
-@@ -12,7 +12,10 @@
+@@ -3,6 +3,7 @@
+ import cpw.mods.fml.common.FMLLog;
+ import cpw.mods.fml.relauncher.Side;
+ import cpw.mods.fml.relauncher.SideOnly;
++
+ import java.util.HashMap;
+ import java.util.Map;
+ import java.util.concurrent.Callable;
+@@ -12,8 +13,12 @@
  import net.minecraft.crash.CrashReportCategory;
  import net.minecraft.init.Blocks;
  import net.minecraft.nbt.NBTTagCompound;
@@ -9,9 +17,11 @@
 +import net.minecraft.network.play.server.S35PacketUpdateTileEntity;
 +import net.minecraft.util.AxisAlignedBB;
  import net.minecraft.world.World;
++import net.minecraftforge.common.util.ForgeDirection;
  
  import org.apache.logging.log4j.Level;
-@@ -296,4 +299,93 @@
+ import org.apache.logging.log4j.LogManager;
+@@ -296,4 +301,131 @@
          addMapping(TileEntityComparator.class, "Comparator");
          addMapping(TileEntityFlowerPot.class, "FlowerPot");
      }
@@ -103,5 +113,43 @@
 +            }
 +        }
 +        return bb;
++    }
++    /** Use this method to request any required behavior, like IInventory, instead of simple type cast
++     * 
++     * Sample override which utilizes internal behaviors map
++     * @code
++     * private Map<Class, Object> behaviors = new HashMap<Class, Object>();
++     * 
++     * public<T> T getBehavior(Class<T> clazz, ForgeDirection side) {
++     *     Object behavior = behaviors.get(clazz);
++     *     if (behavior != null && clazz.isInstance(behavior))
++     *         return clazz.cast(behavior); 
++     *     return super.getBehavior(clazz, side);
++     * }
++     * @endcode
++     * Sample usage:
++     * @code
++     * IInventory inv = tileEntity.getBehavior(IInventory.class, ForgeDirection.UP);
++     * if (inv != null)
++     *     // perform actions with IInventory
++     * @endcode
++     * 
++     * @param  clazz Requested behavior type
++     * @param  side  Side to get behavior from 
++     * @return       Behavior reference or null, if this TileEntity doesn't support requested behavior on specified side
++     */
++    public<T> T getBehavior(Class<T> clazz, ForgeDirection side) {
++        if (clazz != null && clazz.isInstance(this))
++            return clazz.cast(this);
++        return null;
++    }
++    /** Requests behavior from ForgeDirection.UNKNOWN side.
++     *  Shouldn't be overridden. Override other overload, which requests side explicitly, instead.
++     * 
++     * @param clazz Requested behavior type
++     * @return      Behavior reference or null, if this TileEntity doesn't support requested behavior on unknown side
++     */
++    final public<T> T getBehavior(Class<T> clazz) {
++        return getBehavior(clazz, ForgeDirection.UNKNOWN);
 +    }
  }

--- a/patches/minecraft/net/minecraft/tileentity/TileEntity.java.patch
+++ b/patches/minecraft/net/minecraft/tileentity/TileEntity.java.patch
@@ -21,7 +21,7 @@
  
  import org.apache.logging.log4j.Level;
  import org.apache.logging.log4j.LogManager;
-@@ -296,4 +301,131 @@
+@@ -296,4 +301,141 @@
          addMapping(TileEntityComparator.class, "Comparator");
          addMapping(TileEntityFlowerPot.class, "FlowerPot");
      }
@@ -151,5 +151,15 @@
 +     */
 +    final public<T> T getBehavior(Class<T> clazz) {
 +        return getBehavior(clazz, ForgeDirection.UNKNOWN);
++    }
++    /** Requests behavior from specified side.
++     *  Shouldn't be overridden. Override other overload, which requests side explicitly as ForgeDirection, instead.
++     * 
++     * @param clazz Requested behavior type
++     * @param side  Behavior is requested from this side; specified via integer
++     * @return      Behavior reference or null, if this TileEntity doesn't support requested behavior on unknown side
++     */
++    final public<T> T getBehavior(Class<T> clazz, int side) {
++        return getBehavior(clazz, ForgeDirection.getOrientation(side));
 +    }
  }

--- a/patches/minecraft/net/minecraft/tileentity/TileEntity.java.patch
+++ b/patches/minecraft/net/minecraft/tileentity/TileEntity.java.patch
@@ -116,14 +116,14 @@
 +    }
 +    /** Use this method to request any required behavior, like IInventory, instead of simple type cast
 +     * 
-+     * Sample override which utilizes internal behaviors map
++     * Sample override which utilizes internal behaviors map (we assume that addition to map is properly guarded)
 +     * @code
 +     * private Map<Class, Object> behaviors = new HashMap<Class, Object>();
 +     * 
 +     * public<T> T getBehavior(Class<T> clazz, ForgeDirection side) {
 +     *     Object behavior = behaviors.get(clazz);
-+     *     if (behavior != null && clazz.isInstance(behavior))
-+     *         return clazz.cast(behavior); 
++     *     if (behavior != null)
++     *         return (T)behavior; 
 +     *     return super.getBehavior(clazz, side);
 +     * }
 +     * @endcode
@@ -140,7 +140,7 @@
 +     */
 +    public<T> T getBehavior(Class<T> clazz, ForgeDirection side) {
 +        if (clazz != null && clazz.isInstance(this))
-+            return clazz.cast(this);
++            return (T)this;
 +        return null;
 +    }
 +    /** Requests behavior from ForgeDirection.UNKNOWN side.

--- a/patches/minecraft/net/minecraft/tileentity/TileEntityChest.java.patch
+++ b/patches/minecraft/net/minecraft/tileentity/TileEntityChest.java.patch
@@ -1,0 +1,48 @@
+--- ../src-base/minecraft/net/minecraft/tileentity/TileEntityChest.java
++++ ../src-work/minecraft/net/minecraft/tileentity/TileEntityChest.java
+@@ -2,8 +2,10 @@
+ 
+ import cpw.mods.fml.relauncher.Side;
+ import cpw.mods.fml.relauncher.SideOnly;
++
+ import java.util.Iterator;
+ import java.util.List;
++
+ import net.minecraft.block.Block;
+ import net.minecraft.block.BlockChest;
+ import net.minecraft.entity.player.EntityPlayer;
+@@ -14,6 +16,7 @@
+ import net.minecraft.nbt.NBTTagCompound;
+ import net.minecraft.nbt.NBTTagList;
+ import net.minecraft.util.AxisAlignedBB;
++import net.minecraft.util.Util;
+ 
+ public class TileEntityChest extends TileEntity implements IInventory
+ {
+@@ -260,22 +263,22 @@
+ 
+             if (this.func_145977_a(this.xCoord - 1, this.yCoord, this.zCoord))
+             {
+-                this.adjacentChestXNeg = (TileEntityChest)this.worldObj.getTileEntity(this.xCoord - 1, this.yCoord, this.zCoord);
++                this.adjacentChestXNeg = Util.getTileBehavior(this.worldObj, this.xCoord - 1, this.yCoord, this.zCoord, TileEntityChest.class);
+             }
+ 
+             if (this.func_145977_a(this.xCoord + 1, this.yCoord, this.zCoord))
+             {
+-                this.adjacentChestXPos = (TileEntityChest)this.worldObj.getTileEntity(this.xCoord + 1, this.yCoord, this.zCoord);
++                this.adjacentChestXPos = Util.getTileBehavior(this.worldObj, this.xCoord + 1, this.yCoord, this.zCoord, TileEntityChest.class);
+             }
+ 
+             if (this.func_145977_a(this.xCoord, this.yCoord, this.zCoord - 1))
+             {
+-                this.adjacentChestZNeg = (TileEntityChest)this.worldObj.getTileEntity(this.xCoord, this.yCoord, this.zCoord - 1);
++                this.adjacentChestZNeg = Util.getTileBehavior(this.worldObj, this.xCoord, this.yCoord, this.zCoord - 1, TileEntityChest.class);
+             }
+ 
+             if (this.func_145977_a(this.xCoord, this.yCoord, this.zCoord + 1))
+             {
+-                this.adjacentChestZPos = (TileEntityChest)this.worldObj.getTileEntity(this.xCoord, this.yCoord, this.zCoord + 1);
++                this.adjacentChestZPos = Util.getTileBehavior(this.worldObj, this.xCoord, this.yCoord, this.zCoord + 1, TileEntityChest.class);
+             }
+ 
+             if (this.adjacentChestZNeg != null)

--- a/patches/minecraft/net/minecraft/tileentity/TileEntityHopper.java.patch
+++ b/patches/minecraft/net/minecraft/tileentity/TileEntityHopper.java.patch
@@ -38,3 +38,23 @@
              }
  
              if (flag)
+@@ -456,12 +469,15 @@
+         int j = MathHelper.floor_double(p_145893_3_);
+         int k = MathHelper.floor_double(p_145893_5_);
+         TileEntity tileentity = p_145893_0_.getTileEntity(i, j, k);
++        TileEntityChest tilechest = null;
++        if (tileentity != null) {
++            iinventory = tileentity.getBehavior(IInventory.class);
++            tilechest = tileentity.getBehavior(TileEntityChest.class);
++        }
+ 
+-        if (tileentity != null && tileentity instanceof IInventory)
++        if (iinventory != null)
+         {
+-            iinventory = (IInventory)tileentity;
+-
+-            if (iinventory instanceof TileEntityChest)
++            if (tilechest != null)
+             {
+                 Block block = p_145893_0_.getBlock(i, j, k);
+ 

--- a/patches/minecraft/net/minecraft/util/Util.java.patch
+++ b/patches/minecraft/net/minecraft/util/Util.java.patch
@@ -15,7 +15,7 @@
  public class Util
  {
      // JAVADOC FIELD $$ field_147174_a
-@@ -62,4 +67,26 @@
+@@ -62,4 +67,30 @@
  
          private static final String __OBFID = "CL_00001660";
      }
@@ -40,5 +40,9 @@
 +    
 +    public static <T> T getTileBehavior(IBlockAccess world, int x, int y, int z, Class<T> clazz) {
 +        return getTileBehavior(world, x, y, z, clazz, ForgeDirection.UNKNOWN);
++    }
++
++    public static <T> T getTileBehavior(IBlockAccess world, int x, int y, int z, Class<T> clazz, int side) {
++        return getTileBehavior(world, x, y, z, clazz, ForgeDirection.getOrientation(side));
 +    }
  }

--- a/patches/minecraft/net/minecraft/util/Util.java.patch
+++ b/patches/minecraft/net/minecraft/util/Util.java.patch
@@ -1,0 +1,44 @@
+--- ../src-base/minecraft/net/minecraft/util/Util.java
++++ ../src-work/minecraft/net/minecraft/util/Util.java
+@@ -2,9 +2,14 @@
+ 
+ import cpw.mods.fml.relauncher.Side;
+ import cpw.mods.fml.relauncher.SideOnly;
++
+ import java.util.UUID;
+ import java.util.regex.Pattern;
+ 
++import net.minecraft.tileentity.TileEntity;
++import net.minecraft.world.IBlockAccess;
++import net.minecraftforge.common.util.ForgeDirection;
++
+ public class Util
+ {
+     // JAVADOC FIELD $$ field_147174_a
+@@ -62,4 +67,26 @@
+ 
+         private static final String __OBFID = "CL_00001660";
+     }
++    // == FORGE ==
++    /** Shortcut method, gets tile entity, then gets desired behavior.
++     * Returns null if there's no tile entity
++     * 
++     * @param world Block provider
++     * @param x
++     * @param y
++     * @param z
++     * @param clazz Behavior type
++     * @param side  Side to get behavior from
++     * @return      Behavior, if there's tile entity present and behavior is supported; null otherwise
++     */
++    public static <T> T getTileBehavior(IBlockAccess world, int x, int y, int z, Class<T> clazz, ForgeDirection side) {
++        TileEntity tile = world.getTileEntity(x, y, z);
++        if (tile != null)
++            return tile.getBehavior(clazz, side);
++        return null;
++    }
++    
++    public static <T> T getTileBehavior(IBlockAccess world, int x, int y, int z, Class<T> clazz) {
++        return getTileBehavior(world, x, y, z, clazz, ForgeDirection.UNKNOWN);
++    }
+ }

--- a/patches/minecraft/net/minecraft/world/gen/feature/WorldGenDungeons.java.patch
+++ b/patches/minecraft/net/minecraft/world/gen/feature/WorldGenDungeons.java.patch
@@ -1,7 +1,16 @@
 --- ../src-base/minecraft/net/minecraft/world/gen/feature/WorldGenDungeons.java
 +++ ../src-work/minecraft/net/minecraft/world/gen/feature/WorldGenDungeons.java
-@@ -8,6 +8,9 @@
+@@ -1,13 +1,18 @@
+ package net.minecraft.world.gen.feature;
+ 
+ import java.util.Random;
++
+ import net.minecraft.block.material.Material;
+ import net.minecraft.init.Blocks;
+ import net.minecraft.init.Items;
+ import net.minecraft.tileentity.TileEntityChest;
  import net.minecraft.tileentity.TileEntityMobSpawner;
++import net.minecraft.util.Util;
  import net.minecraft.util.WeightedRandomChestContent;
  import net.minecraft.world.World;
 +import net.minecraftforge.common.ChestGenHooks;
@@ -10,12 +19,13 @@
  
  public class WorldGenDungeons extends WorldGenerator
  {
-@@ -123,12 +126,11 @@
+@@ -123,12 +128,11 @@
                                  if (k2 == 1)
                                  {
                                      par1World.setBlock(i2, par4, j2, Blocks.chest, 0, 2);
 -                                    WeightedRandomChestContent[] aweightedrandomchestcontent = WeightedRandomChestContent.func_92080_a(field_111189_a, new WeightedRandomChestContent[] {Items.enchanted_book.func_92114_b(par2Random)});
-                                     TileEntityChest tileentitychest = (TileEntityChest)par1World.getTileEntity(i2, par4, j2);
+-                                    TileEntityChest tileentitychest = (TileEntityChest)par1World.getTileEntity(i2, par4, j2);
++                                    TileEntityChest tileentitychest = Util.getTileBehavior(par1World, i2, par4, j2, TileEntityChest.class);
  
                                      if (tileentitychest != null)
                                      {
@@ -24,7 +34,16 @@
                                      }
  
                                      break label101;
-@@ -168,7 +170,6 @@
+@@ -146,7 +150,7 @@
+             }
+ 
+             par1World.setBlock(par3, par4, par5, Blocks.mob_spawner, 0, 2);
+-            TileEntityMobSpawner tileentitymobspawner = (TileEntityMobSpawner)par1World.getTileEntity(par3, par4, par5);
++            TileEntityMobSpawner tileentitymobspawner = Util.getTileBehavior(par1World, par3, par4, par5, TileEntityMobSpawner.class);
+ 
+             if (tileentitymobspawner != null)
+             {
+@@ -168,7 +172,6 @@
      // JAVADOC METHOD $$ func_76543_b
      private String pickMobSpawner(Random par1Random)
      {

--- a/patches/minecraft/net/minecraft/world/gen/feature/WorldGeneratorBonusChest.java.patch
+++ b/patches/minecraft/net/minecraft/world/gen/feature/WorldGeneratorBonusChest.java.patch
@@ -1,6 +1,19 @@
 --- ../src-base/minecraft/net/minecraft/world/gen/feature/WorldGeneratorBonusChest.java
 +++ ../src-work/minecraft/net/minecraft/world/gen/feature/WorldGeneratorBonusChest.java
-@@ -26,10 +26,12 @@
+@@ -1,10 +1,12 @@
+ package net.minecraft.world.gen.feature;
+ 
+ import java.util.Random;
++
+ import net.minecraft.block.Block;
+ import net.minecraft.block.material.Material;
+ import net.minecraft.init.Blocks;
+ import net.minecraft.tileentity.TileEntityChest;
++import net.minecraft.util.Util;
+ import net.minecraft.util.WeightedRandomChestContent;
+ import net.minecraft.world.World;
+ 
+@@ -26,10 +28,12 @@
      {
          Block block;
  
@@ -16,3 +29,12 @@
  
          if (par4 < 1)
          {
+@@ -48,7 +52,7 @@
+                 if (par1World.isAirBlock(i1, j1, k1) && World.doesBlockHaveSolidTopSurface(par1World, i1, j1 - 1, k1))
+                 {
+                     par1World.setBlock(i1, j1, k1, Blocks.chest, 0, 2);
+-                    TileEntityChest tileentitychest = (TileEntityChest)par1World.getTileEntity(i1, j1, k1);
++                    TileEntityChest tileentitychest = Util.getTileBehavior(par1World, i1, j1, k1, TileEntityChest.class);
+ 
+                     if (tileentitychest != null && tileentitychest != null)
+                     {

--- a/patches/minecraft/net/minecraft/world/gen/structure/StructureComponent.java.patch
+++ b/patches/minecraft/net/minecraft/world/gen/structure/StructureComponent.java.patch
@@ -1,6 +1,22 @@
 --- ../src-base/minecraft/net/minecraft/world/gen/structure/StructureComponent.java
 +++ ../src-work/minecraft/net/minecraft/world/gen/structure/StructureComponent.java
-@@ -36,6 +36,10 @@
+@@ -3,6 +3,7 @@
+ import java.util.Iterator;
+ import java.util.List;
+ import java.util.Random;
++
+ import net.minecraft.block.Block;
+ import net.minecraft.block.BlockDirectional;
+ import net.minecraft.block.material.Material;
+@@ -13,6 +14,7 @@
+ import net.minecraft.tileentity.TileEntityDispenser;
+ import net.minecraft.util.Direction;
+ import net.minecraft.util.Facing;
++import net.minecraft.util.Util;
+ import net.minecraft.util.WeightedRandomChestContent;
+ import net.minecraft.world.ChunkPosition;
+ import net.minecraft.world.World;
+@@ -36,6 +38,10 @@
  
      public NBTTagCompound func_143010_b()
      {
@@ -11,3 +27,21 @@
          NBTTagCompound nbttagcompound = new NBTTagCompound();
          nbttagcompound.setString("id", MapGenStructureIO.func_143036_a(this));
          nbttagcompound.setTag("BB", this.boundingBox.func_151535_h());
+@@ -749,7 +755,7 @@
+         if (par2StructureBoundingBox.isVecInside(i1, j1, k1) && par1World.getBlock(i1, j1, k1) != Blocks.chest)
+         {
+             par1World.setBlock(i1, j1, k1, Blocks.chest, 0, 2);
+-            TileEntityChest tileentitychest = (TileEntityChest)par1World.getTileEntity(i1, j1, k1);
++            TileEntityChest tileentitychest = Util.getTileBehavior(par1World, i1, j1, k1, TileEntityChest.class);
+ 
+             if (tileentitychest != null)
+             {
+@@ -774,7 +780,7 @@
+         if (par2StructureBoundingBox.isVecInside(j1, k1, l1) && par1World.getBlock(j1, k1, l1) != Blocks.dispenser)
+         {
+             par1World.setBlock(j1, k1, l1, Blocks.dispenser, this.getMetadataWithOffset(Blocks.dispenser, par7), 2);
+-            TileEntityDispenser tileentitydispenser = (TileEntityDispenser)par1World.getTileEntity(j1, k1, l1);
++            TileEntityDispenser tileentitydispenser = Util.getTileBehavior(par1World, j1, k1, l1, TileEntityDispenser.class);
+ 
+             if (tileentitydispenser != null)
+             {

--- a/patches/minecraft/net/minecraft/world/gen/structure/StructureMineshaftPieces.java.patch
+++ b/patches/minecraft/net/minecraft/world/gen/structure/StructureMineshaftPieces.java.patch
@@ -1,16 +1,28 @@
 --- ../src-base/minecraft/net/minecraft/world/gen/structure/StructureMineshaftPieces.java
 +++ ../src-work/minecraft/net/minecraft/world/gen/structure/StructureMineshaftPieces.java
-@@ -16,6 +16,9 @@
+@@ -4,6 +4,7 @@
+ import java.util.LinkedList;
+ import java.util.List;
+ import java.util.Random;
++
+ import net.minecraft.block.Block;
+ import net.minecraft.block.material.Material;
+ import net.minecraft.entity.item.EntityMinecartChest;
+@@ -12,9 +13,13 @@
+ import net.minecraft.item.Item;
+ import net.minecraft.nbt.NBTTagCompound;
+ import net.minecraft.nbt.NBTTagList;
++import net.minecraft.tileentity.TileEntity;
+ import net.minecraft.tileentity.TileEntityMobSpawner;
++import net.minecraft.util.Util;
  import net.minecraft.util.WeightedRandomChestContent;
  import net.minecraft.world.World;
- 
 +import net.minecraftforge.common.ChestGenHooks;
 +import static net.minecraftforge.common.ChestGenHooks.*;
-+
+ 
  public class StructureMineshaftPieces
  {
-     // JAVADOC FIELD $$ field_78818_a
-@@ -664,14 +667,15 @@
+@@ -664,14 +669,15 @@
                          this.func_151552_a(par1World, par3StructureBoundingBox, par2Random, 0.05F, 1, 2, k - 1, Blocks.torch, 0);
                          this.func_151552_a(par1World, par3StructureBoundingBox, par2Random, 0.05F, 1, 2, k + 1, Blocks.torch, 0);
  
@@ -28,3 +40,17 @@
                          }
  
                          if (this.hasSpiders && !this.spawnerPlaced)
+@@ -685,12 +691,9 @@
+                             {
+                                 this.spawnerPlaced = true;
+                                 par1World.setBlock(j1, l, i1, Blocks.mob_spawner, 0, 2);
+-                                TileEntityMobSpawner tileentitymobspawner = (TileEntityMobSpawner)par1World.getTileEntity(j1, l, i1);
+-
++                                TileEntityMobSpawner tileentitymobspawner = Util.getTileBehavior(par1World, j1, l, i1, TileEntityMobSpawner.class);
+                                 if (tileentitymobspawner != null)
+-                                {
+                                     tileentitymobspawner.func_145881_a().setEntityName("CaveSpider");
+-                                }
+                             }
+                         }
+                     }

--- a/patches/minecraft/net/minecraft/world/gen/structure/StructureNetherBridgePieces.java.patch
+++ b/patches/minecraft/net/minecraft/world/gen/structure/StructureNetherBridgePieces.java.patch
@@ -1,0 +1,30 @@
+--- ../src-base/minecraft/net/minecraft/world/gen/structure/StructureNetherBridgePieces.java
++++ ../src-work/minecraft/net/minecraft/world/gen/structure/StructureNetherBridgePieces.java
+@@ -4,10 +4,13 @@
+ import java.util.Iterator;
+ import java.util.List;
+ import java.util.Random;
++
+ import net.minecraft.init.Blocks;
+ import net.minecraft.init.Items;
+ import net.minecraft.nbt.NBTTagCompound;
++import net.minecraft.tileentity.TileEntity;
+ import net.minecraft.tileentity.TileEntityMobSpawner;
++import net.minecraft.util.Util;
+ import net.minecraft.util.WeightedRandomChestContent;
+ import net.minecraft.world.World;
+ 
+@@ -521,12 +524,9 @@
+                     {
+                         this.hasSpawner = true;
+                         par1World.setBlock(j, i, k, Blocks.mob_spawner, 0, 2);
+-                        TileEntityMobSpawner tileentitymobspawner = (TileEntityMobSpawner)par1World.getTileEntity(j, i, k);
+-
++                        TileEntityMobSpawner tileentitymobspawner = Util.getTileBehavior(par1World, j, i, k, TileEntityMobSpawner.class);
+                         if (tileentitymobspawner != null)
+-                        {
+                             tileentitymobspawner.func_145881_a().setEntityName("Blaze");
+-                        }
+                     }
+                 }
+ 

--- a/patches/minecraft/net/minecraft/world/gen/structure/StructureStrongholdPieces.java.patch
+++ b/patches/minecraft/net/minecraft/world/gen/structure/StructureStrongholdPieces.java.patch
@@ -1,16 +1,25 @@
 --- ../src-base/minecraft/net/minecraft/world/gen/structure/StructureStrongholdPieces.java
 +++ ../src-work/minecraft/net/minecraft/world/gen/structure/StructureStrongholdPieces.java
-@@ -12,6 +12,9 @@
+@@ -4,13 +4,18 @@
+ import java.util.Iterator;
+ import java.util.List;
+ import java.util.Random;
++
+ import net.minecraft.init.Blocks;
+ import net.minecraft.init.Items;
+ import net.minecraft.nbt.NBTTagCompound;
++import net.minecraft.tileentity.TileEntity;
+ import net.minecraft.tileentity.TileEntityMobSpawner;
++import net.minecraft.util.Util;
+ import net.minecraft.util.WeightedRandomChestContent;
  import net.minecraft.world.ChunkPosition;
  import net.minecraft.world.World;
- 
 +import net.minecraftforge.common.ChestGenHooks;
 +import static net.minecraftforge.common.ChestGenHooks.*;
-+
+ 
  public class StructureStrongholdPieces
  {
-     private static final StructureStrongholdPieces.PieceWeight[] pieceWeightArray = new StructureStrongholdPieces.PieceWeight[] {new StructureStrongholdPieces.PieceWeight(StructureStrongholdPieces.Straight.class, 40, 0), new StructureStrongholdPieces.PieceWeight(StructureStrongholdPieces.Prison.class, 5, 5), new StructureStrongholdPieces.PieceWeight(StructureStrongholdPieces.LeftTurn.class, 20, 0), new StructureStrongholdPieces.PieceWeight(StructureStrongholdPieces.RightTurn.class, 20, 0), new StructureStrongholdPieces.PieceWeight(StructureStrongholdPieces.RoomCrossing.class, 10, 6), new StructureStrongholdPieces.PieceWeight(StructureStrongholdPieces.StairsStraight.class, 5, 5), new StructureStrongholdPieces.PieceWeight(StructureStrongholdPieces.Stairs.class, 5, 5), new StructureStrongholdPieces.PieceWeight(StructureStrongholdPieces.Crossing.class, 5, 4), new StructureStrongholdPieces.PieceWeight(StructureStrongholdPieces.ChestCorridor.class, 5, 4), new StructureStrongholdPieces.PieceWeight(StructureStrongholdPieces.Library.class, 10, 2)
-@@ -573,12 +576,14 @@
+@@ -573,12 +578,14 @@
                          this.placeBlockAtCurrentPosition(par1World, Blocks.torch, 0, b1, 8, b2 + 1, par3StructureBoundingBox);
                      }
  
@@ -27,7 +36,21 @@
                      }
  
                      return true;
-@@ -806,7 +811,7 @@
+@@ -718,12 +725,9 @@
+                     {
+                         this.hasSpawner = true;
+                         par1World.setBlock(k, i1, l, Blocks.mob_spawner, 0, 2);
+-                        TileEntityMobSpawner tileentitymobspawner = (TileEntityMobSpawner)par1World.getTileEntity(k, i1, l);
+-
++                        TileEntityMobSpawner tileentitymobspawner = Util.getTileBehavior(par1World, k, i1, l, TileEntityMobSpawner.class);
+                         if (tileentitymobspawner != null)
+-                        {
+                             tileentitymobspawner.func_145881_a().setEntityName("Silverfish");
+-                        }
+                     }
+                 }
+ 
+@@ -806,7 +810,7 @@
                          if (par3StructureBoundingBox.isVecInside(j, i, k))
                          {
                              this.hasMadeChest = true;
@@ -36,7 +59,7 @@
                          }
                      }
  
-@@ -960,7 +965,7 @@
+@@ -960,7 +964,7 @@
                              this.placeBlockAtCurrentPosition(par1World, Blocks.ladder, this.getMetadataWithOffset(Blocks.ladder, 4), 9, 1, 3, par3StructureBoundingBox);
                              this.placeBlockAtCurrentPosition(par1World, Blocks.ladder, this.getMetadataWithOffset(Blocks.ladder, 4), 9, 2, 3, par3StructureBoundingBox);
                              this.placeBlockAtCurrentPosition(par1World, Blocks.ladder, this.getMetadataWithOffset(Blocks.ladder, 4), 9, 3, 3, par3StructureBoundingBox);


### PR DESCRIPTION
This PR shows a way of migrating TE to dynamic behavior resolution, instead of currently used instanceof+typecast. I thought that a single PR would speak for itself better than tons of pages on forum.
I don't expect this PR to be merged - this is more of a concept or sketch. And even if such changes would be taken into account, I don't think they would happen before MC 1.8
Main changes are in TileEntity and Util classes, all other patched files are just brought in sync to TE changes

Pros of this approach:
+ TileEntity can function as a transparent proxy for other tiles, or a 'transparent' container for parts. As example, we potentially won't need to subclass Forge Multipart TE class to integrate pipes/wires/etc as multipart.
+ More convenient way of presenting temporary or sided behaviors. As example, you won't need ISidedInventory - just return IInventory on some sides and don't return on the other ones.

Cons:
- Would require to rewrite large portions of code. This might even need to be done on Mojang side.
- I still have no good idea on how to prohibit/discourage modders from using instanceof and move to getBehavior; making a proxy class would require to hide TE's public mutable fields behind accessor methods
