### PR TITLE
Add oredict support for tool/armor materials

### DIFF
--- a/patches/minecraft/net/minecraft/item/Item.java.patch
+++ b/patches/minecraft/net/minecraft/item/Item.java.patch
@@ -601,52 +601,106 @@
      public static void func_150900_l()
      {
          func_179214_a(Blocks.field_150348_b, (new ItemMultiTexture(Blocks.field_150348_b, Blocks.field_150348_b, new Function()
-@@ -936,6 +1495,10 @@
+@@ -936,6 +1495,12 @@
  
          private static final String __OBFID = "CL_00000042";
  
 +        //Added by forge for custom Tool materials.
-+        @Deprecated public Item customCraftingMaterial = null; // Remote in 1.8.1
-+        private ItemStack repairMaterial = null;
++        @Deprecated public Item customCraftingMaterial = null; // Remove in 1.8.1
++        private com.google.common.base.Predicate<ItemStack> repairMaterial = null;
++        private boolean isCached = false;
++        private ItemStack cachedItem = null;
 +
          private ToolMaterial(int p_i1874_3_, int p_i1874_4_, float p_i1874_5_, float p_i1874_6_, int p_i1874_7_)
          {
              this.field_78001_f = p_i1874_3_;
-@@ -970,9 +1533,36 @@
+@@ -970,9 +1535,88 @@
              return this.field_78008_j;
          }
  
-+        @Deprecated // Use getRepairItemStack below
++        @Deprecated // Use getRepairMaterial below
          public Item func_150995_f()
          {
 -            return this == WOOD ? Item.func_150898_a(Blocks.field_150344_f) : (this == STONE ? Item.func_150898_a(Blocks.field_150347_e) : (this == GOLD ? Items.field_151043_k : (this == IRON ? Items.field_151042_j : (this == EMERALD ? Items.field_151045_i : null))));
-+            switch (this)
-+            {
-+                case WOOD:    return Item.func_150898_a(Blocks.field_150344_f);
-+                case STONE:   return Item.func_150898_a(Blocks.field_150347_e);
-+                case GOLD:    return Items.field_151043_k;
-+                case IRON:    return Items.field_151042_j;
-+                case EMERALD: return Items.field_151045_i;
-+                default:      return customCraftingMaterial;
-+            }
++            ItemStack ret = getRepairItemStack();
++            return ret != null ? ret.func_77973_b() : null;
          }
 +
++        /* ======================================== FORGE START =====================================*/
++        @Deprecated // use setRepairMaterial below
 +        public ToolMaterial setRepairItem(ItemStack stack)
 +        {
-+            if (this.repairMaterial != null || customCraftingMaterial != null) throw new RuntimeException("Can not change already set repair material");
-+            if (this == WOOD || this == STONE || this == GOLD || this == IRON || this == EMERALD) throw new RuntimeException("Can not change vanilla tool repair materials");
-+            this.repairMaterial = stack;
-+            this.customCraftingMaterial = stack.func_77973_b();
++            setRepairMaterial(new net.minecraftforge.oredict.ItemPredicate(stack));
++            customCraftingMaterial = stack.func_77973_b(); // maintain behavior
 +            return this;
 +        }
 +
++        /**
++         * Set the repairing material with a {@code Predicate}. One may use {@code OreNamePredicate} for ores
++         * or {@code ItemPredicate} for items.
++         * 
++         * <p><i>Attention: If the object passed in this method is also an {@link Iterable}, its iterator may be called
++         * to give the actual items.</i>
++         *
++         * @param predicate a predicate of {@link ItemStack} represents repairing material
++         * @return this
++         */
++        public ToolMaterial setRepairMaterial(com.google.common.base.Predicate<ItemStack> predicate)
++        {
++            if (repairMaterial != null || customCraftingMaterial != null) throw new RuntimeException("Can not change already set repair material");
++            repairMaterial = predicate;
++            isCached = false;
++            cachedItem = null;
++            return this;
++        }
++
++        /**
++         * Give a {@code Predicate} representation of the repairing material.
++         *
++         * @return a predicate of {@link ItemStack} represents repairing material
++         */
++        public com.google.common.base.Predicate<ItemStack> getRepairMaterial()
++        {
++            com.google.common.base.Predicate<ItemStack> ret = repairMaterial;
++            if (ret != null) return ret;
++            Item i = customCraftingMaterial;
++            if (i != null)
++            {
++                cachedItem = new ItemStack(i, 1, net.minecraftforge.oredict.OreDictionary.WILDCARD_VALUE);
++                isCached = true;
++                return repairMaterial = new net.minecraftforge.oredict.ItemPredicate(cachedItem);
++            }
++            return com.google.common.base.Predicates.alwaysFalse();
++        }
++
++        /**
++         * An {@link ItemStack} version of {@link ToolMaterial#getRepairItem}.
++         *
++         * @return an item that can be used as repairing material, null if the representation as an {@code ItemStack}
++         * is not available.
++         */
 +        public ItemStack getRepairItemStack()
 +        {
-+            if (repairMaterial != null) return repairMaterial;
-+            Item ret = this.func_150995_f();
-+            if (ret == null) return null;
-+            repairMaterial = new ItemStack(ret, 1, net.minecraftforge.oredict.OreDictionary.WILDCARD_VALUE);
-+            return repairMaterial;
++            if (isCached) return cachedItem;
++            Object p = getRepairMaterial();
++            if (p instanceof Iterable) // use Iterable so we don't check twice
++            {
++                Object obj = com.google.common.collect.Iterables.getFirst((Iterable<?>) p, null);
++                if (obj instanceof ItemStack) {
++                    isCached = true;
++                    return cachedItem = (ItemStack) obj;
++                }
++            }
++            isCached = true;
++            return null;
++        }
++
++        static {
++            WOOD.repairMaterial = new net.minecraftforge.oredict.OreNamePredicate("plankWood");
++            STONE.repairMaterial = new net.minecraftforge.oredict.OreNamePredicate("cobblestone");
++            IRON.repairMaterial = new net.minecraftforge.oredict.OreNamePredicate("ingotIron");
++            EMERALD.repairMaterial = new net.minecraftforge.oredict.OreNamePredicate("gemDiamond");
++            GOLD.repairMaterial = new net.minecraftforge.oredict.OreNamePredicate("ingotGold");
 +        }
      }
  }

--- a/patches/minecraft/net/minecraft/item/ItemArmor.java.patch
+++ b/patches/minecraft/net/minecraft/item/ItemArmor.java.patch
@@ -9,6 +9,15 @@
                  int i1 = EntityLiving.func_82159_b(p_82487_2_);
                  ItemStack itemstack1 = p_82487_2_.func_77946_l();
                  itemstack1.field_77994_a = 1;
+@@ -182,7 +182,7 @@
+ 
+     public boolean func_82789_a(ItemStack p_82789_1_, ItemStack p_82789_2_)
+     {
+-        return this.field_77878_bZ.func_151685_b() == p_82789_2_.func_77973_b() ? true : super.func_82789_a(p_82789_1_, p_82789_2_);
++        return this.field_77878_bZ.getRepairMaterial().apply(p_82789_2_) || super.func_82789_a(p_82789_1_, p_82789_2_);
+     }
+ 
+     public ItemStack func_77659_a(ItemStack p_77659_1_, World p_77659_2_, EntityPlayer p_77659_3_)
 @@ -192,7 +192,7 @@
  
          if (itemstack1 == null)
@@ -18,30 +27,104 @@
              p_77659_1_.field_77994_a = 0;
          }
  
-@@ -213,6 +213,9 @@
+@@ -213,6 +213,12 @@
  
          private static final String __OBFID = "CL_00001768";
  
 +        //Added by forge for custom Armor materials.
-+        public Item customCraftingMaterial = null;
++        @Deprecated public Item customCraftingMaterial = null; // Remove in 1.8.1
++        private com.google.common.base.Predicate<ItemStack> repairMaterial = null;
++        private boolean isCached = false;
++        private ItemStack cachedItem = null;
 +
          private ArmorMaterial(String p_i45789_3_, int p_i45789_4_, int[] p_i45789_5_, int p_i45789_6_)
          {
              this.field_179243_f = p_i45789_3_;
-@@ -238,7 +241,15 @@
+@@ -236,9 +242,11 @@
+             return this.field_78055_h;
+         }
  
++        @Deprecated // Use getRepairMaterial below
          public Item func_151685_b()
          {
 -            return this == LEATHER ? Items.field_151116_aA : (this == CHAIN ? Items.field_151042_j : (this == GOLD ? Items.field_151043_k : (this == IRON ? Items.field_151042_j : (this == DIAMOND ? Items.field_151045_i : null))));
-+            switch (this)
-+            {
-+                case LEATHER: return Items.field_151116_aA;
-+                case CHAIN:   return Items.field_151042_j;
-+                case GOLD:    return Items.field_151043_k;
-+                case IRON:    return Items.field_151042_j;
-+                case DIAMOND: return Items.field_151045_i;
-+                default:      return customCraftingMaterial;
-+            }
++            ItemStack ret = getRepairItemStack();
++            return ret != null ? ret.func_77973_b() : null;
          }
  
          @SideOnly(Side.CLIENT)
+@@ -246,5 +254,74 @@
+         {
+             return this.field_179243_f;
+         }
++
++        /* ======================================== FORGE START =====================================*/
++        /**
++         * Set the repairing material with a {@code Predicate}. One may use {@code OreNamePredicate} for ores
++         * or {@code ItemPredicate} for items.
++         * 
++         * <p><i>Attention: If the object passed in this method is also an {@link Iterable}, its iterator may be called
++         * to give the actual items.</i>
++         *
++         * @param predicate a predicate of {@link ItemStack} represents repairing material
++         * @return this
++         */
++        public ArmorMaterial setRepairMaterial(com.google.common.base.Predicate<ItemStack> predicate)
++        {
++            if (repairMaterial != null || customCraftingMaterial != null) throw new RuntimeException("Can not change already set repair material");
++            repairMaterial = predicate;
++            isCached = false;
++            cachedItem = null;
++            return this;
++        }
++
++        /**
++         * Give a {@code Predicate} representation of the repairing material.
++         *
++         * @return a predicate of {@link ItemStack} represents repairing material
++         */
++        public com.google.common.base.Predicate<ItemStack> getRepairMaterial()
++        {
++            com.google.common.base.Predicate<ItemStack> ret = repairMaterial;
++            if (ret != null) return ret;
++            Item i = customCraftingMaterial;
++            if (i != null)
++            {
++                cachedItem = new ItemStack(i, 1, net.minecraftforge.oredict.OreDictionary.WILDCARD_VALUE);
++                isCached = true;
++                return repairMaterial = new net.minecraftforge.oredict.ItemPredicate(cachedItem);
++            }
++            return com.google.common.base.Predicates.alwaysFalse();
++        }
++
++        /**
++         * An {@link ItemStack} version of {@link ArmorMaterial#getRepairItem}.
++         *
++         * @return an item that can be used as repairing material, null if the representation as an {@code ItemStack}
++         * is not available.
++         */
++        public ItemStack getRepairItemStack()
++        {
++            if (isCached) return cachedItem;
++            Object p = getRepairMaterial();
++            if (p instanceof Iterable) // use Iterable so we don't check twice
++            {
++                Object obj = com.google.common.collect.Iterables.getFirst((Iterable<?>) p, null);
++                if (obj instanceof ItemStack) {
++                    isCached = true;
++                    return cachedItem = (ItemStack) obj;
++                }
++            }
++            isCached = true;
++            return null;
++        }
++
++        static {
++            LEATHER.repairMaterial = new net.minecraftforge.oredict.OreNamePredicate("leather");
++            CHAIN.repairMaterial = ToolMaterial.IRON.getRepairMaterial();
++            IRON.repairMaterial = CHAIN.repairMaterial;
++            GOLD.repairMaterial = ToolMaterial.GOLD.getRepairMaterial();
++            DIAMOND.repairMaterial = ToolMaterial.EMERALD.getRepairMaterial();
++        }
+     }
+ }

