### PR TITLE
Fix a typo in jar detection

### DIFF
--- a/src/main/java/net/minecraftforge/fml/common/ModClassLoader.java
+++ b/src/main/java/net/minecraftforge/fml/common/ModClassLoader.java
@@ -116,7 +116,7 @@ public class ModClassLoader extends URLClassLoader
             "librarylwjglopenal-",
             "soundsystem-",
             "netty-all-",
-            "quava-",
+            "guava-",
             "commons-lang3-",
             "commons-compress-",
             "commons-logging-",


### PR DESCRIPTION
`quava` -> `guava`