### PR TITLE
Fix DungeonHooks method to use correct type

### DIFF
--- a/src/main/java/net/minecraftforge/common/DungeonHooks.java
+++ b/src/main/java/net/minecraftforge/common/DungeonHooks.java
@@ -62,13 +62,21 @@ public class DungeonHooks
         return rarity;
     }
 
+    // TODO: remove
+    /** @deprecated use {@link #removeDungeonMob(ResourceLocation)} */
+    @Deprecated
+    public static int removeDungeonMob(String name)
+    {
+        return removeDungeonMob(new ResourceLocation(name));
+    }
+
     /**
      * Will completely remove a Mob from the dungeon spawn list.
      *
      * @param name The name of the mob to remove
      * @return The rarity of the removed mob, prior to being removed.
      */
-    public static int removeDungeonMob(String name)
+    public static int removeDungeonMob(ResourceLocation name)
     {
         for (DungeonMob mob : dungeonMobs)
         {


### PR DESCRIPTION
`DungeonHooks` switched to using `ResourceLocation`s in 1.11, as entities became namespaced.

However, `removeDungeonMob()` wasn't updated and currently takes a `String` parameter. This means it will never work, as the `equals()` check will fail due to differing classes.

This changes the method to take a `ResourceLocation`, keeping a deprecated method taking a `String` for compatibility.

Open to suggestions about what the 'legacy' behaviour should be.