### PR TITLE
Added EntityWalkingEvent

### DIFF
--- a/patches/minecraft/net/minecraft/entity/Entity.java.patch
+++ b/patches/minecraft/net/minecraft/entity/Entity.java.patch
@@ -75,6 +75,15 @@
      }
  
      protected abstract void func_70088_a();
+@@ -765,7 +794,7 @@
+                     }
+ 
+                     this.func_145780_a(j1, k, l, block);
+-                    block.func_149724_b(this.field_70170_p, j1, k, l, this);
++                    if (!net.minecraftforge.common.MinecraftForge.EVENT_BUS.post(new net.minecraftforge.event.entity.EntityWalkingEvent(this.field_70170_p, this, block, j1, k, l))) block.func_149724_b(this.field_70170_p, j1, k, l, this);
+                 }
+             }
+ 
 @@ -991,9 +1020,22 @@
  
          if (block.func_149688_o() == p_70055_1_)

--- a/src/main/java/net/minecraftforge/event/entity/EntityWalkingEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/EntityWalkingEvent.java
@@ -1,0 +1,47 @@
+package net.minecraftforge.event.entity;
+
+import net.minecraft.block.Block;
+import net.minecraft.entity.Entity;
+import net.minecraft.world.World;
+import cpw.mods.fml.common.eventhandler.Cancelable;
+
+/**
+ * An event triggered when an entity walks over a block. Cancel this event to
+ * prevent the block from running Block.onEntityWalking
+ */
+@Cancelable
+public class EntityWalkingEvent extends EntityEvent {
+
+    /**
+     * The world containing the entity and block
+     */
+    public final World world;
+    /**
+     * The block the entity is walking over
+     */
+    public final Block block;
+    /**
+     * The X coordinate of the block
+     */
+    public final int x;
+    /**
+     * The Y coordinate of the block
+     */
+    public final int y;
+    /**
+     * The Z coordinate of the block
+     */
+    public final int z;
+
+    public EntityWalkingEvent(World world, Entity entity, Block block, int x, int y, int z)
+    {
+        super(entity);
+        this.world = world;
+        this.block = block;
+        this.x = x;
+        this.y = y;
+        this.z = z;
+
+    }
+
+}


### PR DESCRIPTION
Allows for calculations to be made when an entity walks over a block.
Also added ability to prevent the triggering of Block.onEntityWalking
