### PR TITLE
Improved Control of Enchantment.canApplyTogether() in Mod Enchantments

### DIFF
--- a/patches/minecraft/net/minecraft/command/CommandEnchant.java.patch
+++ b/patches/minecraft/net/minecraft/command/CommandEnchant.java.patch
@@ -1,0 +1,11 @@
+--- ../src-base/minecraft/net/minecraft/command/CommandEnchant.java
++++ ../src-work/minecraft/net/minecraft/command/CommandEnchant.java
+@@ -76,7 +76,7 @@
+                                 {
+                                     Enchantment enchantment1 = Enchantment.field_77331_b[short1];
+ 
+-                                    if (!enchantment1.func_77326_a(enchantment))
++                                    if (!enchantment1.func_77326_a(enchantment) || !enchantment.func_77326_a(enchantment1))
+                                     {
+                                         throw new CommandException("commands.enchant.cantCombine", new Object[] {enchantment.func_77316_c(j), enchantment1.func_77316_c(nbttaglist.func_150305_b(k).func_74765_d("lvl"))});
+                                     }

--- a/patches/minecraft/net/minecraft/enchantment/EnchantmentHelper.java.patch
+++ b/patches/minecraft/net/minecraft/enchantment/EnchantmentHelper.java.patch
@@ -18,6 +18,15 @@
  
          if (j <= 0)
          {
+@@ -393,7 +393,7 @@
+                                 {
+                                     EnchantmentData enchantmentdata1 = (EnchantmentData)iterator1.next();
+ 
+-                                    if (enchantmentdata1.field_76302_b.func_77326_a(Enchantment.field_77331_b[integer.intValue()]))
++                                    if (enchantmentdata1.field_76302_b.func_77326_a(Enchantment.field_77331_b[integer.intValue()]) && Enchantment.field_77331_b[integer.intValue()].func_77326_a(enchantmentdata1.field_76302_b))
+                                     {
+                                         continue;
+                                     }
 @@ -435,7 +435,8 @@
          {
              Enchantment enchantment = aenchantment[k];

--- a/patches/minecraft/net/minecraft/inventory/ContainerRepair.java.patch
+++ b/patches/minecraft/net/minecraft/inventory/ContainerRepair.java.patch
@@ -34,6 +34,15 @@
                  flag = itemstack2.func_77973_b() == Items.field_151134_bR && Items.field_151134_bR.func_92110_g(itemstack2).func_74745_c() > 0;
  
                  if (itemstack1.func_77984_f() && itemstack1.func_77973_b().func_82789_a(itemstack, itemstack2))
+@@ -258,7 +262,7 @@
+                         {
+                             int j2 = ((Integer)iterator.next()).intValue();
+ 
+-                            if (j2 != i1 && !enchantment.func_77326_a(Enchantment.field_77331_b[j2]))
++                            if (j2 != i1 && (!enchantment.func_77326_a(Enchantment.field_77331_b[j2]) || !Enchantment.field_77331_b[j2].func_77326_a(enchantment)))
+                             {
+                                 flag1 = false;
+                                 i += i2;
 @@ -373,6 +377,8 @@
                  k2 = Math.max(1, k2 / 2);
              }


### PR DESCRIPTION
Enchantment.canApplyTogether() is now called on both involved Enchantments in all instances, allowing non-vanilla enchantments to prevent mixing with vanilla ones without gimmicky inheritance.

In order to determine whether certain enchantments can be mixed on items, Enchantment.canApplyTogether(Enchantment) returns a boolean to indicate whether the the two Enchantments are allowed to co-exist.  Vanilla behavior is that this is call is only made on one of the Enchantments, effectively disabling the second Enchantment's ability to control being placed on an item with the first.  This PR addresses this issue by requiring a pair of Enchantments to each pass the other's check.
