### PR TITLE
deprecate isGaseous field in favour of just checking the density sign

### DIFF
--- a/src/main/java/net/minecraftforge/client/model/ModelDynBucket.java
+++ b/src/main/java/net/minecraftforge/client/model/ModelDynBucket.java
@@ -127,7 +127,7 @@ public final class ModelDynBucket implements IModel, IModelCustomData, IRetextur
         ImmutableMap<TransformType, TRSRTransformation> transformMap = IPerspectiveAwareModel.MapWrapper.getTransforms(state);
 
         // if the fluid is a gas wi manipulate the initial state to be rotated 180° to turn it upside down
-        if (flipGas && fluid != null && fluid.isGaseous())
+        if (flipGas && fluid != null && fluid.isLighterThanAir())
         {
             state = new ModelStateComposition(state, TRSRTransformation.blockCenterToCorner(new TRSRTransformation(null, new Quat4f(0, 0, 1, 0), null, null)));
         }

--- a/src/main/java/net/minecraftforge/client/model/ModelFluid.java
+++ b/src/main/java/net/minecraftforge/client/model/ModelFluid.java
@@ -89,7 +89,7 @@ public final class ModelFluid implements IModelCustomData
     public IBakedModel bake(IModelState state, VertexFormat format, Function<ResourceLocation, TextureAtlasSprite> bakedTextureGetter)
     {
         ImmutableMap<TransformType, TRSRTransformation> map = IPerspectiveAwareModel.MapWrapper.getTransforms(state);
-        return new BakedFluid(state.apply(Optional.<IModelPart>absent()), map, format, fluid.getColor(), bakedTextureGetter.apply(fluid.getStill()), bakedTextureGetter.apply(fluid.getFlowing()), fluid.isGaseous(), Optional.<IExtendedBlockState>absent());
+        return new BakedFluid(state.apply(Optional.<IModelPart>absent()), map, format, fluid.getColor(), bakedTextureGetter.apply(fluid.getStill()), bakedTextureGetter.apply(fluid.getFlowing()), fluid.isLighterThanAir(), Optional.<IExtendedBlockState>absent());
     }
 
     public IModelState getDefaultState()

--- a/src/main/java/net/minecraftforge/fluids/Fluid.java
+++ b/src/main/java/net/minecraftforge/fluids/Fluid.java
@@ -164,7 +164,7 @@ public class Fluid
     public Fluid setDensity(int density)
     {
         this.density = density;
-	this.isGaseous = density < 0;
+        this.isGaseous = density < 0;
         return this;
     }
 

--- a/src/main/java/net/minecraftforge/fluids/Fluid.java
+++ b/src/main/java/net/minecraftforge/fluids/Fluid.java
@@ -104,6 +104,7 @@ public class Fluid
     protected int viscosity = 1000;
 
     /**
+     * @deprecated This flag is going to be removed, use isLighterThanAir() / density instead.
      * This indicates if the fluid is gaseous.
      *
      * Useful for rendering the fluid in containers and the world.
@@ -304,7 +305,16 @@ public class Fluid
         return this.viscosity;
     }
 
+    /**
+     * @deprecated Use isLighterThanAir() instead
+     */
+    @Deprecated
     public final boolean isGaseous()
+    {
+        return isLighterThanAir();
+    }
+
+    public final boolean isLighterThanAir()
     {
         return this.density < 0;
     }
@@ -368,7 +378,12 @@ public class Fluid
     public int getDensity(FluidStack stack){ return getDensity(); }
     public int getTemperature(FluidStack stack){ return getTemperature(); }
     public int getViscosity(FluidStack stack){ return getViscosity(); }
-    public boolean isGaseous(FluidStack stack){ return isGaseous(); }
+    /**
+     * @deprecated Use isLighterThanAir() instead
+     */
+    @Deprecated
+    public boolean isGaseous(FluidStack stack){ return isLighterThanAir(); }
+    public boolean isLighterThanAir(FluidStack stack){ return isLighterThanAir(); }
     public EnumRarity getRarity(FluidStack stack){ return getRarity(); }
     public int getColor(FluidStack stack){ return getColor(); }
     public ResourceLocation getStill(FluidStack stack) { return getStill(); }
@@ -381,7 +396,12 @@ public class Fluid
     public int getDensity(World world, BlockPos pos){ return getDensity(); }
     public int getTemperature(World world, BlockPos pos){ return getTemperature(); }
     public int getViscosity(World world, BlockPos pos){ return getViscosity(); }
-    public boolean isGaseous(World world, BlockPos pos){ return isGaseous(); }
+    /**
+     * @deprecated Use isLighterThanAir() instead
+     */
+    @Deprecated
+    public boolean isGaseous(World world, BlockPos pos){ return isLighterThanAir(); }
+    public boolean isLighterThanAir(World world, BlockPos pos){ return isLighterThanAir(); }
     public EnumRarity getRarity(World world, BlockPos pos){ return getRarity(); }
     public int getColor(World world, BlockPos pos){ return getColor(); }
     public ResourceLocation getStill(World world, BlockPos pos) { return getStill(); }

--- a/src/main/java/net/minecraftforge/fluids/Fluid.java
+++ b/src/main/java/net/minecraftforge/fluids/Fluid.java
@@ -110,6 +110,7 @@ public class Fluid
      *
      * Generally this is associated with negative density fluids.
      */
+    @Deprecated
     protected boolean isGaseous;
 
     /**
@@ -163,6 +164,7 @@ public class Fluid
     public Fluid setDensity(int density)
     {
         this.density = density;
+	this.isGaseous = density < 0;
         return this;
     }
 
@@ -178,9 +180,9 @@ public class Fluid
         return this;
     }
 
+    @Deprecated
     public Fluid setGaseous(boolean isGaseous)
     {
-        this.isGaseous = isGaseous;
         return this;
     }
 
@@ -301,7 +303,7 @@ public class Fluid
 
     public final boolean isGaseous()
     {
-        return this.isGaseous;
+        return this.density < 0;
     }
 
     public EnumRarity getRarity()

--- a/src/main/java/net/minecraftforge/fluids/Fluid.java
+++ b/src/main/java/net/minecraftforge/fluids/Fluid.java
@@ -180,6 +180,9 @@ public class Fluid
         return this;
     }
 
+    /**
+     * @deprecated Use setDensity() with a negative value to achieve reverse fluid gravity
+     */
     @Deprecated
     public Fluid setGaseous(boolean isGaseous)
     {

--- a/src/test/java/net/minecraftforge/debug/ModelFluidDebug.java
+++ b/src/test/java/net/minecraftforge/debug/ModelFluidDebug.java
@@ -152,7 +152,6 @@ public class ModelFluidDebug
         {
             super(name, new ResourceLocation("blocks/lava_still"), new ResourceLocation("blocks/lava_flow"));
             density = -1000;
-            isGaseous = true;
         }
 
         @Override

--- a/src/test/java/net/minecraftforge/debug/ModelFluidDebug.java
+++ b/src/test/java/net/minecraftforge/debug/ModelFluidDebug.java
@@ -152,6 +152,7 @@ public class ModelFluidDebug
         {
             super(name, new ResourceLocation("blocks/lava_still"), new ResourceLocation("blocks/lava_flow"));
             density = -1000;
+            isGaseous = true;
         }
 
         @Override


### PR DESCRIPTION
In Fluid, isGaseous (a boolean) and the sign of density both do the same thing. If you do not set them consistently, you can get rendering errors ( #3746 ). I propose to get rid of isGaseous in 1.12 and to deprecate it for now, as well as replacing isGaseous() with a density sign check. This makes the fluid API harder to use incorrectly. 