### PR TITLE
Fixed stronghold library chest overwriting corridor chest

### DIFF
--- a/patches/minecraft/net/minecraft/world/gen/structure/StructureStrongholdPieces.java.patch
+++ b/patches/minecraft/net/minecraft/world/gen/structure/StructureStrongholdPieces.java.patch
@@ -37,8 +37,8 @@
  
 +            static
 +            {
-+                ChestGenHooks.init(STRONGHOLD_CORRIDOR, field_75007_b, 1, 5);
-+                ChestGenHooks.addItem(STRONGHOLD_CORRIDOR, new WeightedRandomChestContent(new net.minecraft.item.ItemStack(Items.field_151134_bR, 1, 0), 1, 5, 2));
++                ChestGenHooks.init(STRONGHOLD_LIBRARY, field_75007_b, 1, 5);
++                ChestGenHooks.addItem(STRONGHOLD_LIBRARY, new WeightedRandomChestContent(new net.minecraft.item.ItemStack(Items.field_151134_bR, 1, 0), 1, 5, 2));
 +            }
 +
              public Library() {}


### PR DESCRIPTION
The stronghold corridor chests had the library loot, and the library
chests were empty. =P