### PR TITLE
Added EnumHand parameter to Block.getStateForPlacement

### DIFF
--- a/patches/minecraft/net/minecraft/block/Block.java.patch
+++ b/patches/minecraft/net/minecraft/block/Block.java.patch
@@ -1382,10 +1382,10 @@
 +     * @param hitZ The Z coordinate of the hit vector
 +     * @param meta The metadata of {@link ItemStack} as processed by {@link Item#getMetadata(int)}
 +     * @param placer The entity placing the block
-+     * @param stack The stack being used to place this block
++     * @param hand The player hand used to place this block
 +     * @return The state to be placed in the world
 +     */
-+    public IBlockState getStateForPlacement(World world, BlockPos pos, EnumFacing facing, float hitX, float hitY, float hitZ, int meta, EntityLivingBase placer)
++    public IBlockState getStateForPlacement(World world, BlockPos pos, EnumFacing facing, float hitX, float hitY, float hitZ, int meta, EntityLivingBase placer, EnumHand hand)
 +    {
 +        return func_180642_a(world, pos, facing, hitX, hitY, hitZ, meta, placer);
 +    }

--- a/patches/minecraft/net/minecraft/item/ItemBlock.java.patch
+++ b/patches/minecraft/net/minecraft/item/ItemBlock.java.patch
@@ -5,7 +5,7 @@
          {
              int i = this.func_77647_b(itemstack.func_77960_j());
 -            IBlockState iblockstate1 = this.field_150939_a.func_180642_a(p_180614_2_, p_180614_3_, p_180614_5_, p_180614_6_, p_180614_7_, p_180614_8_, i, p_180614_1_);
-+            IBlockState iblockstate1 = this.field_150939_a.getStateForPlacement(p_180614_2_, p_180614_3_, p_180614_5_, p_180614_6_, p_180614_7_, p_180614_8_, i, p_180614_1_);
++            IBlockState iblockstate1 = this.field_150939_a.getStateForPlacement(p_180614_2_, p_180614_3_, p_180614_5_, p_180614_6_, p_180614_7_, p_180614_8_, i, p_180614_1_, p_180614_4_);
  
 -            if (p_180614_2_.func_180501_a(p_180614_3_, iblockstate1, 11))
 +            if (placeBlockAt(itemstack, p_180614_1_, p_180614_2_, p_180614_3_, p_180614_5_, p_180614_6_, p_180614_7_, p_180614_8_, iblockstate1))

--- a/patches/minecraft/net/minecraft/item/ItemBlockSpecial.java.patch
+++ b/patches/minecraft/net/minecraft/item/ItemBlockSpecial.java.patch
@@ -5,7 +5,7 @@
          if (!itemstack.func_190926_b() && p_180614_1_.func_175151_a(p_180614_3_, p_180614_5_, itemstack) && p_180614_2_.func_190527_a(this.field_150935_a, p_180614_3_, false, p_180614_5_, (Entity)null))
          {
 -            IBlockState iblockstate1 = this.field_150935_a.func_180642_a(p_180614_2_, p_180614_3_, p_180614_5_, p_180614_6_, p_180614_7_, p_180614_8_, 0, p_180614_1_);
-+            IBlockState iblockstate1 = this.field_150935_a.getStateForPlacement(p_180614_2_, p_180614_3_, p_180614_5_, p_180614_6_, p_180614_7_, p_180614_8_, 0, p_180614_1_);
++            IBlockState iblockstate1 = this.field_150935_a.getStateForPlacement(p_180614_2_, p_180614_3_, p_180614_5_, p_180614_6_, p_180614_7_, p_180614_8_, 0, p_180614_1_, p_180614_4_);
  
              if (!p_180614_2_.func_180501_a(p_180614_3_, iblockstate1, 11))
              {

--- a/patches/minecraft/net/minecraft/item/ItemDye.java.patch
+++ b/patches/minecraft/net/minecraft/item/ItemDye.java.patch
@@ -14,7 +14,7 @@
                      if (p_180614_2_.func_175623_d(p_180614_3_))
                      {
 -                        IBlockState iblockstate1 = Blocks.field_150375_by.func_180642_a(p_180614_2_, p_180614_3_, p_180614_5_, p_180614_6_, p_180614_7_, p_180614_8_, 0, p_180614_1_);
-+                        IBlockState iblockstate1 = Blocks.field_150375_by.getStateForPlacement(p_180614_2_, p_180614_3_, p_180614_5_, p_180614_6_, p_180614_7_, p_180614_8_, 0, p_180614_1_);
++                        IBlockState iblockstate1 = Blocks.field_150375_by.getStateForPlacement(p_180614_2_, p_180614_3_, p_180614_5_, p_180614_6_, p_180614_7_, p_180614_8_, 0, p_180614_1_, p_180614_4_);
                          p_180614_2_.func_180501_a(p_180614_3_, iblockstate1, 10);
  
                          if (!p_180614_1_.field_71075_bZ.field_75098_d)


### PR DESCRIPTION
This also fixes compile error (which prevents MDK from working) with mappings snapshot_20161117.

In 1.10.x this method had ItemStack argument, but it was removed in 1.11 update, which made it exactly the same as the vanilla method. It also causes compile error with latest mappings (the vanilla method now has the same name as forge method). Now most methods have EnumHand instead of ItemStack, so I added that.

Another possibility would be to readd ItemStack argument, as onBlockPlaced (where getStateForPlacement is used) already has that.