### PR TITLE
Migrate server lifecycle events to Forge event bus

### DIFF
--- a/patches/minecraft/net/minecraft/server/MinecraftServer.java.patch
+++ b/patches/minecraft/net/minecraft/server/MinecraftServer.java.patch
@@ -114,7 +114,7 @@
          {
              if (this.func_71197_b())
              {
-+                net.minecraftforge.fml.common.FMLCommonHandler.instance().handleServerStarted();
++                net.minecraftforge.fml.common.FMLCommonHandler.instance().handleServerStarted(this);
                  this.field_175591_ab = func_130071_aq();
                  long i = 0L;
                  this.field_147147_p.func_151315_a(new TextComponentString(this.field_71286_C));
@@ -122,7 +122,7 @@
                      Thread.sleep(Math.max(1L, 50L - i));
                      this.field_71296_Q = true;
                  }
-+                net.minecraftforge.fml.common.FMLCommonHandler.instance().handleServerStopping();
++                net.minecraftforge.fml.common.FMLCommonHandler.instance().handleServerStopping(this);
 +                net.minecraftforge.fml.common.FMLCommonHandler.instance().expectServerStopped(); // has to come before finalTick to avoid race conditions
              }
              else
@@ -160,7 +160,7 @@
              }
              finally
              {
-+                net.minecraftforge.fml.common.FMLCommonHandler.instance().handleServerStopped();
++                net.minecraftforge.fml.common.FMLCommonHandler.instance().handleServerStopped(this);
 +                this.field_71316_v = true;
                  this.func_71240_o();
              }

--- a/src/main/java/net/minecraftforge/common/ForgeModContainer.java
+++ b/src/main/java/net/minecraftforge/common/ForgeModContainer.java
@@ -17,6 +17,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 
+import net.minecraft.command.CommandHandler;
 import net.minecraft.nbt.NBTBase;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.world.storage.SaveHandler;
@@ -26,6 +27,7 @@ import net.minecraftforge.common.config.Configuration;
 import net.minecraftforge.common.config.Property;
 import net.minecraftforge.common.model.animation.CapabilityAnimation;
 import net.minecraftforge.common.network.ForgeNetworkHandler;
+import net.minecraftforge.event.server.ServerLifecycleEvent;
 import net.minecraftforge.fluids.FluidRegistry;
 import net.minecraftforge.items.CapabilityItemHandler;
 import net.minecraftforge.fluids.UniversalBucket;
@@ -353,10 +355,10 @@ public class ForgeModContainer extends DummyModContainer implements WorldAccessC
         FluidRegistry.validateFluidRegistry();
     }
 
-    @Subscribe
-    public void serverStarting(FMLServerStartingEvent evt)
+    @SubscribeEvent
+    public void serverStarting(ServerLifecycleEvent.Starting evt)
     {
-        evt.registerServerCommand(new ForgeCommand());
+        ((CommandHandler)evt.getServer().getCommandManager()).registerCommand(new ForgeCommand());
     }
     @Override
     public NBTTagCompound getDataForWriting(SaveHandler handler, WorldInfo info)

