### PR TITLE
[1.10.x] Add an event to control whether fluids can create source blocks

### DIFF
--- a/patches/minecraft/net/minecraft/block/BlockDynamicLiquid.java.patch
+++ b/patches/minecraft/net/minecraft/block/BlockDynamicLiquid.java.patch
@@ -1,0 +1,11 @@
+--- ../src-base/minecraft/net/minecraft/block/BlockDynamicLiquid.java
++++ ../src-work/minecraft/net/minecraft/block/BlockDynamicLiquid.java
+@@ -67,7 +67,7 @@
+                 }
+             }
+ 
+-            if (this.field_149815_a >= 2 && this.field_149764_J == Material.field_151586_h)
++            if (this.field_149815_a >= 2 && net.minecraftforge.event.ForgeEventFactory.canCreateFluidSource(p_180650_1_, p_180650_2_, p_180650_3_, this.field_149764_J == Material.field_151586_h))
+             {
+                 IBlockState iblockstate = p_180650_1_.func_180495_p(p_180650_2_.func_177977_b());
+ 

--- a/src/main/java/net/minecraftforge/event/ForgeEventFactory.java
+++ b/src/main/java/net/minecraftforge/event/ForgeEventFactory.java
@@ -98,6 +98,7 @@ import net.minecraftforge.event.entity.player.UseHoeEvent;
 import net.minecraftforge.event.terraingen.ChunkGeneratorEvent;
 import net.minecraftforge.event.terraingen.PopulateChunkEvent;
 import net.minecraftforge.event.world.BlockEvent;
+import net.minecraftforge.event.world.BlockEvent.CreateFluidSourceEvent;
 import net.minecraftforge.event.world.BlockEvent.MultiPlaceEvent;
 import net.minecraftforge.event.world.BlockEvent.NeighborNotifyEvent;
 import net.minecraftforge.event.world.BlockEvent.PlaceEvent;
@@ -583,6 +584,15 @@ public class ForgeEventFactory
         if (MinecraftForge.EVENT_BUS.post(event))
             return LootTable.EMPTY_LOOT_TABLE;
         return event.getTable();
+    }
+
+    public static boolean canCreateFluidSource(World world, BlockPos pos, IBlockState state, boolean def)
+    {
+        CreateFluidSourceEvent evt = new CreateFluidSourceEvent(world, pos, state);
+        MinecraftForge.EVENT_BUS.post(evt);
+
+        Result result = evt.getResult();
+        return result == Result.DEFAULT ? def : result == Result.ALLOW;
     }
 
 }

--- a/src/main/java/net/minecraftforge/event/world/BlockEvent.java
+++ b/src/main/java/net/minecraftforge/event/world/BlockEvent.java
@@ -252,4 +252,20 @@ public class BlockEvent extends Event
             return notifiedSides;
         }
     }
+
+    /**
+     * Fired to check whether a non-source block can turn into a source block.
+     * A result of ALLOW causes a source block to be created even if the liquid
+     * usually doesn't do that (like lava), and a result of DENY prevents creation
+     * even if the liquid usually does do that (like water).
+     */
+    @HasResult
+    public static class CreateFluidSourceEvent extends BlockEvent
+    {
+        public CreateFluidSourceEvent(World world, BlockPos pos, IBlockState state)
+        {
+            super(world, pos, state);
+        }
+    }
+
 }

--- a/src/main/java/net/minecraftforge/fluids/BlockFluidClassic.java
+++ b/src/main/java/net/minecraftforge/fluids/BlockFluidClassic.java
@@ -27,6 +27,7 @@ import net.minecraft.init.Blocks;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.IBlockAccess;
 import net.minecraft.world.World;
+import net.minecraftforge.event.ForgeEventFactory;
 
 /**
  * This is a fluid block implementation which emulates vanilla Minecraft fluid behavior.
@@ -102,6 +103,17 @@ public class BlockFluidClassic extends BlockFluidBase
     @Override
     public void updateTick(World world, BlockPos pos, IBlockState state, Random rand)
     {
+        if (!isSourceBlock(world, pos) && ForgeEventFactory.canCreateFluidSource(world, pos, state, false))
+        {
+            int adjacentSourceBlocks =
+                    (isSourceBlock(world, pos.north()) ? 1 : 0) +
+                    (isSourceBlock(world, pos.south()) ? 1 : 0) +
+                    (isSourceBlock(world, pos.east()) ? 1 : 0) +
+                    (isSourceBlock(world, pos.west()) ? 1 : 0);
+            if (adjacentSourceBlocks >= 2 && (world.getBlockState(pos.up(densityDir)).getMaterial().isSolid() || isSourceBlock(world, pos.up(densityDir))))
+                world.setBlockState(pos, state.withProperty(LEVEL, 0));
+        }
+
         int quantaRemaining = quantaPerBlock - state.getValue(LEVEL);
         int expQuanta = -101;
 

--- a/src/test/java/net/minecraftforge/test/CreateFluidSourceTest.java
+++ b/src/test/java/net/minecraftforge/test/CreateFluidSourceTest.java
@@ -1,0 +1,32 @@
+package net.minecraftforge.test;
+
+import net.minecraft.init.Blocks;
+import net.minecraftforge.common.MinecraftForge;
+import net.minecraftforge.event.world.BlockEvent.CreateFluidSourceEvent;
+import net.minecraftforge.fml.common.Mod;
+import net.minecraftforge.fml.common.event.FMLInitializationEvent;
+import net.minecraftforge.fml.common.eventhandler.Event.Result;
+import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
+
+@Mod(modid = "CreateFluidSourceTest", version = "1.0")
+public class CreateFluidSourceTest
+{
+    public static final boolean ENABLE = false;
+
+    @Mod.EventHandler
+    public static void init(FMLInitializationEvent event)
+    {
+        if (ENABLE)
+            MinecraftForge.EVENT_BUS.register(CreateFluidSourceTest.class);
+    }
+
+    @SubscribeEvent
+    public static void onCreateFluidSource(CreateFluidSourceEvent event)
+    {
+        // make it work exactly the opposite of how it works by default
+        if (event.getState().getBlock() == Blocks.FLOWING_WATER)
+            event.setResult(Result.DENY);
+        else
+            event.setResult(Result.ALLOW);
+    }
+}


### PR DESCRIPTION
When two fluid source blocks are next to a non-source block, add an event to allow mods to change the default behavior where water is "infinite" and other fluids are not.