### PR TITLE
Fixes Client Login Issue when logging into a non existent dimension

### DIFF
--- a/src/main/java/net/minecraftforge/fml/common/network/handshake/NetworkDispatcher.java
+++ b/src/main/java/net/minecraftforge/fml/common/network/handshake/NetworkDispatcher.java
@@ -34,6 +34,7 @@ import net.minecraft.network.play.server.S3FPacketCustomPayload;
 import net.minecraft.network.play.server.S40PacketDisconnect;
 import net.minecraft.server.management.ServerConfigurationManager;
 import net.minecraft.util.ChatComponentText;
+import net.minecraftforge.common.DimensionManager;
 import net.minecraftforge.fml.common.FMLCommonHandler;
 import net.minecraftforge.fml.common.FMLLog;
 import net.minecraftforge.fml.common.network.FMLNetworkEvent;
@@ -199,12 +200,13 @@ public class NetworkDispatcher extends SimpleChannelInboundHandler<Packet> imple
         NBTTagCompound playerNBT = scm.getPlayerNBT(player);
         if (playerNBT!=null)
         {
-            return playerNBT.getInteger("Dimension");
+            int dimension = playerNBT.getInteger("Dimension");
+            if (DimensionManager.isDimensionRegistered(dimension))
+            {
+        	    return dimension;
+            }
         }
-        else
-        {
-            return 0;
-        }
+        return 0;
     }
 
     void clientListenForServerHandshake()


### PR DESCRIPTION
I made this #1164 PR which is supposed to respawn clients in the overworld if they login and are in a dimension that no longer exists on the server. The "pre-sending" of the dimension id to the client to allow higher dimension ids somewhat breaks that as it sends the non existent dimension instead of the overworld. Therefore the clients world is set to null which prevents him from logging in (And spams tons of errors in his console). If the client just tries to login again it fixes itself but it's still annoying. 

This PR fixes that issue by making the dimension hack thingy check whether the dimension actually exists before sending it to the player. If it doesn't it just sends the Overworld (0).