### PR TITLE
[1.11.2] Make AbstractSkeleton implementable by fixing limited access on getStepSound

### DIFF
--- a/src/main/resources/forge_at.cfg
+++ b/src/main/resources/forge_at.cfg
@@ -294,3 +294,12 @@ public net.minecraft.util.datafix.DataFixer field_188262_d # version
 
 # AbstractSkeleton
 protected net.minecraft.entity.monster.AbstractSkeleton func_190727_o()Lnet/minecraft/util/SoundEvent; # getStepSound - make AbstractSkeleton implementable
+
+# EntityWitherSkeleton
+protected net.minecraft.entity.monster.EntityWitherSkeleton func_190727_o()Lnet/minecraft/util/SoundEvent; # getStepSound - make AbstractSkeleton implementable
+
+# EntityStray
+protected net.minecraft.entity.monster.EntityStray func_190727_o()Lnet/minecraft/util/SoundEvent; # getStepSound - make AbstractSkeleton implementable
+
+# EntitySkeleton
+protected net.minecraft.entity.monster.EntitySkeleton func_190727_o()Lnet/minecraft/util/SoundEvent; # getStepSound - make AbstractSkeleton implementable

--- a/src/main/resources/forge_at.cfg
+++ b/src/main/resources/forge_at.cfg
@@ -291,3 +291,6 @@ public net.minecraft.tileentity.TileEntityHopper func_145896_c(I)V # setTransfer
 
 # DataFixer
 public net.minecraft.util.datafix.DataFixer field_188262_d # version
+
+# AbstractSkeleton
+protected net.minecraft.entity.monster.AbstractSkeleton func_190727_o()Lnet/minecraft/util/SoundEvent; # getStepSound - make AbstractSkeleton implementable


### PR DESCRIPTION
Since AbstractSkeleton is abstract, and getStepSound lacks any access level specifier, only classes within the net.minecraft.entity.monster package could extend the class, this PR to the forge AT allows anything outside that package to also extend it.