### PR TITLE
Added ArmorChangedEvent

### DIFF
--- a/patches/minecraft/net/minecraft/inventory/ContainerPlayer.java.patch
+++ b/patches/minecraft/net/minecraft/inventory/ContainerPlayer.java.patch
@@ -1,6 +1,15 @@
 --- ../src-base/minecraft/net/minecraft/inventory/ContainerPlayer.java
 +++ ../src-work/minecraft/net/minecraft/inventory/ContainerPlayer.java
-@@ -48,7 +48,8 @@
+@@ -11,6 +11,8 @@
+ import net.minecraft.item.ItemStack;
+ import net.minecraft.item.crafting.CraftingManager;
+ import net.minecraft.util.IIcon;
++import net.minecraftforge.common.MinecraftForge;
++import net.minecraftforge.event.entity.player.ArmorChangedEvent;
+ 
+ public class ContainerPlayer extends Container
+ {
+@@ -48,8 +50,14 @@
                  }
                  public boolean func_75214_a(ItemStack p_75214_1_)
                  {
@@ -8,5 +17,11 @@
 +                    if (p_75214_1_ == null) return false;
 +                    return p_75214_1_.func_77973_b().isValidArmor(p_75214_1_, k, field_82862_h);
                  }
++                public void func_75218_e()
++                {
++                    super.func_75218_e();
++                    MinecraftForge.EVENT_BUS.post(new ArmorChangedEvent(field_82862_h, this.func_75211_c(), this));
++                }
                  @SideOnly(Side.CLIENT)
                  public IIcon func_75212_b()
+                 {

--- a/patches/minecraft/net/minecraft/inventory/ContainerPlayer.java.patch
+++ b/patches/minecraft/net/minecraft/inventory/ContainerPlayer.java.patch
@@ -1,14 +1,5 @@
 --- ../src-base/minecraft/net/minecraft/inventory/ContainerPlayer.java
 +++ ../src-work/minecraft/net/minecraft/inventory/ContainerPlayer.java
-@@ -11,6 +11,8 @@
- import net.minecraft.item.ItemStack;
- import net.minecraft.item.crafting.CraftingManager;
- import net.minecraft.util.IIcon;
-+import net.minecraftforge.common.MinecraftForge;
-+import net.minecraftforge.event.entity.player.ArmorChangedEvent;
- 
- public class ContainerPlayer extends Container
- {
 @@ -48,8 +50,14 @@
                  }
                  public boolean func_75214_a(ItemStack p_75214_1_)
@@ -20,7 +11,7 @@
 +                public void func_75218_e()
 +                {
 +                    super.func_75218_e();
-+                    MinecraftForge.EVENT_BUS.post(new ArmorChangedEvent(field_82862_h, this.func_75211_c(), this));
++                    net.minecraftforge.common.MinecraftForge.EVENT_BUS.post(new net.minecraftforge.event.entity.player.ArmorChangedEvent(field_82862_h, this.func_75211_c(), this));
 +                }
                  @SideOnly(Side.CLIENT)
                  public IIcon func_75212_b()

--- a/src/main/java/net/minecraftforge/event/entity/player/ArmorChangedEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/player/ArmorChangedEvent.java
@@ -1,0 +1,17 @@
+package net.minecraftforge.event.entity.player;
+
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.inventory.Slot;
+import net.minecraft.item.ItemStack;
+
+public class ArmorChangedEvent extends PlayerEvent
+{
+    public final ItemStack armor;
+    public final Slot slot;
+    public ArmorChangedEvent(EntityPlayer player, ItemStack armor, Slot slot)
+    {
+        super(player);
+        this.armor = armor;
+        this.slot = slot;
+    }
+}


### PR DESCRIPTION
Added an event to fire upon changes to the armor slots. It is posted to
the event bus when onSlotChanged() is called on the four armor slots in
ContainerPlayer.
By this, developers will be able to recognize these changes more easily,
without comparing armor on each tick, and possibly force players to drop armor or call other effects upon equipping.

First time using git from the command line, please don't rip my head off =P