### PR TITLE
Player sensitive version of Block.getPickBlock

### DIFF
--- a/patches/minecraft/net/minecraft/block/Block.java.patch
+++ b/patches/minecraft/net/minecraft/block/Block.java.patch
@@ -161,7 +161,7 @@
      }
  
      protected ItemStack func_180643_i(IBlockState p_180643_1_)
-@@ -971,6 +989,1028 @@
+@@ -971,6 +989,1033 @@
          return Block.EnumOffsetType.NONE;
      }
  
@@ -734,6 +734,11 @@
 +     * @param target The full target the player is looking at
 +     * @return A ItemStack to add to the player's inventory, Null if nothing should be added.
 +     */
++    public ItemStack getPickBlock(MovingObjectPosition target, World world, BlockPos pos, EntityPlayer player)
++    {
++        return getPickBlock(target, world, pos);
++    }
++    @Deprecated
 +    public ItemStack getPickBlock(MovingObjectPosition target, World world, BlockPos pos)
 +    {
 +        Item item = func_180665_b(world, pos);

--- a/src/main/java/net/minecraftforge/common/ForgeHooks.java
+++ b/src/main/java/net/minecraftforge/common/ForgeHooks.java
@@ -264,7 +264,7 @@ public class ForgeHooks
             if (isCreative && GuiScreen.isCtrlKeyDown())
                 te = world.getTileEntity(target.getBlockPos());
 
-            result = state.getBlock().getPickBlock(target, world, target.getBlockPos());
+            result = state.getBlock().getPickBlock(target, world, target.getBlockPos(), player);
         }
         else
         {


### PR DESCRIPTION
Block.getPickBlock was patched in 1.7 but was overlooked in 1.8.

Closes: https://github.com/MinecraftForge/MinecraftForge/issues/1709