### PR TITLE
Fix for local player not being rendered when alternative view entity is set

### DIFF
--- a/patches/minecraft/net/minecraft/client/renderer/entity/RenderPlayer.java.patch
+++ b/patches/minecraft/net/minecraft/client/renderer/entity/RenderPlayer.java.patch
@@ -1,0 +1,26 @@
+--- ../src-base/minecraft/net/minecraft/client/renderer/entity/RenderPlayer.java
++++ ../src-work/minecraft/net/minecraft/client/renderer/entity/RenderPlayer.java
+@@ -1,5 +1,6 @@
+ package net.minecraft.client.renderer.entity;
+ 
++import net.minecraft.client.Minecraft;
+ import net.minecraft.client.entity.AbstractClientPlayer;
+ import net.minecraft.client.entity.EntityPlayerSP;
+ import net.minecraft.client.model.ModelBase;
+@@ -13,6 +14,7 @@
+ import net.minecraft.client.renderer.entity.layers.LayerHeldItem;
+ import net.minecraft.entity.Entity;
+ import net.minecraft.entity.EntityLivingBase;
++import net.minecraft.entity.player.EntityPlayer;
+ import net.minecraft.entity.player.EnumPlayerModelParts;
+ import net.minecraft.item.EnumAction;
+ import net.minecraft.item.ItemStack;
+@@ -53,7 +55,7 @@
+ 
+     public void func_180596_a(AbstractClientPlayer p_180596_1_, double p_180596_2_, double p_180596_4_, double p_180596_6_, float p_180596_8_, float p_180596_9_)
+     {
+-        if (!p_180596_1_.func_175144_cb() || this.field_76990_c.field_78734_h == p_180596_1_)
++        if (!(Minecraft.func_71410_x().func_175606_aa() instanceof EntityPlayer) || !p_180596_1_.func_175144_cb() || this.field_76990_c.field_78734_h == p_180596_1_)
+         {
+             double d3 = p_180596_4_;
+ 


### PR DESCRIPTION
In RenderPlayer
mc does if (!abstractClientPlayer.isUser() || this.renderManager.livingPlayer == abstractClientPlayer)
to determine if it should render the entity
but livingPlayer is set to the view entity in the render cache method,
becuase of this, it doesn't render the player when using a alternative camera