### PR TITLE
[1.8.9] Add EntityInteractAtEvent

### DIFF
--- a/patches/minecraft/net/minecraft/client/multiplayer/PlayerControllerMP.java.patch
+++ b/patches/minecraft/net/minecraft/client/multiplayer/PlayerControllerMP.java.patch
@@ -85,3 +85,11 @@
                  }
  
                  return true;
+@@ -462,6 +479,7 @@
+         this.func_78750_j();
+         Vec3 vec3 = new Vec3(p_178894_3_.field_72307_f.field_72450_a - p_178894_2_.field_70165_t, p_178894_3_.field_72307_f.field_72448_b - p_178894_2_.field_70163_u, p_178894_3_.field_72307_f.field_72449_c - p_178894_2_.field_70161_v);
+         this.field_78774_b.func_147297_a(new C02PacketUseEntity(p_178894_2_, vec3));
++        if (!net.minecraftforge.event.ForgeEventFactory.canInteractAt(p_178894_1_, p_178894_2_, vec3)) return false;
+         return this.field_78779_k != WorldSettings.GameType.SPECTATOR && p_178894_2_.func_174825_a(p_178894_1_, vec3);
+     }
+ 

--- a/patches/minecraft/net/minecraft/network/NetHandlerPlayServer.java.patch
+++ b/patches/minecraft/net/minecraft/network/NetHandlerPlayServer.java.patch
@@ -110,7 +110,15 @@
              }
  
              this.field_147374_l += 20;
-@@ -916,7 +937,7 @@
+@@ -864,6 +885,7 @@
+                 }
+                 else if (p_147340_1_.func_149565_c() == C02PacketUseEntity.Action.INTERACT_AT)
+                 {
++                    if (!net.minecraftforge.event.ForgeEventFactory.canInteractAt(this.field_147369_b, entity, p_147340_1_.func_179712_b())) return;
+                     entity.func_174825_a(this.field_147369_b, p_147340_1_.func_179712_b());
+                 }
+                 else if (p_147340_1_.func_149565_c() == C02PacketUseEntity.Action.ATTACK)
+@@ -916,7 +938,7 @@
                          return;
                      }
  

--- a/src/main/java/net/minecraftforge/event/ForgeEventFactory.java
+++ b/src/main/java/net/minecraftforge/event/ForgeEventFactory.java
@@ -22,6 +22,7 @@ import net.minecraft.util.DamageSource;
 import net.minecraft.util.EnumFacing;
 import net.minecraft.util.IChatComponent;
 import net.minecraft.util.MovingObjectPosition;
+import net.minecraft.util.Vec3;
 import net.minecraft.world.Explosion;
 import net.minecraft.world.World;
 import net.minecraft.world.WorldServer;
@@ -47,6 +48,7 @@ import net.minecraftforge.event.entity.living.LivingSpawnEvent;
 import net.minecraftforge.event.entity.living.LivingSpawnEvent.AllowDespawn;
 import net.minecraftforge.event.entity.living.ZombieEvent.SummonAidEvent;
 import net.minecraftforge.event.entity.player.BonemealEvent;
+import net.minecraftforge.event.entity.player.EntityInteractAtEvent;
 import net.minecraftforge.event.entity.player.EntityInteractEvent;
 import net.minecraftforge.event.entity.player.EntityItemPickupEvent;
 import net.minecraftforge.event.entity.player.FillBucketEvent;
@@ -356,6 +358,11 @@ public class ForgeEventFactory
                 player.joinEntityItemWithWorld(item);
             }
         }
+    }
+
+    public static boolean canInteractAt(EntityPlayer player, Entity entity, Vec3 vec3)
+    {
+        return !MinecraftForge.EVENT_BUS.post(new EntityInteractAtEvent(player, entity, vec3));
     }
 
     public static boolean canInteractWith(EntityPlayer player, Entity entity)

