### PR TITLE
Make World.setBlockState check whether the light value from getLightValue(IBlockAccess, BlockPos) has changed.

### DIFF
--- a/patches/minecraft/net/minecraft/world/World.java.patch
+++ b/patches/minecraft/net/minecraft/world/World.java.patch
@@ -99,7 +99,7 @@
      }
  
      public boolean func_175667_e(BlockPos p_175667_1_)
-@@ -286,10 +318,19 @@
+@@ -286,39 +318,58 @@
          {
              Chunk chunk = this.func_175726_f(p_180501_1_);
              Block block = p_180501_2_.func_177230_c();
@@ -110,6 +110,7 @@
 +                blockSnapshot = net.minecraftforge.common.util.BlockSnapshot.getBlockSnapshot(this, p_180501_1_, p_180501_3_);
 +                this.capturedBlockSnapshots.add(blockSnapshot);
 +            }
++            int oldLight = func_180495_p(p_180501_1_).func_177230_c().getLightValue(this, p_180501_1_);
 +
              IBlockState iblockstate1 = chunk.func_177436_a(p_180501_1_, p_180501_2_);
  
@@ -119,7 +120,14 @@
                  return false;
              }
              else
-@@ -303,22 +344,31 @@
+             {
+                 Block block1 = iblockstate1.func_177230_c();
+ 
+-                if (block.func_149717_k() != block1.func_149717_k() || block.func_149750_m() != block1.func_149750_m())
++                if (block.func_149717_k() != block1.func_149717_k() || block.getLightValue(this, p_180501_1_) != oldLight)
+                 {
+                     this.field_72984_F.func_76320_a("checkLight");
+                     this.func_175664_x(p_180501_1_);
                      this.field_72984_F.func_76319_b();
                  }
  
@@ -162,7 +170,7 @@
              }
          }
      }
