### PR TITLE
Added: onBlockDestroyedByFire

### DIFF
--- a/patches/minecraft/net/minecraft/block/BlockFire.java.patch
+++ b/patches/minecraft/net/minecraft/block/BlockFire.java.patch
@@ -111,6 +111,20 @@
          if (p_176536_4_.nextInt(p_176536_3_) < i)
          {
              IBlockState iblockstate = p_176536_1_.func_180495_p(p_176536_2_);
+@@ -290,11 +300,11 @@
+                     j = 15;
+                 }
+ 
+-                p_176536_1_.func_180501_a(p_176536_2_, this.func_176223_P().func_177226_a(field_176543_a, Integer.valueOf(j)), 3);
++                if (net.minecraftforge.common.ForgeHooks.onBlockDestroyedByFire(p_176536_1_, p_176536_2_, iblockstate, face)) p_176536_1_.func_180501_a(p_176536_2_, this.func_176223_P().func_177226_a(field_176543_a, Integer.valueOf(j)), 3);
+             }
+             else
+             {
+-                p_176536_1_.func_175698_g(p_176536_2_);
++                if (net.minecraftforge.common.ForgeHooks.onBlockDestroyedByFire(p_176536_1_, p_176536_2_, iblockstate, face)) p_176536_1_.func_175698_g(p_176536_2_);
+             }
+ 
+             if (iblockstate.func_177230_c() == Blocks.field_150335_W)
 @@ -308,7 +318,7 @@
      {
          for (EnumFacing enumfacing : EnumFacing.values())

--- a/src/main/java/net/minecraftforge/common/ForgeHooks.java
+++ b/src/main/java/net/minecraftforge/common/ForgeHooks.java
@@ -906,4 +906,9 @@ public class ForgeHooks
         if (stack != null && stack.getItem().onLeftClickEntity(stack, player, target)) return false;
         return true;
     }
+
+    public static boolean onBlockDestroyedByFire(World world, BlockPos pos, IBlockState state, EnumFacing facing)
+    {
+        return !(MinecraftForge.EVENT_BUS.post(new BlockEvent.DestroyedByFireEvent(world, pos, state, facing)));
+    }
 }

--- a/src/main/java/net/minecraftforge/event/world/BlockEvent.java
+++ b/src/main/java/net/minecraftforge/event/world/BlockEvent.java
@@ -204,4 +204,29 @@ public class BlockEvent extends Event
             return notifiedSides;
         }
     }
+
+    /**
+     * DestroyedByFireEvent is fired when BlockFire replaces a block with fire or air.
+     * 
+     * If this event is cancelled, the block is not replaced.
+     */
+    @Cancelable
+    public static class DestroyedByFireEvent extends BlockEvent
+    {
+        private final EnumFacing facing;
+
+        public DestroyedByFireEvent(World world, BlockPos pos, IBlockState state, EnumFacing facing)
+        {
+            super(world, pos, state);
+            this.facing = facing;
+        }
+
+        /**
+         * Gets the face being lit on fire
+         */
+        public EnumFacing getFace()
+        {
+            return this.facing;
+        }
+    }
 }

--- a/src/test/java/net/minecraftforge/test/DestroyedByFireTest.java
+++ b/src/test/java/net/minecraftforge/test/DestroyedByFireTest.java
@@ -1,0 +1,48 @@
+package net.minecraftforge.test;
+
+import net.minecraft.block.Block;
+import net.minecraft.block.BlockFire;
+import net.minecraft.init.Blocks;
+import net.minecraft.init.Items;
+import net.minecraft.item.ItemStack;
+import net.minecraft.util.BlockPos;
+import net.minecraftforge.common.MinecraftForge;
+import net.minecraftforge.event.world.BlockEvent.DestroyedByFireEvent;
+import net.minecraftforge.fml.common.Mod;
+import net.minecraftforge.fml.common.event.FMLPreInitializationEvent;
+import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
+
+@Mod(modid = DestroyedByFireTest.MODID, version = DestroyedByFireTest.VERSION)
+public class DestroyedByFireTest
+{
+    public static final String MODID = "DestroyedByFireTest";
+    public static final String VERSION = "1.0";
+
+    @Mod.EventHandler
+    public void preInit(FMLPreInitializationEvent event)
+    {
+        MinecraftForge.EVENT_BUS.register(new EventHandler());
+    }
+
+    public static class EventHandler
+    {
+        @SubscribeEvent
+        public void destroyedByFireEvent(DestroyedByFireEvent event)
+        {
+            Block block = event.state.getBlock();
+            if (block == Blocks.log2) // Acacia, Dark Oak
+            {
+                event.setCanceled(true);
+                BlockPos fire = event.pos.offset(event.getFace());
+                if (event.world.getBlockState(fire).getBlock() instanceof BlockFire)
+                {
+                    event.world.setBlockToAir(fire);
+                }
+            }
+            else if (block == Blocks.log) // Oak, Spruce, Birch, Jungle
+            {
+                Block.spawnAsEntity(event.world, event.pos, new ItemStack(Items.coal, 1, 1));
+            }
+        }
+    }
+}


### PR DESCRIPTION
This is an update of my pull request: https://github.com/MinecraftForge/MinecraftForge/pull/1780

BlockEvent.DestroyedByFireEvent
-- Fired when BlockFire replaces a block with fire or air.
-- If cancelled, the block is not replaced.
-- Primary Use: protection plugins stopping fire from destroying blocks.

Includes a Test Mod (for the event):
-- Oak, Spruce, Birch, and Jungle Logs will burn into charcoal
-- Acacia, and Dark Oak will not burn