### PR TITLE
Added a Food/Hunger API

### DIFF
--- a/patches/minecraft/net/minecraft/block/BlockCake.java.patch
+++ b/patches/minecraft/net/minecraft/block/BlockCake.java.patch
@@ -1,0 +1,41 @@
+--- ../src-base/minecraft/net/minecraft/block/BlockCake.java
++++ ../src-work/minecraft/net/minecraft/block/BlockCake.java
+@@ -18,7 +18,7 @@
+ import net.minecraftforge.fml.relauncher.Side;
+ import net.minecraftforge.fml.relauncher.SideOnly;
+ 
+-public class BlockCake extends Block
++public class BlockCake extends Block implements net.minecraftforge.common.food.IEdible
+ {
+     public static final PropertyInteger field_176589_a = PropertyInteger.func_177719_a("bites", 0, 6);
+     private static final String __OBFID = "CL_00000211";
+@@ -84,7 +84,11 @@
+     {
+         if (p_180682_4_.func_71043_e(false))
+         {
+-            p_180682_4_.func_71024_bL().func_75122_a(2, 0.1F);
++            net.minecraftforge.common.food.FoodValues modifiedFoodValues = net.minecraftforge.event.ForgeEventFactory.onBlockFoodEaten(this, p_180682_4_);
++            int prevFoodLevel = p_180682_4_.func_71024_bL().func_75116_a();
++            float prevSaturationLevel = p_180682_4_.func_71024_bL().func_75115_e();
++            p_180682_4_.func_71024_bL().func_75122_a(modifiedFoodValues.hunger, modifiedFoodValues.saturationModifier);
++            net.minecraftforge.event.ForgeEventFactory.onPostBlockFoodEaten(this, modifiedFoodValues, prevFoodLevel, prevSaturationLevel, p_180682_4_);
+             int i = ((Integer)p_180682_3_.func_177229_b(field_176589_a)).intValue();
+ 
+             if (i < 6)
+@@ -162,4 +166,16 @@
+     {
+         return true;
+     }
++
++    @Override
++    public boolean isEdible(net.minecraft.item.ItemStack stack)
++    {
++        return true;
++    }
++
++    @Override
++    public net.minecraftforge.common.food.FoodValues getFoodValues(net.minecraft.item.ItemStack stack)
++    {
++        return new net.minecraftforge.common.food.FoodValues(2, 0.1F);
++    }
+ }

--- a/patches/minecraft/net/minecraft/entity/player/EntityPlayer.java.patch
+++ b/patches/minecraft/net/minecraft/entity/player/EntityPlayer.java.patch
@@ -495,7 +495,7 @@
 @@ -2158,6 +2298,120 @@
          net.minecraftforge.fml.common.network.internal.FMLNetworkHandler.openGui(this, mod, modGuiId, world, x, y, z);
      }
-
+ 
 +
 +    /* ======================================== FORGE START =====================================*/
 +    /**

--- a/patches/minecraft/net/minecraft/entity/player/EntityPlayer.java.patch
+++ b/patches/minecraft/net/minecraft/entity/player/EntityPlayer.java.patch
@@ -1,6 +1,6 @@
 --- ../src-base/minecraft/net/minecraft/entity/player/EntityPlayer.java
 +++ ../src-work/minecraft/net/minecraft/entity/player/EntityPlayer.java
-@@ -77,9 +77,23 @@
+@@ -77,14 +77,28 @@
  import net.minecraft.world.WorldSettings;
  import net.minecraftforge.fml.relauncher.Side;
  import net.minecraftforge.fml.relauncher.SideOnly;
@@ -14,7 +14,7 @@
 +import net.minecraftforge.event.entity.player.PlayerDropsEvent;
 +import net.minecraftforge.event.entity.player.PlayerFlyableFallEvent;
 +import net.minecraftforge.event.entity.player.PlayerSleepInBedEvent;
- 
+
  public abstract class EntityPlayer extends EntityLivingBase
  {
 +    public static final String PERSISTED_NBT_TAG = "PlayerPersisted";
@@ -24,13 +24,19 @@
      public InventoryPlayer field_71071_by = new InventoryPlayer(this);
      private InventoryEnderChest field_71078_a = new InventoryEnderChest();
      public Container field_71069_bz;
+     public Container field_71070_bA;
+-    protected FoodStats field_71100_bB = new FoodStats();
++    protected FoodStats field_71100_bB = new FoodStats(this);
+     protected int field_71101_bC;
+     public float field_71107_bF;
+     public float field_71109_bG;
 @@ -118,6 +132,7 @@
      private final GameProfile field_146106_i;
      private boolean field_175153_bG = false;
      public EntityFishHook field_71104_cf;
 +    public float eyeHeight = this.getDefaultEyeHeight();
      private static final String __OBFID = "CL_00001711";
- 
+
      public EntityPlayer(World p_i45324_1_, GameProfile p_i45324_2_)
 @@ -176,7 +191,8 @@
      {
@@ -40,10 +46,10 @@
 +            if (!net.minecraftforge.event.ForgeEventFactory.onUseItemStop(this, field_71074_e, this.field_71072_f))
 +                this.field_71074_e.func_77974_b(this.field_70170_p, this, this.field_71072_f);
          }
- 
+
          this.func_71041_bz();
 @@ -214,6 +230,14 @@
- 
+
              if (itemstack == this.field_71074_e)
              {
 +                field_71072_f = net.minecraftforge.event.ForgeEventFactory.onItemUseTick(this, field_71074_e, field_71072_f);
@@ -66,9 +72,9 @@
              else
              {
 @@ -268,7 +293,7 @@
- 
+
          super.func_70071_h_();
- 
+
 -        if (!this.field_70170_p.field_72995_K && this.field_71070_bA != null && !this.field_71070_bA.func_75145_c(this))
 +        if (!this.field_70170_p.field_72995_K && this.field_71070_bA != null && !net.minecraftforge.common.ForgeHooks.canInteractWith(this, this.field_71070_bA))
          {
@@ -77,13 +83,13 @@
 @@ -415,11 +440,13 @@
              int i = this.field_71074_e.field_77994_a;
              ItemStack itemstack = this.field_71074_e.func_77950_b(this.field_70170_p, this);
- 
+
 +            itemstack = net.minecraftforge.event.ForgeEventFactory.onItemUseFinish(this, field_71074_e, field_71072_f, itemstack);
 +
              if (itemstack != this.field_71074_e || itemstack != null && itemstack.field_77994_a != i)
              {
                  this.field_71071_by.field_70462_a[this.field_71071_by.field_70461_c] = itemstack;
- 
+
 -                if (itemstack.field_77994_a == 0)
 +                if (itemstack != null && itemstack.field_77994_a == 0)
                  {
@@ -92,7 +98,7 @@
 @@ -479,11 +506,11 @@
              this.field_71109_bG = 0.0F;
              this.func_71015_k(this.field_70165_t - d0, this.field_70163_u - d1, this.field_70161_v - d2);
- 
+
 -            if (this.field_70154_o instanceof EntityPig)
 +            if (this.field_70154_o instanceof EntityLivingBase && ((EntityLivingBase)field_70154_o).shouldRiderFaceForward(this))
              {
@@ -103,8 +109,21 @@
              }
          }
      }
-@@ -613,11 +640,15 @@
- 
+@@ -515,7 +542,11 @@
+         {
+             if (this.func_110143_aJ() < this.func_110138_aP() && this.field_70173_aa % 20 == 0)
+             {
+-                this.func_70691_i(1.0F);
++                net.minecraftforge.event.food.HealthRegenEvent.PeacefulRegen peacefulRegenEvent = net.minecraftforge.event.ForgeEventFactory.firePeacefulRegenEvent(this);
++                if (!peacefulRegenEvent.isCanceled())
++                {
++                    this.func_70691_i(peacefulRegenEvent.deltaHealth);
++                }
+             }
+
+             if (this.field_71100_bB.func_75121_c() && this.field_70173_aa % 10 == 0)
+@@ -613,11 +644,15 @@
+
      public void func_70645_a(DamageSource p_70645_1_)
      {
 +        if (net.minecraftforge.common.ForgeHooks.onLivingDeath(this,  p_70645_1_)) return;
@@ -112,25 +131,25 @@
          this.func_70105_a(0.2F, 0.2F);
          this.func_70107_b(this.field_70165_t, this.field_70163_u, this.field_70161_v);
          this.field_70181_x = 0.10000000149011612D;
- 
+
 +        captureDrops = true;
 +        capturedDrops.clear();
 +
          if (this.func_70005_c_().equals("Notch"))
          {
              this.func_146097_a(new ItemStack(Items.field_151034_e, 1), true, false);
-@@ -628,6 +659,9 @@
+@@ -628,6 +663,9 @@
              this.field_71071_by.func_70436_m();
          }
- 
+
 +        captureDrops = false;
 +        if (!field_70170_p.field_72995_K) net.minecraftforge.event.ForgeEventFactory.onPlayerDrops(this, p_70645_1_, capturedDrops, field_70718_bc > 0);
 +
          if (p_70645_1_ != null)
          {
              this.field_70159_w = (double)(-MathHelper.func_76134_b((this.field_70739_aP + this.field_70177_z) * (float)Math.PI / 180.0F) * 0.1F);
-@@ -716,12 +750,25 @@
- 
+@@ -716,12 +754,25 @@
+
      public EntityItem func_71040_bB(boolean p_71040_1_)
      {
 -        return this.func_146097_a(this.field_71071_by.func_70298_a(this.field_71071_by.field_70461_c, p_71040_1_ && this.field_71071_by.func_70448_g() != null ? this.field_71071_by.func_70448_g().field_77994_a : 1), false, true);
@@ -149,16 +168,16 @@
 +
 +        return null;
      }
- 
+
      public EntityItem func_71019_a(ItemStack p_71019_1_, boolean p_71019_2_)
      {
 -        return this.func_146097_a(p_71019_1_, false, false);
 +        return net.minecraftforge.common.ForgeHooks.onPlayerTossEvent(this, p_71019_1_, false);
      }
- 
+
      public EntityItem func_146097_a(ItemStack p_146097_1_, boolean p_146097_2_, boolean p_146097_3_)
-@@ -782,13 +829,25 @@
- 
+@@ -782,13 +833,25 @@
+
      public void func_71012_a(EntityItem p_71012_1_)
      {
 +        if (captureDrops)
@@ -168,14 +187,14 @@
 +        }
          this.field_70170_p.func_72838_d(p_71012_1_);
      }
- 
+
 +    @Deprecated //Use location sensitive version below
      public float func_180471_a(Block p_180471_1_)
      {
 -        float f = this.field_71071_by.func_146023_a(p_180471_1_);
 +        return getBreakSpeed(p_180471_1_.func_176223_P(), new BlockPos(0, -1, 0));
 +    }
- 
+
 +    public float getBreakSpeed(IBlockState state, BlockPos pos)
 +    {
 +        ItemStack stack = field_71071_by.func_70448_g();
@@ -184,26 +203,26 @@
          if (f > 1.0F)
          {
              int i = EnchantmentHelper.func_77509_b(this);
-@@ -838,12 +897,13 @@
+@@ -838,12 +901,13 @@
              f /= 5.0F;
          }
- 
+
 -        return f;
 +        f = net.minecraftforge.event.ForgeEventFactory.getBreakSpeed(this, state, f, pos);
 +        return (f < 0 ? 0 : f);
      }
- 
+
      public boolean func_146099_a(Block p_146099_1_)
      {
 -        return this.field_71071_by.func_146025_b(p_146099_1_);
 +        return net.minecraftforge.event.ForgeEventFactory.doPlayerHarvestCheck(this, p_146099_1_, this.field_71071_by.func_146025_b(p_146099_1_));
      }
- 
+
      public void func_70037_a(NBTTagCompound p_70037_1_)
-@@ -879,6 +939,16 @@
+@@ -879,6 +943,16 @@
              this.field_82248_d = p_70037_1_.func_74767_n("SpawnForced");
          }
- 
+
 +        NBTTagList spawnlist = null;
 +        spawnlist = p_70037_1_.func_150295_c("Spawns", 10);
 +        for (int i = 0; i < spawnlist.func_74745_c(); i++)
@@ -216,11 +235,11 @@
 +
          this.field_71100_bB.func_75112_a(p_70037_1_);
          this.field_71075_bZ.func_75095_b(p_70037_1_);
- 
-@@ -910,6 +980,23 @@
+
+@@ -910,6 +984,23 @@
              p_70014_1_.func_74757_a("SpawnForced", this.field_82248_d);
          }
- 
+
 +        NBTTagList spawnlist = new NBTTagList();
 +        for (java.util.Map.Entry<Integer, BlockPos> entry : this.spawnChunkMap.entrySet())
 +        {
@@ -241,15 +260,15 @@
          this.field_71100_bB.func_75117_b(p_70014_1_);
          this.field_71075_bZ.func_75091_a(p_70014_1_);
          p_70014_1_.func_74782_a("EnderItems", this.field_71078_a.func_70487_g());
-@@ -923,6 +1010,7 @@
- 
+@@ -923,6 +1014,7 @@
+
      public boolean func_70097_a(DamageSource p_70097_1_, float p_70097_2_)
      {
 +        if (!net.minecraftforge.common.ForgeHooks.onLivingAttack(this, p_70097_1_, p_70097_2_)) return false;
          if (this.func_180431_b(p_70097_1_))
          {
              return false;
-@@ -1023,12 +1111,15 @@
+@@ -1023,12 +1115,15 @@
      {
          if (!this.func_180431_b(p_70665_1_))
          {
@@ -259,41 +278,41 @@
              {
                  p_70665_2_ = (1.0F + p_70665_2_) * 0.5F;
              }
- 
+
 -            p_70665_2_ = this.func_70655_b(p_70665_1_, p_70665_2_);
 +            p_70665_2_ = net.minecraftforge.common.ISpecialArmor.ArmorProperties.applyArmor(this, field_71071_by.field_70460_b, p_70665_1_, p_70665_2_);
 +            if (p_70665_2_ <= 0) return;
              p_70665_2_ = this.func_70672_c(p_70665_1_, p_70665_2_);
              float f1 = p_70665_2_;
              p_70665_2_ = Math.max(p_70665_2_ - this.func_110139_bj(), 0.0F);
-@@ -1076,6 +1167,7 @@
+@@ -1076,6 +1171,7 @@
          }
          else
          {
 +            if (!net.minecraftforge.event.ForgeEventFactory.canInteractWith(this, p_70998_1_)) return false;
              ItemStack itemstack = this.func_71045_bC();
              ItemStack itemstack1 = itemstack != null ? itemstack.func_77946_l() : null;
- 
-@@ -1127,7 +1219,9 @@
- 
+
+@@ -1127,7 +1223,9 @@
+
      public void func_71028_bD()
      {
 +        ItemStack orig = func_71045_bC();
          this.field_71071_by.func_70299_a(this.field_71071_by.field_70461_c, (ItemStack)null);
 +        net.minecraftforge.event.ForgeEventFactory.onPlayerDestroyItem(this, orig);
      }
- 
+
      public double func_70033_W()
-@@ -1137,6 +1231,7 @@
- 
+@@ -1137,6 +1235,7 @@
+
      public void func_71059_n(Entity p_71059_1_)
      {
 +        if (!net.minecraftforge.common.ForgeHooks.onPlayerAttackTarget(this, p_71059_1_)) return;
          if (p_71059_1_.func_70075_an())
          {
              if (!p_71059_1_.func_85031_j(this))
-@@ -1307,6 +1402,8 @@
- 
+@@ -1307,6 +1406,8 @@
+
      public EntityPlayer.EnumStatus func_180469_a(BlockPos p_180469_1_)
      {
 +        EntityPlayer.EnumStatus ret = net.minecraftforge.event.ForgeEventFactory.onPlayerSleepInBed(this, p_180469_1_);
@@ -301,23 +320,23 @@
          if (!this.field_70170_p.field_72995_K)
          {
              if (this.func_70608_bn() || !this.func_70089_S())
-@@ -1348,7 +1445,7 @@
- 
+@@ -1348,7 +1449,7 @@
+
          if (this.field_70170_p.func_175667_e(p_180469_1_))
          {
 -            EnumFacing enumfacing = (EnumFacing)this.field_70170_p.func_180495_p(p_180469_1_).func_177229_b(BlockDirectional.field_176387_N);
 +            EnumFacing enumfacing = this.field_70170_p.func_180495_p(p_180469_1_).func_177230_c().getBedDirection(field_70170_p, p_180469_1_);
              float f = 0.5F;
              float f1 = 0.5F;
- 
-@@ -1411,13 +1508,14 @@
- 
+
+@@ -1411,13 +1512,14 @@
+
      public void func_70999_a(boolean p_70999_1_, boolean p_70999_2_, boolean p_70999_3_)
      {
 +        net.minecraftforge.event.ForgeEventFactory.onPlayerWakeup(this, p_70999_1_, p_70999_2_, p_70999_3_);
          this.func_70105_a(0.6F, 1.8F);
          IBlockState iblockstate = this.field_70170_p.func_180495_p(this.field_71081_bT);
- 
+
 -        if (this.field_71081_bT != null && iblockstate.func_177230_c() == Blocks.field_150324_C)
 +        if (this.field_71081_bT != null && iblockstate.func_177230_c().isBed(field_70170_p, field_71081_bT, this))
          {
@@ -325,17 +344,17 @@
 -            BlockPos blockpos = BlockBed.func_176468_a(this.field_70170_p, this.field_71081_bT, 0);
 +            iblockstate.func_177230_c().setBedOccupied(field_70170_p, field_71081_bT, this, false);
 +            BlockPos blockpos = iblockstate.func_177230_c().getBedSpawnPosition(field_70170_p, field_71081_bT, this);
- 
+
              if (blockpos == null)
              {
-@@ -1444,12 +1542,12 @@
- 
+@@ -1444,12 +1546,12 @@
+
      private boolean func_175143_p()
      {
 -        return this.field_70170_p.func_180495_p(this.field_71081_bT).func_177230_c() == Blocks.field_150324_C;
 +        return this.field_70170_p.func_180495_p(this.field_71081_bT).func_177230_c().isBed(field_70170_p, field_71081_bT, this);
      }
- 
+
      public static BlockPos func_180467_a(World p_180467_0_, BlockPos p_180467_1_, boolean p_180467_2_)
      {
 -        if (p_180467_0_.func_180495_p(p_180467_1_).func_177230_c() != Blocks.field_150324_C)
@@ -343,7 +362,7 @@
          {
              if (!p_180467_2_)
              {
-@@ -1466,7 +1564,7 @@
+@@ -1466,7 +1568,7 @@
          }
          else
          {
@@ -351,31 +370,31 @@
 +            return p_180467_0_.func_180495_p(p_180467_1_).func_177230_c().getBedSpawnPosition(p_180467_0_, p_180467_1_, null);
          }
      }
- 
-@@ -1475,7 +1573,7 @@
+
+@@ -1475,7 +1577,7 @@
      {
          if (this.field_71081_bT != null)
          {
 -            EnumFacing enumfacing = (EnumFacing)this.field_70170_p.func_180495_p(this.field_71081_bT).func_177229_b(BlockDirectional.field_176387_N);
 +            EnumFacing enumfacing = this.field_70170_p.func_180495_p(this.field_71081_bT).func_177230_c().getBedDirection(field_70170_p, field_71081_bT);
- 
+
              switch (EntityPlayer.SwitchEnumFacing.field_179420_a[enumfacing.ordinal()])
              {
-@@ -1513,16 +1611,22 @@
- 
+@@ -1513,16 +1615,22 @@
+
      public BlockPos func_180470_cg()
      {
 -        return this.field_71077_c;
 +        return getBedLocation(this.field_71093_bK);
      }
- 
+
 +    @Deprecated
      public boolean func_82245_bX()
      {
 -        return this.field_82248_d;
 +        return isSpawnForced(this.field_71093_bK);
      }
- 
+
      public void func_180473_a(BlockPos p_180473_1_, boolean p_180473_2_)
      {
 +        if (this.field_71093_bK != 0)
@@ -386,8 +405,8 @@
          if (p_180473_1_ != null)
          {
              this.field_71077_c = p_180473_1_;
-@@ -1704,6 +1808,10 @@
- 
+@@ -1704,6 +1812,10 @@
+
              super.func_180430_e(p_180430_1_, p_180430_2_);
          }
 +        else
@@ -395,9 +414,9 @@
 +            net.minecraftforge.event.ForgeEventFactory.onPlayerFall(this, p_180430_1_, p_180430_2_);
 +        }
      }
- 
+
      protected void func_71061_d_()
-@@ -1840,6 +1948,8 @@
+@@ -1840,6 +1952,8 @@
      {
          if (p_71008_1_ != this.field_71074_e)
          {
@@ -405,8 +424,8 @@
 +            if (p_71008_2_ <= 0) return;
              this.field_71074_e = p_71008_1_;
              this.field_71072_f = p_71008_2_;
- 
-@@ -1909,6 +2019,10 @@
+
+@@ -1909,6 +2023,10 @@
              this.field_71106_cc = p_71049_1_.field_71106_cc;
              this.func_85040_s(p_71049_1_.func_71037_bA());
              this.field_82152_aq = p_71049_1_.field_82152_aq;
@@ -417,8 +436,8 @@
          }
          else if (this.field_70170_p.func_82736_K().func_82766_b("keepInventory"))
          {
-@@ -1921,6 +2035,18 @@
- 
+@@ -1921,6 +2039,18 @@
+
          this.field_71078_a = p_71049_1_.field_71078_a;
          this.func_70096_w().func_75692_b(10, Byte.valueOf(p_71049_1_.func_70096_w().func_75683_a(10)));
 +
@@ -434,10 +453,10 @@
 +        }
 +        net.minecraftforge.event.ForgeEventFactory.onPlayerClone(this, p_71049_1_, !p_71049_2_);
      }
- 
+
      protected boolean func_70041_e_()
-@@ -1954,7 +2080,14 @@
- 
+@@ -1954,7 +2084,14 @@
+
      public void func_70062_b(int p_70062_1_, ItemStack p_70062_2_)
      {
 -        this.field_71071_by.field_70460_b[p_70062_1_] = p_70062_2_;
@@ -450,10 +469,10 @@
 +            this.field_71071_by.field_70460_b[p_70062_1_ - 1] = p_70062_2_;
 +        }
      }
- 
+
      @SideOnly(Side.CLIENT)
-@@ -1999,7 +2132,10 @@
- 
+@@ -1999,7 +2136,10 @@
+
      public IChatComponent func_145748_c_()
      {
 -        ChatComponentText chatcomponenttext = new ChatComponentText(ScorePlayerTeam.func_96667_a(this.func_96124_cp(), this.func_70005_c_()));
@@ -464,19 +483,19 @@
          chatcomponenttext.func_150256_b().func_150241_a(new ClickEvent(ClickEvent.Action.SUGGEST_COMMAND, "/msg " + this.func_70005_c_() + " "));
          chatcomponenttext.func_150256_b().func_150209_a(this.func_174823_aP());
          chatcomponenttext.func_150256_b().func_179989_a(this.func_70005_c_());
-@@ -2008,7 +2144,7 @@
- 
+@@ -2008,7 +2148,7 @@
+
      public float func_70047_e()
      {
 -        float f = 1.62F;
 +        float f = eyeHeight;
- 
+
          if (this.func_70608_bn())
          {
-@@ -2158,6 +2294,120 @@
+@@ -2158,6 +2298,120 @@
          net.minecraftforge.fml.common.network.internal.FMLNetworkHandler.openGui(this, mod, modGuiId, world, x, y, z);
      }
- 
+
 +
 +    /* ======================================== FORGE START =====================================*/
 +    /**
@@ -570,22 +589,22 @@
 +    {
 +        this.displayname = ForgeEventFactory.getPlayerDisplayName(this, this.func_70005_c_());
 +    }
-+    
++
 +    private final java.util.Collection<net.minecraft.util.IChatComponent> prefixes = new java.util.LinkedList<net.minecraft.util.IChatComponent>();
 +    private final java.util.Collection<net.minecraft.util.IChatComponent> suffixes = new java.util.LinkedList<net.minecraft.util.IChatComponent>();
-+    
++
 +    /**
 +     * Add a prefix to the player's username in chat
 +     * @param prefix The prefix
 +     */
 +    public void addPrefix(net.minecraft.util.IChatComponent prefix) { prefixes.add(prefix); }
-+    
++
 +    /**
 +     * Add a suffix to the player's username in chat
 +     * @param suffix The suffix
 +     */
 +    public void addSuffix(net.minecraft.util.IChatComponent suffix) { suffixes.add(suffix); }
-+    
++
 +    public java.util.Collection<net.minecraft.util.IChatComponent> getPrefixes() { return this.prefixes; }
 +    public java.util.Collection<net.minecraft.util.IChatComponent> getSuffixes() { return this.suffixes; }
 +

--- a/patches/minecraft/net/minecraft/item/ItemFood.java.patch
+++ b/patches/minecraft/net/minecraft/item/ItemFood.java.patch
@@ -1,0 +1,28 @@
+--- ../src-base/minecraft/net/minecraft/item/ItemFood.java
++++ ../src-work/minecraft/net/minecraft/item/ItemFood.java
+@@ -6,7 +6,7 @@
+ import net.minecraft.stats.StatList;
+ import net.minecraft.world.World;
+ 
+-public class ItemFood extends Item
++public class ItemFood extends Item implements net.minecraftforge.common.food.IEdible
+ {
+     public final int field_77855_a;
+     private final int field_77853_b;
+@@ -100,4 +100,16 @@
+         this.field_77852_bZ = true;
+         return this;
+     }
++
++    @Override
++    public boolean isEdible(ItemStack stack)
++    {
++        return true;
++    }
++
++    @Override
++    public net.minecraftforge.common.food.FoodValues getFoodValues(ItemStack stack)
++    {
++        return new net.minecraftforge.common.food.FoodValues(func_150905_g(stack), func_150906_h(stack));
++    }
+ }

