### PR TITLE
Fixes #1747

### DIFF
--- a/src/main/java/net/minecraftforge/common/WorldSpecificSaveHandler.java
+++ b/src/main/java/net/minecraftforge/common/WorldSpecificSaveHandler.java
@@ -1,6 +1,8 @@
 package net.minecraftforge.common;
 
 import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
 
 import net.minecraft.world.chunk.storage.IChunkLoader;
 import net.minecraft.world.storage.IPlayerFileData;
@@ -10,6 +12,7 @@ import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.world.storage.WorldInfo;
 import net.minecraft.world.WorldProvider;
 import net.minecraft.world.WorldServer;
+import net.minecraftforge.fml.common.FMLLog;
 
 //Class used internally to provide the world specific data directories.
 
@@ -43,7 +46,23 @@ public class WorldSpecificSaveHandler implements ISaveHandler
             dataDir = new File(world.getChunkSaveLocation(), "data");
             dataDir.mkdirs();
         }
-        return new File(dataDir, name + ".dat");
+        File file = new File(dataDir, name + ".dat");
+        if (!file.exists() && name.equalsIgnoreCase("FORTRESS"))
+        {
+            File parentFile = parent.getMapFileFromName(name);
+            if (parentFile.exists())
+            {
+                try
+                {
+                    Files.copy(parentFile.toPath(), file.toPath());
+                }
+                catch (IOException e)
+                {
+                    FMLLog.log(Level.ERROR, e, "A critical error occured copying fortress.dat to world specific dat folder - new file will be created.");
+                }
+            }
+        }
+        return file;
     }
 
 }


### PR DESCRIPTION
If the dat file isn't in the dimension specific folder but is present in the vanilla data folder then copy it over.