### PR TITLE
Fix ASM SignatureReader choking on invalid lambda local var signatures emitted by JDT

### DIFF
--- a/src/main/java/net/minecraftforge/fml/common/asm/transformers/deobf/FMLDeobfuscatingRemapper.java
+++ b/src/main/java/net/minecraftforge/fml/common/asm/transformers/deobf/FMLDeobfuscatingRemapper.java
@@ -313,6 +313,17 @@ public class FMLDeobfuscatingRemapper extends Remapper {
         String methodDescriptor = name+desc;
         return methodMap!=null && methodMap.containsKey(methodDescriptor) ? methodMap.get(methodDescriptor) : name;
     }
+    
+    @Override
+    public String mapSignature(String signature, boolean typeSignature)
+    {
+        // JDT decorates some lambdas with this and SignatureReader chokes on it
+        if (signature != null && signature.contains("!*"))
+        {
+            return null;
+        }
+        return super.mapSignature(signature, typeSignature);
+    }
 
     private Map<String,String> getFieldMap(String className)
     {


### PR DESCRIPTION
When running under Eclipse, for some bizarre reason JDT decorates some internal lamba local variables with invalid signature token `!*`. This isn't normally a problem since the signature is generally ignored, but the deobf transformer causes it to be visited and ASM's `SignatureReader` chokes on it.

This change basically just has the remapper strip the invalid signature so that the adapter doesn't shit the bed.