### PR TITLE
Added smelt amount tracking to ItemSmeltedEvent

### DIFF
--- a/patches/minecraft/net/minecraft/inventory/SlotFurnaceOutput.java.patch
+++ b/patches/minecraft/net/minecraft/inventory/SlotFurnaceOutput.java.patch
@@ -1,11 +1,18 @@
 --- ../src-base/minecraft/net/minecraft/inventory/SlotFurnaceOutput.java
 +++ ../src-work/minecraft/net/minecraft/inventory/SlotFurnaceOutput.java
-@@ -81,6 +81,8 @@
+@@ -37,6 +37,7 @@
  
+     public void func_82870_a(EntityPlayer p_82870_1_, ItemStack p_82870_2_)
+     {
++        if(field_75228_b>0)//Fix ContainerFurnace invalid call after -onSlotChange(ItemStack,ItemStack), without removing valid call after -decrStackSize(int).
+         this.func_75208_c(p_82870_2_);
+         super.func_82870_a(p_82870_1_, p_82870_2_);
+     }
+@@ -81,6 +82,7 @@
+             }
+         }
+ 
++        net.minecraftforge.fml.common.FMLCommonHandler.instance().firePlayerSmeltedEvent(field_75229_a, p_75208_1_, field_75228_b);
          this.field_75228_b = 0;
  
-+        net.minecraftforge.fml.common.FMLCommonHandler.instance().firePlayerSmeltedEvent(field_75229_a, p_75208_1_);
-+
          if (p_75208_1_.func_77973_b() == Items.field_151042_j)
-         {
-             this.field_75229_a.func_71029_a(AchievementList.field_187987_k);

--- a/src/main/java/net/minecraftforge/fml/common/FMLCommonHandler.java
+++ b/src/main/java/net/minecraftforge/fml/common/FMLCommonHandler.java
@@ -577,6 +577,12 @@ public class FMLCommonHandler
         bus().post(new PlayerEvent.ItemCraftedEvent(player, crafted, craftMatrix));
     }
 
+    public void firePlayerSmeltedEvent(EntityPlayer player, ItemStack smelted, int amount)
+    {
+        bus().post(new PlayerEvent.ItemSmeltedEvent(player, smelted, amount));
+    }
+
+    @Deprecated
     public void firePlayerSmeltedEvent(EntityPlayer player, ItemStack smelted)
     {
         bus().post(new PlayerEvent.ItemSmeltedEvent(player, smelted));

--- a/src/main/java/net/minecraftforge/fml/common/gameevent/PlayerEvent.java
+++ b/src/main/java/net/minecraftforge/fml/common/gameevent/PlayerEvent.java
@@ -34,10 +34,20 @@ public class PlayerEvent extends Event {
     }
     public static class ItemSmeltedEvent extends PlayerEvent {
         public final ItemStack smelting;
+        public final int amount;
+        @Deprecated
         public ItemSmeltedEvent(EntityPlayer player, ItemStack crafting)
         {
             super(player);
             this.smelting = crafting;
+            this.amount = 0;
+        }
+
+        public ItemSmeltedEvent(EntityPlayer player, ItemStack crafting, int amount)
+        {
+            super(player);
+            this.smelting = crafting;
+            this.amount = amount;
         }
     }
 


### PR DESCRIPTION
Because stack size is not accurate, since already merged with what the player had selected, and in case of fast-transfer (shift-click).
Fix #1965 then.
Was also an issue in 1.7.