### PR TITLE
PlayerInteractEvent: Don't modify results unless the event was canceled

### DIFF
--- a/src/main/java/net/minecraftforge/event/entity/player/PlayerInteractEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/player/PlayerInteractEvent.java
@@ -182,8 +182,11 @@ public class PlayerInteractEvent extends PlayerEvent
         public void setCanceled(boolean canceled)
         {
             super.setCanceled(canceled);
-            useBlock = DENY;
-            useItem = DENY;
+            if (canceled)
+            {
+                useBlock = DENY;
+                useItem = DENY;
+            }
         }
     }
 
@@ -274,8 +277,11 @@ public class PlayerInteractEvent extends PlayerEvent
         public void setCanceled(boolean canceled)
         {
             super.setCanceled(canceled);
-            useBlock = DENY;
-            useItem = DENY;
+            if (canceled)
+            {
+                useBlock = DENY;
+                useItem = DENY;
+            }
         }
     }
 


### PR DESCRIPTION
This moves the `PlayerInteractEvent` behavior in line with the default `Event` behavior that calling `setCanceled` with `false` won't actually cancel the event.

e.g.

New behavior:
```java
@SubscribeEvent
public void onRightClickBlock(PlayerInteractEvent.RightClickBlock event) {
    boolean success = false;
    // ...
    event.setCanceled(success);
}
```

Old behavior
```java
@SubscribeEvent
public void onRightClickBlock(PlayerInteractEvent.RightClickBlock event) {
    boolean success = false;
    // ...
    if (success) {
        event.setCanceled(true);
    }
}
```