### PR TITLE
Added a cloud renderer that uploads geometry to the GPU.

### DIFF
--- a/patches/minecraft/net/minecraft/client/Minecraft.java.patch
+++ b/patches/minecraft/net/minecraft/client/Minecraft.java.patch
@@ -165,7 +165,20 @@
          }
  
          this.field_71424_I.func_76319_b();
-@@ -1397,9 +1417,9 @@
+@@ -1069,6 +1089,12 @@
+             this.field_71424_I.field_76327_a = true;
+             this.func_71366_a(i1);
+         }
++        else if (net.minecraftforge.client.ForgeHooksClient.onProfilingEnable().isEnabled())
++        {   // Separated to prevent display showing unless it's enabled by the user.
++            if (!this.field_71424_I.field_76327_a)
++                this.field_71424_I.func_76317_a();
++            this.field_71424_I.field_76327_a = true;
++        }
+         else
+         {
+             this.field_71424_I.field_76327_a = false;
+@@ -1397,9 +1423,9 @@
              {
                  BlockPos blockpos = this.field_71476_x.func_178782_a();
  
@@ -177,7 +190,7 @@
                      this.field_71439_g.func_184609_a(EnumHand.MAIN_HAND);
                  }
              }
-@@ -1433,7 +1453,7 @@
+@@ -1433,7 +1459,7 @@
                      case BLOCK:
                          BlockPos blockpos = this.field_71476_x.func_178782_a();
  
@@ -186,7 +199,7 @@
                          {
                              this.field_71442_b.func_180511_b(blockpos, this.field_71476_x.field_178784_b);
                              break;
-@@ -1447,6 +1467,7 @@
+@@ -1447,6 +1473,7 @@
                          }
  
                          this.field_71439_g.func_184821_cY();
@@ -194,7 +207,7 @@
                  }
  
                  this.field_71439_g.func_184609_a(EnumHand.MAIN_HAND);
-@@ -1512,6 +1533,7 @@
+@@ -1512,6 +1539,7 @@
                          }
                      }
  
@@ -202,7 +215,7 @@
                      if (!itemstack.func_190926_b() && this.field_71442_b.func_187101_a(this.field_71439_g, this.field_71441_e, enumhand) == EnumActionResult.SUCCESS)
                      {
                          this.field_71460_t.field_78516_c.func_187460_a(enumhand);
-@@ -1618,6 +1640,8 @@
+@@ -1618,6 +1646,8 @@
              --this.field_71467_ac;
          }
  
@@ -211,7 +224,7 @@
          this.field_71424_I.func_76320_a("gui");
  
          if (!this.field_71445_n)
-@@ -1729,6 +1753,7 @@
+@@ -1729,6 +1759,7 @@
                      this.field_71457_ai = 0;
                      this.field_71441_e.func_72897_h(this.field_71439_g);
                  }
@@ -219,7 +232,7 @@
              }
  
              this.field_71424_I.func_76318_c("gameRenderer");
-@@ -1816,6 +1841,7 @@
+@@ -1816,6 +1847,7 @@
              this.field_71453_ak.func_74428_b();
          }
  
@@ -227,7 +240,7 @@
          this.field_71424_I.func_76319_b();
          this.field_71423_H = func_71386_F();
      }
-@@ -1922,6 +1948,7 @@
+@@ -1922,6 +1954,7 @@
                      }
                  }
              }
@@ -235,7 +248,7 @@
          }
  
          this.func_184117_aA();
