### PR TITLE
Fix a possible NPE when checking supertypes of interfaces.

### DIFF
--- a/src/main/java/net/minecraftforge/fml/common/registry/GameData.java
+++ b/src/main/java/net/minecraftforge/fml/common/registry/GameData.java
@@ -1010,7 +1010,7 @@ public class GameData {
             .put("minecraft:items", Item.class).build());
 
     private void findSuperTypes(Class<?> type, Set<Class<?>> types) {
-        if (type == Object.class) {
+        if (type == null || type == Object.class) {
             return;
         }
         types.add(type);


### PR DESCRIPTION
This fixes `GameData.createRegistry` where the class implements any interface, directly and indirectly, will currently crash due to interfaces having `null` as their superclass via Reflection API.

The associated issue is #2176 