### PR TITLE
Add PlayerSetSpawnEvent

### DIFF
--- a/patches/minecraft/net/minecraft/entity/player/EntityPlayer.java.patch
+++ b/patches/minecraft/net/minecraft/entity/player/EntityPlayer.java.patch
@@ -377,7 +377,7 @@
  
              switch (EntityPlayer.SwitchEnumFacing.field_179420_a[enumfacing.ordinal()])
              {
-@@ -1511,16 +1611,22 @@
+@@ -1511,16 +1611,23 @@
  
      public BlockPos func_180470_cg()
      {
@@ -394,6 +394,7 @@
  
      public void func_180473_a(BlockPos p_180473_1_, boolean p_180473_2_)
      {
++        if(net.minecraftforge.event.ForgeEventFactory.onPlayerSpawnSet(this, p_180473_1_, p_180473_2_)) return;
 +        if (this.field_71093_bK != 0)
 +        {
 +            setSpawnChunk(p_180473_1_, p_180473_2_, this.field_71093_bK);
@@ -402,7 +403,7 @@
          if (p_180473_1_ != null)
          {
              this.field_71077_c = p_180473_1_;
-@@ -1702,6 +1808,10 @@
+@@ -1702,6 +1809,10 @@
  
              super.func_180430_e(p_180430_1_, p_180430_2_);
          }
@@ -413,7 +414,7 @@
      }
  
      protected void func_71061_d_()
-@@ -1725,6 +1835,7 @@
+@@ -1725,6 +1836,7 @@
          }
  
          EntityList.EntityEggInfo entityegginfo = (EntityList.EntityEggInfo)EntityList.field_75627_a.get(Integer.valueOf(EntityList.func_75619_a(p_70074_1_)));
@@ -421,7 +422,7 @@
  
          if (entityegginfo != null)
          {
-@@ -1837,6 +1948,8 @@
+@@ -1837,6 +1949,8 @@
      {
          if (p_71008_1_ != this.field_71074_e)
          {
@@ -430,7 +431,7 @@
              this.field_71074_e = p_71008_1_;
              this.field_71072_f = p_71008_2_;
  
-@@ -1906,6 +2019,10 @@
+@@ -1906,6 +2020,10 @@
              this.field_71106_cc = p_71049_1_.field_71106_cc;
              this.func_85040_s(p_71049_1_.func_71037_bA());
              this.field_82152_aq = p_71049_1_.field_82152_aq;
@@ -441,7 +442,7 @@
          }
          else if (this.field_70170_p.func_82736_K().func_82766_b("keepInventory"))
          {
-@@ -1918,6 +2035,18 @@
+@@ -1918,6 +2036,18 @@
  
          this.field_71078_a = p_71049_1_.field_71078_a;
          this.func_70096_w().func_75692_b(10, Byte.valueOf(p_71049_1_.func_70096_w().func_75683_a(10)));
@@ -460,7 +461,7 @@
      }
  
      protected boolean func_70041_e_()
-@@ -1951,7 +2080,14 @@
+@@ -1951,7 +2081,14 @@
  
      public void func_70062_b(int p_70062_1_, ItemStack p_70062_2_)
      {
@@ -476,7 +477,7 @@
      }
  
      @SideOnly(Side.CLIENT)
-@@ -1996,7 +2132,10 @@
+@@ -1996,7 +2133,10 @@
  
      public IChatComponent func_145748_c_()
      {
@@ -488,7 +489,7 @@
          chatcomponenttext.func_150256_b().func_150241_a(new ClickEvent(ClickEvent.Action.SUGGEST_COMMAND, "/msg " + this.func_70005_c_() + " "));
          chatcomponenttext.func_150256_b().func_150209_a(this.func_174823_aP());
          chatcomponenttext.func_150256_b().func_179989_a(this.func_70005_c_());
-@@ -2005,7 +2144,7 @@
+@@ -2005,7 +2145,7 @@
  
      public float func_70047_e()
      {
@@ -497,7 +498,7 @@
  
          if (this.func_70608_bn())
          {
-@@ -2139,6 +2278,136 @@
+@@ -2139,6 +2279,136 @@
          this.field_175153_bG = p_175150_1_;
      }
  

--- a/src/main/java/net/minecraftforge/event/ForgeEventFactory.java
+++ b/src/main/java/net/minecraftforge/event/ForgeEventFactory.java
@@ -63,6 +63,7 @@ import net.minecraftforge.event.entity.player.PlayerEvent;
 import net.minecraftforge.event.entity.player.PlayerFlyableFallEvent;
 import net.minecraftforge.event.entity.player.PlayerInteractEvent;
 import net.minecraftforge.event.entity.player.PlayerInteractEvent.Action;
+import net.minecraftforge.event.entity.player.PlayerSetSpawnEvent;
 import net.minecraftforge.event.entity.player.PlayerSleepInBedEvent;
 import net.minecraftforge.event.entity.player.PlayerUseItemEvent;
 import net.minecraftforge.event.entity.player.PlayerWakeUpEvent;
@@ -396,6 +397,10 @@ public class ForgeEventFactory
     public static void onPlayerFall(EntityPlayer player, float distance, float multiplier)
     {
         MinecraftForge.EVENT_BUS.post(new PlayerFlyableFallEvent(player, distance, multiplier));
+    }
+    
+    public static boolean onPlayerSpawnSet(EntityPlayer player, BlockPos pos, boolean forced) {
+        return MinecraftForge.EVENT_BUS.post(new PlayerSetSpawnEvent(player, pos, forced));
     }
 
     public static void onPlayerClone(EntityPlayer player, EntityPlayer oldPlayer, boolean wasDeath)

--- a/src/main/java/net/minecraftforge/event/entity/player/PlayerSetSpawnEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/player/PlayerSetSpawnEvent.java
@@ -1,0 +1,23 @@
+package net.minecraftforge.event.entity.player;
+
+import net.minecraftforge.fml.common.eventhandler.Cancelable;
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.util.BlockPos;
+
+@Cancelable
+public class PlayerSetSpawnEvent extends PlayerEvent
+{
+    /**
+     * This event is called before a player's spawn point is changed.
+     * The event can be canceled, and no further processing will be done.
+     */
+    public final boolean forced;
+    public final BlockPos newSpawn;
+    
+    public PlayerSetSpawnEvent(EntityPlayer player, BlockPos newSpawn, boolean forced) {
+        super(player);
+        this.newSpawn = newSpawn;
+        this.forced = forced;
+    }
+
+}

--- a/src/test/java/net/minecraftforge/test/PlayerSetSpawnTest.java
+++ b/src/test/java/net/minecraftforge/test/PlayerSetSpawnTest.java
@@ -1,0 +1,25 @@
+package net.minecraftforge.test;
+
+import net.minecraftforge.common.MinecraftForge;
+import net.minecraftforge.event.entity.player.PlayerSetSpawnEvent;
+import net.minecraftforge.fml.common.Mod;
+import net.minecraftforge.fml.common.Mod.EventHandler;
+import net.minecraftforge.fml.common.event.FMLInitializationEvent;
+import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
+
+@Mod(modid="playersetspawntest", name="Player Set Spawn Test", version="0.0.0")
+public class PlayerSetSpawnTest {
+    
+    @EventHandler
+    public void init(FMLInitializationEvent event) 
+    {
+        MinecraftForge.EVENT_BUS.register(this);
+    }
+    
+    @SubscribeEvent
+    public void onPlayerSetSpawn(PlayerSetSpawnEvent event) 
+    {
+        System.out.println(event.forced + " " + event.newSpawn.toString());
+        event.setCanceled(true);
+    }
+}


### PR DESCRIPTION
Fired just before a player's spawn is set, allows you to prevent a user from setting spawn. As well as knowing when their spawn is being changed.

For example see: PlayerSetSpawnTest

If I'm missing something please let me know so I can fix it.