### PR TITLE
Fixed error-messages for "/title" and "/tellraw"

### DIFF
--- a/patches/minecraft/net/minecraft/command/CommandTitle.java.patch
+++ b/patches/minecraft/net/minecraft/command/CommandTitle.java.patch
@@ -1,0 +1,11 @@
+--- ../src-base/minecraft/net/minecraft/command/CommandTitle.java
++++ ../src-work/minecraft/net/minecraft/command/CommandTitle.java
+@@ -89,7 +89,7 @@
+                     catch (JsonParseException jsonparseexception)
+                     {
+                         Throwable throwable = ExceptionUtils.getRootCause(jsonparseexception);
+-                        throw new SyntaxErrorException("commands.tellraw.jsonException", new Object[] {throwable == null ? "" : throwable.getMessage()});
++                        throw new SyntaxErrorException("commands.tellraw.jsonException", new Object[] {(throwable == null ? jsonparseexception : throwable).getMessage()});
+                     }
+ 
+                     S45PacketTitle s45packettitle1 = new S45PacketTitle(s45packettitle$type, ChatComponentProcessor.func_179985_a(p_71515_1_, ichatcomponent, entityplayermp));

--- a/patches/minecraft/net/minecraft/command/server/CommandMessageRaw.java.patch
+++ b/patches/minecraft/net/minecraft/command/server/CommandMessageRaw.java.patch
@@ -1,0 +1,11 @@
+--- ../src-base/minecraft/net/minecraft/command/server/CommandMessageRaw.java
++++ ../src-work/minecraft/net/minecraft/command/server/CommandMessageRaw.java
+@@ -50,7 +50,7 @@
+             catch (JsonParseException jsonparseexception)
+             {
+                 Throwable throwable = ExceptionUtils.getRootCause(jsonparseexception);
+-                throw new SyntaxErrorException("commands.tellraw.jsonException", new Object[] {throwable == null ? "" : throwable.getMessage()});
++                throw new SyntaxErrorException("commands.tellraw.jsonException", new Object[] {(throwable == null ? jsonparseexception : throwable).getMessage()});
+             }
+         }
+     }


### PR DESCRIPTION
This fixes error-messages for commands "/title" and "/tellraw" for
JsonExceptions with no rootcause (i.e. the ones not generated by GSON). Without this fix, any exception thrown without cause displays as 'Invalid JSON: ' (see for example '/tellraw @a {}')