### PR TITLE
Fix the rand given to PopulateChunkEvent

### DIFF
--- a/patches/minecraft/net/minecraft/world/gen/ChunkProviderEnd.java.patch
+++ b/patches/minecraft/net/minecraft/world/gen/ChunkProviderEnd.java.patch
@@ -58,7 +58,7 @@
      public void func_185931_b(int p_185931_1_, int p_185931_2_)
      {
          BlockFalling.field_149832_M = true;
-+        net.minecraftforge.event.ForgeEventFactory.onChunkPopulate(true, this, this.field_73230_p, p_185931_1_, p_185931_2_, false);
++        net.minecraftforge.event.ForgeEventFactory.onChunkPopulate(true, this, this.field_73230_p, this.field_73220_k, p_185931_1_, p_185931_2_, false);
          BlockPos blockpos = new BlockPos(p_185931_1_ * 16, 0, p_185931_2_ * 16);
  
          if (this.field_73229_q)
@@ -66,7 +66,7 @@
              }
          }
  
-+        net.minecraftforge.event.ForgeEventFactory.onChunkPopulate(false, this, this.field_73230_p, p_185931_1_, p_185931_2_, false);
++        net.minecraftforge.event.ForgeEventFactory.onChunkPopulate(false, this, this.field_73230_p, this.field_73220_k, p_185931_1_, p_185931_2_, false);
          BlockFalling.field_149832_M = false;
      }
  

--- a/patches/minecraft/net/minecraft/world/gen/ChunkProviderHell.java.patch
+++ b/patches/minecraft/net/minecraft/world/gen/ChunkProviderHell.java.patch
@@ -43,7 +43,7 @@
      public void func_185931_b(int p_185931_1_, int p_185931_2_)
      {
          BlockFalling.field_149832_M = true;
-+        net.minecraftforge.event.ForgeEventFactory.onChunkPopulate(true, this, this.field_185952_n, p_185931_1_, p_185931_2_, false);
++        net.minecraftforge.event.ForgeEventFactory.onChunkPopulate(true, this, this.field_185952_n, this.field_185954_p, p_185931_1_, p_185931_2_, false);
          BlockPos blockpos = new BlockPos(p_185931_1_ * 16, 0, p_185931_2_ * 16);
          ChunkCoordIntPair chunkcoordintpair = new ChunkCoordIntPair(p_185931_1_, p_185931_2_);
          this.field_73172_c.func_175794_a(this.field_185952_n, this.field_185954_p, chunkcoordintpair);
@@ -71,7 +71,7 @@
          }
 +        }//Forge: End doGLowstone
  
-+        net.minecraftforge.event.ForgeEventFactory.onChunkPopulate(false, this, this.field_185952_n, p_185931_1_, p_185931_2_, false);
++        net.minecraftforge.event.ForgeEventFactory.onChunkPopulate(false, this, this.field_185952_n, this.field_185954_p, p_185931_1_, p_185931_2_, false);
 +        net.minecraftforge.common.MinecraftForge.EVENT_BUS.post(new net.minecraftforge.event.terraingen.DecorateBiomeEvent.Pre(this.field_185952_n, this.field_185954_p, blockpos));
 +
 +        if (net.minecraftforge.event.terraingen.TerrainGen.decorate(this.field_185952_n, this.field_185954_p, blockpos, net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.SHROOM))

--- a/patches/minecraft/net/minecraft/world/gen/ChunkProviderOverworld.java.patch
+++ b/patches/minecraft/net/minecraft/world/gen/ChunkProviderOverworld.java.patch
@@ -46,7 +46,7 @@
          boolean flag = false;
          ChunkCoordIntPair chunkcoordintpair = new ChunkCoordIntPair(p_185931_1_, p_185931_2_);
  
-+        net.minecraftforge.event.ForgeEventFactory.onChunkPopulate(true, this, this.field_185995_n, p_185931_1_, p_185931_2_, flag);
++        net.minecraftforge.event.ForgeEventFactory.onChunkPopulate(true, this, this.field_185995_n, this.field_185990_i, p_185931_1_, p_185931_2_, flag);
 +
          if (this.field_185996_o)
          {
@@ -94,7 +94,7 @@
          }
 +        }//Forge: End ICE
  
-+        net.minecraftforge.event.ForgeEventFactory.onChunkPopulate(false, this, this.field_185995_n, p_185931_1_, p_185931_2_, flag);
++        net.minecraftforge.event.ForgeEventFactory.onChunkPopulate(false, this, this.field_185995_n, this.field_185990_i, p_185931_1_, p_185931_2_, flag);
 +
          BlockFalling.field_149832_M = false;
      }

--- a/src/main/java/net/minecraftforge/event/ForgeEventFactory.java
+++ b/src/main/java/net/minecraftforge/event/ForgeEventFactory.java
@@ -3,6 +3,7 @@ package net.minecraftforge.event;
 import java.io.File;
 import java.util.EnumSet;
 import java.util.List;
+import java.util.Random;
 
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.entity.Entity;
@@ -525,9 +526,19 @@ public class ForgeEventFactory
         return event.getResult() != net.minecraftforge.fml.common.eventhandler.Event.Result.DENY;
     }
 
+    /**
+     * @deprecated Use {@link #onChunkPopulate(boolean, IChunkGenerator, World, Random, int, int, boolean)}<br>
+     * The Random param should not be world.rand, it should be the same chunk-position-seeded rand used by the Chunk Provider.
+     */
+    @Deprecated
     public static void onChunkPopulate(boolean pre, IChunkGenerator gen, World world, int x, int z, boolean hasVillageGenerated)
     {
         MinecraftForge.EVENT_BUS.post(pre ? new PopulateChunkEvent.Pre(gen, world, world.rand, x, z, hasVillageGenerated) : new PopulateChunkEvent.Post(gen, world, world.rand, x, z, hasVillageGenerated));
+    }
+
+    public static void onChunkPopulate(boolean pre, IChunkGenerator gen, World world, Random rand, int x, int z, boolean hasVillageGenerated)
+    {
+        MinecraftForge.EVENT_BUS.post(pre ? new PopulateChunkEvent.Pre(gen, world, rand, x, z, hasVillageGenerated) : new PopulateChunkEvent.Post(gen, world, rand, x, z, hasVillageGenerated));
     }
 
 }


### PR DESCRIPTION
I ran into an extremely puzzling issue:
![](http://i.imgur.com/FZdWkMv.jpg)

The code is written to randomly pepper and world with hives, but my hives were placing themselves in the exact same way in every chunk in huge batches, and then none for long stretches.
Turns out `rand` parameter I got from the `PopulateChunkEvent.Post` was returning the same values every time my world populating code was called!

![](http://puu.sh/oJ8QR/dd67b0e67f.png)

The vanilla MapGen classes all call `world.setRandomSeed` during normal chunk population. It sort of looks like they're setting it with the chunk positions, but no. The params they give to `setRandomSeed` are identical many many times in a row.
Additionally, the `ForgeEventFactory.onChunkPopulate` was using `world.rand` for its rand parameter instead of the chunk-and-world-seeded one used for all the other world populating calls.

~~This PR fixes both of those issues.~~
This PR fixes the rand given to the `onChunkPopulate` event so it gets the chunk-seeded one.