### PR TITLE
Added EntityTriggerPressurePlateEvent

### DIFF
--- a/patches/minecraft/net/minecraft/block/BlockPressurePlate.java.patch
+++ b/patches/minecraft/net/minecraft/block/BlockPressurePlate.java.patch
@@ -1,0 +1,11 @@
+--- ../src-base/minecraft/net/minecraft/block/BlockPressurePlate.java
++++ ../src-work/minecraft/net/minecraft/block/BlockPressurePlate.java
+@@ -56,7 +56,7 @@
+             {
+                 Entity entity = (Entity)iterator.next();
+ 
+-                if (!entity.func_145773_az())
++                if (!entity.func_145773_az() && !net.minecraftforge.common.MinecraftForge.EVENT_BUS.post(new net.minecraftforge.event.entity.EntityTriggerPressurePlateEvent(entity, p_150065_1_, p_150065_2_, p_150065_3_, p_150065_4_, this)))
+                 {
+                     return 15;
+                 }

--- a/src/main/java/net/minecraftforge/event/entity/EntityTriggerPressurePlateEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/EntityTriggerPressurePlateEvent.java
@@ -1,0 +1,43 @@
+package net.minecraftforge.event.entity;
+
+import cpw.mods.fml.common.eventhandler.Cancelable;
+import net.minecraft.block.Block;
+import net.minecraft.entity.Entity;
+import net.minecraft.world.World;
+
+/**
+ * An event used to modify an entity's ability to trigger a pressure plate.
+ * Cancel if you want to prevent an entity from triggering a pressure plate.
+ */
+@Cancelable
+public class EntityTriggerPressurePlateEvent extends EntityEvent {
+    
+    public final World world;
+    /**
+     * The x coord of the pressure plate
+     */
+    public final int blockX;
+    /**
+     * The y coord of the pressure plate
+     */
+    public final int blockY;
+    /**
+     * The z coord of the pressure plate
+     */
+    public final int blockZ;
+    
+    public final Block pressurePlateBlock;
+    
+    public EntityTriggerPressurePlateEvent(Entity entity, World world, int blockX, int blockY, int blockZ, Block pressurePlate)
+    {
+        super(entity);
+        
+        this.world = world;
+        this.blockX = blockX;
+        this.blockY = blockY;
+        this.blockZ = blockZ;
+        this.pressurePlateBlock = pressurePlate;
+        
+    }
+    
+}


### PR DESCRIPTION
Adds an event to decide whether an entity can trigger a pressure plate.
Does NOT override the inherit traits of the entity (if the entity says
it cannot trigger, then it won’t trigger ever).
I apologize for earlier PRs. This one should be good and proper.