### PR TITLE
Fixed Missing Furnace Fuels

### DIFF
--- a/patches/minecraft/net/minecraft/tileentity/TileEntityFurnace.java.patch
+++ b/patches/minecraft/net/minecraft/tileentity/TileEntityFurnace.java.patch
@@ -58,7 +58,7 @@
              }
  
              if (itemstack.func_77973_b() == Item.func_150898_a(Blocks.field_150360_v) && itemstack.func_77960_j() == 1 && !((ItemStack)this.field_145957_n.get(1)).func_190926_b() && ((ItemStack)this.field_145957_n.get(1)).func_77973_b() == Items.field_151133_ar)
-@@ -300,7 +303,36 @@
+@@ -300,7 +303,62 @@
          else
          {
              Item item = p_145952_0_.func_77973_b();
@@ -71,6 +71,26 @@
 +                if (block == Blocks.field_150376_bx)
 +                {
 +                    return 150;
++                }
++
++                if(block == Blocks.field_150325_L)
++                {
++                    return 100;
++                }
++
++                if(block == Blocks.field_150404_cg)
++                {
++                    return 67;
++                }
++
++                if(block == Blocks.field_150468_ap)
++                {
++                    return 300;
++                }
++
++                if(block == Blocks.field_150471_bO)
++                {
++                    return 100;
 +                }
 +
 +                if (block.func_176223_P().func_185904_a() == Material.field_151575_d)
@@ -88,15 +108,21 @@
 +            if (item instanceof ItemSword && "WOOD".equals(((ItemSword)item).func_150932_j())) return 200;
 +            if (item instanceof ItemHoe && "WOOD".equals(((ItemHoe)item).func_77842_f())) return 200;
 +            if (item == Items.field_151055_y) return 100;
++            if (item == Items.field_151031_f) return 300;
++            if (item == Items.field_151112_aM) return 300;
++            if (item == Items.field_151155_ap) return 200;
 +            if (item == Items.field_151044_h) return 1600;
 +            if (item == Items.field_151129_at) return 20000;
 +            if (item == Item.func_150898_a(Blocks.field_150345_g)) return 100;
++            if (item == Items.field_151054_z) return 100;
 +            if (item == Items.field_151072_bj) return 2400;
++            if (item instanceof ItemDoor && item != Items.field_151139_aw) return 200;
++            if (item instanceof ItemBoat) return 400;
 +            return net.minecraftforge.fml.common.registry.GameRegistry.getFuelValue(p_145952_0_);
          }
      }
  
-@@ -418,4 +450,22 @@
+@@ -418,4 +476,22 @@
      {
          this.field_145957_n.clear();
      }

--- a/patches/minecraft/net/minecraft/tileentity/TileEntityFurnace.java.patch
+++ b/patches/minecraft/net/minecraft/tileentity/TileEntityFurnace.java.patch
@@ -58,17 +58,15 @@
              }
  
              if (itemstack.func_77973_b() == Item.func_150898_a(Blocks.field_150360_v) && itemstack.func_77960_j() == 1 && !((ItemStack)this.field_145957_n.get(1)).func_190926_b() && ((ItemStack)this.field_145957_n.get(1)).func_77973_b() == Items.field_151133_ar)
