### PR TITLE
Add implementation for Living Attack event on client-side

### DIFF
--- a/patches/minecraft/net/minecraft/client/entity/EntityOtherPlayerMP.java.patch
+++ b/patches/minecraft/net/minecraft/client/entity/EntityOtherPlayerMP.java.patch
@@ -1,0 +1,10 @@
+--- ../src-base/minecraft/net/minecraft/client/entity/EntityOtherPlayerMP.java
++++ ../src-work/minecraft/net/minecraft/client/entity/EntityOtherPlayerMP.java
+@@ -43,6 +43,7 @@
+ 
+     public boolean func_70097_a(DamageSource p_70097_1_, float p_70097_2_)
+     {
++        net.minecraftforge.common.ForgeHooks.onLivingAttack(this, p_70097_1_, p_70097_2_);
+         return true;
+     }
+ 

--- a/patches/minecraft/net/minecraft/client/entity/EntityPlayerSP.java.patch
+++ b/patches/minecraft/net/minecraft/client/entity/EntityPlayerSP.java.patch
@@ -1,6 +1,22 @@
 --- ../src-base/minecraft/net/minecraft/client/entity/EntityPlayerSP.java
 +++ ../src-work/minecraft/net/minecraft/client/entity/EntityPlayerSP.java
-@@ -428,6 +428,15 @@
+@@ -75,6 +75,7 @@
+ import net.minecraft.util.text.ITextComponent;
+ import net.minecraft.world.IInteractionObject;
+ import net.minecraft.world.World;
++import net.minecraftforge.fml.common.FMLCommonHandler;
+ import net.minecraftforge.fml.relauncher.Side;
+ import net.minecraftforge.fml.relauncher.SideOnly;
+ 
+@@ -125,6 +126,7 @@
+ 
+     public boolean func_70097_a(DamageSource p_70097_1_, float p_70097_2_)
+     {
++        net.minecraftforge.common.ForgeHooks.onLivingAttack(this, p_70097_1_, p_70097_2_);
+         return false;
+     }
+ 
+@@ -428,6 +430,15 @@
          }
      }
  
@@ -16,7 +32,7 @@
      protected boolean func_145771_j(double p_145771_1_, double p_145771_3_, double p_145771_5_)
      {
          if (this.field_70145_X)
-@@ -440,30 +449,34 @@
+@@ -440,30 +451,34 @@
              double d0 = p_145771_1_ - (double)blockpos.func_177958_n();
              double d1 = p_145771_5_ - (double)blockpos.func_177952_p();
  
@@ -56,7 +72,7 @@
                  {
                      d2 = 1.0D - d1;
                      i = 5;
-@@ -498,7 +511,8 @@
+@@ -498,7 +513,8 @@
  
      private boolean func_175162_d(BlockPos p_175162_1_)
      {
@@ -66,7 +82,7 @@
      }
  
      public void func_70031_b(boolean p_70031_1_)
-@@ -543,7 +557,13 @@
+@@ -543,7 +559,13 @@
  
      public void func_184185_a(SoundEvent p_184185_1_, float p_184185_2_, float p_184185_3_)
      {

--- a/patches/minecraft/net/minecraft/client/entity/EntityPlayerSP.java.patch
+++ b/patches/minecraft/net/minecraft/client/entity/EntityPlayerSP.java.patch
@@ -1,14 +1,6 @@
 --- ../src-base/minecraft/net/minecraft/client/entity/EntityPlayerSP.java
 +++ ../src-work/minecraft/net/minecraft/client/entity/EntityPlayerSP.java
-@@ -75,6 +75,7 @@
- import net.minecraft.util.text.ITextComponent;
- import net.minecraft.world.IInteractionObject;
- import net.minecraft.world.World;
-+import net.minecraftforge.fml.common.FMLCommonHandler;
- import net.minecraftforge.fml.relauncher.Side;
- import net.minecraftforge.fml.relauncher.SideOnly;
- 
-@@ -125,6 +126,7 @@
+@@ -125,6 +125,7 @@
  
      public boolean func_70097_a(DamageSource p_70097_1_, float p_70097_2_)
      {
@@ -16,7 +8,7 @@
          return false;
      }
  
-@@ -428,6 +430,15 @@
+@@ -428,6 +429,15 @@
          }
      }
  
@@ -32,7 +24,7 @@
      protected boolean func_145771_j(double p_145771_1_, double p_145771_3_, double p_145771_5_)
      {
          if (this.field_70145_X)
-@@ -440,30 +451,34 @@
+@@ -440,30 +450,34 @@
              double d0 = p_145771_1_ - (double)blockpos.func_177958_n();
              double d1 = p_145771_5_ - (double)blockpos.func_177952_p();
  
@@ -72,7 +64,7 @@
                  {
                      d2 = 1.0D - d1;
                      i = 5;
-@@ -498,7 +513,8 @@
+@@ -498,7 +512,8 @@
  
      private boolean func_175162_d(BlockPos p_175162_1_)
      {
@@ -82,7 +74,7 @@
      }
  
      public void func_70031_b(boolean p_70031_1_)
-@@ -543,7 +559,13 @@
+@@ -543,7 +558,13 @@
  
      public void func_184185_a(SoundEvent p_184185_1_, float p_184185_2_, float p_184185_3_)
      {


### PR DESCRIPTION
Good day everyone.
Lately I ran into an annoying issue. The problem is that there isn't a LivingAttackEvent on client-side. Maybe because never ever thought they would be necessary, but I need it for [EnhancedVisuals](https://minecraft.curseforge.com/projects/enhancedvisuals). 
That means there is no proper way for a client to now when the player is hurt. So I added a notification for LivingAttackEvent (as it is done on server side) for EntityPlayerSP and EntityOtherPlayerMP.

LivingAttackEvent is called on server and client for all other entities (except of players). So it looks like players should be included.