### PR TITLE
Added ATs for EnumFacing

### DIFF
--- a/src/main/resources/forge_at.cfg
+++ b/src/main/resources/forge_at.cfg
@@ -149,3 +149,6 @@ protected net.minecraft.client.resources.model.ModelBakery func_177587_c(Lnet/mi
 protected net.minecraft.client.resources.model.ModelBakery func_177582_d(Lnet/minecraft/client/renderer/block/model/ModelBlock;)Lnet/minecraft/client/renderer/block/model/ModelBlock; # makeItemModel
 protected net.minecraft.client.resources.model.ModelBakery func_177580_d(Lnet/minecraft/util/ResourceLocation;)Lnet/minecraft/util/ResourceLocation; # getModelLocation
 public net.minecraft.client.resources.model.WeightedBakedModel field_177565_b # models
+# EnumFacing
+public net.minecraft.util.EnumFacing field_82609_l # VALUES
+public net.minecraft.util.EnumFacing field_176754_o # HORIZONTALS


### PR DESCRIPTION
This is a remake of #1682, with the fixed merge conflicts.

This publics the VALUES array and HORIZONTALS array in EnumFacing, thus giving modders access to these arrays, much like ForgeDirection had.

I don't believe this needs an example mod, as all this is doing is giving modders access to something similar as to what was in ForgeDirection.