### PR TITLE
Fixed wrong method call in ChunkIOProvider.

### DIFF
--- a/src/main/java/net/minecraftforge/common/chunkio/ChunkIOProvider.java
+++ b/src/main/java/net/minecraftforge/common/chunkio/ChunkIOProvider.java
@@ -34,7 +34,7 @@ class ChunkIOProvider implements AsynchronousExecutor.CallBackProvider<QueuedChu
     public void callStage2(QueuedChunk queuedChunk, net.minecraft.world.chunk.Chunk chunk) throws RuntimeException {
         if(chunk == null) {
             // If the chunk loading failed just do it synchronously (may generate)
-            queuedChunk.provider.loadChunk(queuedChunk.x, queuedChunk.z);
+            queuedChunk.provider.originalLoadChunk(queuedChunk.x, queuedChunk.z);
             return;
         }
 


### PR DESCRIPTION
When a chunk fails to load async, we fallback to the original sync method.
In this case, it was calling the async method twice which ended up causing
a stackoverflow.
