### PR TITLE
Fix EntityFallingBlock check for ITileEntityProvider

### DIFF
--- a/patches/minecraft/net/minecraft/entity/item/EntityFallingBlock.java.patch
+++ b/patches/minecraft/net/minecraft/entity/item/EntityFallingBlock.java.patch
@@ -8,3 +8,12 @@
                      if (BlockFalling.func_185759_i(this.field_70170_p.func_180495_p(new BlockPos(this.field_70165_t, this.field_70163_u - 0.009999999776482582D, this.field_70161_v))))
                      {
                          this.field_70122_E = false;
+@@ -159,7 +160,7 @@
+                                     ((BlockFalling)block).func_176502_a_(this.field_70170_p, blockpos1);
+                                 }
+ 
+-                                if (this.field_145810_d != null && block instanceof ITileEntityProvider)
++                                if (this.field_145810_d != null && block.hasTileEntity(iblockstate))
+                                 {
+                                     TileEntity tileentity = this.field_70170_p.func_175625_s(blockpos1);
+ 

--- a/patches/minecraft/net/minecraft/entity/item/EntityFallingBlock.java.patch
+++ b/patches/minecraft/net/minecraft/entity/item/EntityFallingBlock.java.patch
@@ -13,7 +13,7 @@
                                  }
  
 -                                if (this.field_145810_d != null && block instanceof ITileEntityProvider)
-+                                if (this.field_145810_d != null && block.hasTileEntity(iblockstate))
++                                if (this.field_145810_d != null && block.hasTileEntity(this.field_175132_d))
                                  {
                                      TileEntity tileentity = this.field_70170_p.func_175625_s(blockpos1);
  


### PR DESCRIPTION
I'm not sure if it was an oversight, but EntityFallingBlock still requires its associated block to be an instance of ITileEntityProvider when assigning tileEntityData. This PR changes it to use Forge's better hasTileEntity alternative.