### PR TITLE
Add a Slot#isSameInventory() method

### DIFF
--- a/patches/minecraft/net/minecraft/client/gui/inventory/GuiContainer.java.patch
+++ b/patches/minecraft/net/minecraft/client/gui/inventory/GuiContainer.java.patch
@@ -78,6 +78,15 @@
          int k = -1;
  
          if (slot != null)
+@@ -488,7 +493,7 @@
+                 {
+                     for (Slot slot2 : this.field_147002_h.field_75151_b)
+                     {
+-                        if (slot2 != null && slot2.func_82869_a(this.field_146297_k.field_71439_g) && slot2.func_75216_d() && slot2.field_75224_c == slot.field_75224_c && Container.func_94527_a(slot2, this.field_146994_N, true))
++                        if (slot2 != null && slot2.func_82869_a(this.field_146297_k.field_71439_g) && slot2.func_75216_d() && slot2.isSameInventory(slot) && Container.func_94527_a(slot2, this.field_146994_N, true))
+                         {
+                             this.func_184098_a(slot2, slot2.field_75222_d, p_146286_3_, ClickType.QUICK_MOVE);
+                         }
 @@ -575,7 +580,7 @@
              }
              else if (this.field_146297_k.field_71439_g.field_71071_by.func_70445_o() != null)

--- a/patches/minecraft/net/minecraft/inventory/Slot.java.patch
+++ b/patches/minecraft/net/minecraft/inventory/Slot.java.patch
@@ -9,7 +9,7 @@
      }
  
      public ItemStack func_75209_a(int p_75209_1_)
-@@ -115,4 +115,63 @@
+@@ -115,4 +115,73 @@
      {
          return true;
      }
@@ -70,6 +70,16 @@
 +    public int getSlotIndex()
 +    {
 +        return field_75225_a;
++    }
++
++    /**
++     * Checks if the other slot is in the same inventory, by comparing the inventory reference.
++     * @param other
++     * @return true if the other slot is in the same inventory
++     */
++    public boolean isSameInventory(Slot other)
++    {
++        return this.field_75224_c == other.field_75224_c;
 +    }
 +    /*========================================= FORGE END =====================================*/
  }

--- a/src/main/java/net/minecraftforge/items/SlotItemHandler.java
+++ b/src/main/java/net/minecraftforge/items/SlotItemHandler.java
@@ -77,4 +77,10 @@ public class SlotItemHandler extends Slot
     {
         return itemHandler;
     }
+
+    @Override
+    public boolean isSameInventory(Slot other)
+    {
+        return other instanceof SlotItemHandler && ((SlotItemHandler) other).getItemHandler() == this.itemHandler;
+    }
 }


### PR DESCRIPTION
This fixes shift + double clicking items in Containers that use SlotItemHandler slots.

The vanilla way of directly comparing the Slot#inventory reference in GuiContainer#mouseReleased means that all SlotItemHandler slots are considered being in the same inventory, since they use the same dummy inventory. Which then means that shift + double clicking items in Containers using SlotItemHandler slots causes a shift + click on all the SlotItemHandler slots in the Container.

This is updated for the master branch and replaces #2804.