### PR TITLE
New ClientChatEvent for handling chat messages before thay are sent to the server (Replaces #2636)

### DIFF
--- a/patches/minecraft/net/minecraft/client/gui/GuiScreen.java.patch
+++ b/patches/minecraft/net/minecraft/client/gui/GuiScreen.java.patch
@@ -40,15 +40,16 @@
  
                  if (k1 == 0)
                  {
-@@ -436,6 +442,7 @@
+@@ -436,6 +442,8 @@
          {
              this.field_146297_k.field_71456_v.func_146158_b().func_146239_a(p_175281_1_);
          }
 +        if (net.minecraftforge.client.ClientCommandHandler.instance.func_71556_a(field_146297_k.field_71439_g, p_175281_1_) != 0) return;
++        p_175281_1_ = net.minecraftforge.event.ForgeEventFactory.onClientChat(field_146297_k.field_71439_g, p_175281_1_); if (p_175281_1_ == null) return;
  
          this.field_146297_k.field_71439_g.func_71165_d(p_175281_1_);
      }
-@@ -450,9 +457,15 @@
+@@ -450,9 +458,15 @@
  
                  if (guibutton.func_146116_c(this.field_146297_k, p_73864_1_, p_73864_2_))
                  {
@@ -64,7 +65,7 @@
                  }
              }
          }
-@@ -482,8 +495,12 @@
+@@ -482,8 +496,12 @@
          this.field_146289_q = p_146280_1_.field_71466_p;
          this.field_146294_l = p_146280_2_;
          this.field_146295_m = p_146280_3_;
@@ -77,7 +78,7 @@
      }
  
      public void func_183500_a(int p_183500_1_, int p_183500_2_)
-@@ -502,7 +519,9 @@
+@@ -502,7 +520,9 @@
          {
              while (Mouse.next())
              {
@@ -87,7 +88,7 @@
              }
          }
  
-@@ -510,7 +529,9 @@
+@@ -510,7 +530,9 @@
          {
              while (Keyboard.next())
              {
@@ -97,7 +98,7 @@
              }
          }
      }
