### PR TITLE
Added null-check in SPacketChunkData to allow null getUpdateTag

### DIFF
--- a/patches/minecraft/net/minecraft/network/play/server/SPacketChunkData.java.patch
+++ b/patches/minecraft/net/minecraft/network/play/server/SPacketChunkData.java.patch
@@ -1,0 +1,11 @@
+--- ../src-base/minecraft/net/minecraft/network/play/server/SPacketChunkData.java
++++ ../src-work/minecraft/net/minecraft/network/play/server/SPacketChunkData.java
+@@ -49,7 +49,7 @@
+             if (this.func_149274_i() || (p_i47124_2_ & 1 << i) != 0)
+             {
+                 NBTTagCompound nbttagcompound = tileentity.func_189517_E_();
+-                this.field_189557_e.add(nbttagcompound);
++                if(nbttagcompound != null) this.field_189557_e.add(nbttagcompound); //Null-check to disable sync on tiles which don't need it
+             }
+         }
+     }


### PR DESCRIPTION
Some tile entities, such as ores, don't need sync at all and have custom mechanics. However MC forces to use non-null getUpdateTag and send tons of useless data over a network. 