### PR TITLE
Permissions API

### DIFF
--- a/patches/minecraft/net/minecraft/command/CommandHandler.java.patch
+++ b/patches/minecraft/net/minecraft/command/CommandHandler.java.patch
@@ -10,9 +10,12 @@
  public class CommandHandler implements ICommandManager
  {
      private static final Logger field_147175_a = LogManager.getLogger();
-@@ -47,6 +50,16 @@
+@@ -45,8 +48,18 @@
+                 throw new CommandNotFoundException();
+             }
  
-             if (icommand.func_71519_b(p_71556_1_))
+-            if (icommand.func_71519_b(p_71556_1_))
++            if (net.minecraftforge.server.CommandHandlerForge.canUse(icommand, p_71556_1_))
              {
 +                CommandEvent event = new CommandEvent(icommand, p_71556_1_, astring);
 +                if (MinecraftForge.EVENT_BUS.post(event))
@@ -27,3 +30,30 @@
                  if (i > -1)
                  {
                      EntityPlayerMP[] aentityplayermp = PlayerSelector.func_82380_c(p_71556_1_, astring[i]);
+@@ -140,6 +153,8 @@
+                 }
+             }
+         }
++        
++        net.minecraftforge.server.CommandHandlerForge.doPermissionReg(p_71560_1_);
+ 
+         return p_71560_1_;
+     }
+@@ -170,7 +185,7 @@
+             {
+                 Entry entry = (Entry)iterator.next();
+ 
+-                if (CommandBase.func_71523_a(s1, (String)entry.getKey()) && ((ICommand)entry.getValue()).func_71519_b(p_71558_1_))
++                if (CommandBase.func_71523_a(s1, (String)entry.getKey()) && net.minecraftforge.server.CommandHandlerForge.canUse(((ICommand)entry.getValue()), p_71558_1_))
+                 {
+                     arraylist.add(entry.getKey());
+                 }
+@@ -203,7 +218,7 @@
+         {
+             ICommand icommand = (ICommand)iterator.next();
+ 
+-            if (icommand.func_71519_b(p_71557_1_))
++            if (net.minecraftforge.server.CommandHandlerForge.canUse(icommand, p_71557_1_))
+             {
+                 arraylist.add(icommand);
+             }

--- a/patches/minecraft/net/minecraft/entity/player/EntityPlayerMP.java.patch
+++ b/patches/minecraft/net/minecraft/entity/player/EntityPlayerMP.java.patch
@@ -104,7 +104,35 @@
              this.field_147103_bO.func_150871_b(this, p_71064_1_, p_71064_2_);
              Iterator iterator = this.func_96123_co().func_96520_a(p_71064_1_.func_150952_k()).iterator();
  
-@@ -1021,4 +1036,16 @@
+@@ -929,26 +944,7 @@
+ 
+     public boolean func_70003_b(int p_70003_1_, String p_70003_2_)
+     {
+-        if ("seed".equals(p_70003_2_) && !this.field_71133_b.func_71262_S())
+-        {
+-            return true;
+-        }
+-        else if (!"tell".equals(p_70003_2_) && !"help".equals(p_70003_2_) && !"me".equals(p_70003_2_))
+-        {
+-            if (this.field_71133_b.func_71203_ab().func_152596_g(this.func_146103_bH()))
+-            {
+-                UserListOpsEntry userlistopsentry = (UserListOpsEntry)this.field_71133_b.func_71203_ab().func_152603_m().func_152683_b(this.func_146103_bH());
+-                return userlistopsentry != null ? userlistopsentry.func_152644_a() >= p_70003_1_ : this.field_71133_b.func_110455_j() >= p_70003_1_;
+-            }
+-            else
+-            {
+-                return false;
+-            }
+-        }
+-        else
+-        {
+-            return true;
+-        }
++        return true;
+     }
+ 
+     public String func_71114_r()
+@@ -1021,4 +1017,16 @@
      {
          return this.field_143005_bX;
      }

--- a/patches/minecraft/net/minecraft/network/NetHandlerPlayServer.java.patch
+++ b/patches/minecraft/net/minecraft/network/NetHandlerPlayServer.java.patch
@@ -145,3 +145,12 @@
                  }
  
                  break;
+@@ -1140,7 +1180,7 @@
+                 {
+                     this.field_147369_b.func_145747_a(new ChatComponentTranslation("advMode.notEnabled", new Object[0]));
+                 }
+-                else if (this.field_147369_b.func_70003_b(2, "") && this.field_147369_b.field_71075_bZ.field_75098_d)
++                else if (net.minecraftforge.permissions.PermissionsManager.checkPermission(this.field_147369_b, "mc.cmdblocks") && this.field_147369_b.field_71075_bZ.field_75098_d)
+                 {
+                     packetbuffer = new PacketBuffer(Unpooled.wrappedBuffer(p_147349_1_.func_149558_e()));
+ 

--- a/src/main/java/net/minecraftforge/common/ForgeModContainer.java
+++ b/src/main/java/net/minecraftforge/common/ForgeModContainer.java
@@ -28,6 +28,8 @@ import net.minecraftforge.common.config.Property;
 import net.minecraftforge.common.network.ForgeNetworkHandler;
 import net.minecraftforge.oredict.OreDictionary;
 import net.minecraftforge.oredict.RecipeSorter;
+import net.minecraftforge.permissions.PermissionsManager.RegisteredPermValue;
+import net.minecraftforge.server.CommandHandlerForge;
 import net.minecraftforge.server.command.ForgeCommand;
 
 import com.google.common.collect.ImmutableList;
@@ -301,8 +303,10 @@ public class ForgeModContainer extends DummyModContainer implements WorldAccessC
     @Subscribe
     public void serverStarting(FMLServerStartingEvent evt)
     {
-        evt.registerServerCommand(new ForgeCommand(evt.getServer()));
+        // evt.registerServerCommand(new ForgeCommand(evt.getServer())); this call is not permissions aware, the one below is
+        CommandHandlerForge.registerCommand(new ForgeCommand(evt.getServer()), "forge.command", RegisteredPermValue.OP);
     }
+    
     @Override
     public NBTTagCompound getDataForWriting(SaveHandler handler, WorldInfo info)
     {

--- a/src/main/java/net/minecraftforge/permissions/DefaultPermProvider.java
+++ b/src/main/java/net/minecraftforge/permissions/DefaultPermProvider.java
@@ -1,0 +1,48 @@
+package net.minecraftforge.permissions;
+
+import java.util.HashSet;
+
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.server.MinecraftServer;
+import net.minecraftforge.permissions.PermissionsManager.RegisteredPermValue;
+
+public class DefaultPermProvider implements IPermissionsProvider {
+
+    static HashSet<String> operatorPermissions = new HashSet<String>();
+
+    static HashSet<String> deniesPermissions = new HashSet<String>();
+
+    @Override
+    public void registerPermission(String permissionNode, RegisteredPermValue level)
+    {
+        switch (level)
+        {
+        case FALSE:
+            deniesPermissions.add(permissionNode);
+            break;
+        case OP:
+            operatorPermissions.add(permissionNode);
+            break;
+        default:
+            break;
+        }
+    }
+
+    @Override
+    public boolean checkPermission(IContext contextInfo, String node)
+    {
+        if (deniesPermissions.contains(node))
+        {
+            return false;
+        }
+        else if (operatorPermissions.contains(node))
+        {
+            EntityPlayer player = contextInfo.getPlayer();
+            return player == null ? false : MinecraftServer.getServer().getConfigurationManager().func_152596_g(player.getGameProfile());
+        }
+        else
+        {
+            return true;
+        }
+    }
+}

--- a/src/main/java/net/minecraftforge/permissions/IContext.java
+++ b/src/main/java/net/minecraftforge/permissions/IContext.java
@@ -1,0 +1,35 @@
+package net.minecraftforge.permissions;
+
+import net.minecraft.command.ICommand;
+import net.minecraft.command.ICommandSender;
+import net.minecraft.entity.Entity;
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.util.Vec3;
+
+/**
+ * An interface for a Context class. Contexts are not meant to be saved and never should be.
+ * Framework authors, do not implement this interface directly. Subclass PermissionContext.
+ *
+ */
+public interface IContext
+{
+    EntityPlayer getPlayer();
+    
+    EntityPlayer getTargetPlayer();
+    
+    ICommand getCommand();
+    
+    ICommandSender getCommandSender();
+    
+    Vec3 getSourceLocationStart();
+    
+    Vec3 getSourceLocationEnd();
+    
+    Vec3 getTargetLocationStart();
+    
+    Vec3 getTargetLocationEnd();
+    
+    Entity getSourceEntity();
+    
+    Entity getTargetEntity();
+}

--- a/src/main/java/net/minecraftforge/permissions/IPermissionsProvider.java
+++ b/src/main/java/net/minecraftforge/permissions/IPermissionsProvider.java
@@ -1,0 +1,44 @@
+package net.minecraftforge.permissions;
+
+import net.minecraft.command.ICommand;
+import net.minecraft.command.ICommandSender;
+import net.minecraft.entity.Entity;
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.util.Vec3;
+import net.minecraftforge.permissions.PermissionsManager.RegisteredPermValue;
+
+
+/**
+ * An interface for permission frameworks to implement.
+ * 
+ * Framework authors:
+ * The class implementing this interface will be called by the API to check permissions.
+ * Do all necessary calls here. You can bounce them to helper classes if you want.
+ * 
+ */
+public interface IPermissionsProvider
+{
+
+    /**
+     * Checks a permission
+     * 
+     * @param context
+     *            Context, where the permission is checked in.
+     * @param permissionNode
+     *            The permission node, that should be checked
+     * @return Whether the permission is allowed
+     */
+    boolean checkPermission(IContext context, String permissionNode);
+
+    /**
+     * This is where permissions are registered with their default value.
+     * 
+     * @param permissionNode
+     * @param level
+     *            Default level of the permission. This can be used to tell the
+     *            underlying {@link IPermissionsProvider} whether a player
+     *            should be allowed to access this permission by default, or as
+     *            operator only.
+     */
+    void registerPermission(String permissionNode, RegisteredPermValue level);
+}

--- a/src/main/java/net/minecraftforge/permissions/PermissionContext.java
+++ b/src/main/java/net/minecraftforge/permissions/PermissionContext.java
@@ -1,0 +1,179 @@
+package net.minecraftforge.permissions;
+
+import net.minecraft.command.ICommand;
+import net.minecraft.command.ICommandSender;
+import net.minecraft.entity.Entity;
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.util.Vec3;
+import net.minecraft.world.World;
+import net.minecraftforge.common.DimensionManager;
+
+/**
+ * This is the base class for a context. A permission framework
+ * <i><b>might</b></i> subclass this context, to allow additional properties for
+ * the context.
+ */
+public class PermissionContext implements IContext{
+
+    private EntityPlayer player;
+
+    private EntityPlayer targetPlayer;
+
+    private ICommand command;
+
+    private ICommandSender commandSender;
+
+    private Vec3 sourceLocationStart;
+
+    private Vec3 sourceLocationEnd;
+
+    private Vec3 targetLocationStart;
+
+    private Vec3 targetLocationEnd;
+
+    private Entity sourceEntity;
+
+    private Entity targetEntity;
+    
+    private World world;
+
+    public EntityPlayer getPlayer()
+    {
+        return player;
+    }
+
+    public EntityPlayer getTargetPlayer()
+    {
+        return targetPlayer;
+    }
+
+    public ICommand getCommand()
+    {
+        return command;
+    }
+
+    public ICommandSender getCommandSender()
+    {
+        return commandSender;
+    }
+
+    public Vec3 getSourceLocationStart()
+    {
+        return sourceLocationStart;
+    }
+
+    public Vec3 getSourceLocationEnd()
+    {
+        return sourceLocationEnd;
+    }
+
+    public Vec3 getTargetLocationStart()
+    {
+        return targetLocationStart;
+    }
+
+    public Vec3 getTargetLocationEnd()
+    {
+        return targetLocationEnd;
+    }
+
+    public Entity getSourceEntity()
+    {
+        return sourceEntity;
+    }
+
+    public Entity getTargetEntity()
+    {
+        return targetEntity;
+    }
+    
+    public World getWorld()
+    {
+        return world;
+    }
+
+    public PermissionContext setPlayer(EntityPlayer player)
+    {
+        this.player = player;
+        return this;
+    }
+
+    public PermissionContext setTargetPlayer(EntityPlayer player)
+    {
+        this.targetPlayer = player;
+        return this;
+    }
+
+    public PermissionContext setCommand(ICommand command)
+    {
+        this.command = command;
+        return this;
+    }
+
+    public PermissionContext setCommandSender(ICommandSender sender)
+    {
+        this.commandSender = sender;
+        return this;
+    }
+
+    public PermissionContext setSourceLocationStart(Vec3 location)
+    {
+        this.sourceLocationStart = location;
+        return this;
+    }
+
+    public PermissionContext setSourceLocationEnd(Vec3 location)
+    {
+        this.sourceLocationEnd = location;
+        return this;
+    }
+
+    public PermissionContext setTargetLocationStart(Vec3 location)
+    {
+        this.targetLocationStart = location;
+        return this;
+    }
+
+    public PermissionContext setTargetLocationEnd(Vec3 location)
+    {
+        this.targetLocationEnd = location;
+        return this;
+    }
+
+    public PermissionContext setSourceEntity(Entity entity)
+    {
+        this.sourceEntity = entity;
+        return this;
+    }
+
+    public PermissionContext setTargetEntity(Entity entity)
+    {
+        this.targetEntity = entity;
+        return this;
+    }
+    
+    public PermissionContext setWorld(int dimID)
+    {
+        this.world = DimensionManager.getWorld(dimID);
+        return this;
+    }
+    
+    public PermissionContext setWorld(World world)
+    {
+        this.world = world;
+        return this;
+    }
+
+    public PermissionContext(){}
+
+    public boolean isConsole()
+    {
+        return player == null && commandSender != null && !(commandSender instanceof EntityPlayer);
+    }
+
+    public boolean isPlayer()
+    {
+        return (player instanceof EntityPlayer) || (commandSender instanceof EntityPlayer);
+    }
+
+}

--- a/src/main/java/net/minecraftforge/permissions/PermissionsManager.java
+++ b/src/main/java/net/minecraftforge/permissions/PermissionsManager.java
@@ -1,0 +1,116 @@
+package net.minecraftforge.permissions;
+
+import net.minecraft.entity.player.EntityPlayer;
+import cpw.mods.fml.common.FMLLog;
+import cpw.mods.fml.common.Loader;
+import cpw.mods.fml.common.LoaderState;
+
+/**
+ * The main entry point for the Permissions API.
+ * At most, mods should only use this class.
+ *
+ */
+public final class PermissionsManager
+{
+    private static IPermissionsProvider provider = new DefaultPermProvider();
+    
+    private static boolean wasSet = false;
+    
+    private PermissionsManager(){}
+    
+    /**
+     * Checks a permission
+     * 
+     * @param player
+     *            The player to use as a context
+     * @param permissionNode
+     *            The permission node, that should be checked
+     * @return Whether the permission is allowed
+     */
+    public static boolean checkPermission(EntityPlayer player, String permissionNode)
+    {
+        return provider.checkPermission(new PermissionContext().setPlayer(player), permissionNode);
+    }
+
+    /**
+     * Checks a permission
+     * 
+     * @param context
+     *            Context, where the permission is checked in.
+     * @param permissionNode
+     *            The permission node, that should be checked
+     * @return Whether the permission is allowed
+     */
+    public static boolean checkPermission(IContext contextInfo, String permissionNode)
+    {
+        return provider.checkPermission(contextInfo, permissionNode);
+    }
+
+    /**
+     * This is where permissions are registered with their default value.
+     * 
+     * @param permissionNode
+     * @param level
+     *            Default level of the permission. This can be used to tell the
+     *            underlying {@link IPermissionsProvider} whether a player
+     *            should be allowed to access this permission by default, or as
+     *            operator only.
+     */
+    public static void registerPermission(String permissionNode, RegisteredPermValue level)
+    {
+        provider.registerPermission(permissionNode, level);
+    }
+
+    /**
+     * Framework authors: <br>
+     * Call this method to register your own implementation of
+     * {@link IPermissionsProvider}. <br>
+     * <br>
+     * Registers a new {@link IPermissionsProvider} to replace the default
+     * implementation. This method can only called in
+     * {@link cpw.mods.fml.common.event.FMLPreInitializationEvent}, otherwise an
+     * {@link IllegalStateException} will be thrown.
+     * 
+     * @param provider
+     *            The new instance that should replace the default
+     *            implementation of {@link IPermissionsProvider}
+     * @throws IllegalStateException
+     */
+    public static void setPermProvider(IPermissionsProvider factory) throws IllegalStateException
+    {
+        if (Loader.instance().hasReachedState(LoaderState.INITIALIZATION))
+        {
+            throw new IllegalStateException(String.format("Attempted to register permissions framework %s after preinit! This is not allowed!", factory.getClass().getName()));
+        }
+        if (factory == null)
+        {
+            throw new IllegalArgumentException("Attempted to register a null provider - this is not allowed!");
+        }
+        else if (wasSet)
+        {
+            throw new IllegalStateException(String.format("Attempted to register permissions framework %s1 when permissions framework %s2 is already registered!", factory.getClass().getName(), provider.getClass().getName()));
+        }
+        else
+        {
+            provider = factory;
+            wasSet = true;
+            FMLLog.fine("Registered permissions framework " + provider.getClass().getName());
+        }
+    }
+    
+    /**
+     * Based on Bukkit's PermissionDefault system.
+     * Accepted names: True, False, Op
+     *
+     */
+    public static enum RegisteredPermValue
+    {
+        TRUE, FALSE, OP;
+        
+        public static RegisteredPermValue fromBoolean(boolean toConvert)
+        {
+            if (toConvert) return TRUE;
+            else return FALSE;
+        }
+    }
+}

--- a/src/main/java/net/minecraftforge/server/CommandHandlerForge.java
+++ b/src/main/java/net/minecraftforge/server/CommandHandlerForge.java
@@ -1,0 +1,103 @@
+package net.minecraftforge.server;
+ 
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import cpw.mods.fml.common.FMLLog;
+import net.minecraft.command.CommandBase;
+import net.minecraft.command.CommandHandler;
+import net.minecraft.command.ICommand;
+import net.minecraft.command.ICommandSender;
+import net.minecraft.entity.player.EntityPlayerMP;
+import net.minecraft.server.MinecraftServer;
+import net.minecraftforge.permissions.PermissionsManager;
+import net.minecraftforge.permissions.PermissionsManager.RegisteredPermValue;
+
+import static net.minecraftforge.permissions.PermissionsManager.RegisteredPermValue.*;
+ 
+/**
+ * Helper class for Forge permissions and command handling.
+ *
+ */
+public class CommandHandlerForge {
+    
+    private static Map<String, String> permMap = new HashMap<String, String>();
+    
+    /**
+     * This is a permissions-aware version of
+     * {@link cpw.mods.fml.common.event.FMLServerStartingEvent#registerServerCommand(ICommand)}
+     * . You should be using this, and NOT FML's, if you wish to specify a
+     * custom permission node
+     * 
+     * @param your
+     *            ICommand
+     * @param node
+     *            a permission node
+     * @param permLevel
+     *            the default permission level ({@link RegisteredPermValue})
+     */
+    public static void registerCommand(ICommand command, String node, RegisteredPermValue permLevel)
+    {
+        if (permMap.containsKey(command.getCommandName()))
+        {
+            FMLLog.warning("Command %s registered a duplicate permission!", command);
+        }
+        permMap.put(command.getCommandName(), node);
+        PermissionsManager.registerPermission(node, permLevel);
+        CommandHandler ch = (CommandHandler) MinecraftServer.getServer().getCommandManager();
+        ch.registerCommand(command);
+    }
+    
+    /**
+     * INTERNAL USE ONLY - used by CommandHandler for auto-registration of command permissions
+     * Mods should be using registerCommand(ICommand, String, RegisteredPermValue)
+     * @param cmd
+     */
+    public static void doPermissionReg(ICommand cmd)
+    {
+        if (permMap.containsKey(cmd.getCommandName()))return;
+        
+        String node = cmd.getClass().getName().startsWith("net.minecraft.command") ? "mc." : "cmd." + cmd.getCommandName();
+
+        RegisteredPermValue value;
+        if (cmd instanceof CommandBase){
+            int level = ((CommandBase) cmd).getRequiredPermissionLevel();
+            
+            switch (level)
+            {
+            case 0: 
+                value = TRUE;
+                break;
+            case 1:
+            case 2:
+            case 3:
+            case 4:
+                value = OP;
+                break;
+            default:
+                value = FALSE;
+            }
+        }
+        else
+            value = OP;
+        permMap.put(cmd.getCommandName(), "mc." + cmd.getCommandName());
+        PermissionsManager.registerPermission("mc." + cmd.getCommandName(), value);
+    }
+    
+    /**
+     * INTERNAL USE ONLY - used by CommandHandler to check usage permissions
+     * If you need to check permissions for non-command objects, or additional permissions for commands,
+     * call PermissionsManager directly.
+     */
+    public static boolean canUse(ICommand command, ICommandSender sender)
+    {
+        if (sender instanceof EntityPlayerMP && permMap.get(command.getCommandName()) != null)
+        {
+            return PermissionsManager.checkPermission((EntityPlayerMP) sender, permMap.get(command.getCommandName()));
+        }
+        else return command.canCommandSenderUseCommand(sender);
+    }
+
+}

--- a/src/main/java/net/minecraftforge/server/command/ForgeCommand.java
+++ b/src/main/java/net/minecraftforge/server/command/ForgeCommand.java
@@ -2,12 +2,17 @@ package net.minecraftforge.server.command;
 
 import java.lang.ref.WeakReference;
 import java.text.DecimalFormat;
+
 import net.minecraft.command.CommandBase;
 import net.minecraft.command.ICommandSender;
 import net.minecraft.command.WrongUsageException;
+import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.server.MinecraftServer;
 import net.minecraft.util.ChatComponentTranslation;
 import net.minecraftforge.common.DimensionManager;
+import net.minecraftforge.permissions.PermissionsManager;
+import net.minecraftforge.permissions.PermissionsManager.RegisteredPermValue;
+import net.minecraftforge.server.CommandHandlerForge;
 import net.minecraftforge.server.ForgeTimeTracker;
 
 public class ForgeCommand extends CommandBase {
@@ -18,6 +23,11 @@ public class ForgeCommand extends CommandBase {
     public ForgeCommand(MinecraftServer server)
     {
         this.server = new WeakReference(server);
+        // the master permission has been registered in ForgeModContainer
+        
+        // slave permissions, so use PermissionsManager
+        PermissionsManager.registerPermission("forge.tps", RegisteredPermValue.OP);
+        PermissionsManager.registerPermission("forge.track", RegisteredPermValue.OP);
     }
 
     @Override
@@ -40,6 +50,19 @@ public class ForgeCommand extends CommandBase {
     @Override
     public void processCommand(ICommandSender sender, String[] args)
     {
+        boolean allowTPS, allowTracking;
+        
+        if (sender instanceof EntityPlayer)
+        {
+            allowTPS = PermissionsManager.checkPermission((EntityPlayer) sender, "forge.tps");
+            allowTracking = PermissionsManager.checkPermission((EntityPlayer) sender, "forge.track");
+        }
+        
+        else{
+            allowTPS = true;
+            allowTracking = true;
+        }
+        
         if (args.length == 0)
         {
             throw new WrongUsageException("commands.forge.usage");
@@ -48,7 +71,7 @@ public class ForgeCommand extends CommandBase {
         {
             throw new WrongUsageException("commands.forge.usage");
         }
-        else if ("tps".equals(args[0]))
+        else if ("tps".equals(args[0]) && allowTPS)
         {
             displayTPS(sender,args);
         }
@@ -56,7 +79,7 @@ public class ForgeCommand extends CommandBase {
         {
             doTPSLog(sender,args);
         }
-        else if ("track".equals(args[0]))
+        else if ("track".equals(args[0]) && allowTracking)
         {
             handleTracking(sender, args);
         }


### PR DESCRIPTION
Permissions API specification and default implementation by me, @olee and @AbrarSyed

Patches:
CommandHandler: Redirect all canCommandSenderUseCommand calls to a forge equivalent, which is permissions-aware
EntityPlayerMP: Allow all commands to be used, to let the permissions API handle the permission checks
NetHandlerPlayServer: Allow command blocks to be controlled by permissions

This commit introduces a new way to handle command registrations. A new permissions-aware method to register commands is in CommandHandlerForge. Please use this instead of the FMLServerStartingEvent if you wish to be compatible with permissions (and not just assigned an auto-generated node)

This is a re-pull of #1220, we've modified the API to make it easier to use. Also switched to targeting the new branch instead of master.

Please do get in touch with us if there's anything we can do to make this API meet your needs.

NOTE: This PR will not function properly unless MinecraftForge/FML#498 is also accepted!

Forge Essentials is already implementing the API specified here in its 1.7.10 versions.
