### PR TITLE
[1.9] Fix double dropping of items. Closes #2549

### DIFF
--- a/src/main/java/net/minecraftforge/common/ForgeHooks.java
+++ b/src/main/java/net/minecraftforge/common/ForgeHooks.java
@@ -556,7 +556,10 @@ public class ForgeHooks
             return null;
         }
 
-        player.getEntityWorld().spawnEntityInWorld(event.entityItem);
+        if (player.isServerWorld())
+        {
+            player.getEntityWorld().spawnEntityInWorld(event.entityItem);
+        }
         return event.entityItem;
     }
 


### PR DESCRIPTION
1.8.9: 

https://github.com/MinecraftForge/MinecraftForge/blob/master/src/main/java/net/minecraftforge/common/ForgeHooks.java#L544

Note that joinEntityItemWithWorld is a NO-OP on the clientside (for EntityPlayerSP)

1.9:

https://github.com/MinecraftForge/MinecraftForge/blob/1.9/src/main/java/net/minecraftforge/common/ForgeHooks.java#L559

The item is spawned regardless of side.

This PR adds a remote check to fix that