### PR TITLE
Fixes issue #1552 Where the flowIntoBlock method was not setting the Block to the fluid and causing crashes

### DIFF
--- a/src/main/java/net/minecraftforge/fluids/BlockFluidClassic.java
+++ b/src/main/java/net/minecraftforge/fluids/BlockFluidClassic.java
@@ -272,7 +272,7 @@ public class BlockFluidClassic extends BlockFluidBase
         if (meta < 0) return;
         if (displaceIfPossible(world, pos))
         {
-            world.setBlockState(pos, world.getBlockState(pos).withProperty(LEVEL, meta), 3);
+            world.setBlockState(pos, this.getBlockState().getBaseState().withProperty(LEVEL, meta), 3);
         }
     }
 


### PR DESCRIPTION
Set the destination block the to the fluid.
In the previous code the destination block was still Air and would 
cause a crash because air doesn't have a property for LEVEL

The new version of the code will set the block to the Fluid block and set the fluid's level property.