### PR TITLE
Fixed messages not being added to the chat history

### DIFF
--- a/patches/minecraft/net/minecraft/client/gui/GuiSleepMP.java.patch
+++ b/patches/minecraft/net/minecraft/client/gui/GuiSleepMP.java.patch
@@ -1,0 +1,11 @@
+--- ../src-base/minecraft/net/minecraft/client/gui/GuiSleepMP.java
++++ ../src-work/minecraft/net/minecraft/client/gui/GuiSleepMP.java
+@@ -33,7 +33,7 @@
+ 
+             if (!s.isEmpty())
+             {
+-                this.field_146297_k.field_71439_g.func_71165_d(s);
++                this.func_146403_a(s); // Forge: fix vanilla not adding messages to the sent list while sleeping
+             }
+ 
+             this.field_146415_a.func_146180_a("");


### PR DESCRIPTION
Fixed messages not being added to the chat history and ClientCommandHandler not being called when sleeping (client side commands are ignored).

The same bug exists in 1.8, except that the function should be `func_175275_f` (`sendChatMessage`).
