### PR TITLE
[1.11] Improve the way containers interact with inventories 

### DIFF
--- a/src/main/java/net/minecraftforge/items/IItemHandlerContainer.java
+++ b/src/main/java/net/minecraftforge/items/IItemHandlerContainer.java
@@ -20,6 +20,7 @@ package net.minecraftforge.items;
 
 import net.minecraft.item.ItemStack;
 
+import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
 /**
@@ -33,13 +34,13 @@ public interface IItemHandlerContainer
      * @param stack The stack being tested
      * @return True if the provided stack is acceptable
      */
-    boolean isItemValidForSlot(int slot, ItemStack stack);
+    boolean acceptsStack(int slot, @Nonnull ItemStack stack);
 
     /**
-     * Gets the stack size limit allowed by the given slot
+     * Gets the stack size limit allowed by the given slot and the given stack
      * @param slot The slot number within the inventory
      * @param stack An optional stack, for when the limit depends on the input
      * @return The stack size limit
      */
-    int getInventoryStackLimit(int slot, @Nullable ItemStack stack);
+    int getEffectiveStackLimit(int slot, @Nonnull ItemStack stack);
 }

--- a/src/main/java/net/minecraftforge/items/IItemHandlerContainer.java
+++ b/src/main/java/net/minecraftforge/items/IItemHandlerContainer.java
@@ -1,0 +1,45 @@
+/*
+ * Minecraft Forge
+ * Copyright (c) 2016.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation version 2.1
+ * of the License.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+package net.minecraftforge.items;
+
+import net.minecraft.item.ItemStack;
+
+import javax.annotation.Nullable;
+
+/**
+ * Declares an item handler as being aware of container slot interactions.
+ */
+public interface IItemHandlerContainer
+{
+    /**
+     * Queries if the given slot is acceptable for the inventory
+     * @param slot The slot number within the inventory
+     * @param stack The stack being tested
+     * @return True if the provided stack is acceptable
+     */
+    boolean isItemValidForSlot(int slot, ItemStack stack);
+
+    /**
+     * Gets the stack size limit allowed by the given slot
+     * @param slot The slot number within the inventory
+     * @param stack An optional stack, for when the limit depends on the input
+     * @return The stack size limit
+     */
+    int getInventoryStackLimit(int slot, @Nullable ItemStack stack);
+}

--- a/src/main/java/net/minecraftforge/items/ItemStackHandler.java
+++ b/src/main/java/net/minecraftforge/items/ItemStackHandler.java
@@ -204,15 +204,15 @@ public class ItemStackHandler implements IItemHandler, IItemHandlerModifiable, I
     }
 
     @Override
-    public boolean isItemValidForSlot(int slot, ItemStack stack)
+    public boolean acceptsStack(int slot, @Nonnull ItemStack stack)
     {
         return true;
     }
 
     @Override
-    public int getInventoryStackLimit(int slot, ItemStack stack)
+    public int getEffectiveStackLimit(int slot, @Nonnull ItemStack stack)
     {
-        return stack != null ? stack.getMaxStackSize() : 64;
+        return getStackLimit(slot, stack);
     }
 
     protected void validateSlotIndex(int slot)

--- a/src/main/java/net/minecraftforge/items/ItemStackHandler.java
+++ b/src/main/java/net/minecraftforge/items/ItemStackHandler.java
@@ -28,7 +28,7 @@ import net.minecraftforge.common.util.INBTSerializable;
 
 import javax.annotation.Nonnull;
 
-public class ItemStackHandler implements IItemHandler, IItemHandlerModifiable, INBTSerializable<NBTTagCompound>
+public class ItemStackHandler implements IItemHandler, IItemHandlerModifiable, IItemHandlerContainer, INBTSerializable<NBTTagCompound>
 {
     protected NonNullList<ItemStack> stacks;
 
@@ -201,6 +201,18 @@ public class ItemStackHandler implements IItemHandler, IItemHandlerModifiable, I
             }
         }
         onLoad();
+    }
+
+    @Override
+    public boolean isItemValidForSlot(int slot, ItemStack stack)
+    {
+        return true;
+    }
+
+    @Override
+    public int getInventoryStackLimit(int slot, ItemStack stack)
+    {
+        return stack != null ? stack.getMaxStackSize() : 64;
     }
 
     protected void validateSlotIndex(int slot)

