### PR TITLE
Expose IItemHandler on vanilla entities

### DIFF
--- a/patches/minecraft/net/minecraft/entity/EntityLivingBase.java.patch
+++ b/patches/minecraft/net/minecraft/entity/EntityLivingBase.java.patch
@@ -285,3 +285,38 @@
          }
  
          this.func_184602_cy();
+@@ -2626,4 +2707,34 @@
+     {
+         return true;
+     }
++
++    // FORGE
++    private final net.minecraftforge.items.IItemHandlerModifiable handHandler = new net.minecraftforge.items.ItemStackHandler(field_184630_bs);
++    private final net.minecraftforge.items.IItemHandlerModifiable armorHandler = new net.minecraftforge.items.ItemStackHandler(field_184631_bt);
++    private final net.minecraftforge.items.IItemHandler joinedHandler = new net.minecraftforge.items.wrapper.CombinedInvWrapper(armorHandler, handHandler);
++
++    @Override
++    public <T> T getCapability(net.minecraftforge.common.capabilities.Capability<T> capability, net.minecraft.util.EnumFacing facing)
++    {
++        if (capability == net.minecraftforge.items.CapabilityItemHandler.ITEM_HANDLER_CAPABILITY)
++        {
++            if (facing == net.minecraft.util.EnumFacing.UP)
++            {
++                return (T) armorHandler;
++            } else if (facing.func_176740_k().func_176722_c())
++            {
++                return (T) handHandler;
++            } else
++            {
++                return (T) joinedHandler;
++            }
++        }
++        return super.getCapability(capability, facing);
++    }
++
++    @Override
++    public boolean hasCapability(net.minecraftforge.common.capabilities.Capability<?> capability, net.minecraft.util.EnumFacing facing)
++    {
++        return capability == net.minecraftforge.items.CapabilityItemHandler.ITEM_HANDLER_CAPABILITY || super.hasCapability(capability, facing);
++    }
+ }

--- a/patches/minecraft/net/minecraft/entity/EntityLivingBase.java.patch
+++ b/patches/minecraft/net/minecraft/entity/EntityLivingBase.java.patch
@@ -285,7 +285,7 @@
          }
  
          this.func_184602_cy();
-@@ -2626,4 +2707,34 @@
+@@ -2626,4 +2707,27 @@
      {
          return true;
      }
@@ -300,16 +300,9 @@
 +    {
 +        if (capability == net.minecraftforge.items.CapabilityItemHandler.ITEM_HANDLER_CAPABILITY)
 +        {
-+            if (facing == net.minecraft.util.EnumFacing.UP)
-+            {
-+                return (T) armorHandler;
-+            } else if (facing.func_176740_k().func_176722_c())
-+            {
-+                return (T) handHandler;
-+            } else
-+            {
-+                return (T) joinedHandler;
-+            }
++            if (facing == null) return (T) joinedHandler;
++            else if (facing.func_176740_k().func_176720_b()) return (T) handHandler;
++            else if (facing.func_176740_k().func_176722_c()) return (T) armorHandler;
 +        }
 +        return super.getCapability(capability, facing);
 +    }

--- a/patches/minecraft/net/minecraft/entity/passive/EntityHorse.java.patch
+++ b/patches/minecraft/net/minecraft/entity/passive/EntityHorse.java.patch
@@ -16,7 +16,7 @@
              }
  
              this.field_70138_W = 1.0F;
-@@ -1793,4 +1795,25 @@
+@@ -1793,4 +1795,20 @@
                  this.field_188477_b = p_i46589_2_;
              }
          }
@@ -27,18 +27,13 @@
 +    @Override
 +    public <T> T getCapability(net.minecraftforge.common.capabilities.Capability<T> capability, net.minecraft.util.EnumFacing facing)
 +    {
-+        if (capability == net.minecraftforge.items.CapabilityItemHandler.ITEM_HANDLER_CAPABILITY
-+                && itemHandler != null)
-+        {
-+            return (T) itemHandler;
-+        }
++        if (capability == net.minecraftforge.items.CapabilityItemHandler.ITEM_HANDLER_CAPABILITY) return (T) itemHandler;
 +        return super.getCapability(capability, facing);
 +    }
 +
 +    @Override
 +    public boolean hasCapability(net.minecraftforge.common.capabilities.Capability<?> capability, net.minecraft.util.EnumFacing facing)
 +    {
-+        return capability == net.minecraftforge.items.CapabilityItemHandler.ITEM_HANDLER_CAPABILITY && itemHandler != null
-+                || super.hasCapability(capability, facing);
++        return capability == net.minecraftforge.items.CapabilityItemHandler.ITEM_HANDLER_CAPABILITY || super.hasCapability(capability, facing);
 +    }
  }

