### PR TITLE
Fix various issues with the Forge config GUI.

### DIFF
--- a/src/main/resources/assets/forge/lang/en_US.lang
+++ b/src/main/resources/assets/forge/lang/en_US.lang
@@ -44,8 +44,8 @@ forge.configgui.zombieBabyChance=Zombie Baby Chance
 forge.configgui.zombieBaseSummonChance.tooltip=Base zombie summoning spawn chance. Allows changing the bonus zombie summoning mechanic.
 forge.configgui.zombieBaseSummonChance=Zombie Summon Chance
 forge.configgui.stencilbits=Enable GL Stencil Bits
-forge.configgui.spawnfuzz=Respawn Fuzz Diameter
-forge.configgui.replaceBuckets=Use Forges' bucket model
+forge.configgui.forgeLightPipeline=Use Forge's block lighting pipeline
+forge.configgui.replaceBuckets=Use Forge's bucket model
 
 forge.configgui.modID.tooltip=The mod ID that you want to define override settings for.
 forge.configgui.modID=Mod ID


### PR DESCRIPTION
* Fixed settings not saving and taking effect when in-game, or when changing Client section settings. (Since the settings that should not be set when a world is loaded are disabled in the config GUI, there's no issue with allowing the config to change settings in-game.)
* Moved "forgeLightPipelineEnabled" from the General to the Client section because it has no effect on a server, and added localization string.
* "disableStitchedFileSaving", "spawnHasFuzz" and "defaultSpawnFuzz" were removed as they are unused now and have no effect.