### PR TITLE
Allow custom parsing of EntitySelector [1.11]

### DIFF
--- a/patches/minecraft/net/minecraft/command/EntitySelector.java.patch
+++ b/patches/minecraft/net/minecraft/command/EntitySelector.java.patch
@@ -1,6 +1,18 @@
 --- ../src-base/minecraft/net/minecraft/command/EntitySelector.java
 +++ ../src-work/minecraft/net/minecraft/command/EntitySelector.java
-@@ -148,6 +148,7 @@
+@@ -116,6 +116,11 @@
+ 
+     public static <T extends Entity> List<T> func_179656_b(ICommandSender p_179656_0_, String p_179656_1_, Class <? extends T > p_179656_2_) throws CommandException
+     {
++        return net.minecraftforge.common.command.SelectorHandlerManager.getHandler().matchEntities(p_179656_0_, p_179656_1_, p_179656_2_);
++    }
++
++    public static <T extends Entity> List<T> matchEntitiesDefault(ICommandSender p_179656_0_, String p_179656_1_, Class <? extends T > p_179656_2_) throws CommandException
++    {
+         Matcher matcher = field_82389_a.matcher(p_179656_1_);
+ 
+         if (matcher.matches() && p_179656_0_.func_70003_b(1, "@"))
+@@ -148,6 +153,7 @@
                          list2.addAll(func_184951_f(map));
                          list2.addAll(func_180698_a(map, vec3d));
                          list2.addAll(func_179662_g(map));
@@ -8,3 +20,27 @@
                          list1.addAll(func_179660_a(map, p_179656_2_, list2, s, world, blockpos));
                      }
                  }
+@@ -722,6 +728,11 @@
+ 
+     public static boolean func_82377_a(String p_82377_0_) throws CommandException
+     {
++        return net.minecraftforge.common.command.SelectorHandlerManager.getHandler().matchesMultiplePlayers(p_82377_0_);
++    }
++
++    public static boolean matchesMultiplePlayersDefault(String p_82377_0_) throws CommandException
++    {
+         Matcher matcher = field_82389_a.matcher(p_82377_0_);
+ 
+         if (!matcher.matches())
+@@ -739,6 +750,11 @@
+ 
+     public static boolean func_82378_b(String p_82378_0_)
+     {
++        return net.minecraftforge.common.command.SelectorHandlerManager.getHandler().hasArguments(p_82378_0_);
++    }
++
++    public static boolean hasArgumentsDefault(String p_82378_0_)
++    {
+         return field_82389_a.matcher(p_82378_0_).matches();
+     }
+ 

--- a/src/main/java/net/minecraftforge/common/command/SelectorHandler.java
+++ b/src/main/java/net/minecraftforge/common/command/SelectorHandler.java
@@ -1,0 +1,54 @@
+/*
+ * Minecraft Forge
+ * Copyright (c) 2016.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation version 2.1
+ * of the License.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+package net.minecraftforge.common.command;
+
+import net.minecraft.command.CommandException;
+import net.minecraft.command.EntitySelector;
+import net.minecraft.command.ICommandSender;
+import net.minecraft.entity.Entity;
+
+import java.util.List;
+
+/**
+ * A proxy for {@link EntitySelector} methods. Can be used to customize the parsing behavior<br>
+ * <b>Note:</b>  You should generally override all three methods to produce consistent results<br>
+ * <b>Note:</b> These methods are called on both client and server<br>
+ * <b>Note:</b>  For compatibility reasons, you should not break the key=value pattern
+ */
+public class SelectorHandler
+{
+    public <T extends Entity> List<T> matchEntities(ICommandSender sender, String token, Class<? extends T> targetClass) throws CommandException
+    {
+        return EntitySelector.matchEntitiesDefault(sender, token, targetClass);
+    }
+
+    /**
+     * This should raise an {@link net.minecraftforge.event.EntitySelectorEvent EntitySelectorEvent}
+     */
+    public boolean matchesMultiplePlayers(String selectorStr) throws CommandException
+    {
+        return EntitySelector.matchesMultiplePlayersDefault(selectorStr);
+    }
+
+    public boolean hasArguments(String selectorStr)
+    {
+        return EntitySelector.hasArgumentsDefault(selectorStr);
+    }
+}

--- a/src/main/java/net/minecraftforge/common/command/SelectorHandlerManager.java
+++ b/src/main/java/net/minecraftforge/common/command/SelectorHandlerManager.java
@@ -1,0 +1,72 @@
+/*
+ * Minecraft Forge
+ * Copyright (c) 2016.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation version 2.1
+ * of the License.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+package net.minecraftforge.common.command;
+
+import net.minecraftforge.fml.common.FMLLog;
+import net.minecraftforge.fml.common.Loader;
+
+public class SelectorHandlerManager
+{
+    private SelectorHandlerManager()
+    {
+    }
+
+    private static SelectorHandler handler = new SelectorHandler();
+    private static boolean isCustom = false;
+    private static String modifyingMod = "Minecraft";
+
+    /**
+     * Allows you to override the behavior of EnitySelector by setting this handler to a custom implementation<br>
+     * This overrides any previous handlers set<br>
+     * This method must be called only during mod loading
+     * Always use {@link net.minecraftforge.event.EntitySelectorEvent EntitySelectorEvent} if possible
+     */
+    public static void setHandler(SelectorHandler handler)
+    {
+        final String newModifyingMod = Loader.instance().activeModContainer().getName();
+
+        FMLLog.info("SelectorHandler is being overridden by '" + newModifyingMod + "'");
+
+        if (isCustom)
+            FMLLog.bigWarning("SelectorHandler was already overridden by '" + modifyingMod + "'");
+
+        isCustom = true;
+        modifyingMod = newModifyingMod;
+        SelectorHandlerManager.handler = handler;
+    }
+
+    public static SelectorHandler getHandler()
+    {
+        return handler;
+    }
+
+    public static boolean isCustom()
+    {
+        return isCustom;
+    }
+
+    /**
+     * @return "Minecraft" if not custom, and name of modifying mod otherwise
+     */
+    public static String getModifyingMod()
+    {
+        return modifyingMod;
+    }
+}

