### PR TITLE
Add missing Nullable annotations to Forge methods

### DIFF
--- a/patches/minecraft/net/minecraft/client/gui/inventory/GuiContainer.java.patch
+++ b/patches/minecraft/net/minecraft/client/gui/inventory/GuiContainer.java.patch
@@ -128,7 +128,7 @@
                  {
                      this.func_184098_a(this.field_147006_u, this.field_147006_u.field_75222_d, i, ClickType.SWAP);
                      return true;
-@@ -686,4 +691,16 @@
+@@ -686,4 +691,17 @@
              this.field_146297_k.field_71439_g.func_71053_j();
          }
      }
@@ -138,6 +138,7 @@
 +    /**
 +     * Returns the slot that is currently displayed under the mouse.
 +     */
++    @javax.annotation.Nullable
 +    public Slot getSlotUnderMouse()
 +    {
 +        return this.field_147006_u;

--- a/patches/minecraft/net/minecraft/client/renderer/block/model/ItemOverrideList.java.patch
+++ b/patches/minecraft/net/minecraft/client/renderer/block/model/ItemOverrideList.java.patch
@@ -13,7 +13,7 @@
          return null;
      }
 +
-+    public IBakedModel handleItemState(IBakedModel originalModel, ItemStack stack, World world, EntityLivingBase entity)
++    public IBakedModel handleItemState(IBakedModel originalModel, ItemStack stack, @Nullable World world, @Nullable EntityLivingBase entity)
 +    {
 +        net.minecraft.item.Item item = stack.func_77973_b();
 +        if (item != null && item.func_185040_i())

--- a/patches/minecraft/net/minecraft/item/Item.java.patch
+++ b/patches/minecraft/net/minecraft/item/Item.java.patch
@@ -367,7 +367,7 @@
 +     * @return A instance of FontRenderer or null to use default
 +     */
 +    @SideOnly(Side.CLIENT)
-+    public net.minecraft.client.gui.FontRenderer getFontRenderer(ItemStack stack)
++    @Nullable public net.minecraft.client.gui.FontRenderer getFontRenderer(ItemStack stack)
 +    {
 +        return null;
 +    }


### PR DESCRIPTION
While fixing up JEI's annotations, I ran across a few methods added to Minecraft classes by Forge that don't have the correct `@Nullable` annotation included. This is only an issue in the Minecraft classes because they are all marked as `@Nonnull` by default, from the package annotation. 

This PR adds the missing annotations.
