### PR TITLE
Fix silk harvest blockstate being air when tested

### DIFF
--- a/patches/minecraft/net/minecraft/block/Block.java.patch
+++ b/patches/minecraft/net/minecraft/block/Block.java.patch
@@ -149,7 +149,7 @@
          p_180657_2_.func_71020_j(0.025F);
  
 -        if (this.func_149700_E() && EnchantmentHelper.func_77502_d(p_180657_2_))
-+        if (this.canSilkHarvest(p_180657_1_, p_180657_3_, p_180657_1_.func_180495_p(p_180657_3_), p_180657_2_) && EnchantmentHelper.func_77502_d(p_180657_2_))
++        if (this.canSilkHarvest(p_180657_1_, p_180657_3_, p_180639_3_, p_180657_2_) && EnchantmentHelper.func_77502_d(p_180657_2_))
          {
 +            java.util.ArrayList<ItemStack> items = new java.util.ArrayList<ItemStack>();
              ItemStack itemstack = this.func_180643_i(p_180657_4_);
@@ -160,7 +160,7 @@
 +                items.add(itemstack);
              }
 +
-+            net.minecraftforge.event.ForgeEventFactory.fireBlockHarvesting(items, p_180657_1_, p_180657_3_, p_180657_1_.func_180495_p(p_180657_3_), 0, 1.0f, true, p_180657_2_);
++            net.minecraftforge.event.ForgeEventFactory.fireBlockHarvesting(items, p_180657_1_, p_180657_3_, p_180639_3_, 0, 1.0f, true, p_180657_2_);
 +            for (ItemStack stack : items)
 +            {
 +                func_180635_a(p_180657_1_, p_180657_3_, stack);


### PR DESCRIPTION
When testing the block state of a block in the canSilkHarvest function, an [error](https://paste.ee/p/UfDOO) is thrown because the current code tests the world for the blockstate, which is called after the block has been removed, which means you test against air. This patch uses the already existing blockstate instead of calling for a new one, which improves performance, I guess.