### PR TITLE
Fixed a bug with item model loading 

### DIFF
--- a/src/main/java/net/minecraftforge/client/model/ModelLoader.java
+++ b/src/main/java/net/minecraftforge/client/model/ModelLoader.java
@@ -217,13 +217,20 @@ public class ModelLoader extends ModelBakery
             throw new IllegalStateException("circular model dependencies involving model " + location);
         }
         loadingModels.add(location);
-        IModel model = ModelLoaderRegistry.getModel(location);
-        for(ResourceLocation dep : model.getDependencies())
+        try
         {
-            getModel(dep);
+            IModel model = ModelLoaderRegistry.getModel(location);
+            for (ResourceLocation dep : model.getDependencies())
+            {
+                getModel(dep);
+               
+            }
+            textures.addAll(model.getTextures());
         }
-        textures.addAll(model.getTextures());
-        loadingModels.remove(location);
+        finally
+        {
+            loadingModels.remove(location);
+        }
     }
 
     private class VanillaModelWrapper implements IRetexturableModel


### PR DESCRIPTION
Fixed a bug with item model loading that would occur if ModelBakery.addVariantName() was called with the same string location parameter for 2 different items, and the string pointed to a location that didn't exist, where ModelLoader.loadAnyModel() would substitute the blockdefinition in for the item model, but wouldn't remove the original input location from the loadingModels list, which would cause the location from the second call to throw an IllegalStateException even though that location now has a model.