### PR TITLE
Record which ModContainer creates each crafting recipe

### DIFF
--- a/patches/minecraft/net/minecraft/item/crafting/CraftingManager.java.patch
+++ b/patches/minecraft/net/minecraft/item/crafting/CraftingManager.java.patch
@@ -1,0 +1,27 @@
+--- ../src-base/minecraft/net/minecraft/item/crafting/CraftingManager.java
++++ ../src-work/minecraft/net/minecraft/item/crafting/CraftingManager.java
+@@ -24,7 +24,7 @@
+ public class CraftingManager
+ {
+     private static final CraftingManager field_77598_a = new CraftingManager();
+-    private final List<IRecipe> field_77597_b = Lists.<IRecipe>newArrayList();
++    private final List<IRecipe> field_77597_b = new net.minecraftforge.fml.common.ModTrackingList<IRecipe>(Lists.<IRecipe>newArrayList());
+ 
+     public static CraftingManager func_77594_a()
+     {
+@@ -345,4 +345,15 @@
+     {
+         return this.field_77597_b;
+     }
++
++    /* ======================================== FORGE START =====================================*/
++    /**
++     * returns the ModContainer that registered the given recipe with the CraftingManager.
++     * returns null if the ModContainer is unknown or it was registered by vanilla.
++     */
++    @javax.annotation.Nullable
++    public net.minecraftforge.fml.common.ModContainer getModContainer(IRecipe recipe)
++    {
++        return ((net.minecraftforge.fml.common.ModTrackingList<IRecipe>) field_77597_b).getModContainer(recipe);
++    }
+ }

--- a/src/main/java/net/minecraftforge/fml/common/ModTrackingList.java
+++ b/src/main/java/net/minecraftforge/fml/common/ModTrackingList.java
@@ -31,17 +31,18 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.ListIterator;
 import java.util.Map;
+import java.util.RandomAccess;
 
 /**
  * Wraps a list and keeps track of which active mod container added each element in the list.
  * Adds the method {@link #getModContainer(Object)}.
  */
-public class ModTrackingList<T> extends ForwardingList<T>
+public class ModTrackingList<T> extends ForwardingList<T> implements RandomAccess
 {
     private final List<T> delegate;
     private final Map<T, ModContainer> modContainerMap;
 
-    public ModTrackingList(@Nonnull List<T> delegate)
+    public <D extends List<T> & RandomAccess> ModTrackingList(@Nonnull D delegate)
     {
         this(delegate, new IdentityHashMap<T, ModContainer>());
     }

--- a/src/main/java/net/minecraftforge/fml/common/ModTrackingList.java
+++ b/src/main/java/net/minecraftforge/fml/common/ModTrackingList.java
@@ -1,0 +1,315 @@
+/*
+ * Minecraft Forge
+ * Copyright (c) 2016.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation version 2.1
+ * of the License.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+package net.minecraftforge.fml.common;
+
+import com.google.common.collect.ForwardingIterator;
+import com.google.common.collect.ForwardingList;
+import com.google.common.collect.ForwardingListIterator;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.util.Collection;
+import java.util.IdentityHashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.ListIterator;
+import java.util.Map;
+
+/**
+ * Wraps a list and keeps track of which active mod container added each element in the list.
+ * Adds the method {@link #getModContainer(Object)}.
+ */
+public class ModTrackingList<T> extends ForwardingList<T>
+{
+    private final List<T> delegate;
+    private final Map<T, ModContainer> modContainerMap;
+
+    public ModTrackingList(@Nonnull List<T> delegate)
+    {
+        this(delegate, new IdentityHashMap<T, ModContainer>());
+    }
+
+    private ModTrackingList(@Nonnull List<T> delegate, @Nonnull Map<T, ModContainer> modContainerMap)
+    {
+        this.delegate = delegate;
+        this.modContainerMap = modContainerMap;
+    }
+
+    @Nullable
+    public ModContainer getModContainer(@Nonnull T element)
+    {
+        return modContainerMap.get(element);
+    }
+
+    @Override
+    protected List<T> delegate()
+    {
+        return delegate;
+    }
+
+    private void trackModContainer(@Nonnull T element)
+    {
+        ModContainer modContainer = Loader.instance().activeModContainer();
+        if (modContainer != null)
+        {
+            modContainerMap.put(element, modContainer);
+        }
+    }
+
+    @Override
+    public boolean add(@Nonnull T t)
+    {
+        boolean changed = delegate.add(t);
+        if (changed)
+        {
+            trackModContainer(t);
+        }
+        return changed;
+    }
+
+    @Override
+    public void add(int index, @Nonnull T element)
+    {
+        delegate.add(index, element);
+        trackModContainer(element);
+    }
+
+    @Override
+    public boolean addAll(int index, @Nonnull Collection<? extends T> elements)
+    {
+        boolean changed = delegate.addAll(index, elements);
+        if (changed)
+        {
+            ModContainer modContainer = Loader.instance().activeModContainer();
+            if (modContainer != null)
+            {
+                for (T element : elements)
+                {
+                    modContainerMap.put(element, modContainer);
+                }
+            }
+        }
+        return changed;
+    }
+
+    @Override
+    public boolean addAll(@Nonnull Collection<? extends T> collection)
+    {
+        boolean changed = delegate.addAll(collection);
+        if (changed)
+        {
+            ModContainer modContainer = Loader.instance().activeModContainer();
+            if (modContainer != null)
+            {
+                for (T element : collection)
+                {
+                    modContainerMap.put(element, modContainer);
+                }
+            }
+        }
+        return changed;
+    }
+
+    @Override
+    public T remove(int index)
+    {
+        T removed = delegate.remove(index);
+        if (removed != null)
+        {
+            modContainerMap.remove(removed);
+        }
+        return removed;
+    }
+
+    @Override
+    public boolean remove(@Nonnull Object object)
+    {
+        boolean changed = delegate.remove(object);
+        if (changed)
+        {
+            modContainerMap.remove(object);
+        }
+        return changed;
+    }
+
+    @Override
+    public boolean removeAll(@Nonnull Collection<?> collection)
+    {
+        boolean changed = delegate.removeAll(collection);
+        if (changed)
+        {
+            modContainerMap.keySet().removeAll(collection);
+        }
+        return changed;
+    }
+
+    @Override
+    public T set(int index, @Nonnull T element)
+    {
+        T previous = delegate.set(index, element);
+        if (previous != null)
+        {
+            modContainerMap.remove(previous);
+        }
+        trackModContainer(element);
+        return previous;
+    }
+
+    @Nonnull
+    @Override
+    public List<T> subList(int fromIndex, int toIndex)
+    {
+        List<T> delegateSubList = delegate.subList(fromIndex, toIndex);
+        return new ModTrackingList<T>(delegateSubList, modContainerMap);
+    }
+
+    @Override
+    public boolean retainAll(@Nonnull Collection<?> collection)
+    {
+        boolean changed = delegate.retainAll(collection);
+        if (changed)
+        {
+            modContainerMap.keySet().retainAll(collection);
+        }
+        return changed;
+    }
+
+    @Nonnull
+    @Override
+    public Iterator<T> iterator()
+    {
+        return new ModTrackedIterator(delegate.iterator());
+    }
+
+    @Nonnull
+    @Override
+    public ListIterator<T> listIterator()
+    {
+        return new ModTrackedListIterator(delegate.listIterator());
+    }
+
+    @Nonnull
+    @Override
+    public ListIterator<T> listIterator(int index)
+    {
+        return new ModTrackedListIterator(delegate.listIterator(index));
+    }
+
+    @Override
+    public void clear()
+    {
+        delegate.clear();
+        modContainerMap.clear();
+    }
+
+    private class ModTrackedIterator extends ForwardingIterator<T>
+    {
+        private final Iterator<T> delegate;
+        @Nullable
+        private T lastValue;
+
+        public ModTrackedIterator(Iterator<T> delegate)
+        {
+            this.delegate = delegate;
+        }
+
+        @Override
+        protected Iterator<T> delegate()
+        {
+            return delegate;
+        }
+
+        @Override
+        public T next()
+        {
+            lastValue = delegate.next();
+            return lastValue;
+        }
+
+        @Override
+        public void remove()
+        {
+            delegate.remove();
+            if (lastValue != null)
+            {
+                modContainerMap.remove(lastValue);
+            }
+        }
+    }
+
+    private class ModTrackedListIterator extends ForwardingListIterator<T>
+    {
+        private final ListIterator<T> delegate;
+        @Nullable
+        private T lastValue;
+
+        public ModTrackedListIterator(ListIterator<T> delegate)
+        {
+            this.delegate = delegate;
+        }
+        @Override
+        protected ListIterator<T> delegate()
+        {
+            return delegate;
+        }
+
+        @Override
+        public T next()
+        {
+            lastValue = delegate.next();
+            return lastValue;
+        }
+
+        @Override
+        public T previous()
+        {
+            lastValue = delegate.previous();
+            return lastValue;
+        }
+
+        @Override
+        public void remove()
+        {
+            delegate.remove();
+            if (lastValue != null)
+            {
+                modContainerMap.remove(lastValue);
+            }
+        }
+
+        @Override
+        public void add(@Nonnull T element)
+        {
+            delegate.add(element);
+            trackModContainer(element);
+        }
+
+        @Override
+        public void set(@Nonnull T element)
+        {
+            delegate.set(element);
+            if (lastValue != null)
+            {
+                modContainerMap.remove(lastValue);
+            }
+            trackModContainer(element);
+        }
+    }
+}

--- a/src/main/java/net/minecraftforge/fml/common/ModTrackingList.java
+++ b/src/main/java/net/minecraftforge/fml/common/ModTrackingList.java
@@ -74,6 +74,18 @@ public class ModTrackingList<T> extends ForwardingList<T> implements RandomAcces
         }
     }
 
