### PR TITLE
Add getCapabilityProvider() to ItemStack

### DIFF
--- a/patches/minecraft/net/minecraft/item/ItemStack.java.patch
+++ b/patches/minecraft/net/minecraft/item/ItemStack.java.patch
@@ -15,12 +15,13 @@
  
 +    private net.minecraftforge.fml.common.registry.RegistryDelegate<Item> delegate;
 +    private net.minecraftforge.common.capabilities.CapabilityDispatcher capabilities;
++    private net.minecraftforge.common.capabilities.ICapabilityProvider capabilityProvider;
 +    private NBTTagCompound capNBT;
 +
      public ItemStack(Block p_i1876_1_)
      {
          this((Block)p_i1876_1_, 1);
-@@ -88,8 +92,10 @@
+@@ -88,8 +93,10 @@
          this((Item)p_i1880_1_, p_i1880_2_, 0);
      }
  
@@ -32,7 +33,7 @@
          this.field_151002_e = p_i1881_1_;
          this.field_77991_e = p_i1881_3_;
          this.field_77994_a = p_i1881_2_;
-@@ -100,6 +106,7 @@
+@@ -100,6 +107,7 @@
          }
  
          this.func_190923_F();
@@ -40,7 +41,7 @@
      }
  
      private void func_190923_F()
-@@ -109,6 +116,7 @@
+@@ -109,6 +117,7 @@
  
      public ItemStack(NBTTagCompound p_i47263_1_)
      {
@@ -48,7 +49,7 @@
          this.field_151002_e = Item.func_111206_d(p_i47263_1_.func_74779_i("id"));
          this.field_77994_a = p_i47263_1_.func_74771_c("Count");
          this.field_77991_e = Math.max(0, p_i47263_1_.func_74765_d("Damage"));
-@@ -124,11 +132,12 @@
+@@ -124,11 +133,12 @@
          }
  
          this.func_190923_F();
@@ -62,7 +63,7 @@
      }
  
      public static void func_189868_a(DataFixer p_189868_0_)
-@@ -148,11 +157,12 @@
+@@ -148,11 +158,12 @@
  
      public Item func_77973_b()
      {
@@ -76,7 +77,7 @@
          EnumActionResult enumactionresult = this.func_77973_b().func_180614_a(p_179546_1_, p_179546_2_, p_179546_3_, p_179546_4_, p_179546_5_, p_179546_6_, p_179546_7_, p_179546_8_);
  
          if (enumactionresult == EnumActionResult.SUCCESS)
-@@ -163,6 +173,19 @@
+@@ -163,6 +174,19 @@
          return enumactionresult;
      }
  
@@ -96,7 +97,7 @@
      public float func_150997_a(IBlockState p_150997_1_)
      {
          return this.func_77973_b().func_150893_a(this, p_150997_1_);
-@@ -190,12 +213,18 @@
+@@ -190,12 +214,18 @@
              p_77955_1_.func_74782_a("tag", this.field_77990_d);
          }
  
@@ -116,7 +117,7 @@
      }
  
      public boolean func_77985_e()
-@@ -205,7 +234,7 @@
+@@ -205,7 +235,7 @@
  
      public boolean func_77984_f()
      {
@@ -125,7 +126,7 @@
      }
  
      public boolean func_77981_g()
-@@ -215,32 +244,27 @@
+@@ -215,32 +245,27 @@
  
      public boolean func_77951_h()
      {
@@ -163,7 +164,7 @@
      }
  
      public boolean func_96631_a(int p_96631_1_, Random p_96631_2_)
-@@ -272,8 +296,8 @@
+@@ -272,8 +297,8 @@
                  }
              }
  
@@ -174,7 +175,7 @@
          }
      }
  
-@@ -322,7 +346,7 @@
+@@ -322,7 +347,7 @@
  
      public boolean func_150998_b(IBlockState p_150998_1_)
      {
@@ -183,7 +184,7 @@
      }
  
      public boolean func_111282_a(EntityPlayer p_111282_1_, EntityLivingBase p_111282_2_, EnumHand p_111282_3_)
-@@ -332,7 +356,7 @@
+@@ -332,7 +357,7 @@
  
      public ItemStack func_77946_l()
      {
@@ -192,7 +193,7 @@
  
          if (this.field_77990_d != null)
          {
-@@ -344,7 +368,7 @@
+@@ -344,7 +369,7 @@
  
      public static boolean func_77970_a(ItemStack p_77970_0_, ItemStack p_77970_1_)
      {
@@ -201,7 +202,7 @@
      }
  
      public static boolean func_77989_b(ItemStack p_77989_0_, ItemStack p_77989_1_)
-@@ -354,7 +378,7 @@
+@@ -354,7 +379,7 @@
  
      private boolean func_77959_d(ItemStack p_77959_1_)
      {
@@ -210,7 +211,7 @@
      }
  
      public static boolean func_179545_c(ItemStack p_179545_0_, ItemStack p_179545_1_)
-@@ -758,6 +782,7 @@
+@@ -758,6 +783,7 @@
              }
          }
  
@@ -218,7 +219,7 @@
          return list;
      }
  
-@@ -869,7 +894,7 @@
+@@ -869,7 +895,7 @@
          }
          else
          {
@@ -227,7 +228,7 @@
          }
  
          return multimap;
-@@ -982,6 +1007,53 @@
+@@ -982,6 +1008,53 @@
          }
      }
  
@@ -278,10 +279,19 @@
 +        }
 +    }
 +
++    /**
++     * @return The result of the {@link Item#initCapabilities(ItemStack, NBTTagCompound)}
++     */
++    @javax.annotation.Nullable
++    public net.minecraftforge.common.capabilities.ICapabilityProvider getCapabilityProvider()
++    {
++        return this.capabilityProvider;
++    }
++
      @SideOnly(Side.CLIENT)
      public int func_190921_D()
      {
-@@ -1013,4 +1085,28 @@
+@@ -1013,4 +1095,28 @@
      {
          this.func_190917_f(-p_190918_1_);
      }


### PR DESCRIPTION
This PR adds the `getCapabilityProvider()` method to `ItemStack`, which returns the `ICapabilityProvider` instance returned by `Item.initCapabilities(ItemStack, NBTTagCompound)` or `null`.

---

Closes #3782 