### PR TITLE
[1.10] PlayerInteractEvent - allow result to be modified

### DIFF
--- a/patches/minecraft/net/minecraft/client/multiplayer/PlayerControllerMP.java.patch
+++ b/patches/minecraft/net/minecraft/client/multiplayer/PlayerControllerMP.java.patch
@@ -146,7 +146,7 @@
              }
              else
              {
-+                EnumActionResult eventResult = net.minecraftforge.common.ForgeHooks.onItemRightClick(p_187101_1_, p_187101_4_, p_187101_3_);
++                EnumActionResult eventResult = net.minecraftforge.common.ForgeHooks.onItemRightClickAction(p_187101_1_, p_187101_4_, p_187101_3_);
 +                if(eventResult != null) return eventResult;
                  int i = p_187101_3_.field_77994_a;
                  ActionResult<ItemStack> actionresult = p_187101_3_.func_77957_a(p_187101_2_, p_187101_1_, p_187101_4_);
@@ -167,7 +167,7 @@
          this.func_78750_j();
          Vec3d vec3d = new Vec3d(p_187102_3_.field_72307_f.field_72450_a - p_187102_2_.field_70165_t, p_187102_3_.field_72307_f.field_72448_b - p_187102_2_.field_70163_u, p_187102_3_.field_72307_f.field_72449_c - p_187102_2_.field_70161_v);
          this.field_78774_b.func_147297_a(new CPacketUseEntity(p_187102_2_, p_187102_5_, vec3d));
-+        EnumActionResult eventResult = net.minecraftforge.common.ForgeHooks.onInteractEntityAt(p_187102_1_, p_187102_2_, p_187102_3_, p_187102_1_.func_184586_b(p_187102_5_), p_187102_5_);
++        EnumActionResult eventResult = net.minecraftforge.common.ForgeHooks.onInteractEntityAtAction(p_187102_1_, p_187102_2_, p_187102_3_, p_187102_1_.func_184586_b(p_187102_5_), p_187102_5_);
 +        if(eventResult != null) return eventResult;
          return this.field_78779_k == GameType.SPECTATOR ? EnumActionResult.PASS : p_187102_2_.func_184199_a(p_187102_1_, vec3d, p_187102_4_, p_187102_5_);
      }

--- a/patches/minecraft/net/minecraft/client/multiplayer/PlayerControllerMP.java.patch
+++ b/patches/minecraft/net/minecraft/client/multiplayer/PlayerControllerMP.java.patch
@@ -142,25 +142,16 @@
                      }
                  }
              }
-<<<<<<< HEAD
-@@ -456,6 +490,7 @@
-=======
-             else
-@@ -446,6 +480,8 @@
->>>>>>> 83231e9... Allow cancel result to be changed
+@@ -456,6 +490,8 @@
              }
              else
              {
-+                net.minecraftforge.event.entity.player.PlayerInteractEvent.RightClickItem evt = net.minecraftforge.common.ForgeHooks.onItemRightClick(p_187101_1_, p_187101_4_, p_187101_3_);
-+                if(evt.isCanceled()) return evt.getSubstituteResult();
++                EnumActionResult eventResult = net.minecraftforge.common.ForgeHooks.onItemRightClick(p_187101_1_, p_187101_4_, p_187101_3_);
++                if(eventResult != null) return eventResult;
                  int i = p_187101_3_.field_77994_a;
                  ActionResult<ItemStack> actionresult = p_187101_3_.func_77957_a(p_187101_2_, p_187101_1_, p_187101_4_);
                  ItemStack itemstack = (ItemStack)actionresult.func_188398_b();
-<<<<<<< HEAD
-@@ -464,9 +499,10 @@
-=======
-@@ -454,9 +490,10 @@
->>>>>>> 83231e9... Allow cancel result to be changed
+@@ -464,9 +500,10 @@
                  {
                      p_187101_1_.func_184611_a(p_187101_4_, itemstack);
  
@@ -172,21 +163,12 @@
                      }
                  }
  
-<<<<<<< HEAD
-@@ -504,6 +540,7 @@
+@@ -504,6 +541,8 @@
          this.func_78750_j();
          Vec3d vec3d = new Vec3d(p_187102_3_.field_72307_f.field_72450_a - p_187102_2_.field_70165_t, p_187102_3_.field_72307_f.field_72448_b - p_187102_2_.field_70163_u, p_187102_3_.field_72307_f.field_72449_c - p_187102_2_.field_70161_v);
          this.field_78774_b.func_147297_a(new CPacketUseEntity(p_187102_2_, p_187102_5_, vec3d));
-+        if(net.minecraftforge.common.ForgeHooks.onInteractEntityAt(p_187102_1_, p_187102_2_, p_187102_3_, p_187102_1_.func_184586_b(p_187102_5_), p_187102_5_)) return EnumActionResult.PASS;
++        EnumActionResult eventResult = net.minecraftforge.common.ForgeHooks.onInteractEntityAt(p_187102_1_, p_187102_2_, p_187102_3_, p_187102_1_.func_184586_b(p_187102_5_), p_187102_5_);
++        if(eventResult != null) return eventResult;
          return this.field_78779_k == GameType.SPECTATOR ? EnumActionResult.PASS : p_187102_2_.func_184199_a(p_187102_1_, vec3d, p_187102_4_, p_187102_5_);
-=======
-@@ -494,6 +531,8 @@
-         this.func_78750_j();
-         Vec3d vec3d = new Vec3d(p_187102_3_.field_72307_f.field_72450_a - p_187102_2_.field_70165_t, p_187102_3_.field_72307_f.field_72448_b - p_187102_2_.field_70163_u, p_187102_3_.field_72307_f.field_72449_c - p_187102_2_.field_70161_v);
-         this.field_78774_b.func_147297_a(new CPacketUseEntity(p_187102_2_, p_187102_5_, vec3d));
-+        net.minecraftforge.event.entity.player.PlayerInteractEvent.EntityInteractSpecific evt =  net.minecraftforge.common.ForgeHooks.onInteractEntityAt(p_187102_1_, p_187102_2_, p_187102_3_, p_187102_1_.func_184586_b(p_187102_5_), p_187102_5_);
-+        if(evt.isCanceled()) return evt.getSubstituteResult();
-         return this.field_78779_k == WorldSettings.GameType.SPECTATOR ? EnumActionResult.PASS : p_187102_2_.func_184199_a(p_187102_1_, vec3d, p_187102_4_, p_187102_5_);
->>>>>>> 83231e9... Allow cancel result to be changed
      }
  

--- a/patches/minecraft/net/minecraft/client/multiplayer/PlayerControllerMP.java.patch
+++ b/patches/minecraft/net/minecraft/client/multiplayer/PlayerControllerMP.java.patch
@@ -87,7 +87,7 @@
 +            {
 +                // Give the server a chance to fire event as well. That way server event is not dependant on client event.
 +                this.field_78774_b.func_147297_a(new CPacketPlayerTryUseItemOnBlock(p_187099_4_, p_187099_5_, p_187099_7_, f, f1, f2));
-+                return EnumActionResult.PASS;
++                return event.getSubstituteResult();
 +            }
 +            EnumActionResult result = EnumActionResult.PASS;
 +
@@ -142,15 +142,25 @@
                      }
                  }
              }
+<<<<<<< HEAD
 @@ -456,6 +490,7 @@
