### PR TITLE
Prevent player from dying due to zero max health

### DIFF
--- a/patches/minecraft/net/minecraft/entity/SharedMonsterAttributes.java.patch
+++ b/patches/minecraft/net/minecraft/entity/SharedMonsterAttributes.java.patch
@@ -5,7 +5,7 @@
  {
      private static final Logger field_151476_f = LogManager.getLogger();
 -    public static final IAttribute field_111267_a = (new RangedAttribute((IAttribute)null, "generic.maxHealth", 20.0D, 0.0D, 1024.0D)).func_111117_a("Max Health").func_111112_a(true);
-+    public static final IAttribute field_111267_a = (new RangedAttribute((IAttribute)null, "generic.maxHealth", 20.0D, 1.0D, 1024.0D)).func_111117_a("Max Health").func_111112_a(true);
++    public static final IAttribute field_111267_a = (new RangedAttribute((IAttribute)null, "generic.maxHealth", 20.0D, 1e-45D, 1024.0D)).func_111117_a("Max Health").func_111112_a(true);
      public static final IAttribute field_111265_b = (new RangedAttribute((IAttribute)null, "generic.followRange", 32.0D, 0.0D, 2048.0D)).func_111117_a("Follow Range");
      public static final IAttribute field_111266_c = (new RangedAttribute((IAttribute)null, "generic.knockbackResistance", 0.0D, 0.0D, 1.0D)).func_111117_a("Knockback Resistance");
      public static final IAttribute field_111263_d = (new RangedAttribute((IAttribute)null, "generic.movementSpeed", 0.699999988079071D, 0.0D, 1024.0D)).func_111117_a("Movement Speed").func_111112_a(true);

--- a/patches/minecraft/net/minecraft/entity/SharedMonsterAttributes.java.patch
+++ b/patches/minecraft/net/minecraft/entity/SharedMonsterAttributes.java.patch
@@ -1,0 +1,11 @@
+--- ../src-base/minecraft/net/minecraft/entity/SharedMonsterAttributes.java
++++ ../src-work/minecraft/net/minecraft/entity/SharedMonsterAttributes.java
+@@ -16,7 +16,7 @@
+ public class SharedMonsterAttributes
+ {
+     private static final Logger field_151476_f = LogManager.getLogger();
+-    public static final IAttribute field_111267_a = (new RangedAttribute((IAttribute)null, "generic.maxHealth", 20.0D, 0.0D, 1024.0D)).func_111117_a("Max Health").func_111112_a(true);
++    public static final IAttribute field_111267_a = (new RangedAttribute((IAttribute)null, "generic.maxHealth", 20.0D, 1.0D, 1024.0D)).func_111117_a("Max Health").func_111112_a(true);
+     public static final IAttribute field_111265_b = (new RangedAttribute((IAttribute)null, "generic.followRange", 32.0D, 0.0D, 2048.0D)).func_111117_a("Follow Range");
+     public static final IAttribute field_111266_c = (new RangedAttribute((IAttribute)null, "generic.knockbackResistance", 0.0D, 0.0D, 1.0D)).func_111117_a("Knockback Resistance");
+     public static final IAttribute field_111263_d = (new RangedAttribute((IAttribute)null, "generic.movementSpeed", 0.699999988079071D, 0.0D, 1024.0D)).func_111117_a("Movement Speed").func_111112_a(true);


### PR DESCRIPTION
This occurs most readily when two mods both decrease max health at the same time. If the mods do this when a player first spawns, this will result in the player being caught in an infinite death loop.