### PR TITLE
GameData.findBlock(): containsKey() needs a ResourceLocation as argument

### DIFF
--- a/src/main/java/net/minecraftforge/fml/common/registry/GameData.java
+++ b/src/main/java/net/minecraftforge/fml/common/registry/GameData.java
@@ -161,7 +161,7 @@ public class GameData {
     static Block findBlock(String modId, String name)
     {
         String key = modId + ":" + name;
-        return getMain().iBlockRegistry.containsKey(key) ? getMain().iBlockRegistry.getObject(key) : null;
+        return getMain().iBlockRegistry.containsKey(new ResourceLocation(key)) ? getMain().iBlockRegistry.getObject(key) : null;
     }
 
     static UniqueIdentifier getUniqueName(Block block)


### PR DESCRIPTION
GameData.findBlock() doesn't find anything without this fix.  The
call to iBlockRegistry.containsKey() needs to have a ResourceLocation
as argument rather than a String as that's how the map is keyed,
it won't do the translation for you the way getObject() will.