### PR TITLE
Add CapabilityWorker

### DIFF
--- a/patches/minecraft/net/minecraft/tileentity/TileEntityBrewingStand.java.patch
+++ b/patches/minecraft/net/minecraft/tileentity/TileEntityBrewingStand.java.patch
@@ -76,13 +76,20 @@
      }
  
      public boolean[] func_174902_m()
-@@ -386,4 +393,18 @@
+@@ -386,4 +393,26 @@
              this.field_145945_j[i] = null;
          }
      }
 +
 +    net.minecraftforge.items.IItemHandler handlerInput = new net.minecraftforge.items.wrapper.SidedInvWrapper(this, net.minecraft.util.EnumFacing.UP);
 +    net.minecraftforge.items.IItemHandler handlerOutput = new net.minecraftforge.items.wrapper.SidedInvWrapper(this, net.minecraft.util.EnumFacing.DOWN);
++    net.minecraftforge.common.capabilities.work.IWorker capabilityWorker = new net.minecraftforge.common.capabilities.work.VanillaBrewingStandWorker(this);
++
++    @Override
++    public boolean hasCapability(net.minecraftforge.common.capabilities.Capability<?> capability, EnumFacing facing)
++    {
++        return capability == net.minecraftforge.common.capabilities.work.CapabilityWorker.WORKER_CAPABILITY || super.hasCapability(capability, facing);
++    }
 +
 +    @Override
 +    public <T> T getCapability(net.minecraftforge.common.capabilities.Capability<T> capability, net.minecraft.util.EnumFacing facing)
@@ -92,6 +99,7 @@
 +                return (T) handlerInput;
 +            else
 +                return (T) handlerOutput;
++        if(capability == net.minecraftforge.common.capabilities.work.CapabilityWorker.WORKER_CAPABILITY) return (T) capabilityWorker;
 +        return super.getCapability(capability, facing);
 +    }
  }

--- a/patches/minecraft/net/minecraft/tileentity/TileEntityFurnace.java.patch
+++ b/patches/minecraft/net/minecraft/tileentity/TileEntityFurnace.java.patch
@@ -49,7 +49,7 @@
          }
      }
  
-@@ -451,4 +462,21 @@
+@@ -451,4 +462,29 @@
              this.field_145957_n[i] = null;
          }
      }
@@ -57,6 +57,13 @@
 +    net.minecraftforge.items.IItemHandler handlerTop = new net.minecraftforge.items.wrapper.SidedInvWrapper(this, net.minecraft.util.EnumFacing.UP);
 +    net.minecraftforge.items.IItemHandler handlerBottom = new net.minecraftforge.items.wrapper.SidedInvWrapper(this, net.minecraft.util.EnumFacing.DOWN);
 +    net.minecraftforge.items.IItemHandler handlerSide = new net.minecraftforge.items.wrapper.SidedInvWrapper(this, net.minecraft.util.EnumFacing.WEST);
++    net.minecraftforge.common.capabilities.work.IWorker capabilityWorker = new net.minecraftforge.common.capabilities.work.VanillaFurnaceWorker(this);
++
++    @Override
++    public boolean hasCapability(net.minecraftforge.common.capabilities.Capability<?> capability, EnumFacing facing)
++    {
++        return capability == net.minecraftforge.common.capabilities.work.CapabilityWorker.WORKER_CAPABILITY || super.hasCapability(capability, facing);
++    }
 +
 +    @Override
 +    public <T> T getCapability(net.minecraftforge.common.capabilities.Capability<T> capability, net.minecraft.util.EnumFacing facing)
@@ -68,6 +75,7 @@
 +                return (T) handlerTop;
 +            else
 +                return (T) handlerSide;
++        if(capability == net.minecraftforge.common.capabilities.work.CapabilityWorker.WORKER_CAPABILITY) return (T) capabilityWorker;
 +        return super.getCapability(capability, facing);
 +    }
  }

