### PR TITLE
Fix a possible crash in EventBus

### DIFF
--- a/src/main/java/net/minecraftforge/fml/common/eventhandler/EventBus.java
+++ b/src/main/java/net/minecraftforge/fml/common/eventhandler/EventBus.java
@@ -121,6 +121,8 @@ public class EventBus implements IEventExceptionHandler
     public void unregister(Object object)
     {
         ArrayList<IEventListener> list = listeners.remove(object);
+        if(list == null)
+            return;
         for (IEventListener listener : list)
         {
             ListenerList.unregisterAll(busID, listener);


### PR DESCRIPTION
Re-pull of #2103 targeting 1.8.

There is currently no way to check if an event handler has been registered or not.
But when trying to unregister a not-registered event handler, Minecraft crashes with a NullPointerException.
This is a simple fix to prevent such crashes.