### PR TITLE
Added BiomeSpecificOreGenEvent 

### DIFF
--- a/patches/minecraft/net/minecraft/world/biome/BiomeGenHills.java.patch
+++ b/patches/minecraft/net/minecraft/world/biome/BiomeGenHills.java.patch
@@ -1,11 +1,23 @@
 --- ../src-base/minecraft/net/minecraft/world/biome/BiomeGenHills.java
 +++ ../src-work/minecraft/net/minecraft/world/biome/BiomeGenHills.java
-@@ -55,7 +55,7 @@
+@@ -48,16 +48,16 @@
+         int l;
+         int i1;
+         int j1;
+-
+-        for (l = 0; l < k; ++l)
++        net.minecraftforge.event.terraingen.BiomeSpecificOreGenEvent event = net.minecraftforge.event.terraingen.TerrainGen.generateBiomeSpecificOre(p_76728_1_, p_76728_2_, p_76728_3_, p_76728_4_, Blocks.field_150412_bA);
++        for (l = 0; event.getResult() != cpw.mods.fml.common.eventhandler.Event.Result.DENY && l < k; ++l)
+         {
+             i1 = p_76728_3_ + p_76728_2_.nextInt(16);
              j1 = p_76728_2_.nextInt(28) + 4;
              int k1 = p_76728_4_ + p_76728_2_.nextInt(16);
  
 -            if (p_76728_1_.func_147439_a(i1, j1, k1) == Blocks.field_150348_b)
 +            if (p_76728_1_.func_147439_a(i1, j1, k1).isReplaceableOreGen(p_76728_1_, i1, j1, k1, Blocks.field_150348_b))
              {
-                 p_76728_1_.func_147465_d(i1, j1, k1, Blocks.field_150412_bA, 0, 2);
+-                p_76728_1_.func_147465_d(i1, j1, k1, Blocks.field_150412_bA, 0, 2);
++                p_76728_1_.func_147465_d(i1, j1, k1, event.block, 0, 2);
              }
+         }
+ 

--- a/src/main/java/net/minecraftforge/event/terraingen/BiomeSpecificOreGenEvent.java
+++ b/src/main/java/net/minecraftforge/event/terraingen/BiomeSpecificOreGenEvent.java
@@ -1,0 +1,34 @@
+package net.minecraftforge.event.terraingen;
+
+import java.util.Random;
+
+import net.minecraft.block.Block;
+import net.minecraft.world.World;
+import net.minecraft.world.biome.BiomeGenHills;
+import cpw.mods.fml.common.eventhandler.Cancelable;
+import cpw.mods.fml.common.eventhandler.Event.HasResult;
+
+/**
+ * BiomeSpecificOreGenEvent is fired whenever biome-specific ore is set to be generated. <br> 
+ * This event is fired during the invocation of BiomeGenHills#decorate(World, Random, int, int) for Emeralds by default. <br>
+ * <br>
+ * {@link #block} contains the Block that is attempting to be generated.<br>
+ * <br>
+ * This event is not {@link Cancelable}. <br>
+ * <br>
+ * This event has a result. {@link HasResult}<br>
+ * Changing this result to {@link Result#DENY} causes nothing to be generated. <br>
+ * <br>
+ * This event is fired on the {@link MinecraftForge#ORE_GEN_BUS}.<br>
+ **/
+@HasResult
+public class BiomeSpecificOreGenEvent extends OreGenEvent 
+{
+    public Block block;
+    
+    public BiomeSpecificOreGenEvent(World world, Random rand, int worldX, int worldZ, Block block)
+    {
+        super(world, rand, worldX, worldZ);
+        this.block = block;
+    }
+}

--- a/src/main/java/net/minecraftforge/event/terraingen/TerrainGen.java
+++ b/src/main/java/net/minecraftforge/event/terraingen/TerrainGen.java
@@ -4,6 +4,7 @@ import java.util.Random;
 
 import cpw.mods.fml.common.eventhandler.Event.*;
 
+import net.minecraft.block.Block;
 import net.minecraft.world.World;
 import net.minecraft.world.chunk.IChunkProvider;
 import net.minecraft.world.gen.MapGenBase;
@@ -56,5 +57,12 @@ public abstract class TerrainGen
         SaplingGrowTreeEvent event = new SaplingGrowTreeEvent(world, rand, x, y, z);
         MinecraftForge.TERRAIN_GEN_BUS.post(event);
         return event.getResult() != Result.DENY;
+    }
+
+    public static BiomeSpecificOreGenEvent generateBiomeSpecificOre(World world, Random rand, int worldX, int worldY, Block ore)
+    {
+        BiomeSpecificOreGenEvent event = new BiomeSpecificOreGenEvent(world, rand, worldX, worldY, ore);
+        MinecraftForge.ORE_GEN_BUS.post(event);
+        return event;
     }
 }


### PR DESCRIPTION
As of now, this event is simply used for Emerald generation in reference to #1158. I wasn't exactly sure if this is what was intended by Lex's last comment of "need to find a different event to figure it," so this is what  I quickly put together. If this isn't what you meant or if you wanted to reuse the GenerateMineable event (or obviously, if you wanted this implemented in a different way) just let me know. I think I kept the patch as minimalistic as possible, but if you see a way that I could reduce it further, again, just let me know. 

A simple example mod utilizing this event can be found here: http://pastebin.com/xgRzH8p4
