### PR TITLE
[WIP] Generalise 'static' access via ILanguageAdapter

### DIFF
--- a/src/main/java/net/minecraftforge/fml/common/AutomaticEventSubscriber.java
+++ b/src/main/java/net/minecraftforge/fml/common/AutomaticEventSubscriber.java
@@ -79,7 +79,12 @@ public class AutomaticEventSubscriber
                         FMLLog.fine("Skipping @EventBusSubscriber injection for %s since it is not for mod %s", targ.getClassName(), mod.getModId());
                         continue; //We're not injecting this guy
                     }
-                    Class<?> subscriptionTarget = Class.forName(targ.getClassName(), true, mcl);
+                    Class<?> subscriptionTargetClass = Class.forName(targ.getClassName(), true, mcl);
+                    Object subscriptionTarget = subscriptionTargetClass;
+                    if (mod instanceof FMLModContainer)
+                    {
+                        subscriptionTarget = ((FMLModContainer) mod).getLanguageAdapter().getStaticContainer(subscriptionTargetClass, mcl).getInstance();
+                    }
                     MinecraftForge.EVENT_BUS.register(subscriptionTarget);
                     FMLLog.fine("Injected @EventBusSubscriber class %s", targ.getClassName());
                 }

--- a/src/main/java/net/minecraftforge/fml/common/FMLModContainer.java
+++ b/src/main/java/net/minecraftforge/fml/common/FMLModContainer.java
@@ -148,7 +148,8 @@ public class FMLModContainer implements ModContainer
             throw new IllegalArgumentException(String.format("The modid %s is not the same as it's lowercase version. Lowercasing will be enforced in 1.11", modid));
         }
     }
-    private ILanguageAdapter getLanguageAdapter()
+
+    public ILanguageAdapter getLanguageAdapter()
     {
         if (languageAdapter == null)
         {


### PR DESCRIPTION
As outlined in #3764, Forge currently does not support some other JVM languages (especially Scala) in places where it relies on `static` fields or methods to be present. This PR intends to move access to these static objects into an additional layer which wraps around this basic concept present in most JVM languages. This takes the form of a `IStaticContainer` accessible via an `ILanguageAdapter`.

The PR includes basic implementations of static containers for both class-based (e.g. Java) and singleton-based (e.g. Scala) languages. Custom language adapters can provide their own implementation if they want to, the provided ones should suffice, however.

Known places where a static container is required, with implementation status:

- [x] `AutomaticEventSubscriber`
- [ ] Annotation-based config system (this needs some consideration, maybe `Config.Type` could be expanded)

*Note: This PR is marked as WIP since I'm still looking for places where statics are still expected. However, I've already created the PR for reviews of the basic concept.*