### PR TITLE
Fix #2961 Capability data is not preserved by fluid handler interactions

### DIFF
--- a/src/main/java/net/minecraftforge/fluids/FluidUtil.java
+++ b/src/main/java/net/minecraftforge/fluids/FluidUtil.java
@@ -170,9 +170,7 @@ public class FluidUtil
             ItemStack filledReal = tryFillContainer(container, fluidSource, maxAmount, player, true);
             if (filledReal != null)
             {
-                container.setItem(filledReal.getItem());
-                container.setTagCompound(filledReal.getTagCompound());
-                container.setItemDamage(filledReal.getItemDamage());
+                container.deserializeNBT(filledReal.serializeNBT());
                 return true;
             }
         }
@@ -243,9 +241,7 @@ public class FluidUtil
                 }
                 else
                 {
-                    container.setItem(emptiedReal.getItem());
-                    container.setTagCompound(emptiedReal.getTagCompound());
-                    container.setItemDamage(emptiedReal.getItemDamage());
+                    container.deserializeNBT(emptiedReal.serializeNBT());
                 }
                 return true;
             }

--- a/src/main/java/net/minecraftforge/fluids/UniversalBucket.java
+++ b/src/main/java/net/minecraftforge/fluids/UniversalBucket.java
@@ -280,8 +280,7 @@ public class UniversalBucket extends Item implements IFluidContainerItem
         {
             if (doFill)
             {
-                container.setItem(Items.WATER_BUCKET);
-                container.setTagCompound(null);
+                container.deserializeNBT(new ItemStack(Items.WATER_BUCKET).serializeNBT());
             }
             return getCapacity();
         }
@@ -289,8 +288,7 @@ public class UniversalBucket extends Item implements IFluidContainerItem
         {
             if (doFill)
             {
-                container.setItem(Items.LAVA_BUCKET);
-                container.setTagCompound(null);
+                container.deserializeNBT(new ItemStack(Items.LAVA_BUCKET).serializeNBT());
             }
             return getCapacity();
         }
@@ -318,9 +316,7 @@ public class UniversalBucket extends Item implements IFluidContainerItem
         {
             if(getEmpty() != null)
             {
-                container.setItem(getEmpty().getItem());
-                container.setTagCompound(getEmpty().getTagCompound());
-                container.setItemDamage(getEmpty().getItemDamage());
+                container.deserializeNBT(getEmpty().serializeNBT());
             }
             else {
                 container.stackSize = 0;

--- a/src/main/java/net/minecraftforge/fluids/capability/templates/FluidHandlerItemStack.java
+++ b/src/main/java/net/minecraftforge/fluids/capability/templates/FluidHandlerItemStack.java
@@ -221,9 +221,7 @@ public class FluidHandlerItemStack implements IFluidHandler, ICapabilityProvider
         protected void setContainerToEmpty()
         {
             super.setContainerToEmpty();
-            container.setItem(emptyContainer.getItem());
-            container.setTagCompound(emptyContainer.getTagCompound());
-            container.setItemDamage(emptyContainer.getItemDamage());
+            container.deserializeNBT(emptyContainer.serializeNBT());
         }
     }
 }

--- a/src/main/java/net/minecraftforge/fluids/capability/templates/FluidHandlerItemStackSimple.java
+++ b/src/main/java/net/minecraftforge/fluids/capability/templates/FluidHandlerItemStackSimple.java
@@ -198,9 +198,7 @@ public class FluidHandlerItemStackSimple implements IFluidHandler, ICapabilityPr
         protected void setContainerToEmpty()
         {
             super.setContainerToEmpty();
-            container.setItem(emptyContainer.getItem());
-            container.setTagCompound(emptyContainer.getTagCompound());
-            container.setItemDamage(emptyContainer.getItemDamage());
+            container.deserializeNBT(emptyContainer.serializeNBT());
         }
     }
 }

