### PR TITLE
[1.10.X] Add Block#getSoundEvent, Block#getSoundVolume, and Block#getSoundPitch

### DIFF
--- a/patches/minecraft/net/minecraft/block/Block.java.patch
+++ b/patches/minecraft/net/minecraft/block/Block.java.patch
@@ -195,7 +195,7 @@
      }
  
      @SideOnly(Side.CLIENT)
-@@ -893,6 +912,1141 @@
+@@ -893,6 +912,1185 @@
          return "Block{" + field_149771_c.func_177774_c(this) + "}";
      }
  
@@ -1331,6 +1331,50 @@
 +     */
 +    public void addInformation(ItemStack stack, EntityPlayer player, List<String> tooltip, boolean advanced)
 +    {
++    }
++    
++    /**
++     * 
++     * @param worldIn The World of the Block
++     * @param pos The position of the Block
++     * @param entityIn The Entity that is requesting the sound
++     * @param type The SoundEvent type that should be returned
++     * @return The sound that will be played
++     */
++    public net.minecraft.util.SoundEvent getSoundEvent(IBlockAccess worldIn, BlockPos pos, @Nullable Entity entityIn, net.minecraftforge.common.EnumSoundEventType type)
++    {
++        switch(type)
++        {
++            case BLOCK_STEP : return this.field_149762_H.func_185844_d();
++            case BLOCK_PLACE : return this.field_149762_H.func_185841_e();
++            case BLOCK_HIT : return this.field_149762_H.func_185846_f();
++            case BLOCK_FALL : return this.field_149762_H.func_185842_g();
++            default : return this.field_149762_H.func_185845_c();
++        }
++    }
++
++    /**
++     * 
++     * @param worldIn The World of the Block
++     * @param pos The position of the Block
++     * @param entityIn The entity requesting the volume
++     * @return The volume that will be played
++     */
++    public float getSoundVolume(IBlockAccess worldIn, BlockPos pos, @Nullable Entity entityIn)
++    {
++        return this.field_149762_H.func_185843_a();
++    }
++
++    /**
++     * 
++     * @param worldIn The World of the Block
++     * @param pos The position of the Block
++     * @param entityIn The entity requesting the volume
++     * @return The volume that will be played
++     */
++    public float getSoundPitch(IBlockAccess worldIn, BlockPos pos, @Nullable Entity entityIn)
++    {
++        return this.field_149762_H.func_185847_b();
 +    }
 +    /* ========================================= FORGE END ======================================*/
 +

--- a/patches/minecraft/net/minecraft/block/SoundType.java.patch
+++ b/patches/minecraft/net/minecraft/block/SoundType.java.patch
@@ -1,0 +1,18 @@
+--- ../src-base/minecraft/net/minecraft/block/SoundType.java
++++ ../src-work/minecraft/net/minecraft/block/SoundType.java
+@@ -48,7 +48,6 @@
+         return this.field_185861_n;
+     }
+ 
+-    @SideOnly(Side.CLIENT)
+     public SoundEvent func_185845_c()
+     {
+         return this.field_185862_o;
+@@ -64,7 +63,6 @@
+         return this.field_185864_q;
+     }
+ 
+-    @SideOnly(Side.CLIENT)
+     public SoundEvent func_185846_f()
+     {
+         return this.field_185865_r;

--- a/patches/minecraft/net/minecraft/client/multiplayer/PlayerControllerMP.java.patch
+++ b/patches/minecraft/net/minecraft/client/multiplayer/PlayerControllerMP.java.patch
@@ -1,6 +1,25 @@
 --- ../src-base/minecraft/net/minecraft/client/multiplayer/PlayerControllerMP.java
 +++ ../src-work/minecraft/net/minecraft/client/multiplayer/PlayerControllerMP.java
-@@ -123,6 +123,12 @@
+@@ -1,11 +1,11 @@
+ package net.minecraft.client.multiplayer;
+ import javax.annotation.Nullable;
+ import io.netty.buffer.Unpooled;
+ import net.minecraft.block.Block;
+ import net.minecraft.block.BlockCommandBlock;
+ import net.minecraft.block.BlockStructure;
+-import net.minecraft.block.SoundType;
+ import net.minecraft.block.material.Material;
+ import net.minecraft.block.state.IBlockState;
+ import net.minecraft.client.Minecraft;
+@@ -15,7 +15,6 @@
+ import net.minecraft.entity.Entity;
+ import net.minecraft.entity.passive.EntityHorse;
+ import net.minecraft.entity.player.EntityPlayer;
+-import net.minecraft.init.Blocks;
+ import net.minecraft.inventory.ClickType;
+ import net.minecraft.item.ItemBlock;
+ import net.minecraft.item.ItemStack;
+@@ -123,6 +122,12 @@
              }
          }
  
@@ -13,7 +32,7 @@
          if (this.field_78779_k.func_77145_d() && this.field_78776_a.field_71439_g.func_184614_ca() != null && this.field_78776_a.field_71439_g.func_184614_ca().func_77973_b() instanceof ItemSword)
          {
              return false;
-@@ -144,14 +150,7 @@
+@@ -144,14 +149,7 @@
              else
              {
                  world.func_175718_b(2001, p_187103_1_, Block.func_176210_f(iblockstate));
@@ -28,7 +47,7 @@
                  this.field_178895_c = new BlockPos(this.field_178895_c.func_177958_n(), -1, this.field_178895_c.func_177952_p());
  
                  if (!this.field_78779_k.func_77145_d())
-@@ -162,13 +161,20 @@
+@@ -162,13 +160,20 @@
                      {
                          itemstack1.func_179548_a(world, iblockstate, p_187103_1_, this.field_78776_a.field_71439_g);
  
@@ -50,7 +69,7 @@
                  return flag;
              }
          }
-@@ -208,6 +214,7 @@
+@@ -208,6 +213,7 @@
              if (this.field_78779_k.func_77145_d())
              {
                  this.field_78774_b.func_147297_a(new CPacketPlayerDigging(CPacketPlayerDigging.Action.START_DESTROY_BLOCK, p_180511_1_, p_180511_2_));
@@ -58,7 +77,7 @@
                  func_178891_a(this.field_78776_a, this, p_180511_1_, p_180511_2_);
                  this.field_78781_i = 5;
              }
-@@ -219,14 +226,17 @@
+@@ -219,14 +225,17 @@
                  }
  
                  this.field_78774_b.func_147297_a(new CPacketPlayerDigging(CPacketPlayerDigging.Action.START_DESTROY_BLOCK, p_180511_1_, p_180511_2_));
@@ -77,7 +96,20 @@
                  if (flag && iblockstate.func_185903_a(this.field_78776_a.field_71439_g, this.field_78776_a.field_71439_g.field_70170_p, p_180511_1_) >= 1.0F)
                  {
                      this.func_187103_a(p_180511_1_);
-@@ -373,13 +383,32 @@
+@@ -290,8 +299,10 @@
+ 
+                 if (this.field_78780_h % 4.0F == 0.0F)
+                 {
+-                    SoundType soundtype = block.func_185467_w();
+-                    this.field_78776_a.func_147118_V().func_147682_a(new PositionedSoundRecord(soundtype.func_185846_f(), SoundCategory.NEUTRAL, (soundtype.func_185843_a() + 1.0F) / 8.0F, soundtype.func_185847_b() * 0.5F, p_180512_1_));
++                    net.minecraft.util.SoundEvent hitSound = block.getSoundEvent(this.field_78776_a.field_71441_e, p_180512_1_, this.field_78776_a.field_71439_g, net.minecraftforge.common.EnumSoundEventType.BLOCK_HIT);
++                    float volume = block.getSoundVolume(this.field_78776_a.field_71441_e, p_180512_1_, this.field_78776_a.field_71439_g);
++                    float pitch = block.getSoundPitch(this.field_78776_a.field_71441_e, p_180512_1_, this.field_78776_a.field_71439_g);
++                    this.field_78776_a.func_147118_V().func_147682_a(new PositionedSoundRecord(hitSound, SoundCategory.NEUTRAL, (volume + 1.0F) / 8.0F, pitch * 0.5F, p_180512_1_));
+                 }
+ 
+                 ++this.field_78780_h;
+@@ -373,13 +384,32 @@
          }
          else
          {
@@ -112,7 +144,7 @@
                  }
  
                  if (!flag && p_187099_3_ != null && p_187099_3_.func_77973_b() instanceof ItemBlock)
