### PR TITLE
Added SignEditEvent

### DIFF
--- a/patches/minecraft/net/minecraft/network/NetHandlerPlayServer.java.patch
+++ b/patches/minecraft/net/minecraft/network/NetHandlerPlayServer.java.patch
@@ -145,3 +145,50 @@
                  }
  
                  break;
+@@ -938,6 +978,9 @@
+                     return;
+                 }
+             }
++            
++            String[] text = ForgeHooks.onSignEditEvent(this, p_147343_1_);
++            if (text == null)return;
+ 
+             int i;
+             int j;
+@@ -946,15 +989,15 @@
+             {
+                 boolean flag = true;
+ 
+-                if (p_147343_1_.func_149589_f()[j].length() > 15)
++                if (text[j].length() > 15)
+                 {
+                     flag = false;
+                 }
+                 else
+                 {
+-                    for (i = 0; i < p_147343_1_.func_149589_f()[j].length(); ++i)
++                    for (i = 0; i < text[j].length(); ++i)
+                     {
+-                        if (!ChatAllowedCharacters.func_71566_a(p_147343_1_.func_149589_f()[j].charAt(i)))
++                        if (!ChatAllowedCharacters.func_71566_a(text[j].charAt(i)))
+                         {
+                             flag = false;
+                         }
+@@ -963,7 +1006,7 @@
+ 
+                 if (!flag)
+                 {
+-                    p_147343_1_.func_149589_f()[j] = "!?";
++                    text[j] = "!?";
+                 }
+             }
+ 
+@@ -973,7 +1016,7 @@
+                 int k = p_147343_1_.func_149586_d();
+                 i = p_147343_1_.func_149585_e();
+                 TileEntitySign tileentitysign1 = (TileEntitySign)tileentity;
+-                System.arraycopy(p_147343_1_.func_149589_f(), 0, tileentitysign1.field_145915_a, 0, 4);
++                System.arraycopy(text, 0, tileentitysign1.field_145915_a, 0, 4);
+                 tileentitysign1.func_70296_d();
+                 worldserver.func_147471_g(j, k, i);
+             }

--- a/src/main/java/net/minecraftforge/common/ForgeHooks.java
+++ b/src/main/java/net/minecraftforge/common/ForgeHooks.java
@@ -24,6 +24,7 @@ import net.minecraft.item.ItemStack;
 import net.minecraft.item.ItemSword;
 import net.minecraft.network.NetHandlerPlayServer;
 import net.minecraft.network.Packet;
+import net.minecraft.network.play.client.C12PacketUpdateSign;
 import net.minecraft.network.play.server.S23PacketBlockChange;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.tileentity.TileEntityNote;
@@ -38,6 +39,7 @@ import net.minecraft.world.World;
 import net.minecraft.world.WorldSettings.GameType;
 import net.minecraftforge.event.AnvilUpdateEvent;
 import net.minecraftforge.event.ServerChatEvent;
+import net.minecraftforge.event.SignEditEvent;
 import net.minecraftforge.event.entity.item.ItemTossEvent;
 import net.minecraftforge.event.entity.living.LivingAttackEvent;
 import net.minecraftforge.event.entity.living.LivingDeathEvent;
@@ -459,5 +461,16 @@ public class ForgeHooks
         }
         te.note = (byte)e.getVanillaNoteId();
         return true;
+    }
+    
+    public static String[] onSignEditEvent(NetHandlerPlayServer net, C12PacketUpdateSign data)
+    {
+        SignEditEvent e = new SignEditEvent(data.func_149588_c(), data.func_149586_d(), data.func_149585_e(), data.func_149589_f(), net.playerEntity);
+        if (MinecraftForge.EVENT_BUS.post(e))
+        {
+            return null;
+        }
+        return e.text;
+        
     }
 }

--- a/src/main/java/net/minecraftforge/event/SignEditEvent.java
+++ b/src/main/java/net/minecraftforge/event/SignEditEvent.java
@@ -1,0 +1,42 @@
+package net.minecraftforge.event;
+
+import net.minecraft.entity.player.EntityPlayerMP;
+import cpw.mods.fml.common.eventhandler.Cancelable;
+import cpw.mods.fml.common.eventhandler.Event;
+
+/**
+ * SignEditEvent is fired whenever a C12PacketUpdateSign is processed. If you have a custom sign, please manually fire this event. <br>
+ * This event is fired via {@link ForgeHooks#onSignEditEvent(NetHandlerPlayServer, C12PacketUpdateSign)}, 
+ * which is executed by the NetHandlerPlayServer#processUpdateSign(net.minecraft.network.play.client.C12PacketUpdateSign)<br>
+ * <br>
+ * {@link #text} contains the text being written.<br>
+ * {@link #player} the instance of EntityPlayerMP for the player sending the chat message.<br>
+ * {@link #x} contains the x-coordinate of the sign being edited.
+ * {@link #y} contains the y-coordinate of the sign being edited.
+ * {@link #z} contains the z-coordinate of the sign being edited.<br>
+ * <br>
+ * This event is {@link Cancelable}. <br>
+ * If this event is canceled, the chat message is never distributed to all clients.<br>
+ * <br>
+ * This event does not have a result. {@link HasResult}<br>
+ * <br>
+ * This event is fired on the {@link MinecraftForge#EVENT_BUS}.
+ **/
+
+@Cancelable
+public class SignEditEvent extends Event
+{
+    public final int x, y, z;
+    public final String[] text;
+    public final EntityPlayerMP editor;
+    
+    public SignEditEvent(int x, int y, int z, String[] text, EntityPlayerMP editor)
+    {
+        super();
+        this.x = x;
+        this.y = y;
+        this.z = z;
+        this.text = text;
+        this.editor = editor;
+    }
+}


### PR DESCRIPTION
This event allows mods to manipulate sign text at edit time. This is useful for serverside mods to define coloured text, censor unacceptable words, etc, like what is possible in ServerChatEvent. Mods providing custom signs are expected to manually throw this event.

The text field is an array containing the 4 lines of text that should be written to the sign. You'll want to modify this. This array may be larger than 4 lines, if thrown by a mod providing custom signs.

The additional parameters are for protection plugins to determine whether the sign should be edited.

I apologise for the size of the NetHandlerPlayServer patch, however it is required to actually apply the edited text to the sign.

This is a re-pull of PR #1391, targeting the new branch instead of master.
