### PR TITLE
changed method return type of EntityLivingBase#onDeath() to boolean instead of void

### DIFF
--- a/patches/minecraft/net/minecraft/entity/EntityLivingBase.java.patch
+++ b/patches/minecraft/net/minecraft/entity/EntityLivingBase.java.patch
@@ -68,20 +68,36 @@
  
                          if (entitywolf.func_70909_n())
                          {
-@@ -1107,6 +1112,7 @@
+@@ -980,7 +985,7 @@
+                             this.func_184185_a(soundevent, this.func_70599_aP(), this.func_70647_i());
+                         }
  
-     public void func_70645_a(DamageSource p_70645_1_)
+-                        this.func_70645_a(p_70097_1_);
++                        this.onDeath(p_70097_1_);
+                     }
+                 }
+                 else if (flag1)
+@@ -1105,11 +1110,12 @@
+         }
+     }
+ 
+-    public void func_70645_a(DamageSource p_70645_1_)
++    public boolean onDeath(DamageSource cause)
      {
-+        if (net.minecraftforge.common.ForgeHooks.onLivingDeath(this, p_70645_1_)) return;
++        if (net.minecraftforge.common.ForgeHooks.onLivingDeath(this, cause)) return true;
          if (!this.field_70729_aU)
          {
-             Entity entity = p_70645_1_.func_76346_g();
-@@ -1127,18 +1133,26 @@
+-            Entity entity = p_70645_1_.func_76346_g();
++            Entity entity = cause.func_76346_g();
+             EntityLivingBase entitylivingbase = this.func_94060_bK();
+ 
+             if (this.field_70744_aE >= 0 && entitylivingbase != null)
+@@ -1127,22 +1133,31 @@
  
              if (!this.field_70170_p.field_72995_K)
              {
 -                int i = 0;
-+                int i = net.minecraftforge.common.ForgeHooks.getLootingLevel(this, entity, p_70645_1_);
++                int i = net.minecraftforge.common.ForgeHooks.getLootingLevel(this, entity, cause);
  
 -                if (entity instanceof EntityPlayer)
 -                {
@@ -93,12 +109,13 @@
                  if (this.func_146066_aG() && this.field_70170_p.func_82736_K().func_82766_b("doMobLoot"))
                  {
                      boolean flag = this.field_70718_bc > 0;
-                     this.func_184610_a(flag, i, p_70645_1_);
+-                    this.func_184610_a(flag, i, p_70645_1_);
++                    this.func_184610_a(flag, i, cause);
                  }
 +
 +                captureDrops = false;
 +
-+                if (!net.minecraftforge.common.ForgeHooks.onLivingDrops(this, p_70645_1_, capturedDrops, i, field_70718_bc > 0))
++                if (!net.minecraftforge.common.ForgeHooks.onLivingDrops(this, cause, capturedDrops, i, field_70718_bc > 0))
 +                {
 +                    for (EntityItem item : capturedDrops)
 +                    {
@@ -108,7 +125,12 @@
              }
  
              this.field_70170_p.func_72960_a(this, (byte)3);
-@@ -1215,7 +1229,7 @@
+         }
++        return false;
+     }
+ 
+     protected void func_184610_a(boolean p_184610_1_, int p_184610_2_, DamageSource p_184610_3_)
+@@ -1215,7 +1230,7 @@
              BlockPos blockpos = new BlockPos(i, j, k);
              IBlockState iblockstate = this.field_70170_p.func_180495_p(blockpos);
              Block block = iblockstate.func_177230_c();
@@ -117,7 +139,7 @@
          }
      }
  
-@@ -1241,6 +1255,9 @@
+@@ -1241,6 +1256,9 @@
  
      public void func_180430_e(float p_180430_1_, float p_180430_2_)
      {
@@ -127,7 +149,7 @@
          super.func_180430_e(p_180430_1_, p_180430_2_);
          PotionEffect potioneffect = this.func_70660_b(MobEffects.field_76430_j);
          float f = potioneffect == null ? 0.0F : (float)(potioneffect.func_76458_c() + 1);
-@@ -1257,7 +1274,7 @@
+@@ -1257,7 +1275,7 @@
  
              if (iblockstate.func_185904_a() != Material.field_151579_a)
              {
@@ -136,7 +158,7 @@
                  this.func_184185_a(soundtype.func_185842_g(), soundtype.func_185843_a() * 0.5F, soundtype.func_185847_b() * 0.75F);
              }
          }
-@@ -1334,6 +1351,8 @@
+@@ -1334,6 +1352,8 @@
      {
          if (!this.func_180431_b(p_70665_1_))
          {
@@ -145,7 +167,7 @@
              p_70665_2_ = this.func_70655_b(p_70665_1_, p_70665_2_);
              p_70665_2_ = this.func_70672_c(p_70665_1_, p_70665_2_);
              float f = p_70665_2_;
-@@ -1383,6 +1402,11 @@
+@@ -1383,6 +1403,11 @@
  
      public void func_184609_a(EnumHand p_184609_1_)
      {
@@ -157,7 +179,16 @@
          if (!this.field_82175_bq || this.field_110158_av >= this.func_82166_i() / 2 || this.field_110158_av < 0)
          {
              this.field_110158_av = -1;
-@@ -1613,7 +1637,7 @@
+@@ -1413,7 +1438,7 @@
+                 }
+ 
+                 this.func_70606_j(0.0F);
+-                this.func_70645_a(DamageSource.field_76377_j);
++                this.onDeath(DamageSource.field_76377_j);
+             }
+             else if (p_70103_1_ == 30)
+             {
+@@ -1613,7 +1638,7 @@
  
                      if (!this.field_70170_p.func_184143_b(axisalignedbb1))
                      {
@@ -166,7 +197,7 @@
                          {
                              this.func_70634_a(d11, this.field_70163_u + 1.0D, d12);
                              return;
-@@ -1621,14 +1645,14 @@
+@@ -1621,14 +1646,14 @@
  
                          BlockPos blockpos = new BlockPos(d11, this.field_70163_u - 1.0D, d12);
  
@@ -183,7 +214,7 @@
                      {
                          d1 = d11;
                          d13 = this.field_70163_u + 2.0D;
-@@ -1700,6 +1724,7 @@
+@@ -1700,6 +1725,7 @@
          }
  
          this.field_70160_al = true;
@@ -191,7 +222,7 @@
      }
  
      protected void func_70629_bd()
-@@ -1972,6 +1997,7 @@
+@@ -1972,6 +1998,7 @@
  
      public void func_70071_h_()
      {
@@ -199,7 +230,7 @@
          super.func_70071_h_();
          this.func_184608_ct();
  
-@@ -2015,6 +2041,7 @@
+@@ -2015,6 +2042,7 @@
                  if (!ItemStack.func_77989_b(itemstack1, itemstack))
                  {
                      ((WorldServer)this.field_70170_p).func_73039_n().func_151247_a(this, new SPacketEntityEquipment(this.func_145782_y(), entityequipmentslot, itemstack1));
@@ -207,7 +238,7 @@
  
                      if (!itemstack.func_190926_b())
                      {
-@@ -2488,6 +2515,40 @@
+@@ -2488,6 +2516,40 @@
          this.field_70752_e = true;
      }
  
@@ -248,7 +279,7 @@
      public abstract EnumHandSide func_184591_cq();
  
      public boolean func_184587_cr()
-@@ -2508,12 +2569,19 @@
+@@ -2508,12 +2570,19 @@
  
              if (itemstack == this.field_184627_bm)
              {
@@ -269,7 +300,7 @@
                  {
                      this.func_71036_o();
                  }
-@@ -2531,8 +2599,10 @@
+@@ -2531,8 +2600,10 @@
  
          if (!itemstack.func_190926_b() && !this.func_184587_cr())
          {
@@ -281,7 +312,7 @@
  
              if (!this.field_70170_p.field_72995_K)
              {
-@@ -2613,7 +2683,9 @@
+@@ -2613,7 +2684,9 @@
          if (!this.field_184627_bm.func_190926_b() && this.func_184587_cr())
          {
              this.func_184584_a(this.field_184627_bm, 16);
@@ -292,7 +323,7 @@
              this.func_184602_cy();
          }
      }
-@@ -2637,7 +2709,8 @@
+@@ -2637,7 +2710,8 @@
      {
          if (!this.field_184627_bm.func_190926_b())
          {
@@ -302,7 +333,7 @@
          }
  
          this.func_184602_cy();
-@@ -2761,4 +2834,29 @@
+@@ -2761,4 +2835,29 @@
      {
          return true;
      }

--- a/patches/minecraft/net/minecraft/entity/monster/AbstractSkeleton.java.patch
+++ b/patches/minecraft/net/minecraft/entity/monster/AbstractSkeleton.java.patch
@@ -1,0 +1,28 @@
+--- ../src-base/minecraft/net/minecraft/entity/monster/AbstractSkeleton.java
++++ ../src-work/minecraft/net/minecraft/entity/monster/AbstractSkeleton.java
+@@ -157,13 +157,13 @@
+         }
+     }
+ 
+-    public void func_70645_a(DamageSource p_70645_1_)
++    public boolean onDeath(DamageSource cause)
+     {
+-        super.func_70645_a(p_70645_1_);
++        if(super.onDeath(cause)) return true;
+ 
+-        if (p_70645_1_.func_76364_f() instanceof EntityArrow && p_70645_1_.func_76346_g() instanceof EntityPlayer)
++        if (cause.func_76364_f() instanceof EntityArrow && cause.func_76346_g() instanceof EntityPlayer)
+         {
+-            EntityPlayer entityplayer = (EntityPlayer)p_70645_1_.func_76346_g();
++            EntityPlayer entityplayer = (EntityPlayer)cause.func_76346_g();
+             double d0 = entityplayer.field_70165_t - this.field_70165_t;
+             double d1 = entityplayer.field_70161_v - this.field_70161_v;
+ 
+@@ -172,6 +172,7 @@
+                 entityplayer.func_71029_a(AchievementList.field_187994_v);
+             }
+         }
++        return false;
+     }
+ 
+     protected void func_180481_a(DifficultyInstance p_180481_1_)

--- a/patches/minecraft/net/minecraft/entity/monster/EntityCreeper.java.patch
+++ b/patches/minecraft/net/minecraft/entity/monster/EntityCreeper.java.patch
@@ -1,0 +1,34 @@
+--- ../src-base/minecraft/net/minecraft/entity/monster/EntityCreeper.java
++++ ../src-work/minecraft/net/minecraft/entity/monster/EntityCreeper.java
+@@ -182,25 +182,26 @@
+         return SoundEvents.field_187568_ap;
+     }
+ 
+-    public void func_70645_a(DamageSource p_70645_1_)
++    public boolean onDeath(DamageSource cause)
+     {
+-        super.func_70645_a(p_70645_1_);
++        if(super.onDeath(cause)) return true;
+ 
+         if (this.field_70170_p.func_82736_K().func_82766_b("doMobLoot"))
+         {
+-            if (p_70645_1_.func_76346_g() instanceof EntitySkeleton)
++            if (cause.func_76346_g() instanceof EntitySkeleton)
+             {
+                 int i = Item.func_150891_b(Items.field_151096_cd);
+                 int j = Item.func_150891_b(Items.field_151084_co);
+                 int k = i + this.field_70146_Z.nextInt(j - i + 1);
+                 this.func_145779_a(Item.func_150899_d(k), 1);
+             }
+-            else if (p_70645_1_.func_76346_g() instanceof EntityCreeper && p_70645_1_.func_76346_g() != this && ((EntityCreeper)p_70645_1_.func_76346_g()).func_70830_n() && ((EntityCreeper)p_70645_1_.func_76346_g()).func_70650_aV())
++            else if (cause.func_76346_g() instanceof EntityCreeper && cause.func_76346_g() != this && ((EntityCreeper)cause.func_76346_g()).func_70830_n() && ((EntityCreeper)cause.func_76346_g()).func_70650_aV())
+             {
+-                ((EntityCreeper)p_70645_1_.func_76346_g()).func_175493_co();
++                ((EntityCreeper)cause.func_76346_g()).func_175493_co();
+                 this.func_70099_a(new ItemStack(Items.field_151144_bL, 1, 4), 0.0F);
+             }
+         }
++        return false;
+     }
+ 
+     public boolean func_70652_k(Entity p_70652_1_)

--- a/patches/minecraft/net/minecraft/entity/monster/EntityIronGolem.java.patch
+++ b/patches/minecraft/net/minecraft/entity/monster/EntityIronGolem.java.patch
@@ -1,0 +1,18 @@
+--- ../src-base/minecraft/net/minecraft/entity/monster/EntityIronGolem.java
++++ ../src-work/minecraft/net/minecraft/entity/monster/EntityIronGolem.java
+@@ -283,13 +283,13 @@
+         }
+     }
+ 
+-    public void func_70645_a(DamageSource p_70645_1_)
++    public boolean onDeath(DamageSource cause)
+     {
+         if (!this.func_70850_q() && this.field_70717_bb != null && this.field_70857_d != null)
+         {
+             this.field_70857_d.func_82688_a(this.field_70717_bb.func_70005_c_(), -5);
+         }
+ 
+-        super.func_70645_a(p_70645_1_);
++        return super.onDeath(cause);
+     }
+ }

--- a/patches/minecraft/net/minecraft/entity/monster/EntitySkeleton.java.patch
+++ b/patches/minecraft/net/minecraft/entity/monster/EntitySkeleton.java.patch
@@ -1,0 +1,28 @@
+--- ../src-base/minecraft/net/minecraft/entity/monster/EntitySkeleton.java
++++ ../src-work/minecraft/net/minecraft/entity/monster/EntitySkeleton.java
+@@ -54,13 +54,13 @@
+         return SoundEvents.field_187868_fj;
+     }
+ 
+-    public void func_70645_a(DamageSource p_70645_1_)
++    public boolean onDeath(DamageSource cause)
+     {
+-        super.func_70645_a(p_70645_1_);
++        if(super.onDeath(cause)) return true;
+ 
+-        if (p_70645_1_.func_76346_g() instanceof EntityCreeper)
++        if (cause.func_76346_g() instanceof EntityCreeper)
+         {
+-            EntityCreeper entitycreeper = (EntityCreeper)p_70645_1_.func_76346_g();
++            EntityCreeper entitycreeper = (EntityCreeper)cause.func_76346_g();
+ 
+             if (entitycreeper.func_70830_n() && entitycreeper.func_70650_aV())
+             {
+@@ -68,6 +68,7 @@
+                 this.func_70099_a(new ItemStack(Items.field_151144_bL, 1, 0), 0.0F);
+             }
+         }
++        return false;
+     }
+ 
+     protected EntityArrow func_190726_a(float p_190726_1_)

--- a/patches/minecraft/net/minecraft/entity/monster/EntityWitherSkeleton.java.patch
+++ b/patches/minecraft/net/minecraft/entity/monster/EntityWitherSkeleton.java.patch
@@ -1,0 +1,28 @@
+--- ../src-base/minecraft/net/minecraft/entity/monster/EntityWitherSkeleton.java
++++ ../src-work/minecraft/net/minecraft/entity/monster/EntityWitherSkeleton.java
+@@ -61,13 +61,13 @@
+         return SoundEvents.field_190039_hd;
+     }
+ 
+-    public void func_70645_a(DamageSource p_70645_1_)
++    public boolean onDeath(DamageSource cause)
+     {
+-        super.func_70645_a(p_70645_1_);
++        if(super.onDeath(cause)) return true;
+ 
+-        if (p_70645_1_.func_76346_g() instanceof EntityCreeper)
++        if (cause.func_76346_g() instanceof EntityCreeper)
+         {
+-            EntityCreeper entitycreeper = (EntityCreeper)p_70645_1_.func_76346_g();
++            EntityCreeper entitycreeper = (EntityCreeper)cause.func_76346_g();
+ 
+             if (entitycreeper.func_70830_n() && entitycreeper.func_70650_aV())
+             {
+@@ -75,6 +75,7 @@
+                 this.func_70099_a(new ItemStack(Items.field_151144_bL, 1, 1), 0.0F);
+             }
+         }
++        return false;
+     }
+ 
+     protected void func_180481_a(DifficultyInstance p_180481_1_)

--- a/patches/minecraft/net/minecraft/entity/monster/EntityZombie.java.patch
+++ b/patches/minecraft/net/minecraft/entity/monster/EntityZombie.java.patch
@@ -56,3 +56,29 @@
                              entityzombie.func_180482_a(this.field_70170_p.func_175649_E(new BlockPos(entityzombie)), (IEntityLivingData)null);
                              this.func_110148_a(field_110186_bp).func_111121_a(new AttributeModifier("Zombie reinforcement caller charge", -0.05000000074505806D, 0));
                              entityzombie.func_110148_a(field_110186_bp).func_111121_a(new AttributeModifier("Zombie reinforcement callee charge", -0.05000000074505806D, 0));
+@@ -529,13 +541,13 @@
+         return this.func_70631_g_() ? 0.0D : -0.45D;
+     }
+ 
+-    public void func_70645_a(DamageSource p_70645_1_)
++    public boolean onDeath(DamageSource cause)
+     {
+-        super.func_70645_a(p_70645_1_);
++        if(super.onDeath(cause)) return true;
+ 
+-        if (p_70645_1_.func_76346_g() instanceof EntityCreeper)
++        if (cause.func_76346_g() instanceof EntityCreeper)
+         {
+-            EntityCreeper entitycreeper = (EntityCreeper)p_70645_1_.func_76346_g();
++            EntityCreeper entitycreeper = (EntityCreeper)cause.func_76346_g();
+ 
+             if (entitycreeper.func_70830_n() && entitycreeper.func_70650_aV())
+             {
+@@ -548,6 +560,7 @@
+                 }
+             }
+         }
++        return false;
+     }
+ 
+     protected ItemStack func_190732_dj()

