### PR TITLE
Added Soil & Plant Events

### DIFF
--- a/patches/minecraft/net/minecraft/block/Block.java.patch
+++ b/patches/minecraft/net/minecraft/block/Block.java.patch
@@ -890,40 +890,40 @@
 +    {
 +        IBlockState plant = plantable.getPlant(world, pos.func_177972_a(direction));
 +        net.minecraftforge.common.EnumPlantType plantType = plantable.getPlantType(world, pos.func_177972_a(direction));
-+        boolean canSustain = false;
++        
 +        if (plant.func_177230_c() == net.minecraft.init.Blocks.field_150434_aF && this == net.minecraft.init.Blocks.field_150434_aF)
 +        {
-+            canSustain = true;
++        	return true;
 +        }
 +
 +        if (plant.func_177230_c() == net.minecraft.init.Blocks.field_150436_aH && this == net.minecraft.init.Blocks.field_150436_aH)
 +        {
-+            canSustain = true;
++        	return true;
 +        }
 +
 +        if (plantable instanceof BlockBush && ((BlockBush)plantable).func_185514_i(state))
 +        {
-+            canSustain = true;
++        	return true;
 +        }
 +
 +        switch (plantType)
 +        {
-+            case Desert: canSustain |= this == net.minecraft.init.Blocks.field_150354_m || this == net.minecraft.init.Blocks.field_150405_ch || this == net.minecraft.init.Blocks.field_150406_ce || this == net.minecraft.init.Blocks.field_150346_d;
-+            case Nether: canSustain |= this == net.minecraft.init.Blocks.field_150425_aM;
-+            case Crop:   canSustain |= this == net.minecraft.init.Blocks.field_150458_ak;
-+            case Cave:   canSustain |= state.isSideSolid(world, pos, EnumFacing.UP);
-+            case Plains: canSustain |= this == net.minecraft.init.Blocks.field_150349_c || this == net.minecraft.init.Blocks.field_150346_d || this == net.minecraft.init.Blocks.field_150458_ak;
-+            case Water:  canSustain |= state.func_185904_a() == Material.field_151586_h && state.func_177229_b(BlockLiquid.field_176367_b) == 0;
++            case Desert: return this == net.minecraft.init.Blocks.field_150354_m || this == net.minecraft.init.Blocks.field_150405_ch || this == net.minecraft.init.Blocks.field_150406_ce || this == net.minecraft.init.Blocks.field_150346_d;
++            case Nether: return this == net.minecraft.init.Blocks.field_150425_aM;
++            case Crop:   return this == net.minecraft.init.Blocks.field_150458_ak;
++            case Cave:   return state.isSideSolid(world, pos, EnumFacing.UP);
++            case Plains: return this == net.minecraft.init.Blocks.field_150349_c || this == net.minecraft.init.Blocks.field_150346_d || this == net.minecraft.init.Blocks.field_150458_ak;
++            case Water:  return state.func_185904_a() == Material.field_151586_h && state.func_177229_b(BlockLiquid.field_176367_b) == 0;
 +            case Beach:
 +                boolean isBeach = this == net.minecraft.init.Blocks.field_150349_c || this == net.minecraft.init.Blocks.field_150346_d || this == net.minecraft.init.Blocks.field_150354_m;
 +                boolean hasWater = (world.func_180495_p(pos.func_177974_f()).func_185904_a() == Material.field_151586_h ||
 +                                    world.func_180495_p(pos.func_177976_e()).func_185904_a() == Material.field_151586_h ||
 +                                    world.func_180495_p(pos.func_177978_c()).func_185904_a() == Material.field_151586_h ||
 +                                    world.func_180495_p(pos.func_177968_d()).func_185904_a() == Material.field_151586_h);
-+                canSustain |= isBeach && hasWater;
++                return isBeach && hasWater;
 +        }
 +
-+        return net.minecraftforge.event.ForgeEventFactory.canSoilSustainPlant(world, pos, direction, plantable, canSustain);
++        return false;
 +    }
 +
 +    /**

--- a/patches/minecraft/net/minecraft/block/Block.java.patch
+++ b/patches/minecraft/net/minecraft/block/Block.java.patch
@@ -890,40 +890,40 @@
 +    {
 +        IBlockState plant = plantable.getPlant(world, pos.func_177972_a(direction));
 +        net.minecraftforge.common.EnumPlantType plantType = plantable.getPlantType(world, pos.func_177972_a(direction));
-+
++        boolean canSustain = false;
 +        if (plant.func_177230_c() == net.minecraft.init.Blocks.field_150434_aF && this == net.minecraft.init.Blocks.field_150434_aF)
 +        {
-+            return true;
++            canSustain = true;
 +        }
 +
 +        if (plant.func_177230_c() == net.minecraft.init.Blocks.field_150436_aH && this == net.minecraft.init.Blocks.field_150436_aH)
 +        {
-+            return true;
++            canSustain = true;
 +        }
 +
 +        if (plantable instanceof BlockBush && ((BlockBush)plantable).func_185514_i(state))
 +        {
-+            return true;
++            canSustain = true;
 +        }
 +
 +        switch (plantType)
 +        {
-+            case Desert: return this == net.minecraft.init.Blocks.field_150354_m || this == net.minecraft.init.Blocks.field_150405_ch || this == net.minecraft.init.Blocks.field_150406_ce || this == net.minecraft.init.Blocks.field_150346_d;
-+            case Nether: return this == net.minecraft.init.Blocks.field_150425_aM;
-+            case Crop:   return this == net.minecraft.init.Blocks.field_150458_ak;
-+            case Cave:   return state.isSideSolid(world, pos, EnumFacing.UP);
-+            case Plains: return this == net.minecraft.init.Blocks.field_150349_c || this == net.minecraft.init.Blocks.field_150346_d || this == net.minecraft.init.Blocks.field_150458_ak;
-+            case Water:  return state.func_185904_a() == Material.field_151586_h && state.func_177229_b(BlockLiquid.field_176367_b) == 0;
++            case Desert: canSustain |= this == net.minecraft.init.Blocks.field_150354_m || this == net.minecraft.init.Blocks.field_150405_ch || this == net.minecraft.init.Blocks.field_150406_ce || this == net.minecraft.init.Blocks.field_150346_d;
++            case Nether: canSustain |= this == net.minecraft.init.Blocks.field_150425_aM;
++            case Crop:   canSustain |= this == net.minecraft.init.Blocks.field_150458_ak;
++            case Cave:   canSustain |= state.isSideSolid(world, pos, EnumFacing.UP);
++            case Plains: canSustain |= this == net.minecraft.init.Blocks.field_150349_c || this == net.minecraft.init.Blocks.field_150346_d || this == net.minecraft.init.Blocks.field_150458_ak;
++            case Water:  canSustain |= state.func_185904_a() == Material.field_151586_h && state.func_177229_b(BlockLiquid.field_176367_b) == 0;
 +            case Beach:
 +                boolean isBeach = this == net.minecraft.init.Blocks.field_150349_c || this == net.minecraft.init.Blocks.field_150346_d || this == net.minecraft.init.Blocks.field_150354_m;
 +                boolean hasWater = (world.func_180495_p(pos.func_177974_f()).func_185904_a() == Material.field_151586_h ||
 +                                    world.func_180495_p(pos.func_177976_e()).func_185904_a() == Material.field_151586_h ||
 +                                    world.func_180495_p(pos.func_177978_c()).func_185904_a() == Material.field_151586_h ||
 +                                    world.func_180495_p(pos.func_177968_d()).func_185904_a() == Material.field_151586_h);
-+                return isBeach && hasWater;
++                canSustain |= isBeach && hasWater;
 +        }
 +
-+        return false;
++        return net.minecraftforge.event.ForgeEventFactory.canSoilSustainPlant(world, pos, direction, plantable, canSustain);
 +    }
 +
 +    /**

--- a/patches/minecraft/net/minecraft/block/BlockCrops.java.patch
+++ b/patches/minecraft/net/minecraft/block/BlockCrops.java.patch
@@ -14,7 +14,13 @@
                      {
                          f1 = 3.0F;
                      }
-@@ -161,7 +161,8 @@
+@@ -156,12 +156,13 @@
+             }
+         }
+ 
+-        return f;
++        return net.minecraftforge.event.ForgeEventFactory.getGrowthChance(p_180672_0_, p_180672_1_, p_180672_2_, f);
+     }
  
      public boolean func_180671_f(World p_180671_1_, BlockPos p_180671_2_, IBlockState p_180671_3_)
      {

--- a/patches/minecraft/net/minecraft/block/BlockNetherWart.java.patch
+++ b/patches/minecraft/net/minecraft/block/BlockNetherWart.java.patch
@@ -1,6 +1,6 @@
 --- ../src-base/minecraft/net/minecraft/block/BlockNetherWart.java
 +++ ../src-work/minecraft/net/minecraft/block/BlockNetherWart.java
-@@ -42,7 +42,7 @@
+@@ -42,14 +42,14 @@
  
      public boolean func_180671_f(World p_180671_1_, BlockPos p_180671_2_, IBlockState p_180671_3_)
      {
@@ -9,6 +9,14 @@
      }
  
      public void func_180650_b(World p_180650_1_, BlockPos p_180650_2_, IBlockState p_180650_3_, Random p_180650_4_)
+     {
+         int i = ((Integer)p_180650_3_.func_177229_b(field_176486_a)).intValue();
+ 
+-        if (i < 3 && p_180650_4_.nextInt(10) == 0)
++        if (i < 3 && p_180650_4_.nextInt((int) net.minecraftforge.event.ForgeEventFactory.getGrowthChance(this, p_180650_1_, p_180650_2_, 10)) == 0)
+         {
+             p_180650_3_ = p_180650_3_.func_177226_a(field_176486_a, Integer.valueOf(i + 1));
+             p_180650_1_.func_180501_a(p_180650_2_, p_180650_3_, 2);
 @@ -58,9 +58,11 @@
          super.func_180650_b(p_180650_1_, p_180650_2_, p_180650_3_, p_180650_4_);
      }

--- a/src/main/java/net/minecraftforge/event/ForgeEventFactory.java
+++ b/src/main/java/net/minecraftforge/event/ForgeEventFactory.java
@@ -4,6 +4,7 @@ import java.io.File;
 import java.util.EnumSet;
 import java.util.List;
 
+import net.minecraft.block.Block;
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.EntityLiving;
@@ -27,9 +28,9 @@ import net.minecraft.util.SoundCategory;
 import net.minecraft.util.SoundEvent;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.RayTraceResult;
-import net.minecraft.util.math.Vec3d;
 import net.minecraft.util.text.ITextComponent;
 import net.minecraft.world.Explosion;
+import net.minecraft.world.IBlockAccess;
 import net.minecraft.world.World;
 import net.minecraft.world.WorldServer;
 import net.minecraft.world.WorldSettings;
@@ -41,6 +42,7 @@ import net.minecraft.world.storage.SaveHandler;
 import net.minecraftforge.client.event.ClientChatReceivedEvent;
 import net.minecraftforge.client.event.RenderBlockOverlayEvent;
 import net.minecraftforge.client.event.RenderBlockOverlayEvent.OverlayType;
+import net.minecraftforge.common.IPlantable;
 import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.common.capabilities.CapabilityDispatcher;
 import net.minecraftforge.common.capabilities.ICapabilityProvider;
@@ -79,6 +81,8 @@ import net.minecraftforge.event.world.BlockEvent;
 import net.minecraftforge.event.world.BlockEvent.MultiPlaceEvent;
 import net.minecraftforge.event.world.BlockEvent.NeighborNotifyEvent;
 import net.minecraftforge.event.world.BlockEvent.PlaceEvent;
+import net.minecraftforge.event.world.BlockEvent.SoilPlantEvent.CanSoilSustainPlantEvent;
+import net.minecraftforge.event.world.BlockEvent.SoilPlantEvent.GetGrowthChanceEvent;
 import net.minecraftforge.event.world.ExplosionEvent;
 import net.minecraftforge.event.world.WorldEvent;
 import net.minecraftforge.fml.common.ObfuscationReflectionHelper;
@@ -123,6 +127,23 @@ public class ForgeEventFactory
     {
         PlayerEvent.BreakSpeed event = new PlayerEvent.BreakSpeed(player, state, original, pos);
         return (MinecraftForge.EVENT_BUS.post(event) ? -1 : event.getNewSpeed());
+    }
+    
+    public static boolean canSoilSustainPlant(IBlockAccess world, BlockPos pos, EnumFacing direction, IPlantable plantable, boolean canSustain)
+    {
+        if(world instanceof World){
+            CanSoilSustainPlantEvent event = new CanSoilSustainPlantEvent((World) world, pos, world.getBlockState(pos), plantable, direction, canSustain);
+            MinecraftForge.EVENT_BUS.post(event);
+            return event.canSustain();
+        } else{
+        	return canSustain;
+        }
+    }
+
+    public static float getGrowthChance(Block plant, World worldIn, BlockPos pos, float growthChance){
+        GetGrowthChanceEvent event = new GetGrowthChanceEvent(worldIn, pos, worldIn.getBlockState(pos.down()), (IPlantable) plant, growthChance);
+        MinecraftForge.EVENT_BUS.post(event);
+        return event.getGrowthChance();
     }
 
     public static void onPlayerDestroyItem(EntityPlayer player, ItemStack stack, EnumHand hand)

--- a/src/main/java/net/minecraftforge/event/ForgeEventFactory.java
+++ b/src/main/java/net/minecraftforge/event/ForgeEventFactory.java
@@ -30,7 +30,6 @@ import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.RayTraceResult;
 import net.minecraft.util.text.ITextComponent;
 import net.minecraft.world.Explosion;
-import net.minecraft.world.IBlockAccess;
 import net.minecraft.world.World;
 import net.minecraft.world.WorldServer;
 import net.minecraft.world.WorldSettings;
@@ -78,11 +77,10 @@ import net.minecraftforge.event.entity.player.UseHoeEvent;
 import net.minecraftforge.event.terraingen.ChunkGeneratorEvent;
 import net.minecraftforge.event.terraingen.PopulateChunkEvent;
 import net.minecraftforge.event.world.BlockEvent;
+import net.minecraftforge.event.world.BlockEvent.GetGrowthChanceEvent;
 import net.minecraftforge.event.world.BlockEvent.MultiPlaceEvent;
 import net.minecraftforge.event.world.BlockEvent.NeighborNotifyEvent;
 import net.minecraftforge.event.world.BlockEvent.PlaceEvent;
-import net.minecraftforge.event.world.BlockEvent.SoilPlantEvent.CanSoilSustainPlantEvent;
-import net.minecraftforge.event.world.BlockEvent.SoilPlantEvent.GetGrowthChanceEvent;
 import net.minecraftforge.event.world.ExplosionEvent;
 import net.minecraftforge.event.world.WorldEvent;
 import net.minecraftforge.fml.common.ObfuscationReflectionHelper;
@@ -128,20 +126,9 @@ public class ForgeEventFactory
         PlayerEvent.BreakSpeed event = new PlayerEvent.BreakSpeed(player, state, original, pos);
         return (MinecraftForge.EVENT_BUS.post(event) ? -1 : event.getNewSpeed());
     }
-    
-    public static boolean canSoilSustainPlant(IBlockAccess world, BlockPos pos, EnumFacing direction, IPlantable plantable, boolean canSustain)
-    {
-        if(world instanceof World){
-            CanSoilSustainPlantEvent event = new CanSoilSustainPlantEvent((World) world, pos, world.getBlockState(pos), plantable, direction, canSustain);
-            MinecraftForge.EVENT_BUS.post(event);
-            return event.canSustain();
-        } else{
-        	return canSustain;
-        }
-    }
 
     public static float getGrowthChance(Block plant, World worldIn, BlockPos pos, float growthChance){
-        GetGrowthChanceEvent event = new GetGrowthChanceEvent(worldIn, pos, worldIn.getBlockState(pos.down()), (IPlantable) plant, growthChance);
+        GetGrowthChanceEvent event = new GetGrowthChanceEvent(worldIn, pos.down(), worldIn.getBlockState(pos.down()), (IPlantable) plant, growthChance);
         MinecraftForge.EVENT_BUS.post(event);
         return event.getGrowthChance();
     }

--- a/src/main/java/net/minecraftforge/event/world/BlockEvent.java
+++ b/src/main/java/net/minecraftforge/event/world/BlockEvent.java
@@ -3,20 +3,23 @@ package net.minecraftforge.event.world;
 import java.util.EnumSet;
 import java.util.List;
 
+import com.google.common.collect.ImmutableList;
+
+import net.minecraft.block.Block;
+import net.minecraft.block.BlockCrops;
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.enchantment.EnchantmentHelper;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.init.Enchantments;
 import net.minecraft.item.ItemStack;
-import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.EnumFacing;
+import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.World;
 import net.minecraftforge.common.ForgeHooks;
+import net.minecraftforge.common.IPlantable;
 import net.minecraftforge.common.util.BlockSnapshot;
 import net.minecraftforge.fml.common.eventhandler.Cancelable;
 import net.minecraftforge.fml.common.eventhandler.Event;
-
-import com.google.common.collect.ImmutableList;
 
 public class BlockEvent extends Event
 {
@@ -231,6 +234,90 @@ public class BlockEvent extends Event
         public EnumSet<EnumFacing> getNotifiedSides()
         {
             return notifiedSides;
+        }
+    }
+    
+    /**
+     * {@link BlockEvent#pos} and {@link BlockEvent#state} are soil's position and state.
+     * @author elix_x
+     *
+     */
+    public static class SoilPlantEvent extends BlockEvent
+    {
+        private final IPlantable plant;
+
+        public SoilPlantEvent(World world, BlockPos pos, IBlockState soil, IPlantable plant)
+        {
+            super(world, pos, soil);
+            this.plant = plant;
+        }
+
+        public IPlantable getPlant()
+        {
+            return plant;
+        }
+
+        /**
+         * Fired when plant checks whether it can sustain on soil.
+         * <br>
+         * This event is called from block updates, crops planting and other various things, so {@link SoilPlantEvent#plant} may not be {@link Block}.
+         * @author elix_x
+         *
+         */
+        public static class CanSoilSustainPlantEvent extends SoilPlantEvent
+        {
+            private final EnumFacing direction;
+            private boolean canSustain;
+
+            public CanSoilSustainPlantEvent(World world, BlockPos pos, IBlockState soil, IPlantable plant, EnumFacing direction, boolean canSustain)
+            {
+                super(world, pos, soil, plant);
+                this.direction = direction;
+                this.canSustain = canSustain;
+            }
+
+            public EnumFacing getDirection()
+            {
+                return direction;
+            }
+
+            public boolean canSustain()
+            {
+                return canSustain;
+            }
+
+            public void setCanSustain(boolean canSustain)
+            {
+                this.canSustain = canSustain;
+            }
+        }
+
+        /**
+         * Fired when crop calculates it's growth chance to grow.
+         * <br>
+         * For example, crop extending {@link BlockCrops} will grow if random int between 0 and 25/growthChance + 1 is 0 (<code>rand.nextInt((int)(25.0F / growthChance) + 1) == 0</code>).
+         * @author elix_x
+         *
+         */
+        public static class GetGrowthChanceEvent extends SoilPlantEvent
+        {
+            private float growthChance;
+
+            public GetGrowthChanceEvent(World world, BlockPos pos, IBlockState soil, IPlantable plant, float growthChance)
+            {
+                super(world, pos, soil, plant);
+                this.growthChance = growthChance;
+            }
+
+            public float getGrowthChance()
+            {
+                return growthChance;
+            }
+
+            public void setGrowthChance(float growthChance)
+            {
+                this.growthChance = growthChance;
+            }
         }
     }
 }

