### PR TITLE
Added IItemHandler.getSlotLimit

### DIFF
--- a/src/main/java/net/minecraftforge/items/IItemHandler.java
+++ b/src/main/java/net/minecraftforge/items/IItemHandler.java
@@ -56,4 +56,12 @@ public interface IItemHandler
      * @return ItemStack extracted from the slot, must be null, if nothing can be extracted
      **/
     ItemStack extractItem(int slot, int amount, boolean simulate);
+
+    /**
+     * Retrieves the maximum stack size allowed to exist in the given slot.
+     *
+     * @param slot Slot to query.
+     * @return     The maximum stack size allowed in the slot.
+     */
+    int getSlotLimit(int slot);
 }

--- a/src/main/java/net/minecraftforge/items/ItemHandlerHelper.java
+++ b/src/main/java/net/minecraftforge/items/ItemHandlerHelper.java
@@ -6,6 +6,7 @@ import net.minecraft.init.SoundEvents;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.util.SoundCategory;
+import net.minecraft.util.math.MathHelper;
 import net.minecraft.world.World;
 import net.minecraftforge.items.wrapper.PlayerMainInvWrapper;
 
@@ -172,4 +173,38 @@ public class ItemHandlerHelper
             world.spawnEntityInWorld(entityitem);
         }
     }
+
+    /**
+     * This method uses the standard vanilla algorithm to calculate a comparator level for how "full" the inventory is.
+     * This method is an adaptation of {@link net.minecraft.inventory.Container#calcRedstoneFromInventory(IInventory)}.
+     * @param inv The inventory handler to test.
+     * @return A redstone value in the range [0,15] representing how "full" this inventory is.
+     */
+    public static int getComparatorOutput(IItemHandler inv)
+    {
+        if (inv == null)
+        {
+            return 0;
+        }
+        else
+        {
+            boolean foundOne = false;
+            float proportion = 0.0F;
+
+            for (int j = 0; j < inv.getSlots(); ++j)
+            {
+                ItemStack itemstack = inv.getStackInSlot(j);
+
+                if (itemstack != null)
+                {
+                    proportion += itemstack.stackSize / (float)Math.min(inv.getSlotLimit(j), itemstack.getMaxStackSize());
+                    foundOne = true;
+                }
+            }
+
+            proportion /= inv.getSlots();
+            return MathHelper.floor_float(proportion * 14.0F) + (foundOne ? 1 : 0);
+        }
+    }
+
 }

--- a/src/main/java/net/minecraftforge/items/ItemStackHandler.java
+++ b/src/main/java/net/minecraftforge/items/ItemStackHandler.java
@@ -129,9 +129,15 @@ public class ItemStackHandler implements IItemHandler, IItemHandlerModifiable, I
         }
     }
 
+    @Override
+    public int getSlotLimit(int slot)
+    {
+        return 64;
+    }
+
     protected int getStackLimit(int slot, ItemStack stack)
     {
-        return stack.getMaxStackSize();
+        return Math.min(getSlotLimit(slot), stack.getMaxStackSize());
     }
 
     @Override

--- a/src/main/java/net/minecraftforge/items/VanillaDoubleChestItemHandler.java
+++ b/src/main/java/net/minecraftforge/items/VanillaDoubleChestItemHandler.java
@@ -110,6 +110,13 @@ public class VanillaDoubleChestItemHandler extends WeakReference<TileEntityChest
     }
 
     @Override
+    public int getSlotLimit(int slot)
+    {
+        boolean accessingUpperChest = slot < 27;
+        return getChest(accessingUpperChest).getInventoryStackLimit();
+    }
+
+    @Override
     public boolean equals(Object o)
     {
         if (this == o)

--- a/src/main/java/net/minecraftforge/items/wrapper/CombinedInvWrapper.java
+++ b/src/main/java/net/minecraftforge/items/wrapper/CombinedInvWrapper.java
@@ -99,4 +99,13 @@ public class CombinedInvWrapper implements IItemHandlerModifiable
         slot = getSlotFromIndex(slot, index);
         return handler.extractItem(slot, amount, simulate);
     }
+
+    @Override
+    public int getSlotLimit(int slot)
+    {
+        int index = getIndexForSlot(slot);
+        IItemHandlerModifiable handler = getHandlerFromIndex(index);
+        slot = getSlotFromIndex(slot, index);
+        return handler.getSlotLimit(slot);
+    }
 }

