### PR TITLE
Let modders add custom instruments

### DIFF
--- a/patches/minecraft/net/minecraft/block/BlockNote.java.patch
+++ b/patches/minecraft/net/minecraft/block/BlockNote.java.patch
@@ -10,15 +10,22 @@
                  tileentitynote.func_145878_a(p_149727_1_, p_149727_2_, p_149727_3_, p_149727_4_);
              }
  
-@@ -73,6 +75,11 @@
+@@ -73,6 +75,10 @@
  
      public boolean func_149696_a(World p_149696_1_, int p_149696_2_, int p_149696_3_, int p_149696_4_, int p_149696_5_, int p_149696_6_)
      {
 +        int meta = p_149696_1_.func_72805_g(p_149696_2_, p_149696_3_, p_149696_4_);
 +        net.minecraftforge.event.world.NoteBlockEvent.Play e = new net.minecraftforge.event.world.NoteBlockEvent.Play(p_149696_1_, p_149696_2_, p_149696_3_, p_149696_4_, meta, p_149696_6_, p_149696_5_);
 +        if (net.minecraftforge.common.MinecraftForge.EVENT_BUS.post(e)) return false;
-+        p_149696_5_ = e.instrument.ordinal();
 +        p_149696_6_ = e.getVanillaNoteId(); 
          float f = (float)Math.pow(2.0D, (double)(p_149696_6_ - 12) / 12.0D);
          String s = "harp";
  
+@@ -96,6 +102,7 @@
+             s = "bassattack";
+         }
+ 
++        s = e.instrument.name;
+         p_149696_1_.func_72908_a((double)p_149696_2_ + 0.5D, (double)p_149696_3_ + 0.5D, (double)p_149696_4_ + 0.5D, "note." + s, 3.0F, f);
+         p_149696_1_.func_72869_a("note", (double)p_149696_2_ + 0.5D, (double)p_149696_3_ + 1.2D, (double)p_149696_4_ + 0.5D, (double)p_149696_6_ / 24.0D, 0.0D, 0.0D);
+         return true;

--- a/src/main/java/net/minecraftforge/event/world/NoteBlockEvent.java
+++ b/src/main/java/net/minecraftforge/event/world/NoteBlockEvent.java
@@ -1,5 +1,7 @@
 package net.minecraftforge.event.world;
 
+import java.util.ArrayList;
+
 import com.google.common.base.Preconditions;
 
 import net.minecraft.block.Block;
@@ -100,20 +102,36 @@ public class NoteBlockEvent extends BlockEvent
      * Describes the types of musical Instruments that can be played by a Noteblock.
      * The Instrument being played can be overridden with {@link NoteBlockEvent.Play#setInstrument(Instrument)}
      */
-    public static enum Instrument
+    public static class Instrument
     {
-        PIANO,
-        BASSDRUM,
-        SNARE,
-        CLICKS,
-        BASSGUITAR;
+        public static final Instrument PIANO = new Instrument("harp", 0);
+        public static final Instrument BASSDRUM = new Instrument("bd", 1);
+        public static final Instrument SNARE = new Instrument("snare", 2);
+        public static final Instrument CLICKS = new Instrument("hat", 3);
+        public static final Instrument BASSGUITAR = new Instrument("bassattack", 4);
         
-        // cache to avoid creating a new array every time
-        private static final Instrument[] values = values();
+        // can't be final because of the above
+        private static ArrayList<Instrument> values;
         
+        private final int id; // TODO remove this?
+        public final String name;
+        
+        private Instrument(String name, int id)
+        {
+            if (values == null) values = new ArrayList();
+            values.add(id, this);
+            this.id = id;
+            this.name = name;
+        }
+        
+        public static Instrument registerInstrument(String name)
+        {
+            return new Instrument(name, values.size());
+        }
+
         static Instrument fromId(int id)
         {
-            return id < 0 || id > 4 ? PIANO : values[id];
+            return id < 0 || id >= values.size() ? PIANO : values.get(id);
         }
     }
     


### PR DESCRIPTION
This change lets modders add custom vanilla-noteblock-compatible instruments, so that a modder could add a "pling" instrument, hook noteblock events, check the block below the noteblock, and if it matches an arbitrary block/material, change the instrument to "pling".