### PR TITLE
Fix #2918 Make dispensers with buckets work with modded fluids

### DIFF
--- a/patches/minecraft/net/minecraft/init/Bootstrap.java.patch
+++ b/patches/minecraft/net/minecraft/init/Bootstrap.java.patch
@@ -1,6 +1,16 @@
 --- ../src-base/minecraft/net/minecraft/init/Bootstrap.java
 +++ ../src-work/minecraft/net/minecraft/init/Bootstrap.java
-@@ -541,6 +541,7 @@
+@@ -264,6 +264,9 @@
+         };
+         BlockDispenser.field_149943_a.func_82595_a(Items.field_151129_at, ibehaviordispenseitem);
+         BlockDispenser.field_149943_a.func_82595_a(Items.field_151131_as, ibehaviordispenseitem);
++        BlockDispenser.field_149943_a.func_82595_a(Items.field_151117_aB, net.minecraftforge.fluids.DispenseFluidContainer.getInstance());
++        BlockDispenser.field_149943_a.func_82595_a(Items.field_151133_ar, net.minecraftforge.fluids.DispenseFluidContainer.getInstance());
++        if (false)
+         BlockDispenser.field_149943_a.func_82595_a(Items.field_151133_ar, new BehaviorDefaultDispenseItem()
+         {
+             private final BehaviorDefaultDispenseItem field_150840_b = new BehaviorDefaultDispenseItem();
+@@ -541,6 +544,7 @@
              StatList.func_151178_a();
              Biome.func_185358_q();
              func_151353_a();

--- a/src/main/java/net/minecraftforge/fluids/DispenseFluidContainer.java
+++ b/src/main/java/net/minecraftforge/fluids/DispenseFluidContainer.java
@@ -1,0 +1,107 @@
+package net.minecraftforge.fluids;
+
+import net.minecraft.block.BlockDispenser;
+import net.minecraft.dispenser.BehaviorDefaultDispenseItem;
+import net.minecraft.dispenser.IBlockSource;
+import net.minecraft.item.ItemStack;
+import net.minecraft.tileentity.TileEntityDispenser;
+import net.minecraft.util.EnumFacing;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.World;
+import net.minecraftforge.fluids.capability.IFluidHandler;
+
+/**
+ * Fills or drains a fluid container item using a Dispenser.
+ */
+public class DispenseFluidContainer extends BehaviorDefaultDispenseItem
+{
+    private static final DispenseFluidContainer INSTANCE = new DispenseFluidContainer();
+
+    public static DispenseFluidContainer getInstance()
+    {
+        return INSTANCE;
+    }
+
+    private DispenseFluidContainer() {}
+
+    private final BehaviorDefaultDispenseItem dispenseBehavior = new BehaviorDefaultDispenseItem();
+
+    public ItemStack dispenseStack(IBlockSource source, ItemStack stack)
+    {
+        if (FluidUtil.getFluidContained(stack) != null)
+        {
+            return dumpContainer(source, stack);
+        }
+        else
+        {
+            return fillContainer(source, stack);
+        }
+    }
+
+    /**
+     * Picks up fluid in front of a Dispenser and fills a container with it.
+     */
+    private ItemStack fillContainer(IBlockSource source, ItemStack stack)
+    {
+        World world = source.getWorld();
+        EnumFacing dispenserFacing = BlockDispenser.getFacing(source.getBlockMetadata());
+        BlockPos blockpos = source.getBlockPos().offset(dispenserFacing);
+
+        ItemStack result = FluidUtil.tryPickUpFluid(stack, null, world, blockpos, dispenserFacing.getOpposite());
+        if (result == null)
+        {
+            return super.dispenseStack(source, stack);
+        }
+
+        world.setBlockToAir(blockpos);
+
+        if (--stack.stackSize == 0)
+        {
+            stack.deserializeNBT(result.serializeNBT());
+        }
+        else if (((TileEntityDispenser)source.getBlockTileEntity()).addItemStack(result) < 0)
+        {
+            this.dispenseBehavior.dispense(source, result);
+        }
+
+        return stack;
+    }
+
+    /**
+     * Drains a filled container and places the fluid in front of the Dispenser.
+     */
+    private ItemStack dumpContainer(IBlockSource source, ItemStack stack)
+    {
+        ItemStack dispensedStack = stack.copy();
+        dispensedStack.stackSize = 1;
+        IFluidHandler fluidHandler = FluidUtil.getFluidHandler(dispensedStack);
+        if (fluidHandler == null)
+        {
+            return super.dispenseStack(source, stack);
+        }
+
+        FluidStack fluidStack = fluidHandler.drain(Fluid.BUCKET_VOLUME, false);
+        EnumFacing dispenserFacing = BlockDispenser.getFacing(source.getBlockMetadata());
+        BlockPos blockpos = source.getBlockPos().offset(dispenserFacing);
+
+        if (fluidStack != null && fluidStack.amount == Fluid.BUCKET_VOLUME && FluidUtil.tryPlaceFluid(null, source.getWorld(), fluidStack, blockpos))
+        {
+            fluidHandler.drain(Fluid.BUCKET_VOLUME, true);
+
+            if (--stack.stackSize == 0)
+            {
+                stack.deserializeNBT(dispensedStack.serializeNBT());
+            }
+            else if (((TileEntityDispenser)source.getBlockTileEntity()).addItemStack(dispensedStack) < 0)
+            {
+                this.dispenseBehavior.dispense(source, dispensedStack);
+            }
+
+            return stack;
+        }
+        else
+        {
+            return this.dispenseBehavior.dispense(source, stack);
+        }
+    }
+}

--- a/src/main/java/net/minecraftforge/fluids/UniversalBucket.java
+++ b/src/main/java/net/minecraftforge/fluids/UniversalBucket.java
@@ -1,6 +1,7 @@
 package net.minecraftforge.fluids;
 
 import net.minecraft.block.Block;
+import net.minecraft.block.BlockDispenser;
 import net.minecraft.block.material.Material;
 import net.minecraft.creativetab.CreativeTabs;
 import net.minecraft.entity.player.EntityPlayer;
@@ -55,6 +56,8 @@ public class UniversalBucket extends Item implements IFluidContainerItem
         this.setMaxStackSize(1);
 
         this.setCreativeTab(CreativeTabs.MISC);
+
+        BlockDispenser.DISPENSE_BEHAVIOR_REGISTRY.putObject(this, DispenseFluidContainer.getInstance());
     }
 
     @SideOnly(Side.CLIENT)


### PR DESCRIPTION
Tested many variations.

If the universal bucket is registered, everything can be picked up and placed.
If it isn't, the vanilla fluids can be picked up and placed, but the modded ones cannot. The empty bucket is ejected as an item instead of turning modded fluids into water or lava.

If milk is registered as a fluid block, it can be placed and picked up. If it is not, the milk bucket is ejected as an item.

All of these behaviors are abstracted away by IFluidHandler, you can see the logic here has no special cases.