### PR TITLE
Changed toolClass Scope

### DIFF
--- a/patches/minecraft/net/minecraft/item/ItemTool.java.patch
+++ b/patches/minecraft/net/minecraft/item/ItemTool.java.patch
@@ -40,7 +40,7 @@
      }
 +
 +    /*===================================== FORGE START =================================*/
-+    private String toolClass;
++    protected String toolClass;
 +    @Override
 +    public int getHarvestLevel(ItemStack stack, String toolClass)
 +    {


### PR DESCRIPTION
I am in need of creating new tool classes and assigning multiple tool classes to a custom tool, and since no one could find me a solution for using it in the Forge forums, I decided to see if you would allow changing the scope so that I may use the toolClass field. If not, I would like to know how I could do what I've listed above without my edit.
