### PR TITLE
Fix ISBMs not getting proper context for getParticleTexture

### DIFF
--- a/patches/minecraft/net/minecraft/client/particle/EntityDiggingFX.java.patch
+++ b/patches/minecraft/net/minecraft/client/particle/EntityDiggingFX.java.patch
@@ -1,0 +1,11 @@
+--- ../src-base/minecraft/net/minecraft/client/particle/EntityDiggingFX.java
++++ ../src-work/minecraft/net/minecraft/client/particle/EntityDiggingFX.java
+@@ -30,6 +30,8 @@
+     public EntityDiggingFX func_174846_a(BlockPos p_174846_1_)
+     {
+         this.field_181019_az = p_174846_1_;
++        // FORGE: This fixes models not getting proper context for particle texture
++        this.func_180435_a(Minecraft.func_71410_x().func_175602_ab().func_175022_a(field_174847_a, func_130014_f_(), p_174846_1_).func_177554_e());
+ 
+         if (this.field_174847_a.func_177230_c() == Blocks.field_150349_c)
+         {


### PR DESCRIPTION
The `IBakedModel` stored in `BlockModelShapes` is not sufficient context. We have all the context needed at this stage to provide the actual/extended state's model, and call `getParticleTexture` on that.

However, `EntityDiggingFX` does not get the block's position in its constructor, so we use `BlockModelShapes` as a fallback in case `func_174846_a` (which seems to be a method that sets the block's position) is *not* called. However in both the cases of breaking and digging blocks, vanilla calls this function. I would expect modders to call it as well.