### PR TITLE
Improve performance of inserting into inventory wrappers

### DIFF
--- a/src/main/java/net/minecraftforge/items/wrapper/InvWrapper.java
+++ b/src/main/java/net/minecraftforge/items/wrapper/InvWrapper.java
@@ -75,15 +75,15 @@ public class InvWrapper implements IItemHandlerModifiable
         if (stack.isEmpty())
             return ItemStack.EMPTY;
 
-        if (!getInv().isItemValidForSlot(slot, stack))
-            return stack;
-
         ItemStack stackInSlot = getInv().getStackInSlot(slot);
 
         int m;
         if (!stackInSlot.isEmpty())
         {
             if (!ItemHandlerHelper.canItemStacksStack(stack, stackInSlot))
+                return stack;
+
+            if (!getInv().isItemValidForSlot(slot, stack))
                 return stack;
 
             m = Math.min(stack.getMaxStackSize(), getSlotLimit(slot)) - stackInSlot.getCount();
@@ -121,6 +121,9 @@ public class InvWrapper implements IItemHandlerModifiable
         }
         else
         {
+            if (!getInv().isItemValidForSlot(slot, stack))
+                return stack;
+
             m = Math.min(stack.getMaxStackSize(), getSlotLimit(slot));
             if (m < stack.getCount())
             {

--- a/src/main/java/net/minecraftforge/items/wrapper/SidedInvWrapper.java
+++ b/src/main/java/net/minecraftforge/items/wrapper/SidedInvWrapper.java
@@ -93,15 +93,15 @@ public class SidedInvWrapper implements IItemHandlerModifiable
         if (slot1 == -1)
             return stack;
 
-        if (!inv.isItemValidForSlot(slot1, stack) || !inv.canInsertItem(slot1, stack, side))
-            return stack;
-
         ItemStack stackInSlot = inv.getStackInSlot(slot1);
 
         int m;
         if (!stackInSlot.isEmpty())
         {
             if (!ItemHandlerHelper.canItemStacksStack(stack, stackInSlot))
+                return stack;
+
+            if (!inv.isItemValidForSlot(slot1, stack) || !inv.canInsertItem(slot1, stack, side))
                 return stack;
 
             m = Math.min(stack.getMaxStackSize(), getSlotLimit(slot)) - stackInSlot.getCount();
@@ -137,6 +137,9 @@ public class SidedInvWrapper implements IItemHandlerModifiable
         }
         else
         {
+            if (!inv.isItemValidForSlot(slot1, stack) || !inv.canInsertItem(slot1, stack, side))
+                return stack;
+
             m = Math.min(stack.getMaxStackSize(), getSlotLimit(slot));
             if (m < stack.getCount())
             {


### PR DESCRIPTION
This moves the `isItemValidForSlot` check after `canItemStacksStack` where appropriate.
The can-stack check is generally faster, and in some cases can be much faster.
This fix was prompted by lag caused by an automated system trying to insert items into full furnaces that only accept smeltable items.