### PR TITLE
Allow custom parsing of EntitySelector

### DIFF
--- a/patches/minecraft/net/minecraft/command/EntitySelector.java.patch
+++ b/patches/minecraft/net/minecraft/command/EntitySelector.java.patch
@@ -12,7 +12,19 @@
      private static final Set<String> field_179666_d = Sets.newHashSet(new String[] {"x", "y", "z", "dx", "dy", "dz", "rm", "r"});
  
      @Nullable
-@@ -111,6 +111,7 @@
+@@ -79,6 +79,11 @@
+ 
+     public static <T extends Entity> List<T> func_179656_b(ICommandSender p_179656_0_, String p_179656_1_, Class <? extends T > p_179656_2_)
+     {
++        return net.minecraftforge.common.command.SelectorHandler.getHandler().matchEntities(p_179656_0_, p_179656_1_, p_179656_2_);
++    }
++
++    public static <T extends Entity> List<T> matchEntitiesDefault(ICommandSender p_179656_0_, String p_179656_1_, Class <? extends T > p_179656_2_)
++    {
+         Matcher matcher = field_82389_a.matcher(p_179656_1_);
+ 
+         if (matcher.matches() && p_179656_0_.func_70003_b(1, "@"))
+@@ -111,6 +116,7 @@
                          list2.addAll(func_184951_f(map));
                          list2.addAll(func_180698_a(map, vec3d));
                          list2.addAll(func_179662_g(map));
@@ -20,3 +32,27 @@
                          list1.addAll(func_179660_a(map, p_179656_2_, list2, s, world, blockpos));
                      }
                  }
