### PR TITLE
Add simple Permissions API

### DIFF
--- a/patches/minecraft/net/minecraft/command/CommandBase.java.patch
+++ b/patches/minecraft/net/minecraft/command/CommandBase.java.patch
@@ -1,0 +1,12 @@
+--- ../src-base/minecraft/net/minecraft/command/CommandBase.java
++++ ../src-work/minecraft/net/minecraft/command/CommandBase.java
+@@ -493,4 +493,9 @@
+     {
+         return this.compareTo((ICommand)p_compareTo_1_);
+     }
++    
++    public String getPermNode()
++    {
++        return "cmd." + func_71517_b();
++    }
+ }

--- a/patches/minecraft/net/minecraft/command/CommandHandler.java.patch
+++ b/patches/minecraft/net/minecraft/command/CommandHandler.java.patch
@@ -10,9 +10,12 @@
  public class CommandHandler implements ICommandManager
  {
      private static final Logger field_147175_a = LogManager.getLogger();
-@@ -47,6 +50,16 @@
+@@ -45,8 +48,18 @@
+                 throw new CommandNotFoundException();
+             }
  
-             if (icommand.func_71519_b(p_71556_1_))
+-            if (icommand.func_71519_b(p_71556_1_))
++            if (net.minecraftforge.permissions.PermissionsManager.getPermHandler().checkCommand(icommand, p_71556_1_))
              {
 +                CommandEvent event = new CommandEvent(icommand, p_71556_1_, astring);
 +                if (MinecraftForge.EVENT_BUS.post(event))
@@ -27,3 +30,29 @@
                  if (i > -1)
                  {
                      EntityPlayerMP[] aentityplayermp = PlayerSelector.func_82380_c(p_71556_1_, astring[i]);
+@@ -124,6 +137,7 @@
+         List list = p_71560_1_.func_71514_a();
+         this.field_71562_a.put(p_71560_1_.func_71517_b(), p_71560_1_);
+         this.field_71561_b.add(p_71560_1_);
++        net.minecraftforge.permissions.PermissionsManager.getPermHandler().registerCommand(p_71560_1_);
+ 
+         if (list != null)
+         {
+@@ -170,7 +184,7 @@
+             {
+                 Entry entry = (Entry)iterator.next();
+ 
+-                if (CommandBase.func_71523_a(s1, (String)entry.getKey()) && ((ICommand)entry.getValue()).func_71519_b(p_71558_1_))
++                if (CommandBase.func_71523_a(s1, (String)entry.getKey()) && net.minecraftforge.permissions.PermissionsManager.getPermHandler().checkCommand((ICommand)entry.getValue(), p_71558_1_))
+                 {
+                     arraylist.add(entry.getKey());
+                 }
+@@ -203,7 +217,7 @@
+         {
+             ICommand icommand = (ICommand)iterator.next();
+ 
+-            if (icommand.func_71519_b(p_71557_1_))
++            if (net.minecraftforge.permissions.PermissionsManager.getPermHandler().checkCommand(icommand, p_71557_1_))
+             {
+                 arraylist.add(icommand);
+             }

--- a/src/main/java/net/minecraftforge/permissions/DefaultPermHandler.java
+++ b/src/main/java/net/minecraftforge/permissions/DefaultPermHandler.java
@@ -1,0 +1,111 @@
+package net.minecraftforge.permissions;
+
+import java.util.Map;
+
+import net.minecraft.command.CommandBase;
+import net.minecraft.command.ICommand;
+import net.minecraft.command.ICommandSender;
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.server.MinecraftServer;
+
+import com.google.common.collect.Maps;
+import com.mojang.authlib.GameProfile;
+
+public class DefaultPermHandler implements IPermissionHandler {
+
+    private Map<String, DefaultValue> permMap = Maps.newHashMap();
+
+    @Override
+    public boolean checkPerm(String perm, EntityPlayer player)
+    {
+        DefaultValue result = permMap.get(perm);
+
+        if (result == null) return false;
+
+        switch (result)
+        {
+        case FALSE:
+            return false;
+        case TRUE:
+            return true;
+        case OP:
+            return isOp(player.getGameProfile());
+        }
+
+        return false;
+    }
+
+    @Override
+    public void regiserPerm(String perm, DefaultValue defaultValue)
+    {
+        permMap.put(perm, defaultValue);
+    }
+
+    @Override
+    public boolean checkCommand(ICommand command, ICommandSender sender)
+    {
+
+        if (!(sender instanceof EntityPlayer))
+        {
+            return true; // Rcon, Console, or Command Blocks are always allowed
+        }
+
+        EntityPlayer player = (EntityPlayer) sender;
+
+        if (command instanceof CommandBase)
+        {
+            CommandBase cmdBase = (CommandBase) command;
+            DefaultValue result = permMap.get(cmdBase.getPermNode());
+
+            if (result == null) return false;
+
+            switch (result)
+            {
+            case TRUE:
+                return true;
+            case FALSE:
+                return false;
+            case OP:
+                return isOp(player.getGameProfile());
+            }
+
+        }
+
+        return false;
+    }
+
+    @Override
+    public void registerCommand(ICommand command)
+    {
+        if (command instanceof CommandBase)
+        {
+            CommandBase cmdBase = (CommandBase) command;
+
+            switch (cmdBase.getRequiredPermissionLevel())
+            {
+            case 0:
+                permMap.put(cmdBase.getPermNode(), DefaultValue.TRUE);
+                break;
+            case 1:
+            case 2:
+            case 3:
+            case 4:
+                permMap.put(cmdBase.getPermNode(), DefaultValue.OP);
+                break;
+            default:
+                permMap.put(cmdBase.getPermNode(), DefaultValue.FALSE);
+            }
+        }
+        else
+        // People should extend CommandBase, but whatever
+        {
+            permMap.put("cmd." + command.getCommandName(), DefaultValue.OP);
+        }
+    }
+
+    public static boolean isOp(GameProfile profile)
+    {
+        return MinecraftServer.getServer().getConfigurationManager().func_152596_g(profile);
+    }
+
+}

--- a/src/main/java/net/minecraftforge/permissions/DefaultValue.java
+++ b/src/main/java/net/minecraftforge/permissions/DefaultValue.java
@@ -1,0 +1,7 @@
+package net.minecraftforge.permissions;
+
+public enum DefaultValue {
+    TRUE, // The permission is always allowed
+    FALSE, // The permission is never allowed
+    OP // The permission is allowed for ops only
+}

--- a/src/main/java/net/minecraftforge/permissions/IPermissionHandler.java
+++ b/src/main/java/net/minecraftforge/permissions/IPermissionHandler.java
@@ -1,0 +1,54 @@
+package net.minecraftforge.permissions;
+
+import net.minecraft.command.ICommand;
+import net.minecraft.command.ICommandSender;
+import net.minecraft.entity.player.EntityPlayer;
+
+public interface IPermissionHandler {
+
+    /**
+     * Check if a permission is allowed
+     * <p>
+     * <b>The EntityPlayer instance may be a
+     * {@link net.minecraftforge.common.util.FakePlayer FakePlayer}</b>
+     * 
+     * @param perm
+     *            the perm node
+     * @param player
+     *            the EntityPlayer
+     * @return if the permission is allowed
+     */
+    public boolean checkPerm(String perm, EntityPlayer player);
+
+    /**
+     * Register a permission with its default value
+     * 
+     * @param perm
+     *            the perm node
+     * @param defaultValue
+     *            the default value
+     */
+    public void regiserPerm(String perm, DefaultValue defaultValue);
+
+    /**
+     * Check if a command is allowed
+     * <p>
+     * Commands are handled here instead of
+     * {@link #checkPerm(String, EntityPlayer)}
+     * 
+     * @param command
+     *            the command
+     * @param sender
+     *            the command sender
+     * @return if the command is allowed
+     */
+    public boolean checkCommand(ICommand command, ICommandSender sender);
+
+    /**
+     * Callback for when a command is registered
+     * 
+     * @param command
+     *            the command
+     */
+    public void registerCommand(ICommand command);
+}

--- a/src/main/java/net/minecraftforge/permissions/PermissionsManager.java
+++ b/src/main/java/net/minecraftforge/permissions/PermissionsManager.java
@@ -1,0 +1,41 @@
+package net.minecraftforge.permissions;
+
+/**
+ * The Minecraft Forge Permissions API
+ * <p>
+ * Permission mods should register a {@link IPermissionHandler
+ * PermissionHandler} instance during
+ * {@link cpw.mods.fml.common.event.FMLPreInitializationEvent PreInit}
+ * <p>
+ * Mods should register commands and permissions during
+ * {@link cpw.mods.fml.common.event.FMLServerStartingEvent ServerStarting
+ */
+public class PermissionsManager {
+
+    private static IPermissionHandler permHandler = null;
+
+    public static synchronized IPermissionHandler getPermHandler()
+    {
+        if (permHandler == null)
+        {
+            // If no mods have registered, create the default instance
+            permHandler = new DefaultPermHandler();
+        }
+
+        return permHandler;
+    }
+
+    /**
+     * Set the permission handler framework
+     * <p>
+     * <b>This should be called during
+     * {@link cpw.mods.fml.common.event.FMLPreInitializationEvent PreInit}</b>
+     * 
+     * @param handler
+     *            the Permission Handler
+     */
+    public static void setPermHandler(IPermissionHandler handler)
+    {
+        permHandler = handler;
+    }
+}


### PR DESCRIPTION
Very simplified version of MinecraftForge/MinecraftForge#1220

This version supports the use of Fake Players in tile entities and other things that can interact with the world. I don't think using fake players is a bad idea, the worldObj, X, Y, Z of the Fake Player should give you the location of the TE/Whatever that is doing the action. And if mods use a unique UUID for each type of block (All Buildcraft quarrys have the same ID, All ComputerCraft turtles, etc.), banning certain blocks on servers should be trivial for protection mods.

Open to conversation.

CC: @luacs1998 @AbrarSyed
