### PR TITLE
[1.10] Deprecate vanilla getExplosionResistance and add correct nullability to state/location aware version

### DIFF
--- a/patches/minecraft/net/minecraft/block/Block.java.patch
+++ b/patches/minecraft/net/minecraft/block/Block.java.patch
@@ -134,16 +134,15 @@
              float f = 0.5F;
              double d0 = (double)(p_180635_0_.field_73012_v.nextFloat() * 0.5F) + 0.25D;
              double d1 = (double)(p_180635_0_.field_73012_v.nextFloat() * 0.5F) + 0.25D;
-@@ -584,7 +591,7 @@
+@@ -584,6 +591,7 @@
          return 0;
      }
  
--    public float func_149638_a(Entity p_149638_1_)
-+    public float func_149638_a(@Nullable Entity p_149638_1_)
++    @Deprecated //Forge: New State sensitive version.
+     public float func_149638_a(Entity p_149638_1_)
      {
          return this.field_149781_w / 5.0F;
-     }
-@@ -627,7 +634,7 @@
+@@ -627,7 +635,7 @@
  
      public boolean func_176196_c(World p_176196_1_, BlockPos p_176196_2_)
      {
@@ -152,7 +151,7 @@
      }
  
      public boolean func_180639_a(World p_180639_1_, BlockPos p_180639_2_, IBlockState p_180639_3_, EntityPlayer p_180639_4_, EnumHand p_180639_5_, @Nullable ItemStack p_180639_6_, EnumFacing p_180639_7_, float p_180639_8_, float p_180639_9_, float p_180639_10_)
-@@ -639,6 +646,8 @@
+@@ -639,6 +647,8 @@
      {
      }
  
@@ -161,7 +160,7 @@
      public IBlockState func_180642_a(World p_180642_1_, BlockPos p_180642_2_, EnumFacing p_180642_3_, float p_180642_4_, float p_180642_5_, float p_180642_6_, int p_180642_7_, EntityLivingBase p_180642_8_)
      {
          return this.func_176203_a(p_180642_7_);
-@@ -680,25 +689,35 @@
+@@ -680,25 +690,35 @@
          p_180657_2_.func_71029_a(StatList.func_188055_a(this));
          p_180657_2_.func_71020_j(0.025F);
  
@@ -200,7 +199,7 @@
      }
  
      @Nullable
-@@ -794,9 +813,11 @@
+@@ -794,9 +814,11 @@
      }
  
      @Nullable
@@ -213,7 +212,7 @@
      }
  
      @SideOnly(Side.CLIENT)
-@@ -883,6 +904,7 @@
+@@ -883,6 +905,7 @@
          return Block.EnumOffsetType.NONE;
      }
  
@@ -221,7 +220,7 @@
      public SoundType func_185467_w()
      {
          return this.field_149762_H;
-@@ -893,6 +915,1187 @@
+@@ -893,6 +916,1187 @@
          return "Block{" + field_149771_c.func_177774_c(this) + "}";
      }
  
@@ -743,7 +742,7 @@
 +    }
 +
 +    /**
-+     * Location sensitive version of getExplosionRestance
++     * Location sensitive version of getExplosionResistance
 +     *
 +     * @param world The current world
 +     * @param pos Block position in world
@@ -1409,7 +1408,7 @@
      public static void func_149671_p()
      {
          func_176215_a(0, field_176230_a, (new BlockAir()).func_149663_c("air"));
-@@ -1169,11 +2372,7 @@
+@@ -1169,11 +2373,7 @@
              }
              else
              {

--- a/patches/minecraft/net/minecraft/block/Block.java.patch
+++ b/patches/minecraft/net/minecraft/block/Block.java.patch
@@ -134,6 +134,15 @@
              float f = 0.5F;
              double d0 = (double)(p_180635_0_.field_73012_v.nextFloat() * 0.5F) + 0.25D;
              double d1 = (double)(p_180635_0_.field_73012_v.nextFloat() * 0.5F) + 0.25D;
+@@ -584,7 +591,7 @@
+         return 0;
+     }
+ 
+-    public float func_149638_a(Entity p_149638_1_)
++    public float func_149638_a(@Nullable Entity p_149638_1_)
+     {
+         return this.field_149781_w / 5.0F;
+     }
 @@ -627,7 +634,7 @@
  
      public boolean func_176196_c(World p_176196_1_, BlockPos p_176196_2_)
@@ -742,7 +751,7 @@
 +     * @param explosion The explosion
 +     * @return The amount of the explosion absorbed.
 +     */
-+    public float getExplosionResistance(World world, BlockPos pos, Entity exploder, Explosion explosion)
++    public float getExplosionResistance(World world, BlockPos pos, @Nullable Entity exploder, Explosion explosion)
 +    {
 +        return func_149638_a(exploder);
 +    }

--- a/patches/minecraft/net/minecraft/block/BlockStairs.java.patch
+++ b/patches/minecraft/net/minecraft/block/BlockStairs.java.patch
@@ -1,5 +1,14 @@
 --- ../src-base/minecraft/net/minecraft/block/BlockStairs.java
 +++ ../src-work/minecraft/net/minecraft/block/BlockStairs.java
+@@ -188,7 +188,7 @@
+         return this.field_150151_M.func_185889_a(p_185484_2_, p_185484_3_);
+     }
+ 
+-    public float func_149638_a(Entity p_149638_1_)
++    public float func_149638_a(@Nullable Entity p_149638_1_)
+     {
+         return this.field_150149_b.func_149638_a(p_149638_1_);
+     }
 @@ -445,6 +445,29 @@
          return new BlockStateContainer(this, new IProperty[] {field_176309_a, field_176308_b, field_176310_M});
      }

--- a/patches/minecraft/net/minecraft/block/BlockStairs.java.patch
+++ b/patches/minecraft/net/minecraft/block/BlockStairs.java.patch
@@ -1,14 +1,5 @@
 --- ../src-base/minecraft/net/minecraft/block/BlockStairs.java
 +++ ../src-work/minecraft/net/minecraft/block/BlockStairs.java
-@@ -188,7 +188,7 @@
-         return this.field_150151_M.func_185889_a(p_185484_2_, p_185484_3_);
-     }
- 
--    public float func_149638_a(Entity p_149638_1_)
-+    public float func_149638_a(@Nullable Entity p_149638_1_)
-     {
-         return this.field_150149_b.func_149638_a(p_149638_1_);
-     }
 @@ -445,6 +445,29 @@
          return new BlockStateContainer(this, new IProperty[] {field_176309_a, field_176308_b, field_176310_M});
      }


### PR DESCRIPTION
`getExplosionResistance`, both the location/state aware and the other, has a nullable `exploder` parameter as stated in javadocs, and is also called with null in Explosion::doExplosionA(). They are unfortunately not annotated as such, violating `@ParametersAreNonnullByDefault`.

This contract violation caused a crash issue for one of my mods.

This PR fixes the issue by simply adding `@Nullable` where expected.