### PR TITLE
[1.10] Add ItemBlockSpecial#getBlock

### DIFF
--- a/patches/minecraft/net/minecraft/item/ItemBlockSpecial.java.patch
+++ b/patches/minecraft/net/minecraft/item/ItemBlockSpecial.java.patch
@@ -18,3 +18,13 @@
                  p_180614_3_.func_184133_a(p_180614_2_, p_180614_4_, soundtype.func_185841_e(), SoundCategory.BLOCKS, (soundtype.func_185843_a() + 1.0F) / 2.0F, soundtype.func_185847_b() * 0.8F);
                  --p_180614_1_.field_77994_a;
                  return EnumActionResult.SUCCESS;
+@@ -66,4 +66,9 @@
+             return EnumActionResult.FAIL;
+         }
+     }
++
++    public Block getBlock()
++    {
++        return this.field_150935_a;
++    }
+ }


### PR DESCRIPTION
This adds a getter for `ItemBlockSpecial#block`.

You might think that modders can easily work around this. But, this PR has been made to have consistency   with `ItemBlock`, which already has a `getBlock` method.

Merging this will get rid of ugly workarounds like shown here:
https://github.com/raoulvdberge/refinedstorage/blob/mc1.10/src/main/java/com/raoulvdberge/refinedstorage/container/slot/SlotSpecimen.java#L71-L80

With this, we can mostly treat `ItemBlockSpecial` the same as `ItemBlock` without any ugly reflection or ATs.
