### PR TITLE
Provide access to GuiContainer location and dimensions

### DIFF
--- a/patches/minecraft/net/minecraft/client/gui/inventory/GuiContainer.java.patch
+++ b/patches/minecraft/net/minecraft/client/gui/inventory/GuiContainer.java.patch
@@ -127,7 +127,7 @@
                  {
                      this.func_184098_a(this.field_147006_u, this.field_147006_u.field_75222_d, i, ClickType.SWAP);
                      return true;
-@@ -689,4 +693,37 @@
+@@ -689,4 +693,18 @@
              this.field_146297_k.field_71439_g.func_71053_j();
          }
      }
@@ -138,30 +138,11 @@
 +     * Returns the slot that is currently displayed under the mouse.
 +     */
 +    @javax.annotation.Nullable
-+    public Slot getSlotUnderMouse()
-+    {
-+        return this.field_147006_u;
-+    }
-+
-+    public int getGuiLeft()
-+    {
-+        return field_147003_i;
-+    }
-+
-+    public int getGuiTop()
-+    {
-+        return field_147009_r;
-+    }
-+
-+    public int getXSize()
-+    {
-+        return field_146999_f;
-+    }
-+
-+    public int getYSize()
-+    {
-+        return field_147000_g;
-+    }
++    public Slot getSlotUnderMouse() { return this.field_147006_u; }
++    public int getGuiLeft() { return field_147003_i; }
++    public int getGuiTop() { return field_147009_r; }
++    public int getXSize() { return field_146999_f; }
++    public int getYSize() { return field_147000_g; }
 +
 +    /* ======================================== FORGE END   =====================================*/
  }

--- a/patches/minecraft/net/minecraft/client/gui/inventory/GuiContainer.java.patch
+++ b/patches/minecraft/net/minecraft/client/gui/inventory/GuiContainer.java.patch
@@ -127,7 +127,7 @@
                  {
                      this.func_184098_a(this.field_147006_u, this.field_147006_u.field_75222_d, i, ClickType.SWAP);
                      return true;
-@@ -689,4 +693,17 @@
+@@ -689,4 +693,37 @@
              this.field_146297_k.field_71439_g.func_71053_j();
          }
      }
@@ -141,6 +141,26 @@
 +    public Slot getSlotUnderMouse()
 +    {
 +        return this.field_147006_u;
++    }
++
++    public int getGuiLeft()
++    {
++        return field_147003_i;
++    }
++
++    public int getGuiTop()
++    {
++        return field_147009_r;
++    }
++
++    public int getXSize()
++    {
++        return field_146999_f;
++    }
++
++    public int getYSize()
++    {
++        return field_147000_g;
 +    }
 +
 +    /* ======================================== FORGE END   =====================================*/


### PR DESCRIPTION
Mods that draw over existing `GuiContainer`s need to know the size and location of that gui, in order to draw things in the right location.

Currently [jei_at.cfg](https://github.com/mezz/JustEnoughItems/blob/1.11/src/main/resources/jei_at.cfg#L2-L5), [baubles_at.cfg](https://github.com/mezz/Baubles/blob/master/src/main/resources/baubles_at.cfg), and probably others have ATs for these fields. 
A while ago, Baubles was hard coding the values instead of using an AT but it had issues with potion shift and other things.

This PR adds getters for `GuiContainer` `xSize`, `ySize`, `guiLeft`, and `guiTop`, which will make it easier to write gui overlays correctly.