### PR TITLE
Add isBreedingItem hook for items being used to breed animals

### DIFF
--- a/patches/minecraft/net/minecraft/entity/passive/EntityAnimal.java.patch
+++ b/patches/minecraft/net/minecraft/entity/passive/EntityAnimal.java.patch
@@ -1,0 +1,11 @@
+--- ../src-base/minecraft/net/minecraft/entity/passive/EntityAnimal.java
++++ ../src-work/minecraft/net/minecraft/entity/passive/EntityAnimal.java
+@@ -306,7 +306,7 @@
+ 
+     public boolean func_70877_b(ItemStack p_70877_1_)
+     {
+-        return p_70877_1_.func_77973_b() == Items.field_151015_O;
++        return p_70877_1_ != null && p_70877_1_.func_77973_b().isBreedingItem(this, p_70877_1_);
+     }
+ 
+     public boolean func_70085_c(EntityPlayer p_70085_1_)

--- a/patches/minecraft/net/minecraft/entity/passive/EntityChicken.java.patch
+++ b/patches/minecraft/net/minecraft/entity/passive/EntityChicken.java.patch
@@ -1,0 +1,14 @@
+--- ../src-base/minecraft/net/minecraft/entity/passive/EntityChicken.java
++++ ../src-work/minecraft/net/minecraft/entity/passive/EntityChicken.java
+@@ -149,11 +149,6 @@
+         return new EntityChicken(this.field_70170_p);
+     }
+ 
+-    public boolean func_70877_b(ItemStack p_70877_1_)
+-    {
+-        return p_70877_1_ != null && p_70877_1_.func_77973_b() instanceof ItemSeeds;
+-    }
+-
+     public void func_70037_a(NBTTagCompound p_70037_1_)
+     {
+         super.func_70037_a(p_70037_1_);

--- a/patches/minecraft/net/minecraft/entity/passive/EntityPig.java.patch
+++ b/patches/minecraft/net/minecraft/entity/passive/EntityPig.java.patch
@@ -1,0 +1,14 @@
+--- ../src-base/minecraft/net/minecraft/entity/passive/EntityPig.java
++++ ../src-work/minecraft/net/minecraft/entity/passive/EntityPig.java
+@@ -193,11 +193,6 @@
+         return new EntityPig(this.field_70170_p);
+     }
+ 
+-    public boolean func_70877_b(ItemStack p_70877_1_)
+-    {
+-        return p_70877_1_ != null && p_70877_1_.func_77973_b() == Items.field_151172_bF;
+-    }
+-
+     public EntityAIControlledByPlayer func_82183_n()
+     {
+         return this.field_82184_d;

--- a/patches/minecraft/net/minecraft/entity/passive/EntityWolf.java.patch
+++ b/patches/minecraft/net/minecraft/entity/passive/EntityWolf.java.patch
@@ -1,0 +1,20 @@
+--- ../src-base/minecraft/net/minecraft/entity/passive/EntityWolf.java
++++ ../src-work/minecraft/net/minecraft/entity/passive/EntityWolf.java
+@@ -331,7 +331,7 @@
+                 {
+                     ItemFood itemfood = (ItemFood)itemstack.func_77973_b();
+ 
+-                    if (itemfood.func_77845_h() && this.field_70180_af.func_111145_d(18) < 20.0F)
++                    if (itemfood.isWolfFood(itemstack) && this.field_70180_af.func_111145_d(18) < 20.0F)
+                     {
+                         if (!p_70085_1_.field_71075_bZ.field_75098_d)
+                         {
+@@ -436,7 +436,7 @@
+ 
+     public boolean func_70877_b(ItemStack p_70877_1_)
+     {
+-        return p_70877_1_ == null ? false : (!(p_70877_1_.func_77973_b() instanceof ItemFood) ? false : ((ItemFood)p_70877_1_.func_77973_b()).func_77845_h());
++        return super.func_70877_b(p_70877_1_) || (p_70877_1_.func_77973_b() instanceof ItemFood && ((ItemFood) p_70877_1_.func_77973_b()).isWolfFood(p_70877_1_));
+     }
+ 
+     public int func_70641_bl()

--- a/patches/minecraft/net/minecraft/item/Item.java.patch
+++ b/patches/minecraft/net/minecraft/item/Item.java.patch
@@ -113,7 +113,7 @@
      public Multimap func_111205_h()
      {
          return HashMultimap.create();
-@@ -728,6 +746,591 @@
+@@ -728,6 +746,605 @@
          return this.field_111218_cA == null ? "MISSING_ICON_ITEM_" + field_150901_e.func_148757_b(this) + "_" + this.field_77774_bZ : this.field_111218_cA;
      }
  
@@ -700,12 +700,26 @@
 +    {
 +        return this == Items.field_151166_bC || this == Items.field_151045_i || this == Items.field_151043_k || this == Items.field_151042_j;
 +    }
++
++    /**
++     * Whether this Item can be used to breed the given animal.
++     * @param entity the {@link EntityAnimal} being bred
++     * @param stack the {@link ItemStack} being used on the animal
++     * @return true if the {@link ItemStack stack} will put the {@link EntityAnimal entity} into breeding mode
++     */
++    public boolean isBreedingItem(net.minecraft.entity.passive.EntityAnimal entity, ItemStack stack)
++    {
++        // Use instanceof here because that's how it was in EntityChicken
++        if (this instanceof ItemSeeds) return entity.getClass() == net.minecraft.entity.passive.EntityChicken.class;
++        if (this == Items.field_151172_bF) return entity.getClass() == net.minecraft.entity.passive.EntityPig.class;
++        return this == Items.field_151015_O; // This is needed since wheat is just an instance of the Item class
++    }
 +    /* ======================================== FORGE END   =====================================*/
 +
      public static enum ToolMaterial
      {
          WOOD(0, 59, 2.0F, 0.0F, 15),
-@@ -743,6 +1346,10 @@
+@@ -743,6 +1360,10 @@
  
          private static final String __OBFID = "CL_00000042";
  
@@ -716,7 +730,7 @@
          private ToolMaterial(int p_i1874_3_, int p_i1874_4_, float p_i1874_5_, float p_i1874_6_, int p_i1874_7_)
          {
              this.field_78001_f = p_i1874_3_;
-@@ -777,9 +1384,36 @@
+@@ -777,9 +1398,36 @@
              return this.field_78008_j;
          }
  

--- a/patches/minecraft/net/minecraft/item/ItemFood.java.patch
+++ b/patches/minecraft/net/minecraft/item/ItemFood.java.patch
@@ -1,0 +1,14 @@
+--- ../src-base/minecraft/net/minecraft/item/ItemFood.java
++++ ../src-work/minecraft/net/minecraft/item/ItemFood.java
+@@ -83,6 +83,11 @@
+     {
+         return this.field_77856_bY;
+     }
++    
++    public boolean isWolfFood(ItemStack stack)
++    {
++        return func_77845_h();
++    }
+ 
+     public ItemFood func_77844_a(int p_77844_1_, int p_77844_2_, int p_77844_3_, float p_77844_4_)
+     {


### PR DESCRIPTION
Also added an ItemStack sensitive isWolfFood method

This PR allows modders to make their items breeding items for vanilla mobs, but also keeps the ability to define the breeding item in the entity class. 
