### PR TITLE
Allowed blocks to use custom icons

### DIFF
--- a/patches/minecraft/net/minecraft/client/renderer/texture/TextureAtlasSprite.java.patch
+++ b/patches/minecraft/net/minecraft/client/renderer/texture/TextureAtlasSprite.java.patch
@@ -26,8 +26,8 @@
 +    /**
 +     * The result of this function determines is the below 'load' function is called, and the
 +     * default vanilla loading code is bypassed completely.
-+     * @param manager
-+     * @param location
++     * @param manager Main resource manager
++     * @param location File resource location
 +     * @return True to use your own custom load code and bypass vanilla loading.
 +     */
 +    public boolean hasCustomLoader(net.minecraft.client.resources.IResourceManager manager, net.minecraft.util.ResourceLocation location)

--- a/patches/minecraft/net/minecraft/client/renderer/texture/TextureMap.java.patch
+++ b/patches/minecraft/net/minecraft/client/renderer/texture/TextureMap.java.patch
@@ -40,11 +40,18 @@
      }
  
      private void func_110569_e()
-@@ -89,12 +102,26 @@
+@@ -74,6 +87,7 @@
+     public void func_174943_a(IResourceManager p_174943_1_, ITextureMapPopulator p_174943_2_)
+     {
+         this.field_110574_e.clear();
++        net.minecraftforge.client.ForgeHooksClient.onTextureStitchedPre(this);
+         p_174943_2_.func_177059_a(this);
+         this.func_110569_e();
+         this.func_147631_c();
+@@ -89,12 +103,25 @@
          int j = Integer.MAX_VALUE;
          int k = 1 << this.field_147636_j;
  
-+        net.minecraftforge.client.ForgeHooksClient.onTextureStitchedPre(this);
 +        net.minecraftforge.fml.common.FMLLog.info("Max texture size: %d", i);
 +        net.minecraftforge.fml.common.ProgressManager.ProgressBar bar = net.minecraftforge.fml.common.ProgressManager.push("Texture stitching", skipFirst ? 0 : this.field_110574_e.size());
 +

--- a/patches/minecraft/net/minecraft/client/renderer/texture/TextureMap.java.patch
+++ b/patches/minecraft/net/minecraft/client/renderer/texture/TextureMap.java.patch
@@ -175,7 +175,7 @@
  
              if (textureatlassprite == null)
              {
-@@ -318,4 +363,52 @@
+@@ -318,4 +363,48 @@
      {
          return this.field_94249_f;
      }
@@ -190,32 +190,28 @@
 +     * @param name The name of the entry to find
 +     * @return The registered entry, null if nothing was registered.
 +     */
++    @Nullable
 +    public TextureAtlasSprite getTextureExtry(String name)
 +    {
-+        return (TextureAtlasSprite)field_110574_e.get(name);
++        return field_110574_e.get(name);
 +    }
 +
 +    /**
 +     * Adds a texture registry entry to this map for the specified name if one does not already exist.
 +     * Returns false if the map already contains a entry for the specified name.
 +     *
-+     * @param name Entry name
 +     * @param entry Entry instance
 +     * @return True if the entry was added to the map, false otherwise.
 +     */
-+    @Deprecated //Use non-String version
-+    public boolean setTextureEntry(String name, TextureAtlasSprite entry)
++    public boolean setTextureEntry(TextureAtlasSprite entry)
 +    {
++        String name = entry.func_94215_i();
 +        if (!field_110574_e.containsKey(name))
 +        {
 +            field_110574_e.put(name, entry);
 +            return true;
 +        }
 +        return false;
-+    }
-+    public boolean setTextureEntry(TextureAtlasSprite entry)
-+    {
-+        return setTextureEntry(entry.func_94215_i(), entry);
 +    }
 +
 +    public String getBasePath()

--- a/src/main/java/net/minecraftforge/client/model/ModelLoader.java
+++ b/src/main/java/net/minecraftforge/client/model/ModelLoader.java
@@ -918,7 +918,7 @@ public final class ModelLoader extends ModelBakery
 
         public void register(TextureMap map)
         {
-            map.setTextureEntry(White.LOCATION.toString(), White.INSTANCE);
+            map.setTextureEntry(White.INSTANCE);
         }
     }
 

--- a/src/test/java/net/minecraftforge/test/CustomSpriteTest.java
+++ b/src/test/java/net/minecraftforge/test/CustomSpriteTest.java
@@ -1,0 +1,88 @@
+package net.minecraftforge.test;
+
+import net.minecraft.block.Block;
+import net.minecraft.block.material.Material;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.renderer.texture.TextureAtlasSprite;
+import net.minecraft.client.resources.IResource;
+import net.minecraft.client.resources.IResourceManager;
+import net.minecraft.creativetab.CreativeTabs;
+import net.minecraft.util.ResourceLocation;
+import net.minecraftforge.client.event.TextureStitchEvent;
+import net.minecraftforge.common.MinecraftForge;
+import net.minecraftforge.fml.common.Mod;
+import net.minecraftforge.fml.common.event.FMLPreInitializationEvent;
+import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
+import net.minecraftforge.fml.common.registry.GameRegistry;
+
+import javax.imageio.ImageIO;
+import java.awt.image.BufferedImage;
+import java.io.IOException;
+
+/**
+ * Test for {@link TextureStitchEvent.Pre}.
+ */
+@Mod(modid = CustomSpriteTest.MOD_ID, name = CustomSpriteTest.NAME)
+public class CustomSpriteTest
+{
+    static final String MOD_ID = "custom_sprite_test";
+    static final String NAME = "Custom sprite test";
+
+    public void init(FMLPreInitializationEvent event)
+    {
+        MinecraftForge.EVENT_BUS.register(this);
+        Block block = new Block(Material.WOOD).setRegistryName(MOD_ID, "custom_sprite_block").setCreativeTab(CreativeTabs.MISC);
+        GameRegistry.register(block);
+    }
+
+    @SubscribeEvent
+    public void textureStitch(TextureStitchEvent.Pre event)
+    {
+        event.getMap().setTextureEntry(DelegateSprite.make("bottom", "blocks/diamond_block"));
+        event.getMap().setTextureEntry(DelegateSprite.make("top", "blocks/tnt_side"));
+    }
+
+    static final class DelegateSprite extends TextureAtlasSprite
+    {
+        final ResourceLocation location;
+        final ResourceLocation delegate;
+
+        private DelegateSprite(ResourceLocation loc, ResourceLocation delegate)
+        {
+            super(loc.toString());
+            this.location = loc;
+            this.delegate = delegate;
+        }
+
+        static DelegateSprite make(String name, String delegate)
+        {
+            return new DelegateSprite(new ResourceLocation(MOD_ID, name), new ResourceLocation("minecraft", delegate));
+        }
+
+        @Override
+        public boolean hasCustomLoader(IResourceManager manager, ResourceLocation location)
+        {
+            return location.equals(this.location);
+        }
+
+        @Override
+        public boolean load(IResourceManager manager, ResourceLocation location)
+        {
+            BufferedImage image;
+            try
+            {
+                image = ImageIO.read(manager.getResource(delegate).getInputStream());
+            }
+            catch (IOException ioe)
+            {
+                return false;
+            }
+            int[][] pixels = new int[Minecraft.getMinecraft().gameSettings.mipmapLevels + 1][];
+            pixels[0] = new int[image.getWidth() * image.getHeight()];
+            image.getRGB(0, 0, image.getWidth(), image.getHeight(), pixels[0], 0, image.getWidth());
+            this.clearFramesTextureData();
+            this.framesTextureData.add(pixels);
+            return false;
+        }
+    }
+}

--- a/src/test/java/net/minecraftforge/test/CustomSpriteTest.java
+++ b/src/test/java/net/minecraftforge/test/CustomSpriteTest.java
@@ -4,17 +4,20 @@ import net.minecraft.block.Block;
 import net.minecraft.block.material.Material;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.renderer.texture.TextureAtlasSprite;
+import net.minecraft.client.renderer.texture.TextureMap;
 import net.minecraft.client.resources.IResource;
 import net.minecraft.client.resources.IResourceManager;
 import net.minecraft.creativetab.CreativeTabs;
 import net.minecraft.util.ResourceLocation;
 import net.minecraftforge.client.event.TextureStitchEvent;
 import net.minecraftforge.common.MinecraftForge;
+import net.minecraftforge.fml.common.FMLLog;
 import net.minecraftforge.fml.common.Mod;
 import net.minecraftforge.fml.common.event.FMLPreInitializationEvent;
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
 import net.minecraftforge.fml.common.registry.GameRegistry;
 
+import javax.annotation.Nonnull;
 import javax.imageio.ImageIO;
 import java.awt.image.BufferedImage;
 import java.io.IOException;
@@ -22,12 +25,13 @@ import java.io.IOException;
 /**
  * Test for {@link TextureStitchEvent.Pre}.
  */
-@Mod(modid = CustomSpriteTest.MOD_ID, name = CustomSpriteTest.NAME)
+@Mod(modid = CustomSpriteTest.MOD_ID, name = CustomSpriteTest.NAME, version = "1.0")
 public class CustomSpriteTest
 {
     static final String MOD_ID = "custom_sprite_test";
     static final String NAME = "Custom sprite test";
 
+    @Mod.EventHandler
     public void init(FMLPreInitializationEvent event)
     {
         MinecraftForge.EVENT_BUS.register(this);
@@ -38,45 +42,51 @@ public class CustomSpriteTest
     @SubscribeEvent
     public void textureStitch(TextureStitchEvent.Pre event)
     {
-        event.getMap().setTextureEntry(DelegateSprite.make("bottom", "blocks/diamond_block"));
-        event.getMap().setTextureEntry(DelegateSprite.make("top", "blocks/tnt_side"));
+        DelegateSprite bottom = DelegateSprite.make("bottom", new ResourceLocation("textures/blocks/diamond_block.png"));
+        DelegateSprite top = DelegateSprite.make("top", new ResourceLocation("textures/blocks/tnt_side.png"));
+
+        TextureMap textureMap = event.getMap();
+        textureMap.setTextureEntry(bottom);
+        textureMap.setTextureEntry(top);
     }
 
     static final class DelegateSprite extends TextureAtlasSprite
     {
-        final ResourceLocation location;
         final ResourceLocation delegate;
 
         private DelegateSprite(ResourceLocation loc, ResourceLocation delegate)
         {
             super(loc.toString());
-            this.location = loc;
             this.delegate = delegate;
         }
 
-        static DelegateSprite make(String name, String delegate)
+        static DelegateSprite make(String name, ResourceLocation delegate)
         {
-            return new DelegateSprite(new ResourceLocation(MOD_ID, name), new ResourceLocation("minecraft", delegate));
+            return new DelegateSprite(new ResourceLocation(MOD_ID, name), delegate);
         }
 
         @Override
-        public boolean hasCustomLoader(IResourceManager manager, ResourceLocation location)
+        public boolean hasCustomLoader(@Nonnull IResourceManager manager, @Nonnull ResourceLocation location)
         {
-            return location.equals(this.location);
+            return true;
         }
 
         @Override
-        public boolean load(IResourceManager manager, ResourceLocation location)
+        public boolean load(@Nonnull IResourceManager manager, @Nonnull ResourceLocation location)
         {
             BufferedImage image;
             try
             {
-                image = ImageIO.read(manager.getResource(delegate).getInputStream());
+                IResource resource = manager.getResource(delegate);
+                image = ImageIO.read(resource.getInputStream());
             }
             catch (IOException ioe)
             {
-                return false;
+                FMLLog.getLogger().error("Could not find resource", ioe);
+                return true;
             }
+            this.width = image.getWidth();
+            this.height = image.getHeight();
             int[][] pixels = new int[Minecraft.getMinecraft().gameSettings.mipmapLevels + 1][];
             pixels[0] = new int[image.getWidth() * image.getHeight()];
             image.getRGB(0, 0, image.getWidth(), image.getHeight(), pixels[0], 0, image.getWidth());

--- a/src/test/resources/assets/custom_sprite_test/blockstates/custom_sprite_block.json
+++ b/src/test/resources/assets/custom_sprite_test/blockstates/custom_sprite_block.json
@@ -1,0 +1,5 @@
+{
+  "variants": {
+    "normal": { "model": "custom_sprite_test:custom_sprite_block" }
+  }
+}

--- a/src/test/resources/assets/custom_sprite_test/models/block/custom_sprite_block.json
+++ b/src/test/resources/assets/custom_sprite_test/models/block/custom_sprite_block.json
@@ -1,0 +1,7 @@
+{
+  "parent": "block/crafting_table",
+  "textures": {
+    "down": "custom_sprite_test:bottom",
+    "up": "custom_sprite_test:top"
+  }
+}


### PR DESCRIPTION
Currently, there is no event which could allow **blocks** to use custom classes extending `TextureAtlasSprite` for textures. This is the correct way to fix #3375 and CovertJaguar/Railcraft#924.