### PR TITLE
[1.9] Updated armour calculations for EntityPlayer, changes to ISpecialArmor

### DIFF
--- a/src/main/java/net/minecraftforge/common/ForgeHooks.java
+++ b/src/main/java/net/minecraftforge/common/ForgeHooks.java
@@ -27,6 +27,7 @@ import net.minecraft.init.Blocks;
 import net.minecraft.init.Items;
 import net.minecraft.inventory.Container;
 import net.minecraft.inventory.ContainerRepair;
+import net.minecraft.inventory.EntityEquipmentSlot;
 import net.minecraft.inventory.IInventory;
 import net.minecraft.inventory.InventoryCrafting;
 import net.minecraft.item.ItemArmor;
@@ -226,16 +227,19 @@ public class ForgeHooks
     public static int getTotalArmorValue(EntityPlayer player)
     {
         int ret = 0;
-        for (int x = 0; x < player.inventory.armorInventory.length; x++)
+        for(EntityEquipmentSlot slot : EntityEquipmentSlot.values())
         {
-            ItemStack stack = player.inventory.armorInventory[x];
-            if (stack != null && stack.getItem() instanceof ISpecialArmor)
+            if(slot.getSlotType() == EntityEquipmentSlot.Type.ARMOR)
             {
-                ret += ((ISpecialArmor)stack.getItem()).getArmorDisplay(player, stack, x);
-            }
-            else if (stack != null && stack.getItem() instanceof ItemArmor)
-            {
-                ret += ((ItemArmor)stack.getItem()).damageReduceAmount;
+                ItemStack stack = player.getItemStackFromSlot(slot);
+                if (stack != null && stack.getItem() instanceof ISpecialArmor)
+                {
+                    ret += ((ISpecialArmor)stack.getItem()).getArmorDisplay(player, stack, slot);
+                }
+                else if (stack != null && stack.getItem() instanceof ItemArmor)
+                {
+                    ret += ((ItemArmor)stack.getItem()).damageReduceAmount;
+                }  
             }
         }
         return ret;


### PR DESCRIPTION
This is in order to fix https://github.com/MinecraftForge/MinecraftForge/issues/2720 and to implement https://github.com/MinecraftForge/MinecraftForge/issues/2571.

First of all, ISpecialArmor was modernized so that it now takes arguments of EntityEquipmentSlot instead of int slot. 

Secondly, ISpecialArmor was updated so that it provides an extra parameter for ArmorProperties: double Armor. This parameter allows armour pieces that implement ISpecialArmor to provide additional vanilla armour points, while still allowing ISpecialArmor to apply a flat reduction to incoming damage.

ISpecialArmor now implements a hybrid damage reduction formula: when calculating the damage reduction from the armour, it first applies the flat percentage reduction that is provided by the ISpecialArmor and damages the armour accordingly. It then applies the vanilla calculations to the remaining damage and uses the vanilla calculations for the damage applied to the armour if this is greater than 0.
