### PR TITLE
Fix forge:default-tool transformation

### DIFF
--- a/src/main/java/net/minecraftforge/client/model/ForgeBlockStateV1.java
+++ b/src/main/java/net/minecraftforge/client/model/ForgeBlockStateV1.java
@@ -530,11 +530,14 @@ public class ForgeBlockStateV1 extends Marker
                         // item/handheld
                         else if (transform.equals("forge:default-tool"))
                         {
-                            ret.state = Optional.<IModelState>of(new SimpleModelState(ImmutableMap.of(
-                                TransformType.THIRD_PERSON_RIGHT_HAND, get(0, 4, 0.5f,         0, -90, 55, 0.85f),
-                                TransformType.THIRD_PERSON_LEFT_HAND,  get(0, 4, 0.5f,         0, 90, -55, 0.85f),
-                                TransformType.FIRST_PERSON_RIGHT_HAND, get(1.13f, 3.2f, 1.13f, 0, -90, 25, 0.68f),
-                                TransformType.FIRST_PERSON_LEFT_HAND,  get(1.13f, 3.2f, 1.13f, 0, 90, -25, 0.68f))));
+                            ImmutableMap.Builder<TransformType, TRSRTransformation> builder = ImmutableMap.builder();
+                            builder.put(TransformType.GROUND,                  get(0, 2, 0,            0, 0, 0,    0.5f));
+                            builder.put(TransformType.HEAD,                    get(0, 13, 7,           0, 180, 0,  1));
+                            builder.put(TransformType.THIRD_PERSON_RIGHT_HAND, get(0, 4, 0.5f,         0, -90, 55, 0.85f));
+                            builder.put(TransformType.THIRD_PERSON_LEFT_HAND,  get(0, 4, 0.5f,         0, 90, -55, 0.85f));
+                            builder.put(TransformType.FIRST_PERSON_RIGHT_HAND, get(1.13f, 3.2f, 1.13f, 0, -90, 25, 0.68f));
+                            builder.put(TransformType.FIRST_PERSON_LEFT_HAND,  get(1.13f, 3.2f, 1.13f, 0, 90, -25, 0.68f));
+                            ret.state = Optional.<IModelState>of(new SimpleModelState(builder.build()));
                         }
                         else
                         {


### PR DESCRIPTION
Currently, items that use the forge:default-tool transformation are rendered too large when in entity form:
![2016-04-30_18 25 17](https://cloud.githubusercontent.com/assets/3437174/14937224/098c8376-0f01-11e6-8d4a-c661fac31036.png)
They are twice as large as they are supposed to be.

This is because the "GROUND" transform type (and "HEAD" as well for that matter) is missing from the transformation.
In vanilla, "item/handheld" has "item/generated" as parent, so it inherits its transformations. Seems like the inherited transformations have been forgotten here.