### PR TITLE
Fix universal bucket not being returned in crafting recipes

### DIFF
--- a/src/main/java/net/minecraftforge/fluids/UniversalBucket.java
+++ b/src/main/java/net/minecraftforge/fluids/UniversalBucket.java
@@ -79,6 +79,18 @@ public class UniversalBucket extends Item implements IFluidContainerItem
         BlockDispenser.DISPENSE_BEHAVIOR_REGISTRY.putObject(this, DispenseFluidContainer.getInstance());
     }
 
+    @Override
+    public boolean hasContainerItem(ItemStack stack)
+    {
+        return getEmpty() != null;
+    }
+
+    @Override
+    public ItemStack getContainerItem(ItemStack itemStack)
+    {
+        return getEmpty();
+    }
+
     @SideOnly(Side.CLIENT)
     @Override
     public void getSubItems(Item itemIn, CreativeTabs tab, List<ItemStack> subItems)

--- a/src/main/java/net/minecraftforge/fluids/UniversalBucket.java
+++ b/src/main/java/net/minecraftforge/fluids/UniversalBucket.java
@@ -88,7 +88,12 @@ public class UniversalBucket extends Item implements IFluidContainerItem
     @Override
     public ItemStack getContainerItem(ItemStack itemStack)
     {
-        return getEmpty();
+        if (getEmpty() != null)
+        {
+            // Create a copy such that the game can't mess with it
+            return getEmpty().copy();
+        }
+        return super.getContainerItem(itemStack);
     }
 
     @SideOnly(Side.CLIENT)

--- a/src/test/java/net/minecraftforge/debug/DynBucketTest.java
+++ b/src/test/java/net/minecraftforge/debug/DynBucketTest.java
@@ -28,6 +28,7 @@ import net.minecraft.util.EnumHand;
 import net.minecraft.util.ResourceLocation;
 import net.minecraft.world.World;
 import net.minecraftforge.client.model.ModelLoader;
+import net.minecraftforge.common.ForgeModContainer;
 import net.minecraftforge.debug.ModelFluidDebug.TestFluid;
 import net.minecraftforge.debug.ModelFluidDebug.TestGas;
 import net.minecraftforge.event.entity.player.FillBucketEvent;
@@ -121,6 +122,8 @@ public class DynBucketTest
 
         //GameRegistry.registerItem(dynBucket, "dynbucket");
         GameRegistry.register(dynBottle);
+        GameRegistry.addShapelessRecipe(new ItemStack(Items.DIAMOND),
+            UniversalBucket.getFilledBucket(ForgeModContainer.getInstance().universalBucket, TestFluid.instance));
 
         // register fluid containers
         int i = 0;


### PR DESCRIPTION
`UniversalBucket` and derivatives will now leave their empty variant (i.e. the empty Vanilla bucket for the Forge-provided item) on the crafting grid when used in a recipe, mimicking Vanilla behaviour. If a mod wishes to destroy the bucket upon crafting, it should override the modified methods.

The 'DynBucket' test mod was modified to include a recipe converting a bucket of the test fluid into a diamond.
