### PR TITLE
Updated PR for Issue #1024 (PlayerRepairEvent and AnvilUpdateEvent)

### DIFF
--- a/patches/minecraft/net/minecraft/inventory/ContainerRepair.java.patch
+++ b/patches/minecraft/net/minecraft/inventory/ContainerRepair.java.patch
@@ -8,7 +8,25 @@
  import org.apache.commons.lang3.StringUtils;
  import org.apache.logging.log4j.LogManager;
  import org.apache.logging.log4j.Logger;
-@@ -170,6 +171,7 @@
+@@ -66,6 +67,8 @@
+                     p_82870_1_.func_82242_a(-ContainerRepair.this.field_82854_e);
+                 }
+ 
++                float breakChance = ForgeHooks.onAnvilRepair(p_82870_1_, p_82870_2_, ContainerRepair.this.field_82853_g.func_70301_a(0), ContainerRepair.this.field_82853_g.func_70301_a(1));
++                
+                 ContainerRepair.this.field_82853_g.func_70299_a(0, (ItemStack)null);
+ 
+                 if (ContainerRepair.this.field_82856_l > 0)
+@@ -89,7 +92,7 @@
+ 
+                 ContainerRepair.this.field_82854_e = 0;
+ 
+-                if (!p_82870_1_.field_71075_bZ.field_75098_d && !p_i1800_2_.field_72995_K && p_i1800_2_.func_147439_a(p_i1800_3_, p_i1800_4_, p_i1800_5_) == Blocks.field_150467_bQ && p_82870_1_.func_70681_au().nextFloat() < 0.12F)
++                if (!p_82870_1_.field_71075_bZ.field_75098_d && !p_i1800_2_.field_72995_K && p_i1800_2_.func_147439_a(p_i1800_3_, p_i1800_4_, p_i1800_5_) == Blocks.field_150467_bQ && p_82870_1_.func_70681_au().nextFloat() < breakChance)
+                 {
+                     int i1 = p_i1800_2_.func_72805_g(p_i1800_3_, p_i1800_4_, p_i1800_5_);
+                     int k = i1 & 3;
+@@ -170,6 +173,7 @@
  
              if (itemstack2 != null)
              {
@@ -16,7 +34,7 @@
                  flag = itemstack2.func_77973_b() == Items.field_151134_bR && Items.field_151134_bR.func_92110_g(itemstack2).func_74745_c() > 0;
  
                  if (itemstack1.func_77984_f() && itemstack1.func_77973_b().func_82789_a(itemstack, itemstack2))
-@@ -373,6 +375,8 @@
+@@ -373,6 +377,8 @@
                  k2 = Math.max(1, k2 / 2);
              }
  

--- a/src/main/java/net/minecraftforge/common/ForgeHooks.java
+++ b/src/main/java/net/minecraftforge/common/ForgeHooks.java
@@ -48,6 +48,7 @@ import net.minecraftforge.event.entity.living.LivingFallEvent;
 import net.minecraftforge.event.entity.living.LivingHurtEvent;
 import net.minecraftforge.event.entity.living.LivingSetAttackTargetEvent;
 import net.minecraftforge.event.entity.player.PlayerOpenContainerEvent;
+import net.minecraftforge.event.entity.player.AnvilRepairEvent;
 import net.minecraftforge.event.world.BlockEvent;
 import net.minecraftforge.event.world.NoteBlockEvent;
 import static net.minecraft.init.Blocks.*;
@@ -437,7 +438,15 @@ public class ForgeHooks
 
         outputSlot.setInventorySlotContents(0, e.output);
         container.maximumCost = e.cost;
+        container.stackSizeToBeUsedInRepair = e.materialCost;
         return false;
+    }
+    
+    public static float onAnvilRepair(EntityPlayer player, ItemStack output, ItemStack left, ItemStack right)
+    {
+        AnvilRepairEvent e = new AnvilRepairEvent(player, left, right, output);
+        MinecraftForge.EVENT_BUS.post(e);
+        return e.breakChance;
     }
 
     public static boolean onNoteChange(TileEntityNote te, byte old)

--- a/src/main/java/net/minecraftforge/event/AnvilUpdateEvent.java
+++ b/src/main/java/net/minecraftforge/event/AnvilUpdateEvent.java
@@ -19,6 +19,7 @@ public class AnvilUpdateEvent extends Event
     public final String name;     // The name to set the item, if the user specified one.
     public ItemStack output;      // Set this to set the output stack
     public int cost;              // The base cost, set this to change it if output != null
+    public int materialCost; // The number of items from the right slot to be consumed during the repair. Leave as 0 to consume the entire stack.
 
     public AnvilUpdateEvent(ItemStack left, ItemStack right, String name, int cost)
     {
@@ -26,5 +27,6 @@ public class AnvilUpdateEvent extends Event
         this.right = right;
         this.name = name;
         this.cost = cost;
+        this.materialCost = 0;
     }
 }

--- a/src/main/java/net/minecraftforge/event/entity/player/AnvilRepairEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/player/AnvilRepairEvent.java
@@ -1,0 +1,29 @@
+package net.minecraftforge.event.entity.player;
+
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.item.ItemStack;
+
+public class AnvilRepairEvent extends PlayerEvent
+{
+    /**
+     * Fired when the player removes a "repaired" item from the Anvil's Output slot.
+     *
+     * breakChance specifies as a percentage the chance that the anvil will be "damaged" when used.
+     *
+     * ItemStacks are the inputs/output from the anvil. They cannot be edited.
+     */
+    
+    public final ItemStack left; // The left side of the input
+    public final ItemStack right; // The right side of the input
+    public final ItemStack output; // Set this to set the output stack
+    public float breakChance; // Anvil's chance to break (reduced by 1 durability) when this is complete. Default is 12% (0.12f)
+
+    public AnvilRepairEvent(EntityPlayer player, ItemStack output, ItemStack left, ItemStack right)
+    {
+        super(player);
+        this.output = output;
+        this.left = left;
+        this.right = right;
+        this.breakChance = 0.12f;
+    }
+}

--- a/src/main/resources/forge_at.cfg
+++ b/src/main/resources/forge_at.cfg
@@ -112,6 +112,8 @@ public net.minecraft.item.crafting.ShapelessRecipes field_77579_b #recipeItems
 #protected awy.a(Lwe;)V #MD:GuiContainer/func_74192_a #drawSlotInventory
 # ContainerPlayer
 #protected vv.h #FD:ContainerPlayer/field_82862_h #player
+# ContainerRepair
+public net.minecraft.inventory.ContainerRepair field_82856_l #ContainerRepair/stackSizeToBeUsedInRepair
 # BlockButton
 #protected anf.n(Labw;III)V #MD:BlockButton/func_82535_o #checkActivation
 #protected-f anf.a #FD:BlockButton/field_82537_a #sensible


### PR DESCRIPTION
- Added ability to AnvilUpdateEvent to alter stackSizeToBeUsedInRepair (vanilla behavior is now reproducable)
- Added AnvilRepairEvent, fired when the player removes an ItemStack from the output slot of ContainerRepair, and allows the chance to damage the anvil to be altered.
