### PR TITLE
Fix #3733 Splash Screen memory bar background matches screen background

### DIFF
--- a/src/main/java/net/minecraftforge/fml/client/SplashProgress.java
+++ b/src/main/java/net/minecraftforge/fml/client/SplashProgress.java
@@ -453,7 +453,7 @@ public class SplashProgress
                 setColor(barBorderColor);
                 drawBox(barWidth, barHeight);
                 // interior
-                setColor(backgroundColor);
+                setColor(barBackgroundColor);
                 glTranslatef(1, 1, 0);
                 drawBox(barWidth - 2, barHeight - 2);
                 // slidy part


### PR DESCRIPTION
Fixes #3733, I used the wrong variable for the bar's background color.