### PR TITLE
[1.11.2] Added in UseShovelEvent

### DIFF
--- a/patches/minecraft/net/minecraft/item/ItemSpade.java.patch
+++ b/patches/minecraft/net/minecraft/item/ItemSpade.java.patch
@@ -1,0 +1,12 @@
+--- ../src-base/minecraft/net/minecraft/item/ItemSpade.java
++++ ../src-work/minecraft/net/minecraft/item/ItemSpade.java
+@@ -40,6 +40,9 @@
+         }
+         else
+         {
++            int hook = net.minecraftforge.event.ForgeEventFactory.onShovelUse(itemstack, p_180614_1_, p_180614_2_, p_180614_3_);
++            if (hook != 0) return hook > 0 ? EnumActionResult.SUCCESS : EnumActionResult.FAIL;
++
+             IBlockState iblockstate = p_180614_2_.func_180495_p(p_180614_3_);
+             Block block = iblockstate.func_177230_c();
+ 

--- a/patches/minecraft/net/minecraft/item/ItemSpade.java.patch
+++ b/patches/minecraft/net/minecraft/item/ItemSpade.java.patch
@@ -1,12 +1,11 @@
 --- ../src-base/minecraft/net/minecraft/item/ItemSpade.java
 +++ ../src-work/minecraft/net/minecraft/item/ItemSpade.java
-@@ -40,6 +40,9 @@
+@@ -40,6 +40,8 @@
          }
          else
          {
 +            int hook = net.minecraftforge.event.ForgeEventFactory.onShovelUse(itemstack, p_180614_1_, p_180614_2_, p_180614_3_);
 +            if (hook != 0) return hook > 0 ? EnumActionResult.SUCCESS : EnumActionResult.FAIL;
-+
              IBlockState iblockstate = p_180614_2_.func_180495_p(p_180614_3_);
              Block block = iblockstate.func_177230_c();
  

--- a/src/main/java/net/minecraftforge/event/ForgeEventFactory.java
+++ b/src/main/java/net/minecraftforge/event/ForgeEventFactory.java
@@ -100,6 +100,7 @@ import net.minecraftforge.event.entity.player.PlayerSleepInBedEvent;
 import net.minecraftforge.event.entity.player.PlayerWakeUpEvent;
 import net.minecraftforge.event.entity.player.SleepingLocationCheckEvent;
 import net.minecraftforge.event.entity.player.UseHoeEvent;
+import net.minecraftforge.event.entity.player.UseShovelEvent;
 import net.minecraftforge.event.terraingen.ChunkGeneratorEvent;
 import net.minecraftforge.event.terraingen.PopulateChunkEvent;
 import net.minecraftforge.event.world.BlockEvent;
@@ -342,6 +343,18 @@ public class ForgeEventFactory
     public static int onHoeUse(ItemStack stack, EntityPlayer player, World worldIn, BlockPos pos)
     {
         UseHoeEvent event = new UseHoeEvent(player, stack, worldIn, pos);
+        if (MinecraftForge.EVENT_BUS.post(event)) return -1;
+        if (event.getResult() == Result.ALLOW)
+        {
+            stack.damageItem(1, player);
+            return 1;
+        }
+        return 0;
+    }
+
+    public static int onShovelUse(ItemStack stack, EntityPlayer player, World worldIn, BlockPos pos)
+    {
+        UseShovelEvent event = new UseShovelEvent(player, stack, worldIn, pos);
         if (MinecraftForge.EVENT_BUS.post(event)) return -1;
         if (event.getResult() == Result.ALLOW)
         {

--- a/src/main/java/net/minecraftforge/event/entity/player/UseShovelEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/player/UseShovelEvent.java
@@ -1,0 +1,72 @@
+/*
+ * Minecraft Forge
+ * Copyright (c) 2016.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation version 2.1
+ * of the License.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+package net.minecraftforge.event.entity.player;
+
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.item.ItemStack;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.World;
+import net.minecraftforge.fml.common.eventhandler.Cancelable;
+import net.minecraftforge.fml.common.eventhandler.Event;
+
+import javax.annotation.Nonnull;
+
+/**
+ * This event is fired when a player attempts to use a Shovel on a block, it
+ * can be canceled to completely prevent any further processing.
+ *
+ * You can also set the result to ALLOW to mark the event as processed
+ * and damage the shovel.
+ *
+ * setResult(ALLOW) is the same as the old setHandled();
+ */
+@Cancelable
+@Event.HasResult
+public class UseShovelEvent extends PlayerEvent
+{
+
+    private final ItemStack current;
+    private final World world;
+    private final BlockPos pos;
+
+    public UseShovelEvent(EntityPlayer player, @Nonnull ItemStack current, World world, BlockPos pos)
+    {
+        super(player);
+        this.current = current;
+        this.world = world;
+        this.pos = pos;
+    }
+
+    @Nonnull
+    public ItemStack getCurrent()
+    {
+        return current;
+    }
+
+    public World getWorld()
+    {
+        return world;
+    }
+
+    public BlockPos getPos()
+    {
+        return pos;
+    }
+}


### PR DESCRIPTION
This will allow custom logic to run when a Shovel is used to create a Grass Path. This works just like the UseHoeEvent.

Examples:
Cancel turning Grass into a Grass Path
Place a custom Path block