--- a/patches/minecraft/net/minecraft/util/FoodStats.java.patch
+++ b/patches/minecraft/net/minecraft/util/FoodStats.java.patch
@@ -1,0 +1,132 @@
+--- ../src-base/minecraft/net/minecraft/util/FoodStats.java
++++ ../src-work/minecraft/net/minecraft/util/FoodStats.java
+@@ -16,16 +16,36 @@
+     private int field_75123_d;
+     private int field_75124_e = 20;
+     private static final String __OBFID = "CL_00001729";
++    //FORGE START
++    private EntityPlayer player;
++    private int starveTimer;
++    //FORGE END
+ 
++    @Deprecated //Forge: Provided for backwards compatibility. Use the Player-specific constructor instead.
++    public FoodStats()
++    {
++        this.player = null;
++    }
++
++    public FoodStats(EntityPlayer player)
++    {
++        this.player = player;
++    }
++
+     public void func_75122_a(int p_75122_1_, float p_75122_2_)
+     {
++        if(!net.minecraftforge.event.ForgeEventFactory.canAddFoodStats(player, new net.minecraftforge.common.food.FoodValues(p_75122_1_, p_75122_2_))) return;
+         this.field_75127_a = Math.min(p_75122_1_ + this.field_75127_a, 20);
+         this.field_75125_b = Math.min(this.field_75125_b + (float)p_75122_1_ * p_75122_2_ * 2.0F, (float)this.field_75127_a);
+     }
+ 
+     public void func_151686_a(ItemFood p_151686_1_, ItemStack p_151686_2_)
+     {
+-        this.func_75122_a(p_151686_1_.func_150905_g(p_151686_2_), p_151686_1_.func_150906_h(p_151686_2_));
++        net.minecraftforge.common.food.FoodValues modifiedFoodValues = net.minecraftforge.event.ForgeEventFactory.onFoodStatsAdded(p_151686_2_, this.player);
++        int prevFoodLevel = this.field_75127_a;
++        float prevSaturationLevel = this.field_75125_b;
++        this.func_75122_a(modifiedFoodValues.hunger, modifiedFoodValues.saturationModifier);
++        net.minecraftforge.event.ForgeEventFactory.onPostFoodStatsAdded(p_151686_2_, modifiedFoodValues, this.field_75127_a - prevFoodLevel, this.field_75125_b - prevSaturationLevel, this.player);
+     }
+ 
+     public void func_75118_a(EntityPlayer p_75118_1_)
+@@ -33,48 +53,59 @@
+         EnumDifficulty enumdifficulty = p_75118_1_.field_70170_p.func_175659_aa();
+         this.field_75124_e = this.field_75127_a;
+ 
+-        if (this.field_75126_c > 4.0F)
++        net.minecraftforge.fml.common.eventhandler.Event.Result allowExhaustionResult = net.minecraftforge.event.ForgeEventFactory.fireAllowExhaustionEvent(p_75118_1_);
++        float maxExhaustion = net.minecraftforge.event.ForgeEventFactory.fireExhaustionTickEvent(p_75118_1_);
++        if (allowExhaustionResult == net.minecraftforge.fml.common.eventhandler.Event.Result.ALLOW || (allowExhaustionResult == net.minecraftforge.fml.common.eventhandler.Event.Result.DEFAULT && this.field_75126_c >= maxExhaustion))
+         {
+-            this.field_75126_c -= 4.0F;
++            net.minecraftforge.event.food.ExhaustionEvent.Exhausted exhaustedEvent = net.minecraftforge.event.ForgeEventFactory.fireExhaustionMaxEvent(p_75118_1_, maxExhaustion, field_75126_c);
+ 
+-            if (this.field_75125_b > 0.0F)
++            this.field_75126_c += exhaustedEvent.deltaExhaustion;
++            if (!exhaustedEvent.isCanceled())
+             {
+-                this.field_75125_b = Math.max(this.field_75125_b - 1.0F, 0.0F);
++                this.field_75125_b = Math.max(this.field_75125_b + exhaustedEvent.deltaSaturation, 0.0F);
++                this.field_75127_a = Math.max(this.field_75127_a + exhaustedEvent.deltaHunger, 0);
+             }
+-            else if (enumdifficulty != EnumDifficulty.PEACEFUL)
+-            {
+-                this.field_75127_a = Math.max(this.field_75127_a - 1, 0);
+-            }
+         }
+ 
+-        if (p_75118_1_.field_70170_p.func_82736_K().func_82766_b("naturalRegeneration") && this.field_75127_a >= 18 && p_75118_1_.func_70996_bM())
++        net.minecraftforge.fml.common.eventhandler.Event.Result allowRegenResult = net.minecraftforge.event.ForgeEventFactory.fireAllowRegenEvent(p_75118_1_);
++        if (allowRegenResult == net.minecraftforge.fml.common.eventhandler.Event.Result.ALLOW || (allowRegenResult == net.minecraftforge.fml.common.eventhandler.Event.Result.DEFAULT && p_75118_1_.field_70170_p.func_82736_K().func_82766_b("naturalRegeneration") && this.field_75127_a >= 18 && p_75118_1_.func_70996_bM()))
+         {
+             ++this.field_75123_d;
+ 
+-            if (this.field_75123_d >= 80)
++            if (this.field_75123_d >= net.minecraftforge.event.ForgeEventFactory.fireRegenTickEvent(p_75118_1_))
+             {
+-                p_75118_1_.func_70691_i(1.0F);
+-                this.func_75113_a(3.0F);
++                net.minecraftforge.event.food.HealthRegenEvent.Regen regenEvent = net.minecraftforge.event.ForgeEventFactory.fireRegenEvent(p_75118_1_);
++                if (!regenEvent.isCanceled())
++                {
++                    p_75118_1_.func_70691_i(regenEvent.deltaHealth);
++                    this.func_75113_a(regenEvent.deltaExhaustion);
++                }
+                 this.field_75123_d = 0;
+             }
+         }
+-        else if (this.field_75127_a <= 0)
++        else
+         {
+-            ++this.field_75123_d;
++            this.field_75123_d = 0;
++        }
+ 
+-            if (this.field_75123_d >= 80)
++        net.minecraftforge.fml.common.eventhandler.Event.Result allowStarvationResult = net.minecraftforge.event.ForgeEventFactory.fireAllowStarvation(p_75118_1_);
++        if (allowStarvationResult == net.minecraftforge.fml.common.eventhandler.Event.Result.ALLOW || (allowStarvationResult == net.minecraftforge.fml.common.eventhandler.Event.Result.DEFAULT && this.field_75127_a <= 0))
++        {
++            ++this.starveTimer;
++
++            if (this.starveTimer >= net.minecraftforge.event.ForgeEventFactory.fireStarvationTickEvent(p_75118_1_))
+             {
+-                if (p_75118_1_.func_110143_aJ() > 10.0F || enumdifficulty == EnumDifficulty.HARD || p_75118_1_.func_110143_aJ() > 1.0F && enumdifficulty == EnumDifficulty.NORMAL)
++                net.minecraftforge.event.food.StarvationEvent.Starve starveEvent = net.minecraftforge.event.ForgeEventFactory.fireStarveEvent(p_75118_1_);
++                if (!starveEvent.isCanceled())
+                 {
+-                    p_75118_1_.func_70097_a(DamageSource.field_76366_f, 1.0F);
++                    p_75118_1_.func_70097_a(DamageSource.field_76366_f, starveEvent.starveDamage);
+                 }
+-
+-                this.field_75123_d = 0;
++                this.starveTimer = 0;
+             }
+         }
+         else
+         {
+-            this.field_75123_d = 0;
++            this.starveTimer = 0;
+         }
+     }
+ 
+@@ -133,4 +164,11 @@
+     {
+         this.field_75125_b = p_75119_1_;
+     }
++
++    /* ======================================== FORGE START ===================================== */
++    public float getExhaustionLevel()
++    {
++        return field_75126_c;
++    }
++    /* ========================================= FORGE END ====================================== */
+ }

