### PR TITLE
Add version range support to @IFMLLoadingPlugin.MCVersion annotation

### DIFF
--- a/src/main/java/net/minecraftforge/fml/relauncher/CoreModManager.java
+++ b/src/main/java/net/minecraftforge/fml/relauncher/CoreModManager.java
@@ -42,6 +42,8 @@ import net.minecraftforge.fml.common.asm.ASMTransformerWrapper;
 import net.minecraftforge.fml.common.asm.transformers.ModAccessTransformer;
 import net.minecraftforge.fml.common.launcher.FMLInjectionAndSortingTweaker;
 import net.minecraftforge.fml.common.launcher.FMLTweaker;
+import net.minecraftforge.fml.common.versioning.DefaultArtifactVersion;
+import net.minecraftforge.fml.common.versioning.VersionParser;
 import net.minecraftforge.fml.relauncher.IFMLLoadingPlugin.DependsOn;
 import net.minecraftforge.fml.relauncher.IFMLLoadingPlugin.MCVersion;
 import net.minecraftforge.fml.relauncher.IFMLLoadingPlugin.Name;
@@ -541,12 +543,13 @@ public class CoreModManager {
                 FMLRelaunchLog.finer("coremod named %s is loading", coreModName);
             }
             MCVersion requiredMCVersion = coreModClazz.getAnnotation(IFMLLoadingPlugin.MCVersion.class);
+            DefaultArtifactVersion mcVersion = new DefaultArtifactVersion(FMLInjectionData.mccversion);
             if (!Arrays.asList(rootPlugins).contains(coreModClass) && (requiredMCVersion == null || Strings.isNullOrEmpty(requiredMCVersion.value())))
             {
                 FMLRelaunchLog.log(Level.WARN, "The coremod %s does not have a MCVersion annotation, it may cause issues with this version of Minecraft",
                         coreModClass);
             }
-            else if (requiredMCVersion != null && !FMLInjectionData.mccversion.equals(requiredMCVersion.value()))
+            else if (requiredMCVersion != null && !(VersionParser.parseRange(requiredMCVersion.value()).containsVersion(mcVersion)))
             {
                 FMLRelaunchLog.log(Level.ERROR, "The coremod %s is requesting minecraft version %s and minecraft is %s. It will be ignored.", coreModClass,
                         requiredMCVersion.value(), FMLInjectionData.mccversion);

--- a/src/main/java/net/minecraftforge/fml/relauncher/IFMLLoadingPlugin.java
+++ b/src/main/java/net/minecraftforge/fml/relauncher/IFMLLoadingPlugin.java
@@ -89,8 +89,10 @@ public interface IFMLLoadingPlugin
     }
 
     /**
-     * Use this to target a specific minecraft version for your coremod. It will refuse to load with an error if
-     * minecraft is not this exact version.
+     * Use this to target specific minecraft versions for your coremod. Should be a version range 
+     * as specified by the maven version range specification
+     * 
+     * The coremod will refuse to load with an error if the minecraft version is not in this range.
      *
      * @author cpw
      *


### PR DESCRIPTION
Brings it in line with `@Mod.acceptedMinecraftVersions`. Example of a possible annotation after this change: `@IFMLLoadingPlugin.MCVersion("[1.8.8,1.9)")`