### PR TITLE
Fix Potion IDs above 127

### DIFF
--- a/patches/minecraft/net/minecraft/client/network/NetHandlerPlayClient.java.patch
+++ b/patches/minecraft/net/minecraft/client/network/NetHandlerPlayClient.java.patch
@@ -61,3 +61,12 @@
          }
      }
  
+@@ -1346,7 +1358,7 @@
+ 
+         if (entity instanceof EntityLivingBase)
+         {
+-            PotionEffect potioneffect = new PotionEffect(p_147260_1_.func_149427_e(), p_147260_1_.func_180755_e(), p_147260_1_.func_149428_f(), false, p_147260_1_.func_179707_f());
++            PotionEffect potioneffect = new PotionEffect(p_147260_1_.func_149427_e() & 0xff, p_147260_1_.func_180755_e(), p_147260_1_.func_149428_f(), false, p_147260_1_.func_179707_f());
+             potioneffect.func_100012_b(p_147260_1_.func_149429_c());
+             ((EntityLivingBase)entity).func_70690_d(potioneffect);
+         }

--- a/patches/minecraft/net/minecraft/potion/PotionEffect.java.patch
+++ b/patches/minecraft/net/minecraft/potion/PotionEffect.java.patch
@@ -26,6 +26,15 @@
      }
  
      public void func_76452_a(PotionEffect p_76452_1_)
+@@ -191,7 +196,7 @@
+ 
+     public static PotionEffect func_82722_b(NBTTagCompound p_82722_0_)
+     {
+-        byte b0 = p_82722_0_.func_74771_c("Id");
++        int b0 = p_82722_0_.func_74771_c("Id") & 0xff;
+ 
+         if (b0 >= 0 && b0 < Potion.field_76425_a.length && Potion.field_76425_a[b0] != null)
+         {
 @@ -224,4 +229,62 @@
      {
          return this.field_100013_f;


### PR DESCRIPTION
The fix from https://github.com/MinecraftForge/MinecraftForge/pull/2108 in simplified form.