### PR TITLE
fix logic for guessing mesa tag in biome dict

### DIFF
--- a/src/main/java/net/minecraftforge/common/BiomeDictionary.java
+++ b/src/main/java/net/minecraftforge/common/BiomeDictionary.java
@@ -416,13 +416,13 @@ public class BiomeDictionary
         {
             BiomeDictionary.registerBiomeType(biome, SANDY);
         }
-        else if (biome.topBlock == Blocks.hardened_clay)
-        {
-            BiomeDictionary.registerBiomeType(biome, MESA);
-        }
         else if (biome.topBlock == Blocks.mycelium)
         {
             BiomeDictionary.registerBiomeType(biome, MUSHROOM);
+        }
+        if (biome.fillerBlock == Blocks.hardened_clay)
+        {
+            BiomeDictionary.registerBiomeType(biome, MESA);
         }
     }
 


### PR DESCRIPTION
The biome dictionary guessing logic looks for stained clay as the *top* block, while the vanilla mesa biome uses stained clay as the *filler* block. This causes the dictionary to miss mutated vanilla mesa biomes, for example. This patch fixes that.