### PR TITLE
Fix WorldEvent.PotentialSpawns Event passing the list instance of the…

### DIFF
--- a/src/main/java/net/minecraftforge/event/world/WorldEvent.java
+++ b/src/main/java/net/minecraftforge/event/world/WorldEvent.java
@@ -103,7 +103,7 @@ public class WorldEvent extends Event
             this.type = type;
             if (oldList != null)
             {
-                this.list = oldList;
+                this.list = new ArrayList<SpawnListEntry>(oldList);
             }
             else
             {


### PR DESCRIPTION
… ChunkProvider to users

Basically if you modify the list in any way in that event, you modify the list instance saved in the chunkprovider, meaning the modification will be there/removed for ALL future calls instead of only the one where the list was changed through the event.