### PR TITLE
Fix crash when using ReflectionHelper#findMethod on sided methods with lambdas. Also Close #3676

### DIFF
--- a/src/main/java/net/minecraftforge/fml/common/registry/FMLControlledNamespacedRegistry.java
+++ b/src/main/java/net/minecraftforge/fml/common/registry/FMLControlledNamespacedRegistry.java
@@ -121,7 +121,7 @@ public class FMLControlledNamespacedRegistry<I extends IForgeRegistryEntry<I>> e
     {
         try
         {
-            ReflectionHelper.findMethod(BitSet.class, this.availabilityMap, new String[]{"trimToSize"}).invoke(this.availabilityMap);
+            ReflectionHelper.findMethod(BitSet.class, "trimToSize", "trimToSize").invoke(this.availabilityMap);
         }
         catch (Exception e)
         {

--- a/src/main/java/net/minecraftforge/fml/common/registry/FMLControlledNamespacedRegistry.java
+++ b/src/main/java/net/minecraftforge/fml/common/registry/FMLControlledNamespacedRegistry.java
@@ -121,7 +121,7 @@ public class FMLControlledNamespacedRegistry<I extends IForgeRegistryEntry<I>> e
     {
         try
         {
-            ReflectionHelper.findMethod(BitSet.class, "trimToSize", "trimToSize").invoke(this.availabilityMap);
+            ReflectionHelper.findMethod(BitSet.class, "trimToSize", null).invoke(this.availabilityMap);
         }
         catch (Exception e)
         {

--- a/src/main/java/net/minecraftforge/fml/relauncher/ReflectionHelper.java
+++ b/src/main/java/net/minecraftforge/fml/relauncher/ReflectionHelper.java
@@ -18,6 +18,11 @@
  */
 package net.minecraftforge.fml.relauncher;
 
+import com.google.common.base.Preconditions;
+import net.minecraft.launchwrapper.Launch;
+import org.apache.commons.lang3.StringUtils;
+
+import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
@@ -38,6 +43,11 @@ public class ReflectionHelper
         {
             super(failed);
             //this.methodNames = methodNames;
+        }
+
+        public UnableToFindMethodException(Throwable failed)
+        {
+            super(failed);
         }
 
     }
@@ -170,10 +180,13 @@ public class ReflectionHelper
         throw new UnableToFindClassException(classNames, err);
     }
 
-
+    /**
+     * @deprecated use {@link #findMethod(Class, String, String, Class[])}
+     */
+    @Deprecated
     public static <E> Method findMethod(Class<? super E> clazz, E instance, String[] methodNames, Class<?>... methodTypes)
     {
-        Exception failed = null;
+        Throwable failed = null;
         for (String methodName : methodNames)
         {
             try
@@ -186,7 +199,50 @@ public class ReflectionHelper
             {
                 failed = e;
             }
+            catch (LinkageError e)
+            {
+                failed = e;
+            }
         }
-        throw new UnableToFindMethodException(methodNames, failed);
+        throw new UnableToFindMethodException(failed);
+    }
+
+    /**
+     * Finds a method with the specified name and parameters in the given class and makes it accessible.
+     * Note: for performance, store the returned value and avoid calling this repeatedly.
+     * <p>
+     * Throws an exception if the method is not found.
+     *
+     * @param clazz          The class to find the method on.
+     * @param methodName     The name of the method to find (used in developer environments, i.e. "getWorldTime").
+     * @param methodObfName  The obfuscated name of the method to find (used in obfuscated environments, i.e. "func_72820_D").
+     *                       If the name you are looking for is on a class that is never obfuscated, this should equal methodName.
+     * @param parameterTypes The parameter types of the method to find.
+     * @return The method with the specified name and parameters in the given class.
+     */
+    @Nonnull
+    public static Method findMethod(@Nonnull Class<?> clazz, @Nonnull String methodName, @Nonnull String methodObfName, Class<?>... parameterTypes)
+    {
+        Preconditions.checkNotNull(clazz);
+        Preconditions.checkArgument(StringUtils.isNotEmpty(methodName), "Method name cannot be empty");
+        Preconditions.checkArgument(StringUtils.isNotEmpty(methodObfName), "Obfuscated Method name cannot be empty");
+
+        Throwable failed;
+        String nameToFind = (Boolean) Launch.blackboard.get("fml.deobfuscatedEnvironment") ? methodName : methodObfName;
+        try
+        {
+            Method m = clazz.getDeclaredMethod(nameToFind, parameterTypes);
+            m.setAccessible(true);
+            return m;
+        }
+        catch (Exception e)
+        {
+            failed = e;
+        }
+        catch (LinkageError e)
+        {
+            failed = e;
+        }
+        throw new UnableToFindMethodException(failed);
     }
 }

--- a/src/main/java/net/minecraftforge/fml/relauncher/ReflectionHelper.java
+++ b/src/main/java/net/minecraftforge/fml/relauncher/ReflectionHelper.java
@@ -199,10 +199,6 @@ public class ReflectionHelper
             {
                 failed = e;
             }
-            catch (LinkageError e)
-            {
-                failed = e;
-            }
         }
         throw new UnableToFindMethodException(failed);
     }
