### PR TITLE
Allow Tweak Mods to have a ModContainer

### DIFF
--- a/fml/src/main/java/net/minecraftforge/fml/common/TweakModContainer.java
+++ b/fml/src/main/java/net/minecraftforge/fml/common/TweakModContainer.java
@@ -1,0 +1,39 @@
+/*
+ * Forge Mod Loader
+ * Copyright (c) 2012-2013 cpw.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the GNU Lesser Public License v2.1
+ * which accompanies this distribution, and is available at
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.html
+ *
+ * Contributors:
+ *     Guichaguri - implementation
+ */
+
+package net.minecraftforge.fml.common;
+
+import com.google.common.eventbus.EventBus;
+
+public class TweakModContainer extends DummyModContainer
+{
+    private ModMetadata md;
+
+    public TweakModContainer(ModMetadata md)
+    {
+        super(md);
+        this.md = md;
+    }
+
+    @Override
+    public boolean registerBus(EventBus bus, LoadController controller)
+    {
+        return true;
+    }
+
+    @Override
+    public String toString()
+    {
+        return md != null ? getModId() : "Tweak Container ("+md.modId+") @" + System.identityHashCode(this);
+    }
+
+}

--- a/fml/src/main/java/net/minecraftforge/fml/relauncher/CoreModManager.java
+++ b/fml/src/main/java/net/minecraftforge/fml/relauncher/CoreModManager.java
@@ -360,7 +360,14 @@ public class CoreModManager {
                 Integer sortOrder = Ints.tryParse(Strings.nullToEmpty(mfAttributes.getValue("TweakOrder")));
                 sortOrder = (sortOrder == null ? Integer.valueOf(0) : sortOrder);
                 handleCascadingTweak(coreMod, jar, cascadedTweaker, classLoader, sortOrder);
-                loadedCoremods.add(coreMod.getName());
+                if(mfAttributes.getValue("TweakName") != null)
+                {
+                    reparsedCoremods.add(coreMod.getName());
+                }
+                else
+                {
+                    loadedCoremods.add(coreMod.getName());
+                }
                 continue;
             }
             List<String> modTypes = mfAttributes.containsKey(MODTYPE) ? Arrays.asList(mfAttributes.getValue(MODTYPE).split(",")) : ImmutableList.of("FML");


### PR DESCRIPTION
This PR allows Tweak Mods to have a ModContainer if there is "TweakName" in the manifest. Additionally, the mod can have `TweakVersion` and `TweakAuthor` in the manifest or a `mcmod.info` file inside the jar to provide more information.
It's a simple change useful for making tweak mods appear in the mod list, be checked for duplicates and be checked for the correct MC version.

Mod Example (following the guidelines):
http://www.mediafire.com/download/nuqfhal939n9mqg/TweakMod-src.zip

Reason: Instead of creating a special version just for Forge, tweak mods can "exist" in a Forge installation. ( #1961 )