### PR TITLE
Removed @SideOnly(Side.CLIENT) from EnumWorldBlockLayer.

### DIFF
--- a/patches/minecraft/net/minecraft/util/EnumWorldBlockLayer.java.patch
+++ b/patches/minecraft/net/minecraft/util/EnumWorldBlockLayer.java.patch
@@ -1,0 +1,12 @@
+--- ../src-base/minecraft/net/minecraft/util/EnumWorldBlockLayer.java
++++ ../src-work/minecraft/net/minecraft/util/EnumWorldBlockLayer.java
+@@ -1,9 +1,5 @@
+ package net.minecraft.util;
+ 
+-import net.minecraftforge.fml.relauncher.Side;
+-import net.minecraftforge.fml.relauncher.SideOnly;
+-
+-@SideOnly(Side.CLIENT)
+ public enum EnumWorldBlockLayer
+ {
+     SOLID("Solid"),


### PR DESCRIPTION
Removed "@SideOnly(Side.CLIENT)" from EnumWorldBlockLayer to solve a crash which occurs if something attempts to get the list of methods in Block or a subclass of Block. This is caused by "Block.canRenderInLayer(EnumWorldBlockLayer)" not being removed on the server side, so the server would attempt to load EnumWorldBlockLayer when it does not exist.