### PR TITLE
Make Potion.isBadEffect available server-side

### DIFF
--- a/patches/minecraft/net/minecraft/potion/Potion.java.patch
+++ b/patches/minecraft/net/minecraft/potion/Potion.java.patch
@@ -1,6 +1,14 @@
 --- ../src-base/minecraft/net/minecraft/potion/Potion.java
 +++ ../src-work/minecraft/net/minecraft/potion/Potion.java
-@@ -307,4 +307,27 @@
+@@ -221,7 +221,6 @@
+         return this.field_76417_J;
+     }
+ 
+-    @SideOnly(Side.CLIENT)
+     public boolean func_76398_f()
+     {
+         return this.field_76418_K;
+@@ -307,4 +306,27 @@
      {
          return p_111183_2_.func_111164_d() * (double)(p_111183_1_ + 1);
      }


### PR DESCRIPTION
In the Minecraft source, they made Potion.isBadEffect() client-side-only because it's only used for rendering tooltips. (or at least that's the best reason I can come up with...)

I would like to be able to use it for more than that.

Forestry has an apiarist's suit that protects against negative bee effects. Some of the bee effects use potions. I want to use Potion.isBadEffect() to determine if the effect is negative and should be protected against.
```java
EntityPlayer player = ...
int duration = ...
if (potion.isBadEffect()) {
	// Reduce duration based on the amount of apiarist armor worn
}
 
player.addPotionEffect(new PotionEffect(potion.getId(), duration, 0));
```