### PR TITLE
Pass exceptions thrown in mod event buses back to FML to handle appropriately 

### DIFF
--- a/src/main/java/net/minecraftforge/fml/common/LoadController.java
+++ b/src/main/java/net/minecraftforge/fml/common/LoadController.java
@@ -44,6 +44,8 @@ import com.google.common.collect.Maps;
 import com.google.common.collect.Multimap;
 import com.google.common.eventbus.EventBus;
 import com.google.common.eventbus.Subscribe;
+import com.google.common.eventbus.SubscriberExceptionHandler;
+import com.google.common.eventbus.SubscriberExceptionContext;
 
 public class LoadController
 {
@@ -88,10 +90,18 @@ public class LoadController
     {
         Builder<String, EventBus> eventBus = ImmutableMap.builder();
 
-        for (ModContainer mod : loader.getModList())
+        for (final ModContainer mod : loader.getModList())
         {
             //Create mod logger, and make the EventBus logger a child of it.
-            EventBus bus = new EventBus(mod.getModId());
+            EventBus bus = new EventBus(new SubscriberExceptionHandler()
+            {
+                @Override
+                public void handleException(final Throwable exception, final SubscriberExceptionContext context)
+                {
+                    LoadController.this.errorOccurred(mod, exception);
+                }
+            });
+
             boolean isActive = mod.registerBus(bus, this);
             if (isActive)
             {


### PR DESCRIPTION
The default behavior of the Google event bus just logs a single line to a java.util.Logger where it is likely to be not noticed. This passes the exception back to FML so it can handle it appropriately. 