### PR TITLE
Detect and log cascading chunk generation issues during terrain population

### DIFF
--- a/patches/minecraft/net/minecraft/world/World.java.patch
+++ b/patches/minecraft/net/minecraft/world/World.java.patch
@@ -986,3 +986,22 @@
      public void func_184135_a(Packet<?> p_184135_1_)
      {
          throw new UnsupportedOperationException("Can\'t send packets to server unless you\'re on the client.");
+@@ -3609,4 +3910,18 @@
+     {
+         return null;
+     }
++
++    private boolean populatingTerrain; // keep track of cascading chunk generation during chunk decoration
++
++    /** for Forge internal use, to detect cascading chunk generation issues */
++    public boolean isPopulatingTerrain()
++    {
++        return this.populatingTerrain;
++    }
++
++    /** for Forge internal use, to detect cascading chunk generation issues */
++    public void setPopulatingTerrain(boolean populatingTerrain)
++    {
++        this.populatingTerrain = populatingTerrain;
++    }
+ }

--- a/patches/minecraft/net/minecraft/world/World.java.patch
+++ b/patches/minecraft/net/minecraft/world/World.java.patch
@@ -986,22 +986,3 @@
      public void func_184135_a(Packet<?> p_184135_1_)
      {
          throw new UnsupportedOperationException("Can\'t send packets to server unless you\'re on the client.");
-@@ -3609,4 +3910,18 @@
-     {
-         return null;
-     }
-+
-+    private boolean populatingTerrain; // keep track of cascading chunk generation during chunk decoration
-+
-+    /** for Forge internal use, to detect cascading chunk generation issues */
-+    public boolean isPopulatingTerrain()
-+    {
-+        return this.populatingTerrain;
-+    }
-+
-+    /** for Forge internal use, to detect cascading chunk generation issues */
-+    public void setPopulatingTerrain(boolean populatingTerrain)
-+    {
-+        this.populatingTerrain = populatingTerrain;
-+    }
- }

--- a/patches/minecraft/net/minecraft/world/chunk/Chunk.java.patch
+++ b/patches/minecraft/net/minecraft/world/chunk/Chunk.java.patch
@@ -206,15 +206,21 @@
          i = MathHelper.func_76125_a(i, 0, this.field_76645_j.length - 1);
          j = MathHelper.func_76125_a(j, 0, this.field_76645_j.length - 1);
  
-@@ -995,6 +998,7 @@
+@@ -993,9 +996,13 @@
+         }
+         else
          {
++            if (field_76637_e.isPopulatingTerrain()) reportCascadingWorldGeneration();
++            this.field_76637_e.setPopulatingTerrain(true);
              this.func_150809_p();
              p_186034_1_.func_185931_b(this.field_76635_g, this.field_76647_h);
 +            net.minecraftforge.fml.common.registry.GameRegistry.generateWorld(this.field_76635_g, this.field_76647_h, this.field_76637_e, p_186034_1_, this.field_76637_e.func_72863_F());
              this.func_76630_e();
++            this.field_76637_e.setPopulatingTerrain(false);
          }
      }
