### PR TITLE
Add AnimalTameEvent for handling animal taming

### DIFF
--- a/patches/minecraft/net/minecraft/entity/ai/EntityAIRunAroundLikeCrazy.java.patch
+++ b/patches/minecraft/net/minecraft/entity/ai/EntityAIRunAroundLikeCrazy.java.patch
@@ -1,0 +1,11 @@
+--- ../src-base/minecraft/net/minecraft/entity/ai/EntityAIRunAroundLikeCrazy.java
++++ ../src-work/minecraft/net/minecraft/entity/ai/EntityAIRunAroundLikeCrazy.java
+@@ -70,7 +70,7 @@
+                 int i = this.field_111180_a.func_110252_cg();
+                 int j = this.field_111180_a.func_190676_dC();
+ 
+-                if (j > 0 && this.field_111180_a.func_70681_au().nextInt(j) < i)
++                if (j > 0 && this.field_111180_a.func_70681_au().nextInt(j) < i && !net.minecraftforge.event.ForgeEventFactory.onAnimalTame(field_111180_a, (EntityPlayer)entity))
+                 {
+                     this.field_111180_a.func_110263_g((EntityPlayer)entity);
+                     return;

--- a/patches/minecraft/net/minecraft/entity/passive/EntityOcelot.java.patch
+++ b/patches/minecraft/net/minecraft/entity/passive/EntityOcelot.java.patch
@@ -1,5 +1,14 @@
 --- ../src-base/minecraft/net/minecraft/entity/passive/EntityOcelot.java
 +++ ../src-work/minecraft/net/minecraft/entity/passive/EntityOcelot.java
+@@ -208,7 +208,7 @@
+ 
+             if (!this.field_70170_p.field_72995_K)
+             {
+-                if (this.field_70146_Z.nextInt(3) == 0)
++                if (this.field_70146_Z.nextInt(3) == 0 && !net.minecraftforge.event.ForgeEventFactory.onAnimalTame(this, p_184645_1_))
+                 {
+                     this.func_70903_f(true);
+                     this.func_70912_b(1 + this.field_70170_p.field_73012_v.nextInt(3));
 @@ -299,7 +299,7 @@
              IBlockState iblockstate = this.field_70170_p.func_180495_p(blockpos.func_177977_b());
              Block block = iblockstate.func_177230_c();

--- a/patches/minecraft/net/minecraft/entity/passive/EntityWolf.java.patch
+++ b/patches/minecraft/net/minecraft/entity/passive/EntityWolf.java.patch
@@ -1,0 +1,11 @@
+--- ../src-base/minecraft/net/minecraft/entity/passive/EntityWolf.java
++++ ../src-work/minecraft/net/minecraft/entity/passive/EntityWolf.java
+@@ -423,7 +423,7 @@
+ 
+             if (!this.field_70170_p.field_72995_K)
+             {
+-                if (this.field_70146_Z.nextInt(3) == 0)
++                if (this.field_70146_Z.nextInt(3) == 0 && !net.minecraftforge.event.ForgeEventFactory.onAnimalTame(this, p_184645_1_))
+                 {
+                     this.func_70903_f(true);
+                     this.field_70699_by.func_75499_g();

--- a/src/main/java/net/minecraftforge/event/ForgeEventFactory.java
+++ b/src/main/java/net/minecraftforge/event/ForgeEventFactory.java
@@ -35,6 +35,7 @@ import net.minecraft.entity.EnumCreatureType;
 import net.minecraft.entity.effect.EntityLightningBolt;
 import net.minecraft.entity.item.EntityItem;
 import net.minecraft.entity.monster.EntityZombie;
+import net.minecraft.entity.passive.EntityAnimal;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.entity.player.EntityPlayer.SleepResult;
 import net.minecraft.init.Blocks;
@@ -78,6 +79,7 @@ import net.minecraftforge.event.entity.EntityMountEvent;
 import net.minecraftforge.event.entity.EntityStruckByLightningEvent;
 import net.minecraftforge.event.entity.PlaySoundAtEntityEvent;
 import net.minecraftforge.event.entity.item.ItemExpireEvent;
+import net.minecraftforge.event.entity.living.AnimalTameEvent;
 import net.minecraftforge.event.entity.living.LivingEntityUseItemEvent;
 import net.minecraftforge.event.entity.living.LivingExperienceDropEvent;
 import net.minecraftforge.event.entity.living.LivingHealEvent;
@@ -439,6 +441,11 @@ public class ForgeEventFactory
         }
         else
             return true;
+    }
+
+    public static boolean onAnimalTame(EntityAnimal animal, EntityPlayer tamer)
+    {
+        return MinecraftForge.EVENT_BUS.post(new AnimalTameEvent(animal, tamer));
     }
 
     public static SleepResult onPlayerSleepInBed(EntityPlayer player, BlockPos pos)

--- a/src/main/java/net/minecraftforge/event/entity/living/AnimalTameEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/living/AnimalTameEvent.java
@@ -1,0 +1,57 @@
+/*
+ * Minecraft Forge
+ * Copyright (c) 2016.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation version 2.1
+ * of the License.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+package net.minecraftforge.event.entity.living;
+
+import net.minecraft.entity.passive.EntityAnimal;
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraftforge.common.MinecraftForge;
+import net.minecraftforge.event.ForgeEventFactory;
+import net.minecraftforge.fml.common.eventhandler.Cancelable;
+
+/**
+ * This event is fired when an {@link EntityAnimal} is tamed. <br>
+ * It is fired via {@link ForgeEventFactory#onAnimalTame(EntityAnimal, EntityPlayer)}.
+ * Forge fires this event for applicable vanilla animals, mods need to fire it themselves.
+ * This event is {@link Cancelable}. If canceled, taming the animal will fail.
+ * This event is fired on the {@link MinecraftForge#EVENT_BUS}.
+ */
+@Cancelable
+public class AnimalTameEvent extends LivingEvent
+{
+    private final EntityAnimal animal;
+    private final EntityPlayer tamer;
+
+    public AnimalTameEvent(EntityAnimal animal, EntityPlayer tamer)
+    {
+        super(animal);
+        this.animal = animal;
+        this.tamer = tamer;
+    }
+
+    public EntityAnimal getAnimal()
+    {
+        return animal;
+    }
+
+    public EntityPlayer getTamer()
+    {
+        return tamer;
+    }
+}

--- a/src/test/java/net/minecraftforge/test/AnimalTameEventTest.java
+++ b/src/test/java/net/minecraftforge/test/AnimalTameEventTest.java
@@ -1,0 +1,25 @@
+package net.minecraftforge.test;
+
+import net.minecraft.entity.passive.EntityWolf;
+import net.minecraftforge.event.entity.living.AnimalTameEvent;
+import net.minecraftforge.fml.common.Mod;
+import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
+
+@Mod(modid = AnimalTameEventTest.MOD_ID, name = "AnimalTameEvent test mod", version = "1.0")
+@Mod.EventBusSubscriber
+public class AnimalTameEventTest
+{
+    static final String MOD_ID = "animal_tame_event_test";
+    static final boolean ENABLED = false;
+
+    @SubscribeEvent
+    public static void onAnimalTame(AnimalTameEvent event)
+    {
+        if (!ENABLED) return;
+
+        if (event.getAnimal() instanceof EntityWolf)
+        {
+            event.setCanceled(true);
+        }
+    }
+}


### PR DESCRIPTION
This PR adds a new `AnimalTameEvent`, allowing mods to handle animals being tamed.

There was some talk about possible use for something similar in #3046.
Here we just provide an event for mods to subscribe to, rather than adding new methods to `EntityTameable`.

Points to note:
*  The class used to represent the entity involved is `EntityAnimal`.
This is the class that is common to all vanilla animals that can be tamed.
The `EntityPlayer` performing the taming is also available through the event.
*  It supports horses and llamas as well, despite them not extending `EntityTameable`.
The behaviour is inherited from the AI handling of `AbstractHorse`.
*  An event means mods can prevent the taming of animals without interfering with other interactions.
Currently, you would have to anticipate the behaviour of `processInteract()` and then selectively abort the entire interaction.
*  The event is fired via patches to:
    *  `EntityAIRunAroundLikeCrazy.updateTask()`  (for vanilla `AbstractHorse` based entities)
    *  `EntityOcelot.processInteract()`
    *  `EntityWolf.processInteract()`
*  Mods will have to fire this event manually for other `EntityTameable` derived entities as well as other custom animals.

A quick test mod is included that makes wolves untameable.