### PR TITLE
Prevent mipmap reduction by incorrectly sized textures

### DIFF
--- a/patches/minecraft/net/minecraft/client/renderer/texture/TextureMap.java.patch
+++ b/patches/minecraft/net/minecraft/client/renderer/texture/TextureMap.java.patch
@@ -84,7 +84,16 @@
                  continue;
              }
              finally
-@@ -129,6 +158,7 @@
+@@ -117,6 +146,8 @@
+                 IOUtils.closeQuietly((Closeable)iresource);
+             }
+ 
++            if (checkForMipmapReduction(resourcelocation, textureatlassprite, k)) continue;
++
+             j = Math.min(j, Math.min(textureatlassprite.func_94211_a(), textureatlassprite.func_94216_b()));
+             int lvt_11_2_ = Math.min(Integer.lowestOneBit(textureatlassprite.func_94211_a()), Integer.lowestOneBit(textureatlassprite.func_94216_b()));
+ 
+@@ -129,6 +160,7 @@
              stitcher.func_110934_a(textureatlassprite);
          }
  
@@ -92,7 +101,7 @@
          int l = Math.min(j, k);
          int i1 = MathHelper.func_151239_c(l);
  
-@@ -140,9 +170,12 @@
+@@ -140,9 +172,12 @@
  
          this.field_94249_f.func_147963_d(this.field_147636_j);
          stitcher.func_110934_a(this.field_94249_f);
@@ -105,7 +114,7 @@
              stitcher.func_94305_f();
          }
          catch (StitcherException stitcherexception)
-@@ -151,11 +184,16 @@
+@@ -151,11 +186,16 @@
          }
  
          field_147635_d.info("Created: {}x{} {}-atlas", new Object[] {Integer.valueOf(stitcher.func_110935_a()), Integer.valueOf(stitcher.func_110936_b()), this.field_94254_c});
@@ -122,7 +131,7 @@
              if (textureatlassprite1 == this.field_94249_f || this.func_184397_a(p_110571_1_, textureatlassprite1))
              {
                  String s = textureatlassprite1.func_94215_i();
-@@ -186,6 +224,13 @@
+@@ -186,6 +226,13 @@
          {
              textureatlassprite2.func_94217_a(this.field_94249_f);
          }
@@ -136,7 +145,7 @@
      }
  
      private boolean func_184397_a(IResourceManager p_184397_1_, final TextureAtlasSprite p_184397_2_)
