### PR TITLE
Add LivingEnchantmentLevelEvent to alter effective enchantment levels

### DIFF
--- a/patches/minecraft/net/minecraft/block/Block.java.patch
+++ b/patches/minecraft/net/minecraft/block/Block.java.patch
@@ -148,7 +148,7 @@
          p_180657_2_.func_71020_j(0.025F);
  
 -        if (this.func_149700_E() && EnchantmentHelper.func_77506_a(Enchantments.field_185306_r, p_180657_6_) > 0)
-+        if (this.canSilkHarvest(p_180657_1_, p_180657_3_, p_180657_4_, p_180657_2_) && EnchantmentHelper.func_77506_a(Enchantments.field_185306_r, p_180657_6_) > 0)
++        if (this.canSilkHarvest(p_180657_1_, p_180657_3_, p_180657_4_, p_180657_2_) && EnchantmentHelper.getEnchantmentLevel(Enchantments.field_185306_r, p_180657_6_, p_180657_2_) > 0)
          {
 +            java.util.List<ItemStack> items = new java.util.ArrayList<ItemStack>();
              ItemStack itemstack = this.func_180643_i(p_180657_4_);
@@ -167,8 +167,9 @@
          }
          else
          {
+-            int i = EnchantmentHelper.func_77506_a(Enchantments.field_185308_t, p_180657_6_);
 +            harvesters.set(p_180657_2_);
-             int i = EnchantmentHelper.func_77506_a(Enchantments.field_185308_t, p_180657_6_);
++            int i = EnchantmentHelper.getEnchantmentLevel(Enchantments.field_185308_t, p_180657_6_, p_180657_2_);
              this.func_176226_b(p_180657_1_, p_180657_3_, p_180657_4_, i);
 +            harvesters.set(null);
          }

--- a/patches/minecraft/net/minecraft/block/BlockIce.java.patch
+++ b/patches/minecraft/net/minecraft/block/BlockIce.java.patch
@@ -5,7 +5,7 @@
          p_180657_2_.func_71020_j(0.025F);
  
 -        if (this.func_149700_E() && EnchantmentHelper.func_77506_a(Enchantments.field_185306_r, p_180657_6_) > 0)
-+        if (this.canSilkHarvest(p_180657_1_, p_180657_3_, p_180657_4_, p_180657_2_) && EnchantmentHelper.func_77506_a(Enchantments.field_185306_r, p_180657_6_) > 0)
++        if (this.canSilkHarvest(p_180657_1_, p_180657_3_, p_180657_4_, p_180657_2_) && EnchantmentHelper.getEnchantmentLevel(Enchantments.field_185306_r, p_180657_6_, p_180657_2_) > 0)
          {
 +            java.util.List<ItemStack> items = new java.util.ArrayList<ItemStack>();
              ItemStack itemstack = this.func_180643_i(p_180657_4_);
@@ -22,10 +22,12 @@
          }
          else
          {
-@@ -58,7 +63,9 @@
+@@ -57,8 +62,10 @@
+                 return;
              }
  
-             int i = EnchantmentHelper.func_77506_a(Enchantments.field_185308_t, p_180657_6_);
+-            int i = EnchantmentHelper.func_77506_a(Enchantments.field_185308_t, p_180657_6_);
++            int i = EnchantmentHelper.getEnchantmentLevel(Enchantments.field_185308_t, p_180657_6_, p_180657_2_);
 +            harvesters.set(p_180657_2_);
              this.func_176226_b(p_180657_1_, p_180657_3_, p_180657_4_, i);
 +            harvesters.set(null);

--- a/patches/minecraft/net/minecraft/enchantment/EnchantmentHelper.java.patch
+++ b/patches/minecraft/net/minecraft/enchantment/EnchantmentHelper.java.patch
@@ -1,6 +1,19 @@
 --- ../src-base/minecraft/net/minecraft/enchantment/EnchantmentHelper.java
 +++ ../src-work/minecraft/net/minecraft/enchantment/EnchantmentHelper.java
