### PR TITLE
[1.10] Made WalkNodeProcessor consider burning blocks

### DIFF
--- a/patches/minecraft/net/minecraft/pathfinding/WalkNodeProcessor.java.patch
+++ b/patches/minecraft/net/minecraft/pathfinding/WalkNodeProcessor.java.patch
@@ -4,7 +4,7 @@
                          {
                              pathnodetype = PathNodeType.DANGER_FIRE;
                          }
-+                        else if(block1.isBurning(p_186330_1_, blockpos$pooledmutableblockpos.func_181079_c(j + p_186330_2_, p_186330_3_, i + p_186330_4_))) pathnodetype = PathNodeType.DAMAGE_FIRE;
++                        else if(block1.isBurning(p_186330_1_, blockpos$pooledmutableblockpos.func_181079_c(j + p_186330_2_, p_186330_3_, i + p_186330_4_))) pathnodetype = PathNodeType.DANGER_FIRE;
                      }
                  }
              }

--- a/patches/minecraft/net/minecraft/pathfinding/WalkNodeProcessor.java.patch
+++ b/patches/minecraft/net/minecraft/pathfinding/WalkNodeProcessor.java.patch
@@ -1,0 +1,18 @@
+--- ../src-base/minecraft/net/minecraft/pathfinding/WalkNodeProcessor.java
++++ ../src-work/minecraft/net/minecraft/pathfinding/WalkNodeProcessor.java
+@@ -415,6 +415,7 @@
+                         {
+                             pathnodetype = PathNodeType.DANGER_FIRE;
+                         }
++                        else if(block1.isBurning(p_186330_1_, blockpos$pooledmutableblockpos.func_181079_c(j + p_186330_2_, p_186330_3_, i + p_186330_4_))) pathnodetype = PathNodeType.DAMAGE_FIRE;
+                     }
+                 }
+             }
+@@ -430,6 +431,6 @@
+         IBlockState iblockstate = p_189553_1_.func_180495_p(blockpos);
+         Block block = iblockstate.func_177230_c();
+         Material material = iblockstate.func_185904_a();
+-        return material == Material.field_151579_a ? PathNodeType.OPEN : (block != Blocks.field_150415_aT && block != Blocks.field_180400_cw && block != Blocks.field_150392_bi ? (block == Blocks.field_150480_ab ? PathNodeType.DAMAGE_FIRE : (block == Blocks.field_150434_aF ? PathNodeType.DAMAGE_CACTUS : (block instanceof BlockDoor && material == Material.field_151575_d && !((Boolean)iblockstate.func_177229_b(BlockDoor.field_176519_b)).booleanValue() ? PathNodeType.DOOR_WOOD_CLOSED : (block instanceof BlockDoor && material == Material.field_151573_f && !((Boolean)iblockstate.func_177229_b(BlockDoor.field_176519_b)).booleanValue() ? PathNodeType.DOOR_IRON_CLOSED : (block instanceof BlockDoor && ((Boolean)iblockstate.func_177229_b(BlockDoor.field_176519_b)).booleanValue() ? PathNodeType.DOOR_OPEN : (block instanceof BlockRailBase ? PathNodeType.RAIL : (!(block instanceof BlockFence) && !(block instanceof BlockWall) && (!(block instanceof BlockFenceGate) || ((Boolean)iblockstate.func_177229_b(BlockFenceGate.field_176466_a)).booleanValue()) ? (material == Material.field_151586_h ? PathNodeType.WATER : (material == Material.field_151587_i ? PathNodeType.LAVA : (block.func_176205_b(p_189553_1_, blockpos) ? PathNodeType.OPEN : PathNodeType.BLOCKED))) : PathNodeType.FENCE))))))) : PathNodeType.TRAPDOOR);
++        return material == Material.field_151579_a ? PathNodeType.OPEN : (block != Blocks.field_150415_aT && block != Blocks.field_180400_cw && block != Blocks.field_150392_bi ? (block == Blocks.field_150480_ab ? PathNodeType.DAMAGE_FIRE : (block.isBurning(p_189553_1_, blockpos) ? PathNodeType.DAMAGE_FIRE : (block == Blocks.field_150434_aF ? PathNodeType.DAMAGE_CACTUS : (block instanceof BlockDoor && material == Material.field_151575_d && !((Boolean)iblockstate.func_177229_b(BlockDoor.field_176519_b)).booleanValue() ? PathNodeType.DOOR_WOOD_CLOSED : (block instanceof BlockDoor && material == Material.field_151573_f && !((Boolean)iblockstate.func_177229_b(BlockDoor.field_176519_b)).booleanValue() ? PathNodeType.DOOR_IRON_CLOSED : (block instanceof BlockDoor && ((Boolean)iblockstate.func_177229_b(BlockDoor.field_176519_b)).booleanValue() ? PathNodeType.DOOR_OPEN : (block instanceof BlockRailBase ? PathNodeType.RAIL : (!(block instanceof BlockFence) && !(block instanceof BlockWall) && (!(block instanceof BlockFenceGate) || ((Boolean)iblockstate.func_177229_b(BlockFenceGate.field_176466_a)).booleanValue()) ? (material == Material.field_151586_h ? PathNodeType.WATER : (material == Material.field_151587_i ? PathNodeType.LAVA : (block.func_176205_b(p_189553_1_, blockpos) ? PathNodeType.OPEN : PathNodeType.BLOCKED))) : PathNodeType.FENCE)))))))) : PathNodeType.TRAPDOOR);
+     }
+ }


### PR DESCRIPTION
Forge adds the method `isBurning` to blocks, which is used to check if a entity should start burning if it is in this block.
Unfortunately the path finding does not care about this. While vanilla fire blocks are avoided, it does not care about blocks, which use `isBurning` to set entities on fire.

This PR adds a check for `isBurning` blocks in addition to the vanilla fire check.