### PR TITLE
Fix comparison stability of the Recipe Sorter with unknown recipes

### DIFF
--- a/src/main/java/net/minecraftforge/oredict/RecipeSorter.java
+++ b/src/main/java/net/minecraftforge/oredict/RecipeSorter.java
@@ -157,11 +157,17 @@ public class RecipeSorter implements Comparator<IRecipe>
     {
         Category c1 = getCategory(r1);
         Category c2 = getCategory(r2);
-        if (c1 == SHAPELESS && c2 == SHAPED) return  1;
-        if (c1 == SHAPED && c2 == SHAPELESS) return -1;
-        if (r2.getRecipeSize() < r1.getRecipeSize()) return -1;
-        if (r2.getRecipeSize() > r1.getRecipeSize()) return  1;
-        return getPriority(r2) - getPriority(r1); // high priority value first!
+        int categoryComparison = -c1.compareTo(c2);
+        if (categoryComparison != 0)
+        {
+            return categoryComparison;
+        }
+        else
+        {
+            if (r2.getRecipeSize() < r1.getRecipeSize()) return -1;
+            if (r2.getRecipeSize() > r1.getRecipeSize()) return  1;
+            return getPriority(r2) - getPriority(r1); // high priority value first!
+        }
     }
 
     private static Set<Class<?>> warned = Sets.newHashSet();


### PR DESCRIPTION
When someone doesn't register their recipe with the RecipeSorter it will often crash because the comparison does not handle UNKNOWN in a way that follows the comparison contract.

This PR keeps the same ordering, but handles UNKNOWN so that it will not crash.