--- a/src/main/resources/forge.exc
+++ b/src/main/resources/forge.exc
@@ -55,3 +55,7 @@ net/minecraft/world/storage/loot/LootEntry.<init>(II[Lnet/minecraft/world/storag
 net/minecraft/world/storage/loot/LootEntryItem.<init>(Lnet/minecraft/item/Item;II[Lnet/minecraft/world/storage/loot/functions/LootFunction;[Lnet/minecraft/world/storage/loot/conditions/LootCondition;Ljava/lang/String;)V=|p_i46644_1_,p_i46644_2_,p_i46644_3_,p_i46644_4_,p_i46644_5_,entryName
 net/minecraft/world/storage/loot/LootEntryTable.<init>(Lnet/minecraft/util/ResourceLocation;II[Lnet/minecraft/world/storage/loot/conditions/LootCondition;Ljava/lang/String;)V=|p_i46639_1_,p_i46639_2_,p_i46639_3_,p_i46639_4_,entryName
 net/minecraft/world/storage/loot/LootEntryEmpty.<init>(II[Lnet/minecraft/world/storage/loot/conditions/LootCondition;Ljava/lang/String;)V=|p_i46645_1_,p_i46645_2_,p_i46645_3_,entryName
+
+net/minecraft/command/EntitySelector.matchEntitiesDefault(Lnet/minecraft/command/ICommandSender;Ljava/lang/String;Ljava/lang/Class;)Ljava/util/List;=|p_179656_0_,p_179656_1_,p_179656_2_
+net/minecraft/command/EntitySelector.matchesMultiplePlayersDefault(Ljava/lang/String;)Z=|p_82377_0_
+net/minecraft/command/EntitySelector.hasArgumentsDefault(Ljava/lang/String;)Z=|p_82378_0_


### PR DESCRIPTION
1.11 version of #3353

One minor change: `SelectorHandler.matchEntities(...)` and `.matchesMultiplePlayers(...)` now throw `CommandException` since Vanilla now does.