### PR TITLE
Fixed AnvilRepairEvent getLeft(), getRight(), and getOutput() returning incorrect itemstack.

### DIFF
--- a/src/main/java/net/minecraftforge/common/ForgeHooks.java
+++ b/src/main/java/net/minecraftforge/common/ForgeHooks.java
@@ -841,7 +841,7 @@ public class ForgeHooks
 
     public static float onAnvilRepair(EntityPlayer player, ItemStack output, ItemStack left, ItemStack right)
     {
-        AnvilRepairEvent e = new AnvilRepairEvent(player, left, right, output);
+        AnvilRepairEvent e = new AnvilRepairEvent(player, output, left, right);
         MinecraftForge.EVENT_BUS.post(e);
         return e.getBreakChance();
     }


### PR DESCRIPTION
- The AnvilRepairEvent was being feed parameters in the wrong order. It was being feed parameters that would make the getOutput() was the itemstack in the left slot, the getLeft() was the itemstack in the right slot, and the getRight() was the itemstack in the output slot.