### PR TITLE
Remove ID parameter descriptor from OreDict registerOreImpl JavaDoc

### DIFF
--- a/src/main/java/net/minecraftforge/oredict/OreDictionary.java
+++ b/src/main/java/net/minecraftforge/oredict/OreDictionary.java
@@ -423,7 +423,6 @@ public class OreDictionary
      * Raises the registerOre function in all registered handlers.
      *
      * @param name The name of the ore
-     * @param id The ID of the ore
      * @param ore The ore's ItemStack
      */
     private static void registerOreImpl(String name, ItemStack ore)


### PR DESCRIPTION
Removed a redundant, misleading line in the JavaDoc of OreDictionary.registerOreImpl