### PR TITLE
Fix NoteBlockEvent broken-ness

### DIFF
--- a/patches/minecraft/net/minecraft/block/BlockNote.java.patch
+++ b/patches/minecraft/net/minecraft/block/BlockNote.java.patch
@@ -15,7 +15,7 @@
      public boolean func_149696_a(World p_149696_1_, int p_149696_2_, int p_149696_3_, int p_149696_4_, int p_149696_5_, int p_149696_6_)
      {
 +        int meta = p_149696_1_.func_72805_g(p_149696_2_, p_149696_3_, p_149696_4_);
-+        net.minecraftforge.event.world.NoteBlockEvent.Play e = new net.minecraftforge.event.world.NoteBlockEvent.Play(p_149696_1_, p_149696_2_, p_149696_3_, p_149696_4_, meta, p_149696_6_, p_149696_5_);
++        net.minecraftforge.event.world.NoteBlockEvent.Play e = new net.minecraftforge.event.world.NoteBlockEvent.Play(p_149696_1_, this, p_149696_2_, p_149696_3_, p_149696_4_, meta, p_149696_6_, p_149696_5_);
 +        if (net.minecraftforge.common.MinecraftForge.EVENT_BUS.post(e)) return false;
 +        p_149696_5_ = e.instrument.ordinal();
 +        p_149696_6_ = e.getVanillaNoteId(); 

--- a/src/main/java/net/minecraftforge/common/ForgeHooks.java
+++ b/src/main/java/net/minecraftforge/common/ForgeHooks.java
@@ -10,6 +10,7 @@ import java.util.regex.Pattern;
 import cpw.mods.fml.common.eventhandler.Event;
 import cpw.mods.fml.relauncher.ReflectionHelper;
 import net.minecraft.block.Block;
+import net.minecraft.block.BlockNote;
 import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.entity.item.EntityItem;
 import net.minecraft.entity.player.EntityPlayer;
@@ -601,7 +602,7 @@ public class ForgeHooks
 
     public static boolean onNoteChange(TileEntityNote te, byte old)
     {
-        NoteBlockEvent.Change e = new NoteBlockEvent.Change(te.getWorldObj(), te.xCoord, te.yCoord, te.zCoord, te.getBlockMetadata(), old, te.note);
+        NoteBlockEvent.Change e = new NoteBlockEvent.Change(te.getWorldObj(), (BlockNote) te.getBlockType(), te.xCoord, te.yCoord, te.zCoord, te.getBlockMetadata(), old, te.note);
         if (MinecraftForge.EVENT_BUS.post(e))
         {
             te.note = old;

--- a/src/main/java/net/minecraftforge/event/world/NoteBlockEvent.java
+++ b/src/main/java/net/minecraftforge/event/world/NoteBlockEvent.java
@@ -3,6 +3,7 @@ package net.minecraftforge.event.world;
 import com.google.common.base.Preconditions;
 
 import net.minecraft.block.Block;
+import net.minecraft.block.BlockNote;
 import net.minecraft.init.Blocks;
 import net.minecraft.world.World;
 import net.minecraftforge.event.world.BlockEvent;
@@ -17,9 +18,9 @@ public class NoteBlockEvent extends BlockEvent
 {
     private int noteId;
 
-    NoteBlockEvent(World world, int x, int y, int z, int meta, int note)
+    NoteBlockEvent(World world, BlockNote block, int x, int y, int z, int meta, int note)
     {
-        super(x, y, z, world, Blocks.noteblock, meta);
+        super(x, y, z, world, block, meta);
         this.noteId = note;
     }
     
@@ -71,9 +72,9 @@ public class NoteBlockEvent extends BlockEvent
     {
         public Instrument instrument;
 
-        public Play(World world, int x, int y, int z, int meta, int note, int instrument)
+        public Play(World world, BlockNote block, int x, int y, int z, int meta, int note, int instrument)
         {
-            super(world, x, y, z, meta, note);
+            super(world, block, x, y, z, meta, note);
             this.instrument = Instrument.fromId(instrument);
         }
     }
@@ -88,9 +89,9 @@ public class NoteBlockEvent extends BlockEvent
         public final Note oldNote;
         public final Octave oldOctave;
         
-        public Change(World world, int x, int y, int z, int meta, int oldNote, int newNote)
+        public Change(World world, BlockNote block, int x, int y, int z, int meta, int oldNote, int newNote)
         {
-            super(world, x, y, z, meta, newNote);
+            super(world, block, x, y, z, meta, newNote);
             this.oldNote = Note.fromId(oldNote);
             this.oldOctave = Octave.fromId(oldNote);
         }        


### PR DESCRIPTION
Should take a BlockNote instead of always throwing a Blocks.noteblock