### PR TITLE
Add an event that allows to modify the looting level based on damagesource

### DIFF
--- a/patches/minecraft/net/minecraft/entity/EntityLivingBase.java.patch
+++ b/patches/minecraft/net/minecraft/entity/EntityLivingBase.java.patch
@@ -76,9 +76,11 @@
          if (!this.field_70729_aU)
          {
              Entity entity = p_70645_1_.func_76346_g();
-@@ -1070,11 +1076,24 @@
+@@ -1069,12 +1075,26 @@
+                 {
                      i = EnchantmentHelper.func_185283_h((EntityLivingBase)entity);
                  }
++                i = net.minecraftforge.common.ForgeHooks.getLootingLevel(this, p_70645_1_, i);
  
 +                captureDrops = true;
 +                capturedDrops.clear();

--- a/src/main/java/net/minecraftforge/common/ForgeHooks.java
+++ b/src/main/java/net/minecraftforge/common/ForgeHooks.java
@@ -109,6 +109,7 @@ import net.minecraftforge.event.entity.living.LivingEvent.LivingUpdateEvent;
 import net.minecraftforge.event.entity.living.LivingFallEvent;
 import net.minecraftforge.event.entity.living.LivingHurtEvent;
 import net.minecraftforge.event.entity.living.LivingSetAttackTargetEvent;
+import net.minecraftforge.event.entity.living.LootingLevelEvent;
 import net.minecraftforge.event.entity.player.AnvilRepairEvent;
 import net.minecraftforge.event.entity.player.AttackEntityEvent;
 import net.minecraftforge.event.entity.player.PlayerInteractEvent;
@@ -513,6 +514,12 @@ public class ForgeHooks
     {
         LivingFallEvent event = new LivingFallEvent(entity, distance, damageMultiplier);
         return (MinecraftForge.EVENT_BUS.post(event) ? null : new float[]{event.getDistance(), event.getDamageMultiplier()});
+    }
+
+    public static int getLootingLevel(EntityLivingBase target, DamageSource cause, int level) {
+        LootingLevelEvent event = new LootingLevelEvent(target, cause, level);
+        MinecraftForge.EVENT_BUS.post(event);
+        return event.getLootingLevel();
     }
 
     public static boolean isLivingOnLadder(IBlockState state, World world, BlockPos pos, EntityLivingBase entity)

--- a/src/main/java/net/minecraftforge/event/entity/living/LootingLevelEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/living/LootingLevelEvent.java
@@ -1,0 +1,29 @@
+package net.minecraftforge.event.entity.living;
+
+import net.minecraft.entity.EntityLivingBase;
+import net.minecraft.util.DamageSource;
+
+public class LootingLevelEvent extends LivingEvent {
+
+    private final DamageSource damageSource;
+
+    private int lootingLevel;
+
+    public LootingLevelEvent(EntityLivingBase entity, DamageSource damageSource, int lootingLevel) {
+        super(entity);
+        this.damageSource = damageSource;
+        this.lootingLevel = lootingLevel;
+    }
+
+    public DamageSource getDamageSource() {
+        return damageSource;
+    }
+
+    public int getLootingLevel() {
+        return lootingLevel;
+    }
+
+    public void setLootingLevel(int lootingLevel) {
+        this.lootingLevel = lootingLevel;
+    }
+}

--- a/src/test/java/net/minecraftforge/debug/LootTablesDebug.java
+++ b/src/test/java/net/minecraftforge/debug/LootTablesDebug.java
@@ -1,6 +1,9 @@
 package net.minecraftforge.debug;
 
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.entity.projectile.EntityArrow;
 import net.minecraft.init.Items;
+import net.minecraft.util.DamageSource;
 import net.minecraft.util.ResourceLocation;
 import net.minecraft.world.storage.loot.LootEntryItem;
 import net.minecraft.world.storage.loot.LootPool;
@@ -9,6 +12,7 @@ import net.minecraft.world.storage.loot.conditions.LootCondition;
 import net.minecraft.world.storage.loot.functions.LootFunction;
 import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.event.LootTableLoadEvent;
+import net.minecraftforge.event.entity.living.LootingLevelEvent;
 import net.minecraftforge.fml.common.Mod;
 import net.minecraftforge.fml.common.event.FMLInitializationEvent;
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
@@ -38,5 +42,14 @@ public class LootTablesDebug {
 
         // Get rid of all building mats. Which is pool #3, index starts at 0, but 0 is named "main"
         event.getTable().removePool("pool3");
+    }
+
+    @SubscribeEvent
+    public void lootingEvent(LootingLevelEvent event) {
+        // if the player shoots something with a projectile, use looting 3
+        DamageSource damageSource = event.getDamageSource();
+        if(damageSource.isProjectile() && damageSource.getEntity() instanceof EntityPlayer && damageSource.getSourceOfDamage() instanceof EntityArrow) {
+            event.setLootingLevel(3);
+        }
     }
 }


### PR DESCRIPTION
Currently the looting level on entity kill is always determined by the item currently held in the main hand. This meas it's impossible to get a non-0 looting level for anything that's not the player hitting something directly. This is a problem especially for projectiles and things that do stuff from the offhand.

The PR adds an event that is fired after obtaining the looting level, providing the damage source. This allows to determine what killed the entity, since modders can pass their own damagesource with arbitrary data (or use EntityDamageSourceand). Furthermore this also allows for custom fortune interaction depending on what damage you deal.

Test mod makes it so that whenever you kill something with an arrow it drops with looting3.