### PR TITLE
Fix custom array entry class for config GUI being ignored when adding new entries

### DIFF
--- a/src/main/java/net/minecraftforge/fml/client/FMLConfigGuiFactory.java
+++ b/src/main/java/net/minecraftforge/fml/client/FMLConfigGuiFactory.java
@@ -34,6 +34,8 @@ import net.minecraft.client.resources.I18n;
 import net.minecraftforge.fml.client.config.ConfigGuiType;
 import net.minecraftforge.fml.client.config.DummyConfigElement;
 import net.minecraftforge.fml.client.config.GuiConfig;
+import net.minecraftforge.fml.client.config.GuiEditArray;
+import net.minecraftforge.fml.client.config.GuiEditArrayEntries;
 import net.minecraftforge.fml.client.config.IConfigElement;
 import net.minecraftforge.fml.client.config.DummyConfigElement.DummyCategoryElement;
 import net.minecraftforge.fml.client.config.DummyConfigElement.DummyListElement;
@@ -79,7 +81,8 @@ public class FMLConfigGuiFactory implements IModGuiFactory
             listsList.add(new DummyListElement("stringListFixed", new String[] {"A", "fixed", "length", "array", "of", "string", "values"}, ConfigGuiType.STRING, "fml.config.sample.stringListFixed", true));
             listsList.add(new DummyListElement("stringListMax", new String[] {"An", "array", "of", "string", "values", "with", "a", "max", "length", "of", "15"}, ConfigGuiType.STRING, "fml.config.sample.stringListMax", 15));
             listsList.add(new DummyListElement("stringListPattern", new String[] {"Valid", "Not Valid", "Is, Valid", "Comma, Separated, Value"}, ConfigGuiType.STRING, "fml.config.sample.stringListPattern", commaDelimitedPattern));
-            
+            listsList.add(new DummyListElement("stringListCustom", new Object[0], ConfigGuiType.STRING, "fml.config.sample.stringListCustom").setArrayEntryClass(CustomArrayEntry.class));
+
             list.add(new DummyCategoryElement("lists", "fml.config.sample.ctgy.lists", listsList));
             
             // Strings category
@@ -102,6 +105,21 @@ public class FMLConfigGuiFactory implements IModGuiFactory
             list.add(new DummyCategoryElement("numbers", "fml.config.sample.ctgy.numbers", numbersList));
             
             return list;
+        }
+    }
+
+    public static class CustomArrayEntry extends GuiEditArrayEntries.StringEntry
+    {
+        public CustomArrayEntry(GuiEditArray owningScreen, GuiEditArrayEntries owningEntryList, IConfigElement configElement, Object value)
+        {
+            super(owningScreen, owningEntryList, configElement, value);
+        }
+
+        @Override
+        public void drawEntry(int slotIndex, int x, int y, int listWidth, int slotHeight, int mouseX, int mouseY, boolean isSelected)
+        {
+            textFieldValue.setTextColor((int) (Math.random() * 0xFFFFFF));
+            super.drawEntry(slotIndex, x, y, listWidth, slotHeight, mouseX, mouseY, isSelected);
         }
     }
 

