### PR TITLE
Add ScreenshotEvent

### DIFF
--- a/patches/minecraft/net/minecraft/util/ScreenShotHelper.java.patch
+++ b/patches/minecraft/net/minecraft/util/ScreenShotHelper.java.patch
@@ -1,12 +1,13 @@
 --- ../src-base/minecraft/net/minecraft/util/ScreenShotHelper.java
 +++ ../src-work/minecraft/net/minecraft/util/ScreenShotHelper.java
-@@ -52,7 +52,14 @@
+@@ -52,7 +52,12 @@
                  file2 = new File(file1, p_148259_1_);
              }
  
-+            net.minecraftforge.client.event.ScreenshotEvent.Pre preEvent = net.minecraftforge.client.ForgeHooksClient.onScreenshotPre(file2);
++            net.minecraftforge.client.event.ScreenshotEvent.Pre preEvent = net.minecraftforge.client.ForgeHooksClient.onScreenshotPre(bufferedimage, file2);
 +            if (preEvent.isCanceled()) return preEvent.getCancelReason();
 +            file2 = preEvent.getScreenshotFile();
++            bufferedimage = preEvent.getImage();
              ImageIO.write(bufferedimage, "png", (File)file2);
 +            net.minecraftforge.client.ForgeHooksClient.onScreenshotPost(file2);
              ITextComponent itextcomponent = new TextComponentString(file2.getName());

--- a/patches/minecraft/net/minecraft/util/ScreenShotHelper.java.patch
+++ b/patches/minecraft/net/minecraft/util/ScreenShotHelper.java.patch
@@ -1,11 +1,16 @@
 --- ../src-base/minecraft/net/minecraft/util/ScreenShotHelper.java
 +++ ../src-work/minecraft/net/minecraft/util/ScreenShotHelper.java
-@@ -52,6 +52,8 @@
+@@ -52,10 +52,13 @@
                  file2 = new File(file1, p_148259_1_);
              }
  
 +            net.minecraftforge.client.event.ScreenshotEvent event = net.minecraftforge.client.ForgeHooksClient.onScreenshot(bufferedimage, file2);
-+            if (event.isCanceled()) return event.getCancelReason(); else file2 = event.getScreenshotFile();
++            if (event.isCanceled()) return event.getCancelMessage(); else file2 = event.getScreenshotFile();
              ImageIO.write(bufferedimage, "png", (File)file2);
              ITextComponent itextcomponent = new TextComponentString(file2.getName());
              itextcomponent.func_150256_b().func_150241_a(new ClickEvent(ClickEvent.Action.OPEN_FILE, file2.getAbsolutePath()));
+             itextcomponent.func_150256_b().func_150228_d(Boolean.valueOf(true));
++            if (event.getResultMessage() != null) return event.getResultMessage();
+             return new TextComponentTranslation("screenshot.success", new Object[] {itextcomponent});
+         }
+         catch (Exception exception)

--- a/patches/minecraft/net/minecraft/util/ScreenShotHelper.java.patch
+++ b/patches/minecraft/net/minecraft/util/ScreenShotHelper.java.patch
@@ -1,0 +1,14 @@
+--- ../src-base/minecraft/net/minecraft/util/ScreenShotHelper.java
++++ ../src-work/minecraft/net/minecraft/util/ScreenShotHelper.java
+@@ -52,7 +52,14 @@
+                 file2 = new File(file1, p_148259_1_);
+             }
+ 
++            net.minecraftforge.client.event.ScreenshotEvent.Pre preEvent = net.minecraftforge.client.ForgeHooksClient.onScreenshotPre(file2);
++            if (preEvent.isCanceled()) return preEvent.getCancelReason();
++            file2 = preEvent.getScreenshotFile();
+             ImageIO.write(bufferedimage, "png", (File)file2);
++            net.minecraftforge.client.ForgeHooksClient.onScreenshotPost(file2);
+             ITextComponent itextcomponent = new TextComponentString(file2.getName());
+             itextcomponent.func_150256_b().func_150241_a(new ClickEvent(ClickEvent.Action.OPEN_FILE, file2.getAbsolutePath()));
+             itextcomponent.func_150256_b().func_150228_d(Boolean.valueOf(true));

