### PR TITLE
Several fixes for PlayerInteractEvent

### DIFF
--- a/patches/minecraft/net/minecraft/client/Minecraft.java.patch
+++ b/patches/minecraft/net/minecraft/client/Minecraft.java.patch
@@ -192,16 +192,15 @@
                  }
  
                  this.field_71439_g.func_184609_a(EnumHand.MAIN_HAND);
-@@ -1476,7 +1495,7 @@
+@@ -1476,7 +1495,6 @@
                          switch (this.field_71476_x.field_72313_a)
                          {
                              case ENTITY:
 -
-+                                if(!net.minecraftforge.common.ForgeHooks.onInteractEntityAt(field_71439_g, field_71476_x.field_72308_g, field_71476_x, field_71439_g.func_184586_b(enumhand), enumhand))
                                  if (this.field_71442_b.func_187102_a(this.field_71439_g, this.field_71476_x.field_72308_g, this.field_71476_x, this.field_71439_g.func_184586_b(enumhand), enumhand) == EnumActionResult.SUCCESS)
                                  {
                                      return;
-@@ -1519,7 +1538,7 @@
+@@ -1519,7 +1537,7 @@
                      }
  
                      ItemStack itemstack1 = this.field_71439_g.func_184586_b(enumhand);
@@ -210,7 +209,7 @@
                      if (itemstack1 != null && this.field_71442_b.func_187101_a(this.field_71439_g, this.field_71441_e, itemstack1, enumhand) == EnumActionResult.SUCCESS)
                      {
                          this.field_71460_t.field_78516_c.func_187460_a(enumhand);
-@@ -1626,6 +1645,8 @@
+@@ -1626,6 +1644,8 @@
              --this.field_71467_ac;
          }
  
@@ -219,7 +218,7 @@
          this.field_71424_I.func_76320_a("gui");
  
          if (!this.field_71445_n)
-@@ -1737,6 +1758,7 @@
+@@ -1737,6 +1757,7 @@
                      this.field_71457_ai = 0;
                      this.field_71441_e.func_72897_h(this.field_71439_g);
                  }
@@ -227,7 +226,7 @@
              }
  
              this.field_71424_I.func_76318_c("gameRenderer");
-@@ -1824,6 +1846,7 @@
+@@ -1824,6 +1845,7 @@
              this.field_71453_ak.func_74428_b();
          }
  
@@ -235,7 +234,7 @@
          this.field_71424_I.func_76319_b();
          this.field_71423_H = func_71386_F();
      }
-@@ -1930,6 +1953,7 @@
+@@ -1930,6 +1952,7 @@
                      }
                  }
              }
@@ -243,7 +242,7 @@
          }
  
          this.func_184117_aA();
