### PR TITLE
[1.10.x] IngredientStack implementation

### DIFF
--- a/src/main/java/net/minecraftforge/common/ForgeInternalHandler.java
+++ b/src/main/java/net/minecraftforge/common/ForgeInternalHandler.java
@@ -24,12 +24,16 @@ import net.minecraft.entity.item.EntityItem;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraft.world.WorldServer;
+import net.minecraftforge.common.capabilities.Capability;
+import net.minecraftforge.common.capabilities.ICapabilityProvider;
 import net.minecraftforge.common.util.FakePlayerFactory;
+import net.minecraftforge.event.AttachCapabilitiesEvent;
 import net.minecraftforge.event.entity.EntityJoinWorldEvent;
 import net.minecraftforge.event.world.WorldEvent;
 import net.minecraftforge.fml.common.FMLLog;
 import net.minecraftforge.fml.common.eventhandler.EventPriority;
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
+import net.minecraftforge.ingredients.capability.wrappers.VanillaIngredientCapabilityInjector;
 
 public class ForgeInternalHandler
 {
@@ -95,5 +99,15 @@ public class ForgeInternalHandler
         ForgeChunkManager.unloadWorld(event.getWorld());
         if (event.getWorld() instanceof WorldServer)
             FakePlayerFactory.unloadWorld((WorldServer) event.getWorld());
+    }
+
+    @SubscribeEvent(priority = EventPriority.HIGHEST)
+    public void attachVanillaIngredientCaps(AttachCapabilitiesEvent.Item event)
+    {
+        ICapabilityProvider cap = VanillaIngredientCapabilityInjector.getWrapperForItem(event.getItem(), event.getItemStack());
+        if(cap != null)
+        {
+            event.addCapability(VanillaIngredientCapabilityInjector.ResourceHandle, cap);
+        }
     }
 }

--- a/src/main/java/net/minecraftforge/common/ForgeModContainer.java
+++ b/src/main/java/net/minecraftforge/common/ForgeModContainer.java
@@ -40,6 +40,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import net.minecraftforge.ingredients.capability.CapabilityIngredientHandler;
 import org.apache.logging.log4j.Level;
 
 import net.minecraft.crash.CrashReport;
@@ -401,6 +402,7 @@ public class ForgeModContainer extends DummyModContainer implements WorldAccessC
         CapabilityItemHandler.register();
         CapabilityFluidHandler.register();
         CapabilityAnimation.register();
+        CapabilityIngredientHandler.register();
         MinecraftForge.EVENT_BUS.register(MinecraftForge.INTERNAL_HANDLER);
         ForgeChunkManager.captureConfig(evt.getModConfigurationDirectory());
         MinecraftForge.EVENT_BUS.register(this);

--- a/src/main/java/net/minecraftforge/common/network/ForgeNetworkHandler.java
+++ b/src/main/java/net/minecraftforge/common/network/ForgeNetworkHandler.java
@@ -53,5 +53,6 @@ public class ForgeNetworkHandler
         String handlerName = clientChannel.findChannelHandlerNameForType(ForgeRuntimeCodec.class);
         clientChannel.pipeline().addAfter(handlerName, "DimensionHandler", new DimensionMessageHandler());
         clientChannel.pipeline().addAfter(handlerName, "FluidIdRegistryHandler", new FluidIdRegistryMessageHandler());
+        clientChannel.pipeline().addAfter(handlerName, "IngredientIdRegistryHandler", new IngredientIdRegistryMessageHandler());
     }
 }

--- a/src/main/java/net/minecraftforge/common/network/ForgeRuntimeCodec.java
+++ b/src/main/java/net/minecraftforge/common/network/ForgeRuntimeCodec.java
@@ -28,6 +28,7 @@ public class ForgeRuntimeCodec extends FMLIndexedMessageToMessageCodec<ForgeMess
     {
         addDiscriminator(1, ForgeMessage.DimensionRegisterMessage.class);
         addDiscriminator(2, ForgeMessage.FluidIdMapMessage.class);
+        addDiscriminator(3, ForgeMessage.IngredientIdMapMessage.class);
     }
     @Override
     public void encodeInto(ChannelHandlerContext ctx, ForgeMessage msg, ByteBuf target) throws Exception

--- a/src/main/java/net/minecraftforge/common/network/IngredientIdRegistryMessageHandler.java
+++ b/src/main/java/net/minecraftforge/common/network/IngredientIdRegistryMessageHandler.java
@@ -1,0 +1,25 @@
+package net.minecraftforge.common.network;
+
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.SimpleChannelInboundHandler;
+import net.minecraftforge.fml.common.FMLLog;
+import net.minecraftforge.ingredients.IngredientRegistry;
+import org.apache.logging.log4j.Level;
+
+public class IngredientIdRegistryMessageHandler extends SimpleChannelInboundHandler<ForgeMessage.IngredientIdMapMessage>
+{
+
+    @Override
+    protected void channelRead0(ChannelHandlerContext ctx, ForgeMessage.IngredientIdMapMessage msg) throws Exception
+    {
+        IngredientRegistry.initIngredientIDs(msg.ingredientIds, msg.defaultIngredients);
+    }
+
+    @Override
+    public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) throws Exception
+    {
+        FMLLog.log(Level.ERROR, cause, "FluidIdRegistryMessageHandler exception");
+        super.exceptionCaught(ctx, cause);
+    }
+
+}

