### PR TITLE
Added support for sending custom ITextComponents in SMP

### DIFF
--- a/patches/minecraft/net/minecraft/util/text/ITextComponent.java.patch
+++ b/patches/minecraft/net/minecraft/util/text/ITextComponent.java.patch
@@ -12,7 +12,7 @@
                      JsonObject jsonobject = p_deserialize_1_.getAsJsonObject();
                      ITextComponent itextcomponent;
  
-+                    if ((itextcomponent = net.minecraftforge.common.ForgeHooks.onTextComponentDeserialize(jsonobject)) != null) {} else 
++                    if ((itextcomponent = net.minecraftforge.common.ForgeHooks.onTextComponentDeserialize(jsonobject)) != null) {/*NOOP*/} else 
                      if (jsonobject.has("text"))
                      {
                          itextcomponent = new TextComponentString(jsonobject.get("text").getAsString());

--- a/patches/minecraft/net/minecraft/util/text/ITextComponent.java.patch
+++ b/patches/minecraft/net/minecraft/util/text/ITextComponent.java.patch
@@ -8,18 +8,14 @@
      String func_150254_d();
  
      List<ITextComponent> func_150253_a();
-@@ -138,9 +137,10 @@
-                     {
-                         if (!jsonobject.has("selector"))
-                         {
-+                            if ((itextcomponent = net.minecraftforge.common.ForgeHooks.onTextComponentDeserialize(jsonobject)) == null) 
-                             throw new JsonParseException("Don\'t know how to turn " + p_deserialize_1_.toString() + " into a Component");
-                         }
--
-+                        else
-                         itextcomponent = new TextComponentSelector(JsonUtils.func_151200_h(jsonobject, "selector"));
-                     }
+@@ -83,6 +82,7 @@
+                     JsonObject jsonobject = p_deserialize_1_.getAsJsonObject();
+                     ITextComponent itextcomponent;
  
++                    if ((itextcomponent = net.minecraftforge.common.ForgeHooks.onTextComponentDeserialize(jsonobject)) != null) {} else 
+                     if (jsonobject.has("text"))
+                     {
+                         itextcomponent = new TextComponentString(jsonobject.get("text").getAsString());
 @@ -241,6 +241,7 @@
                  {
                      if (!(p_serialize_1_ instanceof TextComponentSelector))

--- a/patches/minecraft/net/minecraft/util/text/ITextComponent.java.patch
+++ b/patches/minecraft/net/minecraft/util/text/ITextComponent.java.patch
@@ -8,3 +8,19 @@
      String func_150254_d();
  
      List<ITextComponent> func_150253_a();
+@@ -134,6 +133,7 @@
+                             ((TextComponentScore)itextcomponent).func_179997_b(JsonUtils.func_151200_h(jsonobject1, "value"));
+                         }
+                     }
++                    else if ((itextcomponent = net.minecraftforge.common.ForgeHooks.onTextComponentDeserialize(jsonobject)) != null) {}
+                     else
+                     {
+                         if (!jsonobject.has("selector"))
+@@ -237,6 +237,7 @@
+                     jsonobject1.addProperty("value", textcomponentscore.func_150261_e());
+                     jsonobject.add("score", jsonobject1);
+                 }
++                else if (net.minecraftforge.common.ForgeHooks.onTextComponentSerialize(p_serialize_1_, jsonobject)) {}
+                 else
+                 {
+                     if (!(p_serialize_1_ instanceof TextComponentSelector))

--- a/patches/minecraft/net/minecraft/util/text/ITextComponent.java.patch
+++ b/patches/minecraft/net/minecraft/util/text/ITextComponent.java.patch
@@ -8,19 +8,23 @@
      String func_150254_d();
  
      List<ITextComponent> func_150253_a();
-@@ -134,6 +133,7 @@
-                             ((TextComponentScore)itextcomponent).func_179997_b(JsonUtils.func_151200_h(jsonobject1, "value"));
-                         }
-                     }
-+                    else if ((itextcomponent = net.minecraftforge.common.ForgeHooks.onTextComponentDeserialize(jsonobject)) != null) {}
-                     else
+@@ -138,9 +137,10 @@
                      {
                          if (!jsonobject.has("selector"))
-@@ -237,6 +237,7 @@
-                     jsonobject1.addProperty("value", textcomponentscore.func_150261_e());
-                     jsonobject.add("score", jsonobject1);
-                 }
-+                else if (net.minecraftforge.common.ForgeHooks.onTextComponentSerialize(p_serialize_1_, jsonobject)) {}
-                 else
+                         {
++                            if ((itextcomponent = net.minecraftforge.common.ForgeHooks.onTextComponentDeserialize(jsonobject)) == null) 
+                             throw new JsonParseException("Don\'t know how to turn " + p_deserialize_1_.toString() + " into a Component");
+                         }
+-
++                        else
+                         itextcomponent = new TextComponentSelector(JsonUtils.func_151200_h(jsonobject, "selector"));
+                     }
+ 
+@@ -241,6 +241,7 @@
                  {
                      if (!(p_serialize_1_ instanceof TextComponentSelector))
+                     {
++                        if (net.minecraftforge.common.ForgeHooks.onTextComponentSerialize(p_serialize_1_, jsonobject)) return jsonobject;
+                         throw new IllegalArgumentException("Don\'t know how to serialize " + p_serialize_1_ + " as a Component");
+                     }
+ 

--- a/src/main/java/net/minecraftforge/common/ForgeHooks.java
+++ b/src/main/java/net/minecraftforge/common/ForgeHooks.java
@@ -1124,6 +1124,7 @@ public class ForgeHooks
     {
         if (tc instanceof IJsonSerializable)
         {
+            jsonobject.add("text", new JsonPrimitive("{Unsupported component type: "+tc.getClass().getName()+"}"));
             jsonobject.add("data", ((IJsonSerializable)tc).getSerializableElement());
             jsonobject.add("class", new JsonPrimitive(tc.getClass().getName()));
             return true;
@@ -1136,18 +1137,19 @@ public class ForgeHooks
     {
         if (!jsonobject.has("class"))
             return null;
-        
+
         ITextComponent tc;
         try
         {
             Class<?> clazz = Class.forName(jsonobject.get("class").getAsString());
             tc = (ITextComponent) clazz.newInstance();
             if(!(tc instanceof IJsonSerializable))
-                throw new ReportedException(new CrashReport("Error deserializing ITextComponent", new UnsupportedOperationException("Deserializing custom chat components requires IJsonSerializable")));
+                throw new UnsupportedOperationException("Deserializing custom chat components requires IJsonSerializable");
         }
-        catch (ReflectiveOperationException e)
+        catch (Exception e)
         {
-            throw new ReportedException(new CrashReport("Error deserializing ITextComponent", e));
+            jsonobject.add("text", new JsonPrimitive("{Error deserializing Component: " + e.getMessage() + "}"));
+            return null;
         }
 
         if (jsonobject.has("data"))

--- a/src/main/java/net/minecraftforge/common/ForgeHooks.java
+++ b/src/main/java/net/minecraftforge/common/ForgeHooks.java
@@ -17,6 +17,7 @@ import com.google.common.collect.Sets;
 import com.google.gson.Gson;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParseException;
+import com.google.gson.JsonPrimitive;
 
 import net.minecraft.block.Block;
 import net.minecraft.block.BlockLiquid;
@@ -24,6 +25,7 @@ import net.minecraft.block.material.Material;
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.GuiScreen;
+import net.minecraft.crash.CrashReport;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.EntityList;
 import net.minecraft.entity.EntityLivingBase;
@@ -56,7 +58,9 @@ import net.minecraft.util.DamageSource;
 import net.minecraft.util.EnumActionResult;
 import net.minecraft.util.EnumFacing;
 import net.minecraft.util.EnumHand;
+import net.minecraft.util.IJsonSerializable;
 import net.minecraft.util.JsonUtils;
+import net.minecraft.util.ReportedException;
 import net.minecraft.util.ResourceLocation;
 import net.minecraft.util.WeightedRandom;
 import net.minecraft.util.math.AxisAlignedBB;
@@ -74,7 +78,6 @@ import net.minecraft.world.WorldSettings;
 import net.minecraft.world.WorldSettings.GameType;
 import net.minecraft.world.storage.loot.LootEntry;
 import net.minecraft.world.storage.loot.LootTable;
-import net.minecraft.world.storage.loot.LootTableManager;
 import net.minecraft.world.storage.loot.conditions.LootCondition;
 import net.minecraftforge.common.util.BlockSnapshot;
 import net.minecraftforge.event.AnvilUpdateEvent;
@@ -1116,4 +1119,40 @@ public class ForgeHooks
     //TODO: Some registry to support custom LootEntry types?
     public static LootEntry deserializeJsonLootEntry(String type, JsonObject json, int weight, int quality, LootCondition[] conditions){ return null; }
     public static String getLootEntryType(LootEntry entry){ return null; } //Companion to above function
+
+    public static boolean onTextComponentSerialize(ITextComponent tc, JsonObject jsonobject)
+    {
+        if (tc instanceof IJsonSerializable)
+        {
+            jsonobject.add("data", ((IJsonSerializable)tc).getSerializableElement());
+            jsonobject.add("class", new JsonPrimitive(tc.getClass().getName()));
+            return true;
+        }
+
+        return false;
+    }
+
+    public static ITextComponent onTextComponentDeserialize(JsonObject jsonobject) 
+    {
+        if (!jsonobject.has("class"))
+            return null;
+        
+        ITextComponent tc;
+        try
+        {
+            Class<?> clazz = Class.forName(jsonobject.get("class").getAsString());
+            tc = (ITextComponent) clazz.newInstance();
+            if(!(tc instanceof IJsonSerializable))
+                throw new ReportedException(new CrashReport("Error deserializing ITextComponent", new UnsupportedOperationException("Deserializing custom chat components requires IJsonSerializable")));
+        }
+        catch (ReflectiveOperationException e)
+        {
+            throw new ReportedException(new CrashReport("Error deserializing ITextComponent", e));
+        }
+
+        if (jsonobject.has("data"))
+            ((IJsonSerializable)tc).fromJson(jsonobject.get("data"));
+
+        return tc;
+    }
 }

--- a/src/test/java/net/minecraftforge/debug/CustomTextComponentDebug.java
+++ b/src/test/java/net/minecraftforge/debug/CustomTextComponentDebug.java
@@ -8,6 +8,7 @@ import com.google.gson.JsonParser;
 import com.google.gson.JsonPrimitive;
 
 import net.minecraft.crash.CrashReport;
+import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.init.Items;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
@@ -21,6 +22,7 @@ import net.minecraft.util.text.ITextComponent;
 import net.minecraft.util.text.TextComponentBase;
 import net.minecraft.util.text.TextComponentString;
 import net.minecraftforge.common.MinecraftForge;
+import net.minecraftforge.event.entity.EntityJoinWorldEvent;
 import net.minecraftforge.fml.common.Mod;
 import net.minecraftforge.fml.common.Mod.EventHandler;
 import net.minecraftforge.fml.common.event.FMLPreInitializationEvent;
@@ -40,10 +42,10 @@ public class CustomTextComponentDebug
     }
 
     @SubscribeEvent
-    public void playerLogin(PlayerLoggedInEvent ev)
+    public void playerLogin(EntityJoinWorldEvent ev)
     {
-        if(ENABLE)
-            ev.player.addChatMessage(new TextComponentItemStack(new ItemStack(Items.COOKIE)));
+        if(ENABLE && (ev.getEntity() instanceof EntityPlayer))
+            ev.getEntity().addChatMessage(new TextComponentItemStack(new ItemStack(Items.COOKIE)));
     }
     
     public static class TextComponentItemStack extends TextComponentBase implements IJsonSerializable

--- a/src/test/java/net/minecraftforge/debug/CustomTextComponentDebug.java
+++ b/src/test/java/net/minecraftforge/debug/CustomTextComponentDebug.java
@@ -29,7 +29,7 @@ import net.minecraftforge.fml.common.event.FMLPreInitializationEvent;
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
 import net.minecraftforge.fml.common.gameevent.PlayerEvent.PlayerLoggedInEvent;
 
-@Mod(modid="CustomTextComponentDebug", name="CustomTextComponentDebug", version="0.0.0")
+@Mod(modid="CustomTextComponentDebug", name="CustomTextComponentDebug", version="0.0.0", acceptableRemoteVersions="*")
 public class CustomTextComponentDebug
 {
     // NOTE: Test with both this ON and OFF - ensure none of the test behaviours show when this is off!
@@ -44,7 +44,7 @@ public class CustomTextComponentDebug
     @SubscribeEvent
     public void playerLogin(EntityJoinWorldEvent ev)
     {
-        if(ENABLE && (ev.getEntity() instanceof EntityPlayer))
+        if(ENABLE && !ev.getWorld().isRemote && (ev.getEntity() instanceof EntityPlayer))
             ev.getEntity().addChatMessage(new TextComponentItemStack(new ItemStack(Items.COOKIE)));
     }
     

--- a/src/test/java/net/minecraftforge/debug/CustomTextComponentDebug.java
+++ b/src/test/java/net/minecraftforge/debug/CustomTextComponentDebug.java
@@ -1,0 +1,172 @@
+package net.minecraftforge.debug;
+
+import org.apache.logging.log4j.Logger;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+import com.google.gson.JsonPrimitive;
+
+import net.minecraft.crash.CrashReport;
+import net.minecraft.init.Items;
+import net.minecraft.item.Item;
+import net.minecraft.item.ItemStack;
+import net.minecraft.nbt.JsonToNBT;
+import net.minecraft.nbt.NBTException;
+import net.minecraft.nbt.NBTTagCompound;
+import net.minecraft.util.IJsonSerializable;
+import net.minecraft.util.ReportedException;
+import net.minecraft.util.ResourceLocation;
+import net.minecraft.util.text.ITextComponent;
+import net.minecraft.util.text.TextComponentBase;
+import net.minecraft.util.text.TextComponentString;
+import net.minecraftforge.common.MinecraftForge;
+import net.minecraftforge.fml.common.Mod;
+import net.minecraftforge.fml.common.Mod.EventHandler;
+import net.minecraftforge.fml.common.event.FMLPreInitializationEvent;
+import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
+import net.minecraftforge.fml.common.gameevent.PlayerEvent.PlayerLoggedInEvent;
+
+@Mod(modid="CustomTextComponentDebug", name="CustomTextComponentDebug", version="0.0.0")
+public class CustomTextComponentDebug
+{
+    // NOTE: Test with both this ON and OFF - ensure none of the test behaviours show when this is off!
+    private static final boolean ENABLE = true;
+
+    @EventHandler
+    public void preinit(FMLPreInitializationEvent event)
+    {
+        MinecraftForge.EVENT_BUS.register(this);
+    }
+
+    @SubscribeEvent
+    public void playerLogin(PlayerLoggedInEvent ev)
+    {
+        if(ENABLE)
+            ev.player.addChatMessage(new TextComponentItemStack(new ItemStack(Items.COOKIE)));
+    }
+    
+    public static class TextComponentItemStack extends TextComponentBase implements IJsonSerializable
+    {
+        private ItemStack stack;
+    
+        public TextComponentItemStack()
+        {
+        }
+    
+        public TextComponentItemStack(ItemStack stack)
+        {
+            this.stack = stack.copy();
+        }
+    
+        public ItemStack getItemStack()
+        {
+            return stack;
+        }
+    
+        @Override
+        public String getUnformattedComponentText()
+        {
+            return "[" + stack.getDisplayName() + "]";
+        }
+    
+        @Override
+        public TextComponentItemStack createCopy()
+        {
+            TextComponentItemStack copy = new TextComponentItemStack(stack);
+    
+            copy.setStyle(this.getStyle().createShallowCopy());
+    
+            for (ITextComponent itextcomponent : this.getSiblings())
+            {
+                copy.appendSibling(itextcomponent.createCopy());
+            }
+    
+            return copy;
+        }
+    
+        public boolean equals(Object other)
+        {
+            if (this == other)
+            {
+                return true;
+            }
+            else if (!(other instanceof TextComponentItemStack))
+            {
+                return false;
+            }
+            else
+            {
+                return ItemStack.areItemStacksEqual(this.stack, ((TextComponentItemStack) other).getItemStack()) && super.equals(other);
+            }
+        }
+    
+        public String toString()
+        {
+            ResourceLocation item = stack.getItem().getRegistryName();
+            int meta = stack.getMetadata();
+            int stackSize = stack.stackSize;
+            NBTTagCompound tag = stack.getTagCompound();
+    
+            StringBuilder b = new StringBuilder();
+            b.append("ItemStack{item='"); b.append(item.toString()); b.append("'");
+            b.append(", stackSize="); b.append(stackSize);
+            if (meta != 0)
+            {
+                b.append(", meta="); b.append(meta);
+            }
+            if(tag != null && !tag.hasNoTags())
+            {
+                b.append(", tag="); b.append(tag.toString());
+            }
+            b.append("}");
+    
+            return b.toString();
+        }
+
+        @Override
+        public void fromJson(JsonElement json)
+        {
+            JsonObject obj = json.getAsJsonObject();
+
+            Item item = Item.REGISTRY.getObject(new ResourceLocation(obj.get("item").getAsString()));
+            int meta = obj.has("meta") ? obj.get("meta").getAsInt() : 0;
+            int stackSize = obj.get("stackSize").getAsInt();
+
+            stack = new ItemStack(item, stackSize, meta);
+            
+            if (obj.has("tag"))
+            {
+                try
+                {
+                    stack.setTagCompound((NBTTagCompound)JsonToNBT.getTagFromJson(obj.get("tag").getAsString()));
+                }
+                catch (NBTException e)
+                {
+                    throw new ReportedException(new CrashReport("Error deserializing ItemStack text component", e));
+                }
+            }
+        }
+
+        @Override
+        public JsonElement getSerializableElement()
+        {
+            JsonObject obj = new JsonObject();
+
+            ResourceLocation item = stack.getItem().getRegistryName();
+            int meta = stack.getMetadata();
+            int stackSize = stack.stackSize;
+            NBTTagCompound tag = stack.getTagCompound();
+
+            obj.add("item", new JsonPrimitive(item.toString()));
+            obj.add("stackSize", new JsonPrimitive(stackSize));
+            if(meta != 0) obj.add("meta", new JsonPrimitive(meta));
+            if(tag != null && !tag.hasNoTags())
+            {
+                obj.add("tag", new JsonPrimitive(tag.toString()).getAsJsonObject());
+            }
+
+            return obj;
+        }
+    }
+}


### PR DESCRIPTION
This PR adds hooks for serializing and deserializing on ITextComponent.Serializer, which are used alongside IJsonSerializable to allow transferring custom ITextComponent data to the clients on SMP situations.

Case in point (only the name display is implemented in the debug mod): 
* An ITextComponent that transfers an ItemStack: Allows translating the item name on the client, making it a clickable link that opens the item's recipe, showing a tooltip on hover, ...

EDIT: It has been brought to my attention that vanilla already has ItemStack#getTextComponent() for the example use case described here. However, it is also true that the vanilla code performs the translation on the SERVER, which means the item name will never show on the local language in those cases, so my use case still stands.