### PR TITLE
Add state param to Block.canRenderInLayer

### DIFF
--- a/patches/minecraft/net/minecraft/block/Block.java.patch
+++ b/patches/minecraft/net/minecraft/block/Block.java.patch
@@ -201,7 +201,7 @@
      }
  
      @SideOnly(Side.CLIENT)
-@@ -844,6 +866,1179 @@
+@@ -844,6 +866,1191 @@
          return "Block{" + field_149771_c.func_177774_c(this) + "}";
      }
  
@@ -1286,11 +1286,23 @@
 +
 +     /**
 +     * Queries if this block should render in a given layer.
-+     * ISmartBlockModel can use MinecraftForgeClient.getRenderLayer to alter their model based on layer
++     * ISmartBlockModel can use {@link MinecraftForgeClient#getRenderLayer()} to alter their model based on layer.
++     * 
++     * @deprecated New method with state sensitivity: {@link #canRenderInLayer(IBlockState, BlockRenderLayer)}
 +     */
++    @Deprecated
 +    public boolean canRenderInLayer(BlockRenderLayer layer)
 +    {
 +        return func_180664_k() == layer;
++    }
++    
++     /**
++     * Queries if this block should render in a given layer.
++     * ISmartBlockModel can use {@link MinecraftForgeClient#getRenderLayer()} to alter their model based on layer.
++     */
++    public boolean canRenderInLayer(IBlockState state, BlockRenderLayer layer)
++    {
++        return canRenderInLayer(layer);
 +    }
 +
 +    // For Internal use only to capture droped items inside getDrops

--- a/patches/minecraft/net/minecraft/client/renderer/chunk/RenderChunk.java.patch
+++ b/patches/minecraft/net/minecraft/client/renderer/chunk/RenderChunk.java.patch
@@ -26,7 +26,7 @@
  
 -                BlockRenderLayer blockrenderlayer1 = block.func_180664_k();
 +                for(BlockRenderLayer blockrenderlayer1 : BlockRenderLayer.values()) {
-+                     if(!block.canRenderInLayer(blockrenderlayer1)) continue;
++                     if(!block.canRenderInLayer(iblockstate, blockrenderlayer1)) continue;
 +                     net.minecraftforge.client.ForgeHooksClient.setRenderLayer(blockrenderlayer1);
                  int j = blockrenderlayer1.ordinal();
  


### PR DESCRIPTION
Also cleaned up the javadocs a tad.

This is useful for mods with varied block subtypes (i.e. chisel). The state was already a variable in the place where canRenderInLayer was called, so it was a trivial patch. I think the use case is obvious, but if you need an example, just say so.