### PR TITLE
Fix #3432 Hopper and Dropper item moving does not exactly match vanilla

### DIFF
--- a/patches/minecraft/net/minecraft/tileentity/TileEntityHopper.java.patch
+++ b/patches/minecraft/net/minecraft/tileentity/TileEntityHopper.java.patch
@@ -43,3 +43,10 @@
          {
              TileEntity tileentity = p_145893_0_.func_175625_s(blockpos);
  
+@@ -589,4 +599,6 @@
+     {
+         return this.field_145900_a;
+     }
++
++    public long getLastUpdateTime() { return field_190578_g; } // Forge
+ }

--- a/src/main/java/net/minecraftforge/items/VanillaHopperItemHandler.java
+++ b/src/main/java/net/minecraftforge/items/VanillaHopperItemHandler.java
@@ -39,17 +39,31 @@ public class VanillaHopperItemHandler extends InvWrapper
     @Nonnull
     public ItemStack insertItem(int slot, @Nonnull ItemStack stack, boolean simulate)
     {
-        if (stack.func_190926_b())
-            return ItemStack.field_190927_a;
-        if (simulate || !hopper.mayTransfer())
-            return super.insertItem(slot, stack, simulate);
-
-        int curStackSize = stack.func_190916_E();
-        ItemStack itemStack = super.insertItem(slot, stack, false);
-        if (itemStack.func_190926_b() || curStackSize != itemStack.func_190916_E())
+        if (simulate)
         {
-            hopper.setTransferCooldown(8);
+            return super.insertItem(slot, stack, simulate);
         }
-        return itemStack;
+        else
+        {
+            boolean wasEmpty = getInv().func_191420_l();
+
+            int originalStackSize = stack.func_190916_E();
+            stack = super.insertItem(slot, stack, simulate);
+
+            if (wasEmpty && originalStackSize > stack.func_190916_E())
+            {
+                if (!hopper.mayTransfer())
+                {
+                    // This cooldown is always set to 8 in vanilla with one exception:
+                    // Hopper -> Hopper transfer sets this cooldown to 7 when this hopper
+                    // has not been updated as recently as the one pushing items into it.
+                    // This vanilla behavior is preserved by VanillaInventoryCodeHooks#insertStack,
+                    // the cooldown is set properly by the hopper that is pushing items into this one.
+                    hopper.setTransferCooldown(8);
+                }
+            }
+
+            return stack;
+        }
     }
 }

--- a/src/main/java/net/minecraftforge/items/VanillaInventoryCodeHooks.java
+++ b/src/main/java/net/minecraftforge/items/VanillaInventoryCodeHooks.java
@@ -19,27 +19,29 @@
 
 package net.minecraftforge.items;
 
-import com.google.common.base.Predicate;
 import javafx.util.Pair;
 import net.minecraft.block.Block;
 import net.minecraft.block.BlockDropper;
 import net.minecraft.block.BlockHopper;
-import net.minecraft.entity.Entity;
 import net.minecraft.item.ItemStack;
-import net.minecraft.tileentity.*;
-import net.minecraft.util.math.AxisAlignedBB;
-import net.minecraft.util.math.BlockPos;
+import net.minecraft.tileentity.IHopper;
+import net.minecraft.tileentity.TileEntity;
+import net.minecraft.tileentity.TileEntityDispenser;
+import net.minecraft.tileentity.TileEntityHopper;
 import net.minecraft.util.EnumFacing;
+import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.MathHelper;
 import net.minecraft.world.World;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
-import java.util.List;
 
 public class VanillaInventoryCodeHooks
 {
-    //Return: Null if we did nothing {no IItemHandler}, True if we moved an item, False if we moved no items
+    /**
+     * Copied from TileEntityHopper#captureDroppedItems and added capability support
+     * @return Null if we did nothing {no IItemHandler}, True if we moved an item, False if we moved no items
+     */
     public static Boolean extractHook(IHopper dest)
     {
         Pair<IItemHandler, Object> itemHandlerResult = getItemHandler(dest, EnumFacing.UP);
@@ -76,6 +78,9 @@ public class VanillaInventoryCodeHooks
         return false;
     }
 
+    /**
+     * Copied from BlockDropper#dispense and added capability support
+     */
     public static boolean dropperInsertHook(World world, BlockPos pos, TileEntityDispenser dropper, int slot, @Nonnull ItemStack stack)
     {
         EnumFacing enumfacing = world.getBlockState(pos).getValue(BlockDropper.FACING);
@@ -107,6 +112,9 @@ public class VanillaInventoryCodeHooks
         }
     }
 
+    /**
+     * Copied from TileEntityHopper#transferItemsOut and added capability support
+     */
     public static boolean insertHook(TileEntityHopper hopper)
     {
         EnumFacing hopperFacing = BlockHopper.getFacing(hopper.getBlockMetadata());
@@ -156,6 +164,9 @@ public class VanillaInventoryCodeHooks
         return stack;
     }
 
+    /**
+     * Copied from TileEntityHopper#insertStack and added capability support
+     */
     private static ItemStack insertStack(TileEntity source, Object destination, IItemHandler destInventory, ItemStack stack, int slot)
     {
         ItemStack itemstack = destInventory.getStackInSlot(slot);
@@ -261,25 +272,6 @@ public class VanillaInventoryCodeHooks
                     IItemHandler capability = tileentity.getCapability(CapabilityItemHandler.ITEM_HANDLER_CAPABILITY, side);
                     destination = new Pair<IItemHandler, Object>(capability, tileentity);
                 }
-            }
-        }
-
-        if (destination == null)
-        {
-            Predicate<Entity> hasItemCapability = new Predicate<Entity>()
-            {
-                @Override
-                public boolean apply(@Nullable Entity entity)
-                {
-                    return entity != null && entity.hasCapability(CapabilityItemHandler.ITEM_HANDLER_CAPABILITY, side) && entity.isEntityAlive();
-                }
-            };
-            List<Entity> list = worldIn.getEntitiesInAABBexcluding(null, new AxisAlignedBB(x - 0.5D, y - 0.5D, z - 0.5D, x + 0.5D, y + 0.5D, z + 0.5D), hasItemCapability);
-
-            if (!list.isEmpty())
-            {
-                Entity entity = list.get(worldIn.rand.nextInt(list.size()));
-                destination = new Pair<IItemHandler, Object>(entity.getCapability(CapabilityItemHandler.ITEM_HANDLER_CAPABILITY, side), entity);
             }
         }
 


### PR DESCRIPTION
![2016-11-23_00 51 57](https://cloud.githubusercontent.com/assets/916092/20555470/215b3cfa-b117-11e6-9013-a5b769aef64c.png)

Fixes #3432
Makes the forge hooks follow vanilla behavior closely, adding support for capabilities where applicable.
Adds support for hoppering into and out of modded entities with item capabilities.

Breaking changes to `VanillaInventoryCodeHooks`, although I have no idea why anyone would be using it.