### PR TITLE
Fix harvest logic running in addition to shearable logic

### DIFF
--- a/patches/minecraft/net/minecraft/block/BlockDoublePlant.java.patch
+++ b/patches/minecraft/net/minecraft/block/BlockDoublePlant.java.patch
@@ -45,7 +45,16 @@
          {
              super.func_180657_a(p_180657_1_, p_180657_2_, p_180657_3_, p_180657_4_, p_180657_5_);
          }
-@@ -296,6 +293,32 @@
+@@ -220,8 +217,6 @@
+         else
+         {
+             p_176489_4_.func_71029_a(StatList.field_75934_C[Block.func_149682_b(this)]);
+-            int i = (enumplanttype == BlockDoublePlant.EnumPlantType.GRASS ? BlockTallGrass.EnumType.GRASS : BlockTallGrass.EnumType.FERN).func_177044_a();
+-            func_180635_a(p_176489_1_, p_176489_2_, new ItemStack(Blocks.field_150329_H, 2, i));
+             return true;
+         }
+     }
+@@ -296,6 +291,32 @@
          return Block.EnumOffsetType.XZ;
      }
  

--- a/patches/minecraft/net/minecraft/block/BlockOldLeaf.java.patch
+++ b/patches/minecraft/net/minecraft/block/BlockOldLeaf.java.patch
@@ -1,6 +1,13 @@
 --- ../src-base/minecraft/net/minecraft/block/BlockOldLeaf.java
 +++ ../src-work/minecraft/net/minecraft/block/BlockOldLeaf.java
-@@ -155,4 +155,11 @@
+@@ -148,11 +148,17 @@
+         if (!p_180657_1_.field_72995_K && p_180657_2_.func_71045_bC() != null && p_180657_2_.func_71045_bC().func_77973_b() == Items.field_151097_aZ)
+         {
+             p_180657_2_.func_71029_a(StatList.field_75934_C[Block.func_149682_b(this)]);
+-            func_180635_a(p_180657_1_, p_180657_3_, new ItemStack(Item.func_150898_a(this), 1, ((BlockPlanks.EnumType)p_180657_4_.func_177229_b(field_176239_P)).func_176839_a()));
+         }
+         else
+         {
              super.func_180657_a(p_180657_1_, p_180657_2_, p_180657_3_, p_180657_4_, p_180657_5_);
          }
      }

--- a/patches/minecraft/net/minecraft/item/ItemShears.java.patch
+++ b/patches/minecraft/net/minecraft/item/ItemShears.java.patch
@@ -55,7 +55,7 @@
 +    @Override
 +    public boolean onBlockStartBreak(ItemStack itemstack, BlockPos pos, net.minecraft.entity.player.EntityPlayer player)
 +    {
-+        if (player.field_70170_p.field_72995_K)
++        if (player.field_70170_p.field_72995_K || player.field_71075_bZ.field_75098_d)
 +        {
 +            return false;
 +        }


### PR DESCRIPTION
This pull request aims to fix two issues, the first is that onSheared runs in creative mode and the second is that in survival both the harvestBlock logic and the onSheared logic runs. In order to restore vanilla functionality this patch does two things.

1. Adds a check into ItemShears to see if the player attempting to break a block with shears is in creative mode, aborting the shear logic if so.

2. Keeps existing harvestBlock functionality while removing the base logic that destroys and drops the blocks letting forge handle that in onSheared.

This fixes https://github.com/SpongePowered/Sponge/issues/283 and makes forge behavior match vanilla. Note that shearing of entities likes sheep remains untouched because vanilla does drop wool in creative mode when shearing a sheep.

This probably also takes care of https://github.com/MinecraftForge/MinecraftForge/pull/1425 and https://github.com/MinecraftForge/MinecraftForge/issues/1308 if those issues weren't already fixed.