### PR TITLE
Fixed players smaller than 1 block not being able to walk under overhang

### DIFF
--- a/patches/minecraft/net/minecraft/client/entity/EntityPlayerSP.java.patch
+++ b/patches/minecraft/net/minecraft/client/entity/EntityPlayerSP.java.patch
@@ -8,7 +8,7 @@
 +    {
 +        for (int y = 0; y < height; y++)
 +        {
-+            if (func_175162_d(pos.func_177982_a(0, y, 0))) return false;
++            if (!func_175162_d(pos.func_177982_a(0, y, 0))) return false;
 +        }
 +        return true;
 +    }
@@ -21,7 +21,7 @@
              double d1 = p_145771_5_ - (double)blockpos.func_177952_p();
  
 -            if (!this.func_175162_d(blockpos))
-+            int entHeight = Math.max(Math.round(this.field_70131_O), 1);
++            int entHeight = Math.max((int)Math.ceil(this.field_70131_O), 1);
 +
 +            boolean inTranslucentBlock = this.isHeadspaceFree(blockpos, entHeight);
 +
@@ -56,6 +56,15 @@
                  {
                      d2 = 1.0D - d1;
                      i = 5;
+@@ -415,7 +428,7 @@
+ 
+     private boolean func_175162_d(BlockPos p_175162_1_)
+     {
+-        return !this.field_70170_p.func_180495_p(p_175162_1_).func_177230_c().func_149721_r() && !this.field_70170_p.func_180495_p(p_175162_1_.func_177984_a()).func_177230_c().func_149721_r();
++        return !this.field_70170_p.func_180495_p(p_175162_1_).func_177230_c().func_149721_r();
+     }
+ 
+     public void func_70031_b(boolean p_70031_1_)
 @@ -448,6 +461,12 @@
  
      public void func_85030_a(String p_85030_1_, float p_85030_2_, float p_85030_3_)


### PR DESCRIPTION
With the vanilla code, it is impossible to make a player collide less than 1 block tall, as it will always check the block above for headroom.

This PR adds in a check to see if the player height is less than 1 block, and if so, does not check the block above for headroom.