### PR TITLE
Generic quad vertex data interface.

### DIFF
--- a/src/main/java/net/minecraftforge/client/model/BakedModelBuilder.java
+++ b/src/main/java/net/minecraftforge/client/model/BakedModelBuilder.java
@@ -1,0 +1,181 @@
+package net.minecraftforge.client.model;
+
+import java.nio.ByteBuffer;
+import java.nio.IntBuffer;
+import java.util.List;
+
+import com.google.common.collect.ImmutableList;
+
+import net.minecraft.client.renderer.block.model.BakedQuad;
+import net.minecraft.client.renderer.block.model.ItemCameraTransforms;
+import net.minecraft.client.renderer.texture.TextureAtlasSprite;
+import net.minecraft.client.renderer.vertex.VertexFormat;
+import net.minecraft.util.EnumFacing;
+
+/**
+ * Doesn't touch the buffer in any way - you'll probably want to at least call buffer.flip after filling it with data.
+ */
+public class BakedModelBuilder extends IVertexConsumer.ByteBufferImpl
+{
+    private final ByteBuffer buf;
+    private final IQuadInfo info;
+    private final TextureAtlasSprite particle;
+    private boolean isAmbientOcclusion = false;
+    private boolean isGui3d = false;
+    private VertexFormat format;
+
+    public BakedModelBuilder(int quads, IQuadInfo info, TextureAtlasSprite particle)
+    {
+        this(createBuffer(quads), info, particle);
+    }
+
+    public BakedModelBuilder(ByteBuffer buf, IQuadInfo info, TextureAtlasSprite particle)
+    {
+        super(buf);
+        this.buf = buf;
+        this.info = info;
+        this.particle = particle;
+    }
+
+    private static ByteBuffer createBuffer(int quads)
+    {
+        return ByteBuffer.allocate(quads);
+    }
+
+    @Override
+    public void setVertexFormat(VertexFormat format)
+    {
+        this.format = new VertexFormat(format);
+        super.setVertexFormat(format);
+    }
+
+    public BakedModelBuilder setFormat(VertexFormat format)
+    {
+        this.setVertexFormat(format);
+        return this;
+    }
+
+    public BakedModelBuilder setAO(boolean isAmbientOcclusion)
+    {
+        this.isAmbientOcclusion = isAmbientOcclusion;
+        return this;
+    }
+
+    public BakedModelBuilder set3d(boolean isGui3d)
+    {
+        this.isGui3d = isGui3d;
+        return this;
+    }
+
+    public IFlexibleBakedModel build()
+    {
+        return new BakedModel(isAmbientOcclusion, isGui3d, particle, format, buf, info);
+    }
+
+    private static class BakedModel implements IFastBakedModel
+    {
+        private final boolean isAmbientOcclusion;
+        private final boolean isGui3d;
+        private final TextureAtlasSprite particle;
+        private final VertexFormat format;
+        private final ByteBuffer buf;
+        private final IQuadInfo info;
+
+        private ImmutableList<BakedQuad> quadList = null;
+
+        public BakedModel(boolean isAmbientOcclusion, boolean isGui3d, TextureAtlasSprite particle, VertexFormat format, ByteBuffer buf, IQuadInfo info)
+        {
+            this.isAmbientOcclusion = isAmbientOcclusion;
+            this.isGui3d = isGui3d;
+            this.particle = particle;
+            this.format = format;
+            this.buf = buf;
+            this.info = info;
+        }
+
+        public boolean isAmbientOcclusion()
+        {
+            return isAmbientOcclusion;
+        }
+
+        public boolean isGui3d()
+        {
+            return isGui3d;
+        }
+
+        public boolean isBuiltInRenderer()
+        {
+            return false;
+        }
+
+        public TextureAtlasSprite getTexture()
+        {
+            return particle;
+        }
+
+        public ItemCameraTransforms getItemCameraTransforms()
+        {
+            return ItemCameraTransforms.DEFAULT;
+        }
+
+        public List<BakedQuad> getFaceQuads(EnumFacing side)
+        {
+            return ImmutableList.of();
+        }
+
+        // Culling data is lost right now.
+        public List<BakedQuad> getGeneralQuads()
+        {
+            if(quadList == null)
+            {
+                ImmutableList.Builder<BakedQuad> builder = ImmutableList.builder();
+                IntBuffer iBuf = buf.asIntBuffer();
+                for(int i = 0; i < iBuf.limit(); i += format.getNextOffset() / 4)
+                {
+                    int[] data = new int[format.getNextOffset() / 4];
+                    iBuf.get(data, i, data.length);
+                    if(isColored(i))
+                    {
+                        builder.add(new IColoredBakedQuad.ColoredBakedQuad(data, getTintIndex(i), getOrientation(i)));
+                    }
+                    else
+                    {
+                        builder.add(new BakedQuad(data, getTintIndex(i), getOrientation(i)));
+                    }
+                }
+                quadList = builder.build();
+            }
+            return quadList;
+        }
+
+        public VertexFormat getFormat()
+        {
+            return format;
+        }
+
+        public ByteBuffer getDataBuffer()
+        {
+            return buf;
+        }
+
+        public int getTintIndex(int quad)
+        {
+            return info.getTintIndex(quad);
+        }
+
+        public EnumFacing getOrientation(int quad)
+        {
+            return info.getOrientation(quad);
+        }
+
+        public boolean isColored(int quad)
+        {
+            return info.isColored(quad);
+        }
+
+        public boolean isCulled(int quad)
+        {
+            return info.isCulled(quad);
+        }
+    }
+}

