### PR TITLE
Fix #3213 Clean up nullability annotations for capabilities

### DIFF
--- a/patches/minecraft/net/minecraft/entity/Entity.java.patch
+++ b/patches/minecraft/net/minecraft/entity/Entity.java.patch
@@ -126,7 +126,7 @@
      }
  
      public boolean func_174816_a(Explosion p_174816_1_, World p_174816_2_, BlockPos p_174816_3_, IBlockState p_174816_4_, float p_174816_5_)
-@@ -2726,6 +2746,164 @@
+@@ -2726,6 +2746,165 @@
          EnchantmentHelper.func_151385_b(p_174815_1_, p_174815_2_);
      }
  
@@ -263,14 +263,15 @@
 +        return this instanceof EntityLivingBase;
 +    }
 +
-+    public boolean hasCapability(net.minecraftforge.common.capabilities.Capability<?> capability, net.minecraft.util.EnumFacing facing)
++    public boolean hasCapability(net.minecraftforge.common.capabilities.Capability<?> capability, @Nullable net.minecraft.util.EnumFacing facing)
 +    {
 +        if (getCapability(capability, facing) != null)
 +            return true;
 +        return capabilities == null ? false : capabilities.hasCapability(capability, facing);
 +    }
 +
-+    public <T> T getCapability(net.minecraftforge.common.capabilities.Capability<T> capability, net.minecraft.util.EnumFacing facing)
++    @Nullable
++    public <T> T getCapability(net.minecraftforge.common.capabilities.Capability<T> capability, @Nullable net.minecraft.util.EnumFacing facing)
 +    {
 +        return capabilities == null ? null : capabilities.getCapability(capability, facing);
 +    }

--- a/patches/minecraft/net/minecraft/entity/EntityLivingBase.java.patch
+++ b/patches/minecraft/net/minecraft/entity/EntityLivingBase.java.patch
@@ -292,7 +292,7 @@
          }
  
          this.func_184602_cy();
-@@ -2685,4 +2757,28 @@
+@@ -2685,4 +2757,29 @@
      {
          return true;
      }
@@ -304,7 +304,8 @@
 +
 +    @SuppressWarnings("unchecked")
 +    @Override
-+    public <T> T getCapability(net.minecraftforge.common.capabilities.Capability<T> capability, net.minecraft.util.EnumFacing facing)
++    @Nullable
++    public <T> T getCapability(net.minecraftforge.common.capabilities.Capability<T> capability, @Nullable net.minecraft.util.EnumFacing facing)
 +    {
 +        if (capability == net.minecraftforge.items.CapabilityItemHandler.ITEM_HANDLER_CAPABILITY)
 +        {
@@ -316,7 +317,7 @@
 +    }
 +
 +    @Override
-+    public boolean hasCapability(net.minecraftforge.common.capabilities.Capability<?> capability, net.minecraft.util.EnumFacing facing)
++    public boolean hasCapability(net.minecraftforge.common.capabilities.Capability<?> capability, @Nullable net.minecraft.util.EnumFacing facing)
 +    {
 +        return capability == net.minecraftforge.items.CapabilityItemHandler.ITEM_HANDLER_CAPABILITY || super.hasCapability(capability, facing);
 +    }

--- a/patches/minecraft/net/minecraft/entity/item/EntityMinecartContainer.java.patch
+++ b/patches/minecraft/net/minecraft/entity/item/EntityMinecartContainer.java.patch
@@ -8,7 +8,7 @@
          if (!this.field_70170_p.field_72995_K)
          {
              p_184230_1_.func_71007_a(this);
-@@ -288,6 +289,25 @@
+@@ -288,6 +289,26 @@
          }
      }
  
@@ -16,7 +16,8 @@
 +
 +    @SuppressWarnings("unchecked")
 +    @Override
