### PR TITLE
Metadata sensitive isReplaceableOreGen

### DIFF
--- a/patches/minecraft/net/minecraft/block/Block.java.patch
+++ b/patches/minecraft/net/minecraft/block/Block.java.patch
@@ -743,6 +743,25 @@
 +    }
 +
 +    /**
++     * Metadata sensitive version of {@link #isReplaceableOreGen}. Useful to customized ore gens that specify
++     * blocks with specific metadata to replace while leaving the ability for other mods to add equivalence.
++     *
++     * One should use {@link #isReplaceableOreGen} instead if metadata is not specific.
++     *
++     * @param world The current world
++     * @param x X Position
++     * @param y Y Position
++     * @param z Z Position
++     * @param targetBlock The generic target block the customized ore gen is looking for
++     * @param targetMeta The generic target metadata the gen is looking for
++     * @return True to allow this block to be replaced by a ore
++     */
++    public boolean isReplaceableOreGenMeta(World world, int x, int y, int z, Block targetBlock, int targetMeta)
++    {
++        return isReplaceableOreGen(world, x, y, z, targetBlock) && world.getBlockMetadata(x, y, z) == targetMeta;
++    }
++
++    /**
 +     * Location sensitive version of getExplosionRestance
 +     *
 +     * @param par1Entity The entity that caused the explosion


### PR DESCRIPTION
Consider a customized mod oregen that perform replacement to a block type with specific metadata. One could always use:

1) world.getBlock(x, y, z) == targetBlock && world.getBlockMetadata(x, y, z) == targetMeta

to perfom such a matching to the target block and metadata, but if you want to resemble the forge-modified vanilla oregen, the method isReplaceableOreGen would be a little bit inappropriate, considering only half of the criteria could be delegated to the block itself:

2) block.isReplaceableOreGen(world, x, y, z, targetBlock) && world.getBlockMetadata(x, y, z) == targetMeta

And comparing it with:

3) block.isReplaceableOreGenMeta(world, x, y, z, targetBlock, targetMeta)

The latter one is much clear and compact. And most importantly, it allows other mods to add equivalent block in a sensible way: no need to have the same usage of metadata to the original block.

And it would nice if the new method could co-exist with the old isReplaceableOreGen, considering block.isReplaceableOreGen(world, x, y, z, targetBlock) being a forge equivalent for block == targetBlock, and, 3) being a forge equivalent for 1).
