### PR TITLE
Don't overwrite the still icon

### DIFF
--- a/src/main/java/net/minecraftforge/fluids/FluidRegistry.java
+++ b/src/main/java/net/minecraftforge/fluids/FluidRegistry.java
@@ -409,7 +409,7 @@ public abstract class FluidRegistry
             if(fluid.getFlowing() != null)
             {
                 TextureAtlasSprite flowing = map.registerSprite(fluid.getFlowing());
-                fluid.setStillIcon(flowing);
+                fluid.setFlowingIcon(flowing);
             }
         }
     }


### PR DESCRIPTION
While I'm assuming this was a bug, these methods are deprecated so i'm not sure if you want this fixed or not.