### PR TITLE
ForgeHooks: set correct harvest level for the Enchanting Table

### DIFF
--- a/src/main/java/net/minecraftforge/common/ForgeHooks.java
+++ b/src/main/java/net/minecraftforge/common/ForgeHooks.java
@@ -170,6 +170,7 @@ public class ForgeHooks
         }
 
         Blocks.obsidian.setHarvestLevel("pickaxe", 3);
+        Blocks.enchanting_table.setHarvestLevel("pickaxe", 0);
         for (Block block : new Block[]{emerald_ore, emerald_block, diamond_ore, diamond_block, gold_ore, gold_block, redstone_ore, lit_redstone_ore})
         {
             block.setHarvestLevel("pickaxe", 2);


### PR DESCRIPTION
Enchanting Table is missing its harvest level