### PR TITLE
Let modders add custom noteblock instruments

### DIFF
--- a/patches/minecraft/net/minecraft/block/BlockNote.java.patch
+++ b/patches/minecraft/net/minecraft/block/BlockNote.java.patch
@@ -10,15 +10,22 @@
                  tileentitynote.func_145878_a(p_149727_1_, p_149727_2_, p_149727_3_, p_149727_4_);
              }
  
-@@ -73,6 +75,11 @@
+@@ -73,6 +75,10 @@
  
      public boolean func_149696_a(World p_149696_1_, int p_149696_2_, int p_149696_3_, int p_149696_4_, int p_149696_5_, int p_149696_6_)
      {
 +        int meta = p_149696_1_.func_72805_g(p_149696_2_, p_149696_3_, p_149696_4_);
 +        net.minecraftforge.event.world.NoteBlockEvent.Play e = new net.minecraftforge.event.world.NoteBlockEvent.Play(p_149696_1_, p_149696_2_, p_149696_3_, p_149696_4_, meta, p_149696_6_, p_149696_5_);
 +        if (net.minecraftforge.common.MinecraftForge.EVENT_BUS.post(e)) return false;
-+        p_149696_5_ = e.instrument.ordinal();
 +        p_149696_6_ = e.getVanillaNoteId(); 
          float f = (float)Math.pow(2.0D, (double)(p_149696_6_ - 12) / 12.0D);
          String s = "harp";
  
+@@ -96,6 +102,7 @@
+             s = "bassattack";
+         }
+ 
++        s = e.instrument.name;
+         p_149696_1_.func_72908_a((double)p_149696_2_ + 0.5D, (double)p_149696_3_ + 0.5D, (double)p_149696_4_ + 0.5D, "note." + s, 3.0F, f);
+         p_149696_1_.func_72869_a("note", (double)p_149696_2_ + 0.5D, (double)p_149696_3_ + 1.2D, (double)p_149696_4_ + 0.5D, (double)p_149696_6_ / 24.0D, 0.0D, 0.0D);
+         return true;

--- a/src/main/java/net/minecraftforge/common/util/EnumHelper.java
+++ b/src/main/java/net/minecraftforge/common/util/EnumHelper.java
@@ -21,6 +21,7 @@ import net.minecraft.util.MovingObjectPosition.MovingObjectType;
 import net.minecraft.world.EnumSkyBlock;
 import net.minecraft.world.gen.structure.StructureStrongholdPieces.Stronghold.Door;
 import net.minecraftforge.classloading.FMLForgePlugin;
+import net.minecraftforge.event.world.NoteBlockEvent.Instrument;
 
 public class EnumHelper
 {
@@ -48,7 +49,8 @@ public class EnumHelper
         {EnumSkyBlock.class, int.class},
         {EnumStatus.class},
         {ToolMaterial.class, int.class, int.class, float.class, float.class, int.class},
-        {EnumRarity.class, EnumChatFormatting.class, String.class}
+        {EnumRarity.class, EnumChatFormatting.class, String.class},
+        {Instrument.class, String.class}
     };
 
     public static EnumAction addAction(String name)
@@ -107,6 +109,22 @@ public class EnumHelper
     public static EnumRarity addRarity(String name, EnumChatFormatting color, String displayName)
     {
         return addEnum(EnumRarity.class, name, color, displayName);
+    }
+    public static Instrument addInstrument(String name, String soundName)
+    {
+        Instrument inst = addEnum(Instrument.class, name, soundName);
+        try
+        {
+            Field f = Instrument.class.getDeclaredField("values");
+            f.setAccessible(true);
+            f.set(null, Instrument.values()); // update values
+        }
+        catch (Exception e)
+        {
+            e.printStackTrace();
+            throw new RuntimeException(e.getMessage(), e);
+        }
+        return inst;
     }
 
     private static void setup()

--- a/src/main/java/net/minecraftforge/event/world/NoteBlockEvent.java
+++ b/src/main/java/net/minecraftforge/event/world/NoteBlockEvent.java
@@ -102,18 +102,26 @@ public class NoteBlockEvent extends BlockEvent
      */
     public static enum Instrument
     {
-        PIANO,
-        BASSDRUM,
-        SNARE,
-        CLICKS,
-        BASSGUITAR;
+        PIANO("harp"),
+        BASSDRUM("bd"),
+        SNARE("snare"),
+        CLICKS("hat"),
+        BASSGUITAR("bassattack");
+        
+        /** The sound name, without the "note" prefix. */
+        public final String name;
+        
+        private Instrument(String name)
+        {
+            this.name = name;
+        }
         
         // cache to avoid creating a new array every time
-        private static final Instrument[] values = values();
+        private static Instrument[] values = values();
         
         static Instrument fromId(int id)
         {
-            return id < 0 || id > 4 ? PIANO : values[id];
+            return id < 0 || id >= values.length ? PIANO : values[id];
         }
     }
     


### PR DESCRIPTION
This change lets modders add custom vanilla noteblock-compatible instruments using EnumHelper and stuff. So a modder could add a `GUITAR("pling")` instrument, then hook noteblock events, check the block below, and change it into `GUITAR("pling")`.

Existing noteblock mods should be compatible with this change, but without support for extra instruments (that is, custom instruments should play as `PIANO("harp")`, until they update).