--- a/patches/minecraft/net/minecraft/item/ItemSword.java.patch
+++ b/patches/minecraft/net/minecraft/item/ItemSword.java.patch
@@ -1,13 +1,11 @@
 --- ../src-base/minecraft/net/minecraft/item/ItemSword.java
 +++ ../src-work/minecraft/net/minecraft/item/ItemSword.java
-@@ -102,7 +102,9 @@
+@@ -102,7 +102,7 @@
  
      public boolean func_82789_a(ItemStack p_82789_1_, ItemStack p_82789_2_)
      {
 -        return this.field_150933_b.func_150995_f() == p_82789_2_.func_77973_b() ? true : super.func_82789_a(p_82789_1_, p_82789_2_);
-+        ItemStack mat = this.field_150933_b.getRepairItemStack();
-+        if (mat != null && net.minecraftforge.oredict.OreDictionary.itemMatches(mat, p_82789_2_, false)) return true;
-+        return super.func_82789_a(p_82789_1_, p_82789_2_);
++        return this.field_150933_b.getRepairMaterial().apply(p_82789_2_) || super.func_82789_a(p_82789_1_, p_82789_2_);
      }
  
      public Multimap func_111205_h()

--- a/patches/minecraft/net/minecraft/item/ItemTool.java.patch
+++ b/patches/minecraft/net/minecraft/item/ItemTool.java.patch
@@ -19,18 +19,16 @@
      }
  
      public float func_150893_a(ItemStack p_150893_1_, Block p_150893_2_)
