### PR TITLE
Fix display of Attack Damage/Speed AttributeModifiers loaded from ItemStack NBT

### DIFF
--- a/patches/minecraft/net/minecraft/item/ItemStack.java.patch
+++ b/patches/minecraft/net/minecraft/item/ItemStack.java.patch
@@ -164,6 +164,22 @@
  
          if (this.field_77990_d != null)
          {
+@@ -649,13 +655,13 @@
+                     double d0 = attributemodifier.func_111164_d();
+                     boolean flag = false;
+ 
+-                    if (attributemodifier.func_111167_a() == Item.field_111210_e)
++                    if (attributemodifier.func_111167_a().equals(Item.field_111210_e)) // FORGE - Fix improper attribute modifier formatting
+                     {
+                         d0 = d0 + p_82840_1_.func_110148_a(SharedMonsterAttributes.field_111264_e).func_111125_b();
+                         d0 = d0 + (double)EnchantmentHelper.func_152377_a(this, EnumCreatureAttribute.UNDEFINED);
+                         flag = true;
+                     }
+-                    else if (attributemodifier.func_111167_a() == Item.field_185050_h)
++                    else if (attributemodifier.func_111167_a().equals(Item.field_185050_h)) // FORGE - Fix improper attribute modifier formatting
+                     {
+                         d0 += p_82840_1_.func_110148_a(SharedMonsterAttributes.field_188790_f).func_111125_b();
+                         flag = true;
 @@ -759,6 +765,7 @@
              }
          }


### PR DESCRIPTION
This fixes a vanilla bug where Attack Damage/Speed `AttributeModifier`s loaded from `ItemStack` NBT are displayed differently to `AttributeModifier`s provided by `Item#getAttributeModifiers`.

Vanilla compares the `UUID`s of the `AttributeModifier`s using the `==` operator instead of the `.equals()` method.

Before:
![2016-04-14_11 26 09](https://cloud.githubusercontent.com/assets/878073/14514822/6e9758c6-0237-11e6-8d34-33f0912cc7a7.png)

After:
![2016-04-14_11 55 22](https://cloud.githubusercontent.com/assets/878073/14514858/ccb7c7a6-0237-11e6-9bc6-ace637d69ede.png)

The code that produces this `ItemStack` can be found [here](https://github.com/Choonster/TestMod3/blob/d41939b7443a7130fc5803c85b4d800e5868ca9e/src/main/java/com/choonster/testmod3/util/SwordUpgrades.java).