--- a/src/main/java/net/minecraftforge/common/capabilities/work/CapabilityWorker.java
+++ b/src/main/java/net/minecraftforge/common/capabilities/work/CapabilityWorker.java
@@ -1,0 +1,44 @@
+package net.minecraftforge.common.capabilities.work;
+
+import java.util.concurrent.Callable;
+
+import net.minecraft.nbt.NBTBase;
+import net.minecraft.util.EnumFacing;
+import net.minecraftforge.common.capabilities.Capability;
+import net.minecraftforge.common.capabilities.CapabilityInject;
+import net.minecraftforge.common.capabilities.CapabilityManager;
+
+/**
+ * Capability for {@link IWorker}.
+ * @author rubensworks
+ */
+public class CapabilityWorker
+{
+    @CapabilityInject(IWorker.class)
+    public static Capability<IWorker> WORKER_CAPABILITY = null;
+
+    public static void register()
+    {
+        CapabilityManager.INSTANCE.register(IWorker.class, new Capability.IStorage<IWorker>()
+        {
+            @Override
+            public NBTBase writeNBT(Capability<IWorker> capability, IWorker instance, EnumFacing side)
+            {
+                return null;
+            }
+
+            @Override
+            public void readNBT(Capability<IWorker> capability, IWorker instance, EnumFacing side, NBTBase base)
+            {
+            }
+        }, new Callable<DefaultWorker>()
+        {
+            @Override
+            public DefaultWorker call() throws Exception
+            {
+                return new DefaultWorker();
+            }
+        });
+    }
+
+}

--- a/src/main/java/net/minecraftforge/common/capabilities/work/DefaultWorker.java
+++ b/src/main/java/net/minecraftforge/common/capabilities/work/DefaultWorker.java
@@ -1,0 +1,20 @@
+package net.minecraftforge.common.capabilities.work;
+
+/**
+ * Default implementation of an {@link IWorker}
+ * @author rubensworks
+ */
+public class DefaultWorker implements IWorker
+{
+    @Override
+    public boolean hasWork()
+    {
+        return false;
+    }
+
+    @Override
+    public boolean canWork()
+    {
+        return false;
+    }
+}

--- a/src/main/java/net/minecraftforge/common/capabilities/work/IWorker.java
+++ b/src/main/java/net/minecraftforge/common/capabilities/work/IWorker.java
@@ -1,0 +1,32 @@
+package net.minecraftforge.common.capabilities.work;
+
+
+/**
+ * Capability instance for targets that are able to
+ * work on something and have their state detected.
+ * This capability does not store anything itself,
+ * the information should be supplied by its owner.
+ * 
+ * For this implementation to be sane, it is expected
+ * that when hasWork() and canWork() are both true,
+ * that the target is actually performing its work.
+ *  
+ * @author rubensworks
+ */
+public interface IWorker
+{
+    /**
+     * If the target has a valid input for things to process.
+     * In case of the vanilla furnace, this will return true if there
+     * is a valid smeltable in its input slot.
+     **/
+    boolean hasWork();
+    
+    /**
+     * If the target is able to start working in its current state,
+     * and if it is not being blocked by some external or internal factor.
+     * In case of the vanilla furnace, this will return true if there is enough
+     * fuel in its fuel slot.
+     **/
+    boolean canWork();
+}

--- a/src/main/java/net/minecraftforge/common/capabilities/work/VanillaBrewingStandWorker.java
+++ b/src/main/java/net/minecraftforge/common/capabilities/work/VanillaBrewingStandWorker.java
@@ -1,0 +1,38 @@
+package net.minecraftforge.common.capabilities.work;
+
+import net.minecraft.item.ItemStack;
+import net.minecraft.tileentity.TileEntityBrewingStand;
+import net.minecraftforge.common.brewing.BrewingRecipeRegistry;
+
+/**
+ * Worker capability for the vanilla brewing stand tile entity.
+ * @author rubensworks
+ */
+public class VanillaBrewingStandWorker implements IWorker
+{
+    private static final int[] outputSlots = new int[] {0, 1, 2};
+    
+    private final TileEntityBrewingStand brewingStand;
+
+    public VanillaBrewingStandWorker(TileEntityBrewingStand brewingStand)
+    {
+        this.brewingStand = brewingStand;
+    }
+
+    @Override
+    public boolean hasWork()
+    {
+        ItemStack[] inputs = new ItemStack[outputSlots.length]; 
+        for (int i = 0; i < inputs.length; i++)
+        {
+            inputs[i] = brewingStand.getStackInSlot(outputSlots[i]);
+        }
+        return BrewingRecipeRegistry.canBrew(inputs, brewingStand.getStackInSlot(outputSlots.length), outputSlots);
+    }
+
+    @Override
+    public boolean canWork()
+    {
+        return true; // This will become an indicator of the blaze powder in 1.9
+    }
+}