--- a/patches/minecraft/net/minecraft/entity/passive/EntityHorse.java.patch
+++ b/patches/minecraft/net/minecraft/entity/passive/EntityHorse.java.patch
@@ -1,6 +1,14 @@
 --- ../src-base/minecraft/net/minecraft/entity/passive/EntityHorse.java
 +++ ../src-work/minecraft/net/minecraft/entity/passive/EntityHorse.java
-@@ -1200,6 +1200,7 @@
+@@ -433,6 +433,7 @@
+ 
+         this.field_110296_bG.func_110134_a(this);
+         this.func_110232_cE();
++        this.itemHandler = new net.minecraftforge.items.wrapper.InvWrapper(this.field_110296_bG);
+     }
+ 
+     private void func_110232_cE()
+@@ -1200,6 +1201,7 @@
                  }
  
                  this.field_110277_bt = 0.0F;
@@ -8,3 +16,29 @@
              }
  
              this.field_70138_W = 1.0F;
+@@ -1793,4 +1795,25 @@
+                 this.field_188477_b = p_i46589_2_;
+             }
+         }
++
++    // FORGE
++    private net.minecraftforge.items.IItemHandler itemHandler = null; // Initialized by initHorseChest above.
++
++    @Override
++    public <T> T getCapability(net.minecraftforge.common.capabilities.Capability<T> capability, net.minecraft.util.EnumFacing facing)
++    {
++        if (capability == net.minecraftforge.items.CapabilityItemHandler.ITEM_HANDLER_CAPABILITY
++                && itemHandler != null)
++        {
++            return (T) itemHandler;
++        }
++        return super.getCapability(capability, facing);
++    }
++
++    @Override
++    public boolean hasCapability(net.minecraftforge.common.capabilities.Capability<?> capability, net.minecraft.util.EnumFacing facing)
++    {
++        return capability == net.minecraftforge.items.CapabilityItemHandler.ITEM_HANDLER_CAPABILITY && itemHandler != null
++                || super.hasCapability(capability, facing);
++    }
+ }

--- a/patches/minecraft/net/minecraft/entity/player/EntityPlayer.java.patch
+++ b/patches/minecraft/net/minecraft/entity/player/EntityPlayer.java.patch
@@ -401,7 +401,7 @@
  
          if (this.func_70608_bn())
          {
-@@ -2340,6 +2447,169 @@
+@@ -2340,6 +2447,160 @@
          return (float)this.func_110148_a(SharedMonsterAttributes.field_188792_h).func_111126_e();
      }
  
@@ -534,8 +534,9 @@
 +    public java.util.Collection<ITextComponent> getSuffixes() { return this.suffixes; }
 +
 +    private final net.minecraftforge.items.IItemHandler playerMainHandler = new net.minecraftforge.items.wrapper.PlayerMainInvWrapper(field_71071_by);
-+    private final net.minecraftforge.items.IItemHandler playerArmorHandler = new net.minecraftforge.items.wrapper.PlayerArmorInvWrapper(field_71071_by);
-+    private final net.minecraftforge.items.IItemHandler playerOffhandHandler = new net.minecraftforge.items.wrapper.PlayerOffhandInvWrapper(field_71071_by);
++    private final net.minecraftforge.items.IItemHandler playerEquipmentHandler = new net.minecraftforge.items.wrapper.CombinedInvWrapper(
++                    new net.minecraftforge.items.wrapper.PlayerArmorInvWrapper(field_71071_by),
++                    new net.minecraftforge.items.wrapper.PlayerOffhandInvWrapper(field_71071_by));
 +    private final net.minecraftforge.items.IItemHandler playerJoinedHandler = new net.minecraftforge.items.wrapper.PlayerInvWrapper(field_71071_by);
 +
 +    @Override
