### PR TITLE
Make AddPlayerData a static inner class

### DIFF
--- a/patches/minecraft/net/minecraft/network/play/server/S38PacketPlayerListItem.java.patch
+++ b/patches/minecraft/net/minecraft/network/play/server/S38PacketPlayerListItem.java.patch
@@ -1,0 +1,11 @@
+--- ../src-base/minecraft/net/minecraft/network/play/server/S38PacketPlayerListItem.java
++++ ../src-work/minecraft/net/minecraft/network/play/server/S38PacketPlayerListItem.java
+@@ -215,7 +215,7 @@
+         REMOVE_PLAYER;
+     }
+ 
+-    public class AddPlayerData
++    public static class AddPlayerData
+     {
+         private final int field_179966_b;
+         private final WorldSettings.GameType field_179967_c;


### PR DESCRIPTION
This changes `net.minecraft.network.play.server.S38PacketPlayerListItem.AddPlayerData` to be a `static` inner class, instead of a non-`static` inner class.

Currently, to construct `AddPlayerData` you require an instance of `S38PacketPlayerListItem`, which is not always available (ex: constructing entries (`AddPlayerData`) before constructing the `S38PacketPlayerListItem`; re-using copies of `AddPlayerData` in multiple packets; etc).
Now that the class is a static inner class, no instance of `S38PacketPlayerListItem` is required when constructing `AddPlayerData`.


The inner class does not access any instance members of its parent class (`S38PacketPlayerListItem`), so nothing vanilla-wise will break.