### PR TITLE
Fire PlayerInteractEvent on client + more changes

### DIFF
--- a/patches/minecraft/net/minecraft/client/Minecraft.java.patch
+++ b/patches/minecraft/net/minecraft/client/Minecraft.java.patch
@@ -1,6 +1,6 @@
 --- ../src-base/minecraft/net/minecraft/client/Minecraft.java
 +++ ../src-work/minecraft/net/minecraft/client/Minecraft.java
-@@ -135,6 +135,14 @@
+@@ -134,6 +134,14 @@
  import net.minecraft.world.storage.ISaveFormat;
  import net.minecraft.world.storage.ISaveHandler;
  import net.minecraft.world.storage.WorldInfo;
@@ -15,7 +15,7 @@
  import org.apache.logging.log4j.LogManager;
  import org.apache.logging.log4j.Logger;
  import org.lwjgl.LWJGLException;
-@@ -246,7 +254,7 @@
+@@ -245,7 +253,7 @@
          this.func_71389_H();
          this.field_71449_j = p_i1014_1_;
          field_147123_G.info("Setting user: " + p_i1014_1_.func_111285_a());
@@ -72,16 +72,20 @@
          if (p_147108_1_ instanceof GuiMainMenu)
          {
              this.field_71474_y.field_74330_P = false;
-@@ -1297,7 +1311,7 @@
- 
-                     if (this.field_71439_g.func_82246_f(i, j, k))
-                     {
+@@ -1294,12 +1308,6 @@
+                 if (this.field_71441_e.func_147439_a(i, j, k).func_149688_o() != Material.field_151579_a)
+                 {
+                     this.field_71442_b.func_78759_c(i, j, k, this.field_71476_x.field_72310_e);
+-
+-                    if (this.field_71439_g.func_82246_f(i, j, k))
+-                    {
 -                        this.field_71452_i.func_78867_a(i, j, k, this.field_71476_x.field_72310_e);
-+                        this.field_71452_i.addBlockHitEffects(i, j, k, this.field_71476_x);
-                         this.field_71439_g.func_71038_i();
-                     }
+-                        this.field_71439_g.func_71038_i();
+-                    }
                  }
-@@ -1378,11 +1392,12 @@
+             }
+             else
+@@ -1378,16 +1386,19 @@
                      int j = this.field_71476_x.field_72312_c;
                      int k = this.field_71476_x.field_72309_d;
  
