### PR TITLE
Add "User Authenticator" thread name to getEffectiveSide() check

### DIFF
--- a/src/main/java/net/minecraftforge/fml/common/FMLCommonHandler.java
+++ b/src/main/java/net/minecraftforge/fml/common/FMLCommonHandler.java
@@ -192,8 +192,8 @@ public class FMLCommonHandler
      */
     public Side getEffectiveSide()
     {
-        Thread thr = Thread.currentThread();
-        if (thr.getName().equals("Server thread") || thr.getName().startsWith("Netty Server IO"))
+        String tName = Thread.currentThread().getName();
+        if (tName.equals("Server thread") || tName.startsWith("Netty Server IO") || tName.startsWith("User Authenticator"))
         {
             return Side.SERVER;
         }


### PR DESCRIPTION
The user authenticator thread (in `NetHandlerLoginServer`) is a server side thread. This PR adds an additional check for the thread name to determine what effective side code is executing on.
See https://github.com/SpongePowered/Sponge/commit/a091461547e050feadc9dc5427317320eeb309be and these two mixins in Sponge https://github.com/SpongePowered/SpongeCommon/tree/master/src/main/java/org/spongepowered/common/mixin/core/server/network