### PR TITLE
[1.11] Fixes for Chunk.getBlockLightOpacity implementation

### DIFF
--- a/patches/minecraft/net/minecraft/world/chunk/Chunk.java.patch
+++ b/patches/minecraft/net/minecraft/world/chunk/Chunk.java.patch
@@ -21,7 +21,7 @@
      {
 -        return this.func_186032_a(p_150808_1_, p_150808_2_, p_150808_3_).func_185891_c();
 +        IBlockState state = this.func_186032_a(p_150808_1_, p_150808_2_, p_150808_3_); //Forge: Can sometimes be called before we are added to the global world list. So use the less accurate one during that. It'll be recalculated later
-+        return this.field_189550_d ? state.func_185891_c() : state.getLightOpacity(this.field_76637_e, new BlockPos(p_150808_1_, p_150808_2_, p_150808_3_));
++        return !this.field_76636_d ? state.func_185891_c() : state.getLightOpacity(this.field_76637_e, new BlockPos(p_150808_1_, p_150808_2_, p_150808_3_));
      }
  
      public IBlockState func_177435_g(BlockPos p_177435_1_)

--- a/patches/minecraft/net/minecraft/world/chunk/Chunk.java.patch
+++ b/patches/minecraft/net/minecraft/world/chunk/Chunk.java.patch
@@ -5,7 +5,7 @@
                      IBlockState iblockstate = this.func_186032_a(j, l - 1, k);
  
 -                    if (iblockstate.func_185891_c() != 0)
-+                    if (iblockstate.getLightOpacity(this.field_76637_e, new BlockPos(j, l - 1, k)) != 0)
++                    if (this.func_150808_b(j, l - 1, k) != 0)
                      {
                          this.field_76634_f[k << 4 | j] = l;
  
@@ -21,7 +21,7 @@
      {
 -        return this.func_186032_a(p_150808_1_, p_150808_2_, p_150808_3_).func_185891_c();
 +        IBlockState state = this.func_186032_a(p_150808_1_, p_150808_2_, p_150808_3_); //Forge: Can sometimes be called before we are added to the global world list. So use the less accurate one during that. It'll be recalculated later
-+        return !this.field_76636_d ? state.func_185891_c() : state.getLightOpacity(this.field_76637_e, new BlockPos(p_150808_1_, p_150808_2_, p_150808_3_));
++        return !field_76636_d ? state.func_185891_c() : state.getLightOpacity(field_76637_e, new BlockPos(field_76635_g << 4 | p_150808_1_ & 15, p_150808_2_, field_76647_h << 4 | p_150808_3_ & 15));
      }
  
      public IBlockState func_177435_g(BlockPos p_177435_1_)


### PR DESCRIPTION
The current code checks the value of `<chunk>.unloaded` which is false by default and only used in vanilla by `ChunkProviderServer` for tracking chunks to unload.

This changes the check to `!<chunk>.isChunkLoaded`, which is set by `onChunkLoad/Unload()` instead.

The issue behind this is that `getBlockLightOpacity` is called by `generateSkylightMap`, which is called during initial chunk generation. As it currently stands a newly created chunk has never been unloaded, so the logic calls `state.getLightOpacity(IBlockAccess, BlockPos)`.

Then:
  * An implementation of this may call `world.getBlockState(pos)`
  * The world calls `IChunkProvider.provideChunk()`
  * The provider sees the chunk as not loaded, and calls `IChunkGenerator.provideChunk()`
  * The chunk generator begins generating a new chunk, and during this, calls `generateSkylightMap()`
  * Which calls `getBlockLightOpacity()`, and so on, until a `StackOverflowError` occurs

I believe this is a problem that the check was intended to prevent, but the `unloaded` field doesn't actually work to prevent this. `isChunkLoaded` will be false on initial chunk generation, so this will no longer occur.