### PR TITLE
Fixed a bug with item model loading 

### DIFF
--- a/patches/minecraft/net/minecraft/block/BlockDoublePlant.java.patch
+++ b/patches/minecraft/net/minecraft/block/BlockDoublePlant.java.patch
@@ -45,16 +45,7 @@
          {
              super.func_180657_a(p_180657_1_, p_180657_2_, p_180657_3_, p_180657_4_, p_180657_5_);
          }
-@@ -220,8 +217,6 @@
-         else
-         {
-             p_176489_4_.func_71029_a(StatList.field_75934_C[Block.func_149682_b(this)]);
--            int i = (enumplanttype == BlockDoublePlant.EnumPlantType.GRASS ? BlockTallGrass.EnumType.GRASS : BlockTallGrass.EnumType.FERN).func_177044_a();
--            func_180635_a(p_176489_1_, p_176489_2_, new ItemStack(Blocks.field_150329_H, 2, i));
-             return true;
-         }
-     }
-@@ -296,6 +291,32 @@
+@@ -296,6 +293,32 @@
          return Block.EnumOffsetType.XZ;
      }
  

--- a/patches/minecraft/net/minecraft/block/BlockOldLeaf.java.patch
+++ b/patches/minecraft/net/minecraft/block/BlockOldLeaf.java.patch
@@ -1,13 +1,6 @@
 --- ../src-base/minecraft/net/minecraft/block/BlockOldLeaf.java
 +++ ../src-work/minecraft/net/minecraft/block/BlockOldLeaf.java
-@@ -148,11 +148,17 @@
-         if (!p_180657_1_.field_72995_K && p_180657_2_.func_71045_bC() != null && p_180657_2_.func_71045_bC().func_77973_b() == Items.field_151097_aZ)
-         {
-             p_180657_2_.func_71029_a(StatList.field_75934_C[Block.func_149682_b(this)]);
--            func_180635_a(p_180657_1_, p_180657_3_, new ItemStack(Item.func_150898_a(this), 1, ((BlockPlanks.EnumType)p_180657_4_.func_177229_b(field_176239_P)).func_176839_a()));
-         }
-         else
-         {
+@@ -155,4 +155,11 @@
              super.func_180657_a(p_180657_1_, p_180657_2_, p_180657_3_, p_180657_4_, p_180657_5_);
          }
      }

--- a/patches/minecraft/net/minecraft/client/renderer/ItemRenderer.java.patch
+++ b/patches/minecraft/net/minecraft/client/renderer/ItemRenderer.java.patch
@@ -9,48 +9,7 @@
              {
                  this.func_178097_a(entityplayersp, f3, f1, f2);
              }
