### PR TITLE
[1.9.4] New method: EntityTameable#isTamingItem(ItemStack)

### DIFF
--- a/patches/minecraft/net/minecraft/entity/passive/EntityOcelot.java.patch
+++ b/patches/minecraft/net/minecraft/entity/passive/EntityOcelot.java.patch
@@ -1,5 +1,14 @@
 --- ../src-base/minecraft/net/minecraft/entity/passive/EntityOcelot.java
 +++ ../src-work/minecraft/net/minecraft/entity/passive/EntityOcelot.java
+@@ -188,7 +188,7 @@
+                 this.field_70911_d.func_75270_a(!this.func_70906_o());
+             }
+         }
+-        else if ((this.field_70914_e == null || this.field_70914_e.func_75277_f()) && p_184645_3_ != null && p_184645_3_.func_77973_b() == Items.field_151115_aP && p_184645_1_.func_70068_e(this) < 9.0D)
++        else if ((this.field_70914_e == null || this.field_70914_e.func_75277_f()) && isTamingItem(p_184645_3_) && p_184645_1_.func_70068_e(this) < 9.0D)
+         {
+             if (!p_184645_1_.field_71075_bZ.field_75098_d)
+             {
 @@ -288,7 +288,7 @@
              IBlockState iblockstate = this.field_70170_p.func_180495_p(blockpos.func_177977_b());
              Block block = iblockstate.func_177230_c();
@@ -9,3 +18,14 @@
              {
                  return true;
              }
+@@ -307,6 +307,10 @@
+         super.func_70903_f(p_70903_1_);
+     }
+ 
++    public boolean isTamingItem(ItemStack stack)
++    {
++        return stack != null && stack.func_77973_b() == Items.field_151115_aP;
++    }
+     protected void func_175544_ck()
+     {
+         if (this.field_175545_bm == null)

--- a/patches/minecraft/net/minecraft/entity/passive/EntityOcelot.java.patch
+++ b/patches/minecraft/net/minecraft/entity/passive/EntityOcelot.java.patch
@@ -18,14 +18,3 @@
              {
                  return true;
              }
-@@ -307,6 +307,10 @@
-         super.func_70903_f(p_70903_1_);
-     }
- 
-+    public boolean isTamingItem(ItemStack stack)
-+    {
-+        return stack != null && stack.func_77973_b() == Items.field_151115_aP;
-+    }
-     protected void func_175544_ck()
-     {
-         if (this.field_175545_bm == null)

--- a/patches/minecraft/net/minecraft/entity/passive/EntityTameable.java.patch
+++ b/patches/minecraft/net/minecraft/entity/passive/EntityTameable.java.patch
@@ -6,7 +6,7 @@
  
 +    public boolean isTamingItem(net.minecraft.item.ItemStack stack)
 +    {
-+        return false;
++        return stack != null && ((stack.func_77973_b() == net.minecraft.init.Items.field_151103_aS && this instanceof EntityWolf) || (stack.func_77973_b() == net.minecraft.init.Items.field_151115_aP && this instanceof EntityOcelot));
 +    }
 +
      public void func_70903_f(boolean p_70903_1_)

--- a/patches/minecraft/net/minecraft/entity/passive/EntityTameable.java.patch
+++ b/patches/minecraft/net/minecraft/entity/passive/EntityTameable.java.patch
@@ -1,10 +1,13 @@
 --- ../src-base/minecraft/net/minecraft/entity/passive/EntityTameable.java
 +++ ../src-work/minecraft/net/minecraft/entity/passive/EntityTameable.java
-@@ -137,6 +137,8 @@
+@@ -137,6 +137,11 @@
          return (((Byte)this.field_70180_af.func_187225_a(field_184755_bv)).byteValue() & 4) != 0;
      }
  
-+    public abstract boolean isTamingItem(net.minecraft.item.ItemStack stack);
++    public boolean isTamingItem(net.minecraft.item.ItemStack stack)
++    {
++        return false;
++    }
 +
      public void func_70903_f(boolean p_70903_1_)
      {

--- a/patches/minecraft/net/minecraft/entity/passive/EntityTameable.java.patch
+++ b/patches/minecraft/net/minecraft/entity/passive/EntityTameable.java.patch
@@ -1,0 +1,11 @@
+--- ../src-base/minecraft/net/minecraft/entity/passive/EntityTameable.java
++++ ../src-work/minecraft/net/minecraft/entity/passive/EntityTameable.java
+@@ -137,6 +137,8 @@
+         return (((Byte)this.field_70180_af.func_187225_a(field_184755_bv)).byteValue() & 4) != 0;
+     }
+ 
++    public abstract boolean isTamingItem(net.minecraft.item.ItemStack stack);
++
+     public void func_70903_f(boolean p_70903_1_)
+     {
+         byte b0 = ((Byte)this.field_70180_af.func_187225_a(field_184755_bv)).byteValue();

--- a/patches/minecraft/net/minecraft/entity/passive/EntityWolf.java.patch
+++ b/patches/minecraft/net/minecraft/entity/passive/EntityWolf.java.patch
@@ -1,18 +1,6 @@
 --- ../src-base/minecraft/net/minecraft/entity/passive/EntityWolf.java
 +++ ../src-work/minecraft/net/minecraft/entity/passive/EntityWolf.java
-@@ -355,6 +355,11 @@
-         this.func_110148_a(SharedMonsterAttributes.field_111264_e).func_111128_a(4.0D);
-     }
- 
-+    public boolean isTamingItem(ItemStack stack)
-+    {
-+        return stack != null && stack.func_77973_b() == Items.field_151103_aS;
-+    }
-+
-     public boolean func_184645_a(EntityPlayer p_184645_1_, EnumHand p_184645_2_, @Nullable ItemStack p_184645_3_)
-     {
-         if (this.func_70909_n())
-@@ -402,7 +407,7 @@
+@@ -402,7 +402,7 @@
                  this.func_70624_b((EntityLivingBase)null);
              }
          }

