### PR TITLE
Fix WordServer.canCreatureTypeSpawnHere not using Forge Events.

### DIFF
--- a/patches/minecraft/net/minecraft/world/WorldServer.java.patch
+++ b/patches/minecraft/net/minecraft/world/WorldServer.java.patch
@@ -60,7 +60,7 @@
          this.field_72984_F.func_76319_b();
          this.func_147488_Z();
      }
-@@ -217,6 +237,7 @@
+@@ -217,12 +237,14 @@
      public BiomeGenBase.SpawnListEntry func_175734_a(EnumCreatureType p_175734_1_, BlockPos p_175734_2_)
      {
          List<BiomeGenBase.SpawnListEntry> list = this.func_72863_F().func_177458_a(p_175734_1_, p_175734_2_);
@@ -68,7 +68,14 @@
          return list != null && !list.isEmpty() ? (BiomeGenBase.SpawnListEntry)WeightedRandom.func_76271_a(this.field_73012_v, list) : null;
      }
  
-@@ -268,10 +289,7 @@
+     public boolean func_175732_a(EnumCreatureType p_175732_1_, BiomeGenBase.SpawnListEntry p_175732_2_, BlockPos p_175732_3_)
+     {
+         List<BiomeGenBase.SpawnListEntry> list = this.func_72863_F().func_177458_a(p_175732_1_, p_175732_3_);
++        list = net.minecraftforge.event.ForgeEventFactory.getPotentialSpawns(this, p_175732_1_, p_175732_3_, list);
+         return list != null && !list.isEmpty() ? list.contains(p_175732_2_) : false;
+     }
+ 
+@@ -268,10 +290,7 @@
  
      private void func_73051_P()
      {

--- a/src/main/java/net/minecraftforge/event/world/WorldEvent.java
+++ b/src/main/java/net/minecraftforge/event/world/WorldEvent.java
@@ -87,6 +87,10 @@ public class WorldEvent extends Event
 
     /**
      * Called by WorldServer to gather a list of all possible entities that can spawn at the specified location.
+     * If an entry is added to the list, it needs to be a globally unique instance.
+     * The event is called in WorldServer#getSpawnListEntryForTypeAt(EnumCreatureType, BlockPos) as well as
+     * WorldServer#canCreatureTypeSpawnHere(EnumCreatureType creatureType, BiomeGenBase.SpawnListEntry spawnListEntry, BlockPos pos)
+     * where the latter checks for identity, meaning both events must add the same instance.
      * Canceling the event will result in a empty list, meaning no entity will be spawned.
      */
     @Cancelable


### PR DESCRIPTION
Followup of #2496

Also expanded the events documentation.