### PR TITLE
Fix the entity shader hook

### DIFF
--- a/patches/minecraft/net/minecraft/client/renderer/EntityRenderer.java.patch
+++ b/patches/minecraft/net/minecraft/client/renderer/EntityRenderer.java.patch
@@ -4,7 +4,7 @@
              {
                  this.func_175069_a(new ResourceLocation("shaders/post/invert.json"));
              }
-+            else net.minecraftforge.client.ForgeHooksClient.loadEntityShader(p_175066_1_.getClass(), this);
++            else net.minecraftforge.client.ForgeHooksClient.loadEntityShader(p_175066_1_, this);
          }
      }
  

--- a/src/main/java/net/minecraftforge/client/ForgeHooksClient.java
+++ b/src/main/java/net/minecraftforge/client/ForgeHooksClient.java
@@ -575,12 +575,15 @@ public class ForgeHooksClient
         return Optional.of(new TRSRTransformation(matrix));
     }
 
-    public static void loadEntityShader(Class<? extends Entity> entityClass, EntityRenderer entityRenderer)
+    public static void loadEntityShader(Entity entity, EntityRenderer entityRenderer)
     {
-        ResourceLocation shader = ClientRegistry.getEntityShader(entityClass);
-        if (shader != null)
+        if (entity != null)
         {
-            entityRenderer.loadShader(shader);
+            ResourceLocation shader = ClientRegistry.getEntityShader(entity.getClass());
+            if (shader != null)
+            {
+                entityRenderer.loadShader(shader);
+            }
         }
     }
 }


### PR DESCRIPTION
Fixes [the NPE](http://pastebin.com/egAXxAxB) caused by https://github.com/MinecraftForge/MinecraftForge/pull/2467.
