### PR TITLE
Make daylight sensor recipe use ore dictionary wooden slabs

### DIFF
--- a/src/main/java/net/minecraftforge/oredict/OreDictionary.java
+++ b/src/main/java/net/minecraftforge/oredict/OreDictionary.java
@@ -133,6 +133,7 @@ public class OreDictionary
         replacements.put(new ItemStack(Items.stick), "stickWood");
         replacements.put(new ItemStack(Blocks.planks), "plankWood");
         replacements.put(new ItemStack(Blocks.planks, 1, WILDCARD_VALUE), "plankWood");
+        replacements.put(new ItemStack(Blocks.wooden_slab, 1, WILDCARD_VALUE), "slabWood");
         replacements.put(new ItemStack(Blocks.stone), "stone");
         replacements.put(new ItemStack(Blocks.stone, 1, WILDCARD_VALUE), "stone");
         replacements.put(new ItemStack(Blocks.cobblestone), "cobblestone");
@@ -202,6 +203,7 @@ public class OreDictionary
             new ItemStack(Blocks.jungle_stairs),
             new ItemStack(Blocks.acacia_stairs),
             new ItemStack(Blocks.dark_oak_stairs),
+            new ItemStack(Blocks.wooden_slab),
             new ItemStack(Blocks.glass_pane),
             new ItemStack(Blocks.stained_glass)
         };


### PR DESCRIPTION
Improved this PR https://github.com/MinecraftForge/MinecraftForge/pull/1554

Now only the Daylight sensor recipe is changed.
![2014-12-09_22 46](https://cloud.githubusercontent.com/assets/916092/5371927/928ce55e-7ff5-11e4-9fe6-2ae126557fce.png)
![2014-12-09_22 462](https://cloud.githubusercontent.com/assets/916092/5371928/928cfa44-7ff5-11e4-828c-8001c479aebc.png)
![2014-12-09_22 50](https://cloud.githubusercontent.com/assets/916092/5371943/eaa9ca86-7ff5-11e4-9563-1c8ae4d3872a.png)
