### PR TITLE
[1.8] Allow changing the number of arguments passed to a command using CommandEvent

### DIFF
--- a/patches/minecraft/net/minecraft/command/CommandHandler.java.patch
+++ b/patches/minecraft/net/minecraft/command/CommandHandler.java.patch
@@ -1,6 +1,6 @@
 --- ../src-base/minecraft/net/minecraft/command/CommandHandler.java
 +++ ../src-work/minecraft/net/minecraft/command/CommandHandler.java
-@@ -48,6 +48,16 @@
+@@ -48,6 +48,17 @@
          }
          else if (icommand.func_71519_b(p_71556_1_))
          {
@@ -13,6 +13,7 @@
 +                }
 +                return 1;
 +            }
++            if (event.parameters != null) astring = event.parameters;
 +
              if (i > -1)
              {


### PR DESCRIPTION
Previously, you were already able to modify the parameters passed to a command by listening to CommandEvents and changing entries in the event's `parameters` Array. However, adding or removing parameters requires assigning a new Array to that field. This commit makes the CommandHandler recognize possible changes to the amount of parameters passed to the command and thus allows adding and removing paramters for the command.