### PR TITLE
Sign edit event

### DIFF
--- a/patches/minecraft/net/minecraft/network/NetHandlerPlayServer.java.patch
+++ b/patches/minecraft/net/minecraft/network/NetHandlerPlayServer.java.patch
@@ -119,3 +119,12 @@
                  }
  
                  break;
+@@ -1089,7 +1110,7 @@
+                 return;
+             }
+ 
+-            IChatComponent[] aichatcomponent = p_147343_1_.func_180768_b();
++            IChatComponent[] aichatcomponent = net.minecraftforge.common.ForgeHooks.onSignEditEvent(p_147343_1_, field_147369_b); if (aichatcomponent == null){ return;};
+ 
+             for (int i = 0; i < aichatcomponent.length; ++i)
+             {

--- a/src/main/java/net/minecraftforge/common/ForgeHooks.java
+++ b/src/main/java/net/minecraftforge/common/ForgeHooks.java
@@ -49,6 +49,7 @@ import net.minecraft.nbt.NBTTagList;
 import net.minecraft.nbt.NBTTagString;
 import net.minecraft.network.NetHandlerPlayServer;
 import net.minecraft.network.Packet;
+import net.minecraft.network.play.client.C12PacketUpdateSign;
 import net.minecraft.network.play.server.S23PacketBlockChange;
 import net.minecraft.stats.StatList;
 import net.minecraft.tileentity.TileEntity;
@@ -90,6 +91,7 @@ import net.minecraftforge.event.entity.player.PlayerDestroyItemEvent;
 import net.minecraftforge.event.entity.player.PlayerOpenContainerEvent;
 import net.minecraftforge.event.world.BlockEvent;
 import net.minecraftforge.event.world.NoteBlockEvent;
+import net.minecraftforge.event.entity.player.PlayerEditSignEvent;
 import net.minecraftforge.fluids.IFluidBlock;
 import net.minecraftforge.fml.common.eventhandler.Event;
 import net.minecraftforge.fml.relauncher.ReflectionHelper;
@@ -922,5 +924,12 @@ public class ForgeHooks
             }
         }
         return !event.isCanceled();
+    }
+
+    public static IChatComponent[] onSignEditEvent(C12PacketUpdateSign data, EntityPlayerMP player)
+    {
+        PlayerEditSignEvent e = new PlayerEditSignEvent(data.getPosition(), data.getLines(), player);
+        if (MinecraftForge.EVENT_BUS.post(e))return null;
+        return e.getText();
     }
 }

--- a/src/main/java/net/minecraftforge/event/entity/player/PlayerEditSignEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/player/PlayerEditSignEvent.java
@@ -1,0 +1,62 @@
+package net.minecraftforge.event.entity.player;
+
+import net.minecraft.util.BlockPos;
+import net.minecraft.util.ChatComponentTranslation;
+import net.minecraft.util.IChatComponent;
+import net.minecraftforge.fml.common.eventhandler.Cancelable;
+import net.minecraft.entity.player.EntityPlayerMP;
+
+/**
+ * This event is fired when a C12PacketUpdateSign is processed.
+ *
+ * This event is fired via {@link ForgeHooks#onSignEditEvent(net.minecraft.network.play.client.C12PacketUpdateSign, EntityPlayerMP)},
+ * which is executed by the NetHandlerPlayServer#processUpdateSign(net.minecraft.network.play.client.C12PacketUpdateSign)<br>
+ *
+ * This event is {@link Cancelable}. <br>
+ * If this event is canceled, the sign will not be updated with the contents of this event.<br>
+ * If it has been newly placed. there will be a blank sign at the given coordinates.<br>
+ * <br>
+ * This event does not have a result. {@link HasResult}<br>
+ * <br>
+ * This event is fired on the {@link MinecraftForge#EVENT_BUS}.
+ **/
+
+@Cancelable
+public class PlayerEditSignEvent extends PlayerEvent
+{
+    /**
+     * The location of the sign being edited
+     */
+    public final BlockPos pos;
+
+    private IChatComponent[] text;
+
+    public PlayerEditSignEvent(BlockPos pos, IChatComponent[] text, EntityPlayerMP editor)
+    {
+        super(editor);
+        this.pos = pos;
+        this.text = text;
+    }
+
+    /**
+     * Get the contents of the sign
+     * Vanilla signs will have 4 items in the array, modded ones may have more.
+     *
+     * @return an array of IChatComponents, one for each line of text
+     */
+    public IChatComponent[] getText()
+    {
+        return text;
+    }
+
+    /**
+     * Set the contents of the sign
+     * Vanilla signs will have 4 items in the array, modded ones may have more.
+     *
+     * @param text an array of IChatComponents, one for each line of text
+     */
+    public void setText(IChatComponent[] text)
+    {
+        this.text = text;
+    }
+}

--- a/src/test/java/net/minecraftforge/test/SignEditTest.java
+++ b/src/test/java/net/minecraftforge/test/SignEditTest.java
@@ -1,0 +1,34 @@
+package net.minecraftforge.test;
+
+import net.minecraft.util.IChatComponent;
+import net.minecraftforge.common.MinecraftForge;
+import net.minecraftforge.event.entity.player.PlayerEditSignEvent;
+import net.minecraftforge.fml.common.Mod;
+import net.minecraftforge.fml.common.Mod.EventHandler;
+import net.minecraftforge.fml.common.event.FMLInitializationEvent;
+import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
+
+@Mod(modid = "forgesigntest")
+public class SignEditTest
+{
+    public static final boolean ENABLE = false;
+
+    @EventHandler
+    public void init(FMLInitializationEvent event)
+    {
+        MinecraftForge.EVENT_BUS.register(this);
+    }
+
+    @SubscribeEvent
+    public void onSignEdit(PlayerEditSignEvent event)
+    {
+        if(ENABLE)
+        {
+            for (IChatComponent component : event.getText())
+            {
+                System.out.println(component.getUnformattedText());
+            }
+            //event.setCanceled(true);
+        }
+    }
+}


### PR DESCRIPTION
This event allows mods to manipulate sign text at edit time, based off an earlier implementation in #1459. This is useful for serverside mods to define coloured text, censor unacceptable words, etc, like what is possible in ServerChatEvent. Mods providing custom signs are expected to manually throw this event.

The text field is an array containing the 4 lines of text that should be written to the sign. You'll want to modify this using the setText() method. This array may be larger than 4 lines, if thrown by a mod providing custom signs.

The additional parameters are for protection plugins to determine whether the sign should be edited, and to apply any possible permissions.

A test mod is also provided. In its current implementation, it will echo out the contents of a sign that has just been edited to the console

Questions and comments are welcome.