### PR TITLE
[1.12] Add amount and contextual data to DecorateBiomeEvent.Decorate.

### DIFF
--- a/patches/minecraft/net/minecraft/world/biome/BiomeDecorator.java.patch
+++ b/patches/minecraft/net/minecraft/world/biome/BiomeDecorator.java.patch
@@ -1,135 +1,186 @@
 --- ../src-base/minecraft/net/minecraft/world/biome/BiomeDecorator.java
 +++ ../src-work/minecraft/net/minecraft/world/biome/BiomeDecorator.java
-@@ -92,8 +92,10 @@
+@@ -92,23 +92,28 @@
  
      protected void func_150513_a(Biome p_150513_1_, World p_150513_2_, Random p_150513_3_)
      {
 +        net.minecraftforge.common.MinecraftForge.EVENT_BUS.post(new net.minecraftforge.event.terraingen.DecorateBiomeEvent.Pre(p_150513_2_, p_150513_3_, field_180294_c));
          this.func_76797_b(p_150513_2_, p_150513_3_);
  
-+        if(net.minecraftforge.event.terraingen.TerrainGen.decorate(p_150513_2_, p_150513_3_, field_180294_c, net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.SAND))
-         for (int i = 0; i < this.field_76805_H; ++i)
+-        for (int i = 0; i < this.field_76805_H; ++i)
++        int moddedAmount;
++        moddedAmount = net.minecraftforge.event.terraingen.TerrainGen.decorate(p_150513_2_, p_150513_3_, field_180294_c, net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.SAND, this.field_76805_H);
++        for (int i = 0; i < moddedAmount; ++i)
          {
              int j = p_150513_3_.nextInt(16) + 8;
-@@ -101,6 +103,7 @@
+             int k = p_150513_3_.nextInt(16) + 8;
              this.field_76810_g.func_180709_b(p_150513_2_, p_150513_3_, p_150513_2_.func_175672_r(this.field_180294_c.func_177982_a(j, 0, k)));
          }
  
-+        if(net.minecraftforge.event.terraingen.TerrainGen.decorate(p_150513_2_, p_150513_3_, field_180294_c, net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.CLAY))
-         for (int i1 = 0; i1 < this.field_76806_I; ++i1)
+-        for (int i1 = 0; i1 < this.field_76806_I; ++i1)
++        moddedAmount = net.minecraftforge.event.terraingen.TerrainGen.decorate(p_150513_2_, p_150513_3_, field_180294_c, net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.CLAY, this.field_76806_I);
++        for (int i1 = 0; i1 < moddedAmount; ++i1)
          {
              int l1 = p_150513_3_.nextInt(16) + 8;
-@@ -108,6 +111,7 @@
+             int i6 = p_150513_3_.nextInt(16) + 8;
              this.field_76809_f.func_180709_b(p_150513_2_, p_150513_3_, p_150513_2_.func_175672_r(this.field_180294_c.func_177982_a(l1, 0, i6)));
          }
  
-+        if(net.minecraftforge.event.terraingen.TerrainGen.decorate(p_150513_2_, p_150513_3_, field_180294_c, net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.SAND_PASS2))
-         for (int j1 = 0; j1 < this.field_76801_G; ++j1)
+-        for (int j1 = 0; j1 < this.field_76801_G; ++j1)
++        moddedAmount = net.minecraftforge.event.terraingen.TerrainGen.decorate(p_150513_2_, p_150513_3_, field_180294_c, net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.SAND_PASS2, this.field_76801_G);
++        for (int j1 = 0; j1 < moddedAmount; ++j1)
          {
              int i2 = p_150513_3_.nextInt(16) + 8;
-@@ -122,6 +126,7 @@
+             int j6 = p_150513_3_.nextInt(16) + 8;
+@@ -122,6 +127,8 @@
              ++k1;
          }
  
-+        if(net.minecraftforge.event.terraingen.TerrainGen.decorate(p_150513_2_, p_150513_3_, field_180294_c, net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.TREE))
++        k1 = net.minecraftforge.event.terraingen.TerrainGen.decorate(p_150513_2_, p_150513_3_, field_180294_c, net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.TREE, k1);
++
          for (int j2 = 0; j2 < k1; ++j2)
          {
              int k6 = p_150513_3_.nextInt(16) + 8;
-@@ -136,6 +141,7 @@
+@@ -136,14 +143,16 @@
              }
          }
  
-+        if(net.minecraftforge.event.terraingen.TerrainGen.decorate(p_150513_2_, p_150513_3_, field_180294_c, net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.BIG_SHROOM))
-         for (int k2 = 0; k2 < this.field_76807_J; ++k2)
+-        for (int k2 = 0; k2 < this.field_76807_J; ++k2)
++        moddedAmount = net.minecraftforge.event.terraingen.TerrainGen.decorate(p_150513_2_, p_150513_3_, field_180294_c, net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.BIG_SHROOM, this.field_76807_J);
++        for (int k2 = 0; k2 < moddedAmount; ++k2)
          {
              int l6 = p_150513_3_.nextInt(16) + 8;
-@@ -143,6 +149,7 @@
+             int k10 = p_150513_3_.nextInt(16) + 8;
              this.field_76826_u.func_180709_b(p_150513_2_, p_150513_3_, p_150513_2_.func_175645_m(this.field_180294_c.func_177982_a(l6, 0, k10)));
          }
  
