### PR TITLE
Add ModifyBlockEvent

### DIFF
--- a/src/main/java/net/minecraftforge/event/entity/player/PlayerInteractEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/player/PlayerInteractEvent.java
@@ -323,27 +323,6 @@ public class PlayerInteractEvent extends PlayerEvent
     }
 
     /**
-     * This event is fired by mods, before they interact with blocks in non-standard way, so protection mods can cancel it.
-     * ResourceLocation 'action' has to be your modid:action, e.g "gravity_altering_mod:pick_up_block"
-     */
-    @Cancelable
-    public static class ModifyBlock extends PlayerInteractEvent
-    {
-        private final ResourceLocation action;
-
-        public ModifyBlock(EntityPlayer player, EnumHand hand, ItemStack stack, BlockPos pos, EnumFacing face, ResourceLocation action)
-        {
-            super(player, hand, stack, pos, face);
-            this.action = Preconditions.checkNotNull(action, "Null action in PlayerInteractEvent!");
-        }
-
-        public ResourceLocation getAction()
-        {
-            return action;
-        }
-    }
-
-    /**
      * @return The hand involved in this interaction. Will never be null.
      */
     public EnumHand getHand()

--- a/src/main/java/net/minecraftforge/event/entity/player/PlayerInteractEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/player/PlayerInteractEvent.java
@@ -27,6 +27,7 @@ import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.EnumFacing;
 import net.minecraft.util.EnumHand;
+import net.minecraft.util.ResourceLocation;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.Vec3d;
 import net.minecraft.world.IBlockAccess;
@@ -323,13 +324,22 @@ public class PlayerInteractEvent extends PlayerEvent
 
     /**
      * This event is fired by mods, before they interact with blocks in non-standard way, so protection mods can cancel it.
+     * ResourceLocation 'action' has to be your modid:action, e.g "gravity_altering_mod:pick_up_block"
      */
     @Cancelable
     public static class ModifyBlock extends PlayerInteractEvent
     {
-        public ModifyBlock(EntityPlayer player, EnumHand hand, ItemStack stack, BlockPos pos, EnumFacing face)
+        private final ResourceLocation action;
+
+        public ModifyBlock(EntityPlayer player, EnumHand hand, ItemStack stack, BlockPos pos, EnumFacing face, ResourceLocation action)
         {
             super(player, hand, stack, pos, face);
+            this.action = Preconditions.checkNotNull(action, "Null action in PlayerInteractEvent!");
+        }
+
+        public ResourceLocation getAction()
+        {
+            return action;
         }
     }
 

--- a/src/main/java/net/minecraftforge/event/entity/player/PlayerInteractEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/player/PlayerInteractEvent.java
@@ -322,6 +322,18 @@ public class PlayerInteractEvent extends PlayerEvent
     }
 
     /**
+     * This event is fired by mods, before they interact with blocks in non-standard way, so protection mods can cancel it.
+     */
+    @Cancelable
+    public static class ModifyBlock extends PlayerInteractEvent
+    {
+        public ModifyBlock(EntityPlayer player, EnumHand hand, ItemStack stack, BlockPos pos, EnumFacing face)
+        {
+            super(player, hand, stack, pos, face);
+        }
+    }
+
+    /**
      * @return The hand involved in this interaction. Will never be null.
      */
     public EnumHand getHand()

--- a/src/main/java/net/minecraftforge/event/entity/player/PlayerInteractEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/player/PlayerInteractEvent.java
@@ -27,7 +27,6 @@ import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.EnumFacing;
 import net.minecraft.util.EnumHand;
-import net.minecraft.util.ResourceLocation;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.Vec3d;
 import net.minecraft.world.IBlockAccess;

--- a/src/main/java/net/minecraftforge/event/world/ModifyBlockEvent.java
+++ b/src/main/java/net/minecraftforge/event/world/ModifyBlockEvent.java
@@ -1,0 +1,102 @@
+/*
+ * Minecraft Forge
+ * Copyright (c) 2016.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation version 2.1
+ * of the License.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+package net.minecraftforge.event.world;
+
+import com.google.common.base.Preconditions;
+import net.minecraft.block.state.IBlockState;
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.util.EnumFacing;
+import net.minecraft.util.EnumHand;
+import net.minecraft.util.ResourceLocation;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.World;
+import net.minecraftforge.event.entity.player.PlayerEvent;
+
+import javax.annotation.Nullable;
+
+/**
+ * This event is fired by mods, before they interact with blocks in non-standard way, so protection mods can cancel it.
+ * ResourceLocation 'action' has to be your modid:action, e.g "gravity_altering_mod:pick_up_block"
+ */
+public class ModifyBlockEvent extends PlayerEvent
+{
+    private final EnumHand hand;
+    private final BlockPos pos;
+    private final EnumFacing face;
+    private final ResourceLocation action;
+
+    public ModifyBlockEvent(EntityPlayer player, EnumHand hand, BlockPos pos, EnumFacing face, ResourceLocation action)
+    {
+        super(Preconditions.checkNotNull(player, "Null player in ModifyBlockEvent!"));
+        this.hand = Preconditions.checkNotNull(hand, "Null hand in ModifyBlockEvent!");
+        this.pos = Preconditions.checkNotNull(pos, "Null position in ModifyBlockEvent!");
+        this.face = face;
+        this.action = Preconditions.checkNotNull(action, "Null action in ModifyBlockEvent!");
+    }
+
+    /**
+     * @return The hand involved in this modification. Will never be null.
+     */
+    public EnumHand getHand()
+    {
+        return hand;
+    }
+
+    /**
+     * @return The position of the block
+     */
+    public BlockPos getPos()
+    {
+        return pos;
+    }
+
+    /**
+     * @return The face involved in this modification. This can return null.
+     */
+    @Nullable
+    public EnumFacing getFace()
+    {
+        return face;
+    }
+
+    /**
+     * @return Convenience method to get the world.
+     */
+    public World getWorld()
+    {
+        return getEntityPlayer().getEntityWorld();
+    }
+
+    /**
+     * @return Action that this mod is currently doing, e.h
+     */
+    public ResourceLocation getAction()
+    {
+        return action;
+    }
+
+    /**
+     * @return Convenience method to get the block state.
+     */
+    public IBlockState getBlockState()
+    {
+        return getWorld().getGroundAboveSeaLevel(getPos());
+    }
+}


### PR DESCRIPTION
This event is needed to resolve all custom mod integrations. Instead mods would fire this event, and protection mods could catch and cancel it. Examples: Gravity Gun picking up block, Chisels&Bits adding/removing bit from the block (there even is an event in this mod's api - https://github.com/AlgorithmX2/Chisels-and-Bits/blob/1.10/src/main/java/mod/chiselsandbits/api/EventBlockBitModification.java), wrenches rotating / removing blocks, etc.
The problem with APIs is that you either have to know all mods and all of their APIs (if they have one at all) or wait for someone to request support. 