### PR TITLE
[1.9] Granting modders access to the villager trades and fixes issues with villager names.

### DIFF
--- a/patches/minecraft/net/minecraft/entity/passive/EntityVillager.java.patch
+++ b/patches/minecraft/net/minecraft/entity/passive/EntityVillager.java.patch
@@ -120,7 +120,7 @@
              this.field_175562_bw = 1;
          }
  
-@@ -552,7 +596,7 @@
+@@ -552,11 +596,11 @@
  
          int i = this.field_175563_bv - 1;
          int j = this.field_175562_bw - 1;
@@ -129,6 +129,11 @@
  
          if (j >= 0 && j < aentityvillager$itradelist1.length)
          {
+-            EntityVillager.ITradeList[] aentityvillager$itradelist2 = aentityvillager$itradelist1[j];
++            EntityVillager.ITradeList[] aentityvillager$itradelist2 = net.minecraftforge.common.ForgeHooks.onVillagerTradePopulation(this, this.field_175563_bv - 1, aentityvillager$itradelist1[j]);
+ 
+             for (EntityVillager.ITradeList entityvillager$itradelist : aentityvillager$itradelist2)
+             {
 @@ -647,9 +691,14 @@
                      }
              }

--- a/patches/minecraft/net/minecraft/entity/passive/EntityVillager.java.patch
+++ b/patches/minecraft/net/minecraft/entity/passive/EntityVillager.java.patch
@@ -134,15 +134,11 @@
  
              for (EntityVillager.ITradeList entityvillager$itradelist : aentityvillager$itradelist2)
              {
-@@ -647,9 +691,14 @@
+@@ -647,9 +691,10 @@
                      }
              }
  