-@@ -195,7 +240,7 @@
+@@ -195,7 +242,7 @@
          label9:
          {
              boolean flag;
@@ -145,7 +154,7 @@
              try
              {
                  iresource = p_184397_1_.func_110536_a(resourcelocation);
-@@ -292,7 +337,7 @@
+@@ -292,7 +339,7 @@
          }
          else
          {
@@ -154,7 +163,7 @@
  
              if (textureatlassprite == null)
              {
-@@ -318,4 +363,42 @@
+@@ -318,4 +365,64 @@
      {
          return this.field_94249_f;
      }
@@ -195,5 +204,27 @@
 +    public boolean setTextureEntry(TextureAtlasSprite entry)
 +    {
 +        return setTextureEntry(entry.func_94215_i(), entry);
++    }
++
++    /**
++     * Checks if a texture would reduce the client's mipmap level, if ForgeModContainer.preventMipmapReduction is true.
++     * @param resourceLocation   the location of the texture for logging purposes
++     * @param textureAtlasSprite the texture to check the size of
++     * @param desiredMipPower    the client's desired mipmap power
++     * @return true if ForgeModContainer.preventMipmapReduction is true and the texture would reduce the client's mipmap level.
++     */
++    private static boolean checkForMipmapReduction(ResourceLocation resourceLocation, TextureAtlasSprite textureAtlasSprite, int desiredMipPower)
++    {
++        if (net.minecraftforge.common.ForgeModContainer.preventMipmapReduction)
++        {
++            int mipPower = Math.min(Integer.lowestOneBit(textureAtlasSprite.func_94211_a()), Integer.lowestOneBit(textureAtlasSprite.func_94216_b()));
++            if (mipPower < desiredMipPower)
++            {
++                field_147635_d.warn("Texture {} with size {}x{} would limit mip level from {} to {}. Forge client config option preventMipmapReduction is enabled, so it is being replaced with a missing texture.", resourceLocation, textureAtlasSprite.func_94211_a(), textureAtlasSprite.func_94216_b(), MathHelper.func_151239_c(desiredMipPower), MathHelper.func_151239_c(mipPower));
++                return true;
++            }
++        }
++
++        return false;
 +    }
  }

--- a/src/main/java/net/minecraftforge/common/ForgeModContainer.java
+++ b/src/main/java/net/minecraftforge/common/ForgeModContainer.java
@@ -108,6 +108,7 @@ public class ForgeModContainer extends DummyModContainer implements WorldAccessC
     public static boolean forgeLightPipelineEnabled = true;
     public static boolean replaceVanillaBucketModel = true;
     public static long java8Reminder = 0;
+    public static boolean preventMipmapReduction = true;
 
     private static Configuration config;
     private static ForgeModContainer INSTANCE;
@@ -296,6 +297,12 @@ public class ForgeModContainer extends DummyModContainer implements WorldAccessC
         prop = config.get(Configuration.CATEGORY_CLIENT, "java8Reminder", java8Reminder,
                 "The timestamp of the last reminder to update to Java 8 in number of milliseconds since January 1, 1970, 00:00:00 GMT. Nag will show only once every 24 hours. To disable it set this to some really high number.");
         java8Reminder = prop.getLong(java8Reminder);
+        propOrder.add(prop.getName());
+
+        prop = config.get(Configuration.CATEGORY_CLIENT, "preventMipmapReduction", preventMipmapReduction,
+                "Prevent incorrectly sized textures from reducing the client's mipmap setting. Replaces them with an error texture.");
+        prop.setLanguageKey("forge.configgui.preventMipmapReduction").setRequiresMcRestart(true);
+        preventMipmapReduction = prop.getBoolean(preventMipmapReduction);
         propOrder.add(prop.getName());
 
         config.setCategoryPropertyOrder(CATEGORY_CLIENT, propOrder);

--- a/src/main/resources/assets/forge/lang/en_US.lang
+++ b/src/main/resources/assets/forge/lang/en_US.lang
@@ -46,6 +46,8 @@ forge.configgui.zombieBaseSummonChance=Zombie Summon Chance
 forge.configgui.stencilbits=Enable GL Stencil Bits
 forge.configgui.spawnfuzz=Respawn Fuzz Diameter
 forge.configgui.replaceBuckets=Use Forges' bucket model
+forge.configgui.preventMipmapReduction=Prevent Mipmap Reduction
+forge.configgui.preventMipmapReduction.tooltip=Prevent incorrectly sized textures from reducing the client's mipmap setting. Replaces them with a missing texture.
 
 forge.configgui.modID.tooltip=The mod ID that you want to define override settings for.
 forge.configgui.modID=Mod ID


### PR DESCRIPTION
## Problem:
The texture atlas needs textures that are multiples of 16x in order to support level 4 mipmapping.

A single mis-sized texture from a mod messes up the whole thing, and so most packs are stuck at level 0 or 2 mipmapping. 

Distant textures on mip level 0 look terrible, like this (cropped):
![mip0](https://cloud.githubusercontent.com/assets/916092/16756822/7fd01234-47bc-11e6-9aa6-91718ac2dd51.png)
It is even worse looking in motion.

The log only lists the first couple offenders like this so it is rarely noticed or fixed:
```
[Client thread/WARN]: Texture draconicevolution:textures/items/tools/obj/draconicHoe.png with size 4x4 limits mip level from 4 to 2
[Client thread/WARN]: Texture simplycaterpillar:textures/block/pieces/wood_piece.png with size 11x11 limits mip level from 2 to 0
```

## Solution:
This PR adds a config option, on by default, to disable these textures and preserve the desired mip level. 

Distant textures will look decent by default, like this (cropped):
![mip4](https://cloud.githubusercontent.com/assets/916092/16756859/cb9cc28e-47bc-11e6-82fb-d4ddce7c08d0.png)

It logs all offenders instead of the first few, like this:
```
[22:31:24] [Client thread/WARN]: Texture draconicevolution:textures/items/tools/obj/draconicHoe.png with size 4x4 would limit mip level from 4 to 2. Forge client config option preventMipmapReduction is true, so it is being replaced with a missing texture.
[22:31:24] [Client thread/WARN]: Texture draconicevolution:textures/items/tools/obj/draconicStaffOfPower.png with size 4x4 would limit mip level from 4 to 2. Forge client config option preventMipmapReduction is true, so it is being replaced with a missing texture.
[22:31:24] [Client thread/WARN]: Texture betterwithmods:textures/items/ironKnife.png with size 12x12 would limit mip level from 4 to 2. Forge client config option preventMipmapReduction is true, so it is being replaced with a missing texture.
[22:31:24] [Client thread/WARN]: Texture draconicevolution:textures/items/tools/obj/wyvernBow00.png with size 4x4 would limit mip level from 4 to 2. Forge client config option preventMipmapReduction is true, so it is being replaced with a missing texture.
[22:31:24] [Client thread/WARN]: Texture harvestfestival:textures/models/egg.png with size 8x8 would limit mip level from 4 to 3. Forge client config option preventMipmapReduction is true, so it is being replaced with a missing texture.
[22:31:24] [Client thread/WARN]: Texture draconicevolution:textures/items/tools/obj/wyvernShovel.png with size 4x4 would limit mip level from 4 to 2. Forge client config option preventMipmapReduction is true, so it is being replaced with a missing texture.
[22:31:24] [Client thread/WARN]: Texture draconicevolution:textures/items/tools/obj/draconicAxe.png with size 4x4 would limit mip level from 4 to 2. Forge client config option preventMipmapReduction is true, so it is being replaced with a missing texture.
[22:31:24] [Client thread/WARN]: Texture draconicevolution:textures/items/tools/obj/wyvernPickaxe.png with size 4x4 would limit mip level from 4 to 2. Forge client config option preventMipmapReduction is true, so it is being replaced with a missing texture.
[22:31:25] [Client thread/WARN]: Texture draconicevolution:textures/items/tools/obj/wyvernAxe.png with size 4x4 would limit mip level from 4 to 2. Forge client config option preventMipmapReduction is true, so it is being replaced with a missing texture.
[22:31:25] [Client thread/WARN]: Texture draconicevolution:textures/items/tools/obj/draconicBow00.png with size 4x4 would limit mip level from 4 to 2. Forge client config option preventMipmapReduction is true, so it is being replaced with a missing texture.
[22:31:25] [Client thread/WARN]: Texture draconicevolution:textures/items/tools/obj/draconicShovel.png with size 4x4 would limit mip level from 4 to 2. Forge client config option preventMipmapReduction is true, so it is being replaced with a missing texture.
[22:31:25] [Client thread/WARN]: Texture draconicevolution:textures/items/tools/obj/wyvernSword.png with size 4x4 would limit mip level from 4 to 2. Forge client config option preventMipmapReduction is true, so it is being replaced with a missing texture.
[22:31:25] [Client thread/WARN]: Texture simplycaterpillar:textures/block/pieces/wood_piece.png with size 11x11 would limit mip level from 4 to 0. Forge client config option preventMipmapReduction is true, so it is being replaced with a missing texture.
[22:31:25] [Client thread/WARN]: Texture draconicevolution:textures/items/tools/obj/draconicPickaxe.png with size 4x4 would limit mip level from 4 to 2. Forge client config option preventMipmapReduction is true, so it is being replaced with a missing texture.
[22:31:25] [Client thread/WARN]: Texture totemic:textures/blocks/tipi.png with size 40x40 would limit mip level from 4 to 3. Forge client config option preventMipmapReduction is true, so it is being replaced with a missing texture.
[22:31:25] [Client thread/WARN]: Texture draconicevolution:textures/items/tools/obj/draconicSword.png with size 4x4 would limit mip level from 4 to 2. Forge client config option preventMipmapReduction is true, so it is being replaced with a missing texture.
```

The messed up textures will become broken textures, and the mip level will stay at 4. This is much more noticeable, so mod makers will be notified of their texture issues. If desired, the player can disable the config or set their mip level lower so that they will not have missing textures.