### PR TITLE
Remove duplicate AT entry

### DIFF
--- a/src/main/resources/forge_at.cfg
+++ b/src/main/resources/forge_at.cfg
@@ -165,8 +165,6 @@ public net.minecraft.network.play.server.S23PacketBlockChange field_148884_e # M
 public-f net.minecraft.world.WorldType field_77139_a #worldTypes
 # DamageSource
 public net.minecraft.util.DamageSource *() #All methods public, most are already
-# ItemBlock
-public net.minecraft.item.ItemBlock field_150939_a # block
 # EntityAITasks 
 public net.minecraft.entity.ai.EntityAITasks field_75782_a # taskEntries
 # EntityXPOrb


### PR DESCRIPTION
This entry is already added in FML (https://github.com/MinecraftForge/FML/blob/master/src/main/resources/fml_at.cfg#L78), and causes the "Merging access map" message while decompiling/deobfuscating.

Not that big of a problem, but it does remove that message.
