### PR TITLE
Changed exception message for duplicate enchantment ids

### DIFF
--- a/patches/minecraft/net/minecraft/enchantment/Enchantment.java.patch
+++ b/patches/minecraft/net/minecraft/enchantment/Enchantment.java.patch
@@ -1,5 +1,14 @@
 --- ../src-base/minecraft/net/minecraft/enchantment/Enchantment.java
 +++ ../src-work/minecraft/net/minecraft/enchantment/Enchantment.java
+@@ -50,7 +50,7 @@
+ 
+         if (field_77331_b[p_i1926_1_] != null)
+         {
+-            throw new IllegalArgumentException("Duplicate enchantment id!");
++            throw new IllegalArgumentException("Duplicate enchantment id! " + this.getClass() + " and " + field_77331_b[p_i1926_1_].getClass() + " Enchantment ID:" + p_i1926_1_);
+         }
+         else
+         {
 @@ -124,6 +124,45 @@
  
      public void func_151367_b(EntityLivingBase p_151367_1_, Entity p_151367_2_, int p_151367_3_) {}


### PR DESCRIPTION
The exception message for duplicated enchantment ids contains both the class path to both enchantments and the enchantment id in question. 

Example exception message: Duplicate enchantment id! class net.darkhax.testmod.enchantment.TestEnchantment and class net.minecraft.enchantment.EnchantmentWaterWorker Enchantment ID:6

A test mod for this can be found [here](https://dl.dropboxusercontent.com/u/38575752/files/examples/Duplicated%20Enchantmend%20ID%20Test%20Mod.jar) both compiled and src versions are within the jar. 