--- a/src/main/java/net/minecraftforge/common/food/FoodAccess.java
+++ b/src/main/java/net/minecraftforge/common/food/FoodAccess.java
@@ -1,0 +1,96 @@
+package net.minecraftforge.common.food;
+
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.init.Items;
+import net.minecraft.item.EnumAction;
+import net.minecraft.item.ItemBlock;
+import net.minecraft.item.ItemFood;
+import net.minecraft.item.ItemStack;
+import net.minecraftforge.common.MinecraftForge;
+import net.minecraftforge.event.food.ExhaustionEvent;
+import net.minecraftforge.event.food.FoodEvent;
+import net.minecraftforge.event.food.HealthRegenEvent;
+import net.minecraftforge.event.food.StarvationEvent;
+
+public class FoodAccess {
+
+
+    public static IEdible getEdible(ItemStack food)
+    {
+        if(food.getItem() instanceof IEdible)
+            return (IEdible)food.getItem();
+        else if(food.getItem() instanceof ItemBlock && ((ItemBlock)food.getItem()).block instanceof IEdible)
+            return (IEdible)((ItemBlock)food.getItem()).block;
+        else
+            return null;
+    }
+
+    public static boolean isFood(ItemStack food)
+    {
+        return getEdible(food) != null;
+    }
+
+    public static boolean isEdible(ItemStack food)
+    {
+        IEdible edible = getEdible(food);
+        return edible != null && edible.isEdible(food);
+    }
+
+    public static FoodValues getFoodValues(ItemStack food)
+    {
+        FoodValues foodValues = getUnmodifiedFoodValues(food);
+        if (foodValues != null)
+        {
+            FoodEvent.GetFoodValues event = new FoodEvent.GetFoodValues(food, foodValues);
+            MinecraftForge.EVENT_BUS.post(event);
+            return event.foodValues;
+        }
+        return null;
+    }
+
+    public static FoodValues getFoodValuesForPlayer(ItemStack food, EntityPlayer player)
+    {
+        FoodValues foodValues = getFoodValues(food);
+        if (foodValues != null)
+        {
+            FoodEvent.GetPlayerFoodValues event = new FoodEvent.GetPlayerFoodValues(player, food, foodValues);
+            MinecraftForge.EVENT_BUS.post(event);
+            return event.foodValues;
+        }
+        return null;
+    }
+
+    public static FoodValues getUnmodifiedFoodValues(ItemStack food)
+    {
+        if (isEdible(food))
+            return getEdible(food).getFoodValues(food);
+
+        return null;
+    }
+
+    public static float getExhaustion(EntityPlayer player)
+    {
+        return player.getFoodStats().getExhaustionLevel();
+    }
+
+    public static float getMaxExhaustion(EntityPlayer player)
+    {
+        ExhaustionEvent.GetMaxExhaustion event = new ExhaustionEvent.GetMaxExhaustion(player);
+        MinecraftForge.EVENT_BUS.post(event);
+        return event.maxExhaustionLevel;
+    }
+
+    public static int getHealthRegenTickPeriod(EntityPlayer player)
+    {
+        HealthRegenEvent.GetRegenTickPeriod event = new HealthRegenEvent.GetRegenTickPeriod(player);
+        MinecraftForge.EVENT_BUS.post(event);
+        return event.regenTickPeriod;
+    }
+
+    public static int getStarveDamageTickPeriod(EntityPlayer player)
+    {
+        StarvationEvent.GetStarveTickPeriod event = new StarvationEvent.GetStarveTickPeriod(player);
+        MinecraftForge.EVENT_BUS.post(event);
+        return event.starveTickPeriod;
+    }
+}

