### PR TITLE
Provide access to ShapedOreRecipe width and height

### DIFF
--- a/src/main/java/net/minecraftforge/oredict/ShapedOreRecipe.java
+++ b/src/main/java/net/minecraftforge/oredict/ShapedOreRecipe.java
@@ -283,4 +283,14 @@ public class ShapedOreRecipe implements IRecipe
     {
         return ForgeHooks.defaultRecipeGetRemainingItems(inv);
     }
+
+    public int getWidth()
+    {
+        return width;
+    }
+
+    public int getHeight()
+    {
+        return height;
+    }
 }


### PR DESCRIPTION
JEI has to use reflection to get the `ShapedOreRecipe`'s width and height. Other recipes have them easily accessible.
This PR adds getters for the width and height.