### PR TITLE
Add true support for unicode fonts

### DIFF
--- a/patches/minecraft/net/minecraft/client/gui/FontRenderer.java.patch
+++ b/patches/minecraft/net/minecraft/client/gui/FontRenderer.java.patch
@@ -1,0 +1,31 @@
+--- ../src-base/minecraft/net/minecraft/client/gui/FontRenderer.java
++++ ../src-work/minecraft/net/minecraft/client/gui/FontRenderer.java
+@@ -97,6 +97,7 @@
+     public void func_110549_a(IResourceManager p_110549_1_)
+     {
+         this.func_111272_d();
++        this.func_98306_d();
+     }
+ 
+     private void func_111272_d()
+@@ -390,7 +391,7 @@
+                     j = k;
+                 }
+ 
+-                float f1 = this.field_78293_l ? 0.5F : 1.0F;
++                float f1 = func_78263_a(c0) / 32f;
+                 boolean flag1 = (c0 == 0 || j == -1 || this.field_78293_l) && p_78255_2_;
+ 
+                 if (flag1)
+@@ -583,11 +584,6 @@
+                 int j = this.field_78287_e[p_78263_1_] >>> 4;
+                 int k = this.field_78287_e[p_78263_1_] & 15;
+ 
+-                if (k > 7)
+-                {
+-                    k = 15;
+-                    j = 0;
+-                }
+ 
+                 ++k;
+                 return (k - j) / 2 + 1;


### PR DESCRIPTION
1. Add additional readGlyphSizes call in onResourceManagerReload for allowance to specify custom glyph sizes in resourcepacks (now it works only after restart).
2. Remove artificial restriction of max glyph size of unicode.
3. Remove force shadow shift for unicode font.

Some screenshots:
Vanilla (almost), default resource pack:
![screenshot from 2015-04-16 22-45-27](https://cloud.githubusercontent.com/assets/1416030/7185005/20b05938-e482-11e4-89ef-a18ff5c5d843.png)
Vanilla, custom resource pack:
![screenshot from 2015-04-16 22-33-33](https://cloud.githubusercontent.com/assets/1416030/7185024/3e27c8ca-e482-11e4-8827-452137ad9b38.png)
Patch (without shadow), custom resource pack:
![screenshot from 2015-04-16 22-34-19](https://cloud.githubusercontent.com/assets/1416030/7185037/4d8fa012-e482-11e4-98bc-00b226b9dd1f.png)
Patch with shadow support:
![screenshot from 2015-04-17 17-42-58](https://cloud.githubusercontent.com/assets/1416030/7200656/fb11c73a-e520-11e4-90b1-3be7b5f57437.png)

*Possible also can be useful for 1.7.10 branch*