### PR TITLE
Add Item#getNBTShareTag

### DIFF
--- a/patches/minecraft/net/minecraft/item/Item.java.patch
+++ b/patches/minecraft/net/minecraft/item/Item.java.patch
@@ -60,7 +60,7 @@
          return p_77621_1_.func_147447_a(vec3d, vec3d1, p_77621_3_, !p_77621_3_, false);
      }
  
-@@ -426,11 +433,591 @@
+@@ -426,11 +433,592 @@
          return false;
      }
  
@@ -142,7 +142,8 @@
 +    }
 +
 +    /**
-+     * Called by the packet buffer to send the NBT tag to the client.
++     * Override this method to change the NBT data being sent to the client.
++     * You should ONLY override this when you have no other choice, as this might change behavior client side!
 +     *
 +     * @param stack The stack to send the NBT tag for
 +     * @return The NBT tag
@@ -652,7 +653,7 @@
      public static void func_150900_l()
      {
          func_179214_a(Blocks.field_150348_b, (new ItemMultiTexture(Blocks.field_150348_b, Blocks.field_150348_b, new Function<ItemStack, String>()
-@@ -962,6 +1549,10 @@
+@@ -962,6 +1550,10 @@
          private final float field_78011_i;
          private final int field_78008_j;
  
@@ -663,7 +664,7 @@
          private ToolMaterial(int p_i1874_3_, int p_i1874_4_, float p_i1874_5_, float p_i1874_6_, int p_i1874_7_)
          {
              this.field_78001_f = p_i1874_3_;
-@@ -996,9 +1587,36 @@
+@@ -996,9 +1588,36 @@
              return this.field_78008_j;
          }
  

--- a/patches/minecraft/net/minecraft/item/Item.java.patch
+++ b/patches/minecraft/net/minecraft/item/Item.java.patch
@@ -60,7 +60,7 @@
          return p_77621_1_.func_147447_a(vec3d, vec3d1, p_77621_3_, !p_77621_3_, false);
      }
  
-@@ -426,11 +433,580 @@
+@@ -426,11 +433,591 @@
          return false;
      }
  
@@ -139,6 +139,17 @@
 +    {
 +        canRepair = false;
 +        return this;
++    }
++
++    /**
++     * Called by the packet buffer to send the NBT tag to the client.
++     *
++     * @param stack The stack to send the NBT tag for
++     * @return The NBT tag
++     */
++    public NBTTagCompound getNBTShareTag(ItemStack stack)
++    {
++        return stack.func_77978_p();
 +    }
 +
 +    /**
@@ -641,7 +652,7 @@
      public static void func_150900_l()
      {
          func_179214_a(Blocks.field_150348_b, (new ItemMultiTexture(Blocks.field_150348_b, Blocks.field_150348_b, new Function<ItemStack, String>()
-@@ -962,6 +1538,10 @@
+@@ -962,6 +1549,10 @@
          private final float field_78011_i;
          private final int field_78008_j;
  
@@ -652,7 +663,7 @@
          private ToolMaterial(int p_i1874_3_, int p_i1874_4_, float p_i1874_5_, float p_i1874_6_, int p_i1874_7_)
          {
              this.field_78001_f = p_i1874_3_;
-@@ -996,9 +1576,36 @@
+@@ -996,9 +1587,36 @@
              return this.field_78008_j;
          }
  

--- a/patches/minecraft/net/minecraft/network/PacketBuffer.java.patch
+++ b/patches/minecraft/net/minecraft/network/PacketBuffer.java.patch
@@ -1,0 +1,11 @@
+--- ../src-base/minecraft/net/minecraft/network/PacketBuffer.java
++++ ../src-work/minecraft/net/minecraft/network/PacketBuffer.java
+@@ -333,7 +333,7 @@
+ 
+             if (p_150788_1_.func_77973_b().func_77645_m() || p_150788_1_.func_77973_b().func_77651_p())
+             {
+-                nbttagcompound = p_150788_1_.func_77978_p();
++                nbttagcompound = p_150788_1_.func_77973_b().getNBTShareTag(p_150788_1_);
+             }
+ 
+             this.func_150786_a(nbttagcompound);


### PR DESCRIPTION
Allows a mod to have custom NBT data for an item sent to the client.

One big use case for this is that mods can keep big NBT data on the server, and prevent crashes of sending too big NBT tags.
