### PR TITLE
Restore missing patch for Biome GetWaterColor event.

### DIFF
--- a/patches/minecraft/net/minecraft/world/biome/Biome.java.patch
+++ b/patches/minecraft/net/minecraft/world/biome/Biome.java.patch
@@ -70,6 +70,15 @@
      }
  
      public Class <? extends Biome > func_150562_l()
+@@ -385,7 +390,7 @@
+     @SideOnly(Side.CLIENT)
+     public final int func_185361_o()
+     {
+-        return this.field_76759_H;
++        return getWaterColorMultiplier();
+     }
+ 
+     public final boolean func_150559_j()
 @@ -393,6 +398,83 @@
          return this.field_76766_R;
      }


### PR DESCRIPTION
Closes #3164 

So this is how it used to be in 1.8.9:
`Block.colorMultiplier` -> `BiomeColorHelper.getWaterColorAtPos` 
-patch> `BiomeGenBase.getWaterColorMultiplier` -> event -> `int`

Somewhere in 1.9 the patch got dropped so it looks like this now:
`IBlockColor.colorMultiplier` -> `BiomeColorHelper.getWaterColorAtPos` -> `Biome.getWaterColor` -> `int` (no event)

`getWaterColorMultiplier` is forge added and does the necessary event firing to allow modders to change the water color, but it's no longer being called.

This PR adds the patch back in, but instead puts it in `Biome.getWaterColor`. All the other color events such as grass and foliage are now fired from `Biome` itself, so I readded it in Biome instead of in BiomeColorHelper, for consistency, and to avoid introducing a new patch file.

Now it's:
`IBlockColor.colorMultiplier` -> `BiomeColorHelper.getWaterColorAtPos` -> `Biome.getWaterColor`
-patch> `Biome.getWaterColorMultiplier` -> event -> `int`