### PR TITLE
Fix source block check for BlockFluidClassic

### DIFF
--- a/src/main/java/net/minecraftforge/fluids/BlockFluidClassic.java
+++ b/src/main/java/net/minecraftforge/fluids/BlockFluidClassic.java
@@ -171,7 +171,7 @@ public class BlockFluidClassic extends BlockFluidBase
 
     public boolean isSourceBlock(IBlockAccess world, BlockPos pos)
     {
-        return world.getBlockState(pos) == this && ((Integer)world.getBlockState(pos).getValue(LEVEL)).intValue() == 0;
+        return world.getBlockState(pos).getBlock() == this && ((Integer)world.getBlockState(pos).getValue(LEVEL)).intValue() == 0;
     }
 
     protected boolean[] getOptimalFlowDirections(World world, BlockPos pos)


### PR DESCRIPTION
The method `isSourceBlock` was comparing a blockstate with a block, which always returns false.