### PR TITLE
[1.9] Pull isAir up into IBlockProperties/IBlockState

### DIFF
--- a/patches/minecraft/net/minecraft/block/state/BlockStateContainer.java.patch
+++ b/patches/minecraft/net/minecraft/block/state/BlockStateContainer.java.patch
@@ -49,7 +49,7 @@
              public Collection < IProperty<? >> func_177227_a()
              {
                  return Collections. < IProperty<? >> unmodifiableCollection(this.field_177237_b.keySet());
-@@ -414,5 +431,34 @@
+@@ -414,5 +431,40 @@
              {
                  return this.field_177239_a.func_185481_k(this);
              }
@@ -81,6 +81,12 @@
 +            public boolean doesSideBlockRendering(IBlockAccess world, BlockPos pos, EnumFacing side)
 +            {
 +                return this.field_177239_a.doesSideBlockRendering(this, world, pos, side);
++            }
++
++            @Override
++            public boolean isAir(IBlockAccess world, BlockPos pos)
++            {
++                return this.field_177239_a.isAir(this, world, pos);
 +            }
          }
  }

--- a/patches/minecraft/net/minecraft/block/state/IBlockProperties.java.patch
+++ b/patches/minecraft/net/minecraft/block/state/IBlockProperties.java.patch
@@ -14,7 +14,7 @@
  
      @SideOnly(Side.CLIENT)
      boolean func_185895_e();
-@@ -88,5 +92,10 @@
+@@ -88,5 +92,11 @@
  
      RayTraceResult func_185910_a(World p_185910_1_, BlockPos p_185910_2_, Vec3d p_185910_3_, Vec3d p_185910_4_);
  
@@ -24,4 +24,5 @@
 +    //Forge added functions
 +    boolean doesSideBlockRendering(IBlockAccess world, BlockPos pos, EnumFacing side);
 +    boolean isSideSolid(IBlockAccess world, BlockPos pos, EnumFacing side);
++    boolean isAir(IBlockAccess world, BlockPos pos);
  }


### PR DESCRIPTION
this method is really commonly used, so it would be great if we could use state.isAir instead of having do state.getBlock().isAir(state, world, pos). especially when state isn't a local variable.

Closes #2575 