### PR TITLE
Fix NPE in OreDictionary

### DIFF
--- a/src/main/java/net/minecraftforge/oredict/OreDictionary.java
+++ b/src/main/java/net/minecraftforge/oredict/OreDictionary.java
@@ -406,7 +406,7 @@ public class OreDictionary
 
     public static boolean itemMatches(ItemStack target, ItemStack input, boolean strict)
     {
-        if (input == null && target != null || input != null && target == null)
+        if (input == null || target == null)
         {
             return false;
         }


### PR DESCRIPTION
If either ItemStack is null in the existing code, it will pass this check and then immediately NPE on `.getItem()`.