### PR TITLE
Added a Pick (MiddleClick) event

### DIFF
--- a/src/main/java/net/minecraftforge/common/ForgeHooks.java
+++ b/src/main/java/net/minecraftforge/common/ForgeHooks.java
@@ -455,7 +455,6 @@ public class ForgeHooks
                 }
             }
          */
-
         ItemStack result;
         boolean isCreative = player.capabilities.isCreativeMode;
         TileEntity te = null;
@@ -486,7 +485,8 @@ public class ForgeHooks
 
         PlayerInteractEvent.Pick pickEvent = new PlayerInteractEvent.Pick(player, target, result);
         MinecraftForge.EVENT_BUS.post(pickEvent);
-        if(pickEvent.isCanceled()) {
+        if (pickEvent.isCanceled())
+        {
             return false;
         }
         result = pickEvent.getCurrentResult();

--- a/src/main/java/net/minecraftforge/common/ForgeHooks.java
+++ b/src/main/java/net/minecraftforge/common/ForgeHooks.java
@@ -455,9 +455,9 @@ public class ForgeHooks
                 }
             }
          */
-        PlayerInteractEvent.MiddleClick.Pre middleClickPre = new PlayerInteractEvent.MiddleClick.Pre(player, target);
-        MinecraftForge.EVENT_BUS.post(middleClickPre);
-        if(middleClickPre.isCanceled()){
+        PlayerInteractEvent.Pick.Pre pickPre = new PlayerInteractEvent.Pick.Pre(player, target);
+        MinecraftForge.EVENT_BUS.post(pickPre);
+        if(pickPre.isCanceled()){
             return false;
         }
 
@@ -489,9 +489,9 @@ public class ForgeHooks
             result = target.entityHit.getPickedResult(target);
         }
 
-        PlayerInteractEvent.MiddleClick.Post middleClickPost = new PlayerInteractEvent.MiddleClick.Post(player, target, result);
-        MinecraftForge.EVENT_BUS.post(middleClickPost);
-        result = middleClickPost.getCurrentResult();
+        PlayerInteractEvent.Pick.Post pickPost = new PlayerInteractEvent.Pick.Post(player, target, result);
+        MinecraftForge.EVENT_BUS.post(pickPost);
+        result = pickPost.getCurrentResult();
 
         if (result.isEmpty())
         {

--- a/src/main/java/net/minecraftforge/common/ForgeHooks.java
+++ b/src/main/java/net/minecraftforge/common/ForgeHooks.java
@@ -486,7 +486,7 @@ public class ForgeHooks
 
         PlayerInteractEvent.Pick pickEvent = new PlayerInteractEvent.Pick(player, target, result);
         MinecraftForge.EVENT_BUS.post(pickEvent);
-        if(pickEvent.isCanceled()){
+        if(pickEvent.isCanceled()) {
             return false;
         }
         result = pickEvent.getCurrentResult();

--- a/src/main/java/net/minecraftforge/common/ForgeHooks.java
+++ b/src/main/java/net/minecraftforge/common/ForgeHooks.java
@@ -485,11 +485,7 @@ public class ForgeHooks
 
         PlayerInteractEvent.Pick pickEvent = new PlayerInteractEvent.Pick(player, target, result);
         MinecraftForge.EVENT_BUS.post(pickEvent);
-        if (pickEvent.isCanceled())
-        {
-            return false;
-        }
-        result = pickEvent.getCurrentResult();
+        result = pickEvent.isCanceled() ? ItemStack.EMPTY : pickEvent.getCurrentResult();
 
         if (result.isEmpty())
         {

--- a/src/main/java/net/minecraftforge/common/ForgeHooks.java
+++ b/src/main/java/net/minecraftforge/common/ForgeHooks.java
@@ -455,6 +455,12 @@ public class ForgeHooks
                 }
             }
          */
+        PlayerInteractEvent.MiddleClick.Pre middleClickPre = new PlayerInteractEvent.MiddleClick.Pre(player, target);
+        MinecraftForge.EVENT_BUS.post(middleClickPre);
+        if(middleClickPre.isCanceled()){
+            return false;
+        }
+
         ItemStack result;
         boolean isCreative = player.capabilities.isCreativeMode;
         TileEntity te = null;
@@ -482,6 +488,10 @@ public class ForgeHooks
 
             result = target.entityHit.getPickedResult(target);
         }
