### PR TITLE
[1.10.x] Fix blank tab in creative inventory

### DIFF
--- a/patches/minecraft/net/minecraft/client/gui/inventory/GuiContainerCreative.java.patch
+++ b/patches/minecraft/net/minecraft/client/gui/inventory/GuiContainerCreative.java.patch
@@ -18,7 +18,7 @@
 +            {
 +                field_146292_n.add(new GuiButton(101, field_147003_i,              field_147009_r - 50, 20, 20, "<"));
 +                field_146292_n.add(new GuiButton(102, field_147003_i + field_146999_f - 20, field_147009_r - 50, 20, 20, ">"));
-+                maxPages = ((tabCount - 12) / 10) + 1;
++                maxPages = (int) Math.ceil((tabCount - 12) / 10);
 +            }
          }
          else

--- a/patches/minecraft/net/minecraft/client/gui/inventory/GuiContainerCreative.java.patch
+++ b/patches/minecraft/net/minecraft/client/gui/inventory/GuiContainerCreative.java.patch
@@ -18,7 +18,7 @@
 +            {
 +                field_146292_n.add(new GuiButton(101, field_147003_i,              field_147009_r - 50, 20, 20, "<"));
 +                field_146292_n.add(new GuiButton(102, field_147003_i + field_146999_f - 20, field_147009_r - 50, 20, 20, ">"));
-+                maxPages = (int) Math.ceil((tabCount - 12) / 10);
++                maxPages = (int) Math.ceil((tabCount - 12) / 10D);
 +            }
          }
          else


### PR DESCRIPTION
In a my private modpack, I have three full pages worth of tabs (3*10, 30, excluding the search/inventory tab) which causes a fourth 'blank' page to appear that has only the search and inventory tab on it. This fixes said issue which was due to the addition of 1 to the max page value.