### PR TITLE
Fix item use counting towards craft stat

### DIFF
--- a/src/main/java/net/minecraftforge/common/ForgeHooks.java
+++ b/src/main/java/net/minecraftforge/common/ForgeHooks.java
@@ -819,7 +819,7 @@ public class ForgeHooks
 
                     world.markAndNotifyBlock(snap.getPos(), null, oldBlock, newBlock, updateFlag);
                 }
-                player.addStat(StatList.getCraftStats(itemstack.getItem()));
+                player.addStat(StatList.getObjectUseStats(itemstack.getItem()));
             }
         }
         world.capturedBlockSnapshots.clear();


### PR DESCRIPTION
Commit 8863aab mistakenly replaced the use stat with the craft stat in ForgeHooks#onPlaceItemIntoWorld, this corrects the error.