--- a/patches/minecraft/net/minecraft/util/ScreenShotHelper.java.patch
+++ b/patches/minecraft/net/minecraft/util/ScreenShotHelper.java.patch
@@ -1,13 +1,11 @@
 --- ../src-base/minecraft/net/minecraft/util/ScreenShotHelper.java
 +++ ../src-work/minecraft/net/minecraft/util/ScreenShotHelper.java
-@@ -52,7 +52,10 @@
+@@ -52,6 +52,8 @@
                  file2 = new File(file1, p_148259_1_);
              }
  
-+            net.minecraftforge.client.event.ScreenshotEvent.Pre preEvent = net.minecraftforge.client.ForgeHooksClient.onScreenshotPre(bufferedimage, file2);
-+            if (preEvent.isCanceled()) return preEvent.getCancelReason(); else file2 = preEvent.getScreenshotFile();
++            net.minecraftforge.client.event.ScreenshotEvent event = net.minecraftforge.client.ForgeHooksClient.onScreenshot(bufferedimage, file2);
++            if (event.isCanceled()) return event.getCancelReason(); else file2 = event.getScreenshotFile();
              ImageIO.write(bufferedimage, "png", (File)file2);
-+            net.minecraftforge.client.ForgeHooksClient.onScreenshotPost(file2);
              ITextComponent itextcomponent = new TextComponentString(file2.getName());
              itextcomponent.func_150256_b().func_150241_a(new ClickEvent(ClickEvent.Action.OPEN_FILE, file2.getAbsolutePath()));
-             itextcomponent.func_150256_b().func_150228_d(Boolean.valueOf(true));

--- a/patches/minecraft/net/minecraft/util/ScreenShotHelper.java.patch
+++ b/patches/minecraft/net/minecraft/util/ScreenShotHelper.java.patch
@@ -1,13 +1,11 @@
 --- ../src-base/minecraft/net/minecraft/util/ScreenShotHelper.java
 +++ ../src-work/minecraft/net/minecraft/util/ScreenShotHelper.java
-@@ -52,7 +52,12 @@
+@@ -52,7 +52,10 @@
                  file2 = new File(file1, p_148259_1_);
              }
  
 +            net.minecraftforge.client.event.ScreenshotEvent.Pre preEvent = net.minecraftforge.client.ForgeHooksClient.onScreenshotPre(bufferedimage, file2);
-+            if (preEvent.isCanceled()) return preEvent.getCancelReason();
-+            file2 = preEvent.getScreenshotFile();
-+            bufferedimage = preEvent.getImage();
++            if (preEvent.isCanceled()) return preEvent.getCancelReason(); else file2 = preEvent.getScreenshotFile();
              ImageIO.write(bufferedimage, "png", (File)file2);
 +            net.minecraftforge.client.ForgeHooksClient.onScreenshotPost(file2);
              ITextComponent itextcomponent = new TextComponentString(file2.getName());

--- a/src/main/java/net/minecraftforge/client/ForgeHooksClient.java
+++ b/src/main/java/net/minecraftforge/client/ForgeHooksClient.java
@@ -5,6 +5,7 @@ import static net.minecraftforge.common.ForgeVersion.Status.BETA_OUTDATED;
 import static org.lwjgl.opengl.GL11.*;
 import static org.lwjgl.opengl.GL20.*;
 
+import java.io.File;
 import java.nio.ByteBuffer;
 import java.nio.FloatBuffer;
 import java.util.Map;
@@ -68,6 +69,7 @@ import net.minecraftforge.client.event.ModelBakeEvent;
 import net.minecraftforge.client.event.MouseEvent;
 import net.minecraftforge.client.event.RenderHandEvent;
 import net.minecraftforge.client.event.RenderWorldLastEvent;
+import net.minecraftforge.client.event.ScreenshotEvent;
 import net.minecraftforge.client.event.TextureStitchEvent;
 import net.minecraftforge.client.event.sound.PlaySoundEvent;
 import net.minecraftforge.client.model.IModelPart;
@@ -636,4 +638,15 @@ public class ForgeHooksClient
         }
         return !from.getItem().shouldCauseReequipAnimation(from, to, changed);
     }
