### PR TITLE
Fixed inconsistent scrolling in the mods list and vanilla lists.

### DIFF
--- a/patches/minecraft/net/minecraft/client/gui/GuiSlot.java.patch
+++ b/patches/minecraft/net/minecraft/client/gui/GuiSlot.java.patch
@@ -18,7 +18,24 @@
              int k = this.field_148152_e + this.field_148155_a / 2 - this.func_148139_c() / 2 + 2;
              int l = this.field_148153_b + 4 - (int)this.field_148169_q;
  
-@@ -458,4 +451,18 @@
+@@ -358,7 +351,7 @@
+ 
+             int i2 = Mouse.getEventDWheel();
+ 
+-            if (i2 != 0)
++            if (false && i2 != 0)
+             {
+                 if (i2 > 0)
+                 {
+@@ -371,6 +364,7 @@
+ 
+                 this.field_148169_q += (float)(i2 * this.field_148149_f / 2);
+             }
++            if (i2 != 0) this.field_148169_q -= Math.min((i2 / 120.0F) * this.field_148149_f, (this.field_148154_c - this.field_148153_b - 4) / 4);
+         }
+     }
+ 
+@@ -458,4 +452,18 @@
      {
          return this.field_148149_f;
      }

--- a/src/main/java/net/minecraftforge/fml/client/GuiModList.java
+++ b/src/main/java/net/minecraftforge/fml/client/GuiModList.java
@@ -289,6 +289,16 @@ public class GuiModList extends GuiScreen
         super.actionPerformed(button);
     }
 
+    public void handleMouseInput() throws IOException
+    {
+        if (modList.handleMouseInput())
+            return;
+        if (modInfo != null && modInfo.handleMouseInput())
+            return;
+        
+        super.handleMouseInput();
+    }
+
     public int drawLine(String line, int offset, int shifty)
     {
         this.fontRendererObj.drawString(line, offset, shifty, 0xd7edea);
@@ -488,7 +498,7 @@ public class GuiModList extends GuiScreen
                 }
 
                 ITextComponent chat = ForgeHooks.newChatWithLinks(line, false);
-                ret.addAll(GuiUtilRenderComponents.splitText(chat, this.listWidth-8, GuiModList.this.fontRendererObj, false, true));
+                ret.addAll(GuiUtilRenderComponents.splitText(chat, this.getViewWidth(), GuiModList.this.fontRendererObj, false, true));
             }
             return ret;
         }
@@ -512,7 +522,7 @@ public class GuiModList extends GuiScreen
               height += 10;
           }
           height += (lines.size() * 10);
-          if (height < this.bottom - this.top - 8) height = this.bottom - this.top - 8;
+          //if (height < this.bottom - this.top - 8) height = this.bottom - this.top - 8;
           return height;
         }
 


### PR DESCRIPTION
This fixes the bug where a large amount of the scrolling events in GuiScrollingLists are missed due to being handled by GuiScreen instead.

The scroll amount is also now not clamped, meaning that two combined scroll events will not be treated as one. This was done to vanilla GuiSlot as well (if this is undesirable it can be removed).

The scroll speed has been limited to a quarter the height of the box per normal increment.


This also makes the scroll bar in GuiScrollingList properly fit within the vertical space (which wasn't the case with the mod info scroll box before), and always fill all but one pixel of the scroll bar when the overflow space is small enough.

I've also moved the top border height and scroll bar width into fields. These could instead be moved to constants in the class, either way is good if it fixes the magic numbers in the class. :)

There are a few functions with obfuscated names that appear to be useless now, which could be removed. Also, the fields listHeight, screenWidth and screenHeight are unused, since the Minecraft instance is used in place of those fields. Perhaps the resolution could be stored in some final fields though, because the lists are re-constructed when the window is scaled.