### PR TITLE
[1.10] Add ability to perform an SRV record check, per feature request #2352.

### DIFF
--- a/patches/minecraft/net/minecraft/client/multiplayer/ServerAddress.java.patch
+++ b/patches/minecraft/net/minecraft/client/multiplayer/ServerAddress.java.patch
@@ -1,0 +1,16 @@
+--- ../src-base/minecraft/net/minecraft/client/multiplayer/ServerAddress.java
++++ ../src-work/minecraft/net/minecraft/client/multiplayer/ServerAddress.java
+@@ -98,6 +98,13 @@
+             hashtable.put("java.naming.provider.url", "dns:");
+             hashtable.put("com.sun.jndi.dns.timeout.retries", "1");
+             DirContext dircontext = new InitialDirContext(hashtable);
++            try
++            {
++                Attributes lookup = dircontext.getAttributes("_" + net.minecraftforge.common.ForgeModContainer.srvRecordKey + "._tcp." + p_78863_0_, new String[] {"SRV"});
++                String[] result = lookup.get("srv").get().toString().split(" ", 4);
++                return new String[] {result[3], result[2]};
++            }
++            catch (javax.naming.NamingException ignored) {}
+             Attributes attributes = dircontext.getAttributes("_minecraft._tcp." + p_78863_0_, new String[] {"SRV"});
+             String[] astring = attributes.get("srv").get().toString().split(" ", 4);
+             return new String[] {astring[3], astring[2]};

--- a/src/main/java/net/minecraftforge/common/ForgeModContainer.java
+++ b/src/main/java/net/minecraftforge/common/ForgeModContainer.java
@@ -107,6 +107,7 @@ public class ForgeModContainer extends DummyModContainer implements WorldAccessC
     public static boolean replaceVanillaBucketModel = true;
     public static long java8Reminder = 0;
     public static boolean disableStairSlabCulling = false; // Also known as the "DontCullStairsBecauseIUseACrappyTexturePackThatBreaksBasicBlockShapesSoICantTrustBasicBlockCulling" flag
+    public static String srvRecordKey = "minecraft";
 
     private static Configuration config;
     private static ForgeModContainer INSTANCE;
@@ -291,6 +292,12 @@ public class ForgeModContainer extends DummyModContainer implements WorldAccessC
                 "Disable culling of hidden faces next to stairs and slabs. Causes extra rendering, but may fix some resource packs that exploit this vanilla mechanic.");
         disableStairSlabCulling = prop.getBoolean(disableStairSlabCulling);
         prop.setLanguageKey("forge.configgui.disableStairSlabCulling").setRequiresMcRestart(false);
+        propOrder.add(prop.getName());
+
+        prop = config.get(Configuration.CATEGORY_CLIENT, "srvRecordKey", srvRecordKey,
+                "Override the SRV record Minecraft uses to attempt to determine what server you intend to connect to.");
+        srvRecordKey = prop.getString();
+        prop.setLanguageKey("forge.configgui.srvRecordKey");
         propOrder.add(prop.getName());
 
         config.setCategoryPropertyOrder(CATEGORY_CLIENT, propOrder);

--- a/src/main/resources/assets/forge/lang/en_US.lang
+++ b/src/main/resources/assets/forge/lang/en_US.lang
@@ -49,6 +49,7 @@ forge.configgui.forgeLightPipelineEnabled=Forge Light Pipeline Enabled
 forge.configgui.java8Reminder=Java 8 Reminder timestamp
 forge.configgui.disableStairSlabCulling=Disable Stair/Slab culling.
 forge.configgui.disableStairSlabCulling.tooltip=Enable this if you see through blocks touching stairs/slabs with your resource pack.
+forge.configgui.srvRecordKey=Server SRV Record Key
 
 forge.configgui.modID.tooltip=The mod ID that you want to define override settings for.
 forge.configgui.modID=Mod ID


### PR DESCRIPTION
In January, I created a feature request #2352 to allow one to set a custom SRV record for connecting to Minecraft servers, with the usecase that such a feature would allow for a server administrator with multiple packs to use the same server hostname.

For example, if someone created Example Pack 1, and set the client -> S:srvRecordKey in config/forge.cfg to `examplepack1`, if a client is given a server hostname of 'example.com' what this patch will do is perform an SRV lookup for `_examplepack1._tcp.example.com` first. If this address exists, a server administrator is allowed to have multiple packs on the same URL, so long as each has a unique S:srvRecordKey value. A pack maker who set client -> S:srvRecordKey to `examplepack2` would be able to run with `example.com` as the server hostname at the same time as `examplepack1`. If that fails, the fallback is to `_minecraft._tcp.example.com` via SRV, and then an A record lookup for `example.com`.

The behavior of this patch is slightly different from vanilla, in that if the setting is unmodified, if _minecraft._tcp does not exist as an SRV record, the client will try twice with 1 retry, rather than just once with 1 retry. There is no expected incompatibility with vanilla servers arising from this deviation.

A test mod for this patch is available [here](https://github.com/rallias/FR2352Test).
