### PR TITLE
[1.10.0] Added access to the auto-jump distance

### DIFF
--- a/patches/minecraft/net/minecraft/client/entity/EntityPlayerSP.java.patch
+++ b/patches/minecraft/net/minecraft/client/entity/EntityPlayerSP.java.patch
@@ -1,6 +1,14 @@
 --- ../src-base/minecraft/net/minecraft/client/entity/EntityPlayerSP.java
 +++ ../src-work/minecraft/net/minecraft/client/entity/EntityPlayerSP.java
-@@ -415,6 +415,15 @@
+@@ -111,6 +111,7 @@
+     private boolean field_189811_cr = true;
+     private int field_189812_cs;
+     private boolean field_189813_ct;
++    private float autoJumpDistance = 7.0f;
+ 
+     public EntityPlayerSP(Minecraft p_i46278_1_, World p_i46278_2_, NetHandlerPlayClient p_i46278_3_, StatisticsManager p_i46278_4_)
+     {
+@@ -415,6 +416,15 @@
          this.field_71159_c.field_71456_v.func_146158_b().func_146227_a(p_146105_1_);
      }
  
@@ -16,7 +24,7 @@
      protected boolean func_145771_j(double p_145771_1_, double p_145771_3_, double p_145771_5_)
      {
          if (this.field_70145_X)
-@@ -427,30 +436,34 @@
+@@ -427,30 +437,34 @@
              double d0 = p_145771_1_ - (double)blockpos.func_177958_n();
              double d1 = p_145771_5_ - (double)blockpos.func_177952_p();
  
@@ -56,7 +64,7 @@
                  {
                      d2 = 1.0D - d1;
                      i = 5;
-@@ -485,7 +498,7 @@
+@@ -485,7 +499,7 @@
  
      private boolean func_175162_d(BlockPos p_175162_1_)
      {
@@ -65,7 +73,7 @@
      }
  
      public void func_70031_b(boolean p_70031_1_)
-@@ -530,7 +543,13 @@
+@@ -530,7 +544,13 @@
  
      public void func_184185_a(SoundEvent p_184185_1_, float p_184185_2_, float p_184185_3_)
      {
@@ -80,3 +88,27 @@
      }
  
      public boolean func_70613_aW()
+@@ -1047,7 +1067,7 @@
+                                     f7 += (float)(this.func_70660_b(MobEffects.field_76430_j).func_76458_c() + 1) * 0.75F;
+                                 }
+ 
+-                                float f8 = Math.max(f * 7.0F, 1.0F / f12);
++                                float f8 = Math.max(f * getAutoJumpDistance(), 1.0F / f12);
+                                 Vec3d vec3d4 = vec3d1.func_178787_e(vec3d12.func_186678_a((double)f8));
+                                 float f9 = this.field_70130_N;
+                                 float f10 = this.field_70131_O;
+@@ -1132,4 +1152,14 @@
+             }
+         }
+     }
++
++    public float getAutoJumpDistance()
++    {
++        return autoJumpDistance;
++    }
++    
++    public void setAutoJumpDistance(float distance)
++    {
++        autoJumpDistance = distance;
++    }
+ }

--- a/src/test/java/net/minecraftforge/test/AutoJumpDistanceTest.java
+++ b/src/test/java/net/minecraftforge/test/AutoJumpDistanceTest.java
@@ -1,0 +1,32 @@
+package net.minecraftforge.test;
+
+import net.minecraft.client.entity.EntityPlayerSP;
+import net.minecraft.init.Items;
+import net.minecraft.item.ItemStack;
+import net.minecraftforge.common.MinecraftForge;
+import net.minecraftforge.fml.common.Mod;
+import net.minecraftforge.fml.common.Mod.EventHandler;
+import net.minecraftforge.fml.common.event.FMLInitializationEvent;
+import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
+import net.minecraftforge.fml.common.gameevent.TickEvent.PlayerTickEvent;
+
+@Mod(modid="autojumpdisancetest", name="Auto-Jump Distance Test", version="0.0.0", clientSideOnly = true)
+public class AutoJumpDistanceTest {
+
+    @EventHandler
+    public void init(FMLInitializationEvent event)
+    {
+        MinecraftForge.EVENT_BUS.register(this);
+    }
+
+    @SubscribeEvent
+    public void updateAutoJumpDistance(PlayerTickEvent e) {
+        if(e.player instanceof EntityPlayerSP){
+        	ItemStack held=e.player.getHeldItemMainhand();
+        	if( held!=null && held.getItem()==Items.STICK ){
+    			((EntityPlayerSP)e.player).setAutoJumpDistance(3F);
+        	}else
+        		((EntityPlayerSP)e.player).setAutoJumpDistance(7F);
+        }
+    }
+}


### PR DESCRIPTION
It adds a getter and a setter to the EntityPlayerSP (it's client-side) class. Setting it will change the distance the predictive auto-jump triggers at. I am not sure if having it on EntityPlayerSP is fine or not. Just tell me if you want it somewhere else.

In the test mod you can hold a stick to significantly shorten the auto-jump distance (7.0->3.0) therefore you have to get closer to the block in question in order for the auto-jump to trigger.