### PR TITLE
[1.11] Don't run client commands without a / unless a setting is enabled

### DIFF
--- a/src/main/java/net/minecraftforge/client/ClientCommandHandler.java
+++ b/src/main/java/net/minecraftforge/client/ClientCommandHandler.java
@@ -29,6 +29,7 @@ import net.minecraft.command.ICommand;
 import net.minecraft.command.ICommandSender;
 import net.minecraft.command.WrongUsageException;
 import net.minecraft.server.MinecraftServer;
+import net.minecraftforge.common.ForgeModContainer;
 import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.event.CommandEvent;
 import net.minecraftforge.fml.client.FMLClientHandler;
@@ -62,6 +63,10 @@ public class ClientCommandHandler extends CommandHandler
         if (message.startsWith("/"))
         {
             message = message.substring(1);
+        }
+        else if (ForgeModContainer.clientCommandsRequireSlash)
+        {
+            return 0;
         }
 
         String[] temp = message.split(" ");

--- a/src/main/java/net/minecraftforge/common/ForgeModContainer.java
+++ b/src/main/java/net/minecraftforge/common/ForgeModContainer.java
@@ -110,6 +110,7 @@ public class ForgeModContainer extends DummyModContainer implements WorldAccessC
     public static boolean replaceVanillaBucketModel = true;
     public static long java8Reminder = 0;
     public static boolean disableStairSlabCulling = false; // Also known as the "DontCullStairsBecauseIUseACrappyTexturePackThatBreaksBasicBlockShapesSoICantTrustBasicBlockCulling" flag
+    public static boolean clientCommandsRequireSlash = true;
 
     private static Configuration config;
     private static ForgeModContainer INSTANCE;
@@ -294,6 +295,12 @@ public class ForgeModContainer extends DummyModContainer implements WorldAccessC
                 "Disable culling of hidden faces next to stairs and slabs. Causes extra rendering, but may fix some resource packs that exploit this vanilla mechanic.");
         disableStairSlabCulling = prop.getBoolean(disableStairSlabCulling);
         prop.setLanguageKey("forge.configgui.disableStairSlabCulling").setRequiresMcRestart(false);
+        propOrder.add(prop.getName());
+
+        prop = config.get(Configuration.CATEGORY_CLIENT, "clientCommandsRequireSlash", true,
+                "Require client-side chat commands to be prefixed with a / like server-side commands do.");
+        clientCommandsRequireSlash = prop.getBoolean(true);
+        prop.setLanguageKey("forge.configgui.clientCommandsRequireSlash");
         propOrder.add(prop.getName());
 
         config.setCategoryPropertyOrder(CATEGORY_CLIENT, propOrder);

--- a/src/main/resources/assets/forge/lang/en_US.lang
+++ b/src/main/resources/assets/forge/lang/en_US.lang
@@ -50,6 +50,8 @@ forge.configgui.forgeLightPipelineEnabled=Forge Light Pipeline Enabled
 forge.configgui.java8Reminder=Java 8 Reminder timestamp
 forge.configgui.disableStairSlabCulling=Disable Stair/Slab culling.
 forge.configgui.disableStairSlabCulling.tooltip=Enable this if you see through blocks touching stairs/slabs with your resource pack.
+forge.configgui.clientCommandsRequireSlash=Require "/" before client commands
+forge.configgui.clientCommandsRequireSlash.tooltip=Disable this to be able to use client-side commands in chat without prefixing them with "/".
 
 forge.configgui.modID.tooltip=The mod ID that you want to define override settings for.
 forge.configgui.modID=Mod ID


### PR DESCRIPTION
As was brought up in #3352, it's surprising and potentially unwanted for
client commands to run in chat without a / as a prefix. Hide this behind a
config option.