### PR TITLE
Add RenderTooltipEvent

### DIFF
--- a/patches/minecraft/net/minecraft/client/gui/GuiScreen.java.patch
+++ b/patches/minecraft/net/minecraft/client/gui/GuiScreen.java.patch
@@ -1,16 +1,18 @@
 --- ../src-base/minecraft/net/minecraft/client/gui/GuiScreen.java
 +++ ../src-work/minecraft/net/minecraft/client/gui/GuiScreen.java
-@@ -141,7 +141,8 @@
+@@ -141,7 +141,10 @@
              }
          }
  
 -        this.func_146283_a(list, p_146285_2_, p_146285_3_);
 +        FontRenderer font = p_146285_1_.func_77973_b().getFontRenderer(p_146285_1_);
++        net.minecraftforge.fml.client.config.GuiUtils.preItemToolTip(p_146285_1_);
 +        this.drawHoveringText(list, p_146285_2_, p_146285_3_, (font == null ? field_146289_q : font));
++        net.minecraftforge.fml.client.config.GuiUtils.postItemToolTip();
      }
  
      protected void func_146279_a(String p_146279_1_, int p_146279_2_, int p_146279_3_)
-@@ -151,7 +152,13 @@
+@@ -151,7 +154,13 @@
  
      protected void func_146283_a(List<String> p_146283_1_, int p_146283_2_, int p_146283_3_)
      {
@@ -25,7 +27,7 @@
          {
              GlStateManager.func_179101_C();
              RenderHelper.func_74518_a();
-@@ -421,6 +428,7 @@
+@@ -421,6 +430,7 @@
          {
              this.field_146297_k.field_71456_v.func_146158_b().func_146239_a(p_175281_1_);
          }
@@ -33,7 +35,7 @@
  
          this.field_146297_k.field_71439_g.func_71165_d(p_175281_1_);
      }
-@@ -435,9 +443,15 @@
+@@ -435,9 +445,15 @@
  
                  if (guibutton.func_146116_c(this.field_146297_k, p_73864_1_, p_73864_2_))
                  {
@@ -49,7 +51,7 @@
                  }
              }
          }
-@@ -467,8 +481,12 @@
+@@ -467,8 +483,12 @@
          this.field_146289_q = p_146280_1_.field_71466_p;
          this.field_146294_l = p_146280_2_;
          this.field_146295_m = p_146280_3_;
@@ -62,7 +64,7 @@
      }
  
      public void func_183500_a(int p_183500_1_, int p_183500_2_)
-@@ -487,7 +505,9 @@
+@@ -487,7 +507,9 @@
          {
              while (Mouse.next())
              {
@@ -72,7 +74,7 @@
              }
          }
  
-@@ -495,7 +515,9 @@
+@@ -495,7 +517,9 @@
          {
              while (Keyboard.next())
              {
@@ -82,7 +84,7 @@
              }
          }
      }
-@@ -557,6 +579,7 @@
+@@ -557,6 +581,7 @@
      public void func_146276_q_()
      {
          this.func_146270_b(0);

--- a/patches/minecraft/net/minecraft/client/gui/inventory/GuiContainerCreative.java.patch
+++ b/patches/minecraft/net/minecraft/client/gui/inventory/GuiContainerCreative.java.patch
@@ -162,7 +162,18 @@
          GlStateManager.func_179131_c(1.0F, 1.0F, 1.0F, 1.0F);
          GlStateManager.func_179140_f();
      }
-@@ -638,16 +687,35 @@
+@@ -623,8 +672,9 @@
+                     list.set(i, TextFormatting.GRAY + (String)list.get(i));
+                 }
+             }
+-
++            net.minecraftforge.fml.client.config.GuiUtils.preItemToolTip(p_146285_1_);
+             this.func_146283_a(list, p_146285_2_, p_146285_3_);
++            net.minecraftforge.fml.client.config.GuiUtils.postItemToolTip();
+         }
+         else
+         {
+@@ -638,16 +688,35 @@
          RenderHelper.func_74520_c();
          CreativeTabs creativetabs = CreativeTabs.field_78032_a[field_147058_w];
  
@@ -199,7 +210,7 @@
          this.field_146297_k.func_110434_K().func_110577_a(new ResourceLocation("textures/gui/container/creative_inventory/tab_" + creativetabs.func_78015_f()));
          this.func_73729_b(this.field_147003_i, this.field_147009_r, 0, 0, this.field_146999_f, this.field_147000_g);
          this.field_147062_A.func_146194_f();
-@@ -662,6 +730,14 @@
+@@ -662,6 +731,14 @@
              this.func_73729_b(i, j + (int)((float)(k - j - 17) * this.field_147067_x), 232 + (this.func_147055_p() ? 0 : 12), 0, 12, 15);
          }
  
