### PR TITLE
Update FluidRegistry.java

### DIFF
--- a/src/main/java/net/minecraftforge/fluids/FluidRegistry.java
+++ b/src/main/java/net/minecraftforge/fluids/FluidRegistry.java
@@ -82,6 +82,7 @@ public abstract class FluidRegistry
         if (fluids.containsKey(fluid.getName()))
         {
             FMLLog.bigWarning("Duplicate registration attempt for fluid %s (type %s) has occurred. This is not a problem itself, but subsequent failed FluidStacks might be a result if not handled properly", fluid.getName(), fluid.getClass().getName());
+            fluidIDs.put(fluid, getFluidID(fluid.getName()));
             return false;
         }
         fluids.put(fluid.getName(), fluid);


### PR DESCRIPTION
Trying to avoid missing fluid crash with certain mods (spec for te #1775).

Using workaround: bind all duplicates of fluid to one original id so mods can still use duplicate fluid.