--- a/src/main/java/net/minecraftforge/event/server/ServerLifecycleEvent.java
+++ b/src/main/java/net/minecraftforge/event/server/ServerLifecycleEvent.java
@@ -1,0 +1,87 @@
+package net.minecraftforge.event.server;
+
+import net.minecraft.server.MinecraftServer;
+import net.minecraftforge.common.MinecraftForge;
+import net.minecraftforge.fml.common.eventhandler.Cancelable;
+import net.minecraftforge.fml.common.eventhandler.Event;
+
+public class ServerLifecycleEvent extends Event
+{
+    private final MinecraftServer server;
+    protected ServerLifecycleEvent(MinecraftServer server)
+    {
+        this.server = server;
+    }
+    public MinecraftServer getServer()
+    {
+        return this.server;
+    }
+    
+    /**
+     * This event is fired before the server starts.
+     * <br>
+     * This event is not {@link Cancelable}.<br>
+     * <br>
+     * This event does not have a result. {@link HasResult}<br>
+     * <br>
+     * This event is fired on the {@link MinecraftForge#EVENT_BUS}.
+     **/
+    public static class Starting extends ServerLifecycleEvent
+    {
+        public Starting(MinecraftServer server)
+        {
+            super(server);
+        }
+    }
+
+    /**
+     * This event is fired after the server starts.
+     * <br>
+     * This event is not {@link Cancelable}.<br>
+     * <br>
+     * This event does not have a result. {@link HasResult}<br>
+     * <br>
+     * This event is fired on the {@link MinecraftForge#EVENT_BUS}.
+     **/
+    public static class Started extends ServerLifecycleEvent
+    {
+        public Started(MinecraftServer server)
+        {
+            super(server);
+        }
+    }
+
+    /**
+     * This event is fired before the server shuts down.
+     * <br>
+     * This event is not {@link Cancelable}.<br>
+     * <br>
+     * This event does not have a result. {@link HasResult}<br>
+     * <br>
+     * This event is fired on the {@link MinecraftForge#EVENT_BUS}.
+     **/
+    public static class Stopping extends ServerLifecycleEvent
+    {
+        public Stopping(MinecraftServer server)
+        {
+            super(server);
+        }
+    }
+
+    /**
+     * This event is fired after the server shuts down.
+     * <br>
+     * This event is not {@link Cancelable}.<br>
+     * <br>
+     * This event does not have a result. {@link HasResult}<br>
+     * <br>
+     * This event is fired on the {@link MinecraftForge#EVENT_BUS}.
+     **/
+    public static class Stopped extends ServerLifecycleEvent
+    {
+        public Stopped(MinecraftServer server)
+        {
+            super(server);
+        }
+    }
+}

