### PR TITLE
Add shouldCauseBlockBreakReset callback to Item.

### DIFF
--- a/patches/minecraft/net/minecraft/client/multiplayer/PlayerControllerMP.java.patch
+++ b/patches/minecraft/net/minecraft/client/multiplayer/PlayerControllerMP.java.patch
@@ -77,6 +77,15 @@
                  if (flag && iblockstate.func_185903_a(this.field_78776_a.field_71439_g, this.field_78776_a.field_71439_g.field_70170_p, p_180511_1_) >= 1.0F)
                  {
                      this.func_187103_a(p_180511_1_);
+@@ -342,7 +352,7 @@
+ 
+         if (this.field_85183_f != null && itemstack != null)
+         {
+-            flag = itemstack.func_77973_b() == this.field_85183_f.func_77973_b() && ItemStack.func_77970_a(itemstack, this.field_85183_f) && (itemstack.func_77984_f() || itemstack.func_77960_j() == this.field_85183_f.func_77960_j());
++            flag = !net.minecraftforge.client.ForgeHooksClient.shouldCauseBlockBreakReset(this.field_85183_f, itemstack);
+         }
+ 
+         return p_178893_1_.equals(this.field_178895_c) && flag;
 @@ -373,13 +383,32 @@
          }
          else

--- a/patches/minecraft/net/minecraft/item/Item.java.patch
+++ b/patches/minecraft/net/minecraft/item/Item.java.patch
@@ -52,7 +52,7 @@
          return p_77621_1_.func_147447_a(vec3d, vec3d1, p_77621_3_, !p_77621_3_, false);
      }
  
-@@ -426,11 +432,557 @@
+@@ -426,11 +432,569 @@
          return false;
      }
  
@@ -571,6 +571,18 @@
 +    }
 +
 +    /**
++     * Called when the player is mining a block and the item in his hand changes.
++     * Allows to not reset blockbreaking if only NBT or similar changes.
++     * @param oldStack The old stack that was used for mining. Item in players main hand
++     * @param newStack The new stack
++     * @return True to reset block break progress
++     */
++    public boolean shouldCauseBlockBreakReset(ItemStack oldStack, ItemStack newStack)
++    {
++        return !(newStack.func_77973_b() == oldStack.func_77973_b() && ItemStack.func_77970_a(newStack, oldStack) && (newStack.func_77984_f() || newStack.func_77960_j() == oldStack.func_77960_j()));
++    }
++
++    /**
 +     * Called from ItemStack.setItem, will hold extra data for the life of this ItemStack.
 +     * Can be retrieved from stack.getCapabilities()
 +     * The NBT can be null if this is not called from readNBT or if the item the stack is
@@ -610,7 +622,7 @@
      public static void func_150900_l()
      {
          func_179214_a(Blocks.field_150348_b, (new ItemMultiTexture(Blocks.field_150348_b, Blocks.field_150348_b, new Function<ItemStack, String>()
-@@ -962,6 +1514,10 @@
+@@ -962,6 +1526,10 @@
          private final float field_78011_i;
          private final int field_78008_j;
  
@@ -621,7 +633,7 @@
          private ToolMaterial(int p_i1874_3_, int p_i1874_4_, float p_i1874_5_, float p_i1874_6_, int p_i1874_7_)
          {
              this.field_78001_f = p_i1874_3_;
-@@ -996,9 +1552,36 @@
+@@ -996,9 +1564,36 @@
              return this.field_78008_j;
          }
  

--- a/src/main/java/net/minecraftforge/client/ForgeHooksClient.java
+++ b/src/main/java/net/minecraftforge/client/ForgeHooksClient.java
@@ -32,6 +32,7 @@ import java.nio.FloatBuffer;
 import java.util.Collections;
 import java.util.Map;
 
+import javax.annotation.Nonnull;
 import javax.vecmath.Matrix3f;
 import javax.vecmath.Matrix4f;
 import javax.vecmath.Vector3f;
@@ -675,6 +676,11 @@ public class ForgeHooksClient
             slotMainHand = slot;
         }
         return from.getItem().shouldCauseReequipAnimation(from, to, changed);
+    }
+
+    public static boolean shouldCauseBlockBreakReset(@Nonnull ItemStack from, @Nonnull ItemStack to)
+    {
+        return from.getItem().shouldCauseBlockBreakReset(from, to);
     }
 
     public static BlockFaceUV applyUVLock(BlockFaceUV blockFaceUV, EnumFacing originalSide, ITransformation rotation)

--- a/src/test/java/net/minecraftforge/debug/ItemLayerModelDebug.java
+++ b/src/test/java/net/minecraftforge/debug/ItemLayerModelDebug.java
@@ -2,14 +2,20 @@ package net.minecraftforge.debug;
 
 import net.minecraft.client.renderer.block.model.ModelResourceLocation;
 import net.minecraft.creativetab.CreativeTabs;
+import net.minecraft.entity.Entity;
 import net.minecraft.item.Item;
+import net.minecraft.item.ItemStack;
+import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.util.ResourceLocation;
+import net.minecraft.world.World;
 import net.minecraftforge.client.model.ModelLoader;
 import net.minecraftforge.fml.common.Mod;
 import net.minecraftforge.fml.common.Mod.EventHandler;
 import net.minecraftforge.fml.common.SidedProxy;
 import net.minecraftforge.fml.common.event.FMLPreInitializationEvent;
 import net.minecraftforge.fml.common.registry.GameRegistry;
+
+import java.util.Random;
 
 @Mod(modid = ItemLayerModelDebug.MODID, version = ItemLayerModelDebug.VERSION)
 public class ItemLayerModelDebug
@@ -54,6 +60,31 @@ public class ItemLayerModelDebug
             setCreativeTab(CreativeTabs.BUILDING_BLOCKS);
             setUnlocalizedName(MODID + ":" + name);
             setRegistryName(new ResourceLocation(MODID, name));
+        }
+
+        @Override
+        public void onUpdate(ItemStack stack, World worldIn, Entity entityIn, int itemSlot, boolean isSelected)
+        {
+            NBTTagCompound tag = new NBTTagCompound();
+            tag.setInteger("foo", new Random().nextInt());
+            stack.setTagCompound(tag);
+            stack.setStackDisplayName(String.valueOf(new Random().nextInt()));
+        }
+
+        @Override
+        public boolean shouldCauseBlockBreakReset(ItemStack oldStack, ItemStack newStack)
+        {
+            return shouldCauseReequipAnimation(oldStack, newStack, false);
+        }
+
+        @Override
+        public boolean shouldCauseReequipAnimation(ItemStack oldStack, ItemStack newStack, boolean slotChanged)
+        {
+            oldStack = oldStack.copy();
+            oldStack.setTagCompound(null);
+            newStack = newStack.copy();
+            newStack.setTagCompound(null);
+            return !ItemStack.areItemStacksEqual(oldStack, newStack);
         }
     }
 }


### PR DESCRIPTION
This allows to keep breaking blocks if the NBT or similar changes.

The forever old problem with stuff that changes NBT data while mining blocks, like autorepair and RF and whatnot.