### PR TITLE
Added method Block.addDustEffects

### DIFF
--- a/patches/minecraft/net/minecraft/block/Block.java.patch
+++ b/patches/minecraft/net/minecraft/block/Block.java.patch
@@ -161,7 +161,7 @@
      }
  
      protected ItemStack func_180643_i(IBlockState p_180643_1_)
-@@ -971,6 +989,1028 @@
+@@ -971,6 +989,1042 @@
          return Block.EnumOffsetType.NONE;
      }
  
@@ -788,6 +788,20 @@
 +     */
 +    @SideOnly(Side.CLIENT)
 +    public boolean addDestroyEffects(World world, BlockPos pos, net.minecraft.client.particle.EffectRenderer effectRenderer)
++    {
++        return false;
++    }
++
++    /**
++     * Allows overriding of dust effect when a living entity lands on a block, 
++     *
++     * @param the server world of were the entity resides.
++     * @param pos the block the entity "landed on"
++     * @param fallingEntity the entity that is landing on the block.
++     * @param stateAtPos the value of worldObj.getBlockState(pos)
++     * @return True to prevent vanilla dust particles form spawning.
++     */
++    public boolean addDustEffects(net.minecraft.world.WorldServer worldObj, BlockPos pos, EntityLivingBase fallingEntity, IBlockState stateAtPos )
 +    {
 +        return false;
 +    }

--- a/patches/minecraft/net/minecraft/entity/EntityLivingBase.java.patch
+++ b/patches/minecraft/net/minecraft/entity/EntityLivingBase.java.patch
@@ -1,6 +1,14 @@
 --- ../src-base/minecraft/net/minecraft/entity/EntityLivingBase.java
 +++ ../src-work/minecraft/net/minecraft/entity/EntityLivingBase.java
-@@ -233,7 +233,7 @@
+@@ -168,6 +168,7 @@
+                 }
+ 
+                 int i = (int)(150.0D * d1);
++                if ( !block1.addDustEffects( (WorldServer)this.field_70170_p, p_180433_5_, this, iblockstate ) )
+                 ((WorldServer)this.field_70170_p).func_175739_a(EnumParticleTypes.BLOCK_DUST, this.field_70165_t, this.field_70163_u, this.field_70161_v, i, 0.0D, 0.0D, 0.0D, 0.15000000596046448D, new int[] {Block.func_176210_f(iblockstate)});
+             }
+         }
+@@ -233,7 +234,7 @@
                  }
              }
  
@@ -9,7 +17,7 @@
              {
                  this.func_70078_a((Entity)null);
              }
-@@ -377,6 +377,7 @@
+@@ -377,6 +378,7 @@
      {
          this.field_70755_b = p_70604_1_;
          this.field_70756_c = this.field_70173_aa;
@@ -17,7 +25,7 @@
      }
  
      public EntityLivingBase func_110144_aD()
-@@ -672,7 +673,6 @@
+@@ -672,7 +674,6 @@
          return this.func_70668_bt() == EnumCreatureAttribute.UNDEAD;
      }
  
