### PR TITLE
Caching of unpacked data in models is now optional.

### DIFF
--- a/src/main/java/net/minecraftforge/common/ForgeModContainer.java
+++ b/src/main/java/net/minecraftforge/common/ForgeModContainer.java
@@ -40,6 +40,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 
+import net.minecraftforge.client.model.pipeline.UnpackedBakedQuad;
 import org.apache.logging.log4j.Level;
 
 import net.minecraft.crash.ICrashReportDetail;
@@ -266,6 +267,12 @@ public class ForgeModContainer extends DummyModContainer implements WorldAccessC
                 "Enable the forge block rendering pipeline - fixes the lighting of custom models.");
         forgeLightPipelineEnabled = prop.getBoolean(Boolean.TRUE);
         prop.setLanguageKey("forge.configgui.forgeLightPipelineEnabled");
+        propOrder.add(prop.getName());
+
+        prop = config.get(Configuration.CATEGORY_GENERAL, "cacheUnpackedQuads", Boolean.TRUE,
+                "Enable caching of unpacked date in the quads - speeds up rendering, but leads to more memory usage.");
+        UnpackedBakedQuad.setCacheUnpacked(prop.getBoolean(Boolean.TRUE));
+        prop.setLanguageKey("forge.configgui.cacheUnpackedQuads");
         propOrder.add(prop.getName());
 
         config.setCategoryPropertyOrder(CATEGORY_GENERAL, propOrder);

--- a/src/main/resources/assets/forge/lang/en_US.lang
+++ b/src/main/resources/assets/forge/lang/en_US.lang
@@ -47,6 +47,7 @@ forge.configgui.zombieBaseSummonChance=Zombie Summon Chance
 forge.configgui.stencilbits=Enable GL Stencil Bits
 forge.configgui.replaceBuckets=Use Forge's bucket model
 forge.configgui.forgeLightPipelineEnabled=Forge Light Pipeline Enabled
+forge.configgui.cacheUnpackedQuads=Cache unpacked model data
 forge.configgui.java8Reminder=Java 8 Reminder timestamp
 forge.configgui.disableStairSlabCulling=Disable Stair/Slab culling.
 forge.configgui.disableStairSlabCulling.tooltip=Enable this if you see through blocks touching stairs/slabs with your resource pack.


### PR DESCRIPTION
This is a PR instead of a direct commit due to breaking of binary compatibility - unpackedData is now private and hidden behind a getter. Should be merged during the next breaking update stage.