### PR TITLE
[1.8.8] Minor Fixes to PotionEffect.java.patch

### DIFF
--- a/patches/minecraft/net/minecraft/potion/PotionEffect.java.patch
+++ b/patches/minecraft/net/minecraft/potion/PotionEffect.java.patch
@@ -57,16 +57,15 @@
 +     */
 +    public boolean isCurativeItem(net.minecraft.item.ItemStack stack)
 +    {
-+        boolean found = false;
 +        for (net.minecraft.item.ItemStack curativeItem : this.curativeItems)
 +        {
 +            if (curativeItem.func_77969_a(stack))
 +            {
-+                found = true;
++                return true;
 +            }
 +        }
 +
-+        return found;
++        return false;
 +    }
 +
 +    /***
@@ -84,15 +83,7 @@
 +     */
 +    public void addCurativeItem(net.minecraft.item.ItemStack stack)
 +    {
-+        boolean found = false;
-+        for (net.minecraft.item.ItemStack curativeItem : this.curativeItems)
-+        {
-+            if (curativeItem.func_77969_a(stack))
-+            {
-+                found = true;
-+            }
-+        }
-+        if (!found)
++        if (!this.isCurativeItem(stack))
 +        {
 +            this.curativeItems.add(stack);
 +        }


### PR DESCRIPTION
PR to branch 1.8.8 of https://github.com/MinecraftForge/MinecraftForge/pull/2265
Prevents the whole loop from running if a matching item has been found, as well as replacing duplicate code with a method call