### PR TITLE
Fix MC-91728: Tipped Instant Arrows not working at all

### DIFF
--- a/patches/minecraft/net/minecraft/entity/projectile/EntityTippedArrow.java.patch
+++ b/patches/minecraft/net/minecraft/entity/projectile/EntityTippedArrow.java.patch
@@ -1,0 +1,10 @@
+--- ../src-base/minecraft/net/minecraft/entity/projectile/EntityTippedArrow.java
++++ ../src-work/minecraft/net/minecraft/entity/projectile/EntityTippedArrow.java
+@@ -176,6 +176,7 @@
+ 
+         for (PotionEffect potioneffect : this.field_184560_g.func_185170_a())
+         {
++            if(potioneffect.func_188419_a().func_76403_b()) potioneffect.func_188419_a().func_180793_a(this, field_70250_c, p_184548_1_, potioneffect.func_76458_c(), 1); else // FORGE: Fix MC-91728 Tipped Arrows do not apply instant effects
+             p_184548_1_.func_70690_d(new PotionEffect(potioneffect.func_188419_a(), potioneffect.func_76459_b() / 8, potioneffect.func_76458_c(), potioneffect.func_82720_e(), potioneffect.func_188418_e()));
+         }
+ 


### PR DESCRIPTION
Upstream ticket: https://bugs.mojang.com/browse/MC-91728

What: Tipped instant arrows are not being considered - they simply don't apply their effect (the proper method is not called)

Upstream ticket suggests twiddling with the duration, but I don't believe that to be correct. I simply patched the relevant area from `EntityTippedArrow` (line 179) so that it looks much like the equivalent area in `EntityPotion` (line 158), which works.

The last `1` parameter is used by splash potions to attenuate the effect based on distance. Since we are directly striking the entity, we pass 1 to apply the full effect (splash potions also pass 1 if an entity is directly struck with a splash potion).

This fix can be simply verified by shooting a zombie with fully charged instant damage II arrows. It won't die as the potion will just keep healing it (for 6 hearts each time iirc). Without this fix the zombie dies in a couple shots.