### PR TITLE
Only run block physics for TileEntities while capturing block placement.

### DIFF
--- a/patches/minecraft/net/minecraft/world/chunk/Chunk.java.patch
+++ b/patches/minecraft/net/minecraft/world/chunk/Chunk.java.patch
@@ -64,12 +64,14 @@
  
                      if (j1 > 0)
                      {
-@@ -668,28 +673,18 @@
+@@ -668,28 +673,19 @@
                      }
                  }
  
 -                if (block1 instanceof ITileEntityProvider)
--                {
++                // If capturing blocks, only run block physics for TE's. Non-TE's are handled in ForgeHooks.onPlaceItemIntoWorld
++                if (!this.field_76637_e.field_72995_K && block1 != block && (!this.field_76637_e.captureBlockSnapshots || block.hasTileEntity(p_177436_2_)))
+                 {
 -                    TileEntity tileentity = this.func_177424_a(p_177436_1_, Chunk.EnumCreateEntityType.CHECK);
 -
 -                    if (tileentity != null)
@@ -78,8 +80,8 @@
 -                    }
 -                }
 -
-                 if (!this.field_76637_e.field_72995_K && block1 != block)
-                 {
+-                if (!this.field_76637_e.field_72995_K && block1 != block)
+-                {
                      block.func_176213_c(this.field_76637_e, p_177436_1_, p_177436_2_);
                  }
  
@@ -95,7 +97,7 @@
                          this.field_76637_e.func_175690_a(p_177436_1_, tileentity1);
                      }
  
-@@ -792,6 +787,7 @@
+@@ -792,6 +788,7 @@
              k = this.field_76645_j.length - 1;
          }
  
@@ -103,7 +105,7 @@
          p_76612_1_.field_70175_ag = true;
          p_76612_1_.field_70176_ah = this.field_76635_g;
          p_76612_1_.field_70162_ai = k;
-@@ -830,13 +826,20 @@
+@@ -830,13 +827,20 @@
      private TileEntity func_177422_i(BlockPos p_177422_1_)
      {
          Block block = this.func_177428_a(p_177422_1_);
@@ -125,7 +127,7 @@
          if (tileentity == null)
          {
              if (p_177424_2_ == Chunk.EnumCreateEntityType.IMMEDIATE)
-@@ -846,14 +849,9 @@
+@@ -846,14 +850,9 @@
              }
              else if (p_177424_2_ == Chunk.EnumCreateEntityType.QUEUED)
              {
@@ -141,7 +143,7 @@
  
          return tileentity;
      }
-@@ -873,7 +871,7 @@
+@@ -873,7 +872,7 @@
          p_177426_2_.func_145834_a(this.field_76637_e);
          p_177426_2_.func_174878_a(p_177426_1_);
  
@@ -150,7 +152,7 @@
          {
              if (this.field_150816_i.containsKey(p_177426_1_))
              {
-@@ -882,6 +880,7 @@
+@@ -882,6 +881,7 @@
  
              p_177426_2_.func_145829_t();
              this.field_150816_i.put(p_177426_1_, p_177426_2_);
@@ -158,7 +160,7 @@
          }
      }
  
-@@ -910,8 +909,9 @@
+@@ -910,8 +910,9 @@
                  entity.func_110123_P();
              }
  
@@ -169,7 +171,7 @@
      }
  
      public void func_76623_d()
-@@ -927,6 +927,7 @@
+@@ -927,6 +928,7 @@
          {
              this.field_76637_e.func_175681_c(this.field_76645_j[i]);
          }
@@ -177,7 +179,7 @@
      }
  
      public void func_76630_e()
-@@ -936,8 +937,8 @@
+@@ -936,8 +938,8 @@
  
      public void func_177414_a(Entity p_177414_1_, AxisAlignedBB p_177414_2_, List<Entity> p_177414_3_, Predicate <? super Entity > p_177414_4_)
      {
@@ -188,7 +190,7 @@
          i = MathHelper.func_76125_a(i, 0, this.field_76645_j.length - 1);
          j = MathHelper.func_76125_a(j, 0, this.field_76645_j.length - 1);
  
-@@ -976,8 +977,8 @@
+@@ -976,8 +978,8 @@
  
      public <T extends Entity> void func_177430_a(Class <? extends T > p_177430_1_, AxisAlignedBB p_177430_2_, List<T> p_177430_3_, Predicate <? super T > p_177430_4_)
      {
@@ -199,7 +201,7 @@
          i = MathHelper.func_76125_a(i, 0, this.field_76645_j.length - 1);
          j = MathHelper.func_76125_a(j, 0, this.field_76645_j.length - 1);
  
-@@ -1137,8 +1138,10 @@
+@@ -1137,8 +1139,10 @@
          while (!this.field_177447_w.isEmpty())
          {
              BlockPos blockpos = (BlockPos)this.field_177447_w.poll();
@@ -211,7 +213,7 @@
              {
                  TileEntity tileentity = this.func_177422_i(blockpos);
                  this.field_76637_e.func_175690_a(blockpos, tileentity);
-@@ -1200,6 +1203,13 @@
+@@ -1200,6 +1204,13 @@
      @SideOnly(Side.CLIENT)
      public void func_177439_a(byte[] p_177439_1_, int p_177439_2_, boolean p_177439_3_)
      {
@@ -225,7 +227,7 @@
          int i = 0;
          boolean flag = !this.field_76637_e.field_73011_w.func_177495_o();
  
-@@ -1267,10 +1277,16 @@
+@@ -1267,10 +1278,16 @@
          this.field_76646_k = true;
          this.func_76590_a();
  
@@ -242,7 +244,7 @@
      }
  
      public BiomeGenBase func_177411_a(BlockPos p_177411_1_, WorldChunkManager p_177411_2_)
-@@ -1583,4 +1599,20 @@
+@@ -1583,4 +1600,20 @@
          QUEUED,
          CHECK;
      }


### PR DESCRIPTION
Currently, all blocks placed by players that are not TE's run physics
twice. Blocks that contain a TileEntity are not affected due to a check in
'ForgeHooks.onPlaceItemIntoWorld'.

In order to fix the problem, 'Chunk.setBlockState' will now verify if
blocks are being captured before running onBlockAdded and if so, only run
physics if the block has a tileentity. This check also prevents blocks
such as TNT's from running its physics (explosion) when placement event is
cancelled.