### PR TITLE
Fix placing signs with NBT prompting for text

### DIFF
--- a/patches/minecraft/net/minecraft/item/ItemBlock.java.patch
+++ b/patches/minecraft/net/minecraft/item/ItemBlock.java.patch
@@ -38,7 +38,7 @@
 +                //Forge: Fixes  MC-75630 - Exploit with signs and command blocks
 +                final net.minecraft.server.MinecraftServer server = net.minecraft.server.MinecraftServer.func_71276_C();
 +                if (!p_179224_0_.field_72995_K && tileentity.restrictNBTCopy() &&
-+                   (server == null || server.func_71203_ab().func_152596_g(player.func_146103_bH())))
++                   (server == null || !server.func_71203_ab().func_152596_g(player.func_146103_bH())))
 +                       return false;
                  NBTTagCompound nbttagcompound = new NBTTagCompound();
                  NBTTagCompound nbttagcompound1 = (NBTTagCompound)nbttagcompound.func_74737_b();


### PR DESCRIPTION
This fixes the issue that signs with NBT data don't place their data when the item is clicked on a block.
The problem was originally discovered in: https://github.com/SpongePowered/Sponge/issues/289

I fixed the issue by comparing forge's patch to vanilla's patch.
So I opened a clean 1.8.7 jar (in jd-gui) and after some snooping around the classes I identified some key classes (by comparing them to 1.8 classes).
Class `aar` is `ItemSign`, class `yo` is `ItemBlock`, the method `public static boolean a(adm ☃, wn ☃, cj ☃, zx ☃)` is `setTileEntityNBT`
within that method there is the line:
```java
if ((!☃.D) && (☃.F()) && (!☃.ap().h(☃.cd()))) {
    return false;
}
```
Comparing this to forge's patch and some more class investigation the line is expanded to:
```java
if ((!worldIn.isRemote) && (tileentity.restrictNBTCopy()) && (!server.getConfigurationManager().canSendCommands(player.getGameProfile()))) {
    return false;
}
```
This is very similar to forge's patch except the fact that `canSendCommands` is negated.
Therefore I conclude that there is a missing `!` in the patch.

I can confirm this fixes the original issue (from Sponge)
