### PR TITLE
Fix creative inventory having blank pages at times

### DIFF
--- a/patches/minecraft/net/minecraft/client/gui/inventory/GuiContainerCreative.java.patch
+++ b/patches/minecraft/net/minecraft/client/gui/inventory/GuiContainerCreative.java.patch
@@ -18,7 +18,7 @@
                      {
                          if (p_146984_3_ == 0)
                          {
-@@ -260,6 +262,13 @@
+@@ -260,6 +262,14 @@
              this.func_147050_b(CreativeTabs.field_78032_a[i]);
              this.field_147059_E = new CreativeCrafting(this.field_146297_k);
              this.field_146297_k.field_71439_g.field_71069_bz.func_75132_a(this.field_147059_E);
@@ -27,12 +27,13 @@
 +            {
 +                field_146292_n.add(new GuiButton(101, field_147003_i,                       field_147009_r - 50, 20, 20, "<"));
 +                field_146292_n.add(new GuiButton(102, field_147003_i + field_146999_f - 20, field_147009_r - 50, 20, 20, ">"));
-+                maxPages = ((tabCount - 12) / 10) + 1;
++                final int rawMaxPages = (tabCount - 12) / 10;
++                maxPages = rawMaxPages % 10 > 0 ? rawMaxPages + 1 : rawMaxPages;
 +            }
          }
          else
          {
-@@ -281,7 +290,7 @@
+@@ -281,7 +291,7 @@
  
      protected void func_73869_a(char p_73869_1_, int p_73869_2_)
      {
@@ -41,7 +42,7 @@
          {
              if (GameSettings.func_100015_a(this.field_146297_k.field_71474_y.field_74310_D))
              {
-@@ -318,6 +327,15 @@
+@@ -318,6 +328,15 @@
      {
          GuiContainerCreative.ContainerCreative containercreative = (GuiContainerCreative.ContainerCreative)this.field_147002_h;
          containercreative.field_148330_a.clear();
@@ -57,7 +58,7 @@
          Iterator iterator = Item.field_150901_e.iterator();
  
          while (iterator.hasNext())
-@@ -329,10 +347,17 @@
+@@ -329,10 +348,17 @@
                  item.func_150895_a(item, (CreativeTabs)null, containercreative.field_148330_a);
              }
          }
@@ -75,7 +76,7 @@
          for (int i = 0; i < j; ++i)
          {
              Enchantment enchantment = aenchantment[i];
-@@ -383,7 +408,7 @@
+@@ -383,7 +409,7 @@
      {
          CreativeTabs creativetabs = CreativeTabs.field_78032_a[field_147058_w];
  
@@ -84,7 +85,7 @@
          {
              GL11.glDisable(GL11.GL_BLEND);
              this.field_146289_q.func_78276_b(I18n.func_135052_a(creativetabs.func_78024_c(), new Object[0]), 8, 6, 4210752);
-@@ -403,7 +428,7 @@
+@@ -403,7 +429,7 @@
              {
                  CreativeTabs creativetabs = acreativetabs[k1];
  
@@ -93,7 +94,7 @@
                  {
                      return;
                  }
-@@ -426,7 +451,7 @@
+@@ -426,7 +452,7 @@
              {
                  CreativeTabs creativetabs = acreativetabs[k1];
  
@@ -102,7 +103,7 @@
                  {
                      this.func_147050_b(creativetabs);
                      return;
-@@ -439,11 +464,13 @@
+@@ -439,11 +465,13 @@
  
      private boolean func_147055_p()
      {
@@ -116,7 +117,7 @@
          int i = field_147058_w;
          field_147058_w = p_147050_1_.func_78021_a();
          GuiContainerCreative.ContainerCreative containercreative = (GuiContainerCreative.ContainerCreative)this.field_147002_h;
-@@ -512,12 +539,14 @@
+@@ -512,12 +540,14 @@
  
          if (this.field_147062_A != null)
          {
@@ -132,7 +133,7 @@
                  this.func_147053_i();
              }
              else
-@@ -608,23 +637,45 @@
+@@ -608,23 +638,45 @@
  
          super.func_73863_a(p_73863_1_, p_73863_2_, p_73863_3_);
          CreativeTabs[] acreativetabs = CreativeTabs.field_78032_a;
@@ -180,7 +181,7 @@
          GL11.glColor4f(1.0F, 1.0F, 1.0F, 1.0F);
          GL11.glDisable(GL11.GL_LIGHTING);
      }
-@@ -693,17 +744,37 @@
+@@ -693,17 +745,37 @@
          int k = acreativetabs.length;
          int l;
  
@@ -219,7 +220,7 @@
          this.field_146297_k.func_110434_K().func_110577_a(new ResourceLocation("textures/gui/container/creative_inventory/tab_" + creativetabs.func_78015_f()));
          this.func_73729_b(this.field_147003_i, this.field_147009_r, 0, 0, this.field_146999_f, this.field_147000_g);
          this.field_147062_A.func_146194_f();
-@@ -718,6 +789,14 @@
+@@ -718,6 +790,14 @@
              this.func_73729_b(i1, k + (int)((float)(l - k - 17) * this.field_147067_x), 232 + (this.func_147055_p() ? 0 : 12), 0, 12, 15);
          }
  
@@ -234,7 +235,7 @@
          this.func_147051_a(creativetabs);
  
          if (creativetabs == CreativeTabs.field_78036_m)
-@@ -728,6 +807,15 @@
+@@ -728,6 +808,15 @@
  
      protected boolean func_147049_a(CreativeTabs p_147049_1_, int p_147049_2_, int p_147049_3_)
      {
@@ -250,7 +251,7 @@
          int k = p_147049_1_.func_78020_k();
          int l = 28 * k;
          byte b0 = 0;
-@@ -828,6 +916,8 @@
+@@ -828,6 +917,8 @@
          }
  
          GL11.glDisable(GL11.GL_LIGHTING);
@@ -259,7 +260,7 @@
          this.func_73729_b(l, i1, j, k, 28, b0);
          this.field_73735_i = 100.0F;
          field_146296_j.field_77023_b = 100.0F;
-@@ -854,6 +944,15 @@
+@@ -854,6 +945,15 @@
          {
              this.field_146297_k.func_147108_a(new GuiStats(this, this.field_146297_k.field_71439_g.func_146107_m()));
          }


### PR DESCRIPTION
In a private mod of ours, we have three full pages worth of tabs (3*10, 30, excluding the search/inventory tab) which causes a fourth 'blank' page to appear that has only the search and inventory tab on it. This fixes said issue which was due to the addition of 1 to the max page value.

Signed-off-by: Steven Downer <grinch@outlook.com>