### PR TITLE
Fixed a bug with GuiConfigEntries.SelectValueEntry

### DIFF
--- a/src/main/java/net/minecraftforge/fml/client/config/GuiSelectString.java
+++ b/src/main/java/net/minecraftforge/fml/client/config/GuiSelectString.java
@@ -82,7 +82,11 @@ public class GuiSelectString extends GuiScreen
             this.titleLine2 = ((GuiConfig) parentScreen).titleLine2;
             this.titleLine3 = I18n.format(configElement.getLanguageKey());
             this.tooltipHoverChecker = new HoverChecker(28, 37, 0, parentScreen.width, 800);
-
+            if(titleLine3 != null && titleLine2 == null)
+            {
+                ((GuiConfig) parentScreen).titleLine2 = "";
+                this.titleLine2 = "";
+            }
         }
         else
         {


### PR DESCRIPTION
Fixed a bug with GuiConfigEntries.SelectValueEntry that caused the config option name to overlap with the selectable values, fixes #2114

Lex, unless I missed something, I am following Forge code formatting guidelines. The braces are on new lines, and I used spaces instead of tabs.