### PR TITLE
Fixed mismatched registry names and mod ids

### DIFF
--- a/src/main/java/net/minecraftforge/fml/common/registry/IForgeRegistryEntry.java
+++ b/src/main/java/net/minecraftforge/fml/common/registry/IForgeRegistryEntry.java
@@ -57,7 +57,7 @@ public interface IForgeRegistryEntry<V>
             String oldPrefix = index == -1 ? "" : name.substring(0, index);
             name = index == -1 ? name : name.substring(index + 1);
             ModContainer mc = Loader.instance().activeModContainer();
-            String prefix = mc == null || (mc instanceof InjectedModContainer && ((InjectedModContainer)mc).wrappedContainer instanceof FMLContainer) ? "minecraft" : mc.getModId();
+            String prefix = mc == null || (mc instanceof InjectedModContainer && ((InjectedModContainer)mc).wrappedContainer instanceof FMLContainer) ? "minecraft" : mc.getModId().toLowerCase();
             if (!oldPrefix.equals(prefix) && oldPrefix.length() > 0)
             {
                 FMLLog.bigWarning("Dangerous alternative prefix %s for name %s, invalid registry invocation/invalid name?", oldPrefix, name);


### PR DESCRIPTION
setRegistryName is called with a name argument which is derived from a ResourceLocation, which is case insensitive for domain names. As a result, mods with uppercase letters in their mod ids will always cause an error as a mismatch occurs between the lowercase registry name, and their uppercase mod id.