-@@ -395,7 +424,7 @@
+@@ -395,7 +425,7 @@
  
              this.field_78774_b.func_147297_a(new CPacketPlayerTryUseItemOnBlock(p_187099_4_, p_187099_5_, p_187099_7_, f, f1, f2));
  
@@ -121,7 +153,7 @@
              {
                  if (p_187099_3_ == null)
                  {
-@@ -421,14 +450,19 @@
+@@ -421,14 +451,19 @@
                      {
                          int i = p_187099_3_.func_77960_j();
                          int j = p_187099_3_.field_77994_a;
@@ -142,7 +174,7 @@
                      }
                  }
              }
-@@ -456,6 +490,7 @@
+@@ -456,6 +491,7 @@
              }
              else
              {
@@ -150,7 +182,7 @@
                  int i = p_187101_3_.field_77994_a;
                  ActionResult<ItemStack> actionresult = p_187101_3_.func_77957_a(p_187101_2_, p_187101_1_, p_187101_4_);
                  ItemStack itemstack = (ItemStack)actionresult.func_188398_b();
-@@ -464,9 +499,10 @@
+@@ -464,9 +500,10 @@
                  {
                      p_187101_1_.func_184611_a(p_187101_4_, itemstack);
  
@@ -162,7 +194,7 @@
                      }
                  }
  
-@@ -504,6 +540,7 @@
+@@ -504,6 +541,7 @@
          this.func_78750_j();
          Vec3d vec3d = new Vec3d(p_187102_3_.field_72307_f.field_72450_a - p_187102_2_.field_70165_t, p_187102_3_.field_72307_f.field_72448_b - p_187102_2_.field_70163_u, p_187102_3_.field_72307_f.field_72449_c - p_187102_2_.field_70161_v);
          this.field_78774_b.func_147297_a(new CPacketUseEntity(p_187102_2_, p_187102_5_, vec3d));

--- a/patches/minecraft/net/minecraft/client/renderer/RenderGlobal.java.patch
+++ b/patches/minecraft/net/minecraft/client/renderer/RenderGlobal.java.patch
@@ -1,6 +1,55 @@
 --- ../src-base/minecraft/net/minecraft/client/renderer/RenderGlobal.java
 +++ ../src-work/minecraft/net/minecraft/client/renderer/RenderGlobal.java
-@@ -548,8 +548,10 @@
+@@ -1,10 +1,5 @@
+ package net.minecraft.client.renderer;
+ 
+-import com.google.common.collect.Lists;
+-import com.google.common.collect.Maps;
+-import com.google.common.collect.Queues;
+-import com.google.common.collect.Sets;
+-import com.google.gson.JsonSyntaxException;
+ import java.io.IOException;
+ import java.util.Collection;
+ import java.util.Iterator;
+@@ -13,13 +8,25 @@
+ import java.util.Queue;
+ import java.util.Random;
+ import java.util.Set;
++
+ import javax.annotation.Nullable;
++
++import org.apache.logging.log4j.LogManager;
++import org.apache.logging.log4j.Logger;
++import org.lwjgl.util.vector.Vector3f;
++import org.lwjgl.util.vector.Vector4f;
++
++import com.google.common.collect.Lists;
++import com.google.common.collect.Maps;
++import com.google.common.collect.Queues;
++import com.google.common.collect.Sets;
++import com.google.gson.JsonSyntaxException;
++
+ import net.minecraft.block.Block;
+ import net.minecraft.block.BlockChest;
+ import net.minecraft.block.BlockEnderChest;
+ import net.minecraft.block.BlockSign;
+ import net.minecraft.block.BlockSkull;
+-import net.minecraft.block.SoundType;
+ import net.minecraft.block.material.Material;
+ import net.minecraft.block.state.IBlockState;
+ import net.minecraft.client.Minecraft;
+@@ -86,10 +93,6 @@
+ import net.minecraft.world.chunk.Chunk;
+ import net.minecraftforge.fml.relauncher.Side;
+ import net.minecraftforge.fml.relauncher.SideOnly;
+-import org.apache.logging.log4j.LogManager;
+-import org.apache.logging.log4j.Logger;
+-import org.lwjgl.util.vector.Vector3f;
+-import org.lwjgl.util.vector.Vector4f;
+ 
+ @SideOnly(Side.CLIENT)
+ public class RenderGlobal implements IWorldEventListener, IResourceManagerReloadListener
+@@ -548,8 +551,10 @@
  
      public void func_180446_a(Entity p_180446_1_, ICamera p_180446_2_, float p_180446_3_)
      {
@@ -11,7 +60,7 @@
              --this.field_72740_G;
          }
          else
-@@ -560,9 +562,12 @@
+@@ -560,9 +565,12 @@
              this.field_72769_h.field_72984_F.func_76320_a("prepare");
              TileEntityRendererDispatcher.field_147556_a.func_190056_a(this.field_72769_h, this.field_72777_q.func_110434_K(), this.field_72777_q.field_71466_p, this.field_72777_q.func_175606_aa(), this.field_72777_q.field_71476_x, p_180446_3_);
              this.field_175010_j.func_180597_a(this.field_72769_h, this.field_72777_q.field_71466_p, this.field_72777_q.func_175606_aa(), this.field_72777_q.field_147125_j, this.field_72777_q.field_71474_y, p_180446_3_);
@@ -24,7 +73,7 @@
              Entity entity = this.field_72777_q.func_175606_aa();
              double d3 = entity.field_70142_S + (entity.field_70165_t - entity.field_70142_S) * (double)p_180446_3_;
              double d4 = entity.field_70137_T + (entity.field_70163_u - entity.field_70137_T) * (double)p_180446_3_;
-@@ -574,11 +579,15 @@
+@@ -574,11 +582,15 @@
              this.field_72777_q.field_71460_t.func_180436_i();
              this.field_72769_h.field_72984_F.func_76318_c("global");
              List<Entity> list = this.field_72769_h.func_72910_y();
@@ -40,7 +89,7 @@
                  ++this.field_72749_I;
  
                  if (entity1.func_145770_h(d0, d1, d2))
-@@ -601,6 +610,7 @@
+@@ -601,6 +613,7 @@
                  {
                      for (Entity entity2 : classinheritancemultimap)
                      {
@@ -48,7 +97,7 @@
                          boolean flag = this.field_175010_j.func_178635_a(entity2, p_180446_2_, d0, d1, d2) || entity2.func_184215_y(this.field_72777_q.field_71439_g);
  
                          if (flag)
-@@ -637,6 +647,7 @@
+@@ -637,6 +650,7 @@
                  }
              }
  