@@ -543,19 +544,9 @@
 +    {
 +        if (capability == net.minecraftforge.items.CapabilityItemHandler.ITEM_HANDLER_CAPABILITY)
 +        {
-+            if (facing == net.minecraft.util.EnumFacing.UP)
-+            {
-+                return (T) playerArmorHandler;
-+            } else if (facing == net.minecraft.util.EnumFacing.DOWN)
-+            {
-+                return (T) playerMainHandler;
-+            } else if (facing.func_176740_k().func_176722_c())
-+            {
-+                return (T) playerOffhandHandler;
-+            } else
-+            {
-+                return (T) playerJoinedHandler;
-+            }
++            if (facing == null) return (T) playerJoinedHandler;
++            else if (facing.func_176740_k().func_176720_b()) return (T) playerMainHandler;
++            else if (facing.func_176740_k().func_176722_c()) return (T) playerEquipmentHandler;
 +        }
 +        return super.getCapability(capability, facing);
 +    }

--- a/patches/minecraft/net/minecraft/entity/player/EntityPlayer.java.patch
+++ b/patches/minecraft/net/minecraft/entity/player/EntityPlayer.java.patch
@@ -401,7 +401,7 @@
  
          if (this.func_70608_bn())
          {
-@@ -2340,6 +2447,136 @@
+@@ -2340,6 +2447,169 @@
          return (float)this.func_110148_a(SharedMonsterAttributes.field_188792_h).func_111126_e();
      }
  
@@ -532,6 +532,39 @@
 +
 +    public java.util.Collection<ITextComponent> getPrefixes() { return this.prefixes; }
 +    public java.util.Collection<ITextComponent> getSuffixes() { return this.suffixes; }
++
++    private final net.minecraftforge.items.IItemHandler playerMainHandler = new net.minecraftforge.items.wrapper.PlayerMainInvWrapper(field_71071_by);
++    private final net.minecraftforge.items.IItemHandler playerArmorHandler = new net.minecraftforge.items.wrapper.PlayerArmorInvWrapper(field_71071_by);
++    private final net.minecraftforge.items.IItemHandler playerOffhandHandler = new net.minecraftforge.items.wrapper.PlayerOffhandInvWrapper(field_71071_by);
++    private final net.minecraftforge.items.IItemHandler playerJoinedHandler = new net.minecraftforge.items.wrapper.PlayerInvWrapper(field_71071_by);
++
++    @Override
++    public <T> T getCapability(net.minecraftforge.common.capabilities.Capability<T> capability, net.minecraft.util.EnumFacing facing)
++    {
++        if (capability == net.minecraftforge.items.CapabilityItemHandler.ITEM_HANDLER_CAPABILITY)
++        {
++            if (facing == net.minecraft.util.EnumFacing.UP)
++            {
++                return (T) playerArmorHandler;
++            } else if (facing == net.minecraft.util.EnumFacing.DOWN)
++            {
++                return (T) playerMainHandler;
++            } else if (facing.func_176740_k().func_176722_c())
++            {
++                return (T) playerOffhandHandler;
++            } else
++            {
++                return (T) playerJoinedHandler;
++            }
++        }
++        return super.getCapability(capability, facing);
++    }
++
++    @Override
++    public boolean hasCapability(net.minecraftforge.common.capabilities.Capability<?> capability, net.minecraft.util.EnumFacing facing)
++    {
++        return capability == net.minecraftforge.items.CapabilityItemHandler.ITEM_HANDLER_CAPABILITY || super.hasCapability(capability, facing);
++    }
 +
 +    /* ======================================== FORGE END  =====================================*/
 +

--- a/src/main/java/net/minecraftforge/items/ItemStackHandler.java
+++ b/src/main/java/net/minecraftforge/items/ItemStackHandler.java
@@ -20,6 +20,11 @@ public class ItemStackHandler implements IItemHandler, IItemHandlerModifiable, I
         stacks = new ItemStack[size];
     }
 
