### PR TITLE
[1.10.x] ItemStack capabilities Server > Client synchronization change

### DIFF
--- a/patches/minecraft/net/minecraft/entity/EntityLivingBase.java.patch
+++ b/patches/minecraft/net/minecraft/entity/EntityLivingBase.java.patch
@@ -193,7 +193,17 @@
          super.func_70071_h_();
          this.func_184608_ct();
  
-@@ -2409,6 +2442,40 @@
+@@ -1945,7 +1978,8 @@
+ 
+                 if (!ItemStack.func_77989_b(itemstack1, itemstack))
+                 {
+-                    ((WorldServer)this.field_70170_p).func_73039_n().func_151247_a(this, new SPacketEntityEquipment(this.func_145782_y(), entityequipmentslot, itemstack1));
++                    if (itemstack == null || itemstack1 == null || (!itemstack.hasCapabilities() && !itemstack1.hasCapabilities()) || !ItemStack.areItemStacksEqualIgnoreCaps(itemstack1, itemstack))
++                        ((WorldServer)this.field_70170_p).func_73039_n().func_151247_a(this, new SPacketEntityEquipment(this.func_145782_y(), entityequipmentslot, itemstack1));
+ 
+                     if (itemstack != null)
+                     {
+@@ -2409,6 +2443,40 @@
          this.field_70752_e = true;
      }
  
@@ -234,7 +244,7 @@
      public abstract EnumHandSide func_184591_cq();
  
      public boolean func_184587_cr()
-@@ -2429,12 +2496,19 @@
+@@ -2429,12 +2497,19 @@
  
              if (itemstack == this.field_184627_bm)
              {
@@ -255,7 +265,7 @@
                  {
                      this.func_71036_o();
                  }
-@@ -2452,8 +2526,10 @@
+@@ -2452,8 +2527,10 @@
  
          if (itemstack != null && !this.func_184587_cr())
          {
@@ -267,7 +277,7 @@
  
              if (!this.field_70170_p.field_72995_K)
              {
-@@ -2536,6 +2612,8 @@
+@@ -2536,6 +2613,8 @@
              this.func_184584_a(this.field_184627_bm, 16);
              ItemStack itemstack = this.field_184627_bm.func_77950_b(this.field_70170_p, this);
  
@@ -276,7 +286,7 @@
              if (itemstack != null && itemstack.field_77994_a == 0)
              {
                  itemstack = null;
-@@ -2566,7 +2644,8 @@
+@@ -2566,7 +2645,8 @@
      {
          if (this.field_184627_bm != null)
          {
@@ -286,7 +296,7 @@
          }
  
          this.func_184602_cy();
-@@ -2685,4 +2764,28 @@
+@@ -2685,4 +2765,28 @@
      {
          return true;
      }

--- a/patches/minecraft/net/minecraft/entity/EntityLivingBase.java.patch
+++ b/patches/minecraft/net/minecraft/entity/EntityLivingBase.java.patch
@@ -193,16 +193,14 @@
          super.func_70071_h_();
          this.func_184608_ct();
  
-@@ -1945,7 +1978,8 @@
+@@ -1945,6 +1978,7 @@
  
                  if (!ItemStack.func_77989_b(itemstack1, itemstack))
                  {
--                    ((WorldServer)this.field_70170_p).func_73039_n().func_151247_a(this, new SPacketEntityEquipment(this.func_145782_y(), entityequipmentslot, itemstack1));
 +                    if (itemstack == null || itemstack1 == null || (!itemstack.hasCapabilities() && !itemstack1.hasCapabilities()) || !ItemStack.areItemStacksEqualIgnoreCaps(itemstack1, itemstack))
-+                        ((WorldServer)this.field_70170_p).func_73039_n().func_151247_a(this, new SPacketEntityEquipment(this.func_145782_y(), entityequipmentslot, itemstack1));
+                     ((WorldServer)this.field_70170_p).func_73039_n().func_151247_a(this, new SPacketEntityEquipment(this.func_145782_y(), entityequipmentslot, itemstack1));
  
                      if (itemstack != null)
-                     {
 @@ -2409,6 +2443,40 @@
          this.field_70752_e = true;
      }

--- a/patches/minecraft/net/minecraft/inventory/Container.java.patch
+++ b/patches/minecraft/net/minecraft/inventory/Container.java.patch
@@ -1,6 +1,25 @@
 --- ../src-base/minecraft/net/minecraft/inventory/Container.java
 +++ ../src-work/minecraft/net/minecraft/inventory/Container.java
-@@ -650,7 +650,7 @@
+@@ -76,12 +76,16 @@
+ 
+             if (!ItemStack.func_77989_b(itemstack1, itemstack))
+             {
++                boolean nonCapDifference = itemstack == null || itemstack1 == null || (!itemstack.hasCapabilities() && !itemstack1.hasCapabilities()) || !ItemStack.areItemStacksEqualIgnoreCaps(itemstack1, itemstack);
+                 itemstack1 = itemstack == null ? null : itemstack.func_77946_l();
+                 this.field_75153_a.set(i, itemstack1);
+ 
+-                for (int j = 0; j < this.field_75149_d.size(); ++j)
++                if (nonCapDifference)
+                 {
+-                    ((IContainerListener)this.field_75149_d.get(j)).func_71111_a(this, i, itemstack1);
++                    for (int j = 0; j < this.field_75149_d.size(); ++j)
++                    {
++                        ((IContainerListener)this.field_75149_d.get(j)).func_71111_a(this, i, itemstack1);
++                    }
+                 }
+             }
+         }
+@@ -650,7 +654,7 @@
                  Slot slot1 = (Slot)this.field_75151_b.get(i);
                  ItemStack itemstack1 = slot1.func_75211_c();
  
@@ -9,7 +28,7 @@
                  {
                      slot1.func_75215_d(p_75135_1_.func_77946_l());
                      slot1.func_75218_e();
-@@ -728,7 +728,7 @@
+@@ -728,7 +732,7 @@
                  p_94525_2_.field_77994_a = 1;
                  break;
              case 2:

--- a/patches/minecraft/net/minecraft/inventory/Container.java.patch
+++ b/patches/minecraft/net/minecraft/inventory/Container.java.patch
@@ -1,6 +1,6 @@
 --- ../src-base/minecraft/net/minecraft/inventory/Container.java
 +++ ../src-work/minecraft/net/minecraft/inventory/Container.java
-@@ -76,12 +76,16 @@
+@@ -76,9 +76,11 @@
  
              if (!ItemStack.func_77989_b(itemstack1, itemstack))
              {
@@ -8,18 +8,11 @@
                  itemstack1 = itemstack == null ? null : itemstack.func_77946_l();
                  this.field_75153_a.set(i, itemstack1);
  
--                for (int j = 0; j < this.field_75149_d.size(); ++j)
 +                if (nonCapDifference)
+                 for (int j = 0; j < this.field_75149_d.size(); ++j)
                  {
--                    ((IContainerListener)this.field_75149_d.get(j)).func_71111_a(this, i, itemstack1);
-+                    for (int j = 0; j < this.field_75149_d.size(); ++j)
-+                    {
-+                        ((IContainerListener)this.field_75149_d.get(j)).func_71111_a(this, i, itemstack1);
-+                    }
-                 }
-             }
-         }
-@@ -650,7 +654,7 @@
+                     ((IContainerListener)this.field_75149_d.get(j)).func_71111_a(this, i, itemstack1);
+@@ -650,7 +652,7 @@
                  Slot slot1 = (Slot)this.field_75151_b.get(i);
                  ItemStack itemstack1 = slot1.func_75211_c();
  
@@ -28,7 +21,7 @@
                  {
                      slot1.func_75215_d(p_75135_1_.func_77946_l());
                      slot1.func_75218_e();
-@@ -728,7 +732,7 @@
+@@ -728,7 +730,7 @@
                  p_94525_2_.field_77994_a = 1;
                  break;
              case 2:

--- a/patches/minecraft/net/minecraft/item/ItemStack.java.patch
+++ b/patches/minecraft/net/minecraft/item/ItemStack.java.patch
@@ -235,7 +235,7 @@
          this.field_151002_e = p_150996_1_;
      }
  
-@@ -993,4 +1029,45 @@
+@@ -993,4 +1029,69 @@
              return false;
          }
      }
@@ -279,5 +279,29 @@
 +        {
 +            return this.capabilities.areCompatible(other.capabilities);
 +        }
++    }
++
++    public static boolean areItemStacksEqualIgnoreCaps(@Nullable ItemStack stackA, @Nullable ItemStack stackB)
++    {
++        if (stackA == null && stackB == null) return true;
++        if (stackA == null && stackB != null) return false;
++        if (stackA != null && stackB == null) return false;
++        if (stackA.field_77994_a != stackB.field_77994_a) return false;
++        if (stackA.field_151002_e != stackB.field_151002_e) return false;
++        if (stackA.field_77991_e != stackB.field_77991_e) return false;
++        if (stackA.field_77990_d == null && stackB.field_77990_d != null) return false;
++        if (stackA.field_77990_d != null && stackB.field_77990_d == null) return false;
++        if (stackA.field_77990_d != null && !stackA.field_77990_d.equals(stackB.field_77990_d)) return false;
++        return true;
++    }
++
++    public boolean hasCapabilities()
++    {
++        return this.capabilities != null;
++    }
++
++    public NBTTagCompound getCapNBT()
++    {
++        return this.capabilities == null ? null : this.capabilities.serializeNBT();
 +    }
  }

--- a/patches/minecraft/net/minecraft/network/PacketBuffer.java.patch
+++ b/patches/minecraft/net/minecraft/network/PacketBuffer.java.patch
@@ -1,0 +1,19 @@
+--- ../src-base/minecraft/net/minecraft/network/PacketBuffer.java
++++ ../src-work/minecraft/net/minecraft/network/PacketBuffer.java
+@@ -331,6 +331,7 @@
+             this.writeShort(p_150788_1_.func_77960_j());
+             NBTTagCompound nbttagcompound = null;
+ 
++            this.func_150786_a(p_150788_1_.getCapNBT());
+             if (p_150788_1_.func_77973_b().func_77645_m() || p_150788_1_.func_77973_b().func_77651_p())
+             {
+                 nbttagcompound = p_150788_1_.func_77978_p();
+@@ -352,7 +353,7 @@
+         {
+             int j = this.readByte();
+             int k = this.readShort();
+-            itemstack = new ItemStack(Item.func_150899_d(i), j, k);
++            itemstack = new ItemStack(Item.func_150899_d(i), j, k, this.func_150793_b());
+             itemstack.func_77982_d(this.func_150793_b());
+         }
+ 


### PR DESCRIPTION
Change to prevent capability only ItemStack changes updating client and change to include capability data in packets when they do sync.

Current behavior is that itemstacks on client get updated on every capability change, but the capabilities are not included in update packets and thus it only deletes them on client (in case that they got there using some other packet). 
After this change the two packets that get triggered on itemstack changes (SPacketEntityEquipment and SPacketSetSlot) are not triggered for capability only changes.
Also the change adds capNBT data to the itemstack syncing packets (through PacketBuffer change).

After this change it will be possible to update capabilities in onUsingTick and if the mod chooses to they can sync the cap data to client using their own packet. 
And when stuff like nbt or damage update on the item it won't delete the cap data on client causing pretty bad loses of data like it does today, but instead will sync the cap data with the rest of the itemstack.

Here is a bit of investigation I did around the packets that sync itemstack data to client and reasoning behind change/no change:
https://gist.github.com/P3pp3rF1y/e4830a82d3ed9733f08fafe3b7e084db
