### PR TITLE
Fix an issue with cancelling BlockEvent.PlaceEvent

### DIFF
--- a/src/main/java/net/minecraftforge/common/ForgeHooks.java
+++ b/src/main/java/net/minecraftforge/common/ForgeHooks.java
@@ -811,7 +811,7 @@ public class ForgeHooks
         NBTTagCompound nbt = null;
         if (itemstack.getTagCompound() != null)
         {
-            nbt = (NBTTagCompound)itemstack.getTagCompound().copy();
+            nbt = itemstack.getTagCompound().copy();
         }
 
         if (!(itemstack.getItem() instanceof ItemBucket)) // if not bucket
@@ -830,11 +830,11 @@ public class ForgeHooks
             NBTTagCompound newNBT = null;
             if (itemstack.getTagCompound() != null)
             {
-                newNBT = (NBTTagCompound)itemstack.getTagCompound().copy();
+                newNBT = itemstack.getTagCompound().copy();
             }
-            net.minecraftforge.event.world.BlockEvent.PlaceEvent placeEvent = null;
+            BlockEvent.PlaceEvent placeEvent = null;
             @SuppressWarnings("unchecked")
-            List<net.minecraftforge.common.util.BlockSnapshot> blockSnapshots = (List<BlockSnapshot>)world.capturedBlockSnapshots.clone();
+            List<BlockSnapshot> blockSnapshots = (List<BlockSnapshot>)world.capturedBlockSnapshots.clone();
             world.capturedBlockSnapshots.clear();
 
             // make sure to set pre-placement item data for event
@@ -853,7 +853,7 @@ public class ForgeHooks
                 placeEvent = ForgeEventFactory.onPlayerBlockPlace(player, blockSnapshots.get(0), side, hand);
             }
 
-            if (placeEvent != null && (placeEvent.isCanceled()))
+            if (placeEvent != null && placeEvent.isCanceled())
             {
                 ret = EnumActionResult.FAIL; // cancel placement
                 // revert back all captured blocks

--- a/src/main/java/net/minecraftforge/common/ForgeHooks.java
+++ b/src/main/java/net/minecraftforge/common/ForgeHooks.java
@@ -30,6 +30,7 @@ import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import com.google.common.collect.Lists;
 import com.google.common.collect.Queues;
 import com.google.common.collect.Sets;
 import com.google.gson.Gson;
@@ -856,7 +857,7 @@ public class ForgeHooks
             {
                 ret = EnumActionResult.FAIL; // cancel placement
                 // revert back all captured blocks
-                for (net.minecraftforge.common.util.BlockSnapshot blocksnapshot : blockSnapshots)
+                for (BlockSnapshot blocksnapshot : Lists.reverse(blockSnapshots))
                 {
                     world.restoringBlockSnapshots = true;
                     blocksnapshot.restore(true, false);

--- a/src/test/java/net/minecraftforge/test/BlockPlaceEventTest.java
+++ b/src/test/java/net/minecraftforge/test/BlockPlaceEventTest.java
@@ -1,0 +1,26 @@
+package net.minecraftforge.test;
+
+import net.minecraft.init.Blocks;
+import net.minecraftforge.event.world.BlockEvent;
+import net.minecraftforge.fml.common.Mod;
+import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
+
+@Mod(modid = BlockPlaceEventTest.MOD_ID, name = "BlockPlaceEvent test mod", version = "1.0")
+@Mod.EventBusSubscriber
+public class BlockPlaceEventTest
+{
+    static final String MOD_ID = "block_place_event_test";
+    static final boolean ENABLED = false;
+
+    @SubscribeEvent
+    public static void onBlockPlaced(BlockEvent.PlaceEvent event)
+    {
+        if (!ENABLED) return;
+
+        if (event.getPlacedBlock().getBlock() == Blocks.CHEST
+                && event.getPlacedAgainst().getBlock() != Blocks.DIAMOND_BLOCK)
+        {
+            event.setCanceled(true);
+        }
+    }
+}


### PR DESCRIPTION
Fixes #3608.

The issue is caused by `ForgeHooks.onPlaceItemIntoWorld()`:

Block snapshots are set to be captured, then `itemstack.getItem().onItemUse()` is called.
*  `ItemBlock.onItemUse()` calls into 
*  `ItemBlock.placeBlockAt()`, which first calls
    *  `World.setBlockState()` and then
    *  `Block.onBlockPlacedBy()`.

`BlockChest.onBlockPlacedBy()`, and possibly other overrides, calls `World.setBlockState()` itself.

This means that multiple block snapshots are captured for a single block placement.

Later in the method, the event is checked to see if it was cancelled, and if so, the captured block snapshots are reverted.

However, currently the snapshots are reverted in the same order as they were captured in. This causes issues, particularly if there are multiple captured snapshots for a single block position (as is the case for placing a chest).

This PR changes the method to instead revert block snapshots in the reverse order, producing the correct final state.

A test mod is also included. When enabled, chests should only be able to be placed against diamond blocks.