### PR TITLE
Added local click position to PlayerInteractEvent. Fixes #2482

### DIFF
--- a/patches/minecraft/net/minecraft/client/Minecraft.java.patch
+++ b/patches/minecraft/net/minecraft/client/Minecraft.java.patch
@@ -170,7 +170,7 @@
                              int i = itemstack != null ? itemstack.field_77994_a : 0;
  
 +
-+                            boolean result = !net.minecraftforge.event.ForgeEventFactory.onPlayerInteract(field_71439_g, net.minecraftforge.event.entity.player.PlayerInteractEvent.Action.RIGHT_CLICK_BLOCK, this.field_71441_e, blockpos, this.field_71476_x.field_178784_b).isCanceled();
++                            boolean result = !net.minecraftforge.event.ForgeEventFactory.onPlayerInteract(field_71439_g, net.minecraftforge.event.entity.player.PlayerInteractEvent.Action.RIGHT_CLICK_BLOCK, this.field_71441_e, blockpos, this.field_71476_x.field_178784_b, this.field_71476_x.field_72307_f).isCanceled();
 +                            if (result) { //Forge: Kept separate to simplify patch
                              if (this.field_71442_b.func_178890_a(this.field_71439_g, this.field_71441_e, itemstack, blockpos, this.field_71476_x.field_178784_b, this.field_71476_x.field_72307_f))
                              {
@@ -186,7 +186,7 @@
                  ItemStack itemstack1 = this.field_71439_g.field_71071_by.func_70448_g();
  
 -                if (itemstack1 != null && this.field_71442_b.func_78769_a(this.field_71439_g, this.field_71441_e, itemstack1))
-+                boolean result = !net.minecraftforge.event.ForgeEventFactory.onPlayerInteract(field_71439_g, net.minecraftforge.event.entity.player.PlayerInteractEvent.Action.RIGHT_CLICK_AIR, field_71441_e, null, null).isCanceled();
++                boolean result = !net.minecraftforge.event.ForgeEventFactory.onPlayerInteract(field_71439_g, net.minecraftforge.event.entity.player.PlayerInteractEvent.Action.RIGHT_CLICK_AIR, field_71441_e, null, null, null).isCanceled();
 +                if (result && itemstack1 != null && this.field_71442_b.func_78769_a(this.field_71439_g, this.field_71441_e, itemstack1))
                  {
                      this.field_71460_t.field_78516_c.func_78445_c();

--- a/patches/minecraft/net/minecraft/network/NetHandlerPlayServer.java.patch
+++ b/patches/minecraft/net/minecraft/network/NetHandlerPlayServer.java.patch
@@ -69,7 +69,7 @@
                  return;
              }
  
-+            net.minecraftforge.event.entity.player.PlayerInteractEvent event = net.minecraftforge.event.ForgeEventFactory.onPlayerInteract(field_147369_b, net.minecraftforge.event.entity.player.PlayerInteractEvent.Action.RIGHT_CLICK_AIR, worldserver, new BlockPos(0, 0, 0), null);
++            net.minecraftforge.event.entity.player.PlayerInteractEvent event = net.minecraftforge.event.ForgeEventFactory.onPlayerInteract(field_147369_b, net.minecraftforge.event.entity.player.PlayerInteractEvent.Action.RIGHT_CLICK_AIR, worldserver, new BlockPos(0, 0, 0), null, new net.minecraft.util.Vec3(p_147346_1_.func_149573_h(), p_147346_1_.func_149569_i(), p_147346_1_.func_149575_j()));
 +            if (event.useItem != net.minecraftforge.fml.common.eventhandler.Event.Result.DENY)
 +            {
              this.field_147369_b.field_71134_c.func_73085_a(this.field_147369_b, worldserver, itemstack);

--- a/patches/minecraft/net/minecraft/server/management/ItemInWorldManager.java.patch
+++ b/patches/minecraft/net/minecraft/server/management/ItemInWorldManager.java.patch
@@ -23,7 +23,7 @@
      public void func_180784_a(BlockPos p_180784_1_, EnumFacing p_180784_2_)
      {
 +        net.minecraftforge.event.entity.player.PlayerInteractEvent event = net.minecraftforge.event.ForgeEventFactory.onPlayerInteract(field_73090_b,
-+                net.minecraftforge.event.entity.player.PlayerInteractEvent.Action.LEFT_CLICK_BLOCK, field_73092_a, p_180784_1_, p_180784_2_);
++                net.minecraftforge.event.entity.player.PlayerInteractEvent.Action.LEFT_CLICK_BLOCK, field_73092_a, p_180784_1_, p_180784_2_, net.minecraftforge.common.ForgeHooks.rayTraceEyeHitVec(field_73090_b, getBlockReachDistance() + 1));
 +        if (event.isCanceled())
 +        {
 +            field_73090_b.field_71135_a.func_147359_a(new S23PacketBlockChange(field_73092_a, p_180784_1_));
@@ -186,7 +186,7 @@
          {
 -            if (!p_180236_1_.func_70093_af() || p_180236_1_.func_70694_bm() == null)
 +            net.minecraftforge.event.entity.player.PlayerInteractEvent event = net.minecraftforge.event.ForgeEventFactory.onPlayerInteract(p_180236_1_,
-+                    net.minecraftforge.event.entity.player.PlayerInteractEvent.Action.RIGHT_CLICK_BLOCK, p_180236_2_, p_180236_4_, p_180236_5_);
++                    net.minecraftforge.event.entity.player.PlayerInteractEvent.Action.RIGHT_CLICK_BLOCK, p_180236_2_, p_180236_4_, p_180236_5_, new net.minecraft.util.Vec3(p_180236_6_, p_180236_7_, p_180236_8_));
 +            if (event.isCanceled())
              {
 -                IBlockState iblockstate = p_180236_2_.func_180495_p(p_180236_4_);

--- a/src/main/java/net/minecraftforge/common/ForgeHooks.java
+++ b/src/main/java/net/minecraftforge/common/ForgeHooks.java
@@ -64,6 +64,7 @@ import net.minecraft.util.IChatComponent;
 import net.minecraft.util.MathHelper;
 import net.minecraft.util.MovingObjectPosition;
 import net.minecraft.util.MovingObjectPosition.MovingObjectType;
+import net.minecraft.util.Vec3;
 import net.minecraft.util.WeightedRandom;
 import net.minecraft.world.IBlockAccess;
 import net.minecraft.world.World;
@@ -922,5 +923,18 @@ public class ForgeHooks
             }
         }
         return !event.isCanceled();
+    }
+
+    public static MovingObjectPosition rayTraceEyes(EntityLivingBase entity, double length)
+    {
+        Vec3 startPos = new Vec3(entity.posX, entity.posY + entity.getEyeHeight(), entity.posZ);
+        Vec3 endPos = startPos.add(new Vec3(entity.getLookVec().xCoord * length, entity.getLookVec().yCoord * length, entity.getLookVec().zCoord * length));
+        return entity.worldObj.rayTraceBlocks(startPos, endPos);
+    }
+
+    public static Vec3 rayTraceEyeHitVec(EntityLivingBase entity, double length)
+    {
+        MovingObjectPosition movingObjectPosition = rayTraceEyes(entity, length);
+        return movingObjectPosition == null ? null : movingObjectPosition.hitVec;
     }
 }

--- a/src/main/java/net/minecraftforge/event/ForgeEventFactory.java
+++ b/src/main/java/net/minecraftforge/event/ForgeEventFactory.java
@@ -24,6 +24,7 @@ import net.minecraft.util.DamageSource;
 import net.minecraft.util.EnumFacing;
 import net.minecraft.util.IChatComponent;
 import net.minecraft.util.MovingObjectPosition;
+import net.minecraft.util.Vec3;
 import net.minecraft.world.Explosion;
 import net.minecraft.world.World;
 import net.minecraft.world.WorldServer;
@@ -117,9 +118,15 @@ public class ForgeEventFactory
         return (MinecraftForge.EVENT_BUS.post(event) ? -1 : event.newSpeed);
     }
 
