### PR TITLE
Removed an unsafe usage of `EntityMinecart.getType()`

### DIFF
--- a/patches/minecraft/net/minecraft/block/BlockRailBase.java.patch
+++ b/patches/minecraft/net/minecraft/block/BlockRailBase.java.patch
@@ -9,6 +9,15 @@
      }
  
      protected BlockRailBase(boolean p_i45389_1_)
+@@ -56,7 +56,7 @@
+ 
+     public AxisAlignedBB func_185496_a(IBlockState p_185496_1_, IBlockAccess p_185496_2_, BlockPos p_185496_3_)
+     {
+-        BlockRailBase.EnumRailDirection blockrailbase$enumraildirection = p_185496_1_.func_177230_c() == this ? (BlockRailBase.EnumRailDirection)p_185496_1_.func_177229_b(this.func_176560_l()) : null;
++        BlockRailBase.EnumRailDirection blockrailbase$enumraildirection = p_185496_1_.func_177230_c() == this ? getRailDirection(p_185496_2_, p_185496_3_, p_185496_1_, null) : null;
+         return blockrailbase$enumraildirection != null && blockrailbase$enumraildirection.func_177018_c() ? field_190959_b : field_185590_a;
+     }
+ 
 @@ -67,7 +67,7 @@
  
      public boolean func_176196_c(World p_176196_1_, BlockPos p_176196_2_)
@@ -18,8 +27,12 @@
      }
  
      public void func_176213_c(World p_176213_1_, BlockPos p_176213_2_, IBlockState p_176213_3_)
-@@ -90,24 +90,24 @@
-             BlockRailBase.EnumRailDirection blockrailbase$enumraildirection = (BlockRailBase.EnumRailDirection)p_189540_1_.func_177229_b(this.func_176560_l());
+@@ -87,27 +87,27 @@
+     {
+         if (!p_189540_2_.field_72995_K)
+         {
+-            BlockRailBase.EnumRailDirection blockrailbase$enumraildirection = (BlockRailBase.EnumRailDirection)p_189540_1_.func_177229_b(this.func_176560_l());
++            BlockRailBase.EnumRailDirection blockrailbase$enumraildirection = getRailDirection(p_189540_2_, p_189540_3_, p_189540_2_.func_180495_p(p_189540_3_), null);
              boolean flag = false;
  
 -            if (!p_189540_2_.func_180495_p(p_189540_3_.func_177977_b()).func_185896_q())
@@ -48,8 +61,20 @@
              {
                  flag = true;
              }
-@@ -162,6 +162,98 @@
+@@ -148,7 +148,7 @@
+     {
+         super.func_180663_b(p_180663_1_, p_180663_2_, p_180663_3_);
  
+-        if (((BlockRailBase.EnumRailDirection)p_180663_3_.func_177229_b(this.func_176560_l())).func_177018_c())
++        if (getRailDirection(p_180663_1_, p_180663_2_, p_180663_3_, null).func_177018_c())
+         {
+             p_180663_1_.func_175685_c(p_180663_2_.func_177984_a(), this, false);
+         }
+@@ -160,8 +160,101 @@
+         }
+     }
+ 
++    //Forge: Use getRailDirection(IBlockAccess, BlockPos, IBlockState, EntityMinecart) for enhanced ability
      public abstract IProperty<BlockRailBase.EnumRailDirection> func_176560_l();
  
 +    /* ======================================== FORGE START =====================================*/
@@ -147,7 +172,7 @@
      public static enum EnumRailDirection implements IStringSerializable
      {
          NORTH_SOUTH(0, "north_south"),
-@@ -232,6 +324,7 @@
+@@ -232,6 +325,7 @@
          private IBlockState field_180366_e;
          private final boolean field_150656_f;
          private final List<BlockPos> field_150657_g = Lists.<BlockPos>newArrayList();
@@ -155,7 +180,7 @@
  
          public Rail(World p_i45739_2_, BlockPos p_i45739_3_, IBlockState p_i45739_4_)
          {
-@@ -239,8 +332,9 @@
+@@ -239,8 +333,9 @@
              this.field_180367_c = p_i45739_3_;
              this.field_180366_e = p_i45739_4_;
              this.field_180365_d = (BlockRailBase)p_i45739_4_.func_177230_c();
@@ -167,7 +192,7 @@
              this.func_180360_a(blockrailbase$enumraildirection);
          }
  
-@@ -432,7 +526,7 @@
+@@ -432,7 +527,7 @@
                  }
              }
  
