### PR TITLE
Add previousStackSize to PlayerUseItemEvent.Finish Close #1379

### DIFF
--- a/patches/minecraft/net/minecraft/entity/player/EntityPlayer.java.patch
+++ b/patches/minecraft/net/minecraft/entity/player/EntityPlayer.java.patch
@@ -74,7 +74,7 @@
              int i = this.field_71074_e.field_77994_a;
              ItemStack itemstack = this.field_71074_e.func_77950_b(this.field_70170_p, this);
  
-+            itemstack = net.minecraftforge.event.ForgeEventFactory.onItemUseFinish(this, field_71074_e, field_71072_f, itemstack);
++            itemstack = net.minecraftforge.event.ForgeEventFactory.onItemUseFinish(this, field_71074_e, field_71072_f, itemstack, i);
              if (itemstack != this.field_71074_e || itemstack != null && itemstack.field_77994_a != i)
              {
                  this.field_71071_by.field_70462_a[this.field_71071_by.field_70461_c] = itemstack;

--- a/src/main/java/net/minecraftforge/event/ForgeEventFactory.java
+++ b/src/main/java/net/minecraftforge/event/ForgeEventFactory.java
@@ -232,9 +232,17 @@ public class ForgeEventFactory
         return MinecraftForge.EVENT_BUS.post(new PlayerUseItemEvent.Stop(player, item, duration));
     }
 
+    @Deprecated
     public static ItemStack onItemUseFinish(EntityPlayer player, ItemStack item, int duration, ItemStack result)
     {
         PlayerUseItemEvent.Finish event = new PlayerUseItemEvent.Finish(player, item, duration, result);
+        MinecraftForge.EVENT_BUS.post(event);
+        return event.result;
+    }
+    
+    public static ItemStack onItemUseFinish(EntityPlayer player, ItemStack item, int duration, ItemStack result, int previous)
+    {
+        PlayerUseItemEvent.Finish event = new PlayerUseItemEvent.Finish(player, item, duration, result, previous);
         MinecraftForge.EVENT_BUS.post(event);
         return event.result;
     }

--- a/src/main/java/net/minecraftforge/event/entity/player/PlayerUseItemEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/player/PlayerUseItemEvent.java
@@ -80,15 +80,24 @@ public abstract class PlayerUseItemEvent extends PlayerEvent
      * If you wish to cancel those effects, you should cancel one of the above events.
      * 
      * The result item stack is the stack that is placed in the player's inventory in replacement of the stack that is currently being used.
+     * The previous stack size is the stack size before it finished being used.
      *
      */
     public static class Finish extends PlayerUseItemEvent
     {
         public ItemStack result;
-        public Finish(EntityPlayer player, ItemStack item, int duration, ItemStack result)
+        public final int previousStackSize;
+        public Finish(EntityPlayer player, ItemStack item, int duration, ItemStack result, int previous)
         {
             super(player, item, duration);
             this.result = result;
+            this.previousStackSize = previous;
+        }
+        
+        @Deprecated
+        public Finish(EntityPlayer player, ItemStack item, int duration, ItemStack result)
+        {
+            this(player, item, duration, result, -1);
         }
     }
 }


### PR DESCRIPTION
-Deprecated old constructor and method
-Added new constructor and method with the previous stack size variable as additional parameter

This way, a listener can mirror vanilla behavior and react to a change in stack size when the item finish being used.