### PR TITLE
[1.7.10] Fix FluidRegsitry.registerFluid

### DIFF
--- a/src/main/java/net/minecraftforge/fluids/FluidRegistry.java
+++ b/src/main/java/net/minecraftforge/fluids/FluidRegistry.java
@@ -79,7 +79,7 @@ public abstract class FluidRegistry
      */
     public static boolean registerFluid(Fluid fluid)
     {
-        if (fluidIDs.containsKey(fluid.getName()))
+        if (fluids.containsKey(fluid.getName()))
         {
             FMLLog.bigWarning("Duplicate registration attempt for fluid %s (type %s) has occurred. This is not a problem itself, but subsequent failed FluidStacks might be a result if not handled properly", fluid.getName(), fluid.getClass().getName());
             return false;


### PR DESCRIPTION
FluidRegistry:
```java
    static BiMap<String, Fluid> fluids = HashBiMap.create();
    static BiMap<Fluid, Integer> fluidIDs = HashBiMap.create();
...
    public static boolean registerFluid(Fluid fluid)
    {
        if (fluidIDs.containsKey(fluid.getName()))
            ^^^^^^^
```
There is definitely should be fluids instead fluidIDs. This mistake broke many mods.