### PR TITLE
Add support for custom entity selectors in commands

### DIFF
--- a/patches/minecraft/net/minecraft/command/EntitySelector.java.patch
+++ b/patches/minecraft/net/minecraft/command/EntitySelector.java.patch
@@ -1,10 +1,6 @@
 --- ../src-base/minecraft/net/minecraft/command/EntitySelector.java
 +++ ../src-work/minecraft/net/minecraft/command/EntitySelector.java
-@@ -34,12 +34,13 @@
- import net.minecraft.util.text.TextFormatting;
- import net.minecraft.world.GameType;
- import net.minecraft.world.World;
-+import net.minecraftforge.event.ForgeEventFactory;
+@@ -37,9 +37,9 @@
  
  public class EntitySelector
  {
@@ -16,11 +12,11 @@
      private static final Set<String> field_179666_d = Sets.newHashSet(new String[] {"x", "y", "z", "dx", "dy", "dz", "rm", "r"});
  
      @Nullable
-@@ -111,6 +112,7 @@
+@@ -111,6 +111,7 @@
                          list2.addAll(func_184951_f(map));
                          list2.addAll(func_180698_a(map, vec3d));
                          list2.addAll(func_179662_g(map));
-+                        list2.addAll(ForgeEventFactory.gatherEntitySelectors(map,s,p_179656_0_,vec3d));
++                        list2.addAll(net.minecraftforge.event.ForgeEventFactory.gatherEntitySelectors(map, s, p_179656_0_, vec3d));
                          list1.addAll(func_179660_a(map, p_179656_2_, list2, s, world, blockpos));
                      }
                  }

--- a/patches/minecraft/net/minecraft/command/EntitySelector.java.patch
+++ b/patches/minecraft/net/minecraft/command/EntitySelector.java.patch
@@ -1,14 +1,26 @@
 --- ../src-base/minecraft/net/minecraft/command/EntitySelector.java
 +++ ../src-work/minecraft/net/minecraft/command/EntitySelector.java
-@@ -37,9 +37,9 @@
+@@ -34,12 +34,13 @@
+ import net.minecraft.util.text.TextFormatting;
+ import net.minecraft.world.GameType;
+ import net.minecraft.world.World;
++import net.minecraftforge.event.ForgeEventFactory;
  
  public class EntitySelector
  {
 -    private static final Pattern field_82389_a = Pattern.compile("^@([pare])(?:\\[([\\w=,!-]*)\\])?$");
-+    private static final Pattern field_82389_a = Pattern.compile("^@([pare])(?:\\[([\\w\\.=,!-]*)\\])?$"); // FORGE: allow . in entity selectors
++    private static final Pattern field_82389_a = Pattern.compile("^@([pare])(?:\\[([\\w\\.:=,!-]*)\\])?$"); // FORGE: allow '.' and ':' in entity selectors
      private static final Pattern field_82387_b = Pattern.compile("\\G([-!]?[\\w-]*)(?:$|,)");
 -    private static final Pattern field_82388_c = Pattern.compile("\\G(\\w+)=([-!]?[\\w-]*)(?:$|,)");
-+    private static final Pattern field_82388_c = Pattern.compile("\\G(\\w+)=([-!]?[\\w\\.-]*)(?:$|,)"); // FORGE: allow . in entity selectors
++    private static final Pattern field_82388_c = Pattern.compile("\\G([\\w:]+)=([-!]?[\\w\\.-]*)(?:$|,)"); // FORGE: allow ':' in arguments and '.' in value of entity selectors
      private static final Set<String> field_179666_d = Sets.newHashSet(new String[] {"x", "y", "z", "dx", "dy", "dz", "rm", "r"});
  
      @Nullable
+@@ -111,6 +112,7 @@
+                         list2.addAll(func_184951_f(map));
+                         list2.addAll(func_180698_a(map, vec3d));
+                         list2.addAll(func_179662_g(map));
++                        list2.addAll(ForgeEventFactory.gatherEntitySelectors(map,s,p_179656_0_,vec3d));
+                         list1.addAll(func_179660_a(map, p_179656_2_, list2, s, world, blockpos));
+                     }
+                 }

