### PR TITLE
Adjusts OreDictionary to prevent invalid registrations.

### DIFF
--- a/src/main/java/net/minecraftforge/fluids/FluidContainerRegistry.java
+++ b/src/main/java/net/minecraftforge/fluids/FluidContainerRegistry.java
@@ -171,7 +171,7 @@ public abstract class FluidContainerRegistry
         }
         if (data.fluid == null || data.fluid.getFluid() == null)
         {
-        	FMLLog.bigWarning("Invalid registration attempt for a fluid container item %s (type %s) has occurred. The registration has been denied to prevent crashes. The mod responsible for the registration needs to correct this.", data.filledContainer.getItem().getUnlocalizedName(data.filledContainer));
+        	FMLLog.bigWarning("Invalid registration attempt for a fluid container item %s has occurred. The registration has been denied to prevent crashes. The mod responsible for the registration needs to correct this.", data.filledContainer.getItem().getUnlocalizedName(data.filledContainer));
         	return false;
         }
         containerFluidMap.put(new ContainerKey(data.filledContainer), data);

--- a/src/main/java/net/minecraftforge/oredict/OreDictionary.java
+++ b/src/main/java/net/minecraftforge/oredict/OreDictionary.java
@@ -344,7 +344,7 @@ public class OreDictionary
      */
     public static ArrayList<ItemStack> getOres(String name) //TODO: 1.8 ArrayList -> List
     {
-        return getOres(getOreID(name));
+        return nameToId.get(name) != null ? getOres(getOreID(name)) : EMPTY_LIST;
     }
 
     /**
@@ -447,7 +447,12 @@ public class OreDictionary
      */
     private static void registerOreImpl(String name, ItemStack ore)
     {
-        if ("Unknown".equals(name)) return; //prevent bad IDs.
+        if (name == null || name.isEmpty() || "Unknown".equals(name)) return; //prevent bad IDs.
+        if (ore == null || ore.getItem() == null)
+        {
+        	FMLLog.bigWarning("Invalid registration attempt for an Ore Dictionary item with name %s has occurred. The registration has been denied to prevent crashes. The mod responsible for the registration needs to correct this.", name);
+        	return; //prevent bad ItemStacks.
+        }
 
         int oreID = getOreID(name);
         int hash = Item.getIdFromItem(ore.getItem());


### PR DESCRIPTION
Getting Ore Names for a non-existent ore will no longer automatically add that Name to the list nor generate an ID.

Tweaks a warning message in the FluidContainerRegistry. No functionality change.

Signed-off-by: King Lemming <kinglemming@gmail.com>