### PR TITLE
Modified doesEntityNotTriggerPressurePlate

### DIFF
--- a/patches/minecraft/net/minecraft/entity/Entity.java.patch
+++ b/patches/minecraft/net/minecraft/entity/Entity.java.patch
@@ -195,7 +195,17 @@
      }
  
      public boolean func_145774_a(Explosion p_145774_1_, World p_145774_2_, int p_145774_3_, int p_145774_4_, int p_145774_5_, Block p_145774_6_, float p_145774_7_)
-@@ -2058,6 +2150,174 @@
+@@ -2008,7 +2100,8 @@
+ 
+     public boolean func_145773_az()
+     {
+-        return false;
++        NBTTagCompound customEntityData = this.getEntityData();
++        return customEntityData != null && customEntityData.func_74764_b("forge:canTriggerPressurePlate") ? customEntityData.func_74767_n("forge:canTriggerPressurePlate") : false;
+     }
+ 
+     public void func_85029_a(CrashReportCategory p_85029_1_)
+@@ -2058,6 +2151,174 @@
  
      public void func_145781_i(int p_145781_1_) {}
  

--- a/patches/minecraft/net/minecraft/entity/passive/EntityBat.java.patch
+++ b/patches/minecraft/net/minecraft/entity/passive/EntityBat.java.patch
@@ -1,0 +1,12 @@
+--- ../src-base/minecraft/net/minecraft/entity/passive/EntityBat.java
++++ ../src-work/minecraft/net/minecraft/entity/passive/EntityBat.java
+@@ -173,7 +173,8 @@
+ 
+     public boolean func_145773_az()
+     {
+-        return true;
++        NBTTagCompound customEntityData = this.getEntityData();
++        return customEntityData != null && customEntityData.func_74764_b("forge:canTriggerPressurePlate") ? customEntityData.func_74767_n("forge:canTriggerPressurePlate") : true;
+     }
+ 
+     public boolean func_70097_a(DamageSource p_70097_1_, float p_70097_2_)


### PR DESCRIPTION
Added functionality for developers to change an entity’s ability to
trigger a pressure plate. Just add the boolean value you want to the key
“forge:canTriggerPressurePlate” in the entity’s customEntityData.
