### PR TITLE
Fix Block.getPickBlock returning an ItemStack with a null Item

### DIFF
--- a/patches/minecraft/net/minecraft/block/Block.java.patch
+++ b/patches/minecraft/net/minecraft/block/Block.java.patch
@@ -188,15 +188,20 @@
      }
  
      protected ItemStack func_180643_i(IBlockState p_180643_1_)
-@@ -747,6 +767,7 @@
+@@ -747,9 +767,11 @@
          p_176216_2_.field_70181_x = 0.0D;
      }
  
 +    @Deprecated // Forge: Use more sensitive version below: getPickBlock
      public ItemStack func_185473_a(World p_185473_1_, BlockPos p_185473_2_, IBlockState p_185473_3_)
      {
-         return new ItemStack(Item.func_150898_a(this), 1, this.func_180651_a(p_185473_3_));
-@@ -844,6 +865,1168 @@
+-        return new ItemStack(Item.func_150898_a(this), 1, this.func_180651_a(p_185473_3_));
++        Item item = Item.func_150898_a(this);
++        return item == null ? null : new ItemStack(item, 1, this.func_180651_a(p_185473_3_));
+     }
+ 
+     @SideOnly(Side.CLIENT)
+@@ -844,6 +866,1168 @@
          return "Block{" + field_149771_c.func_177774_c(this) + "}";
      }
  


### PR DESCRIPTION
`Block.getPickBlock` calls this method by default (when nothing overrides it). Blocks without a corresponding Item will return an ItemStack with a null item here.

If `ForgeHooks.onPickBlock` gets an ItemStack with a null item, it warns about it. 
Returning null instead is easier for modders to handle (and is already handled as a normal case by `ForgeHooks.onPickBlock`).
Minecraft 1.7.10 and 1.8.9 both returned null from `getPickBlock` in this case.