### PR TITLE
Fix MC-111753 Broken brewing stand automation

### DIFF
--- a/patches/minecraft/net/minecraft/tileentity/TileEntityBrewingStand.java.patch
+++ b/patches/minecraft/net/minecraft/tileentity/TileEntityBrewingStand.java.patch
@@ -51,7 +51,7 @@
          {
              Item item = p_94041_2_.func_77973_b();
 -            return p_94041_1_ == 4 ? item == Items.field_151065_br : (item == Items.field_151068_bn || item == Items.field_185155_bH || item == Items.field_185156_bI || item == Items.field_151069_bo) && this.func_70301_a(p_94041_1_) == ItemStack.field_190927_a;
-+            return p_94041_1_ == 4 ? item == Items.field_151065_br : net.minecraftforge.common.brewing.BrewingRecipeRegistry.isValidInput(p_94041_2_) && this.func_70301_a(p_94041_1_) == ItemStack.field_190927_a;
++            return p_94041_1_ == 4 ? item == Items.field_151065_br : net.minecraftforge.common.brewing.BrewingRecipeRegistry.isValidInput(p_94041_2_) && this.func_70301_a(p_94041_1_).func_190926_b(); // FORGE - Fix MC-111753 Identity comparing with ItemStack.EMPTY
          }
      }
  


### PR DESCRIPTION
fixes [MC-111753](https://bugs.mojang.com/browse/MC-111753) which is an extremely severe bug near the top of the tracker that prevents automation from working properly on brewing stands.

It's due to an identity comparison with `ItemStack.EMPTY` instead of `isEmpty()`

Reproduction and details can be found at the ticket