### PR TITLE
[1.9] Boss bar render event

### DIFF
--- a/patches/minecraft/net/minecraft/client/gui/GuiBossOverlay.java.patch
+++ b/patches/minecraft/net/minecraft/client/gui/GuiBossOverlay.java.patch
@@ -1,0 +1,10 @@
+--- ../src-base/minecraft/net/minecraft/client/gui/GuiBossOverlay.java
++++ ../src-work/minecraft/net/minecraft/client/gui/GuiBossOverlay.java
+@@ -34,6 +34,7 @@
+ 
+             for (BossInfoLerping bossinfolerping : this.field_184060_g.values())
+             {
++                if (net.minecraftforge.event.ForgeEventFactory.onBossRender(bossinfolerping)) continue;
+                 int k = i / 2 - 91;
+                 GlStateManager.func_179131_c(1.0F, 1.0F, 1.0F, 1.0F);
+                 this.field_184059_f.func_110434_K().func_110577_a(field_184058_a);

--- a/src/main/java/net/minecraftforge/client/event/RenderBossInfoEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/RenderBossInfoEvent.java
@@ -1,0 +1,27 @@
+package net.minecraftforge.client.event;
+
+import net.minecraft.world.BossInfoLerping;
+import net.minecraftforge.fml.common.eventhandler.Cancelable;
+import net.minecraftforge.fml.common.eventhandler.Event;
+
+/**
+ * This event is fired on MinecraftForge.EVENT_BUS before the boss bars render in GuiBossOverlay.renderBossHealth.
+ * This is useful if you want to draw your boss' bar using custom textures or other rendering.
+ * This event is cancelable. If canceled, the vanilla boss bar rendering logic will not run.
+ */
+@Cancelable
+public class RenderBossInfoEvent extends Event {
+
+    private final BossInfoLerping bossInfo;
+
+    public RenderBossInfoEvent(BossInfoLerping bossInfo)
+    {
+        this.bossInfo = bossInfo;
+    }
+
+    public BossInfoLerping getBossInfo()
+    {
+        return bossInfo;
+    }
+
+}

--- a/src/main/java/net/minecraftforge/event/ForgeEventFactory.java
+++ b/src/main/java/net/minecraftforge/event/ForgeEventFactory.java
@@ -31,6 +31,7 @@ import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.RayTraceResult;
 import net.minecraft.util.math.Vec3d;
 import net.minecraft.util.text.ITextComponent;
+import net.minecraft.world.BossInfoLerping;
 import net.minecraft.world.Explosion;
 import net.minecraft.world.World;
 import net.minecraft.world.WorldServer;
@@ -43,6 +44,7 @@ import net.minecraft.world.storage.SaveHandler;
 import net.minecraftforge.client.event.ClientChatReceivedEvent;
 import net.minecraftforge.client.event.RenderBlockOverlayEvent;
 import net.minecraftforge.client.event.RenderBlockOverlayEvent.OverlayType;
+import net.minecraftforge.client.event.RenderBossInfoEvent;
 import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.common.capabilities.CapabilityDispatcher;
 import net.minecraftforge.common.capabilities.ICapabilityProvider;
@@ -551,6 +553,10 @@ public class ForgeEventFactory
     public static void onChunkPopulate(boolean pre, IChunkGenerator gen, World world, int x, int z, boolean hasVillageGenerated)
     {
         MinecraftForge.EVENT_BUS.post(new PopulateChunkEvent.Pre(gen, world, world.rand, x, z, hasVillageGenerated));
+    }
+
+    public static boolean onBossRender(BossInfoLerping bossInfo) {
+        return MinecraftForge.EVENT_BUS.post(new RenderBossInfoEvent(bossInfo));
     }
 
 }


### PR DESCRIPTION
1.9 changed how boss bars are rendered. This quick PR adds in an event that fires whenever a single boss bar is rendered. Canceling the event will cause that single bar to not render, allowing you to perform custom rendering logic in its stead.

Botania needs this because it adds extra info on to the boss bar, as well as applies a shader and uses a custom bar texture.

Unfortunately, BossInfoLerping gives you almost no info (you don't even know what entity you're rendering a bar for), but that's out of  the scope of this PR. With this, I can have enough info to do what I did it in 1.8 by syncing a mapping of BossInfo's UUID to entity UUIDs on my own.

Thanks!