### PR TITLE
Fix possible crash in EventBus

### DIFF
--- a/fml/src/main/java/cpw/mods/fml/common/eventhandler/EventBus.java
+++ b/fml/src/main/java/cpw/mods/fml/common/eventhandler/EventBus.java
@@ -121,6 +121,8 @@ public class EventBus implements IEventExceptionHandler
     public void unregister(Object object)
     {
         ArrayList<IEventListener> list = listeners.remove(object);
+        if (list == null)
+            return;
         for (IEventListener listener : list)
         {
             ListenerList.unregisterAll(busID, listener);


### PR DESCRIPTION
There is currently no way to check if an event handler has been registered or not.
But when trying to unregister a not-registered event handler, Minecraft crashes with a NullPointerException.
This is a simple fix to prevent such crashes.

(Same applies to 1.8 and newer)