-@@ -292,7 +292,7 @@
+@@ -30,6 +30,12 @@
+     private static final EnchantmentHelper.HurtIterator field_151388_d = new EnchantmentHelper.HurtIterator();
+     private static final EnchantmentHelper.DamageIterator field_151389_e = new EnchantmentHelper.DamageIterator();
+ 
++    public static int getEnchantmentLevel(Enchantment enchID, ItemStack stack, EntityLivingBase entityLivingBase)
++    {
++        return net.minecraftforge.common.ForgeHooks.getEnchantmentLevel(entityLivingBase, enchID, stack, func_77506_a(enchID, stack));
++    }
++
++    @Deprecated
+     public static int func_77506_a(Enchantment p_77506_0_, ItemStack p_77506_1_)
+     {
+         if (p_77506_1_ == null)
+@@ -292,7 +298,7 @@
      public static int func_77514_a(Random p_77514_0_, int p_77514_1_, int p_77514_2_, ItemStack p_77514_3_)
      {
          Item item = p_77514_3_.func_77973_b();
@@ -9,7 +22,7 @@
  
          if (i <= 0)
          {
-@@ -339,7 +339,7 @@
+@@ -339,7 +345,7 @@
      {
          List<EnchantmentData> list = Lists.<EnchantmentData>newArrayList();
          Item item = p_77513_1_.func_77973_b();
@@ -18,7 +31,7 @@
  
          if (i <= 0)
          {
-@@ -380,7 +380,8 @@
+@@ -380,7 +386,8 @@
  
          while (iterator.hasNext())
          {
@@ -28,7 +41,7 @@
              {
                  iterator.remove();
              }
-@@ -395,7 +396,7 @@
+@@ -395,7 +402,7 @@
  
          for (Enchantment enchantment : Enchantment.field_185264_b)
          {

--- a/patches/minecraft/net/minecraft/item/ItemBow.java.patch
+++ b/patches/minecraft/net/minecraft/item/ItemBow.java.patch
@@ -1,7 +1,11 @@
 --- ../src-base/minecraft/net/minecraft/item/ItemBow.java
 +++ ../src-work/minecraft/net/minecraft/item/ItemBow.java
-@@ -90,6 +90,10 @@
-             boolean flag = entityplayer.field_71075_bZ.field_75098_d || EnchantmentHelper.func_77506_a(Enchantments.field_185312_x, p_77615_1_) > 0;
+@@ -87,9 +87,13 @@
+         if (p_77615_3_ instanceof EntityPlayer)
+         {
+             EntityPlayer entityplayer = (EntityPlayer)p_77615_3_;
+-            boolean flag = entityplayer.field_71075_bZ.field_75098_d || EnchantmentHelper.func_77506_a(Enchantments.field_185312_x, p_77615_1_) > 0;
++            boolean flag = entityplayer.field_71075_bZ.field_75098_d || EnchantmentHelper.getEnchantmentLevel(Enchantments.field_185312_x, p_77615_1_, p_77615_3_) > 0;
              ItemStack itemstack = this.func_185060_a(entityplayer);
  
 +            int i = this.func_77626_a(p_77615_1_) - p_77615_4_;
@@ -25,6 +29,31 @@
  
                      if (!p_77615_2_.field_72995_K)
                      {
+@@ -115,21 +118,21 @@
+                             entityarrow.func_70243_d(true);
+                         }
+ 
+-                        int j = EnchantmentHelper.func_77506_a(Enchantments.field_185309_u, p_77615_1_);
++                        int j = EnchantmentHelper.getEnchantmentLevel(Enchantments.field_185309_u, p_77615_1_, p_77615_3_);
+ 
+                         if (j > 0)
+                         {
+                             entityarrow.func_70239_b(entityarrow.func_70242_d() + (double)j * 0.5D + 0.5D);
+                         }
+ 
+-                        int k = EnchantmentHelper.func_77506_a(Enchantments.field_185310_v, p_77615_1_);
++                        int k = EnchantmentHelper.getEnchantmentLevel(Enchantments.field_185310_v, p_77615_1_, p_77615_3_);
+ 
+                         if (k > 0)
+                         {
+                             entityarrow.func_70240_a(k);
+                         }
+ 
+-                        if (EnchantmentHelper.func_77506_a(Enchantments.field_185311_w, p_77615_1_) > 0)
++                        if (EnchantmentHelper.getEnchantmentLevel(Enchantments.field_185311_w, p_77615_1_, p_77615_3_) > 0)
+                         {
+                             entityarrow.func_70015_d(100);
+                         }
 @@ -189,6 +192,9 @@
      {
          boolean flag = this.func_185060_a(p_77659_3_) != null;

--- a/patches/minecraft/net/minecraft/item/ItemShears.java.patch
+++ b/patches/minecraft/net/minecraft/item/ItemShears.java.patch
@@ -29,7 +29,7 @@
 +            if (target.isShearable(itemstack, entity.field_70170_p, pos))
 +            {
 +                java.util.List<ItemStack> drops = target.onSheared(itemstack, entity.field_70170_p, pos,
-+                        net.minecraft.enchantment.EnchantmentHelper.func_77506_a(net.minecraft.init.Enchantments.field_185308_t, itemstack));
++                        net.minecraft.enchantment.EnchantmentHelper.getEnchantmentLevel(net.minecraft.init.Enchantments.field_185308_t, itemstack, player));
 +
 +                java.util.Random rand = new java.util.Random();
 +                for(ItemStack stack : drops)
@@ -60,7 +60,7 @@
 +            if (target.isShearable(itemstack, player.field_70170_p, pos))
 +            {
 +                java.util.List<ItemStack> drops = target.onSheared(itemstack, player.field_70170_p, pos,
-+                        net.minecraft.enchantment.EnchantmentHelper.func_77506_a(net.minecraft.init.Enchantments.field_185308_t, itemstack));
++                        net.minecraft.enchantment.EnchantmentHelper.getEnchantmentLevel(net.minecraft.init.Enchantments.field_185308_t, itemstack, player));
 +                java.util.Random rand = new java.util.Random();
 +
 +                for(ItemStack stack : drops)

--- a/patches/minecraft/net/minecraft/item/ItemStack.java.patch
+++ b/patches/minecraft/net/minecraft/item/ItemStack.java.patch
@@ -135,6 +135,15 @@
      }
  
      public boolean func_96631_a(int p_96631_1_, Random p_96631_2_)
+@@ -254,7 +260,7 @@
+         {
+             if (p_96631_1_ > 0)
+             {
+-                int i = EnchantmentHelper.func_77506_a(Enchantments.field_185307_s, this);
++                int i = EnchantmentHelper.getEnchantmentLevel(Enchantments.field_185307_s, this, null);
+                 int j = 0;
+ 
+                 for (int k = 0; i > 0 && k < p_96631_1_; ++k)
 @@ -273,8 +279,8 @@
                  }
              }

--- a/src/main/java/net/minecraftforge/common/ForgeHooks.java
+++ b/src/main/java/net/minecraftforge/common/ForgeHooks.java
@@ -24,6 +24,7 @@ import net.minecraft.block.material.Material;
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.GuiScreen;
+import net.minecraft.enchantment.Enchantment;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.EntityList;
 import net.minecraft.entity.EntityLivingBase;
@@ -85,6 +86,7 @@ import net.minecraftforge.event.entity.item.ItemTossEvent;
 import net.minecraftforge.event.entity.living.LivingAttackEvent;
 import net.minecraftforge.event.entity.living.LivingDeathEvent;
 import net.minecraftforge.event.entity.living.LivingDropsEvent;
+import net.minecraftforge.event.entity.living.LivingEnchantmentLevelEvent;
 import net.minecraftforge.event.entity.living.LivingEvent.LivingJumpEvent;
 import net.minecraftforge.event.entity.living.LivingEvent.LivingUpdateEvent;
 import net.minecraftforge.event.entity.living.LivingFallEvent;
@@ -984,6 +986,13 @@ public class ForgeHooks
     public static void onEmptyClick(EntityPlayer player, EnumHand hand)
     {
         MinecraftForge.EVENT_BUS.post(new PlayerInteractEvent.RightClickEmpty(player, hand));
+    }
+    
+    public static int getEnchantmentLevel(EntityLivingBase entityLiving, Enchantment enchantment, ItemStack heldItem, int level)
+    {
+        LivingEnchantmentLevelEvent e = new LivingEnchantmentLevelEvent(entityLiving, enchantment, heldItem, level);
+        MinecraftForge.EVENT_BUS.post(e);
+        return e.getLevel();
     }
 
     private static ThreadLocal<Deque<LootTableContext>> lootContext = new ThreadLocal<Deque<LootTableContext>>();

--- a/src/main/java/net/minecraftforge/event/entity/living/LivingEnchantmentLevelEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/living/LivingEnchantmentLevelEvent.java
@@ -1,0 +1,45 @@
+package net.minecraftforge.event.entity.living;
+
+import net.minecraft.enchantment.Enchantment;
+import net.minecraft.entity.EntityLivingBase;
+import net.minecraft.item.ItemStack;
+
+/**
+ * This event is fired when an enchantment level is being looked up for an entity.
+ * @author rubensworks
+ **/
+public class LivingEnchantmentLevelEvent extends LivingEvent
+{
+
+    private final Enchantment enchantment;
+    private final ItemStack heldItem;
+    private int level;
+
+    public LivingEnchantmentLevelEvent(EntityLivingBase entityLiving, Enchantment enchantment, ItemStack heldItem, int level)
+    {
+        super(entityLiving);
+        this.enchantment = enchantment;
+        this.heldItem = heldItem;
+        this.level = level;
+    }
+
+    public Enchantment getEnchantment()
+    {
+        return enchantment;
+    }
+    
+    public ItemStack getHeldItem()
+    {
+        return heldItem;
+    }
+    
+    public int getLevel()
+    {
+        return level;
+    }
+
+    public void setLevel(int level)
+    {
+        this.level = level;
+    }
+}

--- a/src/main/java/net/minecraftforge/event/world/BlockEvent.java
+++ b/src/main/java/net/minecraftforge/event/world/BlockEvent.java
@@ -101,13 +101,13 @@ public class BlockEvent extends Event
             this.player = player;
 
             if (state == null || !ForgeHooks.canHarvestBlock(state.getBlock(), player, world, pos) || // Handle empty block or player unable to break block scenario
-                (state.getBlock().canSilkHarvest(world, pos, world.getBlockState(pos), player) && EnchantmentHelper.getEnchantmentLevel(Enchantments.silkTouch, player.getHeldItemMainhand()) > 0)) // If the block is being silk harvested, the exp dropped is 0
+                (state.getBlock().canSilkHarvest(world, pos, world.getBlockState(pos), player) && EnchantmentHelper.getEnchantmentLevel(Enchantments.silkTouch, player.getHeldItemMainhand(), player) > 0)) // If the block is being silk harvested, the exp dropped is 0
             {
                 this.exp = 0;
             }
             else
             {
-                int bonusLevel = EnchantmentHelper.getEnchantmentLevel(Enchantments.fortune, player.getHeldItemMainhand());
+                int bonusLevel = EnchantmentHelper.getEnchantmentLevel(Enchantments.fortune, player.getHeldItemMainhand(), player);
                 this.exp = state.getBlock().getExpDrop(state, world, pos, bonusLevel);
             }
         }

--- a/src/test/java/net/minecraftforge/test/EnchantmentLevelEventTest.java
+++ b/src/test/java/net/minecraftforge/test/EnchantmentLevelEventTest.java
@@ -1,0 +1,31 @@
+package net.minecraftforge.test;
+
+import net.minecraft.init.Enchantments;
+import net.minecraftforge.common.MinecraftForge;
+import net.minecraftforge.event.entity.living.LivingEnchantmentLevelEvent;
+import net.minecraftforge.fml.common.Mod;
+import net.minecraftforge.fml.common.event.FMLPreInitializationEvent;
+import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
+
+@Mod(modid="forge.enchantmentleveleventtest",version="1.0")
+public class EnchantmentLevelEventTest
+{
+
+    @Mod.EventHandler
+    public void preinit(FMLPreInitializationEvent evt)
+    {
+        MinecraftForge.EVENT_BUS.register(this);
+    }
+
+    @SubscribeEvent
+    public void onInteract(LivingEnchantmentLevelEvent event)
+    {
+        if (event.getEnchantment() == Enchantments.fortune && event.getEntityLiving().isSneaking())
+        {
+            int oldLevel = event.getLevel();
+            int newLevel = (oldLevel + 1) * 10;
+            event.setLevel(newLevel);
+            System.out.println("Set fortune level from " + oldLevel + " to " + newLevel);
+        }
+    }
+}


### PR DESCRIPTION
This adds an event that allows enchantment levels to be modified when they are calculated.
This makes it possible to change these levels based on the player and its environment, rather than always being fixed per ItemStack.
Note that this is not the same as #2826, which adds an event to alter things *during* the enchant action, while this PR adds an event to change the enchantment level *after* the enchant action.

This is useful in cases like:
* Changing fortune level if the player is sneaking.
* Changing fire aspect modifier if the player is in a warm biome.
* Increase looting level if the player is mounted on a certain entity.
* Changing lure level if fishing while it's night.

This PR deprecates (but does not remove) the `EnchantmentHelper#getEnchantmentLevel` method and adds a player-sensitive one, which is used instead now.

The only part I'm not convinced about is the application of the unbreaking modifier: https://github.com/rubensworks/MinecraftForge/blob/cb20e0553ae95bc371426e95306052fc52466678/patches/minecraft/net/minecraft/item/ItemStack.java.patch#L143

A test mod is included that multiplies the fortune level when mining by 10 levels when the player is sneaking.
`null` is passed as entity parameter, because the containing method does not have an entity parameter, and changing that would require a lot patching in other places which may be undesirable.