--- a/src/main/java/net/minecraftforge/fml/client/config/GuiEditArrayEntries.java
+++ b/src/main/java/net/minecraftforge/fml/client/config/GuiEditArrayEntries.java
@@ -132,7 +132,36 @@ public class GuiEditArrayEntries extends GuiListExtended
 
     public void addNewEntry(int index)
     {
-        if (configElement.isList() && configElement.getType() == ConfigGuiType.BOOLEAN)
+        if (configElement.isList() && configElement.getArrayEntryClass() != null)
+        {
+            Class<? extends IArrayEntry> clazz = configElement.getArrayEntryClass();
+            try
+            {
+                Object value;
+                switch(configElement.getType())
+                {
+                    case BOOLEAN:
+                        value = true;
+                        break;
+                    case INTEGER:
+                        value = 0;
+                        break;
+                    case DOUBLE:
+                        value = 0.0D;
+                        break;
+                    default:
+                        value = "";
+                        break;
+                }
+                listEntries.add(index, clazz.getConstructor(GuiEditArray.class, GuiEditArrayEntries.class, IConfigElement.class, Object.class).newInstance(this.owningGui, this, configElement, value));
+            }
+            catch (Throwable e)
+            {
+                FMLLog.severe("There was a critical error instantiating the custom IGuiEditListEntry for property %s.", configElement.getName());
+                e.printStackTrace();
+            }
+        }
+        else if (configElement.isList() && configElement.getType() == ConfigGuiType.BOOLEAN)
             listEntries.add(index, new BooleanEntry(this.owningGui, this, this.configElement, true));
         else if (configElement.isList() && configElement.getType() == ConfigGuiType.INTEGER)
             listEntries.add(index, new IntegerEntry(this.owningGui, this, this.configElement, 0));

--- a/src/main/java/net/minecraftforge/fml/client/config/GuiEditArrayEntries.java
+++ b/src/main/java/net/minecraftforge/fml/client/config/GuiEditArrayEntries.java
@@ -31,6 +31,7 @@ import net.minecraft.util.text.TextFormatting;
 import net.minecraftforge.fml.client.config.GuiConfigEntries.ArrayEntry;
 import net.minecraftforge.fml.common.FMLLog;
 
+import org.apache.logging.log4j.Level;
 import org.lwjgl.input.Keyboard;
 
 import static net.minecraftforge.fml.client.config.GuiUtils.INVALID;
@@ -80,8 +81,7 @@ public class GuiEditArrayEntries extends GuiListExtended
                 }
                 catch (Throwable e)
                 {
-                    FMLLog.severe("There was a critical error instantiating the custom IGuiEditListEntry for property %s.", configElement.getName());
-                    e.printStackTrace();
+                    FMLLog.log(Level.ERROR, e, "There was a critical error instantiating the custom IGuiEditListEntry for property %s.", configElement.getName());
                 }
             }
         }
@@ -138,7 +138,7 @@ public class GuiEditArrayEntries extends GuiListExtended
             try
             {
                 Object value;
-                switch(configElement.getType())
+                switch (configElement.getType())
                 {
                     case BOOLEAN:
                         value = true;
@@ -151,14 +151,12 @@ public class GuiEditArrayEntries extends GuiListExtended
                         break;
                     default:
                         value = "";
-                        break;
                 }
                 listEntries.add(index, clazz.getConstructor(GuiEditArray.class, GuiEditArrayEntries.class, IConfigElement.class, Object.class).newInstance(this.owningGui, this, configElement, value));
             }
             catch (Throwable e)
             {
-                FMLLog.severe("There was a critical error instantiating the custom IGuiEditListEntry for property %s.", configElement.getName());
-                e.printStackTrace();
+                FMLLog.log(Level.ERROR, e, "There was a critical error instantiating the custom IGuiEditListEntry for property %s.", configElement.getName());
             }
         }
         else if (configElement.isList() && configElement.getType() == ConfigGuiType.BOOLEAN)

--- a/src/main/resources/assets/forge/lang/en_US.lang
+++ b/src/main/resources/assets/forge/lang/en_US.lang
@@ -133,6 +133,7 @@ fml.config.sample.stringListMax.tooltip=A string list that has a max length of 1
 fml.config.sample.stringListMax=Max Length String List
 fml.config.sample.stringListPattern.tooltip=A string list that validates each value using a Pattern object.
 fml.config.sample.stringListPattern=Pattern Validated String List
+fml.config.sample.stringListCustom=Custom Entry List
 fml.config.sample.title=This is for playing with the Config GUI behavior. Changes are not saved.
 
 fml.configgui.applyGlobally=Apply globally


### PR DESCRIPTION
Previously, when you set a custom array entry class for a list element in a config screen (via `IConfigElement.getArrayEntryClass`), it would only respect this for values that already existed in the list.

Newly added values (via the plus button in the GUI) would get the default entry classes based on their `ConfigGuiType`, since unlike the [constructor](https://github.com/MinecraftForge/MinecraftForge/blob/1.11.x/src/main/java/net/minecraftforge/fml/client/config/GuiEditArrayEntries.java#L71-L87), `addNewEntry` [didn't check for the custom class](https://github.com/MinecraftForge/MinecraftForge/blob/1.11.x/src/main/java/net/minecraftforge/fml/client/config/GuiEditArrayEntries.java#L133-L146) at all.

This PR fixes that issue and also adds a list with a custom array entry class to the FML sample config screen, for testing.