### PR TITLE
Changes to GuiIngameForge to respect static flags

### DIFF
--- a/src/main/java/net/minecraftforge/client/GuiIngameForge.java
+++ b/src/main/java/net/minecraftforge/client/GuiIngameForge.java
@@ -92,9 +92,9 @@ public class GuiIngameForge extends GuiIngame
         eventParent = new RenderGameOverlayEvent(partialTicks, res, mouseX, mouseY);
         int width = res.getScaledWidth();
         int height = res.getScaledHeight();
-        renderHealthMount = mc.thePlayer.ridingEntity instanceof EntityLivingBase;
-        renderFood = mc.thePlayer.ridingEntity == null;
-        renderJumpBar = mc.thePlayer.isRidingHorse();
+        boolean doRenderHealthMount = renderHealthMount && mc.thePlayer.ridingEntity instanceof EntityLivingBase;
+        boolean doRenderFood = renderFood && mc.thePlayer.ridingEntity == null;
+        boolean doRenderJumpBar = renderJumpBar && mc.thePlayer.isRidingHorse();
 
         right_height = 39;
         left_height = 39;
@@ -134,14 +134,14 @@ public class GuiIngameForge extends GuiIngame
             {
                 if (renderHealth) renderHealth(width, height);
                 if (renderArmor)  renderArmor(width, height);
-                if (renderFood)   renderFood(width, height);
-                if (renderHealthMount) renderHealthMount(width, height);
+                if (doRenderFood)   renderFood(width, height);
+                if (doRenderHealthMount) renderHealthMount(width, height);
                 if (renderAir)    renderAir(width, height);
             }
             if (renderHotbar) renderHotbar(width, height, partialTicks);
         }
 
-        if (renderJumpBar)
+        if (doRenderJumpBar)
         {
             renderJumpBar(width, height);
         }


### PR DESCRIPTION
The renderGameOverlay was overriding these render flags each tick. These changes use a local variable to determine whether to render mount health, food or the jump bar and respect the static flag when computing the local value.

This change would also fix issue #1537.