### PR TITLE
Fix client side command auto-complete not working correctly.

### DIFF
--- a/patches/minecraft/net/minecraft/client/gui/GuiChat.java.patch
+++ b/patches/minecraft/net/minecraft/client/gui/GuiChat.java.patch
@@ -29,3 +29,11 @@
              for (String s : p_146406_1_)
              {
                  if (s.length() > 0)
+@@ -291,6 +298,7 @@
+ 
+             String s1 = this.field_146415_a.func_146179_b().substring(this.field_146415_a.func_146197_a(-1, this.field_146415_a.func_146198_h(), false));
+             String s2 = StringUtils.getCommonPrefix(p_146406_1_);
++            s2 = net.minecraft.util.EnumChatFormatting.func_110646_a(s2);
+ 
+             if (s2.length() > 0 && !s1.equalsIgnoreCase(s2))
+             {

--- a/src/test/java/net/minecraftforge/test/ClientCommandTest.java
+++ b/src/test/java/net/minecraftforge/test/ClientCommandTest.java
@@ -1,0 +1,68 @@
+package net.minecraftforge.test;
+
+import java.util.Arrays;
+import java.util.List;
+
+import net.minecraft.command.CommandBase;
+import net.minecraft.command.CommandException;
+import net.minecraft.command.ICommandSender;
+import net.minecraft.util.BlockPos;
+import net.minecraft.util.ChatComponentText;
+import net.minecraftforge.client.ClientCommandHandler;
+import net.minecraftforge.fml.common.Mod;
+import net.minecraftforge.fml.common.Mod.EventHandler;
+import net.minecraftforge.fml.common.event.FMLInitializationEvent;
+import net.minecraftforge.fml.common.registry.GameData;
+
+@Mod(modid="clientcommandtest", name="Client Command Test", version="0.0.0")
+public class ClientCommandTest {
+    @EventHandler
+    public void init(FMLInitializationEvent event)
+    {
+        ClientCommandHandler.instance.registerCommand(new TestCommand());
+    }
+
+    private class TestCommand extends CommandBase {
+        @Override
+        public String getCommandName()
+        {
+            return "clientCommandTest";
+        }
+
+        @Override
+        public String getCommandUsage(ICommandSender sender)
+        {
+            return "clientCommandTest <block>";
+        }
+
+        @Override
+        public boolean canCommandSenderUseCommand(ICommandSender sender)
+        {
+            return true;
+        }
+
+        @Override
+        public List<String> addTabCompletionOptions(ICommandSender sender, String[] args, BlockPos pos)
+        {
+            if (args.length > 0)
+            {
+                return getListOfStringsMatchingLastWord(args, GameData.getBlockRegistry().getKeys());
+            }
+
+            return null;
+        }
+
+        @Override
+        public void processCommand(ICommandSender sender, String[] args) throws CommandException
+        {
+            if (args.length > 0)
+            {
+                sender.addChatMessage(new ChatComponentText("Input: " + Arrays.toString(args)));
+            }
+            else
+            {
+                sender.addChatMessage(new ChatComponentText("No arguments."));
+            }
+        }
+    }
+}


### PR DESCRIPTION
It appears that vanilla changed the way auto-completion is handled (the text is written into the input field in different parts of the code), requiring an additional stripping of the gray/reset color codes.