@@ -56,7 +105,7 @@
              if (this.func_174985_d() && (!list1.isEmpty() || this.field_184386_ad))
              {
                  this.field_72769_h.field_72984_F.func_76318_c("entityOutlines");
-@@ -676,6 +687,7 @@
+@@ -676,6 +690,7 @@
              this.field_72769_h.field_72984_F.func_76318_c("blockentities");
              RenderHelper.func_74519_b();
  
@@ -64,7 +113,7 @@
              for (RenderGlobal.ContainerLocalRenderInformation renderglobal$containerlocalrenderinformation1 : this.field_72755_R)
              {
                  List<TileEntity> list3 = renderglobal$containerlocalrenderinformation1.field_178036_a.func_178571_g().func_178485_b();
-@@ -684,6 +696,7 @@
+@@ -684,6 +699,7 @@
                  {
                      for (TileEntity tileentity2 : list3)
                      {
@@ -72,7 +121,7 @@
                          TileEntityRendererDispatcher.field_147556_a.func_180546_a(tileentity2, p_180446_3_, -1);
                      }
                  }
-@@ -693,9 +706,11 @@
+@@ -693,9 +709,11 @@
              {
                  for (TileEntity tileentity : this.field_181024_n)
                  {
@@ -84,7 +133,7 @@
  
              this.func_180443_s();
  
-@@ -722,7 +737,7 @@
+@@ -722,7 +740,7 @@
  
                  Block block = this.field_72769_h.func_180495_p(blockpos).func_177230_c();
  
@@ -93,7 +142,7 @@
                  {
                      TileEntityRendererDispatcher.field_147556_a.func_180546_a(tileentity1, p_180446_3_, destroyblockprogress.func_73106_e());
                  }
-@@ -1213,6 +1228,13 @@
+@@ -1213,6 +1231,13 @@
  
      public void func_174976_a(float p_174976_1_, int p_174976_2_)
      {
@@ -107,7 +156,7 @@
          if (this.field_72777_q.field_71441_e.field_73011_w.func_186058_p().func_186068_a() == 1)
          {
              this.func_180448_r();
-@@ -1430,6 +1452,12 @@
+@@ -1430,6 +1455,12 @@
  
      public void func_180447_b(float p_180447_1_, int p_180447_2_)
      {
@@ -120,7 +169,7 @@
          if (this.field_72777_q.field_71441_e.field_73011_w.func_76569_d())
          {
              if (this.field_72777_q.field_71474_y.func_181147_e() == 2)
-@@ -1857,8 +1885,11 @@
+@@ -1857,8 +1888,11 @@
                  double d4 = (double)blockpos.func_177956_o() - d1;
                  double d5 = (double)blockpos.func_177952_p() - d2;
                  Block block = this.field_72769_h.func_180495_p(blockpos).func_177230_c();
@@ -133,3 +182,16 @@
                  {
                      if (d3 * d3 + d4 * d4 + d5 * d5 > 1024.0D)
                      {
+@@ -2304,8 +2338,10 @@
+ 
+                 if (block.func_176223_P().func_185904_a() != Material.field_151579_a)
+                 {
+-                    SoundType soundtype = block.func_185467_w();
+-                    this.field_72769_h.func_184156_a(p_180439_3_, soundtype.func_185845_c(), SoundCategory.BLOCKS, (soundtype.func_185843_a() + 1.0F) / 2.0F, soundtype.func_185847_b() * 0.8F, false);
++                    net.minecraft.util.SoundEvent breakSound = block.getSoundEvent(this.field_72769_h, p_180439_3_, p_180439_1_, net.minecraftforge.common.EnumSoundEventType.BLOCK_BREAK);
++                    float volume = block.getSoundVolume(this.field_72769_h, p_180439_3_, p_180439_1_);
++                    float pitch = block.getSoundPitch(this.field_72769_h, p_180439_3_, p_180439_1_);
++                    this.field_72769_h.func_184156_a(p_180439_3_, breakSound, SoundCategory.BLOCKS, (volume + 1.0F) / 2.0F, pitch * 0.8F, false);
+                 }
+ 
+                 this.field_72777_q.field_71452_i.func_180533_a(p_180439_3_, block.func_176203_a(p_180439_4_ >> 12 & 255));

--- a/patches/minecraft/net/minecraft/entity/Entity.java.patch
+++ b/patches/minecraft/net/minecraft/entity/Entity.java.patch
@@ -1,15 +1,40 @@
 --- ../src-base/minecraft/net/minecraft/entity/Entity.java
 +++ ../src-work/minecraft/net/minecraft/entity/Entity.java
-@@ -78,7 +78,7 @@
+@@ -1,21 +1,25 @@
+ package net.minecraft.entity;
+ 
+ import java.util.Collection;
+ import java.util.Collections;
+ import java.util.List;
+ import java.util.Random;
+ import java.util.Set;
+ import java.util.UUID;
+ import javax.annotation.Nullable;
  import org.apache.logging.log4j.LogManager;
  import org.apache.logging.log4j.Logger;
+ import com.google.common.collect.Iterables;
+ import com.google.common.collect.Lists;
+ import com.google.common.collect.Sets;
+ import net.minecraft.block.Block;
+ import net.minecraft.block.BlockFence;
+ import net.minecraft.block.BlockFenceGate;
+-import net.minecraft.block.BlockLiquid;
+ import net.minecraft.block.BlockWall;
+-import net.minecraft.block.SoundType;
+ import net.minecraft.block.material.EnumPushReaction;
+ import net.minecraft.block.material.Material;
+ import net.minecraft.block.state.IBlockState;
+@@ -75,10 +79,8 @@
+ import net.minecraft.world.WorldServer;
+ import net.minecraftforge.fml.relauncher.Side;
+ import net.minecraftforge.fml.relauncher.SideOnly;
  
 -public abstract class Entity implements ICommandSender
 +public abstract class Entity implements ICommandSender, net.minecraftforge.common.capabilities.ICapabilitySerializable<NBTTagCompound>
  {
      private static final Logger field_184243_a = LogManager.getLogger();
      private static final AxisAlignedBB field_174836_a = new AxisAlignedBB(0.0D, 0.0D, 0.0D, 0.0D, 0.0D, 0.0D);
-@@ -190,7 +190,7 @@
+@@ -190,7 +192,7 @@
  
          if (p_i1582_1_ != null)
          {
@@ -18,7 +43,7 @@
          }
  
          this.field_70180_af = new EntityDataManager(this);
-@@ -201,8 +201,16 @@
+@@ -201,8 +203,16 @@
          this.field_70180_af.func_187214_a(field_184234_aB, Boolean.valueOf(false));
          this.field_70180_af.func_187214_a(field_189655_aD, Boolean.valueOf(false));
          this.func_70088_a();
@@ -35,7 +60,34 @@
      public int func_145782_y()
      {
          return this.field_145783_c;
-@@ -1151,12 +1159,12 @@
+@@ -944,16 +954,20 @@
+ 
+     protected void func_180429_a(BlockPos p_180429_1_, Block p_180429_2_)
+     {
+-        SoundType soundtype = p_180429_2_.func_185467_w();
++        net.minecraft.util.SoundEvent stepSound = p_180429_2_.getSoundEvent(this.field_70170_p, p_180429_1_, this, net.minecraftforge.common.EnumSoundEventType.BLOCK_STEP);
++        float volume = p_180429_2_.getSoundVolume(this.field_70170_p, p_180429_1_, this);
++        float pitch = p_180429_2_.getSoundPitch(this.field_70170_p, p_180429_1_, this);
++        Block block1 = this.field_70170_p.func_180495_p(p_180429_1_.func_177984_a()).func_177230_c();
+ 
+-        if (this.field_70170_p.func_180495_p(p_180429_1_.func_177984_a()).func_177230_c() == Blocks.field_150431_aC)
++        if (block1 == Blocks.field_150431_aC)
+         {
+-            soundtype = Blocks.field_150431_aC.func_185467_w();
+-            this.func_184185_a(soundtype.func_185844_d(), soundtype.func_185843_a() * 0.15F, soundtype.func_185847_b());
++            stepSound = p_180429_2_.getSoundEvent(this.field_70170_p, p_180429_1_.func_177984_a(), this, net.minecraftforge.common.EnumSoundEventType.BLOCK_STEP);
++            volume = p_180429_2_.getSoundVolume(this.field_70170_p, p_180429_1_.func_177984_a(), this);
++            pitch = p_180429_2_.getSoundPitch(this.field_70170_p, p_180429_1_, this);
+         }
+-        else if (!p_180429_2_.func_176223_P().func_185904_a().func_76224_d())
++        if (!p_180429_2_.func_176223_P().func_185904_a().func_76224_d())
+         {
+-            this.func_184185_a(soundtype.func_185844_d(), soundtype.func_185843_a() * 0.15F, soundtype.func_185847_b());
++            this.func_184185_a(stepSound, volume * 0.15F, pitch);
+         }
+     }
+ 
+@@ -1151,12 +1165,12 @@
              BlockPos blockpos = new BlockPos(this.field_70165_t, d0, this.field_70161_v);
              IBlockState iblockstate = this.field_70170_p.func_180495_p(blockpos);
  
@@ -52,7 +104,7 @@
              }
              else
              {
-@@ -1568,6 +1576,9 @@
+@@ -1568,6 +1582,9 @@
                  p_189511_1_.func_74782_a("Tags", nbttaglist);
              }
  
@@ -62,7 +114,7 @@
              this.func_70014_b(p_189511_1_);
  
              if (this.func_184207_aI())
-@@ -1675,6 +1686,9 @@
+@@ -1675,6 +1692,9 @@
              this.func_189654_d(p_70020_1_.func_74767_n("NoGravity"));
              this.func_184195_f(p_70020_1_.func_74767_n("Glowing"));
  
@@ -72,7 +124,7 @@
              if (p_70020_1_.func_150297_b("Tags", 9))
              {
                  this.field_184236_aF.clear();
-@@ -1757,7 +1771,10 @@
+@@ -1757,7 +1777,10 @@
          {
              EntityItem entityitem = new EntityItem(this.field_70170_p, this.field_70165_t, this.field_70163_u + (double)p_70099_2_, this.field_70161_v, p_70099_1_);
              entityitem.func_174869_p();
@@ -84,7 +136,7 @@
              return entityitem;
          }
          else
-@@ -1867,6 +1884,7 @@
+@@ -1867,6 +1890,7 @@
  
      public boolean func_184205_a(Entity p_184205_1_, boolean p_184205_2_)
      {
@@ -92,7 +144,7 @@
          if (p_184205_2_ || this.func_184228_n(p_184205_1_) && p_184205_1_.func_184219_q(this))
          {
              if (this.func_184218_aH())
-@@ -2336,6 +2354,7 @@
+@@ -2336,6 +2360,7 @@
      {
          if (!this.field_70170_p.field_72995_K && !this.field_70128_L)
          {
@@ -100,7 +152,7 @@
              this.field_70170_p.field_72984_F.func_76320_a("changeDimension");
              MinecraftServer minecraftserver = this.func_184102_h();
              int i = this.field_71093_bK;
-@@ -2429,7 +2448,7 @@
+@@ -2429,7 +2454,7 @@
  
      public float func_180428_a(Explosion p_180428_1_, World p_180428_2_, BlockPos p_180428_3_, IBlockState p_180428_4_)
      {
@@ -109,7 +161,7 @@
      }
  
      public boolean func_174816_a(Explosion p_174816_1_, World p_174816_2_, BlockPos p_174816_3_, IBlockState p_174816_4_, float p_174816_5_)
-@@ -2726,6 +2745,164 @@
+@@ -2726,6 +2751,164 @@
          EnchantmentHelper.func_151385_b(p_174815_1_, p_174815_2_);
      }
  

--- a/patches/minecraft/net/minecraft/entity/EntityLivingBase.java.patch
+++ b/patches/minecraft/net/minecraft/entity/EntityLivingBase.java.patch
@@ -1,6 +1,13 @@
 --- ../src-base/minecraft/net/minecraft/entity/EntityLivingBase.java
 +++ ../src-work/minecraft/net/minecraft/entity/EntityLivingBase.java
-@@ -193,10 +193,11 @@
+@@ -68,6 +68,7 @@
+ import net.minecraft.util.math.Vec3d;
+ import net.minecraft.world.World;
+ import net.minecraft.world.WorldServer;
+ import net.minecraftforge.fml.relauncher.Side;
+ import net.minecraftforge.fml.relauncher.SideOnly;
+ 
+@@ -193,10 +194,11 @@
          {
              float f = (float)MathHelper.func_76123_f(this.field_70143_R - 3.0F);
  
@@ -13,7 +20,7 @@
                  ((WorldServer)this.field_70170_p).func_175739_a(EnumParticleTypes.BLOCK_DUST, this.field_70165_t, this.field_70163_u, this.field_70161_v, i, 0.0D, 0.0D, 0.0D, 0.15000000596046448D, new int[] {Block.func_176210_f(p_184231_4_)});
              }
          }
-@@ -273,7 +274,7 @@
+@@ -273,7 +275,7 @@
                      }
                  }
  
@@ -22,7 +29,7 @@
                  {
                      this.func_184210_p();
                  }
-@@ -372,7 +373,7 @@
+@@ -372,7 +374,7 @@
              if (!this.field_70170_p.field_72995_K && (this.func_70684_aJ() || this.field_70718_bc > 0 && this.func_146066_aG() && this.field_70170_p.func_82736_K().func_82766_b("doMobLoot")))
              {
                  int i = this.func_70693_a(this.field_70717_bb);
@@ -31,7 +38,7 @@
                  while (i > 0)
                  {
                      int j = EntityXPOrb.func_70527_a(i);
-@@ -433,6 +434,7 @@
+@@ -433,6 +435,7 @@
      {
          this.field_70755_b = p_70604_1_;
          this.field_70756_c = this.field_70173_aa;
@@ -39,7 +46,7 @@
      }
  
      public EntityLivingBase func_110144_aD()
-@@ -793,6 +795,8 @@
+@@ -793,6 +796,8 @@
  
      public void func_70691_i(float p_70691_1_)
      {
@@ -48,7 +55,7 @@
          float f = this.func_110143_aJ();
  
          if (f > 0.0F)
-@@ -813,6 +817,7 @@
+@@ -813,6 +818,7 @@
  
      public boolean func_70097_a(DamageSource p_70097_1_, float p_70097_2_)
      {
@@ -56,7 +63,7 @@
          if (this.func_180431_b(p_70097_1_))
          {
              return false;
-@@ -902,9 +907,9 @@
+@@ -902,9 +908,9 @@
                          this.field_70718_bc = 100;
                          this.field_70717_bb = (EntityPlayer)entity;
                      }
@@ -68,7 +75,7 @@
  
                          if (entitywolf.func_70909_n())
                          {
-@@ -1043,6 +1048,7 @@
+@@ -1043,6 +1049,7 @@
  
      public void func_70645_a(DamageSource p_70645_1_)
      {
@@ -76,7 +83,7 @@
          if (!this.field_70729_aU)
          {
              Entity entity = p_70645_1_.func_76346_g();
-@@ -1069,12 +1075,26 @@
+@@ -1069,12 +1076,26 @@
                  {
                      i = EnchantmentHelper.func_185283_h((EntityLivingBase)entity);
                  }
@@ -103,7 +110,7 @@
              }
  
              this.field_70170_p.func_72960_a(this, (byte)3);
-@@ -1151,7 +1171,7 @@
+@@ -1151,7 +1172,7 @@
              BlockPos blockpos = new BlockPos(i, j, k);
              IBlockState iblockstate = this.field_70170_p.func_180495_p(blockpos);
              Block block = iblockstate.func_177230_c();
@@ -112,7 +119,7 @@
          }
      }
  
-@@ -1177,6 +1197,9 @@
+@@ -1177,6 +1198,9 @@
  
      public void func_180430_e(float p_180430_1_, float p_180430_2_)
      {
@@ -122,7 +129,27 @@
          super.func_180430_e(p_180430_1_, p_180430_2_);
          PotionEffect potioneffect = this.func_70660_b(MobEffects.field_76430_j);
          float f = potioneffect == null ? 0.0F : (float)(potioneffect.func_76458_c() + 1);
-@@ -1270,6 +1293,8 @@
+@@ -1189,12 +1213,16 @@
+             int j = MathHelper.func_76128_c(this.field_70165_t);
+             int k = MathHelper.func_76128_c(this.field_70163_u - 0.20000000298023224D);
+             int l = MathHelper.func_76128_c(this.field_70161_v);
+-            IBlockState iblockstate = this.field_70170_p.func_180495_p(new BlockPos(j, k, l));
++            BlockPos pos = new BlockPos(j, k, l);
++            IBlockState iblockstate = this.field_70170_p.func_180495_p(pos);
+ 
+             if (iblockstate.func_185904_a() != Material.field_151579_a)
+             {
+-                SoundType soundtype = iblockstate.func_177230_c().func_185467_w();
+-                this.func_184185_a(soundtype.func_185842_g(), soundtype.func_185843_a() * 0.5F, soundtype.func_185847_b() * 0.75F);
++                Block block = iblockstate.func_177230_c();
++                net.minecraft.util.SoundEvent fallSound = block.getSoundEvent(this.field_70170_p, pos, this, net.minecraftforge.common.EnumSoundEventType.BLOCK_FALL);
++                float volume = block.getSoundVolume(this.field_70170_p, pos, this);
++                float pitch = block.getSoundPitch(this.field_70170_p, pos, this);
++                this.func_184185_a(fallSound, volume * 0.5F, pitch * 0.75F);
+             }
+         }
+     }
+@@ -1270,6 +1298,8 @@
      {
          if (!this.func_180431_b(p_70665_1_))
          {
@@ -131,7 +158,7 @@
              p_70665_2_ = this.func_70655_b(p_70665_1_, p_70665_2_);
              p_70665_2_ = this.func_70672_c(p_70665_1_, p_70665_2_);
              float f = p_70665_2_;
-@@ -1319,6 +1344,11 @@
+@@ -1319,6 +1349,11 @@
  
      public void func_184609_a(EnumHand p_184609_1_)
      {
@@ -143,7 +170,7 @@
          if (!this.field_82175_bq || this.field_110158_av >= this.func_82166_i() / 2 || this.field_110158_av < 0)
          {
              this.field_110158_av = -1;
-@@ -1521,6 +1551,7 @@
+@@ -1521,6 +1556,7 @@
  
      public void func_110145_l(Entity p_110145_1_)
      {
@@ -151,7 +178,7 @@
          if (!(p_110145_1_ instanceof EntityBoat) && !(p_110145_1_ instanceof EntityHorse))
          {
              double d1 = p_110145_1_.field_70165_t;
-@@ -1545,7 +1576,7 @@
+@@ -1545,7 +1581,7 @@
  
                  if (!this.field_70170_p.func_184143_b(axisalignedbb1))
                  {
@@ -160,7 +187,7 @@
                      {
                          this.func_70634_a(d11, this.field_70163_u + 1.0D, d12);
                          return;
-@@ -1553,14 +1584,14 @@
+@@ -1553,14 +1589,14 @@
  
                      BlockPos blockpos = new BlockPos(d11, this.field_70163_u - 1.0D, d12);
  
@@ -177,7 +204,7 @@
                  {
                      d1 = d11;
                      d13 = this.field_70163_u + 2.0D;
-@@ -1631,6 +1662,7 @@
+@@ -1631,6 +1667,7 @@
          }
  
          this.field_70160_al = true;
@@ -185,7 +212,7 @@
      }
  
      protected void func_70629_bd()
-@@ -1903,6 +1935,7 @@
+@@ -1903,6 +1940,7 @@
  
      public void func_70071_h_()
      {
@@ -193,7 +220,7 @@
          super.func_70071_h_();
          this.func_184608_ct();
  
-@@ -2409,6 +2442,40 @@
+@@ -2409,6 +2447,40 @@
          this.field_70752_e = true;
      }
  
@@ -234,7 +261,7 @@
      public abstract EnumHandSide func_184591_cq();
  
      public boolean func_184587_cr()
-@@ -2429,12 +2496,19 @@
+@@ -2429,12 +2501,19 @@
  
              if (itemstack == this.field_184627_bm)
              {
@@ -255,7 +282,7 @@
                  {
                      this.func_71036_o();
                  }
-@@ -2452,8 +2526,10 @@
+@@ -2452,8 +2531,10 @@
  
          if (itemstack != null && !this.func_184587_cr())
          {
@@ -267,7 +294,7 @@
  
              if (!this.field_70170_p.field_72995_K)
              {
-@@ -2536,6 +2612,8 @@
+@@ -2536,6 +2617,8 @@
              this.func_184584_a(this.field_184627_bm, 16);
              ItemStack itemstack = this.field_184627_bm.func_77950_b(this.field_70170_p, this);
  
@@ -276,7 +303,7 @@
              if (itemstack != null && itemstack.field_77994_a == 0)
              {
                  itemstack = null;
-@@ -2566,7 +2644,8 @@
+@@ -2566,7 +2649,8 @@
      {
          if (this.field_184627_bm != null)
          {
@@ -286,7 +313,7 @@
          }
  
          this.func_184602_cy();
-@@ -2685,4 +2764,28 @@
+@@ -2685,4 +2769,28 @@
      {
          return true;
      }

--- a/patches/minecraft/net/minecraft/entity/passive/EntityHorse.java.patch
+++ b/patches/minecraft/net/minecraft/entity/passive/EntityHorse.java.patch
@@ -1,6 +1,45 @@
 --- ../src-base/minecraft/net/minecraft/entity/passive/EntityHorse.java
 +++ ../src-work/minecraft/net/minecraft/entity/passive/EntityHorse.java
-@@ -441,6 +441,7 @@
+@@ -1,11 +1,13 @@
+ package net.minecraft.entity.passive;
+ 
+ import com.google.common.base.Optional;
+ import com.google.common.base.Predicate;
+ import java.util.UUID;
+ import javax.annotation.Nullable;
+ import net.minecraft.block.Block;
+-import net.minecraft.block.SoundType;
+ import net.minecraft.block.material.Material;
+ import net.minecraft.block.state.IBlockState;
+ import net.minecraft.entity.Entity;
+@@ -58,6 +60,7 @@
+ import net.minecraft.util.math.MathHelper;
+ import net.minecraft.world.DifficultyInstance;
+ import net.minecraft.world.World;
+ import net.minecraftforge.fml.relauncher.Side;
+ import net.minecraftforge.fml.relauncher.SideOnly;
+ 
+@@ -400,13 +403,16 @@
+                 }
+             }
+ 
+-            IBlockState iblockstate = this.field_70170_p.func_180495_p(new BlockPos(this.field_70165_t, this.field_70163_u - 0.2D - (double)this.field_70126_B, this.field_70161_v));
++            BlockPos pos = new BlockPos(this.field_70165_t, this.field_70163_u - 0.2D - (double)this.field_70126_B, this.field_70161_v);
++            IBlockState iblockstate = this.field_70170_p.func_180495_p(pos);
+             Block block = iblockstate.func_177230_c();
+ 
+             if (iblockstate.func_185904_a() != Material.field_151579_a && !this.func_174814_R())
+             {
+-                SoundType soundtype = block.func_185467_w();
+-                this.field_70170_p.func_184148_a((EntityPlayer)null, this.field_70165_t, this.field_70163_u, this.field_70161_v, soundtype.func_185844_d(), this.func_184176_by(), soundtype.func_185843_a() * 0.5F, soundtype.func_185847_b() * 0.75F);
++                net.minecraft.util.SoundEvent stepSound = block.getSoundEvent(this.field_70170_p, pos, this, net.minecraftforge.common.EnumSoundEventType.BLOCK_STEP);
++                float volume = block.getSoundVolume(this.field_70170_p, pos, this);
++                float pitch = block.getSoundPitch(this.field_70170_p, pos, this);
++                this.field_70170_p.func_184148_a((EntityPlayer)null, this.field_70165_t, this.field_70163_u, this.field_70161_v, stepSound, this.func_184176_by(), volume * 0.5F, pitch * 0.75F);
+             }
+         }
+     }
+@@ -441,6 +447,7 @@
  
          this.field_110296_bG.func_110134_a(this);
          this.func_110232_cE();
@@ -8,7 +47,56 @@
      }
  
      private void func_110232_cE()
-@@ -1212,6 +1213,7 @@
+@@ -556,11 +563,14 @@
+ 
+     protected void func_180429_a(BlockPos p_180429_1_, Block p_180429_2_)
+     {
+-        SoundType soundtype = p_180429_2_.func_185467_w();
++        float volume = p_180429_2_.getSoundVolume(this.field_70170_p, p_180429_1_, this);
++        float pitch = p_180429_2_.getSoundPitch(this.field_70170_p, p_180429_1_, this);
++        Block block1 = this.field_70170_p.func_180495_p(p_180429_1_.func_177984_a()).func_177230_c();
+ 
+         if (this.field_70170_p.func_180495_p(p_180429_1_.func_177984_a()).func_177230_c() == Blocks.field_150431_aC)
+         {
+-            soundtype = Blocks.field_150431_aC.func_185467_w();
++            volume = block1.getSoundVolume(this.field_70170_p, p_180429_1_.func_177984_a(), this);
++            pitch = block1.getSoundPitch(this.field_70170_p, p_180429_1_.func_177984_a(), this);
+         }
+ 
+         if (!p_180429_2_.func_176223_P().func_185904_a().func_76224_d())
+@@ -573,25 +583,25 @@
+ 
+                 if (this.field_110285_bP > 5 && this.field_110285_bP % 3 == 0)
+                 {
+-                    this.func_184185_a(SoundEvents.field_187714_cq, soundtype.func_185843_a() * 0.15F, soundtype.func_185847_b());
++                    this.func_184185_a(SoundEvents.field_187714_cq, volume * 0.15F, pitch);
+ 
+                     if (horsetype == HorseType.HORSE && this.field_70146_Z.nextInt(10) == 0)
+                     {
+-                        this.func_184185_a(SoundEvents.field_187705_cn, soundtype.func_185843_a() * 0.6F, soundtype.func_185847_b());
++                        this.func_184185_a(SoundEvents.field_187705_cn, volume * 0.6F, pitch);
+                     }
+                 }
+                 else if (this.field_110285_bP <= 5)
+                 {
+-                    this.func_184185_a(SoundEvents.field_187732_cw, soundtype.func_185843_a() * 0.15F, soundtype.func_185847_b());
++                    this.func_184185_a(SoundEvents.field_187732_cw, volume * 0.15F, pitch);
+                 }
+             }
+-            else if (soundtype == SoundType.field_185848_a)
++            else if (p_180429_2_.getSoundEvent(this.field_70170_p, p_180429_1_, this, EnumSoundEventType.BLOCK_STEP) == net.minecraft.init.SoundEvents.field_187897_gY)
+             {
+-                this.func_184185_a(SoundEvents.field_187732_cw, soundtype.func_185843_a() * 0.15F, soundtype.func_185847_b());
++                this.func_184185_a(SoundEvents.field_187732_cw, volume * 0.15F, pitch);
+             }
+             else
+             {
+-                this.func_184185_a(SoundEvents.field_187729_cv, soundtype.func_185843_a() * 0.15F, soundtype.func_185847_b());
++                this.func_184185_a(SoundEvents.field_187729_cv, volume * 0.15F, pitch);
+             }
+         }
+     }
+@@ -1212,6 +1222,7 @@
                  }
  
                  this.field_110277_bt = 0.0F;
@@ -16,7 +104,7 @@
              }
  
              this.field_70747_aH = this.func_70689_ay() * 0.1F;
-@@ -1813,4 +1815,21 @@
+@@ -1813,4 +1824,21 @@
                  this.field_188477_b = p_i46589_2_;
              }
          }

--- a/patches/minecraft/net/minecraft/item/ItemBed.java.patch
+++ b/patches/minecraft/net/minecraft/item/ItemBed.java.patch
@@ -1,0 +1,16 @@
+--- ../src-base/minecraft/net/minecraft/item/ItemBed.java
++++ ../src-work/minecraft/net/minecraft/item/ItemBed.java
+@@ -63,8 +63,11 @@
+                         p_180614_3_.func_180501_a(blockpos, iblockstate2, 11);
+                     }
+ 
+-                    SoundType soundtype = iblockstate1.func_177230_c().func_185467_w();
+-                    p_180614_3_.func_184133_a((EntityPlayer)null, p_180614_4_, soundtype.func_185841_e(), SoundCategory.BLOCKS, (soundtype.func_185843_a() + 1.0F) / 2.0F, soundtype.func_185847_b() * 0.8F);
++                    Block block1 = iblockstate1.func_177230_c();
++                    net.minecraft.util.SoundEvent placeSound = block1.getSoundEvent(p_180614_3_, p_180614_4_, p_180614_2_, net.minecraftforge.common.EnumSoundEventType.BLOCK_PLACE);
++                    float volume = block1.getSoundVolume(p_180614_3_, p_180614_4_, p_180614_2_);
++                    float pitch = block1.getSoundPitch(p_180614_3_, blockpos, p_180614_2_);
++                    p_180614_3_.func_184133_a((EntityPlayer)null, p_180614_4_, placeSound, SoundCategory.BLOCKS, (volume + 1.0F) / 2.0F, pitch * 0.8F);
+                     --p_180614_1_.field_77994_a;
+                     return EnumActionResult.SUCCESS;
+                 }

--- a/patches/minecraft/net/minecraft/item/ItemBlock.java.patch
+++ b/patches/minecraft/net/minecraft/item/ItemBlock.java.patch
@@ -1,6 +1,6 @@
 --- ../src-base/minecraft/net/minecraft/item/ItemBlock.java
 +++ ../src-work/minecraft/net/minecraft/item/ItemBlock.java
-@@ -51,16 +51,8 @@
+@@ -51,18 +51,13 @@
              int i = this.func_77647_b(p_180614_1_.func_77960_j());
              IBlockState iblockstate1 = this.field_150939_a.func_180642_a(p_180614_3_, p_180614_4_, p_180614_6_, p_180614_7_, p_180614_8_, p_180614_9_, i, p_180614_2_);
  
@@ -15,10 +15,17 @@
 -                    this.field_150939_a.func_180633_a(p_180614_3_, p_180614_4_, iblockstate1, p_180614_2_, p_180614_1_);
 -                }
 -
-                 SoundType soundtype = this.field_150939_a.func_185467_w();
-                 p_180614_3_.func_184133_a(p_180614_2_, p_180614_4_, soundtype.func_185841_e(), SoundCategory.BLOCKS, (soundtype.func_185843_a() + 1.0F) / 2.0F, soundtype.func_185847_b() * 0.8F);
+-                SoundType soundtype = this.field_150939_a.func_185467_w();
+-                p_180614_3_.func_184133_a(p_180614_2_, p_180614_4_, soundtype.func_185841_e(), SoundCategory.BLOCKS, (soundtype.func_185843_a() + 1.0F) / 2.0F, soundtype.func_185847_b() * 0.8F);
++                Block block1 = iblockstate1.func_177230_c();
++                net.minecraft.util.SoundEvent placeSound = block1.getSoundEvent(p_180614_3_, p_180614_4_, p_180614_2_, net.minecraftforge.common.EnumSoundEventType.BLOCK_PLACE);
++                float volume = block1.getSoundVolume(p_180614_3_, p_180614_4_, p_180614_2_);
++                float pitch = block1.getSoundPitch(p_180614_3_, p_180614_4_, p_180614_2_);
++                p_180614_3_.func_184133_a(p_180614_2_, p_180614_4_, placeSound, SoundCategory.BLOCKS, (volume + 1.0F) / 2.0F, pitch * 0.8F);
                  --p_180614_1_.field_77994_a;
-@@ -121,7 +113,7 @@
+             }
+ 
+@@ -121,7 +116,7 @@
      {
          Block block = p_179222_1_.func_180495_p(p_179222_2_).func_177230_c();
  
@@ -27,7 +34,7 @@
          {
              p_179222_3_ = EnumFacing.UP;
          }
-@@ -159,4 +151,32 @@
+@@ -159,4 +154,32 @@
      {
          return this.field_150939_a;
      }

--- a/patches/minecraft/net/minecraft/item/ItemBlockSpecial.java.patch
+++ b/patches/minecraft/net/minecraft/item/ItemBlockSpecial.java.patch
@@ -1,0 +1,16 @@
+--- ../src-base/minecraft/net/minecraft/item/ItemBlockSpecial.java
++++ ../src-work/minecraft/net/minecraft/item/ItemBlockSpecial.java
+@@ -55,8 +55,11 @@
+                     iblockstate1.func_177230_c().func_180633_a(p_180614_3_, p_180614_4_, iblockstate1, p_180614_2_, p_180614_1_);
+                 }
+ 
+-                SoundType soundtype = this.field_150935_a.func_185467_w();
+-                p_180614_3_.func_184133_a(p_180614_2_, p_180614_4_, soundtype.func_185841_e(), SoundCategory.BLOCKS, (soundtype.func_185843_a() + 1.0F) / 2.0F, soundtype.func_185847_b() * 0.8F);
++                Block block1 = iblockstate1.func_177230_c();
++                net.minecraft.util.SoundEvent placeSound = block1.getSoundEvent(p_180614_3_, p_180614_4_, p_180614_2_, net.minecraftforge.common.EnumSoundEventType.BLOCK_PLACE);
++                float volume = block1.getSoundVolume(p_180614_3_, p_180614_4_, p_180614_2_);
++                float pitch = block1.getSoundPitch(p_180614_3_, p_180614_4_, p_180614_2_);
++                p_180614_3_.func_184133_a(p_180614_2_, p_180614_4_, placeSound, SoundCategory.BLOCKS, (volume + 1.0F) / 2.0F, pitch * 0.8F);
+                 --p_180614_1_.field_77994_a;
+                 return EnumActionResult.SUCCESS;
+             }

--- a/patches/minecraft/net/minecraft/item/ItemDoor.java.patch
+++ b/patches/minecraft/net/minecraft/item/ItemDoor.java.patch
@@ -1,0 +1,68 @@
+--- ../src-base/minecraft/net/minecraft/item/ItemDoor.java
++++ ../src-work/minecraft/net/minecraft/item/ItemDoor.java
+@@ -45,9 +45,11 @@
+                 int i = enumfacing.func_82601_c();
+                 int j = enumfacing.func_82599_e();
+                 boolean flag = i < 0 && p_180614_9_ < 0.5F || i > 0 && p_180614_9_ > 0.5F || j < 0 && p_180614_7_ > 0.5F || j > 0 && p_180614_7_ < 0.5F;
+-                func_179235_a(p_180614_3_, p_180614_4_, enumfacing, this.field_179236_a, flag);
+-                SoundType soundtype = this.field_179236_a.func_185467_w();
+-                p_180614_3_.func_184133_a(p_180614_2_, p_180614_4_, soundtype.func_185841_e(), SoundCategory.BLOCKS, (soundtype.func_185843_a() + 1.0F) / 2.0F, soundtype.func_185847_b() * 0.8F);
++                Block block1 = placeDoor(p_180614_3_, p_180614_4_, enumfacing, this.field_179236_a, flag).func_177230_c();
++                net.minecraft.util.SoundEvent placeSound = block1.getSoundEvent(p_180614_3_, p_180614_4_, p_180614_2_, net.minecraftforge.common.EnumSoundEventType.BLOCK_PLACE);
++                float volume = block1.getSoundVolume(p_180614_3_, p_180614_4_, p_180614_2_);
++                float pitch = block1.getSoundPitch(p_180614_3_, p_180614_4_, p_180614_2_);
++                p_180614_3_.func_184133_a(p_180614_2_, p_180614_4_, placeSound, SoundCategory.BLOCKS, (volume + 1.0F) / 2.0F, pitch * 0.8F);
+                 --p_180614_1_.field_77994_a;
+                 return EnumActionResult.SUCCESS;
+             }
+@@ -58,33 +60,34 @@
+         }
+     }
+ 
+-    public static void func_179235_a(World p_179235_0_, BlockPos p_179235_1_, EnumFacing p_179235_2_, Block p_179235_3_, boolean p_179235_4_)
++    public static IBlockState placeDoor(World worldIn, BlockPos pos, EnumFacing facing, Block door, boolean isRightHinge)
+     {
+-        BlockPos blockpos = p_179235_1_.func_177972_a(p_179235_2_.func_176746_e());
+-        BlockPos blockpos1 = p_179235_1_.func_177972_a(p_179235_2_.func_176735_f());
+-        int i = (p_179235_0_.func_180495_p(blockpos1).func_185915_l() ? 1 : 0) + (p_179235_0_.func_180495_p(blockpos1.func_177984_a()).func_185915_l() ? 1 : 0);
+-        int j = (p_179235_0_.func_180495_p(blockpos).func_185915_l() ? 1 : 0) + (p_179235_0_.func_180495_p(blockpos.func_177984_a()).func_185915_l() ? 1 : 0);
+-        boolean flag = p_179235_0_.func_180495_p(blockpos1).func_177230_c() == p_179235_3_ || p_179235_0_.func_180495_p(blockpos1.func_177984_a()).func_177230_c() == p_179235_3_;
+-        boolean flag1 = p_179235_0_.func_180495_p(blockpos).func_177230_c() == p_179235_3_ || p_179235_0_.func_180495_p(blockpos.func_177984_a()).func_177230_c() == p_179235_3_;
++        BlockPos blockpos = pos.func_177972_a(facing.func_176746_e());
++        BlockPos blockpos1 = pos.func_177972_a(facing.func_176735_f());
++        int i = (worldIn.func_180495_p(blockpos1).func_185915_l() ? 1 : 0) + (worldIn.func_180495_p(blockpos1.func_177984_a()).func_185915_l() ? 1 : 0);
++        int j = (worldIn.func_180495_p(blockpos).func_185915_l() ? 1 : 0) + (worldIn.func_180495_p(blockpos.func_177984_a()).func_185915_l() ? 1 : 0);
++        boolean flag = worldIn.func_180495_p(blockpos1).func_177230_c() == door || worldIn.func_180495_p(blockpos1.func_177984_a()).func_177230_c() == door;
++        boolean flag1 = worldIn.func_180495_p(blockpos).func_177230_c() == door || worldIn.func_180495_p(blockpos.func_177984_a()).func_177230_c() == door;
+ 
+         if ((!flag || flag1) && j <= i)
+         {
+             if (flag1 && !flag || j < i)
+             {
+-                p_179235_4_ = false;
++                isRightHinge = false;
+             }
+         }
+         else
+         {
+-            p_179235_4_ = true;
++            isRightHinge = true;
+         }
+ 
+-        BlockPos blockpos2 = p_179235_1_.func_177984_a();
+-        boolean flag2 = p_179235_0_.func_175640_z(p_179235_1_) || p_179235_0_.func_175640_z(blockpos2);
+-        IBlockState iblockstate = p_179235_3_.func_176223_P().func_177226_a(BlockDoor.field_176520_a, p_179235_2_).func_177226_a(BlockDoor.field_176521_M, p_179235_4_ ? BlockDoor.EnumHingePosition.RIGHT : BlockDoor.EnumHingePosition.LEFT).func_177226_a(BlockDoor.field_176522_N, Boolean.valueOf(flag2)).func_177226_a(BlockDoor.field_176519_b, Boolean.valueOf(flag2));
+-        p_179235_0_.func_180501_a(p_179235_1_, iblockstate.func_177226_a(BlockDoor.field_176523_O, BlockDoor.EnumDoorHalf.LOWER), 2);
+-        p_179235_0_.func_180501_a(blockpos2, iblockstate.func_177226_a(BlockDoor.field_176523_O, BlockDoor.EnumDoorHalf.UPPER), 2);
+-        p_179235_0_.func_175685_c(p_179235_1_, p_179235_3_);
+-        p_179235_0_.func_175685_c(blockpos2, p_179235_3_);
++        BlockPos blockpos2 = pos.func_177984_a();
++        boolean flag2 = worldIn.func_175640_z(pos) || worldIn.func_175640_z(blockpos2);
++        IBlockState iblockstate = door.func_176223_P().func_177226_a(BlockDoor.field_176520_a, facing).func_177226_a(BlockDoor.field_176521_M, isRightHinge ? BlockDoor.EnumHingePosition.RIGHT : BlockDoor.EnumHingePosition.LEFT).func_177226_a(BlockDoor.field_176522_N, Boolean.valueOf(flag2)).func_177226_a(BlockDoor.field_176519_b, Boolean.valueOf(flag2));
++        worldIn.func_180501_a(pos, iblockstate.func_177226_a(BlockDoor.field_176523_O, BlockDoor.EnumDoorHalf.LOWER), 2);
++        worldIn.func_180501_a(blockpos2, iblockstate.func_177226_a(BlockDoor.field_176523_O, BlockDoor.EnumDoorHalf.UPPER), 2);
++        worldIn.func_175685_c(pos, door);
++        worldIn.func_175685_c(blockpos2, door);
++        return iblockstate;
+     }
+ }

--- a/patches/minecraft/net/minecraft/item/ItemSlab.java.patch
+++ b/patches/minecraft/net/minecraft/item/ItemSlab.java.patch
@@ -1,0 +1,30 @@
+--- ../src-base/minecraft/net/minecraft/item/ItemSlab.java
++++ ../src-work/minecraft/net/minecraft/item/ItemSlab.java
+@@ -60,8 +60,11 @@
+ 
+                     if (axisalignedbb != Block.field_185506_k && p_180614_3_.func_72855_b(axisalignedbb.func_186670_a(p_180614_4_)) && p_180614_3_.func_180501_a(p_180614_4_, iblockstate1, 11))
+                     {
+-                        SoundType soundtype = this.field_179226_c.func_185467_w();
+-                        p_180614_3_.func_184133_a(p_180614_2_, p_180614_4_, soundtype.func_185841_e(), SoundCategory.BLOCKS, (soundtype.func_185843_a() + 1.0F) / 2.0F, soundtype.func_185847_b() * 0.8F);
++                        Block block1 = iblockstate1.func_177230_c();
++                        net.minecraft.util.SoundEvent placeSound = block1.getSoundEvent(p_180614_3_, p_180614_4_, p_180614_2_, net.minecraftforge.common.EnumSoundEventType.BLOCK_PLACE);
++                        float volume = block1.getSoundVolume(p_180614_3_, p_180614_4_, p_180614_2_);
++                        float pitch = block1.getSoundPitch(p_180614_3_, p_180614_4_, p_180614_2_);
++                        p_180614_3_.func_184133_a(p_180614_2_, p_180614_4_, placeSound, SoundCategory.BLOCKS, (volume + 1.0F) / 2.0F, pitch * 0.8F);
+                         --p_180614_1_.field_77994_a;
+                     }
+ 
+@@ -115,8 +118,11 @@
+ 
+                 if (axisalignedbb != Block.field_185506_k && p_180615_3_.func_72855_b(axisalignedbb.func_186670_a(p_180615_4_)) && p_180615_3_.func_180501_a(p_180615_4_, iblockstate1, 11))
+                 {
+-                    SoundType soundtype = this.field_179226_c.func_185467_w();
+-                    p_180615_3_.func_184133_a(p_180615_1_, p_180615_4_, soundtype.func_185841_e(), SoundCategory.BLOCKS, (soundtype.func_185843_a() + 1.0F) / 2.0F, soundtype.func_185847_b() * 0.8F);
++                    Block block1 = iblockstate1.func_177230_c();
++                    net.minecraft.util.SoundEvent placeSound = block1.getSoundEvent(p_180615_3_, p_180615_4_, p_180615_1_, net.minecraftforge.common.EnumSoundEventType.BLOCK_PLACE);
++                    float volume = block1.getSoundVolume(p_180615_3_, p_180615_4_, p_180615_1_);
++                    float pitch = block1.getSoundPitch(p_180615_3_ , p_180615_4_, p_180615_1_);
++                    p_180615_3_.func_184133_a(p_180615_1_, p_180615_4_, placeSound, SoundCategory.BLOCKS, (volume + 1.0F) / 2.0F, pitch * 0.8F);
+                     --p_180615_2_.field_77994_a;
+                 }
+ 

--- a/patches/minecraft/net/minecraft/item/ItemSnow.java.patch
+++ b/patches/minecraft/net/minecraft/item/ItemSnow.java.patch
@@ -1,6 +1,20 @@
 --- ../src-base/minecraft/net/minecraft/item/ItemSnow.java
 +++ ../src-work/minecraft/net/minecraft/item/ItemSnow.java
-@@ -68,4 +68,10 @@
+@@ -48,8 +48,11 @@
+ 
+                     if (axisalignedbb != Block.field_185506_k && p_180614_3_.func_72855_b(axisalignedbb.func_186670_a(blockpos)) && p_180614_3_.func_180501_a(blockpos, iblockstate1, 10))
+                     {
+-                        SoundType soundtype = this.field_150939_a.func_185467_w();
+-                        p_180614_3_.func_184133_a(p_180614_2_, blockpos, soundtype.func_185841_e(), SoundCategory.BLOCKS, (soundtype.func_185843_a() + 1.0F) / 2.0F, soundtype.func_185847_b() * 0.8F);
++                        Block block1 = iblockstate1.func_177230_c();
++                        net.minecraft.util.SoundEvent placeSound = block1.getSoundEvent(p_180614_3_, blockpos, p_180614_2_, net.minecraftforge.common.EnumSoundEventType.BLOCK_PLACE);
++                        float volume = block1.getSoundVolume(p_180614_3_, blockpos, p_180614_2_);
++                        float pitch = block1.getSoundPitch(p_180614_3_, blockpos, p_180614_2_);
++                        p_180614_3_.func_184133_a(p_180614_2_, blockpos, placeSound, SoundCategory.BLOCKS, (volume + 1.0F) / 2.0F, pitch * 0.8F);
+                         --p_180614_1_.field_77994_a;
+                         return EnumActionResult.SUCCESS;
+                     }
+@@ -68,4 +71,10 @@
      {
          return p_77647_1_;
      }

--- a/src/main/java/net/minecraftforge/common/EnumSoundEventType.java
+++ b/src/main/java/net/minecraftforge/common/EnumSoundEventType.java
@@ -1,0 +1,10 @@
+package net.minecraftforge.common;
+
+public enum EnumSoundEventType
+{
+    BLOCK_BREAK,
+    BLOCK_STEP,
+    BLOCK_PLACE,
+    BLOCK_HIT,
+    BLOCK_FALL
+}


### PR DESCRIPTION
Some other changes I forgot to mention are ItemDoor#placeDoor now returns IBlockState and apparently all of the imports are reformatted? I blame eclipse for this -.-. This should allow for more flexibility when getting the SoundEvent from a Block. A good example would be if somebody made a multipart mod and they want each individual multipart to have their own SoundEvent. Another good example would be if a Block has IBlockStates with different SoundEvents.