-+    public <T> T getCapability(net.minecraftforge.common.capabilities.Capability<T> capability, net.minecraft.util.EnumFacing facing)
++    @Nullable
++    public <T> T getCapability(net.minecraftforge.common.capabilities.Capability<T> capability, @Nullable net.minecraft.util.EnumFacing facing)
 +    {
 +        if (capability == net.minecraftforge.items.CapabilityItemHandler.ITEM_HANDLER_CAPABILITY)
 +        {
@@ -26,7 +27,7 @@
 +    }
 +
 +    @Override
-+    public boolean hasCapability(net.minecraftforge.common.capabilities.Capability<?> capability, net.minecraft.util.EnumFacing facing)
++    public boolean hasCapability(net.minecraftforge.common.capabilities.Capability<?> capability, @Nullable net.minecraft.util.EnumFacing facing)
 +    {
 +        return capability == net.minecraftforge.items.CapabilityItemHandler.ITEM_HANDLER_CAPABILITY || super.hasCapability(capability, facing);
 +    }

--- a/patches/minecraft/net/minecraft/entity/passive/EntityHorse.java.patch
+++ b/patches/minecraft/net/minecraft/entity/passive/EntityHorse.java.patch
@@ -34,7 +34,7 @@
              }
  
              this.field_70747_aH = this.func_70689_ay() * 0.1F;
-@@ -1813,4 +1815,21 @@
+@@ -1813,4 +1815,22 @@
                  this.field_188477_b = p_i46589_2_;
              }
          }
@@ -44,14 +44,15 @@
 +
 +    @SuppressWarnings("unchecked")
 +    @Override
-+    public <T> T getCapability(net.minecraftforge.common.capabilities.Capability<T> capability, net.minecraft.util.EnumFacing facing)
++    @Nullable
++    public <T> T getCapability(net.minecraftforge.common.capabilities.Capability<T> capability, @Nullable net.minecraft.util.EnumFacing facing)
 +    {
 +        if (capability == net.minecraftforge.items.CapabilityItemHandler.ITEM_HANDLER_CAPABILITY) return (T) itemHandler;
 +        return super.getCapability(capability, facing);
 +    }
 +
 +    @Override
-+    public boolean hasCapability(net.minecraftforge.common.capabilities.Capability<?> capability, net.minecraft.util.EnumFacing facing)
++    public boolean hasCapability(net.minecraftforge.common.capabilities.Capability<?> capability, @Nullable net.minecraft.util.EnumFacing facing)
 +    {
 +        return capability == net.minecraftforge.items.CapabilityItemHandler.ITEM_HANDLER_CAPABILITY || super.hasCapability(capability, facing);
 +    }

--- a/patches/minecraft/net/minecraft/entity/player/EntityPlayer.java.patch
+++ b/patches/minecraft/net/minecraft/entity/player/EntityPlayer.java.patch
@@ -421,7 +421,7 @@
  
          if (this.func_70608_bn())
          {
-@@ -2367,6 +2478,161 @@
+@@ -2367,6 +2478,162 @@
          return this.field_71075_bZ.field_75098_d && this.func_70003_b(2, "");
      }
  
@@ -561,7 +561,8 @@
 +
 +    @SuppressWarnings("unchecked")
 +    @Override
-+    public <T> T getCapability(net.minecraftforge.common.capabilities.Capability<T> capability, net.minecraft.util.EnumFacing facing)
++    @Nullable
++    public <T> T getCapability(net.minecraftforge.common.capabilities.Capability<T> capability, @Nullable net.minecraft.util.EnumFacing facing)
 +    {
 +        if (capability == net.minecraftforge.items.CapabilityItemHandler.ITEM_HANDLER_CAPABILITY)
 +        {
@@ -573,7 +574,7 @@
 +    }
 +
 +    @Override
-+    public boolean hasCapability(net.minecraftforge.common.capabilities.Capability<?> capability, net.minecraft.util.EnumFacing facing)
++    public boolean hasCapability(net.minecraftforge.common.capabilities.Capability<?> capability, @Nullable net.minecraft.util.EnumFacing facing)
 +    {
 +        return capability == net.minecraftforge.items.CapabilityItemHandler.ITEM_HANDLER_CAPABILITY || super.hasCapability(capability, facing);
 +    }

--- a/patches/minecraft/net/minecraft/item/ItemStack.java.patch
+++ b/patches/minecraft/net/minecraft/item/ItemStack.java.patch
@@ -239,17 +239,18 @@
          this.field_151002_e = p_150996_1_;
      }
  
