### PR TITLE
Fix NumberFormatException being thrown for empty ItemStack deserialization

### DIFF
--- a/patches/minecraft/net/minecraft/item/ItemStack.java.patch
+++ b/patches/minecraft/net/minecraft/item/ItemStack.java.patch
@@ -34,7 +34,15 @@
          this.field_77994_a = p_i1881_2_;
          this.field_77991_e = p_i1881_3_;
  
-@@ -117,7 +123,7 @@
+@@ -99,6 +105,7 @@
+ 
+     public static ItemStack func_77949_a(NBTTagCompound p_77949_0_)
+     {
++        if (p_77949_0_.func_82582_d()) return null; // Deserialized inventories can have empty ItemStack compounds. Fixes tons of NumberFormatExceptions
+         ItemStack itemstack = new ItemStack();
+         itemstack.func_77963_c(p_77949_0_);
+         return itemstack.func_77973_b() != null ? itemstack : null;
+@@ -117,7 +124,7 @@
      public ItemStack func_77979_a(int p_77979_1_)
      {
          p_77979_1_ = Math.min(p_77979_1_, this.field_77994_a);
@@ -43,7 +51,7 @@
  
          if (this.field_77990_d != null)
          {
-@@ -130,11 +136,12 @@
+@@ -130,11 +137,12 @@
  
      public Item func_77973_b()
      {
@@ -57,7 +65,7 @@
          EnumActionResult enumactionresult = this.func_77973_b().func_180614_a(this, p_179546_1_, p_179546_2_, p_179546_3_, p_179546_4_, p_179546_5_, p_179546_6_, p_179546_7_, p_179546_8_);
  
          if (enumactionresult == EnumActionResult.SUCCESS)
-@@ -173,12 +180,20 @@
+@@ -173,12 +181,20 @@
              p_77955_1_.func_74782_a("tag", this.field_77990_d);
          }
  
@@ -79,7 +87,7 @@
          this.field_77994_a = p_77963_1_.func_74771_c("Count");
          this.field_77991_e = p_77963_1_.func_74765_d("Damage");
  
-@@ -196,11 +211,12 @@
+@@ -196,11 +212,12 @@
                  this.field_151002_e.func_179215_a(this.field_77990_d);
              }
          }
@@ -93,7 +101,7 @@
      }
  
      public boolean func_77985_e()
-@@ -210,7 +226,7 @@
+@@ -210,7 +227,7 @@
  
      public boolean func_77984_f()
      {
@@ -102,7 +110,7 @@
      }
  
      public boolean func_77981_g()
-@@ -220,32 +236,27 @@
+@@ -220,32 +237,27 @@
  
      public boolean func_77951_h()
      {
@@ -140,7 +148,7 @@
      }
  
      public boolean func_96631_a(int p_96631_1_, Random p_96631_2_)
-@@ -277,8 +288,8 @@
+@@ -277,8 +289,8 @@
                  }
              }
  
@@ -151,7 +159,7 @@
          }
      }
  
-@@ -332,7 +343,7 @@
+@@ -332,7 +344,7 @@
  
      public boolean func_150998_b(IBlockState p_150998_1_)
      {
@@ -160,7 +168,7 @@
      }
  
      public boolean func_111282_a(EntityPlayer p_111282_1_, EntityLivingBase p_111282_2_, EnumHand p_111282_3_)
-@@ -342,7 +353,7 @@
+@@ -342,7 +354,7 @@
  
      public ItemStack func_77946_l()
      {
@@ -169,7 +177,7 @@
  
          if (this.field_77990_d != null)
          {
-@@ -354,7 +365,19 @@
+@@ -354,7 +366,19 @@
  
      public static boolean func_77970_a(@Nullable ItemStack p_77970_0_, @Nullable ItemStack p_77970_1_)
      {
@@ -190,7 +198,7 @@
      }
  
      public static boolean func_77989_b(@Nullable ItemStack p_77989_0_, @Nullable ItemStack p_77989_1_)
-@@ -364,7 +387,11 @@
+@@ -364,7 +388,11 @@
  
      private boolean func_77959_d(ItemStack p_77959_1_)
      {
@@ -203,7 +211,7 @@
      }
  
      public static boolean func_179545_c(@Nullable ItemStack p_179545_0_, @Nullable ItemStack p_179545_1_)
-@@ -764,6 +791,7 @@
+@@ -764,6 +792,7 @@
              }
          }
  
@@ -211,7 +219,7 @@
          return list;
      }
  
-@@ -875,7 +903,7 @@
+@@ -875,7 +904,7 @@
          }
          else
          {
@@ -220,7 +228,7 @@
          }
  
          return multimap;
-@@ -908,6 +936,18 @@
+@@ -908,6 +937,18 @@
      @Deprecated
      public void func_150996_a(Item p_150996_1_)
      {
@@ -239,7 +247,7 @@
          this.field_151002_e = p_150996_1_;
      }
  
-@@ -993,4 +1033,45 @@
+@@ -993,4 +1034,45 @@
              return false;
          }
      }


### PR DESCRIPTION
This resolves the issue discovered by #3828 where an `ItemStack` is attempted to be deserialized from an empty `NBTTagCompound`. This patch short circuits a `null` `ItemStack` in the event the tag compound is empty.