### PR TITLE
Improve BiomeDictionary's interaction with the new registries

### DIFF
--- a/src/main/java/net/minecraftforge/common/BiomeDictionary.java
+++ b/src/main/java/net/minecraftforge/common/BiomeDictionary.java
@@ -21,6 +21,8 @@ package net.minecraftforge.common;
 
 import java.util.*;
 
+import javax.annotation.Nonnull;
+
 import net.minecraft.init.Biomes;
 import net.minecraft.init.Blocks;
 import net.minecraft.util.ResourceLocation;
@@ -188,8 +190,9 @@ public class BiomeDictionary
      * Returns a list of biomes registered with a specific type
      *
      * @param type the Type to look for
-     * @return a list of biomes of the specified type, null if there are none
+     * @return a list of biomes of the specified type
      */
+    @Nonnull
     public static Set<Biome> getBiomesForType(Type type)
     {
         return type.biomesUn;
@@ -199,8 +202,9 @@ public class BiomeDictionary
      * Gets a list of Types that a specific biome is registered with
      *
      * @param biome the biome to check
-     * @return the list of types, null if there are none
+     * @return the list of types
      */
+    @Nonnull
     public static Set<Type> getTypesForBiome(Biome biome)
     {
         checkRegistration(biome);

--- a/src/main/java/net/minecraftforge/common/BiomeDictionary.java
+++ b/src/main/java/net/minecraftforge/common/BiomeDictionary.java
@@ -137,7 +137,7 @@ public class BiomeDictionary
         }
     }
 
-    private static Map<ResourceLocation, BiomeInfo> biomeInfoMap = new HashMap<ResourceLocation, BiomeInfo>();
+    private static final Map<ResourceLocation, BiomeInfo> biomeInfoMap = new HashMap<ResourceLocation, BiomeInfo>();
 
     private static class BiomeInfo
     {

--- a/src/main/java/net/minecraftforge/common/BiomeDictionary.java
+++ b/src/main/java/net/minecraftforge/common/BiomeDictionary.java
@@ -368,7 +368,7 @@ public class BiomeDictionary
     {
         if (!hasAnyType(biome))
         {
-            FMLLog.warning("No types have been added to Biome %s, types will be assigned on a best-effort guess.");
+            FMLLog.warning("No types have been added to Biome %s, types will be assigned on a best-effort guess.", biome.getRegistryName());
             makeBestGuess(biome);
         }
     }

--- a/src/main/java/net/minecraftforge/common/BiomeDictionary.java
+++ b/src/main/java/net/minecraftforge/common/BiomeDictionary.java
@@ -180,10 +180,7 @@ public class BiomeDictionary
         }
         else
         {
-            for (Type type : subTags)
-            {
-                getBiomeInfo(biome).types.add(type);
-            }
+            getBiomeInfo(biome).types.addAll(subTags);
         }
     }
 

