### PR TITLE
[1.8] Fix Scoreboard rendering for the sidebar.

### DIFF
--- a/src/main/java/net/minecraftforge/client/GuiIngameForge.java
+++ b/src/main/java/net/minecraftforge/client/GuiIngameForge.java
@@ -170,9 +170,9 @@ public class GuiIngameForge extends GuiIngame
             if (slot >= 0) objective = scoreboard.getObjectiveInDisplaySlot(3 + slot);
         }
         ScoreObjective scoreobjective1 = objective != null ? objective : scoreboard.getObjectiveInDisplaySlot(1);
-        if (renderObjective && objective != null)
+        if (renderObjective && scoreobjective1 != null)
         {
-            this.func_180475_a(objective, res);
+            this.func_180475_a(scoreobjective1, res);
         }
 
         GlStateManager.enableBlend();


### PR DESCRIPTION
I noticed that the sidebar scoreboard wasn't displayed.

So I compared with the vanilla `GuiIngame` and noticed a little difference. The comparison shows clearly that `scoreobjective1` should be used to render the scoreboard.

Screenshot form net.minecraft.client.gui.GuiIngame, beginning at line 295
![image](https://cloud.githubusercontent.com/assets/3661485/5525600/fa27a4ea-89e8-11e4-886e-dbd4dbff8990.png)
