### PR TITLE
[1.10.2] TESR allowed to use renderTileEntityFast AND renderTileEntityAt

### DIFF
--- a/patches/minecraft/net/minecraft/client/renderer/tileentity/TileEntityRendererDispatcher.java.patch
+++ b/patches/minecraft/net/minecraft/client/renderer/tileentity/TileEntityRendererDispatcher.java.patch
@@ -15,19 +15,23 @@
              BlockPos blockpos = p_180546_1_.func_174877_v();
              this.func_178469_a(p_180546_1_, (double)blockpos.func_177958_n() - field_147554_b, (double)blockpos.func_177956_o() - field_147555_c, (double)blockpos.func_177952_p() - field_147552_d, p_180546_2_, p_180546_3_);
          }
-@@ -136,6 +139,11 @@
+@@ -136,7 +139,14 @@
          {
              try
              {
+-                tileentityspecialrenderer.func_180535_a(p_178469_1_, p_178469_2_, p_178469_4_, p_178469_6_, p_178469_8_, p_178469_9_);
 +                if(drawingBatch && p_178469_1_.hasFastRenderer())
 +                {
 +                    tileentityspecialrenderer.renderTileEntityFast(p_178469_1_, p_178469_2_, p_178469_4_, p_178469_6_, p_178469_8_, p_178469_9_, batchBuffer.func_178180_c());
 +                }
-+                else
-                 tileentityspecialrenderer.func_180535_a(p_178469_1_, p_178469_2_, p_178469_4_, p_178469_6_, p_178469_8_, p_178469_9_);
++                if(p_178469_1_.hasGLRenderer())
++                {
++                	tileentityspecialrenderer.func_180535_a(p_178469_1_, p_178469_2_, p_178469_4_, p_178469_6_, p_178469_8_, p_178469_9_);
++                }
              }
              catch (Throwable throwable)
-@@ -162,4 +170,52 @@
+             {
+@@ -162,4 +172,52 @@
      {
          return this.field_147557_n;
      }

--- a/patches/minecraft/net/minecraft/tileentity/TileEntity.java.patch
+++ b/patches/minecraft/net/minecraft/tileentity/TileEntity.java.patch
@@ -68,7 +68,7 @@
      public double func_145835_a(double p_145835_1_, double p_145835_3_, double p_145835_5_)
      {
          double d0 = (double)this.field_174879_c.func_177958_n() + 0.5D - p_145835_1_;
-@@ -305,6 +315,198 @@
+@@ -305,6 +315,206 @@
      {
      }
  
@@ -227,6 +227,14 @@
 +        // NOOP
 +    }
 +
++    /**
++     * Determines whether the TileEntitySpecialRenderer associated with this TileEntity can render with can access GlStateManager or GL11.
++     */
++    public boolean hasGLRenderer()
++    {
++    	return !this.hasFastRenderer();
++    }
++    
 +    /**
 +     * If the TileEntitySpecialRenderer associated with this TileEntity can be batched in with another renderers, and won't access the GL state.
 +     * If TileEntity returns true, then TESR should have the same functionality as (and probably extend) the FastTESR class.


### PR DESCRIPTION
## What I Changed
- In TileEntity, I added a new boolean called hasGLRenderer. This defines whether a TileEntitySpecialRenderer has the ability to use GLStateManager or GL11. By default it returns the opposite of what TileEntity#hasFastRenderer returns, which mimics the if-else statement I will discuss now.
- In TileEntitySpecialRenderer, I split the if-else statement (The one that determines what method to use for rendering) to two if statements, the first if statement being the original if statement and the second one calling TileEntity#hasGLRenderer through the tileEntity variable.
## Purpose

This change will allow modders to render objects with the primary VertexBuffer AND GlStateManager/GL11