--- a/src/main/java/net/minecraftforge/items/wrapper/EmptyHandler.java
+++ b/src/main/java/net/minecraftforge/items/wrapper/EmptyHandler.java
@@ -37,4 +37,11 @@ public class EmptyHandler implements IItemHandlerModifiable
     {
         // nothing to do here
     }
+
+    @Override
+    public int getSlotLimit(int slot)
+    {
+        return 0;
+    }
+
 }

--- a/src/main/java/net/minecraftforge/items/wrapper/InvWrapper.java
+++ b/src/main/java/net/minecraftforge/items/wrapper/InvWrapper.java
@@ -63,7 +63,7 @@ public class InvWrapper implements IItemHandlerModifiable
             if (!ItemHandlerHelper.canItemStacksStack(stack, stackInSlot))
                 return stack;
 
-            m = Math.min(stack.getMaxStackSize(), getInv().getInventoryStackLimit()) - stackInSlot.stackSize;
+            m = Math.min(stack.getMaxStackSize(), getSlotLimit(slot)) - stackInSlot.stackSize;
 
             if (stack.stackSize <= m)
             {
@@ -98,7 +98,7 @@ public class InvWrapper implements IItemHandlerModifiable
         }
         else
         {
-            m = Math.min(stack.getMaxStackSize(), getInv().getInventoryStackLimit());
+            m = Math.min(stack.getMaxStackSize(), getSlotLimit(slot));
             if (m < stack.stackSize)
             {
                 // copy the stack to not modify the original one
@@ -166,6 +166,12 @@ public class InvWrapper implements IItemHandlerModifiable
     public void setStackInSlot(int slot, ItemStack stack)
     {
         getInv().setInventorySlotContents(slot, stack);
+    }
+
+    @Override
+    public int getSlotLimit(int slot)
+    {
+        return getInv().getInventoryStackLimit();
     }
 
     public IInventory getInv()

--- a/src/main/java/net/minecraftforge/items/wrapper/RangedWrapper.java
+++ b/src/main/java/net/minecraftforge/items/wrapper/RangedWrapper.java
@@ -70,6 +70,17 @@ public class RangedWrapper implements IItemHandlerModifiable {
         }
     }
 
+    @Override
+    public int getSlotLimit(int slot)
+    {
+        if (checkSlot(slot))
+        {
+            return compose.getSlotLimit(slot + minSlot);
+        }
+
+        return 0;
+    }
+
     private boolean checkSlot(int localSlot)
     {
         return localSlot + minSlot < maxSlot;

--- a/src/main/java/net/minecraftforge/items/wrapper/SidedInvWrapper.java
+++ b/src/main/java/net/minecraftforge/items/wrapper/SidedInvWrapper.java
@@ -82,7 +82,7 @@ public class SidedInvWrapper implements IItemHandlerModifiable
             if (!ItemHandlerHelper.canItemStacksStack(stack, stackInSlot))
                 return stack;
 
-            m = Math.min(stack.getMaxStackSize(), inv.getInventoryStackLimit()) - stackInSlot.stackSize;
+            m = Math.min(stack.getMaxStackSize(), getSlotLimit(slot1)) - stackInSlot.stackSize;
 
             if (stack.stackSize <= m)
             {
@@ -115,7 +115,7 @@ public class SidedInvWrapper implements IItemHandlerModifiable
         }
         else
         {
-            m = Math.min(stack.getMaxStackSize(), inv.getInventoryStackLimit());
+            m = Math.min(stack.getMaxStackSize(), getSlotLimit(slot1));
             if (m < stack.stackSize)
             {
                 // copy the stack to not modify the original one
@@ -185,4 +185,11 @@ public class SidedInvWrapper implements IItemHandlerModifiable
             return inv.decrStackSize(slot1, m);
         }
     }
+
+    @Override
+    public int getSlotLimit(int slot)
+    {
+        return inv.getInventoryStackLimit();
+    }
+
 }


### PR DESCRIPTION
Closes #2740, please read that issue for my full rationale.

Added IItemhandler.getSlotLimit(int slot);
Retrofitted into all IItemHandler implementations

Breaks binary compat but I feel it's merited because
1. 1.9.x is not out of beta yet (alternatively, we can hold off til 1.9.3?)
2. IItemHandlers cannot use comparators at all which is a pretty big flaw (see issue for more details)
