### PR TITLE
Skylight Hooks for Minecraft Forge

### DIFF
--- a/patches/minecraft/net/minecraft/world/World.java.patch
+++ b/patches/minecraft/net/minecraft/world/World.java.patch
@@ -189,15 +189,54 @@
  
              this.func_72964_e(i, j).func_76612_a(p_72838_1_);
              this.field_72996_f.add(p_72838_1_);
-@@ -1418,7 +1496,6 @@
-         return (int)(f2 * 11.0F);
+@@ -1398,6 +1476,20 @@
+ 
+     public int func_72967_a(float p_72967_1_)
+     {
++        float f2 = field_73011_w.getSunBrightnessFactor(p_72967_1_);
++        f2 = 1.0F - f2;
++        return (int)(f2 * 11.0F);
++    }
++    
++    /**
++     * The current sun brightness factor for this dimension.
++     * 0.0f means no light at all, and 1.0f means maximum sunlight.
++     * Highly recommended for sunlight detection like solar panel.
++     * 
++     * @return The current brightness factor
++     * */
++    public float getSunBrightnessFactor(float p_72967_1_)
++    {
+         float f1 = this.func_72826_c(p_72967_1_);
+         float f2 = 1.0F - (MathHelper.func_76134_b(f1 * (float)Math.PI * 2.0F) * 2.0F + 0.5F);
+ 
+@@ -1414,11 +1506,9 @@
+         f2 = 1.0F - f2;
+         f2 = (float)((double)f2 * (1.0D - (double)(this.func_72867_j(p_72967_1_) * 5.0F) / 16.0D));
+         f2 = (float)((double)f2 * (1.0D - (double)(this.func_72819_i(p_72967_1_) * 5.0F) / 16.0D));
+-        f2 = 1.0F - f2;
+-        return (int)(f2 * 11.0F);
++        return f2;
      }
  
 -    @SideOnly(Side.CLIENT)
      public void func_72848_b(IWorldAccess p_72848_1_)
      {
          this.field_73021_x.remove(p_72848_1_);
-@@ -1449,6 +1526,12 @@
+@@ -1427,6 +1517,12 @@
+     @SideOnly(Side.CLIENT)
+     public float func_72971_b(float p_72971_1_)
+     {
++        return field_73011_w.getSunBrightness(p_72971_1_);
++    }
++    
++    @SideOnly(Side.CLIENT)
++    public float getSunBrightnessBody(float p_72971_1_)
++    {
+         float f1 = this.func_72826_c(p_72971_1_);
+         float f2 = 1.0F - (MathHelper.func_76134_b(f1 * (float)Math.PI * 2.0F) * 2.0F + 0.2F);
+ 
+@@ -1449,6 +1545,12 @@
      @SideOnly(Side.CLIENT)
      public Vec3 func_72833_a(Entity p_72833_1_, float p_72833_2_)
      {
@@ -210,7 +249,7 @@
          float f1 = this.func_72826_c(p_72833_2_);
          float f2 = MathHelper.func_76134_b(f1 * (float)Math.PI * 2.0F) * 2.0F + 0.5F;
  
-@@ -1465,9 +1548,7 @@
+@@ -1465,9 +1567,7 @@
          int i = MathHelper.func_76128_c(p_72833_1_.field_70165_t);
          int j = MathHelper.func_76128_c(p_72833_1_.field_70163_u);
          int k = MathHelper.func_76128_c(p_72833_1_.field_70161_v);
@@ -221,7 +260,19 @@
          float f4 = (float)(l >> 16 & 255) / 255.0F;
          float f5 = (float)(l >> 8 & 255) / 255.0F;
          float f6 = (float)(l & 255) / 255.0F;
-@@ -1541,6 +1622,12 @@
+@@ -1529,6 +1629,11 @@
+ 
+     public float func_130001_d()
+     {
++        return field_73011_w.getCurrentMoonPhaseFactor();
++    }
++    
++    public float getCurrentMoonPhaseFactorBody()
++    {
+         return WorldProvider.field_111203_a[this.field_73011_w.func_76559_b(this.field_72986_A.func_76073_f())];
+     }
+ 
+@@ -1541,6 +1646,12 @@
      @SideOnly(Side.CLIENT)
      public Vec3 func_72824_f(float p_72824_1_)
      {
@@ -234,7 +285,7 @@
          float f1 = this.func_72826_c(p_72824_1_);
          float f2 = MathHelper.func_76134_b(f1 * (float)Math.PI * 2.0F) * 2.0F + 0.5F;
  
-@@ -1602,6 +1689,8 @@
+@@ -1602,6 +1713,8 @@
      public int func_72825_h(int p_72825_1_, int p_72825_2_)
      {
          Chunk chunk = this.func_72938_d(p_72825_1_, p_72825_2_);
@@ -243,7 +294,7 @@
          int k = chunk.func_76625_h() + 15;
          p_72825_1_ &= 15;
  
-@@ -1609,7 +1698,7 @@
+@@ -1609,7 +1722,7 @@
          {
              Block block = chunk.func_150810_a(p_72825_1_, k, p_72825_2_);
  
@@ -252,7 +303,7 @@
              {
                  return k + 1;
              }
-@@ -1621,7 +1710,13 @@
+@@ -1621,7 +1734,13 @@
      @SideOnly(Side.CLIENT)
      public float func_72880_h(float p_72880_1_)
      {
@@ -267,7 +318,7 @@
          float f2 = 1.0F - (MathHelper.func_76134_b(f1 * (float)Math.PI * 2.0F) * 2.0F + 0.25F);
  
          if (f2 < 0.0F)
-@@ -1675,7 +1770,15 @@
+@@ -1675,7 +1794,15 @@
                      entity.func_85029_a(crashreportcategory);
                  }
  
@@ -284,7 +335,7 @@
              }
  
              if (entity.field_70128_L)
-@@ -1737,7 +1840,16 @@
+@@ -1737,7 +1864,16 @@
                      crashreport = CrashReport.func_85055_a(throwable1, "Ticking entity");
                      crashreportcategory = crashreport.func_85058_a("Entity being ticked");
                      entity.func_85029_a(crashreportcategory);
@@ -302,7 +353,7 @@
                  }
              }
  
-@@ -1780,7 +1892,16 @@
+@@ -1780,7 +1916,16 @@
                      crashreport = CrashReport.func_85055_a(throwable, "Ticking block entity");
                      crashreportcategory = crashreport.func_85058_a("Block entity being ticked");
                      tileentity.func_145828_a(crashreportcategory);
@@ -320,7 +371,7 @@
                  }
              }
  
-@@ -1794,7 +1915,7 @@
+@@ -1794,7 +1939,7 @@
  
                      if (chunk != null)
                      {
@@ -329,7 +380,7 @@
                      }
                  }
              }
