### PR TITLE
Allow finite fluids to be drained correctly

### DIFF
--- a/src/main/java/net/minecraftforge/fluids/BlockFluidFinite.java
+++ b/src/main/java/net/minecraftforge/fluids/BlockFluidFinite.java
@@ -228,13 +228,15 @@ public class BlockFluidFinite extends BlockFluidBase
     @Override
     public FluidStack drain(World world, BlockPos pos, boolean doDrain)
     {
+        final FluidStack fluidStack = new FluidStack(getFluid(),
+                MathHelper.floor_float(getQuantaPercentage(world, pos) * FluidContainerRegistry.BUCKET_VOLUME));
+
         if (doDrain)
         {
             world.setBlockToAir(pos);
         }
 
-        return new FluidStack(getFluid(),
-                MathHelper.floor_float(getQuantaPercentage(world, pos) * FluidContainerRegistry.BUCKET_VOLUME));
+        return fluidStack;
     }
 
     @Override


### PR DESCRIPTION
When `BlockFluidFinite#drain` is called with a `doDrain` argument of `true`, the block is removed from the world before the `FluidStack` is created. This causes the returned `FluidStack` to be created with an amount of 0, since `getQuantaPercentage` uses the in-world state (which is now air instead of the fluid).

This PR moves the `FluidStack` creation to the top of the method, before the block is removed from the world.