### PR TITLE
Fix #3576 Unnecessary warning about totem being renamed

### DIFF
--- a/src/main/java/net/minecraftforge/common/ForgeModContainer.java
+++ b/src/main/java/net/minecraftforge/common/ForgeModContainer.java
@@ -24,7 +24,6 @@
 
 package net.minecraftforge.common;
 
-import net.minecraft.item.Item;
 import net.minecraft.util.ResourceLocation;
 import net.minecraft.world.biome.Biome;
 import static net.minecraftforge.common.config.Configuration.CATEGORY_CLIENT;
@@ -359,7 +358,7 @@ public class ForgeModContainer extends DummyModContainer implements WorldAccessC
             if (entry.name.equals("minecraft:totem")) //This item changed from 1.11 -> 1.11.2
             {
                 ResourceLocation newTotem = new ResourceLocation("minecraft:totem_of_undying");
-                entry.remap(Item.REGISTRY.getObject(newTotem));
+                entry.remap(ForgeRegistries.ITEMS.getValue(newTotem));
             }
         }
     }

--- a/src/main/java/net/minecraftforge/common/ForgeModContainer.java
+++ b/src/main/java/net/minecraftforge/common/ForgeModContainer.java
@@ -24,6 +24,8 @@
 
 package net.minecraftforge.common;
 
+import net.minecraft.item.Item;
+import net.minecraft.util.ResourceLocation;
 import net.minecraft.world.biome.Biome;
 import static net.minecraftforge.common.config.Configuration.CATEGORY_CLIENT;
 import static net.minecraftforge.common.config.Configuration.CATEGORY_GENERAL;
@@ -86,6 +88,7 @@ import net.minecraftforge.fml.common.WorldAccessContainer;
 import net.minecraftforge.fml.common.discovery.ASMDataTable.ASMData;
 import net.minecraftforge.fml.common.event.FMLConstructionEvent;
 import net.minecraftforge.fml.common.event.FMLLoadCompleteEvent;
+import net.minecraftforge.fml.common.event.FMLMissingMappingsEvent;
 import net.minecraftforge.fml.common.event.FMLModIdMappingEvent;
 import net.minecraftforge.fml.common.event.FMLPostInitializationEvent;
 import net.minecraftforge.fml.common.event.FMLPreInitializationEvent;
@@ -344,6 +347,18 @@ public class ForgeModContainer extends DummyModContainer implements WorldAccessC
                     disableStairSlabCulling = tmp;
                     FMLCommonHandler.instance().reloadRenderers();
                 }
+            }
+        }
+    }
+
+    @Subscribe
+    public void missingMapping(FMLMissingMappingsEvent event){
+        for (FMLMissingMappingsEvent.MissingMapping evt:event.getAll())
+        {
+            if (evt.name.equals("minecraft:totem"))//This item changed from 1.11 -> 1.11.2
+            {
+                ResourceLocation newTotem = new ResourceLocation("minecraft:totem_of_undying");
+                evt.remap(Item.REGISTRY.getObject(newTotem));
             }
         }
     }

--- a/src/main/java/net/minecraftforge/common/ForgeModContainer.java
+++ b/src/main/java/net/minecraftforge/common/ForgeModContainer.java
@@ -352,13 +352,14 @@ public class ForgeModContainer extends DummyModContainer implements WorldAccessC
     }
 
     @Subscribe
-    public void missingMapping(FMLMissingMappingsEvent event){
-        for (FMLMissingMappingsEvent.MissingMapping evt:event.getAll())
+    public void missingMapping(FMLMissingMappingsEvent event)
+    {
+        for (FMLMissingMappingsEvent.MissingMapping entry : event.getAll())
         {
-            if (evt.name.equals("minecraft:totem"))//This item changed from 1.11 -> 1.11.2
+            if (entry.name.equals("minecraft:totem")) //This item changed from 1.11 -> 1.11.2
             {
                 ResourceLocation newTotem = new ResourceLocation("minecraft:totem_of_undying");
-                evt.remap(Item.REGISTRY.getObject(newTotem));
+                entry.remap(Item.REGISTRY.getObject(newTotem));
             }
         }
     }

--- a/src/main/java/net/minecraftforge/fml/common/registry/FMLControlledNamespacedRegistry.java
+++ b/src/main/java/net/minecraftforge/fml/common/registry/FMLControlledNamespacedRegistry.java
@@ -785,7 +785,7 @@ public class FMLControlledNamespacedRegistry<I extends IForgeRegistryEntry<I>> e
             }
             I obj = currentRegistry.getRaw(itemName);
             I sub = obj;
