### PR TITLE
Allow mutating a baby entity based on it's parents

### DIFF
--- a/patches/minecraft/net/minecraft/entity/ai/EntityAIMate.java.patch
+++ b/patches/minecraft/net/minecraft/entity/ai/EntityAIMate.java.patch
@@ -1,30 +1,21 @@
 --- ../src-base/minecraft/net/minecraft/entity/ai/EntityAIMate.java
 +++ ../src-work/minecraft/net/minecraft/entity/ai/EntityAIMate.java
-@@ -95,6 +95,16 @@
-                 entityplayer = this.field_75391_e.func_146083_cb();
-             }
+@@ -86,6 +86,18 @@
+     {
+         EntityAgeable entityageable = this.field_75390_d.func_90011_a(this.field_75391_e);
  
++        final net.minecraftforge.event.entity.living.BabyEntitySpawnEvent event = new net.minecraftforge.event.entity.living.BabyEntitySpawnEvent(field_75390_d, field_75391_e, entityageable);
++        final boolean cancelled = net.minecraftforge.common.MinecraftForge.EVENT_BUS.post(event);
++        entityageable = event.getChild();
++        if (cancelled) {
++            //Reset the "inLove" state for the animals
 +            this.field_75390_d.func_70873_a(6000);
 +            this.field_75391_e.func_70873_a(6000);
 +            this.field_75390_d.func_70875_t();
 +            this.field_75391_e.func_70875_t();
++            return;
++        }
 +
-+            final net.minecraftforge.event.entity.living.BabyEntitySpawnEvent event = new net.minecraftforge.event.entity.living.BabyEntitySpawnEvent(field_75390_d, field_75391_e, entityageable, entityplayer);
-+            final boolean post = net.minecraftforge.common.MinecraftForge.EVENT_BUS.post(event);
-+            if (post || event.getChild() == null) { return; }
-+            entityageable = event.getChild();
-+
-             if (entityplayer != null)
-             {
-                 entityplayer.func_71029_a(StatList.field_151186_x);
-@@ -105,10 +115,6 @@
-                 }
-             }
- 
--            this.field_75390_d.func_70873_a(6000);
--            this.field_75391_e.func_70873_a(6000);
--            this.field_75390_d.func_70875_t();
--            this.field_75391_e.func_70875_t();
-             entityageable.func_70873_a(-24000);
-             entityageable.func_70012_b(this.field_75390_d.field_70165_t, this.field_75390_d.field_70163_u, this.field_75390_d.field_70161_v, 0.0F, 0.0F);
-             this.field_75394_a.func_72838_d(entityageable);
+         if (entityageable != null)
+         {
+             EntityPlayer entityplayer = this.field_75390_d.func_146083_cb();

--- a/patches/minecraft/net/minecraft/entity/ai/EntityAIMate.java.patch
+++ b/patches/minecraft/net/minecraft/entity/ai/EntityAIMate.java.patch
@@ -1,15 +1,6 @@
 --- ../src-base/minecraft/net/minecraft/entity/ai/EntityAIMate.java
 +++ ../src-work/minecraft/net/minecraft/entity/ai/EntityAIMate.java
-@@ -11,6 +11,8 @@
- import net.minecraft.stats.StatList;
- import net.minecraft.util.EnumParticleTypes;
- import net.minecraft.world.World;
-+import net.minecraftforge.common.MinecraftForge;
-+import net.minecraftforge.event.entity.living.BabyEntitySpawnEvent;
- 
- public class EntityAIMate extends EntityAIBase
- {
-@@ -95,6 +97,16 @@
+@@ -95,6 +95,16 @@
                  entityplayer = this.field_75391_e.func_146083_cb();
              }
  
@@ -18,15 +9,15 @@
 +            this.field_75390_d.func_70875_t();
 +            this.field_75391_e.func_70875_t();
 +
-+            final BabyEntitySpawnEvent event = new BabyEntitySpawnEvent(field_75390_d, field_75391_e, entityageable, entityplayer);
-+            final boolean post = MinecraftForge.EVENT_BUS.post(event);
++            final net.minecraftforge.event.entity.living.BabyEntitySpawnEvent event = new net.minecraftforge.event.entity.living.BabyEntitySpawnEvent(field_75390_d, field_75391_e, entityageable, entityplayer);
++            final boolean post = net.minecraftforge.common.MinecraftForge.EVENT_BUS.post(event);
 +            if (post || event.getChild() == null) { return; }
 +            entityageable = event.getChild();
 +
              if (entityplayer != null)
              {
                  entityplayer.func_71029_a(StatList.field_151186_x);
-@@ -105,10 +117,6 @@
+@@ -105,10 +115,6 @@
                  }
              }
  

