### PR TITLE
Add getServer() methods to all of the other FMLServer* events.

### DIFF
--- a/patches/minecraft/net/minecraft/server/MinecraftServer.java.patch
+++ b/patches/minecraft/net/minecraft/server/MinecraftServer.java.patch
@@ -114,7 +114,7 @@
          {
              if (this.func_71197_b())
              {
-+                net.minecraftforge.fml.common.FMLCommonHandler.instance().handleServerStarted();
++                net.minecraftforge.fml.common.FMLCommonHandler.instance().handleServerStarted(this);
                  this.field_175591_ab = func_130071_aq();
                  long i = 0L;
                  this.field_147147_p.func_151315_a(new TextComponentString(this.field_71286_C));
@@ -122,7 +122,7 @@
                      Thread.sleep(Math.max(1L, 50L - i));
                      this.field_71296_Q = true;
                  }
-+                net.minecraftforge.fml.common.FMLCommonHandler.instance().handleServerStopping();
++                net.minecraftforge.fml.common.FMLCommonHandler.instance().handleServerStopping(this);
 +                net.minecraftforge.fml.common.FMLCommonHandler.instance().expectServerStopped(); // has to come before finalTick to avoid race conditions
              }
              else
@@ -160,7 +160,7 @@
              }
              finally
              {
-+                net.minecraftforge.fml.common.FMLCommonHandler.instance().handleServerStopped();
++                net.minecraftforge.fml.common.FMLCommonHandler.instance().handleServerStopped(this);
 +                this.field_71316_v = true;
                  this.func_71240_o();
              }

--- a/src/main/java/net/minecraftforge/fml/common/FMLCommonHandler.java
+++ b/src/main/java/net/minecraftforge/fml/common/FMLCommonHandler.java
@@ -284,15 +284,15 @@ public class FMLCommonHandler
         return Loader.instance().serverStarting(server);
     }
 
-    public void handleServerStarted()
+    public void handleServerStarted(MinecraftServer server)
     {
-        Loader.instance().serverStarted();
+        Loader.instance().serverStarted(server);
         sidedDelegate.allowLogins();
     }
 
-    public void handleServerStopping()
+    public void handleServerStopping(MinecraftServer server)
     {
-        Loader.instance().serverStopping();
+        Loader.instance().serverStopping(server);
     }
 
     public File getSavesDirectory() {
@@ -483,11 +483,10 @@ public class FMLCommonHandler
         System.exit(retVal);
     }
 
-    public void handleServerStopped()
+    public void handleServerStopped(MinecraftServer server)
     {
         sidedDelegate.serverStopped();
-        MinecraftServer server = getMinecraftServerInstance();
-        Loader.instance().serverStopped();
+        Loader.instance().serverStopped(server);
         // FORCE the internal server to stop: hello optifine workaround!
         if (server!=null) ObfuscationReflectionHelper.setPrivateValue(MinecraftServer.class, server, false, "field_71316"+"_v", "u", "serverStopped");
 

--- a/src/main/java/net/minecraftforge/fml/common/Loader.java
+++ b/src/main/java/net/minecraftforge/fml/common/Loader.java
@@ -26,6 +26,7 @@ import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
 
+import net.minecraft.server.MinecraftServer;
 import net.minecraft.util.ResourceLocation;
 import net.minecraftforge.common.capabilities.CapabilityManager;
 import net.minecraftforge.fml.common.LoaderState.ModState;
@@ -780,7 +781,7 @@ public class Loader
         return "Minecraft " + mccversion;
     }
 
-    public boolean serverStarting(Object server)
+    public boolean serverStarting(MinecraftServer server)
     {
         try
         {
@@ -795,15 +796,15 @@ public class Loader
         return true;
     }
 
-    public void serverStarted()
+    public void serverStarted(MinecraftServer server)
     {
-        modController.distributeStateMessage(LoaderState.SERVER_STARTED);
+        modController.distributeStateMessage(LoaderState.SERVER_STARTED, server);
         modController.transition(LoaderState.SERVER_STARTED, false);
     }
 
-    public void serverStopping()
+    public void serverStopping(MinecraftServer server)
     {
-        modController.distributeStateMessage(LoaderState.SERVER_STOPPING);
+        modController.distributeStateMessage(LoaderState.SERVER_STOPPING, server);
         modController.transition(LoaderState.SERVER_STOPPING, false);
     }
 
@@ -842,10 +843,10 @@ public class Loader
         return String.format("MCP %s", mcpversion);
     }
 
