### PR TITLE
Fixed missing assignment of constructor arg (thanks @Lunatrius)

### DIFF
--- a/src/main/java/net/minecraftforge/common/config/Configuration.java
+++ b/src/main/java/net/minecraftforge/common/config/Configuration.java
@@ -93,6 +93,7 @@ public class Configuration
     public Configuration(File file, String configVersion)
     {
         this.file = file;
+        this.definedConfigVersion = configVersion;
         String basePath = ((File)(FMLInjectionData.data()[6])).getAbsolutePath().replace(File.separatorChar, '/').replace("/.", "");
         String path = file.getAbsolutePath().replace(File.separatorChar, '/').replace("/./", "/").replace(basePath, "");
         if (PARENT != null)


### PR DESCRIPTION
I must have edited this out when I was cleaning up my formatting commit spam.
