### PR TITLE
Start Forge SLF4J transition

### DIFF
--- a/jsons/1.8.8-dev.json
+++ b/jsons/1.8.8-dev.json
@@ -163,6 +163,12 @@
       "name": "org.apache.logging.log4j:log4j-core:2.0-beta9"
     },
     {
+      "name": "org.slf4j:slf4j-api:1.7.13"
+    },
+    {
+      "name": "org.apache.logging.log4j:log4j-slf4j-impl:2.0-beta9"
+    },
+    {
       "name": "org.lwjgl.lwjgl:lwjgl:2.9.4-nightly-20150209",
       "rules": [
         {

--- a/jsons/1.8.8.json
+++ b/jsons/1.8.8.json
@@ -84,6 +84,12 @@
       "name": "org.apache.logging.log4j:log4j-core:2.0-beta9"
     },
     {
+      "name": "org.slf4j:slf4j-api:1.7.13"
+    },
+    {
+      "name": "org.apache.logging.log4j:log4j-slf4j-impl:2.0-beta9"
+    },
+    {
       "name": "org.lwjgl.lwjgl:lwjgl:2.9.4-nightly-20150209",
       "rules": [
         {

--- a/patches/minecraft/net/minecraft/util/Session.java.patch
+++ b/patches/minecraft/net/minecraft/util/Session.java.patch
@@ -22,13 +22,13 @@
 +        {
 +            p_i1098_1_ = "MissingName";
 +            p_i1098_2_ = p_i1098_3_ = "NotValid";
-+            FMLLog.getLogger().log(org.apache.logging.log4j.Level.WARN, "=========================================================");
-+            FMLLog.getLogger().log(org.apache.logging.log4j.Level.WARN, "WARNING!! the username was not set for this session, typically");
-+            FMLLog.getLogger().log(org.apache.logging.log4j.Level.WARN, "this means you installed Forge incorrectly. We have set your");
-+            FMLLog.getLogger().log(org.apache.logging.log4j.Level.WARN, "name to \"MissingName\" and your session to nothing. Please");
-+            FMLLog.getLogger().log(org.apache.logging.log4j.Level.WARN, "check your installation and post a console log from the launcher");
-+            FMLLog.getLogger().log(org.apache.logging.log4j.Level.WARN, "when asking for help!");
-+            FMLLog.getLogger().log(org.apache.logging.log4j.Level.WARN, "=========================================================");
++            FMLLog.log(org.apache.logging.log4j.Level.WARN, "=========================================================");
++            FMLLog.log(org.apache.logging.log4j.Level.WARN, "WARNING!! the username was not set for this session, typically");
++            FMLLog.log(org.apache.logging.log4j.Level.WARN, "this means you installed Forge incorrectly. We have set your");
++            FMLLog.log(org.apache.logging.log4j.Level.WARN, "name to \"MissingName\" and your session to nothing. Please");
++            FMLLog.log(org.apache.logging.log4j.Level.WARN, "check your installation and post a console log from the launcher");
++            FMLLog.log(org.apache.logging.log4j.Level.WARN, "when asking for help!");
++            FMLLog.log(org.apache.logging.log4j.Level.WARN, "=========================================================");
 +        }
 +
          this.field_74286_b = p_i1098_1_;

--- a/src/main/java/net/minecraftforge/client/model/b3d/B3DModel.java
+++ b/src/main/java/net/minecraftforge/client/model/b3d/B3DModel.java
@@ -27,8 +27,8 @@ import javax.vecmath.Vector4f;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.commons.lang3.tuple.Triple;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.slf4j.Logger;
 
 import com.google.common.base.Function;
 import com.google.common.base.Optional;
@@ -42,7 +42,7 @@ import com.google.common.collect.Table;
 
 public class B3DModel
 {
-    static final Logger logger = LogManager.getLogger(B3DModel.class);
+    static final Logger logger = LoggerFactory.getLogger(B3DModel.class);
     private final List<Texture> textures;
     private final List<Brush> brushes;
     private final Node<?> root;

--- a/src/main/java/net/minecraftforge/common/DimensionManager.java
+++ b/src/main/java/net/minecraftforge/common/DimensionManager.java
@@ -33,7 +33,6 @@ import net.minecraft.world.WorldSettings;
 import net.minecraft.world.storage.ISaveHandler;
 import net.minecraft.world.storage.SaveHandler;
 import net.minecraftforge.event.world.WorldEvent;
-import net.minecraftforge.fml.common.FMLCommonHandler;
 import net.minecraftforge.fml.common.FMLLog;
 
 public class DimensionManager
@@ -301,7 +300,7 @@ public class DimensionManager
         }
         catch (Exception e)
         {
-            FMLCommonHandler.instance().getFMLLogger().log(Level.ERROR, String.format("An error occured trying to create an instance of WorldProvider %d (%s)",
+            FMLLog.log(Level.ERROR, String.format("An error occured trying to create an instance of WorldProvider %d (%s)",
                     dim, providers.get(getProviderType(dim)).getSimpleName()),e);
             throw new RuntimeException(e);
         }

--- a/src/main/java/net/minecraftforge/common/UsernameCache.java
+++ b/src/main/java/net/minecraftforge/common/UsernameCache.java
@@ -11,8 +11,8 @@ import java.util.UUID;
 
 import javax.annotation.Nullable;
 
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.slf4j.Logger;
 
 import com.google.common.base.Charsets;
 import com.google.common.collect.ImmutableMap;
@@ -42,7 +42,7 @@ public final class UsernameCache {
     private static final File saveFile = new File( /* The minecraft dir */(File) FMLInjectionData.data()[6], "usernamecache.json");
     private static final Gson gson = new GsonBuilder().setPrettyPrinting().create();
 
-    private static final Logger log = LogManager.getLogger(UsernameCache.class);
+    private static final Logger log = LoggerFactory.getLogger(UsernameCache.class);
 
     private UsernameCache() {}
 

--- a/src/main/java/net/minecraftforge/common/network/ForgeMessage.java
+++ b/src/main/java/net/minecraftforge/common/network/ForgeMessage.java
@@ -85,7 +85,7 @@ public abstract class ForgeMessage {
             }
             else
             {
-                FMLLog.getLogger().log(Level.INFO, "Legacy server message contains no default fluid list - there may be problems with fluids");
+                FMLLog.log(Level.INFO, "Legacy server message contains no default fluid list - there may be problems with fluids");
                 defaultFluids.clear();
             }
         }

--- a/src/main/java/net/minecraftforge/fluids/FluidRegistry.java
+++ b/src/main/java/net/minecraftforge/fluids/FluidRegistry.java
@@ -102,13 +102,13 @@ public abstract class FluidRegistry
                 String derivedName = defaultName.split(":",2)[1];
                 String localDefault = defaultFluidName.get(derivedName);
                 if (localDefault == null) {
-                    FMLLog.getLogger().log(Level.ERROR, "The fluid {} (specified as {}) is missing from this instance - it will be removed", derivedName, defaultName);
+                    FMLLog.log(Level.ERROR, "The fluid {} (specified as {}) is missing from this instance - it will be removed", derivedName, defaultName);
                     continue;
                 }
                 fluid = masterFluidReference.get(localDefault);
-                FMLLog.getLogger().log(Level.ERROR, "The fluid {} specified as default is not present - it will be reverted to default {}", defaultName, localDefault);
+                FMLLog.log(Level.ERROR, "The fluid {} specified as default is not present - it will be reverted to default {}", defaultName, localDefault);
             }
-            FMLLog.getLogger().log(Level.DEBUG, "The fluid {} has been selected as the default fluid for {}", defaultName, fluid.getName());
+            FMLLog.log(Level.DEBUG, "The fluid {} has been selected as the default fluid for {}", defaultName, fluid.getName());
             Fluid oldFluid = localFluids.put(fluid.getName(), fluid);
             Integer id = localFluidIDs.remove(oldFluid);
             localFluidIDs.put(fluid, id);
@@ -287,7 +287,7 @@ public abstract class FluidRegistry
     {
         String name = masterFluidReference.inverse().get(key);
         if (Strings.isNullOrEmpty(name)) {
-            FMLLog.getLogger().log(Level.ERROR, "The fluid registry is corrupted. A fluid {} {} is not properly registered. The mod that registered this is broken", key.getClass().getName(), key.getName());
+            FMLLog.log(Level.ERROR, "The fluid registry is corrupted. A fluid {} {} is not properly registered. The mod that registered this is broken", key.getClass().getName(), key.getName());
             throw new IllegalStateException("The fluid registry is corrupted");
         }
         return name;
@@ -298,7 +298,7 @@ public abstract class FluidRegistry
         Set<String> defaults = Sets.newHashSet();
         if (tag.hasKey("DefaultFluidList",9))
         {
-            FMLLog.getLogger().log(Level.DEBUG, "Loading persistent fluid defaults from world");
+            FMLLog.log(Level.DEBUG, "Loading persistent fluid defaults from world");
             NBTTagList tl = tag.getTagList("DefaultFluidList", 8);
             for (int i = 0; i < tl.tagCount(); i++)
             {
@@ -307,7 +307,7 @@ public abstract class FluidRegistry
         }
         else
         {
-            FMLLog.getLogger().log(Level.DEBUG, "World is missing persistent fluid defaults - using local defaults");
+            FMLLog.log(Level.DEBUG, "World is missing persistent fluid defaults - using local defaults");
         }
         loadFluidDefaults(HashBiMap.create(fluidIDs), defaults);
     }
@@ -337,13 +337,13 @@ public abstract class FluidRegistry
 
         if (!illegalFluids.isEmpty())
         {
-            FMLLog.getLogger().log(Level.FATAL, "The fluid registry is corrupted. Something has inserted a fluid without registering it");
-            FMLLog.getLogger().log(Level.FATAL, "There is {} unregistered fluids", illegalFluids.size());
+            FMLLog.log(Level.FATAL, "The fluid registry is corrupted. Something has inserted a fluid without registering it");
+            FMLLog.log(Level.FATAL, "There is {} unregistered fluids", illegalFluids.size());
             for (Fluid f: illegalFluids)
             {
-                FMLLog.getLogger().log(Level.FATAL, "  Fluid name : {}, type: {}", f.getName(), f.getClass().getName());
+                FMLLog.log(Level.FATAL, "  Fluid name : {}, type: {}", f.getName(), f.getClass().getName());
             }
-            FMLLog.getLogger().log(Level.FATAL, "The mods that own these fluids need to register them properly");
+            FMLLog.log(Level.FATAL, "The mods that own these fluids need to register them properly");
             throw new IllegalStateException("The fluid map contains fluids unknown to the master fluid registry");
         }
     }

--- a/src/main/java/net/minecraftforge/fml/client/FMLClientHandler.java
+++ b/src/main/java/net/minecraftforge/fml/client/FMLClientHandler.java
@@ -95,8 +95,8 @@ import net.minecraftforge.fml.common.toposort.ModSortingException;
 import net.minecraftforge.fml.relauncher.Side;
 
 import org.apache.logging.log4j.Level;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.slf4j.Logger;
 import org.lwjgl.LWJGLUtil;
 import org.lwjgl.input.Mouse;
 import org.lwjgl.opengl.Display;
@@ -924,7 +924,7 @@ public class FMLClientHandler implements IFMLSidedHandler
         {
             return;
         }
-        Logger logger = LogManager.getLogger("TEXTURE ERRORS");
+        Logger logger = LoggerFactory.getLogger("TEXTURE ERRORS");
         logger.error(Strings.repeat("+=", 25));
         logger.error("The following texture errors were found.");
         Map<String,FallbackResourceManager> resManagers = ObfuscationReflectionHelper.getPrivateValue(SimpleReloadableResourceManager.class, (SimpleReloadableResourceManager)Minecraft.getMinecraft().getResourceManager(), "domainResourceManagers", "field_110548"+"_a");

--- a/src/main/java/net/minecraftforge/fml/client/config/DummyConfigElement.java
+++ b/src/main/java/net/minecraftforge/fml/client/config/DummyConfigElement.java
@@ -53,7 +53,7 @@ public class DummyConfigElement implements IConfigElement
     protected Class<? extends IArrayEntry> arrayEntryClass;
     
     /**
-     * This class provides a Dummy Category IConfigElement. It can be used to define a custom list of GUI entries that will 
+     * This class provides a Dummy Category IConfigElement. It can be used to define a custom list of GUI entries that will
      * appear on the child screen or to specify a custom IGuiConfigListEntryfor a special category.
      */
     public static class DummyCategoryElement extends DummyConfigElement

--- a/src/main/java/net/minecraftforge/fml/common/FMLCommonHandler.java
+++ b/src/main/java/net/minecraftforge/fml/common/FMLCommonHandler.java
@@ -64,7 +64,7 @@ import net.minecraftforge.fml.server.FMLServerHandler;
 import org.apache.commons.io.Charsets;
 import org.apache.commons.io.IOUtils;
 import org.apache.logging.log4j.Level;
-import org.apache.logging.log4j.Logger;
+import org.slf4j.Logger;
 
 import com.google.common.base.Joiner;
 import com.google.common.base.Strings;

--- a/src/main/java/net/minecraftforge/fml/common/FMLLog.java
+++ b/src/main/java/net/minecraftforge/fml/common/FMLLog.java
@@ -13,7 +13,7 @@
 package net.minecraftforge.fml.common;
 
 import org.apache.logging.log4j.Level;
-import org.apache.logging.log4j.Logger;
+import org.slf4j.Logger;
 
 @SuppressWarnings("static-access")
 public class FMLLog

--- a/src/main/java/net/minecraftforge/fml/common/Loader.java
+++ b/src/main/java/net/minecraftforge/fml/common/Loader.java
@@ -345,7 +345,7 @@ public class Loader
         discoverer.findClasspathMods(modClassLoader);
         FMLLog.fine("Minecraft jar mods loaded successfully");
 
-        FMLLog.getLogger().log(Level.INFO, "Found {} mods from the command line. Injecting into mod discoverer",ModListHelper.additionalMods.size());
+        FMLLog.log(Level.INFO, "Found {} mods from the command line. Injecting into mod discoverer",ModListHelper.additionalMods.size());
         FMLLog.info("Searching %s for mods", canonicalModsDir.getAbsolutePath());
         discoverer.findModDirMods(canonicalModsDir, ModListHelper.additionalMods.values().toArray(new File[0]));
         File versionSpecificModsDir = new File(canonicalModsDir,mccversion);
@@ -1032,7 +1032,7 @@ public class Loader
         File injectedDepFile = new File(getConfigDir(),"injectedDependencies.json");
         if (!injectedDepFile.exists())
         {
-            FMLLog.getLogger().log(Level.DEBUG, "File {} not found. No dependencies injected", injectedDepFile.getAbsolutePath());
+            FMLLog.log(Level.DEBUG, "File {} not found. No dependencies injected", injectedDepFile.getAbsolutePath());
             return;
         }
         JsonParser parser = new JsonParser();
@@ -1054,18 +1054,18 @@ public class Loader
                     } else if (type.equals("after")) {
                         injectedAfter.put(modId, VersionParser.parseVersionReference(depObj.get("target").getAsString()));
                     } else {
-                        FMLLog.getLogger().log(Level.ERROR, "Invalid dependency type {}", type);
+                        FMLLog.log(Level.ERROR, "Invalid dependency type {}", type);
                         throw new RuntimeException("Unable to parse type");
                     }
                 }
             }
         } catch (Exception e)
         {
-            FMLLog.getLogger().log(Level.ERROR, "Unable to parse {} - skipping", injectedDepFile);
-            FMLLog.getLogger().throwing(Level.ERROR, e);
+            FMLLog.log(Level.ERROR, "Unable to parse {} - skipping", injectedDepFile);
+            FMLLog.log(Level.ERROR, "{}", e);
             return;
         }
-        FMLLog.getLogger().log(Level.DEBUG, "Loaded {} injected dependencies on modIds: {}", injectedBefore.size(), injectedBefore.keySet());
+        FMLLog.log(Level.DEBUG, "Loaded {} injected dependencies on modIds: {}", injectedBefore.size(), injectedBefore.keySet());
     }
 
     List<ArtifactVersion> getInjectedBefore(String modId)

--- a/src/main/java/net/minecraftforge/fml/common/TracingPrintStream.java
+++ b/src/main/java/net/minecraftforge/fml/common/TracingPrintStream.java
@@ -11,7 +11,7 @@ package net.minecraftforge.fml.common;
 
 import java.io.PrintStream;
 
-import org.apache.logging.log4j.Logger;
+import org.slf4j.Logger;
 
 /**
  * PrintStream which redirects it's output to a given logger.

--- a/src/main/java/net/minecraftforge/fml/common/event/FMLInterModComms.java
+++ b/src/main/java/net/minecraftforge/fml/common/event/FMLInterModComms.java
@@ -169,7 +169,7 @@ public class FMLInterModComms {
                 Function<T,V> f = Class.forName((String) value).asSubclass(Function.class).newInstance();
                 return Optional.of(f);
             } catch (Exception e) {
-                FMLLog.getLogger().log(Level.INFO, "An error occurred instantiating the IMC function. key: {} value: {}, caller: {}", key,value,sender);
+                FMLLog.log(Level.INFO, "An error occurred instantiating the IMC function. key: {} value: {}, caller: {}", key,value,sender);
                 return Optional.absent();
             }
         }

--- a/src/main/java/net/minecraftforge/fml/common/event/FMLPostInitializationEvent.java
+++ b/src/main/java/net/minecraftforge/fml/common/event/FMLPostInitializationEvent.java
@@ -76,7 +76,7 @@ public class FMLPostInitializationEvent extends FMLStateEvent
             }
             catch (Exception e)
             {
-                FMLLog.getLogger().log(Level.INFO, "An error occurred trying to build a soft depend proxy",e);
+                FMLLog.log(Level.INFO, "An error occurred trying to build a soft depend proxy",e);
                 return Optional.absent();
             }
         }

--- a/src/main/java/net/minecraftforge/fml/common/event/FMLPreInitializationEvent.java
+++ b/src/main/java/net/minecraftforge/fml/common/event/FMLPreInitializationEvent.java
@@ -22,7 +22,6 @@ import net.minecraftforge.fml.common.ModContainer;
 import net.minecraftforge.fml.common.ModMetadata;
 import net.minecraftforge.fml.common.LoaderState.ModState;
 import net.minecraftforge.fml.common.discovery.ASMDataTable;
-
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -142,6 +141,7 @@ public class FMLPreInitializationEvent extends FMLStateEvent
      *
      * @return A logger
      */
+    // Not updated to slf4j yet as that would be a breaking change
     public Logger getModLog()
     {
         Logger log = LogManager.getLogger(modContainer.getModId());

--- a/src/main/java/net/minecraftforge/fml/common/launcher/FMLTweaker.java
+++ b/src/main/java/net/minecraftforge/fml/common/launcher/FMLTweaker.java
@@ -14,7 +14,7 @@ import net.minecraftforge.fml.relauncher.FMLLaunchHandler;
 import net.minecraftforge.fml.relauncher.FMLSecurityManager;
 
 import org.apache.logging.log4j.Level;
-import org.apache.logging.log4j.LogManager;
+import org.slf4j.LoggerFactory;
 
 import com.google.common.base.Throwables;
 import com.google.common.collect.Lists;
@@ -108,7 +108,7 @@ public class FMLTweaker implements ITweaker {
         }
         catch (URISyntaxException e)
         {
-            LogManager.getLogger("FMLTWEAK").log(Level.ERROR, "Missing URI information for FML tweak");
+            LoggerFactory.getLogger("FMLTWEAK").error("Missing URI information for FML tweak");
             throw Throwables.propagate(e);
         }
     }

--- a/src/main/java/net/minecraftforge/fml/common/launcher/Yggdrasil.java
+++ b/src/main/java/net/minecraftforge/fml/common/launcher/Yggdrasil.java
@@ -3,7 +3,7 @@ package net.minecraftforge.fml.common.launcher;
 import java.net.Proxy;
 import java.util.Map;
 
-import org.apache.logging.log4j.LogManager;
+import org.slf4j.LoggerFactory;
 
 import com.google.common.base.Throwables;
 import com.mojang.authlib.Agent;
@@ -30,7 +30,7 @@ public class Yggdrasil
         }
         catch (AuthenticationException e)
         {
-            LogManager.getLogger("FMLTWEAK").error("-- Login failed!  " + e.getMessage());
+            LoggerFactory.getLogger("FMLTWEAK").error("-- Login failed!  " + e.getMessage());
             Throwables.propagate(e);
             return; // dont set other variables
         }

