### PR TITLE
Added hook for potion inventory icons

### DIFF
--- a/patches/minecraft/net/minecraft/client/renderer/InventoryEffectRenderer.java.patch
+++ b/patches/minecraft/net/minecraft/client/renderer/InventoryEffectRenderer.java.patch
@@ -1,0 +1,11 @@
+--- ../src-base/minecraft/net/minecraft/client/renderer/InventoryEffectRenderer.java
++++ ../src-work/minecraft/net/minecraft/client/renderer/InventoryEffectRenderer.java
+@@ -75,6 +75,8 @@
+                     this.func_73729_b(i + 6, j + 7, 0 + l % 8 * 18, 198 + l / 8 * 18, 18, 18);
+                 }
+ 
++                potion.renderInventoryEffect(i, j, potioneffect, field_146297_k);
++                if (!potion.shouldRenderInvText(potioneffect)) continue;
+                 String s1 = I18n.func_135052_a(potion.func_76393_a(), new Object[0]);
+ 
+                 if (potioneffect.func_76458_c() == 1)

--- a/patches/minecraft/net/minecraft/potion/Potion.java.patch
+++ b/patches/minecraft/net/minecraft/potion/Potion.java.patch
@@ -1,0 +1,30 @@
+--- ../src-base/minecraft/net/minecraft/potion/Potion.java
++++ ../src-work/minecraft/net/minecraft/potion/Potion.java
+@@ -307,4 +307,27 @@
+     {
+         return p_111183_2_.func_111164_d() * (double)(p_111183_1_ + 1);
+     }
++    
++    /* ======================================== FORGE START =====================================*/
++    
++    /**
++     * If the standard PotionEffect text (name and duration) should be drawn when this potion is active. 
++     * @param effect the active PotionEffect
++     * @return true to draw the standard text
++     */
++    public boolean shouldRenderInvText(PotionEffect effect)
++    {
++        return true;
++    }
++    
++    /**
++     * Called to draw the this Potion onto the player's inventory when it's active.
++     * This can be used to e.g. render Potion icons from your own texture.
++     * @param x the x coordinate
++     * @param y the y coordinate
++     * @param effect the active PotionEffect
++     * @param mc the Minecraft instance, for convenience
++     */
++    @SideOnly(Side.CLIENT)
++    public void renderInventoryEffect(int x, int y, PotionEffect effect, net.minecraft.client.Minecraft mc) { }
+ }


### PR DESCRIPTION
Allow mods to draw the inventory icon for potions from their own texture without having to bind a texture in `hasStatusIcon` (it's just an ugly hack).
(As kinda discussed on IRC).
