### PR TITLE
[1.11] Patch EntityPlayerSP to use location-aware version of isNormalCube

### DIFF
--- a/patches/minecraft/net/minecraft/block/Block.java.patch
+++ b/patches/minecraft/net/minecraft/block/Block.java.patch
@@ -247,7 +247,7 @@
 +     */
 +    public boolean isNormalCube(IBlockState state, IBlockAccess world, BlockPos pos)
 +    {
-+        return state.func_185904_a().func_76218_k() && state.func_185917_h() && !state.func_185897_m();
++        return state.func_185915_l();
 +    }
 +
 +    /**

--- a/patches/minecraft/net/minecraft/client/entity/EntityPlayerSP.java.patch
+++ b/patches/minecraft/net/minecraft/client/entity/EntityPlayerSP.java.patch
@@ -56,16 +56,17 @@
                  {
                      d2 = 1.0D - d1;
                      i = 5;
-@@ -498,7 +511,7 @@
+@@ -498,7 +511,8 @@
  
      private boolean func_175162_d(BlockPos p_175162_1_)
      {
 -        return !this.field_70170_p.func_180495_p(p_175162_1_).func_185915_l() && !this.field_70170_p.func_180495_p(p_175162_1_.func_177984_a()).func_185915_l();
-+        return !this.field_70170_p.func_180495_p(p_175162_1_).func_185915_l();
++        IBlockState iblockstate = field_70170_p.func_180495_p(p_175162_1_);
++        return !iblockstate.func_177230_c().isNormalCube(iblockstate, field_70170_p, p_175162_1_);
      }
  
      public void func_70031_b(boolean p_70031_1_)
-@@ -543,7 +556,13 @@
+@@ -543,7 +557,13 @@
  
      public void func_184185_a(SoundEvent p_184185_1_, float p_184185_2_, float p_184185_3_)
      {


### PR DESCRIPTION
Cherry-picked from #3304. This patches `EntityPlayerSP.isOpenBlockSpace()` to use the Forge provided version of `Block.isNormalCube()` which takes additional `IBlockAccess`/`BlockPos` parameters.

As the collision/bounding box functions all provide these parameters, this allows blocks overriding those functions to have consistent collision behavior between client/server.

Also, the implementation of `isNormalCube` is changed to call through to the original method, so that overrides of that method are respected, but if there is some reason why that should not be the case, please let me know and I'll change it.