### PR TITLE
Added ore dictionary smelting

### DIFF
--- a/patches/minecraft/net/minecraft/item/crafting/FurnaceRecipes.java.patch
+++ b/patches/minecraft/net/minecraft/item/crafting/FurnaceRecipes.java.patch
@@ -1,12 +1,31 @@
 --- ../src-base/minecraft/net/minecraft/item/crafting/FurnaceRecipes.java
 +++ ../src-work/minecraft/net/minecraft/item/crafting/FurnaceRecipes.java
-@@ -107,6 +107,9 @@
+@@ -78,6 +78,8 @@
+ 
+     public ItemStack func_151395_a(ItemStack p_151395_1_)
+     {
++        ItemStack output = net.minecraftforge.oredict.FurnaceOreRecipes.getSmeltingResult(p_151395_1_);
++        if(output != null) return output;
+         Iterator iterator = this.field_77604_b.entrySet().iterator();
+         Entry entry;
+ 
+@@ -107,6 +109,11 @@
  
      public float func_151398_b(ItemStack p_151398_1_)
      {
 +        float ret = p_151398_1_.func_77973_b().getSmeltingExperience(p_151398_1_);
 +        if (ret != -1) return ret;
++        ret = net.minecraftforge.oredict.FurnaceOreRecipes.getSmeltingExperience(p_151398_1_);
++        if (ret != -1) return ret;
 +
          Iterator iterator = this.field_77605_c.entrySet().iterator();
          Entry entry;
  
+@@ -123,4 +130,7 @@
+ 
+         return ((Float)entry.getValue()).floatValue();
+     }
++    
++    public Map<ItemStack, Float> getExperienceList() { return this.field_77605_c; }
++    public void addSmelting(String ore, ItemStack output, float xp) { net.minecraftforge.oredict.FurnaceOreRecipes.addSmelting(ore, output, xp); }
+ }

--- a/src/main/java/net/minecraftforge/oredict/FurnaceOreRecipes.java
+++ b/src/main/java/net/minecraftforge/oredict/FurnaceOreRecipes.java
@@ -1,0 +1,102 @@
+package net.minecraftforge.oredict;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Set;
+
+import net.minecraft.init.Blocks;
+import net.minecraft.item.ItemStack;
+import net.minecraft.item.crafting.FurnaceRecipes;
+import cpw.mods.fml.common.FMLLog;
+
+public class FurnaceOreRecipes {
+
+    private static Map<ArrayList<ItemStack>, ItemStack> outputsMap = new HashMap<ArrayList<ItemStack>, ItemStack>();
+    private static Map<ArrayList<ItemStack>, Float> experienceMap = new HashMap<ArrayList<ItemStack>, Float>();
+
+    public static void addSmelting(String ore, ItemStack output, float xp)
+    {
+        if (output != null && ore != null)
+        {
+            ArrayList<ItemStack> oreStacks = OreDictionary.getOres(ore);
+            outputsMap.put(oreStacks, output.copy());
+            experienceMap.put(oreStacks, xp);
+        }
+    }
+
+    public static ItemStack getSmeltingResult(ItemStack stack)
+    {
+        return getValue(stack, outputsMap);
+    }
+
+    public static float getSmeltingExperience(ItemStack stack)
+    {
+        Float xp = getValue(stack, experienceMap);
+        return xp == null ? -1 : xp;
+    }
+
+    private static <T> T getValue(ItemStack stack, Map<ArrayList<ItemStack>, T> map)
+    {
+        for (Iterator<Entry<ArrayList<ItemStack>, T>> iterator = map.entrySet().iterator(); iterator.hasNext();)
+        {
+            Entry<ArrayList<ItemStack>, T> entry = iterator.next();
+            for (ItemStack target : entry.getKey())
+            {
+                if (OreDictionary.itemMatches(target, stack, false))
+                {
+                    return entry.getValue();
+                }
+            }
+        }
+        return null;
+    }
+
+    public static void replaceSmeltingRecipes()
+    {
+        Map<ItemStack, String> replacements = new HashMap<ItemStack, String>();
+        replacements.put(new ItemStack(Blocks.iron_ore), "oreIron");
+        replacements.put(new ItemStack(Blocks.gold_ore), "oreGold");
+        replacements.put(new ItemStack(Blocks.diamond_ore), "oreDiamond");
+        replacements.put(new ItemStack(Blocks.log), "logWood");
+        replacements.put(new ItemStack(Blocks.log2), "logWood");
+        replacements.put(new ItemStack(Blocks.emerald_ore), "oreEmerald");
+        replacements.put(new ItemStack(Blocks.coal_ore), "oreCoal");
+        replacements.put(new ItemStack(Blocks.redstone_ore), "oreRedstone");
+        replacements.put(new ItemStack(Blocks.lapis_ore), "oreLapis");
+        replacements.put(new ItemStack(Blocks.quartz_ore), "oreQuartz");
+
+        List<ItemStack> stacksToRemove = new ArrayList<ItemStack>();
+        List<ItemStack> xpsToRemove = new ArrayList<ItemStack>();
+        for (Entry<ItemStack, ItemStack> entry : (Set<Entry<ItemStack, ItemStack>>) FurnaceRecipes.smelting().getSmeltingList().entrySet())
+        {
+            for (Entry<ItemStack, String> replacement : replacements.entrySet())
+            {
+                if (OreDictionary.itemMatches(entry.getKey(), replacement.getKey(), false))
+                {
+                    addSmelting(replacement.getValue(), entry.getValue(), FurnaceRecipes.smelting().func_151398_b(entry.getKey()));
+                    stacksToRemove.add(entry.getKey());
+                    xpsToRemove.add(entry.getValue());
+                }
+            }
+        }
+
+        for (ItemStack toRemove : stacksToRemove)
+        {
+            FurnaceRecipes.smelting().getSmeltingList().remove(toRemove);
+        }
+
+        for (ItemStack toRemove : xpsToRemove)
+        {
+            FurnaceRecipes.smelting().getExperienceList().remove(toRemove);
+        }
+
+        if (stacksToRemove.size() > 0)
+        {
+            FMLLog.info("Replaced %d smelting recipes", stacksToRemove.size());
+        }
+    }
+}

--- a/src/main/java/net/minecraftforge/oredict/OreDictionary.java
+++ b/src/main/java/net/minecraftforge/oredict/OreDictionary.java
@@ -249,8 +249,11 @@ public class OreDictionary
         recipes.addAll(recipesToAdd);
         if (recipesToRemove.size() > 0)
         {
-            FMLLog.info("Replaced %d ore recipies", recipesToRemove.size());
+            FMLLog.info("Replaced %d ore recipes", recipesToRemove.size());
         }
+        
+        // Replace smelting recipes
+        FurnaceOreRecipes.replaceSmeltingRecipes();
     }
 
     /**


### PR DESCRIPTION
Allows adding ore dictionary inputs to the furnace.
Also creates a getter for the experience list.

Vanilla smelting recipes that use items registered in the ore dictionary are overridden.

Example on how to add new recipes:
```JAVA
FurnaceRecipes.instance().addSmelting("oreCopper", new ItemStack(Items.copperIngot), 1.0F);
```