### PR TITLE
Use already provided profile for the player's own skin

### DIFF
--- a/patches/minecraft/net/minecraft/client/resources/SkinManager.java.patch
+++ b/patches/minecraft/net/minecraft/client/resources/SkinManager.java.patch
@@ -1,0 +1,13 @@
+--- ../src-base/minecraft/net/minecraft/client/resources/SkinManager.java
++++ ../src-work/minecraft/net/minecraft/client/resources/SkinManager.java
+@@ -129,7 +129,9 @@
+ 
+                 if (hashmap.isEmpty() && p_152790_1_.getId().equals(Minecraft.func_71410_x().func_110432_I().func_148256_e().getId()))
+                 {
+-                    hashmap.putAll(SkinManager.this.field_152797_e.getTextures(SkinManager.this.field_152797_e.fillProfileProperties(p_152790_1_, false), false));
++                    // FORGE: Use already filled profile from session rather
++                    // than getting rate limited by filling the input profile
++                    hashmap.putAll(SkinManager.this.field_152797_e.getTextures(Minecraft.func_71410_x().func_110432_I().func_148256_e(), false));
+                 }
+ 
+                 Minecraft.func_71410_x().func_152344_a(new Runnable()


### PR DESCRIPTION
When running forge in a dev environment (untested in obf), two calls are made to `fillProfileProperties` on the same UUID which results in the rate limit blocking the second call.
See my comment on https://github.com/SpongePowered/SpongeCommon/issues/117#issuecomment-128977276 for a more detailed diagnostic.

Steps to reproduce the problem:
* Setup a clean forge development workspace
* Launch Client
* Create new single player world
* `com.mojang.authlib.exceptions.AuthenticationException: The client has sent too many requests within a certain amount of time`