+    public ItemStackHandler(ItemStack[] stacks)
+    {
+        this.stacks = stacks;
+    }
+
     public void setSize(int size)
     {
         stacks = new ItemStack[size];

--- a/src/main/java/net/minecraftforge/items/wrapper/PlayerArmorInvWrapper.java
+++ b/src/main/java/net/minecraftforge/items/wrapper/PlayerArmorInvWrapper.java
@@ -4,29 +4,14 @@ import net.minecraft.entity.player.InventoryPlayer;
 import net.minecraft.inventory.EntityEquipmentSlot;
 import net.minecraft.item.ItemStack;
 
-public class PlayerArmorInvWrapper extends InvWrapper
+public class PlayerArmorInvWrapper extends RangedWrapper
 {
     public final InventoryPlayer inventoryPlayer;
-    private final int offset;
 
     public PlayerArmorInvWrapper(InventoryPlayer inv)
     {
-        super(inv);
-
+        super(new InvWrapper(inv), inv.mainInventory.length, inv.mainInventory.length + inv.armorInventory.length);
         inventoryPlayer = inv;
-        offset = inventoryPlayer.mainInventory.length;
-    }
-
-    @Override
-    public int getSlots()
-    {
-        return inventoryPlayer.armorInventory.length;
-    }
-
-    @Override
-    public ItemStack getStackInSlot(int slot)
-    {
-        return super.getStackInSlot(slot + offset);
     }
 
     @Override
@@ -44,20 +29,8 @@ public class PlayerArmorInvWrapper extends InvWrapper
         // check if it's valid for the armor slot
         if (slot < 4 && stack != null && stack.getItem().isValidArmor(stack, equ, inventoryPlayer.player))
         {
-            return super.insertItem(slot + offset, stack, simulate);
+            return super.insertItem(slot, stack, simulate);
         }
         return stack;
-    }
-
-    @Override
-    public void setStackInSlot(int slot, ItemStack stack)
-    {
-        super.setStackInSlot(slot + offset, stack);
-    }
-
-    @Override
-    public ItemStack extractItem(int slot, int amount, boolean simulate)
-    {
-        return super.extractItem(slot + offset, amount, simulate);
     }
 }

--- a/src/main/java/net/minecraftforge/items/wrapper/PlayerInvWrapper.java
+++ b/src/main/java/net/minecraftforge/items/wrapper/PlayerInvWrapper.java
@@ -6,6 +6,6 @@ public class PlayerInvWrapper extends CombinedInvWrapper
 {
     public PlayerInvWrapper(InventoryPlayer inv)
     {
-        super(new PlayerMainInvWrapper(inv), new PlayerArmorInvWrapper(inv));
+        super(new PlayerMainInvWrapper(inv), new PlayerArmorInvWrapper(inv), new PlayerOffhandInvWrapper(inv));
     }
 }

--- a/src/main/java/net/minecraftforge/items/wrapper/PlayerMainInvWrapper.java
+++ b/src/main/java/net/minecraftforge/items/wrapper/PlayerMainInvWrapper.java
@@ -8,54 +8,19 @@ import net.minecraft.item.ItemStack;
  * Exposes the player inventory WITHOUT the armor inventory as IItemHandler.
  * Also takes core of inserting/extracting having the same logic as picking up items.
  */
-public class PlayerMainInvWrapper extends InvWrapper
+public class PlayerMainInvWrapper extends RangedWrapper
 {
     public final InventoryPlayer inventoryPlayer;
 
     public PlayerMainInvWrapper(InventoryPlayer inv)
     {
-        super(inv);
-
+        super(new InvWrapper(inv), 0, inv.mainInventory.length);
         inventoryPlayer = inv;
-    }
-
-    @Override
-    public int getSlots()
-    {
-        return inventoryPlayer.mainInventory.length;
-    }
-
-    @Override
-    public void setStackInSlot(int slot, ItemStack stack)
-    {
-        // prevent setting of armor and offhand
-        if (slot > getSlots())
-        {
-            return;
-        }
-        super.setStackInSlot(slot, stack);
-    }
-
-    @Override
-    public ItemStack getStackInSlot(int slot)
-    {
-        // prevent getting of armor and offhand
-        if (slot > getSlots())
-        {
-            return null;
-        }
-        return super.getStackInSlot(slot);
     }
 
     @Override
     public ItemStack insertItem(int slot, ItemStack stack, boolean simulate)
     {
-        // prevent inserting into armor and offhand
-        if (slot > getSlots())
-        {
-            return stack;
-        }
-
         ItemStack rest = super.insertItem(slot, stack, simulate);
         if (rest == null || rest.stackSize != stack.stackSize)
         {
@@ -73,16 +38,5 @@ public class PlayerMainInvWrapper extends InvWrapper
             }
         }
         return rest;
-    }
-
-    @Override
-    public ItemStack extractItem(int slot, int amount, boolean simulate)
-    {
-        // prevent extraction from armor and offhand
-        if (slot > getSlots())
-        {
-            return null;
-        }
-        return super.extractItem(slot, amount, simulate);
     }
 }