-+            if (s1 == null)
-+                s1 = this.getProfessionForge().getCareer(this.field_175563_bv).getName();
-+            else
-+                s1 = "entity.Villager." + s1;
-+            //TODO: Hook into VillagerRegistry to get name
++            s1 = this.getProfessionForge().getCareer(this.field_175563_bv - 1).getUnlocalizedName();
              if (s1 != null)
              {
 -                TextComponentTranslation textcomponenttranslation = new TextComponentTranslation("entity.Villager." + s1, new Object[0]);
@@ -150,7 +146,7 @@
                  textcomponenttranslation.func_150256_b().func_150209_a(this.func_174823_aP());
                  textcomponenttranslation.func_150256_b().func_179989_a(this.func_110124_au().toString());
  
-@@ -708,7 +757,7 @@
+@@ -708,7 +753,7 @@
      public IEntityLivingData func_180482_a(DifficultyInstance p_180482_1_, IEntityLivingData p_180482_2_)
      {
          p_180482_2_ = super.func_180482_a(p_180482_1_, p_180482_2_);

--- a/src/main/java/net/minecraftforge/common/ForgeHooks.java
+++ b/src/main/java/net/minecraftforge/common/ForgeHooks.java
@@ -17,6 +17,7 @@ import com.google.common.collect.Sets;
 import com.google.gson.Gson;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParseException;
+import com.google.common.collect.Lists;
 
 import net.minecraft.block.Block;
 import net.minecraft.block.BlockLiquid;
@@ -29,6 +30,8 @@ import net.minecraft.entity.EntityList;
 import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.entity.item.EntityItem;
 import net.minecraft.entity.item.EntityMinecartContainer;
+import net.minecraft.entity.passive.EntityVillager;
+import net.minecraft.entity.passive.EntityVillager.ITradeList;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraft.entity.player.InventoryPlayer;
@@ -90,6 +93,7 @@ import net.minecraftforge.event.entity.living.LivingEvent.LivingUpdateEvent;
 import net.minecraftforge.event.entity.living.LivingFallEvent;
 import net.minecraftforge.event.entity.living.LivingHurtEvent;
 import net.minecraftforge.event.entity.living.LivingSetAttackTargetEvent;
+import net.minecraftforge.event.entity.living.VillagerTradePopulationEvent;
 import net.minecraftforge.event.entity.player.AnvilRepairEvent;
 import net.minecraftforge.event.entity.player.AttackEntityEvent;
 import net.minecraftforge.event.entity.player.PlayerInteractEvent;
@@ -1113,4 +1117,11 @@ public class ForgeHooks
     //TODO: Some registry to support custom LootEntry types?
     public static LootEntry deserializeJsonLootEntry(String type, JsonObject json, int weight, int quality, LootCondition[] conditions){ return null; }
     public static String getLootEntryType(LootEntry entry){ return null; } //Companion to above function
+    
+    public static ITradeList[] onVillagerTradePopulation(EntityVillager villager, int forgeCareerID, ITradeList[] originalTrades)
+    {
+        VillagerTradePopulationEvent event = new VillagerTradePopulationEvent(villager, villager.getProfessionForge().getCareer(forgeCareerID), Lists.newArrayList(originalTrades));
+        MinecraftForge.EVENT_BUS.post(event);
+        return event.getTrades().toArray(new ITradeList[]{});
+    }
 }

--- a/src/main/java/net/minecraftforge/event/entity/living/VillagerTradePopulationEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/living/VillagerTradePopulationEvent.java
@@ -1,0 +1,64 @@
+package net.minecraftforge.event.entity.living;
+
+import java.util.List;
+import net.minecraft.entity.passive.EntityVillager;
+import net.minecraft.entity.passive.EntityVillager.ITradeList;
+import net.minecraftforge.fml.common.eventhandler.Cancelable;
+import net.minecraftforge.fml.common.eventhandler.Event;
+import net.minecraftforge.fml.common.eventhandler.Event.HasResult;
+import net.minecraftforge.fml.common.registry.VillagerRegistry.VillagerCareer;
+
+/**
+ * The VillagerTradePopulationEvent is fired when the trades are populated<br>
+ * in {@link EntityVillager#populateBuyingList()}.<br>
+ * It allows the modder to modify the trades of an individual Villager.<br>
+ * This event is fired via the {@link ForgeHooks#onVillagerTradePopulation}.<br>
+ * {@link #villager} contains the villager the trades are applied to.<br>
+ * {@link #career} contains the villager's careerr.<br>
+ * {@link #trades} contains the trades the villager wil get<br>
+ * <br>
+ * This event is not {@link Cancelable}.<br>
+ * This event does not have a result. {@link HasResult}<br>
+ * The modifications are made to the given list in {@link #trades}.
+ *<br>
+ * This event is fired on the {@link MinecraftForge#EVENT_BUS}.
+ */
+public class VillagerTradePopulationEvent extends Event
+{
+
+    private final EntityVillager villager;
+    private final VillagerCareer career;
+    private final List<ITradeList> trades;
+    
+    public VillagerTradePopulationEvent(EntityVillager villager, VillagerCareer career, List<ITradeList> originalTrades)
+    {
+        this.villager = villager;
+        this.career = career;
+        this.trades = originalTrades;
+    }
+    
+    /**
+     * @return the villager these trades are added to.
+     */
+    public EntityVillager getVillager()
+    {
+        return this.villager;
+    }
+    
+    /**
+     * @return the villager's career
+     */
+    public VillagerCareer getVillagerCareer()
+    {
+        return this.career;
+    }
+    
+    /**
+     * 
+     * @return the list containing the villager trades.
+     */
+    public List<ITradeList> getTrades()
+    {
+        return this.trades;
+    }
+}

--- a/src/main/java/net/minecraftforge/fml/common/registry/VillagerRegistry.java
+++ b/src/main/java/net/minecraftforge/fml/common/registry/VillagerRegistry.java
@@ -256,7 +256,7 @@ public class VillagerRegistry
             if(professionName.getResourceDomain().equals("minecraft"))
                 return String.format("entity.Villager.%s", this.getName());
             else
-                return String.format("entity.Villager.%s.%s", professionName.getResourceDomain(), this.getName());
+                return String.format("entity.Villager.%s.%s.%s", professionName.getResourceDomain(), professionName.getResourcePath(), this.getName());
         }
 
         public ITradeList[][] getTrades()

--- a/src/main/java/net/minecraftforge/fml/common/registry/VillagerRegistry.java
+++ b/src/main/java/net/minecraftforge/fml/common/registry/VillagerRegistry.java
@@ -12,6 +12,8 @@
 
 package net.minecraftforge.fml.common.registry;
 
+import java.util.ArrayList;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Random;
@@ -212,6 +214,15 @@ public class VillagerRegistry
             }
             return this.careers.get(0);
         }
