### PR TITLE
Changed Configuration.save()

### DIFF
--- a/src/main/java/net/minecraftforge/common/config/Configuration.java
+++ b/src/main/java/net/minecraftforge/common/config/Configuration.java
@@ -1048,15 +1048,28 @@ public class Configuration
 
         resetChangedState();
     }
-
+    
     public void save()
+    {
+        save(false);
+    }
+    
+    public void save(boolean forceSave)
     {
         if (PARENT != null && PARENT != this)
         {
             PARENT.save();
             return;
         }
-
+        
+        if (!forceSave)
+        {
+            if (!hasChanged())
+            {
+                return;
+            }
+        }
+        
         try
         {
             if (file.getParentFile() != null)


### PR DESCRIPTION
This basically prevents config files from being recreated every time Minecraft restarts
It's really annoying when your Notepad++ says 'THIS FILE WERE UPDATED. WOULD YOU LIKE TO RELOAD IT?' 100 times.
I'm not sure if I did that right, but you always can fix it :)
