### PR TITLE
Fixed longstanding bug with the achievements gui [MC-33065]

### DIFF
--- a/patches/minecraft/net/minecraft/client/gui/achievement/GuiAchievements.java.patch
+++ b/patches/minecraft/net/minecraft/client/gui/achievement/GuiAchievements.java.patch
@@ -61,7 +61,17 @@
          }
      }
  
-@@ -339,11 +365,12 @@
+@@ -260,8 +286,7 @@
+         GL11.glDepthFunc(GL11.GL_GEQUAL);
+         GL11.glPushMatrix();
+         GL11.glTranslatef((float)k1, (float)l1, -200.0F);
+-        GL11.glScalef(1.0F / this.field_146570_r, 1.0F / this.field_146570_r, 0.0F);
+-        GL11.glEnable(GL11.GL_TEXTURE_2D);
++        GL11.glEnable(GL11.GL_TEXTURE_2D); //Forge: Removed glScalef call that was above this line. Fixes MC-33065
+         GL11.glDisable(GL11.GL_LIGHTING);
+         GL11.glEnable(GL12.GL_RESCALE_NORMAL);
+         GL11.glEnable(GL11.GL_COLOR_MATERIAL);
+@@ -339,11 +364,12 @@
          int j4;
          int l4;
  
@@ -77,7 +87,7 @@
              {
                  j3 = achievement1.field_75993_a * 24 - k + 11;
                  k3 = achievement1.field_75991_b * 24 - l + 11;
-@@ -400,9 +427,9 @@
+@@ -400,9 +426,9 @@
          int i5;
          int j5;
  


### PR DESCRIPTION
Since 1.7, a vanilla bug with the achievements gui has been present. The details are outlined in the mc bug report listed above, but basically, blocks in the achievement were rendered darker than normal. After lots of testing, I figured out it was a glScalef that was causing it. Removal of it fixed it. I didn't see any other side effects from removing that line; all looked fine. Before and after:

![Before](https://cloud.githubusercontent.com/assets/5672271/4540988/0f4626e2-4e0e-11e4-9f1d-91904b9e4eb6.png)

![After](https://cloud.githubusercontent.com/assets/5672271/4540998/248a9768-4e0e-11e4-832b-b308dc4e9740.png)
