### PR TITLE
Fix rightclickempty being fired from too broad scope

### DIFF
--- a/patches/minecraft/net/minecraft/client/Minecraft.java.patch
+++ b/patches/minecraft/net/minecraft/client/Minecraft.java.patch
@@ -198,7 +198,7 @@
  
                      ItemStack itemstack1 = this.field_71439_g.func_184586_b(enumhand);
 -
-+                    if (itemstack1 == null) net.minecraftforge.common.ForgeHooks.onEmptyClick(this.field_71439_g, enumhand);
++                    if (itemstack1 == null && (this.field_71476_x == null || this.field_71476_x.field_72313_a == RayTraceResult.Type.MISS)) net.minecraftforge.common.ForgeHooks.onEmptyClick(this.field_71439_g, enumhand);
                      if (itemstack1 != null && this.field_71442_b.func_187101_a(this.field_71439_g, this.field_71441_e, itemstack1, enumhand) == EnumActionResult.SUCCESS)
                      {
                          this.field_71460_t.field_78516_c.func_187460_a(enumhand);


### PR DESCRIPTION
It closed my other one for force pushing .-.
Fixes RightClickEmpty being fired any time the hand is empty instead of when the player is only targeting nothing