### PR TITLE
Add Item.canDestroyBlocksInCreative() to override vanilla sword hardcode

### DIFF
--- a/patches/minecraft/net/minecraft/client/multiplayer/PlayerControllerMP.java.patch
+++ b/patches/minecraft/net/minecraft/client/multiplayer/PlayerControllerMP.java.patch
@@ -11,7 +11,7 @@
              return false;
          }
 +
-+        if (this.field_78779_k.func_77145_d() && !this.field_78776_a.field_71439_g.func_184614_ca().func_190926_b() && !this.field_78776_a.field_71439_g.func_184614_ca().func_77973_b().canDestroyBlocksInCreative())
++        if (this.field_78779_k.func_77145_d() && !stack.func_190926_b() && !stack.func_77973_b().canDestroyBlocksInCreative())
 +        {
 +            return false;
 +        }

--- a/patches/minecraft/net/minecraft/client/multiplayer/PlayerControllerMP.java.patch
+++ b/patches/minecraft/net/minecraft/client/multiplayer/PlayerControllerMP.java.patch
@@ -1,6 +1,18 @@
 --- ../src-base/minecraft/net/minecraft/client/multiplayer/PlayerControllerMP.java
 +++ ../src-work/minecraft/net/minecraft/client/multiplayer/PlayerControllerMP.java
-@@ -122,10 +122,16 @@
+@@ -14,11 +14,9 @@
+ import net.minecraft.entity.Entity;
+ import net.minecraft.entity.passive.AbstractHorse;
+ import net.minecraft.entity.player.EntityPlayer;
+-import net.minecraft.init.Blocks;
+ import net.minecraft.inventory.ClickType;
+ import net.minecraft.item.ItemBlock;
+ import net.minecraft.item.ItemStack;
+-import net.minecraft.item.ItemSword;
+ import net.minecraft.network.PacketBuffer;
+ import net.minecraft.network.play.client.CPacketClickWindow;
+ import net.minecraft.network.play.client.CPacketCreativeInventoryAction;
+@@ -122,10 +120,16 @@
              }
          }
  
@@ -11,14 +23,14 @@
              return false;
          }
 +
-+        if (this.field_78779_k.func_77145_d() && !stack.func_190926_b() && !stack.func_77973_b().canDestroyBlocksInCreative())
++        if (this.field_78779_k.func_77145_d() && !stack.func_190926_b() && !stack.func_77973_b().canDestroyBlockInCreative(stack, field_78776_a.field_71441_e.func_180495_p(p_187103_1_), field_78776_a.field_71439_g))
 +        {
 +            return false;
 +        }
          else
          {
              World world = this.field_78776_a.field_71441_e;
-@@ -143,19 +149,13 @@
+@@ -143,19 +147,13 @@
              else
              {
                  world.func_175718_b(2001, p_187103_1_, Block.func_176210_f(iblockstate));
@@ -39,7 +51,7 @@
  
                      if (!itemstack1.func_190926_b())
                      {
-@@ -163,11 +163,18 @@
+@@ -163,11 +161,18 @@
  
                          if (itemstack1.func_190926_b())
                          {
@@ -58,7 +70,7 @@
                  return flag;
              }
          }
-@@ -207,6 +214,7 @@
+@@ -207,6 +212,7 @@
              if (this.field_78779_k.func_77145_d())
              {
                  this.field_78774_b.func_147297_a(new CPacketPlayerDigging(CPacketPlayerDigging.Action.START_DESTROY_BLOCK, p_180511_1_, p_180511_2_));
@@ -66,7 +78,7 @@
                  func_178891_a(this.field_78776_a, this, p_180511_1_, p_180511_2_);
                  this.field_78781_i = 5;
              }
-@@ -218,14 +226,17 @@
+@@ -218,14 +224,17 @@
                  }
  
                  this.field_78774_b.func_147297_a(new CPacketPlayerDigging(CPacketPlayerDigging.Action.START_DESTROY_BLOCK, p_180511_1_, p_180511_2_));
@@ -85,7 +97,7 @@
                  if (flag && iblockstate.func_185903_a(this.field_78776_a.field_71439_g, this.field_78776_a.field_71439_g.field_70170_p, p_180511_1_) >= 1.0F)
                  {
                      this.func_187103_a(p_180511_1_);
-@@ -289,7 +300,7 @@
+@@ -289,7 +298,7 @@
  
                  if (this.field_78780_h % 4.0F == 0.0F)
                  {
@@ -94,7 +106,7 @@
                      this.field_78776_a.func_147118_V().func_147682_a(new PositionedSoundRecord(soundtype.func_185846_f(), SoundCategory.NEUTRAL, (soundtype.func_185843_a() + 1.0F) / 8.0F, soundtype.func_185847_b() * 0.5F, p_180512_1_));
                  }
  
-@@ -341,7 +352,7 @@
+@@ -341,7 +350,7 @@
  
          if (!this.field_85183_f.func_190926_b() && !itemstack.func_190926_b())
          {
@@ -103,7 +115,7 @@
          }
  
          return p_178893_1_.equals(this.field_178895_c) && flag;
-@@ -373,13 +384,29 @@
+@@ -373,13 +382,29 @@
          }
          else
          {
@@ -135,7 +147,7 @@
                  }
  
                  if (!flag && itemstack.func_77973_b() instanceof ItemBlock)
-@@ -395,7 +422,7 @@
+@@ -395,7 +420,7 @@
  
              this.field_78774_b.func_147297_a(new CPacketPlayerTryUseItemOnBlock(p_187099_3_, p_187099_4_, p_187099_6_, f, f1, f2));
  
@@ -144,7 +156,7 @@
              {
                  if (itemstack.func_190926_b())
                  {
-@@ -421,14 +448,20 @@
+@@ -421,14 +446,20 @@
                      {
                          int i = itemstack.func_77960_j();
                          int j = itemstack.func_190916_E();
@@ -166,7 +178,7 @@
                      }
                  }
              }
-@@ -457,6 +490,7 @@
+@@ -457,6 +488,7 @@
              }
              else
              {
@@ -174,7 +186,7 @@
                  int i = itemstack.func_190916_E();
                  ActionResult<ItemStack> actionresult = itemstack.func_77957_a(p_187101_2_, p_187101_1_, p_187101_3_);
                  ItemStack itemstack1 = (ItemStack)actionresult.func_188398_b();
-@@ -464,6 +498,10 @@
+@@ -464,6 +496,10 @@
                  if (itemstack1 != itemstack || itemstack1.func_190916_E() != i)
                  {
                      p_187101_1_.func_184611_a(p_187101_3_, itemstack1);
@@ -185,7 +197,7 @@
                  }
  
                  return actionresult.func_188397_a();
-@@ -500,6 +538,7 @@
+@@ -500,6 +536,7 @@
          this.func_78750_j();
          Vec3d vec3d = new Vec3d(p_187102_3_.field_72307_f.field_72450_a - p_187102_2_.field_70165_t, p_187102_3_.field_72307_f.field_72448_b - p_187102_2_.field_70163_u, p_187102_3_.field_72307_f.field_72449_c - p_187102_2_.field_70161_v);
          this.field_78774_b.func_147297_a(new CPacketUseEntity(p_187102_2_, p_187102_4_, vec3d));

--- a/patches/minecraft/net/minecraft/client/multiplayer/PlayerControllerMP.java.patch
+++ b/patches/minecraft/net/minecraft/client/multiplayer/PlayerControllerMP.java.patch
@@ -1,6 +1,6 @@
 --- ../src-base/minecraft/net/minecraft/client/multiplayer/PlayerControllerMP.java
 +++ ../src-work/minecraft/net/minecraft/client/multiplayer/PlayerControllerMP.java
-@@ -14,11 +14,9 @@
+@@ -14,7 +14,6 @@
  import net.minecraft.entity.Entity;
  import net.minecraft.entity.passive.AbstractHorse;
  import net.minecraft.entity.player.EntityPlayer;
@@ -8,11 +8,7 @@
  import net.minecraft.inventory.ClickType;
  import net.minecraft.item.ItemBlock;
  import net.minecraft.item.ItemStack;
--import net.minecraft.item.ItemSword;
- import net.minecraft.network.PacketBuffer;
- import net.minecraft.network.play.client.CPacketClickWindow;
- import net.minecraft.network.play.client.CPacketCreativeInventoryAction;
-@@ -122,10 +120,16 @@
+@@ -122,10 +121,16 @@
              }
          }
  
