### PR TITLE
Fix Forge setting for baby zombie chance.

### DIFF
--- a/patches/minecraft/net/minecraft/entity/monster/EntityZombie.java.patch
+++ b/patches/minecraft/net/minecraft/entity/monster/EntityZombie.java.patch
@@ -56,3 +56,12 @@
                              entityzombie.func_180482_a(this.field_70170_p.func_175649_E(new BlockPos(entityzombie)), (IEntityLivingData)null);
                              this.func_110148_a(field_110186_bp).func_111121_a(new AttributeModifier("Zombie reinforcement caller charge", -0.05000000074505806D, 0));
                              entityzombie.func_110148_a(field_110186_bp).func_111121_a(new AttributeModifier("Zombie reinforcement callee charge", -0.05000000074505806D, 0));
+@@ -435,7 +447,7 @@
+ 
+         if (p_180482_2_ == null)
+         {
+-            p_180482_2_ = new EntityZombie.GroupData(this.field_70170_p.field_73012_v.nextFloat() < 0.05F);
++            p_180482_2_ = new EntityZombie.GroupData(this.field_70170_p.field_73012_v.nextFloat() < net.minecraftforge.common.ForgeModContainer.zombieBabyChance);
+         }
+ 
+         if (p_180482_2_ instanceof EntityZombie.GroupData)


### PR DESCRIPTION
Fixes #3690.
This got deleted in the 1.11 update, due to being tucked in with the removed zombie villager logic.
It's correctly remade here.