### PR TITLE
Add Jumps event

### DIFF
--- a/patches/minecraft/net/minecraft/entity/EntityLivingBase.java.patch
+++ b/patches/minecraft/net/minecraft/entity/EntityLivingBase.java.patch
@@ -175,6 +175,43 @@
      }
  
      public void func_70612_e(float p_70612_1_, float p_70612_2_)
+@@ -1358,9 +1392,9 @@
+             this.func_70060_a(p_70612_1_, p_70612_2_, this.func_70650_aV() ? 0.04F : 0.02F);
+             this.func_70091_d(this.field_70159_w, this.field_70181_x, this.field_70179_y);
+             this.field_70159_w *= 0.800000011920929D;
+-            this.field_70181_x *= 0.800000011920929D;
++            this.field_70181_x *= getYFriction(true, false);
+             this.field_70179_y *= 0.800000011920929D;
+-            this.field_70181_x -= 0.02D;
++            this.field_70181_x -= getGravity(true, false);
+ 
+             if (this.field_70123_F && this.func_70038_c(this.field_70159_w, this.field_70181_x + 0.6000000238418579D - this.field_70163_u + d0, this.field_70179_y))
+             {
+@@ -1373,9 +1407,9 @@
+             this.func_70060_a(p_70612_1_, p_70612_2_, 0.02F);
+             this.func_70091_d(this.field_70159_w, this.field_70181_x, this.field_70179_y);
+             this.field_70159_w *= 0.5D;
+-            this.field_70181_x *= 0.5D;
++            this.field_70181_x *= getYFriction(false, true);
+             this.field_70179_y *= 0.5D;
+-            this.field_70181_x -= 0.02D;
++            this.field_70181_x -= getGravity(false, true);
+ 
+             if (this.field_70123_F && this.func_70038_c(this.field_70159_w, this.field_70181_x + 0.6000000238418579D - this.field_70163_u + d0, this.field_70179_y))
+             {
+@@ -1470,10 +1504,10 @@
+             }
+             else
+             {
+-                this.field_70181_x -= 0.08D;
++                this.field_70181_x -= getGravity(false, false);
+             }
+ 
+-            this.field_70181_x *= 0.9800000190734863D;
++            this.field_70181_x *= getYFriction(false, false);
+             this.field_70159_w *= (double)f2;
+             this.field_70179_y *= (double)f2;
+         }
 @@ -1520,6 +1554,7 @@
  
      public void func_70071_h_()
@@ -183,12 +220,74 @@
          super.func_70071_h_();
  
          if (!this.field_70170_p.field_72995_K)
-@@ -2000,4 +2035,62 @@
+@@ -2000,4 +2035,124 @@
      {
          return this.func_96124_cp() != null ? this.func_96124_cp().func_142054_a(p_142012_1_) : false;
      }
 +
 +    /**************** Start Forge modification **************/