-@@ -2169,6 +2193,8 @@
+@@ -2169,6 +2192,8 @@
      {
          while (Mouse.next())
          {
@@ -252,7 +251,7 @@
              int i = Mouse.getEventButton();
              KeyBinding.func_74510_a(i - 100, Mouse.getEventButtonState());
  
-@@ -2234,6 +2260,7 @@
+@@ -2234,6 +2259,7 @@
  
      public void func_71371_a(String p_71371_1_, String p_71371_2_, @Nullable WorldSettings p_71371_3_)
      {
@@ -260,7 +259,7 @@
          this.func_71403_a((WorldClient)null);
          System.gc();
          ISaveHandler isavehandler = this.field_71469_aa.func_75804_a(p_71371_1_, false);
-@@ -2276,6 +2303,12 @@
+@@ -2276,6 +2302,12 @@
  
          while (!this.field_71437_Z.func_71200_ad())
          {
@@ -273,7 +272,7 @@
              String s = this.field_71437_Z.func_71195_b_();
  
              if (s != null)
-@@ -2301,8 +2334,14 @@
+@@ -2301,8 +2333,14 @@
          SocketAddress socketaddress = this.field_71437_Z.func_147137_ag().func_151270_a();
          NetworkManager networkmanager = NetworkManager.func_150722_a(socketaddress);
          networkmanager.func_150719_a(new NetHandlerLoginClient(networkmanager, this, (GuiScreen)null));
@@ -290,7 +289,7 @@
          this.field_71453_ak = networkmanager;
      }
  
-@@ -2313,6 +2352,8 @@
+@@ -2313,6 +2351,8 @@
  
      public void func_71353_a(@Nullable WorldClient p_71353_1_, String p_71353_2_)
      {
@@ -299,7 +298,7 @@
          if (p_71353_1_ == null)
          {
              NetHandlerPlayClient nethandlerplayclient = this.func_147114_u();
-@@ -2325,6 +2366,18 @@
+@@ -2325,6 +2365,18 @@
              if (this.field_71437_Z != null && this.field_71437_Z.func_175578_N())
              {
                  this.field_71437_Z.func_71263_m();
@@ -318,7 +317,7 @@
              }
  
              this.field_71437_Z = null;
-@@ -2348,6 +2401,7 @@
+@@ -2348,6 +2400,7 @@
              this.field_71456_v.func_181029_i();
              this.func_71351_a((ServerData)null);
              this.field_71455_al = false;
@@ -326,7 +325,7 @@
          }
  
          this.field_147127_av.func_147690_c();
-@@ -2464,159 +2518,8 @@
+@@ -2464,159 +2517,8 @@
      {
          if (this.field_71476_x != null && this.field_71476_x.field_72313_a != RayTraceResult.Type.MISS)
          {
@@ -488,7 +487,7 @@
          }
      }
  
-@@ -2912,18 +2815,8 @@
+@@ -2912,18 +2814,8 @@
  
      public static int func_71369_N()
      {
@@ -509,7 +508,7 @@
      }
  
      public boolean func_70002_Q()
-@@ -3060,15 +2953,16 @@
+@@ -3060,15 +2952,16 @@
              {
                  if (Keyboard.getEventKeyState())
                  {
@@ -528,7 +527,7 @@
              }
          }
      }
-@@ -3195,4 +3089,10 @@
+@@ -3195,4 +3088,10 @@
      {
          return this.field_184127_aH;
      }

--- a/patches/minecraft/net/minecraft/client/Minecraft.java.patch
+++ b/patches/minecraft/net/minecraft/client/Minecraft.java.patch
@@ -184,7 +184,15 @@
                          {
                              this.field_71442_b.func_180511_b(blockpos, this.field_71476_x.field_178784_b);
                              break;
-@@ -1476,7 +1494,7 @@
+@@ -1447,6 +1465,7 @@
+                         }
+ 
+                         this.field_71439_g.func_184821_cY();
++                        net.minecraftforge.common.ForgeHooks.onEmptyLeftClick(this.field_71439_g, this.field_71439_g.func_184614_ca());
+                 }
+ 
+                 this.field_71439_g.func_184609_a(EnumHand.MAIN_HAND);
+@@ -1476,7 +1495,7 @@
                          switch (this.field_71476_x.field_72313_a)
                          {
                              case ENTITY:
@@ -193,7 +201,7 @@
                                  if (this.field_71442_b.func_187102_a(this.field_71439_g, this.field_71476_x.field_72308_g, this.field_71476_x, this.field_71439_g.func_184586_b(enumhand), enumhand) == EnumActionResult.SUCCESS)
                                  {
                                      return;
-@@ -1519,7 +1537,7 @@
+@@ -1519,7 +1538,7 @@
                      }
  
                      ItemStack itemstack1 = this.field_71439_g.func_184586_b(enumhand);
@@ -202,7 +210,7 @@
                      if (itemstack1 != null && this.field_71442_b.func_187101_a(this.field_71439_g, this.field_71441_e, itemstack1, enumhand) == EnumActionResult.SUCCESS)
                      {
                          this.field_71460_t.field_78516_c.func_187460_a(enumhand);
-@@ -1626,6 +1644,8 @@
+@@ -1626,6 +1645,8 @@
              --this.field_71467_ac;
          }
  
@@ -211,7 +219,7 @@
          this.field_71424_I.func_76320_a("gui");
  
          if (!this.field_71445_n)
-@@ -1737,6 +1757,7 @@
+@@ -1737,6 +1758,7 @@
                      this.field_71457_ai = 0;
                      this.field_71441_e.func_72897_h(this.field_71439_g);
                  }
@@ -219,7 +227,7 @@
              }
  
              this.field_71424_I.func_76318_c("gameRenderer");
-@@ -1824,6 +1845,7 @@
+@@ -1824,6 +1846,7 @@
              this.field_71453_ak.func_74428_b();
          }
  
