### PR TITLE
Revert changes to ItemTool for binary compatibility

### DIFF
--- a/patches/minecraft/net/minecraft/item/ItemTool.java.patch
+++ b/patches/minecraft/net/minecraft/item/ItemTool.java.patch
@@ -50,9 +50,9 @@
 +    /*===================================== FORGE START =================================*/
 +    private String toolClass;
 +    @Override
-+    public int getHarvestLevel(ItemStack stack, String toolClass, @javax.annotation.Nullable net.minecraft.entity.player.EntityPlayer player, @javax.annotation.Nullable IBlockState blockState)
++    public int getHarvestLevel(ItemStack stack, String toolClass)
 +    {
-+        int level = super.getHarvestLevel(stack, toolClass, player, blockState);
++        int level = super.getHarvestLevel(stack, toolClass);
 +        if (level == -1 && toolClass != null && toolClass.equals(this.toolClass))
 +        {
 +            return this.field_77862_b.func_77996_d();


### PR DESCRIPTION
Reverts ItemTool to its previous state, where it only overloads the old getHarvestLevel.

This way when the new getHarvestLevel is called, it'll redirect to the overloaded getHarvestLevel in ItemTool, while keeping binary compatibility.