@@ -216,19 +212,27 @@ public class ReflectionHelper
      * @param clazz          The class to find the method on.
      * @param methodName     The name of the method to find (used in developer environments, i.e. "getWorldTime").
      * @param methodObfName  The obfuscated name of the method to find (used in obfuscated environments, i.e. "func_72820_D").
-     *                       If the name you are looking for is on a class that is never obfuscated, this should equal methodName.
+     *                       If the name you are looking for is on a class that is never obfuscated, this should be null.
      * @param parameterTypes The parameter types of the method to find.
      * @return The method with the specified name and parameters in the given class.
      */
     @Nonnull
-    public static Method findMethod(@Nonnull Class<?> clazz, @Nonnull String methodName, @Nonnull String methodObfName, Class<?>... parameterTypes)
+    public static Method findMethod(@Nonnull Class<?> clazz, @Nonnull String methodName, @Nullable String methodObfName, Class<?>... parameterTypes)
     {
         Preconditions.checkNotNull(clazz);
         Preconditions.checkArgument(StringUtils.isNotEmpty(methodName), "Method name cannot be empty");
-        Preconditions.checkArgument(StringUtils.isNotEmpty(methodObfName), "Obfuscated Method name cannot be empty");
+
+        String nameToFind;
+        if (methodObfName == null || (Boolean) Launch.blackboard.get("fml.deobfuscatedEnvironment"))
+        {
+            nameToFind = methodName;
+        }
+        else
+        {
+            nameToFind = methodObfName;
+        }
 
         Throwable failed;
-        String nameToFind = (Boolean) Launch.blackboard.get("fml.deobfuscatedEnvironment") ? methodName : methodObfName;
         try
         {
             Method m = clazz.getDeclaredMethod(nameToFind, parameterTypes);
@@ -236,10 +240,6 @@ public class ReflectionHelper
             return m;
         }
         catch (Exception e)
-        {
-            failed = e;
-        }
-        catch (LinkageError e)
         {
             failed = e;
         }

--- a/src/main/java/net/minecraftforge/fml/relauncher/ReflectionHelper.java
+++ b/src/main/java/net/minecraftforge/fml/relauncher/ReflectionHelper.java
@@ -232,7 +232,6 @@ public class ReflectionHelper
             nameToFind = methodObfName;
         }
 
-        Throwable failed;
         try
         {
             Method m = clazz.getDeclaredMethod(nameToFind, parameterTypes);
@@ -241,8 +240,7 @@ public class ReflectionHelper
         }
         catch (Exception e)
         {
-            failed = e;
+            throw new UnableToFindMethodException(e);
         }
-        throw new UnableToFindMethodException(failed);
     }
 }


### PR DESCRIPTION
`net.minecraftforge.fml.relauncher.ReflectionHelper#findMethod(java.lang.Class<? super E>, E, java.lang.String[], java.lang.Class<?>...)` 
throws an unexpected exception when looking for a class marked `@SideOnly` when that method has a lamda in it. 

This catches the exception and throws an `UnableToFindMethodException` instead.

Since I was there I added an improved version of `findMethod` to address #3676 and other concerns brought up in the MinecraftForge IRC channel.