--- a/patches/minecraft/net/minecraft/entity/passive/AbstractChestHorse.java.patch
+++ b/patches/minecraft/net/minecraft/entity/passive/AbstractChestHorse.java.patch
@@ -1,0 +1,22 @@
+--- ../src-base/minecraft/net/minecraft/entity/passive/AbstractChestHorse.java
++++ ../src-work/minecraft/net/minecraft/entity/passive/AbstractChestHorse.java
+@@ -70,9 +70,9 @@
+         return SoundEvents.field_187582_aw;
+     }
+ 
+-    public void func_70645_a(DamageSource p_70645_1_)
++    public boolean onDeath(DamageSource cause)
+     {
+-        super.func_70645_a(p_70645_1_);
++        if(super.onDeath(cause)) return true;
+ 
+         if (this.func_190695_dh())
+         {
+@@ -83,6 +83,7 @@
+ 
+             this.func_110207_m(false);
+         }
++        return false;
+     }
+ 
+     public static void func_190694_b(DataFixer p_190694_0_, Class<?> p_190694_1_)

--- a/patches/minecraft/net/minecraft/entity/passive/AbstractHorse.java.patch
+++ b/patches/minecraft/net/minecraft/entity/passive/AbstractHorse.java.patch
@@ -1,5 +1,26 @@
 --- ../src-base/minecraft/net/minecraft/entity/passive/AbstractHorse.java
 +++ ../src-work/minecraft/net/minecraft/entity/passive/AbstractHorse.java