@@ -30,7 +26,7 @@
          else
          {
              World world = this.field_78776_a.field_71441_e;
-@@ -143,19 +147,13 @@
+@@ -143,19 +148,13 @@
              else
              {
                  world.func_175718_b(2001, p_187103_1_, Block.func_176210_f(iblockstate));
@@ -51,7 +47,7 @@
  
                      if (!itemstack1.func_190926_b())
                      {
-@@ -163,11 +161,18 @@
+@@ -163,11 +162,18 @@
  
                          if (itemstack1.func_190926_b())
                          {
@@ -70,7 +66,7 @@
                  return flag;
              }
          }
-@@ -207,6 +212,7 @@
+@@ -207,6 +213,7 @@
              if (this.field_78779_k.func_77145_d())
              {
                  this.field_78774_b.func_147297_a(new CPacketPlayerDigging(CPacketPlayerDigging.Action.START_DESTROY_BLOCK, p_180511_1_, p_180511_2_));
@@ -78,7 +74,7 @@
                  func_178891_a(this.field_78776_a, this, p_180511_1_, p_180511_2_);
                  this.field_78781_i = 5;
              }
-@@ -218,14 +224,17 @@
+@@ -218,14 +225,17 @@
                  }
  
                  this.field_78774_b.func_147297_a(new CPacketPlayerDigging(CPacketPlayerDigging.Action.START_DESTROY_BLOCK, p_180511_1_, p_180511_2_));
@@ -97,7 +93,7 @@
                  if (flag && iblockstate.func_185903_a(this.field_78776_a.field_71439_g, this.field_78776_a.field_71439_g.field_70170_p, p_180511_1_) >= 1.0F)
                  {
                      this.func_187103_a(p_180511_1_);
-@@ -289,7 +298,7 @@
+@@ -289,7 +299,7 @@
  
                  if (this.field_78780_h % 4.0F == 0.0F)
                  {
@@ -106,7 +102,7 @@
                      this.field_78776_a.func_147118_V().func_147682_a(new PositionedSoundRecord(soundtype.func_185846_f(), SoundCategory.NEUTRAL, (soundtype.func_185843_a() + 1.0F) / 8.0F, soundtype.func_185847_b() * 0.5F, p_180512_1_));
                  }
  
-@@ -341,7 +350,7 @@
+@@ -341,7 +351,7 @@
  
          if (!this.field_85183_f.func_190926_b() && !itemstack.func_190926_b())
          {
@@ -115,7 +111,7 @@
          }
  
          return p_178893_1_.equals(this.field_178895_c) && flag;
-@@ -373,13 +382,29 @@
+@@ -373,13 +383,29 @@
          }
          else
          {
@@ -147,7 +143,7 @@
                  }
  
                  if (!flag && itemstack.func_77973_b() instanceof ItemBlock)
-@@ -395,7 +420,7 @@
+@@ -395,7 +421,7 @@
  
              this.field_78774_b.func_147297_a(new CPacketPlayerTryUseItemOnBlock(p_187099_3_, p_187099_4_, p_187099_6_, f, f1, f2));
  
@@ -156,7 +152,7 @@
              {
                  if (itemstack.func_190926_b())
                  {
-@@ -421,14 +446,20 @@
+@@ -421,14 +447,20 @@
                      {
                          int i = itemstack.func_77960_j();
                          int j = itemstack.func_190916_E();
@@ -178,7 +174,7 @@
                      }
                  }
              }
-@@ -457,6 +488,7 @@
+@@ -457,6 +489,7 @@
              }
              else
              {
@@ -186,7 +182,7 @@
                  int i = itemstack.func_190916_E();
                  ActionResult<ItemStack> actionresult = itemstack.func_77957_a(p_187101_2_, p_187101_1_, p_187101_3_);
                  ItemStack itemstack1 = (ItemStack)actionresult.func_188398_b();
-@@ -464,6 +496,10 @@
+@@ -464,6 +497,10 @@
                  if (itemstack1 != itemstack || itemstack1.func_190916_E() != i)
                  {
                      p_187101_1_.func_184611_a(p_187101_3_, itemstack1);
@@ -197,7 +193,7 @@
                  }
  
                  return actionresult.func_188397_a();
-@@ -500,6 +536,7 @@
+@@ -500,6 +537,7 @@
          this.func_78750_j();
          Vec3d vec3d = new Vec3d(p_187102_3_.field_72307_f.field_72450_a - p_187102_2_.field_70165_t, p_187102_3_.field_72307_f.field_72448_b - p_187102_2_.field_70163_u, p_187102_3_.field_72307_f.field_72449_c - p_187102_2_.field_70161_v);
          this.field_78774_b.func_147297_a(new CPacketUseEntity(p_187102_2_, p_187102_4_, vec3d));

--- a/patches/minecraft/net/minecraft/client/multiplayer/PlayerControllerMP.java.patch
+++ b/patches/minecraft/net/minecraft/client/multiplayer/PlayerControllerMP.java.patch
@@ -1,14 +1,6 @@
 --- ../src-base/minecraft/net/minecraft/client/multiplayer/PlayerControllerMP.java
 +++ ../src-work/minecraft/net/minecraft/client/multiplayer/PlayerControllerMP.java
-@@ -14,7 +14,6 @@
- import net.minecraft.entity.Entity;
- import net.minecraft.entity.passive.AbstractHorse;
- import net.minecraft.entity.player.EntityPlayer;
--import net.minecraft.init.Blocks;
- import net.minecraft.inventory.ClickType;
- import net.minecraft.item.ItemBlock;
- import net.minecraft.item.ItemStack;
-@@ -122,10 +121,16 @@
+@@ -122,10 +122,16 @@
              }
          }
  
