### PR TITLE
Fix mod spawn eggs and EntityList.func_188429_b

### DIFF
--- a/patches/minecraft/net/minecraft/entity/EntityList.java.patch
+++ b/patches/minecraft/net/minecraft/entity/EntityList.java.patch
@@ -38,3 +38,13 @@
          }
          else
          {
+@@ -202,7 +214,8 @@
+ 
+     public static Entity func_188429_b(String p_188429_0_, World p_188429_1_)
+     {
+-        return func_75616_a(func_180122_a(p_188429_0_), p_188429_1_);
++        Entity e = func_75620_a(p_188429_0_, p_188429_1_); // Forge: Support entities without global ID
++        return e == null ? func_75620_a("Pig", p_188429_1_) : e;
+     }
+ 
+     public static int func_75619_a(Entity p_75619_0_)


### PR DESCRIPTION
Fix mod SpawnEggs only spawning pigs by using `EntityList.createEntityByName` instead of `func_188429_b` which relies on int IDs.
Also add a data fixer to upgrade old spawn eggs from 1.8 to the new format. To enable that `GameRegistry.registerDataFixer` was added as well.

If you want me to split out the `registerDataFixer` into a separate PR I can do so.

Fixes #2581.