### PR TITLE
[1.10] Added gradle.properties

### DIFF
--- a/mdk/gradle.properties
+++ b/mdk/gradle.properties
@@ -1,0 +1,1 @@
+org.gradle.jvmargs=-Xmx3G

--- a/mdk/gradle.properties
+++ b/mdk/gradle.properties
@@ -1,1 +1,3 @@
+# Sets default memory used for gradle commands. Can be overridden by user or command line properties.
+# This is required to provide enough memory for the Minecraft decompilation process.
 org.gradle.jvmargs=-Xmx3G


### PR DESCRIPTION
The file sets the default max heap size to 3 GiB so that the decompilation doesn't fail as often.