### PR TITLE
Bulk Chunk Data packets should also check TileEntity.shouldRefresh().

### DIFF
--- a/patches/minecraft/net/minecraft/world/chunk/Chunk.java.patch
+++ b/patches/minecraft/net/minecraft/world/chunk/Chunk.java.patch
@@ -258,7 +258,7 @@
 +            int y = tileentity.field_145848_d;
 +            int z = tileentity.field_145849_e & 15;
 +            Block block = tileentity.func_145838_q();
-+            if (block != func_150810_a(x, y, z) || tileentity.field_145847_g != this.func_76628_c(x, y, z))
++            if (tileentity.shouldRefresh(block, func_150810_a(x, y, z), tileentity.field_145847_g, this.func_76628_c(x, y, z), field_76637_e, x, y, z))
 +            {
 +                invalidList.add(tileentity);
 +            }


### PR DESCRIPTION
Forge adds the TileEntity.shouldRefresh() function to allow more control over when Tile Entities should be recreated when the block or metadata changes. 

The original vanilla fillChunk functionality appears to not care about "validating" that the block didn't change. I imagine that this may even have adverse effects on some vanilla tile entities, as they return false to shouldRefresh() by default.

This issue was discovered while tracing an issue with Forestry's Leaf TileEntities being randomly wiped client side when the decay metadata was updated. Single block update packets work properly, but the bulk data packets would delete the tile entities.

https://github.com/ForestryMC/ForestryMC/issues/431