### PR TITLE
Fix screenshot link paths on Windows

### DIFF
--- a/patches/minecraft/net/minecraft/util/ScreenShotHelper.java.patch
+++ b/patches/minecraft/net/minecraft/util/ScreenShotHelper.java.patch
@@ -1,9 +1,10 @@
 --- ../src-base/minecraft/net/minecraft/util/ScreenShotHelper.java
 +++ ../src-work/minecraft/net/minecraft/util/ScreenShotHelper.java
-@@ -52,10 +52,13 @@
+@@ -52,10 +52,14 @@
                  file2 = new File(file1, p_148259_1_);
              }
  
++            file2 = file2.getCanonicalFile(); // FORGE: Fix errors on Windows with paths that include \.\
 +            net.minecraftforge.client.event.ScreenshotEvent event = net.minecraftforge.client.ForgeHooksClient.onScreenshot(bufferedimage, file2);
 +            if (event.isCanceled()) return event.getCancelMessage(); else file2 = event.getScreenshotFile();
              ImageIO.write(bufferedimage, "png", (File)file2);


### PR DESCRIPTION
On most windows machines, the "link" put in chat after taking a screenshot fails to open up the screenshot image.

This is because ScreenshotHelper gets passed mcDataDir, which most of the time is simply `"./"` . Using this form of the local directory causes the path given by `new File(gameDirectory, "screenshots")` to look like `"./screenshots"` which when made absolute is something like `"C:/Path/To/Minecraft/./screenshots"`. For most purposes, this URI is valid, but when used for `Desktop.browse()` it fails. Calling `getCanonicalFile()` on the initial screenshots folder removes this redundant `"./"`.

