### PR TITLE
Fixed Ore Dictionary replacing the oak boat recipe

### DIFF
--- a/src/main/java/net/minecraftforge/oredict/OreDictionary.java
+++ b/src/main/java/net/minecraftforge/oredict/OreDictionary.java
@@ -337,6 +337,7 @@ public class OreDictionary
             new ItemStack(Blocks.WOODEN_SLAB),
             new ItemStack(Blocks.GLASS_PANE),
             new ItemStack(Blocks.field_189880_di), // Bone Block, to prevent conversion of dyes into bone meal.
+            new ItemStack(Items.BOAT), 
             null //So the above can have a comma and we don't have to keep editing extra lines.
         };
 


### PR DESCRIPTION
Fixes the oak boat recipe being able to be crafted with any wood.
Current Forge behavior
http://imgur.com/Nf9jFyc
Vanilla Behavior
http://imgur.com/UBsAkNwl
