### PR TITLE
Call Looting Event on player death and loot table drops

### DIFF
--- a/patches/minecraft/net/minecraft/entity/EntityLivingBase.java.patch
+++ b/patches/minecraft/net/minecraft/entity/EntityLivingBase.java.patch
@@ -76,15 +76,20 @@
          if (!this.field_70729_aU)
          {
              Entity entity = p_70645_1_.func_76346_g();
-@@ -1069,12 +1075,26 @@
-                 {
-                     i = EnchantmentHelper.func_185283_h((EntityLivingBase)entity);
-                 }
-+                i = net.minecraftforge.common.ForgeHooks.getLootingLevel(this, p_70645_1_, i);
+@@ -1063,18 +1069,26 @@
  
+             if (!this.field_70170_p.field_72995_K)
+             {
+-                int i = 0;
++                int i = net.minecraftforge.common.ForgeHooks.getLootingLevel(this, entity, p_70645_1_);
+ 
+-                if (entity instanceof EntityPlayer)
+-                {
+-                    i = EnchantmentHelper.func_185283_h((EntityLivingBase)entity);
+-                }
 +                captureDrops = true;
 +                capturedDrops.clear();
-+
+ 
                  if (this.func_146066_aG() && this.field_70170_p.func_82736_K().func_82766_b("doMobLoot"))
                  {
                      boolean flag = this.field_70718_bc > 0;

--- a/patches/minecraft/net/minecraft/world/storage/loot/LootContext.java.patch
+++ b/patches/minecraft/net/minecraft/world/storage/loot/LootContext.java.patch
@@ -1,12 +1,18 @@
 --- ../src-base/minecraft/net/minecraft/world/storage/loot/LootContext.java
 +++ ../src-work/minecraft/net/minecraft/world/storage/loot/LootContext.java
-@@ -89,6 +89,11 @@
+@@ -89,6 +89,17 @@
          }
      }
  
 +    public WorldServer getWorld()
 +    {
 +        return field_186499_b;
++    }
++
++    @Nullable
++    public DamageSource getDamageSource()
++    {
++        return field_186503_f;
 +    }
 +
      public static class Builder

--- a/patches/minecraft/net/minecraft/world/storage/loot/LootContext.java.patch
+++ b/patches/minecraft/net/minecraft/world/storage/loot/LootContext.java.patch
@@ -1,6 +1,6 @@
 --- ../src-base/minecraft/net/minecraft/world/storage/loot/LootContext.java
 +++ ../src-work/minecraft/net/minecraft/world/storage/loot/LootContext.java
-@@ -89,6 +89,17 @@
+@@ -89,6 +89,16 @@
          }
      }
  
@@ -9,10 +9,9 @@
 +        return field_186499_b;
 +    }
 +
-+    @Nullable
-+    public DamageSource getDamageSource()
++    public int getLootingModifier()
 +    {
-+        return field_186503_f;
++        return net.minecraftforge.common.ForgeHooks.getLootingLevel(func_186493_a(), func_186492_c(), field_186503_f);
 +    }
 +
      public static class Builder

--- a/patches/minecraft/net/minecraft/world/storage/loot/conditions/RandomChanceWithLooting.java.patch
+++ b/patches/minecraft/net/minecraft/world/storage/loot/conditions/RandomChanceWithLooting.java.patch
@@ -1,0 +1,10 @@
+--- ../src-base/minecraft/net/minecraft/world/storage/loot/conditions/RandomChanceWithLooting.java
++++ ../src-work/minecraft/net/minecraft/world/storage/loot/conditions/RandomChanceWithLooting.java
+@@ -29,6 +29,7 @@
+         {
+             i = EnchantmentHelper.func_185283_h((EntityLivingBase)p_186618_2_.func_186492_c());
+         }
++        if (p_186618_2_.func_186493_a() instanceof EntityLivingBase) i = net.minecraftforge.common.ForgeHooks.getLootingLevel((EntityLivingBase) p_186618_2_.func_186493_a(), p_186618_2_.getDamageSource(), i);
+ 
+         return p_186618_1_.nextFloat() < this.field_186627_a + (float)i * this.field_186628_b;
+     }

--- a/patches/minecraft/net/minecraft/world/storage/loot/conditions/RandomChanceWithLooting.java.patch
+++ b/patches/minecraft/net/minecraft/world/storage/loot/conditions/RandomChanceWithLooting.java.patch
@@ -1,10 +1,17 @@
 --- ../src-base/minecraft/net/minecraft/world/storage/loot/conditions/RandomChanceWithLooting.java
 +++ ../src-work/minecraft/net/minecraft/world/storage/loot/conditions/RandomChanceWithLooting.java
