### PR TITLE
Add string to default ore dictionary entries

### DIFF
--- a/src/main/java/net/minecraftforge/oredict/OreDictionary.java
+++ b/src/main/java/net/minecraftforge/oredict/OreDictionary.java
@@ -132,6 +132,7 @@ public class OreDictionary
             registerOre("chestWood",   Blocks.chest);
             registerOre("chestEnder",  Blocks.ender_chest);
             registerOre("chestTrapped", Blocks.trapped_chest);
+            registerOre("string", Items.string);
         }
 
         // Build our list of items to replace with ore tags
@@ -156,6 +157,7 @@ public class OreDictionary
         replacements.put(new ItemStack(Blocks.chest), "chestWood");
         replacements.put(new ItemStack(Blocks.ender_chest), "chestEnder");
         replacements.put(new ItemStack(Blocks.trapped_chest), "chestTrapped");
+        replacements.put(new ItemStack(Items.string), "string");
 
         // Register dyes
         String[] dyes =


### PR DESCRIPTION
I noticed that string didn't have an ore dictionary entry, so I added one.