### PR TITLE
[1.11] Allow PIE to return a custom EnumActionResult on cancel instead of PASS

### DIFF
--- a/patches/minecraft/net/minecraft/client/multiplayer/PlayerControllerMP.java.patch
+++ b/patches/minecraft/net/minecraft/client/multiplayer/PlayerControllerMP.java.patch
@@ -108,7 +108,7 @@
 +            {
 +                // Give the server a chance to fire event as well. That way server event is not dependant on client event.
 +                this.field_78774_b.func_147297_a(new CPacketPlayerTryUseItemOnBlock(p_187099_3_, p_187099_4_, p_187099_6_, f, f1, f2));
-+                return EnumActionResult.PASS;
++                return event.getInteractionResult();
 +            }
 +            EnumActionResult result = EnumActionResult.PASS;
 +
@@ -163,15 +163,16 @@
                      }
                  }
              }
-@@ -457,6 +492,7 @@
+@@ -457,6 +492,8 @@
              }
              else
              {
-+                if (net.minecraftforge.common.ForgeHooks.onItemRightClick(p_187101_1_, p_187101_3_)) return net.minecraft.util.EnumActionResult.PASS;
++                net.minecraftforge.event.entity.player.PlayerInteractEvent.RightClickItem event = net.minecraftforge.common.ForgeHooks.onItemRightClick2(p_187101_1_, p_187101_3_);
++                if (event.isCanceled()) return event.getInteractionResult();
                  int i = itemstack.func_190916_E();
                  ActionResult<ItemStack> actionresult = itemstack.func_77957_a(p_187101_2_, p_187101_1_, p_187101_3_);
                  ItemStack itemstack1 = (ItemStack)actionresult.func_188398_b();
-@@ -464,6 +500,10 @@
+@@ -464,6 +501,10 @@
                  if (itemstack1 != itemstack || itemstack1.func_190916_E() != i)
                  {
                      p_187101_1_.func_184611_a(p_187101_3_, itemstack1);
@@ -182,7 +183,7 @@
                  }
  
                  return actionresult.func_188397_a();
-@@ -500,6 +540,7 @@
+@@ -500,6 +541,7 @@
          this.func_78750_j();
          Vec3d vec3d = new Vec3d(p_187102_3_.field_72307_f.field_72450_a - p_187102_2_.field_70165_t, p_187102_3_.field_72307_f.field_72448_b - p_187102_2_.field_70163_u, p_187102_3_.field_72307_f.field_72449_c - p_187102_2_.field_70161_v);
          this.field_78774_b.func_147297_a(new CPacketUseEntity(p_187102_2_, p_187102_4_, vec3d));

--- a/patches/minecraft/net/minecraft/server/management/PlayerInteractionManager.java.patch
+++ b/patches/minecraft/net/minecraft/server/management/PlayerInteractionManager.java.patch
@@ -199,18 +199,19 @@
                  return flag1;
              }
          }
-@@ -330,8 +352,10 @@
+@@ -330,8 +352,11 @@
          }
          else
          {
-+            if (net.minecraftforge.common.ForgeHooks.onItemRightClick(p_187250_1_, p_187250_4_)) return net.minecraft.util.EnumActionResult.PASS;
++            net.minecraftforge.event.entity.player.PlayerInteractEvent.RightClickItem event = net.minecraftforge.common.ForgeHooks.onItemRightClick2(p_187250_1_, p_187250_4_);
++            if (event.isCanceled()) return event.getInteractionResult();
              int i = p_187250_3_.func_190916_E();
              int j = p_187250_3_.func_77960_j();
 +            ItemStack copyBeforeUse = p_187250_3_.func_77946_l();
              ActionResult<ItemStack> actionresult = p_187250_3_.func_77957_a(p_187250_2_, p_187250_1_, p_187250_4_);
              ItemStack itemstack = (ItemStack)actionresult.func_188398_b();
  
-@@ -360,6 +384,7 @@
+@@ -360,6 +385,7 @@
                  if (itemstack.func_190926_b())
                  {
                      p_187250_1_.func_184611_a(p_187250_4_, ItemStack.field_190927_a);
@@ -218,14 +219,14 @@
                  }
  
                  if (!p_187250_1_.func_184587_cr())
-@@ -404,13 +429,25 @@
+@@ -404,13 +430,25 @@
          }
          else
          {
 -            if (!p_187251_1_.func_70093_af() || p_187251_1_.func_184614_ca().func_190926_b() && p_187251_1_.func_184592_cb().func_190926_b())
 +            net.minecraftforge.event.entity.player.PlayerInteractEvent.RightClickBlock event = net.minecraftforge.common.ForgeHooks
 +                    .onRightClickBlock(p_187251_1_, p_187251_4_, p_187251_5_, p_187251_6_, net.minecraftforge.common.ForgeHooks.rayTraceEyeHitVec(field_73090_b, getBlockReachDistance() + 1));
-+            if (event.isCanceled()) return EnumActionResult.PASS;
++            if (event.isCanceled()) return event.getInteractionResult();
 +
 +            EnumActionResult ret = p_187251_3_.onItemUseFirst(p_187251_1_, p_187251_2_, p_187251_5_, p_187251_4_, p_187251_6_, p_187251_7_, p_187251_8_, p_187251_9_);
 +            if (ret != EnumActionResult.PASS) return ret;
@@ -247,7 +248,7 @@
                  }
              }
  
