### PR TITLE
Add LootTableManager to the LootTableLoadEvent

### DIFF
--- a/patches/minecraft/net/minecraft/world/storage/loot/LootTableManager.java.patch
+++ b/patches/minecraft/net/minecraft/world/storage/loot/LootTableManager.java.patch
@@ -5,7 +5,7 @@
                      try
                      {
 -                        return (LootTable)LootTableManager.field_186526_b.fromJson(s, LootTable.class);
-+                        return net.minecraftforge.common.ForgeHooks.loadLootTable(LootTableManager.field_186526_b, p_186517_1_, s, true);
++                        return net.minecraftforge.common.ForgeHooks.loadLootTable(LootTableManager.field_186526_b, p_186517_1_, s, true, LootTableManager.this);
                      }
                      catch (JsonParseException jsonparseexception)
                      {
@@ -14,7 +14,7 @@
                  try
                  {
 -                    return (LootTable)LootTableManager.field_186526_b.fromJson(s, LootTable.class);
-+                    return net.minecraftforge.common.ForgeHooks.loadLootTable(LootTableManager.field_186526_b, p_186518_1_, s, false);
++                    return net.minecraftforge.common.ForgeHooks.loadLootTable(LootTableManager.field_186526_b, p_186518_1_, s, false, LootTableManager.this);
                  }
                  catch (JsonParseException jsonparseexception)
                  {

--- a/src/main/java/net/minecraftforge/common/ForgeHooks.java
+++ b/src/main/java/net/minecraftforge/common/ForgeHooks.java
@@ -93,6 +93,7 @@ import net.minecraft.world.EnumDifficulty;
 import net.minecraft.world.GameType;
 import net.minecraft.world.storage.loot.LootEntry;
 import net.minecraft.world.storage.loot.LootTable;
+import net.minecraft.world.storage.loot.LootTableManager;
 import net.minecraft.world.storage.loot.conditions.LootCondition;
 import net.minecraftforge.common.util.BlockSnapshot;
 import net.minecraftforge.event.AnvilUpdateEvent;
@@ -1092,13 +1093,21 @@ public class ForgeHooks
         LootTableContext ctx = lootContext.get().peek();
 
         if (ctx == null)
-            throw new JsonParseException("Invalid call stack, could to grab json context!"); // Show I throw this? Do we care about custom deserializers outside the manager?
+            throw new JsonParseException("Invalid call stack, could not grab json context!"); // Should I throw this? Do we care about custom deserializers outside the manager?
 
         return ctx;
     }
 
-    @Nullable
+    // TODO: remove
+    /** @deprecated use {@link ForgeHooks#loadLootTable(Gson, ResourceLocation, String, boolean, LootTableManager)} */
+    @Deprecated
     public static LootTable loadLootTable(Gson gson, ResourceLocation name, String data, boolean custom)
+    {
+        return loadLootTable(gson, name, data, custom, null);
+    }
+
+    @Nullable
+    public static LootTable loadLootTable(Gson gson, ResourceLocation name, String data, boolean custom, LootTableManager lootTableManager)
     {
         Deque<LootTableContext> que = lootContext.get();
         if (que == null)
@@ -1121,7 +1130,7 @@ public class ForgeHooks
         }
 
         if (!custom)
-            ret = ForgeEventFactory.loadLootTable(name, ret);
+            ret = ForgeEventFactory.loadLootTable(name, ret, lootTableManager);
 
         if (ret != null)
             ret.freeze();

--- a/src/main/java/net/minecraftforge/event/ForgeEventFactory.java
+++ b/src/main/java/net/minecraftforge/event/ForgeEventFactory.java
@@ -637,6 +637,15 @@ public class ForgeEventFactory
         MinecraftForge.EVENT_BUS.post(pre ? new PopulateChunkEvent.Pre(gen, world, rand, x, z, hasVillageGenerated) : new PopulateChunkEvent.Post(gen, world, rand, x, z, hasVillageGenerated));
     }
 
