### PR TITLE
[1.8.9] Add EntityTravelToDimensionEvent

### DIFF
--- a/patches/minecraft/net/minecraft/entity/Entity.java.patch
+++ b/patches/minecraft/net/minecraft/entity/Entity.java.patch
@@ -131,7 +131,15 @@
      }
  
      public boolean func_70093_af()
-@@ -2092,7 +2146,7 @@
+@@ -2049,6 +2103,7 @@
+     {
+         if (!this.field_70170_p.field_72995_K && !this.field_70128_L)
+         {
++            if (!net.minecraftforge.common.ForgeHooks.onTravelToDimension(this, p_71027_1_)) return;
+             this.field_70170_p.field_72984_F.func_76320_a("changeDimension");
+             MinecraftServer minecraftserver = MinecraftServer.func_71276_C();
+             int i = this.field_71093_bK;
+@@ -2092,7 +2147,7 @@
  
      public float func_180428_a(Explosion p_180428_1_, World p_180428_2_, BlockPos p_180428_3_, IBlockState p_180428_4_)
      {
@@ -140,7 +148,7 @@
      }
  
      public boolean func_174816_a(Explosion p_174816_1_, World p_174816_2_, BlockPos p_174816_3_, IBlockState p_174816_4_, float p_174816_5_)
-@@ -2353,4 +2407,209 @@
+@@ -2353,4 +2408,209 @@
  
          EnchantmentHelper.func_151385_b(p_174815_1_, p_174815_2_);
      }

--- a/patches/minecraft/net/minecraft/entity/player/EntityPlayerMP.java.patch
+++ b/patches/minecraft/net/minecraft/entity/player/EntityPlayerMP.java.patch
@@ -72,7 +72,15 @@
  
              if (entitylist$entityegginfo != null)
              {
-@@ -831,6 +848,7 @@
+@@ -528,6 +545,7 @@
+ 
+     public void func_71027_c(int p_71027_1_)
+     {
++        if (!net.minecraftforge.common.ForgeHooks.onTravelToDimension(this, p_71027_1_)) return;
+         if (this.field_71093_bK == 1 && p_71027_1_ == 1)
+         {
+             this.func_71029_a(AchievementList.field_76003_C);
+@@ -831,6 +849,7 @@
      {
          if (p_71064_1_ != null)
          {

--- a/src/main/java/net/minecraftforge/common/ForgeHooks.java
+++ b/src/main/java/net/minecraftforge/common/ForgeHooks.java
@@ -26,6 +26,7 @@ import net.minecraft.client.gui.GuiScreen;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.entity.item.EntityItem;
+import net.minecraft.entity.item.EntityMinecartContainer;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraft.event.ClickEvent;
@@ -73,6 +74,7 @@ import net.minecraftforge.common.util.BlockSnapshot;
 import net.minecraftforge.event.AnvilUpdateEvent;
 import net.minecraftforge.event.ForgeEventFactory;
 import net.minecraftforge.event.ServerChatEvent;
+import net.minecraftforge.event.entity.EntityTravelToDimensionEvent;
 import net.minecraftforge.event.entity.item.ItemTossEvent;
 import net.minecraftforge.event.entity.living.LivingAttackEvent;
 import net.minecraftforge.event.entity.living.LivingDeathEvent;
@@ -905,5 +907,20 @@ public class ForgeHooks
         ItemStack stack = player.getCurrentEquippedItem();
         if (stack != null && stack.getItem().onLeftClickEntity(stack, player, target)) return false;
         return true;
+    }
+
+    public static boolean onTravelToDimension(Entity entity, int dimension)
+    {
+        EntityTravelToDimensionEvent event = new EntityTravelToDimensionEvent(entity, dimension);
+        MinecraftForge.EVENT_BUS.post(event);
+        if (event.isCanceled())
+        {
+            // Revert variable back to true as it would have been set to false
+            if (entity instanceof EntityMinecartContainer)
+            {
+               ((EntityMinecartContainer) entity).dropContentsWhenDead = true;
+            }
+        }
+        return !event.isCanceled();
     }
 }

--- a/src/main/java/net/minecraftforge/event/entity/EntityTravelToDimensionEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/EntityTravelToDimensionEvent.java
@@ -1,0 +1,29 @@
+package net.minecraftforge.event.entity;
+
+import net.minecraft.entity.Entity;
+import net.minecraftforge.fml.common.eventhandler.Cancelable;
+import net.minecraftforge.fml.common.eventhandler.Event.HasResult;
+
+/**
+ * EntityTravelToDimensionEvent is fired before an Entity travels to a dimension.<br>
+ * <br>
+ * {@link #dimension} contains the id of the dimension the entity is traveling to.<br>
+ * <br>
+ * This event is {@link Cancelable}.<br>
+ * If this event is canceled, the Entity does not travel to the dimension.<br>
+ * <br>
+ * This event does not have a result. {@link HasResult}<br>
+ * <br>
+ * This event is fired on the {@link MinecraftForge#EVENT_BUS}.<br>
+ **/
+@Cancelable
+public class EntityTravelToDimensionEvent extends EntityEvent
+{
+    public final int dimension;
+
+    public EntityTravelToDimensionEvent(Entity entity, int dimension)
+    {
+        super(entity);
+        this.dimension = dimension;
+    }
+}

--- a/src/main/resources/forge_at.cfg
+++ b/src/main/resources/forge_at.cfg
@@ -173,6 +173,8 @@ public net.minecraft.entity.ai.EntityAITasks$EntityAITaskEntry
 ## EntityLiving
 public net.minecraft.entity.EntityLiving field_70714_bg #tasks
 public net.minecraft.entity.EntityLiving field_70715_bh #targetTasks
+## EntityMinecartContainer
+public net.minecraft.entity.item.EntityMinecartContainer field_94112_b #dropContentsWhenDead
 # GuiScreen
 public net.minecraft.client.gui.GuiScreen field_146297_k # minecraft instance - public because gui's outside access it
 # Minecraft

--- a/src/test/java/net/minecraftforge/test/EntityTravelToDimensionEventTest.java
+++ b/src/test/java/net/minecraftforge/test/EntityTravelToDimensionEventTest.java
@@ -1,0 +1,29 @@
+package net.minecraftforge.test;
+
+import net.minecraftforge.common.MinecraftForge;
+import net.minecraftforge.event.entity.EntityTravelToDimensionEvent;
+import net.minecraftforge.fml.common.Mod;
+import net.minecraftforge.fml.common.Mod.EventHandler;
+import net.minecraftforge.fml.common.event.FMLInitializationEvent;
+import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
+
+@Mod(modid="EntityTravelToDimensionEventTest", name="EntityTravelToDimensionEventTest", version="0.0.0")
+public class EntityTravelToDimensionEventTest
+{
+    public static final boolean ENABLE = false;
+
+    @EventHandler
+    public void init(FMLInitializationEvent event)
+    {
+        MinecraftForge.EVENT_BUS.register(this);
+    }
+
+    @SubscribeEvent
+    public void onDimensionTravel(EntityTravelToDimensionEvent event)
+    {
+        if(ENABLE) {
+            System.out.println("Travelling to Dimension " + event.dimension);
+            event.setCanceled(true);
+        }
+    }
+}


### PR DESCRIPTION
This event fires before an entity travels to a dimension. Along with it comes the entity traveling to the dimension and the dimension id. I would like to be able to use this event in my mod to be able to cancel travelling to the nether/end. However, I see that it may have purpose for other mods which add their own dimensions and they wish to do something before they change to the dimension.

EntityMinecartContainer overrides Entity.travelToDimension (where this event is fired), but calls the super after it changes a single variable. This variable is dropContentsWhenDead. This is also a private variable, so for me to revert this value change I needed to add it to the access transformer.

I have put a test mod in the test directory which demonstrates stopping any entities from travelling dimensions and logging when there was an attempt.