### PR TITLE
Added PlayerAddXpEvent and PlayerChangeLevelEvent

### DIFF
--- a/patches/minecraft/net/minecraft/entity/player/EntityPlayer.java.patch
+++ b/patches/minecraft/net/minecraft/entity/player/EntityPlayer.java.patch
@@ -390,31 +390,37 @@
      }
  
      protected void func_71061_d_()
-@@ -1867,6 +1963,7 @@
+@@ -1867,6 +1963,9 @@
  
      public void func_71023_q(int p_71023_1_)
      {
-+        if(net.minecraftforge.common.MinecraftForge.EVENT_BUS.post(new net.minecraftforge.event.entity.player.PlayerAddXpEvent(this, p_71023_1_))) return;
++        net.minecraftforge.event.entity.player.PlayerAddXpEvent event = new net.minecraftforge.event.entity.player.PlayerAddXpEvent(this, p_71023_1_);
++        if(net.minecraftforge.common.MinecraftForge.EVENT_BUS.post(event)) return;
++        p_71023_1_ = event.getAmount();
          this.func_85039_t(p_71023_1_);
          int i = Integer.MAX_VALUE - this.field_71067_cb;
  
-@@ -1891,6 +1988,7 @@
+@@ -1891,6 +1990,9 @@
  
      public void func_71013_b(int p_71013_1_)
      {
-+        if(net.minecraftforge.common.MinecraftForge.EVENT_BUS.post(new net.minecraftforge.event.entity.player.PlayerChangeLevelEvent(this, -p_71013_1_))) return;
++        net.minecraftforge.event.entity.player.PlayerChangeLevelEvent event = new net.minecraftforge.event.entity.player.PlayerChangeLevelEvent(this, p_71013_1_);
++        if(net.minecraftforge.common.MinecraftForge.EVENT_BUS.post(event)) return;
++        p_71013_1_ = -event.getLevels();
          this.field_71068_ca -= p_71013_1_;
  
          if (this.field_71068_ca < 0)
-@@ -1905,6 +2003,7 @@
+@@ -1905,6 +2007,9 @@
  
      public void func_82242_a(int p_82242_1_)
      {
-+        if(net.minecraftforge.common.MinecraftForge.EVENT_BUS.post(new net.minecraftforge.event.entity.player.PlayerChangeLevelEvent(this, p_82242_1_))) return;
++        net.minecraftforge.event.entity.player.PlayerChangeLevelEvent event = new net.minecraftforge.event.entity.player.PlayerChangeLevelEvent(this, p_82242_1_);
++        if(net.minecraftforge.common.MinecraftForge.EVENT_BUS.post(event)) return;
++        p_82242_1_ = event.getLevels();
          this.field_71068_ca += p_82242_1_;
  
          if (this.field_71068_ca < 0)
-@@ -2027,6 +2126,18 @@
+@@ -2027,6 +2132,18 @@
          this.field_175152_f = p_71049_1_.field_175152_f;
          this.field_71078_a = p_71049_1_.field_71078_a;
          this.func_184212_Q().func_187227_b(field_184827_bp, p_71049_1_.func_184212_Q().func_187225_a(field_184827_bp));
@@ -433,7 +439,7 @@
      }
  
      protected boolean func_70041_e_()
-@@ -2126,7 +2237,10 @@
+@@ -2126,7 +2243,10 @@
  
      public ITextComponent func_145748_c_()
      {
@@ -445,7 +451,7 @@
          itextcomponent.func_150256_b().func_150241_a(new ClickEvent(ClickEvent.Action.SUGGEST_COMMAND, "/msg " + this.func_70005_c_() + " "));
          itextcomponent.func_150256_b().func_150209_a(this.func_174823_aP());
          itextcomponent.func_150256_b().func_179989_a(this.func_70005_c_());
-@@ -2135,7 +2249,7 @@
+@@ -2135,7 +2255,7 @@
  
      public float func_70047_e()
      {
@@ -454,7 +460,7 @@
  
          if (this.func_70608_bn())
          {
-@@ -2346,6 +2460,161 @@
+@@ -2346,6 +2466,161 @@
          return (float)this.func_110148_a(SharedMonsterAttributes.field_188792_h).func_111126_e();
      }
  

--- a/patches/minecraft/net/minecraft/entity/player/EntityPlayer.java.patch
+++ b/patches/minecraft/net/minecraft/entity/player/EntityPlayer.java.patch
@@ -390,7 +390,31 @@
      }
  
      protected void func_71061_d_()
-@@ -2027,6 +2123,18 @@
+@@ -1867,6 +1963,7 @@
+ 
+     public void func_71023_q(int p_71023_1_)
+     {
++        if(net.minecraftforge.common.MinecraftForge.EVENT_BUS.post(new net.minecraftforge.event.entity.player.PlayerAddXpEvent(this, p_71023_1_))) return;
+         this.func_85039_t(p_71023_1_);
+         int i = Integer.MAX_VALUE - this.field_71067_cb;
+ 
+@@ -1891,6 +1988,7 @@
+ 
+     public void func_71013_b(int p_71013_1_)
+     {
++        if(net.minecraftforge.common.MinecraftForge.EVENT_BUS.post(new net.minecraftforge.event.entity.player.PlayerChangeLevelEvent(this, -p_71013_1_))) return;
+         this.field_71068_ca -= p_71013_1_;
+ 
+         if (this.field_71068_ca < 0)
+@@ -1905,6 +2003,7 @@
+ 
+     public void func_82242_a(int p_82242_1_)
+     {
++        if(net.minecraftforge.common.MinecraftForge.EVENT_BUS.post(new net.minecraftforge.event.entity.player.PlayerChangeLevelEvent(this, p_82242_1_))) return;
+         this.field_71068_ca += p_82242_1_;
+ 
+         if (this.field_71068_ca < 0)
+@@ -2027,6 +2126,18 @@
          this.field_175152_f = p_71049_1_.field_175152_f;
          this.field_71078_a = p_71049_1_.field_71078_a;
          this.func_184212_Q().func_187227_b(field_184827_bp, p_71049_1_.func_184212_Q().func_187225_a(field_184827_bp));
@@ -409,7 +433,7 @@
      }
  
      protected boolean func_70041_e_()
-@@ -2126,7 +2234,10 @@
+@@ -2126,7 +2237,10 @@
  
      public ITextComponent func_145748_c_()
      {
@@ -421,7 +445,7 @@
          itextcomponent.func_150256_b().func_150241_a(new ClickEvent(ClickEvent.Action.SUGGEST_COMMAND, "/msg " + this.func_70005_c_() + " "));
          itextcomponent.func_150256_b().func_150209_a(this.func_174823_aP());
          itextcomponent.func_150256_b().func_179989_a(this.func_70005_c_());
-@@ -2135,7 +2246,7 @@
+@@ -2135,7 +2249,7 @@
  
      public float func_70047_e()
      {
@@ -430,7 +454,7 @@
  
          if (this.func_70608_bn())
          {
-@@ -2346,6 +2457,161 @@
+@@ -2346,6 +2460,161 @@
          return (float)this.func_110148_a(SharedMonsterAttributes.field_188792_h).func_111126_e();
      }
  

--- a/src/main/java/net/minecraftforge/event/entity/player/PlayerAddXpEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/player/PlayerAddXpEvent.java
@@ -1,0 +1,26 @@
+package net.minecraftforge.event.entity.player;
+
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraftforge.fml.common.eventhandler.Cancelable;
+
+/**
+ * PlayerAddXpEvent is fired when a player's Xp increases through {@link EntityPlayer#addExperience(int)}<br />
+ * {@link #getAmount} contains the amount to be added to the player's total.<br />
+ * This event is {@link Cancelable}. If it is canceled, then no further processing will be done.
+ */
+@Cancelable
+public class PlayerAddXpEvent extends PlayerEvent
+{
+    private final int amount;
+
+    public PlayerAddXpEvent(EntityPlayer player, int amount)
+    {
+        super(player);
+        this.amount = amount;
+    }
+
+    public int getAmount()
+    {
+        return this.amount;
+    }
+}

--- a/src/main/java/net/minecraftforge/event/entity/player/PlayerAddXpEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/player/PlayerAddXpEvent.java
@@ -11,7 +11,7 @@ import net.minecraftforge.fml.common.eventhandler.Cancelable;
 @Cancelable
 public class PlayerAddXpEvent extends PlayerEvent
 {
-    private final int amount;
+    private int amount;
 
     public PlayerAddXpEvent(EntityPlayer player, int amount)
     {
@@ -22,5 +22,10 @@ public class PlayerAddXpEvent extends PlayerEvent
     public int getAmount()
     {
         return this.amount;
+    }
+    
+    public void setAmount(int amount)
+    {
+        this.amount = amount;
     }
 }

--- a/src/main/java/net/minecraftforge/event/entity/player/PlayerChangeLevelEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/player/PlayerChangeLevelEvent.java
@@ -1,0 +1,27 @@
+package net.minecraftforge.event.entity.player;
+
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraftforge.fml.common.eventhandler.Cancelable;
+
+/**
+ * PlayerChangeLevelEvent is fired when a player's level changes through either {@link EntityPlayer#addExperienceLevel(int)} or
+ * {@link EntityPlayer#removeExperienceLevel(int)}<br />
+ * {@link #getLevel} contains the levels to be added to the player's total, with negative for remove.<br />
+ * This event is {@link Cancelable}. If it is canceled, then no further processing will be done.
+ */
+@Cancelable
+public class PlayerChangeLevelEvent extends PlayerEvent
+{
+    private final int levels;
+
+    public PlayerChangeLevelEvent(EntityPlayer player, int levels)
+    {
+        super(player);
+        this.levels = levels;
+    }
+
+    public int getLevels()
+    {
+        return this.levels;
+    }
+}

--- a/src/main/java/net/minecraftforge/event/entity/player/PlayerChangeLevelEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/player/PlayerChangeLevelEvent.java
@@ -12,7 +12,7 @@ import net.minecraftforge.fml.common.eventhandler.Cancelable;
 @Cancelable
 public class PlayerChangeLevelEvent extends PlayerEvent
 {
-    private final int levels;
+    private int levels;
 
     public PlayerChangeLevelEvent(EntityPlayer player, int levels)
     {
@@ -23,5 +23,10 @@ public class PlayerChangeLevelEvent extends PlayerEvent
     public int getLevels()
     {
         return this.levels;
+    }
+    
+    public void setLevels(int levels)
+    {
+        this.levels = levels;
     }
 }

--- a/src/test/java/net/minecraftforge/test/PlayerXpEventsTest.java
+++ b/src/test/java/net/minecraftforge/test/PlayerXpEventsTest.java
@@ -1,0 +1,38 @@
+package net.minecraftforge.test;
+
+import net.minecraftforge.common.MinecraftForge;
+import net.minecraftforge.event.entity.player.PlayerAddXpEvent;
+import net.minecraftforge.event.entity.player.PlayerChangeLevelEvent;
+import net.minecraftforge.fml.common.Mod;
+import net.minecraftforge.fml.common.Mod.EventHandler;
+import net.minecraftforge.fml.common.event.FMLInitializationEvent;
+import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
+
+/**
+ * This is a test for {@link PlayerChangeLevelEvent} and {@link PlayerAddXpEvent}
+ */
+@Mod(modid = "playerxpeventtest", name = "Player Xp Event Test", version = "0.0.0")
+public class PlayerXpEventsTest
+{
+    public static final boolean ENABLE = false;
+
+    @EventHandler
+    public void init(FMLInitializationEvent event)
+    {
+        MinecraftForge.EVENT_BUS.register(this);
+    }
+
+    @SubscribeEvent
+    public void onAddXp(PlayerAddXpEvent event)
+    {
+        if (!ENABLE) return;
+        System.out.println("Adding " + event.getAmount() + "XP to " + event.getEntityPlayer().getName());
+    }
+
+    @SubscribeEvent
+    public void onLevelChange(PlayerChangeLevelEvent event)
+    {
+        if (!ENABLE) return;
+        System.out.println("Changing " + event.getEntityPlayer().getName() + "'s XP Level by " + event.getLevels());
+    }
+}


### PR DESCRIPTION
Created 2 new events relating to XP. One is for gaining physical XP, and the other is for adding and removing levels. 

They can be used to more finely control how the XP system works. The only thing currently implemented for this is PlayerPickupXpEvent, which only fires for picking up XP Orbs.

[Demo](https://gist.github.com/Coolway99/543c8da55a5eb81cd75f4b9a7f81e075)