+=======
+             else
+@@ -446,6 +480,8 @@
+>>>>>>> 83231e9... Allow cancel result to be changed
              }
              else
              {
-+                if (net.minecraftforge.common.ForgeHooks.onItemRightClick(p_187101_1_, p_187101_4_, p_187101_3_)) return net.minecraft.util.EnumActionResult.PASS;
++                net.minecraftforge.event.entity.player.PlayerInteractEvent.RightClickItem evt = net.minecraftforge.common.ForgeHooks.onItemRightClick(p_187101_1_, p_187101_4_, p_187101_3_);
++                if(evt.isCanceled()) return evt.getSubstituteResult();
                  int i = p_187101_3_.field_77994_a;
                  ActionResult<ItemStack> actionresult = p_187101_3_.func_77957_a(p_187101_2_, p_187101_1_, p_187101_4_);
                  ItemStack itemstack = (ItemStack)actionresult.func_188398_b();
+<<<<<<< HEAD
 @@ -464,9 +499,10 @@
+=======
+@@ -454,9 +490,10 @@
+>>>>>>> 83231e9... Allow cancel result to be changed
                  {
                      p_187101_1_.func_184611_a(p_187101_4_, itemstack);
  
@@ -162,11 +172,21 @@
                      }
                  }
  
+<<<<<<< HEAD
 @@ -504,6 +540,7 @@
          this.func_78750_j();
          Vec3d vec3d = new Vec3d(p_187102_3_.field_72307_f.field_72450_a - p_187102_2_.field_70165_t, p_187102_3_.field_72307_f.field_72448_b - p_187102_2_.field_70163_u, p_187102_3_.field_72307_f.field_72449_c - p_187102_2_.field_70161_v);
          this.field_78774_b.func_147297_a(new CPacketUseEntity(p_187102_2_, p_187102_5_, vec3d));
 +        if(net.minecraftforge.common.ForgeHooks.onInteractEntityAt(p_187102_1_, p_187102_2_, p_187102_3_, p_187102_1_.func_184586_b(p_187102_5_), p_187102_5_)) return EnumActionResult.PASS;
          return this.field_78779_k == GameType.SPECTATOR ? EnumActionResult.PASS : p_187102_2_.func_184199_a(p_187102_1_, vec3d, p_187102_4_, p_187102_5_);
+=======
+@@ -494,6 +531,8 @@
+         this.func_78750_j();
+         Vec3d vec3d = new Vec3d(p_187102_3_.field_72307_f.field_72450_a - p_187102_2_.field_70165_t, p_187102_3_.field_72307_f.field_72448_b - p_187102_2_.field_70163_u, p_187102_3_.field_72307_f.field_72449_c - p_187102_2_.field_70161_v);
+         this.field_78774_b.func_147297_a(new CPacketUseEntity(p_187102_2_, p_187102_5_, vec3d));
++        net.minecraftforge.event.entity.player.PlayerInteractEvent.EntityInteractSpecific evt =  net.minecraftforge.common.ForgeHooks.onInteractEntityAt(p_187102_1_, p_187102_2_, p_187102_3_, p_187102_1_.func_184586_b(p_187102_5_), p_187102_5_);
++        if(evt.isCanceled()) return evt.getSubstituteResult();
+         return this.field_78779_k == WorldSettings.GameType.SPECTATOR ? EnumActionResult.PASS : p_187102_2_.func_184199_a(p_187102_1_, vec3d, p_187102_4_, p_187102_5_);
+>>>>>>> 83231e9... Allow cancel result to be changed
      }
  

--- a/patches/minecraft/net/minecraft/entity/player/EntityPlayer.java.patch
+++ b/patches/minecraft/net/minecraft/entity/player/EntityPlayer.java.patch
@@ -210,24 +210,16 @@
              p_70665_2_ = this.func_70672_c(p_70665_1_, p_70665_2_);
              float f = p_70665_2_;
              p_70665_2_ = Math.max(p_70665_2_ - this.func_110139_bj(), 0.0F);
