### PR TITLE
[1.9] Set the world to tile entities whenever they are added.

### DIFF
--- a/patches/minecraft/net/minecraft/world/World.java.patch
+++ b/patches/minecraft/net/minecraft/world/World.java.patch
@@ -469,7 +469,7 @@
          this.field_72984_F.func_76318_c("pendingBlockEntities");
  
          if (!this.field_147484_a.isEmpty())
-@@ -1748,7 +1872,8 @@
+@@ -1748,13 +1872,14 @@
  
      public boolean func_175700_a(TileEntity p_175700_1_)
      {
@@ -479,7 +479,22 @@
  
          if (flag && p_175700_1_ instanceof ITickable)
          {
-@@ -1782,9 +1907,13 @@
+             this.field_175730_i.add(p_175700_1_);
+         }
+-
++        p_175700_1_.func_145834_a(this); // Forge - set the world early as vanilla doesn't set it until next tick
+         return flag;
+     }
+ 
+@@ -1763,6 +1888,7 @@
+         if (this.field_147481_N)
+         {
+             this.field_147484_a.addAll(p_147448_1_);
++            for (TileEntity tile : p_147448_1_) tile.func_145834_a(this); // Forge - set the world early as vanilla doesn't set it until next tick
+         }
+         else
+         {
+@@ -1782,9 +1908,13 @@
      {
          int i = MathHelper.func_76128_c(p_72866_1_.field_70165_t);
          int j = MathHelper.func_76128_c(p_72866_1_.field_70161_v);
@@ -495,7 +510,7 @@
          {
              p_72866_1_.field_70142_S = p_72866_1_.field_70165_t;
              p_72866_1_.field_70137_T = p_72866_1_.field_70163_u;
-@@ -1913,7 +2042,7 @@
+@@ -1913,7 +2043,7 @@
                  {
                      IBlockState iblockstate = this.func_180495_p(blockpos$pooledmutableblockpos.func_185343_d(k1, l1, i2));
  
@@ -504,7 +519,7 @@
                      {
                          blockpos$pooledmutableblockpos.func_185344_t();
                          return true;
-@@ -1983,6 +2112,10 @@
+@@ -1983,6 +2113,10 @@
                              blockpos$pooledmutableblockpos.func_185344_t();
                              return true;
                          }
@@ -515,7 +530,7 @@
                      }
                  }
              }
-@@ -2022,6 +2155,16 @@
+@@ -2022,6 +2156,16 @@
                          IBlockState iblockstate = this.func_180495_p(blockpos$pooledmutableblockpos);
                          Block block = iblockstate.func_177230_c();
  
@@ -532,7 +547,7 @@
                          if (iblockstate.func_185904_a() == p_72918_2_)
                          {
                              double d0 = (double)((float)(l1 + 1) - BlockLiquid.func_149801_b(((Integer)iblockstate.func_177229_b(BlockLiquid.field_176367_b)).intValue()));
-@@ -2098,6 +2241,9 @@
+@@ -2098,6 +2242,9 @@
                  {
                      IBlockState iblockstate = this.func_180495_p(blockpos$pooledmutableblockpos.func_185343_d(k1, l1, i2));
  
@@ -542,7 +557,7 @@
                      if (iblockstate.func_185904_a() == p_72830_2_)
                      {
                          int j2 = ((Integer)iblockstate.func_177229_b(BlockLiquid.field_176367_b)).intValue();
-@@ -2130,6 +2276,7 @@
+@@ -2130,6 +2277,7 @@
      public Explosion func_72885_a(Entity p_72885_1_, double p_72885_2_, double p_72885_4_, double p_72885_6_, float p_72885_8_, boolean p_72885_9_, boolean p_72885_10_)
      {
          Explosion explosion = new Explosion(this, p_72885_1_, p_72885_2_, p_72885_4_, p_72885_6_, p_72885_8_, p_72885_9_, p_72885_10_);
@@ -550,7 +565,7 @@
          explosion.func_77278_a();
          explosion.func_77279_a(true);
          return explosion;
-@@ -2253,6 +2400,7 @@
+@@ -2253,11 +2401,13 @@
  
      public void func_175690_a(BlockPos p_175690_1_, TileEntity p_175690_2_)
      {
@@ -558,7 +573,13 @@
          if (p_175690_2_ != null && !p_175690_2_.func_145837_r())
          {
              if (this.field_147481_N)
-@@ -2276,19 +2424,27 @@
+             {
+                 p_175690_2_.func_174878_a(p_175690_1_);
++                p_175690_2_.func_145834_a(this); // Forge - set the world early as vanilla doesn't set it until next tick
+                 Iterator<TileEntity> iterator = this.field_147484_a.iterator();
+ 
+                 while (iterator.hasNext())
+@@ -2276,19 +2426,27 @@
              else
              {
                  this.func_175700_a(p_175690_2_);
@@ -587,7 +608,7 @@
          }
          else
          {
-@@ -2301,6 +2457,7 @@
+@@ -2301,6 +2459,7 @@
  
              this.func_175726_f(p_175713_1_).func_177425_e(p_175713_1_);
          }
@@ -595,7 +616,7 @@
      }
  
      public void func_147457_a(TileEntity p_147457_1_)
-@@ -2327,7 +2484,7 @@
+@@ -2327,7 +2486,7 @@
              if (chunk != null && !chunk.func_76621_g())
              {
                  IBlockState iblockstate = this.func_180495_p(p_175677_1_);
@@ -604,7 +625,7 @@
              }
              else
              {
-@@ -2350,6 +2507,7 @@
+@@ -2350,6 +2509,7 @@
      {
          this.field_72985_G = p_72891_1_;
          this.field_72992_H = p_72891_2_;
@@ -612,7 +633,7 @@
      }
  
      public void func_72835_b()
-@@ -2359,6 +2517,11 @@
+@@ -2359,6 +2519,11 @@
  
      protected void func_72947_a()
      {
@@ -624,7 +645,7 @@
          if (this.field_72986_A.func_76059_o())
          {
              this.field_73004_o = 1.0F;
-@@ -2372,6 +2535,11 @@
+@@ -2372,6 +2537,11 @@
  
      protected void func_72979_l()
      {
@@ -636,7 +657,7 @@
          if (!this.field_73011_w.func_177495_o())
          {
              if (!this.field_72995_K)
-@@ -2491,28 +2659,33 @@
+@@ -2491,28 +2661,33 @@
  
      public boolean func_175670_e(BlockPos p_175670_1_, boolean p_175670_2_)
      {
@@ -676,7 +697,7 @@
  
                      if (!flag)
                      {
-@@ -2532,24 +2705,29 @@
+@@ -2532,24 +2707,29 @@
  
      public boolean func_175708_f(BlockPos p_175708_1_, boolean p_175708_2_)
      {
@@ -712,7 +733,7 @@
                  {
                      return true;
                  }
-@@ -2581,10 +2759,11 @@
+@@ -2581,10 +2761,11 @@
          else
          {
              IBlockState iblockstate = this.func_180495_p(p_175638_1_);
@@ -727,7 +748,7 @@
              {
                  j = 1;
              }
-@@ -2683,7 +2862,7 @@
+@@ -2683,7 +2864,7 @@
                                      int j4 = j2 + enumfacing.func_96559_d();
                                      int k4 = k2 + enumfacing.func_82599_e();
                                      blockpos$pooledmutableblockpos.func_185343_d(i4, j4, k4);
@@ -736,7 +757,7 @@
                                      i3 = this.func_175642_b(p_180500_1_, blockpos$pooledmutableblockpos);
  
                                      if (i3 == l2 - l4 && j < this.field_72994_J.length)
-@@ -2789,10 +2968,10 @@
+@@ -2789,10 +2970,10 @@
      public List<Entity> func_175674_a(Entity p_175674_1_, AxisAlignedBB p_175674_2_, Predicate <? super Entity > p_175674_3_)
      {
          List<Entity> list = Lists.<Entity>newArrayList();
@@ -751,7 +772,7 @@
  
          for (int i1 = i; i1 <= j; ++i1)
          {
-@@ -2845,10 +3024,10 @@
+@@ -2845,10 +3026,10 @@
  
      public <T extends Entity> List<T> func_175647_a(Class <? extends T > p_175647_1_, AxisAlignedBB p_175647_2_, Predicate <? super T > p_175647_3_)
      {
@@ -766,7 +787,7 @@
          List<T> list = Lists.<T>newArrayList();
  
          for (int i1 = i; i1 < j; ++i1)
-@@ -2926,11 +3105,13 @@
+@@ -2926,11 +3107,13 @@
  
      public void func_175650_b(Collection<Entity> p_175650_1_)
      {
@@ -783,7 +804,7 @@
          }
      }
  
-@@ -2943,7 +3124,7 @@
+@@ -2943,7 +3126,7 @@
      {
          IBlockState iblockstate = this.func_180495_p(p_175716_2_);
          AxisAlignedBB axisalignedbb = p_175716_3_ ? null : p_175716_1_.func_176223_P().func_185890_d(this, p_175716_2_);
@@ -792,7 +813,7 @@
      }
  
      public int func_181545_F()
-@@ -3026,7 +3207,7 @@
+@@ -3026,7 +3209,7 @@
      public int func_175651_c(BlockPos p_175651_1_, EnumFacing p_175651_2_)
      {
          IBlockState iblockstate = this.func_180495_p(p_175651_1_);
@@ -801,7 +822,7 @@
      }
  
      public boolean func_175640_z(BlockPos p_175640_1_)
-@@ -3215,7 +3396,7 @@
+@@ -3215,7 +3398,7 @@
  
      public long func_72905_C()
      {
@@ -810,7 +831,7 @@
      }
  
      public long func_82737_E()
-@@ -3225,17 +3406,17 @@
+@@ -3225,17 +3408,17 @@
  
      public long func_72820_D()
      {
@@ -831,7 +852,7 @@
  
          if (!this.func_175723_af().func_177746_a(blockpos))
          {
-@@ -3247,7 +3428,7 @@
+@@ -3247,7 +3430,7 @@
  
      public void func_175652_B(BlockPos p_175652_1_)
      {
@@ -840,7 +861,7 @@
      }
  
      @SideOnly(Side.CLIENT)
-@@ -3267,12 +3448,18 @@
+@@ -3267,12 +3450,18 @@
  
          if (!this.field_72996_f.contains(p_72897_1_))
          {
@@ -859,7 +880,7 @@
          return true;
      }
  
-@@ -3366,8 +3553,7 @@
+@@ -3366,8 +3555,7 @@
  
      public boolean func_180502_D(BlockPos p_180502_1_)
      {
@@ -869,7 +890,7 @@
      }
  
      public MapStorage func_175693_T()
-@@ -3426,12 +3612,12 @@
+@@ -3426,12 +3614,12 @@
  
      public int func_72800_K()
      {
@@ -884,7 +905,7 @@
      }
  
      public Random func_72843_D(int p_72843_1_, int p_72843_2_, int p_72843_3_)
-@@ -3481,7 +3667,7 @@
+@@ -3481,7 +3669,7 @@
      @SideOnly(Side.CLIENT)
      public double func_72919_O()
      {
@@ -893,7 +914,7 @@
      }
  
      public void func_175715_c(int p_175715_1_, BlockPos p_175715_2_, int p_175715_3_)
-@@ -3515,7 +3701,7 @@
+@@ -3515,7 +3703,7 @@
  
      public void func_175666_e(BlockPos p_175666_1_, Block p_175666_2_)
      {
@@ -902,7 +923,7 @@
          {
              BlockPos blockpos = p_175666_1_.func_177972_a(enumfacing);
  
-@@ -3523,18 +3709,14 @@
+@@ -3523,18 +3711,14 @@
              {
                  IBlockState iblockstate = this.func_180495_p(blockpos);
  
@@ -925,7 +946,7 @@
                      }
                  }
              }
-@@ -3600,6 +3782,87 @@
+@@ -3600,6 +3784,87 @@
          return i >= -k && i <= k && j >= -k && j <= k;
      }
  

--- a/patches/minecraft/net/minecraft/world/World.java.patch
+++ b/patches/minecraft/net/minecraft/world/World.java.patch
@@ -475,7 +475,7 @@
      {
 -        boolean flag = this.field_147482_g.add(p_175700_1_);
 +        List<TileEntity> dest = field_147481_N ? field_147484_a : field_147482_g;
-+        p_175700_1_.func_145834_a(this); // Forge - set the world early as vanilla doesn't set it until next tick
++        if (p_175700_1_.func_145831_w() != this) p_175700_1_.func_145834_a(this); // Forge - set the world early as vanilla doesn't set it until next tick
 +        boolean flag = dest.add(p_175700_1_);
  
          if (flag && p_175700_1_ instanceof ITickable)
@@ -484,7 +484,7 @@
      {
          if (this.field_147481_N)
          {
-+            for (TileEntity tile : p_147448_1_) tile.func_145834_a(this); // Forge - set the world early as vanilla doesn't set it until next tick
++            for (TileEntity tile : p_147448_1_) if (tile.func_145831_w() != this)  tile.func_145834_a(this); // Forge - set the world early as vanilla doesn't set it until next tick
              this.field_147484_a.addAll(p_147448_1_);
          }
          else
@@ -569,7 +569,7 @@
              if (this.field_147481_N)
              {
                  p_175690_2_.func_174878_a(p_175690_1_);
-+                p_175690_2_.func_145834_a(this); // Forge - set the world early as vanilla doesn't set it until next tick
++                if (p_175690_2_.func_145831_w() != this) p_175690_2_.func_145834_a(this); // Forge - set the world early as vanilla doesn't set it until next tick
                  Iterator<TileEntity> iterator = this.field_147484_a.iterator();
  
                  while (iterator.hasNext())

--- a/patches/minecraft/net/minecraft/world/World.java.patch
+++ b/patches/minecraft/net/minecraft/world/World.java.patch
@@ -469,32 +469,26 @@
          this.field_72984_F.func_76318_c("pendingBlockEntities");
  
          if (!this.field_147484_a.isEmpty())
-@@ -1748,13 +1872,14 @@
+@@ -1748,7 +1872,9 @@
  
      public boolean func_175700_a(TileEntity p_175700_1_)
      {
 -        boolean flag = this.field_147482_g.add(p_175700_1_);
 +        List<TileEntity> dest = field_147481_N ? field_147484_a : field_147482_g;
++        p_175700_1_.func_145834_a(this); // Forge - set the world early as vanilla doesn't set it until next tick
 +        boolean flag = dest.add(p_175700_1_);
  
          if (flag && p_175700_1_ instanceof ITickable)
          {
-             this.field_175730_i.add(p_175700_1_);
-         }
--
-+        p_175700_1_.func_145834_a(this); // Forge - set the world early as vanilla doesn't set it until next tick
-         return flag;
-     }
- 
-@@ -1763,6 +1888,7 @@
+@@ -1762,6 +1888,7 @@
+     {
          if (this.field_147481_N)
          {
-             this.field_147484_a.addAll(p_147448_1_);
 +            for (TileEntity tile : p_147448_1_) tile.func_145834_a(this); // Forge - set the world early as vanilla doesn't set it until next tick
+             this.field_147484_a.addAll(p_147448_1_);
          }
          else
-         {
-@@ -1782,9 +1908,13 @@
+@@ -1782,9 +1909,13 @@
      {
          int i = MathHelper.func_76128_c(p_72866_1_.field_70165_t);
          int j = MathHelper.func_76128_c(p_72866_1_.field_70161_v);
@@ -510,7 +504,7 @@
          {
              p_72866_1_.field_70142_S = p_72866_1_.field_70165_t;
              p_72866_1_.field_70137_T = p_72866_1_.field_70163_u;
-@@ -1913,7 +2043,7 @@
+@@ -1913,7 +2044,7 @@
                  {
                      IBlockState iblockstate = this.func_180495_p(blockpos$pooledmutableblockpos.func_185343_d(k1, l1, i2));
  
@@ -519,7 +513,7 @@
                      {
                          blockpos$pooledmutableblockpos.func_185344_t();
                          return true;
-@@ -1983,6 +2113,10 @@
+@@ -1983,6 +2114,10 @@
                              blockpos$pooledmutableblockpos.func_185344_t();
                              return true;
                          }
@@ -530,7 +524,7 @@
                      }
                  }
              }
-@@ -2022,6 +2156,16 @@
+@@ -2022,6 +2157,16 @@
                          IBlockState iblockstate = this.func_180495_p(blockpos$pooledmutableblockpos);
                          Block block = iblockstate.func_177230_c();
  
@@ -547,7 +541,7 @@
                          if (iblockstate.func_185904_a() == p_72918_2_)
                          {
                              double d0 = (double)((float)(l1 + 1) - BlockLiquid.func_149801_b(((Integer)iblockstate.func_177229_b(BlockLiquid.field_176367_b)).intValue()));
-@@ -2098,6 +2242,9 @@
+@@ -2098,6 +2243,9 @@
                  {
                      IBlockState iblockstate = this.func_180495_p(blockpos$pooledmutableblockpos.func_185343_d(k1, l1, i2));
  
@@ -557,7 +551,7 @@
                      if (iblockstate.func_185904_a() == p_72830_2_)
                      {
                          int j2 = ((Integer)iblockstate.func_177229_b(BlockLiquid.field_176367_b)).intValue();
-@@ -2130,6 +2277,7 @@
+@@ -2130,6 +2278,7 @@
      public Explosion func_72885_a(Entity p_72885_1_, double p_72885_2_, double p_72885_4_, double p_72885_6_, float p_72885_8_, boolean p_72885_9_, boolean p_72885_10_)
      {
          Explosion explosion = new Explosion(this, p_72885_1_, p_72885_2_, p_72885_4_, p_72885_6_, p_72885_8_, p_72885_9_, p_72885_10_);
@@ -565,7 +559,7 @@
          explosion.func_77278_a();
          explosion.func_77279_a(true);
          return explosion;
-@@ -2253,11 +2401,13 @@
+@@ -2253,11 +2402,13 @@
  
      public void func_175690_a(BlockPos p_175690_1_, TileEntity p_175690_2_)
      {
@@ -579,7 +573,7 @@
                  Iterator<TileEntity> iterator = this.field_147484_a.iterator();
  
                  while (iterator.hasNext())
-@@ -2276,19 +2426,27 @@
+@@ -2276,19 +2427,27 @@
              else
              {
                  this.func_175700_a(p_175690_2_);
@@ -608,7 +602,7 @@
          }
          else
          {
-@@ -2301,6 +2459,7 @@
+@@ -2301,6 +2460,7 @@
  
              this.func_175726_f(p_175713_1_).func_177425_e(p_175713_1_);
          }
@@ -616,7 +610,7 @@
      }
  
      public void func_147457_a(TileEntity p_147457_1_)
-@@ -2327,7 +2486,7 @@
+@@ -2327,7 +2487,7 @@
              if (chunk != null && !chunk.func_76621_g())
              {
                  IBlockState iblockstate = this.func_180495_p(p_175677_1_);
@@ -625,7 +619,7 @@
              }
              else
              {
-@@ -2350,6 +2509,7 @@
+@@ -2350,6 +2510,7 @@
      {
          this.field_72985_G = p_72891_1_;
          this.field_72992_H = p_72891_2_;
@@ -633,7 +627,7 @@
      }
  
      public void func_72835_b()
-@@ -2359,6 +2519,11 @@
+@@ -2359,6 +2520,11 @@
  
      protected void func_72947_a()
      {
@@ -645,7 +639,7 @@
          if (this.field_72986_A.func_76059_o())
          {
              this.field_73004_o = 1.0F;
-@@ -2372,6 +2537,11 @@
+@@ -2372,6 +2538,11 @@
  
      protected void func_72979_l()
      {
@@ -657,7 +651,7 @@
          if (!this.field_73011_w.func_177495_o())
          {
              if (!this.field_72995_K)
-@@ -2491,28 +2661,33 @@
+@@ -2491,28 +2662,33 @@
  
      public boolean func_175670_e(BlockPos p_175670_1_, boolean p_175670_2_)
      {
@@ -697,7 +691,7 @@
  
                      if (!flag)
                      {
-@@ -2532,24 +2707,29 @@
+@@ -2532,24 +2708,29 @@
  
      public boolean func_175708_f(BlockPos p_175708_1_, boolean p_175708_2_)
      {
@@ -733,7 +727,7 @@
                  {
                      return true;
                  }
-@@ -2581,10 +2761,11 @@
+@@ -2581,10 +2762,11 @@
          else
          {
              IBlockState iblockstate = this.func_180495_p(p_175638_1_);
@@ -748,7 +742,7 @@
              {
                  j = 1;
              }
-@@ -2683,7 +2864,7 @@
+@@ -2683,7 +2865,7 @@
                                      int j4 = j2 + enumfacing.func_96559_d();
                                      int k4 = k2 + enumfacing.func_82599_e();
                                      blockpos$pooledmutableblockpos.func_185343_d(i4, j4, k4);
@@ -757,7 +751,7 @@
                                      i3 = this.func_175642_b(p_180500_1_, blockpos$pooledmutableblockpos);
  
                                      if (i3 == l2 - l4 && j < this.field_72994_J.length)
-@@ -2789,10 +2970,10 @@
+@@ -2789,10 +2971,10 @@
      public List<Entity> func_175674_a(Entity p_175674_1_, AxisAlignedBB p_175674_2_, Predicate <? super Entity > p_175674_3_)
      {
          List<Entity> list = Lists.<Entity>newArrayList();
@@ -772,7 +766,7 @@
  
          for (int i1 = i; i1 <= j; ++i1)
          {
-@@ -2845,10 +3026,10 @@
+@@ -2845,10 +3027,10 @@
  
      public <T extends Entity> List<T> func_175647_a(Class <? extends T > p_175647_1_, AxisAlignedBB p_175647_2_, Predicate <? super T > p_175647_3_)
      {
@@ -787,7 +781,7 @@
          List<T> list = Lists.<T>newArrayList();
  
          for (int i1 = i; i1 < j; ++i1)
-@@ -2926,11 +3107,13 @@
+@@ -2926,11 +3108,13 @@
  
      public void func_175650_b(Collection<Entity> p_175650_1_)
      {
@@ -804,7 +798,7 @@
          }
      }
  
-@@ -2943,7 +3126,7 @@
+@@ -2943,7 +3127,7 @@
      {
          IBlockState iblockstate = this.func_180495_p(p_175716_2_);
          AxisAlignedBB axisalignedbb = p_175716_3_ ? null : p_175716_1_.func_176223_P().func_185890_d(this, p_175716_2_);
@@ -813,7 +807,7 @@
      }
  
      public int func_181545_F()
-@@ -3026,7 +3209,7 @@
+@@ -3026,7 +3210,7 @@
      public int func_175651_c(BlockPos p_175651_1_, EnumFacing p_175651_2_)
      {
          IBlockState iblockstate = this.func_180495_p(p_175651_1_);
@@ -822,7 +816,7 @@
      }
  
      public boolean func_175640_z(BlockPos p_175640_1_)
-@@ -3215,7 +3398,7 @@
+@@ -3215,7 +3399,7 @@
  
      public long func_72905_C()
      {
@@ -831,7 +825,7 @@
      }
  
      public long func_82737_E()
-@@ -3225,17 +3408,17 @@
+@@ -3225,17 +3409,17 @@
  
      public long func_72820_D()
      {
@@ -852,7 +846,7 @@
  
          if (!this.func_175723_af().func_177746_a(blockpos))
          {
-@@ -3247,7 +3430,7 @@
+@@ -3247,7 +3431,7 @@
  
      public void func_175652_B(BlockPos p_175652_1_)
      {
@@ -861,7 +855,7 @@
      }
  
      @SideOnly(Side.CLIENT)
-@@ -3267,12 +3450,18 @@
+@@ -3267,12 +3451,18 @@
  
          if (!this.field_72996_f.contains(p_72897_1_))
          {
@@ -880,7 +874,7 @@
          return true;
      }
  
-@@ -3366,8 +3555,7 @@
+@@ -3366,8 +3556,7 @@
  
      public boolean func_180502_D(BlockPos p_180502_1_)
      {
@@ -890,7 +884,7 @@
      }
  
      public MapStorage func_175693_T()
-@@ -3426,12 +3614,12 @@
+@@ -3426,12 +3615,12 @@
  
      public int func_72800_K()
      {
@@ -905,7 +899,7 @@
      }
  
      public Random func_72843_D(int p_72843_1_, int p_72843_2_, int p_72843_3_)
-@@ -3481,7 +3669,7 @@
+@@ -3481,7 +3670,7 @@
      @SideOnly(Side.CLIENT)
      public double func_72919_O()
      {
@@ -914,7 +908,7 @@
      }
  
      public void func_175715_c(int p_175715_1_, BlockPos p_175715_2_, int p_175715_3_)
-@@ -3515,7 +3703,7 @@
+@@ -3515,7 +3704,7 @@
  
      public void func_175666_e(BlockPos p_175666_1_, Block p_175666_2_)
      {
@@ -923,7 +917,7 @@
          {
              BlockPos blockpos = p_175666_1_.func_177972_a(enumfacing);
  
-@@ -3523,18 +3711,14 @@
+@@ -3523,18 +3712,14 @@
              {
                  IBlockState iblockstate = this.func_180495_p(blockpos);
  
@@ -946,7 +940,7 @@
                      }
                  }
              }
-@@ -3600,6 +3784,87 @@
+@@ -3600,6 +3785,87 @@
          return i >= -k && i <= k && j >= -k && j <= k;
      }
  

--- a/patches/minecraft/net/minecraft/world/chunk/Chunk.java.patch
+++ b/patches/minecraft/net/minecraft/world/chunk/Chunk.java.patch
@@ -142,8 +142,12 @@
  
          return tileentity;
      }
-@@ -801,7 +799,7 @@
-         p_177426_2_.func_145834_a(this.field_76637_e);
+@@ -798,10 +796,10 @@
+ 
+     public void func_177426_a(BlockPos p_177426_1_, TileEntity p_177426_2_)
+     {
+-        p_177426_2_.func_145834_a(this.field_76637_e);
++        if (p_177426_2_.func_145831_w() != this.field_76637_e) p_177426_2_.func_145834_a(this.field_76637_e);
          p_177426_2_.func_174878_a(p_177426_1_);
  
 -        if (this.func_177435_g(p_177426_1_).func_177230_c() instanceof ITileEntityProvider)


### PR DESCRIPTION
If you add a tile entity to the world via ````world.setTileEntity````, ````world.addTileEntity````, or ````world.addTileEntities```` while the world is ticking all existing tiles then its added to an internal list without setting its world. The next tick the tile entities are added to the world properly (and added to the chunk) so the chunk sets the world to the tile. Its possible to set a tile entity to the world and then call ````world.getTileEntity```` and get a tile entity from the list of processing tiles which doesn't have a world set.

This has caused a tonne of odd bugs where you somehow got a tile from a world and it didn't know that it was part of the world.

This PR just adds ````tile.setWorld```` to the 3 methods to ensure that the tile entities do have the world set.

Fixes BuildCraft/BuildCraft#3279 properly.
Related to the conversation in #2855 (it might fix this but I haven't encountered it this way).
