### PR TITLE
Added the possibility to change the pitch and volume of entity sounds

### DIFF
--- a/patches/minecraft/net/minecraft/client/entity/EntityPlayerSP.java.patch
+++ b/patches/minecraft/net/minecraft/client/entity/EntityPlayerSP.java.patch
@@ -1,16 +1,17 @@
 --- ../src-base/minecraft/net/minecraft/client/entity/EntityPlayerSP.java
 +++ ../src-work/minecraft/net/minecraft/client/entity/EntityPlayerSP.java
-@@ -53,6 +53,9 @@
+@@ -53,6 +53,10 @@
  import net.minecraft.world.World;
  import net.minecraftforge.fml.relauncher.Side;
  import net.minecraftforge.fml.relauncher.SideOnly;
 +import net.minecraftforge.client.ForgeHooksClient;
 +import net.minecraftforge.common.MinecraftForge;
++import net.minecraftforge.event.ForgeEventFactory;
 +import net.minecraftforge.event.entity.PlaySoundAtEntityEvent;
  
  @SideOnly(Side.CLIENT)
  public class EntityPlayerSP extends AbstractClientPlayer
-@@ -342,6 +345,15 @@
+@@ -342,6 +346,15 @@
          this.field_71159_c.field_71456_v.func_146158_b().func_146227_a(p_146105_1_);
      }
  
