### PR TITLE
Add events for piston extension and retraction, called once for each …

### DIFF
--- a/patches/minecraft/net/minecraft/block/BlockPistonBase.java.patch
+++ b/patches/minecraft/net/minecraft/block/BlockPistonBase.java.patch
@@ -18,7 +18,15 @@
              }
              else
              {
-@@ -371,7 +371,9 @@
+@@ -363,6 +363,7 @@
+         }
+         else
+         {
++            if (net.minecraftforge.event.ForgeEventFactory.onPistonMove(p_176319_1_, p_176319_2_, p_176319_3_, p_176319_4_)) return false;
+             int i = list.size() + list1.size();
+             Block[] ablock = new Block[i];
+             EnumFacing enumfacing = p_176319_4_ ? p_176319_3_ : p_176319_3_.func_176734_d();
+@@ -371,7 +372,9 @@
              {
                  BlockPos blockpos = (BlockPos)list1.get(j);
                  Block block = p_176319_1_.func_180495_p(blockpos).func_177230_c();

--- a/src/main/java/net/minecraftforge/event/ForgeEventFactory.java
+++ b/src/main/java/net/minecraftforge/event/ForgeEventFactory.java
@@ -476,4 +476,11 @@ public class ForgeEventFactory
         return MinecraftForge.EVENT_BUS.post(new RenderBlockOverlayEvent(player, renderPartialTicks, type, block, pos));
     }
 
+    public static boolean onPistonMove(World world, BlockPos pos, EnumFacing facing, boolean extending)
+    {
+        if (extending)
+            return MinecraftForge.EVENT_BUS.post(new net.minecraftforge.event.world.PistonEvent.PistonExtendEvent(world, pos, facing));
+        else
+            return MinecraftForge.EVENT_BUS.post(new net.minecraftforge.event.world.PistonEvent.PistonRetractEvent(world, pos, facing));
+    }
 }

--- a/src/main/java/net/minecraftforge/event/world/PistonEvent.java
+++ b/src/main/java/net/minecraftforge/event/world/PistonEvent.java
@@ -1,0 +1,46 @@
+package net.minecraftforge.event.world;
+
+import net.minecraft.block.Block;
+import net.minecraft.util.BlockPos;
+import net.minecraft.util.EnumFacing;
+import net.minecraft.world.World;
+import net.minecraftforge.fml.common.eventhandler.Cancelable;
+
+public class PistonEvent extends BlockEvent
+{
+    /** Stores the direction of the piston */
+    public final EnumFacing facing;
+
+    public PistonEvent(World world, BlockPos pos, EnumFacing facing)
+    {
+        super(world, pos, world.getBlockState(pos));
+        
+        this.facing = facing;
+    }
+    
+    /***
+     * Posts when a piston tries to extend
+     * If canceled the piston will not extend
+     ***/
+    @Cancelable
+    public static class PistonExtendEvent extends PistonEvent
+    {
+        public PistonExtendEvent(World world, BlockPos pos, EnumFacing facing)
+        {
+            super(world, pos, facing);
+        }
+    }
+    
+    /***
+     * Posts when a piston tries to retract
+     * If canceled the piston will not pull the block it is attached to
+     ***/
+    @Cancelable
+    public static class PistonRetractEvent extends PistonEvent
+    {
+        public PistonRetractEvent(World world, BlockPos pos, EnumFacing facing)
+        {
+            super(world, pos, facing);
+        }
+    }
+}

--- a/src/test/java/net/minecraftforge/debug/EventPistonDebug.java
+++ b/src/test/java/net/minecraftforge/debug/EventPistonDebug.java
@@ -1,0 +1,61 @@
+package net.minecraftforge.debug;
+
+import net.minecraft.block.BlockPistonExtension;
+import net.minecraft.block.BlockPistonExtension.EnumPistonType;
+import net.minecraft.block.state.BlockPistonStructureHelper;
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.init.Blocks;
+import net.minecraft.util.ChatComponentText;
+import net.minecraftforge.common.MinecraftForge;
+import net.minecraftforge.event.world.PistonEvent;
+import net.minecraftforge.fml.common.Mod;
+import net.minecraftforge.fml.common.Mod.EventHandler;
+import net.minecraftforge.fml.common.event.FMLInitializationEvent;
+import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
+
+@Mod(modid = EventPistonDebug.MODID)
+public class EventPistonDebug {
+	public static final String MODID = "EventPistonDebug";
+
+	@EventHandler
+	public void init(FMLInitializationEvent event) {
+		MinecraftForge.EVENT_BUS.register(this);
+	}
+
+	@SubscribeEvent
+	public void onPistonExtend(PistonEvent.PistonExtendEvent event) {
+		if (event.world.isRemote) {
+			BlockPistonStructureHelper pistonHelper =
+					new BlockPistonStructureHelper(event.world, event.pos, event.facing, true);
+			for (EntityPlayer player : event.world.playerEntities) {
+				if (pistonHelper.canMove())
+					player.addChatMessage(new ChatComponentText(String.format("Piston will extend moving %d blocks and destroy %d blocks",
+							pistonHelper.getBlocksToMove().size(), pistonHelper.getBlocksToDestroy().size())));
+				else
+					player.addChatMessage(new ChatComponentText("Piston won't extend"));
+			}
+		}
+		event.setCanceled(event.world.getBlockState(event.pos.offset(event.facing)).getBlock() == Blocks.cobblestone);
+	}
+
+	@SubscribeEvent
+	public void onPistonRetract(PistonEvent.PistonRetractEvent event) {
+		if (!event.world.isRemote) {
+			for (EntityPlayer player : event.world.playerEntities) {
+				boolean isSticky = event.world.getBlockState(event.pos).getValue(BlockPistonExtension.TYPE) == EnumPistonType.STICKY;
+				if (isSticky) {
+					BlockPistonStructureHelper pistonHelper =
+							new BlockPistonStructureHelper(event.world, event.pos, event.facing, false);
+					if (pistonHelper.canMove())
+						player.addChatMessage(new ChatComponentText(String.format("Piston will retract moving %d blocks and destroy %d blocks",
+								pistonHelper.getBlocksToMove().size(), pistonHelper.getBlocksToDestroy().size())));
+					else
+						player.addChatMessage(new ChatComponentText("Piston won't retract"));
+				} else {
+					player.addChatMessage(new ChatComponentText("Piston will retract"));
+				}
+			}
+		}
+		event.setCanceled(event.world.getBlockState(event.pos.offset(event.facing, 2)).getBlock() == Blocks.cobblestone);
+	}
+}


### PR DESCRIPTION
…piston being extended/retracted. Cancel the event to prevent the movement of blocks.

This is based on #1549, except that I changed the position from where the event is fired. In #1549, because of the way the extension/retraction of slime blocks is handled, the event was being called multiple times per operation. The event in this PR is called only once per piston that its moving. It also includes a small debug mod that tests the usage of the event.
