### PR TITLE
Fix forge pipeline block shifts

### DIFF
--- a/src/main/java/net/minecraftforge/client/model/pipeline/BlockInfo.java
+++ b/src/main/java/net/minecraftforge/client/model/pipeline/BlockInfo.java
@@ -25,6 +25,7 @@ import net.minecraft.client.renderer.color.BlockColors;
 import net.minecraft.util.EnumFacing;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.MathHelper;
+import net.minecraft.util.math.Vec3d;
 import net.minecraft.world.IBlockAccess;
 
 public class BlockInfo
@@ -61,22 +62,16 @@ public class BlockInfo
 
     public void updateShift()
     {
-        updateShift(false);
+        Vec3d offset = state.getOffset(world, blockPos);
+        shx = (float) offset.xCoord;
+        shy = (float) offset.yCoord;
+        shz = (float) offset.zCoord;
     }
 
+    @Deprecated
     public void updateShift(boolean ignoreY)
     {
-        long rand = 0;
-        if(state.getBlock().getOffsetType() != EnumOffsetType.NONE)
-        {
-            rand = MathHelper.getCoordinateRandom(blockPos.getX(), ignoreY ? 0 : blockPos.getY(), blockPos.getZ());
-            shx = ((float)((rand >> 16) & 0xF) / 0xF - .5f) * .5f;
-            shz = ((float)((rand >> 24) & 0xF) / 0xF - .5f) * .5f;
-            if(state.getBlock().getOffsetType() == EnumOffsetType.XYZ)
-            {
-                shy = ((float)((rand >> 20) & 0xF) / 0xF - 1) * .2f;
-            }
-        }
+        updateShift();
     }
 
     public void setWorld(IBlockAccess world)

--- a/src/main/java/net/minecraftforge/client/model/pipeline/VertexLighterFlat.java
+++ b/src/main/java/net/minecraftforge/client/model/pipeline/VertexLighterFlat.java
@@ -286,6 +286,6 @@ public class VertexLighterFlat extends QuadGatheringTransformer
 
     public void updateBlockInfo()
     {
-        blockInfo.updateShift(true);
+        blockInfo.updateShift();
     }
 }

--- a/src/main/java/net/minecraftforge/client/model/pipeline/VertexLighterSmoothAo.java
+++ b/src/main/java/net/minecraftforge/client/model/pipeline/VertexLighterSmoothAo.java
@@ -182,7 +182,7 @@ public class VertexLighterSmoothAo extends VertexLighterFlat
     @Override
     public void updateBlockInfo()
     {
-        blockInfo.updateShift(false);
+        super.updateBlockInfo();
         blockInfo.updateLightMatrix();
     }
 }


### PR DESCRIPTION
Fixes #3788, by just calling into vanilla and using the result from the vanilla method.
Verified to work for the bug examples shown in the report (shifts now match bounding box and vanilla rendering aka forge pipeline off). Double plant shifts still working.

Moved the logic back into the no-args method and deprecated the one with an arg, as the y-argument passed to `MathHelper` should *always* be 0 when rendering blockstates (can be verified using a find usages on said mathhelper method)

