### PR TITLE
Added IAnvilRecipe

### DIFF
--- a/patches/minecraft/net/minecraft/inventory/ContainerRepair.java.patch
+++ b/patches/minecraft/net/minecraft/inventory/ContainerRepair.java.patch
@@ -1,15 +1,29 @@
 --- ../src-base/minecraft/net/minecraft/inventory/ContainerRepair.java
 +++ ../src-work/minecraft/net/minecraft/inventory/ContainerRepair.java
+@@ -60,7 +60,7 @@
+             }
+             public boolean func_82869_a(EntityPlayer p_82869_1_)
+             {
+-                return (p_82869_1_.field_71075_bZ.field_75098_d || p_82869_1_.field_71068_ca >= ContainerRepair.this.field_82854_e) && ContainerRepair.this.field_82854_e > 0 && this.func_75216_d();
++                return (p_82869_1_.field_71075_bZ.field_75098_d || p_82869_1_.field_71068_ca >= ContainerRepair.this.field_82854_e) && this.func_75216_d();
+             }
+             public void func_82870_a(EntityPlayer p_82870_1_, ItemStack p_82870_2_)
+             {
 @@ -69,6 +69,8 @@
                      p_82870_1_.func_82242_a(-ContainerRepair.this.field_82854_e);
                  }
  
 +                float breakChance = net.minecraftforge.common.ForgeHooks.onAnvilRepair(p_82870_1_, p_82870_2_, ContainerRepair.this.field_82853_g.func_70301_a(0), ContainerRepair.this.field_82853_g.func_70301_a(1));
-+
++                if (!net.minecraftforge.common.AnvilRecipeHandler.INSTANCE.onPickupFromSlot(ContainerRepair.this.field_82853_g, ContainerRepair.this.field_82857_m, ContainerRepair.this.field_82860_h)) {
                  ContainerRepair.this.field_82853_g.func_70299_a(0, (ItemStack)null);
  
                  if (ContainerRepair.this.field_82856_l > 0)
-@@ -93,7 +95,7 @@
+@@ -89,11 +91,11 @@
+                 {
+                     ContainerRepair.this.field_82853_g.func_70299_a(1, (ItemStack)null);
+                 }
+-
++                }
                  ContainerRepair.this.field_82854_e = 0;
                  IBlockState iblockstate = p_i45807_2_.func_180495_p(p_i45807_3_);
  
@@ -18,12 +32,21 @@
                  {
                      int l = ((Integer)iblockstate.func_177229_b(BlockAnvil.field_176505_b)).intValue();
                      ++l;
-@@ -160,10 +162,12 @@
+@@ -113,6 +115,7 @@
+                 {
+                     p_i45807_2_.func_175718_b(1030, p_i45807_3_, 0);
+                 }
++                ContainerRepair.this.func_82848_d();
+             }
+         });
+ 
+@@ -160,10 +163,12 @@
              Map<Enchantment, Integer> map = EnchantmentHelper.func_82781_a(itemstack1);
              j = j + itemstack.func_82838_A() + (itemstack2 == null ? 0 : itemstack2.func_82838_A());
              this.field_82856_l = 0;
+-
 +            boolean flag = false;
