### PR TITLE
Write the correct default value for StringList comments in the config

### DIFF
--- a/src/main/java/net/minecraftforge/common/config/Configuration.java
+++ b/src/main/java/net/minecraftforge/common/config/Configuration.java
@@ -1596,7 +1596,7 @@ public class Configuration
         Property prop = this.get(category, name, defaultValue);
         prop.setLanguageKey(langKey);
         prop.setValidValues(validValues);
-        prop.comment = comment + " [default: " + defaultValue + "]";
+        prop.comment = comment + " [default: " + prop.getDefault() + "]";
         return prop.getStringList();
     }
     


### PR DESCRIPTION
Fixes Configuration.getStringList displaying a String[].toString ([Ljava.lang.String;@xxxxxxxx]) instead of the actual default values
