### PR TITLE
Allow custom selector types to be defined

### DIFF
--- a/patches/minecraft/net/minecraft/command/EntitySelector.java.patch
+++ b/patches/minecraft/net/minecraft/command/EntitySelector.java.patch
@@ -1,6 +1,18 @@
 --- ../src-base/minecraft/net/minecraft/command/EntitySelector.java
 +++ ../src-work/minecraft/net/minecraft/command/EntitySelector.java
-@@ -148,6 +148,7 @@
+@@ -116,6 +116,11 @@
+ 
+     public static <T extends Entity> List<T> func_179656_b(ICommandSender p_179656_0_, String p_179656_1_, Class <? extends T > p_179656_2_) throws CommandException
+     {
++        return net.minecraftforge.common.command.SelectorHandlerManager.matchEntities(p_179656_0_, p_179656_1_, p_179656_2_);
++    }
++
++    public static <T extends Entity> List<T> matchEntitiesDefault(ICommandSender p_179656_0_, String p_179656_1_, Class <? extends T > p_179656_2_) throws CommandException
++    {
+         Matcher matcher = field_82389_a.matcher(p_179656_1_);
+ 
+         if (matcher.matches() && p_179656_0_.func_70003_b(1, "@"))
+@@ -148,6 +153,7 @@
                          list2.addAll(func_184951_f(map));
                          list2.addAll(func_180698_a(map, vec3d));
                          list2.addAll(func_179662_g(map));
@@ -8,3 +20,27 @@
                          list1.addAll(func_179660_a(map, p_179656_2_, list2, s, world, blockpos));
                      }
                  }
