### PR TITLE
Fix textures not stitching even if height allows.

### DIFF
--- a/patches/minecraft/net/minecraft/client/renderer/texture/Stitcher.java.patch
+++ b/patches/minecraft/net/minecraft/client/renderer/texture/Stitcher.java.patch
@@ -9,3 +9,12 @@
              }
              else
              {
+@@ -183,7 +183,7 @@
+ 
+         j = Math.max(p_94311_1_.func_94197_a(), p_94311_1_.func_94199_b());
+ 
+-        if (MathHelper.func_151236_b((flag1 ? this.field_94315_d : this.field_94318_c) + j) > (flag1 ? this.field_94313_f : this.field_94316_e))
++        if (MathHelper.func_151236_b((!flag1 ? this.field_94315_d : this.field_94318_c) + j) > (!flag1 ? this.field_94313_f : this.field_94316_e))
+         {
+             return false;
+         }


### PR DESCRIPTION
Ex.

Computer supports 8192x8192 max texture size
Current stitch size is 8192x4096
Texture wanting to be stitched is 256x256
The current code would do 8192 + 256 > 8192 and therefore throw the
exception instead of 4096 + 256 > 8192.