@@ -214,7 +225,7 @@
          this.func_147051_a(creativetabs);
  
          if (creativetabs == CreativeTabs.field_78036_m)
-@@ -672,6 +748,14 @@
+@@ -672,6 +749,14 @@
  
      protected boolean func_147049_a(CreativeTabs p_147049_1_, int p_147049_2_, int p_147049_3_)
      {
@@ -229,7 +240,7 @@
          int i = p_147049_1_.func_78020_k();
          int j = 28 * i;
          int k = 0;
-@@ -768,6 +852,8 @@
+@@ -768,6 +853,8 @@
          }
  
          GlStateManager.func_179140_f();
@@ -238,7 +249,7 @@
          this.func_73729_b(l, i1, j, k, 28, j1);
          this.field_73735_i = 100.0F;
          this.field_146296_j.field_77023_b = 100.0F;
-@@ -794,6 +880,15 @@
+@@ -794,6 +881,15 @@
          {
              this.field_146297_k.func_147108_a(new GuiStats(this, this.field_146297_k.field_71439_g.func_146107_m()));
          }

--- a/src/main/java/net/minecraftforge/client/event/RenderTooltipEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/RenderTooltipEvent.java
@@ -1,0 +1,225 @@
+package net.minecraftforge.client.event;
+
+import java.util.Collections;
+import java.util.List;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+import net.minecraft.client.gui.FontRenderer;
+import net.minecraft.item.ItemStack;
+import net.minecraftforge.event.entity.player.ItemTooltipEvent;
+import net.minecraftforge.fml.common.eventhandler.Cancelable;
+import net.minecraftforge.fml.common.eventhandler.Event;
+
+/**
+ * A set of events which are fired at various points during tooltip rendering.
+ * <p>
+ * Can be used to change the rendering parameters, draw something extra, etc.
+ * <p>
+ * Do not use this event directly, use one of the subclasses:
+ * <ul>
+ * <li>{@link RenderTooltipEvent.Pre}</li>
+ * <li>{@link RenderTooltipEvent.PostBackground}</li>
+ * <li>{@link RenderTooltipEvent.PostText}</li>
+ * </ul>
+ */
+public abstract class RenderTooltipEvent extends Event
+{
+    protected final ItemStack stack;
+    protected final List<String> lines;
+    protected int x;
+    protected int y;
+    protected FontRenderer fr;
+
+    public RenderTooltipEvent(@Nullable ItemStack stack, @Nonnull List<String> lines, int x, int y, @Nonnull FontRenderer fr)
+    {
+        this.stack = stack;
+        this.lines = Collections.unmodifiableList(lines); // Leave editing to ItemTooltipEvent
+        this.x = x;
+        this.y = y;
+        this.fr = fr;
+    }
+
+    /**
+     * @return The stack which the tooltip is being rendered for. As tooltips can be drawn without itemstacks, this return is {@link Nullable}. 
+     */
+    @Nullable
+    public ItemStack getStack()
+    {
+        return stack;
+    }
+    
+    /**
+     * The lines to be drawn. May change between {@link RenderTooltipEvent.Pre} and {@link RenderTooltipEvent.Post}.
+     * 
+     * @return An <i>unmodifiable</i> list of strings. Use {@link ItemTooltipEvent} to modify tooltip text.
+     */
+    @Nonnull
+    public List<String> getLines()
+    {
+        return lines;
+    }
+
+    /**
+     * @return The X position of the tooltip box. By default, the mouse X position.
+     */
+    public int getX()
+    {
+        return x;
+    }
+
+    /**
+     * @return The Y position of the tooltip box. By default, the mouse Y position.
+     */
+    public int getY()
+    {
+        return y;
+    }
+    
+    /**
+     * @return The {@link FontRenderer} instance the current render is using.
+     */
+    @Nonnull
+    public FontRenderer getFontRenderer()
+    {
+        return fr;
+    }
+
+    /**
+     * This event is fired before any tooltip calculations are done. It provides setters for all aspects of the tooltip, so the final render can be modified.
+     * <p>
+     * This event is {@link Cancelable}.
+     */
+    @Cancelable
+    public static class Pre extends RenderTooltipEvent
+    {
+        private int screenWidth;
+        private int screenHeight;
+        private int maxWidth;
+
+        public Pre(@Nullable ItemStack stack, @Nonnull List<String> lines, int x, int y, int screenWidth, int screenHeight, int maxWidth, @Nonnull FontRenderer fr)
+        {
+            super(stack, lines, x, y, fr);
+            this.screenWidth = screenWidth;
+            this.screenHeight = screenHeight;
+            this.maxWidth = maxWidth;
+        }
+
+        public int getScreenWidth()
+        {
+            return screenWidth;
+        }
+
+        public void setScreenWidth(int screenWidth)
+        {
+            this.screenWidth = screenWidth;
+        }
+
+        public int getScreenHeight()
+        {
+            return screenHeight;
+        }
+
+        public void setScreenHeight(int screenHeight)
+        {
+            this.screenHeight = screenHeight;
+        }
+
+        /**
+         * @return The max width the tooltip can be. Defaults to -1 (unlimited).
+         */
+        public int getMaxWidth()
+        {
+            return maxWidth;
+        }
+
+        /**
+         * Sets the max width of the tooltip. Use -1 for unlimited.
+         */
+        public void setMaxWidth(int maxWidth)
+        {
+            this.maxWidth = maxWidth;
+        }
+        
+        /**
+         * Sets the {@link FontRenderer} to be used to render text.
+         */
+        public void setFontRenderer(@Nonnull FontRenderer fr)
+        {
+            this.fr = fr;
+        }
+
+        /**
+         * Set the X origin of the tooltip.
+         */
+        public void setX(int x)
+        {
+            this.x = x;
+        }
+
+        /**
+         * Set the Y origin of the tooltip.
+         */
+        public void setY(int y)
+        {
+            this.y = y;
+        }
+    }
+
+    /**
+     * Events inheriting from this class are fired at different stages during the tooltip rendering.
+     * <p>
+     * Do not use this event directly, use one of its subclasses:
+     * <ul>
+     * <li>{@link RenderTooltipEvent.PostBackground}</li>
+     * <li>{@link RenderTooltipEvent.PostText}</li>
+     * </ul>
+     */
+    protected static abstract class Post extends RenderTooltipEvent
+    {
+        private final int width;
+        private final int height;
+        
+        public Post(@Nullable ItemStack stack, @Nonnull List<String> textLines, int x, int y, @Nonnull FontRenderer fr, int width, int height)
+        {
+            super(stack, textLines, x, y, fr);
+            this.width = width;
+            this.height = height;
+        }
+
+        /**
+         * @return The width of the tooltip box. This is the width of the <i>inner</i> box, not including the border.
+         */
+        public int getWidth()
+        {
+            return width;
+        }
+
+        /**
+         * @return The height of the tooltip box. This is the height of the <i>inner</i> box, not including the border.
+         */
+        public int getHeight()
+        {
+            return height;
+        }
+    }
+    
+    /**
+     * This event is fired directly after the tooltip background is drawn, but before any text is drawn.
+     */
+    public static class PostBackground extends Post 
+    {
+        public PostBackground(@Nullable ItemStack stack, @Nonnull List<String> textLines, int x, int y, @Nonnull FontRenderer fr, int width, int height)
+            { super(stack, textLines, x, y, fr, width, height); }
+    }
+
+    /**
+     * This event is fired directly after the tooltip text is drawn, but before the GL state is reset.
+     */
+    public static class PostText extends Post
+    {
+        public PostText(@Nullable ItemStack stack, @Nonnull List<String> textLines, int x, int y, @Nonnull FontRenderer fr, int width, int height)
+            { super(stack, textLines, x, y, fr, width, height); }
+    }
+}

