### PR TITLE
Fix MC-112730 TE global renderer duplicate render

### DIFF
--- a/patches/minecraft/net/minecraft/client/renderer/chunk/RenderChunk.java.patch
+++ b/patches/minecraft/net/minecraft/client/renderer/chunk/RenderChunk.java.patch
@@ -9,7 +9,19 @@
                  {
                      TileEntity tileentity = this.field_189564_r.func_190300_a(blockpos$mutableblockpos, Chunk.EnumCreateEntityType.CHECK);
  
-@@ -181,7 +181,9 @@
+@@ -171,17 +171,19 @@
+ 
+                         if (tileentityspecialrenderer != null)
+                         {
+-                            compiledchunk.func_178490_a(tileentity);
+ 
++
+                             if (tileentityspecialrenderer.func_188185_a(tileentity))
+                             {
+                                 lvt_10_1_.add(tileentity);
+-                            }
++                            } else compiledchunk.func_178490_a(tileentity); // FORGE: Fix TE global renderers rendering twice when their chunk sector visible
+                         }
                      }
                  }
  

--- a/patches/minecraft/net/minecraft/client/renderer/chunk/RenderChunk.java.patch
+++ b/patches/minecraft/net/minecraft/client/renderer/chunk/RenderChunk.java.patch
@@ -15,12 +15,11 @@
                          {
 -                            compiledchunk.func_178490_a(tileentity);
  
-+
                              if (tileentityspecialrenderer.func_188185_a(tileentity))
                              {
                                  lvt_10_1_.add(tileentity);
--                            }
-+                            } else compiledchunk.func_178490_a(tileentity); // FORGE: Fix TE global renderers rendering twice when their chunk sector visible
+                             }
++                            else compiledchunk.func_178490_a(tileentity); // FORGE: Fix MC-112730
                          }
                      }
                  }


### PR DESCRIPTION
Currently a TESR which returns true for `isGlobalRenderer` will most of the time cause the TESR to render twice. First from the render chunk's tile entity list while in view and second from the global renderer set. This PR corrects the issue by only adding tile entities to the render chunk list when they are not a global renderer.

The error is visually observable in vanilla with the beacon's [outer beam opacity decreasing](http://i.imgur.com/O2JbaI1.gifv) when there is only a single TESR render from the global renderer set. With this patch the opacity remains constant regardless if the chunk sector is culled.