### PR TITLE
[1.9] New LivingUpdateBlockEvent for handling entities (excluding player) updating block states

### DIFF
--- a/patches/minecraft/net/minecraft/entity/ai/EntityAIBreakDoor.java.patch
+++ b/patches/minecraft/net/minecraft/entity/ai/EntityAIBreakDoor.java.patch
@@ -1,0 +1,11 @@
+--- ../src-base/minecraft/net/minecraft/entity/ai/EntityAIBreakDoor.java
++++ ../src-work/minecraft/net/minecraft/entity/ai/EntityAIBreakDoor.java
+@@ -82,7 +82,7 @@
+             this.field_75358_j = i;
+         }
+ 
+-        if (this.field_75359_i == 240 && this.field_75356_a.field_70170_p.func_175659_aa() == EnumDifficulty.HARD)
++        if (this.field_75359_i == 240 && this.field_75356_a.field_70170_p.func_175659_aa() == EnumDifficulty.HARD && !net.minecraftforge.event.ForgeEventFactory.onLivingUpdateBlock(field_75356_a, field_179507_b, net.minecraft.init.Blocks.field_150350_a.func_176223_P()))
+         {
+             this.field_75356_a.field_70170_p.func_175698_g(this.field_179507_b);
+             this.field_75356_a.field_70170_p.func_175718_b(1021, this.field_179507_b, 0);

--- a/patches/minecraft/net/minecraft/entity/ai/EntityAIEatGrass.java.patch
+++ b/patches/minecraft/net/minecraft/entity/ai/EntityAIEatGrass.java.patch
@@ -1,0 +1,20 @@
+--- ../src-base/minecraft/net/minecraft/entity/ai/EntityAIEatGrass.java
++++ ../src-work/minecraft/net/minecraft/entity/ai/EntityAIEatGrass.java
+@@ -70,7 +70,7 @@
+ 
+             if (field_179505_b.apply(this.field_151501_c.func_180495_p(blockpos)))
+             {
+-                if (this.field_151501_c.func_82736_K().func_82766_b("mobGriefing"))
++                if (this.field_151501_c.func_82736_K().func_82766_b("mobGriefing") && !net.minecraftforge.event.ForgeEventFactory.onLivingUpdateBlock(field_151500_b, blockpos, Blocks.field_150350_a.func_176223_P()))
+                 {
+                     this.field_151501_c.func_175655_b(blockpos, false);
+                 }
+@@ -83,7 +83,7 @@
+ 
+                 if (this.field_151501_c.func_180495_p(blockpos1).func_177230_c() == Blocks.field_150349_c)
+                 {
+-                    if (this.field_151501_c.func_82736_K().func_82766_b("mobGriefing"))
++                    if (this.field_151501_c.func_82736_K().func_82766_b("mobGriefing") && !net.minecraftforge.event.ForgeEventFactory.onLivingUpdateBlock(field_151500_b, blockpos, Blocks.field_150346_d.func_176223_P()))
+                     {
+                         this.field_151501_c.func_175718_b(2001, blockpos1, Block.func_149682_b(Blocks.field_150349_c));
+                         this.field_151501_c.func_180501_a(blockpos1, Blocks.field_150346_d.func_176223_P(), 2);

--- a/patches/minecraft/net/minecraft/entity/ai/EntityAIHarvestFarmland.java.patch
+++ b/patches/minecraft/net/minecraft/entity/ai/EntityAIHarvestFarmland.java.patch
@@ -1,0 +1,38 @@
+--- ../src-base/minecraft/net/minecraft/entity/ai/EntityAIHarvestFarmland.java
++++ ../src-work/minecraft/net/minecraft/entity/ai/EntityAIHarvestFarmland.java
+@@ -68,7 +68,7 @@
+             IBlockState iblockstate = world.func_180495_p(blockpos);
+             Block block = iblockstate.func_177230_c();
+ 
+-            if (this.field_179501_f == 0 && block instanceof BlockCrops && ((BlockCrops)block).func_185525_y(iblockstate))
++            if (this.field_179501_f == 0 && block instanceof BlockCrops && ((BlockCrops)block).func_185525_y(iblockstate) && !net.minecraftforge.event.ForgeEventFactory.onLivingUpdateBlock(field_179504_c, blockpos, Blocks.field_150350_a.func_176223_P()))
+             {
+                 world.func_175655_b(blockpos, true);
+             }
+@@ -83,22 +83,22 @@
+ 
+                     if (itemstack != null)
+                     {
+-                        if (itemstack.func_77973_b() == Items.field_151014_N)
++                        if (itemstack.func_77973_b() == Items.field_151014_N && !net.minecraftforge.event.ForgeEventFactory.onLivingUpdateBlock(field_179504_c, blockpos, Blocks.field_150464_aj.func_176223_P()))
+                         {
+                             world.func_180501_a(blockpos, Blocks.field_150464_aj.func_176223_P(), 3);
+                             flag = true;
+                         }
+-                        else if (itemstack.func_77973_b() == Items.field_151174_bG)
++                        else if (itemstack.func_77973_b() == Items.field_151174_bG && !net.minecraftforge.event.ForgeEventFactory.onLivingUpdateBlock(field_179504_c, blockpos, Blocks.field_150469_bN.func_176223_P()))
+                         {
+                             world.func_180501_a(blockpos, Blocks.field_150469_bN.func_176223_P(), 3);
+                             flag = true;
+                         }
+-                        else if (itemstack.func_77973_b() == Items.field_151172_bF)
++                        else if (itemstack.func_77973_b() == Items.field_151172_bF && !net.minecraftforge.event.ForgeEventFactory.onLivingUpdateBlock(field_179504_c, blockpos, Blocks.field_150459_bM.func_176223_P()))
+                         {
+                             world.func_180501_a(blockpos, Blocks.field_150459_bM.func_176223_P(), 3);
+                             flag = true;
+                         }
+-                        else if (itemstack.func_77973_b() == Items.field_185163_cU)
++                        else if (itemstack.func_77973_b() == Items.field_185163_cU && !net.minecraftforge.event.ForgeEventFactory.onLivingUpdateBlock(field_179504_c, blockpos, Blocks.field_185773_cZ.func_176223_P()))
+                         {
+                             world.func_180501_a(blockpos, Blocks.field_185773_cZ.func_176223_P(), 3);
+                             flag = true;

--- a/patches/minecraft/net/minecraft/entity/boss/EntityDragon.java.patch
+++ b/patches/minecraft/net/minecraft/entity/boss/EntityDragon.java.patch
@@ -1,6 +1,6 @@
 --- ../src-base/minecraft/net/minecraft/entity/boss/EntityDragon.java
 +++ ../src-work/minecraft/net/minecraft/entity/boss/EntityDragon.java
-@@ -474,13 +474,13 @@
+@@ -474,16 +474,17 @@
                      IBlockState iblockstate = this.field_70170_p.func_180495_p(blockpos);
                      Block block = iblockstate.func_177230_c();
  
@@ -16,3 +16,7 @@
                          {
                              if (block != Blocks.field_150483_bI && block != Blocks.field_185776_dc && block != Blocks.field_185777_dd && block != Blocks.field_150411_aY && block != Blocks.field_185775_db)
                              {
++                                if(!net.minecraftforge.event.ForgeEventFactory.onLivingUpdateBlock(this, blockpos, Blocks.field_150350_a.func_176223_P()))
+                                 flag1 = this.field_70170_p.func_175698_g(blockpos) || flag1;
+                             }
+                             else

--- a/patches/minecraft/net/minecraft/entity/boss/EntityWither.java.patch
+++ b/patches/minecraft/net/minecraft/entity/boss/EntityWither.java.patch
@@ -5,7 +5,7 @@
                                  Block block = iblockstate.func_177230_c();
  
 -                                if (iblockstate.func_185904_a() != Material.field_151579_a && func_181033_a(block))
-+                                if (!block.isAir(iblockstate, this.field_70170_p, blockpos) && block.canEntityDestroy(iblockstate, field_70170_p, blockpos, this))
++                                if (!block.isAir(iblockstate, this.field_70170_p, blockpos) && block.canEntityDestroy(iblockstate, field_70170_p, blockpos, this) && !net.minecraftforge.event.ForgeEventFactory.onLivingUpdateBlock(this, blockpos, Blocks.field_150350_a.func_176223_P()))
                                  {
                                      flag = this.field_70170_p.func_175655_b(blockpos, true) || flag;
                                  }

--- a/patches/minecraft/net/minecraft/entity/monster/EntityEnderman.java.patch
+++ b/patches/minecraft/net/minecraft/entity/monster/EntityEnderman.java.patch
@@ -30,3 +30,21 @@
      public boolean func_70823_r()
      {
          return ((Boolean)this.field_70180_af.func_187225_a(field_184719_bw)).booleanValue();
+@@ -484,7 +498,7 @@
+                 IBlockState iblockstate1 = world.func_180495_p(blockpos.func_177977_b());
+                 IBlockState iblockstate2 = this.field_179475_a.func_175489_ck();
+ 
+-                if (iblockstate2 != null && this.func_188518_a(world, blockpos, iblockstate2.func_177230_c(), iblockstate, iblockstate1))
++                if (iblockstate2 != null && this.func_188518_a(world, blockpos, iblockstate2.func_177230_c(), iblockstate, iblockstate1) && !net.minecraftforge.event.ForgeEventFactory.onLivingUpdateBlock(field_179475_a, blockpos, iblockstate2))
+                 {
+                     world.func_180501_a(blockpos, iblockstate2, 3);
+                     this.field_179475_a.func_175490_a((IBlockState)null);
+@@ -524,7 +538,7 @@
+                 RayTraceResult raytraceresult = world.func_147447_a(new Vec3d((double)((float)MathHelper.func_76128_c(this.field_179473_a.field_70165_t) + 0.5F), (double)((float)j + 0.5F), (double)((float)MathHelper.func_76128_c(this.field_179473_a.field_70161_v) + 0.5F)), new Vec3d((double)((float)i + 0.5F), (double)((float)j + 0.5F), (double)((float)k + 0.5F)), false, true, false);
+                 boolean flag = raytraceresult != null && raytraceresult.func_178782_a().equals(blockpos);
+ 
+-                if (EntityEnderman.field_70827_d.contains(block) && flag)
++                if (EntityEnderman.field_70827_d.contains(block) && flag && !net.minecraftforge.event.ForgeEventFactory.onLivingUpdateBlock(field_179473_a, blockpos, Blocks.field_150350_a.func_176223_P()))
+                 {
+                     this.field_179473_a.func_175490_a(iblockstate);
+                     world.func_175698_g(blockpos);

--- a/patches/minecraft/net/minecraft/entity/monster/EntitySilverfish.java.patch
+++ b/patches/minecraft/net/minecraft/entity/monster/EntitySilverfish.java.patch
@@ -1,0 +1,29 @@
+--- ../src-base/minecraft/net/minecraft/entity/monster/EntitySilverfish.java
++++ ../src-work/minecraft/net/minecraft/entity/monster/EntitySilverfish.java
+@@ -209,9 +209,10 @@
+                     BlockPos blockpos = (new BlockPos(this.field_179485_a.field_70165_t, this.field_179485_a.field_70163_u + 0.5D, this.field_179485_a.field_70161_v)).func_177972_a(this.field_179483_b);
+                     IBlockState iblockstate = world.func_180495_p(blockpos);
+ 
+-                    if (BlockSilverfish.func_176377_d(iblockstate))
++                    IBlockState state = Blocks.field_150418_aU.func_176223_P().func_177226_a(BlockSilverfish.field_176378_a, BlockSilverfish.EnumType.func_176878_a(iblockstate));
++                    if (BlockSilverfish.func_176377_d(iblockstate) && !net.minecraftforge.event.ForgeEventFactory.onLivingUpdateBlock(field_179485_a, blockpos, state))
+                     {
+-                        world.func_180501_a(blockpos, Blocks.field_150418_aU.func_176223_P().func_177226_a(BlockSilverfish.field_176378_a, BlockSilverfish.EnumType.func_176878_a(iblockstate)), 3);
++                        world.func_180501_a(blockpos, state, 3);
+                         this.field_179485_a.func_70656_aK();
+                         this.field_179485_a.func_70106_y();
+                     }
+@@ -263,11 +264,11 @@
+ 
+                                 if (iblockstate.func_177230_c() == Blocks.field_150418_aU)
+                                 {
+-                                    if (world.func_82736_K().func_82766_b("mobGriefing"))
++                                    if (world.func_82736_K().func_82766_b("mobGriefing") && !net.minecraftforge.event.ForgeEventFactory.onLivingUpdateBlock(field_179464_a, blockpos1, Blocks.field_150350_a.func_176223_P()))
+                                     {
+                                         world.func_175655_b(blockpos1, true);
+                                     }
+-                                    else
++                                    else if(!net.minecraftforge.event.ForgeEventFactory.onLivingUpdateBlock(field_179464_a, blockpos1, ((BlockSilverfish.EnumType)iblockstate.func_177229_b(BlockSilverfish.field_176378_a)).func_176883_d()))
+                                     {
+                                         world.func_180501_a(blockpos1, ((BlockSilverfish.EnumType)iblockstate.func_177229_b(BlockSilverfish.field_176378_a)).func_176883_d(), 3);
+                                     }

--- a/patches/minecraft/net/minecraft/entity/monster/EntitySnowman.java.patch
+++ b/patches/minecraft/net/minecraft/entity/monster/EntitySnowman.java.patch
@@ -1,0 +1,11 @@
+--- ../src-base/minecraft/net/minecraft/entity/monster/EntitySnowman.java
++++ ../src-work/minecraft/net/minecraft/entity/monster/EntitySnowman.java
+@@ -92,7 +92,7 @@
+                 k = MathHelper.func_76128_c(this.field_70161_v + (double)((float)(l / 2 % 2 * 2 - 1) * 0.25F));
+                 BlockPos blockpos = new BlockPos(i, j, k);
+ 
+-                if (this.field_70170_p.func_180495_p(blockpos).func_185904_a() == Material.field_151579_a && this.field_70170_p.func_180494_b(new BlockPos(i, 0, k)).func_180626_a(blockpos) < 0.8F && Blocks.field_150431_aC.func_176196_c(this.field_70170_p, blockpos))
++                if (this.field_70170_p.func_180495_p(blockpos).func_185904_a() == Material.field_151579_a && this.field_70170_p.func_180494_b(new BlockPos(i, 0, k)).func_180626_a(blockpos) < 0.8F && Blocks.field_150431_aC.func_176196_c(this.field_70170_p, blockpos) && !net.minecraftforge.event.ForgeEventFactory.onLivingUpdateBlock(this, blockpos, Blocks.field_150431_aC.func_176223_P()))
+                 {
+                     this.field_70170_p.func_175656_a(blockpos, Blocks.field_150431_aC.func_176223_P());
+                 }

--- a/patches/minecraft/net/minecraft/entity/passive/EntityRabbit.java.patch
+++ b/patches/minecraft/net/minecraft/entity/passive/EntityRabbit.java.patch
@@ -1,0 +1,25 @@
+--- ../src-base/minecraft/net/minecraft/entity/passive/EntityRabbit.java
++++ ../src-work/minecraft/net/minecraft/entity/passive/EntityRabbit.java
+@@ -578,15 +578,19 @@
+                     {
+                         Integer integer = (Integer)iblockstate.func_177229_b(BlockCarrot.field_176488_a);
+ 
+-                        if (integer.intValue() == 0)
++                        if (integer.intValue() == 0 && !net.minecraftforge.event.ForgeEventFactory.onLivingUpdateBlock(field_179500_c, blockpos, Blocks.field_150350_a.func_176223_P()))
+                         {
+                             world.func_180501_a(blockpos, Blocks.field_150350_a.func_176223_P(), 2);
+                             world.func_175655_b(blockpos, true);
+                         }
+                         else
+                         {
+-                            world.func_180501_a(blockpos, iblockstate.func_177226_a(BlockCarrot.field_176488_a, Integer.valueOf(integer.intValue() - 1)), 2);
+-                            world.func_175718_b(2001, blockpos, Block.func_176210_f(iblockstate));
++                            IBlockState state = iblockstate.func_177226_a(BlockCarrot.field_176488_a, Integer.valueOf(integer.intValue() - 1));
++                            if(!net.minecraftforge.event.ForgeEventFactory.onLivingUpdateBlock(field_179500_c, blockpos, state))
++                            {
++                                world.func_180501_a(blockpos, state, 2);
++                                world.func_175718_b(2001, blockpos, Block.func_176210_f(iblockstate));
++                            }
+                         }
+ 
+                         this.field_179500_c.func_175528_cn();

--- a/src/main/java/net/minecraftforge/event/ForgeEventFactory.java
+++ b/src/main/java/net/minecraftforge/event/ForgeEventFactory.java
@@ -27,7 +27,6 @@ import net.minecraft.util.SoundCategory;
 import net.minecraft.util.SoundEvent;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.RayTraceResult;
-import net.minecraft.util.math.Vec3d;
 import net.minecraft.util.text.ITextComponent;
 import net.minecraft.world.Explosion;
 import net.minecraft.world.World;
@@ -56,6 +55,7 @@ import net.minecraftforge.event.entity.living.LivingExperienceDropEvent;
 import net.minecraftforge.event.entity.living.LivingHealEvent;
 import net.minecraftforge.event.entity.living.LivingPackSizeEvent;
 import net.minecraftforge.event.entity.living.LivingSpawnEvent;
+import net.minecraftforge.event.entity.living.LivingUpdateBlockEvent;
 import net.minecraftforge.event.entity.living.LivingSpawnEvent.AllowDespawn;
 import net.minecraftforge.event.entity.living.ZombieEvent.SummonAidEvent;
 import net.minecraftforge.event.entity.player.ArrowLooseEvent;
@@ -528,6 +528,12 @@ public class ForgeEventFactory
     public static void onChunkPopulate(boolean pre, IChunkGenerator gen, World world, int x, int z, boolean hasVillageGenerated)
     {
         MinecraftForge.EVENT_BUS.post(pre ? new PopulateChunkEvent.Pre(gen, world, world.rand, x, z, hasVillageGenerated) : new PopulateChunkEvent.Post(gen, world, world.rand, x, z, hasVillageGenerated));
+    }
+    
+    public static boolean onLivingUpdateBlock(EntityLivingBase entity, BlockPos pos, IBlockState state)
+    {
+        LivingUpdateBlockEvent event = new LivingUpdateBlockEvent(entity, pos, state);
+        return MinecraftForge.EVENT_BUS.post(event);
     }
 
 }

--- a/src/main/java/net/minecraftforge/event/entity/living/LivingUpdateBlockEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/living/LivingUpdateBlockEvent.java
@@ -1,0 +1,64 @@
+package net.minecraftforge.event.entity.living;
+
+import net.minecraft.block.state.IBlockState;
+import net.minecraft.entity.EntityLivingBase;
+import net.minecraft.util.math.BlockPos;
+import net.minecraftforge.common.MinecraftForge;
+import net.minecraftforge.fml.common.eventhandler.Cancelable;
+
+/**
+ * LivingUpdateBlockEvent is fired whenever a living Entity (excluding player) changes or replaces block state. <br>
+ * <br>
+ * Entities which can trigger this event: Sheep, EnderDragon, Enderman, Rabbit, Silverfish, Wither, Zombie, Snowman and Villager (Farmer)
+ * <br>
+ * This event is fired in these methods: <br>
+ * <ul>
+ *     <li>{@link net.minecraft.entity.monster.EntityEnderman.AIPlaceBlock#updateTask()}</li>
+ *     <li>{@link net.minecraft.entity.monster.EntityEnderman.AITakeBlock#updateTask()}</li>
+ *     <li>{@link net.minecraft.entity.ai.EntityAIEatGrass#updateTask()}</li>
+ *     <li>{@link net.minecraft.entity.boss.EntityDragon#destroyBlocksInAABB()}</li>
+ *     <li>{@link net.minecraft.entity.passive.EntityRabbit.AIRaidFarm#updateTask()}</li>
+ *     <li>{@link net.minecraft.entity.monster.EntitySilverfish.AISummonSilverfish#updateTask()}</li>
+ *     <li>{@link net.minecraft.entity.monster.EntitySilverfish.AIHideInStone#startExecuting()}</li>
+ *     <li>{@link net.minecraft.entity.boss.EntityWither#updateAITasks()}</li>
+ *     <li>{@link net.minecraft.entity.ai.EntityAIBreakDoor#updateTask()}</li>
+ *     <li>{@link net.minecraft.entity.ai.EntityAIHarvestFarmland#updateTask()}</li>
+ *     <li>{@link net.minecraft.entity.monster.EntitySnowman#onLivingUpdate()}>
+ * </ul>
+ * <br>
+ * {@link #pos} contains position of the block which being updated/replaced<br>
+ * {@link #block} contains new state of the block.<br>
+ * <br>
+ * This event is {@link Cancelable}.<br>
+ * If this event is canceled, block is not updated.<br>
+ * Be aware that some entities will try to update block even if it was canceled on previous tick <br>
+ * <br>
+ * This event does not have a result. {@link HasResult}<br>
+ * <br>
+ * This event is fired on the {@link MinecraftForge#EVENT_BUS}.
+ **/
+@Cancelable
+public class LivingUpdateBlockEvent extends LivingEvent
+{
+
+    private final BlockPos pos;
+    private final IBlockState block;
+
+    public LivingUpdateBlockEvent(EntityLivingBase entity, BlockPos pos, IBlockState block)
+    {
+        super(entity);
+        this.pos = pos;
+        this.block = block;
+    }
+
+    public BlockPos getPos()
+    {
+        return pos;
+    }
+
+    public IBlockState getBlock()
+    {
+        return block;
+    }
+    
+}

--- a/src/test/java/net/minecraftforge/test/LivingUpdateBlockEventTest.java
+++ b/src/test/java/net/minecraftforge/test/LivingUpdateBlockEventTest.java
@@ -1,0 +1,35 @@
+package net.minecraftforge.test;
+
+import net.minecraft.block.Block;
+import net.minecraft.entity.boss.EntityDragon;
+import net.minecraft.init.Blocks;
+import net.minecraftforge.common.MinecraftForge;
+import net.minecraftforge.event.entity.living.LivingUpdateBlockEvent;
+import net.minecraftforge.fml.common.Mod;
+import net.minecraftforge.fml.common.Mod.EventHandler;
+import net.minecraftforge.fml.common.event.FMLInitializationEvent;
+import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
+
+@Mod(modid="livingupdateblocktest", name="Living Update Block Event", version="0.0.0")
+public class LivingUpdateBlockEventTest 
+{
+ 
+    //because this test can generate a large amount of output, by default it is turned off
+    private static final boolean DEBUG_OUTPUT = false;
+    
+    @EventHandler
+    public void init(FMLInitializationEvent event) 
+    {
+        MinecraftForge.EVENT_BUS.register(this);
+    }
+    
+    @SubscribeEvent
+    public void onEntityBlockChange(LivingUpdateBlockEvent event)
+    {
+        if(DEBUG_OUTPUT)
+            System.out.printf("%s tried to change block to %s at %s\n", 
+                    event.getEntityLiving().getName(), Block.blockRegistry.getNameForObject(event.getBlock().getBlock()).getResourcePath(), event.getPos());
+        event.getEntity().worldObj.setBlockState(event.getPos(), Blocks.gold_block.getDefaultState());
+        event.setCanceled(true);
+    }
+}


### PR DESCRIPTION
This is a copy of #2737 but for `master` branch

Currently, there is no way we can catch or prevent block updates by entities, such as sheeps, endermans, zombies or others.

This PR adds the new event which is triggered right before entity tries to update or replace the block.
What it covers:
- Enderman trying to take or place block
- Sheep trying to change block to dirt or destroy long grass
- Ender Dragon trying to destroy blocks which he is flying through
- Silverfish trying to hide into stone
- Zombie trying to break the door
- Wither trying to destroy blocks which he is flying through
- Rabbit trying to eat carrot
- Villager trying to harvest farmland
- Snowman trying to place snow layer block when he is moving

What it doesn't cover:
- It will not fire for any explosions caused by entities such as Creeper or spawning Wither because there is already an event for explosions

Canceling of this event will prevent any of changes to happen.

If you have any ideas what entities can also trigger block changes please tell me.

Thanks!