### PR TITLE
Fix: Wrong block state in punch, run, & fall particles

### DIFF
--- a/patches/minecraft/net/minecraft/client/particle/EffectRenderer.java.patch
+++ b/patches/minecraft/net/minecraft/client/particle/EffectRenderer.java.patch
@@ -17,6 +17,15 @@
          {
              p_180533_2_ = p_180533_2_.func_177230_c().func_176221_a(p_180533_2_, this.field_78878_a, p_180533_1_);
              int i = 4;
+@@ -376,7 +377,7 @@
+     {
+         IBlockState iblockstate = this.field_78878_a.func_180495_p(p_180532_1_);
+         Block block = iblockstate.func_177230_c();
+-
++        iblockstate = block.func_176221_a(iblockstate, this.field_78878_a, p_180532_1_);
+         if (block.func_149645_b() != -1)
+         {
+             int i = p_180532_1_.func_177958_n();
 @@ -457,4 +458,13 @@
  
          return "" + i;

--- a/patches/minecraft/net/minecraft/client/particle/EntityBlockDustFX.java.patch
+++ b/patches/minecraft/net/minecraft/client/particle/EntityBlockDustFX.java.patch
@@ -1,0 +1,11 @@
+--- ../src-base/minecraft/net/minecraft/client/particle/EntityBlockDustFX.java
++++ ../src-work/minecraft/net/minecraft/client/particle/EntityBlockDustFX.java
+@@ -22,7 +22,7 @@
+         {
+             public EntityFX func_178902_a(int p_178902_1_, World p_178902_2_, double p_178902_3_, double p_178902_5_, double p_178902_7_, double p_178902_9_, double p_178902_11_, double p_178902_13_, int... p_178902_15_)
+             {
+-                IBlockState iblockstate = Block.func_176220_d(p_178902_15_[0]);
++                IBlockState iblockstate = net.minecraftforge.client.ForgeHooksClient.getStateForEntityFX(p_178902_2_, p_178902_15_);
+                 return iblockstate.func_177230_c().func_149645_b() == -1 ? null : (new EntityBlockDustFX(p_178902_2_, p_178902_3_, p_178902_5_, p_178902_7_, p_178902_9_, p_178902_11_, p_178902_13_, iblockstate)).func_174845_l();
+             }
+         }

--- a/patches/minecraft/net/minecraft/client/particle/EntityDiggingFX.java.patch
+++ b/patches/minecraft/net/minecraft/client/particle/EntityDiggingFX.java.patch
@@ -1,0 +1,11 @@
+--- ../src-base/minecraft/net/minecraft/client/particle/EntityDiggingFX.java
++++ ../src-work/minecraft/net/minecraft/client/particle/EntityDiggingFX.java
+@@ -115,7 +115,7 @@
+         {
+             public EntityFX func_178902_a(int p_178902_1_, World p_178902_2_, double p_178902_3_, double p_178902_5_, double p_178902_7_, double p_178902_9_, double p_178902_11_, double p_178902_13_, int... p_178902_15_)
+             {
+-                return (new EntityDiggingFX(p_178902_2_, p_178902_3_, p_178902_5_, p_178902_7_, p_178902_9_, p_178902_11_, p_178902_13_, Block.func_176220_d(p_178902_15_[0]))).func_174845_l();
++                return (new EntityDiggingFX(p_178902_2_, p_178902_3_, p_178902_5_, p_178902_7_, p_178902_9_, p_178902_11_, p_178902_13_, net.minecraftforge.client.ForgeHooksClient.getStateForEntityFX(p_178902_2_, p_178902_15_))).func_174845_l();
+             }
+         }
+ }

--- a/patches/minecraft/net/minecraft/entity/Entity.java.patch
+++ b/patches/minecraft/net/minecraft/entity/Entity.java.patch
@@ -35,6 +35,15 @@
      }
  
      protected abstract void func_70088_a();
+@@ -980,7 +992,7 @@
+ 
+         if (block.func_149645_b() != -1)
+         {
+-            this.field_70170_p.func_175688_a(EnumParticleTypes.BLOCK_CRACK, this.field_70165_t + ((double)this.field_70146_Z.nextFloat() - 0.5D) * (double)this.field_70130_N, this.func_174813_aQ().field_72338_b + 0.1D, this.field_70161_v + ((double)this.field_70146_Z.nextFloat() - 0.5D) * (double)this.field_70130_N, -this.field_70159_w * 4.0D, 1.5D, -this.field_70179_y * 4.0D, new int[] {Block.func_176210_f(iblockstate)});
++            this.field_70170_p.func_175688_a(EnumParticleTypes.BLOCK_CRACK, this.field_70165_t + ((double)this.field_70146_Z.nextFloat() - 0.5D) * (double)this.field_70130_N, this.func_174813_aQ().field_72338_b + 0.1D, this.field_70161_v + ((double)this.field_70146_Z.nextFloat() - 0.5D) * (double)this.field_70130_N, -this.field_70159_w * 4.0D, 1.5D, -this.field_70179_y * 4.0D, new int[] {Block.func_176210_f(iblockstate), i, ((int)Math.ceil(this.field_70163_u) - 1), k});
+         }
+     }
+ 
 @@ -998,10 +1010,7 @@
  
          if (block.func_149688_o() == p_70055_1_)

