### PR TITLE
Fix ContainerRepair patch for isBookEnchantable

### DIFF
--- a/patches/minecraft/net/minecraft/inventory/ContainerRepair.java.patch
+++ b/patches/minecraft/net/minecraft/inventory/ContainerRepair.java.patch
@@ -41,12 +41,12 @@
                                  {
                                      flag1 = false;
                                      ++i;
-@@ -281,6 +285,8 @@
-                 }
+@@ -304,6 +308,8 @@
+                 itemstack1 = ItemStack.field_190927_a;
              }
  
-+            if (flag && !itemstack1.func_77973_b().isBookEnchantable(itemstack1, itemstack2)) itemstack1 = null;
++            if (flag && !itemstack1.func_77973_b().isBookEnchantable(itemstack1, itemstack2)) itemstack1 = ItemStack.field_190927_a;
 +
-             if (StringUtils.isBlank(this.field_82857_m))
+             if (k == i && k > 0 && this.field_82854_e >= 40)
              {
-                 if (itemstack.func_82837_s())
+                 this.field_82854_e = 39;

--- a/patches/minecraft/net/minecraft/inventory/ContainerRepair.java.patch
+++ b/patches/minecraft/net/minecraft/inventory/ContainerRepair.java.patch
@@ -41,12 +41,11 @@
                                  {
                                      flag1 = false;
                                      ++i;
-@@ -304,6 +308,8 @@
+@@ -304,6 +308,7 @@
                  itemstack1 = ItemStack.field_190927_a;
              }
  
 +            if (flag && !itemstack1.func_77973_b().isBookEnchantable(itemstack1, itemstack2)) itemstack1 = ItemStack.field_190927_a;
-+
              if (k == i && k > 0 && this.field_82854_e >= 40)
              {
                  this.field_82854_e = 39;


### PR DESCRIPTION
I have found this issue in as far back as 1.9.4, making `isBookEnchantable` basically useless (as reported in https://github.com/MinecraftForge/MinecraftForge/issues/3548).

I have moved the forge check down to where vanilla performs a similar check for "nulling out" the output.