### PR TITLE
Propagate diffuse lighting flag in UnpackedBakedQuad.pipe

### DIFF
--- a/src/main/java/net/minecraftforge/client/model/pipeline/UnpackedBakedQuad.java
+++ b/src/main/java/net/minecraftforge/client/model/pipeline/UnpackedBakedQuad.java
@@ -74,6 +74,7 @@ public class UnpackedBakedQuad extends BakedQuad
         {
             // catch missing method errors caused by change to IVertexConsumer
         }
+        consumer.setApplyDiffuseLighting(applyDiffuseLighting);
         consumer.setQuadOrientation(getFace());
         for(int v = 0; v < 4; v++)
         {


### PR DESCRIPTION
Unlike BakedQuad.pipe, UnpackedBakedQuad.pipe does not pipe the applyDiffuseLighting flag into the vertex consumer. While this behavior is not actually used in forge itself, any mod trying to disable the flag in the UnpackedBakedQuad.Builder might run into trouble.

Regarding current VertexConsumers and how this change might affect them:
The only class that actually consumes the diffuse flag seems to be VertexLighterFlat, which defaults the flag to true. So in cases where a mod author didn't intentionally try to disable diffuse for an unbaked quad, no change should be observed. 
