### PR TITLE
More flexible generic types for event handlers

### DIFF
--- a/src/main/java/net/minecraftforge/event/AttachCapabilitiesEvent.java
+++ b/src/main/java/net/minecraftforge/event/AttachCapabilitiesEvent.java
@@ -19,6 +19,7 @@
 
 package net.minecraftforge.event;
 
+import java.lang.reflect.Type;
 import java.util.Collections;
 import java.util.Map;
 
@@ -38,6 +39,7 @@ import net.minecraftforge.fml.common.eventhandler.GenericEvent;
 public class AttachCapabilitiesEvent<T> extends GenericEvent<T>
 {
     private final T obj;
+    private final Class<T> type;
     private final Map<ResourceLocation, ICapabilityProvider> caps = Maps.newLinkedHashMap();
     private final Map<ResourceLocation, ICapabilityProvider> view = Collections.unmodifiableMap(caps);
 
@@ -47,10 +49,19 @@ public class AttachCapabilitiesEvent<T> extends GenericEvent<T>
     {
         this((Class<T>)Object.class, obj);
     }
+
+    @SuppressWarnings("unchecked")
     public AttachCapabilitiesEvent(Class<T> type, T obj)
     {
-        super(type);
+        super((Class<T>)obj.getClass());
         this.obj = obj;
+        this.type = type;
+    }
+
+    @Override
+    public boolean matchParameterizedTypeArgument(Type targetType)
+    {
+        return targetType == type || super.matchParameterizedTypeArgument(targetType);
     }
 
     /**

--- a/src/main/java/net/minecraftforge/fml/common/eventhandler/ASMEventHandler.java
+++ b/src/main/java/net/minecraftforge/fml/common/eventhandler/ASMEventHandler.java
@@ -85,7 +85,7 @@ public class ASMEventHandler implements IEventListener
         {
             if (!event.isCancelable() || !event.isCanceled() || subInfo.receiveCanceled())
             {
-                if (filter == null || filter == ((IGenericEvent)event).getGenericType())
+                if (filter == null || ((IGenericEvent)event).matchParameterizedTypeArgument(filter))
                 {
                     handler.invoke(event);
                 }

--- a/src/main/java/net/minecraftforge/fml/common/eventhandler/GenericEvent.java
+++ b/src/main/java/net/minecraftforge/fml/common/eventhandler/GenericEvent.java
@@ -19,6 +19,9 @@
 package net.minecraftforge.fml.common.eventhandler;
 
 import java.lang.reflect.Type;
+import java.lang.reflect.WildcardType;
+
+import org.apache.commons.lang3.reflect.TypeUtils;
 
 public class GenericEvent<T> extends Event implements IGenericEvent<T>
 {
@@ -32,5 +35,11 @@ public class GenericEvent<T> extends Event implements IGenericEvent<T>
     public Type getGenericType()
     {
         return type;
+    }
+
+    @Override
+    public boolean matchParameterizedTypeArgument(Type targetType)
+    {
+        return targetType == type || targetType instanceof WildcardType && TypeUtils.isAssignable(type, targetType);
     }
 }

--- a/src/main/java/net/minecraftforge/fml/common/eventhandler/IGenericEvent.java
+++ b/src/main/java/net/minecraftforge/fml/common/eventhandler/IGenericEvent.java
@@ -23,4 +23,12 @@ import java.lang.reflect.Type;
 public interface IGenericEvent<T>
 {
     Type getGenericType();
+
+    /**
+     * Checks if the event is compatible with the target type as the generic
+     * type of a parameter of the event handler method.
+     *
+     * @return {@code true} if it is compatible.
+     */
+    boolean matchParameterizedTypeArgument(Type targetType);
 }

--- a/src/test/java/net/minecraftforge/test/TestCapabilityMod.java
+++ b/src/test/java/net/minecraftforge/test/TestCapabilityMod.java
@@ -4,9 +4,12 @@ import net.minecraft.init.Blocks;
 import net.minecraft.init.Items;
 import net.minecraft.nbt.NBTBase;
 import net.minecraft.tileentity.TileEntity;
+import net.minecraft.tileentity.TileEntityDispenser;
+import net.minecraft.tileentity.TileEntityDropper;
 import net.minecraft.util.text.TextComponentString;
 import net.minecraft.util.text.TextFormatting;
 import net.minecraft.util.EnumFacing;
+import net.minecraft.util.ITickable;
 import net.minecraft.util.ResourceLocation;
 import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.common.capabilities.Capability;
@@ -123,7 +126,23 @@ public class TestCapabilityMod
     public void attachTileEntity(AttachCapabilitiesEvent<TileEntity> event)
     {
         if (!(event.getObject() instanceof TileEntity))
-            throw new IllegalArgumentException("Generic event handler failed! Exprected Tile Entity got " + event.getObject());
+            throw new IllegalArgumentException("Generic event handler failed! Expected Tile Entity got " + event.getObject());
+    }
+
+    // Dispensers are only wanted.
+    @SubscribeEvent
+    public void attachTileEntityDispenser(AttachCapabilitiesEvent<TileEntityDispenser> event)
+    {
+        if (!(event.getObject() instanceof TileEntityDispenser) || event.getObject() instanceof TileEntityDropper)
+            throw new IllegalArgumentException("Generic event handler failed! Expected TileEntityDispenser got " + event.getObject());
+    }
+
+    // Lower bounds.
+    @SubscribeEvent
+    public void attachITickable(AttachCapabilitiesEvent<? extends ITickable> event)
+    {
+        if (!(event.getObject() instanceof ITickable))
+            throw new IllegalArgumentException("Generic event handler failed! Expected ? extends ITickable got " + event.getObject());
     }
 
     // Capabilities SHOULD be interfaces, NOT concrete classes, this allows for


### PR DESCRIPTION
Maybe parameters of event handler methods could have more flexible uses, such as fake co-variance, and lower bounds, which is the purpose of this pull request.

For example, the `AttachCapabilitiesEvent` is triggered for a dropper:

``` java
 MinecraftForge.EVENT_BUS.post(new AttachCapabilitiesEvent<TileEntity>(TileEntity.class, tileEntityDropper));
```

The code in the past will allow only one way to listen it with generic types:

``` java
    @SubscribeEvent
    public void attachTileEntity(AttachCapabilitiesEvent<TileEntity> event)
    {
        if (event.getObject() instanceof TileEntityDropper)
        {
            // do something.
        }
    }
```

But now, it could be:

``` java
    // OK
    @SubscribeEvent
    public void attachTileEntityDropper(AttachCapabilitiesEvent<TileEntityDropper> event)
    {
        // do something.
    }
    // OK, for lower bounds
    @SubscribeEvent
    public void attachIInventory(AttachCapabilitiesEvent<? extends IInventory> event)
    {
        // do something.
    }
    // Will not be called, although 'TileEntityDropper' is the subclass of 'TileEntityDispenser', while '? extends TileEntityDispenser' is OK
    @SubscribeEvent
    public void attachTileEntityDispenser(AttachCapabilitiesEvent<TileEntityDispenser> event)
    {
        // nothing will be done.
    }
    // Still OK, but only for the forward compatibility
    @SubscribeEvent
    public void attachTileEntity(AttachCapabilitiesEvent<TileEntity> event)
    {
        // do something.
    }
```