-@@ -438,14 +475,20 @@
+@@ -438,14 +476,20 @@
                  {
                      int j = p_187251_3_.func_77960_j();
                      int i = p_187251_3_.func_190916_E();
@@ -268,7 +269,7 @@
                  }
              }
          }
-@@ -455,4 +498,13 @@
+@@ -455,4 +499,13 @@
      {
          this.field_73092_a = p_73080_1_;
      }

--- a/src/main/java/net/minecraftforge/common/ForgeHooks.java
+++ b/src/main/java/net/minecraftforge/common/ForgeHooks.java
@@ -1038,9 +1038,18 @@ public class ForgeHooks
         return MinecraftForge.EVENT_BUS.post(new PlayerInteractEvent.EntityInteract(player, hand, entity));
     }
 
+    @Deprecated
     public static boolean onItemRightClick(EntityPlayer player, EnumHand hand)
     {
         return MinecraftForge.EVENT_BUS.post(new PlayerInteractEvent.RightClickItem(player, hand));
+    }
+    
+    // TODO: Get rid of the old onItemRightClick in 1.12
+    public static PlayerInteractEvent.RightClickItem onItemRightClick2(EntityPlayer player, EnumHand hand)
+    {
+        PlayerInteractEvent.RightClickItem evt = new PlayerInteractEvent.RightClickItem(player, hand);
+        MinecraftForge.EVENT_BUS.post(evt);
+        return evt;
     }
 
     public static PlayerInteractEvent.LeftClickBlock onLeftClickBlock(EntityPlayer player, BlockPos pos, EnumFacing face, Vec3d hitVec)

--- a/src/main/java/net/minecraftforge/event/entity/player/PlayerInteractEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/player/PlayerInteractEvent.java
@@ -25,6 +25,7 @@ import net.minecraft.entity.Entity;
 import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemStack;
+import net.minecraft.util.EnumActionResult;
 import net.minecraft.util.EnumFacing;
 import net.minecraft.util.EnumHand;
 import net.minecraft.util.math.BlockPos;
@@ -145,6 +146,7 @@ public class PlayerInteractEvent extends PlayerEvent
         private Result useBlock = DEFAULT;
         private Result useItem = DEFAULT;
         private final Vec3d hitVec;
+        private EnumActionResult result = EnumActionResult.PASS;
 
         public RightClickBlock(EntityPlayer player, EnumHand hand, BlockPos pos, EnumFacing face, Vec3d hitVec) {
             super(player, hand, pos, face);
@@ -205,6 +207,24 @@ public class PlayerInteractEvent extends PlayerEvent
                 useItem = DENY;
             }
         }
+
+        /**
+         * If the event is cancelled, determines if the interaction was
+         * successful and whether the event should be passed to the other hands.
+         */
+        public void setInteractionResult(EnumActionResult result)
+        {
+            this.result = result;
+        }
+        
+        /**
+         * Gets the result of this event being cancelled.
+         * Behaves the same way as if it were returned by the item itself.
+         */
+        public EnumActionResult getInteractionResult()
+        {
+            return result;
+        }
     }
 
     /**
@@ -216,9 +236,29 @@ public class PlayerInteractEvent extends PlayerEvent
     @Cancelable
     public static class RightClickItem extends PlayerInteractEvent
     {
+        private EnumActionResult result = EnumActionResult.PASS;
+        
         public RightClickItem(EntityPlayer player, EnumHand hand)
         {
             super(player, hand, new BlockPos(player), null);
+        }
+
+        /**
+         * If the event is cancelled, determines if the interaction was
+         * successful and whether the event should be passed to the other hands.
+         */
+        public void setInteractionResult(EnumActionResult result)
+        {
+            this.result = result;
+        }
+        
+        /**
+         * Gets the result of this event being cancelled.
+         * Behaves the same way as if it were returned by the item itself.
+         */
+        public EnumActionResult getInteractionResult()
+        {
+            return result;
         }
     }
 


### PR DESCRIPTION
As the title states, this PR adds a couple methods to `PlayerInteractEvent.RightClickItem` and `PlayerInteractEvent.RightClickBlock` that allow the user to return an `EnumActionResult` when they cancel the event instead of what was being used by default until now (`EnumActionResult.PASS`).

In most cases, when you cancel the interaction event you don't want any further action to take place and to do that you'll want to return either `EnumActionResult.SUCCESS` or `EnumActionResult.FAIL`. If the new method isn't called, the result of this event being fired will be the same as it was in the past so compatibility with previous implementations won't be broken.

It wasn't a problem when there was only one hand since nothing happened after cancelling the event, but now that we have two of them we should be able to decide what happens after we cancel it.