### PR TITLE
Living Entity PickUp Patch

### DIFF
--- a/patches/minecraft/net/minecraft/entity/EntityLiving.java.patch
+++ b/patches/minecraft/net/minecraft/entity/EntityLiving.java.patch
@@ -18,7 +18,15 @@
      }
  
      public boolean func_70686_a(Class p_70686_1_)
-@@ -476,10 +480,22 @@
+@@ -450,6 +454,7 @@
+                                 }
+                             }
+ 
++                            if (net.minecraftforge.common.MinecraftForge.EVENT_BUS.post(new net.minecraftforge.event.entity.living.LivingItemPickUpEvent((EntityLivingBase) this, entityitem))) return;
+                             this.func_70062_b(i, itemstack);
+                             this.field_82174_bp[i] = 2.0F;
+                             this.field_82179_bU = true;
+@@ -476,10 +481,22 @@
  
      protected void func_70623_bb()
      {
@@ -41,7 +49,7 @@
          else
          {
              EntityPlayer entityplayer = this.field_70170_p.func_72890_a(this, -1.0D);
-@@ -642,7 +658,6 @@
+@@ -642,7 +659,6 @@
          return this.field_70170_p.func_72855_b(this.field_70121_D) && this.field_70170_p.func_72945_a(this, this.field_70121_D).isEmpty() && !this.field_70170_p.func_72953_d(this.field_70121_D);
      }
  

--- a/src/main/java/net/minecraftforge/event/entity/living/LivingItemPickUpEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/living/LivingItemPickUpEvent.java
@@ -1,0 +1,30 @@
+package net.minecraftforge.event.entity.living;
+
+import cpw.mods.fml.common.eventhandler.Cancelable;
+import cpw.mods.fml.common.eventhandler.Event;
+import net.minecraft.entity.EntityLivingBase;
+import net.minecraft.entity.item.EntityItem;
+
+@Cancelable
+@Event.HasResult
+public class LivingItemPickUpEvent extends LivingEvent
+{
+    /**
+     * This event is called when a living entity collides with a EntityItem on the ground.
+     * The event can be canceled, and no further processing will be done.
+     * 
+     *  You can set the result of this event to ALLOW which will trigger
+     *  FML's event, play the sound, and kill the 
+     *  entity if all the items are picked up.
+     *  
+     *  setResult(ALLOW) is the same as the old setHandled()
+     */
+    
+    public EntityItem itemEntity;
+    
+    public LivingItemPickUpEvent(EntityLivingBase pEntity, EntityItem itemEntity)
+    {
+        super(pEntity);
+        this.itemEntity = itemEntity;
+    }
+}


### PR DESCRIPTION
This event extends the pick up control we currently already have on players to living entities, like zombies and skeletons. Allowing us to control what they pick up and when.

The implementation uses the exact same event structure as the player one, just modified for living entities instead.
