### PR TITLE
Changed EntityWolf to EntityTameable in EntityLivingbase

### DIFF
--- a/patches/minecraft/net/minecraft/entity/EntityLivingBase.java.patch
+++ b/patches/minecraft/net/minecraft/entity/EntityLivingBase.java.patch
@@ -49,6 +49,18 @@
          if (this.func_85032_ar())
          {
              return false;
+@@ -796,9 +799,9 @@
+                         this.field_70718_bc = 100;
+                         this.field_70717_bb = (EntityPlayer)entity;
+                     }
+-                    else if (entity instanceof EntityWolf)
++                    else if (entity instanceof net.minecraft.entity.passive.EntityTameable)
+                     {
+-                        EntityWolf entitywolf = (EntityWolf)entity;
++                        net.minecraft.entity.passive.EntityTameable entitywolf = (net.minecraft.entity.passive.EntityTameable)entity;
+ 
+                         if (entitywolf.func_70909_n())
+                         {
 @@ -883,6 +886,7 @@
  
      public void func_70645_a(DamageSource p_70645_1_)


### PR DESCRIPTION
Changed EntityWolf to EntityTameable in EntityLivingbase so added/modded entities can still trigger mobs to drop experience on death. _adjusted so only 2 lines get changed_

(Also, sorry about the many different PR's. I'm new to the system.)
