### PR TITLE
Fix some plain keybinds not working when a modifier is active

### DIFF
--- a/src/main/java/net/minecraftforge/client/settings/KeyBindingMap.java
+++ b/src/main/java/net/minecraftforge/client/settings/KeyBindingMap.java
@@ -22,11 +22,15 @@ public class KeyBindingMap
     public KeyBinding lookupActive(int keyCode)
     {
         KeyModifier activeModifier = KeyModifier.getActiveModifier();
-        if (activeModifier.matches(keyCode))
+        if (!activeModifier.matches(keyCode))
         {
-            activeModifier = KeyModifier.NONE;
+            KeyBinding binding = getBinding(keyCode, activeModifier);
+            if (binding != null)
+            {
+                return binding;
+            }
         }
-        return getBinding(keyCode, activeModifier);
+        return getBinding(keyCode, KeyModifier.NONE);
     }
 
     private KeyBinding getBinding(int keyCode, KeyModifier keyModifier)


### PR DESCRIPTION
For instance, the hotkey for opening the inventory (e) wouldn't work while holding shift to sneak.
This also caused some weirdness with holding shift and mining, the block's mining animation wouldn't reset when you stop mining.