### PR TITLE
Fix NPE being thrown when brewing event is fired

### DIFF
--- a/src/main/java/net/minecraftforge/event/ForgeEventFactory.java
+++ b/src/main/java/net/minecraftforge/event/ForgeEventFactory.java
@@ -261,7 +261,7 @@ public class ForgeEventFactory
     {
         ItemStack[] tmp = new ItemStack[stacks.length];
         for (int x = 0; x < tmp.length; x++)
-            tmp[x] = stacks[x].copy();
+            tmp[x] = ItemStack.copyItemStack(stacks[x]);
 
         PotionBrewEvent.Pre event = new PotionBrewEvent.Pre(tmp);
         if (MinecraftForge.EVENT_BUS.post(event))


### PR DESCRIPTION
When brewing a potion with less than 3 stacks in the stand an NPE is thrown.

I believe this fixes the issue described on #1558
