### PR TITLE
Added ATs for EnumFacing

### DIFF
--- a/src/main/resources/forge_at.cfg
+++ b/src/main/resources/forge_at.cfg
@@ -147,3 +147,6 @@ protected net.minecraft.client.resources.model.ModelBakery func_177581_b(Lnet/mi
 protected net.minecraft.client.resources.model.ModelBakery func_177587_c(Lnet/minecraft/client/renderer/block/model/ModelBlock;)Z # isCustomRenderer
 protected net.minecraft.client.resources.model.ModelBakery func_177582_d(Lnet/minecraft/client/renderer/block/model/ModelBlock;)Lnet/minecraft/client/renderer/block/model/ModelBlock; # makeItemModel
 protected net.minecraft.client.resources.model.ModelBakery func_177580_d(Lnet/minecraft/util/ResourceLocation;)Lnet/minecraft/util/ResourceLocation; # getModelLocation
+# EnumFacing
+public net.minecraft.util.EnumFacing field_82609_l # VALUES
+public net.minecraft.util.EnumFacing field_176754_o # HORIZONTALS


### PR DESCRIPTION
ForgeDirection had these types of things public as well, so I figured it would assist in the jump over. Also, having direct access to these arrays makes it easier to iterate over the values of this enum.