### PR TITLE
Better EnumHelper

### DIFF
--- a/src/main/java/net/minecraftforge/common/util/EnumHelper.java
+++ b/src/main/java/net/minecraftforge/common/util/EnumHelper.java
@@ -119,17 +119,17 @@ public class EnumHelper
 
     private static void setUpCommonTypes()
     {
-        commonTypes.put(EnumAction.class, new Class[]{});
+        commonTypes.put(EnumAction.class, new Class[0]);
         commonTypes.put(ArmorMaterial.class, new Class[]{String.class, int.class, int[].class, int.class, SoundEvent.class});
         commonTypes.put(EnumArt.class, new Class[]{String.class, int.class, int.class, int.class, int.class});
-        commonTypes.put(EnumCreatureAttribute.class, new Class[]{});
+        commonTypes.put(EnumCreatureAttribute.class, new Class[0]);
         commonTypes.put(EnumCreatureType.class, new Class[]{Class.class, int.class, Material.class, boolean.class, boolean.class});
-        commonTypes.put(Door.class, new Class[]{});
-        commonTypes.put(EnumEnchantmentType.class, new Class[]{});
-        commonTypes.put(Sensitivity.class, new Class[]{});
-        commonTypes.put(RayTraceResult.Type.class, new Class[]{});
+        commonTypes.put(Door.class, new Class[0]);
+        commonTypes.put(EnumEnchantmentType.class, new Class[0]);
+        commonTypes.put(Sensitivity.class, new Class[0]);
+        commonTypes.put(RayTraceResult.Type.class, new Class[0]);
         commonTypes.put(EnumSkyBlock.class, new Class[]{int.class});
-        commonTypes.put(EnumStatus.class, new Class[]{});
+        commonTypes.put(EnumStatus.class, new Class[0]);
         commonTypes.put(ToolMaterial.class, new Class[]{int.class, int.class, float.class, float.class, int.class});
         commonTypes.put(EnumRarity.class, new Class[]{TextFormatting.class, String.class});
     }
@@ -194,8 +194,7 @@ public class EnumHelper
 
     public static <T extends Enum<? >> T addEnum(Map<Class<? extends Enum<?>>, Class<?>[]> map, Class<T> enumType, String enumName, Object... paramValues)
     {
-        Class<?>[] paramTypes = map.get(enumType);
-        paramTypes = paramTypes == null ? new Class[]{} : paramTypes;
+        Class<?>[] paramTypes = map.get(enumType) == null ? new Class[0] : map.get(enumType);
         return map.containsKey(enumType) ? null : addEnum(enumType, enumName, paramTypes, paramValues);
     }
 


### PR DESCRIPTION
Change something about commonTypes.
Someone can do something like this
`
private static Class<?>[][] commonTypes =
{
{Door.class},
{Block.class, int.class}, // Someone : Add block.
};
`
EnumHelper is for enum, but **`Block`** is not an enum!
So I change it to Map<Class<? extends Enum<?>>, Class<?>[]> for type safe.
`
private static Map<Class<? extends Enum<?>>, Class<?>[]> commonTypes = Map<Class<? extends Enum<?>>, Class<?>[]>Maps.newHashMap();
private static void setUpCommonTypes()
{
commonTypes.put(Door.class, new Class[]{});
commonTypes.put(Block.class, new Class[]{int.class});
}
`
Then it will give you an error something like saying **Block.class** does not match.