### PR TITLE
[1.11] Added new ReplaceEvent

### DIFF
--- a/patches/minecraft/net/minecraft/block/BlockGrass.java.patch
+++ b/patches/minecraft/net/minecraft/block/BlockGrass.java.patch
@@ -1,15 +1,20 @@
 --- ../src-base/minecraft/net/minecraft/block/BlockGrass.java
 +++ ../src-work/minecraft/net/minecraft/block/BlockGrass.java
-@@ -38,7 +38,7 @@
+@@ -38,9 +38,11 @@
      {
          if (!p_180650_1_.field_72995_K)
          {
 -            if (p_180650_1_.func_175671_l(p_180650_2_.func_177984_a()) < 4 && p_180650_1_.func_180495_p(p_180650_2_.func_177984_a()).func_185891_c() > 2)
 +            if (p_180650_1_.func_175671_l(p_180650_2_.func_177984_a()) < 4 && p_180650_1_.func_180495_p(p_180650_2_.func_177984_a()).getLightOpacity(p_180650_1_, p_180650_2_.func_177984_a()) > 2)
              {
-                 p_180650_1_.func_175656_a(p_180650_2_, Blocks.field_150346_d.func_176223_P());
+-                p_180650_1_.func_175656_a(p_180650_2_, Blocks.field_150346_d.func_176223_P());
++                net.minecraftforge.event.world.BlockEvent.ReplaceEvent event = net.minecraftforge.event.ForgeEventFactory.onBlockReplace(p_180650_1_, p_180650_2_, p_180650_1_.func_180495_p(p_180650_2_), Blocks.field_150346_d.func_176223_P());
++                if (event.isCanceled()) return;
++                p_180650_1_.func_175656_a(p_180650_2_, event.getNextState());
              }
-@@ -58,7 +58,7 @@
+             else
+             {
+@@ -58,7 +60,7 @@
                          IBlockState iblockstate = p_180650_1_.func_180495_p(blockpos.func_177984_a());
                          IBlockState iblockstate1 = p_180650_1_.func_180495_p(blockpos);
  
@@ -18,7 +23,7 @@
                          {
                              p_180650_1_.func_175656_a(blockpos, Blocks.field_150349_c.func_176223_P());
                          }
-@@ -96,18 +96,11 @@
+@@ -96,18 +98,11 @@
              {
                  if (j >= i / 16)
                  {

--- a/patches/minecraft/net/minecraft/block/BlockIce.java.patch
+++ b/patches/minecraft/net/minecraft/block/BlockIce.java.patch
@@ -27,3 +27,17 @@
              Material material = p_180657_1_.func_180495_p(p_180657_3_.func_177977_b()).func_185904_a();
  
              if (material.func_76230_c() || material.func_76224_d())
+@@ -85,9 +92,11 @@
+         }
+         else
+         {
++            net.minecraftforge.event.world.BlockEvent.ReplaceEvent event = net.minecraftforge.event.ForgeEventFactory.onBlockReplace(p_185679_1_, p_185679_2_, p_185679_1_.func_180495_p(p_185679_2_), Blocks.field_150355_j.func_176223_P());
++            if (event.isCanceled()) return;
+             this.func_176226_b(p_185679_1_, p_185679_2_, p_185679_1_.func_180495_p(p_185679_2_), 0);
+-            p_185679_1_.func_175656_a(p_185679_2_, Blocks.field_150355_j.func_176223_P());
+-            p_185679_1_.func_190524_a(p_185679_2_, Blocks.field_150355_j, p_185679_2_);
++            p_185679_1_.func_175656_a(p_185679_2_, event.getNextState());
++            p_185679_1_.func_190524_a(p_185679_2_, event.getNextState().func_177230_c(), p_185679_2_);
+         }
+     }
+ 

--- a/patches/minecraft/net/minecraft/block/BlockReed.java.patch
+++ b/patches/minecraft/net/minecraft/block/BlockReed.java.patch
@@ -38,7 +38,19 @@
  
          if (block == this)
          {
-@@ -164,6 +170,17 @@
+@@ -111,8 +117,10 @@
+         }
+         else
+         {
++            net.minecraftforge.event.world.BlockEvent.ReplaceEvent event = net.minecraftforge.event.ForgeEventFactory.onBlockReplace(p_176353_1_, p_176353_2_, p_176353_1_.func_180495_p(p_176353_2_), Blocks.field_150350_a.func_176223_P());
++            if (event.isCanceled()) return true;
+             this.func_176226_b(p_176353_1_, p_176353_2_, p_176353_3_, 0);
+-            p_176353_1_.func_175698_g(p_176353_2_);
++            p_176353_1_.func_175656_a(p_176353_2_, event.getNextState());
+             return false;
+         }
+     }
+@@ -164,6 +172,17 @@
          return ((Integer)p_176201_1_.func_177229_b(field_176355_a)).intValue();
      }
  

--- a/patches/minecraft/net/minecraft/block/BlockReed.java.patch
+++ b/patches/minecraft/net/minecraft/block/BlockReed.java.patch
@@ -38,19 +38,7 @@
  
          if (block == this)
          {
-@@ -111,8 +117,10 @@
-         }
-         else
-         {
-+            net.minecraftforge.event.world.BlockEvent.ReplaceEvent event = net.minecraftforge.event.ForgeEventFactory.onBlockReplace(p_176353_1_, p_176353_2_, p_176353_1_.func_180495_p(p_176353_2_), Blocks.field_150350_a.func_176223_P());
-+            if (event.isCanceled()) return true;
-             this.func_176226_b(p_176353_1_, p_176353_2_, p_176353_3_, 0);
--            p_176353_1_.func_175698_g(p_176353_2_);
-+            p_176353_1_.func_175656_a(p_176353_2_, event.getNextState());
-             return false;
-         }
-     }
-@@ -164,6 +172,17 @@
+@@ -164,6 +170,17 @@
          return ((Integer)p_176201_1_.func_177229_b(field_176355_a)).intValue();
      }
  

