### PR TITLE
Don't allow CapabilityDispatcher to get a null Capability

### DIFF
--- a/src/main/java/net/minecraftforge/common/capabilities/CapabilityDispatcher.java
+++ b/src/main/java/net/minecraftforge/common/capabilities/CapabilityDispatcher.java
@@ -69,11 +69,14 @@ public final class CapabilityDispatcher implements INBTSerializable<NBTTagCompou
     @Override
     public boolean hasCapability(Capability<?> capability, @Nullable EnumFacing facing)
     {
-        for (ICapabilityProvider cap : caps)
+        if (capability != null)
         {
-            if (cap.hasCapability(capability, facing))
+            for (ICapabilityProvider cap : caps)
             {
-                return true;
+                if (cap.hasCapability(capability, facing))
+                {
+                    return true;
+                }
             }
         }
         return false;
@@ -82,12 +85,15 @@ public final class CapabilityDispatcher implements INBTSerializable<NBTTagCompou
     @Override
     public <T> T getCapability(Capability<T> capability, @Nullable EnumFacing facing)
     {
-        for (ICapabilityProvider cap : caps)
+        if (capability != null)
         {
-            T ret = cap.getCapability(capability, facing);
-            if (ret != null)
+            for (ICapabilityProvider cap : caps)
             {
-                return ret;
+                T ret = cap.getCapability(capability, facing);
+                if (ret != null)
+                {
+                    return ret;
+                }
             }
         }
         return null;


### PR DESCRIPTION
Prevents people from making the mistake of using a @CapabilityInject field of a capability that has not been registered (not realizing that the @CapabilityInject will do nothing without the capability being registered)

---

Learning from my own dumb mistakes, and thought it might be nice to prevent others from making the same mistakes. See https://github.com/squeek502/SpiceOfLife/issues/91

> Neither of us are registering our capabilities with `CapabilityManager.INSTANCE`, which means that our `@CapabilityInject` annotated fields never get populated, which means that we're sending `null` to `getCapability`, which then 'succeeds' the conditional and we return our capabilities to eachother incorrectly.

Let me know if you'd prefer a different fix.