### PR TITLE
Fix EnderTeleportEvent for Ender Pearls.

### DIFF
--- a/patches/minecraft/net/minecraft/entity/item/EntityEnderPearl.java.patch
+++ b/patches/minecraft/net/minecraft/entity/item/EntityEnderPearl.java.patch
@@ -9,7 +9,7 @@
  
  public class EntityEnderPearl extends EntityThrowable
  {
-@@ -50,6 +52,9 @@
+@@ -50,14 +52,18 @@
  
                  if (entityplayermp.field_71135_a.func_147362_b().func_150724_d() && entityplayermp.field_70170_p == this.field_70170_p)
                  {
@@ -19,10 +19,13 @@
                      if (this.func_85052_h().func_70115_ae())
                      {
                          this.func_85052_h().func_70078_a((Entity)null);
-@@ -58,6 +63,7 @@
-                     this.func_85052_h().func_70634_a(this.field_70165_t, this.field_70163_u, this.field_70161_v);
+                     }
+ 
+-                    this.func_85052_h().func_70634_a(this.field_70165_t, this.field_70163_u, this.field_70161_v);
++                    this.func_85052_h().func_70634_a(event.targetX, event.targetY, event.targetZ);
                      this.func_85052_h().field_70143_R = 0.0F;
-                     this.func_85052_h().func_70097_a(DamageSource.field_76379_h, 5.0F);
+-                    this.func_85052_h().func_70097_a(DamageSource.field_76379_h, 5.0F);
++                    this.func_85052_h().func_70097_a(DamageSource.field_76379_h, event.attackDamage);
 +                    }
                  }
              }


### PR DESCRIPTION
Ender Pearls now respect the target position and attack damage from EnderTeleportEvent. Closes #1132.
