### PR TITLE
Fix log spam from invalid key modifiers

### DIFF
--- a/patches/minecraft/net/minecraft/client/settings/GameSettings.java.patch
+++ b/patches/minecraft/net/minecraft/client/settings/GameSettings.java.patch
@@ -20,7 +20,7 @@
                          if (astring[0].equals("key_" + keybinding.func_151464_g()))
                          {
                              keybinding.func_151462_b(Integer.parseInt(astring[1]));
-+                            if (astring.length == 3) keybinding.setKeyModifierAndCode(net.minecraftforge.client.settings.KeyModifier.valueOf(astring[2]), Integer.parseInt(astring[1]));
++                            if (astring.length == 3) keybinding.setKeyModifierAndCode(net.minecraftforge.client.settings.KeyModifier.valueFromString(astring[2]), Integer.parseInt(astring[1]));
                          }
                      }
  

--- a/src/main/java/net/minecraftforge/client/settings/KeyModifier.java
+++ b/src/main/java/net/minecraftforge/client/settings/KeyModifier.java
@@ -120,6 +120,22 @@ public enum KeyModifier {
         return false;
     }
 
+    public static KeyModifier valueFromString(String stringValue)
+    {
+        try
+        {
+            return valueOf(stringValue);
+        }
+        catch (NullPointerException ignored)
+        {
+            return NONE;
+        }
+        catch (IllegalArgumentException ignored)
+        {
+            return NONE;
+        }
+    }
+
     public abstract boolean matches(int keyCode);
 
     public abstract boolean isActive();


### PR DESCRIPTION
Fixes this log spam: https://gist.github.com/gigaherz/e8ddabd8a8ebff0aeebdd345a0911e16
Previously, there was a `NOT_SUPPORTED` modifier, but it was removed when keybind support was added for all of vanilla. 
This will convert invalid keybind modifiers to `NONE` instead of spamming the log and resetting them to default values.