### PR TITLE
Added a new PistonPushEvent

### DIFF
--- a/patches/minecraft/net/minecraft/block/BlockPistonBase.java.patch
+++ b/patches/minecraft/net/minecraft/block/BlockPistonBase.java.patch
@@ -8,17 +8,34 @@
  import net.minecraft.tileentity.TileEntity;
  import net.minecraft.tileentity.TileEntityPiston;
  import net.minecraft.util.AxisAlignedBB;
-@@ -360,7 +361,8 @@
+@@ -127,7 +128,7 @@
+ 
+             if (flag && !func_150075_c(l))
+             {
+-                if (func_150077_h(p_150078_1_, p_150078_2_, p_150078_3_, p_150078_4_, i1))
++                if (func_150077_h(p_150078_1_, p_150078_2_, p_150078_3_, p_150078_4_, i1) && !net.minecraftforge.event.ForgeEventFactory.onPistonPushEvent(p_150078_1_, p_150078_2_, p_150078_3_, p_150078_4_, i1))
+                 {
+                     p_150078_1_.func_147452_c(p_150078_2_, p_150078_3_, p_150078_4_, this, 0, i1);
+                 }
+@@ -212,7 +213,7 @@
+                     }
+                 }
+ 
+-                if (!flag1 && block.func_149688_o() != Material.field_151579_a && func_150080_a(block, p_149696_1_, j1, k1, l1, false) && (block.func_149656_h() == 0 || block == Blocks.field_150331_J || block == Blocks.field_150320_F))
++                if (!flag1 && block.func_149688_o() != Material.field_151579_a && func_150080_a(block, p_149696_1_, j1, k1, l1, false) && (block.func_149656_h() == 0 || block == Blocks.field_150331_J || block == Blocks.field_150320_F) && !net.minecraftforge.event.ForgeEventFactory.onPistonRetractEvent(p_149696_1_, p_149696_2_, p_149696_3_, p_149696_4_, i2))
+                 {
+                     p_149696_2_ += Facing.field_71586_b[p_149696_6_];
+                     p_149696_3_ += Facing.field_71587_c[p_149696_6_];
+@@ -360,7 +361,7 @@
                  return false;
              }
  
 -            return !(p_150080_0_ instanceof ITileEntityProvider);
 +            return !(p_150080_1_.func_147439_a(p_150080_2_, p_150080_3_, p_150080_4_).hasTileEntity(p_150080_1_.func_72805_g(p_150080_2_, p_150080_3_, p_150080_4_)));
-+            
          }
      }
  
