### PR TITLE
Avoid two possible ClassCastExceptions in IChatComponent.Serializer

### DIFF
--- a/patches/minecraft/net/minecraft/util/IChatComponent.java.patch
+++ b/patches/minecraft/net/minecraft/util/IChatComponent.java.patch
@@ -8,3 +8,44 @@
      String func_150254_d();
  
      List<IChatComponent> func_150253_a();
+@@ -57,7 +56,7 @@
+ 
+                         for (JsonElement jsonelement : jsonarray1)
+                         {
+-                            IChatComponent ichatcomponent2 = this.deserialize(jsonelement, jsonelement.getClass(), p_deserialize_3_);
++                            IChatComponent ichatcomponent2 = p_deserialize_3_.deserialize(jsonelement, IChatComponent.class);
+ 
+                             if (ichatcomponent1 == null)
+                             {
+@@ -91,12 +90,13 @@
+ 
+                         if (jsonobject.has("with"))
+                         {
++                            if (!jsonobject.isJsonArray()) throw new JsonParseException("'with' tag has to be an array");
+                             JsonArray jsonarray = jsonobject.getAsJsonArray("with");
+                             Object[] aobject = new Object[jsonarray.size()];
+ 
+                             for (int i = 0; i < aobject.length; ++i)
+                             {
+-                                aobject[i] = this.deserialize(jsonarray.get(i), p_deserialize_2_, p_deserialize_3_);
++                                aobject[i] = p_deserialize_3_.deserialize(jsonarray.get(i), IChatComponent.class);
+ 
+                                 if (aobject[i] instanceof ChatComponentText)
+                                 {
+@@ -143,6 +143,7 @@
+                     }
+ 
+                     if (jsonobject.has("extra"))
++                    if (!jsonobject.isJsonArray()) ichatcomponent.func_150257_a(p_deserialize_3_.<IChatComponent>deserialize(jsonobject, IChatComponent.class)); else
+                     {
+                         JsonArray jsonarray2 = jsonobject.getAsJsonArray("extra");
+ 
+@@ -153,7 +154,7 @@
+ 
+                         for (int j = 0; j < jsonarray2.size(); ++j)
+                         {
+-                            ichatcomponent.func_150257_a(this.deserialize(jsonarray2.get(j), p_deserialize_2_, p_deserialize_3_));
++                            ichatcomponent.func_150257_a(p_deserialize_3_.<IChatComponent>deserialize(jsonarray2.get(j), IChatComponent.class));
+                         }
+                     }
+ 

--- a/patches/minecraft/net/minecraft/util/IChatComponent.java.patch
+++ b/patches/minecraft/net/minecraft/util/IChatComponent.java.patch
@@ -21,7 +21,7 @@
  
                          if (jsonobject.has("with"))
                          {
-+                            if (!jsonobject.isJsonArray()) throw new JsonParseException("'with' tag has to be an array");
++                            if (!jsonobject.get("with").isJsonArray()) throw new JsonParseException("'with' tag has to be an array");
                              JsonArray jsonarray = jsonobject.getAsJsonArray("with");
                              Object[] aobject = new Object[jsonarray.size()];
  
@@ -36,7 +36,7 @@
                      }
  
                      if (jsonobject.has("extra"))
-+                    if (!jsonobject.isJsonArray()) ichatcomponent.func_150257_a(p_deserialize_3_.<IChatComponent>deserialize(jsonobject, IChatComponent.class)); else
++                    if (!jsonobject.get("extra").isJsonArray()) ichatcomponent.func_150257_a(p_deserialize_3_.<IChatComponent>deserialize(jsonobject.get("extra"), IChatComponent.class)); else
                      {
                          JsonArray jsonarray2 = jsonobject.getAsJsonArray("extra");
  

--- a/patches/minecraft/net/minecraft/util/IChatComponent.java.patch
+++ b/patches/minecraft/net/minecraft/util/IChatComponent.java.patch
@@ -8,16 +8,7 @@
      String func_150254_d();
  
      List<IChatComponent> func_150253_a();
-@@ -57,7 +56,7 @@
- 
-                         for (JsonElement jsonelement : jsonarray1)
-                         {
--                            IChatComponent ichatcomponent2 = this.deserialize(jsonelement, jsonelement.getClass(), p_deserialize_3_);
-+                            IChatComponent ichatcomponent2 = p_deserialize_3_.deserialize(jsonelement, IChatComponent.class);
- 
-                             if (ichatcomponent1 == null)
-                             {
-@@ -91,12 +90,13 @@
+@@ -91,6 +90,7 @@
  
                          if (jsonobject.has("with"))
                          {
@@ -25,13 +16,6 @@
                              JsonArray jsonarray = jsonobject.getAsJsonArray("with");
                              Object[] aobject = new Object[jsonarray.size()];
  
-                             for (int i = 0; i < aobject.length; ++i)
-                             {
--                                aobject[i] = this.deserialize(jsonarray.get(i), p_deserialize_2_, p_deserialize_3_);
-+                                aobject[i] = p_deserialize_3_.deserialize(jsonarray.get(i), IChatComponent.class);
- 
-                                 if (aobject[i] instanceof ChatComponentText)
-                                 {
 @@ -143,6 +143,7 @@
                      }
  
@@ -39,13 +23,4 @@
 +                    if (!jsonobject.get("extra").isJsonArray()) ichatcomponent.func_150257_a(p_deserialize_3_.<IChatComponent>deserialize(jsonobject.get("extra"), IChatComponent.class)); else
                      {
                          JsonArray jsonarray2 = jsonobject.getAsJsonArray("extra");
- 
-@@ -153,7 +154,7 @@
- 
-                         for (int j = 0; j < jsonarray2.size(); ++j)
-                         {
--                            ichatcomponent.func_150257_a(this.deserialize(jsonarray2.get(j), p_deserialize_2_, p_deserialize_3_));
-+                            ichatcomponent.func_150257_a(p_deserialize_3_.<IChatComponent>deserialize(jsonarray2.get(j), IChatComponent.class));
-                         }
-                     }
  


### PR DESCRIPTION
~~Basically, the deserialization is now rerouted back over the DeserializationContext (as is should be, according to the Gson-doc). This allows you to hook into the deserialization process by supplying a custom DeserializationContext (since this context is now used everywhere where appropriate).~~ (see [this comment](https://github.com/MinecraftForge/MinecraftForge/pull/2380#issuecomment-178768083))~~Making the GSON field public allows you to use it as fallback when doing some custom deserializations.~~ [Removed: Can easily be done by anyone using ATs - Thanks @ diesieben07 for pointing that out]
This PR fixes two ClassCastExceptions caused by malformed JSON. One now throws a JsonParseException ('with'-tag) and one interprets the element as a one element array ('extra'-tag)
(For more details, see commit message)