### PR TITLE
Fix unbound keybindings are activated by special keyboard keys

### DIFF
--- a/patches/minecraft/net/minecraft/client/settings/KeyBinding.java.patch
+++ b/patches/minecraft/net/minecraft/client/settings/KeyBinding.java.patch
@@ -101,7 +101,7 @@
 +     */
 +    public boolean isActiveAndMatches(int keyCode)
 +    {
-+        return keyCode == this.func_151463_i() && getKeyConflictContext().isActive() && getKeyModifier().isActive();
++        return keyCode != 0 && keyCode == this.func_151463_i() && getKeyConflictContext().isActive() && getKeyModifier().isActive();
 +    }
 +
 +    public void setKeyConflictContext(net.minecraftforge.client.settings.IKeyConflictContext keyConflictContext)


### PR DESCRIPTION
Some keyboard have media keys and other functions that do not map to a regular key in lwjgl. These keys show up as keyCode 0. 

This matches keybindings that are unbound (set to NONE in the controls panel).
Vanilla correctly ignores keyCode 0 in its `KeyBinding` methods, but one method added by Forge (by me lol) does not.

This PR makes `keyBinding.isActiveAndMatches(int keycode)` ignore keyCode 0 like it should.

First found the bug here: https://github.com/mezz/JustEnoughItems/issues/479
