### PR TITLE
Adding saving and config GUIs to the @Config based configuration System

### DIFF
--- a/src/main/java/net/minecraftforge/client/gui/ForgeGuiFactory.java
+++ b/src/main/java/net/minecraftforge/client/gui/ForgeGuiFactory.java
@@ -105,6 +105,9 @@ public class ForgeGuiFactory implements IModGuiFactory
 
     @Override
     public GuiScreen mainConfigGui(GuiScreen parent) { return new ForgeConfigGui(parent); }
+    
+    @Override
+    public Class<? extends GuiScreen> mainConfigGuiClass() { return null; }
 
     @Override
     public Set<RuntimeOptionCategoryElement> runtimeGuiCategories() { return null; }

--- a/src/main/java/net/minecraftforge/client/gui/ForgeGuiFactory.java
+++ b/src/main/java/net/minecraftforge/client/gui/ForgeGuiFactory.java
@@ -102,6 +102,10 @@ public class ForgeGuiFactory implements IModGuiFactory
 {
     @Override
     public void initialize(Minecraft minecraftInstance) {}
+    
+
+    @Override
+    public boolean hasConfigGui() {return true;}
 
     @Override
     public GuiScreen createConfigGui(GuiScreen parent) { return new ForgeConfigGui(parent); }

--- a/src/main/java/net/minecraftforge/client/gui/ForgeGuiFactory.java
+++ b/src/main/java/net/minecraftforge/client/gui/ForgeGuiFactory.java
@@ -105,7 +105,7 @@ public class ForgeGuiFactory implements IModGuiFactory
     
 
     @Override
-    public boolean hasConfigGui() {return true;}
+    public boolean hasConfigGui() { return true; }
 
     @Override
     public GuiScreen createConfigGui(GuiScreen parent) { return new ForgeConfigGui(parent); }

--- a/src/main/java/net/minecraftforge/client/gui/ForgeGuiFactory.java
+++ b/src/main/java/net/minecraftforge/client/gui/ForgeGuiFactory.java
@@ -104,7 +104,7 @@ public class ForgeGuiFactory implements IModGuiFactory
     public void initialize(Minecraft minecraftInstance) {}
 
     @Override
-    public Class<? extends GuiScreen> mainConfigGuiClass() { return ForgeConfigGui.class; }
+    public GuiScreen mainConfigGui(GuiScreen parent) { return new ForgeConfigGui(parent); }
 
     @Override
     public Set<RuntimeOptionCategoryElement> runtimeGuiCategories() { return null; }

--- a/src/main/java/net/minecraftforge/client/gui/ForgeGuiFactory.java
+++ b/src/main/java/net/minecraftforge/client/gui/ForgeGuiFactory.java
@@ -104,7 +104,7 @@ public class ForgeGuiFactory implements IModGuiFactory
     public void initialize(Minecraft minecraftInstance) {}
 
     @Override
-    public GuiScreen mainConfigGui(GuiScreen parent) { return new ForgeConfigGui(parent); }
+    public GuiScreen createConfigGui(GuiScreen parent) { return new ForgeConfigGui(parent); }
     
     @Override
     public Class<? extends GuiScreen> mainConfigGuiClass() { return null; }

--- a/src/main/java/net/minecraftforge/common/ForgeModContainer.java
+++ b/src/main/java/net/minecraftforge/common/ForgeModContainer.java
@@ -421,7 +421,7 @@ public class ForgeModContainer extends DummyModContainer implements WorldAccessC
 
         NetworkRegistry.INSTANCE.register(this, this.getClass(), "*", evt.getASMHarvestedData());
         ForgeNetworkHandler.registerChannel(this, evt.getSide());
-        ConfigManager.load(this.getModId(), Config.Type.INSTANCE);
+        ConfigManager.sync(this.getModId(), Config.Type.INSTANCE);
     }
 
     @Subscribe

--- a/src/main/java/net/minecraftforge/common/config/Config.java
+++ b/src/main/java/net/minecraftforge/common/config/Config.java
@@ -66,7 +66,7 @@ public @interface Config
     }
 
     @Retention(RetentionPolicy.RUNTIME)
-    @Target(ElementType.FIELD)
+    @Target({ElementType.FIELD, ElementType.TYPE})
     public @interface LangKey
     {
         String value();

--- a/src/main/java/net/minecraftforge/common/config/Config.java
+++ b/src/main/java/net/minecraftforge/common/config/Config.java
@@ -101,4 +101,14 @@ public @interface Config
     {
         String value();
     }
+    
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target({ElementType.FIELD, ElementType.TYPE})
+    public @interface RequiresMcRestart
+    {}
+    
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target({ElementType.FIELD, ElementType.TYPE})
+    public @interface RequiresWorldRestart
+    {}
 }

--- a/src/main/java/net/minecraftforge/common/config/ConfigCategory.java
+++ b/src/main/java/net/minecraftforge/common/config/ConfigCategory.java
@@ -348,6 +348,8 @@ public class ConfigCategory implements Map<String, Property>
                 char type = prop.getType().getID();
                 write(out, pad1, String.valueOf(type), ":", propName, "=", prop.getString());
             }
+            
+            prop.resetChangedState();
         }
 
         if (children.size() > 0)

--- a/src/main/java/net/minecraftforge/common/config/ConfigElement.java
+++ b/src/main/java/net/minecraftforge/common/config/ConfigElement.java
@@ -27,9 +27,11 @@ package net.minecraftforge.common.config;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Set;
 import java.util.regex.Pattern;
 
 import net.minecraftforge.fml.client.config.ConfigGuiType;
+import net.minecraftforge.fml.client.config.DummyConfigElement.DummyCategoryElement;
 import net.minecraftforge.fml.client.config.GuiConfigEntries.IConfigEntry;
 import net.minecraftforge.fml.client.config.GuiEditArrayEntries.IArrayEntry;
 import net.minecraftforge.fml.client.config.IConfigElement;
@@ -359,5 +361,27 @@ public class ConfigElement implements IConfigElement
     public Object getMaxValue()
     {
         return isProperty ? prop.getMaxValue() : null;
+    }
+    
+    public static List<IConfigElement> getConfigElementsFromConfigManager(String modid)
+    {
+        Configuration config = ConfigManager.getConfiguration(modid);
+        Set<String> categoryNames = config.getCategoryNames();
+        if(categoryNames.size() == 1)
+        {
+            return new ConfigElement(config.getCategory(categoryNames.iterator().next())).getChildElements();
+        }
+        else
+        {
+            List<IConfigElement> elements = new ArrayList<IConfigElement>();
+            for(String name : categoryNames)
+            {
+                ConfigCategory category = config.getCategory(name);
+                String languageKey = category.getLanguagekey();
+                List<IConfigElement> children = new ConfigElement(category).getChildElements();
+                elements.add(new DummyCategoryElement(name, languageKey, children));
+            }
+            return elements;
+        }
     }
 }

--- a/src/main/java/net/minecraftforge/common/config/ConfigElement.java
+++ b/src/main/java/net/minecraftforge/common/config/ConfigElement.java
@@ -374,11 +374,11 @@ public class ConfigElement implements IConfigElement
     public static IConfigElement from(Class<?> configClass)
     {
         Config annotation = configClass.getAnnotation(Config.class);
-        if(annotation == null)
+        if (annotation == null)
             throw new RuntimeException(String.format("The class '%s' has no @Config annotation!", configClass.getName()));
         
         Configuration config = ConfigManager.getConfiguration(annotation.modid(), annotation.name());
-        if(config == null)
+        if (config == null)
         {
             String error = String.format("The configuration '%s' of mod '%s' isn't loaded with the ConfigManager!", annotation.name(), annotation.modid());
             throw new RuntimeException(error);
@@ -387,18 +387,18 @@ public class ConfigElement implements IConfigElement
         String name = Strings.isNullOrEmpty(annotation.name()) ? annotation.modid() : annotation.name();
         String langKey = name;
         Config.LangKey langKeyAnnotation = configClass.getAnnotation(Config.LangKey.class);
-        if(langKeyAnnotation != null)
+        if (langKeyAnnotation != null)
         {
             langKey = langKeyAnnotation.value();
         }
          
-        if(annotation.category().isEmpty())
+        if (annotation.category().isEmpty())
         {
             List<IConfigElement> elements = Lists.newArrayList();
             Set<String> catNames = config.getCategoryNames();
-            for(String catName : catNames)
+            for (String catName : catNames)
             {
-                if(catName.isEmpty())
+                if (catName.isEmpty())
                     continue;
                 ConfigCategory category = config.getCategory(catName);
                 DummyCategoryElement element = new DummyCategoryElement(category.getName(), category.getLanguagekey(), new ConfigElement(category).getChildElements());

--- a/src/main/java/net/minecraftforge/common/config/ConfigElement.java
+++ b/src/main/java/net/minecraftforge/common/config/ConfigElement.java
@@ -391,9 +391,8 @@ public class ConfigElement implements IConfigElement
         {
             langKey = langKeyAnnotation.value();
         }
-        
-        ConfigCategory category = config.getCategory(annotation.category());
-        if(category.getName().isEmpty())
+         
+        if(annotation.category().isEmpty())
         {
             List<IConfigElement> elements = Lists.newArrayList();
             Set<String> catNames = config.getCategoryNames();
@@ -401,13 +400,22 @@ public class ConfigElement implements IConfigElement
             {
                 if(catName.isEmpty())
                     continue;
-                category = config.getCategory(catName);
-                elements.add(new DummyCategoryElement(category.getName(), category.getLanguagekey(), new ConfigElement(category).getChildElements()));
+                ConfigCategory category = config.getCategory(catName);
+                DummyCategoryElement element = new DummyCategoryElement(category.getName(), category.getLanguagekey(), new ConfigElement(category).getChildElements());
+                element.setRequiresMcRestart(category.requiresMcRestart());
+                element.setRequiresWorldRestart(category.requiresWorldRestart());
+                elements.add(element);
             }
                 
             return new DummyCategoryElement(name, langKey, elements);
         }
         else
-            return new DummyCategoryElement(name, langKey, new ConfigElement(category).getChildElements());
+        {
+            ConfigCategory category = config.getCategory(annotation.category());
+            DummyCategoryElement element = new DummyCategoryElement(name, langKey, new ConfigElement(category).getChildElements());   
+            element.setRequiresMcRestart(category.requiresMcRestart());
+            element.setRequiresWorldRestart(category.requiresWorldRestart());
+            return element;
+        } 
     }
 }

--- a/src/main/java/net/minecraftforge/common/config/ConfigElement.java
+++ b/src/main/java/net/minecraftforge/common/config/ConfigElement.java
@@ -29,8 +29,6 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.regex.Pattern;
 
-import javax.annotation.Nullable;
-
 import net.minecraftforge.fml.client.config.ConfigGuiType;
 import net.minecraftforge.fml.client.config.GuiConfigEntries.IConfigEntry;
 import net.minecraftforge.fml.client.config.GuiEditArrayEntries.IArrayEntry;
@@ -363,39 +361,24 @@ public class ConfigElement implements IConfigElement
         return isProperty ? prop.getMaxValue() : null;
     }
     
-    public static ConfigElement from(String modid)
-    {
-        return from(modid, null);
-    }
-    
-    /**
-     * Provides a ConfigElement which contains
-     * @param modid
-     * @param name
-     * @return
-     */
-    public static ConfigElement from(String modid, @Nullable String name)
-    {
-        return from(modid, name, "general");//'general' is default in @Config annotation
-    }
-    
     /**
      * Provides a ConfigElement derived from the annotation-based config system
-     * @param modid The modid stated in the {@code @Config} annotation.
-     * @param name The name stated in the {@code @Config} annotation.
-     * @param categoryName The category name stated in the {@code @Config} annotation.
+     * @param configClass the class which contains the configuration
      * @return A ConfigElement based on the described category.
      */
-    public static ConfigElement from(String modid, @Nullable String name, @Nullable String categoryName)
+    public static ConfigElement from(Class<?> configClass)
     {
-        Configuration config = ConfigManager.getConfiguration(modid, name);
+        Config annotation = configClass.getAnnotation(Config.class);
+        if(annotation == null)
+            throw new RuntimeException(String.format("The class '%s' has no @Config annotation!", configClass.getName()));
+        Configuration config = ConfigManager.getConfiguration(annotation.modid(), annotation.name());
         if(config == null)
         {
-            String error = String.format("The configuration '%s' of mod '%s' is not handled by the ConfigManager!", name, modid);
+            String error = String.format("The configuration '%s' of mod '%s' isn't loaded with the ConfigManager!", annotation.name(), annotation.modid());
             throw new RuntimeException(error);
         }
         
-        ConfigCategory category = config.getCategory(categoryName);
+        ConfigCategory category = config.getCategory(annotation.category());
         return new ConfigElement(category);
     }
 }

--- a/src/main/java/net/minecraftforge/common/config/ConfigElement.java
+++ b/src/main/java/net/minecraftforge/common/config/ConfigElement.java
@@ -29,6 +29,8 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.regex.Pattern;
 
+import javax.annotation.Nullable;
+
 import net.minecraftforge.fml.client.config.ConfigGuiType;
 import net.minecraftforge.fml.client.config.GuiConfigEntries.IConfigEntry;
 import net.minecraftforge.fml.client.config.GuiEditArrayEntries.IArrayEntry;
@@ -367,12 +369,12 @@ public class ConfigElement implements IConfigElement
     }
     
     /**
-     * Provides a ConfigElement which conta
+     * Provides a ConfigElement which contains
      * @param modid
      * @param name
      * @return
      */
-    public static ConfigElement from(String modid, String name)
+    public static ConfigElement from(String modid, @Nullable String name)
     {
         return from(modid, name, "general");//'general' is default in @Config annotation
     }
@@ -384,7 +386,7 @@ public class ConfigElement implements IConfigElement
      * @param categoryName The category name stated in the {@code @Config} annotation.
      * @return A ConfigElement based on the described category.
      */
-    public static ConfigElement from(String modid, String name, String categoryName)
+    public static ConfigElement from(String modid, @Nullable String name, @Nullable String categoryName)
     {
         Configuration config = ConfigManager.getConfiguration(modid, name);
         if(config == null)

--- a/src/main/java/net/minecraftforge/common/config/ConfigManager.java
+++ b/src/main/java/net/minecraftforge/common/config/ConfigManager.java
@@ -161,7 +161,7 @@ public class ConfigManager
                 Class<?> cls = Class.forName(targ.getClassName(), true, mcl);
                 
                 if(MOD_CONFIG_CLASSES.get(modid) == null)
-                    MOD_CONFIG_CLASSES.put(modid, Sets.newHashSet());
+                    MOD_CONFIG_CLASSES.put(modid, Sets.<Class<?>>newHashSet());
                 MOD_CONFIG_CLASSES.get(modid).add(cls);
                 
                 String name = (String)targ.getAnnotationInfo().get("name");

--- a/src/main/java/net/minecraftforge/common/config/ConfigManager.java
+++ b/src/main/java/net/minecraftforge/common/config/ConfigManager.java
@@ -352,6 +352,8 @@ public class ConfigManager
                             TypeAdapters.Str.setDefaultValue(property, m.get(property.getName()));
                         m.put(property.getName(), val);
                     }
+                    else
+                        throw new RuntimeException("Unknown type in map! " + f.getDeclaringClass() + "/" + f.getName() + " " + mtype);
                 }
             }
             
@@ -382,6 +384,8 @@ public class ConfigManager
                         TypeAdapters.Str.setDefaultValue(property, defaultValue);
                         TypeAdapters.Str.setValue(property, defaultValue);
                     }
+                    else
+                        throw new RuntimeException("Unknown type in map! " + f.getDeclaringClass() + "/" + f.getName() + " " + mtype);
                 }
                 else //If the key is not new, sync according to shoudlReadFromVar()
                 {
@@ -412,6 +416,8 @@ public class ConfigManager
                         else
                             e.setValue(Enum.valueOf((Class<? extends Enum>)ftype, propVal));
                     }
+                    else
+                        throw new RuntimeException("Unknown type in map! " + f.getDeclaringClass() + "/" + f.getName() + " " + mtype);
                 }
             }
             prop = null;

--- a/src/main/java/net/minecraftforge/common/config/ConfigManager.java
+++ b/src/main/java/net/minecraftforge/common/config/ConfigManager.java
@@ -229,7 +229,7 @@ public class ConfigManager
 
             if (FieldWrapper.hasWrapperFor(f)) //Access the field
             {
-                if(Strings.isNullOrEmpty(category))
+                if (Strings.isNullOrEmpty(category))
                     throw new RuntimeException("An empty category may not contain anything but objects representing categories!");
                 try
                 {
@@ -247,7 +247,7 @@ public class ConfigManager
                             Property property = property(cfg, wrapper.getCategory(), suffix, propType, adapt.isArrayAdapter());
                         
                             adapt.setDefaultValue(property, wrapper.getValue(key));
-                            if(!existed)
+                            if (!existed)
                                 adapt.setValue(property, wrapper.getValue(key));
                             else
                                 wrapper.setValue(key, adapt.getValue(property));
@@ -279,7 +279,7 @@ public class ConfigManager
                         }
                     }
                     
-                    if(loading) //Doing this after the loops. The wrapper should set cosmetic stuff. 
+                    if (loading) //Doing this after the loops. The wrapper should set cosmetic stuff. 
                         wrapper.setupConfiguration(cfg, comment, langKey, requiresMcRestart, requiresWorldRestart);
                 
                 }
@@ -290,7 +290,7 @@ public class ConfigManager
                     throw new RuntimeException(error, e);
                 }
             } 
