### PR TITLE
Make getRGBDurabilityForDisplay use getDurabilityForDisplay by default

### DIFF
--- a/patches/minecraft/net/minecraft/item/Item.java.patch
+++ b/patches/minecraft/net/minecraft/item/Item.java.patch
@@ -454,7 +454,7 @@
 +     * Queries the percentage of the 'Durability' bar that should be drawn.
 +     *
 +     * @param stack The current ItemStack
-+     * @return 1.0 for 100% 0 for 0%
++     * @return 0.0 for 100% (no damage / full bar), 1.0 for 0% (fully damaged / empty bar)
 +     */
 +    public double getDurabilityForDisplay(ItemStack stack)
 +    {
@@ -463,14 +463,14 @@
 +
 +    /**
 +     * Returns the packed int RGB value used to render the durability bar in the GUI.
-+     * Defaults to a value based on the hue scaled as the damage decreases, but can be overriden.
++     * Defaults to a value based on the hue scaled based on {@link #getDurabilityForDisplay}, but can be overriden.
 +     *
 +     * @param stack Stack to get durability from
 +     * @return A packed RGB value for the durability colour (0x00RRGGBB)
 +     */
 +    public int getRGBDurabilityForDisplay(ItemStack stack)
 +    {
-+        return MathHelper.func_181758_c(Math.max(0.0F, (float)(stack.func_77958_k() - stack.func_77952_i()) / stack.func_77958_k()) / 3.0F, 1.0F, 1.0F);
++        return MathHelper.func_181758_c(Math.max(0.0F, (float) (1.0F - getDurabilityForDisplay(stack))) / 3.0F, 1.0F, 1.0F);
 +    }
 +    /**
 +     * Return the maxDamage for this ItemStack. Defaults to the maxDamage field in this item,


### PR DESCRIPTION
Closes #3670

getRGBDurabilityForDisplay checks the stack meta directly instead of calling to getDurabilityForDisplay meaning items that override the second are forced to override the first to have properly colored bars

also, fixed an incorrect comment on getDurabilityForDisplay, no functional change