### PR TITLE
Deprecated stackTagCompound for easier 1.8 update for modders

### DIFF
--- a/patches/minecraft/net/minecraft/item/ItemStack.java.patch
+++ b/patches/minecraft/net/minecraft/item/ItemStack.java.patch
@@ -8,7 +8,15 @@
  
  public final class ItemStack
  {
-@@ -124,6 +125,7 @@
+@@ -40,6 +41,7 @@
+     public int field_77994_a;
+     public int field_77992_b;
+     private Item field_151002_e;
++    @Deprecated //Forge: Direct access removed in 1.8. Use getter and setter instead.
+     public NBTTagCompound field_77990_d;
+     int field_77991_e;
+     private EntityItemFrame field_82843_f;
+@@ -124,6 +126,7 @@
  
      public boolean func_77943_a(EntityPlayer p_77943_1_, World p_77943_2_, int p_77943_3_, int p_77943_4_, int p_77943_5_, int p_77943_6_, float p_77943_7_, float p_77943_8_, float p_77943_9_)
      {
@@ -16,7 +24,7 @@
          boolean flag = this.func_77973_b().func_77648_a(this, p_77943_1_, p_77943_2_, p_77943_3_, p_77943_4_, p_77943_5_, p_77943_6_, p_77943_7_, p_77943_8_, p_77943_9_);
  
          if (flag)
-@@ -182,7 +184,7 @@
+@@ -182,7 +185,7 @@
  
      public int func_77976_d()
      {
@@ -25,7 +33,7 @@
      }
  
      public boolean func_77985_e()
-@@ -192,7 +194,7 @@
+@@ -192,7 +195,7 @@
  
      public boolean func_77984_f()
      {
@@ -34,7 +42,7 @@
      }
  
      public boolean func_77981_g()
-@@ -202,32 +204,27 @@
+@@ -202,32 +205,27 @@
  
      public boolean func_77951_h()
      {
@@ -72,7 +80,7 @@
      }
  
      public boolean func_96631_a(int p_96631_1_, Random p_96631_2_)
-@@ -259,8 +256,8 @@
+@@ -259,8 +257,8 @@
                  }
              }
  
@@ -83,7 +91,7 @@
          }
      }
  
-@@ -319,7 +316,7 @@
+@@ -319,7 +317,7 @@
  
      public boolean func_150998_b(Block p_150998_1_)
      {
@@ -92,7 +100,7 @@
      }
  
      public boolean func_111282_a(EntityPlayer p_111282_1_, EntityLivingBase p_111282_2_)
-@@ -626,16 +623,24 @@
+@@ -626,16 +624,24 @@
          {
              arraylist.add("Durability: " + (this.func_77958_k() - this.func_77952_i()) + " / " + this.func_77958_k());
          }
@@ -118,7 +126,7 @@
      public EnumRarity func_77953_t()
      {
          return this.func_77973_b().func_77613_e(this);
-@@ -737,7 +742,7 @@
+@@ -737,7 +743,7 @@
          }
          else
          {


### PR DESCRIPTION
Much like when the Vec3 pools and AABB pools were removed in 1.7.10, and the getters for those two were deprecated in 1.7.2 to alert modders of this change, I've deprecated the stackTagCompound field because it's changed to private in 1.8. This will alert modders to switch to the getter and setter for the stackTagCompound.