### PR TITLE
Added server-side EnchantItemEvent

### DIFF
--- a/patches/minecraft/net/minecraft/inventory/ContainerEnchantment.java.patch
+++ b/patches/minecraft/net/minecraft/inventory/ContainerEnchantment.java.patch
@@ -1,14 +1,6 @@
 --- ../src-base/minecraft/net/minecraft/inventory/ContainerEnchantment.java
 +++ ../src-work/minecraft/net/minecraft/inventory/ContainerEnchantment.java
-@@ -12,6 +12,7 @@
- import net.minecraft.init.Items;
- import net.minecraft.item.ItemStack;
- import net.minecraft.world.World;
-+import net.minecraftforge.common.ForgeHooks;
- 
- public class ContainerEnchantment extends Container
- {
-@@ -116,6 +117,7 @@
+@@ -116,6 +116,7 @@
                  {
                      i = 0;
                      int j;
@@ -16,7 +8,7 @@
  
                      for (j = -1; j <= 1; ++j)
                      {
-@@ -123,37 +125,15 @@
+@@ -123,37 +124,15 @@
                          {
                              if ((j != 0 || k != 0) && this.field_75172_h.func_147437_c(this.field_75173_i + k, this.field_75170_j, this.field_75171_k + j) && this.field_75172_h.func_147437_c(this.field_75173_i + k, this.field_75170_j + 1, this.field_75171_k + j))
                              {
@@ -24,8 +16,8 @@
 -                                {
 -                                    ++i;
 -                                }
-+                                power += ForgeHooks.getEnchantPower(field_75172_h, field_75173_i + k * 2, field_75170_j,     field_75171_k + j * 2);
-+                                power += ForgeHooks.getEnchantPower(field_75172_h, field_75173_i + k * 2, field_75170_j + 1, field_75171_k + j * 2);
++                                power += net.minecraftforge.common.ForgeHooks.getEnchantPower(field_75172_h, field_75173_i + k * 2, field_75170_j,     field_75171_k + j * 2);
++                                power += net.minecraftforge.common.ForgeHooks.getEnchantPower(field_75172_h, field_75173_i + k * 2, field_75170_j + 1, field_75171_k + j * 2);
  
 -                                if (this.field_75172_h.func_147439_a(this.field_75173_i + k * 2, this.field_75170_j + 1, this.field_75171_k + j * 2) == Blocks.field_150342_X)
 -                                {
@@ -53,14 +45,14 @@
 -                                    {
 -                                        ++i;
 -                                    }
-+                                    power += ForgeHooks.getEnchantPower(field_75172_h, field_75173_i + k * 2, field_75170_j,     field_75171_k + j    );
-+                                    power += ForgeHooks.getEnchantPower(field_75172_h, field_75173_i + k * 2, field_75170_j + 1, field_75171_k + j    );
-+                                    power += ForgeHooks.getEnchantPower(field_75172_h, field_75173_i + k,     field_75170_j,     field_75171_k + j * 2);
-+                                    power += ForgeHooks.getEnchantPower(field_75172_h, field_75173_i + k,     field_75170_j + 1, field_75171_k + j * 2);
++                                    power += net.minecraftforge.common.ForgeHooks.getEnchantPower(field_75172_h, field_75173_i + k * 2, field_75170_j,     field_75171_k + j    );
++                                    power += net.minecraftforge.common.ForgeHooks.getEnchantPower(field_75172_h, field_75173_i + k * 2, field_75170_j + 1, field_75171_k + j    );
++                                    power += net.minecraftforge.common.ForgeHooks.getEnchantPower(field_75172_h, field_75173_i + k,     field_75170_j,     field_75171_k + j * 2);
++                                    power += net.minecraftforge.common.ForgeHooks.getEnchantPower(field_75172_h, field_75173_i + k,     field_75170_j + 1, field_75171_k + j * 2);
                                  }
                              }
                          }
-@@ -161,7 +141,7 @@
+@@ -161,7 +140,7 @@
  
                      for (j = 0; j < 3; ++j)
                      {
@@ -69,3 +61,38 @@
                      }
  
                      this.func_75142_b();
+@@ -179,7 +158,8 @@
+ 
+     public boolean func_75140_a(EntityPlayer p_75140_1_, int p_75140_2_)
+     {
+-        ItemStack itemstack = this.field_75168_e.func_70301_a(0);
++        ItemStack original = this.field_75168_e.func_70301_a(0);
++        ItemStack itemstack = original.func_77946_l();
+ 
+         if (this.field_75167_g[p_75140_2_] > 0 && itemstack != null && (p_75140_1_.field_71068_ca >= this.field_75167_g[p_75140_2_] || p_75140_1_.field_71075_bZ.field_75098_d))
+         {
+@@ -190,8 +170,6 @@
+ 
+                 if (list != null)
+                 {
+-                    p_75140_1_.func_82242_a(-this.field_75167_g[p_75140_2_]);
+-
+                     if (flag)
+                     {
+                         itemstack.func_150996_a(Items.field_151134_bR);
+@@ -215,8 +193,13 @@
+                             }
+                         }
+                     }
+-
+-                    this.func_75130_a(this.field_75168_e);
++                    net.minecraftforge.event.entity.player.EnchantItemEvent event = new net.minecraftforge.event.entity.player.EnchantItemEvent(p_75140_1_, original.func_77946_l(), itemstack, p_75140_2_, this.field_75167_g[p_75140_2_]);
++                    net.minecraftforge.common.MinecraftForge.EVENT_BUS.post(event);
++                    if (!event.isCanceled()){
++                        this.field_75168_e.func_70299_a(0, event.output);
++                        p_75140_1_.func_82242_a(-this.field_75167_g[p_75140_2_]);
++                        this.func_75130_a(this.field_75168_e);
++                    }
+                 }
+             }
+ 

--- a/src/main/java/net/minecraftforge/event/entity/player/EnchantItemEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/player/EnchantItemEvent.java
@@ -1,0 +1,41 @@
+package net.minecraftforge.event.entity.player;
+
+import cpw.mods.fml.common.eventhandler.Cancelable;
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.item.ItemStack;
+
+/**
+ * Fired when the player enchants an item with an enchanting table.
+ * This only fires server-side.
+ * It does not fire on /enchant. Use command events for that.
+ */
+@Cancelable 
+public class EnchantItemEvent extends PlayerEvent
+{
+    /**
+     * This is the ItemStack the player enchanted. Do not modify it, so other mods may access it. 
+     */
+    public final ItemStack input;
+    /**
+     * This is the ItemStack that resulted from enchanting. You may change it.
+     */
+    public ItemStack output;
+    /**
+     * This is the slot from which the enchantment resulted. 0 is top, 1 is middle, and 2 is bottom.
+     */
+    public final int slot;
+    /**
+     * This is the number of levels the player spent to enchant the item. (Or didn't spend, if in Creative.)
+     */
+    public final int level;
+    
+    public EnchantItemEvent(EntityPlayer player, ItemStack input, ItemStack output, int slot, int level)
+    {
+        super(player);
+        this.input = input;
+        this.output = output;
+        this.slot = slot;
+        this.level = level;
+    }
+}
+


### PR DESCRIPTION
This is a server-side EnchantItemEvent that fires when a player enchants an item with an enchanting table. Modders may change the output or cancel the event. 

This is a re-pull of #1407 but on the branch new instead of master.
