### PR TITLE
Added @NetworkWrapper annotation

### DIFF
--- a/src/main/java/net/minecraftforge/fml/common/FMLModContainer.java
+++ b/src/main/java/net/minecraftforge/fml/common/FMLModContainer.java
@@ -398,6 +398,14 @@ public class FMLModContainer implements ModContainer
                 return mc.getMetadata();
             }
         });
+        parseSimpleFieldAnnotation(annotations, NetworkWrapper.class.getName(), new Function<ModContainer, Object>()
+        {
+            @Override
+            public Object apply(ModContainer input)
+            {
+                return NetworkRegistry.INSTANCE.newSimpleChannel(input.getModId());
+            }
+        });
     }
 
     private void parseSimpleFieldAnnotation(SetMultimap<String, ASMData> annotations, String annotationClassName, Function<ModContainer, Object> retreiver) throws IllegalAccessException

--- a/src/main/java/net/minecraftforge/fml/common/NetworkWrapper.java
+++ b/src/main/java/net/minecraftforge/fml/common/NetworkWrapper.java
@@ -1,0 +1,19 @@
+package net.minecraftforge.fml.common;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Populate the annotated field with a {@link net.minecraftforge.fml.common.network.simpleimpl.SimpleNetworkWrapper} instance using the modid as channel name.
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.FIELD)
+public @interface NetworkWrapper
+{
+    /**
+     * The modid to use in this field
+     */
+    String value() default "";
+}


### PR DESCRIPTION
This annotation can be used the same way as `@SidedProxy` and `@Instance`, but for network wrappers.
It uses the modid as channel name.