### PR TITLE
Fix a bug in BlockState$StateImplementation that caused withProperty to return null in some situations.

### DIFF
--- a/patches/minecraft/net/minecraft/block/state/BlockState.java.patch
+++ b/patches/minecraft/net/minecraft/block/state/BlockState.java.patch
@@ -26,6 +26,15 @@
              linkedhashmap.put(map, stateimplementation);
              arraylist.add(stateimplementation);
          }
+@@ -165,7 +175,7 @@
+                 }
+                 else
+                 {
+-                    return (IBlockState)(this.field_177237_b.get(p_177226_1_) == p_177226_2_ ? this : (IBlockState)this.field_177238_c.get(p_177226_1_, p_177226_2_));
++                    return (IBlockState)(this.field_177237_b.get(p_177226_1_).equals(p_177226_2_) ? this : (IBlockState)this.field_177238_c.get(p_177226_1_, p_177226_2_));
+                 }
+             }
+ 
 @@ -231,5 +241,10 @@
              {
                  this(p_i45661_1_, p_i45661_2_);


### PR DESCRIPTION
This pull request fixes a bug in BlockSate$StateImplementation which causes withProperty to return null when it is passed a property whose class extends .equals(), and the same value that StateImplementation's property is already set to. This was caused by StateImplementation using "properties.get(iproperty) == value" rather than ".equals(value)" to check whether its property is already the correct value, to allow it to return itself.