### PR TITLE
Add missing Minecart/Track hook.

### DIFF
--- a/patches/minecraft/net/minecraft/block/BlockRailBase.java.patch
+++ b/patches/minecraft/net/minecraft/block/BlockRailBase.java.patch
@@ -9,7 +9,7 @@
      }
  
      protected BlockRailBase(boolean p_i45389_1_)
-@@ -175,6 +175,81 @@
+@@ -175,6 +175,98 @@
  
      public abstract IProperty<BlockRailBase.EnumRailDirection> func_176560_l();
  
@@ -18,7 +18,7 @@
 +     * Return true if the rail can make corners.
 +     * Used by placement logic.
 +     * @param world The world.
-+     * @param pod Block's position in world
++     * @param pos Block's position in world
 +     * @return True if the rail can make corners.
 +     */
 +    public boolean isFlexibleRail(IBlockAccess world, BlockPos pos)
@@ -30,7 +30,7 @@
 +     * Returns true if the rail can make up and down slopes.
 +     * Used by placement logic.
 +     * @param world The world.
-+     * @param pod Block's position in world
++     * @param pos Block's position in world
 +     * @return True if the rail can make slopes.
 +     */
 +    public boolean canMakeSlopes(IBlockAccess world, BlockPos pos)
@@ -39,10 +39,27 @@
 +    }
 +
 +    /**
++     * Return the rail's direction.
++     * Can be used to make the cart think the rail is a different shape,
++     * for example when making diamond junctions or switches.
++     * The cart parameter will often be null unless it it called from EntityMinecart.
++     *
++     * @param world The world.
++     * @param pos Block's position in world
++     * @param state The BlockState
++     * @param cart The cart asking for the metadata, null if it is not called by EntityMinecart.
++     * @return The direction.
++     */
++    public EnumRailDirection getRailDirection(IBlockAccess world, BlockPos pos, IBlockState state, @javax.annotation.Nullable net.minecraft.entity.item.EntityMinecart cart)
++    {
++        return state.func_177229_b(func_176560_l());
++    }
++
++    /**
 +     * Returns the max speed of the rail at the specified position.
 +     * @param world The world.
 +     * @param cart The cart on the rail, may be null.
-+     * @param pod Block's position in world
++     * @param pos Block's position in world
 +     * @return The max speed of the current rail.
 +     */
 +    public float getRailMaxSpeed(World world, net.minecraft.entity.item.EntityMinecart cart, BlockPos pos)
@@ -55,7 +72,7 @@
 +     * It is called once per update tick that the minecart is on the rail.
 +     * @param world The world.
 +     * @param cart The cart on the rail.
-+     * @param pod Block's position in world
++     * @param pos Block's position in world
 +     */
 +    public void onMinecartPass(World world, net.minecraft.entity.item.EntityMinecart cart, BlockPos pos)
 +    {
@@ -91,7 +108,7 @@
      public static enum EnumRailDirection implements IStringSerializable
      {
          NORTH_SOUTH(0, "north_south"),
-@@ -245,6 +320,7 @@
+@@ -245,6 +337,7 @@
          private IBlockState field_180366_e;
          private final boolean field_150656_f;
          private final List<BlockPos> field_150657_g = Lists.<BlockPos>newArrayList();
@@ -99,17 +116,19 @@
  
          public Rail(World p_i45739_2_, BlockPos p_i45739_3_, IBlockState p_i45739_4_)
          {
-@@ -253,7 +329,8 @@
+@@ -252,8 +345,9 @@
+             this.field_180367_c = p_i45739_3_;
              this.field_180366_e = p_i45739_4_;
              this.field_180365_d = (BlockRailBase)p_i45739_4_.func_177230_c();
-             BlockRailBase.EnumRailDirection blockrailbase$enumraildirection = (BlockRailBase.EnumRailDirection)p_i45739_4_.func_177229_b(BlockRailBase.this.func_176560_l());
+-            BlockRailBase.EnumRailDirection blockrailbase$enumraildirection = (BlockRailBase.EnumRailDirection)p_i45739_4_.func_177229_b(BlockRailBase.this.func_176560_l());
 -            this.field_150656_f = this.field_180365_d.field_150053_a;
++            BlockRailBase.EnumRailDirection blockrailbase$enumraildirection = field_180365_d.getRailDirection(p_i45739_2_, p_i45739_3_, p_i45739_4_, null);
 +            this.field_150656_f = !this.field_180365_d.isFlexibleRail(p_i45739_2_, p_i45739_3_);
 +            canMakeSlopes = this.field_180365_d.canMakeSlopes(p_i45739_2_, p_i45739_3_);
              this.func_180360_a(blockrailbase$enumraildirection);
          }
  
-@@ -439,7 +516,7 @@
+@@ -439,7 +533,7 @@
                  }
              }
  