-@@ -29,6 +29,7 @@
-         {
-             i = EnchantmentHelper.func_185283_h((EntityLivingBase)p_186618_2_.func_186492_c());
-         }
-+        if (p_186618_2_.func_186493_a() instanceof EntityLivingBase) i = net.minecraftforge.common.ForgeHooks.getLootingLevel((EntityLivingBase) p_186618_2_.func_186493_a(), p_186618_2_.getDamageSource(), i);
+@@ -23,13 +23,8 @@
  
+     public boolean func_186618_a(Random p_186618_1_, LootContext p_186618_2_)
+     {
+-        int i = 0;
++        int i = p_186618_2_.getLootingModifier();
+ 
+-        if (p_186618_2_.func_186492_c() instanceof EntityLivingBase)
+-        {
+-            i = EnchantmentHelper.func_185283_h((EntityLivingBase)p_186618_2_.func_186492_c());
+-        }
+-
          return p_186618_1_.nextFloat() < this.field_186627_a + (float)i * this.field_186628_b;
      }
+ 

--- a/patches/minecraft/net/minecraft/world/storage/loot/functions/LootingEnchantBonus.java.patch
+++ b/patches/minecraft/net/minecraft/world/storage/loot/functions/LootingEnchantBonus.java.patch
@@ -1,0 +1,10 @@
+--- ../src-base/minecraft/net/minecraft/world/storage/loot/functions/LootingEnchantBonus.java
++++ ../src-work/minecraft/net/minecraft/world/storage/loot/functions/LootingEnchantBonus.java
+@@ -33,6 +33,7 @@
+         if (entity instanceof EntityLivingBase)
+         {
+             int i = EnchantmentHelper.func_185283_h((EntityLivingBase)entity);
++            if (p_186553_3_.func_186493_a() instanceof EntityLivingBase) i = net.minecraftforge.common.ForgeHooks.getLootingLevel((EntityLivingBase) p_186553_3_.func_186493_a(), p_186553_3_.getDamageSource(), i);
+ 
+             if (i == 0)
+             {

--- a/patches/minecraft/net/minecraft/world/storage/loot/functions/LootingEnchantBonus.java.patch
+++ b/patches/minecraft/net/minecraft/world/storage/loot/functions/LootingEnchantBonus.java.patch
@@ -1,10 +1,11 @@
 --- ../src-base/minecraft/net/minecraft/world/storage/loot/functions/LootingEnchantBonus.java
 +++ ../src-work/minecraft/net/minecraft/world/storage/loot/functions/LootingEnchantBonus.java
-@@ -33,6 +33,7 @@
+@@ -32,7 +32,7 @@
+ 
          if (entity instanceof EntityLivingBase)
          {
-             int i = EnchantmentHelper.func_185283_h((EntityLivingBase)entity);
-+            if (p_186553_3_.func_186493_a() instanceof EntityLivingBase) i = net.minecraftforge.common.ForgeHooks.getLootingLevel((EntityLivingBase) p_186553_3_.func_186493_a(), p_186553_3_.getDamageSource(), i);
+-            int i = EnchantmentHelper.func_185283_h((EntityLivingBase)entity);
++            int i = p_186553_3_.getLootingModifier();
  
              if (i == 0)
              {

--- a/src/main/java/net/minecraftforge/common/ForgeHooks.java
+++ b/src/main/java/net/minecraftforge/common/ForgeHooks.java
@@ -518,7 +518,8 @@ public class ForgeHooks
         return (MinecraftForge.EVENT_BUS.post(event) ? null : new float[]{event.getDistance(), event.getDamageMultiplier()});
     }
 
-    public static int getLootingLevel(EntityLivingBase target, DamageSource cause, int level) {
+    public static int getLootingLevel(EntityLivingBase target, DamageSource cause, int level)
+    {
         LootingLevelEvent event = new LootingLevelEvent(target, cause, level);
         MinecraftForge.EVENT_BUS.post(event);
         return event.getLootingLevel();

--- a/src/main/java/net/minecraftforge/common/ForgeHooks.java
+++ b/src/main/java/net/minecraftforge/common/ForgeHooks.java
@@ -528,7 +528,7 @@ public class ForgeHooks
         }
         if (target instanceof EntityLivingBase)
         {
-            looting = net.minecraftforge.common.ForgeHooks.getLootingLevel((EntityLivingBase)target, cause, looting);
+            looting = getLootingLevel((EntityLivingBase)target, cause, looting);
         }
         return looting;
     }

--- a/src/main/java/net/minecraftforge/common/ForgeHooks.java
+++ b/src/main/java/net/minecraftforge/common/ForgeHooks.java
@@ -43,6 +43,7 @@ import net.minecraft.block.material.Material;
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.GuiScreen;
+import net.minecraft.enchantment.EnchantmentHelper;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.EntityList;
 import net.minecraft.entity.EntityLivingBase;
@@ -516,6 +517,20 @@ public class ForgeHooks
     {
         LivingFallEvent event = new LivingFallEvent(entity, distance, damageMultiplier);
         return (MinecraftForge.EVENT_BUS.post(event) ? null : new float[]{event.getDistance(), event.getDamageMultiplier()});
+    }
+
+    public static int getLootingLevel(Entity target, Entity killer, DamageSource cause)
+    {
+        int looting = 0;
+        if (killer instanceof EntityLivingBase)
+        {
+            looting = EnchantmentHelper.getLootingModifier((EntityLivingBase)killer);
+        }
+        if (target instanceof EntityLivingBase)
+        {
+            looting = net.minecraftforge.common.ForgeHooks.getLootingLevel((EntityLivingBase)target, cause, looting);
+        }
+        return looting;
     }
 
     public static int getLootingLevel(EntityLivingBase target, DamageSource cause, int level)

--- a/src/main/java/net/minecraftforge/event/entity/player/PlayerDropsEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/player/PlayerDropsEvent.java
@@ -21,6 +21,8 @@ package net.minecraftforge.event.entity.player;
 
 import java.util.List;
 
+import net.minecraft.entity.EntityLivingBase;
+import net.minecraftforge.common.ForgeHooks;
 import net.minecraftforge.fml.common.eventhandler.Cancelable;
 
 import net.minecraft.enchantment.EnchantmentHelper;
@@ -48,12 +50,19 @@ public class PlayerDropsEvent extends LivingDropsEvent
      */
     public PlayerDropsEvent(EntityPlayer entity, DamageSource source, List<EntityItem> drops, boolean recentlyHit)
     {
-        super(entity, source, drops,
-            (source.getEntity() instanceof EntityPlayer) ?
-                EnchantmentHelper.getLootingModifier(((EntityPlayer)source.getEntity())) : 0,
-            recentlyHit);
+        super(entity, source, drops, getLootingLevel(entity, source), recentlyHit);
 
         this.entityPlayer = entity;
+    }
+
+    private static int getLootingLevel(EntityPlayer entity, DamageSource source)
+    {
+        int looting = 0;
+        if(source.getEntity() instanceof EntityPlayer)
+        {
+            looting = EnchantmentHelper.getLootingModifier(((EntityPlayer)source.getEntity()));
+        }
+        return ForgeHooks.getLootingLevel(entity, source, looting);
     }
 
     public EntityPlayer getEntityPlayer()

--- a/src/main/java/net/minecraftforge/event/entity/player/PlayerDropsEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/player/PlayerDropsEvent.java
@@ -21,11 +21,9 @@ package net.minecraftforge.event.entity.player;
 
 import java.util.List;
 
-import net.minecraft.entity.EntityLivingBase;
 import net.minecraftforge.common.ForgeHooks;
 import net.minecraftforge.fml.common.eventhandler.Cancelable;
 
-import net.minecraft.enchantment.EnchantmentHelper;
 import net.minecraft.entity.item.EntityItem;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.util.DamageSource;
@@ -50,19 +48,9 @@ public class PlayerDropsEvent extends LivingDropsEvent
      */
     public PlayerDropsEvent(EntityPlayer entity, DamageSource source, List<EntityItem> drops, boolean recentlyHit)
     {
-        super(entity, source, drops, getLootingLevel(entity, source), recentlyHit);
+        super(entity, source, drops, ForgeHooks.getLootingLevel(entity, source.getEntity(), source), recentlyHit);
 
         this.entityPlayer = entity;
-    }
-
-    private static int getLootingLevel(EntityPlayer entity, DamageSource source)
-    {
-        int looting = 0;
-        if(source.getEntity() instanceof EntityPlayer)
-        {
-            looting = EnchantmentHelper.getLootingModifier(((EntityPlayer)source.getEntity()));
-        }
-        return ForgeHooks.getLootingLevel(entity, source, looting);
     }
 
     public EntityPlayer getEntityPlayer()


### PR DESCRIPTION
The event for Looting is not called when the drops are obtained through a looting table. This PR calls the event on every occasion where the looting enchantment is queried.

The event is now also called when firing the PlayerDropsEvent (for consistency).
