### PR TITLE
Fixed special mods being ignored by the mod list

### DIFF
--- a/src/main/java/net/minecraftforge/fml/client/GuiModList.java
+++ b/src/main/java/net/minecraftforge/fml/client/GuiModList.java
@@ -226,7 +226,12 @@ public class GuiModList extends GuiScreen
     {
         ArrayList<ModContainer> mods = modList.getMods();
         mods.clear();
-        for (ModContainer m : Loader.instance().getActiveModList())
+        
+        ArrayList<ModContainer> activeMods = Lists.newArrayList();
+        FMLClientHandler.instance().addSpecialModEntries(activeMods);
+        activeMods.addAll(Loader.instance().getActiveModList());
+        
+        for (ModContainer m : activeMods)
         {
             // If it passes the filter, and is not a child mod
             if (m.getName().toLowerCase().contains(search.getText().toLowerCase()) && m.getMetadata().parentMod == null)


### PR DESCRIPTION
Special mods (Optifine) are ignored by the mod list since searching and sorting were added.