### PR TITLE
Fix hopper extract behavior being broken due to capability patch

### DIFF
--- a/patches/minecraft/net/minecraft/tileentity/TileEntityHopper.java.patch
+++ b/patches/minecraft/net/minecraft/tileentity/TileEntityHopper.java.patch
@@ -12,7 +12,7 @@
  
      public static boolean func_145891_a(IHopper p_145891_0_)
      {
-+        if (net.minecraftforge.items.VanillaInventoryCodeHooks.extractHook(p_145891_0_)) { return true; }
++        int r = net.minecraftforge.items.VanillaInventoryCodeHooks.extractHook(p_145891_0_); if (r != net.minecraftforge.items.VanillaInventoryCodeHooks.RUN_VANILLA) return r == net.minecraftforge.items.VanillaInventoryCodeHooks.EXIT_TRUE;
          IInventory iinventory = func_145884_b(p_145891_0_);
  
          if (iinventory != null)

--- a/src/main/java/net/minecraftforge/items/VanillaInventoryCodeHooks.java
+++ b/src/main/java/net/minecraftforge/items/VanillaInventoryCodeHooks.java
@@ -33,12 +33,14 @@ import net.minecraft.world.World;
 public class VanillaInventoryCodeHooks
 {
 
-    public static boolean extractHook(IHopper dest)
+    public static int RUN_VANILLA = 0, EXIT_FALSE = 1, EXIT_TRUE = 2;
+
+    public static int extractHook(IHopper dest)
     {
         TileEntity tileEntity = dest.getWorld().getTileEntity(new BlockPos(dest.getXPos(), dest.getYPos() + 1, dest.getZPos()));
 
         if (tileEntity == null || !tileEntity.hasCapability(CapabilityItemHandler.ITEM_HANDLER_CAPABILITY, EnumFacing.DOWN))
-            return false;
+            return RUN_VANILLA;
 
         IItemHandler handler = tileEntity.getCapability(CapabilityItemHandler.ITEM_HANDLER_CAPABILITY, EnumFacing.DOWN);
 
@@ -61,13 +63,13 @@ public class VanillaInventoryCodeHooks
                             dest.setInventorySlotContents(j, destStack);
                         }
                         dest.markDirty();
-                        return true;
+                        return EXIT_TRUE;
                     }
                 }
             }
         }
 
-        return true;
+        return EXIT_FALSE;
     }
 
     public static boolean dropperInsertHook(World world, BlockPos pos, TileEntityDispenser dropper, int slot, ItemStack stack)


### PR DESCRIPTION
Reported [on the forums](http://www.minecraftforge.net/forum/index.php/topic,40256.0.html).

Vanilla returns `false` from `captureDroppedItems` (`func_145891_a`) if there is an empty inventory above the hopper. Forge's patch changed this to `true`. This PR fixes that, by making the return value from `extractHook` a 3-value int: do vanilla logic, exit with true, exit with false.