### PR TITLE
Provided ability to maintain persistence with IExtendedEntityProperties.

### DIFF
--- a/patches/minecraft/net/minecraft/entity/player/EntityPlayer.java.patch
+++ b/patches/minecraft/net/minecraft/entity/player/EntityPlayer.java.patch
@@ -509,9 +509,12 @@
          }
          else if (this.field_70170_p.func_82736_K().func_82766_b("keepInventory"))
          {
-@@ -1876,6 +2024,17 @@
+@@ -1874,8 +2022,34 @@
+             this.field_71106_cc = p_71049_1_.field_71106_cc;
+             this.func_85040_s(p_71049_1_.func_71037_bA());
          }
- 
+-
++        
          this.field_71078_a = p_71049_1_.field_71078_a;
 +
 +        this.spawnChunkMap = p_71049_1_.spawnChunkMap;
@@ -524,10 +527,25 @@
 +        {
 +            getEntityData().func_74782_a(PERSISTED_NBT_TAG, old.func_74775_l(PERSISTED_NBT_TAG));
 +        }
++        
++        //Copy and re-init persistent ExtendedProperties when respawning.
++        //Allows mods to maintain persistent data via Extended Properties files.
++        if(!p_71049_2_)
++        {
++            for(String key : p_71049_1_.extendedProperties.keySet())
++            {
++                net.minecraftforge.common.IExtendedEntityProperties p = p_71049_1_.extendedProperties.get(key);
++                if(p.isDataPersistent())
++                {
++                    this.extendedProperties.put(key, p);
++                    p.init(this, field_70170_p);
++                }
++            }
++        }
      }
  
      protected boolean func_70041_e_()
-@@ -1914,7 +2073,14 @@
+@@ -1914,7 +2088,14 @@
  
      public void func_70062_b(int p_70062_1_, ItemStack p_70062_2_)
      {
@@ -543,7 +561,7 @@
      }
  
      @SideOnly(Side.CLIENT)
-@@ -1959,7 +2125,7 @@
+@@ -1959,7 +2140,7 @@
  
      public IChatComponent func_145748_c_()
      {
@@ -552,7 +570,7 @@
          chatcomponenttext.func_150256_b().func_150241_a(new ClickEvent(ClickEvent.Action.SUGGEST_COMMAND, "/msg " + this.func_70005_c_() + " "));
          return chatcomponenttext;
      }
-@@ -2042,6 +2208,118 @@
+@@ -2042,6 +2223,118 @@
          FMLNetworkHandler.openGui(this, mod, modGuiId, world, x, y, z);
      }
  

--- a/src/main/java/net/minecraftforge/common/IExtendedEntityProperties.java
+++ b/src/main/java/net/minecraftforge/common/IExtendedEntityProperties.java
@@ -36,4 +36,10 @@ public interface IExtendedEntityProperties {
      * @param world  The world in which the entity exists
      */
     public void init(Entity entity, World world);
+
+    /**
+     * Used in the re-initialization of the Entity after death.
+     * @return If the data contained by this object should remain persistent for the entity.
+     */
+    public boolean isDataPersistent();
 }


### PR DESCRIPTION
While mod authors are already able to maintain persistence using getEntityData() and the PERSISTED_NBT_TAG, there are some instances in which it seems a persistent extended properties file would be better. I realize that, if considered at all, this request would be better suited for a Minecraft Version update due to the addition of the isDataPersistent() method to the IExtendedEntityProperties interface and the many issues that could arise with current modifications which utilize this interface.