--- a/patches/minecraft/net/minecraft/entity/EntityLivingBase.java.patch
+++ b/patches/minecraft/net/minecraft/entity/EntityLivingBase.java.patch
@@ -1,13 +1,15 @@
 --- ../src-base/minecraft/net/minecraft/entity/EntityLivingBase.java
 +++ ../src-work/minecraft/net/minecraft/entity/EntityLivingBase.java
-@@ -170,6 +170,7 @@
+@@ -170,7 +170,8 @@
                  }
  
                  int i = (int)(150.0D * d0);
+-                ((WorldServer)this.field_70170_p).func_175739_a(EnumParticleTypes.BLOCK_DUST, this.field_70165_t, this.field_70163_u, this.field_70161_v, i, 0.0D, 0.0D, 0.0D, 0.15000000596046448D, new int[] {Block.func_176210_f(iblockstate)});
 +                if ( !block.addLandingEffects( (WorldServer)this.field_70170_p, p_180433_5_, iblockstate, this, i ) )
-                 ((WorldServer)this.field_70170_p).func_175739_a(EnumParticleTypes.BLOCK_DUST, this.field_70165_t, this.field_70163_u, this.field_70161_v, i, 0.0D, 0.0D, 0.0D, 0.15000000596046448D, new int[] {Block.func_176210_f(iblockstate)});
++                ((WorldServer)this.field_70170_p).func_175739_a(EnumParticleTypes.BLOCK_DUST, this.field_70165_t, this.field_70163_u, this.field_70161_v, i, 0.0D, 0.0D, 0.0D, 0.15000000596046448D, new int[] {Block.func_176210_f(iblockstate), p_180433_5_.func_177958_n(), ((int)Math.ceil(this.field_70163_u) - 1), p_180433_5_.func_177952_p()});
              }
          }
+ 
 @@ -237,7 +238,7 @@
                      }
                  }

--- a/src/main/java/net/minecraftforge/client/ForgeHooksClient.java
+++ b/src/main/java/net/minecraftforge/client/ForgeHooksClient.java
@@ -576,4 +576,19 @@ public class ForgeHooksClient
         if(part.isPresent()) return Optional.absent();
         return Optional.of(new TRSRTransformation(matrix));
     }
+
+    public static IBlockState getStateForEntityFX(World world, int... arguments)
+    {
+        IBlockState state = Block.getStateById(arguments[0]);
+        if (arguments.length == 4)
+        {
+            BlockPos pos = new BlockPos(arguments[1], arguments[2], arguments[3]);
+            if (!world.isAirBlock(pos))
+            {
+                state = world.getBlockState(pos);
+                state = state.getBlock().getActualState(state, world, pos);
+            }
+        }
+        return state;
+    }
 }


### PR DESCRIPTION
Fixes incorrect punch, run, and fall particles on mod blocks that rely on tile entity data for texture.

Punch fix is done in EffectRenderer.addBlockHitEffects by adding a call to getActualState.

Run is fixed by passing the block's position from Entity.createRunningParticles to EntityDiggingFX.Factory.getEntityFX which is passed to ForgeHooksClient.getStateForEntityFX

Fall is fixed by passing the block's position from EntityLivingBase.updateFallState to EntityBlockDustFX.Factory.getEntityFX which is passed to ForgeHooksClient.getStateForEntityFX

A side effect is vanilla carpet now uses it own particles.

Closes: https://github.com/MinecraftForge/MinecraftForge/issues/2440