-+        if(net.minecraftforge.event.terraingen.TerrainGen.decorate(p_150513_2_, p_150513_3_, field_180294_c, net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.FLOWERS))
-         for (int l2 = 0; l2 < this.field_76802_A; ++l2)
+-        for (int l2 = 0; l2 < this.field_76802_A; ++l2)
++        moddedAmount = net.minecraftforge.event.terraingen.TerrainGen.decorate(p_150513_2_, p_150513_3_, field_180294_c, net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.FLOWERS, this.field_76802_A);
++        for (int l2 = 0; l2 < moddedAmount; ++l2)
          {
              int i7 = p_150513_3_.nextInt(16) + 8;
-@@ -164,6 +171,7 @@
+             int l10 = p_150513_3_.nextInt(16) + 8;
+@@ -164,7 +173,8 @@
              }
          }
  
-+        if(net.minecraftforge.event.terraingen.TerrainGen.decorate(p_150513_2_, p_150513_3_, field_180294_c, net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.GRASS))
-         for (int i3 = 0; i3 < this.field_76803_B; ++i3)
+-        for (int i3 = 0; i3 < this.field_76803_B; ++i3)
++        moddedAmount = net.minecraftforge.event.terraingen.TerrainGen.decorate(p_150513_2_, p_150513_3_, field_180294_c, net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.GRASS, this.field_76803_B);
++        for (int i3 = 0; i3 < moddedAmount; ++i3)
          {
              int j7 = p_150513_3_.nextInt(16) + 8;
-@@ -177,6 +185,7 @@
+             int i11 = p_150513_3_.nextInt(16) + 8;
+@@ -177,7 +187,8 @@
              }
          }
  
-+        if(net.minecraftforge.event.terraingen.TerrainGen.decorate(p_150513_2_, p_150513_3_, field_180294_c, net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.DEAD_BUSH))
-         for (int j3 = 0; j3 < this.field_76804_C; ++j3)
+-        for (int j3 = 0; j3 < this.field_76804_C; ++j3)
++        moddedAmount = net.minecraftforge.event.terraingen.TerrainGen.decorate(p_150513_2_, p_150513_3_, field_180294_c, net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.DEAD_BUSH, this.field_76804_C);
++        for (int j3 = 0; j3 < moddedAmount; ++j3)
          {
              int k7 = p_150513_3_.nextInt(16) + 8;
-@@ -190,6 +199,7 @@
+             int j11 = p_150513_3_.nextInt(16) + 8;
+@@ -190,7 +201,8 @@
              }
          }
  
-+        if(net.minecraftforge.event.terraingen.TerrainGen.decorate(p_150513_2_, p_150513_3_, field_180294_c, net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.LILYPAD))
-         for (int k3 = 0; k3 < this.field_76833_y; ++k3)
+-        for (int k3 = 0; k3 < this.field_76833_y; ++k3)
++        moddedAmount = net.minecraftforge.event.terraingen.TerrainGen.decorate(p_150513_2_, p_150513_3_, field_180294_c, net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.LILYPAD, this.field_76833_y);
++        for (int k3 = 0; k3 < moddedAmount; ++k3)
          {
              int l7 = p_150513_3_.nextInt(16) + 8;
-@@ -216,6 +226,8 @@
-             }
-         }
- 
-+        if(net.minecraftforge.event.terraingen.TerrainGen.decorate(p_150513_2_, p_150513_3_, field_180294_c, net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.SHROOM))
-+        {
+             int k11 = p_150513_3_.nextInt(16) + 8;
+@@ -219,6 +231,7 @@
          for (int l3 = 0; l3 < this.field_76798_D; ++l3)
          {
              if (p_150513_3_.nextInt(4) == 0)
-@@ -266,7 +278,9 @@
-                 this.field_76827_t.func_180709_b(p_150513_2_, p_150513_3_, this.field_180294_c.func_177982_a(j4, l15, l8));
++            for (int mI = net.minecraftforge.event.terraingen.TerrainGen.mushroom(p_150513_2_, p_150513_3_, field_180294_c, field_76828_s, net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.Generator.Position.SURFACE, 1); mI > 0; mI--)
+             {
+                 int i8 = p_150513_3_.nextInt(16) + 8;
+                 int l11 = p_150513_3_.nextInt(16) + 8;
+@@ -227,6 +240,7 @@
              }
+ 
+             if (p_150513_3_.nextInt(8) == 0)
++            for (int mI = net.minecraftforge.event.terraingen.TerrainGen.mushroom(p_150513_2_, p_150513_3_, field_180294_c, field_76827_t, net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.Generator.Position.ANYWHERE, 1); mI > 0; mI--)
+             {
+                 int j8 = p_150513_3_.nextInt(16) + 8;
+                 int i12 = p_150513_3_.nextInt(16) + 8;
+@@ -242,6 +256,7 @@
          }
--
-+        } // End of Mushroom generation
-+        if(net.minecraftforge.event.terraingen.TerrainGen.decorate(p_150513_2_, p_150513_3_, field_180294_c, net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.REED))
-+        {
-         for (int k4 = 0; k4 < this.field_76799_E; ++k4)
+ 
+         if (p_150513_3_.nextInt(4) == 0)
++        for (int mI = net.minecraftforge.event.terraingen.TerrainGen.mushroom(p_150513_2_, p_150513_3_, field_180294_c, field_76828_s, net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.Generator.Position.ANYWHERE, 1); mI > 0; mI--)
          {
-             int i9 = p_150513_3_.nextInt(16) + 8;
-@@ -292,7 +306,8 @@
-                 this.field_76825_v.func_180709_b(p_150513_2_, p_150513_3_, this.field_180294_c.func_177982_a(j9, i19, i13));
-             }
+             int i4 = p_150513_3_.nextInt(16) + 8;
+             int k8 = p_150513_3_.nextInt(16) + 8;
+@@ -255,6 +270,7 @@
          }
--
-+        } // End of Reed generation
-+        if(net.minecraftforge.event.terraingen.TerrainGen.decorate(p_150513_2_, p_150513_3_, field_180294_c, net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.PUMPKIN))
-         if (p_150513_3_.nextInt(32) == 0)
+ 
+         if (p_150513_3_.nextInt(8) == 0)
++        for (int mI = net.minecraftforge.event.terraingen.TerrainGen.mushroom(p_150513_2_, p_150513_3_, field_180294_c, field_76827_t, net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.Generator.Position.ANYWHERE, 1); mI > 0; mI--)
          {
-             int i5 = p_150513_3_.nextInt(16) + 8;
-@@ -306,6 +321,7 @@
+             int j4 = p_150513_3_.nextInt(16) + 8;
+             int l8 = p_150513_3_.nextInt(16) + 8;
+@@ -267,7 +283,8 @@
              }
          }
  
