### PR TITLE
Now the method getEntityId takes a class as paramated instead of an e…

### DIFF
--- a/patches/minecraft/net/minecraft/entity/Entity.java.patch
+++ b/patches/minecraft/net/minecraft/entity/Entity.java.patch
@@ -196,7 +196,7 @@
 +        }
 +        else
 +        {
-+            int id = EntityList.func_75619_a(this);
++            int id = EntityList.getEntityID(this.getClass());
 +            if (id > 0 && EntityList.field_75627_a.containsKey(id))
 +            {
 +                return new ItemStack(net.minecraft.init.Items.field_151063_bx, 1, id);

--- a/patches/minecraft/net/minecraft/entity/EntityList.java.patch
+++ b/patches/minecraft/net/minecraft/entity/EntityList.java.patch
@@ -8,3 +8,15 @@
          if (field_75625_b.containsKey(p_75618_1_))
          {
              throw new IllegalArgumentException("ID is already registered: " + p_75618_1_);
+@@ -216,9 +217,9 @@
+         return entity;
+     }
+ 
+-    public static int func_75619_a(Entity p_75619_0_)
++    public static int getEntityID(Class p_75619_0_)
+     {
+-        Integer integer = (Integer)field_75624_e.get(p_75619_0_.getClass());
++        Integer integer = (Integer)field_75624_e.get(p_75619_0_);
+         return integer == null ? 0 : integer.intValue();
+     }
+ 

--- a/patches/minecraft/net/minecraft/entity/player/EntityPlayer.java.patch
+++ b/patches/minecraft/net/minecraft/entity/player/EntityPlayer.java.patch
@@ -397,6 +397,15 @@
      }
  
      protected void func_71061_d_()
+@@ -1726,7 +1834,7 @@
+             this.func_71029_a(AchievementList.field_76023_s);
+         }
+ 
+-        EntityList.EntityEggInfo entityegginfo = (EntityList.EntityEggInfo)EntityList.field_75627_a.get(Integer.valueOf(EntityList.func_75619_a(p_70074_1_)));
++        EntityList.EntityEggInfo entityegginfo = (EntityList.EntityEggInfo)EntityList.field_75627_a.get(Integer.valueOf(EntityList.getEntityID(p_70074_1_.getClass())));
+         if (entityegginfo == null) entityegginfo = net.minecraftforge.fml.common.registry.EntityRegistry.getEggs().get(EntityList.func_75621_b(p_70074_1_));
+ 
+         if (entityegginfo != null)
 @@ -1840,6 +1948,8 @@
      {
          if (p_71008_1_ != this.field_71074_e)

--- a/patches/minecraft/net/minecraft/entity/player/EntityPlayerMP.java.patch
+++ b/patches/minecraft/net/minecraft/entity/player/EntityPlayerMP.java.patch
@@ -74,6 +74,15 @@
          }
  
          Collection collection = this.field_70170_p.func_96441_U().func_96520_a(IScoreObjectiveCriteria.field_96642_c);
+@@ -480,7 +497,7 @@
+ 
+         if (entitylivingbase != null)
+         {
+-            EntityList.EntityEggInfo entityegginfo = (EntityList.EntityEggInfo)EntityList.field_75627_a.get(Integer.valueOf(EntityList.func_75619_a(entitylivingbase)));
++            EntityList.EntityEggInfo entityegginfo = (EntityList.EntityEggInfo)EntityList.field_75627_a.get(Integer.valueOf(EntityList.getEntityID(entitylivingbase.getClass())));
+             if (entityegginfo == null) entityegginfo = net.minecraftforge.fml.common.registry.EntityRegistry.getEggs().get(EntityList.func_75621_b(entitylivingbase));
+ 
+             if (entityegginfo != null)
 @@ -850,6 +867,7 @@
      {
          if (p_71064_1_ != null)

--- a/patches/minecraft/net/minecraft/network/play/server/S0FPacketSpawnMob.java.patch
+++ b/patches/minecraft/net/minecraft/network/play/server/S0FPacketSpawnMob.java.patch
@@ -1,0 +1,11 @@
+--- ../src-base/minecraft/net/minecraft/network/play/server/S0FPacketSpawnMob.java
++++ ../src-work/minecraft/net/minecraft/network/play/server/S0FPacketSpawnMob.java
+@@ -35,7 +35,7 @@
+     public S0FPacketSpawnMob(EntityLivingBase p_i45192_1_)
+     {
+         this.field_149042_a = p_i45192_1_.func_145782_y();
+-        this.field_149040_b = (byte)EntityList.func_75619_a(p_i45192_1_);
++        this.field_149040_b = (byte)EntityList.getEntityID(p_i45192_1_.getClass());
+         this.field_149041_c = MathHelper.func_76128_c(p_i45192_1_.field_70165_t * 32.0D);
+         this.field_149038_d = MathHelper.func_76128_c(p_i45192_1_.field_70163_u * 32.0D);
+         this.field_149039_e = MathHelper.func_76128_c(p_i45192_1_.field_70161_v * 32.0D);


### PR DESCRIPTION
Now the method getEntityId takes a class as paramated instead of an entity. This allows modder to get the entity id by the entity class without an instance of Entity.