### PR TITLE
BiomeGenBase: Rename some functions for ease of use

### DIFF
--- a/patches.mcp/minecraft/net/minecraft/client/gui/GuiCustomizeWorldScreen.java.patch
+++ b/patches.mcp/minecraft/net/minecraft/client/gui/GuiCustomizeWorldScreen.java.patch
@@ -1,0 +1,17 @@
+--- ../src-base/minecraft/net/minecraft/client/gui/GuiCustomizeWorldScreen.java
++++ ../src-work/minecraft/net/minecraft/client/gui/GuiCustomizeWorldScreen.java
+@@ -305,12 +305,12 @@
+                 else if ((int)p_175330_2_ >= BiomeGenBase.func_185362_a(Biomes.hell))
+                 {
+                     BiomeGenBase biomegenbase1 = BiomeGenBase.func_185357_a((int)p_175330_2_ + 2);
+-                    return biomegenbase1 != null ? biomegenbase1.func_185359_l() : "?";
++                    return biomegenbase1 != null ? biomegenbase1.getBiomeName() : "?";
+                 }
+                 else
+                 {
+                     BiomeGenBase biomegenbase = BiomeGenBase.func_185357_a((int)p_175330_2_);
+-                    return biomegenbase != null ? biomegenbase.func_185359_l() : "?";
++                    return biomegenbase != null ? biomegenbase.getBiomeName() : "?";
+                 }
+         }
+     }

--- a/patches.mcp/minecraft/net/minecraft/client/gui/GuiOverlayDebug.java.patch
+++ b/patches.mcp/minecraft/net/minecraft/client/gui/GuiOverlayDebug.java.patch
@@ -1,5 +1,14 @@
 --- ../src-base/minecraft/net/minecraft/client/gui/GuiOverlayDebug.java
 +++ ../src-work/minecraft/net/minecraft/client/gui/GuiOverlayDebug.java
+@@ -145,7 +145,7 @@
+                 }
+                 else if (!chunk.isEmpty())
+                 {
+-                    list.add("Biome: " + chunk.getBiome(blockpos, this.mc.theWorld.getWorldChunkManager()).func_185359_l());
++                    list.add("Biome: " + chunk.getBiome(blockpos, this.mc.theWorld.getWorldChunkManager()).getBiomeName());
+                     list.add("Light: " + chunk.getLightSubtracted(blockpos, 0) + " (" + chunk.getLightFor(EnumSkyBlock.SKY, blockpos) + " sky, " + chunk.getLightFor(EnumSkyBlock.BLOCK, blockpos) + " block)");
+                     DifficultyInstance difficultyinstance = this.mc.theWorld.getDifficultyForLocation(blockpos);
+ 
 @@ -190,6 +190,9 @@
          long l = j - k;
          List<String> list = Lists.newArrayList(new String[] {String.format("Java: %s %dbit", new Object[]{System.getProperty("java.version"), Integer.valueOf(this.mc.isJava64bit() ? 64 : 32)}), String.format("Mem: % 2d%% %03d/%03dMB", new Object[]{Long.valueOf(l * 100L / i), Long.valueOf(bytesToMb(l)), Long.valueOf(bytesToMb(i))}), String.format("Allocated: % 2d%% %03dMB", new Object[]{Long.valueOf(j * 100L / i), Long.valueOf(bytesToMb(j))}), "", String.format("CPU: %s", new Object[]{OpenGlHelper.getCpu()}), "", String.format("Display: %dx%d (%s)", new Object[]{Integer.valueOf(Display.getWidth()), Integer.valueOf(Display.getHeight()), GlStateManager.func_187416_u(7936)}), GlStateManager.func_187416_u(7937), GlStateManager.func_187416_u(7938)});

--- a/patches.mcp/minecraft/net/minecraft/entity/player/EntityPlayerMP.java.patch
+++ b/patches.mcp/minecraft/net/minecraft/entity/player/EntityPlayerMP.java.patch
@@ -27,6 +27,24 @@
          {
              this.closeScreen();
              this.openContainer = this.inventoryContainer;
+@@ -390,7 +391,7 @@
+     protected void updateBiomesExplored()
+     {
+         BiomeGenBase biomegenbase = this.worldObj.getBiomeGenForCoords(new BlockPos(MathHelper.floor_double(this.posX), 0, MathHelper.floor_double(this.posZ)));
+-        String s = biomegenbase.func_185359_l();
++        String s = biomegenbase.getBiomeName();
+         JsonSerializableSet jsonserializableset = (JsonSerializableSet)this.getStatFile().func_150870_b(AchievementList.field_187979_L);
+ 
+         if (jsonserializableset == null)
+@@ -412,7 +413,7 @@
+                 {
+                     BiomeGenBase biomegenbase1 = (BiomeGenBase)iterator.next();
+ 
+-                    if (biomegenbase1.func_185359_l().equals(s1))
++                    if (biomegenbase1.getBiomeName().equals(s1))
+                     {
+                         iterator.remove();
+                     }
 @@ -433,6 +434,7 @@
  
      public void onDeath(DamageSource cause)

--- a/patches.mcp/minecraft/net/minecraft/world/biome/BiomeGenBase.java.patch
+++ b/patches.mcp/minecraft/net/minecraft/world/biome/BiomeGenBase.java.patch
@@ -14,6 +14,20 @@
      }
  
      public boolean func_185363_b()
+@@ -205,11 +206,11 @@
+         if (pos.getY() > 64)
+         {
+             float f = (float)(temperatureNoise.func_151601_a((double)((float)pos.getX() / 8.0F), (double)((float)pos.getZ() / 8.0F)) * 4.0D);
+-            return this.func_185353_n() - (f + (float)pos.getY() - 64.0F) * 0.05F / 30.0F;
++            return this.getTemperature() - (f + (float)pos.getY() - 64.0F) * 0.05F / 30.0F;
+         }
+         else
+         {
+-            return this.func_185353_n();
++            return this.getTemperature();
+         }
+     }
+ 
 @@ -228,7 +229,7 @@
      {
          double d0 = (double)MathHelper.clamp_float(this.getFloatTemperature(pos), 0.0F, 1.0F);
@@ -32,6 +46,45 @@
      }
  
      public Class <? extends BiomeGenBase > getBiomeClass()
+@@ -331,7 +332,7 @@
+ 
+     public BiomeGenBase.TempCategory getTempCategory()
+     {
+-        return (double)this.func_185353_n() < 0.2D ? BiomeGenBase.TempCategory.COLD : ((double)this.func_185353_n() < 1.0D ? BiomeGenBase.TempCategory.MEDIUM : BiomeGenBase.TempCategory.WARM);
++        return (double)this.getTemperature() < 0.2D ? BiomeGenBase.TempCategory.COLD : ((double)this.getTemperature() < 1.0D ? BiomeGenBase.TempCategory.MEDIUM : BiomeGenBase.TempCategory.WARM);
+     }
+ 
+     public static BiomeGenBase getBiome(int id)
+@@ -350,7 +351,7 @@
+         return false;
+     }
+ 
+-    public final float func_185355_j()
++    public final float getMinHeight()
+     {
+         return this.minHeight;
+     }
+@@ -360,17 +361,17 @@
+         return this.rainfall;
+     }
+ 
+-    public final String func_185359_l()
++    public final String getBiomeName()
+     {
+         return this.biomeName;
+     }
+ 
+-    public final float func_185360_m()
++    public final float getMaxHeight()
+     {
+         return this.maxHeight;
+     }
+ 
+-    public final float func_185353_n()
++    public final float getTemperature()
+     {
+         return this.temperature;
+     }
 @@ -386,6 +387,83 @@
          return this.enableSnow;
      }