--- a/src/main/java/net/minecraftforge/client/model/IFastBakedModel.java
+++ b/src/main/java/net/minecraftforge/client/model/IFastBakedModel.java
@@ -1,0 +1,14 @@
+package net.minecraftforge.client.model;
+
+import java.nio.ByteBuffer;
+
+import net.minecraft.util.EnumFacing;
+
+public interface IFastBakedModel extends IFlexibleBakedModel, IQuadInfo
+{
+    /**
+     * @return the buffer containing the vertex data for this model.
+     * data will be read from the buffer according to the buffer's position and limit.
+     */
+    ByteBuffer getDataBuffer();
+}

--- a/src/main/java/net/minecraftforge/client/model/IQuadInfo.java
+++ b/src/main/java/net/minecraftforge/client/model/IQuadInfo.java
@@ -1,0 +1,66 @@
+package net.minecraftforge.client.model;
+
+import net.minecraft.client.renderer.block.model.BakedQuad;
+import net.minecraft.util.EnumFacing;
+
+/**
+ * Get various info about face data, which is not recoverable from the raw vertex data.
+ */
+public interface IQuadInfo
+{
+    int getTintIndex(int quad);
+    EnumFacing getOrientation(int quad);
+    boolean isCulled(int quad);
+    boolean isColored(int quad);
+
+    /**
+     * All side quads are after the general quads, in the order of EnumFacing.values().
+     */
+    public static class Impl implements IQuadInfo
+    {
+        private final IFlexibleBakedModel parent;
+
+        protected BakedQuad getQuad(int quad)
+        {
+            if(quad < parent.getGeneralQuads().size())
+            {
+                return parent.getGeneralQuads().get(quad);
+            }
+            quad -= parent.getGeneralQuads().size();
+            for(EnumFacing side : EnumFacing.values())
+            {
+                if(quad < parent.getFaceQuads(side).size())
+                {
+                    return parent.getFaceQuads(side).get(quad);
+                }
+                quad -= parent.getFaceQuads(side).size();
+            }
+            throw new IndexOutOfBoundsException();
+        }
+
+        public Impl(IFlexibleBakedModel parent)
+        {
+            this.parent = parent;
+        }
+
+        public int getTintIndex(int quad)
+        {
+            return getQuad(quad).getTintIndex();
+        }
+
+        public EnumFacing getOrientation(int quad)
+        {
+            return getQuad(quad).getFace();
+        }
+
+        public boolean isCulled(int quad)
+        {
+            return quad >= parent.getGeneralQuads().size();
+        }
+
+        public boolean isColored(int quad)
+        {
+            return getQuad(quad) instanceof IColoredBakedQuad;
+        }
+    }
+}

