### PR TITLE
Fix @Config.Comment not working on subcategory Objects. Closes #3593

### DIFF
--- a/src/main/java/net/minecraftforge/common/config/ConfigManager.java
+++ b/src/main/java/net/minecraftforge/common/config/ConfigManager.java
@@ -239,6 +239,8 @@ public class ConfigManager
         else if (ftype.getSuperclass() == Object.class) //Only support classes that are one level below Object.
         {
             String sub = category + "." + f.getName().toLowerCase(Locale.ENGLISH);
+            cfg.getCategory(sub).setComment(comment);
+
             Object sinst = get(instance, f);
             for (Field sf : ftype.getDeclaredFields())
             {

--- a/src/test/java/net/minecraftforge/debug/ConfigTest.java
+++ b/src/test/java/net/minecraftforge/debug/ConfigTest.java
@@ -70,5 +70,13 @@ public class ConfigTest
         @LangKey("this.is.not.a.good.key")
         @Comment({"This is a really long", "Multi-line comment"})
         public static String Comments = "Hi Tv!";
+
+        @Comment("Category Comment Test")
+        public static NestedType Inner = new NestedType();
+
+        public static class NestedType
+        {
+            public String HeyLook = "Go in!";
+        }
     }
 }


### PR DESCRIPTION
Fixes @Comment not working on subcategory objects, 1 line fix, closes #3593

The changes to the test mod basically show what this fixes.

How it looks with the fix:
```
    #########################################################################################################
    # inner
    #--------------------------------------------------------------------------------------------------------#
    # Category Comment Test
    ##########################################################################################################

    inner {
        S:HeyLook=Go in!
    }
```

the box surrounded by ### would be missing without this fix