### PR TITLE
Added ClientPlayerChatEvent

### DIFF
--- a/patches/minecraft/net/minecraft/client/entity/EntityClientPlayerMP.java.patch
+++ b/patches/minecraft/net/minecraft/client/entity/EntityClientPlayerMP.java.patch
@@ -1,0 +1,16 @@
+--- ../src-base/minecraft/net/minecraft/client/entity/EntityClientPlayerMP.java
++++ ../src-work/minecraft/net/minecraft/client/entity/EntityClientPlayerMP.java
+@@ -180,9 +180,11 @@
+ 
+     public void func_71165_d(String p_71165_1_)
+     {
+-        this.field_71174_a.func_147297_a(new C01PacketChatMessage(p_71165_1_));
++        net.minecraftforge.event.entity.player.ClientPlayerChatEvent evt=new net.minecraftforge.event.entity.player.ClientPlayerChatEvent(p_71165_1_);
++        if (net.minecraftforge.common.MinecraftForge.EVENT_BUS.post(evt)) return;
++        this.field_71174_a.func_147297_a(new C01PacketChatMessage(evt.message));
+     }
+-
++    
+     public void func_71038_i()
+     {
+         super.func_71038_i();

--- a/src/main/java/net/minecraftforge/event/entity/player/ClientPlayerChatEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/player/ClientPlayerChatEvent.java
@@ -1,0 +1,12 @@
+package net.minecraftforge.event.entity.player;
+import cpw.mods.fml.common.eventhandler.Cancelable;
+
+@Cancelable
+public class ClientPlayerChatEvent extends cpw.mods.fml.common.eventhandler.Event 
+{
+    public String message;
+    public ClientPlayerChatEvent(String message)
+    {
+        this.message=message;
+    }
+}


### PR DESCRIPTION
This adds a hook to EntityClientPlayerMP#sendChatMessage which allows mods to cancel a chat message message from being sent, modifying, or just inspecting it.

http://pastebin.com/9mNXWzRU