--- a/src/main/java/net/minecraftforge/common/BiomeDictionary.java
+++ b/src/main/java/net/minecraftforge/common/BiomeDictionary.java
@@ -356,7 +356,7 @@ public class BiomeDictionary
     }
 
     /**
-     * Ensure that the given biome has been tagged with at least one type
+     * Ensure that at least one type has been added to the given biome.
      */
     static void ensureHasTypes(Biome biome)
     {

--- a/src/main/java/net/minecraftforge/common/BiomeDictionary.java
+++ b/src/main/java/net/minecraftforge/common/BiomeDictionary.java
@@ -38,6 +38,9 @@ public class BiomeDictionary
 {
     public static final class Type
     {
+
+        private static final Map<String, Type> byName = new HashMap<String, Type>();
+
         /*Temperature-based tags. Specifying neither implies a biome is temperate*/
         public static final Type HOT = new Type("HOT");
         public static final Type COLD = new Type("COLD");
@@ -84,8 +87,6 @@ public class BiomeDictionary
         public static final Type WASTELAND = new Type("WASTELAND");
         public static final Type BEACH = new Type("BEACH");
 
-        private static final Map<String, Type> byName = new HashMap<String, Type>();
-
         private final String name;
         private final List<Type> subTypes;
         private final Set<Biome> biomes = new HashSet<Biome>();
@@ -108,6 +109,11 @@ public class BiomeDictionary
          * Gets the name for this type.
          */
         public String getName()
+        {
+            return name;
+        }
+
+        public String toString()
         {
             return name;
         }

--- a/src/main/java/net/minecraftforge/common/BiomeDictionary.java
+++ b/src/main/java/net/minecraftforge/common/BiomeDictionary.java
@@ -223,10 +223,10 @@ public class BiomeDictionary
     }
 
     /**
-     * Checks if any types have been added to the given biome.
+     * Checks if any type has been added to the given biome.
      *
      */
-    public static boolean hasTypes(Biome biome)
+    public static boolean hasAnyType(Biome biome)
     {
         return !getBiomeInfo(biome).types.isEmpty();
     }
@@ -360,7 +360,7 @@ public class BiomeDictionary
      */
     static void ensureHasTypes(Biome biome)
     {
-        if (!hasTypes(biome))
+        if (!hasAnyType(biome))
         {
             FMLLog.warning("No types have been added to Biome %s, types will be assigned on a best-effort guess.");
             makeBestGuess(biome);

--- a/src/main/java/net/minecraftforge/common/BiomeDictionary.java
+++ b/src/main/java/net/minecraftforge/common/BiomeDictionary.java
@@ -268,7 +268,7 @@ public class BiomeDictionary
      */
     public static boolean isBiomeRegistered(Biome biome)
     {
-        return biomeInfoMap.containsKey(Biome.REGISTRY.getNameForObject(biome));
+        return biomeInfoMap.containsKey(ForgeRegistries.BIOMES.getKey(biome));
     }
 
     public static void registerAllBiomes()
@@ -412,7 +412,7 @@ public class BiomeDictionary
     //Internal implementation
     private static BiomeInfo getBiomeInfo(Biome biome)
     {
-        return biomeInfoMap.get(Biome.REGISTRY.getNameForObject(biome));
+        return biomeInfoMap.get(ForgeRegistries.BIOMES.getKey(biome));
     }
 
     private static void checkRegistration(Biome biome)

--- a/src/main/java/net/minecraftforge/common/BiomeDictionary.java
+++ b/src/main/java/net/minecraftforge/common/BiomeDictionary.java
@@ -164,7 +164,7 @@ public class BiomeDictionary
      * @param biome the biome to be registered
      * @param types the types to register the biome as
      */
-    public static void registerBiomeType(Biome biome, Type... types)
+    public static void register(Biome biome, Type... types)
     {
         Preconditions.checkArgument(ForgeRegistries.BIOMES.containsValue(biome), "Cannot register biome types for unregistered biome");
 
@@ -175,7 +175,7 @@ public class BiomeDictionary
             type.biomes.add(biome);
         }
 
-        if (!isBiomeRegistered(biome))
+        if (!isRegistered(biome))
         {
             ResourceLocation location = ForgeRegistries.BIOMES.getKey(biome);
             biomeInfoMap.put(location, new BiomeInfo(subTags));
@@ -193,7 +193,7 @@ public class BiomeDictionary
      * @return a list of biomes of the specified type
      */
     @Nonnull
-    public static Set<Biome> getBiomesForType(Type type)
+    public static Set<Biome> getBiomes(Type type)
     {
         return type.biomesUn;
     }
@@ -205,7 +205,7 @@ public class BiomeDictionary
      * @return the list of types
      */
     @Nonnull
-    public static Set<Type> getTypesForBiome(Biome biome)
+    public static Set<Type> getTypes(Biome biome)
     {
         ensureRegistered(biome);
         return getBiomeInfo(biome).typesUn;
@@ -218,12 +218,12 @@ public class BiomeDictionary
      * @param biomeB the second biome
      * @return returns true if a common type is found, false otherwise
      */
-    public static boolean areBiomesEquivalent(Biome biomeA, Biome biomeB)
+    public static boolean areSimilar(Biome biomeA, Biome biomeB)
     {
         ensureRegistered(biomeA);
         ensureRegistered(biomeB);
 
-        for (Type type : getTypesForBiome(biomeA))
+        for (Type type : getTypes(biomeA))
         {
             if (containsType(getBiomeInfo(biomeB), type))
             {
@@ -241,7 +241,7 @@ public class BiomeDictionary
      * @param type  the type to check for
      * @return returns true if the biome is registered as being of type type, false otherwise
      */
-    public static boolean isBiomeOfType(Biome biome, Type type)
+    public static boolean isOfType(Biome biome, Type type)
     {
         ensureRegistered(biome);
         return containsType(getBiomeInfo(biome), type);
@@ -253,7 +253,7 @@ public class BiomeDictionary
      * @param biome the biome to consider
      * @return returns true if the biome has been registered, false otherwise
      */
-    public static boolean isBiomeRegistered(Biome biome)
+    public static boolean isRegistered(Biome biome)
     {
         return biomeInfoMap.containsKey(ForgeRegistries.BIOMES.getKey(biome));
     }
@@ -271,15 +271,15 @@ public class BiomeDictionary
         {
             if (biome.isHighHumidity() && biome.getTemperature() >= 0.9F)
             {
-                BiomeDictionary.registerBiomeType(biome, JUNGLE);
+                BiomeDictionary.register(biome, JUNGLE);
             }
             else if (!biome.isHighHumidity())
             {
-                BiomeDictionary.registerBiomeType(biome, FOREST);
+                BiomeDictionary.register(biome, FOREST);
 
                 if (biome.getTemperature() <= 0.2f)
                 {
-                    BiomeDictionary.registerBiomeType(biome, CONIFEROUS);
+                    BiomeDictionary.register(biome, CONIFEROUS);
                 }
             }
         }
@@ -287,87 +287,87 @@ public class BiomeDictionary
         {
             if (!biome.isHighHumidity() || biome.getBaseHeight() >= 0.0F)
             {
-                BiomeDictionary.registerBiomeType(biome, PLAINS);
+                BiomeDictionary.register(biome, PLAINS);
             }
         }
 
         if (biome.getRainfall() > 0.85f)
         {
-            BiomeDictionary.registerBiomeType(biome, WET);
+            BiomeDictionary.register(biome, WET);
         }
 
         if (biome.getRainfall() < 0.15f)
         {
-            BiomeDictionary.registerBiomeType(biome, DRY);
+            BiomeDictionary.register(biome, DRY);
         }
 
         if (biome.getTemperature() > 0.85f)
         {
-            BiomeDictionary.registerBiomeType(biome, HOT);
+            BiomeDictionary.register(biome, HOT);
         }
 
         if (biome.getTemperature() < 0.15f)
         {
-            BiomeDictionary.registerBiomeType(biome, COLD);
+            BiomeDictionary.register(biome, COLD);
         }
 
         if (biome.theBiomeDecorator.treesPerChunk > 0 && biome.theBiomeDecorator.treesPerChunk < 3)
         {
-            BiomeDictionary.registerBiomeType(biome, SPARSE);
+            BiomeDictionary.register(biome, SPARSE);
         }
         else if (biome.theBiomeDecorator.treesPerChunk >= 10)
         {
-            BiomeDictionary.registerBiomeType(biome, DENSE);
+            BiomeDictionary.register(biome, DENSE);
         }
 
         if (biome.isHighHumidity() && biome.getBaseHeight() < 0.0F && (biome.getHeightVariation() <= 0.3F && biome.getHeightVariation() >= 0.0F))
         {
-            BiomeDictionary.registerBiomeType(biome, SWAMP);
+            BiomeDictionary.register(biome, SWAMP);
         }
 
         if (biome.getBaseHeight() <= -0.5F)
         {
             if (biome.getHeightVariation() == 0.0F)
             {
-                BiomeDictionary.registerBiomeType(biome, RIVER);
+                BiomeDictionary.register(biome, RIVER);
             }
             else
             {
-                BiomeDictionary.registerBiomeType(biome, OCEAN);
+                BiomeDictionary.register(biome, OCEAN);
             }
         }
 
         if (biome.getHeightVariation() >= 0.4F && biome.getHeightVariation() < 1.5F)
         {
-            BiomeDictionary.registerBiomeType(biome, HILLS);
+            BiomeDictionary.register(biome, HILLS);
         }
 
         if (biome.getHeightVariation() >= 1.5F)
         {
-            BiomeDictionary.registerBiomeType(biome, MOUNTAIN);
+            BiomeDictionary.register(biome, MOUNTAIN);
         }
 
         if (biome.getEnableSnow())
         {
-            BiomeDictionary.registerBiomeType(biome, SNOWY);
+            BiomeDictionary.register(biome, SNOWY);
         }
 
         if (biome.topBlock != Blocks.SAND && biome.getTemperature() >= 1.0f && biome.getRainfall() < 0.2f)
         {
-            BiomeDictionary.registerBiomeType(biome, SAVANNA);
+            BiomeDictionary.register(biome, SAVANNA);
         }
 
         if (biome.topBlock == Blocks.SAND)
         {
-            BiomeDictionary.registerBiomeType(biome, SANDY);
+            BiomeDictionary.register(biome, SANDY);
         }
         else if (biome.topBlock == Blocks.MYCELIUM)
         {
-            BiomeDictionary.registerBiomeType(biome, MUSHROOM);
+            BiomeDictionary.register(biome, MUSHROOM);
         }
         if (biome.fillerBlock == Blocks.HARDENED_CLAY)
         {
-            BiomeDictionary.registerBiomeType(biome, MESA);
+            BiomeDictionary.register(biome, MESA);
         }
     }
 
@@ -383,7 +383,7 @@ public class BiomeDictionary
      */
     static void ensureRegistered(Biome biome)
     {
-        if (!isBiomeRegistered(biome))
+        if (!isRegistered(biome))
         {
             FMLLog.warning("No types registered for Biome %s, types will be assigned on a best-effort guess.");
             makeBestGuess(biome);
@@ -423,45 +423,45 @@ public class BiomeDictionary
 
     private static void registerVanillaBiomes()
     {
-        registerBiomeType(Biomes.OCEAN,                    OCEAN                                        );
-        registerBiomeType(Biomes.PLAINS,                   PLAINS                                       );
-        registerBiomeType(Biomes.DESERT,                   HOT,      DRY,        SANDY                  );
-        registerBiomeType(Biomes.EXTREME_HILLS,            MOUNTAIN, HILLS                              );
-        registerBiomeType(Biomes.FOREST,                   FOREST                                       );
-        registerBiomeType(Biomes.TAIGA,                    COLD,     CONIFEROUS, FOREST                 );
-        registerBiomeType(Biomes.TAIGA_HILLS,              COLD,     CONIFEROUS, FOREST,   HILLS        );
-        registerBiomeType(Biomes.SWAMPLAND,                WET,      SWAMP                              );
-        registerBiomeType(Biomes.RIVER,                    RIVER                                        );
-        registerBiomeType(Biomes.FROZEN_OCEAN,             COLD,     OCEAN,      SNOWY                  );
-        registerBiomeType(Biomes.FROZEN_RIVER,             COLD,     RIVER,      SNOWY                  );
-        registerBiomeType(Biomes.ICE_PLAINS,               COLD,     SNOWY,      WASTELAND              );
-        registerBiomeType(Biomes.ICE_MOUNTAINS,            COLD,     SNOWY,      MOUNTAIN               );
-        registerBiomeType(Biomes.BEACH,                    BEACH                                        );
-        registerBiomeType(Biomes.DESERT_HILLS,             HOT,      DRY,        SANDY,    HILLS        );
-        registerBiomeType(Biomes.JUNGLE,                   HOT,      WET,        DENSE,    JUNGLE       );
-        registerBiomeType(Biomes.JUNGLE_HILLS,             HOT,      WET,        DENSE,    JUNGLE, HILLS);
-        registerBiomeType(Biomes.FOREST_HILLS,             FOREST,   HILLS                              );
-        registerBiomeType(Biomes.SKY,                      COLD,     DRY,        END                    );
-        registerBiomeType(Biomes.HELL,                     HOT,      DRY,        NETHER                 );
-        registerBiomeType(Biomes.MUSHROOM_ISLAND,          MUSHROOM                                     );
-        registerBiomeType(Biomes.EXTREME_HILLS_EDGE,       MOUNTAIN                                     );
-        registerBiomeType(Biomes.MUSHROOM_ISLAND_SHORE,    MUSHROOM, BEACH                              );
-        registerBiomeType(Biomes.JUNGLE_EDGE,              HOT,      WET,        JUNGLE,   FOREST       );
-        registerBiomeType(Biomes.DEEP_OCEAN,               OCEAN                                        );
-        registerBiomeType(Biomes.STONE_BEACH,              BEACH                                        );
-        registerBiomeType(Biomes.COLD_BEACH,               COLD,     BEACH,      SNOWY                  );
-        registerBiomeType(Biomes.BIRCH_FOREST,             FOREST                                       );
-        registerBiomeType(Biomes.BIRCH_FOREST_HILLS,       FOREST,   HILLS                              );
-        registerBiomeType(Biomes.ROOFED_FOREST,            SPOOKY,   DENSE,      FOREST                 );
-        registerBiomeType(Biomes.COLD_TAIGA,               COLD,     CONIFEROUS, FOREST,   SNOWY        );
-        registerBiomeType(Biomes.COLD_TAIGA_HILLS,         COLD,     CONIFEROUS, FOREST,   SNOWY,  HILLS);
-        registerBiomeType(Biomes.REDWOOD_TAIGA,            COLD,     CONIFEROUS, FOREST                 );
-        registerBiomeType(Biomes.REDWOOD_TAIGA_HILLS,      COLD,     CONIFEROUS, FOREST,   HILLS        );
-        registerBiomeType(Biomes.EXTREME_HILLS_WITH_TREES, MOUNTAIN, FOREST,     SPARSE                 );
-        registerBiomeType(Biomes.SAVANNA,                  HOT,      SAVANNA,    PLAINS,   SPARSE       );
-        registerBiomeType(Biomes.SAVANNA_PLATEAU,          HOT,      SAVANNA,    PLAINS,   SPARSE       );
-        registerBiomeType(Biomes.MESA,                     MESA,     SANDY                              );
-        registerBiomeType(Biomes.MESA_ROCK,                MESA,     SPARSE,     SANDY                  );
-        registerBiomeType(Biomes.MESA_CLEAR_ROCK,          MESA,     SANDY                              );
+        register(Biomes.OCEAN,                    OCEAN                                        );
+        register(Biomes.PLAINS,                   PLAINS                                       );
+        register(Biomes.DESERT,                   HOT,      DRY,        SANDY                  );
+        register(Biomes.EXTREME_HILLS,            MOUNTAIN, HILLS                              );
+        register(Biomes.FOREST,                   FOREST                                       );
+        register(Biomes.TAIGA,                    COLD,     CONIFEROUS, FOREST                 );
+        register(Biomes.TAIGA_HILLS,              COLD,     CONIFEROUS, FOREST,   HILLS        );
+        register(Biomes.SWAMPLAND,                WET,      SWAMP                              );
+        register(Biomes.RIVER,                    RIVER                                        );
+        register(Biomes.FROZEN_OCEAN,             COLD,     OCEAN,      SNOWY                  );
+        register(Biomes.FROZEN_RIVER,             COLD,     RIVER,      SNOWY                  );
+        register(Biomes.ICE_PLAINS,               COLD,     SNOWY,      WASTELAND              );
+        register(Biomes.ICE_MOUNTAINS,            COLD,     SNOWY,      MOUNTAIN               );
+        register(Biomes.BEACH,                    BEACH                                        );
+        register(Biomes.DESERT_HILLS,             HOT,      DRY,        SANDY,    HILLS        );
+        register(Biomes.JUNGLE,                   HOT,      WET,        DENSE,    JUNGLE       );
+        register(Biomes.JUNGLE_HILLS,             HOT,      WET,        DENSE,    JUNGLE, HILLS);
+        register(Biomes.FOREST_HILLS,             FOREST,   HILLS                              );
+        register(Biomes.SKY,                      COLD,     DRY,        END                    );
+        register(Biomes.HELL,                     HOT,      DRY,        NETHER                 );
+        register(Biomes.MUSHROOM_ISLAND,          MUSHROOM                                     );
+        register(Biomes.EXTREME_HILLS_EDGE,       MOUNTAIN                                     );
+        register(Biomes.MUSHROOM_ISLAND_SHORE,    MUSHROOM, BEACH                              );
+        register(Biomes.JUNGLE_EDGE,              HOT,      WET,        JUNGLE,   FOREST       );
+        register(Biomes.DEEP_OCEAN,               OCEAN                                        );
+        register(Biomes.STONE_BEACH,              BEACH                                        );
+        register(Biomes.COLD_BEACH,               COLD,     BEACH,      SNOWY                  );
+        register(Biomes.BIRCH_FOREST,             FOREST                                       );
+        register(Biomes.BIRCH_FOREST_HILLS,       FOREST,   HILLS                              );
+        register(Biomes.ROOFED_FOREST,            SPOOKY,   DENSE,      FOREST                 );
+        register(Biomes.COLD_TAIGA,               COLD,     CONIFEROUS, FOREST,   SNOWY        );
+        register(Biomes.COLD_TAIGA_HILLS,         COLD,     CONIFEROUS, FOREST,   SNOWY,  HILLS);
+        register(Biomes.REDWOOD_TAIGA,            COLD,     CONIFEROUS, FOREST                 );
+        register(Biomes.REDWOOD_TAIGA_HILLS,      COLD,     CONIFEROUS, FOREST,   HILLS        );
+        register(Biomes.EXTREME_HILLS_WITH_TREES, MOUNTAIN, FOREST,     SPARSE                 );
+        register(Biomes.SAVANNA,                  HOT,      SAVANNA,    PLAINS,   SPARSE       );
+        register(Biomes.SAVANNA_PLATEAU,          HOT,      SAVANNA,    PLAINS,   SPARSE       );
+        register(Biomes.MESA,                     MESA,     SANDY                              );
+        register(Biomes.MESA_ROCK,                MESA,     SPARSE,     SANDY                  );
+        register(Biomes.MESA_CLEAR_ROCK,          MESA,     SANDY                              );
     }
 }

--- a/src/main/java/net/minecraftforge/common/ForgeModContainer.java
+++ b/src/main/java/net/minecraftforge/common/ForgeModContainer.java
@@ -442,7 +442,7 @@ public class ForgeModContainer extends DummyModContainer implements WorldAccessC
                 decorator.fireCreateEventAndReplace(biome);
             }
 
-            BiomeDictionary.ensureTagged(biome);
+            BiomeDictionary.ensureHasTypes(biome);
         }
     }
 

--- a/src/main/java/net/minecraftforge/common/ForgeModContainer.java
+++ b/src/main/java/net/minecraftforge/common/ForgeModContainer.java
@@ -442,7 +442,7 @@ public class ForgeModContainer extends DummyModContainer implements WorldAccessC
                 decorator.fireCreateEventAndReplace(biome);
             }
 
-            BiomeDictionary.ensureRegistered(biome);
+            BiomeDictionary.ensureTagged(biome);
         }
     }
 

--- a/src/main/java/net/minecraftforge/common/ForgeModContainer.java
+++ b/src/main/java/net/minecraftforge/common/ForgeModContainer.java
@@ -24,6 +24,7 @@
 
 package net.minecraftforge.common;
 
+import net.minecraft.world.biome.Biome;
 import static net.minecraftforge.common.config.Configuration.CATEGORY_CLIENT;
 import static net.minecraftforge.common.config.Configuration.CATEGORY_GENERAL;
 
@@ -38,11 +39,9 @@ import java.util.Date;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 
 import org.apache.logging.log4j.Level;
 
-import net.minecraft.crash.CrashReport;
 import net.minecraft.crash.ICrashReportDetail;
 import net.minecraft.nbt.NBTBase;
 import net.minecraft.nbt.NBTTagCompound;
@@ -57,8 +56,10 @@ import net.minecraftforge.common.config.Property;
 import net.minecraftforge.common.model.animation.CapabilityAnimation;
 import net.minecraftforge.common.network.ForgeNetworkHandler;
 import net.minecraftforge.energy.CapabilityEnergy;
+import net.minecraftforge.event.terraingen.DeferredBiomeDecorator;
 import net.minecraftforge.fluids.FluidRegistry;
 import net.minecraftforge.fluids.capability.CapabilityFluidHandler;
+import net.minecraftforge.fml.common.registry.ForgeRegistries;
 import net.minecraftforge.items.CapabilityItemHandler;
 import net.minecraftforge.fluids.UniversalBucket;
 import net.minecraftforge.fml.common.registry.GameRegistry;
@@ -82,7 +83,6 @@ import net.minecraftforge.fml.common.LoadController;
 import net.minecraftforge.fml.common.Loader;
 import net.minecraftforge.fml.common.ModMetadata;
 import net.minecraftforge.fml.common.WorldAccessContainer;
-import net.minecraftforge.fml.common.discovery.ASMDataTable;
 import net.minecraftforge.fml.common.discovery.ASMDataTable.ASMData;
 import net.minecraftforge.fml.common.event.FMLConstructionEvent;
 import net.minecraftforge.fml.common.event.FMLLoadCompleteEvent;
@@ -428,8 +428,22 @@ public class ForgeModContainer extends DummyModContainer implements WorldAccessC
     @Subscribe
     public void postInit(FMLPostInitializationEvent evt)
     {
-        BiomeDictionary.registerAllBiomesAndGenerateEvents();
+        registerAllBiomesAndGenerateEvents();
         ForgeChunkManager.loadConfiguration();
+    }
+
+    private static void registerAllBiomesAndGenerateEvents()
+    {
+        for (Biome biome : ForgeRegistries.BIOMES.getValues())
+        {
+            if (biome.theBiomeDecorator instanceof DeferredBiomeDecorator)
+            {
+                DeferredBiomeDecorator decorator = (DeferredBiomeDecorator)biome.theBiomeDecorator;
+                decorator.fireCreateEventAndReplace(biome);
+            }
+
+            BiomeDictionary.ensureRegistered(biome);
+        }
     }
 
     @Subscribe


### PR DESCRIPTION
Main point here is that `BiomeDictionary.registerBiomeType` no longer silently ignores unregistered biomes without any kind of indication.
At the same time update the class to decouple from vanilla's registries and use the cleaner forge interface.
This now makes the return type redundant, should I change as part of the "1.11.x binary change"?

There is a lot more that's wrong with the class:

- The formatting is all over the place and does not follow forge's standards.
- There are unused, seemingly random methods like `registerAllBiomes`, which does nothing but log a warning.

Should this be cleaned up?