### PR TITLE
[1.9.4]Added weather events.

### DIFF
--- a/patches/minecraft/net/minecraft/world/World.java.patch
+++ b/patches/minecraft/net/minecraft/world/World.java.patch
@@ -546,7 +546,73 @@
          if (!this.field_73011_w.func_177495_o())
          {
              if (!this.field_72995_K)
-@@ -2499,6 +2666,11 @@
+@@ -2389,6 +2556,7 @@
+                 if (i > 0)
+                 {
+                     --i;
++                    if(!net.minecraftforge.common.MinecraftForge.EVENT_BUS.post(new net.minecraftforge.event.world.WeatherEvent.CleanWeatherTime(this, i)))
+                     this.field_72986_A.func_176142_i(i);
+                     this.field_72986_A.func_76090_f(this.field_72986_A.func_76061_m() ? 1 : 2);
+                     this.field_72986_A.func_76080_g(this.field_72986_A.func_76059_o() ? 1 : 2);
+@@ -2400,20 +2568,26 @@
+                 {
+                     if (this.field_72986_A.func_76061_m())
+                     {
+-                        this.field_72986_A.func_76090_f(this.field_73012_v.nextInt(12000) + 3600);
++                        int time=this.field_73012_v.nextInt(12000) + 3600;
++                        if(!net.minecraftforge.common.MinecraftForge.EVENT_BUS.post(new net.minecraftforge.event.world.WeatherEvent.ThunderTime(this, time)))
++                        this.field_72986_A.func_76090_f(time);
+                     }
+                     else
+                     {
+-                        this.field_72986_A.func_76090_f(this.field_73012_v.nextInt(168000) + 12000);
++                        int time=this.field_73012_v.nextInt(168000) + 12000;
++                        if(!net.minecraftforge.common.MinecraftForge.EVENT_BUS.post(new net.minecraftforge.event.world.WeatherEvent.ThunderTime(this, time)))
++                        this.field_72986_A.func_76090_f(time);
+                     }
+                 }
+                 else
+                 {
+                     --j;
++                    if(!net.minecraftforge.common.MinecraftForge.EVENT_BUS.post(new net.minecraftforge.event.world.WeatherEvent.ThunderTime(this, j)))
+                     this.field_72986_A.func_76090_f(j);
+ 
+                     if (j <= 0)
+                     {
++                        if(!net.minecraftforge.common.MinecraftForge.EVENT_BUS.post(new net.minecraftforge.event.world.WeatherEvent.ThunderingState(this, !this.field_72986_A.func_76061_m())))
+                         this.field_72986_A.func_76069_a(!this.field_72986_A.func_76061_m());
+                     }
+                 }
+@@ -2436,20 +2610,26 @@
+                 {
+                     if (this.field_72986_A.func_76059_o())
+                     {
+-                        this.field_72986_A.func_76080_g(this.field_73012_v.nextInt(12000) + 12000);
++                        int time=this.field_73012_v.nextInt(12000) + 12000;
++                        if(!net.minecraftforge.common.MinecraftForge.EVENT_BUS.post(new net.minecraftforge.event.world.WeatherEvent.RainTime(this, time)))
++                        this.field_72986_A.func_76080_g(time);
+                     }
+                     else
+                     {
+-                        this.field_72986_A.func_76080_g(this.field_73012_v.nextInt(168000) + 12000);
++                        int time=this.field_73012_v.nextInt(168000) + 12000;
++                        if(!net.minecraftforge.common.MinecraftForge.EVENT_BUS.post(new net.minecraftforge.event.world.WeatherEvent.RainTime(this, time)))
++                        this.field_72986_A.func_76080_g(time);
+                     }
+                 }
+                 else
+                 {
+                     --k;
++                    if(!net.minecraftforge.common.MinecraftForge.EVENT_BUS.post(new net.minecraftforge.event.world.WeatherEvent.RainTime(this, k)))
+                     this.field_72986_A.func_76080_g(k);
+ 
+                     if (k <= 0)
+                     {
++                        if(!net.minecraftforge.common.MinecraftForge.EVENT_BUS.post(new net.minecraftforge.event.world.WeatherEvent.RainingState(this, !this.field_72986_A.func_76059_o())))
+                         this.field_72986_A.func_76084_b(!this.field_72986_A.func_76059_o());
+                     }
+                 }
+@@ -2499,6 +2679,11 @@
  
      public boolean func_175670_e(BlockPos p_175670_1_, boolean p_175670_2_)
      {
@@ -558,7 +624,7 @@
          Biome biome = this.func_180494_b(p_175670_1_);
          float f = biome.func_180626_a(p_175670_1_);
  
-@@ -2540,6 +2712,11 @@
+@@ -2540,6 +2725,11 @@
  
      public boolean func_175708_f(BlockPos p_175708_1_, boolean p_175708_2_)
      {
@@ -570,7 +636,7 @@
          Biome biome = this.func_180494_b(p_175708_1_);
          float f = biome.func_180626_a(p_175708_1_);
  
-@@ -2557,7 +2734,7 @@
+@@ -2557,7 +2747,7 @@
              {
                  IBlockState iblockstate = this.func_180495_p(p_175708_1_);
  
@@ -579,7 +645,7 @@
                  {
                      return true;
                  }
-@@ -2589,10 +2766,11 @@
+@@ -2589,10 +2779,11 @@
          else
          {
              IBlockState iblockstate = this.func_180495_p(p_175638_1_);
@@ -594,7 +660,7 @@
              {
                  j = 1;
              }
-@@ -2691,7 +2869,7 @@
+@@ -2691,7 +2882,7 @@
                                      int j4 = j2 + enumfacing.func_96559_d();
                                      int k4 = k2 + enumfacing.func_82599_e();
                                      blockpos$pooledmutableblockpos.func_185343_d(i4, j4, k4);
@@ -603,7 +669,7 @@
                                      i3 = this.func_175642_b(p_180500_1_, blockpos$pooledmutableblockpos);
  
                                      if (i3 == l2 - l4 && j < this.field_72994_J.length)
-@@ -2799,10 +2977,10 @@
+@@ -2799,10 +2990,10 @@
      public List<Entity> func_175674_a(@Nullable Entity p_175674_1_, AxisAlignedBB p_175674_2_, @Nullable Predicate <? super Entity > p_175674_3_)
      {
          List<Entity> list = Lists.<Entity>newArrayList();
@@ -618,7 +684,7 @@
  
          for (int i1 = i; i1 <= j; ++i1)
          {
-@@ -2855,10 +3033,10 @@
+@@ -2855,10 +3046,10 @@
  
      public <T extends Entity> List<T> func_175647_a(Class <? extends T > p_175647_1_, AxisAlignedBB p_175647_2_, @Nullable Predicate <? super T > p_175647_3_)
      {
@@ -633,7 +699,7 @@
          List<T> list = Lists.<T>newArrayList();
  
          for (int i1 = i; i1 < j; ++i1)
-@@ -2938,11 +3116,13 @@
+@@ -2938,11 +3129,13 @@
  
      public void func_175650_b(Collection<Entity> p_175650_1_)
      {
@@ -650,7 +716,7 @@
          }
      }
  
-@@ -2955,7 +3135,7 @@
+@@ -2955,7 +3148,7 @@
      {
          IBlockState iblockstate = this.func_180495_p(p_175716_2_);
          AxisAlignedBB axisalignedbb = p_175716_3_ ? null : p_175716_1_.func_176223_P().func_185890_d(this, p_175716_2_);
@@ -659,7 +725,7 @@
      }
  
      public int func_181545_F()
-@@ -3038,7 +3218,7 @@
+@@ -3038,7 +3231,7 @@
      public int func_175651_c(BlockPos p_175651_1_, EnumFacing p_175651_2_)
      {
          IBlockState iblockstate = this.func_180495_p(p_175651_1_);
@@ -668,7 +734,7 @@
      }
  
      public boolean func_175640_z(BlockPos p_175640_1_)
-@@ -3235,7 +3415,7 @@
+@@ -3235,7 +3428,7 @@
  
      public long func_72905_C()
      {
@@ -677,7 +743,7 @@
      }
  
      public long func_82737_E()
-@@ -3245,17 +3425,17 @@
+@@ -3245,17 +3438,17 @@
  
      public long func_72820_D()
      {
@@ -698,7 +764,7 @@
  
          if (!this.func_175723_af().func_177746_a(blockpos))
          {
-@@ -3267,7 +3447,7 @@
+@@ -3267,7 +3460,7 @@
  
      public void func_175652_B(BlockPos p_175652_1_)
      {
@@ -707,7 +773,7 @@
      }
  
      @SideOnly(Side.CLIENT)
-@@ -3287,12 +3467,18 @@
+@@ -3287,12 +3480,18 @@
  
          if (!this.field_72996_f.contains(p_72897_1_))
          {
@@ -726,7 +792,7 @@
          return true;
      }
  
-@@ -3386,8 +3572,7 @@
+@@ -3386,8 +3585,7 @@
  
      public boolean func_180502_D(BlockPos p_180502_1_)
      {
@@ -736,7 +802,7 @@
      }
  
      @Nullable
-@@ -3448,12 +3633,12 @@
+@@ -3448,12 +3646,12 @@
  
      public int func_72800_K()
      {
@@ -751,7 +817,7 @@
      }
  
      public Random func_72843_D(int p_72843_1_, int p_72843_2_, int p_72843_3_)
-@@ -3503,7 +3688,7 @@
+@@ -3503,7 +3701,7 @@
      @SideOnly(Side.CLIENT)
      public double func_72919_O()
      {
@@ -760,7 +826,7 @@
      }
  
      public void func_175715_c(int p_175715_1_, BlockPos p_175715_2_, int p_175715_3_)
-@@ -3537,7 +3722,7 @@
+@@ -3537,7 +3735,7 @@
  
      public void func_175666_e(BlockPos p_175666_1_, Block p_175666_2_)
      {
@@ -769,7 +835,7 @@
          {
              BlockPos blockpos = p_175666_1_.func_177972_a(enumfacing);
  
-@@ -3545,18 +3730,14 @@
+@@ -3545,18 +3743,14 @@
              {
                  IBlockState iblockstate = this.func_180495_p(blockpos);
  
@@ -792,7 +858,7 @@
                      }
                  }
              }
-@@ -3622,6 +3803,87 @@
+@@ -3622,6 +3816,87 @@
          return i >= -k && i <= k && j >= -k && j <= k;
      }
  

--- a/src/main/java/net/minecraftforge/event/world/WeatherEvent.java
+++ b/src/main/java/net/minecraftforge/event/world/WeatherEvent.java
@@ -1,0 +1,176 @@
+package net.minecraftforge.event.world;
+
+import net.minecraft.world.World;
+import net.minecraftforge.common.MinecraftForge;
+import net.minecraftforge.fml.common.eventhandler.Cancelable;
+import net.minecraftforge.fml.common.eventhandler.Event;
+import net.minecraftforge.fml.common.eventhandler.Event.HasResult;
+
+/**
+ * WeatherEvent is fired when an event involving the weather cycle is about to occur.<br>
+ * If a method utilizes this {@link Event} as its parameter, the method will
+ * receive every child event of this class.<br>
+ * <br>
+ * {@link #world} contains the {@link World} this event is occurring in.<br>
+ * <br>
+ * All children of this event are fired on the {@link MinecraftForge#EVENT_BUS}.<br>
+ **/   
+public class WeatherEvent extends Event
+{
+    private final World world;
+    
+    public World getWorld()
+    {
+        return world;
+    }
+    
+    public WeatherEvent(World world)
+    {
+        this.world = world;
+    }
+    
+    /**
+     * WeatherEvent.CleanWeatherTime is fired when a change of the clean weather time in the natural weather cycle is about to occur.<br>
+     * This event is fired when the method World#updateWeatherBody is called. It is fired on the server side. <br>
+     * <br>
+     * {@link #newCleanWeatherTime} contains the value the clean weather time is about to be set to.<br>
+     * <br>
+     * This event is {@link Cancelable}. Canceling it will prevent the changes form occurring.<br>
+     * <br>
+     * This event does not have a result. {@link HasResult} <br>
+     * <br>
+     * This event is fired on the {@link MinecraftForge#EVENT_BUS}.<br>
+     **/    
+    @Cancelable
+    public static class CleanWeatherTime extends WeatherEvent
+    {
+        private final int newCleanWeatherTime;
+        
+        public CleanWeatherTime(World world, int newCleanWeatherTime)
+        {
+            super(world);
+            this.newCleanWeatherTime = newCleanWeatherTime;
+        }
+
+        public int getNewCleanWeatherTime()
+        {
+            return newCleanWeatherTime;
+        }
+    }
+    
+    /**
+     * WeatherEvent.RainingState is fired when a change of the raining state in the natural weather cycle is about to occur.<br>
+     * This event is fired when the method World#updateWeatherBody is called. It is fired on the server side. <br>
+     * <br>
+     * {@link #newRainingState} contains the value the raining state is about to be set to.<br>
+     * <br>
+     * This event is {@link Cancelable}. Canceling it will prevent the changes form occurring.<br>
+     * <br>
+     * This event does not have a result. {@link HasResult} <br>
+     * <br>
+     * This event is fired on the {@link MinecraftForge#EVENT_BUS}.<br>
+     **/
+    @Cancelable
+    public static class RainingState extends WeatherEvent
+    {
+        private final boolean newRainingState;
+
+        public RainingState(World world, boolean newRainingState)
+        {
+            super(world);
+            this.newRainingState = newRainingState;
+        }
+
+        public boolean getNewRainingState()
+        {
+            return newRainingState;
+        }
+    }
+    
+    /**
+     * WeatherEvent.RainTime is fired when a change of the rain time in the natural weather cycle is about to occur.<br>
+     * This event is fired when the method World#updateWeatherBody is called. It is fired on the server side. <br>
+     * <br>
+     * {@link #newRainTime} contains the value the rain time is about to be set to.<br>
+     * <br>
+     * This event is {@link Cancelable}. Canceling it will prevent the changes form occurring.<br>
+     * <br>
+     * This event does not have a result. {@link HasResult} <br>
+     * <br>
+     * This event is fired on the {@link MinecraftForge#EVENT_BUS}.<br>
+     **/
+    @Cancelable
+    public static class RainTime extends WeatherEvent
+    {
+        private final int newRainTime;
+        
+        public RainTime(World world, int newRainTime)
+        {
+            super(world);
+            this.newRainTime = newRainTime;
+        }
+
+        public int getNewRainTime()
+        {
+            return newRainTime;
+        }
+    }
+
+    /**
+     * WeatherEvent.ThunderingState is fired when a change of the thundering state in the natural weather cycle is about to occur.<br>
+     * This event is fired when the method World#updateWeatherBody is called. It is fired on the server side. <br>
+     * <br>
+     * {@link #newThunderingState} contains the value the thundering state is about to be set to.<br>
+     * <br>
+     * This event is {@link Cancelable}. Canceling it will prevent the changes form occurring.<br>
+     * <br>
+     * This event does not have a result. {@link HasResult} <br>
+     * <br>
+     * This event is fired on the {@link MinecraftForge#EVENT_BUS}.<br>
+     **/
+    @Cancelable
+    public static class ThunderingState extends WeatherEvent
+    {
+        private final boolean newThunderingState;
+        
+        public ThunderingState(World world, boolean newThunderingState)
+        {
+            super(world);
+            this.newThunderingState = newThunderingState;
+        }
+
+        public boolean getNewThunderingState()
+        {
+            return newThunderingState;
+        }
+    }
+    
+    /**
+     * WeatherEvent.ThunderTime is fired when a change of the thunder time in the natural weather cycle is about to occur.<br>
+     * This event is fired when the method World#updateWeatherBody is called. It is fired on the server side. <br>
+     * <br>
+     * {@link #newThunderTime} contains the value the thunder time is about to be set to.<br>
+     * <br>
+     * This event is {@link Cancelable}. Canceling it will prevent the changes form occurring.<br>
+     * <br>
+     * This event does not have a result. {@link HasResult} <br>
+     * <br>
+     * This event is fired on the {@link MinecraftForge#EVENT_BUS}.<br>
+     **/
+    @Cancelable
+    public static class ThunderTime extends WeatherEvent
+    {
+        private final int newThunderTime;
+        
+        public ThunderTime(World world, int newThunderTime)
+        {
+            super(world);
+            this.newThunderTime = newThunderTime;
+        }
+
+        public int getNewThunderTime()
+        {
+            return newThunderTime;
+        }
+    }
+}

--- a/src/test/java/net/minecraftforge/test/WeatherEventsTest.java
+++ b/src/test/java/net/minecraftforge/test/WeatherEventsTest.java
@@ -1,0 +1,126 @@
+package net.minecraftforge.test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import net.minecraft.command.CommandException;
+import net.minecraft.command.ICommand;
+import net.minecraft.command.ICommandSender;
+import net.minecraft.server.MinecraftServer;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.World;
+import net.minecraft.world.storage.WorldInfo;
+import net.minecraftforge.common.MinecraftForge;
+import net.minecraftforge.event.world.WeatherEvent;
+import net.minecraftforge.fml.common.Mod;
+import net.minecraftforge.fml.common.Mod.EventHandler;
+import net.minecraftforge.fml.common.event.FMLInitializationEvent;
+import net.minecraftforge.fml.common.event.FMLServerStartingEvent;
+import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
+
+@Mod(modid="weathereventstest", name="Weather Events Test", version="0.0.0")
+public class WeatherEventsTest {
+    public boolean canceled=false;
+
+    @EventHandler
+    public void init(FMLInitializationEvent event)
+    {
+        MinecraftForge.EVENT_BUS.register(this);
+    }
+
+    @EventHandler
+    public void init(FMLServerStartingEvent event)
+    {
+        event.registerServerCommand(new CommandToggleWeather(this));
+        System.out.println("Use /toggleWeatherCycle to toggle the natural weather cycle.");
+    }
+
+    public void toggleWeather(World w) {
+        canceled=!canceled;
+        WorldInfo info=w.getWorldInfo();
+        System.out.println("Weather cycle is now "+(canceled?"deactivated":"activated")+".");
+        System.out.println("CleanWeatherTime:"+info.getCleanWeatherTime());
+        System.out.println("RainTime:"+info.getRainTime());
+        System.out.println("ThunderTime:"+info.getThunderTime());
+        System.out.println("Raining:"+info.isRaining());
+        System.out.println("Thundering:"+info.isThundering());
+    }
+
+    @SubscribeEvent
+    public void onRainingStateChange(WeatherEvent.RainingState event) {
+        event.setCanceled(canceled);
+    }
+
+    @SubscribeEvent
+    public void onThunderingStateChange(WeatherEvent.ThunderingState event) {
+        event.setCanceled(canceled);
+    }
+
+    @SubscribeEvent
+    public void onRainTimeChange(WeatherEvent.RainTime event) {
+        event.setCanceled(canceled);
+    }
+
+    @SubscribeEvent
+    public void onThunderTimeChange(WeatherEvent.ThunderTime event) {
+        event.setCanceled(canceled);
+    }
+
+    @SubscribeEvent
+    public void onCleanWeatherTimeChange(WeatherEvent.CleanWeatherTime event) {
+        event.setCanceled(canceled);
+    }
+    
+    public class CommandToggleWeather implements ICommand{
+        
+        public WeatherEventsTest mod;
+
+        public CommandToggleWeather(WeatherEventsTest m){
+            mod = m;
+        }
+        
+        @Override
+        public int compareTo(ICommand arg0) {
+            return this.getCommandName().compareTo(arg0.getCommandName());
+        }
+
+        @Override
+        public String getCommandName() {
+            return "toggleWeatherCycle";
+        }
+
+        @Override
+        public String getCommandUsage(ICommandSender sender) {
+            return "/toggleWeatherCycle";
+        }
+
+        @Override
+        public List<String> getCommandAliases() {
+            ArrayList<String> list=new ArrayList<String>();
+            list.add("twc");
+            return list;
+        }
+
+        @Override
+        public void execute(MinecraftServer server, ICommandSender sender, String[] args) throws CommandException {
+            mod.toggleWeather(sender.getEntityWorld());
+        }
+
+        @Override
+        public boolean checkPermission(MinecraftServer server, ICommandSender sender) {
+            return true;
+        }
+
+        @Override
+        public boolean isUsernameIndex(String[] args, int index) {
+            return false;
+        }
+
+		@Override
+		public List<String> getTabCompletionOptions(MinecraftServer server, ICommandSender sender, String[] args,
+				BlockPos pos) {
+            return new ArrayList<String>();
+		}
+        
+    }
+}


### PR DESCRIPTION
It adds weather events that will be called for the world's updateWeatherBody method. These will only be triggered server-side because there is of course no natural weather cycle on the client-side.

I accidentaly closed the previous PR while trying to resolve the merge conflicts because I had to revert some changes to update the fork. Sorry! See https://github.com/MinecraftForge/MinecraftForge/pull/2920 .

The test mod adds a command "/toggleWeatherCycle" that uses the events to prevent all changes to Weather: https://gist.github.com/Necr0/e11f3556d51f6a6394137892ce49612a