-+        if(net.minecraftforge.event.terraingen.TerrainGen.decorate(p_150513_2_, p_150513_3_, field_180294_c, net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.CACTUS))
-         for (int j5 = 0; j5 < this.field_76800_F; ++j5)
+-        for (int k4 = 0; k4 < this.field_76799_E; ++k4)
++        moddedAmount = net.minecraftforge.event.terraingen.TerrainGen.decorate(p_150513_2_, p_150513_3_, field_180294_c, net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.REED, this.field_76799_E);
++        for (int k4 = 0; k4 < moddedAmount; ++k4)
+         {
+             int i9 = p_150513_3_.nextInt(16) + 8;
+             int l12 = p_150513_3_.nextInt(16) + 8;
+@@ -280,7 +297,8 @@
+             }
+         }
+ 
+-        for (int l4 = 0; l4 < 10; ++l4)
++        moddedAmount = net.minecraftforge.event.terraingen.TerrainGen.decorate(p_150513_2_, p_150513_3_, field_180294_c, net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.REED, 10);
++        for (int l4 = 0; l4 < moddedAmount; ++l4)
+         {
+             int j9 = p_150513_3_.nextInt(16) + 8;
+             int i13 = p_150513_3_.nextInt(16) + 8;
+@@ -294,6 +312,7 @@
+         }
+ 
+         if (p_150513_3_.nextInt(32) == 0)
++        for (int mI = net.minecraftforge.event.terraingen.TerrainGen.decorate(p_150513_2_, p_150513_3_, field_180294_c, net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.PUMPKIN, 1); mI > 0; mI--)
+         {
+             int i5 = p_150513_3_.nextInt(16) + 8;
+             int k9 = p_150513_3_.nextInt(16) + 8;
+@@ -306,7 +325,8 @@
+             }
+         }
+ 
+-        for (int j5 = 0; j5 < this.field_76800_F; ++j5)
++        moddedAmount = net.minecraftforge.event.terraingen.TerrainGen.decorate(p_150513_2_, p_150513_3_, field_180294_c, net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.CACTUS, this.field_76800_F);
++        for (int j5 = 0; j5 < moddedAmount; ++j5)
          {
              int l9 = p_150513_3_.nextInt(16) + 8;
-@@ -321,6 +337,7 @@
+             int k13 = p_150513_3_.nextInt(16) + 8;
+@@ -321,7 +341,8 @@
  
          if (this.field_76808_K)
          {
-+            if(net.minecraftforge.event.terraingen.TerrainGen.decorate(p_150513_2_, p_150513_3_, field_180294_c, net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.LAKE_WATER))
-             for (int k5 = 0; k5 < 50; ++k5)
+-            for (int k5 = 0; k5 < 50; ++k5)
++            moddedAmount = net.minecraftforge.event.terraingen.TerrainGen.decorate(p_150513_2_, p_150513_3_, field_180294_c, net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.LAKE_WATER, 50);
++            for (int k5 = 0; k5 < moddedAmount; ++k5)
              {
                  int i10 = p_150513_3_.nextInt(16) + 8;
-@@ -335,6 +352,7 @@
+                 int l13 = p_150513_3_.nextInt(16) + 8;
+@@ -335,7 +356,8 @@
                  }
              }
  
-+            if(net.minecraftforge.event.terraingen.TerrainGen.decorate(p_150513_2_, p_150513_3_, field_180294_c, net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.LAKE_LAVA))
-             for (int l5 = 0; l5 < 20; ++l5)
+-            for (int l5 = 0; l5 < 20; ++l5)
++            moddedAmount = net.minecraftforge.event.terraingen.TerrainGen.decorate(p_150513_2_, p_150513_3_, field_180294_c, net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.LAKE_LAVA, 20);
++            for (int l5 = 0; l5 < moddedAmount; ++l5)
              {
                  int j10 = p_150513_3_.nextInt(16) + 8;
-@@ -344,21 +362,35 @@
+                 int i14 = p_150513_3_.nextInt(16) + 8;
+@@ -344,21 +366,35 @@
                  (new WorldGenLiquids(Blocks.field_150356_k)).func_180709_b(p_150513_2_, p_150513_3_, blockpos3);
              }
          }