--- a/src/main/java/net/minecraftforge/common/food/FoodValues.java
+++ b/src/main/java/net/minecraftforge/common/food/FoodValues.java
@@ -1,0 +1,80 @@
+package net.minecraftforge.common.food;
+
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.item.ItemStack;
+
+public class FoodValues
+{
+    public final int hunger;
+    public final float saturationModifier;
+
+    public FoodValues(int hunger, float saturationModifier)
+    {
+        this.hunger = hunger;
+        this.saturationModifier = saturationModifier;
+    }
+
+    public FoodValues(FoodValues other)
+    {
+        this(other.hunger, other.saturationModifier);
+    }
+
+    /**
+     * @return The amount of saturation that the food values would provide.
+     */
+    public float getSaturationIncrement()
+    {
+        return Math.min(20, hunger * saturationModifier * 2f);
+    }
+
+    /**
+     * See {@link FoodAccess#getUnmodifiedFoodValues}
+     */
+    public static FoodValues getUnmodified(ItemStack itemStack)
+    {
+        return FoodAccess.getUnmodifiedFoodValues(itemStack);
+    }
+
+    /**
+     * See {@link FoodAccess#getFoodValues}
+     */
+    public static FoodValues get(ItemStack itemStack)
+    {
+        return FoodAccess.getFoodValues(itemStack);
+    }
+
+    /**
+     * See {@link FoodAccess#getFoodValuesForPlayer}
+     */
+    public static FoodValues get(ItemStack itemStack, EntityPlayer player)
+    {
+        return FoodAccess.getFoodValuesForPlayer(itemStack, player);
+    }
+
+    @Override
+    public int hashCode()
+    {
+        final int prime = 31;
+        int result = 1;
+        result = prime * result + hunger;
+        result = prime * result + Float.floatToIntBits(saturationModifier);
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object obj)
+    {
+        if (this == obj)
+            return true;
+        if (obj == null)
+            return false;
+        if (getClass() != obj.getClass())
+            return false;
+        FoodValues other = (FoodValues) obj;
+        if (hunger != other.hunger)
+            return false;
+        if (Float.floatToIntBits(saturationModifier) != Float.floatToIntBits(other.saturationModifier))
+            return false;
+        return true;
+    }
+}