@@ -19,14 +11,14 @@
              return false;
          }
 +
-+        if (this.field_78779_k.func_77145_d() && !stack.func_190926_b() && !stack.func_77973_b().canDestroyBlockInCreative(stack, field_78776_a.field_71441_e.func_180495_p(p_187103_1_), field_78776_a.field_71439_g))
++        if (this.field_78779_k.func_77145_d() && !stack.func_190926_b() && !stack.func_77973_b().canDestroyBlockInCreative(field_78776_a.field_71441_e, p_187103_1_, stack, field_78776_a.field_71439_g))
 +        {
 +            return false;
 +        }
          else
          {
              World world = this.field_78776_a.field_71441_e;
-@@ -143,19 +148,13 @@
+@@ -143,19 +149,13 @@
              else
              {
                  world.func_175718_b(2001, p_187103_1_, Block.func_176210_f(iblockstate));
@@ -47,7 +39,7 @@
  
                      if (!itemstack1.func_190926_b())
                      {
-@@ -163,11 +162,18 @@
+@@ -163,11 +163,18 @@
  
                          if (itemstack1.func_190926_b())
                          {
@@ -66,7 +58,7 @@
                  return flag;
              }
          }
-@@ -207,6 +213,7 @@
+@@ -207,6 +214,7 @@
              if (this.field_78779_k.func_77145_d())
              {
                  this.field_78774_b.func_147297_a(new CPacketPlayerDigging(CPacketPlayerDigging.Action.START_DESTROY_BLOCK, p_180511_1_, p_180511_2_));
@@ -74,7 +66,7 @@
                  func_178891_a(this.field_78776_a, this, p_180511_1_, p_180511_2_);
                  this.field_78781_i = 5;
              }
-@@ -218,14 +225,17 @@
+@@ -218,14 +226,17 @@
                  }
  
                  this.field_78774_b.func_147297_a(new CPacketPlayerDigging(CPacketPlayerDigging.Action.START_DESTROY_BLOCK, p_180511_1_, p_180511_2_));
@@ -93,7 +85,7 @@
                  if (flag && iblockstate.func_185903_a(this.field_78776_a.field_71439_g, this.field_78776_a.field_71439_g.field_70170_p, p_180511_1_) >= 1.0F)
                  {
                      this.func_187103_a(p_180511_1_);
-@@ -289,7 +299,7 @@
+@@ -289,7 +300,7 @@
  
                  if (this.field_78780_h % 4.0F == 0.0F)
                  {
@@ -102,7 +94,7 @@
                      this.field_78776_a.func_147118_V().func_147682_a(new PositionedSoundRecord(soundtype.func_185846_f(), SoundCategory.NEUTRAL, (soundtype.func_185843_a() + 1.0F) / 8.0F, soundtype.func_185847_b() * 0.5F, p_180512_1_));
                  }
  
-@@ -341,7 +351,7 @@
+@@ -341,7 +352,7 @@
  
          if (!this.field_85183_f.func_190926_b() && !itemstack.func_190926_b())
          {
@@ -111,7 +103,7 @@
          }
  
          return p_178893_1_.equals(this.field_178895_c) && flag;
-@@ -373,13 +383,29 @@
+@@ -373,13 +384,29 @@
          }
          else
          {
@@ -143,7 +135,7 @@
                  }
  
                  if (!flag && itemstack.func_77973_b() instanceof ItemBlock)
-@@ -395,7 +421,7 @@
+@@ -395,7 +422,7 @@
  
              this.field_78774_b.func_147297_a(new CPacketPlayerTryUseItemOnBlock(p_187099_3_, p_187099_4_, p_187099_6_, f, f1, f2));
  
@@ -152,7 +144,7 @@
              {
                  if (itemstack.func_190926_b())
                  {
-@@ -421,14 +447,20 @@
+@@ -421,14 +448,20 @@
                      {
                          int i = itemstack.func_77960_j();
                          int j = itemstack.func_190916_E();
@@ -174,7 +166,7 @@
                      }
                  }
              }
-@@ -457,6 +489,7 @@
+@@ -457,6 +490,7 @@
              }
              else
              {
@@ -182,7 +174,7 @@
                  int i = itemstack.func_190916_E();
                  ActionResult<ItemStack> actionresult = itemstack.func_77957_a(p_187101_2_, p_187101_1_, p_187101_3_);
                  ItemStack itemstack1 = (ItemStack)actionresult.func_188398_b();
-@@ -464,6 +497,10 @@
+@@ -464,6 +498,10 @@
                  if (itemstack1 != itemstack || itemstack1.func_190916_E() != i)
                  {
                      p_187101_1_.func_184611_a(p_187101_3_, itemstack1);
@@ -193,7 +185,7 @@
                  }
  
                  return actionresult.func_188397_a();
-@@ -500,6 +537,7 @@
+@@ -500,6 +538,7 @@
          this.func_78750_j();
          Vec3d vec3d = new Vec3d(p_187102_3_.field_72307_f.field_72450_a - p_187102_2_.field_70165_t, p_187102_3_.field_72307_f.field_72448_b - p_187102_2_.field_70163_u, p_187102_3_.field_72307_f.field_72449_c - p_187102_2_.field_70161_v);
          this.field_78774_b.func_147297_a(new CPacketUseEntity(p_187102_2_, p_187102_4_, vec3d));

--- a/patches/minecraft/net/minecraft/client/multiplayer/PlayerControllerMP.java.patch
+++ b/patches/minecraft/net/minecraft/client/multiplayer/PlayerControllerMP.java.patch
@@ -1,18 +1,23 @@
 --- ../src-base/minecraft/net/minecraft/client/multiplayer/PlayerControllerMP.java
 +++ ../src-work/minecraft/net/minecraft/client/multiplayer/PlayerControllerMP.java
-@@ -122,6 +122,12 @@
+@@ -122,10 +122,16 @@
              }
          }
  
