### PR TITLE
Width and Height Getters for Shaped OreDict recipes

### DIFF
--- a/src/main/java/net/minecraftforge/oredict/ShapedOreRecipe.java
+++ b/src/main/java/net/minecraftforge/oredict/ShapedOreRecipe.java
@@ -255,4 +255,12 @@ public class ShapedOreRecipe implements IRecipe
     {
         return this.input;
     }
+
+    public int getWidth() {
+      return this.width;
+    }
+
+    public int getHeight() {
+      return this.height;
+    }
 }


### PR DESCRIPTION
Without these the width of a non-square recipe is ambiguous