--- a/src/main/java/net/minecraftforge/common/food/IEdible.java
+++ b/src/main/java/net/minecraftforge/common/food/IEdible.java
@@ -1,0 +1,13 @@
+package net.minecraftforge.common.food;
+
+import net.minecraft.item.ItemStack;
+
+/**
+ * An interface for edible objects that should add hunger and saturation to the player.
+ */
+public interface IEdible
+{
+    boolean isEdible(ItemStack stack);
+
+    FoodValues getFoodValues(ItemStack stack);
+}

--- a/src/main/java/net/minecraftforge/event/food/ExhaustionEvent.java
+++ b/src/main/java/net/minecraftforge/event/food/ExhaustionEvent.java
@@ -1,0 +1,109 @@
+package net.minecraftforge.event.food;
+
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.world.EnumDifficulty;
+import net.minecraftforge.fml.common.eventhandler.Cancelable;
+import net.minecraftforge.fml.common.eventhandler.Event;
+
+/**
+ * Base class for all ExhaustionEvent events.<br>
+ * <br>
+ * All children of this event are fired on the {@link MinecraftForge#EVENT_BUS}.
+ */
+public abstract class ExhaustionEvent extends Event
+{
+    public final EntityPlayer player;
+
+    public ExhaustionEvent(EntityPlayer player)
+    {
+        this.player = player;
+    }
+
+    /**
+     * Fired each FoodStats update to determine whether or not exhaustion is allowed for the {@link #player}.
+     *
+     * This event is fired in {@link FoodStats#onUpdate}.<br>
+     * <br>
+     * This event is not {@link Cancelable}.<br>
+     * <br>
+     * This event uses the {@link Result}. {@link HasResult}<br>
+     * {@link Result#DEFAULT} will use the vanilla conditionals.<br>
+     * {@link Result#ALLOW} will allow exhaustion without condition.<br>
+     * {@link Result#DENY} will deny exhaustion without condition.<br>
+     */
+    @HasResult
+    public static class AllowExhaustion extends ExhaustionEvent
+    {
+        public AllowExhaustion(EntityPlayer player)
+        {
+            super(player);
+        }
+    }
+
+    /**
+     * Fired every time max exhaustion level is retrieved to allow control over its value.
+     *
+     * This event is fired in {@link FoodStats#onUpdate}.<br>
+     * <br>
+     * {@link #maxExhaustionLevel} contains the exhaustion level that will trigger a hunger/saturation decrement.<br>
+     * <br>
+     * This event is not {@link Cancelable}.<br>
+     * <br>
+     * This event does not have a result. {@link HasResult}<br>
+     */
+    public static class GetMaxExhaustion extends ExhaustionEvent
+    {
+        public float maxExhaustionLevel = 4f;
+
+        public GetMaxExhaustion(EntityPlayer player)
+        {
+            super(player);
+        }
+    }
+
+    /**
+     * Fired once exchaustionLevel exceeds maxExhaustionLevel (see {@link GetMaxExhaustion}),
+     * in order to control how exhaustion affects hunger/saturation.
+     *
+     * This event is fired in {@link FoodStats#onUpdate}.<br>
+     * <br>
+     * {@link #currentExhaustionLevel} contains the exhaustion level of the {@link #player}.<br>
+     * {@link #deltaExhaustion} contains the delta to be applied to exhaustion level (default: {@link GetMaxExhaustion#maxExhaustionLevel}).<br>
+     * {@link #deltaHunger} contains the delta to be applied to hunger.<br>
+     * {@link #deltaSaturation} contains the delta to be applied to saturation.<br>
+     * <br>
+     * Note: {@link #deltaHunger} and {@link #deltaSaturation} will vary depending on their vanilla conditionals.
+     * For example, deltaHunger will be 0 when this event is fired in Peaceful difficulty.<br>
+     * <br>
+     * This event is {@link Cancelable}.<br>
+     * If this event is canceled, it will skip applying the delta values to hunger and saturation.<br>
+     * <br>
+     * This event does not have a result. {@link HasResult}<br>
+     */
+    @Cancelable
+    public static class Exhausted extends ExhaustionEvent
+    {
+        public final float currentExhaustionLevel;
+        public float deltaExhaustion;
+        public int deltaHunger = -1;
+        public float deltaSaturation = -1f;
+
+        public Exhausted(EntityPlayer player, float exhaustionToRemove, float currentExhaustionLevel)
+        {
+            super(player);
+            this.deltaExhaustion = -exhaustionToRemove;
+            this.currentExhaustionLevel = currentExhaustionLevel;
+
+            boolean shouldDecreaseSaturationLevel = player.getFoodStats().getSaturationLevel() > 0f;
+
+            if (!shouldDecreaseSaturationLevel)
+                deltaSaturation = 0f;
+
+            EnumDifficulty difficulty = player.worldObj.getDifficulty();
+            boolean shouldDecreaseFoodLevel = !shouldDecreaseSaturationLevel && difficulty != EnumDifficulty.PEACEFUL;
+
+            if (!shouldDecreaseFoodLevel)
+                deltaHunger = 0;
+        }
+    }
+}

