### PR TITLE
Add General way to create a DamageSource for a PotionEffect

### DIFF
--- a/patches/minecraft/net/minecraft/potion/Potion.java.patch
+++ b/patches/minecraft/net/minecraft/potion/Potion.java.patch
@@ -12,6 +12,15 @@
      private final Map<IAttribute, AttributeModifier> field_111188_I = Maps.<IAttribute, AttributeModifier>newHashMap();
      private final boolean field_76418_K;
      private final int field_76414_N;
+@@ -82,7 +82,7 @@
+         {
+             if (p_76394_1_.func_110143_aJ() > 1.0F)
+             {
+-                p_76394_1_.func_70097_a(DamageSource.field_76376_m, 1.0F);
++                p_76394_1_.func_70097_a(DamageSource.causePotionEffectDamage(MobEffects.field_76436_u), 1.0F);
+             }
+         }
+         else if (this == MobEffects.field_82731_v)
 @@ -195,7 +195,6 @@
          return this.field_76417_J;
      }

--- a/patches/minecraft/net/minecraft/util/DamageSource.java.patch
+++ b/patches/minecraft/net/minecraft/util/DamageSource.java.patch
@@ -1,0 +1,50 @@
+--- ../src-base/minecraft/net/minecraft/util/DamageSource.java
++++ ../src-work/minecraft/net/minecraft/util/DamageSource.java
+@@ -39,6 +39,7 @@
+     private boolean field_76381_t;
+     private boolean field_82730_x;
+     private boolean field_76378_k;
++    final private net.minecraft.potion.Potion potion;
+     public String field_76373_n;
+ 
+     public static DamageSource func_76358_a(EntityLivingBase p_76358_0_)
+@@ -91,6 +92,11 @@
+         return p_188405_0_ != null ? (new EntityDamageSource("explosion.player", p_188405_0_)).func_76351_m().func_94540_d() : (new DamageSource("explosion")).func_76351_m().func_94540_d();
+     }
+ 
++    public static DamageSource causePotionEffectDamage(net.minecraft.potion.Potion potion)
++    {
++        return (new DamageSource(potion == net.minecraft.init.MobEffects.field_76436_u ? "magic" : potion.getRegistryName().func_110624_b() + "." + potion.getRegistryName().func_110623_a(), potion)).func_76348_h().func_82726_p();
++    }
++
+     public boolean func_76352_a()
+     {
+         return this.field_76382_s;
+@@ -136,8 +142,15 @@
+     public DamageSource(String p_i1566_1_)
+     {
+         this.field_76373_n = p_i1566_1_;
++        this.potion = null;
+     }
+ 
++    public DamageSource(String damageTypeIn, net.minecraft.potion.Potion potion)
++    {
++        this.field_76373_n = damageTypeIn;
++        this.potion = potion;
++    }
++
+     public Entity func_76364_f()
+     {
+         return this.func_76346_g();
+@@ -148,6 +161,11 @@
+         return null;
+     }
+ 
++    public net.minecraft.potion.Potion getPotion()
++    {
++       return potion;
++    }
++
+     public DamageSource func_76348_h()
+     {
+         this.field_76374_o = true;


### PR DESCRIPTION
**Problem:**
Currently there is no (known to me & reasonable) way to differentiate Poison damage from other Magic damage. If you were planning on creating an item/effect/whatever that reduced poison damage, you'd have no way of knowing whether the damage received is poison or some other magic. The same applies for armor that should cancel Harming Splash Potions' damage, but not poison. This is particularly noticeable if a player is engaged with a Witch, once the Poison Potion Effect is in place it is difficult to determine what damage is from Poison or Harming Potions. 

**Solution:**
This replaces PR #2812 with a more general way of of creating a DamageSource linked to a Potion.

This adds `DamageSource.causePotionEffectDamage(Potion)` which will create a DamageSource with the same properties as the current magic/poison DamageDource (`DamageSource.magic`). It will also create a damage type string based upon the Potion's Regristry Name, using the format "<resourceDomain>.<resourcePath>". (Exception: Vanilla Poison uses the damage type "magic" to preserve compatibility.

This also adds a `DamageSource#getPotion()` method for determining which Potion caused the damage. This will return null when not a Potion Effect DamageSource.  

Additionally this changes the Poison Potion to use the new method, rather than   `DamageSource.magic`.

**Caveats/Oddities:**

I am using the terms "Potion" and "PotionEffect" here in perhaps a confusing way. The intention of this PR is to provide a way to determine damage caused by a PotionEffect from other magic damage  (specifically, Vanilla Poison damage, mods can solve this problem for their own PotionEffects as it stands now). I cannot however use  a reference to the PotionEffect in the code, as the point at which the damage is applied does not have this (`Potion#PerformAffect(EntityLivingBase, int)`). I keep the wording "PotionEffect" to indicate that this is not applicable for Thrown or Lingering Potions.

The Wither DamamageSource (`DamageSource.wither`) is also used from `Potion#PerformAffect` in the same way as Poison, however it cannot (simply) be done in the general way, as it has different properties from Poison (it is not considered magic damage).