### PR TITLE
Fix duplicate achievements getting added to the achievement list (#3770)

### DIFF
--- a/patches/minecraft/net/minecraft/stats/StatList.java.patch
+++ b/patches/minecraft/net/minecraft/stats/StatList.java.patch
@@ -123,7 +123,7 @@
  
          if (p_151180_0_[i] != null && p_151180_0_[j] == null)
          {
-@@ -310,4 +317,36 @@
+@@ -310,4 +317,37 @@
      {
          return (StatBase)field_188093_a.get(p_151177_0_);
      }
@@ -147,6 +147,7 @@
 +                }
 +            }
 +        }
++        field_75940_b.removeAll(AchievementList.field_187981_e);
 +        List<StatBase> unknown = Lists.newArrayList(field_75940_b);
 +        field_75940_b.clear();
 +

--- a/patches/minecraft/net/minecraft/stats/StatList.java.patch
+++ b/patches/minecraft/net/minecraft/stats/StatList.java.patch
@@ -135,6 +135,7 @@
 +        field_188094_c.clear();
 +        field_188095_d.clear();
 +        field_188096_e.clear();
++        AchievementList.field_187981_e.clear();
 +
 +        for (StatBase[] sb : new StatBase[][]{field_188065_ae,  field_188066_af, field_75929_E, field_75930_F, field_188067_ai, field_188068_aj})
 +        {
@@ -147,7 +148,6 @@
 +                }
 +            }
 +        }
-+        field_75940_b.removeAll(AchievementList.field_187981_e);
 +        List<StatBase> unknown = Lists.newArrayList(field_75940_b);
 +        field_75940_b.clear();
 +


### PR DESCRIPTION
Fixes duplicate achievements getting added to the achievement list (#3770), which was causing strange behaviour with the `/achievement` command.