### PR TITLE
Make SimpleNetworkWrapper "threadsafe"

### DIFF
--- a/fml/src/test/java/net/minecraftforge/fml/debug/simplenet/AsyncTestMessage.java
+++ b/fml/src/test/java/net/minecraftforge/fml/debug/simplenet/AsyncTestMessage.java
@@ -1,0 +1,63 @@
+package net.minecraftforge.fml.debug.simplenet;
+
+import io.netty.buffer.ByteBuf;
+import net.minecraftforge.fml.common.network.simpleimpl.IMessage;
+import net.minecraftforge.fml.common.network.simpleimpl.IMessageHandler;
+import net.minecraftforge.fml.common.network.simpleimpl.MessageContext;
+import net.minecraftforge.fml.common.network.simpleimpl.SimpleNetworkWrapper.Async;
+
+public class AsyncTestMessage implements IMessage {
+
+    @Override
+    public void fromBytes(ByteBuf buf)
+    {
+        
+    }
+
+    @Override
+    public void toBytes(ByteBuf buf)
+    {
+        
+    }
+    
+    @Async
+    static class Handler implements IMessageHandler<AsyncTestMessage, IMessage> {
+        
+        @Override
+        public IMessage onMessage(AsyncTestMessage message, MessageContext ctx)
+        {
+            System.out.println("received async message on thread: " + Thread.currentThread().getName());
+            new Exception("debug").printStackTrace();
+            return new Response();
+        }
+                
+    }
+    
+    public static class Response implements IMessage {
+
+        @Override
+        public void fromBytes(ByteBuf buf)
+        {
+            
+        }
+
+        @Override
+        public void toBytes(ByteBuf buf)
+        {
+            
+        }
+        
+    }
+    
+    static class ResponseHandler implements IMessageHandler<Response, IMessage> {
+        
+        @Override
+        public IMessage onMessage(Response message, MessageContext ctx)
+        {
+            System.out.println("received response from async");
+            return null;
+        }
+        
+    }
+
+}

--- a/fml/src/test/java/net/minecraftforge/fml/debug/simplenet/SimpleNetworkTestMod.java
+++ b/fml/src/test/java/net/minecraftforge/fml/debug/simplenet/SimpleNetworkTestMod.java
@@ -1,0 +1,46 @@
+package net.minecraftforge.fml.debug.simplenet;
+
+import net.minecraft.entity.player.EntityPlayerMP;
+import net.minecraftforge.fml.common.FMLCommonHandler;
+import net.minecraftforge.fml.common.Mod;
+import net.minecraftforge.fml.common.Mod.EventHandler;
+import net.minecraftforge.fml.common.event.FMLPreInitializationEvent;
+import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
+import net.minecraftforge.fml.common.gameevent.PlayerEvent.PlayerLoggedInEvent;
+import net.minecraftforge.fml.common.network.NetworkRegistry;
+import net.minecraftforge.fml.common.network.simpleimpl.SimpleNetworkWrapper;
+import net.minecraftforge.fml.relauncher.Side;
+
+@Mod(modid = SimpleNetworkTestMod.MOD_ID, version = SimpleNetworkTestMod.VERSION)
+public class SimpleNetworkTestMod
+{
+
+    static final String MOD_ID = "debug.simplenet";
+    static final String VERSION = "1.0";
+    
+    private static final boolean enabled = false;
+    
+    private static SimpleNetworkWrapper network;
+    
+    @EventHandler
+    public void preInit(FMLPreInitializationEvent event)
+    {
+        if (!enabled) return;
+        
+        network = NetworkRegistry.INSTANCE.newSimpleChannel("debug");
+        network.registerMessage(new TestMessage.Handler(), TestMessage.class, 0, Side.CLIENT);
+        network.registerMessage(new AsyncTestMessage.ResponseHandler(), AsyncTestMessage.Response.class, 1, Side.SERVER);
+        network.registerMessage(new AsyncTestMessage.Handler(), AsyncTestMessage.class, 2, Side.CLIENT);
+        network.registerMessage(new TestMessage.ResponseHandler(), TestMessage.Response.class, 3, Side.SERVER);
+        
+        FMLCommonHandler.instance().bus().register(this);
+    }
+    
+    @SubscribeEvent
+    public void joinHandler(PlayerLoggedInEvent event)
+    {
+        network.sendTo(new TestMessage(), (EntityPlayerMP) event.player);
+        network.sendTo(new AsyncTestMessage(), (EntityPlayerMP) event.player);
+    }
+    
+}

--- a/fml/src/test/java/net/minecraftforge/fml/debug/simplenet/TestMessage.java
+++ b/fml/src/test/java/net/minecraftforge/fml/debug/simplenet/TestMessage.java
@@ -1,0 +1,64 @@
+package net.minecraftforge.fml.debug.simplenet;
+
+import io.netty.buffer.ByteBuf;
+import net.minecraftforge.fml.common.network.simpleimpl.IMessage;
+import net.minecraftforge.fml.common.network.simpleimpl.IMessageHandler;
+import net.minecraftforge.fml.common.network.simpleimpl.MessageContext;
+import net.minecraftforge.fml.debug.simplenet.AsyncTestMessage.Response;
+
+public class TestMessage implements IMessage
+{
+    
+    @Override
+    public void fromBytes(ByteBuf buf)
+    {
+        
+    }
+
+    @Override
+    public void toBytes(ByteBuf buf)
+    {
+        
+    }
+    
+    static class Handler implements IMessageHandler<TestMessage, IMessage>
+    {
+
+        @Override
+        public IMessage onMessage(TestMessage message, MessageContext ctx)
+        {
+            System.out.println("received non-async message on thread: " + Thread.currentThread().getName());
+            new Exception("debug").printStackTrace();
+            return new Response();
+        }
+        
+    }
+    
+    public static class Response implements IMessage {
+
+        @Override
+        public void fromBytes(ByteBuf buf)
+        {
+            
+        }
+
+        @Override
+        public void toBytes(ByteBuf buf)
+        {
+            
+        }
+        
+    }
+    
+    static class ResponseHandler implements IMessageHandler<Response, IMessage> {
+        
+        @Override
+        public IMessage onMessage(Response message, MessageContext ctx)
+        {
+            System.out.println("received response from sync");
+            return null;
+        }
+        
+    }
+
+}


### PR DESCRIPTION
SimpleNetworkWrapper now executes the handler code on the appropriate main thread. Opt-out is possible using the `Async` annotation on the handler class.

This restores 1.7 behavior and thereby "fixes" many mods out there that incorrectly still interact with the world directly from the handler code.

Also actually allow IMessageHandler instances to be re-used for multiple message types.