### PR TITLE
Persist PotionEffect curative items and initialize defaults from Potion

### DIFF
--- a/patches/minecraft/net/minecraft/potion/Potion.java.patch
+++ b/patches/minecraft/net/minecraft/potion/Potion.java.patch
@@ -20,7 +20,7 @@
      public boolean func_76398_f()
      {
          return this.field_76418_K;
-@@ -269,7 +268,61 @@
+@@ -269,7 +268,74 @@
          return p_111183_2_.func_111164_d() * (double)(p_111183_1_ + 1);
      }
  
@@ -75,6 +75,19 @@
 +     */
 +    @SideOnly(Side.CLIENT)
 +    public void renderHUDEffect(int x, int y, PotionEffect effect, net.minecraft.client.Minecraft mc, float alpha) { }
++
++    /**
++     * Get a fresh list of items that can cure this Potion.
++     * All new PotionEffects created from this Potion will call this to initialize the default curative items
++     * @see PotionEffect#getCurativeItems
++     * @return A list of items that can cure this Potion
++     */
++    public java.util.List<net.minecraft.item.ItemStack> getCurativeItems()
++    {
++        java.util.ArrayList<net.minecraft.item.ItemStack> ret = new java.util.ArrayList<net.minecraft.item.ItemStack>();
++        ret.add(new net.minecraft.item.ItemStack(net.minecraft.init.Items.field_151117_aB));
++        return ret;
++    }
 +
 +    /* ======================================== FORGE END =====================================*/
 +

--- a/patches/minecraft/net/minecraft/potion/PotionEffect.java.patch
+++ b/patches/minecraft/net/minecraft/potion/PotionEffect.java.patch
@@ -17,7 +17,18 @@
      }
  
      public void func_76452_a(PotionEffect p_76452_1_)
-@@ -200,7 +203,7 @@
+@@ -195,12 +198,18 @@
+         p_82719_1_.func_74768_a("Duration", this.func_76459_b());
+         p_82719_1_.func_74757_a("Ambient", this.func_82720_e());
+         p_82719_1_.func_74757_a("ShowParticles", this.func_188418_e());
++        net.minecraft.nbt.NBTTagList list = new net.minecraft.nbt.NBTTagList();
++        for (net.minecraft.item.ItemStack stack : getCurativeItems())
++        {
++            list.func_74742_a(stack.func_77955_b(new NBTTagCompound()));
++        }
++        p_82719_1_.func_74782_a("CurativeItems", list);
+         return p_82719_1_;
+     }
  
      public static PotionEffect func_82722_b(NBTTagCompound p_82722_0_)
      {
@@ -26,7 +37,29 @@
          Potion potion = Potion.func_188412_a(i);
  
          if (potion == null)
-@@ -240,4 +243,58 @@
+@@ -219,7 +228,20 @@
+                 flag1 = p_82722_0_.func_74767_n("ShowParticles");
+             }
+ 
+-            return new PotionEffect(potion, k, j < 0 ? 0 : j, flag, flag1);
++            PotionEffect ret = new PotionEffect(potion, k, j < 0 ? 0 : j, flag, flag1);
++
++            if (p_82722_0_.func_150297_b("CurativeItems", net.minecraftforge.common.util.Constants.NBT.TAG_LIST))
++            {
++                java.util.List<net.minecraft.item.ItemStack> items = new java.util.ArrayList<net.minecraft.item.ItemStack>();
++                net.minecraft.nbt.NBTTagList list = p_82722_0_.func_150295_c("CurativeItems", net.minecraftforge.common.util.Constants.NBT.TAG_COMPOUND);
++                for (int iter = 0; iter < list.func_74745_c(); iter++)
++                {
++                    items.add(new net.minecraft.item.ItemStack(list.func_150305_b(iter)));
++                }
++                ret.setCurativeItems(items);
++            }
++
++            return ret;
+         }
+     }
+ 
+@@ -240,4 +262,59 @@
      {
          return this.field_100013_f;
      }
@@ -34,22 +67,23 @@
 +    /* ======================================== FORGE START =====================================*/
 +    /***
 +     * Returns a list of curative items for the potion effect
++     * By default, this list is initialized using {@link Potion#getCurativeItems}
++     *
 +     * @return The list (ItemStack) of curative items for the potion effect
 +     */
 +    public java.util.List<net.minecraft.item.ItemStack> getCurativeItems()
 +    {
 +        if (this.curativeItems == null) //Lazy load this so that we don't create a circular dep on Items.
 +        {
-+            this.curativeItems = new java.util.ArrayList<net.minecraft.item.ItemStack>();
-+            this.curativeItems.add(new net.minecraft.item.ItemStack(net.minecraft.init.Items.field_151117_aB));
++            this.curativeItems = func_188419_a().getCurativeItems();
 +        }
 +        return this.curativeItems;
 +    }
 +
 +    /***
 +     * Checks the given ItemStack to see if it is in the list of curative items for the potion effect
-+     * @param stack The ItemStack being checked against the list of curative items for the potion effect
-+     * @return true if the given ItemStack is in the list of curative items for the potion effect, false otherwise
++     * @param stack The ItemStack being checked against the list of curative items for this PotionEffect
++     * @return true if the given ItemStack is in the list of curative items for this PotionEffect, false otherwise
 +     */
 +    public boolean isCurativeItem(net.minecraft.item.ItemStack stack)
 +    {
@@ -65,7 +99,7 @@
 +    }
 +
 +    /***
-+     * Sets the array of curative items for the potion effect
++     * Sets the list of curative items for this potion effect, overwriting any already present
 +     * @param curativeItems The list of ItemStacks being set to the potion effect
 +     */
 +    public void setCurativeItems(java.util.List<net.minecraft.item.ItemStack> curativeItems)
