### PR TITLE
Fix GameData.findBlock

### DIFF
--- a/src/main/java/net/minecraftforge/fml/common/registry/GameData.java
+++ b/src/main/java/net/minecraftforge/fml/common/registry/GameData.java
@@ -155,13 +155,12 @@ public class GameData {
 
     static Item findItem(String modId, String name)
     {
-        return (Item)getMain().iItemRegistry.getObject(modId + ":" + name);
+        return getMain().iItemRegistry.getObject(modId + ":" + name);
     }
 
     static Block findBlock(String modId, String name)
     {
-        String key = modId + ":" + name;
-        return getMain().iBlockRegistry.containsKey(key) ? getMain().iBlockRegistry.getObject(key) : null;
+        return getMain().iBlockRegistry.getObject(modId + ":" + name);
     }
 
     static UniqueIdentifier getUniqueName(Block block)


### PR DESCRIPTION
GameData.findBlock first checked containsKey on the Block registry, but the registry only contains ResourceLocations, hence the checked String is never in there.
While fixing this bug I also discovered that `containsKey` generally is broken, if desired I will fix that, too.