### PR TITLE
Fixed EnumHelper, added banner support.

### DIFF
--- a/src/main/java/net/minecraftforge/client/EnumHelperClient.java
+++ b/src/main/java/net/minecraftforge/client/EnumHelperClient.java
@@ -8,13 +8,6 @@ import net.minecraftforge.common.util.EnumHelper;
 
 public class EnumHelperClient extends EnumHelper
 {
-    @SuppressWarnings("rawtypes")
-    private static Class[][] clentTypes =
-    {
-        {GameType.class, int.class, String.class},
-        {Options.class, String.class, boolean.class, boolean.class},
-        {EnumOS.class}
-    };
     
     public static GameType addGameType(String name, int id, String displayName)
     {
@@ -29,10 +22,5 @@ public class EnumHelperClient extends EnumHelper
     public static EnumOS addOS2(String name)
     {
         return addEnum(EnumOS.class, name);
-    }
-
-    public static <T extends Enum<? >> T addEnum(Class<T> enumType, String enumName, Object... paramValues)
-    {
-        return addEnum(clentTypes, enumType, enumName, paramValues);
     }
 }

--- a/src/main/java/net/minecraftforge/common/util/EnumHelper.java
+++ b/src/main/java/net/minecraftforge/common/util/EnumHelper.java
@@ -1,5 +1,5 @@
 package net.minecraftforge.common.util;
-
+ 
 import java.lang.reflect.*;
 import java.util.*;
 
@@ -24,7 +24,7 @@ import net.minecraft.util.MovingObjectPosition.MovingObjectType;
 import net.minecraft.world.EnumSkyBlock;
 import net.minecraft.world.gen.structure.StructureStrongholdPieces.Stronghold.Door;
 import net.minecraftforge.classloading.FMLForgePlugin;
-
+ 
 public class EnumHelper
 {
     private static Object reflectionFactory      = null;
@@ -33,102 +33,110 @@ public class EnumHelper
     private static Method newFieldAccessor       = null;
     private static Method fieldAccessorSet       = null;
     private static boolean isSetup               = false;
-
-    //Some enums are decompiled with extra arguments, so lets check for that
-    @SuppressWarnings("rawtypes")
-    private static Class[][] commonTypes =
-    {
-        {EnumAction.class},
-        {ArmorMaterial.class, String.class, int.class, int[].class, int.class},
-        {EnumArt.class, String.class, int.class, int.class, int.class, int.class},
-        {EnumCreatureAttribute.class},
-        {EnumCreatureType.class, Class.class, int.class, Material.class, boolean.class, boolean.class},
-        {Door.class},
-        {EnumEnchantmentType.class},
-        {Sensitivity.class},
-        {MovingObjectType.class},
-        {EnumSkyBlock.class, int.class},
-        {EnumStatus.class},
-        {ToolMaterial.class, int.class, int.class, float.class, float.class, int.class},
-        {EnumRarity.class, EnumChatFormatting.class, String.class},
-        {EnumBannerPattern.class, String.class, String.class},
-        {EnumBannerPattern.class, String.class, String.class, ItemStack.class},
-        {EnumBannerPattern.class, String.class, String.class, String.class, String.class, String.class}
-    };
-
+    
+    @Deprecated
     public static EnumAction addAction(String name)
     {
         return addEnum(EnumAction.class, name);
     }
+    
+    @Deprecated
     public static ArmorMaterial addArmorMaterial(String name, String type, int durability, int[] reductionAmounts, int enchantability)
     {
         return addEnum(ArmorMaterial.class, name, type, durability, reductionAmounts, enchantability);
     }
+    
+    @Deprecated
     public static EnumArt addArt(String name, String tile, int sizeX, int sizeY, int offsetX, int offsetY)
     {
         return addEnum(EnumArt.class, name, tile, sizeX, sizeY, offsetX, offsetY);
     }
+    
+    @Deprecated
     public static EnumCreatureAttribute addCreatureAttribute(String name)
     {
         return addEnum(EnumCreatureAttribute.class, name);
     }
-    @SuppressWarnings("rawtypes")
+    
+    @Deprecated
     public static EnumCreatureType addCreatureType(String name, Class typeClass, int maxNumber, Material material, boolean peaceful, boolean animal)
     {
         return addEnum(EnumCreatureType.class, name, typeClass, maxNumber, material, peaceful, animal);
     }
+    
+    @Deprecated
     public static Door addDoor(String name)
     {
         return addEnum(Door.class, name);
     }
+    
+    @Deprecated
     public static EnumEnchantmentType addEnchantmentType(String name)
     {
         return addEnum(EnumEnchantmentType.class, name);
     }
+    
+    @Deprecated
     public static Sensitivity addSensitivity(String name)
     {
         return addEnum(Sensitivity.class, name);
     }
+    
+    @Deprecated
     public static MovingObjectType addMovingObjectType(String name)
     {
         return addEnum(MovingObjectType.class, name);
     }
+    
+    @Deprecated
     public static EnumSkyBlock addSkyBlock(String name, int lightValue)
     {
         return addEnum(EnumSkyBlock.class, name, lightValue);
     }
+    
+    @Deprecated
     public static EnumStatus addStatus(String name)
     {
         return addEnum(EnumStatus.class, name);
     }
+    
+    @Deprecated
     public static ToolMaterial addToolMaterial(String name, int harvestLevel, int maxUses, float efficiency, float damage, int enchantability)
     {
         return addEnum(ToolMaterial.class, name, harvestLevel, maxUses, efficiency, damage, enchantability);
     }
+    
+    @Deprecated
     public static EnumRarity addRarity(String name, EnumChatFormatting color, String displayName)
     {
         return addEnum(EnumRarity.class, name, color, displayName);
     }
+    
+    @Deprecated
     public static EnumBannerPattern addBannerPattern(String name, String type, String id)
     {
         return addEnum(EnumBannerPattern.class, name, type, id);
     }
+    
+    @Deprecated
     public static EnumBannerPattern addBannerPattern(String name, String type, String id, ItemStack craftingStack)
     {
         return addEnum(EnumBannerPattern.class, name, type, id, craftingStack);
     }
+    
+    @Deprecated
     public static EnumBannerPattern addBannerPattern(String name, String type, String id, String craftingTop, String craftingMid, String craftingBot)
     {
         return addEnum(EnumBannerPattern.class, name, type, id, craftingTop, craftingMid, craftingBot);
     }
-
+ 
     private static void setup()
     {
         if (isSetup)
         {
             return;
         }
-
+ 
         try
         {
             Method getReflectionFactory = Class.forName("sun.reflect.ReflectionFactory").getDeclaredMethod("getReflectionFactory");
@@ -142,10 +150,10 @@ public class EnumHelper
         {
             e.printStackTrace();
         }
-
+ 
         isSetup = true;
     }
-
+ 
     /*
      * Everything below this is found at the site below, and updated to be able to compile in Eclipse/Java 1.6+
      * Also modified for use in decompiled code.
@@ -159,7 +167,7 @@ public class EnumHelper
         System.arraycopy(additionalParameterTypes, 0, parameterTypes, 2, additionalParameterTypes.length);
         return newConstructorAccessor.invoke(reflectionFactory, enumClass.getDeclaredConstructor(parameterTypes));
     }
-
+ 
     private static < T extends Enum<? >> T makeEnum(Class<T> enumClass, String value, int ordinal, Class<?>[] additionalTypes, Object[] additionalValues) throws Exception
     {
         Object[] parms = new Object[additionalValues.length + 2];
@@ -168,7 +176,7 @@ public class EnumHelper
         System.arraycopy(additionalValues, 0, parms, 2, additionalValues.length);
         return enumClass.cast(newInstance.invoke(getConstructorAccessor(enumClass, additionalTypes), new Object[] {parms}));
     }
-
+ 
     public static void setFailsafeFieldValue(Field field, Object target, Object value) throws Exception
     {
         field.setAccessible(true);
@@ -178,7 +186,7 @@ public class EnumHelper
         Object fieldAccessor = newFieldAccessor.invoke(reflectionFactory, field, false);
         fieldAccessorSet.invoke(fieldAccessor, target, value);
     }
-
+ 
     private static void blankField(Class<?> enumClass, String fieldName) throws Exception
     {
         for (Field field : Class.class.getDeclaredFields())
@@ -191,125 +199,111 @@ public class EnumHelper
             }
         }
     }
-
+ 
     private static void cleanEnumCache(Class<?> enumClass) throws Exception
     {
         blankField(enumClass, "enumConstantDirectory");
         blankField(enumClass, "enumConstants");
     }
-
-    public static <T extends Enum<? >> T addEnum(Class<T> enumType, String enumName, Object... paramValues)
+ 
+    @SuppressWarnings("unchecked")
+    public static <T extends Enum<? >> T addEnum(Class<T> enumType, String enumName,  Object... paramValues)
     {
         setup();
-        return addEnum(commonTypes, enumType, enumName, paramValues);
-    }
-
-    @SuppressWarnings("rawtypes")
-    public static <T extends Enum<? >> T addEnum(Class[][] map, Class<T> enumType, String enumName, Object... paramValues)
-    {
-        for (Class[] lookup : map)
+        for (Constructor<?> lookup : enumType.getDeclaredConstructors())
         {
-            if (compareCommonTypes(lookup, enumType, paramValues))
+            if (compareCommonTypes(lookup.getParameterTypes(), paramValues))
             {
-                Class<?>[] paramTypes = new Class<?>[lookup.length - 1];
+                Class<?>[] paramTypes = new Class<?>[lookup.getParameterTypes().length - 2];
                 if (paramTypes.length > 0)
                 {
-                    System.arraycopy(lookup, 1, paramTypes, 0, paramTypes.length);
+                    System.arraycopy(lookup.getParameterTypes(), 2, paramTypes, 0, paramTypes.length);
                 }
-                return addEnum(enumType, enumName, paramTypes, paramValues);
+                
+                Field valuesField = null;
+                Field[] fields = enumType.getDeclaredFields();
+         
+                for (Field field : fields)
+                {
+                    String name = field.getName();
+                    if (name.equals("$VALUES") || name.equals("ENUM$VALUES")) //Added 'ENUM$VALUES' because Eclipse's internal compiler doesn't follow standards
+                    {
+                        valuesField = field;
+                        break;
+                    }
+                }
+         
+                int flags = (FMLForgePlugin.RUNTIME_DEOBF ? Modifier.PUBLIC : Modifier.PRIVATE) | Modifier.STATIC | Modifier.FINAL | 0x1000 /*SYNTHETIC*/;
+                if (valuesField == null)
+                {
+                    String valueType = String.format("[L%s;", enumType.getName().replace('.', '/'));
+         
+                    for (Field field : fields)
+                    {
+                        if ((field.getModifiers() & flags) == flags &&
+                                field.getType().getName().replace('.', '/').equals(valueType)) //Apparently some JVMs return .'s and some don't..
+                        {
+                            valuesField = field;
+                            break;
+                        }
+                    }
+                }
+         
+                if (valuesField == null)
+                {
+                    FMLLog.severe("Could not find $VALUES field for enum: %s", enumType.getName());
+                    FMLLog.severe("Runtime Deobf: %s", FMLForgePlugin.RUNTIME_DEOBF);
+                    FMLLog.severe("Flags: %s", String.format("%16s", Integer.toBinaryString(flags)).replace(' ', '0'));
+                    FMLLog.severe("Fields:");
+                    for (Field field : fields)
+                    {
+                        String mods = String.format("%16s", Integer.toBinaryString(field.getModifiers())).replace(' ', '0');
+                        FMLLog.severe("       %s %s: %s", mods, field.getName(), field.getType().getName());
+                    }
+                    return null;
+                }
+         
+                valuesField.setAccessible(true);
+         
+                try
+                {
+                    T[] previousValues = (T[])valuesField.get(enumType);
+                    List<T> values = new ArrayList<T>(Arrays.asList(previousValues));
+                    T newValue = (T)makeEnum(enumType, enumName, values.size(), paramTypes, paramValues);
+                    values.add(newValue);
+                    setFailsafeFieldValue(valuesField, null, values.toArray((T[]) Array.newInstance(enumType, 0)));
+                    cleanEnumCache(enumType);
+         
+                    return newValue;
+                }
+                catch (Exception e)
+                {
+                    e.printStackTrace();
+                    throw new RuntimeException(e.getMessage(), e);
+                }
             }
         }
         return null;
     }
