### PR TITLE
Show the EULA message early

### DIFF
--- a/patches/minecraft/net/minecraft/server/gui/MinecraftServerGui.java.patch
+++ b/patches/minecraft/net/minecraft/server/gui/MinecraftServerGui.java.patch
@@ -1,6 +1,25 @@
 --- ../src-base/minecraft/net/minecraft/server/gui/MinecraftServerGui.java
 +++ ../src-work/minecraft/net/minecraft/server/gui/MinecraftServerGui.java
-@@ -77,6 +77,7 @@
+@@ -38,7 +38,9 @@
+     private static final Font field_164249_a = new Font("Monospaced", 0, 12);
+     private static final Logger field_164248_b = LogManager.getLogger();
+     private final DedicatedServer field_120021_b;
++    private static JFrame jframe;
+ 
++    public static JFrame getJFrame() { return jframe; }
+     public static void func_120016_a(final DedicatedServer p_120016_0_)
+     {
+         try
+@@ -51,7 +53,7 @@
+         }
+ 
+         MinecraftServerGui minecraftservergui = new MinecraftServerGui(p_120016_0_);
+-        JFrame jframe = new JFrame("Minecraft server");
++        jframe = new JFrame("Minecraft server");
+         jframe.add(minecraftservergui);
+         jframe.pack();
+         jframe.setLocationRelativeTo((Component)null);
+@@ -77,6 +79,7 @@
                  System.exit(0);
              }
          });
@@ -8,7 +27,7 @@
      }
  
      public MinecraftServerGui(DedicatedServer p_i2362_1_)
-@@ -161,8 +162,13 @@
+@@ -161,8 +164,13 @@
          return jpanel;
      }
  

--- a/src/main/java/net/minecraftforge/fml/server/FMLServerHandler.java
+++ b/src/main/java/net/minecraftforge/fml/server/FMLServerHandler.java
@@ -30,8 +30,10 @@ import net.minecraft.network.INetHandler;
 import net.minecraft.network.NetHandlerPlayServer;
 import net.minecraft.network.NetworkManager;
 import net.minecraft.server.MinecraftServer;
+import net.minecraft.server.ServerEula;
 import net.minecraft.server.dedicated.DedicatedServer;
 import net.minecraft.server.dedicated.PendingCommand;
+import net.minecraft.server.gui.MinecraftServerGui;
 import net.minecraft.util.IThreadListener;
 import net.minecraft.util.text.translation.LanguageMap;
 import net.minecraft.world.storage.SaveFormatOld;
@@ -50,6 +52,8 @@ import net.minecraftforge.fml.relauncher.Side;
 
 import com.google.common.collect.ImmutableList;
 import org.apache.commons.io.IOUtils;
+
+import javax.swing.*;
 
 /**
  * Handles primary communication from hooked code into the system
@@ -96,6 +100,17 @@ public class FMLServerHandler implements IFMLSidedHandler
     public void beginServerLoading(MinecraftServer minecraftServer)
     {
         server = minecraftServer;
+        ServerEula eula = new ServerEula(new File("eula.txt"));
+        if (!eula.hasAcceptedEULA()) //Call this early so it happens before any mod begins loading, saves some time
+        {
+            FMLLog.info("You need to agree to the EULA in order to run the server. Go to eula.txt for more info.");
+            eula.createEULAFile();
+            if (minecraftServer.getGuiEnabled())
+            {
+                JOptionPane.showMessageDialog(MinecraftServerGui.getJFrame(), "You need to agree to the EULA in order to run the server. Go to eula.txt for more info.", "Cannot continue loading", JOptionPane.ERROR_MESSAGE);
+            }
+            FMLCommonHandler.instance().exitJava(0, false);
+        }
         Loader.instance().loadMods(injectedModContainers);
         Loader.instance().preinitializeMods();
     }


### PR DESCRIPTION
This fixes #3659.
It also adds a small GUI message if the server gui is enabled.
![eula](https://cloud.githubusercontent.com/assets/20151702/22351129/d6a415e6-e416-11e6-8b71-fae5f760a9bf.JPG)
I thought it would be usefull and may prevent some bug reports, but I'm open for feedback.