### PR TITLE
Fix Stained Glass pane rendering issues

### DIFF
--- a/patches/minecraft/net/minecraft/client/renderer/RenderBlocks.java.patch
+++ b/patches/minecraft/net/minecraft/client/renderer/RenderBlocks.java.patch
@@ -92,6 +92,21 @@
              {
                  d5 = (double)p_147801_2_ + 0.5D + 0.5D;
                  d6 = (double)p_147801_2_ + 0.5D - 0.5D;
+@@ -2724,10 +2728,10 @@
+         double d16 = (double)p_147733_2_ + 0.5D + 0.0625D;
+         double d17 = (double)p_147733_4_ + 0.5D - 0.0625D;
+         double d18 = (double)p_147733_4_ + 0.5D + 0.0625D;
+-        boolean flag = flag5 ? ((BlockStainedGlassPane)p_147733_1_).func_150098_a(this.field_147845_a.func_147439_a(p_147733_2_, p_147733_3_, p_147733_4_ - 1)) : ((BlockPane)p_147733_1_).func_150098_a(this.field_147845_a.func_147439_a(p_147733_2_, p_147733_3_, p_147733_4_ - 1));
+-        boolean flag1 = flag5 ? ((BlockStainedGlassPane)p_147733_1_).func_150098_a(this.field_147845_a.func_147439_a(p_147733_2_, p_147733_3_, p_147733_4_ + 1)) : ((BlockPane)p_147733_1_).func_150098_a(this.field_147845_a.func_147439_a(p_147733_2_, p_147733_3_, p_147733_4_ + 1));
+-        boolean flag2 = flag5 ? ((BlockStainedGlassPane)p_147733_1_).func_150098_a(this.field_147845_a.func_147439_a(p_147733_2_ - 1, p_147733_3_, p_147733_4_)) : ((BlockPane)p_147733_1_).func_150098_a(this.field_147845_a.func_147439_a(p_147733_2_ - 1, p_147733_3_, p_147733_4_));
+-        boolean flag3 = flag5 ? ((BlockStainedGlassPane)p_147733_1_).func_150098_a(this.field_147845_a.func_147439_a(p_147733_2_ + 1, p_147733_3_, p_147733_4_)) : ((BlockPane)p_147733_1_).func_150098_a(this.field_147845_a.func_147439_a(p_147733_2_ + 1, p_147733_3_, p_147733_4_));
++        boolean flag  = ((BlockPane)p_147733_1_).canPaneConnectTo(this.field_147845_a, p_147733_2_, p_147733_3_, p_147733_4_ - 1, NORTH);
++        boolean flag1 = ((BlockPane)p_147733_1_).canPaneConnectTo(this.field_147845_a, p_147733_2_, p_147733_3_, p_147733_4_ + 1, SOUTH);
++        boolean flag2 = ((BlockPane)p_147733_1_).canPaneConnectTo(this.field_147845_a, p_147733_2_ - 1, p_147733_3_, p_147733_4_, WEST );
++        boolean flag3 = ((BlockPane)p_147733_1_).canPaneConnectTo(this.field_147845_a, p_147733_2_ + 1, p_147733_3_, p_147733_4_, EAST );
+         double d19 = 0.001D;
+         double d20 = 0.999D;
+         double d21 = 0.001D;
 @@ -3121,10 +3125,10 @@
          double d16 = (double)p_147767_2_ + 0.5D + 0.0625D;
          double d17 = (double)p_147767_4_ + 0.5D - 0.0625D;


### PR DESCRIPTION
This change to the Stained Glass Pane renderer fixes them not connecting to non-opaque blocks with solid side surfaces. For example, if a block has to return `false` in `isOpaqueCube` because there are non-opaque sub-blocks, but also has a solid sub-block that returns `true` on all `isSideSolid` and wants Glass Panes to connect to it, Glass Panes do not connect to the block.
**Before:**
![2014-08-18_20 18 10](https://cloud.githubusercontent.com/assets/4145923/3955885/cfaeb802-2705-11e4-96ef-149281d04fb8.png)
**After:**
![2014-08-18_20 19 37](https://cloud.githubusercontent.com/assets/4145923/3955886/cfb1add2-2705-11e4-9af0-819eebfafc7b.png)

However, this cannot be intended, since the hitbox correctly connects to the block.
**Before:**
![2014-08-18_20 21 11](https://cloud.githubusercontent.com/assets/4145923/3955887/cfc7ba1e-2705-11e4-9cfe-c785feca95be.png)
![2014-08-18_20 21 22](https://cloud.githubusercontent.com/assets/4145923/3955889/cfc8a4c4-2705-11e4-8383-f31dbd633124.png)
**After:**
![2014-08-18_20 20 02](https://cloud.githubusercontent.com/assets/4145923/3955888/cfc804e2-2705-11e4-817b-639322509d37.png)

This patch fixes that issue.
