### PR TITLE
Adds VillagerTradePopulationEvent and name-based access to VillagerCareers

### DIFF
--- a/patches/minecraft/net/minecraft/entity/passive/EntityVillager.java.patch
+++ b/patches/minecraft/net/minecraft/entity/passive/EntityVillager.java.patch
@@ -120,7 +120,7 @@
              this.field_175562_bw = 1;
          }
  
-@@ -552,13 +596,11 @@
+@@ -552,17 +596,16 @@
  
          int i = this.field_175563_bv - 1;
          int j = this.field_175562_bw - 1;
@@ -137,7 +137,12 @@
              {
                  entityvillager$itradelist.func_179401_a(this.field_70963_i, this.field_70146_Z);
              }
-@@ -647,9 +689,14 @@
+         }
++        net.minecraftforge.common.ForgeHooks.onVillagerTradePopulation(this, this.field_70963_i, i);
+     }
+ 
+     @SideOnly(Side.CLIENT)
+@@ -647,9 +690,14 @@
                      }
              }
  
@@ -153,7 +158,7 @@
                  textcomponenttranslation.func_150256_b().func_150209_a(this.func_174823_aP());
                  textcomponenttranslation.func_150256_b().func_179989_a(this.func_110124_au().toString());
  
-@@ -708,7 +755,7 @@
+@@ -708,7 +756,7 @@
      public IEntityLivingData func_180482_a(DifficultyInstance p_180482_1_, IEntityLivingData p_180482_2_)
      {
          p_180482_2_ = super.func_180482_a(p_180482_1_, p_180482_2_);

--- a/src/main/java/net/minecraftforge/common/ForgeHooks.java
+++ b/src/main/java/net/minecraftforge/common/ForgeHooks.java
@@ -29,6 +29,7 @@ import net.minecraft.entity.EntityList;
 import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.entity.item.EntityItem;
 import net.minecraft.entity.item.EntityMinecartContainer;
+import net.minecraft.entity.passive.EntityVillager;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraft.entity.player.InventoryPlayer;
@@ -68,6 +69,7 @@ import net.minecraft.util.text.ITextComponent;
 import net.minecraft.util.text.TextComponentString;
 import net.minecraft.util.text.TextFormatting;
 import net.minecraft.util.text.event.ClickEvent;
+import net.minecraft.village.MerchantRecipeList;
 import net.minecraft.world.IBlockAccess;
 import net.minecraft.world.World;
 import net.minecraft.world.WorldSettings;
@@ -90,6 +92,7 @@ import net.minecraftforge.event.entity.living.LivingEvent.LivingUpdateEvent;
 import net.minecraftforge.event.entity.living.LivingFallEvent;
 import net.minecraftforge.event.entity.living.LivingHurtEvent;
 import net.minecraftforge.event.entity.living.LivingSetAttackTargetEvent;
+import net.minecraftforge.event.entity.living.VillagerTradePopulationEvent;
 import net.minecraftforge.event.entity.player.AnvilRepairEvent;
 import net.minecraftforge.event.entity.player.AttackEntityEvent;
 import net.minecraftforge.event.entity.player.PlayerInteractEvent;
@@ -99,6 +102,7 @@ import net.minecraftforge.event.world.NoteBlockEvent;
 import net.minecraftforge.fluids.IFluidBlock;
 import net.minecraftforge.fml.common.FMLLog;
 import net.minecraftforge.fml.common.eventhandler.Event;
+import net.minecraftforge.fml.common.registry.VillagerRegistry.VillagerCareer;
 import net.minecraftforge.fml.relauncher.ReflectionHelper;
 
 public class ForgeHooks
@@ -1116,4 +1120,10 @@ public class ForgeHooks
     //TODO: Some registry to support custom LootEntry types?
     public static LootEntry deserializeJsonLootEntry(String type, JsonObject json, int weight, int quality, LootCondition[] conditions){ return null; }
     public static String getLootEntryType(LootEntry entry){ return null; } //Companion to above function
+
+    public static void onVillagerTradePopulation(EntityVillager villager, MerchantRecipeList trades, int careerID)
+    {
+        VillagerCareer career = villager.getProfessionForge().getCareer(careerID);
+        MinecraftForge.EVENT_BUS.post(new VillagerTradePopulationEvent(villager, career, trades));
+    }
 }

