### PR TITLE
Clean up patches to ChunkCache

### DIFF
--- a/patches/minecraft/net/minecraft/world/ChunkCache.java.patch
+++ b/patches/minecraft/net/minecraft/world/ChunkCache.java.patch
@@ -9,25 +9,31 @@
      }
  
      @Nullable
-@@ -69,6 +69,8 @@
+@@ -69,6 +69,7 @@
      {
          int i = (p_190300_1_.func_177958_n() >> 4) - this.field_72818_a;
          int j = (p_190300_1_.func_177952_p() >> 4) - this.field_72816_b;
-+        if (i < 0 || i >= field_72817_c.length || j < 0 || j >= field_72817_c[i].length) return null;
-+        if (field_72817_c[i][j] == null) return null;
++        if (!checkForChunk(i, j)) return null;
          return this.field_72817_c[i][j].func_177424_a(p_190300_1_, p_190300_2_);
      }
  
-@@ -149,6 +151,8 @@
+@@ -112,6 +113,7 @@
+     {
+         int i = (p_180494_1_.func_177958_n() >> 4) - this.field_72818_a;
+         int j = (p_180494_1_.func_177952_p() >> 4) - this.field_72816_b;
++        if (!checkForChunk(i, j)) return net.minecraft.init.Biomes.field_76772_c;
+         return this.field_72817_c[i][j].func_177411_a(p_180494_1_, this.field_72815_e.func_72959_q());
+     }
+ 
+@@ -149,6 +151,7 @@
              {
                  int i = (p_175629_2_.func_177958_n() >> 4) - this.field_72818_a;
                  int j = (p_175629_2_.func_177952_p() >> 4) - this.field_72816_b;
-+                if (i < 0 || i >= field_72817_c.length || j < 0 || j >= field_72817_c[i].length) return p_175629_1_.field_77198_c;
-+                if (field_72817_c[i][j] == null) return p_175629_1_.field_77198_c;
++                if (!checkForChunk(i, j)) return p_175629_1_.field_77198_c;
                  return this.field_72817_c[i][j].func_177413_a(p_175629_1_, p_175629_2_);
              }
          }
-@@ -160,7 +164,8 @@
+@@ -160,7 +163,8 @@
  
      public boolean func_175623_d(BlockPos p_175623_1_)
      {
@@ -37,15 +43,15 @@
      }
  
      @SideOnly(Side.CLIENT)
-@@ -170,6 +175,7 @@
+@@ -170,6 +174,7 @@
          {
              int i = (p_175628_2_.func_177958_n() >> 4) - this.field_72818_a;
              int j = (p_175628_2_.func_177952_p() >> 4) - this.field_72816_b;
-+            if (i < 0 || i >= field_72817_c.length || j < 0 || j >= field_72817_c[i].length) return p_175628_1_.field_77198_c;
++            if (!checkForChunk(i, j)) return p_175628_1_.field_77198_c;
              return this.field_72817_c[i][j].func_177413_a(p_175628_1_, p_175628_2_);
          }
          else
-@@ -188,4 +194,17 @@
+@@ -188,4 +193,21 @@
      {
          return this.field_72815_e.func_175624_G();
      }
@@ -56,10 +62,14 @@
 +        int x = (pos.func_177958_n() >> 4) - this.field_72818_a;
 +        int z = (pos.func_177952_p() >> 4) - this.field_72816_b;
 +        if (pos.func_177956_o() < 0 || pos.func_177956_o() >= 256) return _default;
-+        if (x < 0 || x >= field_72817_c.length || z < 0 || z >= field_72817_c[x].length) return _default;
-+        if (field_72817_c[x][z] == null) return _default;
++        if (!checkForChunk(x, z)) return _default;
 +
 +        IBlockState state = func_180495_p(pos);
 +        return state.func_177230_c().isSideSolid(state, this, pos, side);
++    }
++
++    private boolean checkForChunk(int x, int z)
++    {
++        return x >= 0 && x < field_72817_c.length && z >= 0 && z < field_72817_c[x].length && field_72817_c[x][z] != null;
 +    }
  }

--- a/patches/minecraft/net/minecraft/world/ChunkCache.java.patch
+++ b/patches/minecraft/net/minecraft/world/ChunkCache.java.patch
@@ -13,7 +13,7 @@
      {
          int i = (p_190300_1_.func_177958_n() >> 4) - this.field_72818_a;
          int j = (p_190300_1_.func_177952_p() >> 4) - this.field_72816_b;
-+        if (!checkForChunk(i, j)) return null;
++        if (!withinBounds(i, j)) return null;
          return this.field_72817_c[i][j].func_177424_a(p_190300_1_, p_190300_2_);
      }
  
@@ -21,7 +21,7 @@
      {
          int i = (p_180494_1_.func_177958_n() >> 4) - this.field_72818_a;
          int j = (p_180494_1_.func_177952_p() >> 4) - this.field_72816_b;
-+        if (!checkForChunk(i, j)) return net.minecraft.init.Biomes.field_76772_c;
++        if (!withinBounds(i, j)) return net.minecraft.init.Biomes.field_76772_c;
          return this.field_72817_c[i][j].func_177411_a(p_180494_1_, this.field_72815_e.func_72959_q());
      }
  
@@ -29,7 +29,7 @@
              {
                  int i = (p_175629_2_.func_177958_n() >> 4) - this.field_72818_a;
                  int j = (p_175629_2_.func_177952_p() >> 4) - this.field_72816_b;
-+                if (!checkForChunk(i, j)) return p_175629_1_.field_77198_c;
++                if (!withinBounds(i, j)) return p_175629_1_.field_77198_c;
                  return this.field_72817_c[i][j].func_177413_a(p_175629_1_, p_175629_2_);
              }
          }
@@ -47,7 +47,7 @@
          {
              int i = (p_175628_2_.func_177958_n() >> 4) - this.field_72818_a;
              int j = (p_175628_2_.func_177952_p() >> 4) - this.field_72816_b;
-+            if (!checkForChunk(i, j)) return p_175628_1_.field_77198_c;
++            if (!withinBounds(i, j)) return p_175628_1_.field_77198_c;
              return this.field_72817_c[i][j].func_177413_a(p_175628_1_, p_175628_2_);
          }
          else
@@ -62,13 +62,13 @@
 +        int x = (pos.func_177958_n() >> 4) - this.field_72818_a;
 +        int z = (pos.func_177952_p() >> 4) - this.field_72816_b;
 +        if (pos.func_177956_o() < 0 || pos.func_177956_o() >= 256) return _default;
-+        if (!checkForChunk(x, z)) return _default;
++        if (!withinBounds(x, z)) return _default;
 +
 +        IBlockState state = func_180495_p(pos);
 +        return state.func_177230_c().isSideSolid(state, this, pos, side);
 +    }
 +
-+    private boolean checkForChunk(int x, int z)
++    private boolean withinBounds(int x, int z)
 +    {
 +        return x >= 0 && x < field_72817_c.length && z >= 0 && z < field_72817_c[x].length && field_72817_c[x][z] != null;
 +    }


### PR DESCRIPTION
This moves all the patched in validity checks for accessing chunks from the chunk arrays to a new private method. A check has also been added to `getBiome()`, which was missing it before.

(The biome returned is `Biomes.PLAINS` as that seems to be the default return value used in other biome getting methods.)

There have been issues caused by inconsistent logic here in the past, see a9a022f45ee985dbc60f28f701f72e42d3a53571 and d8166f5d6b1ca2565e62712d738df6088fad4dab.

I hope adding a private method here is acceptable, it should make any future changes required to this logic easier.