@@ -227,7 +235,7 @@
          this.field_71424_I.func_76319_b();
          this.field_71423_H = func_71386_F();
      }
-@@ -1930,6 +1952,7 @@
+@@ -1930,6 +1953,7 @@
                      }
                  }
              }
@@ -235,7 +243,7 @@
          }
  
          this.func_184117_aA();
-@@ -2169,6 +2192,8 @@
+@@ -2169,6 +2193,8 @@
      {
          while (Mouse.next())
          {
@@ -244,7 +252,7 @@
              int i = Mouse.getEventButton();
              KeyBinding.func_74510_a(i - 100, Mouse.getEventButtonState());
  
-@@ -2234,6 +2259,7 @@
+@@ -2234,6 +2260,7 @@
  
      public void func_71371_a(String p_71371_1_, String p_71371_2_, @Nullable WorldSettings p_71371_3_)
      {
@@ -252,7 +260,7 @@
          this.func_71403_a((WorldClient)null);
          System.gc();
          ISaveHandler isavehandler = this.field_71469_aa.func_75804_a(p_71371_1_, false);
-@@ -2276,6 +2302,12 @@
+@@ -2276,6 +2303,12 @@
  
          while (!this.field_71437_Z.func_71200_ad())
          {
@@ -265,7 +273,7 @@
              String s = this.field_71437_Z.func_71195_b_();
  
              if (s != null)
-@@ -2301,8 +2333,14 @@
+@@ -2301,8 +2334,14 @@
          SocketAddress socketaddress = this.field_71437_Z.func_147137_ag().func_151270_a();
          NetworkManager networkmanager = NetworkManager.func_150722_a(socketaddress);
          networkmanager.func_150719_a(new NetHandlerLoginClient(networkmanager, this, (GuiScreen)null));
@@ -282,7 +290,7 @@
          this.field_71453_ak = networkmanager;
      }
  
-@@ -2313,6 +2351,8 @@
+@@ -2313,6 +2352,8 @@
  
      public void func_71353_a(@Nullable WorldClient p_71353_1_, String p_71353_2_)
      {
@@ -291,7 +299,7 @@
          if (p_71353_1_ == null)
          {
              NetHandlerPlayClient nethandlerplayclient = this.func_147114_u();
-@@ -2325,6 +2365,18 @@
+@@ -2325,6 +2366,18 @@
              if (this.field_71437_Z != null && this.field_71437_Z.func_175578_N())
              {
                  this.field_71437_Z.func_71263_m();
@@ -310,7 +318,7 @@
              }
  
              this.field_71437_Z = null;
-@@ -2348,6 +2400,7 @@
+@@ -2348,6 +2401,7 @@
              this.field_71456_v.func_181029_i();
              this.func_71351_a((ServerData)null);
              this.field_71455_al = false;
@@ -318,7 +326,7 @@
          }
  
          this.field_147127_av.func_147690_c();
-@@ -2464,159 +2517,8 @@
+@@ -2464,159 +2518,8 @@
      {
          if (this.field_71476_x != null && this.field_71476_x.field_72313_a != RayTraceResult.Type.MISS)
          {
@@ -480,7 +488,7 @@
          }
      }
  
-@@ -2912,18 +2814,8 @@
+@@ -2912,18 +2815,8 @@
  
      public static int func_71369_N()
      {
@@ -501,7 +509,7 @@
      }
  
      public boolean func_70002_Q()
-@@ -3060,15 +2952,16 @@
+@@ -3060,15 +2953,16 @@
              {
                  if (Keyboard.getEventKeyState())
                  {
@@ -520,7 +528,7 @@
              }
          }
      }
-@@ -3195,4 +3088,10 @@
+@@ -3195,4 +3089,10 @@
      {
          return this.field_184127_aH;
      }

--- a/patches/minecraft/net/minecraft/client/Minecraft.java.patch
+++ b/patches/minecraft/net/minecraft/client/Minecraft.java.patch
@@ -198,7 +198,7 @@
  
                      ItemStack itemstack1 = this.field_71439_g.func_184586_b(enumhand);
 -
-+                    if (itemstack1 == null) net.minecraftforge.common.ForgeHooks.onEmptyClick(this.field_71439_g, enumhand);
++                    if (itemstack1 == null && (this.field_71476_x == null || this.field_71476_x.field_72313_a == RayTraceResult.Type.MISS)) net.minecraftforge.common.ForgeHooks.onEmptyClick(this.field_71439_g, enumhand);
                      if (itemstack1 != null && this.field_71442_b.func_187101_a(this.field_71439_g, this.field_71441_e, itemstack1, enumhand) == EnumActionResult.SUCCESS)
                      {
                          this.field_71460_t.field_78516_c.func_187460_a(enumhand);

--- a/patches/minecraft/net/minecraft/client/multiplayer/PlayerControllerMP.java.patch
+++ b/patches/minecraft/net/minecraft/client/multiplayer/PlayerControllerMP.java.patch
@@ -50,7 +50,15 @@
                  return flag;
              }
          }
-@@ -218,14 +224,17 @@
+@@ -207,6 +213,7 @@
+             if (this.field_78779_k.func_77145_d())
+             {
+                 this.field_78774_b.func_147297_a(new CPacketPlayerDigging(CPacketPlayerDigging.Action.START_DESTROY_BLOCK, p_180511_1_, p_180511_2_));
++                if (!net.minecraftforge.common.ForgeHooks.onLeftClickBlock(this.field_78776_a.field_71439_g, p_180511_1_, p_180511_2_, net.minecraftforge.common.ForgeHooks.rayTraceEyeHitVec(this.field_78776_a.field_71439_g, func_78757_d() + 1)).isCanceled())
+                 func_178891_a(this.field_78776_a, this, p_180511_1_, p_180511_2_);
+                 this.field_78781_i = 5;
+             }
+@@ -218,14 +225,17 @@
                  }
  
                  this.field_78774_b.func_147297_a(new CPacketPlayerDigging(CPacketPlayerDigging.Action.START_DESTROY_BLOCK, p_180511_1_, p_180511_2_));
@@ -69,7 +77,7 @@
                  if (flag && iblockstate.func_185903_a(this.field_78776_a.field_71439_g, this.field_78776_a.field_71439_g.field_70170_p, p_180511_1_) >= 1.0F)
                  {
                      this.func_187103_a(p_180511_1_);
-@@ -372,13 +381,32 @@
+@@ -372,13 +382,32 @@
          }
          else
          {
@@ -104,7 +112,7 @@
                  }
  
                  if (!flag && p_187099_3_ != null && p_187099_3_.func_77973_b() instanceof ItemBlock)
-@@ -394,7 +422,7 @@
+@@ -394,7 +423,7 @@
  
              this.field_78774_b.func_147297_a(new CPacketPlayerTryUseItemOnBlock(p_187099_4_, p_187099_5_, p_187099_7_, f, f1, f2));
  
@@ -113,7 +121,7 @@
              {
                  if (p_187099_3_ == null)
                  {
-@@ -412,14 +440,19 @@
+@@ -412,14 +441,19 @@
                  {
                      int i = p_187099_3_.func_77960_j();
                      int j = p_187099_3_.field_77994_a;
@@ -134,7 +142,7 @@
                  }
              }
              else
-@@ -446,6 +479,7 @@
+@@ -446,6 +480,7 @@
              }
              else
              {
@@ -142,7 +150,7 @@
                  int i = p_187101_3_.field_77994_a;
                  ActionResult<ItemStack> actionresult = p_187101_3_.func_77957_a(p_187101_2_, p_187101_1_, p_187101_4_);
                  ItemStack itemstack = (ItemStack)actionresult.func_188398_b();
-@@ -454,9 +488,10 @@
+@@ -454,9 +489,10 @@
                  {
                      p_187101_1_.func_184611_a(p_187101_4_, itemstack);
  
@@ -154,7 +162,7 @@
                      }
                  }
  
-@@ -494,6 +529,7 @@
+@@ -494,6 +530,7 @@
          this.func_78750_j();
          Vec3d vec3d = new Vec3d(p_187102_3_.field_72307_f.field_72450_a - p_187102_2_.field_70165_t, p_187102_3_.field_72307_f.field_72448_b - p_187102_2_.field_70163_u, p_187102_3_.field_72307_f.field_72449_c - p_187102_2_.field_70161_v);
          this.field_78774_b.func_147297_a(new CPacketUseEntity(p_187102_2_, p_187102_5_, vec3d));

--- a/patches/minecraft/net/minecraft/client/multiplayer/PlayerControllerMP.java.patch
+++ b/patches/minecraft/net/minecraft/client/multiplayer/PlayerControllerMP.java.patch
@@ -154,3 +154,11 @@
                      }
                  }
  
