### PR TITLE
Fix sky colour blending not working for render distances >16

### DIFF
--- a/src/main/java/net/minecraftforge/client/ForgeHooksClient.java
+++ b/src/main/java/net/minecraftforge/client/ForgeHooksClient.java
@@ -261,7 +261,7 @@ public class ForgeHooksClient
         GameSettings settings = Minecraft.getMinecraft().gameSettings;
         int[] ranges = ForgeModContainer.blendRanges;
         int distance = 0;
-        if (settings.fancyGraphics)
+        if (settings.fancyGraphics && ranges.length > 0)
         {
             distance = ranges[MathHelper.clamp_int(settings.renderDistanceChunks, 0, ranges.length-1)];
         }

--- a/src/main/java/net/minecraftforge/client/ForgeHooksClient.java
+++ b/src/main/java/net/minecraftforge/client/ForgeHooksClient.java
@@ -261,9 +261,9 @@ public class ForgeHooksClient
         GameSettings settings = Minecraft.getMinecraft().gameSettings;
         int[] ranges = ForgeModContainer.blendRanges;
         int distance = 0;
-        if (settings.fancyGraphics && settings.renderDistanceChunks >= 0 && settings.renderDistanceChunks < ranges.length)
+        if (settings.fancyGraphics)
         {
-            distance = ranges[settings.renderDistanceChunks];
+            distance = ranges[MathHelper.clamp_int(settings.renderDistanceChunks, 0, ranges.length-1)];
         }
 
         int r = 0;


### PR DESCRIPTION
Currently, `ForgeModContainer.blendRanges` is only defined by default for render distances up to 16. If the render distance is set to more than that, the distance used will be 0, effectively disabling sky colour blending.

This patch changes the logic to instead clamp the view distance to the range for which blending is defined. Thus, a view distance of 20 will have blending over the same range as view distance 16, rather than no blending at all.