### PR TITLE
Event for when players regenerate from food

### DIFF
--- a/patches/minecraft/net/minecraft/util/FoodStats.java.patch
+++ b/patches/minecraft/net/minecraft/util/FoodStats.java.patch
@@ -1,0 +1,15 @@
+--- ../src-base/minecraft/net/minecraft/util/FoodStats.java
++++ ../src-work/minecraft/net/minecraft/util/FoodStats.java
+@@ -53,8 +53,10 @@
+ 
+             if (this.field_75123_d >= 80)
+             {
+-                p_75118_1_.func_70691_i(1.0F);
+-                this.func_75113_a(3.0F);
++                net.minecraftforge.event.entity.player.FoodRegenerationEvent event = net.minecraftforge.event.ForgeEventFactory.onNaturalRegenerate(p_75118_1_, 1.0F, 3.0F);
++                if (event.isCanceled()) return;
++                p_75118_1_.func_70691_i(event.getRegeneratedHealth());
++                this.func_75113_a(event.getExhaustion());
+                 this.field_75123_d = 0;
+             }
+         }

--- a/src/main/java/net/minecraftforge/event/ForgeEventFactory.java
+++ b/src/main/java/net/minecraftforge/event/ForgeEventFactory.java
@@ -56,6 +56,7 @@ import net.minecraftforge.event.entity.player.BonemealEvent;
 import net.minecraftforge.event.entity.player.EntityInteractEvent;
 import net.minecraftforge.event.entity.player.EntityItemPickupEvent;
 import net.minecraftforge.event.entity.player.FillBucketEvent;
+import net.minecraftforge.event.entity.player.FoodRegenerationEvent;
 import net.minecraftforge.event.entity.player.ItemTooltipEvent;
 import net.minecraftforge.event.entity.player.PlayerDestroyItemEvent;
 import net.minecraftforge.event.entity.player.PlayerDropsEvent;
@@ -460,6 +461,13 @@ public class ForgeEventFactory
     public static void onPotionBrewed(ItemStack[] brewingItemStacks)
     {
         MinecraftForge.EVENT_BUS.post(new PotionBrewEvent.Post(brewingItemStacks));
+    }
+    
+    public static FoodRegenerationEvent onNaturalRegenerate(EntityPlayer player, float health, float exhaustion)
+    {
+        FoodRegenerationEvent event = new FoodRegenerationEvent(player, health, exhaustion);
+        MinecraftForge.EVENT_BUS.post(event);
+        return event;
     }
     
     public static boolean renderFireOverlay(EntityPlayer player, float renderPartialTicks)

--- a/src/main/java/net/minecraftforge/event/entity/player/FoodRegenerationEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/player/FoodRegenerationEvent.java
@@ -1,0 +1,51 @@
+package net.minecraftforge.event.entity.player;
+
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraftforge.fml.common.eventhandler.Cancelable;
+
+/**
+ * This event is fired server-side immediately before a player regenerates naturally from the food bar.
+ * It allows modification of the amount to regenerate and exhaustion to add after regenerating.
+ * 
+ * This event is {@link Cancelable}.
+ * The current attempt to regenerate is skipped if this event is canceled.
+ * This event has no result. {@link HasResult}
+ * 
+ * {@link regeneratedHealth} contains the health to be regenerated.
+ * {@link exhaustion} contains the exhaustion to be added after regeneration.
+ * 
+ * @author williewillus
+ */
+@Cancelable
+public class FoodRegenerationEvent extends PlayerEvent 
+{
+    private float regeneratedHealth;   
+    private float exhaustion;
+    
+    public FoodRegenerationEvent(EntityPlayer player, float regeneratedHealth, float exhaustion) 
+    {
+        super(player);
+        this.regeneratedHealth = regeneratedHealth;
+        this.exhaustion = exhaustion;
+    }
+
+    public float getRegeneratedHealth()
+    {
+        return regeneratedHealth;
+    }
+
+    public void setRegeneratedHealth(float regeneratedHealth)
+    {
+        this.regeneratedHealth = regeneratedHealth;
+    }
+
+    public float getExhaustion()
+    {
+        return exhaustion;
+    }
+
+    public void setExhaustion(float exhaustion)
+    {
+        this.exhaustion = exhaustion;
+    }
+}


### PR DESCRIPTION
This pull request adds an event that fires immediately before a player regenerates health from a full food bar. It allows customization and control of the amount to be regenerated and the resulting exhaustion penalty to be added to the player.

A valid usecase would be to remove the food exhaustion application entirely. I'm tremendously opposed to that change they made in 1.6, and currently I have a coremod (ew) to stop it from happening, but with this event I could just subscribe to it and set the exhaustion amount to 0 every time.

LivingHealEvent exists, but it fires later than this and does not have the precision this event does, making it hard to use to track hunger-based regeneration. Nor does it have the ability to control the exhaustion.

Other uses would be to grant extra health regen or deny health regen based on certain player variables or (de-)buffs

Any feedback is welcome.