### PR TITLE
Add event for text-field focusing.

### DIFF
--- a/patches/minecraft/net/minecraft/client/gui/GuiTextField.java.patch
+++ b/patches/minecraft/net/minecraft/client/gui/GuiTextField.java.patch
@@ -1,0 +1,21 @@
+--- ../src-base/minecraft/net/minecraft/client/gui/GuiTextField.java
++++ ../src-work/minecraft/net/minecraft/client/gui/GuiTextField.java
+@@ -4,6 +4,8 @@
+ import cpw.mods.fml.relauncher.SideOnly;
+ import net.minecraft.client.renderer.Tessellator;
+ import net.minecraft.util.ChatAllowedCharacters;
++import net.minecraftforge.client.event.TextFieldFocusEvent;
++import net.minecraftforge.common.MinecraftForge;
+ import org.lwjgl.opengl.GL11;
+ 
+ @SideOnly(Side.CLIENT)
+@@ -572,6 +574,9 @@
+         }
+ 
+         this.field_146213_o = p_146195_1_;
++
++        TextFieldFocusEvent event = new TextFieldFocusEvent(this);
++        MinecraftForge.EVENT_BUS.post(event);
+     }
+ 
+     public boolean func_146206_l()

--- a/src/main/java/net/minecraftforge/client/event/TextFieldFocusEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/TextFieldFocusEvent.java
@@ -1,0 +1,15 @@
+package net.minecraftforge.client.event;
+
+import cpw.mods.fml.common.eventhandler.Event;
+import net.minecraft.client.gui.GuiTextField;
+
+/**
+ * This event is called when the focused state of a GuiTextField changes.
+ *
+ * @author Kobata
+ */
+public class TextFieldFocusEvent extends Event
+{
+    public GuiTextField gui;
+    public TextFieldFocusEvent(GuiTextField gui) { this.gui = gui; }
+}


### PR DESCRIPTION
This is a fairly simple event, the main purpose of it is to allow mods that have 'global'
hotkeys to disable them when a text field is active so they don't fire off accidentally.
