### PR TITLE
Boss bar render event

### DIFF
--- a/patches/minecraft/net/minecraft/client/gui/GuiBossOverlay.java.patch
+++ b/patches/minecraft/net/minecraft/client/gui/GuiBossOverlay.java.patch
@@ -1,0 +1,22 @@
+--- ../src-base/minecraft/net/minecraft/client/gui/GuiBossOverlay.java
++++ ../src-work/minecraft/net/minecraft/client/gui/GuiBossOverlay.java
+@@ -35,13 +35,18 @@
+             for (BossInfoLerping bossinfolerping : this.field_184060_g.values())
+             {
+                 int k = i / 2 - 91;
++                net.minecraftforge.client.event.RenderGameOverlayEvent.BossInfo event =
++                        net.minecraftforge.client.ForgeHooksClient.bossBarRenderPre(scaledresolution, bossinfolerping, k, j, 10 + this.field_184059_f.field_71466_p.field_78288_b);
++                if (!event.isCanceled()) {
+                 GlStateManager.func_179131_c(1.0F, 1.0F, 1.0F, 1.0F);
+                 this.field_184059_f.func_110434_K().func_110577_a(field_184058_a);
+                 this.func_184052_a(k, j, bossinfolerping);
+                 String s = bossinfolerping.func_186744_e().func_150254_d();
+                 this.field_184059_f.field_71466_p.func_175063_a(s, (float)(i / 2 - this.field_184059_f.field_71466_p.func_78256_a(s) / 2), (float)(j - 9), 16777215);
+-                j += 10 + this.field_184059_f.field_71466_p.field_78288_b;
++                }
++                j += event.getIncrement();
+ 
++                net.minecraftforge.client.ForgeHooksClient.bossBarRenderPost(scaledresolution);
+                 if (j >= scaledresolution.func_78328_b() / 3)
+                 {
+                     break;

--- a/src/main/java/net/minecraftforge/client/ForgeHooksClient.java
+++ b/src/main/java/net/minecraftforge/client/ForgeHooksClient.java
@@ -1,5 +1,6 @@
 package net.minecraftforge.client;
 
+import static net.minecraftforge.client.event.RenderGameOverlayEvent.ElementType.BOSSINFO;
 import static net.minecraftforge.common.ForgeVersion.Status.BETA;
 import static net.minecraftforge.common.ForgeVersion.Status.BETA_OUTDATED;
 import static org.lwjgl.opengl.GL11.*;
@@ -22,6 +23,7 @@ import net.minecraft.client.audio.SoundManager;
 import net.minecraft.client.gui.FontRenderer;
 import net.minecraft.client.gui.GuiMainMenu;
 import net.minecraft.client.gui.GuiScreen;
+import net.minecraft.client.gui.ScaledResolution;
 import net.minecraft.client.model.ModelBiped;
 import net.minecraft.client.renderer.EntityRenderer;
 import net.minecraft.client.renderer.GlStateManager;
@@ -61,6 +63,7 @@ import net.minecraft.util.math.MathHelper;
 import net.minecraft.util.math.RayTraceResult;
 import net.minecraft.util.registry.IRegistry;
 import net.minecraft.util.text.TextFormatting;
+import net.minecraft.world.BossInfoLerping;
 import net.minecraft.world.IBlockAccess;
 import net.minecraft.world.World;
 import net.minecraft.world.biome.BiomeGenBase;
@@ -70,12 +73,14 @@ import net.minecraftforge.client.event.FOVUpdateEvent;
 import net.minecraftforge.client.event.GuiScreenEvent;
 import net.minecraftforge.client.event.ModelBakeEvent;
 import net.minecraftforge.client.event.MouseEvent;
+import net.minecraftforge.client.event.RenderGameOverlayEvent;
 import net.minecraftforge.client.event.RenderHandEvent;
 import net.minecraftforge.client.event.RenderWorldLastEvent;
 import net.minecraftforge.client.event.TextureStitchEvent;
 import net.minecraftforge.client.event.sound.PlaySoundEvent;
 import net.minecraftforge.client.model.IPerspectiveAwareModel;
 import net.minecraftforge.client.model.ModelLoader;
+import net.minecraftforge.client.model.animation.Animation;
 import net.minecraftforge.common.ForgeModContainer;
 import net.minecraftforge.common.ForgeVersion;
 import net.minecraftforge.common.ForgeVersion.Status;
@@ -651,5 +656,18 @@ public class ForgeHooksClient
         rot.transform(rv);
         int angle = MathHelper.normalizeAngle(-(int)Math.round(Math.toDegrees(Math.atan2(rv.y, rv.x)) / 90) * 90, 360);
         return new BlockFaceUV(new float[]{ uMin, vMin, uMax, vMax }, angle);
+    }
+
+    public static RenderGameOverlayEvent.BossInfo bossBarRenderPre(ScaledResolution res, BossInfoLerping bossInfo, int x, int y, int increment)
+    {
+        RenderGameOverlayEvent.BossInfo evt = new RenderGameOverlayEvent.BossInfo(new RenderGameOverlayEvent(Animation.getPartialTickTime(), res),
+                BOSSINFO, bossInfo, x, y, increment);
+        MinecraftForge.EVENT_BUS.post(evt);
+        return evt;
+    }
+
+    public static void bossBarRenderPost(ScaledResolution res)
+    {
+        MinecraftForge.EVENT_BUS.post(new RenderGameOverlayEvent.Post(new RenderGameOverlayEvent(Animation.getPartialTickTime(), res), BOSSINFO));
     }
 }

