### PR TITLE
[1.11] Added a world sensitive version of getRenderType

### DIFF
--- a/patches/minecraft/net/minecraft/block/Block.java.patch
+++ b/patches/minecraft/net/minecraft/block/Block.java.patch
@@ -197,7 +197,7 @@
      public SoundType func_185467_w()
      {
          return this.field_149762_H;
-@@ -908,6 +932,1166 @@
+@@ -908,6 +932,1182 @@
      {
      }
  
@@ -1359,12 +1359,28 @@
 +        return false;
 +    }
 +
++    /**
++     * A world sensitive version of getRenderType
++     *
++     * The type of render function called. MODEL for mixed tesr and static model, MODELBLOCK_ANIMATED for TESR-only,
++     * LIQUID for vanilla liquids, INVISIBLE to skip all rendering
++     *
++     * @param world The current world
++     * @param pos The position of this block
++     * @param state The current state of this block
++     * @return The RenderType how the block should be rendered
++     */
++    public EnumBlockRenderType getRenderType(IBlockAccess world, BlockPos pos, IBlockState state)
++    {
++        return func_149645_b(state);
++    }
++
 +    /* ========================================= FORGE END ======================================*/
 +
      public static void func_149671_p()
      {
          func_176215_a(0, field_176230_a, (new BlockAir()).func_149663_c("air"));
-@@ -1201,14 +2385,7 @@
+@@ -1201,14 +2401,7 @@
              }
              else
              {

--- a/patches/minecraft/net/minecraft/client/renderer/BlockRendererDispatcher.java.patch
+++ b/patches/minecraft/net/minecraft/client/renderer/BlockRendererDispatcher.java.patch
@@ -18,6 +18,15 @@
              this.field_175027_c.func_178267_a(p_175020_4_, ibakedmodel1, p_175020_1_, p_175020_2_, Tessellator.func_178181_a().func_178180_c(), true);
          }
      }
+@@ -52,7 +52,7 @@
+     {
+         try
+         {
+-            EnumBlockRenderType enumblockrendertype = p_175018_1_.func_185901_i();
++            EnumBlockRenderType enumblockrendertype = p_175018_1_.func_177230_c().getRenderType(p_175018_3_, p_175018_2_, p_175018_1_);
+ 
+             if (enumblockrendertype == EnumBlockRenderType.INVISIBLE)
+             {
 @@ -75,7 +75,9 @@
                  switch (enumblockrendertype)
                  {


### PR DESCRIPTION
In my current modding project I need to define the render type of the block with the blockstate of the block, but the blockstate that is given of the normal getRenderType method does not contains the correct values. If I check in another method the state.getActualState method, then I see that it contains the correct property values. With this pr it is possible to get the actual state in the getRenderType method, so that I can solve my problem and maybe other Modder too.