### PR TITLE
Allow an item to have some say in what enchants can be applied to it

### DIFF
--- a/patches/minecraft/net/minecraft/enchantment/Enchantment.java.patch
+++ b/patches/minecraft/net/minecraft/enchantment/Enchantment.java.patch
@@ -9,7 +9,15 @@
          }
          else
          {
-@@ -124,6 +124,45 @@
+@@ -117,13 +117,52 @@
+ 
+     public boolean func_92089_a(ItemStack p_92089_1_)
+     {
+-        return this.field_77351_y.func_77557_a(p_92089_1_.func_77973_b());
++        return p_92089_1_.func_77973_b() instanceof net.minecraftforge.common.IEnchantable ? ((net.minecraftforge.common.IEnchantable)p_92089_1_.func_77973_b()).canApply(p_92089_1_, this) : this.field_77351_y.func_77557_a(p_92089_1_.func_77973_b());
+     }
+ 
+     public void func_151368_a(EntityLivingBase p_151368_1_, Entity p_151368_2_, int p_151368_3_) {}
  
      public void func_151367_b(EntityLivingBase p_151367_1_, Entity p_151367_2_, int p_151367_3_) {}
  

--- a/src/main/java/net/minecraftforge/common/IEnchantable.java
+++ b/src/main/java/net/minecraftforge/common/IEnchantable.java
@@ -1,0 +1,24 @@
+package net.minecraftforge.common;
+
+import net.minecraft.enchantment.Enchantment;
+import net.minecraft.item.ItemStack;
+
+/**
+*
+* This allows for mods to create items that can accept 
+* enchants they would not otherwise be able too
+* e.g. a tool descended from ItemTool that can have
+* Sharpness and Smite
+*
+*/
+public interface IEnchantable 
+{
+    /**
+     * Checks if the object can accept the enchant
+     *
+     * @param stack The ItemStack that is being used, Possible to be null
+     * @param enchant the enchant in question
+     * @return If this enchant can go on this item, true
+     */
+    public boolean canApply( ItemStack stack, Enchantment enchant);
+}


### PR DESCRIPTION
Allows an easy way for an item to accept an enchant that it would be otherwise difficult to do. 

This redirects the logic of Enchant::canApply(...) for items that implement IEnchantable, calling a method controlled by the Item to see if the enchant can be applied (IEnchantable::canApply(ItemStack, Enchantment).

I created a short [example](https://github.com/thor12022/SillyThings/tree/master/src/main/java/thor12022/sillythings) that uses an Item inheriting ItemAxe that can also accept enchants intended for ItemSword.

Where it falls short:
It does not allow for an equally common and easy way for an item to deny the application of an Enchant. What I mean is, due to the nature of overridden methods, child classes of Enchant can decided enchant applicability first. Like: EnchantmentDurability explicitly checks for items being damageable and returns true before IEnchantable::canApply(...) can get called. Meaning you can't disallow the application of the Unbreaking enchant using this method.
