### PR TITLE
Make access to the Capability IStorage less annoying

### DIFF
--- a/src/main/java/net/minecraftforge/common/capabilities/Capability.java
+++ b/src/main/java/net/minecraftforge/common/capabilities/Capability.java
@@ -65,10 +65,29 @@ public class Capability<T>
      * the fully qualified class name for the target interface.
      */
     public String getName() { return name; }
+
     /**
      * @return An instance of the default storage handler. You can safely use this store your default implementation in NBT.
      */
     public IStorage<T> getStorage() { return storage; }
+    
+    /**
+     * Quick access to the IStorage's readNBT. 
+     * See {@link IStorage#readNBT(Capability, Object, EnumFacing, NBTBase)}  for documentation.
+     */
+    public void readNBT(T instance, EnumFacing side, NBTBase nbt)
+    {
+    	storage.readNBT(this, instance, side, nbt); 
+    }
+    
+    /**
+     * Quick access to the IStorage's writeNBT. 
+     * See {@link IStorage#writeNBT(Capability, Object, EnumFacing)} for documentation.
+     */
+    public NBTBase writeNBT(T instance, EnumFacing side)
+    {
+    	return storage.writeNBT(this, instance, side);
+    }
 
     /**
      * A NEW instance of the default implementation.


### PR DESCRIPTION
This PR adds a couple of methods that allow accessing the storage directly from the capability. This reduces the extremely reduncant calls such as:

```java
NBTBase tag = CapabilityItemHandler.ITEM_HANDLER_CAPABILITY.getStorage().writeNBT(CapabilityItemHandler.ITEM_HANDLER_CAPABILITY, inventory, side);
```

to a more manageable:

```java
NBTBase tag = CapabilityItemHandler.ITEM_HANDLER_CAPABILITY.writeNBT(inventory, side);
```

Which I believe turns capability storage from something no one would ever use into an useful storage solution, without changing any of the semantics of the IStorage itself.