### PR TITLE
Add EnumHand and ItemStack to BonemealEvent

### DIFF
--- a/patches/minecraft/net/minecraft/item/ItemDye.java.patch
+++ b/patches/minecraft/net/minecraft/item/ItemDye.java.patch
@@ -40,7 +40,7 @@
 +    {
          IBlockState iblockstate = p_179234_1_.func_180495_p(p_179234_2_);
  
-+        int hook =  net.minecraftforge.event.ForgeEventFactory.onApplyBonemeal(player, p_179234_1_, p_179234_2_, iblockstate, p_179234_0_, hand);
++        int hook = net.minecraftforge.event.ForgeEventFactory.onApplyBonemeal(player, p_179234_1_, p_179234_2_, iblockstate, p_179234_0_, hand);
 +        if (hook != 0) return hook > 0;
 +
          if (iblockstate.func_177230_c() instanceof IGrowable)

--- a/patches/minecraft/net/minecraft/item/ItemDye.java.patch
+++ b/patches/minecraft/net/minecraft/item/ItemDye.java.patch
@@ -5,7 +5,7 @@
              if (enumdyecolor == EnumDyeColor.WHITE)
              {
 -                if (func_179234_a(itemstack, p_180614_2_, p_180614_3_))
-+                if (applyBonemeal(itemstack, p_180614_2_, p_180614_3_, p_180614_1_))
++                if (applyBonemeal(itemstack, p_180614_2_, p_180614_3_, p_180614_1_, p_180614_4_))
                  {
                      if (!p_180614_2_.field_72995_K)
                      {
@@ -18,26 +18,35 @@
                          p_180614_2_.func_180501_a(p_180614_3_, iblockstate1, 10);
  
                          if (!p_180614_1_.field_71075_bZ.field_75098_d)
-@@ -99,8 +99,18 @@
+@@ -99,8 +99,27 @@
  
      public static boolean func_179234_a(ItemStack p_179234_0_, World p_179234_1_, BlockPos p_179234_2_)
      {
 +        if (p_179234_1_ instanceof net.minecraft.world.WorldServer)
-+            return applyBonemeal(p_179234_0_, p_179234_1_, p_179234_2_, net.minecraftforge.common.util.FakePlayerFactory.getMinecraft((net.minecraft.world.WorldServer)p_179234_1_));
++            return applyBonemeal(p_179234_0_, p_179234_1_, p_179234_2_, net.minecraftforge.common.util.FakePlayerFactory.getMinecraft((net.minecraft.world.WorldServer)p_179234_1_), null);
 +        return false;
 +    }
 +
++    /**
++     * @deprecated Use {@link #applyBonemeal(ItemStack, World, BlockPos, EntityPlayer, EnumHand)} instead.
++     */
++    @Deprecated
 +    public static boolean applyBonemeal(ItemStack p_179234_0_, World p_179234_1_, BlockPos p_179234_2_, EntityPlayer player)
++    {
++        return applyBonemeal(p_179234_0_, p_179234_1_, p_179234_2_, player, null);
++    }
++
++    public static boolean applyBonemeal(ItemStack p_179234_0_, World p_179234_1_, BlockPos p_179234_2_, EntityPlayer player, @javax.annotation.Nullable EnumHand hand)
 +    {
          IBlockState iblockstate = p_179234_1_.func_180495_p(p_179234_2_);
  
-+        int hook = net.minecraftforge.event.ForgeEventFactory.onApplyBonemeal(player, p_179234_1_, p_179234_2_, iblockstate, p_179234_0_);
++        int hook =  net.minecraftforge.event.ForgeEventFactory.onApplyBonemeal(player, p_179234_1_, p_179234_2_, iblockstate, p_179234_0_, hand);
 +        if (hook != 0) return hook > 0;
 +
          if (iblockstate.func_177230_c() instanceof IGrowable)
          {
              IGrowable igrowable = (IGrowable)iblockstate.func_177230_c();
-@@ -144,6 +154,16 @@
+@@ -144,6 +163,16 @@
                  p_180617_0_.func_175688_a(EnumParticleTypes.VILLAGER_HAPPY, (double)((float)p_180617_1_.func_177958_n() + field_77697_d.nextFloat()), (double)p_180617_1_.func_177956_o() + (double)field_77697_d.nextFloat() * iblockstate.func_185900_c(p_180617_0_, p_180617_1_).field_72337_e, (double)((float)p_180617_1_.func_177952_p() + field_77697_d.nextFloat()), d0, d1, d2, new int[0]);
              }
          }

--- a/src/main/java/net/minecraftforge/event/ForgeEventFactory.java
+++ b/src/main/java/net/minecraftforge/event/ForgeEventFactory.java
@@ -355,7 +355,8 @@ public class ForgeEventFactory
      * @deprecated Use {@link #onApplyBonemeal(EntityPlayer, World, BlockPos, IBlockState, ItemStack, EnumHand)} instead.
      */
     @Deprecated
-    public static int onApplyBonemeal(EntityPlayer player, World world, BlockPos pos, IBlockState state, ItemStack stack){
+    public static int onApplyBonemeal(EntityPlayer player, World world, BlockPos pos, IBlockState state, ItemStack stack)
+    {
         return onApplyBonemeal(player, world, pos, state, stack, null);
     }
 

--- a/src/main/java/net/minecraftforge/event/ForgeEventFactory.java
+++ b/src/main/java/net/minecraftforge/event/ForgeEventFactory.java
@@ -351,9 +351,17 @@ public class ForgeEventFactory
         return 0;
     }
 
-    public static int onApplyBonemeal(EntityPlayer player, World world, BlockPos pos, IBlockState state, ItemStack stack)
+    /**
+     * @deprecated Use {@link #onApplyBonemeal(EntityPlayer, World, BlockPos, IBlockState, ItemStack, EnumHand)} instead.
+     */
+    @Deprecated
+    public static int onApplyBonemeal(EntityPlayer player, World world, BlockPos pos, IBlockState state, ItemStack stack){
+        return onApplyBonemeal(player, world, pos, state, stack, null);
+    }
+
+    public static int onApplyBonemeal(@Nonnull EntityPlayer player, @Nonnull World world, @Nonnull BlockPos pos, @Nonnull IBlockState state, @Nonnull ItemStack stack, @Nullable EnumHand hand)
     {
-        BonemealEvent event = new BonemealEvent(player, world, pos, state);
+        BonemealEvent event = new BonemealEvent(player, world, pos, state, hand, stack);
         if (MinecraftForge.EVENT_BUS.post(event)) return -1;
         if (event.getResult() == Result.ALLOW)
         {

--- a/src/main/java/net/minecraftforge/event/entity/player/BonemealEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/player/BonemealEvent.java
@@ -23,8 +23,13 @@ import net.minecraftforge.fml.common.eventhandler.Cancelable;
 import net.minecraftforge.fml.common.eventhandler.Event;
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.item.ItemStack;
+import net.minecraft.util.EnumHand;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.World;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 
 /**
  * This event is called when a player attempts to use Bonemeal on a block.
@@ -43,13 +48,27 @@ public class BonemealEvent extends PlayerEvent
     private final World world;
     private final BlockPos pos;
     private final IBlockState block;
+    private final EnumHand hand;
+    private final ItemStack stack;
 
+    /**
+     * @deprecated Use {@link #BonemealEvent(EntityPlayer, World, BlockPos, IBlockState, EnumHand, ItemStack)} instead.
+     */
+    @Deprecated
     public BonemealEvent(EntityPlayer player, World world, BlockPos pos, IBlockState block)
+    {
+        this(player, world, pos, block, null, ItemStack.EMPTY);
+    }
+
+    public BonemealEvent(@Nonnull EntityPlayer player, @Nonnull World world, @Nonnull BlockPos pos, @Nonnull IBlockState block, @Nullable EnumHand hand,
+            @Nonnull ItemStack stack)
     {
         super(player);
         this.world = world;
         this.pos = pos;
         this.block = block;
+        this.hand = hand;
+        this.stack = stack;
     }
 
     public World getWorld()
@@ -65,5 +84,17 @@ public class BonemealEvent extends PlayerEvent
     public IBlockState getBlock()
     {
         return block;
+    }
+
+    @Nullable
+    public EnumHand getHand()
+    {
+        return hand;
+    }
+
+    @Nonnull
+    public ItemStack getStack()
+    {
+        return stack;
     }
 }

--- a/src/test/java/net/minecraftforge/debug/BonemealEventTest.java
+++ b/src/test/java/net/minecraftforge/debug/BonemealEventTest.java
@@ -14,7 +14,7 @@ public class BonemealEventTest
 {
     public static final String MODID = "bonemealeventtest";
 
-    private static final boolean ENABLED = true;
+    private static final boolean ENABLED = false;
     private static Logger logger;
 
     @Mod.EventHandler

--- a/src/test/java/net/minecraftforge/debug/BonemealEventTest.java
+++ b/src/test/java/net/minecraftforge/debug/BonemealEventTest.java
@@ -1,0 +1,52 @@
+package net.minecraftforge.debug;
+
+import net.minecraft.util.EnumHand;
+import net.minecraftforge.common.MinecraftForge;
+import net.minecraftforge.event.entity.player.BonemealEvent;
+import net.minecraftforge.fml.common.Mod;
+import net.minecraftforge.fml.common.event.FMLPreInitializationEvent;
+import net.minecraftforge.fml.common.eventhandler.Event;
+import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
+import org.apache.logging.log4j.Logger;
+
+@Mod(modid = BonemealEventTest.MODID, version = "1.0")
+public class BonemealEventTest
+{
+    public static final String MODID = "bonemealeventtest";
+
+    private static final boolean ENABLED = true;
+    private static Logger logger;
+
+    @Mod.EventHandler
+    public void preInit(FMLPreInitializationEvent event)
+    {
+        logger = event.getModLog();
+
+        if (ENABLED)
+        {
+            MinecraftForge.EVENT_BUS.register(BonemealEventTest.class);
+        }
+    }
+
+    @SubscribeEvent
+    public static void onBonemeal(BonemealEvent event)
+    {
+        if (event.getHand() == EnumHand.MAIN_HAND)
+        {
+            // If the bone meal is being used from the main hand, set the result to ALLOW to use up the bone meal without growing the crop
+            event.setResult(Event.Result.ALLOW);
+            logger.info("Prevented bone meal growth effect from main hand");
+        }
+        else if (event.getHand() == EnumHand.OFF_HAND)
+        {
+            // If the bone meal is being used from the off hand, cancel the event to prevent it being used at all
+            event.setCanceled(true);
+            logger.info("Prevented bone meal use from off hand");
+        }
+        else
+        {
+            // If the bone meal is being used from a dispenser or something similar, allow it
+            logger.info("Allowed bone meal use from dispenser");
+        }
+    }
+}


### PR DESCRIPTION
There's currently no way of telling which hand a player used to trigger `BonemealEvent`.

This PR allows access to the `EnumHand` and the `ItemStack` that triggered `BonemealEvent`.

When bone meal is used in something like a dispenser, the `EnumHand` will be `null`.

This could be used for things like only allowing bone meal to function in one hand (which the included test mod does) or conditionally cancelling the event based on an item capability.