### PR TITLE
[1.8] [Bugfix] Made armor stands send an EntityInteractEvent when right clicked on.

### DIFF
--- a/patches/minecraft/net/minecraft/entity/item/EntityArmorStand.java.patch
+++ b/patches/minecraft/net/minecraft/entity/item/EntityArmorStand.java.patch
@@ -1,0 +1,11 @@
+--- ../src-base/minecraft/net/minecraft/entity/item/EntityArmorStand.java
++++ ../src-work/minecraft/net/minecraft/entity/item/EntityArmorStand.java
+@@ -329,7 +329,7 @@
+ 
+     public boolean func_174825_a(EntityPlayer p_174825_1_, Vec3 p_174825_2_)
+     {
+-        if (!this.field_70170_p.field_72995_K && !p_174825_1_.func_175149_v())
++        if (!this.field_70170_p.field_72995_K && !p_174825_1_.func_175149_v() && !net.minecraftforge.common.MinecraftForge.EVENT_BUS.post(new net.minecraftforge.event.entity.player.EntityInteractEvent(p_174825_1_, this)))
+         {
+             byte b0 = 0;
+             ItemStack itemstack = p_174825_1_.func_71045_bC();


### PR DESCRIPTION
Armor stands aren't interacted with like other entities and a special function (currently named func_174825_a) is called when they're right clicked on, I've added a patch for the EntityArmorStand class that sends out a new EntityInteractEvent, and allows the event to be cancelled, when they're right clicked.