### PR TITLE
[1.10] FluidStack Container support for Ore Recipes

### DIFF
--- a/src/main/java/net/minecraftforge/oredict/ShapedOreRecipe.java
+++ b/src/main/java/net/minecraftforge/oredict/ShapedOreRecipe.java
@@ -32,6 +32,9 @@ import net.minecraft.item.ItemStack;
 import net.minecraft.item.crafting.ShapedRecipes;
 import net.minecraft.world.World;
 import net.minecraftforge.common.ForgeHooks;
+import net.minecraftforge.fluids.FluidStack;
+import net.minecraftforge.fluids.FluidUtil;
+import net.minecraftforge.fluids.capability.IFluidHandler;
 
 public class ShapedOreRecipe implements IRecipe
 {
@@ -123,6 +126,10 @@ public class ShapedOreRecipe implements IRecipe
             else if (in instanceof String)
             {
                 itemMap.put(chr, OreDictionary.getOres((String)in));
+            }
+            else if (in instanceof FluidStack)
+            {
+                itemMap.put(chr, ((FluidStack) in).copy());
             }
             else
             {
@@ -242,6 +249,25 @@ public class ShapedOreRecipe implements IRecipe
                     while (itr.hasNext() && !matched)
                     {
                         matched = OreDictionary.itemMatches(itr.next(), slot, false);
+                    }
+
+                    if (!matched)
+                    {
+                        return false;
+                    }
+                }
+                else if (target instanceof FluidStack)
+                {
+                    boolean matched = false;
+
+                    IFluidHandler fluidHandler = FluidUtil.getFluidHandler(slot);
+                    if (fluidHandler != null)
+                    {
+                        FluidStack drained = fluidHandler.drain((FluidStack) target, false);
+                        if (drained != null)
+                        {
+                            matched = drained.containsFluid((FluidStack) target);
+                        }
                     }
 
                     if (!matched)

--- a/src/main/java/net/minecraftforge/oredict/ShapelessOreRecipe.java
+++ b/src/main/java/net/minecraftforge/oredict/ShapelessOreRecipe.java
@@ -32,6 +32,9 @@ import net.minecraft.item.ItemStack;
 import net.minecraft.item.crafting.ShapelessRecipes;
 import net.minecraft.world.World;
 import net.minecraftforge.common.ForgeHooks;
+import net.minecraftforge.fluids.FluidStack;
+import net.minecraftforge.fluids.FluidUtil;
+import net.minecraftforge.fluids.capability.IFluidHandler;
 
 public class ShapelessOreRecipe implements IRecipe
 {
@@ -61,6 +64,10 @@ public class ShapelessOreRecipe implements IRecipe
             else if (in instanceof String)
             {
                 input.add(OreDictionary.getOres((String)in));
+            }
+            else if (in instanceof FluidStack)
+            {
+                input.add(((FluidStack) in).copy());
             }
             else
             {
@@ -134,6 +141,18 @@ public class ShapelessOreRecipe implements IRecipe
                         while (itr.hasNext() && !match)
                         {
                             match = OreDictionary.itemMatches(itr.next(), slot, false);
+                        }
+                    }
+                    else if(next instanceof FluidStack)
+                    {
+                        IFluidHandler fluidHandler = FluidUtil.getFluidHandler(slot);
+                        if (fluidHandler != null)
+                        {
+                            FluidStack drained = fluidHandler.drain((FluidStack) next, false);
+                            if (drained != null)
+                            {
+                                match = drained.containsFluid((FluidStack) next);
+                            }
                         }
                     }
 

--- a/src/test/java/net/minecraftforge/test/OreRecipeTest.java
+++ b/src/test/java/net/minecraftforge/test/OreRecipeTest.java
@@ -1,0 +1,69 @@
+package net.minecraftforge.test;
+
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.init.Items;
+import net.minecraft.inventory.Container;
+import net.minecraft.inventory.InventoryCrafting;
+import net.minecraft.item.ItemStack;
+import net.minecraftforge.fluids.Fluid;
+import net.minecraftforge.fluids.FluidRegistry;
+import net.minecraftforge.fluids.FluidStack;
+import net.minecraftforge.fml.common.Mod;
+import net.minecraftforge.fml.common.Mod.EventHandler;
+import net.minecraftforge.fml.common.event.FMLInitializationEvent;
+import net.minecraftforge.oredict.ShapedOreRecipe;
+import net.minecraftforge.oredict.ShapelessOreRecipe;
+
+@Mod(modid="orerecipetest", name="OreRecipeTest", version="0.0.0")
+public class OreRecipeTest
+{
+
+    public static final boolean ENABLE = false;
+
+    @EventHandler
+    public void init(FMLInitializationEvent event)
+    {
+        if(!ENABLE) return;
+
+        // Create a shapeless recipe to fill a Bottle from a Bucket
+        ShapelessOreRecipe shapelessOreRecipe = new ShapelessOreRecipe(new ItemStack(Items.POTIONITEM),
+                new ItemStack(Items.GLASS_BOTTLE),
+                new FluidStack(FluidRegistry.WATER, Fluid.BUCKET_VOLUME));
+
+        InventoryCrafting inventoryCrafting = new TestInventoryCrafting();
+        inventoryCrafting.setInventorySlotContents(0, new ItemStack(Items.GLASS_BOTTLE));
+        inventoryCrafting.setInventorySlotContents(1, new ItemStack(Items.WATER_BUCKET));
+        if (shapelessOreRecipe.matches(inventoryCrafting, null))
+        {
+            System.out.println("Shapeless Ore Recipe FluidStack matching successful");
+        }
+
+        // Create a shaped recipe to fill a Bottle from a Bucket
+        ShapedOreRecipe shapedOreRecipe = new ShapedOreRecipe(new ItemStack(Items.POTIONITEM),
+                "B",
+                "F",
+                'B', new ItemStack(Items.GLASS_BOTTLE),
+                'F', new FluidStack(FluidRegistry.WATER, Fluid.BUCKET_VOLUME));
+
+        inventoryCrafting = new TestInventoryCrafting();
+        inventoryCrafting.setInventorySlotContents(1, new ItemStack(Items.GLASS_BOTTLE));
+        inventoryCrafting.setInventorySlotContents(4, new ItemStack(Items.WATER_BUCKET));
+        if (shapedOreRecipe.matches(inventoryCrafting, null))
+        {
+            System.out.println("Shaped Ore Recipe FluidStack matching successful");
+        }
+    }
+
+    private class TestInventoryCrafting extends InventoryCrafting
+    {
+        TestInventoryCrafting() {
+            super(new Container() {
+                @Override
+                public boolean canInteractWith(EntityPlayer playerIn)
+                {
+                    return true;
+                }
+            }, 3, 3);
+        }
+    }
+}


### PR DESCRIPTION
This PR adds the ability to specify a FluidStack in an Ore Recipe and have any Fluid Container that contains the requested Fluid match, regardless of the specific Item used: Bucket, Bottle, Barrel, Cell, etc... The condition being that you be able to drain the required fluid from the item.

I left getRemainingItems() as it was, but an argument could be made that instead of replacing all items with their containers or consuming them entirely you should drain the requested Fluid amount. I'm not entirely sure how capability based containers handle this kind of thing. Input is welcome.

I also included an example test mini-mod, but I couldn't figure out how to actually run it unfortunately. Any pointers on that would be welcome as well.

Pokes @mezz
