### PR TITLE
Silk touch fireBlockState should use passed IBlockState

### DIFF
--- a/patches/minecraft/net/minecraft/block/Block.java.patch
+++ b/patches/minecraft/net/minecraft/block/Block.java.patch
@@ -165,7 +165,7 @@
 +                items.add(itemstack);
              }
 +
-+            net.minecraftforge.event.ForgeEventFactory.fireBlockHarvesting(items, p_180657_1_, p_180657_3_, p_180657_1_.func_180495_p(p_180657_3_), 0, 1.0f, true, p_180657_2_);
++            net.minecraftforge.event.ForgeEventFactory.fireBlockHarvesting(items, p_180657_1_, p_180657_3_, p_180657_4_, 0, 1.0f, true, p_180657_2_);
 +            for (ItemStack stack : items)
 +            {
 +                func_180635_a(p_180657_1_, p_180657_3_, stack);


### PR DESCRIPTION
Since the block has been destroyed, getting the blockstate from the world will only return minecraft:air, not the blockstate, which is passed in.

