### PR TITLE
Add null check for ItemShears in the event a null EntityItem is returned

### DIFF
--- a/patches/minecraft/net/minecraft/item/ItemShears.java.patch
+++ b/patches/minecraft/net/minecraft/item/ItemShears.java.patch
@@ -9,7 +9,7 @@
      }
  
      public boolean func_150897_b(IBlockState p_150897_1_)
-@@ -36,4 +36,71 @@
+@@ -36,4 +36,74 @@
          Block block = p_150893_2_.func_177230_c();
          return block != Blocks.field_150321_G && p_150893_2_.func_185904_a() != Material.field_151584_j ? (block == Blocks.field_150325_L ? 5.0F : super.func_150893_a(p_150893_1_, p_150893_2_)) : 15.0F;
      }
@@ -35,9 +35,12 @@
 +                for(ItemStack stack : drops)
 +                {
 +                    net.minecraft.entity.item.EntityItem ent = entity.func_70099_a(stack, 1.0F);
-+                    ent.field_70181_x += rand.nextFloat() * 0.05F;
-+                    ent.field_70159_w += (rand.nextFloat() - rand.nextFloat()) * 0.1F;
-+                    ent.field_70179_y += (rand.nextFloat() - rand.nextFloat()) * 0.1F;
++                    if (ent != null) // In various cases the item returned may be null
++                    {
++                        ent.field_70181_x += rand.nextFloat() * 0.05F;
++                        ent.field_70159_w += (rand.nextFloat() - rand.nextFloat()) * 0.1F;
++                        ent.field_70179_y += (rand.nextFloat() - rand.nextFloat()) * 0.1F;
++                    }
 +                }
 +                itemstack.func_77972_a(1, entity);
 +            }


### PR DESCRIPTION
Plainly cut and dry for the cases that an `IShearable` entity may return a `null` `EntityItem` to avoid an NPE. Pretty cut and dry.