### PR TITLE
Use travis_wait to extend the timeout on gradlew build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,7 @@ cache:
   directories:
     - $HOME/.gradle/caches/
     - $HOME/.gradle/wrapper/
+    - $HOME/build/localCache/Forge/rangemap.txt
 
 before_install: chmod +x gradlew
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ install:
   - ./gradlew --refresh-dependencies
   - ./gradlew ciWriteBuildNumber
 script:
-  - travis_wait ./gradlew build -x createExe -S
+  - ./gradlew build -i -x createExe -S
   - ./gradlew -p projects/Forge test -S
 
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ install:
   - ./gradlew --refresh-dependencies
   - ./gradlew ciWriteBuildNumber
 script:
-  - ./gradlew build -x createExe -S
+  - travis_wait ./gradlew build -x createExe -S
   - ./gradlew -p projects/Forge test -S
 
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ cache:
   directories:
     - $HOME/.gradle/caches/
     - $HOME/.gradle/wrapper/
-    - $HOME/build/localCache/Forge/rangemap.txt
+    - $TRAVIS_BUILD_DIR/build/localCache/Forge/
 
 before_install: chmod +x gradlew
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ install:
   - ./gradlew --refresh-dependencies
   - ./gradlew ciWriteBuildNumber
 script:
-  - ./gradlew build -i -x createExe -S
+  - travis_wait ./gradlew build -x createExe -S
   - ./gradlew -p projects/Forge test -S
 
 notifications:


### PR DESCRIPTION
While building https://github.com/MinecraftForge/MinecraftForge/pull/3590, travis timed out because build took too long without outputting anything. 
This PR will extend the timeout to 20 minutes, up from 10.