### PR TITLE
Added in CreatureTypeSpawnEvent Closes #3808

### DIFF
--- a/patches/minecraft/net/minecraft/world/WorldEntitySpawner.java.patch
+++ b/patches/minecraft/net/minecraft/world/WorldEntitySpawner.java.patch
@@ -50,19 +50,17 @@
                                                      {
                                                          continue label411;
                                                      }
-@@ -206,6 +210,11 @@
+@@ -206,6 +210,9 @@
          {
              IBlockState iblockstate = p_180267_1_.func_180495_p(p_180267_2_);
  
 +            net.minecraftforge.fml.common.eventhandler.Event.Result canSpawn = net.minecraftforge.event.ForgeEventFactory.canCreatureTypeSpawnAtPos(p_180267_0_, p_180267_1_, p_180267_2_, iblockstate);
-+
 +            if (canSpawn == net.minecraftforge.fml.common.eventhandler.Event.Result.ALLOW) return true;
 +            else if (canSpawn == net.minecraftforge.fml.common.eventhandler.Event.Result.DENY) return false;
-+
              if (p_180267_0_ == EntityLiving.SpawnPlacementType.IN_WATER)
              {
                  return iblockstate.func_185904_a() == Material.field_151586_h && p_180267_1_.func_180495_p(p_180267_2_.func_177977_b()).func_185904_a() == Material.field_151586_h && !p_180267_1_.func_180495_p(p_180267_2_.func_177984_a()).func_185915_l();
-@@ -213,8 +222,9 @@
+@@ -213,8 +220,9 @@
              else
              {
                  BlockPos blockpos = p_180267_2_.func_177977_b();
@@ -73,7 +71,7 @@
                  {
                      return false;
                  }
-@@ -258,7 +268,7 @@
+@@ -258,7 +266,7 @@
  
                              try
                              {

--- a/patches/minecraft/net/minecraft/world/WorldEntitySpawner.java.patch
+++ b/patches/minecraft/net/minecraft/world/WorldEntitySpawner.java.patch
@@ -50,7 +50,19 @@
                                                      {
                                                          continue label411;
                                                      }
-@@ -213,8 +217,9 @@
+@@ -206,6 +210,11 @@
+         {
+             IBlockState iblockstate = p_180267_1_.func_180495_p(p_180267_2_);
+ 
++            net.minecraftforge.fml.common.eventhandler.Event.Result canSpawn = net.minecraftforge.event.ForgeEventFactory.canCreatureTypeSpawnAtPos(p_180267_0_, p_180267_1_, p_180267_2_, iblockstate);
++
++            if (canSpawn == net.minecraftforge.fml.common.eventhandler.Event.Result.ALLOW) return true;
++            else if (canSpawn == net.minecraftforge.fml.common.eventhandler.Event.Result.DENY) return false;
++
+             if (p_180267_0_ == EntityLiving.SpawnPlacementType.IN_WATER)
+             {
+                 return iblockstate.func_185904_a() == Material.field_151586_h && p_180267_1_.func_180495_p(p_180267_2_.func_177977_b()).func_185904_a() == Material.field_151586_h && !p_180267_1_.func_180495_p(p_180267_2_.func_177984_a()).func_185915_l();
+@@ -213,8 +222,9 @@
              else
              {
                  BlockPos blockpos = p_180267_2_.func_177977_b();
@@ -61,7 +73,7 @@
                  {
                      return false;
                  }
-@@ -258,7 +263,7 @@
+@@ -258,7 +268,7 @@
  
                              try
                              {

--- a/src/main/java/net/minecraftforge/event/ForgeEventFactory.java
+++ b/src/main/java/net/minecraftforge/event/ForgeEventFactory.java
@@ -699,4 +699,11 @@ public class ForgeEventFactory
     {
         return !MinecraftForge.EVENT_BUS.post(new LivingDestroyBlockEvent(entity, pos, state));
     }
+
+    public static Result canCreatureTypeSpawnAtPos(EntityLiving.SpawnPlacementType type, World world, BlockPos pos, IBlockState state)
+    {
+        WorldEvent.CreatureTypeSpawnEvent event = new WorldEvent.CreatureTypeSpawnEvent(type, world, pos, state);
+        MinecraftForge.EVENT_BUS.post(event);
+        return event.getResult();
+    }
 }

--- a/src/main/java/net/minecraftforge/event/ForgeEventFactory.java
+++ b/src/main/java/net/minecraftforge/event/ForgeEventFactory.java
@@ -659,4 +659,11 @@ public class ForgeEventFactory
         net.minecraftforge.common.MinecraftForge.EVENT_BUS.post(e);
         return e.getLevel();
     }
+
+    public static Result canCreatureTypeSpawnAtPos(EntityLiving.SpawnPlacementType type, World world, BlockPos pos, IBlockState state)
+    {
+        WorldEvent.CreatureTypeSpawnEvent event = new WorldEvent.CreatureTypeSpawnEvent(type, world, pos, state);
+        MinecraftForge.EVENT_BUS.post(event);
+        return event.getResult();
+    }
 }

--- a/src/main/java/net/minecraftforge/event/world/WorldEvent.java
+++ b/src/main/java/net/minecraftforge/event/world/WorldEvent.java
@@ -23,9 +23,11 @@ import java.util.ArrayList;
 import java.util.Hashtable;
 import java.util.List;
 
+import net.minecraft.block.state.IBlockState;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.multiplayer.WorldClient;
 import net.minecraft.client.network.NetHandlerPlayClient;
+import net.minecraft.entity.EntityLiving;
 import net.minecraft.entity.EnumCreatureType;
 import net.minecraft.profiler.Profiler;
 import net.minecraft.server.MinecraftServer;
@@ -182,6 +184,48 @@ public class WorldEvent extends Event
         public WorldSettings getSettings()
         {
             return settings;
+        }
+    }
+
+    /**
+     * Fires before mob spawn events.
+     *
+     * Result is significant:
+     *    DEFAULT: use vanilla spawn rules
+     *    ALLOW:   allow the spawn
+     *    DENY:    deny the spawn
+     *
+     */
+    @HasResult
+    public static class CreatureTypeSpawnEvent extends WorldEvent
+    {
+        private final EntityLiving.SpawnPlacementType type;
+
+        private final BlockPos pos;
+
+        private final IBlockState state;
+
+        public CreatureTypeSpawnEvent(EntityLiving.SpawnPlacementType type, World world, BlockPos pos, IBlockState state)
+        {
+            super(world);
+            this.type = type;
+            this.pos = pos;
+            this.state = state;
+        }
+
+        public EntityLiving.SpawnPlacementType getType()
+        {
+            return type;
+        }
+
+        public BlockPos getPos()
+        {
+            return pos;
+        }
+
+        public IBlockState getState()
+        {
+            return state;
         }
     }
 }

--- a/src/main/java/net/minecraftforge/event/world/WorldEvent.java
+++ b/src/main/java/net/minecraftforge/event/world/WorldEvent.java
@@ -200,9 +200,7 @@ public class WorldEvent extends Event
     public static class CreatureTypeSpawnEvent extends WorldEvent
     {
         private final EntityLiving.SpawnPlacementType type;
-
         private final BlockPos pos;
-
         private final IBlockState state;
 
         public CreatureTypeSpawnEvent(EntityLiving.SpawnPlacementType type, World world, BlockPos pos, IBlockState state)

--- a/src/test/java/net/minecraftforge/test/CreatureTypeSpawnTest.java
+++ b/src/test/java/net/minecraftforge/test/CreatureTypeSpawnTest.java
@@ -1,0 +1,28 @@
+package net.minecraftforge.test;
+
+import net.minecraft.init.Blocks;
+import net.minecraftforge.common.MinecraftForge;
+import net.minecraftforge.event.world.WorldEvent;
+import net.minecraftforge.fml.common.Mod;
+import net.minecraftforge.fml.common.event.FMLInitializationEvent;
+import net.minecraftforge.fml.common.eventhandler.Event;
+import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
+
+@Mod(modid = "creaturetypespawntest", name = "creaturetypespawntest", version = "0.0.0")
+public class CreatureTypeSpawnTest
+{
+    private static final boolean ENABLE = false;
+
+    @Mod.EventHandler
+    public void init(FMLInitializationEvent event)
+    {
+        if (ENABLE) MinecraftForge.EVENT_BUS.register(this);
+    }
+
+    @SubscribeEvent
+    public void onCreatureTypeSpawn(WorldEvent.CreatureTypeSpawnEvent event)
+    {
+        if (event.getState().getBlock() == Blocks.WATER) event.setResult(Event.Result.ALLOW);
+        else event.setResult(Event.Result.DENY);
+    }
+}


### PR DESCRIPTION
With the current entity spawning system, entities are unable to spawn in a fluid that is not water without custom entity spawning code. This PR fixes that issue by adding in an event that allows modders to control if a certain EntityLiving.SpawnPlacementType can spawn at a given location.