### PR TITLE
[1.9] Fix registering sprites multiple times ignoring all but the last

### DIFF
--- a/patches/minecraft/net/minecraft/client/renderer/texture/TextureMap.java.patch
+++ b/patches/minecraft/net/minecraft/client/renderer/texture/TextureMap.java.patch
@@ -145,6 +145,15 @@
              try
              {
                  iresource = p_184397_1_.func_110536_a(resourcelocation);
+@@ -291,7 +336,7 @@
+         }
+         else
+         {
+-            TextureAtlasSprite textureatlassprite = (TextureAtlasSprite)this.field_110574_e.get(p_174942_1_);
++            TextureAtlasSprite textureatlassprite = (TextureAtlasSprite)this.field_110574_e.get(p_174942_1_.toString());
+ 
+             if (textureatlassprite == null)
+             {
 @@ -317,4 +362,37 @@
      {
          return this.field_94249_f;


### PR DESCRIPTION
Currently ````TextureMap.registerSprite```` checks to see if it already has a sprite with the same location by passing the ````ResourceLocation```` object directly into the map of sprites - which has a key type of ````String```` and so always fails to find an existing entry. This results in replacing the previous ````TextureAtlasSprite```` entry with a new one, forgetting the old one and never stitching it. This can be an issue for mods that register the same sprite location multiple times in different places.