### PR TITLE
BiomeManager: Fix off-by-one errors

### DIFF
--- a/src/main/java/net/minecraftforge/common/BiomeManager.java
+++ b/src/main/java/net/minecraftforge/common/BiomeManager.java
@@ -147,7 +147,7 @@ public class BiomeManager
     public static ImmutableList<BiomeEntry> getBiomes(BiomeType type)
     {
         int idx = type.ordinal();
-        List<BiomeEntry> list = idx > biomes.length ? null : biomes[idx];
+        List<BiomeEntry> list = idx >= biomes.length ? null : biomes[idx];
 
         return list != null ? ImmutableList.copyOf(list) : null;
     }
@@ -179,7 +179,7 @@ public class BiomeManager
 
             if (ret.ordinal() >= biomes.length)
             {
-                biomes = Arrays.copyOf(biomes, ret.ordinal());
+                biomes = Arrays.copyOf(biomes, ret.ordinal() + 1);
             }
 
             return ret;


### PR DESCRIPTION
Adding a `BiomeManager.BiomeType` after `BiomeManager` has been loaded won't extend the `biomes` array correctly (the new array will be the same length as the existing one).

 `BiomeManager.getBiomes` can crash with an `ArrayIndexOutOfBoundsException` if called with a `BiomeManager.BiomeType` whose ordinal is equal to the `biomes` array's length.

[Test case](https://github.com/Choonster/ForgeBiomeManagerTestMod/blob/master/src/main/java/com/choonster/forgebiomemanagertestmod/ForgeBiomeManagerTestMod.java)
[Crash report](https://gist.github.com/Choonster/36998b9778fe226095bc)