### PR TITLE
Use the FMLSecurityManager checkPermission(Permission) method for context-based permission checks

### DIFF
--- a/src/main/java/net/minecraftforge/fml/relauncher/FMLSecurityManager.java
+++ b/src/main/java/net/minecraftforge/fml/relauncher/FMLSecurityManager.java
@@ -37,6 +37,12 @@ public class FMLSecurityManager extends SecurityManager {
         return;
     }
 
+    @Override
+    public void checkPermission(Permission perm, Object context)
+    {
+        this.checkPermission(perm);
+    }
+
     public static class ExitTrappedException extends SecurityException {
         private static final long serialVersionUID = 1L;
     }


### PR DESCRIPTION
Use the FMLSecurityManager `checkPermission(Permission)` method for context-based permission checks.

In the case of MBean registration, the MBean Trust permission "register" is checked using an `AccessControlContext` (see below). The `checkPermission(Permission)` method is not called in this case, instead the `checkPermission(Permission, Object)` method is.
```java
    private static void checkMBeanTrustPermission(final Class<?> theClass)
        throws SecurityException {
        SecurityManager sm = System.getSecurityManager();
        if (sm != null) {
            Permission perm = new MBeanTrustPermission("register");
            PrivilegedAction<ProtectionDomain> act =
                new PrivilegedAction<ProtectionDomain>() {
                    public ProtectionDomain run() {
                        return theClass.getProtectionDomain();
                    }
                };
            ProtectionDomain pd = AccessController.doPrivileged(act);
            AccessControlContext acc =
                new AccessControlContext(new ProtectionDomain[] { pd });
            sm.checkPermission(perm, acc);
        }
    }
```

https://gist.github.com/kashike/1065d0cbb6ac047a14bd

Fixes #2067