### PR TITLE
Added Block.canPlaceInFlowerPot

### DIFF
--- a/patches/minecraft/net/minecraft/block/Block.java.patch
+++ b/patches/minecraft/net/minecraft/block/Block.java.patch
@@ -199,7 +199,7 @@
      }
  
      protected ItemStack func_149644_j(int p_149644_1_)
-@@ -1114,6 +1153,1099 @@
+@@ -1114,6 +1153,1115 @@
          return null;
      }
  
@@ -1189,6 +1189,22 @@
 +    public boolean getWeakChanges(IBlockAccess world, int x, int y, int z)
 +    {
 +        return false;
++    }
++    
++    /**
++     * Returns true if this block from then given {@link ItemStack} {@code stack}
++     * can be placed in a flower pot in the given location. Delegates to
++     * {@link Block#canPlaceInFlowerPot(int)}.
++     * @param stack the stack
++     * @param world the world
++     * @param x the x position of the flower pot
++     * @param y the y position of the flower pot
++     * @param z the z position of the flower pot
++     * @return true, if the block can be placed in a flower pot
++     */
++    public boolean canPlaceInFlowerPot(ItemStack stack, World world, int x, int y, int z)
++    {
++        return this == Blocks.field_150327_N || this == Blocks.field_150328_O || this == Blocks.field_150434_aF || this == Blocks.field_150338_P || this == Blocks.field_150337_Q || this == Blocks.field_150345_g || this == Blocks.field_150330_I || (this == Blocks.field_150329_H && stack.func_77960_j() == 2);
 +    }
 +
 +    private String[] harvestTool = new String[16];

--- a/patches/minecraft/net/minecraft/block/BlockFlowerPot.java.patch
+++ b/patches/minecraft/net/minecraft/block/BlockFlowerPot.java.patch
@@ -8,6 +8,15 @@
  import java.util.Random;
  import net.minecraft.block.material.Material;
  import net.minecraft.entity.player.EntityPlayer;
+@@ -64,7 +65,7 @@
+                 {
+                     Block block = Block.func_149634_a(itemstack.func_77973_b());
+ 
+-                    if (!this.func_149928_a(block, itemstack.func_77960_j()))
++                    if (!block.canPlaceInFlowerPot(itemstack, p_149727_1_, p_149727_2_, p_149727_3_, p_149727_4_))
+                     {
+                         return false;
+                     }
 @@ -138,13 +139,6 @@
  
      public void func_149749_a(World p_149749_1_, int p_149749_2_, int p_149749_3_, int p_149749_4_, Block p_149749_5_, int p_149749_6_)


### PR DESCRIPTION
Added hook for Blocks to check if they can be placed in Flower Pots. Useful for custom plants and saplings.