--- a/patches/minecraft/net/minecraft/world/biome/BiomeDesert.java.patch
+++ b/patches/minecraft/net/minecraft/world/biome/BiomeDesert.java.patch
@@ -1,18 +1,18 @@
 --- ../src-base/minecraft/net/minecraft/world/biome/BiomeDesert.java
 +++ ../src-work/minecraft/net/minecraft/world/biome/BiomeDesert.java
-@@ -47,6 +47,7 @@
-     {
+@@ -48,6 +48,7 @@
          super.func_180624_a(p_180624_1_, p_180624_2_, p_180624_3_);
  
-+        if(net.minecraftforge.event.terraingen.TerrainGen.decorate(p_180624_1_, p_180624_2_, p_180624_3_, net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.DESERT_WELL))
          if (p_180624_2_.nextInt(1000) == 0)
++        for (int mI = net.minecraftforge.event.terraingen.TerrainGen.decorate(p_180624_1_, p_180624_2_, p_180624_3_, net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.DESERT_WELL, 1); mI > 0; mI--)
          {
              int i = p_180624_2_.nextInt(16) + 8;
-@@ -55,6 +56,7 @@
-             (new WorldGenDesertWells()).func_180709_b(p_180624_1_, p_180624_2_, blockpos);
+             int j = p_180624_2_.nextInt(16) + 8;
+@@ -56,6 +57,7 @@
          }
  
-+        if(net.minecraftforge.event.terraingen.TerrainGen.decorate(p_180624_1_, p_180624_2_, p_180624_3_, net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.FOSSIL))
          if (p_180624_2_.nextInt(64) == 0)
++        for (int mI = net.minecraftforge.event.terraingen.TerrainGen.decorate(p_180624_1_, p_180624_2_, p_180624_3_, net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.FOSSIL, 1); mI > 0; mI--)
          {
              (new WorldGenFossils()).func_180709_b(p_180624_1_, p_180624_2_, p_180624_3_);
+         }

--- a/patches/minecraft/net/minecraft/world/biome/BiomeForest.java.patch
+++ b/patches/minecraft/net/minecraft/world/biome/BiomeForest.java.patch
@@ -1,19 +1,13 @@
 --- ../src-base/minecraft/net/minecraft/world/biome/BiomeForest.java
 +++ ../src-work/minecraft/net/minecraft/world/biome/BiomeForest.java
-@@ -74,6 +74,8 @@
-             this.func_185379_b(p_180624_1_, p_180624_2_, p_180624_3_);
+@@ -81,12 +81,16 @@
+             i += 2;
          }
  
-+        if(net.minecraftforge.event.terraingen.TerrainGen.decorate(p_180624_1_, p_180624_2_, p_180624_3_, net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.FLOWERS))
-+        { // no tab for patch
-         int i = p_180624_2_.nextInt(5) - 3;
- 
-         if (this.field_150632_aF == BiomeForest.Type.FLOWER)
-@@ -82,11 +84,13 @@
-         }
- 
++        i = net.minecraftforge.event.terraingen.TerrainGen.decorate(p_180624_1_, p_180624_2_, p_180624_3_, net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.FLOWERS, i);
++
          this.func_185378_a(p_180624_1_, p_180624_2_, p_180624_3_, i);
-+        }
++
          super.func_180624_a(p_180624_1_, p_180624_2_, p_180624_3_);
      }
  
@@ -23,22 +17,22 @@
          for (int i = 0; i < 4; ++i)
          {
              for (int j = 0; j < 4; ++j)
-@@ -95,12 +99,12 @@
-                 int l = j * 4 + 1 + 8 + p_185379_2_.nextInt(3);
+@@ -96,11 +100,14 @@
                  BlockPos blockpos = p_185379_1_.func_175645_m(p_185379_3_.func_177982_a(k, 0, l));
  
--                if (p_185379_2_.nextInt(20) == 0)
-+                if (p_185379_2_.nextInt(20) == 0 && net.minecraftforge.event.terraingen.TerrainGen.decorate(p_185379_1_, p_185379_2_, blockpos, net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.BIG_SHROOM))
+                 if (p_185379_2_.nextInt(20) == 0)
++                for (int mI = net.minecraftforge.event.terraingen.TerrainGen.decorate(p_185379_1_, p_185379_2_, blockpos, net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.BIG_SHROOM, 1); mI > 0; mI--)
                  {
++
                      WorldGenBigMushroom worldgenbigmushroom = new WorldGenBigMushroom();
                      worldgenbigmushroom.func_180709_b(p_185379_1_, p_185379_2_, blockpos);
                  }
--                else
-+                else if (net.minecraftforge.event.terraingen.TerrainGen.decorate(p_185379_1_, p_185379_2_, blockpos, net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.TREE))
+                 else
++                for (int mI = net.minecraftforge.event.terraingen.TerrainGen.decorate(p_185379_1_, p_185379_2_, blockpos, net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.TREE, 1); mI > 0; mI--)
                  {
                      WorldGenAbstractTree worldgenabstracttree = this.func_150567_a(p_185379_2_);
                      worldgenabstracttree.func_175904_e();
-@@ -147,6 +151,22 @@
+@@ -147,6 +154,22 @@
          }
      }
  

--- a/patches/minecraft/net/minecraft/world/biome/BiomeJungle.java.patch
+++ b/patches/minecraft/net/minecraft/world/biome/BiomeJungle.java.patch
@@ -1,6 +1,6 @@
 --- ../src-base/minecraft/net/minecraft/world/biome/BiomeJungle.java
 +++ ../src-work/minecraft/net/minecraft/world/biome/BiomeJungle.java
