### PR TITLE
Remove @SideOnly(Side.CLIENT) from BossInfo/BossInfoServer methods

### DIFF
--- a/patches/minecraft/net/minecraft/world/BossInfo.java.patch
+++ b/patches/minecraft/net/minecraft/world/BossInfo.java.patch
@@ -1,0 +1,35 @@
+--- ../src-base/minecraft/net/minecraft/world/BossInfo.java
++++ ../src-work/minecraft/net/minecraft/world/BossInfo.java
+@@ -2,8 +2,6 @@
+ 
+ import java.util.UUID;
+ import net.minecraft.util.text.ITextComponent;
+-import net.minecraftforge.fml.relauncher.Side;
+-import net.minecraftforge.fml.relauncher.SideOnly;
+ 
+ public abstract class BossInfo
+ {
+@@ -35,7 +33,6 @@
+         return this.field_186749_a;
+     }
+ 
+-    @SideOnly(Side.CLIENT)
+     public void func_186739_a(ITextComponent p_186739_1_)
+     {
+         this.field_186749_a = p_186739_1_;
+@@ -56,7 +53,6 @@
+         return this.field_186751_c;
+     }
+ 
+-    @SideOnly(Side.CLIENT)
+     public void func_186745_a(BossInfo.Color p_186745_1_)
+     {
+         this.field_186751_c = p_186745_1_;
+@@ -67,7 +63,6 @@
+         return this.field_186752_d;
+     }
+ 
+-    @SideOnly(Side.CLIENT)
+     public void func_186746_a(BossInfo.Overlay p_186746_1_)
+     {
+         this.field_186752_d = p_186746_1_;

--- a/patches/minecraft/net/minecraft/world/BossInfoServer.java.patch
+++ b/patches/minecraft/net/minecraft/world/BossInfoServer.java.patch
@@ -1,0 +1,35 @@
+--- ../src-base/minecraft/net/minecraft/world/BossInfoServer.java
++++ ../src-work/minecraft/net/minecraft/world/BossInfoServer.java
+@@ -9,8 +9,6 @@
+ import net.minecraft.network.play.server.SPacketUpdateEntityNBT;
+ import net.minecraft.util.math.MathHelper;
+ import net.minecraft.util.text.ITextComponent;
+-import net.minecraftforge.fml.relauncher.Side;
+-import net.minecraftforge.fml.relauncher.SideOnly;
+ 
+ public class BossInfoServer extends BossInfo
+ {
+@@ -34,7 +32,6 @@
+         }
+     }
+ 
+-    @SideOnly(Side.CLIENT)
+     public void func_186745_a(BossInfo.Color p_186745_1_)
+     {
+         if (p_186745_1_ != this.field_186751_c)
+@@ -44,7 +41,6 @@
+         }
+     }
+ 
+-    @SideOnly(Side.CLIENT)
+     public void func_186746_a(BossInfo.Overlay p_186746_1_)
+     {
+         if (p_186746_1_ != this.field_186752_d)
+@@ -87,7 +83,6 @@
+         return this;
+     }
+ 
+-    @SideOnly(Side.CLIENT)
+     public void func_186739_a(ITextComponent p_186739_1_)
+     {
+         if (!Objects.equal(p_186739_1_, this.field_186749_a))


### PR DESCRIPTION
These methods can also be used by the server (see `BossInfoServer`, it sends packets to the client but the methods are annotated with `@SideOnly(Side.CLIENT)`).