### PR TITLE
Fixed Redstone Torch Memory Leak

### DIFF
--- a/patches/minecraft/net/minecraft/block/BlockRedstoneTorch.java.patch
+++ b/patches/minecraft/net/minecraft/block/BlockRedstoneTorch.java.patch
@@ -1,0 +1,11 @@
+--- ../src-base/minecraft/net/minecraft/block/BlockRedstoneTorch.java
++++ ../src-work/minecraft/net/minecraft/block/BlockRedstoneTorch.java
+@@ -23,7 +23,7 @@
+ 
+ public class BlockRedstoneTorch extends BlockTorch
+ {
+-    private static Map<World, List<BlockRedstoneTorch.Toggle>> field_150112_b = Maps.<World, List<BlockRedstoneTorch.Toggle>>newHashMap();
++    private static Map<World, List<BlockRedstoneTorch.Toggle>> field_150112_b = new java.util.WeakHashMap<World, List<BlockRedstoneTorch.Toggle>>();
+     private final boolean field_150113_a;
+ 
+     private boolean func_176598_a(World p_176598_1_, BlockPos p_176598_2_, boolean p_176598_3_)


### PR DESCRIPTION
In BlockRedstoneTorch there is a HashMap that is used to determine whether a Redstone Torch should burn out (Basically counts the amount of times it has been toggled). That map has World as keys and a list of "toggles" as values. Mappings are never removed, only added when there was a "toggle" in a world so the World instances stay in memory.

Steps to reproduce:
1. Place Redstone Torch in World & Toggle it with a lever.
2. Leave & Re-Enter World.
3. Repeat.

![visual vm screenshot](https://cloud.githubusercontent.com/assets/3648306/15108939/1bdb0366-15d9-11e6-8b6b-34db2886c820.png)