@@ -96,17 +100,24 @@
                          {
                              flag = false;
                              this.field_71439_g.func_71038_i();
-@@ -1409,7 +1424,8 @@
+                         }
+ 
++                        itemstack = this.field_71439_g.func_71045_bC();
++
+                         if (itemstack == null)
+                         {
+                             return;
+@@ -1409,7 +1420,8 @@
          {
              ItemStack itemstack1 = this.field_71439_g.field_71071_by.func_70448_g();
  
 -            if (itemstack1 != null && this.field_71442_b.func_78769_a(this.field_71439_g, this.field_71441_e, itemstack1))
 +            boolean result = !ForgeEventFactory.onPlayerInteract(field_71439_g, Action.RIGHT_CLICK_AIR, 0, 0, 0, -1, this.field_71441_e).isCanceled();
-+            if (result && itemstack1 != null && this.field_71442_b.func_78769_a(this.field_71439_g, this.field_71441_e, itemstack1))
++            if (this.field_71442_b.func_78769_a(this.field_71439_g, this.field_71441_e, itemstack1))
              {
                  this.field_71460_t.field_78516_c.func_78445_c();
              }
-@@ -1608,6 +1624,8 @@
+@@ -1608,6 +1620,8 @@
  
              while (Mouse.next())
              {
@@ -115,7 +126,7 @@
                  i = Mouse.getEventButton();
  
                  if (field_142025_a && i == 0 && (Keyboard.isKeyDown(29) || Keyboard.isKeyDown(157)))
-@@ -2081,6 +2099,11 @@
+@@ -2075,6 +2089,11 @@
  
      public void func_71353_a(WorldClient p_71353_1_, String p_71353_2_)
      {
@@ -127,7 +138,7 @@
          if (p_71353_1_ == null)
          {
              NetHandlerPlayClient nethandlerplayclient = this.func_147114_u();
-@@ -2093,6 +2116,18 @@
+@@ -2087,6 +2106,18 @@
              if (this.field_71437_Z != null)
              {
                  this.field_71437_Z.func_71263_m();
@@ -146,7 +157,7 @@
              }
  
              this.field_71437_Z = null;
-@@ -2241,113 +2276,10 @@
+@@ -2235,113 +2266,10 @@
          if (this.field_71476_x != null)
          {
              boolean flag = this.field_71439_g.field_71075_bZ.field_75098_d;
@@ -262,7 +273,7 @@
              if (flag)
              {
                  j = this.field_71439_g.field_71069_bz.field_75151_b.size() - 9 + this.field_71439_g.field_71071_by.field_70461_c;
-@@ -2514,8 +2446,15 @@
+@@ -2508,8 +2436,15 @@
          p_70001_1_.func_76472_a("gl_max_texture_size", Integer.valueOf(func_71369_N()));
      }
  
@@ -278,7 +289,7 @@
          for (int i = 16384; i > 0; i >>= 1)
          {
              GL11.glTexImage2D(GL11.GL_PROXY_TEXTURE_2D, 0, GL11.GL_RGBA, i, i, 0, GL11.GL_RGBA, GL11.GL_UNSIGNED_BYTE, (ByteBuffer)null);
-@@ -2523,6 +2462,7 @@
+@@ -2517,6 +2452,7 @@
  
              if (j != 0)
              {

--- a/patches/minecraft/net/minecraft/client/multiplayer/PlayerControllerMP.java.patch
+++ b/patches/minecraft/net/minecraft/client/multiplayer/PlayerControllerMP.java.patch
@@ -1,30 +1,37 @@
 --- ../src-base/minecraft/net/minecraft/client/multiplayer/PlayerControllerMP.java
 +++ ../src-work/minecraft/net/minecraft/client/multiplayer/PlayerControllerMP.java
-@@ -28,6 +28,10 @@
+@@ -1,5 +1,6 @@
+ package net.minecraft.client.multiplayer;
+ 
++import cpw.mods.fml.common.eventhandler.Event;
+ import cpw.mods.fml.relauncher.Side;
+ import cpw.mods.fml.relauncher.SideOnly;
+ import net.minecraft.block.Block;
+@@ -28,6 +29,13 @@
  import net.minecraft.world.World;
  import net.minecraft.world.WorldSettings;
  
 +import net.minecraftforge.common.ForgeHooks;
 +import net.minecraftforge.common.MinecraftForge;
++import net.minecraftforge.event.ForgeEventFactory;
 +import net.minecraftforge.event.entity.player.PlayerDestroyItemEvent;
++import net.minecraftforge.event.entity.player.PlayerInteractEvent;
++import net.minecraftforge.event.entity.player.PlayerInteractEvent.Action;
 +
  @SideOnly(Side.CLIENT)
  public class PlayerControllerMP
  {
-@@ -88,6 +92,12 @@
+@@ -88,7 +96,8 @@
  
      public boolean func_78751_a(int p_78751_1_, int p_78751_2_, int p_78751_3_, int p_78751_4_)
      {
+-        if (this.field_78779_k.func_82752_c() && !this.field_78776_a.field_71439_g.func_82246_f(p_78751_1_, p_78751_2_, p_78751_3_))
 +        ItemStack stack = field_78776_a.field_71439_g.func_71045_bC();
 +        if (stack != null && stack.func_77973_b() != null && stack.func_77973_b().onBlockStartBreak(stack, p_78751_1_, p_78751_2_, p_78751_3_, field_78776_a.field_71439_g))
-+        {
-+            return false;
-+        }
-+
-         if (this.field_78779_k.func_82752_c() && !this.field_78776_a.field_71439_g.func_82246_f(p_78751_1_, p_78751_2_, p_78751_3_))
          {
              return false;
-@@ -109,7 +119,7 @@
+         }
+@@ -109,15 +118,13 @@
              {
                  worldclient.func_72926_e(2001, p_78751_1_, p_78751_2_, p_78751_3_, Block.func_149682_b(block) + (worldclient.func_72805_g(p_78751_1_, p_78751_2_, p_78751_3_) << 12));
                  int i1 = worldclient.func_72805_g(p_78751_1_, p_78751_2_, p_78751_3_);
@@ -33,20 +40,148 @@
  
                  if (flag)
                  {
-@@ -304,11 +314,18 @@
+                     block.func_149664_b(worldclient, p_78751_1_, p_78751_2_, p_78751_3_, i1);
+                 }
+ 
+-                this.field_78772_d = -1;
+-
+                 if (!this.field_78779_k.func_77145_d())
+                 {
+                     ItemStack itemstack = this.field_78776_a.field_71439_g.func_71045_bC();
+@@ -140,40 +147,47 @@
+ 
+     public void func_78743_b(int p_78743_1_, int p_78743_2_, int p_78743_3_, int p_78743_4_)
+     {
+-        if (!this.field_78779_k.func_82752_c() || this.field_78776_a.field_71439_g.func_82246_f(p_78743_1_, p_78743_2_, p_78743_3_))
++        PlayerInteractEvent event = ForgeEventFactory.onPlayerInteract(this.field_78776_a.field_71439_g, Action.LEFT_CLICK_BLOCK, p_78743_1_, p_78743_2_, p_78743_3_, p_78743_4_, this.field_78776_a.field_71441_e);
++        boolean canBreak = !this.field_78779_k.func_82752_c() || this.field_78776_a.field_71439_g.func_82246_f(p_78743_1_, p_78743_2_, p_78743_3_);
++        canBreak = event.useItem == Event.Result.DEFAULT ? canBreak : event.useItem == Event.Result.ALLOW;
++
++        if (!event.isCanceled() && (!this.field_78778_j || !this.func_85182_a(p_78743_1_, p_78743_2_, p_78743_3_)))
+         {
+-            if (this.field_78779_k.func_77145_d())
++            if (this.field_78778_j)
+             {
+-                this.field_78774_b.func_147297_a(new C07PacketPlayerDigging(0, p_78743_1_, p_78743_2_, p_78743_3_, p_78743_4_));
+-                func_78744_a(this.field_78776_a, this, p_78743_1_, p_78743_2_, p_78743_3_, p_78743_4_);
+-                this.field_78781_i = 5;
++                this.field_78774_b.func_147297_a(new C07PacketPlayerDigging(1, this.field_78775_c, this.field_78772_d, this.field_78773_e, p_78743_4_));
+             }
+-            else if (!this.field_78778_j || !this.func_85182_a(p_78743_1_, p_78743_2_, p_78743_3_))
++
++            this.field_78774_b.func_147297_a(new C07PacketPlayerDigging(0, p_78743_1_, p_78743_2_, p_78743_3_, p_78743_4_));
++            Block block = this.field_78776_a.field_71441_e.func_147439_a(p_78743_1_, p_78743_2_, p_78743_3_);
++            boolean flag = block.func_149688_o() != Material.field_151579_a;
++
++            boolean breakInstantly = block.func_149737_a(this.field_78776_a.field_71439_g, this.field_78776_a.field_71439_g.field_70170_p, p_78743_1_, p_78743_2_, p_78743_3_) >= 1.0F;
++            breakInstantly = canBreak && (breakInstantly || this.field_78779_k.func_77145_d());
++
++            if (flag && !breakInstantly && this.field_78770_f == 0.0F && event.useBlock != Event.Result.DENY)
+             {
+-                if (this.field_78778_j)
+-                {
+-                    this.field_78774_b.func_147297_a(new C07PacketPlayerDigging(1, this.field_78775_c, this.field_78772_d, this.field_78773_e, p_78743_4_));
+-                }
++                block.func_149699_a(this.field_78776_a.field_71441_e, p_78743_1_, p_78743_2_, p_78743_3_, this.field_78776_a.field_71439_g);
++            }
+ 
+-                this.field_78774_b.func_147297_a(new C07PacketPlayerDigging(0, p_78743_1_, p_78743_2_, p_78743_3_, p_78743_4_));
+-                Block block = this.field_78776_a.field_71441_e.func_147439_a(p_78743_1_, p_78743_2_, p_78743_3_);
+-                boolean flag = block.func_149688_o() != Material.field_151579_a;
++            if (canBreak)
++            {
++                this.field_78775_c = p_78743_1_;
++                this.field_78772_d = p_78743_2_;
++                this.field_78773_e = p_78743_3_;
+ 
+-                if (flag && this.field_78770_f == 0.0F)
++                if (this.field_78779_k.func_77145_d())
+                 {
+-                    block.func_149699_a(this.field_78776_a.field_71441_e, p_78743_1_, p_78743_2_, p_78743_3_, this.field_78776_a.field_71439_g);
++                    func_78744_a(this.field_78776_a, this, p_78743_1_, p_78743_2_, p_78743_3_, p_78743_4_);
++                    this.field_78781_i = 5;
+                 }
+-
+-                if (flag && block.func_149737_a(this.field_78776_a.field_71439_g, this.field_78776_a.field_71439_g.field_70170_p, p_78743_1_, p_78743_2_, p_78743_3_) >= 1.0F)
++                else if (breakInstantly)
+                 {
+                     this.func_78751_a(p_78743_1_, p_78743_2_, p_78743_3_, p_78743_4_);
+                 }
+                 else
+                 {
+                     this.field_78778_j = true;
+-                    this.field_78775_c = p_78743_1_;
+-                    this.field_78772_d = p_78743_2_;
+-                    this.field_78773_e = p_78743_3_;
+                     this.field_85183_f = this.field_78776_a.field_71439_g.func_70694_bm();
+                     this.field_78770_f = 0.0F;
+                     this.field_78780_h = 0.0F;
+@@ -181,6 +195,12 @@
+                 }
+             }
+         }
++
++        if (!canBreak)
++        {
++            this.func_78767_c();
++            this.field_78772_d = -1;
++        }
+     }
+ 
+     public void func_78767_c()
+@@ -202,7 +222,12 @@
+         if (this.field_78781_i > 0)
+         {
+             --this.field_78781_i;
++            return;
+         }
++        else if (this.field_78772_d == -1)
++        {
++            return;
++        }
+         else if (this.field_78779_k.func_77145_d())
+         {
+             this.field_78781_i = 5;
+@@ -247,6 +272,9 @@
+                 this.func_78743_b(p_78759_1_, p_78759_2_, p_78759_3_, p_78759_4_);
+             }
+         }
++
++        this.field_78776_a.field_71452_i.addBlockHitEffects(p_78759_1_, p_78759_2_, p_78759_3_, this.field_78776_a.field_71476_x);
++        this.field_78776_a.field_71439_g.func_71038_i();
+     }
+ 
+     public float func_78757_d()
+@@ -298,17 +326,34 @@
+ 
+     public boolean func_78760_a(EntityPlayer p_78760_1_, World p_78760_2_, ItemStack p_78760_3_, int p_78760_4_, int p_78760_5_, int p_78760_6_, int p_78760_7_, Vec3 p_78760_8_)
+     {
++        PlayerInteractEvent event = ForgeEventFactory.onPlayerInteract(p_78760_1_, Action.RIGHT_CLICK_BLOCK, p_78760_4_, p_78760_5_, p_78760_6_, p_78760_7_, p_78760_2_);
++        if (event.isCanceled())
++        {
++            return false;
++        }
++
+         this.func_78750_j();
+         float f = (float)p_78760_8_.field_72450_a - (float)p_78760_4_;
+         float f1 = (float)p_78760_8_.field_72448_b - (float)p_78760_5_;
          float f2 = (float)p_78760_8_.field_72449_c - (float)p_78760_6_;
          boolean flag = false;
  
 -        if ((!p_78760_1_.func_70093_af() || p_78760_1_.func_70694_bm() == null) && p_78760_2_.func_147439_a(p_78760_4_, p_78760_5_, p_78760_6_).func_149727_a(p_78760_2_, p_78760_4_, p_78760_5_, p_78760_6_, p_78760_1_, p_78760_7_, f, f1, f2))
-+        if (p_78760_3_ != null &&
++        if (event.useItem != Event.Result.DENY &&
++            p_78760_3_ != null &&
 +            p_78760_3_.func_77973_b() != null &&
 +            p_78760_3_.func_77973_b().onItemUseFirst(p_78760_3_, p_78760_1_, p_78760_2_, p_78760_4_, p_78760_5_, p_78760_6_, p_78760_7_, f, f1, f2))
          {
 -            flag = true;
-+                return true;
++            if (p_78760_3_.field_77994_a <= 0) ForgeEventFactory.onPlayerDestroyItem(p_78760_1_, p_78760_3_);
++            return true;
          }
  
-+        if (!p_78760_1_.func_70093_af() || p_78760_1_.func_70694_bm() == null || p_78760_1_.func_70694_bm().func_77973_b().doesSneakBypassUse(p_78760_2_, p_78760_4_, p_78760_5_, p_78760_6_, p_78760_1_))
++        if (event.useBlock != Event.Result.DENY &&
++            !p_78760_1_.func_70093_af() || p_78760_1_.func_70694_bm() == null ||
++            p_78760_1_.func_70694_bm().func_77973_b().doesSneakBypassUse(p_78760_2_, p_78760_4_, p_78760_5_, p_78760_6_, p_78760_1_))
 +        {
 +            flag = p_78760_2_.func_147439_a(p_78760_4_, p_78760_5_, p_78760_6_).func_149727_a(p_78760_2_, p_78760_4_, p_78760_5_, p_78760_6_, p_78760_1_, p_78760_7_, f, f1, f2);
 +        }
@@ -54,7 +189,18 @@
          if (!flag && p_78760_3_ != null && p_78760_3_.func_77973_b() instanceof ItemBlock)
          {
              ItemBlock itemblock = (ItemBlock)p_78760_3_.func_77973_b();
-@@ -340,7 +357,15 @@
+@@ -329,6 +374,10 @@
+         {
+             return false;
+         }
++        else if (event.useItem == Event.Result.DENY)
++        {
++            return false;
++        }
+         else if (this.field_78779_k.func_77145_d())
+         {
+             int j1 = p_78760_3_.func_77960_j();
+@@ -340,14 +389,34 @@
          }
          else
          {
@@ -71,7 +217,26 @@
          }
      }
  
-@@ -359,9 +384,10 @@
+     public boolean func_78769_a(EntityPlayer p_78769_1_, World p_78769_2_, ItemStack p_78769_3_)
+     {
++        PlayerInteractEvent event = ForgeEventFactory.onPlayerInteract(p_78769_1_, Action.RIGHT_CLICK_AIR, 0, 0, 0, 0, p_78769_2_);
++        if (event.isCanceled())
++        {
++            return false;
++        }
++
+         this.func_78750_j();
+         this.field_78774_b.func_147297_a(new C08PacketPlayerBlockPlacement(-1, -1, -1, 255, p_78769_1_.field_71071_by.func_70448_g(), 0.0F, 0.0F, 0.0F));
++
++        if (p_78769_3_ == null || event.useItem == Event.Result.DENY)
++        {
++            return false;
++        }
++
+         int i = p_78769_3_.field_77994_a;
+         ItemStack itemstack1 = p_78769_3_.func_77957_a(p_78769_2_, p_78769_1_);
+ 
+@@ -359,9 +428,10 @@
          {
              p_78769_1_.field_71071_by.field_70462_a[p_78769_1_.field_71071_by.field_70461_c] = itemstack1;
  

--- a/patches/minecraft/net/minecraft/network/NetHandlerPlayServer.java.patch
+++ b/patches/minecraft/net/minecraft/network/NetHandlerPlayServer.java.patch
@@ -103,20 +103,23 @@
                  {
                      return;
                  }
-@@ -497,7 +529,11 @@
-                 return;
-             }
+@@ -492,12 +524,11 @@
  
--            this.field_147369_b.field_71134_c.func_73085_a(this.field_147369_b, worldserver, itemstack);
+         if (p_147346_1_.func_149568_f() == 255)
+         {
+-            if (itemstack == null)
 +            PlayerInteractEvent event = ForgeEventFactory.onPlayerInteract(field_147369_b, PlayerInteractEvent.Action.RIGHT_CLICK_AIR, 0, 0, 0, -1, worldserver);
-+            if (event.useItem != Event.Result.DENY)
-+            {
++            if (itemstack != null && event.useItem != Event.Result.DENY)
+             {
+-                return;
 +                this.field_147369_b.field_71134_c.func_73085_a(this.field_147369_b, worldserver, itemstack);
-+            }
+             }
+-
+-            this.field_147369_b.field_71134_c.func_73085_a(this.field_147369_b, worldserver, itemstack);
          }
          else if (p_147346_1_.func_149571_d() >= this.field_147367_d.func_71207_Z() - 1 && (p_147346_1_.func_149568_f() == 1 || p_147346_1_.func_149571_d() >= this.field_147367_d.func_71207_Z()))
          {
-@@ -508,7 +544,9 @@
+@@ -508,7 +539,9 @@
          }
          else
          {
@@ -127,7 +130,7 @@
              {
                  this.field_147369_b.field_71134_c.func_73078_a(this.field_147369_b, worldserver, itemstack, i, j, k, l, p_147346_1_.func_149573_h(), p_147346_1_.func_149569_i(), p_147346_1_.func_149575_j());
              }
-@@ -674,6 +712,8 @@
+@@ -674,6 +707,8 @@
              else
              {
                  ChatComponentTranslation chatcomponenttranslation1 = new ChatComponentTranslation("chat.type.text", new Object[] {this.field_147369_b.func_145748_c_(), s});
@@ -136,7 +139,7 @@
                  this.field_147367_d.func_71203_ab().func_148544_a(chatcomponenttranslation1, false);
              }
  
-@@ -810,7 +850,7 @@
+@@ -810,7 +845,7 @@
                          return;
                      }
  

--- a/patches/minecraft/net/minecraft/server/management/ItemInWorldManager.java.patch
+++ b/patches/minecraft/net/minecraft/server/management/ItemInWorldManager.java.patch
@@ -24,63 +24,95 @@
      public World field_73092_a;
      public EntityPlayerMP field_73090_b;
      private WorldSettings.GameType field_73091_c;
-@@ -126,6 +137,13 @@
-     {
-         if (!this.field_73091_c.func_82752_c() || this.field_73090_b.func_82246_f(p_73074_1_, p_73074_2_, p_73074_3_))
-         {
-+            PlayerInteractEvent event = ForgeEventFactory.onPlayerInteract(field_73090_b, Action.LEFT_CLICK_BLOCK, p_73074_1_, p_73074_2_, p_73074_3_, p_73074_4_, field_73092_a);
-+            if (event.isCanceled())
-+            {
-+                field_73090_b.field_71135_a.func_147359_a(new S23PacketBlockChange(p_73074_1_, p_73074_2_, p_73074_3_, field_73092_a));
-+                return;
-+            }
-+
-             if (this.func_73083_d())
-             {
-                 if (!this.field_73092_a.func_72886_a((EntityPlayer)null, p_73074_1_, p_73074_2_, p_73074_3_, p_73074_4_))
-@@ -135,19 +153,36 @@
-             }
-             else
-             {
--                this.field_73092_a.func_72886_a((EntityPlayer)null, p_73074_1_, p_73074_2_, p_73074_3_, p_73074_4_);
-                 this.field_73089_e = this.field_73100_i;
-                 float f = 1.0F;
-                 Block block = this.field_73092_a.func_147439_a(p_73074_1_, p_73074_2_, p_73074_3_);
+@@ -124,43 +135,62 @@
  
+     public void func_73074_a(int p_73074_1_, int p_73074_2_, int p_73074_3_, int p_73074_4_)
+     {
+-        if (!this.field_73091_c.func_82752_c() || this.field_73090_b.func_82246_f(p_73074_1_, p_73074_2_, p_73074_3_))
++        PlayerInteractEvent event = ForgeEventFactory.onPlayerInteract(field_73090_b, Action.LEFT_CLICK_BLOCK, p_73074_1_, p_73074_2_, p_73074_3_, p_73074_4_, field_73092_a);
++        boolean canBreak = !this.field_73091_c.func_82752_c() || this.field_73090_b.func_82246_f(p_73074_1_, p_73074_2_, p_73074_3_);
++        canBreak = event.useItem == Event.Result.DEFAULT ? canBreak : event.useItem == event.useItem.ALLOW;
++
++        if (event.isCanceled())
+         {
+-            if (this.func_73083_d())
++            field_73090_b.field_71135_a.func_147359_a(new S23PacketBlockChange(p_73074_1_, p_73074_2_, p_73074_3_, field_73092_a));
++        }
++        else
++        {
++            this.field_73089_e = this.field_73100_i;
++            float f = 1.0F;
++            Block block = this.field_73092_a.func_147439_a(p_73074_1_, p_73074_2_, p_73074_3_);
++
++            if (!block.isAir(field_73092_a, p_73074_1_, p_73074_2_, p_73074_3_))
+             {
+-                if (!this.field_73092_a.func_72886_a((EntityPlayer)null, p_73074_1_, p_73074_2_, p_73074_3_, p_73074_4_))
++                if (!this.func_73083_d())
+                 {
+-                    this.func_73084_b(p_73074_1_, p_73074_2_, p_73074_3_);
++                    f = block.func_149737_a(field_73090_b, field_73090_b.field_70170_p, p_73074_1_, p_73074_2_, p_73074_3_);
+                 }
+-            }
+-            else
+-            {
+-                this.field_73092_a.func_72886_a((EntityPlayer)null, p_73074_1_, p_73074_2_, p_73074_3_, p_73074_4_);
+-                this.field_73089_e = this.field_73100_i;
+-                float f = 1.0F;
+-                Block block = this.field_73092_a.func_147439_a(p_73074_1_, p_73074_2_, p_73074_3_);
+-
 -                if (block.func_149688_o() != Material.field_151579_a)
-+                
-+                if (!block.isAir(field_73092_a, p_73074_1_, p_73074_2_, p_73074_3_))
++                if (f < 1.0F && event.useBlock != Event.Result.DENY)
                  {
 -                    block.func_149699_a(this.field_73092_a, p_73074_1_, p_73074_2_, p_73074_3_, this.field_73090_b);
 -                    f = block.func_149737_a(this.field_73090_b, this.field_73090_b.field_70170_p, p_73074_1_, p_73074_2_, p_73074_3_);
-+                    if (event.useBlock != Event.Result.DENY)
-+                    {
-+                        block.func_149699_a(field_73092_a, p_73074_1_, p_73074_2_, p_73074_3_, field_73090_b);
-+                        field_73092_a.func_72886_a(field_73090_b, p_73074_1_, p_73074_2_, p_73074_3_, p_73074_4_);
-+                    }
-+                    else
-+                    {
-+                        field_73090_b.field_71135_a.func_147359_a(new S23PacketBlockChange(p_73074_1_, p_73074_2_, p_73074_3_, field_73092_a));
-+                    }
-+                    f = block.func_149737_a(field_73090_b, field_73090_b.field_70170_p, p_73074_1_, p_73074_2_, p_73074_3_);
++                    block.func_149699_a(field_73092_a, p_73074_1_, p_73074_2_, p_73074_3_, field_73090_b);
                  }
- 
+-
 -                if (block.func_149688_o() != Material.field_151579_a && f >= 1.0F)
-+                if (event.useItem == Event.Result.DENY)
++                if (event.useItem != Event.Result.DENY)
                  {
-+                    if (f >= 1.0f)
-+                    {
-+                        field_73090_b.field_71135_a.func_147359_a(new S23PacketBlockChange(p_73074_1_, p_73074_2_, p_73074_3_, field_73092_a));
-+                    }
-+                    return;
-+                }
-+
-+                if (!block.isAir(field_73092_a, p_73074_1_, p_73074_2_, p_73074_3_) && f >= 1.0F)
-+                {
-                     this.func_73084_b(p_73074_1_, p_73074_2_, p_73074_3_);
+-                    this.func_73084_b(p_73074_1_, p_73074_2_, p_73074_3_);
++                    field_73092_a.func_72886_a(field_73090_b, p_73074_1_, p_73074_2_, p_73074_3_, p_73074_4_);
                  }
                  else
-@@ -171,7 +206,7 @@
+                 {
+-                    this.field_73088_d = true;
+-                    this.field_73086_f = p_73074_1_;
+-                    this.field_73087_g = p_73074_2_;
+-                    this.field_73099_h = p_73074_3_;
+-                    int i1 = (int)(f * 10.0F);
+-                    this.field_73092_a.func_147443_d(this.field_73090_b.func_145782_y(), p_73074_1_, p_73074_2_, p_73074_3_, i1);
+-                    this.field_73094_o = i1;
++                    field_73090_b.field_71135_a.func_147359_a(new S23PacketBlockChange(p_73074_1_, p_73074_2_, p_73074_3_, field_73092_a));
+                 }
+             }
++
++            if (!canBreak)
++            {
++                if (f >= 1.0f)
++                {
++                    field_73090_b.field_71135_a.func_147359_a(new S23PacketBlockChange(p_73074_1_, p_73074_2_, p_73074_3_, field_73092_a));
++                }
++                this.field_73087_g = -1;
++            }
++            else if (!block.isAir(field_73092_a, p_73074_1_, p_73074_2_, p_73074_3_) && f >= 1.0F)
++            {
++                this.func_73084_b(p_73074_1_, p_73074_2_, p_73074_3_);
++            }
++            else
++            {
++                this.field_73088_d = true;
++                this.field_73086_f = p_73074_1_;
++                this.field_73087_g = p_73074_2_;
++                this.field_73099_h = p_73074_3_;
++                int i1 = (int)(f * 10.0F);
++                this.field_73092_a.func_147443_d(this.field_73090_b.func_145782_y(), p_73074_1_, p_73074_2_, p_73074_3_, i1);
++                this.field_73094_o = i1;
++            }
+         }
+     }
+ 
+@@ -171,7 +201,7 @@
              int l = this.field_73100_i - this.field_73089_e;
              Block block = this.field_73092_a.func_147439_a(p_73082_1_, p_73082_2_, p_73082_3_);
  
@@ -89,7 +121,7 @@
              {
                  float f = block.func_149737_a(this.field_73090_b, this.field_73090_b.field_70170_p, p_73082_1_, p_73082_2_, p_73082_3_) * (float)(l + 1);
  
-@@ -205,7 +240,7 @@
+@@ -205,7 +235,7 @@
          Block block = this.field_73092_a.func_147439_a(p_73079_1_, p_73079_2_, p_73079_3_);
          int l = this.field_73092_a.func_72805_g(p_73079_1_, p_73079_2_, p_73079_3_);
          block.func_149681_a(this.field_73092_a, p_73079_1_, p_73079_2_, p_73079_3_, l, this.field_73090_b);
@@ -98,7 +130,7 @@
  
          if (flag)
          {
-@@ -217,29 +252,32 @@
+@@ -217,29 +247,32 @@
  
      public boolean func_73084_b(int p_73084_1_, int p_73084_2_, int p_73084_3_)
      {
@@ -138,7 +170,7 @@
  
                  if (itemstack != null)
                  {
-@@ -251,12 +289,18 @@
+@@ -251,12 +284,18 @@
                      }
                  }
  
@@ -157,7 +189,7 @@
              return flag;
          }
      }
-@@ -288,6 +332,7 @@
+@@ -288,6 +327,7 @@
              if (itemstack1.field_77994_a == 0)
              {
                  p_73085_1_.field_71071_by.field_70462_a[p_73085_1_.field_71071_by.field_70461_c] = null;
@@ -165,7 +197,7 @@
              }
  
              if (!p_73085_1_.func_71039_bw())
-@@ -301,31 +346,70 @@
+@@ -301,31 +341,71 @@
  
      public boolean func_73078_a(EntityPlayer p_73078_1_, World p_73078_2_, ItemStack p_73078_3_, int p_73078_4_, int p_73078_5_, int p_73078_6_, int p_73078_7_, float p_73078_8_, float p_73078_9_, float p_73078_10_)
      {
@@ -179,7 +211,8 @@
          }
 -        else if (p_73078_3_ == null)
 +
-+        if (p_73078_3_ != null && p_73078_3_.func_77973_b().onItemUseFirst(p_73078_3_, p_73078_1_, p_73078_2_, p_73078_4_, p_73078_5_, p_73078_6_, p_73078_7_, p_73078_8_, p_73078_9_, p_73078_10_))
++        if (event.useItem != Event.Result.DENY &&
++            p_73078_3_ != null && p_73078_3_.func_77973_b().onItemUseFirst(p_73078_3_, p_73078_1_, p_73078_2_, p_73078_4_, p_73078_5_, p_73078_6_, p_73078_7_, p_73078_8_, p_73078_9_, p_73078_10_))
          {
 -            return false;
 +            if (p_73078_3_.field_77994_a <= 0) ForgeEventFactory.onPlayerDestroyItem(field_73090_b, p_73078_3_);

--- a/src/main/java/net/minecraftforge/event/entity/player/PlayerInteractEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/player/PlayerInteractEvent.java
@@ -6,6 +6,19 @@ import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.world.World;
 import cpw.mods.fml.common.eventhandler.Cancelable;
 
+/**
+ * Called when a player interacts with the world.
+ * Fired both on the server and the client.
+ * 
+ * Setting {@link #useBlock} to DENY will prevent onBlockClicked and
+ * onBlockActivated from being called.
+ * 
+ * Setting {@link #useItem} to DENY will prevent breaking of blocks.
+ * Setting it to ALLOW will allow breaking of blocks even in adventure mode.
+ * 
+ * When cancelled on the client, no packets will be sent to the server,
+ * and therefore no events will be fired on it.
+ */
 @Cancelable
 public class PlayerInteractEvent extends PlayerEvent
 {


### PR DESCRIPTION
This pull request makes PlayerInteractEvent more consistent and useful, mostly making the event available on the client. The following changes are included:
- PlayerInteractEvent fires on the client.
  - Cancelling the event on the client will prevent packets from being sent to the server.
  - Setting useItem to DENY on the client will make blocks appear unbreakable.
- Setting useItem to ALLOW will allow blocks to be broken even in adventure mode.
- Right clicking air without an item will send a packet to the server, causing a right click air event.
- Left click block will fire regardless of game mode, as long as the block isn't broken instantly.

And as a little added bonus:
- Added "documentation" to PlayerInteractEvent.
- Fires PlayerDestroyItemEvent on client too when item is used up in onItemUseFirst.
- Current item is not wrongly set to null on client if the passed item has a stack size of 0, even though the current item was set to a new stack.
