### PR TITLE
Make layer-related fields and methods public.

### DIFF
--- a/src/main/resources/forge_at.cfg
+++ b/src/main/resources/forge_at.cfg
@@ -123,3 +123,8 @@ public net.minecraft.item.crafting.RecipesBanners$RecipeDuplicatePattern
 public net.minecraft.block.state.BlockState$StateImplementation
 protected net.minecraft.block.state.BlockState$StateImplementation <init>(Lnet/minecraft/block/Block;Lcom/google/common/collect/ImmutableMap;)V
 protected net.minecraft.block.state.BlockState$StateImplementation field_177238_c # propertyValueTable
+# RendererLivingEntity
+public net.minecraft.client.renderer.entity.RendererLivingEntity func_177094_a(Lnet/minecraft/client/renderer/entity/layers/LayerRenderer;)Z #addLayer
+public net.minecraft.client.renderer.entity.RendererLivingEntity func_177089_b(Lnet/minecraft/client/renderer/entity/layers/LayerRenderer;)Z #removeLayer
+public net.minecraft.client.renderer.entity.RendererLivingEntity field_177097_h #layerRenderers
+


### PR DESCRIPTION
Layers are essentially the new RenderPlayerEvent.Specials and since it wasn't reimplemented (for players), this would be a nice alternative.