-@@ -375,14 +377,14 @@
+@@ -375,14 +376,14 @@
          {
              if (l1 < 13)
              {
@@ -35,7 +52,7 @@
                  {
                      if (!func_150080_a(block, p_150077_0_, i1, j1, k1, true))
                      {
-@@ -420,14 +422,14 @@
+@@ -420,14 +421,14 @@
          {
              if (l1 < 13)
              {
@@ -52,7 +69,7 @@
                  {
                      if (!func_150080_a(block, p_150079_1_, i1, j1, k1, true))
                      {
-@@ -448,7 +450,9 @@
+@@ -448,7 +449,9 @@
                          continue;
                      }
  

--- a/src/main/java/net/minecraftforge/event/ForgeEventFactory.java
+++ b/src/main/java/net/minecraftforge/event/ForgeEventFactory.java
@@ -3,8 +3,6 @@ package net.minecraftforge.event;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
-import cpw.mods.fml.common.ObfuscationReflectionHelper;
-import cpw.mods.fml.common.eventhandler.Event.Result;
 import net.minecraft.block.Block;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.EntityLiving;
@@ -13,7 +11,6 @@ import net.minecraft.entity.EnumCreatureType;
 import net.minecraft.entity.effect.EntityLightningBolt;
 import net.minecraft.entity.monster.EntityZombie;
 import net.minecraft.entity.player.EntityPlayer;
-import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraft.item.ItemStack;
 import net.minecraft.world.World;
 import net.minecraft.world.WorldServer;
@@ -21,6 +18,7 @@ import net.minecraft.world.biome.BiomeGenBase;
 import net.minecraft.world.storage.IPlayerFileData;
 import net.minecraft.world.storage.SaveHandler;
 import net.minecraftforge.common.MinecraftForge;
+import net.minecraftforge.common.util.ForgeDirection;
 import net.minecraftforge.event.entity.EntityStruckByLightningEvent;
 import net.minecraftforge.event.entity.living.LivingPackSizeEvent;
 import net.minecraftforge.event.entity.living.LivingSpawnEvent;
@@ -33,7 +31,11 @@ import net.minecraftforge.event.entity.player.PlayerInteractEvent;
 import net.minecraftforge.event.entity.player.PlayerInteractEvent.Action;
 import net.minecraftforge.event.entity.player.PlayerUseItemEvent;
 import net.minecraftforge.event.world.BlockEvent;
+import net.minecraftforge.event.world.PistonEvent.PistonExtendEvent;
+import net.minecraftforge.event.world.PistonEvent.PistonRetractEvent;
 import net.minecraftforge.event.world.WorldEvent;
+import cpw.mods.fml.common.ObfuscationReflectionHelper;
+import cpw.mods.fml.common.eventhandler.Event.Result;
 
 public class ForgeEventFactory
 {
@@ -191,5 +193,23 @@ public class ForgeEventFactory
         SaveHandler sh = (SaveHandler) playerFileData;
         File dir = ObfuscationReflectionHelper.getPrivateValue(SaveHandler.class, sh, "playersDirectory", "field_"+"75771_c");
         MinecraftForge.EVENT_BUS.post(new PlayerEvent.LoadFromFile(player, dir, uuidString));
+    }
+    
+    public static boolean onPistonPushEvent(World world, int x, int y, int z, int pistonOrientation)
+    {
+        ForgeDirection direction = ForgeDirection.getOrientation(pistonOrientation);
+                
+        PistonExtendEvent e = new PistonExtendEvent(world, x, y, z, direction, world.getBlock(x + direction.offsetX, y + direction.offsetY, z + direction.offsetZ));
+        MinecraftForge.EVENT_BUS.post(e);
+        return e.isCanceled();
+    }
+    
+    public static boolean onPistonRetractEvent(World world, int x, int y, int z, int pistonOrientation)
+    {
+        ForgeDirection direction = ForgeDirection.getOrientation(pistonOrientation);
+                
+        PistonRetractEvent e = new PistonRetractEvent(world, x, y, z, direction, world.getBlock(x + direction.offsetX, y + direction.offsetY, z + direction.offsetZ));
+        MinecraftForge.EVENT_BUS.post(e);
+        return e.isCanceled();
     }
 }

--- a/src/main/java/net/minecraftforge/event/world/PistonEvent.java
+++ b/src/main/java/net/minecraftforge/event/world/PistonEvent.java
@@ -1,0 +1,45 @@
+package net.minecraftforge.event.world;
+
+import cpw.mods.fml.common.eventhandler.Cancelable;
+import net.minecraft.block.Block;
+import net.minecraft.world.World;
+import net.minecraftforge.common.util.ForgeDirection;
+
+public class PistonEvent extends BlockEvent
+{
+    /** Stores the direction of the piston */
+    public final ForgeDirection forgeDirection;
+    
+    public PistonEvent(World world, int x, int y, int z, ForgeDirection forgeDirection, Block piston)
+    {
+        super(x, y, z, world, piston, world.getBlockMetadata(x, y, z));
+        
+        this.forgeDirection = forgeDirection;
+    }
+    
+    /***
+     * Posts when a piston tries to extend
+     * If canceled the piston will not extend
+     ***/
+    @Cancelable
+    public static class PistonExtendEvent extends PistonEvent
+    {
+        public PistonExtendEvent(World world, int x, int y, int z, ForgeDirection forgeDirection, Block piston)
+        {
+            super(world, x, y, z, forgeDirection, piston);
+        }
+    }
+    
+    /***
+     * Posts when a piston tries to retract
+     * If canceled the piston will not pull the block it is attached to
+     ***/
+    @Cancelable
+    public static class PistonRetractEvent extends PistonEvent
+    {
+        public PistonRetractEvent(World world, int x, int y, int z, ForgeDirection forgeDirection, Block piston)
+        {
+            super(world, x, y, z, forgeDirection, piston);
+        }
+    }
+}


### PR DESCRIPTION
Ok so this PR adds new events,

PistonEvent.PistonExtendEvent and PistonEvent.PistonRetractEvent

If you cancel Extend, the piston will simply not extend,
If you cancel Retract it will not drag the block along with it.

It has a World, a X, Y and Z, along with a ForgeDirection and The piston Block for casting and misc stuff.

PS: Sorry for new PRs, I was tired and now I remember how2git