-@@ -68,10 +68,14 @@
+@@ -68,11 +68,15 @@
          super.func_180624_a(p_180624_1_, p_180624_2_, p_180624_3_);
          int i = p_180624_2_.nextInt(16) + 8;
          int j = p_180624_2_.nextInt(16) + 8;
@@ -8,11 +8,13 @@
 +        int height = p_180624_1_.func_175645_m(p_180624_3_.func_177982_a(i, 0, j)).func_177956_o() * 2; // could == 0, which crashes nextInt
 +        if (height < 1) height = 1;
 +        int k = p_180624_2_.nextInt(height);
-+        if(net.minecraftforge.event.terraingen.TerrainGen.decorate(p_180624_1_, p_180624_2_, p_180624_3_, net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.PUMPKIN))
++        for (int mI = net.minecraftforge.event.terraingen.TerrainGen.decorate(p_180624_1_, p_180624_2_, p_180624_3_, net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.PUMPKIN, 1); mI > 0; mI--)
          (new WorldGenMelon()).func_180709_b(p_180624_1_, p_180624_2_, p_180624_3_.func_177982_a(i, k, j));
          WorldGenVines worldgenvines = new WorldGenVines();
  
-+        if(net.minecraftforge.event.terraingen.TerrainGen.decorate(p_180624_1_, p_180624_2_, p_180624_3_, net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.GRASS))
-         for (j = 0; j < 50; ++j)
+-        for (j = 0; j < 50; ++j)
++        int moddedAmount = net.minecraftforge.event.terraingen.TerrainGen.decorate(p_180624_1_, p_180624_2_, p_180624_3_, net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.GRASS, 50, worldgenvines, net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.Generator.Position.ANYWHERE);
++        for (j = 0; j < moddedAmount; ++j)
          {
              k = p_180624_2_.nextInt(16) + 8;
+             int l = 128;

--- a/patches/minecraft/net/minecraft/world/biome/BiomePlains.java.patch
+++ b/patches/minecraft/net/minecraft/world/biome/BiomePlains.java.patch
@@ -1,14 +1,16 @@
 --- ../src-base/minecraft/net/minecraft/world/biome/BiomePlains.java
 +++ ../src-work/minecraft/net/minecraft/world/biome/BiomePlains.java
-@@ -72,6 +72,7 @@
+@@ -72,7 +72,8 @@
              this.field_76760_I.field_76803_B = 10;
              field_180280_ag.func_180710_a(BlockDoublePlant.EnumPlantType.GRASS);
  
-+            if(net.minecraftforge.event.terraingen.TerrainGen.decorate(p_180624_1_, p_180624_2_, p_180624_3_, net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.GRASS))
-             for (int i = 0; i < 7; ++i)
+-            for (int i = 0; i < 7; ++i)
++            int moddedAmount = net.minecraftforge.event.terraingen.TerrainGen.decorate(p_180624_1_, p_180624_2_, p_180624_3_, net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.GRASS, 7, field_180280_ag, net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.Generator.Position.ANYWHERE);
++            for (int i = 0; i < moddedAmount; ++i)
              {
                  int j = p_180624_2_.nextInt(16) + 8;
-@@ -81,7 +82,7 @@
+                 int k = p_180624_2_.nextInt(16) + 8;
+@@ -81,11 +82,12 @@
              }
          }
  