-@@ -1051,7 +1055,7 @@
+ 
+@@ -1051,7 +1058,7 @@
          {
              BlockPos blockpos = (BlockPos)this.field_177447_w.poll();
  
@@ -223,7 +229,7 @@
              {
                  TileEntity tileentity = this.func_177422_i(blockpos);
                  this.field_76637_e.func_175690_a(blockpos, tileentity);
-@@ -1115,6 +1119,13 @@
+@@ -1115,6 +1122,13 @@
      @SideOnly(Side.CLIENT)
      public void func_186033_a(PacketBuffer p_186033_1_, int p_186033_2_, boolean p_186033_3_)
      {
@@ -237,7 +243,7 @@
          boolean flag = this.field_76637_e.field_73011_w.func_191066_m();
  
          for (int i = 0; i < this.field_76652_q.length; ++i)
-@@ -1163,10 +1174,16 @@
+@@ -1163,10 +1177,16 @@
          this.field_76646_k = true;
          this.func_76590_a();
  
@@ -254,7 +260,7 @@
      }
  
      public Biome func_177411_a(BlockPos p_177411_1_, BiomeProvider p_177411_2_)
-@@ -1231,13 +1248,13 @@
+@@ -1231,13 +1251,13 @@
                      BlockPos blockpos1 = blockpos.func_177982_a(k, (j << 4) + i1, l);
                      boolean flag = i1 == 0 || i1 == 15 || k == 0 || k == 15 || l == 0 || l == 15;
  
@@ -270,7 +276,7 @@
                              {
                                  this.field_76637_e.func_175664_x(blockpos2);
                              }
-@@ -1368,7 +1385,7 @@
+@@ -1368,7 +1388,7 @@
          {
              blockpos$mutableblockpos.func_181079_c(blockpos$mutableblockpos.func_177958_n(), l, blockpos$mutableblockpos.func_177952_p());
  
@@ -279,11 +285,12 @@
              {
                  this.field_76637_e.func_175664_x(blockpos$mutableblockpos);
              }
-@@ -1476,4 +1493,20 @@
+@@ -1476,4 +1496,32 @@
          QUEUED,
          CHECK;
      }
 +
++    /* ======================================== FORGE START =====================================*/
 +    /**
 +     * Removes the tile entity at the specified position, only if it's
 +     * marked as invalid.
@@ -298,5 +305,16 @@
 +                field_150816_i.remove(pos);
 +            }
 +        }
++    }
++
++    private void reportCascadingWorldGeneration()
++    {
++        net.minecraftforge.fml.common.ModContainer activeModContainer = net.minecraftforge.fml.common.Loader.instance().activeModContainer();
++        String format = "%s loaded a new chunk (%d, %d  Dimension: %d) during terrain generation, causing cascading worldgen lag. Please report this to the mod's issue tracker.";
++
++        if (activeModContainer == null) // vanilla minecraft has problems too (MC-114332), log it at a quieter level.
++            net.minecraftforge.fml.common.FMLLog.fine(format, "Minecraft", this.field_76635_g, this.field_76647_h, this.field_76637_e.field_73011_w.getDimension());
++        else
++            net.minecraftforge.fml.common.FMLLog.warning(format, activeModContainer.getName(), this.field_76635_g, this.field_76647_h, this.field_76637_e.field_73011_w.getDimension());
 +    }
  }

--- a/patches/minecraft/net/minecraft/world/chunk/Chunk.java.patch
+++ b/patches/minecraft/net/minecraft/world/chunk/Chunk.java.patch
@@ -210,8 +210,8 @@
  
      protected void func_186034_a(IChunkGenerator p_186034_1_)
      {
-+        if (isPopulatingChunk() && net.minecraftforge.common.ForgeModContainer.logCascadingWorldGeneration) logCascadingWorldGeneration();
-+        setPopulatingChunk(Boolean.TRUE);
++        if (populating.get() == Boolean.TRUE && net.minecraftforge.common.ForgeModContainer.logCascadingWorldGeneration) logCascadingWorldGeneration();
++        populating.set(Boolean.TRUE);
          if (this.func_177419_t())
          {
              if (p_186034_1_.func_185933_a(this, this.field_76635_g, this.field_76647_h))
@@ -222,7 +222,7 @@
 +            net.minecraftforge.fml.common.registry.GameRegistry.generateWorld(this.field_76635_g, this.field_76647_h, this.field_76637_e, p_186034_1_, this.field_76637_e.func_72863_F());
              this.func_76630_e();
          }
-+        setPopulatingChunk(Boolean.FALSE);
++        populating.set(Boolean.FALSE);
      }
  
      public BlockPos func_177440_h(BlockPos p_177440_1_)
@@ -291,7 +291,7 @@
              {
                  this.field_76637_e.func_175664_x(blockpos$mutableblockpos);
              }
-@@ -1476,4 +1496,46 @@
+@@ -1476,4 +1496,34 @@
          QUEUED,
          CHECK;
      }
@@ -314,18 +314,6 @@
 +    }
 +
 +    private static ThreadLocal<Boolean> populating = new ThreadLocal<Boolean>(); // keep track of cascading chunk generation during chunk population
-+
-+    /** for Forge internal use, to detect cascading chunk generation issues */
-+    private static boolean isPopulatingChunk()
-+    {
-+        return populating.get() == Boolean.TRUE;
-+    }
-+
-+    /** for Forge internal use, to detect cascading chunk generation issues */
-+    private static void setPopulatingChunk(Boolean populatingTerrain)
-+    {
-+        populating.set(populatingTerrain);
-+    }
 +
 +    private void logCascadingWorldGeneration()
 +    {

--- a/patches/minecraft/net/minecraft/world/chunk/Chunk.java.patch
+++ b/patches/minecraft/net/minecraft/world/chunk/Chunk.java.patch
@@ -206,20 +206,26 @@
          i = MathHelper.func_76125_a(i, 0, this.field_76645_j.length - 1);
          j = MathHelper.func_76125_a(j, 0, this.field_76645_j.length - 1);
  
-@@ -993,9 +996,13 @@
-         }
-         else
+@@ -984,6 +987,8 @@
+ 
+     protected void func_186034_a(IChunkGenerator p_186034_1_)
+     {
++        if (isPopulatingChunk() && net.minecraftforge.common.ForgeModContainer.logCascadingWorldGeneration) logCascadingWorldGeneration();
++        setPopulatingChunk(Boolean.TRUE);
+         if (this.func_177419_t())
          {
-+            if (field_76637_e.isPopulatingTerrain()) reportCascadingWorldGeneration();
-+            this.field_76637_e.setPopulatingTerrain(true);
+             if (p_186034_1_.func_185933_a(this, this.field_76635_g, this.field_76647_h))
+@@ -995,8 +1000,10 @@
+         {
              this.func_150809_p();
              p_186034_1_.func_185931_b(this.field_76635_g, this.field_76647_h);
 +            net.minecraftforge.fml.common.registry.GameRegistry.generateWorld(this.field_76635_g, this.field_76647_h, this.field_76637_e, p_186034_1_, this.field_76637_e.func_72863_F());
              this.func_76630_e();
-+            this.field_76637_e.setPopulatingTerrain(false);
          }
++        setPopulatingChunk(Boolean.FALSE);
      }
  
+     public BlockPos func_177440_h(BlockPos p_177440_1_)
 @@ -1051,7 +1058,7 @@
          {
              BlockPos blockpos = (BlockPos)this.field_177447_w.poll();
@@ -285,7 +291,7 @@
              {
                  this.field_76637_e.func_175664_x(blockpos$mutableblockpos);
              }
-@@ -1476,4 +1496,32 @@
+@@ -1476,4 +1496,47 @@
          QUEUED,
          CHECK;
      }
@@ -307,10 +313,25 @@
 +        }
 +    }
 +
-+    private void reportCascadingWorldGeneration()
++    private static ThreadLocal<Boolean> populating = new ThreadLocal<Boolean>(); // keep track of cascading chunk generation during chunk population
++
++    /** for Forge internal use, to detect cascading chunk generation issues */
++    private static boolean isPopulatingChunk()
++    {
++        Boolean isPopulating = populating.get();
++        return isPopulating != null && isPopulating;
++    }
++
++    /** for Forge internal use, to detect cascading chunk generation issues */
++    private static void setPopulatingChunk(Boolean populatingTerrain)
++    {
++        populating.set(populatingTerrain);
++    }
++
++    private void logCascadingWorldGeneration()
 +    {
 +        net.minecraftforge.fml.common.ModContainer activeModContainer = net.minecraftforge.fml.common.Loader.instance().activeModContainer();
-+        String format = "%s loaded a new chunk (%d, %d  Dimension: %d) during terrain generation, causing cascading worldgen lag. Please report this to the mod's issue tracker.";
++        String format = "%s loaded a new chunk (%d, %d  Dimension: %d) during chunk population, causing cascading worldgen lag. Please report this to the mod's issue tracker. This log can be disabled in the Forge config.";
 +
 +        if (activeModContainer == null) // vanilla minecraft has problems too (MC-114332), log it at a quieter level.
 +            net.minecraftforge.fml.common.FMLLog.fine(format, "Minecraft", this.field_76635_g, this.field_76647_h, this.field_76637_e.field_73011_w.getDimension());

--- a/patches/minecraft/net/minecraft/world/chunk/Chunk.java.patch
+++ b/patches/minecraft/net/minecraft/world/chunk/Chunk.java.patch
@@ -210,8 +210,8 @@
  
      protected void func_186034_a(IChunkGenerator p_186034_1_)
      {
-+        if (populating.get() == Boolean.TRUE && net.minecraftforge.common.ForgeModContainer.logCascadingWorldGeneration) logCascadingWorldGeneration();
-+        populating.set(Boolean.TRUE);
++        if (populating && net.minecraftforge.common.ForgeModContainer.logCascadingWorldGeneration) logCascadingWorldGeneration();
++        populating = true;
          if (this.func_177419_t())
          {
              if (p_186034_1_.func_185933_a(this, this.field_76635_g, this.field_76647_h))
@@ -222,7 +222,7 @@
 +            net.minecraftforge.fml.common.registry.GameRegistry.generateWorld(this.field_76635_g, this.field_76647_h, this.field_76637_e, p_186034_1_, this.field_76637_e.func_72863_F());
              this.func_76630_e();
          }
-+        populating.set(Boolean.FALSE);
++        populating = false;
      }
  
      public BlockPos func_177440_h(BlockPos p_177440_1_)
@@ -313,7 +313,7 @@
 +        }
 +    }
 +
