### PR TITLE
Avoid creating ChunkCoordIntPair during world ticks

### DIFF
--- a/patches/minecraft/net/minecraft/client/multiplayer/WorldClient.java.patch
+++ b/patches/minecraft/net/minecraft/client/multiplayer/WorldClient.java.patch
@@ -1,6 +1,23 @@
 --- ../src-base/minecraft/net/minecraft/client/multiplayer/WorldClient.java
 +++ ../src-work/minecraft/net/minecraft/client/multiplayer/WorldClient.java
-@@ -54,12 +54,13 @@
+@@ -35,6 +35,7 @@
+ import net.minecraft.world.storage.SaveDataMemoryStorage;
+ import net.minecraft.world.storage.SaveHandlerMP;
+ import net.minecraft.world.storage.WorldInfo;
++import net.minecraftforge.common.ForgeChunkManager;
+ import net.minecraftforge.fml.relauncher.Side;
+ import net.minecraftforge.fml.relauncher.SideOnly;
+ 
+@@ -46,7 +47,7 @@
+     private final Set field_73032_d = Sets.newHashSet();
+     private final Set field_73036_L = Sets.newHashSet();
+     private final Minecraft field_73037_M = Minecraft.func_71410_x();
+-    private final Set field_73038_N = Sets.newHashSet();
++    private final Set field_73038_N = ForgeChunkManager.packedChunkCoordSet();
+     private static final String __OBFID = "CL_00000882";
+ 
+     public WorldClient(NetHandlerPlayClient p_i45063_1_, WorldSettings p_i45063_2_, int p_i45063_3_, EnumDifficulty p_i45063_4_, Profiler p_i45063_5_)
+@@ -54,12 +55,13 @@
          super(new SaveHandlerMP(), new WorldInfo(p_i45063_2_, "MpServer"), WorldProvider.func_76570_a(p_i45063_3_), p_i45063_5_, true);
          this.field_73035_a = p_i45063_1_;
          this.func_72912_H().func_176144_a(p_i45063_4_);
@@ -15,3 +32,28 @@
      }
  
      public void func_72835_b()
