### PR TITLE
[1.11] RegistryDelegate#setName is called before a persistent substitution is activated

### DIFF
--- a/src/main/java/net/minecraftforge/fml/common/registry/FMLControlledNamespacedRegistry.java
+++ b/src/main/java/net/minecraftforge/fml/common/registry/FMLControlledNamespacedRegistry.java
@@ -611,6 +611,7 @@ public class FMLControlledNamespacedRegistry<I extends IForgeRegistryEntry<I>> e
             I original = getRaw(nameToReplace);
             I sub = getPersistentSubstitutions().get(nameToReplace);
             getExistingDelegate(original).changeReference(sub);
+            getExistingDelegate(sub).setName(nameToReplace);
             activeSubstitutions.put(nameToReplace, sub);
             int id = getIDForObjectBypass(original);
             // force the new object into the existing map


### PR DESCRIPTION
Adds a line to FMLControlledNamespacedRegistry#activateSubstitution that sets the name to the nameToReplace variable. Resolves #3131 
