### PR TITLE
Ensures that resource names start with # when loading B3D Models.

### DIFF
--- a/src/main/java/net/minecraftforge/client/model/b3d/B3DModel.java
+++ b/src/main/java/net/minecraftforge/client/model/b3d/B3DModel.java
@@ -210,6 +210,8 @@ public class B3DModel
             while(buf.hasRemaining())
             {
                 String path = readString();
+                if(!path.startsWith("#"))
+                    path = "#"+path;
                 int flags = buf.getInt();
                 int blend = buf.getInt();
                 Vector2f pos = new Vector2f(buf.getFloat(), buf.getFloat());


### PR DESCRIPTION
When attempting to load a B3D model, the parser sets the resource name to the texture filename of the TEXS property of the B3D File. If the original texture filename did not start with # then the Model Loader will never find the texture resulting in the 'Missing Texture' being used. This simply checks the texture name on loading and adds a # to the filename so that the loader can correctly find the texture.

This can be verified by checking the chest.b3d file in the forgedebugmodelloaderregistry assets folder or switching it out with a model that did not use a texture with # at the beginning of the file name.