### PR TITLE
[1.11] Added EnchantmentLevelSetEvent

### DIFF
--- a/patches/minecraft/net/minecraft/inventory/ContainerEnchantment.java.patch
+++ b/patches/minecraft/net/minecraft/inventory/ContainerEnchantment.java.patch
@@ -75,3 +75,11 @@
                          this.field_185001_h[i1] = -1;
                          this.field_185002_i[i1] = -1;
  
+@@ -212,6 +193,7 @@
+                         {
+                             this.field_75167_g[i1] = 0;
+                         }
++                        this.field_75167_g[i1] = net.minecraftforge.event.ForgeEventFactory.onEnchantmentLevelSet(field_75172_h, field_178150_j, i1, (int)power, itemstack, field_75167_g[i1]);
+                     }
+ 
+                     for (int j1 = 0; j1 < 3; ++j1)

--- a/src/main/java/net/minecraftforge/event/ForgeEventFactory.java
+++ b/src/main/java/net/minecraftforge/event/ForgeEventFactory.java
@@ -639,9 +639,9 @@ public class ForgeEventFactory
         return result == Result.DEFAULT ? def : result == Result.ALLOW;
     }
 
-    public static int onEnchantmentLevelSet(World world, BlockPos pos, int enchantNum, int power, ItemStack itemStack, int level)
+    public static int onEnchantmentLevelSet(World world, BlockPos pos, int enchantRow, int power, ItemStack itemStack, int level)
     {
-        net.minecraftforge.event.enchanting.EnchantmentLevelSetEvent e = new net.minecraftforge.event.enchanting.EnchantmentLevelSetEvent(world, pos, enchantNum, power, itemStack, level);
+        net.minecraftforge.event.enchanting.EnchantmentLevelSetEvent e = new net.minecraftforge.event.enchanting.EnchantmentLevelSetEvent(world, pos, enchantRow, power, itemStack, level);
         net.minecraftforge.common.MinecraftForge.EVENT_BUS.post(e);
         return e.getLevel();
     }

--- a/src/main/java/net/minecraftforge/event/ForgeEventFactory.java
+++ b/src/main/java/net/minecraftforge/event/ForgeEventFactory.java
@@ -639,4 +639,10 @@ public class ForgeEventFactory
         return result == Result.DEFAULT ? def : result == Result.ALLOW;
     }
 
+    public static int onEnchantmentLevelSet(World world, BlockPos pos, int enchantNum, int power, ItemStack itemStack, int level)
+    {
+        net.minecraftforge.event.enchanting.EnchantmentLevelSetEvent e = new net.minecraftforge.event.enchanting.EnchantmentLevelSetEvent(world, pos, enchantNum, (int)power, itemStack, level);
+        net.minecraftforge.common.MinecraftForge.EVENT_BUS.post(e);
+        return e.getLevel();
+    }
 }

--- a/src/main/java/net/minecraftforge/event/ForgeEventFactory.java
+++ b/src/main/java/net/minecraftforge/event/ForgeEventFactory.java
@@ -641,7 +641,7 @@ public class ForgeEventFactory
 
     public static int onEnchantmentLevelSet(World world, BlockPos pos, int enchantNum, int power, ItemStack itemStack, int level)
     {
-        net.minecraftforge.event.enchanting.EnchantmentLevelSetEvent e = new net.minecraftforge.event.enchanting.EnchantmentLevelSetEvent(world, pos, enchantNum, (int)power, itemStack, level);
+        net.minecraftforge.event.enchanting.EnchantmentLevelSetEvent e = new net.minecraftforge.event.enchanting.EnchantmentLevelSetEvent(world, pos, enchantNum, power, itemStack, level);
         net.minecraftforge.common.MinecraftForge.EVENT_BUS.post(e);
         return e.getLevel();
     }

