### PR TITLE
Add additional field map for deobfuscation to track overrides 

### DIFF
--- a/src/main/java/net/minecraftforge/fml/common/asm/transformers/deobf/FMLRemappingAdapter.java
+++ b/src/main/java/net/minecraftforge/fml/common/asm/transformers/deobf/FMLRemappingAdapter.java
@@ -20,6 +20,7 @@
 package net.minecraftforge.fml.common.asm.transformers.deobf;
 
 import org.objectweb.asm.ClassVisitor;
+import org.objectweb.asm.FieldVisitor;
 import org.objectweb.asm.MethodVisitor;
 import org.objectweb.asm.Opcodes;
 import org.objectweb.asm.commons.Remapper;
@@ -41,6 +42,16 @@ public class FMLRemappingAdapter extends RemappingClassAdapter {
         }
         FMLDeobfuscatingRemapper.INSTANCE.mergeSuperMaps(name, superName, interfaces);
         super.visit(version, access, name, signature, superName, interfaces);
+    }
+
+    @Override
+    public FieldVisitor visitField(int access, String name, String desc, String signature, Object value) {
+        FMLDeobfuscatingRemapper remapper = FMLDeobfuscatingRemapper.INSTANCE;
+        FieldVisitor fv = cv.visitField(access,
+            remapper.mapMemberFieldName(className, name, desc),
+            remapper.mapDesc(desc), remapper.mapSignature(signature, true),
+            remapper.mapValue(value));
+        return createRemappingFieldAdapter(fv);
     }
 
     @Override


### PR DESCRIPTION
This pull request represents a possible solution to #3043. I have attempted to keep the changes to a minimum to achieve clarity, however the reasons for the specific changes made may not be particularly obvious so I will attempt to describe the nature of the problem and the solution implemented here.

Apologies if this seems a little Peter-and-Jane, I wanted to make it perfectly clear what I'm trying to achieve so that any potential pitfalls of the fix can be identified more easily.

### The Problem

Consider two **vanilla** classes, `Foo` and `Bar`. `Foo` extends `Bar` in this example. In the diagram below, diamonds reprent **field declarations** and circles represent **field accesses**. The arrows represent the accesses to the fields.

![](http://eq2.co.uk/pr/obf/obf1.png)

Each **vanilla** class has mappings for its fields and methods, these are stored in associated **raw mappings** which are themselves stored in a map of classname -> raw map.

At runtime, since field names need to be resolved in super classes as well, the raw maps are merged into a single map which is then used to map field declarations and field accesses within the class. It's important to note that because the raw map contains entries for fields in `Foo`, if name conflicts occur with the superclass these are still properly resolved in the merged map. In the example, the field `Foo.b` which hides the field `Bar.b` is still remapped correctly.

![](http://eq2.co.uk/pr/obf/obf2.png)

After deobfuscation, all the fields and field accesses have the correct names:

![](http://eq2.co.uk/pr/obf/obf3.png)

Let's now consider a **non-vanilla** class `MyCustomClass` which extends the vanilla class `Bar`:

![](http://eq2.co.uk/pr/obf/obf4.png)

Since `MyCustomClass` has no raw map, it can *only* resolve field names using the merged table. This normally works as intended, except in the situation that `MyCustomClass` contains a field with the same name as an obfuscated field in the superclass.

![](http://eq2.co.uk/pr/obf/obf5.png)

This is a problem for the field `b` in this example, since the merged map contains a mapping for this field, and there is no local *raw* map to correct the problem:

![](http://eq2.co.uk/pr/obf/obf6.png)

We can resolve this problem by synthesising the raw map for our derived class, populating the raw map first with entries for the fields which exist in the class.

![](http://eq2.co.uk/pr/obf/obf7.png)

Once this is done, the merged map contains both entries for the local fields, effectively mapped to themselves (preventing them being erroneously remapped), and the unhidden field renames from the superclass are still resolved correctly.

![](http://eq2.co.uk/pr/obf/obf8.png)

### The Solution

Since in the `ClassVisitor` pattern, member fields are "visited" before the methods, we have the opportunity to populate the synthetic raw map (or insert entries into a pre-existing one) in the manner described above by overriding `VisitField` and have it perform the duty of populating the map.

This is achieved by the following:

* A helper method is added to `FMLDeobfuscatingRemapper`, `getRawFieldMap` which retrieves or creates the raw field map for a class

* A method `mapMemberFieldName` is also added, which behaves like `mapFieldName`, but **only** resolves field names in the raw map (if one exists) and immediately *stores* the mapping once resolved. This has the effect of creating the synthetic entries mentioned above.

* `FMLRemappingAdapter` is then updated to include a `visitField` overload which calls `mapMemberFieldName` instead of `mapFieldName`

The proposed changes are included in this PR.
