### PR TITLE
Added EntitySpawnPlacementHelper

### DIFF
--- a/patches/minecraft/net/minecraft/world/SpawnerAnimals.java.patch
+++ b/patches/minecraft/net/minecraft/world/SpawnerAnimals.java.patch
@@ -28,6 +28,15 @@
                          label115:
  
                          while (iterator1.hasNext())
+@@ -137,7 +144,7 @@
+                                                         }
+                                                     }
+ 
+-                                                    if (p_77192_1_.func_175732_a(enumcreaturetype, spawnlistentry, blockpos1) && func_180267_a(EntitySpawnPlacementRegistry.func_180109_a(spawnlistentry.field_76300_b), p_77192_1_, blockpos1))
++                                                    if (p_77192_1_.func_175732_a(enumcreaturetype, spawnlistentry, blockpos1) && net.minecraftforge.common.EntitySpawnPlacementHelper.canCreatureSpawnAtLocation(spawnlistentry.field_76300_b, p_77192_1_, blockpos1))
+                                                     {
+                                                         EntityLiving entityliving;
+ 
 @@ -153,8 +160,10 @@
  
                                                          entityliving.func_70012_b((double)f, (double)l2, (double)f1, p_77192_1_.field_73012_v.nextFloat() * 360.0F, 0.0F);

--- a/src/main/java/net/minecraftforge/common/EntitySpawnPlacementHelper.java
+++ b/src/main/java/net/minecraftforge/common/EntitySpawnPlacementHelper.java
@@ -1,0 +1,136 @@
+package net.minecraftforge.common;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import com.google.common.collect.HashMultimap;
+import com.google.common.collect.Multimap;
+
+import net.minecraft.entity.Entity;
+import net.minecraft.entity.EntityLiving.SpawnPlacementType;
+import net.minecraft.entity.EntitySpawnPlacementRegistry;
+import net.minecraft.util.BlockPos;
+import net.minecraft.world.SpawnerAnimals;
+import net.minecraft.world.World;
+
+/**
+ * <p>This class did the same thing as vanilla {@link EntitySpawnPlacementRegistry}.</p>
+ * 
+ * <p>Entity spawn placement is checked before entity creation. And is also before a
+ * {@link net.minecraft.entity.EntityLiving#getCanSpawnHere} check.<p>
+ * 
+ * @author Herbix
+ * 
+ */
+public class EntitySpawnPlacementHelper {
+
+    private static Multimap<Class<? extends Entity>, ISpawnPlacementHandler> placementRegistry = HashMultimap.create();
+    
+    private static ISpawnPlacementHandler[] SPAWN_PLACEMENT_TYPE_HANDLERS = new ISpawnPlacementHandler[SpawnPlacementType.values().length];
+
+    static {
+        for(SpawnPlacementType type : SpawnPlacementType.values())
+        {
+            SPAWN_PLACEMENT_TYPE_HANDLERS[type.ordinal()] = new SpawnPlacementTypeWarpper(type);
+        }
+    }
+
+    /**
+     * Use {@code EntitySpawnPlacementHelper.addSpawnPlacementHandler(xx.class,
+     * EntitySpawnPlacementHelper.ALWAYS_TRUE_HANDLER)} to disable spawn placement check
+     * and you could do it by overriding {@link net.minecraft.entity.EntityLiving#getCanSpawnHere}.
+     */
+    public static ISpawnPlacementHandler ALWAYS_TRUE_HANDLER = new ISpawnPlacementHandler() {
+        @Override
+        public boolean canCreatureSpawnAtLocation(Class<? extends Entity> entityClass, World worldIn, BlockPos pos)
+        {
+            return true;
+        }
+    };
+    
+    /**
+     * This is a similar method to {@link EntitySpawnPlacementRegistry#setPlacementType},
+     * but multiple placement type can be added here. If one of these type passes the
+     * spawn placement check, this type of entity might spawn here.<br>
+     * If you only need one placement type, {@link EntitySpawnPlacementRegistry#setPlacementType}
+     * is preferred.
+     * @param entityClass   Entity type
+     * @param placementType Placement type
+     */
+    public static void addSpawnPlacementType(Class<? extends Entity> entityClass, SpawnPlacementType placementType)
+    {
+        addSpawnPlacementHandler(entityClass, SPAWN_PLACEMENT_TYPE_HANDLERS[placementType.ordinal()]);
+    }
+    
+    /**
+     * Handlers could be specify here to do the spawn placement check. If one of them
+     * passes the check, this type of entity might spawn here.
+     * @param entityClass   Entity type
+     * @param handler       The handler
+     * @see EntitySpawnPlacementHelper#addSpawnPlacementType
+     */
+    public static void addSpawnPlacementHandler(Class<? extends Entity> entityClass, ISpawnPlacementHandler handler)
+    {
+        placementRegistry.put(entityClass, handler);
+    }
+    
+    /**
+     * A hook called by {@link SpawnerAnimals#findChunksForSpawning}.
+     * @param entityClass   Entity type
+     * @param worldIn       World
+     * @param pos           Spawning position
+     * @return              Whether the creature could spawn here
+     */
+    public static boolean canCreatureSpawnAtLocation(Class<? extends Entity> entityClass, World worldIn, BlockPos pos)
+    {
+        if (!worldIn.getWorldBorder().contains(pos))
+        {
+            return false;
+        }
+        SpawnPlacementType type = EntitySpawnPlacementRegistry.func_180109_a(entityClass);
+        if (placementRegistry.containsKey(entityClass)) {
+            for (ISpawnPlacementHandler handler : placementRegistry.get(entityClass))
+            {
+                if (handler.canCreatureSpawnAtLocation(entityClass, worldIn, pos))
+                {
+                    return true;
+                }
+            }
+            if (type == null)
+            {
+                return false;
+            }
+        }
+        return SpawnerAnimals.canCreatureTypeSpawnAtLocation(type, worldIn, pos);
+    }
+
+    /**
+     * @see EntitySpawnPlacementHelper#addSpawnPlacementHandler
+     */
+    public interface ISpawnPlacementHandler {
+        /**
+         * @see EntitySpawnPlacementHelper#addSpawnPlacementHandler
+         */
+        public boolean canCreatureSpawnAtLocation(Class<? extends Entity> entityClass, World worldIn, BlockPos pos);
+    }
+    
+    private static class SpawnPlacementTypeWarpper implements ISpawnPlacementHandler {
+        
+        private SpawnPlacementType type;
+
+        public SpawnPlacementTypeWarpper(SpawnPlacementType type)
+        {
+            this.type = type;
+        }
+        
+        @Override
+        public boolean canCreatureSpawnAtLocation(Class<? extends Entity> entityClass, World worldIn, BlockPos pos)
+        {
+            return SpawnerAnimals.canCreatureTypeSpawnAtLocation(type, worldIn, pos);
+        }
+        
+    }
+}

--- a/src/test/java/net/minecraftforge/test/SpawnPlacementHandlerTest.java
+++ b/src/test/java/net/minecraftforge/test/SpawnPlacementHandlerTest.java
@@ -1,0 +1,74 @@
+package net.minecraftforge.test;
+
+import net.minecraft.entity.Entity;
+import net.minecraft.entity.EntityLiving;
+import net.minecraft.entity.EnumCreatureType;
+import net.minecraft.entity.EntityLiving.SpawnPlacementType;
+import net.minecraft.entity.passive.EntityWaterMob;
+import net.minecraft.util.BlockPos;
+import net.minecraft.world.World;
+import net.minecraft.world.biome.BiomeGenBase;
+import net.minecraftforge.common.EntitySpawnPlacementHelper;
+import net.minecraftforge.common.EntitySpawnPlacementHelper.ISpawnPlacementHandler;
+import net.minecraftforge.fml.common.Mod;
+import net.minecraftforge.fml.common.Mod.EventHandler;
+import net.minecraftforge.fml.common.event.FMLInitializationEvent;
+import net.minecraftforge.fml.common.registry.EntityRegistry;
+
+@Mod(modid="SpawnPlacementHandlerTest", name="SpawnPlacementHandlerTest", version="0.0.0")
+public class SpawnPlacementHandlerTest {
+
+    @EventHandler
+    public void init(FMLInitializationEvent event)
+    {
+        EntityRegistry.registerModEntity(EntityFrog.class, "Frog", 0, this, 80, 3, true);
+        EntityRegistry.addSpawn(EntityFrog.class, 100, 1, 1, EnumCreatureType.WATER_CREATURE, BiomeGenBase.swampland);
+        EntityRegistry.addSpawn(EntityFrog.class, 100, 1, 1, EnumCreatureType.CREATURE, BiomeGenBase.swampland);
+        EntitySpawnPlacementHelper.addSpawnPlacementType(EntityFrog.class, SpawnPlacementType.ON_GROUND);
+        EntitySpawnPlacementHelper.addSpawnPlacementType(EntityFrog.class, SpawnPlacementType.IN_WATER);
+
+        EntityRegistry.registerModEntity(EntityFlyingBox.class, "FlyingBox", 0, this, 80, 3, true);
+        EntityRegistry.addSpawn(EntityFlyingBox.class, 100, 1, 1, EnumCreatureType.AMBIENT, BiomeGenBase.swampland);
+        EntitySpawnPlacementHelper.addSpawnPlacementHandler(EntityFlyingBox.class, EntitySpawnPlacementHelper.ALWAYS_TRUE_HANDLER);
+    }
+    
+    public static class EntityFrog extends EntityWaterMob {
+
+        public EntityFrog(World worldIn)
+        {
+            super(worldIn);
+            setSize(1f, 1f);
+        }
+        
+        @Override
+        public void onEntityUpdate()
+        {
+            super.onEntityUpdate();
+            setAir(300);
+        }
+
+        @Override
+        public boolean isCreatureType(EnumCreatureType type, boolean forSpawnCount)
+        {
+            return type == EnumCreatureType.AMBIENT;
+        }
+        
+    }
+    
+    public static class EntityFlyingBox extends EntityLiving {
+
+        public EntityFlyingBox(World worldIn)
+        {
+            super(worldIn);
+            setSize(1f, 1f);
+        }
+
+        @Override
+        public boolean isCreatureType(EnumCreatureType type, boolean forSpawnCount)
+        {
+            return type == EnumCreatureType.AMBIENT;
+        }
+
+    }
+
+}


### PR DESCRIPTION
In 1.8, mob spawn mechanism changed. An EntitySpawnPlacementRegister class was added in order to specify where to spawn the mob. For example, ghasts in air, zombies on ground, and guardians in water. But one type of mob, one placement. We can't create a mob frog, which can spawn in water or on ground.

EntitySpawnPlacementHelper helps to do that. By using EntitySpawnPlacementHelper.addSpawnPlacementType, modders can easily make a mob frog, or a mob flying fish, or other mobs which could spawn at anywhere.

I added a hook in SpawnerAnimals.findChunksForSpawning. It replaced old check, which only checks the spawn placement type returned by EntitySpawnPlacementRegistry.func_180109_a. Now I name it primarySpawnReplacementType. An entity could have secondarySpawnReplacementTypes now. It's compatible with vanilla mechanism. Of course, change vanilla mob spawning is not possible here.

An example (or test) is contained in this commit.

Inspired by http://www.minecraftforge.net/forum/index.php/topic,28878.0.html