### PR TITLE
Relocate TileEntity#onLoad call

### DIFF
--- a/patches/minecraft/net/minecraft/tileentity/TileEntity.java.patch
+++ b/patches/minecraft/net/minecraft/tileentity/TileEntity.java.patch
@@ -72,7 +72,7 @@
      public double func_145835_a(double p_145835_1_, double p_145835_3_, double p_145835_5_)
      {
          double d0 = (double)this.field_174879_c.func_177958_n() + 0.5D - p_145835_1_;
-@@ -297,6 +307,205 @@
+@@ -297,6 +307,204 @@
      {
      }
  
@@ -226,9 +226,8 @@
 +
 +
 +    /**
-+     * Called from the Chunk when this is first added to the world. Override instead of adding
-+     * if (firstTick) stuff in update. Happens after validate and after it has been placed into the Chunk tileEntity
-+     * map.
++     * Called when this is first added to the world (by {@link World#addTileEntity(TileEntity)}).
++     * Override instead of adding {@code if (firstTick)} stuff in update.
 +     */
 +    public void onLoad()
 +    {

--- a/patches/minecraft/net/minecraft/world/World.java.patch
+++ b/patches/minecraft/net/minecraft/world/World.java.patch
@@ -460,29 +460,26 @@
          this.field_72984_F.func_76318_c("pendingBlockEntities");
  
          if (!this.field_147484_a.isEmpty())
-@@ -1755,8 +1886,12 @@
+@@ -1755,12 +1886,18 @@
  
      public boolean func_175700_a(TileEntity p_175700_1_)
      {
--        boolean flag = this.field_147482_g.add(p_175700_1_);
-+        if (p_175700_1_.func_145831_w() != this) // Forge - set the world early as vanilla doesn't set it until next tick
-+            p_175700_1_.func_145834_a(this);
- 
-+        List<TileEntity> dest = field_147481_N ? field_147484_a : field_147482_g;
-+        boolean flag = dest.add(p_175700_1_);
++        // Forge - set the world early as vanilla doesn't set it until next tick
++        if (p_175700_1_.func_145831_w() != this) p_175700_1_.func_145834_a(this);
++        // Forge: wait to add new TE if we're currently processing existing ones
++        if (field_147481_N) return field_147484_a.add(p_175700_1_);
 +
+         boolean flag = this.field_147482_g.add(p_175700_1_);
+ 
          if (flag && p_175700_1_ instanceof ITickable)
          {
              this.field_175730_i.add(p_175700_1_);
-@@ -1768,6 +1903,7 @@
-             IBlockState iblockstate = this.func_180495_p(blockpos);
-             this.func_184138_a(blockpos, iblockstate, iblockstate, 2);
          }
-+        if (!field_147481_N) p_175700_1_.onLoad();
++        p_175700_1_.onLoad();
  
-         return flag;
-     }
-@@ -1776,6 +1912,11 @@
+         if (this.field_72995_K)
+         {
+@@ -1776,6 +1913,11 @@
      {
          if (this.field_147481_N)
          {
@@ -494,7 +491,7 @@
              this.field_147484_a.addAll(p_147448_1_);
          }
          else
-@@ -1796,9 +1937,12 @@
+@@ -1796,9 +1938,12 @@
      {
          int i = MathHelper.func_76128_c(p_72866_1_.field_70165_t);
          int j = MathHelper.func_76128_c(p_72866_1_.field_70161_v);
@@ -509,7 +506,7 @@
          {
              p_72866_1_.field_70142_S = p_72866_1_.field_70165_t;
              p_72866_1_.field_70137_T = p_72866_1_.field_70163_u;
-@@ -1816,6 +1960,7 @@
+@@ -1816,6 +1961,7 @@
                  }
                  else
                  {
@@ -517,7 +514,7 @@
                      p_72866_1_.func_70071_h_();
                  }
              }
-@@ -1997,6 +2142,11 @@
+@@ -1997,6 +2143,11 @@
                              blockpos$pooledmutableblockpos.func_185344_t();
                              return true;
                          }
@@ -529,7 +526,7 @@
                      }
                  }
              }
-@@ -2036,6 +2186,16 @@
+@@ -2036,6 +2187,16 @@
                          IBlockState iblockstate = this.func_180495_p(blockpos$pooledmutableblockpos);
                          Block block = iblockstate.func_177230_c();
  
