### PR TITLE
Improve the "missing mods" error screen

### DIFF
--- a/src/main/java/net/minecraftforge/fml/client/GuiModsMissing.java
+++ b/src/main/java/net/minecraftforge/fml/client/GuiModsMissing.java
@@ -12,14 +12,25 @@
 
 package net.minecraftforge.fml.client;
 
+import java.awt.*;
+import java.io.File;
+import java.io.IOException;
+
+import net.minecraft.client.gui.GuiButton;
 import net.minecraft.client.gui.GuiErrorScreen;
+import net.minecraft.client.resources.I18n;
+import net.minecraft.util.text.TextFormatting;
+import net.minecraftforge.fml.common.FMLLog;
+import net.minecraftforge.fml.common.Loader;
 import net.minecraftforge.fml.common.MissingModsException;
 import net.minecraftforge.fml.common.versioning.ArtifactVersion;
 import net.minecraftforge.fml.common.versioning.DefaultArtifactVersion;
+import org.apache.logging.log4j.Level;
 
 public class GuiModsMissing extends GuiErrorScreen
 {
-
+    private File minecraftDir = new File(Loader.instance().getConfigDir().getParent());
+    private File clientLog = new File(minecraftDir, "logs/fml-client-latest.log");
     private MissingModsException modsMissing;
 
     public GuiModsMissing(MissingModsException modsMissing)
@@ -33,15 +44,49 @@ public class GuiModsMissing extends GuiErrorScreen
     {
         super.initGui();
         this.buttonList.clear();
+        this.buttonList.add(new GuiButton(1, 50, this.height - 38, this.width/2 -55, 20, I18n.format("fml.button.open.mods.folder")));
+        String openFileText = I18n.format("fml.button.open.file", clientLog.getName());
+        this.buttonList.add(new GuiButton(2, this.width / 2 + 5, this.height - 38, this.width / 2 - 55, 20, openFileText));
     }
+
+    @Override
+    protected void actionPerformed(GuiButton button) throws IOException
+    {
+        if (button.id == 1)
+        {
+            try
+            {
+                File modsDir = new File(minecraftDir, "mods");
+                Desktop.getDesktop().open(modsDir);
+            }
+            catch (Exception e)
+            {
+                FMLLog.log(Level.ERROR, e, "Problem opening mods folder");
+            }
+        }
+        else if (button.id == 2)
+        {
+            try
+            {
+                Desktop.getDesktop().open(clientLog);
+            }
+            catch (Exception e)
+            {
+                FMLLog.log(Level.ERROR, e, "Problem opening log file " + clientLog);
+            }
+        }
+    }
+
     @Override
     public void drawScreen(int mouseX, int mouseY, float partialTicks)
     {
         this.drawDefaultBackground();
         int offset = Math.max(85 - modsMissing.missingMods.size() * 10, 10);
-        this.drawCenteredString(this.fontRendererObj, "Forge Mod Loader has found a problem with your minecraft installation", this.width / 2, offset, 0xFFFFFF);
+        String modMissingDependenciesText = I18n.format("fml.messages.mod.missing.dependencies", TextFormatting.BOLD + modsMissing.getModName() + TextFormatting.RESET);
+        this.drawCenteredString(this.fontRendererObj, modMissingDependenciesText, this.width / 2, offset, 0xFFFFFF);
         offset+=10;
-        this.drawCenteredString(this.fontRendererObj, "The mods and versions listed below could not be found", this.width / 2, offset, 0xFFFFFF);
+        String fixMissingDependenciesText = I18n.format("fml.messages.mod.missing.dependencies.fix", modsMissing.getModName());
+        this.drawCenteredString(this.fontRendererObj, fixMissingDependenciesText, this.width / 2, offset, 0xFFFFFF);
         offset+=5;
         for (ArtifactVersion v : modsMissing.missingMods)
         {
@@ -49,15 +94,22 @@ public class GuiModsMissing extends GuiErrorScreen
             if (v instanceof DefaultArtifactVersion)
             {
                 DefaultArtifactVersion dav =  (DefaultArtifactVersion)v;
-                if (dav.getRange() != null && dav.getRange().isUnboundedAbove())
+                if (dav.getRange() != null)
                 {
-                    this.drawCenteredString(this.fontRendererObj, String.format("%s : minimum version required is %s", v.getLabel(), dav.getRange().getLowerBoundString()), this.width / 2, offset, 0xEEEEEE);
+                    String message = String.format(TextFormatting.BOLD +  "%s " + TextFormatting.RESET + "%s", v.getLabel(), dav.getRange().toStringFriendly());
+                    this.drawCenteredString(this.fontRendererObj, message, this.width / 2, offset, 0xEEEEEE);
                     continue;
                 }
             }
             this.drawCenteredString(this.fontRendererObj, String.format("%s : %s", v.getLabel(), v.getRangeString()), this.width / 2, offset, 0xEEEEEE);
         }
         offset+=20;
-        this.drawCenteredString(this.fontRendererObj, "The file 'logs/fml-client-latest.log' contains more information", this.width / 2, offset, 0xFFFFFF);
+        String seeLogText = I18n.format("fml.messages.mod.missing.dependencies.see.log", clientLog.getName());
+        this.drawCenteredString(this.fontRendererObj, seeLogText, this.width / 2, offset, 0xFFFFFF);
+
+        for (int i = 0; i < this.buttonList.size(); ++i)
+        {
+            this.buttonList.get(i).drawButton(this.mc, mouseX, mouseY);
+        }
     }
 }

