### PR TITLE
Artificial Hydration

### DIFF
--- a/patches/minecraft/net/minecraft/block/Block.java.patch
+++ b/patches/minecraft/net/minecraft/block/Block.java.patch
@@ -1016,7 +1016,7 @@
 +     * @return true if the block should hydrate/fertilize farmland
 +     */
 +    public boolean canHydrateSoil(World world, int x, int y, int z) {
-+        return false;
++        return func_149688_o() == Material.field_151586_h;
 +    }
 +
 +    /**

--- a/patches/minecraft/net/minecraft/block/Block.java.patch
+++ b/patches/minecraft/net/minecraft/block/Block.java.patch
@@ -199,7 +199,7 @@
      }
  
      protected ItemStack func_149644_j(int p_149644_1_)
-@@ -1114,6 +1153,1099 @@
+@@ -1114,6 +1153,1113 @@
          return null;
      }
  
@@ -1002,6 +1002,20 @@
 +            return world.func_72805_g(x, y, z) > 0;
 +        }
 +
++        return false;
++    }
++    
++    /**
++     * Called by {@link BlockFarmland}. Determines if farmland surrounding the block will
++     * become hydrated/fertile.
++     * 
++     * @param world The current world
++     * @param x X Position
++     * @param y Y Position
++     * @param z Z position
++     * @return true if the block should hydrate/fertilize farmland
++     */
++    public boolean canHydrateSoil(World world, int x, int y, int z) {
 +        return false;
 +    }
 +

--- a/patches/minecraft/net/minecraft/block/BlockFarmland.java.patch
+++ b/patches/minecraft/net/minecraft/block/BlockFarmland.java.patch
@@ -23,7 +23,7 @@
                  for (int j1 = p_149821_4_ - 4; j1 <= p_149821_4_ + 4; ++j1)
                  {
 -                    if (p_149821_1_.func_147439_a(l, i1, j1).func_149688_o() == Material.field_151586_h)
-+                    if (p_149821_1_.func_147439_a(l, i1, j1).func_149688_o() == Material.field_151586_h || p_149821_1_.func_147439_a(l, i1, j1).canHydrateSoil(p_149821_1_, l, i1, j1))
++                    if (p_149821_1_.func_147439_a(l, i1, j1).canHydrateSoil(p_149821_1_, l, i1, j1))
                      {
                          return true;
                      }

--- a/patches/minecraft/net/minecraft/block/BlockFarmland.java.patch
+++ b/patches/minecraft/net/minecraft/block/BlockFarmland.java.patch
@@ -18,3 +18,12 @@
                  {
                      return true;
                  }
+@@ -112,7 +114,7 @@
+             {
+                 for (int j1 = p_149821_4_ - 4; j1 <= p_149821_4_ + 4; ++j1)
+                 {
+-                    if (p_149821_1_.func_147439_a(l, i1, j1).func_149688_o() == Material.field_151586_h)
++                    if (p_149821_1_.func_147439_a(l, i1, j1).func_149688_o() == Material.field_151586_h || p_149821_1_.func_147439_a(l, i1, j1).canHydrateSoil(p_149821_1_, l, i1, j1))
+                     {
+                         return true;
+                     }


### PR DESCRIPTION
Allow blocks to hydrate farmland without having to make the block material water