-            // If we have an object in the originals set, we use that for initial adding - substitute activation will read the substitute if necessary later
+            // If we have an object in the originals set, we use that for initial adding - substitute activation will readd the substitute if necessary later
             if (currentRegistry.substitutionOriginals.containsKey(itemName))
             {
                 obj = currentRegistry.substitutionOriginals.get(itemName);

--- a/src/main/java/net/minecraftforge/fml/common/registry/FMLControlledNamespacedRegistry.java
+++ b/src/main/java/net/minecraftforge/fml/common/registry/FMLControlledNamespacedRegistry.java
@@ -768,8 +768,9 @@ public class FMLControlledNamespacedRegistry<I extends IForgeRegistryEntry<I>> e
             if (currId == -1)
             {
                 FMLLog.info("Found a missing id from the world %s", itemName);
-                if(!itemName.getResourceDomain().equals("minecraft")) {//minecraft will migrate the items with their own system
-                    missingIds.put(entry.getKey(), newId);
+                if(!itemName.getResourceDomain().equals("minecraft"))
+                {//minecraft will migrate the items with their own system
+                    missingIds.put(itemName, newId);
                 }
                 else
                 {
@@ -784,7 +785,7 @@ public class FMLControlledNamespacedRegistry<I extends IForgeRegistryEntry<I>> e
             }
             I obj = currentRegistry.getRaw(itemName);
             I sub = obj;
-            // If we have an object in the originals set, we use that for initial adding - substitute activation will readd the substitute if neceessary later
+            // If we have an object in the originals set, we use that for initial adding - substitute activation will read the substitute if necessary later
             if (currentRegistry.substitutionOriginals.containsKey(itemName))
             {
                 obj = currentRegistry.substitutionOriginals.get(itemName);

--- a/src/main/java/net/minecraftforge/fml/common/registry/FMLControlledNamespacedRegistry.java
+++ b/src/main/java/net/minecraftforge/fml/common/registry/FMLControlledNamespacedRegistry.java
@@ -768,14 +768,7 @@ public class FMLControlledNamespacedRegistry<I extends IForgeRegistryEntry<I>> e
             if (currId == -1)
             {
                 FMLLog.info("Found a missing id from the world %s", itemName);
-                if(!itemName.getResourceDomain().equals("minecraft"))
-                {//minecraft will migrate the items with their own system
-                    missingIds.put(itemName, newId);
-                }
-                else
-                {
-                    FMLLog.fine("Ignoring missing vanilla id as minecraft will probably take care of it");
-                }
+                missingIds.put(itemName, newId);
                 continue; // no block/item -> nothing to add
             }
             else if (currId != newId)
@@ -785,7 +778,7 @@ public class FMLControlledNamespacedRegistry<I extends IForgeRegistryEntry<I>> e
             }
             I obj = currentRegistry.getRaw(itemName);
             I sub = obj;
-            // If we have an object in the originals set, we use that for initial adding - substitute activation will readd the substitute if necessary later
+            // If we have an object in the originals set, we use that for initial adding - substitute activation will re-add the substitute if necessary later
             if (currentRegistry.substitutionOriginals.containsKey(itemName))
             {
                 obj = currentRegistry.substitutionOriginals.get(itemName);

--- a/src/main/java/net/minecraftforge/fml/common/registry/FMLControlledNamespacedRegistry.java
+++ b/src/main/java/net/minecraftforge/fml/common/registry/FMLControlledNamespacedRegistry.java
@@ -768,7 +768,13 @@ public class FMLControlledNamespacedRegistry<I extends IForgeRegistryEntry<I>> e
             if (currId == -1)
             {
                 FMLLog.info("Found a missing id from the world %s", itemName);
-                missingIds.put(entry.getKey(), newId);
+                if(!itemName.getResourceDomain().equals("minecraft")) {//minecraft will migrate the items with their own system
+                    missingIds.put(entry.getKey(), newId);
+                }
+                else
+                {
+                    FMLLog.fine("Ignoring missing vanilla id as minecraft will probably take care of it");
+                }
                 continue; // no block/item -> nothing to add
             }
             else if (currId != newId)


### PR DESCRIPTION
As said in #3576, minecraft takes care of this (see class TotemItemRename)