### PR TITLE
Added redstone events

### DIFF
--- a/patches/minecraft/net/minecraft/block/BlockDoor.java.patch
+++ b/patches/minecraft/net/minecraft/block/BlockDoor.java.patch
@@ -9,6 +9,15 @@
          }
          else
          {
+@@ -198,7 +198,7 @@
+             {
+                 boolean flag = p_189540_2_.func_175640_z(p_189540_3_) || p_189540_2_.func_175640_z(blockpos1);
+ 
+-                if (p_189540_4_ != this && (flag || p_189540_4_.func_176223_P().func_185897_m()) && flag != ((Boolean)iblockstate1.func_177229_b(field_176522_N)).booleanValue())
++                if (p_189540_4_ != this && (flag || p_189540_4_.func_176223_P().func_185897_m() || true) && flag != ((Boolean)iblockstate1.func_177229_b(field_176522_N)).booleanValue())
+                 {
+                     p_189540_2_.func_180501_a(blockpos1, iblockstate1.func_177226_a(field_176522_N, Boolean.valueOf(flag)), 2);
+ 
 @@ -221,7 +221,7 @@
  
      public boolean func_176196_c(World p_176196_1_, BlockPos p_176196_2_)

--- a/patches/minecraft/net/minecraft/block/BlockFenceGate.java.patch
+++ b/patches/minecraft/net/minecraft/block/BlockFenceGate.java.patch
@@ -1,0 +1,11 @@
+--- ../src-base/minecraft/net/minecraft/block/BlockFenceGate.java
++++ ../src-work/minecraft/net/minecraft/block/BlockFenceGate.java
+@@ -130,7 +130,7 @@
+         {
+             boolean flag = p_189540_2_.func_175640_z(p_189540_3_);
+ 
+-            if (flag || p_189540_4_.func_176223_P().func_185897_m())
++            if (flag || p_189540_4_.func_176223_P().func_185897_m() || true)
+             {
+                 if (flag && !((Boolean)p_189540_1_.func_177229_b(field_176466_a)).booleanValue() && !((Boolean)p_189540_1_.func_177229_b(field_176465_b)).booleanValue())
+                 {

--- a/patches/minecraft/net/minecraft/block/BlockTrapDoor.java.patch
+++ b/patches/minecraft/net/minecraft/block/BlockTrapDoor.java.patch
@@ -1,5 +1,14 @@
 --- ../src-base/minecraft/net/minecraft/block/BlockTrapDoor.java
 +++ ../src-work/minecraft/net/minecraft/block/BlockTrapDoor.java
+@@ -130,7 +130,7 @@
+         {
+             boolean flag = p_189540_2_.func_175640_z(p_189540_3_);
+ 
+-            if (flag || p_189540_4_.func_176223_P().func_185897_m())
++            if (flag || p_189540_4_.func_176223_P().func_185897_m() || true)
+             {
+                 boolean flag1 = ((Boolean)p_189540_1_.func_177229_b(field_176283_b)).booleanValue();
+ 
 @@ -242,6 +242,18 @@
          return new BlockStateContainer(this, new IProperty[] {field_176284_a, field_176283_b, field_176285_M});
      }

--- a/patches/minecraft/net/minecraft/world/World.java.patch
+++ b/patches/minecraft/net/minecraft/world/World.java.patch
@@ -650,16 +650,45 @@
      }
  
      public int func_181545_F()
-@@ -3038,7 +3215,7 @@
+@@ -2970,7 +3147,7 @@
+ 
+     public int func_175627_a(BlockPos p_175627_1_, EnumFacing p_175627_2_)
+     {
+-        return this.func_180495_p(p_175627_1_).func_185893_b(this, p_175627_1_, p_175627_2_);
++        return net.minecraftforge.common.ForgeHooks.getStrongPowerOutput(this.func_180495_p(p_175627_1_), this, p_175627_1_, p_175627_2_, this.func_180495_p(p_175627_1_).func_185893_b(this, p_175627_1_, p_175627_2_));
+     }
+ 
+     public WorldType func_175624_G()
+@@ -3038,17 +3215,18 @@
      public int func_175651_c(BlockPos p_175651_1_, EnumFacing p_175651_2_)
      {
          IBlockState iblockstate = this.func_180495_p(p_175651_1_);
 -        return iblockstate.func_185915_l() ? this.func_175676_y(p_175651_1_) : iblockstate.func_185911_a(this, p_175651_1_, p_175651_2_);
-+        return iblockstate.func_177230_c().shouldCheckWeakPower(iblockstate, this, p_175651_1_, p_175651_2_) ? this.func_175676_y(p_175651_1_) : iblockstate.func_185911_a(this, p_175651_1_, p_175651_2_);
++        return net.minecraftforge.common.ForgeHooks.getWeakPowerOutput(iblockstate, this, p_175651_1_, p_175651_2_, net.minecraftforge.common.ForgeHooks.getStrongPowerOutput(iblockstate, this, p_175651_1_, p_175651_2_, (iblockstate.func_177230_c().shouldCheckWeakPower(iblockstate, this, p_175651_1_, p_175651_2_) ? this.func_175676_y(p_175651_1_) : iblockstate.func_185911_a(this, p_175651_1_, p_175651_2_))));
      }
  
      public boolean func_175640_z(BlockPos p_175640_1_)
-@@ -3235,7 +3412,7 @@
+     {
+-        return this.func_175651_c(p_175640_1_.func_177977_b(), EnumFacing.DOWN) > 0 ? true : (this.func_175651_c(p_175640_1_.func_177984_a(), EnumFacing.UP) > 0 ? true : (this.func_175651_c(p_175640_1_.func_177978_c(), EnumFacing.NORTH) > 0 ? true : (this.func_175651_c(p_175640_1_.func_177968_d(), EnumFacing.SOUTH) > 0 ? true : (this.func_175651_c(p_175640_1_.func_177976_e(), EnumFacing.WEST) > 0 ? true : this.func_175651_c(p_175640_1_.func_177974_f(), EnumFacing.EAST) > 0))));
++        return net.minecraftforge.common.ForgeHooks.worldIsBlockPowered(this, p_175640_1_);
+     }
+ 
+     public int func_175687_A(BlockPos p_175687_1_)
+     {
+         int i = 0;
++        net.minecraftforge.common.ForgeHooks.checkingIndirectPower = true;
+ 
+         for (EnumFacing enumfacing : EnumFacing.values())
+         {
+@@ -3065,6 +3243,7 @@
+             }
+         }
+ 
++        net.minecraftforge.common.ForgeHooks.checkingIndirectPower = false;
+         return i;
+     }
+ 
+@@ -3235,7 +3414,7 @@
  
      public long func_72905_C()
      {
@@ -668,7 +697,7 @@
      }
  
      public long func_82737_E()
-@@ -3245,17 +3422,17 @@
+@@ -3245,17 +3424,17 @@
  
      public long func_72820_D()
      {
@@ -689,7 +718,7 @@
  
          if (!this.func_175723_af().func_177746_a(blockpos))
          {
-@@ -3267,7 +3444,7 @@
+@@ -3267,7 +3446,7 @@
  
      public void func_175652_B(BlockPos p_175652_1_)
      {
@@ -698,7 +727,7 @@
      }
  
      @SideOnly(Side.CLIENT)
-@@ -3287,12 +3464,18 @@
+@@ -3287,12 +3466,18 @@
  
          if (!this.field_72996_f.contains(p_72897_1_))
          {
@@ -717,7 +746,7 @@
          return true;
      }
  
-@@ -3386,8 +3569,7 @@
+@@ -3386,8 +3571,7 @@
  
      public boolean func_180502_D(BlockPos p_180502_1_)
      {
@@ -727,7 +756,7 @@
      }
  
      @Nullable
-@@ -3448,12 +3630,12 @@
+@@ -3448,12 +3632,12 @@
  
      public int func_72800_K()
      {
@@ -742,7 +771,7 @@
      }
  
      public Random func_72843_D(int p_72843_1_, int p_72843_2_, int p_72843_3_)
-@@ -3503,7 +3685,7 @@
+@@ -3503,7 +3687,7 @@
      @SideOnly(Side.CLIENT)
      public double func_72919_O()
      {
@@ -751,7 +780,7 @@
      }
  
      public void func_175715_c(int p_175715_1_, BlockPos p_175715_2_, int p_175715_3_)
-@@ -3537,7 +3719,7 @@
+@@ -3537,7 +3721,7 @@
  
      public void func_175666_e(BlockPos p_175666_1_, Block p_175666_2_)
      {
@@ -760,7 +789,7 @@
          {
              BlockPos blockpos = p_175666_1_.func_177972_a(enumfacing);
  
-@@ -3545,18 +3727,14 @@
+@@ -3545,18 +3729,14 @@
              {
                  IBlockState iblockstate = this.func_180495_p(blockpos);
  
@@ -783,7 +812,7 @@
                      }
                  }
              }
-@@ -3622,6 +3800,87 @@
+@@ -3622,6 +3802,87 @@
          return i >= -k && i <= k && j >= -k && j <= k;
      }
  

--- a/src/main/java/net/minecraftforge/event/world/RedstoneEvent.java
+++ b/src/main/java/net/minecraftforge/event/world/RedstoneEvent.java
@@ -1,0 +1,88 @@
+package net.minecraftforge.event.world;
+
+import net.minecraft.block.state.IBlockState;
+import net.minecraft.util.EnumFacing;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.IBlockAccess;
+import net.minecraftforge.fml.common.eventhandler.Event;
+
+
+public class RedstoneEvent extends Event
+{
+
+    private final IBlockState state;
+    private final IBlockAccess world;
+    private final BlockPos pos;
+    private final EnumFacing side;
+    private final int power;
+    private int newPower;
+
+    public RedstoneEvent(IBlockState state, IBlockAccess world, BlockPos pos, EnumFacing side, int power)
+    {
+        this.state = state;
+        this.world = world;
+        this.pos = pos;
+        this.power = power;
+        this.side = side;
+        setNewPower(power);
+    }
+
+    public IBlockState getState()
+    {
+        return state;
+    }
+
+    public IBlockAccess getWorld()
+    {
+        return world;
+    }
+
+    public BlockPos getPos()
+    {
+        return pos;
+    }
+    
+    public EnumFacing getSide()
+    {
+        return side;
+    }
+    
+    public int getPower()
+    {
+        return power;
+    }
+
+    public int getNewPower()
+    {
+        return newPower;
+    }
+
+    public void setNewPower(int newPower)
+    {
+        this.newPower = newPower;
+    }
+    
+    public void increaseNewPowerTo(int newPower)
+    {
+        if (newPower > this.newPower)
+            this.newPower = newPower;
+    }
+    
+    public static class WeakOutput extends RedstoneEvent
+    {        
+        public WeakOutput(IBlockState state, IBlockAccess world, BlockPos pos, EnumFacing side, int power)
+        {
+            super(state, world, pos, side, power);
+        }
+    }
+    
+    public static class StrongOutput extends RedstoneEvent
+    {
+
+        public StrongOutput(IBlockState state, IBlockAccess world, BlockPos pos, EnumFacing side, int power)
+        {
+            super(state, world, pos, side, power);
+        }
+
+    }
+}

--- a/src/test/java/net/minecraftforge/test/RedstoneEventTest.java
+++ b/src/test/java/net/minecraftforge/test/RedstoneEventTest.java
@@ -1,0 +1,84 @@
+package net.minecraftforge.test;
+
+import net.minecraft.block.Block;
+import net.minecraft.block.BlockDynamicLiquid;
+import net.minecraft.block.BlockRedstoneTorch;
+import net.minecraft.block.BlockStoneBrick;
+import net.minecraft.block.BlockStoneBrick.EnumType;
+import net.minecraft.block.state.IBlockState;
+import net.minecraft.init.Blocks;
+import net.minecraft.util.EnumFacing;
+import net.minecraftforge.common.MinecraftForge;
+import net.minecraftforge.event.world.RedstoneEvent;
+import net.minecraftforge.fml.common.Mod;
+import net.minecraftforge.fml.common.Mod.EventHandler;
+import net.minecraftforge.fml.common.event.FMLInitializationEvent;
+import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
+
+/** Simple mod to test redstone events. */
+@Mod(modid = "redstoneeventtest", name = "Redstone Event Test", version = "0.0.0")
+public class RedstoneEventTest
+{
+
+    @EventHandler
+    public void init(FMLInitializationEvent event)
+    {
+        MinecraftForge.EVENT_BUS.register(this);
+    }
+
+    /*
+     * ==== Weak power output ====
+     * 
+     * An iron block will emit a weak redstone signal of exactly 10 on the east
+     * 
+     * A redstone torch with a gold block opposite the side tested will emit a redstone signal of at least 3
+     * 
+     * A dispenser with a dark oak fence on top of it will power itself with a weak signal of 15
+     * 
+     * A redstone block above a redstone torch will only have a signal strength of 8
+     * 
+     * ==== Strong power output ====
+     * 
+     * An iron block will emit a strong redstone signal of exactly 5 on the north
+     * 
+     * A redstone torch will emit a strong redstone signal of at least 5 to any emerald blocks above it
+     * 
+     * A dispenser with an oak fence on top of it will power itself with a strong power of 15
+     */
+
+    @SubscribeEvent
+    public void weakPowerOutput(RedstoneEvent.WeakOutput event)
+    {
+        if(event.getState().getBlock() == Blocks.DISPENSER && event.getWorld().getBlockState(event.getPos().up()).getBlock() == Blocks.DARK_OAK_FENCE) {
+            event.setNewPower(15);
+        }
+        if (event.getState().getBlock() instanceof BlockRedstoneTorch && event.getWorld().getBlockState(event.getPos().offset(event.getSide().getOpposite())).getBlock() == Blocks.GOLD_BLOCK)
+        {
+            event.increaseNewPowerTo(3);
+        }
+        
+        if (event.getState().getBlock() == Blocks.REDSTONE_BLOCK && event.getWorld().getBlockState(event.getPos().down()).getBlock()  instanceof BlockRedstoneTorch )
+        {
+            event.setNewPower(8);
+        }
+        
+        if(event.getState().getBlock() == Blocks.IRON_BLOCK && event.getSide() == EnumFacing.EAST) {
+            event.setNewPower(10);
+        }
+    }
+
+    @SubscribeEvent
+    public void strongPowerOutput(RedstoneEvent.StrongOutput event)
+    {
+        if(event.getState().getBlock() == Blocks.DISPENSER && event.getWorld().getBlockState(event.getPos().up()).getBlock() == Blocks.OAK_FENCE) {
+            event.setNewPower(15);
+        }
+        if(event.getState().getBlock() == Blocks.IRON_BLOCK && event.getSide() == EnumFacing.NORTH) {
+            event.setNewPower(5);
+        }
+        
+        if(event.getState().getBlock() instanceof BlockRedstoneTorch && event.getSide() == EnumFacing.UP && event.getWorld().getBlockState(event.getPos().up()).getBlock() == Blocks.EMERALD_BLOCK) {
+            event.increaseNewPowerTo(5);
+        }
+    }
+}


### PR DESCRIPTION
Added redstone events. `RedstoneEvent.WeakOutput` and `RedstoneEvent.StrongOutput`

I had to remove some conditions (using `|| true`) in `BlockDoor`, `BlockTrapDoor`, and `BlockFenceGate` because they would only update if the changed neighbor's state had `canProvidePower()` true. I'm not sure why this was in there in the first place, but it didn't seem very important since it should update if the power changes whether the block could provide power or not.

This doesn't cause block updates, so mods will have to implement that themselves.

Edit: In case people were confused about what the do, they allow you to modify the redstone signal coming from a block. Making a normally non-power-emitting block emit power, or reducing the power output of a block.