### PR TITLE
Event for when EntityThrowables impact

### DIFF
--- a/patches/minecraft/net/minecraft/entity/projectile/EntityThrowable.java.patch
+++ b/patches/minecraft/net/minecraft/entity/projectile/EntityThrowable.java.patch
@@ -1,0 +1,10 @@
+--- ../src-base/minecraft/net/minecraft/entity/projectile/EntityThrowable.java
++++ ../src-work/minecraft/net/minecraft/entity/projectile/EntityThrowable.java
+@@ -222,6 +222,7 @@
+             }
+             else
+             {
++                if (!net.minecraftforge.common.ForgeHooks.onThrowableImpact(this, movingobjectposition))
+                 this.func_70184_a(movingobjectposition);
+             }
+         }

--- a/src/main/java/net/minecraftforge/common/ForgeHooks.java
+++ b/src/main/java/net/minecraftforge/common/ForgeHooks.java
@@ -28,6 +28,7 @@ import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.entity.item.EntityItem;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.entity.player.EntityPlayerMP;
+import net.minecraft.entity.projectile.EntityThrowable;
 import net.minecraft.event.ClickEvent;
 import net.minecraft.init.Blocks;
 import net.minecraft.init.Items;
@@ -74,6 +75,7 @@ import net.minecraftforge.event.AnvilUpdateEvent;
 import net.minecraftforge.event.ForgeEventFactory;
 import net.minecraftforge.event.ServerChatEvent;
 import net.minecraftforge.event.entity.item.ItemTossEvent;
+import net.minecraftforge.event.entity.item.ThrowableImpactEvent;
 import net.minecraftforge.event.entity.living.LivingAttackEvent;
 import net.minecraftforge.event.entity.living.LivingDeathEvent;
 import net.minecraftforge.event.entity.living.LivingDropsEvent;
@@ -905,5 +907,10 @@ public class ForgeHooks
         ItemStack stack = player.getCurrentEquippedItem();
         if (stack != null && stack.getItem().onLeftClickEntity(stack, player, target)) return false;
         return true;
+    }
+
+    public static boolean onThrowableImpact(EntityThrowable throwable, MovingObjectPosition mop)
+    {
+        return MinecraftForge.EVENT_BUS.post(new ThrowableImpactEvent(throwable, mop));
     }
 }

--- a/src/main/java/net/minecraftforge/event/entity/item/ThrowableImpactEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/item/ThrowableImpactEvent.java
@@ -1,0 +1,41 @@
+package net.minecraftforge.event.entity.item;
+
+import net.minecraft.entity.projectile.EntityThrowable;
+import net.minecraft.util.MovingObjectPosition;
+import net.minecraftforge.event.entity.EntityEvent;
+
+/**
+ * This event is fired before {@link EntityThrowable#onImpact()} is called, inside {@link EntityThrowable#onUpdate()}.
+ * 
+ * This event is {@link Cancelable}. When canceled, {@link EntityThrowable#onImpact()} is not called.
+ * 
+ * This event has no result. {@link HasResult}.
+ * 
+ * This event is fired on the {@link MinecraftForge#EVENT_BUS}.
+ *
+ */
+public class ThrowableImpactEvent extends EntityEvent 
+{
+    /**
+     * The EntityThrowable that is impacting
+     */
+    public final EntityThrowable throwable;
+    
+    /**
+     * The MovingObjectPosition that is generated from this impact
+     */
+    public final MovingObjectPosition movingObjectPosition;
+    
+    /**
+     * Creates a new event for an impacting EntityThrowable
+     * 
+     * @param throwable The EntityThrowable being impacted
+     * @param mop The MovingObjectPosition used in impact calculations
+     */
+    public ThrowableImpactEvent(EntityThrowable throwable, MovingObjectPosition mop)
+    {
+        super(throwable);
+        this.throwable = throwable;
+        this.movingObjectPosition = mop;
+    }
+}


### PR DESCRIPTION
Updated version of #2020. Blurb below:


This pull adds an event that is fired immediately before EntityThrowables (Eggs, Enderpearls, Snowballs, Splash Potions, and Bottles of Enchanting in vanilla) call their onImpact() method. This allows for modders to not only add logic to vanilla throwables but also to those of other mods.

My main purpose for proposing this was to reimplement the "snowballs knockback players in MP" vanilla feature that was removed quite a while ago, and there didn't seem to be any clean solution, other than tracking every snowball in a tickhandler to see if it's touching a player (ew), or coremodding (ewww).

Using this event, I could simply subscribe to a ThrowableImpactEvent, check if it was a snowball, check that the MovingObjectPosition was targeting a player, then knock back said player.

Canceling the event simply skips the call to onImpact. It is up to the modder to handle killing or otherwise resetting the entity.