+@@ -722,6 +728,11 @@
+ 
+     public static boolean func_82377_a(String p_82377_0_) throws CommandException
+     {
++        return net.minecraftforge.common.command.SelectorHandlerManager.matchesMultiplePlayers(p_82377_0_);
++    }
++
++    public static boolean matchesMultiplePlayersDefault(String p_82377_0_) throws CommandException
++    {
+         Matcher matcher = field_82389_a.matcher(p_82377_0_);
+ 
+         if (!matcher.matches())
+@@ -739,6 +750,11 @@
+ 
+     public static boolean func_82378_b(String p_82378_0_)
+     {
++        return net.minecraftforge.common.command.SelectorHandlerManager.isSelector(p_82378_0_);
++    }
++
++    public static boolean isSelectorDefault(String p_82378_0_)
++    {
+         return field_82389_a.matcher(p_82378_0_).matches();
+     }
+ 

--- a/src/main/java/net/minecraftforge/common/command/SelectorHandler.java
+++ b/src/main/java/net/minecraftforge/common/command/SelectorHandler.java
@@ -1,0 +1,52 @@
+/*
+ * Minecraft Forge
+ * Copyright (c) 2016.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation version 2.1
+ * of the License.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+package net.minecraftforge.common.command;
+
+import java.util.List;
+
+import net.minecraft.command.CommandException;
+import net.minecraft.command.ICommandSender;
+import net.minecraft.entity.Entity;
+
+/**
+ * Handler for custom types of selectors registered with {@link SelectorHandlerManager}
+ */
+public abstract class SelectorHandler
+{
+    public abstract <T extends Entity> List<T> matchEntities(ICommandSender sender, String token, Class<? extends T> targetClass) throws CommandException;
+
+    /**
+     * Returns whether the selector string potentially matches multiple entities
+     */
+    public abstract boolean matchesMultiplePlayers(String selectorStr) throws CommandException;
+
+    /**
+     * Returns whether the string represents a selector <br>
+     * This method indicated whether {@link #matchEntities this.matchEntities} should be used to resolve the string<br>
+     * <b>Note:</b> Since the handler is chosen based on the registered prefix, this will mostly return {@code true}<br>
+     * <b>Note:</b> Mostly for legacy reasons.
+     * (Since {@link net.minecraft.command.EntitySelector#matchEntities(ICommandSender, String, Class) EntitySelector.matchEntities}
+     * returns an empty list when the string is illformed instead of throwing an exception (as is indirectly done when this method returns {@code false})
+     */
+    public boolean isSelector(String selectorStr)
+    {
+        return true;
+    }
+}

--- a/src/main/java/net/minecraftforge/common/command/SelectorHandler.java
+++ b/src/main/java/net/minecraftforge/common/command/SelectorHandler.java
@@ -30,6 +30,11 @@ import net.minecraft.entity.Entity;
  */
 public abstract class SelectorHandler
 {
+    /**
+     * Returns a {@link List} of {@link Entity Entities} of class {@code targetClass} ({@code T}) represented by {@code token}
+     * 
+     * @param sender The {@link ICommandSender} that initiated the query
+     */
     public abstract <T extends Entity> List<T> matchEntities(ICommandSender sender, String token, Class<? extends T> targetClass) throws CommandException;
 
     /**

--- a/src/main/java/net/minecraftforge/common/command/SelectorHandler.java
+++ b/src/main/java/net/minecraftforge/common/command/SelectorHandler.java
@@ -44,8 +44,9 @@ public abstract class SelectorHandler
 
     /**
      * Returns whether the string represents a selector <br>
-     * This method indicated whether {@link #matchEntities this.matchEntities} should be used to resolve the string<br>
-     * <b>Note:</b> Since the handler is chosen based on the registered prefix, this will mostly return {@code true}<br>
+     * <b>Note:</b> Returning {@code false} does not prevent {@link #matchEntities this.matchEntities} from being called. It is recommended to not override this method and
+     * simply throw an exception there <br>
+     * <b>Note:</b> If {@code selectorStr} could be a valid entity name, this method should return {@code false} and {@link #matchEntities this.matchEntities} should return an empty list instead of throwing in case {@code selectorStr} is not a valid selector <br>
      * <b>Note:</b> Mostly for legacy reasons.
      * (Since {@link net.minecraft.command.EntitySelector#matchEntities(ICommandSender, String, Class) EntitySelector.matchEntities}
      * returns an empty list when the string is illformed instead of throwing an exception (as is indirectly done when this method returns {@code false})

--- a/src/main/java/net/minecraftforge/common/command/SelectorHandler.java
+++ b/src/main/java/net/minecraftforge/common/command/SelectorHandler.java
@@ -28,31 +28,25 @@ import net.minecraft.entity.Entity;
 /**
  * Handler for custom types of selectors registered with {@link SelectorHandlerManager}
  */
-public abstract class SelectorHandler
+public interface SelectorHandler
 {
     /**
-     * Returns a {@link List} of {@link Entity Entities} of class {@code targetClass} ({@code T}) represented by {@code token}
+     * Returns a {@link List} of {@link Entity Entities} of class {@code targetClass} ({@code T}) represented by {@code token}<br>
+     * <b>Note:</b> If {@code token} does not match the overall syntax defined by {@link #isSelector}, this method should return an empty list.
+     * For any other error, an exception should be thrown
      * 
      * @param sender The {@link ICommandSender} that initiated the query
      */
-    public abstract <T extends Entity> List<T> matchEntities(ICommandSender sender, String token, Class<? extends T> targetClass) throws CommandException;
+    public <T extends Entity> List<T> matchEntities(ICommandSender sender, String token, Class<? extends T> targetClass) throws CommandException;
 
     /**
      * Returns whether the selector string potentially matches multiple entities
      */
-    public abstract boolean matchesMultiplePlayers(String selectorStr) throws CommandException;
+    public boolean matchesMultiplePlayers(String selectorStr) throws CommandException;
 
     /**
-     * Returns whether the string represents a selector <br>
-     * <b>Note:</b> Returning {@code false} does not prevent {@link #matchEntities this.matchEntities} from being called. It is recommended to not override this method and
-     * simply throw an exception there <br>
-     * <b>Note:</b> If {@code selectorStr} could be a valid entity name, this method should return {@code false} and {@link #matchEntities this.matchEntities} should return an empty list instead of throwing in case {@code selectorStr} is not a valid selector <br>
-     * <b>Note:</b> Mostly for legacy reasons.
-     * (Since {@link net.minecraft.command.EntitySelector#matchEntities(ICommandSender, String, Class) EntitySelector.matchEntities}
-     * returns an empty list when the string is illformed instead of throwing an exception (as is indirectly done when this method returns {@code false})
+     * Returns whether the string matches the overall syntax of the selector<br>
+     * <b>Note:</b> If this returns {@code false}, {@link #matchEntities} should return an empty list
      */
-    public boolean isSelector(String selectorStr)
-    {
-        return true;
-    }
+    public boolean isSelector(String selectorStr);
 }

--- a/src/main/java/net/minecraftforge/common/command/SelectorHandlerManager.java
+++ b/src/main/java/net/minecraftforge/common/command/SelectorHandlerManager.java
@@ -101,12 +101,15 @@ public class SelectorHandlerManager
     }
 
     /**
-     * Returns a collection of all registered prefixes less specific than {@code prefix}
+     * Returns a collection of all registered prefixes at most as specific as {@code prefix}
      *
      * @return A {@link Map} mapping the prefixes to the mod ids registering them
      */
     public static Map<String, String> getShadowed(final String prefix)
     {
+        if (prefix.isEmpty())
+            return Collections.emptyMap();
+
         Map<String, String> ret = new HashMap<String, String>();
 
         for (final Entry<String, String> other : registeringMods.subMap(prefix, true, prefix.substring(0, 1), true).entrySet())

--- a/src/main/java/net/minecraftforge/common/command/SelectorHandlerManager.java
+++ b/src/main/java/net/minecraftforge/common/command/SelectorHandlerManager.java
@@ -126,16 +126,16 @@ public class SelectorHandlerManager
         if (prefix.isEmpty())
             throw new IllegalArgumentException("Prefix must not be empty");
 
-        final String modName = Loader.instance().activeModContainer().getName();
+        final String modId = Loader.instance().activeModContainer().getModId();
 
         for (Entry<String, String> other : getShadowed(prefix).entrySet())
-            FMLLog.info("Selector prefix '%s' of mod '%s' is shadowing prefix '%s' of mod '%s'", prefix, modName, other.getKey(), other.getValue());
+            FMLLog.info("Selector prefix '%s' of mod '%s' is shadowing prefix '%s' of mod '%s'", prefix, modId, other.getKey(), other.getValue());
 
         for (Entry<String, String> other : getShadowing(prefix).entrySet())
-            FMLLog.info("Selector prefix '%s' of mod '%s' is shadowed by prefix '%s' of mod '%s'", prefix, modName, other.getKey(), other.getValue());
+            FMLLog.info("Selector prefix '%s' of mod '%s' is shadowed by prefix '%s' of mod '%s'", prefix, modId, other.getKey(), other.getValue());
 
         selectorHandlers.put(prefix, handler);
-        registeringMods.put(prefix, modName);
+        registeringMods.put(prefix, modId);
     }
 
     /**

--- a/src/main/java/net/minecraftforge/common/command/SelectorHandlerManager.java
+++ b/src/main/java/net/minecraftforge/common/command/SelectorHandlerManager.java
@@ -90,12 +90,19 @@ public class SelectorHandlerManager
      */
     public static Map<String, String> getShadowing(final String prefix)
     {
-        Map<String, String> ret = new HashMap<String, String>();
+        final Map<String, String> ret = new HashMap<String, String>();
 
         for (final Entry<String, String> other : registeringMods.descendingMap().tailMap(prefix, false).entrySet())
+        {
             if (other.getKey().startsWith(prefix))
+            {
                 ret.put(other.getKey(), other.getValue());
-            else return ret;
+            }
+            else
+            {
+                return ret;
+            }
+        }
 
         return ret;
     }
@@ -108,13 +115,19 @@ public class SelectorHandlerManager
     public static Map<String, String> getShadowed(final String prefix)
     {
         if (prefix.isEmpty())
+        {
             return Collections.emptyMap();
+        }
 
-        Map<String, String> ret = new HashMap<String, String>();
+        final Map<String, String> ret = new HashMap<String, String>();
 
         for (final Entry<String, String> other : registeringMods.subMap(prefix, true, prefix.substring(0, 1), true).entrySet())
+        {
             if (prefix.startsWith(other.getKey()))
+            {
                 ret.put(other.getKey(), other.getValue());
+            }
+        }
 
         return ret;
     }
@@ -128,15 +141,21 @@ public class SelectorHandlerManager
     public static void register(final String prefix, final SelectorHandler handler)
     {
         if (prefix.isEmpty())
+        {
             throw new IllegalArgumentException("Prefix must not be empty");
+        }
 
         final String modId = Loader.instance().activeModContainer().getModId();
 
-        for (Entry<String, String> other : getShadowed(prefix).entrySet())
+        for (final Entry<String, String> other : getShadowed(prefix).entrySet())
+        {
             FMLLog.info("Selector prefix '%s' of mod '%s' is shadowing prefix '%s' of mod '%s'", prefix, modId, other.getKey(), other.getValue());
+        }
 
-        for (Entry<String, String> other : getShadowing(prefix).entrySet())
+        for (final Entry<String, String> other : getShadowing(prefix).entrySet())
+        {
             FMLLog.info("Selector prefix '%s' of mod '%s' is shadowed by prefix '%s' of mod '%s'", prefix, modId, other.getKey(), other.getValue());
+        }
 
         selectorHandlers.put(prefix, handler);
         registeringMods.put(prefix, modId);
@@ -148,9 +167,15 @@ public class SelectorHandlerManager
     public static SelectorHandler getHandler(final String selectorStr)
     {
         if (!selectorStr.isEmpty())
+        {
             for (final Entry<String, SelectorHandler> handler : selectorHandlers.subMap(selectorStr, true, selectorStr.substring(0, 1), true).entrySet())
+            {
                 if (selectorStr.startsWith(handler.getKey()))
+                {
                     return handler.getValue();
+                }
+            }
+        }
 
         return vanillaHandler;
     }

--- a/src/main/java/net/minecraftforge/common/command/SelectorHandlerManager.java
+++ b/src/main/java/net/minecraftforge/common/command/SelectorHandlerManager.java
@@ -1,0 +1,158 @@
+/*
+ * Minecraft Forge
+ * Copyright (c) 2016.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation version 2.1
+ * of the License.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+package net.minecraftforge.common.command;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map.Entry;
+import java.util.SortedMap;
+import java.util.TreeMap;
+
+import org.apache.commons.lang3.ArrayUtils;
+
+import net.minecraft.command.CommandException;
+import net.minecraft.command.EntitySelector;
+import net.minecraft.command.ICommandSender;
+import net.minecraft.entity.Entity;
+import net.minecraftforge.fml.common.FMLLog;
+import net.minecraftforge.fml.common.Loader;
+
+/**
+ * Allows registration of custom selector types by assigning a {@link SelectorHandler} to a prefix
+ * To check whether a new prefix conflicts with any registered prefix, the methods {@link #isShadowed} and {@link #isShadowing} can be used
+ * This class handles calls to the {@link EntitySelector} methods {@link EntitySelector#matchEntities matchEntities},
+ * {@link EntitySelector#matchesMultiplePlayers matchesMultiplePlayers} and {@link EntitySelector#isSelector isSelector}.<br>
+ * The calls are delegated to the handler with the longest matching prefix
+ */
+public class SelectorHandlerManager
+{
+    private SelectorHandlerManager()
+    {
+    }
+
+    //the ordering is reversed such that longer prefixes appear before their shorter substrings
+    private static final SortedMap<String, SelectorHandler> selectorHandlers = new TreeMap<String, SelectorHandler>(Collections.<String> reverseOrder());
+    private static final SortedMap<String, String> registeringMods = new TreeMap<String, String>(Collections.<String> reverseOrder());
+
+    private static final SelectorHandler vanillaHandler = new SelectorHandler()
+    {
+        @Override
+        public <T extends Entity> List<T> matchEntities(final ICommandSender sender, final String token, final Class<? extends T> targetClass) throws CommandException
+        {
+            return EntitySelector.matchEntitiesDefault(sender, token, targetClass);
+        }
+
+        @Override
+        public boolean matchesMultiplePlayers(final String selectorStr) throws CommandException
+        {
+            return EntitySelector.matchesMultiplePlayersDefault(selectorStr);
+        }
+
+        @Override
+        public boolean isSelector(final String selectorStr)
+        {
+            return EntitySelector.isSelectorDefault(selectorStr);
+        }
+    };
+
+    static
+    {
+        for (final String prefix : ArrayUtils.toArray("@p", "@a", "@r", "@e"))
+        {
+            selectorHandlers.put(prefix, vanillaHandler);
+            registeringMods.put(prefix, "Minecraft");
+        }
+    }
+
+    /**
+     * Returns whether there is already a more specific prefix registered
+     */
+    public static boolean isShadowed(final String prefix)
+    {
+        for (final String other : registeringMods.keySet())
+            if (prefix.startsWith(other))
+                return true;
+
+        return false;
+    }
+
+    /**
+     * Returns whether there is already a less specific prefix registered
+     */
+    public static boolean isShadowing(final String prefix)
+    {
+        for (final String other : registeringMods.keySet())
+            if (other.startsWith(prefix))
+                return true;
+
+        return false;
+    }
+
+    /**
+     * Registers a new {@link SelectorHandler} for the given prefix.
+     * Warnings are emitted when {@link #isShadowing} or {@link #isShadowed} would return {@code true}
+     */
+    public static void register(final String prefix, final SelectorHandler handler)
+    {
+        final String modName = Loader.instance().activeModContainer().getName();
+
+        for (final Entry<String, String> prefixData : registeringMods.entrySet())
+        {
+            final String otherPrefix = prefixData.getKey();
+
+            if (prefix.startsWith(otherPrefix))
+                FMLLog.info("Selector prefix '%s' of mod '%s' is shadowing prefix '%s' of mod '%s'", prefix, modName, otherPrefix, prefixData.getValue());
+            else if (otherPrefix.startsWith(prefix))
+                FMLLog.info("Selector prefix '%s' of mod '%s' is shadowed by prefix '%s' of mod '%s'", prefix, modName, otherPrefix, prefixData.getValue());
+        }
+
+        selectorHandlers.put(prefix, handler);
+        registeringMods.put(prefix, modName);
+    }
+
+    /**
+     * Returns the best matching handler for the given string. Defaults to the vanilla handler if no prefix applies
+     */
+    public static SelectorHandler getHandler(final String selectorStr)
+    {
+        for (final Entry<String, SelectorHandler> handler : selectorHandlers.entrySet())
+            if (selectorStr.startsWith(handler.getKey()))
+                return handler.getValue();
+
+        return vanillaHandler;
+    }
+
+    //These methods are called by the vanilla methods
+
+    public static <T extends Entity> List<T> matchEntities(final ICommandSender sender, final String token, final Class<? extends T> targetClass) throws CommandException
+    {
+        return getHandler(token).matchEntities(sender, token, targetClass);
+    }
+
+    public static boolean matchesMultiplePlayers(final String selectorStr) throws CommandException
+    {
+        return getHandler(selectorStr).matchesMultiplePlayers(selectorStr);
+    }
+
+    public static boolean isSelector(final String selectorStr)
+    {
+        return getHandler(selectorStr).isSelector(selectorStr);
+    }
+}

--- a/src/main/java/net/minecraftforge/common/command/SelectorHandlerManager.java
+++ b/src/main/java/net/minecraftforge/common/command/SelectorHandlerManager.java
@@ -33,7 +33,6 @@ import net.minecraft.command.CommandException;
 import net.minecraft.command.EntitySelector;
 import net.minecraft.command.ICommandSender;
 import net.minecraft.entity.Entity;
-import net.minecraftforge.fml.common.FMLLog;
 import net.minecraftforge.fml.common.Loader;
 
 /**
@@ -134,7 +133,6 @@ public class SelectorHandlerManager
 
     /**
      * Registers a new {@link SelectorHandler} for {@code prefix}.
-     * Warnings are emitted for all prefixes returned by {@link #getShadowing} and {@link #getShadowed}
      *
      * @param prefix A non-empty string
      */
@@ -146,16 +144,6 @@ public class SelectorHandlerManager
         }
 
         final String modId = Loader.instance().activeModContainer().getModId();
-
-        for (final Entry<String, String> other : getShadowed(prefix).entrySet())
-        {
-            FMLLog.info("Selector prefix '%s' of mod '%s' is shadowing prefix '%s' of mod '%s'", prefix, modId, other.getKey(), other.getValue());
-        }
-
-        for (final Entry<String, String> other : getShadowing(prefix).entrySet())
-        {
-            FMLLog.info("Selector prefix '%s' of mod '%s' is shadowed by prefix '%s' of mod '%s'", prefix, modId, other.getKey(), other.getValue());
-        }
 
         selectorHandlers.put(prefix, handler);
         registeringMods.put(prefix, modId);

--- a/src/main/java/net/minecraftforge/common/command/SelectorHandlerManager.java
+++ b/src/main/java/net/minecraftforge/common/command/SelectorHandlerManager.java
@@ -92,9 +92,10 @@ public class SelectorHandlerManager
     {
         Map<String, String> ret = new HashMap<String, String>();
 
-        for (final Entry<String, String> other : registeringMods.headMap(prefix).entrySet())
+        for (final Entry<String, String> other : registeringMods.descendingMap().tailMap(prefix, false).entrySet())
             if (other.getKey().startsWith(prefix))
                 ret.put(other.getKey(), other.getValue());
+            else return ret;
 
         return ret;
     }

--- a/src/main/resources/forge.exc
+++ b/src/main/resources/forge.exc
@@ -60,3 +60,7 @@ net/minecraft/world/storage/loot/LootEntryEmpty.<init>(II[Lnet/minecraft/world/s
 net/minecraft/world/chunk/BlockStateContainer.setBits(IZ)V=|p_186012_1_,forceBits
 net/minecraft/village/Village.getPlayerReputation(Ljava/util/UUID;)I=|p_82684_1_
 net/minecraft/village/Village.modifyPlayerReputation(Ljava/util/UUID;I)I=|p_82688_1_,p_82688_2_
+
+net/minecraft/command/EntitySelector.matchEntitiesDefault(Lnet/minecraft/command/ICommandSender;Ljava/lang/String;Ljava/lang/Class;)Ljava/util/List;=|p_179656_0_,p_179656_1_,p_179656_2_
+net/minecraft/command/EntitySelector.matchesMultiplePlayersDefault(Ljava/lang/String;)Z=|p_82377_0_
+net/minecraft/command/EntitySelector.isSelectorDefault(Ljava/lang/String;)Z=|p_82378_0_

--- a/src/test/java/net/minecraftforge/test/SelectorHandlerTest.java
+++ b/src/test/java/net/minecraftforge/test/SelectorHandlerTest.java
@@ -18,15 +18,25 @@ public class SelectorHandlerTest
     @EventHandler
     public void init(final FMLInitializationEvent event)
     {
-        SelectorHandlerManager.register("@s", new Handler());
-        SelectorHandlerManager.register("@es", new Handler()); //Should produce a warning
+        SelectorHandlerManager.register("@s", new Handler("@s"));
+        SelectorHandlerManager.register("@es", new Handler("@es")); //Should produce a warning
     }
 
     private static class Handler extends SelectorHandler
     {
+        private final String name;
+
+        public Handler(final String name)
+        {
+            this.name = name;
+        }
+
         @Override
         public <T extends Entity> List<T> matchEntities(final ICommandSender sender, final String token, final Class<? extends T> targetClass) throws CommandException
         {
+            if (!name.equals(token))
+                throw new CommandException("Invalid selector '" + token + "'");
+
             return targetClass.isAssignableFrom(sender.getCommandSenderEntity().getClass())
                 ? Collections.singletonList((T) sender.getCommandSenderEntity())
                 : Collections.<T> emptyList();

--- a/src/test/java/net/minecraftforge/test/SelectorHandlerTest.java
+++ b/src/test/java/net/minecraftforge/test/SelectorHandlerTest.java
@@ -22,7 +22,7 @@ public class SelectorHandlerTest
         SelectorHandlerManager.register("@es", new Handler("@es")); //Should produce a warning
     }
 
-    private static class Handler extends SelectorHandler
+    private static class Handler implements SelectorHandler
     {
         private final String name;
 
@@ -31,13 +31,12 @@ public class SelectorHandlerTest
             this.name = name;
         }
 
+        @SuppressWarnings("unchecked")
         @Override
         public <T extends Entity> List<T> matchEntities(final ICommandSender sender, final String token, final Class<? extends T> targetClass) throws CommandException
         {
-            if (!name.equals(token))
-                throw new CommandException("Invalid selector '" + token + "'");
-
-            return targetClass.isAssignableFrom(sender.getCommandSenderEntity().getClass())
+            final Entity senderEntity = sender.getCommandSenderEntity();
+            return senderEntity != null && targetClass.isAssignableFrom(senderEntity.getClass()) && name.equals(token)
                 ? Collections.singletonList((T) sender.getCommandSenderEntity())
                 : Collections.<T> emptyList();
         }
@@ -46,6 +45,12 @@ public class SelectorHandlerTest
         public boolean matchesMultiplePlayers(final String selectorStr) throws CommandException
         {
             return false;
+        }
+
+        @Override
+        public boolean isSelector(final String selectorStr)
+        {
+            return name.equals(selectorStr);
         }
     }
 }

--- a/src/test/java/net/minecraftforge/test/SelectorHandlerTest.java
+++ b/src/test/java/net/minecraftforge/test/SelectorHandlerTest.java
@@ -1,0 +1,41 @@
+package net.minecraftforge.test;
+
+import java.util.Collections;
+import java.util.List;
+
+import net.minecraft.command.CommandException;
+import net.minecraft.command.ICommandSender;
+import net.minecraft.entity.Entity;
+import net.minecraftforge.common.command.SelectorHandler;
+import net.minecraftforge.common.command.SelectorHandlerManager;
+import net.minecraftforge.fml.common.Mod;
+import net.minecraftforge.fml.common.Mod.EventHandler;
+import net.minecraftforge.fml.common.event.FMLInitializationEvent;
+
+@Mod(modid = "selectorhandlertest", name = "Selector Handler Test", version = "0.0.0")
+public class SelectorHandlerTest
+{
+    @EventHandler
+    public void init(final FMLInitializationEvent event)
+    {
+        SelectorHandlerManager.register("@s", new Handler());
+        SelectorHandlerManager.register("@es", new Handler()); //Should produce a warning
+    }
+
+    private static class Handler extends SelectorHandler
+    {
+        @Override
+        public <T extends Entity> List<T> matchEntities(final ICommandSender sender, final String token, final Class<? extends T> targetClass) throws CommandException
+        {
+            return targetClass.isAssignableFrom(sender.getCommandSenderEntity().getClass())
+                ? Collections.singletonList((T) sender.getCommandSenderEntity())
+                : Collections.<T> emptyList();
+        }
+
+        @Override
+        public boolean matchesMultiplePlayers(final String selectorStr) throws CommandException
+        {
+            return false;
+        }
+    }
+}

--- a/src/test/java/net/minecraftforge/test/SelectorHandlerTest.java
+++ b/src/test/java/net/minecraftforge/test/SelectorHandlerTest.java
@@ -18,18 +18,12 @@ public class SelectorHandlerTest
     @EventHandler
     public void init(final FMLInitializationEvent event)
     {
-        SelectorHandlerManager.register("@s", new Handler("@s"));
-        SelectorHandlerManager.register("@es", new Handler("@es")); //Should produce a warning
+        SelectorHandlerManager.register(Handler.name, new Handler());
     }
 
     private static class Handler implements SelectorHandler
     {
-        private final String name;
-
-        public Handler(final String name)
-        {
-            this.name = name;
-        }
+        protected static final String name = "@s";
 
         @SuppressWarnings("unchecked")
         @Override


### PR DESCRIPTION
This PR is an implementation of the proposed changes discussed in #3451 (as a new PR since it works completely different). See #3353 for an overview of what it attempts to achieve.

The goal is to provide a way to allow for more than just adding new parameters to filter entities - this is done by allowing new prefixes to be registered. Each time a selector is parsed, the best matching prefix (i.e. the longest matching one) is selected and the associated `SelectorHandler` is called.

(Note: There may be a better/faster way to do the lookup, e.g. using Tries or similar, but this would require more code)