### PR TITLE
Expose vanilla brewing recipe registration

### DIFF
--- a/src/main/resources/forge_at.cfg
+++ b/src/main/resources/forge_at.cfg
@@ -271,3 +271,10 @@ public net.minecraft.client.renderer.entity.RenderLivingBase func_177089_b(Lnet/
 # LootTable Stuff
 private-f net.minecraft.world.storage.loot.LootPool field_186455_c # rolls
 private-f net.minecraft.world.storage.loot.LootPool field_186456_d # bonusRolls
+
+# Expose vanilla brewing recipe system
+public net.minecraft.potion.PotionHelper$ItemPredicateInstance
+public net.minecraft.potion.PotionHelper$MixPredicate
+public net.minecraft.potion.PotionHelper func_185201_a(Lnet/minecraft/item/ItemPotion;Lnet/minecraft/potion/PotionHelper$ItemPredicateInstance;Lnet/minecraft/item/ItemPotion;)V # registerPotionItemConversion
+public net.minecraft.potion.PotionHelper func_185202_a(Lnet/minecraft/potion/PotionHelper$ItemPredicateInstance;)V # registerPotionItem
+public net.minecraft.potion.PotionHelper func_185204_a(Lnet/minecraft/potion/PotionType;Lcom/google/common/base/Predicate;Lnet/minecraft/potion/PotionType;)V # registerPotionTypeConversion


### PR DESCRIPTION
As of 1.9, the vanilla potion brewing recipe system as actually pretty useful.

You register "potion items" (subclasses of ItemPotion) then you register conversions from one potion item to another potion item, e.g. normal potion + gunpowder => Items.splash_potion and the potion NBT is copied over.

You register PotionTypes then you register conversions from one PotionType to another PotionType.
e.g. minecraft:regeneration + redstone => minecraft:long_regeneration

Most ordinary brewing recipes can simply use this instead of having to implement it in a custom IBrewingRecipe. These recipes will then be called as part of the vanilla behaviour.

This PR makes the necessary registration methods (and classes needed for them) accessible.

Closes #2777