### PR TITLE
Added: onBlockDestroyedByFire (includes an event)

### DIFF
--- a/patches/minecraft/net/minecraft/block/Block.java.patch
+++ b/patches/minecraft/net/minecraft/block/Block.java.patch
@@ -161,7 +161,7 @@
      }
  
      protected ItemStack func_180643_i(IBlockState p_180643_1_)
-@@ -971,6 +989,1028 @@
+@@ -971,6 +989,1042 @@
          return Block.EnumOffsetType.NONE;
      }
  
@@ -326,6 +326,20 @@
 +    public boolean removedByPlayer(World world, BlockPos pos, EntityPlayer player, boolean willHarvest)
 +    {
 +        return world.func_175698_g(pos);
++    }
++
++    /**
++     * Called when the block is destroyed by a fire.
++     * Useful for allowing the block to drop items, cause an explosion, in-world crafting with fire, etc.
++     * 
++     * @param world The current world
++     * @param pos Block position in world
++     * @param state The current blockstate
++     * @return True if the block is actually destroyed.
++     */
++    public boolean onBlockDestroyedByFire(World world, BlockPos pos, IBlockState state)
++    {
++        return true;
 +    }
 +
 +    /**

--- a/patches/minecraft/net/minecraft/block/BlockFire.java.patch
+++ b/patches/minecraft/net/minecraft/block/BlockFire.java.patch
@@ -111,6 +111,20 @@
          if (p_176536_4_.nextInt(p_176536_3_) < k)
          {
              IBlockState iblockstate = p_176536_1_.func_180495_p(p_176536_2_);
+@@ -291,11 +301,11 @@
+                     l = 15;
+                 }
+ 
+-                p_176536_1_.func_180501_a(p_176536_2_, this.func_176223_P().func_177226_a(field_176543_a, Integer.valueOf(l)), 3);
++                if (net.minecraftforge.common.ForgeHooks.onBlockDestroyedByFire(p_176536_1_, p_176536_2_, iblockstate)) p_176536_1_.func_180501_a(p_176536_2_, this.func_176223_P().func_177226_a(field_176543_a, Integer.valueOf(l)), 3);
+             }
+             else
+             {
+-                p_176536_1_.func_175698_g(p_176536_2_);
++                if (net.minecraftforge.common.ForgeHooks.onBlockDestroyedByFire(p_176536_1_, p_176536_2_, iblockstate)) p_176536_1_.func_175698_g(p_176536_2_);
+             }
+ 
+             if (iblockstate.func_177230_c() == Blocks.field_150335_W)
 @@ -314,7 +324,7 @@
          {
              EnumFacing enumfacing = aenumfacing[j];

--- a/src/main/java/net/minecraftforge/common/ForgeHooks.java
+++ b/src/main/java/net/minecraftforge/common/ForgeHooks.java
@@ -755,4 +755,10 @@ public class ForgeHooks
         if (stack != null && stack.getItem().onLeftClickEntity(stack, player, target)) return false;
         return true;
     }
+
+    public static boolean onBlockDestroyedByFire(World world, BlockPos pos, IBlockState state)
+    {
+        if (MinecraftForge.EVENT_BUS.post(new BlockEvent.DestroyedByFireEvent(world, pos, state))) return false;
+        return state.getBlock().onBlockDestroyedByFire(world, pos, state);
+    }
 }

--- a/src/main/java/net/minecraftforge/event/world/BlockEvent.java
+++ b/src/main/java/net/minecraftforge/event/world/BlockEvent.java
@@ -206,4 +206,18 @@ public class BlockEvent extends Event
             return notifiedSides;
         }
     }
+
+    /**
+     * DestroyedByFireEvent is fired when BlockFire replaces a block with fire or air.
+     * 
+     * If this event is cancelled, the block is not replaced.
+     **/
+    @Cancelable
+    public static class DestroyedByFireEvent extends BlockEvent
+    {
+        public DestroyedByFireEvent(World world, BlockPos pos, IBlockState state)
+        {
+            super(world, pos, state);
+        }
+    }
 }


### PR DESCRIPTION
BlockEvent.DestroyedByFireEvent
- Fired when BlockFire replaces a block with fire or air.
- If cancelled, the block is not replaced.
- Primary Use: protection plugins stopping fire from destroying blocks.

Block.onBlockDestroyedByFire
- Fired when BlockFire replaces a block with fire or air. (If
BlockEvent.DestroyedByFireEvent was not cancelled)
- Returning false stops the block from being replaced.
- Primary Use: drop items, cause an explosion, in-world crafting with
fire, etc.