### PR TITLE
[1.11] Add warning text to loading screen if free memory gets very low

### DIFF
--- a/src/main/java/net/minecraftforge/fml/client/SplashProgress.java
+++ b/src/main/java/net/minecraftforge/fml/client/SplashProgress.java
@@ -465,7 +465,7 @@ public class SplashProgress
                 setColor(barColor);
                 drawBox((barWidth - 2) * (usedMemory) / (maxMemory), barHeight - 2); // Step can sometimes be 0.
                 // progress text
-                String progress = "" + usedMemory + "MB / " + maxMemory + "MB";
+                String progress = "" + usedMemory + " MB / " + maxMemory + " MB";
                 glTranslatef(((float)barWidth - 2) / 2 - fontRenderer.getStringWidth(progress), 2, 0);
                 setColor(fontColor);
                 glScalef(2, 2, 1);

--- a/src/main/java/net/minecraftforge/fml/client/SplashProgress.java
+++ b/src/main/java/net/minecraftforge/fml/client/SplashProgress.java
@@ -860,7 +860,6 @@ public class SplashProgress
             glScalef(2, 2, 1);
 
             List<String> list = Lists.newArrayList(
-                    "Warning: low memory!",
                     String.format("Memory: % 2d%% %03d/%03dMB", usedMemoryPercent, bytesToMb(usedMemory), bytesToMb(maxMemory)),
                     String.format("Allocated: % 2d%% %03dMB", totalMemory * 100L / maxMemory, bytesToMb(totalMemory))
             );
@@ -871,8 +870,9 @@ public class SplashProgress
                 if (!Strings.isNullOrEmpty(s))
                 {
                     int y = 2 + fontRenderer.FONT_HEIGHT * i;
+                    int x = 160 - (fontRenderer.getStringWidth(s) / 2);
                     glEnable(GL_TEXTURE_2D);
-                    fontRenderer.drawString(s, 0, y, 0xff0000);
+                    fontRenderer.drawString(s, x, y, 0x000000);
                     glDisable(GL_TEXTURE_2D);
                 }
             }

--- a/src/main/java/net/minecraftforge/fml/client/SplashProgress.java
+++ b/src/main/java/net/minecraftforge/fml/client/SplashProgress.java
@@ -64,6 +64,7 @@ import net.minecraftforge.fml.common.ProgressManager.ProgressBar;
 import net.minecraftforge.fml.common.asm.FMLSanityChecker;
 
 import org.apache.commons.io.IOUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.Level;
 import org.lwjgl.BufferUtils;
 import org.lwjgl.LWJGLException;
@@ -474,16 +475,27 @@ public class SplashProgress
                 {
                     memoryBarColor = memoryLowColor;
                 }
+                setColor(memoryLowColor);
+                glPushMatrix();
+                glTranslatef((barWidth - 2) * (totalMemory) / (maxMemory) - 2, 0, 0);
+                drawBox(2, barHeight - 2);
+                glPopMatrix();
                 setColor(memoryBarColor);
-                drawBox((barWidth - 2) * (usedMemory) / (maxMemory), barHeight - 2); // Step can sometimes be 0.
+                drawBox((barWidth - 2) * (usedMemory) / (maxMemory), barHeight - 2);
+
                 // progress text
-                String progress = "" + usedMemory + " MB / " + maxMemory + " MB";
+                String progress = getMemoryString(usedMemory) + " / " + getMemoryString(maxMemory);
                 glTranslatef(((float)barWidth - 2) / 2 - fontRenderer.getStringWidth(progress), 2, 0);
                 setColor(fontColor);
                 glScalef(2, 2, 1);
                 glEnable(GL_TEXTURE_2D);
                 fontRenderer.drawString(progress, 0, 0, 0x000000);
                 glPopMatrix();
+            }
+
+            private String getMemoryString(int memory)
+            {
+                return StringUtils.leftPad(Integer.toString(memory), 4, ' ') + " MB";
             }
 
             private void setGL()