--- a/src/main/java/net/minecraftforge/fml/client/config/GuiUtils.java
+++ b/src/main/java/net/minecraftforge/fml/client/config/GuiUtils.java
@@ -19,12 +19,17 @@ import net.minecraft.client.renderer.RenderHelper;
 import net.minecraft.client.renderer.Tessellator;
 import net.minecraft.client.renderer.VertexBuffer;
 import net.minecraft.client.renderer.vertex.DefaultVertexFormats;
+import net.minecraft.item.ItemStack;
 import net.minecraft.util.ResourceLocation;
+import net.minecraftforge.client.event.RenderTooltipEvent;
+import net.minecraftforge.common.MinecraftForge;
 
 import org.lwjgl.opengl.GL11;
 
 import java.util.ArrayList;
 import java.util.List;
+
+import javax.annotation.Nullable;
 
 /**
  * This class provides several methods and constants used by the Config GUI classes.
@@ -198,6 +203,26 @@ public class GuiUtils
         tessellator.draw();
     }
 
+    private static ItemStack cachedTooltipStack;
+
+    /**
+     * Must be called from {@code GuiScreen.renderToolTip} before {@code GuiScreen.drawHoveringText} is called.
+     * 
+     * @param stack The stack for which a tooltip is about to be drawn.
+     */
+    public static void preItemToolTip(ItemStack stack)
+    {
+        cachedTooltipStack = stack;
+    }
+    
+    /**
+     * Must be called from {@code GuiScreen.renderToolTip} after {@code GuiScreen.drawHoveringText} is called.
+     */
+    public static void postItemToolTip()
+    {
+        cachedTooltipStack = null;
+    }
+
     /**
      *  Draws a tooltip box on the screen with text in it.
      *  Automatically positions the box relative to the mouse to match Mojang's implementation.
@@ -213,10 +238,32 @@ public class GuiUtils
      *                     Set to a negative number to have no max width.
      * @param font the font for drawing the text in the tooltip box
      */
