### PR TITLE
[1.10] Optimize chunk lookups by using last access cache.

### DIFF
--- a/patches/minecraft/net/minecraft/world/chunk/Chunk.java.patch
+++ b/patches/minecraft/net/minecraft/world/chunk/Chunk.java.patch
@@ -1,6 +1,22 @@
 --- ../src-base/minecraft/net/minecraft/world/chunk/Chunk.java
 +++ ../src-work/minecraft/net/minecraft/world/chunk/Chunk.java
-@@ -178,7 +178,7 @@
+@@ -67,6 +67,7 @@
+     private int field_76649_t;
+     private ConcurrentLinkedQueue<BlockPos> field_177447_w;
+     public boolean field_189550_d;
++    public final long chunkKey; // Forge
+ 
+     public Chunk(World p_i1995_1_, int p_i1995_2_, int p_i1995_3_)
+     {
+@@ -81,6 +82,7 @@
+         this.field_76637_e = p_i1995_1_;
+         this.field_76635_g = p_i1995_2_;
+         this.field_76647_h = p_i1995_3_;
++        this.chunkKey = ChunkPos.func_77272_a(p_i1995_2_, p_i1995_3_); // Forge
+         this.field_76634_f = new int[256];
+ 
+         for (int i = 0; i < this.field_76645_j.length; ++i)
+@@ -178,7 +180,7 @@
                  {
                      IBlockState iblockstate = this.func_186032_a(j, l - 1, k);
  
@@ -9,7 +25,7 @@
                      {
                          this.field_76634_f[k << 4 | j] = l;
  
-@@ -451,12 +451,13 @@
+@@ -451,12 +453,13 @@
  
      public int func_177437_b(BlockPos p_177437_1_)
      {
@@ -25,7 +41,7 @@
      }
  
      public IBlockState func_177435_g(BlockPos p_177435_1_)
-@@ -538,6 +539,7 @@
+@@ -538,6 +541,7 @@
          {
              Block block = p_177436_2_.func_177230_c();
              Block block1 = iblockstate.func_177230_c();
@@ -33,7 +49,7 @@
              ExtendedBlockStorage extendedblockstorage = this.field_76652_q[j >> 4];
              boolean flag = false;
  
-@@ -555,14 +557,19 @@
+@@ -555,14 +559,19 @@
  
              extendedblockstorage.func_177484_a(i, j & 15, k, p_177436_2_);
  
@@ -55,7 +71,7 @@
                      this.field_76637_e.func_175713_t(p_177436_1_);
                  }
              }
-@@ -579,8 +586,7 @@
+@@ -579,8 +588,7 @@
                  }
                  else
                  {
@@ -65,7 +81,7 @@
  
                      if (j1 > 0)
                      {
-@@ -600,28 +606,19 @@
+@@ -600,28 +608,19 @@
                      }
                  }
  
@@ -98,7 +114,7 @@
                          this.field_76637_e.func_175690_a(p_177436_1_, tileentity1);
                      }
  
-@@ -725,6 +722,7 @@
+@@ -725,6 +724,7 @@
              k = this.field_76645_j.length - 1;
          }
  
@@ -106,7 +122,7 @@
          p_76612_1_.field_70175_ag = true;
          p_76612_1_.field_70176_ah = this.field_76635_g;
          p_76612_1_.field_70162_ai = k;
-@@ -765,7 +763,7 @@
+@@ -765,7 +765,7 @@
      {
          IBlockState iblockstate = this.func_177435_g(p_177422_1_);
          Block block = iblockstate.func_177230_c();
@@ -115,7 +131,7 @@
      }
  
      @Nullable
