### PR TITLE
Added IDynamicItemModel as a way to define a custom ItemStack rendering method

### DIFF
--- a/patches/minecraft/net/minecraft/client/renderer/entity/RenderItem.java.patch
+++ b/patches/minecraft/net/minecraft/client/renderer/entity/RenderItem.java.patch
@@ -9,7 +9,15 @@
          this.func_175041_b();
      }
  
-@@ -302,6 +302,10 @@
+@@ -148,6 +148,7 @@
+ 
+     public void func_180454_a(ItemStack p_180454_1_, IBakedModel p_180454_2_)
+     {
++        if(net.minecraftforge.client.ForgeHooksClient.renderDynamicItem(p_180454_1_, p_180454_2_)) return;
+         GlStateManager.func_179094_E();
+         GlStateManager.func_179152_a(0.5F, 0.5F, 0.5F);
+ 
+@@ -302,6 +303,10 @@
                      modelresourcelocation = new ModelResourceLocation("bow_pulling_0", "inventory");
                  }
              }
@@ -20,7 +28,7 @@
  
              if (modelresourcelocation != null)
              {
-@@ -485,10 +489,11 @@
+@@ -485,10 +490,11 @@
                  GlStateManager.func_179126_j();
              }
  
@@ -35,7 +43,7 @@
                  GlStateManager.func_179140_f();
                  GlStateManager.func_179097_i();
                  GlStateManager.func_179090_x();
-@@ -501,7 +506,7 @@
+@@ -501,7 +507,7 @@
                  this.func_175044_a(worldrenderer, p_180453_3_ + 2, p_180453_4_ + 13, 13, 2, 0);
                  this.func_175044_a(worldrenderer, p_180453_3_ + 2, p_180453_4_ + 13, 12, 1, i1);
                  this.func_175044_a(worldrenderer, p_180453_3_ + 2, p_180453_4_ + 13, j1, 1, l);
@@ -44,7 +52,7 @@
                  GlStateManager.func_179141_d();
                  GlStateManager.func_179098_w();
                  GlStateManager.func_179145_e();
-@@ -1078,6 +1083,19 @@
+@@ -1078,6 +1084,19 @@
      {
          this.field_175059_m.func_178085_b();
      }

--- a/src/main/java/net/minecraftforge/client/ForgeHooksClient.java
+++ b/src/main/java/net/minecraftforge/client/ForgeHooksClient.java
@@ -17,6 +17,7 @@ import net.minecraft.client.renderer.RenderGlobal;
 import net.minecraft.client.renderer.texture.TextureManager;
 import net.minecraft.client.renderer.texture.TextureMap;
 import net.minecraft.client.resources.I18n;
+import net.minecraft.client.resources.model.IBakedModel;
 import net.minecraft.client.resources.model.ModelBakery;
 import net.minecraft.client.resources.model.ModelManager;
 import net.minecraft.client.settings.GameSettings;
@@ -41,6 +42,7 @@ import net.minecraftforge.client.event.RenderHandEvent;
 import net.minecraftforge.client.event.RenderWorldLastEvent;
 import net.minecraftforge.client.event.TextureStitchEvent;
 import net.minecraftforge.client.event.sound.PlaySoundEvent;
+import net.minecraftforge.client.model.IDynamicItemModel;
 import net.minecraftforge.common.ForgeModContainer;
 import net.minecraftforge.common.ForgeVersion;
 import net.minecraftforge.common.ForgeVersion.Status;
@@ -224,6 +226,16 @@ public class ForgeHooksClient
             GL11.glPopMatrix();
         }
     }*/
+
+    public static boolean renderDynamicItem(ItemStack stack, IBakedModel model)
+    {
+        if (model instanceof IDynamicItemModel)
+        {
+            ((IDynamicItemModel)model).render(stack);
+            return true;
+        }
+        return false;
+    }
 
     //Optifine Helper Functions u.u, these are here specifically for Optifine
     //Note: When using Optfine, these methods are invoked using reflection, which

--- a/src/main/java/net/minecraftforge/client/model/IDynamicItemModel.java
+++ b/src/main/java/net/minecraftforge/client/model/IDynamicItemModel.java
@@ -1,0 +1,16 @@
+package net.minecraftforge.client.model;
+
+import net.minecraft.client.resources.model.IBakedModel;
+import net.minecraft.item.ItemStack;
+
+/**
+ * An extension of {@link IBakedModel} that allows defining of a custom item rendering method.
+ */
+public interface IDynamicItemModel extends IBakedModel
+{
+    /**
+     * Called by {@link RenderItem#renderItem} to render the passed in ItemStack
+     * @param stack The ItemStack to render
+     */
+    void render(ItemStack stack);
+}


### PR DESCRIPTION
This is my replacement for #1597, which was essentially all RainWarrior's idea; I just implemented it. :P It allows users to create an `IDynamicItemModel`, which is an `IBakedModel`. The special thing here is, when `RenderItem.renderItem()` is called, it first checks if the passed in `IBakedModel` instance is an instanceof `IDynamicBakedModel`, and if it is, delegates all rendering to the model instance. This allows for what I wanted to do in #1597, but just moves the hook farther up in the stack, and allows for more people to use it in many different cases.