### PR TITLE
Fix tooltip for survival tab in the creative menu not drawing on any but the first page

### DIFF
--- a/patches/minecraft/net/minecraft/client/gui/inventory/GuiContainerCreative.java.patch
+++ b/patches/minecraft/net/minecraft/client/gui/inventory/GuiContainerCreative.java.patch
@@ -137,7 +137,7 @@
              }
          }
  
-+        if (!rendered && func_147052_b(CreativeTabs.field_78027_g, p_73863_1_, p_73863_2_))
++        if (!rendered && !func_147052_b(CreativeTabs.field_78027_g, p_73863_1_, p_73863_2_))
 +        {
 +            func_147052_b(CreativeTabs.field_78036_m, p_73863_1_, p_73863_2_);
 +        }


### PR DESCRIPTION
Fixes #2504.