-@@ -299,7 +302,9 @@
-         }
+@@ -300,6 +303,7 @@
          else
          {
-+
              Item item = p_145952_0_.func_77973_b();
 +            if (!item.getRegistryName().func_110624_b().equals("minecraft")) return net.minecraftforge.fml.common.registry.GameRegistry.getFuelValue(p_145952_0_);
              return item == Item.func_150898_a(Blocks.field_150376_bx) ? 150 : (item == Item.func_150898_a(Blocks.field_150325_L) ? 100 : (item == Item.func_150898_a(Blocks.field_150404_cg) ? 67 : (item == Item.func_150898_a(Blocks.field_150468_ap) ? 300 : (item == Item.func_150898_a(Blocks.field_150471_bO) ? 100 : (Block.func_149634_a(item).func_176223_P().func_185904_a() == Material.field_151575_d ? 300 : (item == Item.func_150898_a(Blocks.field_150402_ci) ? 16000 : (item instanceof ItemTool && "WOOD".equals(((ItemTool)item).func_77861_e()) ? 200 : (item instanceof ItemSword && "WOOD".equals(((ItemSword)item).func_150932_j()) ? 200 : (item instanceof ItemHoe && "WOOD".equals(((ItemHoe)item).func_77842_f()) ? 200 : (item == Items.field_151055_y ? 100 : (item != Items.field_151031_f && item != Items.field_151112_aM ? (item == Items.field_151155_ap ? 200 : (item == Items.field_151044_h ? 1600 : (item == Items.field_151129_at ? 20000 : (item != Item.func_150898_a(Blocks.field_150345_g) && item != Items.field_151054_z ? (item == Items.field_151072_bj ? 2400 : (item instanceof ItemDoor && item != Items.field_151139_aw ? 200 : (item instanceof ItemBoat ? 400 : 0))) : 100)))) : 300)))))))))));
          }
      }
-@@ -418,4 +423,22 @@
+@@ -418,4 +422,22 @@
      {
          this.field_145957_n.clear();
      }

--- a/patches/minecraft/net/minecraft/tileentity/TileEntityFurnace.java.patch
+++ b/patches/minecraft/net/minecraft/tileentity/TileEntityFurnace.java.patch
@@ -58,71 +58,17 @@
              }
  
              if (itemstack.func_77973_b() == Item.func_150898_a(Blocks.field_150360_v) && itemstack.func_77960_j() == 1 && !((ItemStack)this.field_145957_n.get(1)).func_190926_b() && ((ItemStack)this.field_145957_n.get(1)).func_77973_b() == Items.field_151133_ar)
