### PR TITLE
ItemFrame Overrides

### DIFF
--- a/patches/minecraft/net/minecraft/entity/item/EntityItemFrame.java.patch
+++ b/patches/minecraft/net/minecraft/entity/item/EntityItemFrame.java.patch
@@ -14,6 +14,6 @@
      public int func_174866_q()
      {
 -        return this.func_82335_i() == null ? 0 : this.func_82333_j() % 8 + 1;
-+        return this.func_82335_i() == null ? 0 :(func_82335_i().func_77973_b().hasItemFrameOutput(field_70170_p,new BlockPos(field_70165_t,field_70163_u,field_70161_v),func_82335_i())?func_82335_i().func_77973_b().getItemFrameOutput(field_70170_p,new BlockPos(field_70165_t,field_70163_u,field_70161_v),func_82335_i(),func_82333_j()%8+1):this.func_82333_j() % 8 + 1);
++        return this.func_82335_i() == null ? 0 :func_82335_i().func_77973_b().getItemFrameOutput(field_70170_p,new BlockPos(field_70165_t,field_70163_u,field_70161_v),func_82335_i(),func_82333_j()%8+1);
      }
  }

--- a/patches/minecraft/net/minecraft/entity/item/EntityItemFrame.java.patch
+++ b/patches/minecraft/net/minecraft/entity/item/EntityItemFrame.java.patch
@@ -9,3 +9,11 @@
              {
                  MapData mapdata = ((ItemMap)p_110131_1_.func_77973_b()).func_77873_a(p_110131_1_, this.field_70170_p);
                  mapdata.field_76203_h.remove("frame-" + this.func_145782_y());
+@@ -278,6 +278,6 @@
+ 
+     public int func_174866_q()
+     {
+-        return this.func_82335_i() == null ? 0 : this.func_82333_j() % 8 + 1;
++        return this.func_82335_i() == null ? 0 :(func_82335_i().func_77973_b().hasItemFrameOutput(field_70170_p,new BlockPos(field_70165_t,field_70163_u,field_70161_v),func_82335_i())?func_82335_i().func_77973_b().getItemFrameOutput(field_70170_p,new BlockPos(field_70165_t,field_70163_u,field_70161_v),func_82335_i(),func_82333_j()%8+1):this.func_82333_j() % 8 + 1);
+     }
+ }

--- a/patches/minecraft/net/minecraft/item/Item.java.patch
+++ b/patches/minecraft/net/minecraft/item/Item.java.patch
@@ -60,7 +60,7 @@
          return p_77621_1_.func_147447_a(vec3d, vec3d1, p_77621_3_, !p_77621_3_, false);
      }
  
-@@ -426,11 +433,580 @@
+@@ -426,11 +433,603 @@
          return false;
      }
  
@@ -635,13 +635,36 @@
 +        }
 +        return builder.build();
 +    }
-+
++    /**
++     * Called from EntityItemFram.getAnalogOutput, used to allow items in item frames to provide their own
++     * Comparator output signal strengths.  Return true to use this feature.
++     * @param worldIn
++     * @param pos
++     * @param stack
++     * @return use value from getItemFrameOutput as redstone signal strength
++     */
++    public boolean hasItemFrameOutput(World worldIn, BlockPos pos, ItemStack stack) {
++        return false;
++    }
++    /**
++     * Called from EntityItemFram.getAnalogOutput, if hasItemFrameOutput returns true. Used to allow items in
++     * item frames to provide their own Comparator output signal strengths, e.g. displaying any sort of world
++     * information, such as biome temperature, rainfall, etc.
++     * @param worldIn
++     * @param pos
++     * @param stack
++     * @param rotation - the default value from the ItemFrame (rotation amount)
++     * @return redstone signal strength
++     */
++    public int getItemFrameOutput(World worldIn, BlockPos pos, ItemStack stack, int rotation) {
++        return rotation;
++    }
 +    /* ======================================== FORGE END   =====================================*/
 +
      public static void func_150900_l()
      {
          func_179214_a(Blocks.field_150348_b, (new ItemMultiTexture(Blocks.field_150348_b, Blocks.field_150348_b, new Function<ItemStack, String>()
-@@ -962,6 +1538,10 @@
+@@ -962,6 +1561,10 @@
          private final float field_78011_i;
          private final int field_78008_j;
  
@@ -652,7 +675,7 @@
          private ToolMaterial(int p_i1874_3_, int p_i1874_4_, float p_i1874_5_, float p_i1874_6_, int p_i1874_7_)
          {
              this.field_78001_f = p_i1874_3_;
-@@ -996,9 +1576,36 @@
+@@ -996,9 +1599,36 @@
              return this.field_78008_j;
          }
  

--- a/patches/minecraft/net/minecraft/item/Item.java.patch
+++ b/patches/minecraft/net/minecraft/item/Item.java.patch
@@ -60,7 +60,7 @@
          return p_77621_1_.func_147447_a(vec3d, vec3d1, p_77621_3_, !p_77621_3_, false);
      }
  
-@@ -426,11 +433,603 @@
+@@ -426,11 +433,592 @@
          return false;
      }
  
@@ -637,19 +637,8 @@
 +    }
 +    /**
 +     * Called from EntityItemFram.getAnalogOutput, used to allow items in item frames to provide their own
-+     * Comparator output signal strengths.  Return true to use this feature.
-+     * @param worldIn
-+     * @param pos
-+     * @param stack
-+     * @return use value from getItemFrameOutput as redstone signal strength
-+     */
-+    public boolean hasItemFrameOutput(World worldIn, BlockPos pos, ItemStack stack) {
-+        return false;
-+    }
-+    /**
-+     * Called from EntityItemFram.getAnalogOutput, if hasItemFrameOutput returns true. Used to allow items in
-+     * item frames to provide their own Comparator output signal strengths, e.g. displaying any sort of world
-+     * information, such as biome temperature, rainfall, etc.
++     * Comparator output signal strengths, e.g. displaying any sort of world information, such as biome
++     * temperature, rainfall, etc.
 +     * @param worldIn
 +     * @param pos
 +     * @param stack
@@ -664,7 +653,7 @@
      public static void func_150900_l()
      {
          func_179214_a(Blocks.field_150348_b, (new ItemMultiTexture(Blocks.field_150348_b, Blocks.field_150348_b, new Function<ItemStack, String>()
-@@ -962,6 +1561,10 @@
+@@ -962,6 +1550,10 @@
          private final float field_78011_i;
          private final int field_78008_j;
  
@@ -675,7 +664,7 @@
          private ToolMaterial(int p_i1874_3_, int p_i1874_4_, float p_i1874_5_, float p_i1874_6_, int p_i1874_7_)
          {
              this.field_78001_f = p_i1874_3_;
-@@ -996,9 +1599,36 @@
+@@ -996,9 +1588,36 @@
              return this.field_78008_j;
          }
  


### PR DESCRIPTION
Added code to let items provide their own comparator output via EntityItemFrame, so that they could supply redstone signal information about the world (e.g. temperature).

I tried to get some input on method to use [here](http://www.minecraftforge.net/forum/index.php?topic=42837.0) with no response.  Willing to refactor.

[My use-case](http://reasonable-realism.wikia.com/wiki/Biome_Data) [with example item](http://pastebin.com/jL4YNXXF)