@@ -176,7 +201,7 @@
              {
                  if (BlockRailBase.func_176562_d(this.field_150660_b, blockpos.func_177984_a()))
                  {
-@@ -445,7 +539,7 @@
+@@ -445,7 +540,7 @@
                  }
              }
  
@@ -185,7 +210,7 @@
              {
                  if (BlockRailBase.func_176562_d(this.field_150660_b, blockpos3.func_177984_a()))
                  {
-@@ -588,7 +682,7 @@
+@@ -588,7 +683,7 @@
                  }
              }
  
@@ -194,7 +219,7 @@
              {
                  if (BlockRailBase.func_176562_d(this.field_150660_b, blockpos.func_177984_a()))
                  {
-@@ -601,7 +695,7 @@
+@@ -601,7 +696,7 @@
                  }
              }
  

--- a/patches/minecraft/net/minecraft/entity/item/EntityArmorStand.java.patch
+++ b/patches/minecraft/net/minecraft/entity/item/EntityArmorStand.java.patch
@@ -1,0 +1,11 @@
+--- ../src-base/minecraft/net/minecraft/entity/item/EntityArmorStand.java
++++ ../src-work/minecraft/net/minecraft/entity/item/EntityArmorStand.java
+@@ -58,7 +58,7 @@
+     {
+         public boolean apply(@Nullable Entity p_apply_1_)
+         {
+-            return p_apply_1_ instanceof EntityMinecart && ((EntityMinecart)p_apply_1_).func_184264_v() == EntityMinecart.Type.RIDEABLE;
++            return p_apply_1_ instanceof EntityMinecart && ((EntityMinecart)p_apply_1_).canBeRidden();
+         }
+     };
+     private final NonNullList<ItemStack> field_184799_bw;

--- a/patches/minecraft/net/minecraft/entity/item/EntityMinecart.java.patch
+++ b/patches/minecraft/net/minecraft/entity/item/EntityMinecart.java.patch
@@ -205,6 +205,24 @@
              double d15 = Math.sqrt(this.field_70159_w * this.field_70159_w + this.field_70179_y * this.field_70179_y);
  
              if (d15 > 0.01D)