+-        if (this.field_78779_k.func_77145_d() && !this.field_78776_a.field_71439_g.func_184614_ca().func_190926_b() && this.field_78776_a.field_71439_g.func_184614_ca().func_77973_b() instanceof ItemSword)
 +        ItemStack stack = field_78776_a.field_71439_g.func_184614_ca();
 +        if (!stack.func_190926_b() && stack.func_77973_b().onBlockStartBreak(stack, p_187103_1_, field_78776_a.field_71439_g))
+         {
+             return false;
+         }
++
++        if (this.field_78779_k.func_77145_d() && !this.field_78776_a.field_71439_g.func_184614_ca().func_190926_b() && !this.field_78776_a.field_71439_g.func_184614_ca().func_77973_b().canDestroyBlocksInCreative())
 +        {
 +            return false;
 +        }
-+
-         if (this.field_78779_k.func_77145_d() && !this.field_78776_a.field_71439_g.func_184614_ca().func_190926_b() && this.field_78776_a.field_71439_g.func_184614_ca().func_77973_b() instanceof ItemSword)
+         else
          {
-             return false;
+             World world = this.field_78776_a.field_71441_e;
 @@ -143,19 +149,13 @@
              else
              {

--- a/patches/minecraft/net/minecraft/item/Item.java.patch
+++ b/patches/minecraft/net/minecraft/item/Item.java.patch
@@ -509,12 +509,12 @@
 +        }
 +    }
 +
-+	/**
++     /**
 +     * Checked from {@link net.minecraft.client.multiplayer.PlayerControllerMP#onPlayerDestroyBlock(BlockPos pos) PlayerControllerMP.onPlayerDestroyBlock()}
 +     * when a creative player left-clicks a block with this item.
-+     * @return true if can destroy blocks in creative mode
++     * @return true if the given player can destroy specified block in creative mode with this item
 +     */
-+    public boolean canDestroyBlocksInCreative()
++    public boolean canDestroyBlockInCreative(ItemStack stack, IBlockState state, EntityPlayer player)
 +    {
 +        return !(this instanceof ItemSword);
 +    }

--- a/patches/minecraft/net/minecraft/item/Item.java.patch
+++ b/patches/minecraft/net/minecraft/item/Item.java.patch
@@ -30,7 +30,19 @@
      public int func_77612_l()
      {
          return this.field_77699_b;
-@@ -322,6 +324,7 @@
+@@ -256,6 +258,11 @@
+         return false;
+     }
+ 
++    public boolean canDestroyBlocksInCreative()
++    {
++        return true;
++    }
++
+     public boolean func_150897_b(IBlockState p_150897_1_)
+     {
+         return false;
+@@ -322,6 +329,7 @@
          return this.field_77700_c;
      }
  
@@ -38,7 +50,7 @@
      public boolean func_77634_r()
      {
          return this.field_77700_c != null;
-@@ -377,7 +380,7 @@
+@@ -377,7 +385,7 @@
  
      public boolean func_77616_k(ItemStack p_77616_1_)
      {
@@ -47,7 +59,7 @@
      }
  
      protected RayTraceResult func_77621_a(World p_77621_1_, EntityPlayer p_77621_2_, boolean p_77621_3_)
-@@ -395,7 +398,11 @@
+@@ -395,7 +403,11 @@
          float f6 = f3 * f4;
          float f7 = f2 * f4;
          double d3 = 5.0D;
@@ -60,7 +72,7 @@
          return p_77621_1_.func_147447_a(vec3d, vec3d1, p_77621_3_, !p_77621_3_, false);
      }
  
-@@ -433,11 +440,613 @@
+@@ -433,11 +445,613 @@
          return false;
      }
  
@@ -674,7 +686,7 @@
      public static void func_150900_l()
      {
          func_179214_a(Blocks.field_150350_a, new ItemAir(Blocks.field_150350_a));
-@@ -972,6 +1581,8 @@
+@@ -972,6 +1586,8 @@
          private final float field_78010_h;
          private final float field_78011_i;
          private final int field_78008_j;
@@ -683,7 +695,7 @@
  
          private ToolMaterial(int p_i1874_3_, int p_i1874_4_, float p_i1874_5_, float p_i1874_6_, int p_i1874_7_)
          {
-@@ -1007,9 +1618,26 @@
+@@ -1007,9 +1623,26 @@
              return this.field_78008_j;
          }
  

--- a/patches/minecraft/net/minecraft/item/Item.java.patch
+++ b/patches/minecraft/net/minecraft/item/Item.java.patch
@@ -1,19 +1,6 @@
 --- ../src-base/minecraft/net/minecraft/item/Item.java
 +++ ../src-work/minecraft/net/minecraft/item/Item.java
-@@ -31,6 +31,7 @@
- import net.minecraft.entity.item.EntityMinecart;
- import net.minecraft.entity.item.EntityPainting;
- import net.minecraft.entity.player.EntityPlayer;
-+import net.minecraft.entity.player.EntityPlayerMP;
- import net.minecraft.init.Blocks;
- import net.minecraft.init.Items;
- import net.minecraft.init.MobEffects;
-@@ -53,14 +54,15 @@
- import net.minecraft.util.registry.RegistryNamespaced;
- import net.minecraft.util.registry.RegistrySimple;
- import net.minecraft.util.text.translation.I18n;
-+import net.minecraft.world.GameType;
- import net.minecraft.world.World;
+@@ -57,10 +57,10 @@
  import net.minecraftforge.fml.relauncher.Side;
  import net.minecraftforge.fml.relauncher.SideOnly;
  
@@ -27,7 +14,7 @@
      private static final IItemPropertyGetter field_185046_b = new IItemPropertyGetter()
      {
          @SideOnly(Side.CLIENT)
-@@ -202,6 +204,7 @@
+@@ -202,6 +202,7 @@
          return p_77654_1_;
      }
  
@@ -35,7 +22,7 @@
      public int func_77639_j()
      {
          return this.field_77777_bU;
-@@ -223,6 +226,7 @@
+@@ -223,6 +224,7 @@
          return this;
      }
  
@@ -43,7 +30,7 @@
      public int func_77612_l()
      {
          return this.field_77699_b;
-@@ -322,6 +326,7 @@
+@@ -322,6 +324,7 @@
          return this.field_77700_c;
      }
  
@@ -51,7 +38,7 @@
      public boolean func_77634_r()
      {
          return this.field_77700_c != null;
-@@ -377,7 +382,7 @@
+@@ -377,7 +380,7 @@
  
      public boolean func_77616_k(ItemStack p_77616_1_)
      {
@@ -60,7 +47,7 @@
      }
  
      protected RayTraceResult func_77621_a(World p_77621_1_, EntityPlayer p_77621_2_, boolean p_77621_3_)
-@@ -395,7 +400,11 @@
+@@ -395,7 +398,11 @@
          float f6 = f3 * f4;
          float f7 = f2 * f4;
          double d3 = 5.0D;
@@ -73,7 +60,7 @@
          return p_77621_1_.func_147447_a(vec3d, vec3d1, p_77621_3_, !p_77621_3_, false);
      }
  
-@@ -433,11 +442,625 @@
+@@ -433,11 +440,625 @@
          return false;
      }
  