-@@ -1802,6 +1923,10 @@
+@@ -1802,6 +1947,10 @@
  
          if (!this.field_147483_b.isEmpty())
          {
@@ -340,7 +391,7 @@
              this.field_147482_g.removeAll(this.field_147483_b);
              this.field_147483_b.clear();
          }
-@@ -1822,18 +1947,18 @@
+@@ -1822,18 +1971,18 @@
                      {
                          this.field_147482_g.add(tileentity1);
                      }
@@ -363,7 +414,7 @@
                  }
              }
  
-@@ -1846,14 +1971,11 @@
+@@ -1846,14 +1995,11 @@
  
      public void func_147448_a(Collection p_147448_1_)
      {
@@ -381,7 +432,7 @@
      }
  
      public void func_72870_g(Entity p_72870_1_)
-@@ -1865,10 +1987,19 @@
+@@ -1865,10 +2011,19 @@
      {
          int i = MathHelper.func_76128_c(p_72866_1_.field_70165_t);
          int j = MathHelper.func_76128_c(p_72866_1_.field_70161_v);
@@ -403,7 +454,7 @@
              p_72866_1_.field_70142_S = p_72866_1_.field_70165_t;
              p_72866_1_.field_70137_T = p_72866_1_.field_70163_u;
              p_72866_1_.field_70136_U = p_72866_1_.field_70161_v;
-@@ -2086,6 +2217,10 @@
+@@ -2086,6 +2241,10 @@
                          {
                              return true;
                          }
@@ -414,7 +465,7 @@
                      }
                  }
              }