+@@ -604,10 +604,9 @@
+         this.field_110278_bp = 1;
+     }
+ 
+-    public void func_70645_a(DamageSource p_70645_1_)
++    public boolean onDeath(DamageSource cause)
+     {
+-        super.func_70645_a(p_70645_1_);
+-
++        if(super.onDeath(cause)) return true;
+         if (!this.field_70170_p.field_72995_K && this.field_110296_bG != null)
+         {
+             for (int i = 0; i < this.field_110296_bG.func_70302_i_(); ++i)
+@@ -620,6 +619,7 @@
+                 }
+             }
+         }
++        return false;
+     }
+ 
+     public void func_70636_d()
 @@ -981,6 +981,7 @@
          }
  

--- a/patches/minecraft/net/minecraft/entity/passive/EntityPig.java.patch
+++ b/patches/minecraft/net/minecraft/entity/passive/EntityPig.java.patch
@@ -1,0 +1,22 @@
+--- ../src-base/minecraft/net/minecraft/entity/passive/EntityPig.java
++++ ../src-work/minecraft/net/minecraft/entity/passive/EntityPig.java
+@@ -173,9 +173,9 @@
+         }
+     }
+ 
+-    public void func_70645_a(DamageSource p_70645_1_)
++    public boolean onDeath(DamageSource cause)
+     {
+-        super.func_70645_a(p_70645_1_);
++        if(super.onDeath(cause)) return true;
+ 
+         if (!this.field_70170_p.field_72995_K)
+         {
+@@ -184,6 +184,7 @@
+                 this.func_145779_a(Items.field_151141_av, 1);
+             }
+         }
++        return false;
+     }
+ 
+     @Nullable

