### PR TITLE
Flexible Rail return value was inverted between 1.6 and 1.7

### DIFF
--- a/patches/minecraft/net/minecraft/block/BlockRailBase.java.patch
+++ b/patches/minecraft/net/minecraft/block/BlockRailBase.java.patch
@@ -42,7 +42,7 @@
 +     */
 +    public boolean isFlexibleRail(IBlockAccess world, int y, int x, int z)
 +    {
-+        return func_150050_e();
++        return !func_150050_e();
 +    }
 +
 +    /**
@@ -165,7 +165,7 @@
 -
 +            BlockRailBase block = (BlockRailBase)p_i45388_2_.func_147439_a(p_i45388_3_, p_i45388_4_, p_i45388_5_);
 +            int l = block.getBasicRailMetadata(p_i45388_2_, null, p_i45388_3_, p_i45388_4_, p_i45388_5_);
-+            this.field_150656_f = block.isFlexibleRail(p_i45388_2_, p_i45388_3_, p_i45388_4_, p_i45388_5_);
++            this.field_150656_f = !block.isFlexibleRail(p_i45388_2_, p_i45388_3_, p_i45388_4_, p_i45388_5_);
 +            canMakeSlopes = block.canMakeSlopes(p_i45388_2_, p_i45388_3_, p_i45388_4_, p_i45388_5_);
              this.func_150648_a(l);
          }


### PR DESCRIPTION
Between 1.6 and 1.7 the return value to BlockRailBase.isFlexibleRail()
was inverted. While this is not a huge deal and could be worked around
by simply inverting your return value, it does mean its no longer
consistent with the function name and javadocs.
