### PR TITLE
Added getters for width and height to ShapedOreRecipe

### DIFF
--- a/src/main/java/net/minecraftforge/oredict/ShapedOreRecipe.java
+++ b/src/main/java/net/minecraftforge/oredict/ShapedOreRecipe.java
@@ -157,6 +157,12 @@ public class ShapedOreRecipe implements IRecipe
 
     @Override
     public int getRecipeSize(){ return input.length; }
+    
+    @Override
+    public int getWidth(){ return width; }
+    
+    @Override
+    public int getHeight(){ return height; }
 
     @Override
     public ItemStack getRecipeOutput(){ return output; }


### PR DESCRIPTION
Added getters for width and height to ShapedOreRecipe
# Reason
A Mod should be able to analyze recipes (and possibly add its own versions of them). While this is not the cleanest type of design (for example, load order of mods becomes important), it is certainly useful when the capabilities of the OreDictionary are not sufficient.

To create a modified version of a recipe, you need a way to obtain its width and height (both are protected).