### PR TITLE
Add PlayerEvent.StartTracking and .StopTracking

### DIFF
--- a/patches/minecraft/net/minecraft/entity/EntityTracker.java.patch
+++ b/patches/minecraft/net/minecraft/entity/EntityTracker.java.patch
@@ -1,0 +1,26 @@
+--- ../src-base/minecraft/net/minecraft/entity/EntityTracker.java
++++ ../src-work/minecraft/net/minecraft/entity/EntityTracker.java
+@@ -337,4 +337,23 @@
+             }
+         }
+     }
++    
++    /* ======================================== FORGE START =====================================*/
++    
++    // don't expose the EntityTrackerEntry directly so mods can't mess with the data in there as easily
++    /**
++     * Get all players tracking the given Entity. The Entity must be part of the World that this Tracker belongs to.
++     * @param entity the Entity
++     * @return all players tracking the Entity
++     */
++    public Set<net.minecraft.entity.player.EntityPlayer> getTrackingPlayers(Entity entity)
++    {
++        EntityTrackerEntry entry = (EntityTrackerEntry) field_72794_c.func_76041_a(entity.func_145782_y());
++        if (entry == null)
++            return java.util.Collections.emptySet();
++        else
++            return java.util.Collections.unmodifiableSet(entry.field_73134_o);
++    }
++    
++    /* ======================================== FORGE END   =====================================*/
+ }

--- a/patches/minecraft/net/minecraft/entity/EntityTrackerEntry.java.patch
+++ b/patches/minecraft/net/minecraft/entity/EntityTrackerEntry.java.patch
@@ -1,0 +1,17 @@
+--- ../src-base/minecraft/net/minecraft/entity/EntityTrackerEntry.java
++++ ../src-work/minecraft/net/minecraft/entity/EntityTrackerEntry.java
+@@ -436,12 +436,14 @@
+                             p_73117_1_.field_71135_a.func_147359_a(new S1DPacketEntityEffect(this.field_73132_a.func_145782_y(), potioneffect));
+                         }
+                     }
++                    net.minecraftforge.event.ForgeEventFactory.onStartEntityTracking(field_73132_a, p_73117_1_);
+                 }
+             }
+             else if (this.field_73134_o.contains(p_73117_1_))
+             {
+                 this.field_73134_o.remove(p_73117_1_);
+                 p_73117_1_.field_71130_g.add(Integer.valueOf(this.field_73132_a.func_145782_y()));
++                net.minecraftforge.event.ForgeEventFactory.onStopEntityTracking(field_73132_a, p_73117_1_);
+             }
+         }
+     }

--- a/src/main/java/net/minecraftforge/event/ForgeEventFactory.java
+++ b/src/main/java/net/minecraftforge/event/ForgeEventFactory.java
@@ -155,4 +155,14 @@ public class ForgeEventFactory
         MinecraftForge.EVENT_BUS.post(event);
         return event.result;
     }
+    
+    public static void onStartEntityTracking(Entity entity, EntityPlayer player)
+    {
+        MinecraftForge.EVENT_BUS.post(new PlayerEvent.StartTracking(player, entity));
+    }
+    
+    public static void onStopEntityTracking(Entity entity, EntityPlayer player)
+    {
+        MinecraftForge.EVENT_BUS.post(new PlayerEvent.StopTracking(player, entity));
+    }
 }

--- a/src/main/java/net/minecraftforge/event/entity/player/PlayerEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/player/PlayerEvent.java
@@ -2,6 +2,7 @@ package net.minecraftforge.event.entity.player;
 
 import cpw.mods.fml.common.eventhandler.Cancelable;
 import net.minecraft.block.Block;
+import net.minecraft.entity.Entity;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraftforge.event.entity.living.LivingEvent;
 
@@ -91,5 +92,43 @@ public class PlayerEvent extends LivingEvent
             this.original = oldPlayer;
             this.wasDeath = wasDeath;
         }
+    }
+    
+    /**
+     * Fired when an Entity is started to be "tracked" by this player (the player receives updates about this entity, e.g. motion).
+     *
+     */
+    public static class StartTracking extends PlayerEvent {
+        
+        /**
+         * The Entity now being tracked.
+         */
+        public final Entity target;
+        
+        public StartTracking(EntityPlayer player, Entity target)
+        {
+            super(player);
+            this.target = target;
+        }
+        
+    }
+    
+    /**
+     * Fired when an Entity is stopped to be "tracked" by this player (the player no longer receives updates about this entity, e.g. motion).
+     *
+     */
+    public static class StopTracking extends PlayerEvent {
+        
+        /**
+         * The Entity no longer being tracked.
+         */
+        public final Entity target;
+        
+        public StopTracking(EntityPlayer player, Entity target)
+        {
+            super(player);
+            this.target = target;
+        }
+        
     }
 }


### PR DESCRIPTION
Allows for mods to Sync their data properly when using e.g. `IExtendedEntityProperties` by firing off an event when a player starts tracking an entity (receiving updates about e.g. motion).
Also makes `EntityTracker#trackedEntityIDs` public.
