### PR TITLE
Remove duplicated universal buckets from the creative list

### DIFF
--- a/src/main/java/net/minecraftforge/fluids/UniversalBucket.java
+++ b/src/main/java/net/minecraftforge/fluids/UniversalBucket.java
@@ -85,12 +85,15 @@ public class UniversalBucket extends Item implements IFluidContainerItem
     {
         for (Fluid fluid : FluidRegistry.getRegisteredFluids().values())
         {
-            // add all fluids that the bucket can be filled  with
-            FluidStack fs = new FluidStack(fluid, getCapacity());
-            ItemStack stack = new ItemStack(this);
-            if (fill(stack, fs, true) == fs.amount)
+            if (fluid != FluidRegistry.WATER && fluid != FluidRegistry.LAVA && !fluid.getName().equals("milk"))
             {
-                subItems.add(stack);
+                // add all fluids that the bucket can be filled  with
+                FluidStack fs = new FluidStack(fluid, getCapacity());
+                ItemStack stack = new ItemStack(this);
+                if (fill(stack, fs, true) == fs.amount)
+                {
+                    subItems.add(stack);
+                }
             }
         }
     }


### PR DESCRIPTION
Vanilla water, lava, and milk buckets are already in the creative list. 
When the universal bucket adds all its subitems, it adds them a second time.
This PR stops the universal bucket from creating subitems for water, lava, and milk.