+    private void trackModContainer(@Nonnull Collection<? extends T> elements)
+    {
+        ModContainer modContainer = Loader.instance().activeModContainer();
+        if (modContainer != null)
+        {
+            for (T element : elements)
+            {
+                modContainerMap.put(element, modContainer);
+            }
+        }
+    }
+
     @Override
     public boolean add(@Nonnull T t)
     {
@@ -98,14 +110,7 @@ public class ModTrackingList<T> extends ForwardingList<T> implements RandomAcces
         boolean changed = delegate.addAll(index, elements);
         if (changed)
         {
-            ModContainer modContainer = Loader.instance().activeModContainer();
-            if (modContainer != null)
-            {
-                for (T element : elements)
-                {
-                    modContainerMap.put(element, modContainer);
-                }
-            }
+            trackModContainer(elements);
         }
         return changed;
     }
@@ -116,14 +121,7 @@ public class ModTrackingList<T> extends ForwardingList<T> implements RandomAcces
         boolean changed = delegate.addAll(collection);
         if (changed)
         {
-            ModContainer modContainer = Loader.instance().activeModContainer();
-            if (modContainer != null)
-            {
-                for (T element : collection)
-                {
-                    modContainerMap.put(element, modContainer);
-                }
-            }
+            trackModContainer(collection);
         }
         return changed;
     }

