### PR TITLE
Move block reach distance to an attribute

### DIFF
--- a/patches/minecraft/net/minecraft/entity/player/EntityPlayerMP.java.patch
+++ b/patches/minecraft/net/minecraft/entity/player/EntityPlayerMP.java.patch
@@ -1,6 +1,14 @@
 --- ../src-base/minecraft/net/minecraft/entity/player/EntityPlayerMP.java
 +++ ../src-work/minecraft/net/minecraft/entity/player/EntityPlayerMP.java
-@@ -146,9 +146,9 @@
+@@ -112,6 +112,7 @@
+ public class EntityPlayerMP extends EntityPlayer implements IContainerListener
+ {
+     private static final Logger field_147102_bM = LogManager.getLogger();
++    public static final net.minecraft.entity.ai.attributes.IAttribute BLOCK_REACH_DISTANCE = new net.minecraft.entity.ai.attributes.RangedAttribute(null, "forge.blockReachDistance", 5.0d, 0.0d, 1024.0d);
+     private String field_71148_cg = "en_US";
+     public NetHandlerPlayServer field_71135_a;
+     public final MinecraftServer field_71133_b;
+@@ -146,9 +147,9 @@
          super(p_i45285_2_, p_i45285_3_);
          p_i45285_4_.field_73090_b = this;
          this.field_71134_c = p_i45285_4_;
@@ -12,7 +20,7 @@
          {
              int i = Math.max(0, p_i45285_1_.func_184108_a(p_i45285_2_));
              int j = MathHelper.func_76128_c(p_i45285_2_.func_175723_af().func_177729_b((double)blockpos.func_177958_n(), (double)blockpos.func_177952_p()));
-@@ -279,7 +279,7 @@
+@@ -279,7 +280,7 @@
  
          this.field_71070_bA.func_75142_b();
  
@@ -21,7 +29,7 @@
          {
              this.func_71053_j();
              this.field_71070_bA = this.field_71069_bz;
-@@ -462,6 +462,7 @@
+@@ -462,6 +463,7 @@
  
      public void func_70645_a(DamageSource p_70645_1_)
      {
@@ -29,7 +37,7 @@
          boolean flag = this.field_70170_p.func_82736_K().func_82766_b("showDeathMessages");
          this.field_71135_a.func_147359_a(new SPacketCombatEvent(this.func_110142_aN(), SPacketCombatEvent.Event.ENTITY_DIED, flag));
  
-@@ -488,8 +489,20 @@
+@@ -488,8 +490,20 @@
  
          if (!this.field_70170_p.func_82736_K().func_82766_b("keepInventory") && !this.func_175149_v())
          {
@@ -50,7 +58,7 @@
          }
  
          for (ScoreObjective scoreobjective : this.field_70170_p.func_96441_U().func_96520_a(IScoreCriteria.field_96642_c))
-@@ -573,6 +586,7 @@
+@@ -573,6 +587,7 @@
      @Nullable
      public Entity func_184204_a(int p_184204_1_)
      {
@@ -58,7 +66,7 @@
          this.field_184851_cj = true;
  
          if (this.field_71093_bK == 1 && p_184204_1_ == 1)
-@@ -730,7 +744,7 @@
+@@ -730,7 +745,7 @@
          BlockPos blockpos = new BlockPos(i, j, k);
          IBlockState iblockstate = this.field_70170_p.func_180495_p(blockpos);
  
@@ -67,7 +75,7 @@
          {
              BlockPos blockpos1 = blockpos.func_177977_b();
              IBlockState iblockstate1 = this.field_70170_p.func_180495_p(blockpos1);
-@@ -770,6 +784,7 @@
+@@ -770,6 +785,7 @@
              this.field_71070_bA = p_180468_1_.func_174876_a(this.field_71071_by, this);
              this.field_71070_bA.field_75152_c = this.field_71139_cq;
              this.field_71070_bA.func_75132_a(this);
@@ -75,7 +83,7 @@
          }
      }
  
-@@ -813,6 +828,7 @@
+@@ -813,6 +829,7 @@
  
              this.field_71070_bA.field_75152_c = this.field_71139_cq;
              this.field_71070_bA.func_75132_a(this);
@@ -83,7 +91,7 @@
          }
      }
  
-@@ -822,6 +838,7 @@
+@@ -822,6 +839,7 @@
          this.field_71070_bA = new ContainerMerchant(this.field_71071_by, p_180472_1_, this.field_70170_p);
          this.field_71070_bA.field_75152_c = this.field_71139_cq;
          this.field_71070_bA.func_75132_a(this);
@@ -91,7 +99,7 @@
          IInventory iinventory = ((ContainerMerchant)this.field_71070_bA).func_75174_d();
          ITextComponent itextcomponent = p_180472_1_.func_145748_c_();
          this.field_71135_a.func_147359_a(new SPacketOpenWindow(this.field_71139_cq, "minecraft:villager", itextcomponent, iinventory.func_70302_i_()));
-@@ -920,6 +937,7 @@
+@@ -920,6 +938,7 @@
      public void func_71128_l()
      {
          this.field_71070_bA.func_75134_a(this);
@@ -99,7 +107,7 @@
          this.field_71070_bA = this.field_71069_bz;
      }
  
-@@ -951,6 +969,7 @@
+@@ -951,6 +970,7 @@
      {
          if (p_71064_1_ != null)
          {

--- a/patches/minecraft/net/minecraft/item/Item.java.patch
+++ b/patches/minecraft/net/minecraft/item/Item.java.patch
@@ -54,7 +54,7 @@
 -        Vec3d vec3d1 = vec3d.func_72441_c((double)f6 * 5.0D, (double)f5 * 5.0D, (double)f7 * 5.0D);
 +        if (p_77621_2_ instanceof net.minecraft.entity.player.EntityPlayerMP)
 +        {
-+            d3 = ((net.minecraft.entity.player.EntityPlayerMP)p_77621_2_).field_71134_c.getBlockReachDistance();
++            d3 = p_77621_2_.func_110148_a(net.minecraft.entity.player.EntityPlayerMP.BLOCK_REACH_DISTANCE).func_111126_e();
 +        }
 +        Vec3d vec3d1 = vec3d.func_72441_c((double)f6 * d3, (double)f5 * d3, (double)f7 * d3);
          return p_77621_1_.func_147447_a(vec3d, vec3d1, p_77621_3_, !p_77621_3_, false);

--- a/patches/minecraft/net/minecraft/network/NetHandlerPlayServer.java.patch
+++ b/patches/minecraft/net/minecraft/network/NetHandlerPlayServer.java.patch
@@ -5,7 +5,7 @@
                  double d3 = d0 * d0 + d1 * d1 + d2 * d2;
  
 -                if (d3 > 36.0D)
-+                double dist = field_147369_b.field_71134_c.getBlockReachDistance() + 1;
++                double dist = this.field_147369_b.func_110148_a(EntityPlayerMP.BLOCK_REACH_DISTANCE).func_111126_e() + 1;
 +                dist *= dist;
 +
 +                if (d3 > dist)
@@ -17,7 +17,7 @@
          if (blockpos.func_177956_o() < this.field_147367_d.func_71207_Z() - 1 || enumfacing != EnumFacing.UP && blockpos.func_177956_o() < this.field_147367_d.func_71207_Z())
          {
 -            if (this.field_184362_y == null && this.field_147369_b.func_70092_e((double)blockpos.func_177958_n() + 0.5D, (double)blockpos.func_177956_o() + 0.5D, (double)blockpos.func_177952_p() + 0.5D) < 64.0D && !this.field_147367_d.func_175579_a(worldserver, blockpos, this.field_147369_b) && worldserver.func_175723_af().func_177746_a(blockpos))
-+            double dist = field_147369_b.field_71134_c.getBlockReachDistance() + 3;
++            double dist = this.field_147369_b.func_110148_a(EntityPlayerMP.BLOCK_REACH_DISTANCE).func_111126_e() + 3;
 +            dist *= dist;
 +            if (this.field_184362_y == null && this.field_147369_b.func_70092_e((double)blockpos.func_177958_n() + 0.5D, (double)blockpos.func_177956_o() + 0.5D, (double)blockpos.func_177952_p() + 0.5D) < dist && !this.field_147367_d.func_175579_a(worldserver, blockpos, this.field_147369_b) && worldserver.func_175723_af().func_177746_a(blockpos))
              {

--- a/patches/minecraft/net/minecraft/server/management/PlayerInteractionManager.java.patch
+++ b/patches/minecraft/net/minecraft/server/management/PlayerInteractionManager.java.patch
@@ -1,15 +1,6 @@
 --- ../src-base/minecraft/net/minecraft/server/management/PlayerInteractionManager.java
 +++ ../src-work/minecraft/net/minecraft/server/management/PlayerInteractionManager.java
-@@ -28,6 +28,8 @@
- 
- public class PlayerInteractionManager
- {
-+    /** Forge reach distance */
-+    private double blockReachDistance = 5.0d;
-     public World field_73092_a;
-     public EntityPlayerMP field_73090_b;
-     private GameType field_73091_c = GameType.NOT_SET;
-@@ -89,7 +91,7 @@
+@@ -89,7 +89,7 @@
              IBlockState iblockstate = this.field_73092_a.func_180495_p(this.field_180241_i);
              Block block = iblockstate.func_177230_c();
  
@@ -18,7 +9,7 @@
              {
                  this.field_73097_j = false;
              }
-@@ -116,7 +118,7 @@
+@@ -116,7 +116,7 @@
              IBlockState iblockstate1 = this.field_73092_a.func_180495_p(this.field_180240_f);
              Block block1 = iblockstate1.func_177230_c();
  
@@ -27,7 +18,7 @@
              {
                  this.field_73092_a.func_175715_c(this.field_73090_b.func_145782_y(), this.field_180240_f, -1);
                  this.field_73094_o = -1;
-@@ -125,7 +127,7 @@
+@@ -125,7 +125,7 @@
              else
              {
                  int k = this.field_73100_i - this.field_73089_e;
@@ -36,11 +27,11 @@
                  int l = (int)(f1 * 10.0F);
  
                  if (l != this.field_73094_o)
-@@ -139,6 +141,15 @@
+@@ -139,6 +139,15 @@
  
      public void func_180784_a(BlockPos p_180784_1_, EnumFacing p_180784_2_)
      {
-+        net.minecraftforge.event.entity.player.PlayerInteractEvent.LeftClickBlock event = net.minecraftforge.common.ForgeHooks.onLeftClickBlock(field_73090_b, p_180784_1_, p_180784_2_, net.minecraftforge.common.ForgeHooks.rayTraceEyeHitVec(field_73090_b, getBlockReachDistance() + 1));
++        net.minecraftforge.event.entity.player.PlayerInteractEvent.LeftClickBlock event = net.minecraftforge.common.ForgeHooks.onLeftClickBlock(field_73090_b, p_180784_1_, p_180784_2_, net.minecraftforge.common.ForgeHooks.rayTraceEyeHitVec(field_73090_b, this.field_73090_b.func_110148_a(EntityPlayerMP.BLOCK_REACH_DISTANCE).func_111126_e() + 1));
 +        if (event.isCanceled())
 +        {
 +            // Restore block and te data
@@ -52,7 +43,7 @@
          if (this.func_73083_d())
          {
              if (!this.field_73092_a.func_175719_a((EntityPlayer)null, p_180784_1_, p_180784_2_))
-@@ -174,17 +185,36 @@
+@@ -174,17 +183,36 @@
                  }
              }
  
@@ -93,7 +84,7 @@
              {
                  this.func_180237_b(p_180784_1_);
              }
-@@ -206,7 +236,7 @@
+@@ -206,7 +234,7 @@
              int i = this.field_73100_i - this.field_73089_e;
              IBlockState iblockstate = this.field_73092_a.func_180495_p(p_180785_1_);
  
@@ -102,7 +93,7 @@
              {
                  float f = iblockstate.func_185903_a(this.field_73090_b, this.field_73090_b.field_70170_p, p_180785_1_) * (float)(i + 1);
  
-@@ -235,13 +265,17 @@
+@@ -235,13 +263,17 @@
  
      private boolean func_180235_c(BlockPos p_180235_1_)
      {
@@ -124,7 +115,7 @@
          }
  
          return flag;
-@@ -249,7 +283,8 @@
+@@ -249,7 +281,8 @@
  
      public boolean func_180237_b(BlockPos p_180237_1_)
      {
@@ -134,7 +125,7 @@
          {
              return false;
          }
-@@ -266,53 +301,40 @@
+@@ -266,53 +299,40 @@
              }
              else
              {
@@ -199,7 +190,7 @@
                  return flag1;
              }
          }
-@@ -330,8 +352,11 @@
+@@ -330,8 +350,11 @@
          }
          else
          {
@@ -211,7 +202,7 @@
              ActionResult<ItemStack> actionresult = p_187250_3_.func_77957_a(p_187250_2_, p_187250_1_, p_187250_4_);
              ItemStack itemstack = (ItemStack)actionresult.func_188398_b();
  
-@@ -360,6 +385,7 @@
+@@ -360,6 +383,7 @@
                  if (itemstack.func_190926_b())
                  {
                      p_187250_1_.func_184611_a(p_187250_4_, ItemStack.field_190927_a);
@@ -219,13 +210,13 @@
                  }
  
                  if (!p_187250_1_.func_184587_cr())
-@@ -404,13 +430,23 @@
+@@ -404,13 +428,23 @@
          }
          else
          {
 -            if (!p_187251_1_.func_70093_af() || p_187251_1_.func_184614_ca().func_190926_b() && p_187251_1_.func_184592_cb().func_190926_b())
 +            net.minecraftforge.event.entity.player.PlayerInteractEvent.RightClickBlock event = net.minecraftforge.common.ForgeHooks
-+                    .onRightClickBlock(p_187251_1_, p_187251_4_, p_187251_5_, p_187251_6_, net.minecraftforge.common.ForgeHooks.rayTraceEyeHitVec(p_187251_1_, getBlockReachDistance() + 1));
++                    .onRightClickBlock(p_187251_1_, p_187251_4_, p_187251_5_, p_187251_6_, net.minecraftforge.common.ForgeHooks.rayTraceEyeHitVec(p_187251_1_, this.field_73090_b.func_110148_a(EntityPlayerMP.BLOCK_REACH_DISTANCE).func_111126_e() + 1));
 +            if (event.isCanceled()) return event.getCancellationResult();
 +
 +            EnumActionResult ret = p_187251_3_.onItemUseFirst(p_187251_1_, p_187251_2_, p_187251_5_, p_187251_4_, p_187251_6_, p_187251_7_, p_187251_8_, p_187251_9_);
@@ -246,7 +237,7 @@
                  }
              }
  
-@@ -438,14 +474,20 @@
+@@ -438,14 +472,20 @@
                  {
                      int j = p_187251_3_.func_77960_j();
                      int i = p_187251_3_.func_190916_E();
@@ -267,17 +258,3 @@
                  }
              }
          }
-@@ -455,4 +497,13 @@
-     {
-         this.field_73092_a = p_73080_1_;
-     }
-+
-+    public double getBlockReachDistance()
-+    {
-+        return blockReachDistance;
-+    }
-+    public void setBlockReachDistance(double distance)
-+    {
-+        blockReachDistance = distance;
-+    }
- }


### PR DESCRIPTION
Adds #3749.

I've removed the getter and setter as I'm not sure it would be wise to keep them:
> It would be really nice if we could change this into an attribute and check that instead, so modders don't have to fight over setting the reach distance and can just use an additive attribute modifier to do it. It also makes things like reach potions and amulets much more easy to implement.

Removing the getter and setter forces mod developers to use the attribute.

This will most likely make it in with 1.12 (or later), opening now to get comments.