### PR TITLE
Add Block#getHasSubtypes and setHasSubtypes used by default ItemBlock impl

### DIFF
--- a/patches/minecraft/net/minecraft/block/Block.java.patch
+++ b/patches/minecraft/net/minecraft/block/Block.java.patch
@@ -203,7 +203,7 @@
      public SoundType func_185467_w()
      {
          return this.field_149762_H;
-@@ -893,6 +913,1168 @@
+@@ -893,6 +913,1189 @@
          return "Block{" + field_149771_c.func_177774_c(this) + "}";
      }
  
@@ -1367,12 +1367,33 @@
 +        return null;
 +    }
 +
++    private boolean hasSubtypes;
++
++    /**
++     * Used by {@link ItemBlock#getHasSubtypes()}
++     * @return If the item for this block has metadata/NBT differentiated subtypes
++     */
++    public boolean getHasSubtypes()
++    {
++        return hasSubtypes;
++    }
++
++    /**
++     * Set if the item for this block has metadata/NBT differentiated subtypes
++     * Used by {@link ItemBlock#getHasSubtypes()}
++     * @param hasSubtypes
++     */
++    public void setHasSubtypes(boolean hasSubtypes)
++    {
++        this.hasSubtypes = hasSubtypes;
++    }
++
 +    /* ========================================= FORGE END ======================================*/
 +
      public static void func_149671_p()
      {
          func_176215_a(0, field_176230_a, (new BlockAir()).func_149663_c("air"));
-@@ -1169,11 +2351,7 @@
+@@ -1169,11 +2372,7 @@
              }
              else
              {

--- a/patches/minecraft/net/minecraft/item/ItemBlock.java.patch
+++ b/patches/minecraft/net/minecraft/item/ItemBlock.java.patch
@@ -29,7 +29,7 @@
          {
              p_179222_3_ = EnumFacing.UP;
          }
-@@ -159,4 +151,32 @@
+@@ -159,4 +151,38 @@
      {
          return this.field_150939_a;
      }
@@ -60,5 +60,11 @@
 +    public void func_77624_a(ItemStack stack, EntityPlayer playerIn, List<String> tooltip, boolean advanced)
 +    {
 +        field_150939_a.addInformation(stack, playerIn, tooltip, advanced);
++    }
++
++    @Override
++    public boolean func_77614_k()
++    {
++        return super.func_77614_k() || field_150939_a.getHasSubtypes();
 +    }
  }


### PR DESCRIPTION
Allows having an `ItemBlock` for a `Block` that has subtypes without needing a custom `ItemBlock` implementation.
