### PR TITLE
Added an event to change the amount of experience an entity drops

### DIFF
--- a/patches/minecraft/net/minecraft/entity/EntityLivingBase.java.patch
+++ b/patches/minecraft/net/minecraft/entity/EntityLivingBase.java.patch
@@ -25,6 +25,15 @@
              {
                  this.func_70078_a((Entity)null);
              }
+@@ -313,7 +315,7 @@
+             if (!this.field_70170_p.field_72995_K && (this.field_70718_bc > 0 || this.func_70684_aJ()) && this.func_146066_aG() && this.field_70170_p.func_82736_K().func_82766_b("doMobLoot"))
+             {
+                 i = this.func_70693_a(this.field_70717_bb);
+-
++                i = net.minecraftforge.event.ForgeEventFactory.getExperienceDrop(this, this.field_70717_bb, i);
+                 while (i > 0)
+                 {
+                     int j = EntityXPOrb.func_70527_a(i);
 @@ -374,6 +376,7 @@
      {
          this.field_70755_b = p_70604_1_;

--- a/src/main/java/net/minecraftforge/event/ForgeEventFactory.java
+++ b/src/main/java/net/minecraftforge/event/ForgeEventFactory.java
@@ -22,6 +22,7 @@ import net.minecraft.world.storage.IPlayerFileData;
 import net.minecraft.world.storage.SaveHandler;
 import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.event.entity.EntityStruckByLightningEvent;
+import net.minecraftforge.event.entity.living.LivingExperienceEvent;
 import net.minecraftforge.event.entity.living.LivingPackSizeEvent;
 import net.minecraftforge.event.entity.living.LivingSpawnEvent;
 import net.minecraftforge.event.entity.living.LivingSpawnEvent.AllowDespawn;
@@ -90,6 +91,13 @@ public class ForgeEventFactory
         AllowDespawn event = new AllowDespawn(entity);
         MinecraftForge.EVENT_BUS.post(event);
         return event.getResult();
+    }
+    
+    public static int getExperienceDrop(EntityLivingBase entity, EntityPlayer attackingPlayer, int originalExperience)
+    {
+        LivingExperienceEvent event = new LivingExperienceEvent(entity, attackingPlayer, originalExperience);
+        MinecraftForge.EVENT_BUS.post(event);
+        return event.experience;
     }
 
     public static List<BiomeGenBase.SpawnListEntry> getPotentialSpawns(WorldServer world, EnumCreatureType type, int x, int y, int z, List<BiomeGenBase.SpawnListEntry> oldList)

--- a/src/main/java/net/minecraftforge/event/entity/living/LivingExperienceEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/living/LivingExperienceEvent.java
@@ -1,0 +1,21 @@
+package net.minecraftforge.event.entity.living;
+
+import cpw.mods.fml.common.eventhandler.Cancelable;
+import net.minecraft.entity.EntityLivingBase;
+import net.minecraft.entity.player.EntityPlayer;
+
+public class LivingExperienceEvent extends LivingEvent 
+{
+    public final int originalExperience;
+    public final EntityPlayer attackingPlayer;
+    
+    public int experience;
+    
+    public LivingExperienceEvent(EntityLivingBase entity, EntityPlayer attackingPlayer, int originalExperience)
+    {
+        super(entity);
+        
+        this.originalExperience = this.experience = originalExperience;
+        this.attackingPlayer = attackingPlayer;
+    }
+}


### PR DESCRIPTION
Lex, you told me that there was a way to do this without an event you didn't told me what that was though :P

The experienceValue field is not respected by every entity and you also don't get access to the "original" experience value. 

The only other thing i can think of is to check for xp orb spawns and then reflect on the stacktrace to find the entity that drops them, that will cause problems though if multiple mods try to do that.