@@ -25,7 +33,7 @@
      public void func_70618_n(int p_70618_1_)
      {
          this.field_70713_bf.remove(Integer.valueOf(p_70618_1_));
-@@ -721,6 +721,8 @@
+@@ -721,6 +722,8 @@
  
      public void func_70691_i(float p_70691_1_)
      {
@@ -34,7 +42,7 @@
          float f1 = this.func_110143_aJ();
  
          if (f1 > 0.0F)
-@@ -741,6 +743,7 @@
+@@ -741,6 +744,7 @@
  
      public boolean func_70097_a(DamageSource p_70097_1_, float p_70097_2_)
      {
@@ -42,7 +50,7 @@
          if (this.func_180431_b(p_70097_1_))
          {
              return false;
-@@ -806,9 +809,9 @@
+@@ -806,9 +810,9 @@
                          this.field_70718_bc = 100;
                          this.field_70717_bb = (EntityPlayer)entity;
                      }
@@ -54,7 +62,7 @@
  
                          if (entitywolf.func_70909_n())
                          {
-@@ -894,6 +897,7 @@
+@@ -894,6 +898,7 @@
  
      public void func_70645_a(DamageSource p_70645_1_)
      {
@@ -62,7 +70,7 @@
          Entity entity = p_70645_1_.func_76346_g();
          EntityLivingBase entitylivingbase = this.func_94060_bK();
  
-@@ -919,6 +923,9 @@
+@@ -919,6 +924,9 @@
                  i = EnchantmentHelper.func_77519_f((EntityLivingBase)entity);
              }
  
@@ -72,7 +80,7 @@
              if (this.func_146066_aG() && this.field_70170_p.func_82736_K().func_82766_b("doMobLoot"))
              {
                  this.func_70628_a(this.field_70718_bc > 0, i);
-@@ -929,6 +936,16 @@
+@@ -929,6 +937,16 @@
                      this.func_82164_bB();
                  }
              }
@@ -89,7 +97,7 @@
          }
  
          this.field_70170_p.func_72960_a(this, (byte)3);
-@@ -977,7 +994,7 @@
+@@ -977,7 +995,7 @@
          int j = MathHelper.func_76128_c(this.func_174813_aQ().field_72338_b);
          int k = MathHelper.func_76128_c(this.field_70161_v);
          Block block = this.field_70170_p.func_180495_p(new BlockPos(i, j, k)).func_177230_c();
@@ -98,7 +106,7 @@
      }
  
      public boolean func_70089_S()
-@@ -987,6 +1004,9 @@
+@@ -987,6 +1005,9 @@
  
      public void func_180430_e(float p_180430_1_, float p_180430_2_)
      {
@@ -108,7 +116,7 @@
          super.func_180430_e(p_180430_1_, p_180430_2_);
          PotionEffect potioneffect = this.func_70660_b(Potion.field_76430_j);
          float f2 = potioneffect != null ? (float)(potioneffect.func_76458_c() + 1) : 0.0F;
-@@ -1105,6 +1125,8 @@
+@@ -1105,6 +1126,8 @@
      {
          if (!this.func_180431_b(p_70665_1_))
          {
@@ -117,7 +125,7 @@
              p_70665_2_ = this.func_70655_b(p_70665_1_, p_70665_2_);
              p_70665_2_ = this.func_70672_c(p_70665_1_, p_70665_2_);
              float f1 = p_70665_2_;
-@@ -1153,6 +1175,11 @@
+@@ -1153,6 +1176,11 @@
  
      public void func_71038_i()
      {
@@ -129,7 +137,7 @@
          if (!this.field_82175_bq || this.field_110158_av >= this.func_82166_i() / 2 || this.field_110158_av < 0)
          {
              this.field_110158_av = -1;
-@@ -1294,6 +1321,7 @@
+@@ -1294,6 +1322,7 @@
  
      public void func_110145_l(Entity p_110145_1_)
      {
@@ -137,7 +145,7 @@
          double d0 = p_110145_1_.field_70165_t;
          double d1 = p_110145_1_.func_174813_aQ().field_72338_b + (double)p_110145_1_.field_70131_O;
          double d2 = p_110145_1_.field_70161_v;
-@@ -1359,6 +1387,7 @@
+@@ -1359,6 +1388,7 @@
          }
  
          this.field_70160_al = true;
@@ -145,7 +153,7 @@
      }
  
      protected void func_70629_bd()
-@@ -1545,6 +1574,7 @@
+@@ -1545,6 +1575,7 @@
  
      public void func_70071_h_()
      {
@@ -153,7 +161,7 @@
          super.func_70071_h_();
  
          if (!this.field_70170_p.field_72995_K)
-@@ -1828,6 +1858,7 @@
+@@ -1828,6 +1859,7 @@
  
      public void func_70078_a(Entity p_70078_1_)
      {
@@ -161,7 +169,7 @@
          if (this.field_70154_o != null && p_70078_1_ == null)
          {
              if (!this.field_70170_p.field_72995_K)
-@@ -2000,4 +2031,39 @@
+@@ -2000,4 +2032,39 @@
      {
          this.field_70752_e = true;
      }


### PR DESCRIPTION
Added method Block.getBlockParticleState which can be used to override which blockstate is used when acquiring textures for impact dust and breaking FX.

I believe this covers most of the requirements for blocks / features that need this kind of override. It is also fairly low profile in comparison to other changes that would provide similar overriding capabilities.

I tested the new method by simply returning the state from Blocks.glowstone it appears to work perfectly in all test cases I attempted.