--- a/src/test/java/net/minecraftforge/debug/RecipeDebug.java
+++ b/src/test/java/net/minecraftforge/debug/RecipeDebug.java
@@ -1,0 +1,89 @@
+package net.minecraftforge.debug;
+
+import net.minecraft.init.Items;
+import net.minecraft.item.ItemStack;
+import net.minecraft.item.crafting.CraftingManager;
+import net.minecraft.item.crafting.IRecipe;
+import net.minecraft.item.crafting.ShapelessRecipes;
+import net.minecraftforge.fml.common.Mod;
+import net.minecraftforge.fml.common.ModContainer;
+import net.minecraftforge.fml.common.event.FMLPostInitializationEvent;
+import net.minecraftforge.fml.common.event.FMLPreInitializationEvent;
+import org.apache.logging.log4j.Logger;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Mod(modid = RecipeDebug.MOD_ID, name = "ForgeRecipeDebug", version = "1.0")
+public class RecipeDebug
+{
+    public static final String MOD_ID = "recipedebug";
+
+    public static final boolean ENABLE = false;
+
+    public Logger logger;
+
+    @Mod.EventHandler
+    public void preInit(FMLPreInitializationEvent event)
+    {
+        if (!ENABLE)
+            return;
+
+        logger = event.getModLog();
+
+        // create a broken shapeless recipe
+        CraftingManager.getInstance().addShapelessRecipe(new ItemStack(Items.DIAMOND, 64), Items.PAPER, Items.AIR, Items.PAPER);
+    }
+
+    @Mod.EventHandler
+    public void postInit(FMLPostInitializationEvent event)
+    {
+        if (!ENABLE)
+            return;
+
+        for (IRecipe recipe : CraftingManager.getInstance().getRecipeList())
+        {
+            if (recipe instanceof ShapelessRecipes)
+            {
+                ShapelessRecipes shapelessRecipe = (ShapelessRecipes) recipe;
+                if (!isValidShapelessRecipe(shapelessRecipe))
+                {
+                    logInvalidShapelessRecipe(shapelessRecipe);
+                }
+            }
+        }
+    }
+
+    private boolean isValidShapelessRecipe(ShapelessRecipes shapelessRecipe)
+    {
+        if (shapelessRecipe.getRecipeOutput().isEmpty())
+        {
+            return false;
+        }
+        for (ItemStack input : shapelessRecipe.recipeItems)
+        {
+            if (input == null || input.isEmpty())
+            {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private void logInvalidShapelessRecipe(ShapelessRecipes shapelessRecipe)
+    {
+        ModContainer modContainer = CraftingManager.getInstance().getModContainer(shapelessRecipe);
+        if (modContainer != null)
+        {
+            List<String> inputs = new ArrayList<String>();
+            for (ItemStack input : shapelessRecipe.recipeItems)
+            {
+                inputs.add(input == null ? "null" : input.toString());
+            }
+            String name = modContainer.getName();
+            String modId = modContainer.getModId();
+            ItemStack recipeOutput = shapelessRecipe.getRecipeOutput();
+            logger.info("Found invalid shapeless crafting recipe from mod: {} ({}).\nInputs: {}\nOutput: {}", name, modId, inputs, recipeOutput);
+        }
+    }
+}

--- a/src/test/java/net/minecraftforge/debug/RecipeDebug.java
+++ b/src/test/java/net/minecraftforge/debug/RecipeDebug.java
@@ -52,14 +52,24 @@ public class RecipeDebug
         CraftingManager.getInstance().addShapelessRecipe(new ItemStack(Items.DIAMOND, 64), Items.PAPER, Items.AIR, Items.PAPER);
     }
 
+    /**
+     * Run tests after {@link ForgeModContainer#onAvailable(FMLLoadCompleteEvent)} has baked the recipe sorter and sorted the recipes.
+     */
     @Mod.EventHandler
-    public void postInit(FMLPostInitializationEvent event)
+    public void onAvailable(FMLLoadCompleteEvent evt)
     {
         if (!ENABLE)
         {
             return;
         }
 
+        checkShapelessRecipes();
+
+        runRecipeTest(Lists.<IRecipe>newArrayList(), "Vanilla");
+        runRecipeTest(new ModTrackingList<IRecipe>(Lists.<IRecipe>newArrayList()), "ModTracking");
+    }
+
+    private void checkShapelessRecipes() {
         for (IRecipe recipe : CraftingManager.getInstance().getRecipeList())
         {
             if (recipe instanceof ShapelessRecipes)
@@ -73,24 +83,6 @@ public class RecipeDebug
         }
     }
 
-    /**
-     * Run performance test after {@link ForgeModContainer#onAvailable(FMLLoadCompleteEvent)} has baked the recipe sorter.
-     */
-    @Mod.EventHandler
-    public void onAvailable(FMLLoadCompleteEvent evt)
-    {
-        if (!ENABLE)
-        {
-            return;
-        }
-
-        for (int i = 0; i < 5; i++)
-        {
-            runRecipeTest(Lists.<IRecipe>newArrayList(), "Vanilla");
-            runRecipeTest(new ModTrackingList<IRecipe>(Lists.<IRecipe>newArrayList()), "ModTracking");
-        }
-    }
-
     private void runRecipeTest(List<IRecipe> listImpl, String listName)
     {
         Stopwatch stopwatch = Stopwatch.createStarted();
@@ -101,7 +93,7 @@ public class RecipeDebug
         }
         Collections.sort(listImpl, RecipeSorter.INSTANCE);
         stopwatch.stop();
-        logger.info("{} recipe list registration and sorting took {} ms", listName, stopwatch.elapsed(TimeUnit.MILLISECONDS));
+        logger.info("10000 {} recipe list registration and sorting took {} ms", listName, stopwatch.elapsed(TimeUnit.MILLISECONDS));
     }
 
     /**

--- a/src/test/java/net/minecraftforge/debug/RecipeDebug.java
+++ b/src/test/java/net/minecraftforge/debug/RecipeDebug.java
@@ -1,18 +1,33 @@
 package net.minecraftforge.debug;
 
+import com.google.common.base.Stopwatch;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+import net.minecraft.block.Block;
+import net.minecraft.init.Blocks;
 import net.minecraft.init.Items;
+import net.minecraft.item.EnumDyeColor;
+import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraft.item.crafting.CraftingManager;
 import net.minecraft.item.crafting.IRecipe;
+import net.minecraft.item.crafting.ShapedRecipes;
 import net.minecraft.item.crafting.ShapelessRecipes;
+import net.minecraftforge.common.ForgeModContainer;
 import net.minecraftforge.fml.common.Mod;
 import net.minecraftforge.fml.common.ModContainer;
+import net.minecraftforge.fml.common.ModTrackingList;
+import net.minecraftforge.fml.common.event.FMLLoadCompleteEvent;
 import net.minecraftforge.fml.common.event.FMLPostInitializationEvent;
 import net.minecraftforge.fml.common.event.FMLPreInitializationEvent;
+import net.minecraftforge.oredict.RecipeSorter;
 import org.apache.logging.log4j.Logger;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
 
 @Mod(modid = RecipeDebug.MOD_ID, name = "ForgeRecipeDebug", version = "1.0")
 public class RecipeDebug
@@ -27,7 +42,9 @@ public class RecipeDebug
     public void preInit(FMLPreInitializationEvent event)
     {
         if (!ENABLE)
+        {
             return;
+        }
 
         logger = event.getModLog();
 
@@ -39,7 +56,9 @@ public class RecipeDebug
     public void postInit(FMLPostInitializationEvent event)
     {
         if (!ENABLE)
+        {
             return;
+        }
 
         for (IRecipe recipe : CraftingManager.getInstance().getRecipeList())
         {
@@ -52,6 +71,145 @@ public class RecipeDebug
                 }
             }
         }
+    }
+
+    /**
+     * Run performance test after {@link ForgeModContainer#onAvailable(FMLLoadCompleteEvent)} has baked the recipe sorter.
+     */
+    @Mod.EventHandler
+    public void onAvailable(FMLLoadCompleteEvent evt)
+    {
+        if (!ENABLE)
+        {
+            return;
+        }
+
+        for (int i = 0; i < 5; i++)
+        {
+            runRecipeTest(Lists.<IRecipe>newArrayList(), "Vanilla");
+            runRecipeTest(new ModTrackingList<IRecipe>(Lists.<IRecipe>newArrayList()), "ModTracking");
+        }
+    }
+
+    private void runRecipeTest(List<IRecipe> listImpl, String listName)
+    {
+        Stopwatch stopwatch = Stopwatch.createStarted();
+        for (int i = 0; i < 10000; i++)
+        {
+            addShapelessRecipe(listImpl, new ItemStack(Items.IRON_SHOVEL), Blocks.DIRT, Items.NETHER_STAR, new ItemStack(Items.DYE, 1, EnumDyeColor.BLACK.getMetadata()));
+            addRecipe(listImpl, new ItemStack(Items.GOLD_INGOT), "DDD", "A A", "NNN", 'D', Blocks.DIRT, 'A', Items.APPLE, 'N', Items.NETHER_STAR);
+        }
+        Collections.sort(listImpl, RecipeSorter.INSTANCE);
+        stopwatch.stop();
+        logger.info("{} recipe list registration and sorting took {} ms", listName, stopwatch.elapsed(TimeUnit.MILLISECONDS));
+    }
+
+    /**
+     * Copied from {@link CraftingManager#addShapelessRecipe(ItemStack, Object...)}
+     * for testing performance of list implementations
+     */
+    public static void addShapelessRecipe(List<IRecipe> recipes, ItemStack stack, Object... recipeComponents)
+    {
+        List<ItemStack> list = Lists.<ItemStack>newArrayList();
+
+        for (Object object : recipeComponents)
+        {
+            if (object instanceof ItemStack)
+            {
+                list.add(((ItemStack) object).copy());
+            }
+            else if (object instanceof Item)
+            {
+                list.add(new ItemStack((Item) object));
+            }
+            else
+            {
+                if (!(object instanceof Block))
+                {
+                    throw new IllegalArgumentException("Invalid shapeless recipe: unknown type " + object.getClass().getName() + "!");
+                }
+
+                list.add(new ItemStack((Block) object));
+            }
+        }
+
+        recipes.add(new ShapelessRecipes(stack, list));
+    }
+
+    /**
+     * Copied from {@link CraftingManager#addRecipe(ItemStack, Object...)}
+     * for testing performance of list implementations
+     */
+    public static void addRecipe(List<IRecipe> recipes, ItemStack stack, Object... recipeComponents)
+    {
+        String s = "";
+        int i = 0;
+        int j = 0;
+        int k = 0;
+
+        if (recipeComponents[i] instanceof String[])
+        {
+            String[] astring = (String[]) ((String[]) recipeComponents[i++]);
+
+            for (String s2 : astring)
+            {
+                ++k;
+                j = s2.length();
+                s = s + s2;
+            }
+        }
+        else
+        {
+            while (recipeComponents[i] instanceof String)
+            {
+                String s1 = (String) recipeComponents[i++];
+                ++k;
+                j = s1.length();
+                s = s + s1;
+            }
+        }
+
+        Map<Character, ItemStack> map;
+
+        for (map = Maps.<Character, ItemStack>newHashMap(); i < recipeComponents.length; i += 2)
+        {
+            Character character = (Character) recipeComponents[i];
+            ItemStack itemstack = ItemStack.EMPTY;
+
+            if (recipeComponents[i + 1] instanceof Item)
+            {
+                itemstack = new ItemStack((Item) recipeComponents[i + 1]);
+            }
+            else if (recipeComponents[i + 1] instanceof Block)
+            {
+                itemstack = new ItemStack((Block) recipeComponents[i + 1], 1, 32767);
+            }
+            else if (recipeComponents[i + 1] instanceof ItemStack)
+            {
+                itemstack = (ItemStack) recipeComponents[i + 1];
+            }
+
+            map.put(character, itemstack);
+        }
+
+        ItemStack[] aitemstack = new ItemStack[j * k];
+
+        for (int l = 0; l < j * k; ++l)
+        {
+            char c0 = s.charAt(l);
+
+            if (map.containsKey(Character.valueOf(c0)))
+            {
+                aitemstack[l] = ((ItemStack) map.get(Character.valueOf(c0))).copy();
+            }
+            else
+            {
+                aitemstack[l] = ItemStack.EMPTY;
+            }
+        }
+
+        ShapedRecipes shapedrecipes = new ShapedRecipes(j, k, aitemstack, stack);
+        recipes.add(shapedrecipes);
     }
 
     private boolean isValidShapelessRecipe(ShapelessRecipes shapelessRecipe)


### PR DESCRIPTION
When JEI runs across a broken recipe, it logs as much information as possible about the recipe to help find the cause, but until now there has been no way to find out which mod registered a crafting recipe.

Often there is no good way to track down the broken crafting recipe without knowing which mod registered it. (https://github.com/mezz/JustEnoughItems/issues/749)

This PR wraps the recipe list in a `ModTrackingList` which keeps track of which active mod container added each element in the list.
I went through the trouble of wrapping the list instead of some other way because it's possible to add recipes to the list directly using `CraftingManager#getRecipeList()`.

This would also be useful as a feature for showing which mod created each recipe in-game.

Test mod output:
```
[17:32:13] [Client thread/INFO] [recipedebug]: Found crafting recipe with empty output from mod: ForgeRecipeDebug (recipedebug).
Inputs: [1xitem.paper@0, 1xtile.air@0, 1xitem.paper@0]
Output: 64xitem.diamond@0
```