### PR TITLE
fix rendering height of non-liquid fluids

### DIFF
--- a/src/main/java/net/minecraftforge/fluids/RenderBlockFluid.java
+++ b/src/main/java/net/minecraftforge/fluids/RenderBlockFluid.java
@@ -57,7 +57,8 @@ public class RenderBlockFluid implements ISimpleBlockRenderingHandler
     {
         if (world.getBlock(x, y, z) == block)
         {
-            if (world.getBlock(x, y - block.densityDir, z).getMaterial().isLiquid())
+            Block verticalOrigin = world.getBlock(x, y - block.densityDir, z);
+            if (verticalOrigin.getMaterial().isLiquid() || verticalOrigin instanceof IFluidBlock)
             {
                 return 1;
             }


### PR DESCRIPTION
Currently gas source blocks stacked on top of each other will render with gaps between them, which is obviously undesirable.
