### PR TITLE
Fix import static use with net.minecraft classes

### DIFF
--- a/src/main/java/net/minecraftforge/common/BiomeDictionary.java
+++ b/src/main/java/net/minecraftforge/common/BiomeDictionary.java
@@ -3,12 +3,13 @@ package net.minecraftforge.common;
 import java.util.*;
 
 import net.minecraftforge.fml.common.FMLLog;
+
+import net.minecraft.init.Biomes;
 import net.minecraft.init.Blocks;
 import net.minecraft.util.ResourceLocation;
 import net.minecraft.world.biome.*;
 import net.minecraftforge.common.util.EnumHelper;
 import net.minecraftforge.event.terraingen.DeferredBiomeDecorator;
-import static net.minecraft.init.Biomes.*;
 import static net.minecraftforge.common.BiomeDictionary.Type.*;
 
 public class BiomeDictionary
@@ -435,45 +436,45 @@ public class BiomeDictionary
 
     private static void registerVanillaBiomes()
     {
-        registerBiomeType(ocean,               OCEAN                                        );
-        registerBiomeType(plains,              PLAINS                                       );
-        registerBiomeType(desert,              HOT,      DRY,        SANDY                  );
-        registerBiomeType(extremeHills,        MOUNTAIN, HILLS                              );
-        registerBiomeType(forest,              FOREST                                       );
-        registerBiomeType(taiga,               COLD,     CONIFEROUS, FOREST                 );
-        registerBiomeType(taigaHills,          COLD,     CONIFEROUS, FOREST,   HILLS        );
-        registerBiomeType(swampland,           WET,      SWAMP                              );
-        registerBiomeType(river,               RIVER                                        );
-        registerBiomeType(frozenOcean,         COLD,     OCEAN,      SNOWY                  );
-        registerBiomeType(frozenRiver,         COLD,     RIVER,      SNOWY                  );
-        registerBiomeType(icePlains,           COLD,     SNOWY,      WASTELAND              );
-        registerBiomeType(iceMountains,        COLD,     SNOWY,      MOUNTAIN               );
-        registerBiomeType(beach,               BEACH                                        );
-        registerBiomeType(desertHills,         HOT,      DRY,        SANDY,    HILLS        );
-        registerBiomeType(jungle,              HOT,      WET,        DENSE,    JUNGLE       );
-        registerBiomeType(jungleHills,         HOT,      WET,        DENSE,    JUNGLE, HILLS);
-        registerBiomeType(forestHills,         FOREST,   HILLS                              );
-        registerBiomeType(sky,                 COLD,     DRY,        END                    );
-        registerBiomeType(hell,                HOT,      DRY,        NETHER                 );
-        registerBiomeType(mushroomIsland,      MUSHROOM                                     );
-        registerBiomeType(extremeHillsEdge,    MOUNTAIN                                     );
-        registerBiomeType(mushroomIslandShore, MUSHROOM, BEACH                              );
-        registerBiomeType(jungleEdge,          HOT,      WET,        JUNGLE,   FOREST       );
-        registerBiomeType(deepOcean,           OCEAN                                        );
-        registerBiomeType(stoneBeach,          BEACH                                        );
-        registerBiomeType(coldBeach,           COLD,     BEACH,      SNOWY                  );
-        registerBiomeType(birchForest,         FOREST                                       );
-        registerBiomeType(birchForestHills,    FOREST,   HILLS                              );
-        registerBiomeType(roofedForest,        SPOOKY,   DENSE,      FOREST                 );
-        registerBiomeType(coldTaiga,           COLD,     CONIFEROUS, FOREST,   SNOWY        );
-        registerBiomeType(coldTaigaHills,      COLD,     CONIFEROUS, FOREST,   SNOWY,  HILLS);
-        registerBiomeType(megaTaiga,           COLD,     CONIFEROUS, FOREST                 );
-        registerBiomeType(megaTaigaHills,      COLD,     CONIFEROUS, FOREST,   HILLS        );
-        registerBiomeType(extremeHillsPlus,    MOUNTAIN, FOREST,     SPARSE                 );
-        registerBiomeType(savanna,             HOT,      SAVANNA,    PLAINS,   SPARSE       );
-        registerBiomeType(savannaPlateau,      HOT,      SAVANNA,    PLAINS,   SPARSE       );
-        registerBiomeType(mesa,                MESA,     SANDY                              );
-        registerBiomeType(mesaPlateau_F,       MESA,     SPARSE,     SANDY                  );
-        registerBiomeType(mesaPlateau,         MESA,     SANDY                              );
+        registerBiomeType(Biomes.ocean,               OCEAN                                        );
+        registerBiomeType(Biomes.plains,              PLAINS                                       );
+        registerBiomeType(Biomes.desert,              HOT,      DRY,        SANDY                  );
+        registerBiomeType(Biomes.extremeHills,        MOUNTAIN, HILLS                              );
+        registerBiomeType(Biomes.forest,              FOREST                                       );
+        registerBiomeType(Biomes.taiga,               COLD,     CONIFEROUS, FOREST                 );
+        registerBiomeType(Biomes.taigaHills,          COLD,     CONIFEROUS, FOREST,   HILLS        );
+        registerBiomeType(Biomes.swampland,           WET,      SWAMP                              );
+        registerBiomeType(Biomes.river,               RIVER                                        );
+        registerBiomeType(Biomes.frozenOcean,         COLD,     OCEAN,      SNOWY                  );
+        registerBiomeType(Biomes.frozenRiver,         COLD,     RIVER,      SNOWY                  );
+        registerBiomeType(Biomes.icePlains,           COLD,     SNOWY,      WASTELAND              );
+        registerBiomeType(Biomes.iceMountains,        COLD,     SNOWY,      MOUNTAIN               );
+        registerBiomeType(Biomes.beach,               BEACH                                        );
+        registerBiomeType(Biomes.desertHills,         HOT,      DRY,        SANDY,    HILLS        );
+        registerBiomeType(Biomes.jungle,              HOT,      WET,        DENSE,    JUNGLE       );
+        registerBiomeType(Biomes.jungleHills,         HOT,      WET,        DENSE,    JUNGLE, HILLS);
+        registerBiomeType(Biomes.forestHills,         FOREST,   HILLS                              );
+        registerBiomeType(Biomes.sky,                 COLD,     DRY,        END                    );
+        registerBiomeType(Biomes.hell,                HOT,      DRY,        NETHER                 );
+        registerBiomeType(Biomes.mushroomIsland,      MUSHROOM                                     );
+        registerBiomeType(Biomes.extremeHillsEdge,    MOUNTAIN                                     );
+        registerBiomeType(Biomes.mushroomIslandShore, MUSHROOM, BEACH                              );
+        registerBiomeType(Biomes.jungleEdge,          HOT,      WET,        JUNGLE,   FOREST       );
+        registerBiomeType(Biomes.deepOcean,           OCEAN                                        );
+        registerBiomeType(Biomes.stoneBeach,          BEACH                                        );
+        registerBiomeType(Biomes.coldBeach,           COLD,     BEACH,      SNOWY                  );
+        registerBiomeType(Biomes.birchForest,         FOREST                                       );
+        registerBiomeType(Biomes.birchForestHills,    FOREST,   HILLS                              );
+        registerBiomeType(Biomes.roofedForest,        SPOOKY,   DENSE,      FOREST                 );
+        registerBiomeType(Biomes.coldTaiga,           COLD,     CONIFEROUS, FOREST,   SNOWY        );
+        registerBiomeType(Biomes.coldTaigaHills,      COLD,     CONIFEROUS, FOREST,   SNOWY,  HILLS);
+        registerBiomeType(Biomes.megaTaiga,           COLD,     CONIFEROUS, FOREST                 );
+        registerBiomeType(Biomes.megaTaigaHills,      COLD,     CONIFEROUS, FOREST,   HILLS        );
+        registerBiomeType(Biomes.extremeHillsPlus,    MOUNTAIN, FOREST,     SPARSE                 );
+        registerBiomeType(Biomes.savanna,             HOT,      SAVANNA,    PLAINS,   SPARSE       );
+        registerBiomeType(Biomes.savannaPlateau,      HOT,      SAVANNA,    PLAINS,   SPARSE       );
+        registerBiomeType(Biomes.mesa,                MESA,     SANDY                              );
+        registerBiomeType(Biomes.mesaPlateau_F,       MESA,     SPARSE,     SANDY                  );
+        registerBiomeType(Biomes.mesaPlateau,         MESA,     SANDY                              );
     }
 }

