### PR TITLE
Give InitMapGenEvent a World object

### DIFF
--- a/patches/minecraft/net/minecraft/world/gen/ChunkProviderGenerate.java.patch
+++ b/patches/minecraft/net/minecraft/world/gen/ChunkProviderGenerate.java.patch
@@ -5,13 +5,13 @@
      public ChunkProviderGenerate(World p_i45636_1_, long p_i45636_2_, boolean p_i45636_4_, String p_i45636_5_)
      {
 +        {
-+            field_73226_t = net.minecraftforge.event.terraingen.TerrainGen.getModdedMapGen(field_73226_t, net.minecraftforge.event.terraingen.InitMapGenEvent.EventType.CAVE);
-+            field_73225_u = (MapGenStronghold)net.minecraftforge.event.terraingen.TerrainGen.getModdedMapGen(field_73225_u, net.minecraftforge.event.terraingen.InitMapGenEvent.EventType.STRONGHOLD);
-+            field_73224_v = (MapGenVillage)net.minecraftforge.event.terraingen.TerrainGen.getModdedMapGen(field_73224_v, net.minecraftforge.event.terraingen.InitMapGenEvent.EventType.VILLAGE);
-+            field_73223_w = (MapGenMineshaft)net.minecraftforge.event.terraingen.TerrainGen.getModdedMapGen(field_73223_w, net.minecraftforge.event.terraingen.InitMapGenEvent.EventType.MINESHAFT);
-+            field_73233_x = (MapGenScatteredFeature)net.minecraftforge.event.terraingen.TerrainGen.getModdedMapGen(field_73233_x, net.minecraftforge.event.terraingen.InitMapGenEvent.EventType.SCATTERED_FEATURE);
-+            field_73232_y = net.minecraftforge.event.terraingen.TerrainGen.getModdedMapGen(field_73232_y, net.minecraftforge.event.terraingen.InitMapGenEvent.EventType.RAVINE);
-+            field_177474_A = (StructureOceanMonument)net.minecraftforge.event.terraingen.TerrainGen.getModdedMapGen(field_177474_A, net.minecraftforge.event.terraingen.InitMapGenEvent.EventType.OCEAN_MONUMENT);
++            field_73226_t = net.minecraftforge.event.terraingen.TerrainGen.getModdedMapGen(field_73226_t, net.minecraftforge.event.terraingen.InitMapGenEvent.EventType.CAVE, p_i45636_1_);
++            field_73225_u = (MapGenStronghold)net.minecraftforge.event.terraingen.TerrainGen.getModdedMapGen(field_73225_u, net.minecraftforge.event.terraingen.InitMapGenEvent.EventType.STRONGHOLD, p_i45636_1_);
++            field_73224_v = (MapGenVillage)net.minecraftforge.event.terraingen.TerrainGen.getModdedMapGen(field_73224_v, net.minecraftforge.event.terraingen.InitMapGenEvent.EventType.VILLAGE, p_i45636_1_);
++            field_73223_w = (MapGenMineshaft)net.minecraftforge.event.terraingen.TerrainGen.getModdedMapGen(field_73223_w, net.minecraftforge.event.terraingen.InitMapGenEvent.EventType.MINESHAFT, p_i45636_1_);
++            field_73233_x = (MapGenScatteredFeature)net.minecraftforge.event.terraingen.TerrainGen.getModdedMapGen(field_73233_x, net.minecraftforge.event.terraingen.InitMapGenEvent.EventType.SCATTERED_FEATURE, p_i45636_1_);
++            field_73232_y = net.minecraftforge.event.terraingen.TerrainGen.getModdedMapGen(field_73232_y, net.minecraftforge.event.terraingen.InitMapGenEvent.EventType.RAVINE, p_i45636_1_);
++            field_177474_A = (StructureOceanMonument)net.minecraftforge.event.terraingen.TerrainGen.getModdedMapGen(field_177474_A, net.minecraftforge.event.terraingen.InitMapGenEvent.EventType.OCEAN_MONUMENT, p_i45636_1_);
 +        }
          this.field_73230_p = p_i45636_1_;
          this.field_73229_q = p_i45636_4_;

--- a/patches/minecraft/net/minecraft/world/gen/ChunkProviderHell.java.patch
+++ b/patches/minecraft/net/minecraft/world/gen/ChunkProviderHell.java.patch
@@ -15,8 +15,8 @@
  
      public ChunkProviderHell(World p_i45637_1_, boolean p_i45637_2_, long p_i45637_3_)
      {
-+        this.field_73172_c = (MapGenNetherBridge) net.minecraftforge.event.terraingen.TerrainGen.getModdedMapGen(new MapGenNetherBridge(), net.minecraftforge.event.terraingen.InitMapGenEvent.EventType.NETHER_BRIDGE);
-+        this.field_73182_t = net.minecraftforge.event.terraingen.TerrainGen.getModdedMapGen(new MapGenCavesHell(), net.minecraftforge.event.terraingen.InitMapGenEvent.EventType.NETHER_CAVE);
++        this.field_73172_c = (MapGenNetherBridge) net.minecraftforge.event.terraingen.TerrainGen.getModdedMapGen(new MapGenNetherBridge(), net.minecraftforge.event.terraingen.InitMapGenEvent.EventType.NETHER_BRIDGE, p_i45637_1_);
++        this.field_73182_t = net.minecraftforge.event.terraingen.TerrainGen.getModdedMapGen(new MapGenCavesHell(), net.minecraftforge.event.terraingen.InitMapGenEvent.EventType.NETHER_CAVE, p_i45637_1_);
          this.field_73175_o = p_i45637_1_;
          this.field_177466_i = p_i45637_2_;
          this.field_73181_i = new Random(p_i45637_3_);

--- a/src/main/java/net/minecraftforge/event/terraingen/InitMapGenEvent.java
+++ b/src/main/java/net/minecraftforge/event/terraingen/InitMapGenEvent.java
@@ -1,7 +1,8 @@
 package net.minecraftforge.event.terraingen;
 
-import net.minecraftforge.fml.common.eventhandler.Event;
+import net.minecraft.world.World;
 import net.minecraft.world.gen.MapGenBase;
+import net.minecraftforge.fml.common.eventhandler.Event;
 
 public class InitMapGenEvent extends Event
 {
@@ -12,11 +13,13 @@ public class InitMapGenEvent extends Event
     public final EventType type;
     public final MapGenBase originalGen;
     public MapGenBase newGen;
+    public final World worldObj;
 
-    InitMapGenEvent(EventType type, MapGenBase original)
+    InitMapGenEvent(EventType type, MapGenBase original, World worldObj)
     {
         this.type = type;
         this.originalGen = original;
         this.newGen = original;
+        this.worldObj = worldObj;
     }
 }

--- a/src/main/java/net/minecraftforge/event/terraingen/TerrainGen.java
+++ b/src/main/java/net/minecraftforge/event/terraingen/TerrainGen.java
@@ -22,9 +22,9 @@ public abstract class TerrainGen
         return event.newNoiseGens;
     }
 
-    public static MapGenBase getModdedMapGen(MapGenBase original, InitMapGenEvent.EventType type)
+    public static MapGenBase getModdedMapGen(MapGenBase original, InitMapGenEvent.EventType type, World worldObj)
     {
-        InitMapGenEvent event = new InitMapGenEvent(type, original);
+        InitMapGenEvent event = new InitMapGenEvent(type, original, worldObj);
         MinecraftForge.TERRAIN_GEN_BUS.post(event);
         return event.newGen;
     }


### PR DESCRIPTION
Add World object to InitMapGenEvent to allow for mods to modify/replace map gens based on dimension.