@@ -546,7 +543,7 @@
                          if (iblockstate.func_185904_a() == p_72918_2_)
                          {
                              double d0 = (double)((float)(l1 + 1) - BlockLiquid.func_149801_b(((Integer)iblockstate.func_177229_b(BlockLiquid.field_176367_b)).intValue()));
-@@ -2102,6 +2262,7 @@
+@@ -2102,6 +2263,7 @@
      public Explosion func_72885_a(@Nullable Entity p_72885_1_, double p_72885_2_, double p_72885_4_, double p_72885_6_, float p_72885_8_, boolean p_72885_9_, boolean p_72885_10_)
      {
          Explosion explosion = new Explosion(this, p_72885_1_, p_72885_2_, p_72885_4_, p_72885_6_, p_72885_8_, p_72885_9_, p_72885_10_);
@@ -554,7 +551,7 @@
          explosion.func_77278_a();
          explosion.func_77279_a(true);
          return explosion;
-@@ -2224,6 +2385,7 @@
+@@ -2224,6 +2386,7 @@
  
      public void func_175690_a(BlockPos p_175690_1_, @Nullable TileEntity p_175690_2_)
      {
@@ -562,7 +559,7 @@
          if (!this.func_189509_E(p_175690_1_))
          {
              if (p_175690_2_ != null && !p_175690_2_.func_145837_r())
-@@ -2231,6 +2393,8 @@
+@@ -2231,6 +2394,8 @@
                  if (this.field_147481_N)
                  {
                      p_175690_2_.func_174878_a(p_175690_1_);
@@ -571,7 +568,7 @@
                      Iterator<TileEntity> iterator = this.field_147484_a.iterator();
  
                      while (iterator.hasNext())
-@@ -2248,7 +2412,8 @@
+@@ -2248,7 +2413,8 @@
                  }
                  else
                  {
@@ -581,7 +578,7 @@
                      this.func_175700_a(p_175690_2_);
                  }
              }
-@@ -2263,6 +2428,8 @@
+@@ -2263,6 +2429,8 @@
          {
              tileentity.func_145843_s();
              this.field_147484_a.remove(tileentity);
@@ -590,7 +587,7 @@
          }
          else
          {
-@@ -2275,6 +2442,7 @@
+@@ -2275,6 +2443,7 @@
  
              this.func_175726_f(p_175713_1_).func_177425_e(p_175713_1_);
          }
@@ -598,7 +595,7 @@
      }
  
      public void func_147457_a(TileEntity p_147457_1_)
-@@ -2301,7 +2469,7 @@
+@@ -2301,7 +2470,7 @@
              if (chunk != null && !chunk.func_76621_g())
              {
                  IBlockState iblockstate = this.func_180495_p(p_175677_1_);
@@ -607,7 +604,7 @@
              }
              else
              {
-@@ -2324,6 +2492,7 @@
+@@ -2324,6 +2493,7 @@
      {
          this.field_72985_G = p_72891_1_;
          this.field_72992_H = p_72891_2_;
@@ -615,7 +612,7 @@
      }
  
      public void func_72835_b()
-@@ -2333,6 +2502,11 @@
+@@ -2333,6 +2503,11 @@
  
      protected void func_72947_a()
      {
@@ -627,7 +624,7 @@
          if (this.field_72986_A.func_76059_o())
          {
              this.field_73004_o = 1.0F;
-@@ -2346,6 +2520,11 @@
+@@ -2346,6 +2521,11 @@
  
      protected void func_72979_l()
      {
@@ -639,7 +636,7 @@
          if (this.field_73011_w.func_191066_m())
          {
              if (!this.field_72995_K)
-@@ -2470,6 +2649,11 @@
+@@ -2470,6 +2650,11 @@
  
      public boolean func_175670_e(BlockPos p_175670_1_, boolean p_175670_2_)
      {
@@ -651,7 +648,7 @@
          Biome biome = this.func_180494_b(p_175670_1_);
          float f = biome.func_180626_a(p_175670_1_);
  
-@@ -2511,6 +2695,11 @@
+@@ -2511,6 +2696,11 @@
  
      public boolean func_175708_f(BlockPos p_175708_1_, boolean p_175708_2_)
      {
@@ -663,7 +660,7 @@
          Biome biome = this.func_180494_b(p_175708_1_);
          float f = biome.func_180626_a(p_175708_1_);
  
-@@ -2528,7 +2717,7 @@
+@@ -2528,7 +2718,7 @@
              {
                  IBlockState iblockstate = this.func_180495_p(p_175708_1_);
  
@@ -672,7 +669,7 @@
                  {
                      return true;
                  }
-@@ -2560,10 +2749,11 @@
+@@ -2560,10 +2750,11 @@
          else
          {
              IBlockState iblockstate = this.func_180495_p(p_175638_1_);
@@ -687,7 +684,7 @@
              {
                  j = 1;
              }
-@@ -2597,6 +2787,7 @@
+@@ -2597,6 +2788,7 @@
  
                      if (i >= 14)
                      {
@@ -695,7 +692,7 @@
                          return i;
                      }
                  }
-@@ -2662,7 +2853,7 @@
+@@ -2662,7 +2854,7 @@
                                      int j4 = j2 + enumfacing.func_96559_d();
                                      int k4 = k2 + enumfacing.func_82599_e();
                                      blockpos$pooledmutableblockpos.func_181079_c(i4, j4, k4);
@@ -704,7 +701,7 @@
                                      i3 = this.func_175642_b(p_180500_1_, blockpos$pooledmutableblockpos);
  
                                      if (i3 == l2 - l4 && j < this.field_72994_J.length)
-@@ -2770,10 +2961,10 @@
+@@ -2770,10 +2962,10 @@
      public List<Entity> func_175674_a(@Nullable Entity p_175674_1_, AxisAlignedBB p_175674_2_, @Nullable Predicate <? super Entity > p_175674_3_)
      {
          List<Entity> list = Lists.<Entity>newArrayList();
@@ -719,7 +716,7 @@
  
          for (int i1 = i; i1 <= j; ++i1)
          {
-@@ -2826,10 +3017,10 @@
+@@ -2826,10 +3018,10 @@
  
      public <T extends Entity> List<T> func_175647_a(Class <? extends T > p_175647_1_, AxisAlignedBB p_175647_2_, @Nullable Predicate <? super T > p_175647_3_)
      {
@@ -734,7 +731,7 @@
          List<T> list = Lists.<T>newArrayList();
  
          for (int i1 = i; i1 < j; ++i1)
-@@ -2909,11 +3100,13 @@
+@@ -2909,11 +3101,13 @@
  
      public void func_175650_b(Collection<Entity> p_175650_1_)
      {
@@ -751,7 +748,7 @@
          }
      }
  
-@@ -2926,7 +3119,7 @@
+@@ -2926,7 +3120,7 @@
      {
          IBlockState iblockstate = this.func_180495_p(p_190527_2_);
          AxisAlignedBB axisalignedbb = p_190527_3_ ? null : p_190527_1_.func_176223_P().func_185890_d(this, p_190527_2_);
@@ -760,7 +757,7 @@
      }
  
      public int func_181545_F()
-@@ -3009,7 +3202,7 @@
+@@ -3009,7 +3203,7 @@
      public int func_175651_c(BlockPos p_175651_1_, EnumFacing p_175651_2_)
      {
          IBlockState iblockstate = this.func_180495_p(p_175651_1_);
@@ -769,7 +766,7 @@
      }
  
      public boolean func_175640_z(BlockPos p_175640_1_)
-@@ -3152,6 +3345,8 @@
+@@ -3152,6 +3346,8 @@
                      d2 *= ((Double)Objects.firstNonNull(p_184150_11_.apply(entityplayer1), Double.valueOf(1.0D))).doubleValue();
                  }
  
@@ -778,7 +775,7 @@
                  if ((p_184150_9_ < 0.0D || Math.abs(entityplayer1.field_70163_u - p_184150_3_) < p_184150_9_ * p_184150_9_) && (p_184150_7_ < 0.0D || d1 < d2 * d2) && (d0 == -1.0D || d1 < d0))
                  {
                      d0 = d1;
-@@ -3213,7 +3408,7 @@
+@@ -3213,7 +3409,7 @@
  
      public long func_72905_C()
      {
@@ -787,7 +784,7 @@
      }
  
      public long func_82737_E()
-@@ -3223,17 +3418,17 @@
+@@ -3223,17 +3419,17 @@
  
      public long func_72820_D()
      {
@@ -808,7 +805,7 @@
  
          if (!this.func_175723_af().func_177746_a(blockpos))
          {
-@@ -3245,7 +3440,7 @@
+@@ -3245,7 +3441,7 @@
  
      public void func_175652_B(BlockPos p_175652_1_)
      {
@@ -817,7 +814,7 @@
      }
  
      @SideOnly(Side.CLIENT)
-@@ -3265,12 +3460,18 @@
+@@ -3265,12 +3461,18 @@
  
          if (!this.field_72996_f.contains(p_72897_1_))
          {
@@ -836,7 +833,7 @@
          return true;
      }
  
-@@ -3364,8 +3565,7 @@
+@@ -3364,8 +3566,7 @@
  
      public boolean func_180502_D(BlockPos p_180502_1_)
      {
@@ -846,7 +843,7 @@
      }
  
      @Nullable
-@@ -3426,12 +3626,12 @@
+@@ -3426,12 +3627,12 @@
  
      public int func_72800_K()
      {
@@ -861,7 +858,7 @@
      }
  
      public Random func_72843_D(int p_72843_1_, int p_72843_2_, int p_72843_3_)
-@@ -3475,7 +3675,7 @@
+@@ -3475,7 +3676,7 @@
      @SideOnly(Side.CLIENT)
      public double func_72919_O()
      {
@@ -870,7 +867,7 @@
      }
  
      public void func_175715_c(int p_175715_1_, BlockPos p_175715_2_, int p_175715_3_)
-@@ -3509,7 +3709,7 @@
+@@ -3509,7 +3710,7 @@
  
      public void func_175666_e(BlockPos p_175666_1_, Block p_175666_2_)
      {
@@ -879,7 +876,7 @@
          {
              BlockPos blockpos = p_175666_1_.func_177972_a(enumfacing);
  
-@@ -3517,18 +3717,14 @@
+@@ -3517,18 +3718,14 @@
              {
                  IBlockState iblockstate = this.func_180495_p(blockpos);
  
@@ -902,7 +899,7 @@
                      }
                  }
              }
-@@ -3594,6 +3790,115 @@
+@@ -3594,6 +3791,115 @@
          return i >= -128 && i <= 128 && j >= -128 && j <= 128;
      }
  

--- a/patches/minecraft/net/minecraft/world/World.java.patch
+++ b/patches/minecraft/net/minecraft/world/World.java.patch
@@ -474,7 +474,15 @@
          if (flag && p_175700_1_ instanceof ITickable)
          {
              this.field_175730_i.add(p_175700_1_);
-@@ -1776,6 +1911,11 @@
+@@ -1768,6 +1903,7 @@
+             IBlockState iblockstate = this.func_180495_p(blockpos);
+             this.func_184138_a(blockpos, iblockstate, iblockstate, 2);
+         }
++        if (!field_147481_N) p_175700_1_.onLoad();
+ 
+         return flag;
+     }
+@@ -1776,6 +1912,11 @@
      {
          if (this.field_147481_N)
          {
@@ -486,7 +494,7 @@
              this.field_147484_a.addAll(p_147448_1_);
          }
          else
-@@ -1796,9 +1936,12 @@
+@@ -1796,9 +1937,12 @@
      {
          int i = MathHelper.func_76128_c(p_72866_1_.field_70165_t);
          int j = MathHelper.func_76128_c(p_72866_1_.field_70161_v);
@@ -501,7 +509,7 @@
          {
              p_72866_1_.field_70142_S = p_72866_1_.field_70165_t;
              p_72866_1_.field_70137_T = p_72866_1_.field_70163_u;
-@@ -1816,6 +1959,7 @@
+@@ -1816,6 +1960,7 @@
                  }
                  else
                  {
@@ -509,7 +517,7 @@
                      p_72866_1_.func_70071_h_();
                  }
              }
-@@ -1997,6 +2141,11 @@
+@@ -1997,6 +2142,11 @@
                              blockpos$pooledmutableblockpos.func_185344_t();
                              return true;
                          }
@@ -521,7 +529,7 @@
                      }
                  }
              }
-@@ -2036,6 +2185,16 @@
+@@ -2036,6 +2186,16 @@
                          IBlockState iblockstate = this.func_180495_p(blockpos$pooledmutableblockpos);
                          Block block = iblockstate.func_177230_c();
  
@@ -538,7 +546,7 @@
                          if (iblockstate.func_185904_a() == p_72918_2_)
                          {
                              double d0 = (double)((float)(l1 + 1) - BlockLiquid.func_149801_b(((Integer)iblockstate.func_177229_b(BlockLiquid.field_176367_b)).intValue()));
-@@ -2102,6 +2261,7 @@
+@@ -2102,6 +2262,7 @@
      public Explosion func_72885_a(@Nullable Entity p_72885_1_, double p_72885_2_, double p_72885_4_, double p_72885_6_, float p_72885_8_, boolean p_72885_9_, boolean p_72885_10_)
      {
          Explosion explosion = new Explosion(this, p_72885_1_, p_72885_2_, p_72885_4_, p_72885_6_, p_72885_8_, p_72885_9_, p_72885_10_);
@@ -546,7 +554,7 @@
          explosion.func_77278_a();
          explosion.func_77279_a(true);
          return explosion;
-@@ -2224,6 +2384,7 @@
+@@ -2224,6 +2385,7 @@
  
      public void func_175690_a(BlockPos p_175690_1_, @Nullable TileEntity p_175690_2_)
      {
@@ -554,7 +562,7 @@
          if (!this.func_189509_E(p_175690_1_))
          {
              if (p_175690_2_ != null && !p_175690_2_.func_145837_r())
-@@ -2231,6 +2392,8 @@
+@@ -2231,6 +2393,8 @@
                  if (this.field_147481_N)
                  {
                      p_175690_2_.func_174878_a(p_175690_1_);
@@ -563,7 +571,7 @@
                      Iterator<TileEntity> iterator = this.field_147484_a.iterator();
  
                      while (iterator.hasNext())
-@@ -2248,7 +2411,8 @@
+@@ -2248,7 +2412,8 @@
                  }
                  else
                  {
@@ -573,7 +581,7 @@
                      this.func_175700_a(p_175690_2_);
                  }
              }
-@@ -2263,6 +2427,8 @@
+@@ -2263,6 +2428,8 @@
          {
              tileentity.func_145843_s();
              this.field_147484_a.remove(tileentity);
@@ -582,7 +590,7 @@
          }
          else
          {
-@@ -2275,6 +2441,7 @@
+@@ -2275,6 +2442,7 @@
  
              this.func_175726_f(p_175713_1_).func_177425_e(p_175713_1_);
          }
@@ -590,7 +598,7 @@
      }
  
      public void func_147457_a(TileEntity p_147457_1_)
-@@ -2301,7 +2468,7 @@
+@@ -2301,7 +2469,7 @@
              if (chunk != null && !chunk.func_76621_g())
              {
                  IBlockState iblockstate = this.func_180495_p(p_175677_1_);
@@ -599,7 +607,7 @@
              }
              else
              {
-@@ -2324,6 +2491,7 @@
+@@ -2324,6 +2492,7 @@
      {
          this.field_72985_G = p_72891_1_;
          this.field_72992_H = p_72891_2_;
@@ -607,7 +615,7 @@
      }
  
      public void func_72835_b()
-@@ -2333,6 +2501,11 @@
+@@ -2333,6 +2502,11 @@
  
      protected void func_72947_a()
      {
@@ -619,7 +627,7 @@
          if (this.field_72986_A.func_76059_o())
          {
              this.field_73004_o = 1.0F;
-@@ -2346,6 +2519,11 @@
+@@ -2346,6 +2520,11 @@
  
      protected void func_72979_l()
      {
@@ -631,7 +639,7 @@
          if (this.field_73011_w.func_191066_m())
          {
              if (!this.field_72995_K)
-@@ -2470,6 +2648,11 @@
+@@ -2470,6 +2649,11 @@
  
      public boolean func_175670_e(BlockPos p_175670_1_, boolean p_175670_2_)
      {
@@ -643,7 +651,7 @@
          Biome biome = this.func_180494_b(p_175670_1_);
          float f = biome.func_180626_a(p_175670_1_);
  
-@@ -2511,6 +2694,11 @@
+@@ -2511,6 +2695,11 @@
  
      public boolean func_175708_f(BlockPos p_175708_1_, boolean p_175708_2_)
      {
@@ -655,7 +663,7 @@
          Biome biome = this.func_180494_b(p_175708_1_);
          float f = biome.func_180626_a(p_175708_1_);
  
-@@ -2528,7 +2716,7 @@
+@@ -2528,7 +2717,7 @@
              {
                  IBlockState iblockstate = this.func_180495_p(p_175708_1_);
  
@@ -664,7 +672,7 @@
                  {
                      return true;
                  }
-@@ -2560,10 +2748,11 @@
+@@ -2560,10 +2749,11 @@
          else
          {
              IBlockState iblockstate = this.func_180495_p(p_175638_1_);
@@ -679,7 +687,7 @@
              {
                  j = 1;
              }
-@@ -2597,6 +2786,7 @@
+@@ -2597,6 +2787,7 @@
  
                      if (i >= 14)
                      {
@@ -687,7 +695,7 @@
                          return i;
                      }
                  }
-@@ -2662,7 +2852,7 @@
+@@ -2662,7 +2853,7 @@
                                      int j4 = j2 + enumfacing.func_96559_d();
                                      int k4 = k2 + enumfacing.func_82599_e();
                                      blockpos$pooledmutableblockpos.func_181079_c(i4, j4, k4);
@@ -696,7 +704,7 @@
                                      i3 = this.func_175642_b(p_180500_1_, blockpos$pooledmutableblockpos);
  
                                      if (i3 == l2 - l4 && j < this.field_72994_J.length)
-@@ -2770,10 +2960,10 @@
+@@ -2770,10 +2961,10 @@
      public List<Entity> func_175674_a(@Nullable Entity p_175674_1_, AxisAlignedBB p_175674_2_, @Nullable Predicate <? super Entity > p_175674_3_)
      {
          List<Entity> list = Lists.<Entity>newArrayList();
@@ -711,7 +719,7 @@
  
          for (int i1 = i; i1 <= j; ++i1)
          {
-@@ -2826,10 +3016,10 @@
+@@ -2826,10 +3017,10 @@
  
      public <T extends Entity> List<T> func_175647_a(Class <? extends T > p_175647_1_, AxisAlignedBB p_175647_2_, @Nullable Predicate <? super T > p_175647_3_)
      {
@@ -726,7 +734,7 @@
          List<T> list = Lists.<T>newArrayList();
  
          for (int i1 = i; i1 < j; ++i1)
-@@ -2909,11 +3099,13 @@
+@@ -2909,11 +3100,13 @@
  
      public void func_175650_b(Collection<Entity> p_175650_1_)
      {
@@ -743,7 +751,7 @@
          }
      }
  
-@@ -2926,7 +3118,7 @@
+@@ -2926,7 +3119,7 @@
      {
          IBlockState iblockstate = this.func_180495_p(p_190527_2_);
          AxisAlignedBB axisalignedbb = p_190527_3_ ? null : p_190527_1_.func_176223_P().func_185890_d(this, p_190527_2_);
@@ -752,7 +760,7 @@
      }
  
      public int func_181545_F()
-@@ -3009,7 +3201,7 @@
+@@ -3009,7 +3202,7 @@
      public int func_175651_c(BlockPos p_175651_1_, EnumFacing p_175651_2_)
      {
          IBlockState iblockstate = this.func_180495_p(p_175651_1_);
@@ -761,7 +769,7 @@
      }
  
      public boolean func_175640_z(BlockPos p_175640_1_)
-@@ -3152,6 +3344,8 @@
+@@ -3152,6 +3345,8 @@
                      d2 *= ((Double)Objects.firstNonNull(p_184150_11_.apply(entityplayer1), Double.valueOf(1.0D))).doubleValue();
                  }
  
@@ -770,7 +778,7 @@
                  if ((p_184150_9_ < 0.0D || Math.abs(entityplayer1.field_70163_u - p_184150_3_) < p_184150_9_ * p_184150_9_) && (p_184150_7_ < 0.0D || d1 < d2 * d2) && (d0 == -1.0D || d1 < d0))
                  {
                      d0 = d1;
-@@ -3213,7 +3407,7 @@
+@@ -3213,7 +3408,7 @@
  
      public long func_72905_C()
      {
@@ -779,7 +787,7 @@
      }
  
      public long func_82737_E()
-@@ -3223,17 +3417,17 @@
+@@ -3223,17 +3418,17 @@
  
      public long func_72820_D()
      {
@@ -800,7 +808,7 @@
  
          if (!this.func_175723_af().func_177746_a(blockpos))
          {
-@@ -3245,7 +3439,7 @@
+@@ -3245,7 +3440,7 @@
  
      public void func_175652_B(BlockPos p_175652_1_)
      {
@@ -809,7 +817,7 @@
      }
  
      @SideOnly(Side.CLIENT)
-@@ -3265,12 +3459,18 @@
+@@ -3265,12 +3460,18 @@
  
          if (!this.field_72996_f.contains(p_72897_1_))
          {
@@ -828,7 +836,7 @@
          return true;
      }
  
-@@ -3364,8 +3564,7 @@
+@@ -3364,8 +3565,7 @@
  
      public boolean func_180502_D(BlockPos p_180502_1_)
      {
@@ -838,7 +846,7 @@
      }
  
      @Nullable
-@@ -3426,12 +3625,12 @@
+@@ -3426,12 +3626,12 @@
  
      public int func_72800_K()
      {
@@ -853,7 +861,7 @@
      }
  
      public Random func_72843_D(int p_72843_1_, int p_72843_2_, int p_72843_3_)
-@@ -3475,7 +3674,7 @@
+@@ -3475,7 +3675,7 @@
      @SideOnly(Side.CLIENT)
      public double func_72919_O()
      {
@@ -862,7 +870,7 @@
      }
  
      public void func_175715_c(int p_175715_1_, BlockPos p_175715_2_, int p_175715_3_)
-@@ -3509,7 +3708,7 @@
+@@ -3509,7 +3709,7 @@
  
      public void func_175666_e(BlockPos p_175666_1_, Block p_175666_2_)
      {
@@ -871,7 +879,7 @@
          {
              BlockPos blockpos = p_175666_1_.func_177972_a(enumfacing);
  
-@@ -3517,18 +3716,14 @@
+@@ -3517,18 +3717,14 @@
              {
                  IBlockState iblockstate = this.func_180495_p(blockpos);
  
@@ -894,7 +902,7 @@
                      }
                  }
              }
-@@ -3594,6 +3789,115 @@
+@@ -3594,6 +3790,115 @@
          return i >= -128 && i <= 128 && j >= -128 && j <= 128;
      }
  

--- a/patches/minecraft/net/minecraft/world/chunk/Chunk.java.patch
+++ b/patches/minecraft/net/minecraft/world/chunk/Chunk.java.patch
@@ -144,7 +144,13 @@
  
          return tileentity;
      }
-@@ -806,10 +805,11 @@
+@@ -801,15 +800,17 @@
+         if (this.field_76636_d)
+         {
+             this.field_76637_e.func_175700_a(p_150813_1_);
++            p_150813_1_.onLoad();
+         }
+     }
  
      public void func_177426_a(BlockPos p_177426_1_, TileEntity p_177426_2_)
      {
@@ -157,15 +163,11 @@
          {
              if (this.field_150816_i.containsKey(p_177426_1_))
              {
-@@ -818,6 +818,7 @@
- 
-             p_177426_2_.func_145829_t();
-             this.field_150816_i.put(p_177426_1_, p_177426_2_);
-+            p_177426_2_.onLoad();
-         }
-     }
- 
-@@ -841,8 +842,9 @@
+@@ -838,11 +839,13 @@
+     {
+         this.field_76636_d = true;
+         this.field_76637_e.func_147448_a(this.field_150816_i.values());
++        for (TileEntity te : field_150816_i.values()) te.onLoad();
  
          for (ClassInheritanceMultiMap<Entity> classinheritancemultimap : this.field_76645_j)
          {
@@ -176,7 +178,7 @@
      }
  
      public void func_76623_d()
-@@ -858,6 +860,7 @@
+@@ -858,6 +861,7 @@
          {
              this.field_76637_e.func_175681_c(classinheritancemultimap);
          }
@@ -184,7 +186,7 @@
      }
  
      public void func_76630_e()
-@@ -867,8 +870,8 @@
+@@ -867,8 +871,8 @@
  
      public void func_177414_a(@Nullable Entity p_177414_1_, AxisAlignedBB p_177414_2_, List<Entity> p_177414_3_, Predicate <? super Entity > p_177414_4_)
      {
@@ -195,7 +197,7 @@
          i = MathHelper.func_76125_a(i, 0, this.field_76645_j.length - 1);
          j = MathHelper.func_76125_a(j, 0, this.field_76645_j.length - 1);
  
-@@ -905,8 +908,8 @@
+@@ -905,8 +909,8 @@
  
      public <T extends Entity> void func_177430_a(Class <? extends T > p_177430_1_, AxisAlignedBB p_177430_2_, List<T> p_177430_3_, Predicate <? super T > p_177430_4_)
      {
@@ -206,7 +208,7 @@
          i = MathHelper.func_76125_a(i, 0, this.field_76645_j.length - 1);
          j = MathHelper.func_76125_a(j, 0, this.field_76645_j.length - 1);
  
-@@ -984,6 +987,8 @@
+@@ -984,6 +988,8 @@
  
      protected void func_186034_a(IChunkGenerator p_186034_1_)
      {
@@ -215,7 +217,7 @@
          if (this.func_177419_t())
          {
              if (p_186034_1_.func_185933_a(this, this.field_76635_g, this.field_76647_h))
-@@ -995,8 +1000,10 @@
+@@ -995,8 +1001,10 @@
          {
              this.func_150809_p();
              p_186034_1_.func_185931_b(this.field_76635_g, this.field_76647_h);
@@ -226,7 +228,7 @@
      }
  
      public BlockPos func_177440_h(BlockPos p_177440_1_)
-@@ -1051,7 +1058,7 @@
+@@ -1051,7 +1059,7 @@
          {
              BlockPos blockpos = (BlockPos)this.field_177447_w.poll();
  
@@ -235,7 +237,7 @@
              {
                  TileEntity tileentity = this.func_177422_i(blockpos);
                  this.field_76637_e.func_175690_a(blockpos, tileentity);
-@@ -1115,6 +1122,13 @@
+@@ -1115,6 +1123,13 @@
      @SideOnly(Side.CLIENT)
      public void func_186033_a(PacketBuffer p_186033_1_, int p_186033_2_, boolean p_186033_3_)
      {
@@ -249,7 +251,7 @@
          boolean flag = this.field_76637_e.field_73011_w.func_191066_m();
  
          for (int i = 0; i < this.field_76652_q.length; ++i)
-@@ -1163,10 +1177,16 @@
+@@ -1163,10 +1178,16 @@
          this.field_76646_k = true;
          this.func_76590_a();
  
@@ -266,7 +268,7 @@
      }
  
      public Biome func_177411_a(BlockPos p_177411_1_, BiomeProvider p_177411_2_)
-@@ -1231,13 +1251,13 @@
+@@ -1231,13 +1252,13 @@
                      BlockPos blockpos1 = blockpos.func_177982_a(k, (j << 4) + i1, l);
                      boolean flag = i1 == 0 || i1 == 15 || k == 0 || k == 15 || l == 0 || l == 15;
  
@@ -282,7 +284,7 @@
                              {
                                  this.field_76637_e.func_175664_x(blockpos2);
                              }
-@@ -1368,7 +1388,7 @@
+@@ -1368,7 +1389,7 @@
          {
              blockpos$mutableblockpos.func_181079_c(blockpos$mutableblockpos.func_177958_n(), l, blockpos$mutableblockpos.func_177952_p());
  
@@ -291,7 +293,7 @@
              {
                  this.field_76637_e.func_175664_x(blockpos$mutableblockpos);
              }
-@@ -1476,4 +1496,34 @@
+@@ -1476,4 +1497,34 @@
          QUEUED,
          CHECK;
      }

--- a/patches/minecraft/net/minecraft/world/chunk/Chunk.java.patch
+++ b/patches/minecraft/net/minecraft/world/chunk/Chunk.java.patch
@@ -144,13 +144,7 @@
  
          return tileentity;
      }
-@@ -801,15 +800,17 @@
-         if (this.field_76636_d)
-         {
-             this.field_76637_e.func_175700_a(p_150813_1_);
-+            p_150813_1_.onLoad();
-         }
-     }
+@@ -806,10 +805,11 @@
  
      public void func_177426_a(BlockPos p_177426_1_, TileEntity p_177426_2_)
      {
@@ -163,11 +157,7 @@
          {
              if (this.field_150816_i.containsKey(p_177426_1_))
              {
-@@ -838,11 +839,13 @@
-     {
-         this.field_76636_d = true;
-         this.field_76637_e.func_147448_a(this.field_150816_i.values());
-+        for (TileEntity te : field_150816_i.values()) te.onLoad();
+@@ -841,8 +841,9 @@
  
          for (ClassInheritanceMultiMap<Entity> classinheritancemultimap : this.field_76645_j)
          {
@@ -178,7 +168,7 @@
      }
  
      public void func_76623_d()
-@@ -858,6 +861,7 @@
+@@ -858,6 +859,7 @@
          {
              this.field_76637_e.func_175681_c(classinheritancemultimap);
          }
@@ -186,7 +176,7 @@
      }
  
      public void func_76630_e()
-@@ -867,8 +871,8 @@
+@@ -867,8 +869,8 @@
  
      public void func_177414_a(@Nullable Entity p_177414_1_, AxisAlignedBB p_177414_2_, List<Entity> p_177414_3_, Predicate <? super Entity > p_177414_4_)
      {
@@ -197,7 +187,7 @@
          i = MathHelper.func_76125_a(i, 0, this.field_76645_j.length - 1);
          j = MathHelper.func_76125_a(j, 0, this.field_76645_j.length - 1);
  
-@@ -905,8 +909,8 @@
+@@ -905,8 +907,8 @@
  
      public <T extends Entity> void func_177430_a(Class <? extends T > p_177430_1_, AxisAlignedBB p_177430_2_, List<T> p_177430_3_, Predicate <? super T > p_177430_4_)
      {
@@ -208,7 +198,7 @@
          i = MathHelper.func_76125_a(i, 0, this.field_76645_j.length - 1);
          j = MathHelper.func_76125_a(j, 0, this.field_76645_j.length - 1);
  
-@@ -984,6 +988,8 @@
+@@ -984,6 +986,8 @@
  
      protected void func_186034_a(IChunkGenerator p_186034_1_)
      {
@@ -217,7 +207,7 @@
          if (this.func_177419_t())
          {
              if (p_186034_1_.func_185933_a(this, this.field_76635_g, this.field_76647_h))
-@@ -995,8 +1001,10 @@
+@@ -995,8 +999,10 @@
          {
              this.func_150809_p();
              p_186034_1_.func_185931_b(this.field_76635_g, this.field_76647_h);
@@ -228,7 +218,7 @@
      }
  
      public BlockPos func_177440_h(BlockPos p_177440_1_)
-@@ -1051,7 +1059,7 @@
+@@ -1051,7 +1057,7 @@
          {
              BlockPos blockpos = (BlockPos)this.field_177447_w.poll();
  
@@ -237,7 +227,7 @@
              {
                  TileEntity tileentity = this.func_177422_i(blockpos);
                  this.field_76637_e.func_175690_a(blockpos, tileentity);
-@@ -1115,6 +1123,13 @@
+@@ -1115,6 +1121,13 @@
      @SideOnly(Side.CLIENT)
      public void func_186033_a(PacketBuffer p_186033_1_, int p_186033_2_, boolean p_186033_3_)
      {
@@ -251,7 +241,7 @@
          boolean flag = this.field_76637_e.field_73011_w.func_191066_m();
  
          for (int i = 0; i < this.field_76652_q.length; ++i)
-@@ -1163,10 +1178,16 @@
+@@ -1163,10 +1176,16 @@
          this.field_76646_k = true;
          this.func_76590_a();
  
@@ -268,7 +258,7 @@
      }
  
      public Biome func_177411_a(BlockPos p_177411_1_, BiomeProvider p_177411_2_)
-@@ -1231,13 +1252,13 @@
+@@ -1231,13 +1250,13 @@
                      BlockPos blockpos1 = blockpos.func_177982_a(k, (j << 4) + i1, l);
                      boolean flag = i1 == 0 || i1 == 15 || k == 0 || k == 15 || l == 0 || l == 15;
  
@@ -284,7 +274,7 @@
                              {
                                  this.field_76637_e.func_175664_x(blockpos2);
                              }
-@@ -1368,7 +1389,7 @@
+@@ -1368,7 +1387,7 @@
          {
              blockpos$mutableblockpos.func_181079_c(blockpos$mutableblockpos.func_177958_n(), l, blockpos$mutableblockpos.func_177952_p());
  
@@ -293,7 +283,7 @@
              {
                  this.field_76637_e.func_175664_x(blockpos$mutableblockpos);
              }
-@@ -1476,4 +1497,34 @@
+@@ -1476,4 +1495,34 @@
          QUEUED,
          CHECK;
      }

--- a/src/test/java/net/minecraftforge/test/TileEntityLoadingTest.java
+++ b/src/test/java/net/minecraftforge/test/TileEntityLoadingTest.java
@@ -1,0 +1,70 @@
+package net.minecraftforge.test;
+
+import net.minecraft.block.Block;
+import net.minecraft.block.material.Material;
+import net.minecraft.block.state.IBlockState;
+import net.minecraft.creativetab.CreativeTabs;
+import net.minecraft.item.ItemBlock;
+import net.minecraft.tileentity.TileEntity;
+import net.minecraft.world.World;
+import net.minecraftforge.fml.common.Mod;
+import net.minecraftforge.fml.common.event.FMLPreInitializationEvent;
+import net.minecraftforge.fml.common.registry.GameRegistry;
+import org.apache.logging.log4j.Logger;
+
+import javax.annotation.Nullable;
+
+@Mod(modid = TileEntityLoadingTest.MOD_ID, name = "TileEntity#onLoad() test mod", version = "1.0")
+public class TileEntityLoadingTest
+{
+    static final String MOD_ID = "te_loading_test";
+    static final boolean DEBUG = false;
+
+    private static Logger logger;
+    private static final Block testBlock = new TestBlock();
+
+    @Mod.EventHandler
+    public static void preInit(FMLPreInitializationEvent event)
+    {
+        logger = event.getModLog();
+        GameRegistry.register(testBlock);
+        GameRegistry.register(new ItemBlock(testBlock).setRegistryName(testBlock.getRegistryName()));
+        GameRegistry.registerTileEntity(TestTE.class, testBlock.getRegistryName().toString());
+    }
+
+    public static class TestBlock extends Block
+    {
+        static final String NAME = "test_block";
+
+        TestBlock()
+        {
+            super(Material.ANVIL);
+            setRegistryName(NAME);
+            setUnlocalizedName(MOD_ID + "." + NAME);
+            setCreativeTab(CreativeTabs.BUILDING_BLOCKS);
+        }
+
+        @Override
+        public boolean hasTileEntity(IBlockState state)
+        {
+            return true;
+        }
+
+        @Nullable
+        @Override
+        public TileEntity createTileEntity(World world, IBlockState state)
+        {
+            return new TestTE();
+        }
+    }
+
+    public static class TestTE extends TileEntity
+    {
+        @Override
+        public void onLoad()
+        {
+            logger.info("World: " + world + ", Pos: " + pos + ", State: " + world.getBlockState(pos));
+            if (DEBUG) logger.trace("Stack trace:", new Exception());
+        }
+    }
+}


### PR DESCRIPTION
This relocates the call to `TileEntity#onLoad()` from after the tile entity is added to the chunk's tile entity map, to after the tile entity is added to the world.
As a result it is possible to safely access the world from this function without causing a crash (see #3075, #2365).
This allows more tile entities to be able to use `onLoad()` instead of being tickable and having an `if (firstTick)` check in `update()`.