### PR TITLE
Fix test mod IDs, names, and versions

### DIFF
--- a/src/test/java/net/minecraftforge/debug/DynBucketTest.java
+++ b/src/test/java/net/minecraftforge/debug/DynBucketTest.java
@@ -45,10 +45,10 @@ import net.minecraftforge.items.wrapper.CombinedInvWrapper;
 
 import java.util.List;
 
-@Mod(modid = DynBucketTest.MODID, version = "0.1", dependencies = "after:" + ModelFluidDebug.MODID)
+@Mod(modid = DynBucketTest.MODID, name = "DynBucketTest", version = "0.1", dependencies = "after:" + ModelFluidDebug.MODID)
 public class DynBucketTest
 {
-    public static final String MODID = "DynBucketTest";
+    public static final String MODID = "dynbuckettest";
     public static final Item dynBucket = new DynBucket();
     public static final Item dynBottle = new DynBottle();
     private static final ResourceLocation simpleTankName = new ResourceLocation(MODID, "simpletank");

--- a/src/test/java/net/minecraftforge/debug/EnumPlantTypeTest.java
+++ b/src/test/java/net/minecraftforge/debug/EnumPlantTypeTest.java
@@ -7,7 +7,7 @@ import net.minecraftforge.fml.common.event.FMLInitializationEvent;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.LogManager;
 
-@Mod(modid = "enumplanttypetest")
+@Mod(modid = "enumplanttypetest", name = "EnumPlantTypeTest", version = "1.0")
 public class EnumPlantTypeTest 
 {
 	private static Logger LOGGER = LogManager.getLogger();

--- a/src/test/java/net/minecraftforge/debug/ForgeBlockStatesLoaderDebug.java
+++ b/src/test/java/net/minecraftforge/debug/ForgeBlockStatesLoaderDebug.java
@@ -30,9 +30,9 @@ import net.minecraftforge.fml.relauncher.SideOnly;
 import com.google.common.base.Function;
 import com.google.common.collect.Maps;
 
-@Mod(modid = ForgeBlockStatesLoaderDebug.MODID)
+@Mod(modid = ForgeBlockStatesLoaderDebug.MODID, name = "ForgeBlockStatesLoader", version = "1.0")
 public class ForgeBlockStatesLoaderDebug {
-    public static final String MODID = "ForgeBlockStatesLoader";
+    public static final String MODID = "forgeblockstatesloader";
     public static final String ASSETS = "forgeblockstatesloader:";
 
     //public static final Block blockCustom = new CustomMappedBlock();

--- a/src/test/java/net/minecraftforge/debug/ItemLayerModelDebug.java
+++ b/src/test/java/net/minecraftforge/debug/ItemLayerModelDebug.java
@@ -17,10 +17,10 @@ import net.minecraftforge.fml.common.registry.GameRegistry;
 
 import java.util.Random;
 
-@Mod(modid = ItemLayerModelDebug.MODID, version = ItemLayerModelDebug.VERSION)
+@Mod(modid = ItemLayerModelDebug.MODID, name = "ForgeDebugItemLayerModel", version = ItemLayerModelDebug.VERSION)
 public class ItemLayerModelDebug
 {
-    public static final String MODID = "ForgeDebugItemLayerModel";
+    public static final String MODID = "forgedebugitemlayermodel";
     public static final String VERSION = "1.0";
 
     @SidedProxy

--- a/src/test/java/net/minecraftforge/debug/ItemTileDebug.java
+++ b/src/test/java/net/minecraftforge/debug/ItemTileDebug.java
@@ -26,10 +26,10 @@ import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
 import net.minecraftforge.fml.common.registry.GameRegistry;
 import static org.lwjgl.opengl.GL11.*;
 
-@Mod(modid = ItemTileDebug.MODID)
+@Mod(modid = ItemTileDebug.MODID, name = "ForgeDebugItemTile", version = "1.0")
 public class ItemTileDebug
 {
-    public static final String MODID = "ForgeDebugItemTile";
+    public static final String MODID = "forgedebugitemtile";
 
     private static String blockName = MODID.toLowerCase() + ":" + TestBlock.name;
 

--- a/src/test/java/net/minecraftforge/debug/LootTablesDebug.java
+++ b/src/test/java/net/minecraftforge/debug/LootTablesDebug.java
@@ -17,7 +17,7 @@ import net.minecraftforge.fml.common.Mod;
 import net.minecraftforge.fml.common.event.FMLInitializationEvent;
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
 
-@Mod(modid=LootTablesDebug.MODID)
+@Mod(modid = LootTablesDebug.MODID, name = "Loot Table Debug", version = "1.0")
 public class LootTablesDebug {
     public static final String MODID = "loot_table_debug";
     private static final ResourceLocation CUSTOM_LOOT = LootTableList.register(new ResourceLocation(MODID, "custom_loot"));

--- a/src/test/java/net/minecraftforge/debug/ModelAnimationDebug.java
+++ b/src/test/java/net/minecraftforge/debug/ModelAnimationDebug.java
@@ -57,7 +57,7 @@ import net.minecraftforge.fml.common.registry.GameRegistry;
 
 import com.google.common.collect.ImmutableMap;
 
-@Mod(modid = ModelAnimationDebug.MODID, version = ModelAnimationDebug.VERSION)
+@Mod(modid = ModelAnimationDebug.MODID, name = "ForgeDebugModelAnimation", version = ModelAnimationDebug.VERSION)
 public class ModelAnimationDebug
 {
     public static final String MODID = "forgedebugmodelanimation";

--- a/src/test/java/net/minecraftforge/debug/ModelBakeEventDebug.java
+++ b/src/test/java/net/minecraftforge/debug/ModelBakeEventDebug.java
@@ -49,10 +49,10 @@ import net.minecraftforge.fml.common.registry.GameRegistry;
 import com.google.common.collect.ImmutableList;
 import com.google.common.primitives.Ints;
 
-@Mod(modid = ModelBakeEventDebug.MODID, version = ModelBakeEventDebug.VERSION)
+@Mod(modid = ModelBakeEventDebug.MODID, name = "ForgeDebugModelBakeEvent", version = ModelBakeEventDebug.VERSION)
 public class ModelBakeEventDebug
 {
-    public static final String MODID = "ForgeDebugModelBakeEvent";
+    public static final String MODID = "forgedebugmodelbakeevent";
     public static final String VERSION = "1.0";
     public static final int cubeSize = 3;
 

--- a/src/test/java/net/minecraftforge/debug/ModelFluidDebug.java
+++ b/src/test/java/net/minecraftforge/debug/ModelFluidDebug.java
@@ -21,10 +21,10 @@ import net.minecraftforge.fml.common.SidedProxy;
 import net.minecraftforge.fml.common.event.FMLPreInitializationEvent;
 import net.minecraftforge.fml.common.registry.GameRegistry;
 
-@Mod(modid = ModelFluidDebug.MODID, version = ModelFluidDebug.VERSION)
+@Mod(modid = ModelFluidDebug.MODID, name = "ForgeDebugModelFluid", version = ModelFluidDebug.VERSION)
 public class ModelFluidDebug
 {
-    public static final String MODID = "ForgeDebugModelFluid";
+    public static final String MODID = "forgedebugmodelfluid";
     public static final String VERSION = "1.0";
 
     public static final boolean ENABLE = false;

--- a/src/test/java/net/minecraftforge/debug/ModelLoaderRegistryDebug.java
+++ b/src/test/java/net/minecraftforge/debug/ModelLoaderRegistryDebug.java
@@ -57,10 +57,10 @@ import net.minecraftforge.fml.relauncher.Side;
 
 import com.google.common.collect.Lists;
 
-@Mod(modid = ModelLoaderRegistryDebug.MODID, version = ModelLoaderRegistryDebug.VERSION)
+@Mod(modid = ModelLoaderRegistryDebug.MODID, name = "ForgeDebugModelLoaderRegistry", version = ModelLoaderRegistryDebug.VERSION)
 public class ModelLoaderRegistryDebug
 {
-    public static final String MODID = "ForgeDebugModelLoaderRegistry";
+    public static final String MODID = "forgedebugmodelloaderregistry";
     public static final String VERSION = "1.0";
 
     @EventHandler

--- a/src/test/java/net/minecraftforge/debug/MultiLayerModelDebug.java
+++ b/src/test/java/net/minecraftforge/debug/MultiLayerModelDebug.java
@@ -16,7 +16,7 @@ import net.minecraftforge.fml.common.SidedProxy;
 import net.minecraftforge.fml.common.event.FMLPreInitializationEvent;
 import net.minecraftforge.fml.common.registry.GameRegistry;
 
-@Mod(modid = MultiLayerModelDebug.MODID, version = MultiLayerModelDebug.VERSION)
+@Mod(modid = MultiLayerModelDebug.MODID, name = "ForgeDebugMultiLayerModel", version = MultiLayerModelDebug.VERSION)
 public class MultiLayerModelDebug
 {
     public static final String MODID = "forgedebugmultilayermodel";

--- a/src/test/java/net/minecraftforge/debug/PotionRegistryDebug.java
+++ b/src/test/java/net/minecraftforge/debug/PotionRegistryDebug.java
@@ -19,9 +19,9 @@ import net.minecraftforge.fml.common.Mod;
 import net.minecraftforge.fml.common.event.FMLPreInitializationEvent;
 import net.minecraftforge.fml.common.registry.GameData;
 
-@Mod(modid=PotionRegistryDebug.MODID)
+@Mod(modid = PotionRegistryDebug.MODID, name = "ForgePotionRegistry", version = "1.0")
 public class PotionRegistryDebug {
-  public static final String MODID = "ForgePotionRegistry";
+  public static final String MODID = "forgepotionregistry";
 
   @Mod.EventHandler
   public void preInit(FMLPreInitializationEvent event) {

--- a/src/test/java/net/minecraftforge/test/BrewingRecipeRegistryTest.java
+++ b/src/test/java/net/minecraftforge/test/BrewingRecipeRegistryTest.java
@@ -7,7 +7,7 @@ import net.minecraftforge.fml.common.Mod;
 import net.minecraftforge.fml.common.Mod.EventHandler;
 import net.minecraftforge.fml.common.event.FMLInitializationEvent;
 
-@Mod(modid="BrewingRecipeRegistryTest", name="BrewingRecipeRegistryTest", version="0.0.0")
+@Mod(modid="brewingreciperegistrytest", name="BrewingRecipeRegistryTest", version="0.0.0")
 public class BrewingRecipeRegistryTest
 {
 

--- a/src/test/java/net/minecraftforge/test/CreateFluidSourceTest.java
+++ b/src/test/java/net/minecraftforge/test/CreateFluidSourceTest.java
@@ -8,7 +8,7 @@ import net.minecraftforge.fml.common.event.FMLInitializationEvent;
 import net.minecraftforge.fml.common.eventhandler.Event.Result;
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
 
-@Mod(modid = "CreateFluidSourceTest", version = "1.0")
+@Mod(modid = "createfluidsourcetest", name = "CreateFluidSourceTest", version = "1.0")
 public class CreateFluidSourceTest
 {
     public static final boolean ENABLE = false;

--- a/src/test/java/net/minecraftforge/test/EntityTravelToDimensionEventTest.java
+++ b/src/test/java/net/minecraftforge/test/EntityTravelToDimensionEventTest.java
@@ -7,7 +7,7 @@ import net.minecraftforge.fml.common.Mod.EventHandler;
 import net.minecraftforge.fml.common.event.FMLInitializationEvent;
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
 
-@Mod(modid="EntityTravelToDimensionEventTest", name="EntityTravelToDimensionEventTest", version="0.0.0")
+@Mod(modid="entitytraveltodimensioneventtest", name="EntityTravelToDimensionEventTest", version="0.0.0")
 public class EntityTravelToDimensionEventTest
 {
     public static final boolean ENABLE = false;

--- a/src/test/java/net/minecraftforge/test/FluidHandlerTest.java
+++ b/src/test/java/net/minecraftforge/test/FluidHandlerTest.java
@@ -18,7 +18,7 @@ import net.minecraftforge.fml.common.event.FMLLoadCompleteEvent;
 import net.minecraftforge.fml.common.registry.ForgeRegistries;
 import net.minecraftforge.fml.relauncher.Side;
 
-@Mod(modid="FluidHandlerTest", name="FluidHandlerTest", version="0.0.0")
+@Mod(modid="fluidhandlertest", name="FluidHandlerTest", version="0.0.0")
 public class FluidHandlerTest
 {
 	public static final boolean ENABLE = false;

--- a/src/test/java/net/minecraftforge/test/NeighborNotifyEventTest.java
+++ b/src/test/java/net/minecraftforge/test/NeighborNotifyEventTest.java
@@ -7,7 +7,7 @@ import net.minecraftforge.fml.common.Mod.EventHandler;
 import net.minecraftforge.fml.common.event.FMLInitializationEvent;
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
 
-@Mod(modid="NeighborNotifyEventTest", name="NeighborNotifyEventTest", version="0.0.0")
+@Mod(modid="neighbornotifyeventtest", name="NeighborNotifyEventTest", version="0.0.0")
 public class NeighborNotifyEventTest 
 {
 

--- a/src/test/java/net/minecraftforge/test/NoBedSleepingTest.java
+++ b/src/test/java/net/minecraftforge/test/NoBedSleepingTest.java
@@ -32,10 +32,10 @@ import net.minecraftforge.fml.common.eventhandler.Event.Result;
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
 import net.minecraftforge.fml.common.registry.GameRegistry;
 
-@Mod(modid = NoBedSleepingTest.MODID, version = NoBedSleepingTest.VERSION)
+@Mod(modid = NoBedSleepingTest.MODID, name = "ForgeDebugNoBedSleeping", version = NoBedSleepingTest.VERSION)
 public class NoBedSleepingTest
 {
-    public static final String MODID = "ForgeDebugNoBedSleeping";
+    public static final String MODID = "forgedebugnobedsleeping";
     public static final String VERSION = "1.0";
     @CapabilityInject(IExtraSleeping.class)
     private static final Capability<IExtraSleeping> SLEEP_CAP = null;

--- a/src/test/java/net/minecraftforge/test/PlayerInteractEventTest.java
+++ b/src/test/java/net/minecraftforge/test/PlayerInteractEventTest.java
@@ -20,7 +20,7 @@ import net.minecraftforge.fml.common.eventhandler.Event;
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
 import org.apache.logging.log4j.Logger;
 
-@Mod(modid="PlayerInteractEventTest", name="PlayerInteractEventTest", version="0.0.0")
+@Mod(modid="playerinteracteventtest", name="PlayerInteractEventTest", version="0.0.0")
 public class PlayerInteractEventTest
 {
     // NOTE: Test with both this ON and OFF - ensure none of the test behaviours show when this is off!

--- a/src/test/java/net/minecraftforge/test/TestCapabilityMod.java
+++ b/src/test/java/net/minecraftforge/test/TestCapabilityMod.java
@@ -20,7 +20,7 @@ import net.minecraftforge.fml.common.Mod;
 import net.minecraftforge.fml.common.event.FMLPreInitializationEvent;
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
 
-@Mod(modid="forge.testcapmod",version="1.0")
+@Mod(modid = "forge.testcapmod", name = "Forge TestCapMod", version = "1.0")
 public class TestCapabilityMod
 {
     // A Holder/Marker for if this capability is installed.

--- a/src/test/java/net/minecraftforge/test/WRNormalMod.java
+++ b/src/test/java/net/minecraftforge/test/WRNormalMod.java
@@ -17,7 +17,7 @@ import net.minecraftforge.fml.common.Mod.Instance;
 import net.minecraftforge.fml.common.event.FMLPreInitializationEvent;
 import net.minecraftforge.fml.common.registry.EntityRegistry;
 
-@Mod(modid = "wrnormal", version = "1.0")
+@Mod(modid = "wrnormal", name = "WRNormal", version = "1.0")
 public class WRNormalMod
 {
     @Instance("wrnormal")


### PR DESCRIPTION
Most of our test mods have bad IDs (uppercase) and are missing names or
versions. Forge produces a bunch of warnings in the console about this, which
makes it more likely that an important message will be missed.