### PR TITLE
Start firing AttachCapabilitiesEvent<ItemStack>

### DIFF
--- a/src/main/java/net/minecraftforge/event/AttachCapabilitiesEvent.java
+++ b/src/main/java/net/minecraftforge/event/AttachCapabilitiesEvent.java
@@ -40,8 +40,8 @@ import javax.annotation.Nonnull;
 public class AttachCapabilitiesEvent<T> extends GenericEvent<T>
 {
     private final T obj;
-    private final Map<ResourceLocation, ICapabilityProvider> caps = Maps.newLinkedHashMap();
-    private final Map<ResourceLocation, ICapabilityProvider> view = Collections.unmodifiableMap(caps);
+    final Map<ResourceLocation, ICapabilityProvider> caps;// package-private for ForgeEventFactory
+    private final Map<ResourceLocation, ICapabilityProvider> view;
 
     @SuppressWarnings("unchecked")
     @Deprecated
@@ -51,8 +51,15 @@ public class AttachCapabilitiesEvent<T> extends GenericEvent<T>
     }
     public AttachCapabilitiesEvent(Class<T> type, T obj)
     {
+        this(type, obj, Maps.<ResourceLocation, ICapabilityProvider>newLinkedHashMap());
+    }
+    // package-private for ForgeEventFactory
+    AttachCapabilitiesEvent(Class<T> type, T obj, Map<ResourceLocation, ICapabilityProvider> caps)
+    {
         super(type);
         this.obj = obj;
+        this.caps = caps;
+        this.view = Collections.unmodifiableMap(caps);
     }
 
     /**
@@ -126,10 +133,10 @@ public class AttachCapabilitiesEvent<T> extends GenericEvent<T>
     /**
      * A version of the parent event which is only fired for ItemStacks.
      */
+    @Deprecated
     public static class Item extends AttachCapabilitiesEvent<net.minecraft.item.Item>
     {
         private final net.minecraft.item.ItemStack stack;
-        @Deprecated
         private final net.minecraft.item.Item item;
         public Item(net.minecraft.item.Item item, @Nonnull  net.minecraft.item.ItemStack stack)
         {
@@ -137,7 +144,6 @@ public class AttachCapabilitiesEvent<T> extends GenericEvent<T>
             this.item = item;
             this.stack = stack;
         }
-        @Deprecated
         public net.minecraft.item.Item getItem()
         {
             return this.item;

--- a/src/main/java/net/minecraftforge/event/ForgeEventFactory.java
+++ b/src/main/java/net/minecraftforge/event/ForgeEventFactory.java
@@ -561,7 +561,13 @@ public class ForgeEventFactory
     @Nullable
     public static CapabilityDispatcher gatherCapabilities(Item item, ItemStack stack, ICapabilityProvider parent)
     {
-        return gatherCapabilities(new AttachCapabilitiesEvent.Item(item, stack), parent);
+        // first fire the legacy event
+        AttachCapabilitiesEvent.Item legacyEvent = new AttachCapabilitiesEvent.Item(item, stack);
+        MinecraftForge.EVENT_BUS.post(legacyEvent);
+
+        // fire new event with the caps that were already registered on the legacy event
+        AttachCapabilitiesEvent<ItemStack> event = new AttachCapabilitiesEvent<ItemStack>(ItemStack.class, stack, legacyEvent.caps);
+        return gatherCapabilities(event, parent);
     }
 
     @Nullable

--- a/src/test/java/net/minecraftforge/test/TestCapabilityMod.java
+++ b/src/test/java/net/minecraftforge/test/TestCapabilityMod.java
@@ -2,6 +2,8 @@ package net.minecraftforge.test;
 
 import net.minecraft.init.Blocks;
 import net.minecraft.init.Items;
+import net.minecraft.item.Item;
+import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTBase;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.tileentity.TileEntity;
@@ -70,7 +72,6 @@ public class TestCapabilityMod
     public void onInteractItem(PlayerInteractEvent.RightClickItem event)
     {
         if (!event.getEntityPlayer().isSneaking()) return;
-        if (event.getItemStack().getItem() != Items.STICK) return;
 
         if (event.getItemStack().hasCapability(TEST_CAP, null))
         {
@@ -143,18 +144,34 @@ public class TestCapabilityMod
     // version of the has/getCapability functions yourself. So you have control
     // over everything yours being called first.
     @SubscribeEvent
-    public void onTELoad(AttachCapabilitiesEvent.TileEntity event)
+    public void onTELoad(AttachCapabilitiesEvent<TileEntity> event)
     {
         //Attach it! The resource location MUST be unique it's recommended that you tag it with your modid and what the cap is.
-        event.addCapability(new ResourceLocation("forge.testcapmod:dummy_cap"), new Provider(event.getTileEntity()));
+        event.addCapability(new ResourceLocation("forge.testcapmod:dummy_cap"), new Provider<TileEntity>(event.getObject()));
     }
 
     @SubscribeEvent
-    public void onItemLoad(AttachCapabilitiesEvent.Item event)
+    public void onItemLoad(AttachCapabilitiesEvent<ItemStack> event)
     {
-        if (event.getItemStack().getItem() == Items.STICK)
-            event.addCapability(new ResourceLocation("forge.testcapmod:dummy_cap"), new Provider(event.getItemStack()));
+        if (event.getObject().getItem() == Items.STICK)
+            event.addCapability(new ResourceLocation("forge.testcapmod:dummy_cap"), new Provider<ItemStack>(event.getObject()));
     }
+
+    // these can be removed if we remove these legacy events
+    @SubscribeEvent
+    public void onItemLoadLegacy(AttachCapabilitiesEvent<Item> event)
+    {
+        if (event.getObject() == Items.APPLE)
+            event.addCapability(new ResourceLocation("forge.testcapmod:dummy_cap"), new Provider<Item>(event.getObject()));
+    }
+
+    @SubscribeEvent
+    public void onItemLoadLegacy(AttachCapabilitiesEvent.Item event)
+    {
+        if (event.getObject() == Items.ARROW)
+            event.addCapability(new ResourceLocation("forge.testcapmod:dummy_cap"), new Provider<Item>(event.getObject()));
+    }
+
 
     @SuppressWarnings("rawtypes")
     @SubscribeEvent


### PR DESCRIPTION
See #3603, which is fixed by this PR.

Also deprecates `AttachCapabilitiesEvent.Item`.