--- a/src/main/java/net/minecraftforge/fluids/capability/wrappers/FluidBucketWrapper.java
+++ b/src/main/java/net/minecraftforge/fluids/capability/wrappers/FluidBucketWrapper.java
@@ -69,34 +69,24 @@ public class FluidBucketWrapper implements IFluidHandler, ICapabilityProvider
     protected void setFluid(Fluid fluid) {
         if (fluid == null)
         {
-            container.setItem(Items.BUCKET);
-            container.setTagCompound(null);
-            container.setItemDamage(0);
+            container.deserializeNBT(new ItemStack(Items.BUCKET).serializeNBT());
         }
         else if (fluid == FluidRegistry.WATER)
         {
-            container.setItem(Items.WATER_BUCKET);
-            container.setTagCompound(null);
-            container.setItemDamage(0);
+            container.deserializeNBT(new ItemStack(Items.WATER_BUCKET).serializeNBT());
         }
         else if (fluid == FluidRegistry.LAVA)
         {
-            container.setItem(Items.LAVA_BUCKET);
-            container.setTagCompound(null);
-            container.setItemDamage(0);
+            container.deserializeNBT(new ItemStack(Items.LAVA_BUCKET).serializeNBT());
         }
         else if (fluid.getName().equals("milk"))
         {
-            container.setItem(Items.MILK_BUCKET);
-            container.setTagCompound(null);
-            container.setItemDamage(0);
+            container.deserializeNBT(new ItemStack(Items.MILK_BUCKET).serializeNBT());
         }
         else if (FluidRegistry.isUniversalBucketEnabled() && FluidRegistry.getBucketFluids().contains(fluid))
         {
             ItemStack filledBucket = UniversalBucket.getFilledBucket(ForgeModContainer.getInstance().universalBucket, fluid);
-            container.setItem(filledBucket.getItem());
-            container.setTagCompound(filledBucket.getTagCompound());
-            container.setItemDamage(filledBucket.getItemDamage());
+            container.deserializeNBT(filledBucket.serializeNBT());
         }
     }
 

--- a/src/main/java/net/minecraftforge/fluids/capability/wrappers/FluidContainerRegistryWrapper.java
+++ b/src/main/java/net/minecraftforge/fluids/capability/wrappers/FluidContainerRegistryWrapper.java
@@ -28,14 +28,6 @@ public class FluidContainerRegistryWrapper implements IFluidHandler, ICapability
         this.container = container;
     }
 
-    private void updateContainer(ItemStack newContainerData)
-    {
-        container.setItem(newContainerData.getItem());
-        container.setTagCompound(newContainerData.getTagCompound());
-        container.setItemDamage(newContainerData.getItemDamage());
-        container.stackSize = newContainerData.stackSize;
-    }
-
     @Override
     public IFluidTankProperties[] getTankProperties()
     {
@@ -62,7 +54,7 @@ public class FluidContainerRegistryWrapper implements IFluidHandler, ICapability
 
         if (doFill)
         {
-            updateContainer(result);
+            container.deserializeNBT(result.serializeNBT());
         }
 
         FluidStack newContained = FluidContainerRegistry.getFluidForFilledItem(result);
@@ -113,7 +105,7 @@ public class FluidContainerRegistryWrapper implements IFluidHandler, ICapability
                         {
                             emptyContainer.stackSize = 0;
                         }
-                        updateContainer(emptyContainer);
+                        container.deserializeNBT(emptyContainer.serializeNBT());
                     }
                     return contained;
                 }


### PR DESCRIPTION
Turns out I wasn't preserving capability data when swapping the item before, the compatibility wrappers just write straight to nbt so it worked for those.

~~This adds a method to ItemStack to make it possible to correctly swap ItemStacks that have capabilities. I don't really like ItemStack swapping so I put a disclaimer comment on it.~~
This uses the existing itemStack serialize/deserialize to swap the stack.