--- a/src/main/java/net/minecraftforge/event/server/ServerLifecycleEvent.java
+++ b/src/main/java/net/minecraftforge/event/server/ServerLifecycleEvent.java
@@ -18,7 +18,7 @@ public class ServerLifecycleEvent extends Event
     }
     
     /**
-     * This event is fired before the server starts.
+     * This event is fired before the server starts.<br>
      * <br>
      * This event is not {@link Cancelable}.<br>
      * <br>
@@ -35,7 +35,7 @@ public class ServerLifecycleEvent extends Event
     }
 
     /**
-     * This event is fired after the server starts.
+     * This event is fired after the server starts.<br>
      * <br>
      * This event is not {@link Cancelable}.<br>
      * <br>
@@ -52,7 +52,7 @@ public class ServerLifecycleEvent extends Event
     }
 
     /**
-     * This event is fired before the server shuts down.
+     * This event is fired before the server shuts down.<br>
      * <br>
      * This event is not {@link Cancelable}.<br>
      * <br>
@@ -69,7 +69,7 @@ public class ServerLifecycleEvent extends Event
     }
 
     /**
-     * This event is fired after the server shuts down.
+     * This event is fired after the server shuts down.<br>
      * <br>
      * This event is not {@link Cancelable}.<br>
      * <br>

--- a/src/main/java/net/minecraftforge/fml/common/Loader.java
+++ b/src/main/java/net/minecraftforge/fml/common/Loader.java
@@ -780,6 +780,7 @@ public class Loader
         return "Minecraft " + mccversion;
     }
 
+    @Deprecated
     public boolean serverStarting(Object server)
     {
         try
@@ -795,12 +796,14 @@ public class Loader
         return true;
     }
 
+    @Deprecated
     public void serverStarted()
     {
         modController.distributeStateMessage(LoaderState.SERVER_STARTED);
         modController.transition(LoaderState.SERVER_STARTED, false);
     }
 
+    @Deprecated
     public void serverStopping()
     {
         modController.distributeStateMessage(LoaderState.SERVER_STOPPING);
@@ -842,6 +845,7 @@ public class Loader
         return String.format("MCP %s", mcpversion);
     }
 
+    @Deprecated
     public void serverStopped()
     {
         PersistentRegistryManager.revertToFrozen();
@@ -850,6 +854,7 @@ public class Loader
         modController.transition(LoaderState.AVAILABLE, true);
     }
 
+    @Deprecated
     public boolean serverAboutToStart(Object server)
     {
         try

--- a/src/main/java/net/minecraftforge/fml/common/LoaderState.java
+++ b/src/main/java/net/minecraftforge/fml/common/LoaderState.java
@@ -40,10 +40,15 @@ public enum LoaderState
     INITIALIZATION("Initializing mods", FMLInitializationEvent.class),
     POSTINITIALIZATION("Post-initializing mods", FMLPostInitializationEvent.class),
     AVAILABLE("Mod loading complete", FMLLoadCompleteEvent.class),
+    @Deprecated
     SERVER_ABOUT_TO_START("Server about to start", FMLServerAboutToStartEvent.class),
+    @Deprecated
     SERVER_STARTING("Server starting", FMLServerStartingEvent.class),
+    @Deprecated
     SERVER_STARTED("Server started", FMLServerStartedEvent.class),
+    @Deprecated
     SERVER_STOPPING("Server stopping", FMLServerStoppingEvent.class),
+    @Deprecated
     SERVER_STOPPED("Server stopped", FMLServerStoppedEvent.class),
     ERRORED("Mod Loading errored",null);
 

--- a/src/main/java/net/minecraftforge/fml/common/Mod.java
+++ b/src/main/java/net/minecraftforge/fml/common/Mod.java
@@ -231,16 +231,9 @@ public @interface Mod
      * send {@link FMLInterModComms} messages to other mods.</li>
      * <li> {@link FMLPostInitializationEvent} : Handle interaction with other mods, complete your setup based on this.</li>
      * </ul>
-     * <p>These are the server lifecycle events. They are fired whenever a server is running, or about to run. Each time a server
-     * starts they will be fired in this sequence.
-     * <ul>
-     * <li> {@link FMLServerAboutToStartEvent} : Use if you need to handle something before the server has even been created.</li>
-     * <li> {@link FMLServerStartingEvent} : Do stuff you need to do to set up the server. register commands, tweak the server.</li>
-     * <li> {@link FMLServerStartedEvent} : Do what you need to with the running server.</li>
-     * <li> {@link FMLServerStoppingEvent} : Do what you need to before the server has started it's shutdown sequence.</li>
-     * <li> {@link FMLServerStoppedEvent} : Do whatever cleanup you need once the server has shutdown. Generally only useful
-     * on the integrated server.</li>
-     * </ul>
+     * <p>The server lifecycle events {@link FMLServerAboutToStartEvent}, {@link FMLServerStartingEvent}, {@link FMLServerStartedEvent},
+     * {@link FMLServerStoppingEvent} and {@link FMLServerStoppedEvent} are deprecated. Use their replacements which are fired
+     * on the Forge event bus.
      * The second set of events are more specialized, for receiving notification of specific
      * information.
      * <ul>

--- a/src/main/java/net/minecraftforge/fml/common/event/FMLServerAboutToStartEvent.java
+++ b/src/main/java/net/minecraftforge/fml/common/event/FMLServerAboutToStartEvent.java
@@ -13,6 +13,7 @@
 package net.minecraftforge.fml.common.event;
 
 import net.minecraft.server.MinecraftServer;
+import net.minecraftforge.event.server.ServerLifecycleEvent;
 import net.minecraftforge.fml.common.LoaderState.ModState;
 
 /**
@@ -22,7 +23,9 @@ import net.minecraftforge.fml.common.LoaderState.ModState;
  * You can obtain a reference to the server with this event.
  * @see net.minecraftforge.fml.common.Mod.EventHandler for how to subscribe to this event
  * @author cpw
+ * @deprecated Use {@link ServerLifecycleEvent.Starting} instead.
  */