--- a/patches/minecraft/net/minecraft/entity/passive/EntityTameable.java.patch
+++ b/patches/minecraft/net/minecraft/entity/passive/EntityTameable.java.patch
@@ -1,0 +1,19 @@
+--- ../src-base/minecraft/net/minecraft/entity/passive/EntityTameable.java
++++ ../src-work/minecraft/net/minecraft/entity/passive/EntityTameable.java
+@@ -251,13 +251,13 @@
+         return super.func_184191_r(p_184191_1_);
+     }
+ 
+-    public void func_70645_a(DamageSource p_70645_1_)
++    public boolean onDeath(DamageSource cause)
+     {
++    	if(super.onDeath(cause)) return true;
+         if (!this.field_70170_p.field_72995_K && this.field_70170_p.func_82736_K().func_82766_b("showDeathMessages") && this.func_70902_q() instanceof EntityPlayerMP)
+         {
+             this.func_70902_q().func_145747_a(this.func_110142_aN().func_151521_b());
+         }
+-
+-        super.func_70645_a(p_70645_1_);
++        return false;
+     }
+ }

--- a/patches/minecraft/net/minecraft/entity/passive/EntityVillager.java.patch
+++ b/patches/minecraft/net/minecraft/entity/passive/EntityVillager.java.patch
@@ -75,6 +75,31 @@
      public boolean func_70941_o()
      {
          return this.field_70952_f;
+@@ -462,11 +502,12 @@
+         }
+     }
+ 
+-    public void func_70645_a(DamageSource p_70645_1_)
++    public boolean onDeath(DamageSource cause)
+     {
++    	if(super.onDeath(cause)) return true; 
+         if (this.field_70954_d != null)
+         {
+-            Entity entity = p_70645_1_.func_76346_g();
++            Entity entity = cause.func_76346_g();
+ 
+             if (entity != null)
+             {
+@@ -489,8 +530,7 @@
+                 }
+             }
+         }
+-
+-        super.func_70645_a(p_70645_1_);
++        return false;
+     }
+ 
+     public void func_70932_a_(EntityPlayer p_70932_1_)
 @@ -607,15 +647,13 @@
  
      private void func_175554_cu()

