### PR TITLE
Fix jukebox message being too low

### DIFF
--- a/src/main/java/net/minecraftforge/client/GuiIngameForge.java
+++ b/src/main/java/net/minecraftforge/client/GuiIngameForge.java
@@ -709,7 +709,7 @@ public class GuiIngameForge extends GuiIngame
             if (opacity > 0)
             {
                 GlStateManager.pushMatrix();
-                GlStateManager.translate((float)(width / 2), (float)(height - 48), 0.0F);
+                GlStateManager.translate((float)(width / 2), (float)(height - 68), 0.0F);
                 GlStateManager.enableBlend();
                 GlStateManager.tryBlendFuncSeparate(GL11.GL_SRC_ALPHA, GL11.GL_ONE_MINUS_SRC_ALPHA, 1, 0);
                 int color = (recordIsPlaying ? Color.HSBtoRGB(hue / 50.0F, 0.7F, 0.6F) & WHITE : WHITE);


### PR DESCRIPTION
This has actually been a long standing bug with `GuiIngameForge` as far as I can tell (I could find it even in 1.6.4). Probably not worth it to fix for 1.7 though.

[With forge](http://i.imgur.com/JwMAJRy.png)
[Without forge](http://i.imgur.com/ee7hPxF.png)

Also reported [on the forums](http://www.minecraftforge.net/forum/index.php/topic,28568.0.html).