+    @Deprecated
     public static PlayerInteractEvent onPlayerInteract(EntityPlayer player, Action action, World world, BlockPos pos, EnumFacing face)
     {
-        PlayerInteractEvent event = new PlayerInteractEvent(player, action, pos, face, world);
+        return onPlayerInteract(player, action, world, pos, face, null);
+    }
+
+    public static PlayerInteractEvent onPlayerInteract(EntityPlayer player, Action action, World world, BlockPos pos, EnumFacing face, Vec3 localPos)
+    {
+        PlayerInteractEvent event = new PlayerInteractEvent(player, action, pos, face, world, localPos);
         MinecraftForge.EVENT_BUS.post(event);
         return event;
     }

--- a/src/main/java/net/minecraftforge/event/entity/player/PlayerInteractEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/player/PlayerInteractEvent.java
@@ -5,6 +5,7 @@ import static net.minecraftforge.fml.common.eventhandler.Event.Result.DENY;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.util.BlockPos;
 import net.minecraft.util.EnumFacing;
+import net.minecraft.util.Vec3;
 import net.minecraft.world.World;
 import net.minecraftforge.fml.common.eventhandler.Cancelable;
 
@@ -45,11 +46,18 @@ public class PlayerInteractEvent extends PlayerEvent
     public final World world;
     public final BlockPos pos;
     public final EnumFacing face; // Can be null if unknown