-+    private static ThreadLocal<Boolean> populating = new ThreadLocal<Boolean>(); // keep track of cascading chunk generation during chunk population
++    private static boolean populating = false; // keep track of cascading chunk generation during chunk population
 +
 +    private void logCascadingWorldGeneration()
 +    {

--- a/patches/minecraft/net/minecraft/world/chunk/Chunk.java.patch
+++ b/patches/minecraft/net/minecraft/world/chunk/Chunk.java.patch
@@ -291,7 +291,7 @@
              {
                  this.field_76637_e.func_175664_x(blockpos$mutableblockpos);
              }
-@@ -1476,4 +1496,47 @@
+@@ -1476,4 +1496,46 @@
          QUEUED,
          CHECK;
      }
@@ -318,8 +318,7 @@
 +    /** for Forge internal use, to detect cascading chunk generation issues */
 +    private static boolean isPopulatingChunk()
 +    {
-+        Boolean isPopulating = populating.get();
-+        return isPopulating != null && isPopulating;
++        return populating.get() == Boolean.TRUE;
 +    }
 +
 +    /** for Forge internal use, to detect cascading chunk generation issues */

--- a/src/main/java/net/minecraftforge/common/ForgeModContainer.java
+++ b/src/main/java/net/minecraftforge/common/ForgeModContainer.java
@@ -116,6 +116,7 @@ public class ForgeModContainer extends DummyModContainer implements WorldAccessC
     public static long java8Reminder = 0;
     public static boolean disableStairSlabCulling = false; // Also known as the "DontCullStairsBecauseIUseACrappyTexturePackThatBreaksBasicBlockShapesSoICantTrustBasicBlockCulling" flag
     public static boolean alwaysSetupTerrainOffThread = false; // In RenderGlobal.setupTerrain, always force the chunk render updates to be queued to the thread