-@@ -300,7 +303,62 @@
+@@ -299,6 +302,9 @@
+         }
          else
          {
++            int burnTime = net.minecraftforge.fml.common.registry.GameRegistry.getFuelValue(p_145952_0_);
++            if( burnTime != 0) return burnTime;
++
              Item item = p_145952_0_.func_77973_b();
--            return item == Item.func_150898_a(Blocks.field_150376_bx) ? 150 : (item == Item.func_150898_a(Blocks.field_150325_L) ? 100 : (item == Item.func_150898_a(Blocks.field_150404_cg) ? 67 : (item == Item.func_150898_a(Blocks.field_150468_ap) ? 300 : (item == Item.func_150898_a(Blocks.field_150471_bO) ? 100 : (Block.func_149634_a(item).func_176223_P().func_185904_a() == Material.field_151575_d ? 300 : (item == Item.func_150898_a(Blocks.field_150402_ci) ? 16000 : (item instanceof ItemTool && "WOOD".equals(((ItemTool)item).func_77861_e()) ? 200 : (item instanceof ItemSword && "WOOD".equals(((ItemSword)item).func_150932_j()) ? 200 : (item instanceof ItemHoe && "WOOD".equals(((ItemHoe)item).func_77842_f()) ? 200 : (item == Items.field_151055_y ? 100 : (item != Items.field_151031_f && item != Items.field_151112_aM ? (item == Items.field_151155_ap ? 200 : (item == Items.field_151044_h ? 1600 : (item == Items.field_151129_at ? 20000 : (item != Item.func_150898_a(Blocks.field_150345_g) && item != Items.field_151054_z ? (item == Items.field_151072_bj ? 2400 : (item instanceof ItemDoor && item != Items.field_151139_aw ? 200 : (item instanceof ItemBoat ? 400 : 0))) : 100)))) : 300)))))))))));
-+
-+            if (item instanceof net.minecraft.item.ItemBlock && Block.func_149634_a(item) != Blocks.field_150350_a)
-+            {
-+                Block block = Block.func_149634_a(item);
-+
-+                if (block == Blocks.field_150376_bx)
-+                {
-+                    return 150;
-+                }
-+
-+                if(block == Blocks.field_150325_L)
-+                {
-+                    return 100;
-+                }
-+
-+                if(block == Blocks.field_150404_cg)
-+                {
-+                    return 67;
-+                }
-+
-+                if(block == Blocks.field_150468_ap)
-+                {
-+                    return 300;
-+                }
-+
-+                if(block == Blocks.field_150471_bO)
-+                {
-+                    return 100;
-+                }
-+
-+                if (block.func_176223_P().func_185904_a() == Material.field_151575_d)
-+                {
-+                    return 300;
-+                }
-+
-+                if (block == Blocks.field_150402_ci)
-+                {
-+                    return 16000;
-+                }
-+            }
-+
-+            if (item instanceof ItemTool && "WOOD".equals(((ItemTool)item).func_77861_e())) return 200;
-+            if (item instanceof ItemSword && "WOOD".equals(((ItemSword)item).func_150932_j())) return 200;
-+            if (item instanceof ItemHoe && "WOOD".equals(((ItemHoe)item).func_77842_f())) return 200;
-+            if (item == Items.field_151055_y) return 100;
-+            if (item == Items.field_151031_f) return 300;
-+            if (item == Items.field_151112_aM) return 300;
-+            if (item == Items.field_151155_ap) return 200;
-+            if (item == Items.field_151044_h) return 1600;
-+            if (item == Items.field_151129_at) return 20000;
-+            if (item == Item.func_150898_a(Blocks.field_150345_g)) return 100;
-+            if (item == Items.field_151054_z) return 100;
-+            if (item == Items.field_151072_bj) return 2400;
-+            if (item instanceof ItemDoor && item != Items.field_151139_aw) return 200;
-+            if (item instanceof ItemBoat) return 400;
-+            return net.minecraftforge.fml.common.registry.GameRegistry.getFuelValue(p_145952_0_);
+             return item == Item.func_150898_a(Blocks.field_150376_bx) ? 150 : (item == Item.func_150898_a(Blocks.field_150325_L) ? 100 : (item == Item.func_150898_a(Blocks.field_150404_cg) ? 67 : (item == Item.func_150898_a(Blocks.field_150468_ap) ? 300 : (item == Item.func_150898_a(Blocks.field_150471_bO) ? 100 : (Block.func_149634_a(item).func_176223_P().func_185904_a() == Material.field_151575_d ? 300 : (item == Item.func_150898_a(Blocks.field_150402_ci) ? 16000 : (item instanceof ItemTool && "WOOD".equals(((ItemTool)item).func_77861_e()) ? 200 : (item instanceof ItemSword && "WOOD".equals(((ItemSword)item).func_150932_j()) ? 200 : (item instanceof ItemHoe && "WOOD".equals(((ItemHoe)item).func_77842_f()) ? 200 : (item == Items.field_151055_y ? 100 : (item != Items.field_151031_f && item != Items.field_151112_aM ? (item == Items.field_151155_ap ? 200 : (item == Items.field_151044_h ? 1600 : (item == Items.field_151129_at ? 20000 : (item != Item.func_150898_a(Blocks.field_150345_g) && item != Items.field_151054_z ? (item == Items.field_151072_bj ? 2400 : (item instanceof ItemDoor && item != Items.field_151139_aw ? 200 : (item instanceof ItemBoat ? 400 : 0))) : 100)))) : 300)))))))))));
          }
-     }
- 
-@@ -418,4 +476,22 @@
+@@ -418,4 +424,22 @@
      {
          this.field_145957_n.clear();
      }