--- a/src/main/java/net/minecraftforge/event/entity/living/VillagerTradePopulationEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/living/VillagerTradePopulationEvent.java
@@ -1,0 +1,54 @@
+package net.minecraftforge.event.entity.living;
+
+import net.minecraft.entity.passive.EntityVillager;
+import net.minecraft.village.MerchantRecipeList;
+import net.minecraftforge.common.ForgeHooks;
+import net.minecraftforge.fml.common.eventhandler.Event.HasResult;
+import net.minecraftforge.fml.common.registry.VillagerRegistry.VillagerCareer;
+
+/**
+ * VillagerTradePopulationEvent is fired when a villager gets his trade options.<br>
+ * This event is fired at the end of {@link EntityVillager#populateBuyingList()}.<br>
+ * <br>
+ * This event is fired via the {@link ForgeHooks#onVillagerTradePopulation(EntityVillager, MerchantRecipeList, int)}.<br>
+ * <br>
+ * {@link LivingEntity#entityLiving} contains the villager.<br>
+ * {@link #carer} contains the villager's career.<br>
+ * {@link #tradeList} contains the villager's trade list.
+ * <br>
+ * This event is not {@link Cancelable}.<br>
+ * <br>
+ * This event does not have a result. {@link HasResult}<br>
+ * <br>
+ * This event is fired on the {@link MinecraftForge#EVENT_BUS}.
+ **/
+public class VillagerTradePopulationEvent extends LivingEvent
+{
+
+    private final VillagerCareer career;
+    private final MerchantRecipeList tradeList;
+
+    public VillagerTradePopulationEvent(EntityVillager villager, VillagerCareer career, MerchantRecipeList tradeList)
+    {
+        super(villager);
+        this.career = career;
+        this.tradeList = tradeList;
+    }
+
+    /**
+     * @return The villager's career.
+     */
+    public VillagerCareer getVillagerCareer()
+    {
+        return career;
+    }
+
+    /**
+     * The returned list can be edited.
+     * @return The list of trades the villager got so far.
+     */
+    public MerchantRecipeList getTradeList()
+    {
+        return tradeList;
+    }
+}

--- a/src/main/java/net/minecraftforge/fml/common/registry/VillagerRegistry.java
+++ b/src/main/java/net/minecraftforge/fml/common/registry/VillagerRegistry.java
@@ -215,6 +215,16 @@ public class VillagerRegistry
             }
             return this.careers.get(0);
         }
+        
+        public VillagerCareer getCareer(String name)
+        {
+            for (VillagerCareer car : this.careers)
+            {
+                if (car.name.equals(name))
+                    return car;
+            }
+            return null;
+        }
 
         public int getRandomCareer(Random rand)
         {

--- a/src/test/java/net/minecraftforge/test/VillagerTradePopulationEventTest.java
+++ b/src/test/java/net/minecraftforge/test/VillagerTradePopulationEventTest.java
@@ -1,0 +1,25 @@
+package net.minecraftforge.test;
+
+import net.minecraftforge.common.MinecraftForge;
+import net.minecraftforge.event.entity.living.VillagerTradePopulationEvent;
+import net.minecraftforge.fml.common.Mod;
+import net.minecraftforge.fml.common.Mod.EventHandler;
+import net.minecraftforge.fml.common.event.FMLInitializationEvent;
+import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
+
+@Mod(modid = "VillagerTradePopulationEventTest", name = "VillagerTradePopulationEventTest", version = "0.0.0")
+public class VillagerTradePopulationEventTest
+{
+
+    @EventHandler
+    public void init(FMLInitializationEvent event){
+        MinecraftForge.EVENT_BUS.register(this);
+    }
+    
+    @SubscribeEvent
+    public void onVillagerTradePopulation(VillagerTradePopulationEvent event){
+        if(event.getVillagerCareer().getName().equals("butcher")){
+            event.getTradeList().clear();
+        }
+    }
+}

--- a/src/test/java/net/minecraftforge/test/VillagerTradePopulationEventTest.java
+++ b/src/test/java/net/minecraftforge/test/VillagerTradePopulationEventTest.java
@@ -1,11 +1,18 @@
 package net.minecraftforge.test;
 
+import net.minecraft.entity.passive.EntityVillager.ListItemForEmeralds;
+import net.minecraft.entity.passive.EntityVillager.PriceInfo;
+import net.minecraft.init.Blocks;
+import net.minecraft.item.Item;
+import net.minecraft.util.ResourceLocation;
 import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.event.entity.living.VillagerTradePopulationEvent;
 import net.minecraftforge.fml.common.Mod;
 import net.minecraftforge.fml.common.Mod.EventHandler;
 import net.minecraftforge.fml.common.event.FMLInitializationEvent;
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
+import net.minecraftforge.fml.common.registry.ForgeRegistries;
+import net.minecraftforge.fml.common.registry.VillagerRegistry.VillagerProfession;
 
 @Mod(modid = "VillagerTradePopulationEventTest", name = "VillagerTradePopulationEventTest", version = "0.0.0")
 public class VillagerTradePopulationEventTest
@@ -13,6 +20,8 @@ public class VillagerTradePopulationEventTest
 
     @EventHandler
     public void init(FMLInitializationEvent event){
+        VillagerProfession profession = ForgeRegistries.VILLAGER_PROFESSIONS.getValue(new ResourceLocation("priest"));
+        profession.getCareer("cleric").addTrade(1, new ListItemForEmeralds(Item.getItemFromBlock(Blocks.command_block), new PriceInfo(32, 64)));
         MinecraftForge.EVENT_BUS.register(this);
     }
     


### PR DESCRIPTION
This PR contains the features form my old PR (see #2823) which have not yet been implemented. The methods to add new trades were added by Lex in a recent commit on the master branch (d5b93bf262aee8e74098c6bf50d70602b03c9ad9).

The added features include the event mentioned in the title.
It allows the modification of the villager's trades based on things like location, biome, or level id (e.g nether, end) in contrast to purely random prices. For example a mod could make fish more expensive in dry biomes.

The added method allows modders to access VillagerCareers easily if their not provided, for example if a modder wishes to modify vanilla career's trades. Without this method, you would have to iterate manually by id over all the careers and check their names.