### PR TITLE
Reimplement RenderPlayerEvent that was removed in the port to 1.8 from 1.7.10.

### DIFF
--- a/patches/minecraft/net/minecraft/client/renderer/entity/RenderPlayer.java.patch
+++ b/patches/minecraft/net/minecraft/client/renderer/entity/RenderPlayer.java.patch
@@ -1,0 +1,18 @@
+--- ../src-base/minecraft/net/minecraft/client/renderer/entity/RenderPlayer.java
++++ ../src-work/minecraft/net/minecraft/client/renderer/entity/RenderPlayer.java
+@@ -53,6 +53,7 @@
+ 
+     public void func_180596_a(AbstractClientPlayer p_180596_1_, double p_180596_2_, double p_180596_4_, double p_180596_6_, float p_180596_8_, float p_180596_9_)
+     {
++        if (net.minecraftforge.common.MinecraftForge.EVENT_BUS.post(new net.minecraftforge.client.event.RenderPlayerEvent.Pre(p_180596_1_, this, p_180596_9_, p_180596_2_, p_180596_4_, p_180596_6_))) return;
+         if (!p_180596_1_.func_175144_cb() || this.field_76990_c.field_78734_h == p_180596_1_)
+         {
+             double d3 = p_180596_4_;
+@@ -65,6 +66,7 @@
+             this.func_177137_d(p_180596_1_);
+             super.func_76986_a((EntityLivingBase)p_180596_1_, p_180596_2_, d3, p_180596_6_, p_180596_8_, p_180596_9_);
+         }
++        net.minecraftforge.common.MinecraftForge.EVENT_BUS.post(new net.minecraftforge.client.event.RenderPlayerEvent.Post(p_180596_1_, this, p_180596_9_, p_180596_2_, p_180596_4_, p_180596_6_));
+     }
+ 
+     private void func_177137_d(AbstractClientPlayer p_177137_1_)

--- a/src/main/java/net/minecraftforge/client/event/RenderPlayerEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/RenderPlayerEvent.java
@@ -10,61 +10,28 @@ public abstract class RenderPlayerEvent extends PlayerEvent
 {
     public final RenderPlayer renderer;
     public final float partialRenderTick;
+    public final double x;
+    public final double y;
+    public final double z;
 
-    public RenderPlayerEvent(EntityPlayer player, RenderPlayer renderer, float partialRenderTick)
+    public RenderPlayerEvent(EntityPlayer player, RenderPlayer renderer, float partialRenderTick, double x, double y, double z)
     {
         super(player);
         this.renderer = renderer;
         this.partialRenderTick = partialRenderTick;
+        this.x = x;
+        this.y = y;
+        this.z = z;
     }
 
     @Cancelable
     public static class Pre extends RenderPlayerEvent
     {
-        public Pre(EntityPlayer player, RenderPlayer renderer, float tick){ super(player, renderer, tick); }
+        public Pre(EntityPlayer player, RenderPlayer renderer, float tick, double x, double y, double z){ super(player, renderer, tick, x, y, z); }
     }
 
     public static class Post extends RenderPlayerEvent
     {
-        public Post(EntityPlayer player, RenderPlayer renderer, float tick){ super(player, renderer, tick); }
-    }
-    
-    public abstract static class Specials extends RenderPlayerEvent
-    {
-        public Specials(EntityPlayer player, RenderPlayer renderer, float partialTicks)
-        {
-            super(player, renderer, partialTicks);
-        }
-
-        @Cancelable
-        public static class Pre extends Specials
-        {
-            public boolean renderHelmet = true;
-            public boolean renderCape = true;
-            public boolean renderItem = true;
-            public Pre(EntityPlayer player, RenderPlayer renderer, float partialTicks){ super(player, renderer, partialTicks); }
-        }
-
-        public static class Post extends Specials
-        {
-            public Post(EntityPlayer player, RenderPlayer renderer, float partialTicks){ super(player, renderer, partialTicks); }
-        }
-    }
-
-    public static class SetArmorModel extends RenderPlayerEvent
-    {
-        /**
-         * Setting this to any value besides -1 will result in the function being 
-         * Immediately exited with the return value specified.
-         */
-        public int result = -1;
-        public final int slot;
-        public final ItemStack stack;
-        public SetArmorModel(EntityPlayer player, RenderPlayer renderer, int slot, float partialTick, ItemStack stack)
-        {
-            super(player, renderer, partialTick);
-            this.slot = slot;
-            this.stack = stack;
-        }
+        public Post(EntityPlayer player, RenderPlayer renderer, float tick, double x, double y, double z){ super(player, renderer, tick, x, y, z); }
     }
 }


### PR DESCRIPTION
RenderPlayerEvent.Specials was removed because the special effects are done in the LayerRenderer now.