### PR TITLE
Fix #2321

### DIFF
--- a/patches/minecraft/net/minecraft/client/renderer/WorldRenderer.java.patch
+++ b/patches/minecraft/net/minecraft/client/renderer/WorldRenderer.java.patch
@@ -1,5 +1,27 @@
 --- ../src-base/minecraft/net/minecraft/client/renderer/WorldRenderer.java
 +++ ../src-work/minecraft/net/minecraft/client/renderer/WorldRenderer.java
+@@ -506,15 +506,15 @@
+                 break;
+             case USHORT:
+             case SHORT:
+-                this.field_179001_a.putShort(i, (short)((int)p_181663_1_ * 32767 & 65535));
+-                this.field_179001_a.putShort(i + 2, (short)((int)p_181663_2_ * 32767 & 65535));
+-                this.field_179001_a.putShort(i + 4, (short)((int)p_181663_3_ * 32767 & 65535));
++                this.field_179001_a.putShort(i, (short)((int)(p_181663_1_ * 32767) & 65535));
++                this.field_179001_a.putShort(i + 2, (short)((int)(p_181663_2_ * 32767) & 65535));
++                this.field_179001_a.putShort(i + 4, (short)((int)(p_181663_3_ * 32767) & 65535));
+                 break;
+             case UBYTE:
+             case BYTE:
+-                this.field_179001_a.put(i, (byte)((int)p_181663_1_ * 127 & 255));
+-                this.field_179001_a.put(i + 1, (byte)((int)p_181663_2_ * 127 & 255));
+-                this.field_179001_a.put(i + 2, (byte)((int)p_181663_3_ * 127 & 255));
++                this.field_179001_a.put(i, (byte)((int)(p_181663_1_ * 127) & 255));
++                this.field_179001_a.put(i + 1, (byte)((int)(p_181663_2_ * 127) & 255));
++                this.field_179001_a.put(i + 2, (byte)((int)(p_181663_3_ * 127) & 255));
+         }
+ 
+         this.func_181667_k();
 @@ -578,6 +578,16 @@
          }
      }

--- a/src/test/java/net/minecraftforge/test/WRNormalMod.java
+++ b/src/test/java/net/minecraftforge/test/WRNormalMod.java
@@ -1,0 +1,114 @@
+package net.minecraftforge.test;
+
+import net.minecraft.client.model.ModelBase;
+import net.minecraft.client.model.ModelRenderer;
+import net.minecraft.client.renderer.entity.RenderManager;
+import net.minecraft.client.renderer.entity.RendererLivingEntity;
+import net.minecraft.entity.Entity;
+import net.minecraft.entity.item.EntityArmorStand;
+import net.minecraft.util.ResourceLocation;
+import net.minecraft.world.World;
+import net.minecraftforge.fml.client.registry.IRenderFactory;
+import net.minecraftforge.fml.client.registry.RenderingRegistry;
+import net.minecraftforge.fml.common.Mod;
+import net.minecraftforge.fml.common.SidedProxy;
+import net.minecraftforge.fml.common.Mod.EventHandler;
+import net.minecraftforge.fml.common.Mod.Instance;
+import net.minecraftforge.fml.common.event.FMLPreInitializationEvent;
+import net.minecraftforge.fml.common.registry.EntityRegistry;
+
+@Mod(modid = "wrnormal", version = "1.0")
+public class WRNormalMod
+{
+    @Instance("wrnormal")
+    public static WRNormalMod instance;
+
+    @SidedProxy
+    public static ServerProxy proxy;
+
+    @EventHandler
+    public void init(FMLPreInitializationEvent event)
+    {
+        EntityRegistry.registerModEntity(EntityScaleTest.class, "ScaleTest", 0, instance, 60, 3, true);
+        proxy.registerRenders();
+    }
+
+    public static class ServerProxy
+    {
+        public void registerRenders()
+        {
+        }
+    }
+
+    public static class ClientProxy extends ServerProxy
+    {
+        @Override
+        public void registerRenders()
+        {
+            RenderingRegistry.registerEntityRenderingHandler(EntityScaleTest.class, new RenderScaleTestFactory());
+        }
+    }
+
+    public static class RenderScaleTestFactory implements IRenderFactory<EntityScaleTest>
+    {
+        @Override
+        public RenderScaleTest createRenderFor(RenderManager manager)
+        {
+            return new RenderScaleTest(manager);
+        }
+    }
+
+    public static class EntityScaleTest extends EntityArmorStand
+    {
+        public EntityScaleTest(World world)
+        {
+            super(world);
+        }
+    }
+
+    public static class RenderScaleTest extends RendererLivingEntity<EntityScaleTest>
+    {
+        private static final ResourceLocation TEXTURE = new ResourceLocation("textures/blocks/stone.png");
+
+        public RenderScaleTest(RenderManager manager)
+        {
+            super(manager, new ModelScaleTest(), 0);
+        }
+
+        @Override
+        public void renderName(EntityScaleTest entity, double x, double y, double z)
+        {
+        }
+
+        @Override
+        protected ResourceLocation getEntityTexture(EntityScaleTest entity)
+        {
+            return TEXTURE;
+        }
+    }
+
+    public static class ModelScaleTest extends ModelBase
+    {
+        private ModelRenderer component;
+
+        public ModelScaleTest()
+        {
+            textureWidth = textureHeight = 16;
+            component = new ModelRenderer(this);
+            int size = 10;
+            for (int x = 0; x < size; x++)
+            {
+                for (int z = 0; z < size; z++)
+                {
+                    component.addBox((x - size / 2) * 3, 0, (z - size / 2) * 3, 2, 2, 2, -(x + z * size) / (float) (size * size) * 0.5F);
+                }
+            }
+        }
+
+        @Override
+        public void render(Entity entity, float p1, float p2, float p3, float p4, float p5, float scale)
+        {
+            component.render(scale);
+        }
+    }
+}


### PR DESCRIPTION
This fixes WorldRenderer's incorrect behavior of casting the x, y, and z components of the normal passed into WorlderRenderer#normal(float,float,float) to integers when the normal type is short or byte before the values are scaled to fit the size of the type. This results in the fractional part of normals being discarded, which is evident when attempting to use the scale factor of ModelBoxs in ModelRenderers. Certain scale factors will cause the computed normals of some TexturedQuads to be a zero vector by containing components that are just slightly less than 1 or just above -1, resulting in incorrect lighting for that particular face. Below are before and after screenshots of my patch with ModelBoxes of scale factors ranging from -0.5 to 0.
### Before
![Before Patch](http://i.imgur.com/gjuVCL3.png)
### After
![After Patch](http://i.imgur.com/ETe11op.png)
***
In addition to the patch this PR includes a test mod that adds an entity with the model shown in the before and after screenshots. It can be summed with the following command:
`/summon wrnormal.ScaleTest`