### PR TITLE
Disallow conflicting furnace recipes

### DIFF
--- a/patches/minecraft/net/minecraft/item/crafting/FurnaceRecipes.java.patch
+++ b/patches/minecraft/net/minecraft/item/crafting/FurnaceRecipes.java.patch
@@ -1,6 +1,14 @@
 --- ../src-base/minecraft/net/minecraft/item/crafting/FurnaceRecipes.java
 +++ ../src-work/minecraft/net/minecraft/item/crafting/FurnaceRecipes.java
-@@ -113,6 +113,9 @@
+@@ -78,6 +78,7 @@
+ 
+     public void func_151394_a(ItemStack p_151394_1_, ItemStack p_151394_2_, float p_151394_3_)
+     {
++        if (func_151395_a(p_151394_1_) != null) { net.minecraftforge.fml.common.FMLLog.info("Ignored smelting recipe with conflicting input: " + p_151394_1_ + " = " + p_151394_2_); return; }
+         this.field_77604_b.put(p_151394_1_, p_151394_2_);
+         this.field_77605_c.put(p_151394_2_, Float.valueOf(p_151394_3_));
+     }
+@@ -113,6 +114,9 @@
  
      public float func_151398_b(ItemStack p_151398_1_)
      {


### PR DESCRIPTION
Since the furnace iterates through the list and stops when it finds the first valid recipe, anything added that conflicts with something that's already registered won't ever be used.

So it's be better to just not even add them to the list, which can reduce its size and therefore improve performance.

This would have zero effect on existing mods, since (as already mentioned) any recipes they add that conflict were never used in the first place.