-@@ -993,4 +1033,45 @@
+@@ -993,4 +1033,46 @@
              return false;
          }
      }
 +
-+    public boolean hasCapability(net.minecraftforge.common.capabilities.Capability<?> capability, net.minecraft.util.EnumFacing facing)
++    public boolean hasCapability(net.minecraftforge.common.capabilities.Capability<?> capability, @Nullable net.minecraft.util.EnumFacing facing)
 +    {
 +        return this.capabilities == null ? false : this.capabilities.hasCapability(capability, facing);
 +    }
 +
-+    public <T> T getCapability(net.minecraftforge.common.capabilities.Capability<T> capability, net.minecraft.util.EnumFacing facing)
++    @Nullable
++    public <T> T getCapability(net.minecraftforge.common.capabilities.Capability<T> capability, @Nullable net.minecraft.util.EnumFacing facing)
 +    {
 +        return this.capabilities == null ? null : this.capabilities.getCapability(capability, facing);
 +    }

--- a/patches/minecraft/net/minecraft/tileentity/TileEntity.java.patch
+++ b/patches/minecraft/net/minecraft/tileentity/TileEntity.java.patch
@@ -68,7 +68,7 @@
      public double func_145835_a(double p_145835_1_, double p_145835_3_, double p_145835_5_)
      {
          double d0 = (double)this.field_174879_c.func_177958_n() + 0.5D - p_145835_1_;
-@@ -305,6 +315,202 @@
+@@ -305,6 +315,203 @@
      {
      }
  
@@ -246,12 +246,13 @@
 +        capabilities = net.minecraftforge.event.ForgeEventFactory.gatherCapabilities(this);
 +    }
 +
-+    public boolean hasCapability(net.minecraftforge.common.capabilities.Capability<?> capability, net.minecraft.util.EnumFacing facing)
++    public boolean hasCapability(net.minecraftforge.common.capabilities.Capability<?> capability, @Nullable net.minecraft.util.EnumFacing facing)
 +    {
 +        return capabilities == null ? false : capabilities.hasCapability(capability, facing);
 +    }
 +
-+    public <T> T getCapability(net.minecraftforge.common.capabilities.Capability<T> capability, net.minecraft.util.EnumFacing facing)
++    @Nullable
++    public <T> T getCapability(net.minecraftforge.common.capabilities.Capability<T> capability, @Nullable net.minecraft.util.EnumFacing facing)
 +    {
 +        return capabilities == null ? null : capabilities.getCapability(capability, facing);
 +    }

--- a/patches/minecraft/net/minecraft/tileentity/TileEntityBrewingStand.java.patch
+++ b/patches/minecraft/net/minecraft/tileentity/TileEntityBrewingStand.java.patch
@@ -63,7 +63,7 @@
          }
      }
  
-@@ -375,6 +374,26 @@
+@@ -375,6 +374,27 @@
          }
      }
  
@@ -73,7 +73,8 @@
 +
 +    @SuppressWarnings("unchecked")
 +    @Override
-+    public <T> T getCapability(net.minecraftforge.common.capabilities.Capability<T> capability, net.minecraft.util.EnumFacing facing)
++    @Nullable
++    public <T> T getCapability(net.minecraftforge.common.capabilities.Capability<T> capability, @Nullable net.minecraft.util.EnumFacing facing)
 +    {
 +        if (facing != null && capability == net.minecraftforge.items.CapabilityItemHandler.ITEM_HANDLER_CAPABILITY)
 +        {

--- a/patches/minecraft/net/minecraft/tileentity/TileEntityChest.java.patch
+++ b/patches/minecraft/net/minecraft/tileentity/TileEntityChest.java.patch
@@ -8,7 +8,7 @@
      }
  
      @SuppressWarnings("incomplete-switch")
-@@ -470,4 +471,26 @@
+@@ -470,4 +471,27 @@
              this.field_145985_p[i] = null;
          }
      }
