### PR TITLE
Added Brewing Recipe registering to GameRegistry

### DIFF
--- a/fml/src/main/java/net/minecraftforge/fml/common/registry/GameRegistry.java
+++ b/fml/src/main/java/net/minecraftforge/fml/common/registry/GameRegistry.java
@@ -47,6 +47,7 @@ import net.minecraftforge.fml.common.Loader;
 import net.minecraftforge.fml.common.LoaderException;
 import net.minecraftforge.fml.common.LoaderState;
 import net.minecraftforge.fml.common.ObfuscationReflectionHelper;
+import net.minecraftforge.common.brewing.BrewingRecipeRegistry;
 
 import org.apache.logging.log4j.Level;
 
@@ -267,6 +268,19 @@ public class GameRegistry
     {
         FurnaceRecipes.instance().addSmeltingRecipe(input, output, xp);
     }
+    
+    /**
++     * Register a brewing recipe.
++     * Due to the nature of the brewing stand inputs that stack (a.k.a max stack size > 1) are not allowed.
++     * The item in the output must have a PotionEffect, even if it is an empty String, set by {@link Item#setPotionEffect()}
++     * 
++     * @param input The ItemStack that goes in same slots as the water bottles would.
++     * @param ingredient The ItemStack that goes in the same slot as nether wart would.
++     * @param output The ItemStack that will replace the input once the brewing is done.
++     */
++    public static void addBrewing(ItemStack input, ItemStack ingredient, ItemStack output){
++       BrewingRecipeRegistry.addRecipe(input, ingredient, output);
++    }
 
     public static void registerTileEntity(Class<? extends TileEntity> tileEntityClass, String id)
     {

--- a/fml/src/main/java/net/minecraftforge/fml/common/registry/GameRegistry.java
+++ b/fml/src/main/java/net/minecraftforge/fml/common/registry/GameRegistry.java
@@ -278,7 +278,8 @@ public class GameRegistry
 +     * @param ingredient The ItemStack that goes in the same slot as nether wart would.
 +     * @param output The ItemStack that will replace the input once the brewing is done.
 +     */
-+    public static void addBrewing(ItemStack input, ItemStack ingredient, ItemStack output){
++    public static void addBrewing(ItemStack input, ItemStack ingredient, ItemStack output)
+     {
 +       BrewingRecipeRegistry.addRecipe(input, ingredient, output);
 +    }
 


### PR DESCRIPTION
Now that Forge and FML are together, I don't see any issue with referencing Forge in FML files such as GameRegistry. As for why this is useful, Shapeless Recipes, Shaped Recipes, and Furnace Recipes are all found here, so it is only logical that Brewing Recipes should be as well.