--- a/src/main/java/net/minecraftforge/event/food/FoodEvent.java
+++ b/src/main/java/net/minecraftforge/event/food/FoodEvent.java
@@ -1,0 +1,123 @@
+package net.minecraftforge.event.food;
+
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.item.ItemStack;
+import net.minecraftforge.common.food.FoodValues;
+import net.minecraftforge.fml.common.eventhandler.Cancelable;
+import net.minecraftforge.fml.common.eventhandler.Event;
+
+/**
+ * Base class for all FoodEvent events.<br>
+ * <br>
+ * All children of this event are fired on the {@link MinecraftForge#EVENT_BUS}.
+ */
+public abstract class FoodEvent extends Event
+{
+    /**
+     * Fired every time food values are retrieved to allow player-independent control over their values.
+     *
+     * This event is fired in {@link FoodStats#addStats(ItemFood, ItemStack)}.<br>
+     * <br>
+     * {@link #foodValues} contains the values of the {@link #food}.<br>
+     * {@link #unmodifiedFoodValues} contains the food values of the {@link #food} before the GetFoodValues event was fired.<br>
+     * {@link #food} contains the food in question.<br>
+     * <br>
+     * This event is not {@link Cancelable}.<br>
+     * <br>
+     * This event does not have a result. {@link HasResult}<br>
+     */
+    public static class GetFoodValues extends FoodEvent
+    {
+        public FoodValues foodValues;
+        public final FoodValues unmodifiedFoodValues;
+        public final ItemStack food;
+
+        public GetFoodValues(ItemStack itemStack, FoodValues foodValues)
+        {
+            this.food = itemStack;
+            this.foodValues = foodValues;
+            this.unmodifiedFoodValues = foodValues;
+        }
+    }
+
+    /**
+     * Fired every time food values are retrieved to allow player-dependent control over their values.
+     * This event will always be preceded by {@link GetFoodValues} being fired.
+     *
+     * This event is fired in {@link FoodStats#addStats(ItemFood, ItemStack)}.<br>
+     * <br>
+     * {@link #player} contains the player.<br>
+     * {@link #foodValues} contains the values of the {@link #food}.<br>
+     * {@link #unmodifiedFoodValues} contains the food values of the {@link #food} before the GetFoodValues event was fired.<br>
+     * {@link #food} contains the food in question.<br>
+     * <br>
+     * This event is not {@link Cancelable}.<br>
+     * <br>
+     * This event does not have a result. {@link HasResult}<br>
+     */
+    public static class GetPlayerFoodValues extends FoodEvent
+    {
+        public FoodValues foodValues;
+        public final FoodValues unmodifiedFoodValues;
+        public final ItemStack food;
+        public final EntityPlayer player;
+
+        public GetPlayerFoodValues(EntityPlayer player, ItemStack itemStack, FoodValues foodValues)
+        {
+            this.player = player;
+            this.food = itemStack;
+            this.foodValues = foodValues;
+            this.unmodifiedFoodValues = foodValues;
+        }
+    }
+
+    /**
+     * Fired after {@link FoodStats#addStats}, containing the effects and context for the food that was eaten.
+     *
+     * This event is fired in {@link FoodStats#addStats(ItemFood, ItemStack)}.<br>
+     * <br>
+     * This event is not {@link Cancelable}.<br>
+     * <br>
+     * This event does not have a result. {@link HasResult}<br>
+     */
+    public static class FoodEaten extends FoodEvent
+    {
+        public final FoodValues foodValues;
+        public final int hungerAdded;
+        public final float saturationAdded;
+        public final ItemStack food;
+        public final EntityPlayer player;
+
+        public FoodEaten(EntityPlayer player, ItemStack itemStack, FoodValues foodValues, int hungerAdded, float saturationAdded)
+        {
+            this.player = player;
+            this.food = itemStack;
+            this.foodValues = foodValues;
+            this.hungerAdded = hungerAdded;
+            this.saturationAdded = saturationAdded;
+        }
+    }
+
+    /**
+     * Fired when hunger/saturation is added to a player's FoodStats.
+     *
+     * This event is fired in {@link FoodStats#addStats(int, float)}.<br>
+     * <br>
+     * This event is {@link Cancelable}.<br>
+     * If this event is canceled, the hunger and saturation of the FoodStats will not change.<br>
+     * <br>
+     * This event does not have a result. {@link HasResult}<br>
+     */
+    @Cancelable
+    public static class FoodStatsAddition extends FoodEvent
+    {
+        public final FoodValues foodValuesToBeAdded;
+        public final EntityPlayer player;
+
+        public FoodStatsAddition(EntityPlayer player, FoodValues foodValuesToBeAdded)
+        {
+            this.player = player;
+            this.foodValuesToBeAdded = foodValuesToBeAdded;
+        }
+    }
+}

