### PR TITLE
New ClientChatEvent for handling chat messages before thay are sent to the server

### DIFF
--- a/patches/minecraft/net/minecraft/client/gui/GuiScreen.java.patch
+++ b/patches/minecraft/net/minecraft/client/gui/GuiScreen.java.patch
@@ -40,15 +40,16 @@
  
                  if (k1 == 0)
                  {
-@@ -436,6 +442,7 @@
+@@ -436,6 +442,8 @@
          {
              this.field_146297_k.field_71456_v.func_146158_b().func_146239_a(p_175281_1_);
          }
 +        if (net.minecraftforge.client.ClientCommandHandler.instance.func_71556_a(field_146297_k.field_71439_g, p_175281_1_) != 0) return;
++        if (net.minecraftforge.common.MinecraftForge.EVENT_BUS.post(new net.minecraftforge.event.entity.player.ClientChatEvent(field_146297_k.field_71439_g, p_175281_1_))) return;
  
          this.field_146297_k.field_71439_g.func_71165_d(p_175281_1_);
      }
-@@ -450,9 +457,15 @@
+@@ -450,9 +458,15 @@
  
                  if (guibutton.func_146116_c(this.field_146297_k, p_73864_1_, p_73864_2_))
                  {
@@ -64,7 +65,7 @@
                  }
              }
          }
-@@ -482,8 +495,12 @@
+@@ -482,8 +496,12 @@
          this.field_146289_q = p_146280_1_.field_71466_p;
          this.field_146294_l = p_146280_2_;
          this.field_146295_m = p_146280_3_;
@@ -77,7 +78,7 @@
      }
  
      public void func_183500_a(int p_183500_1_, int p_183500_2_)
-@@ -502,7 +519,9 @@
+@@ -502,7 +520,9 @@
          {
              while (Mouse.next())
              {
@@ -87,7 +88,7 @@
              }
          }
  
-@@ -510,7 +529,9 @@
+@@ -510,7 +530,9 @@
          {
              while (Keyboard.next())
              {
@@ -97,7 +98,7 @@
              }
          }
      }
-@@ -570,6 +591,7 @@
+@@ -570,6 +592,7 @@
      public void func_146276_q_()
      {
          this.func_146270_b(0);

--- a/src/main/java/net/minecraftforge/event/entity/player/ClientChatEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/player/ClientChatEvent.java
@@ -1,0 +1,33 @@
+package net.minecraftforge.event.entity.player;
+
+import net.minecraft.client.entity.EntityPlayerSP;
+import net.minecraftforge.event.entity.player.PlayerEvent;
+
+/**
+ * ClientChatEvent is fired when the user enters a massage in there chat box. <br>
+ * This is a good place to catch chat before it is sent to the server. <br>
+ * <br>
+ * If you are modifying the chat, simply cancel the event and use: <br>
+ * event.sender.sendChatMessage(message); <br>
+ * to send the modified message. <br>
+ * <br>
+ * note: if you want client side commands you should use ClientCommandHandler instead
+ */
+public class ClientChatEvent extends PlayerEvent
+{
+
+    public String message;
+    public EntityPlayerSP sender;
+
+    public ClientChatEvent(EntityPlayerSP player, String msg)
+    {
+        super(player);
+        sender = player;
+        message = msg;
+    }
+
+    public boolean isCancelable()
+    {
+        return true;
+    }
+}

--- a/src/test/java/net/minecraftforge/test/ClientChatTest.java
+++ b/src/test/java/net/minecraftforge/test/ClientChatTest.java
@@ -1,0 +1,37 @@
+package net.minecraftforge.test;
+
+import net.minecraftforge.common.MinecraftForge;
+import net.minecraftforge.event.entity.player.ClientChatEvent;
+import net.minecraftforge.fml.common.Mod;
+import net.minecraftforge.fml.common.Mod.EventHandler;
+import net.minecraftforge.fml.common.event.FMLInitializationEvent;
+import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
+
+/**
+ * This is a mod to test ClientChatEvent. <br>
+ * <br>
+ * It replaces words in chat with better ones ;) <br>
+ * "modloader" -> "Forge" <br>
+ * "lol" -> "laughs out loud!"
+ */
+@Mod(modid="clientChatEventTest", name="Client Chat Event Test", version="0.1")
+public class ClientChatTest
+{
+    @EventHandler
+    public void init(FMLInitializationEvent event)
+    {
+        MinecraftForge.EVENT_BUS.register(this);
+    }
+    
+    @SubscribeEvent
+    public void replaceChat(ClientChatEvent event){
+        String msg = event.message;
+        
+        msg = msg.replace("modloader", "Forge");
+        msg = msg.replace("lol", "laughs out loud!");
+        
+         // cancel the event so we don't send the old and the new massage
+        event.setCanceled(true);
+        event.sender.sendChatMessage(msg);
+    }
+}


### PR DESCRIPTION
This adds a new event (ClientChatEvent) that is fired when the user enters a chat message, but before it is sent to the server. This will allow mods to (for example) replace words in the users chat message on the client side, and other cool stuff.

A test mod is included at net.minecraftforge.test.ClientChatTest