### PR TITLE
Fixed Clientside GameProfile UUID being null on offline mode

### DIFF
--- a/patches/minecraft/net/minecraft/util/Session.java.patch
+++ b/patches/minecraft/net/minecraft/util/Session.java.patch
@@ -1,6 +1,6 @@
 --- ../src-base/minecraft/net/minecraft/util/Session.java
 +++ ../src-work/minecraft/net/minecraft/util/Session.java
-@@ -19,6 +19,19 @@
+@@ -19,6 +21,19 @@
  
      public Session(String p_i1098_1_, String p_i1098_2_, String p_i1098_3_, String p_i1098_4_)
      {
@@ -20,3 +20,12 @@
          this.field_74286_b = p_i1098_1_;
          this.field_148257_b = p_i1098_2_;
          this.field_148258_c = p_i1098_3_;
+@@ -54,7 +69,7 @@
+         }
+         catch (IllegalArgumentException illegalargumentexception)
+         {
+-            return new GameProfile((UUID)null, this.func_111285_a());
++            return new GameProfile(net.minecraft.entity.player.EntityPlayer.func_146094_a(new GameProfile((UUID)null, this.func_111285_a())), this.func_111285_a());
+         }
+     }
+ 


### PR DESCRIPTION
Makes sure both sides get the same UUID when querying a players GameProfile in offline mode.
