### PR TITLE
Allow block to specify their type for AI pathfinding

### DIFF
--- a/patches/minecraft/net/minecraft/block/Block.java.patch
+++ b/patches/minecraft/net/minecraft/block/Block.java.patch
@@ -197,7 +197,7 @@
      public SoundType func_185467_w()
      {
          return this.field_149762_H;
-@@ -908,6 +932,1177 @@
+@@ -908,6 +932,1188 @@
      {
      }
  
@@ -1370,12 +1370,23 @@
 +        return false;
 +    }
 +
++    /**
++     * Get the {@code PathNodeType} for this block. Return {@code null} for vanilla behavior.
++     *
++     * @return the PathNodeType
++     */
++    @Nullable
++    public net.minecraft.pathfinding.PathNodeType getAiPathNodeType(IBlockState state, IBlockAccess world, BlockPos pos)
++    {
++        return isBurning(world, pos) ? net.minecraft.pathfinding.PathNodeType.DAMAGE_FIRE : null;
++    }
++
 +    /* ========================================= FORGE END ======================================*/
 +
      public static void func_149671_p()
      {
          func_176215_a(0, field_176230_a, (new BlockAir()).func_149663_c("air"));
-@@ -1201,14 +2396,7 @@
+@@ -1201,14 +2407,7 @@
              }
              else
              {

--- a/patches/minecraft/net/minecraft/pathfinding/WalkNodeProcessor.java.patch
+++ b/patches/minecraft/net/minecraft/pathfinding/WalkNodeProcessor.java.patch
@@ -8,11 +8,13 @@
                      }
                  }
              }
-@@ -430,6 +431,7 @@
+@@ -430,6 +431,9 @@
          IBlockState iblockstate = p_189553_1_.func_180495_p(blockpos);
          Block block = iblockstate.func_177230_c();
          Material material = iblockstate.func_185904_a();
 +        if(block.isBurning(p_189553_1_, blockpos)) return PathNodeType.DAMAGE_FIRE;
++        PathNodeType type = block.getAiPathNodeType();
++        if (type != null) return type;
          return material == Material.field_151579_a ? PathNodeType.OPEN : (block != Blocks.field_150415_aT && block != Blocks.field_180400_cw && block != Blocks.field_150392_bi ? (block == Blocks.field_150480_ab ? PathNodeType.DAMAGE_FIRE : (block == Blocks.field_150434_aF ? PathNodeType.DAMAGE_CACTUS : (block instanceof BlockDoor && material == Material.field_151575_d && !((Boolean)iblockstate.func_177229_b(BlockDoor.field_176519_b)).booleanValue() ? PathNodeType.DOOR_WOOD_CLOSED : (block instanceof BlockDoor && material == Material.field_151573_f && !((Boolean)iblockstate.func_177229_b(BlockDoor.field_176519_b)).booleanValue() ? PathNodeType.DOOR_IRON_CLOSED : (block instanceof BlockDoor && ((Boolean)iblockstate.func_177229_b(BlockDoor.field_176519_b)).booleanValue() ? PathNodeType.DOOR_OPEN : (block instanceof BlockRailBase ? PathNodeType.RAIL : (!(block instanceof BlockFence) && !(block instanceof BlockWall) && (!(block instanceof BlockFenceGate) || ((Boolean)iblockstate.func_177229_b(BlockFenceGate.field_176466_a)).booleanValue()) ? (material == Material.field_151586_h ? PathNodeType.WATER : (material == Material.field_151587_i ? PathNodeType.LAVA : (block.func_176205_b(p_189553_1_, blockpos) ? PathNodeType.OPEN : PathNodeType.BLOCKED))) : PathNodeType.FENCE))))))) : PathNodeType.TRAPDOOR);
      }
  }

--- a/patches/minecraft/net/minecraft/pathfinding/WalkNodeProcessor.java.patch
+++ b/patches/minecraft/net/minecraft/pathfinding/WalkNodeProcessor.java.patch
@@ -8,12 +8,11 @@
                      }
                  }
              }
