### PR TITLE
Make WorldRendererConsumer.put respect WorldRenderer.noColor.

### DIFF
--- a/patches/minecraft/net/minecraft/client/renderer/BlockModelRenderer.java.patch
+++ b/patches/minecraft/net/minecraft/client/renderer/BlockModelRenderer.java.patch
@@ -1,5 +1,14 @@
 --- ../src-base/minecraft/net/minecraft/client/renderer/BlockModelRenderer.java
 +++ ../src-work/minecraft/net/minecraft/client/renderer/BlockModelRenderer.java
+@@ -32,7 +32,7 @@
+ 
+     public boolean func_178267_a(IBlockAccess p_178267_1_, IBakedModel p_178267_2_, IBlockState p_178267_3_, BlockPos p_178267_4_, WorldRenderer p_178267_5_, boolean p_178267_6_)
+     {
+-        boolean flag = Minecraft.func_71379_u() && p_178267_3_.func_177230_c().func_149750_m() == 0 && p_178267_2_.func_177555_b();
++        boolean flag = Minecraft.func_71379_u() && p_178267_3_.func_177230_c().func_149750_m() == 0 && p_178267_2_.func_177555_b() && !p_178267_5_.isNoColor();
+ 
+         try
+         {
 @@ -533,8 +533,19 @@
      @SideOnly(Side.CLIENT)
      public static enum EnumNeighborInfo

--- a/patches/minecraft/net/minecraft/client/renderer/WorldRenderer.java.patch
+++ b/patches/minecraft/net/minecraft/client/renderer/WorldRenderer.java.patch
@@ -1,6 +1,14 @@
 --- ../src-base/minecraft/net/minecraft/client/renderer/WorldRenderer.java
 +++ ../src-work/minecraft/net/minecraft/client/renderer/WorldRenderer.java
-@@ -578,6 +578,11 @@
+@@ -351,6 +351,7 @@
+     {
+         this.field_78939_q = true;
+     }
++    public boolean isNoColor() { return field_78939_q; }
+ 
+     public WorldRenderer func_181666_a(float p_181666_1_, float p_181666_2_, float p_181666_3_, float p_181666_4_)
+     {
+@@ -578,6 +579,11 @@
          }
      }
  

--- a/src/main/java/net/minecraftforge/client/model/pipeline/WorldRendererConsumer.java
+++ b/src/main/java/net/minecraftforge/client/model/pipeline/WorldRendererConsumer.java
@@ -4,6 +4,7 @@ import java.util.Arrays;
 
 import net.minecraft.client.renderer.WorldRenderer;
 import net.minecraft.client.renderer.vertex.VertexFormat;
+import net.minecraft.client.renderer.vertex.VertexFormatElement.EnumUsage;
 import net.minecraft.util.BlockPos;
 import net.minecraft.util.EnumFacing;
 
@@ -31,6 +32,8 @@ public class WorldRendererConsumer implements IVertexConsumer
 
     public void put(int e, float... data)
     {
+        if (renderer.isNoColor() && getVertexFormat().getElement(e).getUsage() == EnumUsage.COLOR)
+            Arrays.fill(data, 1);
         LightUtil.pack(data, quadData, getVertexFormat(), v, e);
         if(e == getVertexFormat().getElementCount() - 1)
         {


### PR DESCRIPTION
The Forge lighting system currently bypasses the WorldRenderer code to prevent applying colors if its field ("needsUpdate" which should be "noColor") is true. Adding a call to putColorMultiplier for each vertex with a multiplier of [1.0, 1.0, 1.0] causes it to put all one bits in the color data for the vertex, just as vanilla does.

This fixes several issues with the Forge lighting enabled, where the destroy textures on blocks would appear darkened or colored, due to ambient occlusion and the block's tints.

Without Forge lighting:
<img src="http://i.imgur.com/BCe9EI9.png"/>
With:
<img src="http://i.imgur.com/wg10p2f.png"/>

This fix could be applied in WorldRenderer.addVertexData instead, but that may not be preferable as it will affect other code. The fix could <i>also</i> be done by filling the color elements with 1.0 when they are added by WorldRendererConsumer.put, but this requires access to the noColor field (whether through adding a getter, AT, or reflection).