### PR TITLE
No-nonsense sensitive getSoundType

### DIFF
--- a/patches/minecraft/net/minecraft/block/Block.java.patch
+++ b/patches/minecraft/net/minecraft/block/Block.java.patch
@@ -195,7 +195,15 @@
      }
  
      @SideOnly(Side.CLIENT)
-@@ -893,6 +912,1141 @@
+@@ -883,6 +902,7 @@
+         return Block.EnumOffsetType.NONE;
+     }
+ 
++    @Deprecated // Forge - World/state/pos/entity sensitive version below
+     public SoundType func_185467_w()
+     {
+         return this.field_149762_H;
+@@ -893,6 +913,1155 @@
          return "Block{" + field_149771_c.func_177774_c(this) + "}";
      }
  
@@ -1332,6 +1340,20 @@
 +    public void addInformation(ItemStack stack, EntityPlayer player, List<String> tooltip, boolean advanced)
 +    {
 +    }
++
++    /**
++     * Sensitive version of getSoundType
++     * @param state The state
++     * @param world The world
++     * @param pos The position. Note that the world may not necessarily have {@code state} here!
++     * @param entity The entity that is breaking/stepping on/placing/hitting/falling on this block, or null if no entity is in this context
++     * @return A SoundType to use
++     */
++    public SoundType getSoundType(IBlockState state, World world, BlockPos pos, @Nullable Entity entity)
++    {
++        return func_185467_w();
++    }
++
 +    /* ========================================= FORGE END ======================================*/
 +
      public static void func_149671_p()

