### PR TITLE
Added LivingExperienceDropsEvent to change how much experience an entity drops

### DIFF
--- a/patches/minecraft/net/minecraft/entity/EntityLivingBase.java.patch
+++ b/patches/minecraft/net/minecraft/entity/EntityLivingBase.java.patch
@@ -9,6 +9,15 @@
              {
                  this.func_70078_a((Entity)null);
              }
+@@ -316,7 +316,7 @@
+             if (!this.field_70170_p.field_72995_K && (this.field_70718_bc > 0 || this.func_70684_aJ()) && this.func_146066_aG() && this.field_70170_p.func_82736_K().func_82766_b("doMobLoot"))
+             {
+                 i = this.func_70693_a(this.field_70717_bb);
+-
++                i = net.minecraftforge.event.ForgeEventFactory.getExperienceDrop(this, this.field_70717_bb, i);
+                 while (i > 0)
+                 {
+                     int j = EntityXPOrb.func_70527_a(i);
 @@ -377,6 +377,7 @@
      {
          this.field_70755_b = p_70604_1_;

--- a/src/main/java/net/minecraftforge/event/ForgeEventFactory.java
+++ b/src/main/java/net/minecraftforge/event/ForgeEventFactory.java
@@ -43,6 +43,7 @@ import net.minecraftforge.event.entity.EntityMountEvent;
 import net.minecraftforge.event.entity.EntityStruckByLightningEvent;
 import net.minecraftforge.event.entity.PlaySoundAtEntityEvent;
 import net.minecraftforge.event.entity.item.ItemExpireEvent;
+import net.minecraftforge.event.entity.living.LivingExperienceDropEvent;
 import net.minecraftforge.event.entity.living.LivingHealEvent;
 import net.minecraftforge.event.entity.living.LivingPackSizeEvent;
 import net.minecraftforge.event.entity.living.LivingSpawnEvent;
@@ -142,6 +143,16 @@ public class ForgeEventFactory
         AllowDespawn event = new AllowDespawn(entity);
         MinecraftForge.EVENT_BUS.post(event);
         return event.getResult();
+    }
+    
+    public static int getExperienceDrop(EntityLivingBase entity, EntityPlayer attackingPlayer, int originalExperience)
+    {
+       LivingExperienceDropEvent event = new LivingExperienceDropEvent(entity, attackingPlayer, originalExperience);
+       if (MinecraftForge.EVENT_BUS.post(event))
+       {
+           return 0;
+       }
+       return event.getDroppedExperience();
     }
 
     public static List<BiomeGenBase.SpawnListEntry> getPotentialSpawns(WorldServer world, EnumCreatureType type, BlockPos pos, List<BiomeGenBase.SpawnListEntry> oldList)

--- a/src/main/java/net/minecraftforge/event/entity/living/LivingExperienceDropEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/living/LivingExperienceDropEvent.java
@@ -1,0 +1,47 @@
+package net.minecraftforge.event.entity.living;
+
+import net.minecraft.entity.EntityLivingBase;
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraftforge.fml.common.eventhandler.Cancelable;
+
+/**
+ * Event for when an entity drops experience on its death, can be used to change
+ * the amount of experience points dropped or completely prevent dropping of experience
+ * by canceling the event.
+ */
+@Cancelable
+public class LivingExperienceDropEvent extends LivingEvent 
+{
+    final EntityPlayer attackingPlayer;
+    final int originalExperiencePoints;
+
+    int droppedExperiencePoints;
+
+    public LivingExperienceDropEvent(EntityLivingBase entity, EntityPlayer attackingPlayer, int originalExperience)
+    {
+        super(entity);
+
+        this.attackingPlayer = attackingPlayer;
+        this.originalExperiencePoints = this.droppedExperiencePoints = originalExperience;
+    }
+
+    public int getDroppedExperience()
+    {
+        return droppedExperiencePoints;
+    }
+
+    public void setDroppedExperience(int droppedExperience)
+    {
+        this.droppedExperiencePoints = droppedExperience;
+    }
+
+    public EntityPlayer getAttackingPlayer()
+    {
+        return attackingPlayer;
+    }
+
+    public int getOriginalExperience()
+    {
+        return originalExperiencePoints;
+    }
+}


### PR DESCRIPTION
This event allows modders to change the amount of experience entitys drop when they die.

While there is EntityLiving.experienceValue, the code that drops the experience calls EntityLivingBase.getExperiencePoints which is overridden in for example EntityAnimal to return a random value instead of experienceValue.

Example Mod: http://pastebin.com/kSptA30S
   Increases the experience dropped by ALL entitys by a factor of 10.


Remake of https://github.com/MinecraftForge/MinecraftForge/pull/1223, targeted at 1.8.