### PR TITLE
Added CriticalHitEvent

### DIFF
--- a/patches/minecraft/net/minecraft/entity/player/EntityPlayer.java.patch
+++ b/patches/minecraft/net/minecraft/entity/player/EntityPlayer.java.patch
@@ -251,7 +251,24 @@
          if (p_71059_1_.func_70075_an())
          {
              if (!p_71059_1_.func_85031_j(this))
-@@ -1326,6 +1399,7 @@
+@@ -1167,9 +1240,15 @@
+                     flag2 = flag && this.field_70143_R > 0.0F && !this.field_70122_E && !this.func_70617_f_() && !this.func_70090_H() && !this.func_70644_a(MobEffects.field_76440_q) && !this.func_184218_aH() && p_71059_1_ instanceof EntityLivingBase;
+                     flag2 = flag2 && !this.func_70051_ag();
+ 
++                    net.minecraftforge.event.entity.player.CriticalHitEvent hitResult = null;
++                    if(flag2)
++                    {
++                        hitResult = new net.minecraftforge.event.entity.player.CriticalHitEvent(this, (EntityLivingBase)p_71059_1_);
++                        flag2 = !net.minecraftforge.common.MinecraftForge.EVENT_BUS.post(hitResult);
++                    }
+                     if (flag2)
+                     {
+-                        f *= 1.5F;
++                        f *= hitResult.getDamageModifier();
+                     }
+ 
+                     f = f + f1;
+@@ -1326,6 +1405,7 @@
                              if (itemstack1.field_77994_a <= 0)
                              {
                                  this.func_184611_a(EnumHand.MAIN_HAND, (ItemStack)null);
@@ -259,7 +276,7 @@
                              }
                          }
  
