### PR TITLE
Add except-player variants of SimpleImpl methods and make OutboundTarget extendable

### DIFF
--- a/src/main/java/net/minecraftforge/fml/common/network/FMLEmbeddedChannel.java
+++ b/src/main/java/net/minecraftforge/fml/common/network/FMLEmbeddedChannel.java
@@ -67,7 +67,7 @@ public class FMLEmbeddedChannel extends EmbeddedChannel {
      */
     public Packet<?> generatePacketFrom(Object object)
     {
-        IOutboundTarget outboundTarget = attr(FMLOutboundHandler.FML_MESSAGETARGET).getAndSet(OutboundTarget.NOWHERE);
+        OutboundTarget outboundTarget = attr(FMLOutboundHandler.FML_MESSAGETARGET).getAndSet(OutboundTarget.NOWHERE);
         writeOutbound(object);
         Packet<?> pkt = (Packet<?>) outboundMessages().poll();
         attr(FMLOutboundHandler.FML_MESSAGETARGET).set(outboundTarget);

--- a/src/main/java/net/minecraftforge/fml/common/network/FMLEmbeddedChannel.java
+++ b/src/main/java/net/minecraftforge/fml/common/network/FMLEmbeddedChannel.java
@@ -67,7 +67,7 @@ public class FMLEmbeddedChannel extends EmbeddedChannel {
      */
     public Packet<?> generatePacketFrom(Object object)
     {
-        OutboundTarget outboundTarget = attr(FMLOutboundHandler.FML_MESSAGETARGET).getAndSet(OutboundTarget.NOWHERE);
+        IOutboundTarget outboundTarget = attr(FMLOutboundHandler.FML_MESSAGETARGET).getAndSet(OutboundTarget.NOWHERE);
         writeOutbound(object);
         Packet<?> pkt = (Packet<?>) outboundMessages().poll();
         attr(FMLOutboundHandler.FML_MESSAGETARGET).set(outboundTarget);

--- a/src/main/java/net/minecraftforge/fml/common/network/FMLOutboundHandler.java
+++ b/src/main/java/net/minecraftforge/fml/common/network/FMLOutboundHandler.java
@@ -268,6 +268,14 @@ public class FMLOutboundHandler extends ChannelOutboundHandlerAdapter {
         {
             return allowed.contains(side);
         }
+
+        /**
+         * Use except player sensitive version
+         */
+        @Deprecated
+        public List<NetworkDispatcher> selectNetworks(Object args, ChannelHandlerContext context, FMLProxyPacket packet) {
+            return selectNetworks(args, null, context, packet);
+        }
     }
 
     @Override

--- a/src/main/java/net/minecraftforge/fml/common/network/FMLOutboundHandler.java
+++ b/src/main/java/net/minecraftforge/fml/common/network/FMLOutboundHandler.java
@@ -274,6 +274,7 @@ public class FMLOutboundHandler extends ChannelOutboundHandlerAdapter {
          * Use except player sensitive version
          */
         @Deprecated
+        @Nullable
         public List<NetworkDispatcher> selectNetworks(Object args, ChannelHandlerContext context, FMLProxyPacket packet) {
             return selectNetworks(args, null, context, packet);
         }

--- a/src/main/java/net/minecraftforge/fml/common/network/FMLOutboundHandler.java
+++ b/src/main/java/net/minecraftforge/fml/common/network/FMLOutboundHandler.java
@@ -44,7 +44,8 @@ import com.google.common.collect.Sets;
 import javax.annotation.Nullable;
 
 public class FMLOutboundHandler extends ChannelOutboundHandlerAdapter {
-    public static final AttributeKey<IOutboundTarget> FML_MESSAGETARGET = AttributeKey.valueOf("fml:outboundTarget");
+    //TODO Make this an IOutboundTarget in next breaking version
+    public static final AttributeKey<OutboundTarget> FML_MESSAGETARGET = AttributeKey.valueOf("fml:outboundTarget");
     public static final AttributeKey<Object> FML_MESSAGETARGETARGS = AttributeKey.valueOf("fml:outboundTargetArgs");
     public static final AttributeKey<EntityPlayer> FML_MESSAGETARGETEXCEPT = AttributeKey.valueOf("fml:outboundTargetExcept");
     public enum OutboundTarget implements IOutboundTarget {

--- a/src/main/java/net/minecraftforge/fml/common/network/IOutboundTarget.java
+++ b/src/main/java/net/minecraftforge/fml/common/network/IOutboundTarget.java
@@ -1,0 +1,19 @@
+package net.minecraftforge.fml.common.network;
+
+import io.netty.channel.ChannelHandlerContext;
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraftforge.fml.common.network.handshake.NetworkDispatcher;
+import net.minecraftforge.fml.common.network.internal.FMLProxyPacket;
+import net.minecraftforge.fml.relauncher.Side;
+
+import javax.annotation.Nullable;
+import java.util.List;
+
+public interface IOutboundTarget {
+    boolean isSideAllowed(Side side);
+
+    void validateArgs(Object args);
+
+    @Nullable
+    List<NetworkDispatcher> selectNetworks(Object args, @Nullable EntityPlayer except, ChannelHandlerContext context, FMLProxyPacket packet);
+}

--- a/src/main/java/net/minecraftforge/fml/common/network/simpleimpl/SimpleNetworkWrapper.java
+++ b/src/main/java/net/minecraftforge/fml/common/network/simpleimpl/SimpleNetworkWrapper.java
@@ -244,11 +244,8 @@ public class SimpleNetworkWrapper {
 
     /**
      * Send this message to everyone except one player.
+     * Must not be used when synchronizing game logic, only instant visual or audio effects.
      * The {@link IMessageHandler} for this message type should be on the CLIENT side.
-     *
-     * This is particularly useful for player-caused events that require instant feedback. The excepted player will not
-     * receive the message, and is therefore expected to reliably predict the outcome of the event.
-     * Must be used with care when synchronizing game logic.
      *
      * @param message The message to send
      * @param player The player that will not receive the message
@@ -291,11 +288,8 @@ public class SimpleNetworkWrapper {
 
     /**
      * Send this message to everyone within a certain range of a point except one player.
+     * Must not be used when synchronizing game logic, only instant visual or audio effects.
      * The {@link IMessageHandler} for this message type should be on the CLIENT side.
-     *
-     * This is particularly useful for player-caused events that require instant feedback. The excepted player will not
-     * receive the message, and is therefore expected to reliably predict the outcome of the event.
-     * Must be used with care when synchronizing game logic.
      *
      * @param message The message to send
      * @param point The {@link TargetPoint} around which to send
@@ -326,11 +320,8 @@ public class SimpleNetworkWrapper {
 
     /**
      * Send this message to everyone within the supplied dimension except one player.
+     * Must not be used when synchronizing game logic, only instant visual or audio effects.
      * The {@link IMessageHandler} for this message type should be on the CLIENT side.
-     *
-     * This is particularly useful for player-caused events that require instant feedback. The excepted player will not
-     * receive the message, and is therefore expected to reliably predict the outcome of the event.
-     * Must be used with care when synchronizing game logic.
      *
      * @param message The message to send
      * @param dimensionId The dimension id to target

--- a/src/main/java/net/minecraftforge/fml/common/network/simpleimpl/SimpleNetworkWrapper.java
+++ b/src/main/java/net/minecraftforge/fml/common/network/simpleimpl/SimpleNetworkWrapper.java
@@ -246,6 +246,10 @@ public class SimpleNetworkWrapper {
      * Send this message to everyone except one player.
      * The {@link IMessageHandler} for this message type should be on the CLIENT side.
      *
+     * This is particularly useful for player-caused events that require instant feedback. The excepted player will not
+     * receive the message, and is therefore expected to reliably predict the outcome of the event.
+     * Must be used with care when synchronizing game logic.
+     *
      * @param message The message to send
      * @param player The player that will not receive the message
      */
@@ -289,6 +293,10 @@ public class SimpleNetworkWrapper {
      * Send this message to everyone within a certain range of a point except one player.
      * The {@link IMessageHandler} for this message type should be on the CLIENT side.
      *
+     * This is particularly useful for player-caused events that require instant feedback. The excepted player will not
+     * receive the message, and is therefore expected to reliably predict the outcome of the event.
+     * Must be used with care when synchronizing game logic.
+     *
      * @param message The message to send
      * @param point The {@link TargetPoint} around which to send
      * @param player The player that will not receive the message
@@ -319,6 +327,10 @@ public class SimpleNetworkWrapper {
     /**
      * Send this message to everyone within the supplied dimension except one player.
      * The {@link IMessageHandler} for this message type should be on the CLIENT side.
+     *
+     * This is particularly useful for player-caused events that require instant feedback. The excepted player will not
+     * receive the message, and is therefore expected to reliably predict the outcome of the event.
+     * Must be used with care when synchronizing game logic.
      *
      * @param message The message to send
      * @param dimensionId The dimension id to target

--- a/src/main/java/net/minecraftforge/fml/common/network/simpleimpl/SimpleNetworkWrapper.java
+++ b/src/main/java/net/minecraftforge/fml/common/network/simpleimpl/SimpleNetworkWrapper.java
@@ -26,6 +26,7 @@ import java.util.EnumMap;
 
 import com.google.common.base.Throwables;
 
+import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.util.IThreadListener;
 import org.apache.logging.log4j.Level;
 
@@ -237,6 +238,21 @@ public class SimpleNetworkWrapper {
     public void sendToAll(IMessage message)
     {
         channels.get(Side.SERVER).attr(FMLOutboundHandler.FML_MESSAGETARGET).set(FMLOutboundHandler.OutboundTarget.ALL);
+        channels.get(Side.SERVER).attr(FMLOutboundHandler.FML_MESSAGETARGETEXCEPT).set(null);
+        channels.get(Side.SERVER).writeAndFlush(message).addListener(ChannelFutureListener.FIRE_EXCEPTION_ON_FAILURE);
+    }
+
+    /**
+     * Send this message to everyone except one player.
+     * The {@link IMessageHandler} for this message type should be on the CLIENT side.
+     *
+     * @param message The message to send
+     * @param player The player that will not receive the message
+     */
+    public void sendToAllExcept(IMessage message, EntityPlayer player)
+    {
+        channels.get(Side.SERVER).attr(FMLOutboundHandler.FML_MESSAGETARGET).set(FMLOutboundHandler.OutboundTarget.ALL);
+        channels.get(Side.SERVER).attr(FMLOutboundHandler.FML_MESSAGETARGETEXCEPT).set(player);
         channels.get(Side.SERVER).writeAndFlush(message).addListener(ChannelFutureListener.FIRE_EXCEPTION_ON_FAILURE);
     }
 
@@ -265,6 +281,23 @@ public class SimpleNetworkWrapper {
     {
         channels.get(Side.SERVER).attr(FMLOutboundHandler.FML_MESSAGETARGET).set(FMLOutboundHandler.OutboundTarget.ALLAROUNDPOINT);
         channels.get(Side.SERVER).attr(FMLOutboundHandler.FML_MESSAGETARGETARGS).set(point);
+        channels.get(Side.SERVER).attr(FMLOutboundHandler.FML_MESSAGETARGETEXCEPT).set(null);
+        channels.get(Side.SERVER).writeAndFlush(message).addListener(ChannelFutureListener.FIRE_EXCEPTION_ON_FAILURE);
+    }
+
+    /**
+     * Send this message to everyone within a certain range of a point except one player.
+     * The {@link IMessageHandler} for this message type should be on the CLIENT side.
+     *
+     * @param message The message to send
+     * @param point The {@link TargetPoint} around which to send
+     * @param player The player that will not receive the message
+     */
+    public void sendToAllAroundExcept(IMessage message, NetworkRegistry.TargetPoint point, EntityPlayer player)
+    {
+        channels.get(Side.SERVER).attr(FMLOutboundHandler.FML_MESSAGETARGET).set(FMLOutboundHandler.OutboundTarget.ALLAROUNDPOINT);
+        channels.get(Side.SERVER).attr(FMLOutboundHandler.FML_MESSAGETARGETARGS).set(point);
+        channels.get(Side.SERVER).attr(FMLOutboundHandler.FML_MESSAGETARGETEXCEPT).set(player);
         channels.get(Side.SERVER).writeAndFlush(message).addListener(ChannelFutureListener.FIRE_EXCEPTION_ON_FAILURE);
     }
 
@@ -279,6 +312,23 @@ public class SimpleNetworkWrapper {
     {
         channels.get(Side.SERVER).attr(FMLOutboundHandler.FML_MESSAGETARGET).set(FMLOutboundHandler.OutboundTarget.DIMENSION);
         channels.get(Side.SERVER).attr(FMLOutboundHandler.FML_MESSAGETARGETARGS).set(dimensionId);
+        channels.get(Side.SERVER).attr(FMLOutboundHandler.FML_MESSAGETARGETEXCEPT).set(null);
+        channels.get(Side.SERVER).writeAndFlush(message).addListener(ChannelFutureListener.FIRE_EXCEPTION_ON_FAILURE);
+    }
+
+    /**
+     * Send this message to everyone within the supplied dimension except one player.
+     * The {@link IMessageHandler} for this message type should be on the CLIENT side.
+     *
+     * @param message The message to send
+     * @param dimensionId The dimension id to target
+     * @param player The player that will not receive the message
+     */
+    public void sendToDimensionExcept(IMessage message, int dimensionId, EntityPlayer player)
+    {
+        channels.get(Side.SERVER).attr(FMLOutboundHandler.FML_MESSAGETARGET).set(FMLOutboundHandler.OutboundTarget.DIMENSION);
+        channels.get(Side.SERVER).attr(FMLOutboundHandler.FML_MESSAGETARGETARGS).set(dimensionId);
+        channels.get(Side.SERVER).attr(FMLOutboundHandler.FML_MESSAGETARGETEXCEPT).set(player);
         channels.get(Side.SERVER).writeAndFlush(message).addListener(ChannelFutureListener.FIRE_EXCEPTION_ON_FAILURE);
     }
 


### PR DESCRIPTION
I have stumbled upon a limitation in SimpleImpl, which is that it does not support sending packets to several players except a specific player. This PR attempts to fix this and other problems.

Why is this needed? It is very useful to provide instant feedback if a certain event is handled on both on the logical client and server. An example where this functionality is useful and already implemented is when World.playSound is called on both the logical server and client, a block right click event for instance. The server world sends a "play sound" message to all nearby players except the player that triggered the sound. The client world plays the sound without the delay of the server receiving the event message and sending a sound message back to the client.

The current alternatives are not particularly attractive:

1. Use sendTo for each manually filtered player. See Mezz's reply to #3677 
2. Make the client ignore the message. For instance putting the player ID in the message and make the client message handler ignore it if it matches the player ID.
3. ~~Not use SimpleImpl.~~

My specific use case for this is spawning a particle system whose size will depend on the client's graphics settings like explosions do. The particle system must appear instantly on the client, and should also be visible for nearby players.

In addition, this PR attempts to make SimpleImpl extendable so that modders may implement more sending methods should they need them (#3677). Outbound targets were locked to an enum. It has now been moved to the interface IOutboundTarget.