### PR TITLE
Discourage global entity IDs

### DIFF
--- a/fml/patches/minecraft/net/minecraft/client/network/NetHandlerPlayClient.java.patch
+++ b/fml/patches/minecraft/net/minecraft/client/network/NetHandlerPlayClient.java.patch
@@ -9,3 +9,11 @@
          this.field_147299_f.field_71474_y.field_74318_M = p_147282_1_.func_149192_g();
          this.field_147299_f.func_71403_a(this.field_147300_g);
          this.field_147299_f.field_71439_g.field_71093_bK = p_147282_1_.func_149194_f();
+@@ -812,6 +812,7 @@
+         float f = (float)(p_147281_1_.func_149028_l() * 360) / 256.0F;
+         float f1 = (float)(p_147281_1_.func_149030_m() * 360) / 256.0F;
+         EntityLivingBase entitylivingbase = (EntityLivingBase)EntityList.func_75616_a(p_147281_1_.func_149025_e(), this.field_147299_f.field_71441_e);
++        if (entitylivingbase == null) { net.minecraftforge.fml.common.registry.EntityRegistry.failedGlobalIDSpawn(p_147281_1_.func_149025_e()); return; }
+         entitylivingbase.field_70118_ct = p_147281_1_.func_149023_f();
+         entitylivingbase.field_70117_cu = p_147281_1_.func_149034_g();
+         entitylivingbase.field_70116_cv = p_147281_1_.func_149029_h();

--- a/fml/src/main/java/net/minecraftforge/fml/common/registry/EntityRegistry.java
+++ b/fml/src/main/java/net/minecraftforge/fml/common/registry/EntityRegistry.java
@@ -179,15 +179,16 @@ public class EntityRegistry
 
     public static void registerGlobalEntityID(Class <? extends Entity > entityClass, String entityName, int id)
     {
+        ModContainer activeModContainer = Loader.instance().activeModContainer();
+        String modId = "unknown";
+        if (activeModContainer != null)
+        {
+            modId = activeModContainer.getModId();
+        }
+        
         if (EntityList.classToStringMapping.containsKey(entityClass))
         {
-            ModContainer activeModContainer = Loader.instance().activeModContainer();
-            String modId = "unknown";
-            if (activeModContainer != null)
-            {
-                modId = activeModContainer.getModId();
-            }
-            else
+            if (activeModContainer == null)
             {
                 FMLLog.severe("There is a rogue mod failing to register entities from outside the context of mod loading. This is incredibly dangerous and should be stopped.");
             }
@@ -196,6 +197,7 @@ public class EntityRegistry
         }
         id = instance().validateAndClaimId(id);
         EntityList.addMapping(entityClass, entityName, id);
+        warnGlobalIDRegister(modId, id, entityName);
     }
 
     private int validateAndClaimId(int id)
@@ -231,15 +233,16 @@ public class EntityRegistry
 
     public static void registerGlobalEntityID(Class <? extends Entity > entityClass, String entityName, int id, int backgroundEggColour, int foregroundEggColour)
     {
+        ModContainer activeModContainer = Loader.instance().activeModContainer();
+        String modId = "unknown";
+        if (activeModContainer != null)
+        {
+            modId = activeModContainer.getModId();
+        }
+        
         if (EntityList.classToStringMapping.containsKey(entityClass))
         {
-            ModContainer activeModContainer = Loader.instance().activeModContainer();
-            String modId = "unknown";
-            if (activeModContainer != null)
-            {
-                modId = activeModContainer.getModId();
-            }
-            else
+            if (activeModContainer == null)
             {
                 FMLLog.severe("There is a rogue mod failing to register entities from outside the context of mod loading. This is incredibly dangerous and should be stopped.");
             }
@@ -248,6 +251,12 @@ public class EntityRegistry
         }
         instance().validateAndClaimId(id);
         EntityList.addMapping(entityClass, entityName, id, backgroundEggColour, foregroundEggColour);
+        warnGlobalIDRegister(modId, id, entityName);
+    }
+    
+    private static void warnGlobalIDRegister(String mod, int id, String name)
+    {
+        FMLLog.warning("The mod %s registered global EntityID %s as name %s. This is discouraged. Modder see EntityRegistry.registerModEntity", mod, id, name);
     }
 
     public static void addSpawn(Class <? extends EntityLiving > entityClass, int weightedProb, int min, int max, EnumCreatureType typeOfCreature, BiomeGenBase... biomes)
@@ -364,5 +373,12 @@ public class EntityRegistry
             return true;
         }
         return false;
+    }
+    
+    @Deprecated // internal, do not call
+    public static void failedGlobalIDSpawn(int id)
+    {
+        FMLLog.severe("Failed to spawn Entity with global ID %s. This is most likely a result of mods using the outdated global ID system and a discrepancy between the configuration on server and client.", id);
+        FMLLog.severe("The Entity has been skipped, refer to the mod's configuration files to fix this discrepancy.");
     }
 }


### PR DESCRIPTION
-registerGlobalEntityID emits a warning
-PacketSpawnMob emits a warning instead of crashing when the ID is not known on the client

Should the methods be deprecated as well? I think yes.
For 1.7 as well?