@@ -74,7 +108,7 @@
 +    }
 +
 +    /***
-+     * Adds the given stack to list of curative items for the potion effect
++     * Adds the given stack to the list of curative items for this PotionEffect
 +     * @param stack The ItemStack being added to the curative item list
 +     */
 +    public void addCurativeItem(net.minecraft.item.ItemStack stack)

--- a/patches/minecraft/net/minecraft/potion/PotionEffect.java.patch
+++ b/patches/minecraft/net/minecraft/potion/PotionEffect.java.patch
@@ -17,16 +17,11 @@
      }
  
      public void func_76452_a(PotionEffect p_76452_1_)
-@@ -195,12 +198,18 @@
+@@ -195,12 +198,13 @@
          p_82719_1_.func_74768_a("Duration", this.func_76459_b());
          p_82719_1_.func_74757_a("Ambient", this.func_82720_e());
          p_82719_1_.func_74757_a("ShowParticles", this.func_188418_e());
-+        net.minecraft.nbt.NBTTagList list = new net.minecraft.nbt.NBTTagList();
-+        for (net.minecraft.item.ItemStack stack : getCurativeItems())
-+        {
-+            list.func_74742_a(stack.func_77955_b(new NBTTagCompound()));
-+        }
-+        p_82719_1_.func_74782_a("CurativeItems", list);
++        writeCurativeItems(p_82719_1_);
          return p_82719_1_;
      }
  
@@ -37,29 +32,16 @@
          Potion potion = Potion.func_188412_a(i);
  
          if (potion == null)
-@@ -219,7 +228,20 @@
+@@ -219,7 +223,7 @@
                  flag1 = p_82722_0_.func_74767_n("ShowParticles");
              }
  
 -            return new PotionEffect(potion, k, j < 0 ? 0 : j, flag, flag1);
-+            PotionEffect ret = new PotionEffect(potion, k, j < 0 ? 0 : j, flag, flag1);
-+
-+            if (p_82722_0_.func_150297_b("CurativeItems", net.minecraftforge.common.util.Constants.NBT.TAG_LIST))
-+            {
-+                java.util.List<net.minecraft.item.ItemStack> items = new java.util.ArrayList<net.minecraft.item.ItemStack>();
-+                net.minecraft.nbt.NBTTagList list = p_82722_0_.func_150295_c("CurativeItems", net.minecraftforge.common.util.Constants.NBT.TAG_COMPOUND);
-+                for (int iter = 0; iter < list.func_74745_c(); iter++)
-+                {
-+                    items.add(new net.minecraft.item.ItemStack(list.func_150305_b(iter)));
-+                }
-+                ret.setCurativeItems(items);
-+            }
-+
-+            return ret;
++            return readCurativeItems(new PotionEffect(potion, k, j < 0 ? 0 : j, flag, flag1), p_82722_0_);
          }
      }
  
-@@ -240,4 +262,59 @@
+@@ -240,4 +244,85 @@
      {
          return this.field_100013_f;
      }
@@ -117,5 +99,31 @@
 +        {
 +            this.getCurativeItems().add(stack);
 +        }
++    }
++
++    private void writeCurativeItems(NBTTagCompound nbt)
++    {
++        net.minecraft.nbt.NBTTagList list = new net.minecraft.nbt.NBTTagList();
++        for (net.minecraft.item.ItemStack stack : getCurativeItems())
++        {
++            list.func_74742_a(stack.func_77955_b(new NBTTagCompound()));
++        }
++        nbt.func_74782_a("CurativeItems", list);
++    }
++
++    private static PotionEffect readCurativeItems(PotionEffect effect, NBTTagCompound nbt)
++    {
++        if (nbt.func_150297_b("CurativeItems", net.minecraftforge.common.util.Constants.NBT.TAG_LIST))
++        {
++            java.util.List<net.minecraft.item.ItemStack> items = new java.util.ArrayList<net.minecraft.item.ItemStack>();
++            net.minecraft.nbt.NBTTagList list = nbt.func_150295_c("CurativeItems", net.minecraftforge.common.util.Constants.NBT.TAG_COMPOUND);
++            for (int i = 0; i < list.func_74745_c(); i++)
++            {
++                items.add(new net.minecraft.item.ItemStack(list.func_150305_b(i)));
++            }
++            effect.setCurativeItems(items);
++        }
++
++        return effect;
 +    }
  }