--- a/src/main/java/net/minecraftforge/common/capabilities/work/VanillaFurnaceWorker.java
+++ b/src/main/java/net/minecraftforge/common/capabilities/work/VanillaFurnaceWorker.java
@@ -1,0 +1,32 @@
+package net.minecraftforge.common.capabilities.work;
+
+import net.minecraft.item.ItemStack;
+import net.minecraft.item.crafting.FurnaceRecipes;
+import net.minecraft.tileentity.TileEntityFurnace;
+
+/**
+ * Worker capability for the vanilla furnace tile entity.
+ * @author rubensworks
+ */
+public class VanillaFurnaceWorker implements IWorker
+{
+    private final TileEntityFurnace furnace;
+
+    public VanillaFurnaceWorker(TileEntityFurnace furnace)
+    {
+        this.furnace = furnace;
+    }
+
+    @Override
+    public boolean hasWork()
+    {
+        ItemStack toMelt = furnace.getStackInSlot(0);
+        return toMelt != null && FurnaceRecipes.instance().getSmeltingResult(toMelt) != null;
+    }
+
+    @Override
+    public boolean canWork()
+    {
+        return furnace.isBurning() || TileEntityFurnace.getItemBurnTime(furnace.getStackInSlot(1)) > 0;
+    }
+}

--- a/src/test/java/net/minecraftforge/test/TestCapabilityWorkerMod.java
+++ b/src/test/java/net/minecraftforge/test/TestCapabilityWorkerMod.java
@@ -1,0 +1,43 @@
+package net.minecraftforge.test;
+
+import net.minecraft.init.Items;
+import net.minecraft.tileentity.TileEntity;
+import net.minecraftforge.common.MinecraftForge;
+import net.minecraftforge.common.capabilities.work.CapabilityWorker;
+import net.minecraftforge.common.capabilities.work.IWorker;
+import net.minecraftforge.event.entity.player.PlayerInteractEvent;
+import net.minecraftforge.fml.common.Mod;
+import net.minecraftforge.fml.common.event.FMLPreInitializationEvent;
+import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
+
+/**
+ * A simple test mod which will print the work status for worker tiles.
+ * @author rubensworks
+ */
+@Mod(modid="forge.testcapworkermod",version="1.0")
+public class TestCapabilityWorkerMod
+{
+    
+    @Mod.EventHandler
+    public void preinit(FMLPreInitializationEvent evt)
+    {
+        MinecraftForge.EVENT_BUS.register(this);
+    }
+
+    @SubscribeEvent
+    public void onInteract(PlayerInteractEvent event)
+    {
+        if (event.action != PlayerInteractEvent.Action.LEFT_CLICK_BLOCK) return;
+        if (event.entityPlayer.getHeldItem() == null) return;
+        if (event.entityPlayer.getHeldItem().getItem() != Items.blaze_rod) return;
+
+        TileEntity te = event.world.getTileEntity(event.pos);
+        if (te != null && te.hasCapability(CapabilityWorker.WORKER_CAPABILITY, event.face))
+        {
+            event.setCanceled(true);
+            IWorker worker = te.getCapability(CapabilityWorker.WORKER_CAPABILITY, event.face);
+            System.out.println("Has work: " + worker.hasWork());
+            System.out.println("Can work: " + worker.canWork());
+        }
+    }
+}


### PR DESCRIPTION
This adds the capability to read the work state of targets from furnaces and brewing stands as discussed in #2403.
Includes a test mod, right-clicking a tile with a blaze rod will print its work state to stdout.