+@@ -494,6 +529,7 @@
+         this.func_78750_j();
+         Vec3d vec3d = new Vec3d(p_187102_3_.field_72307_f.field_72450_a - p_187102_2_.field_70165_t, p_187102_3_.field_72307_f.field_72448_b - p_187102_2_.field_70163_u, p_187102_3_.field_72307_f.field_72449_c - p_187102_2_.field_70161_v);
+         this.field_78774_b.func_147297_a(new CPacketUseEntity(p_187102_2_, p_187102_5_, vec3d));
++        if(net.minecraftforge.common.ForgeHooks.onInteractEntityAt(p_187102_1_, p_187102_2_, p_187102_3_, p_187102_1_.func_184586_b(p_187102_5_), p_187102_5_)) return EnumActionResult.PASS;
+         return this.field_78779_k == WorldSettings.GameType.SPECTATOR ? EnumActionResult.PASS : p_187102_2_.func_184199_a(p_187102_1_, vec3d, p_187102_4_, p_187102_5_);
+     }
+ 

--- a/src/main/java/net/minecraftforge/common/ForgeHooks.java
+++ b/src/main/java/net/minecraftforge/common/ForgeHooks.java
@@ -986,6 +986,11 @@ public class ForgeHooks
         MinecraftForge.EVENT_BUS.post(new PlayerInteractEvent.RightClickEmpty(player, hand));
     }
 
