### PR TITLE
Setting getExperiencePoints to public

### DIFF
--- a/src/main/resources/forge_at.cfg
+++ b/src/main/resources/forge_at.cfg
@@ -178,4 +178,6 @@ public net.minecraft.client.renderer.entity.RenderBiped field_77071_a #modelBipe
 public net.minecraft.client.renderer.entity.RenderPlayer field_77109_a #modelBipedMain
 public net.minecraft.client.renderer.entity.RenderPlayer field_77108_b #modelArmorChestplate
 public net.minecraft.client.renderer.entity.RenderPlayer field_77111_i #modelArmor
+#EntityLivingBase
+public net.minecraft.entity.EntityLivingBase func_70693_a #getExperiencePoints
 


### PR DESCRIPTION
Currently, entities only drop experience when killed by a player. setting the getExperiencePoints method to public would allow for modders to get the experience when the mob is killed by a custom entity. This would also prevent the modder from needing to use playerdamage on the mob, which would cause it to attack the player, and not the entity itself. (example : levelable pets)