@@ -118,7 +137,7 @@
              {
                  if (BlockRailBase.func_176562_d(this.field_150660_b, blockpos.func_177984_a()))
                  {
-@@ -452,7 +529,7 @@
+@@ -452,7 +546,7 @@
                  }
              }
  
@@ -127,7 +146,7 @@
              {
                  if (BlockRailBase.func_176562_d(this.field_150660_b, blockpos3.func_177984_a()))
                  {
-@@ -595,7 +672,7 @@
+@@ -595,7 +689,7 @@
                  }
              }
  
@@ -136,7 +155,7 @@
              {
                  if (BlockRailBase.func_176562_d(this.field_150660_b, blockpos.func_177984_a()))
                  {
-@@ -608,7 +685,7 @@
+@@ -608,7 +702,7 @@
                  }
              }
  

--- a/patches/minecraft/net/minecraft/entity/item/EntityMinecart.java.patch
+++ b/patches/minecraft/net/minecraft/entity/item/EntityMinecart.java.patch
@@ -117,8 +117,9 @@
          }
  
 -        double d0 = 0.0078125D;
+-        BlockRailBase.EnumRailDirection blockrailbase$enumraildirection = (BlockRailBase.EnumRailDirection)p_180460_2_.func_177229_b(blockrailbase.func_176560_l());
 +        double slopeAdjustment = getSlopeAdjustment();
-         BlockRailBase.EnumRailDirection blockrailbase$enumraildirection = (BlockRailBase.EnumRailDirection)p_180460_2_.func_177229_b(blockrailbase.func_176560_l());
++        BlockRailBase.EnumRailDirection blockrailbase$enumraildirection = blockrailbase.getRailDirection(field_70170_p, p_180460_1_, p_180460_2_, this);
  
          switch (blockrailbase$enumraildirection)
          {
@@ -190,6 +191,24 @@
              double d15 = Math.sqrt(this.field_70159_w * this.field_70159_w + this.field_70179_y * this.field_70179_y);
  
              if (d15 > 0.01D)
+@@ -654,7 +679,7 @@
+ 
+         if (BlockRailBase.func_176563_d(iblockstate))
+         {
+-            BlockRailBase.EnumRailDirection blockrailbase$enumraildirection = (BlockRailBase.EnumRailDirection)iblockstate.func_177229_b(((BlockRailBase)iblockstate.func_177230_c()).func_176560_l());
++            BlockRailBase.EnumRailDirection blockrailbase$enumraildirection = ((BlockRailBase)iblockstate.func_177230_c()).getRailDirection(field_70170_p, new BlockPos(i, j, k), iblockstate, this);
+             p_70495_3_ = (double)j;
+ 
+             if (blockrailbase$enumraildirection.func_177018_c())
+@@ -703,7 +728,7 @@
+ 
+         if (BlockRailBase.func_176563_d(iblockstate))
+         {
+-            BlockRailBase.EnumRailDirection blockrailbase$enumraildirection = (BlockRailBase.EnumRailDirection)iblockstate.func_177229_b(((BlockRailBase)iblockstate.func_177230_c()).func_176560_l());
++            BlockRailBase.EnumRailDirection blockrailbase$enumraildirection = ((BlockRailBase)iblockstate.func_177230_c()).getRailDirection(field_70170_p, new BlockPos(i, j, k), iblockstate, this);
+             int[][] aint = field_70500_g[blockrailbase$enumraildirection.func_177015_a()];
+             double d0 = 0.0D;
+             double d1 = (double)i + 0.5D + (double)aint[0][0] * 0.5D;
 @@ -817,13 +842,20 @@
  
      public void func_70108_f(Entity p_70108_1_)


### PR DESCRIPTION
This was missing from the 1.8 version of Forge.

The 1.9 version is also missing it. I can make another PR for that if needed.

In 1.7 the function was called getBasicRailMetadata(), I've renamed it getRailDirection().