### PR TITLE
Added "shift" variants of the Actions in PlayerInteractEvent.Action.

### DIFF
--- a/patches/minecraft/net/minecraft/client/Minecraft.java.patch
+++ b/patches/minecraft/net/minecraft/client/Minecraft.java.patch
@@ -66,7 +66,7 @@
                          int i = itemstack != null ? itemstack.field_77994_a : 0;
  
 +
-+                        boolean result = !net.minecraftforge.event.ForgeEventFactory.onPlayerInteract(field_71439_g, net.minecraftforge.event.entity.player.PlayerInteractEvent.Action.RIGHT_CLICK_BLOCK, this.field_71441_e, blockpos, this.field_71476_x.field_178784_b).isCanceled();
++                        boolean result = !net.minecraftforge.event.ForgeEventFactory.onPlayerInteract(field_71439_g, field_71439_g.func_70093_af() ? net.minecraftforge.event.entity.player.PlayerInteractEvent.Action.SHIFT_RIGHT_CLICK_BLOCK : net.minecraftforge.event.entity.player.PlayerInteractEvent.Action.RIGHT_CLICK_BLOCK, this.field_71441_e, blockpos, this.field_71476_x.field_178784_b).isCanceled();
 +                        if (result) { //Forge: Kept separate to simplify patch
                          if (this.field_71442_b.func_178890_a(this.field_71439_g, this.field_71441_e, itemstack, blockpos, this.field_71476_x.field_178784_b, this.field_71476_x.field_72307_f))
                          {

--- a/patches/minecraft/net/minecraft/network/NetHandlerPlayServer.java.patch
+++ b/patches/minecraft/net/minecraft/network/NetHandlerPlayServer.java.patch
@@ -98,7 +98,7 @@
                  return;
              }
  
-+            PlayerInteractEvent event = ForgeEventFactory.onPlayerInteract(field_147369_b, PlayerInteractEvent.Action.RIGHT_CLICK_AIR, worldserver, new BlockPos(0, 0, 0), null);
++            PlayerInteractEvent event = ForgeEventFactory.onPlayerInteract(field_147369_b, field_147369_b.func_70093_af() ? PlayerInteractEvent.Action.SHIFT_RIGHT_CLICK_AIR : PlayerInteractEvent.Action.RIGHT_CLICK_AIR, worldserver, new BlockPos(0, 0, 0), null);
 +            if (event.useItem != Event.Result.DENY)
 +            {
              this.field_147369_b.field_71134_c.func_73085_a(this.field_147369_b, worldserver, itemstack);

--- a/patches/minecraft/net/minecraft/server/management/ItemInWorldManager.java.patch
+++ b/patches/minecraft/net/minecraft/server/management/ItemInWorldManager.java.patch
@@ -14,7 +14,7 @@
      public void func_180784_a(BlockPos p_180784_1_, EnumFacing p_180784_2_)
      {
 +        net.minecraftforge.event.entity.player.PlayerInteractEvent event = net.minecraftforge.event.ForgeEventFactory.onPlayerInteract(field_73090_b,
-+                net.minecraftforge.event.entity.player.PlayerInteractEvent.Action.LEFT_CLICK_BLOCK, field_73092_a, p_180784_1_, p_180784_2_);
++                field_73090_b.func_70093_af() ? net.minecraftforge.event.entity.player.PlayerInteractEvent.Action.SHIFT_LEFT_CLICK_BLOCK : net.minecraftforge.event.entity.player.PlayerInteractEvent.Action.LEFT_CLICK_BLOCK, field_73092_a, p_180784_1_, p_180784_2_);
 +        if (event.isCanceled())
 +        {
 +            field_73090_b.field_71135_a.func_147359_a(new S23PacketBlockChange(field_73092_a, p_180784_1_));
@@ -177,7 +177,7 @@
          {
 -            if (!p_180236_1_.func_70093_af() || p_180236_1_.func_70694_bm() == null)
 +            net.minecraftforge.event.entity.player.PlayerInteractEvent event = net.minecraftforge.event.ForgeEventFactory.onPlayerInteract(p_180236_1_,
-+                    net.minecraftforge.event.entity.player.PlayerInteractEvent.Action.RIGHT_CLICK_BLOCK, p_180236_2_, p_180236_4_, p_180236_5_);
++                    p_180236_1_.func_70093_af() ? net.minecraftforge.event.entity.player.PlayerInteractEvent.Action.SHIFT_RIGHT_CLICK_BLOCK : net.minecraftforge.event.entity.player.PlayerInteractEvent.Action.RIGHT_CLICK_BLOCK, p_180236_2_, p_180236_4_, p_180236_5_);
 +            if (event.isCanceled())
              {
 -                IBlockState iblockstate = p_180236_2_.func_180495_p(p_180236_4_);

--- a/src/main/java/net/minecraftforge/event/entity/player/PlayerInteractEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/player/PlayerInteractEvent.java
@@ -37,8 +37,11 @@ public class PlayerInteractEvent extends PlayerEvent
     public static enum Action
     {
         RIGHT_CLICK_AIR,
+        SHIFT_RIGHT_CLICK_AIR,
         RIGHT_CLICK_BLOCK,
-        LEFT_CLICK_BLOCK
+        SHIFT_RIGHT_CLICK_BLOCK,
+        LEFT_CLICK_BLOCK,
+        SHIFT_LEFT_CLICK_BLOCK
     }
 
     public final Action action;


### PR DESCRIPTION
I've added "shift" variants of the actions in PlayerInteractEvent. It could be useful if you want to do something when right-clicking a block, and something different if you shift-right-click the block.