--- a/src/main/java/net/minecraftforge/event/world/BlockEvent.java
+++ b/src/main/java/net/minecraftforge/event/world/BlockEvent.java
@@ -5,7 +5,6 @@ import java.util.List;
 
 import com.google.common.collect.ImmutableList;
 
-import net.minecraft.block.Block;
 import net.minecraft.block.BlockCrops;
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.enchantment.EnchantmentHelper;
@@ -104,7 +103,7 @@ public class BlockEvent extends Event
             this.player = player;
 
             if (state == null || !ForgeHooks.canHarvestBlock(state.getBlock(), player, world, pos) || // Handle empty block or player unable to break block scenario
-                (state.getBlock().canSilkHarvest(world, pos, world.getBlockState(pos), player) && EnchantmentHelper.getEnchantmentLevel(Enchantments.silkTouch, player.getHeldItemMainhand()) > 0)) // If the block is being silk harvested, the exp dropped is 0
+                    (state.getBlock().canSilkHarvest(world, pos, world.getBlockState(pos), player) && EnchantmentHelper.getEnchantmentLevel(Enchantments.silkTouch, player.getHeldItemMainhand()) > 0)) // If the block is being silk harvested, the exp dropped is 0
             {
                 this.exp = 0;
             }
@@ -236,20 +235,26 @@ public class BlockEvent extends Event
             return notifiedSides;
         }
     }
