### PR TITLE
ReplaceBiomeBlocks Event changes

### DIFF
--- a/patches/minecraft/net/minecraft/world/gen/ChunkProviderGenerate.java.patch
+++ b/patches/minecraft/net/minecraft/world/gen/ChunkProviderGenerate.java.patch
@@ -50,7 +50,7 @@
  
      public void func_147422_a(int p_147422_1_, int p_147422_2_, Block[] p_147422_3_, byte[] p_147422_4_, BiomeGenBase[] p_147422_5_)
      {
-+        ChunkProviderEvent.ReplaceBiomeBlocks event = new ChunkProviderEvent.ReplaceBiomeBlocks(this, p_147422_1_, p_147422_2_, p_147422_3_, p_147422_5_);
++        ChunkProviderEvent.ReplaceBiomeBlocks event = new ChunkProviderEvent.ReplaceBiomeBlocks(this, p_147422_1_, p_147422_2_, p_147422_3_, p_147422_4_, p_147422_5_);
 +        MinecraftForge.EVENT_BUS.post(event);
 +        if (event.getResult() == Result.DENY) return;
 +

--- a/src/main/java/net/minecraftforge/event/terraingen/ChunkProviderEvent.java
+++ b/src/main/java/net/minecraftforge/event/terraingen/ChunkProviderEvent.java
@@ -27,6 +27,7 @@ public class ChunkProviderEvent extends Event
         public final int chunkX;
         public final int chunkZ;
         public final Block[] blockArray;
+        public final byte[] metaArray;
         public final BiomeGenBase[] biomeArray;
         
         public ReplaceBiomeBlocks(IChunkProvider chunkProvider, int chunkX, int chunkZ, Block[] blockArray, BiomeGenBase[] biomeArray)
@@ -36,6 +37,17 @@ public class ChunkProviderEvent extends Event
             this.chunkZ = chunkZ;
             this.blockArray = blockArray;
             this.biomeArray = biomeArray;
+            metaArray = new byte[256];
+        }
+        
+        public ReplaceBiomeBlocks(IChunkProvider chunkProvider, int chunkX, int chunkZ, Block[] blockArray, byte[] metaArray, BiomeGenBase[] biomeArray)
+        {
+            super(chunkProvider);
+            this.chunkX = chunkX;
+            this.chunkZ = chunkZ;
+            this.blockArray = blockArray;
+            this.biomeArray = biomeArray;
+            this.metaArray = metaArray;
         }
        
     }


### PR DESCRIPTION
Adds a new ReplaceBiomeBlocks Event constructor that supplies the metadata array if applicable and updates the ChunkProviderGenerate class to pass in the metadata array.