--- a/patches/minecraft/net/minecraft/entity/player/EntityPlayer.java.patch
+++ b/patches/minecraft/net/minecraft/entity/player/EntityPlayer.java.patch
@@ -42,12 +42,16 @@
              }
          }
      }
-@@ -593,11 +600,15 @@
+@@ -591,13 +598,17 @@
+         this.field_70180_af.func_187227_b(field_184830_b, Integer.valueOf(i + p_85039_1_));
+     }
  
-     public void func_70645_a(DamageSource p_70645_1_)
+-    public void func_70645_a(DamageSource p_70645_1_)
++    public boolean onDeath(DamageSource cause)
      {
-+        if (net.minecraftforge.common.ForgeHooks.onLivingDeath(this,  p_70645_1_)) return;
-         super.func_70645_a(p_70645_1_);
+-        super.func_70645_a(p_70645_1_);
++        if (net.minecraftforge.common.ForgeHooks.onLivingDeath(this,  cause)) return true;
++        super.onDeath(cause);
          this.func_70105_a(0.2F, 0.2F);
          this.func_70107_b(this.field_70165_t, this.field_70163_u, this.field_70161_v);
          this.field_70181_x = 0.10000000149011612D;
@@ -58,17 +62,27 @@
          if ("Notch".equals(this.func_70005_c_()))
          {
              this.func_146097_a(new ItemStack(Items.field_151034_e, 1), true, false);
-@@ -609,6 +620,9 @@
+@@ -609,7 +620,10 @@
              this.field_71071_by.func_70436_m();
          }
  
+-        if (p_70645_1_ != null)
 +        captureDrops = false;
-+        if (!field_70170_p.field_72995_K) net.minecraftforge.event.ForgeEventFactory.onPlayerDrops(this, p_70645_1_, capturedDrops, field_70718_bc > 0);
++        if (!field_70170_p.field_72995_K) net.minecraftforge.event.ForgeEventFactory.onPlayerDrops(this, cause, capturedDrops, field_70718_bc > 0);
 +
-         if (p_70645_1_ != null)
++        if (cause != null)
          {
              this.field_70159_w = (double)(-MathHelper.func_76134_b((this.field_70739_aP + this.field_70177_z) * 0.017453292F) * 0.1F);
-@@ -712,13 +726,24 @@
+             this.field_70179_y = (double)(-MathHelper.func_76126_a((this.field_70739_aP + this.field_70177_z) * 0.017453292F) * 0.1F);
+@@ -624,6 +638,7 @@
+         this.func_175145_a(StatList.field_188098_h);
+         this.func_70066_B();
+         this.func_70052_a(0, false);
++        return false;
+     }
+ 
+     protected void func_190776_cN()
+@@ -712,13 +727,24 @@
      @Nullable
      public EntityItem func_71040_bB(boolean p_71040_1_)
      {
@@ -95,7 +109,7 @@
      }
  
      @Nullable
-@@ -778,14 +803,22 @@
+@@ -778,14 +804,22 @@
  
      public ItemStack func_184816_a(EntityItem p_184816_1_)
      {
@@ -119,7 +133,7 @@
          if (f > 1.0F)
          {
              int i = EnchantmentHelper.func_185293_e(this);
-@@ -835,12 +868,13 @@
+@@ -835,12 +869,13 @@
              f /= 5.0F;
          }
  
@@ -135,7 +149,7 @@
      }
  
      public static void func_189806_a(DataFixer p_189806_0_)
-@@ -889,6 +923,16 @@
+@@ -889,6 +924,16 @@
              this.field_82248_d = p_70037_1_.func_74767_n("SpawnForced");
          }
  
