### PR TITLE
[1.11] Fix null checks in shouldCauseReequipAnimation

### DIFF
--- a/src/main/java/net/minecraftforge/client/ForgeHooksClient.java
+++ b/src/main/java/net/minecraftforge/client/ForgeHooksClient.java
@@ -669,12 +669,15 @@ public class ForgeHooksClient
     }
 
     private static int slotMainHand = 0;
-    // FIXME
+
     public static boolean shouldCauseReequipAnimation(@Nonnull ItemStack from, @Nonnull ItemStack to, int slot)
     {
-        boolean fromInvalid = from.func_190926_b(), toInvalid = to.func_190926_b();
+        boolean fromInvalid = from.func_190926_b();
+        boolean toInvalid   = to.func_190926_b();
+
         if (fromInvalid && toInvalid) return false;
         if (fromInvalid || toInvalid) return true;
+
         boolean changed = false;
         if (slot != -1)
         {

--- a/src/main/java/net/minecraftforge/client/ForgeHooksClient.java
+++ b/src/main/java/net/minecraftforge/client/ForgeHooksClient.java
@@ -670,11 +670,11 @@ public class ForgeHooksClient
 
     private static int slotMainHand = 0;
     // FIXME
-    public static boolean shouldCauseReequipAnimation(ItemStack from, ItemStack to, int slot)
+    public static boolean shouldCauseReequipAnimation(@Nonnull ItemStack from, @Nonnull ItemStack to, int slot)
     {
-        if (from == null && to != null) return true;
-        if (from == null && to == null) return false;
-        if (from != null && to == null) return true;
+        boolean fromInvalid = from.func_190926_b(), toInvalid = to.func_190926_b();
+        if (fromInvalid && toInvalid) return false;
+        if (fromInvalid || toInvalid) return true;
         boolean changed = false;
         if (slot != -1)
         {


### PR DESCRIPTION
Noticed this while looking at `ForgeHooksClient`. This just patches the null checks in the usual 1.11 way and adds `@Nonnull` to the `ItemStack` parameters.

Is there anything else that needs the `// FIXME`?