-@@ -408,6 +458,9 @@
+@@ -408,6 +459,9 @@
  
      public void func_175685_c(BlockPos p_175685_1_, Block p_175685_2_)
      {
@@ -172,7 +180,7 @@
          this.func_180496_d(p_175685_1_.func_177976_e(), p_175685_2_);
          this.func_180496_d(p_175685_1_.func_177974_f(), p_175685_2_);
          this.func_180496_d(p_175685_1_.func_177977_b(), p_175685_2_);
-@@ -418,6 +471,11 @@
+@@ -418,6 +472,11 @@
  
      public void func_175695_a(BlockPos p_175695_1_, Block p_175695_2_, EnumFacing p_175695_3_)
      {
@@ -184,7 +192,7 @@
          if (p_175695_3_ != EnumFacing.WEST)
          {
              this.func_180496_d(p_175695_1_.func_177976_e(), p_175695_2_);
-@@ -782,7 +840,7 @@
+@@ -782,7 +841,7 @@
  
      public boolean func_72935_r()
      {
@@ -193,7 +201,7 @@
      }
  
      public MovingObjectPosition func_72933_a(Vec3 p_72933_1_, Vec3 p_72933_2_)
-@@ -978,6 +1036,11 @@
+@@ -978,6 +1037,11 @@
  
      public void func_72956_a(Entity p_72956_1_, String p_72956_2_, float p_72956_3_, float p_72956_4_)
      {
@@ -205,7 +213,7 @@
          for (int i = 0; i < this.field_73021_x.size(); ++i)
          {
              ((IWorldAccess)this.field_73021_x.get(i)).func_72704_a(p_72956_2_, p_72956_1_.field_70165_t, p_72956_1_.field_70163_u, p_72956_1_.field_70161_v, p_72956_3_, p_72956_4_);
-@@ -986,6 +1049,11 @@
+@@ -986,6 +1050,11 @@
  
      public void func_85173_a(EntityPlayer p_85173_1_, String p_85173_2_, float p_85173_3_, float p_85173_4_)
      {
@@ -217,7 +225,7 @@
          for (int i = 0; i < this.field_73021_x.size(); ++i)
          {
              ((IWorldAccess)this.field_73021_x.get(i)).func_85102_a(p_85173_1_, p_85173_2_, p_85173_1_.field_70165_t, p_85173_1_.field_70163_u, p_85173_1_.field_70161_v, p_85173_3_, p_85173_4_);
-@@ -1037,6 +1105,9 @@
+@@ -1037,6 +1106,9 @@
  
      public boolean func_72838_d(Entity p_72838_1_)
      {
@@ -227,7 +235,7 @@
          int i = MathHelper.func_76128_c(p_72838_1_.field_70165_t / 16.0D);
          int j = MathHelper.func_76128_c(p_72838_1_.field_70161_v / 16.0D);
          boolean flag = p_72838_1_.field_98038_p;
-@@ -1059,6 +1130,8 @@
+@@ -1059,6 +1131,8 @@
                  this.func_72854_c();
              }
  
@@ -236,7 +244,7 @@
              this.func_72964_e(i, j).func_76612_a(p_72838_1_);
              this.field_72996_f.add(p_72838_1_);
              this.func_72923_a(p_72838_1_);
-@@ -1271,17 +1344,29 @@
+@@ -1271,17 +1345,29 @@
  
      public int func_72967_a(float p_72967_1_)
      {
@@ -269,7 +277,7 @@
      public void func_72848_b(IWorldAccess p_72848_1_)
      {
          this.field_73021_x.remove(p_72848_1_);
-@@ -1290,6 +1375,12 @@
+@@ -1290,6 +1376,12 @@
      @SideOnly(Side.CLIENT)
      public float func_72971_b(float p_72971_1_)
      {
@@ -282,7 +290,7 @@
          float f1 = this.func_72826_c(p_72971_1_);
          float f2 = 1.0F - (MathHelper.func_76134_b(f1 * (float)Math.PI * 2.0F) * 2.0F + 0.2F);
          f2 = MathHelper.func_76131_a(f2, 0.0F, 1.0F);
-@@ -1302,6 +1393,12 @@
+@@ -1302,6 +1394,12 @@
      @SideOnly(Side.CLIENT)
      public Vec3 func_72833_a(Entity p_72833_1_, float p_72833_2_)
      {
@@ -295,7 +303,7 @@
          float f1 = this.func_72826_c(p_72833_2_);
          float f2 = MathHelper.func_76134_b(f1 * (float)Math.PI * 2.0F) * 2.0F + 0.5F;
          f2 = MathHelper.func_76131_a(f2, 0.0F, 1.0F);
-@@ -1309,9 +1406,7 @@
+@@ -1309,9 +1407,7 @@
          int j = MathHelper.func_76128_c(p_72833_1_.field_70163_u);
          int k = MathHelper.func_76128_c(p_72833_1_.field_70161_v);
          BlockPos blockpos = new BlockPos(i, j, k);
@@ -306,7 +314,7 @@
          float f4 = (float)(l >> 16 & 255) / 255.0F;
          float f5 = (float)(l >> 8 & 255) / 255.0F;
          float f6 = (float)(l & 255) / 255.0F;
-@@ -1373,6 +1468,11 @@
+@@ -1373,6 +1469,11 @@
  
      public float func_130001_d()
      {
@@ -318,7 +326,7 @@
          return WorldProvider.field_111203_a[this.field_73011_w.func_76559_b(this.field_72986_A.func_76073_f())];
      }
  
-@@ -1385,6 +1485,12 @@
+@@ -1385,6 +1486,12 @@
      @SideOnly(Side.CLIENT)
      public Vec3 func_72824_f(float p_72824_1_)
      {
@@ -331,7 +339,7 @@
          float f1 = this.func_72826_c(p_72824_1_);
          float f2 = MathHelper.func_76134_b(f1 * (float)Math.PI * 2.0F) * 2.0F + 0.5F;
          f2 = MathHelper.func_76131_a(f2, 0.0F, 1.0F);
-@@ -1442,9 +1548,9 @@
+@@ -1442,9 +1549,9 @@
          for (blockpos1 = new BlockPos(p_175672_1_.func_177958_n(), chunk.func_76625_h() + 16, p_175672_1_.func_177952_p()); blockpos1.func_177956_o() >= 0; blockpos1 = blockpos2)
          {
              blockpos2 = blockpos1.func_177977_b();
@@ -343,7 +351,7 @@
              {
                  break;
              }
-@@ -1456,6 +1562,12 @@
+@@ -1456,6 +1563,12 @@
      @SideOnly(Side.CLIENT)
      public float func_72880_h(float p_72880_1_)
      {
@@ -356,7 +364,7 @@
          float f1 = this.func_72826_c(p_72880_1_);
          float f2 = 1.0F - (MathHelper.func_76134_b(f1 * (float)Math.PI * 2.0F) * 2.0F + 0.25F);
          f2 = MathHelper.func_76131_a(f2, 0.0F, 1.0F);
-@@ -1500,7 +1612,15 @@
+@@ -1500,7 +1613,15 @@
                      entity.func_85029_a(crashreportcategory);
                  }
  
@@ -373,7 +381,7 @@
              }
  
              if (entity.field_70128_L)
-@@ -1562,7 +1682,16 @@
+@@ -1562,7 +1683,16 @@
                      crashreport = CrashReport.func_85055_a(throwable1, "Ticking entity");
                      crashreportcategory = crashreport.func_85058_a("Entity being ticked");
                      entity.func_85029_a(crashreportcategory);
@@ -391,7 +399,7 @@
                  }
              }
  
-@@ -1609,7 +1738,16 @@
+@@ -1609,7 +1739,16 @@
                          CrashReport crashreport1 = CrashReport.func_85055_a(throwable, "Ticking block entity");
                          CrashReportCategory crashreportcategory1 = crashreport1.func_85058_a("Block entity being ticked");
                          tileentity.func_145828_a(crashreportcategory1);
@@ -409,7 +417,7 @@
                      }
                  }
              }
-@@ -1628,6 +1766,10 @@
+@@ -1628,6 +1767,10 @@
  
          if (!this.field_147483_b.isEmpty())
          {
@@ -420,7 +428,7 @@
              this.field_175730_i.removeAll(this.field_147483_b);
              this.field_147482_g.removeAll(this.field_147483_b);
              this.field_147483_b.clear();
-@@ -1668,7 +1810,8 @@
+@@ -1668,7 +1811,8 @@
  
      public boolean func_175700_a(TileEntity p_175700_1_)
      {
@@ -430,7 +438,7 @@
  
          if (flag && p_175700_1_ instanceof IUpdatePlayerListBox)
          {
-@@ -1710,9 +1853,12 @@
+@@ -1710,9 +1854,12 @@
      {
          int i = MathHelper.func_76128_c(p_72866_1_.field_70165_t);
          int j = MathHelper.func_76128_c(p_72866_1_.field_70161_v);
@@ -445,7 +453,7 @@
          {
              p_72866_1_.field_70142_S = p_72866_1_.field_70165_t;
              p_72866_1_.field_70137_T = p_72866_1_.field_70163_u;
-@@ -1839,7 +1985,7 @@
+@@ -1839,7 +1986,7 @@
                  {
                      Block block = this.func_180495_p(new BlockPos(k1, l1, i2)).func_177230_c();
  
@@ -454,7 +462,7 @@
                      {
                          return true;
                      }
-@@ -1901,6 +2047,10 @@
+@@ -1901,6 +2048,10 @@
                          {
                              return true;
                          }
@@ -465,7 +473,7 @@
                      }
                  }
              }
-@@ -2039,6 +2189,7 @@
+@@ -2039,6 +2190,7 @@
      public Explosion func_72885_a(Entity p_72885_1_, double p_72885_2_, double p_72885_4_, double p_72885_6_, float p_72885_8_, boolean p_72885_9_, boolean p_72885_10_)
      {
          Explosion explosion = new Explosion(this, p_72885_1_, p_72885_2_, p_72885_4_, p_72885_6_, p_72885_8_, p_72885_9_, p_72885_10_);
@@ -473,7 +481,7 @@
          explosion.func_77278_a();
          explosion.func_77279_a(true);
          return explosion;
-@@ -2185,19 +2336,28 @@
+@@ -2185,19 +2337,28 @@
              else
              {
                  this.func_175700_a(p_175690_2_);
@@ -503,7 +511,7 @@
          }
          else
          {
-@@ -2210,6 +2370,7 @@
+@@ -2210,6 +2371,7 @@
  
              this.func_175726_f(p_175713_1_).func_177425_e(p_175713_1_);
          }
@@ -511,7 +519,7 @@
      }
  
      public void func_147457_a(TileEntity p_147457_1_)
-@@ -2228,7 +2389,7 @@
+@@ -2228,7 +2390,7 @@
      {
          IBlockState iblockstate = p_175683_0_.func_180495_p(p_175683_1_);
          Block block = iblockstate.func_177230_c();
@@ -520,7 +528,7 @@
      }
  
      public boolean func_175677_d(BlockPos p_175677_1_, boolean p_175677_2_)
-@@ -2248,7 +2409,7 @@
+@@ -2248,7 +2410,7 @@
              else
              {
                  Block block = this.func_180495_p(p_175677_1_).func_177230_c();
@@ -529,7 +537,7 @@
              }
          }
      }
-@@ -2265,8 +2426,7 @@
+@@ -2265,8 +2427,7 @@
  
      public void func_72891_a(boolean p_72891_1_, boolean p_72891_2_)
      {
@@ -539,7 +547,7 @@
      }
  
      public void func_72835_b()
-@@ -2276,6 +2436,11 @@
+@@ -2276,6 +2437,11 @@
  
      protected void func_72947_a()
      {
@@ -551,7 +559,7 @@
          if (this.field_72986_A.func_76059_o())
          {
              this.field_73004_o = 1.0F;
-@@ -2289,6 +2454,11 @@
+@@ -2289,6 +2455,11 @@
  
      protected void func_72979_l()
      {
@@ -563,7 +571,7 @@
          if (!this.field_73011_w.func_177495_o())
          {
              if (!this.field_72995_K)
-@@ -2383,6 +2553,7 @@
+@@ -2383,6 +2554,7 @@
      {
          this.field_72993_I.clear();
          this.field_72984_F.func_76320_a("buildList");
@@ -571,7 +579,7 @@
          int i;
          EntityPlayer entityplayer;
          int j;
-@@ -2445,7 +2616,7 @@
+@@ -2445,7 +2617,7 @@
              l += p_147467_1_;
              i1 += p_147467_2_;
  
@@ -580,7 +588,7 @@
              {
                  EntityPlayer entityplayer = this.func_72977_a((double)l + 0.5D, (double)j1 + 0.5D, (double)i1 + 0.5D, 8.0D);
  
-@@ -2485,6 +2656,11 @@
+@@ -2485,6 +2657,11 @@
  
      public boolean func_175670_e(BlockPos p_175670_1_, boolean p_175670_2_)
      {
@@ -592,7 +600,7 @@
          BiomeGenBase biomegenbase = this.func_180494_b(p_175670_1_);
          float f = biomegenbase.func_180626_a(p_175670_1_);
  
-@@ -2526,6 +2702,11 @@
+@@ -2526,6 +2703,11 @@
  
      public boolean func_175708_f(BlockPos p_175708_1_, boolean p_175708_2_)
      {
@@ -604,7 +612,7 @@
          BiomeGenBase biomegenbase = this.func_180494_b(p_175708_1_);
          float f = biomegenbase.func_180626_a(p_175708_1_);
  
-@@ -2543,7 +2724,7 @@
+@@ -2543,7 +2725,7 @@
              {
                  Block block = this.func_180495_p(p_175708_1_).func_177230_c();
  
@@ -613,7 +621,7 @@
                  {
                      return true;
                  }
-@@ -2575,10 +2756,11 @@
+@@ -2575,10 +2757,11 @@
          else
          {
              Block block = this.func_180495_p(p_175638_1_).func_177230_c();
@@ -628,7 +636,7 @@
              {
                  j = 1;
              }
-@@ -2792,10 +2974,10 @@
+@@ -2792,10 +2975,10 @@
      public List func_175674_a(Entity p_175674_1_, AxisAlignedBB p_175674_2_, Predicate p_175674_3_)
      {
          ArrayList arraylist = Lists.newArrayList();
@@ -643,7 +651,7 @@
  
          for (int i1 = i; i1 <= j; ++i1)
          {
-@@ -2854,10 +3036,10 @@
+@@ -2854,10 +3037,10 @@
  
      public List func_175647_a(Class p_175647_1_, AxisAlignedBB p_175647_2_, Predicate p_175647_3_)
      {
@@ -658,7 +666,7 @@
          ArrayList arraylist = Lists.newArrayList();
  
          for (int i1 = i; i1 <= j; ++i1)
-@@ -2938,13 +3120,16 @@
+@@ -2938,13 +3121,16 @@
  
      public void func_175650_b(Collection p_175650_1_)
      {
@@ -677,7 +685,7 @@
          }
      }
  
-@@ -2957,7 +3142,9 @@
+@@ -2957,7 +3143,9 @@
      {
          Block block1 = this.func_180495_p(p_175716_2_).func_177230_c();
          AxisAlignedBB axisalignedbb = p_175716_3_ ? null : p_175716_1_.func_180640_a(this, p_175716_2_, p_175716_1_.func_176223_P());
@@ -688,7 +696,7 @@
      }
  
      public int func_175627_a(BlockPos p_175627_1_, EnumFacing p_175627_2_)
-@@ -3032,7 +3219,7 @@
+@@ -3032,7 +3220,7 @@
      {
          IBlockState iblockstate = this.func_180495_p(p_175651_1_);
          Block block = iblockstate.func_177230_c();
@@ -697,7 +705,7 @@
      }
  
      public boolean func_175640_z(BlockPos p_175640_1_)
-@@ -3160,7 +3347,7 @@
+@@ -3160,7 +3348,7 @@
  
      public long func_72905_C()
      {
@@ -706,7 +714,7 @@
      }
  
      public long func_82737_E()
-@@ -3170,17 +3357,17 @@
+@@ -3170,17 +3358,17 @@
  
      public long func_72820_D()
      {
@@ -727,7 +735,7 @@
  
          if (!this.func_175723_af().func_177746_a(blockpos))
          {
-@@ -3192,7 +3379,7 @@
+@@ -3192,7 +3380,7 @@
  
      public void func_175652_B(BlockPos p_175652_1_)
      {
@@ -736,7 +744,7 @@
      }
  
      @SideOnly(Side.CLIENT)
-@@ -3212,12 +3399,18 @@
+@@ -3212,12 +3400,18 @@
  
          if (!this.field_72996_f.contains(p_72897_1_))
          {
@@ -755,7 +763,7 @@
          return true;
      }
  
-@@ -3307,8 +3500,7 @@
+@@ -3307,8 +3501,7 @@
  
      public boolean func_180502_D(BlockPos p_180502_1_)
      {
@@ -765,7 +773,7 @@
      }
  
      public MapStorage func_175693_T()
-@@ -3367,12 +3559,12 @@
+@@ -3367,12 +3560,12 @@
  
      public int func_72800_K()
      {
@@ -780,7 +788,7 @@
      }
  
      public Random func_72843_D(int p_72843_1_, int p_72843_2_, int p_72843_3_)
-@@ -3429,7 +3621,7 @@
+@@ -3429,7 +3622,7 @@
      @SideOnly(Side.CLIENT)
      public double func_72919_O()
      {
@@ -789,7 +797,7 @@
      }
  
      public void func_175715_c(int p_175715_1_, BlockPos p_175715_2_, int p_175715_3_)
-@@ -3461,29 +3653,21 @@
+@@ -3461,29 +3654,21 @@
  
      public void func_175666_e(BlockPos p_175666_1_, Block p_175666_2_)
      {
@@ -826,7 +834,7 @@
                      }
                  }
              }
-@@ -3553,4 +3737,82 @@
+@@ -3553,4 +3738,82 @@
          short short1 = 128;
          return k >= -short1 && k <= short1 && l >= -short1 && l <= short1;
      }


### PR DESCRIPTION
This will fix a bug which causes the light value not to update if a block's light value depends on its block state, using an implementation of getLightValue(IBlockAccess, BlockPos). It's a simple change to make setBlockState compare the light value before and after setting the block state.