### PR TITLE
Updated armour calculations for EntityPlayer, changes to ISpecialArmor

### DIFF
--- a/src/main/java/net/minecraftforge/common/ForgeHooks.java
+++ b/src/main/java/net/minecraftforge/common/ForgeHooks.java
@@ -54,6 +54,7 @@ import net.minecraft.entity.projectile.EntityThrowable;
 import net.minecraft.init.Blocks;
 import net.minecraft.init.Items;
 import net.minecraft.inventory.ContainerRepair;
+import net.minecraft.inventory.EntityEquipmentSlot;
 import net.minecraft.inventory.IInventory;
 import net.minecraft.inventory.InventoryCrafting;
 import net.minecraft.item.ItemArmor;
@@ -268,16 +269,19 @@ public class ForgeHooks
     public static int getTotalArmorValue(EntityPlayer player)
     {
         int ret = 0;
-        for (int x = 0; x < player.inventory.armorInventory.size(); x++)
+        for (EntityEquipmentSlot slot : EntityEquipmentSlot.values())
         {
-            ItemStack stack = player.inventory.armorInventory.get(x);
-            if (stack.getItem() instanceof ISpecialArmor)
+            if(slot.getSlotType() == EntityEquipmentSlot.Type.ARMOR)
             {
-                ret += ((ISpecialArmor)stack.getItem()).getArmorDisplay(player, stack, x);
-            }
-            else if (stack.getItem() instanceof ItemArmor)
-            {
-                ret += ((ItemArmor)stack.getItem()).damageReduceAmount;
+               ItemStack stack = player.GetItemStackFromSlot(slot);
+			   if (stack != null && stack.getItem() instanceof ISpecialArmor)
+			   {
+				   ret += ((ISpecialArmor)stack.getItem()).getArmorDisplay(player, stack, slot);
+			   }
+			   else if (stack != null && stack.getItem() instanceof ItemArmor)
+			   {
+				   ret += ((ItemArmor)stack.getItem()).damageReduceAmount;
+			   }
             }
         }
         return ret;


### PR DESCRIPTION
Updated ISpecialArmor to use EntityEquipmentSlot. Tweaked ISpecialArmor's damage calculations to apply flat reduction first and then vanilla calculations.
This should fix #3095
This is just an updated version of #2765 pull request.