### PR TITLE
Forward ItemBlock#addInformation to Block#addInformation

### DIFF
--- a/patches/minecraft/net/minecraft/block/Block.java.patch
+++ b/patches/minecraft/net/minecraft/block/Block.java.patch
@@ -201,7 +201,7 @@
      }
  
      @SideOnly(Side.CLIENT)
-@@ -844,6 +866,1168 @@
+@@ -844,6 +866,1179 @@
          return "Block{" + field_149771_c.func_177774_c(this) + "}";
      }
  
@@ -1364,6 +1364,17 @@
 +    {
 +        if (delegate.getResourceName() != null) return delegate.getResourceName().toString();
 +        return registryName != null ? registryName.toString() : null;
++    }
++
++    /**
++     * Add information to the blocks tooltip, called from the default implementation of {@link ItemBlock#addInformation(ItemStack, EntityPlayer, List, boolean)}
++     * @param stack The stack the tooltip is being retrieved for
++     * @param player The player retrieving the tooltip
++     * @param tooltip The lines to be displayed on the tooltip
++     * @param advanced If the client has advanced debug tooltips enabled
++     */
++    public void addInformation(ItemStack stack, EntityPlayer player, List<String> tooltip, boolean advanced)
++    {
 +    }
 +    /* ========================================= FORGE END ======================================*/
 +

--- a/patches/minecraft/net/minecraft/item/ItemBlock.java.patch
+++ b/patches/minecraft/net/minecraft/item/ItemBlock.java.patch
@@ -27,7 +27,7 @@
          {
              p_179222_3_ = EnumFacing.UP;
          }
-@@ -159,4 +151,26 @@
+@@ -159,4 +151,32 @@
      {
          return this.field_150939_a;
      }
@@ -52,5 +52,11 @@
 +        }
 +
 +        return true;
++    }
++
++    @SideOnly(Side.CLIENT)
++    public void func_77624_a(ItemStack stack, EntityPlayer playerIn, List<String> tooltip, boolean advanced)
++    {
++        field_150939_a.addInformation(stack, playerIn, tooltip, advanced);
 +    }
  }


### PR DESCRIPTION
Prevents needing a custom ItemBlock just to add a Block tooltip

1.9 version of #2660 