### PR TITLE
Fixed the Jukebox

### DIFF
--- a/patches/minecraft/net/minecraft/block/BlockJukebox.java.patch
+++ b/patches/minecraft/net/minecraft/block/BlockJukebox.java.patch
@@ -1,6 +1,6 @@
 --- ../src-base/minecraft/net/minecraft/block/BlockJukebox.java
 +++ ../src-work/minecraft/net/minecraft/block/BlockJukebox.java
-@@ -19,50 +19,49 @@
+@@ -19,41 +19,40 @@
  
  public class BlockJukebox extends BlockContainer
  {
@@ -29,7 +29,7 @@
 +            {
 +                if (jukeBox.func_145856_a() != null)
 +                {
-+                    this.dropRecord(p_180639_1_, p_180639_2_);
++                    this.func_180678_e(p_180639_1_, p_180639_2_, p_180639_3_);
 +                }
 +            }
          }
@@ -40,70 +40,32 @@
 +        return false;
      }
  
--    public void func_176431_a(World p_176431_1_, BlockPos p_176431_2_, IBlockState p_176431_3_, ItemStack p_176431_4_)
-+    public void insertRecord(World worldIn, BlockPos pos, ItemStack recordStack)
+     public void func_176431_a(World p_176431_1_, BlockPos p_176431_2_, IBlockState p_176431_3_, ItemStack p_176431_4_)
      {
--        if (!p_176431_1_.field_72995_K)
-+        if (!worldIn.field_72995_K)
+         if (!p_176431_1_.field_72995_K)
          {
 -            TileEntity tileentity = p_176431_1_.func_175625_s(p_176431_2_);
-+            BlockJukebox.TileEntityJukebox jukeBox = (BlockJukebox.TileEntityJukebox) worldIn.func_175625_s(pos);
++            BlockJukebox.TileEntityJukebox jukeBox = (BlockJukebox.TileEntityJukebox) p_176431_1_.func_175625_s(p_176431_2_);
  
 -            if (tileentity instanceof BlockJukebox.TileEntityJukebox)
 +            if (jukeBox != null)
              {
 -                ((BlockJukebox.TileEntityJukebox)tileentity).func_145857_a(new ItemStack(p_176431_4_.func_77973_b(), 1, p_176431_4_.func_77960_j()));
 -                p_176431_1_.func_180501_a(p_176431_2_, p_176431_3_.func_177226_a(field_176432_a, Boolean.valueOf(true)), 2);
-+                jukeBox.func_145857_a(recordStack);
++                jukeBox.func_145857_a(p_176431_4_);
              }
          }
      }
