### PR TITLE
Add RenderLivingEvent.PostRotate

### DIFF
--- a/patches/minecraft/net/minecraft/client/renderer/entity/RenderLivingBase.java.patch
+++ b/patches/minecraft/net/minecraft/client/renderer/entity/RenderLivingBase.java.patch
@@ -33,6 +33,15 @@
              {
                  EntityLivingBase entitylivingbase = (EntityLivingBase)p_76986_1_.func_184187_bx();
                  f = this.func_77034_a(entitylivingbase.field_70760_ar, entitylivingbase.field_70761_aq, p_76986_9_);
+@@ -136,7 +141,7 @@
+             GlStateManager.func_179141_d();
+             this.field_77045_g.func_78086_a(p_76986_1_, f6, f5, p_76986_9_);
+             this.field_77045_g.func_78087_a(f6, f5, f8, f2, f7, f4, p_76986_1_);
+-
++            net.minecraftforge.common.MinecraftForge.EVENT_BUS.post(new net.minecraftforge.client.event.RenderLivingEvent.PostRotate<T>(field_77045_g, p_76986_1_, this, p_76986_2_, p_76986_4_, p_76986_6_));
+             if (this.field_188301_f)
+             {
+                 boolean flag1 = this.func_177088_c(p_76986_1_);
 @@ -192,6 +197,7 @@
          GlStateManager.func_179089_o();
          GlStateManager.func_179121_F();

--- a/src/main/java/net/minecraftforge/client/event/RenderLivingEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/RenderLivingEvent.java
@@ -22,6 +22,7 @@ package net.minecraftforge.client.event;
 import net.minecraftforge.fml.common.eventhandler.Cancelable;
 import net.minecraftforge.fml.common.eventhandler.Event;
 import net.minecraft.client.renderer.entity.RenderLivingBase;
+import net.minecraft.client.model.ModelBase;
 import net.minecraft.entity.EntityLivingBase;
 
 public abstract class RenderLivingEvent<T extends EntityLivingBase> extends Event
@@ -70,5 +71,27 @@ public abstract class RenderLivingEvent<T extends EntityLivingBase> extends Even
         {
             public Post(EntityLivingBase entity, RenderLivingBase<T> renderer, double x, double y, double z){ super(entity, renderer, x, y, z); }
         }
+    }
+    /**
+     * PostRotate is fired after an entity's model's parts are rotated.<br>
+     * This event is fired immediately after rotation angles are set in
+     * {@link RenderLivingBase#doRender(Double, Double, Double, Float, Float)}.<br>
+     * <br>
+     * {@link #mainModel} contains the model that had the rotation angles set. <br>
+     * <br>
+     * This event is not {@link Cancelable}.<br>
+     * <br>
+     * This event is fired on the {@link net.minecraftforge.common.MinecraftForge#EVENT_BUS}.
+     **/
+    public static class PostRotate<T extends EntityLivingBase> extends RenderLivingEvent<T>
+    {
+        private ModelBase mainModel;
+
+        public PostRotate(ModelBase mainModel, EntityLivingBase entity, RenderLivingBase<T> renderer, double x, double y, double z){
+            super(entity, renderer, x, y, z);
+            this.mainModel = mainModel;
+        }
+
+        public ModelBase getMainModel() { return mainModel; }
     }
 }


### PR DESCRIPTION
This event allows for rotating the parts of an entity's model after rotation angles are set in RenderLivingBase#doRender, something none of the RenderLivingEvents currently allow.

This would enable modders to move limbs of any EntityLivingBase, which could be useful for emotes, item posing, and probably several other more creative uses I'm not thinking of.

A similar idea was suggested in PR #3350, but it was never updated to 1.11 and was in my opinion poorly implemented. It was not a RenderLivingEvent and instead posted in the ModelBiped class, limiting its use.