### PR TITLE
Fix issues with Block/Item substitution delegate

### DIFF
--- a/fml/src/main/java/cpw/mods/fml/common/registry/FMLControlledNamespacedRegistry.java
+++ b/fml/src/main/java/cpw/mods/fml/common/registry/FMLControlledNamespacedRegistry.java
@@ -10,6 +10,7 @@ import java.util.Map;
 import java.util.Set;
 
 import net.minecraft.block.Block;
+import net.minecraft.item.Item;
 import net.minecraft.item.ItemBlock;
 import net.minecraft.util.ObjectIntIdentityMap;
 import net.minecraft.util.RegistryNamespaced;
@@ -45,7 +46,7 @@ public class FMLControlledNamespacedRegistry<I> extends RegistryNamespaced {
         this.minId = minIdValue;
     }
 
-    void validateContent(int maxId, String type, BitSet availabilityMap, Set<Integer> blockedIds, FMLControlledNamespacedRegistry<Block> iBlockRegistry)
+    void validateContent(int maxId, String type, BitSet availabilityMap, Set<Integer> blockedIds, FMLControlledNamespacedRegistry<Block> iBlockRegistry, FMLControlledNamespacedRegistry<Item> iItemRegistry)
     {
         for (I obj : typeSafeIterable())
         {
@@ -77,6 +78,11 @@ public class FMLControlledNamespacedRegistry<I> extends RegistryNamespaced {
             {
                 Block block = ((ItemBlock) obj).field_150939_a;
 
+                // verify substitution consistency
+                if (iBlockRegistry.getPersistentSubstitutions().containsKey(name) && !iItemRegistry.getPersistentSubstitutions().containsKey(name))
+                {
+                    throw new IllegalStateException(String.format("Registry entry for ItemBlock %s, name %s, id %d, is pointing to a substituted block, but the item does not have a substitution.", obj, name, id));
+                }
                 // verify matching block entry
                 if (iBlockRegistry.getId(block) != id)
                 {

--- a/fml/src/main/java/cpw/mods/fml/common/registry/GameData.java
+++ b/fml/src/main/java/cpw/mods/fml/common/registry/GameData.java
@@ -849,6 +849,14 @@ public class GameData {
             if (itemId != idHint) throw new IllegalStateException(String.format("ItemBlock at block id %d insertion failed, got id %d.", idHint, itemId));
             verifyItemBlockName((ItemBlock) item);
         }
+        
+        // handle substitution for the item
+        if (getMain().itemSubstitutions.containsKey(name))
+        {
+            Item substitute = getMain().itemSubstitutions.get(name);
+            ((RegistryDelegate.Delegate<Item>) item.delegate).changeReference(substitute); // original delegate has wrong reference
+            ((RegistryDelegate.Delegate<Item>) substitute.delegate).setName(name); // substitute has wrong name
+        }
 
         // block the Block Registry slot with the same id
         useSlot(itemId);
@@ -893,6 +901,14 @@ public class GameData {
         {
             if (blockId != idHint) throw new IllegalStateException(String.format("Block at itemblock id %d insertion failed, got id %d.", idHint, blockId));
             verifyItemBlockName(itemBlock);
+        }
+        
+        // handle substitution for the block
+        if (getMain().blockSubstitutions.containsKey(name))
+        {
+            Block substitute = getMain().blockSubstitutions.get(name);
+            ((RegistryDelegate.Delegate<Block>) block.delegate).changeReference(substitute); // original delegate has wrong reference
+            ((RegistryDelegate.Delegate<Block>) substitute.delegate).setName(name); // substitute has wrong name
         }
 
         useSlot(blockId);
@@ -998,7 +1014,7 @@ public class GameData {
             boolean isBlock = pass == 0;
             String type = isBlock ? "block" : "item";
             FMLControlledNamespacedRegistry<?> registry = isBlock ? iBlockRegistry : iItemRegistry;
-            registry.validateContent((isBlock ? MAX_BLOCK_ID : MAX_ITEM_ID), type, availabilityMap, blockedIds, iBlockRegistry);
+            registry.validateContent((isBlock ? MAX_BLOCK_ID : MAX_ITEM_ID), type, availabilityMap, blockedIds, iBlockRegistry, iItemRegistry);
         }
 
         FMLLog.fine("Registry consistency check successful");

--- a/fml/src/main/java/cpw/mods/fml/common/registry/GameRegistry.java
+++ b/fml/src/main/java/cpw/mods/fml/common/registry/GameRegistry.java
@@ -155,10 +155,13 @@ public class GameRegistry
      * Add a forced persistent substitution alias for the block or item to another block or item. This will have
      * the effect of using the substituted block or item instead of the original, where ever it is
      * referenced.
+     * <br><br>
+     * When replacing a block, you need to replace its item too. Pass your NEW block instance to the ItemBlock constructor,
+     * otherwise you will get an error when loading a world.
      *
-     * @param nameToSubstitute The name to link to (this is the NEW block or item)
+     * @param nameToSubstitute The registry name to substitute
      * @param type The type (Block or Item)
-     * @param object a NEW instance that is type compatible with the existing instance
+     * @param object A NEW instance that is type compatible with the existing instance
      * @throws ExistingSubstitutionException if someone else has already registered an alias either from or to one of the names
      * @throws IncompatibleSubstitutionException if the substitution is incompatible
      */

--- a/fml/src/test/java/cpw/mods/fml/test/RegistrySubstituteTest.java
+++ b/fml/src/test/java/cpw/mods/fml/test/RegistrySubstituteTest.java
@@ -1,0 +1,218 @@
+package cpw.mods.fml.test;
+
+import net.minecraft.block.Block;
+import net.minecraft.block.BlockWood;
+import net.minecraft.block.material.Material;
+import net.minecraft.command.CommandBase;
+import net.minecraft.command.ICommandSender;
+import net.minecraft.creativetab.CreativeTabs;
+import net.minecraft.init.Blocks;
+import net.minecraft.init.Items;
+import net.minecraft.item.Item;
+import net.minecraft.item.ItemBlock;
+import net.minecraft.item.ItemEnderEye;
+import net.minecraft.item.ItemMultiTexture;
+import net.minecraft.item.ItemStack;
+import net.minecraft.util.ChatComponentText;
+
+import cpw.mods.fml.common.FMLCommonHandler;
+import cpw.mods.fml.common.Mod;
+import cpw.mods.fml.common.Mod.EventHandler;
+import cpw.mods.fml.common.event.FMLPreInitializationEvent;
+import cpw.mods.fml.common.event.FMLServerStartingEvent;
+import cpw.mods.fml.common.registry.ExistingSubstitutionException;
+import cpw.mods.fml.common.registry.GameRegistry;
+import cpw.mods.fml.common.registry.GameRegistry.Type;
+
+@Mod(modid = "RegistrySubstituteTest", name = "RegistrySubstituteTest", version = "0.0.0")
+public class RegistrySubstituteTest
+{
+	public static boolean ENABLE = false;
+	public static boolean ENABLE_BAD_REPLACEMENT_TEST = false; // substitutes a block without substituting its item, crashes on startup
+	
+	private static ItemStack blockTest, itemTest;
+	
+	@EventHandler
+	public void onPreInit(FMLPreInitializationEvent e)
+	{
+		if (!ENABLE)return;
+		
+		blockTest = new ItemStack(Blocks.planks);
+		itemTest = new ItemStack(Items.ender_eye);
+		
+        try
+        {
+            Block planks = new BlockReplacedPlanks();
+            GameRegistry.addSubstitutionAlias("minecraft:planks", Type.BLOCK, planks);
+            GameRegistry.addSubstitutionAlias("minecraft:planks", Type.ITEM, new ItemReplacedPlanks(planks));
+
+            GameRegistry.addSubstitutionAlias("minecraft:ender_eye", Type.ITEM, new ItemReplacedEnderEye());
+
+            if (ENABLE_BAD_REPLACEMENT_TEST) GameRegistry.addSubstitutionAlias("minecraft:brick_block", Type.BLOCK, new BlockBadlyReplacedBrick());
+        }
+        catch(ExistingSubstitutionException ex)
+        {
+            FMLCommonHandler.instance().raiseException(ex, "Error testing registry substitute.", true);
+        }
+	}
+	
+    // substitute classes
+    private static class BlockReplacedPlanks extends BlockWood
+    {
+        public BlockReplacedPlanks()
+        {
+            setHardness(2F);
+            setResistance(5F);
+            setStepSound(soundTypeWood);
+            setBlockName("wood");
+            setBlockTextureName("planks");
+            setLightLevel(1F); // make the change visible in-game
+        }
+    }
+
+    private static class ItemReplacedPlanks extends ItemMultiTexture
+    {
+        public ItemReplacedPlanks(Block block)
+        {
+            super(block, block, BlockWood.field_150096_a);
+            setUnlocalizedName("wood");
+        }
+
+        @Override
+        public String getItemStackDisplayName(ItemStack is) // make the change visible in-game
+        {
+            return super.getItemStackDisplayName(is) + " (Custom)";
+        }
+    }
+
+    private static class ItemReplacedEnderEye extends ItemEnderEye
+    {
+        public ItemReplacedEnderEye()
+        {
+            setUnlocalizedName("eyeOfEnder");
+            setTextureName("ender_eye");
+        }
+
+        @Override
+        public String getItemStackDisplayName(ItemStack is) // make the change visible in-game
+        {
+            return super.getItemStackDisplayName(is) + " (Custom)";
+        }
+    }
+
+    private static class BlockBadlyReplacedBrick extends Block
+    {
+        public BlockBadlyReplacedBrick()
+        {
+            super(Material.rock);
+            setBlockName("brick");
+            setBlockTextureName("brick");
+        }
+    }
+	
+	// test command - need to test after injectWorldIDMap
+    @EventHandler
+    public void onServerStarting(FMLServerStartingEvent e)
+    {
+        if (ENABLE) e.registerServerCommand(new TestCommand());
+    }
+
+    private static class TestCommand extends CommandBase
+    {
+        @Override
+        public String getCommandName()
+        {
+            return "registry-substitute-test";
+        }
+
+        @Override
+        public String getCommandUsage(ICommandSender sender)
+        {
+            return "/registry-substitute-test";
+        }
+
+        @Override
+        public void processCommand(ICommandSender sender, String[] args)
+        {
+            try
+            {
+                runTest();
+                sender.addChatMessage(new ChatComponentText("Test succeeded!"));
+            }
+            catch(Exception e)
+            {
+                sender.addChatMessage(new ChatComponentText("Test failed: " + e.getMessage()));
+            }
+        }
+    }
+
+    // test
+    private static void runTest() throws Exception
+    {
+        // check stone brick block
+        if (Blocks.planks.delegate.name() == null)
+            throw new Exception("Block delegate name is null.");
+        
+        if (!Blocks.planks.delegate.name().equals("minecraft:planks"))
+            throw new Exception("Block delegate name is incorrect: " + Blocks.planks.delegate.name());
+        
+        if (!BlockReplacedPlanks.class.isInstance(Blocks.planks.delegate.get()))
+            throw new Exception("Block delegate type is incorrect: " + Blocks.planks.delegate.get().getClass().getName());
+
+        if (!BlockReplacedPlanks.class.isInstance(Blocks.planks))
+            throw new Exception("Block class type is incorrect: " + Blocks.planks.getClass().getName());
+        
+        if (Block.blockRegistry.getObject("minecraft:planks") != Blocks.planks)
+            throw new Exception("Block registry has invalid block: " + Block.blockRegistry.getObject("minecraft:planks"));
+        
+        if (Block.getIdFromBlock(Blocks.planks) != 5)
+            throw new Exception("Block registry returns invalid ID: " + Block.getIdFromBlock(Blocks.planks));
+        
+        if (Block.getBlockById(5) != Blocks.planks)
+            throw new Exception("Block registry returns invalid block by ID: " + Block.getBlockById(5));
+
+        // check stone brick itemblock
+        ItemBlock ib = (ItemBlock) Item.getItemFromBlock(Blocks.planks);
+
+        if (ib.delegate.name() == null)
+            throw new Exception("ItemBlock delegate name is null.");
+        
+        if (!ib.delegate.name().equals("minecraft:planks"))
+            throw new Exception("ItemBlock delegate name is incorrect: " + ib.delegate.name());
+        
+        if (!ItemReplacedPlanks.class.isInstance(ib.delegate.get()))
+            throw new Exception("ItemBlock delegate type is incorrect: " + ib.delegate.get().getClass().getName());
+
+        if (!BlockReplacedPlanks.class.isInstance(ib.field_150939_a))
+            throw new Exception("ItemBlock block type is incorrect: " + ib.field_150939_a.getClass().getName());
+        
+        if (!ItemReplacedPlanks.class.isInstance(ib))
+            throw new Exception("ItemBlock class type is incorrect: " + ib.getClass().getName());
+        
+
+        // check ender eye
+        if (Items.ender_eye.delegate.name() == null)
+            throw new Exception("Item delegate name is null.");
+        
+        if (!Items.ender_eye.delegate.name().equals("minecraft:ender_eye"))
+            throw new Exception("Item delegate name is incorrect: " + Items.ender_eye.delegate.name());
+        
+        if (!ItemReplacedEnderEye.class.isInstance(Items.ender_eye.delegate.get()))
+            throw new Exception("Item delegate type is incorrect: " + Items.ender_eye.delegate.get().getClass().getName());
+
+        if (!ItemReplacedEnderEye.class.isInstance(Items.ender_eye))
+            throw new Exception("Item class type is incorrect: " + Items.ender_eye.getClass().getName());
+        
+        if (Item.itemRegistry.getObject("minecraft:ender_eye") != Items.ender_eye)
+            throw new Exception("Item registry has invalid item: " + Item.itemRegistry.getObject("minecraft:ender_eye"));
+        
+        if (Item.getIdFromItem(Items.ender_eye) != Item.getIdFromItem(itemTest.getItem()))
+            throw new Exception("ItemStack item cannot be found in registry: " + Item.getIdFromItem(itemTest.getItem()));
+        
+        if (Item.getIdFromItem(Items.ender_eye) != 381)
+            throw new Exception("Item registry returns invalid ID: " + Item.getIdFromItem(Items.ender_eye));
+        
+        if (Item.getItemById(381) != Items.ender_eye)
+            throw new Exception("Item registry returns invalid item by ID: " + Item.getItemById(381));
+    }
+}


### PR DESCRIPTION
Since the substitutions are nearly never used, they have some serious bugs:
* If you replaced a block/item, calling for ex. Items.ender_eye.delegate.name() would return null
* Any existing references would not get recognized in the registry, which would severely break both vanilla and mods; you can see an example with [crafting](http://i.imgur.com/QrnAagP.png), where the item has ID -1 and crashes when you take it out

I fixed both of these bugs, and added extra safeguards for modders, because replacing blocks is a bit trickier - you have to also replace the itemblock, and use the new block instance in the constructor, otherwise FML refuses to load the world (or crashes on startup).

There is a test triggered by using **/registry-substitute-test** in-game, after the substitutes are applied to world ID mappings (enable the test first). After applying the fix, all of the tests succeed. There is also a special setting to test a bad block replacement, which crashes the game on startup so I didn't include it in the command.

Apart from the test command, I also checked the blocks and items were functional in-game, including crafting, smelting, placing and checking their properties just to be sure. If this is accepted, I'll check whether 1.8 behaves the same and make a PR for that if it does. Please let me know if you see any issues.