### PR TITLE
PlayerInteractEvent - Allow result to be changed

### DIFF
--- a/patches/minecraft/net/minecraft/client/multiplayer/PlayerControllerMP.java.patch
+++ b/patches/minecraft/net/minecraft/client/multiplayer/PlayerControllerMP.java.patch
@@ -87,7 +87,7 @@
 +            {
 +                // Give the server a chance to fire event as well. That way server event is not dependant on client event.
 +                this.field_78774_b.func_147297_a(new CPacketPlayerTryUseItemOnBlock(p_187099_4_, p_187099_5_, p_187099_7_, f, f1, f2));
-+                return EnumActionResult.PASS;
++                return event.getSubstituteResult();
 +            }
 +            EnumActionResult result = EnumActionResult.PASS;
 +
@@ -142,15 +142,16 @@
                  }
              }
              else
-@@ -446,6 +480,7 @@
+@@ -446,6 +480,8 @@
              }
              else
              {
-+                if (net.minecraftforge.common.ForgeHooks.onItemRightClick(p_187101_1_, p_187101_4_, p_187101_3_)) return net.minecraft.util.EnumActionResult.PASS;
++                net.minecraftforge.event.entity.player.PlayerInteractEvent.RightClickItem evt = net.minecraftforge.common.ForgeHooks.onItemRightClick(p_187101_1_, p_187101_4_, p_187101_3_);
++                if(evt.isCanceled()) return evt.getSubstituteResult();
                  int i = p_187101_3_.field_77994_a;
                  ActionResult<ItemStack> actionresult = p_187101_3_.func_77957_a(p_187101_2_, p_187101_1_, p_187101_4_);
                  ItemStack itemstack = (ItemStack)actionresult.func_188398_b();
-@@ -454,9 +489,10 @@
+@@ -454,9 +490,10 @@
                  {
                      p_187101_1_.func_184611_a(p_187101_4_, itemstack);
  
@@ -162,11 +163,12 @@
                      }
                  }
  
-@@ -494,6 +530,7 @@
+@@ -494,6 +531,8 @@
          this.func_78750_j();
          Vec3d vec3d = new Vec3d(p_187102_3_.field_72307_f.field_72450_a - p_187102_2_.field_70165_t, p_187102_3_.field_72307_f.field_72448_b - p_187102_2_.field_70163_u, p_187102_3_.field_72307_f.field_72449_c - p_187102_2_.field_70161_v);
          this.field_78774_b.func_147297_a(new CPacketUseEntity(p_187102_2_, p_187102_5_, vec3d));
-+        if(net.minecraftforge.common.ForgeHooks.onInteractEntityAt(p_187102_1_, p_187102_2_, p_187102_3_, p_187102_1_.func_184586_b(p_187102_5_), p_187102_5_)) return EnumActionResult.PASS;
++        net.minecraftforge.event.entity.player.PlayerInteractEvent.EntityInteractSpecific evt =  net.minecraftforge.common.ForgeHooks.onInteractEntityAt(p_187102_1_, p_187102_2_, p_187102_3_, p_187102_1_.func_184586_b(p_187102_5_), p_187102_5_);
++        if(evt.isCanceled()) return evt.getSubstituteResult();
          return this.field_78779_k == WorldSettings.GameType.SPECTATOR ? EnumActionResult.PASS : p_187102_2_.func_184199_a(p_187102_1_, vec3d, p_187102_4_, p_187102_5_);
      }
  

--- a/patches/minecraft/net/minecraft/entity/player/EntityPlayer.java.patch
+++ b/patches/minecraft/net/minecraft/entity/player/EntityPlayer.java.patch
@@ -219,15 +219,16 @@
              p_70665_2_ = this.func_70672_c(p_70665_1_, p_70665_2_);
              float f = p_70665_2_;
              p_70665_2_ = Math.max(p_70665_2_ - this.func_110139_bj(), 0.0F);
