### PR TITLE
ItemStack nullability fixes

### DIFF
--- a/src/main/java/net/minecraftforge/items/VanillaHopperItemHandler.java
+++ b/src/main/java/net/minecraftforge/items/VanillaHopperItemHandler.java
@@ -40,7 +40,7 @@ public class VanillaHopperItemHandler extends InvWrapper
     public ItemStack insertItem(int slot, @Nonnull ItemStack stack, boolean simulate)
     {
         if (stack.func_190926_b())
-            return null;
+            return ItemStack.field_190927_a;
 //        if (simulate || !hopper.mayTransfer())
 //            return super.insertItem(slot, stack, simulate);
 

--- a/src/main/java/net/minecraftforge/items/VanillaInventoryCodeHooks.java
+++ b/src/main/java/net/minecraftforge/items/VanillaInventoryCodeHooks.java
@@ -120,7 +120,7 @@ public class VanillaInventoryCodeHooks
         for (int i = 0; i < hopper.getSizeInventory(); i++)
         {
             ItemStack stackInSlot = hopper.getStackInSlot(i);
-            if (stackInSlot.func_190926_b())
+            if (!stackInSlot.func_190926_b())
             {
                 ItemStack insert = stackInSlot.copy();
                 insert.func_190920_e(1);


### PR DESCRIPTION
Fix a method return in `VanillaHopperItemHandler` that I missed in #3392 