### PR TITLE
[1.8] Added the brewing registry system

### DIFF
--- a/patches/minecraft/net/minecraft/inventory/ContainerBrewingStand.java.patch
+++ b/patches/minecraft/net/minecraft/inventory/ContainerBrewingStand.java.patch
@@ -1,5 +1,14 @@
 --- ../src-base/minecraft/net/minecraft/inventory/ContainerBrewingStand.java
 +++ ../src-work/minecraft/net/minecraft/inventory/ContainerBrewingStand.java
+@@ -158,7 +158,7 @@
+ 
+         public boolean func_75214_a(ItemStack p_75214_1_)
+         {
+-            return p_75214_1_ != null ? p_75214_1_.func_77973_b().func_150892_m(p_75214_1_) : false;
++            return net.minecraftforge.common.brewing.BrewingRecipeRegistry.isValidIngredient(p_75214_1_);
+         }
+ 
+         public int func_75219_a()
 @@ -190,7 +190,7 @@
  
              public void func_82870_a(EntityPlayer p_82870_1_, ItemStack p_82870_2_)
@@ -14,7 +23,7 @@
              public static boolean func_75243_a_(ItemStack p_75243_0_)
              {
 -                return p_75243_0_ != null && (p_75243_0_.func_77973_b() == Items.field_151068_bn || p_75243_0_.func_77973_b() == Items.field_151069_bo);
-+                return p_75243_0_ != null && (p_75243_0_.func_77973_b() instanceof net.minecraft.item.ItemPotion || p_75243_0_.func_77973_b() == Items.field_151069_bo);
++                return net.minecraftforge.common.brewing.BrewingRecipeRegistry.isValidInput(p_75243_0_);
              }
          }
  }

--- a/patches/minecraft/net/minecraft/tileentity/TileEntityBrewingStand.java.patch
+++ b/patches/minecraft/net/minecraft/tileentity/TileEntityBrewingStand.java.patch
@@ -1,15 +1,54 @@
 --- ../src-base/minecraft/net/minecraft/tileentity/TileEntityBrewingStand.java
 +++ ../src-work/minecraft/net/minecraft/tileentity/TileEntityBrewingStand.java
-@@ -118,7 +118,7 @@
+@@ -104,84 +104,21 @@
  