+@@ -115,17 +117,19 @@
+ 
+         while (iterator.hasNext())
+         {
+-            ChunkCoordIntPair chunkcoordintpair = (ChunkCoordIntPair)iterator.next();
++            long chunkcoordintpair = ForgeChunkManager.nextPackedCoord(iterator);
+ 
+             if (!this.field_73038_N.contains(chunkcoordintpair))
+             {
+-                int j = chunkcoordintpair.field_77276_a * 16;
+-                int k = chunkcoordintpair.field_77275_b * 16;
++                int chunkXPos = ForgeChunkManager.packedChunkCoordX(chunkcoordintpair);
++                int chunkZPos = ForgeChunkManager.packedChunkCoordZ(chunkcoordintpair);
++                int j = chunkXPos * 16;
++                int k = chunkZPos * 16;
+                 this.field_72984_F.func_76320_a("getChunk");
+-                Chunk chunk = this.func_72964_e(chunkcoordintpair.field_77276_a, chunkcoordintpair.field_77275_b);
++                Chunk chunk = this.func_72964_e(chunkXPos, chunkZPos);
+                 this.func_147467_a(j, k, chunk);
+                 this.field_72984_F.func_76319_b();
+-                this.field_73038_N.add(chunkcoordintpair);
++                ForgeChunkManager.addPackedCoord(this.field_73038_N,chunkcoordintpair);
+                 ++i;
+ 
+                 if (i >= 10)

--- a/patches/minecraft/net/minecraft/world/World.java.patch
+++ b/patches/minecraft/net/minecraft/world/World.java.patch
@@ -31,6 +31,15 @@
      protected boolean field_72999_e;
      public final List field_72996_f = Lists.newArrayList();
      protected final List field_72997_g = Lists.newArrayList();
+@@ -90,7 +112,7 @@
+     private final Calendar field_83016_L = Calendar.getInstance();
+     protected Scoreboard field_96442_D = new Scoreboard();
+     public final boolean field_72995_K;
+-    protected Set field_72993_I = Sets.newHashSet();
++    protected Set field_72993_I = ForgeChunkManager.packedChunkCoordSet();
+     private int field_72990_M;
+     protected boolean field_72985_G;
+     protected boolean field_72992_H;
 @@ -99,6 +121,10 @@
      int[] field_72994_J;
      private static final String __OBFID = "CL_00000140";
@@ -590,6 +599,15 @@
          int i;
          EntityPlayer entityplayer;
          int j;
+@@ -2400,7 +2572,7 @@
+             {
+                 for (int j1 = -l; j1 <= l; ++j1)
+                 {
+-                    this.field_72993_I.add(new ChunkCoordIntPair(i1 + j, j1 + k));
++                    ForgeChunkManager.addActiveChunk(this.field_72993_I,i1 + j, j1 + k);
+                 }
+             }
+         }
 @@ -2445,7 +2617,7 @@
              l += p_147467_1_;
              i1 += p_147467_2_;

--- a/patches/minecraft/net/minecraft/world/WorldServer.java.patch
+++ b/patches/minecraft/net/minecraft/world/WorldServer.java.patch
@@ -1,6 +1,14 @@
 --- ../src-base/minecraft/net/minecraft/world/WorldServer.java
 +++ ../src-work/minecraft/net/minecraft/world/WorldServer.java
-@@ -94,30 +94,46 @@
+@@ -67,6 +67,7 @@
+ import net.minecraft.world.storage.ISaveHandler;
+ import net.minecraft.world.storage.MapStorage;
+ import net.minecraft.world.storage.WorldInfo;
++import net.minecraftforge.common.ForgeChunkManager;
+ import net.minecraftforge.fml.relauncher.Side;
+ import net.minecraftforge.fml.relauncher.SideOnly;
+ import org.apache.logging.log4j.LogManager;
+@@ -94,30 +95,46 @@
      private List field_94579_S = Lists.newArrayList();
      private static final String __OBFID = "CL_00001437";
  
@@ -49,7 +57,7 @@
          }
          else
          {
-@@ -210,6 +226,10 @@
+@@ -210,6 +227,10 @@
          this.field_175740_d.func_75528_a();
          this.field_72984_F.func_76318_c("portalForcer");
          this.field_85177_Q.func_85189_a(this.func_82737_E());
@@ -60,7 +68,7 @@
          this.field_72984_F.func_76319_b();
          this.func_147488_Z();
      }
-@@ -217,6 +237,7 @@
+@@ -217,6 +238,7 @@
      public BiomeGenBase.SpawnListEntry func_175734_a(EnumCreatureType p_175734_1_, BlockPos p_175734_2_)
      {
          List list = this.func_72863_F().func_177458_a(p_175734_1_, p_175734_2_);
@@ -68,7 +76,7 @@
          return list != null && !list.isEmpty() ? (BiomeGenBase.SpawnListEntry)WeightedRandom.func_76271_a(this.field_73012_v, list) : null;
      }
  
-@@ -274,10 +295,7 @@
+@@ -274,10 +296,7 @@
  
      private void func_73051_P()
      {
@@ -80,7 +88,38 @@
      }
  
      public boolean func_73056_e()
