### PR TITLE
Add pack.mcmeta to examplemod

### DIFF
--- a/mdk/src/main/resources/pack.mcmeta
+++ b/mdk/src/main/resources/pack.mcmeta
@@ -1,6 +1,6 @@
 {
     "pack": {
-      "description": "examplemod resources",
-      "pack_format": 3
+        "description": "examplemod resources",
+        "pack_format": 3
     }
 }

--- a/mdk/src/main/resources/pack.mcmeta
+++ b/mdk/src/main/resources/pack.mcmeta
@@ -1,6 +1,11 @@
+# http://minecraft.gamepedia.com/Resource_pack#Contents
+# This will not show up in GuiResourcePackList
 {
     "pack": {
+        # Unused, but required.
         "description": "examplemod resources",
+        # A pack_format of "3" should be used starting with Minecraft 1.11. All resources, including language files, should be lowercase (eg: en_us.lang).
+        # A pack_format of "2" will load your mod resources with LegacyV2Adapter, which requires language files to have uppercase letters (eg: en_US.lang).
         "pack_format": 3
     }
 }

--- a/mdk/src/main/resources/pack.mcmeta
+++ b/mdk/src/main/resources/pack.mcmeta
@@ -1,6 +1,6 @@
 {
     "pack": {
-      "description": "examplemod resources"
+      "description": "examplemod resources",
       "pack_format": 3
     }
 }

--- a/mdk/src/main/resources/pack.mcmeta
+++ b/mdk/src/main/resources/pack.mcmeta
@@ -1,11 +1,7 @@
-# http://minecraft.gamepedia.com/Resource_pack#Contents
-# This will not show up in GuiResourcePackList
 {
     "pack": {
-        # Unused, but required.
         "description": "examplemod resources",
-        # A pack_format of "3" should be used starting with Minecraft 1.11. All resources, including language files, should be lowercase (eg: en_us.lang).
-        # A pack_format of "2" will load your mod resources with LegacyV2Adapter, which requires language files to have uppercase letters (eg: en_US.lang).
-        "pack_format": 3
+        "pack_format": 3,
+        "_comment": "A pack_format of 3 should be used starting with Minecraft 1.11. All resources, including language files, should be lowercase (eg: en_us.lang). A pack_format of 2 will load your mod resources with LegacyV2Adapter, which requires language files to have uppercase letters (eg: en_US.lang)."
     }
 }

--- a/mdk/src/main/resources/pack.mcmeta
+++ b/mdk/src/main/resources/pack.mcmeta
@@ -1,0 +1,6 @@
+{
+    "pack": {
+      "description": "examplemod resources"
+      "pack_format": 3
+    }
+}


### PR DESCRIPTION
Even though the example mod adds nothing to localize, a new mod developer building off of the example may be confused when their "en_us.lang" is not loaded. Shouldn't we encourage developers to use the most current resource pack format?