@@ -17,7 +17,8 @@
 +
 +    @SuppressWarnings("unchecked")
 +    @Override
-+    public <T> T getCapability(net.minecraftforge.common.capabilities.Capability<T> capability, net.minecraft.util.EnumFacing facing)
++    @Nullable
++    public <T> T getCapability(net.minecraftforge.common.capabilities.Capability<T> capability, @Nullable net.minecraft.util.EnumFacing facing)
 +    {
 +        if (capability == net.minecraftforge.items.CapabilityItemHandler.ITEM_HANDLER_CAPABILITY)
 +        {

--- a/patches/minecraft/net/minecraft/tileentity/TileEntityFurnace.java.patch
+++ b/patches/minecraft/net/minecraft/tileentity/TileEntityFurnace.java.patch
@@ -75,7 +75,7 @@
          }
      }
  
-@@ -447,4 +458,22 @@
+@@ -447,4 +458,23 @@
              this.field_145957_n[i] = null;
          }
      }
@@ -86,7 +86,8 @@
 +
 +    @SuppressWarnings("unchecked")
 +    @Override
-+    public <T> T getCapability(net.minecraftforge.common.capabilities.Capability<T> capability, net.minecraft.util.EnumFacing facing)
++    @Nullable
++    public <T> T getCapability(net.minecraftforge.common.capabilities.Capability<T> capability, @Nullable net.minecraft.util.EnumFacing facing)
 +    {
 +        if (facing != null && capability == net.minecraftforge.items.CapabilityItemHandler.ITEM_HANDLER_CAPABILITY)
 +            if (facing == EnumFacing.DOWN)

--- a/patches/minecraft/net/minecraft/tileentity/TileEntityLockable.java.patch
+++ b/patches/minecraft/net/minecraft/tileentity/TileEntityLockable.java.patch
@@ -1,6 +1,6 @@
 --- ../src-base/minecraft/net/minecraft/tileentity/TileEntityLockable.java
 +++ ../src-work/minecraft/net/minecraft/tileentity/TileEntityLockable.java
-@@ -49,4 +49,26 @@
+@@ -49,4 +49,27 @@
      {
          return (ITextComponent)(this.func_145818_k_() ? new TextComponentString(this.func_70005_c_()) : new TextComponentTranslation(this.func_70005_c_(), new Object[0]));
      }
@@ -14,7 +14,8 @@
 +
 +    @SuppressWarnings("unchecked")
 +    @Override
-+    public <T> T getCapability(net.minecraftforge.common.capabilities.Capability<T> capability, net.minecraft.util.EnumFacing facing)
++    @javax.annotation.Nullable
++    public <T> T getCapability(net.minecraftforge.common.capabilities.Capability<T> capability, @javax.annotation.Nullable net.minecraft.util.EnumFacing facing)
 +    {
 +        if (capability == net.minecraftforge.items.CapabilityItemHandler.ITEM_HANDLER_CAPABILITY)
 +            return (T) (itemHandler == null ? (itemHandler = createUnSidedHandler()) : itemHandler);
@@ -22,7 +23,7 @@
 +    }
 +
 +    @Override
-+    public boolean hasCapability(net.minecraftforge.common.capabilities.Capability<?> capability, net.minecraft.util.EnumFacing facing)
++    public boolean hasCapability(net.minecraftforge.common.capabilities.Capability<?> capability, @javax.annotation.Nullable net.minecraft.util.EnumFacing facing)
 +    {
 +        return capability == net.minecraftforge.items.CapabilityItemHandler.ITEM_HANDLER_CAPABILITY || super.hasCapability(capability, facing);
 +    }

--- a/patches/minecraft/net/minecraft/world/World.java.patch
+++ b/patches/minecraft/net/minecraft/world/World.java.patch
@@ -830,7 +830,7 @@
                      }
                  }
              }