- 
--    private void func_180678_e(World p_180678_1_, BlockPos p_180678_2_, IBlockState p_180678_3_)
-+    private void dropRecord(World worldIn, BlockPos pos)
-     {
--        if (!p_180678_1_.field_72995_K)
-+        if (!worldIn.field_72995_K)
-         {
--            TileEntity tileentity = p_180678_1_.func_175625_s(p_180678_2_);
-+            TileEntity tileentity = worldIn.func_175625_s(pos);
- 
-             if (tileentity instanceof BlockJukebox.TileEntityJukebox)
-             {
-@@ -71,17 +70,16 @@
- 
-                 if (itemstack != null)
-                 {
--                    p_180678_1_.func_175718_b(1005, p_180678_2_, 0);
--                    p_180678_1_.func_175717_a(p_180678_2_, (String)null);
-+                    worldIn.func_175718_b(1005, pos, 0);
-+                    worldIn.func_175717_a(pos, (String)null);
-                     tileentityjukebox.func_145857_a((ItemStack)null);
-                     float f = 0.7F;
--                    double d0 = (double)(p_180678_1_.field_73012_v.nextFloat() * f) + (double)(1.0F - f) * 0.5D;
--                    double d1 = (double)(p_180678_1_.field_73012_v.nextFloat() * f) + (double)(1.0F - f) * 0.2D + 0.6D;
--                    double d2 = (double)(p_180678_1_.field_73012_v.nextFloat() * f) + (double)(1.0F - f) * 0.5D;
+@@ -78,8 +77,7 @@
+                     double d0 = (double)(p_180678_1_.field_73012_v.nextFloat() * f) + (double)(1.0F - f) * 0.5D;
+                     double d1 = (double)(p_180678_1_.field_73012_v.nextFloat() * f) + (double)(1.0F - f) * 0.2D + 0.6D;
+                     double d2 = (double)(p_180678_1_.field_73012_v.nextFloat() * f) + (double)(1.0F - f) * 0.5D;
 -                    ItemStack itemstack1 = itemstack.func_77946_l();
 -                    EntityItem entityitem = new EntityItem(p_180678_1_, (double)p_180678_2_.func_177958_n() + d0, (double)p_180678_2_.func_177956_o() + d1, (double)p_180678_2_.func_177952_p() + d2, itemstack1);
-+                    double d0 = (double)(worldIn.field_73012_v.nextFloat() * f) + (double)(1.0F - f) * 0.5D;
-+                    double d1 = (double)(worldIn.field_73012_v.nextFloat() * f) + (double)(1.0F - f) * 0.2D + 0.6D;
-+                    double d2 = (double)(worldIn.field_73012_v.nextFloat() * f) + (double)(1.0F - f) * 0.5D;
-+                    EntityItem entityitem = new EntityItem(worldIn, (double)pos.func_177958_n() + d0, (double)pos.func_177956_o() + d1, (double)pos.func_177952_p() + d2, new ItemStack(itemstack.func_77973_b(), 1, itemstack.func_77960_j()));
++                    EntityItem entityitem = new EntityItem(p_180678_1_, (double)p_180678_2_.func_177958_n() + d0, (double)p_180678_2_.func_177956_o() + d1, (double)p_180678_2_.func_177952_p() + d2, new ItemStack(itemstack.func_77973_b(), 1, itemstack.func_77960_j()));
                      entityitem.func_174869_p();
--                    p_180678_1_.func_72838_d(entityitem);
-+                    worldIn.func_72838_d(entityitem);
+                     p_180678_1_.func_72838_d(entityitem);
                  }
-             }
-         }
-@@ -89,7 +87,7 @@
- 
-     public void func_180663_b(World p_180663_1_, BlockPos p_180663_2_, IBlockState p_180663_3_)
-     {
--        this.func_180678_e(p_180663_1_, p_180663_2_, p_180663_3_);
-+        this.dropRecord(p_180663_1_, p_180663_2_);
-         super.func_180663_b(p_180663_1_, p_180663_2_, p_180663_3_);
-     }
- 
 @@ -105,7 +103,7 @@
      {
          return new BlockJukebox.TileEntityJukebox();

--- a/patches/minecraft/net/minecraft/block/BlockJukebox.java.patch
+++ b/patches/minecraft/net/minecraft/block/BlockJukebox.java.patch
@@ -1,0 +1,149 @@
+--- ../src-base/minecraft/net/minecraft/block/BlockJukebox.java
++++ ../src-work/minecraft/net/minecraft/block/BlockJukebox.java
+@@ -1,9 +1,6 @@
+ package net.minecraft.block;
+ 
+ import net.minecraft.block.material.Material;
+-import net.minecraft.block.properties.IProperty;
+-import net.minecraft.block.properties.PropertyBool;
+-import net.minecraft.block.state.BlockState;
+ import net.minecraft.block.state.IBlockState;
+ import net.minecraft.creativetab.CreativeTabs;
+ import net.minecraft.entity.item.EntityItem;
+@@ -19,50 +16,49 @@
+ 
+ public class BlockJukebox extends BlockContainer
+ {
+-    public static final PropertyBool field_176432_a = PropertyBool.func_177716_a("has_record");
+     private static final String __OBFID = "CL_00000260";
+ 
+     protected BlockJukebox()
+     {
+         super(Material.field_151575_d);
+-        this.func_180632_j(this.field_176227_L.func_177621_b().func_177226_a(field_176432_a, Boolean.valueOf(false)));
+         this.func_149647_a(CreativeTabs.field_78031_c);
+     }
+ 
+     public boolean func_180639_a(World p_180639_1_, BlockPos p_180639_2_, IBlockState p_180639_3_, EntityPlayer p_180639_4_, EnumFacing p_180639_5_, float p_180639_6_, float p_180639_7_, float p_180639_8_)
+     {
+-        if (((Boolean)p_180639_3_.func_177229_b(field_176432_a)).booleanValue())
++        if (!p_180639_1_.field_72995_K)
+         {
+-            this.func_180678_e(p_180639_1_, p_180639_2_, p_180639_3_);
+-            p_180639_3_ = p_180639_3_.func_177226_a(field_176432_a, Boolean.valueOf(false));
+-            p_180639_1_.func_180501_a(p_180639_2_, p_180639_3_, 2);
+-            return true;
++            BlockJukebox.TileEntityJukebox jukeBox = (BlockJukebox.TileEntityJukebox) p_180639_1_.func_175625_s(p_180639_2_);
++            
++            if (jukeBox != null)
++            {
++                if (jukeBox.func_145856_a() != null)
++                {
++                    this.dropRecord(p_180639_1_, p_180639_2_);
++                }
++            }
+         }
+-        else
+-        {
+-            return false;
+-        }
++        return false;
+     }
+ 
+-    public void func_176431_a(World p_176431_1_, BlockPos p_176431_2_, IBlockState p_176431_3_, ItemStack p_176431_4_)
++    public void insertRecord(World worldIn, BlockPos pos, ItemStack recordStack)
+     {
+-        if (!p_176431_1_.field_72995_K)
++        if (!worldIn.field_72995_K)
+         {
+-            TileEntity tileentity = p_176431_1_.func_175625_s(p_176431_2_);
++            BlockJukebox.TileEntityJukebox jukeBox = (BlockJukebox.TileEntityJukebox) worldIn.func_175625_s(pos);
+ 
+-            if (tileentity instanceof BlockJukebox.TileEntityJukebox)
++            if (jukeBox != null)
+             {
+-                ((BlockJukebox.TileEntityJukebox)tileentity).func_145857_a(new ItemStack(p_176431_4_.func_77973_b(), 1, p_176431_4_.func_77960_j()));
+-                p_176431_1_.func_180501_a(p_176431_2_, p_176431_3_.func_177226_a(field_176432_a, Boolean.valueOf(true)), 2);
++                jukeBox.func_145857_a(recordStack);
+             }
+         }
+     }
+ 
+-    private void func_180678_e(World p_180678_1_, BlockPos p_180678_2_, IBlockState p_180678_3_)
++    private void dropRecord(World worldIn, BlockPos pos)
+     {
+-        if (!p_180678_1_.field_72995_K)
++        if (!worldIn.field_72995_K)
+         {
+-            TileEntity tileentity = p_180678_1_.func_175625_s(p_180678_2_);
++            TileEntity tileentity = worldIn.func_175625_s(pos);
+ 
+             if (tileentity instanceof BlockJukebox.TileEntityJukebox)
+             {
+@@ -71,17 +67,16 @@
+ 
+                 if (itemstack != null)
+                 {
+-                    p_180678_1_.func_175718_b(1005, p_180678_2_, 0);
+-                    p_180678_1_.func_175717_a(p_180678_2_, (String)null);
++                    worldIn.func_175718_b(1005, pos, 0);
++                    worldIn.func_175717_a(pos, (String)null);
+                     tileentityjukebox.func_145857_a((ItemStack)null);
+                     float f = 0.7F;
+-                    double d0 = (double)(p_180678_1_.field_73012_v.nextFloat() * f) + (double)(1.0F - f) * 0.5D;
+-                    double d1 = (double)(p_180678_1_.field_73012_v.nextFloat() * f) + (double)(1.0F - f) * 0.2D + 0.6D;
+-                    double d2 = (double)(p_180678_1_.field_73012_v.nextFloat() * f) + (double)(1.0F - f) * 0.5D;
+-                    ItemStack itemstack1 = itemstack.func_77946_l();
+-                    EntityItem entityitem = new EntityItem(p_180678_1_, (double)p_180678_2_.func_177958_n() + d0, (double)p_180678_2_.func_177956_o() + d1, (double)p_180678_2_.func_177952_p() + d2, itemstack1);
++                    double d0 = (double)(worldIn.field_73012_v.nextFloat() * f) + (double)(1.0F - f) * 0.5D;
++                    double d1 = (double)(worldIn.field_73012_v.nextFloat() * f) + (double)(1.0F - f) * 0.2D + 0.6D;
++                    double d2 = (double)(worldIn.field_73012_v.nextFloat() * f) + (double)(1.0F - f) * 0.5D;
++                    EntityItem entityitem = new EntityItem(worldIn, (double)pos.func_177958_n() + d0, (double)pos.func_177956_o() + d1, (double)pos.func_177952_p() + d2, new ItemStack(itemstack.func_77973_b(), 1, itemstack.func_77960_j()));
+                     entityitem.func_174869_p();
+-                    p_180678_1_.func_72838_d(entityitem);
++                    worldIn.func_72838_d(entityitem);
+                 }
+             }
+         }
+@@ -89,7 +84,7 @@
+ 
+     public void func_180663_b(World p_180663_1_, BlockPos p_180663_2_, IBlockState p_180663_3_)
+     {
+-        this.func_180678_e(p_180663_1_, p_180663_2_, p_180663_3_);
++        this.dropRecord(p_180663_1_, p_180663_2_);
+         super.func_180663_b(p_180663_1_, p_180663_2_, p_180663_3_);
+     }
+ 
+@@ -105,7 +100,7 @@
+     {
+         return new BlockJukebox.TileEntityJukebox();
+     }
+-
++    
+     public boolean func_149740_M()
+     {
+         return true;
+@@ -132,22 +127,7 @@
+     {
+         return 3;
+     }
+-
+-    public IBlockState func_176203_a(int p_176203_1_)
+-    {
+-        return this.func_176223_P().func_177226_a(field_176432_a, Boolean.valueOf(p_176203_1_ > 0));
+-    }
+-
+-    public int func_176201_c(IBlockState p_176201_1_)
+-    {
+-        return ((Boolean)p_176201_1_.func_177229_b(field_176432_a)).booleanValue() ? 1 : 0;
+-    }
+-
+-    protected BlockState func_180661_e()
+-    {
+-        return new BlockState(this, new IProperty[] {field_176432_a});
+-    }
+-
++    
+     public static class TileEntityJukebox extends TileEntity
+         {
+             private ItemStack field_145858_a;

--- a/patches/minecraft/net/minecraft/block/BlockJukebox.java.patch
+++ b/patches/minecraft/net/minecraft/block/BlockJukebox.java.patch
@@ -1,16 +1,6 @@
 --- ../src-base/minecraft/net/minecraft/block/BlockJukebox.java
 +++ ../src-work/minecraft/net/minecraft/block/BlockJukebox.java
-@@ -1,9 +1,6 @@
- package net.minecraft.block;
- 
- import net.minecraft.block.material.Material;
--import net.minecraft.block.properties.IProperty;
--import net.minecraft.block.properties.PropertyBool;
--import net.minecraft.block.state.BlockState;
- import net.minecraft.block.state.IBlockState;
- import net.minecraft.creativetab.CreativeTabs;
- import net.minecraft.entity.item.EntityItem;
-@@ -19,50 +16,49 @@
+@@ -19,50 +19,49 @@
  
  public class BlockJukebox extends BlockContainer
  {
@@ -80,7 +70,7 @@
  
              if (tileentity instanceof BlockJukebox.TileEntityJukebox)
              {
-@@ -71,17 +67,16 @@
+@@ -71,17 +70,16 @@
  
                  if (itemstack != null)
                  {
@@ -105,7 +95,7 @@
                  }
              }
          }
-@@ -89,7 +84,7 @@
+@@ -89,7 +87,7 @@
  
      public void func_180663_b(World p_180663_1_, BlockPos p_180663_2_, IBlockState p_180663_3_)
      {
@@ -114,7 +104,7 @@
          super.func_180663_b(p_180663_1_, p_180663_2_, p_180663_3_);
      }
  
-@@ -105,7 +100,7 @@
+@@ -105,7 +103,7 @@
      {
          return new BlockJukebox.TileEntityJukebox();
      }
@@ -123,7 +113,7 @@
      public boolean func_149740_M()
      {
          return true;
-@@ -132,22 +127,7 @@
+@@ -132,22 +130,7 @@
      {
          return 3;
      }

--- a/patches/minecraft/net/minecraft/client/renderer/BlockModelShapes.java.patch
+++ b/patches/minecraft/net/minecraft/client/renderer/BlockModelShapes.java.patch
@@ -1,6 +1,22 @@
 --- ../src-base/minecraft/net/minecraft/client/renderer/BlockModelShapes.java
 +++ ../src-work/minecraft/net/minecraft/client/renderer/BlockModelShapes.java
-@@ -321,6 +321,7 @@
+@@ -19,7 +19,6 @@
+ import net.minecraft.block.BlockFire;
+ import net.minecraft.block.BlockFlowerPot;
+ import net.minecraft.block.BlockHopper;
+-import net.minecraft.block.BlockJukebox;
+ import net.minecraft.block.BlockLeaves;
+ import net.minecraft.block.BlockNewLeaf;
+ import net.minecraft.block.BlockNewLog;
+@@ -173,7 +172,6 @@
+         this.func_178121_a(Blocks.field_150361_u, (new StateMap.Builder()).func_178440_a(BlockNewLeaf.field_176240_P).func_178439_a("_leaves").func_178442_a(new IProperty[] {BlockLeaves.field_176236_b, BlockLeaves.field_176237_a}).func_178441_a());
+         this.func_178121_a(Blocks.field_150434_aF, (new StateMap.Builder()).func_178442_a(new IProperty[] {BlockCactus.field_176587_a}).func_178441_a());
+         this.func_178121_a(Blocks.field_150436_aH, (new StateMap.Builder()).func_178442_a(new IProperty[] {BlockReed.field_176355_a}).func_178441_a());
+-        this.func_178121_a(Blocks.field_150421_aI, (new StateMap.Builder()).func_178442_a(new IProperty[] {BlockJukebox.field_176432_a}).func_178441_a());
+         this.func_178121_a(Blocks.field_150483_bI, (new StateMap.Builder()).func_178442_a(new IProperty[] {BlockCommandBlock.field_176452_a}).func_178441_a());
+         this.func_178121_a(Blocks.field_150463_bK, (new StateMap.Builder()).func_178440_a(BlockWall.field_176255_P).func_178439_a("_wall").func_178441_a());
+         this.func_178121_a(Blocks.field_150398_cm, (new StateMap.Builder()).func_178440_a(BlockDoublePlant.field_176493_a).func_178441_a());
+@@ -321,6 +319,7 @@
                  return new ModelResourceLocation(s + "_double_slab", s1);
              }
          });

--- a/patches/minecraft/net/minecraft/client/renderer/BlockModelShapes.java.patch
+++ b/patches/minecraft/net/minecraft/client/renderer/BlockModelShapes.java.patch
@@ -1,14 +1,6 @@
 --- ../src-base/minecraft/net/minecraft/client/renderer/BlockModelShapes.java
 +++ ../src-work/minecraft/net/minecraft/client/renderer/BlockModelShapes.java
-@@ -19,7 +19,6 @@
- import net.minecraft.block.BlockFire;
- import net.minecraft.block.BlockFlowerPot;
- import net.minecraft.block.BlockHopper;
--import net.minecraft.block.BlockJukebox;
- import net.minecraft.block.BlockLeaves;
- import net.minecraft.block.BlockNewLeaf;
- import net.minecraft.block.BlockNewLog;
-@@ -173,7 +172,6 @@
+@@ -173,7 +173,6 @@
          this.func_178121_a(Blocks.field_150361_u, (new StateMap.Builder()).func_178440_a(BlockNewLeaf.field_176240_P).func_178439_a("_leaves").func_178442_a(new IProperty[] {BlockLeaves.field_176236_b, BlockLeaves.field_176237_a}).func_178441_a());
          this.func_178121_a(Blocks.field_150434_aF, (new StateMap.Builder()).func_178442_a(new IProperty[] {BlockCactus.field_176587_a}).func_178441_a());
          this.func_178121_a(Blocks.field_150436_aH, (new StateMap.Builder()).func_178442_a(new IProperty[] {BlockReed.field_176355_a}).func_178441_a());
@@ -16,7 +8,7 @@
          this.func_178121_a(Blocks.field_150483_bI, (new StateMap.Builder()).func_178442_a(new IProperty[] {BlockCommandBlock.field_176452_a}).func_178441_a());
          this.func_178121_a(Blocks.field_150463_bK, (new StateMap.Builder()).func_178440_a(BlockWall.field_176255_P).func_178439_a("_wall").func_178441_a());
          this.func_178121_a(Blocks.field_150398_cm, (new StateMap.Builder()).func_178440_a(BlockDoublePlant.field_176493_a).func_178441_a());
-@@ -321,6 +319,7 @@
+@@ -321,6 +320,7 @@
                  return new ModelResourceLocation(s + "_double_slab", s1);
              }
          });

--- a/patches/minecraft/net/minecraft/item/ItemRecord.java.patch
+++ b/patches/minecraft/net/minecraft/item/ItemRecord.java.patch
@@ -21,7 +21,7 @@
 -            else
 -            {
 -                ((BlockJukebox)Blocks.field_150421_aI).func_176431_a(p_180614_3_, p_180614_4_, iblockstate, p_180614_1_);
-+                ((BlockJukebox)Blocks.field_150421_aI).insertRecord(p_180614_3_, p_180614_4_, p_180614_1_);
++                ((BlockJukebox)Blocks.field_150421_aI).func_176431_a(p_180614_3_, p_180614_4_, p_180614_3_.func_180495_p(p_180614_4_), p_180614_1_);
                  p_180614_3_.func_180498_a((EntityPlayer)null, 1005, p_180614_4_, Item.func_150891_b(this));
                  --p_180614_1_.field_77994_a;
                  return true;

--- a/patches/minecraft/net/minecraft/item/ItemRecord.java.patch
+++ b/patches/minecraft/net/minecraft/item/ItemRecord.java.patch
@@ -1,6 +1,54 @@
 --- ../src-base/minecraft/net/minecraft/item/ItemRecord.java
 +++ ../src-work/minecraft/net/minecraft/item/ItemRecord.java
-@@ -75,4 +75,15 @@
+@@ -1,9 +1,12 @@
+ package net.minecraft.item;
+ 
+ import com.google.common.collect.Maps;
++
+ import java.util.List;
+ import java.util.Map;
++
+ import net.minecraft.block.BlockJukebox;
++import net.minecraft.block.BlockJukebox.TileEntityJukebox;
+ import net.minecraft.block.state.IBlockState;
+ import net.minecraft.creativetab.CreativeTabs;
+ import net.minecraft.entity.player.EntityPlayer;
+@@ -30,27 +33,20 @@
+     }
+ 
+     public boolean func_180614_a(ItemStack p_180614_1_, EntityPlayer p_180614_2_, World p_180614_3_, BlockPos p_180614_4_, EnumFacing p_180614_5_, float p_180614_6_, float p_180614_7_, float p_180614_8_)
+-    {
+-        IBlockState iblockstate = p_180614_3_.func_180495_p(p_180614_4_);
+-
+-        if (iblockstate.func_177230_c() == Blocks.field_150421_aI && !((Boolean)iblockstate.func_177229_b(BlockJukebox.field_176432_a)).booleanValue())
++    {   
++        if (!p_180614_3_.field_72995_K)
+         {
+-            if (p_180614_3_.field_72995_K)
++            BlockJukebox.TileEntityJukebox jukeBox = (BlockJukebox.TileEntityJukebox) p_180614_3_.func_175625_s(p_180614_4_);
++            
++            if (jukeBox != null && jukeBox.func_145856_a() == null)
+             {
+-                return true;
+-            }
+-            else
+-            {
+-                ((BlockJukebox)Blocks.field_150421_aI).func_176431_a(p_180614_3_, p_180614_4_, iblockstate, p_180614_1_);
++                ((BlockJukebox)Blocks.field_150421_aI).insertRecord(p_180614_3_, p_180614_4_, p_180614_1_);
+                 p_180614_3_.func_180498_a((EntityPlayer)null, 1005, p_180614_4_, Item.func_150891_b(this));
+                 --p_180614_1_.field_77994_a;
+                 return true;
+             }
+         }
+-        else
+-        {
+-            return false;
+-        }
++        return false;
+     }
+ 
+     @SideOnly(Side.CLIENT)
+@@ -75,4 +71,15 @@
      {
          return (ItemRecord)field_150928_b.get(p_150926_0_);
      }

--- a/patches/minecraft/net/minecraft/item/ItemRecord.java.patch
+++ b/patches/minecraft/net/minecraft/item/ItemRecord.java.patch
@@ -1,19 +1,6 @@
 --- ../src-base/minecraft/net/minecraft/item/ItemRecord.java
 +++ ../src-work/minecraft/net/minecraft/item/ItemRecord.java
-@@ -1,9 +1,12 @@
- package net.minecraft.item;
- 
- import com.google.common.collect.Maps;
-+
- import java.util.List;
- import java.util.Map;
-+
- import net.minecraft.block.BlockJukebox;
-+import net.minecraft.block.BlockJukebox.TileEntityJukebox;
- import net.minecraft.block.state.IBlockState;
- import net.minecraft.creativetab.CreativeTabs;
- import net.minecraft.entity.player.EntityPlayer;
-@@ -30,27 +33,20 @@
+@@ -30,27 +30,20 @@
      }
  
      public boolean func_180614_a(ItemStack p_180614_1_, EntityPlayer p_180614_2_, World p_180614_3_, BlockPos p_180614_4_, EnumFacing p_180614_5_, float p_180614_6_, float p_180614_7_, float p_180614_8_)
@@ -48,7 +35,7 @@
      }
  
      @SideOnly(Side.CLIENT)
-@@ -75,4 +71,15 @@
+@@ -75,4 +68,15 @@
      {
          return (ItemRecord)field_150928_b.get(p_150926_0_);
      }


### PR DESCRIPTION
- BlockJukebox
     - Removed state sensitive info, because state info wasn't being saved correctly causing records to go missing and jukebox being reset.
- ItemRecord
       - Removed state sensitive info from the onItemUse method to use the TileEntity instead of the Block to save information.
- BlockModelShapes
       - Removed the jukebox registry (this.registerBlockWithStateMapper(Blocks.jukebox, (new StateMap.Builder()).addPropertiesToIgnore(new IProperty[] {BlockJukebox.HAS_RECORD}).build());) from the registerAllBlocks();

The problem with the Jukebox was that Minecraft was using states on the Block to save whether or not their was a record inside of the jukebox, for some reason, in forge, the states did not work save causing the jukebox to malfunction. What I did was get rid of the use of states, because 1) It didn't like to save with forge 2) The states added a unnecessary middleman to get to the TileEntity. I orginally made a issue about this here, #1633. Which was about a month ago so I would like this to work so this is my go at fixing it.