### PR TITLE
Add ItemStack sensitive version of getItemEnchantability

### DIFF
--- a/patches/minecraft/net/minecraft/enchantment/EnchantmentHelper.java.patch
+++ b/patches/minecraft/net/minecraft/enchantment/EnchantmentHelper.java.patch
@@ -1,5 +1,23 @@
 --- ../src-base/minecraft/net/minecraft/enchantment/EnchantmentHelper.java
 +++ ../src-work/minecraft/net/minecraft/enchantment/EnchantmentHelper.java
+@@ -293,7 +293,7 @@
+     public static int func_77514_a(Random p_77514_0_, int p_77514_1_, int p_77514_2_, ItemStack p_77514_3_)
+     {
+         Item item = p_77514_3_.func_77973_b();
+-        int k = item.func_77619_b();
++        int k = item.getItemEnchantability(p_77514_3_);
+ 
+         if (k <= 0)
+         {
+@@ -346,7 +346,7 @@
+     public static List func_77513_b(Random p_77513_0_, ItemStack p_77513_1_, int p_77513_2_)
+     {
+         Item item = p_77513_1_.func_77973_b();
+-        int j = item.func_77619_b();
++        int j = item.getItemEnchantability(p_77513_1_);
+ 
+         if (j <= 0)
+         {
 @@ -435,7 +435,8 @@
          {
              Enchantment enchantment = aenchantment[k];

--- a/patches/minecraft/net/minecraft/item/Item.java.patch
+++ b/patches/minecraft/net/minecraft/item/Item.java.patch
@@ -104,7 +104,7 @@
      public Multimap func_111205_h()
      {
          return HashMultimap.create();
-@@ -726,6 +744,570 @@
+@@ -726,6 +744,581 @@
          return this.field_111218_cA == null ? "MISSING_ICON_ITEM_" + field_150901_e.func_148757_b(this) + "_" + this.field_77774_bZ : this.field_111218_cA;
      }
  
@@ -670,12 +670,23 @@
 +        Integer ret = toolClasses.get(toolClass);
 +        return ret == null ? -1 : ret; 
 +    }
++    
++    /**
++     * ItemStack sensitive version of getItemEnchantability
++     * 
++     * @param stack The ItemStack
++     * @return the item echantability value
++     */
++    public int getItemEnchantability(ItemStack stack)
++    {
++        return func_77619_b();
++    }
 +    /* ======================================== FORGE END   =====================================*/
 +
      public static enum ToolMaterial
      {
          WOOD(0, 59, 2.0F, 0.0F, 15),
-@@ -741,6 +1323,9 @@
+@@ -741,6 +1334,9 @@
  
          private static final String __OBFID = "CL_00000042";
  
@@ -685,7 +696,7 @@
          private ToolMaterial(int p_i1874_3_, int p_i1874_4_, float p_i1874_5_, float p_i1874_6_, int p_i1874_7_)
          {
              this.field_78001_f = p_i1874_3_;
-@@ -777,7 +1362,15 @@
+@@ -777,7 +1373,15 @@
  
          public Item func_150995_f()
          {


### PR DESCRIPTION
Add an ItemStack sensitive version of getItemEnchantability().

Usage:
- Get the item enchantability from NBT Tags. (main)
- Get the item enchantability depending on damage.
- Etc.
