### PR TITLE
[1.10] Changed CanUpdate event to AllowUpdate event and created CancelUpdate event

### DIFF
--- a/patches/minecraft/net/minecraft/world/World.java.patch
+++ b/patches/minecraft/net/minecraft/world/World.java.patch
@@ -453,7 +453,8 @@
 +        boolean isForced = getPersistentChunks().containsKey(new net.minecraft.util.math.ChunkPos(i >> 4, j >> 4));
 +        int k = isForced ? 0 : 32;
 +        boolean canUpdate = !p_72866_2_ || this.func_175663_a(i - k, 0, j - k, i + k, 0, j + k, true);
-+        if (!canUpdate) canUpdate = net.minecraftforge.event.ForgeEventFactory.canEntityUpdate(p_72866_1_);
++        if (!canUpdate) canUpdate = net.minecraftforge.event.ForgeEventFactory.allowEntityUpdate(p_72866_1_);
++        else canUpdate = net.minecraftforge.event.ForgeEventFactory.cancelEntityUpdate(p_72866_1_);
  
 -        if (!p_72866_2_ || this.func_175663_a(i - 32, 0, j - 32, i + 32, 0, j + 32, true))
 +        if (canUpdate)

--- a/src/main/java/net/minecraftforge/event/ForgeEventFactory.java
+++ b/src/main/java/net/minecraftforge/event/ForgeEventFactory.java
@@ -381,11 +381,17 @@ public class ForgeEventFactory
         return null;
     }
 
-    public static boolean canEntityUpdate(Entity entity)
+    public static boolean allowEntityUpdate(Entity entity)
     {
-        EntityEvent.CanUpdate event = new EntityEvent.CanUpdate(entity);
+        EntityEvent.AllowUpdate event = new EntityEvent.AllowUpdate(entity);
         MinecraftForge.EVENT_BUS.post(event);
         return event.getCanUpdate();
+    }
+    
+    public static boolean cancelEntityUpdate(Entity entity){
+    	EntityEvent.CancelUpdate event = new EntityEvent.CancelUpdate(entity);
+    	MinecraftForge.EVENT_BUS.post(event);
+    	return event.getCanUpdate();
     }
 
     public static PlaySoundAtEntityEvent onPlaySoundAtEntity(Entity entity, SoundEvent name, SoundCategory category, float volume, float pitch)

--- a/src/main/java/net/minecraftforge/event/entity/EntityEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/EntityEvent.java
@@ -68,11 +68,11 @@ public class EntityEvent extends Event
     }
 
     /**
-     * CanUpdate is fired when an Entity is being created. <br>
+     * AllowUpdate is fired when an Entity is being created. <br>
      * This event is fired whenever vanilla Minecraft determines that an entity<br>
      * cannot update in {@link World#updateEntityWithOptionalForce(net.minecraft.entity.Entity, boolean)} <br>
      * <br>
-     * {@link CanUpdate#canUpdate} contains the boolean value of whether this entity can update.<br>
+     * {@link AllowUpdate#canUpdate} contains the boolean value of whether this entity can update.<br>
      * If the modder decides that this Entity can be updated, they may change canUpdate to true, <br>
      * and the entity with then be updated.<br>
      * <br>
@@ -80,10 +80,10 @@ public class EntityEvent extends Event
      * <br>
      * This event is fired on the {@link MinecraftForge#EVENT_BUS}.<br>
      **/
-    public static class CanUpdate extends EntityEvent
+    public static class AllowUpdate extends EntityEvent
     {
         private boolean canUpdate = false;
-        public CanUpdate(Entity entity)
+        public AllowUpdate(Entity entity)
         {
             super(entity);
         }
@@ -97,6 +97,37 @@ public class EntityEvent extends Event
         {
             this.canUpdate = canUpdate;
         }
+    }
+    
+    /**
+     * CancelUpdate is fired when an Entity is being created. <br>
+     * This event is fired whenever vanilla Minecraft determines that an entity<br>
+     * can update in {@link World#updateEntityWithOptionalForce(net.minecraft.entity.Entity, boolean)} <br>
+     * <br>
+     * {@link CancelUpdate#canUpdate} contains the boolean value of whether this entity can update.<br>
+     * If the modder decides that this Entity should not be updated, they may change canUpdate to false, <br>
+     * and the entity with then be updated.<br>
+     * <br>
+     * This event is not {@link Cancelable}.<br>
+     * <br>
+     * This event is fired on the {@link MinecraftForge#EVENT_BUS}.<br>
+     **/
+    public static class CancelUpdate extends EntityEvent
+    {
+    	private boolean canUpdate = true;
+    	public CancelUpdate(Entity entity)
+    	{
+    		super(entity);
+    	}
+    	
+		public boolean getCanUpdate()
+		{
+			return canUpdate;
+		}
+		public void setCanUpdate(boolean canUpdate)
+		{
+			this.canUpdate = canUpdate;
+		}
     }
     
     /**


### PR DESCRIPTION
Changed CanUpdate to AllowUpdate to properly suit what it does: allow
an update for an entity that should not be updating (according to
Minecraft). Added CancelUpdate event to cancel entity updates.