### PR TITLE
Fix extended entity properties being lost when leaving the end

### DIFF
--- a/patches/minecraft/net/minecraft/entity/Entity.java.patch
+++ b/patches/minecraft/net/minecraft/entity/Entity.java.patch
@@ -54,7 +54,7 @@
 +    public ArrayList<EntityItem> capturedDrops = new ArrayList<EntityItem>();
 +    private UUID persistentID;
  
-+    private HashMap<String, IExtendedEntityProperties> extendedProperties;
++    protected HashMap<String, IExtendedEntityProperties> extendedProperties;
 +
      public int getEntityId()
      {

--- a/patches/minecraft/net/minecraft/entity/player/EntityPlayer.java.patch
+++ b/patches/minecraft/net/minecraft/entity/player/EntityPlayer.java.patch
@@ -13,11 +13,12 @@
  import net.minecraft.block.Block;
  import net.minecraft.block.BlockBed;
  import net.minecraft.block.material.Material;
-@@ -78,8 +81,24 @@
+@@ -78,8 +81,25 @@
  import net.minecraft.world.WorldSettings;
  import net.minecraft.world.chunk.IChunkProvider;
  
 +import net.minecraftforge.common.ForgeHooks;
++import net.minecraftforge.common.IExtendedEntityProperties;
 +import net.minecraftforge.common.ISpecialArmor.ArmorProperties;
 +import net.minecraftforge.common.MinecraftForge;
 +import net.minecraftforge.event.ForgeEventFactory;
@@ -38,7 +39,7 @@
      // JAVADOC FIELD $$ field_71071_by
      public InventoryPlayer inventory = new InventoryPlayer(this);
      private InventoryEnderChest theInventoryEnderChest = new InventoryEnderChest();
-@@ -148,6 +167,7 @@
+@@ -148,6 +168,7 @@
          this.setLocationAndAngles((double)chunkcoordinates.posX + 0.5D, (double)(chunkcoordinates.posY + 1), (double)chunkcoordinates.posZ + 0.5D, 0.0F, 0.0F);
          this.field_70741_aB = 180.0F;
          this.fireResistance = 20;
@@ -46,7 +47,7 @@
      }
  
      protected void applyEntityAttributes()
-@@ -195,7 +215,8 @@
+@@ -195,7 +216,8 @@
      {
          if (this.itemInUse != null)
          {
@@ -56,7 +57,7 @@
          }
  
          this.clearItemInUse();
-@@ -227,14 +248,23 @@
+@@ -227,14 +249,23 @@
  
              if (itemstack == this.itemInUse)
              {
@@ -85,7 +86,7 @@
                  }
              }
              else
-@@ -281,7 +311,7 @@
+@@ -281,7 +312,7 @@
  
          super.onUpdate();
  
@@ -94,7 +95,7 @@
          {
              this.closeScreen();
              this.openContainer = this.inventoryContainer;
-@@ -416,11 +446,13 @@
+@@ -416,11 +447,13 @@
              int i = this.itemInUse.stackSize;
              ItemStack itemstack = this.itemInUse.onFoodEaten(this.worldObj, this);
  
@@ -109,7 +110,7 @@
                  {
                      this.inventory.mainInventory[this.inventory.currentItem] = null;
                  }
-@@ -498,11 +530,11 @@
+@@ -498,11 +531,11 @@
              this.cameraYaw = 0.0F;
              this.addMountedMovementStat(this.posX - d0, this.posY - d1, this.posZ - d2);
  
@@ -123,7 +124,7 @@
              }
          }
      }