--- a/src/main/java/net/minecraftforge/items/wrapper/PlayerMainInvWrapper.java
+++ b/src/main/java/net/minecraftforge/items/wrapper/PlayerMainInvWrapper.java
@@ -10,7 +10,6 @@ import net.minecraft.item.ItemStack;
  */
 public class PlayerMainInvWrapper extends InvWrapper
 {
-
     public final InventoryPlayer inventoryPlayer;
 
     public PlayerMainInvWrapper(InventoryPlayer inv)
@@ -29,7 +28,7 @@ public class PlayerMainInvWrapper extends InvWrapper
     @Override
     public void setStackInSlot(int slot, ItemStack stack)
     {
-        // prevent setting of armor inventory
+        // prevent setting of armor and offhand
         if (slot > getSlots())
         {
             return;
@@ -40,7 +39,7 @@ public class PlayerMainInvWrapper extends InvWrapper
     @Override
     public ItemStack getStackInSlot(int slot)
     {
-        // prevent getting of armor inventory
+        // prevent getting of armor and offhand
         if (slot > getSlots())
         {
             return null;
@@ -51,7 +50,7 @@ public class PlayerMainInvWrapper extends InvWrapper
     @Override
     public ItemStack insertItem(int slot, ItemStack stack, boolean simulate)
     {
-        // prevent inserting into armor inventory
+        // prevent inserting into armor and offhand
         if (slot > getSlots())
         {
             return stack;
@@ -79,7 +78,7 @@ public class PlayerMainInvWrapper extends InvWrapper
     @Override
     public ItemStack extractItem(int slot, int amount, boolean simulate)
     {
-        // prevent extraction from armor inventory
+        // prevent extraction from armor and offhand
         if (slot > getSlots())
         {
             return null;

--- a/src/main/java/net/minecraftforge/items/wrapper/PlayerOffhandInvWrapper.java
+++ b/src/main/java/net/minecraftforge/items/wrapper/PlayerOffhandInvWrapper.java
@@ -3,47 +3,11 @@ package net.minecraftforge.items.wrapper;
 import net.minecraft.entity.player.InventoryPlayer;
 import net.minecraft.item.ItemStack;
 
-public class PlayerOffhandInvWrapper extends InvWrapper
+public class PlayerOffhandInvWrapper extends RangedWrapper
 {
-    public final InventoryPlayer inventoryPlayer;
-    private final int offset;
-
     public PlayerOffhandInvWrapper(InventoryPlayer inv)
     {
-        super(inv);
-
-        inventoryPlayer = inv;
-        offset = inventoryPlayer.mainInventory.length + inventoryPlayer.armorInventory.length;
+        super(new InvWrapper(inv), inv.mainInventory.length + inv.armorInventory.length,
+                inv.mainInventory.length + inv.armorInventory.length + inv.offHandInventory.length);
     }
-
-    @Override
-    public int getSlots()
-    {
-        return inventoryPlayer.offHandInventory.length;
-    }
-
-    @Override
-    public ItemStack getStackInSlot(int slot)
-    {
-        return super.getStackInSlot(slot + offset);
-    }
-
-    @Override
-    public ItemStack insertItem(int slot, ItemStack stack, boolean simulate)
-    {
-        return super.insertItem(slot + offset, stack, simulate);
-    }
-
-    @Override
-    public void setStackInSlot(int slot, ItemStack stack)
-    {
-        super.setStackInSlot(slot + offset, stack);
-    }
-
-    @Override
-    public ItemStack extractItem(int slot, int amount, boolean simulate)
-    {
-        return super.extractItem(slot + offset, amount, simulate);
-    }
-
 }

--- a/src/main/java/net/minecraftforge/items/wrapper/PlayerOffhandInvWrapper.java
+++ b/src/main/java/net/minecraftforge/items/wrapper/PlayerOffhandInvWrapper.java
@@ -1,26 +1,25 @@
 package net.minecraftforge.items.wrapper;
 
 import net.minecraft.entity.player.InventoryPlayer;
-import net.minecraft.inventory.EntityEquipmentSlot;
 import net.minecraft.item.ItemStack;
 
-public class PlayerArmorInvWrapper extends InvWrapper
+public class PlayerOffhandInvWrapper extends InvWrapper
 {
     public final InventoryPlayer inventoryPlayer;
     private final int offset;
 
-    public PlayerArmorInvWrapper(InventoryPlayer inv)
+    public PlayerOffhandInvWrapper(InventoryPlayer inv)
     {
         super(inv);
 
         inventoryPlayer = inv;
-        offset = inventoryPlayer.mainInventory.length;
+        offset = inventoryPlayer.mainInventory.length + inventoryPlayer.armorInventory.length;
     }
 
     @Override
     public int getSlots()
     {
-        return inventoryPlayer.armorInventory.length;
+        return inventoryPlayer.offHandInventory.length;
     }
 
     @Override
@@ -32,21 +31,7 @@ public class PlayerArmorInvWrapper extends InvWrapper
     @Override
     public ItemStack insertItem(int slot, ItemStack stack, boolean simulate)
     {
-        EntityEquipmentSlot equ = null;
-        for (EntityEquipmentSlot s : EntityEquipmentSlot.values())
-        {
-            if (s.getSlotType() == EntityEquipmentSlot.Type.ARMOR && s.getIndex() == slot)
-            {
-                equ = s;
-                break;
-            }
-        }
-        // check if it's valid for the armor slot
-        if (slot < 4 && stack != null && stack.getItem().isValidArmor(stack, equ, inventoryPlayer.player))
-        {
-            return super.insertItem(slot + offset, stack, simulate);
-        }
-        return stack;
+        return super.insertItem(slot + offset, stack, simulate);
     }
 
     @Override
@@ -60,4 +45,5 @@ public class PlayerArmorInvWrapper extends InvWrapper
     {
         return super.extractItem(slot + offset, amount, simulate);
     }
+
 }

--- a/src/main/java/net/minecraftforge/items/wrapper/RangedWrapper.java
+++ b/src/main/java/net/minecraftforge/items/wrapper/RangedWrapper.java
@@ -1,0 +1,78 @@
+package net.minecraftforge.items.wrapper;
+
+import com.google.common.base.Preconditions;
+import net.minecraft.item.ItemStack;
+import net.minecraftforge.items.IItemHandlerModifiable;
+
+/**
+ * A wrapper that composes another IItemHandlerModifiable, exposing only a range of the composed slots.
+ * Shifting of slot indices is handled automatically for you.
+ */
+public class RangedWrapper implements IItemHandlerModifiable {
+
+    private final IItemHandlerModifiable compose;
+    private final int minSlot;
+    private final int maxSlot;
+
+    public RangedWrapper(IItemHandlerModifiable compose, int minSlot, int maxSlotExclusive)
+    {
+        Preconditions.checkArgument(maxSlotExclusive > minSlot, "Max slot must be greater than min slot");
+        this.compose = compose;
+        this.minSlot = minSlot;
+        this.maxSlot = maxSlotExclusive;
+    }
+
+    @Override
+    public int getSlots()
+    {
+        return maxSlot - minSlot;
+    }
+
+    @Override
+    public ItemStack getStackInSlot(int slot)
+    {
+        if (checkSlot(slot))
+        {
+            return compose.getStackInSlot(slot + minSlot);
+        }
+
+        return null;
+    }
+
+    @Override
+    public ItemStack insertItem(int slot, ItemStack stack, boolean simulate)
+    {
+        if (checkSlot(slot))
+        {
+            return compose.insertItem(slot + minSlot, stack, simulate);
+        }
+
+        return stack;
+    }
+
+    @Override
+    public ItemStack extractItem(int slot, int amount, boolean simulate)
+    {
+        if (checkSlot(slot))
+        {
+            return compose.extractItem(slot + minSlot, amount, simulate);
+        }
+
+        return null;
+    }
+
+    @Override
+    public void setStackInSlot(int slot, ItemStack stack)
+    {
+        if (checkSlot(slot))
+        {
+            compose.setStackInSlot(slot + minSlot, stack);
+        }
+    }
+
+    private boolean checkSlot(int localSlot)
+    {
+        return localSlot + minSlot < maxSlot;
+    }
+
+}


### PR DESCRIPTION
This is so that modders don't have to keep wrapping around vanilla entities again and again to access them from capability-oriented code. They can assume that these will always work.

* EntityLivingBase
    * Array for armor, array for both hands
    * Expose armor from horizontal faces, hands from vertical faces, joined from null face
* EntityHorse
    * IInventory AnimalChest
    * Expose wrapper AnimalChest from all faces and null face
* EntityPlayer
    * InventoryPlayer has array for armor, one-long array for offhand, array for main.
    * Expose main from vertical faces, offhand+armor from horizontal faces, joined from null face.