### PR TITLE
[1.9] Loot hooks

### DIFF
--- a/patches/minecraft/net/minecraft/world/storage/loot/LootContext.java.patch
+++ b/patches/minecraft/net/minecraft/world/storage/loot/LootContext.java.patch
@@ -1,0 +1,20 @@
+--- ../src-base/minecraft/net/minecraft/world/storage/loot/LootContext.java
++++ ../src-work/minecraft/net/minecraft/world/storage/loot/LootContext.java
+@@ -163,4 +163,17 @@
+                 }
+             }
+     }
++
++    /* ======================================== FORGE START =====================================*/
++    /**
++     * Gets the world of this context. Useful when no entities are involved so we cannot use their worlds.
++     * E.g. dungeon chests, etc.
++     * The result should never be null.
++     * @return The world of this context.
++     */
++    public WorldServer getWorld()
++    {
++        return field_186499_b;
++    }
++    /* ======================================== FORGE END =====================================*/
+ }

--- a/patches/minecraft/net/minecraft/world/storage/loot/LootTable.java.patch
+++ b/patches/minecraft/net/minecraft/world/storage/loot/LootTable.java.patch
@@ -1,0 +1,11 @@
+--- ../src-base/minecraft/net/minecraft/world/storage/loot/LootTable.java
++++ ../src-work/minecraft/net/minecraft/world/storage/loot/LootTable.java
+@@ -48,7 +48,7 @@
+         {
+             field_186465_b.warn("Detected infinite loop in loot tables");
+         }
+-
++        if (net.minecraftforge.event.ForgeEventFactory.onLootGenerate(this, p_186462_2_, list)) return Lists.newArrayList();
+         return list;
+     }
+ 

