### PR TITLE
Add PlayerArmorChangeEvent

### DIFF
--- a/patches/minecraft/net/minecraft/entity/player/InventoryPlayer.java.patch
+++ b/patches/minecraft/net/minecraft/entity/player/InventoryPlayer.java.patch
@@ -15,3 +15,12 @@
      }
  
      public boolean func_146026_a(Item p_146026_1_)
+@@ -483,6 +491,8 @@
+         {
+             p_70299_1_ -= aitemstack.length;
+             aitemstack = this.field_70460_b;
++            net.minecraftforge.common.ForgeHooks.onPlayerArmorChange(this.field_70458_d, aitemstack, p_70299_1_, p_70299_2_);
++            return;
+         }
+ 
+         aitemstack[p_70299_1_] = p_70299_2_;

--- a/src/main/java/net/minecraftforge/common/ForgeHooks.java
+++ b/src/main/java/net/minecraftforge/common/ForgeHooks.java
@@ -906,4 +906,10 @@ public class ForgeHooks
         if (stack != null && stack.getItem().onLeftClickEntity(stack, player, target)) return false;
         return true;
     }
+
+    public static void onPlayerArmorChange(EntityPlayer player, ItemStack[] armorInventory, int slot, ItemStack newItemStack) {
+        ItemStack oldArmorStack = armorInventory[slot];
+        armorInventory[slot] = newItemStack;
+        MinecraftForge.EVENT_BUS.post(new PlayerArmorChangeEvent(player, slot, oldArmorStack, armorInventory[slot]));
+    }
 }

--- a/src/main/java/net/minecraftforge/event/entity/player/PlayerArmorChangeEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/player/PlayerArmorChangeEvent.java
@@ -1,0 +1,38 @@
+package net.minecraftforge.event.entity.player;
+
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.item.ItemStack;
+import net.minecraftforge.fml.common.eventhandler.Cancelable;
+import net.minecraftforge.common.MinecraftForge;
+
+/**
+ * PlayerArmorChangeEvent is fired when a player's armor inventory is changed.<br>
+ * This event is fired whenever a player's armor inventory is changed in
+ * InventoryPlayer#setInventorySlotContents(int, ItemStack).<br>
+ * <br>
+ * {@link #armorSlot} The armor inventory slot which is being changed. <br>
+ * <br>
+ * {@link #oldStack} The old armor stack (can be null). <br>
+ * <br>
+ * {@link #newStack} The new armor stack (can be null). <br>
+ * <br>
+ * This event is not {@link Cancelable}.<br>
+ * <br>
+ * This event does not have a result. {@link HasResult}<br>
+ * <br>
+ * This event is fired on the {@link MinecraftForge#EVENT_BUS}.
+ **/
+public class PlayerArmorChangeEvent extends PlayerEvent
+{
+
+	public final int armorSlot;
+	public final ItemStack oldStack, newStack;
+
+	public PlayerArmorChangeEvent(EntityPlayer player, int slot, ItemStack oldItemStack, ItemStack newItemStack)
+	{
+		super(player);
+		this.armorSlot = slot;
+		this.oldStack = oldItemStack;
+		this.newStack = newItemStack;
+	}
+}


### PR DESCRIPTION
This event notifies listeners when the player's armor is changed, passing the old stack, new stack, and slot. It would be helpful for mod's whose armor has a special effect, but only does its effect when added to the inventory (like changing the player's health). The reason why this should be an event (as opposed to editing net.minecraftforge.common.ISpecialArmor) is because a mod could be implementing NBT effects on other armor items and has no control over those item classes, merely the NBT data of their stacks.
For some more context, Baubles provides this for its external equipment slots:
https://github.com/Azanor/Baubles/blob/master/src/main/java/baubles/api/IBauble.java#L26-L34
https://github.com/Azanor/Baubles/blob/6dc6951904f4bda090a9c3f78ddf010f066864c9/src/main/java/baubles/common/container/InventoryBaubles.java#L147-L153

See #2329, #2359