### PR TITLE
Add new ShapedOreRecipe constuctor and getters

### DIFF
--- a/src/main/java/net/minecraftforge/oredict/ShapedOreRecipe.java
+++ b/src/main/java/net/minecraftforge/oredict/ShapedOreRecipe.java
@@ -125,6 +125,23 @@ public class ShapedOreRecipe implements IRecipe
         }
     }
 
+    public ShapedOreRecipe(Object[] input, ItemStack output, int width, int height, boolean mirrored)
+    {
+        this.output = output.copy();
+        this.input = input;
+        this.width = width;
+        this.height = height;
+        this.mirrored = mirrored;
+        
+        for (int i = 0; i < input.length; i++)
+        {
+            if (input[i] instanceof String)
+            {
+                input[i] = OreDictionary.getOres((String)input[i]);
+            }
+        }
+    }
+
     ShapedOreRecipe(ShapedRecipes recipe, Map<ItemStack, String> replacements)
     {
         output = recipe.getRecipeOutput();
@@ -249,10 +266,25 @@ public class ShapedOreRecipe implements IRecipe
     /**
      * Returns the input for this recipe, any mod accessing this value should never
      * manipulate the values in this array as it will effect the recipe itself.
-     * @return The recipes input vales.
+     * @return The recipe's input values.
      */
     public Object[] getInput()
     {
         return this.input;
+    }
+
+    public int getRecipeWidth()
+    {
+        return width;
+    }
+
+    public int getRecipeHeight()
+    {
+        return height;
+    }
+
+    public boolean getIsMirrored()
+    {
+        return mirrored;
     }
 }


### PR DESCRIPTION
This would add another constructor to ShapedOreRecipes, so the input can be used directly without using the easier-to-use mapping / lookup constructor that takes strings and pairs of characters and input items. This allows for recipe creation where input items, width and height are taken at runtime, for example to create copies of other recipes.
Also adds getters for width, height and mirrored fields.

Argument order is input, output, ... (instead of output, input, ... as it should be) to distinct it from the other constructor. If this is a moot point I can change that around.