@@ -699,7 +686,7 @@
      public static void func_150900_l()
      {
          func_179214_a(Blocks.field_150350_a, new ItemAir(Blocks.field_150350_a));
-@@ -972,6 +1595,8 @@
+@@ -972,6 +1593,8 @@
          private final float field_78010_h;
          private final float field_78011_i;
          private final int field_78008_j;
@@ -708,7 +695,7 @@
  
          private ToolMaterial(int p_i1874_3_, int p_i1874_4_, float p_i1874_5_, float p_i1874_6_, int p_i1874_7_)
          {
-@@ -1007,9 +1632,26 @@
+@@ -1007,9 +1630,26 @@
              return this.field_78008_j;
          }
  

--- a/patches/minecraft/net/minecraft/item/Item.java.patch
+++ b/patches/minecraft/net/minecraft/item/Item.java.patch
@@ -1,6 +1,19 @@
 --- ../src-base/minecraft/net/minecraft/item/Item.java
 +++ ../src-work/minecraft/net/minecraft/item/Item.java
-@@ -57,10 +57,10 @@
+@@ -31,6 +31,7 @@
+ import net.minecraft.entity.item.EntityMinecart;
+ import net.minecraft.entity.item.EntityPainting;
+ import net.minecraft.entity.player.EntityPlayer;
++import net.minecraft.entity.player.EntityPlayerMP;
+ import net.minecraft.init.Blocks;
+ import net.minecraft.init.Items;
+ import net.minecraft.init.MobEffects;
+@@ -53,14 +54,15 @@
+ import net.minecraft.util.registry.RegistryNamespaced;
+ import net.minecraft.util.registry.RegistrySimple;
+ import net.minecraft.util.text.translation.I18n;
++import net.minecraft.world.GameType;
+ import net.minecraft.world.World;
  import net.minecraftforge.fml.relauncher.Side;
  import net.minecraftforge.fml.relauncher.SideOnly;
  
@@ -14,7 +27,7 @@
      private static final IItemPropertyGetter field_185046_b = new IItemPropertyGetter()
      {
          @SideOnly(Side.CLIENT)
-@@ -202,6 +202,7 @@
+@@ -202,6 +204,7 @@
          return p_77654_1_;
      }
  
@@ -22,7 +35,7 @@
      public int func_77639_j()
      {
          return this.field_77777_bU;
-@@ -223,6 +224,7 @@
+@@ -223,6 +226,7 @@
          return this;
      }
  
@@ -30,7 +43,7 @@
      public int func_77612_l()
      {
          return this.field_77699_b;
-@@ -322,6 +324,7 @@
+@@ -322,6 +326,7 @@
          return this.field_77700_c;
      }
  
@@ -38,7 +51,7 @@
      public boolean func_77634_r()
      {
          return this.field_77700_c != null;
-@@ -377,7 +380,7 @@
+@@ -377,7 +382,7 @@
  
      public boolean func_77616_k(ItemStack p_77616_1_)
      {
@@ -47,7 +60,7 @@
      }
  
      protected RayTraceResult func_77621_a(World p_77621_1_, EntityPlayer p_77621_2_, boolean p_77621_3_)
-@@ -395,7 +398,11 @@
+@@ -395,7 +400,11 @@
          float f6 = f3 * f4;
          float f7 = f2 * f4;
          double d3 = 5.0D;
@@ -60,7 +73,7 @@
          return p_77621_1_.func_147447_a(vec3d, vec3d1, p_77621_3_, !p_77621_3_, false);
      }
  
-@@ -433,11 +440,623 @@
+@@ -433,11 +442,625 @@
          return false;
      }
  
@@ -509,12 +522,14 @@
 +        }
 +    }
 +
-+     /**
++    /**
 +     * Checked from {@link net.minecraft.client.multiplayer.PlayerControllerMP#onPlayerDestroyBlock(BlockPos pos) PlayerControllerMP.onPlayerDestroyBlock()}
 +     * when a creative player left-clicks a block with this item.
++     * Also checked from {@link net.minecraftforge.common.ForgeHooks#onBlockBreakEvent(World, GameType, EntityPlayerMP, BlockPos)  ForgeHooks.onBlockBreakEvent()}
++     * to prevent sending an event.
 +     * @return true if the given player can destroy specified block in creative mode with this item
 +     */
-+    public boolean canDestroyBlockInCreative(ItemStack stack, IBlockState state, EntityPlayer player)
++    public boolean canDestroyBlockInCreative(World world, BlockPos pos, ItemStack stack, EntityPlayer player)
 +    {
 +        return !(this instanceof ItemSword);
 +    }
@@ -684,7 +699,7 @@
      public static void func_150900_l()
      {
          func_179214_a(Blocks.field_150350_a, new ItemAir(Blocks.field_150350_a));
-@@ -972,6 +1591,8 @@
+@@ -972,6 +1595,8 @@
          private final float field_78010_h;
          private final float field_78011_i;
          private final int field_78008_j;
@@ -693,7 +708,7 @@
  
          private ToolMaterial(int p_i1874_3_, int p_i1874_4_, float p_i1874_5_, float p_i1874_6_, int p_i1874_7_)
          {
-@@ -1007,9 +1628,26 @@
+@@ -1007,9 +1632,26 @@
              return this.field_78008_j;
          }
  

--- a/patches/minecraft/net/minecraft/item/Item.java.patch
+++ b/patches/minecraft/net/minecraft/item/Item.java.patch
@@ -30,19 +30,7 @@
      public int func_77612_l()
      {
          return this.field_77699_b;
-@@ -256,6 +258,11 @@
-         return false;
-     }
- 
-+    public boolean canDestroyBlocksInCreative()
-+    {
-+        return true;
-+    }
-+
-     public boolean func_150897_b(IBlockState p_150897_1_)
-     {
-         return false;
-@@ -322,6 +329,7 @@
+@@ -322,6 +324,7 @@
          return this.field_77700_c;
      }
  
@@ -50,7 +38,7 @@
      public boolean func_77634_r()
      {
          return this.field_77700_c != null;
-@@ -377,7 +385,7 @@
+@@ -377,7 +380,7 @@
  
      public boolean func_77616_k(ItemStack p_77616_1_)
      {
@@ -59,7 +47,7 @@
      }
  
      protected RayTraceResult func_77621_a(World p_77621_1_, EntityPlayer p_77621_2_, boolean p_77621_3_)
-@@ -395,7 +403,11 @@
+@@ -395,7 +398,11 @@
          float f6 = f3 * f4;
          float f7 = f2 * f4;
          double d3 = 5.0D;
@@ -72,7 +60,7 @@
          return p_77621_1_.func_147447_a(vec3d, vec3d1, p_77621_3_, !p_77621_3_, false);
      }
  
-@@ -433,11 +445,613 @@
+@@ -433,11 +440,623 @@
          return false;
      }
  