--- a/src/main/java/net/minecraftforge/event/food/HealthRegenEvent.java
+++ b/src/main/java/net/minecraftforge/event/food/HealthRegenEvent.java
@@ -1,0 +1,114 @@
+package net.minecraftforge.event.food;
+
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraftforge.fml.common.eventhandler.Cancelable;
+import net.minecraftforge.fml.common.eventhandler.Event;
+
+/**
+ * Base class for all HealthRegenEvent events.<br>
+ * <br>
+ * All children of this event are fired on the {@link MinecraftForge#EVENT_BUS}.
+ */
+public abstract class HealthRegenEvent extends Event
+{
+    public final EntityPlayer player;
+
+    public HealthRegenEvent(EntityPlayer player)
+    {
+        this.player = player;
+    }
+
+    /**
+     * Fired each FoodStats update to determine whether or not health regen from food is allowed for the {@link #player}.
+     *
+     * This event is fired in {@link FoodStats#onUpdate}.<br>
+     * <br>
+     * This event is not {@link Cancelable}.<br>
+     * <br>
+     * This event uses the {@link Result}. {@link HasResult}<br>
+     * {@link Result#DEFAULT} will use the vanilla conditionals.<br>
+     * {@link Result#ALLOW} will allow regen without condition.<br>
+     * {@link Result#DENY} will deny regen without condition.<br>
+     */
+    @HasResult
+    public static class AllowRegen extends HealthRegenEvent
+    {
+        public AllowRegen(EntityPlayer player)
+        {
+            super(player);
+        }
+    }
+
+    /**
+     * Fired every time the regen tick period is retrieved to allow control over its value.
+     *
+     * This event is fired in {@link FoodStats#onUpdate}.<br>
+     * <br>
+     * {@link #regenTickPeriod} contains the number of ticks between each regen.<br>
+     * <br>
+     * This event is not {@link Cancelable}.<br>
+     * <br>
+     * This event does not have a {@link Result}. {@link HasResult}<br>
+     */
+    public static class GetRegenTickPeriod extends HealthRegenEvent
+    {
+        public int regenTickPeriod = 80;
+
+        public GetRegenTickPeriod(EntityPlayer player)
+        {
+            super(player);
+        }
+    }
+
+    /**
+     * Fired once the ticks since last regen reaches regenTickPeriod (see {@link GetRegenTickPeriod}),
+     * in order to control how regen affects health/exhaustion.
+     *
+     * This event is fired in {@link FoodStats#onUpdate}.<br>
+     * <br>
+     * {@link #deltaHealth} contains the delta to be applied to health.<br>
+     * {@link #deltaExhaustion} contains the delta to be applied to exhaustion level.<br>
+     * <br>
+     * This event is {@link Cancelable}.<br>
+     * If this event is canceled, it will skip applying the delta values to health and exhaustion.<br>
+     * <br>
+     * This event does not have a {@link Result}. {@link HasResult}<br>
+     */
+    @Cancelable
+    public static class Regen extends HealthRegenEvent
+    {
+        public float deltaHealth = 1f;
+        public float deltaExhaustion = 3f;
+
+        public Regen(EntityPlayer player)
+        {
+            super(player);
+        }
+    }
+
+    /**
+     * Fired every second for each player while in Peaceful difficulty,
+     * in order to control how much health to passively regenerate.
+     *
+     * This event is fired in {@link EntityPlayer#onLivingUpdate}.<br>
+     * <br>
+     * This event is never fired if the game rule "naturalRegeneration" is false.<br>
+     * <br>
+     * {@link #deltaHealth} contains the delta to be applied to health.<br>
+     * <br>
+     * This event is {@link Cancelable}.<br>
+     * If this event is canceled, it will skip healing the player.<br>
+     * <br>
+     * This event does not have a {@link Result}. {@link HasResult}<br>
+     */
+    @Cancelable
+    public static class PeacefulRegen extends HealthRegenEvent
+    {
+        public float deltaHealth = 1f;
+
+        public PeacefulRegen(EntityPlayer player)
+        {
+            super(player);
+        }
+    }
+}

