### PR TITLE
Optimization in GuiScrollingList

### DIFF
--- a/src/main/java/net/minecraftforge/fml/client/GuiScrollingList.java
+++ b/src/main/java/net/minecraftforge/fml/client/GuiScrollingList.java
@@ -280,11 +280,10 @@ public abstract class GuiScrollingList
         VertexBuffer worldr = tess.getBuffer();
 
         ScaledResolution res = new ScaledResolution(client);
-        double scaleW = client.displayWidth / res.getScaledWidth_double();
-        double scaleH = client.displayHeight / res.getScaledHeight_double();
+        int scaleRes = res.getScaleFactor();
         GL11.glEnable(GL11.GL_SCISSOR_TEST);
-        GL11.glScissor((int)(left      * scaleW), (int)(client.displayHeight - (bottom * scaleH)),
-                       (int)(listWidth * scaleW), (int)(viewHeight * scaleH));
+        GL11.glScissor(left      * scaleRes, client.displayHeight - (bottom * scaleRes),
+                       listWidth * scaleRes, viewHeight * scaleRes);
 
         if (this.client.world != null)
         {


### PR DESCRIPTION
The scale for width and height are individually calculated, despite the fact that each can only ever be equal to ScaledResolution#scaleFactor (because the double versions of the dimensions that Minecraft#displayWidth and Minecraft#displayHeight are divided by to obtain scaleW and scaleH are themselves obtained from dividing displayWidth and displayHeight by scaleFactor in ScaledResolution's constructor):

**Taking scaleW as an example:**
DW = Minecraft#displayWidth
SW = ScaledResolution#scaledWidthD (returned by ScaledResolution#getScaledWidth_double)

**ScaledResolution's constructor:**
SW = DW / scaleFactor;

**GuiScrollingList#drawScreen:**
double scaleW = DW / SW;

**This is the same as:**
double scaleW = DW / (DW / scaleFactor);

DWs cancel out, leaving scaleFactor. The same is true for scaleH. Since scaleFactor has a getter, it can replace the individual calculations of it.