### PR TITLE
Added support for sending custom ITextComponents in SMP (Rebased to master)

### DIFF
--- a/patches/minecraft/net/minecraft/util/text/ITextComponent.java.patch
+++ b/patches/minecraft/net/minecraft/util/text/ITextComponent.java.patch
@@ -8,3 +8,19 @@
      String func_150254_d();
  
      List<ITextComponent> func_150253_a();
+@@ -83,6 +82,7 @@
+                     JsonObject jsonobject = p_deserialize_1_.getAsJsonObject();
+                     ITextComponent itextcomponent;
+ 
++                    if ((itextcomponent = net.minecraftforge.common.ForgeHooks.onTextComponentDeserialize(jsonobject)) != null) {/*NOOP*/} else 
+                     if (jsonobject.has("text"))
+                     {
+                         itextcomponent = new TextComponentString(jsonobject.get("text").getAsString());
+@@ -241,6 +241,7 @@
+                 {
+                     if (!(p_serialize_1_ instanceof TextComponentSelector))
+                     {
++                        if (net.minecraftforge.common.ForgeHooks.onTextComponentSerialize(p_serialize_1_, jsonobject)) return jsonobject;
+                         throw new IllegalArgumentException("Don\'t know how to serialize " + p_serialize_1_ + " as a Component");
+                     }
+ 

--- a/src/main/java/net/minecraftforge/common/util/TextComponentSerializable.java
+++ b/src/main/java/net/minecraftforge/common/util/TextComponentSerializable.java
@@ -1,0 +1,9 @@
+package net.minecraftforge.common.util;
+
+import net.minecraft.util.IJsonSerializable;
+import net.minecraft.util.text.TextComponentBase;
+
+public abstract class TextComponentSerializable extends TextComponentBase implements IJsonSerializable
+{
+    public String getFallbackText() { return "{Unsupported component type: "+getClass().getName()+"}"; }
+}

--- a/src/test/java/net/minecraftforge/debug/CustomTextComponentDebug.java
+++ b/src/test/java/net/minecraftforge/debug/CustomTextComponentDebug.java
@@ -1,10 +1,7 @@
 package net.minecraftforge.debug;
 
-import org.apache.logging.log4j.Logger;
-
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
-import com.google.gson.JsonParser;
 import com.google.gson.JsonPrimitive;
 
 import net.minecraft.crash.CrashReport;
@@ -15,19 +12,16 @@ import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.JsonToNBT;
 import net.minecraft.nbt.NBTException;
 import net.minecraft.nbt.NBTTagCompound;
-import net.minecraft.util.IJsonSerializable;
 import net.minecraft.util.ReportedException;
 import net.minecraft.util.ResourceLocation;
 import net.minecraft.util.text.ITextComponent;
-import net.minecraft.util.text.TextComponentBase;
-import net.minecraft.util.text.TextComponentString;
 import net.minecraftforge.common.MinecraftForge;
+import net.minecraftforge.common.util.TextComponentSerializable;
 import net.minecraftforge.event.entity.EntityJoinWorldEvent;
 import net.minecraftforge.fml.common.Mod;
 import net.minecraftforge.fml.common.Mod.EventHandler;
 import net.minecraftforge.fml.common.event.FMLPreInitializationEvent;
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
-import net.minecraftforge.fml.common.gameevent.PlayerEvent.PlayerLoggedInEvent;
 
 @Mod(modid="CustomTextComponentDebug", name="CustomTextComponentDebug", version="0.0.0", acceptableRemoteVersions="*")
 public class CustomTextComponentDebug
@@ -47,46 +41,52 @@ public class CustomTextComponentDebug
         if(ENABLE && !ev.getWorld().isRemote && (ev.getEntity() instanceof EntityPlayer))
             ev.getEntity().addChatMessage(new TextComponentItemStack(new ItemStack(Items.COOKIE)));
     }
-    
-    public static class TextComponentItemStack extends TextComponentBase implements IJsonSerializable
+
+    public static class TextComponentItemStack extends TextComponentSerializable
     {
         private ItemStack stack;
-    
+
         public TextComponentItemStack()
         {
         }
-    
+
         public TextComponentItemStack(ItemStack stack)
         {
             this.stack = stack.copy();
         }
-    
+
         public ItemStack getItemStack()
         {
             return stack;
         }
-    
+
         @Override
         public String getUnformattedComponentText()
         {
             return "[" + stack.getDisplayName() + "]";
         }
-    
+
+        @Override
+        public String getFallbackText()
+        {
+            return getUnformattedComponentText();
+        }
+
         @Override
         public TextComponentItemStack createCopy()
         {
             TextComponentItemStack copy = new TextComponentItemStack(stack);
-    
+
             copy.setStyle(this.getStyle().createShallowCopy());
-    
+
             for (ITextComponent itextcomponent : this.getSiblings())
             {
                 copy.appendSibling(itextcomponent.createCopy());
             }
-    
+
             return copy;
         }
-    
+
         public boolean equals(Object other)
         {
             if (this == other)
@@ -102,14 +102,14 @@ public class CustomTextComponentDebug
                 return ItemStack.areItemStacksEqual(this.stack, ((TextComponentItemStack) other).getItemStack()) && super.equals(other);
             }
         }
-    
+
         public String toString()
         {
             ResourceLocation item = stack.getItem().getRegistryName();
             int meta = stack.getMetadata();
             int stackSize = stack.stackSize;
             NBTTagCompound tag = stack.getTagCompound();
-    
+
             StringBuilder b = new StringBuilder();
             b.append("ItemStack{item='"); b.append(item.toString()); b.append("'");
             b.append(", stackSize="); b.append(stackSize);
@@ -122,7 +122,7 @@ public class CustomTextComponentDebug
                 b.append(", tag="); b.append(tag.toString());
             }
             b.append("}");
-    
+
             return b.toString();
         }
 