-@@ -3628,6 +3820,112 @@
+@@ -3628,6 +3820,113 @@
          return i >= -128 && i <= 128 && j >= -128 && j <= 128;
      }
  
@@ -925,11 +925,12 @@
 +            capabilityData.setCapabilities(field_73011_w, capabilities);
 +        }
 +    }
-+    public boolean hasCapability(net.minecraftforge.common.capabilities.Capability<?> capability, EnumFacing facing)
++    public boolean hasCapability(net.minecraftforge.common.capabilities.Capability<?> capability, @Nullable EnumFacing facing)
 +    {
 +        return capabilities == null ? false : capabilities.hasCapability(capability, facing);
 +    }
-+    public <T> T getCapability(net.minecraftforge.common.capabilities.Capability<T> capability, EnumFacing facing)
++    @Nullable
++    public <T> T getCapability(net.minecraftforge.common.capabilities.Capability<T> capability, @Nullable EnumFacing facing)
 +    {
 +        return capabilities == null ? null : capabilities.getCapability(capability, facing);
 +    }

--- a/src/main/java/net/minecraftforge/common/capabilities/CapabilityDispatcher.java
+++ b/src/main/java/net/minecraftforge/common/capabilities/CapabilityDispatcher.java
@@ -99,6 +99,7 @@ public final class CapabilityDispatcher implements INBTSerializable<NBTTagCompou
     }
 
     @Override
+    @Nullable
     public <T> T getCapability(Capability<T> capability, @Nullable EnumFacing facing)
     {
         for (ICapabilityProvider cap : caps)

--- a/src/main/java/net/minecraftforge/common/capabilities/ICapabilityProvider.java
+++ b/src/main/java/net/minecraftforge/common/capabilities/ICapabilityProvider.java
@@ -50,7 +50,8 @@ public interface ICapabilityProvider
      * @param capability The capability to check
      * @param facing The Side to check from:
      *   CAN BE NULL. Null is defined to represent 'internal' or 'self'
-     * @return True if this object supports the capability.
+     * @return The requested capability. Returns null when {@link #hasCapability(Capability, EnumFacing)} would return false.
      */
+    @Nullable
     <T> T getCapability(Capability<T> capability, @Nullable EnumFacing facing);
 }

--- a/src/main/java/net/minecraftforge/common/model/animation/CapabilityAnimation.java
+++ b/src/main/java/net/minecraftforge/common/model/animation/CapabilityAnimation.java
@@ -19,6 +19,7 @@
 
 package net.minecraftforge.common.model.animation;
 
+import javax.annotation.Nullable;
 import java.util.concurrent.Callable;
 
 import net.minecraft.nbt.NBTBase;
@@ -61,12 +62,15 @@ public class CapabilityAnimation
             this.asm = asm;
         }
 
-        public boolean hasCapability(Capability<?> capability, EnumFacing facing)
+        @Override
+        public boolean hasCapability(Capability<?> capability, @Nullable EnumFacing facing)
         {
             return capability == ANIMATION_CAPABILITY;
         }
 
