### PR TITLE
Hook for filling glass bottles, equivalent to FillBucketEvent

### DIFF
--- a/patches/minecraft/net/minecraft/item/ItemBucket.java.patch
+++ b/patches/minecraft/net/minecraft/item/ItemBucket.java.patch
@@ -10,33 +10,16 @@
  
  public class ItemBucket extends Item
  {
-@@ -32,6 +35,31 @@
+@@ -32,6 +35,14 @@
          }
          else
          {
 +            FillBucketEvent event = new FillBucketEvent(p_77659_3_, p_77659_1_, p_77659_2_, movingobjectposition);
-+            if (MinecraftForge.EVENT_BUS.post(event))
-+            {
-+                return p_77659_1_;
-+            }
-+
-+            if (event.getResult() == Event.Result.ALLOW)
-+            {
-+                if (p_77659_3_.field_71075_bZ.field_75098_d)
-+                {
-+                    return p_77659_1_;
-+                }
-+
-+                if (--p_77659_1_.field_77994_a <= 0)
-+                {
-+                    return event.result;
-+                }
-+
-+                if (!p_77659_3_.field_71071_by.func_70441_a(event.result))
-+                {
-+                    p_77659_3_.func_71019_a(event.result, false);
-+                }
-+
++            if (MinecraftForge.EVENT_BUS.post(event)) return p_77659_1_;
++            if (event.getResult() == Event.Result.ALLOW) {
++                if (p_77659_3_.field_71075_bZ.field_75098_d) return p_77659_1_;
++                if (--p_77659_1_.field_77994_a <= 0) return event.result;
++                if (!p_77659_3_.field_71071_by.func_70441_a(event.result)) p_77659_3_.func_71019_a(event.result, false);
 +                return p_77659_1_;
 +            }
              if (movingobjectposition.field_72313_a == MovingObjectPosition.MovingObjectType.BLOCK)

--- a/patches/minecraft/net/minecraft/item/ItemGlassBottle.java.patch
+++ b/patches/minecraft/net/minecraft/item/ItemGlassBottle.java.patch
@@ -1,0 +1,27 @@
+--- ../src-base/minecraft/net/minecraft/item/ItemGlassBottle.java
++++ ../src-work/minecraft/net/minecraft/item/ItemGlassBottle.java
+@@ -10,6 +10,9 @@
+ import net.minecraft.util.IIcon;
+ import net.minecraft.util.MovingObjectPosition;
+ import net.minecraft.world.World;
++import net.minecraftforge.common.MinecraftForge;
++import net.minecraftforge.event.entity.player.FillGlassBottleEvent;
++import cpw.mods.fml.common.eventhandler.Event;
+ 
+ public class ItemGlassBottle extends Item
+ {
+@@ -36,6 +39,14 @@
+         }
+         else
+         {
++            FillGlassBottleEvent event = new FillGlassBottleEvent(p_77659_3_, p_77659_1_, p_77659_2_, movingobjectposition);
++            if (MinecraftForge.EVENT_BUS.post(event)) return p_77659_1_;
++            if (event.getResult() == Event.Result.ALLOW) {
++                if (p_77659_3_.field_71075_bZ.field_75098_d) return p_77659_1_;
++                if (--p_77659_1_.field_77994_a <= 0) return event.getFilledContainer();
++                if (!p_77659_3_.field_71071_by.func_70441_a(event.getFilledContainer())) p_77659_3_.func_71019_a(event.getFilledContainer(), false);
++                return p_77659_1_;
++            }
+             if (movingobjectposition.field_72313_a == MovingObjectPosition.MovingObjectType.BLOCK)
+             {
+                 int i = movingobjectposition.field_72311_b;

--- a/src/main/java/net/minecraftforge/event/entity/player/FillBucketEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/player/FillBucketEvent.java
@@ -9,7 +9,7 @@ import net.minecraft.world.World;
 
 @Cancelable
 @Event.HasResult
-public class FillBucketEvent extends PlayerEvent
+public class FillBucketEvent extends FillFluidContainerEvent
 {
     /**
      * This event is fired when a player attempts to use a Empty bucket, it 
@@ -29,9 +29,21 @@ public class FillBucketEvent extends PlayerEvent
 
     public FillBucketEvent(EntityPlayer player, ItemStack current, World world, MovingObjectPosition target)
     {
-        super(player);
+        super(player, current, world, target);
         this.current = current;
         this.world = world;
         this.target = target;
+    }
+
+    @Override
+    public ItemStack getFilledContainer()
+    {
+        return this.result;
+    }
+
+    @Override
+    public void setFilledContainer(ItemStack filled)
+    {
+        this.result = filled;
     }
 }

--- a/src/main/java/net/minecraftforge/event/entity/player/FillFluidContainerEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/player/FillFluidContainerEvent.java
@@ -1,0 +1,44 @@
+package net.minecraftforge.event.entity.player;
+
+import cpw.mods.fml.common.eventhandler.Cancelable;
+import cpw.mods.fml.common.eventhandler.Event;
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.item.ItemStack;
+import net.minecraft.util.MovingObjectPosition;
+import net.minecraft.world.World;
+
+/**
+ * This event is fired when a player attempts to use an empty fluid container, it 
+ * can be canceled to completely prevent any further processing.
+ * 
+ * If you set the result to 'ALLOW', it means that you have processed 
+ * the event and wants the basic functionality of adding the new 
+ * ItemStack to your inventory and reducing the stack size to process.
+ * setResult(ALLOW) is the same as the old setHandeled();
+ */
+@Cancelable
+@Event.HasResult
+public class FillFluidContainerEvent extends PlayerEvent {
+
+    public final ItemStack current;
+    public final World world;
+    public final MovingObjectPosition target;
+
+    private ItemStack filledContainer;
+
+    public FillFluidContainerEvent(EntityPlayer player, ItemStack current, World world, MovingObjectPosition target)
+    {
+        super(player);
+        this.current = current;
+        this.world = world;
+        this.target = target;
+    }
+        
+    public ItemStack getFilledContainer() {
+        return this.filledContainer;
+    }
+    
+    public void setFilledContainer(ItemStack filled) {
+        this.filledContainer = filled;
+    }
+}

--- a/src/main/java/net/minecraftforge/event/entity/player/FillGlassBottleEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/player/FillGlassBottleEvent.java
@@ -1,0 +1,27 @@
+package net.minecraftforge.event.entity.player;
+
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.item.ItemStack;
+import net.minecraft.util.MovingObjectPosition;
+import net.minecraft.world.World;
+import cpw.mods.fml.common.eventhandler.Cancelable;
+import cpw.mods.fml.common.eventhandler.Event;
+
+/**
+ * This event is fired when a player attempts to use an empty bottle, it 
+ * can be canceled to completely prevent any further processing.
+ * 
+ * If you set the result to 'ALLOW', it means that you have processed 
+ * the event and wants the basic functionality of adding the new 
+ * ItemStack to your inventory and reducing the stack size to process.
+ * setResult(ALLOW) is the same as the old setHandeled();
+ */
+@Cancelable
+@Event.HasResult
+public class FillGlassBottleEvent extends FillFluidContainerEvent
+{
+    public FillGlassBottleEvent(EntityPlayer player, ItemStack current, World world, MovingObjectPosition target)
+    {
+        super(player, current, world, target);
+    }
+}


### PR DESCRIPTION
add FillFluidContainerEvent as a base class for all container-specific fill events

FillBucketEvent extends FillFluidContainerEvent

introduce FillGlassBottleEvent, to be emitted when a glass bottle is
filled by the player from a fluid source block

ItemGlassBottle emits FillGlassBottleEvent upon fill attempt

Move javadocs on event handler methods to class-level

factor out inventory logic to a method on the event; not really the
role of the event, but this is a convenient way for us to reduce code
duplication and shrink patches

Shrink ItemGlassBottle patch by using FillFluidContainerEvent.fillContainer()

Shrink ItemBucket patch using the ItemGlassBottle approach

readd fields to FillBucketEvent to avoid breaking ABI; leads to
undesirable field hiding but such is the nature of public fields

hiding the non-final 'result' field is problematic; abstract via accessors

rename fillContainer => giveFilledContaner; better name?

Revert "Shrink ItemBucket patch using the ItemGlassBottle approach"

This reverts commit 6e14c67d6a1b9f4c089fa7895ebfc13bdbe9c605.

Revert "Shrink ItemGlassBottle patch by using FillFluidContainerEvent.fillContainer()"

This reverts commit f0e7f4efd559c1d7f25a6b3b9fd932d0220a857b.

Remove giveFilledContainer() method

condense ItemBucket and ItemGlassBottle patches