### PR TITLE
Fix #3521 Make NBSP character display as a space. MC-2595

### DIFF
--- a/patches/minecraft/net/minecraft/client/gui/FontRenderer.java.patch
+++ b/patches/minecraft/net/minecraft/client/gui/FontRenderer.java.patch
@@ -27,7 +27,15 @@
              iresource.func_110527_b().read(this.field_78287_e);
          }
          catch (IOException ioexception)
-@@ -203,7 +203,7 @@
+@@ -187,6 +187,7 @@
+ 
+     private float func_181559_a(char p_181559_1_, boolean p_181559_2_)
+     {
++        if (p_181559_1_ == 160) return 4.0F; // forge: display nbsp as space. MC-2595
+         if (p_181559_1_ == 32)
+         {
+             return 4.0F;
+@@ -203,7 +204,7 @@
          int i = p_78266_1_ % 16 * 8;
          int j = p_78266_1_ / 16 * 8;
          int k = p_78266_2_ ? 1 : 0;
@@ -36,7 +44,7 @@
          int l = this.field_78286_d[p_78266_1_];
          float f = (float)l - 0.01F;
          GlStateManager.func_187447_r(5);
-@@ -231,7 +231,7 @@
+@@ -231,7 +232,7 @@
  
      private void func_78257_a(int p_78257_1_)
      {
@@ -45,7 +53,7 @@
      }
  
      protected float func_78277_a(char p_78277_1_, boolean p_78277_2_)
-@@ -280,7 +280,7 @@
+@@ -280,7 +281,7 @@
  
      public int func_175065_a(String p_175065_1_, float p_175065_2_, float p_175065_3_, int p_175065_4_, boolean p_175065_5_)
      {
@@ -54,7 +62,7 @@
          this.func_78265_b();
          int i;
  
-@@ -350,7 +350,7 @@
+@@ -350,7 +351,7 @@
  
                      int j1 = this.field_78285_g[i1];
                      this.field_78304_r = j1;
@@ -63,7 +71,7 @@
                  }
                  else if (i1 == 16)
                  {
-@@ -379,7 +379,7 @@
+@@ -379,7 +380,7 @@
                      this.field_78299_w = false;
                      this.field_78300_v = false;
                      this.field_78301_u = false;
@@ -72,7 +80,7 @@
                  }
  
                  ++i;
-@@ -407,7 +407,7 @@
+@@ -407,7 +408,7 @@
                      c0 = c1;
                  }
  
@@ -81,7 +89,7 @@
                  boolean flag = (c0 == 0 || j == -1 || this.field_78293_l) && p_78255_2_;
  
                  if (flag)
-@@ -445,7 +445,16 @@
+@@ -445,7 +446,16 @@
  
                      ++f;
                  }
@@ -98,7 +106,7 @@
                  if (this.field_78299_w)
                  {
                      Tessellator tessellator = Tessellator.func_178181_a();
-@@ -518,7 +527,7 @@
+@@ -518,7 +528,7 @@
              this.field_78292_o = (float)(p_180455_4_ >> 8 & 255) / 255.0F;
              this.field_78306_p = (float)(p_180455_4_ & 255) / 255.0F;
              this.field_78305_q = (float)(p_180455_4_ >> 24 & 255) / 255.0F;
@@ -107,7 +115,15 @@
              this.field_78295_j = p_180455_2_;
              this.field_78296_k = p_180455_3_;
              this.func_78255_a(p_180455_1_, p_180455_5_);
-@@ -849,6 +858,26 @@
+@@ -576,6 +586,7 @@
+ 
+     public int func_78263_a(char p_78263_1_)
+     {
++        if (p_78263_1_ == 160) return 4; // forge: display nbsp as space. MC-2595
+         if (p_78263_1_ == 167)
+         {
+             return -1;
+@@ -849,6 +860,26 @@
          return this.field_78294_m;
      }
  

--- a/patches/minecraft/net/minecraft/client/resources/Language.java.patch
+++ b/patches/minecraft/net/minecraft/client/resources/Language.java.patch
@@ -1,0 +1,19 @@
+--- ../src-base/minecraft/net/minecraft/client/resources/Language.java
++++ ../src-work/minecraft/net/minecraft/client/resources/Language.java
+@@ -17,6 +17,7 @@
+         this.field_135037_b = p_i1303_2_;
+         this.field_135038_c = p_i1303_3_;
+         this.field_135036_d = p_i1303_4_;
++        this.javaLocale = new java.util.Locale(field_135039_a, field_135037_b);
+     }
+ 
+     public String func_135034_a()
+@@ -48,4 +49,8 @@
+     {
+         return this.field_135039_a.compareTo(p_compareTo_1_.field_135039_a);
+     }
++
++    // Forge: add access to Locale so modders can create correct number formatters
++    private final java.util.Locale javaLocale;
++    public java.util.Locale getJavaLocale() { return javaLocale; }
+ }

--- a/patches/minecraft/net/minecraft/client/resources/Language.java.patch
+++ b/patches/minecraft/net/minecraft/client/resources/Language.java.patch
@@ -13,7 +13,7 @@
          return this.field_135039_a.compareTo(p_compareTo_1_.field_135039_a);
      }
 +
-+    // Forge: add access to Locale so modders can create correct number formatters
++    // Forge: add access to Locale so modders can create correct string and number formatters
 +    private final java.util.Locale javaLocale;
 +    public java.util.Locale getJavaLocale() { return javaLocale; }
  }

--- a/src/main/java/net/minecraftforge/client/MinecraftForgeClient.java
+++ b/src/main/java/net/minecraftforge/client/MinecraftForgeClient.java
@@ -25,8 +25,10 @@
 package net.minecraftforge.client;
 
 import java.util.BitSet;
+import java.util.Locale;
 import java.util.concurrent.TimeUnit;
 
+import net.minecraft.client.Minecraft;
 import net.minecraft.util.BlockRenderLayer;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.ChunkCache;
@@ -48,6 +50,15 @@ public class MinecraftForgeClient
     public static BlockRenderLayer getRenderLayer()
     {
         return ForgeHooksClient.renderLayer.get();
+    }
+
+    /**
+     * returns the Locale set by the player in Minecraft.
+     * Useful for creating string and number formatters.
+     */
+    public static Locale getLocale()
+    {
+        return Minecraft.getMinecraft().getLanguageManager().getCurrentLanguage().getJavaLocale();
     }
 
     private static BitSet stencilBits = new BitSet(8);


### PR DESCRIPTION
This PR makes NBSP display as a space, solving #3521.

It also exposes the current game Locale, so that modders can use the correct Local for formatting numbers instead of the JVM Locale.
You can get it with `MinecraftForgeClient.getLocale()`