### PR TITLE
Fix infinite loop in RecipeSorter

### DIFF
--- a/src/main/java/net/minecraftforge/oredict/RecipeSorter.java
+++ b/src/main/java/net/minecraftforge/oredict/RecipeSorter.java
@@ -174,9 +174,9 @@ public class RecipeSorter implements Comparator<IRecipe>
 
         if (ret == null)
         {
-            cls = cls.getSuperclass();
             while (cls != Object.class)
             {
+                cls = cls.getSuperclass();
                 ret = categories.get(cls);
                 if (ret != null)
                 {


### PR DESCRIPTION
If recipe is multiple levels of inheritance from Object and not categorized, cls=cls.getSuperclass(); needs to be repeated more than once. It must therefore be moved to inside the while loop.
