### PR TITLE
Fix horse cap patch being reapplied in the wrong place

### DIFF
--- a/patches/minecraft/net/minecraft/entity/passive/AbstractHorse.java.patch
+++ b/patches/minecraft/net/minecraft/entity/passive/AbstractHorse.java.patch
@@ -1,13 +1,13 @@
 --- ../src-base/minecraft/net/minecraft/entity/passive/AbstractHorse.java
 +++ ../src-work/minecraft/net/minecraft/entity/passive/AbstractHorse.java
-@@ -981,6 +981,7 @@
-         }
+@@ -310,6 +310,7 @@
  
+         this.field_110296_bG.func_110134_a(this);
          this.func_110232_cE();
 +        this.itemHandler = new net.minecraftforge.items.wrapper.InvWrapper(this.field_110296_bG);
      }
  
-     public boolean func_70878_b(EntityAnimal p_70878_1_)
+     protected void func_110232_cE()
 @@ -1219,4 +1220,22 @@
  
          return p_180482_2_;


### PR DESCRIPTION
#3417 moved some of my EntityHorse patches to expose capabilities over to AbstractHorse. However, one line ended up in the completely incorrect place.

`this.itemHandler = ...` is supposed to be at the bottom of initHorseChest. It's there because initHorseChest is the only place where the horse's inventory can change from one IInventory instance to another, so we see that change there and re-wrap the cap around it.

It ended up at the bottom of readFromNBT instead, which is just incorrect. This PR restores the correct patch location to how it was originally. The diff looks weird because the context around the patch changed more than the patch itself :P

Easy reproduction:
```Java
// Run this serverside:
AbstractHorse horse = new EntityHorse(world);
world.spawnEntity(horse);
IItemHandler handler = horse.getCapability(ITEM_HANDLER, null);
// ^ NULL! It should never be null as AbstractHorse's always have saddle + armor slot
```