--- a/patches/minecraft/net/minecraft/potion/PotionEffect.java.patch
+++ b/patches/minecraft/net/minecraft/potion/PotionEffect.java.patch
@@ -13,7 +13,7 @@
          this.field_76461_c = p_i1577_1_.field_76461_c;
          this.field_82724_e = p_i1577_1_.field_82724_e;
          this.field_188421_h = p_i1577_1_.field_188421_h;
-+        this.curativeItems = p_i1577_1_.curativeItems;
++        this.curativeItems = p_i1577_1_.curativeItems == null ? null : new java.util.ArrayList<net.minecraft.item.ItemStack>(p_i1577_1_.curativeItems);
      }
  
      public void func_76452_a(PotionEffect p_76452_1_)

--- a/src/test/java/net/minecraftforge/debug/PotionCurativeItemDebug.java
+++ b/src/test/java/net/minecraftforge/debug/PotionCurativeItemDebug.java
@@ -1,0 +1,83 @@
+package net.minecraftforge.debug;
+
+import net.minecraft.entity.EntityLivingBase;
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.item.Item;
+import net.minecraft.item.ItemFood;
+import net.minecraft.item.ItemStack;
+import net.minecraft.potion.Potion;
+import net.minecraft.potion.PotionEffect;
+import net.minecraft.potion.PotionType;
+import net.minecraft.world.World;
+import net.minecraftforge.fml.common.Mod;
+import net.minecraftforge.fml.common.event.FMLPreInitializationEvent;
+import net.minecraftforge.fml.common.registry.GameRegistry;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Usage (use survival so you can eat food):
+ * 1. Drink curable_potion from Brewing creative tab
+ * 2. Relog to test that changes to curative items persist, then eat the "medicine" item to cure the effect
+ * 3. Drink incurable_potion from Brewing creative tab
+ * 4. Relog to test that changes to curative items persist, then try drinking milk and eating medicine: they should have no effect
+ */
+@Mod(modid = PotionCurativeItemDebug.MOD_ID)
+public class PotionCurativeItemDebug
+{
+    public static final String MOD_ID = "potion_curative_item_debug";
+
+    @Mod.EventHandler
+    public void preInit(FMLPreInitializationEvent evt)
+    {
+        Item medicine = new Medicine().setRegistryName(MOD_ID, "medicine");
+        GameRegistry.register(medicine);
+
+        Potion incurablePotion = new IncurablePotion().setRegistryName(MOD_ID, "incurable_potion");
+        GameRegistry.register(incurablePotion);
+
+        // Register PotionType that can be cured with medicine
+        PotionEffect curable = new PotionEffect(incurablePotion, 1200);
+        curable.setCurativeItems(Collections.singletonList(new ItemStack(medicine)));
+        GameRegistry.register(new PotionType(curable).setRegistryName(MOD_ID, "curable_potion_type"));
+
+        // Register PotionType that can't be cured
+        GameRegistry.register(new PotionType(new PotionEffect(incurablePotion, 1200)).setRegistryName(MOD_ID, "incurable_potion_type"));
+    }
+
+    private static class IncurablePotion extends Potion
+    {
+        protected IncurablePotion()
+        {
+            super(false, 0x94A061);
+        }
+
+        @Override
+        public List<ItemStack> getCurativeItems()
+        {
+            // By default, no PotionEffect of this Potion can be cured by anything
+            return new ArrayList<ItemStack>();
+        }
+    }
+
+    private static class Medicine extends ItemFood
+    {
+        public Medicine()
+        {
+            super(2, 1, false);
+            setUnlocalizedName("medicine");
+            setAlwaysEdible();
+        }
+
+        @Override
+        protected void onFoodEaten(ItemStack stack, World worldIn, EntityPlayer player)
+        {
+            if (!worldIn.isRemote)
+            {
+                player.curePotionEffects(stack);
+            }
+        }
+    }
+}

--- a/src/test/java/net/minecraftforge/debug/PotionCurativeItemDebug.java
+++ b/src/test/java/net/minecraftforge/debug/PotionCurativeItemDebug.java
@@ -52,6 +52,8 @@ public class PotionCurativeItemDebug
         protected IncurablePotion()
         {
             super(false, 0x94A061);
+            setPotionName("incurable_potion");
+            setIconIndex(6, 0);
         }
 
         @Override


### PR DESCRIPTION
Title. Updated version of #3214 

This does 2 things:
1. PotionEffects save and restore their curative items. Before, even if a modder changed an effect's cure items they would just revert to milk on relog.
2. Potion's themselves are able to provide a default list of curative items that all PotionEffect's that derive from them use by default (see the patch change in PotionEffect.getCurativeItems). I can make my custom Potion incurable now using just one method override, whereas before I would have to track down every PotionEffect and clear its curative items.
3. some comment updates