-        public <T> T getCapability(Capability<T> capability, EnumFacing facing)
+        @Override
+        @Nullable
+        public <T> T getCapability(Capability<T> capability, @Nullable EnumFacing facing)
         {
             if(capability == ANIMATION_CAPABILITY)
             {

--- a/src/main/java/net/minecraftforge/fluids/TileFluidHandler.java
+++ b/src/main/java/net/minecraftforge/fluids/TileFluidHandler.java
@@ -101,6 +101,7 @@ public class TileFluidHandler extends TileEntity implements IFluidHandler
     }
 
     @Override
+    @Nullable
     public <T> T getCapability(Capability<T> capability, @Nullable EnumFacing facing)
     {
         if (capability == CapabilityFluidHandler.FLUID_HANDLER_CAPABILITY)

--- a/src/main/java/net/minecraftforge/fluids/capability/TileFluidHandler.java
+++ b/src/main/java/net/minecraftforge/fluids/capability/TileFluidHandler.java
@@ -19,6 +19,8 @@
 
 package net.minecraftforge.fluids.capability;
 
+import javax.annotation.Nullable;
+
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.EnumFacing;
@@ -46,17 +48,17 @@ public class TileFluidHandler extends TileEntity
     }
 
     @Override
-    public boolean hasCapability(Capability<?> capability, EnumFacing facing)
+    public boolean hasCapability(Capability<?> capability, @Nullable EnumFacing facing)
     {
         return capability == CapabilityFluidHandler.FLUID_HANDLER_CAPABILITY || super.hasCapability(capability, facing);
     }
 
-    @SuppressWarnings("unchecked")
     @Override
-    public <T> T getCapability(Capability<T> capability, EnumFacing facing)
+    @Nullable
+    public <T> T getCapability(Capability<T> capability, @Nullable EnumFacing facing)
     {
         if (capability == CapabilityFluidHandler.FLUID_HANDLER_CAPABILITY)
-            return (T) tank;
+            return CapabilityFluidHandler.FLUID_HANDLER_CAPABILITY.cast(tank);
         return super.getCapability(capability, facing);
     }
 }

--- a/src/main/java/net/minecraftforge/fluids/capability/templates/FluidHandlerItemStack.java
+++ b/src/main/java/net/minecraftforge/fluids/capability/templates/FluidHandlerItemStack.java
@@ -193,14 +193,15 @@ public class FluidHandlerItemStack implements IFluidHandler, ICapabilityProvider
     }
 
     @Override
-    public boolean hasCapability(Capability<?> capability, EnumFacing facing)
+    public boolean hasCapability(Capability<?> capability, @Nullable EnumFacing facing)
     {
         return capability == CapabilityFluidHandler.FLUID_HANDLER_CAPABILITY;
     }
 
     @SuppressWarnings("unchecked")
     @Override
-    public <T> T getCapability(Capability<T> capability, EnumFacing facing)
+    @Nullable
+    public <T> T getCapability(Capability<T> capability, @Nullable EnumFacing facing)
     {
         return capability == CapabilityFluidHandler.FLUID_HANDLER_CAPABILITY ? (T) this : null;
     }

--- a/src/main/java/net/minecraftforge/fluids/capability/templates/FluidHandlerItemStackSimple.java
+++ b/src/main/java/net/minecraftforge/fluids/capability/templates/FluidHandlerItemStackSimple.java
@@ -170,14 +170,15 @@ public class FluidHandlerItemStackSimple implements IFluidHandler, ICapabilityPr
     }
 
     @Override
-    public boolean hasCapability(Capability<?> capability, EnumFacing facing)
+    public boolean hasCapability(Capability<?> capability, @Nullable EnumFacing facing)
     {
         return capability == CapabilityFluidHandler.FLUID_HANDLER_CAPABILITY;
     }
 
     @SuppressWarnings("unchecked")
     @Override
-    public <T> T getCapability(Capability<T> capability, EnumFacing facing)
+    @Nullable
+    public <T> T getCapability(Capability<T> capability, @Nullable EnumFacing facing)
     {
         return capability == CapabilityFluidHandler.FLUID_HANDLER_CAPABILITY ? (T) this : null;
     }

--- a/src/main/java/net/minecraftforge/fluids/capability/wrappers/FluidBucketWrapper.java
+++ b/src/main/java/net/minecraftforge/fluids/capability/wrappers/FluidBucketWrapper.java
@@ -177,13 +177,14 @@ public class FluidBucketWrapper implements IFluidHandler, ICapabilityProvider
     }
 
     @Override
