### PR TITLE
Fix Vertex Transformer for breaking models

### DIFF
--- a/src/main/java/net/minecraftforge/client/model/pipeline/IVertexConsumer.java
+++ b/src/main/java/net/minecraftforge/client/model/pipeline/IVertexConsumer.java
@@ -19,6 +19,7 @@
 
 package net.minecraftforge.client.model.pipeline;
 
+import net.minecraft.client.renderer.texture.TextureAtlasSprite;
 import net.minecraft.client.renderer.vertex.VertexFormat;
 import net.minecraft.util.EnumFacing;
 
@@ -37,6 +38,6 @@ public interface IVertexConsumer
     void setQuadTint(int tint);
     void setQuadOrientation(EnumFacing orientation);
     void setApplyDiffuseLighting(boolean diffuse);
-
+    void setTexture(TextureAtlasSprite texture);
     void put(int element, float... data);
 }

--- a/src/main/java/net/minecraftforge/client/model/pipeline/LightUtil.java
+++ b/src/main/java/net/minecraftforge/client/model/pipeline/LightUtil.java
@@ -102,6 +102,7 @@ public class LightUtil
 
     public static void putBakedQuad(IVertexConsumer consumer, BakedQuad quad)
     {
+        consumer.setTexture(quad.getSprite());
         consumer.setQuadOrientation(quad.getFace());
         if(quad.hasTintIndex())
         {

--- a/src/main/java/net/minecraftforge/client/model/pipeline/LightUtil.java
+++ b/src/main/java/net/minecraftforge/client/model/pipeline/LightUtil.java
@@ -102,7 +102,14 @@ public class LightUtil
 
     public static void putBakedQuad(IVertexConsumer consumer, BakedQuad quad)
     {
-        consumer.setTexture(quad.getSprite());
+        try
+        {
+            consumer.setTexture(quad.getSprite());
+        }
+        catch(AbstractMethodError e)
+        {
+            // catch missing method errors caused by change to IVertexConsumer
+        }
         consumer.setQuadOrientation(quad.getFace());
         if(quad.hasTintIndex())
         {

--- a/src/main/java/net/minecraftforge/client/model/pipeline/UnpackedBakedQuad.java
+++ b/src/main/java/net/minecraftforge/client/model/pipeline/UnpackedBakedQuad.java
@@ -66,7 +66,14 @@ public class UnpackedBakedQuad extends BakedQuad
         {
             consumer.setQuadTint(getTintIndex());
         }
-        consumer.setTexture(sprite);
+        try
+        {
+            consumer.setTexture(sprite);
+        }
+        catch(AbstractMethodError e)
+        {
+            // catch missing method errors caused by change to IVertexConsumer
+        }
         consumer.setQuadOrientation(getFace());
         for(int v = 0; v < 4; v++)
         {

--- a/src/main/java/net/minecraftforge/client/model/pipeline/UnpackedBakedQuad.java
+++ b/src/main/java/net/minecraftforge/client/model/pipeline/UnpackedBakedQuad.java
@@ -66,6 +66,7 @@ public class UnpackedBakedQuad extends BakedQuad
         {
             consumer.setQuadTint(getTintIndex());
         }
+        consumer.setTexture(sprite);
         consumer.setQuadOrientation(getFace());
         for(int v = 0; v < 4; v++)
         {

--- a/src/main/java/net/minecraftforge/client/model/pipeline/VertexBufferConsumer.java
+++ b/src/main/java/net/minecraftforge/client/model/pipeline/VertexBufferConsumer.java
@@ -20,6 +20,7 @@
 package net.minecraftforge.client.model.pipeline;
 
 import net.minecraft.client.renderer.VertexBuffer;
+import net.minecraft.client.renderer.texture.TextureAtlasSprite;
 import net.minecraft.client.renderer.vertex.VertexFormat;
 import net.minecraft.client.renderer.vertex.VertexFormatElement.EnumUsage;
 import net.minecraft.util.math.BlockPos;
@@ -77,4 +78,5 @@ public class VertexBufferConsumer implements IVertexConsumer
     public void setQuadTint(int tint) {}
     public void setQuadOrientation(EnumFacing orientation) {}
     public void setApplyDiffuseLighting(boolean diffuse) {}
+    public void setTexture(TextureAtlasSprite texture ) {}
 }

--- a/src/main/java/net/minecraftforge/client/model/pipeline/VertexLighterFlat.java
+++ b/src/main/java/net/minecraftforge/client/model/pipeline/VertexLighterFlat.java
@@ -24,6 +24,7 @@ import javax.vecmath.Vector3f;
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.client.renderer.EntityRenderer;
 import net.minecraft.client.renderer.color.BlockColors;
+import net.minecraft.client.renderer.texture.TextureAtlasSprite;
 import net.minecraft.client.renderer.vertex.VertexFormat;
 import net.minecraft.client.renderer.vertex.VertexFormatElement;
 import net.minecraft.util.EnumFacing;
@@ -262,6 +263,7 @@ public class VertexLighterFlat extends QuadGatheringTransformer
     }
     public void setQuadOrientation(EnumFacing orientation) {}
     public void setQuadCulled() {}
+    public void setTexture( TextureAtlasSprite texture ) {}
     public void setApplyDiffuseLighting(boolean diffuse)
     {
         this.diffuse = diffuse;

--- a/src/main/java/net/minecraftforge/client/model/pipeline/VertexTransformer.java
+++ b/src/main/java/net/minecraftforge/client/model/pipeline/VertexTransformer.java
@@ -44,7 +44,14 @@ public class VertexTransformer implements IVertexConsumer
 
     public void setTexture(TextureAtlasSprite texture)
     {
-        parent.setTexture(texture);
+        try
+        {
+            parent.setTexture(texture);
+        }
+        catch(AbstractMethodError e)
+        {
+            // catch missing method errors caused by change to IVertexConsumer
+        }
     }
 
     public void setQuadOrientation(EnumFacing orientation)

--- a/src/main/java/net/minecraftforge/client/model/pipeline/VertexTransformer.java
+++ b/src/main/java/net/minecraftforge/client/model/pipeline/VertexTransformer.java
@@ -19,6 +19,7 @@
 
 package net.minecraftforge.client.model.pipeline;
 
+import net.minecraft.client.renderer.texture.TextureAtlasSprite;
 import net.minecraft.client.renderer.vertex.VertexFormat;
 import net.minecraft.util.EnumFacing;
 
@@ -39,6 +40,11 @@ public class VertexTransformer implements IVertexConsumer
     public void setQuadTint(int tint)
     {
         parent.setQuadTint(tint);
+    }
+
+    public void setTexture(TextureAtlasSprite texture)
+    {
+        parent.setTexture(texture);
     }
 
     public void setQuadOrientation(EnumFacing orientation)


### PR DESCRIPTION
Implementations of VertexBufferConsumer will need to add the new method but this resolves issues with consumers dropping sprites, which fixes potential crashes in dynamic model code, specifically now that extended state models are usable for damage rendering.

Fixes, https://github.com/SlimeKnights/TinkersConstruct/issues/2279