### PR TITLE
[1.10.x] Limit server>client itemstack packet updates to non cap differences only

### DIFF
--- a/patches/minecraft/net/minecraft/entity/EntityLivingBase.java.patch
+++ b/patches/minecraft/net/minecraft/entity/EntityLivingBase.java.patch
@@ -199,7 +199,15 @@
          super.func_70071_h_();
          this.func_184608_ct();
  
-@@ -2409,6 +2435,40 @@
+@@ -1945,6 +1971,7 @@
+ 
+                 if (!ItemStack.func_77989_b(itemstack1, itemstack))
+                 {
++                    if (itemstack == null || itemstack1 == null || itemstack.func_77973_b() == null || itemstack.func_77973_b().getNBTShareTag(itemstack) == null || itemstack1.func_77973_b() == null || itemstack1.func_77973_b().getNBTShareTag(itemstack1) == null || !ItemStack.areItemStacksWithShareTagEqual(itemstack1, itemstack))
+                     ((WorldServer)this.field_70170_p).func_73039_n().func_151247_a(this, new SPacketEntityEquipment(this.func_145782_y(), entityequipmentslot, itemstack1));
+ 
+                     if (itemstack != null)
+@@ -2409,6 +2436,40 @@
          this.field_70752_e = true;
      }
  
@@ -240,7 +248,7 @@
      public abstract EnumHandSide func_184591_cq();
  
      public boolean func_184587_cr()
-@@ -2429,12 +2489,19 @@
+@@ -2429,12 +2490,19 @@
  
              if (itemstack == this.field_184627_bm)
              {
@@ -261,7 +269,7 @@
                  {
                      this.func_71036_o();
                  }
-@@ -2452,8 +2519,10 @@
+@@ -2452,8 +2520,10 @@
  
          if (itemstack != null && !this.func_184587_cr())
          {
@@ -273,7 +281,7 @@
  
              if (!this.field_70170_p.field_72995_K)
              {
-@@ -2536,6 +2605,8 @@
+@@ -2536,6 +2606,8 @@
              this.func_184584_a(this.field_184627_bm, 16);
              ItemStack itemstack = this.field_184627_bm.func_77950_b(this.field_70170_p, this);
  
@@ -282,7 +290,7 @@
              if (itemstack != null && itemstack.field_77994_a == 0)
              {
                  itemstack = null;
-@@ -2566,7 +2637,8 @@
+@@ -2566,7 +2638,8 @@
      {
          if (this.field_184627_bm != null)
          {
@@ -292,7 +300,7 @@
          }
  
          this.func_184602_cy();
-@@ -2685,4 +2757,28 @@
+@@ -2685,4 +2758,28 @@
      {
          return true;
      }

--- a/patches/minecraft/net/minecraft/inventory/Container.java.patch
+++ b/patches/minecraft/net/minecraft/inventory/Container.java.patch
@@ -1,6 +1,18 @@
 --- ../src-base/minecraft/net/minecraft/inventory/Container.java
 +++ ../src-work/minecraft/net/minecraft/inventory/Container.java
-@@ -606,18 +606,19 @@
+@@ -76,9 +76,11 @@
+ 
+             if (!ItemStack.func_77989_b(itemstack1, itemstack))
+             {
++                boolean clientStackDifferent = (itemstack == null || itemstack1 == null || itemstack.func_77973_b() == null || itemstack.func_77973_b().getNBTShareTag(itemstack) == null || itemstack1.func_77973_b() == null || itemstack1.func_77973_b().getNBTShareTag(itemstack1) == null || !ItemStack.areItemStacksWithShareTagEqual(itemstack1, itemstack));
+                 itemstack1 = itemstack == null ? null : itemstack.func_77946_l();
+                 this.field_75153_a.set(i, itemstack1);
+ 
++                if (clientStackDifferent)
+                 for (int j = 0; j < this.field_75149_d.size(); ++j)
+                 {
+                     ((IContainerListener)this.field_75149_d.get(j)).func_71111_a(this, i, itemstack1);
+@@ -606,18 +608,19 @@
                  if (itemstack != null && func_184997_a(p_75135_1_, itemstack))
                  {
                      int j = itemstack.field_77994_a + p_75135_1_.field_77994_a;
@@ -24,7 +36,7 @@
                          slot.func_75218_e();
                          flag = true;
                      }
-@@ -650,7 +651,7 @@
+@@ -650,7 +653,7 @@
                  Slot slot1 = (Slot)this.field_75151_b.get(i);
                  ItemStack itemstack1 = slot1.func_75211_c();
  
@@ -33,7 +45,7 @@
                  {
                      slot1.func_75215_d(p_75135_1_.func_77946_l());
                      slot1.func_75218_e();
-@@ -728,7 +729,7 @@
+@@ -728,7 +731,7 @@
                  p_94525_2_.field_77994_a = 1;
                  break;
              case 2:

--- a/patches/minecraft/net/minecraft/item/ItemStack.java.patch
+++ b/patches/minecraft/net/minecraft/item/ItemStack.java.patch
@@ -239,7 +239,7 @@
          this.field_151002_e = p_150996_1_;
      }
  
-@@ -993,4 +1033,45 @@
+@@ -993,4 +1033,59 @@
              return false;
          }
      }
@@ -283,5 +283,19 @@
 +        {
 +            return this.capabilities.areCompatible(other.capabilities);
 +        }
++    }
++
++    public static boolean areItemStacksWithShareTagEqual(@Nullable ItemStack stackA, @Nullable ItemStack stackB)
++    {
++        if (stackA == null && stackB == null) return true;
++        if (stackA == null && stackB != null) return false;
++        if (stackA != null && stackB == null) return false;
++        if (stackA.field_77994_a != stackB.field_77994_a) return false;
++        if (stackA.field_151002_e != stackB.field_151002_e) return false;
++        if (stackA.field_77991_e != stackB.field_77991_e) return false;
++        if (stackA.field_151002_e == null) return false;
++        if (stackA.field_151002_e.getNBTShareTag(stackA) == null) return false;
++        if (!stackA.field_151002_e.getNBTShareTag(stackA).equals(stackB.field_151002_e.getNBTShareTag(stackB))) return false;
++        return true;
 +    }
  }


### PR DESCRIPTION
Change to prevent capability only ItemStack changes updating client.

Current behavior is that itemstacks on client get updated on every capability change, but the capabilities are not included in update packets and thus it only deletes them on client (in case that they got there using some other packet). 
After this change the two packets that get triggered on itemstack changes (SPacketEntityEquipment and SPacketSetSlot) are not triggered for capability only changes.
After this change it will be possible to update capabilities in onUsingTick and if the mod dev chooses to they can sync the cap data to client using their own packet. 

This is a smaller version of https://github.com/MinecraftForge/MinecraftForge/pull/3099 as suggested by Lex in one of the latest comments.
