### PR TITLE
[1.7.10] Fixes MC-52974: Host's skin doesn't load in LAN

### DIFF
--- a/patches/minecraft/net/minecraft/client/Minecraft.java.patch
+++ b/patches/minecraft/net/minecraft/client/Minecraft.java.patch
@@ -56,7 +56,7 @@
          if (p_147108_1_ instanceof GuiMainMenu)
          {
              this.field_71474_y.field_74330_P = false;
-@@ -1341,7 +1346,7 @@
+@@ -1342,7 +1347,7 @@
  
                      if (this.field_71439_g.func_82246_f(i, j, k))
                      {
@@ -65,7 +65,7 @@
                          this.field_71439_g.func_71038_i();
                      }
                  }
-@@ -1422,11 +1427,12 @@
+@@ -1423,11 +1428,12 @@
                      int j = this.field_71476_x.field_72312_c;
                      int k = this.field_71476_x.field_72309_d;
  
@@ -80,7 +80,7 @@
                          {
                              flag = false;
                              this.field_71439_g.func_71038_i();
-@@ -1453,7 +1459,8 @@
+@@ -1454,7 +1460,8 @@
          {
              ItemStack itemstack1 = this.field_71439_g.field_71071_by.func_70448_g();
  
@@ -90,7 +90,7 @@
              {
                  this.field_71460_t.field_78516_c.func_78445_c();
              }
-@@ -1665,6 +1672,8 @@
+@@ -1666,6 +1673,8 @@
  
              while (Mouse.next())
              {
@@ -99,7 +99,22 @@
                  j = Mouse.getEventButton();
                  KeyBinding.func_74510_a(j - 100, Mouse.getEventButtonState());
  
-@@ -2127,6 +2136,11 @@
+@@ -2117,7 +2126,13 @@
+         NetworkManager networkmanager = NetworkManager.func_150722_a(socketaddress);
+         networkmanager.func_150719_a(new NetHandlerLoginClient(networkmanager, this, (GuiScreen)null));
+         networkmanager.func_150725_a(new C00Handshake(5, socketaddress.toString(), 0, EnumConnectionState.LOGIN), new GenericFutureListener[0]);
+-        networkmanager.func_150725_a(new C00PacketLoginStart(this.func_110432_I().func_148256_e()), new GenericFutureListener[0]);
++        com.mojang.authlib.GameProfile gameProfile = this.func_110432_I().func_148256_e();
++        if (!this.func_110432_I().hasCachedProperties())
++        {
++            gameProfile = field_152355_az.fillProfileProperties(gameProfile, true); //Forge: Fill profile properties upon game load. Fixes MC-52974.
++            this.func_110432_I().setProperties(gameProfile.getProperties());
++        }
++        networkmanager.func_150725_a(new C00PacketLoginStart(gameProfile), new GenericFutureListener[0]);
+         this.field_71453_ak = networkmanager;
+     }
+ 
+@@ -2128,6 +2143,11 @@
  
      public void func_71353_a(WorldClient p_71353_1_, String p_71353_2_)
      {
@@ -111,7 +126,7 @@
          if (p_71353_1_ == null)
          {
              NetHandlerPlayClient nethandlerplayclient = this.func_147114_u();
-@@ -2139,6 +2153,18 @@
+@@ -2140,6 +2160,18 @@
              if (this.field_71437_Z != null)
              {
                  this.field_71437_Z.func_71263_m();
@@ -130,7 +145,7 @@
              }
  
              this.field_71437_Z = null;
-@@ -2287,113 +2313,10 @@
+@@ -2288,113 +2320,10 @@
          if (this.field_71476_x != null)
          {
              boolean flag = this.field_71439_g.field_71075_bZ.field_75098_d;
@@ -246,7 +261,7 @@
              if (flag)
              {
                  j = this.field_71439_g.field_71069_bz.field_75151_b.size() - 9 + this.field_71439_g.field_71071_by.field_70461_c;
-@@ -2659,8 +2582,15 @@
+@@ -2660,8 +2589,15 @@
          p_70001_1_.func_152767_b("gl_max_texture_size", Integer.valueOf(func_71369_N()));
      }
  
@@ -262,7 +277,7 @@
          for (int i = 16384; i > 0; i >>= 1)
          {
              GL11.glTexImage2D(GL11.GL_PROXY_TEXTURE_2D, 0, GL11.GL_RGBA, i, i, 0, GL11.GL_RGBA, GL11.GL_UNSIGNED_BYTE, (ByteBuffer)null);
-@@ -2668,6 +2598,7 @@
+@@ -2669,6 +2605,7 @@
  
              if (j != 0)
              {

--- a/patches/minecraft/net/minecraft/util/Session.java.patch
+++ b/patches/minecraft/net/minecraft/util/Session.java.patch
@@ -1,6 +1,11 @@
 --- ../src-base/minecraft/net/minecraft/util/Session.java
 +++ ../src-work/minecraft/net/minecraft/util/Session.java
-@@ -19,6 +19,19 @@
+@@ -16,9 +16,24 @@
+     private final String field_148258_c;
+     private final Session.Type field_152429_d;
+     private static final String __OBFID = "CL_00000659";
++    /** Forge: Cache of the local session's GameProfile properties. */
++    private com.mojang.authlib.properties.PropertyMap properties;
  
      public Session(String p_i1098_1_, String p_i1098_2_, String p_i1098_3_, String p_i1098_4_)
      {
@@ -20,7 +25,14 @@
          this.field_74286_b = p_i1098_1_;
          this.field_148257_b = p_i1098_2_;
          this.field_148258_c = p_i1098_3_;
-@@ -54,7 +67,7 @@
+@@ -50,11 +65,13 @@
+         try
+         {
+             UUID uuid = UUIDTypeAdapter.fromString(this.func_148255_b());
+-            return new GameProfile(uuid, this.func_111285_a());
++            GameProfile ret = new GameProfile(uuid, this.func_111285_a());    //Forge: Adds cached GameProfile properties to returned GameProfile.
++            if (properties != null) ret.getProperties().putAll(properties); // Helps to cut down on calls to the session service,
++            return ret;                                                     // which helps to fix MC-52974.
          }
          catch (IllegalArgumentException illegalargumentexception)
          {
@@ -29,3 +41,21 @@
          }
      }
  
+@@ -95,4 +112,17 @@
+             }
+         }
+     }
++
++    /* ======================================== FORGE START ===================================== */
++    //For internal use only. Modders should never need to use this.
++    public void setProperties(com.mojang.authlib.properties.PropertyMap properties)
++    {
++        if (this.properties == null) this.properties = properties;
++    }
++
++    public boolean hasCachedProperties()
++    {
++        return properties != null;
++    }
++    /* ========================================= FORGE END ====================================== */
+ }


### PR DESCRIPTION
This was a bugger to track down the cause, and also a pain to find a good solution, but I think I finally got it.

The problem is this. When rendering a player, the SkinManager would take their GameProfile and try to extract the skins out of it. Since 1.7.6 (I think), the skins started to be signed, and when the SkinManager would ask for the skins, they would also verify that they were signed and the signature was valid. If that ended up being false, and the player that they were trying to fetch skins for was the local player, then they would fill the GameProfile properties (because the passed in GameProfile for the local player wouldn't contain the skin properties, which I'll get to in a sec) and then extract the textures from that without verifying the signatures. All well and good

Now, when the player who will be the eventual host for the LAN world boots up a single player world, they construct the EntityPlayer with the GameProfile from the Session, which will just contain the UUID and username. That's because, at the time, it's only a single player world, so the GameProfile doesn't *need* to be constructed with any other properties, because when it comes to the SkinManager will do what I detailed above, so it really doesn't matter. Now, when that player opens up the single player world to LAN, and another client connects to it, Minecraft treats it like a server, kinda. The player who's joining the "server" (or LAN world in this case) get's their GameProfile filled, and that is sent to the LAN host's world. Therefore, the LAN host can see their skin. However, the GameProfile that is sent to all connecting clients is the one used to construct the LAN host's EntityPlayer, which doesn't contain the textures. Therefore, anyone joining can see everyone's skin but the host's, and the host can see everyone's skin including their own.

So there's the problem. Solution, obviously, is to fill the GameProfile used to construct the LAN host's EntityPlayer. However, implementing this was kind of a pain. I started out by just filling the GameProfile when the C00PacketLoginStart was being constructed for the single player world. However, this caused a TooManyRequestsException from Mojang's session servers when the SkinManager queried the servers for the skins to render on the local session's player (which, because there's a client player and a server player, the server player was the one with the skin data, and the client one didn't have it). When that happened may have just been that I was tired or not thinking straight. I spent the next hour and a half toying with a bunch of stuff, but could never get a viable solution. Then I got some food and came back, and it hit me; I should just cache the GameProfile properties in the local session. Now, I can't fill it upon constructing the session because that would rely on the Minecraft class, whose constructor requires a session, so therefore, I couldn't fill it immediately. So, instead, upon constructing the first C00PacketLoginStart for single player worlds, the GameProfile gets filled, and the properties get cached, and any calls to the Session to get the GameProfile after that contain the properties. That way: a) All other players in the LAN world can see the host's skin, and b) the SkinManager never has to call fillProfileProperties, which cuts down on the amount of calls it makes.

Aaaaaaaand that's it. I'd be willing to make another PR for 1.8, but I didn't know if you'd handle that or not. Also, not sure what's up with the Minecraft patch, but every time I run genPatches for ANY PR, it always gens a patch for the Minecraft class with everything shifted down a line and no changes. Considering everything seems to work as it is, I just always left it alone. However, can't really do that now. Hopefully it's not an issue...