### PR TITLE
 BlockColors and ItemColors no longer assume non-Vanilla id constancy. Added a getter for ItemColors.

### DIFF
--- a/patches/minecraft/net/minecraft/client/Minecraft.java.patch
+++ b/patches/minecraft/net/minecraft/client/Minecraft.java.patch
@@ -474,3 +474,14 @@
      }
  
      public boolean func_70002_Q()
+@@ -3192,4 +3084,10 @@
+     {
+         return this.field_184127_aH;
+     }
++
++    // FORGE
++    public ItemColors getItemColors()
++    {
++        return this.field_184128_aI;
++    }
+ }

--- a/patches/minecraft/net/minecraft/client/renderer/color/BlockColors.java.patch
+++ b/patches/minecraft/net/minecraft/client/renderer/color/BlockColors.java.patch
@@ -1,0 +1,32 @@
+--- ../src-base/minecraft/net/minecraft/client/renderer/color/BlockColors.java
++++ ../src-work/minecraft/net/minecraft/client/renderer/color/BlockColors.java
+@@ -25,7 +25,8 @@
+ @SideOnly(Side.CLIENT)
+ public class BlockColors
+ {
+-    private final ObjectIntIdentityMap<IBlockColor> field_186725_a = new ObjectIntIdentityMap(32);
++    // FORGE: Use RegistryDelegates as non-Vanilla block ids are not constant
++    private final java.util.Map<net.minecraftforge.fml.common.registry.RegistryDelegate<Block>, IBlockColor> blockColorMap = com.google.common.collect.Maps.newHashMap();
+ 
+     public static BlockColors func_186723_a()
+     {
+@@ -145,7 +146,7 @@
+ 
+     public int func_186724_a(IBlockState p_186724_1_, IBlockAccess p_186724_2_, BlockPos p_186724_3_, int p_186724_4_)
+     {
+-        IBlockColor iblockcolor = (IBlockColor)this.field_186725_a.func_148745_a(Block.func_149682_b(p_186724_1_.func_177230_c()));
++        IBlockColor iblockcolor = (IBlockColor)this.blockColorMap.get(p_186724_1_.func_177230_c().delegate);
+         return iblockcolor == null ? -1 : iblockcolor.func_186720_a(p_186724_1_, p_186724_2_, p_186724_3_, p_186724_4_);
+     }
+ 
+@@ -155,7 +156,9 @@
+ 
+         for (int j = p_186722_2_.length; i < j; ++i)
+         {
+-            this.field_186725_a.func_148746_a(p_186722_1_, Block.func_149682_b(p_186722_2_[i]));
++            if (p_186722_2_[i] == null) throw new IllegalArgumentException("Block registered to block color handler cannot be null!");
++            if (p_186722_2_[i].getRegistryName() == null) throw new IllegalArgumentException("Block must be registered before assigning color handler.");
++            this.blockColorMap.put(p_186722_2_[i].delegate, p_186722_1_);
+         }
+     }
+ }

--- a/patches/minecraft/net/minecraft/client/renderer/color/ItemColors.java.patch
+++ b/patches/minecraft/net/minecraft/client/renderer/color/ItemColors.java.patch
@@ -1,0 +1,43 @@
+--- ../src-base/minecraft/net/minecraft/client/renderer/color/ItemColors.java
++++ ../src-work/minecraft/net/minecraft/client/renderer/color/ItemColors.java
+@@ -26,7 +26,8 @@
+ @SideOnly(Side.CLIENT)
+ public class ItemColors
+ {
+-    private final ObjectIntIdentityMap<IItemColor> field_186732_a = new ObjectIntIdentityMap(32);
++    // FORGE: Use RegistryDelegates as non-Vanilla item ids are not constant
++    private final java.util.Map<net.minecraftforge.fml.common.registry.RegistryDelegate<Item>, IItemColor> itemColorMap = com.google.common.collect.Maps.newHashMap();
+ 
+     public static ItemColors func_186729_a(final BlockColors p_186729_0_)
+     {
+@@ -136,7 +137,7 @@
+ 
+     public int func_186728_a(ItemStack p_186728_1_, int p_186728_2_)
+     {
+-        IItemColor iitemcolor = (IItemColor)this.field_186732_a.func_148745_a(Item.field_150901_e.func_148757_b(p_186728_1_.func_77973_b()));
++        IItemColor iitemcolor = (IItemColor)this.itemColorMap.get(p_186728_1_.func_77973_b().delegate);
+         return iitemcolor == null ? -1 : iitemcolor.func_186726_a(p_186728_1_, p_186728_2_);
+     }
+ 
+@@ -146,7 +147,9 @@
+ 
+         for (int j = p_186731_2_.length; i < j; ++i)
+         {
+-            this.field_186732_a.func_148746_a(p_186731_1_, Item.func_150891_b(Item.func_150898_a(p_186731_2_[i])));
++            if (p_186731_2_[i] == null) throw new IllegalArgumentException("Block registered to item color handler cannot be null!");
++            if (p_186731_2_[i].getRegistryName() == null) throw new IllegalArgumentException("Block must be registered before assigning color handler.");
++            this.itemColorMap.put(Item.func_150898_a(p_186731_2_[i]).delegate, p_186731_1_);
+         }
+     }
+ 
+@@ -156,7 +159,9 @@
+ 
+         for (int j = p_186730_2_.length; i < j; ++i)
+         {
+-            this.field_186732_a.func_148746_a(p_186730_1_, Item.func_150891_b(p_186730_2_[i]));
++            if (p_186730_2_[i] == null) throw new IllegalArgumentException("Item registered to item color handler cannot be null!");
++            if (p_186730_2_[i].getRegistryName() == null) throw new IllegalArgumentException("Item must be registered before assigning color handler.");
++            this.itemColorMap.put(p_186730_2_[i].delegate, p_186730_1_);
+         }
+     }
+ }


### PR DESCRIPTION
This is an altered version of @Vazkii's https://github.com/MinecraftForge/MinecraftForge/pull/2546, making the changes as suggested in the comments. Found myself needing this for BoP so I thought I might as well spare the trouble of resubmitting this for a third time