-            else if(f.getType().getSuperclass() != null && f.getType().getSuperclass().equals(Object.class)) //Descend the object tree
+            else if (f.getType().getSuperclass() != null && f.getType().getSuperclass().equals(Object.class)) //Descend the object tree
             { 
                 Object newInstance = null;
                 try

--- a/src/main/java/net/minecraftforge/common/config/ConfigManager.java
+++ b/src/main/java/net/minecraftforge/common/config/ConfigManager.java
@@ -28,6 +28,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Set;
 import java.util.regex.Pattern;
 
 import org.apache.logging.log4j.Level;
@@ -38,6 +39,7 @@ import com.google.common.collect.ArrayListMultimap;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Multimap;
+import com.google.common.collect.Sets;
 
 import net.minecraftforge.common.config.Config.Comment;
 import net.minecraftforge.common.config.Config.LangKey;
@@ -56,7 +58,7 @@ public class ConfigManager
     private static Map<String, Multimap<Config.Type, ASMData>> asm_data = Maps.newHashMap();
     private static Map<Class<?>, ITypeAdapter> ADAPTERS = Maps.newHashMap();
     private static Map<String, Configuration> CONFIGS = Maps.newHashMap();
-    private static Multimap<String, Class<?>> MOD_CONFIG_CLASSES = ArrayListMultimap.create();
+    private static Map<String, Set<Class<?>>> MOD_CONFIG_CLASSES = Maps.newHashMap();
 
     static
     {
@@ -157,7 +159,11 @@ public class ConfigManager
             try
             {
                 Class<?> cls = Class.forName(targ.getClassName(), true, mcl);
-                MOD_CONFIG_CLASSES.put(modid, cls);
+                
+                if(MOD_CONFIG_CLASSES.get(modid) == null)
+                    MOD_CONFIG_CLASSES.put(modid, Sets.newHashSet());
+                MOD_CONFIG_CLASSES.get(modid).add(cls);
+                
                 String name = (String)targ.getAnnotationInfo().get("name");
                 if (name == null)
                     name = modid;

--- a/src/main/java/net/minecraftforge/common/config/ConfigManager.java
+++ b/src/main/java/net/minecraftforge/common/config/ConfigManager.java
@@ -325,8 +325,7 @@ public class ConfigManager
         else if (ftype.getSuperclass() == Object.class) //Only support classes that are one level below Object.
         {
             String sub = (category.isEmpty() ? "" : category + ".") + getName(f).toLowerCase(Locale.ENGLISH);
-            ConfigCategory subCat = new ConfigCategory(sub, cfg.getCategory(category));//TODO Make it work. Shall be subcategory
-            subCat.setComment(comment);
+            cfg.getCategory(sub).setComment(comment);
             Object sinst = get(instance, f);
             for (Field sf : ftype.getDeclaredFields())
             {

--- a/src/main/java/net/minecraftforge/common/config/ConfigManager.java
+++ b/src/main/java/net/minecraftforge/common/config/ConfigManager.java
@@ -165,9 +165,11 @@ public class ConfigManager
     // =======================================================
     //                    INTERNAL
     // =======================================================
-    static Configuration getConfiguration(String modid) {
+    static Configuration getConfiguration(String modid, String name) {
+        if(name == null || name.isEmpty())
+            name = modid;
         File configDir = Loader.instance().getConfigDir();
-        File configFile = new File(configDir, modid + ".cfg");
+        File configFile = new File(configDir, name + ".cfg");
         return CONFIGS.get(configFile.getAbsolutePath());
     }
     

--- a/src/main/java/net/minecraftforge/common/config/ConfigManager.java
+++ b/src/main/java/net/minecraftforge/common/config/ConfigManager.java
@@ -165,6 +165,12 @@ public class ConfigManager
     // =======================================================
     //                    INTERNAL
     // =======================================================
+    static Configuration getConfiguration(String modid) {
+        File configDir = Loader.instance().getConfigDir();
+        File configFile = new File(configDir, modid + ".cfg");
+        return CONFIGS.get(configFile.getAbsolutePath());
+    }
+    
     private static void createConfig(Configuration cfg, Class<?> cls, String modid, boolean isStatic, String category)
     {
         for (Field f : cls.getDeclaredFields())

--- a/src/main/java/net/minecraftforge/common/config/ConfigManager.java
+++ b/src/main/java/net/minecraftforge/common/config/ConfigManager.java
@@ -118,6 +118,23 @@ public class ConfigManager
         }
     }
 
+    /**
+     * Synchronizes configuration data between the file on disk, the {@code Configuration} object and the annotated
+     * mod classes containing the configuration variables.
+     * 
+     * When first called, this method will try to load the configuration from disk. If this fails, because the file
+     * does not exist, it will be created with default values derived from the mods config classes variable default values
+     * and comments and ranges, as well as configuration names based on the appropriate annotations found in {@code @Config}.
+     * 
+     * Note, that this method is being called by the {@link FMLModContaier}, so the mod needn't call it in init().
+     * 
+     * If this method is called after the initial load, it will check whether the values in the Configuration object differ
+     * from the values in the corresponding variables. If they differ, it will either overwrite the variables if the Configuration
+     * object is marked as changed (e.g. if it was changed with the ConfigGui) or otherwise overwrite the Configuration object's values.
+     * It then proceeds to saving the changes to disk.
+     * @param modid the mod's ID for which the configuration shall be loaded
+     * @param type the configuration type, currently always {@code Config.Type.INSTANCE}
+     */
     public static void sync(String modid, Config.Type type)
     {
         FMLLog.fine("Attempting to inject @Config classes into %s for type %s", modid, type);

--- a/src/main/java/net/minecraftforge/common/config/ConfigManager.java
+++ b/src/main/java/net/minecraftforge/common/config/ConfigManager.java
@@ -162,7 +162,7 @@ public class ConfigManager
         }
     }
     
-    public void updateConfig(String modid, Config.Type type)
+    public static void updateConfig(String modid, Config.Type type)
     {
         FMLLog.fine("Attempting to update Configuration objects of mod %s for type %s", modid, type);
         ClassLoader mcl = Loader.instance().getModClassLoader();
@@ -229,17 +229,12 @@ public class ConfigManager
     private static void updateConfig(String modid, String category, Configuration cfg, Class<?> ftype, Field f, Object instance)
     {
         ITypeAdapter adapter = ADAPTERS.get(ftype);
-        
-        String comment = null;
-        Comment ca = f.getAnnotation(Comment.class);
-        if (ca != null)
-            comment = NEW_LINE.join(ca.value());
 
         if (adapter != null)
         {
             if (category.isEmpty())
                 throw new RuntimeException("Can not specify a primitive field when the category is empty: " + f.getDeclaringClass() +"/" + f.getName());
-            adapter.getProp(cfg, category, f, instance, comment);
+            adapter.setProperty(cfg, category, f, get(instance, f));
         }
         else if (ftype.getSuperclass() == Enum.class)
         {
@@ -263,11 +258,11 @@ public class ConfigManager
                 
                 if (adpt != null)
                 {
-                    adpt.getProp(cfg, sub, e.getKey(), e.getValue());
+                    adpt.setProperty(cfg, category, e.getKey(), e.getValue());
                 }
                 else if (mtype instanceof Class && ((Class<?>)mtype).getSuperclass() == Enum.class)
                 {
-                    TypeAdapters.Str.getProp(cfg, sub, e.getKey(), ((Enum)e.getValue()).name());
+                    TypeAdapters.Str.setProperty(cfg, sub, e.getKey(), ((Enum)e.getValue()).name());
                 }
                 else
                     throw new RuntimeException("Unknown type in map! " + f.getDeclaringClass() + "/" + f.getName() + " " + mtype);

--- a/src/main/java/net/minecraftforge/common/config/ConfigManager.java
+++ b/src/main/java/net/minecraftforge/common/config/ConfigManager.java
@@ -117,7 +117,7 @@ public class ConfigManager
         }
     }
 
-    public static void load(String modid, Config.Type type)
+    public static void sync(String modid, Config.Type type)
     {
         FMLLog.fine("Attempting to inject @Config classes into %s for type %s", modid, type);
         ClassLoader mcl = Loader.instance().getModClassLoader();

--- a/src/main/java/net/minecraftforge/common/config/ConfigManager.java
+++ b/src/main/java/net/minecraftforge/common/config/ConfigManager.java
@@ -160,7 +160,7 @@ public class ConfigManager
             {
                 Class<?> cls = Class.forName(targ.getClassName(), true, mcl);
                 
-                if(MOD_CONFIG_CLASSES.get(modid) == null)
+                if (MOD_CONFIG_CLASSES.get(modid) == null)
                     MOD_CONFIG_CLASSES.put(modid, Sets.<Class<?>>newHashSet());
                 MOD_CONFIG_CLASSES.get(modid).add(cls);
                 
@@ -205,7 +205,7 @@ public class ConfigManager
     //                    INTERNAL
     // =======================================================
     static Configuration getConfiguration(String modid, String name) {
-        if(Strings.isNullOrEmpty(name))
+        if (Strings.isNullOrEmpty(name))
             name = modid;
         File configDir = Loader.instance().getConfigDir();
         File configFile = new File(configDir, name + ".cfg");
@@ -259,7 +259,7 @@ public class ConfigManager
                 initializeProperty(prop, langKey, comment, requiresMcRestart, requiresWorldRestart);
                 Object fieldValue = get(instance, f);
                 adapter.setDefaultValue(prop, fieldValue);
-                if(!exists)
+                if (!exists)
                     adapter.setValue(prop, fieldValue);
                 else
                     set(instance, f, adapter.getValue(prop));
@@ -269,13 +269,9 @@ public class ConfigManager
                 Object fieldValue = get(instance, f);
                 Object propValue = adapter.getValue(prop);
                 if (shouldReadFromVar(prop, propValue, fieldValue)) 
-                {
                     adapter.setValue(prop, fieldValue);
-                } 
                 else
-                {
                     set(instance, f, propValue);
-                }
             }
         }
         else if (ftype.getSuperclass() == Enum.class) //Is a enum and write as String
@@ -285,11 +281,11 @@ public class ConfigManager
             Enum enu = (Enum)get(instance, f);
             boolean exists = exists(cfg, category, getName(f));
             prop = property(cfg, category, getName(f), TypeAdapters.Str.getType(), false);
-            if(loading)
+            if (loading)
             {
                 initializeProperty(prop, langKey, comment, requiresMcRestart, requiresWorldRestart);
                 TypeAdapters.Str.setDefaultValue(prop, enu.name());
-                if(!exists)
+                if (!exists)
                     TypeAdapters.Str.setValue(prop, enu.name());
                 else
                     set(instance, f, Enum.valueOf((Class<? extends Enum>)ftype, prop.getString()));
@@ -299,7 +295,7 @@ public class ConfigManager
             {    
                 String propValue = prop.getString();
                 
-                if(shouldReadFromVar(prop, propValue, enu.name()))
+                if (shouldReadFromVar(prop, propValue, enu.name()))
                     TypeAdapters.Str.setValue(prop, enu.name());
                 else
                     set(instance, f, Enum.valueOf((Class<? extends Enum>)ftype, propValue));
@@ -318,7 +314,7 @@ public class ConfigManager
             boolean mapsToArrays = ((Class)mtype).isArray();
 
             ConfigCategory confCat = cfg.getCategory(sub);
-            if(loading)
+            if (loading)
             {
                 //Init category
                 confCat.setComment(comment);
@@ -327,14 +323,14 @@ public class ConfigManager
                 confCat.setRequiresWorldRestart(requiresWorldRestart);
             }
             
-            for(Property property : confCat.getOrderedValues())//Are new keys in the Configuration object?
+            for (Property property : confCat.getOrderedValues())//Are new keys in the Configuration object?
             {
-                if(loading || !m.containsKey(property.getName()))
+                if (loading || !m.containsKey(property.getName()))
                 {
                     String propLangKey = langKey + "." + property.getName();
                     initializeProperty(property, propLangKey, null, requiresMcRestart, requiresWorldRestart);
                     
-                    if(adpt != null)
+                    if (adpt != null)
                     {
                         if(!m.containsKey(property.getName()))
                             adpt.setDefaultValue(property, adpt.getValue(property));
@@ -342,7 +338,7 @@ public class ConfigManager
                             adpt.setDefaultValue(property, m.get(property.getName()));
                         m.put(property.getName(), adpt.getValue(property));
                     }
-                    else if(mtype instanceof Class && ((Class<?>)mtype).getSuperclass() == Enum.class)
+                    else if (mtype instanceof Class && ((Class<?>)mtype).getSuperclass() == Enum.class)
                     {
                         String propValue = property.getString();
                         Enum val = Enum.valueOf((Class<? extends Enum>)mtype, propValue);
@@ -357,9 +353,9 @@ public class ConfigManager
                 }
             }
             
-            for(Entry<String, Object> e : m.entrySet())
+            for (Entry<String, Object> e : m.entrySet())
             {
-                if(!exists(cfg, sub, e.getKey())) //Are new programmatically added keys available?
+                if (!exists(cfg, sub, e.getKey())) //Are new programmatically added keys available?
                 {
                     Property.Type propType;
                     if (adpt != null)
@@ -411,7 +407,7 @@ public class ConfigManager
                     {
                         String propVal = property.getString();
                         String mapVal = ((Enum)e.getValue()).name();
-                        if(shouldReadFromVar(property, propVal, mapVal))
+                        if (shouldReadFromVar(property, propVal, mapVal))
                             TypeAdapters.Str.setValue(property, mapVal);
                         else
                             e.setValue(Enum.valueOf((Class<? extends Enum>)ftype, propVal));
@@ -483,9 +479,9 @@ public class ConfigManager
     private static Property property(Configuration cfg, String category, String property, Property.Type type, boolean isList)
     {
         Property prop = cfg.getCategory(category).get(property);
-        if(prop == null)
+        if (prop == null)
         {
-            if(isList)
+            if (isList)
                 prop = new Property(property, new String[0], type);
             else
                 prop = new Property(property, (String)null, type);
@@ -501,9 +497,9 @@ public class ConfigManager
     
     private static boolean shouldReadFromVar(Property property, Object propValue, Object fieldValue)
     {
-        if(!propValue.equals(fieldValue))
+        if (!propValue.equals(fieldValue))
         {
-            if(property.hasChanged())
+            if (property.hasChanged())
                 return false;
             else
                 return true;

--- a/src/main/java/net/minecraftforge/common/config/ConfigManager.java
+++ b/src/main/java/net/minecraftforge/common/config/ConfigManager.java
@@ -117,6 +117,15 @@ public class ConfigManager
             map.put(type, target);
         }
     }
+    
+    /**
+     * Bounces to sync().
+     * TODO: remove
+     */
+    public static void load(String modid, Config.Type type)
+    {
+        sync(modid, type);
+    }
 
     /**
      * Synchronizes configuration data between the file on disk, the {@code Configuration} object and the annotated

--- a/src/main/java/net/minecraftforge/common/config/ConfigManager.java
+++ b/src/main/java/net/minecraftforge/common/config/ConfigManager.java
@@ -33,6 +33,7 @@ import java.util.regex.Pattern;
 import org.apache.logging.log4j.Level;
 
 import com.google.common.base.Joiner;
+import com.google.common.base.Strings;
 import com.google.common.collect.ArrayListMultimap;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
@@ -205,7 +206,7 @@ public class ConfigManager
     //                    INTERNAL
     // =======================================================
     static Configuration getConfiguration(String modid, String name) {
-        if(name == null || name.isEmpty())
+        if(Strings.isNullOrEmpty(name))
             name = modid;
         File configDir = Loader.instance().getConfigDir();
         File configFile = new File(configDir, name + ".cfg");

--- a/src/main/java/net/minecraftforge/common/config/FieldWrapper.java
+++ b/src/main/java/net/minecraftforge/common/config/FieldWrapper.java
@@ -106,7 +106,7 @@ public abstract class FieldWrapper implements IFieldWrapper
         }
 
         @Override
-        public String[] getEntries()
+        public String[] getKeys()
         {
             Set<String> keys = theMap.keySet();
             String[] keyArray = new String[keys.size()];
@@ -127,20 +127,20 @@ public abstract class FieldWrapper implements IFieldWrapper
         }
 
         @Override
-        public void setEntry(String key, Object value)
+        public void setValue(String key, Object value)
         {
             String suffix = key.replaceFirst(category + "." + name + ".", "");
             theMap.put(suffix, value);
         }
 
         @Override
-        public boolean hasEntry(String name)
+        public boolean hasKey(String name)
         {
             return theMap.containsKey(name);
         }
 
         @Override
-        public boolean handlesEntry(String name)
+        public boolean handlesKey(String name)
         {
             if (name == null)
                 return false;
@@ -182,7 +182,7 @@ public abstract class FieldWrapper implements IFieldWrapper
         @Override
         public Object getValue(String key)
         {
-            if (!hasEntry(key))
+            if (!hasKey(key))
                 throw new IllegalArgumentException("Unsupported Key!");
 
             try
@@ -199,9 +199,9 @@ public abstract class FieldWrapper implements IFieldWrapper
         }
 
         @Override
-        public void setEntry(String key, Object value)
+        public void setValue(String key, Object value)
         {
-            if (!hasEntry(key))
+            if (!hasKey(key))
                 throw new IllegalArgumentException("Unsupported Key!");
             @SuppressWarnings({ "unchecked", "rawtypes" })
             Enum enu = Enum.valueOf((Class<? extends Enum>) field.getType(), (String) value);
@@ -256,7 +256,7 @@ public abstract class FieldWrapper implements IFieldWrapper
         @Override
         public Object getValue(String key)
         {
-            if (!hasEntry(key))
+            if (!hasKey(key))
                 throw new IllegalArgumentException("Unknown key!");
             try
             {
@@ -270,9 +270,9 @@ public abstract class FieldWrapper implements IFieldWrapper
         }
 
         @Override
-        public void setEntry(String key, Object value)
+        public void setValue(String key, Object value)
         {
-            if (!hasEntry(key))
+            if (!hasKey(key))
                 throw new IllegalArgumentException("Unknown key: " + key);
             try
             {
@@ -322,21 +322,21 @@ public abstract class FieldWrapper implements IFieldWrapper
         }
 
         @Override
-        public String[] getEntries()
+        public String[] getKeys()
         {
             return asArray(this.category + "." + this.name);
         }
 
         @Override
-        public boolean hasEntry(String name)
+        public boolean hasKey(String name)
         {
             return (this.category + "." + this.name).equals(name);
         }
 
         @Override
-        public boolean handlesEntry(String name)
+        public boolean handlesKey(String name)
         {
-            return hasEntry(name);
+            return hasKey(name);
         }
 
         @Override

--- a/src/main/java/net/minecraftforge/common/config/FieldWrapper.java
+++ b/src/main/java/net/minecraftforge/common/config/FieldWrapper.java
@@ -51,7 +51,7 @@ public abstract class FieldWrapper implements IFieldWrapper
         else
             throw new IllegalArgumentException(String.format("Fields of type '%s' are not supported!", field.getType().getCanonicalName()));
     }
-    
+
     public static boolean hasWrapperFor(Field field)
     {
         if (ADAPTERS.get(field.getType()) != null)
@@ -214,26 +214,26 @@ public abstract class FieldWrapper implements IFieldWrapper
                 Throwables.propagate(e);
             }
         }
-        
+
         @SuppressWarnings({ "unchecked", "rawtypes" })
         @Override
         public void setupConfiguration(Configuration cfg, String desc, String langKey, boolean reqMCRestart, boolean reqWorldRestart)
         {
             super.setupConfiguration(cfg, desc, langKey, reqMCRestart, reqWorldRestart);
-            
-            Property prop = cfg.getCategory(this.category).get(this.name); //Will be setup in general by ConfigManager
+
+            Property prop = cfg.getCategory(this.category).get(this.name); // Will be setup in general by ConfigManager
 
             List<String> lst = Lists.newArrayList();
-            for (Enum e : ((Class<? extends Enum>)field.getType()).getEnumConstants())
+            for (Enum e : ((Class<? extends Enum>) field.getType()).getEnumConstants())
                 lst.add(e.name());
-            
+
             prop.setValidationPattern(Pattern.compile(PIPE.join(lst)));
             prop.setValidValues(lst.toArray(new String[0]));
-            
+
             String validValues = NEW_LINE.join(lst);
-            
+
             if (desc != null)
-                prop.setComment(NEW_LINE.join(new String[]{desc, "Valid values:"}) + "\n" + validValues);
+                prop.setComment(NEW_LINE.join(new String[] { desc, "Valid values:" }) + "\n" + validValues);
             else
                 prop.setComment("Valid values:" + "\n" + validValues);
         }
@@ -283,33 +283,33 @@ public abstract class FieldWrapper implements IFieldWrapper
                 Throwables.propagate(e);
             }
         }
-        
+
         public void setupConfiguration(Configuration cfg, String desc, String langKey, boolean reqMCRestart, boolean reqWorldRestart)
         {
             super.setupConfiguration(cfg, desc, langKey, reqMCRestart, reqWorldRestart);
-            
+
             Property prop = cfg.getCategory(this.category).get(this.name);
-            
+
             RangeInt ia = field.getAnnotation(RangeInt.class);
             if (ia != null)
             {
                 prop.setMinValue(ia.min());
                 prop.setMaxValue(ia.max());
                 if (desc != null)
-                    prop.setComment(NEW_LINE.join(new String[]{desc, "Min: " + ia.min(), "Max: " + ia.max()}));
+                    prop.setComment(NEW_LINE.join(new String[] { desc, "Min: " + ia.min(), "Max: " + ia.max() }));
                 else
-                    prop.setComment(NEW_LINE.join(new String[]{"Min: " + ia.min(), "Max: " + ia.max()}));
+                    prop.setComment(NEW_LINE.join(new String[] { "Min: " + ia.min(), "Max: " + ia.max() }));
             }
-            
+
             RangeDouble da = field.getAnnotation(RangeDouble.class);
             if (da != null)
             {
                 prop.setMinValue(da.min());
                 prop.setMaxValue(da.max());
                 if (desc != null)
-                    prop.setComment(NEW_LINE.join(new String[]{desc, "Min: " + da.min(), "Max: " + da.max()}));
+                    prop.setComment(NEW_LINE.join(new String[] { desc, "Min: " + da.min(), "Max: " + da.max() }));
                 else
-                    prop.setComment(NEW_LINE.join(new String[]{"Min: " + da.min(), "Max: " + da.max()}));
+                    prop.setComment(NEW_LINE.join(new String[] { "Min: " + da.min(), "Max: " + da.max() }));
             }
         }
     }
@@ -342,16 +342,17 @@ public abstract class FieldWrapper implements IFieldWrapper
         @Override
         public void setupConfiguration(Configuration cfg, String desc, String langKey, boolean reqMCRestart, boolean reqWorldRestart)
         {
-            Property prop = cfg.getCategory(this.category).get(this.name); //Will be setup in general by ConfigManager
-            
+            Property prop = cfg.getCategory(this.category).get(this.name); // Will be setup in general by ConfigManager
+
             prop.setComment(desc);
             prop.setLanguageKey(langKey);
             prop.setRequiresMcRestart(reqMCRestart);
             prop.setRequiresWorldRestart(reqWorldRestart);
         }
-        
+
         @Override
-        public String getCategory() {
+        public String getCategory()
+        {
             return category;
         }
 

--- a/src/main/java/net/minecraftforge/common/config/FieldWrapper.java
+++ b/src/main/java/net/minecraftforge/common/config/FieldWrapper.java
@@ -129,7 +129,8 @@ public abstract class FieldWrapper implements IFieldWrapper
         @Override
         public void setEntry(String key, Object value)
         {
-            theMap.put(key, value);
+            String suffix = key.replaceFirst(category + "." + name + ".", "");
+            theMap.put(suffix, value);
         }
 
         @Override

--- a/src/main/java/net/minecraftforge/common/config/FieldWrapper.java
+++ b/src/main/java/net/minecraftforge/common/config/FieldWrapper.java
@@ -1,0 +1,284 @@
+package net.minecraftforge.common.config;
+
+import java.awt.List;
+import java.lang.reflect.Field;
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Set;
+
+import com.google.common.base.Throwables;
+
+public abstract class FieldWrapper implements IFieldWrapper
+{
+    protected String category, name;
+
+    protected Field field;
+    protected Object instance;
+    
+    public FieldWrapper(String category, Field field, Object instance) {
+        this.instance = instance;
+        this.field = field;
+        this.category = category;
+        this.name = field.getName();
+        
+        if(field.isAnnotationPresent(Config.Name.class))
+            this.name = field.getAnnotation(Config.Name.class).value();
+        
+        this.field.setAccessible(true); //Just in case
+    }
+
+    private static IFieldWrapper getFieldAdapter(Object instance, Field field, String category)
+    {
+        if (ConfigManager.ADAPTERS.get(field.getType()) != null)
+            return new PrimitiveWrapper(category, field, instance);
+        else if (Enum.class.isAssignableFrom(field.getType()))
+            return new EnumWrapper(category, field, instance);
+        else if (Map.class.isAssignableFrom(field.getType()))
+            return new MapWrapper(category, field, instance);
+        else if (field.getType().getSuperclass().equals(Object.class))
+            throw new RuntimeException("Objects should not be handled by field wrappers");
+        else
+            throw new IllegalArgumentException(String.format("Fields of type '%s' are not supported!", field.getType().getCanonicalName()));
+    }
+    
+    private static class MapWrapper extends FieldWrapper
+    {
+        private Map<String, Object> theMap = null;
+        private Type mType;
+        
+        @SuppressWarnings("unchecked")
+        private MapWrapper(String category, Field field, Object instance)
+        {
+            super(category, field, instance);
+            
+            try {
+                theMap = (Map<String, Object>) field.get(instance);
+            }
+            catch (ClassCastException cce)
+            {
+                throw new IllegalArgumentException(String.format("The map '%s' of class '%s' must have the key type String!", field.getName(), field.getDeclaringClass().getCanonicalName()), cce);
+            }
+            catch (Exception e)
+            {
+                Throwables.propagate(e);
+            }
+            
+            ParameterizedType type = (ParameterizedType)field.getGenericType();
+            mType = type.getActualTypeArguments()[1];
+            
+            if(ConfigManager.ADAPTERS.get(mType) == null && !Enum.class.isAssignableFrom((Class<?>)mType))
+                throw new IllegalArgumentException(String.format("The map '%s' of class '%s' has target values which are neither primitive nor an enum!", field.getName(), field.getDeclaringClass().getCanonicalName()));
+        }
+
+        @Override
+        public ITypeAdapter getTypeAdapter()
+        {
+            ITypeAdapter adapter = ConfigManager.ADAPTERS.get(mType);
+            if (adapter == null && Enum.class.isAssignableFrom((Class<?>) mType))
+                adapter = TypeAdapters.Str;
+            return adapter;
+        }
+
+        @Override
+        public String[] getEntries()
+        {
+            Set<String> keys = theMap.keySet();
+            String[] keyArray = new String[keys.size()];
+            
+            Iterator<String> it = keys.iterator();
+            for (int i = 0; i < keyArray.length; i++)
+            {
+                keyArray[i] = category + "." + name + "." + it.next();
+            }
+            
+            return keyArray;
+        }
+
+        @Override
+        public Object getValue(String key)
+        {
+            return theMap.get(key);
+        }
+
+        @Override
+        public void setEntry(String key, Object value)
+        {
+            theMap.put(key, value);
+        }
+
+        @Override
+        public boolean hasEntry(String name)
+        {
+            return theMap.containsKey(name);
+        }
+
+        @Override
+        public boolean handlesEntry(String name)
+        {
+            if(name == null)
+                return false;
+            return name.startsWith(category + "." + name + ".");
+        }
+    }
+    
+    private static class EnumWrapper extends SingleValueFieldWrapper
+    {
+        
+        private EnumWrapper(String category, Field field, Object instance)
+        {
+            super(category, field, instance);
+        }
+        
+        @Override
+        public ITypeAdapter getTypeAdapter()
+        {
+            return TypeAdapters.Str;
+        }
+
+        @Override
+        public Object getValue(String key)
+        {
+            if (!hasEntry(key))
+                throw new IllegalArgumentException("Unsupported Key!");
+            
+            try
+            {
+                Enum enu = (Enum) field.get(instance);
+                return enu.name();
+            }
+            catch (Exception e)
+            {
+                Throwables.propagate(e);
+            }
+            return null;
+        }
+
+        @Override
+        public void setEntry(String key, Object value)
+        {
+            if (!hasEntry(key))
+                throw new IllegalArgumentException("Unsupported Key!");
+            @SuppressWarnings("unchecked")
+            Enum enu = Enum.valueOf((Class<? extends Enum>)field.getType(), (String) value);
+            try
+            {
+                field.set(instance, enu);
+            }
+            catch (Exception e)
+            {
+                Throwables.propagate(e);
+            }
+        }
+    }
+
+    private static class PrimitiveWrapper extends SingleValueFieldWrapper
+    {
+        
+        private PrimitiveWrapper(String category, Field field, Object instance)
+        {
+            super(category, field, instance);
+        }
+
+        @Override
+        public ITypeAdapter getTypeAdapter()
+        {
+            return ConfigManager.ADAPTERS.get(field.getType());
+        }
+
+        @Override
+        public Object getValue(String key)
+        {
+            if (!hasEntry(key))
+                throw new IllegalArgumentException("Unknown key!");
+            try
+            {
+                return field.get(instance);
+            }
+            catch (Exception e)
+            {
+                Throwables.propagate(e);
+            }
+            return null;
+        }
+
+        @Override
+        public void setEntry(String key, Object value)
+        {
+            if (!hasEntry(key))
+                throw new IllegalArgumentException("Unknown key!");
+            try
+            {
+                field.set(instance, value);
+            }
+            catch (Exception e)
+            {
+                Throwables.propagate(e);
+            }
+        }
+    }
+    
+    private static abstract class SingleValueFieldWrapper extends FieldWrapper
+    {
+        private SingleValueFieldWrapper(String category, Field field, Object instance)
+        {
+            super(category, field, instance);
+        }
+
+        @Override
+        public String[] getEntries()
+        {
+            return asArray(category + "." + name);
+        }
+        
+        @Override
+        public boolean hasEntry(String name)
+        {
+            return (this.category + "." + this.name).equals(name);
+        }
+
+        @Override
+        public boolean handlesEntry(String name)
+        {
+            return hasEntry(name);
+        }
+    }
+
+    private static <T> T[] asArray(T... in)
+    {
+        return in;
+    }
+
+    public static class BeanEntry<K, V> implements Entry<K, V>
+    {
+        private K key;
+        private V value;
+
+        public BeanEntry(K key, V value)
+        {
+            this.key = key;
+            this.value = value;
+        }
+
+        @Override
+        public K getKey()
+        {
+            return key;
+        }
+
+        @Override
+        public V getValue()
+        {
+            return value;
+        }
+
+        @Override
+        public V setValue(V value)
+        {
+            throw new UnsupportedOperationException("This is a static bean.");
+        }
+
+    }
+}

--- a/src/main/java/net/minecraftforge/common/config/IFieldWrapper.java
+++ b/src/main/java/net/minecraftforge/common/config/IFieldWrapper.java
@@ -1,5 +1,8 @@
 package net.minecraftforge.common.config;
 
+/**
+ * The objects are expected to get their wrapped field, the owning class, instance and category string on initialization.
+ */
 public interface IFieldWrapper
 {
 
@@ -22,4 +25,11 @@ public interface IFieldWrapper
     public boolean hasEntry(String name);
     
     public boolean handlesEntry(String name);
+    
+    public void setupConfiguration(Configuration cfg, String desc, String langKey, boolean reqMCRestart, boolean reqWorldRestart);
+    
+    /**
+     * @return the category name in which the entries should be saved.
+     */
+    public String getCategory();
 }

--- a/src/main/java/net/minecraftforge/common/config/IFieldWrapper.java
+++ b/src/main/java/net/minecraftforge/common/config/IFieldWrapper.java
@@ -16,15 +16,15 @@ public interface IFieldWrapper
      * @param instance The instance whose field shall be queried.
      * @return a list of keys handled by this field
      */
-    public String[] getEntries();
+    public String[] getKeys();
     
     public Object getValue(String key);
     
-    public void setEntry(String key, Object value);
+    public void setValue(String key, Object value);
     
-    public boolean hasEntry(String name);
+    public boolean hasKey(String name);
     
-    public boolean handlesEntry(String name);
+    public boolean handlesKey(String name);
     
     public void setupConfiguration(Configuration cfg, String desc, String langKey, boolean reqMCRestart, boolean reqWorldRestart);
     

--- a/src/main/java/net/minecraftforge/common/config/IFieldWrapper.java
+++ b/src/main/java/net/minecraftforge/common/config/IFieldWrapper.java
@@ -1,0 +1,25 @@
+package net.minecraftforge.common.config;
+
+public interface IFieldWrapper
+{
+
+    /**
+     * @return The type adapter to serialize the values returned by getValue. Null if non-primitive.
+     */
+    public ITypeAdapter getTypeAdapter();
+    
+    /**
+     * @param field the field about which to retrieve information
+     * @param instance The instance whose field shall be queried.
+     * @return a list of keys handled by this field
+     */
+    public String[] getEntries();
+    
+    public Object getValue(String key);
+    
+    public void setEntry(String key, Object value);
+    
+    public boolean hasEntry(String name);
+    
+    public boolean handlesEntry(String name);
+}

--- a/src/main/java/net/minecraftforge/common/config/ITypeAdapter.java
+++ b/src/main/java/net/minecraftforge/common/config/ITypeAdapter.java
@@ -23,11 +23,15 @@ import java.lang.reflect.Field;
 interface ITypeAdapter
 {
 	Property getProp(Configuration cfg, String category, Field field, Object instance, String comment);
+	
+	void setProperty(Configuration cfg, String category, Field field, Object value);
 
 	Object getValue(Property prop);
 
 	public interface Map extends ITypeAdapter
 	{
 		Property getProp(Configuration cfg, String category, String name, Object value);
+		
+		void setProperty(Configuration cfg, String category, String name, Object value);
 	}
 }

--- a/src/main/java/net/minecraftforge/common/config/ITypeAdapter.java
+++ b/src/main/java/net/minecraftforge/common/config/ITypeAdapter.java
@@ -29,4 +29,6 @@ interface ITypeAdapter
 	Object getValue(Property prop);
 
     Type getType();
+    
+    boolean isArrayAdapter();
 }

--- a/src/main/java/net/minecraftforge/common/config/ITypeAdapter.java
+++ b/src/main/java/net/minecraftforge/common/config/ITypeAdapter.java
@@ -18,20 +18,15 @@
  */
 package net.minecraftforge.common.config;
 
-import java.lang.reflect.Field;
+import net.minecraftforge.common.config.Property.Type;
 
 interface ITypeAdapter
 {
-	Property getProp(Configuration cfg, String category, Field field, Object instance, String comment);
+    void setDefaultValue(Property property, Object value);
 	
-	void setProperty(Configuration cfg, String category, Field field, Object value);
+	void setValue(Property property, Object value);
 
 	Object getValue(Property prop);
 
-	public interface Map extends ITypeAdapter
-	{
-		Property getProp(Configuration cfg, String category, String name, Object value);
-		
-		void setProperty(Configuration cfg, String category, String name, Object value);
-	}
+    Type getType();
 }

--- a/src/main/java/net/minecraftforge/common/config/TypeAdapters.java
+++ b/src/main/java/net/minecraftforge/common/config/TypeAdapters.java
@@ -1,5 +1,5 @@
 /*
- * Minecraft Forge
+a * Minecraft Forge
  * Copyright (c) 2016.
  *
  * This library is free software; you can redistribute it and/or
@@ -51,6 +51,11 @@ class TypeAdapters
         public Object getValue(Property prop) {
             return prop.getBoolean();
         }
+        @Override
+        public void setProperty(Configuration cfg, String category, Field field, Object value)
+        {
+            cfg.getCategory(category).get(getName(field)).set((Boolean)value);
+        }
     };
     static ITypeAdapter boolA = new MapAdapter() {
         public Property getProp(Configuration cfg, String category, Field field, Object instance, String comment) {
@@ -61,6 +66,11 @@ class TypeAdapters
         }
         public Object getValue(Property prop) {
             return prop.getBooleanList();
+        }
+        @Override
+        public void setProperty(Configuration cfg, String category, String name, Object value)
+        {
+            cfg.getCategory(category).get(name).set((boolean[])value);
         }
     };
     static ITypeAdapter Bool = new MapAdapter() {
@@ -73,6 +83,11 @@ class TypeAdapters
         public Object getValue(Property prop) {
             return Boolean.valueOf(prop.getBoolean());
         }
+        @Override
+        public void setProperty(Configuration cfg, String category, String name, Object value)
+        {
+            cfg.getCategory(category).get(name).set((Boolean) value);
+        }
     };
     static ITypeAdapter BoolA = new MapAdapter() {
         public Property getProp(Configuration cfg, String category, Field field, Object instance, String comment) {
@@ -84,6 +99,11 @@ class TypeAdapters
         public Object getValue(Property prop) {
             return Booleans.asList(prop.getBooleanList()).toArray(new Boolean[prop.getBooleanList().length]);
         }
+        @Override
+        public void setProperty(Configuration cfg, String category, String name, Object value)
+        {
+            cfg.getCategory(category).get(name).set(Booleans.toArray(Arrays.asList((Boolean[])value)));
+        }
     };
     static ITypeAdapter flt = new TypeAdapter() {
         public Property getProp(Configuration cfg, String category, Field field, Object instance, String comment) {
@@ -91,6 +111,12 @@ class TypeAdapters
         }
         public Object getValue(Property prop) {
             return (float)prop.getDouble();
+        }
+        @Override
+        public void setProperty(Configuration cfg, String category, Field field, Object value)
+        {
+            cfg.getCategory(category).get(getName(field)).set((Float)value);
+            
         }
     };
     static ITypeAdapter fltA = new MapAdapter() {
@@ -103,6 +129,11 @@ class TypeAdapters
         public Object getValue(Property prop) {
             return Floats.toArray(Doubles.asList(prop.getDoubleList()));
         }
+        @Override
+        public void setProperty(Configuration cfg, String category, String name, Object value)
+        {
+            cfg.getCategory(category).get(name).set(Doubles.toArray(Floats.asList((float[])value)));
+        }
     };
     static ITypeAdapter Flt = new MapAdapter() {
         public Property getProp(Configuration cfg, String category, Field field, Object instance, String comment) {
@@ -113,6 +144,11 @@ class TypeAdapters
         }
         public Object getValue(Property prop) {
             return Float.valueOf((float)prop.getDouble());
+        }
+        @Override
+        public void setProperty(Configuration cfg, String category, String name, Object value)
+        {
+            cfg.getCategory(category).get(name).set((Float)value);
         }
     };
     static ITypeAdapter FltA = new MapAdapter() {
@@ -125,6 +161,11 @@ class TypeAdapters
         public Object getValue(Property prop) {
             return Floats.asList(Floats.toArray(Doubles.asList(prop.getDoubleList()))).toArray(new Float[prop.getDoubleList().length]);
         }
+        @Override
+        public void setProperty(Configuration cfg, String category, String name, Object value)
+        {
+            cfg.getCategory(category).get(name).set(Doubles.toArray(Arrays.asList((Float[])value)));
+        }
     };
     static ITypeAdapter dbl = new TypeAdapter() {
         public Property getProp(Configuration cfg, String category, Field field, Object instance, String comment) {
@@ -132,6 +173,11 @@ class TypeAdapters
         }
         public Object getValue(Property prop) {
             return prop.getDouble();
+        }
+        @Override
+        public void setProperty(Configuration cfg, String category, Field field, Object value)
+        {
+            cfg.getCategory(category).get(getName(field)).set((Double)value);
         }
     };
     static ITypeAdapter dblA = new MapAdapter() {
@@ -144,6 +190,11 @@ class TypeAdapters
         public Object getValue(Property prop) {
             return prop.getDoubleList();
         }
+        @Override
+        public void setProperty(Configuration cfg, String category, String name, Object value)
+        {
+            cfg.getCategory(category).get(name).set((double[])value);
+        }
     };
     static ITypeAdapter Dbl = new MapAdapter() {
         public Property getProp(Configuration cfg, String category, Field field, Object instance, String comment) {
@@ -154,6 +205,11 @@ class TypeAdapters
         }
         public Object getValue(Property prop) {
             return Double.valueOf(prop.getDouble());
+        }
+        @Override
+        public void setProperty(Configuration cfg, String category, String name, Object value)
+        {
+            cfg.getCategory(category).get(name).set((Double)value);
         }
     };
     static ITypeAdapter DblA = new MapAdapter() {
@@ -166,6 +222,11 @@ class TypeAdapters
         public Object getValue(Property prop) {
             return Doubles.asList(prop.getDoubleList()).toArray(new Double[prop.getDoubleList().length]);
         }
+        @Override
+        public void setProperty(Configuration cfg, String category, String name, Object value)
+        {
+            cfg.getCategory(category).get(name).set(Doubles.toArray(Arrays.asList((Double[])value)));
+        }
     };
     static ITypeAdapter byt = new TypeAdapter() {
         public Property getProp(Configuration cfg, String category, Field field, Object instance, String comment) {
@@ -173,6 +234,11 @@ class TypeAdapters
         }
         public Object getValue(Property prop) {
             return (byte)prop.getInt();
+        }
+        @Override
+        public void setProperty(Configuration cfg, String category, Field field, Object value)
+        {
+            cfg.getCategory(category).get(getName(field)).set((Byte)value);
         }
     };
     static ITypeAdapter bytA = new MapAdapter() {
@@ -185,6 +251,11 @@ class TypeAdapters
         public Object getValue(Property prop) {
             return Bytes.toArray(Ints.asList(prop.getIntList()));
         }
+        @Override
+        public void setProperty(Configuration cfg, String category, String name, Object value)
+        {
+            cfg.getCategory(category).get(name).set(Ints.toArray(Bytes.asList((byte[])value)));
+        }
     };
     static ITypeAdapter Byt = new MapAdapter() {
         public Property getProp(Configuration cfg, String category, Field field, Object instance, String comment) {
@@ -195,6 +266,11 @@ class TypeAdapters
         }
         public Object getValue(Property prop) {
             return Byte.valueOf((byte)prop.getInt());
+        }
+        @Override
+        public void setProperty(Configuration cfg, String category, String name, Object value)
+        {
+            cfg.getCategory(category).get(name).set((Byte)value);
         }
     };
     static ITypeAdapter BytA = new MapAdapter() {
@@ -207,6 +283,11 @@ class TypeAdapters
         public Object getValue(Property prop) {
             return Bytes.asList(Bytes.toArray(Ints.asList(prop.getIntList()))).toArray(new Byte[prop.getIntList().length]);
         }
+        @Override
+        public void setProperty(Configuration cfg, String category, String name, Object value)
+        {
+            cfg.getCategory(category).get(name).set(Ints.toArray(Arrays.asList((Byte[])value)));
+        }
     };
     static ITypeAdapter chr = new TypeAdapter() {
         public Property getProp(Configuration cfg, String category, Field field, Object instance, String comment) {
@@ -214,6 +295,11 @@ class TypeAdapters
         }
         public Object getValue(Property prop) {
             return (char)prop.getInt();
+        }
+        @Override
+        public void setProperty(Configuration cfg, String category, Field field, Object value)
+        {
+            cfg.getCategory(category).get(getName(field)).set((Character)value);
         }
     };
     static ITypeAdapter chrA = new MapAdapter() {
@@ -237,6 +323,11 @@ class TypeAdapters
                 ret[x] = (char)v[x];
             return ret;
         }
+        @Override
+        public void setProperty(Configuration cfg, String category, String name, Object value)
+        {
+            cfg.getCategory(category).get(name).set(toPrim((char[])value));
+        }
     };
     static ITypeAdapter Chr = new MapAdapter() {
         public Property getProp(Configuration cfg, String category, Field field, Object instance, String comment) {
@@ -247,6 +338,11 @@ class TypeAdapters
         }
         public Object getValue(Property prop) {
             return Character.valueOf((char)prop.getInt());
+        }
+        @Override
+        public void setProperty(Configuration cfg, String category, String name, Object value)
+        {
+            cfg.getCategory(category).get(name).set((Character)value);
         }
     };
     static ITypeAdapter ChrA = new MapAdapter() {
@@ -270,6 +366,12 @@ class TypeAdapters
                 ret[x] = Character.valueOf((char)v[x]);
             return ret;
         }
+        @Override
+        public void setProperty(Configuration cfg, String category, String name, Object value)
+        {
+            cfg.getCategory(category).get(name).set(toPrim((Character[])value));
+        }
+
     };
     static ITypeAdapter shrt = new TypeAdapter() {
         public Property getProp(Configuration cfg, String category, Field field, Object instance, String comment) {
@@ -277,6 +379,11 @@ class TypeAdapters
         }
         public Object getValue(Property prop) {
             return (short)prop.getInt();
+        }
+        @Override
+        public void setProperty(Configuration cfg, String category, Field field, Object value)
+        {
+            cfg.getCategory(category).get(getName(field)).set((Short)value);
         }
     };
     static ITypeAdapter shrtA = new MapAdapter() {
@@ -289,6 +396,12 @@ class TypeAdapters
         public Object getValue(Property prop) {
             return Shorts.toArray(Ints.asList(prop.getIntList()));
         }
+        @Override
+        public void setProperty(Configuration cfg, String category, String name, Object value)
+        {
+            cfg.getCategory(category).get(name).set(Ints.toArray(Shorts.asList((short[])value)));
+        }
+        
     };
     static ITypeAdapter Shrt = new MapAdapter() {
         public Property getProp(Configuration cfg, String category, Field field, Object instance, String comment) {
@@ -299,6 +412,11 @@ class TypeAdapters
         }
         public Object getValue(Property prop) {
             return Short.valueOf((short)prop.getInt());
+        }
+        @Override
+        public void setProperty(Configuration cfg, String category, String name, Object value)
+        {
+            cfg.getCategory(category).get(name).set((Short)value);
         }
     };
     static ITypeAdapter ShrtA = new MapAdapter() {
@@ -315,6 +433,11 @@ class TypeAdapters
                 ret[x] = Short.valueOf((short)v[x]);
             return ret;
         }
+        @Override
+        public void setProperty(Configuration cfg, String category, String name, Object value)
+        {
+            cfg.getCategory(category).get(name).set(Ints.toArray(Arrays.asList((Short[])value)));
+        }
     };
     static ITypeAdapter int_ = new TypeAdapter() {
         public Property getProp(Configuration cfg, String category, Field field, Object instance, String comment) {
@@ -322,6 +445,11 @@ class TypeAdapters
         }
         public Object getValue(Property prop) {
             return prop.getInt();
+        }
+        @Override
+        public void setProperty(Configuration cfg, String category, Field field, Object value)
+        {
+            cfg.getCategory(category).get(getName(field)).set((Integer)value);
         }
     };
     static ITypeAdapter intA = new MapAdapter() {
@@ -334,6 +462,11 @@ class TypeAdapters
         public Object getValue(Property prop) {
             return prop.getIntList();
         }
+        @Override
+        public void setProperty(Configuration cfg, String category, String name, Object value)
+        {
+            cfg.getCategory(category).get(name).set((int[])value);
+        }
     };
     static ITypeAdapter Int = new MapAdapter() {
         public Property getProp(Configuration cfg, String category, Field field, Object instance, String comment) {
@@ -344,6 +477,11 @@ class TypeAdapters
         }
         public Object getValue(Property prop) {
             return (Integer)prop.getInt();
+        }
+        @Override
+        public void setProperty(Configuration cfg, String category, String name, Object value)
+        {
+            cfg.getCategory(category).get(name).set((Integer)value);
         }
     };
     static ITypeAdapter IntA = new MapAdapter() {
@@ -356,6 +494,11 @@ class TypeAdapters
         public Object getValue(Property prop) {
             return Ints.asList(prop.getIntList()).toArray(new Integer[prop.getIntList().length]);
         }
+        @Override
+        public void setProperty(Configuration cfg, String category, String name, Object value)
+        {
+            cfg.getCategory(category).get(name).set(Ints.toArray(Arrays.asList((Integer[])value)));
+        }
     };
     static ITypeAdapter.Map Str = new MapAdapter() {
         public Property getProp(Configuration cfg, String category, Field field, Object instance, String comment) {
@@ -367,6 +510,11 @@ class TypeAdapters
         public Object getValue(Property prop) {
             return prop.getString();
         }
+        @Override
+        public void setProperty(Configuration cfg, String category, String name, Object value)
+        {
+            cfg.getCategory(category).get(name).set((String)value);
+        }
     };
     static ITypeAdapter StrA = new MapAdapter() {
         public Property getProp(Configuration cfg, String category, Field field, Object instance, String comment) {
@@ -377,6 +525,11 @@ class TypeAdapters
         }
         public Object getValue(Property prop) {
             return prop.getStringList();
+        }
+        @Override
+        public void setProperty(Configuration cfg, String category, String name, Object value)
+        {
+            cfg.getCategory(category).get(name).set((String[])value);
         }
     };
 
@@ -463,5 +616,11 @@ class TypeAdapters
             return f.getName();
         }
     }
-    private static abstract class MapAdapter extends TypeAdapter implements ITypeAdapter.Map {}
+    private static abstract class MapAdapter extends TypeAdapter implements ITypeAdapter.Map {
+        @Override
+        public void setProperty(Configuration cfg, String category, Field field, Object value)
+        {
+            setProperty(cfg, category, getName(field), value);
+        }
+    }
 }

--- a/src/main/java/net/minecraftforge/common/config/TypeAdapters.java
+++ b/src/main/java/net/minecraftforge/common/config/TypeAdapters.java
@@ -1,5 +1,5 @@
 /*
-a * Minecraft Forge
+ * Minecraft Forge
  * Copyright (c) 2016.
  *
  * This library is free software; you can redistribute it and/or

--- a/src/main/java/net/minecraftforge/common/config/TypeAdapters.java
+++ b/src/main/java/net/minecraftforge/common/config/TypeAdapters.java
@@ -19,7 +19,6 @@
 
 package net.minecraftforge.common.config;
 
-import java.lang.reflect.Field;
 //=========================================================
 // Run away thar' be dragons!
 //=========================================================
@@ -31,6 +30,8 @@ import com.google.common.primitives.Doubles;
 import com.google.common.primitives.Floats;
 import com.google.common.primitives.Ints;
 import com.google.common.primitives.Shorts;
+
+import net.minecraftforge.common.config.Property.Type;
 
 class TypeAdapters
 {
@@ -44,265 +45,367 @@ class TypeAdapters
     *    int, int[], Integer, Integer[]
     *    String, String[]
     */
-    static ITypeAdapter bool = new TypeAdapter() {
-        public Property getProp(Configuration cfg, String category, Field field, Object instance, String comment) {
-            return cfg.get(category, getName(field), getBoolean(instance, field), comment);
-        }
+    static ITypeAdapter bool = new ITypeAdapter() {
+        @Override
         public Object getValue(Property prop) {
             return prop.getBoolean();
         }
         @Override
-        public void setProperty(Configuration cfg, String category, Field field, Object value)
+        public void setDefaultValue(Property property, Object value)
         {
-            cfg.getCategory(category).get(getName(field)).set((Boolean)value);
+            property.setDefaultValue((Boolean)value);
+        }
+        @Override
+        public void setValue(Property property, Object value)
+        {
+            property.setValue((Boolean)value);
+        }
+        @Override
+        public Type getType()
+        {
+            return Type.BOOLEAN;
         }
     };
-    static ITypeAdapter boolA = new MapAdapter() {
-        public Property getProp(Configuration cfg, String category, Field field, Object instance, String comment) {
-            return cfg.get(category, getName(field), (boolean[])getObject(instance, field), comment);
-        }
-        public Property getProp(Configuration cfg, String category, String name, Object value) {
-            return cfg.get(category, name, (boolean[])value, null);
-        }
+    static ITypeAdapter boolA = new ITypeAdapter() {
+        @Override
         public Object getValue(Property prop) {
             return prop.getBooleanList();
         }
         @Override
-        public void setProperty(Configuration cfg, String category, String name, Object value)
+        public void setDefaultValue(Property property, Object value)
         {
-            cfg.getCategory(category).get(name).set((boolean[])value);
+            property.setDefaultValues((boolean[])value);
+        }
+        @Override
+        public void setValue(Property property, Object value)
+        {
+            property.setValues((boolean[])value);
+        }
+        @Override
+        public Type getType()
+        {
+            return Type.BOOLEAN;
         }
     };
-    static ITypeAdapter Bool = new MapAdapter() {
-        public Property getProp(Configuration cfg, String category, Field field, Object instance, String comment) {
-            return cfg.get(category, getName(field), (Boolean)getObject(instance, field), comment);
-        }
-        public Property getProp(Configuration cfg, String category, String name, Object value) {
-            return cfg.get(category, name, (Boolean)value, null);
-        }
+    static ITypeAdapter Bool = new ITypeAdapter() {
         public Object getValue(Property prop) {
             return Boolean.valueOf(prop.getBoolean());
         }
         @Override
-        public void setProperty(Configuration cfg, String category, String name, Object value)
+        public void setDefaultValue(Property property, Object value)
         {
-            cfg.getCategory(category).get(name).set((Boolean) value);
+            property.setDefaultValue((Boolean)value);
+        }
+        @Override
+        public void setValue(Property property, Object value)
+        {
+            property.setValue((Boolean)value);
+        }
+        @Override
+        public Type getType()
+        {
+            return Type.BOOLEAN;
         }
     };
-    static ITypeAdapter BoolA = new MapAdapter() {
-        public Property getProp(Configuration cfg, String category, Field field, Object instance, String comment) {
-            return cfg.get(category, getName(field), Booleans.toArray(Arrays.asList((Boolean[])getObject(instance, field))), comment);
-        }
-        public Property getProp(Configuration cfg, String category, String name, Object value) {
-            return cfg.get(category, name, (Boolean)value, null);
-        }
+    static ITypeAdapter BoolA = new ITypeAdapter() {
+        @Override
         public Object getValue(Property prop) {
             return Booleans.asList(prop.getBooleanList()).toArray(new Boolean[prop.getBooleanList().length]);
         }
         @Override
-        public void setProperty(Configuration cfg, String category, String name, Object value)
+        public void setDefaultValue(Property property, Object value)
         {
-            cfg.getCategory(category).get(name).set(Booleans.toArray(Arrays.asList((Boolean[])value)));
+            property.setDefaultValues(Booleans.toArray(Arrays.asList((Boolean[]) value)));
+        }
+        @Override
+        public void setValue(Property property, Object value)
+        {
+            property.setValues(Booleans.toArray(Arrays.asList((Boolean[]) value)));
+        }
+        @Override
+        public Type getType()
+        {
+            return Type.BOOLEAN;
         }
     };
-    static ITypeAdapter flt = new TypeAdapter() {
-        public Property getProp(Configuration cfg, String category, Field field, Object instance, String comment) {
-            return cfg.get(category, getName(field), getFloat(instance, field), comment);
-        }
+    static ITypeAdapter flt = new ITypeAdapter() {
+        @Override
         public Object getValue(Property prop) {
             return (float)prop.getDouble();
         }
         @Override
-        public void setProperty(Configuration cfg, String category, Field field, Object value)
+        public void setDefaultValue(Property property, Object value)
         {
-            cfg.getCategory(category).get(getName(field)).set((Float)value);
-            
+            property.setDefaultValue((Float)value);
+        }
+        @Override
+        public void setValue(Property property, Object value)
+        {
+            property.setValue((Float)value);
+        }
+        @Override
+        public Type getType()
+        {
+            return Type.DOUBLE;
         }
     };
-    static ITypeAdapter fltA = new MapAdapter() {
-        public Property getProp(Configuration cfg, String category, Field field, Object instance, String comment) {
-            return cfg.get(category, getName(field), Doubles.toArray(Floats.asList((float[])getObject(instance, field))), comment);
-        }
-        public Property getProp(Configuration cfg, String category, String name, Object value) {
-            return cfg.get(category, name, Doubles.toArray(Floats.asList((float[])value)), null);
-        }
+    static ITypeAdapter fltA = new ITypeAdapter() {
+        @Override
         public Object getValue(Property prop) {
             return Floats.toArray(Doubles.asList(prop.getDoubleList()));
         }
         @Override
-        public void setProperty(Configuration cfg, String category, String name, Object value)
+        public void setDefaultValue(Property property, Object value)
         {
-            cfg.getCategory(category).get(name).set(Doubles.toArray(Floats.asList((float[])value)));
+            property.setDefaultValues(Doubles.toArray(Floats.asList((float[])value)));
+        }
+        @Override
+        public void setValue(Property property, Object value)
+        {
+            property.setValues(Doubles.toArray(Floats.asList((float[])value)));
+        }
+        @Override
+        public Type getType()
+        {
+            return Type.DOUBLE;
         }
     };
-    static ITypeAdapter Flt = new MapAdapter() {
-        public Property getProp(Configuration cfg, String category, Field field, Object instance, String comment) {
-            return cfg.get(category, getName(field), (Float)getObject(instance, field), comment);
-        }
-        public Property getProp(Configuration cfg, String category, String name, Object value) {
-            return cfg.get(category, name, (Float)value, null);
-        }
+    static ITypeAdapter Flt = new ITypeAdapter() {
+        @Override
         public Object getValue(Property prop) {
             return Float.valueOf((float)prop.getDouble());
         }
         @Override
-        public void setProperty(Configuration cfg, String category, String name, Object value)
+        public void setDefaultValue(Property property, Object value)
         {
-            cfg.getCategory(category).get(name).set((Float)value);
+            property.setDefaultValue((Float)value);
+        }
+        @Override
+        public void setValue(Property property, Object value)
+        {
+            property.setValue((Float)value);
+        }
+        @Override
+        public Type getType()
+        {
+            return Type.DOUBLE;
         }
     };
-    static ITypeAdapter FltA = new MapAdapter() {
-        public Property getProp(Configuration cfg, String category, Field field, Object instance, String comment) {
-            return cfg.get(category, getName(field), Doubles.toArray(Arrays.asList((Float[])getObject(instance, field))), comment);
-        }
-        public Property getProp(Configuration cfg, String category, String name, Object value) {
-            return cfg.get(category, name, Doubles.toArray(Arrays.asList((Float[])value)), null);
-        }
+    static ITypeAdapter FltA = new ITypeAdapter() {
+        @Override
         public Object getValue(Property prop) {
             return Floats.asList(Floats.toArray(Doubles.asList(prop.getDoubleList()))).toArray(new Float[prop.getDoubleList().length]);
         }
         @Override
-        public void setProperty(Configuration cfg, String category, String name, Object value)
+        public void setDefaultValue(Property property, Object value)
         {
-            cfg.getCategory(category).get(name).set(Doubles.toArray(Arrays.asList((Float[])value)));
+            property.setDefaultValues(Doubles.toArray(Arrays.asList((Float[])value)));
+        }
+        @Override
+        public void setValue(Property property, Object value)
+        {
+            property.setValues(Doubles.toArray(Arrays.asList((Float[])value)));
+        }
+        @Override
+        public Type getType()
+        {
+            return Type.DOUBLE;
         }
     };
-    static ITypeAdapter dbl = new TypeAdapter() {
-        public Property getProp(Configuration cfg, String category, Field field, Object instance, String comment) {
-            return cfg.get(category, getName(field), getDouble(instance, field), comment);
-        }
-        public Object getValue(Property prop) {
+    static ITypeAdapter dbl = new ITypeAdapter() {
+        @Override
+        public Object getValue(Property prop)
+        {
             return prop.getDouble();
         }
         @Override
-        public void setProperty(Configuration cfg, String category, Field field, Object value)
+        public void setDefaultValue(Property property, Object value)
         {
-            cfg.getCategory(category).get(getName(field)).set((Double)value);
+            property.setDefaultValue((Double)value);
+        }
+        @Override
+        public void setValue(Property property, Object value)
+        {
+            property.setValue((Double)value);
+        }
+        @Override
+        public Type getType()
+        {
+            return Type.DOUBLE;
         }
     };
-    static ITypeAdapter dblA = new MapAdapter() {
-        public Property getProp(Configuration cfg, String category, Field field, Object instance, String comment) {
-            return cfg.get(category, getName(field), (double[])getObject(instance, field), comment);
-        }
-        public Property getProp(Configuration cfg, String category, String name, Object value) {
-            return cfg.get(category, name, (double[])value, null);
-        }
+    static ITypeAdapter dblA = new ITypeAdapter() {
+        @Override
         public Object getValue(Property prop) {
             return prop.getDoubleList();
         }
+
         @Override
-        public void setProperty(Configuration cfg, String category, String name, Object value)
+        public void setDefaultValue(Property property, Object value)
         {
-            cfg.getCategory(category).get(name).set((double[])value);
+            property.setDefaultValues((double[])value);
+        }
+        @Override
+        public void setValue(Property property, Object value)
+        {
+            property.setValues((double[])value);
+        }
+
+        @Override
+        public Type getType()
+        {
+            return Type.DOUBLE;
         }
     };
-    static ITypeAdapter Dbl = new MapAdapter() {
-        public Property getProp(Configuration cfg, String category, Field field, Object instance, String comment) {
-            return cfg.get(category, getName(field), (Double)getObject(instance, field), comment);
-        }
-        public Property getProp(Configuration cfg, String category, String name, Object value) {
-            return cfg.get(category, name, (Double)value, null);
-        }
+    static ITypeAdapter Dbl = new ITypeAdapter() {
+        @Override
         public Object getValue(Property prop) {
             return Double.valueOf(prop.getDouble());
         }
         @Override
-        public void setProperty(Configuration cfg, String category, String name, Object value)
+        public void setDefaultValue(Property property, Object value)
         {
-            cfg.getCategory(category).get(name).set((Double)value);
+            property.setDefaultValue((Double)value);
+        }
+        @Override
+        public void setValue(Property property, Object value)
+        {
+            property.setValue((Double) value);
+        }
+        @Override
+        public Type getType()
+        {
+            return Type.DOUBLE;
         }
     };
-    static ITypeAdapter DblA = new MapAdapter() {
-        public Property getProp(Configuration cfg, String category, Field field, Object instance, String comment) {
-            return cfg.get(category, getName(field), Doubles.toArray(Arrays.asList((Double[])getObject(instance, field))), comment);
-        }
-        public Property getProp(Configuration cfg, String category, String name, Object value) {
-            return cfg.get(category, name, Doubles.toArray(Arrays.asList((Double[])value)), null);
-        }
+    static ITypeAdapter DblA = new ITypeAdapter() {
+        @Override
         public Object getValue(Property prop) {
             return Doubles.asList(prop.getDoubleList()).toArray(new Double[prop.getDoubleList().length]);
         }
         @Override
-        public void setProperty(Configuration cfg, String category, String name, Object value)
+        public void setDefaultValue(Property property, Object value)
         {
-            cfg.getCategory(category).get(name).set(Doubles.toArray(Arrays.asList((Double[])value)));
+            property.setDefaultValues(Doubles.toArray(Arrays.asList((Double[])value)));
+        }
+        @Override
+        public void setValue(Property property, Object value)
+        {
+            property.setValues(Doubles.toArray(Arrays.asList((Double[])value)));
+        }
+        @Override
+        public Type getType()
+        {
+            return Type.DOUBLE;
         }
     };
-    static ITypeAdapter byt = new TypeAdapter() {
-        public Property getProp(Configuration cfg, String category, Field field, Object instance, String comment) {
-            return cfg.get(category, getName(field), getByte(instance, field), comment, Byte.MIN_VALUE, Byte.MAX_VALUE);
-        }
-        public Object getValue(Property prop) {
+    static ITypeAdapter byt = new ITypeAdapter() {
+        @Override
+        public Object getValue(Property prop)
+        {
             return (byte)prop.getInt();
         }
         @Override
-        public void setProperty(Configuration cfg, String category, Field field, Object value)
+        public void setDefaultValue(Property property, Object value)
         {
-            cfg.getCategory(category).get(getName(field)).set((Byte)value);
+            property.setDefaultValue((Byte)value);
+        }
+        @Override
+        public void setValue(Property property, Object value)
+        {
+            property.setValue((Byte)value);
+        }
+        @Override
+        public Type getType()
+        {
+            return Type.INTEGER;
         }
     };
-    static ITypeAdapter bytA = new MapAdapter() {
-        public Property getProp(Configuration cfg, String category, Field field, Object instance, String comment) {
-            return cfg.get(category, getName(field), Ints.toArray(Bytes.asList((byte[])getObject(instance, field))), comment);
-        }
-        public Property getProp(Configuration cfg, String category, String name, Object value) {
-            return cfg.get(category, name, Ints.toArray(Bytes.asList((byte[])value)), null);
-        }
+    static ITypeAdapter bytA = new ITypeAdapter() {
+        @Override
         public Object getValue(Property prop) {
             return Bytes.toArray(Ints.asList(prop.getIntList()));
         }
         @Override
-        public void setProperty(Configuration cfg, String category, String name, Object value)
+        public void setDefaultValue(Property property, Object value)
         {
-            cfg.getCategory(category).get(name).set(Ints.toArray(Bytes.asList((byte[])value)));
+            property.setDefaultValues(Ints.toArray(Bytes.asList((byte[])value)));
+        }
+        @Override
+        public void setValue(Property property, Object value)
+        {
+            property.setValues(Ints.toArray(Bytes.asList((byte[])value)));
+        }
+        @Override
+        public Type getType()
+        {
+            return Type.INTEGER;
         }
     };
-    static ITypeAdapter Byt = new MapAdapter() {
-        public Property getProp(Configuration cfg, String category, Field field, Object instance, String comment) {
-            return cfg.get(category, getName(field), (Byte)getObject(instance, field), comment, Byte.MIN_VALUE, Byte.MAX_VALUE);
-        }
-        public Property getProp(Configuration cfg, String category, String name, Object value) {
-            return cfg.get(category, name, (Byte)value, null, Byte.MIN_VALUE, Byte.MAX_VALUE);
-        }
+    static ITypeAdapter Byt = new ITypeAdapter() {
+        @Override
         public Object getValue(Property prop) {
             return Byte.valueOf((byte)prop.getInt());
         }
         @Override
-        public void setProperty(Configuration cfg, String category, String name, Object value)
+        public void setDefaultValue(Property property, Object value)
         {
-            cfg.getCategory(category).get(name).set((Byte)value);
+            property.setDefaultValue((Byte)value);
+        }
+        @Override
+        public void setValue(Property property, Object value)
+        {
+            property.setValue((Byte)value);
+        }
+        @Override
+        public Type getType()
+        {
+            return Type.INTEGER;
         }
     };
-    static ITypeAdapter BytA = new MapAdapter() {
-        public Property getProp(Configuration cfg, String category, Field field, Object instance, String comment) {
-            return cfg.get(category, getName(field), Ints.toArray(Arrays.asList((Byte[])getObject(instance, field))), comment);
-        }
-        public Property getProp(Configuration cfg, String category, String name, Object value) {
-            return cfg.get(category, name, Ints.toArray(Arrays.asList((Byte[])value)), null);
-        }
+    static ITypeAdapter BytA = new ITypeAdapter() {
+        @Override
         public Object getValue(Property prop) {
             return Bytes.asList(Bytes.toArray(Ints.asList(prop.getIntList()))).toArray(new Byte[prop.getIntList().length]);
         }
         @Override
-        public void setProperty(Configuration cfg, String category, String name, Object value)
+        public void setDefaultValue(Property property, Object value)
         {
-            cfg.getCategory(category).get(name).set(Ints.toArray(Arrays.asList((Byte[])value)));
+            property.setDefaultValues(Ints.toArray(Arrays.asList((Byte[]) value)));
+        }
+        @Override
+        public void setValue(Property property, Object value)
+        {
+            property.setValues(Ints.toArray(Arrays.asList((Byte[]) value)));
+        }
+        @Override
+        public Type getType()
+        {
+            return Type.INTEGER;
         }
     };
-    static ITypeAdapter chr = new TypeAdapter() {
-        public Property getProp(Configuration cfg, String category, Field field, Object instance, String comment) {
-            return cfg.get(category, getName(field), getChar(instance, field), comment, Character.MIN_VALUE, Character.MAX_VALUE);
-        }
+    static ITypeAdapter chr = new ITypeAdapter() {
+        
         public Object getValue(Property prop) {
             return (char)prop.getInt();
         }
         @Override
-        public void setProperty(Configuration cfg, String category, Field field, Object value)
+        public void setDefaultValue(Property property, Object value)
         {
-            cfg.getCategory(category).get(getName(field)).set((Character)value);
+            property.setDefaultValue((Character)value);
+        }
+        @Override
+        public void setValue(Property property, Object value)
+        {
+            property.setValue((Character)value);
+        }
+        @Override
+        public Type getType()
+        {
+            return Type.INTEGER;
         }
     };
-    static ITypeAdapter chrA = new MapAdapter() {
+    static ITypeAdapter chrA = new ITypeAdapter() {
         private int[] toPrim(char[] v) {
             if (v == null) return new int[0];
             int[] ret = new int[v.length];
@@ -310,12 +413,7 @@ class TypeAdapters
                 ret[x] = v[x];
             return ret;
         }
-        public Property getProp(Configuration cfg, String category, Field field, Object instance, String comment) {
-            return cfg.get(category, getName(field), toPrim((char[])getObject(instance, field)), comment);
-        }
-        public Property getProp(Configuration cfg, String category, String name, Object value) {
-            return cfg.get(category, name, toPrim((char[])value), null);
-        }
+        
         public Object getValue(Property prop) {
             int[] v = prop.getIntList();
             char[] ret = new char[v.length];
@@ -324,28 +422,44 @@ class TypeAdapters
             return ret;
         }
         @Override
-        public void setProperty(Configuration cfg, String category, String name, Object value)
+        public void setDefaultValue(Property property, Object value)
         {
-            cfg.getCategory(category).get(name).set(toPrim((char[])value));
+            property.setDefaultValues(toPrim((char[])value));
+        }
+        @Override
+        public void setValue(Property property, Object value)
+        {
+            property.setValues(toPrim((char[])value));
+        }
+
+        @Override
+        public Type getType()
+        {
+            return Type.INTEGER;
         }
     };
-    static ITypeAdapter Chr = new MapAdapter() {
-        public Property getProp(Configuration cfg, String category, Field field, Object instance, String comment) {
-            return cfg.get(category, getName(field), (Character)getObject(instance, field), comment, Character.MIN_VALUE, Character.MAX_VALUE);
-        }
-        public Property getProp(Configuration cfg, String category, String name, Object value) {
-            return cfg.get(category, name, (Character)value, null, Character.MIN_VALUE, Character.MAX_VALUE);
-        }
+    static ITypeAdapter Chr = new ITypeAdapter() {
+        
         public Object getValue(Property prop) {
             return Character.valueOf((char)prop.getInt());
         }
         @Override
-        public void setProperty(Configuration cfg, String category, String name, Object value)
+        public void setDefaultValue(Property property, Object value)
         {
-            cfg.getCategory(category).get(name).set((Character)value);
+            property.setDefaultValue((Character)value);
+        }
+        @Override
+        public void setValue(Property property, Object value)
+        {
+            property.setValue((Character)value);
+        }
+        @Override
+        public Type getType()
+        {
+            return Type.INTEGER;
         }
     };
-    static ITypeAdapter ChrA = new MapAdapter() {
+    static ITypeAdapter ChrA = new ITypeAdapter() {
         private int[] toPrim(Character[] v) {
             if (v == null) return new int[0];
             int[] ret = new int[v.length];
@@ -353,12 +467,7 @@ class TypeAdapters
                 ret[x] = v[x] == null ? 0 : v[x];
             return ret;
         }
-        public Property getProp(Configuration cfg, String category, Field field, Object instance, String comment) {
-            return cfg.get(category, getName(field), toPrim((Character[])getObject(instance, field)), comment);
-        }
-        public Property getProp(Configuration cfg, String category, String name, Object value) {
-            return cfg.get(category, name, toPrim((Character[])value), null);
-        }
+        
         public Object getValue(Property prop) {
             int[] v = prop.getIntList();
             Character[] ret = new Character[v.length];
@@ -367,65 +476,89 @@ class TypeAdapters
             return ret;
         }
         @Override
-        public void setProperty(Configuration cfg, String category, String name, Object value)
+        public void setDefaultValue(Property property, Object value)
         {
-            cfg.getCategory(category).get(name).set(toPrim((Character[])value));
+            property.setDefaultValues(toPrim((Character[])value));
+        }
+        @Override
+        public void setValue(Property property, Object value)
+        {
+            property.setValues(toPrim((Character[]) value));
+        }
+
+        @Override
+        public Type getType()
+        {
+            return Type.INTEGER;
         }
 
     };
-    static ITypeAdapter shrt = new TypeAdapter() {
-        public Property getProp(Configuration cfg, String category, Field field, Object instance, String comment) {
-            return cfg.get(category, getName(field), getShort(instance, field), comment, Short.MIN_VALUE, Short.MAX_VALUE);
-        }
+    static ITypeAdapter shrt = new ITypeAdapter() {
+        @Override
         public Object getValue(Property prop) {
             return (short)prop.getInt();
         }
         @Override
-        public void setProperty(Configuration cfg, String category, Field field, Object value)
+        public void setDefaultValue(Property property, Object value)
         {
-            cfg.getCategory(category).get(getName(field)).set((Short)value);
+            property.setDefaultValue((Short)value);
+        }
+        @Override
+        public void setValue(Property property, Object value)
+        {
+            property.setValue((Short)value);
+        }
+        @Override
+        public Type getType()
+        {
+            return Type.INTEGER;
         }
     };
-    static ITypeAdapter shrtA = new MapAdapter() {
-        public Property getProp(Configuration cfg, String category, Field field, Object instance, String comment) {
-            return cfg.get(category, getName(field), Ints.toArray(Shorts.asList((short[])getObject(instance, field))), comment);
-        }
-        public Property getProp(Configuration cfg, String category, String name, Object value) {
-            return cfg.get(category, name, Ints.toArray(Shorts.asList((short[])value)), null);
-        }
+    static ITypeAdapter shrtA = new ITypeAdapter() {
+        @Override
         public Object getValue(Property prop) {
             return Shorts.toArray(Ints.asList(prop.getIntList()));
         }
         @Override
-        public void setProperty(Configuration cfg, String category, String name, Object value)
+        public void setDefaultValue(Property property, Object value)
         {
-            cfg.getCategory(category).get(name).set(Ints.toArray(Shorts.asList((short[])value)));
+            property.setDefaultValues(Ints.toArray(Shorts.asList((short[])value)));
+        }
+        @Override
+        public void setValue(Property property, Object value)
+        {
+            property.setValues(Ints.toArray(Shorts.asList((short[])value)));
+        }
+        @Override
+        public Type getType()
+        {
+            return Type.INTEGER;
         }
         
     };
-    static ITypeAdapter Shrt = new MapAdapter() {
-        public Property getProp(Configuration cfg, String category, Field field, Object instance, String comment) {
-            return cfg.get(category, getName(field), (Short)getObject(instance, field), comment, Short.MIN_VALUE, Short.MAX_VALUE);
-        }
-        public Property getProp(Configuration cfg, String category, String name, Object value) {
-            return cfg.get(category, name, (Short)value, null, Short.MIN_VALUE, Short.MAX_VALUE);
-        }
+    static ITypeAdapter Shrt = new ITypeAdapter() {
+        @Override
         public Object getValue(Property prop) {
             return Short.valueOf((short)prop.getInt());
         }
         @Override
-        public void setProperty(Configuration cfg, String category, String name, Object value)
+        public void setDefaultValue(Property property, Object value)
         {
-            cfg.getCategory(category).get(name).set((Short)value);
+            property.setDefaultValue((Short)value);
+        }
+        @Override
+        public void setValue(Property property, Object value)
+        {
+            property.setValue((Short)value);
+        }
+        @Override
+        public Type getType()
+        {
+            return Type.INTEGER;
         }
     };
-    static ITypeAdapter ShrtA = new MapAdapter() {
-        public Property getProp(Configuration cfg, String category, Field field, Object instance, String comment) {
-            return cfg.get(category, getName(field), Ints.toArray(Arrays.asList((Short[])getObject(instance, field))), comment);
-        }
-        public Property getProp(Configuration cfg, String category, String name, Object value) {
-            return cfg.get(category, name, Ints.toArray(Arrays.asList((Short[])value)), null);
-        }
+    static ITypeAdapter ShrtA = new ITypeAdapter() {
+        @Override
         public Object getValue(Property prop) {
             int[] v = prop.getIntList();
             Short[] ret = new Short[v.length];
@@ -434,193 +567,145 @@ class TypeAdapters
             return ret;
         }
         @Override
-        public void setProperty(Configuration cfg, String category, String name, Object value)
+        public void setDefaultValue(Property property, Object value)
         {
-            cfg.getCategory(category).get(name).set(Ints.toArray(Arrays.asList((Short[])value)));
+            property.setDefaultValues(Ints.toArray(Arrays.asList((Short[])value)));
+        }
+        @Override
+        public void setValue(Property property, Object value)
+        {
+            property.setValues(Ints.toArray(Arrays.asList((Short[])value)));
+        }
+        @Override
+        public Type getType()
+        {
+            return Type.INTEGER;
         }
     };
-    static ITypeAdapter int_ = new TypeAdapter() {
-        public Property getProp(Configuration cfg, String category, Field field, Object instance, String comment) {
-            return cfg.get(category, getName(field), getInt(instance, field), comment, Integer.MIN_VALUE, Integer.MAX_VALUE);
-        }
+    static ITypeAdapter int_ = new ITypeAdapter() {
+        @Override
         public Object getValue(Property prop) {
             return prop.getInt();
         }
         @Override
-        public void setProperty(Configuration cfg, String category, Field field, Object value)
+        public void setDefaultValue(Property property, Object value)
         {
-            cfg.getCategory(category).get(getName(field)).set((Integer)value);
+            property.setDefaultValue((Integer)value);
+        }
+        @Override
+        public void setValue(Property property, Object value)
+        {
+            property.setValue((Integer)value);
+        }
+        @Override
+        public Type getType()
+        {
+            return Type.INTEGER;
         }
     };
-    static ITypeAdapter intA = new MapAdapter() {
-        public Property getProp(Configuration cfg, String category, Field field, Object instance, String comment) {
-            return cfg.get(category, getName(field), (int[])getObject(instance, field), comment);
-        }
-        public Property getProp(Configuration cfg, String category, String name, Object value) {
-            return cfg.get(category, name, (int[])value, null);
-        }
+    static ITypeAdapter intA = new ITypeAdapter() {
+        @Override
         public Object getValue(Property prop) {
             return prop.getIntList();
         }
         @Override
-        public void setProperty(Configuration cfg, String category, String name, Object value)
+        public void setDefaultValue(Property property, Object value)
         {
-            cfg.getCategory(category).get(name).set((int[])value);
+            property.setDefaultValues((int[])value);
+        }
+        @Override
+        public void setValue(Property property, Object value)
+        {
+            property.setValues((int[])value);
+        }
+        @Override
+        public Type getType()
+        {
+            return Type.INTEGER;
         }
     };
-    static ITypeAdapter Int = new MapAdapter() {
-        public Property getProp(Configuration cfg, String category, Field field, Object instance, String comment) {
-            return cfg.get(category, getName(field), (Integer)getObject(instance, field), comment, Integer.MIN_VALUE, Integer.MAX_VALUE);
-        }
-        public Property getProp(Configuration cfg, String category, String name, Object value) {
-            return cfg.get(category, name, (Integer)value, null, Integer.MIN_VALUE, Integer.MAX_VALUE);
-        }
+    static ITypeAdapter Int = new ITypeAdapter() {
+        @Override
         public Object getValue(Property prop) {
             return (Integer)prop.getInt();
         }
         @Override
-        public void setProperty(Configuration cfg, String category, String name, Object value)
+        public void setDefaultValue(Property property, Object value)
         {
-            cfg.getCategory(category).get(name).set((Integer)value);
+            property.setDefaultValue((Integer)value);
+        }
+        @Override
+        public void setValue(Property property, Object value)
+        {
+            property.setValue((Integer)value);            
+        }
+        @Override
+        public Type getType()
+        {
+            return Type.INTEGER;
         }
     };
-    static ITypeAdapter IntA = new MapAdapter() {
-        public Property getProp(Configuration cfg, String category, Field field, Object instance, String comment) {
-            return cfg.get(category, getName(field), Ints.toArray(Arrays.asList((Integer[])getObject(instance, field))), comment);
-        }
-        public Property getProp(Configuration cfg, String category, String name, Object value) {
-            return cfg.get(category, name, Ints.toArray(Arrays.asList((Integer[])value)), null);
-        }
+    static ITypeAdapter IntA = new ITypeAdapter() {
+        @Override
         public Object getValue(Property prop) {
             return Ints.asList(prop.getIntList()).toArray(new Integer[prop.getIntList().length]);
         }
         @Override
-        public void setProperty(Configuration cfg, String category, String name, Object value)
+        public void setDefaultValue(Property property, Object value)
         {
-            cfg.getCategory(category).get(name).set(Ints.toArray(Arrays.asList((Integer[])value)));
+            property.setDefaultValues(Ints.toArray(Arrays.asList((Integer[])value)));
+        }
+        @Override
+        public void setValue(Property property, Object value)
+        {
+            property.setValues(Ints.toArray(Arrays.asList((Integer[])value)));
+        }
+        @Override
+        public Type getType()
+        {
+            return Type.INTEGER;
         }
     };
-    static ITypeAdapter.Map Str = new MapAdapter() {
-        public Property getProp(Configuration cfg, String category, Field field, Object instance, String comment) {
-            return cfg.get(category, getName(field), (String)getObject(instance, field), comment);
-        }
-        public Property getProp(Configuration cfg, String category, String name, Object value) {
-            return cfg.get(category, name, (String)value, null);
-        }
+    static ITypeAdapter Str = new ITypeAdapter() {
+        @Override
         public Object getValue(Property prop) {
             return prop.getString();
         }
         @Override
-        public void setProperty(Configuration cfg, String category, String name, Object value)
+        public void setDefaultValue(Property property, Object value)
         {
-            cfg.getCategory(category).get(name).set((String)value);
+            property.setDefaultValue((String)value);
+        }
+        @Override
+        public void setValue(Property property, Object value)
+        {
+            property.setValue((String)value);
+        }
+        @Override
+        public Type getType()
+        {
+            return Type.STRING;
         }
     };
-    static ITypeAdapter StrA = new MapAdapter() {
-        public Property getProp(Configuration cfg, String category, Field field, Object instance, String comment) {
-            return cfg.get(category, getName(field), (String[])getObject(instance, field), comment);
-        }
-        public Property getProp(Configuration cfg, String category, String name, Object value) {
-            return cfg.get(category, name, (String[])value, null);
-        }
+    static ITypeAdapter StrA = new ITypeAdapter() {
+        @Override
         public Object getValue(Property prop) {
             return prop.getStringList();
         }
         @Override
-        public void setProperty(Configuration cfg, String category, String name, Object value)
+        public void setDefaultValue(Property property, Object value)
         {
-            cfg.getCategory(category).get(name).set((String[])value);
+            property.setDefaultValues((String[])value);
+        }
+        @Override
+        public void setValue(Property property, Object value)
+        {
+            property.setValues((String[])value);
+        }
+        @Override
+        public Type getType()
+        {
+            return Type.STRING;
         }
     };
-
-
-    private static abstract class TypeAdapter implements ITypeAdapter
-    {
-        public static boolean getBoolean(Object instance, Field f)
-        {
-            try {
-                return f.getBoolean(instance);
-            } catch (Exception e) {
-                e.printStackTrace();
-            }
-            return false;
-        }
-        public static int getInt(Object instance, Field f)
-        {
-            try {
-                return f.getInt(instance);
-            } catch (Exception e) {
-                e.printStackTrace();
-            }
-            return 0;
-        }
-        public static Object getObject(Object instance, Field f)
-        {
-            try {
-                return f.get(instance);
-            } catch (Exception e) {
-                e.printStackTrace();
-            }
-            return null;
-        }
-        public static byte getByte(Object instance, Field f)
-        {
-            try {
-                return f.getByte(instance);
-            } catch (Exception e) {
-                e.printStackTrace();
-            }
-            return 0;
-        }
-        public static char getChar(Object instance, Field f)
-        {
-            try {
-                return f.getChar(instance);
-            } catch (Exception e) {
-                e.printStackTrace();
-            }
-            return 0;
-        }
-        public static double getDouble(Object instance, Field f)
-        {
-            try {
-                return f.getDouble(instance);
-            } catch (Exception e) {
-                e.printStackTrace();
-            }
-            return 0;
-        }
-        public static float getFloat(Object instance, Field f)
-        {
-            try {
-                return f.getFloat(instance);
-            } catch (Exception e) {
-                e.printStackTrace();
-            }
-            return 0;
-        }
-        public static short getShort(Object instance, Field f)
-        {
-            try {
-                return f.getShort(instance);
-            } catch (Exception e) {
-                e.printStackTrace();
-            }
-            return 0;
-        }
-
-        public String getName(Field f)
-        {
-            if (f.isAnnotationPresent(Config.Name.class))
-                return f.getAnnotation(Config.Name.class).value();
-            return f.getName();
-        }
-    }
-    private static abstract class MapAdapter extends TypeAdapter implements ITypeAdapter.Map {
-        @Override
-        public void setProperty(Configuration cfg, String category, Field field, Object value)
-        {
-            setProperty(cfg, category, getName(field), value);
-        }
-    }
 }

--- a/src/main/java/net/minecraftforge/common/config/TypeAdapters.java
+++ b/src/main/java/net/minecraftforge/common/config/TypeAdapters.java
@@ -65,6 +65,11 @@ class TypeAdapters
         {
             return Type.BOOLEAN;
         }
+        @Override
+        public boolean isArrayAdapter()
+        {
+            return false;
+        }
     };
     static ITypeAdapter boolA = new ITypeAdapter() {
         @Override
@@ -86,6 +91,11 @@ class TypeAdapters
         {
             return Type.BOOLEAN;
         }
+        @Override
+        public boolean isArrayAdapter()
+        {
+            return true;
+        }
     };
     static ITypeAdapter Bool = new ITypeAdapter() {
         public Object getValue(Property prop) {
@@ -105,6 +115,11 @@ class TypeAdapters
         public Type getType()
         {
             return Type.BOOLEAN;
+        }
+        @Override
+        public boolean isArrayAdapter()
+        {
+            return false;
         }
     };
     static ITypeAdapter BoolA = new ITypeAdapter() {
@@ -127,6 +142,11 @@ class TypeAdapters
         {
             return Type.BOOLEAN;
         }
+        @Override
+        public boolean isArrayAdapter()
+        {
+            return true;
+        }
     };
     static ITypeAdapter flt = new ITypeAdapter() {
         @Override
@@ -147,6 +167,11 @@ class TypeAdapters
         public Type getType()
         {
             return Type.DOUBLE;
+        }
+        @Override
+        public boolean isArrayAdapter()
+        {
+            return false;
         }
     };
     static ITypeAdapter fltA = new ITypeAdapter() {
@@ -169,6 +194,11 @@ class TypeAdapters
         {
             return Type.DOUBLE;
         }
+        @Override
+        public boolean isArrayAdapter()
+        {
+            return true;
+        }
     };
     static ITypeAdapter Flt = new ITypeAdapter() {
         @Override
@@ -189,6 +219,11 @@ class TypeAdapters
         public Type getType()
         {
             return Type.DOUBLE;
+        }
+        @Override
+        public boolean isArrayAdapter()
+        {
+            return false;
         }
     };
     static ITypeAdapter FltA = new ITypeAdapter() {
@@ -211,6 +246,11 @@ class TypeAdapters
         {
             return Type.DOUBLE;
         }
+        @Override
+        public boolean isArrayAdapter()
+        {
+            return true;
+        }
     };
     static ITypeAdapter dbl = new ITypeAdapter() {
         @Override
@@ -232,6 +272,11 @@ class TypeAdapters
         public Type getType()
         {
             return Type.DOUBLE;
+        }
+        @Override
+        public boolean isArrayAdapter()
+        {
+            return false;
         }
     };
     static ITypeAdapter dblA = new ITypeAdapter() {
@@ -256,6 +301,12 @@ class TypeAdapters
         {
             return Type.DOUBLE;
         }
+
+        @Override
+        public boolean isArrayAdapter()
+        {
+            return true;
+        }
     };
     static ITypeAdapter Dbl = new ITypeAdapter() {
         @Override
@@ -277,6 +328,11 @@ class TypeAdapters
         {
             return Type.DOUBLE;
         }
+        @Override
+        public boolean isArrayAdapter()
+        {
+            return false;
+        }
     };
     static ITypeAdapter DblA = new ITypeAdapter() {
         @Override
@@ -297,6 +353,11 @@ class TypeAdapters
         public Type getType()
         {
             return Type.DOUBLE;
+        }
+        @Override
+        public boolean isArrayAdapter()
+        {
+            return true;
         }
     };
     static ITypeAdapter byt = new ITypeAdapter() {
@@ -320,6 +381,11 @@ class TypeAdapters
         {
             return Type.INTEGER;
         }
+        @Override
+        public boolean isArrayAdapter()
+        {
+            return false;
+        }
     };
     static ITypeAdapter bytA = new ITypeAdapter() {
         @Override
@@ -340,6 +406,11 @@ class TypeAdapters
         public Type getType()
         {
             return Type.INTEGER;
+        }
+        @Override
+        public boolean isArrayAdapter()
+        {
+            return true;
         }
     };
     static ITypeAdapter Byt = new ITypeAdapter() {
@@ -362,6 +433,11 @@ class TypeAdapters
         {
             return Type.INTEGER;
         }
+        @Override
+        public boolean isArrayAdapter()
+        {
+            return false;
+        }
     };
     static ITypeAdapter BytA = new ITypeAdapter() {
         @Override
@@ -383,6 +459,11 @@ class TypeAdapters
         {
             return Type.INTEGER;
         }
+        @Override
+        public boolean isArrayAdapter()
+        {
+            return true;
+        }
     };
     static ITypeAdapter chr = new ITypeAdapter() {
         
@@ -403,6 +484,11 @@ class TypeAdapters
         public Type getType()
         {
             return Type.INTEGER;
+        }
+        @Override
+        public boolean isArrayAdapter()
+        {
+            return false;
         }
     };
     static ITypeAdapter chrA = new ITypeAdapter() {
@@ -437,6 +523,12 @@ class TypeAdapters
         {
             return Type.INTEGER;
         }
+
+        @Override
+        public boolean isArrayAdapter()
+        {
+            return true;
+        }
     };
     static ITypeAdapter Chr = new ITypeAdapter() {
         
@@ -457,6 +549,11 @@ class TypeAdapters
         public Type getType()
         {
             return Type.INTEGER;
+        }
+        @Override
+        public boolean isArrayAdapter()
+        {
+            return false;
         }
     };
     static ITypeAdapter ChrA = new ITypeAdapter() {
@@ -492,6 +589,12 @@ class TypeAdapters
             return Type.INTEGER;
         }
 
+        @Override
+        public boolean isArrayAdapter()
+        {
+            return true;
+        }
+
     };
     static ITypeAdapter shrt = new ITypeAdapter() {
         @Override
@@ -512,6 +615,11 @@ class TypeAdapters
         public Type getType()
         {
             return Type.INTEGER;
+        }
+        @Override
+        public boolean isArrayAdapter()
+        {
+            return false;
         }
     };
     static ITypeAdapter shrtA = new ITypeAdapter() {
@@ -534,6 +642,11 @@ class TypeAdapters
         {
             return Type.INTEGER;
         }
+        @Override
+        public boolean isArrayAdapter()
+        {
+            return true;
+        }
         
     };
     static ITypeAdapter Shrt = new ITypeAdapter() {
@@ -555,6 +668,11 @@ class TypeAdapters
         public Type getType()
         {
             return Type.INTEGER;
+        }
+        @Override
+        public boolean isArrayAdapter()
+        {
+            return false;
         }
     };
     static ITypeAdapter ShrtA = new ITypeAdapter() {
@@ -581,6 +699,11 @@ class TypeAdapters
         {
             return Type.INTEGER;
         }
+        @Override
+        public boolean isArrayAdapter()
+        {
+            return true;
+        }
     };
     static ITypeAdapter int_ = new ITypeAdapter() {
         @Override
@@ -601,6 +724,11 @@ class TypeAdapters
         public Type getType()
         {
             return Type.INTEGER;
+        }
+        @Override
+        public boolean isArrayAdapter()
+        {
+            return false;
         }
     };
     static ITypeAdapter intA = new ITypeAdapter() {
@@ -623,6 +751,11 @@ class TypeAdapters
         {
             return Type.INTEGER;
         }
+        @Override
+        public boolean isArrayAdapter()
+        {
+            return true;
+        }
     };
     static ITypeAdapter Int = new ITypeAdapter() {
         @Override
@@ -643,6 +776,11 @@ class TypeAdapters
         public Type getType()
         {
             return Type.INTEGER;
+        }
+        @Override
+        public boolean isArrayAdapter()
+        {
+            return false;
         }
     };
     static ITypeAdapter IntA = new ITypeAdapter() {
@@ -665,6 +803,11 @@ class TypeAdapters
         {
             return Type.INTEGER;
         }
+        @Override
+        public boolean isArrayAdapter()
+        {
+            return true;
+        }
     };
     static ITypeAdapter Str = new ITypeAdapter() {
         @Override
@@ -686,6 +829,11 @@ class TypeAdapters
         {
             return Type.STRING;
         }
+        @Override
+        public boolean isArrayAdapter()
+        {
+            return false;
+        }
     };
     static ITypeAdapter StrA = new ITypeAdapter() {
         @Override
@@ -706,6 +854,11 @@ class TypeAdapters
         public Type getType()
         {
             return Type.STRING;
+        }
+        @Override
+        public boolean isArrayAdapter()
+        {
+            return true;
         }
     };
 }

--- a/src/main/java/net/minecraftforge/fml/client/DefaultGuiFactory.java
+++ b/src/main/java/net/minecraftforge/fml/client/DefaultGuiFactory.java
@@ -20,6 +20,12 @@ public class DefaultGuiFactory implements IModGuiFactory
     }
 
     @Override
+    public boolean hasConfigGui()
+    {
+        return true;
+    }
+
+    @Override
     public void initialize(Minecraft minecraftInstance)
     {
         this.minecraft = minecraftInstance;
@@ -54,5 +60,4 @@ public class DefaultGuiFactory implements IModGuiFactory
     {
         return new DefaultGuiFactory(mod.getModId(), mod.getName());
     }
-
 }

--- a/src/main/java/net/minecraftforge/fml/client/DefaultGuiFactory.java
+++ b/src/main/java/net/minecraftforge/fml/client/DefaultGuiFactory.java
@@ -7,13 +7,13 @@ import net.minecraft.client.gui.GuiScreen;
 import net.minecraftforge.fml.client.config.GuiConfig;
 import net.minecraftforge.fml.common.ModContainer;
 
-public class DefaultGuiModFactory implements IModGuiFactory
+public class DefaultGuiFactory implements IModGuiFactory
 {
     
     protected String modid, title;
     protected Minecraft minecraft;
     
-    protected DefaultGuiModFactory(String modid, String title)
+    protected DefaultGuiFactory(String modid, String title)
     {
         this.modid = modid;
         this.title = title;
@@ -52,7 +52,7 @@ public class DefaultGuiModFactory implements IModGuiFactory
     
     public static IModGuiFactory forMod(ModContainer mod)
     {
-        return new DefaultGuiModFactory(mod.getModId(), mod.getName());
+        return new DefaultGuiFactory(mod.getModId(), mod.getName());
     }
 
 }

--- a/src/main/java/net/minecraftforge/fml/client/DefaultGuiModFactory.java
+++ b/src/main/java/net/minecraftforge/fml/client/DefaultGuiModFactory.java
@@ -1,0 +1,58 @@
+package net.minecraftforge.fml.client;
+
+import java.util.Set;
+
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.gui.GuiScreen;
+import net.minecraftforge.fml.client.config.GuiConfig;
+import net.minecraftforge.fml.common.ModContainer;
+
+public class DefaultGuiModFactory implements IModGuiFactory
+{
+    
+    protected String modid, title;
+    protected Minecraft minecraft;
+    
+    protected DefaultGuiModFactory(String modid, String title)
+    {
+        this.modid = modid;
+        this.title = title;
+    }
+
+    @Override
+    public void initialize(Minecraft minecraftInstance)
+    {
+        this.minecraft = minecraftInstance;
+    }
+
+    @Override
+    public GuiScreen createConfigGui(GuiScreen parentScreen)
+    {  
+        return new GuiConfig(parentScreen, modid, title);
+    }
+
+    @Deprecated
+    @Override
+    public Class<? extends GuiScreen> mainConfigGuiClass()
+    {
+        return null;
+    }
+
+    @Override
+    public Set<RuntimeOptionCategoryElement> runtimeGuiCategories()
+    {
+        return null;
+    }
+
+    @Override
+    public RuntimeOptionGuiHandler getHandlerFor(RuntimeOptionCategoryElement element)
+    {
+        return null;
+    }
+    
+    public static IModGuiFactory forMod(ModContainer mod)
+    {
+        return new DefaultGuiModFactory(mod.getModId(), mod.getName());
+    }
+
+}

--- a/src/main/java/net/minecraftforge/fml/client/FMLClientHandler.java
+++ b/src/main/java/net/minecraftforge/fml/client/FMLClientHandler.java
@@ -371,7 +371,7 @@ public class FMLClientHandler implements IFMLSidedHandler
             String className = mc.getGuiClassName();
             if (Strings.isNullOrEmpty(className))
             {
-                guiFactories.put(mc, DefaultGuiModFactory.forMod(mc));
+                guiFactories.put(mc, DefaultGuiFactory.forMod(mc));
                 continue;
             }
             try

--- a/src/main/java/net/minecraftforge/fml/client/FMLClientHandler.java
+++ b/src/main/java/net/minecraftforge/fml/client/FMLClientHandler.java
@@ -371,6 +371,7 @@ public class FMLClientHandler implements IFMLSidedHandler
             String className = mc.getGuiClassName();
             if (Strings.isNullOrEmpty(className))
             {
+                guiFactories.put(mc, DefaultGuiModFactory.forMod(mc));
                 continue;
             }
             try

--- a/src/main/java/net/minecraftforge/fml/client/FMLConfigGuiFactory.java
+++ b/src/main/java/net/minecraftforge/fml/client/FMLConfigGuiFactory.java
@@ -111,9 +111,9 @@ public class FMLConfigGuiFactory implements IModGuiFactory
     }
 
     @Override
-    public Class<? extends GuiScreen> mainConfigGuiClass()
+    public GuiScreen mainConfigGui(GuiScreen parentScreen)
     {
-        return FMLConfigGuiScreen.class;
+        return new FMLConfigGuiScreen(parentScreen);
     }
 
     private static final Set<RuntimeOptionCategoryElement> fmlCategories = ImmutableSet.of(new RuntimeOptionCategoryElement("HELP", "FML"));

--- a/src/main/java/net/minecraftforge/fml/client/FMLConfigGuiFactory.java
+++ b/src/main/java/net/minecraftforge/fml/client/FMLConfigGuiFactory.java
@@ -111,7 +111,7 @@ public class FMLConfigGuiFactory implements IModGuiFactory
     }
 
     @Override
-    public GuiScreen mainConfigGui(GuiScreen parentScreen)
+    public GuiScreen createConfigGui(GuiScreen parentScreen)
     {
         return new FMLConfigGuiScreen(parentScreen);
     }

--- a/src/main/java/net/minecraftforge/fml/client/FMLConfigGuiFactory.java
+++ b/src/main/java/net/minecraftforge/fml/client/FMLConfigGuiFactory.java
@@ -115,6 +115,12 @@ public class FMLConfigGuiFactory implements IModGuiFactory
     {
         return new FMLConfigGuiScreen(parentScreen);
     }
+    
+    @Override
+    public Class<? extends GuiScreen> mainConfigGuiClass()
+    {
+        return null;
+    }
 
     private static final Set<RuntimeOptionCategoryElement> fmlCategories = ImmutableSet.of(new RuntimeOptionCategoryElement("HELP", "FML"));
 

--- a/src/main/java/net/minecraftforge/fml/client/FMLConfigGuiFactory.java
+++ b/src/main/java/net/minecraftforge/fml/client/FMLConfigGuiFactory.java
@@ -104,6 +104,13 @@ public class FMLConfigGuiFactory implements IModGuiFactory
             return list;
         }
     }
+    
+
+    @Override
+    public boolean hasConfigGui()
+    {
+        return true;
+    }
 
     @Override
     public void initialize(Minecraft minecraftInstance)

--- a/src/main/java/net/minecraftforge/fml/client/GuiModList.java
+++ b/src/main/java/net/minecraftforge/fml/client/GuiModList.java
@@ -285,7 +285,7 @@ public class GuiModList extends GuiScreen
                             GuiScreen newScreen = null;
                             try 
                             {
-                                newScreen = guiFactory.mainConfigGui(this);
+                                newScreen = guiFactory.createConfigGui(this);
                             }
                             catch (AbstractMethodError error)
                             {
@@ -428,7 +428,7 @@ public class GuiModList extends GuiScreen
             {
                 try
                 {
-                    configModButton.enabled = guiFactory.mainConfigGui(this) != null;
+                    configModButton.enabled = guiFactory.createConfigGui(this) != null;
                 }
                 catch(AbstractMethodError error)
                 {

--- a/src/main/java/net/minecraftforge/fml/client/GuiModList.java
+++ b/src/main/java/net/minecraftforge/fml/client/GuiModList.java
@@ -282,7 +282,15 @@ public class GuiModList extends GuiScreen
                         try
                         {
                             IModGuiFactory guiFactory = FMLClientHandler.instance().getGuiFactoryFor(selectedMod);
-                            GuiScreen newScreen = guiFactory.mainConfigGui(this);
+                            GuiScreen newScreen = null;
+                            try 
+                            {
+                                newScreen = guiFactory.mainConfigGui(this);
+                            }
+                            catch (AbstractMethodError error)
+                            {
+                                newScreen = guiFactory.mainConfigGuiClass().getConstructor(GuiScreen.class).newInstance(this);
+                            }
                             this.mc.displayGuiScreen(newScreen);
                         }
                         catch (Exception e)
@@ -415,8 +423,18 @@ public class GuiModList extends GuiScreen
 
             IModGuiFactory guiFactory = FMLClientHandler.instance().getGuiFactoryFor(selectedMod);
             configModButton.visible = true;
-            configModButton.enabled = guiFactory != null && guiFactory.mainConfigGui(this) != null;
-
+            configModButton.enabled = false;
+            if(guiFactory != null)
+            {
+                try
+                {
+                    configModButton.enabled = guiFactory.mainConfigGui(this) != null;
+                }
+                catch(AbstractMethodError error)
+                {
+                    configModButton.enabled = guiFactory.mainConfigGuiClass() != null;
+                }
+            }
             lines.add(selectedMod.getMetadata().name);
             lines.add(String.format("Version: %s (%s)", selectedMod.getDisplayVersion(), selectedMod.getVersion()));
             lines.add(String.format("Mod ID: '%s' Mod State: %s", selectedMod.getModId(), Loader.instance().getModState(selectedMod)));

--- a/src/main/java/net/minecraftforge/fml/client/GuiModList.java
+++ b/src/main/java/net/minecraftforge/fml/client/GuiModList.java
@@ -424,7 +424,7 @@ public class GuiModList extends GuiScreen
             IModGuiFactory guiFactory = FMLClientHandler.instance().getGuiFactoryFor(selectedMod);
             configModButton.visible = true;
             configModButton.enabled = false;
-            if(guiFactory != null)
+            if (guiFactory != null)
             {
                 try
                 {

--- a/src/main/java/net/minecraftforge/fml/client/GuiModList.java
+++ b/src/main/java/net/minecraftforge/fml/client/GuiModList.java
@@ -428,7 +428,7 @@ public class GuiModList extends GuiScreen
             {
                 try
                 {
-                    configModButton.enabled = guiFactory.createConfigGui(this) != null;
+                    configModButton.enabled = guiFactory.hasConfigGui();
                 }
                 catch(AbstractMethodError error)
                 {

--- a/src/main/java/net/minecraftforge/fml/client/GuiModList.java
+++ b/src/main/java/net/minecraftforge/fml/client/GuiModList.java
@@ -282,7 +282,7 @@ public class GuiModList extends GuiScreen
                         try
                         {
                             IModGuiFactory guiFactory = FMLClientHandler.instance().getGuiFactoryFor(selectedMod);
-                            GuiScreen newScreen = guiFactory.mainConfigGuiClass().getConstructor(GuiScreen.class).newInstance(this);
+                            GuiScreen newScreen = guiFactory.mainConfigGui(this);
                             this.mc.displayGuiScreen(newScreen);
                         }
                         catch (Exception e)
@@ -415,7 +415,7 @@ public class GuiModList extends GuiScreen
 
             IModGuiFactory guiFactory = FMLClientHandler.instance().getGuiFactoryFor(selectedMod);
             configModButton.visible = true;
-            configModButton.enabled = guiFactory != null && guiFactory.mainConfigGuiClass() != null;
+            configModButton.enabled = guiFactory != null && guiFactory.mainConfigGui(this) != null;
 
             lines.add(selectedMod.getMetadata().name);
             lines.add(String.format("Version: %s (%s)", selectedMod.getDisplayVersion(), selectedMod.getVersion()));

--- a/src/main/java/net/minecraftforge/fml/client/IModGuiFactory.java
+++ b/src/main/java/net/minecraftforge/fml/client/IModGuiFactory.java
@@ -35,8 +35,8 @@ public interface IModGuiFactory {
      */
     public void initialize(Minecraft minecraftInstance);
     /**
-     * Return the name of a class extending {@link GuiScreen}. This class will
-     * be instantiated when the "config" button is pressed in the mod list. It will
+     * Return an initializedg {@link GuiScreen}. This screen will be displayed
+     * when the "config" button is pressed in the mod list. It will
      * have a single argument constructor - the "parent" screen, the same as all
      * Minecraft GUIs. The expected behaviour is that this screen will replace the
      * "mod list" screen completely, and will return to the mod list screen through
@@ -52,10 +52,12 @@ public interface IModGuiFactory {
      * desired behaviours that affect server state. Costs, mod game modes, stuff like that
      * can be changed here.
      *
+     * @param parentScreen The screen to which must be returned when closing the
+     * returned screen.
      * @return A class that will be instantiated on clicks on the config button
      *  or null if no GUI is desired.
      */
-    public Class<? extends GuiScreen> mainConfigGuiClass();
+    public GuiScreen mainConfigGui(GuiScreen parentScreen);
 
 
     /**

--- a/src/main/java/net/minecraftforge/fml/client/IModGuiFactory.java
+++ b/src/main/java/net/minecraftforge/fml/client/IModGuiFactory.java
@@ -27,6 +27,11 @@ import net.minecraft.client.gui.GuiScreen;
 
 import javax.annotation.Nullable;
 
+/**
+ * This is the interface you need to implement if you want to provide a customized config screen.
+ * {@link DefaultGuiFactory} provides a default implementation of this interface and will be used
+ * if the mod does not specify anything else.
+ */
 public interface IModGuiFactory {
     /**
      * Called when instantiated to initialize with the active minecraft instance.
@@ -36,15 +41,18 @@ public interface IModGuiFactory {
     public void initialize(Minecraft minecraftInstance);
     
     /**
+     * If this method returns false, the config button in the mod list will be disabled
+     * @return true if this object provides a config gui screen, false otherwise
+     */
+    public boolean hasConfigGui();
+    
+    /**
      * Return an initialized {@link GuiScreen}. This screen will be displayed
      * when the "config" button is pressed in the mod list. It will
      * have a single argument constructor - the "parent" screen, the same as all
      * Minecraft GUIs. The expected behaviour is that this screen will replace the
      * "mod list" screen completely, and will return to the mod list screen through
      * the parent link, once the appropriate action is taken from the config screen.
-     *
-     * A null from this method indicates that the mod does not provide a "config"
-     * button GUI screen, and the config button will be hidden/disabled.
      *
      * This config GUI is anticipated to provide configuration to the mod in a friendly
      * visual way. It should not be abused to set internals such as IDs (they're gonna

--- a/src/main/java/net/minecraftforge/fml/client/IModGuiFactory.java
+++ b/src/main/java/net/minecraftforge/fml/client/IModGuiFactory.java
@@ -34,6 +34,7 @@ public interface IModGuiFactory {
      * @param minecraftInstance the instance
      */
     public void initialize(Minecraft minecraftInstance);
+    
     /**
      * Return an initializedg {@link GuiScreen}. This screen will be displayed
      * when the "config" button is pressed in the mod list. It will
@@ -58,7 +59,31 @@ public interface IModGuiFactory {
      *  or null if no GUI is desired.
      */
     public GuiScreen mainConfigGui(GuiScreen parentScreen);
-
+    
+    /**
+     * Return the name of a class extending {@link GuiScreen}. This class will
+     * be instantiated when the "config" button is pressed in the mod list. It will
+     * have a single argument constructor - the "parent" screen, the same as all
+     * Minecraft GUIs. The expected behaviour is that this screen will replace the
+     * "mod list" screen completely, and will return to the mod list screen through
+     * the parent link, once the appropriate action is taken from the config screen.
+     *
+     * A null from this method indicates that the mod does not provide a "config"
+     * button GUI screen, and the config button will be hidden/disabled.
+     *
+     * This config GUI is anticipated to provide configuration to the mod in a friendly
+     * visual way. It should not be abused to set internals such as IDs (they're gonna
+     * keep disappearing anyway), but rather, interesting behaviours. This config GUI
+     * is never run when a server game is running, and should be used to configure
+     * desired behaviours that affect server state. Costs, mod game modes, stuff like that
+     * can be changed here.
+     *
+     * @deprecated The method {@link IModGuiFactory.maingConfigGui(GuiScreen} is the recommended method.
+     * @return A class that will be instantiated on clicks on the config button
+     *  or null if no GUI is desired.
+     */
+    @Deprecated
+    public Class<? extends GuiScreen> mainConfigGuiClass();
 
     /**
      * Return a list of the "runtime" categories this mod wishes to populate with

--- a/src/main/java/net/minecraftforge/fml/client/IModGuiFactory.java
+++ b/src/main/java/net/minecraftforge/fml/client/IModGuiFactory.java
@@ -36,7 +36,7 @@ public interface IModGuiFactory {
     public void initialize(Minecraft minecraftInstance);
     
     /**
-     * Return an initializedg {@link GuiScreen}. This screen will be displayed
+     * Return an initialized {@link GuiScreen}. This screen will be displayed
      * when the "config" button is pressed in the mod list. It will
      * have a single argument constructor - the "parent" screen, the same as all
      * Minecraft GUIs. The expected behaviour is that this screen will replace the
@@ -58,7 +58,7 @@ public interface IModGuiFactory {
      * @return A class that will be instantiated on clicks on the config button
      *  or null if no GUI is desired.
      */
-    public GuiScreen mainConfigGui(GuiScreen parentScreen);
+    public GuiScreen createConfigGui(GuiScreen parentScreen);
     
     /**
      * Return the name of a class extending {@link GuiScreen}. This class will

--- a/src/main/java/net/minecraftforge/fml/client/config/GuiConfig.java
+++ b/src/main/java/net/minecraftforge/fml/client/config/GuiConfig.java
@@ -223,21 +223,21 @@ public class GuiConfig extends GuiScreen
         this.entryList = new GuiConfigEntries(this, mc);
         this.initEntries = new ArrayList<IConfigEntry>(entryList.listEntries);
         this.allRequireWorldRestart = allRequireWorldRestart;
-        IF:if(!allRequireWorldRestart)
+        IF:if (!allRequireWorldRestart)
         {
-            for(IConfigElement element : configElements)
+            for (IConfigElement element : configElements)
             {
-                if(!element.requiresWorldRestart());
+                if (!element.requiresWorldRestart());
                     break IF;
             }
             allRequireWorldRestart = true;
         }
         this.allRequireMcRestart = allRequireMcRestart;
-        IF:if(!allRequireMcRestart)
+        IF:if (!allRequireMcRestart)
         {
-            for(IConfigElement element : configElements)
+            for (IConfigElement element : configElements)
             {
-                if(!element.requiresMcRestart());
+                if (!element.requiresMcRestart());
                     break IF;
             }
             allRequireMcRestart = true;

--- a/src/main/java/net/minecraftforge/fml/client/config/GuiConfig.java
+++ b/src/main/java/net/minecraftforge/fml/client/config/GuiConfig.java
@@ -25,6 +25,7 @@ import static net.minecraftforge.fml.client.config.GuiUtils.UNDO_CHAR;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Comparator;
 import java.util.List;
 
 import net.minecraft.client.Minecraft;
@@ -40,7 +41,6 @@ import net.minecraftforge.fml.client.event.ConfigChangedEvent;
 import net.minecraftforge.fml.client.event.ConfigChangedEvent.OnConfigChangedEvent;
 import net.minecraftforge.fml.client.event.ConfigChangedEvent.PostConfigChangedEvent;
 import net.minecraftforge.fml.common.Loader;
-import net.minecraftforge.fml.common.ModContainer;
 import net.minecraftforge.fml.common.eventhandler.Event.Result;
 
 import org.lwjgl.input.Keyboard;
@@ -125,7 +125,15 @@ public class GuiConfig extends GuiScreen
                 toReturn.add(ConfigElement.from(clazz));
             }
         }
-        toReturn.sort((IConfigElement e1, IConfigElement e2) -> I18n.format(e1.getLanguageKey()).compareTo(I18n.format(e2.getLanguageKey())));
+        toReturn.sort(new Comparator<IConfigElement>(){
+
+            @Override
+            public int compare(IConfigElement e1, IConfigElement e2)
+            {
+                return I18n.format(e1.getLanguageKey()).compareTo(I18n.format(e2.getLanguageKey()));
+            }
+            
+        });
         return toReturn;
     }
 

--- a/src/main/java/net/minecraftforge/fml/client/config/GuiConfig.java
+++ b/src/main/java/net/minecraftforge/fml/client/config/GuiConfig.java
@@ -33,6 +33,7 @@ import net.minecraft.client.gui.GuiScreen;
 import net.minecraft.client.resources.I18n;
 import net.minecraft.util.text.TextComponentString;
 import net.minecraftforge.common.MinecraftForge;
+import net.minecraftforge.common.config.ConfigElement;
 import net.minecraftforge.fml.client.config.GuiConfigEntries.IConfigEntry;
 import net.minecraftforge.fml.client.event.ConfigChangedEvent;
 import net.minecraftforge.fml.client.event.ConfigChangedEvent.OnConfigChangedEvent;
@@ -80,6 +81,22 @@ public class GuiConfig extends GuiScreen
     protected HoverChecker undoHoverChecker;
     protected HoverChecker resetHoverChecker;
     protected HoverChecker checkBoxHoverChecker;
+    
+    public GuiConfig(GuiScreen parentScreen, String modID, boolean allRequireWorldRestart, boolean allRequireMcRestart, String title,
+            Class<?>... configClasses)
+    {
+        this(parentScreen, collectConfigElements(configClasses), modID, null, allRequireWorldRestart, allRequireMcRestart, title, null);
+    }
+    
+    private static List<IConfigElement> collectConfigElements(Class<?>[] configClasses)
+    {
+        List<IConfigElement> elements = new ArrayList<IConfigElement>();
+        for(Class<?> clazz : configClasses)
+        {
+            elements.add(ConfigElement.from(clazz));
+        }
+        return elements;
+    }
 
     /**
      * GuiConfig constructor that will use ConfigChangedEvent when editing is concluded. If a non-null value is passed for configID,

--- a/src/main/java/net/minecraftforge/fml/client/config/GuiConfig.java
+++ b/src/main/java/net/minecraftforge/fml/client/config/GuiConfig.java
@@ -34,11 +34,13 @@ import net.minecraft.client.resources.I18n;
 import net.minecraft.util.text.TextComponentString;
 import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.common.config.ConfigElement;
+import net.minecraftforge.common.config.ConfigManager;
 import net.minecraftforge.fml.client.config.GuiConfigEntries.IConfigEntry;
 import net.minecraftforge.fml.client.event.ConfigChangedEvent;
 import net.minecraftforge.fml.client.event.ConfigChangedEvent.OnConfigChangedEvent;
 import net.minecraftforge.fml.client.event.ConfigChangedEvent.PostConfigChangedEvent;
 import net.minecraftforge.fml.common.Loader;
+import net.minecraftforge.fml.common.ModContainer;
 import net.minecraftforge.fml.common.eventhandler.Event.Result;
 
 import org.lwjgl.input.Keyboard;
@@ -81,6 +83,17 @@ public class GuiConfig extends GuiScreen
     protected HoverChecker undoHoverChecker;
     protected HoverChecker resetHoverChecker;
     protected HoverChecker checkBoxHoverChecker;
+    
+    /**
+     * TODO: handle mcRestart and worldRestart
+     * This constructor handles the {@code @Config} configuration classes
+     * @param parentScreen the parent GuiScreen object
+     * @param mod the mod for which to create a screen
+     */
+    public GuiConfig(GuiScreen parentScreen, ModContainer mod)
+    {
+        this(parentScreen, mod.getModId(), false, false, mod.getName(), ConfigManager.getModConfigClasses(mod.getModId())); 
+    }
     
     /**
      * 
@@ -198,7 +211,25 @@ public class GuiConfig extends GuiScreen
         this.entryList = new GuiConfigEntries(this, mc);
         this.initEntries = new ArrayList<IConfigEntry>(entryList.listEntries);
         this.allRequireWorldRestart = allRequireWorldRestart;
+        IF:if(!allRequireWorldRestart)
+        {
+            for(IConfigElement element : configElements)
+            {
+                if(!element.requiresWorldRestart());
+                    break IF;
+            }
+            allRequireWorldRestart = true;
+        }
         this.allRequireMcRestart = allRequireMcRestart;
+        IF:if(!allRequireMcRestart)
+        {
+            for(IConfigElement element : configElements)
+            {
+                if(!element.requiresMcRestart());
+                    break IF;
+            }
+            allRequireMcRestart = true;
+        }
         this.modID = modID;
         this.configID = configID;
         this.isWorldRunning = mc.world != null;

--- a/src/main/java/net/minecraftforge/fml/client/config/GuiConfig.java
+++ b/src/main/java/net/minecraftforge/fml/client/config/GuiConfig.java
@@ -85,14 +85,13 @@ public class GuiConfig extends GuiScreen
     protected HoverChecker checkBoxHoverChecker;
     
     /**
-     * TODO: handle mcRestart and worldRestart
      * This constructor handles the {@code @Config} configuration classes
      * @param parentScreen the parent GuiScreen object
      * @param mod the mod for which to create a screen
      */
-    public GuiConfig(GuiScreen parentScreen, ModContainer mod)
+    public GuiConfig(GuiScreen parentScreen, String modid, String title)
     {
-        this(parentScreen, mod.getModId(), false, false, mod.getName(), ConfigManager.getModConfigClasses(mod.getModId())); 
+        this(parentScreen, modid, false, false, title, ConfigManager.getModConfigClasses(modid)); 
     }
     
     /**
@@ -113,16 +112,21 @@ public class GuiConfig extends GuiScreen
     
     private static List<IConfigElement> collectConfigElements(Class<?>[] configClasses)
     {
+        List<IConfigElement> toReturn;
         if(configClasses.length == 1)
         {
-            return ConfigElement.from(configClasses[0]).getChildElements();
+            toReturn = ConfigElement.from(configClasses[0]).getChildElements();
         }
-        List<IConfigElement> elements = new ArrayList<IConfigElement>();
-        for(Class<?> clazz : configClasses)
+        else
         {
-            elements.add(ConfigElement.from(clazz));
+            toReturn = new ArrayList<IConfigElement>();
+            for(Class<?> clazz : configClasses)
+            {
+                toReturn.add(ConfigElement.from(clazz));
+            }
         }
-        return elements;
+        toReturn.sort((IConfigElement e1, IConfigElement e2) -> I18n.format(e1.getLanguageKey()).compareTo(I18n.format(e2.getLanguageKey())));
+        return toReturn;
     }
 
     /**

--- a/src/main/java/net/minecraftforge/fml/client/config/GuiConfig.java
+++ b/src/main/java/net/minecraftforge/fml/client/config/GuiConfig.java
@@ -82,6 +82,16 @@ public class GuiConfig extends GuiScreen
     protected HoverChecker resetHoverChecker;
     protected HoverChecker checkBoxHoverChecker;
     
+    /**
+     * 
+     * @param parentScreen the parrent GuiScreen object
+     * @param modID the mod ID for the mod whose config settings will be editted
+     * @param allRequireWorldRestart whether all config elements on this screen require a world restart
+     * @param allRequireMcRestart whether all config elements on this screen require a game restart
+     * @param title the desired title for this screen. For consistency it is recommended that you pass the path of the config file being
+     *            edited.
+     * @param configClasses an array of classes annotated with {@code @Config} providing the configuration
+     */
     public GuiConfig(GuiScreen parentScreen, String modID, boolean allRequireWorldRestart, boolean allRequireMcRestart, String title,
             Class<?>... configClasses)
     {
@@ -90,6 +100,10 @@ public class GuiConfig extends GuiScreen
     
     private static List<IConfigElement> collectConfigElements(Class<?>[] configClasses)
     {
+        if(configClasses.length == 1)
+        {
+            return ConfigElement.from(configClasses[0]).getChildElements();
+        }
         List<IConfigElement> elements = new ArrayList<IConfigElement>();
         for(Class<?> clazz : configClasses)
         {

--- a/src/main/java/net/minecraftforge/fml/common/FMLModContainer.java
+++ b/src/main/java/net/minecraftforge/fml/common/FMLModContainer.java
@@ -617,7 +617,7 @@ public class FMLModContainer implements ModContainer
             }
             ProxyInjector.inject(this, event.getASMHarvestedData(), FMLCommonHandler.instance().getSide(), getLanguageAdapter());
             AutomaticEventSubscriber.inject(this, event.getASMHarvestedData(), FMLCommonHandler.instance().getSide());
-            ConfigManager.load(this.getModId(), Config.Type.INSTANCE);
+            ConfigManager.sync(this.getModId(), Config.Type.INSTANCE);
 
             processFieldAnnotations(event.getASMHarvestedData());
         }

--- a/src/test/java/net/minecraftforge/debug/ConfigTest.java
+++ b/src/test/java/net/minecraftforge/debug/ConfigTest.java
@@ -1,7 +1,5 @@
 package net.minecraftforge.debug;
 
-import java.util.ArrayList;
-import java.util.List;
 import java.util.Set;
 
 import net.minecraft.client.Minecraft;
@@ -10,11 +8,8 @@ import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.common.config.Config;
 import net.minecraftforge.common.config.ConfigManager;
 import net.minecraftforge.common.config.Config.*;
-import net.minecraftforge.common.config.ConfigElement;
 import net.minecraftforge.fml.client.IModGuiFactory;
-import net.minecraftforge.fml.client.config.DummyConfigElement;
 import net.minecraftforge.fml.client.config.GuiConfig;
-import net.minecraftforge.fml.client.config.IConfigElement;
 import net.minecraftforge.fml.client.event.ConfigChangedEvent;
 import net.minecraftforge.fml.common.Mod;
 import net.minecraftforge.fml.common.event.FMLInitializationEvent;
@@ -49,6 +44,7 @@ public class ConfigTest implements IModGuiFactory
         }
     }
 
+    @LangKey("config_test.config.types")
     @Config(modid = MODID, type = Type.INSTANCE, name = MODID + "_types")
     public static class CONFIG_TYPES
     {
@@ -91,6 +87,7 @@ public class ConfigTest implements IModGuiFactory
             public String HeyLook = "I'm Inside!";
         }
     }
+    @LangKey("config_test.config.annotations")
     @Config(modid = MODID)
     public static class CONFIG_ANNOTATIONS
     {
@@ -112,6 +109,7 @@ public class ConfigTest implements IModGuiFactory
             public String HeyLook = "Go in!";
         }
     }
+    @LangKey("config_test.config.subcats")
     @Config(modid = MODID, name = MODID + "_subcats", category = "")
     public static class CONFIG_SUBCATS
     {
@@ -133,28 +131,6 @@ public class ConfigTest implements IModGuiFactory
         }
     }
 
-    public static class ConfigurationGui extends GuiConfig
-    {
-        public ConfigurationGui(GuiScreen parentScreen)
-        {
-            super(parentScreen, collectElements(), MODID, false, false, MODID + " Config Screen");
-        }
-        
-        private static List<IConfigElement> collectElements() {
-            List<IConfigElement> elements = new ArrayList<IConfigElement>();
-            
-            elements.add(new DummyConfigElement.DummyCategoryElement("general", "gui.general", ConfigElement.from(CONFIG_ANNOTATIONS.class).getChildElements()));
-            
-            //List<IConfigElement> subcatElements = new ArrayList<IConfigElement>();
-            //subcatElements.add(new DummyConfigElement.DummyCategoryElement("test_a", "test_a", ConfigElement.from(MODID, MODID + "_subcats", "test_a").getChildElements()));
-            //subcatElements.add(new DummyConfigElement.DummyCategoryElement("test_b", "test_b", ConfigElement.from(MODID, MODID + "_subcats", "test_b").getChildElements()));
-            elements.add(new DummyConfigElement.DummyCategoryElement("subcats", "gui.subcats", ConfigElement.from(CONFIG_SUBCATS.class).getChildElements()));
-            
-            elements.add(new DummyConfigElement.DummyCategoryElement("types", "gui.types", ConfigElement.from(CONFIG_TYPES.class).getChildElements()));
-            return elements;
-        }
-    }
-
     @Override
     public void initialize(Minecraft minecraftInstance)
     {}
@@ -162,7 +138,17 @@ public class ConfigTest implements IModGuiFactory
     @Override
     public Class<? extends GuiScreen> mainConfigGuiClass()
     {
-        return ConfigurationGui.class;
+        return Gui.class;
+    }
+    
+    public static class Gui extends GuiConfig
+    {
+
+        public Gui(GuiScreen parentScreen)
+        {
+            super(parentScreen, MODID, false, false, "Config test config screen", CONFIG_ANNOTATIONS.class, CONFIG_SUBCATS.class, CONFIG_TYPES.class);
+        }
+        
     }
 
     @Override

--- a/src/test/java/net/minecraftforge/debug/ConfigTest.java
+++ b/src/test/java/net/minecraftforge/debug/ConfigTest.java
@@ -17,6 +17,7 @@ import net.minecraftforge.fml.client.config.GuiConfig;
 import net.minecraftforge.fml.client.config.IConfigElement;
 import net.minecraftforge.fml.client.event.ConfigChangedEvent;
 import net.minecraftforge.fml.common.Mod;
+import net.minecraftforge.fml.common.event.FMLInitializationEvent;
 import net.minecraftforge.fml.common.event.FMLPreInitializationEvent;
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
 
@@ -29,6 +30,16 @@ public class ConfigTest implements IModGuiFactory
     @Mod.EventHandler
     public void preInit(FMLPreInitializationEvent event) {
       MinecraftForge.EVENT_BUS.register(this);
+    }
+    
+    @Mod.EventHandler
+    public void init(FMLInitializationEvent event) {
+      System.out.println("Old: " + CONFIG_TYPES.bool);
+      CONFIG_TYPES.bool = !CONFIG_TYPES.bool;
+      System.out.println("New: " + CONFIG_TYPES.bool);
+      ConfigManager.updateConfig(MODID, Type.INSTANCE);
+      ConfigManager.sync(MODID, Type.INSTANCE);
+      System.out.println("After sync: " + CONFIG_TYPES.bool);
     }
     
     @SubscribeEvent

--- a/src/test/java/net/minecraftforge/debug/ConfigTest.java
+++ b/src/test/java/net/minecraftforge/debug/ConfigTest.java
@@ -21,11 +21,10 @@ import net.minecraftforge.fml.common.event.FMLInitializationEvent;
 import net.minecraftforge.fml.common.event.FMLPreInitializationEvent;
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
 
-@Mod(modid = ConfigTest.MODID, name = "ConfigTest", version = "1.0", acceptableRemoteVersions = "*", guiFactory = ConfigTest.GUI_FACTORY)
-public class ConfigTest implements IModGuiFactory
+@Mod(modid = ConfigTest.MODID, name = "ConfigTest", version = "1.0", acceptableRemoteVersions = "*")
+public class ConfigTest
 {
     public static final String MODID = "config_test";
-    public static final String GUI_FACTORY = "net.minecraftforge.debug.ConfigTest";
     
     @Mod.EventHandler
     public void preInit(FMLPreInitializationEvent event) {
@@ -141,6 +140,7 @@ public class ConfigTest implements IModGuiFactory
     public static class CONFIG_MAP
     {
         @Name("map")
+        @RequiresMcRestart
         public static Map<String, Integer[]> theMap;
         
         static 
@@ -156,33 +156,5 @@ public class ConfigTest implements IModGuiFactory
                 theMap.put("" + i, array);
             }
         }
-    }
-
-    @Override
-    public void initialize(Minecraft minecraftInstance)
-    {}
-
-    @Override
-    public GuiScreen createConfigGui(GuiScreen parentScreen)
-    {
-        return new GuiConfig(parentScreen, MODID, false, false, "Config test config screen", CONFIG_ANNOTATIONS.class, CONFIG_SUBCATS.class, CONFIG_TYPES.class, CONFIG_MAP.class);
-    }
-
-    @Override
-    public Set<RuntimeOptionCategoryElement> runtimeGuiCategories()
-    {
-        return null;
-    }
-
-    @Override
-    public RuntimeOptionGuiHandler getHandlerFor(RuntimeOptionCategoryElement element)
-    {
-        return null;
-    }
-
-    @Override
-    public Class<? extends GuiScreen> mainConfigGuiClass()
-    {
-        return null;
     }
 }

--- a/src/test/java/net/minecraftforge/debug/ConfigTest.java
+++ b/src/test/java/net/minecraftforge/debug/ConfigTest.java
@@ -42,7 +42,7 @@ public class ConfigTest
     
     @SubscribeEvent
     public void onConfigChangedEvent(OnConfigChangedEvent event) {
-        if(event.getModID().equals(MODID))
+        if (event.getModID().equals(MODID))
         {
             ConfigManager.sync(MODID, Type.INSTANCE);
         }
@@ -146,7 +146,7 @@ public class ConfigTest
         static 
         {
             theMap = Maps.newHashMap();
-            for(int i = 0; i < 7; i++)
+            for (int i = 0; i < 7; i++)
             {
                 Integer[] array = new Integer[6];
                 for (int x = 0; x < array.length; x++)

--- a/src/test/java/net/minecraftforge/debug/ConfigTest.java
+++ b/src/test/java/net/minecraftforge/debug/ConfigTest.java
@@ -127,7 +127,7 @@ public class ConfigTest
         public static class SubCat
         {
             @Name("i_say")
-            public static String value;
+            public String value;
             public SubCat(String value)
             {
                 this.value = value;

--- a/src/test/java/net/minecraftforge/debug/ConfigTest.java
+++ b/src/test/java/net/minecraftforge/debug/ConfigTest.java
@@ -144,14 +144,14 @@ public class ConfigTest implements IModGuiFactory
         private static List<IConfigElement> collectElements() {
             List<IConfigElement> elements = new ArrayList<IConfigElement>();
             
-            elements.add(new DummyConfigElement.DummyCategoryElement("general", "gui.general", ConfigElement.from(MODID).getChildElements()));
+            elements.add(new DummyConfigElement.DummyCategoryElement("general", "gui.general", ConfigElement.from(CONFIG_ANNOTATIONS.class).getChildElements()));
             
-            List<IConfigElement> subcatElements = new ArrayList<IConfigElement>();
-            subcatElements.add(new DummyConfigElement.DummyCategoryElement("test_a", "test_a", ConfigElement.from(MODID, MODID + "_subcats", "test_a").getChildElements()));
-            subcatElements.add(new DummyConfigElement.DummyCategoryElement("test_b", "test_b", ConfigElement.from(MODID, MODID + "_subcats", "test_b").getChildElements()));
-            elements.add(new DummyConfigElement.DummyCategoryElement("subcats", "gui.subcats", subcatElements));
+            //List<IConfigElement> subcatElements = new ArrayList<IConfigElement>();
+            //subcatElements.add(new DummyConfigElement.DummyCategoryElement("test_a", "test_a", ConfigElement.from(MODID, MODID + "_subcats", "test_a").getChildElements()));
+            //subcatElements.add(new DummyConfigElement.DummyCategoryElement("test_b", "test_b", ConfigElement.from(MODID, MODID + "_subcats", "test_b").getChildElements()));
+            elements.add(new DummyConfigElement.DummyCategoryElement("subcats", "gui.subcats", ConfigElement.from(CONFIG_SUBCATS.class).getChildElements()));
             
-            elements.add(new DummyConfigElement.DummyCategoryElement("types", "gui.types", ConfigElement.from(MODID, MODID + "_types").getChildElements()));
+            elements.add(new DummyConfigElement.DummyCategoryElement("types", "gui.types", ConfigElement.from(CONFIG_TYPES.class).getChildElements()));
             return elements;
         }
     }

--- a/src/test/java/net/minecraftforge/debug/ConfigTest.java
+++ b/src/test/java/net/minecraftforge/debug/ConfigTest.java
@@ -1,6 +1,11 @@
 package net.minecraftforge.debug;
 
+import java.util.Map;
 import java.util.Set;
+
+import com.google.common.base.Function;
+import com.google.common.collect.Maps;
+import com.google.common.collect.Sets;
 
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.GuiScreen;
@@ -10,7 +15,7 @@ import net.minecraftforge.common.config.ConfigManager;
 import net.minecraftforge.common.config.Config.*;
 import net.minecraftforge.fml.client.IModGuiFactory;
 import net.minecraftforge.fml.client.config.GuiConfig;
-import net.minecraftforge.fml.client.event.ConfigChangedEvent;
+import net.minecraftforge.fml.client.event.ConfigChangedEvent.OnConfigChangedEvent;
 import net.minecraftforge.fml.common.Mod;
 import net.minecraftforge.fml.common.event.FMLInitializationEvent;
 import net.minecraftforge.fml.common.event.FMLPreInitializationEvent;
@@ -37,7 +42,7 @@ public class ConfigTest implements IModGuiFactory
     }
     
     @SubscribeEvent
-    public void onConfigChangedEvent(ConfigChangedEvent event) {
+    public void onConfigChangedEvent(OnConfigChangedEvent event) {
         if(event.getModID().equals(MODID))
         {
             ConfigManager.sync(MODID, Type.INSTANCE);
@@ -130,6 +135,28 @@ public class ConfigTest implements IModGuiFactory
             }
         }
     }
+    
+    @LangKey("config_test.config.map")
+    @Config(modid = MODID, name = MODID + "_map")
+    public static class CONFIG_MAP
+    {
+        @Name("map")
+        public static Map<String, Integer[]> theMap;
+        
+        static 
+        {
+            theMap = Maps.newHashMap();
+            for(int i = 0; i < 7; i++)
+            {
+                Integer[] array = new Integer[6];
+                for (int x = 0; x < array.length; x++)
+                {
+                    array[x] = i + x;
+                }
+                theMap.put("" + i, array);
+            }
+        }
+    }
 
     @Override
     public void initialize(Minecraft minecraftInstance)
@@ -138,7 +165,7 @@ public class ConfigTest implements IModGuiFactory
     @Override
     public GuiScreen createConfigGui(GuiScreen parentScreen)
     {
-        return new GuiConfig(parentScreen, MODID, false, false, "Config test config screen", CONFIG_ANNOTATIONS.class, CONFIG_SUBCATS.class, CONFIG_TYPES.class);
+        return new GuiConfig(parentScreen, MODID, false, false, "Config test config screen", CONFIG_ANNOTATIONS.class, CONFIG_SUBCATS.class, CONFIG_TYPES.class, CONFIG_MAP.class);
     }
 
     @Override

--- a/src/test/java/net/minecraftforge/debug/ConfigTest.java
+++ b/src/test/java/net/minecraftforge/debug/ConfigTest.java
@@ -37,7 +37,6 @@ public class ConfigTest implements IModGuiFactory
       System.out.println("Old: " + CONFIG_TYPES.bool);
       CONFIG_TYPES.bool = !CONFIG_TYPES.bool;
       System.out.println("New: " + CONFIG_TYPES.bool);
-      ConfigManager.updateConfig(MODID, Type.INSTANCE);
       ConfigManager.sync(MODID, Type.INSTANCE);
       System.out.println("After sync: " + CONFIG_TYPES.bool);
     }

--- a/src/test/java/net/minecraftforge/debug/ConfigTest.java
+++ b/src/test/java/net/minecraftforge/debug/ConfigTest.java
@@ -17,7 +17,6 @@ import net.minecraftforge.fml.client.config.GuiConfig;
 import net.minecraftforge.fml.client.config.IConfigElement;
 import net.minecraftforge.fml.client.event.ConfigChangedEvent;
 import net.minecraftforge.fml.common.Mod;
-import net.minecraftforge.fml.common.event.FMLInitializationEvent;
 import net.minecraftforge.fml.common.event.FMLPreInitializationEvent;
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
 
@@ -30,16 +29,6 @@ public class ConfigTest implements IModGuiFactory
     @Mod.EventHandler
     public void preInit(FMLPreInitializationEvent event) {
       MinecraftForge.EVENT_BUS.register(this);
-    }
-    
-    @Mod.EventHandler
-    public void init(FMLInitializationEvent event) {
-        System.out.println("Boolean sample config is: " + CONFIG_TYPES.bool);
-        CONFIG_TYPES.bool = !CONFIG_TYPES.bool;
-        System.out.println("Changing boolean sample config to: " + CONFIG_TYPES.bool );
-        ConfigManager.sync(MODID, Type.INSTANCE);
-        System.out.println("Synced config.");
-        System.out.println("Boolean sample config now is: " + CONFIG_TYPES.bool);
     }
     
     @SubscribeEvent

--- a/src/test/java/net/minecraftforge/debug/ConfigTest.java
+++ b/src/test/java/net/minecraftforge/debug/ConfigTest.java
@@ -136,7 +136,7 @@ public class ConfigTest implements IModGuiFactory
         }
     }
     
-    @LangKey("config_test.config.map")
+    @LangKey("config_test.config.maps")
     @Config(modid = MODID, name = MODID + "_map")
     public static class CONFIG_MAP
     {

--- a/src/test/java/net/minecraftforge/debug/ConfigTest.java
+++ b/src/test/java/net/minecraftforge/debug/ConfigTest.java
@@ -152,4 +152,10 @@ public class ConfigTest implements IModGuiFactory
     {
         return null;
     }
+
+    @Override
+    public Class<? extends GuiScreen> mainConfigGuiClass()
+    {
+        return null;
+    }
 }

--- a/src/test/java/net/minecraftforge/debug/ConfigTest.java
+++ b/src/test/java/net/minecraftforge/debug/ConfigTest.java
@@ -136,19 +136,9 @@ public class ConfigTest implements IModGuiFactory
     {}
 
     @Override
-    public Class<? extends GuiScreen> mainConfigGuiClass()
+    public GuiScreen mainConfigGui(GuiScreen parentScreen)
     {
-        return Gui.class;
-    }
-    
-    public static class Gui extends GuiConfig
-    {
-
-        public Gui(GuiScreen parentScreen)
-        {
-            super(parentScreen, MODID, false, false, "Config test config screen", CONFIG_ANNOTATIONS.class, CONFIG_SUBCATS.class, CONFIG_TYPES.class);
-        }
-        
+        return new GuiConfig(parentScreen, MODID, false, false, "Config test config screen", CONFIG_ANNOTATIONS.class, CONFIG_SUBCATS.class, CONFIG_TYPES.class);
     }
 
     @Override

--- a/src/test/java/net/minecraftforge/debug/ConfigTest.java
+++ b/src/test/java/net/minecraftforge/debug/ConfigTest.java
@@ -136,7 +136,7 @@ public class ConfigTest implements IModGuiFactory
     {}
 
     @Override
-    public GuiScreen mainConfigGui(GuiScreen parentScreen)
+    public GuiScreen createConfigGui(GuiScreen parentScreen)
     {
         return new GuiConfig(parentScreen, MODID, false, false, "Config test config screen", CONFIG_ANNOTATIONS.class, CONFIG_SUBCATS.class, CONFIG_TYPES.class);
     }

--- a/src/test/resources/assets/config_test/lang/en_US.lang
+++ b/src/test/resources/assets/config_test/lang/en_US.lang
@@ -1,0 +1,3 @@
+config_test.config.types=Field Types
+config_test.config.annotations=Annotations
+config_test.config.subcats=Subcategories

--- a/src/test/resources/assets/config_test/lang/en_US.lang
+++ b/src/test/resources/assets/config_test/lang/en_US.lang
@@ -1,3 +1,4 @@
 config_test.config.types=Field Types
 config_test.config.annotations=Annotations
 config_test.config.subcats=Subcategories
+config_test.config.maps=Maps

--- a/src/test/resources/mcmod.info
+++ b/src/test/resources/mcmod.info
@@ -1,0 +1,16 @@
+[
+{
+  "modid": "config_test",
+  "name": "ConfigTest",
+  "description": "Tests config",
+  "version": "1.0",
+  "mcversion": "",
+  "url": "",
+  "updateUrl": "",
+  "authorList": [""],
+  "credits": "",
+  "logoFile": "",
+  "screenshots": [],
+  "dependencies": []
+}
+]


### PR DESCRIPTION
Currently, the annotation based configuration system provides no easy way to get access to the necessary objects to create a configuration GUI. Also it is currently not possible to save changes, which were made programatically to the configuration variables, to disk.

This PR changes the following:
It renames the `ConfigManager.load()` method to `ConfigManager.sync()` as it is capable of saving changes made to the Configuration object to the config file.
The usage of this method to write to disk is needed, as changes to the Configuration object are now possible with the now creatable configuration GUIs, aswell as with the new `ConfigManager.updateConfig()` method, which applies changes made to the variables the config is saved in to the Configuration object.

The class `ConfigElement` was changed to provide Methods to get an object for Configuration objects managed by the ConfigManager.

The already existing test mod ConfigTest was changed to showcase the new methods used to create a ConfigGui and to showcase the new saving method in `init()`.

This PR closes Issue #3729