### PR TITLE
Minor tweak to UsernameCache to also cache usernames of offline players

### DIFF
--- a/src/main/java/net/minecraftforge/common/ForgeModContainer.java
+++ b/src/main/java/net/minecraftforge/common/ForgeModContainer.java
@@ -257,7 +257,7 @@ public class ForgeModContainer extends DummyModContainer implements WorldAccessC
     @SubscribeEvent
     public void playerLogin(PlayerEvent.PlayerLoggedInEvent event)
     {
-        UsernameCache.setUsername(event.player.getGameProfile().getId(), event.player.getGameProfile().getName());
+        UsernameCache.setUsername(event.player.getPersistentID(), event.player.getGameProfile().getName());
     }
 
     @Override


### PR DESCRIPTION
`getPersistentID()` returns the same UUID as `getGameProfile().getId()` when the player is online, but when they are offline a UUID based on the hash of the username is returned. This prevents the returned UUID from ever returning `null`, making sure we can cache the offline players' UUID -> username mappings.