### PR TITLE
Fix ForgeChunkManager world unloading check

### DIFF
--- a/src/main/java/net/minecraftforge/common/ForgeChunkManager.java
+++ b/src/main/java/net/minecraftforge/common/ForgeChunkManager.java
@@ -598,7 +598,7 @@ public class ForgeChunkManager
         forcedChunks.remove(world);
         dormantChunkCache.remove(world);
         // integrated server is shutting down
-        if (FMLCommonHandler.instance().getMinecraftServerInstance().isServerRunning())
+        if (!FMLCommonHandler.instance().getMinecraftServerInstance().isServerRunning())
         {
             playerTickets.clear();
             tickets.clear();


### PR DESCRIPTION
Someone missed the ! from the check, so atm as soon as any world unloads, chunk loading for other worlds starts to crash.