### PR TITLE
Add hook for adding EnumPlantType and fixed npe in BiomeType

### DIFF
--- a/src/main/java/net/minecraftforge/common/BiomeManager.java
+++ b/src/main/java/net/minecraftforge/common/BiomeManager.java
@@ -175,7 +175,7 @@ public class BiomeManager
                 if (t.name().equals(name)) return t;
             }
 
-            BiomeType ret = EnumHelper.addEnum(BiomeType.class, name, BiomeType.class);
+            BiomeType ret = EnumHelper.addEnum(BiomeType.class, name, new Class[0], new Object[0]);
 
             if (ret.ordinal() >= biomes.length)
             {

--- a/src/main/java/net/minecraftforge/common/EnumPlantType.java
+++ b/src/main/java/net/minecraftforge/common/EnumPlantType.java
@@ -1,5 +1,7 @@
 package net.minecraftforge.common;
 
+import net.minecraftforge.common.util.EnumHelper;
+
 public enum EnumPlantType
 {
     Plains,
@@ -8,5 +10,27 @@ public enum EnumPlantType
     Cave,
     Water,
     Nether,
-    Crop
+    Crop;
+
+    /**
+     * Getting a custom {@link EnumPlantType}, or an existing one if it has the same name as that one. Your plant should implement {@link IPlantable}
+     * and return this custom type in {@link IPlantable#getPlantType(net.minecraft.world.IBlockAccess, net.minecraft.util.BlockPos)}.
+     * 
+     * <p>If your new plant grows on blocks like any one of them above, never create a new {@link EnumPlantType}. 
+     * This enumeration is only functioning in 
+     * {@link net.minecraft.block.Block#canSustainPlant(net.minecraft.world.IBlockAccess, net.minecraft.util.BlockPos, net.minecraft.util.EnumFacing, IPlantable)},
+     * which you are supposed to override this function in your new block and create a new plant type to grow on that block.
+     * 
+     * <p>You can create an instance of your plant type in your API and let your/others mods access it. It will be faster than calling this method.
+     * @param name the name of the type of plant, you had better follow the style above
+     * @return the acquired {@EnumPlantType}, a new one if not found.
+     */
+    public static EnumPlantType getPlantType(String name) 
+    {
+        for (EnumPlantType t : values()) 
+        { 
+            if (t.name().equalsIgnoreCase(name)) return t;
+        }
+        return EnumHelper.addEnum(EnumPlantType.class, name, new Class[0], new Object[0]);
+    }
 }

--- a/src/test/java/net/minecraftforge/debug/EnumPlantTypeTest.java
+++ b/src/test/java/net/minecraftforge/debug/EnumPlantTypeTest.java
@@ -1,0 +1,49 @@
+package net.minecraftforge.debug;
+
+import net.minecraftforge.common.BiomeManager.BiomeType;
+import net.minecraftforge.common.EnumPlantType;
+import net.minecraftforge.fml.common.Mod;
+import net.minecraftforge.fml.common.event.FMLInitializationEvent;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+
+@Mod(modid = "enumplanttypetest")
+public class EnumPlantTypeTest 
+{
+	private static Logger LOGGER = LogManager.getLogger();
+	
+	@Mod.EventHandler
+	public void onInit(FMLInitializationEvent event) 
+	{
+		BiomeType biomeType = null;
+		try 
+		{ 
+			biomeType = BiomeType.getType("FAKE");
+		} 
+		catch (NullPointerException npe)
+		{
+			LOGGER.warn("EnumHelper in BiomeType is working incorrectly!", npe);
+		}
+		finally
+		{
+		    if (biomeType == null || !biomeType.name().equals("FAKE")) 
+			    LOGGER.warn("EnumHelper in BiomeType is working incorrectly!");
+		}
+	    EnumPlantType plantType = null;
+	    if (plantType == null || !plantType.name().equals("FAKE"))
+	    	;
+	    try 
+		{ 
+	    	 plantType = EnumPlantType.getPlantType("FAKE");
+		} 
+		catch (NullPointerException npe)
+		{
+			LOGGER.warn("EnumHelper in EnumPlantType is working incorrectly!", npe);
+		}
+		finally
+		{
+		    if (plantType == null || !plantType.name().equals("FAKE")) 
+		    	LOGGER.warn("EnumHelper in EnumPlantType is working incorrectly!");
+		}
+	}
+}


### PR DESCRIPTION
This commit includes three changes:
1. The `EnumPlantType.java` with a new hook added, not considering to break the compatibility.
2. The `BiomeManager.java` with an incorrect usage of `EnumHelper` in subclass (enumeration) `BiomeType` fixed. When calling that method it will throw an NPE on [this line](https://github.com/MinecraftForge/MinecraftForge/blob/master/src/main/java/net/minecraftforge/common/BiomeManager.java#L180) because `EnumHelper` returns null when it cannot function properly.
3. The `EnumHelperTest.java` with 2 tests, to check whether those two things works. (When I run it with this commit now it does not post any warning, of course this change compiles)

Hope any one of those 321 watchers to leave a comment here. I am glad to listen to your suggestions and going to improve this commit/pr.