### PR TITLE
Add support for (Java 7/Java 8) annotation

### DIFF
--- a/src/main/java/net/minecraftforge/fml/common/discovery/asm/ASMModParser.java
+++ b/src/main/java/net/minecraftforge/fml/common/discovery/asm/ASMModParser.java
@@ -29,6 +29,7 @@ import com.google.common.base.Objects;
 import com.google.common.base.Strings;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
+import org.objectweb.asm.TypeReference;
 
 public class ASMModParser
 {
@@ -90,27 +91,21 @@ public class ASMModParser
         annotations.addFirst(ann);
     }
 
-    public enum EnumMethodAdditionalInfo
-    {
-        RETURN_VALUE_TYPE,
-        PARAMETER_TYPE
-    }
-
     public void startFieldTypeAnnotation(String fieldName, String typePath, String signature, String annotationName)
     {
-        ModAnnotation ann = new ModAnnotation(AnnotationType.TYPE, Type.getType(annotationName), typePath + "(" + signature + ")", fieldName);
+        ModAnnotation ann = new ModAnnotation(AnnotationType.TYPE, Type.getType(annotationName), fieldName + "$" + typePath + "(" + signature + ")");
         annotations.addFirst(ann);
     }
 
-    public void startMethodTypeAnnotation(String methodName, String typePath, String signature, String annotationName, EnumMethodAdditionalInfo additionalInfo)
+    public void startMethodTypeAnnotation(String methodName, String typePath, String signature, String annotationName, String additionalInfo)
     {
-        ModAnnotation ann = new ModAnnotation(AnnotationType.TYPE, Type.getType(annotationName), typePath + "(" + signature + ")" + "[" + additionalInfo.toString() + "]", methodName);
+        ModAnnotation ann = new ModAnnotation(AnnotationType.TYPE, Type.getType(annotationName), methodName + "$" + typePath + "(" + signature + ")" + "[" + additionalInfo.toString() + "]");
         annotations.addFirst(ann);
     }
 
     public void startLocalVariableTypeAnnotation(String methodName, String methodDescriptor, String typePath, String annotationName, String localVariableName, String localVariableDescriptor)
     {
-        ModAnnotation ann = new ModAnnotation(AnnotationType.LOCAL_VARIABLE, Type.getType(annotationName), typePath + "(" + localVariableDescriptor + ")", methodName + methodDescriptor + "$" + localVariableName);
+        ModAnnotation ann = new ModAnnotation(AnnotationType.LOCAL_VARIABLE, Type.getType(annotationName), methodName + methodDescriptor + "$" + localVariableName + "$" + typePath + "(" + localVariableDescriptor + ")");
         annotations.addFirst(ann);
     }
 
@@ -175,14 +170,7 @@ public class ASMModParser
     {
         for (ModAnnotation ma : annotations)
         {
-            if (ma.getExtraName() != null)
-            {
-                table.addASMData(candidate, ma.asmType.getClassName(), this.asmType.getClassName() + "$" + ma.getExtraName(), ma.member, ma.values);
-            }
-            else
-            {
-                table.addASMData(candidate, ma.asmType.getClassName(), this.asmType.getClassName(), ma.member, ma.values);
-            }
+            table.addASMData(candidate, ma.asmType.getClassName(), this.asmType.getClassName(), ma.member, ma.values);
         }
 
         for (String intf : interfaces)
@@ -229,13 +217,13 @@ public class ASMModParser
 
     public void startMethodParameterAnnotation(int parameter, String methodName, String methodDescriptor, String parameterDescriptor, String annotationName)
     {
-        ModAnnotation ann = new ModAnnotation(AnnotationType.PARAMETER, Type.getType(annotationName), parameter + "(" + parameterDescriptor + ")", methodName + methodDescriptor);
+        ModAnnotation ann = new ModAnnotation(AnnotationType.PARAMETER, Type.getType(annotationName), methodName + methodDescriptor + "$" + parameter + "(" + parameterDescriptor + ")");
         annotations.addFirst(ann);
     }
 
     public void startLocalVariableAnnotation(String methodName, String methodDescriptor, String annotationName, String localVariableName)
     {
-        ModAnnotation ann = new ModAnnotation(AnnotationType.LOCAL_VARIABLE, Type.getType(annotationName), localVariableName, methodName + methodDescriptor);
+        ModAnnotation ann = new ModAnnotation(AnnotationType.LOCAL_VARIABLE, Type.getType(annotationName), methodName + methodDescriptor + "$" + localVariableName);
         annotations.addFirst(ann);
     }
 
@@ -408,15 +396,15 @@ public class ASMModParser
         return fieldSignatureMap;
     }
 
