### PR TITLE
Replace canProvidePower with the blockstate sensitive one

### DIFF
--- a/patches/minecraft/net/minecraft/block/Block.java.patch
+++ b/patches/minecraft/net/minecraft/block/Block.java.patch
@@ -179,7 +179,7 @@
      }
  
      protected ItemStack func_180643_i(IBlockState p_180643_1_)
-@@ -1010,6 +1030,1029 @@
+@@ -1010,6 +1030,1043 @@
          return "Block{" + field_149771_c.func_177774_c(this) + "}";
      }
  
@@ -226,7 +226,7 @@
 +     */
 +    public boolean isNormalCube(IBlockAccess world, BlockPos pos)
 +    {
-+        return func_149688_o().func_76218_k() && func_149686_d() && !func_149744_f();
++        return func_149688_o().func_76218_k() && func_149686_d() && !canProvidePower(world, pos);
 +    }
 +
 +    /**
@@ -710,7 +710,21 @@
 +     */
 +    public boolean canConnectRedstone(IBlockAccess world, BlockPos pos, EnumFacing side)
 +    {
-+        return func_149744_f() && side != null;
++        return canProvidePower(world, pos) && side != null;
++    }
++    
++    /**
++     * Determine if this block can provide power, 
++     * use {@link #isProvidingWeakPower(IBlockAccess, BlockPos, IBlockState, EnumFacing)}
++     * or {@link #isProvidingStrongPower(IBlockAccess, BlockPos, IBlockState, EnumFacing)}
++     * to determine to power level the block outputs.
++     * 
++     * @param world The current world
++     * @param pos Block position in world
++     * @return True to allow this block to provide power
++     */
++    public boolean canProvidePower(IBlockAccess world, BlockPos pos) {
++        return func_149744_f();
 +    }
 +
 +    /**
@@ -1073,7 +1087,7 @@
 +     */
 +    public boolean shouldCheckWeakPower(IBlockAccess world, BlockPos pos, EnumFacing side)
 +    {
-+        return func_149721_r();
++        return isNormalCube(world, pos);
 +    }
 +
 +    /**

--- a/patches/minecraft/net/minecraft/block/BlockEnderChest.java.patch
+++ b/patches/minecraft/net/minecraft/block/BlockEnderChest.java.patch
@@ -1,0 +1,11 @@
+--- ../src-base/minecraft/net/minecraft/block/BlockEnderChest.java
++++ ../src-work/minecraft/net/minecraft/block/BlockEnderChest.java
+@@ -82,7 +82,7 @@
+ 
+         if (inventoryenderchest != null && tileentity instanceof TileEntityEnderChest)
+         {
+-            if (p_180639_1_.func_180495_p(p_180639_2_.func_177984_a()).func_177230_c().func_149721_r())
++            if (p_180639_1_.func_180495_p(p_180639_2_.func_177984_a()).func_177230_c().isNormalCube(p_180639_1_, p_180639_2_.func_177984_a()))
+             {
+                 return true;
+             }

--- a/patches/minecraft/net/minecraft/block/BlockGrass.java.patch
+++ b/patches/minecraft/net/minecraft/block/BlockGrass.java.patch
@@ -27,3 +27,12 @@
                      {
                          if (p_176474_2_.nextInt(8) == 0)
                          {
+@@ -139,7 +139,7 @@
+ 
+                 blockpos1 = blockpos1.func_177982_a(p_176474_2_.nextInt(3) - 1, (p_176474_2_.nextInt(3) - 1) * p_176474_2_.nextInt(3) / 2, p_176474_2_.nextInt(3) - 1);
+ 
+-                if (p_176474_1_.func_180495_p(blockpos1.func_177977_b()).func_177230_c() != Blocks.field_150349_c || p_176474_1_.func_180495_p(blockpos1).func_177230_c().func_149721_r())
++                if (p_176474_1_.func_180495_p(blockpos1.func_177977_b()).func_177230_c() != Blocks.field_150349_c || p_176474_1_.func_180495_p(blockpos1).func_177230_c().isNormalCube(p_176474_1_, blockpos1))
+                 {
+                     break;
+                 }

--- a/patches/minecraft/net/minecraft/block/BlockPortal.java.patch
+++ b/patches/minecraft/net/minecraft/block/BlockPortal.java.patch
@@ -1,0 +1,11 @@
+--- ../src-base/minecraft/net/minecraft/block/BlockPortal.java
++++ ../src-work/minecraft/net/minecraft/block/BlockPortal.java
+@@ -48,7 +48,7 @@
+                 ;
+             }
+ 
+-            if (i > 0 && !p_180650_1_.func_180495_p(blockpos.func_177984_a()).func_177230_c().func_149721_r())
++            if (i > 0 && !p_180650_1_.func_180495_p(blockpos.func_177984_a()).func_177230_c().isNormalCube(p_180650_1_, blockpos.func_177984_a()))
+             {
+                 Entity entity = ItemMonsterPlacer.func_77840_a(p_180650_1_, 57, (double)blockpos.func_177958_n() + 0.5D, (double)blockpos.func_177956_o() + 1.1D, (double)blockpos.func_177952_p() + 0.5D);
+ 

--- a/patches/minecraft/net/minecraft/block/BlockRedstoneComparator.java.patch
+++ b/patches/minecraft/net/minecraft/block/BlockRedstoneComparator.java.patch
@@ -1,5 +1,14 @@
 --- ../src-base/minecraft/net/minecraft/block/BlockRedstoneComparator.java
 +++ ../src-work/minecraft/net/minecraft/block/BlockRedstoneComparator.java
+@@ -123,7 +123,7 @@
+         {
+             i = block.func_180641_l(p_176397_1_, blockpos);
+         }
+-        else if (i < 15 && block.func_149721_r())
++        else if (i < 15 && block.isNormalCube(p_176397_1_, blockpos))
+         {
+             blockpos = blockpos.func_177972_a(enumfacing);
+             block = p_176397_1_.func_180495_p(blockpos).func_177230_c();
 @@ -295,6 +295,21 @@
          return this.func_176223_P().func_177226_a(field_176387_N, p_180642_8_.func_174811_aO().func_176734_d()).func_177226_a(field_176464_a, Boolean.valueOf(false)).func_177226_a(field_176463_b, BlockRedstoneComparator.Mode.COMPARE);
      }

--- a/patches/minecraft/net/minecraft/block/BlockRedstoneWire.java.patch
+++ b/patches/minecraft/net/minecraft/block/BlockRedstoneWire.java.patch
@@ -13,11 +13,50 @@
          }
          else
          {
-@@ -359,35 +359,24 @@
+@@ -137,14 +137,14 @@
+                 l = this.func_176342_a(p_176345_1_, blockpos, l);
+             }
+ 
+-            if (p_176345_1_.func_180495_p(blockpos).func_177230_c().func_149721_r() && !p_176345_1_.func_180495_p(p_176345_2_.func_177984_a()).func_177230_c().func_149721_r())
++            if (p_176345_1_.func_180495_p(blockpos).func_177230_c().isNormalCube(p_176345_1_, blockpos) && !p_176345_1_.func_180495_p(p_176345_2_.func_177984_a()).func_177230_c().isNormalCube(p_176345_1_, p_176345_2_.func_177984_a()))
+             {
+                 if (flag && p_176345_2_.func_177956_o() >= p_176345_3_.func_177956_o())
+                 {
+                     l = this.func_176342_a(p_176345_1_, blockpos.func_177984_a(), l);
+                 }
+             }
+-            else if (!p_176345_1_.func_180495_p(blockpos).func_177230_c().func_149721_r() && flag && p_176345_2_.func_177956_o() <= p_176345_3_.func_177956_o())
++            else if (!p_176345_1_.func_180495_p(blockpos).func_177230_c().isNormalCube(p_176345_1_, blockpos) && flag && p_176345_2_.func_177956_o() <= p_176345_3_.func_177956_o())
+             {
+                 l = this.func_176342_a(p_176345_1_, blockpos.func_177977_b(), l);
+             }
+@@ -221,7 +221,7 @@
+             {
+                 BlockPos blockpos = p_176213_2_.func_177972_a(enumfacing2);
+ 
+-                if (p_176213_1_.func_180495_p(blockpos).func_177230_c().func_149721_r())
++                if (p_176213_1_.func_180495_p(blockpos).func_177230_c().isNormalCube(p_176213_1_, blockpos))
+                 {
+                     this.func_176344_d(p_176213_1_, blockpos.func_177984_a());
+                 }
+@@ -255,7 +255,7 @@
+             {
+                 BlockPos blockpos = p_180663_2_.func_177972_a(enumfacing2);
+ 
+-                if (p_180663_1_.func_180495_p(blockpos).func_177230_c().func_149721_r())
++                if (p_180663_1_.func_180495_p(blockpos).func_177230_c().isNormalCube(p_180663_1_, blockpos))
+                 {
+                     this.func_176344_d(p_180663_1_, blockpos.func_177984_a());
+                 }
+@@ -357,37 +357,26 @@
+         BlockPos blockpos = p_176339_2_.func_177972_a(p_176339_3_);
+         IBlockState iblockstate = p_176339_1_.func_180495_p(blockpos);
          Block block = iblockstate.func_177230_c();
-         boolean flag = block.func_149721_r();
-         boolean flag1 = p_176339_1_.func_180495_p(p_176339_2_.func_177984_a()).func_177230_c().func_149721_r();
+-        boolean flag = block.func_149721_r();
+-        boolean flag1 = p_176339_1_.func_180495_p(p_176339_2_.func_177984_a()).func_177230_c().func_149721_r();
 -        return !flag1 && flag && func_176340_e(p_176339_1_, blockpos.func_177984_a()) ? true : (func_176343_a(iblockstate, p_176339_3_) ? true : (block == Blocks.field_150416_aS && iblockstate.func_177229_b(BlockRedstoneDiode.field_176387_N) == p_176339_3_ ? true : !flag && func_176340_e(p_176339_1_, blockpos.func_177977_b())));
++        boolean flag = block.isNormalCube(p_176339_1_, blockpos);
++        boolean flag1 = p_176339_1_.func_180495_p(p_176339_2_.func_177984_a()).func_177230_c().isNormalCube(p_176339_1_, p_176339_2_.func_177984_a());
 +        return !flag1 && flag && canRestoneConnect(p_176339_1_, blockpos.func_177984_a(), null) ? true : (canRestoneConnect(p_176339_1_, blockpos, p_176339_3_) ? true : (block == Blocks.field_150416_aS && iblockstate.func_177229_b(BlockRedstoneDiode.field_176387_N) == p_176339_3_ ? true : !flag && canRestoneConnect(p_176339_1_, blockpos.func_177977_b(), null)));
      }
  

--- a/patches/minecraft/net/minecraft/client/entity/EntityPlayerSP.java.patch
+++ b/patches/minecraft/net/minecraft/client/entity/EntityPlayerSP.java.patch
@@ -56,6 +56,15 @@
                  {
                      d2 = 1.0D - d1;
                      i = 5;
+@@ -415,7 +428,7 @@
+ 
+     private boolean func_175162_d(BlockPos p_175162_1_)
+     {
+-        return !this.field_70170_p.func_180495_p(p_175162_1_).func_177230_c().func_149721_r() && !this.field_70170_p.func_180495_p(p_175162_1_.func_177984_a()).func_177230_c().func_149721_r();
++        return !this.field_70170_p.func_180495_p(p_175162_1_).func_177230_c().isNormalCube(field_70170_p, p_175162_1_) && !this.field_70170_p.func_180495_p(p_175162_1_.func_177984_a()).func_177230_c().isNormalCube(field_70170_p, p_175162_1_.func_177984_a());
+     }
+ 
+     public void func_70031_b(boolean p_70031_1_)
 @@ -448,6 +461,12 @@
  
      public void func_85030_a(String p_85030_1_, float p_85030_2_, float p_85030_3_)

--- a/patches/minecraft/net/minecraft/entity/item/EntityMinecart.java.patch
+++ b/patches/minecraft/net/minecraft/entity/item/EntityMinecart.java.patch
@@ -190,6 +190,33 @@
              double d15 = Math.sqrt(this.field_70159_w * this.field_70159_w + this.field_70179_y * this.field_70179_y);
  
              if (d15 > 0.01D)
+@@ -589,22 +614,22 @@
+             }
+             else if (blockrailbase$enumraildirection == BlockRailBase.EnumRailDirection.EAST_WEST)
+             {
+-                if (this.field_70170_p.func_180495_p(p_180460_1_.func_177976_e()).func_177230_c().func_149721_r())
++                if (this.field_70170_p.func_180495_p(p_180460_1_.func_177976_e()).func_177230_c().isNormalCube(field_70170_p, p_180460_1_.func_177976_e()))
+                 {
+                     this.field_70159_w = 0.02D;
+                 }
+-                else if (this.field_70170_p.func_180495_p(p_180460_1_.func_177974_f()).func_177230_c().func_149721_r())
++                else if (this.field_70170_p.func_180495_p(p_180460_1_.func_177974_f()).func_177230_c().isNormalCube(field_70170_p, p_180460_1_.func_177974_f()))
+                 {
+                     this.field_70159_w = -0.02D;
+                 }
+             }
+             else if (blockrailbase$enumraildirection == BlockRailBase.EnumRailDirection.NORTH_SOUTH)
+             {
+-                if (this.field_70170_p.func_180495_p(p_180460_1_.func_177978_c()).func_177230_c().func_149721_r())
++                if (this.field_70170_p.func_180495_p(p_180460_1_.func_177978_c()).func_177230_c().isNormalCube(field_70170_p, p_180460_1_.func_177978_c()))
+                 {
+                     this.field_70179_y = 0.02D;
+                 }
+-                else if (this.field_70170_p.func_180495_p(p_180460_1_.func_177968_d()).func_177230_c().func_149721_r())
++                else if (this.field_70170_p.func_180495_p(p_180460_1_.func_177968_d()).func_177230_c().isNormalCube(field_70170_p, p_180460_1_.func_177968_d()))
+                 {
+                     this.field_70179_y = -0.02D;
+                 }
 @@ -817,13 +842,20 @@
  
      public void func_70108_f(Entity p_70108_1_)

--- a/patches/minecraft/net/minecraft/entity/passive/EntityBat.java.patch
+++ b/patches/minecraft/net/minecraft/entity/passive/EntityBat.java.patch
@@ -1,0 +1,20 @@
+--- ../src-base/minecraft/net/minecraft/entity/passive/EntityBat.java
++++ ../src-work/minecraft/net/minecraft/entity/passive/EntityBat.java
+@@ -114,7 +114,7 @@
+ 
+         if (this.func_82235_h())
+         {
+-            if (!this.field_70170_p.func_180495_p(blockpos1).func_177230_c().func_149721_r())
++            if (!this.field_70170_p.func_180495_p(blockpos1).func_177230_c().isNormalCube(field_70170_p, blockpos1))
+             {
+                 this.func_82236_f(false);
+                 this.field_70170_p.func_180498_a((EntityPlayer)null, 1015, blockpos, 0);
+@@ -156,7 +156,7 @@
+             this.field_70701_bs = 0.5F;
+             this.field_70177_z += f1;
+ 
+-            if (this.field_70146_Z.nextInt(100) == 0 && this.field_70170_p.func_180495_p(blockpos1).func_177230_c().func_149721_r())
++            if (this.field_70146_Z.nextInt(100) == 0 && this.field_70170_p.func_180495_p(blockpos1).func_177230_c().isNormalCube(field_70170_p, blockpos1))
+             {
+                 this.func_82236_f(true);
+             }

--- a/patches/minecraft/net/minecraft/item/ItemDoor.java.patch
+++ b/patches/minecraft/net/minecraft/item/ItemDoor.java.patch
@@ -1,0 +1,13 @@
+--- ../src-base/minecraft/net/minecraft/item/ItemDoor.java
++++ ../src-work/minecraft/net/minecraft/item/ItemDoor.java
+@@ -56,8 +56,8 @@
+     {
+         BlockPos blockpos = p_179235_1_.func_177972_a(p_179235_2_.func_176746_e());
+         BlockPos blockpos1 = p_179235_1_.func_177972_a(p_179235_2_.func_176735_f());
+-        int i = (p_179235_0_.func_180495_p(blockpos1).func_177230_c().func_149721_r() ? 1 : 0) + (p_179235_0_.func_180495_p(blockpos1.func_177984_a()).func_177230_c().func_149721_r() ? 1 : 0);
+-        int j = (p_179235_0_.func_180495_p(blockpos).func_177230_c().func_149721_r() ? 1 : 0) + (p_179235_0_.func_180495_p(blockpos.func_177984_a()).func_177230_c().func_149721_r() ? 1 : 0);
++        int i = (p_179235_0_.func_180495_p(blockpos1).func_177230_c().isNormalCube(p_179235_0_, blockpos1) ? 1 : 0) + (p_179235_0_.func_180495_p(blockpos1.func_177984_a()).func_177230_c().isNormalCube(p_179235_0_, blockpos1) ? 1 : 0);
++        int j = (p_179235_0_.func_180495_p(blockpos).func_177230_c().isNormalCube(p_179235_0_, blockpos) ? 1 : 0) + (p_179235_0_.func_180495_p(blockpos.func_177984_a()).func_177230_c().isNormalCube(p_179235_0_, blockpos.func_177984_a()) ? 1 : 0);
+         boolean flag = p_179235_0_.func_180495_p(blockpos1).func_177230_c() == p_179235_3_ || p_179235_0_.func_180495_p(blockpos1.func_177984_a()).func_177230_c() == p_179235_3_;
+         boolean flag1 = p_179235_0_.func_180495_p(blockpos).func_177230_c() == p_179235_3_ || p_179235_0_.func_180495_p(blockpos.func_177984_a()).func_177230_c() == p_179235_3_;
+         boolean flag2 = false;

--- a/patches/minecraft/net/minecraft/village/Village.java.patch
+++ b/patches/minecraft/net/minecraft/village/Village.java.patch
@@ -1,0 +1,12 @@
+--- ../src-base/minecraft/net/minecraft/village/Village.java
++++ ../src-work/minecraft/net/minecraft/village/Village.java
+@@ -116,7 +116,8 @@
+                 {
+                     for (int i1 = j; i1 < j + p_179861_1_.func_177952_p(); ++i1)
+                     {
+-                        if (this.field_75586_a.func_180495_p(new BlockPos(k, l, i1)).func_177230_c().func_149721_r())
++                        BlockPos blockpos = new BlockPos(k, l, i1);
++                        if (this.field_75586_a.func_180495_p(blockpos).func_177230_c().isNormalCube(field_75586_a, blockpos))
+                         {
+                             return false;
+                         }

--- a/patches/minecraft/net/minecraft/world/SpawnerAnimals.java.patch
+++ b/patches/minecraft/net/minecraft/world/SpawnerAnimals.java.patch
@@ -19,6 +19,15 @@
                          {
                              BlockPos blockpos = func_180621_a(p_77192_1_, chunkcoordintpair1.field_77276_a, chunkcoordintpair1.field_77275_b);
                              int k1 = blockpos.func_177958_n();
+@@ -84,7 +85,7 @@
+                             int i2 = blockpos.func_177952_p();
+                             Block block = p_77192_1_.func_180495_p(blockpos).func_177230_c();
+ 
+-                            if (!block.func_149721_r())
++                            if (!block.isNormalCube(p_77192_1_, blockpos))
+                             {
+                                 int j2 = 0;
+ 
 @@ -134,8 +135,10 @@
  
                                                  entityliving.func_70012_b((double)f, (double)i3, (double)f1, p_77192_1_.field_73012_v.nextFloat() * 360.0F, 0.0F);
@@ -40,7 +49,14 @@
                                                      {
                                                          continue label374;
                                                      }
-@@ -193,7 +196,7 @@
+@@ -187,13 +190,13 @@
+ 
+             if (p_180267_0_ == EntityLiving.SpawnPlacementType.IN_WATER)
+             {
+-                return block.func_149688_o().func_76224_d() && p_180267_1_.func_180495_p(p_180267_2_.func_177977_b()).func_177230_c().func_149688_o().func_76224_d() && !p_180267_1_.func_180495_p(p_180267_2_.func_177984_a()).func_177230_c().func_149721_r();
++                return block.func_149688_o().func_76224_d() && p_180267_1_.func_180495_p(p_180267_2_.func_177977_b()).func_177230_c().func_149688_o().func_76224_d() && !p_180267_1_.func_180495_p(p_180267_2_.func_177984_a()).func_177230_c().isNormalCube(p_180267_1_, p_180267_2_.func_177984_a());
+             }
+             else
              {
                  BlockPos blockpos = p_180267_2_.func_177977_b();
  
@@ -49,3 +65,12 @@
                  {
                      return false;
                  }
+@@ -201,7 +204,7 @@
+                 {
+                     Block block1 = p_180267_1_.func_180495_p(blockpos).func_177230_c();
+                     boolean flag = block1 != Blocks.field_150357_h && block1 != Blocks.field_180401_cv;
+-                    return flag && !block.func_149721_r() && !block.func_149688_o().func_76224_d() && !p_180267_1_.func_180495_p(p_180267_2_.func_177984_a()).func_177230_c().func_149721_r();
++                    return flag && !block.isNormalCube(p_180267_1_, blockpos) && !block.func_149688_o().func_76224_d() && !p_180267_1_.func_180495_p(p_180267_2_.func_177984_a()).func_177230_c().isNormalCube(p_180267_1_, p_180267_2_.func_177984_a());
+                 }
+             }
+         }

--- a/src/test/java/net/minecraftforge/debug/BlockRedstoneDebug.java
+++ b/src/test/java/net/minecraftforge/debug/BlockRedstoneDebug.java
@@ -1,0 +1,117 @@
+package net.minecraftforge.debug;
+
+import java.util.List;
+
+import net.minecraft.block.Block;
+import net.minecraft.block.material.Material;
+import net.minecraft.block.properties.PropertyEnum;
+import net.minecraft.block.state.BlockState;
+import net.minecraft.block.state.IBlockState;
+import net.minecraft.creativetab.CreativeTabs;
+import net.minecraft.item.Item;
+import net.minecraft.item.ItemBlock;
+import net.minecraft.item.ItemStack;
+import net.minecraft.util.BlockPos;
+import net.minecraft.util.EnumFacing;
+import net.minecraft.util.IStringSerializable;
+import net.minecraft.world.IBlockAccess;
+import net.minecraftforge.fml.common.Mod;
+import net.minecraftforge.fml.common.Mod.EventHandler;
+import net.minecraftforge.fml.common.event.FMLPreInitializationEvent;
+import net.minecraftforge.fml.common.registry.GameRegistry;
+
+@Mod(modid = BlockRedstoneDebug.MODID)
+public class BlockRedstoneDebug
+{
+    public static final String MODID = "ForgeDebugBlockRedstone";
+
+    @EventHandler
+    public void preInit(FMLPreInitializationEvent event)
+    {
+        GameRegistry.registerBlock(TestBlock.instance, ItemTestBlock.class, TestBlock.name);
+    }
+
+    public static enum TestBlockType implements IStringSerializable {
+
+        NORMAL,
+        POWERED;
+
+        @Override
+        public String getName()
+        {
+            return toString();
+        }
+    }
+
+    public static class TestBlock extends Block
+    {
+        public static final String name = "custom_redstone_block";
+        public static PropertyEnum<TestBlockType> property = PropertyEnum.create("type", TestBlockType.class);
+        public static TestBlock instance = new TestBlock();
+
+        public TestBlock()
+        {
+            super(Material.iron);
+            setDefaultState(getDefaultState().withProperty(property, TestBlockType.NORMAL));
+            setCreativeTab(CreativeTabs.tabBlock);
+        }
+
+        @Override
+        public String getLocalizedName()
+        {
+            return name;
+        }
+
+        @Override
+        protected BlockState createBlockState()
+        {
+            return new BlockState(this, property);
+        }
+
+        @Override
+        public IBlockState getStateFromMeta(int meta)
+        {
+            return getDefaultState().withProperty(property, TestBlockType.values()[meta & 1]);
+        }
+
+        @Override
+        public int getMetaFromState(IBlockState state)
+        {
+            return state.getValue(property).ordinal() & 1;
+        }
+
+        @Override
+        public boolean canProvidePower(IBlockAccess world, BlockPos pos) {
+            return world.getBlockState(pos).getValue(property) == TestBlockType.POWERED;
+        }
+
+        @Override
+        public int isProvidingWeakPower(IBlockAccess world, BlockPos pos, IBlockState state, EnumFacing side)
+        {
+            return state.getValue(property) == TestBlockType.NORMAL ? 0 : 15;
+        }
+
+        @Override
+        public void getSubBlocks(Item item, CreativeTabs tab, List<ItemStack> list)
+        {
+            list.add(new ItemStack(item, 1, 0));
+            list.add(new ItemStack(item, 1, 1));
+        }
+    }
+
+    public static class ItemTestBlock extends ItemBlock {
+
+        public ItemTestBlock(Block block)
+        {
+            super(block);
+            setHasSubtypes(true);
+            setMaxDamage(0);
+        }
+
+        @Override
+        public int getMetadata(int meta)
+        {
+            return meta;
+        }
+    }
+}


### PR DESCRIPTION
- Replace isNormalBlock with the blockstate sensitive one, because currently the `isNormalBlock()` function is called a lot more than the `isNormalBlock(IBlockAcess, BlockPosition)` one, which is pretty inconsistent.
- Add `canProvidePower(IBlockAccess, BlockPosition)` to replace the block state insensitive one `canProvidePower()`
- Replaced all `canProvidePower()` calls with the block state sensitive one, except from a few occurrences in `Block.onNeighborBlockChange()` as there is no information about the neighbor block position and `World.isBlockPowered()` already handles these cases.

I made a test mod with a block that has a normal and powered state. Without this patch the normal block can never pass redstone power through itself:
![Before](http://i.imgur.com/gI0U02P.png)
After this change that behavior is possible:
![After](http://i.imgur.com/KYbCYXb.png)