### PR TITLE
Skip first baking in ModelLoader

### DIFF
--- a/src/main/java/net/minecraftforge/client/model/ModelLoader.java
+++ b/src/main/java/net/minecraftforge/client/model/ModelLoader.java
@@ -178,9 +178,9 @@ public final class ModelLoader extends ModelBakery
         if (firstLoad)
         {
             firstLoad = false;
-            for (Entry<ModelResourceLocation, IModel> e : stateModels.entrySet())
+            for (ModelResourceLocation mrl : stateModels.keySet())
             {
-                bakedRegistry.putObject(e.getKey(), missingBaked);
+                bakedRegistry.putObject(mrl, missingBaked);
             }
             return bakedRegistry;
         }

--- a/src/main/java/net/minecraftforge/client/model/ModelLoader.java
+++ b/src/main/java/net/minecraftforge/client/model/ModelLoader.java
@@ -178,7 +178,10 @@ public final class ModelLoader extends ModelBakery
         if (firstLoad)
         {
             firstLoad = false;
-            bakedRegistry.putObject(MODEL_MISSING, missingBaked);
+            for (Entry<ModelResourceLocation, IModel> e : stateModels.entrySet())
+            {
+                bakedRegistry.putObject(e.getKey(), missingBaked);
+            }
             return bakedRegistry;
         }
 

--- a/src/main/java/net/minecraftforge/client/model/ModelLoader.java
+++ b/src/main/java/net/minecraftforge/client/model/ModelLoader.java
@@ -123,6 +123,7 @@ import com.google.common.collect.Sets;
 
 public final class ModelLoader extends ModelBakery
 {
+    private static boolean firstLoad = true;
     private final Map<ModelResourceLocation, IModel> stateModels = Maps.newHashMap();
     private final Set<ModelResourceLocation> missingVariants = Sets.newHashSet();
     private final Map<ResourceLocation, Exception> loadingExceptions = Maps.newHashMap();
@@ -173,6 +174,13 @@ public final class ModelLoader extends ModelBakery
         Map<IModel, IBakedModel> bakedModels = Maps.newHashMap();
         HashMultimap<IModel, ModelResourceLocation> models = HashMultimap.create();
         Multimaps.invertFrom(Multimaps.forMap(stateModels), models);
+
+        if (firstLoad)
+        {
+            firstLoad = false;
+            bakedRegistry.putObject(MODEL_MISSING, missingBaked);
+            return bakedRegistry;
+        }
 
         ProgressBar bakeBar = ProgressManager.push("ModelLoader: baking", models.keySet().size());
 

--- a/src/main/java/net/minecraftforge/client/model/ModelLoader.java
+++ b/src/main/java/net/minecraftforge/client/model/ModelLoader.java
@@ -123,7 +123,7 @@ import com.google.common.collect.Sets;
 
 public final class ModelLoader extends ModelBakery
 {
-    private static boolean firstLoad = true;
+    private static boolean firstLoad = Boolean.parseBoolean(System.getProperty("fml.skipFirstModelBake", "true"));
     private final Map<ModelResourceLocation, IModel> stateModels = Maps.newHashMap();
     private final Set<ModelResourceLocation> missingVariants = Sets.newHashSet();
     private final Map<ResourceLocation, Exception> loadingExceptions = Maps.newHashMap();


### PR DESCRIPTION
### Overview
Simply put, skips baking models the first time around.
I structured this similar to Lex's "skip first stitch" optimization back in 1.8.0.

Similar to how the "skip first stitch" optimization still loads textures, but just prevents them from being added to the atlas, this optimization is also fairly conservative in that the models are still loaded and parsed, but are simply not baked. This will still bring a substantial speedup to large packs as the baking time dominates both model loading and texture stitching - there are *many* more actual baked models than json and texture files.

### Things that I think will be FAQ:

Q: Why is `firstLoad` static?
A: A new `ModelLoader` instance is created every resource reload, so it can't be an instance variable

Q: What about ModelBakeEvent?
A: It is still fired after the first bake, just like how TextureStitchEvent.Pre/Post are still fired even if the first stitch is skipped. That's what lets this PR be so small, and not need vanilla patching.

Q: Why put the baked missing-model in everything before returning?
A: It serves as the default value of the bakedRegistry that is returned, and later parts of the loading process assume it's present. Also some mods' `ModelBakeEvent` handlers assume that their model is already in the registry and that it's not null, so just to be safe we put it the missing baked model into every MRL so far.

### Open things I'd like feedback on:
* Should I stick a comment in saying what's happening?
* All rendering in the Forge dev environment appears to still work (vanilla + all test mods. I also tried RFTools), but this should be tested with other mods.
* "Skip first stitch" has a JVM flag to disable it. Should this too?
* IMO we should Cherry pick this to 1.10.2 since there are big packs on 1.10.2 that would greatly benefit from this (SF3, Infinity "Lite", etc)