### PR TITLE
[1.10] Fix keys with KeyModifier failing to load

### DIFF
--- a/patches/minecraft/net/minecraft/client/settings/GameSettings.java.patch
+++ b/patches/minecraft/net/minecraft/client/settings/GameSettings.java.patch
@@ -24,19 +24,17 @@
          try
          {
              if (!this.field_74354_ai.exists())
-@@ -886,7 +889,11 @@
+@@ -886,6 +889,10 @@
                      {
                          if (s1.equals("key_" + keybinding.func_151464_g()))
                          {
--                            keybinding.func_151462_b(Integer.parseInt(s2));
-+                            if (s2.indexOf(':') != -1)
-+                            {
++                            if (s2.indexOf(':') != -1) {
 +                                String[] t = s2.split(":");
 +                                keybinding.setKeyModifierAndCode(net.minecraftforge.client.settings.KeyModifier.valueFromString(t[1]), Integer.parseInt(t[0]));
-+                            } else { keybinding.func_151462_b(Integer.parseInt(s2)); }
++                            } else
+                             keybinding.func_151462_b(Integer.parseInt(s2));
                          }
                      }
- 
 @@ -1016,7 +1023,8 @@
  
              for (KeyBinding keybinding : this.field_74324_K)

--- a/patches/minecraft/net/minecraft/client/settings/GameSettings.java.patch
+++ b/patches/minecraft/net/minecraft/client/settings/GameSettings.java.patch
@@ -24,19 +24,20 @@
          try
          {
              if (!this.field_74354_ai.exists())
-@@ -887,6 +890,11 @@
+@@ -886,7 +889,11 @@
+                     {
                          if (s1.equals("key_" + keybinding.func_151464_g()))
                          {
-                             keybinding.func_151462_b(Integer.parseInt(s2));
+-                            keybinding.func_151462_b(Integer.parseInt(s2));
 +                            if (s2.indexOf(':') != -1)
 +                            {
 +                                String[] t = s2.split(":");
 +                                keybinding.setKeyModifierAndCode(net.minecraftforge.client.settings.KeyModifier.valueFromString(t[1]), Integer.parseInt(t[0]));
-+                            }
++                            } else { keybinding.func_151462_b(Integer.parseInt(s2)); }
                          }
                      }
  
-@@ -1016,7 +1024,8 @@
+@@ -1016,7 +1023,8 @@
  
              for (KeyBinding keybinding : this.field_74324_K)
              {
@@ -46,7 +47,7 @@
              }
  
              for (SoundCategory soundcategory : SoundCategory.values())
-@@ -1249,4 +1258,24 @@
+@@ -1249,4 +1257,24 @@
              return p_148264_1_;
          }
      }

--- a/patches/minecraft/net/minecraft/client/settings/GameSettings.java.patch
+++ b/patches/minecraft/net/minecraft/client/settings/GameSettings.java.patch
@@ -24,18 +24,19 @@
          try
          {
              if (!this.field_74354_ai.exists())
-@@ -886,6 +889,10 @@
+@@ -886,6 +889,11 @@
                      {
                          if (s1.equals("key_" + keybinding.func_151464_g()))
                          {
-+                            if (s2.indexOf(':') != -1) {
++                            if (s2.indexOf(':') != -1)
++                            {
 +                                String[] t = s2.split(":");
 +                                keybinding.setKeyModifierAndCode(net.minecraftforge.client.settings.KeyModifier.valueFromString(t[1]), Integer.parseInt(t[0]));
 +                            } else
                              keybinding.func_151462_b(Integer.parseInt(s2));
                          }
                      }
-@@ -1016,7 +1023,8 @@
+@@ -1016,7 +1024,8 @@
  
              for (KeyBinding keybinding : this.field_74324_K)
              {
@@ -45,7 +46,7 @@
              }
  
              for (SoundCategory soundcategory : SoundCategory.values())
-@@ -1249,4 +1257,24 @@
+@@ -1249,4 +1258,24 @@
              return p_148264_1_;
          }
      }


### PR DESCRIPTION
Integer.parseInt(s2) throws a NumberFormatException in the case of a KeyModifier being applied, as the input will be something like "2:SHIFT", causing the option to be skipped.

This fixes the _already existing patch that got broken during the 1.10 update_ to only run the Vanilla setKeyCode if no KeyModifier is saved.