### PR TITLE
Fixed error GUIs showing a white screen

### DIFF
--- a/fml/src/main/java/net/minecraftforge/fml/client/FMLClientHandler.java
+++ b/fml/src/main/java/net/minecraftforge/fml/client/FMLClientHandler.java
@@ -40,6 +40,7 @@ import net.minecraft.client.multiplayer.ServerData;
 import net.minecraft.client.multiplayer.WorldClient;
 import net.minecraft.client.network.NetHandlerPlayClient;
 import net.minecraft.client.network.OldServerPinger;
+import net.minecraft.client.renderer.GlStateManager;
 import net.minecraft.client.renderer.entity.Render;
 import net.minecraft.client.resources.AbstractResourcePack;
 import net.minecraft.client.resources.FallbackResourceManager;
@@ -382,6 +383,9 @@ public class FMLClientHandler implements IFMLSidedHandler
     }
     public void onInitializationComplete()
     {
+        // re-sync TEXTURE_2D, splash screen disables it with a direct GL call
+        GlStateManager.disableTexture2D();
+        GlStateManager.enableTexture2D();
         if (wrongMC != null)
         {
             showGuiScreen(new GuiWrongMinecraft(wrongMC));

--- a/src/main/java/net/minecraftforge/client/GuiIngameForge.java
+++ b/src/main/java/net/minecraftforge/client/GuiIngameForge.java
@@ -206,7 +206,7 @@ public class GuiIngameForge extends GuiIngame
             GlStateManager.enableAlpha();
             drawTexturedModalRect(width / 2 - 7, height / 2 - 7, 0, 0, 16, 16);
             GlStateManager.tryBlendFuncSeparate(GL11.GL_SRC_ALPHA, GL11.GL_ONE_MINUS_SRC_ALPHA, 1, 0);
-            GL11.glDisable(GL11.GL_BLEND);
+            GlStateManager.disableBlend();
         }
         post(CROSSHAIRS);
     }


### PR DESCRIPTION
Tested by adding `dependencies = "required-after:IDoNotExist@[0,1]"` to LayerBreakingTest.

![](http://puu.sh/iDIf6.png)