### PR TITLE
Fix number of stencil bits when FBO is used

### DIFF
--- a/patches/minecraft/net/minecraft/client/renderer/OpenGlHelper.java.patch
+++ b/patches/minecraft/net/minecraft/client/renderer/OpenGlHelper.java.patch
@@ -11,7 +11,16 @@
      public static void func_77474_a()
      {
          ContextCapabilities contextcapabilities = GLContext.getCapabilities();
-@@ -688,6 +692,12 @@
+@@ -182,6 +186,8 @@
+ 
+         field_148824_g = field_148823_f && field_153213_x;
+         field_153197_d = GL11.glGetString(GL11.GL_VENDOR).toLowerCase().contains("nvidia");
++
++        net.minecraftforge.client.ForgeHooksClient.setupFramebufferStencilBitPool(func_148822_b());
+     }
+ 
+     public static boolean func_153193_b()
+@@ -688,6 +694,12 @@
          {
              GL13.glMultiTexCoord2f(p_77475_0_, p_77475_1_, p_77475_2_);
          }

--- a/patches/minecraft/net/minecraft/client/shader/Framebuffer.java.patch
+++ b/patches/minecraft/net/minecraft/client/shader/Framebuffer.java.patch
@@ -4,7 +4,7 @@
              if (this.field_147619_e)
              {
                  OpenGlHelper.func_153176_h(OpenGlHelper.field_153199_f, this.field_147624_h);
-+                if (net.minecraftforge.client.MinecraftForgeClient.getStencilBits() == 0)
++                if (!net.minecraftforge.client.ForgeHooksClient.isFramebufferStencilAllowed())
 +                {
                  OpenGlHelper.func_153186_a(OpenGlHelper.field_153199_f, 33190, this.field_147622_a, this.field_147620_b);
                  OpenGlHelper.func_153190_b(OpenGlHelper.field_153198_e, OpenGlHelper.field_153201_h, OpenGlHelper.field_153199_f, this.field_147624_h);

--- a/src/main/java/net/minecraftforge/client/ForgeHooksClient.java
+++ b/src/main/java/net/minecraftforge/client/ForgeHooksClient.java
@@ -314,7 +314,16 @@ public class ForgeHooksClient
         return modelbiped == null ? _default : modelbiped;
     }
 
-    static int stencilBits = 0;
+    public static boolean isFramebufferStencilAllowed()
+    {
+        return Boolean.parseBoolean(System.getProperty("forge.fboStencilAllowed", "true"));
+    }
+
+    public static void setupFramebufferStencilBitPool(boolean fboEnabled)
+    {
+        MinecraftForgeClient.setStencilPoolSize(fboEnabled && isFramebufferStencilAllowed() ? 8 : 0);
+    }
+
     public static void createDisplay() throws LWJGLException
     {
         ImageIO.setUseCache(false); //Disable on-disc stream cache should speed up texture pack reloading.
@@ -325,19 +334,21 @@ public class ForgeHooksClient
             //According to ChickenBones, Mumfrey and Pig The only real use is in the FBO.
             //So lets default to normal init to fix the issues yet add the bits to the FBO.
             Display.create(format);
-            stencilBits = 0;
+            
+            // set pool size to zero for now - may be updated later, once OpenGL capabilites are known
+            MinecraftForgeClient.setStencilPoolSize(0);
             return;
         }
         try
         {
             //TODO: Figure out how to determine the max bits.
             Display.create(format.withStencilBits(8));
-            stencilBits = 8;
+            MinecraftForgeClient.setStencilPoolSize(8);
         }
         catch(LWJGLException e)
         {
             Display.create(format);
-            stencilBits = 0;
+            MinecraftForgeClient.setStencilPoolSize(0);
         }
     }
 

--- a/src/main/java/net/minecraftforge/client/MinecraftForgeClient.java
+++ b/src/main/java/net/minecraftforge/client/MinecraftForgeClient.java
@@ -5,7 +5,6 @@
 
 package net.minecraftforge.client;
 
