### PR TITLE
Add position-agnostic ForgeHooks.canHarvestBlock method

### DIFF
--- a/src/main/java/net/minecraftforge/common/ForgeHooks.java
+++ b/src/main/java/net/minecraftforge/common/ForgeHooks.java
@@ -121,16 +121,15 @@ public class ForgeHooks
     private static boolean toolInit = false;
     //static HashSet<List> toolEffectiveness = new HashSet<List>();
 
-    public static boolean canHarvestBlock(Block block, EntityPlayer player, IBlockAccess world, BlockPos pos)
+    public static boolean canHarvestBlock(EntityPlayer player, IBlockState state)
     {
+        Block block = state.getBlock();
         if (block.getMaterial().isToolNotRequired())
         {
             return true;
         }
 
         ItemStack stack = player.inventory.getCurrentItem();
-        IBlockState state = world.getBlockState(pos);
-        state = state.getBlock().getActualState(state, world, pos);
         String tool = block.getHarvestTool(state);
         if (stack == null || tool == null)
         {
@@ -144,6 +143,13 @@ public class ForgeHooks
         }
 
         return toolLevel >= block.getHarvestLevel(state);
+    }
+
+    public static boolean canHarvestBlock(Block block, EntityPlayer player, IBlockAccess world, BlockPos pos)
+    {
+        IBlockState state = world.getBlockState(pos);
+        state = state.getBlock().getActualState(state, world, pos);
+        return canHarvestBlock(player, state);
     }
 
     public static boolean canToolHarvestBlock(IBlockAccess world, BlockPos pos, ItemStack stack)


### PR DESCRIPTION
 - The only use for world/position that the existing canHarvestBlock has is to get the block state
 - IBlockState as the third param matches better with previous versions of ForgeHooks.canHarvestBlock (it was `int meta` in 1.7)
 - Getting the harvestability of a block without the position can be useful for getting the harvestability of a block that is disguised as a different block

Specific use-case: https://github.com/squeek502/WailaHarvestability/issues/45