### PR TITLE
Add IForgeRegistry#getDefaultValue

### DIFF
--- a/src/main/java/net/minecraftforge/fml/common/registry/IForgeRegistry.java
+++ b/src/main/java/net/minecraftforge/fml/common/registry/IForgeRegistry.java
@@ -47,6 +47,7 @@ public interface IForgeRegistry<V extends IForgeRegistryEntry<V>> extends Iterab
 
     Set<ResourceLocation>           getKeys();
     List<V>                         getValues();
+    V                               getDefaultValue();
     Set<Entry<ResourceLocation, V>> getEntries();
 
     /**


### PR DESCRIPTION
Allows modders to get the default value of an IForgeRegistry instance.
