### PR TITLE
[1.11] Fix null check in BrewingRecipeRegistry

### DIFF
--- a/src/main/java/net/minecraftforge/common/brewing/BrewingRecipeRegistry.java
+++ b/src/main/java/net/minecraftforge/common/brewing/BrewingRecipeRegistry.java
@@ -96,7 +96,7 @@ public class BrewingRecipeRegistry {
         for (IBrewingRecipe recipe : recipes)
         {
             ItemStack output = recipe.getOutput(input, ingredient);
-            if (output != null)
+            if (!output.isEmpty())
             {
                 return output;
             }


### PR DESCRIPTION
Prevents IBrewingRecipe#getOutput from being called for anything but VanillaBrewingRecipe.