### PR TITLE
Added ItemMap type check to item frames and ItemRenderer, enabling vanilla style rendering for custom ItemMaps

### DIFF
--- a/patches/minecraft/net/minecraft/client/renderer/ItemRenderer.java.patch
+++ b/patches/minecraft/net/minecraft/client/renderer/ItemRenderer.java.patch
@@ -1,0 +1,11 @@
+--- ../src-base/minecraft/net/minecraft/client/renderer/ItemRenderer.java
++++ ../src-work/minecraft/net/minecraft/client/renderer/ItemRenderer.java
+@@ -308,7 +308,7 @@
+ 
+         if (this.field_78453_b != null)
+         {
+-            if (this.field_78453_b.func_77973_b() == Items.field_151098_aY)
++            if (this.field_78453_b.func_77973_b() instanceof net.minecraft.item.ItemMap)
+             {
+                 this.func_178097_a(entityplayersp, f3, f1, f2);
+             }

--- a/patches/minecraft/net/minecraft/client/renderer/tileentity/RenderItemFrame.java.patch
+++ b/patches/minecraft/net/minecraft/client/renderer/tileentity/RenderItemFrame.java.patch
@@ -1,15 +1,26 @@
 --- ../src-base/minecraft/net/minecraft/client/renderer/tileentity/RenderItemFrame.java
 +++ ../src-work/minecraft/net/minecraft/client/renderer/tileentity/RenderItemFrame.java
-@@ -106,6 +106,9 @@
+@@ -99,15 +99,18 @@
+             GlStateManager.func_179140_f();
+             int i = p_82402_1_.func_82333_j();
+ 
+-            if (item == Items.field_151098_aY)
++            if (item instanceof net.minecraft.item.ItemMap)
+             {
+                 i = i % 4 * 2;
+             }
  
              GlStateManager.func_179114_b((float)i * 360.0F / 8.0F, 0.0F, 0.0F, 1.0F);
  
+-            if (item == Items.field_151098_aY)
 +            net.minecraftforge.client.event.RenderItemInFrameEvent event = new net.minecraftforge.client.event.RenderItemInFrameEvent(p_82402_1_, this);
 +            if (!net.minecraftforge.common.MinecraftForge.EVENT_BUS.post(event))
-+            {
-             if (item == Items.field_151098_aY)
              {
++            if (item instanceof net.minecraft.item.ItemMap)
++            {
                  this.field_76990_c.field_78724_e.func_110577_a(field_110789_a);
+                 GlStateManager.func_179114_b(180.0F, 0.0F, 0.0F, 1.0F);
+                 float f = 0.0078125F;
 @@ -165,6 +168,7 @@
                      textureatlassprite.func_94219_l();
                  }

--- a/patches/minecraft/net/minecraft/entity/item/EntityItemFrame.java.patch
+++ b/patches/minecraft/net/minecraft/entity/item/EntityItemFrame.java.patch
@@ -1,0 +1,11 @@
+--- ../src-base/minecraft/net/minecraft/entity/item/EntityItemFrame.java
++++ ../src-work/minecraft/net/minecraft/entity/item/EntityItemFrame.java
+@@ -123,7 +123,7 @@
+     {
+         if (p_110131_1_ != null)
+         {
+-            if (p_110131_1_.func_77973_b() == Items.field_151098_aY)
++            if (p_110131_1_.func_77973_b() instanceof net.minecraft.item.ItemMap)
+             {
+                 MapData mapdata = ((ItemMap)p_110131_1_.func_77973_b()).func_77873_a(p_110131_1_, this.field_70170_p);
+                 mapdata.field_76203_h.remove("frame-" + this.func_145782_y());


### PR DESCRIPTION
This small addition adds type checks to `ItemRenderer`, `RenderItemFrame`, and `EntityItemFrame`. This enables ItemMaps to be rendered via pre-existing code without the need to reinvent any wheels. There is no need to write OpenGL, and allows modders to make custom maps by simply extending `ItemMap` and overriding `updateMapData` to transform the data from within the map itself to create the desired output.

![testing](https://cloud.githubusercontent.com/assets/9277116/7900955/ec653f92-072f-11e5-826b-873b32f63d4b.gif)