### PR TITLE
Removed duped AT

### DIFF
--- a/src/main/resources/forge_at.cfg
+++ b/src/main/resources/forge_at.cfg
@@ -171,8 +171,6 @@ public net.minecraft.network.play.server.S23PacketBlockChange field_148884_e # M
 public-f net.minecraft.world.WorldType field_77139_a #worldTypes
 # DamageSource
 public net.minecraft.util.DamageSource *() #All methods public, most are already
-# ItemBlock
-public net.minecraft.item.ItemBlock field_150939_a # block
 # EntityAITasks 
 public net.minecraft.entity.ai.EntityAITasks field_75782_a # taskEntries
 # EntityXPOrb


### PR DESCRIPTION
Removed public ItemBlock.field_150939_a AT, as it exists in FML, so it is not needed in Forge.