--- a/patches/minecraft/net/minecraft/tileentity/TileEntityFurnace.java.patch
+++ b/patches/minecraft/net/minecraft/tileentity/TileEntityFurnace.java.patch
@@ -58,15 +58,19 @@
              }
  
              if (itemstack.func_77973_b() == Item.func_150898_a(Blocks.field_150360_v) && itemstack.func_77960_j() == 1 && !((ItemStack)this.field_145957_n.get(1)).func_190926_b() && ((ItemStack)this.field_145957_n.get(1)).func_77973_b() == Items.field_151133_ar)
-@@ -300,6 +303,7 @@
+@@ -300,6 +303,11 @@
          else
          {
              Item item = p_145952_0_.func_77973_b();
-+            if (!item.getRegistryName().func_110624_b().equals("minecraft")) return net.minecraftforge.fml.common.registry.GameRegistry.getFuelValue(p_145952_0_);
++            if (!item.getRegistryName().func_110624_b().equals("minecraft"))
++            {
++                int burnTime = net.minecraftforge.fml.common.registry.GameRegistry.getFuelValue(p_145952_0_);
++                if (burnTime != 0) return burnTime;
++            }
              return item == Item.func_150898_a(Blocks.field_150376_bx) ? 150 : (item == Item.func_150898_a(Blocks.field_150325_L) ? 100 : (item == Item.func_150898_a(Blocks.field_150404_cg) ? 67 : (item == Item.func_150898_a(Blocks.field_150468_ap) ? 300 : (item == Item.func_150898_a(Blocks.field_150471_bO) ? 100 : (Block.func_149634_a(item).func_176223_P().func_185904_a() == Material.field_151575_d ? 300 : (item == Item.func_150898_a(Blocks.field_150402_ci) ? 16000 : (item instanceof ItemTool && "WOOD".equals(((ItemTool)item).func_77861_e()) ? 200 : (item instanceof ItemSword && "WOOD".equals(((ItemSword)item).func_150932_j()) ? 200 : (item instanceof ItemHoe && "WOOD".equals(((ItemHoe)item).func_77842_f()) ? 200 : (item == Items.field_151055_y ? 100 : (item != Items.field_151031_f && item != Items.field_151112_aM ? (item == Items.field_151155_ap ? 200 : (item == Items.field_151044_h ? 1600 : (item == Items.field_151129_at ? 20000 : (item != Item.func_150898_a(Blocks.field_150345_g) && item != Items.field_151054_z ? (item == Items.field_151072_bj ? 2400 : (item instanceof ItemDoor && item != Items.field_151139_aw ? 200 : (item instanceof ItemBoat ? 400 : 0))) : 100)))) : 300)))))))))));
          }
      }
-@@ -418,4 +422,22 @@
+@@ -418,4 +426,22 @@
      {
          this.field_145957_n.clear();
      }

--- a/patches/minecraft/net/minecraft/tileentity/TileEntityFurnace.java.patch
+++ b/patches/minecraft/net/minecraft/tileentity/TileEntityFurnace.java.patch
@@ -58,17 +58,17 @@
              }
  
              if (itemstack.func_77973_b() == Item.func_150898_a(Blocks.field_150360_v) && itemstack.func_77960_j() == 1 && !((ItemStack)this.field_145957_n.get(1)).func_190926_b() && ((ItemStack)this.field_145957_n.get(1)).func_77973_b() == Items.field_151133_ar)