-    
+
     /**
+     * Fired when crop calculates it's growth chance to grow.
+     * <br>
      * {@link BlockEvent#pos} and {@link BlockEvent#state} are soil's position and state.
+     * <br>
+     * For example, crop extending {@link BlockCrops} will grow if random int between 0 and 25/growthChance + 1 is 0 (<code>rand.nextInt((int)(25.0F / growthChance) + 1) == 0</code>).
      * @author elix_x
      *
      */
-    public static class SoilPlantEvent extends BlockEvent
+    public static class GetGrowthChanceEvent extends BlockEvent
     {
         private final IPlantable plant;
+        private float growthChance;
 
-        public SoilPlantEvent(World world, BlockPos pos, IBlockState soil, IPlantable plant)
+        public GetGrowthChanceEvent(World world, BlockPos pos, IBlockState soil, IPlantable plant, float growthChance)
         {
             super(world, pos, soil);
             this.plant = plant;
+            this.growthChance = growthChance;
         }
 
         public IPlantable getPlant()
@@ -257,67 +262,14 @@ public class BlockEvent extends Event
             return plant;
         }
 
-        /**
-         * Fired when plant checks whether it can sustain on soil.
-         * <br>
-         * This event is called from block updates, crops planting and other various things, so {@link SoilPlantEvent#plant} may not be {@link Block}.
-         * @author elix_x
-         *
-         */
-        public static class CanSoilSustainPlantEvent extends SoilPlantEvent
+        public float getGrowthChance()
         {
-            private final EnumFacing direction;
-            private boolean canSustain;
-
-            public CanSoilSustainPlantEvent(World world, BlockPos pos, IBlockState soil, IPlantable plant, EnumFacing direction, boolean canSustain)
-            {
-                super(world, pos, soil, plant);
-                this.direction = direction;
-                this.canSustain = canSustain;
-            }
-
-            public EnumFacing getDirection()
-            {
-                return direction;
-            }
-
-            public boolean canSustain()
-            {
-                return canSustain;
-            }
-
-            public void setCanSustain(boolean canSustain)
-            {
-                this.canSustain = canSustain;
-            }
+            return growthChance;
         }
 
