### PR TITLE
Remove stacktrace from the Missing Texture error log

### DIFF
--- a/patches/minecraft/net/minecraft/client/renderer/texture/TextureMap.java.patch
+++ b/patches/minecraft/net/minecraft/client/renderer/texture/TextureMap.java.patch
@@ -40,6 +40,15 @@
              try
              {
                  IResource iresource = p_110571_1_.func_110536_a(resourcelocation1);
+@@ -161,7 +175,7 @@
+             }
+             catch (IOException ioexception1)
+             {
+-                field_147635_d.error("Using missing texture, unable to load " + resourcelocation1, ioexception1);
++                field_147635_d.error("Using missing texture, unable to load " + resourcelocation1);
+                 continue;
+             }
+ 
 @@ -274,6 +288,7 @@
              textureatlassprite = (TextureAtlasSprite)iterator2.next();
              textureatlassprite.func_94217_a(this.field_94249_f);


### PR DESCRIPTION
The log shows exactly which texture is missing already. The stack trace is just for loadTexture which isn't useful to know (and clogs up the log file).

Example error log before patch:

```
[23:12:12] [Client thread/ERROR]: Using missing texture, unable to load forestry:textures/items/misc/liquid.png
java.io.FileNotFoundException: forestry:textures/items/misc/liquid.png
    at net.minecraft.client.resources.FallbackResourceManager.getResource(FallbackResourceManager.java:65) ~[FallbackResourceManager.class:?]
    at net.minecraft.client.resources.SimpleReloadableResourceManager.getResource(SimpleReloadableResourceManager.java:67) ~[SimpleReloadableResourceManager.class:?]
    at net.minecraft.client.renderer.texture.TextureMap.loadTextureAtlas(TextureMap.java:126) [TextureMap.class:?]
    at net.minecraft.client.renderer.texture.TextureMap.loadTexture(TextureMap.java:91) [TextureMap.class:?]
    at net.minecraft.client.renderer.texture.TextureManager.loadTexture(TextureManager.java:89) [TextureManager.class:?]
    at net.minecraft.client.renderer.texture.TextureManager.onResourceManagerReload(TextureManager.java:170) [TextureManager.class:?]
    at net.minecraft.client.resources.SimpleReloadableResourceManager.notifyReloadListeners(SimpleReloadableResourceManager.java:134) [SimpleReloadableResourceManager.class:?]
    at net.minecraft.client.resources.SimpleReloadableResourceManager.reloadResources(SimpleReloadableResourceManager.java:118) [SimpleReloadableResourceManager.class:?]
    at net.minecraft.client.Minecraft.refreshResources(Minecraft.java:653) [Minecraft.class:?]
    at cpw.mods.fml.client.FMLClientHandler.finishMinecraftLoading(FMLClientHandler.java:303) [FMLClientHandler.class:?]
    at net.minecraft.client.Minecraft.startGame(Minecraft.java:596) [Minecraft.class:?]
    at net.minecraft.client.Minecraft.run(Minecraft.java:941) [Minecraft.class:?]
    at net.minecraft.client.main.Main.main(Main.java:164) [Main.class:?]
    at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method) ~[?:1.7.0_67]
    at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:57) ~[?:1.7.0_67]
    at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43) ~[?:1.7.0_67]
    at java.lang.reflect.Method.invoke(Method.java:606) ~[?:1.7.0_67]
    at net.minecraft.launchwrapper.Launch.launch(Launch.java:134) [launchwrapper-1.9.jar:?]
    at net.minecraft.launchwrapper.Launch.main(Launch.java:28) [launchwrapper-1.9.jar:?]
    at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method) ~[?:1.7.0_67]
    at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:57) ~[?:1.7.0_67]
    at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43) ~[?:1.7.0_67]
    at java.lang.reflect.Method.invoke(Method.java:606) ~[?:1.7.0_67]
    at GradleStart.bounce(GradleStart.java:107) [start/:?]
    at GradleStart.startClient(GradleStart.java:100) [start/:?]
    at GradleStart.main(GradleStart.java:55) [start/:?]
```

Example error log after patch:

```
[01:21:48] [Client thread/ERROR]: Using missing texture, unable to load forestry:textures/items/misc/liquid.png
```