-@@ -430,6 +431,9 @@
+@@ -430,6 +431,8 @@
          IBlockState iblockstate = p_189553_1_.func_180495_p(blockpos);
          Block block = iblockstate.func_177230_c();
          Material material = iblockstate.func_185904_a();
-+        if(block.isBurning(p_189553_1_, blockpos)) return PathNodeType.DAMAGE_FIRE;
-+        PathNodeType type = block.getAiPathNodeType();
++        PathNodeType type = block.getAiPathNodeType(iblockstate, p_189553_1_,blockpos);
 +        if (type != null) return type;
          return material == Material.field_151579_a ? PathNodeType.OPEN : (block != Blocks.field_150415_aT && block != Blocks.field_180400_cw && block != Blocks.field_150392_bi ? (block == Blocks.field_150480_ab ? PathNodeType.DAMAGE_FIRE : (block == Blocks.field_150434_aF ? PathNodeType.DAMAGE_CACTUS : (block instanceof BlockDoor && material == Material.field_151575_d && !((Boolean)iblockstate.func_177229_b(BlockDoor.field_176519_b)).booleanValue() ? PathNodeType.DOOR_WOOD_CLOSED : (block instanceof BlockDoor && material == Material.field_151573_f && !((Boolean)iblockstate.func_177229_b(BlockDoor.field_176519_b)).booleanValue() ? PathNodeType.DOOR_IRON_CLOSED : (block instanceof BlockDoor && ((Boolean)iblockstate.func_177229_b(BlockDoor.field_176519_b)).booleanValue() ? PathNodeType.DOOR_OPEN : (block instanceof BlockRailBase ? PathNodeType.RAIL : (!(block instanceof BlockFence) && !(block instanceof BlockWall) && (!(block instanceof BlockFenceGate) || ((Boolean)iblockstate.func_177229_b(BlockFenceGate.field_176466_a)).booleanValue()) ? (material == Material.field_151586_h ? PathNodeType.WATER : (material == Material.field_151587_i ? PathNodeType.LAVA : (block.func_176205_b(p_189553_1_, blockpos) ? PathNodeType.OPEN : PathNodeType.BLOCKED))) : PathNodeType.FENCE))))))) : PathNodeType.TRAPDOOR);
      }

--- a/src/test/java/net/minecraftforge/test/BlockAiNodeTypeTest.java
+++ b/src/test/java/net/minecraftforge/test/BlockAiNodeTypeTest.java
@@ -1,0 +1,44 @@
+package net.minecraftforge.test;
+
+import javax.annotation.Nullable;
+
+import net.minecraft.block.Block;
+import net.minecraft.block.material.Material;
+import net.minecraft.block.state.IBlockState;
+import net.minecraft.pathfinding.PathNodeType;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.IBlockAccess;
+import net.minecraftforge.event.RegistryEvent;
+import net.minecraftforge.fml.common.Mod;
+import net.minecraftforge.fml.common.event.FMLPreInitializationEvent;
+import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
+
+@Mod(modid = "ainodetypetest", name="AiNodeTypeTest", version = "1.0")
+@Mod.EventBusSubscriber
+public class BlockAiNodeTypeTest
+{
+
+    private static final Block TEST_BLOCK = new TestBlock();
+
+    @SubscribeEvent
+    public static void register(RegistryEvent.Register<Block> event)
+    {
+        event.getRegistry().register(TEST_BLOCK);
+    }
+
+    private static final class TestBlock extends Block {
+
+        TestBlock() {
+            super(Material.ROCK);
+            setRegistryName("testblock");
+        }
+
+        @Nullable
+        @Override
+        public PathNodeType getAiPathNodeType(IBlockState state, IBlockAccess world, BlockPos pos)
+        {
+            return PathNodeType.DOOR_OPEN;
+        }
+    }
+
+}


### PR DESCRIPTION
Allow blocks to specify their `PathNodeType` for AI pathfinding. This allows e.g. mod-added fences to behave like vanilla fences in respect to Mob AI.