+    /**
+     * @deprecated Use {@link #loadLootTable(ResourceLocation, LootTable, LootTableManager)}<br>
+     */
+    @Deprecated
+    public static LootTable loadLootTable(ResourceLocation name, LootTable table)
+    {
+        return loadLootTable(name, table, null);
+    }
+
     public static LootTable loadLootTable(ResourceLocation name, LootTable table, LootTableManager lootTableManager)
     {
         LootTableLoadEvent event = new LootTableLoadEvent(name, table, lootTableManager);

--- a/src/main/java/net/minecraftforge/event/ForgeEventFactory.java
+++ b/src/main/java/net/minecraftforge/event/ForgeEventFactory.java
@@ -64,6 +64,7 @@ import net.minecraft.world.chunk.IChunkGenerator;
 import net.minecraft.world.storage.IPlayerFileData;
 import net.minecraft.world.storage.SaveHandler;
 import net.minecraft.world.storage.loot.LootTable;
+import net.minecraft.world.storage.loot.LootTableManager;
 import net.minecraftforge.client.event.ClientChatReceivedEvent;
 import net.minecraftforge.client.event.RenderBlockOverlayEvent;
 import net.minecraftforge.client.event.RenderBlockOverlayEvent.OverlayType;
@@ -636,9 +637,9 @@ public class ForgeEventFactory
         MinecraftForge.EVENT_BUS.post(pre ? new PopulateChunkEvent.Pre(gen, world, rand, x, z, hasVillageGenerated) : new PopulateChunkEvent.Post(gen, world, rand, x, z, hasVillageGenerated));
     }
 
