### PR TITLE
Fixed NPE when calling canBrew

### DIFF
--- a/src/main/java/net/minecraftforge/common/brewing/BrewingRecipeRegistry.java
+++ b/src/main/java/net/minecraftforge/common/brewing/BrewingRecipeRegistry.java
@@ -72,7 +72,7 @@ public class BrewingRecipeRegistry {
 
         for (IBrewingRecipe recipe : recipes)
         {
-            ItemStack output = recipe.getOutput(input, ingredient);
+            ItemStack output = recipe.isInput(input) && recipe.isIngredient(ingredient) ? recipe.getOutput(input, ingredient) : null;
             if (output != null)
             {
                 return output;


### PR DESCRIPTION
When brewing recipe adds ingredient, it tries to apply to every recipes in canBrew.
For example, getOutput of VanillaBrewingRecipe tries PotionHelper.applyIngredient.
PotionHelper.applyIngredient needs that the second argument mustn't be null.
At that time, Brewing Stand throws NullPointerException.
