### PR TITLE
Update OreDictionary.java

### DIFF
--- a/src/main/java/net/minecraftforge/oredict/OreDictionary.java
+++ b/src/main/java/net/minecraftforge/oredict/OreDictionary.java
@@ -103,7 +103,7 @@ public class OreDictionary
             registerOre("gemQuartz",   Items.quartz);
             registerOre("dustRedstone",  Items.redstone);
             registerOre("dustGlowstone", Items.glowstone_dust);
-            registerOre("dustLapis",   new ItemStack(Items.dye, 1, 4));
+            registerOre("gemLapis",   new ItemStack(Items.dye, 1, 4));
             registerOre("slimeball",   Items.slime_ball);
             registerOre("glowstone",   Blocks.glowstone);
             registerOre("cropWheat",   Items.wheat);


### PR DESCRIPTION
Lapis Lazuli is _NOT_ a dust, it is a rock, such as at: http://spiraltimes.files.wordpress.com/2012/11/lapis.jpg
Pretty sure that is what the MC Lapis Lazuli icon is based on as well, flip and rotate it and it matches.
Calling this "dustLapis" was a breaking change.
