### PR TITLE
Fix very laggy mipmap slider MC-64581

### DIFF
--- a/patches/minecraft/net/minecraft/client/gui/GuiVideoSettings.java.patch
+++ b/patches/minecraft/net/minecraft/client/gui/GuiVideoSettings.java.patch
@@ -1,0 +1,15 @@
+--- ../src-base/minecraft/net/minecraft/client/gui/GuiVideoSettings.java
++++ ../src-work/minecraft/net/minecraft/client/gui/GuiVideoSettings.java
+@@ -107,4 +107,12 @@
+         this.func_73732_a(this.field_146289_q, this.field_146500_a, this.field_146294_l / 2, 5, 16777215);
+         super.func_73863_a(p_73863_1_, p_73863_2_, p_73863_3_);
+     }
++
++    // FORGE: fix for MC-64581 very laggy mipmap slider
++    @Override
++    public void func_146281_b()
++    {
++        super.func_146281_b();
++        this.field_146297_k.field_71474_y.onGuiClosed();
++    }
+ }

--- a/patches/minecraft/net/minecraft/client/settings/GameSettings.java.patch
+++ b/patches/minecraft/net/minecraft/client/settings/GameSettings.java.patch
@@ -16,6 +16,15 @@
          this.field_74324_K = (KeyBinding[])ArrayUtils.addAll(new KeyBinding[] {this.field_74312_F, this.field_74313_G, this.field_74351_w, this.field_74370_x, this.field_74368_y, this.field_74366_z, this.field_74314_A, this.field_74311_E, this.field_151444_V, this.field_74316_C, this.field_151445_Q, this.field_74310_D, this.field_74321_H, this.field_74322_I, this.field_74323_J, this.field_151447_Z, this.field_151457_aa, this.field_151458_ab, this.field_152395_am, this.field_178883_an, this.field_186718_X}, this.field_151456_ac);
          this.field_74318_M = EnumDifficulty.NORMAL;
          this.field_74332_R = "";
+@@ -265,7 +267,7 @@
+                 this.field_74317_L.func_147117_R().func_147633_a(this.field_151442_I);
+                 this.field_74317_L.func_110434_K().func_110577_a(TextureMap.field_110575_b);
+                 this.field_74317_L.func_147117_R().func_174937_a(false, this.field_151442_I > 0);
+-                this.field_74317_L.func_175603_A();
++                this.needsResourceRefresh = true; // FORGE: fix for MC-64581 very laggy mipmap slider
+             }
+         }
+ 
 @@ -887,7 +889,12 @@
                      {
                          if (s1.equals("key_" + keybinding.func_151464_g()))
@@ -48,7 +57,7 @@
              }
  
              for (SoundCategory soundcategory : SoundCategory.values())
-@@ -1250,4 +1259,24 @@
+@@ -1250,4 +1259,35 @@
              return p_148264_1_;
          }
      }
@@ -70,6 +79,17 @@
 +        field_151457_aa.setKeyConflictContext(inGame);
 +        field_151458_ab.setKeyConflictContext(inGame);
 +        field_186718_X.setKeyConflictContext(inGame);
++    }
++
++    // FORGE: fix for MC-64581 very laggy mipmap slider
++    private boolean needsResourceRefresh = false;
++    public void onGuiClosed()
++    {
++        if (needsResourceRefresh)
++        {
++            this.field_74317_L.func_175603_A();
++            this.needsResourceRefresh = false;
++        }
 +    }
 +    /******* Forge End ***********/
  }


### PR DESCRIPTION
https://bugs.mojang.com/browse/MC-64581

When you move the Mipmap Levels slider in the Video Settings, Minecraft reloads all its textures and sounds immediately. This makes it very hard to change the level to what you want, the game is frozen until everything finishes reloading. If you try to drag the slider from one end to the other, it stops at each level to reload everything for some time.

This problem is made much worse by large texture packs or mods with many textures and sounds, the delay for moving the slider can be very long.

This PR makes is so that resources are only reloaded when you close the Video Options after you've messed with the mipmap control. This way players can move the control freely, and apply the new setting only once.
