### PR TITLE
New ClientChatPrintedEvent (1.10)

### DIFF
--- a/patches/minecraft/net/minecraft/client/gui/GuiNewChat.java.patch
+++ b/patches/minecraft/net/minecraft/client/gui/GuiNewChat.java.patch
@@ -1,27 +1,6 @@
 --- ../src-base/minecraft/net/minecraft/client/gui/GuiNewChat.java
 +++ ../src-work/minecraft/net/minecraft/client/gui/GuiNewChat.java
-@@ -3,9 +3,6 @@
- import com.google.common.base.Joiner;
- import com.google.common.base.Splitter;
- import com.google.common.collect.Lists;
--import java.util.Iterator;
--import java.util.List;
--import javax.annotation.Nullable;
- import net.minecraft.client.Minecraft;
- import net.minecraft.client.renderer.GlStateManager;
- import net.minecraft.entity.player.EntityPlayer;
-@@ -17,6 +14,10 @@
- import org.apache.logging.log4j.LogManager;
- import org.apache.logging.log4j.Logger;
- 
-+import javax.annotation.Nullable;
-+import java.util.Iterator;
-+import java.util.List;
-+
- @SideOnly(Side.CLIENT)
- public class GuiNewChat extends Gui
- {
-@@ -136,6 +137,9 @@
+@@ -136,6 +136,9 @@
  
      public void func_146234_a(ITextComponent p_146234_1_, int p_146234_2_)
      {

--- a/patches/minecraft/net/minecraft/client/gui/GuiNewChat.java.patch
+++ b/patches/minecraft/net/minecraft/client/gui/GuiNewChat.java.patch
@@ -1,0 +1,33 @@
+--- ../src-base/minecraft/net/minecraft/client/gui/GuiNewChat.java
++++ ../src-work/minecraft/net/minecraft/client/gui/GuiNewChat.java
+@@ -3,9 +3,6 @@
+ import com.google.common.base.Joiner;
+ import com.google.common.base.Splitter;
+ import com.google.common.collect.Lists;
+-import java.util.Iterator;
+-import java.util.List;
+-import javax.annotation.Nullable;
+ import net.minecraft.client.Minecraft;
+ import net.minecraft.client.renderer.GlStateManager;
+ import net.minecraft.entity.player.EntityPlayer;
+@@ -17,6 +14,10 @@
+ import org.apache.logging.log4j.LogManager;
+ import org.apache.logging.log4j.Logger;
+ 
++import javax.annotation.Nullable;
++import java.util.Iterator;
++import java.util.List;
++
+ @SideOnly(Side.CLIENT)
+ public class GuiNewChat extends Gui
+ {
+@@ -136,6 +137,9 @@
+ 
+     public void func_146234_a(ITextComponent p_146234_1_, int p_146234_2_)
+     {
++        net.minecraftforge.client.event.ClientChatPrintedEvent event = new net.minecraftforge.client.event.ClientChatPrintedEvent(p_146234_1_, p_146234_2_);
++        if (net.minecraftforge.common.MinecraftForge.EVENT_BUS.post(event)) return;
++        p_146234_1_ = event.getMessage();
+         this.func_146237_a(p_146234_1_, p_146234_2_, this.field_146247_f.field_71456_v.func_73834_c(), false);
+         field_146249_a.info("[CHAT] {}", new Object[] {field_184062_f.join(field_184061_a.split(p_146234_1_.func_150260_c()))});
+     }

--- a/patches/minecraft/net/minecraft/client/gui/GuiNewChat.java.patch
+++ b/patches/minecraft/net/minecraft/client/gui/GuiNewChat.java.patch
@@ -1,12 +1,13 @@
 --- ../src-base/minecraft/net/minecraft/client/gui/GuiNewChat.java
 +++ ../src-work/minecraft/net/minecraft/client/gui/GuiNewChat.java
-@@ -136,6 +136,9 @@
+@@ -136,6 +136,10 @@
  
      public void func_146234_a(ITextComponent p_146234_1_, int p_146234_2_)
      {
 +        net.minecraftforge.client.event.ClientChatPrintedEvent event = new net.minecraftforge.client.event.ClientChatPrintedEvent(p_146234_1_, p_146234_2_);
 +        if (net.minecraftforge.common.MinecraftForge.EVENT_BUS.post(event)) return;
 +        p_146234_1_ = event.getMessage();
++        p_146234_2_ = event.getChatLineID();
          this.func_146237_a(p_146234_1_, p_146234_2_, this.field_146247_f.field_71456_v.func_73834_c(), false);
          field_146249_a.info("[CHAT] {}", new Object[] {field_184062_f.join(field_184061_a.split(p_146234_1_.func_150260_c()))});
      }

--- a/src/main/java/net/minecraftforge/client/event/ClientChatPrintedEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/ClientChatPrintedEvent.java
@@ -36,4 +36,9 @@ public class ClientChatPrintedEvent extends Event
     {
         return chatLineID;
     }
+
+    public void setChatLineID(int chatLineID)
+    {
+        this.chatLineID = chatLineID;
+    }
 }

--- a/src/main/java/net/minecraftforge/client/event/ClientChatPrintedEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/ClientChatPrintedEvent.java
@@ -1,0 +1,39 @@
+package net.minecraftforge.client.event;
+
+import net.minecraft.util.text.ITextComponent;
+import net.minecraftforge.fml.common.eventhandler.Cancelable;
+import net.minecraftforge.fml.common.eventhandler.Event;
+
+/**
+ * ClientChatPrintedEvent is posted right <i>before</i> a chat message is added to the player's chat GUI.
+ * Canceling the event will prevent it from being added to the GUI or logged.
+ *
+ * It is posted in {@link net.minecraft.client.gui.GuiNewChat#printChatMessageWithOptionalDeletion(ITextComponent, int)}
+ */
+@Cancelable
+public class ClientChatPrintedEvent extends Event
+{
+    private ITextComponent message;
+    private int chatLineID;
+
+    public ClientChatPrintedEvent(ITextComponent message, int chatLineID)
+    {
+        this.message = message;
+        this.chatLineID = chatLineID;
+    }
+
+    public ITextComponent getMessage()
+    {
+        return message;
+    }
+
+    public void setMessage(ITextComponent message)
+    {
+        this.message = message;
+    }
+
+    public int getChatLineID()
+    {
+        return chatLineID;
+    }
+}

--- a/src/test/java/net/minecraftforge/test/ClientChatModificataionsTest.java
+++ b/src/test/java/net/minecraftforge/test/ClientChatModificataionsTest.java
@@ -1,0 +1,50 @@
+package net.minecraftforge.test;
+
+import net.minecraft.client.entity.EntityPlayerSP;
+import net.minecraft.entity.Entity;
+import net.minecraft.util.text.ITextComponent;
+import net.minecraft.util.text.TextComponentString;
+import net.minecraftforge.client.event.ClientChatPrintedEvent;
+import net.minecraftforge.common.MinecraftForge;
+import net.minecraftforge.event.entity.EntityJoinWorldEvent;
+import net.minecraftforge.fml.common.Mod;
+import net.minecraftforge.fml.common.event.FMLInitializationEvent;
+import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
+
+@Mod(modid="clientchatmodificationstest", name="Client Chat Modifications Test", version="0.0.0", clientSideOnly = true)
+public class ClientChatModificataionsTest
+{
+    @Mod.EventHandler
+    public void init(FMLInitializationEvent event)
+    {
+        MinecraftForge.EVENT_BUS.register(this);
+    }
+
+    private static final String CHANGE = "Welcome! This message will be modified.";
+    private static final String REMOVE = "Welcome! This message will not appear.";
+
+    @SubscribeEvent
+    public void addWelcomeMessage(EntityJoinWorldEvent event)
+    {
+        Entity entity = event.getEntity();
+        if (event.getWorld().isRemote && entity instanceof EntityPlayerSP)
+        {
+            entity.addChatMessage(new TextComponentString(CHANGE));
+            entity.addChatMessage(new TextComponentString(REMOVE));
+        }
+    }
+
+    @SubscribeEvent
+    public void changeMessages(ClientChatPrintedEvent event)
+    {
+        ITextComponent component = event.getMessage();
+        if (component instanceof TextComponentString)
+        {
+            String message = ((TextComponentString) component).getText();
+            if (message.equals(CHANGE))
+                event.setMessage(new TextComponentString(CHANGE + " This is the modification."));
+            else if (message.equals(REMOVE))
+                event.setCanceled(true);
+        }
+    }
+}


### PR DESCRIPTION
This PR adds a new event, ClientChatPrintedEvent, which is posted right before a chat message is added to the client's chat GUI. It can be canceled to prevent the printing and logging of the message. The chat message can also be modified using setMessage. It gives you access to the new chat line ID as well, in case anybody ever wants that.

This closes #1936 and #2810

This also includes a test to show two basic use examples: modifying a chat message, and canceling a chat message. It sends the messages to modify when the player joins the world because that is easiest, in my opinion, to test.

_Note: There are two commits, as in the first one IDEA reorganized the imports in the GuiNewChat class, making the patch much larger than necessary. I can squash the commits if you'd like, but I figured you'd do it if you merged anyway through GitHub._
