### PR TITLE
Fix fluid tanks incorrectly reading NBT when empty

### DIFF
--- a/src/main/java/net/minecraftforge/fluids/FluidTank.java
+++ b/src/main/java/net/minecraftforge/fluids/FluidTank.java
@@ -37,11 +37,11 @@ public class FluidTank implements IFluidTank
         if (!nbt.hasKey("Empty"))
         {
             FluidStack fluid = FluidStack.loadFluidStackFromNBT(nbt);
-
-            if (fluid != null)
-            {
-                setFluid(fluid);
-            }
+            setFluid(fluid);
+        }
+        else
+        {
+            setFluid(null);
         }
         return this;
     }


### PR DESCRIPTION
If the Empty flag was set, the tank would not correctly read the data, keeping the outdated FluidStack instead. This is especially relevant with updatable TileFluidHandler TEs.