### PR TITLE
Call markDirty when restoring blocks with TileEntities.

### DIFF
--- a/src/main/java/net/minecraftforge/common/util/BlockSnapshot.java
+++ b/src/main/java/net/minecraftforge/common/util/BlockSnapshot.java
@@ -178,6 +178,7 @@ public class BlockSnapshot implements Serializable
             if (te != null)
             {
                 te.readFromNBT(nbt);
+                te.markDirty();
             }
         }
 
@@ -213,6 +214,7 @@ public class BlockSnapshot implements Serializable
             if (te != null)
             {
                 te.readFromNBT(nbt);
+                te.markDirty();
             }
         }
 


### PR DESCRIPTION
This change makes sure the updated tileentity is saved properly within the
chunk during restores.