### PR TITLE
Fix bug with /give command and items with larger than default lifespans

### DIFF
--- a/patches/minecraft/net/minecraft/entity/item/EntityItem.java.patch
+++ b/patches/minecraft/net/minecraft/entity/item/EntityItem.java.patch
@@ -92,3 +92,11 @@
                  if (!this.func_174814_R())
                  {
                      this.field_70170_p.func_72956_a(p_70100_1_, "random.pop", 0.2F, ((this.field_70146_Z.nextFloat() - this.field_70146_Z.nextFloat()) * 0.7F + 1.0F) * 2.0F);
+@@ -480,6 +501,6 @@
+     public void func_174870_v()
+     {
+         this.func_174871_r();
+-        this.field_70292_b = 5999;
++        this.field_70292_b = func_92059_d().func_77973_b().getEntityLifespan(func_92059_d(), field_70170_p);
+     }
+ }


### PR DESCRIPTION
This PR resolves an issue with item entities in 1.8 and the /give command.

### Background info

In 1.8.x, the vanilla /give command seemingly appears to spawn an item entity in from of you, which you then pick up.
However that is not the actual case. 

Looking in class CommandBase
Line 70: The item is added *directly* to the player inventory
Then we enter an if. If the remainder stacksize is 0 or less (inventory had room), then we call player.dropPlayerItem, and then call func_174870_v() on it, which sets the age to 5999 and pickup delay to 32767. This effectively spawns an item in from of the player that immediately dies (because the vanilla default max age is 6000), just for the visual effect. Why that instead of directly spawning a pickupable item? Idk, Mojang -.-

### The issue

The issue lies in func_174870_v() and when you have an Item which overrides getEntityLifespan(), a forge provided callback, with a time longer than the vanilla default of 6000 ticks. Since func_174870_v() sets the age to a hardcoded 5999, the "visual effect" itemstack will persist much longer in the world. If getEntityLifespan() of overriden to be 6020 ticks, for example, the "visual effect itemstack" will stay around for an 20 ticks, and so on and so forth. This causes items from mods that are infinite lifespan, for example, to spawn other essentially-infinite life span entity items that can't be picked up (Integer.MAX_VALUE - 6000).

Patching EntityItem.func_174870_v() to set the age to getEntityItem().getEntityLifespan() - 1 instead of the hardcoded 5999 fixes this issue, allowing the entity to once more be a useless visual effect entity that lives for one tick and immediately dies.