### PR TITLE
Fix PlaySoundEvent replacing a sound with PositionedSound causing an NPE.

### DIFF
--- a/patches/minecraft/net/minecraft/client/audio/SoundManager.java.patch
+++ b/patches/minecraft/net/minecraft/client/audio/SoundManager.java.patch
@@ -16,16 +16,16 @@
      }
  
      private synchronized void func_148608_i()
-@@ -350,6 +352,9 @@
-             }
-             else
-             {
-+                p_148611_1_ = net.minecraftforge.client.ForgeHooksClient.playSound(this, p_148611_1_);
-+                if (p_148611_1_ == null) return;
+@@ -338,6 +340,9 @@
+     {
+         if (this.field_148617_f)
+         {
++            p_148611_1_ = net.minecraftforge.client.ForgeHooksClient.playSound(this, p_148611_1_);
++            if (p_148611_1_ == null) return;
 +
-                 if (!this.field_188777_o.isEmpty())
-                 {
-                     for (ISoundEventListener isoundeventlistener : this.field_188777_o)
+             SoundEventAccessor soundeventaccessor = p_148611_1_.func_184366_a(this.field_148622_c);
+             ResourceLocation resourcelocation = p_148611_1_.func_147650_b();
+ 
 @@ -400,10 +405,12 @@
                              if (sound.func_188723_h())
                              {


### PR DESCRIPTION
This PR moves the call to PlaySoundEvent to before ISound.createAccessor is called on the played sound, so that PositionedSound (and any other ISound that chooses to implement createAccessor) gets a chance to resolve the sound. Without this change, PositionedSound will NPE when trying to play the sound because the Sound field has not been set.