-    public static LootTable loadLootTable(ResourceLocation name, LootTable table)
+    public static LootTable loadLootTable(ResourceLocation name, LootTable table, LootTableManager lootTableManager)
     {
-        LootTableLoadEvent event = new LootTableLoadEvent(name, table);
+        LootTableLoadEvent event = new LootTableLoadEvent(name, table, lootTableManager);
         if (MinecraftForge.EVENT_BUS.post(event))
             return LootTable.EMPTY_LOOT_TABLE;
         return event.getTable();

--- a/src/main/java/net/minecraftforge/event/LootTableLoadEvent.java
+++ b/src/main/java/net/minecraftforge/event/LootTableLoadEvent.java
@@ -41,6 +41,14 @@ public class LootTableLoadEvent extends Event
     private LootTable table;
     private LootTableManager lootTableManager;
 
+    /**
+     * @deprecated Use {@link #LootTableLoadEvent(ResourceLocation, LootTable, LootTableManager)}<br>
+     */
+    @Deprecated
+    public LootTableLoadEvent(ResourceLocation name, LootTable table) {
+        this(name, table, null);
+    }
+
     public LootTableLoadEvent(ResourceLocation name, LootTable table, LootTableManager lootTableManager)
     {
         this.name = name;

--- a/src/main/java/net/minecraftforge/event/LootTableLoadEvent.java
+++ b/src/main/java/net/minecraftforge/event/LootTableLoadEvent.java
@@ -21,6 +21,7 @@ package net.minecraftforge.event;
 
 import net.minecraft.util.ResourceLocation;
 import net.minecraft.world.storage.loot.LootTable;
+import net.minecraft.world.storage.loot.LootTableManager;
 import net.minecraftforge.fml.common.eventhandler.Cancelable;
 import net.minecraftforge.fml.common.eventhandler.Event;
 
@@ -38,11 +39,13 @@ public class LootTableLoadEvent extends Event
 {
     private final ResourceLocation name;
     private LootTable table;
+    private LootTableManager lootTableManager;
 
-    public LootTableLoadEvent(ResourceLocation name, LootTable table)
+    public LootTableLoadEvent(ResourceLocation name, LootTable table, LootTableManager lootTableManager)
     {
         this.name = name;
         this.table = table;
+        this.lootTableManager = lootTableManager;
     }
 
     public ResourceLocation getName()
@@ -53,6 +56,11 @@ public class LootTableLoadEvent extends Event
     public LootTable getTable()
     {
         return this.table;
+    }
+
+    public LootTableManager getLootTableManager()
+    {
+        return this.lootTableManager;
     }
 
     public void setTable(LootTable table)

--- a/src/test/java/net/minecraftforge/test/LootTableLoadEventTest.java
+++ b/src/test/java/net/minecraftforge/test/LootTableLoadEventTest.java
@@ -1,0 +1,32 @@
+package net.minecraftforge.test;
+
+import net.minecraft.util.ResourceLocation;
+import net.minecraft.world.storage.loot.LootTable;
+import net.minecraft.world.storage.loot.LootTableList;
+import net.minecraftforge.common.MinecraftForge;
+import net.minecraftforge.event.LootTableLoadEvent;
+import net.minecraftforge.fml.common.Mod;
+import net.minecraftforge.fml.common.Mod.EventHandler;
+import net.minecraftforge.fml.common.event.FMLInitializationEvent;
+import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
+
+@Mod(modid = LootTableLoadEventTest.MODID, name = "LootTableLoadEventTest", version = "1.0", acceptableRemoteVersions = "*")
+public class LootTableLoadEventTest {
+    public static final String MODID = "loottable_load_event_test";
+
+    @EventHandler
+    public void init(FMLInitializationEvent event)
+    {
+        MinecraftForge.EVENT_BUS.register(this);
+    }
+
+    @SubscribeEvent
+    public void onLootTableLoadEvent(LootTableLoadEvent event)
+    {
+        if (LootTableList.CHESTS_SPAWN_BONUS_CHEST.equals(event.getName())) {
+            ResourceLocation loc = new ResourceLocation(MODID,"chests/custom_spawn_bonus_chest");
+            LootTable customLootTable = event.getLootTableManager().getLootTableFromLocation(loc);
+            event.setTable(customLootTable);
+        }
+    }
+}

--- a/src/test/resources/assets/loottable_load_event_test/loot_tables/chests/custom_spawn_bonus_chest.json
+++ b/src/test/resources/assets/loottable_load_event_test/loot_tables/chests/custom_spawn_bonus_chest.json
@@ -1,0 +1,146 @@
+{
+    "pools": [
+        {
+            "name": "custom-spawn-chest-1",
+            "rolls": 1,
+            "entries": [
+                {
+                    "type": "item",
+                    "name": "minecraft:diamond_axe",
+                    "weight": 1
+                },
+                {
+                    "type": "item",
+                    "name": "minecraft:iron_axe",
+                    "weight": 3
+                }
+            ]
+        },
+        {
+            "name": "custom-spawn-chest-2",
+            "rolls": 1,
+            "entries": [
+                {
+                    "type": "item",
+                    "name": "minecraft:diamond_pickaxe",
+                    "weight": 1
+                },
+                {
+                    "type": "item",
+                    "name": "minecraft:iron_pickaxe",
+                    "weight": 3
+                }
+            ]
+        },
+        {
+            "name": "custom-spawn-chest-3",
+            "rolls": 3,
+            "entries": [
+                {
+                    "type": "item",
+                    "name": "minecraft:golden_apple",
+                    "weight": 5,
+                    "functions": [
+                        {
+                            "function": "minecraft:set_count",
+                            "count": {
+                                "min": 1,
+                                "max": 2
+                            }
+                        }
+                    ]
+                },
+                {
+                    "type": "item",
+                    "name": "minecraft:beef",
+                    "weight": 3,
+                    "functions": [
+                        {
+                            "function": "minecraft:set_count",
+                            "count": {
+                                "min": 1,
+                                "max": 2
+                            }
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "name": "custom-spawn-chest-4",
+            "rolls": 4,
+            "entries": [
+                {
+                    "type": "item",
+                    "name": "minecraft:stick",
+                    "weight": 10,
+                    "functions": [
+                        {
+                            "function": "minecraft:set_count",
+                            "count": {
+                                "min": 1,
+                                "max": 24
+                            }
+                        }
+                    ]
+                },
+                {
+                    "type": "item",
+                    "name": "minecraft:planks",
+                    "weight": 10,
+                    "functions": [
+                        {
+                            "function": "minecraft:set_count",
+                            "count": {
+                                "min": 1,
+                                "max": 24
+                            }
+                        }
+                    ]
+                },
+                {
+                    "type": "item",
+                    "name": "minecraft:log",
+                    "weight": 10,
+                    "functions": [
+                        {
+                            "function": "minecraft:set_count",
+                            "count": {
+                                "min": 1,
+                                "max": 3
+                            }
+                        },
+                        {
+                            "function": "minecraft:set_data",
+                            "data": {
+                                "min": 0,
+                                "max": 3
+                            }
+                        }
+                    ]
+                },
+                {
+                    "type": "item",
+                    "name": "minecraft:log2",
+                    "weight": 10,
+                    "functions": [
+                        {
+                            "function": "minecraft:set_count",
+                            "count": {
+                                "min": 1,
+                                "max": 3
+                            }
+                        },
+                        {
+                            "function": "minecraft:set_data",
+                            "data": {
+                                "min": 0,
+                                "max": 1
+                            }
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
So that it is easier to create new `LootTable`s when handling the event. A small discussion that motivated this PR can be found here: http://www.minecraftforge.net/forum/topic/50767-access-to-loottablemanager-from-loottableloadevent/

Now, I'm not 100% sure this is the right way to do this. Any other options / ideas?