### PR TITLE
Patch Block.isVisuallyOpaque() to be state-aware

### DIFF
--- a/patches/minecraft/net/minecraft/block/Block.java.patch
+++ b/patches/minecraft/net/minecraft/block/Block.java.patch
@@ -220,7 +220,7 @@
      public SoundType func_185467_w()
      {
          return this.field_149762_H;
-@@ -893,6 +916,1197 @@
+@@ -893,6 +916,1201 @@
          return "Block{" + field_149771_c.func_177774_c(this) + "}";
      }
  
@@ -274,12 +274,16 @@
 +    }
 +
 +    /**
-+     * State-sensitive version of isVisuallyOpaque.
++     * State-sensitive version of func_176214_u.
++     * <p>
++     * This method is used for:
++     * <br> Checking if an entity should be suffocating
++     * <br> Checking if the suffocation overlay should be rendered in 1st person
 +     *
 +     * @param state The current state
-+     * @return True if the block is visually opaque
++     * @return True if the block can suffocate entities that are inside it.
 +     */
-+    public boolean isVisuallyOpaque(IBlockState state)
++    public boolean causesSuffocation(IBlockState state)
 +    {
 +        return state.func_185904_a().func_76230_c() && state.func_185917_h();
 +    }
@@ -1418,7 +1422,7 @@
      public static void func_149671_p()
      {
          func_176215_a(0, field_176230_a, (new BlockAir()).func_149663_c("air"));
-@@ -1169,11 +2383,7 @@
+@@ -1169,11 +2387,7 @@
              }
              else
              {

--- a/patches/minecraft/net/minecraft/block/Block.java.patch
+++ b/patches/minecraft/net/minecraft/block/Block.java.patch
@@ -26,7 +26,15 @@
      }
  
      public static IBlockState func_176220_d(int p_176220_0_)
-@@ -292,7 +294,7 @@
+@@ -268,6 +270,7 @@
+         return p_149721_1_.func_185904_a().func_76218_k() && p_149721_1_.func_185917_h() && !p_149721_1_.func_185897_m();
+     }
+ 
++    @Deprecated // Forge: Use state-sensitive version
+     public boolean func_176214_u()
+     {
+         return this.field_149764_J.func_76230_c() && this.func_176223_P().func_185917_h();
+@@ -292,7 +295,7 @@
  
      public boolean func_176200_f(IBlockAccess p_176200_1_, BlockPos p_176200_2_)
      {
@@ -35,7 +43,7 @@
      }
  
      public Block func_149711_c(float p_149711_1_)
-@@ -330,9 +332,10 @@
+@@ -330,9 +333,10 @@
          return this.field_149789_z;
      }
  
@@ -47,7 +55,7 @@
      }
  
      @Deprecated
-@@ -376,13 +379,13 @@
+@@ -376,13 +380,13 @@
      @SideOnly(Side.CLIENT)
      public int func_185484_c(IBlockState p_185484_1_, IBlockAccess p_185484_2_, BlockPos p_185484_3_)
      {
@@ -63,7 +71,7 @@
          }
          else
          {
-@@ -446,7 +449,7 @@
+@@ -446,7 +450,7 @@
                  }
          }
  
@@ -72,7 +80,7 @@
      }
  
      @Deprecated
-@@ -506,6 +509,10 @@
+@@ -506,6 +510,10 @@
  
      public void func_180663_b(World p_180663_1_, BlockPos p_180663_2_, IBlockState p_180663_3_)
      {
@@ -83,7 +91,7 @@
      }
  
      public int func_149745_a(Random p_149745_1_)
-@@ -522,8 +529,7 @@
+@@ -522,8 +530,7 @@
      @Deprecated
      public float func_180647_a(IBlockState p_180647_1_, EntityPlayer p_180647_2_, World p_180647_3_, BlockPos p_180647_4_)
      {
@@ -93,7 +101,7 @@
      }
  
      public final void func_176226_b(World p_176226_1_, BlockPos p_176226_2_, IBlockState p_176226_3_, int p_176226_4_)
-@@ -533,20 +539,16 @@
+@@ -533,20 +540,16 @@
  
      public void func_180653_a(World p_180653_1_, BlockPos p_180653_2_, IBlockState p_180653_3_, float p_180653_4_, int p_180653_5_)
      {
@@ -119,7 +127,7 @@
                  }
              }
          }
-@@ -554,8 +556,13 @@
+@@ -554,8 +557,13 @@
  
      public static void func_180635_a(World p_180635_0_, BlockPos p_180635_1_, ItemStack p_180635_2_)
      {
@@ -134,7 +142,7 @@
              float f = 0.5F;
              double d0 = (double)(p_180635_0_.field_73012_v.nextFloat() * 0.5F) + 0.25D;
              double d1 = (double)(p_180635_0_.field_73012_v.nextFloat() * 0.5F) + 0.25D;
-@@ -627,7 +634,7 @@
+@@ -627,7 +635,7 @@
  
      public boolean func_176196_c(World p_176196_1_, BlockPos p_176196_2_)
      {
@@ -143,7 +151,7 @@
      }
  
      public boolean func_180639_a(World p_180639_1_, BlockPos p_180639_2_, IBlockState p_180639_3_, EntityPlayer p_180639_4_, EnumHand p_180639_5_, @Nullable ItemStack p_180639_6_, EnumFacing p_180639_7_, float p_180639_8_, float p_180639_9_, float p_180639_10_)
-@@ -639,6 +646,8 @@
+@@ -639,6 +647,8 @@
      {
      }
  
@@ -152,7 +160,7 @@
      public IBlockState func_180642_a(World p_180642_1_, BlockPos p_180642_2_, EnumFacing p_180642_3_, float p_180642_4_, float p_180642_5_, float p_180642_6_, int p_180642_7_, EntityLivingBase p_180642_8_)
      {
          return this.func_176203_a(p_180642_7_);
-@@ -680,25 +689,35 @@
+@@ -680,25 +690,35 @@
          p_180657_2_.func_71029_a(StatList.func_188055_a(this));
          p_180657_2_.func_71020_j(0.025F);
  
@@ -191,7 +199,7 @@
      }
  
      @Nullable
-@@ -794,9 +813,11 @@
+@@ -794,9 +814,11 @@
      }
  
      @Nullable
