### PR TITLE
Remove sideonly on SoundType.getBreakSound() and getHitSound()

### DIFF
--- a/patches/minecraft/net/minecraft/block/SoundType.java.patch
+++ b/patches/minecraft/net/minecraft/block/SoundType.java.patch
@@ -1,0 +1,18 @@
+--- ../src-base/minecraft/net/minecraft/block/SoundType.java
++++ ../src-work/minecraft/net/minecraft/block/SoundType.java
+@@ -48,7 +48,6 @@
+         return this.field_185861_n;
+     }
+ 
+-    @SideOnly(Side.CLIENT)
+     public SoundEvent func_185845_c()
+     {
+         return this.field_185862_o;
+@@ -64,7 +63,6 @@
+         return this.field_185864_q;
+     }
+ 
+-    @SideOnly(Side.CLIENT)
+     public SoundEvent func_185846_f()
+     {
+         return this.field_185865_r;


### PR DESCRIPTION
All the other ones are common, just these two aren't.

Closes #2869