### PR TITLE
Fix InvWrapper not making a copy in one case

### DIFF
--- a/src/main/java/net/minecraftforge/items/wrapper/InvWrapper.java
+++ b/src/main/java/net/minecraftforge/items/wrapper/InvWrapper.java
@@ -119,7 +119,8 @@ public class InvWrapper implements IItemHandlerModifiable
             {
                 if (!simulate)
                 {
-                    inv.setInventorySlotContents(slot, stack);
+                    // copy the stack to not preserve the reference from the original into the inventory
+                    inv.setInventorySlotContents(slot, stack.copy());
                     inv.markDirty();
                 }
                 return null;


### PR DESCRIPTION
The InvWrapper did not make a copy of the input ItemStack when the whole input stack fits into an empty slot. This means that the caller can accidentally still modify the inserted stack inside the inventory.