@@ -152,7 +166,7 @@
          this.field_71100_bB.func_75112_a(p_70037_1_);
          this.field_71075_bZ.func_75095_b(p_70037_1_);
  
-@@ -903,6 +947,7 @@
+@@ -903,6 +948,7 @@
      {
          super.func_70014_b(p_70014_1_);
          p_70014_1_.func_74768_a("DataVersion", 819);
@@ -160,7 +174,7 @@
          p_70014_1_.func_74782_a("Inventory", this.field_71071_by.func_70442_a(new NBTTagList()));
          p_70014_1_.func_74768_a("SelectedItemSlot", this.field_71071_by.field_70461_c);
          p_70014_1_.func_74757_a("Sleeping", this.field_71083_bS);
-@@ -921,6 +966,23 @@
+@@ -921,6 +967,23 @@
              p_70014_1_.func_74757_a("SpawnForced", this.field_82248_d);
          }
  
@@ -184,7 +198,7 @@
          this.field_71100_bB.func_75117_b(p_70014_1_);
          this.field_71075_bZ.func_75091_a(p_70014_1_);
          p_70014_1_.func_74782_a("EnderItems", this.field_71078_a.func_70487_g());
-@@ -928,6 +990,7 @@
+@@ -928,6 +991,7 @@
  
      public boolean func_70097_a(DamageSource p_70097_1_, float p_70097_2_)
      {
@@ -192,7 +206,7 @@
          if (this.func_180431_b(p_70097_1_))
          {
              return false;
-@@ -1006,6 +1069,7 @@
+@@ -1006,6 +1070,7 @@
              if (this.field_184627_bm.func_190926_b())
              {
                  EnumHand enumhand = this.func_184600_cs();
@@ -200,7 +214,7 @@
  
                  if (enumhand == EnumHand.MAIN_HAND)
                  {
-@@ -1041,7 +1105,10 @@
+@@ -1041,7 +1106,10 @@
      {
          if (!this.func_180431_b(p_70665_1_))
          {
@@ -212,7 +226,7 @@
              p_70665_2_ = this.func_70672_c(p_70665_1_, p_70665_2_);
              float f = p_70665_2_;
              p_70665_2_ = Math.max(p_70665_2_ - this.func_110139_bj(), 0.0F);
-@@ -1111,6 +1178,7 @@
+@@ -1111,6 +1179,7 @@
          }
          else
          {
@@ -220,7 +234,7 @@
              ItemStack itemstack = this.func_184586_b(p_190775_2_);
              ItemStack itemstack1 = itemstack.func_190926_b() ? ItemStack.field_190927_a : itemstack.func_77946_l();
  
-@@ -1120,7 +1188,10 @@
+@@ -1120,7 +1189,10 @@
                  {
                      itemstack.func_190920_e(itemstack1.func_190916_E());
                  }
@@ -232,7 +246,7 @@
                  return EnumActionResult.SUCCESS;
              }
              else
-@@ -1136,6 +1207,7 @@
+@@ -1136,6 +1208,7 @@
                      {
                          if (itemstack.func_190926_b() && !this.field_71075_bZ.field_75098_d)
                          {
@@ -240,7 +254,7 @@
                              this.func_184611_a(p_190775_2_, ItemStack.field_190927_a);
                          }
  
-@@ -1161,6 +1233,7 @@
+@@ -1161,6 +1234,7 @@
  
      public void func_71059_n(Entity p_71059_1_)
      {
@@ -248,7 +262,7 @@
          if (p_71059_1_.func_70075_an())
          {
              if (!p_71059_1_.func_85031_j(this))
-@@ -1331,11 +1404,13 @@
+@@ -1331,11 +1405,13 @@
  
                          if (!itemstack1.func_190926_b() && entity instanceof EntityLivingBase)
                          {
@@ -262,7 +276,7 @@
                              }
                          }
  
-@@ -1441,6 +1516,8 @@
+@@ -1441,6 +1517,8 @@
  
      public EntityPlayer.SleepResult func_180469_a(BlockPos p_180469_1_)
      {
@@ -271,7 +285,7 @@
          EnumFacing enumfacing = (EnumFacing)this.field_70170_p.func_180495_p(p_180469_1_).func_177229_b(BlockHorizontal.field_185512_D);
  
          if (!this.field_70170_p.field_72995_K)
-@@ -1482,8 +1559,9 @@
+@@ -1482,8 +1560,9 @@
  
          this.func_70105_a(0.2F, 0.2F);
  
@@ -283,7 +297,7 @@
              float f1 = 0.5F + (float)enumfacing.func_82601_c() * 0.4F;
              float f = 0.5F + (float)enumfacing.func_82599_e() * 0.4F;
              this.func_175139_a(enumfacing);
-@@ -1530,13 +1608,14 @@
+@@ -1530,13 +1609,14 @@
  
      public void func_70999_a(boolean p_70999_1_, boolean p_70999_2_, boolean p_70999_3_)
      {
@@ -301,7 +315,7 @@
  
              if (blockpos == null)
              {
-@@ -1545,6 +1624,10 @@
+@@ -1545,6 +1625,10 @@
  
              this.func_70107_b((double)((float)blockpos.func_177958_n() + 0.5F), (double)((float)blockpos.func_177956_o() + 0.1F), (double)((float)blockpos.func_177952_p() + 0.5F));
          }
@@ -312,7 +326,7 @@
  
          this.field_71083_bS = false;
  
-@@ -1563,15 +1646,16 @@
+@@ -1563,15 +1647,16 @@
  
      private boolean func_175143_p()
      {
@@ -332,7 +346,7 @@
          {
              if (!p_180467_2_)
              {
-@@ -1586,16 +1670,17 @@
+@@ -1586,16 +1671,17 @@
          }
          else
          {
@@ -353,7 +367,7 @@
  
              switch (enumfacing)
              {
-@@ -1635,16 +1720,24 @@
+@@ -1635,16 +1721,24 @@
  
      public BlockPos func_180470_cg()
      {
@@ -380,7 +394,7 @@
          if (p_180473_1_ != null)
          {
              this.field_71077_c = p_180473_1_;
-@@ -1839,6 +1932,10 @@
+@@ -1839,6 +1933,10 @@
  
              super.func_180430_e(p_180430_1_, p_180430_2_);
          }
@@ -391,7 +405,7 @@
      }
  
      protected void func_71061_d_()
-@@ -2039,6 +2136,18 @@
+@@ -2039,6 +2137,18 @@
          this.field_175152_f = p_71049_1_.field_175152_f;
          this.field_71078_a = p_71049_1_.field_71078_a;
          this.func_184212_Q().func_187227_b(field_184827_bp, p_71049_1_.func_184212_Q().func_187225_a(field_184827_bp));
@@ -410,7 +424,7 @@
      }
  
      protected boolean func_70041_e_()
-@@ -2137,7 +2246,10 @@
+@@ -2137,7 +2247,10 @@
  
      public ITextComponent func_145748_c_()
      {
@@ -422,7 +436,7 @@
          itextcomponent.func_150256_b().func_150241_a(new ClickEvent(ClickEvent.Action.SUGGEST_COMMAND, "/msg " + this.func_70005_c_() + " "));
          itextcomponent.func_150256_b().func_150209_a(this.func_174823_aP());
          itextcomponent.func_150256_b().func_179989_a(this.func_70005_c_());
-@@ -2146,7 +2258,7 @@
+@@ -2146,7 +2259,7 @@
  
      public float func_70047_e()
      {
@@ -431,7 +445,7 @@
  
          if (this.func_70608_bn())
          {
-@@ -2362,6 +2474,162 @@
+@@ -2362,6 +2475,162 @@
          return this.field_71075_bZ.field_75098_d && this.func_70003_b(2, "");
      }
  

--- a/patches/minecraft/net/minecraft/entity/player/EntityPlayerMP.java.patch
+++ b/patches/minecraft/net/minecraft/entity/player/EntityPlayerMP.java.patch
@@ -21,11 +21,14 @@
          {
              this.func_71053_j();
              this.field_71070_bA = this.field_71069_bz;
-@@ -436,6 +436,7 @@
+@@ -434,8 +434,9 @@
+         }
+     }
  
-     public void func_70645_a(DamageSource p_70645_1_)
+-    public void func_70645_a(DamageSource p_70645_1_)
++    public boolean onDeath(DamageSource cause)
      {
-+        if (net.minecraftforge.common.ForgeHooks.onLivingDeath(this, p_70645_1_)) return;
++        if (net.minecraftforge.common.ForgeHooks.onLivingDeath(this, cause)) return true;
          boolean flag = this.field_70170_p.func_82736_K().func_82766_b("showDeathMessages");
          this.field_71135_a.func_147359_a(new SPacketCombatEvent(this.func_110142_aN(), SPacketCombatEvent.Event.ENTITY_DIED, flag));
  
@@ -39,7 +42,7 @@
              this.field_71071_by.func_70436_m();
 +
 +            captureDrops = false;
-+            net.minecraftforge.event.entity.player.PlayerDropsEvent event = new net.minecraftforge.event.entity.player.PlayerDropsEvent(this, p_70645_1_, capturedDrops, field_70718_bc > 0);
++            net.minecraftforge.event.entity.player.PlayerDropsEvent event = new net.minecraftforge.event.entity.player.PlayerDropsEvent(this, cause, capturedDrops, field_70718_bc > 0);
 +            if (!net.minecraftforge.common.MinecraftForge.EVENT_BUS.post(event))
 +            {
 +                for (net.minecraft.entity.item.EntityItem item : capturedDrops)
@@ -50,7 +53,16 @@
          }
  
          for (ScoreObjective scoreobjective : this.field_70170_p.func_96441_U().func_96520_a(IScoreCriteria.field_96642_c))
-@@ -547,6 +560,7 @@
+@@ -491,6 +504,8 @@
+         this.func_70066_B();
+         this.func_70052_a(0, false);
+         this.func_110142_aN().func_94549_h();
++        
++        return false;
+     }
+ 
+     public boolean func_70097_a(DamageSource p_70097_1_, float p_70097_2_)
+@@ -547,6 +562,7 @@
      @Nullable
      public Entity func_184204_a(int p_184204_1_)
      {
@@ -58,7 +70,7 @@
          this.field_184851_cj = true;
  
          if (this.field_71093_bK == 1 && p_184204_1_ == 1)
-@@ -704,7 +718,7 @@
+@@ -704,7 +720,7 @@
          BlockPos blockpos = new BlockPos(i, j, k);
          IBlockState iblockstate = this.field_70170_p.func_180495_p(blockpos);
  
@@ -67,7 +79,7 @@
          {
              BlockPos blockpos1 = blockpos.func_177977_b();
              IBlockState iblockstate1 = this.field_70170_p.func_180495_p(blockpos1);
-@@ -744,6 +758,7 @@
+@@ -744,6 +760,7 @@
              this.field_71070_bA = p_180468_1_.func_174876_a(this.field_71071_by, this);
              this.field_71070_bA.field_75152_c = this.field_71139_cq;
              this.field_71070_bA.func_75132_a(this);
@@ -75,7 +87,7 @@
          }
      }
  
-@@ -787,6 +802,7 @@
+@@ -787,6 +804,7 @@
  
              this.field_71070_bA.field_75152_c = this.field_71139_cq;
              this.field_71070_bA.func_75132_a(this);
@@ -83,7 +95,7 @@
          }
      }
  
-@@ -796,6 +812,7 @@
+@@ -796,6 +814,7 @@
          this.field_71070_bA = new ContainerMerchant(this.field_71071_by, p_180472_1_, this.field_70170_p);
          this.field_71070_bA.field_75152_c = this.field_71139_cq;
          this.field_71070_bA.func_75132_a(this);
@@ -91,7 +103,7 @@
          IInventory iinventory = ((ContainerMerchant)this.field_71070_bA).func_75174_d();
          ITextComponent itextcomponent = p_180472_1_.func_145748_c_();
          this.field_71135_a.func_147359_a(new SPacketOpenWindow(this.field_71139_cq, "minecraft:villager", itextcomponent, iinventory.func_70302_i_()));
-@@ -894,6 +911,7 @@
+@@ -894,6 +913,7 @@
      public void func_71128_l()
      {
          this.field_71070_bA.func_75134_a(this);
@@ -99,7 +111,7 @@
          this.field_71070_bA = this.field_71069_bz;
      }
  
-@@ -925,6 +943,7 @@
+@@ -925,6 +945,7 @@
      {
          if (p_71064_1_ != null)
          {

--- a/src/main/java/net/minecraftforge/common/util/FakePlayer.java
+++ b/src/main/java/net/minecraftforge/common/util/FakePlayer.java
@@ -49,7 +49,7 @@ public class FakePlayer extends EntityPlayerMP
     @Override public void openGui(Object mod, int modGuiId, World world, int x, int y, int z){}
     @Override public boolean isEntityInvulnerable(DamageSource source){ return true; }
     @Override public boolean canAttackPlayer(EntityPlayer player){ return false; }
-    @Override public void onDeath(DamageSource source){ return; }
+    @Override public boolean onDeath(DamageSource source){ return false; }
     @Override public void onUpdate(){ return; }
     @Override public Entity changeDimension(int dim){ return this; }
     @Override public void handleClientSettings(CPacketClientSettings pkt){ return; }


### PR DESCRIPTION
changed method return type of EntityLivingBase#onDeath() to boolean isntead of void to prevent dropping items when LivingDeathEvent is cancelled. (closes #3477 )