### PR TITLE
Fixed BlockColors and ItemColors not working for mods. 

### DIFF
--- a/patches/minecraft/net/minecraft/client/Minecraft.java.patch
+++ b/patches/minecraft/net/minecraft/client/Minecraft.java.patch
@@ -474,3 +474,14 @@
      }
  
      public boolean func_70002_Q()
+@@ -3192,4 +3084,10 @@
+     {
+         return this.field_184127_aH;
+     }
++    
++    // FORGE
++    public ItemColors getItemColors()
++    {
++    	return this.field_184128_aI;
++    }
+ }

--- a/patches/minecraft/net/minecraft/client/renderer/color/BlockColors.java.patch
+++ b/patches/minecraft/net/minecraft/client/renderer/color/BlockColors.java.patch
@@ -1,0 +1,47 @@
+--- ../src-base/minecraft/net/minecraft/client/renderer/color/BlockColors.java
++++ ../src-work/minecraft/net/minecraft/client/renderer/color/BlockColors.java
+@@ -1,5 +1,7 @@
+ package net.minecraft.client.renderer.color;
+ 
++import java.util.HashMap;
++
+ import net.minecraft.block.Block;
+ import net.minecraft.block.BlockDoublePlant;
+ import net.minecraft.block.BlockOldLeaf;
+@@ -13,7 +15,6 @@
+ import net.minecraft.item.ItemBlock;
+ import net.minecraft.tileentity.TileEntity;
+ import net.minecraft.tileentity.TileEntityFlowerPot;
+-import net.minecraft.util.ObjectIntIdentityMap;
+ import net.minecraft.util.math.BlockPos;
+ import net.minecraft.world.ColorizerFoliage;
+ import net.minecraft.world.ColorizerGrass;
+@@ -25,7 +26,9 @@
+ @SideOnly(Side.CLIENT)
+ public class BlockColors
+ {
+-    private final ObjectIntIdentityMap<IBlockColor> field_186725_a = new ObjectIntIdentityMap(32);
++    // private final ObjectIntIdentityMap<IBlockColor> mapBlockColors = new ObjectIntIdentityMap(32); Vanilla
++    // FORGE
++    private final HashMap<Block, IBlockColor> field_186725_a = new HashMap<Block, IBlockColor>(); 
+ 
+     public static BlockColors func_186723_a()
+     {
+@@ -145,7 +148,7 @@
+ 
+     public int func_186724_a(IBlockState p_186724_1_, IBlockAccess p_186724_2_, BlockPos p_186724_3_, int p_186724_4_)
+     {
+-        IBlockColor iblockcolor = (IBlockColor)this.field_186725_a.func_148745_a(Block.func_149682_b(p_186724_1_.func_177230_c()));
++        IBlockColor iblockcolor = (IBlockColor)this.field_186725_a.get(p_186724_1_.func_177230_c());
+         return iblockcolor == null ? -1 : iblockcolor.func_186720_a(p_186724_1_, p_186724_2_, p_186724_3_, p_186724_4_);
+     }
+ 
+@@ -155,7 +158,7 @@
+ 
+         for (int j = p_186722_2_.length; i < j; ++i)
+         {
+-            this.field_186725_a.func_148746_a(p_186722_1_, Block.func_149682_b(p_186722_2_[i]));
++            this.field_186725_a.put(p_186722_2_[i], p_186722_1_);
+         }
+     }
+ }

--- a/patches/minecraft/net/minecraft/client/renderer/color/ItemColors.java.patch
+++ b/patches/minecraft/net/minecraft/client/renderer/color/ItemColors.java.patch
@@ -1,0 +1,56 @@
+--- ../src-base/minecraft/net/minecraft/client/renderer/color/ItemColors.java
++++ ../src-work/minecraft/net/minecraft/client/renderer/color/ItemColors.java
+@@ -1,5 +1,7 @@
+ package net.minecraft.client.renderer.color;
+ 
++import java.util.HashMap;
++
+ import net.minecraft.block.Block;
+ import net.minecraft.block.BlockDoublePlant;
+ import net.minecraft.block.state.IBlockState;
+@@ -16,7 +18,6 @@
+ import net.minecraft.nbt.NBTBase;
+ import net.minecraft.nbt.NBTTagIntArray;
+ import net.minecraft.potion.PotionUtils;
+-import net.minecraft.util.ObjectIntIdentityMap;
+ import net.minecraft.util.math.BlockPos;
+ import net.minecraft.world.ColorizerGrass;
+ import net.minecraft.world.IBlockAccess;
+@@ -26,7 +27,9 @@
+ @SideOnly(Side.CLIENT)
+ public class ItemColors
+ {
+-    private final ObjectIntIdentityMap<IItemColor> field_186732_a = new ObjectIntIdentityMap(32);
++//    private final ObjectIntIdentityMap<IItemColor> mapItemColors = new ObjectIntIdentityMap(32); Vanilla
++    // FORGE
++    private final HashMap<Item, IItemColor> field_186732_a = new HashMap<Item, IItemColor>();
+ 
+     public static ItemColors func_186729_a(final BlockColors p_186729_0_)
+     {
+@@ -136,7 +139,7 @@
+ 
+     public int func_186728_a(ItemStack p_186728_1_, int p_186728_2_)
+     {
+-        IItemColor iitemcolor = (IItemColor)this.field_186732_a.func_148745_a(Item.field_150901_e.func_148757_b(p_186728_1_.func_77973_b()));
++        IItemColor iitemcolor = (IItemColor)this.field_186732_a.get(p_186728_1_.func_77973_b());
+         return iitemcolor == null ? -1 : iitemcolor.func_186726_a(p_186728_1_, p_186728_2_);
+     }
+ 
+@@ -146,7 +149,7 @@
+ 
+         for (int j = p_186731_2_.length; i < j; ++i)
+         {
+-            this.field_186732_a.func_148746_a(p_186731_1_, Item.func_150891_b(Item.func_150898_a(p_186731_2_[i])));
++            this.field_186732_a.put(Item.func_150898_a(p_186731_2_[i]), p_186731_1_);
+         }
+     }
+ 
+@@ -156,7 +159,7 @@
+ 
+         for (int j = p_186730_2_.length; i < j; ++i)
+         {
+-            this.field_186732_a.func_148746_a(p_186730_1_, Item.func_150891_b(p_186730_2_[i]));
++            this.field_186732_a.put(p_186730_2_[i], p_186730_1_);
+         }
+     }
+ }


### PR DESCRIPTION
Also added a getter for the ItemColors instance.

As it stood, the maps used in BlockColors and ItemColors were mapping from the block/item IDs, before the world resolution of those, which would work fine for vanilla, as they stay constant, but would break completely for modded.