### PR TITLE
Fix for #1333: Quartz Ore can be harvested with wooden picks

### DIFF
--- a/src/main/java/net/minecraftforge/common/ForgeHooks.java
+++ b/src/main/java/net/minecraftforge/common/ForgeHooks.java
@@ -173,6 +173,7 @@ public class ForgeHooks
         Blocks.iron_block.setHarvestLevel("pickaxe", 1);
         Blocks.lapis_ore.setHarvestLevel("pickaxe", 1);
         Blocks.lapis_block.setHarvestLevel("pickaxe", 1);
+        Blocks.quartz_ore.setHarvestLevel("pickaxe", 0);
     }
 
     public static int getTotalArmorValue(EntityPlayer player)


### PR DESCRIPTION
According to the wiki Quartz Ore is harvestable with wooden pickaxes: http://minecraft.gamepedia.com/Nether_Quartz_Ore
