### PR TITLE
Add an ignore for any file that is contained in the JAVA_HOME directory.

### DIFF
--- a/src/main/java/net/minecraftforge/fml/common/ModClassLoader.java
+++ b/src/main/java/net/minecraftforge/fml/common/ModClassLoader.java
@@ -29,6 +29,7 @@ import net.minecraftforge.fml.common.discovery.ASMDataTable;
 
 import org.apache.logging.log4j.Level;
 
+import com.google.common.base.StandardSystemProperty;
 import com.google.common.collect.ImmutableList;
 
 /**
@@ -88,6 +89,7 @@ public class ModClassLoader extends URLClassLoader
 
     public boolean isDefaultLibrary(File file)
     {
+    	if (file.getAbsolutePath().startsWith(StandardSystemProperty.JAVA_HOME.value())) return true;
         // Should really pull this from the json somehow, but we dont have that at runtime.
         String name = file.getName();
         if (!name.endsWith(".jar")) return false;


### PR DESCRIPTION
I believe this will partially fix an issue where any jars included in the JAVA_HOME directory are being searched for mods by the ModClassLoader. PR'ing this to master for 1.8, though I can imagine this can be easily back ported for 1.7.10.

Relevant issue: #2249 
