### PR TITLE
Added Forge slot methods to the creative container

### DIFF
--- a/patches/minecraft/net/minecraft/client/gui/inventory/GuiContainerCreative.java.patch
+++ b/patches/minecraft/net/minecraft/client/gui/inventory/GuiContainerCreative.java.patch
@@ -264,3 +264,41 @@
      }
  
      public int func_147056_g()
+@@ -984,5 +1081,37 @@
+         {
+             return this.field_148332_b.func_82869_a(p_82869_1_);
+         }
++
++        /*========================================= FORGE START =====================================*/
++        public net.minecraft.util.ResourceLocation getBackgroundLocation()
++        {
++            return this.field_148332_b.getBackgroundLocation();
++        }
++
++        public void setBackgroundLocation(net.minecraft.util.ResourceLocation texture)
++        {
++            this.field_148332_b.setBackgroundLocation(texture);
++        }
++
++        public void setBackgroundName(String name)
++        {
++            this.field_148332_b.setBackgroundName(name);
++        }
++
++        public net.minecraft.client.renderer.texture.TextureAtlasSprite getBackgroundSprite()
++        {
++            return this.field_148332_b.getBackgroundSprite();
++        }
++
++        public int getSlotIndex()
++        {
++            return this.field_148332_b.getSlotIndex();
++        }
++
++        public boolean isSameInventory(Slot other)
++        {
++            return this.field_148332_b.isSameInventory(other);
++        }
++        /*========================================= FORGE END =====================================*/
+     }
+ }


### PR DESCRIPTION
`GuiContainerCreative.CreativeSlot` is a "proxy" class that extends Slot. Currently, it passes through all methods (such as `getStack`) except [Forge ones](https://github.com/MinecraftForge/MinecraftForge/blob/1.11.x/patches/minecraft/net/minecraft/inventory/Slot.java.patch#L17-L84) (such as `getSlotIndex`).

This PR adds the missing methods to make it work as expected