### PR TITLE
Add PlayerArmorChangeEvent

### DIFF
--- a/patches/minecraft/net/minecraft/entity/player/InventoryPlayer.java.patch
+++ b/patches/minecraft/net/minecraft/entity/player/InventoryPlayer.java.patch
@@ -1,22 +1,6 @@
 --- ../src-base/minecraft/net/minecraft/entity/player/InventoryPlayer.java
 +++ ../src-work/minecraft/net/minecraft/entity/player/InventoryPlayer.java
-@@ -1,6 +1,5 @@
- package net.minecraft.entity.player;
- 
--import java.util.concurrent.Callable;
- import net.minecraft.block.Block;
- import net.minecraft.crash.CrashReport;
- import net.minecraft.crash.CrashReportCategory;
-@@ -18,6 +17,8 @@
- import net.minecraftforge.fml.relauncher.Side;
- import net.minecraftforge.fml.relauncher.SideOnly;
- 
-+import java.util.concurrent.Callable;
-+
- public class InventoryPlayer implements IInventory
- {
-     public ItemStack[] field_70462_a = new ItemStack[36];
-@@ -315,6 +316,14 @@
+@@ -315,6 +315,14 @@
                  this.field_70462_a[i].func_77945_a(this.field_70458_d.field_70170_p, this.field_70458_d, i, this.field_70461_c == i);
              }
          }
@@ -31,7 +15,7 @@
      }
  
      public boolean func_146026_a(Item p_146026_1_)
-@@ -483,6 +492,10 @@
+@@ -483,6 +491,10 @@
          {
              p_70299_1_ -= aitemstack.length;
              aitemstack = this.field_70460_b;

--- a/patches/minecraft/net/minecraft/entity/player/InventoryPlayer.java.patch
+++ b/patches/minecraft/net/minecraft/entity/player/InventoryPlayer.java.patch
@@ -1,6 +1,22 @@
 --- ../src-base/minecraft/net/minecraft/entity/player/InventoryPlayer.java
 +++ ../src-work/minecraft/net/minecraft/entity/player/InventoryPlayer.java
-@@ -315,6 +315,14 @@
+@@ -1,6 +1,5 @@
+ package net.minecraft.entity.player;
+ 
+-import java.util.concurrent.Callable;
+ import net.minecraft.block.Block;
+ import net.minecraft.crash.CrashReport;
+ import net.minecraft.crash.CrashReportCategory;
+@@ -18,6 +17,8 @@
+ import net.minecraftforge.fml.relauncher.Side;
+ import net.minecraftforge.fml.relauncher.SideOnly;
+ 
++import java.util.concurrent.Callable;
++
+ public class InventoryPlayer implements IInventory
+ {
+     public ItemStack[] field_70462_a = new ItemStack[36];
+@@ -315,6 +316,14 @@
                  this.field_70462_a[i].func_77945_a(this.field_70458_d.field_70170_p, this.field_70458_d, i, this.field_70461_c == i);
              }
          }
@@ -15,13 +31,13 @@
      }
  
      public boolean func_146026_a(Item p_146026_1_)
-@@ -483,6 +491,10 @@
+@@ -483,6 +492,10 @@
          {
              p_70299_1_ -= aitemstack.length;
              aitemstack = this.field_70460_b;
 +            ItemStack oldArmorStack = aitemstack[p_70299_1_];
 +            aitemstack[p_70299_1_] = p_70299_2_;
-+            new net.minecraftforge.event.entity.player.PlayerArmorChangeEvent(this.field_70458_d, p_70299_1_, oldArmorStack, aitemstack[p_70299_1_]);
++            net.minecraftforge.common.MinecraftForge.EVENT_BUS.post(new net.minecraftforge.event.entity.player.PlayerArmorChangeEvent(this.field_70458_d, p_70299_1_, oldArmorStack, aitemstack[p_70299_1_]));
 +            return;
          }
  

--- a/patches/minecraft/net/minecraft/entity/player/InventoryPlayer.java.patch
+++ b/patches/minecraft/net/minecraft/entity/player/InventoryPlayer.java.patch
@@ -15,13 +15,11 @@
      }
  
      public boolean func_146026_a(Item p_146026_1_)