-@@ -773,6 +771,12 @@
+@@ -773,6 +773,12 @@
      {
          TileEntity tileentity = (TileEntity)this.field_150816_i.get(p_177424_1_);
  
@@ -128,7 +144,7 @@
          if (tileentity == null)
          {
              if (p_177424_2_ == Chunk.EnumCreateEntityType.IMMEDIATE)
-@@ -782,14 +786,9 @@
+@@ -782,14 +788,9 @@
              }
              else if (p_177424_2_ == Chunk.EnumCreateEntityType.QUEUED)
              {
@@ -144,7 +160,7 @@
  
          return tileentity;
      }
-@@ -806,10 +805,11 @@
+@@ -806,10 +807,11 @@
  
      public void func_177426_a(BlockPos p_177426_1_, TileEntity p_177426_2_)
      {
@@ -157,7 +173,7 @@
          {
              if (this.field_150816_i.containsKey(p_177426_1_))
              {
-@@ -818,6 +818,7 @@
+@@ -818,6 +820,7 @@
  
              p_177426_2_.func_145829_t();
              this.field_150816_i.put(p_177426_1_, p_177426_2_);
@@ -165,7 +181,7 @@
          }
      }
  
-@@ -841,8 +842,9 @@
+@@ -841,8 +844,9 @@
  
          for (ClassInheritanceMultiMap<Entity> classinheritancemultimap : this.field_76645_j)
          {
@@ -176,7 +192,7 @@
      }
  
      public void func_76623_d()
-@@ -858,6 +860,7 @@
+@@ -858,6 +862,7 @@
          {
              this.field_76637_e.func_175681_c(classinheritancemultimap);
          }
@@ -184,7 +200,7 @@
      }
  
      public void func_76630_e()
-@@ -867,8 +870,8 @@
+@@ -867,8 +872,8 @@
  
      public void func_177414_a(@Nullable Entity p_177414_1_, AxisAlignedBB p_177414_2_, List<Entity> p_177414_3_, Predicate <? super Entity > p_177414_4_)
      {
@@ -195,7 +211,7 @@
          i = MathHelper.func_76125_a(i, 0, this.field_76645_j.length - 1);
          j = MathHelper.func_76125_a(j, 0, this.field_76645_j.length - 1);
  
-@@ -905,8 +908,8 @@
+@@ -905,8 +910,8 @@
  
      public <T extends Entity> void func_177430_a(Class <? extends T > p_177430_1_, AxisAlignedBB p_177430_2_, List<T> p_177430_3_, Predicate <? super T > p_177430_4_)
      {
@@ -206,7 +222,7 @@
          i = MathHelper.func_76125_a(i, 0, this.field_76645_j.length - 1);
          j = MathHelper.func_76125_a(j, 0, this.field_76645_j.length - 1);
  
-@@ -995,6 +998,7 @@
+@@ -995,6 +1000,7 @@
          {
              this.func_150809_p();
              p_186034_1_.func_185931_b(this.field_76635_g, this.field_76647_h);
@@ -214,7 +230,7 @@
              this.func_76630_e();
          }
      }
-@@ -1051,7 +1055,7 @@
+@@ -1051,7 +1057,7 @@
          {
              BlockPos blockpos = (BlockPos)this.field_177447_w.poll();
  
@@ -223,7 +239,7 @@
              {
                  TileEntity tileentity = this.func_177422_i(blockpos);
                  this.field_76637_e.func_175690_a(blockpos, tileentity);
-@@ -1115,6 +1119,13 @@
+@@ -1115,6 +1121,13 @@
      @SideOnly(Side.CLIENT)
      public void func_186033_a(PacketBuffer p_186033_1_, int p_186033_2_, boolean p_186033_3_)
      {
@@ -237,7 +253,7 @@
          boolean flag = !this.field_76637_e.field_73011_w.func_177495_o();
  
          for (int i = 0; i < this.field_76652_q.length; ++i)
-@@ -1163,10 +1174,16 @@
+@@ -1163,10 +1176,16 @@
          this.field_76646_k = true;
          this.func_76590_a();
  
@@ -254,7 +270,7 @@
      }
  
      public Biome func_177411_a(BlockPos p_177411_1_, BiomeProvider p_177411_2_)
-@@ -1231,13 +1248,13 @@
+@@ -1231,13 +1250,13 @@
                      BlockPos blockpos1 = blockpos.func_177982_a(k, (j << 4) + i1, l);
                      boolean flag = i1 == 0 || i1 == 15 || k == 0 || k == 15 || l == 0 || l == 15;
  
@@ -270,7 +286,7 @@
                              {
                                  this.field_76637_e.func_175664_x(blockpos2);
                              }
-@@ -1368,7 +1385,7 @@
+@@ -1368,7 +1387,7 @@
          {
              blockpos$mutableblockpos.func_181079_c(blockpos$mutableblockpos.func_177958_n(), l, blockpos$mutableblockpos.func_177952_p());
  
@@ -279,7 +295,7 @@
              {
                  this.field_76637_e.func_175664_x(blockpos$mutableblockpos);
              }
-@@ -1476,4 +1493,20 @@
+@@ -1476,4 +1495,20 @@
          QUEUED,
          CHECK;
      }

--- a/patches/minecraft/net/minecraft/world/gen/ChunkProviderServer.java.patch
+++ b/patches/minecraft/net/minecraft/world/gen/ChunkProviderServer.java.patch
@@ -1,14 +1,39 @@
 --- ../src-base/minecraft/net/minecraft/world/gen/ChunkProviderServer.java
 +++ ../src-work/minecraft/net/minecraft/world/gen/ChunkProviderServer.java
-@@ -35,6 +35,7 @@
+@@ -33,8 +33,31 @@
+     private final Set<Long> field_73248_b = Sets.<Long>newHashSet();
+     public final IChunkGenerator field_186029_c;
      public final IChunkLoader field_73247_e;
-     public final Long2ObjectMap<Chunk> field_73244_f = new Long2ObjectOpenHashMap(8192);
+-    public final Long2ObjectMap<Chunk> field_73244_f = new Long2ObjectOpenHashMap(8192);
++    // Forge start - optimize chunk lookups by using last access cache
++    public final Long2ObjectMap<Chunk> field_73244_f = new Long2ObjectOpenHashMap<Chunk>(8192) {
++
++        private static final long serialVersionUID = 1L;
++        protected Chunk lastChunkByPos = null;
++
++        @Override
++        public Chunk get(long key) {
++            if (this.lastChunkByPos != null && key == this.lastChunkByPos.chunkKey) {
++                return this.lastChunkByPos;
++            }
++            return this.lastChunkByPos = super.get(key);
++        }
++
++        @Override
++        public Chunk remove(long key) {
++            if (this.lastChunkByPos != null && key == this.lastChunkByPos.chunkKey) {
++                this.lastChunkByPos = null;
++            }
++            return super.remove(key);
++        }
++    };
++    // Forge end
      public final WorldServer field_73251_h;
 +    private Set<Long> loadingChunks = com.google.common.collect.Sets.newHashSet();
  
      public ChunkProviderServer(WorldServer p_i46838_1_, IChunkLoader p_i46838_2_, IChunkGenerator p_i46838_3_)
      {
-@@ -82,20 +83,47 @@
+@@ -82,20 +105,47 @@
      @Nullable
      public Chunk func_186028_c(int p_186028_1_, int p_186028_2_)
      {
@@ -60,7 +85,7 @@
          return chunk;
      }
  
-@@ -221,6 +249,11 @@
+@@ -221,6 +271,11 @@
          {
              if (!this.field_73248_b.isEmpty())
              {
@@ -72,7 +97,7 @@
                  Iterator<Long> iterator = this.field_73248_b.iterator();
  
                  for (int i = 0; i < 100 && iterator.hasNext(); iterator.remove())
-@@ -235,6 +268,11 @@
+@@ -235,6 +290,11 @@
                          this.func_73243_a(chunk);
                          this.field_73244_f.remove(olong);
                          ++i;


### PR DESCRIPTION
This commit was created by Aikar which can be found here

https://github.com/PaperMC/Paper/blob/master/Spigot-Server-Patches/0094-Optimize-Chunk-Access.patch

The patch essentially avoids repeated lookups to 'ChunkProviderServer.id2ChunkMap' for the same chunk key. It does this by caching the last chunk lookup and returns it immediately if the chunk key matches.

The main methods involved in this are getChunkFromChunkCoords, getChunkFromBlockCoords, getBlockState, getLoadedChunk, as well as any other method that performs a lookup on id2ChunkMap.

Some examples of this occuring are the following
-  Entity AI repeatedly calling getBlockState for the same location.
-  Entity block collisions repeatedly calling getBlockState for the same location.