--- a/patches/minecraft/net/minecraft/entity/passive/EntityWolf.java.patch
+++ b/patches/minecraft/net/minecraft/entity/passive/EntityWolf.java.patch
@@ -1,0 +1,23 @@
+--- ../src-base/minecraft/net/minecraft/entity/passive/EntityWolf.java
++++ ../src-work/minecraft/net/minecraft/entity/passive/EntityWolf.java
+@@ -355,6 +355,11 @@
+         this.func_110148_a(SharedMonsterAttributes.field_111264_e).func_111128_a(4.0D);
+     }
+ 
++    public boolean isTamingItem(ItemStack stack)
++    {
++        return stack != null && stack.func_77973_b() == Items.field_151103_aS;
++    }
++
+     public boolean func_184645_a(EntityPlayer p_184645_1_, EnumHand p_184645_2_, @Nullable ItemStack p_184645_3_)
+     {
+         if (this.func_70909_n())
+@@ -402,7 +407,7 @@
+                 this.func_70624_b((EntityLivingBase)null);
+             }
+         }
+-        else if (p_184645_3_ != null && p_184645_3_.func_77973_b() == Items.field_151103_aS && !this.func_70919_bu())
++        else if (isTamingItem(p_184645_3_) && !this.func_70919_bu())
+         {
+             if (!p_184645_1_.field_71075_bZ.field_75098_d)
+             {


### PR DESCRIPTION
This PR adds a new method to EntityTameable, `isTamingItem`. It returns a boolean, and takes an ItemStack. This allows us to write code relating to taming such that:

``` java
Entity entity = getEntity();
if (entity instanceof EntityTameable) {
    EntityTameable entityTameable = (EntityTameable) entity;
    if ((entityTameable instanceof EntityWolf && myItemStack.getItem() == Items.BONE) || (entityTameable instanceof EntityOcelot && myItemStack.getItem() == Items.FISH)) {
        doStuff();
    }
}
```

can become

``` java
Entity entity = getEntity();
if (entity instanceof EntityTameable) {
    EntityTameable entityTameable = (EntityTameable) entity;
    if (entityTameable.isTamingItem(myItemStack)) {
        doStuff();
    }
}
```

which allows us to easily support other mods' EntityTameables, write shorter code, and change isTamingItem without having to modify code anywhere else.

If you want an actual use case, my mod ChaoticKarma has custom behavior when an entity is tamed. I just noticed a bug caused by stupidly using isBreedingItem instead of that first code sample above. With this patch, I'd be able to simply use `tameable.isTamingItem(itemstack) && !tameable.isTamed()`.

**side note**
If I should have submitted this to master, let me know and I'll resubmit it. I didn't find that anywhere on the wiki or CONTRIBUTING.md, and I assumed that that branch was for whatever the latest stuff is, so probably 1.10.
