### PR TITLE
Corrected CapabilityItemHandler.readNBT ignoring anything in slot 0 in 1.9

### DIFF
--- a/src/main/java/net/minecraftforge/items/CapabilityItemHandler.java
+++ b/src/main/java/net/minecraftforge/items/CapabilityItemHandler.java
@@ -51,7 +51,7 @@ public class CapabilityItemHandler
                     NBTTagCompound itemTags = tagList.getCompoundTagAt(i);
                     int j = itemTags.getInteger("Slot");
 
-                    if (j > 0 && j < instance.getSlots())
+                    if (j >= 0 && j < instance.getSlots())
                     {
                         itemHandlerModifiable.setStackInSlot(j, ItemStack.loadItemStackFromNBT(itemTags));
                     }


### PR DESCRIPTION
CapabilityItemHandler's readNBT would only read above Slot 1 and above, skipping the first slot, 0, all together