-    public static void drawHoveringText(List<String> textLines, final int mouseX, final int mouseY, final int screenWidth, final int screenHeight, final int maxTextWidth, FontRenderer font)
+    public static void drawHoveringText(List<String> textLines, int mouseX, int mouseY, int screenWidth, int screenHeight, int maxTextWidth, FontRenderer font)
+    {
+        drawHoveringText(cachedTooltipStack, textLines, mouseX, mouseY, screenWidth, screenHeight, maxTextWidth, font);
+    }
+    
+    /**
+     * Use this version if calling from somewhere where ItemStack context is available.
+     * 
+     * @see #drawHoveringText(List, int, int, int, int, int, FontRenderer)
+     */
+    public static void drawHoveringText(@Nullable final ItemStack stack, List<String> textLines, int mouseX, int mouseY, int screenWidth, int screenHeight,
+            int maxTextWidth, FontRenderer font)
     {
         if (!textLines.isEmpty())
         {
+            RenderTooltipEvent.Pre event = new RenderTooltipEvent.Pre(stack, textLines, mouseX, mouseY, screenWidth, screenHeight, maxTextWidth, font);
+            if (MinecraftForge.EVENT_BUS.post(event)) {
+                return;
+            }
+            mouseX = event.getX();
+            mouseY = event.getY();
+            screenWidth = event.getScreenWidth();
+            screenHeight = event.getScreenHeight();
+            maxTextWidth = event.getMaxWidth();
+            font = event.getFontRenderer();
+            
             GlStateManager.disableRescaleNormal();
             RenderHelper.disableStandardItemLighting();
             GlStateManager.disableLighting();
@@ -326,6 +373,9 @@ public class GuiUtils
             drawGradientRect(zLevel, tooltipX - 3, tooltipY - 3, tooltipX + tooltipTextWidth + 3, tooltipY - 3 + 1, borderColorStart, borderColorStart);
             drawGradientRect(zLevel, tooltipX - 3, tooltipY + tooltipHeight + 2, tooltipX + tooltipTextWidth + 3, tooltipY + tooltipHeight + 3, borderColorEnd, borderColorEnd);
 
+            MinecraftForge.EVENT_BUS.post(new RenderTooltipEvent.PostBackground(stack, textLines, tooltipX, tooltipY, font, tooltipTextWidth, tooltipHeight));
+            int tooltipTop = tooltipY;
+            
             for (int lineNumber = 0; lineNumber < textLines.size(); ++lineNumber)
             {
                 String line = textLines.get(lineNumber);
@@ -338,6 +388,8 @@ public class GuiUtils
 
                 tooltipY += 10;
             }
+
+            MinecraftForge.EVENT_BUS.post(new RenderTooltipEvent.PostText(stack, textLines, tooltipX, tooltipTop, font, tooltipTextWidth, tooltipHeight));
 
             GlStateManager.enableLighting();
             GlStateManager.enableDepth();


### PR DESCRIPTION
This event provides a way to hook into tooltip rendering, where the GUI methods fall short. For instance, with this event, custom rendering could be done that would always match the true position of the tooltip box, without reproducing the calculations that led to it.

I will be adding javadocs come tomorrow, but I figured i'd put the code up for review now.