-@@ -75,7 +87,9 @@
+@@ -75,7 +87,7 @@
  
      public boolean func_82789_a(ItemStack p_82789_1_, ItemStack p_82789_2_)
      {
 -        return this.field_77862_b.func_150995_f() == p_82789_2_.func_77973_b() ? true : super.func_82789_a(p_82789_1_, p_82789_2_);
-+        ItemStack mat = this.field_77862_b.getRepairItemStack();
-+        if (mat != null && net.minecraftforge.oredict.OreDictionary.itemMatches(mat, p_82789_2_, false)) return true;
-+        return super.func_82789_a(p_82789_1_, p_82789_2_);
++        return this.field_77862_b.getRepairMaterial().apply(p_82789_2_) || super.func_82789_a(p_82789_1_, p_82789_2_);
      }
  
      public Multimap func_111205_h()
-@@ -84,4 +98,38 @@
+@@ -84,4 +96,38 @@
          multimap.put(SharedMonsterAttributes.field_111264_e.func_111108_a(), new AttributeModifier(field_111210_e, "Tool modifier", (double)this.field_77865_bY, 0));
          return multimap;
      }

--- a/src/main/java/net/minecraftforge/oredict/ItemPredicate.java
+++ b/src/main/java/net/minecraftforge/oredict/ItemPredicate.java
@@ -1,0 +1,34 @@
+package net.minecraftforge.oredict;
+
+import java.util.Iterator;
+
+import net.minecraft.item.Item;
+import net.minecraft.item.ItemStack;
+import net.minecraftforge.fml.common.registry.RegistryDelegate;
+
+import com.google.common.base.Predicate;
+import com.google.common.collect.Iterators;
+
+public class ItemPredicate implements Predicate<ItemStack>, Iterable<ItemStack>
+{
+    private final RegistryDelegate<Item> item;
+    private final int damage;
+
+    public ItemPredicate(ItemStack item)
+    {
+        this.item = item.getItem().delegate;
+        damage = item.getItemDamage();
+    }
+
+    @Override
+    public boolean apply(ItemStack in)
+    {
+        return in != null && item.get() == in.getItem() && (damage == OreDictionary.WILDCARD_VALUE || damage == in.getItemDamage());
+    }
+
+    @Override
+    public Iterator<ItemStack> iterator()
+    {
+        return Iterators.singletonIterator(new ItemStack(item.get(), 1, damage));
+    }
+}

