### PR TITLE
Fix biome specific flower generation

### DIFF
--- a/patches/minecraft/net/minecraft/world/biome/Biome.java.patch
+++ b/patches/minecraft/net/minecraft/world/biome/Biome.java.patch
@@ -31,7 +31,7 @@
          this.field_76761_J.add(new Biome.SpawnListEntry(EntityWitch.class, 5, 1, 1));
          this.field_76755_L.add(new Biome.SpawnListEntry(EntitySquid.class, 10, 4, 4));
          this.field_82914_M.add(new Biome.SpawnListEntry(EntityBat.class, 10, 8, 8));
-+        this.addDefaultFlowers();
++        if (shouldAddDefaultFlowers()) this.addDefaultFlowers();
      }
  
      public BiomeDecorator func_76729_a()
@@ -70,7 +70,7 @@
      }
  
      public Class <? extends Biome > func_150562_l()
-@@ -393,6 +398,83 @@
+@@ -393,6 +398,93 @@
          return this.field_76766_R;
      }
  
@@ -123,7 +123,17 @@
 +    public void addDefaultFlowers()
 +    {
 +        addFlower(Blocks.field_150327_N.func_176223_P().func_177226_a(Blocks.field_150327_N.func_176494_l(), BlockFlower.EnumFlowerType.DANDELION), 20);
-+        addFlower(Blocks.field_150328_O.func_176223_P().func_177226_a(Blocks.field_150328_O.func_176494_l(), BlockFlower.EnumFlowerType.POPPY), 20);
++        addFlower(Blocks.field_150328_O.func_176223_P().func_177226_a(Blocks.field_150328_O.func_176494_l(), BlockFlower.EnumFlowerType.POPPY), 10);
++    }
++
++    /**
++     * Whether the Biome class constructor should call addDefaultFlowers. Changing this to false is useful if in addDefaultFlowers you need access
++     * to data that is initialized in your constructor. In that case you must call addDefaultFlowers yourself.
++     * @return true to call addDefaultFlowers in the Biome constructor
++     */
++    protected boolean shouldAddDefaultFlowers()
++    {
++        return true;
 +    }
 +
 +    /** Register a new plant to be planted when bonemeal is used on grass.
@@ -154,7 +164,7 @@
      public static void func_185358_q()
      {
          func_185354_a(0, "ocean", new BiomeOcean((new Biome.BiomeProperties("Ocean")).func_185398_c(-1.0F).func_185400_d(0.1F)));
-@@ -549,6 +631,7 @@
+@@ -549,6 +641,7 @@
              public Class <? extends EntityLiving > field_76300_b;
              public int field_76301_c;
              public int field_76299_d;
@@ -162,7 +172,7 @@
  
              public SpawnListEntry(Class <? extends EntityLiving > p_i1970_1_, int p_i1970_2_, int p_i1970_3_, int p_i1970_4_)
              {
-@@ -556,12 +639,28 @@
+@@ -556,12 +649,28 @@
                  this.field_76300_b = p_i1970_1_;
                  this.field_76301_c = p_i1970_3_;
                  this.field_76299_d = p_i1970_4_;

--- a/patches/minecraft/net/minecraft/world/biome/BiomeForest.java.patch
+++ b/patches/minecraft/net/minecraft/world/biome/BiomeForest.java.patch
@@ -1,6 +1,14 @@
 --- ../src-base/minecraft/net/minecraft/world/biome/BiomeForest.java
 +++ ../src-work/minecraft/net/minecraft/world/biome/BiomeForest.java
-@@ -74,6 +74,8 @@
+@@ -46,6 +46,7 @@
+         {
+             this.field_76760_I.field_76832_z = -999;
+         }
++        addDefaultFlowers();
+     }
+ 
+     public WorldGenAbstractTree func_150567_a(Random p_150567_1_)
+@@ -74,6 +75,8 @@
              this.func_185379_b(p_180624_1_, p_180624_2_, p_180624_3_);
          }
  
@@ -9,7 +17,7 @@
          int i = p_180624_2_.nextInt(5) - 3;
  
          if (this.field_150632_aF == BiomeForest.Type.FLOWER)
-@@ -82,11 +84,13 @@
+@@ -82,11 +85,13 @@
          }
  
          this.func_185378_a(p_180624_1_, p_180624_2_, p_180624_3_, i);
@@ -23,7 +31,7 @@
          for (int i = 0; i < 4; ++i)
          {
              for (int j = 0; j < 4; ++j)
-@@ -95,12 +99,12 @@
+@@ -95,12 +100,12 @@
                  int l = j * 4 + 1 + 8 + p_185379_2_.nextInt(3);
                  BlockPos blockpos = p_185379_1_.func_175645_m(p_185379_3_.func_177982_a(k, 0, l));
  
@@ -38,7 +46,7 @@
                  {
                      WorldGenAbstractTree worldgenabstracttree = this.func_150567_a(p_185379_2_);
                      worldgenabstracttree.func_175904_e();
-@@ -147,6 +151,22 @@
+@@ -147,6 +152,28 @@
          }
      }
  
@@ -56,6 +64,12 @@
 +            if (type == BlockFlower.EnumFlowerType.BLUE_ORCHID) type = BlockFlower.EnumFlowerType.POPPY;
 +            addFlower(net.minecraft.init.Blocks.field_150328_O.func_176223_P().func_177226_a(net.minecraft.init.Blocks.field_150328_O.func_176494_l(), type), 10);
 +        }
++    }
++
++    @Override
++    protected boolean shouldAddDefaultFlowers()
++    {
++        return false;
 +    }
 +
      public Class <? extends Biome > func_150562_l()


### PR DESCRIPTION
Flower forests do not generate their special flowers in forge. This happens, because of the following race-condition:

- new `BiomeForest` with type `FLOWER`
    - calls `Biome` constructor
        - calls `addDefaultFlowers`, which tries to read the `type` field, which is still `null`
    - sets the `type` field to `FLOWER`

I fixed this by introducing a new method `shouldAddDefaultFlowers` which determines if the `Biome` constructor should call `addDefaultFlowers`. This allows `BiomeForest` (and other mod biomes who might suffer from this problem) to delay the call to `addDefaultFlowers`.
I am not sure if this is the optimal route, suggestions welcome.

This also fixes the default ratio between dandelions and poppies to be 2:1, as in vanilla instead of 1:1.

Reported [here on the forums](http://www.minecraftforge.net/forum/index.php?topic=44869.0).