-@@ -2168,6 +2195,8 @@
+@@ -2168,6 +2201,8 @@
      {
          while (Mouse.next())
          {
@@ -244,7 +257,7 @@
              int i = Mouse.getEventButton();
              KeyBinding.func_74510_a(i - 100, Mouse.getEventButtonState());
  
-@@ -2233,6 +2262,7 @@
+@@ -2233,6 +2268,7 @@
  
      public void func_71371_a(String p_71371_1_, String p_71371_2_, @Nullable WorldSettings p_71371_3_)
      {
@@ -252,7 +265,7 @@
          this.func_71403_a((WorldClient)null);
          System.gc();
          ISaveHandler isavehandler = this.field_71469_aa.func_75804_a(p_71371_1_, false);
-@@ -2275,6 +2305,12 @@
+@@ -2275,6 +2311,12 @@
  
          while (!this.field_71437_Z.func_71200_ad())
          {
@@ -265,7 +278,7 @@
              String s = this.field_71437_Z.func_71195_b_();
  
              if (s != null)
-@@ -2300,8 +2336,14 @@
+@@ -2300,8 +2342,14 @@
          SocketAddress socketaddress = this.field_71437_Z.func_147137_ag().func_151270_a();
          NetworkManager networkmanager = NetworkManager.func_150722_a(socketaddress);
          networkmanager.func_150719_a(new NetHandlerLoginClient(networkmanager, this, (GuiScreen)null));
@@ -282,7 +295,7 @@
          this.field_71453_ak = networkmanager;
      }
  
-@@ -2312,6 +2354,8 @@
+@@ -2312,6 +2360,8 @@
  
      public void func_71353_a(@Nullable WorldClient p_71353_1_, String p_71353_2_)
      {
@@ -291,7 +304,7 @@
          if (p_71353_1_ == null)
          {
              NetHandlerPlayClient nethandlerplayclient = this.func_147114_u();
-@@ -2324,6 +2368,18 @@
+@@ -2324,6 +2374,18 @@
              if (this.field_71437_Z != null && this.field_71437_Z.func_175578_N())
              {
                  this.field_71437_Z.func_71263_m();
@@ -310,7 +323,7 @@
              }
  
              this.field_71437_Z = null;
-@@ -2347,6 +2403,7 @@
+@@ -2347,6 +2409,7 @@
              this.field_71456_v.func_181029_i();
              this.func_71351_a((ServerData)null);
              this.field_71455_al = false;
@@ -318,7 +331,7 @@
          }
  
          this.field_147127_av.func_147690_c();
-@@ -2464,159 +2521,8 @@
+@@ -2464,159 +2527,8 @@
      {
          if (this.field_71476_x != null && this.field_71476_x.field_72313_a != RayTraceResult.Type.MISS)
          {
@@ -480,7 +493,7 @@
          }
      }
  
-@@ -2919,18 +2825,8 @@
+@@ -2919,18 +2831,8 @@
  
      public static int func_71369_N()
      {
@@ -501,7 +514,7 @@
      }
  
      public boolean func_70002_Q()
-@@ -3069,15 +2965,16 @@
+@@ -3069,15 +2971,16 @@
              {
                  if (Keyboard.getEventKeyState())
                  {
@@ -520,7 +533,7 @@
              }
          }
      }
-@@ -3197,6 +3094,12 @@
+@@ -3197,6 +3100,12 @@
          return this.field_184127_aH;
      }
  

--- a/patches/minecraft/net/minecraft/client/renderer/RenderGlobal.java.patch
+++ b/patches/minecraft/net/minecraft/client/renderer/RenderGlobal.java.patch
@@ -98,7 +98,7 @@
          if (this.field_72777_q.field_71441_e.field_73011_w.func_186058_p().func_186068_a() == 1)
          {
              this.func_180448_r();
-@@ -1437,6 +1459,12 @@
+@@ -1437,6 +1459,13 @@
  
      public void func_180447_b(float p_180447_1_, int p_180447_2_)
      {
@@ -108,10 +108,11 @@
 +            renderer.render(p_180447_1_, this.field_72777_q.field_71441_e, field_72777_q);
 +            return;
 +        }
++        if (net.minecraftforge.client.CloudRenderer.instance().render(this.field_72773_u, p_180447_1_)) return;
          if (this.field_72777_q.field_71441_e.field_73011_w.func_76569_d())
          {
              if (this.field_72777_q.field_71474_y.func_181147_e() == 2)
-@@ -1864,8 +1892,11 @@
+@@ -1864,8 +1893,11 @@
                  double d4 = (double)blockpos.func_177956_o() - d1;
                  double d5 = (double)blockpos.func_177952_p() - d2;
                  Block block = this.field_72769_h.func_180495_p(blockpos).func_177230_c();
@@ -124,7 +125,7 @@
                  {
                      if (d3 * d3 + d4 * d4 + d5 * d5 > 1024.0D)
                      {
-@@ -2333,7 +2364,7 @@
+@@ -2333,7 +2365,7 @@
  
                  if (block.func_176223_P().func_185904_a() != Material.field_151579_a)
                  {

--- a/patches/minecraft/net/minecraft/profiler/Profiler.java.patch
+++ b/patches/minecraft/net/minecraft/profiler/Profiler.java.patch
@@ -1,0 +1,19 @@
+--- ../src-base/minecraft/net/minecraft/profiler/Profiler.java
++++ ../src-work/minecraft/net/minecraft/profiler/Profiler.java
+@@ -170,4 +170,16 @@
+                 return (this.field_76331_c.hashCode() & 11184810) + 4473924;
+             }
+         }
++
++    // Begin Forge
++    /**
++     * @param section The profiling section.
++     * @return The total amount of time spent in the section in nanoseconds.
++     */
++    public long getTotalTime(String section)
++    {
++        if (!field_76324_e.containsKey(section))
++            return -1L;
++        return field_76324_e.get(section);
++    }
+ }

--- a/src/main/java/net/minecraftforge/client/CloudRenderer.java
+++ b/src/main/java/net/minecraftforge/client/CloudRenderer.java
@@ -1,0 +1,477 @@
+/*
+ * Minecraft Forge
+ * Copyright (c) 2016.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation version 2.1
+ * of the License.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+package net.minecraftforge.client;
+
+import java.nio.ByteBuffer;
+
+import org.lwjgl.opengl.GL11;
+
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.renderer.EntityRenderer;
+import net.minecraft.client.renderer.GLAllocation;
+import net.minecraft.client.renderer.GlStateManager;
+import net.minecraft.client.renderer.OpenGlHelper;
+import net.minecraft.client.renderer.Tessellator;
+import net.minecraft.client.renderer.VertexBuffer;
+import net.minecraft.client.renderer.texture.DynamicTexture;
+import net.minecraft.client.renderer.vertex.DefaultVertexFormats;
+import net.minecraft.client.renderer.vertex.VertexFormat;
+import net.minecraft.client.resources.IReloadableResourceManager;
+import net.minecraft.client.resources.IResourceManager;
+import net.minecraft.client.resources.IResourceManagerReloadListener;
+import net.minecraft.entity.Entity;
+import net.minecraft.util.ResourceLocation;
+import net.minecraft.util.math.Vec3d;
+import net.minecraftforge.common.ForgeModContainer;
+import net.minecraftforge.common.MinecraftForge;
+import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
+import net.minecraftforge.fml.common.gameevent.TickEvent.ClientTickEvent;
+import net.minecraftforge.fml.common.gameevent.TickEvent.Phase;
+
+public class CloudRenderer implements IResourceManagerReloadListener
+{
+    private static CloudRenderer instance;
+
+    public static void init()
+    {
+        instance = new CloudRenderer();
+    }
+
+    public static CloudRenderer instance()
+    {
+        return instance;
+    }
+
+    // Shared constants.
+    private static final float PX_SIZE = 1 / 256F;
+
+    // Building constants.
+    private static final VertexFormat FORMAT = DefaultVertexFormats.POSITION_TEX_COLOR;
+    private static final int HEIGHT = 4;
+    private static final int FULL_WIDTH = 64;
+    private static final int START = -FULL_WIDTH / 2;
+    private static final int END = FULL_WIDTH / 2;
+    private static final int SECTION_WIDTH = 8;
+    private static final float INSET = 0.001F;
+    private static final float ALPHA = 0.8F;
+
+    private final Minecraft mc = Minecraft.getMinecraft();
+    private final ResourceLocation texture = new ResourceLocation("textures/environment/clouds.png");
+
+    private int displayList = -1;
+    private net.minecraft.client.renderer.vertex.VertexBuffer vbo;
+    private boolean enabled = false;
+    private int cloudMode = -1;
+
+    private DynamicTexture COLOR_TEX = null;
+
+    private int texW;
+    private int texH;
+
+    public CloudRenderer()
+    {
+        ((IReloadableResourceManager) mc.getResourceManager()).registerReloadListener(this);
+
+        MinecraftForge.EVENT_BUS.register(this);
+    }
+
+    private int getScale()
+    {
+        return cloudMode == 2 ? 12 : 8;
+    }
+
+    private void vertices(VertexBuffer buffer)
+    {
+        boolean fancy = cloudMode == 2;    // Defines whether to hide all but the bottom.
+
+        float scale = getScale();
+        float CULL_DIST = 2 * scale;
+
+        float bCol = fancy ? 0.7F : 1F;
+
+        buffer.begin(GL11.GL_QUADS, FORMAT);
+
+        // Create 1200 quads (with SECTION_WIDTH 8). SECTION_WIDTH defines width of slices and vertical faces.
+        // With the minimum number (built above), the clouds nearest the player will still be fully fogged.
+        float sectStart = START * scale;
+        float sectEnd = END * scale;
+        float sectStep = SECTION_WIDTH * scale;
+        float sectPx = PX_SIZE / scale;
+
+        float sectX0 = sectStart;
+        float sectX1;
+
+        for (sectX1 = sectStart + sectStep; sectX1 <= sectEnd; sectX1 += sectStep)
+        {
+            if (Float.isNaN(sectX0))
+            {
+                sectX0 = sectX1;
+                continue;
+            }
+
+            float sectZ0 = sectStart;
+            float sectZ1;
+
+            for (sectZ1 = sectStart + sectStep; sectZ1 <= sectEnd; sectZ1 += sectStep)
+            {
+                float u0 = sectX0 * sectPx;
+                float u1 = sectX1 * sectPx;
+                float v0 = sectZ0 * sectPx;
+                float v1 = sectZ1 * sectPx;
+
+                // Bottom
+                buffer.pos(sectX0, 0, sectZ0).tex(u0, v0).color(bCol, bCol, bCol, ALPHA).endVertex();
+                buffer.pos(sectX1, 0, sectZ0).tex(u1, v0).color(bCol, bCol, bCol, ALPHA).endVertex();
+                buffer.pos(sectX1, 0, sectZ1).tex(u1, v1).color(bCol, bCol, bCol, ALPHA).endVertex();
+                buffer.pos(sectX0, 0, sectZ1).tex(u0, v1).color(bCol, bCol, bCol, ALPHA).endVertex();
+
+                if (fancy)
+                {
+                    // Top
+                    buffer.pos(sectX0, HEIGHT, sectZ0).tex(u0, v0).color(1, 1, 1, ALPHA).endVertex();
+                    buffer.pos(sectX0, HEIGHT, sectZ1).tex(u0, v1).color(1, 1, 1, ALPHA).endVertex();
+                    buffer.pos(sectX1, HEIGHT, sectZ1).tex(u1, v1).color(1, 1, 1, ALPHA).endVertex();
+                    buffer.pos(sectX1, HEIGHT, sectZ0).tex(u1, v0).color(1, 1, 1, ALPHA).endVertex();
+
+                    float slice;
+                    float sliceCoord0;
+                    float sliceCoord1;
+
+                    for (slice = sectX0; slice < sectX1;)
+                    {
+                        sliceCoord0 = slice * sectPx;
+                        sliceCoord1 = sliceCoord0 + PX_SIZE;
+
+                        // X sides
+                        if (slice > -CULL_DIST)
+                        {
+                            slice += INSET;
+                            buffer.pos(slice, 0,      sectZ1).tex(sliceCoord0, v1).color(0.9F, 0.9F, 0.9F, ALPHA).endVertex();
+                            buffer.pos(slice, HEIGHT, sectZ1).tex(sliceCoord1, v1).color(0.9F, 0.9F, 0.9F, ALPHA).endVertex();
+                            buffer.pos(slice, HEIGHT, sectZ0).tex(sliceCoord1, v0).color(0.9F, 0.9F, 0.9F, ALPHA).endVertex();
+                            buffer.pos(slice, 0,      sectZ0).tex(sliceCoord0, v0).color(0.9F, 0.9F, 0.9F, ALPHA).endVertex();
+                            slice -= INSET;
+                        }
+
+                        slice += scale;
+
+                        if (slice <= CULL_DIST)
+                        {
+                            slice -= INSET;
+                            buffer.pos(slice, 0,      sectZ0).tex(sliceCoord0, v0).color(0.9F, 0.9F, 0.9F, ALPHA).endVertex();
+                            buffer.pos(slice, HEIGHT, sectZ0).tex(sliceCoord1, v0).color(0.9F, 0.9F, 0.9F, ALPHA).endVertex();
+                            buffer.pos(slice, HEIGHT, sectZ1).tex(sliceCoord1, v1).color(0.9F, 0.9F, 0.9F, ALPHA).endVertex();
+                            buffer.pos(slice, 0,      sectZ1).tex(sliceCoord0, v1).color(0.9F, 0.9F, 0.9F, ALPHA).endVertex();
+                            slice += INSET;
+                        }
+                    }
+
+                    for (slice = sectZ0; slice < sectZ1;)
+                    {
+                        sliceCoord0 = slice * sectPx;
+                        sliceCoord1 = sliceCoord0 + PX_SIZE;
+
+                        // Z sides
+                        if (slice > -CULL_DIST)
+                        {
+                            slice += INSET;
+                            buffer.pos(sectX0, 0,      slice).tex(u0, sliceCoord0).color(0.8F, 0.8F, 0.8F, ALPHA).endVertex();
+                            buffer.pos(sectX0, HEIGHT, slice).tex(u0, sliceCoord1).color(0.8F, 0.8F, 0.8F, ALPHA).endVertex();
+                            buffer.pos(sectX1, HEIGHT, slice).tex(u1, sliceCoord1).color(0.8F, 0.8F, 0.8F, ALPHA).endVertex();
+                            buffer.pos(sectX1, 0,      slice).tex(u1, sliceCoord0).color(0.8F, 0.8F, 0.8F, ALPHA).endVertex();
+                            slice -= INSET;
+                        }
+
+                        slice += scale;
+
+                        if (slice <= CULL_DIST)
+                        {
+                            slice -= INSET;
+                            buffer.pos(sectX1, 0,      slice).tex(u1, sliceCoord0).color(0.8F, 0.8F, 0.8F, ALPHA).endVertex();
+                            buffer.pos(sectX1, HEIGHT, slice).tex(u1, sliceCoord1).color(0.8F, 0.8F, 0.8F, ALPHA).endVertex();
+                            buffer.pos(sectX0, HEIGHT, slice).tex(u0, sliceCoord1).color(0.8F, 0.8F, 0.8F, ALPHA).endVertex();
+                            buffer.pos(sectX0, 0,      slice).tex(u0, sliceCoord0).color(0.8F, 0.8F, 0.8F, ALPHA).endVertex();
+                            slice += INSET;
+                        }
+                    }
+                }
+
+                sectZ0 = sectZ1;
+            }
+
+            sectX0 = sectX1;
+        }
+    }
+
+    private void dispose()
+    {
+        if (vbo != null)
+        {
+            vbo.deleteGlBuffers();
+            vbo = null;
+        }
+        if (displayList >= 0)
+        {
+            GLAllocation.deleteDisplayLists(displayList);
+            displayList = -1;
+        }
+    }
+
+    private void build()
+    {
+        Tessellator tess = Tessellator.getInstance();
+        VertexBuffer buffer = tess.getBuffer();
+
+        if (OpenGlHelper.useVbo())
+            vbo = new net.minecraft.client.renderer.vertex.VertexBuffer(FORMAT);
+        else
+            GlStateManager.glNewList(displayList = GLAllocation.generateDisplayLists(1), GL11.GL_COMPILE);
+
+        vertices(buffer);
+
+        if (OpenGlHelper.useVbo())
+        {
+            buffer.finishDrawing();
+            buffer.reset();
+            vbo.bufferData(buffer.getByteBuffer());
+        }
+        else
+        {
+            tess.draw();
+            GlStateManager.glEndList();
+        }
+    }
+
+    private int fullCoord(double coord, int scale)
+    {   // Corrects misalignment of UV offset when on negative coords.
+        return ((int) coord / scale) - (coord < 0 ? 1 : 0);
+    }
+
+    @SubscribeEvent
+    public void checkSettings(ClientTickEvent event)
+    {
+        if (event.phase == Phase.END)
+        {
+            boolean newEnabled = ForgeModContainer.forgeCloudsEnabled
+                    && mc.gameSettings.shouldRenderClouds() != 0
+                    && mc.world != null
+                    && mc.world.provider.isSurfaceWorld();
+
+            if (newEnabled != enabled)
+            {
+                if (newEnabled)
+                    build();
+                else
+                    dispose();
+                enabled = newEnabled;
+            }
+
+            if (enabled)
+            {
+                if (mc.gameSettings.shouldRenderClouds() != cloudMode)
+                {
+                    cloudMode = mc.gameSettings.shouldRenderClouds();
+                    dispose();
+                    build();
+                }
+
+                if (OpenGlHelper.useVbo() ? vbo == null : displayList < 0)
+                {
+                    dispose();
+                    build();
+                }
+            }
+        }
+    }
+
+    public boolean render(int cloudTicks, float partialTicks)
+    {
+        if (OpenGlHelper.useVbo() ? vbo == null : displayList < 0)
+            return false;
+
+        Entity entity = mc.getRenderViewEntity();
+
+        double totalOffset = cloudTicks + partialTicks;
+
+        double x = entity.prevPosX + (entity.posX - entity.prevPosX) * partialTicks
+                + totalOffset * 0.03;
+        double y = mc.world.provider.getCloudHeight()
+                - (entity.lastTickPosY + (entity.posY - entity.lastTickPosY) * partialTicks)
+                + 0.33;
+        double z = entity.prevPosZ + (entity.posZ - entity.prevPosZ) * partialTicks;
+
+        if (cloudMode == 2)
+            z += 0.33 * getScale();
+
+        int scale = getScale();
+
+        // Integer UVs to translate the texture matrix by.
+        int offU = fullCoord(x, scale);
+        int offV = fullCoord(z, scale);
+
+        GlStateManager.pushMatrix();
+
+        // Translate by the remainder after the UV offset.
+        GlStateManager.translate((offU * scale) - x, y, (offV * scale) - z);
+
+        // Modulo to prevent texture samples becoming inaccurate at extreme offsets.
+        offU = offU % texW;
+        offV = offV % texH;
+
+        // Translate the texture.
+        GlStateManager.matrixMode(GL11.GL_TEXTURE);
+        GlStateManager.translate(offU * PX_SIZE, offV * PX_SIZE, 0);
+        GlStateManager.matrixMode(GL11.GL_MODELVIEW);
+
+        GlStateManager.disableCull();
+
+        GlStateManager.enableBlend();
+        GlStateManager.tryBlendFuncSeparate(
+                GlStateManager.SourceFactor.SRC_ALPHA, GlStateManager.DestFactor.ONE_MINUS_SRC_ALPHA,
+                GlStateManager.SourceFactor.ONE, GlStateManager.DestFactor.ZERO);
+
+        // Color multiplier.
+        Vec3d color = mc.world.getCloudColour(partialTicks);
+        float r = (float) color.xCoord;
+        float g = (float) color.yCoord;
+        float b = (float) color.zCoord;
+
+        if (mc.gameSettings.anaglyph)
+        {
+            float tempR = r * 0.3F + g * 0.59F + b * 0.11F;
+            float tempG = r * 0.3F + g * 0.7F;
+            float tempB = r * 0.3F + b * 0.7F;
+            r = tempR;
+            g = tempG;
+            b = tempB;
+        }
+
+        if (COLOR_TEX == null)
+            COLOR_TEX = new DynamicTexture(1, 1);
+
+        // Apply a color multiplier through a texture upload if shaders aren't supported.
+        COLOR_TEX.getTextureData()[0] = 255 << 24
+                | ((int) (r * 255)) << 16
+                | ((int) (g * 255)) << 8
+                | (int) (b * 255);
+        COLOR_TEX.updateDynamicTexture();
+
+        GlStateManager.setActiveTexture(OpenGlHelper.lightmapTexUnit);
+        GlStateManager.bindTexture(COLOR_TEX.getGlTextureId());
+        GlStateManager.enableTexture2D();
+
+        // Bind the clouds texture last so the shader's sampler2D is correct.
+        GlStateManager.setActiveTexture(OpenGlHelper.defaultTexUnit);
+        mc.renderEngine.bindTexture(texture);
+
+        ByteBuffer buffer = Tessellator.getInstance().getBuffer().getByteBuffer();
+
+        // Set up pointers for the display list/VBO.
+        if (OpenGlHelper.useVbo())
+        {
+            vbo.bindBuffer();
+
+            int stride = FORMAT.getNextOffset();
+            GlStateManager.glVertexPointer(3, GL11.GL_FLOAT, stride, 0);
+            GlStateManager.glEnableClientState(GL11.GL_VERTEX_ARRAY);
+            GlStateManager.glTexCoordPointer(2, GL11.GL_FLOAT, stride, 12);
+            GlStateManager.glEnableClientState(GL11.GL_TEXTURE_COORD_ARRAY);
+            GlStateManager.glColorPointer(4, GL11.GL_UNSIGNED_BYTE, stride, 20);
+            GlStateManager.glEnableClientState(GL11.GL_COLOR_ARRAY);
+        }
+        else
+        {
+            buffer.limit(FORMAT.getNextOffset());
+            for (int i = 0; i < FORMAT.getElementCount(); i++)
+                FORMAT.getElements().get(i).getUsage().preDraw(FORMAT, i, FORMAT.getNextOffset(), buffer);
+            buffer.position(0);
+        }
+
+        // Depth pass to prevent insides rendering from the outside.
+        GlStateManager.colorMask(false, false, false, false);
+        if (OpenGlHelper.useVbo())
+            vbo.drawArrays(GL11.GL_QUADS);
+        else
+            GlStateManager.callList(displayList);
+
+        // Full render.
+        if (!mc.gameSettings.anaglyph)
+        {
+            GlStateManager.colorMask(true, true, true, true);
+        }
+        else
+        {
+            switch (EntityRenderer.anaglyphField)
+            {
+            case 0:
+                GlStateManager.colorMask(false, true, true, true);
+                break;
+            case 1:
+                GlStateManager.colorMask(true, false, false, true);
+                break;
+            }
+        }
+
+        if (OpenGlHelper.useVbo())
+        {
+            vbo.drawArrays(GL11.GL_QUADS);
+            vbo.unbindBuffer(); // Unbind buffer and disable pointers.
+        }
+        else
+        {
+            GlStateManager.callList(displayList);
+        }
+
+        buffer.limit(0);
+        for (int i = 0; i < FORMAT.getElementCount(); i++)
+            FORMAT.getElements().get(i).getUsage().postDraw(FORMAT, i, FORMAT.getNextOffset(), buffer);
+        buffer.position(0);
+
+        // Disable our coloring.
+        GlStateManager.setActiveTexture(OpenGlHelper.lightmapTexUnit);
+        GlStateManager.disableTexture2D();
+        GlStateManager.setActiveTexture(OpenGlHelper.defaultTexUnit);
+
+        // Reset texture matrix.
+        GlStateManager.matrixMode(GL11.GL_TEXTURE);
+        GlStateManager.loadIdentity();
+        GlStateManager.matrixMode(GL11.GL_MODELVIEW);
+
+        GlStateManager.disableBlend();
+        GlStateManager.enableCull();
+
+        GlStateManager.popMatrix();
+
+        return true;
+    }
+
+    private void reloadTextures()
+    {
+        mc.renderEngine.bindTexture(texture);
+        texW = GlStateManager.glGetTexLevelParameteri(GL11.GL_TEXTURE_2D, 0, GL11.GL_TEXTURE_WIDTH);
+        texH = GlStateManager.glGetTexLevelParameteri(GL11.GL_TEXTURE_2D, 0, GL11.GL_TEXTURE_HEIGHT);
+    }
+
+    @Override
+    public void onResourceManagerReload(IResourceManager resourceManager)
+    {
+        reloadTextures();
+    }
+}

--- a/src/main/java/net/minecraftforge/client/ForgeHooksClient.java
+++ b/src/main/java/net/minecraftforge/client/ForgeHooksClient.java
@@ -97,6 +97,7 @@ import net.minecraftforge.client.event.FOVUpdateEvent;
 import net.minecraftforge.client.event.GuiScreenEvent;
 import net.minecraftforge.client.event.ModelBakeEvent;
 import net.minecraftforge.client.event.MouseEvent;
+import net.minecraftforge.client.event.ProfilerEnableEvent;
 import net.minecraftforge.client.event.RenderGameOverlayEvent;
 import net.minecraftforge.client.event.RenderHandEvent;
 import net.minecraftforge.client.event.RenderSpecificHandEvent;
@@ -746,6 +747,13 @@ public class ForgeHooksClient
     public static ScreenshotEvent onScreenshot(BufferedImage image, File screenshotFile)
     {
         ScreenshotEvent event = new ScreenshotEvent(image, screenshotFile);
+        MinecraftForge.EVENT_BUS.post(event);
+        return event;
+    }
+
+    public static ProfilerEnableEvent onProfilingEnable()
+    {
+        ProfilerEnableEvent event = new ProfilerEnableEvent();
         MinecraftForge.EVENT_BUS.post(event);
         return event;
     }

--- a/src/main/java/net/minecraftforge/client/event/ProfilerEnableEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/ProfilerEnableEvent.java
@@ -1,0 +1,42 @@
+/*
+ * Minecraft Forge
+ * Copyright (c) 2016.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation version 2.1
+ * of the License.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+package net.minecraftforge.client.event;
+
+import net.minecraftforge.fml.common.eventhandler.Event;
+
+/**
+ * ProfilerEnableEvent is fired each frame when the profiler is enabled or disabled.
+ * 
+ * When using this to force enable profiling, the profiler chart will not show unless
+ * the player explicitly enables it in-game.
+ */
+public class ProfilerEnableEvent extends Event {
+    private boolean enable = false;
+
+    public boolean isEnabled()
+    { 
+        return enable;
+    }
+
+    public void setEnabled()
+    {
+        enable = true;
+    }
+}

--- a/src/main/resources/assets/forge/lang/en_US.lang
+++ b/src/main/resources/assets/forge/lang/en_US.lang
@@ -47,6 +47,7 @@ forge.configgui.zombieBaseSummonChance=Zombie Summon Chance
 forge.configgui.stencilbits=Enable GL Stencil Bits
 forge.configgui.replaceBuckets=Use Forge's bucket model
 forge.configgui.forgeLightPipelineEnabled=Forge Light Pipeline Enabled
+forge.configgui.forgeCloudsEnabled=Use Forge's cloud renderer
 forge.configgui.java8Reminder=Java 8 Reminder timestamp
 forge.configgui.disableStairSlabCulling=Disable Stair/Slab culling.
 forge.configgui.disableStairSlabCulling.tooltip=Enable this if you see through blocks touching stairs/slabs with your resource pack.

--- a/src/test/java/net/minecraftforge/test/FastCloudsPerfTest.java
+++ b/src/test/java/net/minecraftforge/test/FastCloudsPerfTest.java
@@ -1,0 +1,104 @@
+package net.minecraftforge.test;
+
+import net.minecraft.client.Minecraft;
+import net.minecraftforge.client.event.ProfilerEnableEvent;
+import net.minecraftforge.common.ForgeModContainer;
+import net.minecraftforge.common.MinecraftForge;
+import net.minecraftforge.fml.common.FMLLog;
+import net.minecraftforge.fml.common.Mod;
+import net.minecraftforge.fml.common.Mod.EventHandler;
+import net.minecraftforge.fml.common.event.FMLInitializationEvent;
+import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
+import net.minecraftforge.fml.common.gameevent.TickEvent;
+
+@Mod(modid = "fastcloudsperftest", name = "Fast Clouds Performance Test", version = "0.0.0", clientSideOnly = true)
+public class FastCloudsPerfTest
+{
+    private static final boolean ENABLED = false;
+
+    @EventHandler
+    public void init(FMLInitializationEvent event)
+    {
+        if (ENABLED)
+        {
+            MinecraftForge.EVENT_BUS.register(this);
+        }
+    }
+
+    private boolean originalSetting;
+    private int timer = 0;
+    private static final int TESTS_START = 2;
+    private static final int TESTS_END = 6;
+    private int tests = 0;
+    private int frames = 0;
+    private boolean nextTest = false;
+
+    @SubscribeEvent
+    public void onProfilingEnable(ProfilerEnableEvent event)
+    {
+        if (tests >= TESTS_START && tests < TESTS_END)
+        {
+            event.setEnabled();
+        }
+
+        if (nextTest)
+        {
+            nextTest = false;
+            frames = 0;
+            Minecraft.getMinecraft().mcProfiler.clearProfiling();
+
+            ForgeModContainer.forgeCloudsEnabled = !ForgeModContainer.forgeCloudsEnabled;
+            timer = 200;
+            tests++;
+        }
+    }
+
+    @SubscribeEvent
+    public void onTick(TickEvent event)
+    {
+        if (event.phase == TickEvent.Phase.END && Minecraft.getMinecraft().world != null && !nextTest)
+        {
+            switch (event.type)
+            {
+            case RENDER:
+                if (tests < TESTS_END)
+                    frames++;
+                break;
+            case CLIENT:
+                if (--timer < 0 && tests < TESTS_END)
+                {
+                    // Let the renderer settle first
+                    if (tests >= TESTS_START && frames > 0)
+                    {
+                        long time = Minecraft.getMinecraft().mcProfiler.getTotalTime("root.gameRenderer.level.clouds");
+
+                        if (time > 0)
+                        {
+                            FMLLog.info(
+                                    (ForgeModContainer.forgeCloudsEnabled ? "Forge clouds took " : "Vanilla clouds took ")
+                                    + (time / 1e+6F / frames)
+                                    + "ms per frame average");
+                        }
+                    }
+                    else if (tests == 0)
+                    {   // Save the original setting to revert after we're finished.
+                        originalSetting = ForgeModContainer.forgeCloudsEnabled;
+                    }
+
+                    // Reset our profiling for the inverted test
+                    nextTest = true;
+                }
+                else if (tests == TESTS_END)
+                {
+                    ForgeModContainer.forgeCloudsEnabled = originalSetting;
+                    FMLLog.info("Switched back to %s",
+                            ForgeModContainer.forgeCloudsEnabled ? "Forge clouds" : "vanilla clouds");
+                    tests++;
+                }
+                break;
+            default:
+                break;
+            }
+        }
+    }
+}


### PR DESCRIPTION
#3188 updated to 1.11.x. All comments on that PR have been addressed.

Code in CloudRenderer is cleaned up a bit to rebuild the VBOs/display lists as little as possible, in a client tick handler rather than the renderer.

To avoid adding unnecessary profiling lines EntityRenderer, ProfilerEnableEvent was added to temporarily force on the profiler to time the rendering of the clouds. This can also be reused for other profiling test mods in the future, if any such tests are needed.