--- a/patches/minecraft/net/minecraft/world/storage/loot/LootTableManager.java.patch
+++ b/patches/minecraft/net/minecraft/world/storage/loot/LootTableManager.java.patch
@@ -1,0 +1,11 @@
+--- ../src-base/minecraft/net/minecraft/world/storage/loot/LootTableManager.java
++++ ../src-work/minecraft/net/minecraft/world/storage/loot/LootTableManager.java
+@@ -64,7 +64,7 @@
+             else
+             {
+                 LootTable loottable = this.func_186517_b(p_load_1_);
+-
++                if(loottable == null) loottable = net.minecraftforge.common.loot.LootRegistry.loadModLootTable(p_load_1_, field_186526_b);
+                 if (loottable == null)
+                 {
+                     loottable = this.func_186518_c(p_load_1_);

--- a/src/main/java/net/minecraftforge/common/loot/LootRegistry.java
+++ b/src/main/java/net/minecraftforge/common/loot/LootRegistry.java
@@ -1,6 +1,5 @@
 package net.minecraftforge.common.loot;
 
-import com.google.common.base.Charsets;
 import com.google.common.base.Function;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Maps;

--- a/src/main/java/net/minecraftforge/common/loot/LootRegistry.java
+++ b/src/main/java/net/minecraftforge/common/loot/LootRegistry.java
@@ -1,0 +1,90 @@
+package net.minecraftforge.common.loot;
+
+import com.google.common.base.Charsets;
+import com.google.common.base.Function;
+import com.google.common.base.Preconditions;
+import com.google.common.collect.Maps;
+import com.google.gson.Gson;
+import com.google.gson.JsonIOException;
+import com.google.gson.JsonSyntaxException;
+import net.minecraft.util.ResourceLocation;
+import net.minecraft.world.storage.loot.LootTable;
+import net.minecraftforge.fml.common.FMLLog;
+import net.minecraftforge.fml.common.Loader;
+import net.minecraftforge.fml.common.LoaderState;
+import net.minecraftforge.fml.common.ModContainer;
+
+import java.io.BufferedInputStream;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.util.Map;
+
+public class LootRegistry {
+
+    /**
+     * This is called by LootTableManager after it looks for loot tables in the world folder
+     * and before it looks for loot tables in vanilla.
+     * By default, loot tables are loaded from the resource path (jar) of the mod whose modid matches the resource domain of the given path.
+     * If there exists an override handler, then that is used instead.
+     * @param path The path of the loot table to load.
+     * @param deserializer The gson that can handle Loot Tables.
+     * @return A LootTable object, or null indicating that the LootTableManager should continue looking elsewhere.
+     */
+    public static LootTable loadModLootTable(ResourceLocation path, Gson deserializer)
+    {
+        String modid = path.getResourceDomain();
+        InputStream input = null;
+
+        if (LOADING_OVERRIDES.containsKey(modid))
+        {
+            input = LOADING_OVERRIDES.get(modid).apply(path);
+        }
+        else
+        {
+            ModContainer mod = Loader.instance().getIndexedModList().get(modid);
+            if (mod != null)
+            {
+                input = mod.getMod().getClass().getResourceAsStream("/assets/" + path.getResourceDomain() + "/loot_tables/" + path.getResourcePath() + ".json");
+            }
+        }
+
+
+        if (input == null)
+        {
+            return null;
+        }
+
+        try
+        {
+            return deserializer.fromJson(new InputStreamReader(new BufferedInputStream(input)), LootTable.class);
+        }
+        catch (JsonSyntaxException ex)
+        {
+            FMLLog.warning("Failed to load loot table from path %s: Malformed json", path);
+            ex.printStackTrace();
+            return null;
+        }
+        catch (JsonIOException ex)
+        {
+            FMLLog.warning("Failed to load loot table from path %s: IOException", path);
+            ex.printStackTrace();
+            return null;
+        }
+    }
+
+    private static final Map<String, Function<ResourceLocation, InputStream>> LOADING_OVERRIDES = Maps.newHashMap();
+
+    /**
+     * By default, loot tables are only loaded from the mod whose mod id matches the resource domain of the path.
+     * By registering an override here, a mod can handle the ResourceLocation -> InputStream process on its own.
+     * This allows a mod to, for example, allow addons to register modified loot tables.
+     * Call this anytime during startup.
+     */
+    public static void registerOverride(Function<ResourceLocation, InputStream> override)
+    {
+        Preconditions.checkState(!Loader.instance().hasReachedState(LoaderState.AVAILABLE),
+                "Mod %s calling LootRegistry.registerOverride too late!", Loader.instance().activeModContainer().getModId());
+        LOADING_OVERRIDES.put(Loader.instance().activeModContainer().getModId(), override);
+    }
+
+}

--- a/src/main/java/net/minecraftforge/event/ForgeEventFactory.java
+++ b/src/main/java/net/minecraftforge/event/ForgeEventFactory.java
@@ -40,6 +40,8 @@ import net.minecraft.world.chunk.ChunkPrimer;
 import net.minecraft.world.chunk.IChunkGenerator;
 import net.minecraft.world.storage.IPlayerFileData;
 import net.minecraft.world.storage.SaveHandler;
+import net.minecraft.world.storage.loot.LootContext;
+import net.minecraft.world.storage.loot.LootTable;
 import net.minecraftforge.client.event.ClientChatReceivedEvent;
 import net.minecraftforge.client.event.RenderBlockOverlayEvent;
 import net.minecraftforge.client.event.RenderBlockOverlayEvent.OverlayType;
@@ -551,6 +553,11 @@ public class ForgeEventFactory
     public static void onChunkPopulate(boolean pre, IChunkGenerator gen, World world, int x, int z, boolean hasVillageGenerated)
     {
         MinecraftForge.EVENT_BUS.post(new PopulateChunkEvent.Pre(gen, world, world.rand, x, z, hasVillageGenerated));
+    }
+
+    public static boolean onLootGenerate(LootTable table, LootContext context, List<ItemStack> lootList)
+    {
+        return MinecraftForge.EVENT_BUS.post(new LootEvent(table, context, lootList));
     }
 
 }

--- a/src/main/java/net/minecraftforge/event/ForgeEventFactory.java
+++ b/src/main/java/net/minecraftforge/event/ForgeEventFactory.java
@@ -4,7 +4,6 @@ import java.io.File;
 import java.util.EnumSet;
 import java.util.List;
 
-import net.minecraft.block.Block;
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.EntityLiving;
@@ -16,7 +15,6 @@ import net.minecraft.entity.monster.EntityZombie;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.entity.player.EntityPlayer.EnumStatus;
 import net.minecraft.init.Blocks;
-import net.minecraft.init.Items;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraft.tileentity.TileEntity;
@@ -25,6 +23,7 @@ import net.minecraft.util.DamageSource;
 import net.minecraft.util.EnumActionResult;
 import net.minecraft.util.EnumFacing;
 import net.minecraft.util.EnumHand;
+import net.minecraft.util.ResourceLocation;
 import net.minecraft.util.SoundCategory;
 import net.minecraft.util.SoundEvent;
 import net.minecraft.util.math.BlockPos;
@@ -557,7 +556,14 @@ public class ForgeEventFactory
 
     public static boolean onLootGenerate(LootTable table, LootContext context, List<ItemStack> lootList)
     {
-        return MinecraftForge.EVENT_BUS.post(new LootEvent(table, context, lootList));
+        return MinecraftForge.EVENT_BUS.post(new LootGenerateEvent(table, context, lootList));
+    }
+
+    public static LootTable onLootTableLoad(LootTable table, ResourceLocation loc)
+    {
+        LootTableLoadEvent evt = new LootTableLoadEvent(table, loc);
+        MinecraftForge.EVENT_BUS.post(evt);
+        return evt.getTable();
     }
 
 }