+        public VillagerCareer getCareer(String name)
+        {
+            for (VillagerCareer car : this.careers)
+            {
+                if (car.getName() == name)
+                    return car;
+            }
+            return null;
+        }
 
         public int getRandomCareer(Random rand)
         {
@@ -224,7 +235,7 @@ public class VillagerRegistry
         private VillagerProfession profession;
         private String name;
         private int id;
-        private ITradeList[][] trades;
+        private List<List<ITradeList>> trades;
 
         public VillagerCareer(VillagerProfession parent, String name)
         {
@@ -240,13 +251,40 @@ public class VillagerRegistry
 
         public ITradeList[][] getTrades()
         {
-            return this.trades;
+            ITradeList[][] returnValue = new ITradeList[this.trades.size()][];
+            for(int i = 0; i < this.trades.size(); i++)
+            {
+               returnValue[i] = this.trades.get(i).toArray(new ITradeList[]{});
+            }
+            return returnValue;
         }
 
         private VillagerCareer init(EntityVillager.ITradeList[][] trades)
         {
-            this.trades = trades;
+            this.trades = new ArrayList<List<ITradeList>>();
+            for(int i = 0; i < trades.length; i++)
+            {
+                List<ITradeList> inner = new LinkedList<ITradeList>();
+                for(ITradeList trade : trades[i]){
+                    inner.add(trade);
+                }
+                this.trades.add(i, inner);
+            }
             return this;
+        }
+        
+        public List<ITradeList> getTradesForCareerLevel(int careerLevel)
+        {
+            Validate.isTrue(careerLevel >= 0, "The requested career level is negative!");
+            if(careerLevel >= trades.size() || trades.get(careerLevel) == null){
+                trades.add(careerLevel, new LinkedList<ITradeList>());
+            }
+            return trades.get(careerLevel);
+        }
+        
+        public int getHighestCareerLevel()
+        {
+            return trades.size() - 1;
         }
 
         @Override

--- a/src/main/java/net/minecraftforge/fml/common/registry/VillagerRegistry.java
+++ b/src/main/java/net/minecraftforge/fml/common/registry/VillagerRegistry.java
@@ -218,7 +218,7 @@ public class VillagerRegistry
         {
             for (VillagerCareer car : this.careers)
             {
-                if (car.getName() == name)
+                if (car.getName().equals(name))
                     return car;
             }
             return null;

--- a/src/main/java/net/minecraftforge/fml/common/registry/VillagerRegistry.java
+++ b/src/main/java/net/minecraftforge/fml/common/registry/VillagerRegistry.java
@@ -241,6 +241,7 @@ public class VillagerRegistry
         {
             this.profession = parent;
             this.name = name;
+            this.trades = new ArrayList<List<ITradeList>>();
             parent.register(this);
         }
 
@@ -260,8 +261,7 @@ public class VillagerRegistry
         }
 
         private VillagerCareer init(EntityVillager.ITradeList[][] trades)
-        {
-            this.trades = new ArrayList<List<ITradeList>>();
+        { 
             for(int i = 0; i < trades.length; i++)
             {
                 List<ITradeList> inner = new LinkedList<ITradeList>();

--- a/src/main/java/net/minecraftforge/fml/common/registry/VillagerRegistry.java
+++ b/src/main/java/net/minecraftforge/fml/common/registry/VillagerRegistry.java
@@ -249,6 +249,15 @@ public class VillagerRegistry
         {
             return this.name;
         }
+        
+        public String getUnlocalizedName()
+        {
+            ResourceLocation professionName = profession.getRegistryName();
+            if(professionName.getResourceDomain().equals("minecraft"))
+                return String.format("entity.Villager.%s", this.getName());
+            else
+                return String.format("entity.Villager.%s.%s", professionName.getResourceDomain(), this.getName());
+        }
 
         public ITradeList[][] getTrades()
         {

--- a/src/test/java/net/minecraftforge/fml/test/VillagerTradesTest.java
+++ b/src/test/java/net/minecraftforge/fml/test/VillagerTradesTest.java
@@ -16,7 +16,7 @@ import net.minecraftforge.fml.common.registry.ForgeRegistries;
 import net.minecraftforge.fml.common.registry.VillagerRegistry.VillagerProfession;
 import net.minecraftforge.fml.common.registry.VillagerRegistry.VillagerCareer;
 
-@Mod(modid = "VillagerTradesTest", name = "VillagerTradesTest", version = "0.0.0")
+@Mod(modid = "villagertradestest", name = "VillagerTradesTest", version = "0.0.0")
 public class VillagerTradesTest
 {
     

--- a/src/test/java/net/minecraftforge/fml/test/VillagerTradesTest.java
+++ b/src/test/java/net/minecraftforge/fml/test/VillagerTradesTest.java
@@ -1,0 +1,34 @@
+package net.minecraftforge.fml.test;
+
+import net.minecraft.entity.passive.EntityVillager.ListItemForEmeralds;
+import net.minecraft.entity.passive.EntityVillager.PriceInfo;
+import net.minecraft.init.Items;
+import net.minecraft.util.ResourceLocation;
+import net.minecraftforge.common.MinecraftForge;
+import net.minecraftforge.event.entity.living.VillagerTradePopulationEvent;
+import net.minecraftforge.fml.common.Mod;
+import net.minecraftforge.fml.common.Mod.EventHandler;
+import net.minecraftforge.fml.common.event.FMLInitializationEvent;
+import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
+import net.minecraftforge.fml.common.registry.ForgeRegistries;
+
+@Mod(modid = "VillagerTradesTest", name = "VillagerTradesTest", version = "0.0.0")
+public class VillagerTradesTest
+{
+    
+    @EventHandler
+    public void init(FMLInitializationEvent event)
+    {
+        ForgeRegistries.VILLAGER_PROFESSIONS.getValue(new ResourceLocation("minecraft:butcher")).getCareer("butcher").getTradesForCareerLevel(0).add(new ListItemForEmeralds(Items.diamond, new PriceInfo(-10, -9)));
+        MinecraftForge.EVENT_BUS.register(this);
+    }
+    
+    @SubscribeEvent
+    public void onTradePopulation(VillagerTradePopulationEvent event)
+    {
+        if(event.getVillagerCareer().getName().equals("leather"))
+        {
+            event.getTrades().clear();
+        }
+    }
+} 

--- a/src/test/java/net/minecraftforge/fml/test/VillagerTradesTest.java
+++ b/src/test/java/net/minecraftforge/fml/test/VillagerTradesTest.java
@@ -2,7 +2,9 @@ package net.minecraftforge.fml.test;
 
 import net.minecraft.entity.passive.EntityVillager.ListItemForEmeralds;
 import net.minecraft.entity.passive.EntityVillager.PriceInfo;
+import net.minecraft.init.Blocks;
 import net.minecraft.init.Items;
+import net.minecraft.item.Item;
 import net.minecraft.util.ResourceLocation;
 import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.event.entity.living.VillagerTradePopulationEvent;
@@ -11,6 +13,8 @@ import net.minecraftforge.fml.common.Mod.EventHandler;
 import net.minecraftforge.fml.common.event.FMLInitializationEvent;
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
 import net.minecraftforge.fml.common.registry.ForgeRegistries;
+import net.minecraftforge.fml.common.registry.VillagerRegistry.VillagerProfession;
+import net.minecraftforge.fml.common.registry.VillagerRegistry.VillagerCareer;
 
 @Mod(modid = "VillagerTradesTest", name = "VillagerTradesTest", version = "0.0.0")
 public class VillagerTradesTest
@@ -21,8 +25,17 @@ public class VillagerTradesTest
     {
         ForgeRegistries.VILLAGER_PROFESSIONS.getValue(new ResourceLocation("minecraft:butcher")).getCareer("butcher").getTradesForCareerLevel(0).add(new ListItemForEmeralds(Items.diamond, new PriceInfo(-10, -9)));
         MinecraftForge.EVENT_BUS.register(this);
+        
+        createNewCareer();
     }
     
+    private void createNewCareer()
+    {
+        VillagerProfession priest = ForgeRegistries.VILLAGER_PROFESSIONS.getValue(new ResourceLocation("minecraft:priest"));
+        VillagerCareer programmer = new VillagerCareer(priest, "programmer");
+        programmer.getTradesForCareerLevel(0).add(new ListItemForEmeralds(Item.getItemFromBlock(Blocks.command_block), new PriceInfo(32, 64)));
+    }
+
     @SubscribeEvent
     public void onTradePopulation(VillagerTradePopulationEvent event)
     {

--- a/src/test/resources/assets/villagertradestest/lang/en_US.lang
+++ b/src/test/resources/assets/villagertradestest/lang/en_US.lang
@@ -1,0 +1,1 @@
+entity.Villager.programmer=Programmer


### PR DESCRIPTION
With this PR I intend to grant modders the ability to add trades to already existing villagers and to allow them to create new kinds of villagers easily. Also, with the new Event, modders can manipulate trades more easily and flexibly.

Usecases:

- Modifying a villager careers trade options (-> VillagerCareer methods)
- Modifying the villager trades when they are created (-> Event)
- Creating custom careers to already existing professions
- Allows modders, if they are adding new careers to vanilla professions, to set custom names in cases where vanilla knows only one career per profession

All the above mentioned features have a reference implementation in the example mod.