### PR TITLE
[1.10] Prevent a crash when scheduling block updates for non-existing blocks

### DIFF
--- a/patches/minecraft/net/minecraft/block/Block.java.patch
+++ b/patches/minecraft/net/minecraft/block/Block.java.patch
@@ -26,6 +26,15 @@
      }
  
      public static IBlockState func_176220_d(int p_176220_0_)
+@@ -116,7 +118,7 @@
+             }
+             catch (NumberFormatException var3)
+             {
+-                return null;
++                return net.minecraft.init.Blocks.field_150350_a;
+             }
+         }
+     }
 @@ -292,7 +294,7 @@
  
      public boolean func_176200_f(IBlockAccess p_176200_1_, BlockPos p_176200_2_)

--- a/patches/minecraft/net/minecraft/command/server/CommandTestForBlock.java.patch
+++ b/patches/minecraft/net/minecraft/command/server/CommandTestForBlock.java.patch
@@ -1,5 +1,14 @@
 --- ../src-base/minecraft/net/minecraft/command/server/CommandTestForBlock.java
 +++ ../src-work/minecraft/net/minecraft/command/server/CommandTestForBlock.java
+@@ -49,7 +49,7 @@
+             BlockPos blockpos = func_175757_a(p_184881_2_, p_184881_3_, 0, false);
+             Block block = Block.func_149684_b(p_184881_3_[3]);
+ 
+-            if (block == null)
++            if (block == net.minecraft.init.Blocks.field_150350_a && ! p_184881_3_[3].equals("air") && ! p_184881_3_[3].equals("minecraft:air"))
+             {
+                 throw new NumberInvalidException("commands.setblock.notFound", new Object[] {p_184881_3_[3]});
+             }
 @@ -73,7 +73,7 @@
                      NBTTagCompound nbttagcompound = new NBTTagCompound();
                      boolean flag = false;

--- a/patches/minecraft/net/minecraft/item/ItemStack.java.patch
+++ b/patches/minecraft/net/minecraft/item/ItemStack.java.patch
@@ -203,6 +203,24 @@
      }
  
      public static boolean func_179545_c(@Nullable ItemStack p_179545_0_, @Nullable ItemStack p_179545_1_)
+@@ -712,7 +739,7 @@
+                 {
+                     Block block = Block.func_149684_b(nbttaglist1.func_150307_f(j1));
+ 
+-                    if (block != null)
++                    if (block != net.minecraft.init.Blocks.field_150350_a)
+                     {
+                         list.add(TextFormatting.DARK_GRAY + block.func_149732_F());
+                     }
+@@ -737,7 +764,7 @@
+                 {
+                     Block block1 = Block.func_149684_b(nbttaglist2.func_150307_f(k1));
+ 
+-                    if (block1 != null)
++                    if (block1 != net.minecraft.init.Blocks.field_150350_a)
+                     {
+                         list.add(TextFormatting.DARK_GRAY + block1.func_149732_F());
+                     }
 @@ -764,6 +791,7 @@
              }
          }

--- a/patches/minecraft/net/minecraft/world/gen/FlatGeneratorInfo.java.patch
+++ b/patches/minecraft/net/minecraft/world/gen/FlatGeneratorInfo.java.patch
@@ -1,0 +1,20 @@
+--- ../src-base/minecraft/net/minecraft/world/gen/FlatGeneratorInfo.java
++++ ../src-work/minecraft/net/minecraft/world/gen/FlatGeneratorInfo.java
+@@ -161,7 +161,7 @@
+                 astring = s.split(":", 3);
+                 block = astring.length > 1 ? Block.func_149684_b(astring[0] + ":" + astring[1]) : null;
+ 
+-                if (block != null)
++                if (block != null && (block != Blocks.field_150350_a || (astring[0].equals("minecraft") && astring[1].equals("air"))))
+                 {
+                     j = astring.length > 2 ? Integer.parseInt(astring[2]) : 0;
+                 }
+@@ -169,7 +169,7 @@
+                 {
+                     block = Block.func_149684_b(astring[0]);
+ 
+-                    if (block != null)
++                    if (block == Blocks.field_150350_a && ! astring[0].equals("air")) { return null; } else
+                     {
+                         j = astring.length > 1 ? Integer.parseInt(astring[1]) : 0;
+                     }


### PR DESCRIPTION
This fixes a crash when trying to load scheduled block updates from Chunk
NBT data (see AnvilChunkLoader#loadEntities()) for blocks that don't exist
anymore for whatever reason (maybe a mod was removed for example).