### PR TITLE
Add GuiScreenEvents for keyboard and mouse input

### DIFF
--- a/patches/minecraft/net/minecraft/client/gui/GuiScreen.java.patch
+++ b/patches/minecraft/net/minecraft/client/gui/GuiScreen.java.patch
@@ -84,3 +84,23 @@
      }
  
      public void func_73866_w_() {}
+@@ -246,7 +265,9 @@
+         {
+             while (Mouse.next())
+             {
++                if (MinecraftForge.EVENT_BUS.post(new net.minecraftforge.client.event.GuiScreenEvent.MouseInputEvent.Pre(this))) continue;
+                 this.func_146274_d();
++                if (this.equals(this.field_146297_k.field_71462_r)) MinecraftForge.EVENT_BUS.post(new net.minecraftforge.client.event.GuiScreenEvent.MouseInputEvent.Post(this));
+             }
+         }
+ 
+@@ -254,7 +275,9 @@
+         {
+             while (Keyboard.next())
+             {
++                if (MinecraftForge.EVENT_BUS.post(new net.minecraftforge.client.event.GuiScreenEvent.KeyboardInputEvent.Pre(this))) continue;
+                 this.func_146282_l();
++                if (this.equals(this.field_146297_k.field_71462_r)) MinecraftForge.EVENT_BUS.post(new net.minecraftforge.client.event.GuiScreenEvent.KeyboardInputEvent.Post(this));
+             }
+         }
+     }

--- a/patches/minecraft/net/minecraft/client/gui/inventory/GuiContainer.java.patch
+++ b/patches/minecraft/net/minecraft/client/gui/inventory/GuiContainer.java.patch
@@ -53,3 +53,20 @@
          Slot slot = this.func_146975_c(p_146286_1_, p_146286_2_);
          int l = this.field_147003_i;
          int i1 = this.field_147009_r;
+@@ -691,4 +702,16 @@
+             this.field_146297_k.field_71439_g.func_71053_j();
+         }
+     }
++
++    /* ======================================== FORGE START =====================================*/
++
++    /**
++     * Returns the slot that is currently displayed under the mouse.
++     */
++    public Slot getSlotUnderMouse()
++    {
++        return this.field_147006_u;
++    }
++
++    /* ======================================== FORGE END   =====================================*/
+ }

--- a/src/main/java/net/minecraftforge/client/event/GuiScreenEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/GuiScreenEvent.java
@@ -176,4 +176,70 @@ public class GuiScreenEvent extends Event
             }
         }
     }
+
+    public static class MouseInputEvent extends GuiScreenEvent
+    {
+        public MouseInputEvent(GuiScreen gui)
+        {
+            super(gui);
+        }
+
+        /**
+         * This event fires when mouse input is detected by a GuiScreen.
+         * Cancel this event to bypass {@code GuiScreen.handleMouseInput()}.
+         */
+        @Cancelable
+        public static class Pre extends MouseInputEvent
+        {
+            public Pre(GuiScreen gui)
+            {
+                super(gui);
+            }
+        }
+
+        /**
+         * This event fires after {@code GuiScreen.handleMouseInput()} provided that the active
+         * screen has not been changed as a result of {@code GuiScreen.handleMouseInput()}.
+         */
+        public static class Post extends MouseInputEvent
+        {
+            public Post(GuiScreen gui)
+            {
+                super(gui);
+            }
+        }
+    }
+
+    public static class KeyboardInputEvent extends GuiScreenEvent
+    {
+        public KeyboardInputEvent(GuiScreen gui)
+        {
+            super(gui);
+        }
+
+        /**
+         * This event fires when keyboard input is detected by a GuiScreen.
+         * Cancel this event to bypass {@code GuiScreen.handleKeyboardInput()}.
+         */
+        @Cancelable
+        public static class Pre extends KeyboardInputEvent
+        {
+            public Pre(GuiScreen gui)
+            {
+                super(gui);
+            }
+        }
+
+        /**
+         * This event fires after {@code GuiScreen.handleKeyboardInput()} provided that the active
+         * screen has not been changed as a result of {@code GuiScreen.handleKeyboardInput()}.
+         */
+        public static class Post extends KeyboardInputEvent
+        {
+            public Post(GuiScreen gui)
+            {
+                super(gui);
+            }
+        }
+    }
 }


### PR DESCRIPTION
Problem:
GuiScreen consumes keyboard and mouse input in such a way that the existing events aren't fired. (it uses Mouse.next() and Keyboard.next()).
There is no way to detect these events without using .next() first, which messes up keyboard and mouse detection for everything.

Use case 1:
I'm writing [an NEI alternative that isn't a coremod](https://github.com/mezz/JustEnoughItems). It needs to know about keyboard and mouse events when a GuiScreen is open. My current options are not good, and the current implementation is broken.

Use case 2:
Forestry backpacks can't be opened from the inventory because there is no way to detect a click or key press. With the mouse event and the ability to getTheSlot() from a guiContainer, we can detect a mouse click or key press and open the backpack that's under the mouse.

Solution:
 * Fire new GuiScreenEvents:
  * `MouseInputEvent.Pre (Cancelable)`
  * `MouseInputEvent.Post`
  * `KeyboardInputEvent.Pre (Cancelable)`
  * `KeyboardInputEvent.Post`
 * Add method:
  * `GuiContainer.getTheSlot()`

Modeled after the existing GuiScreenEvents https://github.com/MinecraftForge/MinecraftForge/commit/eb2549c7730d9430adb11282e05e2fcb2022a4ed

Rather than querying and passing all the mouse and keyboard data like the old Forge MouseEvent, they work like FML's mouse and keyboard events. The consumer of the event can query the relevant fields of Mouse or Keyboard directly rather than making the event copy every field.