+    public final Vec3 localPos; // Can be null if unknown
 
     public Result useBlock = DEFAULT;
     public Result useItem = DEFAULT;
 
+    @Deprecated
     public PlayerInteractEvent(EntityPlayer player, Action action, BlockPos pos, EnumFacing face, World world)
+    {
+        this(player, action, pos, face, world, null);
+    }
+
+    public PlayerInteractEvent(EntityPlayer player, Action action, BlockPos pos, EnumFacing face, World world, Vec3 localPos)
     {
         super(player);
         this.action = action;
@@ -57,6 +65,7 @@ public class PlayerInteractEvent extends PlayerEvent
         this.face = face;
         if (face == null) useBlock = DENY;
         this.world = world;
+        this.localPos = localPos;
     }
 
     @Override

--- a/src/test/java/net/minecraftforge/test/PlayerInteractEventLocalTest.java
+++ b/src/test/java/net/minecraftforge/test/PlayerInteractEventLocalTest.java
@@ -1,0 +1,29 @@
+package net.minecraftforge.test;
+
+import net.minecraftforge.common.MinecraftForge;
+import net.minecraftforge.event.entity.player.PlayerInteractEvent;
+import net.minecraftforge.fml.common.Mod;
+import net.minecraftforge.fml.common.Mod.EventHandler;
+import net.minecraftforge.fml.common.event.FMLInitializationEvent;
+import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
+
+@Mod(modid="PlayerInteractEventLocalTest", name="PlayerInteractEventLocalTest", version="0.0.0")
+public class PlayerInteractEventLocalTest
+{
+
+    public static final boolean ENABLE = false;
+    
+    @EventHandler
+    public void init(FMLInitializationEvent event) 
+    {
+        MinecraftForge.EVENT_BUS.register(this);
+    }
+    
+    @SubscribeEvent
+    public void onPlayerInteract(PlayerInteractEvent event)
+    {
+        if(ENABLE && event.localPos != null) {
+            System.out.println(event.localPos.toString());
+        }
+    }
+}


### PR DESCRIPTION
This PR adds the ability to obtain the locally clicked position for some interact events.

The local position refers to where on the face of the block the click took place, and can be very useful information for mods to have.

I specifically made this PR so that SpongeForge can grab it from the event, as the SpongeAPI interact event contains a method to grab this information.