### PR TITLE
Added support for invisible armour

### DIFF
--- a/patches/minecraft/net/minecraft/entity/player/EntityPlayer.java.patch
+++ b/patches/minecraft/net/minecraft/entity/player/EntityPlayer.java.patch
@@ -241,7 +241,29 @@
          if (this.func_180431_b(p_70097_1_))
          {
              return false;
-@@ -1023,12 +1110,15 @@
+@@ -1002,7 +1089,7 @@
+ 
+     public float func_82243_bO()
+     {
+-        int i = 0;
++        float f = 0.0F;
+         ItemStack[] aitemstack = this.field_71071_by.field_70460_b;
+         int j = aitemstack.length;
+ 
+@@ -1012,23 +1099,26 @@
+ 
+             if (itemstack != null)
+             {
+-                ++i;
++                f += itemstack.func_77973_b().getItemVisibility(itemstack);
+             }
+         }
+ 
+-        return (float)i / (float)this.field_71071_by.field_70460_b.length;
++        return f / (float)this.field_71071_by.field_70460_b.length;
+     }
+ 
+     protected void func_70665_d(DamageSource p_70665_1_, float p_70665_2_)
      {
          if (!this.func_180431_b(p_70665_1_))
          {

--- a/patches/minecraft/net/minecraft/entity/player/EntityPlayer.java.patch
+++ b/patches/minecraft/net/minecraft/entity/player/EntityPlayer.java.patch
@@ -246,24 +246,20 @@
      public float func_82243_bO()
      {
 -        int i = 0;
-+        float f = 0.0F;
++        float i = 0.0F;
          ItemStack[] aitemstack = this.field_71071_by.field_70460_b;
          int j = aitemstack.length;
  
-@@ -1012,23 +1099,26 @@
+@@ -1012,7 +1099,7 @@
  
              if (itemstack != null)
              {
 -                ++i;
-+                f += itemstack.func_77973_b().getItemVisibility(itemstack);
++                i += itemstack.func_77973_b().getItemVisibility(itemstack);
              }
          }
  
--        return (float)i / (float)this.field_71071_by.field_70460_b.length;
-+        return f / (float)this.field_71071_by.field_70460_b.length;
-     }
- 
-     protected void func_70665_d(DamageSource p_70665_1_, float p_70665_2_)
+@@ -1023,12 +1110,15 @@
      {
          if (!this.func_180431_b(p_70665_1_))
          {

--- a/patches/minecraft/net/minecraft/item/Item.java.patch
+++ b/patches/minecraft/net/minecraft/item/Item.java.patch
@@ -45,7 +45,7 @@
          Vec3 vec31 = vec3.func_72441_c((double)f6 * d3, (double)f5 * d3, (double)f7 * d3);
          return p_77621_1_.func_147447_a(vec3, vec31, p_77621_3_, !p_77621_3_, false);
      }
-@@ -366,11 +372,564 @@
+@@ -366,11 +372,574 @@
          return false;
      }
  
@@ -604,13 +604,23 @@
 +    {
 +        return this == Items.field_151166_bC || this == Items.field_151045_i || this == Items.field_151043_k || this == Items.field_151042_j;
 +    }
++
++    /**
++     * How easy it is for mobs to see this item when the player is invisible
++     * @param stack The ItemStack
++     * @return the visibility, between 0 and 1
++     */
++    public float getItemVisibility(ItemStack stack)
++    {
++    	return 1.0F;
++    }
 +    /* ======================================== FORGE END   =====================================*/
 +
 +
      public static void func_150900_l()
      {
          func_179214_a(Blocks.field_150348_b, (new ItemMultiTexture(Blocks.field_150348_b, Blocks.field_150348_b, new Function()
-@@ -936,6 +1495,10 @@
+@@ -936,6 +1505,10 @@
  
          private static final String __OBFID = "CL_00000042";
  
@@ -621,7 +631,7 @@
          private ToolMaterial(int p_i1874_3_, int p_i1874_4_, float p_i1874_5_, float p_i1874_6_, int p_i1874_7_)
          {
              this.field_78001_f = p_i1874_3_;
-@@ -970,9 +1533,36 @@
+@@ -970,9 +1543,36 @@
              return this.field_78008_j;
          }
  


### PR DESCRIPTION
Allows invisible armours (e.g. Modular Powersuits) to be invisible to mobs when the player is invisible, meaning they won't target the player.
Can be extended to include the held Item without much work