### PR TITLE
Update BiomeBlocksEvent

### DIFF
--- a/patches/minecraft/net/minecraft/world/gen/ChunkProviderEnd.java.patch
+++ b/patches/minecraft/net/minecraft/world/gen/ChunkProviderEnd.java.patch
@@ -37,14 +37,22 @@
 +    }
 +    public void replaceBiomeBlocks(int p_147421_1_, int p_147421_2_, Block[] p_147421_3_, BiomeGenBase[] p_147421_4_, byte[] meta)
 +    {
-+        ChunkProviderEvent.ReplaceBiomeBlocks event = new ChunkProviderEvent.ReplaceBiomeBlocks(this, p_147421_1_, p_147421_2_, p_147421_3_, meta, p_147421_4_, this.field_73200_m);
++        ChunkProviderEvent.ReplaceBiomeBlocks event = new ChunkProviderEvent.ReplaceBiomeBlocks.Pre(this, p_147421_1_, p_147421_2_, p_147421_3_, meta, p_147421_4_, null, this.field_73200_m);
 +        MinecraftForge.EVENT_BUS.post(event);
 +        if (event.getResult() == Result.DENY) return;
 +
          for (int k = 0; k < 16; ++k)
          {
              for (int l = 0; l < 16; ++l)
-@@ -177,10 +198,11 @@
+@@ -166,6 +187,7 @@
+                 }
+             }
+         }
++        MinecraftForge.EVENT_BUS.post(new ChunkProviderEvent.ReplaceBiomeBlocks.Post(this, p_147421_1_, p_147421_2_, p_147421_3_, meta, p_147421_4_, null, this.field_73200_m));
+     }
+ 
+     public Chunk func_73158_c(int p_73158_1_, int p_73158_2_)
+@@ -177,10 +199,11 @@
      {
          this.field_73204_i.setSeed((long)p_73154_1_ * 341873128712L + (long)p_73154_2_ * 132897987541L);
          Block[] ablock = new Block[32768];
@@ -58,7 +66,7 @@
          byte[] abyte = chunk.func_76605_m();
  
          for (int k = 0; k < abyte.length; ++k)
-@@ -194,6 +216,10 @@
+@@ -194,6 +217,10 @@
  
      private double[] func_73187_a(double[] p_73187_1_, int p_73187_2_, int p_73187_3_, int p_73187_4_, int p_73187_5_, int p_73187_6_, int p_73187_7_)
      {
@@ -69,7 +77,7 @@
          if (p_73187_1_ == null)
          {
              p_73187_1_ = new double[p_73187_5_ * p_73187_6_ * p_73187_7_];
-@@ -335,10 +361,16 @@
+@@ -335,10 +362,16 @@
      public void func_73153_a(IChunkProvider p_73153_1_, int p_73153_2_, int p_73153_3_)
      {
          BlockFalling.field_149832_M = true;

--- a/patches/minecraft/net/minecraft/world/gen/ChunkProviderGenerate.java.patch
+++ b/patches/minecraft/net/minecraft/world/gen/ChunkProviderGenerate.java.patch
@@ -46,18 +46,26 @@
      }
  
      public void func_147424_a(int p_147424_1_, int p_147424_2_, Block[] p_147424_3_)
-@@ -157,6 +182,10 @@
- 
-     public void func_147422_a(int p_147422_1_, int p_147422_2_, Block[] p_147422_3_, byte[] p_147422_4_, BiomeGenBase[] p_147422_5_)
-     {
-+        ChunkProviderEvent.ReplaceBiomeBlocks event = new ChunkProviderEvent.ReplaceBiomeBlocks(this, p_147422_1_, p_147422_2_, p_147422_3_, p_147422_4_, p_147422_5_, this.field_73230_p);
-+        MinecraftForge.EVENT_BUS.post(event);
-+        if (event.getResult() == Result.DENY) return;
-+
+@@ -160,6 +185,10 @@
          double d0 = 0.03125D;
          this.field_73227_s = this.field_147430_m.func_151599_a(this.field_73227_s, (double)(p_147422_1_ * 16), (double)(p_147422_2_ * 16), 16, 16, d0 * 2.0D, d0 * 2.0D, 1.0D);
  
-@@ -345,6 +374,8 @@
++        ChunkProviderEvent.ReplaceBiomeBlocks event = new ChunkProviderEvent.ReplaceBiomeBlocks.Pre(this, p_147422_1_, p_147422_2_, p_147422_3_, p_147422_4_, p_147422_5_, this.field_73227_s, this.field_73230_p);
++        MinecraftForge.EVENT_BUS.post(event);
++        if (event.getResult() == Result.DENY) return;
++
+         for (int k = 0; k < 16; ++k)
+         {
+             for (int l = 0; l < 16; ++l)
+@@ -168,6 +197,7 @@
+                 biomegenbase.func_150573_a(this.field_73230_p, this.field_73220_k, p_147422_3_, p_147422_4_, p_147422_1_ * 16 + k, p_147422_2_ * 16 + l, this.field_73227_s[l + k * 16]);
+             }
+         }
++        MinecraftForge.EVENT_BUS.post(new ChunkProviderEvent.ReplaceBiomeBlocks.Post(this, p_147422_1_, p_147422_2_, p_147422_3_, p_147422_4_, p_147422_5_, this.field_73227_s, this.field_73230_p));
+     }
+ 
+     public Chunk func_73158_c(int p_73158_1_, int p_73158_2_)
+@@ -345,6 +375,8 @@
          this.field_73220_k.setSeed((long)p_73153_2_ * i1 + (long)p_73153_3_ * j1 ^ this.field_73230_p.func_72905_C());
          boolean flag = false;
  
@@ -66,7 +74,7 @@
          if (this.field_73229_q)
          {
              this.field_73223_w.func_75051_a(this.field_73230_p, this.field_73220_k, p_73153_2_, p_73153_3_);
-@@ -357,7 +388,8 @@
+@@ -357,7 +389,8 @@
          int l1;
          int i2;
  
@@ -76,7 +84,7 @@
          {
              k1 = k + this.field_73220_k.nextInt(16) + 8;
              l1 = this.field_73220_k.nextInt(256);
-@@ -365,7 +397,7 @@
+@@ -365,7 +398,7 @@
              (new WorldGenLakes(Blocks.field_150355_j)).func_76484_a(this.field_73230_p, this.field_73220_k, k1, l1, i2);
          }
  
@@ -85,7 +93,7 @@
          {
              k1 = k + this.field_73220_k.nextInt(16) + 8;
              l1 = this.field_73220_k.nextInt(this.field_73220_k.nextInt(248) + 8);
-@@ -377,7 +409,8 @@
+@@ -377,7 +410,8 @@
              }
          }
  
@@ -95,7 +103,7 @@
          {
              l1 = k + this.field_73220_k.nextInt(16) + 8;
              i2 = this.field_73220_k.nextInt(256);
-@@ -386,11 +419,15 @@
+@@ -386,11 +420,15 @@
          }
  
          biomegenbase.func_76728_a(this.field_73230_p, this.field_73220_k, k, l);
@@ -112,7 +120,7 @@
          {
              for (l1 = 0; l1 < 16; ++l1)
              {
-@@ -408,6 +445,8 @@
+@@ -408,6 +446,8 @@
              }
          }
  

--- a/patches/minecraft/net/minecraft/world/gen/ChunkProviderHell.java.patch
+++ b/patches/minecraft/net/minecraft/world/gen/ChunkProviderHell.java.patch
@@ -55,14 +55,22 @@
 +    }
 +    public void replaceBiomeBlocks(int p_147418_1_, int p_147418_2_, Block[] p_147418_3_, byte[] meta, BiomeGenBase[] biomes)
 +    {
-+        ChunkProviderEvent.ReplaceBiomeBlocks event = new ChunkProviderEvent.ReplaceBiomeBlocks(this, p_147418_1_, p_147418_2_, p_147418_3_, meta, biomes, this.field_73175_o);
++        ChunkProviderEvent.ReplaceBiomeBlocks event = new ChunkProviderEvent.ReplaceBiomeBlocks.Pre(this, p_147418_1_, p_147418_2_, p_147418_3_, meta, biomes, null, this.field_73175_o);
 +        MinecraftForge.EVENT_BUS.post(event);
 +        if (event.getResult() == Result.DENY) return;
 +
          byte b0 = 64;
          double d0 = 0.03125D;
          this.field_73185_q = this.field_73177_m.func_76304_a(this.field_73185_q, p_147418_1_ * 16, p_147418_2_ * 16, 0, 16, 16, 1, d0, d0, 1.0D);
-@@ -234,12 +266,13 @@
+@@ -223,6 +255,7 @@
+                 }
+             }
+         }
++        MinecraftForge.EVENT_BUS.post(new ChunkProviderEvent.ReplaceBiomeBlocks.Post(this, p_147418_1_, p_147418_2_, p_147418_3_, meta, biomes, null, this.field_73175_o));
+     }
+ 
+     public Chunk func_73158_c(int p_73158_1_, int p_73158_2_)
+@@ -234,12 +267,13 @@
      {
          this.field_73181_i.setSeed((long)p_73154_1_ * 341873128712L + (long)p_73154_2_ * 132897987541L);
          Block[] ablock = new Block[32768];
@@ -79,7 +87,7 @@
          byte[] abyte = chunk.func_76605_m();
  
          for (int k = 0; k < abyte.length; ++k)
-@@ -253,6 +286,10 @@
+@@ -253,6 +287,10 @@
  
      private double[] func_73164_a(double[] p_73164_1_, int p_73164_2_, int p_73164_3_, int p_73164_4_, int p_73164_5_, int p_73164_6_, int p_73164_7_)
      {
@@ -90,7 +98,7 @@
          if (p_73164_1_ == null)
          {
              p_73164_1_ = new double[p_73164_5_ * p_73164_6_ * p_73164_7_];
-@@ -399,6 +436,9 @@
+@@ -399,6 +437,9 @@
      public void func_73153_a(IChunkProvider p_73153_1_, int p_73153_2_, int p_73153_3_)
      {
          BlockFalling.field_149832_M = true;
@@ -100,7 +108,7 @@
          int k = p_73153_2_ * 16;
          int l = p_73153_3_ * 16;
          this.field_73172_c.func_75051_a(this.field_73175_o, this.field_73181_i, p_73153_2_, p_73153_3_);
-@@ -407,7 +447,8 @@
+@@ -407,7 +448,8 @@
          int k1;
          int l1;
  
@@ -110,7 +118,7 @@
          {
              j1 = k + this.field_73181_i.nextInt(16) + 8;
              k1 = this.field_73181_i.nextInt(120) + 4;
-@@ -418,7 +459,8 @@
+@@ -418,7 +460,8 @@
          i1 = this.field_73181_i.nextInt(this.field_73181_i.nextInt(10) + 1) + 1;
          int i2;
  
@@ -120,7 +128,7 @@
          {
              k1 = k + this.field_73181_i.nextInt(16) + 8;
              l1 = this.field_73181_i.nextInt(120) + 4;
-@@ -428,7 +470,8 @@
+@@ -428,7 +471,8 @@
  
          i1 = this.field_73181_i.nextInt(this.field_73181_i.nextInt(10) + 1);
  
@@ -130,7 +138,7 @@
          {
              k1 = k + this.field_73181_i.nextInt(16) + 8;
              l1 = this.field_73181_i.nextInt(120) + 4;
-@@ -436,7 +479,7 @@
+@@ -436,7 +480,7 @@
              (new WorldGenGlowStone1()).func_76484_a(this.field_73175_o, this.field_73181_i, k1, l1, i2);
          }
  
@@ -139,7 +147,7 @@
          {
              k1 = k + this.field_73181_i.nextInt(16) + 8;
              l1 = this.field_73181_i.nextInt(128);
-@@ -444,7 +487,10 @@
+@@ -444,7 +488,10 @@
              (new WorldGenGlowStone2()).func_76484_a(this.field_73175_o, this.field_73181_i, k1, l1, i2);
          }
  
@@ -151,7 +159,7 @@
          {
              j1 = k + this.field_73181_i.nextInt(16) + 8;
              k1 = this.field_73181_i.nextInt(128);
-@@ -452,7 +498,7 @@
+@@ -452,7 +499,7 @@
              (new WorldGenFlowers(Blocks.field_150338_P)).func_76484_a(this.field_73175_o, this.field_73181_i, j1, k1, l1);
          }
  
@@ -160,7 +168,7 @@
          {
              j1 = k + this.field_73181_i.nextInt(16) + 8;
              k1 = this.field_73181_i.nextInt(128);
-@@ -463,7 +509,8 @@
+@@ -463,7 +510,8 @@
          WorldGenMinable worldgenminable = new WorldGenMinable(Blocks.field_150449_bY, 13, Blocks.field_150424_aL);
          int j2;
  
@@ -170,7 +178,7 @@
          {
              l1 = k + this.field_73181_i.nextInt(16);
              i2 = this.field_73181_i.nextInt(108) + 10;
-@@ -479,6 +526,9 @@
+@@ -479,6 +527,9 @@
              (new WorldGenHellLava(Blocks.field_150356_k, true)).func_76484_a(this.field_73175_o, this.field_73181_i, l1, i2, j2);
          }
  

--- a/src/main/java/net/minecraftforge/event/terraingen/ChunkProviderEvent.java
+++ b/src/main/java/net/minecraftforge/event/terraingen/ChunkProviderEvent.java
@@ -16,13 +16,6 @@ public class ChunkProviderEvent extends Event
         this.chunkProvider = chunkProvider;
     }
 
-    /**
-     * This event is fired when a chunks blocks are replaced by a biomes top and
-     * filler blocks.
-     *
-     * You can set the result to DENY to prevent the default replacement.
-     */
-    @HasResult
     public static class ReplaceBiomeBlocks extends ChunkProviderEvent
     {
         public final int chunkX;
@@ -30,31 +23,58 @@ public class ChunkProviderEvent extends Event
         public final Block[] blockArray;
         public final byte[] metaArray; // CAN BE NULL
         public final BiomeGenBase[] biomeArray;
+        public final double[] stoneNoise;
         public final World world; // CAN BE NULL
 
         @Deprecated // TODO: Remove in 1.8
         public ReplaceBiomeBlocks(IChunkProvider chunkProvider, int chunkX, int chunkZ, Block[] blockArray, BiomeGenBase[] biomeArray)
         {
-            this(chunkProvider, chunkX, chunkZ, blockArray, new byte[256], biomeArray, null);
+            this(chunkProvider, chunkX, chunkZ, blockArray, new byte[256], biomeArray, null, null);
         }
 
         @Deprecated // TODO: Remove in 1.8
         public ReplaceBiomeBlocks(IChunkProvider chunkProvider, int chunkX, int chunkZ, Block[] blockArray, byte[] metaArray, BiomeGenBase[] biomeArray)
         {
-            this(chunkProvider, chunkZ, chunkZ, blockArray, metaArray, biomeArray, null);
+            this(chunkProvider, chunkZ, chunkZ, blockArray, metaArray, biomeArray, null, null);
         }
 
-        public ReplaceBiomeBlocks(IChunkProvider chunkProvider, int chunkX, int chunkZ, Block[] blockArray, byte[] metaArray, BiomeGenBase[] biomeArray, World world)
+        public ReplaceBiomeBlocks(IChunkProvider chunkProvider, int chunkX, int chunkZ, Block[] blockArray, byte[] metaArray, BiomeGenBase[] biomeArray, double[] stoneNoise, World world)
         {
             super(chunkProvider);
             this.chunkX = chunkX;
             this.chunkZ = chunkZ;
             this.blockArray = blockArray;
-            this.biomeArray = biomeArray;
             this.metaArray = metaArray;
+            this.biomeArray = biomeArray;
+            this.stoneNoise = stoneNoise;
             this.world = world;
         }
 
+        /**
+         * This event is fired before a chunks blocks are replaced by a biomes top and
+         * filler blocks.
+         *
+         * You can set the result to DENY to prevent the default replacement.
+         */
+        @HasResult
+        public static class Pre extends ReplaceBiomeBlocks
+        {
+            public Pre(IChunkProvider chunkProvider, int chunkX, int chunkZ, Block[] blockArray, byte[] metaArray, BiomeGenBase[] biomeArray, double[] stoneNoise, World world)
+            {
+                super(chunkProvider, chunkX, chunkZ, blockArray, metaArray, biomeArray, stoneNoise, world);
+            }
+        }
+        
+        /**
+         * This event is fired after a chunks blocks are replaced by a biomes top and filler blocks.
+         */
+        public static class Post extends ReplaceBiomeBlocks
+        {
+            public Post(IChunkProvider chunkProvider, int chunkX, int chunkZ, Block[] blockArray, byte[] metaArray, BiomeGenBase[] biomeArray, double[] stoneNoise, World world)
+            {
+                super(chunkProvider, chunkX, chunkZ, blockArray, metaArray, biomeArray, stoneNoise, world);
+            }
+        }
     }
 
     /**


### PR DESCRIPTION
The following changes have been made to the ReplaceBiomeBlocks event:

Added the stoneNoise array as a constructor argument (can be null).
Added Pre and Post events.
This is useful for example when a mod only wants to replace stone blocks in a biome. Without a Post event, the mod will replace all blocks in the biome, since everything is stone before the biome populates the top and filler blocks.