### PR TITLE
[1.9]Random block tick event

### DIFF
--- a/patches/minecraft/net/minecraft/world/WorldServer.java.patch
+++ b/patches/minecraft/net/minecraft/world/WorldServer.java.patch
@@ -108,6 +108,15 @@
                  {
                      this.field_73005_l = this.field_73005_l * 3 + 1013904223;
                      int j2 = this.field_73005_l >> 2;
+@@ -453,7 +465,7 @@
+ 
+                                 if (block.func_149653_t())
+                                 {
+-                                    block.func_180645_a(this, new BlockPos(k1 + j, i2 + extendedblockstorage.func_76662_d(), l1 + k), iblockstate, this.field_73012_v);
++                                    net.minecraftforge.common.ForgeHooks.onBlockRandomTick(this, new BlockPos(k1 + j, i2 + extendedblockstorage.func_76662_d(), l1 + k), iblockstate, this.field_73012_v);
+                                 }
+ 
+                                 this.field_72984_F.func_76319_b();
 @@ -527,6 +539,9 @@
              if (p_175654_2_.func_149698_L())
              {

--- a/src/main/java/net/minecraftforge/common/ForgeHooks.java
+++ b/src/main/java/net/minecraftforge/common/ForgeHooks.java
@@ -986,7 +986,7 @@ public class ForgeHooks
     		{
     			state.getBlock().randomTick(worldIn, pos, state, random);
     			BlockEvent.RandomTickEvent.Post post = new BlockEvent.RandomTickEvent.Post(worldIn, pos, state);
-        		MinecraftForge.EVENT_BUS.post(post);
+    			MinecraftForge.EVENT_BUS.post(post);
     		}
     		else
     		{

--- a/src/main/java/net/minecraftforge/common/ForgeHooks.java
+++ b/src/main/java/net/minecraftforge/common/ForgeHooks.java
@@ -985,6 +985,8 @@ public class ForgeHooks
     		if(!rte.isCanceled())
     		{
     			state.getBlock().randomTick(worldIn, pos, state, random);
+    			BlockEvent.RandomTickEvent.Post post = new BlockEvent.RandomTickEvent.Post(worldIn, pos, state);
+        		MinecraftForge.EVENT_BUS.post(post);
     		}
     		else
     		{

--- a/src/main/java/net/minecraftforge/common/ForgeHooks.java
+++ b/src/main/java/net/minecraftforge/common/ForgeHooks.java
@@ -980,7 +980,7 @@ public class ForgeHooks
     {
     	if(BlockEvent.RandomTickEvent.RandomBlockTickEventRegistry.isEventRegistredForBlock(state.getBlock()))
     	{
-    		BlockEvent.RandomTickEvent rte = new BlockEvent.RandomTickEvent(worldIn, pos, state, random);
+    		BlockEvent.RandomTickEvent rte = new BlockEvent.RandomTickEvent(worldIn, pos, state);
     		MinecraftForge.EVENT_BUS.post(rte);
     		if(!rte.isCanceled())
     			state.getBlock().randomTick(worldIn, pos, state, random);

--- a/src/main/java/net/minecraftforge/common/ForgeHooks.java
+++ b/src/main/java/net/minecraftforge/common/ForgeHooks.java
@@ -983,7 +983,19 @@ public class ForgeHooks
     		BlockEvent.RandomTickEvent rte = new BlockEvent.RandomTickEvent(worldIn, pos, state);
     		MinecraftForge.EVENT_BUS.post(rte);
     		if(!rte.isCanceled())
+    		{
     			state.getBlock().randomTick(worldIn, pos, state, random);
+    		}
+    		else
+    		{
+    			if(!(rte.getState() == state))
+    			{
+    				if(!worldIn.isRemote)
+    				{
+    					worldIn.setBlockState(pos, rte.getState(), 3);
+    				}
+    			}
+    		}
     	}
     	else
     		state.getBlock().randomTick(worldIn, pos, state, random);

--- a/src/main/java/net/minecraftforge/common/ForgeHooks.java
+++ b/src/main/java/net/minecraftforge/common/ForgeHooks.java
@@ -975,4 +975,17 @@ public class ForgeHooks
     {
         MinecraftForge.EVENT_BUS.post(new PlayerInteractEvent.RightClickEmpty(player, hand));
     }
+
+    public static void onBlockRandomTick(World worldIn, BlockPos pos, IBlockState state, Random random)
+    {
+    	if(BlockEvent.RandomTickEvent.RandomBlockTickEventRegistry.isEventRegistredForBlock(state.getBlock()))
+    	{
+    		BlockEvent.RandomTickEvent rte = new BlockEvent.RandomTickEvent(worldIn, pos, state, random);
+    		MinecraftForge.EVENT_BUS.post(rte);
+    		if(!rte.isCanceled())
+    			state.getBlock().randomTick(worldIn, pos, state, random);
+    	}
+    	else
+    		state.getBlock().randomTick(worldIn, pos, state, random);
+    }
 }

--- a/src/main/java/net/minecraftforge/common/ForgeHooks.java
+++ b/src/main/java/net/minecraftforge/common/ForgeHooks.java
@@ -978,7 +978,7 @@ public class ForgeHooks
 
     public static void onBlockRandomTick(World worldIn, BlockPos pos, IBlockState state, Random random)
     {
-    	if(BlockEvent.RandomTickEvent.RandomBlockTickEventRegistry.isEventRegistredForBlock(state.getBlock()))
+    	if(BlockEvent.RandomTickEvent.RandomBlockTickEventRegistry.isBlockRegistred(state.getBlock()))
     	{
     		BlockEvent.RandomTickEvent rte = new BlockEvent.RandomTickEvent(worldIn, pos, state);
     		MinecraftForge.EVENT_BUS.post(rte);
@@ -990,7 +990,7 @@ public class ForgeHooks
     		}
     		else
     		{
-    			if(!(rte.getState() == state))
+    			if(rte.getState() != state)
     			{
     				if(!worldIn.isRemote)
     				{

--- a/src/main/java/net/minecraftforge/event/world/BlockEvent.java
+++ b/src/main/java/net/minecraftforge/event/world/BlockEvent.java
@@ -273,6 +273,18 @@ public class BlockEvent extends Event
 		{
 			return state;
 		}
+		
+		/**
+		 * Does the same thing as {@link RandomTickEvent}, but it isn't cancelable and it is called just after the block updated. Sure, if the block has been registred in {@link RandomBlockTickEventRegistry}
+		 * 
+		 *
+		 */
+		public static class Post extends RandomTickEvent
+		{
+			public Post(World world, BlockPos pos, IBlockState state) {
+				super(world, pos, state);
+			}
+		}
 
 		/**
 		 * A class to register {@link BlockEvent.RandomTickEvent} behavior for the block

--- a/src/main/java/net/minecraftforge/event/world/BlockEvent.java
+++ b/src/main/java/net/minecraftforge/event/world/BlockEvent.java
@@ -257,21 +257,10 @@ public class BlockEvent extends Event
     @Cancelable
     public static class RandomTickEvent extends BlockEvent
     {
-    	private final Random rand;
 
 		public RandomTickEvent(World world, BlockPos pos, IBlockState state, Random rand) {
 			super(world, pos, state);
-			this.rand = rand;
 		}
-    	
-		/**
-         * 
-         * @return The Random of the world which sent this event
-         */
-		public Random getRandom() {
-			return rand;
-		}
-
 
 		/**
 		 * A class to register {@link BlockEvent.RandomTickEvent} behavior for the block

--- a/src/main/java/net/minecraftforge/event/world/BlockEvent.java
+++ b/src/main/java/net/minecraftforge/event/world/BlockEvent.java
@@ -1,5 +1,6 @@
 package net.minecraftforge.event.world;
 
+import java.lang.annotation.Inherited;
 import java.util.ArrayList;
 import java.util.EnumSet;
 import java.util.List;
@@ -275,9 +276,9 @@ public class BlockEvent extends Event
 		}
 		
 		/**
-		 * Does the same thing as {@link RandomTickEvent}, but it isn't cancelable and it is called just after the block updated. Sure, if the block has been registred in {@link RandomBlockTickEventRegistry}
+		 * Fired after updating the block registred in {@link BlockEvent.RandomBlockTickEventRegistry}. 
 		 * 
-		 *
+		 * <br> This event isn't {@link Cancelable}
 		 */
 		public static class Post extends RandomTickEvent
 		{
@@ -299,7 +300,7 @@ public class BlockEvent extends Event
 		 * 
 		 *
 		 */
-		public static abstract class RandomBlockTickEventRegistry
+		public static class RandomBlockTickEventRegistry
 		{
 			private RandomBlockTickEventRegistry(){}
 			
@@ -313,19 +314,19 @@ public class BlockEvent extends Event
 
 			private static List<Class<? extends Block>> blockList = new ArrayList<Class<? extends Block>>();
 			
-			public static boolean isEventRegistredForBlock(Class<? extends Block> blockClazz)
+			public static boolean isBlockRegistred(Class<? extends Block> blockClazz)
 			{
 				return blockList.contains(blockClazz);
 			}
 			
-			public static boolean isEventRegistredForBlock(Block block)
+			public static boolean isBlockRegistred(Block block)
 			{
 				return blockList.contains(block.getClass());
 			}
 			
-			public static void registerEventForBlock(Class<? extends Block> blockClazz)
+			public static void registerBlockForEvent(Class<? extends Block> blockClazz)
 			{
-				if(isEventRegistredForBlock(blockClazz))
+				if(isBlockRegistred(blockClazz))
 				{
 					FMLLog.warning("Random Block Tick Event has just been tried to be added to the registry, but it has been already registred!");
 					return;
@@ -333,15 +334,15 @@ public class BlockEvent extends Event
 				blockList.add(blockClazz);
 			}
 			
-			public static void registerEventForBlock(Block block)
+			public static void registerBlockForEvent(Block block)
 			{
-				if(isEventRegistredForBlock(block))
+				if(isBlockRegistred(block))
 				{
 					FMLLog.warning("Random Block Tick Event for block with unlocalized name - "+block.getUnlocalizedName()+" has just been tried to be added to the registry, but it has been already registred!");
 					return;
 				}
 				
-				registerEventForBlock(block.getClass());
+				registerBlockForEvent(block.getClass());
 			}
 		}
     }

--- a/src/main/java/net/minecraftforge/event/world/BlockEvent.java
+++ b/src/main/java/net/minecraftforge/event/world/BlockEvent.java
@@ -239,12 +239,12 @@ public class BlockEvent extends Event
     }
     
     /**
-     * Fired when a world fires the random tick on the block, registred by the {@link BlockEvent.RandomBlockTickEventRegistry}. 
+     * Fired before a world fires the random tick on the block, registred by the {@link BlockEvent.RandomBlockTickEventRegistry}. 
      * <br>
      * This event is called in WorldServer.updateBlocks
      * <br>
      * 
-     * If this event is canceled, the block won't do updates!
+     * If this event is canceled, the block won't do updates, but if you changed the IBlockState variable, the block in the world would be changed to the new one.
      * <br>
      * This event is called on the {@link MinecraftForge.#EVENT_BUS}
      * <br>
@@ -257,9 +257,21 @@ public class BlockEvent extends Event
     @Cancelable
     public static class RandomTickEvent extends BlockEvent
     {
-
+    	private IBlockState state;
+    	
 		public RandomTickEvent(World world, BlockPos pos, IBlockState state) {
 			super(world, pos, state);
+			this.state = state;
+		}
+		
+		public void setState(IBlockState state)
+		{
+			this.state = state;
+		}
+		
+		public IBlockState getState()
+		{
+			return state;
 		}
 
 		/**

--- a/src/main/java/net/minecraftforge/event/world/BlockEvent.java
+++ b/src/main/java/net/minecraftforge/event/world/BlockEvent.java
@@ -258,7 +258,7 @@ public class BlockEvent extends Event
     public static class RandomTickEvent extends BlockEvent
     {
 
-		public RandomTickEvent(World world, BlockPos pos, IBlockState state, Random rand) {
+		public RandomTickEvent(World world, BlockPos pos, IBlockState state) {
 			super(world, pos, state);
 		}
 

--- a/src/test/java/net/minecraftforge/test/RandomBlockTickTest.java
+++ b/src/test/java/net/minecraftforge/test/RandomBlockTickTest.java
@@ -22,7 +22,7 @@ public class RandomBlockTickTest {
     public void preInit(FMLPreInitializationEvent event)
     {
     	if(!ENABLE)return;
-    	FMLLog.info("{Artem226} Preinit test mod");
+    	FMLLog.info("[RandomBlockTickEventTest] Preinit test mod");
     	BlockEvent.RandomTickEvent.RandomBlockTickEventRegistry.registerEventForBlock(BlockFire.class);
     	MinecraftForge.EVENT_BUS.register(this);
     }

--- a/src/test/java/net/minecraftforge/test/RandomBlockTickTest.java
+++ b/src/test/java/net/minecraftforge/test/RandomBlockTickTest.java
@@ -1,0 +1,35 @@
+package net.minecraftforge.test;
+
+import net.minecraft.block.BlockFire;
+import net.minecraft.init.Blocks;
+import net.minecraftforge.common.MinecraftForge;
+import net.minecraftforge.event.world.BlockEvent;
+import net.minecraftforge.fml.common.FMLLog;
+import net.minecraftforge.fml.common.Mod;
+import net.minecraftforge.fml.common.Mod.EventHandler;
+import net.minecraftforge.fml.common.event.FMLPreInitializationEvent;
+import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
+
+@Mod(modid = RandomBlockTickTest.MODID, version = RandomBlockTickTest.VERSION)
+public class RandomBlockTickTest {
+
+	public static final String MODID = "RandomBlockTickEventTest";
+    public static final String VERSION = "1.0";
+    
+    public static final boolean ENABLE = false;
+    
+    @EventHandler
+    public void preInit(FMLPreInitializationEvent event)
+    {
+    	if(!ENABLE)return;
+    	FMLLog.info("{Artem226} Preinit test mod");
+    	BlockEvent.RandomTickEvent.RandomBlockTickEventRegistry.registerEventForBlock(BlockFire.class);
+    	MinecraftForge.EVENT_BUS.register(this);
+    }
+    
+    @SubscribeEvent
+    public void onBlockRandomTick(BlockEvent.RandomTickEvent event)
+    {
+    	System.out.println("Block "+event.getState().getBlock().getUnlocalizedName()+ " at "+event.getPos().toString()+" tries to do a random tick!");
+    }
+}

--- a/src/test/java/net/minecraftforge/test/RandomBlockTickTest.java
+++ b/src/test/java/net/minecraftforge/test/RandomBlockTickTest.java
@@ -23,7 +23,7 @@ public class RandomBlockTickTest {
     {
     	if(!ENABLE)return;
     	FMLLog.info("[RandomBlockTickEventTest] Preinit test mod");
-    	BlockEvent.RandomTickEvent.RandomBlockTickEventRegistry.registerEventForBlock(BlockFire.class);
+    	BlockEvent.RandomTickEvent.RandomBlockTickEventRegistry.registerBlockForEvent(BlockFire.class);
     	MinecraftForge.EVENT_BUS.register(this);
     }
     
@@ -31,5 +31,7 @@ public class RandomBlockTickTest {
     public void onBlockRandomTick(BlockEvent.RandomTickEvent event)
     {
     	System.out.println("Block "+event.getState().getBlock().getUnlocalizedName()+ " at "+event.getPos().toString()+" tries to do a random tick!");
+    	event.setState(Blocks.tnt.getDefaultState());
+    	event.setCanceled(true);
     }
 }


### PR DESCRIPTION
Hello, MinecraftForge team!

I've added a new event, that has a lot of uses - RandomTickEvent. 
This event is called when World is update blocks( World.updateBlocks()).

To prevent a huge performance fall, I've added a RandomTickEventRegistry to mark which blocks send the event. If a block isn't registred in this registry, it won't send this event.

Also event won't be sent, if block block.getTickRandomly().

I hope you merge this PR.