+
+    public static ScreenshotEvent.Pre onScreenshotPre(File screenshotFile) {
+        ScreenshotEvent.Pre event = new ScreenshotEvent.Pre(screenshotFile);
+        MinecraftForge.EVENT_BUS.post(event);
+        return event;
+    }
+
+    public static void onScreenshotPost(File screenshotFile) {
+        MinecraftForge.EVENT_BUS.post(new ScreenshotEvent.Post(screenshotFile));
+    }
+
 }

--- a/src/main/java/net/minecraftforge/client/ForgeHooksClient.java
+++ b/src/main/java/net/minecraftforge/client/ForgeHooksClient.java
@@ -640,16 +640,11 @@ public class ForgeHooksClient
         return !from.getItem().shouldCauseReequipAnimation(from, to, changed);
     }
 
-    public static ScreenshotEvent.Pre onScreenshotPre(BufferedImage image, File screenshotFile)
+    public static ScreenshotEvent onScreenshot(BufferedImage image, File screenshotFile)
     {
-        ScreenshotEvent.Pre event = new ScreenshotEvent.Pre(image, screenshotFile);
+        ScreenshotEvent event = new ScreenshotEvent(image, screenshotFile);
         MinecraftForge.EVENT_BUS.post(event);
         return event;
-    }
-
-    public static void onScreenshotPost(File screenshotFile)
-    {
-        MinecraftForge.EVENT_BUS.post(new ScreenshotEvent.Post(screenshotFile));
     }
 
 }

--- a/src/main/java/net/minecraftforge/client/ForgeHooksClient.java
+++ b/src/main/java/net/minecraftforge/client/ForgeHooksClient.java
@@ -640,13 +640,15 @@ public class ForgeHooksClient
         return !from.getItem().shouldCauseReequipAnimation(from, to, changed);
     }
 
