### PR TITLE
Only run block physics for TileEntities while capturing block placement.

### DIFF
--- a/patches/minecraft/net/minecraft/world/chunk/Chunk.java.patch
+++ b/patches/minecraft/net/minecraft/world/chunk/Chunk.java.patch
@@ -64,12 +64,14 @@
  
                      if (j1 > 0)
                      {
-@@ -595,28 +600,18 @@
+@@ -595,28 +600,19 @@
                      }
                  }
  
 -                if (block1 instanceof ITileEntityProvider)
--                {
++                // If capturing blocks, only run block physics for TE's. Non-TE's are handled in ForgeHooks.onPlaceItemIntoWorld
++                if (!this.field_76637_e.field_72995_K && block1 != block && (!this.field_76637_e.captureBlockSnapshots || block.hasTileEntity(p_177436_2_)))
+                 {
 -                    TileEntity tileentity = this.func_177424_a(p_177436_1_, Chunk.EnumCreateEntityType.CHECK);
 -
 -                    if (tileentity != null)
@@ -78,8 +80,8 @@
 -                    }
 -                }
 -
-                 if (!this.field_76637_e.field_72995_K && block1 != block)
-                 {
+-                if (!this.field_76637_e.field_72995_K && block1 != block)
+-                {
                      block.func_176213_c(this.field_76637_e, p_177436_1_, p_177436_2_);
                  }
  
@@ -95,7 +97,7 @@
                          this.field_76637_e.func_175690_a(p_177436_1_, tileentity1);
                      }
  
-@@ -719,6 +714,7 @@
+@@ -719,6 +715,7 @@
              k = this.field_76645_j.length - 1;
          }
  
@@ -103,7 +105,7 @@
          p_76612_1_.field_70175_ag = true;
          p_76612_1_.field_70176_ah = this.field_76635_g;
          p_76612_1_.field_70162_ai = k;
-@@ -758,13 +754,19 @@
+@@ -758,13 +755,19 @@
      {
          IBlockState iblockstate = this.func_177435_g(p_177422_1_);
          Block block = iblockstate.func_177230_c();
@@ -124,7 +126,7 @@
          if (tileentity == null)
          {
              if (p_177424_2_ == Chunk.EnumCreateEntityType.IMMEDIATE)
-@@ -774,14 +776,9 @@
+@@ -774,14 +777,9 @@
              }
              else if (p_177424_2_ == Chunk.EnumCreateEntityType.QUEUED)
              {
@@ -140,7 +142,7 @@
  
          return tileentity;
      }
-@@ -801,7 +798,7 @@
+@@ -801,7 +799,7 @@
          p_177426_2_.func_145834_a(this.field_76637_e);
          p_177426_2_.func_174878_a(p_177426_1_);
  
@@ -149,7 +151,7 @@
          {
              if (this.field_150816_i.containsKey(p_177426_1_))
              {
-@@ -810,6 +807,7 @@
+@@ -810,6 +808,7 @@
  
              p_177426_2_.func_145829_t();
              this.field_150816_i.put(p_177426_1_, p_177426_2_);
@@ -157,7 +159,7 @@
          }
      }
  
-@@ -838,8 +836,9 @@
+@@ -838,8 +837,9 @@
                  entity.func_110123_P();
              }
  
@@ -168,7 +170,7 @@
      }
  
      public void func_76623_d()
-@@ -855,6 +854,7 @@
+@@ -855,6 +855,7 @@
          {
              this.field_76637_e.func_175681_c(this.field_76645_j[i]);
          }
@@ -176,7 +178,7 @@
      }
  
      public void func_76630_e()
-@@ -864,8 +864,8 @@
+@@ -864,8 +865,8 @@
  
      public void func_177414_a(Entity p_177414_1_, AxisAlignedBB p_177414_2_, List<Entity> p_177414_3_, Predicate <? super Entity > p_177414_4_)
      {
@@ -187,7 +189,7 @@
          i = MathHelper.func_76125_a(i, 0, this.field_76645_j.length - 1);
          j = MathHelper.func_76125_a(j, 0, this.field_76645_j.length - 1);
  
-@@ -904,8 +904,8 @@
+@@ -904,8 +905,8 @@
  
      public <T extends Entity> void func_177430_a(Class <? extends T > p_177430_1_, AxisAlignedBB p_177430_2_, List<T> p_177430_3_, Predicate <? super T > p_177430_4_)
      {
@@ -198,7 +200,7 @@
          i = MathHelper.func_76125_a(i, 0, this.field_76645_j.length - 1);
          j = MathHelper.func_76125_a(j, 0, this.field_76645_j.length - 1);
  
-@@ -994,6 +994,7 @@
+@@ -994,6 +995,7 @@
          {
              this.func_150809_p();
              p_186034_1_.func_185931_b(this.field_76635_g, this.field_76647_h);
@@ -206,7 +208,7 @@
              this.func_76630_e();
          }
      }
-@@ -1050,7 +1051,7 @@
+@@ -1050,7 +1052,7 @@
          {
              BlockPos blockpos = (BlockPos)this.field_177447_w.poll();
  
@@ -215,7 +217,7 @@
              {
                  TileEntity tileentity = this.func_177422_i(blockpos);
                  this.field_76637_e.func_175690_a(blockpos, tileentity);
-@@ -1114,6 +1115,13 @@
+@@ -1114,6 +1116,13 @@
      @SideOnly(Side.CLIENT)
      public void func_186033_a(PacketBuffer p_186033_1_, int p_186033_2_, boolean p_186033_3_)
      {
@@ -229,7 +231,7 @@
          boolean flag = !this.field_76637_e.field_73011_w.func_177495_o();
  
          for (int i = 0; i < this.field_76652_q.length; ++i)
-@@ -1162,10 +1170,16 @@
+@@ -1162,10 +1171,16 @@
          this.field_76646_k = true;
          this.func_76590_a();
  
@@ -246,7 +248,7 @@
      }
  
      public BiomeGenBase func_177411_a(BlockPos p_177411_1_, BiomeProvider p_177411_2_)
-@@ -1233,13 +1247,13 @@
+@@ -1233,13 +1248,13 @@
                      BlockPos blockpos1 = blockpos.func_177982_a(k, (j << 4) + i1, l);
                      boolean flag = i1 == 0 || i1 == 15 || k == 0 || k == 15 || l == 0 || l == 15;
  
@@ -262,7 +264,7 @@
                              {
                                  this.field_76637_e.func_175664_x(blockpos2);
                              }
-@@ -1370,7 +1384,7 @@
+@@ -1370,7 +1385,7 @@
          {
              blockpos$mutableblockpos.func_181079_c(blockpos$mutableblockpos.func_177958_n(), l, blockpos$mutableblockpos.func_177952_p());
  
@@ -271,7 +273,7 @@
              {
                  this.field_76637_e.func_175664_x(blockpos$mutableblockpos);
              }
-@@ -1481,4 +1495,20 @@
+@@ -1481,4 +1496,20 @@
          QUEUED,
          CHECK;
      }


### PR DESCRIPTION
Currently, all blocks placed by players that are not TE's run physics twice. Blocks that contain a TileEntity are not affected due to a check in 'ForgeHooks.onPlaceItemIntoWorld'.

In order to fix the problem, 'Chunk.setBlockState' will now verify if blocks are being captured before running onBlockAdded and if so, only run physics if the block has a tileentity. This check also prevents blocks such as TNT's from running its physics (explosion) when placement event is cancelled.