### PR TITLE
Workaround JDK-8087309: Constant folding "static final boolean" is incomplete

### DIFF
--- a/src/main/java/net/minecraftforge/fml/common/eventhandler/ASMEventHandler.java
+++ b/src/main/java/net/minecraftforge/fml/common/eventhandler/ASMEventHandler.java
@@ -40,14 +40,8 @@ public class ASMEventHandler implements IEventListener
     @Override
     public void invoke(Event event)
     {
-        if (owner != null && GETCONTEXT)
-        {
-            ThreadContext.put("mod", owner.getName());
-        }
-        else if (GETCONTEXT)
-        {
-            ThreadContext.put("mod", "");
-        }
+        if (GETCONTEXT)
+            ThreadContext.put("mod", owner == null ? "" : owner.getName());
         if (handler != null)
         {
             if (!event.isCancelable() || !event.isCanceled() || subInfo.receiveCanceled())


### PR DESCRIPTION
https://bugs.openjdk.java.net/browse/JDK-8087309

Workaround for a JVM bug preventing constant folding. As event invocation is a hot code path, it seems worth fixing.

The change could be reduced to swapping `(owner != null && GETCONTEXT)` with `(GETCONTEXT && owner != null)`, but replacing the two ifs by using a ternary operator seemed cleaner.