### PR TITLE
Fixed enchanting table applying secondary enchs.

### DIFF
--- a/patches/minecraft/net/minecraft/enchantment/Enchantment.java.patch
+++ b/patches/minecraft/net/minecraft/enchantment/Enchantment.java.patch
@@ -9,7 +9,15 @@
          }
          else
          {
-@@ -156,6 +156,45 @@
+@@ -149,13 +149,52 @@
+ 
+     public boolean func_92089_a(ItemStack p_92089_1_)
+     {
+-        return this.field_77351_y.func_77557_a(p_92089_1_.func_77973_b());
++        return canApplyAtEnchantingTable(p_92089_1_);
+     }
+ 
+     public void func_151368_a(EntityLivingBase p_151368_1_, Entity p_151368_2_, int p_151368_3_) {}
  
      public void func_151367_b(EntityLivingBase p_151367_1_, Entity p_151367_2_, int p_151367_3_) {}
  
@@ -21,7 +29,7 @@
 +     */
 +    public boolean canApplyAtEnchantingTable(ItemStack stack)
 +    {
-+        return func_92089_a(stack);
++        return this.field_77351_y.func_77557_a(stack.func_77973_b());
 +    }
 +
 +    private static final java.lang.reflect.Field bookSetter = Enchantment.class.getDeclaredFields()[1];


### PR DESCRIPTION
Secondary enchantments is implemented by overriding the ```canApply``` method. Reversing the delegation between ```canApply``` and ```canApplyAtEnchantingTable``` should fix them giving same result for both cases. Fix  #1428.