### PR TITLE
[1.10] Add canApplyAtEnchantmentTable to Item

### DIFF
--- a/patches/minecraft/net/minecraft/enchantment/Enchantment.java.patch
+++ b/patches/minecraft/net/minecraft/enchantment/Enchantment.java.patch
@@ -33,7 +33,7 @@
 +     */
 +    public boolean canApplyAtEnchantingTable(ItemStack stack)
 +    {
-+        return this.field_77351_y.func_77557_a(stack.func_77973_b());
++        return stack.func_77973_b().canApplyAtEnchantingTable(stack, this);
 +    }
 +
 +    /**

--- a/patches/minecraft/net/minecraft/item/Item.java.patch
+++ b/patches/minecraft/net/minecraft/item/Item.java.patch
@@ -60,7 +60,7 @@
          return p_77621_1_.func_147447_a(vec3d, vec3d1, p_77621_3_, !p_77621_3_, false);
      }
  
-@@ -426,11 +433,580 @@
+@@ -426,11 +433,593 @@
          return false;
      }
  
@@ -566,6 +566,19 @@
 +    }
 +
 +    /**
++     * Checks whether an item can be enchanted with a certain enchantment. This applies specifically to enchanting an item in the enchanting table and is called when retrieving the list of possible enchantments for an item.
++     * Enchantments may additionally (or exclusively) be doing their own checks in {@link net.minecraft.enchantment.Enchantment#canApplyAtEnchantingTable(ItemStack)}; check the individual implementation for reference.
++     * By default this will check if the enchantment type is valid for this item type.
++     * @param stack the item stack to be enchanted
++     * @param enchantment the enchantment to be applied
++     * @return true if the enchantment can be applied to this item
++     */
++    public boolean canApplyAtEnchantingTable(ItemStack stack, net.minecraft.enchantment.Enchantment enchantment)
++    {
++        return enchantment.field_77351_y.func_77557_a(stack.func_77973_b());
++    }
++
++    /**
 +     * Whether this Item can be used as a payment to activate the vanilla beacon.
 +     * @param stack the ItemStack
 +     * @return true if this Item can be used
@@ -641,7 +654,7 @@
      public static void func_150900_l()
      {
          func_179214_a(Blocks.field_150348_b, (new ItemMultiTexture(Blocks.field_150348_b, Blocks.field_150348_b, new Function<ItemStack, String>()
-@@ -962,6 +1538,10 @@
+@@ -962,6 +1551,10 @@
          private final float field_78011_i;
          private final int field_78008_j;
  
@@ -652,7 +665,7 @@
          private ToolMaterial(int p_i1874_3_, int p_i1874_4_, float p_i1874_5_, float p_i1874_6_, int p_i1874_7_)
          {
              this.field_78001_f = p_i1874_3_;
-@@ -996,9 +1576,36 @@
+@@ -996,9 +1589,36 @@
              return this.field_78008_j;
          }
  

--- a/src/test/java/net/minecraftforge/test/CanApplyAtEnchantingTableTest.java
+++ b/src/test/java/net/minecraftforge/test/CanApplyAtEnchantingTableTest.java
@@ -1,0 +1,44 @@
+package net.minecraftforge.test;
+
+import net.minecraft.enchantment.Enchantment;
+import net.minecraft.init.Enchantments;
+import net.minecraft.item.Item;
+import net.minecraft.item.ItemStack;
+import net.minecraftforge.fml.common.Mod;
+import net.minecraftforge.fml.common.event.FMLPreInitializationEvent;
+import net.minecraftforge.fml.common.registry.GameRegistry;
+
+@Mod(modid="canapplyatenchantingtabletest", name="CanApplyAtEnchantingTableTest", version="0.0.0")
+public class CanApplyAtEnchantingTableTest
+{
+	public static final boolean ENABLE = false;
+
+	public static final Item testItem = new Item()
+	{
+		public boolean isItemTool(ItemStack stack)
+		{
+			return true;
+		}
+
+		@Override
+		public int getItemEnchantability()
+		{
+			return 30;
+		}
+
+		@Override
+		public boolean canApplyAtEnchantingTable(ItemStack stack, Enchantment enchantment)
+		{
+			return super.canApplyAtEnchantingTable(stack, enchantment) || enchantment == Enchantments.FORTUNE;
+		}
+	};
+
+	@Mod.EventHandler
+	public void preInit(FMLPreInitializationEvent event)
+	{
+		if(ENABLE)
+		{
+			GameRegistry.register(testItem.setRegistryName("test_item").setMaxStackSize(1));
+		}
+	}
+}


### PR DESCRIPTION
This adds a `canApplyAtEnchantmentTable` function to the `Item` class, allowing increased control of what enchantments can be put on an item over Vanilla's hard-coded item type checks.

Prior, this was all hard-coded in `EnumEnchantmentType`, and the only way to make your item receive certain enchantments was to extend a specific Item class (such as `ItemTool`, `ItemSword`, `ItemBow`), which does not cover all cases.

Specifically in my case, to explain in real-world terms, the new Sieve Meshes coming to Ex Nihilo & Ex Compressum, which are meant to be enchantable for increased output or speed. While it would be possible to extend `ItemTool` for the mesh item and make it accept the Fortune/Efficiency enchantment that way, it would also allow unwanted enchantments such as Silk Touch to be applied and pollute the mesh's item class with methods from `ItemTool` which are not meant to be implemented for this type of item.

The default behaviour of checking the enchantment type remains unchanged.