@@ -521,6 +509,16 @@
 +        }
 +    }
 +
++	/**
++     * Checked from {@link net.minecraft.client.multiplayer.PlayerControllerMP#onPlayerDestroyBlock(BlockPos pos) PlayerControllerMP.onPlayerDestroyBlock()}
++     * when a creative player left-clicks a block with this item.
++     * @return true if can destroy blocks in creative mode
++     */
++    public boolean canDestroyBlocksInCreative()
++    {
++        return !(this instanceof ItemSword);
++    }
++
 +    /**
 +     * ItemStack sensitive version of {@link #canHarvestBlock(IBlockState)}
 +     * @param state The block trying to harvest
@@ -686,7 +684,7 @@
      public static void func_150900_l()
      {
          func_179214_a(Blocks.field_150350_a, new ItemAir(Blocks.field_150350_a));
-@@ -972,6 +1586,8 @@
+@@ -972,6 +1591,8 @@
          private final float field_78010_h;
          private final float field_78011_i;
          private final int field_78008_j;
@@ -695,7 +693,7 @@
  
          private ToolMaterial(int p_i1874_3_, int p_i1874_4_, float p_i1874_5_, float p_i1874_6_, int p_i1874_7_)
          {
-@@ -1007,9 +1623,26 @@
+@@ -1007,9 +1628,26 @@
              return this.field_78008_j;
          }
  

--- a/patches/minecraft/net/minecraft/item/ItemSword.java.patch
+++ b/patches/minecraft/net/minecraft/item/ItemSword.java.patch
@@ -1,19 +1,6 @@
 --- ../src-base/minecraft/net/minecraft/item/ItemSword.java
 +++ ../src-work/minecraft/net/minecraft/item/ItemSword.java
-@@ -65,6 +65,12 @@
-         return true;
-     }
- 
-+    @Override
-+    public boolean canDestroyBlocksInCreative()
-+    {
-+        return false;
-+    }
-+
-     public boolean func_150897_b(IBlockState p_150897_1_)
-     {
-         return p_150897_1_.func_177230_c() == Blocks.field_150321_G;
-@@ -88,7 +94,9 @@
+@@ -88,7 +88,9 @@
  
      public boolean func_82789_a(ItemStack p_82789_1_, ItemStack p_82789_2_)
      {

--- a/patches/minecraft/net/minecraft/item/ItemSword.java.patch
+++ b/patches/minecraft/net/minecraft/item/ItemSword.java.patch
@@ -1,6 +1,19 @@
 --- ../src-base/minecraft/net/minecraft/item/ItemSword.java
 +++ ../src-work/minecraft/net/minecraft/item/ItemSword.java
-@@ -88,7 +88,9 @@
+@@ -65,6 +65,12 @@
+         return true;
+     }
+ 
++    @Override
++    public boolean canDestroyBlocksInCreative()
++    {
++        return false;
++    }
++
+     public boolean func_150897_b(IBlockState p_150897_1_)
+     {
+         return p_150897_1_.func_177230_c() == Blocks.field_150321_G;
+@@ -88,7 +94,9 @@
  
      public boolean func_82789_a(ItemStack p_82789_1_, ItemStack p_82789_2_)
      {

--- a/src/main/java/net/minecraftforge/common/ForgeHooks.java
+++ b/src/main/java/net/minecraftforge/common/ForgeHooks.java
@@ -30,11 +30,8 @@ import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import com.google.common.collect.Queues;
-import com.google.common.collect.Sets;
-import com.google.gson.Gson;
-import com.google.gson.JsonObject;
-import com.google.gson.JsonParseException;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 
 import net.minecraft.block.Block;
 import net.minecraft.block.BlockLiquid;
@@ -86,10 +83,10 @@ import net.minecraft.util.text.ITextComponent;
 import net.minecraft.util.text.TextComponentString;
 import net.minecraft.util.text.TextFormatting;
 import net.minecraft.util.text.event.ClickEvent;
-import net.minecraft.world.IBlockAccess;
-import net.minecraft.world.World;
 import net.minecraft.world.EnumDifficulty;
 import net.minecraft.world.GameType;
+import net.minecraft.world.IBlockAccess;
+import net.minecraft.world.World;
 import net.minecraft.world.storage.loot.LootEntry;
 import net.minecraft.world.storage.loot.LootTable;
 import net.minecraft.world.storage.loot.conditions.LootCondition;
@@ -120,8 +117,11 @@ import net.minecraftforge.fluids.IFluidBlock;
 import net.minecraftforge.fml.common.eventhandler.Event;
 import net.minecraftforge.fml.relauncher.ReflectionHelper;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import com.google.common.collect.Queues;
+import com.google.common.collect.Sets;
+import com.google.gson.Gson;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParseException;
 
 public class ForgeHooks
 {
@@ -751,7 +751,9 @@ public class ForgeHooks
     {
         // Logic from tryHarvestBlock for pre-canceling the event
         boolean preCancelEvent = false;
-        if (gameType.isCreative() && !entityPlayer.getHeldItemMainhand().isEmpty() && !entityPlayer.getHeldItemMainhand().getItem().canDestroyBlockInCreative(world, pos, entityPlayer.getHeldItemMainhand(), entityPlayer))
+        ItemStack stack = entityPlayer.getHeldItemMainhand();
+        if (gameType.isCreative() && !stack.isEmpty()
+                && !stack.getItem().canDestroyBlockInCreative(world, pos, stack, entityPlayer))
             preCancelEvent = true;
 
         if (gameType.isAdventure())

--- a/src/main/java/net/minecraftforge/common/ForgeHooks.java
+++ b/src/main/java/net/minecraftforge/common/ForgeHooks.java
@@ -30,8 +30,11 @@ import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import com.google.common.collect.Queues;
+import com.google.common.collect.Sets;
+import com.google.gson.Gson;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParseException;
 
 import net.minecraft.block.Block;
 import net.minecraft.block.BlockLiquid;
@@ -83,10 +86,10 @@ import net.minecraft.util.text.ITextComponent;
 import net.minecraft.util.text.TextComponentString;
 import net.minecraft.util.text.TextFormatting;
 import net.minecraft.util.text.event.ClickEvent;
-import net.minecraft.world.EnumDifficulty;
-import net.minecraft.world.GameType;
 import net.minecraft.world.IBlockAccess;
 import net.minecraft.world.World;
+import net.minecraft.world.EnumDifficulty;
+import net.minecraft.world.GameType;
 import net.minecraft.world.storage.loot.LootEntry;
 import net.minecraft.world.storage.loot.LootTable;
 import net.minecraft.world.storage.loot.conditions.LootCondition;
@@ -117,11 +120,8 @@ import net.minecraftforge.fluids.IFluidBlock;
 import net.minecraftforge.fml.common.eventhandler.Event;
 import net.minecraftforge.fml.relauncher.ReflectionHelper;
 
-import com.google.common.collect.Queues;
-import com.google.common.collect.Sets;
-import com.google.gson.Gson;
-import com.google.gson.JsonObject;
-import com.google.gson.JsonParseException;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 
 public class ForgeHooks
 {
@@ -751,9 +751,9 @@ public class ForgeHooks
     {
         // Logic from tryHarvestBlock for pre-canceling the event
         boolean preCancelEvent = false;
-        ItemStack stack = entityPlayer.getHeldItemMainhand();
-        if (gameType.isCreative() && !stack.isEmpty()
-                && !stack.getItem().canDestroyBlockInCreative(world, pos, stack, entityPlayer))
+        ItemStack itemstack = entityPlayer.getHeldItemMainhand();
+        if (gameType.isCreative() && !itemstack.isEmpty()
+                && !itemstack.getItem().canDestroyBlockInCreative(world, pos, itemstack, entityPlayer))
             preCancelEvent = true;
 
         if (gameType.isAdventure())
@@ -763,7 +763,6 @@ public class ForgeHooks
 
             if (!entityPlayer.isAllowEdit())
             {
-                ItemStack itemstack = entityPlayer.getHeldItemMainhand();
                 if (itemstack.isEmpty() || !itemstack.canDestroy(world.getBlockState(pos).getBlock()))
                     preCancelEvent = true;
             }

--- a/src/main/java/net/minecraftforge/common/ForgeHooks.java
+++ b/src/main/java/net/minecraftforge/common/ForgeHooks.java
@@ -751,7 +751,7 @@ public class ForgeHooks
     {
         // Logic from tryHarvestBlock for pre-canceling the event
         boolean preCancelEvent = false;
-        if (gameType.isCreative() && !entityPlayer.getHeldItemMainhand().isEmpty() && !entityPlayer.getHeldItemMainhand().getItem().canDestroyBlockInCreative(entityPlayer.getHeldItemMainhand(), world.getBlockState(pos), entityPlayer))
+        if (gameType.isCreative() && !entityPlayer.getHeldItemMainhand().isEmpty() && !entityPlayer.getHeldItemMainhand().getItem().canDestroyBlockInCreative(world, pos, entityPlayer.getHeldItemMainhand(), entityPlayer))
             preCancelEvent = true;
 
         if (gameType.isAdventure())

--- a/src/main/java/net/minecraftforge/common/ForgeHooks.java
+++ b/src/main/java/net/minecraftforge/common/ForgeHooks.java
@@ -752,7 +752,7 @@ public class ForgeHooks
     {
         // Logic from tryHarvestBlock for pre-canceling the event
         boolean preCancelEvent = false;
-        if (gameType.isCreative() && !entityPlayer.getHeldItemMainhand().isEmpty() && entityPlayer.getHeldItemMainhand().getItem() instanceof ItemSword)
+        if (gameType.isCreative() && !entityPlayer.getHeldItemMainhand().isEmpty() && !entityPlayer.getHeldItemMainhand().getItem().canDestroyBlocksInCreative())
             preCancelEvent = true;
 
         if (gameType.isAdventure())

--- a/src/main/java/net/minecraftforge/common/ForgeHooks.java
+++ b/src/main/java/net/minecraftforge/common/ForgeHooks.java
@@ -62,7 +62,6 @@ import net.minecraft.item.ItemBucket;
 import net.minecraft.item.ItemPickaxe;
 import net.minecraft.item.ItemSpade;
 import net.minecraft.item.ItemStack;
-import net.minecraft.item.ItemSword;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.network.NetHandlerPlayServer;
 import net.minecraft.network.Packet;
@@ -752,7 +751,7 @@ public class ForgeHooks
     {
         // Logic from tryHarvestBlock for pre-canceling the event
         boolean preCancelEvent = false;
-        if (gameType.isCreative() && !entityPlayer.getHeldItemMainhand().isEmpty() && !entityPlayer.getHeldItemMainhand().getItem().canDestroyBlocksInCreative())
+        if (gameType.isCreative() && !entityPlayer.getHeldItemMainhand().isEmpty() && !entityPlayer.getHeldItemMainhand().getItem().canDestroyBlockInCreative(entityPlayer.getHeldItemMainhand(), world.getBlockState(pos), entityPlayer))
             preCancelEvent = true;
 
         if (gameType.isAdventure())

--- a/src/test/java/net/minecraftforge/test/ItemCanDestroyBlocksInCreativeTest.java
+++ b/src/test/java/net/minecraftforge/test/ItemCanDestroyBlocksInCreativeTest.java
@@ -1,31 +1,36 @@
 package net.minecraftforge.test;
 
-import net.minecraft.block.state.IBlockState;
 import net.minecraft.creativetab.CreativeTabs;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.World;
 import net.minecraftforge.fml.common.Mod;
 import net.minecraftforge.fml.common.event.FMLInitializationEvent;
 import net.minecraftforge.fml.common.registry.GameRegistry;
 
 @Mod(modid = ItemCanDestroyBlocksInCreativeTest.MODID, name = "Item.canDestroyBlockInCreative() Test", version = "1.0", acceptableRemoteVersions = "*")
-public class ItemCanDestroyBlocksInCreativeTest{
-	public static final boolean ENABLE = false;
-	public static final String MODID = "itemcandestroyblocksincreativetest";
+public class ItemCanDestroyBlocksInCreativeTest
+{
+    public static final boolean ENABLE = true;
+    public static final String MODID = "item_can_destroy_blocks_in_creative_test";
 
-	public static Item testItem = new Item(){
-		@Override
-		public boolean canDestroyBlockInCreative(ItemStack stack, IBlockState state, EntityPlayer player){
-			return false;
-		}
-	}.setRegistryName(MODID, "item_test_candestroyincreative")
-			.setUnlocalizedName(MODID + ".item_test_candestroyincreative")
-			.setCreativeTab(CreativeTabs.TOOLS);
+    public static Item testItem = new Item()
+    {
+        @Override
+        public boolean canDestroyBlockInCreative(World world, BlockPos pos, ItemStack stack, EntityPlayer player)
+        {
+            return false;
+        }
+    }.setRegistryName(MODID, "item_test")
+            .setUnlocalizedName(MODID + ".item_test")
+            .setCreativeTab(CreativeTabs.TOOLS);
 
-	@Mod.EventHandler
-	public static void init(FMLInitializationEvent event){
-		if(ENABLE)
-			GameRegistry.register(testItem);
-	}
+    @Mod.EventHandler
+    public static void init(FMLInitializationEvent event)
+    {
+        if (ENABLE)
+            GameRegistry.register(testItem);
+    }
 }

--- a/src/test/java/net/minecraftforge/test/ItemCanDestroyBlocksInCreativeTest.java
+++ b/src/test/java/net/minecraftforge/test/ItemCanDestroyBlocksInCreativeTest.java
@@ -1,19 +1,22 @@
 package net.minecraftforge.test;
 
+import net.minecraft.block.state.IBlockState;
 import net.minecraft.creativetab.CreativeTabs;
+import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.Item;
+import net.minecraft.item.ItemStack;
 import net.minecraftforge.fml.common.Mod;
 import net.minecraftforge.fml.common.event.FMLInitializationEvent;
 import net.minecraftforge.fml.common.registry.GameRegistry;
 
-@Mod(modid = ItemCanDestroyBlocksInCreativeTest.MODID, name = "Item.canDestroyBlocksInCreative() Test", version = "1.0", acceptableRemoteVersions = "*")
+@Mod(modid = ItemCanDestroyBlocksInCreativeTest.MODID, name = "Item.canDestroyBlockInCreative() Test", version = "1.0", acceptableRemoteVersions = "*")
 public class ItemCanDestroyBlocksInCreativeTest{
 	public static final boolean ENABLE = false;
 	public static final String MODID = "itemcandestroyblocksincreativetest";
 
 	public static Item testItem = new Item(){
 		@Override
-		public boolean canDestroyBlocksInCreative(){
+		public boolean canDestroyBlockInCreative(ItemStack stack, IBlockState state, EntityPlayer player){
 			return false;
 		}
 	}.setRegistryName(MODID, "item_test_candestroyincreative")

--- a/src/test/java/net/minecraftforge/test/ItemCanDestroyBlocksInCreativeTest.java
+++ b/src/test/java/net/minecraftforge/test/ItemCanDestroyBlocksInCreativeTest.java
@@ -1,0 +1,27 @@
+package net.minecraftforge.test;
+
+import net.minecraft.creativetab.CreativeTabs;
+import net.minecraft.item.Item;
+import net.minecraftforge.fml.common.Mod;
+import net.minecraftforge.fml.common.event.FMLInitializationEvent;
+import net.minecraftforge.fml.common.registry.GameRegistry;
+
+@Mod(modid = ItemCanDestroyBlocksInCreativeTest.MODID, name = "Item.canDestroyBlocksInCreative() Test", version = "1.0", acceptableRemoteVersions = "*")
+public class ItemCanDestroyBlocksInCreativeTest{
+	public static final boolean ENABLE = true;
+	public static final String MODID = "itemcandestroyblocksincreativetest";
+
+	public static Item testItem = new Item(){
+		@Override
+		public boolean canDestroyBlocksInCreative(){
+			return false;
+		}
+	}.setRegistryName(MODID, "testItem")
+	.setUnlocalizedName(MODID + ".testItem")
+	.setCreativeTab(CreativeTabs.TOOLS);
+
+	@Mod.EventHandler
+	public static void init(FMLInitializationEvent event){
+		GameRegistry.register(testItem);
+	}
+}

--- a/src/test/java/net/minecraftforge/test/ItemCanDestroyBlocksInCreativeTest.java
+++ b/src/test/java/net/minecraftforge/test/ItemCanDestroyBlocksInCreativeTest.java
@@ -8,7 +8,7 @@ import net.minecraftforge.fml.common.registry.GameRegistry;
 
 @Mod(modid = ItemCanDestroyBlocksInCreativeTest.MODID, name = "Item.canDestroyBlocksInCreative() Test", version = "1.0", acceptableRemoteVersions = "*")
 public class ItemCanDestroyBlocksInCreativeTest{
-	public static final boolean ENABLE = true;
+	public static final boolean ENABLE = false;
 	public static final String MODID = "itemcandestroyblocksincreativetest";
 
 	public static Item testItem = new Item(){
@@ -17,11 +17,12 @@ public class ItemCanDestroyBlocksInCreativeTest{
 			return false;
 		}
 	}.setRegistryName(MODID, "testItem")
-	.setUnlocalizedName(MODID + ".testItem")
-	.setCreativeTab(CreativeTabs.TOOLS);
+			.setUnlocalizedName(MODID + ".testItem")
+			.setCreativeTab(CreativeTabs.TOOLS);
 
 	@Mod.EventHandler
 	public static void init(FMLInitializationEvent event){
-		GameRegistry.register(testItem);
+		if(ENABLE)
+			GameRegistry.register(testItem);
 	}
 }

--- a/src/test/java/net/minecraftforge/test/ItemCanDestroyBlocksInCreativeTest.java
+++ b/src/test/java/net/minecraftforge/test/ItemCanDestroyBlocksInCreativeTest.java
@@ -16,8 +16,8 @@ public class ItemCanDestroyBlocksInCreativeTest{
 		public boolean canDestroyBlocksInCreative(){
 			return false;
 		}
-	}.setRegistryName(MODID, "testItem")
-			.setUnlocalizedName(MODID + ".testItem")
+	}.setRegistryName(MODID, "item_test_candestroyincreative")
+			.setUnlocalizedName(MODID + ".item_test_candestroyincreative")
 			.setCreativeTab(CreativeTabs.TOOLS);
 
 	@Mod.EventHandler


### PR DESCRIPTION
As title tells, vanilla sword can't destroy blocks when player is in creative gamemode, and this feature is hardcoded. Would be nice to have it for custom items like ones which should interact with entities via both RMB and LMB without accidentally damaging the blocks in _any_ gamemode. 

My real example: a train mod, where player wants to couple two trains. To do so player has to left-click rolling stock entities with a prybar item. While accidental miss in survival is not very critical, accidental miss in creative often leads to breaking the surrounding blocks (including tracks, which are huge structures) which is very frustrating for players. 