### PR TITLE
Fix vanilla bug MC-98707

### DIFF
--- a/patches/minecraft/net/minecraft/client/renderer/texture/TextureManager.java.patch
+++ b/patches/minecraft/net/minecraft/client/renderer/texture/TextureManager.java.patch
@@ -1,6 +1,13 @@
 --- ../src-base/minecraft/net/minecraft/client/renderer/texture/TextureManager.java
 +++ ../src-work/minecraft/net/minecraft/client/renderer/texture/TextureManager.java
-@@ -137,9 +137,12 @@
+@@ -131,15 +131,19 @@
+ 
+         if (itextureobject != null)
+         {
++            this.field_110585_a.remove(p_147645_1_);
+             TextureUtil.func_147942_a(itextureobject.func_110552_b());
+         }
+     }
  
      public void func_110549_a(IResourceManager p_110549_1_)
      {

--- a/patches/minecraft/net/minecraft/client/renderer/texture/TextureManager.java.patch
+++ b/patches/minecraft/net/minecraft/client/renderer/texture/TextureManager.java.patch
@@ -4,7 +4,7 @@
  
          if (itextureobject != null)
          {
-+            this.field_110585_a.remove(p_147645_1_);
++            this.field_110585_a.remove(p_147645_1_); // Forge: fix MC-98707
              TextureUtil.func_147942_a(itextureobject.func_110552_b());
          }
      }


### PR DESCRIPTION
Fix for [this](https://bugs.mojang.com/browse/MC-98707) vanilla bug.

Patches `TextureManager.deleteTexture()` to remove the corresponding `mapTextureObjects` entry when a texture is deleted.

Comments welcome.