### PR TITLE
Fix universal bucket logging an exception

### DIFF
--- a/src/main/java/net/minecraftforge/client/model/ModelLoader.java
+++ b/src/main/java/net/minecraftforge/client/model/ModelLoader.java
@@ -219,13 +219,13 @@ public class ModelLoader extends ModelBakery
 
     private void loadItems()
     {
-        registerVariantNames();
-
         // register model for the universal bucket, if it exists
         if(FluidRegistry.isUniversalBucketEnabled())
         {
             setBucketModelDefinition(ForgeModContainer.getInstance().universalBucket);
         }
+
+        registerVariantNames();
         
         List<String> itemVariants = Lists.newArrayList();
         for(Item item : GameData.getItemRegistry().typeSafeIterable())


### PR DESCRIPTION
Fucked up the order in which things are registered/called. Prevents MC from trying to load the default-model for the universal bucket item instead of using the forgebucket model on the initial loading pass.