### PR TITLE
Fix Dispensers with buckets can destroy fluid handler blocks

### DIFF
--- a/src/main/java/net/minecraftforge/fluids/DispenseFluidContainer.java
+++ b/src/main/java/net/minecraftforge/fluids/DispenseFluidContainer.java
@@ -72,8 +72,6 @@ public class DispenseFluidContainer extends BehaviorDefaultDispenseItem
             return super.dispenseStack(source, stack);
         }
 
-        world.setBlockToAir(blockpos);
-
         if (--stack.stackSize == 0)
         {
             stack.deserializeNBT(result.serializeNBT());

--- a/src/main/java/net/minecraftforge/fluids/FluidUtil.java
+++ b/src/main/java/net/minecraftforge/fluids/FluidUtil.java
@@ -495,10 +495,16 @@ public class FluidUtil
             return null;
         }
 
-        IFluidHandler targetFluidHandler = FluidUtil.getFluidHandler(worldIn, pos, side);
-        if (targetFluidHandler != null)
+        IBlockState state = worldIn.getBlockState(pos);
+        Block block = state.getBlock();
+
+        if (block instanceof IFluidBlock || block instanceof BlockLiquid)
         {
-            return FluidUtil.tryFillContainer(emptyContainer, targetFluidHandler, Integer.MAX_VALUE, playerIn, true);
+            IFluidHandler targetFluidHandler = FluidUtil.getFluidHandler(worldIn, pos, side);
+            if (targetFluidHandler != null)
+            {
+                return FluidUtil.tryFillContainer(emptyContainer, targetFluidHandler, Integer.MAX_VALUE, playerIn, true);
+            }
         }
         return null;
     }


### PR DESCRIPTION
Fixes issue #3165

This makes `FluidUtil.tryPickUpFluid` only pick up fluid blocks, not fluid from tanks or other fluid handlers. This is the original intention of the method, as described in the javadoc.

It also makes it so that `DispenseFluidContainer` does not set the block to air. That is already done in the fluid handlers for fluid blocks.
