### PR TITLE
VillagerRegistry changes

### DIFF
--- a/patches/minecraft/net/minecraft/entity/passive/EntityVillager.java.patch
+++ b/patches/minecraft/net/minecraft/entity/passive/EntityVillager.java.patch
@@ -17,23 +17,134 @@
          {
              if (!this.field_70170_p.field_72995_K && (this.field_70963_i == null || this.field_70963_i.size() > 0))
              {
-@@ -540,6 +541,7 @@
+@@ -338,9 +339,19 @@
+ 
+     public int func_70946_n()
+     {
+-        return Math.max(this.field_70180_af.func_75679_c(16) % 5, 0);
++        return Math.max(this.field_70180_af.func_75679_c(16) % net.minecraftforge.fml.common.registry.VillagerRegistry.VillagerProfession.nextId, 0);
+     }
+ 
++    public void setCareer(int careerId)
++    {
++        this.field_175563_bv = careerId;
++    }
++
++    public int getCareer()
++    {
++        return this.field_175563_bv;
++    }
++
+     public boolean func_70941_o()
+     {
+         return this.field_70952_f;
+@@ -540,15 +551,14 @@
  
      private void func_175554_cu()
      {
-+        //TODO: Hook into VillagerRegistry
-         EntityVillager.ITradeList[][][] aitradelist = field_175561_bA[this.func_70946_n()];
- 
+-        EntityVillager.ITradeList[][][] aitradelist = field_175561_bA[this.func_70946_n()];
+-
          if (this.field_175563_bv != 0 && this.field_175562_bw != 0)
-@@ -648,6 +650,7 @@
-                     }
+         {
+             ++this.field_175562_bw;
+         }
+         else
+         {
+-            this.field_175563_bv = this.field_70146_Z.nextInt(aitradelist.length) + 1;
++            int careerCount = net.minecraftforge.fml.common.registry.VillagerRegistry.getNumberOfCareers(this.func_70946_n());
++            this.field_175563_bv = this.field_70146_Z.nextInt(careerCount) + 1;
+             this.field_175562_bw = 1;
+         }
+ 
+@@ -556,23 +566,7 @@
+         {
+             this.field_70963_i = new MerchantRecipeList();
+         }
+-
+-        int i = this.field_175563_bv - 1;
+-        int j = this.field_175562_bw - 1;
+-        EntityVillager.ITradeList[][] aitradelist1 = aitradelist[i];
+-
+-        if (j < aitradelist1.length)
+-        {
+-            EntityVillager.ITradeList[] aitradelist2 = aitradelist1[j];
+-            EntityVillager.ITradeList[] aitradelist3 = aitradelist2;
+-            int k = aitradelist2.length;
+-
+-            for (int l = 0; l < k; ++l)
+-            {
+-                EntityVillager.ITradeList itradelist = aitradelist3[l];
+-                itradelist.func_179401_a(this.field_70963_i, this.field_70146_Z);
+-            }
+-        }
++        net.minecraftforge.fml.common.registry.VillagerRegistry.populateBuyingList(this.field_70963_i, this.func_70946_n(), this.field_175563_bv, this.field_175562_bw, this.field_70146_Z);
+     }
+ 
+     @SideOnly(Side.CLIENT)
+@@ -593,61 +587,7 @@
+                 this.func_175554_cu();
              }
  
-+            //TODO: Hook into VillagerRegistry to get name
+-            String s1 = null;
+-
+-            switch (this.func_70946_n())
+-            {
+-                case 0:
+-                    if (this.field_175563_bv == 1)
+-                    {
+-                        s1 = "farmer";
+-                    }
+-                    else if (this.field_175563_bv == 2)
+-                    {
+-                        s1 = "fisherman";
+-                    }
+-                    else if (this.field_175563_bv == 3)
+-                    {
+-                        s1 = "shepherd";
+-                    }
+-                    else if (this.field_175563_bv == 4)
+-                    {
+-                        s1 = "fletcher";
+-                    }
+-
+-                    break;
+-                case 1:
+-                    s1 = "librarian";
+-                    break;
+-                case 2:
+-                    s1 = "cleric";
+-                    break;
+-                case 3:
+-                    if (this.field_175563_bv == 1)
+-                    {
+-                        s1 = "armor";
+-                    }
+-                    else if (this.field_175563_bv == 2)
+-                    {
+-                        s1 = "weapon";
+-                    }
+-                    else if (this.field_175563_bv == 3)
+-                    {
+-                        s1 = "tool";
+-                    }
+-
+-                    break;
+-                case 4:
+-                    if (this.field_175563_bv == 1)
+-                    {
+-                        s1 = "butcher";
+-                    }
+-                    else if (this.field_175563_bv == 2)
+-                    {
+-                        s1 = "leather";
+-                    }
+-            }
+-
++            String s1 = net.minecraftforge.fml.common.registry.VillagerRegistry.getVillagerDisplay(func_70946_n(), field_175563_bv);
              if (s1 != null)
              {
                  ChatComponentTranslation chatcomponenttranslation = new ChatComponentTranslation("entity.Villager." + s1, new Object[0]);
-@@ -710,7 +713,7 @@
+@@ -710,7 +650,7 @@
      public IEntityLivingData func_180482_a(DifficultyInstance p_180482_1_, IEntityLivingData p_180482_2_)
      {
          p_180482_2_ = super.func_180482_a(p_180482_1_, p_180482_2_);

--- a/src/test/java/net/minecraftforge/test/SimpleVillagerTest.java
+++ b/src/test/java/net/minecraftforge/test/SimpleVillagerTest.java
@@ -1,0 +1,77 @@
+package net.minecraftforge.test;
+
+import net.minecraft.entity.passive.EntityVillager;
+import net.minecraft.entity.passive.EntityVillager.EmeraldForItems;
+import net.minecraft.entity.passive.EntityVillager.PriceInfo;
+import net.minecraft.init.Blocks;
+import net.minecraft.init.Items;
+import net.minecraft.item.Item;
+import net.minecraft.util.ChatComponentText;
+import net.minecraftforge.common.MinecraftForge;
+import net.minecraftforge.event.entity.player.EntityInteractEvent;
+import net.minecraftforge.event.entity.player.PlayerInteractEvent;
+import net.minecraftforge.fml.common.Mod;
+import net.minecraftforge.fml.common.Mod.EventHandler;
+import net.minecraftforge.fml.common.event.FMLPostInitializationEvent;
+import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
+import net.minecraftforge.fml.common.registry.VillagerRegistry;
+
+@Mod(modid = "VillagerTest", name = "SimpleVillagerTest", version = "1.0")
+public class SimpleVillagerTest {
+
+    public static final VillagerRegistry.VillagerProfession PROFESSION = new VillagerRegistry.VillagerProfession("Derpington", "minecraft:textures/entity/villager/farmer.png");
+    public static final VillagerRegistry.VillagerCareer CAREER = new VillagerRegistry.VillagerCareer(PROFESSION, "Derpington");
+
+    @EventHandler
+    public void onInit(FMLPostInitializationEvent event) {
+        VillagerRegistry.instance().register(PROFESSION);
+        //add a trade for the career, using an addTrade(ITradeList trade, int careerLevel) method in VillagerCareer
+        CAREER.addTrade(new EmeraldForItems(Item.getItemFromBlock(Blocks.dirt), new PriceInfo(1, 1)), 0);
+        CAREER.addTrade(new EmeraldForItems(Item.getItemFromBlock(Blocks.stone), new PriceInfo(1, 1)), 0);
+        CAREER.addTrade(new EmeraldForItems(Item.getItemFromBlock(Blocks.dirt), new PriceInfo(5, 5)), 1);
+        CAREER.addTrade(new EmeraldForItems(Item.getItemFromBlock(Blocks.stone), new PriceInfo(5, 5)), 1);
+        CAREER.addTrade(new EmeraldForItems(Item.getItemFromBlock(Blocks.dirt), new PriceInfo(10, 10)), 2);
+        CAREER.addTrade(new EmeraldForItems(Item.getItemFromBlock(Blocks.stone), new PriceInfo(10, 10)), 2);
+        MinecraftForge.EVENT_BUS.register(this);
+    }
+
+    @SubscribeEvent
+    public void spawning(EntityInteractEvent event) {
+        //Set all spawning villagers to new profession for a test, 
+        //in reality, these methods will be used when the villager is constructed elsewhere for spawning.
+        if (event.target instanceof EntityVillager && !event.entity.worldObj.isRemote
+                && event.entityPlayer.getHeldItem() != null 
+                && event.entityPlayer.getHeldItem().getItem() == Items.stick) {
+            EntityVillager villager = (EntityVillager) event.target;
+            
+            event.entityPlayer.addChatMessage(new ChatComponentText(villager.getCareer()+" "+villager.getProfession()));
+           
+        }
+    }
+    
+    @SubscribeEvent
+    public void interact(PlayerInteractEvent event) {
+        //Sneak right click with stick to spawn in the new villager
+        if (event.entityPlayer.getHeldItem() != null && event.entityPlayer.isSneaking() && !event.world.isRemote
+                && event.entityPlayer.getHeldItem().getItem() == Items.stick) {
+            
+            EntityVillager villager = new EntityVillager(event.world, PROFESSION.getId());
+            
+            /*
+             * This VillagerProfession.getId() should probably check a value set while regsitering the profession
+             * with VillagerRegistry.instance().register(PROFESSION);
+             */
+            villager.setProfession(PROFESSION.getId());
+            
+            /**
+             * If this Method isn't called, it should randomly select a career from the list of careers for that
+             * profession, every time new VillagerRegistry.VillagerCareer(PROFESSION, "Derpington"); is called,
+             * it should add that new VillageCareer to a list for PROFESSION
+             */
+            villager.setCareer(CAREER.getId());
+            
+            villager.setPosition(event.entity.posX + 1, event.entity.posY, event.entity.posZ);
+            event.world.spawnEntityInWorld(villager);
+        }
+    }
+}


### PR DESCRIPTION
Adds the ability to add custom villager professions and careers, as well
as the ability to add trades for certain levels of the careers.

the random villager selector will now randomly select any profession
added, and the random career selector will properly look for the careers
available to that profession from the registry.

The sample mod works a follows:
right click a villager with a stick prints out his profession and career
number.

Shift right click with a stick spawns in a villager with the newly added
profession, though using spawn eggs will also occasionally get one.