### PR TITLE
Remove redundant classloader exclusion

### DIFF
--- a/fml/src/main/java/net/minecraftforge/fml/common/launcher/FMLTweaker.java
+++ b/fml/src/main/java/net/minecraftforge/fml/common/launcher/FMLTweaker.java
@@ -116,7 +116,6 @@ public class FMLTweaker implements ITweaker {
     @Override
     public void injectIntoClassLoader(LaunchClassLoader classLoader)
     {
-        classLoader.addClassLoaderExclusion("org.apache.");
         classLoader.addClassLoaderExclusion("com.google.common.");
         classLoader.addClassLoaderExclusion("org.objectweb.asm.");
         classLoader.addTransformerExclusion("net.minecraftforge.fml.repackage.");


### PR DESCRIPTION
This PR removes the redundant classloader exclusion for the `org.apache` namespace. This exclusion is only in place for `log4j` [as per blame](https://github.com/MinecraftForge/MinecraftForge/blame/master/fml/src/main/java/net/minecraftforge/fml/common/launcher/FMLTweaker.java#L119), which [is excluded by LaunchWrapper](https://github.com/Mojang/LegacyLauncher/blob/master/src/main/java/net/minecraft/launchwrapper/LaunchClassLoader.java#L58) anyhow. Subsequently, this removes the restriction on mods shading Apache libraries.