-@@ -632,11 +664,15 @@
+@@ -632,11 +665,15 @@
      // JAVADOC METHOD $$ func_70645_a
      public void onDeath(DamageSource par1DamageSource)
      {
@@ -139,7 +140,7 @@
          if (this.getCommandSenderName().equals("Notch"))
          {
              this.func_146097_a(new ItemStack(Items.apple, 1), true, false);
-@@ -647,6 +683,20 @@
+@@ -647,6 +684,20 @@
              this.inventory.dropAllItems();
          }
  
@@ -160,7 +161,7 @@
          if (par1DamageSource != null)
          {
              this.motionX = (double)(-MathHelper.cos((this.attackedAtYaw + this.rotationYaw) * (float)Math.PI / 180.0F) * 0.1F);
-@@ -702,13 +752,26 @@
+@@ -702,13 +753,26 @@
      // JAVADOC METHOD $$ func_71040_bB
      public EntityItem dropOneItem(boolean par1)
      {
@@ -189,7 +190,7 @@
      }
  
      public EntityItem func_146097_a(ItemStack p_146097_1_, boolean p_146097_2_, boolean p_146097_3_)
-@@ -765,14 +828,26 @@
+@@ -765,14 +829,26 @@
      // JAVADOC METHOD $$ func_71012_a
      public void joinEntityItemWithWorld(EntityItem par1EntityItem)
      {
@@ -217,7 +218,7 @@
          if (f > 1.0F)
          {
              int i = EnchantmentHelper.getEfficiencyModifier(this);
-@@ -782,7 +857,9 @@
+@@ -782,7 +858,9 @@
              {
                  float f1 = (float)(i * i + 1);
  
@@ -228,7 +229,7 @@
                  {
                      f += f1 * 0.08F;
                  }
-@@ -813,13 +890,14 @@
+@@ -813,13 +891,14 @@
              f /= 5.0F;
          }
  
@@ -245,7 +246,7 @@
      }
  
      // JAVADOC METHOD $$ func_70037_a
-@@ -849,6 +927,16 @@
+@@ -849,6 +928,16 @@
              this.spawnForced = par1NBTTagCompound.getBoolean("SpawnForced");
          }
  
@@ -262,7 +263,7 @@
          this.foodStats.readNBT(par1NBTTagCompound);
          this.capabilities.readCapabilitiesFromNBT(par1NBTTagCompound);
  
-@@ -880,6 +968,23 @@
+@@ -880,6 +969,23 @@
              par1NBTTagCompound.setBoolean("SpawnForced", this.spawnForced);
          }
  
@@ -286,7 +287,7 @@
          this.foodStats.writeNBT(par1NBTTagCompound);
          this.capabilities.writeCapabilitiesToNBT(par1NBTTagCompound);
          par1NBTTagCompound.setTag("EnderItems", this.theInventoryEnderChest.saveInventoryToNBT());
-@@ -904,7 +1009,7 @@
+@@ -904,7 +1010,7 @@
  
      public float getEyeHeight()
      {
@@ -295,7 +296,7 @@
      }
  
      // JAVADOC METHOD $$ func_71061_d_
-@@ -916,6 +1021,7 @@
+@@ -916,6 +1022,7 @@
      // JAVADOC METHOD $$ func_70097_a
      public boolean attackEntityFrom(DamageSource par1DamageSource, float par2)
      {
@@ -303,7 +304,7 @@
          if (this.isEntityInvulnerable())
          {
              return false;
-@@ -1020,12 +1126,15 @@
+@@ -1020,12 +1127,15 @@
      {
          if (!this.isEntityInvulnerable())
          {
@@ -320,7 +321,7 @@
              par2 = this.applyPotionDamageCalculations(par1DamageSource, par2);
              float f1 = par2;
              par2 = Math.max(par2 - this.getAbsorptionAmount(), 0.0F);
-@@ -1060,6 +1169,7 @@
+@@ -1060,6 +1170,7 @@
  
      public boolean interactWith(Entity par1Entity)
      {
@@ -328,7 +329,7 @@
          ItemStack itemstack = this.getCurrentEquippedItem();
          ItemStack itemstack1 = itemstack != null ? itemstack.copy() : null;
  
-@@ -1112,7 +1222,9 @@
+@@ -1112,7 +1223,9 @@
      // JAVADOC METHOD $$ func_71028_bD
      public void destroyCurrentEquippedItem()
      {
@@ -338,7 +339,7 @@
      }
  
      // JAVADOC METHOD $$ func_70033_W
-@@ -1124,6 +1236,15 @@
+@@ -1124,6 +1237,15 @@
      // JAVADOC METHOD $$ func_71059_n
      public void attackTargetEntityWithCurrentItem(Entity par1Entity)
      {
@@ -354,7 +355,7 @@
          if (par1Entity.canAttackWithItem())
          {
              if (!par1Entity.hitByEntity(this))
-@@ -1276,6 +1397,12 @@
+@@ -1276,6 +1398,12 @@
      // JAVADOC METHOD $$ func_71018_a
      public EntityPlayer.EnumStatus sleepInBedAt(int par1, int par2, int par3)
      {
@@ -367,7 +368,7 @@
          if (!this.worldObj.isRemote)
          {
              if (this.isPlayerSleeping() || !this.isEntityAlive())
-@@ -1318,8 +1445,7 @@
+@@ -1318,8 +1446,7 @@
  
          if (this.worldObj.blockExists(par1, par2, par3))
          {
@@ -377,7 +378,7 @@
              float f1 = 0.5F;
              float f = 0.5F;
  
-@@ -1387,11 +1513,12 @@
+@@ -1387,11 +1514,12 @@
          this.resetHeight();
          ChunkCoordinates chunkcoordinates = this.playerLocation;
          ChunkCoordinates chunkcoordinates1 = this.playerLocation;
@@ -393,7 +394,7 @@
  
              if (chunkcoordinates1 == null)
              {
-@@ -1426,7 +1553,7 @@
+@@ -1426,7 +1554,7 @@
      // JAVADOC METHOD $$ func_71065_l
      private boolean isInBed()
      {
@@ -402,7 +403,7 @@
      }
  
      // JAVADOC METHOD $$ func_71056_a
-@@ -1438,9 +1565,9 @@
+@@ -1438,9 +1566,9 @@
          ichunkprovider.loadChunk(par1ChunkCoordinates.posX - 3 >> 4, par1ChunkCoordinates.posZ + 3 >> 4);
          ichunkprovider.loadChunk(par1ChunkCoordinates.posX + 3 >> 4, par1ChunkCoordinates.posZ + 3 >> 4);
  
@@ -414,7 +415,7 @@
              return chunkcoordinates1;
          }
          else
-@@ -1459,8 +1586,10 @@
+@@ -1459,8 +1587,10 @@
      {
          if (this.playerLocation != null)
          {
@@ -427,7 +428,7 @@
  
              switch (j)
              {
-@@ -1519,19 +1648,26 @@
+@@ -1519,19 +1649,26 @@
      public void addChatComponentMessage(IChatComponent p_146105_1_) {}
  
      // JAVADOC METHOD $$ func_70997_bJ
@@ -456,7 +457,7 @@
          if (par1ChunkCoordinates != null)
          {
              this.spawnChunk = new ChunkCoordinates(par1ChunkCoordinates);
-@@ -1713,6 +1849,10 @@
+@@ -1713,6 +1850,10 @@
  
              super.fall(par1);
          }
@@ -467,7 +468,7 @@
      }
  
      protected String func_146067_o(int p_146067_1_)
-@@ -1758,11 +1898,6 @@
+@@ -1758,11 +1899,6 @@
          }
          else
          {
@@ -479,7 +480,7 @@
              if (this.itemInUse != null && par1ItemStack.getItem() == Items.bow)
              {
                  int j = par1ItemStack.getMaxItemUseDuration() - this.itemInUseCount;
-@@ -1782,6 +1917,7 @@
+@@ -1782,6 +1918,7 @@
                      return Items.bow.getItemIconForUseDuration(0);
                  }
              }
@@ -487,7 +488,7 @@
          }
  
          return iicon;
-@@ -1872,6 +2008,8 @@
+@@ -1872,6 +2009,8 @@
      {
          if (par1ItemStack != this.itemInUse)
          {
@@ -496,7 +497,20 @@
              this.itemInUse = par1ItemStack;
              this.itemInUseCount = par2;
  
-@@ -1970,6 +2108,17 @@
+@@ -1959,6 +2098,12 @@
+             this.experience = par1EntityPlayer.experience;
+             this.setScore(par1EntityPlayer.getScore());
+             this.teleportDirection = par1EntityPlayer.teleportDirection;
++            //Make sure extended properties are kept when leaving the end.
++            this.extendedProperties = par1EntityPlayer.extendedProperties;
++            for (IExtendedEntityProperties props : this.extendedProperties.values())
++            {
++                props.init(this, this.worldObj);
++            }
+         }
+         else if (this.worldObj.getGameRules().getGameRuleBooleanValue("keepInventory"))
+         {
+@@ -1970,6 +2115,17 @@
          }
  
          this.theInventoryEnderChest = par1EntityPlayer.theInventoryEnderChest;
@@ -514,7 +528,7 @@
      }
  
      // JAVADOC METHOD $$ func_70041_e_
-@@ -2016,7 +2165,14 @@
+@@ -2016,7 +2172,14 @@
      // JAVADOC METHOD $$ func_70062_b
      public void setCurrentItemOrArmor(int par1, ItemStack par2ItemStack)
      {
@@ -530,7 +544,7 @@
      }
  
      // JAVADOC METHOD $$ func_98034_c
-@@ -2062,7 +2218,7 @@
+@@ -2062,7 +2225,7 @@
  
      public IChatComponent func_145748_c_()
      {
@@ -539,7 +553,7 @@
          chatcomponenttext.getChatStyle().setChatClickEvent(new ClickEvent(ClickEvent.Action.SUGGEST_COMMAND, "/msg " + this.getCommandSenderName() + " "));
          return chatcomponenttext;
      }
-@@ -2099,6 +2255,119 @@
+@@ -2099,6 +2262,119 @@
          FMLNetworkHandler.openGui(this, mod, modGuiId, world, x, y, z);
      }
  

--- a/src/main/java/net/minecraftforge/common/IExtendedEntityProperties.java
+++ b/src/main/java/net/minecraftforge/common/IExtendedEntityProperties.java
@@ -30,6 +30,7 @@ public interface IExtendedEntityProperties {
      * Used to initialize the extended properties with the entity that this is attached to, as well
      * as the world object.
      * Called automatically if you register with the EntityConstructing event.
+     * May be called multiple times if the extended properties is moved over to a new entity.
      * @param entity  The entity that this extended properties is attached to
      * @param world  The world in which the entity exists
      */


### PR DESCRIPTION
Currently, when a player leaves the end and respawns in the overworld, all extended properties on them are lost. This pull request attempts to fix that by moving over the extended properties from the old player entity to the new one, and calling init on them another time.

Respawning normally (after a death) is not affected. Extended entity properties are still lost, and you're supposed to use LivingDeathEvent and the persistent player NBT data to save data you want to keep.

Problems could arise depending on what mods do in the init function, if it gets called more than once. Since this would only happen when leaving the end, where it previously just lost all properties, I think that is acceptable.
