### PR TITLE
Add AchievementEvent

### DIFF
--- a/patches/minecraft/net/minecraft/entity/player/EntityPlayerMP.java.patch
+++ b/patches/minecraft/net/minecraft/entity/player/EntityPlayerMP.java.patch
@@ -96,7 +96,15 @@
          }
  
          Collection collection = this.field_70170_p.func_96441_U().func_96520_a(IScoreObjectiveCriteria.field_96642_c);
-@@ -1021,4 +1035,16 @@
+@@ -806,6 +820,7 @@
+     {
+         if (p_71064_1_ != null)
+         {
++            if (p_71064_1_.func_75967_d() && MinecraftForge.EVENT_BUS.post(new net.minecraftforge.event.entity.player.AchievementEvent(this, (net.minecraft.stats.Achievement) p_71064_1_))) return;
+             this.field_147103_bO.func_150871_b(this, p_71064_1_, p_71064_2_);
+             Iterator iterator = this.func_96123_co().func_96520_a(p_71064_1_.func_150952_k()).iterator();
+ 
+@@ -1021,4 +1036,16 @@
      {
          return this.field_143005_bX;
      }

--- a/src/main/java/net/minecraftforge/event/entity/player/AchievementEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/player/AchievementEvent.java
@@ -1,0 +1,20 @@
+package net.minecraftforge.event.entity.player;
+
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.stats.Achievement;
+import cpw.mods.fml.common.eventhandler.Cancelable;
+import cpw.mods.fml.common.eventhandler.Event;
+
+/**
+ * When the player receives an achievement. If canceled the player will not receive anything.
+ */
+@Cancelable
+public class AchievementEvent extends PlayerEvent {
+
+    public final Achievement achievement;
+    public AchievementEvent(EntityPlayer player, Achievement achievement)
+    {
+        super(player);
+        this.achievement = achievement;
+    }
+}


### PR DESCRIPTION
Allows modders to react to players receiving achievements, and cancel
them.

Only fired serverside, in EntityPlayerMP.
