### PR TITLE
Fixed minor typo in item registering.

### DIFF
--- a/src/main/java/net/minecraftforge/fml/common/registry/GameRegistry.java
+++ b/src/main/java/net/minecraftforge/fml/common/registry/GameRegistry.java
@@ -147,7 +147,7 @@ public class GameRegistry
     {
         if (Strings.isNullOrEmpty(name))
         {
-            throw new IllegalArgumentException("Attempted to register a block with no name: " + item);
+            throw new IllegalArgumentException("Attempted to register an item with no name: " + item);
         }
         GameData.getMain().registerItem(item, name);
     }


### PR DESCRIPTION
The old warning message would refer to the item as a block. This changes the message to refer to it as an item. Not a huge issue, but makes it easier to differentiate between the two messages at a glance. 