### PR TITLE
Added an event for rendering fog

### DIFF
--- a/patches/minecraft/net/minecraft/client/renderer/EntityRenderer.java.patch
+++ b/patches/minecraft/net/minecraft/client/renderer/EntityRenderer.java.patch
@@ -193,3 +193,11 @@
              if (entitylivingbase.func_70644_a(Potion.field_76440_q))
              {
                  f1 = 5.0F;
+@@ -1930,6 +1980,7 @@
+                     GL11.glFogf(GL11.GL_FOG_START, f1 * 0.05F);
+                     GL11.glFogf(GL11.GL_FOG_END, Math.min(f1, 192.0F) * 0.5F);
+                 }
++                MinecraftForge.EVENT_BUS.post(new net.minecraftforge.client.event.EntityViewRenderEvent.RenderFogEvent(this, entitylivingbase, block, p_78468_2_, p_78468_1_, f1));
+             }
+ 
+             GL11.glEnable(GL11.GL_COLOR_MATERIAL);

--- a/src/main/java/net/minecraftforge/client/event/EntityViewRenderEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/EntityViewRenderEvent.java
@@ -5,6 +5,7 @@ import net.minecraft.client.renderer.EntityRenderer;
 import net.minecraft.entity.EntityLivingBase;
 import cpw.mods.fml.common.eventhandler.Cancelable;
 import cpw.mods.fml.common.eventhandler.Event;
+import cpw.mods.fml.common.eventhandler.Event.Result;
 
 /**
  * Event that hooks into EntityRenderer, allowing any feature to customize visual attributes of
@@ -38,6 +39,23 @@ public abstract class EntityViewRenderEvent extends Event
         {
             super(renderer, entity, block, renderPartialTicks);
             this.density = density;
+        }
+    }
+    
+    /**
+     * Event that allows any feature to customize the rendering of fog.
+     */
+    @HasResult
+    public static class RenderFogEvent extends EntityViewRenderEvent
+    {
+        public final int fogMode;
+        public final float farPlaneDistance;
+        
+        public RenderFogEvent(EntityRenderer renderer, EntityLivingBase entity, Block block, double renderPartialTicks, int fogMode, float farPlaneDistance)
+        {
+            super(renderer, entity, block, renderPartialTicks);
+            this.fogMode = fogMode;
+            this.farPlaneDistance = farPlaneDistance;
         }
     }
 


### PR DESCRIPTION
Adds an event for changing fog distance. This event occurs after fog is rendered normally, which makes it much more useful than the current fog density event which takes no consideration of vanilla fog. It is also at much better timing, as other GL functions can be performed to modify fog too if so desired.
