### PR TITLE
Event for when EntityThrowables impact

### DIFF
--- a/patches/minecraft/net/minecraft/entity/projectile/EntityThrowable.java.patch
+++ b/patches/minecraft/net/minecraft/entity/projectile/EntityThrowable.java.patch
@@ -1,0 +1,10 @@
+--- ../src-base/minecraft/net/minecraft/entity/projectile/EntityThrowable.java
++++ ../src-work/minecraft/net/minecraft/entity/projectile/EntityThrowable.java
+@@ -213,6 +213,7 @@
+             }
+             else
+             {
++                net.minecraftforge.common.MinecraftForge.EVENT_BUS.post(new net.minecraftforge.event.entity.item.ThrowableImpactEvent(this, movingobjectposition));
+                 this.func_70184_a(movingobjectposition);
+             }
+         }

--- a/src/main/java/net/minecraftforge/event/entity/item/ThrowableImpactEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/item/ThrowableImpactEvent.java
@@ -1,0 +1,42 @@
+package net.minecraftforge.event.entity.item;
+
+import net.minecraft.entity.projectile.EntityThrowable;
+import net.minecraft.util.MovingObjectPosition;
+import net.minecraftforge.event.entity.EntityEvent;
+
+/**
+ * This event is fired before {@link EntityThrowable#onImpact()} is called, inside {@link EntityThrowable#onUpdate()}.
+ * 
+ * This event is not {@link Cancelable}.
+ * 
+ * This event has no result. {@link HasResult}.
+ * 
+ * This event is fired on the {@link MinecraftForge#EVENT_BUS}.
+ * 
+ * @author williewillus
+ */
+public class ThrowableImpactEvent extends EntityEvent 
+{
+    /**
+     * The EntityThrowable that is impacting
+     */
+    public final EntityThrowable throwable;
+    
+    /**
+     * The MovingObjectPosition that is generated from this impact
+     */
+    public final MovingObjectPosition movingObjectPosition;
+    
+    /**
+     * Creates a new event for an impacting EntityThrowable
+     * 
+     * @param throwable The EntityThrowable being impacted
+     * @param mop The MovingObjectPosition used in impact calculations
+     */
+    public ThrowableImpactEvent(EntityThrowable throwable, MovingObjectPosition mop)
+    {
+        super(throwable);
+        this.throwable = throwable;
+        this.movingObjectPosition = mop;
+    }
+}


### PR DESCRIPTION
This pull adds an event that is fired immediately before EntityThrowables (Eggs, Enderpearls, Snowballs, Splash Potions, and Bottles of Enchanting in vanilla) call their onImpact() method. This allows for modders to not only add logic to vanilla throwables but also to those of other mods.

My main purpose for proposing this was to reimplement the "snowballs knockback players in MP" vanilla feature that was removed quite a while ago, and there didn't seem to be any clean solution, other than tracking every snowball in a tickhandler to see if it's touching a player.

Using this event, I could simply subscribe to a ThrowableImpactEvent, check if it was a snowball, check that the MovingObjectPosition was targeting a player, then knock back said player.

I didn't make the event cancelable because if done so, the entity would simply keep its current trajectory into whatever block or entity it hit, and, more likely than not, just fire the same event again in subsequent ticks. Perhaps the entity could be killed after the event is canceled, but that is up for debate.