### PR TITLE
Don't ignore 'occupied' parameter in Block#setBedOccupied

### DIFF
--- a/patches/minecraft/net/minecraft/block/Block.java.patch
+++ b/patches/minecraft/net/minecraft/block/Block.java.patch
@@ -629,7 +629,7 @@
 +        {
 +            IBlockState state = world.func_180495_p(pos);
 +            state = state.func_177230_c().func_176221_a(state, world, pos);
-+            state = state.func_177226_a(BlockBed.field_176471_b, true);
++            state = state.func_177226_a(BlockBed.field_176471_b, occupied);
 +            ((World)world).func_180501_a(pos, state, 4);
 +        }
 +    }


### PR DESCRIPTION
Currently, `Block#setBedOccupied` always sets the `BlockBed.OCCUPIED` property on the state to `true`. This causes the `OCCUPIED` property to never change back to `false` when a player leaves the bed.
