### PR TITLE
Small cleanup for PlayerInteractEvent

### DIFF
--- a/patches/minecraft/net/minecraft/client/Minecraft.java.patch
+++ b/patches/minecraft/net/minecraft/client/Minecraft.java.patch
@@ -190,7 +190,7 @@
                          }
  
                          this.field_71439_g.func_184821_cY();
-+                        net.minecraftforge.common.ForgeHooks.onEmptyLeftClick(this.field_71439_g, this.field_71439_g.func_184614_ca());
++                        net.minecraftforge.common.ForgeHooks.onEmptyLeftClick(this.field_71439_g);
                  }
  
                  this.field_71439_g.func_184609_a(EnumHand.MAIN_HAND);

--- a/src/main/java/net/minecraftforge/common/ForgeHooks.java
+++ b/src/main/java/net/minecraftforge/common/ForgeHooks.java
@@ -1067,6 +1067,14 @@ public class ForgeHooks
         MinecraftForge.EVENT_BUS.post(new PlayerInteractEvent.LeftClickEmpty(player));
     }
 
+    // TODO: remove
+    /** @deprecated use {@link ForgeHooks#onEmptyLeftClick(EntityPlayer)} */
+    @Deprecated
+    public static void onEmptyLeftClick(EntityPlayer player, @Nonnull ItemStack stack)
+    {
+        onEmptyLeftClick(player);
+    }
+
     private static ThreadLocal<Deque<LootTableContext>> lootContext = new ThreadLocal<Deque<LootTableContext>>();
     private static LootTableContext getLootTableContext()
     {

--- a/src/main/java/net/minecraftforge/common/ForgeHooks.java
+++ b/src/main/java/net/minecraftforge/common/ForgeHooks.java
@@ -1062,9 +1062,9 @@ public class ForgeHooks
         MinecraftForge.EVENT_BUS.post(new PlayerInteractEvent.RightClickEmpty(player, hand));
     }
 
-    public static void onEmptyLeftClick(EntityPlayer player, @Nonnull ItemStack stack)
+    public static void onEmptyLeftClick(EntityPlayer player)
     {
-        MinecraftForge.EVENT_BUS.post(new PlayerInteractEvent.LeftClickEmpty(player, stack));
+        MinecraftForge.EVENT_BUS.post(new PlayerInteractEvent.LeftClickEmpty(player));
     }
 
     private static ThreadLocal<Deque<LootTableContext>> lootContext = new ThreadLocal<Deque<LootTableContext>>();

--- a/src/main/java/net/minecraftforge/event/entity/player/PlayerInteractEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/player/PlayerInteractEvent.java
@@ -20,16 +20,13 @@
 package net.minecraftforge.event.entity.player;
 
 import com.google.common.base.Preconditions;
-import net.minecraft.block.state.IBlockState;
 import net.minecraft.entity.Entity;
-import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.EnumFacing;
 import net.minecraft.util.EnumHand;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.Vec3d;
-import net.minecraft.world.IBlockAccess;
 import net.minecraft.world.World;
 import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.fml.common.eventhandler.Cancelable;
@@ -313,7 +310,7 @@ public class PlayerInteractEvent extends PlayerEvent
      */
     public static class LeftClickEmpty extends PlayerInteractEvent
     {
-        public LeftClickEmpty(EntityPlayer player, @Nonnull ItemStack stack)
+        public LeftClickEmpty(EntityPlayer player)
         {
             super(player, EnumHand.MAIN_HAND, new BlockPos(player), null);
         }
@@ -322,13 +319,14 @@ public class PlayerInteractEvent extends PlayerEvent
     /**
      * @return The hand involved in this interaction. Will never be null.
      */
+    @Nonnull
     public EnumHand getHand()
     {
         return hand;
     }
 
     /**
-     * @return The itemstack involved in this interaction, or null if the hand was empty.
+     * @return The itemstack involved in this interaction, {@code ItemStack.EMPTY} if the hand was empty.
      */
     @Nonnull
     public ItemStack getItemStack()
@@ -343,6 +341,7 @@ public class PlayerInteractEvent extends PlayerEvent
      * Will never be null.
      * @return The position involved in this interaction.
      */
+    @Nonnull
     public BlockPos getPos()
     {
         return pos;

--- a/src/main/java/net/minecraftforge/event/entity/player/PlayerInteractEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/player/PlayerInteractEvent.java
@@ -314,6 +314,14 @@ public class PlayerInteractEvent extends PlayerEvent
         {
             super(player, EnumHand.MAIN_HAND, new BlockPos(player), null);
         }
+
+        // TODO: remove
+        /** @deprecated use {@link LeftClickEmpty(EntityPlayer)} */
+        @Deprecated
+        public LeftClickEmpty(EntityPlayer player, @Nonnull ItemStack stack)
+        {
+            this(player);
+        }
     }
 
     /**


### PR DESCRIPTION
This is just a cleanup of the existing code, removing the unused `ItemStack` parameter for `LeftClickEmpty` and updating the docs for nullability.