-    public boolean hasCapability(Capability<?> capability, EnumFacing facing)
+    public boolean hasCapability(Capability<?> capability, @Nullable EnumFacing facing)
     {
         return capability == CapabilityFluidHandler.FLUID_HANDLER_CAPABILITY;
     }
 
     @Override
-    public <T> T getCapability(Capability<T> capability, EnumFacing facing)
+    @Nullable
+    public <T> T getCapability(Capability<T> capability, @Nullable EnumFacing facing)
     {
         if (capability == CapabilityFluidHandler.FLUID_HANDLER_CAPABILITY)
         {

--- a/src/main/java/net/minecraftforge/fluids/capability/wrappers/FluidContainerItemWrapper.java
+++ b/src/main/java/net/minecraftforge/fluids/capability/wrappers/FluidContainerItemWrapper.java
@@ -19,6 +19,8 @@
 
 package net.minecraftforge.fluids.capability.wrappers;
 
+import javax.annotation.Nullable;
+
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.EnumFacing;
 import net.minecraftforge.common.capabilities.Capability;
@@ -92,13 +94,14 @@ public class FluidContainerItemWrapper implements IFluidHandler, ICapabilityProv
     }
 
     @Override
-    public boolean hasCapability(Capability<?> capability, EnumFacing facing)
+    public boolean hasCapability(Capability<?> capability, @Nullable EnumFacing facing)
     {
         return capability == CapabilityFluidHandler.FLUID_HANDLER_CAPABILITY;
     }
 
     @Override
-    public <T> T getCapability(Capability<T> capability, EnumFacing facing)
+    @Nullable
+    public <T> T getCapability(Capability<T> capability, @Nullable EnumFacing facing)
     {
         if (capability == CapabilityFluidHandler.FLUID_HANDLER_CAPABILITY)
         {

--- a/src/main/java/net/minecraftforge/fluids/capability/wrappers/FluidContainerRegistryWrapper.java
+++ b/src/main/java/net/minecraftforge/fluids/capability/wrappers/FluidContainerRegistryWrapper.java
@@ -141,6 +141,7 @@ public class FluidContainerRegistryWrapper implements IFluidHandler, ICapability
     }
 
     @Override
+    @Nullable
     public <T> T getCapability(Capability<T> capability, @Nullable EnumFacing facing)
     {
         if (capability == CapabilityFluidHandler.FLUID_HANDLER_CAPABILITY)

--- a/src/test/java/net/minecraftforge/debug/ModelAnimationDebug.java
+++ b/src/test/java/net/minecraftforge/debug/ModelAnimationDebug.java
@@ -1,5 +1,8 @@
 package net.minecraftforge.debug;
 
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
 import net.minecraft.block.Block;
 import net.minecraft.block.BlockPistonBase;
 import net.minecraft.block.material.Material;
@@ -330,7 +333,7 @@ public class ModelAnimationDebug
         }
 
         @Override
-        public boolean hasCapability(Capability<?> capability, EnumFacing side)
+        public boolean hasCapability(Capability<?> capability, @Nullable EnumFacing side)
         {
             if(capability == CapabilityAnimation.ANIMATION_CAPABILITY)
             {
@@ -340,7 +343,8 @@ public class ModelAnimationDebug
         }
 
         @Override
-        public <T> T getCapability(Capability<T> capability, EnumFacing side)
+        @Nullable
+        public <T> T getCapability(Capability<T> capability, @Nullable EnumFacing side)
         {
             if(capability == CapabilityAnimation.ANIMATION_CAPABILITY)
             {
@@ -387,7 +391,7 @@ public class ModelAnimationDebug
         }
 
         @Override
-        public boolean hasCapability(Capability<?> capability, EnumFacing side)
+        public boolean hasCapability(@Nonnull Capability<?> capability, @Nullable EnumFacing side)
         {
             if(capability == CapabilityAnimation.ANIMATION_CAPABILITY)
             {
@@ -397,7 +401,8 @@ public class ModelAnimationDebug
         }
 
         @Override
-        public <T> T getCapability(Capability<T> capability, EnumFacing side)
+        @Nullable
+        public <T> T getCapability(@Nonnull Capability<T> capability, @Nullable EnumFacing side)
         {
             if(capability == CapabilityAnimation.ANIMATION_CAPABILITY)
             {

--- a/src/test/java/net/minecraftforge/test/NoBedSleepingTest.java
+++ b/src/test/java/net/minecraftforge/test/NoBedSleepingTest.java
@@ -1,5 +1,7 @@
 package net.minecraftforge.test;
 
+import javax.annotation.Nullable;
+
 import net.minecraft.client.renderer.block.model.ModelResourceLocation;
 import net.minecraft.creativetab.CreativeTabs;
 import net.minecraft.entity.player.EntityPlayer;
@@ -83,12 +85,13 @@ public class NoBedSleepingTest
             {
                 IExtraSleeping inst = SLEEP_CAP.getDefaultInstance();
                 @Override
-                public boolean hasCapability(Capability<?> capability, EnumFacing facing) {
+                public boolean hasCapability(Capability<?> capability, @Nullable EnumFacing facing) {
                     return capability == SLEEP_CAP;
                 }
 
                 @Override
-                public <T> T getCapability(Capability<T> capability, EnumFacing facing) {
+                @Nullable
+                public <T> T getCapability(Capability<T> capability, @Nullable EnumFacing facing) {
                     return capability == SLEEP_CAP ? SLEEP_CAP.<T>cast(inst) : null;
                 }
 

--- a/src/test/java/net/minecraftforge/test/TestCapabilityMod.java
+++ b/src/test/java/net/minecraftforge/test/TestCapabilityMod.java
@@ -1,5 +1,7 @@
 package net.minecraftforge.test;
 
+import javax.annotation.Nullable;
+
 import net.minecraft.init.Blocks;
 import net.minecraft.init.Items;
 import net.minecraft.nbt.NBTBase;
@@ -92,12 +94,13 @@ public class TestCapabilityMod
                 this.te = te;
             }
             @Override
-            public boolean hasCapability(Capability<?> capability, EnumFacing facing)
+            public boolean hasCapability(Capability<?> capability, @Nullable EnumFacing facing)
             {
                 return TEST_CAP != null && capability == TEST_CAP;
             }
             @Override
-            public <T> T getCapability(Capability<T> capability, EnumFacing facing)
+            @Nullable
+            public <T> T getCapability(Capability<T> capability, @Nullable EnumFacing facing)
             {
                 if (TEST_CAP != null && capability == TEST_CAP) return TEST_CAP.cast(this);
                 return null;

--- a/src/test/java/net/minecraftforge/test/WorldCapabilityRainTimerTest.java
+++ b/src/test/java/net/minecraftforge/test/WorldCapabilityRainTimerTest.java
@@ -1,5 +1,7 @@
 package net.minecraftforge.test;
 
+import javax.annotation.Nullable;
+
 import net.minecraft.nbt.NBTBase;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.util.EnumFacing;
@@ -139,13 +141,14 @@ public class WorldCapabilityRainTimerTest {
         private IRainTimer timer = TIMER_CAP.getDefaultInstance();
 
         @Override
-        public boolean hasCapability(Capability<?> capability, EnumFacing facing)
+        public boolean hasCapability(Capability<?> capability, @Nullable EnumFacing facing)
         {
             return capability == TIMER_CAP;
         }
 
         @Override
-        public <T> T getCapability(Capability<T> capability, EnumFacing facing)
+        @Nullable
+        public <T> T getCapability(Capability<T> capability, @Nullable EnumFacing facing)
         {
             return capability == TIMER_CAP? TIMER_CAP.<T>cast(this.timer) : null;
         }


### PR DESCRIPTION
Fixes #3213
The main change here is adding `@Nullable` to the return value of `ICapabilityProvider.getCapability` so that it matches the documentation.
Also adds the appropriate `@Nullable` annotations for all the capabilities added by Forge.
