### PR TITLE
Added FluidStack sensitive version for Fluid's localised name

### DIFF
--- a/src/main/java/net/minecraftforge/fluids/Fluid.java
+++ b/src/main/java/net/minecraftforge/fluids/Fluid.java
@@ -190,6 +190,15 @@ public class Fluid
     /**
      * Returns the localized name of this fluid.
      */
+    public String getLocalizedName(FluidStack stack)
+    {
+        return getLocalizedName();
+    }
+    
+    /**
+     * Use the FluidStack sensitive version above
+     */
+     @Deprecated
     public String getLocalizedName()
     {
         String s = this.getUnlocalizedName();


### PR DESCRIPTION
Would be helpful for determining names for more complex FluidStacks (with tag compounds for example)