+    public static void onEmptyLeftClick(EntityPlayer player, ItemStack stack)
+    {
+        MinecraftForge.EVENT_BUS.post(new PlayerInteractEvent.LeftClickEmpty(player, stack));
+    }
+
     private static ThreadLocal<Deque<LootTableContext>> lootContext = new ThreadLocal<Deque<LootTableContext>>();
     private static LootTableContext getLootTableContext()
     {

--- a/src/main/java/net/minecraftforge/event/entity/player/PlayerInteractEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/player/PlayerInteractEvent.java
@@ -286,6 +286,19 @@ public class PlayerInteractEvent extends PlayerEvent
     }
 
     /**
+     * This event is fired on the client side when the player left clicks empty space with any ItemStack.
+     * The server is not aware of when the client left clicks empty space, you will need to tell the server yourself.
+     * This event cannot be canceled.
+     */
+    public static class LeftClickEmpty extends PlayerInteractEvent
+    {
+        public LeftClickEmpty(EntityPlayer player, ItemStack stack)
+        {
+            super(player, EnumHand.MAIN_HAND, stack, new BlockPos(player), null);
+        }
+    }
+
+    /**
      * @return The hand involved in this interaction. Will never be null.
      */
     public EnumHand getHand()

--- a/src/main/java/net/minecraftforge/event/entity/player/PlayerInteractEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/player/PlayerInteractEvent.java
@@ -223,8 +223,12 @@ public class PlayerInteractEvent extends PlayerEvent
      * This event controls which of {@link net.minecraft.block.Block#onBlockClicked} and/or the item harvesting methods will be called
      * Canceling the event will cause none of the above noted methods to be called.
      * There are various results to this event, see the getters below.
+     *
      * Note that if the event is canceled and the player holds down left mouse, the event will continue to fire.
      * This is due to how vanilla calls the left click handler methods.
+     *
+     * Also note that creative mode directly breaks the block without running any other logic.
+     * Therefore, in creative mode, {@link #setUseBlock} and {@link #setUseItem} have no effect.
      */
     @Cancelable
     public static class LeftClickBlock extends PlayerInteractEvent
@@ -248,7 +252,7 @@ public class PlayerInteractEvent extends PlayerEvent
         }
 
         /**
-         * @return If {@link net.minecraft.block.Block#onBlockClicked} should be called
+         * @return If {@link net.minecraft.block.Block#onBlockClicked} should be called. Changing this has no effect in creative mode
          */
         public Result getUseBlock()
         {
@@ -256,7 +260,7 @@ public class PlayerInteractEvent extends PlayerEvent
         }
 
         /**
-         * @return If the block should be attempted to be mined with the current item
+         * @return If the block should be attempted to be mined with the current item. Changing this has no effect in creative mode
          */
         public Result getUseItem()
         {

--- a/src/main/java/net/minecraftforge/event/entity/player/PlayerInteractEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/player/PlayerInteractEvent.java
@@ -182,8 +182,11 @@ public class PlayerInteractEvent extends PlayerEvent
         public void setCanceled(boolean canceled)
         {
             super.setCanceled(canceled);
-            useBlock = DENY;
-            useItem = DENY;
+            if (canceled)
+            {
+                useBlock = DENY;
+                useItem = DENY;
+            }
         }
     }
 
@@ -274,8 +277,11 @@ public class PlayerInteractEvent extends PlayerEvent
         public void setCanceled(boolean canceled)
         {
             super.setCanceled(canceled);
-            useBlock = DENY;
-            useItem = DENY;
+            if (canceled)
+            {
+                useBlock = DENY;
+                useItem = DENY;
+            }
         }
     }
 


### PR DESCRIPTION
This PR does ~~three~~ ~~four~~ five things:

* Calling `setCanceled(false)` will no longer interfere with the useBlock/useItem `Result`'s in LeftClickBlock and RightClickBlock
* Fixes `RightClickEmpty` firing even if targeting a block or entity. It is intended to fire when the hand is empty and targeting nothing but currently fires whenever the hand is empty at all.
* Add a `LeftClickEmpty`, an event that fires whenever the player clicks empty space with any itemstack. This is useful for a variety of cases (I need it myself in Botania). Like `RightClickEmpty`, this is clientside-only because server is not aware of this action.

@Zaggy1024 has brought to my attention a (quite severe IMO but shouldn't be too difficult to fix) limitation of how I designed this PIE, but I wanted to do these small fixes in a separate PR before I attack that one (which is going to be pretty big).