--- a/src/main/java/net/minecraftforge/event/ForgeEventFactory.java
+++ b/src/main/java/net/minecraftforge/event/ForgeEventFactory.java
@@ -645,4 +645,11 @@ public class ForgeEventFactory
         net.minecraftforge.common.MinecraftForge.EVENT_BUS.post(e);
         return e.getLevel();
     }
+
+    public static BlockEvent.ReplaceEvent onBlockReplace(World world, BlockPos pos, IBlockState currentState, IBlockState nextState)
+    {
+        BlockEvent.ReplaceEvent event = new BlockEvent.ReplaceEvent(world, pos, currentState, nextState);
+        MinecraftForge.EVENT_BUS.post(event);
+        return event;
+    }
 }

--- a/src/main/java/net/minecraftforge/event/world/BlockEvent.java
+++ b/src/main/java/net/minecraftforge/event/world/BlockEvent.java
@@ -208,8 +208,7 @@ public class BlockEvent extends Event
     }
 
     /**
-     * Fired when a block is replaced, like ice changing to water, water and lava to Obsidian/Cobblestone/Stone, and
-     * Grass to Dirt
+     * Fired when a block is replaced (Ice changing to Water, Grass changing to Dirt)
      */
     @Cancelable
     public static class ReplaceEvent extends BlockEvent

--- a/src/main/java/net/minecraftforge/event/world/BlockEvent.java
+++ b/src/main/java/net/minecraftforge/event/world/BlockEvent.java
@@ -208,6 +208,29 @@ public class BlockEvent extends Event
     }
 
     /**
+     * Fired when a block is replaced, like ice changing to water, water and lava to Obsidian/Cobblestone/Stone, and
+     * Grass to Dirt
+     */
+    @Cancelable
+    public static class ReplaceEvent extends BlockEvent
+    {
+
+        private final IBlockState state;
+        private IBlockState nextState;
+
+        public ReplaceEvent(World world, BlockPos pos, IBlockState state, IBlockState nextState) {
+            super(world,pos,state);
+            this.state = state;
+            this.nextState = nextState;
+        }
+
+
+        public IBlockState getState() { return state; }
+        public IBlockState getNextState() { return nextState; }
+        public void setNextState(IBlockState nextState) { this.nextState =  nextState; }
+    }
+
+    /**
      * Fired when a single block placement action of a player triggers the
      * creation of multiple blocks(e.g. placing a bed block). The block returned
      * by {@link #state} and its related methods is the block where

--- a/src/test/java/net/minecraftforge/test/BlockReplaceEventTest.java
+++ b/src/test/java/net/minecraftforge/test/BlockReplaceEventTest.java
@@ -1,0 +1,33 @@
+package net.minecraftforge.test;
+
+import net.minecraft.init.Blocks;
+import net.minecraftforge.common.MinecraftForge;
+import net.minecraftforge.event.world.BlockEvent;
+import net.minecraftforge.fml.common.Mod;
+import net.minecraftforge.fml.common.Mod.EventHandler;
+import net.minecraftforge.fml.common.event.FMLInitializationEvent;
+import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
+
+@Mod(modid="blockreplaceeventtest", name="BlockReplaceEventTest", version="0.0.0", acceptableRemoteVersions = "*")
+public class BlockReplaceEventTest
+{
+
+    public static final boolean ENABLE = false;
+
+    @EventHandler
+    public void init(FMLInitializationEvent event)
+    {
+        MinecraftForge.EVENT_BUS.register(this);
+    }
+
+    @SubscribeEvent
+    public void onBlockReplace(BlockEvent.ReplaceEvent event)
+    {
+        if(ENABLE) {
+            if (event.getState() == Blocks.GRASS.getDefaultState()) {
+                System.out.println("Not replacing " + event.getState().getBlock() + " with " + event.getNextState());
+                event.setCanceled(true);
+            }
+        }
+    }
+}


### PR DESCRIPTION
The PR adds a new ReplaceEvent. The event currently occurs when Ice melts, Grass changes to Dirt, and when Water and Lava form Cobblestone, Obsidian, or Stone. The event is cancelable and also has a setter `setNextState(BlockState state)` to change what the block is replaced with, and getters `getState()` and `getNextState()` to determine what state change is occuring. 