--- a/src/main/java/net/minecraftforge/event/food/StarvationEvent.java
+++ b/src/main/java/net/minecraftforge/event/food/StarvationEvent.java
@@ -1,0 +1,93 @@
+package net.minecraftforge.event.food;
+
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.world.EnumDifficulty;
+import net.minecraftforge.fml.common.eventhandler.Cancelable;
+import net.minecraftforge.fml.common.eventhandler.Event;
+
+/**
+ * Base class for all StarvationEvent events.<br>
+ * <br>
+ * All children of this event are fired on the {@link MinecraftForge#EVENT_BUS}.
+ */
+public abstract class StarvationEvent extends Event
+{
+    public final EntityPlayer player;
+
+    public StarvationEvent(EntityPlayer player)
+    {
+        this.player = player;
+    }
+
+    /**
+     * Fired each FoodStats update to determine whether or not starvation is allowed for the {@link #player}.
+     *
+     * This event is fired in {@link FoodStats#onUpdate}.<br>
+     * <br>
+     * This event is not {@link Cancelable}.<br>
+     * <br>
+     * This event uses the {@link Result}. {@link HasResult}<br>
+     * {@link Result#DEFAULT} will use the vanilla conditionals.
+     * {@link Result#ALLOW} will allow starvation without condition.
+     * {@link Result#DENY} will deny starvation without condition.
+     */
+    @HasResult
+    public static class AllowStarvation extends StarvationEvent
+    {
+        public AllowStarvation(EntityPlayer player)
+        {
+            super(player);
+        }
+    }
+
+    /**
+     * Fired every time the starve tick period is retrieved to allow control over its value.
+     *
+     * This event is fired in {@link FoodStats#onUpdate}.<br>
+     * <br>
+     * {@link #starveTickPeriod} contains the number of ticks between starvation damage being done.<br>
+     * <br>
+     * This event is not {@link Cancelable}.<br>
+     * <br>
+     * This event does not have a {@link Result}. {@link HasResult}<br>
+     */
+    public static class GetStarveTickPeriod extends StarvationEvent
+    {
+        public int starveTickPeriod = 80;
+
+        public GetStarveTickPeriod(EntityPlayer player)
+        {
+            super(player);
+        }
+    }
+
+    /**
+     * Fired once the time since last starvation damage reaches starveTickPeriod (see {@link GetStarveTickPeriod}),
+     * in order to control how much starvation damage to do.
+     *
+     * This event is fired in {@link FoodStats#onUpdate}.<br>
+     * <br>
+     * {@link #starveDamage} contains the amount of damage to deal from starvation.<br>
+     * <br>
+     * This event is {@link Cancelable}.<br>
+     * If this event is canceled, it will skip dealing starvation damage.<br>
+     * <br>
+     * This event does not have a {@link Result}. {@link HasResult}<br>
+     */
+    @Cancelable
+    public static class Starve extends StarvationEvent
+    {
+        public float starveDamage = 1f;
+
+        public Starve(EntityPlayer player)
+        {
+            super(player);
+
+            EnumDifficulty difficulty = player.worldObj.getDifficulty();
+            boolean shouldDoDamage = player.getHealth() > 10.0F || difficulty == EnumDifficulty.HARD || player.getHealth() > 1.0F && difficulty == EnumDifficulty.NORMAL;
+
+            if (!shouldDoDamage)
+                starveDamage = 0f;
+        }
+    }
+}


### PR DESCRIPTION
This adds various events and utilities to help with the manipulation of Food and the Hunger system.

This code has been lifted from AppleCore, and documentation on all this can be found here: https://github.com/squeek502/AppleCore/wiki/Using-the-AppleCore-API under the first two bullet points in the Events section, and the Accessor section.

Also, tagging @squeek502, as this is his original code. I just took it out of his mod and lifted it into forge for all to have! (with permission of course :P)