### PR TITLE
Update decorate for biomes to support Decorate event

### DIFF
--- a/patches/minecraft/net/minecraft/world/biome/BiomeDesert.java.patch
+++ b/patches/minecraft/net/minecraft/world/biome/BiomeDesert.java.patch
@@ -1,0 +1,18 @@
+--- ../src-base/minecraft/net/minecraft/world/biome/BiomeDesert.java
++++ ../src-work/minecraft/net/minecraft/world/biome/BiomeDesert.java
+@@ -28,6 +28,7 @@
+     {
+         super.func_180624_a(p_180624_1_, p_180624_2_, p_180624_3_);
+ 
++        if(net.minecraftforge.event.terraingen.TerrainGen.decorate(p_180624_1_, p_180624_2_, p_180624_3_, net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.DESERT_WELL))
+         if (p_180624_2_.nextInt(1000) == 0)
+         {
+             int i = p_180624_2_.nextInt(16) + 8;
+@@ -36,6 +37,7 @@
+             (new WorldGenDesertWells()).func_180709_b(p_180624_1_, p_180624_2_, blockpos);
+         }
+ 
++        if(net.minecraftforge.event.terraingen.TerrainGen.decorate(p_180624_1_, p_180624_2_, p_180624_3_, net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.FOSSIL))
+         if (p_180624_2_.nextInt(64) == 0)
+         {
+             (new WorldGenFossils()).func_180709_b(p_180624_1_, p_180624_2_, p_180624_3_);

--- a/patches/minecraft/net/minecraft/world/biome/BiomeForest.java.patch
+++ b/patches/minecraft/net/minecraft/world/biome/BiomeForest.java.patch
@@ -1,6 +1,36 @@
 --- ../src-base/minecraft/net/minecraft/world/biome/BiomeForest.java
 +++ ../src-work/minecraft/net/minecraft/world/biome/BiomeForest.java
-@@ -147,6 +147,22 @@
+@@ -69,19 +69,23 @@
+ 
+     public void func_180624_a(World p_180624_1_, Random p_180624_2_, BlockPos p_180624_3_)
+     {
++    	if(net.minecraftforge.event.terraingen.TerrainGen.decorate(p_180624_1_, p_180624_2_, p_180624_3_, net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.SHROOM))
+         if (this.field_150632_aF == BiomeForest.Type.ROOFED)
+         {
+             this.func_185379_b(p_180624_1_, p_180624_2_, p_180624_3_);
+         }
+ 
+-        int i = p_180624_2_.nextInt(5) - 3;
+-
+-        if (this.field_150632_aF == BiomeForest.Type.FLOWER)
++    	if(net.minecraftforge.event.terraingen.TerrainGen.decorate(p_180624_1_, p_180624_2_, p_180624_3_, net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.FLOWERS))
+         {
+-            i += 2;
+-        }
++    	    int i = p_180624_2_.nextInt(5) - 3;
+ 
+-        this.func_185378_a(p_180624_1_, p_180624_2_, p_180624_3_, i);
++            if (this.field_150632_aF == BiomeForest.Type.FLOWER)
++            {
++                i += 2;
++            }
++            
++            this.func_185378_a(p_180624_1_, p_180624_2_, p_180624_3_, i);
++        }
+         super.func_180624_a(p_180624_1_, p_180624_2_, p_180624_3_);
+     }
+ 
+@@ -147,6 +151,22 @@
          }
      }
  

--- a/patches/minecraft/net/minecraft/world/biome/BiomeJungle.java.patch
+++ b/patches/minecraft/net/minecraft/world/biome/BiomeJungle.java.patch
@@ -1,6 +1,6 @@
 --- ../src-base/minecraft/net/minecraft/world/biome/BiomeJungle.java
 +++ ../src-work/minecraft/net/minecraft/world/biome/BiomeJungle.java
-@@ -68,7 +68,9 @@
+@@ -68,10 +68,14 @@
          super.func_180624_a(p_180624_1_, p_180624_2_, p_180624_3_);
          int i = p_180624_2_.nextInt(16) + 8;
          int j = p_180624_2_.nextInt(16) + 8;
@@ -8,6 +8,11 @@
 +        int height = p_180624_1_.func_175645_m(p_180624_3_.func_177982_a(i, 0, j)).func_177956_o() * 2; // could == 0, which crashes nextInt
 +        if (height < 1) height = 1;
 +        int k = p_180624_2_.nextInt(height);