-                 for (int i = 0; i < 3; ++i)
-                 {
+     private boolean func_145934_k()
+     {
+-        if (this.field_145945_j[3] != null && this.field_145945_j[3].field_77994_a > 0)
+-        {
+-            ItemStack itemstack = this.field_145945_j[3];
+-
+-            if (!itemstack.func_77973_b().func_150892_m(itemstack))
+-            {
+-                return false;
+-            }
+-            else
+-            {
+-                boolean flag = false;
+-
+-                for (int i = 0; i < 3; ++i)
+-                {
 -                    if (this.field_145945_j[i] != null && this.field_145945_j[i].func_77973_b() == Items.field_151068_bn)
-+                    if (this.field_145945_j[i] != null && this.field_145945_j[i].func_77973_b() instanceof ItemPotion)
-                     {
-                         int j = this.field_145945_j[i].func_77960_j();
-                         int k = this.func_145936_c(j, itemstack);
-@@ -151,13 +151,14 @@
+-                    {
+-                        int j = this.field_145945_j[i].func_77960_j();
+-                        int k = this.func_145936_c(j, itemstack);
+-
+-                        if (!ItemPotion.func_77831_g(j) && ItemPotion.func_77831_g(k))
+-                        {
+-                            flag = true;
+-                            break;
+-                        }
+-
+-                        List list = Items.field_151068_bn.func_77834_f(j);
+-                        List list1 = Items.field_151068_bn.func_77834_f(k);
+-
+-                        if ((j <= 0 || list != list1) && (list == null || !list.equals(list1) && list1 != null) && j != k)
+-                        {
+-                            flag = true;
+-                            break;
+-                        }
+-                    }
+-                }
+-
+-                return flag;
+-            }
+-        }
+-        else
+-        {
+-            return false;
+-        }
++        return net.minecraftforge.common.brewing.BrewingRecipeRegistry.canBrew(field_145945_j, field_145947_i, 3);
+     }
  
      private void func_145940_l()
      {
@@ -17,27 +56,41 @@
          if (this.func_145934_k())
          {
              ItemStack itemstack = this.field_145945_j[3];
++            net.minecraftforge.common.brewing.BrewingRecipeRegistry.brewPotions(field_145945_j, field_145947_i, 3);
  
-             for (int i = 0; i < 3; ++i)
-             {
--                if (this.field_145945_j[i] != null && this.field_145945_j[i].func_77973_b() == Items.field_151068_bn)
-+                if (this.field_145945_j[i] != null && this.field_145945_j[i].func_77973_b() instanceof ItemPotion)
-                 {
-                     int j = this.field_145945_j[i].func_77960_j();
-                     int k = this.func_145936_c(j, itemstack);
-@@ -178,9 +179,9 @@
-                 }
-             }
- 
--            if (itemstack.func_77973_b().func_77634_r())
+-            for (int i = 0; i < 3; ++i)
 +            if (itemstack.func_77973_b().hasContainerItem(itemstack))
              {
--                this.field_145945_j[3] = new ItemStack(itemstack.func_77973_b().func_77668_q());
+-                if (this.field_145945_j[i] != null && this.field_145945_j[i].func_77973_b() == Items.field_151068_bn)
+-                {
+-                    int j = this.field_145945_j[i].func_77960_j();
+-                    int k = this.func_145936_c(j, itemstack);
+-                    List list = Items.field_151068_bn.func_77834_f(j);
+-                    List list1 = Items.field_151068_bn.func_77834_f(k);
+-
+-                    if ((j <= 0 || list != list1) && (list == null || !list.equals(list1) && list1 != null))
+-                    {
+-                        if (j != k)
+-                        {
+-                            this.field_145945_j[i].func_77964_b(k);
+-                        }
+-                    }
+-                    else if (!ItemPotion.func_77831_g(j) && ItemPotion.func_77831_g(k))
+-                    {
+-                        this.field_145945_j[i].func_77964_b(k);
+-                    }
+-                }
 +                this.field_145945_j[3] = itemstack.func_77973_b().getContainerItem(itemstack);
              }
+-
+-            if (itemstack.func_77973_b().func_77634_r())
+-            {
+-                this.field_145945_j[3] = new ItemStack(itemstack.func_77973_b().func_77668_q());
+-            }
              else
              {
-@@ -191,6 +192,7 @@
+                 --this.field_145945_j[3].field_77994_a;
+@@ -191,6 +128,7 @@
                      this.field_145945_j[3] = null;
                  }
              }
@@ -45,12 +98,14 @@
          }
      }
  
-@@ -306,7 +308,7 @@
+@@ -306,7 +244,9 @@
  
      public boolean func_94041_b(int p_94041_1_, ItemStack p_94041_2_)
      {
 -        return p_94041_1_ == 3 ? p_94041_2_.func_77973_b().func_150892_m(p_94041_2_) : p_94041_2_.func_77973_b() == Items.field_151068_bn || p_94041_2_.func_77973_b() == Items.field_151069_bo;
-+        return p_94041_1_ == 3 ? p_94041_2_.func_77973_b().func_150892_m(p_94041_2_) : p_94041_2_.func_77973_b() instanceof ItemPotion || p_94041_2_.func_77973_b() == Items.field_151069_bo;
++        if (p_94041_1_ == 3 && net.minecraftforge.common.brewing.BrewingRecipeRegistry.isValidIngredient(p_94041_2_)) return true;
++        else if (p_94041_1_ != 3 && net.minecraftforge.common.brewing.BrewingRecipeRegistry.isValidInput(p_94041_2_)) return true;
++        return false;
      }
  
      public boolean[] func_174902_m()

--- a/src/main/java/net/minecraftforge/common/brewing/AbstractBrewingRecipe.java
+++ b/src/main/java/net/minecraftforge/common/brewing/AbstractBrewingRecipe.java
@@ -1,0 +1,35 @@
+package net.minecraftforge.common.brewing;
+
+import net.minecraft.item.ItemStack;
+import net.minecraftforge.oredict.OreDictionary;
+
+public abstract class AbstractBrewingRecipe<T> implements IBrewingRecipe {
+
+    public final ItemStack input;
+    public final T ingredient;
+    public final ItemStack output;
+
+    protected AbstractBrewingRecipe(ItemStack input, T ingredient, ItemStack output)
+    {
+        this.input = input;
+        this.ingredient = ingredient;
+        this.output = output;
+
+        if (this.input == null || this.ingredient == null || this.output == null)
+        {
+            throw new IllegalArgumentException("A brewing recipe cannot have a null parameter.");
+        }
+    }
+
+    @Override
+    public boolean isInput(ItemStack stack)
+    {
+        return OreDictionary.itemMatches(this.input, stack, false);
+    }
+
+    @Override
+    public ItemStack getOutput(ItemStack input, ItemStack ingredient)
+    {
+        return isInput(input) && isIngredient(ingredient) ? ItemStack.copyItemStack(output) : null;
+    }
+}

--- a/src/main/java/net/minecraftforge/common/brewing/BrewingOreRecipe.java
+++ b/src/main/java/net/minecraftforge/common/brewing/BrewingOreRecipe.java
@@ -1,0 +1,32 @@
+package net.minecraftforge.common.brewing;
+
+import java.util.List;
+import net.minecraft.item.ItemStack;
+import net.minecraftforge.oredict.OreDictionary;
+
+public class BrewingOreRecipe extends AbstractBrewingRecipe<List<ItemStack>> {
+
+    public BrewingOreRecipe(ItemStack input, String ingredient, ItemStack output)
+    {
+        super(input, OreDictionary.getOres(ingredient), output);
+    }
+
+    public BrewingOreRecipe(ItemStack input, List<ItemStack> ingredient, ItemStack output)
+    {
+        super(input, ingredient, output);
+    }
+
+    @Override
+    public boolean isIngredient(ItemStack stack)
+    {
+        for (ItemStack target : this.ingredient)
+        {
+            if (OreDictionary.itemMatches(target, stack, false))
+            {
+                return true;
+            }
+
+        }
+        return false;
+    }
+}

--- a/src/main/java/net/minecraftforge/common/brewing/BrewingRecipe.java
+++ b/src/main/java/net/minecraftforge/common/brewing/BrewingRecipe.java
@@ -1,0 +1,18 @@
+package net.minecraftforge.common.brewing;
+
+import net.minecraft.item.ItemStack;
+import net.minecraftforge.oredict.OreDictionary;
+
+public class BrewingRecipe extends AbstractBrewingRecipe<ItemStack> {
+
+    public BrewingRecipe(ItemStack input, ItemStack ingredient, ItemStack output)
+    {
+        super(input, ingredient, output);
+    }
+
+    @Override
+    public boolean isIngredient(ItemStack stack)
+    {
+        return OreDictionary.itemMatches(this.ingredient, stack, false);
+    }
+}

--- a/src/main/java/net/minecraftforge/common/brewing/BrewingRecipeRegistry.java
+++ b/src/main/java/net/minecraftforge/common/brewing/BrewingRecipeRegistry.java
@@ -1,0 +1,171 @@
+package net.minecraftforge.common.brewing;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import net.minecraft.item.ItemStack;
+
+public class BrewingRecipeRegistry {
+
+    private static List<IBrewingRecipe> recipes = new ArrayList<IBrewingRecipe>();
+
+    static
+    {
+        addRecipe(new VanillaBrewingRecipe());
+    }
+
+    /**
+     * Adds a recipe to the registry. Due to the nature of the brewing stand
+     * inputs that stack (a.k.a max stack size > 1) are not allowed.
+     * 
+     * @param input
+     *            The ItemStack that goes in same slots as the water bottles
+     *            would.
+     * @param ingredient
+     *            The ItemStack that goes in the same slot as nether wart would.
+     * @param output
+     *            The ItemStack that will replace the input once the brewing is
+     *            done.
+     * @return true if the recipe was added.
+     */
+    public static boolean addRecipe(ItemStack input, ItemStack ingredient, ItemStack output)
+    {
+        return addRecipe(new BrewingRecipe(input, ingredient, output));
+    }
+
+    /**
+     * Adds a recipe to the registry. Due to the nature of the brewing stand
+     * inputs that stack (a.k.a max stack size > 1) are not allowed.
+     * 
+     * @param input
+     *            The ItemStack that goes in same slots as the water bottles
+     *            would.
+     * @param ingredient
+     *            The ItemStack that goes in the same slot as nether wart would.
+     * @param output
+     *            The ItemStack that will replace the input once the brewing is
+     *            done.
+     * @return true if the recipe was added.
+     */
+    public static boolean addRecipe(ItemStack input, String ingredient, ItemStack output)
+    {
+        return addRecipe(new BrewingOreRecipe(input, ingredient, output));
+    }
+
+    /**
+     * Adds a recipe to the registry. Due to the nature of the brewing stand
+     * inputs that stack (a.k.a max stack size > 1) are not allowed.
+     */
+    public static boolean addRecipe(IBrewingRecipe recipe)
+    {
+        return recipes.add(recipe);
+    }
+
+    /**
+     * Returns the output ItemStack obtained by brewing the passed input and
+     * ingredient. Null if no matches are found.
+     */
+    public static ItemStack getOutput(ItemStack input, ItemStack ingredient)
+    {
+        if (input == null || input.getMaxStackSize() != 1 || input.stackSize != 1) return null;
+        if (ingredient == null || ingredient.stackSize <= 0) return null;
+
+        for (IBrewingRecipe recipe : recipes)
+        {
+            ItemStack output = recipe.getOutput(input, ingredient);
+            if (output != null)
+            {
+                return output;
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Returns true if the passed input and ingredient have an output
+     */
+    public static boolean hasOuput(ItemStack input, ItemStack ingredient)
+    {
+        return getOutput(input, ingredient) != null;
+    }
+
+    /**
+     * Used by the brewing stand to determine if its contents can be brewed.
+     * Extra parameters exist to allow modders to create bigger brewing stands
+     * without much hassle
+     */
+    public static boolean canBrew(ItemStack[] stacks, int[] inputIndexes, int ingredientIndex)
+    {
+        if (stacks[ingredientIndex] == null || stacks[ingredientIndex].stackSize <= 0) return false;
+
+        for (int i : inputIndexes)
+        {
+            if (getOutput(stacks[i], stacks[ingredientIndex]) != null)
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Used by the brewing stand to brew its inventory Extra parameters exist to
+     * allow modders to create bigger brewing stands without much hassle
+     */
+    public static void brewPotions(ItemStack[] stacks, int[] inputIndexes, int ingredientIndex)
+    {
+        for (int i : inputIndexes)
+        {
+            ItemStack output = getOutput(stacks[i], stacks[ingredientIndex]);
+            if (output != null)
+            {
+                stacks[i] = output;
+            }
+        }
+    }
+
+    /**
+     * Returns true if the passed ItemStack is a valid ingredient for any of the
+     * recipes in the registry.
+     */
+    public static boolean isValidIngredient(ItemStack stack)
+    {
+        if (stack == null || stack.stackSize <= 0) return false;
+
+        for (IBrewingRecipe recipe : recipes)
+        {
+            if (recipe.isIngredient(stack))
+            {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Returns true if the passed ItemStack is a valid input for any of the
+     * recipes in the registry.
+     */
+    public static boolean isValidInput(ItemStack stack)
+    {
+        if (stack == null || stack.getMaxStackSize() != 1 || stack.stackSize != 1) return false;
+
+        for (IBrewingRecipe recipe : recipes)
+        {
+            if (recipe.isInput(stack))
+            {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Returns an unmodifiable list containing all the recipes in the registry
+     */
+    public static List<IBrewingRecipe> getRecipes()
+    {
+        return Collections.unmodifiableList(recipes);
+    }
+}

--- a/src/main/java/net/minecraftforge/common/brewing/IBrewingRecipe.java
+++ b/src/main/java/net/minecraftforge/common/brewing/IBrewingRecipe.java
@@ -1,0 +1,26 @@
+package net.minecraftforge.common.brewing;
+
+import net.minecraft.item.ItemStack;
+
+public interface IBrewingRecipe {
+
+    /**
+     * Returns true is the passed ItemStack is an input for this recipe. "Input"
+     * being the item that goes in one of the three bottom slots of the brewing
+     * stand (e.g: water bottle)
+     */
+    public boolean isInput(ItemStack input);
+
+    /**
+     * Returns true if the passed ItemStack is an ingredient for this recipe.
+     * "Ingredient" being the item that goes in the top slot of the brewing
+     * stand (e.g: nether wart)
+     */
+    public boolean isIngredient(ItemStack ingredient);
+
+    /**
+     * Returns the output when the passed input is brewed with the passed
+     * ingredient. Null if invalid input or ingredient.
+     */
+    public ItemStack getOutput(ItemStack input, ItemStack ingredient);
+}

--- a/src/main/java/net/minecraftforge/common/brewing/VanillaBrewingRecipe.java
+++ b/src/main/java/net/minecraftforge/common/brewing/VanillaBrewingRecipe.java
@@ -1,0 +1,59 @@
+package net.minecraftforge.common.brewing;
+
+import java.util.List;
+import net.minecraft.init.Items;
+import net.minecraft.item.ItemPotion;
+import net.minecraft.item.ItemStack;
+import net.minecraft.potion.PotionHelper;
+import net.minecraftforge.oredict.OreDictionary;
+
+public class VanillaBrewingRecipe implements IBrewingRecipe {
+
+    @Override
+    public boolean isInput(ItemStack stack)
+    {
+        return stack.getItem() instanceof ItemPotion || stack.getItem() == Items.glass_bottle;
+    }
+
+    @Override
+    public boolean isIngredient(ItemStack stack)
+    {
+        return stack.getItem().isPotionIngredient(stack);
+    }
+
+    @Override
+    public ItemStack getOutput(ItemStack input, ItemStack ingredient)
+    {
+        if (ingredient != null && input != null && input.getItem() instanceof ItemPotion)
+        {
+            int inputMeta = input.getMetadata();
+            int outputMeta = PotionHelper.applyIngredient(inputMeta, ingredient.getItem().getPotionEffect(ingredient));
+            if (inputMeta == outputMeta)
+            {
+                return null;
+            }
+
+            List oldEffects = Items.potionitem.getEffects(inputMeta);
+            List newEffects = Items.potionitem.getEffects(outputMeta);
+
+            boolean hasResult = false;
+            if ((inputMeta <= 0 || oldEffects != newEffects) && (oldEffects == null || !oldEffects.equals(newEffects) && newEffects != null))
+            {
+                hasResult = true;
+            }
+            else if (!ItemPotion.isSplash(inputMeta) && ItemPotion.isSplash(outputMeta))
+            {
+                hasResult = true;
+            }
+
+            if (hasResult)
+            {
+                ItemStack output = input.copy();
+                output.setItemDamage(outputMeta);
+                return output;
+            }
+        }
+
+        return null;
+    }
+}


### PR DESCRIPTION
As mentioned on #1779, this adds a brewing recipe registry allowing modders to add recipes to the brewing stand much more freely. I thought showing that it can be done is better than just saying it can, so here is it.

A few observations:
-The vanilla mechanic is still in place, it was moved to the VanillaBrewingRecipe class.
-Inputs (items that would go in the 3 bottoms slots of the brewing stands) cannot have stack sizes bigger than 1, since when the brewing occurs they are replaced by the output.
-I tried to be as vague as possible with the IBrewingRecipe interface to give as much freedom as possible for modders to do whatever they please.
-The forge events are still in place.

Not sure if what I did is up to Forge's standards, but even if not I hope this at least serves as an example to show that it can be done and maybe someone else will come along and do a better job XD

This was done to 1.8 but can be easily ported to 1.7.10 and I'll do so myself if this gets accepted.