### PR TITLE
Make InventoryHelper#spawnItemStack use ItemStack#splitStack to avoid losing capability data

### DIFF
--- a/patches/minecraft/net/minecraft/inventory/InventoryHelper.java.patch
+++ b/patches/minecraft/net/minecraft/inventory/InventoryHelper.java.patch
@@ -1,0 +1,23 @@
+--- ../src-base/minecraft/net/minecraft/inventory/InventoryHelper.java
++++ ../src-work/minecraft/net/minecraft/inventory/InventoryHelper.java
+@@ -44,19 +44,8 @@
+         {
+             int i = field_180177_a.nextInt(21) + 10;
+ 
+-            if (i > p_180173_7_.field_77994_a)
+-            {
+-                i = p_180173_7_.field_77994_a;
+-            }
++            EntityItem entityitem = new EntityItem(p_180173_0_, p_180173_1_ + (double)f, p_180173_3_ + (double)f1, p_180173_5_ + (double)f2, p_180173_7_.func_77979_a(i));
+ 
+-            p_180173_7_.field_77994_a -= i;
+-            EntityItem entityitem = new EntityItem(p_180173_0_, p_180173_1_ + (double)f, p_180173_3_ + (double)f1, p_180173_5_ + (double)f2, new ItemStack(p_180173_7_.func_77973_b(), i, p_180173_7_.func_77960_j()));
+-
+-            if (p_180173_7_.func_77942_o())
+-            {
+-                entityitem.func_92059_d().func_77982_d(p_180173_7_.func_77978_p().func_74737_b());
+-            }
+-
+             float f3 = 0.05F;
+             entityitem.field_70159_w = field_180177_a.nextGaussian() * 0.05000000074505806D;
+             entityitem.field_70181_x = field_180177_a.nextGaussian() * 0.05000000074505806D + 0.20000000298023224D;


### PR DESCRIPTION
This adjusts `InventoryHelper#spawnItemStack` to use `ItemStack#splitStack` instead of manually creating a new ItemStack instance, to avoid item stacks spawned into the world losing their capability data. Before this patch, when an item was dropped into the world via this method (for example when breaking a vanilla chest), the `EntityItem`'s item stack was missing any persistent capability data (i.e. data that gets stored in the `ForgeCaps` tag).

I decided to remove code that is now redundant due to the same checks and operations (copying the NBT tag, in particular) being performed in `splitStack`. If this is undesired due to the increased patch size, let me know, and I'll reduce it to the single line.