### PR TITLE
Add ServerSendChatEvent

### DIFF
--- a/patches/minecraft/net/minecraft/server/management/PlayerList.java.patch
+++ b/patches/minecraft/net/minecraft/server/management/PlayerList.java.patch
@@ -227,3 +227,12 @@
                  p_82448_4_.func_72838_d(p_82448_1_);
                  p_82448_4_.func_72866_a(p_82448_1_, false);
              }
+@@ -1005,6 +1065,8 @@
+ 
+     public void func_148539_a(ITextComponent p_148539_1_)
+     {
++        p_148539_1_ = net.minecraftforge.event.ForgeEventFactory.serverSendChat(p_148539_1_);
++        if (p_148539_1_ == null) return;
+         this.func_148544_a(p_148539_1_, true);
+     }
+ 

--- a/src/main/java/net/minecraftforge/event/ForgeEventFactory.java
+++ b/src/main/java/net/minecraftforge/event/ForgeEventFactory.java
@@ -4,7 +4,6 @@ import java.io.File;
 import java.util.EnumSet;
 import java.util.List;
 
-import net.minecraft.block.Block;
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.EntityLiving;
@@ -16,7 +15,6 @@ import net.minecraft.entity.monster.EntityZombie;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.entity.player.EntityPlayer.EnumStatus;
 import net.minecraft.init.Blocks;
-import net.minecraft.init.Items;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraft.tileentity.TileEntity;
@@ -551,6 +549,14 @@ public class ForgeEventFactory
     public static void onChunkPopulate(boolean pre, IChunkGenerator gen, World world, int x, int z, boolean hasVillageGenerated)
     {
         MinecraftForge.EVENT_BUS.post(new PopulateChunkEvent.Pre(gen, world, world.rand, x, z, hasVillageGenerated));
+    }
+
+    public static ITextComponent serverSendChat(ITextComponent component)
+    {
+        ServerSendChatEvent event = new ServerSendChatEvent(component);
+        MinecraftForge.EVENT_BUS.post(event);
+        if (event.isCanceled()) return null;
+        return event.getComponent();
     }
 
 }

--- a/src/main/java/net/minecraftforge/event/ServerSendChatEvent.java
+++ b/src/main/java/net/minecraftforge/event/ServerSendChatEvent.java
@@ -1,0 +1,37 @@
+package net.minecraftforge.event;
+
+import net.minecraft.util.text.ITextComponent;
+import net.minecraftforge.fml.common.eventhandler.Cancelable;
+import net.minecraftforge.fml.common.eventhandler.Event;
+
+/**
+ * ServerSendChatEvent is fired whenever a chat message is sent by the server (e.g. with the /say command)
+ * Fired via {@link ForgeEventFactory#serverSendChat} which is called from {@link net.minecraft.server.management.PlayerList#sendChatMsg}
+ *
+ * {@link #component} contains the message to be sent by the server
+ *
+ * This event is {@link Cancelable}
+ * This event does not have a result
+ */
+@Cancelable
+public class ServerSendChatEvent extends Event
+{
+
+    private ITextComponent component;
+
+    public ServerSendChatEvent(ITextComponent component)
+    {
+        this.component = component;
+    }
+
+    public ITextComponent getComponent()
+    {
+        return component;
+    }
+
+    public void setComponent(ITextComponent component)
+    {
+        this.component = component;
+    }
+
+}

--- a/src/test/java/net/minecraftforge/test/ServerSendChatTest.java
+++ b/src/test/java/net/minecraftforge/test/ServerSendChatTest.java
@@ -1,0 +1,27 @@
+package net.minecraftforge.test;
+
+import net.minecraft.util.text.TextComponentString;
+import net.minecraftforge.common.MinecraftForge;
+import net.minecraftforge.event.ServerSendChatEvent;
+import net.minecraftforge.fml.common.Mod;
+import net.minecraftforge.fml.common.event.FMLPreInitializationEvent;
+import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
+
+/**
+ * @author shadowfacts
+ */
+@Mod(modid = "ServerSendChatTest")
+public class ServerSendChatTest
+{
+
+    @Mod.EventHandler
+    public void preInit(FMLPreInitializationEvent event) {
+        MinecraftForge.EVENT_BUS.register(this);
+    }
+
+    @SubscribeEvent
+    public void onServerSendChat(ServerSendChatEvent event) {
+        event.setComponent(new TextComponentString("[From server] ").appendSibling(event.getComponent()));
+    }
+
+}


### PR DESCRIPTION
Allows messages sent from the server (e.g. through `/say`) to be intercepted and canceled/modified.

Tested using [this](https://gist.github.com/shadowfacts/679f6e91d46f65f738bd).

Remake of #2418 for 1.9.