### PR TITLE
[1.11]Fixed getArmorModel returning null despite being Nonnull

### DIFF
--- a/patches/minecraft/net/minecraft/item/Item.java.patch
+++ b/patches/minecraft/net/minecraft/item/Item.java.patch
@@ -389,7 +389,7 @@
 +    @Nullable
 +    public net.minecraft.client.model.ModelBiped getArmorModel(EntityLivingBase entityLiving, ItemStack itemStack, EntityEquipmentSlot armorSlot, net.minecraft.client.model.ModelBiped _default)
 +    {
-+        return null;
++        return _default;
 +    }
 +
 +    /**


### PR DESCRIPTION
So, I noticed that apparently getArmorModel is annotated with MethodsReturnNonnullByDefault, and saw that it returned null.
[Imgur](http://i.imgur.com/s73O7BY.png?1)
Since the default model is available as a parameter, I figured that is what should be returned instead of null.