### PR TITLE
Fix dispenser action for modded spawn eggs

### DIFF
--- a/patches/minecraft/net/minecraft/init/Bootstrap.java.patch
+++ b/patches/minecraft/net/minecraft/init/Bootstrap.java.patch
@@ -8,6 +8,15 @@
      static void func_151353_a()
      {
          BlockDispenser.field_149943_a.func_82595_a(Items.field_151032_g, new BehaviorProjectileDispense()
+@@ -144,7 +145,7 @@
+                 double d0 = p_82487_1_.func_82615_a() + (double)enumfacing.func_82601_c();
+                 double d1 = (double)((float)p_82487_1_.func_180699_d().func_177956_o() + 0.2F);
+                 double d2 = p_82487_1_.func_82616_c() + (double)enumfacing.func_82599_e();
+-                Entity entity = ItemMonsterPlacer.func_77840_a(p_82487_1_.func_82618_k(), p_82487_2_.func_77960_j(), d0, d1, d2);
++                Entity entity = ItemMonsterPlacer.spawnCreature(p_82487_1_.func_82618_k(), ItemMonsterPlacer.getEntityName(p_82487_2_), d0, d1, d2);
+ 
+                 if (entity instanceof EntityLivingBase && p_82487_2_.func_82837_s())
+                 {
 @@ -509,6 +510,7 @@
                  }
              }

--- a/patches/minecraft/net/minecraft/item/ItemMonsterPlacer.java.patch
+++ b/patches/minecraft/net/minecraft/item/ItemMonsterPlacer.java.patch
@@ -91,7 +91,7 @@
 +        }
      }
 +
-+    private static String getEntityName(ItemStack stack)
++    public static String getEntityName(ItemStack stack)
 +    {
 +        if (stack.func_77942_o() && stack.func_77978_p().func_150297_b("entity_name", 8))
 +            return stack.func_77978_p().func_74779_i("entity_name");


### PR DESCRIPTION
The dispenser action does not take into account the generalization introduced in c158af902f2a689f612fd20427b5a1590fc2f1ba to allow modders to register spawn eggs, activating a spawn egg for a modded mob simply causes the egg to vanish.

This fixes this by simply using the new `spawnCreature` method which uses the unique mob name instead of mob id. This required this method to become public.