### PR TITLE
Bugfix for B3DLoader

### DIFF
--- a/src/main/java/net/minecraftforge/client/model/b3d/B3DLoader.java
+++ b/src/main/java/net/minecraftforge/client/model/b3d/B3DLoader.java
@@ -126,12 +126,12 @@ public class B3DLoader implements ICustomModelLoader
                 }
                 B3DModel.Parser parser = new B3DModel.Parser(resource.getInputStream());
                 B3DModel model = parser.parse();
-                cache.put(modelLocation, model);
+                cache.put(file, model);
             }
             catch(IOException e)
             {
                 //FMLLog.log(Level.ERROR, e, "Exception loading model %s with B3D loader, skipping", modelLocation);
-                cache.put(modelLocation, null);
+                cache.put(file, null);
                 throw e;
             }
         }


### PR DESCRIPTION
In the current B3DLoader class, in the cache map, the values are retrieved by a specially copied ResourceLocation - but they are added to the map identified by the originally passed ResourceLocation.
If the original ResourceLocation is a B3DMeshLocation, the equals method returns false when being compared to the cloned ResourceLocation, and the loadModel method ceases to work.
This PR fixes this bug by putting the model into the map using the cloned ResourceLocation.