### PR TITLE
Corrected it's to its

### DIFF
--- a/src/main/java/net/minecraftforge/fml/client/FMLClientHandler.java
+++ b/src/main/java/net/minecraftforge/fml/client/FMLClientHandler.java
@@ -628,7 +628,7 @@ public class FMLClientHandler implements IFMLSidedHandler
             }
             catch (NoSuchMethodException e)
             {
-                FMLLog.log(Level.ERROR, "The container %s (type %s) returned an invalid class for it's resource pack.", container.getName(), container.getClass().getName());
+                FMLLog.log(Level.ERROR, "The container %s (type %s) returned an invalid class for its resource pack.", container.getName(), container.getClass().getName());
                 return;
             }
             catch (Exception e)


### PR DESCRIPTION
I found a typo in the error "The container %s (type %s) returned an invalid class for it's resource pack." 

It's should read its instead, since it is the possessive form.