### PR TITLE
Fix FluidContainerRegistry handling potions as water bottles

### DIFF
--- a/src/main/java/net/minecraftforge/fluids/FluidContainerRegistry.java
+++ b/src/main/java/net/minecraftforge/fluids/FluidContainerRegistry.java
@@ -74,6 +74,7 @@ public abstract class FluidContainerRegistry
             ContainerKey ck = (ContainerKey)o;
             if (container.getItem() != ck.container.getItem()) return false;
             if (container.getItemDamage() != ck.container.getItemDamage()) return false;
+            if (!ItemStack.areItemStackTagsEqual(container, ck.container)) return false;
             if (fluid == null && ck.fluid != null) return false;
             if (fluid != null && ck.fluid == null) return false;
             if (fluid == null && ck.fluid == null) return true;


### PR DESCRIPTION
The `FluidContainerRegistry` incorrectly thinks that potions can be drained for water.

The water bottle and potions share an item. Before, only the water bottle could be filled and drained with water. This is a bug that appeared recently, when potions started using NBT instead of meta.  `FluidContainerRegistry` only checks meta, not NBT. This PR makes it check the item NBT too, so that only water bottles can be filled and emptied.