-@@ -359,7 +359,8 @@
- 
-         if (this.field_78455_a.field_71439_g.func_70094_T())
-         {
--            IBlockState iblockstate = this.field_78455_a.field_71441_e.func_180495_p(new BlockPos(this.field_78455_a.field_71439_g));
-+            BlockPos blockpos = new BlockPos(this.field_78455_a.field_71439_g);
-+            IBlockState iblockstate = this.field_78455_a.field_71441_e.func_180495_p(blockpos);
-             EntityPlayerSP entityplayersp = this.field_78455_a.field_71439_g;
- 
-             for (int i = 0; i < 8; ++i)
-@@ -367,7 +368,7 @@
-                 double d0 = entityplayersp.field_70165_t + (double)(((float)((i >> 0) % 2) - 0.5F) * entityplayersp.field_70130_N * 0.8F);
-                 double d1 = entityplayersp.field_70163_u + (double)(((float)((i >> 1) % 2) - 0.5F) * 0.1F);
-                 double d2 = entityplayersp.field_70161_v + (double)(((float)((i >> 2) % 2) - 0.5F) * entityplayersp.field_70130_N * 0.8F);
--                BlockPos blockpos = new BlockPos(d0, d1 + (double)entityplayersp.func_70047_e(), d2);
-+                blockpos = new BlockPos(d0, d1 + (double)entityplayersp.func_70047_e(), d2);
-                 IBlockState iblockstate1 = this.field_78455_a.field_71441_e.func_180495_p(blockpos);
- 
-                 if (iblockstate1.func_177230_c().func_176214_u())
-@@ -378,6 +379,7 @@
- 
-             if (iblockstate.func_177230_c().func_149645_b() != -1)
-             {
-+                if (!net.minecraftforge.event.ForgeEventFactory.renderBlockOverlay(field_78455_a.field_71439_g, p_78447_1_, net.minecraftforge.client.event.RenderBlockOverlayEvent.OverlayType.BLOCK, iblockstate, blockpos))
-                 this.func_178108_a(p_78447_1_, this.field_78455_a.func_175602_ab().func_175023_a().func_178122_a(iblockstate));
-             }
-         }
-@@ -386,11 +388,13 @@
-         {
-             if (this.field_78455_a.field_71439_g.func_70055_a(Material.field_151586_h))
-             {
-+                if (!net.minecraftforge.event.ForgeEventFactory.renderWaterOverlay(field_78455_a.field_71439_g, p_78447_1_))
-                 this.func_78448_c(p_78447_1_);
-             }
- 
-             if (this.field_78455_a.field_71439_g.func_70027_ad())
-             {
-+                if (!net.minecraftforge.event.ForgeEventFactory.renderFireOverlay(field_78455_a.field_71439_g, p_78447_1_))
-                 this.func_78442_d(p_78447_1_);
-             }
-         }
-@@ -507,6 +511,12 @@
+@@ -507,6 +507,12 @@
          {
              if (!this.field_78453_b.func_179549_c(itemstack))
              {

--- a/patches/minecraft/net/minecraft/item/ItemShears.java.patch
+++ b/patches/minecraft/net/minecraft/item/ItemShears.java.patch
@@ -55,7 +55,7 @@
 +    @Override
 +    public boolean onBlockStartBreak(ItemStack itemstack, BlockPos pos, net.minecraft.entity.player.EntityPlayer player)
 +    {
-+        if (player.field_70170_p.field_72995_K || player.field_71075_bZ.field_75098_d)
++        if (player.field_70170_p.field_72995_K)
 +        {
 +            return false;
 +        }

--- a/patches/minecraft/net/minecraft/item/ItemSkull.java.patch
+++ b/patches/minecraft/net/minecraft/item/ItemSkull.java.patch
@@ -17,7 +17,7 @@
              if (!flag)
              {
 -                if (!p_180614_3_.func_180495_p(p_180614_4_).func_177230_c().func_149688_o().func_76220_a())
-+                if (!p_180614_3_.func_180495_p(p_180614_4_).func_177230_c().func_149688_o().func_76220_a() && !p_180614_3_.isSideSolid(p_180614_4_, p_180614_5_, true))
++                if (!p_180614_3_.isSideSolid(p_180614_4_, p_180614_5_, true))
                  {
                      return false;
                  }

--- a/patches/minecraft/net/minecraft/world/gen/feature/WorldGenDungeons.java.patch
+++ b/patches/minecraft/net/minecraft/world/gen/feature/WorldGenDungeons.java.patch
@@ -23,7 +23,7 @@
 +                                        WeightedRandomChestContent.func_177630_a(p_180709_2_, ChestGenHooks.getItems(DUNGEON_CHEST, p_180709_2_), (TileEntityChest)tileentity1, ChestGenHooks.getCount(DUNGEON_CHEST, p_180709_2_));
                                      }
  
-                                     break label197;
+                                     break label100;
 @@ -184,6 +186,12 @@
  
      private String func_76543_b(Random p_76543_1_)

--- a/src/main/java/net/minecraftforge/client/model/ModelLoader.java
+++ b/src/main/java/net/minecraftforge/client/model/ModelLoader.java
@@ -222,13 +222,20 @@ public class ModelLoader extends ModelBakery
             throw new IllegalStateException("circular model dependencies involving model " + location);
         }
         loadingModels.add(location);
-        IModel model = ModelLoaderRegistry.getModel(location);
-        for(ResourceLocation dep : model.getDependencies())
+        try
         {
-            getModel(dep);
+            IModel model = ModelLoaderRegistry.getModel(location);
+            for (ResourceLocation dep : model.getDependencies())
+            {
+                getModel(dep);
+               
+            }
+            textures.addAll(model.getTextures());
         }
-        textures.addAll(model.getTextures());
-        loadingModels.remove(location);
+        finally
+        {
+            loadingModels.remove(location);
+        }
     }
 
     private class VanillaModelWrapper implements IRetexturableModel


### PR DESCRIPTION
that would occur if ModelBakery.addVariantName() was called with the same string location parameter for 2 different items, and the string pointed to a location that didn't exist, where ModelLoader.loadAnyModel() would substitute the blockdefinition in for the item model, but wouldn't remove the original input location from the loadingModels list, which would cause the location from the second call to throw an IllegalStateException even though that location now has a model.