### PR TITLE
added an entity-sensitive version of Entity.getBoundingBox()

### DIFF
--- a/patches/minecraft/net/minecraft/entity/Entity.java.patch
+++ b/patches/minecraft/net/minecraft/entity/Entity.java.patch
@@ -125,7 +125,7 @@
      }
  
      public boolean func_174816_a(Explosion p_174816_1_, World p_174816_2_, BlockPos p_174816_3_, IBlockState p_174816_4_, float p_174816_5_)
-@@ -2357,4 +2405,183 @@
+@@ -2357,4 +2405,196 @@
  
          EnchantmentHelper.func_151385_b(p_174815_1_, p_174815_2_);
      }
@@ -306,6 +306,19 @@
 +    public boolean shouldDismountInWater(Entity rider)
 +    {
 +        return this instanceof EntityLivingBase;
++    }
++    
++    /**
++     * An entity-sensitive version of {@link Entity#getBoundingBox()}.<br>
++     * It will block the actual movement of the entity (like a block does or the {@link EntityBoat})
++     * 
++     * @param entity The entity that this will collide with
++     * @return a bounding box (for example {@code this.boundingBox}) or null,
++     *         if no collision should take place.
++     */
++    public AxisAlignedBB getBoundingBox(Entity entity)
++    {
++        return this.func_70046_E();
 +    }
 +    /* ================================== Forge End =====================================*/
  }

--- a/patches/minecraft/net/minecraft/world/World.java.patch
+++ b/patches/minecraft/net/minecraft/world/World.java.patch
@@ -244,6 +244,15 @@
              this.func_72964_e(i, j).func_76612_a(p_72838_1_);
              this.field_72996_f.add(p_72838_1_);
              this.func_72923_a(p_72838_1_);
+@@ -1186,7 +1260,7 @@
+         {
+             if (p_72945_1_.field_70153_n != list && p_72945_1_.field_70154_o != list)
+             {
+-                AxisAlignedBB axisalignedbb1 = ((Entity)list.get(j2)).func_70046_E();
++                AxisAlignedBB axisalignedbb1 = ((Entity)list.get(j2)).getBoundingBox(p_72945_1_);
+ 
+                 if (axisalignedbb1 != null && axisalignedbb1.func_72326_a(p_72945_2_))
+                 {
 @@ -1271,17 +1345,29 @@
  
      public int func_72967_a(float p_72967_1_)


### PR DESCRIPTION
This hook allows for entity-specific collisions. It works the same way as the boat collision works (you can stand on top of it), but this allows for selecting specific entities, like only players can stand on a custom entity.