-<<<<<<< HEAD
-@@ -1086,6 +1155,7 @@
-=======
-@@ -1071,6 +1140,8 @@
->>>>>>> 83231e9... Allow cancel result to be changed
+@@ -1086,6 +1155,8 @@
          }
          else
          {
-+            net.minecraftforge.event.entity.player.PlayerInteractEvent.EntityInteract evt = net.minecraftforge.common.ForgeHooks.onInteractEntity(this, p_184822_1_, p_184822_2_, p_184822_3_);
-+            if(evt.isCanceled()) return evt.getSubstituteResult();
++            EnumActionResult eventResult = net.minecraftforge.common.ForgeHooks.onInteractEntity(this, p_184822_1_, p_184822_2_, p_184822_3_);
++            if(eventResult != null) return eventResult;
              ItemStack itemstack = p_184822_2_ != null ? p_184822_2_.func_77946_l() : null;
  
              if (!p_184822_1_.func_184230_a(this, p_184822_2_, p_184822_3_))
-<<<<<<< HEAD
-@@ -1101,6 +1171,7 @@
-=======
-@@ -1086,6 +1157,7 @@
->>>>>>> 83231e9... Allow cancel result to be changed
+@@ -1101,6 +1172,7 @@
                      {
                          if (p_184822_2_.field_77994_a <= 0 && !this.field_71075_bZ.field_75098_d)
                          {
@@ -235,11 +227,7 @@
                              this.func_184611_a(p_184822_3_, (ItemStack)null);
                          }
  
-<<<<<<< HEAD
-@@ -1116,6 +1187,7 @@
-=======
-@@ -1101,6 +1173,7 @@
->>>>>>> 83231e9... Allow cancel result to be changed
+@@ -1116,6 +1188,7 @@
                  {
                      if (p_184822_2_.field_77994_a <= 0 && !this.field_71075_bZ.field_75098_d)
                      {
@@ -247,11 +235,7 @@
                          this.func_184611_a(p_184822_3_, (ItemStack)null);
                      }
                      else if (p_184822_2_.field_77994_a < itemstack.field_77994_a && this.field_71075_bZ.field_75098_d)
-<<<<<<< HEAD
-@@ -1142,6 +1214,7 @@
-=======
-@@ -1127,6 +1200,7 @@
->>>>>>> 83231e9... Allow cancel result to be changed
+@@ -1142,6 +1215,7 @@
  
      public void func_71059_n(Entity p_71059_1_)
      {
@@ -259,11 +243,7 @@
          if (p_71059_1_.func_70075_an())
          {
              if (!p_71059_1_.func_85031_j(this))
-<<<<<<< HEAD
-@@ -1340,6 +1413,7 @@
-=======
-@@ -1326,6 +1400,7 @@
->>>>>>> 83231e9... Allow cancel result to be changed
+@@ -1340,6 +1414,7 @@
                              if (itemstack1.field_77994_a <= 0)
                              {
                                  this.func_184611_a(EnumHand.MAIN_HAND, (ItemStack)null);
@@ -271,11 +251,7 @@
                              }
                          }
  
-<<<<<<< HEAD
-@@ -1428,6 +1502,8 @@
-=======
-@@ -1414,6 +1489,8 @@
->>>>>>> 83231e9... Allow cancel result to be changed
+@@ -1428,6 +1503,8 @@
  
      public EntityPlayer.SleepResult func_180469_a(BlockPos p_180469_1_)
      {
@@ -284,11 +260,7 @@
          if (!this.field_70170_p.field_72995_K)
          {
              if (this.func_70608_bn() || !this.func_70089_S())
-<<<<<<< HEAD
-@@ -1467,9 +1543,10 @@
-=======
-@@ -1453,9 +1530,10 @@
->>>>>>> 83231e9... Allow cancel result to be changed
+@@ -1467,9 +1544,10 @@
  
          this.func_70105_a(0.2F, 0.2F);
  
@@ -302,11 +274,7 @@
              float f = 0.5F;
              float f1 = 0.5F;
  
-<<<<<<< HEAD
-@@ -1534,13 +1611,14 @@
-=======
-@@ -1518,13 +1596,14 @@
->>>>>>> 83231e9... Allow cancel result to be changed
+@@ -1534,13 +1612,14 @@
  
      public void func_70999_a(boolean p_70999_1_, boolean p_70999_2_, boolean p_70999_3_)
      {
@@ -324,11 +292,7 @@
  
              if (blockpos == null)
              {
-<<<<<<< HEAD
-@@ -1549,6 +1627,10 @@
-=======
-@@ -1533,6 +1612,10 @@
->>>>>>> 83231e9... Allow cancel result to be changed
+@@ -1549,6 +1628,10 @@
  
              this.func_70107_b((double)((float)blockpos.func_177958_n() + 0.5F), (double)((float)blockpos.func_177956_o() + 0.1F), (double)((float)blockpos.func_177952_p() + 0.5F));
          }
@@ -339,11 +303,7 @@
  
          this.field_71083_bS = false;
  
-<<<<<<< HEAD
-@@ -1567,15 +1649,16 @@
-=======
-@@ -1551,15 +1634,16 @@
->>>>>>> 83231e9... Allow cancel result to be changed
+@@ -1567,15 +1650,16 @@
  
      private boolean func_175143_p()
      {
@@ -363,11 +323,7 @@
          {
              if (!p_180467_2_)
              {
-<<<<<<< HEAD
-@@ -1590,16 +1673,17 @@
-=======
-@@ -1574,16 +1658,17 @@
->>>>>>> 83231e9... Allow cancel result to be changed
+@@ -1590,16 +1674,17 @@
          }
          else
          {
@@ -388,11 +344,7 @@
  
              switch (enumfacing)
              {
-<<<<<<< HEAD
-@@ -1639,16 +1723,24 @@
-=======
-@@ -1623,16 +1708,24 @@
->>>>>>> 83231e9... Allow cancel result to be changed
+@@ -1639,16 +1724,24 @@
  
      public BlockPos func_180470_cg()
      {
@@ -419,11 +371,7 @@
          if (p_180473_1_ != null)
          {
              this.field_71077_c = p_180473_1_;
-<<<<<<< HEAD
-@@ -1843,6 +1935,10 @@
-=======
-@@ -1827,6 +1920,10 @@
->>>>>>> 83231e9... Allow cancel result to be changed
+@@ -1843,6 +1936,10 @@
  
              super.func_180430_e(p_180430_1_, p_180430_2_);
          }
@@ -434,11 +382,7 @@
      }
  
      protected void func_71061_d_()
-<<<<<<< HEAD
-@@ -2043,6 +2139,18 @@
-=======
-@@ -2027,6 +2124,18 @@
->>>>>>> 83231e9... Allow cancel result to be changed
+@@ -2043,6 +2140,18 @@
          this.field_175152_f = p_71049_1_.field_175152_f;
          this.field_71078_a = p_71049_1_.field_71078_a;
          this.func_184212_Q().func_187227_b(field_184827_bp, p_71049_1_.func_184212_Q().func_187225_a(field_184827_bp));
@@ -457,11 +401,7 @@
      }
  
      protected boolean func_70041_e_()
-<<<<<<< HEAD
-@@ -2142,7 +2250,10 @@
-=======
-@@ -2126,7 +2235,10 @@
->>>>>>> 83231e9... Allow cancel result to be changed
+@@ -2142,7 +2251,10 @@
  
      public ITextComponent func_145748_c_()
      {
@@ -473,11 +413,7 @@
          itextcomponent.func_150256_b().func_150241_a(new ClickEvent(ClickEvent.Action.SUGGEST_COMMAND, "/msg " + this.func_70005_c_() + " "));
          itextcomponent.func_150256_b().func_150209_a(this.func_174823_aP());
          itextcomponent.func_150256_b().func_179989_a(this.func_70005_c_());
-<<<<<<< HEAD
-@@ -2151,7 +2262,7 @@
-=======
-@@ -2135,7 +2247,7 @@
->>>>>>> 83231e9... Allow cancel result to be changed
+@@ -2151,7 +2263,7 @@
  
      public float func_70047_e()
      {
@@ -486,13 +422,8 @@
  
          if (this.func_70608_bn())
          {
-<<<<<<< HEAD
-@@ -2367,6 +2478,161 @@
+@@ -2367,6 +2479,161 @@
          return this.field_71075_bZ.field_75098_d && this.func_70003_b(2, "");
-=======
-@@ -2346,6 +2458,161 @@
-         return (float)this.func_110148_a(SharedMonsterAttributes.field_188792_h).func_111126_e();
->>>>>>> 83231e9... Allow cancel result to be changed
      }
  
 +    /**

--- a/patches/minecraft/net/minecraft/entity/player/EntityPlayer.java.patch
+++ b/patches/minecraft/net/minecraft/entity/player/EntityPlayer.java.patch
@@ -214,7 +214,7 @@
          }
          else
          {
-+            EnumActionResult eventResult = net.minecraftforge.common.ForgeHooks.onInteractEntity(this, p_184822_1_, p_184822_2_, p_184822_3_);
++            EnumActionResult eventResult = net.minecraftforge.common.ForgeHooks.onInteractEntityAction(this, p_184822_1_, p_184822_2_, p_184822_3_);
 +            if(eventResult != null) return eventResult;
              ItemStack itemstack = p_184822_2_ != null ? p_184822_2_.func_77946_l() : null;
  

--- a/patches/minecraft/net/minecraft/entity/player/EntityPlayer.java.patch
+++ b/patches/minecraft/net/minecraft/entity/player/EntityPlayer.java.patch
@@ -210,15 +210,24 @@
              p_70665_2_ = this.func_70672_c(p_70665_1_, p_70665_2_);
              float f = p_70665_2_;
              p_70665_2_ = Math.max(p_70665_2_ - this.func_110139_bj(), 0.0F);
+<<<<<<< HEAD
 @@ -1086,6 +1155,7 @@
+=======
+@@ -1071,6 +1140,8 @@
+>>>>>>> 83231e9... Allow cancel result to be changed
          }
          else
          {
-+            if (net.minecraftforge.common.ForgeHooks.onInteractEntity(this, p_184822_1_, p_184822_2_, p_184822_3_)) return EnumActionResult.PASS;
++            net.minecraftforge.event.entity.player.PlayerInteractEvent.EntityInteract evt = net.minecraftforge.common.ForgeHooks.onInteractEntity(this, p_184822_1_, p_184822_2_, p_184822_3_);
++            if(evt.isCanceled()) return evt.getSubstituteResult();
              ItemStack itemstack = p_184822_2_ != null ? p_184822_2_.func_77946_l() : null;
  
              if (!p_184822_1_.func_184230_a(this, p_184822_2_, p_184822_3_))
+<<<<<<< HEAD
 @@ -1101,6 +1171,7 @@
+=======
+@@ -1086,6 +1157,7 @@
+>>>>>>> 83231e9... Allow cancel result to be changed
                      {
                          if (p_184822_2_.field_77994_a <= 0 && !this.field_71075_bZ.field_75098_d)
                          {
@@ -226,7 +235,11 @@
                              this.func_184611_a(p_184822_3_, (ItemStack)null);
                          }
  
+<<<<<<< HEAD
 @@ -1116,6 +1187,7 @@
+=======
+@@ -1101,6 +1173,7 @@
+>>>>>>> 83231e9... Allow cancel result to be changed
                  {
                      if (p_184822_2_.field_77994_a <= 0 && !this.field_71075_bZ.field_75098_d)
                      {
@@ -234,7 +247,11 @@
                          this.func_184611_a(p_184822_3_, (ItemStack)null);
                      }
                      else if (p_184822_2_.field_77994_a < itemstack.field_77994_a && this.field_71075_bZ.field_75098_d)
+<<<<<<< HEAD
 @@ -1142,6 +1214,7 @@
+=======
+@@ -1127,6 +1200,7 @@
+>>>>>>> 83231e9... Allow cancel result to be changed
  
      public void func_71059_n(Entity p_71059_1_)
      {
@@ -242,7 +259,11 @@
          if (p_71059_1_.func_70075_an())
          {
              if (!p_71059_1_.func_85031_j(this))
+<<<<<<< HEAD
 @@ -1340,6 +1413,7 @@
+=======
+@@ -1326,6 +1400,7 @@
+>>>>>>> 83231e9... Allow cancel result to be changed
                              if (itemstack1.field_77994_a <= 0)
                              {
                                  this.func_184611_a(EnumHand.MAIN_HAND, (ItemStack)null);
@@ -250,7 +271,11 @@
                              }
                          }
  
+<<<<<<< HEAD
 @@ -1428,6 +1502,8 @@
+=======
+@@ -1414,6 +1489,8 @@
+>>>>>>> 83231e9... Allow cancel result to be changed
  
      public EntityPlayer.SleepResult func_180469_a(BlockPos p_180469_1_)
      {
@@ -259,7 +284,11 @@
          if (!this.field_70170_p.field_72995_K)
          {
              if (this.func_70608_bn() || !this.func_70089_S())
+<<<<<<< HEAD
 @@ -1467,9 +1543,10 @@
+=======
+@@ -1453,9 +1530,10 @@
+>>>>>>> 83231e9... Allow cancel result to be changed
  
          this.func_70105_a(0.2F, 0.2F);
  
@@ -273,7 +302,11 @@
              float f = 0.5F;
              float f1 = 0.5F;
  
+<<<<<<< HEAD
 @@ -1534,13 +1611,14 @@
+=======
+@@ -1518,13 +1596,14 @@
+>>>>>>> 83231e9... Allow cancel result to be changed
  
      public void func_70999_a(boolean p_70999_1_, boolean p_70999_2_, boolean p_70999_3_)
      {
@@ -291,7 +324,11 @@
  
              if (blockpos == null)
              {
+<<<<<<< HEAD
 @@ -1549,6 +1627,10 @@
+=======
+@@ -1533,6 +1612,10 @@
+>>>>>>> 83231e9... Allow cancel result to be changed
  
              this.func_70107_b((double)((float)blockpos.func_177958_n() + 0.5F), (double)((float)blockpos.func_177956_o() + 0.1F), (double)((float)blockpos.func_177952_p() + 0.5F));
          }
@@ -302,7 +339,11 @@
  
          this.field_71083_bS = false;
  
+<<<<<<< HEAD
 @@ -1567,15 +1649,16 @@
+=======
+@@ -1551,15 +1634,16 @@
+>>>>>>> 83231e9... Allow cancel result to be changed
  
      private boolean func_175143_p()
      {
@@ -322,7 +363,11 @@
          {
              if (!p_180467_2_)
              {
+<<<<<<< HEAD
 @@ -1590,16 +1673,17 @@
+=======
+@@ -1574,16 +1658,17 @@
+>>>>>>> 83231e9... Allow cancel result to be changed
          }
          else
          {
@@ -343,7 +388,11 @@
  
              switch (enumfacing)
              {
+<<<<<<< HEAD
 @@ -1639,16 +1723,24 @@
+=======
+@@ -1623,16 +1708,24 @@
+>>>>>>> 83231e9... Allow cancel result to be changed
  
      public BlockPos func_180470_cg()
      {
@@ -370,7 +419,11 @@
          if (p_180473_1_ != null)
          {
              this.field_71077_c = p_180473_1_;
+<<<<<<< HEAD
 @@ -1843,6 +1935,10 @@
+=======
+@@ -1827,6 +1920,10 @@
+>>>>>>> 83231e9... Allow cancel result to be changed
  
              super.func_180430_e(p_180430_1_, p_180430_2_);
          }
@@ -381,7 +434,11 @@
      }
  
      protected void func_71061_d_()
+<<<<<<< HEAD
 @@ -2043,6 +2139,18 @@
+=======
+@@ -2027,6 +2124,18 @@
+>>>>>>> 83231e9... Allow cancel result to be changed
          this.field_175152_f = p_71049_1_.field_175152_f;
          this.field_71078_a = p_71049_1_.field_71078_a;
          this.func_184212_Q().func_187227_b(field_184827_bp, p_71049_1_.func_184212_Q().func_187225_a(field_184827_bp));
@@ -400,7 +457,11 @@
      }
  
      protected boolean func_70041_e_()
+<<<<<<< HEAD
 @@ -2142,7 +2250,10 @@
+=======
+@@ -2126,7 +2235,10 @@
+>>>>>>> 83231e9... Allow cancel result to be changed
  
      public ITextComponent func_145748_c_()
      {
@@ -412,7 +473,11 @@
          itextcomponent.func_150256_b().func_150241_a(new ClickEvent(ClickEvent.Action.SUGGEST_COMMAND, "/msg " + this.func_70005_c_() + " "));
          itextcomponent.func_150256_b().func_150209_a(this.func_174823_aP());
          itextcomponent.func_150256_b().func_179989_a(this.func_70005_c_());
+<<<<<<< HEAD
 @@ -2151,7 +2262,7 @@
+=======
+@@ -2135,7 +2247,7 @@
+>>>>>>> 83231e9... Allow cancel result to be changed
  
      public float func_70047_e()
      {
@@ -421,8 +486,13 @@
  
          if (this.func_70608_bn())
          {
+<<<<<<< HEAD
 @@ -2367,6 +2478,161 @@
          return this.field_71075_bZ.field_75098_d && this.func_70003_b(2, "");
+=======
+@@ -2346,6 +2458,161 @@
+         return (float)this.func_110148_a(SharedMonsterAttributes.field_188792_h).func_111126_e();
+>>>>>>> 83231e9... Allow cancel result to be changed
      }
  
 +    /**

--- a/patches/minecraft/net/minecraft/network/NetHandlerPlayServer.java.patch
+++ b/patches/minecraft/net/minecraft/network/NetHandlerPlayServer.java.patch
@@ -54,7 +54,7 @@
                  {
                      EnumHand enumhand1 = p_147340_1_.func_186994_b();
                      ItemStack itemstack1 = this.field_147369_b.func_184586_b(enumhand1);
-+                    if(net.minecraftforge.common.ForgeHooks.onInteractEntityAt(field_147369_b, entity, p_147340_1_.func_179712_b(), itemstack1, enumhand1).isCanceled()) return;
++                    if(net.minecraftforge.common.ForgeHooks.onInteractEntityAt(field_147369_b, entity, p_147340_1_.func_179712_b(), itemstack1, enumhand1) != null) return;
                      entity.func_184199_a(this.field_147369_b, p_147340_1_.func_179712_b(), itemstack1, enumhand1);
                  }
                  else if (p_147340_1_.func_149565_c() == CPacketUseEntity.Action.ATTACK)

--- a/patches/minecraft/net/minecraft/network/NetHandlerPlayServer.java.patch
+++ b/patches/minecraft/net/minecraft/network/NetHandlerPlayServer.java.patch
@@ -54,7 +54,7 @@
                  {
                      EnumHand enumhand1 = p_147340_1_.func_186994_b();
                      ItemStack itemstack1 = this.field_147369_b.func_184586_b(enumhand1);
-+                    if(net.minecraftforge.common.ForgeHooks.onInteractEntityAt(field_147369_b, entity, p_147340_1_.func_179712_b(), itemstack1, enumhand1) != null) return;
++                    if(net.minecraftforge.common.ForgeHooks.onInteractEntityAtAction(field_147369_b, entity, p_147340_1_.func_179712_b(), itemstack1, enumhand1) != null) return;
                      entity.func_184199_a(this.field_147369_b, p_147340_1_.func_179712_b(), itemstack1, enumhand1);
                  }
                  else if (p_147340_1_.func_149565_c() == CPacketUseEntity.Action.ATTACK)

--- a/patches/minecraft/net/minecraft/network/NetHandlerPlayServer.java.patch
+++ b/patches/minecraft/net/minecraft/network/NetHandlerPlayServer.java.patch
@@ -54,7 +54,7 @@
                  {
                      EnumHand enumhand1 = p_147340_1_.func_186994_b();
                      ItemStack itemstack1 = this.field_147369_b.func_184586_b(enumhand1);
-+                    if(net.minecraftforge.common.ForgeHooks.onInteractEntityAt(field_147369_b, entity, p_147340_1_.func_179712_b(), itemstack1, enumhand1)) return;
++                    if(net.minecraftforge.common.ForgeHooks.onInteractEntityAt(field_147369_b, entity, p_147340_1_.func_179712_b(), itemstack1, enumhand1).isCanceled()) return;
                      entity.func_184199_a(this.field_147369_b, p_147340_1_.func_179712_b(), itemstack1, enumhand1);
                  }
                  else if (p_147340_1_.func_149565_c() == CPacketUseEntity.Action.ATTACK)

--- a/patches/minecraft/net/minecraft/server/management/PlayerInteractionManager.java.patch
+++ b/patches/minecraft/net/minecraft/server/management/PlayerInteractionManager.java.patch
@@ -206,24 +206,16 @@
                  return flag1;
              }
          }
-<<<<<<< HEAD
-@@ -336,6 +359,7 @@
-=======
-@@ -334,6 +357,8 @@
->>>>>>> 83231e9... Allow cancel result to be changed
+@@ -336,6 +359,8 @@
          }
          else
          {
-+            net.minecraftforge.event.entity.player.PlayerInteractEvent.RightClickItem evt = net.minecraftforge.common.ForgeHooks.onItemRightClick(p_187250_1_, p_187250_4_, p_187250_3_);
-+            if(evt.isCanceled()) return evt.getSubstituteResult();
++            EnumActionResult eventResult = net.minecraftforge.common.ForgeHooks.onItemRightClick(p_187250_1_, p_187250_4_, p_187250_3_);
++            if(eventResult != null) return eventResult;
              int i = p_187250_3_.field_77994_a;
              int j = p_187250_3_.func_77960_j();
              ActionResult<ItemStack> actionresult = p_187250_3_.func_77957_a(p_187250_2_, p_187250_1_, p_187250_4_);
-<<<<<<< HEAD
-@@ -362,6 +386,7 @@
-=======
-@@ -360,6 +385,7 @@
->>>>>>> 83231e9... Allow cancel result to be changed
+@@ -362,6 +387,7 @@
                  if (itemstack.field_77994_a == 0)
                  {
                      p_187250_1_.func_184611_a(p_187250_4_, (ItemStack)null);
@@ -231,11 +223,7 @@
                  }
  
                  if (!p_187250_1_.func_184587_cr())
-<<<<<<< HEAD
-@@ -406,13 +431,26 @@
-=======
-@@ -404,13 +430,26 @@
->>>>>>> 83231e9... Allow cancel result to be changed
+@@ -406,13 +432,26 @@
          }
          else
          {
@@ -265,8 +253,7 @@
                  }
              }
  
-<<<<<<< HEAD
-@@ -440,14 +478,20 @@
+@@ -440,14 +479,20 @@
                  {
                      int j = p_187251_3_.func_77960_j();
                      int i = p_187251_3_.field_77994_a;
@@ -287,32 +274,7 @@
                  }
              }
          }
-@@ -457,4 +501,13 @@
-=======
-@@ -430,14 +469,21 @@
-             {
-                 int j = p_187251_3_.func_77960_j();
-                 int i = p_187251_3_.field_77994_a;
-+                if (result != EnumActionResult.SUCCESS && event.getUseItem() != net.minecraftforge.fml.common.eventhandler.Event.Result.DENY
-+                        || result == EnumActionResult.SUCCESS && event.getUseItem() == net.minecraftforge.fml.common.eventhandler.Event.Result.ALLOW) {
-                 EnumActionResult enumactionresult = p_187251_3_.func_179546_a(p_187251_1_, p_187251_2_, p_187251_5_, p_187251_4_, p_187251_6_, p_187251_7_, p_187251_8_, p_187251_9_);
-                 p_187251_3_.func_77964_b(j);
-                 p_187251_3_.field_77994_a = i;
-                 return enumactionresult;
-+                } else return result;
-+
-             }
-             else
-             {
-+                if (result != EnumActionResult.SUCCESS && event.getUseItem() != net.minecraftforge.fml.common.eventhandler.Event.Result.DENY
-+                        || result == EnumActionResult.SUCCESS && event.getUseItem() == net.minecraftforge.fml.common.eventhandler.Event.Result.ALLOW)
-                 return p_187251_3_.func_179546_a(p_187251_1_, p_187251_2_, p_187251_5_, p_187251_4_, p_187251_6_, p_187251_7_, p_187251_8_, p_187251_9_);
-+                else return result;
-             }
-         }
-     }
-@@ -446,4 +492,13 @@
->>>>>>> 83231e9... Allow cancel result to be changed
+@@ -457,4 +502,13 @@
      {
          this.field_73092_a = p_73080_1_;
      }

--- a/patches/minecraft/net/minecraft/server/management/PlayerInteractionManager.java.patch
+++ b/patches/minecraft/net/minecraft/server/management/PlayerInteractionManager.java.patch
@@ -210,7 +210,7 @@
          }
          else
          {
-+            EnumActionResult eventResult = net.minecraftforge.common.ForgeHooks.onItemRightClick(p_187250_1_, p_187250_4_, p_187250_3_);
++            EnumActionResult eventResult = net.minecraftforge.common.ForgeHooks.onItemRightClickAction(p_187250_1_, p_187250_4_, p_187250_3_);
 +            if(eventResult != null) return eventResult;
              int i = p_187250_3_.field_77994_a;
              int j = p_187250_3_.func_77960_j();

--- a/patches/minecraft/net/minecraft/server/management/PlayerInteractionManager.java.patch
+++ b/patches/minecraft/net/minecraft/server/management/PlayerInteractionManager.java.patch
@@ -206,15 +206,24 @@
                  return flag1;
              }
          }
+<<<<<<< HEAD
 @@ -336,6 +359,7 @@
+=======
+@@ -334,6 +357,8 @@
+>>>>>>> 83231e9... Allow cancel result to be changed
          }
          else
          {
-+            if (net.minecraftforge.common.ForgeHooks.onItemRightClick(p_187250_1_, p_187250_4_, p_187250_3_)) return net.minecraft.util.EnumActionResult.PASS;
++            net.minecraftforge.event.entity.player.PlayerInteractEvent.RightClickItem evt = net.minecraftforge.common.ForgeHooks.onItemRightClick(p_187250_1_, p_187250_4_, p_187250_3_);
++            if(evt.isCanceled()) return evt.getSubstituteResult();
              int i = p_187250_3_.field_77994_a;
              int j = p_187250_3_.func_77960_j();
              ActionResult<ItemStack> actionresult = p_187250_3_.func_77957_a(p_187250_2_, p_187250_1_, p_187250_4_);
+<<<<<<< HEAD
 @@ -362,6 +386,7 @@
+=======
+@@ -360,6 +385,7 @@
+>>>>>>> 83231e9... Allow cancel result to be changed
                  if (itemstack.field_77994_a == 0)
                  {
                      p_187250_1_.func_184611_a(p_187250_4_, (ItemStack)null);
@@ -222,14 +231,18 @@
                  }
  
                  if (!p_187250_1_.func_184587_cr())
+<<<<<<< HEAD
 @@ -406,13 +431,26 @@
+=======
+@@ -404,13 +430,26 @@
+>>>>>>> 83231e9... Allow cancel result to be changed
          }
          else
          {
 -            if (!p_187251_1_.func_70093_af() || p_187251_1_.func_184614_ca() == null && p_187251_1_.func_184592_cb() == null)
 +            net.minecraftforge.event.entity.player.PlayerInteractEvent.RightClickBlock event = net.minecraftforge.common.ForgeHooks
 +                    .onRightClickBlock(p_187251_1_, p_187251_4_, p_187251_3_, p_187251_5_, p_187251_6_, net.minecraftforge.common.ForgeHooks.rayTraceEyeHitVec(field_73090_b, getBlockReachDistance() + 1));
-+            if (event.isCanceled()) return EnumActionResult.PASS;
++            if (event.isCanceled()) return event.getSubstituteResult();
 +
 +            net.minecraft.item.Item item = p_187251_3_ == null ? null : p_187251_3_.func_77973_b();
 +            EnumActionResult ret = item == null ? EnumActionResult.PASS : item.onItemUseFirst(p_187251_3_, p_187251_1_, p_187251_2_, p_187251_5_, p_187251_6_, p_187251_7_, p_187251_8_, p_187251_9_, p_187251_4_);
@@ -252,6 +265,7 @@
                  }
              }
  
+<<<<<<< HEAD
 @@ -440,14 +478,20 @@
                  {
                      int j = p_187251_3_.func_77960_j();
@@ -274,6 +288,31 @@
              }
          }
 @@ -457,4 +501,13 @@
+=======
+@@ -430,14 +469,21 @@
+             {
+                 int j = p_187251_3_.func_77960_j();
+                 int i = p_187251_3_.field_77994_a;
++                if (result != EnumActionResult.SUCCESS && event.getUseItem() != net.minecraftforge.fml.common.eventhandler.Event.Result.DENY
++                        || result == EnumActionResult.SUCCESS && event.getUseItem() == net.minecraftforge.fml.common.eventhandler.Event.Result.ALLOW) {
+                 EnumActionResult enumactionresult = p_187251_3_.func_179546_a(p_187251_1_, p_187251_2_, p_187251_5_, p_187251_4_, p_187251_6_, p_187251_7_, p_187251_8_, p_187251_9_);
+                 p_187251_3_.func_77964_b(j);
+                 p_187251_3_.field_77994_a = i;
+                 return enumactionresult;
++                } else return result;
++
+             }
+             else
+             {
++                if (result != EnumActionResult.SUCCESS && event.getUseItem() != net.minecraftforge.fml.common.eventhandler.Event.Result.DENY
++                        || result == EnumActionResult.SUCCESS && event.getUseItem() == net.minecraftforge.fml.common.eventhandler.Event.Result.ALLOW)
+                 return p_187251_3_.func_179546_a(p_187251_1_, p_187251_2_, p_187251_5_, p_187251_4_, p_187251_6_, p_187251_7_, p_187251_8_, p_187251_9_);
++                else return result;
+             }
+         }
+     }
+@@ -446,4 +492,13 @@
+>>>>>>> 83231e9... Allow cancel result to be changed
      {
          this.field_73092_a = p_73080_1_;
      }

--- a/src/main/java/net/minecraftforge/common/ForgeHooks.java
+++ b/src/main/java/net/minecraftforge/common/ForgeHooks.java
@@ -958,31 +958,31 @@ public class ForgeHooks
         return git == null ? null : git.hitVec;
     }
 
-    public static PlayerInteractEvent.EntityInteractSpecific onInteractEntityAt(EntityPlayer player, Entity entity, RayTraceResult ray, ItemStack stack, EnumHand hand)
+    public static EnumActionResult onInteractEntityAt(EntityPlayer player, Entity entity, RayTraceResult ray, ItemStack stack, EnumHand hand)
     {
         Vec3d vec3d = new Vec3d(ray.hitVec.xCoord - entity.posX, ray.hitVec.yCoord - entity.posY, ray.hitVec.zCoord - entity.posZ);
         return onInteractEntityAt(player, entity, vec3d, stack, hand);
     }
 
-    public static PlayerInteractEvent.EntityInteractSpecific onInteractEntityAt(EntityPlayer player, Entity entity, Vec3d vec3d, ItemStack stack, EnumHand hand)
+    public static EnumActionResult onInteractEntityAt(EntityPlayer player, Entity entity, Vec3d vec3d, ItemStack stack, EnumHand hand)
     {
         PlayerInteractEvent.EntityInteractSpecific evt = new PlayerInteractEvent.EntityInteractSpecific(player, hand, stack, entity, vec3d);
         MinecraftForge.EVENT_BUS.post(evt);
-        return evt;
+        return evt.isCanceled() ? evt.getSubstituteResult() : null;
     }
 
-    public static PlayerInteractEvent.EntityInteract onInteractEntity(EntityPlayer player, Entity entity, ItemStack item, EnumHand hand)
+    public static EnumActionResult onInteractEntity(EntityPlayer player, Entity entity, ItemStack item, EnumHand hand)
     {
         PlayerInteractEvent.EntityInteract evt = new PlayerInteractEvent.EntityInteract(player, hand, item, entity);
         MinecraftForge.EVENT_BUS.post(evt);
-        return evt;
+        return evt.isCanceled() ? evt.getSubstituteResult() : null;
     }
 
-    public static PlayerInteractEvent.RightClickItem onItemRightClick(EntityPlayer player, EnumHand hand, ItemStack stack)
+    public static EnumActionResult onItemRightClick(EntityPlayer player, EnumHand hand, ItemStack stack)
     {
         PlayerInteractEvent.RightClickItem evt = new PlayerInteractEvent.RightClickItem(player, hand, stack);
         MinecraftForge.EVENT_BUS.post(evt);
-        return evt;
+        return evt.isCanceled() ? evt.getSubstituteResult() : null;
     }
 
     public static PlayerInteractEvent.LeftClickBlock onLeftClickBlock(EntityPlayer player, BlockPos pos, EnumFacing face, Vec3d hitVec)

--- a/src/main/java/net/minecraftforge/common/ForgeHooks.java
+++ b/src/main/java/net/minecraftforge/common/ForgeHooks.java
@@ -958,27 +958,51 @@ public class ForgeHooks
         return git == null ? null : git.hitVec;
     }
 
-    public static EnumActionResult onInteractEntityAt(EntityPlayer player, Entity entity, RayTraceResult ray, ItemStack stack, EnumHand hand)
+    @Deprecated
+    public static boolean onInteractEntityAt(EntityPlayer player, Entity entity, RayTraceResult ray, ItemStack stack, EnumHand hand)
     {
-        Vec3d vec3d = new Vec3d(ray.hitVec.xCoord - entity.posX, ray.hitVec.yCoord - entity.posY, ray.hitVec.zCoord - entity.posZ);
-        return onInteractEntityAt(player, entity, vec3d, stack, hand);
+        return onInteractEntityAtAction(player, entity, ray, stack, hand) != null;
     }
 
-    public static EnumActionResult onInteractEntityAt(EntityPlayer player, Entity entity, Vec3d vec3d, ItemStack stack, EnumHand hand)
+    @Deprecated
+    public static boolean onInteractEntityAt(EntityPlayer player, Entity entity, Vec3d vec3d, ItemStack stack, EnumHand hand)
+    {
+        return onInteractEntityAtAction(player, entity, vec3d, stack, hand) != null;
+    }
+
+    public static EnumActionResult onInteractEntityAtAction(EntityPlayer player, Entity entity, RayTraceResult ray, ItemStack stack, EnumHand hand)
+    {
+        Vec3d vec3d = new Vec3d(ray.hitVec.xCoord - entity.posX, ray.hitVec.yCoord - entity.posY, ray.hitVec.zCoord - entity.posZ);
+        return onInteractEntityAtAction(player, entity, vec3d, stack, hand);
+    }
+
+    public static EnumActionResult onInteractEntityAtAction(EntityPlayer player, Entity entity, Vec3d vec3d, ItemStack stack, EnumHand hand)
     {
         PlayerInteractEvent.EntityInteractSpecific evt = new PlayerInteractEvent.EntityInteractSpecific(player, hand, stack, entity, vec3d);
         MinecraftForge.EVENT_BUS.post(evt);
         return evt.isCanceled() ? evt.getSubstituteResult() : null;
     }
 
-    public static EnumActionResult onInteractEntity(EntityPlayer player, Entity entity, ItemStack item, EnumHand hand)
+    @Deprecated
+    public static boolean onInteractEntity(EntityPlayer player, Entity entity, ItemStack item, EnumHand hand)
+    {
+        return onInteractEntityAction(player, entity, item, hand) != null;
+    }
+
+    public static EnumActionResult onInteractEntityAction(EntityPlayer player, Entity entity, ItemStack item, EnumHand hand)
     {
         PlayerInteractEvent.EntityInteract evt = new PlayerInteractEvent.EntityInteract(player, hand, item, entity);
         MinecraftForge.EVENT_BUS.post(evt);
         return evt.isCanceled() ? evt.getSubstituteResult() : null;
     }
 
-    public static EnumActionResult onItemRightClick(EntityPlayer player, EnumHand hand, ItemStack stack)
+    @Deprecated
+    public static boolean onItemRightClick(EntityPlayer player, EnumHand hand, ItemStack stack)
+    {
+        return onItemRightClickAction(player, hand, stack) != null;
+    }
+
+    public static EnumActionResult onItemRightClickAction(EntityPlayer player, EnumHand hand, ItemStack stack)
     {
         PlayerInteractEvent.RightClickItem evt = new PlayerInteractEvent.RightClickItem(player, hand, stack);
         MinecraftForge.EVENT_BUS.post(evt);

--- a/src/main/java/net/minecraftforge/common/ForgeHooks.java
+++ b/src/main/java/net/minecraftforge/common/ForgeHooks.java
@@ -958,25 +958,31 @@ public class ForgeHooks
         return git == null ? null : git.hitVec;
     }
 
-    public static boolean onInteractEntityAt(EntityPlayer player, Entity entity, RayTraceResult ray, ItemStack stack, EnumHand hand)
+    public static PlayerInteractEvent.EntityInteractSpecific onInteractEntityAt(EntityPlayer player, Entity entity, RayTraceResult ray, ItemStack stack, EnumHand hand)
     {
         Vec3d vec3d = new Vec3d(ray.hitVec.xCoord - entity.posX, ray.hitVec.yCoord - entity.posY, ray.hitVec.zCoord - entity.posZ);
         return onInteractEntityAt(player, entity, vec3d, stack, hand);
     }
 
-    public static boolean onInteractEntityAt(EntityPlayer player, Entity entity, Vec3d vec3d, ItemStack stack, EnumHand hand)
+    public static PlayerInteractEvent.EntityInteractSpecific onInteractEntityAt(EntityPlayer player, Entity entity, Vec3d vec3d, ItemStack stack, EnumHand hand)
     {
-        return MinecraftForge.EVENT_BUS.post(new PlayerInteractEvent.EntityInteractSpecific(player, hand, stack, entity, vec3d));
+        PlayerInteractEvent.EntityInteractSpecific evt = new PlayerInteractEvent.EntityInteractSpecific(player, hand, stack, entity, vec3d);
+        MinecraftForge.EVENT_BUS.post(evt);
+        return evt;
     }
 
-    public static boolean onInteractEntity(EntityPlayer player, Entity entity, ItemStack item, EnumHand hand)
+    public static PlayerInteractEvent.EntityInteract onInteractEntity(EntityPlayer player, Entity entity, ItemStack item, EnumHand hand)
     {
-        return MinecraftForge.EVENT_BUS.post(new PlayerInteractEvent.EntityInteract(player, hand, item, entity));
+        PlayerInteractEvent.EntityInteract evt = new PlayerInteractEvent.EntityInteract(player, hand, item, entity);
+        MinecraftForge.EVENT_BUS.post(evt);
+        return evt;
     }
 
-    public static boolean onItemRightClick(EntityPlayer player, EnumHand hand, ItemStack stack)
+    public static PlayerInteractEvent.RightClickItem onItemRightClick(EntityPlayer player, EnumHand hand, ItemStack stack)
     {
-        return MinecraftForge.EVENT_BUS.post(new PlayerInteractEvent.RightClickItem(player, hand, stack));
+        PlayerInteractEvent.RightClickItem evt = new PlayerInteractEvent.RightClickItem(player, hand, stack);
+        MinecraftForge.EVENT_BUS.post(evt);
+        return evt;
     }
 
     public static PlayerInteractEvent.LeftClickBlock onLeftClickBlock(EntityPlayer player, BlockPos pos, EnumFacing face, Vec3d hitVec)

--- a/src/test/java/net/minecraftforge/test/PlayerInteractEventTest.java
+++ b/src/test/java/net/minecraftforge/test/PlayerInteractEventTest.java
@@ -6,9 +6,13 @@ import net.minecraft.entity.monster.EntitySkeleton;
 import net.minecraft.entity.monster.SkeletonType;
 import net.minecraft.entity.passive.EntityHorse;
 import net.minecraft.init.Items;
+import net.minecraft.item.Item;
+import net.minecraft.item.ItemBlock;
+import net.minecraft.item.ItemStack;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.tileentity.TileEntityChest;
 import net.minecraft.tileentity.TileEntityDropper;
+import net.minecraft.util.EnumActionResult;
 import net.minecraft.util.EnumHand;
 import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.event.entity.player.PlayerInteractEvent;
@@ -71,7 +75,7 @@ public class PlayerInteractEventTest
         logger.info("HIT VEC: {}", evt.getHitVec());
 
         // Shift right clicking dropper with an item in hand should still open the dropper contrary to normal mechanics
-        // The item in hand is used as well (not specifying anything would not use the item)
+        // The item in hand is used as well (not specifying anything would not use the item) - a splash potion works well for testing this.
         TileEntity te = evt.getWorld().getTileEntity(evt.getPos());
         if (te instanceof TileEntityDropper)
         {
@@ -87,7 +91,7 @@ public class PlayerInteractEventTest
         }
 
         // Case: Flint and steel in main hand on top of a TE will light a fire, not open the TE.
-        // Note that if you do this on a chest, the f+s will fail, but then your off hand will open the chest
+        // Note that if you do this on a chest, the f+s will fail (since chests aren't full blocks), but then your off hand will open the chest
         // If you dual wield flints and steels and right click a chest nothing should happen
         if (evt.getItemStack() != null && evt.getItemStack().getItem() == Items.FLINT_AND_STEEL)
             evt.setUseBlock(Event.Result.DENY);
@@ -99,9 +103,22 @@ public class PlayerInteractEventTest
         }
 
         // Spawn egg in main hand, block in offhand -> block should be placed
-        // Sword in main hand, spawn egg in offhand -> nothing should happen
-        if (evt.getItemStack() != null && evt.getItemStack().getItem() == Items.SPAWN_EGG) {
+        if (evt.getItemStack() != null
+                && evt.getItemStack().getItem() == Items.SPAWN_EGG
+                && evt.getHand() == EnumHand.MAIN_HAND
+                && evt.getEntityPlayer().getHeldItemOffhand() != null
+                && evt.getEntityPlayer().getHeldItemOffhand().getItem() instanceof ItemBlock) {
             evt.setCanceled(true);
+        }
+
+        // Spawn egg in main hand, block in offhand -> potion should NOT be thrown
+        if (evt.getItemStack() != null
+                && evt.getItemStack().getItem() == Items.SPAWN_EGG
+                && evt.getHand() == EnumHand.MAIN_HAND
+                && evt.getEntityPlayer().getHeldItemOffhand() != null
+                && evt.getEntityPlayer().getHeldItemOffhand().getItem() == Items.SPLASH_POTION) {
+            evt.setCanceled(true);
+            evt.setSubstituteResult(EnumActionResult.SUCCESS); // Fake spawn egg success so splash potion does not trigger
         }
 
 
@@ -112,11 +129,25 @@ public class PlayerInteractEventTest
     {
         if (!ENABLE) return;
 
-        // Use survival mode
+        // Case: Ender pearl in main hand, block in offhand -> Block is NOT placed
+        if (evt.getItemStack() != null
+                && evt.getItemStack().getItem() == Items.ENDER_PEARL
+                && evt.getHand() == EnumHand.MAIN_HAND
+                && evt.getEntityPlayer().getHeldItemOffhand() != null
+                && evt.getEntityPlayer().getHeldItemOffhand().getItem() instanceof ItemBlock)
+        {
+            evt.setCanceled(true);
+            evt.setSubstituteResult(EnumActionResult.SUCCESS); // We fake success on the ender pearl so block is not placed
+            return;
+        }
+
         // Case: Ender pearl in main hand, bow in offhand with arrows in inv -> Bow should trigger
         // Case: Sword in main hand, ender pearl in offhand -> Nothing should happen
-
-        if (evt.getItemStack() != null && evt.getItemStack().getItem() == Items.ENDER_PEARL)
+        if (evt.getItemStack() != null
+                && evt.getItemStack().getItem() == Items.ENDER_PEARL
+                && evt.getHand() == EnumHand.MAIN_HAND
+                && evt.getEntityPlayer().getHeldItemOffhand() != null
+                && evt.getEntityPlayer().getHeldItemOffhand().getItem() instanceof ItemBlock)
             evt.setCanceled(true);
     }
 
@@ -131,7 +162,17 @@ public class PlayerInteractEventTest
                 && evt.getItemStack().getItem() == Items.IRON_HELMET)
             evt.setCanceled(true); // Should not be able to place iron helmet onto armor stand (you will put it on instead)
 
-        if (evt.getWorld().isRemote
+        if (evt.getItemStack() != null
+                && evt.getTarget() instanceof EntityArmorStand
+                && evt.getItemStack().getItem() == Items.GOLDEN_HELMET)
+        {
+            evt.setCanceled(true);
+            evt.setSubstituteResult(EnumActionResult.SUCCESS);
+            // Should not be able to place golden helmet onto armor stand
+            // However you will NOT put it on because we fake success on the armorstand.
+        }
+
+        if (!evt.getWorld().isRemote
                 && evt.getTarget() instanceof EntitySkeleton
                 && evt.getLocalPos().yCoord > evt.getTarget().height / 2.0)
         {
@@ -146,10 +187,18 @@ public class PlayerInteractEventTest
     {
         if (!ENABLE) return;
 
-        if (evt.getItemStack() != null && (evt.getTarget() instanceof EntityHorse || evt.getTarget() instanceof EntityCreeper))
+        if (evt.getItemStack() != null && evt.getTarget() instanceof EntityHorse) {
             // Should not be able to feed wild horses with golden apple (you will start eating it in survival)
-            // Should not be able to ignite creeper with F+S
-            // Applies to both hands
-            evt.setCanceled(true);
+            if (evt.getItemStack().getItem() == Items.GOLDEN_APPLE
+                    && evt.getItemStack().getItemDamage() == 0)
+                evt.setCanceled(true);
+            // Should not be able to feed wild horses with notch apple but you will NOT eat it
+            if (evt.getItemStack().getItem() == Items.GOLDEN_APPLE
+                    && evt.getItemStack().getItemDamage() == 1)
+            {
+                evt.setCanceled(true);
+                evt.setSubstituteResult(EnumActionResult.SUCCESS);
+            }
+        }
     }
 }


### PR DESCRIPTION
Updated copy of #3041.
As, suggested, I changed it to return the EnumActionResult instead of returning the event.

Still have to hold on to the event in some (3) cases because the event state needs to be read and modified multiple times