--- a/src/main/java/net/minecraftforge/event/enchanting/EnchantmentLevelSetEvent.java
+++ b/src/main/java/net/minecraftforge/event/enchanting/EnchantmentLevelSetEvent.java
@@ -28,7 +28,7 @@ import net.minecraftforge.fml.common.eventhandler.Event;
  * Fired when the enchantment level is set for each of the three potential enchantments in the enchanting table.
  * The {@link #level} is set to the vanilla value and can be modified by this event handler.
  *
- * The {@link #enchantNum} is used to determine which enchantment level is being set, 1, 2, or 3. The {@link power} is a number
+ * The {@link #enchantRow} is used to determine which enchantment level is being set, 1, 2, or 3. The {@link power} is a number
  * from 0-15 and indicates how many bookshelves surround the enchanting table. The {@link itemStack} representing the item being
  * enchanted is also available.
  */
@@ -36,17 +36,17 @@ public class EnchantmentLevelSetEvent extends Event
 {
     private final World world;
     private final BlockPos pos;
-    private final int enchantNum;
+    private final int enchantRow;
     private final int power;
     private final ItemStack itemStack;
     private final int originalLevel;
     private int level;
 
-    public EnchantmentLevelSetEvent(World world, BlockPos pos, int enchantNum, int power, ItemStack itemStack, int level)
+    public EnchantmentLevelSetEvent(World world, BlockPos pos, int enchantRow, int power, ItemStack itemStack, int level)
     {
         this.world = world;
         this.pos = pos;
-        this.enchantNum = enchantNum;
+        this.enchantRow = enchantRow;
         this.power = power;
         this.itemStack = itemStack;
         this.originalLevel = level;
@@ -74,13 +74,13 @@ public class EnchantmentLevelSetEvent extends Event
     }
 
     /**
-     * Get the enchantNum for which the enchantment level is being set
+     * Get the row for which the enchantment level is being set
      * 
-     * @return the enchantNum for which the enchantment level is being set
+     * @return the row for which the enchantment level is being set
      */
-    public int getEnchantNum()
+    public int getEnchantRow()
     {
-        return enchantNum;
+        return enchantRow;
     }
 
     /**
@@ -104,9 +104,9 @@ public class EnchantmentLevelSetEvent extends Event
     }
 
     /**
-     * Get the original level of the enchantment for this enchantNum (0-30)
+     * Get the original level of the enchantment for this row (0-30)
      * 
-     * @return the original level of the enchantment for this enchantNum (0-30)
+     * @return the original level of the enchantment for this row (0-30)
      */
     public int getOriginalLevel()
     {
@@ -114,9 +114,9 @@ public class EnchantmentLevelSetEvent extends Event
     }
 
     /**
-     * Get the level of the enchantment for this enchantNum (0-30)
+     * Get the level of the enchantment for this row (0-30)
      * 
-     * @return the level of the enchantment for this enchantNum (0-30)
+     * @return the level of the enchantment for this row (0-30)
      */
     public int getLevel()
     {

--- a/src/main/java/net/minecraftforge/event/enchanting/EnchantmentLevelSetEvent.java
+++ b/src/main/java/net/minecraftforge/event/enchanting/EnchantmentLevelSetEvent.java
@@ -1,0 +1,135 @@
+/*
+ * Minecraft Forge
+ * Copyright (c) 2016.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation version 2.1
+ * of the License.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+package net.minecraftforge.event.enchanting;
+
+import net.minecraft.item.ItemStack;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.World;
+import net.minecraftforge.fml.common.eventhandler.Event;
+
+/**
+ * Fired when the enchantment level is set for a slot in the enchanting table. The {@link #level} is set to the vanilla value 
+ * and can be modified by this event handler.
+ *
+ * The {@link #slot} is used to determine which slot's enchantment level is being set. The {@link power} is a number from 0-15
+ * and indicates how many bookshelves surround the enchanting table. The {@link itemStack} representing the item being enchanted
+ * is also available.
+ */
+public class EnchantmentLevelSetEvent extends Event
+{
+    private final World world;
+    private final BlockPos pos;
+    private final int enchantNum;
+    private final int power;
+    private final ItemStack itemStack;
+    private final int originalLevel;
+    private int level;
+
+    public EnchantmentLevelSetEvent(World world, BlockPos pos, int enchantNum, int power, ItemStack itemStack, int level)
+    {
+        this.world = world;
+        this.pos = pos;
+        this.enchantNum = enchantNum;
+        this.power = power;
+        this.itemStack = itemStack;
+        this.originalLevel = level;
+        this.level = level;
+    }
+
+    /**
+     * Get the world object
+     * 
+     * @return the world object
+     */
+    public World getWorld()
+    {
+        return world;
+    }
+
+    /**
+     * Get the pos of the enchantment table
+     * 
+     * @return the pos of the enchantment table
+     */
+    public BlockPos getPos()
+    {
+        return pos;
+    }
+
+    /**
+     * Get the enchantNum for which the enchantment level is being set
+     * 
+     * @return the enchantNum for which the enchantment level is being set
+     */
+    public int getEnchantNum()
+    {
+        return enchantNum;
+    }
+
+    /**
+     * Get the power (# of bookshelves) for the enchanting table
+     * 
+     * @return the power (# of bookshelves) for the enchanting table
+     */
+    public int getPower()
+    {
+        return power;
+    }
+
+    /**
+     * Get the item being enchanted
+     * 
+     * @return the item being enchanted
+     */
+    public ItemStack getItem()
+    {
+        return itemStack;
+    }
+
+    /**
+     * Get the original level of the enchantment for this enchantNum (0-30)
+     * 
+     * @return the original level of the enchantment for this enchantNum (0-30)
+     */
+    public int getOriginalLevel()
+    {
+        return originalLevel;
+    }
+
+    /**
+     * Get the level of the enchantment for this enchantNum (0-30)
+     * 
+     * @return the level of the enchantment for this enchantNum (0-30)
+     */
+    public int getLevel()
+    {
+        return level;
+    }
+
+    /**
+     * Set the new level of the enchantment for this slot (0-30)
+     * 
+     * @param the new level of the enchantment for this slot (0-30)
+     */
+    public void setLevel(int level)
+    {
+        this.level = level;
+    }
+}

--- a/src/main/java/net/minecraftforge/event/enchanting/EnchantmentLevelSetEvent.java
+++ b/src/main/java/net/minecraftforge/event/enchanting/EnchantmentLevelSetEvent.java
@@ -25,12 +25,12 @@ import net.minecraft.world.World;
 import net.minecraftforge.fml.common.eventhandler.Event;
 
 /**
- * Fired when the enchantment level is set for a slot in the enchanting table. The {@link #level} is set to the vanilla value 
- * and can be modified by this event handler.
+ * Fired when the enchantment level is set for each of the three potential enchantments in the enchanting table.
+ * The {@link #level} is set to the vanilla value and can be modified by this event handler.
  *
- * The {@link #slot} is used to determine which slot's enchantment level is being set. The {@link power} is a number from 0-15
- * and indicates how many bookshelves surround the enchanting table. The {@link itemStack} representing the item being enchanted
- * is also available.
+ * The {@link #enchantNum} is used to determine which enchantment level is being set, 1, 2, or 3. The {@link power} is a number
+ * from 0-15 and indicates how many bookshelves surround the enchanting table. The {@link itemStack} representing the item being
+ * enchanted is also available.
  */
 public class EnchantmentLevelSetEvent extends Event
 {
@@ -124,9 +124,9 @@ public class EnchantmentLevelSetEvent extends Event
     }
 
     /**
-     * Set the new level of the enchantment for this slot (0-30)
+     * Set the new level of the enchantment (0-30)
      * 
-     * @param the new level of the enchantment for this slot (0-30)
+     * @param the new level of the enchantment (0-30)
      */
     public void setLevel(int level)
     {

--- a/src/test/java/net/minecraftforge/test/EnchantmentLevelSetTest.java
+++ b/src/test/java/net/minecraftforge/test/EnchantmentLevelSetTest.java
@@ -25,7 +25,7 @@ public class EnchantmentLevelSetTest
     public static void onEnchantmentLevelSet(EnchantmentLevelSetEvent event)
     {
         // invert enchantment level, just for fun
-        FMLLog.info("Enchantment number: " + event.getEnchantNum() + ", level: " + event.getLevel());
+        FMLLog.info("Enchantment row: " + event.getEnchantRow() + ", level: " + event.getLevel());
         event.setLevel(30 - event.getLevel());
     }
 }

--- a/src/test/java/net/minecraftforge/test/EnchantmentLevelSetTest.java
+++ b/src/test/java/net/minecraftforge/test/EnchantmentLevelSetTest.java
@@ -1,0 +1,31 @@
+package net.minecraftforge.test;
+
+import net.minecraftforge.common.MinecraftForge;
+import net.minecraftforge.event.enchanting.EnchantmentLevelSetEvent;
+import net.minecraftforge.fml.common.FMLLog;
+import net.minecraftforge.fml.common.Mod;
+import net.minecraftforge.fml.common.event.FMLInitializationEvent;
+import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
+
+@Mod(modid = "enchantmentlevelsettest", name = "EnchantmentLevelSetTest", version = "1.0")
+public class EnchantmentLevelSetTest
+{
+    public static final boolean ENABLE = false;
+
+    @Mod.EventHandler
+    public static void init(FMLInitializationEvent event)
+    {
+        if (ENABLE) {
+            FMLLog.info("Wiring up enchantment level set test");
+            MinecraftForge.EVENT_BUS.register(EnchantmentLevelSetTest.class);
+        }
+    }
+
+    @SubscribeEvent
+    public static void onEnchantmentLevelSet(EnchantmentLevelSetEvent event)
+    {
+        // invert enchantment level, just for fun
+        FMLLog.info("Enchantment number: " + event.getEnchantNum() + ", level: " + event.getLevel());
+        event.setLevel(30 - event.getLevel());
+    }
+}


### PR DESCRIPTION
Allows enchantment level to be modified before enchantments are chosen
in the enchanting table.

Same change as in https://github.com/MinecraftForge/MinecraftForge/pull/3373, but for 1.11