@@ -204,7 +212,7 @@
      }
  
      @SideOnly(Side.CLIENT)
-@@ -883,6 +904,7 @@
+@@ -883,6 +905,7 @@
          return Block.EnumOffsetType.NONE;
      }
  
@@ -212,7 +220,7 @@
      public SoundType func_185467_w()
      {
          return this.field_149762_H;
-@@ -893,6 +915,1186 @@
+@@ -893,6 +916,1197 @@
          return "Block{" + field_149771_c.func_177774_c(this) + "}";
      }
  
@@ -263,6 +271,17 @@
 +    public boolean isNormalCube(IBlockState state, IBlockAccess world, BlockPos pos)
 +    {
 +        return state.func_185904_a().func_76218_k() && state.func_185917_h() && !state.func_185897_m();
++    }
++
++    /**
++     * State-sensitive version of isVisuallyOpaque.
++     *
++     * @param state The current state
++     * @return True if the block is visually opaque
++     */
++    public boolean isVisuallyOpaque(IBlockState state)
++    {
++        return state.func_185904_a().func_76230_c() && state.func_185917_h();
 +    }
 +
 +    /**
@@ -1399,7 +1418,7 @@
      public static void func_149671_p()
      {
          func_176215_a(0, field_176230_a, (new BlockAir()).func_149663_c("air"));
-@@ -1169,11 +2371,7 @@
+@@ -1169,11 +2383,7 @@
              }
              else
              {

--- a/patches/minecraft/net/minecraft/client/renderer/ItemRenderer.java.patch
+++ b/patches/minecraft/net/minecraft/client/renderer/ItemRenderer.java.patch
@@ -47,7 +47,7 @@
                  IBlockState iblockstate1 = this.field_78455_a.field_71441_e.func_180495_p(blockpos);
  
 -                if (iblockstate1.func_177230_c().func_176214_u())
-+                if (iblockstate1.func_177230_c().isVisuallyOpaque(iblockstate1))
++                if (iblockstate1.func_177230_c().causesSuffocation(iblockstate1))
                  {
                      iblockstate = iblockstate1;
 +                    overlayPos = blockpos;

--- a/patches/minecraft/net/minecraft/client/renderer/ItemRenderer.java.patch
+++ b/patches/minecraft/net/minecraft/client/renderer/ItemRenderer.java.patch
@@ -42,8 +42,12 @@
              EntityPlayer entityplayer = this.field_78455_a.field_71439_g;
  
              for (int i = 0; i < 8; ++i)
-@@ -458,11 +461,13 @@
-                 if (iblockstate1.func_177230_c().func_176214_u())
+@@ -455,14 +458,16 @@
+                 BlockPos blockpos = new BlockPos(d0, d1 + (double)entityplayer.func_70047_e(), d2);
+                 IBlockState iblockstate1 = this.field_78455_a.field_71441_e.func_180495_p(blockpos);
+ 
+-                if (iblockstate1.func_177230_c().func_176214_u())
++                if (iblockstate1.func_177230_c().isVisuallyOpaque(iblockstate1))
                  {
                      iblockstate = iblockstate1;
 +                    overlayPos = blockpos;

--- a/patches/minecraft/net/minecraft/entity/Entity.java.patch
+++ b/patches/minecraft/net/minecraft/entity/Entity.java.patch
@@ -93,6 +93,17 @@
              return entityitem;
          }
          else
+@@ -1790,8 +1807,8 @@
+                 if (blockpos$pooledmutableblockpos.func_177958_n() != k || blockpos$pooledmutableblockpos.func_177956_o() != j || blockpos$pooledmutableblockpos.func_177952_p() != l)
+                 {
+                     blockpos$pooledmutableblockpos.func_181079_c(k, j, l);
+-
+-                    if (this.field_70170_p.func_180495_p(blockpos$pooledmutableblockpos).func_177230_c().func_176214_u())
++                    IBlockState iblockstate = this.field_70170_p.func_180495_p(blockpos$pooledmutableblockpos);
++                    if (iblockstate.func_177230_c().isVisuallyOpaque(iblockstate))
+                     {
+                         blockpos$pooledmutableblockpos.func_185344_t();
+                         return true;
 @@ -1867,6 +1884,7 @@
  
      public boolean func_184205_a(Entity p_184205_1_, boolean p_184205_2_)

--- a/patches/minecraft/net/minecraft/entity/Entity.java.patch
+++ b/patches/minecraft/net/minecraft/entity/Entity.java.patch
@@ -100,7 +100,7 @@
 -
 -                    if (this.field_70170_p.func_180495_p(blockpos$pooledmutableblockpos).func_177230_c().func_176214_u())
 +                    IBlockState iblockstate = this.field_70170_p.func_180495_p(blockpos$pooledmutableblockpos);
-+                    if (iblockstate.func_177230_c().isVisuallyOpaque(iblockstate))
++                    if (iblockstate.func_177230_c().causesSuffocation(iblockstate))
                      {
                          blockpos$pooledmutableblockpos.func_185344_t();
                          return true;


### PR DESCRIPTION
This adds an override of `isVisuallyOpaque()` that takes an `IBlockState` parameter. Tried to keep changes as small as possible.
