### PR TITLE
[1.10.0] Fix guis closing as soon as they are opened

### DIFF
--- a/patches/minecraft/net/minecraft/entity/player/EntityPlayerMP.java.patch
+++ b/patches/minecraft/net/minecraft/entity/player/EntityPlayerMP.java.patch
@@ -23,7 +23,7 @@
          this.field_71070_bA.func_75142_b();
  
 -        if (!this.field_70170_p.field_72995_K && !this.field_71070_bA.func_75145_c(this))
-+        if (!this.field_70170_p.field_72995_K && this.field_71070_bA != null && this.field_71070_bA.func_75145_c(this))
++        if (!this.field_70170_p.field_72995_K && this.field_71070_bA != null && !this.field_71070_bA.func_75145_c(this))
          {
              this.func_71053_j();
              this.field_71070_bA = this.field_71069_bz;


### PR DESCRIPTION
There's inverted logic in a patch that causes guis to close constantly.