### PR TITLE
Fixed PlayerInteractEvent server/client inconsistencies

### DIFF
--- a/patches/minecraft/net/minecraft/client/Minecraft.java.patch
+++ b/patches/minecraft/net/minecraft/client/Minecraft.java.patch
@@ -65,7 +65,7 @@
                          this.field_71439_g.func_71038_i();
                      }
                  }
-@@ -1423,11 +1428,12 @@
+@@ -1423,7 +1428,7 @@
                      int j = this.field_71476_x.field_72312_c;
                      int k = this.field_71476_x.field_72309_d;
  
@@ -74,23 +74,7 @@
                      {
                          int l = itemstack != null ? itemstack.field_77994_a : 0;
  
--                        if (this.field_71442_b.func_78760_a(this.field_71439_g, this.field_71441_e, itemstack, i, j, k, this.field_71476_x.field_72310_e, this.field_71476_x.field_72307_f))
-+                        boolean result = !net.minecraftforge.event.ForgeEventFactory.onPlayerInteract(field_71439_g, net.minecraftforge.event.entity.player.PlayerInteractEvent.Action.RIGHT_CLICK_BLOCK, i, j, k, this.field_71476_x.field_72310_e, this.field_71441_e).isCanceled();
-+                        if (result && this.field_71442_b.func_78760_a(this.field_71439_g, this.field_71441_e, itemstack, i, j, k, this.field_71476_x.field_72310_e, this.field_71476_x.field_72307_f))
-                         {
-                             flag = false;
-                             this.field_71439_g.func_71038_i();
-@@ -1454,7 +1460,8 @@
-         {
-             ItemStack itemstack1 = this.field_71439_g.field_71071_by.func_70448_g();
- 
--            if (itemstack1 != null && this.field_71442_b.func_78769_a(this.field_71439_g, this.field_71441_e, itemstack1))
-+            boolean result = !net.minecraftforge.event.ForgeEventFactory.onPlayerInteract(field_71439_g, net.minecraftforge.event.entity.player.PlayerInteractEvent.Action.RIGHT_CLICK_AIR, 0, 0, 0, -1, this.field_71441_e).isCanceled();
-+            if (result && itemstack1 != null && this.field_71442_b.func_78769_a(this.field_71439_g, this.field_71441_e, itemstack1))
-             {
-                 this.field_71460_t.field_78516_c.func_78445_c();
-             }
-@@ -1666,6 +1673,8 @@
+@@ -1666,6 +1671,8 @@
  
              while (Mouse.next())
              {
@@ -99,7 +83,7 @@
                  j = Mouse.getEventButton();
                  KeyBinding.func_74510_a(j - 100, Mouse.getEventButtonState());
  
-@@ -2128,6 +2137,11 @@
+@@ -2128,6 +2135,11 @@
  
      public void func_71353_a(WorldClient p_71353_1_, String p_71353_2_)
      {
@@ -111,7 +95,7 @@
          if (p_71353_1_ == null)
          {
              NetHandlerPlayClient nethandlerplayclient = this.func_147114_u();
-@@ -2140,6 +2154,18 @@
+@@ -2140,6 +2152,18 @@
              if (this.field_71437_Z != null)
              {
                  this.field_71437_Z.func_71263_m();
@@ -130,7 +114,7 @@
              }
  
              this.field_71437_Z = null;
-@@ -2288,113 +2314,10 @@
+@@ -2288,113 +2312,10 @@
          if (this.field_71476_x != null)
          {
              boolean flag = this.field_71439_g.field_71075_bZ.field_75098_d;
@@ -246,7 +230,7 @@
              if (flag)
              {
                  j = this.field_71439_g.field_71069_bz.field_75151_b.size() - 9 + this.field_71439_g.field_71071_by.field_70461_c;
-@@ -2660,8 +2583,15 @@
+@@ -2660,8 +2581,15 @@
          p_70001_1_.func_152767_b("gl_max_texture_size", Integer.valueOf(func_71369_N()));
      }
  
@@ -262,7 +246,7 @@
          for (int i = 16384; i > 0; i >>= 1)
          {
              GL11.glTexImage2D(GL11.GL_PROXY_TEXTURE_2D, 0, GL11.GL_RGBA, i, i, 0, GL11.GL_RGBA, GL11.GL_UNSIGNED_BYTE, (ByteBuffer)null);
-@@ -2669,6 +2599,7 @@
+@@ -2669,6 +2597,7 @@
  
              if (j != 0)
              {

--- a/patches/minecraft/net/minecraft/client/multiplayer/PlayerControllerMP.java.patch
+++ b/patches/minecraft/net/minecraft/client/multiplayer/PlayerControllerMP.java.patch
@@ -1,17 +1,20 @@
 --- ../src-base/minecraft/net/minecraft/client/multiplayer/PlayerControllerMP.java
 +++ ../src-work/minecraft/net/minecraft/client/multiplayer/PlayerControllerMP.java
-@@ -28,6 +28,10 @@
+@@ -28,6 +28,13 @@
  import net.minecraft.world.World;
  import net.minecraft.world.WorldSettings;
  
-+import net.minecraftforge.common.ForgeHooks;
 +import net.minecraftforge.common.MinecraftForge;
++import cpw.mods.fml.common.eventhandler.Event;
++import net.minecraftforge.event.ForgeEventFactory;
 +import net.minecraftforge.event.entity.player.PlayerDestroyItemEvent;
++import net.minecraftforge.event.entity.player.PlayerInteractEvent;
++import net.minecraftforge.event.entity.player.PlayerInteractEvent.Action;
 +
  @SideOnly(Side.CLIENT)
  public class PlayerControllerMP
  {
-@@ -88,6 +92,12 @@
+@@ -88,6 +95,12 @@
  
      public boolean func_78751_a(int p_78751_1_, int p_78751_2_, int p_78751_3_, int p_78751_4_)
      {
@@ -24,7 +27,7 @@
          if (this.field_78779_k.func_82752_c() && !this.field_78776_a.field_71439_g.func_82246_f(p_78751_1_, p_78751_2_, p_78751_3_))
          {
              return false;
-@@ -109,7 +119,7 @@
+@@ -109,7 +122,7 @@
              {
                  worldclient.func_72926_e(2001, p_78751_1_, p_78751_2_, p_78751_3_, Block.func_149682_b(block) + (worldclient.func_72805_g(p_78751_1_, p_78751_2_, p_78751_3_) << 12));
                  int i1 = worldclient.func_72805_g(p_78751_1_, p_78751_2_, p_78751_3_);
@@ -33,7 +36,54 @@
  
                  if (flag)
                  {
-@@ -304,11 +314,18 @@
+@@ -142,6 +155,12 @@
+     {
+         if (!this.field_78779_k.func_82752_c() || this.field_78776_a.field_71439_g.func_82246_f(p_78743_1_, p_78743_2_, p_78743_3_))
+         {
++            PlayerInteractEvent event = ForgeEventFactory.onPlayerInteract(this.field_78776_a.field_71439_g, Action.LEFT_CLICK_BLOCK, p_78743_1_, p_78743_2_, p_78743_3_, p_78743_4_, this.field_78776_a.field_71441_e);
++            if (event.isCanceled())
++            {
++                return;
++            }
++
+             if (this.field_78779_k.func_77145_d())
+             {
+                 this.field_78774_b.func_147297_a(new C07PacketPlayerDigging(0, p_78743_1_, p_78743_2_, p_78743_3_, p_78743_4_));
+@@ -157,13 +176,19 @@
+ 
+                 this.field_78774_b.func_147297_a(new C07PacketPlayerDigging(0, p_78743_1_, p_78743_2_, p_78743_3_, p_78743_4_));
+                 Block block = this.field_78776_a.field_71441_e.func_147439_a(p_78743_1_, p_78743_2_, p_78743_3_);
+-                boolean flag = block.func_149688_o() != Material.field_151579_a;
++                float blockHardness = 1.0F;
++                boolean flag = !block.isAir(this.field_78776_a.field_71441_e, p_78743_1_, p_78743_2_, p_78743_3_);
+ 
+-                if (flag && this.field_78770_f == 0.0F)
++                if (flag && this.field_78770_f == 0.0F && event.useBlock != Event.Result.DENY)
+                 {
+                     block.func_149699_a(this.field_78776_a.field_71441_e, p_78743_1_, p_78743_2_, p_78743_3_, this.field_78776_a.field_71439_g);
+                 }
+ 
++                if (event.useItem == Event.Result.DENY)
++                {
++                    return;
++                }
++
+                 if (flag && block.func_149737_a(this.field_78776_a.field_71439_g, this.field_78776_a.field_71439_g.field_70170_p, p_78743_1_, p_78743_2_, p_78743_3_) >= 1.0F)
+                 {
+                     this.func_78751_a(p_78743_1_, p_78743_2_, p_78743_3_, p_78743_4_);
+@@ -298,17 +323,30 @@
+ 
+     public boolean func_78760_a(EntityPlayer p_78760_1_, World p_78760_2_, ItemStack p_78760_3_, int p_78760_4_, int p_78760_5_, int p_78760_6_, int p_78760_7_, Vec3 p_78760_8_)
+     {
++        PlayerInteractEvent event = ForgeEventFactory.onPlayerInteract(p_78760_1_, Action.RIGHT_CLICK_BLOCK, p_78760_4_, p_78760_5_, p_78760_6_, p_78760_7_, p_78760_2_);
++        if (event.isCanceled())
++        {
++            return false;
++        }
++
+         this.func_78750_j();
+         float f = (float)p_78760_8_.field_72450_a - (float)p_78760_4_;
+         float f1 = (float)p_78760_8_.field_72448_b - (float)p_78760_5_;
          float f2 = (float)p_78760_8_.field_72449_c - (float)p_78760_6_;
          boolean flag = false;
  
@@ -46,7 +96,7 @@
 +                return true;
          }
  
-+        if (!p_78760_1_.func_70093_af() || p_78760_1_.func_70694_bm() == null || p_78760_1_.func_70694_bm().func_77973_b().doesSneakBypassUse(p_78760_2_, p_78760_4_, p_78760_5_, p_78760_6_, p_78760_1_))
++        if (event.useBlock != Event.Result.DENY && (!p_78760_1_.func_70093_af() || p_78760_1_.func_70694_bm() == null || p_78760_1_.func_70694_bm().func_77973_b().doesSneakBypassUse(p_78760_2_, p_78760_4_, p_78760_5_, p_78760_6_, p_78760_1_)))
 +        {
 +            flag = p_78760_2_.func_147439_a(p_78760_4_, p_78760_5_, p_78760_6_).func_149727_a(p_78760_2_, p_78760_4_, p_78760_5_, p_78760_6_, p_78760_1_, p_78760_7_, f, f1, f2);
 +        }
@@ -54,7 +104,16 @@
          if (!flag && p_78760_3_ != null && p_78760_3_.func_77973_b() instanceof ItemBlock)
          {
              ItemBlock itemblock = (ItemBlock)p_78760_3_.func_77973_b();
-@@ -340,7 +357,15 @@
+@@ -325,7 +363,7 @@
+         {
+             return true;
+         }
+-        else if (p_78760_3_ == null)
++        else if (p_78760_3_ == null || event.useItem == Event.Result.DENY)
+         {
+             return false;
+         }
+@@ -340,12 +378,26 @@
          }
          else
          {
@@ -71,7 +130,18 @@
          }
      }
  
-@@ -359,9 +384,10 @@
+     public boolean func_78769_a(EntityPlayer p_78769_1_, World p_78769_2_, ItemStack p_78769_3_)
+     {
++        PlayerInteractEvent event = ForgeEventFactory.onPlayerInteract(p_78769_1_, PlayerInteractEvent.Action.RIGHT_CLICK_AIR, 0, 0, 0, -1, p_78769_2_);
++        if (event.isCanceled() || event.useItem == Event.Result.DENY)
++        {
++            return false;
++        }
++
+         this.func_78750_j();
+         this.field_78774_b.func_147297_a(new C08PacketPlayerBlockPlacement(-1, -1, -1, 255, p_78769_1_.field_71071_by.func_70448_g(), 0.0F, 0.0F, 0.0F));
+         int i = p_78769_3_.field_77994_a;
+@@ -359,9 +411,10 @@
          {
              p_78769_1_.field_71071_by.field_70462_a[p_78769_1_.field_71071_by.field_70461_c] = itemstack1;
  

--- a/patches/minecraft/net/minecraft/network/NetHandlerPlayServer.java.patch
+++ b/patches/minecraft/net/minecraft/network/NetHandlerPlayServer.java.patch
@@ -103,20 +103,7 @@
                  {
                      return;
                  }
-@@ -500,7 +532,11 @@
-                 return;
-             }
- 
--            this.field_147369_b.field_71134_c.func_73085_a(this.field_147369_b, worldserver, itemstack);
-+            PlayerInteractEvent event = ForgeEventFactory.onPlayerInteract(field_147369_b, PlayerInteractEvent.Action.RIGHT_CLICK_AIR, 0, 0, 0, -1, worldserver);
-+            if (event.useItem != Event.Result.DENY)
-+            {
-+                this.field_147369_b.field_71134_c.func_73085_a(this.field_147369_b, worldserver, itemstack);
-+            }
-         }
-         else if (p_147346_1_.func_149571_d() >= this.field_147367_d.func_71207_Z() - 1 && (p_147346_1_.func_149568_f() == 1 || p_147346_1_.func_149571_d() >= this.field_147367_d.func_71207_Z()))
-         {
-@@ -511,7 +547,9 @@
+@@ -511,7 +543,9 @@
          }
          else
          {
@@ -127,7 +114,7 @@
              {
                  this.field_147369_b.field_71134_c.func_73078_a(this.field_147369_b, worldserver, itemstack, i, j, k, l, p_147346_1_.func_149573_h(), p_147346_1_.func_149569_i(), p_147346_1_.func_149575_j());
              }
-@@ -677,6 +715,8 @@
+@@ -677,6 +711,8 @@
              else
              {
                  ChatComponentTranslation chatcomponenttranslation1 = new ChatComponentTranslation("chat.type.text", new Object[] {this.field_147369_b.func_145748_c_(), s});
@@ -136,7 +123,7 @@
                  this.field_147367_d.func_71203_ab().func_148544_a(chatcomponenttranslation1, false);
              }
  
-@@ -812,7 +852,7 @@
+@@ -812,7 +848,7 @@
                          return;
                      }
  

--- a/patches/minecraft/net/minecraft/server/management/ItemInWorldManager.java.patch
+++ b/patches/minecraft/net/minecraft/server/management/ItemInWorldManager.java.patch
@@ -145,7 +145,7 @@
  
                  if (itemstack != null)
                  {
-@@ -251,12 +293,18 @@
+@@ -251,18 +293,30 @@
                      }
                  }
  
@@ -164,7 +164,19 @@
              return flag;
          }
      }
-@@ -288,6 +336,7 @@
+ 
+     public boolean func_73085_a(EntityPlayer p_73085_1_, World p_73085_2_, ItemStack p_73085_3_)
+     {
++        PlayerInteractEvent event = ForgeEventFactory.onPlayerInteract(p_73085_1_, PlayerInteractEvent.Action.RIGHT_CLICK_AIR, 0, 0, 0, -1, p_73085_2_);
++        if (event.isCanceled() || event.useItem == Event.Result.DENY)
++        {
++            return false;
++        }
++
+         int i = p_73085_3_.field_77994_a;
+         int j = p_73085_3_.func_77960_j();
+         ItemStack itemstack1 = p_73085_3_.func_77957_a(p_73085_2_, p_73085_1_);
+@@ -288,6 +342,7 @@
              if (itemstack1.field_77994_a == 0)
              {
                  p_73085_1_.field_71071_by.field_70462_a[p_73085_1_.field_71071_by.field_70461_c] = null;
@@ -172,7 +184,7 @@
              }
  
              if (!p_73085_1_.func_71039_bw())
-@@ -301,31 +350,70 @@
+@@ -301,31 +356,70 @@
  
      public boolean func_73078_a(EntityPlayer p_73078_1_, World p_73078_2_, ItemStack p_73078_3_, int p_73078_4_, int p_73078_5_, int p_73078_6_, int p_73078_7_, float p_73078_8_, float p_73078_9_, float p_73078_10_)
      {


### PR DESCRIPTION
 * Made Action.RIGHT_CLICK_BLOCK get handled the same on the client as it does on the server (before, the client would only react to isCanceled() and nothing else)
 * Made Action.LEFT_CLICK_BLOCK get fired and handled on the client the same as it does on the server
 * Made Action.RIGHT_CLICK_AIR not get fired on the client when not holding an item to match how the server fires it

As an example of what this fixes, it will stop the following code from causing desyncing when trying to plant something like potatoes (currently, the client will ignore the Result.DENY and plant the seed but the server will not allow it):
```
    @SubscribeEvent
    public void onPlayerInteraction(PlayerInteractEvent event)
    {
        if (event.action != PlayerInteractEvent.Action.RIGHT_CLICK_BLOCK)
            return;

        if (event.entityPlayer.getHeldItem() != null && event.entityPlayer.getHeldItem().getItem() instanceof ItemSeedFood)
        {
            event.useItem = Result.DENY;
        }
    }
```