--- a/src/main/java/net/minecraftforge/event/LootEvent.java
+++ b/src/main/java/net/minecraftforge/event/LootEvent.java
@@ -1,0 +1,54 @@
+package net.minecraftforge.event;
+
+import net.minecraft.item.ItemStack;
+import net.minecraft.world.storage.loot.LootContext;
+import net.minecraft.world.storage.loot.LootTable;
+import net.minecraftforge.fml.common.eventhandler.Cancelable;
+import net.minecraftforge.fml.common.eventhandler.Event;
+
+import java.util.List;
+
+/**
+ * This is fired after a LootTable has finished generating a list of possible loot.
+ * Modifications to the list will change the loot directly.
+ * Canceling the event will cause an empty list to be returned (existing list will not be cleared)
+ * Note that further random picking
+ */
+@Cancelable
+public class LootEvent extends Event
+{
+    private final LootTable table;
+    private final LootContext context;
+    private final List<ItemStack> lootList;
+
+    public LootEvent(LootTable table, LootContext context, List<ItemStack> lootList)
+    {
+        this.table = table;
+        this.context = context;
+        this.lootList = lootList;
+    }
+
+    /**
+     * @return The loot table currently generating
+     */
+    public LootTable getTable()
+    {
+        return table;
+    }
+
+    /**
+     * @return The loot context currently in use
+     */
+    public LootContext getContext()
+    {
+        return context;
+    }
+
+    /**
+     * @return The loot that this loot table has produced. Modifying this list will change the final result
+     */
+    public List<ItemStack> getLoot()
+    {
+        return lootList;
+    }
+}

--- a/src/main/java/net/minecraftforge/event/LootGenerateEvent.java
+++ b/src/main/java/net/minecraftforge/event/LootGenerateEvent.java
@@ -9,19 +9,20 @@ import net.minecraftforge.fml.common.eventhandler.Event;
 import java.util.List;
 
 /**
- * This is fired after a LootTable has finished generating a list of possible loot.
- * Modifications to the list will change the loot directly.
- * Canceling the event will cause an empty list to be returned (existing list will not be cleared)
- * Note that further random picking
+ * This event is fired on MinecraftForge.EVENT_BUS after a LootTable has finished generating a list of possible loot.
+ * Modifications to the ItemStack list will change the loot directly.
+ * Canceling the event will cause an empty list to be returned in the end (existing list will not be cleared).
+ * This is so that uncanceling the event will work as intended.
+ * This event has no result.
  */
 @Cancelable
