### PR TITLE
Add DrawHoveringTextEvent

### DIFF
--- a/patches/minecraft/net/minecraft/client/gui/GuiScreen.java.patch
+++ b/patches/minecraft/net/minecraft/client/gui/GuiScreen.java.patch
@@ -20,18 +20,20 @@
      }
  
      protected void func_146279_a(String p_146279_1_, int p_146279_2_, int p_146279_3_)
-@@ -156,6 +160,11 @@
+@@ -156,7 +160,12 @@
  
      protected void func_146283_a(List p_146283_1_, int p_146283_2_, int p_146283_3_)
      {
+-        if (!p_146283_1_.isEmpty())
 +        drawHoveringText(p_146283_1_, p_146283_2_, p_146283_3_, field_146289_q);   
 +    }
 +
 +    protected void drawHoveringText(List p_146283_1_, int p_146283_2_, int p_146283_3_, FontRenderer font)
 +    {
-         if (!p_146283_1_.isEmpty())
++        if (!p_146283_1_.isEmpty() && net.minecraftforge.client.ForgeHooksClient.onDrawHoveringText(p_146283_1_, p_146283_2_, p_146283_3_))
          {
              GlStateManager.func_179101_C();
+             RenderHelper.func_74518_a();
 @@ -168,7 +177,7 @@
              while (iterator.hasNext())
              {

--- a/src/main/java/net/minecraftforge/client/ForgeHooksClient.java
+++ b/src/main/java/net/minecraftforge/client/ForgeHooksClient.java
@@ -7,6 +7,7 @@ import static org.lwjgl.opengl.GL20.*;
 
 import java.nio.ByteBuffer;
 import java.nio.FloatBuffer;
+import java.util.List;
 
 import javax.vecmath.Matrix4f;
 import javax.vecmath.Vector3d;
@@ -54,6 +55,7 @@ import net.minecraft.world.IBlockAccess;
 import net.minecraft.world.World;
 import net.minecraft.world.biome.BiomeGenBase;
 import net.minecraftforge.client.event.DrawBlockHighlightEvent;
+import net.minecraftforge.client.event.DrawHoveringTextEvent;
 import net.minecraftforge.client.event.EntityViewRenderEvent;
 import net.minecraftforge.client.event.FOVUpdateEvent;
 import net.minecraftforge.client.event.GuiScreenEvent;
@@ -264,6 +266,11 @@ public class ForgeHooksClient
         {
             GL11.glRotatef((float)(block.getBedDirection(world, pos).getHorizontalIndex() * 90), 0.0F, 1.0F, 0.0F);
         }
+    }
+    
+    public static boolean onDrawHoveringText(List textLines, int posX, int posY)
+    {
+        return MinecraftForge.EVENT_BUS.post(new DrawHoveringTextEvent(textLines, posX, posY));
     }
 
     public static boolean onDrawBlockHighlight(RenderGlobal context, EntityPlayer player, MovingObjectPosition target, int subID, ItemStack currentItem, float partialTicks)

--- a/src/main/java/net/minecraftforge/client/event/DrawHoveringTextEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/DrawHoveringTextEvent.java
@@ -1,0 +1,21 @@
+package net.minecraftforge.client.event;
+
+import java.util.List;
+
+import net.minecraftforge.fml.common.eventhandler.Cancelable;
+import net.minecraftforge.fml.common.eventhandler.Event;
+
+@Cancelable
+public class DrawHoveringTextEvent extends Event
+{
+    public final List textLines;
+    public final int posX;
+    public final int posY;
+    
+    public DrawHoveringTextEvent(List textLines, int posX, int posY)
+    {
+        this.textLines = textLines;
+        this.posX = posX;
+        this.posY = posY;
+    }
+}


### PR DESCRIPTION
A good use of this would be to override the default tooltip for a
non-minecraft themed gui. It's also a good use for fixing gui render
event gliches.