### PR TITLE
Fix uses of uppercase "Forge" where it fails Loader.isModLoaded(modID)

### DIFF
--- a/src/main/java/net/minecraftforge/client/gui/ForgeGuiFactory.java
+++ b/src/main/java/net/minecraftforge/client/gui/ForgeGuiFactory.java
@@ -116,7 +116,7 @@ public class ForgeGuiFactory implements IModGuiFactory
     {
         public ForgeConfigGui(GuiScreen parentScreen)
         {
-            super(parentScreen, getConfigElements(), ForgeModContainer.MOD_ID, false, false, I18n.format("forge.configgui.forgeConfigTitle"));
+            super(parentScreen, getConfigElements(), ForgeVersion.MOD_ID, false, false, I18n.format("forge.configgui.forgeConfigTitle"));
         }
 
         private static List<IConfigElement> getConfigElements()

--- a/src/main/java/net/minecraftforge/client/gui/ForgeGuiFactory.java
+++ b/src/main/java/net/minecraftforge/client/gui/ForgeGuiFactory.java
@@ -116,7 +116,7 @@ public class ForgeGuiFactory implements IModGuiFactory
     {
         public ForgeConfigGui(GuiScreen parentScreen)
         {
-            super(parentScreen, getConfigElements(), "forge", false, false, I18n.format("forge.configgui.forgeConfigTitle"));
+            super(parentScreen, getConfigElements(), ForgeModContainer.MOD_ID, false, false, I18n.format("forge.configgui.forgeConfigTitle"));
         }
 
         private static List<IConfigElement> getConfigElements()

--- a/src/main/java/net/minecraftforge/client/gui/ForgeGuiFactory.java
+++ b/src/main/java/net/minecraftforge/client/gui/ForgeGuiFactory.java
@@ -116,7 +116,7 @@ public class ForgeGuiFactory implements IModGuiFactory
     {
         public ForgeConfigGui(GuiScreen parentScreen)
         {
-            super(parentScreen, getConfigElements(), "Forge", false, false, I18n.format("forge.configgui.forgeConfigTitle"));
+            super(parentScreen, getConfigElements(), "forge", false, false, I18n.format("forge.configgui.forgeConfigTitle"));
         }
 
         private static List<IConfigElement> getConfigElements()

--- a/src/main/java/net/minecraftforge/client/gui/NotificationModUpdateScreen.java
+++ b/src/main/java/net/minecraftforge/client/gui/NotificationModUpdateScreen.java
@@ -37,7 +37,7 @@ import net.minecraftforge.fml.relauncher.SideOnly;
 public class NotificationModUpdateScreen extends GuiScreen
 {
 
-    private static final ResourceLocation VERSION_CHECK_ICONS = new ResourceLocation(ForgeModContainer.MOD_ID, "textures/gui/version_check_icons.png");
+    private static final ResourceLocation VERSION_CHECK_ICONS = new ResourceLocation(ForgeVersion.MOD_ID, "textures/gui/version_check_icons.png");
 
     private final GuiButton modButton;
     private Status showNotification = null;

--- a/src/main/java/net/minecraftforge/client/gui/NotificationModUpdateScreen.java
+++ b/src/main/java/net/minecraftforge/client/gui/NotificationModUpdateScreen.java
@@ -37,7 +37,7 @@ import net.minecraftforge.fml.relauncher.SideOnly;
 public class NotificationModUpdateScreen extends GuiScreen
 {
 
-    private static final ResourceLocation VERSION_CHECK_ICONS = new ResourceLocation("forge", "textures/gui/version_check_icons.png");
+    private static final ResourceLocation VERSION_CHECK_ICONS = new ResourceLocation(ForgeModContainer.MOD_ID, "textures/gui/version_check_icons.png");
 
     private final GuiButton modButton;
     private Status showNotification = null;

--- a/src/main/java/net/minecraftforge/client/model/ItemLayerModel.java
+++ b/src/main/java/net/minecraftforge/client/model/ItemLayerModel.java
@@ -27,7 +27,7 @@ import java.util.List;
 import javax.vecmath.Matrix4f;
 import javax.vecmath.Vector4f;
 
-import net.minecraftforge.common.ForgeModContainer;
+import net.minecraftforge.common.ForgeVersion;
 import org.apache.commons.lang3.tuple.Pair;
 
 import net.minecraft.block.state.IBlockState;
@@ -426,7 +426,7 @@ public final class ItemLayerModel implements IRetexturableModel
 
         public boolean accepts(ResourceLocation modelLocation)
         {
-            return modelLocation.getResourceDomain().equals(ForgeModContainer.MOD_ID) && (
+            return modelLocation.getResourceDomain().equals(ForgeVersion.MOD_ID) && (
                 modelLocation.getResourcePath().equals("item-layer") ||
                 modelLocation.getResourcePath().equals("models/block/item-layer") ||
                 modelLocation.getResourcePath().equals("models/item/item-layer"));

--- a/src/main/java/net/minecraftforge/client/model/ItemLayerModel.java
+++ b/src/main/java/net/minecraftforge/client/model/ItemLayerModel.java
@@ -27,6 +27,7 @@ import java.util.List;
 import javax.vecmath.Matrix4f;
 import javax.vecmath.Vector4f;
 
+import net.minecraftforge.common.ForgeModContainer;
 import org.apache.commons.lang3.tuple.Pair;
 
 import net.minecraft.block.state.IBlockState;
@@ -425,7 +426,7 @@ public final class ItemLayerModel implements IRetexturableModel
 
         public boolean accepts(ResourceLocation modelLocation)
         {
-            return modelLocation.getResourceDomain().equals("forge") && (
+            return modelLocation.getResourceDomain().equals(ForgeModContainer.MOD_ID) && (
                 modelLocation.getResourcePath().equals("item-layer") ||
                 modelLocation.getResourcePath().equals("models/block/item-layer") ||
                 modelLocation.getResourcePath().equals("models/item/item-layer"));

--- a/src/main/java/net/minecraftforge/client/model/ModelDynBucket.java
+++ b/src/main/java/net/minecraftforge/client/model/ModelDynBucket.java
@@ -45,6 +45,7 @@ import net.minecraft.item.ItemStack;
 import net.minecraft.util.EnumFacing;
 import net.minecraft.util.ResourceLocation;
 import net.minecraft.world.World;
+import net.minecraftforge.common.ForgeModContainer;
 import net.minecraftforge.common.model.IModelPart;
 import net.minecraftforge.common.model.IModelState;
 import net.minecraftforge.common.model.TRSRTransformation;
@@ -64,7 +65,7 @@ import com.google.common.collect.Maps;
 
 public final class ModelDynBucket implements IModel, IModelCustomData, IRetexturableModel
 {
-    public static final ModelResourceLocation LOCATION = new ModelResourceLocation(new ResourceLocation("forge", "dynbucket"), "inventory");
+    public static final ModelResourceLocation LOCATION = new ModelResourceLocation(new ResourceLocation(ForgeModContainer.MOD_ID, "dynbucket"), "inventory");
 
     // minimal Z offset to prevent depth-fighting
     private static final float NORTH_Z_BASE = 7.496f / 16f;
@@ -230,7 +231,7 @@ public final class ModelDynBucket implements IModel, IModelCustomData, IRetextur
         @Override
         public boolean accepts(ResourceLocation modelLocation)
         {
-            return modelLocation.getResourceDomain().equals("forge") && modelLocation.getResourcePath().contains("forgebucket");
+            return modelLocation.getResourceDomain().equals(ForgeModContainer.MOD_ID) && modelLocation.getResourcePath().contains("forgebucket");
         }
 
         @Override

--- a/src/main/java/net/minecraftforge/client/model/ModelDynBucket.java
+++ b/src/main/java/net/minecraftforge/client/model/ModelDynBucket.java
@@ -45,7 +45,7 @@ import net.minecraft.item.ItemStack;
 import net.minecraft.util.EnumFacing;
 import net.minecraft.util.ResourceLocation;
 import net.minecraft.world.World;
-import net.minecraftforge.common.ForgeModContainer;
+import net.minecraftforge.common.ForgeVersion;
 import net.minecraftforge.common.model.IModelPart;
 import net.minecraftforge.common.model.IModelState;
 import net.minecraftforge.common.model.TRSRTransformation;
@@ -65,7 +65,7 @@ import com.google.common.collect.Maps;
 
 public final class ModelDynBucket implements IModel, IModelCustomData, IRetexturableModel
 {
-    public static final ModelResourceLocation LOCATION = new ModelResourceLocation(new ResourceLocation(ForgeModContainer.MOD_ID, "dynbucket"), "inventory");
+    public static final ModelResourceLocation LOCATION = new ModelResourceLocation(new ResourceLocation(ForgeVersion.MOD_ID, "dynbucket"), "inventory");
 
     // minimal Z offset to prevent depth-fighting
     private static final float NORTH_Z_BASE = 7.496f / 16f;
@@ -231,7 +231,7 @@ public final class ModelDynBucket implements IModel, IModelCustomData, IRetextur
         @Override
         public boolean accepts(ResourceLocation modelLocation)
         {
-            return modelLocation.getResourceDomain().equals(ForgeModContainer.MOD_ID) && modelLocation.getResourcePath().contains("forgebucket");
+            return modelLocation.getResourceDomain().equals(ForgeVersion.MOD_ID) && modelLocation.getResourcePath().contains("forgebucket");
         }
 
         @Override

--- a/src/main/java/net/minecraftforge/client/model/ModelFluid.java
+++ b/src/main/java/net/minecraftforge/client/model/ModelFluid.java
@@ -41,7 +41,7 @@ import net.minecraft.util.EnumFacing;
 import net.minecraft.util.ResourceLocation;
 import net.minecraft.util.math.MathHelper;
 import net.minecraftforge.client.model.pipeline.UnpackedBakedQuad;
-import net.minecraftforge.common.ForgeModContainer;
+import net.minecraftforge.common.ForgeVersion;
 import net.minecraftforge.common.model.IModelPart;
 import net.minecraftforge.common.model.IModelState;
 import net.minecraftforge.common.model.TRSRTransformation;
@@ -105,7 +105,7 @@ public final class ModelFluid implements IModelCustomData
 
         public boolean accepts(ResourceLocation modelLocation)
         {
-            return modelLocation.getResourceDomain().equals(ForgeModContainer.MOD_ID) && (
+            return modelLocation.getResourceDomain().equals(ForgeVersion.MOD_ID) && (
                 modelLocation.getResourcePath().equals("fluid") ||
                 modelLocation.getResourcePath().equals("models/block/fluid") ||
                 modelLocation.getResourcePath().equals("models/item/fluid"));

--- a/src/main/java/net/minecraftforge/client/model/ModelFluid.java
+++ b/src/main/java/net/minecraftforge/client/model/ModelFluid.java
@@ -41,6 +41,7 @@ import net.minecraft.util.EnumFacing;
 import net.minecraft.util.ResourceLocation;
 import net.minecraft.util.math.MathHelper;
 import net.minecraftforge.client.model.pipeline.UnpackedBakedQuad;
+import net.minecraftforge.common.ForgeModContainer;
 import net.minecraftforge.common.model.IModelPart;
 import net.minecraftforge.common.model.IModelState;
 import net.minecraftforge.common.model.TRSRTransformation;
@@ -104,7 +105,7 @@ public final class ModelFluid implements IModelCustomData
 
         public boolean accepts(ResourceLocation modelLocation)
         {
-            return modelLocation.getResourceDomain().equals("forge") && (
+            return modelLocation.getResourceDomain().equals(ForgeModContainer.MOD_ID) && (
                 modelLocation.getResourcePath().equals("fluid") ||
                 modelLocation.getResourcePath().equals("models/block/fluid") ||
                 modelLocation.getResourcePath().equals("models/item/fluid"));

--- a/src/main/java/net/minecraftforge/client/model/ModelLoader.java
+++ b/src/main/java/net/minecraftforge/client/model/ModelLoader.java
@@ -360,7 +360,7 @@ public final class ModelLoader extends ModelBakery
             for(String s : getVariantNames(Items.BUCKET))
             {
                 ModelResourceLocation memory = getInventoryVariant(s);
-                IModel model = ModelLoaderRegistry.getModelOrMissing(new ResourceLocation("forge", "item/bucket"));
+                IModel model = ModelLoaderRegistry.getModelOrMissing(new ResourceLocation(ForgeModContainer.MOD_ID, "item/bucket"));
                 // only on successful load, otherwise continue using the old model
                 if(model != getMissingModel())
                 {
@@ -388,7 +388,7 @@ public final class ModelLoader extends ModelBakery
                 for(String s : getVariantNames(Items.MILK_BUCKET))
                 {
                     ModelResourceLocation memory = getInventoryVariant(s);
-                    IModel model = ModelLoaderRegistry.getModelOrMissing(new ResourceLocation("forge", "item/bucket_milk"));
+                    IModel model = ModelLoaderRegistry.getModelOrMissing(new ResourceLocation(ForgeModContainer.MOD_ID, "item/bucket_milk"));
                     // only on successful load, otherwise continue using the old model
                     if(model != getMissingModel())
                     {

--- a/src/main/java/net/minecraftforge/client/model/ModelLoader.java
+++ b/src/main/java/net/minecraftforge/client/model/ModelLoader.java
@@ -80,6 +80,7 @@ import net.minecraftforge.client.model.animation.AnimationItemOverrideList;
 import net.minecraftforge.client.model.animation.IAnimatedModel;
 import net.minecraftforge.client.model.animation.ModelBlockAnimation;
 import net.minecraftforge.common.ForgeModContainer;
+import net.minecraftforge.common.ForgeVersion;
 import net.minecraftforge.common.model.IModelPart;
 import net.minecraftforge.common.model.IModelState;
 import net.minecraftforge.common.model.Models;
@@ -360,7 +361,7 @@ public final class ModelLoader extends ModelBakery
             for(String s : getVariantNames(Items.BUCKET))
             {
                 ModelResourceLocation memory = getInventoryVariant(s);
-                IModel model = ModelLoaderRegistry.getModelOrMissing(new ResourceLocation(ForgeModContainer.MOD_ID, "item/bucket"));
+                IModel model = ModelLoaderRegistry.getModelOrMissing(new ResourceLocation(ForgeVersion.MOD_ID, "item/bucket"));
                 // only on successful load, otherwise continue using the old model
                 if(model != getMissingModel())
                 {
@@ -388,7 +389,7 @@ public final class ModelLoader extends ModelBakery
                 for(String s : getVariantNames(Items.MILK_BUCKET))
                 {
                     ModelResourceLocation memory = getInventoryVariant(s);
-                    IModel model = ModelLoaderRegistry.getModelOrMissing(new ResourceLocation(ForgeModContainer.MOD_ID, "item/bucket_milk"));
+                    IModel model = ModelLoaderRegistry.getModelOrMissing(new ResourceLocation(ForgeVersion.MOD_ID, "item/bucket_milk"));
                     // only on successful load, otherwise continue using the old model
                     if(model != getMissingModel())
                     {

--- a/src/main/java/net/minecraftforge/client/model/MultiLayerModel.java
+++ b/src/main/java/net/minecraftforge/client/model/MultiLayerModel.java
@@ -38,6 +38,7 @@ import net.minecraft.util.BlockRenderLayer;
 import net.minecraft.util.EnumFacing;
 import net.minecraft.util.ResourceLocation;
 import net.minecraftforge.client.MinecraftForgeClient;
+import net.minecraftforge.common.ForgeModContainer;
 import net.minecraftforge.common.model.IModelState;
 import net.minecraftforge.common.model.TRSRTransformation;
 import net.minecraftforge.fml.common.FMLLog;
@@ -248,7 +249,7 @@ public final class MultiLayerModel implements IModelCustomData
 
         public boolean accepts(ResourceLocation modelLocation)
         {
-            return modelLocation.getResourceDomain().equals("forge") && (
+            return modelLocation.getResourceDomain().equals(ForgeModContainer.MOD_ID) && (
                 modelLocation.getResourcePath().equals("multi-layer") ||
                 modelLocation.getResourcePath().equals("models/block/multi-layer") ||
                 modelLocation.getResourcePath().equals("models/item/multi-layer"));

--- a/src/main/java/net/minecraftforge/client/model/MultiLayerModel.java
+++ b/src/main/java/net/minecraftforge/client/model/MultiLayerModel.java
@@ -38,7 +38,7 @@ import net.minecraft.util.BlockRenderLayer;
 import net.minecraft.util.EnumFacing;
 import net.minecraft.util.ResourceLocation;
 import net.minecraftforge.client.MinecraftForgeClient;
-import net.minecraftforge.common.ForgeModContainer;
+import net.minecraftforge.common.ForgeVersion;
 import net.minecraftforge.common.model.IModelState;
 import net.minecraftforge.common.model.TRSRTransformation;
 import net.minecraftforge.fml.common.FMLLog;
@@ -249,7 +249,7 @@ public final class MultiLayerModel implements IModelCustomData
 
         public boolean accepts(ResourceLocation modelLocation)
         {
-            return modelLocation.getResourceDomain().equals(ForgeModContainer.MOD_ID) && (
+            return modelLocation.getResourceDomain().equals(ForgeVersion.MOD_ID) && (
                 modelLocation.getResourcePath().equals("multi-layer") ||
                 modelLocation.getResourcePath().equals("models/block/multi-layer") ||
                 modelLocation.getResourcePath().equals("models/item/multi-layer"));

--- a/src/main/java/net/minecraftforge/common/ForgeChunkManager.java
+++ b/src/main/java/net/minecraftforge/common/ForgeChunkManager.java
@@ -494,7 +494,7 @@ public class ForgeChunkManager
             {
                 NBTTagCompound ticketHolder = ticketList.getCompoundTagAt(i);
                 String modId = ticketHolder.getString("Owner");
-                boolean isPlayer = "forge".equals(modId);
+                boolean isPlayer = ForgeModContainer.MOD_ID.equals(modId);
 
                 if (!isPlayer && !Loader.isModLoaded(modId))
                 {
@@ -600,7 +600,7 @@ public class ForgeChunkManager
                     tickets = orderedLoadingCallback.playerTicketsLoaded(ImmutableListMultimap.copyOf(tickets), world);
                     playerTickets.putAll(tickets);
                 }
-                ForgeChunkManager.tickets.get(world).putAll("forge", tickets.values());
+                ForgeChunkManager.tickets.get(world).putAll(ForgeModContainer.MOD_ID, tickets.values());
                 loadingCallback.ticketsLoaded(ImmutableList.copyOf(tickets.values()), world);
             }
         }
@@ -702,7 +702,7 @@ public class ForgeChunkManager
         }
         Ticket ticket = new Ticket(mc.getModId(),type,world,player);
         playerTickets.put(player, ticket);
-        tickets.get(world).put("forge", ticket);
+        tickets.get(world).put(ForgeModContainer.MOD_ID, ticket);
         return ticket;
     }
     /**
@@ -770,7 +770,7 @@ public class ForgeChunkManager
         if (ticket.isPlayerTicket())
         {
             playerTickets.remove(ticket.player, ticket);
-            tickets.get(ticket.world).remove("forge",ticket);
+            tickets.get(ticket.world).remove(ForgeModContainer.MOD_ID, ticket);
         }
         else
         {
@@ -856,7 +856,7 @@ public class ForgeChunkManager
         chunkConstraints.clear();
         for (String mod : config.getCategoryNames())
         {
-            if (mod.equals("forge") || mod.equals("defaults"))
+            if (mod.equals(ForgeModContainer.MOD_ID) || mod.equals("defaults"))
             {
                 continue;
             }
@@ -1061,18 +1061,18 @@ public class ForgeChunkManager
 
         config.setCategoryPropertyOrder("defaults", propOrder);
 
-        config.addCustomCategoryComment("forge", "Sample mod specific control section.\n" +
+        config.addCustomCategoryComment(ForgeModContainer.MOD_ID, "Sample mod specific control section.\n" +
                 "Copy this section and rename the with the modid for the mod you wish to override.\n" +
                 "A value of zero in either entry effectively disables any chunkloading capabilities\n" +
                 "for that mod");
 
-        temp = config.get("forge", "maximumTicketCount", 200);
+        temp = config.get(ForgeModContainer.MOD_ID, "maximumTicketCount", 200);
         temp.setComment("Maximum ticket count for the mod. Zero disables chunkloading capabilities.");
-        temp = config.get("forge", "maximumChunksPerTicket", 25);
+        temp = config.get(ForgeModContainer.MOD_ID, "maximumChunksPerTicket", 25);
         temp.setComment("Maximum chunks per ticket for the mod.");
         for (String mod : config.getCategoryNames())
         {
-            if (mod.equals("forge") || mod.equals("defaults"))
+            if (mod.equals(ForgeModContainer.MOD_ID) || mod.equals("defaults"))
             {
                 continue;
             }
@@ -1101,7 +1101,7 @@ public class ForgeChunkManager
         List<ConfigCategory> list = new ArrayList<ConfigCategory>();
         for (String mod : config.getCategoryNames())
         {
-            if (mod.equals("forge") || mod.equals("defaults"))
+            if (mod.equals(ForgeModContainer.MOD_ID) || mod.equals("defaults"))
             {
                 continue;
             }

--- a/src/main/java/net/minecraftforge/common/ForgeChunkManager.java
+++ b/src/main/java/net/minecraftforge/common/ForgeChunkManager.java
@@ -494,7 +494,7 @@ public class ForgeChunkManager
             {
                 NBTTagCompound ticketHolder = ticketList.getCompoundTagAt(i);
                 String modId = ticketHolder.getString("Owner");
-                boolean isPlayer = "Forge".equals(modId);
+                boolean isPlayer = "forge".equals(modId);
 
                 if (!isPlayer && !Loader.isModLoaded(modId))
                 {
@@ -600,7 +600,7 @@ public class ForgeChunkManager
                     tickets = orderedLoadingCallback.playerTicketsLoaded(ImmutableListMultimap.copyOf(tickets), world);
                     playerTickets.putAll(tickets);
                 }
-                ForgeChunkManager.tickets.get(world).putAll("Forge", tickets.values());
+                ForgeChunkManager.tickets.get(world).putAll("forge", tickets.values());
                 loadingCallback.ticketsLoaded(ImmutableList.copyOf(tickets.values()), world);
             }
         }
@@ -702,7 +702,7 @@ public class ForgeChunkManager
         }
         Ticket ticket = new Ticket(mc.getModId(),type,world,player);
         playerTickets.put(player, ticket);
-        tickets.get(world).put("Forge", ticket);
+        tickets.get(world).put("forge", ticket);
         return ticket;
     }
     /**
@@ -770,7 +770,7 @@ public class ForgeChunkManager
         if (ticket.isPlayerTicket())
         {
             playerTickets.remove(ticket.player, ticket);
-            tickets.get(ticket.world).remove("Forge",ticket);
+            tickets.get(ticket.world).remove("forge",ticket);
         }
         else
         {
@@ -856,7 +856,7 @@ public class ForgeChunkManager
         chunkConstraints.clear();
         for (String mod : config.getCategoryNames())
         {
-            if (mod.equals("Forge") || mod.equals("defaults"))
+            if (mod.equals("forge") || mod.equals("defaults"))
             {
                 continue;
             }
@@ -1061,18 +1061,18 @@ public class ForgeChunkManager
 
         config.setCategoryPropertyOrder("defaults", propOrder);
 
-        config.addCustomCategoryComment("Forge", "Sample mod specific control section.\n" +
+        config.addCustomCategoryComment("forge", "Sample mod specific control section.\n" +
                 "Copy this section and rename the with the modid for the mod you wish to override.\n" +
                 "A value of zero in either entry effectively disables any chunkloading capabilities\n" +
                 "for that mod");
 
-        temp = config.get("Forge", "maximumTicketCount", 200);
+        temp = config.get("forge", "maximumTicketCount", 200);
         temp.setComment("Maximum ticket count for the mod. Zero disables chunkloading capabilities.");
-        temp = config.get("Forge", "maximumChunksPerTicket", 25);
+        temp = config.get("forge", "maximumChunksPerTicket", 25);
         temp.setComment("Maximum chunks per ticket for the mod.");
         for (String mod : config.getCategoryNames())
         {
-            if (mod.equals("Forge") || mod.equals("defaults"))
+            if (mod.equals("forge") || mod.equals("defaults"))
             {
                 continue;
             }
@@ -1101,7 +1101,7 @@ public class ForgeChunkManager
         List<ConfigCategory> list = new ArrayList<ConfigCategory>();
         for (String mod : config.getCategoryNames())
         {
-            if (mod.equals("Forge") || mod.equals("defaults"))
+            if (mod.equals("forge") || mod.equals("defaults"))
             {
                 continue;
             }

--- a/src/main/java/net/minecraftforge/common/ForgeChunkManager.java
+++ b/src/main/java/net/minecraftforge/common/ForgeChunkManager.java
@@ -494,7 +494,7 @@ public class ForgeChunkManager
             {
                 NBTTagCompound ticketHolder = ticketList.getCompoundTagAt(i);
                 String modId = ticketHolder.getString("Owner");
-                boolean isPlayer = ForgeModContainer.MOD_ID.equals(modId);
+                boolean isPlayer = ForgeVersion.MOD_ID.equals(modId);
 
                 if (!isPlayer && !Loader.isModLoaded(modId))
                 {
@@ -600,7 +600,7 @@ public class ForgeChunkManager
                     tickets = orderedLoadingCallback.playerTicketsLoaded(ImmutableListMultimap.copyOf(tickets), world);
                     playerTickets.putAll(tickets);
                 }
-                ForgeChunkManager.tickets.get(world).putAll(ForgeModContainer.MOD_ID, tickets.values());
+                ForgeChunkManager.tickets.get(world).putAll(ForgeVersion.MOD_ID, tickets.values());
                 loadingCallback.ticketsLoaded(ImmutableList.copyOf(tickets.values()), world);
             }
         }
@@ -702,7 +702,7 @@ public class ForgeChunkManager
         }
         Ticket ticket = new Ticket(mc.getModId(),type,world,player);
         playerTickets.put(player, ticket);
-        tickets.get(world).put(ForgeModContainer.MOD_ID, ticket);
+        tickets.get(world).put(ForgeVersion.MOD_ID, ticket);
         return ticket;
     }
     /**
@@ -770,7 +770,7 @@ public class ForgeChunkManager
         if (ticket.isPlayerTicket())
         {
             playerTickets.remove(ticket.player, ticket);
-            tickets.get(ticket.world).remove(ForgeModContainer.MOD_ID, ticket);
+            tickets.get(ticket.world).remove(ForgeVersion.MOD_ID, ticket);
         }
         else
         {
@@ -856,7 +856,7 @@ public class ForgeChunkManager
         chunkConstraints.clear();
         for (String mod : config.getCategoryNames())
         {
-            if (mod.equals(ForgeModContainer.MOD_ID) || mod.equals("defaults"))
+            if (mod.equals(ForgeVersion.MOD_ID) || mod.equals("defaults"))
             {
                 continue;
             }
@@ -1061,18 +1061,18 @@ public class ForgeChunkManager
 
         config.setCategoryPropertyOrder("defaults", propOrder);
 
-        config.addCustomCategoryComment(ForgeModContainer.MOD_ID, "Sample mod specific control section.\n" +
+        config.addCustomCategoryComment(ForgeVersion.MOD_ID, "Sample mod specific control section.\n" +
                 "Copy this section and rename the with the modid for the mod you wish to override.\n" +
                 "A value of zero in either entry effectively disables any chunkloading capabilities\n" +
                 "for that mod");
 
-        temp = config.get(ForgeModContainer.MOD_ID, "maximumTicketCount", 200);
+        temp = config.get(ForgeVersion.MOD_ID, "maximumTicketCount", 200);
         temp.setComment("Maximum ticket count for the mod. Zero disables chunkloading capabilities.");
-        temp = config.get(ForgeModContainer.MOD_ID, "maximumChunksPerTicket", 25);
+        temp = config.get(ForgeVersion.MOD_ID, "maximumChunksPerTicket", 25);
         temp.setComment("Maximum chunks per ticket for the mod.");
         for (String mod : config.getCategoryNames())
         {
-            if (mod.equals(ForgeModContainer.MOD_ID) || mod.equals("defaults"))
+            if (mod.equals(ForgeVersion.MOD_ID) || mod.equals("defaults"))
             {
                 continue;
             }
@@ -1101,7 +1101,7 @@ public class ForgeChunkManager
         List<ConfigCategory> list = new ArrayList<ConfigCategory>();
         for (String mod : config.getCategoryNames())
         {
-            if (mod.equals(ForgeModContainer.MOD_ID) || mod.equals("defaults"))
+            if (mod.equals(ForgeVersion.MOD_ID) || mod.equals("defaults"))
             {
                 continue;
             }

--- a/src/main/java/net/minecraftforge/common/ForgeModContainer.java
+++ b/src/main/java/net/minecraftforge/common/ForgeModContainer.java
@@ -96,7 +96,6 @@ import net.minecraftforge.fml.common.network.NetworkRegistry;
 
 public class ForgeModContainer extends DummyModContainer implements WorldAccessContainer
 {
-    public static final String MOD_ID = "forge";
     public static final String VERSION_CHECK_CAT = "version_checking";
     public static int clumpingThreshold = 64;
     public static boolean removeErroringEntities = false;
@@ -126,7 +125,7 @@ public class ForgeModContainer extends DummyModContainer implements WorldAccessC
     {
         super(new ModMetadata());
         ModMetadata meta = getMetadata();
-        meta.modId       = MOD_ID;
+        meta.modId       = ForgeVersion.MOD_ID;
         meta.name        = "Minecraft Forge";
         meta.version     = ForgeVersion.getVersion();
         meta.credits     = "Made possible with help from many people";
@@ -380,11 +379,11 @@ public class ForgeModContainer extends DummyModContainer implements WorldAccessC
                 itr.remove();
         }
 
-        FMLLog.log(MOD_ID, Level.DEBUG, "Preloading CrashReport Classes");
+        FMLLog.log(ForgeVersion.MOD_ID, Level.DEBUG, "Preloading CrashReport Classes");
         Collections.sort(all); //Sort it because I like pretty output ;)
         for (String name : all)
         {
-            FMLLog.log(MOD_ID, Level.DEBUG, "\t" + name);
+            FMLLog.log(ForgeVersion.MOD_ID, Level.DEBUG, "\t" + name);
             try
             {
                 Class.forName(name.replace('/', '.'), false, MinecraftForge.class.getClassLoader());
@@ -421,7 +420,7 @@ public class ForgeModContainer extends DummyModContainer implements WorldAccessC
         {
             universalBucket = new UniversalBucket();
             universalBucket.setUnlocalizedName("forge.bucketFilled");
-            GameRegistry.register(universalBucket.setRegistryName(MOD_ID, "bucketFilled"));
+            GameRegistry.register(universalBucket.setRegistryName(ForgeVersion.MOD_ID, "bucketFilled"));
             MinecraftForge.EVENT_BUS.register(universalBucket);
         }
     }

--- a/src/main/java/net/minecraftforge/common/ForgeModContainer.java
+++ b/src/main/java/net/minecraftforge/common/ForgeModContainer.java
@@ -96,6 +96,7 @@ import net.minecraftforge.fml.common.network.NetworkRegistry;
 
 public class ForgeModContainer extends DummyModContainer implements WorldAccessContainer
 {
+    public static final String MOD_ID = "forge";
     public static final String VERSION_CHECK_CAT = "version_checking";
     public static int clumpingThreshold = 64;
     public static boolean removeErroringEntities = false;
@@ -125,7 +126,7 @@ public class ForgeModContainer extends DummyModContainer implements WorldAccessC
     {
         super(new ModMetadata());
         ModMetadata meta = getMetadata();
-        meta.modId       = "forge";
+        meta.modId       = MOD_ID;
         meta.name        = "Minecraft Forge";
         meta.version     = ForgeVersion.getVersion();
         meta.credits     = "Made possible with help from many people";
@@ -379,11 +380,11 @@ public class ForgeModContainer extends DummyModContainer implements WorldAccessC
                 itr.remove();
         }
 
-        FMLLog.log("Forge", Level.DEBUG, "Preloading CrashReport Classes");
+        FMLLog.log(MOD_ID, Level.DEBUG, "Preloading CrashReport Classes");
         Collections.sort(all); //Sort it because I like pretty output ;)
         for (String name : all)
         {
-            FMLLog.log("Forge", Level.DEBUG, "\t" + name);
+            FMLLog.log(MOD_ID, Level.DEBUG, "\t" + name);
             try
             {
                 Class.forName(name.replace('/', '.'), false, MinecraftForge.class.getClassLoader());
@@ -420,7 +421,7 @@ public class ForgeModContainer extends DummyModContainer implements WorldAccessC
         {
             universalBucket = new UniversalBucket();
             universalBucket.setUnlocalizedName("forge.bucketFilled");
-            GameRegistry.register(universalBucket.setRegistryName("forge", "bucketFilled"));
+            GameRegistry.register(universalBucket.setRegistryName(MOD_ID, "bucketFilled"));
             MinecraftForge.EVENT_BUS.register(universalBucket);
         }
     }

--- a/src/main/java/net/minecraftforge/common/ForgeVersion.java
+++ b/src/main/java/net/minecraftforge/common/ForgeVersion.java
@@ -49,6 +49,8 @@ import net.minecraftforge.fml.common.versioning.ComparableVersion;
 
 public class ForgeVersion
 {
+    // This is Forge's Mod Id, used for the ForgeModContainer and resource locations
+    public static final String MOD_ID = "forge";
     //This number is incremented every time we remove deprecated code/major API changes, never reset
     public static final int majorVersion    = 13;
     //This number is incremented every minecraft release, never reset

--- a/src/main/java/net/minecraftforge/fml/client/GuiSlotModList.java
+++ b/src/main/java/net/minecraftforge/fml/client/GuiSlotModList.java
@@ -28,6 +28,7 @@ import net.minecraft.client.renderer.GlStateManager;
 import net.minecraft.client.renderer.Tessellator;
 import net.minecraft.util.ResourceLocation;
 import net.minecraft.util.StringUtils;
+import net.minecraftforge.common.ForgeModContainer;
 import net.minecraftforge.common.ForgeVersion;
 import net.minecraftforge.common.ForgeVersion.CheckResult;
 import net.minecraftforge.fml.common.Loader;
@@ -41,7 +42,7 @@ import net.minecraftforge.fml.common.ModContainer;
 public class GuiSlotModList extends GuiScrollingList
 {
     
-    private static final ResourceLocation VERSION_CHECK_ICONS = new ResourceLocation("forge", "textures/gui/version_check_icons.png");
+    private static final ResourceLocation VERSION_CHECK_ICONS = new ResourceLocation(ForgeModContainer.MOD_ID, "textures/gui/version_check_icons.png");
     
     private GuiModList parent;
     private ArrayList<ModContainer> mods;

--- a/src/main/java/net/minecraftforge/fml/client/GuiSlotModList.java
+++ b/src/main/java/net/minecraftforge/fml/client/GuiSlotModList.java
@@ -28,7 +28,6 @@ import net.minecraft.client.renderer.GlStateManager;
 import net.minecraft.client.renderer.Tessellator;
 import net.minecraft.util.ResourceLocation;
 import net.minecraft.util.StringUtils;
-import net.minecraftforge.common.ForgeModContainer;
 import net.minecraftforge.common.ForgeVersion;
 import net.minecraftforge.common.ForgeVersion.CheckResult;
 import net.minecraftforge.fml.common.Loader;
@@ -42,7 +41,7 @@ import net.minecraftforge.fml.common.ModContainer;
 public class GuiSlotModList extends GuiScrollingList
 {
     
-    private static final ResourceLocation VERSION_CHECK_ICONS = new ResourceLocation(ForgeModContainer.MOD_ID, "textures/gui/version_check_icons.png");
+    private static final ResourceLocation VERSION_CHECK_ICONS = new ResourceLocation(ForgeVersion.MOD_ID, "textures/gui/version_check_icons.png");
     
     private GuiModList parent;
     private ArrayList<ModContainer> mods;

--- a/src/main/java/net/minecraftforge/fml/common/FMLCommonHandler.java
+++ b/src/main/java/net/minecraftforge/fml/common/FMLCommonHandler.java
@@ -55,7 +55,6 @@ import net.minecraft.world.World;
 import net.minecraft.world.storage.SaveHandler;
 import net.minecraft.world.storage.WorldInfo;
 import net.minecraftforge.client.model.animation.Animation;
-import net.minecraftforge.common.ForgeModContainer;
 import net.minecraftforge.common.ForgeVersion;
 import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.common.util.CompoundDataFixer;
@@ -517,7 +516,7 @@ public class FMLCommonHandler
         modNames.add("fml");
         if (!noForge)
         {
-            modNames.add(ForgeModContainer.MOD_ID);
+            modNames.add(ForgeVersion.MOD_ID);
         }
 
         if (Loader.instance().getFMLBrandingProperties().containsKey("snooperbranding"))

--- a/src/main/java/net/minecraftforge/fml/common/FMLCommonHandler.java
+++ b/src/main/java/net/minecraftforge/fml/common/FMLCommonHandler.java
@@ -55,6 +55,7 @@ import net.minecraft.world.World;
 import net.minecraft.world.storage.SaveHandler;
 import net.minecraft.world.storage.WorldInfo;
 import net.minecraftforge.client.model.animation.Animation;
+import net.minecraftforge.common.ForgeModContainer;
 import net.minecraftforge.common.ForgeVersion;
 import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.common.util.CompoundDataFixer;
@@ -516,7 +517,7 @@ public class FMLCommonHandler
         modNames.add("fml");
         if (!noForge)
         {
-            modNames.add("forge");
+            modNames.add(ForgeModContainer.MOD_ID);
         }
 
         if (Loader.instance().getFMLBrandingProperties().containsKey("snooperbranding"))

--- a/src/test/java/net/minecraftforge/debug/DynBucketTest.java
+++ b/src/test/java/net/minecraftforge/debug/DynBucketTest.java
@@ -30,6 +30,7 @@ import net.minecraft.util.ResourceLocation;
 import net.minecraft.world.World;
 import net.minecraftforge.client.model.ModelLoader;
 import net.minecraftforge.common.ForgeModContainer;
+import net.minecraftforge.common.ForgeVersion;
 import net.minecraftforge.common.capabilities.Capability;
 import net.minecraftforge.debug.ModelFluidDebug.TestFluid;
 import net.minecraftforge.debug.ModelFluidDebug.TestGas;
@@ -103,7 +104,7 @@ public class DynBucketTest
 
             ModelLoader.setBucketModelDefinition(dynBucket);
 
-            final ModelResourceLocation bottle = new ModelResourceLocation(new ResourceLocation(ForgeModContainer.MOD_ID, "dynbottle"), "inventory");
+            final ModelResourceLocation bottle = new ModelResourceLocation(new ResourceLocation(ForgeVersion.MOD_ID, "dynbottle"), "inventory");
             ModelLoader.setCustomMeshDefinition(dynBottle, new ItemMeshDefinition()
             {
                 @Override

--- a/src/test/java/net/minecraftforge/debug/DynBucketTest.java
+++ b/src/test/java/net/minecraftforge/debug/DynBucketTest.java
@@ -103,7 +103,7 @@ public class DynBucketTest
 
             ModelLoader.setBucketModelDefinition(dynBucket);
 
-            final ModelResourceLocation bottle = new ModelResourceLocation(new ResourceLocation("forge", "dynbottle"), "inventory");
+            final ModelResourceLocation bottle = new ModelResourceLocation(new ResourceLocation(ForgeModContainer.MOD_ID, "dynbottle"), "inventory");
             ModelLoader.setCustomMeshDefinition(dynBottle, new ItemMeshDefinition()
             {
                 @Override

--- a/src/test/java/net/minecraftforge/debug/ModelFluidDebug.java
+++ b/src/test/java/net/minecraftforge/debug/ModelFluidDebug.java
@@ -12,6 +12,7 @@ import net.minecraft.item.ItemBlock;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.ResourceLocation;
 import net.minecraftforge.client.model.ModelLoader;
+import net.minecraftforge.common.ForgeModContainer;
 import net.minecraftforge.fluids.BlockFluidClassic;
 import net.minecraftforge.fluids.Fluid;
 import net.minecraftforge.fluids.FluidRegistry;
@@ -32,7 +33,7 @@ public class ModelFluidDebug
     @SidedProxy
     public static CommonProxy proxy;
 
-    public static final Fluid milkFluid = new Fluid("milk", new ResourceLocation("forge", "blocks/milk_still"), new ResourceLocation("forge", "blocks/milk_flow"));
+    public static final Fluid milkFluid = new Fluid("milk", new ResourceLocation(ForgeModContainer.MOD_ID, "blocks/milk_still"), new ResourceLocation(ForgeModContainer.MOD_ID, "blocks/milk_flow"));
 
     @EventHandler
     public void preInit(FMLPreInitializationEvent event)

--- a/src/test/java/net/minecraftforge/debug/ModelFluidDebug.java
+++ b/src/test/java/net/minecraftforge/debug/ModelFluidDebug.java
@@ -12,7 +12,7 @@ import net.minecraft.item.ItemBlock;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.ResourceLocation;
 import net.minecraftforge.client.model.ModelLoader;
-import net.minecraftforge.common.ForgeModContainer;
+import net.minecraftforge.common.ForgeVersion;
 import net.minecraftforge.fluids.BlockFluidClassic;
 import net.minecraftforge.fluids.Fluid;
 import net.minecraftforge.fluids.FluidRegistry;
@@ -33,7 +33,7 @@ public class ModelFluidDebug
     @SidedProxy
     public static CommonProxy proxy;
 
-    public static final Fluid milkFluid = new Fluid("milk", new ResourceLocation(ForgeModContainer.MOD_ID, "blocks/milk_still"), new ResourceLocation(ForgeModContainer.MOD_ID, "blocks/milk_flow"));
+    public static final Fluid milkFluid = new Fluid("milk", new ResourceLocation(ForgeVersion.MOD_ID, "blocks/milk_still"), new ResourceLocation(ForgeVersion.MOD_ID, "blocks/milk_flow"));
 
     @EventHandler
     public void preInit(FMLPreInitializationEvent event)

--- a/src/test/java/net/minecraftforge/debug/PotionRegistryDebug.java
+++ b/src/test/java/net/minecraftforge/debug/PotionRegistryDebug.java
@@ -15,6 +15,7 @@ import net.minecraft.client.renderer.vertex.DefaultVertexFormats;
 import net.minecraft.potion.Potion;
 import net.minecraft.potion.PotionEffect;
 import net.minecraft.util.ResourceLocation;
+import net.minecraftforge.common.ForgeModContainer;
 import net.minecraftforge.fml.common.Mod;
 import net.minecraftforge.fml.common.event.FMLPreInitializationEvent;
 import net.minecraftforge.fml.common.registry.GameData;
@@ -25,10 +26,10 @@ public class PotionRegistryDebug {
 
   @Mod.EventHandler
   public void preInit(FMLPreInitializationEvent event) {
-    Potion forge = new PotionForge(new ResourceLocation("forge", "forge"), false, 0xff00ff); // test automatic id distribution
-    Potion forgy = new PotionForge(new ResourceLocation("forge", "forgy"), true, 0x00ff00); // test that ids above 127 work
-    GameData.getPotionRegistry().register(-1, new ResourceLocation("forge", "forge"), forge); //TODo: Generic this out in GameRegistry, 'RegistryEntry' base type?
-    GameData.getPotionRegistry().register(200, new ResourceLocation("forge", "forgy"), forgy);
+    Potion forge = new PotionForge(new ResourceLocation(ForgeModContainer.MOD_ID, "forge"), false, 0xff00ff); // test automatic id distribution
+    Potion forgy = new PotionForge(new ResourceLocation(ForgeModContainer.MOD_ID, "forgy"), true, 0x00ff00); // test that ids above 127 work
+    GameData.getPotionRegistry().register(-1, new ResourceLocation(ForgeModContainer.MOD_ID, "forge"), forge); //TODo: Generic this out in GameRegistry, 'RegistryEntry' base type?
+    GameData.getPotionRegistry().register(200, new ResourceLocation(ForgeModContainer.MOD_ID, "forgy"), forgy);
 
     Random rand = new Random();
     TIntSet taken = new TIntHashSet(100);
@@ -36,7 +37,7 @@ public class PotionRegistryDebug {
     taken.add(ra);
 
     // a new potion with a random id so that forge has to remap it
-    //new PotionForge(ra, new ResourceLocation("forge", "realRandomPotion"), false, 0x0000ff);
+    //new PotionForge(ra, new ResourceLocation(ForgeModContainer.MOD_ID, "realRandomPotion"), false, 0x0000ff);
 
     for(int i = 0; i < 20; i++) {
       int r = rand.nextInt(200) + 35;
@@ -46,7 +47,7 @@ public class PotionRegistryDebug {
       taken.add(r);
       // this potions will most likely not have the same IDs between server and client.
       // The forge handshake on connect should fix this.
-      //new PotionForge(new ResourceLocation("forge", "randomPotion" + r), false, 0xff00ff);
+      //new PotionForge(new ResourceLocation(ForgeModContainer.MOD_ID, "randomPotion" + r), false, 0xff00ff);
     }
   }
 

--- a/src/test/java/net/minecraftforge/debug/PotionRegistryDebug.java
+++ b/src/test/java/net/minecraftforge/debug/PotionRegistryDebug.java
@@ -15,7 +15,7 @@ import net.minecraft.client.renderer.vertex.DefaultVertexFormats;
 import net.minecraft.potion.Potion;
 import net.minecraft.potion.PotionEffect;
 import net.minecraft.util.ResourceLocation;
-import net.minecraftforge.common.ForgeModContainer;
+import net.minecraftforge.common.ForgeVersion;
 import net.minecraftforge.fml.common.Mod;
 import net.minecraftforge.fml.common.event.FMLPreInitializationEvent;
 import net.minecraftforge.fml.common.registry.GameData;
@@ -26,10 +26,10 @@ public class PotionRegistryDebug {
 
   @Mod.EventHandler
   public void preInit(FMLPreInitializationEvent event) {
-    Potion forge = new PotionForge(new ResourceLocation(ForgeModContainer.MOD_ID, "forge"), false, 0xff00ff); // test automatic id distribution
-    Potion forgy = new PotionForge(new ResourceLocation(ForgeModContainer.MOD_ID, "forgy"), true, 0x00ff00); // test that ids above 127 work
-    GameData.getPotionRegistry().register(-1, new ResourceLocation(ForgeModContainer.MOD_ID, "forge"), forge); //TODo: Generic this out in GameRegistry, 'RegistryEntry' base type?
-    GameData.getPotionRegistry().register(200, new ResourceLocation(ForgeModContainer.MOD_ID, "forgy"), forgy);
+    Potion forge = new PotionForge(new ResourceLocation(ForgeVersion.MOD_ID, "forge"), false, 0xff00ff); // test automatic id distribution
+    Potion forgy = new PotionForge(new ResourceLocation(ForgeVersion.MOD_ID, "forgy"), true, 0x00ff00); // test that ids above 127 work
+    GameData.getPotionRegistry().register(-1, new ResourceLocation(ForgeVersion.MOD_ID, "forge"), forge); //TODo: Generic this out in GameRegistry, 'RegistryEntry' base type?
+    GameData.getPotionRegistry().register(200, new ResourceLocation(ForgeVersion.MOD_ID, "forgy"), forgy);
 
     Random rand = new Random();
     TIntSet taken = new TIntHashSet(100);


### PR DESCRIPTION
There are a couple cases where uppercase "Forge" is used as a modId, and then checked by `Loader.isModLoaded` and fails the check because it needs to be lowercase.

This is currently preventing Forge's in-game configs from updating, and it looks like it breaks something related to chunkloading by Forge as well.

This PR makes "forge" lowercase.