### PR TITLE
Add GetCollisionBoxesEvent. Allows manipulation of the collision boxes of blocks for entities. MC1.11 edition.

### DIFF
--- a/patches/minecraft/net/minecraft/world/World.java.patch
+++ b/patches/minecraft/net/minecraft/world/World.java.patch
@@ -204,6 +204,15 @@
              this.func_72964_e(i, j).func_76612_a(p_72838_1_);
              this.field_72996_f.add(p_72838_1_);
              this.func_72923_a(p_72838_1_);
+@@ -1290,7 +1353,7 @@
+                 }
+             }
+         }
+-
++        net.minecraftforge.common.MinecraftForge.EVENT_BUS.post(new net.minecraftforge.event.world.GetCollisionBoxesEvent(this, p_184144_1_, p_184144_2_, list));
+         return list;
+     }
+ 
 @@ -1319,7 +1382,6 @@
          return p_175673_2_.field_70165_t > d0 && p_175673_2_.field_70165_t < d2 && p_175673_2_.field_70161_v > d1 && p_175673_2_.field_70161_v < d3;
      }
@@ -212,6 +221,15 @@
      public void func_72848_b(IWorldEventListener p_72848_1_)
      {
          this.field_73021_x.remove(p_72848_1_);
+@@ -1360,7 +1422,7 @@
+ 
+                                 IBlockState iblockstate = this.func_180495_p(blockpos$pooledmutableblockpos);
+                                 iblockstate.func_185908_a(this, blockpos$pooledmutableblockpos, p_184143_1_, list, (Entity)null);
+-
++                                net.minecraftforge.common.MinecraftForge.EVENT_BUS.post(new net.minecraftforge.event.world.GetCollisionBoxesEvent(this, null, p_184143_1_, list));
+                                 if (!list.isEmpty())
+                                 {
+                                     boolean flag = true;
 @@ -1382,19 +1444,38 @@
  
      public int func_72967_a(float p_72967_1_)

--- a/src/main/java/net/minecraftforge/event/world/GetCollisionBoxesEvent.java
+++ b/src/main/java/net/minecraftforge/event/world/GetCollisionBoxesEvent.java
@@ -1,0 +1,73 @@
+/*
+ * Minecraft Forge
+ * Copyright (c) 2016.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation version 2.1
+ * of the License.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+package net.minecraftforge.event.world;
+
+import net.minecraft.entity.Entity;
+import net.minecraft.util.math.AxisAlignedBB;
+import net.minecraft.world.World;
+import net.minecraftforge.common.MinecraftForge;
+import net.minecraftforge.fml.common.eventhandler.Cancelable;
+
+import javax.annotation.Nullable;
+import java.util.List;
+
+/**
+ * This event is fired during {@link World#collidesWithAnyBlock(AxisAlignedBB)}
+ * and before returning the list in {@link World#getCollisionBoxes(Entity, AxisAlignedBB)}<br>
+ * <br>
+ * {@link #entity} contains the entity passed in the {@link World#getCollisionBoxes(Entity, AxisAlignedBB)}. <b>Can be null.</b> Calls from {@link World#collidesWithAnyBlock(AxisAlignedBB)} will be null.<br>
+ * {@link #aabb} contains the AxisAlignedBB passed in the method. <b>Do not modify this AABB</b><br>
+ * {@link #collisionBoxesList} contains the list of detected collision boxes intersecting with {@link #aabb}.<br>
+ * <br>
+ * This event is not {@link Cancelable}.<br>
+ * <br>
+ * This event does not have a result. {@link HasResult} <br>
+ * <br>
+ * This event is fired on the {@link MinecraftForge#EVENT_BUS}.<br>
+ **/
+public class GetCollisionBoxesEvent extends WorldEvent
+{
+    private final Entity entity;
+    private final AxisAlignedBB aabb;
+    private final List<AxisAlignedBB> collisionBoxesList;
+
+    public GetCollisionBoxesEvent(World world, @Nullable Entity entity, AxisAlignedBB aabb, List<AxisAlignedBB> collisionBoxesList)
+    {
+        super(world);
+        this.entity = entity;
+        this.aabb = aabb;
+        this.collisionBoxesList = collisionBoxesList;
+    }
+
+    public Entity getEntity()
+    {
+        return entity;
+    }
+
+    public AxisAlignedBB getAabb()
+    {
+        return aabb;
+    }
+
+    public List<AxisAlignedBB> getCollisionBoxesList()
+    {
+        return collisionBoxesList;
+    }
+}

--- a/src/main/java/net/minecraftforge/event/world/GetCollisionBoxesEvent.java
+++ b/src/main/java/net/minecraftforge/event/world/GetCollisionBoxesEvent.java
@@ -33,8 +33,8 @@ import java.util.List;
  * and before returning the list in {@link World#getCollisionBoxes(Entity, AxisAlignedBB)}<br>
  * <br>
  * {@link #entity} contains the entity passed in the {@link World#getCollisionBoxes(Entity, AxisAlignedBB)}. <b>Can be null.</b> Calls from {@link World#collidesWithAnyBlock(AxisAlignedBB)} will be null.<br>
- * {@link #aabb} contains the AxisAlignedBB passed in the method. <b>Do not modify this AABB</b><br>
- * {@link #collisionBoxesList} contains the list of detected collision boxes intersecting with {@link #aabb}.<br>
+ * {@link #aabb} contains the AxisAlignedBB passed in the method.<br>
+ * {@link #collisionBoxesList} contains the list of detected collision boxes intersecting with {@link #aabb}. The list can be modified.<br>
  * <br>
  * This event is not {@link Cancelable}.<br>
  * <br>


### PR DESCRIPTION
Slightly different from https://github.com/MinecraftForge/MinecraftForge/pull/3397/files but generally the same idea, for MC1.11