### PR TITLE
Add method to check if an Entity can trample a Block

### DIFF
--- a/patches/minecraft/net/minecraft/block/BlockFarmland.java.patch
+++ b/patches/minecraft/net/minecraft/block/BlockFarmland.java.patch
@@ -1,5 +1,14 @@
 --- ../src-base/minecraft/net/minecraft/block/BlockFarmland.java
 +++ ../src-work/minecraft/net/minecraft/block/BlockFarmland.java
+@@ -70,7 +70,7 @@
+ 
+     public void func_180658_a(World p_180658_1_, BlockPos p_180658_2_, Entity p_180658_3_, float p_180658_4_)
+     {
+-        if (!p_180658_1_.field_72995_K && p_180658_1_.field_73012_v.nextFloat() < p_180658_4_ - 0.5F && p_180658_3_ instanceof EntityLivingBase && (p_180658_3_ instanceof EntityPlayer || p_180658_1_.func_82736_K().func_82766_b("mobGriefing")) && p_180658_3_.field_70130_N * p_180658_3_.field_70130_N * p_180658_3_.field_70131_O > 0.512F)
++        if (!p_180658_1_.field_72995_K && p_180658_3_.canTrample(p_180658_1_, this, p_180658_2_, p_180658_4_)) // Forge: Move logic to Entity#canTrample
+         {
+             this.func_190970_b(p_180658_1_, p_180658_2_);
+         }
 @@ -93,7 +93,7 @@
      private boolean func_176529_d(World p_176529_1_, BlockPos p_176529_2_)
      {

--- a/patches/minecraft/net/minecraft/entity/Entity.java.patch
+++ b/patches/minecraft/net/minecraft/entity/Entity.java.patch
@@ -126,7 +126,7 @@
      }
  
      public boolean func_174816_a(Explosion p_174816_1_, World p_174816_2_, BlockPos p_174816_3_, IBlockState p_174816_4_, float p_174816_5_)
-@@ -2802,6 +2822,167 @@
+@@ -2802,6 +2822,184 @@
          EnchantmentHelper.func_151385_b(p_174815_1_, p_174815_2_);
      }
  
@@ -288,6 +288,23 @@
 +        NBTTagCompound ret = new NBTTagCompound();
 +        ret.func_74778_a("id", this.func_70022_Q());
 +        return this.func_189511_e(ret);
++    }
++
++    /**
++     * Checks if this {@link Entity} can trample a {@link Block}.
++     *
++     * @param world The world in which the block will be trampled
++     * @param block The block being tested
++     * @param pos The block pos
++     * @param fallDistance The fall distance
++     * @return {@code true} if this entity can trample, {@code false} otherwise
++     */
++    public boolean canTrample(World world, Block block, BlockPos pos, float fallDistance)
++    {
++        return world.field_73012_v.nextFloat() < fallDistance - 0.5F
++            && this instanceof EntityLivingBase
++            && (this instanceof EntityPlayer || world.func_82736_K().func_82766_b("mobGriefing"))
++            && this.field_70130_N * this.field_70130_N * this.field_70131_O > 0.512F;
 +    }
 +    /* ================================== Forge End =====================================*/
 +


### PR DESCRIPTION
This allows entities to override the new `canTrample` method to allow/disallow trampling of blocks.

Fixes #2510