-@@ -2378,13 +2513,15 @@
+@@ -2378,13 +2537,15 @@
  
      public void func_147455_a(int p_147455_1_, int p_147455_2_, int p_147455_3_, TileEntity p_147455_4_)
      {
@@ -434,7 +485,7 @@
                  Iterator iterator = this.field_147484_a.iterator();
  
                  while (iterator.hasNext())
-@@ -2403,40 +2540,22 @@
+@@ -2403,40 +2564,22 @@
              else
              {
                  this.field_147482_g.add(p_147455_4_);
@@ -485,7 +536,7 @@
      }
  
      public void func_147457_a(TileEntity p_147457_1_)
-@@ -2453,8 +2572,7 @@
+@@ -2453,8 +2596,7 @@
      public static boolean func_147466_a(IBlockAccess p_147466_0_, int p_147466_1_, int p_147466_2_, int p_147466_3_)
      {
          Block block = p_147466_0_.func_147439_a(p_147466_1_, p_147466_2_, p_147466_3_);
@@ -495,7 +546,7 @@
      }
  
      public boolean func_147445_c(int p_147445_1_, int p_147445_2_, int p_147445_3_, boolean p_147445_4_)
-@@ -2466,7 +2584,7 @@
+@@ -2466,7 +2608,7 @@
              if (chunk != null && !chunk.func_76621_g())
              {
                  Block block = this.func_147439_a(p_147445_1_, p_147445_2_, p_147445_3_);
@@ -504,7 +555,7 @@
              }
              else
              {
-@@ -2491,8 +2609,7 @@
+@@ -2491,8 +2633,7 @@
  
      public void func_72891_a(boolean p_72891_1_, boolean p_72891_2_)
      {
@@ -514,7 +565,7 @@
      }
  
      public void func_72835_b()
-@@ -2502,6 +2619,11 @@
+@@ -2502,6 +2643,11 @@
  
      private void func_72947_a()
      {
@@ -526,7 +577,7 @@
          if (this.field_72986_A.func_76059_o())
          {
              this.field_73004_o = 1.0F;
-@@ -2515,6 +2637,11 @@
+@@ -2515,6 +2661,11 @@
  
      protected void func_72979_l()
      {
@@ -538,7 +589,7 @@
          if (!this.field_73011_w.field_76576_e)
          {
              if (!this.field_72995_K)
-@@ -2599,6 +2726,7 @@
+@@ -2599,6 +2750,7 @@
      {
          this.field_72993_I.clear();
          this.field_72984_F.func_76320_a("buildList");
@@ -546,7 +597,7 @@
          int i;
          EntityPlayer entityplayer;
          int j;
-@@ -2693,6 +2821,11 @@
+@@ -2693,6 +2845,11 @@
  
      public boolean func_72834_c(int p_72834_1_, int p_72834_2_, int p_72834_3_, boolean p_72834_4_)
      {
@@ -558,7 +609,7 @@
          BiomeGenBase biomegenbase = this.func_72807_a(p_72834_1_, p_72834_3_);
          float f = biomegenbase.func_150564_a(p_72834_1_, p_72834_2_, p_72834_3_);
  
-@@ -2748,6 +2881,11 @@
+@@ -2748,6 +2905,11 @@
  
      public boolean func_147478_e(int p_147478_1_, int p_147478_2_, int p_147478_3_, boolean p_147478_4_)
      {
@@ -570,7 +621,7 @@
          BiomeGenBase biomegenbase = this.func_72807_a(p_147478_1_, p_147478_3_);
          float f = biomegenbase.func_150564_a(p_147478_1_, p_147478_2_, p_147478_3_);
  
-@@ -2797,10 +2935,11 @@
+@@ -2797,10 +2959,11 @@
          else
          {
              Block block = this.func_147439_a(p_98179_1_, p_98179_2_, p_98179_3_);
@@ -585,7 +636,7 @@
              {
                  i1 = 1;
              }
-@@ -2900,7 +3039,7 @@
+@@ -2900,7 +3063,7 @@
                                      int j4 = i2 + Facing.field_71586_b[i4];
                                      int k4 = j2 + Facing.field_71587_c[i4];
                                      int l4 = k2 + Facing.field_71585_d[i4];
@@ -594,7 +645,7 @@
                                      i3 = this.func_72972_b(p_147463_1_, j4, k4, l4);
  
                                      if (i3 == l2 - i5 && i1 < this.field_72994_J.length)
-@@ -2998,10 +3137,10 @@
+@@ -2998,10 +3161,10 @@
      public List func_94576_a(Entity p_94576_1_, AxisAlignedBB p_94576_2_, IEntitySelector p_94576_3_)
      {
          ArrayList arraylist = new ArrayList();
@@ -609,7 +660,7 @@
  
          for (int i1 = i; i1 <= j; ++i1)
          {
-@@ -3024,10 +3163,10 @@
+@@ -3024,10 +3187,10 @@
  
      public List func_82733_a(Class p_82733_1_, AxisAlignedBB p_82733_2_, IEntitySelector p_82733_3_)
      {
@@ -624,7 +675,7 @@
          ArrayList arraylist = new ArrayList();
  
          for (int i1 = i; i1 <= j; ++i1)
-@@ -3104,11 +3243,14 @@
+@@ -3104,11 +3267,14 @@
  
      public void func_72868_a(List p_72868_1_)
      {
@@ -642,7 +693,7 @@
          }
      }
  
-@@ -3121,7 +3263,7 @@
+@@ -3121,7 +3287,7 @@
      {
          Block block1 = this.func_147439_a(p_147472_2_, p_147472_3_, p_147472_4_);
          AxisAlignedBB axisalignedbb = p_147472_5_ ? null : p_147472_1_.func_149668_a(this, p_147472_2_, p_147472_3_, p_147472_4_);
@@ -651,7 +702,7 @@
      }
  
      public PathEntity func_72865_a(Entity p_72865_1_, Entity p_72865_2_, float p_72865_3_, boolean p_72865_4_, boolean p_72865_5_, boolean p_72865_6_, boolean p_72865_7_)
-@@ -3226,7 +3368,8 @@
+@@ -3226,7 +3392,8 @@
  
      public int func_72878_l(int p_72878_1_, int p_72878_2_, int p_72878_3_, int p_72878_4_)
      {
@@ -661,7 +712,7 @@
      }
  
      public boolean func_72864_z(int p_72864_1_, int p_72864_2_, int p_72864_3_)
-@@ -3374,7 +3517,7 @@
+@@ -3374,7 +3541,7 @@
  
      public long func_72905_C()
      {
@@ -670,7 +721,7 @@
      }
  
      public long func_82737_E()
-@@ -3384,22 +3527,22 @@
+@@ -3384,22 +3551,22 @@
  
      public long func_72820_D()
      {
@@ -697,7 +748,7 @@
      }
  
      @SideOnly(Side.CLIENT)
-@@ -3419,12 +3562,20 @@
+@@ -3419,12 +3586,20 @@
  
          if (!this.field_72996_f.contains(p_72897_1_))
          {
@@ -719,7 +770,7 @@
          return true;
      }
  
-@@ -3514,8 +3665,7 @@
+@@ -3514,8 +3689,7 @@
  
      public boolean func_72958_C(int p_72958_1_, int p_72958_2_, int p_72958_3_)
      {
@@ -729,7 +780,7 @@
      }
  
      public void func_72823_a(String p_72823_1_, WorldSavedData p_72823_2_)
-@@ -3569,12 +3719,12 @@
+@@ -3569,12 +3743,12 @@
  
      public int func_72800_K()
      {
@@ -744,7 +795,7 @@
      }
  
      public Random func_72843_D(int p_72843_1_, int p_72843_2_, int p_72843_3_)
-@@ -3598,7 +3748,7 @@
+@@ -3598,7 +3772,7 @@
      @SideOnly(Side.CLIENT)
      public double func_72919_O()
      {
@@ -753,7 +804,7 @@
      }
  
      public CrashReportCategory func_72914_a(CrashReport p_72914_1_)
-@@ -3663,25 +3813,24 @@
+@@ -3663,25 +3837,24 @@
  
      public void func_147453_f(int p_147453_1_, int p_147453_2_, int p_147453_3_, Block p_147453_4_)
      {
@@ -792,7 +843,7 @@
                  }
              }
          }
-@@ -3722,4 +3871,110 @@
+@@ -3722,4 +3895,110 @@
              iworldaccess.func_147584_b();
          }
      }

--- a/patches/minecraft/net/minecraft/world/WorldProvider.java.patch
+++ b/patches/minecraft/net/minecraft/world/WorldProvider.java.patch
@@ -42,7 +42,7 @@
      }
  
      @SideOnly(Side.CLIENT)
-@@ -193,4 +201,285 @@
+@@ -193,4 +201,320 @@
      }
  
      public abstract String func_80007_l();
@@ -214,6 +214,29 @@
 +    {
 +        return field_76579_a.field_73008_k < 4;
 +    }
++    
++    /**
++     * The current sun brightness factor for this dimension.
++     * 0.0f means no light at all, and 1.0f means maximum sunlight.
++     * This will be used for the "calculateSkylightSubtracted"
++     * which is for Sky light value calculation.
++     * 
++     * @return The current brightness factor
++     * */
++    public float getSunBrightnessFactor(float par1)
++    {
++        return field_76579_a.getSunBrightnessFactor(par1);
++    }
++    
++    /**
++     * Calculates the current moon phase factor.
++     * This factor is effective for slimes.
++     * (This method do not affect the moon rendering)
++     * */
++    public float getCurrentMoonPhaseFactor()
++    {
++        return field_76579_a.getCurrentMoonPhaseFactorBody();
++    }
 +
 +    @SideOnly(Side.CLIENT)
 +    public Vec3 getSkyColor(Entity cameraEntity, float partialTicks)
@@ -227,6 +250,18 @@
 +        return field_76579_a.drawCloudsBody(partialTicks);
 +    }
 +
++    /**
++     * Gets the Sun Brightness for rendering sky.
++     * */
++    @SideOnly(Side.CLIENT)
++    public float getSunBrightness(float par1)
++    {
++        return field_76579_a.getSunBrightnessBody(par1);
++    }
++    
++    /**
++     * Gets the Star Brightness for rendering sky.
++     * */
 +    @SideOnly(Side.CLIENT)
 +    public float getStarBrightness(float par1)
 +    {

--- a/src/main/resources/forge.exc
+++ b/src/main/resources/forge.exc
@@ -6,6 +6,8 @@ net/minecraft/client/renderer/entity/RenderItem.renderItemIntoGUI(Lnet/minecraft
 net/minecraft/server/management/ServerConfigurationManager.transferPlayerToDimension(Lnet/minecraft/entity/player/EntityPlayerMP;ILnet/minecraft/world/Teleporter;)V=|p_72356_1_,p_72356_2_,teleporter
 net/minecraft/server/management/ServerConfigurationManager.transferEntityToWorld(Lnet/minecraft/entity/Entity;ILnet/minecraft/world/WorldServer;Lnet/minecraft/world/WorldServer;Lnet/minecraft/world/Teleporter;)V=|p_82448_1_,p_82448_2_,p_82448_3_,p_82448_4_,teleporter
 net/minecraft/world/World.getBiomeGenForCoordsBody(II)Lnet/minecraft/world/biome/BiomeGenBase;=|p_72807_1_,p_72807_2_
+net/minecraft/world/World.getSunBrightnessFactor(F)F=|p_72967_1_
+net/minecraft/world/World.getSunBrightnessBody(F)F=|p_72971_1_
 net/minecraft/world/World.getSkyColorBody(Lnet/minecraft/entity/Entity;F)Lnet/minecraft/util/Vec3;=|p_72833_1_,p_72833_2_
 net/minecraft/world/World.drawCloudsBody(F)Lnet/minecraft/util/Vec3;=|p_72824_1_
 net/minecraft/world/World.canBlockFreezeBody(IIIZ)Z=|p_72834_1_,p_72834_2_,p_72834_3_,p_72834_4_


### PR DESCRIPTION
World Hooks on sky light, which can provide sunlight / moon factor from the Worldprovider.
mainly for Solar/Lunar Eclipse.

getSunBrightnessFactor is for getting sun brightness, i think it is better than just using getCelestialAngle.. I don't see any problem on it.
