### PR TITLE
Add a null check for the throwable message in NetWorkDispatcher#exceptionCaught

### DIFF
--- a/src/main/java/net/minecraftforge/fml/common/network/handshake/NetworkDispatcher.java
+++ b/src/main/java/net/minecraftforge/fml/common/network/handshake/NetworkDispatcher.java
@@ -583,7 +583,7 @@ public class NetworkDispatcher extends SimpleChannelInboundHandler<Packet<?>> im
         if (!(cause instanceof ClosedChannelException))
         {
             // Mute the reset by peer exception - it's disconnection noise
-            if (cause.getMessage().contains("Connection reset by peer"))
+            if (cause.getMessage() != null && cause.getMessage().contains("Connection reset by peer"))
             {
                 FMLLog.log(Level.DEBUG, cause, "Muted NetworkDispatcher exception");
             }


### PR DESCRIPTION
Some Netty exceptions, such as `ReadTimeoutException`, have no associated message. Adding a null check prevents even more log noise due to a `NullPointerException` being thrown from an exception handler.