### PR TITLE
Glass bottles need equivalent of FillBucketEvent

### DIFF
--- a/patches/minecraft/net/minecraft/item/ItemBucket.java.patch
+++ b/patches/minecraft/net/minecraft/item/ItemBucket.java.patch
@@ -10,33 +10,16 @@
  
  public class ItemBucket extends Item
  {
-@@ -32,6 +35,31 @@
+@@ -32,6 +35,14 @@
          }
          else
          {
 +            FillBucketEvent event = new FillBucketEvent(p_77659_3_, p_77659_1_, p_77659_2_, movingobjectposition);
-+            if (MinecraftForge.EVENT_BUS.post(event))
-+            {
-+                return p_77659_1_;
-+            }
-+
-+            if (event.getResult() == Event.Result.ALLOW)
-+            {
-+                if (p_77659_3_.field_71075_bZ.field_75098_d)
-+                {
-+                    return p_77659_1_;
-+                }
-+
-+                if (--p_77659_1_.field_77994_a <= 0)
-+                {
-+                    return event.result;
-+                }
-+
-+                if (!p_77659_3_.field_71071_by.func_70441_a(event.result))
-+                {
-+                    p_77659_3_.func_71019_a(event.result, false);
-+                }
-+
++            if (MinecraftForge.EVENT_BUS.post(event)) return p_77659_1_;
++            if (event.getResult() == Event.Result.ALLOW) {
++                if (p_77659_3_.field_71075_bZ.field_75098_d) return p_77659_1_;
++                if (--p_77659_1_.field_77994_a <= 0) return event.result;
++                if (!p_77659_3_.field_71071_by.func_70441_a(event.result)) p_77659_3_.func_71019_a(event.result, false);
 +                return p_77659_1_;
 +            }
              if (movingobjectposition.field_72313_a == MovingObjectPosition.MovingObjectType.BLOCK)

--- a/patches/minecraft/net/minecraft/item/ItemGlassBottle.java.patch
+++ b/patches/minecraft/net/minecraft/item/ItemGlassBottle.java.patch
@@ -1,0 +1,27 @@
+--- ../src-base/minecraft/net/minecraft/item/ItemGlassBottle.java
++++ ../src-work/minecraft/net/minecraft/item/ItemGlassBottle.java
+@@ -10,6 +10,9 @@
+ import net.minecraft.util.IIcon;
+ import net.minecraft.util.MovingObjectPosition;
+ import net.minecraft.world.World;
++import net.minecraftforge.common.MinecraftForge;
++import net.minecraftforge.event.entity.player.FillGlassBottleEvent;
++import cpw.mods.fml.common.eventhandler.Event;
+ 
+ public class ItemGlassBottle extends Item
+ {
+@@ -36,6 +39,14 @@
+         }
+         else
+         {
++            FillGlassBottleEvent event = new FillGlassBottleEvent(p_77659_3_, p_77659_1_, p_77659_2_, movingobjectposition);
++            if (MinecraftForge.EVENT_BUS.post(event)) return p_77659_1_;
++            if (event.getResult() == Event.Result.ALLOW) {
++                if (p_77659_3_.field_71075_bZ.field_75098_d) return p_77659_1_;
++                if (--p_77659_1_.field_77994_a <= 0) return event.getFilledContainer();
++                if (!p_77659_3_.field_71071_by.func_70441_a(event.getFilledContainer())) p_77659_3_.func_71019_a(event.getFilledContainer(), false);
++                return p_77659_1_;
++            }
+             if (movingobjectposition.field_72313_a == MovingObjectPosition.MovingObjectType.BLOCK)
+             {
+                 int i = movingobjectposition.field_72311_b;

--- a/src/main/java/net/minecraftforge/event/entity/player/FillBucketEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/player/FillBucketEvent.java
@@ -9,7 +9,7 @@ import net.minecraft.world.World;
 
 @Cancelable
 @Event.HasResult
-public class FillBucketEvent extends PlayerEvent
+public class FillBucketEvent extends FillFluidContainerEvent
 {
     /**
      * This event is fired when a player attempts to use a Empty bucket, it 
@@ -29,9 +29,21 @@ public class FillBucketEvent extends PlayerEvent
 
     public FillBucketEvent(EntityPlayer player, ItemStack current, World world, MovingObjectPosition target)
     {
-        super(player);
+        super(player, current, world, target);
         this.current = current;
         this.world = world;
         this.target = target;
+    }
+
+    @Override
+    public ItemStack getFilledContainer()
+    {
+        return this.result;
+    }
+
+    @Override
+    public void setFilledContainer(ItemStack filled)
+    {
+        this.result = filled;
     }
 }

--- a/src/main/java/net/minecraftforge/event/entity/player/FillFluidContainerEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/player/FillFluidContainerEvent.java
@@ -1,0 +1,44 @@
+package net.minecraftforge.event.entity.player;
+
+import cpw.mods.fml.common.eventhandler.Cancelable;
+import cpw.mods.fml.common.eventhandler.Event;
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.item.ItemStack;
+import net.minecraft.util.MovingObjectPosition;
+import net.minecraft.world.World;
+
+/**
+ * This event is fired when a player attempts to use an empty fluid container, it 
+ * can be canceled to completely prevent any further processing.
+ * 
+ * If you set the result to 'ALLOW', it means that you have processed 
+ * the event and wants the basic functionality of adding the new 
+ * ItemStack to your inventory and reducing the stack size to process.
+ * setResult(ALLOW) is the same as the old setHandeled();
+ */
+@Cancelable
+@Event.HasResult
+public class FillFluidContainerEvent extends PlayerEvent {
+
+    public final ItemStack current;
+    public final World world;
+    public final MovingObjectPosition target;
+
+    private ItemStack filledContainer;
+
+    public FillFluidContainerEvent(EntityPlayer player, ItemStack current, World world, MovingObjectPosition target)
+    {
+        super(player);
+        this.current = current;
+        this.world = world;
+        this.target = target;
+    }
+        
+    public ItemStack getFilledContainer() {
+        return this.filledContainer;
+    }
+    
+    public void setFilledContainer(ItemStack filled) {
+        this.filledContainer = filled;
+    }
+}

--- a/src/main/java/net/minecraftforge/event/entity/player/FillGlassBottleEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/player/FillGlassBottleEvent.java
@@ -1,0 +1,27 @@
+package net.minecraftforge.event.entity.player;
+
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.item.ItemStack;
+import net.minecraft.util.MovingObjectPosition;
+import net.minecraft.world.World;
+import cpw.mods.fml.common.eventhandler.Cancelable;
+import cpw.mods.fml.common.eventhandler.Event;
+
+/**
+ * This event is fired when a player attempts to use an empty bottle, it 
+ * can be canceled to completely prevent any further processing.
+ * 
+ * If you set the result to 'ALLOW', it means that you have processed 
+ * the event and wants the basic functionality of adding the new 
+ * ItemStack to your inventory and reducing the stack size to process.
+ * setResult(ALLOW) is the same as the old setHandeled();
+ */
+@Cancelable
+@Event.HasResult
+public class FillGlassBottleEvent extends FillFluidContainerEvent
+{
+    public FillGlassBottleEvent(EntityPlayer player, ItemStack current, World world, MovingObjectPosition target)
+    {
+        super(player, current, world, target);
+    }
+}


### PR DESCRIPTION
Currently mod liquids tend to use Material.water, which means right-clicking a glass bottle yields a water bottle. Buildcraft oil is one example. Would be nice if glass bottles got the same treatment as buckets. Couple of options:
1. Reuse FillBucketEvent, with the semantic "fill a bucket's worth of liquid into this container". 
2. Introduce a parent of FillBucketEvent, called FillContainerEvent, and add child FillGlassBottleEvent. This introduces some complexity but the naming is more intuitive.

I'm in favor of choice 2. I'll submit a PR if this is deemed acceptable.

As an alternative or in addition, we could revisit the whole custom bucket approach. Now that we have FluidContainerRegistry, it is possible to handle the filling of containers generically.
