### PR TITLE
Change EntityMountEvent to handle only mounting. Adds EntityDismountEvent

### DIFF
--- a/src/main/java/net/minecraftforge/event/ForgeEventFactory.java
+++ b/src/main/java/net/minecraftforge/event/ForgeEventFactory.java
@@ -35,6 +35,7 @@ import net.minecraftforge.client.event.RenderBlockOverlayEvent.OverlayType;
 import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.common.util.BlockSnapshot;
 import net.minecraftforge.event.brewing.PotionBrewEvent;
+import net.minecraftforge.event.entity.EntityDismountEvent;
 import net.minecraftforge.event.entity.EntityEvent;
 import net.minecraftforge.event.entity.EntityMountEvent;
 import net.minecraftforge.event.entity.EntityStruckByLightningEvent;
@@ -365,7 +366,9 @@ public class ForgeEventFactory
     
     public static boolean canMountEntity(Entity entityMounting, Entity entityBeingMounted, boolean isMounting)
     {
-        boolean isCanceled = MinecraftForge.EVENT_BUS.post(new EntityMountEvent(entityMounting, entityBeingMounted, entityMounting.worldObj, isMounting));
+        boolean isCanceled = isMounting ?
+            MinecraftForge.EVENT_BUS.post(new EntityMountEvent(entityMounting, entityBeingMounted, entityMounting.worldObj)) :
+            MinecraftForge.EVENT_BUS.post(new EntityDismountEvent(entityMounting, entityBeingMounted, entityMounting.worldObj));
         
         if(isCanceled)
         {

--- a/src/main/java/net/minecraftforge/event/entity/EntityDismountEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/EntityDismountEvent.java
@@ -3,15 +3,14 @@ package net.minecraftforge.event.entity;
 import net.minecraft.entity.Entity;
 import net.minecraft.world.World;
 import net.minecraftforge.fml.common.eventhandler.Cancelable;
-import net.minecraftforge.fml.common.eventhandler.Event.HasResult;
 
 /**
- * This event gets fired whenever a entity mounts another entity.<br>
+ * This event gets fired whenever a entity dismounts another entity.<br>
  * <b>entityBeingMounted can be null</b>, be sure to check for that.
  * <br>
  * <br>
  * This event is {@link Cancelable}.<br>
- * If this event is canceled, the entity does not mount the other entity.<br>
+ * If this event is canceled, the entity does not dismount the other entity.<br>
  * <br>
  * This event does not have a result. {@link HasResult}<br>
  *<br>
@@ -20,14 +19,14 @@ import net.minecraftforge.fml.common.eventhandler.Event.HasResult;
  */
 
 @Cancelable
-public class EntityMountEvent extends EntityEvent
+public class EntityDismountEvent extends EntityEvent
 {
-    
+
     public final Entity entityMounting;
     public final Entity entityBeingMounted;
     public final World worldObj;
 
-    public EntityMountEvent(Entity entityMounting, Entity entityBeingMounted, World entityWorld)
+    public EntityDismountEvent(Entity entityMounting, Entity entityBeingMounted, World entityWorld)
     {
         super(entityMounting);
         this.entityMounting = entityMounting;


### PR DESCRIPTION
This separates mounting from dismounting to eliminate boilerplate code for `isMounting()`/`isDismounting()` where it's two separate classes, eliminating boilerplate code even further.