### PR TITLE
Add method to set entity placements

### DIFF
--- a/patches/minecraft/net/minecraft/entity/EntitySpawnPlacementRegistry.java.patch
+++ b/patches/minecraft/net/minecraft/entity/EntitySpawnPlacementRegistry.java.patch
@@ -1,0 +1,15 @@
+--- ../src-base/minecraft/net/minecraft/entity/EntitySpawnPlacementRegistry.java
++++ ../src-work/minecraft/net/minecraft/entity/EntitySpawnPlacementRegistry.java
+@@ -45,6 +45,10 @@
+         return (EntityLiving.SpawnPlacementType)field_180110_a.get(p_180109_0_);
+     }
+ 
++    public static void setPlacementType(Class<? extends Entity> entityClass, EntityLiving.SpawnPlacementType placementType)
++    {
++        if(!field_180110_a.contains(entityClass))
++            field_180110_a.put(entityClass, placementType);
++    }
++
+     static
+     {
+         field_180110_a.put(EntityBat.class, EntityLiving.SpawnPlacementType.ON_GROUND);


### PR DESCRIPTION
Current spawner implementation checks the EntitySpawnPlacementRegistry hashmap to check where a entity should spawn
as there is no way to modify this without the use of reflection or a AT, you can not specify where you want your entity to spawn
adding this helper method will allow developers to specify where they want their entity to spawn.
