### PR TITLE
Add getTileData() to TileEntity

### DIFF
--- a/patches/minecraft/net/minecraft/tileentity/TileEntity.java.patch
+++ b/patches/minecraft/net/minecraft/tileentity/TileEntity.java.patch
@@ -1,6 +1,22 @@
 --- ../src-base/minecraft/net/minecraft/tileentity/TileEntity.java
 +++ ../src-work/minecraft/net/minecraft/tileentity/TileEntity.java
-@@ -294,4 +294,106 @@
+@@ -66,6 +66,7 @@
+     public void func_145839_a(NBTTagCompound p_145839_1_)
+     {
+         this.field_174879_c = new BlockPos(p_145839_1_.func_74762_e("x"), p_145839_1_.func_74762_e("y"), p_145839_1_.func_74762_e("z"));
++        if (p_145839_1_.func_74764_b("ForgeData")) this.customTileData = p_145839_1_.func_74775_l("ForgeData");
+     }
+ 
+     public void func_145841_b(NBTTagCompound p_145841_1_)
+@@ -82,6 +83,7 @@
+             p_145841_1_.func_74768_a("x", this.field_174879_c.func_177958_n());
+             p_145841_1_.func_74768_a("y", this.field_174879_c.func_177956_o());
+             p_145841_1_.func_74768_a("z", this.field_174879_c.func_177952_p());
++            if (this.customTileData != null) p_145841_1_.func_74782_a("ForgeData", this.customTileData);
+         }
+     }
+ 
+@@ -294,4 +296,123 @@
          func_145826_a(TileEntityFlowerPot.class, "FlowerPot");
          func_145826_a(TileEntityBanner.class, "Banner");
      }
@@ -105,5 +121,22 @@
 +                block instanceof net.minecraft.block.BlockEnderChest ||
 +                block instanceof net.minecraft.block.BlockSign ||
 +                block instanceof net.minecraft.block.BlockSkull);
++    }
++
++    private NBTTagCompound customTileData;
++
++    /**
++     * Gets a {@link NBTTagCompound} that can be used to store custom data for this tile entity.
++     * It will be written, and read from disc, so it persists over world saves.
++     *
++     * @return A compound tag for custom data
++     */
++    public NBTTagCompound getTileData()
++    {
++        if (this.customTileData == null)
++        {
++            this.customTileData = new NBTTagCompound();
++        }
++        return this.customTileData;
 +    }
  }


### PR DESCRIPTION
This PR adds `getTileData()` to `TileEntity` in the same way that `Entity` has `getEntityData()`.
It can be useful for saving custom data in vanilla TEs.