### PR TITLE
Fix StateMap always mapping properties to the "minecraft" domain

### DIFF
--- a/patches/minecraft/net/minecraft/client/renderer/block/statemap/StateMap.java.patch
+++ b/patches/minecraft/net/minecraft/client/renderer/block/statemap/StateMap.java.patch
@@ -1,0 +1,11 @@
+--- ../src-base/minecraft/net/minecraft/client/renderer/block/statemap/StateMap.java
++++ ../src-work/minecraft/net/minecraft/client/renderer/block/statemap/StateMap.java
+@@ -40,7 +40,7 @@
+         }
+         else
+         {
+-            s = this.field_178142_a.func_177702_a((Comparable)linkedhashmap.remove(this.field_178142_a));
++            s = String.format("%s:%s", ((ResourceLocation)Block.field_149771_c.func_177774_c(p_178132_1_.func_177230_c())).func_110624_b(), this.field_178142_a.func_177702_a((Comparable)linkedhashmap.remove(this.field_178142_a)));
+         }
+ 
+         if (this.field_178141_c != null)

--- a/src/test/java/net/minecraftforge/debug/ForgeBlockStatesLoaderDebug.java
+++ b/src/test/java/net/minecraftforge/debug/ForgeBlockStatesLoaderDebug.java
@@ -8,7 +8,9 @@ import com.google.common.collect.Maps;
 
 import net.minecraft.block.Block;
 import net.minecraft.block.BlockWall;
+import net.minecraft.block.material.Material;
 import net.minecraft.block.properties.IProperty;
+import net.minecraft.block.properties.PropertyEnum;
 import net.minecraft.block.state.BlockState;
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.client.renderer.block.statemap.IStateMapper;
@@ -20,6 +22,7 @@ import net.minecraft.init.Blocks;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemMultiTexture;
 import net.minecraft.item.ItemStack;
+import net.minecraft.util.IStringSerializable;
 import net.minecraftforge.client.model.ModelLoader;
 import net.minecraftforge.fml.common.Mod;
 import net.minecraftforge.fml.common.Mod.EventHandler;
@@ -34,6 +37,7 @@ public class ForgeBlockStatesLoaderDebug {
     public static final String MODID = "ForgeBlockStatesLoader";
     public static final String ASSETS = "forgeblockstatesloader:";
     
+    public static final Block blockCustom = new CustomMappedBlock();
     public static final String nameCustomWall = "custom_wall";
     public static final BlockWall blockCustomWall = new BlockWall(Blocks.cobblestone);
     public static final ItemMultiTexture itemCustomWall = new ItemMultiTexture(blockCustomWall, blockCustomWall, new Function<ItemStack, String>()
@@ -47,7 +51,10 @@ public class ForgeBlockStatesLoaderDebug {
     
     @EventHandler
     public void preInit(FMLPreInitializationEvent event)
-    {
+    {   
+    	blockCustom.setUnlocalizedName(MODID + ".customBlock");
+    	GameRegistry.registerBlock(blockCustom, "customBlock");
+    	
         blockCustomWall.setUnlocalizedName(MODID + ".customWall");
         GameRegistry.registerBlock(blockCustomWall, null, nameCustomWall);
         GameRegistry.registerItem(itemCustomWall, nameCustomWall);
@@ -60,6 +67,8 @@ public class ForgeBlockStatesLoaderDebug {
     @SideOnly(Side.CLIENT)
     public void preInitClient(FMLPreInitializationEvent event)
     {
+    	ModelLoader.setCustomStateMapper(blockCustom, new StateMap.Builder().setProperty(CustomMappedBlock.VARIANT).build());
+    	
         ModelLoader.setCustomStateMapper(blockCustomWall, new IStateMapper()
         {
             StateMap stateMap = new StateMap.Builder().setProperty(BlockWall.VARIANT).setBuilderSuffix("_wall").build();
@@ -82,5 +91,43 @@ public class ForgeBlockStatesLoaderDebug {
         ModelLoader.setCustomModelResourceLocation(customWallItem, 0, new ModelResourceLocation(ASSETS + "cobblestone_wall", "inventory"));
         ModelLoader.setCustomModelResourceLocation(customWallItem, 1, new ModelResourceLocation(ASSETS + "mossy_cobblestone_wall", "inventory"));
         ModelBakery.addVariantName(customWallItem, ASSETS + "cobblestone_wall", ASSETS + "mossy_cobblestone_wall");
+    }
+    
+    // this block is never actually used, it's only needed for the error message on load to see the variant it maps to
+    public static class CustomMappedBlock extends Block {
+    	public static final PropertyEnum VARIANT = PropertyEnum.create("type", CustomVariant.class);
+    	
+		protected CustomMappedBlock() {
+			super(Material.rock);
+			
+			this.setUnlocalizedName(MODID + ".customMappedBlock");
+		}
+    	
+		@Override
+		protected BlockState createBlockState() {
+			return new BlockState(this,  VARIANT);
+		}
+		
+		@Override
+		public int getMetaFromState(IBlockState state)
+		{
+		    return ((CustomVariant)state.getValue(VARIANT)).ordinal();
+		}
+		
+		@Override
+		public IBlockState getStateFromMeta(int meta)
+		{
+		    if(meta > CustomVariant.values().length || meta < 0)
+		        meta = 0;
+		    
+		    return this.getDefaultState().withProperty(VARIANT, CustomVariant.values()[meta]);
+		}
+		
+		public static enum CustomVariant implements IStringSerializable {
+			TypeA,
+			TypeB;
+			
+			public String getName() { return this.toString(); };
+		}
     }
 }


### PR DESCRIPTION
The standard StateMap (built with StateMap.Builder) does not respect the blocks domain and therefore always defaults to "minecraft:foo". A mapping therefore always maps to "minecraft:foo#state" which can't be found, instead of "mymod:foo#state".

The debug block and mapper added are solely there for the error message to confirm that the patch works.

Without Patch:
```[FML]: Model definition for location minecraft:TypeA#normal not found```
With Patch:
```[FML]: Model definition for location forgeblockstatesloader:TypeA#normal not found```