--- a/src/main/java/net/minecraftforge/fml/common/MissingModsException.java
+++ b/src/main/java/net/minecraftforge/fml/common/MissingModsException.java
@@ -20,11 +20,18 @@ public class MissingModsException extends EnhancedRuntimeException
 {
     private static final long serialVersionUID = 1L;
     public final Set<ArtifactVersion> missingMods;
+    private final String modName;
 
     public MissingModsException(Set<ArtifactVersion> missingMods, String id, String name)
     {
         super(String.format("Mod %s (%s) requires %s", id, name, missingMods));
         this.missingMods = missingMods;
+        this.modName = name;
+    }
+
+    public String getModName()
+    {
+        return modName;
     }
 
     @Override

--- a/src/main/java/net/minecraftforge/fml/common/versioning/Restriction.java
+++ b/src/main/java/net/minecraftforge/fml/common/versioning/Restriction.java
@@ -31,6 +31,8 @@ package net.minecraftforge.fml.common.versioning;
  * under the License.
  */
 
+import net.minecraft.client.resources.I18n;
+
 /**
  * Describes a restriction in versioning.
  *
@@ -208,5 +210,46 @@ public class Restriction
         buf.append( isUpperBoundInclusive() ? "]" : ")" );
 
         return buf.toString();
+    }
+
+    public String toStringFriendly()
+    {
+        if ( getLowerBound() == null && getUpperBound() == null )
+        {
+            return I18n.format("fml.messages.version.restriction.any");
+        }
+        else if ( getLowerBound() != null && getUpperBound() != null )
+        {
+            if ( getLowerBound().equals(getUpperBound()) )
+            {
+                return getLowerBound().toString();
+            }
+            else
+            {
+                return I18n.format("fml.messages.version.restriction.bounded", getLowerBound(), getUpperBound());
+            }
+        }
+        else if ( getLowerBound() != null )
+        {
+            if ( isLowerBoundInclusive() )
+            {
+                return I18n.format("fml.messages.version.restriction.lower.inclusive", getLowerBound());
+            }
+            else
+            {
+                return I18n.format("fml.messages.version.restriction.lower.exclusive", getLowerBound());
+            }
+        }
+        else
+        {
+            if ( isUpperBoundInclusive() )
+            {
+                return I18n.format("fml.messages.version.restriction.upper.inclusive", getUpperBound());
+            }
+            else
+            {
+                return I18n.format("fml.messages.version.restriction.upper.exclusive", getUpperBound());
+            }
+        }
     }
 }

--- a/src/main/java/net/minecraftforge/fml/common/versioning/VersionRange.java
+++ b/src/main/java/net/minecraftforge/fml/common/versioning/VersionRange.java
@@ -496,6 +496,23 @@ public class VersionRange
         }
     }
 
+    public String toStringFriendly()
+    {
+        if ( recommendedVersion != null )
+        {
+            return recommendedVersion.getVersionString();
+        }
+        else
+        {
+            List<String> friendlyRestrictions = new ArrayList<String>(restrictions.size());
+            for (Restriction restriction : restrictions)
+            {
+                friendlyRestrictions.add(restriction.toStringFriendly());
+            }
+            return Joiner.on(", ").join(friendlyRestrictions);
+        }
+    }
+
     public ArtifactVersion matchVersion( List<ArtifactVersion> versions )
     {
         // TODO: could be more efficient by sorting the list and then moving along the restrictions in order?

--- a/src/main/resources/assets/forge/lang/en_US.lang
+++ b/src/main/resources/assets/forge/lang/en_US.lang
@@ -165,6 +165,17 @@ fml.messages.javaversion=Your Java version is Java %s (version string %s)
 fml.messages.upgradejavaorremove=%s%sUpdate Java%s or remove these mods to play
 fml.messages.upgradejava=\n\nPros of updating to Java 8\n- Better Performance\n- Better Security\n- Better Compatibility with newer mods
 fml.messages.countbadandgood=%s of %s mods have this problem
+fml.messages.mod.missing.dependencies=%s is missing mods it depends on.
+fml.messages.mod.missing.dependencies.fix=Include the following mods or remove %s.
+fml.messages.mod.missing.dependencies.see.log=See '%s' for technical information.
+fml.messages.version.restriction.any=any
+fml.messages.version.restriction.lower.inclusive=%s or above
+fml.messages.version.restriction.lower.exclusive=above %s
+fml.messages.version.restriction.upper.inclusive=%s or below
+fml.messages.version.restriction.upper.exclusive=below %s
+fml.messages.version.restriction.bounded=between %s and %s
 
 fml.button.visitjavadownloads=Oracle Java SE Downloads
 fml.button.continue=Continue
+fml.button.open.mods.folder=Open Mods Folder
+fml.button.open.file=Open %s


### PR DESCRIPTION
I realize the log has all the information you need, but I see this error screen pasted all over the place with questions about it, so I figure it can use some improvements to help beginners out and cut down on the reports.

Before:
![missing-mods-before](https://cloud.githubusercontent.com/assets/916092/16168061/0d124c74-34b3-11e6-8473-2ccc1ee5607b.png)

After:
_edit: this is the final result after some discussion below_
![missing-mods-after-buttons2](https://cloud.githubusercontent.com/assets/916092/16188433/4d8b4688-368a-11e6-9d27-fcf512d077e8.png)

I removed the "Forge Mod Loader blah blah" since it doesn't say anything and people stop reading there.
The message now prominently displays the mod that is missing its dependencies.
It formats the required version strings in a human-readable way (without requiring knowledge of the bracket/braces range notation). It also can display version ranges and maximum versions, which were not previously supported.