-@@ -1071,6 +1140,7 @@
+@@ -1071,6 +1140,8 @@
          }
          else
          {
-+            if (net.minecraftforge.common.ForgeHooks.onInteractEntity(this, p_184822_1_, p_184822_2_, p_184822_3_)) return EnumActionResult.PASS;
++            net.minecraftforge.event.entity.player.PlayerInteractEvent.EntityInteract evt = net.minecraftforge.common.ForgeHooks.onInteractEntity(this, p_184822_1_, p_184822_2_, p_184822_3_);
++            if(evt.isCanceled()) return evt.getSubstituteResult();
              ItemStack itemstack = p_184822_2_ != null ? p_184822_2_.func_77946_l() : null;
  
              if (!p_184822_1_.func_184230_a(this, p_184822_2_, p_184822_3_))
-@@ -1086,6 +1156,7 @@
+@@ -1086,6 +1157,7 @@
                      {
                          if (p_184822_2_.field_77994_a <= 0 && !this.field_71075_bZ.field_75098_d)
                          {
@@ -235,7 +236,7 @@
                              this.func_184611_a(p_184822_3_, (ItemStack)null);
                          }
  
-@@ -1101,6 +1172,7 @@
+@@ -1101,6 +1173,7 @@
                  {
                      if (p_184822_2_.field_77994_a <= 0 && !this.field_71075_bZ.field_75098_d)
                      {
@@ -243,7 +244,7 @@
                          this.func_184611_a(p_184822_3_, (ItemStack)null);
                      }
                      else if (p_184822_2_.field_77994_a < itemstack.field_77994_a && this.field_71075_bZ.field_75098_d)
-@@ -1127,6 +1199,7 @@
+@@ -1127,6 +1200,7 @@
  
      public void func_71059_n(Entity p_71059_1_)
      {
@@ -251,7 +252,7 @@
          if (p_71059_1_.func_70075_an())
          {
              if (!p_71059_1_.func_85031_j(this))
-@@ -1326,6 +1399,7 @@
+@@ -1326,6 +1400,7 @@
                              if (itemstack1.field_77994_a <= 0)
                              {
                                  this.func_184611_a(EnumHand.MAIN_HAND, (ItemStack)null);
@@ -259,7 +260,7 @@
                              }
                          }
  
-@@ -1414,6 +1488,8 @@
+@@ -1414,6 +1489,8 @@
  
      public EntityPlayer.SleepResult func_180469_a(BlockPos p_180469_1_)
      {
@@ -268,7 +269,7 @@
          if (!this.field_70170_p.field_72995_K)
          {
              if (this.func_70608_bn() || !this.func_70089_S())
-@@ -1453,9 +1529,10 @@
+@@ -1453,9 +1530,10 @@
  
          this.func_70105_a(0.2F, 0.2F);
  
@@ -282,7 +283,7 @@
              float f = 0.5F;
              float f1 = 0.5F;
  
-@@ -1518,13 +1595,14 @@
+@@ -1518,13 +1596,14 @@
  
      public void func_70999_a(boolean p_70999_1_, boolean p_70999_2_, boolean p_70999_3_)
      {
@@ -300,7 +301,7 @@
  
              if (blockpos == null)
              {
-@@ -1533,6 +1611,10 @@
+@@ -1533,6 +1612,10 @@
  
              this.func_70107_b((double)((float)blockpos.func_177958_n() + 0.5F), (double)((float)blockpos.func_177956_o() + 0.1F), (double)((float)blockpos.func_177952_p() + 0.5F));
          }
@@ -311,7 +312,7 @@
  
          this.field_71083_bS = false;
  
-@@ -1551,15 +1633,16 @@
+@@ -1551,15 +1634,16 @@
  
      private boolean func_175143_p()
      {
@@ -331,7 +332,7 @@
          {
              if (!p_180467_2_)
              {
-@@ -1574,16 +1657,17 @@
+@@ -1574,16 +1658,17 @@
          }
          else
          {
@@ -352,7 +353,7 @@
  
              switch (enumfacing)
              {
-@@ -1623,16 +1707,24 @@
+@@ -1623,16 +1708,24 @@
  
      public BlockPos func_180470_cg()
      {
@@ -379,7 +380,7 @@
          if (p_180473_1_ != null)
          {
              this.field_71077_c = p_180473_1_;
-@@ -1827,6 +1919,10 @@
+@@ -1827,6 +1920,10 @@
  
              super.func_180430_e(p_180430_1_, p_180430_2_);
          }
@@ -390,7 +391,7 @@
      }
  
      protected void func_71061_d_()
-@@ -2027,6 +2123,18 @@
+@@ -2027,6 +2124,18 @@
          this.field_175152_f = p_71049_1_.field_175152_f;
          this.field_71078_a = p_71049_1_.field_71078_a;
          this.func_184212_Q().func_187227_b(field_184827_bp, p_71049_1_.func_184212_Q().func_187225_a(field_184827_bp));
@@ -409,7 +410,7 @@
      }
  
      protected boolean func_70041_e_()
-@@ -2126,7 +2234,10 @@
+@@ -2126,7 +2235,10 @@
  
      public ITextComponent func_145748_c_()
      {
@@ -421,7 +422,7 @@
          itextcomponent.func_150256_b().func_150241_a(new ClickEvent(ClickEvent.Action.SUGGEST_COMMAND, "/msg " + this.func_70005_c_() + " "));
          itextcomponent.func_150256_b().func_150209_a(this.func_174823_aP());
          itextcomponent.func_150256_b().func_179989_a(this.func_70005_c_());
-@@ -2135,7 +2246,7 @@
+@@ -2135,7 +2247,7 @@
  
      public float func_70047_e()
      {
@@ -430,7 +431,7 @@
  
          if (this.func_70608_bn())
          {
-@@ -2346,6 +2457,161 @@
+@@ -2346,6 +2458,161 @@
          return (float)this.func_110148_a(SharedMonsterAttributes.field_188792_h).func_111126_e();
      }
  

--- a/patches/minecraft/net/minecraft/network/NetHandlerPlayServer.java.patch
+++ b/patches/minecraft/net/minecraft/network/NetHandlerPlayServer.java.patch
@@ -54,7 +54,7 @@
                  {
                      EnumHand enumhand1 = p_147340_1_.func_186994_b();
                      ItemStack itemstack1 = this.field_147369_b.func_184586_b(enumhand1);
-+                    if(net.minecraftforge.common.ForgeHooks.onInteractEntityAt(field_147369_b, entity, p_147340_1_.func_179712_b(), itemstack1, enumhand1)) return;
++                    if(net.minecraftforge.common.ForgeHooks.onInteractEntityAt(field_147369_b, entity, p_147340_1_.func_179712_b(), itemstack1, enumhand1).isCanceled()) return;
                      entity.func_184199_a(this.field_147369_b, p_147340_1_.func_179712_b(), itemstack1, enumhand1);
                  }
                  else if (p_147340_1_.func_149565_c() == CPacketUseEntity.Action.ATTACK)

--- a/patches/minecraft/net/minecraft/server/management/PlayerInteractionManager.java.patch
+++ b/patches/minecraft/net/minecraft/server/management/PlayerInteractionManager.java.patch
@@ -206,15 +206,16 @@
                  return flag1;
              }
          }
-@@ -334,6 +357,7 @@
+@@ -334,6 +357,8 @@
          }
          else
          {
-+            if (net.minecraftforge.common.ForgeHooks.onItemRightClick(p_187250_1_, p_187250_4_, p_187250_3_)) return net.minecraft.util.EnumActionResult.PASS;
++            net.minecraftforge.event.entity.player.PlayerInteractEvent.RightClickItem evt = net.minecraftforge.common.ForgeHooks.onItemRightClick(p_187250_1_, p_187250_4_, p_187250_3_);
++            if(evt.isCanceled()) return evt.getSubstituteResult();
              int i = p_187250_3_.field_77994_a;
              int j = p_187250_3_.func_77960_j();
              ActionResult<ItemStack> actionresult = p_187250_3_.func_77957_a(p_187250_2_, p_187250_1_, p_187250_4_);
-@@ -360,6 +384,7 @@
+@@ -360,6 +385,7 @@
                  if (itemstack.field_77994_a == 0)
                  {
                      p_187250_1_.func_184611_a(p_187250_4_, (ItemStack)null);
@@ -222,14 +223,14 @@
                  }
  
                  if (!p_187250_1_.func_184587_cr())
-@@ -404,13 +429,26 @@
+@@ -404,13 +430,26 @@
          }
          else
          {
 -            if (!p_187251_1_.func_70093_af() || p_187251_1_.func_184614_ca() == null && p_187251_1_.func_184592_cb() == null)
 +            net.minecraftforge.event.entity.player.PlayerInteractEvent.RightClickBlock event = net.minecraftforge.common.ForgeHooks
 +                    .onRightClickBlock(p_187251_1_, p_187251_4_, p_187251_3_, p_187251_5_, p_187251_6_, net.minecraftforge.common.ForgeHooks.rayTraceEyeHitVec(field_73090_b, getBlockReachDistance() + 1));
-+            if (event.isCanceled()) return EnumActionResult.PASS;
++            if (event.isCanceled()) return event.getSubstituteResult();
 +
 +            net.minecraft.item.Item item = p_187251_3_ == null ? null : p_187251_3_.func_77973_b();
 +            EnumActionResult ret = item == null ? EnumActionResult.PASS : item.onItemUseFirst(p_187251_3_, p_187251_1_, p_187251_2_, p_187251_5_, p_187251_6_, p_187251_7_, p_187251_8_, p_187251_9_, p_187251_4_);
@@ -252,7 +253,7 @@
                  }
              }
  
-@@ -430,14 +468,21 @@
+@@ -430,14 +469,21 @@
              {
                  int j = p_187251_3_.func_77960_j();
                  int i = p_187251_3_.field_77994_a;
@@ -274,7 +275,7 @@
              }
          }
      }
-@@ -446,4 +491,13 @@
+@@ -446,4 +492,13 @@
      {
          this.field_73092_a = p_73080_1_;
      }

--- a/src/main/java/net/minecraftforge/common/ForgeHooks.java
+++ b/src/main/java/net/minecraftforge/common/ForgeHooks.java
@@ -947,25 +947,31 @@ public class ForgeHooks
         return git == null ? null : git.hitVec;
     }
 
-    public static boolean onInteractEntityAt(EntityPlayer player, Entity entity, RayTraceResult ray, ItemStack stack, EnumHand hand)
+    public static PlayerInteractEvent.EntityInteractSpecific onInteractEntityAt(EntityPlayer player, Entity entity, RayTraceResult ray, ItemStack stack, EnumHand hand)
     {
         Vec3d vec3d = new Vec3d(ray.hitVec.xCoord - entity.posX, ray.hitVec.yCoord - entity.posY, ray.hitVec.zCoord - entity.posZ);
         return onInteractEntityAt(player, entity, vec3d, stack, hand);
     }
 
-    public static boolean onInteractEntityAt(EntityPlayer player, Entity entity, Vec3d vec3d, ItemStack stack, EnumHand hand)
+    public static PlayerInteractEvent.EntityInteractSpecific onInteractEntityAt(EntityPlayer player, Entity entity, Vec3d vec3d, ItemStack stack, EnumHand hand)
     {
-        return MinecraftForge.EVENT_BUS.post(new PlayerInteractEvent.EntityInteractSpecific(player, hand, stack, entity, vec3d));
+        PlayerInteractEvent.EntityInteractSpecific evt = new PlayerInteractEvent.EntityInteractSpecific(player, hand, stack, entity, vec3d);
+        MinecraftForge.EVENT_BUS.post(evt);
+        return evt;
     }
 
-    public static boolean onInteractEntity(EntityPlayer player, Entity entity, ItemStack item, EnumHand hand)
+    public static PlayerInteractEvent.EntityInteract onInteractEntity(EntityPlayer player, Entity entity, ItemStack item, EnumHand hand)
     {
-        return MinecraftForge.EVENT_BUS.post(new PlayerInteractEvent.EntityInteract(player, hand, item, entity));
+        PlayerInteractEvent.EntityInteract evt = new PlayerInteractEvent.EntityInteract(player, hand, item, entity);
+        MinecraftForge.EVENT_BUS.post(evt);
+        return evt;
     }
 
-    public static boolean onItemRightClick(EntityPlayer player, EnumHand hand, ItemStack stack)
+    public static PlayerInteractEvent.RightClickItem onItemRightClick(EntityPlayer player, EnumHand hand, ItemStack stack)
     {
-        return MinecraftForge.EVENT_BUS.post(new PlayerInteractEvent.RightClickItem(player, hand, stack));
+        PlayerInteractEvent.RightClickItem evt = new PlayerInteractEvent.RightClickItem(player, hand, stack);
+        MinecraftForge.EVENT_BUS.post(evt);
+        return evt;
     }
 
     public static PlayerInteractEvent.LeftClickBlock onLeftClickBlock(EntityPlayer player, BlockPos pos, EnumFacing face, Vec3d hitVec)

--- a/src/main/java/net/minecraftforge/event/entity/player/PlayerInteractEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/player/PlayerInteractEvent.java
@@ -1,21 +1,20 @@
 package net.minecraftforge.event.entity.player;
 
 import com.google.common.base.Preconditions;
-import net.minecraft.block.state.IBlockState;
 import net.minecraft.entity.Entity;
-import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemStack;
+import net.minecraft.util.EnumActionResult;
 import net.minecraft.util.EnumFacing;
 import net.minecraft.util.EnumHand;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.Vec3d;
-import net.minecraft.world.IBlockAccess;
 import net.minecraft.world.World;
 import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.fml.common.eventhandler.Cancelable;
 import net.minecraftforge.fml.relauncher.Side;
 
+import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
 import static net.minecraftforge.fml.common.eventhandler.Event.Result.DEFAULT;
@@ -25,6 +24,9 @@ import static net.minecraftforge.fml.common.eventhandler.Event.Result.DENY;
  * PlayerInteractEvent is fired when a player interacts in some way.
  * All subclasses are fired on {@link MinecraftForge#EVENT_BUS}.
  * See the individual documentation on each subevent for more details.
+ *
+ * Note that in general, these events occur on the server independently from the client.
+ * Thus, handling things differently on the two sides may result in desynchronization!
  **/
 public class PlayerInteractEvent extends PlayerEvent
 {
@@ -43,18 +45,51 @@ public class PlayerInteractEvent extends PlayerEvent
     }
 
     /**
+     * Marker for all the events related to right click.
+     */
+    public static class RightClick extends PlayerInteractEvent {
+
+        private EnumActionResult substituteResult;
+
+        private RightClick(EntityPlayer player, EnumHand hand, ItemStack stack, BlockPos pos, EnumFacing face) {
+            super(player, hand, stack, pos, face);
+            this.substituteResult = EnumActionResult.PASS;
+        }
+
+        /**
+         * @return The substitute result to use when a right click interaction is canceled. See each event for more information.
+         */
+        @Nonnull
+        public EnumActionResult getSubstituteResult()
+        {
+            return substituteResult;
+        }
+
+        /**
+         * Sets the substitute result to use when a right click interaction is canceled.
+         * @param result The result to use when this event is canceled.
+         */
+        public void setSubstituteResult(EnumActionResult result)
+        {
+            this.substituteResult = result;
+        }
+
+    }
+
+    /**
      * This event is fired on both sides whenever a player right clicks an entity.
      *
      * "Interact at" is an interact where the local vector (which part of the entity you clicked) is known.
      * The state of this event affects whether {@link Entity#applyPlayerInteraction} is called.
-     * If {@link Entity#applyPlayerInteraction} returns {@link net.minecraft.util.EnumActionResult#SUCCESS}, then processing ends.
-     * Otherwise processing will continue to {@link EntityInteract}
      *
-     * Canceling the event clientside will cause processing to continue to {@link EntityInteract},
-     * while canceling serverside will simply do no further processing.
+     * If the event is canceled, the value of {@link #substituteResult}
+     * is used as a result instead of calling the above method.
+     *
+     * If this result is {@link EnumActionResult#SUCCESS}, then processing ends.
+     * Otherwise, the client will attempt the next interaction, {@link EntityInteract}.
      */
     @Cancelable
-    public static class EntityInteractSpecific extends PlayerInteractEvent
+    public static class EntityInteractSpecific extends RightClick
     {
         private final Vec3d localPos;
         private final Entity target;
@@ -87,17 +122,16 @@ public class PlayerInteractEvent extends PlayerEvent
      * This event is fired on both sides when the player right clicks an entity.
      * It is responsible for all general entity interactions.
      *
-     * This event is fired completely independently of the above {@link EntityInteractSpecific}, except for the case
-     * where the above call to {@link Entity#applyPlayerInteraction} returns {@link net.minecraft.util.EnumActionResult#SUCCESS}.
-     * In that case, general entity interactions, and hence this event, will not be called. See the above javadoc for more details.
+     * The state of this event affects whether {@link Entity#processInitialInteract} and {@link net.minecraft.item.Item#itemInteractionForEntity} are called.
      *
-     * This event's state affects whether {@link Entity#processInitialInteract} and {@link net.minecraft.item.Item#itemInteractionForEntity} are called.
+     * If the event is canceled, the value of {@link #substituteResult}
+     * is used as a result instead of calling the above two methods.
      *
-     * Canceling the event clientside will cause processing to continue to {@link RightClickItem},
-     * while canceling serverside will simply do no further processing.
+     * If this result is {@link EnumActionResult#SUCCESS}, then processing ends.
+     * Otherwise, the client will attempt the next interaction, {@link RightClickItem} or {@link RightClickEmpty}.
      */
     @Cancelable
-    public static class EntityInteract extends PlayerInteractEvent
+    public static class EntityInteract extends RightClick
     {
         private final Entity target;
 
@@ -115,14 +149,18 @@ public class PlayerInteractEvent extends PlayerEvent
 
     /**
      * This event is fired on both sides whenever the player right clicks while targeting a block.
-     * This event controls which of {@link net.minecraft.block.Block#onBlockActivated} and/or {@link net.minecraft.item.Item#onItemUse}
-     * will be called after {@link net.minecraft.item.Item#onItemUseFirst} is called.
-     * Canceling the event will cause none of the above three to be called.
-     * There are various results to this event, see the getters below.
-     * Note that handling things differently on the client vs server may cause desynchronizations!
+     *
+     * The state of this event controls which of {@link net.minecraft.block.Block#onBlockActivated} and/or {@link net.minecraft.item.Item#onItemUse}
+     * will be called after {@link net.minecraft.item.Item#onItemUseFirst} is called. See the getters below.
+     *
+     * If the event is canceled, the value of {@link #substituteResult}
+     * is used as a result instead of calling the above three methods.
+     *
+     * If this result is {@link EnumActionResult#SUCCESS}, then processing ends.
+     * Otherwise, the client will attempt the next interaction, {@link RightClickItem} or {@link RightClickEmpty}.
      */
     @Cancelable
-    public static class RightClickBlock extends PlayerInteractEvent
+    public static class RightClickBlock extends RightClick
     {
         private Result useBlock = DEFAULT;
         private Result useItem = DEFAULT;
@@ -177,27 +215,20 @@ public class PlayerInteractEvent extends PlayerEvent
         {
             this.useItem = triggerItem;
         }
-
-        @Override
-        public void setCanceled(boolean canceled)
-        {
-            super.setCanceled(canceled);
-            if (canceled)
-            {
-                useBlock = DENY;
-                useItem = DENY;
-            }
-        }
     }
 
     /**
      * This event is fired on both sides before the player triggers {@link net.minecraft.item.Item#onItemRightClick}.
      * Note that this is NOT fired if the player is targeting a block. For that case, see {@link RightClickBlock}.
-     * Canceling the event clientside causes processing to continue to the other hands,
-     * while canceling serverside will simply do no further processing.
+     *
+     * If the event is canceled, the value of {@link #substituteResult}
+     * is used as a result instead of calling the above method.
+     *
+     * If this result is {@link EnumActionResult#SUCCESS}, then processing ends.
+     * Otherwise, the client will attempt interactions anew with the other hand, or stop if this is the last hand.
      */
     @Cancelable
-    public static class RightClickItem extends PlayerInteractEvent
+    public static class RightClickItem extends RightClick
     {
         public RightClickItem(EntityPlayer player, EnumHand hand, ItemStack stack)
         {
@@ -208,9 +239,9 @@ public class PlayerInteractEvent extends PlayerEvent
     /**
      * This event is fired on the client side when the player right clicks empty space with an empty hand.
      * The server is not aware of when the client right clicks empty space with an empty hand, you will need to tell the server yourself.
-     * This event cannot be canceled.
+     * This event cannot be canceled and thus does not consider {@link #substituteResult}.
      */
-    public static class RightClickEmpty extends PlayerInteractEvent
+    public static class RightClickEmpty extends RightClick
     {
         public RightClickEmpty(EntityPlayer player, EnumHand hand)
         {
@@ -221,8 +252,8 @@ public class PlayerInteractEvent extends PlayerEvent
     /**
      * This event is fired when a player left clicks while targeting a block.
      * This event controls which of {@link net.minecraft.block.Block#onBlockClicked} and/or the item harvesting methods will be called
+     * See the getters below.
      * Canceling the event will cause none of the above noted methods to be called.
-     * There are various results to this event, see the getters below.
      *
      * Note that if the event is canceled and the player holds down left mouse, the event will continue to fire.
      * This is due to how vanilla calls the left click handler methods.

--- a/src/test/java/net/minecraftforge/test/PlayerInteractEventTest.java
+++ b/src/test/java/net/minecraftforge/test/PlayerInteractEventTest.java
@@ -5,9 +5,13 @@ import net.minecraft.entity.monster.EntityCreeper;
 import net.minecraft.entity.monster.EntitySkeleton;
 import net.minecraft.entity.passive.EntityHorse;
 import net.minecraft.init.Items;
+import net.minecraft.item.Item;
+import net.minecraft.item.ItemBlock;
+import net.minecraft.item.ItemStack;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.tileentity.TileEntityChest;
 import net.minecraft.tileentity.TileEntityDropper;
+import net.minecraft.util.EnumActionResult;
 import net.minecraft.util.EnumHand;
 import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.event.entity.player.PlayerInteractEvent;
@@ -70,7 +74,7 @@ public class PlayerInteractEventTest
         logger.info("HIT VEC: {}", evt.getHitVec());
 
         // Shift right clicking dropper with an item in hand should still open the dropper contrary to normal mechanics
-        // The item in hand is used as well (not specifying anything would not use the item)
+        // The item in hand is used as well (not specifying anything would not use the item) - a splash potion works well for testing this.
         TileEntity te = evt.getWorld().getTileEntity(evt.getPos());
         if (te instanceof TileEntityDropper)
         {
@@ -86,7 +90,7 @@ public class PlayerInteractEventTest
         }
 
         // Case: Flint and steel in main hand on top of a TE will light a fire, not open the TE.
-        // Note that if you do this on a chest, the f+s will fail, but then your off hand will open the chest
+        // Note that if you do this on a chest, the f+s will fail (since chests aren't full blocks), but then your off hand will open the chest
         // If you dual wield flints and steels and right click a chest nothing should happen
         if (evt.getItemStack() != null && evt.getItemStack().getItem() == Items.FLINT_AND_STEEL)
             evt.setUseBlock(Event.Result.DENY);
@@ -98,9 +102,22 @@ public class PlayerInteractEventTest
         }
 
         // Spawn egg in main hand, block in offhand -> block should be placed
-        // Sword in main hand, spawn egg in offhand -> nothing should happen
-        if (evt.getItemStack() != null && evt.getItemStack().getItem() == Items.SPAWN_EGG) {
+        if (evt.getItemStack() != null
+                && evt.getItemStack().getItem() == Items.SPAWN_EGG
+                && evt.getHand() == EnumHand.MAIN_HAND
+                && evt.getEntityPlayer().getHeldItemOffhand() != null
+                && evt.getEntityPlayer().getHeldItemOffhand().getItem() instanceof ItemBlock) {
             evt.setCanceled(true);
+        }
+
+        // Spawn egg in main hand, block in offhand -> potion should NOT be thrown
+        if (evt.getItemStack() != null
+                && evt.getItemStack().getItem() == Items.SPAWN_EGG
+                && evt.getHand() == EnumHand.MAIN_HAND
+                && evt.getEntityPlayer().getHeldItemOffhand() != null
+                && evt.getEntityPlayer().getHeldItemOffhand().getItem() == Items.SPLASH_POTION) {
+            evt.setCanceled(true);
+            evt.setSubstituteResult(EnumActionResult.SUCCESS); // Fake spawn egg success so splash potion does not trigger
         }
 
 
@@ -111,11 +128,25 @@ public class PlayerInteractEventTest
     {
         if (!ENABLE) return;
 
-        // Use survival mode
+        // Case: Ender pearl in main hand, block in offhand -> Block is NOT placed
+        if (evt.getItemStack() != null
+                && evt.getItemStack().getItem() == Items.ENDER_PEARL
+                && evt.getHand() == EnumHand.MAIN_HAND
+                && evt.getEntityPlayer().getHeldItemOffhand() != null
+                && evt.getEntityPlayer().getHeldItemOffhand().getItem() instanceof ItemBlock)
+        {
+            evt.setCanceled(true);
+            evt.setSubstituteResult(EnumActionResult.SUCCESS); // We fake success on the ender pearl so block is not placed
+            return;
+        }
+
         // Case: Ender pearl in main hand, bow in offhand with arrows in inv -> Bow should trigger
         // Case: Sword in main hand, ender pearl in offhand -> Nothing should happen
-
-        if (evt.getItemStack() != null && evt.getItemStack().getItem() == Items.ENDER_PEARL)
+        if (evt.getItemStack() != null
+                && evt.getItemStack().getItem() == Items.ENDER_PEARL
+                && evt.getHand() == EnumHand.MAIN_HAND
+                && evt.getEntityPlayer().getHeldItemOffhand() != null
+                && evt.getEntityPlayer().getHeldItemOffhand().getItem() instanceof ItemBlock)
             evt.setCanceled(true);
     }
 
@@ -130,7 +161,17 @@ public class PlayerInteractEventTest
                 && evt.getItemStack().getItem() == Items.IRON_HELMET)
             evt.setCanceled(true); // Should not be able to place iron helmet onto armor stand (you will put it on instead)
 
-        if (evt.getWorld().isRemote
+        if (evt.getItemStack() != null
+                && evt.getTarget() instanceof EntityArmorStand
+                && evt.getItemStack().getItem() == Items.GOLDEN_HELMET)
+        {
+            evt.setCanceled(true);
+            evt.setSubstituteResult(EnumActionResult.SUCCESS);
+            // Should not be able to place golden helmet onto armor stand
+            // However you will NOT put it on because we fake success on the armorstand.
+        }
+
+        if (!evt.getWorld().isRemote
                 && evt.getTarget() instanceof EntitySkeleton
                 && evt.getLocalPos().yCoord > evt.getTarget().height / 2.0)
         {
@@ -145,10 +186,18 @@ public class PlayerInteractEventTest
     {
         if (!ENABLE) return;
 
-        if (evt.getItemStack() != null && (evt.getTarget() instanceof EntityHorse || evt.getTarget() instanceof EntityCreeper))
+        if (evt.getItemStack() != null && evt.getTarget() instanceof EntityHorse) {
             // Should not be able to feed wild horses with golden apple (you will start eating it in survival)
-            // Should not be able to ignite creeper with F+S
-            // Applies to both hands
-            evt.setCanceled(true);
+            if (evt.getItemStack().getItem() == Items.GOLDEN_APPLE
+                    && evt.getItemStack().getItemDamage() == 0)
+                evt.setCanceled(true);
+            // Should not be able to feed wild horses with notch apple but you will NOT eat it
+            if (evt.getItemStack().getItem() == Items.GOLDEN_APPLE
+                    && evt.getItemStack().getItemDamage() == 1)
+            {
+                evt.setCanceled(true);
+                evt.setSubstituteResult(EnumActionResult.SUCCESS);
+            }
+        }
     }
 }


### PR DESCRIPTION
This PR looks enormous but it really only does one thing. I'll try to explain as clearly as I can with an example.

>> TLDR: When a right click event is cancelled, don't just return EnumActionResult.PASS, allow the modder to return their own EnumActionResult

Let's say you want to capture the event where someone right clicks a sponge block. You do something when you capture that event, and now you want to say "an interaction has occurred, please stop processing".

As it stands right now, canceling the RightClickBlock event simply makes the client keep trying other things, skipping the interaction. If you had an ender pearl in hand, for example, it would get thrown, even though you already did your own processing.

This PR makes it so that you can set an EnumActionResult that is used when the event is canceled instead of simply passing control to the next interaction. This allows someone to stop the "chain of interactions" via canceling the event.

This PR does not change default behaviour, which is to continue to the next interaction after cancellation. It should not break compatibility.

(cc @Zaggy1024)