-import java.util.BitSet;
 import java.util.IdentityHashMap;
 
 import com.google.common.collect.Maps;
@@ -46,16 +45,16 @@ public class MinecraftForgeClient
         return ForgeHooksClient.renderPass;
     }
 
+    private static final StencilBitPool stencilBitPool = new StencilBitPool();
+
+    static void setStencilPoolSize(int bitCount)
+    {
+        stencilBitPool.reset(bitCount);
+    }
+    
     public static int getStencilBits()
     {
-        return ForgeHooksClient.stencilBits;
-    }
-
-
-    private static BitSet stencilBits = new BitSet(getStencilBits());
-    static
-    {
-        stencilBits.set(0,getStencilBits());
+        return stencilBitPool.getBitPoolSize();
     }
 
     /**
@@ -65,12 +64,7 @@ public class MinecraftForgeClient
      */
     public static int reserveStencilBit()
     {
-        int bit = stencilBits.nextSetBit(0);
-        if (bit >= 0)
-        {
-            stencilBits.clear(bit);
-        }
-        return bit;
+        return stencilBitPool.reserveStencilBit();
     }
 
     /**
@@ -80,9 +74,6 @@ public class MinecraftForgeClient
      */
     public static void releaseStencilBit(int bit)
     {
-        if (bit >= 0 && bit < getStencilBits())
-        {
-            stencilBits.set(bit);
-        }
+        stencilBitPool.releaseStencilBit(bit);
     }
 }

--- a/src/main/java/net/minecraftforge/client/StencilBitPool.java
+++ b/src/main/java/net/minecraftforge/client/StencilBitPool.java
@@ -1,0 +1,46 @@
+package net.minecraftforge.client;
+
+import java.util.BitSet;
+
+public class StencilBitPool {
+    private BitSet pool = new BitSet(0);
+    private int count;
+
+    void reset(int bitCount) {
+        count = bitCount;
+        pool = new BitSet(bitCount);
+        pool.set(0, bitCount);
+    }
+
+    public int getBitPoolSize() {
+        return count;
+    }
+
+    /**
+     * Reserve a stencil bit for use in rendering
+     *
+     * @return A bit or -1 if no further stencil bits are available
+     */
+    public int reserveStencilBit()
+    {
+        int bit = pool.nextSetBit(0);
+        if (bit >= 0)
+        {
+            pool.clear(bit);
+        }
+        return bit;
+    }
+
+    /**
+     * Release the stencil bit for other use
+     *
+     * @param bit The bit from {@link #reserveStencilBit()}
+     */
+    public void releaseStencilBit(int bit)
+    {
+        if (bit >= 0 && bit < count)
+        {
+            pool.set(bit);
+        }
+    }
+}

--- a/src/main/resources/assets/forge/lang/en_US.lang
+++ b/src/main/resources/assets/forge/lang/en_US.lang
@@ -40,7 +40,6 @@ forge.configgui.zombieBabyChance.tooltip=Chance that a zombie (or subclass) is a
 forge.configgui.zombieBabyChance=Zombie Baby Chance
 forge.configgui.zombieBaseSummonChance.tooltip=Base zombie summoning spawn chance. Allows changing the bonus zombie summoning mechanic.
 forge.configgui.zombieBaseSummonChance=Zombie Summon Chance
-forge.configgui.stencilbits=Enable GL Stencil Bits
 forge.configgui.spawnfuzz=Respawn Fuzz Diameter
 
 forge.configgui.modID.tooltip=The mod ID that you want to define override settings for.


### PR DESCRIPTION
676ecab52ed4c7209620dddf01f1b7043db5a6a9 disabled both display and framebuffer stencil bits. `ForgeHooksClient.stencilBits` value, used also for [FBO stencil buffer allocation](https://github.com/MinecraftForge/MinecraftForge/blob/master/patches/minecraft/net/minecraft/client/shader/Framebuffer.java.patch#L7), is always set to 0, unless forces `forge.forceDisplayStencil`.

This PR adds extra logic to handle cases where display stencil buffer is disabled, but one can be allocated for FBO
