### PR TITLE
Added a potion id version of getActivePotionEffect

### DIFF
--- a/patches/minecraft/net/minecraft/entity/EntityLivingBase.java.patch
+++ b/patches/minecraft/net/minecraft/entity/EntityLivingBase.java.patch
@@ -195,6 +195,13 @@
 +        }
 +    }
 +
++   /**
++    * returns the PotionEffect for the supplied Potion if it is active, null otherwise.
++    */
++    public PotionEffect getActivePotionEffect(int potionId) {
++       return (PotionEffect)this.field_70713_bf.get(Integer.valueOf(potionId));
++    }
++
 +    /**
 +     * Returns true if the entity's rider (EntityPlayer) should face forward when mounted.
 +     * currently only used in vanilla code by pigs.


### PR DESCRIPTION
(This should help with during for loops, where ids would be easier)