@@ -26,7 +27,7 @@
      protected boolean func_145771_j(double p_145771_1_, double p_145771_3_, double p_145771_5_)
      {
          if (this.field_70145_X)
-@@ -354,30 +366,34 @@
+@@ -354,30 +367,34 @@
              double d3 = p_145771_1_ - (double)blockpos.func_177958_n();
              double d4 = p_145771_5_ - (double)blockpos.func_177952_p();
  
@@ -66,13 +67,15 @@
                  {
                      d5 = 1.0D - d4;
                      b0 = 5;
-@@ -445,6 +461,9 @@
+@@ -445,6 +462,11 @@
  
      public void func_85030_a(String p_85030_1_, float p_85030_2_, float p_85030_3_)
      {
-+        PlaySoundAtEntityEvent event = new PlaySoundAtEntityEvent(this, p_85030_1_, p_85030_2_, p_85030_3_);
-+        if (MinecraftForge.EVENT_BUS.post(event)) return;
++        PlaySoundAtEntityEvent event = ForgeEventFactory.onPlaySoundAtEntity(this, p_85030_1_, p_85030_2_, p_85030_3_);
++        if(event.name == null) return;
 +        p_85030_1_ = event.name;
++        p_85030_2_ = event.newVolume;
++        p_85030_3_ = event.newPitch;
          this.field_70170_p.func_72980_b(this.field_70165_t, this.field_70163_u, this.field_70161_v, p_85030_1_, p_85030_2_, p_85030_3_, false);
      }
  

--- a/patches/minecraft/net/minecraft/entity/Entity.java.patch
+++ b/patches/minecraft/net/minecraft/entity/Entity.java.patch
@@ -99,7 +99,15 @@
              return entityitem;
          }
          else
-@@ -1810,7 +1857,7 @@
+@@ -1672,6 +1719,7 @@
+ 
+     public void func_70078_a(Entity p_70078_1_)
+     {
++        if(!(this instanceof EntityLivingBase) && !net.minecraftforge.event.ForgeEventFactory.canMountEntity(this, p_70078_1_, true)){ return; }  
+         this.field_70149_e = 0.0D;
+         this.field_70147_f = 0.0D;
+ 
+@@ -1810,7 +1858,7 @@
  
      public boolean func_70115_ae()
      {
@@ -108,7 +116,7 @@
      }
  
      public boolean func_70093_af()
-@@ -2103,7 +2150,7 @@
+@@ -2103,7 +2151,7 @@
  
      public float func_180428_a(Explosion p_180428_1_, World p_180428_2_, BlockPos p_180428_3_, IBlockState p_180428_4_)
      {
@@ -117,7 +125,7 @@
      }
  
      public boolean func_174816_a(Explosion p_174816_1_, World p_174816_2_, BlockPos p_174816_3_, IBlockState p_174816_4_, float p_174816_5_)
-@@ -2357,4 +2404,176 @@
+@@ -2357,4 +2405,176 @@
  
          EnchantmentHelper.func_151385_b(p_174815_1_, p_174815_2_);
      }

--- a/patches/minecraft/net/minecraft/entity/EntityLivingBase.java.patch
+++ b/patches/minecraft/net/minecraft/entity/EntityLivingBase.java.patch
@@ -129,7 +129,15 @@
          if (!this.field_82175_bq || this.field_110158_av >= this.func_82166_i() / 2 || this.field_110158_av < 0)
          {
              this.field_110158_av = -1;
-@@ -1359,6 +1386,7 @@
+@@ -1294,6 +1321,7 @@
+ 
+     public void func_110145_l(Entity p_110145_1_)
+     {
++        if(!net.minecraftforge.event.ForgeEventFactory.canMountEntity(this, p_110145_1_, false)){ return; }
+         double d0 = p_110145_1_.field_70165_t;
+         double d1 = p_110145_1_.func_174813_aQ().field_72338_b + (double)p_110145_1_.field_70131_O;
+         double d2 = p_110145_1_.field_70161_v;
+@@ -1359,6 +1387,7 @@
          }
  
          this.field_70160_al = true;
@@ -137,7 +145,7 @@
      }
  
      protected void func_70629_bd()
-@@ -1545,6 +1573,7 @@
+@@ -1545,6 +1574,7 @@
  
      public void func_70071_h_()
      {
@@ -145,7 +153,15 @@
          super.func_70071_h_();
  
          if (!this.field_70170_p.field_72995_K)
-@@ -2000,4 +2029,39 @@
+@@ -1828,6 +1858,7 @@
+ 
+     public void func_70078_a(Entity p_70078_1_)
+     {
++        if(!net.minecraftforge.event.ForgeEventFactory.canMountEntity(this, p_70078_1_, true)){ return; }
+         if (this.field_70154_o != null && p_70078_1_ == null)
+         {
+             if (!this.field_70170_p.field_72995_K)
+@@ -2000,4 +2031,39 @@
      {
          this.field_70752_e = true;
      }

--- a/patches/minecraft/net/minecraft/world/World.java.patch
+++ b/patches/minecraft/net/minecraft/world/World.java.patch
@@ -1,9 +1,9 @@
 --- ../src-base/minecraft/net/minecraft/world/World.java
 +++ ../src-work/minecraft/net/minecraft/world/World.java
-@@ -56,8 +56,30 @@
+@@ -55,9 +55,31 @@
+ import net.minecraft.world.storage.WorldInfo;
  import net.minecraftforge.fml.relauncher.Side;
  import net.minecraftforge.fml.relauncher.SideOnly;
- 
 +import net.minecraftforge.fml.common.FMLLog;
 +import com.google.common.collect.ImmutableSetMultimap;
 +import net.minecraftforge.client.ForgeHooksClient;
@@ -13,12 +13,13 @@
 +import net.minecraftforge.common.ForgeHooks;
 +import net.minecraftforge.common.MinecraftForge;
 +import net.minecraftforge.common.WorldSpecificSaveHandler;
++import net.minecraftforge.event.ForgeEventFactory;
 +import net.minecraftforge.event.entity.EntityEvent;
 +import net.minecraftforge.event.entity.EntityJoinWorldEvent;
 +import net.minecraftforge.event.world.WorldEvent;
 +import net.minecraftforge.event.entity.PlaySoundAtEntityEvent;
 +import net.minecraft.entity.EnumCreatureType;
-+
+ 
  public abstract class World implements IBlockAccess
  {
 +   /**
@@ -193,25 +194,31 @@
      }
  
      public MovingObjectPosition func_72933_a(Vec3 p_72933_1_, Vec3 p_72933_2_)
-@@ -978,6 +1036,8 @@
+@@ -978,6 +1036,11 @@
  
      public void func_72956_a(Entity p_72956_1_, String p_72956_2_, float p_72956_3_, float p_72956_4_)
      {
-+        p_72956_2_ = net.minecraftforge.event.ForgeEventFactory.onPlaySoundAt(p_72956_1_, p_72956_2_, p_72956_3_, p_72956_4_);
-+        if (p_72956_2_ == null) return;
++        PlaySoundAtEntityEvent event = ForgeEventFactory.onPlaySoundAtEntity(p_72956_1_, p_72956_2_, p_72956_3_, p_72956_4_);
++        if(event.name == null) return;
++        p_72956_2_ = event.name;
++        p_72956_3_ = event.newVolume;
++        p_72956_4_ = event.newPitch;
          for (int i = 0; i < this.field_73021_x.size(); ++i)
          {
              ((IWorldAccess)this.field_73021_x.get(i)).func_72704_a(p_72956_2_, p_72956_1_.field_70165_t, p_72956_1_.field_70163_u, p_72956_1_.field_70161_v, p_72956_3_, p_72956_4_);
-@@ -986,6 +1046,8 @@
+@@ -986,6 +1049,11 @@
  
      public void func_85173_a(EntityPlayer p_85173_1_, String p_85173_2_, float p_85173_3_, float p_85173_4_)
      {
-+        p_85173_2_ = net.minecraftforge.event.ForgeEventFactory.onPlaySoundAt(p_85173_1_, p_85173_2_, p_85173_3_, p_85173_4_);
-+        if (p_85173_2_ == null) return;
++        PlaySoundAtEntityEvent event = ForgeEventFactory.onPlaySoundAtEntity(p_85173_1_, p_85173_2_, p_85173_3_, p_85173_4_);
++        if(event.name == null) return;
++        p_85173_2_ = event.name;
++        p_85173_3_ = event.newVolume;
++        p_85173_4_ = event.newPitch;
          for (int i = 0; i < this.field_73021_x.size(); ++i)
          {
              ((IWorldAccess)this.field_73021_x.get(i)).func_85102_a(p_85173_1_, p_85173_2_, p_85173_1_.field_70165_t, p_85173_1_.field_70163_u, p_85173_1_.field_70161_v, p_85173_3_, p_85173_4_);
-@@ -1037,6 +1099,9 @@
+@@ -1037,6 +1105,9 @@
  
      public boolean func_72838_d(Entity p_72838_1_)
      {
@@ -221,7 +228,7 @@
          int i = MathHelper.func_76128_c(p_72838_1_.field_70165_t / 16.0D);
          int j = MathHelper.func_76128_c(p_72838_1_.field_70161_v / 16.0D);
          boolean flag = p_72838_1_.field_98038_p;
-@@ -1059,6 +1124,8 @@
+@@ -1059,6 +1130,8 @@
                  this.func_72854_c();
              }
  
@@ -230,7 +237,7 @@
              this.func_72964_e(i, j).func_76612_a(p_72838_1_);
              this.field_72996_f.add(p_72838_1_);
              this.func_72923_a(p_72838_1_);
-@@ -1271,17 +1338,29 @@
+@@ -1271,17 +1344,29 @@
  
      public int func_72967_a(float p_72967_1_)
      {
@@ -263,7 +270,7 @@
      public void func_72848_b(IWorldAccess p_72848_1_)
      {
          this.field_73021_x.remove(p_72848_1_);
-@@ -1290,6 +1369,12 @@
+@@ -1290,6 +1375,12 @@
      @SideOnly(Side.CLIENT)
      public float func_72971_b(float p_72971_1_)
      {
@@ -276,7 +283,7 @@
          float f1 = this.func_72826_c(p_72971_1_);
          float f2 = 1.0F - (MathHelper.func_76134_b(f1 * (float)Math.PI * 2.0F) * 2.0F + 0.2F);
          f2 = MathHelper.func_76131_a(f2, 0.0F, 1.0F);
-@@ -1302,6 +1387,12 @@
+@@ -1302,6 +1393,12 @@
      @SideOnly(Side.CLIENT)
      public Vec3 func_72833_a(Entity p_72833_1_, float p_72833_2_)
      {
@@ -289,7 +296,7 @@
          float f1 = this.func_72826_c(p_72833_2_);
          float f2 = MathHelper.func_76134_b(f1 * (float)Math.PI * 2.0F) * 2.0F + 0.5F;
          f2 = MathHelper.func_76131_a(f2, 0.0F, 1.0F);
-@@ -1309,9 +1400,7 @@
+@@ -1309,9 +1406,7 @@
          int j = MathHelper.func_76128_c(p_72833_1_.field_70163_u);
          int k = MathHelper.func_76128_c(p_72833_1_.field_70161_v);
          BlockPos blockpos = new BlockPos(i, j, k);
@@ -300,7 +307,7 @@
          float f4 = (float)(l >> 16 & 255) / 255.0F;
          float f5 = (float)(l >> 8 & 255) / 255.0F;
          float f6 = (float)(l & 255) / 255.0F;
-@@ -1373,6 +1462,11 @@
+@@ -1373,6 +1468,11 @@
  
      public float func_130001_d()
      {
@@ -312,7 +319,7 @@
          return WorldProvider.field_111203_a[this.field_73011_w.func_76559_b(this.field_72986_A.func_76073_f())];
      }
  
-@@ -1385,6 +1479,12 @@
+@@ -1385,6 +1485,12 @@
      @SideOnly(Side.CLIENT)
      public Vec3 func_72824_f(float p_72824_1_)
      {
@@ -325,7 +332,7 @@
          float f1 = this.func_72826_c(p_72824_1_);
          float f2 = MathHelper.func_76134_b(f1 * (float)Math.PI * 2.0F) * 2.0F + 0.5F;
          f2 = MathHelper.func_76131_a(f2, 0.0F, 1.0F);
-@@ -1442,9 +1542,9 @@
+@@ -1442,9 +1548,9 @@
          for (blockpos1 = new BlockPos(p_175672_1_.func_177958_n(), chunk.func_76625_h() + 16, p_175672_1_.func_177952_p()); blockpos1.func_177956_o() >= 0; blockpos1 = blockpos2)
          {
              blockpos2 = blockpos1.func_177977_b();
@@ -337,7 +344,7 @@
              {
                  break;
              }
-@@ -1456,6 +1556,12 @@
+@@ -1456,6 +1562,12 @@
      @SideOnly(Side.CLIENT)
      public float func_72880_h(float p_72880_1_)
      {
@@ -350,7 +357,7 @@
          float f1 = this.func_72826_c(p_72880_1_);
          float f2 = 1.0F - (MathHelper.func_76134_b(f1 * (float)Math.PI * 2.0F) * 2.0F + 0.25F);
          f2 = MathHelper.func_76131_a(f2, 0.0F, 1.0F);
-@@ -1500,7 +1606,15 @@
+@@ -1500,7 +1612,15 @@
                      entity.func_85029_a(crashreportcategory);
                  }
  
@@ -367,7 +374,7 @@
              }
  
              if (entity.field_70128_L)
-@@ -1562,7 +1676,16 @@
+@@ -1562,7 +1682,16 @@
                      crashreport = CrashReport.func_85055_a(throwable1, "Ticking entity");
                      crashreportcategory = crashreport.func_85058_a("Entity being ticked");
                      entity.func_85029_a(crashreportcategory);
@@ -385,7 +392,7 @@
                  }
              }
  
-@@ -1609,7 +1732,16 @@
+@@ -1609,7 +1738,16 @@
                          CrashReport crashreport1 = CrashReport.func_85055_a(throwable, "Ticking block entity");
                          CrashReportCategory crashreportcategory1 = crashreport1.func_85058_a("Block entity being ticked");
                          tileentity.func_145828_a(crashreportcategory1);
@@ -403,7 +410,7 @@
                      }
                  }
              }
-@@ -1628,6 +1760,10 @@
+@@ -1628,6 +1766,10 @@
  
          if (!this.field_147483_b.isEmpty())
          {
@@ -414,7 +421,7 @@
              this.field_175730_i.removeAll(this.field_147483_b);
              this.field_147482_g.removeAll(this.field_147483_b);
              this.field_147483_b.clear();
-@@ -1668,7 +1804,8 @@
+@@ -1668,7 +1810,8 @@
  
      public boolean func_175700_a(TileEntity p_175700_1_)
      {
@@ -424,7 +431,7 @@
  
          if (flag && p_175700_1_ instanceof IUpdatePlayerListBox)
          {
-@@ -1710,9 +1847,12 @@
+@@ -1710,9 +1853,12 @@
      {
          int i = MathHelper.func_76128_c(p_72866_1_.field_70165_t);
          int j = MathHelper.func_76128_c(p_72866_1_.field_70161_v);
@@ -439,7 +446,7 @@
          {
              p_72866_1_.field_70142_S = p_72866_1_.field_70165_t;
              p_72866_1_.field_70137_T = p_72866_1_.field_70163_u;
-@@ -1839,7 +1979,7 @@
+@@ -1839,7 +1985,7 @@
                  {
                      Block block = this.func_180495_p(new BlockPos(k1, l1, i2)).func_177230_c();
  
@@ -448,7 +455,7 @@
                      {
                          return true;
                      }
-@@ -1901,6 +2041,10 @@
+@@ -1901,6 +2047,10 @@
                          {
                              return true;
                          }
@@ -459,7 +466,7 @@
                      }
                  }
              }
-@@ -2039,6 +2183,7 @@
+@@ -2039,6 +2189,7 @@
      public Explosion func_72885_a(Entity p_72885_1_, double p_72885_2_, double p_72885_4_, double p_72885_6_, float p_72885_8_, boolean p_72885_9_, boolean p_72885_10_)
      {
          Explosion explosion = new Explosion(this, p_72885_1_, p_72885_2_, p_72885_4_, p_72885_6_, p_72885_8_, p_72885_9_, p_72885_10_);
@@ -467,7 +474,7 @@
          explosion.func_77278_a();
          explosion.func_77279_a(true);
          return explosion;
-@@ -2185,19 +2330,28 @@
+@@ -2185,19 +2336,28 @@
              else
              {
                  this.func_175700_a(p_175690_2_);
@@ -497,7 +504,7 @@
          }
          else
          {
-@@ -2210,6 +2364,7 @@
+@@ -2210,6 +2370,7 @@
  
              this.func_175726_f(p_175713_1_).func_177425_e(p_175713_1_);
          }
@@ -505,7 +512,7 @@
      }
  
      public void func_147457_a(TileEntity p_147457_1_)
-@@ -2228,7 +2383,7 @@
+@@ -2228,7 +2389,7 @@
      {
          IBlockState iblockstate = p_175683_0_.func_180495_p(p_175683_1_);
          Block block = iblockstate.func_177230_c();
@@ -514,7 +521,7 @@
      }
  
      public boolean func_175677_d(BlockPos p_175677_1_, boolean p_175677_2_)
-@@ -2248,7 +2403,7 @@
+@@ -2248,7 +2409,7 @@
              else
              {
                  Block block = this.func_180495_p(p_175677_1_).func_177230_c();
@@ -523,7 +530,7 @@
              }
          }
      }
-@@ -2265,8 +2420,7 @@
+@@ -2265,8 +2426,7 @@
  
      public void func_72891_a(boolean p_72891_1_, boolean p_72891_2_)
      {
@@ -533,7 +540,7 @@
      }
  
      public void func_72835_b()
-@@ -2276,6 +2430,11 @@
+@@ -2276,6 +2436,11 @@
  
      protected void func_72947_a()
      {
@@ -545,7 +552,7 @@
          if (this.field_72986_A.func_76059_o())
          {
              this.field_73004_o = 1.0F;
-@@ -2289,6 +2448,11 @@
+@@ -2289,6 +2454,11 @@
  
      protected void func_72979_l()
      {
@@ -557,7 +564,7 @@
          if (!this.field_73011_w.func_177495_o())
          {
              if (!this.field_72995_K)
-@@ -2383,6 +2547,7 @@
+@@ -2383,6 +2553,7 @@
      {
          this.field_72993_I.clear();
          this.field_72984_F.func_76320_a("buildList");
@@ -565,7 +572,7 @@
          int i;
          EntityPlayer entityplayer;
          int j;
-@@ -2445,7 +2610,7 @@
+@@ -2445,7 +2616,7 @@
              l += p_147467_1_;
              i1 += p_147467_2_;
  
@@ -574,7 +581,7 @@
              {
                  EntityPlayer entityplayer = this.func_72977_a((double)l + 0.5D, (double)j1 + 0.5D, (double)i1 + 0.5D, 8.0D);
  
-@@ -2485,6 +2650,11 @@
+@@ -2485,6 +2656,11 @@
  
      public boolean func_175670_e(BlockPos p_175670_1_, boolean p_175670_2_)
      {
@@ -586,7 +593,7 @@
          BiomeGenBase biomegenbase = this.func_180494_b(p_175670_1_);
          float f = biomegenbase.func_180626_a(p_175670_1_);
  
-@@ -2526,6 +2696,11 @@
+@@ -2526,6 +2702,11 @@
  
      public boolean func_175708_f(BlockPos p_175708_1_, boolean p_175708_2_)
      {
@@ -598,7 +605,7 @@
          BiomeGenBase biomegenbase = this.func_180494_b(p_175708_1_);
          float f = biomegenbase.func_180626_a(p_175708_1_);
  
-@@ -2543,7 +2718,7 @@
+@@ -2543,7 +2724,7 @@
              {
                  Block block = this.func_180495_p(p_175708_1_).func_177230_c();
  
@@ -607,7 +614,7 @@
                  {
                      return true;
                  }
-@@ -2575,10 +2750,11 @@
+@@ -2575,10 +2756,11 @@
          else
          {
              Block block = this.func_180495_p(p_175638_1_).func_177230_c();
@@ -622,7 +629,7 @@
              {
                  j = 1;
              }
-@@ -2792,10 +2968,10 @@
+@@ -2792,10 +2974,10 @@
      public List func_175674_a(Entity p_175674_1_, AxisAlignedBB p_175674_2_, Predicate p_175674_3_)
      {
          ArrayList arraylist = Lists.newArrayList();
@@ -637,7 +644,7 @@
  
          for (int i1 = i; i1 <= j; ++i1)
          {
-@@ -2854,10 +3030,10 @@
+@@ -2854,10 +3036,10 @@
  
      public List func_175647_a(Class p_175647_1_, AxisAlignedBB p_175647_2_, Predicate p_175647_3_)
      {
@@ -652,7 +659,7 @@
          ArrayList arraylist = Lists.newArrayList();
  
          for (int i1 = i; i1 <= j; ++i1)
-@@ -2938,13 +3114,16 @@
+@@ -2938,13 +3120,16 @@
  
      public void func_175650_b(Collection p_175650_1_)
      {
@@ -671,7 +678,7 @@
          }
      }
  
-@@ -2957,7 +3136,9 @@
+@@ -2957,7 +3142,9 @@
      {
          Block block1 = this.func_180495_p(p_175716_2_).func_177230_c();
          AxisAlignedBB axisalignedbb = p_175716_3_ ? null : p_175716_1_.func_180640_a(this, p_175716_2_, p_175716_1_.func_176223_P());
@@ -682,7 +689,7 @@
      }
  
      public int func_175627_a(BlockPos p_175627_1_, EnumFacing p_175627_2_)
-@@ -3032,7 +3213,7 @@
+@@ -3032,7 +3219,7 @@
      {
          IBlockState iblockstate = this.func_180495_p(p_175651_1_);
          Block block = iblockstate.func_177230_c();
@@ -691,7 +698,7 @@
      }
  
      public boolean func_175640_z(BlockPos p_175640_1_)
-@@ -3160,7 +3341,7 @@
+@@ -3160,7 +3347,7 @@
  
      public long func_72905_C()
      {
@@ -700,7 +707,7 @@
      }
  
      public long func_82737_E()
-@@ -3170,17 +3351,17 @@
+@@ -3170,17 +3357,17 @@
  
      public long func_72820_D()
      {
@@ -721,7 +728,7 @@
  
          if (!this.func_175723_af().func_177746_a(blockpos))
          {
-@@ -3192,7 +3373,7 @@
+@@ -3192,7 +3379,7 @@
  
      public void func_175652_B(BlockPos p_175652_1_)
      {
@@ -730,7 +737,7 @@
      }
  
      @SideOnly(Side.CLIENT)
-@@ -3212,12 +3393,18 @@
+@@ -3212,12 +3399,18 @@
  
          if (!this.field_72996_f.contains(p_72897_1_))
          {
@@ -749,7 +756,7 @@
          return true;
      }
  
-@@ -3307,8 +3494,7 @@
+@@ -3307,8 +3500,7 @@
  
      public boolean func_180502_D(BlockPos p_180502_1_)
      {
@@ -759,7 +766,7 @@
      }
  
      public MapStorage func_175693_T()
-@@ -3367,12 +3553,12 @@
+@@ -3367,12 +3559,12 @@
  
      public int func_72800_K()
      {
@@ -774,7 +781,7 @@
      }
  
      public Random func_72843_D(int p_72843_1_, int p_72843_2_, int p_72843_3_)
-@@ -3429,7 +3615,7 @@
+@@ -3429,7 +3621,7 @@
      @SideOnly(Side.CLIENT)
      public double func_72919_O()
      {
@@ -783,7 +790,7 @@
      }
  
      public void func_175715_c(int p_175715_1_, BlockPos p_175715_2_, int p_175715_3_)
-@@ -3461,29 +3647,21 @@
+@@ -3461,29 +3653,21 @@
  
      public void func_175666_e(BlockPos p_175666_1_, Block p_175666_2_)
      {
@@ -820,7 +827,7 @@
                      }
                  }
              }
-@@ -3553,4 +3731,82 @@
+@@ -3553,4 +3737,82 @@
          short short1 = 128;
          return k >= -short1 && k <= short1 && l >= -short1 && l <= short1;
      }

--- a/patches/minecraft/net/minecraft/world/gen/feature/WorldGenDungeons.java.patch
+++ b/patches/minecraft/net/minecraft/world/gen/feature/WorldGenDungeons.java.patch
@@ -23,7 +23,7 @@
 +                                        WeightedRandomChestContent.func_177630_a(p_180709_2_, ChestGenHooks.getItems(DUNGEON_CHEST, p_180709_2_), (TileEntityChest)tileentity1, ChestGenHooks.getCount(DUNGEON_CHEST, p_180709_2_));
                                      }
  
-                                     break label100;
+                                     break label197;
 @@ -184,6 +186,12 @@
  
      private String func_76543_b(Random p_76543_1_)

--- a/src/main/java/net/minecraftforge/event/ForgeEventFactory.java
+++ b/src/main/java/net/minecraftforge/event/ForgeEventFactory.java
@@ -39,6 +39,7 @@ import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.common.util.BlockSnapshot;
 import net.minecraftforge.event.brewing.PotionBrewEvent;
 import net.minecraftforge.event.entity.EntityEvent;
+import net.minecraftforge.event.entity.EntityMountEvent;
 import net.minecraftforge.event.entity.EntityStruckByLightningEvent;
 import net.minecraftforge.event.entity.PlaySoundAtEntityEvent;
 import net.minecraftforge.event.entity.item.ItemExpireEvent;
@@ -303,11 +304,22 @@ public class ForgeEventFactory
         return event.canUpdate;
     }
 
+    /**
+     * Use {@link #onPlaySoundAtEntity(Entity,String,float,float)}
+     */
+    @Deprecated
     public static String onPlaySoundAt(Entity entity, String name, float volume, float pitch)
     {
         PlaySoundAtEntityEvent event = new PlaySoundAtEntityEvent(entity, name, volume, pitch);
         MinecraftForge.EVENT_BUS.post(event);
         return event.name;
+    }
+    
+    public static PlaySoundAtEntityEvent onPlaySoundAtEntity(Entity entity, String name, float volume, float pitch)
+    {
+        PlaySoundAtEntityEvent event = new PlaySoundAtEntityEvent(entity, name, volume, pitch);
+        MinecraftForge.EVENT_BUS.post(event);
+        return event;
     }
 
     public static int onItemExpire(EntityItem entity, ItemStack item)
@@ -340,6 +352,19 @@ public class ForgeEventFactory
     public static boolean canInteractWith(EntityPlayer player, Entity entity)
     {
         return !MinecraftForge.EVENT_BUS.post(new EntityInteractEvent(player, entity));
+    }
+    
+    public static boolean canMountEntity(Entity entityMounting, Entity entityBeingMounted, boolean isMounting)
+    {
+        boolean isCanceled = MinecraftForge.EVENT_BUS.post(new EntityMountEvent(entityMounting, entityBeingMounted, entityMounting.worldObj, isMounting));
+        
+        if(isCanceled)
+        {
+            entityMounting.setPositionAndRotation(entityMounting.posX, entityMounting.posY, entityMounting.posZ, entityMounting.prevRotationYaw, entityMounting.prevRotationPitch);
+            return false;
+        }
+        else         
+            return true;       
     }
 
     public static EnumStatus onPlayerSleepInBed(EntityPlayer player, BlockPos pos)

--- a/src/main/java/net/minecraftforge/event/entity/EntityMountEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/EntityMountEvent.java
@@ -1,0 +1,52 @@
+package net.minecraftforge.event.entity;
+
+import net.minecraft.entity.Entity;
+import net.minecraft.entity.EntityLivingBase;
+import net.minecraft.world.World;
+import net.minecraftforge.fml.common.eventhandler.Cancelable;
+import net.minecraftforge.fml.common.eventhandler.Event.HasResult;
+
+/**
+ * This event gets fired whenever a entity mounts/dismounts another entity.<br>
+ * <b>entityBeingMounted can be null</b>, be sure to check for that.
+ * <br>
+ * <br>
+ * This event is {@link Cancelable}.<br>
+ * If this event is canceled, the entity does not mount/dismount the other entity.<br>
+ * <br>
+ * This event does not have a result. {@link HasResult}<br>
+ *<br>
+ * This event is fired on the {@link MinecraftForge#EVENT_BUS}.
+ * 
+ */
+
+@Cancelable
+public class EntityMountEvent extends EntityEvent
+{
+    
+    public final Entity entityMounting;
+    public final Entity entityBeingMounted;
+    public final World worldObj;
+    
+    private final boolean isMounting;
+
+    public EntityMountEvent(Entity entityMounting, Entity entityBeingMounted, World entityWorld, boolean isMounting)
+    {
+        super(entityMounting);
+        this.entityMounting = entityMounting;
+        this.entityBeingMounted = entityBeingMounted;
+        this.worldObj = entityWorld;
+        this.isMounting = isMounting;
+    }
+    
+    public boolean isMounting()
+    {
+        return isMounting;
+    }
+    
+    public boolean isDismounting()
+    {
+        return !isMounting;
+    }
+
+}

--- a/src/main/java/net/minecraftforge/event/entity/PlaySoundAtEntityEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/PlaySoundAtEntityEvent.java
@@ -10,8 +10,10 @@ import net.minecraft.entity.Entity;
  * and World#playerSoundToNearExcept(EntityPlayer, String, float, float).<br>
  * <br>
  * {@link #name} contains the name of the sound to be played at the Entity.<br>
- * {@link #volume} contains the volume at which the sound is to be played.<br>
- * {@link #pitch} contains the pitch at which the sound is to be played.<br>
+ * {@link #volume} contains the volume at which the sound is to be played originally.<br>
+ * {@link #pitch} contains the pitch at which the sound is to be played originally.<br>
+ * {@link #newVolume} contains the volume at which the sound is actually played.<br>
+ * {@link #newPitch} contains the pitch at which the sound is actually played.<br>
  * Changing the {@link #name} field will cause the sound of this name to be played instead of the originally intended sound.<br>
  * <br>
  * This event is {@link Cancelable}.<br>
@@ -27,6 +29,8 @@ public class PlaySoundAtEntityEvent extends EntityEvent
     public String name;
     public final float volume;
     public final float pitch;
+    public float newVolume;
+    public float newPitch;
     
     public PlaySoundAtEntityEvent(Entity entity, String name, float volume, float pitch)
     {
@@ -34,5 +38,7 @@ public class PlaySoundAtEntityEvent extends EntityEvent
         this.name = name;
         this.volume = volume;
         this.pitch = pitch;
+        this.newVolume = volume;
+        this.newPitch = pitch;
     }
 }


### PR DESCRIPTION
Added the possibility to change the pitch and volume of entity sounds with PlaySoundAtEntityEvent. Removed ForgeEventFactory.onPlaySoundAt, and replaced all occurences with manual EVENT_BUS posting, because the event now returns more data than sound resource path

Related to [this issue](https://github.com/MinecraftForge/MinecraftForge/issues/1750).