### PR TITLE
[1.10] Add missing null check to handleUpdateTileEntity

### DIFF
--- a/patches/minecraft/net/minecraft/client/network/NetHandlerPlayClient.java.patch
+++ b/patches/minecraft/net/minecraft/client/network/NetHandlerPlayClient.java.patch
@@ -58,18 +58,23 @@
                      }
                  }
              }
-@@ -1169,6 +1176,10 @@
+@@ -1169,6 +1176,15 @@
              {
                  tileentity.func_145839_a(p_147273_1_.func_148857_g());
              }
 +            else
 +            {
++                if(tileentity == null)
++                {
++                    field_147301_d.error("Received invalid update packet for null tile entity at {} with data: {}", p_147273_1_.func_179823_a(), p_147273_1_.func_148857_g());
++                    return;
++                }
 +                tileentity.onDataPacket(field_147302_e, p_147273_1_);
 +            }
  
              if (flag && this.field_147299_f.field_71462_r instanceof GuiCommandBlock)
              {
-@@ -1266,15 +1277,15 @@
+@@ -1266,15 +1282,15 @@
              }
              else if (f == 101.0F)
              {
@@ -88,7 +93,7 @@
              }
          }
          else if (i == 6)
-@@ -1368,7 +1379,7 @@
+@@ -1368,7 +1384,7 @@
  
          if (entity instanceof EntityLivingBase)
          {


### PR DESCRIPTION
This adds a null-check to the patch that adds the onDataPacket() call for cases where the client receives an SPacketUpdateTileEntity with a position that doesn't contain a tile entity on the client (for [whatever reason](https://github.com/gigabit101/QuantumStorage/issues/30)). Vanilla performs an implicit null-check via its instanceof checks, so this only affects modded tile entities.

Prior to this PR, you'd get a useless NullPointerException stacktrace spammed into the console; in fact in the case where this was happening for us we got 13 of them per second, slaughtering memory usage and log file to gigabytes of useless error messages. Since a packet being received for a position with no tile entity is always a bug and should be fixed, I added an informative error message so that

http://pastebin.com/vVfQwZw2

becomes

`Received invalid update packet for null tile entity at BlockPos{x=321, y=123, z=213} with data: {...}`

making it easier to figure out what mod in a large pack is causing the broken packets.
