### PR TITLE
Switch new ItemAxe constructor to use floats

### DIFF
--- a/patches/minecraft/net/minecraft/item/ItemAxe.java.patch
+++ b/patches/minecraft/net/minecraft/item/ItemAxe.java.patch
@@ -4,7 +4,7 @@
          this.field_185065_c = field_185067_n[p_i45327_1_.ordinal()];
      }
  
-+    protected ItemAxe(Item.ToolMaterial material, int damage, int speed)
++    protected ItemAxe(Item.ToolMaterial material, float damage, float speed)
 +    {
 +        super(material, field_150917_c);
 +        this.field_77865_bY = damage;


### PR DESCRIPTION
Seeing as the values being set by it are floats, the constructor should take floats, not ints.
Will close #2902