### PR TITLE
Fixes trap door not being able to place in solid sides

### DIFF
--- a/patches/minecraft/net/minecraft/block/BlockTrapDoor.java.patch
+++ b/patches/minecraft/net/minecraft/block/BlockTrapDoor.java.patch
@@ -35,7 +35,7 @@
              }
  
 -            return func_150119_a(p_149707_1_.getBlock(p_149707_2_, p_149707_3_, p_149707_4_));
-+            return func_150119_a(p_149707_1_.getBlock(p_149707_2_, p_149707_3_, p_149707_4_)) || p_149707_1_.isSideSolid(p_149707_2_, p_149707_3_, p_149707_4_, ForgeDirection.UP);
++            return func_150119_a(p_149707_1_.getBlock(p_149707_2_, p_149707_3_, p_149707_4_)) || p_149707_1_.isSideSolid(p_149707_2_, p_149707_3_, p_149707_4_, ForgeDirection.VALID_DIRECTIONS[p_149707_5_]);
          }
      }
  


### PR DESCRIPTION
Just a small fix. The trap door could be placed when the support block is solid on top instead of the direction that we were placing the trap door, this was affecting [Forge Multipart (issue 173)](https://github.com/Chicken-Bones/ForgeMultipart/issues/173), if we placed an cover in the top face we could place a trapdoor next to it:
![2014-03-21_00 47 43](https://f.cloud.github.com/assets/3679022/2480027/bc5cff3c-b0ab-11e3-9cae-41cca8c12d9d.png)

Also, when you place a block next to that trap door it drops because it was placed incorrectly.

This fixes will require the face of the support block to be solid and not the top part of the block:
![2014-03-21_00 48 18](https://f.cloud.github.com/assets/3679022/2480032/fb8b6f0e-b0ab-11e3-8c2a-0d5d91834a74.png)

Will also fix the block dropping issue because the trap door will be placed correctly