### PR TITLE
Implemented ShouldRenderPassEvent for all entities

### DIFF
--- a/patches/minecraft/net/minecraft/client/renderer/entity/RenderBiped.java.patch
+++ b/patches/minecraft/net/minecraft/client/renderer/entity/RenderBiped.java.patch
@@ -14,7 +14,20 @@
      public static ResourceLocation func_110858_a(ItemArmor p_110858_0_, int p_110858_1_, String p_110858_2_)
      {
          String s1 = String.format("textures/models/armor/%s_layer_%d%s.png", new Object[] {field_82424_k[p_110858_0_.field_77880_c], Integer.valueOf(p_110858_1_ == 2 ? 2 : 1), p_110858_2_ == null ? "" : String.format("_%s", new Object[]{p_110858_2_})});
-@@ -84,7 +86,7 @@
+@@ -77,6 +79,12 @@
+     {
+         ItemStack itemstack = p_77032_1_.func_130225_q(3 - p_77032_2_);
+ 
++        net.minecraftforge.client.event.ShouldRenderPassEvent event = new net.minecraftforge.client.event.ShouldRenderPassEvent(p_77032_1_, this,  p_77032_3_,3 - p_77032_2_, itemstack);
++        net.minecraftforge.common.MinecraftForge.EVENT_BUS.post(event);
++        if (event.result != -1)
++        {
++            return event.result;
++        }
+         if (itemstack != null)
+         {
+             Item item = itemstack.func_77973_b();
+@@ -84,7 +92,7 @@
              if (item instanceof ItemArmor)
              {
                  ItemArmor itemarmor = (ItemArmor)item;
@@ -23,7 +36,7 @@
                  ModelBiped modelbiped = p_77032_2_ == 2 ? this.field_82425_h : this.field_82423_g;
                  modelbiped.field_78116_c.field_78806_j = p_77032_2_ == 0;
                  modelbiped.field_78114_d.field_78806_j = p_77032_2_ == 0;
-@@ -93,14 +95,16 @@
+@@ -93,14 +101,16 @@
                  modelbiped.field_78113_g.field_78806_j = p_77032_2_ == 1;
                  modelbiped.field_78123_h.field_78806_j = p_77032_2_ == 2 || p_77032_2_ == 3;
                  modelbiped.field_78124_i.field_78806_j = p_77032_2_ == 2 || p_77032_2_ == 3;
@@ -42,7 +55,7 @@
                      float f1 = (float)(j >> 16 & 255) / 255.0F;
                      float f2 = (float)(j >> 8 & 255) / 255.0F;
                      float f3 = (float)(j & 255) / 255.0F;
-@@ -138,7 +142,7 @@
+@@ -138,7 +148,7 @@
  
              if (item instanceof ItemArmor)
              {
@@ -51,7 +64,7 @@
                  float f1 = 1.0F;
                  GL11.glColor3f(1.0F, 1.0F, 1.0F);
              }
-@@ -189,9 +193,12 @@
+@@ -189,9 +199,12 @@
              this.field_77071_a.field_78116_c.func_78794_c(0.0625F);
              item = itemstack1.func_77973_b();
  
@@ -65,7 +78,7 @@
                  {
                      f1 = 0.625F;
                      GL11.glTranslatef(0.0F, -0.25F, 0.0F);
-@@ -243,7 +250,10 @@
+@@ -243,7 +256,10 @@
              this.field_77071_a.field_78112_f.func_78794_c(0.0625F);
              GL11.glTranslatef(-0.0625F, 0.4375F, 0.0625F);
  
@@ -77,7 +90,7 @@
              {
                  f1 = 0.5F;
                  GL11.glTranslatef(0.0F, 0.1875F, -0.3125F);
-@@ -292,7 +302,7 @@
+@@ -292,7 +308,7 @@
  
              if (itemstack.func_77973_b().func_77623_v())
              {
@@ -86,7 +99,7 @@
                  {
                      int j = itemstack.func_77973_b().func_82790_a(itemstack, i);
                      f5 = (float)(j >> 16 & 255) / 255.0F;
-@@ -350,4 +360,33 @@
+@@ -350,4 +366,33 @@
      {
          this.func_76986_a((EntityLiving)p_76986_1_, p_76986_2_, p_76986_4_, p_76986_6_, p_76986_8_, p_76986_9_);
      }

--- a/patches/minecraft/net/minecraft/client/renderer/entity/RenderPlayer.java.patch
+++ b/patches/minecraft/net/minecraft/client/renderer/entity/RenderPlayer.java.patch
@@ -4,7 +4,7 @@
      {
          ItemStack itemstack = p_77032_1_.field_71071_by.func_70440_f(3 - p_77032_2_);
  
-+        net.minecraftforge.client.event.RenderPlayerEvent.SetArmorModel event = new net.minecraftforge.client.event.RenderPlayerEvent.SetArmorModel(p_77032_1_, this, 3 - p_77032_2_, p_77032_3_, itemstack);
++        net.minecraftforge.client.event.ShouldRenderPassEvent event = new net.minecraftforge.client.event.ShouldRenderPassEvent(p_77032_1_, this,  p_77032_3_,3 - p_77032_2_, itemstack);
 +        net.minecraftforge.common.MinecraftForge.EVENT_BUS.post(event);
 +        if (event.result != -1)
 +        {

--- a/src/main/java/net/minecraftforge/client/event/RenderPlayerEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/RenderPlayerEvent.java
@@ -51,6 +51,7 @@ public abstract class RenderPlayerEvent extends PlayerEvent
         }
     }
 
+    @Deprecated
     public static class SetArmorModel extends RenderPlayerEvent
     {
         /**

--- a/src/main/java/net/minecraftforge/client/event/ShouldRenderPassEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/ShouldRenderPassEvent.java
@@ -1,0 +1,41 @@
+package net.minecraftforge.client.event;
+
+import net.minecraft.client.renderer.entity.Render;
+import net.minecraft.entity.Entity;
+import net.minecraft.item.ItemStack;
+import net.minecraftforge.event.entity.EntityEvent;
+
+/**
+ * This event is used to either take over the rendering a certain layer of armor,
+ * by setting the result to -2 (which cancels the rendering of that layer and allows
+ * you to render it with the data provided by this event), or change the ShouldRenderPass
+ * value, telling the vanilla renderer to add special things, like the enchantment
+ * glint, to the current layer being rendered.
+ * 
+ * This event replaces RenderPlayerEvent.setArmorModel.
+ * On each renderpass a different piece of armor is rendered.
+ * For each entity wearing armor this event is fired up to four times during one rendertick.
+ * 
+ * The event is posted when a renderer needs to know if a certain a layer of a armortexture
+ * needs special treatment.
+ */
+public class ShouldRenderPassEvent extends EntityEvent
+{
+
+    public final Render render;
+    public final float partialTickTime;
+    public final int slot;
+    public final ItemStack armorStack;
+    
+    public int result = -1;
+    
+    public ShouldRenderPassEvent(Entity entity, Render render, float partialTickTime, int slot, ItemStack armorStack)
+    {
+        super(entity);
+        
+        this.render = render;
+        this.partialTickTime = partialTickTime;
+        this.slot = slot;
+        this.armorStack = armorStack;
+    }
+}


### PR DESCRIPTION
This change adds the possibility of modifying the renderpass of a piece of armor to every entity that wears armor. As long as they implement this event.

Added the event to Biped entities as an example and an actual addition, cause my initial PR #1392 was just for this purpose.

After some discussions on IRC I decided to make the event general so that it could be reused for the 1.8 Armorstands. Once there is a branch on 1.8 i will make a PR for that to implement it properly.

I also marked RenderPlayerEvent.setArmorModel as Deprecated as it is completely replaced with this event that has the same functionality. On said upcoming PR for 1.8 i will also remove that event completely from the code, giving people time to adapt if they are depending on it, and cleaning up that bid of redundant code.

During said discussion on IRC no one seemed to know were the name setArmorModel came from, after looking through the history of that class I could not find the person who implemented it so after some thinking i also renamed the event to a more understandable one: ShouldRenderPassEvent.

I also added a description to the event as that was not available for the setArmorModel one. It explains what is possible with this powerful rendering event.