-    public static ScreenshotEvent.Pre onScreenshotPre(BufferedImage image, File screenshotFile) {
+    public static ScreenshotEvent.Pre onScreenshotPre(BufferedImage image, File screenshotFile)
+    {
         ScreenshotEvent.Pre event = new ScreenshotEvent.Pre(image, screenshotFile);
         MinecraftForge.EVENT_BUS.post(event);
         return event;
     }
 
-    public static void onScreenshotPost(File screenshotFile) {
+    public static void onScreenshotPost(File screenshotFile)
+    {
         MinecraftForge.EVENT_BUS.post(new ScreenshotEvent.Post(screenshotFile));
     }
 

--- a/src/main/java/net/minecraftforge/client/ForgeHooksClient.java
+++ b/src/main/java/net/minecraftforge/client/ForgeHooksClient.java
@@ -5,6 +5,7 @@ import static net.minecraftforge.common.ForgeVersion.Status.BETA_OUTDATED;
 import static org.lwjgl.opengl.GL11.*;
 import static org.lwjgl.opengl.GL20.*;
 
+import java.awt.image.BufferedImage;
 import java.io.File;
 import java.nio.ByteBuffer;
 import java.nio.FloatBuffer;
@@ -639,8 +640,8 @@ public class ForgeHooksClient
         return !from.getItem().shouldCauseReequipAnimation(from, to, changed);
     }
 
-    public static ScreenshotEvent.Pre onScreenshotPre(File screenshotFile) {
-        ScreenshotEvent.Pre event = new ScreenshotEvent.Pre(screenshotFile);
+    public static ScreenshotEvent.Pre onScreenshotPre(BufferedImage image, File screenshotFile) {
+        ScreenshotEvent.Pre event = new ScreenshotEvent.Pre(image, screenshotFile);
         MinecraftForge.EVENT_BUS.post(event);
         return event;
     }

--- a/src/main/java/net/minecraftforge/client/event/ScreenshotEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/ScreenshotEvent.java
@@ -28,25 +28,25 @@ public class ScreenshotEvent extends Event
      * This event is {@link Cancelable}
      *
      * {@link #screenshotFile} contains the file the screenshot will be/was saved to
-	 * {@link #image} contains the {@link BufferedImage} containing the screenshot
+     * {@link #image} contains the {@link BufferedImage} containing the screenshot
      * {@link #cancelReason} contains the {@link ITextComponent} to be used if the event is canceled
      */
     @Cancelable
     public static class Pre extends ScreenshotEvent
     {
-		private BufferedImage image;
+        private BufferedImage image;
         private ITextComponent cancelReason = new TextComponentString("Screenshot canceled for unknown reason");
 
         public Pre(BufferedImage image, File screenshotFile)
         {
-			this.image = image;
+            this.image = image;
             this.screenshotFile = screenshotFile;
         }
 
-		public void setScreenshotFile(File screenshotFile)
-		{
-			this.screenshotFile = screenshotFile;
-		}
+        public void setScreenshotFile(File screenshotFile)
+        {
+            this.screenshotFile = screenshotFile;
+        }
 
         public ITextComponent getCancelReason()
         {
@@ -58,14 +58,16 @@ public class ScreenshotEvent extends Event
             this.cancelReason = cancelReason;
         }
 
-		public BufferedImage getImage() {
-			return image;
-		}
+        public BufferedImage getImage()
+        {
+            return image;
+        }
 
-		public void setImage(BufferedImage image) {
-			this.image = image;
-		}
-	}
+        public void setImage(BufferedImage image)
+        {
+            this.image = image;
+        }
+    }
 
     /**
      * This event is fired after a screenshot is taken

--- a/src/main/java/net/minecraftforge/client/event/ScreenshotEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/ScreenshotEvent.java
@@ -11,74 +11,50 @@ import java.io.File;
 /**
  * This event is fired before and after a screenshot is taken
  * This event is fired on the {@link net.minecraftforge.common.MinecraftForge#EVENT_BUS}
+ * This event is {@link Cancelable}
  *
  * {@link #screenshotFile} contains the file the screenshot will be/was saved to
+ * {@link #image} contains the {@link BufferedImage} that will be saved
+ * {@link #cancelReason} contains the {@link ITextComponent} to be used if the event is canceled
  */
+@Cancelable
 public class ScreenshotEvent extends Event
 {
 
-    protected File screenshotFile;
+    private BufferedImage image;
+    private File screenshotFile;
 
-    public File getScreenshotFile() {
+    private ITextComponent cancelReason = new TextComponentString("Screenshot canceled for unknown reason");
+
+    public ScreenshotEvent(BufferedImage image, File screenshotFile)
+    {
+        this.image = image;
+        this.screenshotFile = screenshotFile;
+    }
+
+    public BufferedImage getImage()
+    {
+        return image;
+    }
+
+    public File getScreenshotFile()
+    {
         return screenshotFile;
     }
 
-    /**
-     * This event is fired before a screenshot is taken
-     * This event is {@link Cancelable}
-     *
-     * {@link #screenshotFile} contains the file the screenshot will be/was saved to
-     * {@link #image} contains the {@link BufferedImage} containing the screenshot
-     * {@link #cancelReason} contains the {@link ITextComponent} to be used if the event is canceled
-     */
-    @Cancelable
-    public static class Pre extends ScreenshotEvent
+    public void setScreenshotFile(File screenshotFile)
     {
-        private final BufferedImage image;
-        private ITextComponent cancelReason = new TextComponentString("Screenshot canceled for unknown reason");
-
-        public Pre(BufferedImage image, File screenshotFile)
-        {
-            this.image = image;
-            this.screenshotFile = screenshotFile;
-        }
-
-        public void setScreenshotFile(File screenshotFile)
-        {
-            this.screenshotFile = screenshotFile;
-        }
-
-        public ITextComponent getCancelReason()
-        {
-            return cancelReason;
-        }
-
-        public void setCancelReason(ITextComponent cancelReason)
-        {
-            this.cancelReason = cancelReason;
-        }
-
-        public BufferedImage getImage()
-        {
-            return image;
-        }
-
+        this.screenshotFile = screenshotFile;
     }
 
-    /**
-     * This event is fired after a screenshot is taken
-     * This event is <b>not</b> {@link Cancelable}
-     *
-     * {@link #screenshotFile} contains the file the screenshot will be/was saved to
-     */
-    public static class Post extends ScreenshotEvent
+    public ITextComponent getCancelReason()
     {
+        return cancelReason;
+    }
 
-        public Post(File screenshotFile)
-        {
-            this.screenshotFile = screenshotFile;
-        }
-
+    public void setCancelReason(ITextComponent cancelReason)
+    {
+        this.cancelReason = cancelReason;
     }
 
 }

--- a/src/main/java/net/minecraftforge/client/event/ScreenshotEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/ScreenshotEvent.java
@@ -1,0 +1,75 @@
+package net.minecraftforge.client.event;
+
+import net.minecraft.util.text.ITextComponent;
+import net.minecraft.util.text.TextComponentString;
+import net.minecraftforge.fml.common.eventhandler.Cancelable;
+import net.minecraftforge.fml.common.eventhandler.Event;
+
+import java.io.File;
+
+/**
+ * This event is fired before and after a screenshot is taken
+ * This event is fired on the {@link net.minecraftforge.common.MinecraftForge#EVENT_BUS}
+ *
+ * {@link #screenshotFile} contains the file the screenshot will be/was saved to
+ */
+public class ScreenshotEvent extends Event
+{
+
+    protected File screenshotFile;
+
+    public File getScreenshotFile() {
+        return screenshotFile;
+    }
+
+    /**
+     * This event is fired before a screenshot is taken
+     * This event is {@link Cancelable}
+     *
+     * {@link #screenshotFile} contains the file the screenshot will be/was saved to
+     * {@link #cancelReason} contains the {@link ITextComponent} to be used if the event is canceled
+     */
+    @Cancelable
+    public static class Pre extends ScreenshotEvent
+    {
+        private ITextComponent cancelReason = new TextComponentString("Screenshot canceled for unknown reason");
+
+        public Pre(File screenshotFile)
+        {
+            this.screenshotFile = screenshotFile;
+        }
+
+        public ITextComponent getCancelReason()
+        {
+            return cancelReason;
+        }
+
+        public void setCancelReason(ITextComponent cancelReason)
+        {
+            this.cancelReason = cancelReason;
+        }
+
+        public void setScreenshotFile(File screenshotFile)
+        {
+            this.screenshotFile = screenshotFile;
+        }
+
+    }
+
+    /**
+     * This event is fired after a screenshot is taken
+     * This event is <b>not</b> {@link Cancelable}
+     *
+     * {@link #screenshotFile} contains the file the screenshot will be/was saved to
+     */
+    public static class Post extends ScreenshotEvent
+    {
+
+        public Post(File screenshotFile)
+        {
+            this.screenshotFile = screenshotFile;
+        }
+
+    }
+
+}

--- a/src/main/java/net/minecraftforge/client/event/ScreenshotEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/ScreenshotEvent.java
@@ -34,7 +34,7 @@ public class ScreenshotEvent extends Event
     @Cancelable
     public static class Pre extends ScreenshotEvent
     {
-        private BufferedImage image;
+        private final BufferedImage image;
         private ITextComponent cancelReason = new TextComponentString("Screenshot canceled for unknown reason");
 
         public Pre(BufferedImage image, File screenshotFile)

--- a/src/main/java/net/minecraftforge/client/event/ScreenshotEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/ScreenshotEvent.java
@@ -15,16 +15,18 @@ import java.io.File;
  *
  * {@link #screenshotFile} contains the file the screenshot will be/was saved to
  * {@link #image} contains the {@link BufferedImage} that will be saved
- * {@link #cancelReason} contains the {@link ITextComponent} to be used if the event is canceled
+ * {@link #resultMessage} contains the {@link ITextComponent} to be returned. If {@code null}, the default vanilla message will be used instead
  */
 @Cancelable
 public class ScreenshotEvent extends Event
 {
 
+    public static final ITextComponent DEFAULT_CANCEL_REASON = new TextComponentString("Screenshot canceled");
+
     private BufferedImage image;
     private File screenshotFile;
 
-    private ITextComponent cancelReason = new TextComponentString("Screenshot canceled for unknown reason");
+    private ITextComponent resultMessage = null;
 
     public ScreenshotEvent(BufferedImage image, File screenshotFile)
     {
@@ -47,14 +49,19 @@ public class ScreenshotEvent extends Event
         this.screenshotFile = screenshotFile;
     }
 
-    public ITextComponent getCancelReason()
+    public ITextComponent getResultMessage()
     {
-        return cancelReason;
+        return resultMessage;
     }
 
-    public void setCancelReason(ITextComponent cancelReason)
+    public void setResultMessage(ITextComponent resultMessage)
     {
-        this.cancelReason = cancelReason;
+        this.resultMessage = resultMessage;
+    }
+
+    public ITextComponent getCancelMessage()
+    {
+        return getResultMessage() != null ? getResultMessage() : DEFAULT_CANCEL_REASON;
     }
 
 }

--- a/src/main/java/net/minecraftforge/client/event/ScreenshotEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/ScreenshotEvent.java
@@ -5,6 +5,7 @@ import net.minecraft.util.text.TextComponentString;
 import net.minecraftforge.fml.common.eventhandler.Cancelable;
 import net.minecraftforge.fml.common.eventhandler.Event;
 
+import java.awt.image.BufferedImage;
 import java.io.File;
 
 /**
@@ -27,17 +28,25 @@ public class ScreenshotEvent extends Event
      * This event is {@link Cancelable}
      *
      * {@link #screenshotFile} contains the file the screenshot will be/was saved to
+	 * {@link #image} contains the {@link BufferedImage} containing the screenshot
      * {@link #cancelReason} contains the {@link ITextComponent} to be used if the event is canceled
      */
     @Cancelable
     public static class Pre extends ScreenshotEvent
     {
+		private BufferedImage image;
         private ITextComponent cancelReason = new TextComponentString("Screenshot canceled for unknown reason");
 
-        public Pre(File screenshotFile)
+        public Pre(BufferedImage image, File screenshotFile)
         {
+			this.image = image;
             this.screenshotFile = screenshotFile;
         }
+
+		public void setScreenshotFile(File screenshotFile)
+		{
+			this.screenshotFile = screenshotFile;
+		}
 
         public ITextComponent getCancelReason()
         {
@@ -49,12 +58,14 @@ public class ScreenshotEvent extends Event
             this.cancelReason = cancelReason;
         }
 
-        public void setScreenshotFile(File screenshotFile)
-        {
-            this.screenshotFile = screenshotFile;
-        }
+		public BufferedImage getImage() {
+			return image;
+		}
 
-    }
+		public void setImage(BufferedImage image) {
+			this.image = image;
+		}
+	}
 
     /**
      * This event is fired after a screenshot is taken

--- a/src/main/java/net/minecraftforge/client/event/ScreenshotEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/ScreenshotEvent.java
@@ -63,10 +63,6 @@ public class ScreenshotEvent extends Event
             return image;
         }
 
-        public void setImage(BufferedImage image)
-        {
-            this.image = image;
-        }
     }
 
     /**


### PR DESCRIPTION
Adds `ScreenshotEvent.Pre` and `ScreenshotEvent.Post` which are fired respectively before and after screenshots are taken. 

`Pre` can be used to change the screenshot file and cancel the event.

`Post` can be used to perform actions on the screenshot after it has been saved.

This was tested successfully using:

```java
import net.minecraftforge.client.event.ScreenshotEvent;
import net.minecraftforge.common.MinecraftForge;
import net.minecraftforge.fml.common.Mod;
import net.minecraftforge.fml.common.event.FMLPreInitializationEvent;
import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;

import java.io.File;

@Mod(modid = "ScreenshotEventTest")
public class ScreenshotTest
{

    @Mod.EventHandler
    public void preInit(FMLPreInitializationEvent event) {
        MinecraftForge.EVENT_BUS.register(this);
    }

    @SubscribeEvent
    public void onScreenshotPre(ScreenshotEvent.Pre event) {
        event.setScreenshotFile(new File(event.getScreenshotFile().getParentFile(), "Screenshot_test.png"));
    }

    @SubscribeEvent
    public void onScreenshotPost(ScreenshotEvent.Post event) {
        System.out.println("Screenshot saved to: " + event.getScreenshotFile().getName());
    }

}
```