### PR TITLE
Broadcast BlockEvent.PlaceEvent

### DIFF
--- a/patches/minecraft/net/minecraft/world/World.java.patch
+++ b/patches/minecraft/net/minecraft/world/World.java.patch
@@ -120,7 +120,7 @@
              {
 +                if (blockSnapshot != null)
 +                {
-+                    this.capturedBlockSnapshots.remove(blockSnapshot);
++                    //this.capturedBlockSnapshots.remove(blockSnapshot);//Forge handles this for us; Line prevents Block PlaceEvent. 
 +                    blockSnapshot = null;
 +                }
 +


### PR DESCRIPTION
# Adding Broadcast of PlaceEvent to EventBus
## Summary
##### (Currently up to date with version: 1.8-11.14.0.1273-1.8)

Events getting broadcast to the Forge EventBus enables modders to do a variety of things when those events occur.  `BlockEvent.PlaceEvent` is an event that can occur when a block is placed into the world.    Since 1.8, `PlaceEvent` has not yet been implemented (although basically all of the logic is in place from 1.7.10).  This PR changes a line of code that allows broadcast of the event.
## Why

We are working on a mod/app that lets you visualize data generated in minecraft by leveraging [Splunk](http://www.splunk.com/)'s abilities.  Previous versions of the Splunk Minecraft-App have drawn more detailed information about events such as location and player than the vanilla Minecraft statistics; for instance I could compare how many cobblestone blocks I have broken vs my brother over any given time period, or within any minecraft geo-range (e.g. number of cobblestone blocks broken within 100 meters of the origin from November 1st to December 1st).  Additionally Splunk Minecraft-App has used the Overviewer plugin with player position information to retrace their steps on a server (you can see the path players have traveled superimposed on overviewer, and although not yet implemented, could also plot where those player did things like farm, or kill mobs).  Our current goal is to move the Splunk Minecraft-App to Forge.

The old version on Splunk’s webpage using:
[Splunk Minecraft-App](https://apps.splunk.com/app/1618/)

Original plugin:
 http://dev.bukkit.org/bukkit-plugins/logtosplunk/
## Changes

A single line is commented out in `net.minecraft.World` that stops the method `World#setBlockState(...)` from clearing information that is needed to broadcast `BlockEvent#PlaceEvent` to the Forge EventBus.

The basic logic surrounding this change seems to be as follows:

`net.minecraftforge.common.ForgeHooks#onPlaceItemIntoWorld(...)`, which ultimately broadcasts `PlaceEvent` relies on `World#capturedBlockSnapshots` (a list of `BlockSnapshot`s) to get the block being placed.

`World#setBlockState(...)` adds the `BlockSnapshot` used by `ForgeHooks#onPlaceItemIntoWorld(...)` to `World#capturedBlockSnapshots` if and only if (boolean) ``World.captureBlockSnapshots` is set to true.

`ForgeHooks#onPlaceItemIntoWorld` is the only class to manipulate the value of `World#captureBlockSnapshots`, so `BlockSnapshot`s are only added to `World#capturedBlockSnapshots` if `ForgeHooks#onPlaceItemIntoWorld` “says to”.

`ForgeHooks#onPlaceItemIntoWorld` clears all data from `World#capturedBlockSnapshots` when it is done using them. 

Before this change, `World#setBlockState` was removing blocks from `World#capturedBlockSnapshots` before `ForgeHooks#onPlaceItemIntoWorld` checked to see if there was a block in `World#capturedBlockSnapshots` to broadcast to the event bus.  (having already been removed by `World`, `onPlaceItemIntoWorld` just skips posting the event to the bus). 

`ForgeHooks#onPlaceItemInto` currently handles all steps necessary to clear `BlockSnapshots` from `World#capturedBlockSnapshots`,  so it is not necessary for `World#setBlockState` to perform this function.

Currently there are no other cases of `capturedBlockSnapshots` being used except in `ForgeHooks#onPlaceItemIntoWorld`. If they are used later, then the class using them should be responsible for setting `World#captureBlockSnapshots` to true when starting  and false when done, and clean up `capturedBlockSnapshots` by removing any`BlockSnapshot`s added during the time `captureBlockSnapshots` was set to true. 
## How It was Tested
- Code was investigated for any possible side effects, none were found.
- `BlockEvent.PlaceEvent`s (of most types of blocks)  were successfully captured by subscribing to the event bus and receiving events. Side note: it didnt seem like Armor stands were generating both `BreakEvent` and `PlaceEvent` (it generated one of the two I think).  Events were counted and in this investigation the number of blocks placed was equal to the number expected.
- Played Minecraft for an hour or so, with modification, doing normal things, culminating with placing hundreds+ of TNT blocks and triggering them (important test). 
## In Closing

Let us know what you think.  If you decide to accept the update let me know if you want me to add in any documentation anywhere.

Thanks!
