### PR TITLE
Added doesSideBlockRendering to provide finer grain face culling.

### DIFF
--- a/patches/minecraft/net/minecraft/block/Block.java.patch
+++ b/patches/minecraft/net/minecraft/block/Block.java.patch
@@ -69,6 +69,15 @@
          }
          else
          {
+@@ -376,7 +382,7 @@
+     @SideOnly(Side.CLIENT)
+     public boolean func_176225_a(IBlockAccess p_176225_1_, BlockPos p_176225_2_, EnumFacing p_176225_3_)
+     {
+-        return p_176225_3_ == EnumFacing.DOWN && this.field_149760_C > 0.0D ? true : (p_176225_3_ == EnumFacing.UP && this.field_149756_F < 1.0D ? true : (p_176225_3_ == EnumFacing.NORTH && this.field_149754_D > 0.0D ? true : (p_176225_3_ == EnumFacing.SOUTH && this.field_149757_G < 1.0D ? true : (p_176225_3_ == EnumFacing.WEST && this.field_149759_B > 0.0D ? true : (p_176225_3_ == EnumFacing.EAST && this.field_149755_E < 1.0D ? true : !p_176225_1_.func_180495_p(p_176225_2_).func_177230_c().func_149662_c())))));
++        return p_176225_3_ == EnumFacing.DOWN && this.field_149760_C > 0.0D ? true : (p_176225_3_ == EnumFacing.UP && this.field_149756_F < 1.0D ? true : (p_176225_3_ == EnumFacing.NORTH && this.field_149754_D > 0.0D ? true : (p_176225_3_ == EnumFacing.SOUTH && this.field_149757_G < 1.0D ? true : (p_176225_3_ == EnumFacing.WEST && this.field_149759_B > 0.0D ? true : (p_176225_3_ == EnumFacing.EAST && this.field_149755_E < 1.0D ? true : !p_176225_1_.func_180495_p(p_176225_2_).func_177230_c().doesSideBlockRendering(p_176225_1_, p_176225_2_, p_176225_3_))))));
+     }
+ 
+     public boolean func_176212_b(IBlockAccess p_176212_1_, BlockPos p_176212_2_, EnumFacing p_176212_3_)
 @@ -453,6 +459,10 @@
  
      public void func_180663_b(World p_180663_1_, BlockPos p_180663_2_, IBlockState p_180663_3_)
@@ -179,7 +188,7 @@
      }
  
      protected ItemStack func_180643_i(IBlockState p_180643_1_)
-@@ -1010,6 +1030,1029 @@
+@@ -1010,6 +1030,1045 @@
          return "Block{" + field_149771_c.func_177774_c(this) + "}";
      }
  
