### PR TITLE
DimensionPreloadEvent

### DIFF
--- a/src/main/java/net/minecraftforge/common/DimensionManager.java
+++ b/src/main/java/net/minecraftforge/common/DimensionManager.java
@@ -206,7 +206,7 @@ public class DimensionManager
             if( dim!=0 ) {
                 DimensionPreloadEvent adEvent = new DimensionPreloadEvent(dim, type);
                 MinecraftForge.EVENT_BUS.post(adEvent);
-                alterantiveDimension = adEvent.getAlternativeDimensionToLoad();
+                alterantiveDimension = adEvent.getAlternativeDimension();
             }
         }
         catch (Exception e)

--- a/src/main/java/net/minecraftforge/common/DimensionManager.java
+++ b/src/main/java/net/minecraftforge/common/DimensionManager.java
@@ -216,7 +216,7 @@ public class DimensionManager
         }
         try
         {
-            DimensionManager.getProviderType(dim);
+            DimensionType type = DimensionManager.getProviderType(dim); if(MinecraftForge.EVENT_BUS.post(new net.minecraftforge.event.world.DimensionPreloadEvent(dim, type))) return;
         }
         catch (Exception e)
         {

--- a/src/main/java/net/minecraftforge/common/DimensionManager.java
+++ b/src/main/java/net/minecraftforge/common/DimensionManager.java
@@ -203,10 +203,10 @@ public class DimensionManager
         try
         {
             DimensionType type = DimensionManager.getProviderType(dim);
-            if( dim!=0 ) {
+            if(dim != 0) {
                 DimensionPreloadEvent adEvent = new DimensionPreloadEvent(dim, type);
                 MinecraftForge.EVENT_BUS.post(adEvent);
-                alterantiveDimension = adEvent.getAlternativeDimensionToLoad();
+                alterantiveDimension = adEvent.getAlternativeDimension();
             }
         }
         catch (Exception e)
@@ -215,8 +215,6 @@ public class DimensionManager
             return; // If a provider hasn't been registered then we can't hotload the dim
         }
         MinecraftServer mcServer = overworld.getMinecraftServer();
-        //ISaveHandler savehandler = overworld.getSaveHandler();
-        //WorldSettings worldSettings = new WorldSettings(overworld.getWorldInfo());
         WorldServer world = (dim == 0 ? overworld : ( alterantiveDimension != null ? alterantiveDimension : ((WorldServer)(new WorldServerMulti(mcServer, overworld.getSaveHandler(), dim, overworld, mcServer.theProfiler).init()))));
         world.addEventListener(new ServerWorldEventHandler(mcServer, world));
         MinecraftForge.EVENT_BUS.post(new WorldEvent.Load(world));

--- a/src/main/java/net/minecraftforge/event/world/DimensionPreloadEvent.java
+++ b/src/main/java/net/minecraftforge/event/world/DimensionPreloadEvent.java
@@ -1,0 +1,35 @@
+package net.minecraftforge.event.world;
+
+import net.minecraft.world.DimensionType;
+import net.minecraftforge.common.DimensionManager;
+import net.minecraftforge.fml.common.eventhandler.Cancelable;
+import net.minecraftforge.fml.common.eventhandler.Event;
+import net.minecraftforge.common.MinecraftForge;
+
+/**
+ * Created by goreacraft on 17/03/03.
+ *
+ * This event is fired when DimensionManager is starting to load a new dimmension
+ * dimension 0 (Overworld) will not trigger this event
+ * {@link DimensionManager#initDimension(int)},
+ * <br>
+ * This event is {@link Cancelable}.<br>
+ * <br>
+ * <br>
+ * event is fired on the {@link MinecraftForge#EVENT_BUS}.<br>
+ */
+@Cancelable
+public class DimensionPreloadEvent extends Event {
+
+    private final int dimensionId;
+    private final DimensionType type;
+
+    public DimensionPreloadEvent(int dimensionId, DimensionType type) {
+        this.dimensionId = dimensionId;
+        this.type = type;
+    }
+
+    public int getDimensionId() {
+        return this.dimensionId;
+    }
+}

--- a/src/main/java/net/minecraftforge/event/world/DimensionPreloadEvent.java
+++ b/src/main/java/net/minecraftforge/event/world/DimensionPreloadEvent.java
@@ -7,16 +7,14 @@ import net.minecraftforge.fml.common.eventhandler.Event;
 import net.minecraftforge.common.MinecraftForge;
 
 /**
- * Created by goreacraft on 17/03/03.
- *
- * This event is fired when DimensionManager is starting to load a new dimmension
- * dimension 0 (Overworld) will not trigger this event
- * {@link DimensionManager#initDimension(int)},
+ * This event is fired when DimensionManager is starting to init a new dimension
+ * with {@link DimensionManager#initDimension(int)},
  * <br>
  * This event is {@link Cancelable}.<br>
  * <br>
- * <br>
  * event is fired on the {@link MinecraftForge#EVENT_BUS}.<br>
+ * special care should be used when canceling this event
+ * use it only when you know what you are doing
  */
 @Cancelable
 public class DimensionPreloadEvent extends Event {

--- a/src/main/java/net/minecraftforge/event/world/DimensionPreloadEvent.java
+++ b/src/main/java/net/minecraftforge/event/world/DimensionPreloadEvent.java
@@ -7,14 +7,10 @@ import net.minecraftforge.fml.common.eventhandler.Event;
 import net.minecraftforge.common.MinecraftForge;
 
 /**
- * Created by goreacraft on 17/03/03.
- *
- * This event is fired when DimensionManager is starting to load a new dimmension
- * dimension 0 (Overworld) will not trigger this event
- * {@link DimensionManager#initDimension(int)},
+ * This event is fired when DimensionManager is starting to init a new dimension
+ * with {@link DimensionManager#initDimension(int)},
  * <br>
  * This event is {@link Cancelable}.<br>
- * <br>
  * <br>
  * event is fired on the {@link MinecraftForge#EVENT_BUS}.<br>
  */

--- a/src/main/java/net/minecraftforge/event/world/DimensionPreloadEvent.java
+++ b/src/main/java/net/minecraftforge/event/world/DimensionPreloadEvent.java
@@ -1,21 +1,42 @@
+/*
+ * Minecraft Forge
+ * Copyright (c) 2016.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation version 2.1
+ * of the License.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
 package net.minecraftforge.event.world;
 
 import net.minecraft.world.DimensionType;
 import net.minecraft.world.WorldServer;
-import net.minecraftforge.common.DimensionManager;
-import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.fml.common.eventhandler.Event;
+import net.minecraftforge.common.MinecraftForge;
 
 /**
- * This event is fired when DimensionManager starts to initiate a new dimension
- * with {@link DimensionManager#initDimension(int)},<br>
+ * Event is fired when DimensionManager starts to initiate a new dimension
+ * with {@link net.minecraftforge.common.DimensionManager#initDimension(int)},<br>
  * event is fired on the {@link MinecraftForge#EVENT_BUS}.<br>
+ * <br>
+ * This event can be used to override instantiated dimensions <br>
+ * by using {@link #setAlternativeDimension }
  */
 public class DimensionPreloadEvent extends Event {
 
     private final int dimensionId;
     private final DimensionType type;
-    private WorldServer alternativeDimensionToLoad;
+    private WorldServer alternativeDimension;
 
     public DimensionPreloadEvent(int dimensionId, DimensionType type) {
         this.dimensionId = dimensionId;
@@ -29,12 +50,12 @@ public class DimensionPreloadEvent extends Event {
         return this.type;
     }
 
-    public WorldServer getAlternativeDimensionToLoad() {
-        return alternativeDimensionToLoad;
+    public WorldServer getAlternativeDimension() {
+        return alternativeDimension;
     }
 
-    public void setAlternativeDimensionToLoad(WorldServer alternativeDimension) {
-        this.alternativeDimensionToLoad = alternativeDimension;
+    public void setAlternativeDimension(WorldServer alternativeDimension) {
+        this.alternativeDimension = alternativeDimension;
     }
 
 }


### PR DESCRIPTION
By canceling this event will …prevent the dimension from being initialized and then you can use

DimensionManager.setWorld to add your own custom dimension instead. This will make possible to create a proper multiverse server side plugin

I added this event here to have the option to use it if you need it as i don't know another way to do it unless using Mixin, and why adding another dependency just for this?

I made this particularly for 1.10.x because i think this version will be used for some time ahead by modpacks as there are lots of mods not updated to 1.11.x yet ( see FTB for ex)

Special care has to be made when players will connect in a dimension that it's initialization is canceled with this event

This is a remake of the commit i made earlier : #3755