--- a/src/main/java/net/minecraftforge/event/EntitySelectorEvent.java
+++ b/src/main/java/net/minecraftforge/event/EntitySelectorEvent.java
@@ -22,7 +22,8 @@ import java.util.Map;
  * <br>
  * This event is fired on the {@link MinecraftForge#EVENT_BUS}
  */
-public class EntitySelectorEvent extends Event {
+public class EntitySelectorEvent extends Event
+{
 
     private final Map<String, String> map;
     private final String mainSelector;
@@ -30,7 +31,8 @@ public class EntitySelectorEvent extends Event {
     private final Vec3d position;
     private final List<Predicate<Entity>> selectors;
 
-    public EntitySelectorEvent(Map<String, String> map, String mainSelector, ICommandSender sender, Vec3d position) {
+    public EntitySelectorEvent(Map<String, String> map, String mainSelector, ICommandSender sender, Vec3d position)
+    {
         this.map = map;
         this.mainSelector = mainSelector;
         this.sender = sender;
@@ -44,8 +46,10 @@ public class EntitySelectorEvent extends Event {
      *
      * @param selector Your custom predicate
      */
-    public void addPredicate(Predicate<Entity> selector) {
-        if (selector == null) {
+    public void addPredicate(Predicate<Entity> selector)
+    {
+        if (selector == null)
+        {
             throw new NullPointerException("Attempted to add null predicate as entity selector");
         }
         selectors.add(selector);
@@ -54,7 +58,8 @@ public class EntitySelectorEvent extends Event {
     /**
      * @return The main selector used (e.g. 'a' for all players or 'e' for all entities)
      */
-    public String getMainSelector() {
+    public String getMainSelector()
+    {
         return mainSelector;
     }
 
@@ -63,7 +68,8 @@ public class EntitySelectorEvent extends Event {
      *
      * @return The argument map. Maps all given argument names with its value.
      */
-    public Map<String, String> getMap() {
+    public Map<String, String> getMap()
+    {
         return map;
     }
 
@@ -72,23 +78,25 @@ public class EntitySelectorEvent extends Event {
      *
      * @return A position either specified in the selector arguments or by the players position.
      */
-    public Vec3d getPosition() {
+    public Vec3d getPosition()
+    {
         return position;
     }
 
     /**
      * @return The sender of the command.
      */
-    public ICommandSender getSender() {
+    public ICommandSender getSender()
+    {
         return sender;
     }
 
     /**
      * @return The list of added custom selectors
      */
-    List<Predicate<Entity>> getSelectors() {
+    List<Predicate<Entity>> getSelectors()
+    {
         return selectors;
     }
-
 
 }

--- a/src/main/java/net/minecraftforge/event/EntitySelectorEvent.java
+++ b/src/main/java/net/minecraftforge/event/EntitySelectorEvent.java
@@ -1,3 +1,22 @@
+/*
+ * Minecraft Forge
+ * Copyright (c) 2016.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation version 2.1
+ * of the License.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
 package net.minecraftforge.event;
 
 import com.google.common.base.Predicate;
@@ -68,7 +87,7 @@ public class EntitySelectorEvent extends Event
      *
      * @return The argument map. Maps all given argument names with its value.
      */
-    public Map<String, String> getMap()
+    public Map<String, String> getArgumentMap()
     {
         return map;
     }

--- a/src/main/java/net/minecraftforge/event/EntitySelectorEvent.java
+++ b/src/main/java/net/minecraftforge/event/EntitySelectorEvent.java
@@ -1,0 +1,94 @@
+package net.minecraftforge.event;
+
+import com.google.common.base.Predicate;
+import com.google.common.collect.Lists;
+import net.minecraft.command.EntitySelector;
+import net.minecraft.command.ICommandSender;
+import net.minecraft.entity.Entity;
+import net.minecraft.util.math.Vec3d;
+import net.minecraftforge.common.MinecraftForge;
+import net.minecraftforge.fml.common.eventhandler.Event;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * EntitySelectorEvent is fired whenever Minecraft collects entity selectors.
+ * This happens (one or multiple times) when you use something like @a[gamemode=1] in a command.<br>
+ * This event is fired via {@link ForgeEventFactory#gatherEntitySelectors(Map, String, ICommandSender, Vec3d)},
+ * which is executed in {@link net.minecraft.command.EntitySelector#matchEntities(ICommandSender, String, Class)}<br>
+ * <br>
+ * This event is not cancelable and does not have a result.<br>
+ * <br>
+ * This event is fired on the {@link MinecraftForge#EVENT_BUS}
+ */
+public class EntitySelectorEvent extends Event {
+
+    private final Map<String, String> map;
+    private final String mainSelector;
+    private final ICommandSender sender;
+    private final Vec3d position;
+    private final List<Predicate<Entity>> selectors;
+
+    public EntitySelectorEvent(Map<String, String> map, String mainSelector, ICommandSender sender, Vec3d position) {
+        this.map = map;
+        this.mainSelector = mainSelector;
+        this.sender = sender;
+        this.position = position;
+        selectors = Lists.newArrayList();
+    }
+
+    /**
+     * Add your custom selector.
+     * It is recommend to use "modid:name", if checking for own arguments, to avoid inter-mod interference (e.g.  "@a[Forge:timeplayed=100]").
+     *
+     * @param selector Your custom predicate
+     */
+    public void addPredicate(Predicate<Entity> selector) {
+        if (selector == null) {
+            throw new NullPointerException("Attempted to add null predicate as entity selector");
+        }
+        selectors.add(selector);
+    }
+
+    /**
+     * @return The main selector used (e.g. 'a' for all players or 'e' for all entities)
+     */
+    public String getMainSelector() {
+        return mainSelector;
+    }
+
+    /**
+     * Example: "@a[test=true]" would result in a map with "test"=>"true"
+     *
+     * @return The argument map. Maps all given argument names with its value.
+     */
+    public Map<String, String> getMap() {
+        return map;
+    }
+
+    /**
+     * See {@link EntitySelector#getPosFromArguments(Map, Vec3d)}
+     *
+     * @return A position either specified in the selector arguments or by the players position.
+     */
+    public Vec3d getPosition() {
+        return position;
+    }
+
+    /**
+     * @return The sender of the command.
+     */
+    public ICommandSender getSender() {
+        return sender;
+    }
+
+    /**
+     * @return The list of added custom selectors
+     */
+    List<Predicate<Entity>> getSelectors() {
+        return selectors;
+    }
+
+
+}

--- a/src/main/java/net/minecraftforge/event/ForgeEventFactory.java
+++ b/src/main/java/net/minecraftforge/event/ForgeEventFactory.java
@@ -225,8 +225,9 @@ public class ForgeEventFactory
         return event.getDisplayname();
     }
 
-    public static List<Predicate<Entity>> gatherEntitySelectors(Map<String, String> map, String mainSelector, ICommandSender sender, Vec3d position){
-        EntitySelectorEvent event=new EntitySelectorEvent(map,mainSelector,sender,position);
+    public static List<Predicate<Entity>> gatherEntitySelectors(Map<String, String> map, String mainSelector, ICommandSender sender, Vec3d position)
+    {
+        EntitySelectorEvent event=new EntitySelectorEvent(map, mainSelector, sender, position);
         MinecraftForge.EVENT_BUS.post(event);
         return event.getSelectors();
     }

--- a/src/main/java/net/minecraftforge/event/ForgeEventFactory.java
+++ b/src/main/java/net/minecraftforge/event/ForgeEventFactory.java
@@ -22,9 +22,12 @@ package net.minecraftforge.event;
 import java.io.File;
 import java.util.EnumSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Random;
 
+import com.google.common.base.Predicate;
 import net.minecraft.block.state.IBlockState;
+import net.minecraft.command.ICommandSender;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.EntityLiving;
 import net.minecraft.entity.EntityLivingBase;
@@ -220,6 +223,12 @@ public class ForgeEventFactory
         PlayerEvent.NameFormat event = new PlayerEvent.NameFormat(player, username);
         MinecraftForge.EVENT_BUS.post(event);
         return event.getDisplayname();
+    }
+
+    public static List<Predicate<Entity>> gatherEntitySelectors(Map<String, String> map, String mainSelector, ICommandSender sender, Vec3d position){
+        EntitySelectorEvent event=new EntitySelectorEvent(map,mainSelector,sender,position);
+        MinecraftForge.EVENT_BUS.post(event);
+        return event.getSelectors();
     }
 
     public static float fireBlockHarvesting(List<ItemStack> drops, World world, BlockPos pos, IBlockState state, int fortune, float dropChance, boolean silkTouch, EntityPlayer player)


### PR DESCRIPTION
Implementation of #3345
Added event for collecting entity selectors in commands.

- Whenever a selector is used in a command (e.g. "/kill @a[m=2]"), an EntitySelectorEvent is thrown.
  Custom selectors/predicates can be added to that event.
- Also allows ':' in arguments so mods can check for e.g. "vampirism:faction=vampire" to avoid mod conflicts. (Is not checked, so only optional)

I was not sure about the appropriate package and naming, if you do not like it, I will change it.

Example usage:
```java
    
    @SubscribeEvent
    public void onEntitySelector(EntitySelectorEvent event){
        Map<String, String> arguments = event.getMap();
        String argument = arguments.get("vampirism:livetime");
        if(argument!=null){
            final int value=Integer.parseInt(argument);
            event.addPredicate(new Predicate<Entity>() {
                @Override
                public boolean apply(@Nullable Entity input) {
                    if(input!=null){
                        return input.ticksExisted==value;
                    }
                    return false;
                }
            });
        }
    }
```

A more "useful" example, which I already tested, can be found [here](https://github.com/TeamLapen/Vampirism/blob/2f9b592ffd1e47751d350b60e38551410a0c37b6/src/main/java/de/teamlapen/vampirism/core/ModEventHandler.java#L55-L99)