### PR TITLE
Fixing fuel handler override issue

### DIFF
--- a/patches/minecraft/net/minecraft/tileentity/TileEntityFurnace.java.patch
+++ b/patches/minecraft/net/minecraft/tileentity/TileEntityFurnace.java.patch
@@ -32,20 +32,14 @@
              }
  
              if (this.field_145957_n[0].func_77973_b() == Item.func_150898_a(Blocks.field_150360_v) && this.field_145957_n[0].func_77960_j() == 1 && this.field_145957_n[1] != null && this.field_145957_n[1].func_77973_b() == Items.field_151133_ar)
-@@ -348,7 +351,15 @@
-                 }
-             }
- 
--            return item instanceof ItemTool && ((ItemTool)item).func_77861_e().equals("WOOD") ? 200 : (item instanceof ItemSword && ((ItemSword)item).func_150932_j().equals("WOOD") ? 200 : (item instanceof ItemHoe && ((ItemHoe)item).func_77842_f().equals("WOOD") ? 200 : (item == Items.field_151055_y ? 100 : (item == Items.field_151044_h ? 1600 : (item == Items.field_151129_at ? 20000 : (item == Item.func_150898_a(Blocks.field_150345_g) ? 100 : (item == Items.field_151072_bj ? 2400 : 0)))))));
-+            if (item instanceof ItemTool && ((ItemTool)item).func_77861_e().equals("WOOD")) return 200;
-+            if (item instanceof ItemSword && ((ItemSword)item).func_150932_j().equals("WOOD")) return 200;
-+            if (item instanceof ItemHoe && ((ItemHoe)item).func_77842_f().equals("WOOD")) return 200;
-+            if (item == Items.field_151055_y) return 100;
-+            if (item == Items.field_151044_h) return 1600;
-+            if (item == Items.field_151129_at) return 20000;
-+            if (item == Item.func_150898_a(Blocks.field_150345_g)) return 100;
-+            if (item == Items.field_151072_bj) return 2400;
-+            return net.minecraftforge.fml.common.registry.GameRegistry.getFuelValue(p_145952_0_);
-         }
+@@ -319,6 +322,10 @@
      }
  
+     public static int func_145952_a(ItemStack p_145952_0_)
++    { 
++        return net.minecraftforge.fml.common.registry.GameRegistry.getFuelValue(p_145952_0_);
++    }
++    public static int getItemBurnTimeOld(ItemStack p_145952_0_)
+     {
+         if (p_145952_0_ == null)
+         {

--- a/src/main/java/net/minecraftforge/fml/common/IFuelHandler.java
+++ b/src/main/java/net/minecraftforge/fml/common/IFuelHandler.java
@@ -16,5 +16,17 @@ import net.minecraft.item.ItemStack;
 
 public interface IFuelHandler
 {
+    /**
+     * Returns the fuel value of the item stack if this is a fuel.
+     * Returns a negative integer to disallow consuming this item stack.
+     * By default, you should return 0.
+     * <br>
+     * To override other mods' behavior, register your fuel handler after the other mod did.
+     * To override vanilla behavior just register your fuel handler.
+     * <br>
+     * 
+     * @param fuel the item stack
+     * @return the fuel value of the item stack, other cases see above
+     */
     int getBurnTime(ItemStack fuel);
 }

--- a/src/main/java/net/minecraftforge/fml/common/registry/GameRegistry.java
+++ b/src/main/java/net/minecraftforge/fml/common/registry/GameRegistry.java
@@ -21,6 +21,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
+import java.util.ListIterator;
 import java.util.Map;
 import java.util.Random;
 import java.util.Set;
@@ -37,6 +38,7 @@ import net.minecraft.nbt.NBTBase;
 import net.minecraft.nbt.NBTException;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.tileentity.TileEntity;
+import net.minecraft.tileentity.TileEntityFurnace;
 import net.minecraft.util.ResourceLocation;
 import net.minecraft.world.World;
 import net.minecraft.world.chunk.IChunkProvider;
@@ -300,12 +302,16 @@ public class GameRegistry
     }
     public static int getFuelValue(ItemStack itemStack)
     {
-        int fuelValue = 0;
-        for (IFuelHandler handler : fuelHandlers)
+        ListIterator<IFuelHandler> li = fuelHandlers.listIterator(fuelHandlers.size());
+        while (li.hasPrevious())
         {
-            fuelValue = Math.max(fuelValue, handler.getBurnTime(itemStack));
+            int fuelValue = li.previous().getBurnTime(itemStack);
+            if (fuelValue > 0)
+                return fuelValue;
+            if (fuelValue < 0)
+                return 0;
         }
-        return fuelValue;
+        return TileEntityFurnace.getItemBurnTimeOld(itemStack);
     }
 
     /**

--- a/src/test/java/net/minecraftforge/debug/FuelHandlerTest.java
+++ b/src/test/java/net/minecraftforge/debug/FuelHandlerTest.java
@@ -1,0 +1,45 @@
+package net.minecraftforge.debug;
+
+import net.minecraft.init.Items;
+import net.minecraft.item.ItemStack;
+import net.minecraft.item.ItemTool;
+import net.minecraftforge.fml.common.IFuelHandler;
+import net.minecraftforge.fml.common.Mod;
+import net.minecraftforge.fml.common.event.FMLInitializationEvent;
+import net.minecraftforge.fml.common.registry.GameRegistry;
+
+@Mod(modid = "FuelHandlerTest")
+public final class FuelHandlerTest implements IFuelHandler
+{
+    private static final boolean ENABLED = false;
+    
+    @Mod.Instance("FuelHandlerTest")
+    public static FuelHandlerTest instance;
+    
+    @Mod.EventHandler
+    public void init(FMLInitializationEvent event)
+    {
+        if (ENABLED)
+        {
+            GameRegistry.registerFuelHandler(instance);
+        }
+    }
+    
+    @Override
+    public int getBurnTime(ItemStack fuel)
+    {
+        //disallow to burn coal
+        if (fuel.getItem() == Items.coal)
+        {
+            return -1;
+        }
+        
+        //wooden tools are too powerful
+        if (fuel.getItem() instanceof ItemTool && ((ItemTool) fuel.getItem()).getToolMaterialName().equals("WOOD"))
+        {
+            return 10000;
+        }
+        return 0;
+    }
+
+}


### PR DESCRIPTION
Fixes MinecraftForge/FML#559
Fixes #1847

# How does it work
- Load fuel handlers

~~-  Revert them to make later fuel handlers have higher priority~~

- Actually iterated them in reverse order to increase compatibility.

- Redirect old `getItemBurnTime` method to Forge one, still usable.

- Forge one would call vanilla method body for default value

- Test result: 
 - Cannot put coal in the fuel slot in the furnace
 - Wooden pickaxe burn a lot of items


P.S. 
~~1. `Minecraft.java.patch` was generated by the task.~~
2. There might be a small compatibility issue on the return of the IFuelHandler: must return 0
from now on, negative values were allowed to be used before.