--- a/src/main/java/net/minecraftforge/fml/common/network/handshake/NetworkDispatcher.java
+++ b/src/main/java/net/minecraftforge/fml/common/network/handshake/NetworkDispatcher.java
@@ -161,10 +161,10 @@ public class NetworkDispatcher extends SimpleChannelInboundHandler<Packet> imple
     public void handlerAdded(ChannelHandlerContext ctx) throws Exception
     {
         if (this.state != null) {
-            FMLLog.getLogger().log(Level.INFO, "Opening channel which already seems to have a state set. This is a vanilla connection. Handshake handler will stop now");
+            FMLLog.log(Level.INFO, "Opening channel which already seems to have a state set. This is a vanilla connection. Handshake handler will stop now");
             return;
         }
-        FMLLog.getLogger().log(Level.TRACE, "Handshake channel activating");
+        FMLLog.log(Level.TRACE, "Handshake channel activating");
         this.state = ConnectionState.OPENING;
         // send ourselves as a user event, to kick the pipeline active
         this.handshakeChannel.pipeline().fireUserEventTriggered(this);

--- a/src/main/java/net/minecraftforge/fml/common/patcher/GenDiffSet.java
+++ b/src/main/java/net/minecraftforge/fml/common/patcher/GenDiffSet.java
@@ -11,10 +11,7 @@ import java.util.jar.JarFile;
 import net.minecraftforge.fml.common.asm.transformers.deobf.FMLDeobfuscatingRemapper;
 import net.minecraftforge.fml.repackage.com.nothome.delta.Delta;
 
-import org.apache.logging.log4j.Level;
-import org.apache.logging.log4j.LogManager;
-
-import java.util.logging.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.google.common.hash.Hashing;
 import com.google.common.io.ByteArrayDataOutput;
@@ -33,7 +30,7 @@ public class GenDiffSet {
         String outputDir = args[3]; //Path to place generated .binpatch
         String killTarget = args[4]; //"true" if we should destroy the target file if it generated a successful .binpatch
 
-        LogManager.getLogger("GENDIFF").log(Level.INFO, String.format("Creating patches at %s for %s from %s", outputDir, sourceJar, targetDir));
+        LoggerFactory.getLogger("GENDIFF").info(String.format("Creating patches at %s for %s from %s", outputDir, sourceJar, targetDir));
         Delta delta = new Delta();
         FMLDeobfuscatingRemapper remapper = FMLDeobfuscatingRemapper.INSTANCE;
         remapper.setupLoadOnly(deobfData, false);
@@ -45,7 +42,7 @@ public class GenDiffSet {
 
         for (String name : remapper.getObfedClasses())
         {
-//            Logger.getLogger("GENDIFF").info(String.format("Evaluating path for data :%s",name));
+//            LoggerFactory.getLogger("GENDIFF").info(String.format("Evaluating path for data :%s",name));
             String fileName = name;
             String jarName = name;
             if (RESERVED_NAMES.contains(name.toUpperCase(Locale.ENGLISH)))
@@ -87,11 +84,11 @@ public class GenDiffSet {
                 File target = new File(outputDir, targetClassName+".binpatch");
                 target.getParentFile().mkdirs();
                 Files.write(diffOut.toByteArray(), target);
-                Logger.getLogger("GENDIFF").info(String.format("Wrote patch for %s (%s) at %s",name, targetClassName, target.getAbsolutePath()));
+                LoggerFactory.getLogger("GENDIFF").info(String.format("Wrote patch for %s (%s) at %s",name, targetClassName, target.getAbsolutePath()));
                 if (kill)
                 {
                     targetFile.delete();
-                    Logger.getLogger("GENDIFF").info(String.format("  Deleted target: %s", targetFile.toString()));
+                    LoggerFactory.getLogger("GENDIFF").info(String.format("  Deleted target: %s", targetFile.toString()));
                 }
             }
         }

--- a/src/main/java/net/minecraftforge/fml/common/registry/GameRegistry.java
+++ b/src/main/java/net/minecraftforge/fml/common/registry/GameRegistry.java
@@ -506,7 +506,7 @@ public class GameRegistry
         if (itemName == null) throw new IllegalArgumentException("The itemName cannot be null");
         Item item = GameData.getItemRegistry().getObject(itemName);
         if (item == null) {
-            FMLLog.getLogger().log(Level.TRACE, "Unable to find item with name {}", itemName);
+            FMLLog.log(Level.TRACE, "Unable to find item with name {}", itemName);
             return null;
         }
         ItemStack is = new ItemStack(item,1,meta);
@@ -517,11 +517,11 @@ public class GameRegistry
                 nbttag = JsonToNBT.getTagFromJson(nbtString);
             } catch (NBTException e)
             {
-                FMLLog.getLogger().log(Level.WARN, "Encountered an exception parsing ItemStack NBT string {}", nbtString, e);
+                FMLLog.log(Level.WARN, "Encountered an exception parsing ItemStack NBT string {}", nbtString, e);
                 throw Throwables.propagate(e);
             }
             if (!(nbttag instanceof NBTTagCompound)) {
-                FMLLog.getLogger().log(Level.WARN, "Unexpected NBT string - multiple values {}", nbtString);
+                FMLLog.log(Level.WARN, "Unexpected NBT string - multiple values {}", nbtString);
                 throw new RuntimeException("Invalid NBT JSON");
             } else {
                 is.setTagCompound((NBTTagCompound) nbttag);

--- a/src/main/java/net/minecraftforge/fml/common/registry/ItemStackHolderInjector.java
+++ b/src/main/java/net/minecraftforge/fml/common/registry/ItemStackHolderInjector.java
@@ -23,11 +23,11 @@ public enum ItemStackHolderInjector
     private List<ItemStackHolderRef> itemStackHolders = Lists.newArrayList();
 
     public void inject() {
-        FMLLog.getLogger().log(Level.INFO, "Injecting itemstacks");
+        FMLLog.log(Level.INFO, "Injecting itemstacks");
         for (ItemStackHolderRef ishr: itemStackHolders) {
             ishr.apply();
         }
-        FMLLog.getLogger().log(Level.INFO, "Itemstack injection complete");
+        FMLLog.log(Level.INFO, "Itemstack injection complete");
     }
 
     public void findHolders(ASMDataTable table) {

--- a/src/main/java/net/minecraftforge/fml/common/registry/ItemStackHolderRef.java
+++ b/src/main/java/net/minecraftforge/fml/common/registry/ItemStackHolderRef.java
@@ -67,7 +67,7 @@ class ItemStackHolderRef {
             is = GameRegistry.makeItemStack(itemName, meta, 1, serializednbt);
         } catch (RuntimeException e)
         {
-            FMLLog.getLogger().log(Level.ERROR, "Caught exception processing itemstack {},{},{} in annotation at {}.{}", itemName, meta, serializednbt,field.getClass().getName(),field.getName());
+            FMLLog.log(Level.ERROR, "Caught exception processing itemstack {},{},{} in annotation at {}.{}", itemName, meta, serializednbt,field.getClass().getName(),field.getName());
             throw e;
         }
         try
@@ -77,7 +77,7 @@ class ItemStackHolderRef {
         }
         catch (Exception e)
         {
-            FMLLog.getLogger().log(Level.WARN, "Unable to set {} with value {},{},{}", this.field, this.itemName, this.meta, this.serializednbt);
+            FMLLog.log(Level.WARN, "Unable to set {} with value {},{},{}", this.field, this.itemName, this.meta, this.serializednbt);
         }
     }
 }

--- a/src/main/java/net/minecraftforge/fml/common/registry/ObjectHolderRef.java
+++ b/src/main/java/net/minecraftforge/fml/common/registry/ObjectHolderRef.java
@@ -120,7 +120,7 @@ class ObjectHolderRef {
 
         if (thing == null)
         {
-            FMLLog.getLogger().log(Level.DEBUG, "Unable to lookup {} for {}. This means the object wasn't registered. It's likely just mod options.", injectedObject, field);
+            FMLLog.log(Level.DEBUG, "Unable to lookup {} for {}. This means the object wasn't registered. It's likely just mod options.", injectedObject, field);
             return;
         }
         try

--- a/src/main/java/net/minecraftforge/fml/relauncher/CoreModManager.java
+++ b/src/main/java/net/minecraftforge/fml/relauncher/CoreModManager.java
@@ -280,13 +280,13 @@ public class CoreModManager {
         File[] derpdirlist = coreMods.listFiles(derpdirfilter);
         if (derpdirlist != null && derpdirlist.length > 0)
         {
-            FMLRelaunchLog.log.getLogger().log(Level.FATAL, "There appear to be jars extracted into the mods directory. This is VERY BAD and will almost NEVER WORK WELL");
-            FMLRelaunchLog.log.getLogger().log(Level.FATAL, "You should place original jars only in the mods directory. NEVER extract them to the mods directory.");
-            FMLRelaunchLog.log.getLogger().log(Level.FATAL, "The directories below appear to be extracted jar files. Fix this before you continue.");
+            FMLRelaunchLog.log(Level.FATAL, "There appear to be jars extracted into the mods directory. This is VERY BAD and will almost NEVER WORK WELL");
+            FMLRelaunchLog.log(Level.FATAL, "You should place original jars only in the mods directory. NEVER extract them to the mods directory.");
+            FMLRelaunchLog.log(Level.FATAL, "The directories below appear to be extracted jar files. Fix this before you continue.");
 
             for (File f : derpdirlist)
             {
-                FMLRelaunchLog.log.getLogger().log(Level.FATAL, "Directory {} contains {}", f.getName(), Arrays.asList(new File(f,"META-INF").list()));
+                FMLRelaunchLog.log(Level.FATAL, "Directory {} contains {}", f.getName(), Arrays.asList(new File(f,"META-INF").list()));
             }
 
             RuntimeException re = new RuntimeException("Extracted mod jars found, loading will NOT continue");


### PR DESCRIPTION
No markers or killing off String.format yet, but this should lay the groundwork. It purposely doesn't change the `getModLogger` call in preinit to prevent a breaking change.