@@ -136,7 +136,7 @@ public class CustomTextComponentDebug
             int stackSize = obj.get("stackSize").getAsInt();
 
             stack = new ItemStack(item, stackSize, meta);
-            
+
             if (obj.has("tag"))
             {
                 try

--- a/src/test/java/net/minecraftforge/debug/CustomTextComponentDebug.java
+++ b/src/test/java/net/minecraftforge/debug/CustomTextComponentDebug.java
@@ -39,7 +39,12 @@ public class CustomTextComponentDebug
     public void playerLogin(EntityJoinWorldEvent ev)
     {
         if(ENABLE && !ev.getWorld().isRemote && (ev.getEntity() instanceof EntityPlayer))
-            ev.getEntity().addChatMessage(new TextComponentItemStack(new ItemStack(Items.COOKIE)));
+        {
+            ItemStack stack = new ItemStack(Items.COOKIE);
+            stack.setStackDisplayName("Jaffa Cake");
+
+            ev.getEntity().addChatMessage(new TextComponentItemStack(stack));
+        }
     }
 
     public static class TextComponentItemStack extends TextComponentSerializable
@@ -63,7 +68,7 @@ public class CustomTextComponentDebug
         @Override
         public String getUnformattedComponentText()
         {
-            return "[" + stack.getDisplayName() + "]";
+            return "This TextComponent represents " + stack.stackSize + "x " + stack.getDisplayName();
         }
 
         @Override
@@ -105,25 +110,7 @@ public class CustomTextComponentDebug
 
         public String toString()
         {
-            ResourceLocation item = stack.getItem().getRegistryName();
-            int meta = stack.getMetadata();
-            int stackSize = stack.stackSize;
-            NBTTagCompound tag = stack.getTagCompound();
-
-            StringBuilder b = new StringBuilder();
-            b.append("ItemStack{item='"); b.append(item.toString()); b.append("'");
-            b.append(", stackSize="); b.append(stackSize);
-            if (meta != 0)
-            {
-                b.append(", meta="); b.append(meta);
-            }
-            if(tag != null && !tag.hasNoTags())
-            {
-                b.append(", tag="); b.append(tag.toString());
-            }
-            b.append("}");
-
-            return b.toString();
+            return getSerializableElement().toString();
         }
 
         @Override
@@ -165,7 +152,7 @@ public class CustomTextComponentDebug
             if(meta != 0) obj.add("meta", new JsonPrimitive(meta));
             if(tag != null && !tag.hasNoTags())
             {
-                obj.add("tag", new JsonPrimitive(tag.toString()).getAsJsonObject());
+                obj.add("tag", new JsonPrimitive(tag.toString()));
             }
 
             return obj;

--- a/src/test/java/net/minecraftforge/debug/CustomTextComponentDebug.java
+++ b/src/test/java/net/minecraftforge/debug/CustomTextComponentDebug.java
@@ -1,0 +1,174 @@
+package net.minecraftforge.debug;
+
+import org.apache.logging.log4j.Logger;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+import com.google.gson.JsonPrimitive;
+
+import net.minecraft.crash.CrashReport;
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.init.Items;
+import net.minecraft.item.Item;
+import net.minecraft.item.ItemStack;
+import net.minecraft.nbt.JsonToNBT;
+import net.minecraft.nbt.NBTException;
+import net.minecraft.nbt.NBTTagCompound;
+import net.minecraft.util.IJsonSerializable;
+import net.minecraft.util.ReportedException;
+import net.minecraft.util.ResourceLocation;
+import net.minecraft.util.text.ITextComponent;
+import net.minecraft.util.text.TextComponentBase;
+import net.minecraft.util.text.TextComponentString;
+import net.minecraftforge.common.MinecraftForge;
+import net.minecraftforge.event.entity.EntityJoinWorldEvent;
+import net.minecraftforge.fml.common.Mod;
+import net.minecraftforge.fml.common.Mod.EventHandler;
+import net.minecraftforge.fml.common.event.FMLPreInitializationEvent;
+import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
+import net.minecraftforge.fml.common.gameevent.PlayerEvent.PlayerLoggedInEvent;
+
+@Mod(modid="CustomTextComponentDebug", name="CustomTextComponentDebug", version="0.0.0", acceptableRemoteVersions="*")
+public class CustomTextComponentDebug
+{
+    // NOTE: Test with both this ON and OFF - ensure none of the test behaviours show when this is off!
+    private static final boolean ENABLE = true;
+
+    @EventHandler
+    public void preinit(FMLPreInitializationEvent event)
+    {
+        MinecraftForge.EVENT_BUS.register(this);
+    }
+
+    @SubscribeEvent
+    public void playerLogin(EntityJoinWorldEvent ev)
+    {
+        if(ENABLE && !ev.getWorld().isRemote && (ev.getEntity() instanceof EntityPlayer))
+            ev.getEntity().addChatMessage(new TextComponentItemStack(new ItemStack(Items.COOKIE)));
+    }
+    
+    public static class TextComponentItemStack extends TextComponentBase implements IJsonSerializable
+    {
+        private ItemStack stack;
+    
+        public TextComponentItemStack()
+        {
+        }
+    
+        public TextComponentItemStack(ItemStack stack)
+        {
+            this.stack = stack.copy();
+        }
+    
+        public ItemStack getItemStack()
+        {
+            return stack;
+        }
+    
+        @Override
+        public String getUnformattedComponentText()
+        {
+            return "[" + stack.getDisplayName() + "]";
+        }
+    
+        @Override
+        public TextComponentItemStack createCopy()
+        {
+            TextComponentItemStack copy = new TextComponentItemStack(stack);
+    
+            copy.setStyle(this.getStyle().createShallowCopy());
+    
+            for (ITextComponent itextcomponent : this.getSiblings())
+            {
+                copy.appendSibling(itextcomponent.createCopy());
+            }
+    
+            return copy;
+        }
+    
+        public boolean equals(Object other)
+        {
+            if (this == other)
+            {
+                return true;
+            }
+            else if (!(other instanceof TextComponentItemStack))
+            {
+                return false;
+            }
+            else
+            {
+                return ItemStack.areItemStacksEqual(this.stack, ((TextComponentItemStack) other).getItemStack()) && super.equals(other);
+            }
+        }
+    
+        public String toString()
+        {
+            ResourceLocation item = stack.getItem().getRegistryName();
+            int meta = stack.getMetadata();
+            int stackSize = stack.stackSize;
+            NBTTagCompound tag = stack.getTagCompound();
+    
+            StringBuilder b = new StringBuilder();
+            b.append("ItemStack{item='"); b.append(item.toString()); b.append("'");
+            b.append(", stackSize="); b.append(stackSize);
+            if (meta != 0)
+            {
+                b.append(", meta="); b.append(meta);
+            }
+            if(tag != null && !tag.hasNoTags())
+            {
+                b.append(", tag="); b.append(tag.toString());
+            }
+            b.append("}");
+    
+            return b.toString();
+        }
+
+        @Override
+        public void fromJson(JsonElement json)
+        {
+            JsonObject obj = json.getAsJsonObject();
+
+            Item item = Item.REGISTRY.getObject(new ResourceLocation(obj.get("item").getAsString()));
+            int meta = obj.has("meta") ? obj.get("meta").getAsInt() : 0;
+            int stackSize = obj.get("stackSize").getAsInt();
+
+            stack = new ItemStack(item, stackSize, meta);
+            
+            if (obj.has("tag"))
+            {
+                try
+                {
+                    stack.setTagCompound((NBTTagCompound)JsonToNBT.getTagFromJson(obj.get("tag").getAsString()));
+                }
+                catch (NBTException e)
+                {
+                    throw new ReportedException(new CrashReport("Error deserializing ItemStack text component", e));
+                }
+            }
+        }
+
+        @Override
+        public JsonElement getSerializableElement()
+        {
+            JsonObject obj = new JsonObject();
+
+            ResourceLocation item = stack.getItem().getRegistryName();
+            int meta = stack.getMetadata();
+            int stackSize = stack.stackSize;
+            NBTTagCompound tag = stack.getTagCompound();
+
+            obj.add("item", new JsonPrimitive(item.toString()));
+            obj.add("stackSize", new JsonPrimitive(stackSize));
+            if(meta != 0) obj.add("meta", new JsonPrimitive(meta));
+            if(tag != null && !tag.hasNoTags())
+            {
+                obj.add("tag", new JsonPrimitive(tag.toString()).getAsJsonObject());
+            }
+
+            return obj;
+        }
+    }
+}


### PR DESCRIPTION
Replaces #2915.

This PR adds hooks for serializing and deserializing on ITextComponent.Serializer, which are used alongside IJsonSerializable to allow transferring custom ITextComponent data to the clients on SMP situations.

How to use:
* Custom ITextComponents have to extend `TextComponentSerializable`, and implement the `fromJson`and `getSerializableElement` methods (which really need a better name on MCP ;P)
* Optionally, custom ITextComponents can also override `getFallbackText` in order to provide a custom fallback (defaults to a message indicating the unknown class).

Case in point: 
* An ITextComponent that transfers an ItemStack: Allows translating the item name on the client, making it a clickable link that opens the item's recipe, showing a tooltip on hover, ...
  * Vanilla already has `ItemStack#getTextComponent()` for this, but it uses TextComponentString, with the translation performed on the server, and there's no clean way to obtain the full translation key and send it to the client.

If this is accepted, a followup PR would move the TextComponentItemStack from the debug class into Forge proper, and make use of it from the previously mentioned `ItemStack#getTextComponent()`.