### PR TITLE
Expand getHarvestLevel to include player and blockstate

### DIFF
--- a/patches/minecraft/net/minecraft/item/Item.java.patch
+++ b/patches/minecraft/net/minecraft/item/Item.java.patch
@@ -522,17 +522,28 @@
 +    }
 +
 +    /**
-+     * Queries the harvest level of this item stack for the specifred tool class,
-+     * Returns -1 if this tool is not of the specified type
-+     *
-+     * @param stack This item stack instance
-+     * @param toolClass Tool Class
-+     * @return Harvest level, or -1 if not the specified tool type.
++     * Deprecated, Use the position aware variant instead
 +     */
++    @Deprecated
 +    public int getHarvestLevel(ItemStack stack, String toolClass)
 +    {
 +        Integer ret = toolClasses.get(toolClass);
 +        return ret == null ? -1 : ret;
++    }
++
++    /**
++     * Queries the harvest level of this item stack for the specified tool class,
++     * Returns -1 if this tool is not of the specified type
++     *
++     * @param stack This item stack instance
++     * @param toolClass Tool Class
++     * @param player The player trying to harvest the given blockstate
++     * @param blockState The block to harvest
++     * @return Harvest level, or -1 if not the specified tool type.
++     */
++    public int getHarvestLevel(ItemStack stack, String toolClass, @Nullable EntityPlayer player, @Nullable IBlockState blockState)
++    {
++        return getHarvestLevel(stack, toolClass);
 +    }
 +
 +    /**
@@ -622,7 +633,7 @@
      public static void func_150900_l()
      {
          func_179214_a(Blocks.field_150348_b, (new ItemMultiTexture(Blocks.field_150348_b, Blocks.field_150348_b, new Function<ItemStack, String>()
-@@ -962,6 +1526,10 @@
+@@ -962,6 +1537,10 @@
          private final float field_78011_i;
          private final int field_78008_j;
  
@@ -633,7 +644,7 @@
          private ToolMaterial(int p_i1874_3_, int p_i1874_4_, float p_i1874_5_, float p_i1874_6_, int p_i1874_7_)
          {
              this.field_78001_f = p_i1874_3_;
-@@ -996,9 +1564,36 @@
+@@ -996,9 +1575,36 @@
              return this.field_78008_j;
          }
  

--- a/patches/minecraft/net/minecraft/item/ItemTool.java.patch
+++ b/patches/minecraft/net/minecraft/item/ItemTool.java.patch
@@ -50,9 +50,9 @@
 +    /*===================================== FORGE START =================================*/
 +    private String toolClass;
 +    @Override
-+    public int getHarvestLevel(ItemStack stack, String toolClass)
++    public int getHarvestLevel(ItemStack stack, String toolClass, @javax.annotation.Nullable net.minecraft.entity.player.EntityPlayer player, @javax.annotation.Nullable IBlockState blockState)
 +    {
-+        int level = super.getHarvestLevel(stack, toolClass);
++        int level = super.getHarvestLevel(stack, toolClass, player, blockState);
 +        if (level == -1 && toolClass != null && toolClass.equals(this.toolClass))
 +        {
 +            return this.field_77862_b.func_77996_d();

--- a/src/main/java/net/minecraftforge/common/ForgeHooks.java
+++ b/src/main/java/net/minecraftforge/common/ForgeHooks.java
@@ -169,7 +169,7 @@ public class ForgeHooks
             return player.canHarvestBlock(state);
         }
 
-        int toolLevel = stack.getItem().getHarvestLevel(stack, tool);
+        int toolLevel = stack.getItem().getHarvestLevel(stack, tool, player, state);
         if (toolLevel < 0)
         {
             return player.canHarvestBlock(state);
@@ -184,7 +184,7 @@ public class ForgeHooks
         state = state.getBlock().getActualState(state, world, pos);
         String tool = state.getBlock().getHarvestTool(state);
         if (stack == null || tool == null) return false;
-        return stack.getItem().getHarvestLevel(stack, tool) >= state.getBlock().getHarvestLevel(state);
+        return stack.getItem().getHarvestLevel(stack, tool, null, null) >= state.getBlock().getHarvestLevel(state);
     }
 
     public static float blockStrength(IBlockState state, EntityPlayer player, World world, BlockPos pos)

--- a/src/test/java/net/minecraftforge/debug/ItemLayerModelDebug.java
+++ b/src/test/java/net/minecraftforge/debug/ItemLayerModelDebug.java
@@ -1,8 +1,11 @@
 package net.minecraftforge.debug;
 
+import net.minecraft.block.state.IBlockState;
 import net.minecraft.client.renderer.block.model.ModelResourceLocation;
 import net.minecraft.creativetab.CreativeTabs;
 import net.minecraft.entity.Entity;
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.inventory.EntityEquipmentSlot;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
@@ -16,6 +19,8 @@ import net.minecraftforge.fml.common.event.FMLPreInitializationEvent;
 import net.minecraftforge.fml.common.registry.GameRegistry;
 
 import java.util.Random;
+
+import javax.annotation.Nullable;
 
 @Mod(modid = ItemLayerModelDebug.MODID, name = "ForgeDebugItemLayerModel", version = ItemLayerModelDebug.VERSION)
 public class ItemLayerModelDebug
@@ -85,6 +90,20 @@ public class ItemLayerModelDebug
             newStack = newStack.copy();
             newStack.setTagCompound(null);
             return !ItemStack.areItemStacksEqual(oldStack, newStack);
+        }
+
+        @Override
+        public int getHarvestLevel(ItemStack stack, String toolClass, @Nullable EntityPlayer player, @Nullable IBlockState blockState) {
+            // This tool is a super pickaxe if the player is wearing a helment
+            if("pickaxe".equals(toolClass) && player != null && player.getItemStackFromSlot(EntityEquipmentSlot.HEAD) != null) {
+                return 5;
+            }
+            return super.getHarvestLevel(stack, toolClass, player, blockState);
+        }
+
+        @Override
+        public float getStrVsBlock(ItemStack stack, IBlockState state) {
+            return 10f;
         }
     }
 }


### PR DESCRIPTION
This allows for conditional harvest level tools, like only allowing players to harvest X with your tool if they got an achievement first. The test item in the test mod turns into a pickaxe if the player is wearing a helmet.

ForgeHooks.canHarvestBlock could also be supplemented with an Event, however everything not using the forge hook would then not be caught in the changes.

ForgeHooks.canToolHarvestBlock has been marked es deprecated, since it's not used anywhere but would require a signature change to adapt, breaking backwards compatibility.
