### PR TITLE
[1.11] Register Minecraft mod container in FML loader

### DIFF
--- a/src/main/java/net/minecraftforge/fml/common/Loader.java
+++ b/src/main/java/net/minecraftforge/fml/common/Loader.java
@@ -348,6 +348,7 @@ public class Loader
     {
         injectedContainers.addAll(additionalContainers);
         FMLLog.fine("Building injected Mod Containers %s", injectedContainers);
+        mods.add(minecraft);
         // Add in the MCP mod container
         mods.add(new InjectedModContainer(mcp,new File("minecraft.jar")));
         for (String cont : injectedContainers)

--- a/src/main/java/net/minecraftforge/fml/common/MinecraftDummyContainer.java
+++ b/src/main/java/net/minecraftforge/fml/common/MinecraftDummyContainer.java
@@ -19,8 +19,10 @@
 
 package net.minecraftforge.fml.common;
 
+import java.io.File;
 import java.security.cert.Certificate;
 
+import com.google.common.eventbus.EventBus;
 import net.minecraftforge.fml.common.versioning.VersionParser;
 import net.minecraftforge.fml.common.versioning.VersionRange;
 import net.minecraftforge.fml.relauncher.FMLLaunchHandler;
@@ -33,12 +35,29 @@ public class MinecraftDummyContainer extends DummyModContainer
     public MinecraftDummyContainer(String actualMCVersion)
     {
         super(new ModMetadata());
-        getMetadata().modId = "Minecraft";
+        getMetadata().modId = "minecraft";
         getMetadata().name = "Minecraft";
         getMetadata().version = actualMCVersion;
         staticRange = VersionParser.parseRange("["+actualMCVersion+"]");
     }
 
+    @Override
+    public boolean isImmutable()
+    {
+        return true;
+    }
+
+    @Override
+    public File getSource()
+    {
+        return new File("minecraft.jar");
+    }
+
+    @Override
+    public boolean registerBus(EventBus bus, LoadController controller)
+    {
+        return true;
+    }
 
     public VersionRange getStaticVersionRange()
     {


### PR DESCRIPTION
Right now the Minecraft mod container is kept separate in the FML loader and not registered as mod in the mod list. Adding it to the mod list allows other mods to reference it by its mod ID (`minecraft`) instead of just using `Loader.getMinecraftModContainer()`.