### PR TITLE
Fuel Handling Fix

### DIFF
--- a/patches/minecraft/net/minecraft/tileentity/TileEntityFurnace.java.patch
+++ b/patches/minecraft/net/minecraft/tileentity/TileEntityFurnace.java.patch
@@ -32,3 +32,13 @@
              }
  
              --this.field_145957_n[0].field_77994_a;
+@@ -301,6 +304,9 @@
+         }
+         else
+         {
++        	int moddedBurnTime = net.minecraftforge.event.ForgeEventFactory.getFuelBurnTime(p_145952_0_);
++        	if (moddedBurnTime >= 0) return moddedBurnTime;
++        	
+             Item item = p_145952_0_.func_77973_b();
+ 
+             if (item instanceof ItemBlock && Block.func_149634_a(item) != Blocks.field_150350_a)

--- a/src/main/java/net/minecraftforge/event/ForgeEventFactory.java
+++ b/src/main/java/net/minecraftforge/event/ForgeEventFactory.java
@@ -135,6 +135,13 @@ public class ForgeEventFactory
         return event.list;
     }
 
+    public static int getFuelBurnTime(ItemStack fuel)
+    {
+        FuelBurnTimeEvent event = new FuelBurnTimeEvent(fuel);
+        MinecraftForge.EVENT_BUS.post(event);
+        return event.getResult() == Result.DEFAULT ? -1 : event.burnTime;
+    }
+
     public static int getMaxSpawnPackSize(EntityLiving entity)
     {
         LivingPackSizeEvent maxCanSpawnEvent = new LivingPackSizeEvent(entity);

--- a/src/main/java/net/minecraftforge/event/FuelBurnTimeEvent.java
+++ b/src/main/java/net/minecraftforge/event/FuelBurnTimeEvent.java
@@ -1,0 +1,32 @@
+package net.minecraftforge.event;
+
+import net.minecraft.item.ItemStack;
+import cpw.mods.fml.common.eventhandler.Event;
+import cpw.mods.fml.common.eventhandler.Event.HasResult;
+
+/**
+ * FuelBurnTimeEvent is fired whenever a furnace needs the burn time of a fuel. <br>
+ * Normally, a registered {@link cpw.mods.fml.common.IFuelHandler} is preferred, but
+ * this is useful in the rare situation where IFuelHandler is not effective.<br>
+ * <br>
+ * {@link Result#DEFAULT} allows the normal fuel handling code to proceed.
+ * {@link Result#ALLOW} or {@link Result#DENY} uses the value of {@link #burnTime}
+ * for the given {@link fuel}, bypassing both vanilla and IFuelHandler determinations.
+ * <br>
+ * {@link #fuel} contains the potential fuel.<br>
+ * {@link #burnTime} the results if set by an event handler.<br>
+ * <br>
+ * This event are fired on the {@link MinecraftForge#EVENT_BUS}.
+ **/
+@HasResult
+@Deprecated //Remove in 1.8
+public class FuelBurnTimeEvent extends Event
+{
+    public final ItemStack fuel;
+    public int burnTime;
+    
+    public FuelBurnTimeEvent(ItemStack fuel)
+    {
+        this.fuel = fuel;
+    }
+}


### PR DESCRIPTION
Adds an event Hook that allows modification of burn times for items that the vanilla fuel handler thinks it recognizes.

Fixes MinecraftForge/FML#559

...and allows mod developers to proceed with fixes for:

- MinecraftModArchive/Dendrology#1
- ForestryMC/ForestryMC#469
- ForestryMC/ForestryMC#930
- ForestryMC/ForestryMC#960

Example:

    public class FuelHandler
    {
        @SubscribeEvent
        public void onFuelBurnTime(FuelBurnTimeEvent event)
        {
            if (event.fuel.getItem().equals(MyStuff.myItem))
            {
                event.burnTime = 300;
                event.setResult(Result.ALLOW);
            }
        }
    }