+
+        PlayerInteractEvent.MiddleClick.Post middleClickPost = new PlayerInteractEvent.MiddleClick.Post(player, target, result);
+        MinecraftForge.EVENT_BUS.post(middleClickPost);
+        result = middleClickPost.getCurrentResult();
 
         if (result.isEmpty())
         {

--- a/src/main/java/net/minecraftforge/common/ForgeHooks.java
+++ b/src/main/java/net/minecraftforge/common/ForgeHooks.java
@@ -485,7 +485,7 @@ public class ForgeHooks
 
         PlayerInteractEvent.Pick pickEvent = new PlayerInteractEvent.Pick(player, target, result);
         MinecraftForge.EVENT_BUS.post(pickEvent);
-        result = pickEvent.isCanceled() ? ItemStack.EMPTY : pickEvent.getCurrentResult();
+        result = pickEvent.isCanceled() ? ItemStack.EMPTY : pickEvent.getResultStack();
 
         if (result.isEmpty())
         {

--- a/src/main/java/net/minecraftforge/common/ForgeHooks.java
+++ b/src/main/java/net/minecraftforge/common/ForgeHooks.java
@@ -455,11 +455,6 @@ public class ForgeHooks
                 }
             }
          */
-        PlayerInteractEvent.Pick.Pre pickPre = new PlayerInteractEvent.Pick.Pre(player, target);
-        MinecraftForge.EVENT_BUS.post(pickPre);
-        if(pickPre.isCanceled()){
-            return false;
-        }
 
         ItemStack result;
         boolean isCreative = player.capabilities.isCreativeMode;
@@ -489,9 +484,12 @@ public class ForgeHooks
             result = target.entityHit.getPickedResult(target);
         }
 
