### PR TITLE
Add event for main client world change.

### DIFF
--- a/patches/minecraft/net/minecraft/client/Minecraft.java.patch
+++ b/patches/minecraft/net/minecraft/client/Minecraft.java.patch
@@ -271,16 +271,17 @@
          this.field_71453_ak = networkmanager;
      }
  
-@@ -2197,6 +2241,8 @@
+@@ -2197,6 +2241,9 @@
  
      public void func_71353_a(WorldClient p_71353_1_, String p_71353_2_)
      {
 +        if (field_71441_e != null) net.minecraftforge.common.MinecraftForge.EVENT_BUS.post(new net.minecraftforge.event.world.WorldEvent.Unload(field_71441_e));
++        p_71353_2_ = net.minecraftforge.client.ForgeHooksClient.onClientWorldChanged(field_71441_e, p_71353_1_, p_71353_2_);
 +
          if (p_71353_1_ == null)
          {
              NetHandlerPlayClient nethandlerplayclient = this.func_147114_u();
-@@ -2210,6 +2256,18 @@
+@@ -2210,6 +2257,18 @@
              {
                  this.field_71437_Z.func_71263_m();
                  this.field_71437_Z.func_175592_a();
@@ -299,7 +300,7 @@
              }
  
              this.field_71437_Z = null;
-@@ -2232,6 +2290,7 @@
+@@ -2232,6 +2291,7 @@
              this.field_71456_v.func_181029_i();
              this.func_71351_a((ServerData)null);
              this.field_71455_al = false;
@@ -307,7 +308,7 @@
          }
  
          this.field_147127_av.func_147690_c();
-@@ -2336,126 +2395,10 @@
+@@ -2336,126 +2396,10 @@
          if (this.field_71476_x != null)
          {
              boolean flag = this.field_71439_g.field_71075_bZ.field_75098_d;
@@ -436,7 +437,7 @@
              if (flag)
              {
                  int j = this.field_71439_g.field_71069_bz.field_75151_b.size() - 9 + inventoryplayer.field_70461_c;
-@@ -2756,18 +2699,8 @@
+@@ -2756,18 +2700,8 @@
  
      public static int func_71369_N()
      {
@@ -457,7 +458,7 @@
      }
  
      public boolean func_70002_Q()
-@@ -2924,9 +2857,9 @@
+@@ -2924,9 +2858,9 @@
                          {
                              this.func_147108_a(new GuiYesNo(new GuiYesNoCallback()
                              {

--- a/src/main/java/net/minecraftforge/client/ForgeHooksClient.java
+++ b/src/main/java/net/minecraftforge/client/ForgeHooksClient.java
@@ -23,6 +23,7 @@ import net.minecraft.client.gui.FontRenderer;
 import net.minecraft.client.gui.GuiMainMenu;
 import net.minecraft.client.gui.GuiScreen;
 import net.minecraft.client.model.ModelBiped;
+import net.minecraft.client.multiplayer.WorldClient;
 import net.minecraft.client.renderer.EntityRenderer;
 import net.minecraft.client.renderer.GlStateManager;
 import net.minecraft.client.renderer.OpenGlHelper;
@@ -60,15 +61,7 @@ import net.minecraft.util.MovingObjectPosition;
 import net.minecraft.world.IBlockAccess;
 import net.minecraft.world.World;
 import net.minecraft.world.biome.BiomeGenBase;
-import net.minecraftforge.client.event.DrawBlockHighlightEvent;
-import net.minecraftforge.client.event.EntityViewRenderEvent;
-import net.minecraftforge.client.event.FOVUpdateEvent;
-import net.minecraftforge.client.event.GuiScreenEvent;
-import net.minecraftforge.client.event.ModelBakeEvent;
-import net.minecraftforge.client.event.MouseEvent;
-import net.minecraftforge.client.event.RenderHandEvent;
-import net.minecraftforge.client.event.RenderWorldLastEvent;
-import net.minecraftforge.client.event.TextureStitchEvent;
+import net.minecraftforge.client.event.*;
 import net.minecraftforge.client.event.sound.PlaySoundEvent;
 import net.minecraftforge.client.model.IFlexibleBakedModel;
 import net.minecraftforge.client.model.IModelPart;
@@ -352,6 +345,13 @@ public class ForgeHooksClient
         ModelLoader loader = (ModelLoader)modelBakery;
         MinecraftForge.EVENT_BUS.post(new ModelBakeEvent(modelManager, modelRegistry, loader));
         loader.onPostBakeEvent(modelRegistry);
+    }
+
+    public static String onClientWorldChanged(WorldClient oldWorld, WorldClient newWorld, String loadingMessage)
+    {
+        ClientWorldChangedEvent event = new ClientWorldChangedEvent(oldWorld, newWorld, loadingMessage);
+        MinecraftForge.EVENT_BUS.post(event);
+        return event.loadingMessage;
     }
 
 	public static Matrix4f getMatrix(ItemTransformVec3f transform)

--- a/src/main/java/net/minecraftforge/client/event/ClientWorldChangedEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/ClientWorldChangedEvent.java
@@ -1,0 +1,38 @@
+package net.minecraftforge.client.event;
+
+import net.minecraft.client.multiplayer.WorldClient;
+import net.minecraft.world.World;
+import net.minecraftforge.fml.common.eventhandler.Event;
+
+/**
+ * <p>
+ * ClientWorldChangedEvent gets called whenever the main client world changes permanently for a session.
+ * </p>
+ * <p>
+ * The oldWorld field will contain the world we were previously in, or null if we weren't in a world before.
+ * The newWorld field will contain the world we're changing to, or null if we're quitting the world.
+ * The loadingMessage field contains the loading message and can be modified to display a custom message
+ * for clients when they're changing worlds. (Like how going to the nether used to work before)
+ * </p>
+ * <p>
+ * This event gets fired from {@link net.minecraft.client.Minecraft#loadWorld(WorldClient, String)}.
+ * </p>
+ * <p>
+ * <b>MODS THAT CHANGE THE WORLD:</b> If you change the world permanently for a session,
+ * be sure to call this event to let other mods know about the world change!
+ * Failing to do so can cause serious issues with mods relying on this event.
+ * </p>
+ */
+public class ClientWorldChangedEvent extends Event
+{
+    public final WorldClient oldWorld;
+    public final WorldClient newWorld;
+    public String loadingMessage;
+
+    public ClientWorldChangedEvent(WorldClient oldWorld, WorldClient newWorld, String loadingMessage)
+    {
+        this.oldWorld = oldWorld;
+        this.newWorld = newWorld;
+        this.loadingMessage = loadingMessage;
+    }
+}

--- a/src/test/java/net/minecraftforge/test/ClientWorldChangedTest.java
+++ b/src/test/java/net/minecraftforge/test/ClientWorldChangedTest.java
@@ -1,0 +1,49 @@
+package net.minecraftforge.test;
+
+import net.minecraftforge.client.event.ClientWorldChangedEvent;
+import net.minecraftforge.common.MinecraftForge;
+import net.minecraftforge.fml.common.Mod;
+import net.minecraftforge.fml.common.event.FMLInitializationEvent;
+import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
+
+@Mod(modid="clientworldchangedtest", name="Client World Changed Test", version="1.0")
+public class ClientWorldChangedTest
+{
+    @Mod.EventHandler
+    public void init(FMLInitializationEvent event)
+    {
+        MinecraftForge.EVENT_BUS.register(this);
+    }
+
+    @SubscribeEvent
+    public void onClientWorldChanged(ClientWorldChangedEvent event)
+    {
+        if (event.newWorld == null)
+        {
+            System.out.println("Client changed to null world");
+            if (event.oldWorld != null)
+            {
+                event.loadingMessage = "Disconnecting";
+            }
+        }
+        else
+        {
+            System.out.println("Client changed to dimension " + event.newWorld.provider.getDimensionName());
+            if (event.oldWorld == null)
+            {
+                event.loadingMessage = "Connecting to the server";
+            }
+            else
+            {
+                if (event.oldWorld.provider.getDepartMessage() != null)
+                {
+                    event.loadingMessage = event.oldWorld.provider.getDepartMessage();
+                }
+                else if (event.newWorld.provider.getWelcomeMessage() != null)
+                {
+                    event.loadingMessage = event.newWorld.provider.getWelcomeMessage();
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Adds an event that gets called when the client changes the world it is currently in.

Due to the location of the event call, it will get called when the client receives S01PacketJoinGame, or S07PacketRespawn with a different dimension ID than the current dimension. These should be all normal circumstances that the event gets called.

The event is useful for mods that require synchronizing data between server and client, where data needs to flow from client to server. Or for mods that are client-side only and can't rely on a server telling them they've connected to a new server.

Worth mentioning that the event also gets called with null parameters, such that you can know for sure that the main client world has been discarded rather than an arbitrary client world.
#### Why not use WorldEvent.Load and check for isRemote/instanceof WorldClient?

Because there are mods out there that will load other worlds that are marked as isRemote, without actually changing the player world (example: LookingGlass).
There are also mods that rely on WorldEvent.Load and isRemote for detecting client world change, but this method fails with mods like LookingGlass. For example, Journeymap (or maybe a different minimap mod) would change displayed world when a LookingGlass view was opened.

This event gets rid of the ambiguity of whether WorldEvent.Load is called with the new main client world, or just a helper world.
#### What needs to be done?
- For this PR, I'm contemplating splitting the event up in a Pre and Post version, but I'm unsure if it's needed.
- For mods, they should start relying on this event rather than the old ambiguous method. Any mod setting the world field permanently should also call this event (mods that temporarily change it for rendering purposes should however, not).
