### PR TITLE
Close #3768 Skip loading models if there is a fatal mod dependency error

### DIFF
--- a/src/main/java/net/minecraftforge/client/model/ModelLoader.java
+++ b/src/main/java/net/minecraftforge/client/model/ModelLoader.java
@@ -94,6 +94,7 @@ import net.minecraftforge.fluids.FluidRegistry;
 import net.minecraftforge.fluids.FluidStack;
 import net.minecraftforge.fluids.FluidUtil;
 import net.minecraftforge.fluids.capability.IFluidHandler;
+import net.minecraftforge.fml.client.FMLClientHandler;
 import net.minecraftforge.fml.common.FMLLog;
 import net.minecraftforge.fml.common.ProgressManager;
 import net.minecraftforge.fml.common.ProgressManager.ProgressBar;
@@ -151,6 +152,9 @@ public final class ModelLoader extends ModelBakery
     @Override
     public IRegistry<ModelResourceLocation, IBakedModel> setupModelRegistry()
     {
+        if (FMLClientHandler.instance().hasError()) // skip loading models if we're just going to show a fatal error screen
+            return bakedRegistry;
+
         isLoading = true;
         loadBlocks();
         loadVariantItemModels();

--- a/src/main/java/net/minecraftforge/fml/client/FMLClientHandler.java
+++ b/src/main/java/net/minecraftforge/fml/client/FMLClientHandler.java
@@ -333,6 +333,12 @@ public class FMLClientHandler implements IFMLSidedHandler
         client.displayCrashReport(new CrashReport(message, t));
         throw Throwables.propagate(t);
     }
+
+    public boolean hasError()
+    {
+        return modsMissing != null || wrongMC != null || customError != null || dupesFound != null || modSorting != null || j8onlymods != null || multipleModsErrored != null;
+    }
+
     /**
      * Called a bit later on during initialization to finish loading mods
      * Also initializes key bindings
@@ -340,7 +346,7 @@ public class FMLClientHandler implements IFMLSidedHandler
      */
     public void finishMinecraftLoading()
     {
-        if (modsMissing != null || wrongMC != null || customError!=null || dupesFound!=null || modSorting!=null || j8onlymods!=null || multipleModsErrored !=null)
+        if (hasError())
         {
             SplashProgress.finish();
             return;


### PR DESCRIPTION
See issue #3768
This PR skips model loading when FML has caught a mod dependency error and is going to show an error screen.
It helps make the pack-creation debugging process a little bit quicker.