### PR TITLE
Add Block#getStateForPlacement, a stack aware version of onBlockPlaced

### DIFF
--- a/patches/minecraft/net/minecraft/block/Block.java.patch
+++ b/patches/minecraft/net/minecraft/block/Block.java.patch
@@ -143,7 +143,16 @@
      }
  
      public boolean func_180639_a(World p_180639_1_, BlockPos p_180639_2_, IBlockState p_180639_3_, EntityPlayer p_180639_4_, EnumHand p_180639_5_, @Nullable ItemStack p_180639_6_, EnumFacing p_180639_7_, float p_180639_8_, float p_180639_9_, float p_180639_10_)
-@@ -680,25 +687,35 @@
+@@ -639,6 +646,8 @@
+     {
+     }
+ 
++    // Forge: use getStateForPlacement
++    @Deprecated
+     public IBlockState func_180642_a(World p_180642_1_, BlockPos p_180642_2_, EnumFacing p_180642_3_, float p_180642_4_, float p_180642_5_, float p_180642_6_, int p_180642_7_, EntityLivingBase p_180642_8_)
+     {
+         return this.func_176203_a(p_180642_7_);
+@@ -680,25 +689,35 @@
          p_180657_2_.func_71029_a(StatList.func_188055_a(this));
          p_180657_2_.func_71020_j(0.025F);
  
@@ -182,7 +191,7 @@
      }
  
      @Nullable
-@@ -794,9 +811,11 @@
+@@ -794,9 +813,11 @@
      }
  
      @Nullable
@@ -195,7 +204,7 @@
      }
  
      @SideOnly(Side.CLIENT)
-@@ -883,6 +902,7 @@
+@@ -883,6 +904,7 @@
          return Block.EnumOffsetType.NONE;
      }
  
@@ -203,7 +212,7 @@
      public SoundType func_185467_w()
      {
          return this.field_149762_H;
-@@ -893,6 +913,1168 @@
+@@ -893,6 +915,1186 @@
          return "Block{" + field_149771_c.func_177774_c(this) + "}";
      }
  
@@ -1367,12 +1376,30 @@
 +        return null;
 +    }
 +