--- a/src/main/java/net/minecraftforge/fluids/capability/templates/FluidHandlerItemStackSimple.java
+++ b/src/main/java/net/minecraftforge/fluids/capability/templates/FluidHandlerItemStackSimple.java
@@ -139,7 +139,7 @@ public class FluidHandlerItemStackSimple implements IFluidHandler, ICapabilityPr
         if (drainAmount == capacity) {
             FluidStack drained = contained.copy();
 
-            if (doDrain){
+            if (doDrain) {
                 setContainerToEmpty();
             }
 

--- a/src/main/java/net/minecraftforge/fluids/capability/templates/FluidHandlerItemStackSimple.java
+++ b/src/main/java/net/minecraftforge/fluids/capability/templates/FluidHandlerItemStackSimple.java
@@ -97,8 +97,10 @@ public class FluidHandlerItemStackSimple implements IFluidHandler, ICapabilityPr
         if (contained == null)
         {
             int fillAmount = Math.min(capacity, resource.amount);
-            if (fillAmount == capacity) {
-                if (doFill) {
+            if (fillAmount == capacity)
+            {
+                if (doFill)
+                {
                     FluidStack filled = resource.copy();
                     filled.amount = fillAmount;
                     setFluid(filled);
@@ -136,10 +138,12 @@ public class FluidHandlerItemStackSimple implements IFluidHandler, ICapabilityPr
         }
 
         final int drainAmount = Math.min(contained.amount, maxDrain);
-        if (drainAmount == capacity) {
+        if (drainAmount == capacity)
+        {
             FluidStack drained = contained.copy();
 
-            if (doDrain) {
+            if (doDrain)
+            {
                 setContainerToEmpty();
             }
 

--- a/src/main/java/net/minecraftforge/fluids/capability/templates/FluidHandlerItemStackSimple.java
+++ b/src/main/java/net/minecraftforge/fluids/capability/templates/FluidHandlerItemStackSimple.java
@@ -97,10 +97,8 @@ public class FluidHandlerItemStackSimple implements IFluidHandler, ICapabilityPr
         if (contained == null)
         {
             int fillAmount = Math.min(capacity, resource.amount);
-            if (fillAmount == capacity)
-            {
-                if (doFill)
-                {
+            if (fillAmount == capacity) {
+                if (doFill) {
                     FluidStack filled = resource.copy();
                     filled.amount = fillAmount;
                     setFluid(filled);
@@ -138,12 +136,10 @@ public class FluidHandlerItemStackSimple implements IFluidHandler, ICapabilityPr
         }
 
         final int drainAmount = Math.min(contained.amount, maxDrain);
-        if (drainAmount == capacity)
-        {
+        if (drainAmount == capacity) {
             FluidStack drained = contained.copy();
 
-            if (doDrain)
-            {
+            if (doDrain){
                 setContainerToEmpty();
             }
 

--- a/src/main/java/net/minecraftforge/ingredients/EnumMatterState.java
+++ b/src/main/java/net/minecraftforge/ingredients/EnumMatterState.java
@@ -1,0 +1,21 @@
+package net.minecraftforge.ingredients;
+
+/**
+ * The state of an ingredient.
+ * */
+public enum EnumMatterState
+{
+    SOLID,
+    LIQUID,
+    GAS;
+
+    /**
+     * Returns the matter state based on it's ordinal.
+     *
+     * Defaults to solid for non allowed values.
+     * */
+    public static EnumMatterState fromByte(byte id)
+    {
+        return id > -1 && id > values().length ? values()[id] : SOLID;
+    }
+}

--- a/src/main/java/net/minecraftforge/ingredients/EnumRefinementLevel.java
+++ b/src/main/java/net/minecraftforge/ingredients/EnumRefinementLevel.java
@@ -1,0 +1,33 @@
+package net.minecraftforge.ingredients;
+
+/**
+ * Used for defining the refinement level of a given IngredientStack
+ * */
+public enum EnumRefinementLevel
+{
+    /**
+     * Base form of the ingredient.
+     * */
+    RAW,
+    /**
+     * 'Pure' variant of the ingredient.
+     *
+     * Think ore v. ingot.
+     * */
+    REFINED,
+    /**
+     * The recycled variant.
+     *
+     * */
+    RECLAIMED;
+
+    /**
+     * Returns a refinement level based on its ordinal
+     *
+     * Defaults to RAW for non allowed values
+     * */
+    public static EnumRefinementLevel fromByte(byte id)
+    {
+        return id > -1 && id < values().length ? values()[id] : RAW;
+    }
+}

--- a/src/main/java/net/minecraftforge/ingredients/IIngredientSource.java
+++ b/src/main/java/net/minecraftforge/ingredients/IIngredientSource.java
@@ -1,0 +1,57 @@
+package net.minecraftforge.ingredients;
+
+import javax.annotation.Nullable;
+
+/**
+ * The source is the unit for interaction with ingredient inventories.
+ *
+ * */
+public interface IIngredientSource
+{
+    /**
+     * @return IngredientStack representing the Ingredient available from the source, null if the source
+     * is depleted.
+     * */
+    @Nullable
+    IngredientStack getIngredient();
+
+    /**
+     * @return Current amount of the ingredient available.
+     * */
+    int getIngredientVolume();
+
+    /**
+     * @return Capacity of this source.
+     * */
+    int getCapacity();
+
+    /**
+     * Returns a wrapper object {@link IngredientSourceInfo } containing the capacity and the
+     * IngredientStack it holds.
+     *
+     * Should prevent unwanted manipulation of the IIngredientSource. See {@link IngredientSource}.
+     *
+     * @retunr State information for the IIngredientSource.
+     * */
+    IngredientSourceInfo getInfo();
+
+    /**
+     * @param resource
+     *          IngredientStack attempting to be added to the source.
+     * @param doAdd
+     *          If false, the adding will be simulated.
+     * @return Amount of the ingredient that will be accepted.
+     * */
+    int add(IngredientStack resource, boolean doAdd);
+
+    /**
+     * @param maxRemoved
+     *          Maximum amount of the ingredient to be removed from the source.
+     * @param doRemove
+     *          If false, the removal will be simulated
+     * @return Amount of the ingredient that was removed from the source
+     * */
+    @Nullable
+    IngredientStack remove(int maxRemoved, boolean doRemove);
+
+}

--- a/src/main/java/net/minecraftforge/ingredients/Ingredient.java
+++ b/src/main/java/net/minecraftforge/ingredients/Ingredient.java
@@ -1,0 +1,483 @@
+package net.minecraftforge.ingredients;
+
+import net.minecraft.block.Block;
+import net.minecraft.item.EnumRarity;
+import net.minecraft.util.SoundEvent;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.text.translation.I18n;
+import net.minecraft.world.World;
+import net.minecraftforge.fluids.Fluid;
+import net.minecraftforge.fluids.FluidStack;
+
+/**
+ * Material equivalent to Fluids.
+ * <p/>
+ * Intended to aid in the quantification and qualification of what
+ * otherwise are ambiguous materials.
+ * */
+public class Ingredient
+{
+    /**
+     * Volume of one block represented by {@value FULL_BLOCK_VOLUME} millblocks
+     * */
+    public static final int FULL_BLOCK_VOLUME = 1000;
+
+    /**
+     * Volume of one ore's worth of non stone material.
+     *<p/>
+     * Rounded {@value #FULL_BLOCK_VOLUME} / 9 up
+     * to {@value ORE_VOLUME} milliblocks.
+     * */
+    public static final int ORE_VOLUME = 112;
+
+    /**
+     * Volume of one ore's worth of stone/base material
+     * <p/>
+     * Rounded down the other component of {@link Ingredient#ORE_VOLUME}
+     * to {@value ORE_VOLUME_BASE}
+     * */
+    public static final int ORE_VOLUME_BASE = 888;
+
+    /**
+     * Volume of one nugget's worth of material.
+     * <p/>
+     * Rounded {@value ORE_VOLUME} / 9 up to {@value NUGGET_VOLUME} millblocks
+     * */
+    public static final int NUGGET_VOLUME = 13;
+
+    /**
+     * The unique identification String for this ingredient.
+     * */
+    protected final String ingredientName;
+
+    /**
+     * The unlocalized name for this ingredient.
+     * */
+    protected String unlocalizedName;
+
+    /**
+     * Density of the ingredient in kg/m^3 at room temp (300 degrees kelvin).
+     *
+     * Default value is approximately the real-life density of water.
+     * */
+    protected int density = 1000;
+
+    /**
+     * The melting point of the ingredient in kelvin.
+     *
+     * Default value is approximately the real-life melting point of water.
+     * */
+    protected int meltingPoint = 273;
+
+    /**
+     * The boiliing point of the ingredient in kelvin.
+     *
+     * Default value is approximately the real-life boiling point of water.
+     *  */
+    protected int boilingPoint = 323;
+
+    /**
+     * The light level emitted by this ingredient.
+     *
+     * Default value is 0, as most ingredients do not actively emit light.
+     */
+    protected int luminosity = 0;
+
+    /**
+     * The rarity of the ingredient.
+     *
+     * Primarily for usage in tool tips
+     * */
+    protected EnumRarity rarity = EnumRarity.COMMON;
+
+    /**
+     * The state of the ingredient at room temp (300 degrees kelvin).
+     * */
+    protected EnumMatterState roomTempState;
+
+    /**
+     * True if the ingredient melt at 1 atm.
+     * */
+    protected boolean canMelt = true;
+
+    /**
+     * True if the ingredient can boil at 1 atm.
+     * */
+    protected boolean canBoil = true;
+
+    /**
+     * The pure block of the ingredient, representing 1000 milliblocks of the refined material
+     * */
+    protected Block block = null;
+
+    /**
+     * The correlating fluid, if the ingredient has one.
+     * */
+    protected Fluid fluid = null;
+
+    private SoundEvent addSound;
+    private SoundEvent removeSound;
+
+    public Ingredient(String name)
+    {
+        ingredientName = name;
+        unlocalizedName = name;
+    }
+
+    /**
+     * Sets the translation handle of the ingredient.
+     * */
+    public Ingredient setUnlocalizedName(String unlocalizedName)
+    {
+        this.unlocalizedName = unlocalizedName;
+        return this;
+    }
+
+    /**
+     * Sets the room temp (300 degrees kelvin) density of the ingredient.
+     * */
+    public Ingredient setDensity(int density)
+    {
+        this.density = density;
+        return this;
+    }
+
+    /**
+     * Sets the rarity for the ingredient
+     *
+     * Predominately used for tool tips
+     * */
+    public Ingredient setRarity(EnumRarity rarity)
+    {
+        this.rarity = rarity;
+        return this;
+    }
+
+    /**
+     * Sets the boiling point, and rechecks the room temp state of the ingredient.
+     * 
+     * @param meltingPoint
+     *          The melting point of the ingredient in kelvin
+     * */
+    public Ingredient setMeltingPoint(int meltingPoint)
+    {
+        this.meltingPoint = meltingPoint;
+        recheckDefaultState();
+        return this;
+    }
+
+    /**
+     * Sets the boiling point, and rechecks the room temp state of the ingredient.
+     *
+     * @param boilingPoint
+     *          The boiling point of the ingredient in kelvin
+     * */
+    public Ingredient setBoilingPoint(int boilingPoint)
+    {
+        this.boilingPoint = boilingPoint;
+        recheckDefaultState();
+        return this;
+    }
+
+    /**
+     * Sets whether or not the ingredient can melt at 1 atm
+     * */
+    public Ingredient setCanMelt(boolean canMelt)
+    {
+        this.canMelt = canMelt;
+        return this;
+    }
+
+    /**
+     * Sets whether or not the ingredient can boil at 1 atm
+     * */
+    public Ingredient setCanBoil(boolean canBoil)
+    {
+        this.canBoil = canBoil;
+        return this;
+    }
+
+    /**
+     * Sets the block that represents 1000 milliblocks of the refined ingredient, if one exists
+     * <p/>
+     * A good example is the iron block
+     * */
+    public Ingredient setBlock(Block block)
+    {
+        this.block = block;
+        return this;
+    }
+
+    /**
+     * Sets the luminosity of the ingredient.
+     * */
+    public Ingredient setLuminosity(int luminosity)
+    {
+        this.luminosity = luminosity;
+        return this;
+    }
+
+    /**
+     * Sets the correlating fluid for the ingredient, if one exists
+     * */
+    public Ingredient setFluid(Fluid fluid)
+    {
+        this.fluid = fluid;
+        return this;
+    }
+
+    /* Checks the default state based on the given temp of 300 degrees kelvin*/
+    private void recheckDefaultState()
+    {
+        if(canBoil && boilingPoint <= 300)
+        {
+            roomTempState = EnumMatterState.GAS;
+        }
+        else if(canMelt && meltingPoint <= 300)
+        {
+            roomTempState = EnumMatterState.LIQUID;
+        }
+        else
+        {
+            roomTempState = EnumMatterState.SOLID;
+        }
+    }
+
+    public final String getName()
+    {
+        return this.ingredientName;
+    }
+
+    public EnumMatterState getRoomTempState()
+    {
+        return roomTempState;
+    }
+
+    public String getUnlocalizedName()
+    {
+        return unlocalizedName;
+    }
+
+    public EnumRarity getRarity()
+    {
+        return rarity;
+    }
+
+    public int getDensity()
+    {
+        return density;
+    }
+
+    public int getMeltingPoint()
+    {
+        return meltingPoint;
+    }
+
+    public int getBoilingPoint()
+    {
+        return boilingPoint;
+    }
+
+    public int getLuminosity()
+    {
+        return luminosity;
+    }
+
+    public Block getBlock()
+    {
+        return block;
+    }
+
+    public boolean canMelt()
+    {
+        return canMelt;
+    }
+
+    public boolean canBoil()
+    {
+        return canBoil;
+    }
+
+    public SoundEvent getAddSound()
+    {
+        return addSound;
+    }
+
+    public SoundEvent getRemoveSound()
+    {
+        return removeSound;
+    }
+
+    public Fluid getFluid()
+    {
+        return fluid;
+    }
+
+    public FluidStack getFluidStack()
+    {
+        return new FluidStack(fluid, Fluid.BUCKET_VOLUME);
+    }
+
+    public final boolean canBePlacedInWorld()
+    {
+        return block != null;
+    }
+
+    /* Stack based accessors */
+
+    /**
+     * Returns the localized Ingredient name for the given stack.
+     * */
+    public String getLocalizedName(IngredientStack stack)
+    {
+        String s = this.getUnlocalizedName(stack);
+        return s == null ? "" : I18n.translateToLocal(s);
+    }
+
+    public String getUnlocalizedName(IngredientStack stack)
+    {
+        return "ingredient." + this.unlocalizedName;
+    }
+
+    /**
+     * Returns the sound to be played when the source is pulled from a container
+     * */
+    public SoundEvent getAddedSound(IngredientStack stack)
+    {
+        return getRemoveSound();
+    }
+
+    /**
+     * Returns the sound to be played when the source is added into a container
+     * */
+    public SoundEvent getRemovedSound(IngredientStack stack)
+    {
+        return getAddSound();
+    }
+
+    public EnumRarity getRarity(IngredientStack stack)
+    {
+        return getRarity();
+    }
+
+    public int getDensity(IngredientStack stack)
+    {
+        return getDensity();
+    }
+
+    public int getMeltingPoint(IngredientStack stack)
+    {
+        return getMeltingPoint();
+    }
+
+    public int getBoilingPoint(IngredientStack stack)
+    {
+        return getBoilingPoint();
+    }
+
+    public int getLuminosity(IngredientStack stack)
+    {
+        return getLuminosity();
+    }
+
+    public Block getBlock(IngredientStack stack)
+    {
+        return getBlock();
+    }
+
+    public boolean canMelt(IngredientStack stack)
+    {
+        return canMelt();
+    }
+
+    public boolean canBoil(IngredientStack stack)
+    {
+        return canBoil();
+    }
+
+    public SoundEvent getAddSound(IngredientStack stack)
+    {
+        return getAddSound();
+    }
+
+    public SoundEvent getRemoveSound(IngredientStack stack)
+    {
+        return getRemoveSound();
+    }
+
+    public Fluid getFluid(IngredientStack stack)
+    {
+        return getFluid();
+    }
+
+    public FluidStack getFluidStack(IngredientStack stack)
+    {
+        return new FluidStack(getFluidStack(), stack.amount);
+    }
+
+    /**
+     * Returns the sound to be played when the source is pulled from a container
+     * */
+    public SoundEvent getAddedSound(World world, BlockPos pos)
+    {
+        return getRemoveSound();
+    }
+
+    /**
+     * Returns the sound to be played when the source is added into a container
+     * */
+    public SoundEvent getRemovedSound(World world, BlockPos pos)
+    {
+        return getAddSound();
+    }
+
+    public EnumRarity getRarity(World world, BlockPos pos)
+    {
+        return getRarity();
+    }
+
+    public int getDensity(World world, BlockPos pos)
+    {
+        return getDensity();
+    }
+
+    public int getMeltingPoint(World world, BlockPos pos)
+    {
+        return getMeltingPoint();
+    }
+
+    public int getBoilingPoint(World world, BlockPos pos)
+    {
+        return getBoilingPoint();
+    }
+
+    public int getLuminosity(World world, BlockPos pos)
+    {
+        return getLuminosity();
+    }
+
+    public boolean canMelt(World world, BlockPos pos)
+    {
+        return canMelt();
+    }
+
+    public boolean canBoil(World world, BlockPos pos)
+    {
+        return canBoil();
+    }
+
+    public SoundEvent getAddSound(World world, BlockPos pos)
+    {
+        return getAddSound();
+    }
+
+    public SoundEvent getRemoveSound(World world, BlockPos pos)
+    {
+        return getRemoveSound();
+    }
+
+    public FluidStack getFluidStack(World world, BlockPos pos)
+    {
+        return new FluidStack(getFluidStack(), FULL_BLOCK_VOLUME);
+    }
+}

--- a/src/main/java/net/minecraftforge/ingredients/Ingredient.java
+++ b/src/main/java/net/minecraftforge/ingredients/Ingredient.java
@@ -1,5 +1,6 @@
 package net.minecraftforge.ingredients;
 
+import com.google.common.collect.Sets;
 import net.minecraft.block.Block;
 import net.minecraft.item.EnumRarity;
 import net.minecraft.util.SoundEvent;
@@ -8,6 +9,8 @@ import net.minecraft.util.text.translation.I18n;
 import net.minecraft.world.World;
 import net.minecraftforge.fluids.Fluid;
 import net.minecraftforge.fluids.FluidStack;
+
+import java.util.Set;
 
 /**
  * Material equivalent to Fluids.
@@ -114,6 +117,8 @@ public class Ingredient
      * The correlating fluid, if the ingredient has one.
      * */
     protected Fluid fluid = null;
+
+    protected Set<String> indentifiers = Sets.newHashSet();
 
     private SoundEvent addSound;
     private SoundEvent removeSound;
@@ -226,6 +231,20 @@ public class Ingredient
         return this;
     }
 
+    /**
+     * Adds an indentifier to the ingredient. Useful for when the ingredient is being qualified.
+     * <p/>
+     * Use as generic of identifiers as possible. Such as 'metal' or 'mineable'
+     * */
+    public Ingredient addIdentifier(String... identifiers)
+    {
+        for(String toAdd : identifiers)
+        {
+            indentifiers.add(toAdd);
+        }
+        return this;
+    }
+
     /* Checks the default state based on the given temp of 300 degrees kelvin*/
     private void recheckDefaultState()
     {
@@ -321,6 +340,16 @@ public class Ingredient
     public final boolean canBePlacedInWorld()
     {
         return block != null;
+    }
+
+    /**
+     * Returns whether or not this ingredient has the given identifier
+     * <p/>
+     * This is useful for qualifying an item, eg. when checking if it is mineable, or a metal
+     * */
+    public final boolean hasIdentifier(String identifier)
+    {
+        return indentifiers.contains(identifier);
     }
 
     /* Stack based accessors */

--- a/src/main/java/net/minecraftforge/ingredients/IngredientRegistry.java
+++ b/src/main/java/net/minecraftforge/ingredients/IngredientRegistry.java
@@ -1,0 +1,349 @@
+package net.minecraftforge.ingredients;
+
+import com.google.common.base.Strings;
+import com.google.common.collect.*;
+import net.minecraft.block.Block;
+import net.minecraft.init.Blocks;
+import net.minecraft.nbt.NBTTagCompound;
+import net.minecraft.nbt.NBTTagList;
+import net.minecraft.nbt.NBTTagString;
+import net.minecraft.util.ResourceLocation;
+import net.minecraft.util.text.translation.I18n;
+import net.minecraftforge.common.MinecraftForge;
+import net.minecraftforge.fml.common.FMLLog;
+import net.minecraftforge.fml.common.Loader;
+import net.minecraftforge.fml.common.LoaderState;
+import net.minecraftforge.fml.common.ModContainer;
+import net.minecraftforge.fml.common.eventhandler.Event;
+import net.minecraftforge.fml.common.registry.RegistryDelegate;
+import org.apache.logging.log4j.Level;
+
+import java.util.Map;
+import java.util.Set;
+
+public class IngredientRegistry {
+    static int maxID = 0;
+
+    static BiMap<String, Ingredient> ingredients = HashBiMap.create();
+    static BiMap<Ingredient, Integer> ingredientIDs = HashBiMap.create();
+    static BiMap<Integer, String> ingredientNames = HashBiMap.create(); //Caching this just makes some other calls faster
+    static BiMap<Block, Ingredient> ingredientBlocks;
+
+    // the globally unique ingredient map - only used to associate non-defaults during world/server loading
+    static BiMap<String, Ingredient> masterIngredientReference = HashBiMap.create();
+    static BiMap<String, String> defaultIngredientName = HashBiMap.create();
+    static Map<Ingredient, IngredientDelegate> delegates = Maps.newHashMap();
+
+    public static final Ingredient IRON     = new Ingredient("iron").setBlock(Blocks.IRON_BLOCK).setDensity(7874).setMeltingPoint(1808).setBoilingPoint(3023);
+    public static final Ingredient GOLD     = new Ingredient("gold").setBlock(Blocks.GOLD_BLOCK).setDensity(19300).setMeltingPoint(1337).setBoilingPoint(2973);
+    public static final Ingredient DIAMOND  = new Ingredient("diamond").setBlock(Blocks.DIAMOND_BLOCK).setDensity(3539).setMeltingPoint(4600).setBoilingPoint(4600 /**approx sublime point*/).setCanMelt(false);
+    public static final Ingredient COAL     = new Ingredient("coal").setBlock(Blocks.COAL_BLOCK).setDensity(833 /*approx bulk density*/).setMeltingPoint(3900).setBoilingPoint(3900 /*approx sublime point*/).setCanMelt(false);
+    public static final Ingredient CHARCOAL = new Ingredient("charcoal").setDensity(360/*avg*/);
+    public static final Ingredient LAPIS    = new Ingredient("lapis").setBlock(Blocks.LAPIS_BLOCK).setDensity(2400 /*avg*/).setMeltingPoint(1250).setBoilingPoint(2750)/*not enough info on compound. Used estimates for feldspathoids*/;
+    public static final Ingredient STONE    = new Ingredient("stone").setBlock(Blocks.STONE).setDensity(3011).setMeltingPoint(1395).setBoilingPoint(2503); /*treated as basalt*/
+
+    static
+    {
+        registerIngredient(IRON);
+        registerIngredient(GOLD);
+        registerIngredient(DIAMOND);
+        registerIngredient(COAL);
+        registerIngredient(CHARCOAL);
+        registerIngredient(LAPIS);
+    }
+
+    private IngredientRegistry() {
+    }
+
+    /**
+     * Called by Forge to prepare the ID map for server -> client sync.
+     * Modders, DO NOT call this.
+     */
+    public static void initIngredientIDs(BiMap<Ingredient, Integer> newingredientIDs, Set<String> defaultNames)
+    {
+        maxID = newingredientIDs.size();
+        loadIngredientDefaults(newingredientIDs, defaultNames);
+    }
+
+    /**
+     * Called by forge to load default ingredient IDs from the world or from server -> client for syncing
+     * DO NOT call this and expect useful behaviour.
+     *
+     * @param localIngredientIDs
+     * @param defaultNames
+     */
+    private static void loadIngredientDefaults(BiMap<Ingredient, Integer> localIngredientIDs, Set<String> defaultNames)
+    {
+        // If there's an empty set of default names, use the defaults as defined locally
+        if (defaultNames.isEmpty())
+        {
+            defaultNames.addAll(defaultIngredientName.values());
+        }
+        BiMap<String, Ingredient> localIngredients = HashBiMap.create(ingredients);
+        for (String defaultName : defaultNames)
+        {
+            Ingredient ingredient = masterIngredientReference.get(defaultName);
+            if (ingredient == null)
+            {
+                String derivedName = defaultName.split(":", 2)[1];
+                String localDefault = defaultIngredientName.get(derivedName);
+                if (localDefault == null)
+                {
+                    FMLLog.getLogger().log(Level.ERROR, "The ingredient {} (specified as {}) is missing from this instance - it will be removed", derivedName, defaultName);
+                    continue;
+                }
+                ingredient = masterIngredientReference.get(localDefault);
+                FMLLog.getLogger().log(Level.ERROR, "The ingredient {} specified as default is not present - it will be reverted to default {}", defaultName, localDefault);
+            }
+            FMLLog.getLogger().log(Level.DEBUG, "The ingredient {} has been selected as the default ingredient for {}", defaultName, ingredient.getName());
+            Ingredient oldIngredient = localIngredients.put(ingredient.getName(), ingredient);
+            Integer id = localIngredientIDs.remove(oldIngredient);
+            localIngredientIDs.put(ingredient, id);
+        }
+        BiMap<Integer, String> localIngredientNames = HashBiMap.create();
+        for (Map.Entry<Ingredient, Integer> e : localIngredientIDs.entrySet())
+        {
+            localIngredientNames.put(e.getValue(), e.getKey().getName());
+        }
+        ingredientIDs = localIngredientIDs;
+        ingredients = localIngredients;
+        ingredientNames = localIngredientNames;
+        ingredientBlocks = null;
+        for (IngredientDelegate fd : delegates.values())
+        {
+            fd.rebind();
+        }
+    }
+
+    /**
+     * Register a new Ingredient. If a ingredient with the same name already exists, registration the alternative ingredient is tracked
+     * in case it is the default in another place
+     *
+     * @param ingredient The ingredient to register.
+     * @return True if the ingredient was registered as the current default ingredient, false if it was only registered as an alternative
+     */
+    public static boolean registerIngredient(Ingredient ingredient)
+    {
+        masterIngredientReference.put(uniqueName(ingredient), ingredient);
+        delegates.put(ingredient, new IngredientDelegate(ingredient, ingredient.getName()));
+        if (ingredients.containsKey(ingredient.getName()))
+        {
+            return false;
+        }
+        ingredients.put(ingredient.getName(), ingredient);
+        maxID++;
+        ingredientIDs.put(ingredient, maxID);
+        ingredientNames.put(maxID, ingredient.getName());
+        defaultIngredientName.put(ingredient.getName(), uniqueName(ingredient));
+
+        MinecraftForge.EVENT_BUS.post(new IngredientRegisterEvent(ingredient.getName(), maxID));
+        return true;
+    }
+
+    private static String uniqueName(Ingredient ingredient)
+    {
+        ModContainer activeModContainer = Loader.instance().activeModContainer();
+        String activeModContainerName = activeModContainer == null ? "minecraft" : activeModContainer.getModId();
+        return activeModContainerName + ":" + ingredient.getName();
+    }
+
+    /**
+     * Is the supplied ingredient the current default ingredient for it's name
+     *
+     * @param ingredient the ingredient we're testing
+     * @return if the ingredient is default
+     */
+    public static boolean isIngredientDefault(Ingredient ingredient)
+    {
+        return ingredients.containsValue(ingredient);
+    }
+
+    /**
+     * Does the supplied ingredient have an entry for it's name (whether or not the ingredient itself is default)
+     *
+     * @param ingredient the ingredient we're testing
+     * @return if the ingredient's name has a registration entry
+     */
+    public static boolean isIngredientRegistered(Ingredient ingredient)
+    {
+        return ingredient != null && ingredients.containsKey(ingredient.getName());
+    }
+
+    public static boolean isIngredientRegistered(String ingredientName)
+    {
+        return ingredients.containsKey(ingredientName);
+    }
+
+    public static Ingredient getIngredient(String ingredientName)
+    {
+        return ingredients.get(ingredientName);
+    }
+
+    @Deprecated // Modders should never actually use int ID, use String
+    public static Ingredient getIngredient(int ingredientID)
+    {
+        return ingredientIDs.inverse().get(ingredientID);
+    }
+
+    @Deprecated // Modders should never actually use int ID, use String
+    public static int getIngredientID(Ingredient ingredient)
+    {
+        Integer ret = ingredientIDs.get(ingredient);
+        if (ret == null)
+            throw new RuntimeException("Attempted to access ID for unregistered ingredient, Stop using this method modder!");
+        return ret;
+    }
+
+    @Deprecated // Modders should never actually use int ID, use String
+    public static int getIngredientID(String ingredientName)
+    {
+        Integer ret = ingredientIDs.get(getIngredient(ingredientName));
+        if (ret == null)
+            throw new RuntimeException("Attempted to access ID for unregistered ingredient, Stop using this method modder!");
+        return ret;
+    }
+
+    public static String getIngredientName(Ingredient ingredient)
+    {
+        return ingredients.inverse().get(ingredient);
+    }
+
+    public static String getIngredientName(IngredientStack stack)
+    {
+        return getIngredientName(stack.getIngredient());
+    }
+
+    public static IngredientStack getIngredientStack(String ingredientName, int amount) {
+        if (!ingredients.containsKey(ingredientName)) {
+            return null;
+        }
+        return new IngredientStack(getIngredient(ingredientName), amount);
+    }
+
+    /**
+     * Returns a read-only map containing Ingredient Names and their associated Ingredients.
+     */
+    public static Map<String, Ingredient> getRegisteredIngredients() {
+        return ImmutableMap.copyOf(ingredients);
+    }
+
+    /**
+     * Returns a read-only map containing Ingredient Names and their associated IDs.
+     * Modders should never actually use this, use the String names.
+     */
+    @Deprecated
+    public static Map<Ingredient, Integer> getRegisteredIngredientIDs() {
+        return ImmutableMap.copyOf(ingredientIDs);
+    }
+
+
+    public static class IngredientRegisterEvent extends Event {
+        private final String ingredientName;
+        private final int ingredientID;
+
+        public IngredientRegisterEvent(String ingredientName, int ingredientID) {
+            this.ingredientName = ingredientName;
+            this.ingredientID = ingredientID;
+        }
+
+        public String getIngredientName() {
+            return ingredientName;
+        }
+
+        public int getIngredientID() {
+            return ingredientID;
+        }
+    }
+
+    public static int getMaxID() {
+        return maxID;
+    }
+
+    public static String getDefaultIngredientName(Ingredient key) {
+        String name = masterIngredientReference.inverse().get(key);
+        if (Strings.isNullOrEmpty(name)) {
+            FMLLog.getLogger().log(Level.ERROR, "The ingredient registry is corrupted. A ingredient {} {} is not properly registered. The mod that registered this is broken", key.getClass().getName(), key.getName());
+            throw new IllegalStateException("The ingredient registry is corrupted");
+        }
+        return name;
+    }
+
+    public static void loadIngredientDefaults(NBTTagCompound tag) {
+        Set<String> defaults = Sets.newHashSet();
+        if (tag.hasKey("DefaultIngredientList", 9)) {
+            FMLLog.getLogger().log(Level.DEBUG, "Loading persistent ingredient defaults from world");
+            NBTTagList tl = tag.getTagList("DefaultIngredientList", 8);
+            for (int i = 0; i < tl.tagCount(); i++) {
+                defaults.add(tl.getStringTagAt(i));
+            }
+        } else {
+            FMLLog.getLogger().log(Level.DEBUG, "World is missing persistent ingredient defaults - using local defaults");
+        }
+        loadIngredientDefaults(HashBiMap.create(ingredientIDs), defaults);
+    }
+
+    public static void writeDefaultIngredientList(NBTTagCompound forgeData) {
+        NBTTagList tagList = new NBTTagList();
+
+        for (Map.Entry<String, Ingredient> def : ingredients.entrySet()) {
+            tagList.appendTag(new NBTTagString(getDefaultIngredientName(def.getValue())));
+        }
+
+        forgeData.setTag("DefaultIngredientList", tagList);
+    }
+
+    public static void validateIngredientRegistry() {
+        Set<Ingredient> illegalIngredients = Sets.newHashSet();
+        for (Ingredient f : ingredients.values()) {
+            if (!masterIngredientReference.containsValue(f)) {
+                illegalIngredients.add(f);
+            }
+        }
+
+        if (!illegalIngredients.isEmpty()) {
+            FMLLog.getLogger().log(Level.FATAL, "The ingredient registry is corrupted. Something has inserted a ingredient without registering it");
+            FMLLog.getLogger().log(Level.FATAL, "There is {} unregistered ingredients", illegalIngredients.size());
+            for (Ingredient f : illegalIngredients) {
+                FMLLog.getLogger().log(Level.FATAL, "  Ingredient name : {}, type: {}", f.getName(), f.getClass().getName());
+            }
+            FMLLog.getLogger().log(Level.FATAL, "The mods that own these ingredients need to register them properly");
+            throw new IllegalStateException("The ingredient map contains ingredients unknown to the master ingredient registry");
+        }
+    }
+
+    static RegistryDelegate<Ingredient> makeDelegate(Ingredient fl) {
+        return delegates.get(fl);
+    }
+
+
+    private static class IngredientDelegate implements RegistryDelegate<Ingredient> {
+        private String name;
+        private Ingredient ingredient;
+
+        IngredientDelegate(Ingredient ingredient, String name) {
+            this.ingredient = ingredient;
+            this.name = name;
+        }
+
+        @Override
+        public Ingredient get() {
+            return ingredient;
+        }
+
+        @Override
+        public ResourceLocation name() {
+            return new ResourceLocation(name);
+        }
+
+        @Override
+        public Class<Ingredient> type() {
+            return Ingredient.class;
+        }
+
+        void rebind() {
+            ingredient = ingredients.get(name);
+        }
+
+
+    }
+}

--- a/src/main/java/net/minecraftforge/ingredients/IngredientRegistry.java
+++ b/src/main/java/net/minecraftforge/ingredients/IngredientRegistry.java
@@ -42,14 +42,15 @@ public class IngredientRegistry {
     public static final Ingredient LAPIS    = new Ingredient("lapis").setBlock(Blocks.LAPIS_BLOCK).setDensity(2400 /*avg*/).setMeltingPoint(1250).setBoilingPoint(2750)/*not enough info on compound. Used estimates for feldspathoids*/;
     public static final Ingredient STONE    = new Ingredient("stone").setBlock(Blocks.STONE).setDensity(3011).setMeltingPoint(1395).setBoilingPoint(2503); /*treated as basalt*/
 
-    static
+    static   //Add identifiers here to help reduce class width, and maintain readability
     {
-        registerIngredient(IRON);
-        registerIngredient(GOLD);
-        registerIngredient(DIAMOND);
-        registerIngredient(COAL);
-        registerIngredient(CHARCOAL);
-        registerIngredient(LAPIS);
+        registerIngredient(IRON.addIdentifier("metal", "mineable"));
+        registerIngredient(GOLD.addIdentifier("metal","mineable"));
+        registerIngredient(DIAMOND.addIdentifier("crystal", "mineable"));
+        registerIngredient(COAL.addIdentifier("fuel","mineable"));
+        registerIngredient(CHARCOAL.addIdentifier("fuel","mineable"));
+        registerIngredient(LAPIS.addIdentifier("crystal", "mineable"));
+        registerIngredient(STONE.addIdentifier("mineable"));
     }
 
     private IngredientRegistry() {
@@ -116,7 +117,7 @@ public class IngredientRegistry {
     }
 
     /**
-     * Register a new Ingredient. If a ingredient with the same name already exists, registration the alternative ingredient is tracked
+     * Register a new Ingredient. If an ingredient with the same name already exists, registration the alternative ingredient is tracked
      * in case it is the default in another place
      *
      * @param ingredient The ingredient to register.
@@ -301,7 +302,7 @@ public class IngredientRegistry {
         }
 
         if (!illegalIngredients.isEmpty()) {
-            FMLLog.getLogger().log(Level.FATAL, "The ingredient registry is corrupted. Something has inserted a ingredient without registering it");
+            FMLLog.getLogger().log(Level.FATAL, "The ingredient registry is corrupted. Something has inserted an ingredient without registering it");
             FMLLog.getLogger().log(Level.FATAL, "There is {} unregistered ingredients", illegalIngredients.size());
             for (Ingredient f : illegalIngredients) {
                 FMLLog.getLogger().log(Level.FATAL, "  Ingredient name : {}, type: {}", f.getName(), f.getClass().getName());
@@ -311,8 +312,8 @@ public class IngredientRegistry {
         }
     }
 
-    static RegistryDelegate<Ingredient> makeDelegate(Ingredient fl) {
-        return delegates.get(fl);
+    static RegistryDelegate<Ingredient> makeDelegate(Ingredient ing) {
+        return delegates.get(ing);
     }
 
 

--- a/src/main/java/net/minecraftforge/ingredients/IngredientSource.java
+++ b/src/main/java/net/minecraftforge/ingredients/IngredientSource.java
@@ -1,0 +1,326 @@
+package net.minecraftforge.ingredients;
+
+import net.minecraft.item.ItemStack;
+import net.minecraft.nbt.NBTTagCompound;
+import net.minecraft.tileentity.TileEntity;
+import net.minecraftforge.ingredients.capability.IIngredientHandler;
+import net.minecraftforge.ingredients.capability.IIngredientSourceProperties;
+import net.minecraftforge.ingredients.capability.IngredientSourceProperties;
+import net.minecraftforge.ingredients.capability.IngredientSourcePropertiesWrapper;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+/**
+ * Reference implementation of {@link IIngredientSource} use/extend this, or implement your own.
+ * */
+public class IngredientSource implements IIngredientSource, IIngredientHandler
+{
+    @Nullable
+    protected IngredientStack ingredient;
+    protected int capacity;
+    protected TileEntity tile;
+    protected boolean canAdd = true;
+    protected boolean canRemove = false;
+    protected IIngredientSourceProperties[] sourceProps;
+
+    public IngredientSource(int capacity)
+    {
+        this(null, capacity);
+    }
+
+    public IngredientSource(@Nullable IngredientStack ingredientStack, int capacity)
+    {
+        this.ingredient = ingredientStack;
+        this.capacity = capacity;
+    }
+
+    public IngredientSource(IngredientStack ingredientStack, int amount, int capacity)
+    {
+        this(new IngredientStack(ingredientStack.getIngredient(), amount, ingredientStack.materialState, ingredientStack.refinementLevel, ingredientStack.tag), capacity);
+    }
+
+    public IngredientSource readFromNBT(NBTTagCompound nbt)
+    {
+        if(!nbt.hasKey("Empty"))
+        {
+            IngredientStack stack = IngredientStack.loadIngredientStackFromNBT(nbt);
+            setIngredient(stack);
+        }
+        else
+        {
+            setIngredient(null);
+        }
+        return this;
+    }
+
+    public NBTTagCompound writeToNBT(NBTTagCompound nbt)
+    {
+        if(ingredient != null)
+        {
+            ingredient.writeToNBT(nbt);
+        }
+        else
+        {
+            nbt.setString("Empty","");
+        }
+        return nbt;
+    }
+
+    /* IIngredientSource*/
+    @Nullable
+    @Override
+    public IngredientStack getIngredient() {
+        return ingredient;
+    }
+
+    public void setIngredient(IngredientStack stack)
+    {
+        this.ingredient = stack;
+    }
+
+    @Override
+    public int getIngredientVolume() {
+        if(ingredient == null)
+        {
+            return 0;
+        }
+        return ingredient.amount;
+    }
+
+    @Override
+    public int getCapacity() {
+        return capacity;
+    }
+
+    public void setCapacity(int capacity)
+    {
+        this.capacity = capacity;
+    }
+
+    @Override
+    public IngredientSourceInfo getInfo()
+    {
+        return new IngredientSourceInfo(this);
+    }
+
+    @Override
+    public int add(IngredientStack resource, boolean doAdd)
+    {
+        if(!canAddIngredientType(resource))
+        {
+            return 0;
+        }
+        return addInternal(resource, doAdd);
+    }
+
+    /**
+     * Use this method to bypass the restriction from {@link #canAddIngredientType(IngredientStack)}
+     * Meant for use by the tank owner when {@link #canAdd} is false
+     */
+    public int addInternal(IngredientStack resource, boolean doAdd)
+    {
+        if(resource == null || resource.amount <= 0)
+        {
+            return 0;
+        }
+
+        if(!doAdd)
+        {
+            if(ingredient == null)
+            {
+                return Math.min(capacity, resource.amount);
+            }
+
+            if(!ingredient.isIngredientEqual(resource))
+            {
+                return 0;
+            }
+
+            return Math.min(capacity - ingredient.amount, resource.amount);
+        }
+
+        if(ingredient == null)
+        {
+            ingredient = new IngredientStack(resource, Math.min(capacity, resource.amount));
+
+            onContentsChanged();
+
+            return ingredient.amount;
+        }
+
+        if(!ingredient.isIngredientEqual(resource))
+        {
+            return 0;
+        }
+        int fill = capacity - ingredient.amount;
+
+        if(resource.amount < fill)
+        {
+            ingredient.amount += resource.amount;
+            fill = resource.amount;
+        }
+        else
+        {
+            ingredient.amount = capacity;
+        }
+
+        onContentsChanged();
+
+        return fill;
+    }
+
+    @Nullable
+    @Override
+    public IngredientStack remove(int maxRemoved, boolean doRemove)
+    {
+        if(!canRemoveIngredientType(getIngredient()))
+        {
+            return null;
+        }
+        return removeInternal(maxRemoved, doRemove);
+    }
+
+    @Nonnull
+    @Override
+    public IngredientSourceProperties getPrimarySourceIngredient()
+    {
+        return new IngredientSourceProperties(getIngredient(), capacity, canAdd, canRemove);
+    }
+
+    @Nullable
+    @Override
+    public IngredientStack remove(IngredientStack resource, boolean doRemove)
+    {
+        if(resource == null || resource.isIngredientEqual(getIngredient()))
+        {
+            return null;
+        }
+        return removeInternal(resource.amount, doRemove);
+    }
+
+    /**
+     * Use this method to bypass resrtictions from {@link #canRemoveIngredientType(IngredientStack)}
+     * Meant for the source owner when {@link #canRemove} is false
+     */
+    public IngredientStack removeInternal(IngredientStack resource, boolean doRemove)
+    {
+        if(resource == null || !resource.isIngredientEqual(getIngredient()))
+        {
+            return null;
+        }
+        return removeInternal(resource.amount, doRemove);
+    }
+
+    /**
+     * Use this method to bypass resrtictions from {@link #canRemoveIngredientType(IngredientStack)}
+     * Meant for the source owner when {@link #canRemove} is false
+     */
+    public IngredientStack removeInternal(int maxRemoved, boolean doRemove)
+    {
+        if(ingredient == null || maxRemoved <= 0)
+        {
+            return null;
+        }
+        int loss = maxRemoved;
+
+        if(ingredient.amount < loss)
+        {
+            loss = ingredient.amount;
+        }
+        IngredientStack stack = new IngredientStack(ingredient, loss);
+
+        if(doRemove)
+        {
+            ingredient.amount -= loss;
+            if(ingredient.amount <= 0)
+            {
+                ingredient = null;
+            }
+
+            onContentsChanged();
+        }
+
+        return stack;
+    }
+
+    /**
+     * Whether or not the source can be added to with {@link IIngredientHandler}
+     *
+     * @see IIngredientSourceProperties#canAdd()
+     * */
+    public boolean canAdd()
+    {
+        return canAdd;
+    }
+
+    /**
+     * Whether or not the source can be removed from with {@link IIngredientHandler}
+     *
+     * @see IIngredientSourceProperties#canRemove()
+     * */
+    public boolean canRemove()
+    {
+        return canRemove;
+    }
+
+    /**
+     * Sets whether this source can be added to with {@link IIngredientHandler}
+     *
+     * @see IIngredientSourceProperties#canAdd()
+     */
+    public void setCanAdd(boolean canAdd)
+    {
+        this.canAdd = canAdd;
+    }
+
+    /**
+     * Sets whether this source can be removed from with {@link IIngredientHandler}
+     *
+     * @see IIngredientSourceProperties#canRemove()
+     * */
+    public void setCanRemove(boolean canRemove)
+    {
+        this.canRemove = canRemove;
+    }
+
+    /**
+     * Returns true if the source can have the given ingredient added.
+     * Used as a filter for ingredient types.
+     * Does not consider the current contents, or capacity,
+     * only whether it could ever add this ingredient.
+     *
+     * @see IIngredientSourceProperties#canAddIngredientType(IngredientStack)
+     * */
+    public boolean canAddIngredientType(IngredientStack stack)
+    {
+        return canAdd();
+    }
+
+    /**
+     * Returns true if the source can have the given ingredient remove.
+     * Used as a filter for ingredient types.
+     * Does not consider the current contents, or capacity,
+     * only whether it could ever remove this ingredient.
+     *
+     * @see IIngredientSourceProperties#canRemoveIngredientType(IngredientStack)
+     * */
+    public boolean canRemoveIngredientType(IngredientStack stack)
+    {
+        return canRemove();
+    }
+
+    @Override
+    public IIngredientSourceProperties[] getContainerProperties()
+    {
+        if(this.sourceProps == null)
+        {
+            this.sourceProps = new IIngredientSourceProperties[] { new IngredientSourcePropertiesWrapper(this)};
+        }
+        return this.sourceProps;
+    }
+
+    protected void onContentsChanged()
+    {
+    }
+}

--- a/src/main/java/net/minecraftforge/ingredients/IngredientSourceInfo.java
+++ b/src/main/java/net/minecraftforge/ingredients/IngredientSourceInfo.java
@@ -1,0 +1,25 @@
+package net.minecraftforge.ingredients;
+
+import javax.annotation.Nullable;
+
+/**
+ * Wrapper class used to encapsulate the IIngredientSource's information
+ * */
+public final class IngredientSourceInfo
+{
+    @Nullable
+    public final IngredientStack ingredient;
+    public final int capacity;
+
+    public IngredientSourceInfo(@Nullable IngredientStack ingredient, int capacity)
+    {
+        this.ingredient = ingredient;
+        this.capacity = capacity;
+    }
+
+    public IngredientSourceInfo(IIngredientSource source)
+    {
+        this.ingredient = source.getIngredient();
+        this.capacity = source.getCapacity();
+    }
+}

--- a/src/main/java/net/minecraftforge/ingredients/IngredientStack.java
+++ b/src/main/java/net/minecraftforge/ingredients/IngredientStack.java
@@ -1,0 +1,224 @@
+package net.minecraftforge.ingredients;
+
+import net.minecraft.nbt.NBTTagCompound;
+import net.minecraftforge.fml.common.FMLLog;
+import net.minecraftforge.fml.common.registry.RegistryDelegate;
+
+/**
+ * FluidStack equivalent for Ingredient.
+ * <p/>
+ * NOTE: Equality is based purely on the Ingredient.
+ * */
+public class IngredientStack
+{
+
+    public int amount;
+    public int temperature = 300;
+    public EnumMatterState materialState;
+    public EnumRefinementLevel refinementLevel;
+    public NBTTagCompound tag;
+    private RegistryDelegate<Ingredient> ingredientDelegate;
+
+    public IngredientStack(Ingredient ingredient, int amount, EnumMatterState state, EnumRefinementLevel refinement, NBTTagCompound tagData)
+    {
+        if (ingredient == null)
+        {
+            FMLLog.bigWarning("Null ingredient supplied to ingredientstack. Did you try and create a stack for an unregistered ingredient?");
+            throw new IllegalArgumentException("Cannot create an ingredientstack from a null ingredient");
+        }
+        else if (!IngredientRegistry.isIngredientRegistered(ingredient))
+        {
+            FMLLog.bigWarning("Failed attempt to create an IngredientStack for an unregistered Ingredient %s (type %s)", ingredient.getName(), ingredient.getClass().getName());
+            throw new IllegalArgumentException("Cannot create an ingredientstack from an unregistered ingredient");
+        }
+        this.ingredientDelegate = IngredientRegistry.makeDelegate(ingredient);
+        this.amount = amount;
+        this.materialState = state;
+        this.refinementLevel = refinement;
+        if(tagData != null)
+        {
+            this.tag = tagData.copy();
+        }
+    }
+
+    public IngredientStack(Ingredient ingredient, int amount)
+    {
+        this(ingredient, amount, ingredient.getRoomTempState(), EnumRefinementLevel.RAW, null);
+    }
+
+    public IngredientStack(Ingredient ingredient, int amount, EnumMatterState state, EnumRefinementLevel refinement)
+    {
+        this(ingredient, amount, state, refinement, null);
+    }
+
+    public IngredientStack(IngredientStack resource, int amount)
+    {
+        this(resource.getIngredient(), amount, resource.materialState, resource.refinementLevel, resource.tag);
+    }
+
+    public IngredientStack(Ingredient ingredient, int amount, EnumRefinementLevel refinement)
+    {
+        this(ingredient, amount, ingredient.roomTempState, refinement);
+    }
+
+    /**
+     * Provides a safe method for retrieving an IngredientStack- if the Ingredient is invalid, the stack
+     * will return null
+     * */
+    public static IngredientStack loadIngredientStackFromNBT(NBTTagCompound nbt)
+    {
+        if(nbt == null)
+        {
+            return null;
+        }
+        String ingredientName = nbt.getString("IngredientName");
+
+        if(ingredientName == null)
+        {
+            return null;
+        }
+        Ingredient ingredient = IngredientRegistry.getIngredient(ingredientName);
+
+        if(ingredient == null)
+        {
+            return null;
+        }
+        EnumMatterState state = EnumMatterState.fromByte(nbt.getByte("MaterialState"));
+        EnumRefinementLevel refinement = EnumRefinementLevel.fromByte(nbt.getByte("RefinementLevel"));
+
+        IngredientStack stack = new IngredientStack(ingredient, nbt.getInteger("Volume"), state, refinement);
+
+        if(nbt.hasKey("Temperature"))
+        {
+            stack.temperature = nbt.getInteger("Temperature"); //Defaults back to room temp if not available
+            if(stack.temperature < 0) //impossibility check
+            {
+                stack.temperature = 0;
+            }
+        }
+
+        if(nbt.hasKey("Tag"))
+        {
+            stack.tag = nbt.getCompoundTag("Tag");
+        }
+
+        return stack;
+    }
+
+    public NBTTagCompound writeToNBT(NBTTagCompound nbt)
+    {
+        nbt.setString("IngredientName", IngredientRegistry.getIngredientName(getIngredient()));
+        nbt.setInteger("Volume", amount);
+        nbt.setByte("MaterialState", (byte) materialState.ordinal());
+        nbt.setByte("RefinementLevel", (byte) refinementLevel.ordinal());
+
+        if(temperature != 300)
+        {
+            nbt.setInteger("Temperature", temperature);
+        }
+
+        if(tag != null)
+        {
+            nbt.setTag("Tag", tag);
+        }
+
+        return nbt;
+    }
+
+    public final Ingredient getIngredient()
+    {
+        return ingredientDelegate.get();
+    }
+
+    public String getLocalizedName()
+    {
+        return this.getIngredient().getLocalizedName(this);
+    }
+
+    /**
+     * Returns a copy of the Ingredient Stack
+     * */
+    public IngredientStack copy()
+    {
+        return new IngredientStack(getIngredient(), amount, materialState, refinementLevel, tag);
+    }
+
+    /**
+     * Determines if the ingredient ID, material state, refinement level, and tags are equal.
+     * This doesn't check amounts
+     *
+     * @param other
+     *          The IngredientStack for comparison
+     * @return true if the Ingredient (ID, MatterState, RefinementLevel, and tags) are the same
+     * */
+    public boolean isIngredientEqual(IngredientStack other)
+    {
+        return other != null && getIngredient() == other.getIngredient() && materialState == other.materialState && refinementLevel == other.refinementLevel && isIngredientTagEqual(other);
+    }
+
+    private boolean isIngredientTagEqual(IngredientStack other)
+    {
+        return tag == null ? other.tag == null : other.tag == null ? false : tag.equals(other.tag);
+    }
+
+    /**
+     * Determines if the NBT Tags are equal. Useful if the IngredientIDs are known to be equal
+     * */
+    public static boolean areIngredientStacksEqual(IngredientStack stack1, IngredientStack stack2)
+    {
+        return stack1 == null && stack2 == null ? true : stack1 == null || stack2 == null ? false : stack1.isIngredientTagEqual(stack2);
+    }
+
+    /**
+     * Determines if the Ingredients are equal and this stack is larger
+     *
+     * @param other
+     *          The IngredientStack for comparison
+     * @return true if this IngredientStack contains the other IngredientStack (same ingredient and >= amount)
+     * */
+    public boolean containsIngredient(IngredientStack other)
+    {
+        return this.isIngredientEqual(other) && this.amount >= other.amount;
+    }
+
+    /**
+     * Determins if the ingredients, temperatures, and amounts are equal
+     *
+     * @param other
+     *          the IngredientStack for comparison
+     * @return true if the two IngredientStacks are exactly the same
+     * */
+    public boolean isIngredientStackIdentical(IngredientStack other)
+    {
+        return this.isIngredientEqual(other) && this.amount == other.amount && this.temperature == other.temperature;
+    }
+
+    @Override
+    public final int hashCode()
+    {
+        int code = 1;
+        code = 31*code + getIngredient().hashCode();
+        code = 31*code + amount;
+        code = 31*code + materialState.hashCode();
+        code = 31*code + refinementLevel.hashCode();
+        if (tag != null)
+            code = 31*code + tag.hashCode();
+        return code;
+    }
+
+    /**
+     * Default equality comparison for a FluidStack. Same functionality as isFluidEqual().
+     *
+     * This is included for use in data structures.
+     */
+    @Override
+    public final boolean equals(Object o)
+    {
+        if (!(o instanceof IngredientStack))
+        {
+            return false;
+        }
+
+        return isIngredientEqual((IngredientStack) o);
+    }
+}

--- a/src/main/java/net/minecraftforge/ingredients/IngredientUtil.java
+++ b/src/main/java/net/minecraftforge/ingredients/IngredientUtil.java
@@ -1,0 +1,444 @@
+package net.minecraftforge.ingredients;
+
+import net.minecraft.block.Block;
+import net.minecraft.block.state.IBlockState;
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.item.Item;
+import net.minecraft.item.ItemStack;
+import net.minecraft.tileentity.TileEntity;
+import net.minecraft.util.EnumFacing;
+import net.minecraft.util.SoundCategory;
+import net.minecraft.util.SoundEvent;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.World;
+import net.minecraftforge.ingredients.capability.CapabilityIngredientHandler;
+import net.minecraftforge.ingredients.capability.IIngredientHandler;
+import net.minecraftforge.items.IItemHandler;
+import net.minecraftforge.items.ItemHandlerHelper;
+import net.minecraftforge.items.wrapper.InvWrapper;
+import net.minecraftforge.items.wrapper.PlayerMainInvWrapper;
+
+import javax.annotation.Nullable;
+
+public class IngredientUtil
+{
+    private IngredientUtil()
+    {
+    }
+
+    /**
+     * Used to hand common cases of ingredient right-clicking on an ingredient handler.
+     * <p/>
+     * First it tries to add the container item from the ingredient handler,
+     * if that action fails, then it tries to pull from the ingredient handler into the container.
+     *
+     * @param stack
+     *          The ingredient-container/source ItemStack that holds the ingredient stack.
+     * @param handler
+     *          The {@link IIngredientHandler} that is being interacted with.
+     * @param player
+     *          The player that is using the container
+     * @return true if the interaction passed, and false if it failed.
+     * */
+    public static boolean interactWithIngredientHandler(ItemStack stack, IIngredientHandler handler, EntityPlayer player)
+    {
+        if(stack == null || handler == null || player == null)
+        {
+            return false;
+        }
+
+        IItemHandler playerInventory = new InvWrapper(player.inventory);
+        return false;
+    }
+
+    /**
+     * Fill a container from the given handler.
+     *
+     * @param container   The container to be added. Will not be modified.
+     * @param handler The ingredient handler to be removeed.
+     * @param maxAmount   The largest amount of ingredient that should be transferred.
+     * @param player      The player to make the adding noise. Pass null for no noise.
+     * @param doFill      true if the container should actually be added, false if it should be simulated.
+     * @return The added container or null if the ingredient couldn't be taken from the source.
+     */
+    public static ItemStack tryFillContainer(ItemStack container, IIngredientHandler handler, int maxAmount, @Nullable EntityPlayer player, boolean doFill)
+    {
+        container = container.copy(); // do not modify the input
+        container.stackSize = 1;
+        IIngredientHandler containerIngredientHandler = getIngredientHandler(container);
+        if (containerIngredientHandler != null)
+        {
+            IngredientStack simulatedTransfer = tryIngredientTransfer(containerIngredientHandler, handler, maxAmount, false);
+            if (simulatedTransfer != null)
+            {
+                if (doFill)
+                {
+                    tryIngredientTransfer(containerIngredientHandler, handler, maxAmount, true);
+                    if (player != null)
+                    {
+                        SoundEvent soundevent = simulatedTransfer.getIngredient().getAddedSound(simulatedTransfer);
+                        player.playSound(soundevent, 1f, 1f);
+                    }
+                }
+                else
+                {
+                    containerIngredientHandler.add(simulatedTransfer, true);
+                }
+                return container;
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Takes a added container and tries to empty it into the given source.
+     *
+     * @param container        The added container. Will not be modified.
+     * @param ingredientDestination The ingredient handler to be added by the container.
+     * @param maxAmount        The largest amount of ingredient that should be transferred.
+     * @param player           Player for making the bucket removeed sound. Pass null for no noise.
+     * @param doDrain          true if the container should actually be removeed, false if it should be simulated.
+     * @return The empty container if successful, null if the ingredient handler couldn't be added.
+     *         NOTE The empty container will have a stackSize of 0 when a added container is consumable,
+     *              i.e. it has a "null" empty container but has successfully been emptied.
+     */
+    @Nullable
+    public static ItemStack tryEmptyContainer(ItemStack container, IIngredientHandler ingredientDestination, int maxAmount, @Nullable EntityPlayer player, boolean doDrain)
+    {
+        container = container.copy(); // do not modify the input
+        container.stackSize = 1;
+        IIngredientHandler containerIngredientHandler = getIngredientHandler(container);
+        if (containerIngredientHandler != null)
+        {
+            IngredientStack simulatedTransfer = tryIngredientTransfer(ingredientDestination, containerIngredientHandler, maxAmount, false);
+            if (simulatedTransfer != null)
+            {
+                if (doDrain)
+                {
+                    tryIngredientTransfer(ingredientDestination, containerIngredientHandler, maxAmount, true);
+                    if (player != null)
+                    {
+                        SoundEvent soundevent = simulatedTransfer.getIngredient().getRemovedSound(simulatedTransfer);
+                        player.playSound(soundevent, 1f, 1f);
+                    }
+                }
+                else
+                {
+                    containerIngredientHandler.remove(simulatedTransfer, true);
+                }
+                return container;
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Takes an Ingredient Container Item and tries to add it from the given source.
+     * If the player is in creative mode, the container will not be modified on success, and no additional items created.
+     * If the input itemstack has a stacksize > 1 it will stow the added container in the given inventory.
+     * If the inventory does not accept it, it will be given to the player or dropped at the players feet.
+     *      If player is null in this case, the action will be aborted.
+     *
+     * @param container   The Ingredient Container Itemstack to add. This stack WILL be modified on success.
+     * @param ingredientSource The ingredient source to add from
+     * @param inventory   An inventory where any additionally created item (added container if multiple empty are present) are put
+     * @param maxAmount   Maximum amount of ingredient to take from the source.
+     * @param player      The player that gets the items the inventory can't take. Can be null, only used if the inventory cannot take the added stack.
+     * @return True if the container was added successfully and stowed, false otherwise.
+     */
+    public static boolean tryFillContainerAndStow(ItemStack container, IIngredientHandler ingredientSource, IItemHandler inventory, int maxAmount, @Nullable EntityPlayer player)
+    {
+        if (container == null || container.stackSize < 1)
+        {
+            return false;
+        }
+
+        if (player != null && player.capabilities.isCreativeMode)
+        {
+            ItemStack addedReal = tryFillContainer(container, ingredientSource, maxAmount, player, true);
+            if (addedReal != null)
+            {
+                return true;
+            }
+        }
+        else if (container.stackSize == 1) // don't need to stow anything, just add and edit the container stack
+        {
+            ItemStack addedReal = tryFillContainer(container, ingredientSource, maxAmount, player, true);
+            if (addedReal != null)
+            {
+                container.deserializeNBT(addedReal.serializeNBT());
+                return true;
+            }
+        }
+        else
+        {
+            ItemStack addedSimulated = tryFillContainer(container, ingredientSource, maxAmount, player, false);
+            if (addedSimulated != null)
+            {
+                // check if we can give the itemStack to the inventory
+                ItemStack remainder = ItemHandlerHelper.insertItemStacked(inventory, addedSimulated, true);
+                if (remainder == null || player != null)
+                {
+                    ItemStack addedReal = tryFillContainer(container, ingredientSource, maxAmount, player, true);
+                    remainder = ItemHandlerHelper.insertItemStacked(inventory, addedReal, false);
+
+                    // give it to the player or drop it at their feet
+                    if (remainder != null && player != null)
+                    {
+                        ItemHandlerHelper.giveItemToPlayer(player, remainder);
+                    }
+
+                    container.stackSize--;
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Takes an Ingredient Container Item, tries to empty it into the ingredient handler, and stows it in the given inventory.
+     * If the player is in creative mode, the container will not be modified on success, and no additional items created.
+     * If the input itemstack has a stacksize > 1 it will stow the emptied container in the given inventory.
+     * If the inventory does not accept the emptied container, it will be given to the player or dropped at the players feet.
+     *      If player is null in this case, the action will be aborted.
+     *
+     * @param container        The added Ingredient Container Itemstack to empty. This stack WILL be modified on success.
+     * @param ingredientDestination The ingredient destination to add from the ingredient container.
+     * @param inventory        An inventory where any additionally created item (added container if multiple empty are present) are put
+     * @param maxAmount        Maximum amount of ingredient to take from the source.
+     * @param player           The player that gets the items the inventory can't take. Can be null, only used if the inventory cannot take the added stack.
+     * @return True if the container was added successfully and stowed, false otherwise.
+     */
+    public static boolean tryEmptyContainerAndStow(ItemStack container, IIngredientHandler ingredientDestination, IItemHandler inventory, int maxAmount, @Nullable EntityPlayer player)
+    {
+        if (container == null || container.stackSize < 1)
+        {
+            return false;
+        }
+
+        if (player != null && player.capabilities.isCreativeMode)
+        {
+            ItemStack emptiedReal = tryEmptyContainer(container, ingredientDestination, maxAmount, player, true);
+            if (emptiedReal != null)
+            {
+                return true;
+            }
+        }
+        else if (container.stackSize == 1) // don't need to stow anything, just add and edit the container stack
+        {
+            ItemStack emptiedReal = tryEmptyContainer(container, ingredientDestination, maxAmount, player, true);
+            if (emptiedReal != null)
+            {
+                if (emptiedReal.stackSize <= 0)
+                {
+                    container.stackSize--;
+                }
+                else
+                {
+                    container.deserializeNBT(emptiedReal.serializeNBT());
+                }
+                return true;
+            }
+        }
+        else
+        {
+            ItemStack emptiedSimulated = tryEmptyContainer(container, ingredientDestination, maxAmount, player, false);
+            if (emptiedSimulated != null)
+            {
+                if (emptiedSimulated.stackSize <= 0)
+                {
+                    tryEmptyContainer(container, ingredientDestination, maxAmount, player, true);
+                    container.stackSize--;
+                    return true;
+                }
+                else
+                {
+                    // check if we can give the itemStack to the inventory
+                    ItemStack remainder = ItemHandlerHelper.insertItemStacked(inventory, emptiedSimulated, true);
+                    if (remainder == null || player != null)
+                    {
+                        ItemStack emptiedReal = tryEmptyContainer(container, ingredientDestination, maxAmount, player, true);
+                        remainder = ItemHandlerHelper.insertItemStacked(inventory, emptiedReal, false);
+
+                        // give it to the player or drop it at their feet
+                        if (remainder != null && player != null)
+                        {
+                            ItemHandlerHelper.giveItemToPlayer(player, remainder);
+                        }
+
+                        container.stackSize--;
+                        return true;
+                    }
+                }
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Fill a destination ingredient handler from a source ingredient handler.
+     *
+     * @param ingredientDestination The ingredient handler to be added.
+     * @param ingredientSource      The ingredient handler to be removeed.
+     * @param maxAmount        The largest amount of ingredient that should be transferred.
+     * @param doTransfer       True if the transfer should actually be done, false if it should be simulated.
+     * @return the ingredientStack that was transferred from the source to the destination. null on failure.
+     */
+    @Nullable
+    public static IngredientStack tryIngredientTransfer(IIngredientHandler ingredientDestination, IIngredientHandler ingredientSource, int maxAmount, boolean doTransfer)
+    {
+        IngredientStack removeable = ingredientSource.remove(maxAmount, false);
+        if (removeable != null && removeable.amount > 0)
+        {
+            int addableAmount = ingredientDestination.add(removeable, false);
+            if (addableAmount > 0)
+            {
+                IngredientStack removed = ingredientSource.remove(addableAmount, doTransfer);
+                if (removed != null)
+                {
+                    removed.amount = ingredientDestination.add(removed, doTransfer);
+                    return removed;
+                }
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Helper method to get an IIngredientHandler for an itemStack.
+     *
+     * The itemStack passed in here WILL be modified, the IIngredientHandler acts on it directly.
+     *
+     * Note that the itemStack MUST have a stackSize of 1 if you want to add or remove it.
+     * You can't add or remove a whole stack at once, if you do then ingredient is multiplied or destroyed.
+     *
+     * Vanilla buckets will be converted to universal buckets if they are enabled.
+     *
+     * Returns null if the itemStack passed in does not have an ingredient handler.
+     */
+    @Nullable
+    public static IIngredientHandler getIngredientHandler(ItemStack itemStack)
+    {
+        if (itemStack == null)
+        {
+            return null;
+        }
+
+        // check for capability
+        if (itemStack.hasCapability(CapabilityIngredientHandler.INGREDIENT_HANDLER_CAPABILITY, null))
+        {
+            return itemStack.getCapability(CapabilityIngredientHandler.INGREDIENT_HANDLER_CAPABILITY, null);
+        }
+        return null;
+    }
+
+    /**
+     * Helper method to get the ingredient contained in an itemStack
+     */
+    @Nullable
+    public static IngredientStack getIngredientContained(ItemStack container)
+    {
+        if (container != null)
+        {
+            container = container.copy();
+            container.stackSize = 1;
+            IIngredientHandler ingredientHandler = IngredientUtil.getIngredientHandler(container);
+
+            if (ingredientHandler != null)
+            {
+                return ingredientHandler.remove(Integer.MAX_VALUE, false);
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Helper method to get an IIngredientHandler for at a block position.
+     *
+     * Returns null if there is no valid ingredient handler.
+     */
+    @Nullable
+    public static IIngredientHandler getIngredientHandler(World world, BlockPos blockPos, @Nullable EnumFacing side)
+    {
+        IBlockState state = world.getBlockState(blockPos);
+        Block block = state.getBlock();
+
+        if (block.hasTileEntity(state))
+        {
+            TileEntity tileEntity = world.getTileEntity(blockPos);
+            if (tileEntity != null && tileEntity.hasCapability(CapabilityIngredientHandler.INGREDIENT_HANDLER_CAPABILITY, side))
+            {
+                return tileEntity.getCapability(CapabilityIngredientHandler.INGREDIENT_HANDLER_CAPABILITY, side);
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Tries to place an ingredient in the world in block form.
+     * Makes an ingredient removing sound when it is successful.
+     *
+     * Modeled after {@link net.minecraft.item.ItemBucket#tryPlaceContainedLiquid(EntityPlayer, World, BlockPos)}
+     *
+     * @param player     Player who places the ingredient. May be null for blocks like dispensers.
+     * @param worldIn    World to place the ingredient in
+     * @param ingredientStack The ingredientStack to place.
+     * @param pos        The position in the world to place the ingredient block
+     * @return true if successful
+     */
+    public static boolean tryPlaceIngredient(@Nullable EntityPlayer player, World worldIn, IngredientStack ingredientStack, BlockPos pos)
+    {
+        if (worldIn == null || ingredientStack == null || pos == null)
+        {
+            return false;
+        }
+        Ingredient ingredient = ingredientStack.getIngredient();
+
+        if (ingredient == null || !ingredient.canBePlacedInWorld())
+        {
+            return false;
+        }
+        // check that we can place the ingredient at the destination
+        IBlockState destBlockState = worldIn.getBlockState(pos);
+        boolean isDestReplaceable = destBlockState.getBlock().isReplaceable(worldIn, pos);
+
+        if (!worldIn.isAirBlock(pos) && !isDestReplaceable)
+        {
+            return false; // Non-air, irreplacable block. We can't put ingredient here.
+        }
+        SoundEvent soundevent = ingredient.getRemovedSound(ingredientStack);
+        worldIn.playSound(player, pos, soundevent, SoundCategory.BLOCKS, 1.0F, 1.0F);
+        IBlockState ingredientBlockState = ingredient.getBlock().getDefaultState();
+        worldIn.setBlockState(pos, ingredientBlockState, 11);
+        return true;
+    }
+
+    /**
+     * Attempts to pick up an ingredient in the world and put it in an empty container item.
+     *
+     * @param emptyContainer The empty container to add. Will not be modified.
+     * @param playerIn       The player adding the container. Optional.
+     * @param worldIn        The world the ingredient is in.
+     * @param pos            The position of the ingredient in the world.
+     * @param side           The side of the ingredient that is being removeed.
+     * @return a added container if it was successful. returns null on failure.
+     */
+    @Nullable
+    public static ItemStack tryPickUpIngredient(ItemStack emptyContainer, @Nullable EntityPlayer playerIn, World worldIn, BlockPos pos, EnumFacing side)
+    {
+        if (emptyContainer == null || worldIn == null || pos == null) {
+            return null;
+        }
+        IIngredientHandler targetIngredientHandler = IngredientUtil.getIngredientHandler(worldIn, pos, side);
+
+        if (targetIngredientHandler != null)
+        {
+            return IngredientUtil.tryFillContainer(emptyContainer, targetIngredientHandler, Integer.MAX_VALUE, playerIn, true);
+        }
+        return null;
+    }
+
+}

--- a/src/main/java/net/minecraftforge/ingredients/capability/CapabilityIngredientHandler.java
+++ b/src/main/java/net/minecraftforge/ingredients/capability/CapabilityIngredientHandler.java
@@ -1,0 +1,65 @@
+package net.minecraftforge.ingredients.capability;
+
+import net.minecraft.nbt.NBTBase;
+import net.minecraft.nbt.NBTTagCompound;
+import net.minecraft.util.EnumFacing;
+import net.minecraftforge.common.capabilities.Capability;
+import net.minecraftforge.common.capabilities.CapabilityInject;
+import net.minecraftforge.common.capabilities.CapabilityManager;
+import net.minecraftforge.ingredients.IIngredientSource;
+import net.minecraftforge.ingredients.Ingredient;
+import net.minecraftforge.ingredients.IngredientSource;
+import net.minecraftforge.ingredients.IngredientStack;
+
+import java.util.concurrent.Callable;
+
+public class CapabilityIngredientHandler
+{
+    @CapabilityInject(IIngredientHandler.class)
+    public static Capability<IIngredientHandler> INGREDIENT_HANDLER_CAPABILITY = null;
+
+    public static void register()
+    {
+        CapabilityManager.INSTANCE.register(IIngredientHandler.class, new Capability.IStorage<IIngredientHandler>()
+        {
+            @Override
+            public NBTBase writeNBT(Capability<IIngredientHandler> capability, IIngredientHandler instance, EnumFacing side)
+            {
+                if(!(instance instanceof IIngredientSource))
+                    throw new RuntimeException("IIngredientHandler does not implement IIngredientSource");
+                NBTTagCompound nbt = new NBTTagCompound();
+                IIngredientSource source = (IIngredientSource) instance;
+                IngredientStack stack = source.getIngredient();
+                if(stack != null)
+                {
+                    stack.writeToNBT(nbt);
+                }
+                else
+                {
+                    nbt.setString("Empty", "");
+                }
+                nbt.setInteger("Capacity", source.getCapacity());
+                return nbt;
+            }
+
+            @Override
+            public void readNBT(Capability<IIngredientHandler> capability, IIngredientHandler instance, EnumFacing side, NBTBase nbt)
+            {
+                if(!(instance instanceof IIngredientSource))
+                    throw new RuntimeException("IIngredientHandler is not an instance of IngredientSource");
+                NBTTagCompound tags = (NBTTagCompound) nbt;
+                IngredientSource source = (IngredientSource) instance;
+                source.setCapacity(tags.getInteger("Capacity"));
+                source.readFromNBT(tags);
+            }
+        }, new Callable<IIngredientHandler>()
+        {
+
+            @Override
+            public IIngredientHandler call() throws Exception {
+                return new IngredientSource(Ingredient.FULL_BLOCK_VOLUME);
+            }
+        });
+    }
+
+}

--- a/src/main/java/net/minecraftforge/ingredients/capability/IIngredientHandler.java
+++ b/src/main/java/net/minecraftforge/ingredients/capability/IIngredientHandler.java
@@ -1,0 +1,68 @@
+package net.minecraftforge.ingredients.capability;
+
+import net.minecraftforge.ingredients.IngredientSourceInfo;
+import net.minecraftforge.ingredients.IngredientStack;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+/**
+ * Implement this interface as a capability which should handle ingredients, generally storing
+ * the IngredientStacks and providing them on demand
+ * */
+public interface IIngredientHandler
+{
+
+    /**
+     * Returns an array of objects which represent the internal sources.
+     * These objects cannot be sued to manipulate the internal sources.
+     *
+     * @return Properties for the relevant internal sources.
+     * */
+    IIngredientSourceProperties[] getContainerProperties();
+
+    /**
+     * Adds an ingredient into the internal source. Distribution is up to the IIngredientHandler.
+     *
+     * @param resource  IngredientStack representing the Ingredient and the maximum amount to be added.
+     * @param doAdd     If false, adding will only be simulated.
+     * @return The amount of resource that was (or would have been if simulated) added.
+     */
+    int add(IngredientStack resource, boolean doAdd);
+
+    /**
+     * Removes a given ingredient from the internal source. Distribution is up to the IIngredientHandler.
+     *
+     * @param resource  IngredientStack representing the Ingredient and the maximum amount to be removed.
+     * @param doRemove     If false, adding will only be simulated.
+     * @return IngredientStack representing the Ingredient and the amount that was (or would have been if
+     * simulated) removed.
+     */
+    @Nullable
+    IngredientStack remove(IngredientStack resource, boolean doRemove);
+
+    /**
+     * Removes a given ingredient from the internal source. Distribution is up to the IIngredientHandler.
+     * <p/>
+     * This method is not Ingredient-Sensitive.
+     *
+     * @param maxRemoved   The maximum amount of ingredient(s) to be removed;
+     * @param doRemove     If false, adding will only be simulated.
+     * @return IngredientStack representing the Ingredient and the amount that was (or would have been if
+     * simulated) removed.
+     */
+    @Nullable
+    IngredientStack remove(int maxRemoved, boolean doRemove);
+
+    /**
+     * Returns information on the 'main' ingredient to be gleened from the source.
+     * This is the resource that is typically the most valuable.
+     * <p/>
+     * As an example, ore blocks provide the ore itself as their primary source.
+     * <p/>
+     * If no IngredientStack is available for the SourceInfo, then provide info on
+     * the the container.
+     * **/
+    @Nonnull
+    IngredientSourceProperties getPrimarySourceIngredient();
+}

--- a/src/main/java/net/minecraftforge/ingredients/capability/IIngredientSourceProperties.java
+++ b/src/main/java/net/minecraftforge/ingredients/capability/IIngredientSourceProperties.java
@@ -1,0 +1,66 @@
+package net.minecraftforge.ingredients.capability;
+
+import net.minecraftforge.ingredients.IngredientStack;
+
+import javax.annotation.Nullable;
+
+/**
+ * Simplified Read-only Information about the internals of an {@link IIngredientHandler}.
+ * This is useful for displaying information, and as hints for interacting with it.
+ * These properties are constant and do not depend on the ingredients contents (except the contents themselves, of course).
+ *
+ * The information here may not tell the full story of how the source actually works,
+ * for real ingredient transactions you must use {@link IIngredientHandler} to simulate, check, and then interact.
+ * None of the information in these properties is required to successfully interact using an {@link IIngredientHandler}.
+ */
+public interface IIngredientSourceProperties
+{
+
+    /**
+     * @return A copy of the ingredient contents of this source. May be null;
+     * To modify the contents use {@link IIngredientHandler}
+     */
+    @Nullable
+    IngredientStack getContents();
+
+    /**
+     * @return the maximum volume of an ingredient this source can hold, in milliblocks
+     * */
+    int getCapacity();
+
+    /**
+     * Returns true if the source can be added to at any time, regardless of whether it is full.
+     * This does not consider the contents of capacity of the source.
+     *
+     * This value is constant. If the source's behavior is more complicated, return true;
+     * */
+    boolean canAdd();
+
+    /**
+     * Returns true if the source can have its contents taken at any time, regardless of whether it is empty.
+     * This does not consider the contents or capacaity of this source.
+     *
+     * This value is constant. If the source's behavior is more complicated, return true.
+     * */
+    boolean canRemove();
+
+    /**
+     * Returns true if the source can have a particular ingredient added to it.
+     * Use as a filter for ingredients.
+     *
+     * Does not consider the current contents, nor the capacity of the source.
+     * {@link IngredientStack} is used because the material state, refinement level, and tag data may be intrinsic
+     * to the ingredient's properties.
+     * */
+    boolean canAddIngredientType(IngredientStack stack);
+
+    /**
+     * Returns true if the source can have a particular ingredient added to it.
+     * Use as a filter for ingredients.
+     *
+     * Does not consider the current contents, nor the capacity of the source.
+     * {@link IngredientStack} is used because the material state, refinement level, and tag data may be intrinsic
+     * to the ingredient's properties.
+     * */
+    boolean canRemoveIngredientType(IngredientStack stack);
+}

--- a/src/main/java/net/minecraftforge/ingredients/capability/IngredientSourceProperties.java
+++ b/src/main/java/net/minecraftforge/ingredients/capability/IngredientSourceProperties.java
@@ -1,0 +1,85 @@
+package net.minecraftforge.ingredients.capability;
+
+import net.minecraftforge.ingredients.IngredientSourceInfo;
+import net.minecraftforge.ingredients.IngredientStack;
+
+import javax.annotation.Nullable;
+
+/**
+ * Basic implementation of {@link IIngredientSourceProperties}
+ * */
+public class IngredientSourceProperties implements IIngredientSourceProperties
+{
+    @Nullable
+    private final IngredientStack contents;
+    private final int capacity;
+    private final boolean canAdd;
+    private final boolean canRemove;
+
+    public IngredientSourceProperties(@Nullable IngredientStack contents, int capacity, boolean canAdd, boolean canRemove)
+    {
+        this.contents = contents;
+        this.capacity = capacity;
+        this.canAdd = canAdd;
+        this.canRemove = canRemove;
+    }
+
+    @Nullable
+    @Override
+    public IngredientStack getContents()
+    {
+        return contents == null ? null : contents.copy();
+    }
+
+    @Override
+    public int getCapacity()
+    {
+        return capacity;
+    }
+
+    @Override
+    public boolean canAdd()
+    {
+        return canAdd;
+    }
+
+    @Override
+    public boolean canRemove()
+    {
+        return canRemove;
+    }
+
+    @Override
+    public boolean canAddIngredientType(IngredientStack stack)
+    {
+        return canAdd();
+    }
+
+    @Override
+    public boolean canRemoveIngredientType(IngredientStack stack)
+    {
+        return canRemove();
+    }
+
+    /**
+     * Converts the source info to source properties.
+     *
+     * @param mutable
+     *          If true the properties will return true for {@link IIngredientSourceProperties#canAdd()}
+     *          and {@link IngredientSourceProperties#canRemove()}
+     * @param infos
+     *          The {@link IngredientSourceInfo} to be converted.
+     * @return An array of {@link IngredientSourceProperties}
+     * */
+    public static IngredientSourceProperties[] convert(boolean mutable, IngredientSourceInfo... infos)
+    {
+        IngredientSourceProperties[] props = new IngredientSourceProperties[infos.length];
+        for(int i = 0; i < props.length; i++)
+        {
+            IngredientSourceInfo info = infos[i];
+            props[i] = new IngredientSourceProperties(info.ingredient, info.capacity, mutable, mutable);
+        }
+        return props;
+    }
+
+}

--- a/src/main/java/net/minecraftforge/ingredients/capability/IngredientSourcePropertiesWrapper.java
+++ b/src/main/java/net/minecraftforge/ingredients/capability/IngredientSourcePropertiesWrapper.java
@@ -1,0 +1,57 @@
+package net.minecraftforge.ingredients.capability;
+
+import net.minecraftforge.ingredients.IngredientSource;
+import net.minecraftforge.ingredients.IngredientStack;
+
+import javax.annotation.Nullable;
+
+/**
+ * Base {@link IIngredientSourceProperties} wrapper for {@link IngredientSource}
+ * */
+public class IngredientSourcePropertiesWrapper implements IIngredientSourceProperties
+{
+    protected IngredientSource source;
+
+    public IngredientSourcePropertiesWrapper(IngredientSource ingredientSource)
+    {
+        source = ingredientSource;
+    }
+
+    @Nullable
+    @Override
+    public IngredientStack getContents()
+    {
+        IngredientStack stack = source.getIngredient();
+        return stack == null ? null : stack.copy();
+    }
+
+    @Override
+    public int getCapacity()
+    {
+        return source.getCapacity();
+    }
+
+    @Override
+    public boolean canAdd()
+    {
+        return source.canAdd();
+    }
+
+    @Override
+    public boolean canRemove()
+    {
+        return source.canRemove();
+    }
+
+    @Override
+    public boolean canAddIngredientType(IngredientStack stack)
+    {
+        return source.canAddIngredientType(stack);
+    }
+
+    @Override
+    public boolean canRemoveIngredientType(IngredientStack stack)
+    {
+        return source.canRemoveIngredientType(stack);
+    }
+}

--- a/src/main/java/net/minecraftforge/ingredients/capability/ItemIngredientContainer.java
+++ b/src/main/java/net/minecraftforge/ingredients/capability/ItemIngredientContainer.java
@@ -1,0 +1,33 @@
+package net.minecraftforge.ingredients.capability;
+
+import net.minecraft.item.Item;
+import net.minecraft.item.ItemStack;
+import net.minecraft.nbt.NBTTagCompound;
+import net.minecraftforge.common.capabilities.ICapabilityProvider;
+import net.minecraftforge.ingredients.capability.templates.IngredientHandlerItemStack;
+
+/**
+ * A simple ingredient container to mimic the functionality of
+ * {@link net.minecraftforge.fluids.capability.ItemFluidContainer}
+ * This container may be set so it can only be completely filled or empty.
+ * It also may be set to be consumed when emptied.
+ * */
+public class ItemIngredientContainer extends Item
+{
+    protected final int capacity;
+
+    /***
+     * @param capacity
+     *      The maximum capacity of the container
+     */
+    public ItemIngredientContainer(int capacity)
+    {
+        this.capacity = capacity;
+    }
+
+    @Override
+    public ICapabilityProvider initCapabilities(ItemStack stack, NBTTagCompound nbt)
+    {
+        return new IngredientHandlerItemStack(stack, capacity);
+    }
+}

--- a/src/main/java/net/minecraftforge/ingredients/capability/templates/IngredientHandlerItemStack.java
+++ b/src/main/java/net/minecraftforge/ingredients/capability/templates/IngredientHandlerItemStack.java
@@ -1,0 +1,252 @@
+package net.minecraftforge.ingredients.capability.templates;
+
+import net.minecraft.item.ItemStack;
+import net.minecraft.nbt.NBTTagCompound;
+import net.minecraft.util.EnumFacing;
+import net.minecraftforge.common.capabilities.Capability;
+import net.minecraftforge.common.capabilities.ICapabilityProvider;
+import net.minecraftforge.ingredients.IngredientStack;
+import net.minecraftforge.ingredients.capability.CapabilityIngredientHandler;
+import net.minecraftforge.ingredients.capability.IIngredientHandler;
+import net.minecraftforge.ingredients.capability.IIngredientSourceProperties;
+import net.minecraftforge.ingredients.capability.IngredientSourceProperties;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+/**
+ * IngredientHandlerItemStack is a template capability provider for ItemStacks.
+ *
+ * This class allows an itemStack to contain any partial level of an ingredient up to its capacity, unlike {@link IngredientHandlerItemStackSimple}
+ *
+ * Additional examples are provided to enable consumable fluid containers (see {@link Consumable}),
+ * fluid containers with different empty and full items (see {@link SwapEmpty},
+ */
+public class IngredientHandlerItemStack implements IIngredientHandler, ICapabilityProvider
+{
+
+    public static final String INGREDIENT_NBT_KEY = "Ingredient";
+    
+    protected final ItemStack container;
+    protected final int capacity;
+    protected boolean addable = true;
+    protected boolean removable = true;
+
+    /**
+     * @param container  The container itemStack, data is stored on it directly as NBT.
+     * @param capacity   The maximum capacity of this fluid tank.
+     */
+    public IngredientHandlerItemStack(ItemStack container, int capacity)
+    {
+        this.container = container;
+        this.capacity = capacity;
+    }
+
+    public IngredientHandlerItemStack setCanAdd(boolean canAdd)
+    {
+        addable = canAdd;
+        return this;
+    }
+
+    public IngredientHandlerItemStack setCanRemove(boolean canRemove)
+    {
+        removable = canRemove;
+        return this;
+    }
+
+    @Nullable
+    public IngredientStack getIngredient()
+    {
+        NBTTagCompound tag = container.getTagCompound();
+
+        if(tag == null || !tag.hasKey(INGREDIENT_NBT_KEY))
+        {
+            return null;
+        }
+        return IngredientStack.loadIngredientStackFromNBT(tag.getCompoundTag(INGREDIENT_NBT_KEY));
+    }
+
+    protected void setIngredient(IngredientStack ingredient)
+    {
+        if(!container.hasTagCompound())
+        {
+            container.setTagCompound(new NBTTagCompound());
+        }
+
+        NBTTagCompound tag = new NBTTagCompound();
+        ingredient.writeToNBT(tag);
+        container.getTagCompound().setTag(INGREDIENT_NBT_KEY, tag);
+    }
+
+
+    @Override
+    public IIngredientSourceProperties[] getContainerProperties() {
+        return new IIngredientSourceProperties[]{ new IngredientSourceProperties(getIngredient(), capacity, addable, removable)};
+    }
+
+    @Override
+    public int add(IngredientStack resource, boolean doAdd)
+    {
+        if (container.stackSize != 1 || resource == null || resource.amount <= 0 || !canAddIngredientType(resource))
+        {
+            return 0;
+        }
+        IngredientStack contained = getIngredient();
+
+        if(contained == null)
+        {
+            int add = Math.min(capacity, resource.amount);
+
+            if(doAdd)
+            {
+                IngredientStack added = resource.copy();
+                added.amount = add;
+                setIngredient(added);
+            }
+
+            return add;
+        }
+        else
+        {
+            if(contained.isIngredientEqual(resource))
+            {
+                int add = Math.min(capacity - contained.amount, resource.amount);
+
+                if(doAdd && add > 0)
+                {
+                    contained.amount += add;
+                    setIngredient(contained);
+                }
+                return add;
+            }
+        }
+        return 0;
+    }
+
+    @Nullable
+    @Override
+    public IngredientStack remove(IngredientStack resource, boolean doRemove)
+    {
+        if (container.stackSize != 1 || resource == null || resource.amount <= 0 || !resource.isIngredientEqual(getIngredient()))
+        {
+            return null;
+        }
+        return remove(resource.amount, doRemove);
+    }
+
+    @Nullable
+    @Override
+    public IngredientStack remove(int maxRemoved, boolean doRemove)
+    {
+        if(container.stackSize != 1 || maxRemoved <= 0)
+        {
+            return null;
+        }
+        IngredientStack contained = getIngredient();
+
+        if(contained == null || contained.amount <= 0 || !canRemoveIngredientType(contained))
+        {
+            return null;
+        }
+        final int remove = Math.min(contained.amount, maxRemoved);
+        IngredientStack removed = contained.copy();
+        removed.amount = remove;
+
+        if(doRemove)
+        {
+            contained.amount -= remove;
+
+            if(contained.amount == 0)
+            {
+                setContainerToEmpty();
+            }
+            else
+            {
+                setIngredient(contained);
+            }
+
+            return  removed;
+        }
+
+        return null;
+    }
+
+    public boolean canAddIngredientType(IngredientStack resource)
+    {
+        return addable;
+    }
+
+    public boolean canRemoveIngredientType(IngredientStack resource)
+    {
+        return removable;
+    }
+
+    /**
+     * Override this method for special handling.
+     * Can be used to swap out container's item for a different one with "container.setItem".
+     * Can be used to destroy the container with "container.stackSize--"
+     * */
+    public void setContainerToEmpty()
+    {
+        container.getTagCompound().removeTag(INGREDIENT_NBT_KEY);
+    }
+
+    @Nonnull
+    @Override
+    public IngredientSourceProperties getPrimarySourceIngredient()
+    {
+        return new IngredientSourceProperties(getIngredient(), capacity, addable, removable);
+    }
+
+    @Override
+    public boolean hasCapability(Capability<?> capability, @Nullable EnumFacing facing)
+    {
+        return capability == CapabilityIngredientHandler.INGREDIENT_HANDLER_CAPABILITY;
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public <T> T getCapability(Capability<T> capability, @Nullable EnumFacing facing)
+    {
+        return capability == CapabilityIngredientHandler.INGREDIENT_HANDLER_CAPABILITY ? (T) this : null;
+    }
+
+    /**
+     * Destroys the container when it's empty.
+     * */
+    public static class Consumable extends IngredientHandlerItemStack
+    {
+        public Consumable(ItemStack container, int capacity)
+        {
+            super(container, capacity);
+        }
+
+        @Override
+        public void setContainerToEmpty()
+        {
+            super.setContainerToEmpty();
+            container.stackSize--;
+        }
+    }
+
+    /**
+     * Swaps the container Item for a supplied empty stack.
+     * */
+    public static class SwapEmpty extends IngredientHandlerItemStack
+    {
+        protected final ItemStack emptyContainer;
+
+        public SwapEmpty(ItemStack container, ItemStack emptyContainer, int capacity)
+        {
+            super(container, capacity);
+            this.emptyContainer = emptyContainer;
+        }
+
+        @Override
+        public void setContainerToEmpty()
+        {
+            super.setContainerToEmpty();
+            container.deserializeNBT(emptyContainer.serializeNBT());
+        }
+    }
+}

--- a/src/main/java/net/minecraftforge/ingredients/capability/templates/IngredientHandlerItemStackSimple.java
+++ b/src/main/java/net/minecraftforge/ingredients/capability/templates/IngredientHandlerItemStackSimple.java
@@ -1,0 +1,227 @@
+package net.minecraftforge.ingredients.capability.templates;
+
+import net.minecraft.item.ItemStack;
+import net.minecraft.nbt.NBTTagCompound;
+import net.minecraft.util.EnumFacing;
+import net.minecraftforge.common.capabilities.Capability;
+import net.minecraftforge.common.capabilities.ICapabilityProvider;
+import net.minecraftforge.ingredients.IngredientStack;
+import net.minecraftforge.ingredients.capability.CapabilityIngredientHandler;
+import net.minecraftforge.ingredients.capability.IIngredientHandler;
+import net.minecraftforge.ingredients.capability.IIngredientSourceProperties;
+import net.minecraftforge.ingredients.capability.IngredientSourceProperties;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+/**
+ * IngredientHandlerItemSTackSimple is a template capability provider for ItemStacks
+ * Data is stored directly in the NBT
+ *
+ * This implementation only allows for containers to be completely filled or emptied.
+ * This functionality is the ingredient equivalient to vanilla buckets.
+ * */
+public class IngredientHandlerItemStackSimple implements IIngredientHandler, ICapabilityProvider
+{
+    public static final String INGREDIENT_NBT_KEY = "Ingredient";
+
+    protected final ItemStack container;
+    protected final int capacity;
+    protected boolean addable = true;
+    protected boolean removable = true;
+
+    /**
+     * @param container  The container itemStack, data is stored on it directly as NBT.
+     * @param capacity   The maximum capacity of this fluid tank.
+     */
+    public IngredientHandlerItemStackSimple(ItemStack container, int capacity)
+    {
+        this.container = container;
+        this.capacity = capacity;
+    }
+
+    public IngredientHandlerItemStackSimple setCanAdd(boolean canAdd)
+    {
+        addable = canAdd;
+        return this;
+    }
+
+    public IngredientHandlerItemStackSimple setCanRemove(boolean canRemove)
+    {
+        removable = canRemove;
+        return this;
+    }
+
+    @Nullable
+    public IngredientStack getIngredient()
+    {
+        NBTTagCompound tag = container.getTagCompound();
+
+        if(tag == null || !tag.hasKey(INGREDIENT_NBT_KEY))
+        {
+            return null;
+        }
+        return IngredientStack.loadIngredientStackFromNBT(tag.getCompoundTag(INGREDIENT_NBT_KEY));
+    }
+
+    protected void setIngredient(IngredientStack ingredient)
+    {
+        if(!container.hasTagCompound())
+        {
+            container.setTagCompound(new NBTTagCompound());
+        }
+
+        NBTTagCompound tag = new NBTTagCompound();
+        ingredient.writeToNBT(tag);
+        container.getTagCompound().setTag(INGREDIENT_NBT_KEY, tag);
+    }
+
+    @Override
+    public IIngredientSourceProperties[] getContainerProperties() {
+        return new IIngredientSourceProperties[0];
+    }
+
+    @Override
+    public int add(IngredientStack resource, boolean doAdd)
+    {
+        if (container.stackSize != 1 || resource == null || resource.amount <= 0 || !canAddIngredientType(resource))
+        {
+            return 0;
+        }
+        IngredientStack contained = getIngredient();
+
+        if(contained == null)
+        {
+            int add = Math.min(capacity, resource.amount);
+
+            if(add == capacity)
+            {
+                if (doAdd)
+                {
+                    IngredientStack added = resource.copy();
+                    added.amount = add;
+                    setIngredient(added);
+                }
+                return add;
+            }
+        }
+        return 0;
+    }
+
+    @Nullable
+    @Override
+    public IngredientStack remove(IngredientStack resource, boolean doRemove) {
+        if (container.stackSize != 1 || resource == null || resource.amount <= 0 || !resource.isIngredientEqual(getIngredient()))
+        {
+            return null;
+        }
+        return remove(resource.amount, doRemove);
+    }
+
+    @Nullable
+    @Override
+    public IngredientStack remove(int maxRemoved, boolean doRemove) {
+        if(container.stackSize != 1 || maxRemoved <= 0)
+        {
+            return null;
+        }
+        IngredientStack contained = getIngredient();
+
+        if(contained == null || contained.amount <= 0 || !canRemoveIngredientType(contained))
+        {
+            return null;
+        }
+        final int remove = Math.min(contained.amount, maxRemoved);
+
+        if(remove == capacity)
+        {
+            IngredientStack removed = contained.copy();
+
+            if (doRemove)
+            {
+                setContainerToEmpty();
+            }
+            return removed;
+        }
+        return null;
+    }
+
+    @Nonnull
+    @Override
+    public IngredientSourceProperties getPrimarySourceIngredient() {
+        return new IngredientSourceProperties(getIngredient(), capacity, addable, removable);
+    }
+
+    public boolean canAddIngredientType(IngredientStack resource)
+    {
+        return addable;
+    }
+
+    public boolean canRemoveIngredientType(IngredientStack resource)
+    {
+        return removable;
+    }
+
+    /**
+     * Override this method for special handling.
+     * Can be used to swap out container's item for a different one with "container.setItem".
+     * Can be used to destroy the container with "container.stackSize--"
+     * */
+    public void setContainerToEmpty()
+    {
+        container.getTagCompound().removeTag(INGREDIENT_NBT_KEY);
+    }
+
+
+    @Override
+    public boolean hasCapability(Capability<?> capability, @Nullable EnumFacing facing)
+    {
+        return capability == CapabilityIngredientHandler.INGREDIENT_HANDLER_CAPABILITY;
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public <T> T getCapability(Capability<T> capability, @Nullable EnumFacing facing)
+    {
+        return capability == CapabilityIngredientHandler.INGREDIENT_HANDLER_CAPABILITY ? (T) this : null;
+    }
+
+    /**
+     * Destroys the container when it's empty.
+     * */
+    public static class Consumable extends IngredientHandlerItemStackSimple
+    {
+        public Consumable(ItemStack container, int capacity)
+        {
+            super(container, capacity);
+        }
+
+        @Override
+        public void setContainerToEmpty()
+        {
+            super.setContainerToEmpty();
+            container.stackSize--;
+        }
+    }
+
+    /**
+     * Swaps the container Item for a supplied empty stack.
+     * */
+    public static class SwapEmpty extends IngredientHandlerItemStackSimple
+    {
+        protected final ItemStack emptyContainer;
+
+        public SwapEmpty(ItemStack container, ItemStack emptyContainer, int capacity)
+        {
+            super(container, capacity);
+            this.emptyContainer = emptyContainer;
+        }
+
+        @Override
+        public void setContainerToEmpty()
+        {
+            super.setContainerToEmpty();
+            container.deserializeNBT(emptyContainer.serializeNBT());
+        }
+    }
+}

--- a/src/main/java/net/minecraftforge/ingredients/capability/wrappers/VanillaIngredientCapabilityInjector.java
+++ b/src/main/java/net/minecraftforge/ingredients/capability/wrappers/VanillaIngredientCapabilityInjector.java
@@ -16,7 +16,7 @@ import javax.annotation.Nullable;
 
 public final class VanillaIngredientCapabilityInjector
 {
-    public static final ResourceLocation ResourceHandle = new ResourceLocation(ForgeModContainer.getInstance().getModId(), "ingredient");
+    public static final ResourceLocation ResourceHandle = new ResourceLocation("forge", "ingredient");
 
     private static final Item ironOre;
     private static final Item ironBlock;
@@ -24,6 +24,8 @@ public final class VanillaIngredientCapabilityInjector
     private static final Item goldBlock;
     private static final Item diamondOre;
     private static final Item diamondBlock;
+    private static final Item coalBlock;
+    private static final Item coalOre;
 
     static
     {
@@ -34,6 +36,8 @@ public final class VanillaIngredientCapabilityInjector
         goldBlock = map.get(Blocks.GOLD_BLOCK);
         diamondBlock = map.get(Blocks.DIAMOND_BLOCK);
         diamondOre = map.get(Blocks.DIAMOND_ORE);
+        coalBlock = map.get(Blocks.COAL_BLOCK);
+        coalOre = map.get(Blocks.COAL_ORE);
     }
 
     private VanillaIngredientCapabilityInjector()
@@ -89,5 +93,10 @@ public final class VanillaIngredientCapabilityInjector
             return new WrapperPureItem(stack, new IngredientStack(IngredientRegistry.DIAMOND, Ingredient.FULL_BLOCK_VOLUME, EnumRefinementLevel.REFINED));
         }
         return null;
+    }
+
+    public static ICapabilityProvider getCoalWrapper(ItemStack stack)
+    {
+        return stack != null ? new WrapperPureItem(stack, new IngredientStack(stack.getMetadata() == 0 ? IngredientRegistry.COAL : IngredientRegistry.CHARCOAL, Ingredient.ORE_VOLUME, EnumRefinementLevel.REFINED)) : null;
     }
 }

--- a/src/main/java/net/minecraftforge/ingredients/capability/wrappers/VanillaIngredientCapabilityInjector.java
+++ b/src/main/java/net/minecraftforge/ingredients/capability/wrappers/VanillaIngredientCapabilityInjector.java
@@ -1,0 +1,93 @@
+package net.minecraftforge.ingredients.capability.wrappers;
+
+import com.google.common.collect.BiMap;
+import net.minecraft.block.Block;
+import net.minecraft.init.Blocks;
+import net.minecraft.init.Items;
+import net.minecraft.item.Item;
+import net.minecraft.item.ItemStack;
+import net.minecraft.util.ResourceLocation;
+import net.minecraftforge.common.ForgeModContainer;
+import net.minecraftforge.common.capabilities.ICapabilityProvider;
+import net.minecraftforge.fml.common.registry.GameData;
+import net.minecraftforge.ingredients.*;
+
+import javax.annotation.Nullable;
+
+public final class VanillaIngredientCapabilityInjector
+{
+    public static final ResourceLocation ResourceHandle = new ResourceLocation(ForgeModContainer.getInstance().getModId(), "ingredient");
+
+    private static final Item ironOre;
+    private static final Item ironBlock;
+    private static final Item goldOre;
+    private static final Item goldBlock;
+    private static final Item diamondOre;
+    private static final Item diamondBlock;
+
+    static
+    {
+        BiMap<Block, Item> map = GameData.getBlockItemMap();
+        ironOre = map.get(Blocks.IRON_ORE);
+        ironBlock = map.get(Blocks.IRON_BLOCK);
+        goldOre = map.get(Blocks.GOLD_ORE);
+        goldBlock = map.get(Blocks.GOLD_BLOCK);
+        diamondBlock = map.get(Blocks.DIAMOND_BLOCK);
+        diamondOre = map.get(Blocks.DIAMOND_ORE);
+    }
+
+    private VanillaIngredientCapabilityInjector()
+    {
+    }
+
+    /**
+     * Injects vanilla Items with the necessary ingredient capability.
+     * <p/>
+     * Necessary because many needed items do not have their own unique class.
+     * */
+    @Nullable
+    public static ICapabilityProvider getWrapperForItem(Item item, ItemStack stack)
+    {
+        if(item == Items.DIAMOND)
+        {
+            return new WrapperPureItem(stack, new IngredientStack(IngredientRegistry.DIAMOND, Ingredient.ORE_VOLUME, EnumRefinementLevel.REFINED));
+        }
+        if(item == Items.IRON_INGOT)
+        {
+            return new WrapperPureItem(stack, new IngredientStack(IngredientRegistry.IRON, Ingredient.ORE_VOLUME));
+        }
+        if(item == Items.GOLD_INGOT)
+        {
+            return new WrapperPureItem(stack, new IngredientStack(IngredientRegistry.GOLD, Ingredient.ORE_VOLUME));
+        }
+        if(item == Items.GOLD_NUGGET)
+        {
+            return new WrapperPureItem(stack, new IngredientStack(IngredientRegistry.GOLD, Ingredient.NUGGET_VOLUME));
+        }
+        if(item == ironOre)
+        {
+            return new WrapperOreBlock(stack, IngredientRegistry.IRON, IngredientRegistry.STONE);
+        }
+        if(item == ironBlock)
+        {
+            return new WrapperPureItem(stack, new IngredientStack(IngredientRegistry.IRON, Ingredient.FULL_BLOCK_VOLUME, EnumRefinementLevel.REFINED));
+        }
+        if(item == goldOre)
+        {
+            return new WrapperOreBlock(stack, IngredientRegistry.GOLD, IngredientRegistry.STONE);
+        }
+        if(item == goldBlock)
+        {
+            return new WrapperPureItem(stack, new IngredientStack(IngredientRegistry.GOLD, Ingredient.FULL_BLOCK_VOLUME, EnumRefinementLevel.REFINED));
+        }
+        if(item == diamondOre)
+        {
+            return new WrapperOreBlock(stack, IngredientRegistry.DIAMOND, IngredientRegistry.STONE);
+        }
+        if(item == diamondBlock)
+        {
+            return new WrapperPureItem(stack, new IngredientStack(IngredientRegistry.DIAMOND, Ingredient.FULL_BLOCK_VOLUME, EnumRefinementLevel.REFINED));
+        }
+        return null;
+    }
+}

--- a/src/main/java/net/minecraftforge/ingredients/capability/wrappers/WrapperOreBlock.java
+++ b/src/main/java/net/minecraftforge/ingredients/capability/wrappers/WrapperOreBlock.java
@@ -1,0 +1,147 @@
+package net.minecraftforge.ingredients.capability.wrappers;
+
+import net.minecraft.item.ItemStack;
+import net.minecraft.util.EnumFacing;
+import net.minecraftforge.common.capabilities.Capability;
+import net.minecraftforge.common.capabilities.ICapabilityProvider;
+import net.minecraftforge.ingredients.Ingredient;
+import net.minecraftforge.ingredients.IngredientStack;
+import net.minecraftforge.ingredients.capability.CapabilityIngredientHandler;
+import net.minecraftforge.ingredients.capability.IIngredientHandler;
+import net.minecraftforge.ingredients.capability.IIngredientSourceProperties;
+import net.minecraftforge.ingredients.capability.IngredientSourceProperties;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+/**
+ * Wrapper for vanilla ore blocks
+ * */
+public class WrapperOreBlock implements IIngredientHandler, ICapabilityProvider
+{
+    protected final ItemStack source;
+
+    protected final IngredientStack base;
+
+    protected final IngredientStack ore;
+
+    public WrapperOreBlock(ItemStack source, Ingredient ore, Ingredient base)
+    {
+        this.source = source;
+        this.ore = new IngredientStack(ore, Ingredient.ORE_VOLUME);
+        this.base = new IngredientStack(base, Ingredient.ORE_VOLUME_BASE);
+    }
+
+    @Override
+    public IIngredientSourceProperties[] getContainerProperties()
+    {
+        return new IIngredientSourceProperties[]{ new IngredientSourceProperties(ore, ore.amount, false, true), new IngredientSourceProperties(base, base.amount, false, true)};
+    }
+
+    @Override
+    public int add(IngredientStack resource, boolean doAdd)
+    {
+        return 0; //Immutable so always 0
+    }
+
+    @Nullable
+    @Override
+    public IngredientStack remove(IngredientStack resource, boolean doRemove)
+    {
+        if(source.stackSize < 1 || resource == null || resource.amount < 1)
+        {
+            return null;
+        }
+
+        if(ore.isIngredientEqual(resource))
+        {
+            int loss = ore.amount * source.stackSize;
+
+            if(resource.amount < loss)
+            {
+                loss = resource.amount;
+            }
+
+            if(doRemove)
+            {
+                //Cieling the remainder away so that the stack is consumed for the overages.
+                source.stackSize -= Math.ceil(ore.amount / loss);
+            }
+
+            return new IngredientStack(ore, loss);
+        }
+
+        if(base.isIngredientEqual(resource))
+        {
+            int loss = base.amount * source.stackSize;
+
+            if(resource.amount < loss)
+            {
+                loss = resource.amount;
+            }
+
+            if(doRemove)
+            {
+                //Ceiling the remainder away so that the stack is consumed for the overages.
+                source.stackSize -= Math.ceil(base.amount / loss);
+            }
+
+            return new IngredientStack(base, loss);
+        }
+
+        return null;
+    }
+
+    @Nullable
+    @Override
+    public IngredientStack remove(int maxRemoved, boolean doRemove)
+    {
+        if(source.stackSize < 1 || maxRemoved < 1)
+        {
+            return null;
+        }
+        IngredientStack primary = getPrimarySourceIngredient().getContents();
+
+        if(primary == null)
+        {
+            return null;
+        }
+        int loss = primary.amount * source.stackSize;
+
+        if(maxRemoved < loss)
+        {
+            loss = maxRemoved;
+        }
+
+        if(doRemove)
+        {
+            //Ceiling the remainder away so that the stack is consumed for the overages.
+            source.stackSize -= Math.ceil(primary.amount / loss);
+        }
+        return new IngredientStack(primary, loss);
+    }
+
+    @Nonnull
+    @Override
+    public IngredientSourceProperties getPrimarySourceIngredient()
+    {
+        //The ore component is always the 'primary' source
+        return new IngredientSourceProperties(ore, ore.amount, false, true);
+    }
+
+    @Override
+    public boolean hasCapability(Capability<?> capability, @Nullable EnumFacing facing)
+    {
+        return capability == CapabilityIngredientHandler.INGREDIENT_HANDLER_CAPABILITY;
+    }
+
+    @Override
+    public <T> T getCapability(Capability<T> capability, @Nullable EnumFacing facing)
+    {
+        if(capability == CapabilityIngredientHandler.INGREDIENT_HANDLER_CAPABILITY)
+        {
+            return CapabilityIngredientHandler.INGREDIENT_HANDLER_CAPABILITY.cast(this);
+        }
+        return null;
+    }
+}

--- a/src/main/java/net/minecraftforge/ingredients/capability/wrappers/WrapperPureItem.java
+++ b/src/main/java/net/minecraftforge/ingredients/capability/wrappers/WrapperPureItem.java
@@ -1,0 +1,15 @@
+package net.minecraftforge.ingredients.capability.wrappers;
+
+import net.minecraft.item.ItemStack;
+import net.minecraftforge.ingredients.IngredientStack;
+import net.minecraftforge.ingredients.capability.templates.IngredientHandlerItemStackSimple;
+
+public class WrapperPureItem extends IngredientHandlerItemStackSimple.Consumable
+{
+    public WrapperPureItem(ItemStack container, IngredientStack stack)
+    {
+        super(container, stack.amount);
+        setIngredient(stack);
+        setCanAdd(false);
+    }
+}


### PR DESCRIPTION
# **Not a finished PR**

_Opening this purely to encourage input and discussion on this topic. At this point it's still in early development. Please note that as of now that a lot of the code is directly ported from the Fluid implementation. Any and all input is welcome, so tear it apart._

I've been fleshing out an idea for a back end to compliment the ore dictionary with the intent to help mods communicate the composition behind a given ItemStack. This system allows the registration of materials as 'ingredients' which carry various artifacts pertaining to the material's states. There currently is an issue with how it's implemented, as attaching capabilities per ItemStack ~~may~~ _will_ be haphazard with the number of ingredient definitions that are needed.
### The goal of this is to allow the following:
- More robust methods for mods that wish to break down materials to do so. Attached volumes allows for what otherwise would be verbosely supported to be dynamically supported.
- Improved sorting of materials. This should aid in determining where ItemStacks should be stored, given the composition can now be easily rendered. Ingredient identifiers allow for a mod to check an ingredient for identifiers such as 'mineable', 'metal', 'crystal', etc to sort and store accordingly.
- Ability to more verbosely validate equality between items. This is especially pertinent to things with ambiguously quantitative strings as their handle, such as 'dust', 'shards', 'ball' etc.
- New recipe implementations, allowing for the ability to require more finite amounts of materials in various states.
