### PR TITLE
1.7.10 fluid

### DIFF
--- a/src/main/java/net/minecraftforge/fluids/FluidContainerRegistry.java
+++ b/src/main/java/net/minecraftforge/fluids/FluidContainerRegistry.java
@@ -51,7 +51,7 @@ public abstract class FluidContainerRegistry
             code = 31*code + container.getItem().hashCode();
             code = 31*code + container.getItemDamage();
             if (stack != null)
-                code = 31*code + stack.getFluidID();
+                code = 31*code + stack.fluid.hashCode(); 
             return code;
         }
         @Override

--- a/src/main/java/net/minecraftforge/fluids/FluidRegistry.java
+++ b/src/main/java/net/minecraftforge/fluids/FluidRegistry.java
@@ -81,11 +81,12 @@ public abstract class FluidRegistry
     {
         if (fluids.containsKey(fluid.getName()))
         {
-            FMLLog.bigWarning("Duplicate registration attempt for fluid %s (type %s) has occurred. This is not a problem itself, but subsequent failed FluidStacks might be a result if not handled properly", fluid.getName(), fluid.getClass().getName());
+            FMLLog.bigWarning("Duplicate registration attempt for fluid %s (type %s) has occurred. This is not a problem itself, but subsequent failed FluidStacks result if this is not handled properly", fluid.getName(), fluid.getClass().getName());
             return false;
         }
         fluids.put(fluid.getName(), fluid);
-        fluidIDs.put(fluid, ++maxID);
+        maxID++;
+        fluidIDs.put(fluid, maxID);
         fluidNames.put(maxID, fluid.getName());
 
         MinecraftForge.EVENT_BUS.post(new FluidRegisterEvent(fluid.getName(), maxID));


### PR DESCRIPTION
Fixes FluidContainerRegistry keys in such a way that they are ID independent, which was *actually* the goal in the first place.

Also clarifies the multiple Fluid registration error message a bit.