### PR TITLE
Fix typo in LootEntry.Serialiser causing incorrect serialisation. Closes #2757, Fixes MC-115407

### DIFF
--- a/patches/minecraft/net/minecraft/world/storage/loot/LootEntry.java.patch
+++ b/patches/minecraft/net/minecraft/world/storage/loot/LootEntry.java.patch
@@ -61,7 +61,7 @@
                  else if (p_serialize_1_ instanceof LootEntryTable)
                  {
 -                    jsonobject.addProperty("type", "item");
-+                    jsonobject.addProperty("type", "loot_table");
++                    jsonobject.addProperty("type", "loot_table"); //Forge: fix incorrect serialization MC-115407 
                  }
                  else
                  {

--- a/patches/minecraft/net/minecraft/world/storage/loot/LootEntry.java.patch
+++ b/patches/minecraft/net/minecraft/world/storage/loot/LootEntry.java.patch
@@ -47,7 +47,7 @@
                  jsonobject.addProperty("weight", (Number)Integer.valueOf(p_serialize_1_.field_186364_c));
                  jsonobject.addProperty("quality", (Number)Integer.valueOf(p_serialize_1_.field_186365_d));
  
-@@ -86,6 +95,9 @@
+@@ -86,13 +95,16 @@
                      jsonobject.add("conditions", p_serialize_3_.serialize(p_serialize_1_.field_186366_e));
                  }
  
@@ -57,3 +57,11 @@
                  if (p_serialize_1_ instanceof LootEntryItem)
                  {
                      jsonobject.addProperty("type", "item");
+                 }
+                 else if (p_serialize_1_ instanceof LootEntryTable)
+                 {
+-                    jsonobject.addProperty("type", "item");
++                    jsonobject.addProperty("type", "loot_table");
+                 }
+                 else
+                 {


### PR DESCRIPTION
This is a vanilla bug, however it is only revealed when using a mod that serialises loot tables, as vanilla never serialises them. Fixes

I discovered this while debugging Leviathan143/LootTweaker#13.
The vanilla bug report for this issue is [MC-115407](https://bugs.mojang.com/browse/MC-115407).