### PR TITLE
[1.11] Add canApplyAtEnchantmentTable to Item

### DIFF
--- a/patches/minecraft/net/minecraft/client/gui/GuiEnchantment.java.patch
+++ b/patches/minecraft/net/minecraft/client/gui/GuiEnchantment.java.patch
@@ -9,3 +9,22 @@
                  {
                      this.func_73729_b(i1, j + 14 + 19 * l, 0, 185, 108, 19);
                      this.func_73729_b(i1 + 1, j + 15 + 19 * l, 16 * l, 239, 16, 16);
+@@ -217,11 +217,16 @@
+             int l = this.field_147075_G.field_185002_i[j];
+             int i1 = j + 1;
+ 
+-            if (this.func_146978_c(60, 14 + 19 * j, 108, 17, p_73863_1_, p_73863_2_) && k > 0 && l >= 0 && enchantment != null)
++            if (this.func_146978_c(60, 14 + 19 * j, 108, 17, p_73863_1_, p_73863_2_) && k > 0)
+             {
+                 List<String> list = Lists.<String>newArrayList();
+-                list.add("" + TextFormatting.WHITE + TextFormatting.ITALIC + I18n.func_135052_a("container.enchant.clue", new Object[] {enchantment.func_77316_c(l)}));
++                list.add("" + TextFormatting.WHITE + TextFormatting.ITALIC + I18n.func_135052_a("container.enchant.clue", new Object[] {enchantment == null ? "" : enchantment.func_77316_c(l)}));
+ 
++                if(enchantment == null)
++                {
++                    list.add("");
++                    list.add(TextFormatting.RED + I18n.func_135052_a("forge.container.enchant.enchantabilityTooLow"));
++                } else
+                 if (!flag)
+                 {
+                     list.add("");

--- a/patches/minecraft/net/minecraft/client/gui/GuiEnchantment.java.patch
+++ b/patches/minecraft/net/minecraft/client/gui/GuiEnchantment.java.patch
@@ -1,0 +1,11 @@
+--- ../src-base/minecraft/net/minecraft/client/gui/GuiEnchantment.java
++++ ../src-work/minecraft/net/minecraft/client/gui/GuiEnchantment.java
+@@ -171,7 +171,7 @@
+                 FontRenderer fontrenderer = this.field_146297_k.field_71464_q;
+                 int i2 = 6839882;
+ 
+-                if ((k < l + 1 || this.field_146297_k.field_71439_g.field_71068_ca < k1) && !this.field_146297_k.field_71439_g.field_71075_bZ.field_75098_d)
++                if (((k < l + 1 || this.field_146297_k.field_71439_g.field_71068_ca < k1) && !this.field_146297_k.field_71439_g.field_71075_bZ.field_75098_d) || this.field_147075_G.field_185001_h[l] == -1) // Forge: render buttons as disabled when enchantable but enchantability not met on lower levels
+                 {
+                     this.func_73729_b(i1, j + 14 + 19 * l, 0, 185, 108, 19);
+                     this.func_73729_b(i1 + 1, j + 15 + 19 * l, 16 * l, 239, 16, 16);

--- a/patches/minecraft/net/minecraft/client/gui/GuiEnchantment.java.patch
+++ b/patches/minecraft/net/minecraft/client/gui/GuiEnchantment.java.patch
@@ -9,7 +9,7 @@
                  {
                      this.func_73729_b(i1, j + 14 + 19 * l, 0, 185, 108, 19);
                      this.func_73729_b(i1 + 1, j + 15 + 19 * l, 16 * l, 239, 16, 16);
-@@ -217,11 +217,16 @@
+@@ -217,11 +217,12 @@
              int l = this.field_147075_G.field_185002_i[j];
              int i1 = j + 1;
  
@@ -20,11 +20,7 @@
 -                list.add("" + TextFormatting.WHITE + TextFormatting.ITALIC + I18n.func_135052_a("container.enchant.clue", new Object[] {enchantment.func_77316_c(l)}));
 +                list.add("" + TextFormatting.WHITE + TextFormatting.ITALIC + I18n.func_135052_a("container.enchant.clue", new Object[] {enchantment == null ? "" : enchantment.func_77316_c(l)}));
  
-+                if(enchantment == null)
-+                {
-+                    list.add("");
-+                    list.add(TextFormatting.RED + I18n.func_135052_a("forge.container.enchant.enchantabilityTooLow"));
-+                } else
++                if(enchantment == null) java.util.Collections.addAll(list, "", TextFormatting.RED + I18n.func_135052_a("forge.container.enchant.limitedEnchantability")); else
                  if (!flag)
                  {
                      list.add("");

--- a/patches/minecraft/net/minecraft/enchantment/Enchantment.java.patch
+++ b/patches/minecraft/net/minecraft/enchantment/Enchantment.java.patch
@@ -33,7 +33,7 @@
 +     */
 +    public boolean canApplyAtEnchantingTable(ItemStack stack)
 +    {
-+        return this.field_77351_y.func_77557_a(stack.func_77973_b());
++        return stack.func_77973_b().canApplyAtEnchantingTable(stack, this);
 +    }
 +
 +    /**

--- a/patches/minecraft/net/minecraft/item/Item.java.patch
+++ b/patches/minecraft/net/minecraft/item/Item.java.patch
@@ -60,7 +60,7 @@
          return p_77621_1_.func_147447_a(vec3d, vec3d1, p_77621_3_, !p_77621_3_, false);
      }
  
-@@ -433,11 +440,600 @@
+@@ -433,11 +440,613 @@
          return false;
      }
  
@@ -585,6 +585,19 @@
 +    }
 +
 +    /**
++     * Checks whether an item can be enchanted with a certain enchantment. This applies specifically to enchanting an item in the enchanting table and is called when retrieving the list of possible enchantments for an item.
++     * Enchantments may additionally (or exclusively) be doing their own checks in {@link net.minecraft.enchantment.Enchantment#canApplyAtEnchantingTable(ItemStack)}; check the individual implementation for reference.
++     * By default this will check if the enchantment type is valid for this item type.
++     * @param stack the item stack to be enchanted
++     * @param enchantment the enchantment to be applied
++     * @return true if the enchantment can be applied to this item
++     */
++    public boolean canApplyAtEnchantingTable(ItemStack stack, net.minecraft.enchantment.Enchantment enchantment)
++    {
++        return enchantment.field_77351_y.func_77557_a(stack.func_77973_b());
++    }
++
++    /**
 +     * Whether this Item can be used as a payment to activate the vanilla beacon.
 +     * @param stack the ItemStack
 +     * @return true if this Item can be used
@@ -661,7 +674,7 @@
      public static void func_150900_l()
      {
          func_179214_a(Blocks.field_150350_a, new ItemAir(Blocks.field_150350_a));
-@@ -971,6 +1567,8 @@
+@@ -971,6 +1580,8 @@
          private final float field_78010_h;
          private final float field_78011_i;
          private final int field_78008_j;
@@ -670,7 +683,7 @@
  
          private ToolMaterial(int p_i1874_3_, int p_i1874_4_, float p_i1874_5_, float p_i1874_6_, int p_i1874_7_)
          {
-@@ -1006,9 +1604,26 @@
+@@ -1006,9 +1617,26 @@
              return this.field_78008_j;
          }
  

--- a/src/main/resources/assets/forge/lang/en_US.lang
+++ b/src/main/resources/assets/forge/lang/en_US.lang
@@ -183,3 +183,5 @@ fml.button.visitjavadownloads=Oracle Java SE Downloads
 fml.button.continue=Continue
 fml.button.open.mods.folder=Open Mods Folder
 fml.button.open.file=Open %s
+
+forge.container.enchant.enchantabilityTooLow=Enchantability Low

--- a/src/main/resources/assets/forge/lang/en_US.lang
+++ b/src/main/resources/assets/forge/lang/en_US.lang
@@ -184,4 +184,4 @@ fml.button.continue=Continue
 fml.button.open.mods.folder=Open Mods Folder
 fml.button.open.file=Open %s
 
-forge.container.enchant.enchantabilityTooLow=Enchantability Low
+forge.container.enchant.limitedEnchantability=Limited Enchantability

--- a/src/test/java/net/minecraftforge/test/CanApplyAtEnchantingTableTest.java
+++ b/src/test/java/net/minecraftforge/test/CanApplyAtEnchantingTableTest.java
@@ -1,0 +1,44 @@
+package net.minecraftforge.test;
+
+import net.minecraft.enchantment.Enchantment;
+import net.minecraft.init.Enchantments;
+import net.minecraft.item.Item;
+import net.minecraft.item.ItemStack;
+import net.minecraftforge.fml.common.Mod;
+import net.minecraftforge.fml.common.event.FMLPreInitializationEvent;
+import net.minecraftforge.fml.common.registry.GameRegistry;
+
+@Mod(modid="canapplyatenchantingtabletest", name="CanApplyAtEnchantingTableTest", version="0.0.0")
+public class CanApplyAtEnchantingTableTest
+{
+	public static final boolean ENABLE = false;
+
+	public static final Item testItem = new Item()
+	{
+		public boolean isItemTool(ItemStack stack)
+		{
+			return true;
+		}
+
+		@Override
+		public int getItemEnchantability()
+		{
+			return 30;
+		}
+
+		@Override
+		public boolean canApplyAtEnchantingTable(ItemStack stack, Enchantment enchantment)
+		{
+			return super.canApplyAtEnchantingTable(stack, enchantment) || enchantment == Enchantments.FORTUNE;
+		}
+	};
+
+	@Mod.EventHandler
+	public void preInit(FMLPreInitializationEvent event)
+	{
+		if(ENABLE)
+		{
+			GameRegistry.register(testItem.setRegistryName("test_item").setMaxStackSize(1));
+		}
+	}
+}

--- a/src/test/java/net/minecraftforge/test/CanApplyAtEnchantingTableTest.java
+++ b/src/test/java/net/minecraftforge/test/CanApplyAtEnchantingTableTest.java
@@ -11,34 +11,34 @@ import net.minecraftforge.fml.common.registry.GameRegistry;
 @Mod(modid="canapplyatenchantingtabletest", name="CanApplyAtEnchantingTableTest", version="0.0.0")
 public class CanApplyAtEnchantingTableTest
 {
-	public static final boolean ENABLE = true;
+    public static final boolean ENABLE = true;
 
-	public static final Item testItem = new Item()
-	{
-		public boolean isItemTool(ItemStack stack)
-		{
-			return true;
-		}
+    public static final Item testItem = new Item()
+    {
+        public boolean isItemTool(ItemStack stack)
+        {
+            return true;
+        }
 
-		@Override
-		public int getItemEnchantability()
-		{
-			return 30;
-		}
+        @Override
+        public int getItemEnchantability()
+        {
+            return 30;
+        }
 
-		@Override
-		public boolean canApplyAtEnchantingTable(ItemStack stack, Enchantment enchantment)
-		{
-			return super.canApplyAtEnchantingTable(stack, enchantment) || enchantment == Enchantments.FORTUNE;
-		}
-	};
+        @Override
+        public boolean canApplyAtEnchantingTable(ItemStack stack, Enchantment enchantment)
+        {
+            return super.canApplyAtEnchantingTable(stack, enchantment) || enchantment == Enchantments.FORTUNE;
+        }
+    };
 
-	@Mod.EventHandler
-	public void preInit(FMLPreInitializationEvent event)
-	{
-		if(ENABLE)
-		{
-			GameRegistry.register(testItem.setRegistryName("test_item").setUnlocalizedName("FortuneEnchantableOnly").setMaxStackSize(1));
-		}
-	}
+    @Mod.EventHandler
+    public void preInit(FMLPreInitializationEvent event)
+    {
+        if(ENABLE)
+        {
+            GameRegistry.register(testItem.setRegistryName("test_item").setUnlocalizedName("FortuneEnchantableOnly").setMaxStackSize(1));
+        }
+    }
 }

--- a/src/test/java/net/minecraftforge/test/CanApplyAtEnchantingTableTest.java
+++ b/src/test/java/net/minecraftforge/test/CanApplyAtEnchantingTableTest.java
@@ -11,7 +11,7 @@ import net.minecraftforge.fml.common.registry.GameRegistry;
 @Mod(modid="canapplyatenchantingtabletest", name="CanApplyAtEnchantingTableTest", version="0.0.0")
 public class CanApplyAtEnchantingTableTest
 {
-	public static final boolean ENABLE = false;
+	public static final boolean ENABLE = true;
 
 	public static final Item testItem = new Item()
 	{
@@ -38,7 +38,7 @@ public class CanApplyAtEnchantingTableTest
 	{
 		if(ENABLE)
 		{
-			GameRegistry.register(testItem.setRegistryName("test_item").setMaxStackSize(1));
+			GameRegistry.register(testItem.setRegistryName("test_item").setUnlocalizedName("FortuneEnchantableOnly").setMaxStackSize(1));
 		}
 	}
 }


### PR DESCRIPTION
Ported to 1.11 from #3248

This adds a canApplyAtEnchantmentTable function to the Item class, allowing increased control of what enchantments can be put on an item over Vanilla's hard-coded item type checks.

Prior, this was all hard-coded in EnumEnchantmentType, and the only way to make your item receive certain enchantments was to extend a specific Item class (such as ItemTool, ItemSword, ItemBow), which does not cover all cases.

Specifically in my case, to explain in real-world terms, the new Sieve Meshes coming to Ex Nihilo & Ex Compressum, which are meant to be enchantable for increased output or speed. While it would be possible to extend ItemTool for the mesh item and make it accept the Fortune/Efficiency enchantment that way, it would also allow unwanted enchantments such as Silk Touch to be applied and pollute the mesh's item class with methods from ItemTool which are not meant to be implemented for this type of item.

The default behaviour of checking the enchantment type remains unchanged.