### PR TITLE
Crafting and Smelting Hooks

### DIFF
--- a/patches/minecraft/net/minecraft/inventory/ContainerPlayer.java.patch
+++ b/patches/minecraft/net/minecraft/inventory/ContainerPlayer.java.patch
@@ -10,3 +10,12 @@
                  }
                  @SideOnly(Side.CLIENT)
                  public String func_178171_c()
+@@ -75,7 +76,7 @@
+ 
+     public void func_75130_a(IInventory p_75130_1_)
+     {
+-        this.field_75179_f.func_70299_a(0, CraftingManager.func_77594_a().func_82787_a(this.field_75181_e, this.field_82862_h.field_70170_p));
++        this.field_75179_f.func_70299_a(0, net.minecraftforge.event.ForgeEventFactory.onPlayerFindMatchingRecipe(this, field_82862_h));
+     }
+ 
+     public void func_75134_a(EntityPlayer p_75134_1_)

--- a/patches/minecraft/net/minecraft/inventory/ContainerWorkbench.java.patch
+++ b/patches/minecraft/net/minecraft/inventory/ContainerWorkbench.java.patch
@@ -1,0 +1,11 @@
+--- ../src-base/minecraft/net/minecraft/inventory/ContainerWorkbench.java
++++ ../src-work/minecraft/net/minecraft/inventory/ContainerWorkbench.java
+@@ -50,7 +50,7 @@
+ 
+     public void func_75130_a(IInventory p_75130_1_)
+     {
+-        this.field_75160_f.func_70299_a(0, CraftingManager.func_77594_a().func_82787_a(this.field_75162_e, this.field_75161_g));
++        this.field_75160_f.func_70299_a(0, net.minecraftforge.event.ForgeEventFactory.onCraftingBenchFindMatchingRecipe(this, field_75161_g, field_178145_h));
+     }
+ 
+     public void func_75134_a(EntityPlayer p_75134_1_)

--- a/patches/minecraft/net/minecraft/tileentity/TileEntityFurnace.java.patch
+++ b/patches/minecraft/net/minecraft/tileentity/TileEntityFurnace.java.patch
@@ -10,11 +10,13 @@
                              }
                          }
                      }
-@@ -285,7 +284,11 @@
+@@ -284,8 +283,12 @@
+         }
          else
          {
-             ItemStack itemstack = FurnaceRecipes.func_77602_a().func_151395_a(this.field_145957_n[0]);
+-            ItemStack itemstack = FurnaceRecipes.func_77602_a().func_151395_a(this.field_145957_n[0]);
 -            return itemstack == null ? false : (this.field_145957_n[2] == null ? true : (!this.field_145957_n[2].func_77969_a(itemstack) ? false : (this.field_145957_n[2].field_77994_a < this.func_70297_j_() && this.field_145957_n[2].field_77994_a < this.field_145957_n[2].func_77976_d() ? true : this.field_145957_n[2].field_77994_a < itemstack.func_77976_d())));
++            ItemStack itemstack = net.minecraftforge.event.ForgeEventFactory.onFurnaceFindMatchingRecipe(this, this.field_145957_n[0]);
 +            if (itemstack == null) return false;
 +            if (this.field_145957_n[2] == null) return true;
 +            if (!this.field_145957_n[2].func_77969_a(itemstack)) return false;
@@ -23,6 +25,15 @@
          }
      }
  
