### PR TITLE
[1.10] Improve the way containers interact with inventories

### DIFF
--- a/src/main/java/net/minecraftforge/items/IItemHandlerContainer.java
+++ b/src/main/java/net/minecraftforge/items/IItemHandlerContainer.java
@@ -1,0 +1,45 @@
+/*
+ * Minecraft Forge
+ * Copyright (c) 2016.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation version 2.1
+ * of the License.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+package net.minecraftforge.items;
+
+import net.minecraft.item.ItemStack;
+
+import javax.annotation.Nullable;
+
+/**
+ * Declares an item handler as being aware of container slot interactions.
+ */
+public interface IItemHandlerContainer
+{
+    /**
+     * Queries if the given slot is acceptable for the inventory
+     * @param slot The slot number within the inventory
+     * @param stack The stack being tested
+     * @return True if the provided stack is acceptable
+     */
+    boolean isItemValidForSlot(int slot, ItemStack stack);
+
+    /**
+     * Gets the stack size limit allowed by the given slot
+     * @param slot The slot number within the inventory
+     * @param stack An optional stack, for when the limit depends on the input
+     * @return The stack size limit
+     */
+    int getInventoryStackLimit(int slot, @Nullable ItemStack stack);
+}

--- a/src/main/java/net/minecraftforge/items/ItemStackHandler.java
+++ b/src/main/java/net/minecraftforge/items/ItemStackHandler.java
@@ -25,7 +25,7 @@ import net.minecraft.nbt.NBTTagList;
 import net.minecraftforge.common.util.Constants;
 import net.minecraftforge.common.util.INBTSerializable;
 
-public class ItemStackHandler implements IItemHandler, IItemHandlerModifiable, INBTSerializable<NBTTagCompound>
+public class ItemStackHandler implements IItemHandler, IItemHandlerModifiable, IItemHandlerContainer, INBTSerializable<NBTTagCompound>
 {
     protected ItemStack[] stacks;
 
@@ -189,6 +189,18 @@ public class ItemStackHandler implements IItemHandler, IItemHandlerModifiable, I
             }
         }
         onLoad();
+    }
+
+    @Override
+    public boolean isItemValidForSlot(int slot, ItemStack stack)
+    {
+        return true;
+    }
+
+    @Override
+    public int getInventoryStackLimit(int slot, ItemStack stack)
+    {
+        return stack != null ? stack.getMaxStackSize() : 64;
     }
 
     protected void validateSlotIndex(int slot)

--- a/src/main/java/net/minecraftforge/items/SlotItemHandler.java
+++ b/src/main/java/net/minecraftforge/items/SlotItemHandler.java
@@ -43,7 +43,10 @@ public class SlotItemHandler extends Slot
     {
         if (stack == null)
             return false;
-        ItemStack remainder = this.getItemHandler().insertItem(index, stack, true);
+        IItemHandler itemHandler = getItemHandler();
+        if (itemHandler instanceof IItemHandlerContainer)
+            return ((IItemHandlerContainer) itemHandler).isItemValidForSlot(slotNumber, stack);
+        ItemStack remainder = itemHandler.insertItem(index, stack, true);
         return remainder == null || remainder.stackSize < stack.stackSize;
     }
 
@@ -68,8 +71,20 @@ public class SlotItemHandler extends Slot
     }
 
     @Override
+    public int getSlotStackLimit()
+    {
+        IItemHandler itemHandler = getItemHandler();
+        if (itemHandler instanceof IItemHandlerContainer)
+            return ((IItemHandlerContainer) itemHandler).getInventoryStackLimit(slotNumber, null);
+        return 64;
+    }
+
+    @Override
     public int getItemStackLimit(ItemStack stack)
     {
+        IItemHandler itemHandler = getItemHandler();
+        if (itemHandler instanceof IItemHandlerContainer)
+            return ((IItemHandlerContainer) itemHandler).getInventoryStackLimit(slotNumber, stack);
         ItemStack maxAdd = stack.copy();
         maxAdd.stackSize = maxAdd.getMaxStackSize();
         ItemStack currentStack = this.getItemHandler().getStackInSlot(index);


### PR DESCRIPTION
This has a similar purpose to #3273, and in fact, could be said to complement it.

I added an interface that allows Containers and Slots to query more information about inventories (namely, `isItemValidForSlot` and `getInventoryStackLimit`, chosen to keep the same names people were used to in the past, but I'm open to changing them).

This allows improving the logic in `SlotItemHandler`, to allow stack swapping and stack limits, but without the massive hacks seen in #3273. The downside is that this approach does not work for custom inventories that don't also implement this new interface.

This code has been lying around in a [gist](https://gist.github.com/gigaherz/758d42975fd5824e01959ba746d95799) for months, but my job kept me busy and I ended up forgetting about it.

I'm now PRing it to give people my take on this issue.
