### PR TITLE
[1.11.2] Allow mods to change the default dimension for respawning.

### DIFF
--- a/patches/minecraft/net/minecraft/entity/player/EntityPlayer.java.patch
+++ b/patches/minecraft/net/minecraft/entity/player/EntityPlayer.java.patch
@@ -135,7 +135,7 @@
      }
  
      public static void func_189806_a(DataFixer p_189806_0_)
-@@ -889,6 +923,16 @@
+@@ -889,6 +923,17 @@
              this.field_82248_d = p_70037_1_.func_74767_n("SpawnForced");
          }
  
@@ -148,11 +148,12 @@
 +            this.spawnChunkMap.put(spawndim, new BlockPos(spawndata.func_74762_e("SpawnX"), spawndata.func_74762_e("SpawnY"), spawndata.func_74762_e("SpawnZ")));
 +            this.spawnForcedMap.put(spawndim, spawndata.func_74767_n("SpawnForced"));
 +        }
++        this.spawnDimension = p_70037_1_.func_74767_n("HasSpawnDimensionSet") ? p_70037_1_.func_74762_e("SpawnDimension") : null;
 +
          this.field_71100_bB.func_75112_a(p_70037_1_);
          this.field_71075_bZ.func_75095_b(p_70037_1_);
  
-@@ -903,6 +947,7 @@
+@@ -903,6 +948,7 @@
      {
          super.func_70014_b(p_70014_1_);
          p_70014_1_.func_74768_a("DataVersion", 922);
@@ -160,7 +161,7 @@
          p_70014_1_.func_74782_a("Inventory", this.field_71071_by.func_70442_a(new NBTTagList()));
          p_70014_1_.func_74768_a("SelectedItemSlot", this.field_71071_by.field_70461_c);
          p_70014_1_.func_74757_a("Sleeping", this.field_71083_bS);
-@@ -921,6 +966,23 @@
+@@ -921,6 +967,27 @@
              p_70014_1_.func_74757_a("SpawnForced", this.field_82248_d);
          }
  
@@ -181,10 +182,14 @@
 +        }
 +        p_70014_1_.func_74782_a("Spawns", spawnlist);
 +
++        p_70014_1_.func_74757_a("HasSpawnDimensionSet", this.hasSpawnDimension());
++        if (this.hasSpawnDimension())
++            p_70014_1_.func_74768_a("SpawnDimension", this.getSpawnDimension());
++
          this.field_71100_bB.func_75117_b(p_70014_1_);
          this.field_71075_bZ.func_75091_a(p_70014_1_);
          p_70014_1_.func_74782_a("EnderItems", this.field_71078_a.func_70487_g());
