### PR TITLE
Fix values without decimal points in WavefrontObject

### DIFF
--- a/src/main/java/net/minecraftforge/client/model/obj/WavefrontObject.java
+++ b/src/main/java/net/minecraftforge/client/model/obj/WavefrontObject.java
@@ -26,9 +26,9 @@ import cpw.mods.fml.relauncher.SideOnly;
  */
 public class WavefrontObject implements IModelCustom
 {
-    private static Pattern vertexPattern = Pattern.compile("(v( (\\-){0,1}\\d+(\\.)?\\d+){3,4} *\\n)|(v( (\\-){0,1}\\d+(\\.)?\\d+){3,4} *$)");
-    private static Pattern vertexNormalPattern = Pattern.compile("(vn( (\\-){0,1}\\d+(\\.)?\\d+){3,4} *\\n)|(vn( (\\-){0,1}\\d+(\\.)?\\d+){3,4} *$)");
-    private static Pattern textureCoordinatePattern = Pattern.compile("(vt( (\\-){0,1}\\d+(\\.)?\\d+){2,3} *\\n)|(vt( (\\-){0,1}\\d+(\\.)?\\d+){2,3} *$)");
+    private static Pattern vertexPattern = Pattern.compile("(v( (\\-){0,1}\\d+(\\.\\d+)?){3,4} *\\n)|(v( (\\-){0,1}\\d+(\\.\\d+)?){3,4} *$)");
+    private static Pattern vertexNormalPattern = Pattern.compile("(vn( (\\-){0,1}\\d+(\\.\\d+)?){3,4} *\\n)|(vn( (\\-){0,1}\\d+(\\.\\d+)?){3,4} *$)");
+    private static Pattern textureCoordinatePattern = Pattern.compile("(vt( (\\-){0,1}\\d+(\\.\\d+)?){2,3} *\\n)|(vt( (\\-){0,1}\\d+(\\.\\d+)?){2,3} *$)");
     private static Pattern face_V_VT_VN_Pattern = Pattern.compile("(f( \\d+/\\d+/\\d+){3,4} *\\n)|(f( \\d+/\\d+/\\d+){3,4} *$)");
     private static Pattern face_V_VT_Pattern = Pattern.compile("(f( \\d+/\\d+){3,4} *\\n)|(f( \\d+/\\d+){3,4} *$)");
     private static Pattern face_V_VN_Pattern = Pattern.compile("(f( \\d+//\\d+){3,4} *\\n)|(f( \\d+//\\d+){3,4} *$)");


### PR DESCRIPTION
I spent an afternoon trying to find out why forge would report an 'Incorrect Format' error on my OBJ model. Upon further inspection, this piece of regex is severely bugged.

It looks for values of the form x.y as a Float to parseFloat. parseFloat() can handle values like "13" just as well as it can handle "13.51", so I don't think this was intentional.

The change is very simple, I grouped the decimal point matching into a subexpression, then used the 'zero or one times' modifier.

Apparently Blender always appends a '.0' to values that are integers, but other programs, notably Cinema4D, do not.
