### PR TITLE
Extracted the creation of RegionRenderCache into a method for extendability

### DIFF
--- a/patches/minecraft/net/minecraft/client/renderer/chunk/RenderChunk.java.patch
+++ b/patches/minecraft/net/minecraft/client/renderer/chunk/RenderChunk.java.patch
@@ -1,5 +1,14 @@
 --- ../src-base/minecraft/net/minecraft/client/renderer/chunk/RenderChunk.java
 +++ ../src-work/minecraft/net/minecraft/client/renderer/chunk/RenderChunk.java
+@@ -124,7 +124,7 @@
+                 return;
+             }
+ 
+-            regionrendercache = new RegionRenderCache(this.field_178588_d, blockpos.func_177982_a(-1, -1, -1), blockpos1.func_177982_a(1, 1, 1), 1);
++            regionrendercache = createRegionRenderCache(this.field_178588_d, blockpos.func_177982_a(-1, -1, -1), blockpos1.func_177982_a(1, 1, 1), 1);
+             p_178581_4_.func_178543_a(compiledchunk);
+         }
+         finally
 @@ -150,7 +150,7 @@
                      visgraph.func_178606_a(mutableblockpos);
                  }
@@ -28,3 +37,28 @@
              }
  
              EnumWorldBlockLayer[] aenumworldblocklayer = EnumWorldBlockLayer.values();
+@@ -374,4 +377,24 @@
+     {
+         return this.field_178593_n;
+     }
++
++    /* ======================================== FORGE START =====================================*/
++    /**
++     * Creates a new RegionRenderCache instance.<br>
++     * Extending classes can change the behavior of the cache, allowing to visually change
++     * blocks (schematics etc).
++     *
++     * @see RegionRenderCache
++     * @param world The world to cache.
++     * @param from The starting position of the chunk minus one on each axis.
++     * @param to The ending position of the chunk plus one on each axis.
++     * @param subtract Padding used internally by the RegionRenderCache constructor to make
++     *                 the cache a 20x20x20 cube, for a total of 8000 states in the cache.
++     * @return new RegionRenderCache instance
++     */
++    protected RegionRenderCache createRegionRenderCache(World world, BlockPos from, BlockPos to, int subtract)
++    {
++        return new RegionRenderCache(world, from, to, subtract);
++    }
++    /* ========================================= FORGE END ======================================*/
+ }


### PR DESCRIPTION
This allows any extending classes to define their own implementation of `BlockRendererDispatcher`.

The alternative to this (which I'm currently using) is to replace the vanilla instance with the custom instance in every `preRenderBlocks`/`postRenderBlocks` call, but that's not reliable and might cause other issues.

Alternatively this could be moved to a method that would return the dispatcher instance and extending classes would override the method.