--- a/patches/minecraft/net/minecraft/entity/ai/EntityAIMate.java.patch
+++ b/patches/minecraft/net/minecraft/entity/ai/EntityAIMate.java.patch
@@ -1,0 +1,39 @@
+--- ../src-base/minecraft/net/minecraft/entity/ai/EntityAIMate.java
++++ ../src-work/minecraft/net/minecraft/entity/ai/EntityAIMate.java
+@@ -11,6 +11,8 @@
+ import net.minecraft.stats.StatList;
+ import net.minecraft.util.EnumParticleTypes;
+ import net.minecraft.world.World;
++import net.minecraftforge.common.MinecraftForge;
++import net.minecraftforge.event.entity.living.BabyEntitySpawnEvent;
+ 
+ public class EntityAIMate extends EntityAIBase
+ {
+@@ -95,6 +97,16 @@
+                 entityplayer = this.field_75391_e.func_146083_cb();
+             }
+ 
++            this.field_75390_d.func_70873_a(6000);
++            this.field_75391_e.func_70873_a(6000);
++            this.field_75390_d.func_70875_t();
++            this.field_75391_e.func_70875_t();
++
++            final BabyEntitySpawnEvent event = new BabyEntitySpawnEvent(field_75390_d, field_75391_e, entityageable, entityplayer);
++            final boolean post = MinecraftForge.EVENT_BUS.post(event);
++            if (post || event.getChild() == null) { return; }
++            entityageable = event.getChild();
++
+             if (entityplayer != null)
+             {
+                 entityplayer.func_71029_a(StatList.field_151186_x);
+@@ -105,10 +117,6 @@
+                 }
+             }
+ 
+-            this.field_75390_d.func_70873_a(6000);
+-            this.field_75391_e.func_70873_a(6000);
+-            this.field_75390_d.func_70875_t();
+-            this.field_75391_e.func_70875_t();
+             entityageable.func_70873_a(-24000);
+             entityageable.func_70012_b(this.field_75390_d.field_70165_t, this.field_75390_d.field_70163_u, this.field_75390_d.field_70161_v, 0.0F, 0.0F);
+             this.field_75394_a.func_72838_d(entityageable);