-    public Map<EnumMethodAdditionalInfo, Map<String, String>> parseMethodSignature(String signature)
+    public Map<Integer, Map<String, String>> parseMethodSignature(String signature)
     {
         if (signature == null)
         {
             return Maps.newHashMap();
         }
-        Map<EnumMethodAdditionalInfo, Map<String, String>> methodSignatureMap = Maps.newHashMap();
-        methodSignatureMap.put(EnumMethodAdditionalInfo.RETURN_VALUE_TYPE, parseVariableOrMethodSignature(signature.substring(signature.indexOf(")") + 1)));
-        methodSignatureMap.put(EnumMethodAdditionalInfo.PARAMETER_TYPE, parseVariableOrMethodSignature(signature.substring(0, signature.indexOf(")"))));
+        Map<Integer, Map<String, String>> methodSignatureMap = Maps.newHashMap();
+        methodSignatureMap.put(TypeReference.METHOD_RETURN, parseVariableOrMethodSignature(signature.substring(signature.indexOf(")") + 1)));
+        methodSignatureMap.put(TypeReference.METHOD_FORMAL_PARAMETER, parseVariableOrMethodSignature(signature.substring(0, signature.indexOf(")"))));
         return methodSignatureMap;
     }
 

--- a/src/main/java/net/minecraftforge/fml/common/discovery/asm/ModAnnotation.java
+++ b/src/main/java/net/minecraftforge/fml/common/discovery/asm/ModAnnotation.java
@@ -43,7 +43,6 @@ public class ModAnnotation
     Map<String,Object> values = Maps.newHashMap();
     private ArrayList<Object> arrayList;
     private String arrayName;
-    private String extraName;
     public ModAnnotation(AnnotationType type, Type asmType, String member)
     {
         this.type = type;
@@ -55,12 +54,6 @@ public class ModAnnotation
     {
         this.type = type;
         this.asmType = asmType;
-    }
-
-    public ModAnnotation(AnnotationType type, Type asmType, String member, String extraName)
-    {
-        this(type, asmType, member);
-        this.extraName = extraName;
     }
 
     @Override
@@ -104,11 +97,6 @@ public class ModAnnotation
         {
             values.put(key, value);
         }
-    }
-
-    public String getExtraName()
-    {
-        return extraName;
     }
 
     public void addEnumProperty(String key, String enumName, String value)

--- a/src/main/java/net/minecraftforge/fml/common/discovery/asm/ModAnnotation.java
+++ b/src/main/java/net/minecraftforge/fml/common/discovery/asm/ModAnnotation.java
@@ -43,6 +43,7 @@ public class ModAnnotation
     Map<String,Object> values = Maps.newHashMap();
     private ArrayList<Object> arrayList;
     private String arrayName;
+    private String extraName;
     public ModAnnotation(AnnotationType type, Type asmType, String member)
     {
         this.type = type;
@@ -55,6 +56,13 @@ public class ModAnnotation
         this.type = type;
         this.asmType = asmType;
     }
+
+    public ModAnnotation(AnnotationType type, Type asmType, String member, String extraName)
+    {
+        this(type, asmType, member);
+        this.extraName = extraName;
+    }
+
     @Override
     public String toString()
     {
@@ -98,6 +106,11 @@ public class ModAnnotation
         }
     }
 
