### PR TITLE
Make item repair recipe respect itemstack's getMaxDamage

### DIFF
--- a/patches/minecraft/net/minecraft/item/Item.java.patch
+++ b/patches/minecraft/net/minecraft/item/Item.java.patch
@@ -22,7 +22,15 @@
      public int func_77639_j()
      {
          return this.field_77777_bU;
-@@ -316,6 +317,7 @@
+@@ -217,6 +218,7 @@
+         return this;
+     }
+ 
++    @Deprecated
+     public int func_77612_l()
+     {
+         return this.field_77699_b;
+@@ -316,6 +318,7 @@
          return this.field_77700_c;
      }
  
@@ -30,7 +38,7 @@
      public boolean func_77634_r()
      {
          return this.field_77700_c != null;
-@@ -371,7 +373,7 @@
+@@ -371,7 +374,7 @@
  
      public boolean func_77616_k(ItemStack p_77616_1_)
      {
@@ -39,7 +47,7 @@
      }
  
      protected RayTraceResult func_77621_a(World p_77621_1_, EntityPlayer p_77621_2_, boolean p_77621_3_)
-@@ -389,7 +391,11 @@
+@@ -389,7 +392,11 @@
          float f6 = f3 * f4;
          float f7 = f2 * f4;
          double d3 = 5.0D;
@@ -52,7 +60,7 @@
          return p_77621_1_.func_147447_a(vec3d, vec3d1, p_77621_3_, !p_77621_3_, false);
      }
  
-@@ -426,11 +432,569 @@
+@@ -426,11 +433,580 @@
          return false;
      }
  
@@ -633,7 +641,7 @@
      public static void func_150900_l()
      {
          func_179214_a(Blocks.field_150348_b, (new ItemMultiTexture(Blocks.field_150348_b, Blocks.field_150348_b, new Function<ItemStack, String>()
-@@ -962,6 +1537,10 @@
+@@ -962,6 +1538,10 @@
          private final float field_78011_i;
          private final int field_78008_j;
  
@@ -644,7 +652,7 @@
          private ToolMaterial(int p_i1874_3_, int p_i1874_4_, float p_i1874_5_, float p_i1874_6_, int p_i1874_7_)
          {
              this.field_78001_f = p_i1874_3_;
-@@ -996,9 +1575,36 @@
+@@ -996,9 +1576,36 @@
              return this.field_78008_j;
          }
  

--- a/patches/minecraft/net/minecraft/item/crafting/RecipeRepairItem.java.patch
+++ b/patches/minecraft/net/minecraft/item/crafting/RecipeRepairItem.java.patch
@@ -18,15 +18,26 @@
                      {
                          return null;
                      }
-@@ -67,7 +67,7 @@
+@@ -67,13 +67,13 @@
              ItemStack itemstack2 = (ItemStack)list.get(0);
              ItemStack itemstack3 = (ItemStack)list.get(1);
  
 -            if (itemstack2.func_77973_b() == itemstack3.func_77973_b() && itemstack2.field_77994_a == 1 && itemstack3.field_77994_a == 1 && itemstack2.func_77973_b().func_77645_m())
 +            if (itemstack2.func_77973_b() == itemstack3.func_77973_b() && itemstack2.field_77994_a == 1 && itemstack3.field_77994_a == 1 && itemstack2.func_77973_b().isRepairable())
              {
-                 Item item = itemstack2.func_77973_b();
-                 int j = item.func_77612_l() - itemstack2.func_77952_i();
+-                Item item = itemstack2.func_77973_b();
+-                int j = item.func_77612_l() - itemstack2.func_77952_i();
+-                int k = item.func_77612_l() - itemstack3.func_77952_i();
+-                int l = j + k + item.func_77612_l() * 5 / 100;
+-                int i1 = item.func_77612_l() - l;
++                // FORGE: Make itemstack sensitive // Item item = itemstack2.getItem();
++                int j = itemstack2.func_77958_k() - itemstack2.func_77952_i();
++                int k = itemstack2.func_77958_k() - itemstack3.func_77952_i();
++                int l = j + k + itemstack2.func_77958_k() * 5 / 100;
++                int i1 = itemstack2.func_77958_k() - l;
+ 
+                 if (i1 < 0)
+                 {
 @@ -105,11 +105,7 @@
          for (int i = 0; i < aitemstack.length; ++i)
          {


### PR DESCRIPTION
Currently is the only place in the vanilla codebase calling the old method. Went ahead and added `@Deprecated` to the no-arg method for good measure.