-@@ -483,6 +491,10 @@
+@@ -483,6 +491,8 @@
          {
              p_70299_1_ -= aitemstack.length;
              aitemstack = this.field_70460_b;
-+            ItemStack oldArmorStack = aitemstack[p_70299_1_];
-+            aitemstack[p_70299_1_] = p_70299_2_;
-+            net.minecraftforge.common.MinecraftForge.EVENT_BUS.post(new net.minecraftforge.event.entity.player.PlayerArmorChangeEvent(this.field_70458_d, p_70299_1_, oldArmorStack, aitemstack[p_70299_1_]));
++            net.minecraftforge.common.ForgeHooks.onPlayerArmorChange(this.field_70458_d, aitemstack, p_70299_1_, p_70299_2_);
 +            return;
          }
  

--- a/patches/minecraft/net/minecraft/entity/player/InventoryPlayer.java.patch
+++ b/patches/minecraft/net/minecraft/entity/player/InventoryPlayer.java.patch
@@ -15,3 +15,14 @@
      }
  
      public boolean func_146026_a(Item p_146026_1_)
+@@ -483,6 +491,10 @@
+         {
+             p_70299_1_ -= aitemstack.length;
+             aitemstack = this.field_70460_b;
++            ItemStack oldArmorStack = aitemstack[p_70299_1_];
++            aitemstack[p_70299_1_] = p_70299_2_;
++            new net.minecraftforge.event.entity.player.PlayerArmorChangeEvent(this.field_70458_d, p_70299_1_, oldArmorStack, aitemstack[p_70299_1_]);
++            return;
+         }
+ 
+         aitemstack[p_70299_1_] = p_70299_2_;

--- a/src/main/java/net/minecraftforge/common/ForgeHooks.java
+++ b/src/main/java/net/minecraftforge/common/ForgeHooks.java
@@ -82,10 +82,7 @@ import net.minecraftforge.event.entity.living.LivingEvent.LivingUpdateEvent;
 import net.minecraftforge.event.entity.living.LivingFallEvent;
 import net.minecraftforge.event.entity.living.LivingHurtEvent;
 import net.minecraftforge.event.entity.living.LivingSetAttackTargetEvent;
-import net.minecraftforge.event.entity.player.AnvilRepairEvent;
-import net.minecraftforge.event.entity.player.AttackEntityEvent;
-import net.minecraftforge.event.entity.player.PlayerDestroyItemEvent;
-import net.minecraftforge.event.entity.player.PlayerOpenContainerEvent;
+import net.minecraftforge.event.entity.player.*;
 import net.minecraftforge.event.world.BlockEvent;
 import net.minecraftforge.event.world.NoteBlockEvent;
 import net.minecraftforge.fluids.IFluidBlock;
@@ -906,4 +903,11 @@ public class ForgeHooks
         if (stack != null && stack.getItem().onLeftClickEntity(stack, player, target)) return false;
         return true;
     }
+
+    public static void onPlayerArmorChange(EntityPlayer player, ItemStack[] armorInventory, int slot, ItemStack newItemStack) {
+        ItemStack oldArmorStack = armorInventory[slot];
+        armorInventory[slot] = newItemStack;
+        MinecraftForge.EVENT_BUS.post(new PlayerArmorChangeEvent(player, slot, oldArmorStack, armorInventory[slot]));
+    }
+
 }

--- a/src/main/java/net/minecraftforge/event/entity/player/PlayerArmorChangeEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/player/PlayerArmorChangeEvent.java
@@ -1,0 +1,22 @@
+package net.minecraftforge.event.entity.player;
+
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.item.ItemStack;
+
+public class PlayerArmorChangeEvent extends PlayerEvent
+{
+
+	public final int armorSlot;
+	public final ItemStack oldStack, newStack;
+
+	/**
+	 * This event is fired when a player's armor inventory is changed.
+	 */
+	public PlayerArmorChangeEvent(EntityPlayer player, int slot, ItemStack oldItemStack, ItemStack newItemStack)
+	{
+		super(player);
+		this.armorSlot = slot;
+		this.oldStack = oldItemStack;
+		this.newStack = newItemStack;
+	}
+}


### PR DESCRIPTION
This event notifies listeners when the player's armor is changed, passing the old stack, new stack, and slot. It would be helpful for mod's whose armor has a special effect, but only does its effect when added to the inventory (like changing the player's health). The reason why this should be an event (as opposed to editing net.minecraftforge.common.ISpecialArmor) is because a mod could be implementing NBT effects on other armor items and has no control over those item classes, merely the NBT data of their stacks.
For some more context, Baubles provides this for its external equipment slots:
https://github.com/Azanor/Baubles/blob/master/src/main/java/baubles/api/IBauble.java#L26-L34
https://github.com/Azanor/Baubles/blob/6dc6951904f4bda090a9c3f78ddf010f066864c9/src/main/java/baubles/common/container/InventoryBaubles.java#L147-L153

See #2329 