### PR TITLE
Added ItemHurtEvent, ItemDeathEvent (ItemEntity)

### DIFF
--- a/patches/minecraft/net/minecraft/entity/item/EntityItem.java.patch
+++ b/patches/minecraft/net/minecraft/entity/item/EntityItem.java.patch
@@ -86,7 +86,23 @@
                  this.func_70106_y();
              }
          }
-@@ -242,6 +282,7 @@
+@@ -216,6 +256,7 @@
+ 
+     public boolean func_70097_a(DamageSource p_70097_1_, float p_70097_2_)
+     {
++        if(net.minecraftforge.common.ForgeHooks.onItemHurt(this, p_70097_1_, p_70097_2_)) return false;
+         if (this.func_85032_ar())
+         {
+             return false;
+@@ -227,6 +268,7 @@
+         else
+         {
+             this.func_70018_K();
++            if((float)this.field_70291_e - p_70097_2_ <= 0.0F && net.minecraftforge.common.ForgeHooks.onItemDeath(this, p_70097_1_)) return false;
+             this.field_70291_e = (int)((float)this.field_70291_e - p_70097_2_);
+ 
+             if (this.field_70291_e <= 0)
+@@ -242,6 +284,7 @@
      {
          p_70014_1_.func_74777_a("Health", (short)((byte)this.field_70291_e));
          p_70014_1_.func_74777_a("Age", (short)this.field_70292_b);
@@ -94,7 +110,7 @@
  
          if (this.func_145800_j() != null)
          {
-@@ -277,20 +318,39 @@
+@@ -277,20 +320,39 @@
          NBTTagCompound nbttagcompound1 = p_70037_1_.func_74775_l("Item");
          this.func_92058_a(ItemStack.func_77949_a(nbttagcompound1));
  

--- a/src/main/java/net/minecraftforge/common/ForgeHooks.java
+++ b/src/main/java/net/minecraftforge/common/ForgeHooks.java
@@ -38,6 +38,8 @@ import net.minecraft.world.World;
 import net.minecraft.world.WorldSettings.GameType;
 import net.minecraftforge.event.AnvilUpdateEvent;
 import net.minecraftforge.event.ServerChatEvent;
+import net.minecraftforge.event.entity.item.ItemDeathEvent;
+import net.minecraftforge.event.entity.item.ItemHurtEvent;
 import net.minecraftforge.event.entity.item.ItemTossEvent;
 import net.minecraftforge.event.entity.living.LivingAttackEvent;
 import net.minecraftforge.event.entity.living.LivingDeathEvent;
@@ -356,6 +358,16 @@ public class ForgeHooks
 
         player.joinEntityItemWithWorld(event.entityItem);
         return event.entityItem;
+    }
+    
+    public static boolean onItemHurt(EntityItem entityItem, DamageSource damageSource, float amount)
+    {
+        return MinecraftForge.EVENT_BUS.post(new ItemHurtEvent(entityItem, damageSource, amount));
+    }
+    
+    public static boolean onItemDeath(EntityItem entityItem, DamageSource damageSource)
+    {
+        return MinecraftForge.EVENT_BUS.post(new ItemDeathEvent(entityItem, damageSource));
     }
 
     public static float getEnchantPower(World world, int x, int y, int z)

--- a/src/main/java/net/minecraftforge/event/entity/item/ItemDeathEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/item/ItemDeathEvent.java
@@ -1,0 +1,36 @@
+package net.minecraftforge.event.entity.item;
+
+import cpw.mods.fml.common.eventhandler.Cancelable;
+import cpw.mods.fml.common.eventhandler.Event.HasResult;
+import net.minecraft.entity.item.EntityItem;
+import net.minecraft.util.DamageSource;
+
+/**
+ * LivingDeathEvent is fired when an Entity dies. <br>
+ * This event is fired whenever an Entity dies in 
+ * EntityItem#attackEntityFrom(DamageSource, float). <br>
+ * <br>
+ * This event is fired via the {@link ForgeHooks#onItemDeath(EntityItem, DamageSource)}.<br>
+ * <br>
+ * {@link #source} contains the DamageSource that caused the entity to die. <br>
+ * <br>
+ * This event is {@link Cancelable}.<br>
+ * If this event is canceled, the Entity does not die.<br>
+ * <br>
+ * This event does not have a result. {@link HasResult}<br>
+ * <br>
+ * This event is fired on the {@link MinecraftForge#EVENT_BUS}.
+ **/
+@Cancelable
+public class ItemDeathEvent extends ItemEvent
+{
+
+    public final DamageSource damageSource;
+    
+    public ItemDeathEvent(EntityItem entityItem, DamageSource damageSource)
+    {
+        super(entityItem);        
+        this.damageSource = damageSource;
+    }
+
+}

--- a/src/main/java/net/minecraftforge/event/entity/item/ItemHurtEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/item/ItemHurtEvent.java
@@ -1,0 +1,38 @@
+package net.minecraftforge.event.entity.item;
+
+import cpw.mods.fml.common.eventhandler.Cancelable;
+import cpw.mods.fml.common.eventhandler.Event.HasResult;
+import net.minecraft.entity.item.EntityItem;
+import net.minecraft.util.DamageSource;
+
+/**
+ * ItemHurtEvent is fired when an Entity is set to be hurt. <br>
+ * This event is fired whenever an Entity is hurt in 
+ * EntityItem#onDeath(DamageSource, float). <br>
+ * <br>
+ * This event is fired via the {@link ForgeHooks#onItemHurt(EntityItem, DamageSource, float)}.<br>
+ * <br>
+ * {@link #source} contains the DamageSource that caused this Entity to be hurt. <br>
+ * {@link #amount} contains the amount of damage dealt to the Entity that was hurt. <br>
+ * <br>
+ * This event is {@link Cancelable}.<br>
+ * If this event is canceled, the Entity is not hurt.<br>
+ * <br>
+ * This event does not have a result. {@link HasResult}<br>
+ * <br>
+ * This event is fired on the {@link MinecraftForge#EVENT_BUS}.
+ **/
+@Cancelable
+public class ItemHurtEvent extends ItemEvent
+{
+    
+    public final DamageSource damageSource;
+    public final float amount;
+    public ItemHurtEvent(EntityItem entityItem, DamageSource damageSource, float amount)
+    {
+        super(entityItem);
+        this.damageSource = damageSource;
+        this.amount = amount;
+    }
+
+}


### PR DESCRIPTION
-Added ItemDeathEvent
-Added ItemHurtEvent
-Modified ForgeHooks to conform EVENT_BUS.post(Event) conventions:
--added onItemHurt(ItemEntity, DamageSource, float)
--added onItemDeath(ItemEntity, DamageSource)
-Modified attackEntityFrom(DamageSource, float)  EnityItem to post
Events.

Reasoning of being added: Every entity can be hurt and die. This is not excluded to dropped items (EntityItems). This makes it possible for mods to allow crafting through interaction with the world with vanilla items. Currently (one of the many/) a workaround with a custom EntityItem is needed to detect if such EntityItem has died.

Example of workaround here:
The Custom EntityItem:
https://github.com/Scribblon/RiftCraft/blob/master/src/main/java/nl/scribblon/riftcraft/entity/RCEntityItem.java
The Custom EventsHandler:
https://github.com/Scribblon/RiftCraft/blob/master/src/main/java/nl/scribblon/riftcraft/handler/EnderPearlHandler.java

This workaround makes me concerned of future compatibility issues when multiple listeners start spawning their own EntityItem subclasses for the same item. Not to talk about the current issue with the "Fetching addPacket for removed entity"-spam I am trying to resolve.