@@ -227,6 +236,22 @@
 +    public boolean isNormalCube(IBlockAccess world, BlockPos pos)
 +    {
 +        return func_149688_o().func_76218_k() && func_149686_d() && !func_149744_f();
++    }
++
++    /**
++     * Check if the face of a block should block rendering.
++     * 
++     * Faces which are fully opaque should return true, faces with transparency
++     * or faces which do not span the full size of the block should return false.
++     * 
++     * @param world The current world
++     * @param pos Block position in world
++     * @param side The side to check
++     * @return True if the block is opaque on the specified side.
++     */
++    public boolean doesSideBlockRendering(IBlockAccess world, BlockPos pos, EnumFacing face)
++    {
++        return func_149662_c();
 +    }
 +
 +    /**

--- a/patches/minecraft/net/minecraft/block/BlockSlab.java.patch
+++ b/patches/minecraft/net/minecraft/block/BlockSlab.java.patch
@@ -1,0 +1,38 @@
+--- ../src-base/minecraft/net/minecraft/block/BlockSlab.java
++++ ../src-work/minecraft/net/minecraft/block/BlockSlab.java
+@@ -91,6 +91,17 @@
+         return this.func_176552_j();
+     }
+ 
++    @Override
++    public boolean doesSideBlockRendering(IBlockAccess world, BlockPos pos, EnumFacing face)
++	{
++        if ( func_149662_c() )
++            return true;
++        
++        // face is on the block being rendered, not this block.
++        EnumBlockHalf side = world.func_180495_p(pos).func_177229_b(field_176554_a);
++        return (side == EnumBlockHalf.TOP && face == EnumFacing.DOWN) || (side == EnumBlockHalf.BOTTOM && face == EnumFacing.UP);
++    }
++
+     public IBlockState func_180642_a(World p_180642_1_, BlockPos p_180642_2_, EnumFacing p_180642_3_, float p_180642_4_, float p_180642_5_, float p_180642_6_, int p_180642_7_, EntityLivingBase p_180642_8_)
+     {
+         IBlockState iblockstate = super.func_180642_a(p_180642_1_, p_180642_2_, p_180642_3_, p_180642_4_, p_180642_5_, p_180642_6_, p_180642_7_, p_180642_8_).func_177226_a(field_176554_a, BlockSlab.EnumBlockHalf.BOTTOM);
+@@ -118,15 +129,8 @@
+         {
+             return false;
+         }
+-        else
+-        {
+-            BlockPos blockpos = p_176225_2_.func_177972_a(p_176225_3_.func_176734_d());
+-            IBlockState iblockstate = p_176225_1_.func_180495_p(p_176225_2_);
+-            IBlockState iblockstate1 = p_176225_1_.func_180495_p(blockpos);
+-            boolean flag = func_150003_a(iblockstate.func_177230_c()) && iblockstate.func_177229_b(field_176554_a) == BlockSlab.EnumBlockHalf.TOP;
+-            boolean flag1 = func_150003_a(iblockstate1.func_177230_c()) && iblockstate1.func_177229_b(field_176554_a) == BlockSlab.EnumBlockHalf.TOP;
+-            return flag1 ? (p_176225_3_ == EnumFacing.DOWN ? true : (p_176225_3_ == EnumFacing.UP && super.func_176225_a(p_176225_1_, p_176225_2_, p_176225_3_) ? true : !func_150003_a(iblockstate.func_177230_c()) || !flag)) : (p_176225_3_ == EnumFacing.UP ? true : (p_176225_3_ == EnumFacing.DOWN && super.func_176225_a(p_176225_1_, p_176225_2_, p_176225_3_) ? true : !func_150003_a(iblockstate.func_177230_c()) || flag));
+-        }
++        // additional logic breaks doesSideBlockRendering and is no longer useful.
++        return super.func_176225_a(p_176225_1_, p_176225_2_, p_176225_3_);
+     }
+ 
+     @SideOnly(Side.CLIENT)

--- a/patches/minecraft/net/minecraft/block/BlockStairs.java.patch
+++ b/patches/minecraft/net/minecraft/block/BlockStairs.java.patch
@@ -1,0 +1,22 @@
+--- ../src-base/minecraft/net/minecraft/block/BlockStairs.java
++++ ../src-work/minecraft/net/minecraft/block/BlockStairs.java
+@@ -68,6 +68,19 @@
+         return false;
+     }
+ 
++    @Override
++    public boolean doesSideBlockRendering(IBlockAccess world, BlockPos pos, EnumFacing face)
++	{
++        if ( func_149662_c() )
++            return true;
++        
++        // face is on the block being rendered, not this block.
++        IBlockState iblockstate = world.func_180495_p(pos);
++        EnumHalf half = iblockstate.func_177229_b(field_176308_b);
++        EnumFacing side = iblockstate.func_177229_b(field_176309_a);
++        return side == face.func_176734_d() || (half == EnumHalf.TOP && face == EnumFacing.DOWN) || (half == EnumHalf.BOTTOM && face == EnumFacing.UP);
++    }
++
+     public boolean func_149686_d()
+     {
+         return false;


### PR DESCRIPTION
By default calls isOpaqueCube which is the original behavior prior to this patch.

Patch allows a block to claim its own opaque sides rather then requiring all 6 faces to be opaque.