### PR TITLE
Fix BlockCrops.getDrops not respecting new age methods (for beetroots)

### DIFF
--- a/patches/minecraft/net/minecraft/block/BlockCrops.java.patch
+++ b/patches/minecraft/net/minecraft/block/BlockCrops.java.patch
@@ -32,16 +32,16 @@
 +    public java.util.List<ItemStack> getDrops(net.minecraft.world.IBlockAccess world, BlockPos pos, IBlockState state, int fortune)
 +    {
 +        java.util.List<ItemStack> ret = super.getDrops(world, pos, state, fortune);
-+        int age = ((Integer)state.func_177229_b(func_185524_e())).intValue();
++        int age = func_185527_x(state);
 +        Random rand = world instanceof World ? ((World)world).field_73012_v : new Random();
 +
-+        if (age >= 7)
++        if (age >= func_185526_g())
 +        {
 +            int k = 3 + fortune;
 +
 +            for (int i = 0; i < 3 + fortune; ++i)
 +            {
-+                if (rand.nextInt(15) <= age)
++                if (rand.nextInt(2 * func_185526_g()) <= age)
 +                {
 +                    ret.add(new ItemStack(this.func_149866_i(), 1, 0));
 +                }


### PR DESCRIPTION
1.9 added a `getMaxAge` (`func_185526_g`) method to BlockCrops which is used by beetroots. The getDrops patch did not respect those, causing beetroots to never drop anything.
Also use `getAge` (`func_185527_x`) method instead of directly accessing the block state value.