### PR TITLE
ExtendedBiomeDictionary?

### DIFF
--- a/src/main/java/net/minecraftforge/common/BiomeDictionary.java
+++ b/src/main/java/net/minecraftforge/common/BiomeDictionary.java
@@ -12,7 +12,7 @@ public class BiomeDictionary
 {
     public enum Type
     {
-        DECIDUOUSFOREST,  /*Drier forests with aging/dying trees, is manually defined*/
+        DECIDUOUSFOREST,  /*Drier forests with aging/dying trees*/
         TAIGA,  /*The taiga is treated as its own biome group due to all the taiga variants and the existence of cold taigas*/
         RAINFOREST, /*Dense vegetation and high humidity + heat, but lacking the elements associeated with jungles like the cocoa beans or jungle wood*/
         MARSH /*Similiar traits to swamps like many lakes of water and damp grass, but lacks trees*/
@@ -20,7 +20,7 @@ public class BiomeDictionary
         GROVE, /*Temperate biomes with less trees thatn a forest, but a more trees than a plain*/
         MESA,  /*Defined by the use of hard clay blocks in world gen*/
         SAVANNA, /*Hot, relatively flat biomes with acacia trees*/
-        TROPICAL, /*Biomes that make use of palm trees and lush grass, is manually defined*/
+        TROPICAL, /*Biomes that make use of palm trees and lush grass*/
         FOREST,
         PLAINS,
         MOUNTAIN,


### PR DESCRIPTION
I was requested to submit a PR, so I did.

With 1.7.2 a new biome dictionary is needed in order to accommodate the new biomes.  Savannah and Mesa pretty much need their own categories.  Taigas, due to their diversity also got their own category.

Along with that, there are multiple biome adding mods like Highlands, Biomes O Plenty, Natural Biomes, Better World Gen 4, BiomesXL and so on that usually add similar sets of biomes. So I figured that perhaps more definitions would be good in order to keep stuff like mob and structure spawns more diverse in the over world and hopefully avoid too much weirdness like Ostriches spawning in the mesa or a pack of elephants in the middle of a plain full of sun flowers.

There's a several new definitions I added mainly for biome adding mods, give or take.  

I also made a attempt at making the register try to find biomes in the new categories I added, but I doubt it works.  For instance I wanted to define mesa biomes by checking if the biome is hot and generates hardened clay, but being new to coding I just left a comment with the block ID.

Original thread [ignore the different definitions]:

http://www.minecraftforge.net/forum/index.php/topic,19610.0.html

quick link to the modified config:

https://github.com/oZode/MinecraftForge/blob/master/src/main/java/net/minecraftforge/common/BiomeDictionary.java