- 
++            if (net.minecraftforge.common.AnvilRecipeHandler.INSTANCE.updateRepairOutput(this, itemstack, itemstack2, field_82852_f, field_82857_m, j, this.field_82860_h)) return;
              if (itemstack2 != null)
              {
 -                boolean flag = itemstack2.func_77973_b() == Items.field_151134_bR && !Items.field_151134_bR.func_92110_g(itemstack2).func_82582_d();
@@ -32,7 +55,7 @@
  
                  if (itemstack1.func_77984_f() && itemstack1.func_77973_b().func_82789_a(itemstack, itemstack2))
                  {
-@@ -235,7 +239,7 @@
+@@ -235,7 +240,7 @@
  
                              for (Enchantment enchantment : map.keySet())
                              {
@@ -41,7 +64,7 @@
                                  {
                                      flag1 = false;
                                      ++i;
-@@ -279,6 +283,8 @@
+@@ -279,6 +284,8 @@
                  }
              }
  

--- a/src/main/java/net/minecraftforge/common/AnvilRecipeHandler.java
+++ b/src/main/java/net/minecraftforge/common/AnvilRecipeHandler.java
@@ -13,13 +13,13 @@ import net.minecraft.world.World;
 
 public class AnvilRecipeHandler
 {
-    public static final AnvilRecipeHandler INSTANCE     = new AnvilRecipeHandler();
-    private             List<IAnvilRecipe> anvilRecipes = new ArrayList<IAnvilRecipe>();
+    public static final AnvilRecipeHandler INSTANCE = new AnvilRecipeHandler();
+    private List<IAnvilRecipe> anvilRecipes = new ArrayList<IAnvilRecipe>();
 
     /**
      * Add an Anvil Recipe
      */
-    public void addRepair(IAnvilRecipe recipe)
+    public void add(IAnvilRecipe recipe)
     {
         anvilRecipes.add(recipe);
     }
@@ -27,11 +27,9 @@ public class AnvilRecipeHandler
     /**
      * Remove an Anvil Recipe
      */
-    public void removeRepair(IAnvilRecipe recipe)
+    public boolean remove(IAnvilRecipe recipe)
     {
-        if (anvilRecipes.contains(recipe)) {
-            anvilRecipes.remove(recipe);
-        }
+        return anvilRecipes.remove(recipe);
     }
 
     /**
@@ -45,10 +43,13 @@ public class AnvilRecipeHandler
     public boolean onPickupFromSlot(IInventory inputSlots, String name, World world)
     {
         String newName = (!Strings.isNullOrEmpty(name) && !name.equals(inputSlots.getStackInSlot(0).getDisplayName())) ? name : "";
-        if (getRepairResult(inputSlots.getStackInSlot(0), inputSlots.getStackInSlot(1), newName, world) != null) {
+        if (getRepairResult(inputSlots.getStackInSlot(0), inputSlots.getStackInSlot(1), newName, world) != null)
+        {
             doRepair(inputSlots.getStackInSlot(0), inputSlots.getStackInSlot(1), newName, world);
-            for (int slot = 0; slot < 2; slot++) {
-                if (inputSlots.getStackInSlot(slot) != null && inputSlots.getStackInSlot(slot).stackSize < 1) {
+            for (int slot = 0; slot < 2; slot++)
+            {
+                if (inputSlots.getStackInSlot(slot) != null && inputSlots.getStackInSlot(slot).stackSize < 1)
+                {
                     inputSlots.setInventorySlotContents(slot, null);
                 }
             }
@@ -61,11 +62,13 @@ public class AnvilRecipeHandler
     {
         String newName = (!Strings.isNullOrEmpty(name) && !name.equals(inputLeft.getDisplayName())) ? name : "";
         ItemStack result = getRepairResult(inputLeft, inputRight, newName, world);
-        if (result != null) {
+        if (result != null)
+        {
             outputSlot.setInventorySlotContents(0, result);
             container.materialCost = 0;
             container.maximumCost = getRepairCost(inputLeft, inputRight, newName, world);
-            if (!Strings.isNullOrEmpty(newName)) {
+            if (!Strings.isNullOrEmpty(newName))
+            {
                 outputSlot.getStackInSlot(0).setStackDisplayName(name);
             }
             return true;
@@ -82,21 +85,24 @@ public class AnvilRecipeHandler
     public int getRepairCost(ItemStack inputLeft, ItemStack inputRight, String newName, World world)
     {
         IAnvilRecipe recipe = getRecipe(inputLeft, inputRight, newName, world);
-        return recipe == null ? 0 : recipe.getCost(inputLeft, inputRight, newName, world);
+        return recipe == null ? 0 : recipe.getExpCost(inputLeft, inputRight, newName, world);
     }
 
     public void doRepair(ItemStack inputLeft, ItemStack inputRight, String newName, World world)
     {
         IAnvilRecipe recipe = getRecipe(inputLeft, inputRight, newName, world);
-        if (recipe != null) {
+        if (recipe != null)
+        {
             recipe.doRepair(inputLeft, inputRight, newName, world);
         }
     }
 
     private IAnvilRecipe getRecipe(ItemStack inputLeft, ItemStack inputRight, String newName, World world)
     {
-        for (IAnvilRecipe recipe : anvilRecipes) {
-            if (recipe.matches(inputLeft, inputRight, newName, world)) {
+        for (IAnvilRecipe recipe : anvilRecipes)
+        {
+            if (recipe.matches(inputLeft, inputRight, newName, world))
+            {
                 return recipe;
             }
         }

--- a/src/main/java/net/minecraftforge/common/AnvilRecipeHandler.java
+++ b/src/main/java/net/minecraftforge/common/AnvilRecipeHandler.java
@@ -1,0 +1,105 @@
+package net.minecraftforge.common;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import com.google.common.base.Strings;
+import com.google.common.collect.ImmutableList;
+
+import net.minecraft.inventory.ContainerRepair;
+import net.minecraft.inventory.IInventory;
+import net.minecraft.item.ItemStack;
+import net.minecraft.world.World;
+
+public class AnvilRecipeHandler
+{
+    public static final AnvilRecipeHandler INSTANCE     = new AnvilRecipeHandler();
+    private             List<IAnvilRecipe> anvilRecipes = new ArrayList<IAnvilRecipe>();
+
+    /**
+     * Add an Anvil Recipe
+     */
+    public void addRepair(IAnvilRecipe recipe)
+    {
+        anvilRecipes.add(recipe);
+    }
+
+    /**
+     * Remove an Anvil Recipe
+     */
+    public void removeRepair(IAnvilRecipe recipe)
+    {
+        if (anvilRecipes.contains(recipe)) {
+            anvilRecipes.remove(recipe);
+        }
+    }
+
+    /**
+     * Get the list of registered recipes
+     */
+    public List<IAnvilRecipe> getAnvilRecipes()
+    {
+        return ImmutableList.copyOf(this.anvilRecipes);
+    }
+
+    public boolean onPickupFromSlot(IInventory inputSlots, String name, World world)
+    {
+        String newName = (!Strings.isNullOrEmpty(name) && !name.equals(inputSlots.getStackInSlot(0).getDisplayName())) ? name : "";
+        if (getRepairResult(inputSlots.getStackInSlot(0), inputSlots.getStackInSlot(1), newName, world) != null) {
+            doRepair(inputSlots.getStackInSlot(0), inputSlots.getStackInSlot(1), newName, world);
+            for (int slot = 0; slot < 2; slot++) {
+                if (inputSlots.getStackInSlot(slot) != null && inputSlots.getStackInSlot(slot).stackSize < 1) {
+                    inputSlots.setInventorySlotContents(slot, null);
+                }
+            }
+            return true;
+        }
+        return false;
+    }
+
+    public boolean updateRepairOutput(ContainerRepair container, ItemStack inputLeft, ItemStack inputRight, IInventory outputSlot, String name, int baseCost, World world)
+    {
+        String newName = (!Strings.isNullOrEmpty(name) && !name.equals(inputLeft.getDisplayName())) ? name : "";
+        ItemStack result = getRepairResult(inputLeft, inputRight, newName, world);
+        if (result != null) {
+            outputSlot.setInventorySlotContents(0, result);
+            container.materialCost = 0;
+            container.maximumCost = getRepairCost(inputLeft, inputRight, newName, world);
+            if (!Strings.isNullOrEmpty(newName)) {
+                outputSlot.getStackInSlot(0).setStackDisplayName(name);
+            }
+            return true;
+        }
+        return false;
+    }
+
+    public ItemStack getRepairResult(ItemStack inputLeft, ItemStack inputRight, String newName, World world)
+    {
+        IAnvilRecipe recipe = getRecipe(inputLeft, inputRight, newName, world);
+        return recipe == null ? null : recipe.getResult(inputLeft, inputRight, newName, world);
+    }
+
+    public int getRepairCost(ItemStack inputLeft, ItemStack inputRight, String newName, World world)
+    {
+        IAnvilRecipe recipe = getRecipe(inputLeft, inputRight, newName, world);
+        return recipe == null ? 0 : recipe.getCost(inputLeft, inputRight, newName, world);
+    }
+
+    public void doRepair(ItemStack inputLeft, ItemStack inputRight, String newName, World world)
+    {
+        IAnvilRecipe recipe = getRecipe(inputLeft, inputRight, newName, world);
+        if (recipe != null) {
+            recipe.doRepair(inputLeft, inputRight, newName, world);
+        }
+    }
+
+    private IAnvilRecipe getRecipe(ItemStack inputLeft, ItemStack inputRight, String newName, World world)
+    {
+        for (IAnvilRecipe recipe : anvilRecipes) {
+            if (recipe.matches(inputLeft, inputRight, newName, world)) {
+                return recipe;
+            }
+        }
+        return null;
+    }
+}

--- a/src/main/java/net/minecraftforge/common/IAnvilRecipe.java
+++ b/src/main/java/net/minecraftforge/common/IAnvilRecipe.java
@@ -2,6 +2,8 @@ package net.minecraftforge.common;
 
 import java.util.List;
 
+import org.apache.commons.lang3.tuple.Pair;
+
 import net.minecraft.item.ItemStack;
 import net.minecraft.world.World;
 
@@ -10,8 +12,17 @@ public interface IAnvilRecipe
     /**
      * Returns the input for this recipe, any mod accessing this value should never
      * manipulate the values in this array as it will effect the recipe itself.
+     *
+     * @return The recipes input vales.
      */
-    List[] getInputs();
+    Pair<List<ItemStack>, List<ItemStack>> getInput();
+
+    /**
+     * The material cost of this recipe
+     *
+     * @return Returns the amount the inputRight item's stacksize will decrease by.
+     */
+    int getMaterialCost();
 
     /**
      * Used to check if a recipe matches current anvil inventory
@@ -41,7 +52,7 @@ public interface IAnvilRecipe
      * @param newName    The items new name, empty if not being renamed.
      * @param world      The current world
      */
-    int getCost(ItemStack inputLeft, ItemStack inputRight, String newName, World world);
+    int getExpCost(ItemStack inputLeft, ItemStack inputRight, String newName, World world);
 
     /**
      * Called when the repair is done, Use this to modify the input stacks as needed.

--- a/src/main/java/net/minecraftforge/common/IAnvilRecipe.java
+++ b/src/main/java/net/minecraftforge/common/IAnvilRecipe.java
@@ -1,0 +1,56 @@
+package net.minecraftforge.common;
+
+import java.util.List;
+
+import net.minecraft.item.ItemStack;
+import net.minecraft.world.World;
+
+public interface IAnvilRecipe
+{
+    /**
+     * Returns the input for this recipe, any mod accessing this value should never
+     * manipulate the values in this array as it will effect the recipe itself.
+     */
+    List[] getInputs();
+
+    /**
+     * Used to check if a recipe matches current anvil inventory
+     *
+     * @param inputLeft  The item in the left input slot
+     * @param inputRight The item in the right input slot
+     * @param newName    The items new name, empty if not being renamed.
+     * @param world      The current world
+     */
+    boolean matches(ItemStack inputLeft, ItemStack inputRight, String newName, World world);
+
+    /**
+     * Returns an Item that is the result of this recipe
+     *
+     * @param inputLeft  The item in the left input slot
+     * @param inputRight The item in the right input slot
+     * @param newName    The items new name, empty if not being renamed.
+     * @param world      The current world
+     */
+    ItemStack getResult(ItemStack inputLeft, ItemStack inputRight, String newName, World world);
+
+    /**
+     * Returns the experience cost of this recipe
+     *
+     * @param inputLeft  The item in the left input slot
+     * @param inputRight The item in the right input slot
+     * @param newName    The items new name, empty if not being renamed.
+     * @param world      The current world
+     */
+    int getCost(ItemStack inputLeft, ItemStack inputRight, String newName, World world);
+
+    /**
+     * Called when the repair is done, Use this to modify the input stacks as needed.
+     * To remove the item set it's stacksize to 0
+     *
+     * @param inputLeft  The item in the left input slot
+     * @param inputRight The item in the right input slot
+     * @param newName    The items new name, empty if not being renamed.
+     * @param world      The current world
+     */
+    void doRepair(ItemStack inputLeft, ItemStack inputRight, String newName, World world);
+}

--- a/src/main/java/net/minecraftforge/common/SimpleAnvilRecipe.java
+++ b/src/main/java/net/minecraftforge/common/SimpleAnvilRecipe.java
@@ -1,0 +1,106 @@
+package net.minecraftforge.common;
+
+import java.util.List;
+
+import com.google.common.collect.ImmutableList;
+
+import net.minecraft.block.Block;
+import net.minecraft.item.Item;
+import net.minecraft.item.ItemStack;
+import net.minecraft.world.World;
+import net.minecraftforge.oredict.OreDictionary;
+
+public class SimpleAnvilRecipe implements IAnvilRecipe
+{
+    protected final List<ItemStack> left;
+    protected final List<ItemStack> right;
+    protected final ItemStack       output;
+    protected final int             expCost;
+    protected final int             matCost;
+
+    public SimpleAnvilRecipe(ItemStack result, Object inputLeft, Object inputRight, int materialCost, int experienceCost)
+    {
+        this.output = result.copy();
+        this.left = processInput(inputLeft);
+        this.right = processInput(inputRight);
+        this.matCost = materialCost;
+        this.expCost = experienceCost;
+        if (this.left == null || (this.right == null && inputRight != null)) {
+            String ret = "Invalid simple anvil recipe: " + inputLeft + ", " + inputRight + ", " + this.output;
+            throw new RuntimeException(ret);
+        }
+    }
+
+    private List<ItemStack> processInput(Object input)
+    {
+        if (input instanceof String) {
+            return OreDictionary.getOres((String)input);
+        } else {
+            ItemStack stack = null;
+            if (input instanceof ItemStack) {
+                stack = ((ItemStack)input).copy();
+            } else if (input instanceof Item) {
+                stack = new ItemStack((Item)input);
+            } else if (input instanceof Block) {
+                stack = new ItemStack((Block)input, 1, OreDictionary.WILDCARD_VALUE);
+            }
+            return stack != null ? ImmutableList.of(stack) : OreDictionary.EMPTY_LIST;
+        }
+    }
+
+    @Override
+    public boolean matches(ItemStack inputLeft, ItemStack inputRight, String newName, World world)
+    {
+        return checkMatch(this.left, inputLeft) && checkMatch(this.right, inputRight);
+    }
+
+    private boolean checkMatch(List<ItemStack> target, ItemStack tableItem)
+    {
+        if (target == OreDictionary.EMPTY_LIST) {
+            return tableItem == null;
+        }
+        for (ItemStack stack : target) {
+            if (stack != null && OreDictionary.itemMatches(stack, tableItem, false)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Returns the input for this recipe, any mod accessing this value should never
+     * manipulate the values in this array as it will effect the recipe itself.
+     *
+     * @return The recipe input vales. Each value can be an ItemStack, List<ItemStack> or null.
+     */
+    @Override
+    public List[] getInputs()
+    {
+        return new List[] { this.left, this.right };
+    }
+
+    /**
+     * Returns an Item that is the result of this recipe
+     */
+    @Override
+    public ItemStack getResult(ItemStack inputLeft, ItemStack inputRight, String newName, World world)
+    {
+        return this.output.copy();
+    }
+
+    /**
+     * Returns the experience cost of this recipe
+     */
+    @Override
+    public int getCost(ItemStack inputLeft, ItemStack inputRight, String newName, World world)
+    {
+        return this.expCost;
+    }
+
+    @Override
+    public void doRepair(ItemStack inputLeft, ItemStack inputRight, String newName, World world)
+    {
+        inputLeft.stackSize = 0;
+        inputRight.stackSize -= this.matCost;
+    }
+}

--- a/src/test/java/net/minecraftforge/test/AnvilRecipeTest.java
+++ b/src/test/java/net/minecraftforge/test/AnvilRecipeTest.java
@@ -1,8 +1,11 @@
 package net.minecraftforge.test;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.Random;
-import com.google.common.collect.ImmutableList;
+
+import org.apache.commons.lang3.tuple.Pair;
+
 import net.minecraft.init.Blocks;
 import net.minecraft.init.Items;
 import net.minecraft.item.Item;
@@ -24,9 +27,10 @@ public class AnvilRecipeTest
     @Mod.EventHandler
     public void init(FMLInitializationEvent event)
     {
-        AnvilRecipeHandler.INSTANCE.addRepair(new SimpleAnvilRecipe(new ItemStack(Items.iron_chestplate), Items.leather_chestplate, Items.iron_ingot, 5, 0));
-        AnvilRecipeHandler.INSTANCE.addRepair(new MelonAnvilRecipe());
-        AnvilRecipeHandler.INSTANCE.addRepair(new MegmaCreamAnvilRecipe());
+        AnvilRecipeHandler.INSTANCE.add(new SimpleAnvilRecipe(new ItemStack(Items.experience_bottle), Items.glass_bottle, null, 0, 1));
+        AnvilRecipeHandler.INSTANCE.add(new SimpleAnvilRecipe(new ItemStack(Items.iron_chestplate), Items.leather_chestplate, Items.iron_ingot, 5, 0));
+        AnvilRecipeHandler.INSTANCE.add(new MelonAnvilRecipe());
+        AnvilRecipeHandler.INSTANCE.add(new MegmaCreamAnvilRecipe());
     }
 
     public static class MelonAnvilRecipe implements IAnvilRecipe
@@ -36,8 +40,8 @@ public class AnvilRecipeTest
 
         public MelonAnvilRecipe()
         {
-            this.left = ImmutableList.of(new ItemStack(Items.wooden_axe));
-            this.right = ImmutableList.of(new ItemStack(Blocks.melon_block));
+            this.left = Collections.singletonList(new ItemStack(Items.wooden_axe));
+            this.right = Collections.singletonList(new ItemStack(Blocks.melon_block));
         }
 
         @Override
@@ -47,9 +51,15 @@ public class AnvilRecipeTest
         }
 
         @Override
-        public List[] getInputs()
+        public Pair<List<ItemStack>, List<ItemStack>> getInput()
         {
-            return new List[] { this.left, this.right };
+            return Pair.of(this.left, this.right);
+        }
+
+        @Override
+        public int getMaterialCost()
+        {
+            return 1;
         }
 
         @Override
@@ -59,7 +69,7 @@ public class AnvilRecipeTest
         }
 
         @Override
-        public int getCost(ItemStack inputLeft, ItemStack inputRight, String newName, World world)
+        public int getExpCost(ItemStack inputLeft, ItemStack inputRight, String newName, World world)
         {
             return 0;
         }
@@ -88,7 +98,7 @@ public class AnvilRecipeTest
         }
 
         @Override
-        public int getCost(ItemStack inputLeft, ItemStack inputRight, String newName, World world)
+        public int getExpCost(ItemStack inputLeft, ItemStack inputRight, String newName, World world)
         {
             return inputRight == null ? 0 : this.expCost * ((inputRight.stackSize / 8) + 1);
         }

--- a/src/test/java/net/minecraftforge/test/AnvilRecipeTest.java
+++ b/src/test/java/net/minecraftforge/test/AnvilRecipeTest.java
@@ -1,0 +1,103 @@
+package net.minecraftforge.test;
+
+import java.util.List;
+import java.util.Random;
+import com.google.common.collect.ImmutableList;
+import net.minecraft.init.Blocks;
+import net.minecraft.init.Items;
+import net.minecraft.item.Item;
+import net.minecraft.item.ItemAxe;
+import net.minecraft.item.ItemStack;
+import net.minecraft.world.World;
+import net.minecraftforge.common.AnvilRecipeHandler;
+import net.minecraftforge.common.IAnvilRecipe;
+import net.minecraftforge.common.SimpleAnvilRecipe;
+import net.minecraftforge.fml.common.Mod;
+import net.minecraftforge.fml.common.event.FMLInitializationEvent;
+
+@Mod(modid = AnvilRecipeTest.MODID, version = AnvilRecipeTest.VERSION)
+public class AnvilRecipeTest
+{
+    public static final String MODID = "IAnvilRecipeTest";
+    public static final String VERSION = "1.0";
+
+    @Mod.EventHandler
+    public void init(FMLInitializationEvent event)
+    {
+        AnvilRecipeHandler.INSTANCE.addRepair(new SimpleAnvilRecipe(new ItemStack(Items.iron_chestplate), Items.leather_chestplate, Items.iron_ingot, 5, 0));
+        AnvilRecipeHandler.INSTANCE.addRepair(new MelonAnvilRecipe());
+        AnvilRecipeHandler.INSTANCE.addRepair(new MegmaCreamAnvilRecipe());
+    }
+
+    public static class MelonAnvilRecipe implements IAnvilRecipe
+    {
+        protected final List<ItemStack> left;
+        protected final List<ItemStack> right;
+
+        public MelonAnvilRecipe()
+        {
+            this.left = ImmutableList.of(new ItemStack(Items.wooden_axe));
+            this.right = ImmutableList.of(new ItemStack(Blocks.melon_block));
+        }
+
+        @Override
+        public boolean matches(ItemStack inputLeft, ItemStack inputRight, String newName, World world)
+        {
+            return inputLeft != null && inputRight != null && inputLeft.getItem() instanceof ItemAxe && inputRight.getItem() == Item.getItemFromBlock(Blocks.melon_block);
+        }
+
+        @Override
+        public List[] getInputs()
+        {
+            return new List[] { this.left, this.right };
+        }
+
+        @Override
+        public ItemStack getResult(ItemStack inputLeft, ItemStack inputRight, String newName, World world)
+        {
+            return new ItemStack(Items.melon, 6);
+        }
+
+        @Override
+        public int getCost(ItemStack inputLeft, ItemStack inputRight, String newName, World world)
+        {
+            return 0;
+        }
+
+        @Override
+        public void doRepair(ItemStack inputLeft, ItemStack inputRight, String newName, World world)
+        {
+            inputLeft.attemptDamageItem(1, new Random());
+            inputRight.stackSize -= 1;
+        }
+    }
+
+    public static class MegmaCreamAnvilRecipe extends SimpleAnvilRecipe
+    {
+        public MegmaCreamAnvilRecipe()
+        {
+            super(new ItemStack(Items.magma_cream), Items.lava_bucket, "slimeball", 1, 1);
+        }
+
+        @Override
+        public ItemStack getResult(ItemStack inputLeft, ItemStack inputRight, String newName, World world)
+        {
+            ItemStack result = this.output.copy();
+            result.stackSize = inputRight.stackSize;
+            return result;
+        }
+
+        @Override
+        public int getCost(ItemStack inputLeft, ItemStack inputRight, String newName, World world)
+        {
+            return inputRight == null ? 0 : this.expCost * ((inputRight.stackSize / 8) + 1);
+        }
+
+        @Override
+        public void doRepair(ItemStack inputLeft, ItemStack inputRight, String newName, World world)
+        {
+            inputLeft.setItem(Items.bucket);
+            inputRight.stackSize = 0;
+        }
+    }
+}


### PR DESCRIPTION
Allows mods to define recipes for the anvil.

This is an update of my 1.8 version: https://github.com/MinecraftForge/MinecraftForge/pull/2389
And that was an update of DemoXinMC's pull request: https://github.com/MinecraftForge/MinecraftForge/pull/987

With the following changes:
1. minimum code in ContainerRepair, rest is moved into AnvilRecipes
2. added some comments (just some simple ones)
3. changed inputSlot1 and inputSlot2 to inputLeft & inputRight to correspond to the GUI and be similar to the existing anvil events.
4. renamed repair to doRepair, and removed the output stack as there is no point in editing it here because getResult is where you set it up.
5. added SimpleAnvilRecipe, (should cover most needs and supports the OreDictionary)
6. added getInputs() to IAnvilRecipe for use by recipe display mods
7. when renaming the new name is passed to the IAnvilRecipe

Includes a Test Mod:
-- 1x Leather Chest-plate + 5x Iron = 1x Iron Chest-plate
-- 1x Axe + 1x MelonBlock = 6x Melon Slices & -1 durability to axe
-- 1x LavaBucket + [1-64]x Slimeballs + [1-9]x Exp = [1-64]x MagmaCream & 1x EmptyBucket