### PR TITLE
Strip console formatting codes for Vanilla log file

### DIFF
--- a/src/main/resources/log4j2_server.xml
+++ b/src/main/resources/log4j2_server.xml
@@ -13,7 +13,7 @@
             <PatternLayout pattern="[%d{HH:mm:ss}] [%t/%level] [%logger]: %replace{%msg}{(?i)\u00A7[0-9A-FK-OR]}{}%n" />
         </Queue>
         <RollingRandomAccessFile name="File" fileName="logs/latest.log" filePattern="logs/%d{yyyy-MM-dd}-%i.log.gz">
-            <PatternLayout pattern="[%d{HH:mm:ss}] [%t/%level]: %msg%n" />
+            <PatternLayout pattern="[%d{HH:mm:ss}] [%t/%level]: %replace{%msg}{(?i)\u00A7[0-9A-FK-OR]}{}%n" />
             <Policies>
                 <TimeBasedTriggeringPolicy />
                 <OnStartupTriggeringPolicy />


### PR DESCRIPTION
Currently the Vanilla log file (in `logs/latest.log`) will get all console formatting codes written to it because unlike for all other file handlers it doesn't have the formatting code stripping set up. Other than encoding issues, I think this also causes problems like shown in https://forums.spongepowered.org/t/strange-r-appear-in-console-when-someone-types/10913/5?u=minecrell for certain control panels that read this log file.

With this change the formatting codes should get stripped for the Vanilla log file identically to all the other log files created by Forge.