### PR TITLE
Fixed TileEntity#getRenderBoundingBox

### DIFF
--- a/patches/minecraft/net/minecraft/tileentity/TileEntity.java.patch
+++ b/patches/minecraft/net/minecraft/tileentity/TileEntity.java.patch
@@ -164,7 +164,7 @@
 +            net.minecraft.util.math.AxisAlignedBB cbb = null;
 +            try
 +            {
-+                cbb = field_145850_b.func_180495_p(func_174877_v()).func_185890_d(field_145850_b, pos).func_72321_a(pos.func_177958_n(), pos.func_177956_o(), pos.func_177952_p());
++                cbb = field_145850_b.func_180495_p(func_174877_v()).func_185890_d(field_145850_b, pos).func_186670_a(pos);
 +            }
 +            catch (Exception e)
 +            {


### PR DESCRIPTION
The previously used method, `addCoord`, actually *extends* the bounding box to that coordinate. So since 1.9.4, this generated bounding boxes from (0,0,0) to the tile entity's position, meaning potentially a lot more tile entities were rendered than necessary. The proper method here is `offset`, which actually moves the bounding box to the tile entity's position.