### PR TITLE
Fix extracted mods crash report file name for Windows

### DIFF
--- a/src/main/java/net/minecraftforge/fml/relauncher/CoreModManager.java
+++ b/src/main/java/net/minecraftforge/fml/relauncher/CoreModManager.java
@@ -310,7 +310,7 @@ public class CoreModManager {
             {
                 Class<?> crashreportclass = classLoader.loadClass("b");
                 Object crashreport = crashreportclass.getMethod("a", Throwable.class, String.class).invoke(null, re, "FML has discovered extracted jar files in the mods directory.\nThis breaks mod loading functionality completely.\nRemove the directories and replace with the jar files originally provided.");
-                File crashreportfile = new File(new File(coreMods.getParentFile(),"crash-reports"),String.format("fml-crash-%1$tY-%1$tm-%1$td_%1$tT.txt",Calendar.getInstance()));
+                File crashreportfile = new File(new File(coreMods.getParentFile(),"crash-reports"),String.format("fml-crash-%1$tY-%1$tm-%1$td_%1$tH.%1$tM.%1$tS.txt",Calendar.getInstance()));
                 crashreportclass.getMethod("a",File.class).invoke(crashreport, crashreportfile);
                 System.out.println("#@!@# FML has crashed the game deliberately. Crash report saved to: #@!@# " + crashreportfile.getAbsolutePath());
             } catch (Exception e)


### PR DESCRIPTION
When FML finds extracted mods in `CoreModManager`, it crashes the game and saves the crash report to **crash-reports/fml-crash-\<year>-\<month>-\<day>_\<hour>:\<minute>:\<second>.txt**.

Windows doesn't allow colons in file names, so the crash report saving fails with a `FileNotFoundException` that says `The filename, directory name, or volume label syntax is incorrect`.

This pull request replaces the colons with dots, the same date format used by vanilla crash reports.

To reproduce this outside of the development environment, create a directory in **mods** and then create a **META-INF** directory inside of it. Shortly after launching, the game will crash with `java.lang.RuntimeException: Extracted mod jars found, loading will NOT continue` thrown from `CoreModManager#discoverCoreMods`.

When running Forge 1.11.2-13.20.0.2230 on Windows, a `FileNotFoundException` will be logged and the crash report won't be saved. When running the new version, no `FileNotFoundException` will be logged and the crash report will be successfully saved.

It's not possible to reproduce this inside of the development environment because `CoreModManager` uses the Notch names of the `CrashReport` class and its methods.