### PR TITLE
Added vanilla metals to the OreDictionary

### DIFF
--- a/src/main/java/net/minecraftforge/oredict/OreDictionary.java
+++ b/src/main/java/net/minecraftforge/oredict/OreDictionary.java
@@ -65,6 +65,9 @@ public class OreDictionary
             registerOre("oreCoal",     Blocks.coal_ore);
             registerOre("gemDiamond",  Items.diamond);
             registerOre("gemEmerald",  Items.emerald);
+            registerOre("ingotIron",   Items.iron_ingot);
+            registerOre("ingotGold",   Items.gold_ingot);
+            registerOre("nuggetGold",  Items.gold_nugget);
             registerOre("dustRedstone",  Items.redstone);
             registerOre("dustGlowstone", Items.glowstone_dust);
             registerOre("glowstone",   Blocks.glowstone);
@@ -98,6 +101,9 @@ public class OreDictionary
         replacements.put(new ItemStack(Blocks.cobblestone, 1, WILDCARD_VALUE), "cobblestone");
         replacements.put(new ItemStack(Items.diamond), "gemDiamond");
         replacements.put(new ItemStack(Items.emerald), "gemEmerald");
+        replacements.put(new ItemStack(Items.iron_ingot), "ingotIron");
+        replacements.put(new ItemStack(Items.gold_ingot), "ingotGold");
+        replacements.put(new ItemStack(Items.gold_nugget), "nuggetGold");
         replacements.put(new ItemStack(Items.redstone), "dustRedstone");
         replacements.put(new ItemStack(Items.glowstone_dust), "dustGlowstone");
         replacements.put(new ItemStack(Blocks.glowstone), "glowstone");


### PR DESCRIPTION
Registers the iron ingot as ingotIron, gold nugget as nuggetGold and gold ingot as ingotGold. Several mods (e.g. Tinkers' Construct) need to add these, it is cleaner if it forge does so itself.
