### PR TITLE
Fix wrong var being used during getMaxSpawnPackSize check.

### DIFF
--- a/patches/minecraft/net/minecraft/world/WorldEntitySpawner.java.patch
+++ b/patches/minecraft/net/minecraft/world/WorldEntitySpawner.java.patch
@@ -37,7 +37,7 @@
                                                      }
  
 -                                                    if (j2 >= entityliving.func_70641_bl())
-+                                                    if (i2 >= net.minecraftforge.event.ForgeEventFactory.getMaxSpawnPackSize(entityliving))
++                                                    if (j2 >= net.minecraftforge.event.ForgeEventFactory.getMaxSpawnPackSize(entityliving))
                                                      {
                                                          continue label411;
                                                      }


### PR DESCRIPTION
As title states, this fixes the spawner using wrong var with getMaxSpawnPackSize.
