### PR TITLE
Added a getter for the activePotionMap

### DIFF
--- a/patches/minecraft/net/minecraft/entity/EntityLivingBase.java.patch
+++ b/patches/minecraft/net/minecraft/entity/EntityLivingBase.java.patch
@@ -195,12 +195,9 @@
 +        }
 +    }
 +
-+   /**
-+    * returns the PotionEffect for the supplied Potion if it is active, null otherwise.
-+    */
-+    public PotionEffect getActivePotionEffect(int potionId) {
-+       return (PotionEffect)this.field_70713_bf.get(Integer.valueOf(potionId));
-+    }
++     public HashMap getPotionMap() {
++       return this.field_70713_bf;
++     }
 +
 +    /**
 +     * Returns true if the entity's rider (EntityPlayer) should face forward when mounted.


### PR DESCRIPTION
Ignore the "Added a potion id version of getActivePotionEffect." I couldn't find a way to revert my repo.