-@@ -928,6 +990,7 @@
+@@ -928,6 +995,7 @@
  
      public boolean func_70097_a(DamageSource p_70097_1_, float p_70097_2_)
      {
@@ -192,7 +197,7 @@
          if (this.func_180431_b(p_70097_1_))
          {
              return false;
-@@ -1006,6 +1069,7 @@
+@@ -1006,6 +1074,7 @@
              if (this.field_184627_bm.func_190926_b())
              {
                  EnumHand enumhand = this.func_184600_cs();
@@ -200,7 +205,7 @@
  
                  if (enumhand == EnumHand.MAIN_HAND)
                  {
-@@ -1041,7 +1105,10 @@
+@@ -1041,7 +1110,10 @@
      {
          if (!this.func_180431_b(p_70665_1_))
          {
@@ -212,7 +217,7 @@
              p_70665_2_ = this.func_70672_c(p_70665_1_, p_70665_2_);
              float f = p_70665_2_;
              p_70665_2_ = Math.max(p_70665_2_ - this.func_110139_bj(), 0.0F);
-@@ -1111,6 +1178,7 @@
+@@ -1111,6 +1183,7 @@
          }
          else
          {
@@ -220,7 +225,7 @@
              ItemStack itemstack = this.func_184586_b(p_190775_2_);
              ItemStack itemstack1 = itemstack.func_190926_b() ? ItemStack.field_190927_a : itemstack.func_77946_l();
  
-@@ -1120,7 +1188,10 @@
+@@ -1120,7 +1193,10 @@
                  {
                      itemstack.func_190920_e(itemstack1.func_190916_E());
                  }
@@ -232,7 +237,7 @@
                  return EnumActionResult.SUCCESS;
              }
              else
-@@ -1136,6 +1207,7 @@
+@@ -1136,6 +1212,7 @@
                      {
                          if (itemstack.func_190926_b() && !this.field_71075_bZ.field_75098_d)
                          {
@@ -240,7 +245,7 @@
                              this.func_184611_a(p_190775_2_, ItemStack.field_190927_a);
                          }
  
-@@ -1161,6 +1233,7 @@
+@@ -1161,6 +1238,7 @@
  
      public void func_71059_n(Entity p_71059_1_)
      {
@@ -248,7 +253,7 @@
          if (p_71059_1_.func_70075_an())
          {
              if (!p_71059_1_.func_85031_j(this))
-@@ -1333,11 +1406,13 @@
+@@ -1333,11 +1411,13 @@
  
                          if (!itemstack1.func_190926_b() && entity instanceof EntityLivingBase)
                          {
@@ -262,7 +267,7 @@
                              }
                          }
  
-@@ -1443,6 +1518,8 @@
+@@ -1443,6 +1523,8 @@
  
      public EntityPlayer.SleepResult func_180469_a(BlockPos p_180469_1_)
      {
@@ -271,7 +276,7 @@
          EnumFacing enumfacing = (EnumFacing)this.field_70170_p.func_180495_p(p_180469_1_).func_177229_b(BlockHorizontal.field_185512_D);
  
          if (!this.field_70170_p.field_72995_K)
-@@ -1484,8 +1561,9 @@
+@@ -1484,8 +1566,9 @@
  
          this.func_70105_a(0.2F, 0.2F);
  
@@ -283,7 +288,7 @@
              float f1 = 0.5F + (float)enumfacing.func_82601_c() * 0.4F;
              float f = 0.5F + (float)enumfacing.func_82599_e() * 0.4F;
              this.func_175139_a(enumfacing);
-@@ -1532,13 +1610,14 @@
+@@ -1532,13 +1615,14 @@
  
      public void func_70999_a(boolean p_70999_1_, boolean p_70999_2_, boolean p_70999_3_)
      {
@@ -301,7 +306,7 @@
  
              if (blockpos == null)
              {
-@@ -1547,6 +1626,10 @@
+@@ -1547,6 +1631,10 @@
  
              this.func_70107_b((double)((float)blockpos.func_177958_n() + 0.5F), (double)((float)blockpos.func_177956_o() + 0.1F), (double)((float)blockpos.func_177952_p() + 0.5F));
          }
@@ -312,7 +317,7 @@
  
          this.field_71083_bS = false;
  
-@@ -1565,15 +1648,16 @@
+@@ -1565,15 +1653,16 @@
  
      private boolean func_175143_p()
      {
@@ -332,7 +337,7 @@
          {
              if (!p_180467_2_)
              {
-@@ -1588,16 +1672,17 @@
+@@ -1588,16 +1677,17 @@
          }
          else
          {
@@ -353,7 +358,7 @@
  
              switch (enumfacing)
              {
-@@ -1637,16 +1722,24 @@
+@@ -1637,16 +1727,24 @@
  
      public BlockPos func_180470_cg()
      {
@@ -380,7 +385,7 @@
          if (p_180473_1_ != null)
          {
              this.field_71077_c = p_180473_1_;
-@@ -1841,6 +1934,10 @@
+@@ -1841,6 +1939,10 @@
  
              super.func_180430_e(p_180430_1_, p_180430_2_);
          }
@@ -391,7 +396,7 @@
      }
  
      protected void func_71061_d_()
-@@ -2041,6 +2138,18 @@
+@@ -2041,6 +2143,18 @@
          this.field_175152_f = p_71049_1_.field_175152_f;
          this.field_71078_a = p_71049_1_.field_71078_a;
          this.func_184212_Q().func_187227_b(field_184827_bp, p_71049_1_.func_184212_Q().func_187225_a(field_184827_bp));
@@ -410,7 +415,7 @@
      }
  
      protected boolean func_70041_e_()
-@@ -2145,7 +2254,10 @@
+@@ -2145,7 +2259,10 @@
  
      public ITextComponent func_145748_c_()
      {
@@ -422,7 +427,7 @@
          itextcomponent.func_150256_b().func_150241_a(new ClickEvent(ClickEvent.Action.SUGGEST_COMMAND, "/msg " + this.func_70005_c_() + " "));
          itextcomponent.func_150256_b().func_150209_a(this.func_174823_aP());
          itextcomponent.func_150256_b().func_179989_a(this.func_70005_c_());
-@@ -2154,7 +2266,7 @@
+@@ -2154,7 +2271,7 @@
  
      public float func_70047_e()
      {
@@ -431,7 +436,7 @@
  
          if (this.func_70608_bn())
          {
-@@ -2370,6 +2482,162 @@
+@@ -2370,6 +2487,168 @@
          return this.field_71075_bZ.field_75098_d && this.func_70003_b(2, "");
      }
  
@@ -588,6 +593,12 @@
 +    {
 +        return capability == net.minecraftforge.items.CapabilityItemHandler.ITEM_HANDLER_CAPABILITY || super.hasCapability(capability, facing);
 +    }
++
++    @Nullable
++    private Integer spawnDimension;
++    public boolean hasSpawnDimension() { return spawnDimension != null; }
++    public int getSpawnDimension() { return spawnDimension != null ? spawnDimension : 0; }
++    public void setSpawnDimension(@Nullable Integer dimension) { this.spawnDimension = dimension; }
 +
 +    /* ======================================== FORGE END  =====================================*/
 +

--- a/patches/minecraft/net/minecraft/server/management/PlayerList.java.patch
+++ b/patches/minecraft/net/minecraft/server/management/PlayerList.java.patch
@@ -103,19 +103,20 @@
  
          this.func_148540_a(new SPacketPlayerListItem(SPacketPlayerListItem.Action.REMOVE_PLAYER, new EntityPlayerMP[] {p_72367_1_}));
      }
-@@ -450,13 +482,23 @@
+@@ -450,13 +482,24 @@
  
      public EntityPlayerMP func_72368_a(EntityPlayerMP p_72368_1_, int p_72368_2_, boolean p_72368_3_)
      {
 +        World world = field_72400_f.func_71218_a(p_72368_2_);
 +        if (world == null)
 +        {
-+            p_72368_2_ = 0;
++            p_72368_2_ = p_72368_1_.getSpawnDimension();
 +        }
 +        else if (!world.field_73011_w.func_76567_e())
 +        {
 +            p_72368_2_ = world.field_73011_w.getRespawnDimension(p_72368_1_);
 +        }
++        if (field_72400_f.func_71218_a(p_72368_2_) == null) p_72368_2_ = 0;
 +
          p_72368_1_.func_71121_q().func_73039_n().func_72787_a(p_72368_1_);
          p_72368_1_.func_71121_q().func_73039_n().func_72790_b(p_72368_1_);
@@ -129,7 +130,7 @@
          p_72368_1_.field_71093_bK = p_72368_2_;
          PlayerInteractionManager playerinteractionmanager;
  
-@@ -472,6 +514,7 @@
+@@ -472,6 +515,7 @@
          EntityPlayerMP entityplayermp = new EntityPlayerMP(this.field_72400_f, this.field_72400_f.func_71218_a(p_72368_1_.field_71093_bK), p_72368_1_.func_146103_bH(), playerinteractionmanager);
          entityplayermp.field_71135_a = p_72368_1_.field_71135_a;
          entityplayermp.func_71049_a(p_72368_1_, p_72368_3_);
@@ -137,7 +138,7 @@
          entityplayermp.func_145769_d(p_72368_1_.func_145782_y());
          entityplayermp.func_174817_o(p_72368_1_);
          entityplayermp.func_184819_a(p_72368_1_.func_184591_cq());
-@@ -519,6 +562,7 @@
+@@ -519,6 +563,7 @@
          this.field_177454_f.put(entityplayermp.func_110124_au(), entityplayermp);
          entityplayermp.func_71116_b();
          entityplayermp.func_70606_j(entityplayermp.func_110143_aJ());
@@ -145,7 +146,7 @@
          return entityplayermp;
      }
  
-@@ -533,15 +577,20 @@
+@@ -533,15 +578,20 @@
  
      public void func_187242_a(EntityPlayerMP p_187242_1_, int p_187242_2_)
      {
@@ -168,7 +169,7 @@
          this.func_72375_a(p_187242_1_, worldserver);
          p_187242_1_.field_71135_a.func_147364_a(p_187242_1_.field_70165_t, p_187242_1_.field_70163_u, p_187242_1_.field_70161_v, p_187242_1_.field_70177_z, p_187242_1_.field_70125_A);
          p_187242_1_.field_71134_c.func_73080_a(worldserver1);
-@@ -553,17 +602,27 @@
+@@ -553,17 +603,27 @@
          {
              p_187242_1_.field_71135_a.func_147359_a(new SPacketEntityEffect(p_187242_1_.func_145782_y(), potioneffect));
          }
@@ -199,7 +200,7 @@
          {
              d0 = MathHelper.func_151237_a(d0 / 8.0D, p_82448_4_.func_175723_af().func_177726_b() + 16.0D, p_82448_4_.func_175723_af().func_177728_d() - 16.0D);
              d1 = MathHelper.func_151237_a(d1 / 8.0D, p_82448_4_.func_175723_af().func_177736_c() + 16.0D, p_82448_4_.func_175723_af().func_177733_e() - 16.0D);
-@@ -574,7 +633,7 @@
+@@ -574,7 +634,7 @@
                  p_82448_3_.func_72866_a(p_82448_1_, false);
              }
          }
@@ -208,7 +209,7 @@
          {
              d0 = MathHelper.func_151237_a(d0 * 8.0D, p_82448_4_.func_175723_af().func_177726_b() + 16.0D, p_82448_4_.func_175723_af().func_177728_d() - 16.0D);
              d1 = MathHelper.func_151237_a(d1 * 8.0D, p_82448_4_.func_175723_af().func_177736_c() + 16.0D, p_82448_4_.func_175723_af().func_177733_e() - 16.0D);
-@@ -585,7 +644,8 @@
+@@ -585,7 +645,8 @@
                  p_82448_3_.func_72866_a(p_82448_1_, false);
              }
          }
@@ -218,7 +219,7 @@
          {
              BlockPos blockpos;
  
-@@ -620,7 +680,7 @@
+@@ -620,7 +681,7 @@
              if (p_82448_1_.func_70089_S())
              {
                  p_82448_1_.func_70012_b(d0, p_82448_1_.field_70163_u, d1, p_82448_1_.field_70177_z, p_82448_1_.field_70125_A);

--- a/patches/minecraft/net/minecraft/world/WorldProvider.java.patch
+++ b/patches/minecraft/net/minecraft/world/WorldProvider.java.patch
@@ -217,7 +217,7 @@
 +     */
 +    public int getRespawnDimension(net.minecraft.entity.player.EntityPlayerMP player)
 +    {
-+        return 0;
++        return player.getSpawnDimension();
 +    }
 +
 +    /**

--- a/src/test/java/net/minecraftforge/test/CustomSpawnDimensionTest.java
+++ b/src/test/java/net/minecraftforge/test/CustomSpawnDimensionTest.java
@@ -1,0 +1,39 @@
+package net.minecraftforge.test;
+
+import net.minecraft.entity.Entity;
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.util.math.BlockPos;
+import net.minecraftforge.common.MinecraftForge;
+import net.minecraftforge.event.entity.EntityJoinWorldEvent;
+import net.minecraftforge.fml.common.Mod;
+import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
+
+@Mod(modid = CustomSpawnDimensionTest.MODID, name = "CustomSpawnDimensionTest", version = "0.1")
+public class CustomSpawnDimensionTest
+{
+    public static final String MODID = "customspawndimensiontest";
+
+    private static final boolean ENABLE = false;
+
+    public CustomSpawnDimensionTest()
+    {
+        if (ENABLE)
+        {
+            MinecraftForge.EVENT_BUS.register(this);
+        }
+    }
+
+    @SubscribeEvent
+    public void enterDimension(EntityJoinWorldEvent event)
+    {
+        Entity e = event.getEntity();
+        if (!(e instanceof EntityPlayer))
+            return;
+
+        BlockPos pos = e.getPosition();
+        int dim = e.dimension;
+
+        ((EntityPlayer) e).setSpawnDimension(dim);
+        ((EntityPlayer) e).setSpawnChunk(pos, true, dim);
+    }
+}


### PR DESCRIPTION
This allows mods that add personal dimensions or custom dimensions, to act as the preferred respawn location in place of the overworld.

The expected way to use the setter is by handling `PlayerSetSpawnEvent` and setting the dimension if setting the spawn in a "home-able" dimension.