### PR TITLE
Add nether fortress to ChestGenHooks

### DIFF
--- a/patches/minecraft/net/minecraft/world/gen/structure/StructureNetherBridgePieces.java.patch
+++ b/patches/minecraft/net/minecraft/world/gen/structure/StructureNetherBridgePieces.java.patch
@@ -1,0 +1,20 @@
+--- ../src-base/minecraft/net/minecraft/world/gen/structure/StructureNetherBridgePieces.java
++++ ../src-work/minecraft/net/minecraft/world/gen/structure/StructureNetherBridgePieces.java
+@@ -158,7 +158,7 @@
+                     if (p_74875_3_.func_78890_b(j, i, k))
+                     {
+                         this.field_111021_b = false;
+-                        this.func_74879_a(p_74875_1_, p_74875_3_, p_74875_2_, 3, 2, 3, field_111019_a, 2 + p_74875_2_.nextInt(4));
++                        this.func_74879_a(p_74875_1_, p_74875_3_, p_74875_2_, 3, 2, 3, net.minecraftforge.common.ChestGenHooks.getItems(net.minecraftforge.common.ChestGenHooks.NETHER_FORTRESS, p_74875_2_), net.minecraftforge.common.ChestGenHooks.getCount(net.minecraftforge.common.ChestGenHooks.NETHER_FORTRESS, p_74875_2_));
+                     }
+                 }
+ 
+@@ -237,7 +237,7 @@
+                     if (p_74875_3_.func_78890_b(j, i, k))
+                     {
+                         this.field_111020_b = false;
+-                        this.func_74879_a(p_74875_1_, p_74875_3_, p_74875_2_, 1, 2, 3, field_111019_a, 2 + p_74875_2_.nextInt(4));
++                        this.func_74879_a(p_74875_1_, p_74875_3_, p_74875_2_, 1, 2, 3, net.minecraftforge.common.ChestGenHooks.getItems(net.minecraftforge.common.ChestGenHooks.NETHER_FORTRESS, p_74875_2_), net.minecraftforge.common.ChestGenHooks.getCount(net.minecraftforge.common.ChestGenHooks.NETHER_FORTRESS, p_74875_2_));
+                     }
+                 }
+ 

--- a/src/main/java/net/minecraftforge/common/ChestGenHooks.java
+++ b/src/main/java/net/minecraftforge/common/ChestGenHooks.java
@@ -28,6 +28,7 @@ public class ChestGenHooks
     public static final String STRONGHOLD_CORRIDOR      = "strongholdCorridor";
     public static final String STRONGHOLD_LIBRARY       = "strongholdLibrary";
     public static final String STRONGHOLD_CROSSING      = "strongholdCrossing";
+    public static final String NETHER_FORTRESS          = "netherFortress";
     public static final String VILLAGE_BLACKSMITH       = "villageBlacksmith";
     public static final String BONUS_CHEST              = "bonusChest";
     public static final String DUNGEON_CHEST            = "dungeonChest";
@@ -55,6 +56,7 @@ public class ChestGenHooks
         addInfo(STRONGHOLD_CORRIDOR,      ChestCorridor.strongholdChestContents,             2,  4);
         addInfo(STRONGHOLD_LIBRARY,       Library.strongholdLibraryChestContents,            1,  5);
         addInfo(STRONGHOLD_CROSSING,      RoomCrossing.strongholdRoomCrossingChestContents,  1,  5);
+        addInfo(NETHER_FORTRESS,          StructureNetherBridgePieces.Piece.field_111019_a,  2,  5);
         addInfo(VILLAGE_BLACKSMITH,       House2.villageBlacksmithChestContents,             3,  9);
         addInfo(BONUS_CHEST,              WorldServer.bonusChestContent,                    10, 10);
         addInfo(DUNGEON_CHEST,            WorldGenDungeons.field_111189_a,                   8,  8);

--- a/src/main/resources/forge_at.cfg
+++ b/src/main/resources/forge_at.cfg
@@ -72,6 +72,8 @@ public net.minecraft.world.gen.structure.StructureStrongholdPieces$ChestCorridor
 public net.minecraft.world.gen.structure.StructureStrongholdPieces$Library field_75007_b
 public net.minecraft.world.gen.structure.StructureStrongholdPieces$RoomCrossing field_75014_c
 public net.minecraft.world.gen.structure.StructureVillagePieces$House2 field_74918_a
+public net.minecraft.world.gen.structure.StructureNetherBridgePieces$Piece
+public net.minecraft.world.gen.structure.StructureNetherBridgePieces$Piece field_111019_a
 public net.minecraft.world.gen.feature.WorldGenDungeons field_111189_a
 # Save Location
 public net.minecraft.world.chunk.storage.AnvilChunkLoader field_75825_d # chunkSaveLocation


### PR DESCRIPTION
Simply adds the missing Nether Fortress chest to ChestGenHooks