--- a/src/main/java/net/minecraftforge/client/event/RenderGameOverlayEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/RenderGameOverlayEvent.java
@@ -2,6 +2,7 @@ package net.minecraftforge.client.event;
 
 import java.util.ArrayList;
 
+import net.minecraft.world.BossInfoLerping;
 import net.minecraftforge.fml.common.eventhandler.Cancelable;
 import net.minecraftforge.fml.common.eventhandler.Event;
 
@@ -31,7 +32,8 @@ public class RenderGameOverlayEvent extends Event
         HELMET,
         PORTAL,
         CROSSHAIRS,
-        BOSSHEALTH,
+        BOSSHEALTH, // All boss bars
+        BOSSINFO,    // Individual boss bar
         ARMOR,
         HEALTH,
         FOOD,
@@ -81,6 +83,63 @@ public class RenderGameOverlayEvent extends Event
             super(parent, type);
         }
         @Override public boolean isCancelable(){ return false; }
+    }
+
+    public static class BossInfo extends Pre
+    {
+        private final BossInfoLerping bossInfo;
+        private final int x;
+        private final int y;
+        private int increment;
+        public BossInfo(RenderGameOverlayEvent parent, ElementType type, BossInfoLerping bossInfo, int x, int y, int increment)
+        {
+            super(parent, type);
+            this.bossInfo = bossInfo;
+            this.x = x;
+            this.y = y;
+            this.increment = increment;
+        }
+
+        /**
+         * @return The {@link BossInfoLerping} currently being rendered
+         */
+        public BossInfoLerping getBossInfo()
+        {
+            return bossInfo;
+        }
+
+        /**
+         * @return The current x position we are rendering at
+         */
+        public int getX()
+        {
+            return x;
+        }
+
+        /**
+         * @return The current y position we are rendering at
+         */
+        public int getY()
+        {
+            return y;
+        }
+
+        /**
+         * @return How much to move down before rendering the next bar
+         */
+        public int getIncrement()
+        {
+            return increment;
+        }
+
+        /**
+         * Sets the amount to move down before rendering the next bar
+         * @param increment The increment to set
+         */
+        public void setIncrement(int increment)
+        {
+            this.increment = increment;
+        }
     }
 
     public static class Text extends Pre


### PR DESCRIPTION
New version of #2578 

1.9 changed how boss bars are rendered. This quick PR adds in a subcategory to RenderGameOverlayEvent that fires whenever a single boss bar is rendered. Canceling the event will cause that single bar to not render, allowing you to perform custom rendering logic in its stead.

Botania needs this because it does custom rendering for its own bosses (Replaces the bar entirely with its own + shader + extra rendering)

Unfortunately, BossInfoLerping gives you almost no info (you don't even know what entity you're rendering a bar for), but that's out of the scope of this PR. With this, I can have enough info to do what needs to be done.

Thanks!