### PR TITLE
[1.9] Added an event for when a player enchants an Item.

### DIFF
--- a/patches/minecraft/net/minecraft/inventory/ContainerEnchantment.java.patch
+++ b/patches/minecraft/net/minecraft/inventory/ContainerEnchantment.java.patch
@@ -75,3 +75,12 @@
                          this.field_185001_h[i1] = -1;
                          this.field_185002_i[i1] = -1;
  
+@@ -258,7 +239,7 @@
+             {
+                 List<EnchantmentData> list = this.func_178148_a(itemstack, p_75140_2_, this.field_75167_g[p_75140_2_]);
+                 boolean flag = itemstack.func_77973_b() == Items.field_151122_aG;
+-
++                list = net.minecraftforge.common.ForgeHooks.onItemEnchanted(p_75140_1_, i, itemstack, itemstack1, list);
+                 if (list != null)
+                 {
+                     p_75140_1_.func_71013_b(i);

--- a/src/main/java/net/minecraftforge/common/ForgeHooks.java
+++ b/src/main/java/net/minecraftforge/common/ForgeHooks.java
@@ -15,6 +15,7 @@ import net.minecraft.block.material.Material;
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.GuiScreen;
+import net.minecraft.enchantment.EnchantmentData;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.EntityList;
 import net.minecraft.entity.EntityLivingBase;
@@ -77,6 +78,7 @@ import net.minecraftforge.event.entity.living.LivingHurtEvent;
 import net.minecraftforge.event.entity.living.LivingSetAttackTargetEvent;
 import net.minecraftforge.event.entity.player.AnvilRepairEvent;
 import net.minecraftforge.event.entity.player.AttackEntityEvent;
+import net.minecraftforge.event.entity.player.PlayerEnchantItemEvent;
 import net.minecraftforge.event.entity.player.PlayerInteractEvent;
 import net.minecraftforge.event.entity.player.PlayerOpenContainerEvent;
 import net.minecraftforge.event.world.BlockEvent;
@@ -969,5 +971,12 @@ public class ForgeHooks
     public static void onEmptyClick(EntityPlayer player, EnumHand hand)
     {
         MinecraftForge.EVENT_BUS.post(new PlayerInteractEvent.RightClickEmpty(player, hand));
+    }
+    
+    public static List<EnchantmentData> onItemEnchanted(EntityPlayer player, int levels, ItemStack itemstack, ItemStack fuel, List<EnchantmentData> enchantments)
+    {
+    	final PlayerEnchantItemEvent event = new PlayerEnchantItemEvent(player, itemstack, fuel, levels, enchantments);
+    	MinecraftForge.EVENT_BUS.post(event);
+    	return (event.isCanceled()) ? null : event.getEnchantments();
     }
 }

--- a/src/main/java/net/minecraftforge/event/entity/player/PlayerEnchantItemEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/player/PlayerEnchantItemEvent.java
@@ -1,0 +1,70 @@
+package net.minecraftforge.event.entity.player;
+
+import java.util.List;
+
+import net.minecraft.enchantment.EnchantmentData;
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.item.ItemStack;
+import net.minecraftforge.fml.common.eventhandler.Cancelable;
+
+/**
+ * Fired when an item is enchanted. Primarily triggered by enchanting at the
+ * vanilla enchantment table, however it is also possible to be triggered by
+ * other mods.
+ */
+@Cancelable
+public class PlayerEnchantItemEvent extends PlayerEvent {
+
+	/**
+	 * The ItemStack being enchanted.
+	 */
+	private final ItemStack stack;
+
+	/**
+	 * The ItemStack in the Lapis Lazuli fuel slot.
+	 */
+	private final ItemStack fuel;
+	
+	/**
+	 * The list of enchantments being added to the ItemStack.
+	 */
+	private final List<EnchantmentData> enchantments;
+
+	/**
+	 * The amount of levels being used to pay for the enchantments.
+	 */
+	private int levels;
+
+	public PlayerEnchantItemEvent(EntityPlayer player, ItemStack stack, ItemStack fuel, int levels, List<EnchantmentData> enchantments) {
+		super(player);
+		this.stack = stack;
+		this.fuel = fuel;
+		this.levels = levels;
+		this.enchantments = enchantments;
+	}
+
+	public ItemStack getItemStack() 
+	{
+		return stack;
+	}
+	
+	public ItemStack getFuelStack()
+	{
+		return fuel;
+	}
+
+	public List<EnchantmentData> getEnchantments() 
+	{
+		return enchantments;
+	}
+
+	public int getLevels() 
+	{
+		return levels;
+	}
+
+	public void setLevels(int levels) 
+	{
+		this.levels = levels;
+	}
+}

--- a/src/test/java/net/minecraftforge/test/EnchantmentEventTestMod.java
+++ b/src/test/java/net/minecraftforge/test/EnchantmentEventTestMod.java
@@ -1,0 +1,32 @@
+package net.minecraftforge.test;
+
+import net.minecraft.init.Items;
+import net.minecraftforge.common.MinecraftForge;
+import net.minecraftforge.event.entity.player.PlayerEnchantItemEvent;
+import net.minecraftforge.fml.common.Mod;
+import net.minecraftforge.fml.common.Mod.EventHandler;
+import net.minecraftforge.fml.common.event.FMLInitializationEvent;
+import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
+
+/** Simple mod to test fov modifier. */
+@Mod(modid="enchantmenteventtest", name="Enchantment Event Test", version="0.0.0")
+public class EnchantmentEventTestMod {
+
+    @EventHandler
+    public void init(FMLInitializationEvent event)
+    {
+    	MinecraftForge.EVENT_BUS.register(this);
+    }
+    
+    @SubscribeEvent
+    public void onItemEnchanted(PlayerEnchantItemEvent event)
+    {
+    	if (event.getItemStack() != null && event.getFuelStack() != null)
+    	{
+    		System.out.println("Enchanted Item: " + event.getItemStack().getDisplayName());
+    		System.out.println("Fuel Item: " + event.getFuelStack().getDisplayName());  		
+    		if (event.getItemStack().getItem() == Items.stone_sword)
+    			event.setCanceled(true);
+    	}
+    }
+}

--- a/src/test/java/net/minecraftforge/test/EnchantmentEventTestMod.java
+++ b/src/test/java/net/minecraftforge/test/EnchantmentEventTestMod.java
@@ -8,7 +8,6 @@ import net.minecraftforge.fml.common.Mod.EventHandler;
 import net.minecraftforge.fml.common.event.FMLInitializationEvent;
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
 
-/** Simple mod to test fov modifier. */
 @Mod(modid="enchantmenteventtest", name="Enchantment Event Test", version="0.0.0")
 public class EnchantmentEventTestMod {
 


### PR DESCRIPTION
Adds an event that is fired when a player enchants an item. The event in this PR is functionally similar to the one from #1622 however it has been remade for 1.9 and has access to item in the fuel slot that was introduced in 1.8. This event can also be canceled in the traditional way.

This event provides access to the player that enchanted the item, the ItemStack being enchanted, the ItemStack in the Lapis Lazuli fuel slot, the amount of levels being charged and a list of enchantments being applied to the ItemStack. If the event is canceled, the enchantments will not be applied, and the experience and fuel item will not be consumed. Specific enchantments can also be removed from the list of applied enchantments, which will prevent thos enchantments from being installed. If the list of enchantments being applied is empty or null, the vanilla code will act as if the event was canceled. 

Potential Uses
- Give player an achievement when a specific enchantment is applied.
- Specialized conditions for when an enchantment can be applied. For example, only allow a vampirism enchantment to be applied in the nether biome. 
- Alter other attributes of the enchanted item when a specific enchantment is applied, such as writing player UUID to the ItemStack NBT. 
- Add additional costs to the enchantment. Examples include consuming item durability, or damaging the player.

The included test mod will print the names of the enchanted item and the fuel item to the console, and will cancel the event if the player tries to enchant a stone sword. 