++    /**
++     * Gets the {@link IBlockState} to place
++     * @param world The world the block is being placed in
++     * @param pos The position the block is being placed at
++     * @param facing The side the block is being placed on
++     * @param hitX The X coordinate of the hit vector
++     * @param hitY The Y coordinate of the hit vector
++     * @param hitZ The Z coordinate of the hit vector
++     * @param meta The metadata of {@link ItemStack} as processed by {@link Item#getMetadata(int)}
++     * @param placer The entity placing the block
++     * @param stack The stack being used to place this block
++     * @return The state to be placed in the world
++     */
++    public IBlockState getStateForPlacement(World world, BlockPos pos, EnumFacing facing, float hitX, float hitY, float hitZ, int meta, EntityLivingBase placer, ItemStack stack)
++    {
++        return func_180642_a(world, pos, facing, hitX, hitY, hitZ, meta, placer);
++    }
++
 +    /* ========================================= FORGE END ======================================*/
 +
      public static void func_149671_p()
      {
          func_176215_a(0, field_176230_a, (new BlockAir()).func_149663_c("air"));
-@@ -1169,11 +2351,7 @@
+@@ -1169,11 +2371,7 @@
              }
              else
              {

--- a/patches/minecraft/net/minecraft/item/ItemBlock.java.patch
+++ b/patches/minecraft/net/minecraft/item/ItemBlock.java.patch
@@ -1,8 +1,11 @@
 --- ../src-base/minecraft/net/minecraft/item/ItemBlock.java
 +++ ../src-work/minecraft/net/minecraft/item/ItemBlock.java
-@@ -51,17 +51,9 @@
+@@ -49,19 +49,11 @@
+         if (p_180614_1_.field_77994_a != 0 && p_180614_2_.func_175151_a(p_180614_4_, p_180614_6_, p_180614_1_) && p_180614_3_.func_175716_a(this.field_150939_a, p_180614_4_, false, p_180614_6_, (Entity)null, p_180614_1_))
+         {
              int i = this.func_77647_b(p_180614_1_.func_77960_j());
-             IBlockState iblockstate1 = this.field_150939_a.func_180642_a(p_180614_3_, p_180614_4_, p_180614_6_, p_180614_7_, p_180614_8_, p_180614_9_, i, p_180614_2_);
+-            IBlockState iblockstate1 = this.field_150939_a.func_180642_a(p_180614_3_, p_180614_4_, p_180614_6_, p_180614_7_, p_180614_8_, p_180614_9_, i, p_180614_2_);
++            IBlockState iblockstate1 = this.field_150939_a.getStateForPlacement(p_180614_3_, p_180614_4_, p_180614_6_, p_180614_7_, p_180614_8_, p_180614_9_, i, p_180614_2_, p_180614_1_);
  
 -            if (p_180614_3_.func_180501_a(p_180614_4_, iblockstate1, 11))
 +            if (placeBlockAt(p_180614_1_, p_180614_2_, p_180614_3_, p_180614_4_, p_180614_6_, p_180614_7_, p_180614_8_, p_180614_9_, iblockstate1))

--- a/patches/minecraft/net/minecraft/item/ItemBlockSpecial.java.patch
+++ b/patches/minecraft/net/minecraft/item/ItemBlockSpecial.java.patch
@@ -1,5 +1,14 @@
 --- ../src-base/minecraft/net/minecraft/item/ItemBlockSpecial.java
 +++ ../src-work/minecraft/net/minecraft/item/ItemBlockSpecial.java
+@@ -39,7 +39,7 @@
+ 
+         if (p_180614_2_.func_175151_a(p_180614_4_, p_180614_6_, p_180614_1_) && p_180614_1_.field_77994_a != 0 && p_180614_3_.func_175716_a(this.field_150935_a, p_180614_4_, false, p_180614_6_, (Entity)null, p_180614_1_))
+         {
+-            IBlockState iblockstate1 = this.field_150935_a.func_180642_a(p_180614_3_, p_180614_4_, p_180614_6_, p_180614_7_, p_180614_8_, p_180614_9_, 0, p_180614_2_);
++            IBlockState iblockstate1 = this.field_150935_a.getStateForPlacement(p_180614_3_, p_180614_4_, p_180614_6_, p_180614_7_, p_180614_8_, p_180614_9_, 0, p_180614_2_, p_180614_1_);
+ 
+             if (!p_180614_3_.func_180501_a(p_180614_4_, iblockstate1, 11))
+             {
 @@ -55,7 +55,7 @@
                      iblockstate1.func_177230_c().func_180633_a(p_180614_3_, p_180614_4_, iblockstate1, p_180614_2_, p_180614_1_);
                  }

--- a/patches/minecraft/net/minecraft/item/ItemDye.java.patch
+++ b/patches/minecraft/net/minecraft/item/ItemDye.java.patch
@@ -9,6 +9,15 @@
                  {
                      if (!p_180614_3_.field_72995_K)
                      {
+@@ -73,7 +73,7 @@
+ 
+                         if (p_180614_3_.func_175623_d(p_180614_4_))
+                         {
+-                            IBlockState iblockstate1 = Blocks.field_150375_by.func_180642_a(p_180614_3_, p_180614_4_, p_180614_6_, p_180614_7_, p_180614_8_, p_180614_9_, 0, p_180614_2_);
++                            IBlockState iblockstate1 = Blocks.field_150375_by.getStateForPlacement(p_180614_3_, p_180614_4_, p_180614_6_, p_180614_7_, p_180614_8_, p_180614_9_, 0, p_180614_2_, p_180614_1_);
+                             p_180614_3_.func_180501_a(p_180614_4_, iblockstate1, 10);
+ 
+                             if (!p_180614_2_.field_71075_bZ.field_75098_d)
 @@ -97,8 +97,18 @@
  
      public static boolean func_179234_a(ItemStack p_179234_0_, World p_179234_1_, BlockPos p_179234_2_)


### PR DESCRIPTION
Updated version of #2967.

Allows for setting the block state based on non-metadata `ItemStack` attribute such as NBT or Capabilities.

All Vanilla calls to the original method have been updated to call `getStateForPlacement`.