@@ -17,7 +19,13 @@
          {
              field_180280_ag.func_180710_a(BlockDoublePlant.EnumPlantType.SUNFLOWER);
  
-@@ -97,6 +98,21 @@
+-            for (int i1 = 0; i1 < 10; ++i1)
++            int moddedAmount = net.minecraftforge.event.terraingen.TerrainGen.decorate(p_180624_1_, p_180624_2_, p_180624_3_, net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.FLOWERS, 10, field_180280_ag, net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.Generator.Position.ANYWHERE);
++            for (int i1 = 0; i1 < moddedAmount; ++i1)
+             {
+                 int j1 = p_180624_2_.nextInt(16) + 8;
+                 int k1 = p_180624_2_.nextInt(16) + 8;
+@@ -97,6 +99,21 @@
          super.func_180624_a(p_180624_1_, p_180624_2_, p_180624_3_);
      }
  

--- a/patches/minecraft/net/minecraft/world/biome/BiomeSavanna.java.patch
+++ b/patches/minecraft/net/minecraft/world/biome/BiomeSavanna.java.patch
@@ -1,10 +1,12 @@
 --- ../src-base/minecraft/net/minecraft/world/biome/BiomeSavanna.java
 +++ ../src-work/minecraft/net/minecraft/world/biome/BiomeSavanna.java
-@@ -39,6 +39,7 @@
+@@ -39,7 +39,8 @@
      {
          field_180280_ag.func_180710_a(BlockDoublePlant.EnumPlantType.GRASS);
  
-+        if(net.minecraftforge.event.terraingen.TerrainGen.decorate(p_180624_1_, p_180624_2_, p_180624_3_, net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.GRASS))
-         for (int i = 0; i < 7; ++i)
+-        for (int i = 0; i < 7; ++i)
++        int moddedAmount = net.minecraftforge.event.terraingen.TerrainGen.decorate(p_180624_1_, p_180624_2_, p_180624_3_, net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.GRASS, 7, field_180280_ag, net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.Generator.Position.ANYWHERE);
++        for (int i = 0; i < moddedAmount; ++i)
          {
              int j = p_180624_2_.nextInt(16) + 8;
+             int k = p_180624_2_.nextInt(16) + 8;

--- a/patches/minecraft/net/minecraft/world/biome/BiomeSnow.java.patch
+++ b/patches/minecraft/net/minecraft/world/biome/BiomeSnow.java.patch
@@ -1,11 +1,24 @@
 --- ../src-base/minecraft/net/minecraft/world/biome/BiomeSnow.java
 +++ ../src-work/minecraft/net/minecraft/world/biome/BiomeSnow.java
-@@ -56,7 +56,7 @@
+@@ -56,16 +56,18 @@
  
      public void func_180624_a(World p_180624_1_, Random p_180624_2_, BlockPos p_180624_3_)
      {
 -        if (this.field_150615_aC)
 +        if (this.field_150615_aC && net.minecraftforge.event.terraingen.TerrainGen.decorate(p_180624_1_, p_180624_2_, p_180624_3_, net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.ICE))
          {
-             for (int i = 0; i < 3; ++i)
+-            for (int i = 0; i < 3; ++i)
++            int moddedAmount = net.minecraftforge.event.terraingen.TerrainGen.decorate(p_180624_1_, p_180624_2_, p_180624_3_, net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.ICE, 3, field_150616_aD, net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.Generator.Position.SURFACE);
++            for (int i = 0; i < moddedAmount; ++i)
              {
+                 int j = p_180624_2_.nextInt(16) + 8;
+                 int k = p_180624_2_.nextInt(16) + 8;
+                 this.field_150616_aD.func_180709_b(p_180624_1_, p_180624_2_, p_180624_1_.func_175645_m(p_180624_3_.func_177982_a(j, 0, k)));
+             }
+ 
+-            for (int l = 0; l < 2; ++l)
++            moddedAmount = net.minecraftforge.event.terraingen.TerrainGen.decorate(p_180624_1_, p_180624_2_, p_180624_3_, net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.ICE, 2, field_150617_aE, net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.Generator.Position.SURFACE);
++            for (int l = 0; l < moddedAmount; ++l)
+             {
+                 int i1 = p_180624_2_.nextInt(16) + 8;
+                 int j1 = p_180624_2_.nextInt(16) + 8;

--- a/patches/minecraft/net/minecraft/world/biome/BiomeSwamp.java.patch
+++ b/patches/minecraft/net/minecraft/world/biome/BiomeSwamp.java.patch
@@ -1,13 +1,13 @@
 --- ../src-base/minecraft/net/minecraft/world/biome/BiomeSwamp.java
 +++ ../src-work/minecraft/net/minecraft/world/biome/BiomeSwamp.java
-@@ -79,6 +79,7 @@
-     {
+@@ -80,6 +80,7 @@
          super.func_180624_a(p_180624_1_, p_180624_2_, p_180624_3_);
  
-+        if(net.minecraftforge.event.terraingen.TerrainGen.decorate(p_180624_1_, p_180624_2_, p_180624_3_, net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.FOSSIL))
          if (p_180624_2_.nextInt(64) == 0)
++        for (int mI = net.minecraftforge.event.terraingen.TerrainGen.decorate(p_180624_1_, p_180624_2_, p_180624_3_, net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.FOSSIL, 1); mI > 0; mI--)
          {
              (new WorldGenFossils()).func_180709_b(p_180624_1_, p_180624_2_, p_180624_3_);
+         }
 @@ -97,4 +98,10 @@
      {
          return 6975545;

--- a/patches/minecraft/net/minecraft/world/biome/BiomeTaiga.java.patch
+++ b/patches/minecraft/net/minecraft/world/biome/BiomeTaiga.java.patch
@@ -1,19 +1,25 @@
 --- ../src-base/minecraft/net/minecraft/world/biome/BiomeTaiga.java
 +++ ../src-work/minecraft/net/minecraft/world/biome/BiomeTaiga.java
-@@ -60,7 +60,7 @@
+@@ -60,10 +60,11 @@
  
      public void func_180624_a(World p_180624_1_, Random p_180624_2_, BlockPos p_180624_3_)
      {
 -        if (this.field_150644_aH == BiomeTaiga.Type.MEGA || this.field_150644_aH == BiomeTaiga.Type.MEGA_SPRUCE)
-+        if ((this.field_150644_aH == BiomeTaiga.Type.MEGA || this.field_150644_aH == BiomeTaiga.Type.MEGA_SPRUCE) && net.minecraftforge.event.terraingen.TerrainGen.decorate(p_180624_1_, p_180624_2_, p_180624_3_, net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.ROCK))
++        if ((this.field_150644_aH == BiomeTaiga.Type.MEGA || this.field_150644_aH == BiomeTaiga.Type.MEGA_SPRUCE))
          {
              int i = p_180624_2_.nextInt(3);
  
-@@ -75,6 +75,7 @@
++            i = net.minecraftforge.event.terraingen.TerrainGen.decorate(p_180624_1_, p_180624_2_, p_180624_3_, net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.ROCK, i);
+             for (int j = 0; j < i; ++j)
+             {
+                 int k = p_180624_2_.nextInt(16) + 8;
+@@ -75,7 +76,8 @@
  
          field_180280_ag.func_180710_a(BlockDoublePlant.EnumPlantType.FERN);
  
-+        if(net.minecraftforge.event.terraingen.TerrainGen.decorate(p_180624_1_, p_180624_2_, p_180624_3_, net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.FLOWERS))
-         for (int i1 = 0; i1 < 7; ++i1)
+-        for (int i1 = 0; i1 < 7; ++i1)
++        int moddedAmount = net.minecraftforge.event.terraingen.TerrainGen.decorate(p_180624_1_, p_180624_2_, p_180624_3_, net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.FLOWERS, 7);
++        for (int i1 = 0; i1 < moddedAmount; ++i1)
          {
              int j1 = p_180624_2_.nextInt(16) + 8;
+             int k1 = p_180624_2_.nextInt(16) + 8;

--- a/patches/minecraft/net/minecraft/world/gen/ChunkProviderHell.java.patch
+++ b/patches/minecraft/net/minecraft/world/gen/ChunkProviderHell.java.patch
@@ -68,7 +68,7 @@
          for (int j1 = 0; j1 < this.field_185954_p.nextInt(this.field_185954_p.nextInt(10) + 1); ++j1)
          {
              this.field_177469_u.func_180709_b(this.field_185952_n, this.field_185954_p, blockpos.func_177982_a(this.field_185954_p.nextInt(16) + 8, this.field_185954_p.nextInt(120) + 4, this.field_185954_p.nextInt(16) + 8));
-@@ -385,7 +408,13 @@
+@@ -385,17 +408,24 @@
          {
              this.field_177468_v.func_180709_b(this.field_185952_n, this.field_185954_p, blockpos.func_177982_a(this.field_185954_p.nextInt(16) + 8, this.field_185954_p.nextInt(128), this.field_185954_p.nextInt(16) + 8));
          }
@@ -77,22 +77,23 @@
 +        net.minecraftforge.event.ForgeEventFactory.onChunkPopulate(false, this, this.field_185952_n, this.field_185954_p, p_185931_1_, p_185931_2_, false);
 +        net.minecraftforge.common.MinecraftForge.EVENT_BUS.post(new net.minecraftforge.event.terraingen.DecorateBiomeEvent.Pre(this.field_185952_n, this.field_185954_p, blockpos));
 +
-+        if (net.minecraftforge.event.terraingen.TerrainGen.decorate(this.field_185952_n, this.field_185954_p, blockpos, net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.SHROOM))
-+        {
          if (this.field_185954_p.nextBoolean())
++        for (int mI = net.minecraftforge.event.terraingen.TerrainGen.mushroom(this.field_185952_n, this.field_185954_p, blockpos, this.field_177471_z, net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.Generator.Position.ANYWHERE, 1); mI > 0; mI--)
          {
              this.field_177471_z.func_180709_b(this.field_185952_n, this.field_185954_p, blockpos.func_177982_a(this.field_185954_p.nextInt(16) + 8, this.field_185954_p.nextInt(128), this.field_185954_p.nextInt(16) + 8));
-@@ -395,7 +424,9 @@
+         }
+ 
+         if (this.field_185954_p.nextBoolean())
++        for (int mI = net.minecraftforge.event.terraingen.TerrainGen.mushroom(this.field_185952_n, this.field_185954_p, blockpos, this.field_177465_A, net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.Generator.Position.ANYWHERE, 1); mI > 0; mI--)
          {
              this.field_177465_A.func_180709_b(this.field_185952_n, this.field_185954_p, blockpos.func_177982_a(this.field_185954_p.nextInt(16) + 8, this.field_185954_p.nextInt(128), this.field_185954_p.nextInt(16) + 8));
          }
-+        }
  
 +        if (net.minecraftforge.event.terraingen.TerrainGen.generateOre(this.field_185952_n, this.field_185954_p, field_177467_w, blockpos, net.minecraftforge.event.terraingen.OreGenEvent.GenerateMinable.EventType.QUARTZ))
          for (int l1 = 0; l1 < 16; ++l1)
          {
              this.field_177467_w.func_180709_b(this.field_185952_n, this.field_185954_p, blockpos.func_177982_a(this.field_185954_p.nextInt(16), this.field_185954_p.nextInt(108) + 10, this.field_185954_p.nextInt(16)));
-@@ -403,17 +434,22 @@
+@@ -403,17 +433,22 @@
  
          int i2 = this.field_185952_n.func_181545_F() / 2 + 1;
  

--- a/src/main/java/net/minecraftforge/event/terraingen/DecorateBiomeEvent.java
+++ b/src/main/java/net/minecraftforge/event/terraingen/DecorateBiomeEvent.java
@@ -22,14 +22,17 @@ package net.minecraftforge.event.terraingen;
 import java.util.Random;
 
 import net.minecraft.world.biome.Biome;
+import net.minecraft.world.gen.feature.WorldGenerator;
 import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.fml.common.eventhandler.Cancelable;
 import net.minecraftforge.fml.common.eventhandler.Event;
-import net.minecraftforge.fml.common.eventhandler.Event.HasResult;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.World;
 
-/**DecorateBiomeEvent is fired when a BiomeDecorator is created.
+import javax.annotation.Nullable;
+
+/**
+ * DecorateBiomeEvent is fired when a BiomeDecorator is created.
  * <br>
  * This event is fired whenever a BiomeDecorator is created in
  * {@link DeferredBiomeDecorator#fireCreateEventAndReplace(Biome)}.<br>
@@ -96,7 +99,8 @@ public class DecorateBiomeEvent extends Event
 
     /**
      * This event is fired when a chunk is decorated with a biome feature.
-     *
+     * The amount denotes how many instances of the feature will be generated.
+     * <p>
      * You can set the result to DENY to prevent the default biome decoration.
      */
     @HasResult
@@ -107,16 +111,78 @@ public class DecorateBiomeEvent extends Event
             return type;
         }
 
+        public boolean hasAmountData()
+        {
+            return totalAmount != null && modifiedAmount != null;
+        }
+
+        public int getTotalAmount()
+        {
+            if (totalAmount == null)
+                throw new IllegalStateException();
+
+            return totalAmount;
+        }
+
+        public int getModifiedAmount()
+        {
+            if (modifiedAmount == null)
+                throw new IllegalStateException();
+
+            return modifiedAmount;
+        }
+
+        public void setModifiedAmount(int modifiedAmount)
+        {
+            this.modifiedAmount = modifiedAmount;
+        }
+
         /** Use CUSTOM to filter custom event types
          */
         public static enum EventType { BIG_SHROOM, CACTUS, CLAY, DEAD_BUSH, DESERT_WELL, LILYPAD, FLOWERS, FOSSIL, GRASS, ICE, LAKE_WATER, LAKE_LAVA, PUMPKIN, REED, ROCK, SAND, SAND_PASS2, SHROOM, TREE, CUSTOM }
 
         private final EventType type;
+        @Nullable
+        private final Integer totalAmount;
+        @Nullable
+        private Integer modifiedAmount;
 
+        @Deprecated
         public Decorate(World world, Random rand, BlockPos pos, EventType type)
         {
             super(world, rand, pos);
             this.type = type;
+            this.totalAmount = null;
+            this.modifiedAmount = null;
+        }
+
+        public Decorate(World world, Random rand, BlockPos pos, EventType type, int amount)
+        {
+            super(world, rand, pos);
+            this.type = type;
+            this.totalAmount = amount;
+            this.modifiedAmount = amount;
+        }
+
+        public static class Generator extends Decorate
+        {
+            public final WorldGenerator generator;
+            public final Position position;
+
+            public enum Position
+            {
+                SURFACE,
+                UNDERGROUND,
+                AIR,
+                ANYWHERE
+            }
+
+            public Generator(World world, Random rand, BlockPos pos, EventType type, int amount, WorldGenerator generator, Position position)
+            {
+                super(world, rand, pos, type, amount);
+                this.generator = generator;
+                this.position = position;
+            }
         }
     }
 }

--- a/src/main/java/net/minecraftforge/event/terraingen/TerrainGen.java
+++ b/src/main/java/net/minecraftforge/event/terraingen/TerrainGen.java
@@ -55,11 +55,37 @@ public abstract class TerrainGen
         return event.getResult() != Result.DENY;
     }
 
+    /**
+     * This call lacks amount data and should not be used any longer.
+     * It's kept for legacy purposes.
+     */
+    @Deprecated
     public static boolean decorate(World world, Random rand, BlockPos pos, Decorate.EventType type)
     {
         Decorate event = new Decorate(world, rand, pos, type);
         MinecraftForge.TERRAIN_GEN_BUS.post(event);
         return event.getResult() != Result.DENY;
+    }
+
+    public static int decorate(Decorate event)
+    {
+        MinecraftForge.TERRAIN_GEN_BUS.post(event);
+        return event.getResult() != Result.DENY ? event.getModifiedAmount() : -1;
+    }
+
+    public static int mushroom(World world, Random rand, BlockPos pos, WorldGenerator generator, Decorate.Generator.Position position, int amount)
+    {
+        return decorate(new Decorate.Generator(world, rand, pos, Decorate.EventType.SHROOM, amount, generator, position));
+    }
+
+    public static int decorate(World world, Random rand, BlockPos pos, Decorate.EventType type, int amount, WorldGenerator generator, Decorate.Generator.Position position)
+    {
+        return decorate(new Decorate.Generator(world, rand, pos, type, amount, generator, position));
+    }
+
+    public static int decorate(World world, Random rand, BlockPos pos, Decorate.EventType type, int amount)
+    {
+        return decorate(new Decorate(world, rand, pos, type, amount));
     }
 
     public static boolean generateOre(World world, Random rand, WorldGenerator generator, BlockPos pos, GenerateMinable.EventType type)


### PR DESCRIPTION
This PR adds amount and contextual data to the decoration events.

Examples:

With this PR, a decoration mod can now 
- Cancel only parts of a decoration aspect (e.g. replace only 5 out of 10 trees, effectively providing an opportunity to inject weighted decorations (e.g. different tree types while honouring default ones)) 
- Distinguish between more different decoration types using contextual information (e.g. cancel only red mushrooms, but not brown ones)
- Modify the amount of a decoration aspect (e.g. change plains to generate 10 instead of 4 trees per biome). This is different from overriding the value the amount is ready or generated from because many biome mods don't even use the BiomeDecorator and have their own algorithm to generate amounts.

With the current event implementation, you can only cancel any whole decoration aspect of the biome. Since in various places (e.g. roofed forests) it is not guaranteed for an event to be fired just once per biome, you cannot act on these events and use them to decorate the biome yourself. 

This also greatly helps decoration mods and biome mods to interact, as many biome mods do not use the default decorator, and can now pass the actual calculated amount and context through the event.

Note that it keeps backwards compatibility by continuing to provide the old event constructor, fire method, and cancellation capability. 
