### PR TITLE
Pass the correct position into isSideSolid in BlockRailBase#canPlaceBlockAt

### DIFF
--- a/patches/minecraft/net/minecraft/block/BlockRailBase.java.patch
+++ b/patches/minecraft/net/minecraft/block/BlockRailBase.java.patch
@@ -14,7 +14,7 @@
      public boolean func_176196_c(World p_176196_1_, BlockPos p_176196_2_)
      {
 -        return p_176196_1_.func_180495_p(p_176196_2_.func_177977_b()).func_185896_q();
-+        return p_176196_1_.func_180495_p(p_176196_2_.func_177977_b()).isSideSolid(p_176196_1_, p_176196_2_, EnumFacing.UP);
++        return p_176196_1_.func_180495_p(p_176196_2_.func_177977_b()).isSideSolid(p_176196_1_, p_176196_2_.func_177977_b(), EnumFacing.UP);
      }
  
      public void func_176213_c(World p_176213_1_, BlockPos p_176213_2_, IBlockState p_176213_3_)


### PR DESCRIPTION
The block being used is `pos.down()` but originally the position being passed into `isSideSolid` was `pos`, not `pos.down()`. This PR corrects that.