### PR TITLE
Added CheckBreedingEvent

### DIFF
--- a/patches/minecraft/net/minecraft/entity/passive/EntityAnimal.java.patch
+++ b/patches/minecraft/net/minecraft/entity/passive/EntityAnimal.java.patch
@@ -1,0 +1,11 @@
+--- ../src-base/minecraft/net/minecraft/entity/passive/EntityAnimal.java
++++ ../src-work/minecraft/net/minecraft/entity/passive/EntityAnimal.java
+@@ -313,7 +313,7 @@
+     {
+         ItemStack itemstack = p_70085_1_.field_71071_by.func_70448_g();
+ 
+-        if (itemstack != null && this.func_70877_b(itemstack) && this.func_70874_b() == 0 && this.field_70881_d <= 0)
++        if (itemstack != null && net.minecraftforge.event.ForgeEventFactory.isBreedingItem(this, itemstack, this.func_70877_b(itemstack)) && this.func_70874_b() == 0 && this.field_70881_d <= 0)
+         {
+             if (!p_70085_1_.field_71075_bZ.field_75098_d)
+             {

--- a/src/main/java/net/minecraftforge/event/ForgeEventFactory.java
+++ b/src/main/java/net/minecraftforge/event/ForgeEventFactory.java
@@ -12,8 +12,8 @@ import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.entity.EnumCreatureType;
 import net.minecraft.entity.effect.EntityLightningBolt;
 import net.minecraft.entity.monster.EntityZombie;
+import net.minecraft.entity.passive.EntityAnimal;
 import net.minecraft.entity.player.EntityPlayer;
-import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraft.item.ItemStack;
 import net.minecraft.world.World;
 import net.minecraft.world.WorldServer;
@@ -22,6 +22,7 @@ import net.minecraft.world.storage.IPlayerFileData;
 import net.minecraft.world.storage.SaveHandler;
 import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.event.entity.EntityStruckByLightningEvent;
+import net.minecraftforge.event.entity.living.CheckBreedingItemEvent;
 import net.minecraftforge.event.entity.living.LivingPackSizeEvent;
 import net.minecraftforge.event.entity.living.LivingSpawnEvent;
 import net.minecraftforge.event.entity.living.LivingSpawnEvent.AllowDespawn;
@@ -37,6 +38,13 @@ import net.minecraftforge.event.world.WorldEvent;
 
 public class ForgeEventFactory
 {
+    public static boolean isBreedingItem(EntityAnimal entity, ItemStack stack, boolean isBreedingItem)
+    {
+        CheckBreedingItemEvent event = new CheckBreedingItemEvent(entity, stack, isBreedingItem);
+        MinecraftForge.EVENT_BUS.post(event);
+        return event.isBreedingItem;
+    }
+    
     public static boolean doPlayerHarvestCheck(EntityPlayer player, Block block, boolean success)
     {
         PlayerEvent.HarvestCheck event = new PlayerEvent.HarvestCheck(player, block, success);

--- a/src/main/java/net/minecraftforge/event/entity/living/CheckBreedingItemEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/living/CheckBreedingItemEvent.java
@@ -1,0 +1,38 @@
+package net.minecraftforge.event.entity.living;
+
+import net.minecraft.entity.passive.EntityAnimal;
+import net.minecraft.item.ItemStack;
+import net.minecraftforge.common.MinecraftForge;
+import net.minecraftforge.event.ForgeEventFactory;
+import cpw.mods.fml.common.eventhandler.Cancelable;
+
+/**
+ * CheckBreedingItemEvent is fired when an EntityAnimal is right-clicked with a potential breeding item. <br>
+ * This event is fired whenever an EntityAnimal is right-clicked by a player in 
+ * EntityAnimal#interact(EntityPlayer).<br>
+ * <br>
+ * This event is fired via the {@link ForgeEventFactory#isBreedingItem(EntityAnimal, ItemStack, boolean)}.<br>
+ * <br>
+ * {@link #isBreedingItem} contains the boolean for whether the item in {@link #stack} is a valid breeding item. <br>
+ * <br>
+ * This event does not get called if {@link #stack} is null.<br>
+ * <br>
+ * This event does not have a result. {@link HasResult}<br>
+ * <br>
+ * This event will not make the entity tempt {@link #stack}.
+ * You could do that by adding the {@link EntityAITempt} AI task whenever an entity of the desired type joins the world. {@link EntityJoinWorldEvent}<br>  
+ * <br>
+ * This event is fired on the {@link MinecraftForge#EVENT_BUS}.
+ **/
+public class CheckBreedingItemEvent extends LivingEvent
+{
+    public boolean isBreedingItem;
+    public final ItemStack stack;
+    
+    public CheckBreedingItemEvent(EntityAnimal entity, ItemStack stack, boolean isBreedingItem)
+    {
+        super(entity);
+        this.stack = stack;
+        this.isBreedingItem = isBreedingItem;
+    }
+}


### PR DESCRIPTION
Allows for mods to make any item useable for breeding.
Does not make the item tempt the animal. I'd recommend using the event EntityJoinWorld and adding the AI task to the entity. I tested it and it worked perfectly for me.

Here's a simple mod used to demonstrate CheckBreedingEvent:
http://pastebin.com/4FyTPafQ
