### PR TITLE
[1.8] Bugfix for player kicked when floating in water. Fixes #1545

### DIFF
--- a/patches/minecraft/net/minecraft/network/NetHandlerPlayServer.java.patch
+++ b/patches/minecraft/net/minecraft/network/NetHandlerPlayServer.java.patch
@@ -70,7 +70,7 @@
                  AxisAlignedBB axisalignedbb = this.field_147369_b.func_174813_aQ().func_72314_b((double)f3, (double)f3, (double)f3).func_72321_a(0.0D, -0.55D, 0.0D);
  
 -                if (!this.field_147367_d.func_71231_X() && !this.field_147369_b.field_71075_bZ.field_75101_c && !worldserver.func_72829_c(axisalignedbb))
-+                if (!this.field_147367_d.func_71231_X() && !this.field_147369_b.field_71075_bZ.field_75101_c && !worldserver.func_72829_c(axisalignedbb) && !this.field_147369_b.field_71075_bZ.field_75101_c)
++                if (!this.field_147367_d.func_71231_X() && !this.field_147369_b.field_71075_bZ.field_75101_c && !worldserver.func_72829_c(axisalignedbb) && !this.field_147369_b.field_71075_bZ.field_75101_c && this.field_147369_b.field_70160_al)
                  {
                      if (d18 >= -0.03125D)
                      {


### PR DESCRIPTION
## Summary
##### Up to date as of version 11.14.0.1290
In survival,  player is kicked for floating while in water --> bug does not occur in creative.  Floating in water should be allowed. This adds a boolean check on to a line to make sure the player is, in fact, in air when floating before kicking the player.

Bug also occurs when on ladder, fix appears to resolve this issue also.

Closes #1545

To reproduce, go to the bottom of a pond and swim up/forward, also try bobbing up and down a little to try to stay level.  It's a little finicky sometimes but fairly easy to reproduce and should occur quickly.  Player should be kicked with error message "Flying is not enabled on this server".  Server log shows "(player name) was kicked for floating too long!"

Same issue should occur if you place some ladder and climb on it for a bit.

## Code Changes:

Line 399 in ```net.minecraft.network.NetHandlerPlayerServer``` is changed from:

```if (!this.serverController.isFlightAllowed() && !this.playerEntity.capabilities.allowFlying && !worldserver.checkBlockCollision(axisalignedbb) && !this.playerEntity.capabilities.allowFlying)```

To:

```if (!this.serverController.isFlightAllowed() && !this.playerEntity.capabilities.allowFlying && !worldserver.checkBlockCollision(axisalignedbb) && !this.playerEntity.capabilities.allowFlying && this.playerEntity.isAirBorne)```

Note the final check added: ```this.playerEntity.isAirBorne```

Hope this helps.