++        if(net.minecraftforge.event.terraingen.TerrainGen.decorate(p_180624_1_, p_180624_2_, p_180624_3_, net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.PUMPKIN))
          (new WorldGenMelon()).func_180709_b(p_180624_1_, p_180624_2_, p_180624_3_.func_177982_a(i, k, j));
          WorldGenVines worldgenvines = new WorldGenVines();
  
++        if(net.minecraftforge.event.terraingen.TerrainGen.decorate(p_180624_1_, p_180624_2_, p_180624_3_, net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.GRASS))
+         for (j = 0; j < 50; ++j)
+         {
+             k = p_180624_2_.nextInt(16) + 8;

--- a/patches/minecraft/net/minecraft/world/biome/BiomePlains.java.patch
+++ b/patches/minecraft/net/minecraft/world/biome/BiomePlains.java.patch
@@ -1,6 +1,23 @@
 --- ../src-base/minecraft/net/minecraft/world/biome/BiomePlains.java
 +++ ../src-work/minecraft/net/minecraft/world/biome/BiomePlains.java
-@@ -95,6 +95,21 @@
+@@ -70,6 +70,7 @@
+             this.field_76760_I.field_76803_B = 10;
+             field_180280_ag.func_180710_a(BlockDoublePlant.EnumPlantType.GRASS);
+ 
++            if(net.minecraftforge.event.terraingen.TerrainGen.decorate(p_180624_1_, p_180624_2_, p_180624_3_, net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.GRASS))
+             for (int i = 0; i < 7; ++i)
+             {
+                 int j = p_180624_2_.nextInt(16) + 8;
+@@ -79,7 +80,7 @@
+             }
+         }
+ 
+-        if (this.field_150628_aC)
++        if (this.field_150628_aC && net.minecraftforge.event.terraingen.TerrainGen.decorate(p_180624_1_, p_180624_2_, p_180624_3_, net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.FLOWERS))
+         {
+             field_180280_ag.func_180710_a(BlockDoublePlant.EnumPlantType.SUNFLOWER);
+ 
+@@ -95,6 +96,21 @@
          super.func_180624_a(p_180624_1_, p_180624_2_, p_180624_3_);
      }
  

