### PR TITLE
Fix mob-spawners crashing for non-living entities

### DIFF
--- a/patches/minecraft/net/minecraft/tileentity/MobSpawnerBaseLogic.java.patch
+++ b/patches/minecraft/net/minecraft/tileentity/MobSpawnerBaseLogic.java.patch
@@ -1,14 +1,11 @@
 --- ../src-base/minecraft/net/minecraft/tileentity/MobSpawnerBaseLogic.java
 +++ ../src-work/minecraft/net/minecraft/tileentity/MobSpawnerBaseLogic.java
-@@ -117,10 +117,14 @@
+@@ -117,10 +117,11 @@
                      EntityLiving entityliving = entity instanceof EntityLiving ? (EntityLiving)entity : null;
                      entity.func_70012_b(entity.field_70165_t, entity.field_70163_u, entity.field_70161_v, world.field_73012_v.nextFloat() * 360.0F, 0.0F);
  
 -                    if (entityliving == null || entityliving.func_70601_bi() && entityliving.func_70058_J())
-+                    net.minecraftforge.fml.common.eventhandler.Event.Result canSpawn = net.minecraftforge.event.ForgeEventFactory.canEntitySpawn(entityliving, this.func_98271_a(), (float)entity.field_70165_t, (float)entity.field_70163_u, (float)entity.field_70161_v);
-+                    boolean force = canSpawn == net.minecraftforge.fml.common.eventhandler.Event.Result.ALLOW ||
-+                                (canSpawn == net.minecraftforge.fml.common.eventhandler.Event.Result.DEFAULT && (entityliving.func_70601_bi() && entityliving.func_70058_J()));
-+                    if (entityliving == null || force)
++                    if (entityliving == null || net.minecraftforge.event.ForgeEventFactory.canEntitySpawnSpawner(entityliving, func_98271_a(), (float)entity.field_70165_t, (float)entity.field_70163_u, (float)entity.field_70161_v))
                      {
                          if (this.field_98282_f.func_185277_b().func_186856_d() == 1 && this.field_98282_f.func_185277_b().func_150297_b("id", 8) && entity instanceof EntityLiving)
                          {

--- a/src/main/java/net/minecraftforge/event/ForgeEventFactory.java
+++ b/src/main/java/net/minecraftforge/event/ForgeEventFactory.java
@@ -161,6 +161,19 @@ public class ForgeEventFactory
         return event.getResult();
     }
 
+    public static boolean canEntitySpawnSpawner(EntityLiving entity, World world, float x, float y, float z)
+    {
+        Result result = canEntitySpawn(entity, world, x, y, z);
+        if (result == Result.DEFAULT)
+        {
+            return entity.getCanSpawnHere() && entity.isNotColliding(); // vanilla logic
+        }
+        else
+        {
+            return result == Result.ALLOW;
+        }
+    }
+
     public static boolean doSpecialSpawn(EntityLiving entity, World world, float x, float y, float z)
     {
         return MinecraftForge.EVENT_BUS.post(new LivingSpawnEvent.SpecialSpawn(entity, world, x, y, z));


### PR DESCRIPTION
Prevents crashes [like this](http://www.minecraftforge.net/forum/index.php/topic,40097.0.html). Also simplified the patch in the process (-1+4 to -1+1).

Let me know if you want this for 1.9.4 (master) as well.