### PR TITLE
Patch ChunkCache.getTileEntity for thread safety

### DIFF
--- a/patches/minecraft/net/minecraft/world/ChunkCache.java.patch
+++ b/patches/minecraft/net/minecraft/world/ChunkCache.java.patch
@@ -5,7 +5,7 @@
      public TileEntity func_175625_s(BlockPos p_175625_1_)
      {
 -        return this.func_190300_a(p_175625_1_, Chunk.EnumCreateEntityType.IMMEDIATE);
-+        return this.func_190300_a(p_175625_1_, Chunk.EnumCreateEntityType.QUEUED); // Forge: don't modify world from other threads
++        return this.func_190300_a(p_175625_1_, Chunk.EnumCreateEntityType.CHECK); // Forge: don't modify world from other threads
      }
  
      @Nullable

--- a/patches/minecraft/net/minecraft/world/ChunkCache.java.patch
+++ b/patches/minecraft/net/minecraft/world/ChunkCache.java.patch
@@ -1,5 +1,14 @@
 --- ../src-base/minecraft/net/minecraft/world/ChunkCache.java
 +++ ../src-work/minecraft/net/minecraft/world/ChunkCache.java
+@@ -61,7 +61,7 @@
+     @Nullable
+     public TileEntity func_175625_s(BlockPos p_175625_1_)
+     {
+-        return this.func_190300_a(p_175625_1_, Chunk.EnumCreateEntityType.IMMEDIATE);
++        return this.func_190300_a(p_175625_1_, Chunk.EnumCreateEntityType.QUEUED); // Forge: don't modify world from other threads
+     }
+ 
+     @Nullable
 @@ -69,6 +69,8 @@
      {
          int i = (p_190300_1_.func_177958_n() >> 4) - this.field_72818_a;


### PR DESCRIPTION
See [this](https://github.com/MinecraftForge/Documentation/pull/81) Forge documentation PR for details.

This changes `ChunkCache#getTileEntity` to pass `QUEUED` instead of `IMMEDIATE` as the type.
Missing tile entities will be added to a (concurrent) queue and created during the chunk's next update tick.

This will cause the method to return `null` if there is tile entity at the position queried, but the function is annotated `@Nullable`, and currently has a chance of just throwing a `ConcurrentModificationException` anyway, so there shouldn't be any working mods broken by this change.