### PR TITLE
Fix versionCheck config option

### DIFF
--- a/src/main/java/net/minecraftforge/common/ForgeModContainer.java
+++ b/src/main/java/net/minecraftforge/common/ForgeModContainer.java
@@ -280,6 +280,11 @@ public class ForgeModContainer extends DummyModContainer implements WorldAccessC
         MinecraftForge.EVENT_BUS.register(MinecraftForge.INTERNAL_HANDLER);
         ForgeChunkManager.captureConfig(evt.getModConfigurationDirectory());
         FMLCommonHandler.instance().bus().register(this);
+        
+        if (!ForgeModContainer.disableVersionCheck)
+        {
+            ForgeVersion.startVersionCheck();
+        }
     }
 
     @Subscribe

--- a/src/main/java/net/minecraftforge/common/MinecraftForge.java
+++ b/src/main/java/net/minecraftforge/common/MinecraftForge.java
@@ -46,11 +46,6 @@ public class MinecraftForge
 
        OreDictionary.getOreName(0);
 
-       if (!ForgeModContainer.disableVersionCheck)
-       {
-           ForgeVersion.startVersionCheck();
-       }
-
        //Force these classes to be defined, Should prevent derp error hiding.
        new CrashReport("ThisIsFake", new Exception("Not real"));
        


### PR DESCRIPTION
The same as the 1.8 fix, except for the 1.7.10 branch.

Fixes the versionCheck config option not working.