### PR TITLE
[1.10.x] Add support for offhand bow aiming animation

### DIFF
--- a/patches/minecraft/net/minecraft/client/renderer/entity/RenderPlayer.java.patch
+++ b/patches/minecraft/net/minecraft/client/renderer/entity/RenderPlayer.java.patch
@@ -16,3 +16,15 @@
      }
  
      private void func_177137_d(AbstractClientPlayer p_177137_1_)
+@@ -127,6 +129,11 @@
+                     {
+                         modelbiped$armpose1 = ModelBiped.ArmPose.BLOCK;
+                     }
++                    // FORGE: fix MC-88356 allow offhand to use bow and arrow animation
++                    else if (enumaction1 == EnumAction.BOW)
++                    {
++                        modelbiped$armpose1 = ModelBiped.ArmPose.BOW_AND_ARROW;
++                    }
+                 }
+             }
+ 


### PR DESCRIPTION
Vanilla allows you to use a bow in your offhand, but it's not visible to others or in third person. This simply takes what's done to the main hand and replicates it for the offhand, which was missing the BOW action.

Fixes [MC-88356](https://bugs.mojang.com/browse/MC-88356)

1.10 version of #2983 