--- a/patches/minecraft/net/minecraft/client/multiplayer/PlayerControllerMP.java.patch
+++ b/patches/minecraft/net/minecraft/client/multiplayer/PlayerControllerMP.java.patch
@@ -77,6 +77,15 @@
                  if (flag && iblockstate.func_185903_a(this.field_78776_a.field_71439_g, this.field_78776_a.field_71439_g.field_70170_p, p_180511_1_) >= 1.0F)
                  {
                      this.func_187103_a(p_180511_1_);
+@@ -290,7 +300,7 @@
+ 
+                 if (this.field_78780_h % 4.0F == 0.0F)
+                 {
+-                    SoundType soundtype = block.func_185467_w();
++                    SoundType soundtype = block.getSoundType(iblockstate, field_78776_a.field_71441_e, p_180512_1_, field_78776_a.field_71439_g);
+                     this.field_78776_a.func_147118_V().func_147682_a(new PositionedSoundRecord(soundtype.func_185846_f(), SoundCategory.NEUTRAL, (soundtype.func_185843_a() + 1.0F) / 8.0F, soundtype.func_185847_b() * 0.5F, p_180512_1_));
+                 }
+ 
 @@ -342,7 +352,7 @@
  
          if (this.field_85183_f != null && itemstack != null)

--- a/patches/minecraft/net/minecraft/client/renderer/RenderGlobal.java.patch
+++ b/patches/minecraft/net/minecraft/client/renderer/RenderGlobal.java.patch
@@ -133,3 +133,12 @@
                  {
                      if (d3 * d3 + d4 * d4 + d5 * d5 > 1024.0D)
                      {
+@@ -2304,7 +2335,7 @@
+ 
+                 if (block.func_176223_P().func_185904_a() != Material.field_151579_a)
+                 {
+-                    SoundType soundtype = block.func_185467_w();
++                    SoundType soundtype = block.getSoundType(Block.func_176220_d(p_180439_4_), field_72769_h, p_180439_3_, null);
+                     this.field_72769_h.func_184156_a(p_180439_3_, soundtype.func_185845_c(), SoundCategory.BLOCKS, (soundtype.func_185843_a() + 1.0F) / 2.0F, soundtype.func_185847_b() * 0.8F, false);
+                 }
+ 

--- a/patches/minecraft/net/minecraft/entity/Entity.java.patch
+++ b/patches/minecraft/net/minecraft/entity/Entity.java.patch
@@ -35,6 +35,15 @@
      public int func_145782_y()
      {
          return this.field_145783_c;
+@@ -944,7 +952,7 @@
+ 
+     protected void func_180429_a(BlockPos p_180429_1_, Block p_180429_2_)
+     {
+-        SoundType soundtype = p_180429_2_.func_185467_w();
++        SoundType soundtype = p_180429_2_.getSoundType(field_70170_p.func_180495_p(p_180429_1_), field_70170_p, p_180429_1_, this);
+ 
+         if (this.field_70170_p.func_180495_p(p_180429_1_.func_177984_a()).func_177230_c() == Blocks.field_150431_aC)
+         {
 @@ -1151,12 +1159,12 @@
              BlockPos blockpos = new BlockPos(this.field_70165_t, d0, this.field_70161_v);
              IBlockState iblockstate = this.field_70170_p.func_180495_p(blockpos);

--- a/patches/minecraft/net/minecraft/entity/EntityLivingBase.java.patch
+++ b/patches/minecraft/net/minecraft/entity/EntityLivingBase.java.patch
@@ -122,6 +122,15 @@
          super.func_180430_e(p_180430_1_, p_180430_2_);
          PotionEffect potioneffect = this.func_70660_b(MobEffects.field_76430_j);
          float f = potioneffect == null ? 0.0F : (float)(potioneffect.func_76458_c() + 1);
+@@ -1193,7 +1216,7 @@
+ 
+             if (iblockstate.func_185904_a() != Material.field_151579_a)
+             {
+-                SoundType soundtype = iblockstate.func_177230_c().func_185467_w();
++                SoundType soundtype = iblockstate.func_177230_c().getSoundType(iblockstate, field_70170_p, new BlockPos(j, k, l), this);
+                 this.func_184185_a(soundtype.func_185842_g(), soundtype.func_185843_a() * 0.5F, soundtype.func_185847_b() * 0.75F);
+             }
+         }
 @@ -1270,6 +1293,8 @@
      {
          if (!this.func_180431_b(p_70665_1_))

--- a/patches/minecraft/net/minecraft/entity/passive/EntityHorse.java.patch
+++ b/patches/minecraft/net/minecraft/entity/passive/EntityHorse.java.patch
@@ -1,5 +1,14 @@
 --- ../src-base/minecraft/net/minecraft/entity/passive/EntityHorse.java
 +++ ../src-work/minecraft/net/minecraft/entity/passive/EntityHorse.java
+@@ -405,7 +405,7 @@
+ 
+             if (iblockstate.func_185904_a() != Material.field_151579_a && !this.func_174814_R())
+             {
+-                SoundType soundtype = block.func_185467_w();
++                SoundType soundtype = block.getSoundType(iblockstate, field_70170_p, new BlockPos(this.field_70165_t, this.field_70163_u - 0.2D - (double)this.field_70126_B, this.field_70161_v), this);
+                 this.field_70170_p.func_184148_a((EntityPlayer)null, this.field_70165_t, this.field_70163_u, this.field_70161_v, soundtype.func_185844_d(), this.func_184176_by(), soundtype.func_185843_a() * 0.5F, soundtype.func_185847_b() * 0.75F);
+             }
+         }
 @@ -441,6 +441,7 @@
  
          this.field_110296_bG.func_110134_a(this);
@@ -8,6 +17,15 @@
      }
  
      private void func_110232_cE()
+@@ -556,7 +557,7 @@
+ 
+     protected void func_180429_a(BlockPos p_180429_1_, Block p_180429_2_)
+     {
+-        SoundType soundtype = p_180429_2_.func_185467_w();
++        SoundType soundtype = p_180429_2_.getSoundType(field_70170_p.func_180495_p(p_180429_1_), field_70170_p, p_180429_1_, this);
+ 
+         if (this.field_70170_p.func_180495_p(p_180429_1_.func_177984_a()).func_177230_c() == Blocks.field_150431_aC)
+         {
 @@ -1212,6 +1213,7 @@
                  }
  

--- a/patches/minecraft/net/minecraft/item/ItemBed.java.patch
+++ b/patches/minecraft/net/minecraft/item/ItemBed.java.patch
@@ -1,0 +1,11 @@
+--- ../src-base/minecraft/net/minecraft/item/ItemBed.java
++++ ../src-work/minecraft/net/minecraft/item/ItemBed.java
+@@ -63,7 +63,7 @@
+                         p_180614_3_.func_180501_a(blockpos, iblockstate2, 11);
+                     }
+ 
+-                    SoundType soundtype = iblockstate1.func_177230_c().func_185467_w();
++                    SoundType soundtype = iblockstate1.func_177230_c().getSoundType(iblockstate1, p_180614_3_, p_180614_4_, p_180614_2_);
+                     p_180614_3_.func_184133_a((EntityPlayer)null, p_180614_4_, soundtype.func_185841_e(), SoundCategory.BLOCKS, (soundtype.func_185843_a() + 1.0F) / 2.0F, soundtype.func_185847_b() * 0.8F);
+                     --p_180614_1_.field_77994_a;
+                     return EnumActionResult.SUCCESS;

--- a/patches/minecraft/net/minecraft/item/ItemBlock.java.patch
+++ b/patches/minecraft/net/minecraft/item/ItemBlock.java.patch
@@ -1,6 +1,6 @@
 --- ../src-base/minecraft/net/minecraft/item/ItemBlock.java
 +++ ../src-work/minecraft/net/minecraft/item/ItemBlock.java
-@@ -51,16 +51,8 @@
+@@ -51,17 +51,9 @@
              int i = this.func_77647_b(p_180614_1_.func_77960_j());
              IBlockState iblockstate1 = this.field_150939_a.func_180642_a(p_180614_3_, p_180614_4_, p_180614_6_, p_180614_7_, p_180614_8_, p_180614_9_, i, p_180614_2_);
  
@@ -15,9 +15,11 @@
 -                    this.field_150939_a.func_180633_a(p_180614_3_, p_180614_4_, iblockstate1, p_180614_2_, p_180614_1_);
 -                }
 -
-                 SoundType soundtype = this.field_150939_a.func_185467_w();
+-                SoundType soundtype = this.field_150939_a.func_185467_w();
++                SoundType soundtype = p_180614_3_.func_180495_p(p_180614_4_).func_177230_c().getSoundType(p_180614_3_.func_180495_p(p_180614_4_), p_180614_3_, p_180614_4_, p_180614_2_);
                  p_180614_3_.func_184133_a(p_180614_2_, p_180614_4_, soundtype.func_185841_e(), SoundCategory.BLOCKS, (soundtype.func_185843_a() + 1.0F) / 2.0F, soundtype.func_185847_b() * 0.8F);
                  --p_180614_1_.field_77994_a;
+             }
 @@ -121,7 +113,7 @@
      {
          Block block = p_179222_1_.func_180495_p(p_179222_2_).func_177230_c();

--- a/patches/minecraft/net/minecraft/item/ItemBlockSpecial.java.patch
+++ b/patches/minecraft/net/minecraft/item/ItemBlockSpecial.java.patch
@@ -1,0 +1,11 @@
+--- ../src-base/minecraft/net/minecraft/item/ItemBlockSpecial.java
++++ ../src-work/minecraft/net/minecraft/item/ItemBlockSpecial.java
+@@ -55,7 +55,7 @@
+                     iblockstate1.func_177230_c().func_180633_a(p_180614_3_, p_180614_4_, iblockstate1, p_180614_2_, p_180614_1_);
+                 }
+ 
+-                SoundType soundtype = this.field_150935_a.func_185467_w();
++                SoundType soundtype = iblockstate1.func_177230_c().getSoundType(iblockstate1, p_180614_3_, p_180614_4_, p_180614_2_);
+                 p_180614_3_.func_184133_a(p_180614_2_, p_180614_4_, soundtype.func_185841_e(), SoundCategory.BLOCKS, (soundtype.func_185843_a() + 1.0F) / 2.0F, soundtype.func_185847_b() * 0.8F);
+                 --p_180614_1_.field_77994_a;
+                 return EnumActionResult.SUCCESS;

--- a/patches/minecraft/net/minecraft/item/ItemDoor.java.patch
+++ b/patches/minecraft/net/minecraft/item/ItemDoor.java.patch
@@ -1,0 +1,11 @@
+--- ../src-base/minecraft/net/minecraft/item/ItemDoor.java
++++ ../src-work/minecraft/net/minecraft/item/ItemDoor.java
+@@ -46,7 +46,7 @@
+                 int j = enumfacing.func_82599_e();
+                 boolean flag = i < 0 && p_180614_9_ < 0.5F || i > 0 && p_180614_9_ > 0.5F || j < 0 && p_180614_7_ > 0.5F || j > 0 && p_180614_7_ < 0.5F;
+                 func_179235_a(p_180614_3_, p_180614_4_, enumfacing, this.field_179236_a, flag);
+-                SoundType soundtype = this.field_179236_a.func_185467_w();
++                SoundType soundtype = p_180614_3_.func_180495_p(p_180614_4_).func_177230_c().getSoundType(p_180614_3_.func_180495_p(p_180614_4_), p_180614_3_, p_180614_4_, p_180614_2_);
+                 p_180614_3_.func_184133_a(p_180614_2_, p_180614_4_, soundtype.func_185841_e(), SoundCategory.BLOCKS, (soundtype.func_185843_a() + 1.0F) / 2.0F, soundtype.func_185847_b() * 0.8F);
+                 --p_180614_1_.field_77994_a;
+                 return EnumActionResult.SUCCESS;

--- a/patches/minecraft/net/minecraft/item/ItemSlab.java.patch
+++ b/patches/minecraft/net/minecraft/item/ItemSlab.java.patch
@@ -1,0 +1,20 @@
+--- ../src-base/minecraft/net/minecraft/item/ItemSlab.java
++++ ../src-work/minecraft/net/minecraft/item/ItemSlab.java
+@@ -60,7 +60,7 @@
+ 
+                     if (axisalignedbb != Block.field_185506_k && p_180614_3_.func_72855_b(axisalignedbb.func_186670_a(p_180614_4_)) && p_180614_3_.func_180501_a(p_180614_4_, iblockstate1, 11))
+                     {
+-                        SoundType soundtype = this.field_179226_c.func_185467_w();
++                        SoundType soundtype = this.field_179226_c.getSoundType(iblockstate1, p_180614_3_, p_180614_4_,p_180614_2_);
+                         p_180614_3_.func_184133_a(p_180614_2_, p_180614_4_, soundtype.func_185841_e(), SoundCategory.BLOCKS, (soundtype.func_185843_a() + 1.0F) / 2.0F, soundtype.func_185847_b() * 0.8F);
+                         --p_180614_1_.field_77994_a;
+                     }
+@@ -115,7 +115,7 @@
+ 
+                 if (axisalignedbb != Block.field_185506_k && p_180615_3_.func_72855_b(axisalignedbb.func_186670_a(p_180615_4_)) && p_180615_3_.func_180501_a(p_180615_4_, iblockstate1, 11))
+                 {
+-                    SoundType soundtype = this.field_179226_c.func_185467_w();
++                    SoundType soundtype = this.field_179226_c.getSoundType(iblockstate1, p_180615_3_, p_180615_4_, p_180615_1_);
+                     p_180615_3_.func_184133_a(p_180615_1_, p_180615_4_, soundtype.func_185841_e(), SoundCategory.BLOCKS, (soundtype.func_185843_a() + 1.0F) / 2.0F, soundtype.func_185847_b() * 0.8F);
+                     --p_180615_2_.field_77994_a;
+                 }

--- a/patches/minecraft/net/minecraft/item/ItemSnow.java.patch
+++ b/patches/minecraft/net/minecraft/item/ItemSnow.java.patch
@@ -1,5 +1,14 @@
 --- ../src-base/minecraft/net/minecraft/item/ItemSnow.java
 +++ ../src-work/minecraft/net/minecraft/item/ItemSnow.java
+@@ -48,7 +48,7 @@
+ 
+                     if (axisalignedbb != Block.field_185506_k && p_180614_3_.func_72855_b(axisalignedbb.func_186670_a(blockpos)) && p_180614_3_.func_180501_a(blockpos, iblockstate1, 10))
+                     {
+-                        SoundType soundtype = this.field_150939_a.func_185467_w();
++                        SoundType soundtype = this.field_150939_a.getSoundType(iblockstate1, p_180614_3_, blockpos, p_180614_2_);
+                         p_180614_3_.func_184133_a(p_180614_2_, blockpos, soundtype.func_185841_e(), SoundCategory.BLOCKS, (soundtype.func_185843_a() + 1.0F) / 2.0F, soundtype.func_185847_b() * 0.8F);
+                         --p_180614_1_.field_77994_a;
+                         return EnumActionResult.SUCCESS;
 @@ -68,4 +68,10 @@
      {
          return p_77647_1_;


### PR DESCRIPTION
Clean, no-nonsense version of #3109 

Note that sometimes I requery the world when calling getSoundType because onBlockPlaced could have modified the world state since a state local variable was created