### PR TITLE
Added PlayerChangeCurrentItemEvent

### DIFF
--- a/patches/minecraft/net/minecraft/client/Minecraft.java.patch
+++ b/patches/minecraft/net/minecraft/client/Minecraft.java.patch
@@ -56,7 +56,7 @@
          if (p_147108_1_ instanceof GuiMainMenu)
          {
              this.field_71474_y.field_74330_P = false;
-@@ -1353,7 +1358,7 @@
+@@ -1352,7 +1357,7 @@
  
                      if (this.field_71439_g.func_82246_f(i, j, k))
                      {
@@ -65,7 +65,7 @@
                          this.field_71439_g.func_71038_i();
                      }
                  }
-@@ -1434,11 +1439,12 @@
+@@ -1433,11 +1438,12 @@
                      int j = this.field_71476_x.field_72312_c;
                      int k = this.field_71476_x.field_72309_d;
  
@@ -80,7 +80,7 @@
                          {
                              flag = false;
                              this.field_71439_g.func_71038_i();
-@@ -1465,7 +1471,8 @@
+@@ -1464,7 +1470,8 @@
          {
              ItemStack itemstack1 = this.field_71439_g.field_71071_by.func_70448_g();
  
@@ -90,7 +90,7 @@
              {
                  this.field_71460_t.field_78516_c.func_78445_c();
              }
-@@ -1677,6 +1684,8 @@
+@@ -1676,6 +1683,8 @@
  
              while (Mouse.next())
              {
@@ -99,7 +99,16 @@
                  j = Mouse.getEventButton();
                  KeyBinding.func_74510_a(j - 100, Mouse.getEventButtonState());
  
-@@ -2139,6 +2148,11 @@
+@@ -1865,7 +1874,7 @@
+ 
+             for (j = 0; j < 9; ++j)
+             {
+-                if (this.field_71474_y.field_151456_ac[j].func_151468_f())
++                if (this.field_71474_y.field_151456_ac[j].func_151468_f() && !net.minecraftforge.common.MinecraftForge.EVENT_BUS.post(new net.minecraftforge.event.entity.player.PlayerChangeCurrentItemEvent(this.field_71439_g, j)))
+                 {
+                     this.field_71439_g.field_71071_by.field_70461_c = j;
+                 }
+@@ -2138,6 +2147,11 @@
  
      public void func_71353_a(WorldClient p_71353_1_, String p_71353_2_)
      {
@@ -111,7 +120,7 @@
          if (p_71353_1_ == null)
          {
              NetHandlerPlayClient nethandlerplayclient = this.func_147114_u();
-@@ -2151,6 +2165,18 @@
+@@ -2150,6 +2164,18 @@
              if (this.field_71437_Z != null)
              {
                  this.field_71437_Z.func_71263_m();
@@ -130,7 +139,7 @@
              }
  
              this.field_71437_Z = null;
-@@ -2299,113 +2325,10 @@
+@@ -2298,113 +2324,10 @@
          if (this.field_71476_x != null)
          {
              boolean flag = this.field_71439_g.field_71075_bZ.field_75098_d;
@@ -246,7 +255,7 @@
              if (flag)
              {
                  j = this.field_71439_g.field_71069_bz.field_75151_b.size() - 9 + this.field_71439_g.field_71071_by.field_70461_c;
-@@ -2671,8 +2594,15 @@
+@@ -2670,8 +2593,15 @@
          p_70001_1_.func_152767_b("gl_max_texture_size", Integer.valueOf(func_71369_N()));
      }
  
@@ -262,7 +271,7 @@
          for (int i = 16384; i > 0; i >>= 1)
          {
              GL11.glTexImage2D(GL11.GL_PROXY_TEXTURE_2D, 0, GL11.GL_RGBA, i, i, 0, GL11.GL_RGBA, GL11.GL_UNSIGNED_BYTE, (ByteBuffer)null);
-@@ -2680,6 +2610,7 @@
+@@ -2679,6 +2609,7 @@
  
              if (j != 0)
              {

--- a/patches/minecraft/net/minecraft/client/network/NetHandlerPlayClient.java.patch
+++ b/patches/minecraft/net/minecraft/client/network/NetHandlerPlayClient.java.patch
@@ -19,6 +19,15 @@
          entityxporb.field_70118_ct = p_147286_1_.func_148984_d();
          entityxporb.field_70117_cu = p_147286_1_.func_148983_e();
          entityxporb.field_70116_cv = p_147286_1_.func_148982_f();
+@@ -503,7 +506,7 @@
+ 
+     public void func_147257_a(S09PacketHeldItemChange p_147257_1_)
+     {
+-        if (p_147257_1_.func_149385_c() >= 0 && p_147257_1_.func_149385_c() < InventoryPlayer.func_70451_h())
++        if (p_147257_1_.func_149385_c() >= 0 && p_147257_1_.func_149385_c() < InventoryPlayer.func_70451_h() && !net.minecraftforge.common.MinecraftForge.EVENT_BUS.post(new net.minecraftforge.event.entity.player.PlayerChangeCurrentItemEvent(this.field_147299_f.field_71439_g, p_147257_1_.func_149385_c())))
+         {
+             this.field_147299_f.field_71439_g.field_71071_by.field_70461_c = p_147257_1_.func_149385_c();
+         }
 @@ -687,7 +690,11 @@
  
      public void func_147251_a(S02PacketChat p_147251_1_)

--- a/patches/minecraft/net/minecraft/entity/player/InventoryPlayer.java.patch
+++ b/patches/minecraft/net/minecraft/entity/player/InventoryPlayer.java.patch
@@ -1,6 +1,48 @@
 --- ../src-base/minecraft/net/minecraft/entity/player/InventoryPlayer.java
 +++ ../src-work/minecraft/net/minecraft/entity/player/InventoryPlayer.java
-@@ -311,6 +311,14 @@
+@@ -180,24 +180,27 @@
+     @SideOnly(Side.CLIENT)
+     public void func_70453_c(int p_70453_1_)
+     {
+-        if (p_70453_1_ > 0)
++        if (!net.minecraftforge.common.MinecraftForge.EVENT_BUS.post(new net.minecraftforge.event.entity.player.PlayerChangeCurrentItemEvent(this.field_70458_d, p_70453_1_)))
+         {
+-            p_70453_1_ = 1;
+-        }
++            if (p_70453_1_ > 0)
++            {
++                p_70453_1_ = 1;
++            }
+ 
+-        if (p_70453_1_ < 0)
+-        {
+-            p_70453_1_ = -1;
+-        }
++            if (p_70453_1_ < 0)
++            {
++                p_70453_1_ = -1;
++            }
+ 
+-        for (this.field_70461_c -= p_70453_1_; this.field_70461_c < 0; this.field_70461_c += 9)
+-        {
+-            ;
+-        }
++            for (this.field_70461_c -= p_70453_1_; this.field_70461_c < 0; this.field_70461_c += 9)
++            {
++                ;
++            }
+ 
+-        while (this.field_70461_c >= 9)
+-        {
+-            this.field_70461_c -= 9;
++            while (this.field_70461_c >= 9)
++            {
++                this.field_70461_c -= 9;
++            }
+         }
+     }
+ 
+@@ -311,6 +314,14 @@
                  this.field_70462_a[i].func_77945_a(this.field_70458_d.field_70170_p, this.field_70458_d, i, this.field_70461_c == i);
              }
          }

--- a/patches/minecraft/net/minecraft/network/NetHandlerPlayServer.java.patch
+++ b/patches/minecraft/net/minecraft/network/NetHandlerPlayServer.java.patch
@@ -151,7 +151,21 @@
              {
                  this.func_147359_a(new S2FPacketSetSlot(this.field_147369_b.field_71070_bA.field_75152_c, slot.field_75222_d, this.field_147369_b.field_71071_by.func_70448_g()));
              }
-@@ -676,7 +719,9 @@
+@@ -638,8 +681,11 @@
+     {
+         if (p_147355_1_.func_149614_c() >= 0 && p_147355_1_.func_149614_c() < InventoryPlayer.func_70451_h())
+         {
+-            this.field_147369_b.field_71071_by.field_70461_c = p_147355_1_.func_149614_c();
+-            this.field_147369_b.func_143004_u();
++            if (!net.minecraftforge.common.MinecraftForge.EVENT_BUS.post(new net.minecraftforge.event.entity.player.PlayerChangeCurrentItemEvent(this.field_147369_b, p_147355_1_.func_149614_c())))
++            {
++                this.field_147369_b.field_71071_by.field_70461_c = p_147355_1_.func_149614_c();
++                this.field_147369_b.func_143004_u();
++            }
+         }
+         else
+         {
+@@ -676,7 +722,9 @@
              }
              else
              {
@@ -162,7 +176,7 @@
                  this.field_147367_d.func_71203_ab().func_148544_a(chatcomponenttranslation1, false);
              }
  
-@@ -812,7 +857,7 @@
+@@ -812,7 +860,7 @@
                          return;
                      }
  

--- a/patches/minecraft/net/minecraft/server/management/ServerConfigurationManager.java.patch
+++ b/patches/minecraft/net/minecraft/server/management/ServerConfigurationManager.java.patch
@@ -184,3 +184,12 @@
                  p_82448_4_.func_72838_d(p_82448_1_);
                  p_82448_4_.func_72866_a(p_82448_1_, false);
              }
+@@ -907,7 +948,7 @@
+     {
+         p_72385_1_.func_71120_a(p_72385_1_.field_71069_bz);
+         p_72385_1_.func_71118_n();
+-        p_72385_1_.field_71135_a.func_147359_a(new S09PacketHeldItemChange(p_72385_1_.field_71071_by.field_70461_c));
++        if (!net.minecraftforge.common.MinecraftForge.EVENT_BUS.post(new net.minecraftforge.event.entity.player.PlayerChangeCurrentItemEvent(p_72385_1_, p_72385_1_.field_71071_by.field_70461_c))) p_72385_1_.field_71135_a.func_147359_a(new S09PacketHeldItemChange(p_72385_1_.field_71071_by.field_70461_c));
+     }
+ 
+     public int func_72394_k()

--- a/src/main/java/net/minecraftforge/common/ForgeHooks.java
+++ b/src/main/java/net/minecraftforge/common/ForgeHooks.java
@@ -251,7 +251,7 @@ public class ForgeHooks
         for (int x = 0; x < 9; x++)
         {
             ItemStack stack = player.inventory.getStackInSlot(x);
-            if (stack != null && stack.isItemEqual(result) && ItemStack.areItemStackTagsEqual(stack, result))
+            if (stack != null && stack.isItemEqual(result) && ItemStack.areItemStackTagsEqual(stack, result) && !MinecraftForge.EVENT_BUS.post(new net.minecraftforge.event.entity.player.PlayerChangeCurrentItemEvent(player, x)))
             {
                 player.inventory.currentItem = x;
                 return true;
@@ -264,7 +264,7 @@ public class ForgeHooks
         }
 
         int slot = player.inventory.getFirstEmptyStack();
-        if (slot < 0 || slot >= 9)
+        if ((slot < 0 || slot >= 9) && !MinecraftForge.EVENT_BUS.post(new net.minecraftforge.event.entity.player.PlayerChangeCurrentItemEvent(player, slot)))
         {
             slot = player.inventory.currentItem;
         }

--- a/src/main/java/net/minecraftforge/event/entity/player/PlayerChangeCurrentItemEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/player/PlayerChangeCurrentItemEvent.java
@@ -1,0 +1,21 @@
+package net.minecraftforge.event.entity.player;
+
+import cpw.mods.fml.common.eventhandler.Cancelable;
+import net.minecraft.entity.player.EntityPlayer;
+
+/**
+ * This event is fired when the current item of a player is switched for another slot.<br>
+ * slotIndex represents the future slot index.
+ * 
+ * @author SCAREX
+ */
+public class PlayerChangeCurrentItemEvent extends PlayerEvent
+{
+    public final int slotIndex;
+    
+    public PlayerChangeCurrentItemEvent(EntityPlayer player, int slotIndex)
+    {
+        super(player);
+        this.slotIndex = slotIndex;
+    }
+}

--- a/src/test/java/net/minecraftforge/test/PlayerChangeCurrentItemEventTest.java
+++ b/src/test/java/net/minecraftforge/test/PlayerChangeCurrentItemEventTest.java
@@ -1,0 +1,23 @@
+package net.minecraftforge.test;
+
+import net.minecraftforge.common.MinecraftForge;
+import net.minecraftforge.event.entity.player.PlayerChangeCurrentItemEvent;
+import cpw.mods.fml.common.Mod;
+import cpw.mods.fml.common.Mod.EventHandler;
+import cpw.mods.fml.common.event.FMLPreInitializationEvent;
+import cpw.mods.fml.common.eventhandler.SubscribeEvent;
+
+@Mod(modid = "pccietest", name = "PlayerChangeCurrentItemEventTest", version = "1.0.0")
+public class PlayerChangeCurrentItemEventTest
+{
+    @EventHandler
+    public void preInit(FMLPreInitializationEvent event)
+    {
+        MinecraftForge.EVENT_BUS.register(this);
+    }
+    
+    @SubscribeEvent
+    public void onPlayerChangeCurrentItem(PlayerChangeCurrentItemEvent event) {
+        System.out.println("The player " + event.entityPlayer.getCommandSenderName() + " has changed his current slot from " + event.entityPlayer.inventory.currentItem + " to " + event.slotIndex);
+    }
+}


### PR DESCRIPTION
This event is called when the player change his current item. It can be
useful when  the player is using an item and then change his current
item (the event PlayerUseItemEvent.Stop isn't called).

I placed the event's post in "if" blocks so if you want to cancel this
event in the future, it will be easier.

The slot index represents the future slot index.