### PR TITLE
Add MultiplayerConnectionEvent.Pre

### DIFF
--- a/src/main/java/net/minecraftforge/client/event/MultiplayerConnectionEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/MultiplayerConnectionEvent.java
@@ -1,0 +1,33 @@
+package net.minecraftforge.client.event;
+
+import net.minecraft.client.multiplayer.ServerData;
+import net.minecraftforge.fml.common.eventhandler.Cancelable;
+import net.minecraftforge.fml.common.eventhandler.Event;
+
+/**
+ * Represents an event having to do with server and multiplayer connections.
+ */
+public class MultiplayerConnectionEvent extends Event
+{
+        /**
+         * Enables a mod to do things to the client just before connecting to a server.
+         * Examples might be to set up a server-specific profile, or load config data settings.
+         *
+         * This event is cancelable- if canceled, the connection attempt will stop processing.
+         */
+        @Cancelable
+        public static class Pre extends MultiplayerConnectionEvent
+        {
+            private ServerData serverData;
+            public Pre(ServerData serverEntry)
+            {
+                this.serverData = serverEntry;
+            }
+
+            public ServerData getServerData()
+            {
+                return serverData;
+            }
+        }
+
+}

--- a/src/main/java/net/minecraftforge/fml/client/FMLClientHandler.java
+++ b/src/main/java/net/minecraftforge/fml/client/FMLClientHandler.java
@@ -76,7 +76,9 @@ import net.minecraft.util.StringUtils;
 import net.minecraft.world.WorldSettings;
 import net.minecraft.world.storage.WorldSummary;
 import net.minecraft.world.storage.SaveFormatOld;
+import net.minecraftforge.client.event.MultiplayerConnectionEvent;
 import net.minecraftforge.common.ForgeModContainer;
+import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.fml.client.registry.RenderingRegistry;
 import net.minecraftforge.fml.common.DummyModContainer;
 import net.minecraftforge.fml.common.DuplicateModsFoundException;
@@ -867,7 +869,10 @@ public class FMLClientHandler implements IFMLSidedHandler
         }
         else
         {
-            showGuiScreen(new GuiConnecting(guiMultiplayer, client, serverEntry));
+            if(!MinecraftForge.EVENT_BUS.post(new MultiplayerConnectionEvent.Pre(serverEntry)))
+            {
+                showGuiScreen(new GuiConnecting(guiMultiplayer, client, serverEntry));
+            }
         }
     }
 

--- a/src/test/java/net/minecraftforge/test/TestMultiplayerEvent.java
+++ b/src/test/java/net/minecraftforge/test/TestMultiplayerEvent.java
@@ -1,0 +1,31 @@
+package net.minecraftforge.test;
+
+import net.minecraftforge.client.event.MultiplayerConnectionEvent;
+import net.minecraftforge.common.MinecraftForge;
+import net.minecraftforge.fml.common.Mod;
+import net.minecraftforge.fml.common.event.FMLInitializationEvent;
+import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
+
+@Mod(modid="clientmultiplayereventtest", name="Client Multiplayer Event Test", version="0.0.0", clientSideOnly = true)
+public class TestMultiplayerEvent
+{
+
+    @Mod.Instance("clientmultiplayereventtest")
+    public static TestMultiplayerEvent INSTANCE;
+
+    private final boolean ENABLED = false;
+
+    @Mod.EventHandler
+    public void init(FMLInitializationEvent event)
+    {
+        if(!ENABLED) return;
+        MinecraftForge.EVENT_BUS.register(INSTANCE);
+    }
+
+    @SubscribeEvent
+    public void onServerConnectStart(MultiplayerConnectionEvent.Pre preConnectEvent)
+    {
+        if(preConnectEvent.getServerData().serverName.equalsIgnoreCase("test_event"))
+            preConnectEvent.setCanceled(true);
+    }
+}


### PR DESCRIPTION
Thrown just before the connection gui is created on the multiplayer screen, and allows cancelling of the connection. Works with both the arrow button, double-click, and the connect button.

If a server is named "test_event" then the client will refuse to connect to it.

The whole point of this is so mods can set things up for a server before the server actually connects.
