### PR TITLE
1.9: Add EntityItem#getPickupDelay method

### DIFF
--- a/patches/minecraft/net/minecraft/entity/item/EntityItem.java.patch
+++ b/patches/minecraft/net/minecraft/entity/item/EntityItem.java.patch
@@ -104,7 +104,19 @@
              return new ItemStack(Blocks.field_150348_b);
          }
          else
-@@ -494,6 +510,6 @@
+@@ -481,6 +497,11 @@
+         this.field_145804_b = p_174867_1_;
+     }
+ 
++    public int getPickupDelay()
++    {
++        return this.field_145804_b;
++    }
++
+     public boolean func_174874_s()
+     {
+         return this.field_145804_b > 0;
+@@ -494,6 +515,6 @@
      public void func_174870_v()
      {
          this.func_174871_r();


### PR DESCRIPTION
We have lots of new setters for various common behaviors relating to the EntityItem's pickup delay now, which is very handy. However, we have no way to simply get the value of the pickup delay. I have some in-world behavior that depends on being able to get the pickup delay, and I don't really want to do reflection.