-        PlayerInteractEvent.Pick.Post pickPost = new PlayerInteractEvent.Pick.Post(player, target, result);
-        MinecraftForge.EVENT_BUS.post(pickPost);
-        result = pickPost.getCurrentResult();
+        PlayerInteractEvent.Pick pickEvent = new PlayerInteractEvent.Pick(player, target, result);
+        MinecraftForge.EVENT_BUS.post(pickEvent);
+        if(pickEvent.isCanceled()){
+            return false;
+        }
+        result = pickEvent.getCurrentResult();
 
         if (result.isEmpty())
         {

--- a/src/main/java/net/minecraftforge/event/entity/player/PlayerInteractEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/player/PlayerInteractEvent.java
@@ -335,8 +335,9 @@ public class PlayerInteractEvent extends PlayerEvent
     public static class Pick extends PlayerInteractEvent
     {
         private RayTraceResult target;
+        @Nonnull
         private ItemStack currentResult;
-        public Pick(EntityPlayer player, RayTraceResult target, ItemStack currentResult)
+        public Pick(EntityPlayer player, RayTraceResult target, @Nonnull ItemStack currentResult)
         {
             super(player, EnumHand.MAIN_HAND, target.typeOfHit == RayTraceResult.Type.BLOCK ? target.getBlockPos() : new BlockPos(target.entityHit), target.typeOfHit == RayTraceResult.Type.BLOCK ? target.sideHit : null);
             this.target = target;
@@ -348,12 +349,13 @@ public class PlayerInteractEvent extends PlayerEvent
             return target;
         }
 
+        @Nonnull
         public ItemStack getCurrentResult()
         {
             return this.currentResult;
         }
 
-        public void setCurrentResult(ItemStack newResult)
+        public void setCurrentResult(@Nonnull ItemStack newResult)
         {
             this.currentResult = newResult;
         }

--- a/src/main/java/net/minecraftforge/event/entity/player/PlayerInteractEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/player/PlayerInteractEvent.java
@@ -26,6 +26,7 @@ import net.minecraft.item.ItemStack;
 import net.minecraft.util.EnumFacing;
 import net.minecraft.util.EnumHand;
 import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.math.RayTraceResult;
 import net.minecraft.util.math.Vec3d;
 import net.minecraft.world.World;
 import net.minecraftforge.common.MinecraftForge;
@@ -322,6 +323,59 @@ public class PlayerInteractEvent extends PlayerEvent
         public LeftClickEmpty(EntityPlayer player, @Nonnull ItemStack stack)
         {
             this(player);
+        }
+    }
+
+    /**
+     * This event is fired on the client side when a player middle clicks while aiming on a block or entity.
+     * There is no update packet for it, you have to send your own when needed.
+     */
+    public static class MiddleClick extends PlayerInteractEvent
+    {
+        private RayTraceResult target;
+        private MiddleClick(EntityPlayer player, RayTraceResult target){
+            super(player, EnumHand.MAIN_HAND, target.typeOfHit == RayTraceResult.Type.BLOCK ? target.getBlockPos() : new BlockPos(target.entityHit), target.typeOfHit == RayTraceResult.Type.BLOCK ? target.sideHit : null);
+            this.target = target;
+        }
+
+        public RayTraceResult getRayTraceResult(){
+            return target;
+        }
+
+        /**
+         * The Pre event is fired before the RayTraceResult gets analyzed.
+         * Cancel this event to prevent the analyzing.
+         */
+        @Cancelable
+        public static class Pre extends MiddleClick
+        {
+            public Pre(EntityPlayer player, RayTraceResult target){
+                super(player, target);
+            }
+        }
+
+        /**
+         * The Post event is fired after the RayTraceResult was analyzed.
+         * You can change the Result ItemStack here or set it to {@code ItemStack.EMPTY} to prevent further updating.
+         */
+        public static class Post extends MiddleClick
+        {
+            private ItemStack currentResult;
+            public Post(EntityPlayer player, RayTraceResult target, ItemStack currentResult){
+                super(player, target);
+                this.currentResult = currentResult;
+            }
+
+            /**
+             * @return The current analyzed result for the RayTraceResult
+             */
+            public ItemStack getCurrentResult(){
+                return this.currentResult;
+            }
+
+            public void setCurrentResult(ItemStack newResult){
+                this.currentResult = newResult;
+            }
         }
     }
 

--- a/src/main/java/net/minecraftforge/event/entity/player/PlayerInteractEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/player/PlayerInteractEvent.java
@@ -330,10 +330,10 @@ public class PlayerInteractEvent extends PlayerEvent
      * This event is fired on the client side when a player middle clicks while aiming on a block or entity.
      * There is no update packet for it, you have to send your own when needed.
      */
-    public static class MiddleClick extends PlayerInteractEvent
+    public static class Pick extends PlayerInteractEvent
     {
         private RayTraceResult target;
-        private MiddleClick(EntityPlayer player, RayTraceResult target){
+        private Pick(EntityPlayer player, RayTraceResult target){
             super(player, EnumHand.MAIN_HAND, target.typeOfHit == RayTraceResult.Type.BLOCK ? target.getBlockPos() : new BlockPos(target.entityHit), target.typeOfHit == RayTraceResult.Type.BLOCK ? target.sideHit : null);
             this.target = target;
         }
@@ -347,7 +347,7 @@ public class PlayerInteractEvent extends PlayerEvent
          * Cancel this event to prevent the analyzing.
          */
         @Cancelable
-        public static class Pre extends MiddleClick
+        public static class Pre extends Pick
         {
             public Pre(EntityPlayer player, RayTraceResult target){
                 super(player, target);
@@ -358,7 +358,7 @@ public class PlayerInteractEvent extends PlayerEvent
          * The Post event is fired after the RayTraceResult was analyzed.
          * You can change the Result ItemStack here or set it to {@code ItemStack.EMPTY} to prevent further updating.
          */
-        public static class Post extends MiddleClick
+        public static class Post extends Pick
         {
             private ItemStack currentResult;
             public Post(EntityPlayer player, RayTraceResult target, ItemStack currentResult){

--- a/src/main/java/net/minecraftforge/event/entity/player/PlayerInteractEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/player/PlayerInteractEvent.java
@@ -336,21 +336,25 @@ public class PlayerInteractEvent extends PlayerEvent
     {
         private RayTraceResult target;
         private ItemStack currentResult;
-        public Pick(EntityPlayer player, RayTraceResult target, ItemStack currentResult) {
+        public Pick(EntityPlayer player, RayTraceResult target, ItemStack currentResult)
+        {
             super(player, EnumHand.MAIN_HAND, target.typeOfHit == RayTraceResult.Type.BLOCK ? target.getBlockPos() : new BlockPos(target.entityHit), target.typeOfHit == RayTraceResult.Type.BLOCK ? target.sideHit : null);
             this.target = target;
             this.currentResult = currentResult;
         }
 
-        public RayTraceResult getRayTraceResult() {
+        public RayTraceResult getRayTraceResult()
+        {
             return target;
         }
 
-        public ItemStack getCurrentResult() {
+        public ItemStack getCurrentResult()
+        {
             return this.currentResult;
         }
 
-        public void setCurrentResult(ItemStack newResult) {
+        public void setCurrentResult(ItemStack newResult)
+        {
             this.currentResult = newResult;
         }
     }

--- a/src/main/java/net/minecraftforge/event/entity/player/PlayerInteractEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/player/PlayerInteractEvent.java
@@ -329,53 +329,36 @@ public class PlayerInteractEvent extends PlayerEvent
     /**
      * This event is fired on the client side when a player middle clicks while aiming on a block or entity.
      * There is no update packet for it, you have to send your own when needed.
+     * You can change the Result ItemStack here or set it to {@link ItemStack#EMPTY} to prevent further updating.
+     * Cancel the event if you want that nothing happens.
      */
+    @Cancelable
     public static class Pick extends PlayerInteractEvent
     {
         private RayTraceResult target;
-        private Pick(EntityPlayer player, RayTraceResult target){
+        private ItemStack currentResult;
+        public Pick(EntityPlayer player, RayTraceResult target, ItemStack currentResult){
             super(player, EnumHand.MAIN_HAND, target.typeOfHit == RayTraceResult.Type.BLOCK ? target.getBlockPos() : new BlockPos(target.entityHit), target.typeOfHit == RayTraceResult.Type.BLOCK ? target.sideHit : null);
             this.target = target;
+            this.currentResult = currentResult;
         }
 
+        /**
+         * @return The same RayTraceResult as {@link net.minecraft.client.Minecraft#objectMouseOver}
+         */
         public RayTraceResult getRayTraceResult(){
             return target;
         }
 
         /**
-         * The Pre event is fired before the RayTraceResult gets analyzed.
-         * Cancel this event to prevent the analyzing.
+         * @return The current analyzed result for the RayTraceResult
          */
-        @Cancelable
-        public static class Pre extends Pick
-        {
-            public Pre(EntityPlayer player, RayTraceResult target){
-                super(player, target);
-            }
+        public ItemStack getCurrentResult(){
+            return this.currentResult;
         }
 
-        /**
-         * The Post event is fired after the RayTraceResult was analyzed.
-         * You can change the Result ItemStack here or set it to {@code ItemStack.EMPTY} to prevent further updating.
-         */
-        public static class Post extends Pick
-        {
-            private ItemStack currentResult;
-            public Post(EntityPlayer player, RayTraceResult target, ItemStack currentResult){
-                super(player, target);
-                this.currentResult = currentResult;
-            }
-
-            /**
-             * @return The current analyzed result for the RayTraceResult
-             */
-            public ItemStack getCurrentResult(){
-                return this.currentResult;
-            }
-
-            public void setCurrentResult(ItemStack newResult){
-                this.currentResult = newResult;
-            }
+        public void setCurrentResult(ItemStack newResult){
+            this.currentResult = newResult;
         }
     }
 

--- a/src/main/java/net/minecraftforge/event/entity/player/PlayerInteractEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/player/PlayerInteractEvent.java
@@ -328,36 +328,29 @@ public class PlayerInteractEvent extends PlayerEvent
 
     /**
      * This event is fired on the client side when a player middle clicks while aiming on a block or entity.
-     * There is no update packet for it, you have to send your own when needed.
-     * You can change the Result ItemStack here or set it to {@link ItemStack#EMPTY} to prevent further updating.
-     * Cancel the event if you want that nothing happens.
+     * The server is not aware of when the client left clicks empty space, you will need to tell the server yourself.
+     * You can change the Result ItemStack here or set it to {@link ItemStack#EMPTY} or cancel the event to prevent further updating.
      */
     @Cancelable
     public static class Pick extends PlayerInteractEvent
     {
         private RayTraceResult target;
         private ItemStack currentResult;
-        public Pick(EntityPlayer player, RayTraceResult target, ItemStack currentResult){
+        public Pick(EntityPlayer player, RayTraceResult target, ItemStack currentResult) {
             super(player, EnumHand.MAIN_HAND, target.typeOfHit == RayTraceResult.Type.BLOCK ? target.getBlockPos() : new BlockPos(target.entityHit), target.typeOfHit == RayTraceResult.Type.BLOCK ? target.sideHit : null);
             this.target = target;
             this.currentResult = currentResult;
         }
 
-        /**
-         * @return The same RayTraceResult as {@link net.minecraft.client.Minecraft#objectMouseOver}
-         */
-        public RayTraceResult getRayTraceResult(){
+        public RayTraceResult getRayTraceResult() {
             return target;
         }
 
-        /**
-         * @return The current analyzed result for the RayTraceResult
-         */
-        public ItemStack getCurrentResult(){
+        public ItemStack getCurrentResult() {
             return this.currentResult;
         }
 
-        public void setCurrentResult(ItemStack newResult){
+        public void setCurrentResult(ItemStack newResult) {
             this.currentResult = newResult;
         }
     }

--- a/src/main/java/net/minecraftforge/event/entity/player/PlayerInteractEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/player/PlayerInteractEvent.java
@@ -328,8 +328,8 @@ public class PlayerInteractEvent extends PlayerEvent
 
     /**
      * This event is fired on the client side when a player middle clicks while aiming on a block or entity.
-     * The server is not aware of when the client left clicks empty space, you will need to tell the server yourself.
-     * You can change the Result ItemStack here or set it to {@link ItemStack#EMPTY} or cancel the event to prevent further updating.
+     * The server is not aware of when the client middle clicks blocks or entities, you will need to tell the server yourself.
+     * You can change the Result ItemStack here or set it to {@link ItemStack#EMPTY}. Cancelling it equals to return {@link ItemStack#EMPTY}.
      */
     @Cancelable
     public static class Pick extends PlayerInteractEvent

--- a/src/main/java/net/minecraftforge/event/entity/player/PlayerInteractEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/player/PlayerInteractEvent.java
@@ -344,18 +344,18 @@ public class PlayerInteractEvent extends PlayerEvent
             this.currentResult = currentResult;
         }
 
-        public RayTraceResult getRayTraceResult()
+        public RayTraceResult getTarget()
         {
             return target;
         }
 
         @Nonnull
-        public ItemStack getCurrentResult()
+        public ItemStack getResultStack()
         {
             return this.currentResult;
         }
 
-        public void setCurrentResult(@Nonnull ItemStack newResult)
+        public void setResultStack(@Nonnull ItemStack newResult)
         {
             this.currentResult = newResult;
         }

--- a/src/test/java/net/minecraftforge/test/PlayerInteractEventTest.java
+++ b/src/test/java/net/minecraftforge/test/PlayerInteractEventTest.java
@@ -157,21 +157,14 @@ public class PlayerInteractEventTest
     }
 
     @SubscribeEvent
-    public void middleClickPre(PlayerInteractEvent.Pick.Pre evt)
+    public void middleClickPre(PlayerInteractEvent.Pick evt)
     {
         if(!ENABLE) return;
-        logger.info("RayTraceResult: {}", evt.getRayTraceResult());
+        logger.info("result stack: {} | RayTraceResult: {}", evt.getCurrentResult(), evt.getRayTraceResult());
 
         if(evt.getRayTraceResult().typeOfHit == RayTraceResult.Type.ENTITY && evt.getRayTraceResult().entityHit instanceof EntityHorse)
             // Middle click a horse and  don't get a spawn egg
             evt.setCanceled(true);
-    }
-
-    @SubscribeEvent
-    public void middleClickPost(PlayerInteractEvent.Pick.Post evt)
-    {
-        if(!ENABLE) return;
-        logger.info("result stack: {} | RayTraceResult: {}", evt.getCurrentResult(), evt.getRayTraceResult());
 
         if(evt.getRayTraceResult().typeOfHit == RayTraceResult.Type.BLOCK && evt.getWorld().getBlockState(evt.getPos()).getBlock() == Blocks.BONE_BLOCK)
             // Get a baked potato when middle click a bone block

--- a/src/test/java/net/minecraftforge/test/PlayerInteractEventTest.java
+++ b/src/test/java/net/minecraftforge/test/PlayerInteractEventTest.java
@@ -157,7 +157,7 @@ public class PlayerInteractEventTest
     }
 
     @SubscribeEvent
-    public void middleClickPre(PlayerInteractEvent.MiddleClick.Pre evt)
+    public void middleClickPre(PlayerInteractEvent.Pick.Pre evt)
     {
         if(!ENABLE) return;
         logger.info("RayTraceResult: {}", evt.getRayTraceResult());
@@ -168,7 +168,7 @@ public class PlayerInteractEventTest
     }
 
     @SubscribeEvent
-    public void middleClickPost(PlayerInteractEvent.MiddleClick.Post evt)
+    public void middleClickPost(PlayerInteractEvent.Pick.Post evt)
     {
         if(!ENABLE) return;
         logger.info("result stack: {} | RayTraceResult: {}", evt.getCurrentResult(), evt.getRayTraceResult());

--- a/src/test/java/net/minecraftforge/test/PlayerInteractEventTest.java
+++ b/src/test/java/net/minecraftforge/test/PlayerInteractEventTest.java
@@ -16,7 +16,6 @@ import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.event.entity.player.PlayerInteractEvent;
 import net.minecraftforge.fml.common.Mod;
 import net.minecraftforge.fml.common.Mod.EventHandler;
-import net.minecraftforge.fml.common.event.FMLInitializationEvent;
 import net.minecraftforge.fml.common.event.FMLPreInitializationEvent;
 import net.minecraftforge.fml.common.eventhandler.Event;
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
@@ -160,15 +159,15 @@ public class PlayerInteractEventTest
     public void pick(PlayerInteractEvent.Pick evt)
     {
         if(!ENABLE) return;
-        logger.info("result stack: {} | RayTraceResult: {}", evt.getCurrentResult(), evt.getRayTraceResult());
+        logger.info("result stack: {} | RayTraceResult: {}", evt.getResultStack(), evt.getTarget());
 
-        if(evt.getRayTraceResult().typeOfHit == RayTraceResult.Type.ENTITY && evt.getRayTraceResult().entityHit instanceof EntityHorse)
+        if(evt.getTarget().typeOfHit == RayTraceResult.Type.ENTITY && evt.getTarget().entityHit instanceof EntityHorse)
             // Middle click a horse and don't get a spawn egg
             evt.setCanceled(true);
 
-        if(evt.getRayTraceResult().typeOfHit == RayTraceResult.Type.BLOCK && evt.getWorld().getBlockState(evt.getPos()).getBlock() == Blocks.BONE_BLOCK)
+        if(evt.getTarget().typeOfHit == RayTraceResult.Type.BLOCK && evt.getWorld().getBlockState(evt.getPos()).getBlock() == Blocks.BONE_BLOCK)
             // Get a baked potato when middle click a bone block
-            evt.setCurrentResult(new ItemStack(Items.BAKED_POTATO));
+            evt.setResultStack(new ItemStack(Items.BAKED_POTATO));
     }
 
 }

--- a/src/test/java/net/minecraftforge/test/PlayerInteractEventTest.java
+++ b/src/test/java/net/minecraftforge/test/PlayerInteractEventTest.java
@@ -157,13 +157,13 @@ public class PlayerInteractEventTest
     }
 
     @SubscribeEvent
-    public void middleClickPre(PlayerInteractEvent.Pick evt)
+    public void pick(PlayerInteractEvent.Pick evt)
     {
         if(!ENABLE) return;
         logger.info("result stack: {} | RayTraceResult: {}", evt.getCurrentResult(), evt.getRayTraceResult());
 
         if(evt.getRayTraceResult().typeOfHit == RayTraceResult.Type.ENTITY && evt.getRayTraceResult().entityHit instanceof EntityHorse)
-            // Middle click a horse and  don't get a spawn egg
+            // Middle click a horse and don't get a spawn egg
             evt.setCanceled(true);
 
         if(evt.getRayTraceResult().typeOfHit == RayTraceResult.Type.BLOCK && evt.getWorld().getBlockState(evt.getPos()).getBlock() == Blocks.BONE_BLOCK)

--- a/src/test/java/net/minecraftforge/test/PlayerInteractEventTest.java
+++ b/src/test/java/net/minecraftforge/test/PlayerInteractEventTest.java
@@ -4,11 +4,14 @@ import net.minecraft.entity.item.EntityArmorStand;
 import net.minecraft.entity.monster.EntityCreeper;
 import net.minecraft.entity.monster.EntitySkeleton;
 import net.minecraft.entity.passive.EntityHorse;
+import net.minecraft.init.Blocks;
 import net.minecraft.init.Items;
+import net.minecraft.item.ItemStack;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.tileentity.TileEntityChest;
 import net.minecraft.tileentity.TileEntityDropper;
 import net.minecraft.util.EnumHand;
+import net.minecraft.util.math.RayTraceResult;
 import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.event.entity.player.PlayerInteractEvent;
 import net.minecraftforge.fml.common.Mod;
@@ -152,4 +155,27 @@ public class PlayerInteractEventTest
             // Applies to both hands
             evt.setCanceled(true);
     }
+
+    @SubscribeEvent
+    public void middleClickPre(PlayerInteractEvent.MiddleClick.Pre evt)
+    {
+        if(!ENABLE) return;
+        logger.info("RayTraceResult: {}", evt.getRayTraceResult());
+
+        if(evt.getRayTraceResult().typeOfHit == RayTraceResult.Type.ENTITY && evt.getRayTraceResult().entityHit instanceof EntityHorse)
+            // Middle click a horse and  don't get a spawn egg
+            evt.setCanceled(true);
+    }
+
+    @SubscribeEvent
+    public void middleClickPost(PlayerInteractEvent.MiddleClick.Post evt)
+    {
+        if(!ENABLE) return;
+        logger.info("result stack: {} | RayTraceResult: {}", evt.getCurrentResult(), evt.getRayTraceResult());
+
+        if(evt.getRayTraceResult().typeOfHit == RayTraceResult.Type.BLOCK && evt.getWorld().getBlockState(evt.getPos()).getBlock() == Blocks.BONE_BLOCK)
+            // Get a baked potato when middle click a bone block
+            evt.setCurrentResult(new ItemStack(Items.BAKED_POTATO));
+    }
+
 }


### PR DESCRIPTION
Like the title says, this pr adds a event if the middle mouse button gets pressed.
It is triggered on the client side only, but the result can be modified so that it gets send to the server.
You can cancel the event so there is no more analyzing for the result or set a new result stack.