### PR TITLE
Added TileEntityEvent.LoadNBTEvent and SaveNBTEvent.

### DIFF
--- a/patches/minecraft/net/minecraft/world/chunk/storage/AnvilChunkLoader.java.patch
+++ b/patches/minecraft/net/minecraft/world/chunk/storage/AnvilChunkLoader.java.patch
@@ -150,13 +150,14 @@
              }
          }
  
-@@ -303,8 +377,17 @@
+@@ -303,8 +377,18 @@
          {
              TileEntity tileentity = (TileEntity)iterator.next();
              nbttagcompound1 = new NBTTagCompound();
 +            try
 +            {
              tileentity.func_145841_b(nbttagcompound1);
++            nbttagcompound1 = net.minecraftforge.event.ForgeEventFactory.onTileEntitySaved(tileentity, nbttagcompound1);
              nbttaglist2.func_74742_a(nbttagcompound1);
 +            }
 +            catch (Exception e)
@@ -168,7 +169,7 @@
          }
  
          p_75820_3_.func_74782_a("TileEntities", nbttaglist2);
-@@ -386,6 +469,12 @@
+@@ -386,6 +470,12 @@
              chunk.func_76616_a(p_75823_2_.func_74770_j("Biomes"));
          }
  
@@ -181,7 +182,18 @@
          NBTTagList nbttaglist1 = p_75823_2_.func_150295_c("Entities", 10);
  
          if (nbttaglist1 != null)
-@@ -457,8 +546,6 @@
+@@ -425,7 +515,9 @@
+             {
+                 NBTTagCompound nbttagcompound3 = nbttaglist2.func_150305_b(j2);
+                 TileEntity tileentity = TileEntity.func_145827_c(nbttagcompound3);
+-
++                
++                net.minecraftforge.event.ForgeEventFactory.onTileEntityLoaded(tileentity, tileentity.getTileData());
++                
+                 if (tileentity != null)
+                 {
+                     chunk.func_150813_a(tileentity);
+@@ -457,8 +549,6 @@
                  }
              }
          }

--- a/src/main/java/net/minecraftforge/event/ForgeEventFactory.java
+++ b/src/main/java/net/minecraftforge/event/ForgeEventFactory.java
@@ -20,6 +20,8 @@ import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.entity.player.EntityPlayer.EnumStatus;
 import net.minecraft.init.Blocks;
 import net.minecraft.item.ItemStack;
+import net.minecraft.nbt.NBTTagCompound;
+import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.BlockPos;
 import net.minecraft.util.DamageSource;
 import net.minecraft.util.EnumFacing;
@@ -432,6 +434,18 @@ public class ForgeEventFactory
     public static boolean onCreateWorldSpawn(World world, WorldSettings settings)
     {
         return MinecraftForge.EVENT_BUS.post(new WorldEvent.CreateSpawnPosition(world, settings));
+    }
+
+    public static void onTileEntityLoaded(TileEntity tileEntity, NBTTagCompound teTagCompound)
+    {
+    	MinecraftForge.EVENT_BUS.post(new TileEntityEvent.LoadNBTEvent(tileEntity, teTagCompound));
+    }
+
+    public static NBTTagCompound onTileEntitySaved(TileEntity tileEntity, NBTTagCompound teTagCompound)
+    {
+        TileEntityEvent.SaveNBTEvent event = new TileEntityEvent.SaveNBTEvent(tileEntity, teTagCompound);
+        MinecraftForge.EVENT_BUS.post(event);
+        return event.tileEntityNBT;
     }
 
     public static float onLivingHeal(EntityLivingBase entity, float amount)

--- a/src/main/java/net/minecraftforge/event/world/TileEntityEvent.java
+++ b/src/main/java/net/minecraftforge/event/world/TileEntityEvent.java
@@ -1,0 +1,53 @@
+package net.minecraftforge.event.world;
+
+import net.minecraft.nbt.NBTTagCompound;
+import net.minecraft.tileentity.TileEntity;
+import net.minecraftforge.fml.common.eventhandler.Event;
+import net.minecraftforge.fml.common.eventhandler.Event.HasResult;
+
+public class TileEntityEvent extends Event
+{
+    public final TileEntity tileEntity;
+    public TileEntityEvent(TileEntity tileEntity)
+    {
+        this.tileEntity = tileEntity;
+    }
+
+    /**
+     * Called whenever a TileEntity's NBTTagCompound is read from. <br>
+     * <br>
+     * This event is not {@link Cancelable}.<br>
+     * <br>
+     * This event does not have a result. {@link HasResult} <br>
+     * <br>
+     * This event is fired on the {@link MinecraftForge#EVENT_BUS}.<br>
+     **/
+    public static class LoadNBTEvent extends TileEntityEvent
+    {
+    	public final NBTTagCompound tileEntityNBT;
+        public LoadNBTEvent(TileEntity tileEntity, NBTTagCompound tileEntityNBT)
+        {
+            super(tileEntity);
+            this.tileEntityNBT = tileEntityNBT;
+        }
+    }
+
+    /**
+     * Called whenever a TileEntity's NBTTagCompound is about to be saved. <br>
+     * <br>
+     * This event is not {@link Cancelable}.<br>
+     * <br>
+     * This event does not have a result. {@link HasResult} <br>
+     * <br>
+     * This event is fired on the {@link MinecraftForge#EVENT_BUS}.<br>
+     **/
+    public static class SaveNBTEvent extends TileEntityEvent
+    {
+    	public final NBTTagCompound tileEntityNBT;
+        public SaveNBTEvent(TileEntity tileEntity, NBTTagCompound tileEntityNBT)
+        {
+            super(tileEntity);
+            this.tileEntityNBT = tileEntityNBT;
+        }
+    }
+}


### PR DESCRIPTION
This adds two events for TileEntities, LoadNBTEvent and SaveNBTEvent. LoadNBTEvent is called when a TileEntity is loaded, SaveNBTEvent is called when a TileEntity is saved. I thought this could possibly be useful for APIs, but I'm sure there are other uses for it as well. Here's a simple example I uploaded to pastebin: http://pastebin.com/trcvAcwJ

Basically, you'll be able to modify/add stuff to a TileEntity's NBTTagCompound without actually having to override readFromNBT() and writeFromNBT(). (obviously, in this example, it would be quite easy for me to do so, but again, it's just an example.)