### PR TITLE
Allow placing item frames on Solid Block Faces (isSideSolid)

### DIFF
--- a/patches/minecraft/net/minecraft/entity/EntityHanging.java.patch
+++ b/patches/minecraft/net/minecraft/entity/EntityHanging.java.patch
@@ -1,0 +1,12 @@
+--- ../src-base/minecraft/net/minecraft/entity/EntityHanging.java
++++ ../src-work/minecraft/net/minecraft/entity/EntityHanging.java
+@@ -124,6 +124,9 @@
+                 {
+                     BlockPos blockpos1 = blockpos.func_177967_a(enumfacing, k).func_177981_b(l);
+                     Block block = this.field_70170_p.func_180495_p(blockpos1).func_177230_c();
++                    
++                    if ( block.isSideSolid( this.field_70170_p, blockpos1, this.field_174860_b ))
++                        continue;
+ 
+                     if (!block.func_149688_o().func_76220_a() && !BlockRedstoneDiode.func_149909_d(block))
+                     {


### PR DESCRIPTION
Very simple patch to allow Item Frames to be placed on blocks with solid faces.