++
++    /**
++     * Return the gravity applied on this entity
++     * @param inWater   True if the entity is in water
++     * @param inLava    True if the entity is in lava
++     * @return The gravity to apply
++     */
++    protected double getGravity(boolean inWater, boolean inLava)
++    {
++        return inWater ? 0.02D : inLava ? 0.02D : 0.08D;
++    }
++
++    /**
++     * Return the Y friction of the entity
++     * @param inWater   True if the entity is in water
++     * @param inLava    True if the entity is in lava
++     * @return The friction on Y axis
++     */
++    protected double getYFriction(boolean inWater, boolean inLava)
++    {
++        return inWater ? 0.800000011920929D : inLava ? 0.5D : 0.9800000190734863D;
++    }
++
++    /**
++     * Compute and return the jump height of this entity
++     * @return The maximal jump height
++     */
++    public double getJumpHeight()
++    {
++        double jumpSpeed = getInitialJumpSpeed();
++        double jumpHeight = 0;
++
++        if (this.func_70090_H() && (!(this instanceof EntityPlayer) || !((EntityPlayer)this).field_71075_bZ.field_75100_b))
++        {
++            while (jumpSpeed > 0)
++            {
++                jumpHeight += jumpSpeed;
++
++                jumpSpeed *= getYFriction(true, false);
++                jumpSpeed -= getGravity(true, false);
++            }
++        }
++        else if (this.func_70058_J() && (!(this instanceof EntityPlayer) || !((EntityPlayer)this).field_71075_bZ.field_75100_b))
++        {
++            jumpHeight += jumpSpeed;
++
++            jumpSpeed *= getYFriction(false, true);;
++            jumpSpeed -= getGravity(false, true);;
++        }
++        else
++        {
++            while (jumpSpeed > 0)
++            {
++                jumpHeight += jumpSpeed;
++
++                jumpSpeed -= getGravity(false, false);;
++                jumpSpeed *= getYFriction(false, false);;
++            }
++        }
++
++        return jumpHeight;
++    }
 +
 +    /**
 +     * Return the initial jump velocity of this entity

--- a/patches/minecraft/net/minecraft/entity/EntityLivingBase.java.patch
+++ b/patches/minecraft/net/minecraft/entity/EntityLivingBase.java.patch
@@ -148,6 +148,25 @@
          if (!this.field_82175_bq || this.field_110158_av >= this.func_82166_i() / 2 || this.field_110158_av < 0)
          {
              this.field_110158_av = -1;
+@@ -1331,13 +1364,13 @@
+ 
+     protected void func_70664_aZ()
+     {
+-        this.field_70181_x = 0.41999998688697815D;
++        this.field_70181_x = getInitialJumpSpeed();
+ 
+-        if (this.func_70644_a(Potion.field_76430_j))
+-        {
+-            this.field_70181_x += (double)((float)(this.func_70660_b(Potion.field_76430_j).func_76458_c() + 1) * 0.1F);
+-        }
+ 
++
++
++
++
+         if (this.func_70051_ag())
+         {
+             float f = this.field_70177_z * 0.017453292F;
 @@ -1346,6 +1379,7 @@
          }
  
@@ -164,10 +183,28 @@
          super.func_70071_h_();
  
          if (!this.field_70170_p.field_72995_K)
-@@ -2000,4 +2035,42 @@
+@@ -2000,4 +2035,62 @@
      {
          return this.func_96124_cp() != null ? this.func_96124_cp().func_142054_a(p_142012_1_) : false;
      }
++
++    /**************** Start Forge modification **************/
++
++    /**
++     * Return the initial jump velocity of this entity
++     * @return The initial jump velocity
++     */
++    protected double getInitialJumpSpeed()
++    {
++        double jumpSpeed = 0.41999998688697815D;
++
++        if (this.func_70644_a(Potion.field_76430_j))
++        {
++            jumpSpeed += (double)((float)(this.func_70660_b(Potion.field_76430_j).func_76458_c() + 1) * 0.1F);
++        }
++
++        return ForgeHooks.onGetLivingJumpSpeed(this, jumpSpeed);
++    }
 +
 +    /***
 +     * Removes all potion effects that have curativeItem as a curative item for its effect
@@ -206,4 +243,6 @@
 +    {
 +        return this instanceof EntityPig;
 +    }
++
++    /**************** End Forge modification **************/
  }

--- a/patches/minecraft/net/minecraft/entity/monster/EntityMagmaCube.java.patch
+++ b/patches/minecraft/net/minecraft/entity/monster/EntityMagmaCube.java.patch
@@ -1,0 +1,37 @@
+--- ../src-base/minecraft/net/minecraft/entity/monster/EntityMagmaCube.java
++++ ../src-work/minecraft/net/minecraft/entity/monster/EntityMagmaCube.java
+@@ -7,6 +7,7 @@
+ import net.minecraft.item.Item;
+ import net.minecraft.world.EnumDifficulty;
+ import net.minecraft.world.World;
++import net.minecraftforge.common.ForgeHooks;
+ 
+ public class EntityMagmaCube extends EntitySlime
+ {
+@@ -97,7 +98,7 @@
+ 
+     protected void func_70664_aZ()
+     {
+-        this.field_70181_x = (double)(0.42F + (float)this.func_70809_q() * 0.1F);
++        this.field_70181_x = getInitialJumpSpeed();
+         this.field_70160_al = true;
+     }
+ 
+@@ -127,4 +128,17 @@
+     {
+         return true;
+     }
++
++    /**************** Start Forge modification **************/
++
++    /**
++     * Return the initial jump velocity of this entity
++     * @return The initial jump velocity
++     */
++    protected double getInitialJumpSpeed()
++    {
++        return ForgeHooks.onGetLivingJumpSpeed(this, (double)(0.42F + (float)this.func_70809_q() * 0.1F));
++    }
++
++    /**************** End Forge modification **************/
+ }

