### PR TITLE
Create a poison DamageSource

### DIFF
--- a/patches/minecraft/net/minecraft/potion/Potion.java.patch
+++ b/patches/minecraft/net/minecraft/potion/Potion.java.patch
@@ -12,6 +12,15 @@
      private final Map<IAttribute, AttributeModifier> field_111188_I = Maps.<IAttribute, AttributeModifier>newHashMap();
      private final boolean field_76418_K;
      private final int field_76414_N;
+@@ -82,7 +82,7 @@
+         {
+             if (p_76394_1_.func_110143_aJ() > 1.0F)
+             {
+-                p_76394_1_.func_70097_a(DamageSource.field_76376_m, 1.0F);
++                p_76394_1_.func_70097_a(DamageSource.poison, 1.0F);
+             }
+         }
+         else if (this == MobEffects.field_82731_v)
 @@ -195,7 +195,6 @@
          return this.field_76417_J;
      }

--- a/patches/minecraft/net/minecraft/util/DamageSource.java.patch
+++ b/patches/minecraft/net/minecraft/util/DamageSource.java.patch
@@ -1,0 +1,36 @@
+--- ../src-base/minecraft/net/minecraft/util/DamageSource.java
++++ ../src-work/minecraft/net/minecraft/util/DamageSource.java
+@@ -26,6 +26,7 @@
+     public static DamageSource field_76380_i = (new DamageSource("outOfWorld")).func_76348_h().func_76359_i();
+     public static DamageSource field_76377_j = (new DamageSource("generic")).func_76348_h();
+     public static DamageSource field_76376_m = (new DamageSource("magic")).func_76348_h().func_82726_p();
++    public static DamageSource poison = (new DamageSource("magic")).func_76348_h().func_82726_p().setPoisonDamage();
+     public static DamageSource field_82727_n = (new DamageSource("wither")).func_76348_h();
+     public static DamageSource field_82728_o = new DamageSource("anvil");
+     public static DamageSource field_82729_p = new DamageSource("fallingBlock");
+@@ -38,6 +39,7 @@
+     private boolean field_76382_s;
+     private boolean field_76381_t;
+     private boolean field_82730_x;
++    private boolean poisonDamage;
+     private boolean field_76378_k;
+     public String field_76373_n;
+ 
+@@ -214,6 +216,17 @@
+         return this;
+     }
+ 
++    public boolean isPoisonDamage()
++    {
++        return this.poisonDamage;
++    }
++
++    public DamageSource setPoisonDamage()
++    {
++        this.poisonDamage = true;
++        return this;
++    }
++    
+     public boolean func_180136_u()
+     {
+         Entity entity = this.func_76346_g();


### PR DESCRIPTION
Problem:
Currently there is no (known to me & reasonable) way to differentiate Poison damage from other Magic damage. If you were planning on creating an item/effect/whatever that reduced poison damage, you'd have no way of knowing whether the damage received is poison or some other magic. The same applies for armor that should cancel Harming Splash Potions' damage, but not poison. This is particularly noticeable if a player is engaged with a Witch, once the Poison Potion Effect is in place it is difficult to determine what damage is from Poison or Harming Potions. 
_(Note: when speaking of just Vanilla, poison damage is only given as 1.0 health; so reducing it proportionally is not strictly useful until mods come into play. An item that has a chance to cancel poison damage is still applicable to Vanilla though.)_

This Solution:
Add `DamageSource.poison` for use as poison damage, and update Potion to use it.
To preserve compatibility, the new DamageSource is also a magic damage source: `DamageSource.poison.getDamageType()` returns `"magic"` and `DamageSource.isMagicDamage()` returns `true`.
This is compatible with existing vanilla code and should be compatible with mods' code,  unless the mod compares against `DamageSource.magic` directly.


