### PR TITLE
Skip hang detection on first run of the server hang watchdog

### DIFF
--- a/patches/minecraft/net/minecraft/server/dedicated/ServerHangWatchdog.java.patch
+++ b/patches/minecraft/net/minecraft/server/dedicated/ServerHangWatchdog.java.patch
@@ -1,0 +1,28 @@
+--- ../src-base/minecraft/net/minecraft/server/dedicated/ServerHangWatchdog.java
++++ ../src-work/minecraft/net/minecraft/server/dedicated/ServerHangWatchdog.java
+@@ -22,6 +22,7 @@
+     private static final Logger field_180251_a = LogManager.getLogger();
+     private final DedicatedServer field_180249_b;
+     private final long field_180250_c;
++    private boolean firstRun = true;
+
+     public ServerHangWatchdog(DedicatedServer p_i46310_1_)
+     {
+@@ -37,7 +38,7 @@
+             long j = MinecraftServer.func_130071_aq();
+             long k = j - i;
+
+-            if (k > this.field_180250_c)
++            if (k > this.field_180250_c && !this.firstRun)
+             {
+                 field_180251_a.fatal("A single server tick took " + String.format("%.2f", new Object[] {Float.valueOf((float)k / 1000.0F)}) + " seconds (should be max " + String.format("%.2f", new Object[] {Float.valueOf(0.05F)}) + ")");
+                 field_180251_a.fatal("Considering it to be crashed, server will forcibly shutdown.");
+@@ -75,6 +76,8 @@
+                 this.func_180248_a();
+             }
+
++            this.firstRun = false;
++
+             try
+             {
+                 Thread.sleep(i + this.field_180250_c - j);


### PR DESCRIPTION
Prevents the following from happening:
```
[23:28:04] [Server thread/INFO]: Done (10.520s)! For help, type "help" or "?"
[23:28:04] [Server Watchdog/FATAL]: A single server tick took 71.62 seconds (should be max 0.05)
[23:28:04] [Server Watchdog/FATAL]: Considering it to be crashed, server will forcibly shutdown.
[23:28:04] [Server Watchdog/ERROR]: This crash report has been saved to: /.../run/./crash-reports/crash-2015-12-30_23.28.04-server.txt
[23:28:06] [Server thread/WARN]: Can't keep up! Did the system time change, or is the server overloaded? Running 2034ms behind, skipping 40 tick(s)
```