### PR TITLE
[1.11] Cleanup some null checks and remove deprecated methods in Item and Block

### DIFF
--- a/patches/minecraft/net/minecraft/block/Block.java.patch
+++ b/patches/minecraft/net/minecraft/block/Block.java.patch
@@ -16,17 +16,7 @@
      public static final AxisAlignedBB field_185505_j = new AxisAlignedBB(0.0D, 0.0D, 0.0D, 1.0D, 1.0D, 1.0D);
      @Nullable
      public static final AxisAlignedBB field_185506_k = null;
-@@ -91,7 +92,8 @@
- 
-     public static Block func_149729_e(int p_149729_0_)
-     {
--        return (Block)field_149771_c.func_148754_a(p_149729_0_);
-+        Block ret = (Block)field_149771_c.func_148754_a(p_149729_0_);
-+        return ret == null ? net.minecraft.init.Blocks.field_150350_a : ret;
-     }
- 
-     public static IBlockState func_176220_d(int p_176220_0_)
-@@ -307,7 +309,7 @@
+@@ -307,7 +308,7 @@
  
      public boolean func_176200_f(IBlockAccess p_176200_1_, BlockPos p_176200_2_)
      {
@@ -35,7 +25,7 @@
      }
  
      public Block func_149711_c(float p_149711_1_)
-@@ -345,9 +347,10 @@
+@@ -345,9 +346,10 @@
          return this.field_149789_z;
      }
  
@@ -47,7 +37,7 @@
      }
  
      @Deprecated
-@@ -360,13 +363,13 @@
+@@ -360,13 +362,13 @@
      @SideOnly(Side.CLIENT)
      public int func_185484_c(IBlockState p_185484_1_, IBlockAccess p_185484_2_, BlockPos p_185484_3_)
      {
@@ -63,7 +53,7 @@
          }
          else
          {
-@@ -430,7 +433,7 @@
+@@ -430,7 +432,7 @@
                  }
          }
  
@@ -72,7 +62,7 @@
      }
  
      public boolean func_176212_b(IBlockAccess p_176212_1_, BlockPos p_176212_2_, EnumFacing p_176212_3_)
-@@ -521,6 +524,10 @@
+@@ -521,6 +523,10 @@
  
      public void func_180663_b(World p_180663_1_, BlockPos p_180663_2_, IBlockState p_180663_3_)
      {
@@ -83,7 +73,7 @@
      }
  
      public int func_149745_a(Random p_149745_1_)
-@@ -536,8 +543,7 @@
+@@ -536,8 +542,7 @@
      @Deprecated
      public float func_180647_a(IBlockState p_180647_1_, EntityPlayer p_180647_2_, World p_180647_3_, BlockPos p_180647_4_)
      {
@@ -93,7 +83,7 @@
      }
  
      public final void func_176226_b(World p_176226_1_, BlockPos p_176226_2_, IBlockState p_176226_3_, int p_176226_4_)
-@@ -547,20 +553,16 @@
+@@ -547,20 +552,16 @@
  
      public void func_180653_a(World p_180653_1_, BlockPos p_180653_2_, IBlockState p_180653_3_, float p_180653_4_, int p_180653_5_)
      {
@@ -119,7 +109,7 @@
                  }
              }
          }
-@@ -568,8 +570,13 @@
+@@ -568,8 +569,13 @@
  
      public static void func_180635_a(World p_180635_0_, BlockPos p_180635_1_, ItemStack p_180635_2_)
      {
@@ -134,7 +124,7 @@
              float f = 0.5F;
              double d0 = (double)(p_180635_0_.field_73012_v.nextFloat() * 0.5F) + 0.25D;
              double d1 = (double)(p_180635_0_.field_73012_v.nextFloat() * 0.5F) + 0.25D;
-@@ -636,7 +643,7 @@
+@@ -636,7 +642,7 @@
  
      public boolean func_176196_c(World p_176196_1_, BlockPos p_176196_2_)
      {
@@ -143,7 +133,7 @@
      }
  
      public boolean func_180639_a(World p_180639_1_, BlockPos p_180639_2_, IBlockState p_180639_3_, EntityPlayer p_180639_4_, EnumHand p_180639_5_, EnumFacing p_180639_6_, float p_180639_7_, float p_180639_8_, float p_180639_9_)
-@@ -648,6 +655,8 @@
+@@ -648,6 +654,8 @@
      {
      }
  
@@ -152,7 +142,7 @@
      public IBlockState func_180642_a(World p_180642_1_, BlockPos p_180642_2_, EnumFacing p_180642_3_, float p_180642_4_, float p_180642_5_, float p_180642_6_, int p_180642_7_, EntityLivingBase p_180642_8_)
      {
          return this.func_176203_a(p_180642_7_);
-@@ -689,21 +698,35 @@
+@@ -689,21 +697,35 @@
          p_180657_2_.func_71029_a(StatList.func_188055_a(this));
          p_180657_2_.func_71020_j(0.005F);
  
@@ -163,7 +153,7 @@
              ItemStack itemstack = this.func_180643_i(p_180657_4_);
 -            func_180635_a(p_180657_1_, p_180657_3_, itemstack);
 +
-+            if (itemstack != null)
++            if (!itemstack.func_190926_b())
 +            {
 +                items.add(itemstack);
 +            }
@@ -191,16 +181,15 @@
      }
  
      protected ItemStack func_180643_i(IBlockState p_180643_1_)
-@@ -789,6 +812,8 @@
+@@ -789,6 +811,7 @@
          p_176216_2_.field_70181_x = 0.0D;
      }
  
-+    @Nullable
 +    @Deprecated // Forge: Use more sensitive version below: getPickBlock
      public ItemStack func_185473_a(World p_185473_1_, BlockPos p_185473_2_, IBlockState p_185473_3_)
      {
          return new ItemStack(Item.func_150898_a(this), 1, this.func_180651_a(p_185473_3_));
-@@ -893,6 +918,7 @@
+@@ -893,6 +916,7 @@
          }
      }
  