-@@ -299,6 +302,9 @@
+@@ -299,7 +302,9 @@
          }
          else
          {
-+            int burnTime = net.minecraftforge.fml.common.registry.GameRegistry.getFuelValue(p_145952_0_);
-+            if(burnTime != 0) return burnTime;
 +
              Item item = p_145952_0_.func_77973_b();
++            if (!item.getRegistryName().func_110624_b().equals("minecraft")) return net.minecraftforge.fml.common.registry.GameRegistry.getFuelValue(p_145952_0_);
              return item == Item.func_150898_a(Blocks.field_150376_bx) ? 150 : (item == Item.func_150898_a(Blocks.field_150325_L) ? 100 : (item == Item.func_150898_a(Blocks.field_150404_cg) ? 67 : (item == Item.func_150898_a(Blocks.field_150468_ap) ? 300 : (item == Item.func_150898_a(Blocks.field_150471_bO) ? 100 : (Block.func_149634_a(item).func_176223_P().func_185904_a() == Material.field_151575_d ? 300 : (item == Item.func_150898_a(Blocks.field_150402_ci) ? 16000 : (item instanceof ItemTool && "WOOD".equals(((ItemTool)item).func_77861_e()) ? 200 : (item instanceof ItemSword && "WOOD".equals(((ItemSword)item).func_150932_j()) ? 200 : (item instanceof ItemHoe && "WOOD".equals(((ItemHoe)item).func_77842_f()) ? 200 : (item == Items.field_151055_y ? 100 : (item != Items.field_151031_f && item != Items.field_151112_aM ? (item == Items.field_151155_ap ? 200 : (item == Items.field_151044_h ? 1600 : (item == Items.field_151129_at ? 20000 : (item != Item.func_150898_a(Blocks.field_150345_g) && item != Items.field_151054_z ? (item == Items.field_151072_bj ? 2400 : (item instanceof ItemDoor && item != Items.field_151139_aw ? 200 : (item instanceof ItemBoat ? 400 : 0))) : 100)))) : 300)))))))))));
          }
-@@ -418,4 +424,22 @@
+     }
+@@ -418,4 +423,22 @@
      {
          this.field_145957_n.clear();
      }

--- a/patches/minecraft/net/minecraft/tileentity/TileEntityFurnace.java.patch
+++ b/patches/minecraft/net/minecraft/tileentity/TileEntityFurnace.java.patch
@@ -63,7 +63,7 @@
          else
          {
 +            int burnTime = net.minecraftforge.fml.common.registry.GameRegistry.getFuelValue(p_145952_0_);
-+            if( burnTime != 0) return burnTime;
++            if(burnTime != 0) return burnTime;
 +
              Item item = p_145952_0_.func_77973_b();
              return item == Item.func_150898_a(Blocks.field_150376_bx) ? 150 : (item == Item.func_150898_a(Blocks.field_150325_L) ? 100 : (item == Item.func_150898_a(Blocks.field_150404_cg) ? 67 : (item == Item.func_150898_a(Blocks.field_150468_ap) ? 300 : (item == Item.func_150898_a(Blocks.field_150471_bO) ? 100 : (Block.func_149634_a(item).func_176223_P().func_185904_a() == Material.field_151575_d ? 300 : (item == Item.func_150898_a(Blocks.field_150402_ci) ? 16000 : (item instanceof ItemTool && "WOOD".equals(((ItemTool)item).func_77861_e()) ? 200 : (item instanceof ItemSword && "WOOD".equals(((ItemSword)item).func_150932_j()) ? 200 : (item instanceof ItemHoe && "WOOD".equals(((ItemHoe)item).func_77842_f()) ? 200 : (item == Items.field_151055_y ? 100 : (item != Items.field_151031_f && item != Items.field_151112_aM ? (item == Items.field_151155_ap ? 200 : (item == Items.field_151044_h ? 1600 : (item == Items.field_151129_at ? 20000 : (item != Item.func_150898_a(Blocks.field_150345_g) && item != Items.field_151054_z ? (item == Items.field_151072_bj ? 2400 : (item instanceof ItemDoor && item != Items.field_151139_aw ? 200 : (item instanceof ItemBoat ? 400 : 0))) : 100)))) : 300)))))))))));


### PR DESCRIPTION
Forge is missing the additional furnace fuels that were added in 1.11

Initial report found on the forums
[Initial Report](http://www.minecraftforge.net/forum/index.php?topic=44537.0l)