+@Deprecated
 public class FMLServerAboutToStartEvent extends FMLStateEvent {
 
     private MinecraftServer server;

--- a/src/main/java/net/minecraftforge/fml/common/event/FMLServerStartedEvent.java
+++ b/src/main/java/net/minecraftforge/fml/common/event/FMLServerStartedEvent.java
@@ -12,6 +12,7 @@
 
 package net.minecraftforge.fml.common.event;
 
+import net.minecraftforge.event.server.ServerLifecycleEvent;
 import net.minecraftforge.fml.common.LoaderState.ModState;
 
 /**
@@ -19,7 +20,9 @@ import net.minecraftforge.fml.common.LoaderState.ModState;
  *
  * @see net.minecraftforge.fml.common.Mod.EventHandler for how to subscribe to this event
  * @author cpw
+ * @deprecated Use {@link ServerLifecycleEvent.Started} instead.
  */
+@Deprecated
 public class FMLServerStartedEvent extends FMLStateEvent
 {
 

--- a/src/main/java/net/minecraftforge/fml/common/event/FMLServerStartingEvent.java
+++ b/src/main/java/net/minecraftforge/fml/common/event/FMLServerStartingEvent.java
@@ -15,6 +15,7 @@ package net.minecraftforge.fml.common.event;
 import net.minecraft.command.CommandHandler;
 import net.minecraft.command.ICommand;
 import net.minecraft.server.MinecraftServer;
+import net.minecraftforge.event.server.ServerLifecycleEvent;
 import net.minecraftforge.fml.common.LoaderState.ModState;
 
 /**
@@ -24,7 +25,9 @@ import net.minecraftforge.fml.common.LoaderState.ModState;
  *
  * @see net.minecraftforge.fml.common.Mod.EventHandler for how to subscribe to this event
  * @author cpw
+ * @deprecated Use {@link ServerLifecycleEvent.Starting} instead.
  */
+@Deprecated
 public class FMLServerStartingEvent extends FMLStateEvent
 {
 

--- a/src/main/java/net/minecraftforge/fml/common/event/FMLServerStoppedEvent.java
+++ b/src/main/java/net/minecraftforge/fml/common/event/FMLServerStoppedEvent.java
@@ -12,6 +12,7 @@
 
 package net.minecraftforge.fml.common.event;
 
+import net.minecraftforge.event.server.ServerLifecycleEvent;
 import net.minecraftforge.fml.common.LoaderState.ModState;
 
 /**
@@ -21,7 +22,9 @@ import net.minecraftforge.fml.common.LoaderState.ModState;
  *
  * @see net.minecraftforge.fml.common.Mod.EventHandler for how to subscribe to this event
  * @author cpw
+ * @deprecated Use {@link ServerLifecycleEvent.Stopped} instead.
  */
+@Deprecated
 public class FMLServerStoppedEvent extends FMLStateEvent {
 
     public FMLServerStoppedEvent(Object... data)

--- a/src/main/java/net/minecraftforge/fml/common/event/FMLServerStoppingEvent.java
+++ b/src/main/java/net/minecraftforge/fml/common/event/FMLServerStoppingEvent.java
@@ -12,6 +12,7 @@
 
 package net.minecraftforge.fml.common.event;
 
+import net.minecraftforge.event.server.ServerLifecycleEvent;
 import net.minecraftforge.fml.common.LoaderState.ModState;
 
 /**
@@ -19,7 +20,9 @@ import net.minecraftforge.fml.common.LoaderState.ModState;
  *
  * @see net.minecraftforge.fml.common.Mod.EventHandler for how to subscribe to this event
  * @author cpw
+ * @deprecated Use {@link ServerLifecycleEvent.Stopping} instead.
  */
+@Deprecated
 public class FMLServerStoppingEvent extends FMLStateEvent
 {
 


### PR DESCRIPTION
- Added ServerLifecycleEvent.{Starting,Started,Stopping,Stopped} events.
- Deprecated FMLServer{AboutToStart,Starting,Started,Stopping,Stopped}Events
- Made ForgeModContainer use (one of) the new events.

Note that `ServerLifecycleEvent.Starting` corresponds to `FMLServerAboutToStartEvent`, not `FMLServerStartingEvent`. The event called "starting" should be fired _just before_ the server starts, not halfway through the start process (which `FMLServerStartingEvent` is). If you want to do something after worlds are loaded, use `WorldEvent.Load`.

Example mod:

```
package whatever;

import net.minecraftforge.event.server.ServerLifecycleEvent;
import net.minecraftforge.fml.common.Mod;
import net.minecraftforge.fml.common.Mod.EventHandler;
import net.minecraftforge.fml.common.event.FMLPostInitializationEvent;
import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;

@Mod(modid="SLCTestMod", version="1.0")
public class SLCTestMod {
    @EventHandler
    public void preinit(FMLPostInitializationEvent event) {
        MinecraftForge.EVENT_BUS.register(this);
    }
    @SubscribeEvent
    public void printEvent(ServerLifecycleEvent event) {
        System.out.println("Got a "+event.getClass().getSimpleName()+" event.");
    }
}

```
