### PR TITLE
Add Guava and Apache to LaunchClassLoader exclusion list on server

### DIFF
--- a/src/main/java/net/minecraftforge/fml/common/launcher/FMLServerTweaker.java
+++ b/src/main/java/net/minecraftforge/fml/common/launcher/FMLServerTweaker.java
@@ -16,11 +16,6 @@ public class FMLServerTweaker extends FMLTweaker {
         // The log4j2 queue is excluded so it is correctly visible from the obfuscated
         // and deobfuscated parts of the code. Without, the UI won't show anything
         classLoader.addClassLoaderExclusion("com.mojang.util.QueueLogAppender");
-        classLoader.addClassLoaderExclusion("org.objectweb.asm.");
-        classLoader.addTransformerExclusion("net.minecraftforge.fml.repackage.");
-        classLoader.addTransformerExclusion("net.minecraftforge.fml.relauncher.");
-        classLoader.addTransformerExclusion("net.minecraftforge.fml.common.asm.transformers.");
-        classLoader.addClassLoaderExclusion("LZMA.");
         FMLLaunchHandler.configureForServerLaunch(classLoader, this);
         FMLLaunchHandler.appendCoreMods();
     }

--- a/src/main/java/net/minecraftforge/fml/common/launcher/FMLTweaker.java
+++ b/src/main/java/net/minecraftforge/fml/common/launcher/FMLTweaker.java
@@ -116,13 +116,6 @@ public class FMLTweaker implements ITweaker {
     @Override
     public void injectIntoClassLoader(LaunchClassLoader classLoader)
     {
-        classLoader.addClassLoaderExclusion("org.apache.");
-        classLoader.addClassLoaderExclusion("com.google.common.");
-        classLoader.addClassLoaderExclusion("org.objectweb.asm.");
-        classLoader.addTransformerExclusion("net.minecraftforge.fml.repackage.");
-        classLoader.addTransformerExclusion("net.minecraftforge.fml.relauncher.");
-        classLoader.addTransformerExclusion("net.minecraftforge.fml.common.asm.transformers.");
-        classLoader.addClassLoaderExclusion("LZMA.");
         FMLLaunchHandler.configureForClientLaunch(classLoader, this);
         FMLLaunchHandler.appendCoreMods();
     }

--- a/src/main/java/net/minecraftforge/fml/relauncher/FMLLaunchHandler.java
+++ b/src/main/java/net/minecraftforge/fml/relauncher/FMLLaunchHandler.java
@@ -56,8 +56,13 @@ public class FMLLaunchHandler
         this.minecraftHome = tweaker.getGameDir();
         this.classLoader.addClassLoaderExclusion("net.minecraftforge.fml.relauncher.");
         this.classLoader.addClassLoaderExclusion("net.minecraftforge.classloading.");
-        this.classLoader.addTransformerExclusion("net.minecraftforge.fml.common.asm.transformers.deobf.");
+        this.classLoader.addTransformerExclusion("net.minecraftforge.fml.common.asm.transformers.");
         this.classLoader.addTransformerExclusion("net.minecraftforge.fml.common.patcher.");
+        this.classLoader.addTransformerExclusion("net.minecraftforge.fml.repackage.");
+        this.classLoader.addClassLoaderExclusion("org.apache.");
+        this.classLoader.addClassLoaderExclusion("com.google.common.");
+        this.classLoader.addClassLoaderExclusion("org.objectweb.asm.");
+        this.classLoader.addClassLoaderExclusion("LZMA.");
     }
 
     private void setupClient()


### PR DESCRIPTION
This adds `org.apache.` and `com.google.common.` to the `LaunchClassLoader` exclusion list for server, just like they are on the client.
I also moved the exclusions to common place which makes it less likely for the list to go out of sync for client/server.

An example dedicated server crash is when trying to use Sponge and CodeChickenCore.
You end up with some guava classes loaded via the LCL and others on ACL
Examples of crashes (which I believe this PR will fix)
https://forums.spongepowered.org/t/crash-on-launch-mixins/7553
https://forums.spongepowered.org/t/mod-conflict-list/8350 (CCC + NEI)

Error messages look like the following:
> java.lang.LinkageError: loader constraint violation: when resolving method "com.google.common.io.Resources.readLines(Ljava/net/URL;Ljava/nio/charset/Charset;Lcom/google/common/io/LineProcessor;)Ljava/lang/Object;" the class loader (instance of net/minecraft/launchwrapper/LaunchClassLoader) of the current class, net/minecraftforge/fml/common/asm/transformers/MarkerTransformer, and the class loader (instance of sun/misc/Launcher$AppClassLoader) for the method's defining class, com/google/common/io/Resources, have different Class objects for the type com/google/common/io/LineProcessor used in the signature

> java.lang.LinkageError: loader constraint violation: when resolving method "com.google.common.io.Files.asCharSource(Ljava/io/File;Ljava/nio/charset/Charset;)Lcom/google/common/io/CharSource;" the class loader (instance of net/minecraft/launchwrapper/LaunchClassLoader) of the current class, ninja/leaping/configurate/loader/AbstractConfigurationLoader$Builder, and the class loader (instance of sun/misc/Launcher$AppClassLoader) for the method's defining class, com/google/common/io/Files, have different Class objects for the type com/google/common/io/CharSource used in the signature