### PR TITLE
Update README.txt

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -10,7 +10,7 @@ Download the latest Forge source distribution from http://files.minecraftforge.n
 Open a command prompt, navigate to the directory where you unzipped the Forge sources, and run:
 If you have Gradle: gradle setupDevWorkspace
 If you DO NOT have Gradle installed:
-Windows: ./gradlew.bat setupDevWorkspace
+Windows: gradlew.bat setupDevWorkspace
 MacOS/Linux: ./gradlew setupDevWorkspace
 
 If you wish to use the Eclipse IDE, run gradle eclipse instead of gradle setupDevWorkspace, or install the Gradle plugin for Eclipse and import the Forge source folder as a Gradle project.

--- a/README.txt
+++ b/README.txt
@@ -18,7 +18,7 @@ If you wish to use the Eclipse IDE, run gradle eclipse instead of gradle setupDe
 To get the decompiled classes:
 If you have Gradle: gradle setupDecompWorkspace
 If you DO NOT have Gradle installed:
-Windows: ./gradlew.bat setupDecompWorkspace
+Windows: gradlew.bat setupDecompWorkspace
 MacOS/Linux: ./gradlew setupDecompWorkspace
 
 For Contributors: (Note: This assumes you have Gradle installed. If you don't, use ./gradlew(.bat) instead of gradle.


### PR DESCRIPTION
`./` cannot be used in windows:

```
C:\forge-mdk>./gradlew.bat

'.' is not recognized as an internal or external command,
operable program or batch file.
```