--- a/src/main/java/net/minecraftforge/items/SlotItemHandler.java
+++ b/src/main/java/net/minecraftforge/items/SlotItemHandler.java
@@ -45,6 +45,9 @@ public class SlotItemHandler extends Slot
     {
         if (stack.func_190926_b())
             return false;
+        IItemHandler itemHandler = getItemHandler();
+        if (itemHandler instanceof IItemHandlerContainer)
+            return ((IItemHandlerContainer) itemHandler).isItemValidForSlot(slotNumber, stack);
 
         IItemHandler handler = this.getItemHandler();
         ItemStack remainder;
@@ -96,6 +99,10 @@ public class SlotItemHandler extends Slot
     @Override
     public int getItemStackLimit(@Nonnull ItemStack stack)
     {
+        IItemHandler itemHandler = getItemHandler();
+        if (itemHandler instanceof IItemHandlerContainer)
+            return ((IItemHandlerContainer) itemHandler).getInventoryStackLimit(slotNumber, stack);
+
         ItemStack maxAdd = stack.copy();
         int maxInput = stack.getMaxStackSize();
         maxAdd.func_190920_e(maxInput);

--- a/src/main/java/net/minecraftforge/items/SlotItemHandler.java
+++ b/src/main/java/net/minecraftforge/items/SlotItemHandler.java
@@ -31,12 +31,14 @@ public class SlotItemHandler extends Slot
 {
     private static IInventory emptyInventory = new InventoryBasic("[Null]", true, 0);
     private final IItemHandler itemHandler;
+    private final IItemHandlerContainer itemHandlerContainer;
     private final int index;
 
     public SlotItemHandler(IItemHandler itemHandler, int index, int xPosition, int yPosition)
     {
         super(emptyInventory, index, xPosition, yPosition);
         this.itemHandler = itemHandler;
+        this.itemHandlerContainer = (itemHandler instanceof IItemHandlerContainer) ? (IItemHandlerContainer)itemHandler : null;
         this.index = index;
     }
 
@@ -45,9 +47,9 @@ public class SlotItemHandler extends Slot
     {
         if (stack.func_190926_b())
             return false;
-        IItemHandler itemHandler = getItemHandler();
-        if (itemHandler instanceof IItemHandlerContainer)
-            return ((IItemHandlerContainer) itemHandler).isItemValidForSlot(slotNumber, stack);
+        IItemHandlerContainer ihc = getItemHandlerContainer();
+        if (ihc != null)
+            return ihc.isItemValidForSlot(slotNumber, stack);
 
         IItemHandler handler = this.getItemHandler();
         ItemStack remainder;
@@ -99,9 +101,10 @@ public class SlotItemHandler extends Slot
     @Override
     public int getItemStackLimit(@Nonnull ItemStack stack)
     {
-        IItemHandler itemHandler = getItemHandler();
-        if (itemHandler instanceof IItemHandlerContainer)
-            return ((IItemHandlerContainer) itemHandler).getInventoryStackLimit(slotNumber, stack);
+        IItemHandlerContainer ihc = getItemHandlerContainer();
+        if (ihc != null)
+            return ihc.getInventoryStackLimit(slotNumber, stack);
+
 
         ItemStack maxAdd = stack.copy();
         int maxInput = stack.getMaxStackSize();
@@ -146,6 +149,11 @@ public class SlotItemHandler extends Slot
     public IItemHandler getItemHandler()
     {
         return itemHandler;
+    }
+
+    public IItemHandlerContainer getItemHandlerContainer()
+    {
+        return itemHandlerContainer;
     }
 
     @Override

--- a/src/main/java/net/minecraftforge/items/SlotItemHandler.java
+++ b/src/main/java/net/minecraftforge/items/SlotItemHandler.java
@@ -49,7 +49,7 @@ public class SlotItemHandler extends Slot
             return false;
         IItemHandlerContainer ihc = getItemHandlerContainer();
         if (ihc != null)
-            return ihc.isItemValidForSlot(slotNumber, stack);
+            return ihc.acceptsStack(slotNumber, stack);
 
         IItemHandler handler = this.getItemHandler();
         ItemStack remainder;
@@ -103,7 +103,7 @@ public class SlotItemHandler extends Slot
     {
         IItemHandlerContainer ihc = getItemHandlerContainer();
         if (ihc != null)
-            return ihc.getInventoryStackLimit(slotNumber, stack);
+            return ihc.getEffectiveStackLimit(slotNumber, stack);
 
 
         ItemStack maxAdd = stack.copy();


### PR DESCRIPTION
Supersedes #3306. Fixes #3344 (even though the issue was created after this PR ;P)

> This has a similar purpose to #3273, and in fact, could be said to complement it.
> 
> I added an interface that allows Containers and Slots to query more information about inventories (namely, isItemValidForSlot and getInventoryStackLimit, chosen to keep the same names people were used to in the past, but I'm open to changing them).
> 
> This allows improving the logic in SlotItemHandler, to allow stack swapping and stack limits, but without the massive hacks seen in #3273. The downside is that this approach does not work for custom inventories that don't also implement this new interface.
> 
> This code has been lying around in a gist for months, but my job kept me busy and I ended up forgetting about it.
> 
> I'm now PRing it to give people my take on this issue.

@mezz suggested in the previous PR, that it may have been better to modify the IItemHandler interface. Although I believe automation and GUI use cases should be separate, I'm open to that. I left it as a separate interface here to avoid introducing breaking changes, but I will put it into IItemHandler if it's wanted.