--- a/src/main/java/net/minecraftforge/oredict/OreDictionary.java
+++ b/src/main/java/net/minecraftforge/oredict/OreDictionary.java
@@ -133,6 +133,7 @@ public class OreDictionary
             registerOre("chestWood",   Blocks.chest);
             registerOre("chestEnder",  Blocks.ender_chest);
             registerOre("chestTrapped", Blocks.trapped_chest);
+            registerOre("leather",     Items.leather);
         }
 
         // Build our list of items to replace with ore tags
@@ -157,6 +158,7 @@ public class OreDictionary
         replacements.put(new ItemStack(Blocks.chest), "chestWood");
         replacements.put(new ItemStack(Blocks.ender_chest), "chestEnder");
         replacements.put(new ItemStack(Blocks.trapped_chest), "chestTrapped");
+        replacements.put(new ItemStack(Items.leather), "leather");
 
         // Register dyes
         String[] dyes =

--- a/src/main/java/net/minecraftforge/oredict/OreNamePredicate.java
+++ b/src/main/java/net/minecraftforge/oredict/OreNamePredicate.java
@@ -1,0 +1,43 @@
+package net.minecraftforge.oredict;
+
+import java.util.Iterator;
+import java.util.List;
+
+import net.minecraft.item.ItemStack;
+
+import com.google.common.base.Predicate;
+
+public class OreNamePredicate implements Predicate<ItemStack>, Iterable<ItemStack>
+{
+    public final String name;
+    private List<ItemStack> items; // lazily initiated to avoid load order issues
+
+    public OreNamePredicate(String name)
+    {
+        this.name = name;
+    }
+
+    @Override
+    public boolean apply(ItemStack input)
+    {
+        for (ItemStack item : this)
+        {
+            if (OreDictionary.itemMatches(item, input, false))
+            {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    @Override
+    public Iterator<ItemStack> iterator()
+    {
+        List<ItemStack> items = this.items;
+        if (items == null)
+        {
+            this.items = items = OreDictionary.getOres(name);
+        }
+        return items.iterator();
+    }
+}

--- a/src/test/java/net/minecraftforge/newmaterialex/NewMaterialExampleMod.java
+++ b/src/test/java/net/minecraftforge/newmaterialex/NewMaterialExampleMod.java
@@ -1,0 +1,99 @@
+package net.minecraftforge.newmaterialex;
+
+import java.util.List;
+
+import net.minecraft.block.Block;
+import net.minecraft.block.material.Material;
+import net.minecraft.creativetab.CreativeTabs;
+import net.minecraft.init.Blocks;
+import net.minecraft.init.Items;
+import net.minecraft.item.Item;
+import net.minecraft.item.Item.ToolMaterial;
+import net.minecraft.item.ItemArmor;
+import net.minecraft.item.ItemArmor.ArmorMaterial;
+import net.minecraft.item.ItemStack;
+import net.minecraft.item.ItemSword;
+import net.minecraftforge.common.util.EnumHelper;
+import net.minecraftforge.fml.common.Mod;
+import net.minecraftforge.fml.common.Mod.EventHandler;
+import net.minecraftforge.fml.common.event.FMLInitializationEvent;
+import net.minecraftforge.fml.common.event.FMLPreInitializationEvent;
+import net.minecraftforge.fml.common.registry.GameRegistry;
+import net.minecraftforge.fml.common.registry.GameRegistry.ObjectHolder;
+import net.minecraftforge.oredict.OreDictionary;
+import net.minecraftforge.oredict.OreNamePredicate;
+
+@Mod(modid = "newmaterialex")
+@ObjectHolder("newmaterialex")
+public class NewMaterialExampleMod
+{
+    public static final Block neowood_plank = null;
+    public static final Item neocreature_hide = null;
+    public static final Item neoium_ingot = null;
+    public static final Item neoium_sword = null;
+    public static final Item neoium_helmet = null;
+
+    @EventHandler
+    public void preInit(FMLPreInitializationEvent event)
+    {
+        // new creative tab
+        new CreativeTabs("newmaterialex")
+        {
+            @Override
+            public Item getTabIconItem()
+            {
+                return Items.nether_wart;
+            }
+            @Override
+            public void displayAllReleventItems(List list)
+            {
+                // give a list of items required for the demonstration
+                list.add(new ItemStack(Blocks.anvil));
+
+                list.add(new ItemStack(neowood_plank));
+                list.add(new ItemStack(Items.wooden_sword, 1, 59));
+
+                list.add(new ItemStack(neocreature_hide));
+                list.add(new ItemStack(Items.leather_helmet, 1, 55));
+
+                list.add(new ItemStack(neoium_ingot));
+                list.add(new ItemStack(neoium_sword, 1, 99));
+                list.add(new ItemStack(neoium_helmet, 1, 110));
+            }
+        };
+
+        // register material items
+        Block b = new Block(Material.wood) {}.setUnlocalizedName("neowoodPlank");
+        GameRegistry.registerBlock(b, "neowood_plank");
+        GameRegistry.registerItem(new Item().setUnlocalizedName("neocreature_hide"), "neocreature_hide");
+        GameRegistry.registerItem(new Item().setUnlocalizedName("neoiumIngot"), "neoium_ingot");
+
+        // construct instances for ToolMaterial and ArmorMaterial
+        ToolMaterial toolMaterialNeoium = EnumHelper
+                .addToolMaterial("NEOIUM", 10, 99, 10, 10, 10)
+                .setRepairMaterial(new OreNamePredicate("ingotNeoium"));
+        ArmorMaterial armorMaterialNeoium = EnumHelper
+                .addArmorMaterial("NEOIUM", "newmaterialex:neoium", 10, new int[] {10, 10, 10, 10}, 10)
+                .setRepairMaterial(toolMaterialNeoium.getRepairMaterial());
+
+        // register equipment items
+        Item i = new ItemSword(toolMaterialNeoium).setUnlocalizedName("neoiumSword");
+        GameRegistry.registerItem(i, "neoium_sword");
+        i = new ItemArmor(armorMaterialNeoium, -1, 0).setUnlocalizedName("neoiumHelmet");
+        GameRegistry.registerItem(i, "neoium_helmet");
+    }
+
+    @EventHandler
+    public void init(FMLInitializationEvent event)
+    {
+        // register material items with their OreDictionary names
+        // wooden_sword is repairable with neowood_plank with this
+        OreDictionary.registerOre("plankWood", neowood_plank);
+
+        // leather_helmet is repairable with neocreature_hide with this
+        OreDictionary.registerOre("leather", neocreature_hide);
+
+        // neoium_sword / neoium_helmet is repairable with neoium_ingot with this
+        OreDictionary.registerOre("ingotNeoium", neoium_ingot);
+    }
+}


### PR DESCRIPTION
This PR Extends the current ```Item``` or ```ItemStack```  version of custom materials in ```ToolMaterial``` along with ```ArmorMaterial``` to support ore dictionary.

A straightforward ```Predicate<ItemStack> repairMaterial``` based implementation is used, to support both oredict items and non-oredict items.

With this PR, you will be able to:

* Add variations for vanilla materials crafting vanilla tools as well as repairing them, only by ore dictionary registrations. For example, any new wood planks registered with ```"plankWood"``` can be used in both crafting or repairing of vanilla wooden tools.

* Allow others to add variations for your own custom materials crafting your own custom tools as well as repairing them, without explicitly iterating over ore dictionary entries in ```getIsRepairable``` methods of your own tool classes.

A basic example is provided [here](https://gist.github.com/Zot201/1586bfd71727487e6d03). Please feel free to leave your comments for the implementation, ideas or else.