### PR TITLE
Fix crash when texture loading throws RuntimeException without message

### DIFF
--- a/fml/src/main/java/net/minecraftforge/fml/client/FMLClientHandler.java
+++ b/fml/src/main/java/net/minecraftforge/fml/client/FMLClientHandler.java
@@ -99,6 +99,7 @@ import org.lwjgl.LWJGLUtil;
 import org.lwjgl.input.Mouse;
 import org.lwjgl.opengl.Display;
 
+import com.google.common.base.Objects;
 import com.google.common.base.Strings;
 import com.google.common.base.Throwables;
 import com.google.common.collect.BiMap;
@@ -906,7 +907,7 @@ public class FMLClientHandler implements IFMLSidedHandler
         if (badType == null)
         {
             badType = Sets.newHashSet();
-            brokenTextures.put(resourceLocation.getResourceDomain(), error, badType);
+            brokenTextures.put(resourceLocation.getResourceDomain(), Objects.firstNonNull(error, "Unknown error"), badType);
         }
         badType.add(resourceLocation);
     }


### PR DESCRIPTION
Fixes crashes [like this](http://www.minecraftforge.net/forum/index.php/topic,30512.0.html).
I just made it "quick and dirty", it will just swallow any RuntimeExceptions without message. But really we should catch (all) Exceptions and store *those* for later, not just the message. If that is desired I'll update this accordingly.