--- a/patches/minecraft/net/minecraft/world/biome/BiomeSavanna.java.patch
+++ b/patches/minecraft/net/minecraft/world/biome/BiomeSavanna.java.patch
@@ -1,0 +1,10 @@
+--- ../src-base/minecraft/net/minecraft/world/biome/BiomeSavanna.java
++++ ../src-work/minecraft/net/minecraft/world/biome/BiomeSavanna.java
+@@ -30,6 +30,7 @@
+     {
+         field_180280_ag.func_180710_a(BlockDoublePlant.EnumPlantType.GRASS);
+ 
++        if(net.minecraftforge.event.terraingen.TerrainGen.decorate(p_180624_1_, p_180624_2_, p_180624_3_, net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.GRASS))
+         for (int i = 0; i < 7; ++i)
+         {
+             int j = p_180624_2_.nextInt(16) + 8;

--- a/patches/minecraft/net/minecraft/world/biome/BiomeSnow.java.patch
+++ b/patches/minecraft/net/minecraft/world/biome/BiomeSnow.java.patch
@@ -1,0 +1,11 @@
+--- ../src-base/minecraft/net/minecraft/world/biome/BiomeSnow.java
++++ ../src-work/minecraft/net/minecraft/world/biome/BiomeSnow.java
+@@ -39,7 +39,7 @@
+ 
+     public void func_180624_a(World p_180624_1_, Random p_180624_2_, BlockPos p_180624_3_)
+     {
+-        if (this.field_150615_aC)
++        if (this.field_150615_aC && net.minecraftforge.event.terraingen.TerrainGen.decorate(p_180624_1_, p_180624_2_, p_180624_3_, net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.ICE))
+         {
+             for (int i = 0; i < 3; ++i)
+             {

--- a/patches/minecraft/net/minecraft/world/biome/BiomeSwamp.java.patch
+++ b/patches/minecraft/net/minecraft/world/biome/BiomeSwamp.java.patch
@@ -1,6 +1,14 @@
 --- ../src-base/minecraft/net/minecraft/world/biome/BiomeSwamp.java
 +++ ../src-work/minecraft/net/minecraft/world/biome/BiomeSwamp.java
-@@ -97,4 +97,10 @@
+@@ -79,6 +79,7 @@
+     {
+         super.func_180624_a(p_180624_1_, p_180624_2_, p_180624_3_);
+ 
++        if(net.minecraftforge.event.terraingen.TerrainGen.decorate(p_180624_1_, p_180624_2_, p_180624_3_, net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.FOSSIL))
+         if (p_180624_2_.nextInt(64) == 0)
+         {
+             (new WorldGenFossils()).func_180709_b(p_180624_1_, p_180624_2_, p_180624_3_);
+@@ -97,4 +98,10 @@
      {
          return 6975545;
      }

--- a/patches/minecraft/net/minecraft/world/biome/BiomeTaiga.java.patch
+++ b/patches/minecraft/net/minecraft/world/biome/BiomeTaiga.java.patch
@@ -1,0 +1,19 @@
+--- ../src-base/minecraft/net/minecraft/world/biome/BiomeTaiga.java
++++ ../src-work/minecraft/net/minecraft/world/biome/BiomeTaiga.java
+@@ -60,7 +60,7 @@
+ 
+     public void func_180624_a(World p_180624_1_, Random p_180624_2_, BlockPos p_180624_3_)
+     {
+-        if (this.field_150644_aH == BiomeTaiga.Type.MEGA || this.field_150644_aH == BiomeTaiga.Type.MEGA_SPRUCE)
++        if ((this.field_150644_aH == BiomeTaiga.Type.MEGA || this.field_150644_aH == BiomeTaiga.Type.MEGA_SPRUCE) && net.minecraftforge.event.terraingen.TerrainGen.decorate(p_180624_1_, p_180624_2_, p_180624_3_, net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.ROCK))
+         {
+             int i = p_180624_2_.nextInt(3);
+ 
+@@ -75,6 +75,7 @@
+ 
+         field_180280_ag.func_180710_a(BlockDoublePlant.EnumPlantType.FERN);
+ 
++        if(net.minecraftforge.event.terraingen.TerrainGen.decorate(p_180624_1_, p_180624_2_, p_180624_3_, net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.FLOWERS))
+         for (int i1 = 0; i1 < 7; ++i1)
+         {
+             int j1 = p_180624_2_.nextInt(16) + 8;

--- a/src/main/java/net/minecraftforge/event/terraingen/DecorateBiomeEvent.java
+++ b/src/main/java/net/minecraftforge/event/terraingen/DecorateBiomeEvent.java
@@ -109,7 +109,7 @@ public class DecorateBiomeEvent extends Event
 
         /** Use CUSTOM to filter custom event types
          */
-        public static enum EventType { BIG_SHROOM, CACTUS, CLAY, DEAD_BUSH, LILYPAD, FLOWERS, GRASS, LAKE_WATER, LAKE_LAVA, PUMPKIN, REED, SAND, SAND_PASS2, SHROOM, TREE, CUSTOM }
+        public static enum EventType { BIG_SHROOM, CACTUS, CLAY, DEAD_BUSH, DESERT_WELL, LILYPAD, FLOWERS, FOSSIL, GRASS, ICE, LAKE_WATER, LAKE_LAVA, PUMPKIN, REED, ROCK, SAND, SAND_PASS2, SHROOM, TREE, CUSTOM }
 
         private final EventType type;
 

--- a/src/test/java/net/minecraftforge/debug/DecorateEventDebug.java
+++ b/src/test/java/net/minecraftforge/debug/DecorateEventDebug.java
@@ -1,0 +1,30 @@
+package net.minecraftforge.debug;
+
+import net.minecraftforge.common.MinecraftForge;
+import net.minecraftforge.event.terraingen.DecorateBiomeEvent;
+import net.minecraftforge.fml.common.Mod;
+import net.minecraftforge.fml.common.Mod.EventHandler;
+import net.minecraftforge.fml.common.event.FMLInitializationEvent;
+import net.minecraftforge.fml.common.eventhandler.Event.Result;
+import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
+
+@Mod(modid = DecorateEventDebug.MODID, name = DecorateEventDebug.NAME, version = DecorateEventDebug.VERSION)
+public class DecorateEventDebug 
+{
+
+    public static final String MODID = "decorateeventdebug";
+    public static final String NAME = "DecorateEventDebug";
+    public static final String VERSION = "1.0.0";
+
+    @EventHandler
+    public void init(FMLInitializationEvent event) 
+    {
+	    MinecraftForge.TERRAIN_GEN_BUS.register(this);
+    }
+
+    @SubscribeEvent
+    public void decorateEvent(DecorateBiomeEvent.Decorate event) 
+    {
+	    event.setResult(Result.DENY);
+    }
+}


### PR DESCRIPTION
Based off of #2009 this adds support for Decorate event hook for all biomes. This also adds in support for fossils and desert wells.

This uses the DecorateBiomeEvent.Decorate event so if result is set to DENY then nothing extra should decorate.