### PR TITLE
Removed exclusion of white stained glass recipes in ore dictionary.

### DIFF
--- a/src/main/java/net/minecraftforge/oredict/OreDictionary.java
+++ b/src/main/java/net/minecraftforge/oredict/OreDictionary.java
@@ -201,8 +201,7 @@ public class OreDictionary
             new ItemStack(Blocks.jungle_stairs),
             new ItemStack(Blocks.acacia_stairs),
             new ItemStack(Blocks.dark_oak_stairs),
-            new ItemStack(Blocks.glass_pane),
-            new ItemStack(Blocks.stained_glass)
+            new ItemStack(Blocks.glass_pane)
         };
 
         List<IRecipe> recipes = CraftingManager.getInstance().getRecipeList();


### PR DESCRIPTION
Closes #1502 & #1481
