### PR TITLE
Properly deobfuscate lambda expressions

### DIFF
--- a/src/main/java/net/minecraftforge/fml/common/asm/transformers/deobf/FMLRemappingAdapter.java
+++ b/src/main/java/net/minecraftforge/fml/common/asm/transformers/deobf/FMLRemappingAdapter.java
@@ -21,17 +21,29 @@ package net.minecraftforge.fml.common.asm.transformers.deobf;
 
 import org.objectweb.asm.ClassVisitor;
 import org.objectweb.asm.FieldVisitor;
+import org.objectweb.asm.Handle;
 import org.objectweb.asm.MethodVisitor;
 import org.objectweb.asm.Opcodes;
+import org.objectweb.asm.Type;
 import org.objectweb.asm.commons.Remapper;
 import org.objectweb.asm.commons.RemappingClassAdapter;
 import org.objectweb.asm.commons.RemappingMethodAdapter;
+
+import java.util.Arrays;
+import java.util.List;
 
 public class FMLRemappingAdapter extends RemappingClassAdapter {
     public FMLRemappingAdapter(ClassVisitor cv)
     {
         super(cv, FMLDeobfuscatingRemapper.INSTANCE);
     }
+
+    private static final List<Handle> META_FACTORIES = Arrays.asList(
+            new Handle(Opcodes.H_INVOKESTATIC, "java/lang/invoke/LambdaMetafactory", "metafactory",
+                    "(Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/String;Ljava/lang/invoke/MethodType;Ljava/lang/invoke/MethodType;Ljava/lang/invoke/MethodHandle;Ljava/lang/invoke/MethodType;)Ljava/lang/invoke/CallSite;"),
+            new Handle(Opcodes.H_INVOKESTATIC, "java/lang/invoke/LambdaMetafactory", "altMetafactory",
+                    "(Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/String;Ljava/lang/invoke/MethodType;[Ljava/lang/Object;)Ljava/lang/invoke/CallSite;")
+    );
 
     @Override
     public void visit(int version, int access, String name, String signature, String superName, String[] interfaces)
@@ -88,6 +100,19 @@ public class FMLRemappingAdapter extends RemappingClassAdapter {
             if (mv != null) {
                 mv.visitFieldInsn(opcode, type, fieldName, newDesc);
             }
+        }
+
+        @Override
+        public void visitInvokeDynamicInsn(String name, String desc, Handle bsm, Object... bsmArgs)
+        {
+            if (META_FACTORIES.contains(bsm))
+            {
+                String owner = Type.getReturnType(desc).getInternalName();
+                String odesc = ((Type) bsmArgs[0]).getDescriptor(); // First constant argument is "samMethodType - Signature and return type of method to be implemented by the function object."
+                name = remapper.mapMethodName(owner, name, odesc);
+            }
+
+            super.visitInvokeDynamicInsn(name, desc, bsm, bsmArgs);
         }
     }
 }


### PR DESCRIPTION
Tl;dr: While the `invokedynamic` opcode is properly obfuscated by SpecialSoruce (run during a `gradle build` when using ForgeGradle), FML's remapper does not reverse this process. This leads to an `AbstractMethodError` when running an obfuscated jar file in a deobfuscated environment (e.g. an IDE).

**Background**

Lambdas in Java are implemented through a combination of the `invokedynamic` opcode introduced in JRE 7, and [`LambdaFactory#metafactory`](https://docs.oracle.com/javase/8/docs/api/java/lang/invoke/LambdaMetafactory.html#metafactory-java.lang.invoke.MethodHandles.Lookup-java.lang.String-java.lang.invoke.MethodType-java.lang.invoke.MethodType-java.lang.invoke.MethodHandle-java.lang.invoke.MethodType-), introduced with Java 8. Here's a rough outline of the process:


1. The compiler moves the lambda body  into a synthetic private method in the same class where it was declared. All parameters for the implemented interface, along with any variables 'captured' from the enclosing scope. For example, in this snippet:

```
String str = "Foo"
Runnable myRun = () -> System.out.println(str);
```

`str` is 'captured' by the lambda. Note that unused variables from the scope will not be 'captured' and passed in as arguments to the synthetic private method.

2. The compiler emits an `invokedynamic` opcode, which (essentially) will take the name of interface method being implemented (`run` in the example), and two things, as arguments. The last two 'arguments' aren't really important for obfuscation purposes - they specify the signature of an anonymous class that will be generated *at runtime* to complete the lambda implementation, as well as the 'bootstrap method' (always `LambdaFactory#metafactory` for Java) which is responsible for kicking off the whole sequence of dynamic class generation that happens at runtime.
3, The first time the `invokedynamic` opcode is encountered at runtime, the 'bootstrap method' is run to generate a `CallSite`, which is used to actually get a class implementing the target interface (`Runnable` in this case).

**The issue**

When lambdas are used to implement an obfuscated interface (e.g. `ItemMeshDefinition`), the parameters to `invokedynamic` need to be modified so that the class generated by `LambdaMetaFactory` will implement the proper interface. This is accomplished [in SpecialSoure](https://github.com/md-5/SpecialSource/blob/master/src/main/java/net/md_5/specialsource/UnsortedRemappingMethodAdapter.java#L185) (which runs during a `gradle build` in a ForgeGradle project).

However, Forge does not reverse this process in its `DeobfuscationTransformer`. While Minecraft itself does not currently use any lambdas, this can create a problem when an obfuscated build of a mod is run in a deobfuscated (development) environment. When the mod gets classloaded, Forge will properly remap all normal obfuscated references in it to deobfuscated ones, allowing it to run in an environment with MCP names. However, `invokedynamic` is **not** currently remapped during the process. The end result is that Java's `LambdaMetaFactory` will end up generating a class implementing the proper interface, but will generate a method with the obfuscated name, rather than the deobfuscated one.

To see this issue in action, download [this test plugin](https://github.com/Aaron1011/LambdaDeobf/releases/tag/v1.0.0) (source [here](https://github.com/Aaron1011/LambdaDeobf/blob/master/src/main/java/com/aaron1011/lambdadeobf/LambdaDeobf.java)). It's compiled for Forge 1.10, but the interface it implements stays the same between 1.10 and 1.11 - so it should be possible to run under 1.11 by simply changing the `build.gradle`. Run its **production** build in your IDE by placing it in the `mods` folder in your `run` directory, and observe the `AbstractMethodError` on startup.

**The fix**

As both SpecialSource and `FMLRemappingAdapter` use the same underlying ASM `Remapper`, the code is nearly identical. I've removed some redundant calls done in the `SpecialSource` version , such as calling `remapper.mapValue`, as this is automatically done in the superclass.

**Note**: You could make the case that this is something that should be fixed in ASM commons, not Forge. However, it's important to keep in mind that ASM works with Java bytecode in general (e.g. from another JVM langauge), not necessary bytecode generated from Java source code. The `invokedynamic` instruction is a very general-purpose tool, and generating lambdas is only one small possible use of it. Specifically, the class can define the 'static arguments' to the bootstrap method to be absolutely anything it wants - ASM would need to special-case the particular bootstrap methods used by java, which could technically change at any time.