### PR TITLE
 Fix for biome weights under 10 

### DIFF
--- a/patches/minecraft/net/minecraft/world/gen/layer/GenLayerBiome.java.patch
+++ b/patches/minecraft/net/minecraft/world/gen/layer/GenLayerBiome.java.patch
@@ -96,7 +96,7 @@
                  }
                  else
                  {
-@@ -101,4 +124,14 @@
+@@ -101,4 +124,12 @@
  
          return aint1;
      }
@@ -105,9 +105,7 @@
 +    {
 +        List<BiomeEntry> biomeList = biomes[type.ordinal()];
 +        int totalWeight = WeightedRandom.func_76272_a(biomeList);
-+        int rand = func_75902_a(totalWeight / 10) * 10;
-+        int weight = rand + (BiomeManager.isTypeListModded(type) ? func_75902_a(Math.min(10, totalWeight - rand)) : 0);
-+        
++        int weight = BiomeManager.isTypeListModded(type)?func_75902_a(totalWeight):func_75902_a(totalWeight / 10) * 10;
 +        return (BiomeEntry)WeightedRandom.getItem(biomeList, weight);
 +    }
  }


### PR DESCRIPTION
This PR fixes the problem where modded biomes with weights under 10 are not being generated in world.

See https://github.com/Azanor/thaumcraft/issues/1229 and MinecraftForge/MinecraftForge#1458 
