### PR TITLE
added EnchantmentEvent

### DIFF
--- a/patches/minecraft/net/minecraft/inventory/ContainerEnchantment.java.patch
+++ b/patches/minecraft/net/minecraft/inventory/ContainerEnchantment.java.patch
@@ -69,3 +69,12 @@
                      }
  
                      this.func_75142_b();
+@@ -187,7 +167,7 @@
+             {
+                 List list = EnchantmentHelper.func_77513_b(this.field_75169_l, itemstack, this.field_75167_g[p_75140_2_]);
+                 boolean flag = itemstack.func_77973_b() == Items.field_151122_aG;
+-
++                list = ForgeHooks.onEnchantment(p_75140_1_, this.field_75167_g[p_75140_2_], itemstack, list);
+                 if (list != null)
+                 {
+                     p_75140_1_.func_82242_a(-this.field_75167_g[p_75140_2_]);

--- a/src/main/java/net/minecraftforge/common/ForgeHooks.java
+++ b/src/main/java/net/minecraftforge/common/ForgeHooks.java
@@ -10,6 +10,7 @@ import java.util.regex.Pattern;
 import cpw.mods.fml.common.eventhandler.Event;
 import cpw.mods.fml.relauncher.ReflectionHelper;
 import net.minecraft.block.Block;
+import net.minecraft.enchantment.EnchantmentData;
 import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.entity.item.EntityItem;
 import net.minecraft.entity.player.EntityPlayer;
@@ -18,6 +19,7 @@ import net.minecraft.event.ClickEvent;
 import net.minecraft.init.Blocks;
 import net.minecraft.init.Items;
 import net.minecraft.inventory.Container;
+import net.minecraft.inventory.ContainerEnchantment;
 import net.minecraft.inventory.ContainerRepair;
 import net.minecraft.inventory.IInventory;
 import net.minecraft.item.Item;
@@ -58,6 +60,7 @@ import net.minecraftforge.event.entity.living.LivingEvent.LivingUpdateEvent;
 import net.minecraftforge.event.entity.living.LivingFallEvent;
 import net.minecraftforge.event.entity.living.LivingHurtEvent;
 import net.minecraftforge.event.entity.living.LivingSetAttackTargetEvent;
+import net.minecraftforge.event.entity.player.EnchantmentEvent;
 import net.minecraftforge.event.entity.player.PlayerOpenContainerEvent;
 import net.minecraftforge.event.entity.player.AnvilRepairEvent;
 import net.minecraftforge.event.world.BlockEvent;
@@ -609,5 +612,13 @@ public class ForgeHooks
         }
         te.note = (byte)e.getVanillaNoteId();
         return true;
+    }
+    
+    public static List onEnchantment(EntityPlayer player, int levels, ItemStack itemstack, List<EnchantmentData> enchantments)
+    {
+        if (enchantments == null) return null;
+        EnchantmentEvent e = new EnchantmentEvent(player, levels, itemstack, enchantments);
+        MinecraftForge.EVENT_BUS.post(e);
+        return e.enchantments;
     }
 }

--- a/src/main/java/net/minecraftforge/event/entity/player/EnchantmentEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/player/EnchantmentEvent.java
@@ -1,0 +1,22 @@
+package net.minecraftforge.event.entity.player;
+
+import java.util.List;
+
+import net.minecraft.enchantment.EnchantmentData;
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.item.ItemStack;
+
+public class EnchantmentEvent extends PlayerEvent
+{
+    public final List<EnchantmentData> enchantments;
+    public ItemStack item;
+    public final int levels;
+	
+    public EnchantmentEvent(EntityPlayer player, int levels, ItemStack item, List<EnchantmentData> enchantments)
+    {
+        super(player);
+        this.levels = levels;
+        this.item = item;
+        this.enchantments = enchantments;
+    }
+}


### PR DESCRIPTION
Potential Uses:
- Awarding achievements based on obtaining enchantments (example: https://github.com/Qmunity/BluePower/pull/247)
- Adding enchantments based on non-standard criteria, eg: allowing an enchantment to be applied only if the player has gained a certain achievement or is in a specific location
- Adding enchantments that can only be applied to a specific type of item eg. Only Iron Armour can have the "Magnetism" enchantment - or something like that (https://github.com/MinecraftForge/MinecraftForge/issues/1222)

Details of EnchantmentEvent:
 - the EntityPlayer doing the enchantment, allowing for Player/location specific manipulations
 - the number of levels being consumed, to base manipulation on enchanting level
 - the item being enchanted, to allow manipulation only for a specific item/group of items, or based off existing NBT
 - the EnchantmentData (Enchantment, level) list of enchantments about to be applied, which can be modified by adding or removing from the list, or used to trigger achievements