--- a/patches/minecraft/net/minecraft/entity/passive/EntityHorse.java.patch
+++ b/patches/minecraft/net/minecraft/entity/passive/EntityHorse.java.patch
@@ -1,0 +1,59 @@
+--- ../src-base/minecraft/net/minecraft/entity/passive/EntityHorse.java
++++ ../src-work/minecraft/net/minecraft/entity/passive/EntityHorse.java
+@@ -39,6 +39,7 @@
+ import net.minecraft.util.MathHelper;
+ import net.minecraft.util.StatCollector;
+ import net.minecraft.world.World;
++import net.minecraftforge.common.ForgeHooks;
+ 
+ public class EntityHorse extends EntityAnimal implements IInvBasic
+ {
+@@ -1207,13 +1208,13 @@
+ 
+             if (this.field_110277_bt > 0.0F && !this.func_110246_bZ() && this.field_70122_E)
+             {
+-                this.field_70181_x = this.func_110215_cj() * (double)this.field_110277_bt;
++                this.field_70181_x = getInitialJumpSpeed();
+ 
+-                if (this.func_70644_a(Potion.field_76430_j))
+-                {
+-                    this.field_70181_x += (double)((float)(this.func_70660_b(Potion.field_76430_j).func_76458_c() + 1) * 0.1F);
+-                }
+ 
++
++
++
++
+                 this.func_110255_k(true);
+                 this.field_70160_al = true;
+ 
+@@ -1673,4 +1674,29 @@
+                 this.field_111106_b = p_i1684_2_;
+             }
+         }
++
++    /**************** Start Forge modification **************/
++
++    /**
++     * Return the initial jump velocity of this entity
++     * @return The initial jump velocity
++     */
++    protected double getInitialJumpSpeed()
++    {
++        if (this.field_70153_n != null && this.func_110257_ck() && this.field_110277_bt > 0.0F && !this.func_110246_bZ() && this.field_70122_E)
++        {
++            double jumpSpeed = this.func_110215_cj() * (double)this.field_110277_bt;
++
++            if (this.func_70644_a(Potion.field_76430_j))
++            {
++                jumpSpeed += (double)((float)(this.func_70660_b(Potion.field_76430_j).func_76458_c() + 1) * 0.1F);
++            }
++
++            return ForgeHooks.onGetLivingJumpSpeed(this, jumpSpeed);
++        }
++
++        return super.getInitialJumpSpeed();
++    }
++
++    /**************** End Forge modification **************/
+ }

--- a/src/main/java/net/minecraftforge/common/ForgeHooks.java
+++ b/src/main/java/net/minecraftforge/common/ForgeHooks.java
@@ -42,6 +42,7 @@ import net.minecraftforge.event.entity.item.ItemTossEvent;
 import net.minecraftforge.event.entity.living.LivingAttackEvent;
 import net.minecraftforge.event.entity.living.LivingDeathEvent;
 import net.minecraftforge.event.entity.living.LivingDropsEvent;
+import net.minecraftforge.event.entity.living.LivingEvent.GetLivingJumpSpeedEvent;
 import net.minecraftforge.event.entity.living.LivingEvent.LivingJumpEvent;
 import net.minecraftforge.event.entity.living.LivingEvent.LivingUpdateEvent;
 import net.minecraftforge.event.entity.living.LivingFallEvent;
@@ -334,6 +335,19 @@ public class ForgeHooks
     public static void onLivingJump(EntityLivingBase entity)
     {
         MinecraftForge.EVENT_BUS.post(new LivingJumpEvent(entity));
+    }
+
+    public static double onGetLivingJumpSpeed(EntityLivingBase entity, double jumpSpeed)
+    {
+        GetLivingJumpSpeedEvent event = new GetLivingJumpSpeedEvent(entity, jumpSpeed);
+        MinecraftForge.EVENT_BUS.post(event);
+
+        if (jumpSpeed != event.jumpSpeed)
+        {
+            return event.jumpSpeed;
+        }
+
+        return jumpSpeed;
     }
 
     public static EntityItem onPlayerTossEvent(EntityPlayer player, ItemStack item, boolean includeName)

--- a/src/main/java/net/minecraftforge/event/entity/living/LivingEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/living/LivingEvent.java
@@ -23,4 +23,15 @@ public class LivingEvent extends EntityEvent
     {
         public LivingJumpEvent(EntityLivingBase e){ super(e); }
     }
+
+    public static class GetLivingJumpSpeedEvent extends LivingEvent
+    {
+        public double jumpSpeed;
+
+        public GetLivingJumpSpeedEvent(EntityLivingBase e, double jumpSpeed)
+        {
+            super(e);
+            this.jumpSpeed = jumpSpeed;
+        }
+    }
 }


### PR DESCRIPTION
I will need to know the jump capability of an entity in my mod, but there is apparently no good way to do that. So I added new event to do that, but I'm net really sure of the method.

But anyway, the last commit added two missing onLivingJump event (on ridden Horse and Magma Cube), so you can cherry-pick that one at least.