### PR TITLE
[1.11]Added Oak Door to Ore Dictionary Exclusion list

### DIFF
--- a/src/main/java/net/minecraftforge/oredict/OreDictionary.java
+++ b/src/main/java/net/minecraftforge/oredict/OreDictionary.java
@@ -341,6 +341,7 @@ public class OreDictionary
             new ItemStack(Blocks.GLASS_PANE),
             new ItemStack(Blocks.BONE_BLOCK), // Bone Block, to prevent conversion of dyes into bone meal.
             new ItemStack(Items.BOAT),
+            new ItemStack(Items.OAK_DOOR),
             ItemStack.field_190927_a //So the above can have a comma and we don't have to keep editing extra lines.
         };
 


### PR DESCRIPTION
Fixes the Oak door being able to be crafted with any wood