-
-    @SuppressWarnings("unchecked")
-    public static <T extends Enum<? >> T addEnum(Class<T> enumType, String enumName, Class<?>[] paramTypes, Object[] paramValues)
+ 
+    public static boolean compareCommonTypes(Class[] commonType, Object[] paramValues)
     {
-        if (!isSetup)
+        if (commonType.length - 2 != paramValues.length)
         {
-            setup();
-        }
-
-        Field valuesField = null;
-        Field[] fields = enumType.getDeclaredFields();
-
-        for (Field field : fields)
-        {
-            String name = field.getName();
-            if (name.equals("$VALUES") || name.equals("ENUM$VALUES")) //Added 'ENUM$VALUES' because Eclipse's internal compiler doesn't follow standards
-            {
-                valuesField = field;
-                break;
-            }
-        }
-
-        int flags = (FMLForgePlugin.RUNTIME_DEOBF ? Modifier.PUBLIC : Modifier.PRIVATE) | Modifier.STATIC | Modifier.FINAL | 0x1000 /*SYNTHETIC*/;
-        if (valuesField == null)
-        {
-            String valueType = String.format("[L%s;", enumType.getName().replace('.', '/'));
-
-            for (Field field : fields)
-            {
-                if ((field.getModifiers() & flags) == flags &&
-                     field.getType().getName().replace('.', '/').equals(valueType)) //Apparently some JVMs return .'s and some don't..
-                {
-                    valuesField = field;
-                    break;
-                }
-            }
-        }
-
-        if (valuesField == null)
-        {
-            FMLLog.severe("Could not find $VALUES field for enum: %s", enumType.getName());
-            FMLLog.severe("Runtime Deobf: %s", FMLForgePlugin.RUNTIME_DEOBF);
-            FMLLog.severe("Flags: %s", String.format("%16s", Integer.toBinaryString(flags)).replace(' ', '0'));
-            FMLLog.severe("Fields:");
-            for (Field field : fields)
-            {
-                String mods = String.format("%16s", Integer.toBinaryString(field.getModifiers())).replace(' ', '0');
-                FMLLog.severe("       %s %s: %s", mods, field.getName(), field.getType().getName());
-            }
-            return null;
-        }
-
-        valuesField.setAccessible(true);
-
-        try
-        {
-            T[] previousValues = (T[])valuesField.get(enumType);
-            List<T> values = new ArrayList<T>(Arrays.asList(previousValues));
-            T newValue = (T)makeEnum(enumType, enumName, values.size(), paramTypes, paramValues);
-            values.add(newValue);
-            setFailsafeFieldValue(valuesField, null, values.toArray((T[]) Array.newInstance(enumType, 0)));
-            cleanEnumCache(enumType);
-
-            return newValue;
-        }
-        catch (Exception e)
-        {
-            e.printStackTrace();
-            throw new RuntimeException(e.getMessage(), e);
-        }
-    }
-    
-    public static boolean compareCommonTypes(Class[] commonType, Class enumType, Object[] paramValues)
-    {
-        if (commonType[0] != enumType || commonType.length -1 != paramValues.length) 
-        {       
             return false;
         }
-        
+ 
+        // skips the enum information, enumName and ordinal
         for (int i = 0; i < paramValues.length; i++)
         {
-            if (commonType[i + 1] != paramValues[i].getClass() && ClassUtils.primitiveToWrapper(commonType[i + 1]) != paramValues[i].getClass())
-            {       
+            if (!paramValues[i].getClass().isAssignableFrom(commonType[i + 2]) &&  !paramValues[i].getClass().isAssignableFrom(ClassUtils.primitiveToWrapper(commonType[i + 2])))
+            {
                 return false;
             }
         }
         return true;
     }
-
+ 
     static
     {
         if (!isSetup)


### PR DESCRIPTION
There are three major parts to this pull request, the first is the modified check for commonTypes. In previous versions of forge this would only check for the first class when adding to an Enum, however this would not allow for multiple constructors to be utilized, up till now there has been no use for such a thing however the EnumBannerPattern requires this, I will get into why later in the post. The second thing I changed was the method for adding new armor materials, as of 1.8 a string is required for construction, we were still using the params for the old version. The last thing changed was the ability to add new banner patterns. 

The EnumBannerPattern contains three different constructors, each with a unique purpose. The first simply adds a new pattern while the second and third deal with crafting. The second allows for a specific itemstack to be provided (for example the good golden apple is used in vanilla to display a mojang logo) while the third uses three strings to represent a crafting grid, and the items are all unspecified dye items. 

![Crafting Recipe 1](http://i.imgur.com/nG1tClV.png)
![Crafting Recipe 2](http://i.imgur.com/Xfdcves.png)

You can test these additions by using the deobf dev jar found [here.](https://dl-web.dropbox.com/get/Public/Banner%20Test%20Deobf.jar?_subject_uid=38575752&w=AADHHKS8Sim6TRt-Kh6aoImtRI51RudUWkEGCz5APCmxTA&dl=1)

Features of the dev jar
-Three new banner patterns, each using one of the new methods added.
-A new armor set, showing the armor materials work.
-A new Enchantment and EnumEnchantmentType to show that it also still works.
-A new creative tab to hold all the new armor and enchantment. 

Note that there is no way to get the third banner, however you can spawn it in using the following command. 

> /give @p banner 1 0 {BlockEntityTag:{Patterns:[ 0:{Pattern:"sap",Color:14} ]}}
