### PR TITLE
[1.9] Fix KeyInputEvent only being fired if Keyboard.getEventKeyState() is false

### DIFF
--- a/patches/minecraft/net/minecraft/client/Minecraft.java.patch
+++ b/patches/minecraft/net/minecraft/client/Minecraft.java.patch
@@ -200,14 +200,14 @@
          this.field_71424_I.func_76319_b();
          this.field_71423_H = func_71386_F();
      }
-@@ -1926,6 +1948,7 @@
-                         this.field_71474_y.field_181657_aC = this.field_71474_y.field_74330_P && GuiScreen.func_175283_s();
+@@ -1927,6 +1949,7 @@
                      }
                  }
-+                net.minecraftforge.fml.common.FMLCommonHandler.instance().fireKeyInput();
              }
++            net.minecraftforge.fml.common.FMLCommonHandler.instance().fireKeyInput();
          }
  
+         this.func_184117_aA();
 @@ -2166,6 +2189,8 @@
      {
          while (Mouse.next())


### PR DESCRIPTION
It used to be called for both key-up and key-down states prior to 1.9, so I assume Vanilla's changes to F3 behavior broke the patch.

This patch just moves the fireKeyInput() line out of the getEventKeyState() condition above so it gets called for both states again.