-@@ -1414,6 +1488,8 @@
+@@ -1414,6 +1494,8 @@
  
      public EntityPlayer.SleepResult func_180469_a(BlockPos p_180469_1_)
      {
@@ -268,7 +285,7 @@
          if (!this.field_70170_p.field_72995_K)
          {
              if (this.func_70608_bn() || !this.func_70089_S())
-@@ -1453,9 +1529,10 @@
+@@ -1453,9 +1535,10 @@
  
          this.func_70105_a(0.2F, 0.2F);
  
@@ -282,7 +299,7 @@
              float f = 0.5F;
              float f1 = 0.5F;
  
-@@ -1518,13 +1595,14 @@
+@@ -1518,13 +1601,14 @@
  
      public void func_70999_a(boolean p_70999_1_, boolean p_70999_2_, boolean p_70999_3_)
      {
@@ -300,7 +317,7 @@
  
              if (blockpos == null)
              {
-@@ -1533,6 +1611,10 @@
+@@ -1533,6 +1617,10 @@
  
              this.func_70107_b((double)((float)blockpos.func_177958_n() + 0.5F), (double)((float)blockpos.func_177956_o() + 0.1F), (double)((float)blockpos.func_177952_p() + 0.5F));
          }
@@ -311,7 +328,7 @@
  
          this.field_71083_bS = false;
  
-@@ -1551,15 +1633,16 @@
+@@ -1551,15 +1639,16 @@
  
      private boolean func_175143_p()
      {
@@ -331,7 +348,7 @@
          {
              if (!p_180467_2_)
              {
-@@ -1574,16 +1657,17 @@
+@@ -1574,16 +1663,17 @@
          }
          else
          {
@@ -352,7 +369,7 @@
  
              switch (enumfacing)
              {
-@@ -1623,16 +1707,24 @@
+@@ -1623,16 +1713,24 @@
  
      public BlockPos func_180470_cg()
      {
@@ -379,7 +396,7 @@
          if (p_180473_1_ != null)
          {
              this.field_71077_c = p_180473_1_;
-@@ -1827,6 +1919,10 @@
+@@ -1827,6 +1925,10 @@
  
              super.func_180430_e(p_180430_1_, p_180430_2_);
          }
@@ -390,7 +407,7 @@
      }
  
      protected void func_71061_d_()
-@@ -2027,6 +2123,18 @@
+@@ -2027,6 +2129,18 @@
          this.field_175152_f = p_71049_1_.field_175152_f;
          this.field_71078_a = p_71049_1_.field_71078_a;
          this.func_184212_Q().func_187227_b(field_184827_bp, p_71049_1_.func_184212_Q().func_187225_a(field_184827_bp));
@@ -409,7 +426,7 @@
      }
  
      protected boolean func_70041_e_()
-@@ -2126,7 +2234,10 @@
+@@ -2126,7 +2240,10 @@
  
      public ITextComponent func_145748_c_()
      {
@@ -421,7 +438,7 @@
          itextcomponent.func_150256_b().func_150241_a(new ClickEvent(ClickEvent.Action.SUGGEST_COMMAND, "/msg " + this.func_70005_c_() + " "));
          itextcomponent.func_150256_b().func_150209_a(this.func_174823_aP());
          itextcomponent.func_150256_b().func_179989_a(this.func_70005_c_());
-@@ -2135,7 +2246,7 @@
+@@ -2135,7 +2252,7 @@
  
      public float func_70047_e()
      {
@@ -430,7 +447,7 @@
  
          if (this.func_70608_bn())
          {
-@@ -2346,6 +2457,161 @@
+@@ -2346,6 +2463,161 @@
          return (float)this.func_110148_a(SharedMonsterAttributes.field_188792_h).func_111126_e();
      }
  

--- a/src/main/java/net/minecraftforge/event/entity/player/CriticalHitEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/player/CriticalHitEvent.java
@@ -1,0 +1,46 @@
+package net.minecraftforge.event.entity.player;
+
+import net.minecraftforge.fml.common.eventhandler.Cancelable;
+import net.minecraft.entity.EntityLivingBase;
+import net.minecraft.entity.player.EntityPlayer;
+
+/**
+ * AttackEntityEvent is fired when a player is about to make a critical hit.<br>
+ * This event is fired whenever a player attacks an Entity in
+ * EntityPlayer#attackTargetEntityWithCurrentItem(Entity).<br>
+ * <br>
+ * {@link #livingTarget} contains the Entity that was damaged by the player. <br>
+ * <br>
+ * This event is {@link Cancelable}.<br>
+ * If this event is canceled, the player does not make a critical hit (but he still will attack!).<br>
+ * <br>
+ * This event does not have a result. {@link HasResult}<br>
+ * <br>
+ * This event is fired on the {@link MinecraftForge#EVENT_BUS}.
+ **/
+@Cancelable
+public class CriticalHitEvent extends AttackEntityEvent
+{
+    public final EntityLivingBase livingTarget;
+    private float damageModifier;
+    public CriticalHitEvent(EntityPlayer player, EntityLivingBase target)
+    {
+        super(player, target);
+        this.livingTarget = target;
+        this.damageModifier = 1.5F;
+    }
+    
+     /**
+     * This is how much damage you will deal. By default you deal 150% of you normal damage.
+     * If you set it to 0, then the particles are still generated but you don't do damage.
+    */
+    public void setDamageModifier(float mod)
+    {
+        this.damageModifier = mod;
+    }
+    
+    public float getDamageModifier()
+    {
+        return this.damageModifier;
+    }
+}

--- a/src/main/java/net/minecraftforge/event/entity/player/CriticalHitEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/player/CriticalHitEvent.java
@@ -19,13 +19,13 @@ import net.minecraft.entity.player.EntityPlayer;
  * This event is fired on the {@link MinecraftForge#EVENT_BUS}.
  **/
 @Cancelable
-public class CriticalHitEvent extends AttackEntityEvent
+public class CriticalHitEvent extends PlayerEvent
 {
-    public final EntityLivingBase livingTarget;
+    private final EntityLivingBase livingTarget;
     private float damageModifier;
     public CriticalHitEvent(EntityPlayer player, EntityLivingBase target)
     {
-        super(player, target);
+        super(player);
         this.livingTarget = target;
         this.damageModifier = 1.5F;
     }
@@ -42,5 +42,10 @@ public class CriticalHitEvent extends AttackEntityEvent
     public float getDamageModifier()
     {
         return this.damageModifier;
+    }
+	
+	public EntityLivingBase getTarget()
+    {
+        return livingTarget;
     }
 }

--- a/src/main/java/net/minecraftforge/event/entity/player/CriticalHitEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/player/CriticalHitEvent.java
@@ -43,8 +43,8 @@ public class CriticalHitEvent extends PlayerEvent
     {
         return this.damageModifier;
     }
-	
-	public EntityLivingBase getTarget()
+    
+    public EntityLivingBase getTarget()
     {
         return livingTarget;
     }

--- a/src/test/java/net/minecraftforge/test/CriticalHitEventTest.java
+++ b/src/test/java/net/minecraftforge/test/CriticalHitEventTest.java
@@ -1,0 +1,30 @@
+package net.minecraftforge.test;
+
+import net.minecraftforge.common.MinecraftForge;
+import net.minecraftforge.event.entity.player.CriticalHitEvent;
+import net.minecraftforge.fml.common.Mod;
+import net.minecraftforge.fml.common.Mod.EventHandler;
+import net.minecraftforge.fml.common.event.FMLInitializationEvent;
+import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
+
+@Mod(modid="CriticalHitEventTest", name="CriticalHitEventTest", version="0.0.0")
+public class CriticalHitEventTest
+{
+    public static final boolean ENABLE = false;
+
+    @EventHandler
+    public void init(FMLInitializationEvent event)
+    {
+        MinecraftForge.EVENT_BUS.register(this);
+    }
+
+    @SubscribeEvent
+    public void onCriticalHit(CriticalHitEvent event)
+    {
+        if(ENABLE)
+        {
+            System.out.println(event.getTarget() + " got hit by " + event.getEntityPlayer);
+            event.setDamageModifier(2.0F);
+        }
+    }
+}


### PR DESCRIPTION
Adds an Event to control the behauvior if an Player does an critical hit.

This is a retargeting of #2935 and solves #2871 .

Also an example:https://gist.github.com/mcenderdragon/b2e11c054dca08c566934a860087d881