### PR TITLE
Prevent client only commands from bleeding through to the server.

### DIFF
--- a/patches/minecraft/net/minecraft/client/gui/GuiChat.java.patch
+++ b/patches/minecraft/net/minecraft/client/gui/GuiChat.java.patch
@@ -4,7 +4,7 @@
      public void func_146403_a(String p_146403_1_)
      {
          this.field_146297_k.field_71456_v.func_146158_b().func_146239_a(p_146403_1_);
-+        if (net.minecraftforge.client.ClientCommandHandler.instance.func_71556_a(field_146297_k.field_71439_g, p_146403_1_) == 1) return;
++        if (net.minecraftforge.client.ClientCommandHandler.instance.func_71556_a(field_146297_k.field_71439_g, p_146403_1_) != 0) return;
          this.field_146297_k.field_71439_g.func_71165_d(p_146403_1_);
      }
  

--- a/src/main/java/net/minecraftforge/client/ClientCommandHandler.java
+++ b/src/main/java/net/minecraftforge/client/ClientCommandHandler.java
@@ -31,8 +31,8 @@ public class ClientCommandHandler extends CommandHandler
     public String[] latestAutoComplete = null;
 
     /**
-     * @return 1 if successfully executed, 0 if wrong usage, it doesn't exist or
-     *         it was canceled.
+     * @return 1 if successfully executed, -1 if no permission or wrong usage,
+     *         0 if it doesn't exist or it was canceled (it's sent to the server)
      */
     @Override
     public int executeCommand(ICommandSender sender, String message)
@@ -91,7 +91,7 @@ public class ClientCommandHandler extends CommandHandler
             t.printStackTrace();
         }
 
-        return 0;
+        return -1;
     }
 
     //Couple of helpers because the mcp names are stupid and long...


### PR DESCRIPTION
With this change client side commands should only bleed through to the server if the command doesn't exist on the client OR when `CommandEvent` is canceled (return value != 1).

Fixes the following bug: http://puu.sh/a6qAS.png
