### PR TITLE
Added ThornsEvent.

### DIFF
--- a/patches/minecraft/net/minecraft/enchantment/EnchantmentThorns.java.patch
+++ b/patches/minecraft/net/minecraft/enchantment/EnchantmentThorns.java.patch
@@ -1,0 +1,17 @@
+--- ../src-base/minecraft/net/minecraft/enchantment/EnchantmentThorns.java
++++ ../src-work/minecraft/net/minecraft/enchantment/EnchantmentThorns.java
+@@ -42,12 +42,12 @@
+         Random random = p_151367_1_.func_70681_au();
+         ItemStack itemstack = EnchantmentHelper.func_92099_a(Enchantment.field_92091_k, p_151367_1_);
+ 
+-        if (func_92094_a(p_151367_3_, random))
++        if (func_92094_a(p_151367_3_, random) && net.minecraftforge.event.ForgeEventFactory.onThornsEntityDamage(p_151367_2_, p_151367_1_, itemstack, p_151367_3_))
+         {
+             p_151367_2_.func_70097_a(DamageSource.func_92087_a(p_151367_1_), (float)func_92095_b(p_151367_3_, random));
+             p_151367_2_.func_85030_a("damage.thorns", 0.5F, 1.0F);
+ 
+-            if (itemstack != null)
++            if (itemstack != null && net.minecraftforge.event.ForgeEventFactory.onThornsArmorDamage(p_151367_2_, p_151367_1_, itemstack, p_151367_3_))
+             {
+                 itemstack.func_77972_a(3, p_151367_1_);
+             }

--- a/src/main/java/net/minecraftforge/event/ForgeEventFactory.java
+++ b/src/main/java/net/minecraftforge/event/ForgeEventFactory.java
@@ -24,6 +24,7 @@ import net.minecraft.world.storage.SaveHandler;
 import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.common.util.BlockSnapshot;
 import net.minecraftforge.common.util.ForgeDirection;
+import net.minecraftforge.event.ThornsEvent;
 import net.minecraftforge.event.entity.EntityStruckByLightningEvent;
 import net.minecraftforge.event.entity.living.LivingPackSizeEvent;
 import net.minecraftforge.event.entity.living.LivingSpawnEvent;
@@ -215,5 +216,15 @@ public class ForgeEventFactory
         SaveHandler sh = (SaveHandler) playerFileData;
         File dir = ObfuscationReflectionHelper.getPrivateValue(SaveHandler.class, sh, "playersDirectory", "field_"+"75771_c");
         MinecraftForge.EVENT_BUS.post(new PlayerEvent.LoadFromFile(player, dir, uuidString));
+    }
+    
+    public static boolean onThornsEntityDamage(Entity entity, EntityLivingBase enchanted, ItemStack armor, int damageDealt)
+    {
+        return !MinecraftForge.EVENT_BUS.post(new ThornsEvent.ThornsEntityDamageEvent(entity, enchanted, armor, damageDealt));
+    }
+    
+    public static boolean onThornsArmorDamage(Entity entity, EntityLivingBase enchanted, ItemStack armor, int damageDealt)
+    {
+        return !MinecraftForge.EVENT_BUS.post(new ThornsEvent.ThornsArmorDamageEvent(entity, enchanted, armor, damageDealt));
     }
 }

--- a/src/main/java/net/minecraftforge/event/ThornsEvent.java
+++ b/src/main/java/net/minecraftforge/event/ThornsEvent.java
@@ -1,0 +1,58 @@
+package net.minecraftforge.event;
+
+import net.minecraft.entity.Entity;
+import net.minecraft.entity.EntityLivingBase;
+import net.minecraft.item.ItemStack;
+import cpw.mods.fml.common.eventhandler.Cancelable;
+import cpw.mods.fml.common.eventhandler.Event;
+
+public class ThornsEvent extends Event
+{
+    public Entity entity;
+    public EntityLivingBase enchanted;
+    public int damageDealt;
+    
+    public ItemStack armor;
+    
+    /***
+     * @param entity The entity that damaged enchanted
+     * @param enchanted The entity that was wearing thorns armor when damaged by entity
+     * @param armor The enchanted armor that contains the thorns enchantment
+     * @param damageDealt The damage dealt to enchanted by entity
+     */
+    private ThornsEvent(Entity entity, EntityLivingBase enchanted, ItemStack armor, int damageDealt)
+    {
+        this.entity = entity;
+        this.enchanted = enchanted;
+        this.armor = armor;
+        this.damageDealt = damageDealt;
+    }
+    
+    /***
+     * Fired before damaging the entity before damaging the armor.
+     * 
+     * Cancelable. Will cause the entity no damage, and the armor to stay as is.
+     */
+    @Cancelable
+    public static class ThornsEntityDamageEvent extends ThornsEvent
+    {
+        public ThornsEntityDamageEvent(Entity entity, EntityLivingBase enchanted, ItemStack armor, int damageDealt)
+        {
+            super(entity, enchanted, armor, damageDealt);
+        }
+    }
+    
+    /***
+     * Fired before damaging the armor stack after hurting the mob.
+     * 
+     * Cancelable. Will cause the armor to stay as is.
+     */
+    @Cancelable
+    public static class ThornsArmorDamageEvent extends ThornsEvent
+    {
+        public ThornsArmorDamageEvent(Entity entity, EntityLivingBase enchanted, ItemStack armor, int damageDealt)
+        {
+            super(entity, enchanted, armor, damageDealt);
+        }
+    }
+}


### PR DESCRIPTION
Added 2 new events.
* ThornsEntityDamageEvent - Called before Thorns damages the damaging entity. Cancelling will not cause the entity any damage.
* ThornsArmorDamageEvent - Called before Thorns damages armor. Cancelling will not cause the armor to be damaged.

This will be useful for armor that does not use the standard damage system, or armor that does not take damage when applied with thorns.

Example: http://pastebin.com/6divcazh