+@@ -293,7 +296,7 @@
+     {
+         if (this.func_145948_k())
+         {
+-            ItemStack itemstack = FurnaceRecipes.func_77602_a().func_151395_a(this.field_145957_n[0]);
++            ItemStack itemstack = net.minecraftforge.event.ForgeEventFactory.onFurnaceFindMatchingRecipe(this, this.field_145957_n[0]);
+ 
+             if (this.field_145957_n[2] == null)
+             {
 @@ -301,7 +304,7 @@
              }
              else if (this.field_145957_n[2].func_77973_b() == itemstack.func_77973_b())

--- a/src/main/java/net/minecraftforge/event/ForgeEventFactory.java
+++ b/src/main/java/net/minecraftforge/event/ForgeEventFactory.java
@@ -17,7 +17,12 @@ import net.minecraft.entity.item.EntityItem;
 import net.minecraft.entity.monster.EntityZombie;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.entity.player.EntityPlayer.EnumStatus;
+import net.minecraft.inventory.ContainerPlayer;
+import net.minecraft.inventory.ContainerWorkbench;
 import net.minecraft.item.ItemStack;
+import net.minecraft.item.crafting.CraftingManager;
+import net.minecraft.item.crafting.FurnaceRecipes;
+import net.minecraft.tileentity.TileEntityFurnace;
 import net.minecraft.util.BlockPos;
 import net.minecraft.util.DamageSource;
 import net.minecraft.util.EnumFacing;
@@ -37,6 +42,9 @@ import net.minecraftforge.common.IExtendedEntityProperties;
 import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.common.util.BlockSnapshot;
 import net.minecraftforge.event.brewing.PotionBrewEvent;
+import net.minecraftforge.event.crafting.BenchFindMatchingRecipeEvent;
+import net.minecraftforge.event.crafting.FurnaceFindMatchingRecipeEvent;
+import net.minecraftforge.event.crafting.PlayerFindMatchingRecipeEvent;
 import net.minecraftforge.event.entity.EntityEvent;
 import net.minecraftforge.event.entity.EntityStruckByLightningEvent;
 import net.minecraftforge.event.entity.PlaySoundAtEntityEvent;
@@ -412,5 +420,29 @@ public class ForgeEventFactory
     public static void onPotionBrewed(ItemStack[] brewingItemStacks)
     {
         MinecraftForge.EVENT_BUS.post(new PotionBrewEvent.Post(brewingItemStacks));
+    }
+    
+    public static ItemStack onPlayerFindMatchingRecipe(ContainerPlayer container, EntityPlayer player)
+    {
+        ItemStack stack = CraftingManager.getInstance().findMatchingRecipe(container.craftMatrix, player.worldObj);
+        PlayerFindMatchingRecipeEvent event = new PlayerFindMatchingRecipeEvent(container, player, stack);
+        MinecraftForge.EVENT_BUS.post(event);
+        return event.isCanceled() ? null : event.getOutput();
+    }
+
+    public static ItemStack onCraftingBenchFindMatchingRecipe(ContainerWorkbench bench, World world, BlockPos pos)
+    {
+        ItemStack stack = CraftingManager.getInstance().findMatchingRecipe(bench.craftMatrix, world);
+        BenchFindMatchingRecipeEvent event = new BenchFindMatchingRecipeEvent(bench, world, stack, pos);
+        MinecraftForge.EVENT_BUS.post(event);
+        return event.isCanceled() ? null : event.getOutput();
+    }
+
+    public static ItemStack onFurnaceFindMatchingRecipe(TileEntityFurnace furnace, ItemStack in)
+    {
+        ItemStack out = FurnaceRecipes.instance().getSmeltingResult(in);
+        FurnaceFindMatchingRecipeEvent event = new FurnaceFindMatchingRecipeEvent(furnace, in, out);
+        MinecraftForge.EVENT_BUS.post(event);
+        return event.isCanceled() ? null : event.getOutput();
     }
 }

--- a/src/main/java/net/minecraftforge/event/crafting/BenchFindMatchingRecipeEvent.java
+++ b/src/main/java/net/minecraftforge/event/crafting/BenchFindMatchingRecipeEvent.java
@@ -1,0 +1,16 @@
+package net.minecraftforge.event.crafting;
+
+import net.minecraft.inventory.ContainerWorkbench;
+import net.minecraft.item.ItemStack;
+import net.minecraft.util.BlockPos;
+import net.minecraft.world.World;
+
+public class BenchFindMatchingRecipeEvent extends FindMatchingRecipeEvent.Block {
+    public final ContainerWorkbench bench;
+
+    public BenchFindMatchingRecipeEvent(ContainerWorkbench container, World world, ItemStack output, BlockPos pos)
+    {
+        super(world, pos, PlayerFindMatchingRecipeEvent.getInput(container.craftMatrix), output, EType.CRAFT);
+        bench = container;
+    }
+}

--- a/src/main/java/net/minecraftforge/event/crafting/FindMatchingRecipeEvent.java
+++ b/src/main/java/net/minecraftforge/event/crafting/FindMatchingRecipeEvent.java
@@ -1,0 +1,124 @@
+package net.minecraftforge.event.crafting;
+
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.item.ItemStack;
+import net.minecraft.util.BlockPos;
+import net.minecraft.world.World;
+import net.minecraftforge.common.MinecraftForge;
+import net.minecraftforge.fml.common.eventhandler.Cancelable;
+import net.minecraftforge.fml.common.eventhandler.Event;
+
+/**
+ * This event is fired when a crafting-type inventory searches for the first
+ * valid recipe that matches the inputs. It is not recommended that you use this
+ * event just to check if a specific item is being made, as removing all recipes
+ * that output that specific item from the relevant CraftingManager or
+ * FuranceRecipes instance is quicker.
+ * 
+ * <br>
+ * This event is {@link Cancelable}. <br>
+ * If the event is canceled, the current input will be considered invalid, and
+ * no crafting can occur. This event does not have a result. {@link HasResult}<br>
+ * <br>
+ * This event is fired on the {@link MinecraftForge#EVENT_BUS}.<br>
+ * 
+ * @author AlexIIL
+ */
+@Cancelable
+public class FindMatchingRecipeEvent extends Event {
+    /**
+     * This shows the type of crafting that is occurring. It is recommended that
+     * if you have a category that doesn't fit into these that you use OTHER.
+     */
+    /*
+     * OR maybe that this is just a String with constants expressed here? that
+     * would allow for many more possibilities, but I don't know if thats
+     * actually helpful, unless an ore-dictionary type naming convention was
+     * here, and even then, what would you do with that?
+     */
+    public static enum EType {
+        CRAFT, SMELT, OTHER;
+    }
+
+    public final World world;
+    public final ItemStack[] input;
+    public final ItemStack output;
+    public final EType type;
+    private ItemStack newOutput;
+
+    /**
+     * The input can be null, and it will be initialized to an empty array. Type
+     * will be initialized to EType.OTHER if it is null.
+     */
+    private FindMatchingRecipeEvent(World world, ItemStack[] in, ItemStack out, EType type)
+    {
+        input = in == null ? new ItemStack[0] : in;
+        output = out;
+        newOutput = out;
+        this.world = world;
+        this.type = type == null ? EType.OTHER : type;
+        // Is this really wanted? or just throw an NPE early?
+    }
+
+    /**
+     * This sets the output that the recipe will give. NOTE that if this is for
+     * an already existing recipe, the items will be used up
+     */
+    public void setOutput(ItemStack stack)
+    {
+        newOutput = stack;
+    }
+
+    /**
+     * This gets the new output that the recipe will give. If none has been set,
+     * then it will return whatever was output by the recipe
+     */
+    public ItemStack getOutput()
+    {
+        return newOutput;
+    }
+
+    /**
+     * This is fired whenever a block tries to craft with items. More
+     * specifically, this is when a block, or multiple blocks but this as the
+     * center, try to craft something
+     */
+    public static class Block extends FindMatchingRecipeEvent {
+        public final BlockPos pos;
+
+        public Block(World world, BlockPos pos, ItemStack[] in, ItemStack out, EType type)
+        {
+            super(world, in, out, type);
+            this.pos = pos;
+        }
+    }
+
+    /**
+     * This is fired whenever an entity tries to craft items. While this is
+     * never called from vanilla classes, this is intended to allow modded
+     * non-player entities to fire this event, and give the entity.
+     */
+    public static class Entity extends FindMatchingRecipeEvent {
+        public final net.minecraft.entity.Entity entity;
+
+        public Entity(World world, net.minecraft.entity.Entity entity, ItemStack[] in, ItemStack out, EType type)
+        {
+            super(world, in, out, type);
+            this.entity = entity;
+        }
+    }
+
+    /**
+     * This is fired whenever a player tires to craft items. More specifically,
+     * this is whenever a player, and only one player tries to craft something
+     */
+    public static class Player extends Entity {
+        public final EntityPlayer player;
+
+        public Player(World world, EntityPlayer player, ItemStack[] in, ItemStack out, EType type)
+        {
+            super(world, player, in, out, type);
+            this.player = player;
+        }
+    }
+}

--- a/src/main/java/net/minecraftforge/event/crafting/FurnaceFindMatchingRecipeEvent.java
+++ b/src/main/java/net/minecraftforge/event/crafting/FurnaceFindMatchingRecipeEvent.java
@@ -1,0 +1,14 @@
+package net.minecraftforge.event.crafting;
+
+import net.minecraft.item.ItemStack;
+import net.minecraft.tileentity.TileEntityFurnace;
+
+public class FurnaceFindMatchingRecipeEvent extends FindMatchingRecipeEvent.Block {
+    public final TileEntityFurnace furnace;
+
+    public FurnaceFindMatchingRecipeEvent(TileEntityFurnace furnace, ItemStack input, ItemStack output)
+    {
+        super(furnace.getWorld(), furnace.getPos(), new ItemStack[] { input }, output, EType.SMELT);
+        this.furnace = furnace;
+    }
+}

--- a/src/main/java/net/minecraftforge/event/crafting/PlayerFindMatchingRecipeEvent.java
+++ b/src/main/java/net/minecraftforge/event/crafting/PlayerFindMatchingRecipeEvent.java
@@ -1,0 +1,24 @@
+package net.minecraftforge.event.crafting;
+
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.inventory.ContainerPlayer;
+import net.minecraft.inventory.InventoryCrafting;
+import net.minecraft.item.ItemStack;
+
+public class PlayerFindMatchingRecipeEvent extends FindMatchingRecipeEvent.Player {
+    public final ContainerPlayer container;// The container that the crafting is taking place in
+
+    public PlayerFindMatchingRecipeEvent(ContainerPlayer container, EntityPlayer player, ItemStack output)
+    {
+        super(player.worldObj, player, getInput(container.craftMatrix), output, FindMatchingRecipeEvent.EType.CRAFT);
+        this.container = container;
+    }
+
+    public static ItemStack[] getInput(InventoryCrafting craftMatrix)
+    {
+        ItemStack[] in = new ItemStack[craftMatrix.getSizeInventory()];
+        for (int i = 0; i < in.length; i++)
+            in[i] = craftMatrix.getStackInSlot(i);
+        return in;
+    }
+}


### PR DESCRIPTION
Adds a few events to change the output of a crafting or smelting recipe depending on the current location of the furnace, crafting bench, or the player entity.
The crafting events are fired whenever the crafting matrix changes (or whenever the GUI is opened), so the new output can be shown immediately.
The furnace event is fired whenever the furnace checks to see if the item it holds can be smelted into something.

All of the events hold either the BlockPos, or the EntityPlayer that the crafting attempt originated from. They also hold either the TileEntityFurnace, ContainerPlayer, or ContainerWorkbench that they came from.

An example mod is given here:
https://gist.github.com/AlexIIL/af55d022e99e3e636fd0