### PR TITLE
Fix debug command creating empty file (MC-103399)

### DIFF
--- a/patches/minecraft/net/minecraft/command/CommandDebug.java.patch
+++ b/patches/minecraft/net/minecraft/command/CommandDebug.java.patch
@@ -1,0 +1,11 @@
+--- ../src-base/minecraft/net/minecraft/command/CommandDebug.java
++++ ../src-work/minecraft/net/minecraft/command/CommandDebug.java
+@@ -99,7 +99,7 @@
+         {
+             IOUtils.closeQuietly((Writer)filewriter);
+             field_147208_a.error("Could not save profiler results to {}", new Object[] {file1, throwable});
+-        }
++        } finally { IOUtils.closeQuietly(filewriter); }
+     }
+ 
+     private String func_184893_b(long p_184893_1_, int p_184893_3_, MinecraftServer p_184893_4_)

--- a/patches/minecraft/net/minecraft/command/CommandDebug.java.patch
+++ b/patches/minecraft/net/minecraft/command/CommandDebug.java.patch
@@ -5,7 +5,7 @@
              IOUtils.closeQuietly((Writer)filewriter);
              field_147208_a.error("Could not save profiler results to {}", new Object[] {file1, throwable});
 -        }
-+        } finally { IOUtils.closeQuietly(filewriter); }
++        } finally { IOUtils.closeQuietly(filewriter); } // FORGE: Fix MC-10339
      }
  
      private String func_184893_b(long p_184893_1_, int p_184893_3_, MinecraftServer p_184893_4_)

--- a/patches/minecraft/net/minecraft/command/CommandDebug.java.patch
+++ b/patches/minecraft/net/minecraft/command/CommandDebug.java.patch
@@ -5,7 +5,7 @@
              IOUtils.closeQuietly((Writer)filewriter);
              field_147208_a.error("Could not save profiler results to {}", new Object[] {file1, throwable});
 -        }
-+        } finally { IOUtils.closeQuietly(filewriter); } // FORGE: Fix MC-10339
++        } finally { IOUtils.closeQuietly(filewriter); } // FORGE: Fix MC-103399
      }
  
      private String func_184893_b(long p_184893_1_, int p_184893_3_, MinecraftServer p_184893_4_)


### PR DESCRIPTION
This fixes the vanilla bug [MC-103399](https://bugs.mojang.com/browse/MC-103399) introduced in 1.10. When the debug command writes the profile results to a file the used FileWriter is not closed resulting in either an empty file or potentially partial data.
