### PR TITLE
Fixed ArrayIndexOutOfBoundsException in getOreName

### DIFF
--- a/src/main/java/net/minecraftforge/oredict/OreDictionary.java
+++ b/src/main/java/net/minecraftforge/oredict/OreDictionary.java
@@ -282,7 +282,7 @@ public class OreDictionary
      */
     public static String getOreName(int id)
     {
-        return id < idToName.size() ? idToName.get(id) : "Unknown";
+        return (id >= 0 && id < idToName.size()) ? idToName.get(id) : "Unknown";
     }
 
     /**


### PR DESCRIPTION
Added sanity check to prevent ArrayIndexOutOfBoundsException in getOreName for negative ids.
