### PR TITLE
Add a ModelPreRegister event

### DIFF
--- a/patches/minecraft/net/minecraft/client/resources/model/ModelBakery.java.patch
+++ b/patches/minecraft/net/minecraft/client/resources/model/ModelBakery.java.patch
@@ -1,0 +1,20 @@
+--- ../src-base/minecraft/net/minecraft/client/resources/model/ModelBakery.java
++++ ../src-work/minecraft/net/minecraft/client/resources/model/ModelBakery.java
+@@ -800,7 +800,17 @@
+     {
+         return this.field_177608_m.func_178392_a(this.field_177609_j, p_177582_1_);
+     }
++    
++    /* ======================================== FORGE START =====================================*/
++    public void registerModelDefinition(ResourceLocation location, ModelBlockDefinition definition){
++        this.field_177614_t.put(location, definition);
++    }
+ 
++    public void registerModelBlock(ResourceLocation location, ModelBlock modelBlock) {
++        this.field_177611_h.put(location, modelBlock);
++    }
++    /* ========================================= FORGE END ======================================*/
++
+     static
+     {
+         field_177600_d.put("missing", "{ \"textures\": {   \"particle\": \"missingno\",   \"missingno\": \"missingno\"}, \"elements\": [ {     \"from\": [ 0, 0, 0 ],     \"to\": [ 16, 16, 16 ],     \"faces\": {         \"down\":  { \"uv\": [ 0, 0, 16, 16 ], \"cullface\": \"down\", \"texture\": \"#missingno\" },         \"up\":    { \"uv\": [ 0, 0, 16, 16 ], \"cullface\": \"up\", \"texture\": \"#missingno\" },         \"north\": { \"uv\": [ 0, 0, 16, 16 ], \"cullface\": \"north\", \"texture\": \"#missingno\" },         \"south\": { \"uv\": [ 0, 0, 16, 16 ], \"cullface\": \"south\", \"texture\": \"#missingno\" },         \"west\":  { \"uv\": [ 0, 0, 16, 16 ], \"cullface\": \"west\", \"texture\": \"#missingno\" },         \"east\":  { \"uv\": [ 0, 0, 16, 16 ], \"cullface\": \"east\", \"texture\": \"#missingno\" }    }}]}");

--- a/patches/minecraft/net/minecraft/client/resources/model/ModelManager.java.patch
+++ b/patches/minecraft/net/minecraft/client/resources/model/ModelManager.java.patch
@@ -1,7 +1,10 @@
 --- ../src-base/minecraft/net/minecraft/client/resources/model/ModelManager.java
 +++ ../src-work/minecraft/net/minecraft/client/resources/model/ModelManager.java
-@@ -28,6 +28,7 @@
+@@ -26,8 +26,10 @@
+     public void func_110549_a(IResourceManager p_110549_1_)
+     {
          ModelBakery modelbakery = new ModelBakery(p_110549_1_, this.field_174956_b, this.field_174957_c);
++        net.minecraftforge.client.ForgeHooksClient.onModelRegister(this, modelbakery, this.field_174956_b, this.field_174957_c);
          this.field_174958_a = modelbakery.func_177570_a();
          this.field_174955_d = (IBakedModel)this.field_174958_a.func_82594_a(ModelBakery.field_177604_a);
 +        net.minecraftforge.client.ForgeHooksClient.onModelBake(this, this.field_174958_a, modelbakery);

--- a/src/main/java/net/minecraftforge/client/ForgeHooksClient.java
+++ b/src/main/java/net/minecraftforge/client/ForgeHooksClient.java
@@ -12,6 +12,7 @@ import net.minecraft.client.gui.FontRenderer;
 import net.minecraft.client.gui.GuiMainMenu;
 import net.minecraft.client.gui.GuiScreen;
 import net.minecraft.client.model.ModelBase;
+import net.minecraft.client.renderer.BlockModelShapes;
 import net.minecraft.client.renderer.EntityRenderer;
 import net.minecraft.client.renderer.RenderGlobal;
 import net.minecraft.client.renderer.texture.TextureManager;
@@ -36,6 +37,7 @@ import net.minecraftforge.client.event.EntityViewRenderEvent;
 import net.minecraftforge.client.event.FOVUpdateEvent;
 import net.minecraftforge.client.event.GuiScreenEvent;
 import net.minecraftforge.client.event.ModelBakeEvent;
+import net.minecraftforge.client.event.ModelPreRegisterEvent;
 import net.minecraftforge.client.event.MouseEvent;
 import net.minecraftforge.client.event.RenderHandEvent;
 import net.minecraftforge.client.event.RenderWorldLastEvent;
@@ -460,5 +462,10 @@ public class ForgeHooksClient
     public static void onModelBake(ModelManager modelManager, IRegistry modelRegistry, ModelBakery modelBakery)
     {
         MinecraftForge.EVENT_BUS.post(new ModelBakeEvent(modelManager, modelRegistry, modelBakery));
+    }
+    
+    public static void onModelRegister(ModelManager modelManager, ModelBakery modelbakery, TextureMap blockTextureMap, BlockModelShapes blockModelShapes)
+    {
+        MinecraftForge.EVENT_BUS.post(new ModelPreRegisterEvent(modelManager, modelbakery, blockTextureMap, blockModelShapes));
     }
 }

--- a/src/main/java/net/minecraftforge/client/event/ModelPreRegisterEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/ModelPreRegisterEvent.java
@@ -1,0 +1,40 @@
+package net.minecraftforge.client.event;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Map;
+
+import net.minecraft.block.Block;
+import net.minecraft.block.state.IBlockState;
+import net.minecraft.client.renderer.BlockModelShapes;
+import net.minecraft.client.renderer.block.model.ModelBlockDefinition;
+import net.minecraft.client.renderer.block.statemap.DefaultStateMapper;
+import net.minecraft.client.renderer.block.statemap.IStateMapper;
+import net.minecraft.client.renderer.texture.TextureMap;
+import net.minecraft.client.resources.model.ModelBakery;
+import net.minecraft.client.resources.model.ModelManager;
+import net.minecraft.client.resources.model.ModelResourceLocation;
+import net.minecraft.item.Item;
+import net.minecraft.util.ResourceLocation;
+import net.minecraftforge.fml.common.eventhandler.Event;
+
+/**
+ * Fired when the ModelManager is notified of the resource manager reloading.
+ * Called before model registry is setup.
+ */
+public class ModelPreRegisterEvent extends Event
+{
+    public final ModelManager modelManager;
+    public final ModelBakery modelBakery;
+    public final TextureMap blockTextureMap;
+    public final BlockModelShapes blockModelShapes;
+
+    public ModelPreRegisterEvent(ModelManager modelManager, ModelBakery modelBakery, TextureMap blockTextureMap, BlockModelShapes blockModelShapes)
+    {
+        this.modelManager = modelManager;
+        this.modelBakery = modelBakery;
+        this.blockTextureMap = blockTextureMap;
+        this.blockModelShapes = blockModelShapes;
+    }
+}


### PR DESCRIPTION
This is primarily intended to allow blocks to register custom IStateMappers (like how vanilla does in BlockModelShapes.registerAllBlocks()), I've also added public methods for manually adding block models and their definitions to the Bakery.