### PR TITLE
Fixed the gradlew.bat for Windows users

### DIFF
--- a/gradlew.bat
+++ b/gradlew.bat
@@ -33,7 +33,7 @@ goto fail
 
 :findJavaFromJavaHome
 set JAVA_HOME=%JAVA_HOME:"=%
-set JAVA_EXE=%JAVA_HOME%/bin/java.exe
+set JAVA_EXE=%JAVA_HOME%\bin\java.exe
 
 if exist "%JAVA_EXE%" goto init
 


### PR DESCRIPTION
Windows uses \ for it's paths and Unix /.
Now gradlew will find java on Windows as well.
