### PR TITLE
Re-introduce RenderBlockOverlayEvent

### DIFF
--- a/patches/minecraft/net/minecraft/client/renderer/ItemRenderer.java.patch
+++ b/patches/minecraft/net/minecraft/client/renderer/ItemRenderer.java.patch
@@ -9,7 +9,48 @@
              {
                  this.func_178097_a(entityplayersp, f3, f1, f2);
              }
-@@ -507,6 +507,12 @@
+@@ -359,7 +359,8 @@
+ 
+         if (this.field_78455_a.field_71439_g.func_70094_T())
+         {
+-            IBlockState iblockstate = this.field_78455_a.field_71441_e.func_180495_p(new BlockPos(this.field_78455_a.field_71439_g));
++            BlockPos blockpos = new BlockPos(this.field_78455_a.field_71439_g);
++            IBlockState iblockstate = this.field_78455_a.field_71441_e.func_180495_p(blockpos);
+             EntityPlayerSP entityplayersp = this.field_78455_a.field_71439_g;
+ 
+             for (int i = 0; i < 8; ++i)
+@@ -367,7 +368,7 @@
+                 double d0 = entityplayersp.field_70165_t + (double)(((float)((i >> 0) % 2) - 0.5F) * entityplayersp.field_70130_N * 0.8F);
+                 double d1 = entityplayersp.field_70163_u + (double)(((float)((i >> 1) % 2) - 0.5F) * 0.1F);
+                 double d2 = entityplayersp.field_70161_v + (double)(((float)((i >> 2) % 2) - 0.5F) * entityplayersp.field_70130_N * 0.8F);
+-                BlockPos blockpos = new BlockPos(d0, d1 + (double)entityplayersp.func_70047_e(), d2);
++                blockpos = new BlockPos(d0, d1 + (double)entityplayersp.func_70047_e(), d2);
+                 IBlockState iblockstate1 = this.field_78455_a.field_71441_e.func_180495_p(blockpos);
+ 
+                 if (iblockstate1.func_177230_c().func_176214_u())
+@@ -378,6 +379,7 @@
+ 
+             if (iblockstate.func_177230_c().func_149645_b() != -1)
+             {
++                if (!net.minecraftforge.event.ForgeEventFactory.renderBlockOverlay(field_78455_a.field_71439_g, p_78447_1_, net.minecraftforge.client.event.RenderBlockOverlayEvent.OverlayType.BLOCK, iblockstate, blockpos))
+                 this.func_178108_a(p_78447_1_, this.field_78455_a.func_175602_ab().func_175023_a().func_178122_a(iblockstate));
+             }
+         }
+@@ -386,11 +388,13 @@
+         {
+             if (this.field_78455_a.field_71439_g.func_70055_a(Material.field_151586_h))
+             {
++                if (!net.minecraftforge.event.ForgeEventFactory.renderWaterOverlay(field_78455_a.field_71439_g, p_78447_1_))
+                 this.func_78448_c(p_78447_1_);
+             }
+ 
+             if (this.field_78455_a.field_71439_g.func_70027_ad())
+             {
++                if (!net.minecraftforge.event.ForgeEventFactory.renderFireOverlay(field_78455_a.field_71439_g, p_78447_1_))
+                 this.func_78442_d(p_78447_1_);
+             }
+         }
+@@ -507,6 +511,12 @@
          {
              if (!this.field_78453_b.func_179549_c(itemstack))
              {

--- a/src/main/java/net/minecraftforge/client/event/RenderBlockOverlayEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/RenderBlockOverlayEvent.java
@@ -1,8 +1,10 @@
 package net.minecraftforge.client.event;
 
 import net.minecraft.block.Block;
+import net.minecraft.block.state.IBlockState;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.init.Blocks;
+import net.minecraft.util.BlockPos;
 import net.minecraftforge.fml.common.eventhandler.Cancelable;
 import net.minecraftforge.fml.common.eventhandler.Event;
 
@@ -28,23 +30,22 @@ public class RenderBlockOverlayEvent extends Event {
     /**
      * If the overlay type is BLOCK, then this is the block which the overlay is getting it's icon from
      */
-    public final Block blockForOverlay;
-    public final int blockX;
-    public final int blockY;
-    public final int blockZ;
+    public final IBlockState blockForOverlay;
+    public final BlockPos blockPos;
     
-    public RenderBlockOverlayEvent(EntityPlayer player, float renderPartialTicks, OverlayType type, Block block, int blockX, int blockY, int blockZ)
+    @Deprecated
+    public RenderBlockOverlayEvent(EntityPlayer player, float renderPartialTicks, OverlayType type, Block block, int x, int y, int z)
+    {
+        this(player, renderPartialTicks, type, block.getDefaultState(), new BlockPos(x, y, z));
+    }
+    
+    public RenderBlockOverlayEvent(EntityPlayer player, float renderPartialTicks, OverlayType type, IBlockState block, BlockPos blockPos)
     {
         this.player = player;
         this.renderPartialTicks = renderPartialTicks;
         this.overlayType = type;
-        if (this.overlayType == OverlayType.BLOCK)
-            this.blockForOverlay = block;
-        else
-            this.blockForOverlay = null;
-        this.blockX = blockX;
-        this.blockY = blockY;
-        this.blockZ = blockZ;
+        this.blockForOverlay = block;
+        this.blockPos = blockPos;
         
     }
 

--- a/src/main/java/net/minecraftforge/event/ForgeEventFactory.java
+++ b/src/main/java/net/minecraftforge/event/ForgeEventFactory.java
@@ -18,6 +18,7 @@ import net.minecraft.entity.item.EntityItem;
 import net.minecraft.entity.monster.EntityZombie;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.entity.player.EntityPlayer.EnumStatus;
+import net.minecraft.init.Blocks;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.BlockPos;
 import net.minecraft.util.DamageSource;
@@ -33,6 +34,8 @@ import net.minecraft.world.biome.BiomeGenBase;
 import net.minecraft.world.storage.IPlayerFileData;
 import net.minecraft.world.storage.SaveHandler;
 import net.minecraftforge.client.event.ClientChatReceivedEvent;
+import net.minecraftforge.client.event.RenderBlockOverlayEvent;
+import net.minecraftforge.client.event.RenderBlockOverlayEvent.OverlayType;
 import net.minecraftforge.common.ForgeHooks;
 import net.minecraftforge.common.IExtendedEntityProperties;
 import net.minecraftforge.common.MinecraftForge;
@@ -458,4 +461,20 @@ public class ForgeEventFactory
     {
         MinecraftForge.EVENT_BUS.post(new PotionBrewEvent.Post(brewingItemStacks));
     }
+    
+    public static boolean renderFireOverlay(EntityPlayer player, float renderPartialTicks)
+    {
+        return renderBlockOverlay(player, renderPartialTicks, OverlayType.FIRE, Blocks.fire.getDefaultState(), new BlockPos(player));
+    }
+    
+    public static boolean renderWaterOverlay(EntityPlayer player, float renderPartialTicks)
+    {
+        return renderBlockOverlay(player, renderPartialTicks, OverlayType.WATER, Blocks.water.getDefaultState(), new BlockPos(player));
+    }
+    
+    public static boolean renderBlockOverlay(EntityPlayer player, float renderPartialTicks, OverlayType type, IBlockState block, BlockPos pos)
+    {
+        return MinecraftForge.EVENT_BUS.post(new RenderBlockOverlayEvent(player, renderPartialTicks, type, block, pos));
+    }
+
 }


### PR DESCRIPTION
Seems to have been missed during 1.8 update.