### PR TITLE
Add Forge fluid handler test

### DIFF
--- a/src/test/java/net/minecraftforge/debug/DynBucketTest.java
+++ b/src/test/java/net/minecraftforge/debug/DynBucketTest.java
@@ -54,9 +54,14 @@ public class DynBucketTest
     private static final ResourceLocation simpleTankName = new ResourceLocation(MODID, "simpletank");
     private static final ResourceLocation testItemName = new ResourceLocation(MODID, "testitem");
 
+    private static final boolean ENABLE = false;
+
     static
     {
-        FluidRegistry.enableUniversalBucket();
+        if (ENABLE)
+        {
+            FluidRegistry.enableUniversalBucket();
+        }
     }
 
     @SidedProxy
@@ -78,6 +83,9 @@ public class DynBucketTest
         @Override
         void setupModels()
         {
+            if (!ENABLE)
+                return;
+
             ModelLoader.setBucketModelDefinition(dynBucket);
 
             final ModelResourceLocation bottle = new ModelResourceLocation(new ResourceLocation("forge", "dynbottle"), "inventory");
@@ -99,6 +107,9 @@ public class DynBucketTest
     @EventHandler
     public void preInit(FMLPreInitializationEvent event)
     {
+        if (!ENABLE)
+            return;
+
         GameRegistry.register(new TestItem(), testItemName);
         Block tank = new BlockSimpleTank();
         GameRegistry.register(tank, simpleTankName);

--- a/src/test/java/net/minecraftforge/debug/ModelFluidDebug.java
+++ b/src/test/java/net/minecraftforge/debug/ModelFluidDebug.java
@@ -27,13 +27,21 @@ public class ModelFluidDebug
     public static final String MODID = "ForgeDebugModelFluid";
     public static final String VERSION = "1.0";
 
+    public static final boolean ENABLE = false;
+
     @SidedProxy
     public static CommonProxy proxy;
 
     public static final Fluid milkFluid = new Fluid("milk", new ResourceLocation("forge", "blocks/milk_still"), new ResourceLocation("forge", "blocks/milk_flow"));
 
     @EventHandler
-    public void preInit(FMLPreInitializationEvent event) { proxy.preInit(event); }
+    public void preInit(FMLPreInitializationEvent event)
+    {
+        if (ENABLE)
+        {
+            proxy.preInit(event);
+        }
+    }
 
     public static class CommonProxy
     {

--- a/src/test/java/net/minecraftforge/test/FluidHandlerTest.java
+++ b/src/test/java/net/minecraftforge/test/FluidHandlerTest.java
@@ -1,0 +1,108 @@
+package net.minecraftforge.test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import net.minecraft.creativetab.CreativeTabs;
+import net.minecraft.item.Item;
+import net.minecraft.item.ItemStack;
+import net.minecraftforge.fluids.Fluid;
+import net.minecraftforge.fluids.FluidRegistry;
+import net.minecraftforge.fluids.FluidStack;
+import net.minecraftforge.fluids.FluidUtil;
+import net.minecraftforge.fluids.capability.IFluidHandler;
+import net.minecraftforge.fml.common.FMLCommonHandler;
+import net.minecraftforge.fml.common.FMLLog;
+import net.minecraftforge.fml.common.Mod;
+import net.minecraftforge.fml.common.event.FMLLoadCompleteEvent;
+import net.minecraftforge.fml.common.registry.ForgeRegistries;
+import net.minecraftforge.fml.relauncher.Side;
+
+@Mod(modid="FluidHandlerTest", name="FluidHandlerTest", version="0.0.0")
+public class FluidHandlerTest
+{
+	public static final boolean ENABLE = false;
+
+	@Mod.EventHandler
+	public void loadComplete(FMLLoadCompleteEvent event)
+	{
+		if (!ENABLE || FMLCommonHandler.instance().getSide() != Side.CLIENT)
+			return;
+
+		for (ItemStack stack : getAllItems())
+		{
+			testFluidContainer(stack);
+		}
+	}
+
+	private static void testFluidContainer(ItemStack stack)
+	{
+		ItemStack drainedStack = stack.copy();
+		IFluidHandler fluidHandler = FluidUtil.getFluidHandler(drainedStack);
+		if (fluidHandler != null)
+		{
+			FluidStack drain = fluidHandler.drain(Integer.MAX_VALUE, true);
+			FMLLog.info("Draining " + stackString(stack) + " gives " + fluidString(drain) + " and " + stackString(drainedStack));
+
+			for (Fluid fluid : FluidRegistry.getRegisteredFluids().values())
+			{
+				ItemStack filledStack = stack.copy();
+				fluidHandler = FluidUtil.getFluidHandler(filledStack);
+				if (fluidHandler != null)
+				{
+					int filled = fluidHandler.fill(new FluidStack(fluid, Integer.MAX_VALUE), true);
+					if (filled > 0)
+					{
+						FMLLog.info("Filling " + stackString(stack) + " with " + fluidString(new FluidStack(fluid, filled)) + " gives " + stackString(filledStack));
+					}
+				}
+			}
+		}
+	}
+
+	private static String fluidString(FluidStack stack)
+	{
+		if (stack == null)
+		{
+			return "no fluid";
+		}
+		else
+		{
+			return stack.amount + "mB " + stack.getLocalizedName();
+		}
+	}
+
+	private static String stackString(ItemStack stack)
+	{
+		if (stack == null || stack.stackSize <= 0)
+		{
+			return "no item";
+		}
+		else
+		{
+			String resourceDomain;
+			if (stack.getItem() == null || stack.getItem().getRegistryName() == null)
+			{
+				resourceDomain = "unknown";
+			}
+			else
+			{
+				resourceDomain = stack.getItem().getRegistryName().getResourceDomain();
+			}
+			return stack.stackSize + " " + stack.getDisplayName() + " (" + resourceDomain + ")";
+		}
+	}
+
+	private static List<ItemStack> getAllItems()
+	{
+		List<ItemStack> list = new ArrayList<ItemStack>();
+		for (Item item : ForgeRegistries.ITEMS.getValues())
+		{
+			for (CreativeTabs tab : item.getCreativeTabs())
+			{
+				item.getSubItems(item, tab, list);
+			}
+		}
+		return list;
+	}
+}


### PR DESCRIPTION
This adds a test for all fluids and containers, based on @HenryLoenwind's in #3033
It nicely formats the output so that it's easy to check that things are working correctly.

This is disabled by default, you have a set a boolean at the top to enable it. This PR also makes some other tests disabled by default, they register fluids and containers that interfere with this test.

Example output snippet:
```
Draining 1 Bucket (minecraft) gives no fluid and 1 Bucket (minecraft)
Filling 1 Bucket (minecraft) with 1000mB Fire Water gives 1 Fire Water Bucket (forge)
Filling 1 Bucket (minecraft) with 1000mB Liquid XP gives 1 Liquid XP Bucket (forge)
Filling 1 Bucket (minecraft) with 1000mB Liquid Sunshine gives 1 Liquid Sunshine Bucket (forge)
Filling 1 Bucket (minecraft) with 1000mB Hootch gives 1 Hootch Bucket (forge)
Filling 1 Bucket (minecraft) with 1000mB Cloud Seed gives 1 Cloud Seed Bucket (forge)
Filling 1 Bucket (minecraft) with 1000mB Water gives 1 Water Bucket (minecraft)
Filling 1 Bucket (minecraft) with 1000mB Rocket Fuel gives 1 Rocket Fuel Bucket (forge)
Filling 1 Bucket (minecraft) with 1000mB Nutrient Distillation gives 1 Nutrient Distillation Bucket (forge)
Filling 1 Bucket (minecraft) with 1000mB Lava gives 1 Lava Bucket (minecraft)
Filling 1 Bucket (minecraft) with 1000mB Concentrated Cloud Seed gives 1 Concentrated Cloud Seed Bucket (forge)
Draining 1 Water Bucket (minecraft) gives 1000mB Water and 1 Bucket (minecraft)
Draining 1 Lava Bucket (minecraft) gives 1000mB Lava and 1 Bucket (minecraft)
Draining 1 Milk (minecraft) gives no fluid and 1 Milk (minecraft)
Draining 1 Glass Bottle (minecraft) gives no fluid and 1 Glass Bottle (minecraft)
Filling 1 Glass Bottle (minecraft) with 1000mB Water gives 1 Water Bottle (minecraft)
```
Full example output:
https://gist.github.com/mezz/61a7d0c2523d06115708c3c22acc0b04