### PR TITLE
Updated NBTTagString.toString() to escape '\' (and removed indexes from the output of NBTTagList.toString)

### DIFF
--- a/patches/minecraft/net/minecraft/nbt/NBTTagList.java.patch
+++ b/patches/minecraft/net/minecraft/nbt/NBTTagList.java.patch
@@ -1,0 +1,11 @@
+--- ../src-base/minecraft/net/minecraft/nbt/NBTTagList.java
++++ ../src-work/minecraft/net/minecraft/nbt/NBTTagList.java
+@@ -82,7 +82,7 @@
+                 stringbuilder.append(',');
+             }
+ 
+-            stringbuilder.append(i).append(':').append(this.field_74747_a.get(i));
++            stringbuilder.append(this.field_74747_a.get(i));
+         }
+ 
+         return stringbuilder.append(']').toString();

--- a/patches/minecraft/net/minecraft/nbt/NBTTagString.java.patch
+++ b/patches/minecraft/net/minecraft/nbt/NBTTagString.java.patch
@@ -9,3 +9,12 @@
      }
  
      public byte func_74732_a()
+@@ -42,7 +42,7 @@
+ 
+     public String toString()
+     {
+-        return "\"" + this.field_74751_a.replace("\"", "\\\"") + "\"";
++        return "\"" + org.apache.commons.lang3.StringUtils.replaceEach(this.field_74751_a, new String[]{"\\","\""}, new String[]{"\\\\","\\\""}) + "\"";
+     }
+ 
+     public NBTBase func_74737_b()


### PR DESCRIPTION
This change ensures that NBTTagString.toString() generates  valid NBT. Without this, the output of commands like BlockData is invalid. Currently, quotation marks are escaped, but not backslashes, which is extremely inconsistent

EDIT: As explained in [this comment](https://github.com/MinecraftForge/MinecraftForge/pull/2393#issuecomment-177631438), this also fixes some edge cases which are broken in vanilla