### PR TITLE
Fix loading screen keeping global LWJGL lock for too long when vsync is forced

### DIFF
--- a/src/main/java/net/minecraftforge/fml/client/SplashProgress.java
+++ b/src/main/java/net/minecraftforge/fml/client/SplashProgress.java
@@ -357,7 +357,11 @@ public class SplashProgress
                         clearGL();
                         setGL();
                     }
-                    Display.sync(100);
+                    try
+                    {
+                        Thread.sleep(10);
+                    }
+                    catch (InterruptedException ignored) { }
                 }
                 clearGL();
             }


### PR DESCRIPTION
When vsync is forced, either from the graphics card setting or with Optifine, the splash screen keeps the LWJGL global lock tied up for most of the time. ([details here](https://github.com/mezz/JustEnoughItems/issues/746#issuecomment-281959814))
This causes JEI's tooltip gathering at startup to take forever (15 minutes instead of 2 seconds) when a mod has a tooltip handler that checks for the Shift key, because checking the keyboard uses the same global LWJGL lock.