### PR TITLE
Add better key modifier behavior for GUI contexts

### DIFF
--- a/patches/minecraft/net/minecraft/client/settings/KeyBinding.java.patch
+++ b/patches/minecraft/net/minecraft/client/settings/KeyBinding.java.patch
@@ -53,11 +53,11 @@
      public boolean func_151470_d()
      {
 -        return this.field_74513_e;
-+        return this.field_74513_e && getKeyConflictContext().isActive() && getKeyModifier().isActive();
++        return this.field_74513_e && getKeyConflictContext().isActive() && getKeyModifier().isActive(getKeyConflictContext());
      }
  
      public String func_151466_e()
-@@ -158,4 +158,130 @@
+@@ -158,4 +158,135 @@
  
          return i;
      }
@@ -101,7 +101,7 @@
 +     */
 +    public boolean isActiveAndMatches(int keyCode)
 +    {
-+        return keyCode != 0 && keyCode == this.func_151463_i() && getKeyConflictContext().isActive() && getKeyModifier().isActive();
++        return keyCode != 0 && keyCode == this.func_151463_i() && getKeyConflictContext().isActive() && getKeyModifier().isActive(getKeyConflictContext());
 +    }
 +
 +    public void setKeyConflictContext(net.minecraftforge.client.settings.IKeyConflictContext keyConflictContext)
@@ -159,9 +159,14 @@
 +            {
 +                return true;
 +            }
-+            else if (keyModifier == otherKeyModifier || keyModifier == net.minecraftforge.client.settings.KeyModifier.NONE || otherKeyModifier == net.minecraftforge.client.settings.KeyModifier.NONE)
++            else if (func_151463_i() == other.func_151463_i())
 +            {
-+                return func_151463_i() == other.func_151463_i();
++                return keyModifier == otherKeyModifier ||
++                        // IN_GAME key contexts have a conflict when at least one modifier is NONE.
++                        // For example: If you hold shift to crouch, you can still press E to open your inventory. This means that a Shift+E hotkey is in conflict with E.
++                        // GUI and other key contexts do not have this limitation.
++                        (getKeyConflictContext().conflicts(net.minecraftforge.client.settings.KeyConflictContext.IN_GAME) &&
++                                (keyModifier == net.minecraftforge.client.settings.KeyModifier.NONE || otherKeyModifier == net.minecraftforge.client.settings.KeyModifier.NONE));
 +            }
 +        }
 +        return false;

--- a/src/main/java/net/minecraftforge/client/settings/KeyModifier.java
+++ b/src/main/java/net/minecraftforge/client/settings/KeyModifier.java
@@ -19,6 +19,8 @@
 
 package net.minecraftforge.client.settings;
 
+import javax.annotation.Nullable;
+
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.GuiScreen;
 import net.minecraft.client.resources.I18n;
@@ -47,6 +49,12 @@ public enum KeyModifier {
         }
 
         @Override
+        public boolean isActive(@Nullable IKeyConflictContext conflictContext)
+        {
+            return GuiScreen.isCtrlKeyDown();
+        }
+
+        @Override
         public String getLocalizedComboName(int keyCode)
         {
             String keyName = GameSettings.getKeyDisplayString(keyCode);
@@ -63,6 +71,12 @@ public enum KeyModifier {
 
         @Override
         public boolean isActive()
+        {
+            return GuiScreen.isShiftKeyDown();
+        }
+
+        @Override
+        public boolean isActive(@Nullable IKeyConflictContext conflictContext)
         {
             return GuiScreen.isShiftKeyDown();
         }
@@ -88,6 +102,12 @@ public enum KeyModifier {
         }
 
         @Override
+        public boolean isActive(@Nullable IKeyConflictContext conflictContext)
+        {
+            return GuiScreen.isAltKeyDown();
+        }
+
+        @Override
         public String getLocalizedComboName(int keyCode)
         {
             String keyName = GameSettings.getKeyDisplayString(keyCode);
@@ -108,6 +128,22 @@ public enum KeyModifier {
         }
 
         @Override
+        public boolean isActive(@Nullable IKeyConflictContext conflictContext)
+        {
+            if (conflictContext != null && !conflictContext.conflicts(KeyConflictContext.IN_GAME))
+            {
+                for (KeyModifier keyModifier : MODIFIER_VALUES)
+                {
+                    if (keyModifier.isActive(conflictContext))
+                    {
+                        return false;
+                    }
+                }
+            }
+            return true;
+        }
+
+        @Override
         public String getLocalizedComboName(int keyCode)
         {
             return GameSettings.getKeyDisplayString(keyCode);
@@ -120,7 +156,7 @@ public enum KeyModifier {
     {
         for (KeyModifier keyModifier : MODIFIER_VALUES)
         {
-            if (keyModifier.isActive())
+            if (keyModifier.isActive(null))
             {
                 return keyModifier;
             }
@@ -158,7 +194,13 @@ public enum KeyModifier {
 
     public abstract boolean matches(int keyCode);
 
+    /**
+     * @deprecated use {@link #isActive(IKeyConflictContext)}
+     */
+    @Deprecated
     public abstract boolean isActive();
+
+    public abstract boolean isActive(@Nullable IKeyConflictContext conflictContext);
 
     public abstract String getLocalizedComboName(int keyCode);
 }


### PR DESCRIPTION
Original issue: https://github.com/mezz/JustEnoughItems/issues/517

There is an intentional limitation in the key modifier system:

> `R` and `Shift+R` are considered conflicting hotkeys, because of the way modifiers are used in-game. If you hold shift to crouch, you can still press `E` to open your inventory. This means that a `Shift+E` hotkey is in conflict with `E`. 

This is perfectly fine for the `IN_GAME` key context, but when you are in a `GUI` key context you should not have that restriction.

This PR removes the restriction from non-`IN_GAME` key contexts, so key bindings like `R` and `Shift+R` are no longer in conflict for guis. It preserves the old behavior for the `IN_GAME` key context.
