### PR TITLE
Two exceptions in BiomeDictionary

### DIFF
--- a/src/main/java/net/minecraftforge/common/BiomeDictionary.java
+++ b/src/main/java/net/minecraftforge/common/BiomeDictionary.java
@@ -104,7 +104,16 @@ public class BiomeDictionary
             Type ret = EnumHelper.addEnum(Type.class, name, new Class[]{Type[].class}, new Object[]{subTypes});
             if (ret.ordinal() >= typeInfoList.length)
             {
-                typeInfoList = Arrays.copyOf(typeInfoList, ret.ordinal());
+                typeInfoList = Arrays.copyOf(typeInfoList, ret.ordinal()+1);
+            }
+            for(BiomeInfo bInfo:biomeList)
+            {
+                if(bInfo != null)
+                {
+                    EnumSet<Type> oldSet = bInfo.typeList;
+                    bInfo.typeList = EnumSet.noneOf(Type.class);
+                    bInfo.typeList.addAll(oldSet);
+                }
             }
             return ret;
         }


### PR DESCRIPTION
It appears that there are two shortcomings in the BiomeDictionary.

First, when a new Type is created, the typeInfoList is expanded incorrectly. It should be expanded to

    ret.ordinal()+1

Second, EnumSets are great, fantastic even, but they come with stipulations. Since they use bitwise flags and ordinals, they break upon addition of new Enum elements. To fix this, they must be re-instantiated when a new Type is added. This could also be fixed by simply using a regular HashSet instead of an EnumSet.

Test case:
http://pastebin.com/VhNB0C47

This is #1933 for 1.8.