### PR TITLE
Add config for number of ticks in a day

### DIFF
--- a/patches/minecraft/net/minecraft/command/CommandTime.java.patch
+++ b/patches/minecraft/net/minecraft/command/CommandTime.java.patch
@@ -1,0 +1,34 @@
+--- ../src-base/minecraft/net/minecraft/command/CommandTime.java
++++ ../src-work/minecraft/net/minecraft/command/CommandTime.java
+@@ -34,11 +34,11 @@
+ 
+                 if ("day".equals(p_184881_3_[1]))
+                 {
+-                    i1 = 1000;
++                    i1 = (int) net.minecraftforge.common.ForgeModContainer.dayTicks / 24;
+                 }
+                 else if ("night".equals(p_184881_3_[1]))
+                 {
+-                    i1 = 13000;
++                    i1 = Math.round(net.minecraftforge.common.ForgeModContainer.dayTicks * 13.0f / 24.0f);
+                 }
+                 else
+                 {
+@@ -62,7 +62,7 @@
+             {
+                 if ("daytime".equals(p_184881_3_[1]))
+                 {
+-                    int k = (int)(p_184881_2_.func_130014_f_().func_72820_D() % 24000L);
++                    int k = (int)(p_184881_2_.func_130014_f_().func_72820_D() % net.minecraftforge.common.ForgeModContainer.dayTicks);
+                     p_184881_2_.func_174794_a(CommandResultStats.Type.QUERY_RESULT, k);
+                     func_152373_a(p_184881_2_, this, "commands.time.query", new Object[] {Integer.valueOf(k)});
+                     return;
+@@ -70,7 +70,7 @@
+ 
+                 if ("day".equals(p_184881_3_[1]))
+                 {
+-                    int j = (int)(p_184881_2_.func_130014_f_().func_72820_D() / 24000L % 2147483647L);
++                    int j = (int)(p_184881_2_.func_130014_f_().func_72820_D() / net.minecraftforge.common.ForgeModContainer.dayTicks % 2147483647L);
+                     p_184881_2_.func_174794_a(CommandResultStats.Type.QUERY_RESULT, j);
+                     func_152373_a(p_184881_2_, this, "commands.time.query", new Object[] {Integer.valueOf(j)});
+                     return;

--- a/patches/minecraft/net/minecraft/command/CommandTime.java.patch
+++ b/patches/minecraft/net/minecraft/command/CommandTime.java.patch
@@ -5,7 +5,7 @@
                  if ("day".equals(p_184881_3_[1]))
                  {
 -                    i1 = 1000;
-+                    i1 = (int) net.minecraftforge.common.ForgeModContainer.dayTicks / 24;
++                    i1 = Math.round(net.minecraftforge.common.ForgeModContainer.dayTicks / 24.0f);
                  }
                  else if ("night".equals(p_184881_3_[1]))
                  {

--- a/patches/minecraft/net/minecraft/world/WorldProvider.java.patch
+++ b/patches/minecraft/net/minecraft/world/WorldProvider.java.patch
@@ -29,6 +29,26 @@
      }
  
      public boolean func_76566_a(int p_76566_1_, int p_76566_2_)
+@@ -85,8 +71,8 @@
+ 
+     public float func_76563_a(long p_76563_1_, float p_76563_3_)
+     {
+-        int i = (int)(p_76563_1_ % 24000L);
+-        float f = ((float)i + p_76563_3_) / 24000.0F - 0.25F;
++        int i = (int)(p_76563_1_ % net.minecraftforge.common.ForgeModContainer.dayTicks);
++        float f = ((float)i + p_76563_3_) / net.minecraftforge.common.ForgeModContainer.dayTicks - 0.25F;
+ 
+         if (f < 0.0F)
+         {
+@@ -105,7 +91,7 @@
+ 
+     public int func_76559_b(long p_76559_1_)
+     {
+-        return (int)(p_76559_1_ / 24000L % 8L + 8L) % 8;
++        return (int)(p_76559_1_ / net.minecraftforge.common.ForgeModContainer.dayTicks % 8L + 8L) % 8;
+     }
+ 
+     public boolean func_76569_d()
 @@ -160,7 +146,7 @@
      @SideOnly(Side.CLIENT)
      public float func_76571_f()

--- a/patches/minecraft/net/minecraft/world/WorldServer.java.patch
+++ b/patches/minecraft/net/minecraft/world/WorldServer.java.patch
@@ -51,6 +51,17 @@
          return this;
      }
  
+@@ -173,8 +183,8 @@
+         {
+             if (this.func_82736_K().func_82766_b("doDaylightCycle"))
+             {
+-                long i = this.field_72986_A.func_76073_f() + 24000L;
+-                this.field_72986_A.func_76068_b(i - i % 24000L);
++                long i = this.field_72986_A.func_76073_f() + net.minecraftforge.common.ForgeModContainer.dayTicks;
++                this.field_72986_A.func_76068_b(i - i % net.minecraftforge.common.ForgeModContainer.dayTicks);
+             }
+ 
+             this.func_73053_d();
 @@ -214,6 +224,10 @@
          this.field_175740_d.func_75528_a();
          this.field_72984_F.func_76318_c("portalForcer");

--- a/src/main/java/net/minecraftforge/common/ForgeModContainer.java
+++ b/src/main/java/net/minecraftforge/common/ForgeModContainer.java
@@ -104,6 +104,7 @@ public class ForgeModContainer extends DummyModContainer implements WorldAccessC
     public static double zombieSummonBaseChance = 0.1;
     public static int[] blendRanges = { 2, 4, 6, 8, 10, 12, 14, 16, 18, 20, 22, 24, 26, 28, 30, 32, 34 };
     public static float zombieBabyChance = 0.05f;
+    public static long dayTicks = 24000L;
     public static boolean shouldSortRecipies = true;
     public static boolean disableVersionCheck = false;
     public static boolean forgeLightPipelineEnabled = true;
@@ -260,6 +261,12 @@ public class ForgeModContainer extends DummyModContainer implements WorldAccessC
                 "Chance that a zombie (or subclass) is a baby. Allows changing the zombie spawning mechanic.", 0.0D, 1.0D);
         prop.setLanguageKey("forge.configgui.zombieBabyChance").setRequiresWorldRestart(true);
         zombieBabyChance = (float) prop.getDouble(0.05);
+        propOrder.add(prop.getName());
+
+        prop = config.get(Configuration.CATEGORY_GENERAL, "dayTicks", 24000,
+                "The number of ticks in the day/night cycle.");
+        prop.setLanguageKey("forge.configgui.dayTicks").setRequiresWorldRestart(true);
+        dayTicks = prop.getLong(24000);
         propOrder.add(prop.getName());
 
         prop = config.get(Configuration.CATEGORY_GENERAL, "forgeLightPipelineEnabled", Boolean.TRUE,

--- a/src/main/resources/assets/forge/lang/en_US.lang
+++ b/src/main/resources/assets/forge/lang/en_US.lang
@@ -50,6 +50,8 @@ forge.configgui.forgeLightPipelineEnabled=Forge Light Pipeline Enabled
 forge.configgui.java8Reminder=Java 8 Reminder timestamp
 forge.configgui.disableStairSlabCulling=Disable Stair/Slab culling.
 forge.configgui.disableStairSlabCulling.tooltip=Enable this if you see through blocks touching stairs/slabs with your resource pack.
+forge.configgui.dayTicks=Day length (ticks)
+forge.configgui.dayTicks.tooltip=The number of ticks in the day/night cycle.
 
 forge.configgui.modID.tooltip=The mod ID that you want to define override settings for.
 forge.configgui.modID=Mod ID


### PR DESCRIPTION
Modded players often wish for longer days in Minecraft, it feels like we're tied to the bed sometimes.
It would be fun if mod packs and video-makers could make use of it in creative ways as well.

This PR adds a config to Forge for the number of ticks in a day.
The patch is as small as I could get it, 3 files and only one is a new patched file. I avoid editing weather length and baby growth time since there were way too many places to edit, those will stay at their normal rates.