+    public static boolean logCascadingWorldGeneration = true; // see Chunk#logCascadingWorldGeneration()
 
     private static Configuration config;
     private static ForgeModContainer INSTANCE;
@@ -272,6 +273,12 @@ public class ForgeModContainer extends DummyModContainer implements WorldAccessC
                 "Enable the forge block rendering pipeline - fixes the lighting of custom models.");
         forgeLightPipelineEnabled = prop.getBoolean(true);
         prop.setLanguageKey("forge.configgui.forgeLightPipelineEnabled");
+        propOrder.add(prop.getName());
+
+        prop = config.get(Configuration.CATEGORY_GENERAL, "logCascadingWorldGeneration", true,
+                "Log cascading chunk generation issues during terrain population.");
+        logCascadingWorldGeneration = prop.getBoolean();
+        prop.setLanguageKey("forge.configgui.logCascadingWorldGeneration");
         propOrder.add(prop.getName());
 
         config.setCategoryPropertyOrder(CATEGORY_GENERAL, propOrder);

--- a/src/main/resources/assets/forge/lang/en_US.lang
+++ b/src/main/resources/assets/forge/lang/en_US.lang
@@ -66,6 +66,8 @@ forge.configgui.maximumTicketCount.tooltip=This is the number of chunk loading r
 forge.configgui.maximumTicketCount=Mod Ticket Limit
 forge.configgui.playerTicketCount.tooltip=The number of tickets a player can be assigned instead of a mod. This is shared across all mods and it is up to the mods to use it.
 forge.configgui.playerTicketCount=Player Ticket Limit
+forge.configgui.logCascadingWorldGeneration=Log Cascading World Gen
+forge.configgui.logCascadingWorldGeneration.tooltip=Log cascading chunk generation issues during terrain population.
 
 fml.config.sample.basicDouble.tooltip=A double property with no defined bounds.
 fml.config.sample.basicDouble=Unbounded Double


### PR DESCRIPTION
This PR adds a check to see if chunk population is happening recursively.
This can happen when a mod loads a new chunk during the terrain population stage.

Logs look like this and get a bit spammy when things are bad but it can be disabled:

>[00:38:12] [Server thread/WARN] [FML]: Quark loaded a new chunk (-85, 139  Dimension: 0) during chunk population, causing cascading worldgen lag. Please report this to the mod's issue tracker. This log can be disabled in the Forge config.
[00:38:13] [Server thread/WARN] [FML]: Roots 2 loaded a new chunk (-107, 154  Dimension: 0) during chunk population, causing cascading worldgen lag. Please report this to the mod's issue tracker. This log can be disabled in the Forge config.
[00:38:13] [Server thread/WARN] [FML]: Roguelike Dungeons loaded a new chunk (-84, 136  Dimension: 0) during chunk population, causing cascading worldgen lag. Please report this to the mod's issue tracker. This log can be disabled in the Forge config.

I also found a bug in vanilla with this log,  https://bugs.mojang.com/browse/MC-114332
When it's caused by vanilla, I've set the log level to "fine" instead of "warn" because there's not much anyone can do about it.