### PR TITLE
Default implementation of TileEntity.shouldRefresh() is too broad.

### DIFF
--- a/patches/minecraft/net/minecraft/tileentity/TileEntity.java.patch
+++ b/patches/minecraft/net/minecraft/tileentity/TileEntity.java.patch
@@ -11,7 +11,7 @@
  import net.minecraft.world.World;
  
  import org.apache.logging.log4j.Level;
-@@ -278,4 +281,93 @@
+@@ -278,4 +281,100 @@
          func_145826_a(TileEntityComparator.class, "Comparator");
          func_145826_a(TileEntityFlowerPot.class, "FlowerPot");
      }
@@ -63,7 +63,14 @@
 +     */
 +    public boolean shouldRefresh(Block oldBlock, Block newBlock, int oldMeta, int newMeta, World world, int x, int y, int z)
 +    {
-+        return !isVanilla || (oldBlock != newBlock);
++        if (isVanilla)
++        {
++            return oldBlock != newBlock;
++        } 
++        else
++        {
++            return oldBlock != newBlock || oldMeta != newMeta;
++        }
 +    }
 +
 +    public boolean shouldRenderInPass(int pass)


### PR DESCRIPTION
The default assumption of shouldRefresh() seems to be that if its being called, either the block or metadata changed. With the recent change to fillChunk() to call shouldRefresh(), that assumption is no longer true. The default implementation of shouldRefresh() needs to be changed accordingly.

Without this change, fillChunk() is wiping every mod Tile Entity it encounters that doesn't override shouldRefresh() explicitly.

I apologize for not catching this with the previous PR.