-        /**
-         * Fired when crop calculates it's growth chance to grow.
-         * <br>
-         * For example, crop extending {@link BlockCrops} will grow if random int between 0 and 25/growthChance + 1 is 0 (<code>rand.nextInt((int)(25.0F / growthChance) + 1) == 0</code>).
-         * @author elix_x
-         *
-         */
-        public static class GetGrowthChanceEvent extends SoilPlantEvent
+        public void setGrowthChance(float growthChance)
         {
-            private float growthChance;
-
-            public GetGrowthChanceEvent(World world, BlockPos pos, IBlockState soil, IPlantable plant, float growthChance)
-            {
-                super(world, pos, soil, plant);
-                this.growthChance = growthChance;
-            }
-
-            public float getGrowthChance()
-            {
-                return growthChance;
-            }
-
-            public void setGrowthChance(float growthChance)
-            {
-                this.growthChance = growthChance;
-            }
+            this.growthChance = growthChance;
         }
     }
 }

--- a/src/test/java/net/minecraftforge/test/SoilPlantEventsTest.java
+++ b/src/test/java/net/minecraftforge/test/SoilPlantEventsTest.java
@@ -1,0 +1,36 @@
+package net.minecraftforge.test;
+
+import net.minecraft.init.Blocks;
+import net.minecraft.init.Items;
+import net.minecraftforge.common.MinecraftForge;
+import net.minecraftforge.event.world.BlockEvent.SoilPlantEvent.CanSoilSustainPlantEvent;
+import net.minecraftforge.event.world.BlockEvent.SoilPlantEvent.GetGrowthChanceEvent;
+import net.minecraftforge.fml.common.Mod;
+import net.minecraftforge.fml.common.Mod.EventHandler;
+import net.minecraftforge.fml.common.event.FMLInitializationEvent;
+import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
+
+@Mod(modid="SoilPlantEventsTest", name="SoilPlantEventsTest", version="0.0.0")
+public class SoilPlantEventsTest
+{
+
+	@EventHandler
+	public void init(FMLInitializationEvent event)
+	{
+		MinecraftForge.EVENT_BUS.register(this);
+	}
+
+	@SubscribeEvent
+	public void canSustain(CanSoilSustainPlantEvent event)
+	{
+		if(event.getState().getBlock() == Blocks.farmland && (event.getPlant() == Blocks.wheat || event.getPlant() == Items.wheat_seeds)) event.setCanSustain(false);
+		if(event.getState().getBlock() == Blocks.diamond_block && event.getPlant() == Blocks.beetroots) event.setCanSustain(true);
+	}
+
+	@SubscribeEvent
+	public void getGrowthChance(GetGrowthChanceEvent event)
+	{
+		if(event.getState().getBlock() == Blocks.diamond_block && event.getPlant() == Blocks.beetroots) event.setGrowthChance(event.getGrowthChance() * 10);
+	}
+
+}

