### PR TITLE
Update NetworkCheckHandler JavaDoc

### DIFF
--- a/src/main/java/net/minecraftforge/fml/common/network/NetworkCheckHandler.java
+++ b/src/main/java/net/minecraftforge/fml/common/network/NetworkCheckHandler.java
@@ -9,11 +9,11 @@ import net.minecraftforge.fml.relauncher.Side;
 
 /**
  * A method annotated with this will be called when a remote network connection is offered.
- * The method should have two parameters, of types {@link Map<String,String>} and {@link Side}. It should return a boolean
+ * The method should have three parameters, of types {@link Object}, {@link Map<String,String>}, and {@link Side}. It should return a boolean
  * true indicating that the remote party is acceptable, or false if not.
  *
  * <p>
- * When the method is invoked, the map will contain String keys and values listing all mods and their versions present.
+ * When the method is invoked, the object will be the mod instance, the map will contain String keys and values listing all mods and their versions present.
  * The side represents the side of the remote party. So if you're on the server, it'll be CLIENT, and vice versa.
  *
  * <p>


### PR DESCRIPTION
Add mod instance parameter to `NetworkCheckHandler` JavaDoc based on [this](https://github.com/MinecraftForge/MinecraftForge/blob/90829a316439efe7ddeb8f03b030e00366d8d03c/src/main/java/net/minecraftforge/fml/common/network/internal/NetworkModHolder.java#L73).