### PR TITLE
Don't render ItemStack tooltip twice

### DIFF
--- a/patches/minecraft/net/minecraft/client/gui/GuiScreen.java.patch
+++ b/patches/minecraft/net/minecraft/client/gui/GuiScreen.java.patch
@@ -11,12 +11,12 @@
  import org.lwjgl.input.Keyboard;
  import org.lwjgl.input.Mouse;
  import org.lwjgl.opengl.GL11;
-@@ -111,7 +115,9 @@
+@@ -111,7 +115,8 @@
              }
          }
  
 +        FontRenderer font = p_146285_1_.func_77973_b().getFontRenderer(p_146285_1_);
-         this.func_146283_a(list, p_146285_2_, p_146285_3_);
+-        this.func_146283_a(list, p_146285_2_, p_146285_3_);
 +        drawHoveringText(list, p_146285_2_, p_146285_3_, (font == null ? field_146289_q : font));
      }
  


### PR DESCRIPTION
When using a custom FontRenderer for items, it renders the tooltip with the default FontRenderer first and then renders it with the custom FontRenderer. This also causes every vanilla tooltip to be rendered twice, breaking the transparency effect of the hovering frame.