+    public String getExtraName()
+    {
+        return extraName;
+    }
+
     public void addEnumProperty(String key, String enumName, String value)
     {
         values.put(key, new EnumHolder(enumName, value));
@@ -108,6 +121,7 @@ public class ModAnnotation
         values.put(arrayName, arrayList);
         arrayList = null;
     }
+
     public ModAnnotation addChildAnnotation(String name, String desc)
     {
         ModAnnotation child = new ModAnnotation(AnnotationType.SUBTYPE, Type.getType(desc), this);

--- a/src/main/java/net/minecraftforge/fml/common/discovery/asm/ModAnnotationVisitor.java
+++ b/src/main/java/net/minecraftforge/fml/common/discovery/asm/ModAnnotationVisitor.java
@@ -59,12 +59,14 @@ public class ModAnnotationVisitor extends AnnotationVisitor
     {
         return new ModAnnotationVisitor(discoverer, name);
     }
+
     @Override
     public AnnotationVisitor visitAnnotation(String name, String desc)
     {
         discoverer.addSubAnnotation(name, desc);
         return new ModAnnotationVisitor(discoverer, true);
     }
+
     @Override
     public void visitEnd()
     {

--- a/src/main/java/net/minecraftforge/fml/common/discovery/asm/ModAnnotationVisitor.java
+++ b/src/main/java/net/minecraftforge/fml/common/discovery/asm/ModAnnotationVisitor.java
@@ -19,7 +19,6 @@ public class ModAnnotationVisitor extends AnnotationVisitor
 {
     private ASMModParser discoverer;
     private boolean array;
-    private String name;
     private boolean isSubAnnotation;
 
     public ModAnnotationVisitor(ASMModParser discoverer)
@@ -32,7 +31,6 @@ public class ModAnnotationVisitor extends AnnotationVisitor
     {
         this(discoverer);
         this.array = true;
-        this.name = name;
         discoverer.addAnnotationArray(name);
     }
 

--- a/src/main/java/net/minecraftforge/fml/common/discovery/asm/ModClassVisitor.java
+++ b/src/main/java/net/minecraftforge/fml/common/discovery/asm/ModClassVisitor.java
@@ -12,15 +12,14 @@
 
 package net.minecraftforge.fml.common.discovery.asm;
 
-import org.objectweb.asm.AnnotationVisitor;
-import org.objectweb.asm.ClassVisitor;
-import org.objectweb.asm.FieldVisitor;
-import org.objectweb.asm.MethodVisitor;
-import org.objectweb.asm.Opcodes;
+import org.objectweb.asm.*;
+
+import java.util.Map;
 
 public class ModClassVisitor extends ClassVisitor
 {
     private ASMModParser discoverer;
+    private Map<Integer, String> classSignatureMap;
 
     public ModClassVisitor(ASMModParser discoverer)
     {
@@ -28,11 +27,11 @@ public class ModClassVisitor extends ClassVisitor
         this.discoverer = discoverer;
     }
 
-
     @Override
     public void visit(int version, int access, String name, String signature, String superName, String[] interfaces)
     {
         discoverer.beginNewTypeName(name, version, superName, interfaces);
+        classSignatureMap = discoverer.parseClassSignature(signature);
     }
 
     @Override
@@ -42,16 +41,29 @@ public class ModClassVisitor extends ClassVisitor
         return new ModAnnotationVisitor(discoverer);
     }
 
+    @Override
+    public AnnotationVisitor visitTypeAnnotation(int typeRef, TypePath typePath, String annotationName, boolean runtimeVisible)
+    {
+        if (typePath != null)
+        {
+            discoverer.startClassTypeAnnotation(annotationName, classSignatureMap.get(typeRef / 65536));
+            return new ModAnnotationVisitor(discoverer);
+        }
+        else
+        {
+            return null;
+        }
+    }
 
     @Override
     public FieldVisitor visitField(int access, String name, String desc, String signature, Object value)
     {
-        return new ModFieldVisitor(name, discoverer);
+        return new ModFieldVisitor(name, discoverer, signature);
     }
 
     @Override
     public MethodVisitor visitMethod(int access, String name, String desc, String signature, String[] exceptions)
     {
-        return new ModMethodVisitor(name, desc, discoverer);
+        return new ModMethodVisitor(name, desc, signature, discoverer);
     }
 }

--- a/src/main/java/net/minecraftforge/fml/common/discovery/asm/ModFieldVisitor.java
+++ b/src/main/java/net/minecraftforge/fml/common/discovery/asm/ModFieldVisitor.java
@@ -12,21 +12,22 @@
 
 package net.minecraftforge.fml.common.discovery.asm;
 
-import org.objectweb.asm.AnnotationVisitor;
-import org.objectweb.asm.FieldVisitor;
-import org.objectweb.asm.Opcodes;
+import org.objectweb.asm.*;
+
+import java.util.Map;
 
 public class ModFieldVisitor extends FieldVisitor
 {
-
     private String fieldName;
     private ASMModParser discoverer;
+    private Map<String, String> fieldSignatureMap;
 
-    public ModFieldVisitor(String name, ASMModParser discoverer)
+    public ModFieldVisitor(String name, ASMModParser discoverer, String signature)
     {
         super(Opcodes.ASM5);
         this.fieldName = name;
         this.discoverer = discoverer;
+        this.fieldSignatureMap = discoverer.parseVariableOrMethodSignature(signature);
     }
     
     @Override
@@ -34,5 +35,19 @@ public class ModFieldVisitor extends FieldVisitor
     {
         discoverer.startFieldAnnotation(fieldName, annotationName);
         return new ModAnnotationVisitor(discoverer);
+    }
+
+    @Override
+    public AnnotationVisitor visitTypeAnnotation(int typeRef, TypePath typePath, String annotationName, boolean runtimeVisible)
+    {
+        if (typePath != null)
+        {
+            discoverer.startFieldTypeAnnotation(fieldName, typePath.toString(), fieldSignatureMap.get(typePath.toString()), annotationName);
+            return new ModAnnotationVisitor(discoverer);
+        }
+        else
+        {
+            return null;
+        }
     }
 }

--- a/src/main/java/net/minecraftforge/fml/common/discovery/asm/ModMethodVisitor.java
+++ b/src/main/java/net/minecraftforge/fml/common/discovery/asm/ModMethodVisitor.java
@@ -12,7 +12,7 @@ public class ModMethodVisitor extends MethodVisitor {
     private String methodDescriptor;
     private ASMModParser discoverer;
     private Map<Integer, String> methodDescriptorMap;
-    private Map<ASMModParser.EnumMethodAdditionalInfo, Map<String, String>> methodSignatureMap;
+    private Map<Integer, Map<String, String>> methodSignatureMap;
     private Map<Integer, Pair<String, String>> localVariableMap = Maps.newHashMap();
     private Map<Integer, Map<String, String>> localVariableSignatureMap = Maps.newHashMap();
 
@@ -38,14 +38,14 @@ public class ModMethodVisitor extends MethodVisitor {
     {
         if (typePath != null)
         {
-            if (typeRef == 335544320)
+            if (typeRef == TypeReference.newTypeReference(TypeReference.METHOD_RETURN).getValue())
             {
-                discoverer.startMethodTypeAnnotation(methodName, typePath.toString(), methodSignatureMap.get(ASMModParser.EnumMethodAdditionalInfo.RETURN_VALUE_TYPE).get(typePath.toString()), annotationName, ASMModParser.EnumMethodAdditionalInfo.RETURN_VALUE_TYPE);
+                discoverer.startMethodTypeAnnotation(methodName, typePath.toString(), methodSignatureMap.get(TypeReference.METHOD_RETURN).get(typePath.toString()), annotationName, "METHOD_RETURN");
                 return new ModAnnotationVisitor(discoverer);
             }
-            else if (typeRef == 369098752)
+            else if (typeRef == TypeReference.newTypeReference(TypeReference.METHOD_FORMAL_PARAMETER).getValue())
             {
-                discoverer.startMethodTypeAnnotation(methodName, typePath.toString(), methodSignatureMap.get(ASMModParser.EnumMethodAdditionalInfo.PARAMETER_TYPE).get(typePath.toString()), annotationName, ASMModParser.EnumMethodAdditionalInfo.PARAMETER_TYPE);
+                discoverer.startMethodTypeAnnotation(methodName, typePath.toString(), methodSignatureMap.get(TypeReference.METHOD_FORMAL_PARAMETER).get(typePath.toString()), annotationName, "METHOD_FORMAL_PARAMETER");
                 return new ModAnnotationVisitor(discoverer);
             }
             return null;

--- a/src/main/java/net/minecraftforge/fml/common/discovery/asm/ModMethodVisitor.java
+++ b/src/main/java/net/minecraftforge/fml/common/discovery/asm/ModMethodVisitor.java
@@ -1,21 +1,29 @@
 package net.minecraftforge.fml.common.discovery.asm;
 
-import org.objectweb.asm.AnnotationVisitor;
-import org.objectweb.asm.MethodVisitor;
-import org.objectweb.asm.Opcodes;
+import com.google.common.collect.Maps;
+import org.apache.commons.lang3.tuple.Pair;
+import org.objectweb.asm.*;
+
+import java.util.Map;
 
 public class ModMethodVisitor extends MethodVisitor {
 
     private String methodName;
     private String methodDescriptor;
     private ASMModParser discoverer;
+    private Map<Integer, String> methodDescriptorMap;
+    private Map<ASMModParser.EnumMethodAdditionalInfo, Map<String, String>> methodSignatureMap;
+    private Map<Integer, Pair<String, String>> localVariableMap = Maps.newHashMap();
+    private Map<Integer, Map<String, String>> localVariableSignatureMap = Maps.newHashMap();
 
-    public ModMethodVisitor(String name, String desc, ASMModParser discoverer)
+    public ModMethodVisitor(String name, String desc, String signature, ASMModParser discoverer)
     {
         super(Opcodes.ASM5);
         this.methodName = name;
         this.methodDescriptor = desc;
         this.discoverer = discoverer;
+        this.methodDescriptorMap = discoverer.parseMethodDescriptor(desc);
+        this.methodSignatureMap = discoverer.parseMethodSignature(signature);
     }
 
     @Override
@@ -25,4 +33,69 @@ public class ModMethodVisitor extends MethodVisitor {
         return new ModAnnotationVisitor(discoverer);
     }
 
+    @Override
+    public AnnotationVisitor visitTypeAnnotation(int typeRef, TypePath typePath, String annotationName, boolean runtimeVisible)
+    {
+        if (typePath != null)
+        {
+            if (typeRef == 335544320)
+            {
+                discoverer.startMethodTypeAnnotation(methodName, typePath.toString(), methodSignatureMap.get(ASMModParser.EnumMethodAdditionalInfo.RETURN_VALUE_TYPE).get(typePath.toString()), annotationName, ASMModParser.EnumMethodAdditionalInfo.RETURN_VALUE_TYPE);
+                return new ModAnnotationVisitor(discoverer);
+            }
+            else if (typeRef == 369098752)
+            {
+                discoverer.startMethodTypeAnnotation(methodName, typePath.toString(), methodSignatureMap.get(ASMModParser.EnumMethodAdditionalInfo.PARAMETER_TYPE).get(typePath.toString()), annotationName, ASMModParser.EnumMethodAdditionalInfo.PARAMETER_TYPE);
+                return new ModAnnotationVisitor(discoverer);
+            }
+            return null;
+        }
+        else
+        {
+            return null;
+        }
+    }
+
+    @Override
+    public AnnotationVisitor visitParameterAnnotation(int parameter, String annotationName, boolean runtimeVisible)
+    {
+        discoverer.startMethodParameterAnnotation(parameter, methodName, methodDescriptor, methodDescriptorMap.get(parameter), annotationName);
+        return new ModAnnotationVisitor(discoverer);
+    }
+
+    @Override
+    public void visitLocalVariable(String name, String desc, String signature, Label start, Label end, int index)
+    {
+        localVariableMap.put(index, Pair.of(name, signature));
+    }
+
+    @Override
+    public AnnotationVisitor visitLocalVariableAnnotation(int typeRef, TypePath typePath, Label[] start, Label[] end, int[] index, String annotationName, boolean runtimeVisible)
+    {
+        if (localVariableSignatureMap.isEmpty())
+        {
+            for (int i = 0; i < localVariableMap.size(); i++)
+            {
+                localVariableSignatureMap.put(i, discoverer.parseVariableOrMethodSignature(localVariableMap.get(i).getRight()));
+            }
+        }
+
+        if (localVariableMap.containsKey(index[0]))
+        {
+            Pair<String, String> localVariableInformation = localVariableMap.get(index[0]);
+            if (typePath == null)
+            {
+                discoverer.startLocalVariableAnnotation(methodName, methodDescriptor, annotationName, localVariableInformation.getLeft());
+            }
+            else
+            {
+                discoverer.startLocalVariableTypeAnnotation(methodName, methodDescriptor, typePath.toString(), annotationName, localVariableInformation.getLeft(), localVariableSignatureMap.get(index[0]).get(typePath.toString()));
+            }
+            return new ModAnnotationVisitor(discoverer);
+        }
+        else
+        {
+            return null;
+        }
+    }
 }

--- a/src/test/java/net/minecraftforge/test/GlobalAnnotationDataTest.java
+++ b/src/test/java/net/minecraftforge/test/GlobalAnnotationDataTest.java
@@ -1,0 +1,91 @@
+package net.minecraftforge.test;
+
+import com.google.common.collect.Maps;
+import net.minecraftforge.fml.common.Mod;
+import net.minecraftforge.fml.common.discovery.ASMDataTable;
+import net.minecraftforge.fml.common.event.FMLPreInitializationEvent;
+
+import java.lang.annotation.*;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * --------------------<br>
+ * A mod for debugging global annotation.<br>
+ * Adding Feature :<br>
+ * ---Type Annotation---<br>
+ * Class Type Annotation : Success<br>
+ * Field Type Annotation : Success<br>
+ * Method Type Annotation : Success<br>
+ * Method Parameter Type Annotation : Success<br>
+ * ---Method Parameter Annotation---<br>
+ * Method Parameter Annotation : Success<br>
+ * --- Local Variable ---<br>
+ * Local Variable : Success<br>
+ * --------------------
+ */
+@Mod(modid = "GlobalAnnotationDataTest", name = "Global Annotation Data Test", version = "1.0")
+@SuppressWarnings("unused")
+// @GlobalAnnotationDataTest.AnnotationTest.TestAnnotation
+public class GlobalAnnotationDataTest
+{
+    /*
+    private static final boolean ENABLE = false;
+
+    @Mod.EventHandler
+    public void preInit(FMLPreInitializationEvent event)
+    {
+        if (ENABLE)
+        {
+            Set<ASMDataTable.ASMData> asmDataSet = event.getAsmData().getAll(AnnotationTest.TestAnnotation.class.getName());
+            String message = "\n--------------------" + AnnotationTest.TestAnnotation.class.getName() + " Debug Message--------------------\n";
+            for (ASMDataTable.ASMData asmData : asmDataSet)
+            {
+                message += "Class Name : " + asmData.getClassName() + "---Object Name : " + asmData.getObjectName() + "\n";
+            }
+            System.out.println(message);
+        }
+    }
+
+    public static class AnnotationTest<A, B, C, D, E, F, G, H, I, J, K, L>
+    {
+        public static final class TypeAnnotationTest<@TestAnnotation TEST_TYPE extends Map<AnnotationTest, AnnotationTest>, TEST2 extends Annotation, @AnnotationTest.TestAnnotation TEST3 extends Annotation>
+        {
+            @TestAnnotation
+            public static final Class<@TestAnnotation ? extends AnnotationTest<? extends Annotation, NullPointerException, NullPointerException, NullPointerException, NullPointerException, NullPointerException, NullPointerException, NullPointerException, NullPointerException, NullPointerException, NullPointerException, @TestAnnotation NullPointerException>> fieldTypeTest = null;
+
+            public static Class<
+                    @TestAnnotation ? extends Map<
+                            @TestAnnotation ? extends Annotation,
+                            @TestAnnotation ? extends Annotation>>
+            typeAnnotationTest
+                    (@TestAnnotation Class<
+                    @TestAnnotation ? extends Class<
+                            @TestAnnotation ? extends Annotation>> typeTestParameter)
+            {
+                return null;
+            }
+        }
+
+        public static final class MethodAnnotationTest extends AnnotationTest
+        {
+            public static Class<@TestAnnotation ? extends Annotation> methodAnnotationTest(@TestAnnotation Object object, @TestAnnotation Object object2)
+            {
+                @TestAnnotation
+                String a = null;
+                @TestAnnotation
+                Class<@TestAnnotation ? extends Class<@TestAnnotation ?>> abc = null;
+                Map<String, String> map = Maps.newHashMap();
+                return null;
+            }
+        }
+
+        @Retention(RetentionPolicy.RUNTIME)
+        @Target({ElementType.TYPE, ElementType.FIELD, ElementType.PARAMETER, ElementType.TYPE_PARAMETER, ElementType.TYPE_USE, ElementType.LOCAL_VARIABLE})
+        public @interface TestAnnotation
+        {
+
+        }
+    }
+    */
+}

--- a/src/test/java/net/minecraftforge/test/GlobalAnnotationDataTest.java
+++ b/src/test/java/net/minecraftforge/test/GlobalAnnotationDataTest.java
@@ -11,7 +11,7 @@ import java.util.Set;
 
 /**
  * --------------------<br>
- * A mod for debugging global annotation.<br>
+ * A mod for testing global annotation.<br>
  * Adding Feature :<br>
  * ---Type Annotation---<br>
  * Class Type Annotation : Success<br>
@@ -71,7 +71,7 @@ public class GlobalAnnotationDataTest
         {
             public static Class<@TestAnnotation ? extends Annotation> methodAnnotationTest(@TestAnnotation Object object, @TestAnnotation Object object2)
             {
-                @TestAnnotation
+                @TestAnnotation2("Null")
                 String a = null;
                 @TestAnnotation
                 Class<@TestAnnotation ? extends Class<@TestAnnotation ?>> abc = null;
@@ -84,7 +84,16 @@ public class GlobalAnnotationDataTest
         @Target({ElementType.TYPE, ElementType.FIELD, ElementType.PARAMETER, ElementType.TYPE_PARAMETER, ElementType.TYPE_USE, ElementType.LOCAL_VARIABLE})
         public @interface TestAnnotation
         {
+            @TestAnnotation
+            String value() default "Null";
+        }
 
+        @Retention(RetentionPolicy.RUNTIME)
+        @Target({ElementType.TYPE, ElementType.FIELD, ElementType.PARAMETER, ElementType.TYPE_PARAMETER, ElementType.TYPE_USE, ElementType.LOCAL_VARIABLE})
+        public @interface TestAnnotation2
+        {
+            @TestAnnotation
+            String value();
         }
     }
     */


### PR DESCRIPTION
This add support for Java 7 or Java 8 annotation to make AsmDataTable more useful.
Useful for modders using Java 7 or Java 8 to get information about annotations.

The gist file for GlobalAnnotationDataTest(With Markdown):
https://gist.github.com/ChunHin/984b987e936d64f9e18c6a9ee4cebdf5