--- a/src/main/java/net/minecraftforge/event/entity/player/EntityInteractAtEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/player/EntityInteractAtEvent.java
@@ -1,0 +1,40 @@
+package net.minecraftforge.event.entity.player;
+
+import net.minecraft.entity.Entity;
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.util.Vec3;
+import net.minecraftforge.common.MinecraftForge;
+import net.minecraftforge.fml.common.eventhandler.Cancelable;
+
+/**
+ * EntityInteractAtEvent is fired when a player interacts with an Entity<br>
+ * at a specific position (Vec3 hitVec from MovingObjectPosition).<br>
+ * This event is fired whenever a player interacts with an Entity<br>
+ * in Minecraft#rightClickMouse() and on the server in<br>
+ * NetHandlerPlayServer#processUseEntity().<br>
+ * <br>
+ * {@link #target} contains the Entity the player interacted with.<br>
+ * {@link #hitVec} contains the interaction point on the Entity.<br>
+ * <br>
+ * This event is {@link Cancelable}.<br>
+ * If this event is canceled, the player does not interact with the Entity
+ * via the Entity#interactAt() method.<br>
+ * Note that the EntityInteractEvent will then fire instead.<br>
+ * <br>
+ * This event does not have a result. {@link HasResult}<br>
+ * <br>
+ * This event is fired on the {@link MinecraftForge#EVENT_BUS}.
+ **/
+@Cancelable
+public class EntityInteractAtEvent extends PlayerEvent
+{
+    public final Entity target;
+    public final Vec3 hitVec;
+
+    public EntityInteractAtEvent(EntityPlayer player, Entity target, Vec3 vec3)
+    {
+        super(player);
+        this.target = target;
+        this.hitVec = vec3;
+    }
+}

--- a/src/test/java/net/minecraftforge/test/EntityInteractAtEventTest.java
+++ b/src/test/java/net/minecraftforge/test/EntityInteractAtEventTest.java
@@ -1,0 +1,38 @@
+package net.minecraftforge.test;
+
+import net.minecraftforge.common.MinecraftForge;
+import net.minecraftforge.event.entity.player.EntityInteractAtEvent;
+import net.minecraftforge.event.entity.player.EntityInteractEvent;
+import net.minecraftforge.fml.common.Mod;
+import net.minecraftforge.fml.common.Mod.EventHandler;
+import net.minecraftforge.fml.common.event.FMLInitializationEvent;
+import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
+
+@Mod(modid="EntityInteractAtEventTest", name="EntityInteractAtEventTest", version="0.0.0")
+public class EntityInteractAtEventTest
+{
+    public static final boolean ENABLED = false;
+
+    @EventHandler
+    public void init(FMLInitializationEvent event)
+    {
+        if (ENABLED)
+        {
+            MinecraftForge.EVENT_BUS.register(this);
+        }
+    }
+
+    @SubscribeEvent
+    public void onEntityInteractAt(EntityInteractAtEvent event)
+    {
+        System.out.println("EntityInteractAtEvent: Interacting with entity '" + event.target + "' at hit position " + event.hitVec);
+        event.setCanceled(true);
+    }
+
+    @SubscribeEvent
+    public void onEntityInteract(EntityInteractEvent event)
+    {
+        System.out.println("EntityInteractEvent: Interacting with entity '" + event.target);
+        //event.setCanceled(true);
+    }
+}


### PR DESCRIPTION
This adds a new event for Entity#interactAt(), which was added in 1.8 for the Armor Stands.

Without this event there was previously no way to detect when a player was interacting with an Armor Stand (or any other Entity that overrides the Entity#interactAt() method and returns true). This is because Entity#interactAt() is called first, and if it returns true, then the older EntityInteractEvent via EntityPlayer#interactWith() doesn't get called at all.

I have included a small test mod to demonstrate the behaviour. It can be tested with the vanilla Armor Stands and some armor or mob heads.