--- a/src/main/java/net/minecraftforge/client/model/IVertexConsumer.java
+++ b/src/main/java/net/minecraftforge/client/model/IVertexConsumer.java
@@ -1,0 +1,130 @@
+package net.minecraftforge.client.model;
+
+import java.nio.ByteBuffer;
+
+import net.minecraft.client.renderer.WorldRenderer;
+import net.minecraft.client.renderer.vertex.VertexFormat;
+import net.minecraft.client.renderer.vertex.VertexFormatElement;
+
+/**
+ * Assumes that the data length is not less than e.getElementCount().
+ * Also assumes that element index passed will increment from 0 to format.getElementCount() - 1.
+ * Normal, Color and UV are assumed to be in 0-1 range.
+ */
+public interface IVertexConsumer
+{
+    void setVertexFormat(VertexFormat format);
+    void put(int element, float... data);
+
+    /**
+     * Assumes VertexFormatElement is present in the WorlRenderer's vertex format.
+     */
+    public static class WorldRendererImpl implements IVertexConsumer
+    {
+        private final WorldRenderer renderer;
+        private VertexFormat format;
+        private float x, y, z;
+
+        public WorldRendererImpl(WorldRenderer renderer)
+        {
+            super();
+            this.renderer = renderer;
+        }
+
+        public void setVertexFormat(VertexFormat format)
+        {
+            renderer.setVertexFormat(format);
+            this.format = new VertexFormat(format);
+        }
+
+        public void put(int element, float... data)
+        {
+            VertexFormatElement e = format.getElement(element);
+            if(e.getElementCount() > data.length) throw new IllegalArgumentException("not enough elements");
+            switch(e.getUsage())
+            {
+            case POSITION:
+                x = data[0];
+                y = data[1];
+                z = data[2];
+                break;
+            case COLOR:
+                renderer.setColorRGBA_F(data[0], data[1], data[2], data[3]);
+                break;
+            case UV:
+                if (e.getIndex() == 0)
+                {
+                    renderer.setTextureUV(data[0], data[1]);
+                }
+                else if (e.getIndex() == 1)
+                {
+                    // assume the full range is used
+                    int b = (int)(data[0] * 0x10000) << 16 | (int)(data[1] * 0x10000);
+                    renderer.setBrightness(b);
+                }
+                else throw new IllegalArgumentException("WorldRenderer only has 2 texture units");
+                break;
+            case NORMAL:
+                renderer.setNormal(data[0], data[1], data[2]);
+                break;
+            default:
+                // WorldRenderer doesn't know about anything else
+                break;
+            }
+            if(element == format.getElementCount() - 1) // we're done
+            {
+                renderer.addVertex(x, y, z);
+            }
+        }
+    }
+
+    public static class ByteBufferImpl implements IVertexConsumer
+    {
+        private final ByteBuffer buf;
+        private VertexFormat format;
+
+        public ByteBufferImpl(ByteBuffer buf)
+        {
+            this.buf = buf;
+        }
+
+        public void setVertexFormat(VertexFormat format)
+        {
+            this.format = new VertexFormat(format);
+        }
+
+        public void put(int element, float... data)
+        {
+            VertexFormatElement e = format.getElement(element);
+            if(e.getElementCount() > data.length) throw new IllegalArgumentException("not enough elements");
+            for(int i = 0; i < e.getElementCount(); i++)
+            {
+                float f = data[i];
+                switch(e.getType())
+                {
+                case BYTE:
+                    buf.put((byte)(f * (Byte.MAX_VALUE - 1)));
+                    break;
+                case UBYTE:
+                    buf.put((byte)(f * ((1 << Byte.SIZE) - 1)));
+                    break;
+                case SHORT:
+                    buf.putShort((short)(f * (Short.MAX_VALUE - 1)));
+                    break;
+                case USHORT:
+                    buf.putShort((short)(f * ((1 << Short.SIZE) - 1)));
+                    break;
+                case INT:
+                    buf.putInt((int)(f * (Integer.MAX_VALUE - 1)));
+                    break;
+                case UINT:
+                    buf.putInt((int)(f * ((1L << Integer.SIZE) - 1)));
+                    break;
+                case FLOAT:
+                    buf.putFloat(f);
+                    break;
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Should replace all ad-hoc quad generation methods in forge, and make IBakedModel -> WorldRenderer data transfer faster.
TODO:
  - convert everything in forge to use IVertexConsumer/IFastBakedModel
  - make vanilla understand IFastBakedModel

Putting this up right now for possible comments regarding the API.