--- a/src/main/java/net/minecraftforge/fml/client/SplashProgress.java
+++ b/src/main/java/net/minecraftforge/fml/client/SplashProgress.java
@@ -465,7 +465,7 @@ public class SplashProgress
                 setColor(barColor);
                 drawBox((barWidth - 2) * (usedMemory) / (maxMemory), barHeight - 2); // Step can sometimes be 0.
                 // progress text
-                String progress = "" + usedMemory + " Mb / " + maxMemory + "Mb";
+                String progress = "" + usedMemory + "MB / " + maxMemory + "MB";
                 glTranslatef(((float)barWidth - 2) / 2 - fontRenderer.getStringWidth(progress), 2, 0);
                 setColor(fontColor);
                 glScalef(2, 2, 1);

--- a/src/main/java/net/minecraftforge/fml/client/SplashProgress.java
+++ b/src/main/java/net/minecraftforge/fml/client/SplashProgress.java
@@ -33,7 +33,6 @@ import java.io.PrintWriter;
 import java.lang.Thread.UncaughtExceptionHandler;
 import java.nio.IntBuffer;
 import java.util.Iterator;
-import java.util.List;
 import java.util.Properties;
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.locks.Lock;
@@ -43,8 +42,6 @@ import javax.imageio.ImageIO;
 import javax.imageio.ImageReader;
 import javax.imageio.stream.ImageInputStream;
 
-import com.google.common.base.Strings;
-import com.google.common.collect.Lists;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.FontRenderer;
 import net.minecraft.client.renderer.GlStateManager;
@@ -113,6 +110,8 @@ public class SplashProgress
     private static int memoryGoodColor;
     private static int memoryWarnColor;
     private static int memoryLowColor;
+    private static float memoryColorPercent;
+    private static long memoryColorChangeTime;
     static final Semaphore mutex = new Semaphore(1);
 
     private static String getString(String name, String def)
@@ -454,15 +453,28 @@ public class SplashProgress
                 glTranslatef(1, 1, 0);
                 drawBox(barWidth - 2, barHeight - 2);
                 // slidy part
-                int barColor;
-                if (usedMemoryPercent < 0.75f) {
-                    barColor = memoryGoodColor;
-                } else if (usedMemoryPercent < 0.85f) {
-                    barColor = memoryWarnColor;
-                } else {
-                    barColor = memoryLowColor;
+
+                long time = System.currentTimeMillis();
+                if (usedMemoryPercent > memoryColorPercent || (time - memoryColorChangeTime > 1000))
+                {
+                    memoryColorChangeTime = time;
+                    memoryColorPercent = usedMemoryPercent;
                 }
-                setColor(barColor);
+                
+                int memoryBarColor;
+                if (memoryColorPercent < 0.75f)
+                {
+                    memoryBarColor = memoryGoodColor;
+                }
+                else if (memoryColorPercent < 0.85f)
+                {
+                    memoryBarColor = memoryWarnColor;
+                }
+                else
+                {
+                    memoryBarColor = memoryLowColor;
+                }
+                setColor(memoryBarColor);
                 drawBox((barWidth - 2) * (usedMemory) / (maxMemory), barHeight - 2); // Step can sometimes be 0.
                 // progress text
                 String progress = "" + usedMemory + " MB / " + maxMemory + " MB";


### PR DESCRIPTION
I've been seeing reports from a lot of people stalling on the loading screen in 1.10 because they don't have enough RAM allocated.
~~This 1.11 PR adds a basic warning if the memory usage goes past a threshold (default is arbitrarily set at 85%, it's configurable). Once the warning threshold has been hit, the warning stays on the screen for the rest of the loading time.~~

~~[low-memory-warning](https://cloud.githubusercontent.com/assets/916092/20586878/67b42b7a-b1bd-11e6-9dfc-92d36fa1b5e1.png)~~

EDIT: This PR has changed in style a lot. See images further down in the comments: https://github.com/MinecraftForge/MinecraftForge/pull/3447#issuecomment-265674809
