### PR TITLE
ItemEnchantabilityEvent and ItemRarityEvent

### DIFF
--- a/patches/minecraft/net/minecraft/enchantment/EnchantmentHelper.java.patch
+++ b/patches/minecraft/net/minecraft/enchantment/EnchantmentHelper.java.patch
@@ -1,24 +1,32 @@
 --- ../src-base/minecraft/net/minecraft/enchantment/EnchantmentHelper.java
 +++ ../src-work/minecraft/net/minecraft/enchantment/EnchantmentHelper.java
-@@ -293,7 +293,7 @@
+@@ -18,6 +18,7 @@
+ import net.minecraft.nbt.NBTTagList;
+ import net.minecraft.util.DamageSource;
+ import net.minecraft.util.WeightedRandom;
++import net.minecraftforge.event.ForgeEventFactory;
+ 
+ public class EnchantmentHelper
+ {
+@@ -293,7 +294,7 @@
      public static int func_77514_a(Random p_77514_0_, int p_77514_1_, int p_77514_2_, ItemStack p_77514_3_)
      {
          Item item = p_77514_3_.func_77973_b();
 -        int k = item.func_77619_b();
-+        int k = item.getItemEnchantability(p_77514_3_);
++        int k = ForgeEventFactory.onItemEnchantability(p_77514_3_, item.getItemEnchantability(p_77514_3_));
  
          if (k <= 0)
          {
-@@ -346,7 +346,7 @@
+@@ -346,7 +347,7 @@
      public static List func_77513_b(Random p_77513_0_, ItemStack p_77513_1_, int p_77513_2_)
      {
          Item item = p_77513_1_.func_77973_b();
 -        int j = item.func_77619_b();
-+        int j = item.getItemEnchantability(p_77513_1_);
++        int j = ForgeEventFactory.onItemEnchantability(p_77513_1_, item.getItemEnchantability(p_77513_1_));
  
          if (j <= 0)
          {
-@@ -435,7 +435,8 @@
+@@ -435,7 +436,8 @@
          {
              Enchantment enchantment = aenchantment[k];
  

--- a/patches/minecraft/net/minecraft/item/ItemStack.java.patch
+++ b/patches/minecraft/net/minecraft/item/ItemStack.java.patch
@@ -8,7 +8,7 @@
  
  public final class ItemStack
  {
-@@ -181,7 +182,7 @@
+@@ -182,7 +183,7 @@
  
      public int func_77976_d()
      {
@@ -17,7 +17,7 @@
      }
  
      public boolean func_77985_e()
-@@ -191,7 +192,7 @@
+@@ -192,7 +193,7 @@
  
      public boolean func_77984_f()
      {
@@ -26,7 +26,7 @@
      }
  
      public boolean func_77981_g()
-@@ -201,32 +202,27 @@
+@@ -202,32 +203,27 @@
  
      public boolean func_77951_h()
      {
@@ -64,7 +64,7 @@
      }
  
      public boolean func_96631_a(int p_96631_1_, Random p_96631_2_)
-@@ -258,8 +254,8 @@
+@@ -259,8 +255,8 @@
                  }
              }
  
@@ -75,7 +75,7 @@
          }
      }
  
-@@ -318,7 +314,7 @@
+@@ -319,7 +315,7 @@
  
      public boolean func_150998_b(Block p_150998_1_)
      {
@@ -84,7 +84,7 @@
      }
  
      public boolean func_111282_a(EntityPlayer p_111282_1_, EntityLivingBase p_111282_2_)
-@@ -625,16 +621,24 @@
+@@ -626,19 +622,27 @@
          {
              arraylist.add("Durability: " + (this.func_77958_k() - this.func_77952_i()) + " / " + this.func_77958_k());
          }
@@ -109,8 +109,12 @@
 +
      public EnumRarity func_77953_t()
      {
-         return this.func_77973_b().func_77613_e(this);
-@@ -736,7 +740,7 @@
+-        return this.func_77973_b().func_77613_e(this);
++        return ForgeEventFactory.onItemRarity(this, this.func_77973_b().func_77613_e(this));
+     }
+ 
+     public boolean func_77956_u()
+@@ -737,7 +741,7 @@
          }
          else
          {

--- a/src/main/java/net/minecraftforge/event/ForgeEventFactory.java
+++ b/src/main/java/net/minecraftforge/event/ForgeEventFactory.java
@@ -14,6 +14,7 @@ import net.minecraft.entity.effect.EntityLightningBolt;
 import net.minecraft.entity.monster.EntityZombie;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.entity.player.EntityPlayerMP;
+import net.minecraft.item.EnumRarity;
 import net.minecraft.item.ItemStack;
 import net.minecraft.world.World;
 import net.minecraft.world.WorldServer;
@@ -32,6 +33,8 @@ import net.minecraftforge.event.entity.player.PlayerEvent;
 import net.minecraftforge.event.entity.player.PlayerInteractEvent;
 import net.minecraftforge.event.entity.player.PlayerInteractEvent.Action;
 import net.minecraftforge.event.entity.player.PlayerUseItemEvent;
+import net.minecraftforge.event.item.ItemEnchantabilityEvent;
+import net.minecraftforge.event.item.ItemRarityEvent;
 import net.minecraftforge.event.world.BlockEvent;
 import net.minecraftforge.event.world.WorldEvent;
 
@@ -191,5 +194,19 @@ public class ForgeEventFactory
         SaveHandler sh = (SaveHandler) playerFileData;
         File dir = ObfuscationReflectionHelper.getPrivateValue(SaveHandler.class, sh, "playersDirectory", "field_"+"75771_c");
         MinecraftForge.EVENT_BUS.post(new PlayerEvent.LoadFromFile(player, dir, uuidString));
+    }
+    
+    public static int onItemEnchantability(ItemStack stack, int enchantability)
+    {
+        ItemEnchantabilityEvent e = new ItemEnchantabilityEvent(stack, enchantability);
+        MinecraftForge.EVENT_BUS.post(e);
+        return e.enchantability;
+    }
+    
+    public static EnumRarity onItemRarity(ItemStack stack, EnumRarity rarity)
+    {
+        ItemRarityEvent e = new ItemRarityEvent(stack, rarity);
+        MinecraftForge.EVENT_BUS.post(e);
+        return e.rarity;
     }
 }

--- a/src/main/java/net/minecraftforge/event/item/ItemEnchantabilityEvent.java
+++ b/src/main/java/net/minecraftforge/event/item/ItemEnchantabilityEvent.java
@@ -1,0 +1,24 @@
+package net.minecraftforge.event.item;
+
+import net.minecraft.item.ItemStack;
+import cpw.mods.fml.common.eventhandler.Event;
+
+/**
+ * Fired when getting the "enchantability" value of an ItemStack.
+ *
+ * stack contains the ItemStack in question.
+ *
+ * enchantability is the value supplied from the Item.getEnchantability() for the Item.
+ */
+
+public class ItemEnchantabilityEvent extends Event
+{
+    public final ItemStack stack;
+    public int enchantability;
+    
+    public ItemEnchantabilityEvent(ItemStack stack, int enchantability)
+    {
+        this.stack = stack;
+        this.enchantability = enchantability;
+    }
+}

--- a/src/main/java/net/minecraftforge/event/item/ItemRarityEvent.java
+++ b/src/main/java/net/minecraftforge/event/item/ItemRarityEvent.java
@@ -1,0 +1,25 @@
+package net.minecraftforge.event.item;
+
+import net.minecraft.item.EnumRarity;
+import net.minecraft.item.ItemStack;
+import cpw.mods.fml.common.eventhandler.Event;
+
+/**
+ * Fired when getting the "rarity" value of an ItemStack.
+ *
+ * stack contains the ItemStack in question.
+ *
+ * rarity is the value supplied from the Item.getRarity() for the Item.
+ */
+
+public class ItemRarityEvent extends Event
+{
+    public final ItemStack stack;
+    public EnumRarity rarity;
+    
+    public ItemRarityEvent(ItemStack item, EnumRarity rarity)
+    {
+        this.stack = item;
+        this.rarity = rarity;
+    }
+}


### PR DESCRIPTION
2 new events allowing modification of ItemStacks' rarity and enchantability values.  Each event provides the ItemStack in question, as well as the default value.

Enchantability is used during enchanting and repairing, while Rarity is (within vanilla mechanics) primarily a cosmetic value, affecting the color of the item's name in the tooltip, but could also be expanded upon for new, interesting mechanics.
