### PR TITLE
Prevent concurrent modification of ClassInheritanceMultiMap

### DIFF
--- a/patches/minecraft/net/minecraft/util/ClassInheritanceMultiMap.java.patch
+++ b/patches/minecraft/net/minecraft/util/ClassInheritanceMultiMap.java.patch
@@ -1,10 +1,11 @@
 --- ../src-base/minecraft/net/minecraft/util/ClassInheritanceMultiMap.java
 +++ ../src-work/minecraft/net/minecraft/util/ClassInheritanceMultiMap.java
-@@ -12,7 +12,7 @@
+@@ -12,7 +12,8 @@
  
  public class ClassInheritanceMultiMap<T> extends AbstractSet<T>
  {
 -    private static final Set < Class<? >> field_181158_a = Sets. < Class<? >> newHashSet();
++    // Forge: Use concurrent collection to allow creating chunks from multiple threads safely
 +    private static final Set < Class<? >> field_181158_a = java.util.Collections.newSetFromMap(new java.util.concurrent.ConcurrentHashMap<Class<?>, Boolean>());
      private final Map < Class<?>, List<T >> field_180218_a = Maps. < Class<?>, List<T >> newHashMap();
      private final Set < Class<? >> field_180216_b = Sets. < Class<? >> newIdentityHashSet();

--- a/patches/minecraft/net/minecraft/util/ClassInheritanceMultiMap.java.patch
+++ b/patches/minecraft/net/minecraft/util/ClassInheritanceMultiMap.java.patch
@@ -1,0 +1,24 @@
+--- ../src-base/minecraft/net/minecraft/util/ClassInheritanceMultiMap.java
++++ ../src-work/minecraft/net/minecraft/util/ClassInheritanceMultiMap.java
+@@ -12,7 +12,7 @@
+ 
+ public class ClassInheritanceMultiMap<T> extends AbstractSet<T>
+ {
+-    private static final Set < Class<? >> field_181158_a = Sets. < Class<? >> newHashSet();
++    private static final Set < Class<? >> field_181158_a = java.util.Collections.synchronizedSet(Sets. < Class<? >> newHashSet());
+     private final Map < Class<?>, List<T >> field_180218_a = Maps. < Class<?>, List<T >> newHashMap();
+     private final Set < Class<? >> field_180216_b = Sets. < Class<? >> newIdentityHashSet();
+     private final Class<T> field_180217_c;
+@@ -24,10 +24,12 @@
+         this.field_180216_b.add(p_i45909_1_);
+         this.field_180218_a.put(p_i45909_1_, this.field_181745_e);
+ 
++        synchronized (field_181158_a) {
+         for (Class<?> oclass : field_181158_a)
+         {
+             this.func_180213_a(oclass);
+         }
++        }
+     }
+ 
+     protected void func_180213_a(Class<?> p_180213_1_)

--- a/patches/minecraft/net/minecraft/util/ClassInheritanceMultiMap.java.patch
+++ b/patches/minecraft/net/minecraft/util/ClassInheritanceMultiMap.java.patch
@@ -5,20 +5,7 @@
  public class ClassInheritanceMultiMap<T> extends AbstractSet<T>
  {
 -    private static final Set < Class<? >> field_181158_a = Sets. < Class<? >> newHashSet();
-+    private static final Set < Class<? >> field_181158_a = java.util.Collections.synchronizedSet(Sets. < Class<? >> newHashSet());
++    private static final Set < Class<? >> field_181158_a = java.util.Collections.newSetFromMap(new java.util.concurrent.ConcurrentHashMap<Class<?>, Boolean>());
      private final Map < Class<?>, List<T >> field_180218_a = Maps. < Class<?>, List<T >> newHashMap();
      private final Set < Class<? >> field_180216_b = Sets. < Class<? >> newIdentityHashSet();
      private final Class<T> field_180217_c;
-@@ -24,10 +24,12 @@
-         this.field_180216_b.add(p_i45909_1_);
-         this.field_180218_a.put(p_i45909_1_, this.field_181745_e);
- 
-+        synchronized (field_181158_a) {
-         for (Class<?> oclass : field_181158_a)
-         {
-             this.func_180213_a(oclass);
-         }
-+        }
-     }
- 
-     protected void func_180213_a(Class<?> p_180213_1_)


### PR DESCRIPTION
`ClassInheritanceMultiMap`'s constructor is not thread-safe as it iterates over a static collection (`ClassInheritanceMultiMap.ALL_KNOWN`).

This makes `new Chunk()` thread-unsafe, which is an issue as it is called from both client and server threads, as well as potentially Forge async chunk-loading threads.

This can cause `ConcurrentModificationException` crashes to occur when creating new chunks. The patch fixes that by supporting concurrent access to the shared field.

This pull request is intended for discussion of the issue as well as proposing a potential solution.

Notes:
Crashes caused by this are rare, and I have never experienced a crash from this with just vanilla Minecraft. However, I couldn't see any way in which vanilla works to prevent this, it seems to be mostly luck with timings.

Even with good practices around mod threading, I can't see that this can be avoided in the case of single-player with both client and server threads both potentially creating chunks.