### PR TITLE
Add an EntityMountEvent.

### DIFF
--- a/patches/minecraft/net/minecraft/entity/Entity.java.patch
+++ b/patches/minecraft/net/minecraft/entity/Entity.java.patch
@@ -99,7 +99,15 @@
              return entityitem;
          }
          else
-@@ -1810,7 +1857,7 @@
+@@ -1672,6 +1719,7 @@
+ 
+     public void func_70078_a(Entity p_70078_1_)
+     {
++        if(!(this instanceof EntityLivingBase) && !net.minecraftforge.event.ForgeEventFactory.canMountEntity(this, p_70078_1_, true)){ return; }  
+         this.field_70149_e = 0.0D;
+         this.field_70147_f = 0.0D;
+ 
+@@ -1810,7 +1858,7 @@
  
      public boolean func_70115_ae()
      {
@@ -108,7 +116,7 @@
      }
  
      public boolean func_70093_af()
-@@ -2103,7 +2150,7 @@
+@@ -2103,7 +2151,7 @@
  
      public float func_180428_a(Explosion p_180428_1_, World p_180428_2_, BlockPos p_180428_3_, IBlockState p_180428_4_)
      {
@@ -117,7 +125,7 @@
      }
  
      public boolean func_174816_a(Explosion p_174816_1_, World p_174816_2_, BlockPos p_174816_3_, IBlockState p_174816_4_, float p_174816_5_)
-@@ -2357,4 +2404,176 @@
+@@ -2357,4 +2405,176 @@
  
          EnchantmentHelper.func_151385_b(p_174815_1_, p_174815_2_);
      }

--- a/patches/minecraft/net/minecraft/entity/EntityLivingBase.java.patch
+++ b/patches/minecraft/net/minecraft/entity/EntityLivingBase.java.patch
@@ -129,7 +129,15 @@
          if (!this.field_82175_bq || this.field_110158_av >= this.func_82166_i() / 2 || this.field_110158_av < 0)
          {
              this.field_110158_av = -1;
-@@ -1359,6 +1386,7 @@
+@@ -1294,6 +1321,7 @@
+ 
+     public void func_110145_l(Entity p_110145_1_)
+     {
++        if(!net.minecraftforge.event.ForgeEventFactory.canMountEntity(this, p_110145_1_, false)){ return; }
+         double d0 = p_110145_1_.field_70165_t;
+         double d1 = p_110145_1_.func_174813_aQ().field_72338_b + (double)p_110145_1_.field_70131_O;
+         double d2 = p_110145_1_.field_70161_v;
+@@ -1359,6 +1387,7 @@
          }
  
          this.field_70160_al = true;
@@ -137,7 +145,7 @@
      }
  
      protected void func_70629_bd()
-@@ -1545,6 +1573,7 @@
+@@ -1545,6 +1574,7 @@
  
      public void func_70071_h_()
      {
@@ -145,7 +153,15 @@
          super.func_70071_h_();
  
          if (!this.field_70170_p.field_72995_K)
-@@ -2000,4 +2029,39 @@
+@@ -1828,6 +1858,7 @@
+ 
+     public void func_70078_a(Entity p_70078_1_)
+     {
++        if(!net.minecraftforge.event.ForgeEventFactory.canMountEntity(this, p_70078_1_, true)){ return; }
+         if (this.field_70154_o != null && p_70078_1_ == null)
+         {
+             if (!this.field_70170_p.field_72995_K)
+@@ -2000,4 +2031,39 @@
      {
          this.field_70752_e = true;
      }

--- a/src/main/java/net/minecraftforge/event/ForgeEventFactory.java
+++ b/src/main/java/net/minecraftforge/event/ForgeEventFactory.java
@@ -38,6 +38,7 @@ import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.common.util.BlockSnapshot;
 import net.minecraftforge.event.brewing.PotionBrewEvent;
 import net.minecraftforge.event.entity.EntityEvent;
+import net.minecraftforge.event.entity.EntityMountEvent;
 import net.minecraftforge.event.entity.EntityStruckByLightningEvent;
 import net.minecraftforge.event.entity.PlaySoundAtEntityEvent;
 import net.minecraftforge.event.entity.item.ItemExpireEvent;
@@ -331,6 +332,19 @@ public class ForgeEventFactory
     public static boolean canInteractWith(EntityPlayer player, Entity entity)
     {
         return !MinecraftForge.EVENT_BUS.post(new EntityInteractEvent(player, entity));
+    }
+    
+    public static boolean canMountEntity(Entity entityMounting, Entity entityBeingMounted, boolean isMounting)
+    {
+        boolean isCanceled = MinecraftForge.EVENT_BUS.post(new EntityMountEvent(entityMounting, entityBeingMounted, entityMounting.worldObj, isMounting));
+        
+        if(isCanceled)
+        {
+            entityMounting.setPositionAndRotation(entityMounting.posX, entityMounting.posY, entityMounting.posZ, entityMounting.prevRotationYaw, entityMounting.prevRotationPitch);
+            return false;
+        }
+        else         
+            return true;       
     }
 
     public static EnumStatus onPlayerSleepInBed(EntityPlayer player, BlockPos pos)

--- a/src/main/java/net/minecraftforge/event/entity/EntityMountEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/EntityMountEvent.java
@@ -1,0 +1,52 @@
+package net.minecraftforge.event.entity;
+
+import net.minecraft.entity.Entity;
+import net.minecraft.entity.EntityLivingBase;
+import net.minecraft.world.World;
+import net.minecraftforge.fml.common.eventhandler.Cancelable;
+import net.minecraftforge.fml.common.eventhandler.Event.HasResult;
+
+/**
+ * This event gets fired whenever a entity mounts/dismounts another entity.<br>
+ * <b>entityBeingMounted can be null</b>, be sure to check for that.
+ * <br>
+ * <br>
+ * This event is {@link Cancelable}.<br>
+ * If this event is canceled, the entity does not mount/dismount the other entity.<br>
+ * <br>
+ * This event does not have a result. {@link HasResult}<br>
+ *<br>
+ * This event is fired on the {@link MinecraftForge#EVENT_BUS}.
+ * 
+ */
+
+@Cancelable
+public class EntityMountEvent extends EntityEvent
+{
+    
+    public final Entity entityMounting;
+    public final Entity entityBeingMounted;
+    public final World worldObj;
+    
+    private final boolean isMounting;
+
+    public EntityMountEvent(Entity entityMounting, Entity entityBeingMounted, World entityWorld, boolean isMounting)
+    {
+        super(entityMounting);
+        this.entityMounting = entityMounting;
+        this.entityBeingMounted = entityBeingMounted;
+        this.worldObj = entityWorld;
+        this.isMounting = isMounting;
+    }
+    
+    public boolean isMounting()
+    {
+        return isMounting;
+    }
+    
+    public boolean isDismounting()
+    {
+        return !isMounting;
+    }
+
+}


### PR DESCRIPTION
This event gets fired whenever a entity mounts/dismounts another entity, like when a players right-clicks an empty minecart, or right-clicks a horse with a saddle. It contains the entity mounting, and the entity that's being mounted. If it's canceled, the entity does not mount/dismount.

Here's the example mod: 
http://pastebin.com/EbpHgvCJ