-@@ -570,6 +591,7 @@
+@@ -570,6 +592,7 @@
      public void func_146276_q_()
      {
          this.func_146270_b(0);

--- a/src/main/java/net/minecraftforge/client/event/ClientChatEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/ClientChatEvent.java
@@ -1,0 +1,48 @@
+package net.minecraftforge.client.event;
+
+import net.minecraft.client.entity.EntityPlayerSP;
+import net.minecraftforge.fml.common.eventhandler.Cancelable;
+import net.minecraftforge.fml.common.eventhandler.Event;
+
+/**
+ * ClientChatEvent is fired when the user enters a massage in their chat box. <br>
+ * This is a good place to catch chat before it is sent to the server. <br>
+ * <br>
+ * If you are modifying the chat, simply use setMessage(message) <br>
+ * <br>
+ * If you need to send more than one message you can use: <br>
+ * <code>getSender().sendChatMessage(message)</code> <br>
+ * to send extra message. (note: there is no risk of recursive events)<br>
+ * <br>
+ * To stop the message form being sent call <code>setMessage("" or null)</code> or <code>setCanceled(true)</code> <br>
+ * <br>
+ * note: if you want client side commands you should use ClientCommandHandler instead
+ */
+@Cancelable
+public class ClientChatEvent extends Event
+{
+
+    private String message;
+    private final EntityPlayerSP sender;
+
+    public ClientChatEvent(EntityPlayerSP player, String msg)
+    {
+        sender = player;
+        message = msg;
+    }
+
+    public String getMessage()
+    {
+        return message;
+    }
+
+    public void setMessage(String msg)
+    {
+        message = msg;
+    }
+
+    public EntityPlayerSP getSender()
+    {
+        return sender;
+    }
+}

--- a/src/main/java/net/minecraftforge/event/ForgeEventFactory.java
+++ b/src/main/java/net/minecraftforge/event/ForgeEventFactory.java
@@ -4,8 +4,11 @@ import java.io.File;
 import java.util.EnumSet;
 import java.util.List;
 
+import com.google.common.base.Strings;
+
 import net.minecraft.block.Block;
 import net.minecraft.block.state.IBlockState;
+import net.minecraft.client.entity.EntityPlayerSP;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.EntityLiving;
 import net.minecraft.entity.EntityLivingBase;
@@ -32,6 +35,7 @@ import net.minecraft.world.WorldSettings;
 import net.minecraft.world.biome.BiomeGenBase;
 import net.minecraft.world.storage.IPlayerFileData;
 import net.minecraft.world.storage.SaveHandler;
+import net.minecraftforge.client.event.ClientChatEvent;
 import net.minecraftforge.client.event.ClientChatReceivedEvent;
 import net.minecraftforge.client.event.RenderBlockOverlayEvent;
 import net.minecraftforge.client.event.RenderBlockOverlayEvent.OverlayType;
@@ -80,6 +84,16 @@ import net.minecraftforge.fml.common.eventhandler.Event.Result;
 
 public class ForgeEventFactory
 {
+
+    public static String onClientChat(EntityPlayerSP sender, String message){
+        ClientChatEvent event = new ClientChatEvent(sender, message);
+        MinecraftForge.EVENT_BUS.post(event);
+        String newmsg = event.getMessage();
+        if(event.isCanceled() || Strings.isNullOrEmpty(newmsg)){
+            newmsg = null;
+        }
+        return newmsg;
+    }
 
     public static MultiPlaceEvent onPlayerMultiBlockPlace(EntityPlayer player, List<BlockSnapshot> blockSnapshots, EnumFacing direction)
     {

--- a/src/test/java/net/minecraftforge/test/ClientChatTest.java
+++ b/src/test/java/net/minecraftforge/test/ClientChatTest.java
@@ -1,0 +1,49 @@
+package net.minecraftforge.test;
+
+import net.minecraft.util.ChatComponentText;
+import net.minecraftforge.client.event.ClientChatEvent;
+import net.minecraftforge.common.MinecraftForge;
+import net.minecraftforge.fml.common.Mod;
+import net.minecraftforge.fml.common.Mod.EventHandler;
+import net.minecraftforge.fml.common.event.FMLInitializationEvent;
+import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
+
+/**
+ * This is a mod to test ClientChatEvent. <br>
+ * <br>
+ * It replaces words in chat with better ones ;) <br>
+ * "modloader" -> "Forge" <br>
+ * "lol" -> "laughs out loud!"
+ * <br>
+ * And helps you keep track of how many words you have said <br>
+ */
+@Mod(modid = "clientChatEventTest", name = "Client Chat Event Test", version = "0.0.0")
+public class ClientChatTest
+{
+    @EventHandler
+    public void init(FMLInitializationEvent event)
+    {
+        MinecraftForge.EVENT_BUS.register(this);
+    }
+
+    private int totalWords = 0;
+
+    @SubscribeEvent
+    public void replaceChat(ClientChatEvent event)
+    {
+        /* example 1 - replacing words */
+
+        String msg = event.getMessage();
+
+        msg = msg.replace("modloader", "Forge");
+        msg = msg.replace("lol", "laughs out loud!");
+
+        event.setMessage(msg); // replace the message
+
+        /* example 2 - analyzing the users chat */
+
+        totalWords += msg.split(" ").length;
+        event.getSender().addChatMessage(new ChatComponentText(
+                "You have said " + totalWords + " word so far."));
+    }
+}


### PR DESCRIPTION
This adds a new event (ClientChatEvent) that is fired when the user enters a chat message, but before it is sent to the server. This will allow mods to (for example) replace words in the users chat message on the client side, counting/logging the user's chat messages, and other cool stuff.

A test mod is included at net.minecraftforge.test.ClientChatTest

Replaces PR #2636