### PR TITLE
Allow EntityEvent.CanUpdate to cancel entity updates as well as force them

### DIFF
--- a/patches/minecraft/net/minecraft/world/World.java.patch
+++ b/patches/minecraft/net/minecraft/world/World.java.patch
@@ -460,7 +460,7 @@
 +        boolean isForced = getPersistentChunks().containsKey(new net.minecraft.util.math.ChunkPos(i >> 4, j >> 4));
 +        int k = isForced ? 0 : 32;
 +        boolean canUpdate = !p_72866_2_ || this.func_175663_a(i - k, 0, j - k, i + k, 0, j + k, true);
-+        if (!canUpdate) canUpdate = net.minecraftforge.event.ForgeEventFactory.canEntityUpdate(p_72866_1_);
++        canUpdate = net.minecraftforge.event.ForgeEventFactory.canEntityUpdate(p_72866_1_, canUpdate);
  
 -        if (!p_72866_2_ || this.func_175663_a(i - 32, 0, j - 32, i + 32, 0, j + 32, true))
 +        if (canUpdate)

--- a/src/main/java/net/minecraftforge/event/ForgeEventFactory.java
+++ b/src/main/java/net/minecraftforge/event/ForgeEventFactory.java
@@ -384,9 +384,9 @@ public class ForgeEventFactory
         return null;
     }
 
-    public static boolean canEntityUpdate(Entity entity)
+    public static boolean canEntityUpdate(Entity entity, boolean defaultValue)
     {
-        EntityEvent.CanUpdate event = new EntityEvent.CanUpdate(entity);
+        EntityEvent.CanUpdate event = new EntityEvent.CanUpdate(entity, defaultValue);
         MinecraftForge.EVENT_BUS.post(event);
         return event.getCanUpdate();
     }

--- a/src/main/java/net/minecraftforge/event/entity/EntityEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/EntityEvent.java
@@ -82,10 +82,11 @@ public class EntityEvent extends Event
      **/
     public static class CanUpdate extends EntityEvent
     {
-        private boolean canUpdate = false;
-        public CanUpdate(Entity entity)
+        private boolean canUpdate;
+        public CanUpdate(Entity entity, boolean defaultValue)
         {
             super(entity);
+            this.canUpdate = defaultValue;
         }
 
         public boolean getCanUpdate()


### PR DESCRIPTION
The EntityEvent.CanUpdate event allows modders to allow an entity to update even if update conditions aren't valid, however it doesn't allow you to prohibit an entity to update if update conditions are met. This fixes that by making the CanUpdate event not check if canUpdate is false before firing, like it used to.