### PR TITLE
Add validation to WeightedRandomChestContent and BiomeGenBase.SpawnListEntry

### DIFF
--- a/patches/minecraft/net/minecraft/util/WeightedRandomChestContent.java.patch
+++ b/patches/minecraft/net/minecraft/util/WeightedRandomChestContent.java.patch
@@ -1,6 +1,22 @@
 --- ../src-base/minecraft/net/minecraft/util/WeightedRandomChestContent.java
 +++ ../src-work/minecraft/net/minecraft/util/WeightedRandomChestContent.java
-@@ -36,48 +36,39 @@
+@@ -18,6 +18,7 @@
+     public WeightedRandomChestContent(Item p_i45311_1_, int p_i45311_2_, int p_i45311_3_, int p_i45311_4_, int p_i45311_5_)
+     {
+         super(p_i45311_5_);
++        net.minecraftforge.common.ForgeHooks.validateMinMax(p_i45311_3_, p_i45311_4_, "StackSize");
+         this.field_76297_b = new ItemStack(p_i45311_1_, 1, p_i45311_2_);
+         this.field_76295_d = p_i45311_3_;
+         this.field_76296_e = p_i45311_4_;
+@@ -26,6 +27,7 @@
+     public WeightedRandomChestContent(ItemStack p_i1558_1_, int p_i1558_2_, int p_i1558_3_, int p_i1558_4_)
+     {
+         super(p_i1558_4_);
++        net.minecraftforge.common.ForgeHooks.validateMinMax(p_i1558_2_, p_i1558_3_, "StackSize");
+         this.field_76297_b = p_i1558_1_;
+         this.field_76295_d = p_i1558_2_;
+         this.field_76296_e = p_i1558_3_;
+@@ -36,48 +38,39 @@
          for (int i = 0; i < p_177630_3_; ++i)
          {
              WeightedRandomChestContent weightedrandomchestcontent = (WeightedRandomChestContent)WeightedRandom.func_76271_a(p_177630_0_, p_177630_1_);

--- a/patches/minecraft/net/minecraft/world/biome/BiomeGenBase.java.patch
+++ b/patches/minecraft/net/minecraft/world/biome/BiomeGenBase.java.patch
@@ -136,3 +136,11 @@
      static
      {
          field_76772_c.func_150566_k();
+@@ -574,6 +658,7 @@
+             public SpawnListEntry(Class <? extends EntityLiving > p_i1970_1_, int p_i1970_2_, int p_i1970_3_, int p_i1970_4_)
+             {
+                 super(p_i1970_2_);
++                net.minecraftforge.common.ForgeHooks.validateMinMax(p_i1970_3_, p_i1970_4_, "GroupCount");
+                 this.field_76300_b = p_i1970_1_;
+                 this.field_76301_c = p_i1970_3_;
+                 this.field_76299_d = p_i1970_4_;

--- a/src/main/java/net/minecraftforge/common/ForgeHooks.java
+++ b/src/main/java/net/minecraftforge/common/ForgeHooks.java
@@ -923,4 +923,10 @@ public class ForgeHooks
         }
         return !event.isCanceled();
     }
+    
+    public static void validateMinMax(int min, int max, String name)
+    {
+    	if (min > max)
+            throw new IllegalArgumentException(String.format("min%1$s must be <= max%1$s", name));
+    }
 }


### PR DESCRIPTION
The above mentioned classes take min and max arguments of some kind. If a min value greater than max is passed in a very [unhelpful crash](http://pastebin.com/raw/bp6s0FG3) (from [this forum post](http://www.minecraftforge.net/forum/index.php/topic,36729.0.html)) is produced which does not point to a particular mod.
This changes this behavior to being fail-fast at the point of creation, which would then first of all contain the classes responsible for the error in the stacktrace and also make it easier for mod creators to discover this type of mistake.
I've limited this to the `WeightedRandom.Item` subtypes, since that's the only place where this is an issue that I am aware of.