### PR TITLE
Fixed setBlock not using the location version of getLightOpacity()

### DIFF
--- a/patches/minecraft/net/minecraft/world/chunk/Chunk.java.patch
+++ b/patches/minecraft/net/minecraft/world/chunk/Chunk.java.patch
@@ -31,7 +31,16 @@
      }
  
      public Block func_150810_a(final int p_150810_1_, final int p_150810_2_, final int p_150810_3_)
-@@ -585,14 +591,19 @@
+@@ -578,6 +584,8 @@
+ 
+             int l1 = this.field_76635_g * 16 + p_150807_1_;
+             int i2 = this.field_76647_h * 16 + p_150807_3_;
++            
++            int k2 = block1.getLightOpacity(this.field_76637_e, l1, p_150807_2_, i2);
+ 
+             if (!this.field_76637_e.field_72995_K)
+             {
+@@ -585,14 +593,19 @@
              }
  
              extendedblockstorage.func_150818_a(p_150807_1_, p_150807_2_ & 15, p_150807_3_, p_150807_4_);
@@ -53,7 +62,7 @@
              }
  
              if (extendedblockstorage.func_150819_a(p_150807_1_, p_150807_2_ & 15, p_150807_3_) != p_150807_4_)
-@@ -601,8 +612,6 @@
+@@ -601,16 +614,13 @@
              }
              else
              {
@@ -62,7 +71,16 @@
                  if (flag)
                  {
                      this.func_76603_b();
-@@ -632,34 +641,19 @@
+                 }
+                 else
+                 {
+-                    int j2 = p_150807_4_.func_149717_k();
+-                    int k2 = block1.func_149717_k();
++                    int j2 = p_150807_4_.getLightOpacity(this.field_76637_e, l1, p_150807_2_, i2);
+ 
+                     if (j2 > 0)
+                     {
+@@ -632,34 +642,19 @@
  
                  TileEntity tileentity;
  
@@ -99,7 +117,7 @@
                      }
                  }
  
-@@ -690,7 +684,7 @@
+@@ -690,7 +685,7 @@
                  this.field_76643_l = true;
                  extendedblockstorage.func_76654_b(p_76589_1_, p_76589_2_ & 15, p_76589_3_, p_76589_4_);
  
@@ -108,7 +126,7 @@
                  {
                      TileEntity tileentity = this.func_150806_e(p_76589_1_, p_76589_2_, p_76589_3_);
  
-@@ -790,6 +784,7 @@
+@@ -790,6 +785,7 @@
              k = this.field_76645_j.length - 1;
          }
  
@@ -116,7 +134,7 @@
          p_76612_1_.field_70175_ag = true;
          p_76612_1_.field_70176_ah = this.field_76635_g;
          p_76612_1_.field_70162_ai = k;
-@@ -827,28 +822,27 @@
+@@ -827,28 +823,27 @@
          ChunkPosition chunkposition = new ChunkPosition(p_150806_1_, p_150806_2_, p_150806_3_);
          TileEntity tileentity = (TileEntity)this.field_150816_i.get(chunkposition);
  
@@ -155,7 +173,7 @@
      }
  
      public void func_150813_a(TileEntity p_150813_1_)
-@@ -860,7 +854,7 @@
+@@ -860,7 +855,7 @@
  
          if (this.field_76636_d)
          {
@@ -164,7 +182,7 @@
          }
      }
  
-@@ -872,7 +866,8 @@
+@@ -872,7 +867,8 @@
          p_150812_4_.field_145848_d = p_150812_2_;
          p_150812_4_.field_145849_e = this.field_76647_h * 16 + p_150812_3_;
  
@@ -174,7 +192,7 @@
          {
              if (this.field_150816_i.containsKey(chunkposition))
              {
-@@ -916,6 +911,7 @@
+@@ -916,6 +912,7 @@
  
              this.field_76637_e.func_72868_a(this.field_76645_j[i]);
          }
@@ -182,7 +200,7 @@
      }
  
      public void func_76623_d()
-@@ -933,6 +929,7 @@
+@@ -933,6 +930,7 @@
          {
              this.field_76637_e.func_72828_b(this.field_76645_j[i]);
          }
@@ -190,7 +208,7 @@
      }
  
      public void func_76630_e()
-@@ -942,8 +939,8 @@
+@@ -942,8 +940,8 @@
  
      public void func_76588_a(Entity p_76588_1_, AxisAlignedBB p_76588_2_, List p_76588_3_, IEntitySelector p_76588_4_)
      {
@@ -201,7 +219,7 @@
          i = MathHelper.func_76125_a(i, 0, this.field_76645_j.length - 1);
          j = MathHelper.func_76125_a(j, 0, this.field_76645_j.length - 1);
  
-@@ -979,8 +976,8 @@
+@@ -979,8 +977,8 @@
  
      public void func_76618_a(Class p_76618_1_, AxisAlignedBB p_76618_2_, List p_76618_3_, IEntitySelector p_76618_4_)
      {
@@ -212,7 +230,7 @@
          i = MathHelper.func_76125_a(i, 0, this.field_76645_j.length - 1);
          j = MathHelper.func_76125_a(j, 0, this.field_76645_j.length - 1);
  
-@@ -1139,6 +1136,15 @@
+@@ -1139,6 +1137,15 @@
      @SideOnly(Side.CLIENT)
      public void func_76607_a(byte[] p_76607_1_, int p_76607_2_, int p_76607_3_, boolean p_76607_4_)
      {
@@ -228,7 +246,7 @@
          int k = 0;
          boolean flag1 = !this.field_76637_e.field_73011_w.field_76576_e;
          int l;
-@@ -1241,13 +1247,27 @@
+@@ -1241,13 +1248,27 @@
          this.field_150814_l = true;
          this.field_76646_k = true;
          this.func_76590_a();
@@ -257,7 +275,7 @@
      }
  
      public BiomeGenBase func_76591_a(int p_76591_1_, int p_76591_2_, WorldChunkManager p_76591_3_)
-@@ -1450,4 +1470,48 @@
+@@ -1450,4 +1471,48 @@
  
          return true;
      }


### PR DESCRIPTION
This is my first attempt at moding forge and writing a pull request so please forgive me if I've made some stupid mistake.

Anyway currently the setBlock (func_150807_a) method in Chunk uses the simple block.getLightOpacity() to decide whether to update lighting, rather than getLightOpacity(world,x,y,z).

This pull request replaces them with the location version and also moves the call for the block being removed so that it occurs before the block is removed.