--- a/patches.mcp/minecraft/net/minecraft/world/gen/ChunkProviderOverworld.java.patch
+++ b/patches.mcp/minecraft/net/minecraft/world/gen/ChunkProviderOverworld.java.patch
@@ -1,0 +1,22 @@
+--- ../src-base/minecraft/net/minecraft/world/gen/ChunkProviderOverworld.java
++++ ../src-work/minecraft/net/minecraft/world/gen/ChunkProviderOverworld.java
+@@ -260,8 +260,8 @@
+                     for (int k1 = -i1; k1 <= i1; ++k1)
+                     {
+                         BiomeGenBase biomegenbase1 = this.field_185981_C[k + j1 + 2 + (l + k1 + 2) * 10];
+-                        float f5 = this.field_186000_s.biomeDepthOffSet + biomegenbase1.func_185355_j() * this.field_186000_s.biomeDepthWeight;
+-                        float f6 = this.field_186000_s.biomeScaleOffset + biomegenbase1.func_185360_m() * this.field_186000_s.biomeScaleWeight;
++                        float f5 = this.field_186000_s.biomeDepthOffSet + biomegenbase1.getMinHeight() * this.field_186000_s.biomeDepthWeight;
++                        float f6 = this.field_186000_s.biomeScaleOffset + biomegenbase1.getMaxHeight() * this.field_186000_s.biomeScaleWeight;
+ 
+                         if (this.field_185997_p == WorldType.AMPLIFIED && f5 > 0.0F)
+                         {
+@@ -271,7 +271,7 @@
+ 
+                         float f7 = this.field_185999_r[j1 + 2 + (k1 + 2) * 5] / (f5 + 2.0F);
+ 
+-                        if (biomegenbase1.func_185355_j() > biomegenbase.func_185355_j())
++                        if (biomegenbase1.getMinHeight() > biomegenbase.getMinHeight())
+                         {
+                             f7 /= 2.0F;
+                         }

--- a/patches.mcp/minecraft/net/minecraft/world/gen/structure/MapGenStronghold.java.patch
+++ b/patches.mcp/minecraft/net/minecraft/world/gen/structure/MapGenStronghold.java.patch
@@ -1,0 +1,11 @@
+--- ../src-base/minecraft/net/minecraft/world/gen/structure/MapGenStronghold.java
++++ ../src-work/minecraft/net/minecraft/world/gen/structure/MapGenStronghold.java
+@@ -28,7 +28,7 @@
+ 
+         for (BiomeGenBase biomegenbase : BiomeGenBase.field_185377_q)
+         {
+-            if (biomegenbase != null && biomegenbase.func_185355_j() > 0.0F)
++            if (biomegenbase != null && biomegenbase.getMinHeight() > 0.0F)
+             {
+                 this.field_151546_e.add(biomegenbase);
+             }

--- a/src/main/java/net/minecraftforge/common/BiomeDictionary.java
+++ b/src/main/java/net/minecraftforge/common/BiomeDictionary.java
@@ -289,7 +289,7 @@ public class BiomeDictionary
     {
         if (biome.theBiomeDecorator.treesPerChunk >= 3)
         {
-            if (biome.isHighHumidity() && biome.func_185353_n() >= 0.9F)
+            if (biome.isHighHumidity() && biome.getTemperature() >= 0.9F)
             {
                 BiomeDictionary.registerBiomeType(biome, JUNGLE);
             }
@@ -297,15 +297,15 @@ public class BiomeDictionary
             {
                 BiomeDictionary.registerBiomeType(biome, FOREST);
 
-                if (biome.func_185353_n() <= 0.2f)
+                if (biome.getTemperature() <= 0.2f)
                 {
                     BiomeDictionary.registerBiomeType(biome, CONIFEROUS);
                 }
             }
         }
-        else if(biome.func_185360_m() <= 0.3F && biome.func_185360_m() >= 0.0F)
+        else if(biome.getMaxHeight() <= 0.3F && biome.getMaxHeight() >= 0.0F)
         {
-            if(!biome.isHighHumidity() || biome.func_185355_j() >= 0.0F)
+            if(!biome.isHighHumidity() || biome.getMinHeight() >= 0.0F)
             {
                 BiomeDictionary.registerBiomeType(biome, PLAINS);
             }
@@ -321,12 +321,12 @@ public class BiomeDictionary
             BiomeDictionary.registerBiomeType(biome, DRY);
         }
 
-        if (biome.func_185353_n() > 0.85f)
+        if (biome.getTemperature() > 0.85f)
         {
             BiomeDictionary.registerBiomeType(biome, HOT);
         }
 
-        if (biome.func_185353_n() < 0.15f)
+        if (biome.getTemperature() < 0.15f)
         {
             BiomeDictionary.registerBiomeType(biome, COLD);
         }
@@ -340,14 +340,14 @@ public class BiomeDictionary
             BiomeDictionary.registerBiomeType(biome, DENSE);
         }
 
-        if (biome.isHighHumidity() && biome.func_185355_j() < 0.0F && (biome.func_185360_m() <= 0.3F && biome.func_185360_m() >= 0.0F))
+        if (biome.isHighHumidity() && biome.getMinHeight() < 0.0F && (biome.getMaxHeight() <= 0.3F && biome.getMaxHeight() >= 0.0F))
         {
             BiomeDictionary.registerBiomeType(biome, SWAMP);
         }
 
-        if (biome.func_185355_j() <= -0.5F)
+        if (biome.getMinHeight() <= -0.5F)
         {
-            if (biome.func_185360_m() == 0.0F)
+            if (biome.getMaxHeight() == 0.0F)
             {
                 BiomeDictionary.registerBiomeType(biome, RIVER);
             }
@@ -357,12 +357,12 @@ public class BiomeDictionary
             }
         }
 
-        if (biome.func_185360_m() >= 0.4F && biome.func_185360_m() < 1.5F)
+        if (biome.getMaxHeight() >= 0.4F && biome.getMaxHeight() < 1.5F)
         {
             BiomeDictionary.registerBiomeType(biome, HILLS);
         }
 
-        if (biome.func_185360_m() >= 1.5F)
+        if (biome.getMaxHeight() >= 1.5F)
         {
             BiomeDictionary.registerBiomeType(biome, MOUNTAIN);
         }
@@ -372,7 +372,7 @@ public class BiomeDictionary
             BiomeDictionary.registerBiomeType(biome, SNOWY);
         }
 
-        if (biome.topBlock != Blocks.sand && biome.func_185353_n() >= 1.0f && biome.getFloatRainfall() < 0.2f)
+        if (biome.topBlock != Blocks.sand && biome.getTemperature() >= 1.0f && biome.getFloatRainfall() < 0.2f)
         {
             BiomeDictionary.registerBiomeType(biome, SAVANNA);
         }


### PR DESCRIPTION
(Sorry if I messed up anywhere, it's been a while)

This performs the following changes:

 * func_185355_j() -> getMinHeight()
 * func_185359_l() -> getBiomeName()
 * func_185360_m() -> getMaxHeight()
 * func_185353_n() -> getTemperature()

The other patches supplied all seem to be related to these changes.

Also, the recent changes to BiomeDictionary in [706e894cbb5fff4ebd28f2389ecc0a7ceaebf9f0] can confirm the previous equivalent usage of all changes bar getBiomeName()