### PR TITLE
Create ItemFishedEvent

### DIFF
--- a/patches/minecraft/net/minecraft/entity/projectile/EntityFishHook.java.patch
+++ b/patches/minecraft/net/minecraft/entity/projectile/EntityFishHook.java.patch
@@ -1,0 +1,31 @@
+--- ../src-base/minecraft/net/minecraft/entity/projectile/EntityFishHook.java
++++ ../src-work/minecraft/net/minecraft/entity/projectile/EntityFishHook.java
+@@ -506,6 +506,7 @@
+         {
+             int i = 0;
+ 
++            net.minecraftforge.event.entity.player.ItemFishedEvent event = null;
+             if (this.field_146043_c != null)
+             {
+                 this.func_184527_k();
+@@ -516,8 +517,10 @@
+             {
+                 LootContext.Builder lootcontext$builder = new LootContext.Builder((WorldServer)this.field_70170_p);
+                 lootcontext$builder.func_186469_a((float)this.field_191518_aw + this.field_146042_b.func_184817_da());
++                event = new net.minecraftforge.event.entity.player.ItemFishedEvent(this.field_146042_b, this.field_70170_p.func_184146_ak().func_186521_a(LootTableList.field_186387_al).func_186462_a(this.field_70146_Z, lootcontext$builder.func_186471_a()), this.field_146051_au ? 2 : 1, field_70165_t, field_70163_u, field_70161_v);
++                net.minecraftforge.common.MinecraftForge.EVENT_BUS.post(event);
+ 
+-                for (ItemStack itemstack : this.field_70170_p.func_184146_ak().func_186521_a(LootTableList.field_186387_al).func_186462_a(this.field_70146_Z, lootcontext$builder.func_186471_a()))
++                for (ItemStack itemstack : event.stacks)
+                 {
+                     EntityItem entityitem = new EntityItem(this.field_70170_p, this.field_70165_t, this.field_70163_u, this.field_70161_v, itemstack);
+                     double d0 = this.field_146042_b.field_70165_t - this.field_70165_t;
+@@ -547,7 +550,7 @@
+             }
+ 
+             this.func_70106_y();
+-            return i;
++            return event == null ? i : event.getRodDamage();
+         }
+         else
+         {

--- a/patches/minecraft/net/minecraft/entity/projectile/EntityFishHook.java.patch
+++ b/patches/minecraft/net/minecraft/entity/projectile/EntityFishHook.java.patch
@@ -12,7 +12,7 @@
              {
                  LootContext.Builder lootcontext$builder = new LootContext.Builder((WorldServer)this.field_70170_p);
                  lootcontext$builder.func_186469_a((float)this.field_191518_aw + this.field_146042_b.func_184817_da());
-+                event = new net.minecraftforge.event.entity.player.ItemFishedEvent(this.field_146042_b, this.field_70170_p.func_184146_ak().func_186521_a(LootTableList.field_186387_al).func_186462_a(this.field_70146_Z, lootcontext$builder.func_186471_a()), this.field_146051_au ? 2 : 1, field_70165_t, field_70163_u, field_70161_v);
++                event = new net.minecraftforge.event.entity.player.ItemFishedEvent(this.field_70170_p.func_184146_ak().func_186521_a(LootTableList.field_186387_al).func_186462_a(this.field_70146_Z, lootcontext$builder.func_186471_a()), this.field_146051_au ? 2 : 1, this);
 +                net.minecraftforge.common.MinecraftForge.EVENT_BUS.post(event);
  
 -                for (ItemStack itemstack : this.field_70170_p.func_184146_ak().func_186521_a(LootTableList.field_186387_al).func_186462_a(this.field_70146_Z, lootcontext$builder.func_186471_a()))

--- a/patches/minecraft/net/minecraft/entity/projectile/EntityFishHook.java.patch
+++ b/patches/minecraft/net/minecraft/entity/projectile/EntityFishHook.java.patch
@@ -16,7 +16,7 @@
 +                net.minecraftforge.common.MinecraftForge.EVENT_BUS.post(event);
  
 -                for (ItemStack itemstack : this.field_70170_p.func_184146_ak().func_186521_a(LootTableList.field_186387_al).func_186462_a(this.field_70146_Z, lootcontext$builder.func_186471_a()))
-+                for (ItemStack itemstack : event.stacks)
++                for (ItemStack itemstack : event.getItemStacks())
                  {
                      EntityItem entityitem = new EntityItem(this.field_70170_p, this.field_70165_t, this.field_70163_u, this.field_70161_v, itemstack);
                      double d0 = this.field_146042_b.field_70165_t - this.field_70165_t;

--- a/patches/minecraft/net/minecraft/entity/projectile/EntityFishHook.java.patch
+++ b/patches/minecraft/net/minecraft/entity/projectile/EntityFishHook.java.patch
@@ -8,20 +8,25 @@
              if (this.field_146043_c != null)
              {
                  this.func_184527_k();
-@@ -516,8 +517,11 @@
+@@ -516,8 +517,16 @@
              {
                  LootContext.Builder lootcontext$builder = new LootContext.Builder((WorldServer)this.field_70170_p);
                  lootcontext$builder.func_186469_a((float)this.field_191518_aw + this.field_146042_b.func_184817_da());
 +                List<ItemStack> result = this.field_70170_p.func_184146_ak().func_186521_a(LootTableList.field_186387_al).func_186462_a(this.field_70146_Z, lootcontext$builder.func_186471_a());
 +                event = new net.minecraftforge.event.entity.player.ItemFishedEvent(result, this.field_146051_au ? 2 : 1, this);
 +                net.minecraftforge.common.MinecraftForge.EVENT_BUS.post(event);
++                if (event.isCanceled())
++                {
++                    this.func_70106_y();
++                    return event.getRodDamage();
++                }
  
 -                for (ItemStack itemstack : this.field_70170_p.func_184146_ak().func_186521_a(LootTableList.field_186387_al).func_186462_a(this.field_70146_Z, lootcontext$builder.func_186471_a()))
 +                for (ItemStack itemstack : result)
                  {
                      EntityItem entityitem = new EntityItem(this.field_70170_p, this.field_70165_t, this.field_70163_u, this.field_70161_v, itemstack);
                      double d0 = this.field_146042_b.field_70165_t - this.field_70165_t;
-@@ -547,7 +551,7 @@
+@@ -547,7 +556,7 @@
              }
  
              this.func_70106_y();

--- a/patches/minecraft/net/minecraft/entity/projectile/EntityFishHook.java.patch
+++ b/patches/minecraft/net/minecraft/entity/projectile/EntityFishHook.java.patch
@@ -8,19 +8,20 @@
              if (this.field_146043_c != null)
              {
                  this.func_184527_k();
-@@ -516,8 +517,10 @@
+@@ -516,8 +517,11 @@
              {
                  LootContext.Builder lootcontext$builder = new LootContext.Builder((WorldServer)this.field_70170_p);
                  lootcontext$builder.func_186469_a((float)this.field_191518_aw + this.field_146042_b.func_184817_da());
-+                event = new net.minecraftforge.event.entity.player.ItemFishedEvent(this.field_70170_p.func_184146_ak().func_186521_a(LootTableList.field_186387_al).func_186462_a(this.field_70146_Z, lootcontext$builder.func_186471_a()), this.field_146051_au ? 2 : 1, this);
++                List<ItemStack> result = this.field_70170_p.func_184146_ak().func_186521_a(LootTableList.field_186387_al).func_186462_a(this.field_70146_Z, lootcontext$builder.func_186471_a());
++                event = new net.minecraftforge.event.entity.player.ItemFishedEvent(result, this.field_146051_au ? 2 : 1, this);
 +                net.minecraftforge.common.MinecraftForge.EVENT_BUS.post(event);
  
 -                for (ItemStack itemstack : this.field_70170_p.func_184146_ak().func_186521_a(LootTableList.field_186387_al).func_186462_a(this.field_70146_Z, lootcontext$builder.func_186471_a()))
-+                for (ItemStack itemstack : event.getItemStacks())
++                for (ItemStack itemstack : result)
                  {
                      EntityItem entityitem = new EntityItem(this.field_70170_p, this.field_70165_t, this.field_70163_u, this.field_70161_v, itemstack);
                      double d0 = this.field_146042_b.field_70165_t - this.field_70165_t;
-@@ -547,7 +550,7 @@
+@@ -547,7 +551,7 @@
              }
  
              this.func_70106_y();

--- a/src/main/java/net/minecraftforge/event/entity/player/ItemFishedEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/player/ItemFishedEvent.java
@@ -29,15 +29,12 @@ import java.util.List;
 
 /**
  * This event is called when a player fishes an item.
- * You can change the items the player will get using {@link #getItemStacks()}
- * You can also change the damage the rod will take using {@link #setRodDamage(int)}
- * You can use {@link #getHookEntity()} to get stuff based on the entity, like {@link EntityFishHook#fishApproachAngle}
  *
  * This event is not {@link net.minecraftforge.fml.common.eventhandler.Cancelable}
  */
 public class ItemFishedEvent extends PlayerEvent
 {
-    private final List<ItemStack> stacks = NonNullList.create();
+    private final NonNullList<ItemStack> stacks = NonNullList.create();
     private final EntityFishHook hook;
     private int rodDamage;
 
@@ -60,7 +57,7 @@ public class ItemFishedEvent extends PlayerEvent
 
     /**
      * Set the damage the fishing rod will take
-     * @param rodDamage The damage the rod will take. Must be greater or equals zero
+     * @param rodDamage The damage the rod will take. Must be positive
      */
     public void setRodDamage(@Nonnegative int rodDamage)
     {
@@ -69,9 +66,11 @@ public class ItemFishedEvent extends PlayerEvent
     }
 
     /**
-     * Use this to set the items the player will get
+     * Use this to get the items the player will receive.
+     * You cannot use this to modify the ItemStacks the player will get.
+     * If you want to affect the loot, you should use LootTables
      */
-    public List<ItemStack> getItemStacks()
+    public NonNullList<ItemStack> getItemStacks()
     {
         return stacks;
     }

--- a/src/main/java/net/minecraftforge/event/entity/player/ItemFishedEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/player/ItemFishedEvent.java
@@ -30,22 +30,15 @@ import java.util.List;
 
 /**
  * This event is called when a player fishes an item.
- * You can change the items the player will get using {@link #stacks}
+ * You can change the items the player will get using {@link #getItemStacks()}
  * You can also change the damage the rod will take using {@link #setRodDamage(int)}
- *
- * <b>Do not change the BlockPos {@link #pos}.</b> It should only be used to determine the position of the rod
+ * The BlockPos {@link #getPos()} can be used to determine the position of the rod
  *
  * This event is not {@link net.minecraftforge.fml.common.eventhandler.Cancelable}
  */
 public class ItemFishedEvent extends PlayerEvent {
-    /**
-     * Use this to set the items the player will get
-     */
-    public final List<ItemStack> stacks = NonNullList.create();
-    /**
-     * Use this to determine the position of the rod
-     */
-    public final BlockPos pos;
+    private final List<ItemStack> stacks = NonNullList.create();
+    private final BlockPos pos;
     private int rodDamage;
 
     public ItemFishedEvent (EntityPlayer player, List<ItemStack> stacks, int rodDamage, double posX, double posY, double posZ)
@@ -73,5 +66,21 @@ public class ItemFishedEvent extends PlayerEvent {
     {
         Preconditions.checkArgument(rodDamage >= 0);
         this.rodDamage = rodDamage;
+    }
+
+    /**
+     * Use this to set the items the player will get
+     */
+    public List<ItemStack> getItemStacks()
+    {
+        return stacks;
+    }
+
+    /**
+     * Use this to determine the position of the rod
+     */
+    public BlockPos getPos()
+    {
+        return pos;
     }
 }

--- a/src/main/java/net/minecraftforge/event/entity/player/ItemFishedEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/player/ItemFishedEvent.java
@@ -23,6 +23,7 @@ import com.google.common.base.Preconditions;
 import net.minecraft.entity.projectile.EntityFishHook;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.NonNullList;
+import net.minecraftforge.fml.common.eventhandler.Cancelable;
 
 import javax.annotation.Nonnegative;
 import java.util.List;
@@ -30,8 +31,11 @@ import java.util.List;
 /**
  * This event is called when a player fishes an item.
  *
- * This event is not {@link net.minecraftforge.fml.common.eventhandler.Cancelable}
+ * This event is {@link net.minecraftforge.fml.common.eventhandler.Cancelable}
+ * Canceling the event will cause the player to receive no items at all.
+ * The hook will still take the damage specified
  */
+@Cancelable
 public class ItemFishedEvent extends PlayerEvent
 {
     private final NonNullList<ItemStack> stacks = NonNullList.create();
@@ -47,7 +51,7 @@ public class ItemFishedEvent extends PlayerEvent
     }
 
     /**
-     * Get the damage the rod will take
+     * Get the damage the rod will take.
      * @return The damage the rod will take
      */
     public int getRodDamage()
@@ -56,10 +60,11 @@ public class ItemFishedEvent extends PlayerEvent
     }
 
     /**
-     * Set the damage the fishing rod will take
-     * @param rodDamage The damage the rod will take. Must be positive
+     * Specifies the amount of damage that the fishing rod should take.
+     * This is not added to the pre-existing damage to be taken.
+     * @param rodDamage The damage the rod will take. Must be nonnegative
      */
-    public void setRodDamage(@Nonnegative int rodDamage)
+    public void damageRodBy(@Nonnegative int rodDamage)
     {
         Preconditions.checkArgument(rodDamage >= 0);
         this.rodDamage = rodDamage;
@@ -67,16 +72,16 @@ public class ItemFishedEvent extends PlayerEvent
 
     /**
      * Use this to get the items the player will receive.
-     * You cannot use this to modify the ItemStacks the player will get.
-     * If you want to affect the loot, you should use LootTables
+     * You cannot use this to modify the drops the player will get.
+     * If you want to affect the loot, you should use LootTables.
      */
-    public NonNullList<ItemStack> getItemStacks()
+    public NonNullList<ItemStack> getDrops()
     {
         return stacks;
     }
 
     /**
-     * Use this to stuff related to the hook itself, like the position of the bobber
+     * Use this to stuff related to the hook itself, like the position of the bobber.
      */
     public EntityFishHook getHookEntity()
     {

--- a/src/main/java/net/minecraftforge/event/entity/player/ItemFishedEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/player/ItemFishedEvent.java
@@ -20,10 +20,9 @@
 package net.minecraftforge.event.entity.player;
 
 import com.google.common.base.Preconditions;
-import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.entity.projectile.EntityFishHook;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.NonNullList;
-import net.minecraft.util.math.BlockPos;
 
 import javax.annotation.Nonnegative;
 import java.util.List;
@@ -32,21 +31,21 @@ import java.util.List;
  * This event is called when a player fishes an item.
  * You can change the items the player will get using {@link #getItemStacks()}
  * You can also change the damage the rod will take using {@link #setRodDamage(int)}
- * The BlockPos {@link #getPos()} can be used to determine the position of the rod
+ * You can use {@link #getHookEntity()} to get stuff based on the entity, like {@link EntityFishHook#fishApproachAngle}
  *
  * This event is not {@link net.minecraftforge.fml.common.eventhandler.Cancelable}
  */
 public class ItemFishedEvent extends PlayerEvent {
     private final List<ItemStack> stacks = NonNullList.create();
-    private final BlockPos pos;
+    private final EntityFishHook hook;
     private int rodDamage;
 
-    public ItemFishedEvent (EntityPlayer player, List<ItemStack> stacks, int rodDamage, double posX, double posY, double posZ)
+    public ItemFishedEvent (List<ItemStack> stacks, int rodDamage, EntityFishHook hook)
     {
-        super(player);
+        super(hook.getAngler());
         this.stacks.addAll(stacks);
         this.rodDamage = rodDamage;
-        pos = new BlockPos(posX, posY, posZ);
+        this.hook = hook;
     }
 
     /**
@@ -77,10 +76,10 @@ public class ItemFishedEvent extends PlayerEvent {
     }
 
     /**
-     * Use this to determine the position of the rod
+     * Use this to stuff related to the hook itself, like the position of the bobber
      */
-    public BlockPos getPos()
+    public EntityFishHook getHookEntity()
     {
-        return pos;
+        return hook;
     }
 }

--- a/src/main/java/net/minecraftforge/event/entity/player/ItemFishedEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/player/ItemFishedEvent.java
@@ -35,12 +35,13 @@ import java.util.List;
  *
  * This event is not {@link net.minecraftforge.fml.common.eventhandler.Cancelable}
  */
-public class ItemFishedEvent extends PlayerEvent {
+public class ItemFishedEvent extends PlayerEvent
+{
     private final List<ItemStack> stacks = NonNullList.create();
     private final EntityFishHook hook;
     private int rodDamage;
 
-    public ItemFishedEvent (List<ItemStack> stacks, int rodDamage, EntityFishHook hook)
+    public ItemFishedEvent(List<ItemStack> stacks, int rodDamage, EntityFishHook hook)
     {
         super(hook.getAngler());
         this.stacks.addAll(stacks);
@@ -61,7 +62,7 @@ public class ItemFishedEvent extends PlayerEvent {
      * Set the damage the fishing rod will take
      * @param rodDamage The damage the rod will take. Must be greater or equals zero
      */
-    public void setRodDamage (@Nonnegative int rodDamage)
+    public void setRodDamage(@Nonnegative int rodDamage)
     {
         Preconditions.checkArgument(rodDamage >= 0);
         this.rodDamage = rodDamage;

--- a/src/main/java/net/minecraftforge/event/entity/player/ItemFishedEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/player/ItemFishedEvent.java
@@ -1,0 +1,77 @@
+/*
+ * Minecraft Forge
+ * Copyright (c) 2016.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation version 2.1
+ * of the License.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+package net.minecraftforge.event.entity.player;
+
+import com.google.common.base.Preconditions;
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.item.ItemStack;
+import net.minecraft.util.NonNullList;
+import net.minecraft.util.math.BlockPos;
+
+import javax.annotation.Nonnegative;
+import java.util.List;
+
+/**
+ * This event is called when a player fishes an item.
+ * You can change the items the player will get using {@link #stacks}
+ * You can also change the damage the rod will take using {@link #setRodDamage(int)}
+ *
+ * <b>Do not change the BlockPos {@link #pos}.</b> It should only be used to determine the position of the rod
+ *
+ * This event is not {@link net.minecraftforge.fml.common.eventhandler.Cancelable}
+ */
+public class ItemFishedEvent extends PlayerEvent {
+    /**
+     * Use this to set the items the player will get
+     */
+    public final List<ItemStack> stacks = NonNullList.create();
+    /**
+     * Use this to determine the position of the rod
+     */
+    public final BlockPos pos;
+    private int rodDamage;
+
+    public ItemFishedEvent (EntityPlayer player, List<ItemStack> stacks, int rodDamage, double posX, double posY, double posZ)
+    {
+        super(player);
+        this.stacks.addAll(stacks);
+        this.rodDamage = rodDamage;
+        pos = new BlockPos(posX, posY, posZ);
+    }
+
+    /**
+     * Get the damage the rod will take
+     * @return The damage the rod will take
+     */
+    public int getRodDamage()
+    {
+        return rodDamage;
+    }
+
+    /**
+     * Set the damage the fishing rod will take
+     * @param rodDamage The damage the rod will take. Must be greater or equals zero
+     */
+    public void setRodDamage (@Nonnegative int rodDamage)
+    {
+        Preconditions.checkArgument(rodDamage >= 0);
+        this.rodDamage = rodDamage;
+    }
+}

--- a/src/test/java/net/minecraftforge/test/ItemFishedTest.java
+++ b/src/test/java/net/minecraftforge/test/ItemFishedTest.java
@@ -11,7 +11,8 @@ import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
 import java.util.List;
 
 @Mod(modid = "itemfishtest", name = "ItemFishTest", version = "1.0.0")
-public class ItemFishedTest {
+public class ItemFishedTest
+{
 
     private static final boolean ENABLE = true;
 

--- a/src/test/java/net/minecraftforge/test/ItemFishedTest.java
+++ b/src/test/java/net/minecraftforge/test/ItemFishedTest.java
@@ -8,10 +8,12 @@ import net.minecraftforge.fml.common.Mod;
 import net.minecraftforge.fml.common.event.FMLInitializationEvent;
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
 
+import java.util.List;
+
 @Mod(modid = "itemfishtest", name = "ItemFishTest", version = "1.0.0")
 public class ItemFishedTest {
 
-    private static final boolean ENABLE = false;
+    private static final boolean ENABLE = true;
 
     @Mod.EventHandler
     public void onInit(FMLInitializationEvent event)
@@ -27,9 +29,10 @@ public class ItemFishedTest {
     public void onItemFished(ItemFishedEvent event)
     {
         System.out.println("Item fished");
-        event.stacks.clear();
-        event.stacks.add(new ItemStack(Items.SLIME_BALL, 2));
-        event.stacks.add(new ItemStack(Items.SNOWBALL, 3));
+        List<ItemStack> stacks = event.getItemStacks();
+        stacks.clear();
+        stacks.add(new ItemStack(Items.SLIME_BALL, 2));
+        stacks.add(new ItemStack(Items.SNOWBALL, 3));
         event.setRodDamage(50);
     }
 }

--- a/src/test/java/net/minecraftforge/test/ItemFishedTest.java
+++ b/src/test/java/net/minecraftforge/test/ItemFishedTest.java
@@ -1,15 +1,11 @@
 package net.minecraftforge.test;
 
-import net.minecraft.init.Items;
-import net.minecraft.item.ItemStack;
 import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.event.entity.player.ItemFishedEvent;
 import net.minecraftforge.fml.common.Mod;
 import net.minecraftforge.fml.common.event.FMLPreInitializationEvent;
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
 import org.apache.logging.log4j.Logger;
-
-import java.util.List;
 
 @Mod(modid = "itemfishtest", name = "ItemFishTest", version = "1.0.0")
 public class ItemFishedTest
@@ -33,10 +29,6 @@ public class ItemFishedTest
     public void onItemFished(ItemFishedEvent event)
     {
         logger.info("Item fished");
-        List<ItemStack> stacks = event.getItemStacks();
-        stacks.clear();
-        stacks.add(new ItemStack(Items.SLIME_BALL, 2));
-        stacks.add(new ItemStack(Items.SNOWBALL, 3));
         event.setRodDamage(50);
     }
 }

--- a/src/test/java/net/minecraftforge/test/ItemFishedTest.java
+++ b/src/test/java/net/minecraftforge/test/ItemFishedTest.java
@@ -5,8 +5,9 @@ import net.minecraft.item.ItemStack;
 import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.event.entity.player.ItemFishedEvent;
 import net.minecraftforge.fml.common.Mod;
-import net.minecraftforge.fml.common.event.FMLInitializationEvent;
+import net.minecraftforge.fml.common.event.FMLPreInitializationEvent;
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
+import org.apache.logging.log4j.Logger;
 
 import java.util.List;
 
@@ -14,14 +15,16 @@ import java.util.List;
 public class ItemFishedTest
 {
 
-    private static final boolean ENABLE = true;
+    private static final boolean ENABLE = false;
+    private static Logger logger;
 
     @Mod.EventHandler
-    public void onInit(FMLInitializationEvent event)
+    public void onInit(FMLPreInitializationEvent event)
     {
         if (ENABLE)
         {
-            System.out.println("Enabling Fishing Test mod");
+            logger = event.getModLog();
+            logger.info("Enabling Fishing Test mod");
             MinecraftForge.EVENT_BUS.register(this);
         }
     }
@@ -29,7 +32,7 @@ public class ItemFishedTest
     @SubscribeEvent
     public void onItemFished(ItemFishedEvent event)
     {
-        System.out.println("Item fished");
+        logger.info("Item fished");
         List<ItemStack> stacks = event.getItemStacks();
         stacks.clear();
         stacks.add(new ItemStack(Items.SLIME_BALL, 2));

--- a/src/test/java/net/minecraftforge/test/ItemFishedTest.java
+++ b/src/test/java/net/minecraftforge/test/ItemFishedTest.java
@@ -1,0 +1,35 @@
+package net.minecraftforge.test;
+
+import net.minecraft.init.Items;
+import net.minecraft.item.ItemStack;
+import net.minecraftforge.common.MinecraftForge;
+import net.minecraftforge.event.entity.player.ItemFishedEvent;
+import net.minecraftforge.fml.common.Mod;
+import net.minecraftforge.fml.common.event.FMLInitializationEvent;
+import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
+
+@Mod(modid = "itemfishtest", name = "ItemFishTest", version = "1.0.0")
+public class ItemFishedTest {
+
+    private static final boolean ENABLE = false;
+
+    @Mod.EventHandler
+    public void onInit(FMLInitializationEvent event)
+    {
+        if (ENABLE)
+        {
+            System.out.println("Enabling Fishing Test mod");
+            MinecraftForge.EVENT_BUS.register(this);
+        }
+    }
+
+    @SubscribeEvent
+    public void onItemFished(ItemFishedEvent event)
+    {
+        System.out.println("Item fished");
+        event.stacks.clear();
+        event.stacks.add(new ItemStack(Items.SLIME_BALL, 2));
+        event.stacks.add(new ItemStack(Items.SNOWBALL, 3));
+        event.setRodDamage(50);
+    }
+}

--- a/src/test/java/net/minecraftforge/test/ItemFishedTest.java
+++ b/src/test/java/net/minecraftforge/test/ItemFishedTest.java
@@ -1,5 +1,9 @@
 package net.minecraftforge.test;
 
+import net.minecraft.entity.projectile.EntityFishHook;
+import net.minecraft.init.Biomes;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.biome.Biome;
 import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.event.entity.player.ItemFishedEvent;
 import net.minecraftforge.fml.common.Mod;
@@ -28,7 +32,15 @@ public class ItemFishedTest
     @SubscribeEvent
     public void onItemFished(ItemFishedEvent event)
     {
-        logger.info("Item fished");
-        event.setRodDamage(50);
+        EntityFishHook hook = event.getHookEntity();
+        BlockPos bobberPos = hook.getPosition();
+        Biome biomeFishedAt = hook.getEntityWorld().getBiome(bobberPos);
+        logger.info("Item fished in Biome " + biomeFishedAt.getBiomeName());
+        if (biomeFishedAt.equals(Biomes.OCEAN))
+        {
+            logger.info("Canceling the event because biome is ocean");
+            event.setCanceled(true);
+        }
+        event.damageRodBy(50);
     }
 }


### PR DESCRIPTION
While you are able to add loot via loot tables, this event allows some new interaction:
-Keep track of custom achievments
-Only allow specific loot at specific locations or bioms (e.g some items should only be available when in biome = river)
-Set a custom durability when a specific item is pulled out (e.g you pull a "heavy" item and your rod looses 10 durability instead of one)