-@@ -367,7 +385,7 @@
+@@ -344,8 +363,10 @@
+ 
+             while (iterator1.hasNext())
+             {
+-                ChunkCoordIntPair chunkcoordintpair1 = (ChunkCoordIntPair)iterator1.next();
+-                this.func_72964_e(chunkcoordintpair1.field_77276_a, chunkcoordintpair1.field_77275_b).func_150804_b(false);
++                long chunkcoordintpair1 = ForgeChunkManager.nextPackedCoord(iterator1);
++                int chunkXPos = ForgeChunkManager.packedChunkCoordX(chunkcoordintpair1);
++                int chunkZPos = ForgeChunkManager.packedChunkCoordZ(chunkcoordintpair1);
++                this.func_72964_e(chunkXPos, chunkZPos).func_150804_b(false);
+             }
+         }
+         else
+@@ -355,11 +376,13 @@
+ 
+             for (Iterator iterator = this.field_72993_I.iterator(); iterator.hasNext(); this.field_72984_F.func_76319_b())
+             {
+-                ChunkCoordIntPair chunkcoordintpair = (ChunkCoordIntPair)iterator.next();
+-                int k = chunkcoordintpair.field_77276_a * 16;
+-                int l = chunkcoordintpair.field_77275_b * 16;
++                long chunkcoordintpair = ForgeChunkManager.nextPackedCoord(iterator);
++                int chunkXPos = ForgeChunkManager.packedChunkCoordX(chunkcoordintpair);
++                int chunkZPos = ForgeChunkManager.packedChunkCoordZ(chunkcoordintpair);
++                int k = chunkXPos * 16;
++                int l = chunkZPos * 16;
+                 this.field_72984_F.func_76320_a("getChunk");
+-                Chunk chunk = this.func_72964_e(chunkcoordintpair.field_77276_a, chunkcoordintpair.field_77275_b);
++                Chunk chunk = this.func_72964_e(chunkXPos, chunkZPos);
+                 this.func_147467_a(k, l, chunk);
+                 this.field_72984_F.func_76318_c("tickChunk");
+                 chunk.func_150804_b(false);
+@@ -367,7 +390,7 @@
                  int i1;
                  BlockPos blockpos;
  
@@ -89,7 +128,7 @@
                  {
                      this.field_73005_l = this.field_73005_l * 3 + 1013904223;
                      i1 = this.field_73005_l >> 2;
-@@ -381,7 +399,7 @@
+@@ -381,7 +404,7 @@
  
                  this.field_72984_F.func_76318_c("iceandsnow");
  
@@ -98,7 +137,7 @@
                  {
                      this.field_73005_l = this.field_73005_l * 3 + 1013904223;
                      i1 = this.field_73005_l >> 2;
-@@ -483,6 +501,9 @@
+@@ -483,6 +506,9 @@
              if (p_175654_2_.func_149698_L())
              {
                  b0 = 8;
@@ -108,7 +147,7 @@
  
                  if (this.func_175707_a(nextticklistentry.field_180282_a.func_177982_a(-b0, -b0, -b0), nextticklistentry.field_180282_a.func_177982_a(b0, b0, b0)))
                  {
-@@ -535,7 +556,7 @@
+@@ -535,7 +561,7 @@
  
      public void func_72939_s()
      {
@@ -117,7 +156,7 @@
          {
              if (this.field_80004_Q++ >= 1200)
              {
-@@ -601,6 +622,9 @@
+@@ -601,6 +627,9 @@
                  {
                      nextticklistentry = (NextTickListEntry)iterator.next();
                      iterator.remove();
@@ -127,7 +166,7 @@
                      byte b0 = 0;
  
                      if (this.func_175707_a(nextticklistentry.field_180282_a.func_177982_a(-b0, -b0, -b0), nextticklistentry.field_180282_a.func_177982_a(b0, b0, b0)))
-@@ -729,14 +753,29 @@
+@@ -729,14 +758,29 @@
      {
          ArrayList arraylist = Lists.newArrayList();
  
@@ -163,7 +202,7 @@
              }
          }
  
-@@ -745,6 +784,10 @@
+@@ -745,6 +789,10 @@
  
      public boolean func_175660_a(EntityPlayer p_175660_1_, BlockPos p_175660_2_)
      {
@@ -174,7 +213,7 @@
          return !this.field_73061_a.func_175579_a(this, p_175660_2_, p_175660_1_) && this.func_175723_af().func_177746_a(p_175660_2_);
      }
  
-@@ -810,6 +853,7 @@
+@@ -810,6 +858,7 @@
          }
          else
          {
@@ -182,7 +221,7 @@
              this.field_72987_B = true;
              WorldChunkManager worldchunkmanager = this.field_73011_w.func_177499_m();
              List list = worldchunkmanager.func_76932_a();
-@@ -855,7 +899,7 @@
+@@ -855,7 +904,7 @@
  
      protected void func_73047_i()
      {
@@ -191,7 +230,7 @@
  
          for (int i = 0; i < 10; ++i)
          {
-@@ -892,6 +936,7 @@
+@@ -892,6 +941,7 @@
              }
  
              this.field_73020_y.func_73151_a(p_73044_1_, p_73044_2_);
@@ -199,7 +238,7 @@
              List list = this.field_73059_b.func_152380_a();
              Iterator iterator = list.iterator();
  
-@@ -929,6 +974,7 @@
+@@ -929,6 +979,7 @@
          this.field_72986_A.func_176135_e(this.func_175723_af().func_177732_i());
          this.field_73019_z.func_75755_a(this.field_72986_A, this.field_73061_a.func_71203_ab().func_72378_q());
          this.field_72988_C.func_75744_a();
@@ -207,7 +246,7 @@
      }
  
      public void func_72923_a(Entity p_72923_1_)
-@@ -984,6 +1030,7 @@
+@@ -984,6 +1035,7 @@
      public Explosion func_72885_a(Entity p_72885_1_, double p_72885_2_, double p_72885_4_, double p_72885_6_, float p_72885_8_, boolean p_72885_9_, boolean p_72885_10_)
      {
          Explosion explosion = new Explosion(this, p_72885_1_, p_72885_2_, p_72885_4_, p_72885_6_, p_72885_8_, p_72885_9_, p_72885_10_);
@@ -215,7 +254,7 @@
          explosion.func_77278_a();
          explosion.func_77279_a(false);
  
-@@ -1074,19 +1121,23 @@
+@@ -1074,19 +1126,23 @@
              this.field_73061_a.func_71203_ab().func_148537_a(new S2BPacketChangeGameState(8, this.field_73017_q), this.field_73011_w.func_177502_q());
          }
  
@@ -243,7 +282,7 @@
          }
      }
  
-@@ -1152,6 +1203,11 @@
+@@ -1152,6 +1208,11 @@
          return this.field_73061_a.func_152345_ab();
      }
  

--- a/src/main/java/net/minecraftforge/common/CoordFlyweightSet.java
+++ b/src/main/java/net/minecraftforge/common/CoordFlyweightSet.java
@@ -1,0 +1,215 @@
+package net.minecraftforge.common;
+
+import gnu.trove.iterator.TLongIterator;
+import gnu.trove.list.array.TLongArrayList;
+import gnu.trove.set.hash.TLongHashSet;
+
+import java.lang.reflect.Array;
+import java.util.Collection;
+import java.util.Set;
+
+import net.minecraft.world.ChunkCoordIntPair;
+
+/**
+ * Provides a Set class which allows Mods depending on World.activeChunkSet to
+ * get a view of our optimized set.
+ * 
+ * Such Mods may degrade the performance gained by this optimization.
+ */
+public class CoordFlyweightSet implements Set<ChunkCoordIntPair>
+{
+    private final TLongHashSet packedSet = new TLongHashSet(32);
+
+    @Override
+    public int size()
+    {
+        return packedSet.size();
+    }
+
+    @Override
+    public boolean isEmpty()
+    {
+        return packedSet.isEmpty();
+    }
+
+    @Override
+    public boolean contains(Object o)
+    {
+        if (o instanceof ChunkCoordIntPair)
+        {
+            ChunkCoordIntPair intPair = (ChunkCoordIntPair) o;
+            long packed = ForgeChunkManager.packedChunkCoordIntPair(intPair.chunkXPos, intPair.chunkZPos);
+            return containsPacked(packed);
+        }
+
+        return false;
+    }
+
+    public boolean containsPacked(long packedCoord)
+    {
+        return packedSet.contains(packedCoord);
+    }
+
+    @Override
+    public java.util.Iterator<ChunkCoordIntPair> iterator()
+    {
+        return new CoordFlyweightSet.Iterator(packedIterator());
+    }
+
+    public TLongIterator packedIterator()
+    {
+        return packedSet.iterator();
+    }
+
+    @Override
+    public Object[] toArray()
+    {
+        return toArray(new Object[size()]);
+    }
+
+    @Override
+    public <T> T[] toArray(T[] a)
+    {
+        if (a.length < this.size())
+        {
+            a = (T[]) Array.newInstance(a.getClass().getComponentType(), this.size());
+        }
+
+        int i = 0;
+        for (ChunkCoordIntPair fat : this)
+        {
+            a[i++] = (T) fat;
+        }
+        return a;
+    }
+
+    @Override
+    public boolean add(ChunkCoordIntPair e)
+    {
+        return add(e.chunkXPos, e.chunkZPos);
+    }
+
+    public boolean add(int chunkXPos, int chunkZPos)
+    {
+        return packedSet.add(ForgeChunkManager.packedChunkCoordIntPair(chunkXPos, chunkZPos));
+    }
+
+    public boolean addPacked(long intPair)
+    {
+        return packedSet.add(intPair);
+    }
+
+    @Override
+    public boolean remove(Object o)
+    {
+        if (o instanceof ChunkCoordIntPair)
+        {
+            ChunkCoordIntPair intPair = (ChunkCoordIntPair) o;
+            return packedSet.remove(ForgeChunkManager.packedChunkCoordIntPair(intPair.chunkXPos, intPair.chunkZPos));
+        }
+
+        return false;
+    }
+
+    @Override
+    public boolean containsAll(Collection<?> c)
+    {
+        for (Object o : c)
+        {
+            if (!contains(o))
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    @Override
+    public boolean addAll(Collection<? extends ChunkCoordIntPair> c)
+    {
+        boolean changed = false;
+        for (ChunkCoordIntPair intPair : c)
+        {
+            changed |= add(intPair);
+        }
+        return changed;
+    }
+
+    @Override
+    public boolean retainAll(Collection<?> c)
+    {
+        if (c instanceof CoordFlyweightSet)
+        {
+            return packedSet.retainAll(((CoordFlyweightSet) c).packedSet);
+        }
+
+        TLongArrayList retain = null;
+        for (Object o : c)
+        {
+            if (o instanceof ChunkCoordIntPair)
+            {
+                if (retain == null)
+                {
+                    retain = new TLongArrayList(c.size());
+                }
+
+                ChunkCoordIntPair intPair = (ChunkCoordIntPair) o;
+                retain.add(ForgeChunkManager.packedChunkCoordIntPair(intPair.chunkXPos, intPair.chunkZPos));
+            }
+        }
+
+        if (retain != null)
+        {
+            return packedSet.retainAll(retain);
+        }
+
+        packedSet.clear();
+        return true;
+    }
+
+    @Override
+    public boolean removeAll(Collection<?> c)
+    {
+        boolean changed = false;
+        for (Object o : c)
+        {
+            changed |= remove(o);
+        }
+        return changed;
+    }
+
+    @Override
+    public void clear()
+    {
+        packedSet.clear();
+    }
+
+    public static class Iterator implements java.util.Iterator<ChunkCoordIntPair>
+    {
+        private final TLongIterator impl;
+
+        public Iterator(TLongIterator impl)
+        {
+            this.impl = impl;
+        }
+
+        @Override
+        public boolean hasNext()
+        {
+            return impl.hasNext();
+        }
+
+        @Override
+        public ChunkCoordIntPair next()
+        {
+            long packed = nextPacked();
+            return new ChunkCoordIntPair(ForgeChunkManager.packedChunkCoordX(packed), ForgeChunkManager.packedChunkCoordZ(packed));
+        }
+
+        public long nextPacked()
+        {
+            return impl.next();
+        }
+    }
+}

--- a/src/main/java/net/minecraftforge/common/ForgeChunkManager.java
+++ b/src/main/java/net/minecraftforge/common/ForgeChunkManager.java
@@ -1071,4 +1071,64 @@ public class ForgeChunkManager
             cat.put(propertyName, prop);
         }
     }
+    
+    /**
+     * Represents ChunkCoordIntPair as a primitive long
+     */
+    public static long packedChunkCoordIntPair(int x, int z)
+    {
+        long leftX = ((long)x) << 32;
+        long rightZ = z & 0xFFFFFFFFl; // sign extend
+        return leftX | rightZ;
+    }
+    
+    public static int packedChunkCoordX(long intPair)
+    {
+        return (int)(intPair >> 32);
+    }
+    
+    public static int packedChunkCoordZ(long intPair)
+    {
+        return (int)(intPair & 0xFFFFFFFFl);
+    }
+    
+    public static Set packedChunkCoordSet()
+    {
+        return new CoordFlyweightSet();
+    }
+    
+    public static void addActiveChunk(Set activeChunkSet, int x, int z)
+    {
+        if(activeChunkSet instanceof CoordFlyweightSet)
+        {
+            ((CoordFlyweightSet)activeChunkSet).add(x, z);
+        } else {
+            // Forge: compatibility mode, please don't assign to World.activeChunkSet
+            activeChunkSet.add(new ChunkCoordIntPair(x, z));
+        }
+    }
+    
+    public static long nextPackedCoord(Iterator itr)
+    {
+        if(itr instanceof CoordFlyweightSet.Iterator)
+        {
+            return ((CoordFlyweightSet.Iterator)itr).nextPacked();
+        } else {
+            // Forge: compatibility mode
+            ChunkCoordIntPair intPair = (ChunkCoordIntPair)itr.next();
+            return ForgeChunkManager.packedChunkCoordIntPair(intPair.chunkXPos, intPair.chunkZPos);
+        }
+    }
+    
+    public static void addPackedCoord(Set previousActiveChunkSet, long intPair)
+    {
+        if(previousActiveChunkSet instanceof CoordFlyweightSet)
+        {
+            ((CoordFlyweightSet)previousActiveChunkSet).addPacked(intPair);
+        } else {
+            // Forge: compatibility mode, please don't assign to World.activeChunkSet
+            previousActiveChunkSet.add(new ChunkCoordIntPair(
+                    packedChunkCoordX(intPair), packedChunkCoordZ(intPair)));
+        }
+    }
 }

--- a/src/test/java/net/minecraftforge/common/CoordFlyweightSetTest.java
+++ b/src/test/java/net/minecraftforge/common/CoordFlyweightSetTest.java
@@ -1,0 +1,108 @@
+package net.minecraftforge.common;
+
+import java.io.IOException;
+import java.util.Random;
+import java.util.Set;
+
+import net.minecraft.world.ChunkCoordIntPair;
+
+import org.junit.Ignore;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
+
+import com.google.common.collect.Sets;
+
+import scala.actors.threadpool.Arrays;
+
+// HOWTO: run with -Xms -Xmx equal and what the budget of world chunk caching should be (+16M for JVM)
+// spoiler: anything less than 2GB will choke the default impl, 32M will OOM
+public class CoordFlyweightSetTest {
+    @Test
+    @Ignore("this should be replaced by a Caliper benchmark in the integration test suite")
+    public void testTrivialMicrobenchmark() throws InterruptedException, IOException
+    {
+        // HOWTO: try data_size * iterations = 1000M for best results
+
+        // data size roughly describes number of possible active chunks
+        int DATA_SIZE = 1000000;
+        int WARMUP_SIZE = Math.max(100, (int) Math.sqrt(DATA_SIZE));
+
+        // set is cleared after each iteration, increase iterations to show more
+        // contention, similar to world tick
+        int ITERATIONS = 100;
+
+        Random rand = new Random();
+        Runtime javart = Runtime.getRuntime();
+
+        // HOWTO: uncomment this pause if you want to profile
+        // System.out.println("press key to begin!");
+        // System.in.read();
+
+        for (int size : new int[] { WARMUP_SIZE, DATA_SIZE })
+        {
+            int[] data = new int[size];
+
+            long totalMemory = javart.totalMemory();
+            long usedMemory = totalMemory - javart.freeMemory();
+            long temp, time = 0;
+
+            // fill
+            for (int i = 0; i < size; i++)
+            {
+                data[i] = rand.nextInt();
+            }
+
+            System.out.println("Test size=" + size + " iterations=" + ITERATIONS + " startMx=" + totalMemory + " startHeap=" + usedMemory);
+
+            // less favorable timing setup for the new implementation to go
+            // first, and shows us memory gains
+            for (Set set : new Set[] { ForgeChunkManager.packedChunkCoordSet(), Sets.newHashSet() })
+            {
+                time = System.nanoTime();
+
+                // main benchmark - iterate over data pushing it into the set
+                for (int pass = ITERATIONS - 1; pass >= 0; pass--)
+                {
+                    for (int position = size - 2; position >= 0; position -= 2)
+                    {
+                        // HOWTO: try case 1, case 2 in separate runs
+                        // case 1 use reflection and extract raw coords to
+                        // packed coord set, ~3x speedup with 4GB ram
+                        // with 256M ~4x speedup
+                        ForgeChunkManager.addActiveChunk(set, data[position], data[position + 1]);
+
+                        // case 2 allocate temp object, extract coords and shove
+                        // it into TLongHashSet, ~2x speedup with 4GB ram
+                        // with 256M ~3x speedup
+                        // set.add(new ChunkCoordIntPair(data[position],
+                        // data[position+1]));
+                    }
+
+                    // take worst case memory statistics
+                    temp = javart.totalMemory();
+                    totalMemory = Math.max(totalMemory, temp);
+                    usedMemory = Math.max(usedMemory, temp - javart.freeMemory());
+
+                    set.clear(); // possibly simulates world tick behavior
+                }
+
+                time = System.nanoTime() - time;
+
+                System.out.println(set.getClass() + "\tt=" + time + "\tMx=" + totalMemory + "\theap=" + usedMemory);
+
+                set = null;
+
+                // personal voodoo, timing of sleep/GC/yield to release memory
+                // is not consistent across platforms
+                Thread.currentThread().sleep(50);
+                System.gc();
+                Thread.yield();
+                System.gc();
+                Thread.yield();
+
+                // should be in a clean state for the next test candidate
+            }
+        }
+    }
+}

--- a/src/test/java/net/minecraftforge/common/ForgeChunkManagerTest.java
+++ b/src/test/java/net/minecraftforge/common/ForgeChunkManagerTest.java
@@ -1,0 +1,40 @@
+package net.minecraftforge.common;
+
+import static org.junit.Assert.*;
+import static org.hamcrest.CoreMatchers.*;
+
+import java.util.Random;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import scala.actors.threadpool.Arrays;
+
+public class ForgeChunkManagerTest
+{
+    @Before
+    public void setUp() throws Exception
+    {
+    }
+
+    @After
+    public void tearDown() throws Exception
+    {
+    }
+
+    @Test
+    public void testPackedChunkCoordIntPair()
+    {
+        int[] data = new int[]{0, -1, 1, -2, 2, -3, 3, Integer.MIN_VALUE, Integer.MAX_VALUE};
+        for(int x = 0; x < data.length; x++)
+        {
+            for(int z = 0; z < data.length; z++)
+            {
+                long packed = ForgeChunkManager.packedChunkCoordIntPair(x, z);
+                assertThat(ForgeChunkManager.packedChunkCoordX(packed), is(x));
+                assertThat(ForgeChunkManager.packedChunkCoordZ(packed), is(z));
+            }
+        }
+    }
+}


### PR DESCRIPTION
I will still need to gather appropriate data about the current state of performance for this feature.

My current plan is to use jvisualvm to gather allocated bytes per second and compare before/after for a few minutes on a new world created twice with the same seed.

Anecdotally it really helps on low-end machines, but has very good potential for servers. Practical testing I might be able to do by spinning up a bunch of mineflayer bots.

A synthetic benchmark will absolutely overstate the need for this patch because there will be no memory allocated by the TLongHashSet. We all know that this will not result in a practical 100% reduction in memory use as such a benchmark would show.