### PR TITLE
Actually fix dupe drop

### DIFF
--- a/src/main/java/net/minecraftforge/common/ForgeHooks.java
+++ b/src/main/java/net/minecraftforge/common/ForgeHooks.java
@@ -556,7 +556,7 @@ public class ForgeHooks
             return null;
         }
 
-        if (player.isServerWorld())
+        if (!player.worldObj.isRemote)
         {
             player.getEntityWorld().spawnEntityInWorld(event.entityItem);
         }


### PR DESCRIPTION
I have no clue on earth how this originally worked when I was testing the fix the first time. I must've changed it to isServerWorld after testing.

As it turns out, EntityPlayerSP actually overrides isServerWorld to return true instead of `!worldObj.isRemote`, essentially rendering the fix completely useless.

Went back to a `!worldObj.isRemote` check and actually tested it every which way after the change, tossing from survival, creative, Q, CtrlQ, out of inventory, Q in inventory, CtrlQ in inventory. It actually works now.
Side note: Q-ing out of the hot bar in creative mode doesn't drop, and I checked with vanilla 1.9 and it doesn't either.

Sorry about that, let this be an example of why we should test every little change no matter how trivial .-.