### PR TITLE
Fixed NPE when calling canBrew

### DIFF
--- a/src/main/java/net/minecraftforge/common/brewing/VanillaBrewingRecipe.java
+++ b/src/main/java/net/minecraftforge/common/brewing/VanillaBrewingRecipe.java
@@ -40,7 +40,7 @@ public class VanillaBrewingRecipe implements IBrewingRecipe {
     @Override
     public ItemStack getOutput(ItemStack input, ItemStack ingredient)
     {
-        if (ingredient != null && input != null && input.getItem() instanceof ItemPotion)
+        if (ingredient != null && input != null && input.getItem() instanceof ItemPotion && isIngredient(ingredient))
         {
             int inputMeta = input.getMetadata();
             int outputMeta = PotionHelper.applyIngredient(inputMeta, ingredient.getItem().getPotionEffect(ingredient));


### PR DESCRIPTION
Oversight on my part,

If the ingredient doesn't return true in Item.isPotionIngredient, Items.potionitem.getEffects(stack) returns null, causing an NPE to be thrown later on.

This invalidates #1947.