+@@ -694,6 +700,11 @@
+ 
+     public static boolean func_82377_a(String p_82377_0_)
+     {
++        return net.minecraftforge.common.command.SelectorHandler.getHandler().matchesMultiplePlayers(p_82377_0_);
++    }
++
++    public static boolean matchesMultiplePlayersDefault(String p_82377_0_)
++    {
+         Matcher matcher = field_82389_a.matcher(p_82377_0_);
+ 
+         if (!matcher.matches())
+@@ -711,6 +722,11 @@
+ 
+     public static boolean func_82378_b(String p_82378_0_)
+     {
++        return net.minecraftforge.common.command.SelectorHandler.getHandler().hasArguments(p_82378_0_);
++    }
++
++    public static boolean hasArgumentsDefault(String p_82378_0_)
++    {
+         return field_82389_a.matcher(p_82378_0_).matches();
+     }
+ 

--- a/src/main/java/net/minecraftforge/common/command/SelectorHandler.java
+++ b/src/main/java/net/minecraftforge/common/command/SelectorHandler.java
@@ -1,0 +1,101 @@
+/*
+ * Minecraft Forge
+ * Copyright (c) 2016.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation version 2.1
+ * of the License.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+package net.minecraftforge.common.command;
+
+import net.minecraft.command.EntitySelector;
+import net.minecraft.command.ICommandSender;
+import net.minecraft.entity.Entity;
+import net.minecraftforge.fml.common.FMLLog;
+import net.minecraftforge.fml.common.Loader;
+import net.minecraftforge.fml.common.ModContainer;
+
+import java.util.List;
+
+/**
+ * A proxy for {@link EntitySelector} methods. Can be used to customize the parsing behavior<br>
+ * <b>Note:</b>  You should generally override all three methods to produce consistent results<br>
+ * <b>Note:</b> These methods are called on both client and server<br>
+ * <b>Note:</b>  For compatibility reasons, you should not break the key=value pattern
+ */
+public class SelectorHandler
+{
+    public <T extends Entity> List<T> matchEntities(ICommandSender sender, String token, Class<? extends T> targetClass)
+    {
+        return EntitySelector.matchEntitiesDefault(sender, token, targetClass);
+    }
+
+    /**
+     * This should raise an {@link net.minecraftforge.event.EntitySelectorEvent EntitySelectorEvent}
+     */
+    public boolean matchesMultiplePlayers(String selectorStr)
+    {
+        return EntitySelector.matchesMultiplePlayersDefault(selectorStr);
+    }
+
+    public boolean hasArguments(String selectorStr)
+    {
+        return EntitySelector.hasArgumentsDefault(selectorStr);
+    }
+
+    private static SelectorHandler handler = new SelectorHandler();
+    private static boolean isCustom = false;
+    private static String modifyingMod = "Minecraft";
+
+    /**
+     * Allows you to override the behavior of EnitySelector by setting this handler to a custom implementation<br>
+     * This overrides any previous handlers set<br>
+     * Always use {@link net.minecraftforge.event.EntitySelectorEvent EntitySelectorEvent} if possible
+     */
+    public static void setHandler(SelectorHandler handler)
+    {
+        if (isCustom)
+            FMLLog.bigWarning("SelectorHandler is already overridden" + (modifyingMod == null ? "" : " by '" + modifyingMod + "'"));
+
+        isCustom = true;
+        ModContainer container = Loader.instance().activeModContainer();
+
+        if (container == null)
+            FMLLog.bigWarning("SelectorHandler is overridden by an unknown mod. Overriding should be done during mod loading");
+
+        modifyingMod = container == null ? null : container.getName();
+
+        SelectorHandler.handler = handler;
+
+        FMLLog.info("SelectorHandler is being overridden" + (modifyingMod == null ? "" : " by '" + modifyingMod + "'"));
+    }
+
+    public static SelectorHandler getHandler()
+    {
+        return handler;
+    }
+
+    public static boolean isCustom()
+    {
+        return isCustom;
+    }
+
+    /**
+     * @return <code>null</code> if unknown, "Minecraft" if not custom, and name of modifying mod otherwise
+     */
+    public static String getModifyingMod()
+    {
+        return modifyingMod;
+    }
+}

--- a/src/main/resources/forge.exc
+++ b/src/main/resources/forge.exc
@@ -55,3 +55,7 @@ net/minecraft/world/storage/loot/LootEntry.<init>(II[Lnet/minecraft/world/storag
 net/minecraft/world/storage/loot/LootEntryItem.<init>(Lnet/minecraft/item/Item;II[Lnet/minecraft/world/storage/loot/functions/LootFunction;[Lnet/minecraft/world/storage/loot/conditions/LootCondition;Ljava/lang/String;)V=|p_i46644_1_,p_i46644_2_,p_i46644_3_,p_i46644_4_,p_i46644_5_,entryName
 net/minecraft/world/storage/loot/LootEntryTable.<init>(Lnet/minecraft/util/ResourceLocation;II[Lnet/minecraft/world/storage/loot/conditions/LootCondition;Ljava/lang/String;)V=|p_i46639_1_,p_i46639_2_,p_i46639_3_,p_i46639_4_,entryName
 net/minecraft/world/storage/loot/LootEntryEmpty.<init>(II[Lnet/minecraft/world/storage/loot/conditions/LootCondition;Ljava/lang/String;)V=|p_i46645_1_,p_i46645_2_,p_i46645_3_,entryName
+
+net/minecraft/command/EntitySelector.matchEntitiesDefault(Lnet/minecraft/command/ICommandSender;Ljava/lang/String;Ljava/lang/Class;)Ljava/util/List;=|p_179656_0_,p_179656_1_,p_179656_2_
+net/minecraft/command/EntitySelector.matchesMultiplePlayersDefault(Ljava/lang/String;)Z=|p_82377_0_
+net/minecraft/command/EntitySelector.hasArgumentsDefault(Ljava/lang/String;)Z=|p_82378_0_


### PR DESCRIPTION
## What does it do
This PR adds the possibility to override the way the EntitySelector is parsed. It does so by routing calls to the three affected methods (`EntitiySelector.matchEntities(ICommandSender, String, Class)`, `.hasArguments(String)` and `.matchesMultiplePlayers(String)`) over an instance of `SelectorHandler`. The default implementation of this class just calls the old implementation (their names are now `*Default`).

~~Note: We're not sure whether `ForgeHooks` is the best place for the proxy, if there's anything better, we will obviously change that~~
~~Note 2: Currently, the patch changes 6 lines of `EntitySelector`. This could be reduced to 3 by removing the line break between the two, but this is probably worse than 6 lines.~~

## Why this way
### Why these methods
Overriding these three methods allows you to change the behavior of all public methods of `EntitySelector` (except `getScoreMap`, where overriding doesn't make sense). `matchesMultiplePlayers` and `hasArguments` need to be overridden too, if one wants to get consistent behaviour.

### Why not as an event
The issue with using events is that either you have to listen for three events (not reflecting that they belong together) or to a single compound event for all three methods (which is even messier).

## Why at all
Doing it this way allows you to affect all places where selectors are used at once: Commands, IChatComponents and CommandResultStats. While it would be possible to do it for commands using the `CommandEvent` or by overriding the `CommandHandler`, it would be a lot harder, and you would have to use another trick for the other two cases, not to mention that you would never catch if someone used a selector in something entirely different.

For simple additions of other parameters, it would be easier to just provide a hook allowing you to add additional `Predicate`s inside the `matchEntities` method. However, it is not possible to use this approach to introduce a more general syntax. An example would be something like
```
@e[r=$score[@p[rm=5,r=10],radius]]
```
This would read out the score `radius` from the player between `5` and `10` blocks away, and use the resulting value for the `r` parameter of the `@e` selector. The issue here is that you don't know the syntax of the values (the `@e[<key1>=<value1>,...]` structure should remain the same) in general (since they could be literally anything). This means that it can't be fixed by simply changing the RegEx or so (even if an extremely messy recursive RegEx (which is not even part of Java) could potentially do it for this particular example), so you really have to parse the selector yourself.

