### PR TITLE
Adding in LivingPotionEvent, along with more specific events per event type.

### DIFF
--- a/patches/minecraft/net/minecraft/entity/EntityLivingBase.java.patch
+++ b/patches/minecraft/net/minecraft/entity/EntityLivingBase.java.patch
@@ -39,7 +39,45 @@
      }
  
      public EntityLivingBase func_110144_aD()
-@@ -784,6 +786,8 @@
+@@ -580,6 +582,7 @@
+                 if (!this.field_70170_p.field_72995_K)
+                 {
+                     iterator.remove();
++                    net.minecraftforge.common.ForgeHooks.onLivingPotionExpired(this, potioneffect);
+                     this.func_70688_c(potioneffect);
+                 }
+             }
+@@ -673,7 +676,9 @@
+ 
+             while (iterator.hasNext())
+             {
+-                this.func_70688_c((PotionEffect)iterator.next());
++                PotionEffect effect = iterator.next();
++                net.minecraftforge.common.ForgeHooks.onLivingPotionRemoved(this, effect, true);
++                this.func_70688_c(effect);
+                 iterator.remove();
+             }
+         }
+@@ -699,6 +704,7 @@
+     {
+         if (this.func_70687_e(p_70690_1_))
+         {
++            if(!field_70170_p.field_72995_K && net.minecraftforge.common.ForgeHooks.onLivingPotionAdded(this, p_70690_1_)) return;
+             PotionEffect potioneffect = (PotionEffect)this.field_70713_bf.get(p_70690_1_.func_188419_a());
+ 
+             if (potioneffect == null)
+@@ -737,7 +743,9 @@
+     @Nullable
+     public PotionEffect func_184596_c(@Nullable Potion p_184596_1_)
+     {
+-        return (PotionEffect)this.field_70713_bf.remove(p_184596_1_);
++        PotionEffect effect = (PotionEffect)this.field_70713_bf.remove(p_184596_1_);
++        if(!field_70170_p.field_72995_K) net.minecraftforge.common.ForgeHooks.onLivingPotionRemoved(this, effect, false);
++        return effect;
+     }
+ 
+     public void func_184589_d(Potion p_184589_1_)
+@@ -784,6 +792,8 @@
  
      public void func_70691_i(float p_70691_1_)
      {
@@ -48,7 +86,7 @@
          float f = this.func_110143_aJ();
  
          if (f > 0.0F)
-@@ -804,6 +808,7 @@
+@@ -804,6 +814,7 @@
  
      public boolean func_70097_a(DamageSource p_70097_1_, float p_70097_2_)
      {
@@ -56,7 +94,7 @@
          if (this.func_180431_b(p_70097_1_))
          {
              return false;
-@@ -892,9 +897,9 @@
+@@ -892,9 +903,9 @@
                          this.field_70718_bc = 100;
                          this.field_70717_bb = (EntityPlayer)entity;
                      }
@@ -68,7 +106,7 @@
  
                          if (entitywolf.func_70909_n())
                          {
-@@ -1016,6 +1021,7 @@
+@@ -1016,6 +1027,7 @@
  
      public void func_70645_a(DamageSource p_70645_1_)
      {
@@ -76,7 +114,7 @@
          if (!this.field_70729_aU)
          {
              Entity entity = p_70645_1_.func_76346_g();
-@@ -1043,11 +1049,24 @@
+@@ -1043,11 +1055,24 @@
                      i = EnchantmentHelper.func_185283_h((EntityLivingBase)entity);
                  }
  
@@ -101,7 +139,7 @@
              }
  
              this.field_70170_p.func_72960_a(this, (byte)3);
-@@ -1124,7 +1143,7 @@
+@@ -1124,7 +1149,7 @@
              BlockPos blockpos = new BlockPos(i, j, k);
              IBlockState iblockstate = this.field_70170_p.func_180495_p(blockpos);
              Block block = iblockstate.func_177230_c();
@@ -110,7 +148,7 @@
          }
      }
  
-@@ -1150,6 +1169,9 @@
+@@ -1150,6 +1175,9 @@
  
      public void func_180430_e(float p_180430_1_, float p_180430_2_)
      {
@@ -120,7 +158,7 @@
          super.func_180430_e(p_180430_1_, p_180430_2_);
          PotionEffect potioneffect = this.func_70660_b(MobEffects.field_76430_j);
          float f = potioneffect == null ? 0.0F : (float)(potioneffect.func_76458_c() + 1);
-@@ -1242,6 +1264,8 @@
+@@ -1242,6 +1270,8 @@
      {
          if (!this.func_180431_b(p_70665_1_))
          {
@@ -129,7 +167,7 @@
              p_70665_2_ = this.func_70655_b(p_70665_1_, p_70665_2_);
              p_70665_2_ = this.func_70672_c(p_70665_1_, p_70665_2_);
              float f = p_70665_2_;
-@@ -1290,6 +1314,11 @@
+@@ -1290,6 +1320,11 @@
  
      public void func_184609_a(EnumHand p_184609_1_)
      {
@@ -141,7 +179,7 @@
          if (!this.field_82175_bq || this.field_110158_av >= this.func_82166_i() / 2 || this.field_110158_av < 0)
          {
              this.field_110158_av = -1;
-@@ -1491,6 +1520,7 @@
+@@ -1491,6 +1526,7 @@
  
      public void func_110145_l(Entity p_110145_1_)
      {
@@ -149,7 +187,7 @@
          if (!(p_110145_1_ instanceof EntityBoat) && !(p_110145_1_ instanceof EntityHorse))
          {
              double d1 = p_110145_1_.field_70165_t;
-@@ -1515,7 +1545,7 @@
+@@ -1515,7 +1551,7 @@
  
                  if (!this.field_70170_p.func_184143_b(axisalignedbb1))
                  {
@@ -158,7 +196,7 @@
                      {
                          this.func_70634_a(d11, this.field_70163_u + 1.0D, d12);
                          return;
-@@ -1523,14 +1553,14 @@
+@@ -1523,14 +1559,14 @@
  
                      BlockPos blockpos = new BlockPos(d11, this.field_70163_u - 1.0D, d12);
  
@@ -175,7 +213,7 @@
                  {
                      d1 = d11;
                      d13 = this.field_70163_u + 2.0D;
-@@ -1601,6 +1631,7 @@
+@@ -1601,6 +1637,7 @@
          }
  
          this.field_70160_al = true;
@@ -183,7 +221,7 @@
      }
  
      protected void func_70629_bd()
-@@ -1860,6 +1891,7 @@
+@@ -1860,6 +1897,7 @@
  
      public void func_70071_h_()
      {
@@ -191,7 +229,7 @@
          super.func_70071_h_();
          this.func_184608_ct();
  
-@@ -2366,6 +2398,40 @@
+@@ -2366,6 +2404,41 @@
          this.field_70752_e = true;
      }
  
@@ -210,6 +248,7 @@
 +
 +            if (effect.isCurativeItem(curativeItem))
 +            {
++                if(net.minecraftforge.common.ForgeHooks.onLivingPotionCured(this, effect, curativeItem)) continue;
 +                func_70688_c(effect);
 +                iterator.remove();
 +                this.field_70752_e = true;
@@ -232,7 +271,7 @@
      public abstract EnumHandSide func_184591_cq();
  
      public boolean func_184587_cr()
-@@ -2386,12 +2452,19 @@
+@@ -2386,12 +2459,19 @@
  
              if (itemstack == this.field_184627_bm)
              {
@@ -253,7 +292,7 @@
                  {
                      this.func_71036_o();
                  }
-@@ -2409,8 +2482,10 @@
+@@ -2409,8 +2489,10 @@
  
          if (itemstack != null && !this.func_184587_cr())
          {
@@ -265,7 +304,7 @@
  
              if (!this.field_70170_p.field_72995_K)
              {
-@@ -2493,6 +2568,8 @@
+@@ -2493,6 +2575,8 @@
              this.func_184584_a(this.field_184627_bm, 16);
              ItemStack itemstack = this.field_184627_bm.func_77950_b(this.field_70170_p, this);
  
@@ -274,7 +313,7 @@
              if (itemstack != null && itemstack.field_77994_a == 0)
              {
                  itemstack = null;
-@@ -2523,7 +2600,8 @@
+@@ -2523,7 +2607,8 @@
      {
          if (this.field_184627_bm != null)
          {
@@ -284,7 +323,7 @@
          }
  
          this.func_184602_cy();
-@@ -2642,4 +2720,28 @@
+@@ -2642,4 +2727,28 @@
      {
          return true;
      }

--- a/src/main/java/net/minecraftforge/common/ForgeHooks.java
+++ b/src/main/java/net/minecraftforge/common/ForgeHooks.java
@@ -49,6 +49,7 @@ import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.network.NetHandlerPlayServer;
 import net.minecraft.network.Packet;
 import net.minecraft.network.play.server.SPacketBlockChange;
+import net.minecraft.potion.PotionEffect;
 import net.minecraft.stats.StatList;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.tileentity.TileEntityNote;
@@ -89,6 +90,7 @@ import net.minecraftforge.event.entity.living.LivingEvent.LivingJumpEvent;
 import net.minecraftforge.event.entity.living.LivingEvent.LivingUpdateEvent;
 import net.minecraftforge.event.entity.living.LivingFallEvent;
 import net.minecraftforge.event.entity.living.LivingHurtEvent;
+import net.minecraftforge.event.entity.living.LivingPotionEvent;
 import net.minecraftforge.event.entity.living.LivingSetAttackTargetEvent;
 import net.minecraftforge.event.entity.player.AnvilRepairEvent;
 import net.minecraftforge.event.entity.player.AttackEntityEvent;
@@ -489,6 +491,22 @@ public class ForgeHooks
     public static boolean onLivingDrops(EntityLivingBase entity, DamageSource source, ArrayList<EntityItem> drops, int lootingLevel, boolean recentlyHit)
     {
         return MinecraftForge.EVENT_BUS.post(new LivingDropsEvent(entity, source, drops, lootingLevel, recentlyHit));
+    }
+
+    public static boolean onLivingPotionAdded(EntityLivingBase entity, PotionEffect effect) {
+        return MinecraftForge.EVENT_BUS.post(new LivingPotionEvent.LivingPotionAddedEvent(entity, effect));
+    }
+
+    public static boolean onLivingPotionCured(EntityLivingBase entity, PotionEffect effect, ItemStack curativeItem) {
+        return MinecraftForge.EVENT_BUS.post(new LivingPotionEvent.LivingPotionCuredEvent(entity, effect, curativeItem));
+    }
+
+    public static void onLivingPotionRemoved(EntityLivingBase entity, PotionEffect effect, boolean byCommand) {
+        MinecraftForge.EVENT_BUS.post(new LivingPotionEvent.LivingPotionRemovedEvent(entity, effect, byCommand));
+    }
+
+    public static void onLivingPotionExpired(EntityLivingBase entity, PotionEffect effect) {
+        MinecraftForge.EVENT_BUS.post(new LivingPotionEvent.LivingPotionExpiredEvent(entity, effect));
     }
 
     public static float[] onLivingFall(EntityLivingBase entity, float distance, float damageMultiplier)

--- a/src/main/java/net/minecraftforge/event/entity/living/LivingPotionEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/living/LivingPotionEvent.java
@@ -1,0 +1,148 @@
+package net.minecraftforge.event.entity.living;
+
+import net.minecraft.entity.EntityLivingBase;
+import net.minecraft.item.ItemStack;
+import net.minecraft.potion.Potion;
+import net.minecraft.potion.PotionEffect;
+import net.minecraftforge.common.ForgeHooks;
+import net.minecraftforge.common.MinecraftForge;
+import net.minecraftforge.fml.common.eventhandler.Cancelable;
+import net.minecraftforge.fml.common.eventhandler.Event;
+
+/**
+ * LivingPotionEvent is fired when an EntityLivingBase has a change in potion effects.<br>
+ * If a method utilizes this {@link Event} as its parameter, the method will
+ * receive every child event of this class.<br>
+ * <br>
+ * {@link #effect} contains the PotionEffect that is changing.<br>
+ * {@link #type} contains the {@link LivingPotionEventType} for this event.<br>
+ * <br>
+ * All children of this event are fired on the {@link MinecraftForge#EVENT_BUS} on the server.<br>
+ **/
+public class LivingPotionEvent extends LivingEvent {
+    protected PotionEffect effect;
+    private final LivingPotionEventType type;
+
+    public LivingPotionEvent(EntityLivingBase entity, PotionEffect effect, LivingPotionEventType type) {
+        super(entity);
+        this.effect = effect;
+        this.type = type;
+    }
+
+    public PotionEffect getEffect() {
+        return effect;
+    }
+
+    public LivingPotionEventType getType() {
+        return type;
+    }
+
+    /**
+     * LivingPotionAddedEvent is fired when an EntityLivingBase is about to receive a new potion effect.<br>
+     * This event is fired whenever an EntityLivingBase has a potion added through the
+     * {@link EntityLivingBase#addPotionEffect(PotionEffect)} method.<br>
+     * <br>
+     * This event is fired via {@link ForgeHooks#onLivingPotionAdded(EntityLivingBase, PotionEffect)}.<br>
+     * <br>
+     * {@link #entity} contains the EntityLivingBase that will have the new potion effect.<br>
+     * {@link #effect} contains the PotionEffect about to be added.<br>
+     * <br>
+     * This event is {@link Cancelable}.<br>
+     * If this event is canceled, the Entity does not get the new potion effect.<br>
+     * <br>
+     * This event does not have a result. {@link HasResult}<br>
+     * <br>
+     * This event is fired on the {@link MinecraftForge#EVENT_BUS}.
+     **/
+    @Cancelable
+    public static class LivingPotionAddedEvent extends LivingPotionEvent {
+        public LivingPotionAddedEvent(EntityLivingBase entity, PotionEffect effect) {
+            super(entity, effect, LivingPotionEventType.ADDED);
+        }
+    }
+
+    /**
+     * LivingPotionCuredEvent is fired when an EntityLivingBase is about to cure a potion effect.<br>
+     * This event is fired whenever an EntityLivingBase attempts to cure a potion through the
+     * {@link EntityLivingBase#curePotionEffects(ItemStack)} method.<br>
+     * <br>
+     * This event is fired via {@link ForgeHooks#onLivingPotionCured(EntityLivingBase, PotionEffect, ItemStack)}.<br>
+     * <br>
+     * {@link #entity} contains the EntityLivingBase that will have the effect cured.<br>
+     * {@link #effect} contains the PotionEffect about to be cured.<br>
+     * {@link #curativeItem} contains the ItemStack used to cure the effect.<br>
+     * <br>
+     * This event is {@link Cancelable}.<br>
+     * If this event is canceled, the Entity does not cure this potion effect with the item.<br>
+     * <br>
+     * This event does not have a result. {@link HasResult}<br>
+     * <br>
+     * This event is fired on the {@link MinecraftForge#EVENT_BUS}.
+     **/
+    @Cancelable
+    public static class LivingPotionCuredEvent extends LivingPotionEvent {
+        private final ItemStack curativeItem;
+
+        public LivingPotionCuredEvent(EntityLivingBase entity, PotionEffect effect, ItemStack curativeItem) {
+            super(entity, effect, LivingPotionEventType.CURED);
+            this.curativeItem = curativeItem;
+        }
+
+        public ItemStack getCurativeItem() {
+            return curativeItem;
+        }
+    }
+
+    /**
+     * LivingPotionExpiredEvent is fired when an EntityLivingBase is about to have a potion effect expire.<br>
+     * This event is fired whenever an EntityLivingBase a potion effect would expire in the
+     * {@link EntityLivingBase#updatePotionEffects()} method.<br>
+     * <br>
+     * This event is fired via {@link ForgeHooks#onLivingPotionExpired(EntityLivingBase, PotionEffect)}.<br>
+     * <br>
+     * {@link #entity} contains the EntityLivingBase that will have the effect expire.<br>
+     * {@link #effect} contains the PotionEffect about to be expired.<br>
+     * <br>
+     * This event does not have a result. {@link HasResult}<br>
+     * <br>
+     * This event is fired on the {@link MinecraftForge#EVENT_BUS}.
+     **/
+    public static class LivingPotionExpiredEvent extends LivingPotionEvent {
+        public LivingPotionExpiredEvent(EntityLivingBase entity, PotionEffect effect) {
+            super(entity, effect, LivingPotionEventType.EXPIRED);
+        }
+    }
+
+
+    /**
+     * LivingPotionRemovedEvent is fired when an EntityLivingBase is about to have a potion effect removed.<br>
+     * This event is fired whenever an EntityLivingBase a potion effect would be removed in the
+     * {@link EntityLivingBase#clearActivePotions()} and {@link EntityLivingBase#removeActivePotionEffect(Potion)} methods.<br>
+     * <br>
+     * This event is fired via {@link ForgeHooks#onLivingPotionRemoved(EntityLivingBase, PotionEffect, boolean)}.<br>
+     * <br>
+     * {@link #entity} contains the EntityLivingBase that will have the effect removed.<br>
+     * {@link #effect} contains the PotionEffect about to be removed.<br>
+     * {@link #byCommand} contains if the effect was removed via admin command or not.
+     * <br>
+     * This event does not have a result. {@link HasResult}<br>
+     * <br>
+     * This event is fired on the {@link MinecraftForge#EVENT_BUS}.
+     **/
+    public static class LivingPotionRemovedEvent extends LivingPotionEvent {
+        private final boolean byCommand;
+
+        public LivingPotionRemovedEvent(EntityLivingBase entity, PotionEffect effect, boolean byCommand) {
+            super(entity, effect, LivingPotionEventType.REMOVED);
+            this.byCommand = byCommand;
+        }
+
+        public boolean isByCommand() {
+            return byCommand;
+        }
+    }
+
+    public static enum LivingPotionEventType {
+        ADDED, EXPIRED, CURED, REMOVED
+    }
+}

--- a/src/test/java/net/minecraftforge/test/LivingPotionEventsTest.java
+++ b/src/test/java/net/minecraftforge/test/LivingPotionEventsTest.java
@@ -1,0 +1,76 @@
+package net.minecraftforge.test;
+
+import net.minecraft.init.Items;
+import net.minecraft.potion.Potion;
+import net.minecraft.util.ResourceLocation;
+import net.minecraftforge.common.MinecraftForge;
+import net.minecraftforge.event.entity.living.LivingPotionEvent;
+import net.minecraftforge.fml.common.Mod;
+import net.minecraftforge.fml.common.event.FMLInitializationEvent;
+import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
+
+/**
+ * Basic implementation for testing living potion events hooks
+ */
+
+@Mod(modid="livingpotioneventstest", name="Living Potion Events Test", version="0.0.0")
+public class LivingPotionEventsTest {
+    @Mod.EventHandler
+    public void init(FMLInitializationEvent event)
+    {
+        MinecraftForge.EVENT_BUS.register(this);
+    }
+
+    /*
+     * Test of the main LivingPotion event
+     */
+    @SubscribeEvent
+    public void onPotionEvent(LivingPotionEvent event) {
+        System.out.println(event.getEntity().getName() + " had a potion event occur regarding " + event.getEffect().getEffectName());
+    }
+
+    /*
+     * Test of the LivingPotionAdded event
+     */
+    @SubscribeEvent
+    public void onPotionAdded(LivingPotionEvent.LivingPotionAddedEvent event) {
+        System.out.println(event.getEntity().getName() + " about to receive " + event.getEffect().getEffectName());
+
+        if(event.getEffect().getPotion() == Potion.REGISTRY.getObject(new ResourceLocation("minecraft:luck"))) {
+            System.out.println("Preventing luck from being applied from LivingPotionEventsTest.onPotionAdded.");
+            event.setCanceled(true);
+        }
+    }
+
+    /*
+     * Test of the LivingPotionCuredEvent
+     */
+    @SubscribeEvent
+    public void onPotionCured(LivingPotionEvent.LivingPotionCuredEvent event) {
+        System.out.println(event.getEntity().getName() + " about to cure " + event.getEffect().getEffectName() +
+            " with " + event.getCurativeItem().getDisplayName());
+
+        if(event.getCurativeItem().getItem() == Items.MILK_BUCKET && event.getEntity().getEntityWorld().rand.nextDouble() < 0.5) {
+            System.out.println("Preventing this being cured by milk from LivingPotionEventsTest.onPotionCured.");
+            event.setCanceled(true);
+        }
+    }
+
+    /*
+     * Test of the LivingPotionRemoved event
+     */
+    @SubscribeEvent
+    public void onPotionRemoved(LivingPotionEvent.LivingPotionRemovedEvent event) {
+        System.out.println(event.getEntity().getName() + " had " + event.getEffect().getEffectName() + " removed " +
+                (event.isByCommand() ? "via command." : "directly."));
+    }
+
+    /*
+     * Test of the LivingPotionExpired event
+     */
+    @SubscribeEvent
+    public void onPotionExpired(LivingPotionEvent.LivingPotionExpiredEvent event) {
+        System.out.println(event.getEntity().getName() + " had " + event.getEffect().getEffectName() + " expire.");
+    }
+}
+


### PR DESCRIPTION
Adding in a LivingPotionEvent event class, with the following subclasses:
- LivingPotionAddedEvent: Fired from EntityLivingBase#addPotionEffect
- LivingPotionCuredEvent: Fired from EntityLivingBase#curePotionEffects
- LivingPotionExpiredEvent: Fired from EntityLivingBase#updatePotionEffects
- LivingPotionRemovedEvent: Fired from EntityLivingBase#clearActivePotions and EntityLivingBase#removeActivePotionEffect

All events are fired server only, with the first two being cancellable - cancellation will prevent the potion from being added / cured, respectively.

Every event has a reference to the entity and the potion effect in question, while the cured event also gives the ItemStack that will cause the cure, and the removed event will let you know if it was cured via the command line (with clearActivePotions) or directly (with removeActivePotionEffect).

Basic tests are available in the LivingPotionEventsTest class, in the Forge tests project.

Thanks.