### PR TITLE
Added FluidMixingEvent

### DIFF
--- a/src/main/java/net/minecraftforge/fluids/FluidEvent.java
+++ b/src/main/java/net/minecraftforge/fluids/FluidEvent.java
@@ -1,6 +1,8 @@
 
 package net.minecraftforge.fluids;
 
+import cpw.mods.fml.common.eventhandler.Cancelable;
+import cpw.mods.fml.common.eventhandler.Event;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.World;
 import net.minecraftforge.common.MinecraftForge;
@@ -103,6 +105,24 @@ public class FluidEvent extends Event
     }
 
     /**
+     * Mods should fire this event when two different fluids are being {@link IFluidTank#fill(FluidStack, boolean)}
+     * or {@link IFluidHandler#drain(ForgeDirection, FluidStack, boolean)}.
+     * {@link FluidTank} and {@link TileFluidHandler} does this.
+     *
+     */
+    @Cancelable
+    public static class TankMixingEvent extends FluidEvent
+    {
+        public final IFluidTank tank;
+
+        public TankMixingEvent(FluidStack source, World world, int x, int y, int z, IFluidTank tank)
+        {
+            super(source, world, x, y, z);
+            this.tank = tank;
+        }
+    }
+
+    /**
      * Mods should fire this event when a fluid "spills", for example, if a block containing fluid
      * is broken.
      *
@@ -120,8 +140,8 @@ public class FluidEvent extends Event
      *
      * @param event
      */
-    public static final void fireEvent(FluidEvent event)
+    public static final boolean fireEvent(FluidEvent event)
     {
-        MinecraftForge.EVENT_BUS.post(event);
+        return MinecraftForge.EVENT_BUS.post(event);
     }
 }

--- a/src/main/java/net/minecraftforge/fluids/FluidTank.java
+++ b/src/main/java/net/minecraftforge/fluids/FluidTank.java
@@ -150,7 +150,10 @@ public class FluidTank implements IFluidTank, IFluidHandler
 
             if (!fluid.isFluidEqual(resource))
             {
-                return 0;
+                if(!canLiquidsMix(resource))
+                {
+                    return 0;
+                }
             }
 
             return Math.min(capacity - fluid.amount, resource.amount);
@@ -171,7 +174,10 @@ public class FluidTank implements IFluidTank, IFluidHandler
 
         if (!fluid.isFluidEqual(resource))
         {
-            return 0;
+            if(!canLiquidsMix(resource))
+            {
+                return 0;
+            }
         }
         int filled = capacity - fluid.amount;
 
@@ -192,6 +198,11 @@ public class FluidTank implements IFluidTank, IFluidHandler
             FluidEvent.fireEvent(new FluidEvent.FluidFillingEvent(fluid, tile.getWorld(), tile.getPos(), this, filled));
         }
         return filled;
+    }
+
+    private boolean canLiquidsMix(FluidStack resource)
+    {
+        return FluidEvent.fireEvent(new FluidEvent.TankMixingEvent(resource, tile.getWorldObj(), tile.xCoord, tile.yCoord, tile.zCoord, this));
     }
 
     @Override

--- a/src/main/java/net/minecraftforge/fluids/TileFluidHandler.java
+++ b/src/main/java/net/minecraftforge/fluids/TileFluidHandler.java
@@ -44,9 +44,16 @@ public class TileFluidHandler extends TileEntity implements IFluidHandler
     @Override
     public FluidStack drain(EnumFacing from, FluidStack resource, boolean doDrain)
     {
-        if (resource == null || !resource.isFluidEqual(tank.getFluid()))
+        if (resource == null)
         {
             return null;
+        }
+        if(!resource.isFluidEqual(tank.getFluid()))
+        {
+            if(!FluidEvent.fireEvent(new FluidEvent.TankMixingEvent(resource, getWorldObj(), xCoord, yCoord, zCoord, tank)))
+            {
+                return null;
+            }
         }
         return tank.drain(resource.amount, doDrain);
     }


### PR DESCRIPTION
This is a Event that I created for #1090.
I tried to fix the problems that I presented in the issue.

New pull request because I derped the last one...



I am currently creating FluidMixingEvent for Fluid API. This would be send whenever two different fluids are tried to combine.

With this event you could create custom interactions between liquids in machinery. My motivation for this event is to enable of usage of NBT data in FluidStack for functionality instead of it just describing a new liquid.

The problems that I am facing currently:
* I am extending FluidEvent which expects one FluidStack in its constructor, but FluidMixingEvent would need to have to 2 of them. One for source and one for target... Except filling/draining fluid events actually don't need their FluidStack as you can get it from the ITank. This is why I am not sure what to give in the super call. Also should I edit those other FluidEvents?
* First I thought that equality of fluids for denying different fluids mixing was only called in FluidTanks fill method, but I noticed that also TileFluidHandlers drain method with FluidStack parameter does it too. Should I be changing both of those and how should I let people know it in Javadoc?