### PR TITLE
Add getter for the world to LootContext

### DIFF
--- a/patches/minecraft/net/minecraft/world/storage/loot/LootContext.java.patch
+++ b/patches/minecraft/net/minecraft/world/storage/loot/LootContext.java.patch
@@ -1,0 +1,14 @@
+--- ../src-base/minecraft/net/minecraft/world/storage/loot/LootContext.java
++++ ../src-work/minecraft/net/minecraft/world/storage/loot/LootContext.java
+@@ -89,6 +89,11 @@
+         }
+     }
+ 
++    public WorldServer getWorld()
++    {
++        return field_186499_b;
++    }
++
+     public static class Builder
+         {
+             private final WorldServer field_186474_a;


### PR DESCRIPTION
As title, easy enough.

Useful for custom LootFunctions and LootConditions that need the world, but you can't get it because all the entities are null (for example, chest gen tables. No looted entity, no killer either)

Makes it possible to have loot tables that do different things based on the world (raining/nether/etc.)

Closes #2916