### PR TITLE
Allow custom splash screens to override the forge splash screen

### DIFF
--- a/src/main/java/net/minecraftforge/fml/client/ICustomSplashScreen.java
+++ b/src/main/java/net/minecraftforge/fml/client/ICustomSplashScreen.java
@@ -1,0 +1,14 @@
+package net.minecraftforge.fml.client;
+
+/**
+ * This class defines a replacement for the default forge splash screen.
+ *
+ * Only one splash screen can be registered at a time. It it registered with SplashProgress.setCustomSplashScreen().
+ * If you use this, make it a configuration option.
+ */
+public interface ICustomSplashScreen {
+    /**
+     * Render a single frame of the splash screen.
+     */
+    void renderFrame();
+}

--- a/src/main/java/net/minecraftforge/fml/common/ProgressManager.java
+++ b/src/main/java/net/minecraftforge/fml/common/ProgressManager.java
@@ -79,8 +79,9 @@ public class ProgressManager
         FMLCommonHandler.instance().processWindowMessages();
     }
 
-    /*
-     * Internal use only.
+    /**
+     * Used by splash screen's only - you should not need to use this if
+     * you are a normal mod.
      */
     public static Iterator<ProgressBar> barIterator()
     {

--- a/src/test/java/net/minecraftforge/test/SplashScreenTest.java
+++ b/src/test/java/net/minecraftforge/test/SplashScreenTest.java
@@ -1,0 +1,98 @@
+package net.minecraftforge.test;
+
+import static org.lwjgl.opengl.GL11.*;
+
+import java.util.Iterator;
+
+import org.lwjgl.opengl.Display;
+
+import net.minecraftforge.fml.client.ICustomSplashScreen;
+import net.minecraftforge.fml.client.SplashProgress;
+import net.minecraftforge.fml.common.Mod;
+import net.minecraftforge.fml.common.Mod.EventHandler;
+import net.minecraftforge.fml.common.ProgressManager;
+import net.minecraftforge.fml.common.ProgressManager.ProgressBar;
+import net.minecraftforge.fml.common.event.FMLConstructionEvent;
+
+@Mod(modid="splashscreentest", name="Splash Screen Test", version="0.0.0", clientSideOnly = true)
+public class SplashScreenTest {
+
+    public static final boolean ENABLE = false;
+
+    @EventHandler
+    public static void construct(FMLConstructionEvent event)
+    {
+        if (ENABLE)
+        {
+            SplashProgress.setCustomSplashScreen(TestSplashScreen.INSTANCE);
+        }
+    }
+
+    public enum TestSplashScreen implements ICustomSplashScreen
+    {
+        INSTANCE;
+
+        @Override
+        public void renderFrame() {
+            glClear(GL_COLOR_BUFFER_BIT);
+
+            // matrix setup -- similar as SplashProgress
+            int w = Display.getWidth();
+            int h = Display.getHeight();
+            glViewport(0, 0, w, h);
+            glMatrixMode(GL_PROJECTION);
+            glLoadIdentity();
+            glOrtho(-w/2,  w/2, h/2, -h/2, -1, 1);
+            glMatrixMode(GL_MODELVIEW);
+            glLoadIdentity();
+
+            // Actual drawing
+            Iterator<ProgressBar> i = ProgressManager.barIterator();
+            int y = 0;
+            glColor3d(0, 0, 0);
+            glPushMatrix();
+            glScalef(2, 2, 1);
+            glEnable(GL_TEXTURE_2D);
+            while (i.hasNext())
+            {
+                ProgressBar b = i.next();
+
+                int startWidth = SplashProgress.fontRenderer.getStringWidth(b.getTitle() + " ");
+
+                SplashProgress.fontRenderer.drawString(b.getTitle() + " ", -startWidth, y, 0);
+                SplashProgress.fontRenderer.drawString("- " + b.getMessage(), 0, y, 0);
+                String bar = getProgress(b);
+                SplashProgress.fontRenderer.drawString(bar, -SplashProgress.fontRenderer.getStringWidth(bar) / 2 , y + 14, 0);
+
+                y += 30;
+            }
+            glDisable(GL_TEXTURE_2D);
+            glPopMatrix();
+        }
+
+        private static final int NUM_GAPS = 8;
+
+        private static String getProgress(ProgressBar bar)
+        {
+            // Builds a string like [=====---] or [==>-----]
+            String s = "[";
+            double val = NUM_GAPS * bar.getStep() / (double) bar.getSteps();
+            int count = (int) val;
+            boolean endBig = val % 1 > 0.5;
+            for (int i = 0; i < count; i++)
+            {
+                s += "=";
+            }
+            if (endBig & count < NUM_GAPS)
+            {
+                count++;
+                s += ">";
+            }
+            for (int i = count; i < NUM_GAPS; i++)
+            {
+                s += "-";
+            }
+            return s + "]";
+        }
+    }
+}

--- a/src/test/java/net/minecraftforge/test/SplashScreenTest.java
+++ b/src/test/java/net/minecraftforge/test/SplashScreenTest.java
@@ -15,8 +15,8 @@ import net.minecraftforge.fml.common.ProgressManager.ProgressBar;
 import net.minecraftforge.fml.common.event.FMLConstructionEvent;
 
 @Mod(modid="splashscreentest", name="Splash Screen Test", version="0.0.0", clientSideOnly = true)
-public class SplashScreenTest {
-
+public class SplashScreenTest
+{
     public static final boolean ENABLE = false;
 
     @EventHandler


### PR DESCRIPTION
This allows a mod to replace the forge splash screen with their own and can hook properly into the OpenGL context locks. Setting (and clearing) is done via ````SplashProgress.setCustomSplashScreen```` with an instance of ````ICustomSplashScreen````, or ````null```` to release the splash back to forge.

I've moved the default implementation to its own enum class rather than being directly inside the method. I'm not entirely sure if this is what you want done though.

I've also made a few of the fields and classes in ````SplashProgress```` public, as they will be useful for mods that actually provide a splash screen (Specifically the ````SplashFontRenderer```` and ````Texture```` inner classes, and the ````fontRenderer```` field).

I have included a (by default disabled) client-side test mod that will replace the forge loading screen with a fully text based one. While this does use the *dont-use-this-internal* ````FMLConstructEvent```` to replace the splash screen an actual mod would most likely use a core mod so it can replace the splash screen as early as possible.