### PR TITLE
Fix setTileEntity causing the world to remove the new and old tile entities.

### DIFF
--- a/patches/minecraft/net/minecraft/world/World.java.patch
+++ b/patches/minecraft/net/minecraft/world/World.java.patch
@@ -417,7 +417,15 @@
                      }
                  }
              }
-@@ -1626,15 +1765,19 @@
+@@ -1619,22 +1758,26 @@
+                 iterator.remove();
+                 this.field_147482_g.remove(tileentity);
+ 
+-                if (this.func_175667_e(tileentity.func_174877_v()))
++                if (this.func_175667_e(tileentity.func_174877_v()) && this.func_175726_f(tileentity.func_174877_v()).func_177424_a(tileentity.func_174877_v(), Chunk.EnumCreateEntityType.CHECK) == tileentity)
+                 {
+                     this.func_175726_f(tileentity.func_174877_v()).func_177425_e(tileentity.func_174877_v());
+                 }
              }
          }
  


### PR DESCRIPTION
This includes two fixes to solve a problem that occurs when using setTileEntity to replace the tile entity on a block, which caused both the old and the new tile entities to be invalidated and removed from the world. This is because the setTileEntity didn't remove the tile entity from the world's list of tile entities before adding the new one, so it would try to clean that up in updateEntities and in the process remove the new tile entity from the chunk data.

Made setTileEntity call removeTileEntity to remove the previous tile entity from the list of tile entities in the World instance before adding the new one so that the new one isn't removed from the chunk later.

Made the world check whether an invalidated tile entity is actually in the chunk before removing it from the chunk. I did this in case some other situation could cause a tile entity to be invalidated in the World while different one exists in the chunk data.