### PR TITLE
Add the three parameters to PlayerWakeUpEvent, making it actually useful

### DIFF
--- a/patches/minecraft/net/minecraft/entity/player/EntityPlayer.java.patch
+++ b/patches/minecraft/net/minecraft/entity/player/EntityPlayer.java.patch
@@ -384,7 +384,7 @@
  
      public void func_70999_a(boolean p_70999_1_, boolean p_70999_2_, boolean p_70999_3_)
      {
-+        MinecraftForge.EVENT_BUS.post(new net.minecraftforge.event.entity.player.PlayerWakeUpEvent(this));
++        MinecraftForge.EVENT_BUS.post(new net.minecraftforge.event.entity.player.PlayerWakeUpEvent(this, p_70999_1_, p_70999_2_, p_70999_3_));
          this.func_70105_a(0.6F, 1.8F);
          this.func_71061_d_();
          ChunkCoordinates chunkcoordinates = this.field_71081_bT;

--- a/src/main/java/net/minecraftforge/event/entity/player/PlayerWakeUpEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/player/PlayerWakeUpEvent.java
@@ -9,8 +9,29 @@ import net.minecraft.entity.player.EntityPlayer;
  */
 public class PlayerWakeUpEvent extends PlayerEvent
 {
-    public PlayerWakeUpEvent(EntityPlayer player)
+    /**
+     * Used for the 'wake up animation'. 
+     * This is false if the player is considered 'sleepy' and the overlay should slowly fade away.
+     */
+    public final boolean wasSuddenlyWokenUp;
+    
+    /**
+     * Indicates if the server should be notified of sleeping changes. 
+     * This will only be false if the server is considered 'up to date' already, because, for example, it initiated the call.
+     */
+    public final boolean markDirtySleepingFlag;
+    
+    /**
+     * Indicates if the player's sleep was considered successful. 
+     * In vanilla, this is used to determine if the spawn chunk is to be set to the bed's position. 
+     */
+    public final boolean sleptSuccessfully;
+    
+    public PlayerWakeUpEvent(EntityPlayer player, boolean wasSuddenlyWokenUp, boolean markDirtySleepingFlag, boolean sleptSuccessfully)
     {
         super(player);
+        this.wasSuddenlyWokenUp = wasSuddenlyWokenUp;
+        this.markDirtySleepingFlag = markDirtySleepingFlag;
+        this.sleptSuccessfully = sleptSuccessfully;
     }
 }


### PR DESCRIPTION
Not much to describe here. wakeUpPlayer is called every time a player _exits_ a bed, not if he wakes up. This PR simply passes the method's 3 parameters to the event so that mods can react to different call situations accordingly.