+@@ -683,7 +709,7 @@
+ 
+         if (BlockRailBase.func_176563_d(iblockstate))
+         {
+-            BlockRailBase.EnumRailDirection blockrailbase$enumraildirection = (BlockRailBase.EnumRailDirection)iblockstate.func_177229_b(((BlockRailBase)iblockstate.func_177230_c()).func_176560_l());
++            BlockRailBase.EnumRailDirection blockrailbase$enumraildirection = ((BlockRailBase)iblockstate.func_177230_c()).getRailDirection(field_70170_p, new BlockPos(i, j, k), iblockstate, this);
+             p_70495_3_ = (double)j;
+ 
+             if (blockrailbase$enumraildirection.func_177018_c())
+@@ -733,7 +759,7 @@
+ 
+         if (BlockRailBase.func_176563_d(iblockstate))
+         {
+-            BlockRailBase.EnumRailDirection blockrailbase$enumraildirection = (BlockRailBase.EnumRailDirection)iblockstate.func_177229_b(((BlockRailBase)iblockstate.func_177230_c()).func_176560_l());
++            BlockRailBase.EnumRailDirection blockrailbase$enumraildirection = ((BlockRailBase)iblockstate.func_177230_c()).getRailDirection(field_70170_p, new BlockPos(i, j, k), iblockstate, this);
+             int[][] aint = field_70500_g[blockrailbase$enumraildirection.func_177015_a()];
+             double d0 = (double)i + 0.5D + (double)aint[0][0] * 0.5D;
+             double d1 = (double)j + 0.0625D + (double)aint[0][1] * 0.5D;
 @@ -830,6 +856,12 @@
  
      public void func_70108_f(Entity p_70108_1_)

--- a/patches/minecraft/net/minecraft/item/ItemMinecart.java.patch
+++ b/patches/minecraft/net/minecraft/item/ItemMinecart.java.patch
@@ -1,0 +1,29 @@
+--- ../src-base/minecraft/net/minecraft/item/ItemMinecart.java
++++ ../src-work/minecraft/net/minecraft/item/ItemMinecart.java
+@@ -30,7 +30,7 @@
+             double d2 = p_82487_1_.func_82616_c() + (double)enumfacing.func_82599_e() * 1.125D;
+             BlockPos blockpos = p_82487_1_.func_180699_d().func_177972_a(enumfacing);
+             IBlockState iblockstate = world.func_180495_p(blockpos);
+-            BlockRailBase.EnumRailDirection blockrailbase$enumraildirection = iblockstate.func_177230_c() instanceof BlockRailBase ? (BlockRailBase.EnumRailDirection)iblockstate.func_177229_b(((BlockRailBase)iblockstate.func_177230_c()).func_176560_l()) : BlockRailBase.EnumRailDirection.NORTH_SOUTH;
++            BlockRailBase.EnumRailDirection blockrailbase$enumraildirection = iblockstate.func_177230_c() instanceof BlockRailBase ? ((BlockRailBase)iblockstate.func_177230_c()).getRailDirection(world, blockpos, iblockstate, null) : BlockRailBase.EnumRailDirection.NORTH_SOUTH;
+             double d3;
+ 
+             if (BlockRailBase.func_176563_d(iblockstate))
+@@ -52,7 +52,7 @@
+                 }
+ 
+                 IBlockState iblockstate1 = world.func_180495_p(blockpos.func_177977_b());
+-                BlockRailBase.EnumRailDirection blockrailbase$enumraildirection1 = iblockstate1.func_177230_c() instanceof BlockRailBase ? (BlockRailBase.EnumRailDirection)iblockstate1.func_177229_b(((BlockRailBase)iblockstate1.func_177230_c()).func_176560_l()) : BlockRailBase.EnumRailDirection.NORTH_SOUTH;
++                BlockRailBase.EnumRailDirection blockrailbase$enumraildirection1 = iblockstate1.func_177230_c() instanceof BlockRailBase ? ((BlockRailBase)iblockstate.func_177230_c()).getRailDirection(world, blockpos, iblockstate, null) : BlockRailBase.EnumRailDirection.NORTH_SOUTH;
+ 
+                 if (enumfacing != EnumFacing.DOWN && blockrailbase$enumraildirection1.func_177018_c())
+                 {
+@@ -104,7 +104,7 @@
+ 
+             if (!p_180614_2_.field_72995_K)
+             {
+-                BlockRailBase.EnumRailDirection blockrailbase$enumraildirection = iblockstate.func_177230_c() instanceof BlockRailBase ? (BlockRailBase.EnumRailDirection)iblockstate.func_177229_b(((BlockRailBase)iblockstate.func_177230_c()).func_176560_l()) : BlockRailBase.EnumRailDirection.NORTH_SOUTH;
++                BlockRailBase.EnumRailDirection blockrailbase$enumraildirection = iblockstate.func_177230_c() instanceof BlockRailBase ? ((BlockRailBase)iblockstate.func_177230_c()).getRailDirection(p_180614_2_, p_180614_3_, iblockstate, null) : BlockRailBase.EnumRailDirection.NORTH_SOUTH;
+                 double d0 = 0.0D;
+ 
+                 if (blockrailbase$enumraildirection.func_177018_c())


### PR DESCRIPTION
Here, I redirected the call to a Forge provided methods instead. Don't worry too much about the wrong branch name.