--- a/patches/minecraft/net/minecraft/entity/ai/EntityAIVillagerMate.java.patch
+++ b/patches/minecraft/net/minecraft/entity/ai/EntityAIVillagerMate.java.patch
@@ -1,0 +1,33 @@
+--- ../src-base/minecraft/net/minecraft/entity/ai/EntityAIVillagerMate.java
++++ ../src-work/minecraft/net/minecraft/entity/ai/EntityAIVillagerMate.java
+@@ -1,10 +1,13 @@
+ package net.minecraft.entity.ai;
+ 
+ import net.minecraft.entity.Entity;
++import net.minecraft.entity.EntityAgeable;
+ import net.minecraft.entity.passive.EntityVillager;
+ import net.minecraft.util.math.BlockPos;
+ import net.minecraft.village.Village;
+ import net.minecraft.world.World;
++import net.minecraftforge.common.MinecraftForge;
++import net.minecraftforge.event.entity.living.BabyEntitySpawnEvent;
+ 
+ public class EntityAIVillagerMate extends EntityAIBase
+ {
+@@ -113,11 +116,15 @@
+ 
+     private void func_75447_i()
+     {
+-        EntityVillager entityvillager = this.field_75450_b.func_90011_a(this.field_75451_c);
++        EntityAgeable entityvillager = this.field_75450_b.func_90011_a(this.field_75451_c);
+         this.field_75451_c.func_70873_a(6000);
+         this.field_75450_b.func_70873_a(6000);
+         this.field_75451_c.func_175549_o(false);
+         this.field_75450_b.func_175549_o(false);
++
++        final BabyEntitySpawnEvent event = new BabyEntitySpawnEvent(field_75450_b, field_75451_c, entityvillager, null);
++        if (MinecraftForge.EVENT_BUS.post(event) || event.getChild() == null) { return; }
++        entityvillager = event.getChild();
+         entityvillager.func_70873_a(-24000);
+         entityvillager.func_70012_b(this.field_75450_b.field_70165_t, this.field_75450_b.field_70163_u, this.field_75450_b.field_70161_v, 0.0F, 0.0F);
+         this.field_75448_d.func_72838_d(entityvillager);

--- a/patches/minecraft/net/minecraft/entity/ai/EntityAIVillagerMate.java.patch
+++ b/patches/minecraft/net/minecraft/entity/ai/EntityAIVillagerMate.java.patch
@@ -11,7 +11,7 @@
          this.field_75451_c.func_175549_o(false);
          this.field_75450_b.func_175549_o(false);
 +
-+        final net.minecraftforge.event.entity.living.BabyEntitySpawnEvent event = new net.minecraftforge.event.entity.living.BabyEntitySpawnEvent(field_75450_b, field_75451_c, entityvillager, null);
++        final net.minecraftforge.event.entity.living.BabyEntitySpawnEvent event = new net.minecraftforge.event.entity.living.BabyEntitySpawnEvent(field_75450_b, field_75451_c, entityvillager);
 +        if (net.minecraftforge.common.MinecraftForge.EVENT_BUS.post(event) || event.getChild() == null) { return; }
 +        entityvillager = event.getChild();
          entityvillager.func_70873_a(-24000);

--- a/patches/minecraft/net/minecraft/entity/ai/EntityAIVillagerMate.java.patch
+++ b/patches/minecraft/net/minecraft/entity/ai/EntityAIVillagerMate.java.patch
@@ -1,32 +1,18 @@
 --- ../src-base/minecraft/net/minecraft/entity/ai/EntityAIVillagerMate.java
 +++ ../src-work/minecraft/net/minecraft/entity/ai/EntityAIVillagerMate.java
-@@ -1,10 +1,13 @@
- package net.minecraft.entity.ai;
- 
- import net.minecraft.entity.Entity;
-+import net.minecraft.entity.EntityAgeable;
- import net.minecraft.entity.passive.EntityVillager;
- import net.minecraft.util.math.BlockPos;
- import net.minecraft.village.Village;
- import net.minecraft.world.World;
-+import net.minecraftforge.common.MinecraftForge;
-+import net.minecraftforge.event.entity.living.BabyEntitySpawnEvent;
- 
- public class EntityAIVillagerMate extends EntityAIBase
- {
-@@ -113,11 +116,15 @@
+@@ -113,11 +113,15 @@
  
      private void func_75447_i()
      {
 -        EntityVillager entityvillager = this.field_75450_b.func_90011_a(this.field_75451_c);
-+        EntityAgeable entityvillager = this.field_75450_b.func_90011_a(this.field_75451_c);
++        net.minecraft.entity.EntityAgeable entityvillager = this.field_75450_b.func_90011_a(this.field_75451_c);
          this.field_75451_c.func_70873_a(6000);
          this.field_75450_b.func_70873_a(6000);
          this.field_75451_c.func_175549_o(false);
          this.field_75450_b.func_175549_o(false);
 +
-+        final BabyEntitySpawnEvent event = new BabyEntitySpawnEvent(field_75450_b, field_75451_c, entityvillager, null);
-+        if (MinecraftForge.EVENT_BUS.post(event) || event.getChild() == null) { return; }
++        final net.minecraftforge.event.entity.living.BabyEntitySpawnEvent event = new net.minecraftforge.event.entity.living.BabyEntitySpawnEvent(field_75450_b, field_75451_c, entityvillager, null);
++        if (net.minecraftforge.common.MinecraftForge.EVENT_BUS.post(event) || event.getChild() == null) { return; }
 +        entityvillager = event.getChild();
          entityvillager.func_70873_a(-24000);
          entityvillager.func_70012_b(this.field_75450_b.field_70165_t, this.field_75450_b.field_70163_u, this.field_75450_b.field_70161_v, 0.0F, 0.0F);

--- a/src/main/java/net/minecraftforge/event/entity/living/BabyEntitySpawnEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/living/BabyEntitySpawnEvent.java
@@ -23,6 +23,7 @@ import net.minecraft.entity.EntityAgeable;
 import net.minecraft.entity.EntityLiving;
 import net.minecraft.entity.ai.EntityAIMate;
 import net.minecraft.entity.ai.EntityAIVillagerMate;
+import net.minecraft.entity.passive.EntityAnimal;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.fml.common.eventhandler.Cancelable;
@@ -41,7 +42,8 @@ import javax.annotation.Nullable;
  * {@link #child} contains the child that will be spawned.<br>
  * <br>
  * This event is {@link Cancelable}.<br>
- * If this event is canceled, the child Entity is not added to the world.<br>
+ * If this event is canceled, the child Entity is not added to the world, and the parents <br>
+ * will no longer attempt to mate.
  * <br>
  * This event does not have a result. {@link HasResult}<br>
  * <br>
@@ -55,8 +57,19 @@ public class BabyEntitySpawnEvent extends Event
     private final EntityPlayer causedByPlayer;
     private EntityAgeable child;
 
-    public BabyEntitySpawnEvent(EntityLiving parentA, EntityLiving parentB, EntityAgeable proposedChild, @Nullable EntityPlayer causedByPlayer)
+    public BabyEntitySpawnEvent(EntityLiving parentA, EntityLiving parentB, @Nullable EntityAgeable proposedChild)
     {
+        //causedByPlayer calculated here to simplify the patch.
+        EntityPlayer causedByPlayer = null;
+        if (parentA instanceof EntityAnimal) {
+            causedByPlayer = ((EntityAnimal)parentA).getPlayerInLove();
+        }
+
+        if (causedByPlayer == null && parentB instanceof EntityAnimal)
+        {
+            causedByPlayer = ((EntityAnimal)parentB).getPlayerInLove();
+        }
+
         this.parentA = parentA;
         this.parentB = parentB;
         this.causedByPlayer = causedByPlayer;
@@ -79,6 +92,7 @@ public class BabyEntitySpawnEvent extends Event
         return causedByPlayer;
     }
 
+    @Nullable
     public EntityAgeable getChild()
     {
         return child;

--- a/src/main/java/net/minecraftforge/event/entity/living/BabyEntitySpawnEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/living/BabyEntitySpawnEvent.java
@@ -74,6 +74,7 @@ public class BabyEntitySpawnEvent extends Event
         return parentB;
     }
 
+    @Nullable
     public EntityPlayer getCausedByPlayer()
     {
         return causedByPlayer;

--- a/src/main/java/net/minecraftforge/event/entity/living/BabyEntitySpawnEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/living/BabyEntitySpawnEvent.java
@@ -1,0 +1,91 @@
+/*
+ * Minecraft Forge
+ * Copyright (c) 2016.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation version 2.1
+ * of the License.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+package net.minecraftforge.event.entity.living;
+
+import net.minecraft.entity.EntityAgeable;
+import net.minecraft.entity.EntityLiving;
+import net.minecraft.entity.ai.EntityAIMate;
+import net.minecraft.entity.ai.EntityAIVillagerMate;
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraftforge.common.MinecraftForge;
+import net.minecraftforge.fml.common.eventhandler.Cancelable;
+import net.minecraftforge.fml.common.eventhandler.Event;
+import javax.annotation.Nullable;
+
+/**
+ * BabyEntitySpawnEvent is fired just before a baby entity is about to be spawned. <br>
+ * Parents will have disengaged their relationship. {@link @Cancelable} <br>
+ * It is possible to change the child completely by using {@link #setChild(EntityAgeable)} <br>
+ * This event is fired from {@link EntityAIMate#spawnBaby()} and {@link EntityAIVillagerMate#giveBirth()} <br>
+ * <br>
+ * {@link #parentA} contains the initiating parent entity.<br>
+ * {@link #parentB} contains the secondary parent entity.<br>
+ * {@link #causedByPlayer} contains the player responsible for the breading (if applicable).<br>
+ * {@link #child} contains the child that will be spawned.<br>
+ * <br>
+ * This event is {@link Cancelable}.<br>
+ * If this event is canceled, the child Entity is not added to the world.<br>
+ * <br>
+ * This event does not have a result. {@link HasResult}<br>
+ * <br>
+ * This event is fired on the {@link MinecraftForge#EVENT_BUS}.
+ **/
+@Cancelable
+public class BabyEntitySpawnEvent extends Event
+{
+    private final EntityLiving parentA;
+    private final EntityLiving parentB;
+    private final EntityPlayer causedByPlayer;
+    private EntityAgeable child;
+
+    public BabyEntitySpawnEvent(EntityLiving parentA, EntityLiving parentB, EntityAgeable proposedChild, @Nullable EntityPlayer causedByPlayer)
+    {
+
+        this.parentA = parentA;
+        this.parentB = parentB;
+        this.causedByPlayer = causedByPlayer;
+        this.child = proposedChild;
+    }
+
+    public EntityLiving getParentA()
+    {
+        return parentA;
+    }
+
+    public EntityLiving getParentB()
+    {
+        return parentB;
+    }
+
+    public EntityPlayer getCausedByPlayer()
+    {
+        return causedByPlayer;
+    }
+
+    public EntityAgeable getChild()
+    {
+        return child;
+    }
+
+    public void setChild(EntityAgeable proposedChild)
+    {
+        child = proposedChild;
+    }
+}

--- a/src/main/java/net/minecraftforge/event/entity/living/BabyEntitySpawnEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/living/BabyEntitySpawnEvent.java
@@ -57,7 +57,6 @@ public class BabyEntitySpawnEvent extends Event
 
     public BabyEntitySpawnEvent(EntityLiving parentA, EntityLiving parentB, EntityAgeable proposedChild, @Nullable EntityPlayer causedByPlayer)
     {
-
         this.parentA = parentA;
         this.parentB = parentB;
         this.causedByPlayer = causedByPlayer;

--- a/src/test/java/net/minecraftforge/debug/BreedingTest.java
+++ b/src/test/java/net/minecraftforge/debug/BreedingTest.java
@@ -1,0 +1,24 @@
+package net.minecraftforge.debug;
+
+import net.minecraft.entity.passive.EntityCow;
+import net.minecraftforge.common.MinecraftForge;
+import net.minecraftforge.event.entity.living.BabyEntitySpawnEvent;
+import net.minecraftforge.fml.common.Mod;
+import net.minecraftforge.fml.common.event.FMLPreInitializationEvent;
+import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
+
+@Mod(modid = BreedingTest.MODID, name = "BreedingTest", version = "1.0")
+public class BreedingTest
+{
+  public static final String MODID = "breedingtest";
+
+  @Mod.EventHandler
+  public void preInit(FMLPreInitializationEvent event) {
+    MinecraftForge.EVENT_BUS.register(this);
+  }
+
+  @SubscribeEvent
+  public void onBabyBorn(BabyEntitySpawnEvent event) {
+    event.setChild(new EntityCow(event.getChild().worldObj));
+  }
+}


### PR DESCRIPTION
This adds an event to when baby animals and baby villagers are spawned, giving modders the opportunity to set properties or swap out the baby being spawned, based on the parents and potentially, if available, the player that caused the breeding.

I needed to rearrange a little vanilla code to ensure animals weren't perpetually... interested... when the event was cancelled.

an example of using the event can be found here: https://gist.github.com/AtomicBlom/8e9c31ac675a61876e4bc7809e238beb
