### PR TITLE
Add hook for TE data sync on client

### DIFF
--- a/patches/minecraft/net/minecraft/client/network/NetHandlerPlayClient.java.patch
+++ b/patches/minecraft/net/minecraft/client/network/NetHandlerPlayClient.java.patch
@@ -9,6 +9,15 @@
          this.field_147299_f.field_71474_y.field_74318_M = p_147282_1_.func_149192_g();
          this.field_147299_f.func_71403_a(this.field_147300_g);
          this.field_147299_f.field_71439_g.field_71093_bK = p_147282_1_.func_149194_f();
+@@ -719,7 +719,7 @@
+ 
+             if (tileentity != null)
+             {
+-                tileentity.func_145839_a(nbttagcompound);
++                tileentity.handleUpdateTag(nbttagcompound);
+             }
+         }
+     }
 @@ -797,14 +797,16 @@
      public void func_147251_a(SPacketChat p_147251_1_)
      {

--- a/patches/minecraft/net/minecraft/tileentity/TileEntity.java.patch
+++ b/patches/minecraft/net/minecraft/tileentity/TileEntity.java.patch
@@ -68,7 +68,7 @@
      public double func_145835_a(double p_145835_1_, double p_145835_3_, double p_145835_5_)
      {
          double d0 = (double)this.field_174879_c.func_177958_n() + 0.5D - p_145835_1_;
-@@ -283,6 +293,186 @@
+@@ -283,6 +293,198 @@
          return false;
      }
  
@@ -84,6 +84,18 @@
 +     */
 +    public void onDataPacket(net.minecraft.network.NetworkManager net, net.minecraft.network.play.server.SPacketUpdateTileEntity pkt)
 +    {
++    }
++    
++    /**
++     * Called when the chunk's TE update tag, gotten from {@link #getUpdateTag()}, is received on the client.
++     * <p>
++     * Used to handle this tag in a special way. By default this simply calls {@link #readFromNBT(NBTTagCompound)}.
++     * 
++     * @param tag The {@link NBTTagCompound} sent from {@link #getUpdateTag()}
++     */
++    public void handleUpdateTag(NBTTagCompound tag)
++    {
++        this.func_145839_a(tag);
 +    }
 +
 +    /**


### PR DESCRIPTION
This PR simply adds a hook for when `SPacketChunkData` is read on the client, instead of having it directly call `readFromNBT`. The default implementation just calls `readFromNBT` so no behavior will change. This merely provides a hook for modders to have special behavior for their sync data, and to know when data is synced.