--- a/src/test/java/net/minecraftforge/test/SoilPlantEventsTest.java
+++ b/src/test/java/net/minecraftforge/test/SoilPlantEventsTest.java
@@ -1,10 +1,8 @@
 package net.minecraftforge.test;
 
 import net.minecraft.init.Blocks;
-import net.minecraft.init.Items;
 import net.minecraftforge.common.MinecraftForge;
-import net.minecraftforge.event.world.BlockEvent.SoilPlantEvent.CanSoilSustainPlantEvent;
-import net.minecraftforge.event.world.BlockEvent.SoilPlantEvent.GetGrowthChanceEvent;
+import net.minecraftforge.event.world.BlockEvent.GetGrowthChanceEvent;
 import net.minecraftforge.fml.common.Mod;
 import net.minecraftforge.fml.common.Mod.EventHandler;
 import net.minecraftforge.fml.common.event.FMLInitializationEvent;
@@ -14,23 +12,16 @@ import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
 public class SoilPlantEventsTest
 {
 
-	@EventHandler
-	public void init(FMLInitializationEvent event)
-	{
-		MinecraftForge.EVENT_BUS.register(this);
-	}
+    @EventHandler
+    public void init(FMLInitializationEvent event)
+    {
+        MinecraftForge.EVENT_BUS.register(this);
+    }
 
-	@SubscribeEvent
-	public void canSustain(CanSoilSustainPlantEvent event)
-	{
-		if(event.getState().getBlock() == Blocks.farmland && (event.getPlant() == Blocks.wheat || event.getPlant() == Items.wheat_seeds)) event.setCanSustain(false);
-		if(event.getState().getBlock() == Blocks.diamond_block && event.getPlant() == Blocks.beetroots) event.setCanSustain(true);
-	}
-
-	@SubscribeEvent
-	public void getGrowthChance(GetGrowthChanceEvent event)
-	{
-		if(event.getState().getBlock() == Blocks.diamond_block && event.getPlant() == Blocks.beetroots) event.setGrowthChance(event.getGrowthChance() * 10);
-	}
+    @SubscribeEvent
+    public void getGrowthChance(GetGrowthChanceEvent event)
+    {
+        if(event.getPlant() == Blocks.beetroots) event.setGrowthChance(event.getGrowthChance() * 10);
+    }
 
 }


### PR DESCRIPTION
Added SoilPlantEvents: CanSoilSustainPlantEvent and GetGrowthChanceEvent. Can be used to modify plants, crops and soils behaviour (planting & growth speed respectively).

Currently, sustain event supports all crops and most plants.
Growth chance event supports all crops and nether warts.