### PR TITLE
Re-Add Branch Logic to Shearable Blocks on harvest

### DIFF
--- a/patches/minecraft/net/minecraft/block/BlockDeadBush.java.patch
+++ b/patches/minecraft/net/minecraft/block/BlockDeadBush.java.patch
@@ -21,17 +21,18 @@
  {
      private static final String __OBFID = "CL_00000224";
  
-@@ -33,14 +37,15 @@
+@@ -33,14 +37,19 @@
  
      public void func_149636_a(World p_149636_1_, EntityPlayer p_149636_2_, int p_149636_3_, int p_149636_4_, int p_149636_5_, int p_149636_6_)
      {
 -        if (!p_149636_1_.field_72995_K && p_149636_2_.func_71045_bC() != null && p_149636_2_.func_71045_bC().func_77973_b() == Items.field_151097_aZ)
++        if (!p_149636_1_.field_72995_K && p_149636_2_.func_71045_bC() != null && p_149636_2_.func_71045_bC().func_77973_b() instanceof net.minecraft.item.ItemShears)
          {
 -            p_149636_2_.func_71064_a(StatList.field_75934_C[Block.func_149682_b(this)], 1);
 -            this.func_149642_a(p_149636_1_, p_149636_3_, p_149636_4_, p_149636_5_, new ItemStack(Blocks.field_150330_I, 1, p_149636_6_));
--        }
--        else
--        {
+         }
+         else
+         {
              super.func_149636_a(p_149636_1_, p_149636_2_, p_149636_3_, p_149636_4_, p_149636_5_, p_149636_6_);
          }
      }

--- a/patches/minecraft/net/minecraft/block/BlockLeaves.java.patch
+++ b/patches/minecraft/net/minecraft/block/BlockLeaves.java.patch
@@ -87,21 +87,19 @@
      }
  
      protected void func_150124_c(World p_150124_1_, int p_150124_2_, int p_150124_3_, int p_150124_4_, int p_150124_5_, int p_150124_6_) {}
-@@ -281,13 +250,7 @@
+@@ -281,10 +250,8 @@
  
      public void func_149636_a(World p_149636_1_, EntityPlayer p_149636_2_, int p_149636_3_, int p_149636_4_, int p_149636_5_, int p_149636_6_)
      {
 -        if (!p_149636_1_.field_72995_K && p_149636_2_.func_71045_bC() != null && p_149636_2_.func_71045_bC().func_77973_b() == Items.field_151097_aZ)
++        if (!p_149636_1_.field_72995_K && p_149636_2_.func_71045_bC() != null && p_149636_2_.func_71045_bC().func_77973_b() instanceof net.minecraft.item.ItemShears)
          {
 -            p_149636_2_.func_71064_a(StatList.field_75934_C[Block.func_149682_b(this)], 1);
 -            this.func_149642_a(p_149636_1_, p_149636_3_, p_149636_4_, p_149636_5_, new ItemStack(Item.func_150898_a(this), 1, p_149636_6_ & 3));
--        }
--        else
--        {
-             super.func_149636_a(p_149636_1_, p_149636_2_, p_149636_3_, p_149636_4_, p_149636_5_, p_149636_6_);
          }
-     }
-@@ -318,4 +281,67 @@
+         else
+         {
+@@ -318,4 +285,67 @@
      }
  
      public abstract String[] func_150125_e();

--- a/patches/minecraft/net/minecraft/block/BlockTallGrass.java.patch
+++ b/patches/minecraft/net/minecraft/block/BlockTallGrass.java.patch
@@ -38,21 +38,19 @@
      }
  
      public int func_149679_a(int p_149679_1_, Random p_149679_2_)
-@@ -81,13 +84,7 @@
+@@ -81,10 +84,8 @@
  
      public void func_149636_a(World p_149636_1_, EntityPlayer p_149636_2_, int p_149636_3_, int p_149636_4_, int p_149636_5_, int p_149636_6_)
      {
 -        if (!p_149636_1_.field_72995_K && p_149636_2_.func_71045_bC() != null && p_149636_2_.func_71045_bC().func_77973_b() == Items.field_151097_aZ)
++        if (!p_149636_1_.field_72995_K && p_149636_2_.func_71045_bC() != null && p_149636_2_.func_71045_bC().func_77973_b() instanceof net.minecraft.item.ItemShears)
          {
 -            p_149636_2_.func_71064_a(StatList.field_75934_C[Block.func_149682_b(this)], 1);
 -            this.func_149642_a(p_149636_1_, p_149636_3_, p_149636_4_, p_149636_5_, new ItemStack(Blocks.field_150329_H, 1, p_149636_6_));
--        }
--        else
--        {
-             super.func_149636_a(p_149636_1_, p_149636_2_, p_149636_3_, p_149636_4_, p_149636_5_, p_149636_6_);
          }
-     }
-@@ -143,4 +140,28 @@
+         else
+         {
+@@ -143,4 +144,28 @@
              Blocks.field_150398_cm.func_149889_c(p_149853_1_, p_149853_3_, p_149853_4_, p_149853_5_, b0, 2);
          }
      }

--- a/patches/minecraft/net/minecraft/block/BlockVine.java.patch
+++ b/patches/minecraft/net/minecraft/block/BlockVine.java.patch
@@ -24,17 +24,18 @@
  {
      private static final String __OBFID = "CL_00000330";
  
-@@ -375,14 +379,28 @@
+@@ -375,14 +379,32 @@
  
      public void func_149636_a(World p_149636_1_, EntityPlayer p_149636_2_, int p_149636_3_, int p_149636_4_, int p_149636_5_, int p_149636_6_)
      {
 -        if (!p_149636_1_.field_72995_K && p_149636_2_.func_71045_bC() != null && p_149636_2_.func_71045_bC().func_77973_b() == Items.field_151097_aZ)
++        if (!p_149636_1_.field_72995_K && p_149636_2_.func_71045_bC() != null && p_149636_2_.func_71045_bC().func_77973_b() instanceof net.minecraft.item.ItemShears)
          {
 -            p_149636_2_.func_71064_a(StatList.field_75934_C[Block.func_149682_b(this)], 1);
 -            this.func_149642_a(p_149636_1_, p_149636_3_, p_149636_4_, p_149636_5_, new ItemStack(Blocks.field_150395_bd, 1, 0));
--        }
--        else
--        {
+         }
+         else
+         {
              super.func_149636_a(p_149636_1_, p_149636_2_, p_149636_3_, p_149636_4_, p_149636_5_, p_149636_6_);
          }
      }


### PR DESCRIPTION
This is to fix issue #1308

This re-adds the logic to detect if a block is being harvested by a
shear tool. Removed the code that used to run so now if I shear a Leaf
block, the Ishearable logic is executed and the onblockharvested logic
is skipped.