### PR TITLE
Add getBlockState() to PlayerInteractEvent

### DIFF
--- a/patches/minecraft/net/minecraft/world/ChunkCache.java.patch
+++ b/patches/minecraft/net/minecraft/world/ChunkCache.java.patch
@@ -46,7 +46,7 @@
 +    {
 +        int x = (pos.func_177958_n() >> 4) - this.field_72818_a;
 +        int z = (pos.func_177952_p() >> 4) - this.field_72816_b;
-+        if (pos.func_177956_o() >= 0 && pos.func_177956_o() < 256) return _default;
++        if (pos.func_177956_o() < 0 && pos.func_177956_o() >= 256) return _default;
 +        if (x < 0 || x >= field_72817_c.length || z < 0 || z >= field_72817_c[x].length) return _default;
 +        if (field_72817_c[x][z] == null) return _default;
 +

--- a/patches/minecraft/net/minecraft/world/WorldEntitySpawner.java.patch
+++ b/patches/minecraft/net/minecraft/world/WorldEntitySpawner.java.patch
@@ -28,7 +28,7 @@
 +                                                net.minecraftforge.fml.common.eventhandler.Event.Result canSpawn = net.minecraftforge.event.ForgeEventFactory.canEntitySpawn(entityliving, p_77192_1_, f, i3, f1);
 +                                                if (canSpawn == net.minecraftforge.fml.common.eventhandler.Event.Result.ALLOW || (canSpawn == net.minecraftforge.fml.common.eventhandler.Event.Result.DEFAULT && (entityliving.func_70601_bi() && entityliving.func_70058_J())))
                                                  {
-+                                                    if (!net.minecraftforge.event.ForgeEventFactory.doSpecialSpawn(entityliving, p_77192_1_, f, l3, f1))
++                                                    if (!net.minecraftforge.event.ForgeEventFactory.doSpecialSpawn(entityliving, p_77192_1_, f, i3, f1))
                                                      ientitylivingdata = entityliving.func_180482_a(p_77192_1_.func_175649_E(new BlockPos(entityliving)), ientitylivingdata);
  
                                                      if (entityliving.func_70058_J())

--- a/src/main/java/net/minecraftforge/client/model/ModelLoader.java
+++ b/src/main/java/net/minecraftforge/client/model/ModelLoader.java
@@ -873,6 +873,7 @@ public final class ModelLoader extends ModelBakery
         private White()
         {
             super(LOCATION.toString());
+            this.width = this.height = 16;
         }
 
         @Override
@@ -884,10 +885,10 @@ public final class ModelLoader extends ModelBakery
         @Override
         public boolean load(IResourceManager manager, ResourceLocation location)
         {
-            BufferedImage image = new BufferedImage(16, 16, BufferedImage.TYPE_INT_ARGB);
+            BufferedImage image = new BufferedImage(this.getIconWidth(), this.getIconHeight(), BufferedImage.TYPE_INT_ARGB);
             Graphics2D graphics = image.createGraphics();
             graphics.setBackground(Color.WHITE);
-            graphics.clearRect(0, 0, 16, 16);
+            graphics.clearRect(0, 0, this.getIconWidth(), this.getIconHeight());
             int[][] pixels = new int[Minecraft.getMinecraft().gameSettings.mipmapLevels + 1][];
             pixels[0] = new int[image.getWidth() * image.getHeight()];
             image.getRGB(0, 0, image.getWidth(), image.getHeight(), pixels[0], 0, image.getWidth());

--- a/src/main/java/net/minecraftforge/event/entity/player/PlayerInteractEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/player/PlayerInteractEvent.java
@@ -356,4 +356,12 @@ public class PlayerInteractEvent extends PlayerEvent
         return getWorld().isRemote ? Side.CLIENT : Side.SERVER;
     }
 
+    /**
+     * @return The IBlockState of the block being interacted with. For all non-block interactions, this will return null.
+     */
+    @Nullable
+    public IBlockState getBlockState()
+    {
+        return face == null ? null : getWorld().getBlockState(pos);
+    }
 }


### PR DESCRIPTION
Added a `.getBlockState()` method to `PlayerInteractEvent` for clarity and ease of use. Returns null if the event is not a block interaction event, based on the value of `face`.