### PR TITLE
Legacy Liquid Load Fix

### DIFF
--- a/src/main/java/net/minecraftforge/fluids/FluidStack.java
+++ b/src/main/java/net/minecraftforge/fluids/FluidStack.java
@@ -2,7 +2,7 @@
 package net.minecraftforge.fluids;
 
 import java.util.Locale;
-
+import com.google.common.base.Strings;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
 
@@ -60,7 +60,7 @@ public class FluidStack
             return null;
         }
         String fluidName = nbt.getString("FluidName");
-        if (fluidName == null)
+        if (Strings.isNullOrEmpty(fluidName))
         {
             fluidName = nbt.hasKey("LiquidName") ? nbt.getString("LiquidName").toLowerCase(Locale.ENGLISH) : null;
             fluidName = Fluid.convertLegacyName(fluidName);


### PR DESCRIPTION
nbt.getString("FluidName") no longer returns null, it returns an empty string.

This patch allows legacy liquids to be resolved once again.