-    public void serverStopped()
+    public void serverStopped(MinecraftServer server)
     {
         PersistentRegistryManager.revertToFrozen();
-        modController.distributeStateMessage(LoaderState.SERVER_STOPPED);
+        modController.distributeStateMessage(LoaderState.SERVER_STOPPED, server);
         modController.transition(LoaderState.SERVER_STOPPED, true);
         modController.transition(LoaderState.AVAILABLE, true);
     }

--- a/src/main/java/net/minecraftforge/fml/common/event/FMLServerStartedEvent.java
+++ b/src/main/java/net/minecraftforge/fml/common/event/FMLServerStartedEvent.java
@@ -14,6 +14,8 @@ package net.minecraftforge.fml.common.event;
 
 import net.minecraftforge.fml.common.LoaderState.ModState;
 
+import net.minecraft.server.MinecraftServer;
+
 /**
  * Called after {@link FMLServerStartingEvent} when the server is available and ready to play.
  *
@@ -23,9 +25,12 @@ import net.minecraftforge.fml.common.LoaderState.ModState;
 public class FMLServerStartedEvent extends FMLStateEvent
 {
 
+    private final MinecraftServer server;
+
     public FMLServerStartedEvent(Object... data)
     {
         super(data);
+        this.server = (MinecraftServer) data[0];
     }
     
     @Override
@@ -34,4 +39,8 @@ public class FMLServerStartedEvent extends FMLStateEvent
         return ModState.AVAILABLE;
     }
 
+    public MinecraftServer getServer()
+    {
+        return server;
+    }
 }

--- a/src/main/java/net/minecraftforge/fml/common/event/FMLServerStoppedEvent.java
+++ b/src/main/java/net/minecraftforge/fml/common/event/FMLServerStoppedEvent.java
@@ -14,6 +14,8 @@ package net.minecraftforge.fml.common.event;
 
 import net.minecraftforge.fml.common.LoaderState.ModState;
 
+import net.minecraft.server.MinecraftServer;
+
 /**
  * Called after {@link FMLServerStoppingEvent} when the server has completely shut down.
  * Called immediately before shutting down, on the dedicated server, and before returning
@@ -24,9 +26,12 @@ import net.minecraftforge.fml.common.LoaderState.ModState;
  */
 public class FMLServerStoppedEvent extends FMLStateEvent {
 
+    private final MinecraftServer server;
+
     public FMLServerStoppedEvent(Object... data)
     {
         super(data);
+        this.server = (MinecraftServer) data[0];
     }
     @Override
     public ModState getModState()
@@ -34,4 +39,8 @@ public class FMLServerStoppedEvent extends FMLStateEvent {
         return ModState.AVAILABLE;
     }
 
+    public MinecraftServer getServer()
+    {
+        return server;
+    }
 }

--- a/src/main/java/net/minecraftforge/fml/common/event/FMLServerStoppingEvent.java
+++ b/src/main/java/net/minecraftforge/fml/common/event/FMLServerStoppingEvent.java
@@ -14,6 +14,8 @@ package net.minecraftforge.fml.common.event;
 
 import net.minecraftforge.fml.common.LoaderState.ModState;
 
+import net.minecraft.server.MinecraftServer;
+
 /**
  * Called when the server begins an orderly shutdown, before {@link FMLServerStoppedEvent}.
  *
@@ -23,9 +25,12 @@ import net.minecraftforge.fml.common.LoaderState.ModState;
 public class FMLServerStoppingEvent extends FMLStateEvent
 {
 
+    private final MinecraftServer server;
+
     public FMLServerStoppingEvent(Object... data)
     {
         super(data);
+        this.server = (MinecraftServer) data[0];
     }
     
     @Override
@@ -34,4 +39,8 @@ public class FMLServerStoppingEvent extends FMLStateEvent
         return ModState.AVAILABLE;
     }
 
+    public MinecraftServer getServer()
+    {
+        return server;
+    }
 }


### PR DESCRIPTION
Mojang removed the static `MinecraftServer.getServer()` member for 1.9, so this adds a simple way to get to the server instance on each FMLServer* event. `FMLServerStartingEvent` and `FMLServerAboutToStartEvent` already have this.