--- a/src/main/java/net/minecraftforge/common/ForgeHooks.java
+++ b/src/main/java/net/minecraftforge/common/ForgeHooks.java
@@ -1,14 +1,5 @@
 package net.minecraftforge.common;
 
-import static net.minecraft.init.Blocks.diamond_block;
-import static net.minecraft.init.Blocks.diamond_ore;
-import static net.minecraft.init.Blocks.emerald_block;
-import static net.minecraft.init.Blocks.emerald_ore;
-import static net.minecraft.init.Blocks.gold_block;
-import static net.minecraft.init.Blocks.gold_ore;
-import static net.minecraft.init.Blocks.lit_redstone_ore;
-import static net.minecraft.init.Blocks.redstone_ore;
-
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.ArrayList;
@@ -217,7 +208,11 @@ public class ForgeHooks
         }
 
         Blocks.obsidian.setHarvestLevel("pickaxe", 3);
-        for (Block block : new Block[]{emerald_ore, emerald_block, diamond_ore, diamond_block, gold_ore, gold_block, redstone_ore, lit_redstone_ore})
+        Block[] oreBlocks = new Block[] {
+                Blocks.emerald_ore, Blocks.emerald_block, Blocks.diamond_ore, Blocks.diamond_block,
+                Blocks.gold_ore, Blocks.gold_block, Blocks.redstone_ore, Blocks.lit_redstone_ore
+        };
+        for (Block block : oreBlocks)
         {
             block.setHarvestLevel("pickaxe", 2);
         }


### PR DESCRIPTION
Using the latest MCP snapshots causes a wildcard import conflict in Forge because all static final names have been renamed to UPPER_CASE. It also seems that static imports aren't getting remapped properly.

This PR fixes the problem. Alternatively I did this and also updated the Forge mappings in https://github.com/matthewprenger/MinecraftForge/commit/6a290f908ca6f4d1147b3bb1446bdb3439bb4771. Let me know if you want that PR'ed instead.