-public class LootEvent extends Event
+public class LootGenerateEvent extends Event
 {
     private final LootTable table;
     private final LootContext context;
     private final List<ItemStack> lootList;
 
-    public LootEvent(LootTable table, LootContext context, List<ItemStack> lootList)
+    public LootGenerateEvent(LootTable table, LootContext context, List<ItemStack> lootList)
     {
         this.table = table;
         this.context = context;

--- a/src/main/java/net/minecraftforge/event/LootTableLoadEvent.java
+++ b/src/main/java/net/minecraftforge/event/LootTableLoadEvent.java
@@ -1,0 +1,54 @@
+package net.minecraftforge.event;
+
+import com.google.common.collect.Lists;
+import net.minecraft.util.ResourceLocation;
+import net.minecraft.world.storage.loot.LootPool;
+import net.minecraft.world.storage.loot.LootTable;
+import net.minecraftforge.fml.common.eventhandler.Event;
+
+import java.util.List;
+
+/**
+ * This event is fired on MinecraftForge.EVENT_BUS immediately after a loot table finishes loading from disk.
+ * The path is given so you can add your own loot pools based on the table loading.
+ * This is the new replacement for ChestGenHooks/DungeonHooks/FishingHooks, listen for the path of interest and
+ * insert your own loot pools.
+ * This event has no result, and is not cancelable.
+ */
+public class LootTableLoadEvent extends Event {
+    private final List<LootPool> pools;
+    private final ResourceLocation path;
+
+    public LootTableLoadEvent(LootTable originalTable, ResourceLocation path)
+    {
+        this.pools = Lists.newArrayList(originalTable.pools);
+        this.path = path;
+    }
+
+    /**
+     * Add your own loot pool to the Loot Table.
+     * @param pool The pool to add to the list of pools.
+     */
+    public void addPool(LootPool pool)
+    {
+        pools.add(pool);
+    }
+
+    /**
+     * @return the path of the LootTable that is loading
+     */
+    public ResourceLocation getPath()
+    {
+        return path;
+    }
+
+    /**
+     * Build a LootTable based on the currently added pools.
+     * This is an immutable snapshot of the current pools,
+     * further changes made via this event will not be reflected in the returned object!
+     */
+    public LootTable getTable()
+    {
+        return new LootTable(pools.toArray(new LootPool[pools.size()]));
+    }
+}

--- a/src/main/resources/forge_at.cfg
+++ b/src/main/resources/forge_at.cfg
@@ -1,4 +1,6 @@
 #Main Forge Access Transformer configuration file
+# LootTable
+public net.minecraft.world.storage.loot.LootTable field_186466_c # pools
 # EntityFishHook
 #public net.minecraft.entity.projectile.EntityFishHook field_146041_e
 #public net.minecraft.entity.projectile.EntityFishHook field_146036_f

--- a/src/test/java/net/minecraftforge/debug/LootDebug.java
+++ b/src/test/java/net/minecraftforge/debug/LootDebug.java
@@ -4,10 +4,18 @@ import net.minecraft.entity.item.EntityMinecartChest;
 import net.minecraft.entity.monster.EntityCreeper;
 import net.minecraft.entity.monster.EntitySkeleton;
 import net.minecraft.init.Blocks;
+import net.minecraft.init.Items;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.ResourceLocation;
+import net.minecraft.world.storage.loot.LootEntry;
+import net.minecraft.world.storage.loot.LootEntryItem;
+import net.minecraft.world.storage.loot.LootPool;
+import net.minecraft.world.storage.loot.RandomValueRange;
+import net.minecraft.world.storage.loot.conditions.LootCondition;
+import net.minecraft.world.storage.loot.functions.LootFunction;
 import net.minecraftforge.common.MinecraftForge;
-import net.minecraftforge.event.LootEvent;
+import net.minecraftforge.event.LootGenerateEvent;
+import net.minecraftforge.event.LootTableLoadEvent;
 import net.minecraftforge.event.entity.living.LivingDropsEvent;
 import net.minecraftforge.event.entity.minecart.MinecartInteractEvent;
 import net.minecraftforge.fml.common.Mod;
@@ -22,10 +30,22 @@ public class LootDebug {
         MinecraftForge.EVENT_BUS.register(this);
     }
 
+    @SubscribeEvent
+    public void fishingHook(LootTableLoadEvent evt)
+    {
+        System.out.println(evt.getPath().toString());
+        if ("minecraft:gameplay/fishing".equals(evt.getPath().toString()))
+        {
+            evt.addPool(new LootPool(new LootEntry[]{
+                    new LootEntryItem(Items.cooked_porkchop, 200, 1, new LootFunction[0], new LootCondition[0])
+            }, new LootCondition[0], new RandomValueRange(3), new RandomValueRange(0)));
+        }
+    }
+
     // Test that we can load mod loot tables from our own domain
     @SubscribeEvent
     public void handle(MinecartInteractEvent evt) {
-        if (evt.minecart instanceof EntityMinecartChest
+        if (!evt.minecart.worldObj.isRemote && evt.minecart instanceof EntityMinecartChest
                 && "LOOTTEST".equals(evt.minecart.getCustomNameTag())) {
             ((EntityMinecartChest) evt.minecart).setLootTable(new ResourceLocation("forgelootdebug", "test_table"), 0);
         }
@@ -33,7 +53,7 @@ public class LootDebug {
 
     // Test the loot event
     @SubscribeEvent
-    public void onLoot(LootEvent evt) {
+    public void onLoot(LootGenerateEvent evt) {
         if (evt.getContext().getLootedEntity() instanceof EntityCreeper
                 && "LOOTTEST".equals(evt.getContext().getLootedEntity().getCustomNameTag())) {
             evt.getLoot().add(new ItemStack(Blocks.stone));

--- a/src/test/java/net/minecraftforge/debug/LootDebug.java
+++ b/src/test/java/net/minecraftforge/debug/LootDebug.java
@@ -1,0 +1,57 @@
+package net.minecraftforge.debug;
+
+import net.minecraft.entity.item.EntityMinecartChest;
+import net.minecraft.entity.monster.EntityCreeper;
+import net.minecraft.entity.monster.EntitySkeleton;
+import net.minecraft.init.Blocks;
+import net.minecraft.item.ItemStack;
+import net.minecraft.util.ResourceLocation;
+import net.minecraftforge.common.MinecraftForge;
+import net.minecraftforge.event.LootEvent;
+import net.minecraftforge.event.entity.living.LivingDropsEvent;
+import net.minecraftforge.event.entity.minecart.MinecartInteractEvent;
+import net.minecraftforge.fml.common.Mod;
+import net.minecraftforge.fml.common.event.FMLPreInitializationEvent;
+import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
+
+@Mod(modid = "forgelootdebug")
+public class LootDebug {
+
+    @Mod.EventHandler
+    public void preInit(FMLPreInitializationEvent evt) {
+        MinecraftForge.EVENT_BUS.register(this);
+    }
+
+    // Test that we can load mod loot tables from our own domain
+    @SubscribeEvent
+    public void handle(MinecartInteractEvent evt) {
+        if (evt.minecart instanceof EntityMinecartChest
+                && "LOOTTEST".equals(evt.minecart.getCustomNameTag())) {
+            ((EntityMinecartChest) evt.minecart).setLootTable(new ResourceLocation("forgelootdebug", "test_table"), 0);
+        }
+    }
+
+    // Test the loot event
+    @SubscribeEvent
+    public void onLoot(LootEvent evt) {
+        if (evt.getContext().getLootedEntity() instanceof EntityCreeper
+                && "LOOTTEST".equals(evt.getContext().getLootedEntity().getCustomNameTag())) {
+            evt.getLoot().add(new ItemStack(Blocks.stone));
+        }
+
+        if (evt.getContext().getLootedEntity() instanceof EntitySkeleton
+                && "LOOTTEST".equals(evt.getContext().getLootedEntity().getCustomNameTag())) {
+            evt.setCanceled(true);
+        }
+    }
+
+    // Make sure old event still works
+    @SubscribeEvent
+    public void onDrops(LivingDropsEvent evt) {
+        if (evt.entity instanceof EntitySkeleton
+                && "LOOTTEST".equals(evt.entity.getCustomNameTag())) {
+            System.out.println("Should have no arrows or bones: " + evt.drops);
+        }
+    }
+
+}

--- a/src/test/java/net/minecraftforge/debug/LootDebugAddons.java
+++ b/src/test/java/net/minecraftforge/debug/LootDebugAddons.java
@@ -1,0 +1,45 @@
+package net.minecraftforge.debug;
+
+import com.google.common.base.Charsets;
+import com.google.common.base.Function;
+import net.minecraft.entity.item.EntityMinecartChest;
+import net.minecraft.entity.item.EntityMinecartHopper;
+import net.minecraft.util.ResourceLocation;
+import net.minecraftforge.common.MinecraftForge;
+import net.minecraftforge.common.loot.LootRegistry;
+import net.minecraftforge.event.entity.minecart.MinecartInteractEvent;
+import net.minecraftforge.fml.common.Mod;
+import net.minecraftforge.fml.common.event.FMLPreInitializationEvent;
+import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
+
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+
+@Mod(modid = "forgelootdebugaddons")
+public class LootDebugAddons {
+
+    private static final String json = "{\"pools\":[{\"rolls\": 1, \"entries\": [{\"type\": \"item\", \"name\": \"minecraft:golden_apple\", \"weight\": 1}]}]}";
+
+    @Mod.EventHandler
+    public void preInit(FMLPreInitializationEvent evt) {
+        LootRegistry.registerOverride(new Function<ResourceLocation, InputStream>() {
+            @Override
+            public InputStream apply(ResourceLocation input) {
+                // In a hypothetical situation, we would have addons. And this mod would be able to control how exactly it gets
+                // from resourcelocation "forgelootdebugaddons:*" to an InputStream
+                return new ByteArrayInputStream(json.getBytes(Charsets.UTF_8));
+            }
+        });
+
+        MinecraftForge.EVENT_BUS.register(this);
+    }
+
+    @SubscribeEvent
+    public void openHopperCart(MinecartInteractEvent evt) {
+        if (evt.minecart instanceof EntityMinecartHopper
+                && "LOOTTEST".equals(evt.minecart.getCustomNameTag())) {
+            ((EntityMinecartHopper) evt.minecart).setLootTable(new ResourceLocation("forgelootdebugaddons", "handledbymyoverride"), 0);
+        }
+    }
+
+}

--- a/src/test/java/net/minecraftforge/debug/LootDebugAddons.java
+++ b/src/test/java/net/minecraftforge/debug/LootDebugAddons.java
@@ -36,7 +36,7 @@ public class LootDebugAddons {
 
     @SubscribeEvent
     public void openHopperCart(MinecartInteractEvent evt) {
-        if (evt.minecart instanceof EntityMinecartHopper
+        if (!evt.minecart.worldObj.isRemote && evt.minecart instanceof EntityMinecartHopper
                 && "LOOTTEST".equals(evt.minecart.getCustomNameTag())) {
             ((EntityMinecartHopper) evt.minecart).setLootTable(new ResourceLocation("forgelootdebugaddons", "handledbymyoverride"), 0);
         }

--- a/src/test/resources/assets/forgelootdebug/loot_tables/test_table.json
+++ b/src/test/resources/assets/forgelootdebug/loot_tables/test_table.json
@@ -1,0 +1,49 @@
+{
+  "pools": [
+    {
+      "rolls": 10,
+      "entries": [
+        {
+          "type": "item",
+          "name": "minecraft:golden_apple",
+          "weight": 20
+        },
+        {
+          "type": "item",
+          "name": "minecraft:golden_apple",
+          "weight": 1,
+          "functions": [
+            {
+              "function": "set_data",
+              "data": 1
+            }
+          ]
+        },
+        {
+          "type": "item",
+          "name": "minecraft:name_tag",
+          "weight": 30
+        },
+        {
+          "type": "item",
+          "name": "minecraft:book",
+          "weight": 10,
+          "functions": [
+            {
+              "function": "enchant_randomly"
+            }
+          ]
+        },
+        {
+          "type": "item",
+          "name": "minecraft:iron_pickaxe",
+          "weight": 5
+        },
+        {
+          "type": "empty",
+          "weight": 5
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Preliminary draft:

Done so far:
* Loading from mod jars (with overrides)
* Event fired when Loot Table has finished populating a list of items.
* Patch in a getWorld into LootContext. If the context doesn't involve a living thing killing another living thing, then it's impossible to get the world. Useful for chests in dungeons.
* Tests to test the above

Not done yet:
* Method and design of loading needs to be refined (I just went with loading from jars + a override mechanism suggested by @diesieben07)
* A way to modify existing tables
    * Event fired in LootTableManager.Loader.load()?
    * Should world-specific override tables obey changes made during the event or not?

------------

\<From issue ticket\>

I thought I'd start off the discussion for this, since it's one of the parts I'm most interested in in 1.9.

### Some terminology
Ctrl+F "Loot tables" in this for some basic terminology
[https://gist.github.com/williewillus/e37edde85dc78d2e138c](https://gist.github.com/williewillus/e37edde85dc78d2e138c)

### Adding pieces to the looting system
* All the abovementioned classes are easy to add to in code. Each class has its own registry where you can register your object to a name, e.g. I can register a LootFunction "botania:add_mana" that takes a stack and adds mana to it simply by calling LootFunctionManager.registerFunction(Serializer). For all of these, you have to pass in a serializer describing how it'll be (de)serialized from JSON form.

### Activation of the looting system
* For living entities: The entire loot table system is only queried for subclasses of EntityLiving. `EntityLivingBase#onDeath` calls `dropLoot`, which is fully overriden by EntityLiving. `dropFewItems` doesn't do anything anymore (except for slimes which still use it for some reason.
    * The loot table to use is an NBT tag in the entity, "DeathLootTable". Falls back to a default for vanilla mobs.
    * The forge hook to capture drops is in `EntityLivingBase#onDeath` and should still capture all loot dropped. Perhaps we should provide the loot context in LivingDropsEvent, though that would require us to move the event. A more viable alternative is to expose the LootContext in an event, allowing others to modify the Loot Tables in code?
* For TE's and things like minecarts. These implement ILootableContainer, which contains a single method returning the ResourceLocation of the loot table to generate. TE's and carts have a field/NBT tag that holds this ResourceLocation. Upon the first opening of the container, the loot table is queried and then the loot table field in the object is set to null. It's possible in code for the loot table to be re-set so that it regenerates again whenever the container is opened next. I don't think this requires any hooking/modification.

### Loading of loot tables
Probably the most difficulty piece to figure out currently.
Although loot tables in the vanilla jar are in the "/assets/" directory, they are far from being part of the powerful cascading resource pack / clientside asset system. What vanilla does currently in `LootTableManager.Loader.load(ResourceLocation)` is look for loot jsons in the world directory (`new File(LootTableManager#baseFolder, ...)`), a vanilla feature allowing mappers to override tables, and then fall back directly to the classpath (mod jars) if the former is missing (LootTableManager.class.getResource(URL)), then to an empty table if it's still missing.
The easiest solution is simply to place a hook directly below the loading from world folder call, that loads from mod jars, but still lets mappers' world-specific tables have top priority
The question arises is that with this, we don't know what jar to look in. Looking at the resource domain of the resource location to determine which jar to search would be a fallback but it would prevent an addon for example from changing its parent mod's tables. Or we could scan through all jars to look for any loot json, but that implicitly enforces an ordering in the case of conflicting jsons.
(Or we could find a way to bring that whole cascading resource system to the serverside? I don't know that system well enough to say if that's feasible)

Alternatively we could just forego this entirely, use the vanilla registries, and just have mods "figure it out" how to get an instance of `LootTable` to the registry. (i.e. they handle deserialization themselves). But that's meh.

Thoughts?

### What would get obsoleted
* `ChestGenHooks` and `FishingHooks` are both going to go away
    * This requires us to determine a way to inject mod entries into the main loot tables. Can't replace the tables because then mods would conflict. Would using the events proposed above be suitable?