@@ -208,7 +197,7 @@
      public SoundType func_185467_w()
      {
          return this.field_149762_H;
-@@ -908,6 +934,1176 @@
+@@ -908,6 +932,1153 @@
      {
      }
  
@@ -359,7 +348,7 @@
 +     * useful for creating pure logic-blocks that will be invisible
 +     * to the player and otherwise interact as air would.
 +     *
-+     * @param sata The current state
++     * @param state The current state
 +     * @param world The current world
 +     * @param pos Block position in world
 +     * @return True if the block considered air
@@ -372,8 +361,8 @@
 +    /**
 +     * Determines if the player can harvest this block, obtaining it's drops when the block is destroyed.
 +     *
-+     * @param player The player damaging the block, may be null
-+     * @param meta The block's current metadata
++     * @param player The player damaging the block
++     * @param pos The block's current position
 +     * @return True to spawn the drops
 +     */
 +    public boolean canHarvestBlock(IBlockAccess world, BlockPos pos, EntityPlayer player)
@@ -455,7 +444,6 @@
 +     *
 +     * @param world The current world
 +     * @param pos Block position in world
-+     * @param metadata The blocks current metadata
 +     * @param side The face that the fire is coming from
 +     * @return True if this block sustains fire, meaning it will never go out.
 +     */
@@ -493,9 +481,10 @@
 +     * Return the same thing you would from that function.
 +     * This will fall back to ITileEntityProvider.createNewTileEntity(World) if this block is a ITileEntityProvider
 +     *
-+     * @param metadata The Metadata of the current block
++     * @param state The state of the current block
 +     * @return A instance of a class extending TileEntity
 +     */
++    @Nullable
 +    public TileEntity createTileEntity(World world, IBlockState state)
 +    {
 +        if (isTileProvider)
@@ -538,7 +527,7 @@
 +        for(int i = 0; i < count; i++)
 +        {
 +            Item item = this.func_180660_a(state, rand, fortune);
-+            if (item != null)
++            if (item != Items.field_190931_a)
 +            {
 +                ret.add(new ItemStack(item, 1, this.func_180651_a(state)));
 +            }
@@ -589,7 +578,7 @@
 +     * @param player The player or camera entity, null in some cases.
 +     * @return True to treat this as a bed
 +     */
-+    public boolean isBed(IBlockState state, IBlockAccess world, BlockPos pos, Entity player)
++    public boolean isBed(IBlockState state, IBlockAccess world, BlockPos pos, @Nullable Entity player)
 +    {
 +        return this == net.minecraft.init.Blocks.field_150324_C;
 +    }
@@ -604,7 +593,8 @@
 +     * @param player The player or camera entity, null in some cases.
 +     * @return The spawn position
 +     */
-+    public BlockPos getBedSpawnPosition(IBlockState state, IBlockAccess world, BlockPos pos, EntityPlayer player)
++    @Nullable
++    public BlockPos getBedSpawnPosition(IBlockState state, IBlockAccess world, BlockPos pos, @Nullable EntityPlayer player)
 +    {
 +        if (world instanceof World)
 +            return BlockBed.func_176468_a((World)world, pos, 0);
@@ -750,7 +740,7 @@
 +     *
 +     * @param world The current world
 +     * @param pos Block position in world
-+     * @param Explosion The explosion instance affecting the block
++     * @param explosion The explosion instance affecting the block
 +     */
 +    public void onBlockExploded(World world, BlockPos pos, Explosion explosion)
 +    {
@@ -768,7 +758,7 @@
 +     * @param side The side that is trying to make the connection, CAN BE NULL
 +     * @return True to make the connection
 +     */
-+    public boolean canConnectRedstone(IBlockState state, IBlockAccess world, BlockPos pos, EnumFacing side)
++    public boolean canConnectRedstone(IBlockState state, IBlockAccess world, BlockPos pos, @Nullable EnumFacing side)
 +    {
 +        return state.func_185897_m() && side != null;
 +    }
@@ -794,24 +784,11 @@
 +        }
 +    }
 +
-+    /** Dont think this exists in 1.8 anymore
-+    /**
-+     * Determines if this block should render in this pass.
-+     *
-+     * @param pass The pass in question
-+     * @return True to render
-+     * /
-+    public boolean canRenderInPass(int pass)
-+    {
-+        return pass == func_149701_w();
-+    }
-+    */
-+
 +    /**
 +     * Called when a user uses the creative pick block button on this block
 +     *
 +     * @param target The full target the player is looking at
-+     * @return A ItemStack to add to the player's inventory, Null if nothing should be added.
++     * @return A ItemStack to add to the player's inventory, empty itemstack if nothing should be added.
 +     */
 +    public ItemStack getPickBlock(IBlockState state, RayTraceResult target, World world, BlockPos pos, EntityPlayer player)
 +    {
@@ -1076,6 +1053,7 @@
 +     * @param pos Block position in world
 +     * @return An array of valid axes to rotate around, or null for none or unknown
 +     */
++    @Nullable
 +    public EnumFacing[] getValidRotations(World world, BlockPos pos)
 +    {
 +        IBlockState state = world.func_180495_p(pos);
@@ -1170,7 +1148,6 @@
 +     *
 +     * @param world The current world
 +     * @param pos Block position in world
-+     * @param side The side to check
 +     * @return true To be notified of changes
 +     */
 +    public boolean getWeakChanges(IBlockAccess world, BlockPos pos)
@@ -1232,7 +1209,6 @@
 +     * Queries the harvest level of this item stack for the specified tool class,
 +     * Returns -1 if this tool is not of the specified type
 +     *
-+     * @param stack This item stack instance
 +     * @return Harvest level, or -1 if not the specified tool type.
 +     */
 +    public int getHarvestLevel(IBlockState state)
@@ -1272,10 +1248,11 @@
 +      * @param testingHead when true, its testing the entities head for vision, breathing ect... otherwise its testing the body, for swimming and movement adjustment.
 +      * @return null for default behavior, true if the entity is within the material, false if it was not.
 +      */
-+     public Boolean isEntityInsideMaterial(IBlockAccess world, BlockPos blockpos, IBlockState iblockstate, Entity entity, double yToTest, Material materialIn, boolean testingHead)
-+     {
-+         return null;
-+     }
++    @Nullable
++    public Boolean isEntityInsideMaterial(IBlockAccess world, BlockPos blockpos, IBlockState iblockstate, Entity entity, double yToTest, Material materialIn, boolean testingHead)
++    {
++        return null;
++    }
 +
 +     /**
 +      * Called when boats or fishing hooks are inside the block to check if they are inside
@@ -1287,6 +1264,7 @@
 +      * @param materialIn to check for.
 +      * @return null for default behavior, true if the box is within the material, false if it was not.
 +      */
++     @Nullable
 +     public Boolean isAABBInsideMaterial(World world, BlockPos pos, AxisAlignedBB boundingBox, Material materialIn)
 +     {
 +         return null;
@@ -1294,23 +1272,11 @@
 +
 +     /**
 +     * Queries if this block should render in a given layer.
-+     * ISmartBlockModel can use {@link MinecraftForgeClient#getRenderLayer()} to alter their model based on layer.
-+     *
-+     * @deprecated New method with state sensitivity: {@link #canRenderInLayer(IBlockState, BlockRenderLayer)}
-+     */
-+    @Deprecated
-+    public boolean canRenderInLayer(BlockRenderLayer layer)
-+    {
-+        return func_180664_k() == layer;
-+    }
-+
-+     /**
-+     * Queries if this block should render in a given layer.
-+     * ISmartBlockModel can use {@link MinecraftForgeClient#getRenderLayer()} to alter their model based on layer.
++     * ISmartBlockModel can use {@link net.minecraftforge.client.MinecraftForgeClient#getRenderLayer()} to alter their model based on layer.
 +     */
 +    public boolean canRenderInLayer(IBlockState state, BlockRenderLayer layer)
 +    {
-+        return canRenderInLayer(layer);
++        return func_180664_k() == layer;
 +    }
 +    // For Internal use only to capture droped items inside getDrops
 +    protected static ThreadLocal<Boolean> captureDrops = new ThreadLocal<Boolean>()
@@ -1327,7 +1293,7 @@
 +        {
 +            captureDrops.set(true);
 +            capturedDrops.get().clear();
-+            return null;
++            return java.util.Collections.emptyList();
 +        }
 +        else
 +        {
@@ -1385,7 +1351,7 @@
      public static void func_149671_p()
      {
          func_176215_a(0, field_176230_a, (new BlockAir()).func_149663_c("air"));
-@@ -1201,14 +2397,7 @@
+@@ -1201,14 +2372,7 @@
              }
              else
              {

--- a/patches/minecraft/net/minecraft/block/BlockLeaves.java.patch
+++ b/patches/minecraft/net/minecraft/block/BlockLeaves.java.patch
@@ -75,7 +75,7 @@
      }
  
      protected void func_176234_a(World p_176234_1_, BlockPos p_176234_2_, IBlockState p_176234_3_, int p_176234_4_)
-@@ -274,6 +241,49 @@
+@@ -274,6 +241,53 @@
  
      public abstract BlockPlanks.EnumType func_176233_b(int p_176233_1_);
  
@@ -105,7 +105,11 @@
 +        }
 +
 +        if (rand.nextInt(chance) == 0)
-+            ret.add(new ItemStack(func_180660_a(state, rand, fortune), 1, func_180651_a(state)));
++        {
++            ItemStack drop = new ItemStack(func_180660_a(state, rand, fortune), 1, func_180651_a(state));
++            if (!drop.func_190926_b())
++                ret.add(drop);
++        }
 +
 +        chance = 200;
 +        if (fortune > 0)

--- a/patches/minecraft/net/minecraft/client/gui/inventory/GuiContainer.java.patch
+++ b/patches/minecraft/net/minecraft/client/gui/inventory/GuiContainer.java.patch
@@ -127,7 +127,7 @@
                  {
                      this.func_184098_a(this.field_147006_u, this.field_147006_u.field_75222_d, i, ClickType.SWAP);
                      return true;
-@@ -689,4 +693,16 @@
+@@ -689,4 +693,17 @@
              this.field_146297_k.field_71439_g.func_71053_j();
          }
      }
@@ -137,6 +137,7 @@
 +    /**
 +     * Returns the slot that is currently displayed under the mouse.
 +     */
++    @javax.annotation.Nullable
 +    public Slot getSlotUnderMouse()
 +    {
 +        return this.field_147006_u;

--- a/patches/minecraft/net/minecraft/client/renderer/block/model/ItemOverrideList.java.patch
+++ b/patches/minecraft/net/minecraft/client/renderer/block/model/ItemOverrideList.java.patch
@@ -8,15 +8,14 @@
      public ResourceLocation func_188021_a(ItemStack p_188021_1_, @Nullable World p_188021_2_, @Nullable EntityLivingBase p_188021_3_)
      {
          if (!this.field_188023_b.isEmpty())
-@@ -44,4 +45,23 @@
+@@ -44,4 +45,22 @@
  
          return null;
      }
 +
-+    public IBakedModel handleItemState(IBakedModel originalModel, ItemStack stack, World world, EntityLivingBase entity)
++    public IBakedModel handleItemState(IBakedModel originalModel, ItemStack stack, @Nullable World world, @Nullable EntityLivingBase entity)
 +    {
-+        net.minecraft.item.Item item = stack.func_77973_b();
-+        if (item != null && item.func_185040_i())
++        if (!stack.func_190926_b() && stack.func_77973_b().func_185040_i())
 +        {
 +            ResourceLocation location = func_188021_a(stack, world, entity);
 +            if (location != null)

--- a/patches/minecraft/net/minecraft/item/Item.java.patch
+++ b/patches/minecraft/net/minecraft/item/Item.java.patch
@@ -60,7 +60,7 @@
          return p_77621_1_.func_147447_a(vec3d, vec3d1, p_77621_3_, !p_77621_3_, false);
      }
  
-@@ -433,11 +440,605 @@
+@@ -433,11 +440,600 @@
          return false;
      }
  
@@ -148,6 +148,7 @@
 +     * @param stack The stack to send the NBT tag for
 +     * @return The NBT tag
 +     */
++    @Nullable
 +    public NBTTagCompound getNBTShareTag(ItemStack stack)
 +    {
 +        return stack.func_77978_p();
@@ -255,6 +256,7 @@
 +     * @param itemstack The current item stack
 +     * @return A new Entity object to spawn or null
 +     */
++    @Nullable
 +    public Entity createEntity(World world, Entity location, ItemStack itemstack)
 +    {
 +        return null;
@@ -354,6 +356,7 @@
 +     * @param type The subtype, can be null or "overlay"
 +     * @return Path of texture to bind, or null to use default
 +     */
++    @Nullable
 +    public String getArmorTexture(ItemStack stack, Entity entity, EntityEquipmentSlot slot, String type)
 +    {
 +        return null;
@@ -383,6 +386,7 @@
 +     * @return  A ModelBiped to render instead of the default
 +     */
 +    @SideOnly(Side.CLIENT)
++    @Nullable
 +    public net.minecraft.client.model.ModelBiped getArmorModel(EntityLivingBase entityLiving, ItemStack itemStack, EntityEquipmentSlot armorSlot, net.minecraft.client.model.ModelBiped _default)
 +    {
 +        return null;
@@ -554,16 +558,6 @@
 +    }
 +
 +    /**
-+     * Deprecated, Use the position aware variant instead
-+     */
-+    @Deprecated
-+    public int getHarvestLevel(ItemStack stack, String toolClass)
-+    {
-+        Integer ret = toolClasses.get(toolClass);
-+        return ret == null ? -1 : ret;
-+    }
-+
-+    /**
 +     * Queries the harvest level of this item stack for the specified tool class,
 +     * Returns -1 if this tool is not of the specified type
 +     *
@@ -575,7 +569,8 @@
 +     */
 +    public int getHarvestLevel(ItemStack stack, String toolClass, @Nullable EntityPlayer player, @Nullable IBlockState blockState)
 +    {
-+        return getHarvestLevel(stack, toolClass);
++        Integer ret = toolClasses.get(toolClass);
++        return ret == null ? -1 : ret;
 +    }
 +
 +    /**
@@ -666,18 +661,18 @@
      public static void func_150900_l()
      {
          func_179214_a(Blocks.field_150350_a, new ItemAir(Blocks.field_150350_a));
-@@ -972,6 +1573,10 @@
+@@ -972,6 +1568,10 @@
          private final float field_78011_i;
          private final int field_78008_j;
  
 +        //Added by forge for custom Tool materials.
-+        @Deprecated public Item customCraftingMaterial = null; // Remote in 1.8.1
++        @Nullable
 +        private ItemStack repairMaterial = null;
 +
          private ToolMaterial(int p_i1874_3_, int p_i1874_4_, float p_i1874_5_, float p_i1874_6_, int p_i1874_7_)
          {
              this.field_78001_f = p_i1874_3_;
-@@ -1006,9 +1611,36 @@
+@@ -1006,9 +1606,34 @@
              return this.field_78008_j;
          }
  
@@ -692,16 +687,15 @@
 +                case GOLD:    return Items.field_151043_k;
 +                case IRON:    return Items.field_151042_j;
 +                case DIAMOND: return Items.field_151045_i;
-+                default:      return customCraftingMaterial;
++                default:      return Items.field_190931_a;
 +            }
          }
 +
 +        public ToolMaterial setRepairItem(ItemStack stack)
 +        {
-+            if (this.repairMaterial != null || customCraftingMaterial != null) throw new RuntimeException("Can not change already set repair material");
++            if (this.repairMaterial != null) throw new RuntimeException("Repair material has already been set");
 +            if (this == WOOD || this == STONE || this == GOLD || this == IRON || this == DIAMOND) throw new RuntimeException("Can not change vanilla tool repair materials");
 +            this.repairMaterial = stack;
-+            this.customCraftingMaterial = stack.func_77973_b();
 +            return this;
 +        }
 +
@@ -709,7 +703,6 @@
 +        {
 +            if (repairMaterial != null) return repairMaterial;
 +            Item ret = this.func_150995_f();
-+            if (ret == null) return null;
 +            repairMaterial = new ItemStack(ret, 1, net.minecraftforge.oredict.OreDictionary.WILDCARD_VALUE);
 +            return repairMaterial;
 +        }

--- a/patches/minecraft/net/minecraft/item/ItemSword.java.patch
+++ b/patches/minecraft/net/minecraft/item/ItemSword.java.patch
@@ -6,7 +6,7 @@
      {
 -        return this.field_150933_b.func_150995_f() == p_82789_2_.func_77973_b() ? true : super.func_82789_a(p_82789_1_, p_82789_2_);
 +        ItemStack mat = this.field_150933_b.getRepairItemStack();
-+        if (mat != null && net.minecraftforge.oredict.OreDictionary.itemMatches(mat, p_82789_2_, false)) return true;
++        if (!mat.func_190926_b() && net.minecraftforge.oredict.OreDictionary.itemMatches(mat, p_82789_2_, false)) return true;
 +        return super.func_82789_a(p_82789_1_, p_82789_2_);
      }
  

--- a/patches/minecraft/net/minecraft/item/ItemTool.java.patch
+++ b/patches/minecraft/net/minecraft/item/ItemTool.java.patch
@@ -37,23 +37,24 @@
      {
 -        return this.field_77862_b.func_150995_f() == p_82789_2_.func_77973_b() ? true : super.func_82789_a(p_82789_1_, p_82789_2_);
 +        ItemStack mat = this.field_77862_b.getRepairItemStack();
-+        if (mat != null && net.minecraftforge.oredict.OreDictionary.itemMatches(mat, p_82789_2_, false)) return true;
++        if (!mat.func_190926_b() && net.minecraftforge.oredict.OreDictionary.itemMatches(mat, p_82789_2_, false)) return true;
 +        return super.func_82789_a(p_82789_1_, p_82789_2_);
      }
  
      public Multimap<String, AttributeModifier> func_111205_h(EntityEquipmentSlot p_111205_1_)
-@@ -99,4 +118,27 @@
+@@ -99,4 +118,28 @@
  
          return multimap;
      }
 +
 +    /*===================================== FORGE START =================================*/
++    @javax.annotation.Nullable
 +    private String toolClass;
 +    @Override
-+    public int getHarvestLevel(ItemStack stack, String toolClass)
++    public int getHarvestLevel(ItemStack stack, String toolClass, @javax.annotation.Nullable net.minecraft.entity.player.EntityPlayer player, @javax.annotation.Nullable IBlockState blockState)
 +    {
-+        int level = super.getHarvestLevel(stack, toolClass);
-+        if (level == -1 && toolClass != null && toolClass.equals(this.toolClass))
++        int level = super.getHarvestLevel(stack, toolClass,  player, blockState);
++        if (level == -1 && toolClass.equals(this.toolClass))
 +        {
 +            return this.field_77862_b.func_77996_d();
 +        }

--- a/src/main/java/net/minecraftforge/client/model/ModelDynBucket.java
+++ b/src/main/java/net/minecraftforge/client/model/ModelDynBucket.java
@@ -23,6 +23,8 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import javax.vecmath.Matrix4f;
 import javax.vecmath.Quat4f;
 
@@ -253,7 +255,8 @@ public final class ModelDynBucket implements IModel, IModelCustomData, IRetextur
         }
 
         @Override
-        public IBakedModel handleItemState(IBakedModel originalModel, ItemStack stack, World world, EntityLivingBase entity)
+        @Nonnull
+        public IBakedModel handleItemState(@Nonnull IBakedModel originalModel, @Nonnull ItemStack stack, @Nullable World world, @Nullable EntityLivingBase entity)
         {
             FluidStack fluidStack = FluidUtil.getFluidContained(stack);
 

--- a/src/main/java/net/minecraftforge/client/model/MultiModel.java
+++ b/src/main/java/net/minecraftforge/client/model/MultiModel.java
@@ -26,6 +26,8 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
 
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import javax.vecmath.Matrix4f;
 
 import net.minecraft.block.state.IBlockState;
@@ -72,7 +74,8 @@ public final class MultiModel implements IModel
         private final ItemOverrideList overrides = new ItemOverrideList(Lists.<ItemOverride>newArrayList())
         {
             @Override
-            public IBakedModel handleItemState(IBakedModel originalModel, ItemStack stack, World world, EntityLivingBase entity)
+            @Nonnull
+            public IBakedModel handleItemState(@Nonnull IBakedModel originalModel, @Nonnull ItemStack stack, @Nullable World world, @Nullable EntityLivingBase entity)
             {
                 if(originalModel != Baked.this)
                 {

--- a/src/main/java/net/minecraftforge/client/model/animation/AnimationItemOverrideList.java
+++ b/src/main/java/net/minecraftforge/client/model/animation/AnimationItemOverrideList.java
@@ -39,6 +39,9 @@ import net.minecraftforge.common.model.animation.IAnimationStateMachine;
 
 import com.google.common.base.Function;
 
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
 public final class AnimationItemOverrideList extends ItemOverrideList
 {
     private final IModel model;
@@ -60,14 +63,15 @@ public final class AnimationItemOverrideList extends ItemOverrideList
         this.bakedTextureGetter = bakedTextureGetter;
     }
 
+    @Nonnull
     @Override
-    public IBakedModel handleItemState(IBakedModel originalModel, ItemStack stack, World world, EntityLivingBase entity)
+    public IBakedModel handleItemState(@Nonnull IBakedModel originalModel, @Nonnull ItemStack stack, @Nullable World world, @Nullable EntityLivingBase entity)
     {
         if(stack.hasCapability(net.minecraftforge.common.model.animation.CapabilityAnimation.ANIMATION_CAPABILITY, null))
         {
             // TODO: caching?
             IAnimationStateMachine asm = stack.getCapability(CapabilityAnimation.ANIMATION_CAPABILITY, null);
-            if(world == null)
+            if(world == null && entity != null)
             {
                 world = entity.worldObj;
             }

--- a/src/main/java/net/minecraftforge/common/ForgeHooks.java
+++ b/src/main/java/net/minecraftforge/common/ForgeHooks.java
@@ -156,7 +156,7 @@ public class ForgeHooks
     private static boolean toolInit = false;
     //static HashSet<List> toolEffectiveness = new HashSet<List>();
 
-    public static boolean canHarvestBlock(Block block, EntityPlayer player, IBlockAccess world, BlockPos pos)
+    public static boolean canHarvestBlock(@Nonnull Block block, @Nonnull EntityPlayer player, @Nonnull IBlockAccess world, @Nonnull BlockPos pos)
     {
         IBlockState state = world.getBlockState(pos);
         state = state.getBlock().getActualState(state, world, pos);
@@ -165,7 +165,7 @@ public class ForgeHooks
             return true;
         }
 
-        ItemStack stack = player.inventory.getCurrentItem();
+        ItemStack stack = player.getHeldItemMainhand();
         String tool = block.getHarvestTool(state);
         if (stack.func_190926_b() || tool == null)
         {
@@ -190,7 +190,7 @@ public class ForgeHooks
         return stack.getItem().getHarvestLevel(stack, tool, null, null) >= state.getBlock().getHarvestLevel(state);
     }
 
-    public static float blockStrength(IBlockState state, EntityPlayer player, World world, BlockPos pos)
+    public static float blockStrength(@Nonnull IBlockState state, @Nonnull EntityPlayer player, @Nonnull World world, @Nonnull BlockPos pos)
     {
         float hardness = state.getBlockHardness(world, pos);
         if (hardness < 0.0F)

--- a/src/main/java/net/minecraftforge/common/ForgeInternalHandler.java
+++ b/src/main/java/net/minecraftforge/common/ForgeInternalHandler.java
@@ -45,25 +45,7 @@ public class ForgeInternalHandler
         if (entity.getClass().equals(EntityItem.class))
         {
             ItemStack stack = ((EntityItem)entity).getEntityItem();
-
-            if (stack == null)
-            {
-                //entity.setDead();
-                //event.setCanceled(true);
-                return;
-            }
-
             Item item = stack.getItem();
-            if (item == null)
-            {
-                FMLLog.warning("Attempted to add a EntityItem to the world with a invalid item at " +
-                    "(%2.2f,  %2.2f, %2.2f), this is most likely a config issue between you and the server. Please double check your configs",
-                    entity.posX, entity.posY, entity.posZ);
-                entity.setDead();
-                event.setCanceled(true);
-                return;
-            }
-
             if (item.hasCustomEntity(stack))
             {
                 Entity newEntity = item.createEntity(event.getWorld(), entity, stack);

--- a/src/main/java/net/minecraftforge/fluids/BlockFluidBase.java
+++ b/src/main/java/net/minecraftforge/fluids/BlockFluidBase.java
@@ -31,6 +31,7 @@ import net.minecraft.block.state.BlockStateContainer;
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.entity.Entity;
 import net.minecraft.init.Blocks;
+import net.minecraft.init.Items;
 import net.minecraft.item.Item;
 import net.minecraft.util.math.AxisAlignedBB;
 import net.minecraft.util.math.BlockPos;
@@ -48,6 +49,8 @@ import net.minecraftforge.fml.relauncher.SideOnly;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Maps;
+
+import javax.annotation.Nonnull;
 
 /**
  * This is a base implementation for Fluid blocks.
@@ -161,17 +164,20 @@ public abstract class BlockFluidBase extends Block implements IFluidBlock
     }
 
     @Override
+    @Nonnull
     protected BlockStateContainer createBlockState()
     {
         return new ExtendedBlockState(this, new IProperty[] { LEVEL }, FLUID_RENDER_PROPS.toArray(new IUnlistedProperty<?>[0]));
     }
 
     @Override
-    public int getMetaFromState(IBlockState state)
+    public int getMetaFromState(@Nonnull IBlockState state)
     {
         return state.getValue(LEVEL);
     }
+    @Override
     @Deprecated
+    @Nonnull
     public IBlockState getStateFromMeta(int meta)
     {
         return this.getDefaultState().withProperty(LEVEL, meta);
@@ -313,19 +319,19 @@ public abstract class BlockFluidBase extends Block implements IFluidBlock
     public abstract int getQuantaValue(IBlockAccess world, BlockPos pos);
 
     @Override
-    public abstract boolean canCollideCheck(IBlockState state, boolean fullHit);
+    public abstract boolean canCollideCheck(@Nonnull IBlockState state, boolean fullHit);
 
     public abstract int getMaxRenderHeightMeta();
 
     /* BLOCK FUNCTIONS */
     @Override
-    public void onBlockAdded(World world, BlockPos pos, IBlockState state)
+    public void onBlockAdded(@Nonnull World world, @Nonnull BlockPos pos, @Nonnull IBlockState state)
     {
         world.scheduleUpdate(pos, this, tickRate);
     }
 
     @Override
-    public void neighborChanged(IBlockState state, World world, BlockPos pos, Block neighborBlock, BlockPos neighbourPos)
+    public void neighborChanged(@Nonnull IBlockState state, @Nonnull World world, @Nonnull BlockPos pos, @Nonnull Block neighborBlock, @Nonnull BlockPos neighbourPos)
     {
         world.scheduleUpdate(pos, this, tickRate);
     }
@@ -338,31 +344,33 @@ public abstract class BlockFluidBase extends Block implements IFluidBlock
     }
 
     @Override
-    public boolean isPassable(IBlockAccess world, BlockPos pos)
+    public boolean isPassable(@Nonnull IBlockAccess world, @Nonnull BlockPos pos)
     {
         return true;
     }
 
     @Override
-    public Item getItemDropped(IBlockState state, Random rand, int fortune)
+    @Nonnull
+    public Item getItemDropped(@Nonnull IBlockState state, @Nonnull Random rand, int fortune)
     {
-        return null;
+        return Items.field_190931_a;
     }
 
     @Override
-    public int quantityDropped(Random par1Random)
+    public int quantityDropped(@Nonnull Random par1Random)
     {
         return 0;
     }
 
     @Override
-    public int tickRate(World world)
+    public int tickRate(@Nonnull World world)
     {
         return tickRate;
     }
 
     @Override
-    public Vec3d modifyAcceleration(World world, BlockPos pos, Entity entity, Vec3d vec)
+    @Nonnull
+    public Vec3d modifyAcceleration(@Nonnull World world, @Nonnull BlockPos pos, @Nonnull Entity entity, @Nonnull Vec3d vec)
     {
         if (densityDir > 0) return vec;
         Vec3d vec_flow = this.getFlowVector(world, pos);
@@ -373,7 +381,7 @@ public abstract class BlockFluidBase extends Block implements IFluidBlock
     }
 
     @Override
-    public int getLightValue(IBlockState state, IBlockAccess world, BlockPos pos)
+    public int getLightValue(@Nonnull IBlockState state, @Nonnull IBlockAccess world, @Nonnull BlockPos pos)
     {
         if (maxScaledLight == 0)
         {
@@ -384,13 +392,13 @@ public abstract class BlockFluidBase extends Block implements IFluidBlock
     }
 
     @Override
-    public boolean isOpaqueCube(IBlockState state)
+    public boolean isOpaqueCube(@Nonnull IBlockState state)
     {
         return false;
     }
 
     @Override
-    public boolean isFullCube(IBlockState state)
+    public boolean isFullCube(@Nonnull IBlockState state)
     {
         return false;
     }
@@ -406,7 +414,7 @@ public abstract class BlockFluidBase extends Block implements IFluidBlock
     */
 
     @Override
-    public int getPackedLightmapCoords(IBlockState state, IBlockAccess world, BlockPos pos)
+    public int getPackedLightmapCoords(@Nonnull IBlockState state, @Nonnull IBlockAccess world, @Nonnull BlockPos pos)
     {
         int lightThis     = world.getCombinedLight(pos, 0);
         int lightUp       = world.getCombinedLight(pos.up(), 0);
@@ -420,13 +428,14 @@ public abstract class BlockFluidBase extends Block implements IFluidBlock
 
     @Override
     @SideOnly(Side.CLIENT)
+    @Nonnull
     public BlockRenderLayer getBlockLayer()
     {
         return this.renderLayer;
     }
 
     @Override
-    public boolean shouldSideBeRendered(IBlockState state, IBlockAccess world, BlockPos pos, EnumFacing side)
+    public boolean shouldSideBeRendered(@Nonnull IBlockState state, @Nonnull IBlockAccess world, @Nonnull BlockPos pos, @Nonnull EnumFacing side)
     {
         IBlockState neighbor = world.getBlockState(pos.offset(side));
         if (neighbor.getMaterial() == state.getMaterial())
@@ -445,7 +454,8 @@ public abstract class BlockFluidBase extends Block implements IFluidBlock
     }
 
     @Override
-    public IBlockState getExtendedState(IBlockState oldState, IBlockAccess worldIn, BlockPos pos)
+    @Nonnull
+    public IBlockState getExtendedState(@Nonnull IBlockState oldState, @Nonnull IBlockAccess worldIn, @Nonnull BlockPos pos)
     {
         IExtendedBlockState state = (IExtendedBlockState)oldState;
         state = state.withProperty(FLOW_DIRECTION, (float)getFlowDirection(worldIn, pos));
@@ -675,7 +685,7 @@ public abstract class BlockFluidBase extends Block implements IFluidBlock
     }
 
     @Override
-    public AxisAlignedBB getCollisionBoundingBox(IBlockState blockState, IBlockAccess worldIn, BlockPos pos)
+    public AxisAlignedBB getCollisionBoundingBox(@Nonnull IBlockState blockState, @Nonnull IBlockAccess worldIn, @Nonnull BlockPos pos)
     {
         return NULL_AABB;
     }

--- a/src/main/java/net/minecraftforge/fluids/BlockFluidClassic.java
+++ b/src/main/java/net/minecraftforge/fluids/BlockFluidClassic.java
@@ -29,6 +29,8 @@ import net.minecraft.world.IBlockAccess;
 import net.minecraft.world.World;
 import net.minecraftforge.event.ForgeEventFactory;
 
+import javax.annotation.Nonnull;
+
 /**
  * This is a fluid block implementation which emulates vanilla Minecraft fluid behavior.
  *
@@ -78,7 +80,7 @@ public class BlockFluidClassic extends BlockFluidBase
     }
 
     @Override
-    public boolean canCollideCheck(IBlockState state, boolean fullHit)
+    public boolean canCollideCheck(@Nonnull IBlockState state, boolean fullHit)
     {
         return fullHit && state.getValue(LEVEL) == 0;
     }
@@ -90,7 +92,7 @@ public class BlockFluidClassic extends BlockFluidBase
     }
 
     @Override
-    public int getLightValue(IBlockState state, IBlockAccess world, BlockPos pos)
+    public int getLightValue(@Nonnull IBlockState state, @Nonnull IBlockAccess world, @Nonnull BlockPos pos)
     {
         if (maxScaledLight == 0)
         {
@@ -101,7 +103,7 @@ public class BlockFluidClassic extends BlockFluidBase
     }
 
     @Override
-    public void updateTick(World world, BlockPos pos, IBlockState state, Random rand)
+    public void updateTick(@Nonnull World world, @Nonnull BlockPos pos, @Nonnull IBlockState state, @Nonnull Random rand)
     {
         if (!isSourceBlock(world, pos) && ForgeEventFactory.canCreateFluidSource(world, pos, state, false))
         {

--- a/src/main/java/net/minecraftforge/fluids/BlockFluidFinite.java
+++ b/src/main/java/net/minecraftforge/fluids/BlockFluidFinite.java
@@ -30,6 +30,8 @@ import net.minecraft.util.EnumFacing;
 import net.minecraft.world.IBlockAccess;
 import net.minecraft.world.World;
 
+import javax.annotation.Nonnull;
+
 /**
  * This is a cellular-automata based finite fluid block implementation.
  *
@@ -60,7 +62,7 @@ public class BlockFluidFinite extends BlockFluidBase
     }
 
     @Override
-    public boolean canCollideCheck(IBlockState state, boolean fullHit)
+    public boolean canCollideCheck(@Nonnull IBlockState state, boolean fullHit)
     {
         return fullHit && state.getValue(LEVEL) == quantaPerBlock - 1;
     }
@@ -72,7 +74,7 @@ public class BlockFluidFinite extends BlockFluidBase
     }
 
     @Override
-    public void updateTick(World world, BlockPos pos, IBlockState state, Random rand)
+    public void updateTick(@Nonnull World world, @Nonnull BlockPos pos, @Nonnull IBlockState state, @Nonnull Random rand)
     {
         boolean changed = false;
         int quantaRemaining = state.getValue(LEVEL) + 1;

--- a/src/main/java/net/minecraftforge/fluids/UniversalBucket.java
+++ b/src/main/java/net/minecraftforge/fluids/UniversalBucket.java
@@ -103,7 +103,7 @@ public class UniversalBucket extends Item
 
     @SideOnly(Side.CLIENT)
     @Override
-    public void getSubItems(Item itemIn, CreativeTabs tab, NonNullList<ItemStack> subItems)
+    public void getSubItems(@Nonnull Item itemIn, @Nonnull CreativeTabs tab, @Nonnull NonNullList<ItemStack> subItems)
     {
         for (Fluid fluid : FluidRegistry.getRegisteredFluids().values())
         {
@@ -123,6 +123,7 @@ public class UniversalBucket extends Item
     }
 
     @Override
+    @Nonnull
     public String getItemStackDisplayName(@Nonnull ItemStack stack)
     {
         FluidStack fluidStack = getFluid(stack);
@@ -146,7 +147,8 @@ public class UniversalBucket extends Item
     }
 
     @Override
-    public ActionResult<ItemStack> onItemRightClick(World world, EntityPlayer player, EnumHand hand)
+    @Nonnull
+    public ActionResult<ItemStack> onItemRightClick(@Nonnull World world, @Nonnull EntityPlayer player, @Nonnull EnumHand hand)
     {
         ItemStack itemstack = player.getHeldItem(hand);
         FluidStack fluidStack = getFluid(itemstack);

--- a/src/main/java/net/minecraftforge/server/command/CommandTreeBase.java
+++ b/src/main/java/net/minecraftforge/server/command/CommandTreeBase.java
@@ -27,6 +27,7 @@ import net.minecraft.server.MinecraftServer;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.text.TextComponentString;
 
+import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -80,7 +81,8 @@ public abstract class CommandTreeBase extends CommandBase
     }
 
     @Override
-    public List<String> getTabCompletionOptions(MinecraftServer server, ICommandSender sender, String[] args, @Nullable BlockPos pos)
+    @Nonnull
+    public List<String> getTabCompletionOptions(@Nonnull MinecraftServer server, @Nonnull ICommandSender sender, @Nonnull String[] args, @Nullable BlockPos pos)
     {
         if(args.length == 1)
         {
@@ -109,7 +111,7 @@ public abstract class CommandTreeBase extends CommandBase
     }
 
     @Override
-    public boolean isUsernameIndex(String[] args, int index)
+    public boolean isUsernameIndex(@Nonnull String[] args, int index)
     {
         if(index > 0 && args.length > 1)
         {
@@ -124,7 +126,7 @@ public abstract class CommandTreeBase extends CommandBase
     }
 
     @Override
-    public void execute(MinecraftServer server, ICommandSender sender, String[] args) throws CommandException
+    public void execute(@Nonnull MinecraftServer server, @Nonnull ICommandSender sender, @Nonnull String[] args) throws CommandException
     {
         if(args.length < 1)
         {

--- a/src/test/java/net/minecraftforge/debug/BreedingTest.java
+++ b/src/test/java/net/minecraftforge/debug/BreedingTest.java
@@ -19,6 +19,6 @@ public class BreedingTest
 
   @SubscribeEvent
   public void onBabyBorn(BabyEntitySpawnEvent event) {
-    event.setChild(new EntityCow(event.getChild().worldObj));
+    event.setChild(new EntityCow(event.getParentA().worldObj));
   }
 }

--- a/src/test/java/net/minecraftforge/debug/DynBucketTest.java
+++ b/src/test/java/net/minecraftforge/debug/DynBucketTest.java
@@ -263,8 +263,11 @@ public class DynBucketTest
         {
             ItemStack heldItem = playerIn.getHeldItem(hand);
             IFluidHandler tank = FluidUtil.getFluidHandler(worldIn, pos, side.getOpposite());
+            if (tank == null) {
+                return false;
+            }
 
-            if (null == null)
+            if (heldItem.func_190926_b())
             {
                 sendText(playerIn, tank);
                 return false;

--- a/src/test/java/net/minecraftforge/debug/ItemLayerModelDebug.java
+++ b/src/test/java/net/minecraftforge/debug/ItemLayerModelDebug.java
@@ -20,6 +20,7 @@ import net.minecraftforge.fml.common.registry.GameRegistry;
 
 import java.util.Random;
 
+import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
 @Mod(modid = ItemLayerModelDebug.MODID, name = "ForgeDebugItemLayerModel", version = ItemLayerModelDebug.VERSION)
@@ -95,7 +96,7 @@ public class ItemLayerModelDebug
         @Override
         public int getHarvestLevel(ItemStack stack, String toolClass, @Nullable EntityPlayer player, @Nullable IBlockState blockState) {
             // This tool is a super pickaxe if the player is wearing a helment
-            if("pickaxe".equals(toolClass) && player != null && player.getItemStackFromSlot(EntityEquipmentSlot.HEAD) != null) {
+            if("pickaxe".equals(toolClass) && player != null && !player.getItemStackFromSlot(EntityEquipmentSlot.HEAD).func_190926_b()) {
                 return 5;
             }
             return super.getHarvestLevel(stack, toolClass, player, blockState);

--- a/src/test/java/net/minecraftforge/debug/ModelAnimationDebug.java
+++ b/src/test/java/net/minecraftforge/debug/ModelAnimationDebug.java
@@ -158,7 +158,7 @@ public class ModelAnimationDebug
             GameRegistry.register(new ItemBlock(Block.REGISTRY.getObject(blockId))
             {
                 @Override
-                public ICapabilityProvider initCapabilities(ItemStack stack, NBTTagCompound nbt)
+                public ICapabilityProvider initCapabilities(ItemStack stack, @Nullable NBTTagCompound nbt)
                 {
                     return new ItemAnimationHolder();
                 }
@@ -166,11 +166,13 @@ public class ModelAnimationDebug
             GameRegistry.registerTileEntity(Chest.class, MODID + ":" + "tile_" + blockName);
         }
 
+        @Nullable
         public abstract IAnimationStateMachine load(ResourceLocation location, ImmutableMap<String, ITimeValue> parameters);
     }
 
     public static class ServerProxy extends CommonProxy
     {
+        @Nullable
         public IAnimationStateMachine load(ResourceLocation location, ImmutableMap<String, ITimeValue> parameters)
         {
             return null;
@@ -267,6 +269,7 @@ public class ModelAnimationDebug
 
     public static class Chest extends TileEntity
     {
+        @Nullable
         private final IAnimationStateMachine asm;
         private final VariableValue cycleLength = new VariableValue(4);
         private final VariableValue clickTime = new VariableValue(Float.NEGATIVE_INFINITY);

--- a/src/test/java/net/minecraftforge/debug/ModelBakeEventDebug.java
+++ b/src/test/java/net/minecraftforge/debug/ModelBakeEventDebug.java
@@ -22,7 +22,6 @@ import net.minecraft.creativetab.CreativeTabs;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemBlock;
-import net.minecraft.item.ItemStack;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.EnumBlockRenderType;
 import net.minecraft.util.EnumFacing;
@@ -48,6 +47,9 @@ import net.minecraftforge.fml.common.registry.GameRegistry;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.primitives.Ints;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 
 @Mod(modid = ModelBakeEventDebug.MODID, name = "ForgeDebugModelBakeEvent", version = ModelBakeEventDebug.VERSION)
 public class ModelBakeEventDebug
@@ -253,7 +255,7 @@ public class ModelBakeEventDebug
         }
 
         @Override
-        public List<BakedQuad> getQuads(IBlockState state, EnumFacing side, long rand)
+        public List<BakedQuad> getQuads(@Nullable IBlockState state, @Nullable EnumFacing side, long rand)
         {
             if(side != null) return ImmutableList.of();
             IExtendedBlockState exState = (IExtendedBlockState)state;
@@ -310,7 +312,7 @@ public class ModelBakeEventDebug
             case WEST:  return new Vec3d(-vec.yCoord,  vec.xCoord,  vec.zCoord);
             case EAST:  return new Vec3d( vec.yCoord, -vec.xCoord,  vec.zCoord);
         }
-        return null;
+        throw new IllegalArgumentException("Unknown Side " + side);
     }
 
     private static Vec3d revRotate(Vec3d vec, EnumFacing side)
@@ -324,6 +326,6 @@ public class ModelBakeEventDebug
             case WEST:  return new Vec3d( vec.yCoord, -vec.xCoord,  vec.zCoord);
             case EAST:  return new Vec3d(-vec.yCoord,  vec.xCoord,  vec.zCoord);
         }
-        return null;
+        throw new IllegalArgumentException("Unknown Side " + side);
     }
 }

--- a/src/test/java/net/minecraftforge/debug/MultiLayerModelDebug.java
+++ b/src/test/java/net/minecraftforge/debug/MultiLayerModelDebug.java
@@ -47,7 +47,7 @@ public class MultiLayerModelDebug
                 public boolean isFullCube(IBlockState state) { return false; }
 
                 @Override
-                public boolean canRenderInLayer(BlockRenderLayer layer)
+                public boolean canRenderInLayer(IBlockState state, BlockRenderLayer layer)
                 {
                     return layer == BlockRenderLayer.SOLID || layer == BlockRenderLayer.TRANSLUCENT;
                 }

--- a/src/test/java/net/minecraftforge/debug/package-info.java
+++ b/src/test/java/net/minecraftforge/debug/package-info.java
@@ -1,0 +1,7 @@
+@ParametersAreNonnullByDefault
+@MethodsReturnNonnullByDefault
+package net.minecraftforge.debug;
+
+import mcp.MethodsReturnNonnullByDefault;
+
+import javax.annotation.ParametersAreNonnullByDefault;

--- a/src/test/java/net/minecraftforge/fml/common/registry/ItemBlockSubstitutionRemoveRestoreTest.java
+++ b/src/test/java/net/minecraftforge/fml/common/registry/ItemBlockSubstitutionRemoveRestoreTest.java
@@ -1,7 +1,5 @@
 package net.minecraftforge.fml.common.registry;
 
-import com.google.common.base.Function;
-import net.minecraft.block.Block;
 import net.minecraft.block.BlockDirt;
 import net.minecraft.init.Blocks;
 import net.minecraft.init.Bootstrap;
@@ -18,7 +16,6 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
@@ -35,7 +32,7 @@ public class ItemBlockSubstitutionRemoveRestoreTest
         public ItemMyDirt() {
             super(Blocks.DIRT, Blocks.DIRT, new Mapper()
             {
-                @Nullable
+                @Nonnull
                 public String apply(@Nonnull ItemStack p_apply_1_)
                 {
                     return BlockDirt.DirtType.byMetadata(p_apply_1_.getMetadata()).getUnlocalizedName();

--- a/src/test/java/net/minecraftforge/fml/common/registry/SubstitutionInjectionTest.java
+++ b/src/test/java/net/minecraftforge/fml/common/registry/SubstitutionInjectionTest.java
@@ -15,6 +15,8 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
+import javax.annotation.Nonnull;
+
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.fail;
@@ -28,6 +30,7 @@ public class SubstitutionInjectionTest
     private ResourceLocation myDirt = new ResourceLocation("minecraft:dirt");
     private BlockDirt toSub = new BlockDirt() {
         @Override
+        @Nonnull
         public String toString()
         {
             return "SUB" + super.toString() + "SUB";

--- a/src/test/java/net/minecraftforge/test/ClientCommandTest.java
+++ b/src/test/java/net/minecraftforge/test/ClientCommandTest.java
@@ -1,6 +1,7 @@
 package net.minecraftforge.test;
 
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 
 import net.minecraft.command.CommandBase;
@@ -14,6 +15,8 @@ import net.minecraftforge.fml.common.Mod;
 import net.minecraftforge.fml.common.Mod.EventHandler;
 import net.minecraftforge.fml.common.event.FMLInitializationEvent;
 import net.minecraftforge.fml.common.registry.GameData;
+
+import javax.annotation.Nullable;
 
 @Mod(modid="clientcommandtest", name="Client Command Test", version="0.0.0", clientSideOnly = true)
 public class ClientCommandTest {
@@ -43,14 +46,14 @@ public class ClientCommandTest {
         }
 
         @Override
-        public List<String> getTabCompletionOptions(MinecraftServer server, ICommandSender sender, String[] args, BlockPos pos)
+        public List<String> getTabCompletionOptions(MinecraftServer server, ICommandSender sender, String[] args, @Nullable BlockPos pos)
         {
             if (args.length > 0)
             {
                 return getListOfStringsMatchingLastWord(args, GameData.getBlockRegistry().getKeys());
             }
 
-            return null;
+            return Collections.emptyList();
         }
 
         @Override

--- a/src/test/java/net/minecraftforge/test/FluidHandlerTest.java
+++ b/src/test/java/net/minecraftforge/test/FluidHandlerTest.java
@@ -19,6 +19,7 @@ import net.minecraftforge.fml.common.registry.ForgeRegistries;
 import net.minecraftforge.fml.relauncher.Side;
 
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 
 @Mod(modid="fluidhandlertest", name="FluidHandlerTest", version="0.0.0")
 public class FluidHandlerTest
@@ -83,7 +84,7 @@ public class FluidHandlerTest
 		}
 	}
 
-	private static String fluidString(FluidStack stack)
+	private static String fluidString(@Nullable FluidStack stack)
 	{
 		if (stack == null)
 		{

--- a/src/test/java/net/minecraftforge/test/NoBedSleepingTest.java
+++ b/src/test/java/net/minecraftforge/test/NoBedSleepingTest.java
@@ -165,7 +165,8 @@ public class NoBedSleepingTest
         }
 
         @Override
-        public ActionResult<ItemStack> onItemRightClick(World world, EntityPlayer player, EnumHand hand)
+        @Nonnull
+        public ActionResult<ItemStack> onItemRightClick(@Nonnull World world, @Nonnull EntityPlayer player, @Nonnull EnumHand hand)
         {
             ItemStack stack = player.getHeldItem(hand);
             if (!world.isRemote)

--- a/src/test/java/net/minecraftforge/test/TestCapabilityMod.java
+++ b/src/test/java/net/minecraftforge/test/TestCapabilityMod.java
@@ -47,7 +47,7 @@ public class TestCapabilityMod
     @SubscribeEvent
     public void onInteract(PlayerInteractEvent.LeftClickBlock event)
     {
-        if (event.getItemStack() == null) return;
+        if (event.getItemStack().func_190926_b()) return;
         if (event.getItemStack().getItem() != Items.STICK) return;
 
         // This is just a example of how to interact with the TE, note the strong type binding that getCapability has

--- a/src/test/java/net/minecraftforge/test/package-info.java
+++ b/src/test/java/net/minecraftforge/test/package-info.java
@@ -1,0 +1,7 @@
+@ParametersAreNonnullByDefault
+@MethodsReturnNonnullByDefault
+package net.minecraftforge.test;
+
+import mcp.MethodsReturnNonnullByDefault;
+
+import javax.annotation.ParametersAreNonnullByDefault;


### PR DESCRIPTION
Cleanup some null annotations, fixed the null problems that were uncovered. 
Remove the few deprecated Forge methods in Item and Block.
Fix nullability of Forge Tests, using `package.info` annotations.