### PR TITLE
[1.10.x] Fix ItemHandlerHelper canStack methods not checking capabilities

### DIFF
--- a/src/main/java/net/minecraftforge/event/AttachCapabilitiesEvent.java
+++ b/src/main/java/net/minecraftforge/event/AttachCapabilitiesEvent.java
@@ -126,8 +126,8 @@ public class AttachCapabilitiesEvent<T> extends GenericEvent<T>
      */
     public static class Item extends AttachCapabilitiesEvent<net.minecraft.item.Item>
     {
-        @Deprecated
         private final net.minecraft.item.ItemStack stack;
+        @Deprecated
         private final net.minecraft.item.Item item;
         public Item(net.minecraft.item.Item item, net.minecraft.item.ItemStack stack)
         {

--- a/src/main/java/net/minecraftforge/items/ItemHandlerHelper.java
+++ b/src/main/java/net/minecraftforge/items/ItemHandlerHelper.java
@@ -52,9 +52,7 @@ public class ItemHandlerHelper
         if (a == null || !a.isItemEqual(b))
             return false;
 
-        final NBTTagCompound aTag = a.getTagCompound();
-        final NBTTagCompound bTag = b.getTagCompound();
-        return (aTag != null || bTag == null) && (aTag == null || aTag.equals(bTag));
+        return ItemStack.areItemStackTagsEqual(a, b);
     }
 
     /**
@@ -75,9 +73,7 @@ public class ItemHandlerHelper
         if (a.getHasSubtypes() && a.getMetadata() != b.getMetadata())
             return false;
 
-        final NBTTagCompound aTag = a.getTagCompound();
-        final NBTTagCompound bTag = b.getTagCompound();
-        return (aTag != null || bTag == null) && (aTag == null || aTag.equals(bTag));
+        return ItemStack.areItemStackTagsEqual(a, b);
     }
 
     public static ItemStack copyStackWithSize(ItemStack itemStack, int size)


### PR DESCRIPTION
Update of #2980 to target the 1.10.x branch.

Edit 12-3-16:
Currently the canStack methods in ItemHandlerHelper preform a custom check to determine if the NBT tags are equal. The problem with this is capabilities are not taken into account. This PR replaces the custom check with a call to 'ItemStack.areItemStackTagsEqual' which checks capabilities. In addition, I expanded the TestCapMod to include ItemStacks with capability data. Note that only ItemStacks with the same capability data stack.