### PR TITLE
Client-side implementation of PlayerEvent.StartTracking and .StopTracking

### DIFF
--- a/patches/minecraft/net/minecraft/client/multiplayer/WorldClient.java.patch
+++ b/patches/minecraft/net/minecraft/client/multiplayer/WorldClient.java.patch
@@ -23,7 +23,24 @@
      }
  
      public void func_72835_b()
-@@ -261,6 +267,12 @@
+@@ -228,6 +234,7 @@
+         {
+             this.field_73037_M.field_71438_f.func_147584_b();
+         }
++        net.minecraftforge.event.ForgeEventFactory.onStartEntityTracking(p_73027_2_, field_73037_M.field_71439_g);
+     }
+ 
+     public Entity func_73045_a(int p_73045_1_)
+@@ -244,7 +251,7 @@
+             this.field_73032_d.remove(entity);
+             this.func_72900_e(entity);
+         }
+-
++        net.minecraftforge.event.ForgeEventFactory.onStopEntityTracking(entity, field_73037_M.field_71439_g);
+         return entity;
+     }
+ 
+@@ -261,6 +268,12 @@
  
      protected void func_72979_l()
      {


### PR DESCRIPTION
```
net.minecraftforge.event.entity.player.PlayerEvent.StartTracking
net.minecraftforge.event.entity.player.PlayerEvent.StopTracking
```

The events should trigger if an Entity is added to or removed from a client's world. This happens for example when the player enters or leaves the tracking radius of an Entity.

At the moment there is no client-side implementation for this event.

**PlayerEvent.StartTracking can be generated in:**
`net.minecraft.client.multiplayer.WorldClient.addEntityToWorld(int, Entity)`
It is called when one of the following packets is handled by the client:

```
S0CPacketSpawnPlayer
S0EPacketSpawnObject
S0FPacketSpawnMob
S10PacketSpawnPainting
S11PacketSpawnExperienceOrb
```

**PlayerEvent.StopTracking can be generated in:**
`net.minecraft.client.multiplayer.WorldClient.removeEntityFromWorld(int)`
It is called when one of the following packets is handled by the client:

```
S0DPacketCollectItem
S13PacketDestroyEntities
```

**I have tested this PR using the following test mod:**
https://gist.github.com/nairol/acea686439944e58c0f7
