### PR TITLE
Fix getOreIDs not using the wildcard value correctly

### DIFF
--- a/src/main/java/net/minecraftforge/oredict/OreDictionary.java
+++ b/src/main/java/net/minecraftforge/oredict/OreDictionary.java
@@ -319,7 +319,7 @@ public class OreDictionary
         {
             for(ItemStack target : ore.getValue())
             {
-                if (itemMatches(itemStack, target, false))
+                if (itemMatches(target, itemStack, false))
                 {
                     ids.add(ore.getKey());
                 }


### PR DESCRIPTION
You can see it's not working by requesting the ore IDs from lapis, and you'll see the name "dye" is missing (and that's the one registered using the wildcard).

Fixed it by inverting the order of the item stack parameters.
