### PR TITLE
[1.11.2] Fix for bad decompile process on Particle.java for onGround flag and more

### DIFF
--- a/patches/minecraft/net/minecraft/client/particle/Particle.java.patch
+++ b/patches/minecraft/net/minecraft/client/particle/Particle.java.patch
@@ -1,0 +1,29 @@
+--- ../src-base/minecraft/net/minecraft/client/particle/Particle.java
++++ ../src-work/minecraft/net/minecraft/client/particle/Particle.java
+@@ -283,6 +283,8 @@
+     public void func_187110_a(double p_187110_1_, double p_187110_3_, double p_187110_5_)
+     {
+         double d0 = p_187110_3_;
++        double origX = p_187110_1_;
++        double origZ = p_187110_5_;
+ 
+         if (this.field_190017_n)
+         {
+@@ -315,14 +317,14 @@
+         }
+ 
+         this.func_187118_j();
+-        this.field_187132_l = p_187110_3_ != p_187110_3_ && d0 < 0.0D;
++        this.field_187132_l = d0 != p_187110_3_ && d0 < 0.0D;
+ 
+-        if (p_187110_1_ != p_187110_1_)
++        if (origX != p_187110_1_)
+         {
+             this.field_187129_i = 0.0D;
+         }
+ 
+-        if (p_187110_5_ != p_187110_5_)
++        if (origZ != p_187110_5_)
+         {
+             this.field_187131_k = 0.0D;
+         }


### PR DESCRIPTION
Fix for bad decompile process on Particle.java that causes onGround flag to not get set properly as well as motionX and motionZ not being set to 0 when their axis has collision happening. Restores functionality to how the bytecode shows it should be.

With this onGround flag should be usable, and if there were any super high velocity particles used in the game (vanilla or mods), this fix for the x and z axis check will improve performance as it will stop their high motion on the first tick instead of never and every tick continue to scan ahead for all collision AABBs.

I left d0 named as such to keep the patching to a minimum, but if it makes more sense to rename that to origY then I can adjust that.

I believe this issue exists in 1.10.2 as well.