### PR TITLE
i added an ore

### DIFF
--- a/src/main/java/net/minecraftforge/oredict/OreDictionary.java
+++ b/src/main/java/net/minecraftforge/oredict/OreDictionary.java
@@ -112,6 +112,7 @@ public class OreDictionary
             registerOre("stone",       Blocks.stone);
             registerOre("cobblestone", Blocks.cobblestone);
             registerOre("sandstone",   new ItemStack(Blocks.sandstone, 1, WILDCARD_VALUE));
+            registerOre("sand",        new ItemStack(Blocks.sand, 1, WILDCARD_VALUE));
             registerOre("dye",         new ItemStack(Items.dye, 1, WILDCARD_VALUE));
             registerOre("record",      Items.record_13);
             registerOre("record",      Items.record_cat);


### PR DESCRIPTION
i added sand from default minecraft as i would like to make something in a mod of mine using it (basically make a similar block that has been "scoured" of materials (mainly ilmenite dust) and then leave this block in it's place so that this block can still be used in instances of say, making glass, making the blocks for the Railcraft Coke oven multiblock. it's just a thought and i couldn't believe it wasn't already in there.
