### PR TITLE
Added 2 new events for piston retraction and extension.

### DIFF
--- a/patches/minecraft/net/minecraft/block/BlockPistonBase.java.patch
+++ b/patches/minecraft/net/minecraft/block/BlockPistonBase.java.patch
@@ -1,5 +1,22 @@
 --- ../src-base/minecraft/net/minecraft/block/BlockPistonBase.java
 +++ ../src-work/minecraft/net/minecraft/block/BlockPistonBase.java
+@@ -82,14 +82,14 @@
+         EnumFacing enumfacing = (EnumFacing)p_176316_3_.func_177229_b(field_176321_a);
+         boolean flag = this.func_176318_b(p_176316_1_, p_176316_2_, enumfacing);
+ 
+-        if (flag && !((Boolean)p_176316_3_.func_177229_b(field_176320_b)).booleanValue())
++        if (flag && !((Boolean)p_176316_3_.func_177229_b(field_176320_b)).booleanValue() && !net.minecraftforge.event.ForgeEventFactory.onPistonExtend(p_176316_1_, p_176316_2_, enumfacing))
+         {
+             if ((new BlockPistonStructureHelper(p_176316_1_, p_176316_2_, enumfacing, true)).func_177253_a())
+             {
+                 p_176316_1_.func_175641_c(p_176316_2_, this, 0, enumfacing.func_176745_a());
+             }
+         }
+-        else if (!flag && ((Boolean)p_176316_3_.func_177229_b(field_176320_b)).booleanValue())
++        else if (!flag && ((Boolean)p_176316_3_.func_177229_b(field_176320_b)).booleanValue() && !net.minecraftforge.event.ForgeEventFactory.onPistonRetract(p_176316_1_, p_176316_2_, enumfacing))
+         {
+             p_176316_1_.func_180501_a(p_176316_2_, p_176316_3_.func_177226_a(field_176320_b, Boolean.valueOf(false)), 2);
+             p_176316_1_.func_175641_c(p_176316_2_, this, 1, enumfacing.func_176745_a());
 @@ -200,7 +200,7 @@
                      }
                  }

--- a/src/main/java/net/minecraftforge/event/ForgeEventFactory.java
+++ b/src/main/java/net/minecraftforge/event/ForgeEventFactory.java
@@ -346,4 +346,14 @@ public class ForgeEventFactory
     {
         MinecraftForge.EVENT_BUS.post(new net.minecraftforge.event.entity.player.PlayerEvent.Clone(player, oldPlayer, wasDeath));
     }
+    
+    public static boolean onPistonExtend(World world, BlockPos pos, EnumFacing facing)
+    {
+        return MinecraftForge.EVENT_BUS.post(new net.minecraftforge.event.world.PistonEvent.PistonExtendEvent(world, pos, facing));
+    }
+    
+    public static boolean onPistonRetract(World world, BlockPos pos, EnumFacing facing)
+    {
+        return MinecraftForge.EVENT_BUS.post(new net.minecraftforge.event.world.PistonEvent.PistonRetractEvent(world, pos, facing));
+    }
 }

--- a/src/main/java/net/minecraftforge/event/world/PistonEvent.java
+++ b/src/main/java/net/minecraftforge/event/world/PistonEvent.java
@@ -1,0 +1,46 @@
+package net.minecraftforge.event.world;
+
+import net.minecraft.block.Block;
+import net.minecraft.util.BlockPos;
+import net.minecraft.util.EnumFacing;
+import net.minecraft.world.World;
+import net.minecraftforge.fml.common.eventhandler.Cancelable;
+
+public class PistonEvent extends BlockEvent
+{
+    /** Stores the direction of the piston */
+    public final EnumFacing facing;
+    
+    public PistonEvent(World world, BlockPos pos, EnumFacing facing)
+    {
+        super(world, pos, world.getBlockState(pos));
+        
+        this.facing = facing;
+    }
+    
+    /***
+     * Posts when a piston tries to extend
+     * If canceled the piston will not extend
+     ***/
+    @Cancelable
+    public static class PistonExtendEvent extends PistonEvent
+    {
+        public PistonExtendEvent(World world, BlockPos pos, EnumFacing facing)
+        {
+            super(world, pos, facing);
+        }
+    }
+    
+    /***
+     * Posts when a piston tries to retract
+     * If canceled the piston will not pull the block it is attached to
+     ***/
+    @Cancelable
+    public static class PistonRetractEvent extends PistonEvent
+    {
+        public PistonRetractEvent(World world, BlockPos pos, EnumFacing facing)
+        {
+            super(world, pos, facing);
+        }
+    }
+}


### PR DESCRIPTION
They are both cancellable and cause the retraction/extension not to happen when cancelled.

A simple example to prevent pistons from functioning at all.
https://gist.github.com/tattyseal/b487a75fce9a34ab1760

Both events provide whatever way the piston is facing. And all of the normal BlockEvent paramaters.