### PR TITLE
Update EntityPlayer armor calculations and ISpecialArmor

### DIFF
--- a/patches/minecraft/net/minecraft/enchantment/EnchantmentThorns.java.patch
+++ b/patches/minecraft/net/minecraft/enchantment/EnchantmentThorns.java.patch
@@ -23,7 +23,6 @@
 +    private void damageArmor(ItemStack stack, int amount, EntityLivingBase entity)
 +    {
 +        EntityEquipmentSlot targetSlot = null;
-+        int x = 0;
 +        for (EntityEquipmentSlot slot : EntityEquipmentSlot.values())
 +        {
 +            if (slot.func_188453_a() == EntityEquipmentSlot.Type.ARMOR)
@@ -33,7 +32,6 @@
 +                    targetSlot = slot;
 +                    break;
 +                }
-+                x++;
 +            }
 +        }
 +        if (targetSlot == null || !(stack.func_77973_b() instanceof net.minecraftforge.common.ISpecialArmor))

--- a/patches/minecraft/net/minecraft/enchantment/EnchantmentThorns.java.patch
+++ b/patches/minecraft/net/minecraft/enchantment/EnchantmentThorns.java.patch
@@ -22,22 +22,26 @@
 +
 +    private void damageArmor(ItemStack stack, int amount, EntityLivingBase entity)
 +    {
-+        int slot = -1;
++        EntityEquipmentSlot targetSlot = null;
 +        int x = 0;
-+        for (ItemStack i : entity.func_184193_aE())
++        for (EntityEquipmentSlot slot : EntityEquipmentSlot.values())
 +        {
-+            if (i == stack){
-+                slot = x;
-+                break;
++            if (slot.func_188453_a() == EntityEquipmentSlot.Type.ARMOR)
++            {
++                if (entity.func_184582_a(slot) == stack)
++                {
++                    targetSlot = slot;
++                    break;
++                }
++                x++;
 +            }
-+            x++;
 +        }
-+        if (slot == -1 || !(stack.func_77973_b() instanceof net.minecraftforge.common.ISpecialArmor))
++        if (targetSlot == null || !(stack.func_77973_b() instanceof net.minecraftforge.common.ISpecialArmor))
 +        {
 +            stack.func_77972_a(1, entity);
 +            return;
 +        }
 +        net.minecraftforge.common.ISpecialArmor armor = (net.minecraftforge.common.ISpecialArmor)stack.func_77973_b();
-+        armor.damageArmor(entity, stack, DamageSource.func_92087_a(entity), amount, slot);
++        armor.damageArmor(entity, stack, DamageSource.func_92087_a(entity), amount, targetSlot);
 +    }
  }

--- a/patches/minecraft/net/minecraft/enchantment/EnchantmentThorns.java.patch
+++ b/patches/minecraft/net/minecraft/enchantment/EnchantmentThorns.java.patch
@@ -22,24 +22,22 @@
 +
 +    private void damageArmor(ItemStack stack, int amount, EntityLivingBase entity)
 +    {
-+        EntityEquipmentSlot targetSlot = null;
-+        for (EntityEquipmentSlot slot : EntityEquipmentSlot.values())
++        int slot = -1;
++        int x = 0;
++        for (ItemStack i : entity.func_184193_aE())
 +        {
-+            if (slot.func_188453_a() == EntityEquipmentSlot.Type.ARMOR)
-+            {
-+                if (entity.func_184582_a(slot) == stack)
-+                {
-+                    targetSlot = slot;
-+                    break;
-+                }
++            if (i == stack){
++                slot = x;
++                break;
 +            }
++            x++;
 +        }
-+        if (targetSlot == null || !(stack.func_77973_b() instanceof net.minecraftforge.common.ISpecialArmor))
++        if (slot == -1 || !(stack.func_77973_b() instanceof net.minecraftforge.common.ISpecialArmor))
 +        {
 +            stack.func_77972_a(1, entity);
 +            return;
 +        }
 +        net.minecraftforge.common.ISpecialArmor armor = (net.minecraftforge.common.ISpecialArmor)stack.func_77973_b();
-+        armor.damageArmor(entity, stack, DamageSource.func_92087_a(entity), amount, targetSlot);
++        armor.damageArmor(entity, stack, DamageSource.func_92087_a(entity), amount, slot);
 +    }
  }

--- a/src/main/java/net/minecraftforge/common/ForgeHooks.java
+++ b/src/main/java/net/minecraftforge/common/ForgeHooks.java
@@ -269,7 +269,7 @@ public class ForgeHooks
 
     public static int getTotalArmorValue(EntityPlayer player)
     {
-        int ret = 0;
+        int ret = player.getTotalArmorValue();
         for (EntityEquipmentSlot slot : EntityEquipmentSlot.values())
         {
             if (slot.getSlotType() == EntityEquipmentSlot.Type.ARMOR)
@@ -278,10 +278,6 @@ public class ForgeHooks
                 if (stack.getItem() instanceof ISpecialArmor)
                 {
                     ret += ((ISpecialArmor)stack.getItem()).getArmorDisplay(player, stack, slot);
-                }
-                else if (stack.getItem() instanceof ItemArmor)
-                {
-                    ret += ((ItemArmor)stack.getItem()).damageReduceAmount;
                 }
             }
         }

--- a/src/main/java/net/minecraftforge/common/ForgeHooks.java
+++ b/src/main/java/net/minecraftforge/common/ForgeHooks.java
@@ -270,15 +270,12 @@ public class ForgeHooks
     public static int getTotalArmorValue(EntityPlayer player)
     {
         int ret = player.getTotalArmorValue();
-        for (EntityEquipmentSlot slot : EntityEquipmentSlot.values())
+        for (int x = 0; x < player.inventory.armorInventory.size(); x++)
         {
-            if (slot.getSlotType() == EntityEquipmentSlot.Type.ARMOR)
+            ItemStack stack = player.inventory.armorInventory.get(x);
+            if (stack.getItem() instanceof ISpecialArmor)
             {
-                ItemStack stack = player.getItemStackFromSlot(slot);
-                if (stack.getItem() instanceof ISpecialArmor)
-                {
-                    ret += ((ISpecialArmor)stack.getItem()).getArmorDisplay(player, stack, slot);
-                }
+                ret += ((ISpecialArmor)stack.getItem()).getArmorDisplay(player, stack, x);
             }
         }
         return ret;

--- a/src/main/java/net/minecraftforge/common/ForgeHooks.java
+++ b/src/main/java/net/minecraftforge/common/ForgeHooks.java
@@ -55,6 +55,7 @@ import net.minecraft.entity.projectile.EntityThrowable;
 import net.minecraft.init.Blocks;
 import net.minecraft.init.Items;
 import net.minecraft.inventory.ContainerRepair;
+import net.minecraft.inventory.EntityEquipmentSlot;
 import net.minecraft.inventory.IInventory;
 import net.minecraft.inventory.InventoryCrafting;
 import net.minecraft.item.ItemArmor;
@@ -269,16 +270,19 @@ public class ForgeHooks
     public static int getTotalArmorValue(EntityPlayer player)
     {
         int ret = 0;
-        for (int x = 0; x < player.inventory.armorInventory.size(); x++)
+        for (EntityEquipmentSlot slot : EntityEquipmentSlot.values())
         {
-            ItemStack stack = player.inventory.armorInventory.get(x);
-            if (stack.getItem() instanceof ISpecialArmor)
+            if (slot.getSlotType() == EntityEquipmentSlot.Type.ARMOR)
             {
-                ret += ((ISpecialArmor)stack.getItem()).getArmorDisplay(player, stack, x);
-            }
-            else if (stack.getItem() instanceof ItemArmor)
-            {
-                ret += ((ItemArmor)stack.getItem()).damageReduceAmount;
+                ItemStack stack = player.getItemStackFromSlot(slot);
+                if (stack.getItem() instanceof ISpecialArmor)
+                {
+                    ret += ((ISpecialArmor)stack.getItem()).getArmorDisplay(player, stack, slot);
+                }
+                else if (stack.getItem() instanceof ItemArmor)
+                {
+                    ret += ((ItemArmor)stack.getItem()).damageReduceAmount;
+                }
             }
         }
         return ret;

--- a/src/main/java/net/minecraftforge/common/ISpecialArmor.java
+++ b/src/main/java/net/minecraftforge/common/ISpecialArmor.java
@@ -48,6 +48,7 @@ import javax.annotation.Nonnull;
  */
 public interface ISpecialArmor
 {
+    //TODO: Change 'int slot' to EnumArmorType
     /**
      * Retrieves the modifiers to be used when calculating armor damage.
      *
@@ -222,9 +223,7 @@ public interface ISpecialArmor
                         }
                     }
                 }
-                System.out.println(damage);
                 damage = CombatRules.getDamageAfterAbsorb((float)damage, (float)totalArmor, (float)totalToughness);
-                System.out.println(damage);
             }
             if (DEBUG)
             {

--- a/src/main/java/net/minecraftforge/common/ISpecialArmor.java
+++ b/src/main/java/net/minecraftforge/common/ISpecialArmor.java
@@ -201,26 +201,26 @@ public interface ISpecialArmor
                     }
                 }
                 damage -= (damage * ratio);
+            }
+            if (damage > 0 && (totalArmor > 0 || totalToughness > 0))
+            {
+                double armorDamage = Math.max(1.0F, damage / 4.0F);
                 
-                if (damage > 0)
+                for (int i = 0; i < inventory.size(); i++)
                 {
-                    double armorDamage = Math.max(1.0F, damage / 4.0F);
-                    
-                    for (int i = 0; i < inventory.size(); i++)
+                    if (inventory.get(i).getItem() instanceof ItemArmor)
                     {
-                        if (inventory.get(i).getItem() instanceof ItemArmor)
+                        inventory.get(i).damageItem((int)armorDamage, entity);
+                        
+                        if (inventory.get(i).getCount() == 0)
                         {
-                            inventory.get(i).damageItem((int)armorDamage, entity);
-                            
-                            if (inventory.get(i).getCount() == 0)
-                            {
-                                inventory.set(i, ItemStack.EMPTY);
-                            }
+                            inventory.set(i, ItemStack.EMPTY);
                         }
                     }
-                    
-                    damage = CombatRules.getDamageAfterAbsorb((float)damage, (float)totalArmor, (float)totalToughness);
                 }
+                System.out.println(damage);
+                damage = CombatRules.getDamageAfterAbsorb((float)damage, (float)totalArmor, (float)totalToughness);
+                System.out.println(damage);
             }
             if (DEBUG)
             {

--- a/src/main/java/net/minecraftforge/common/ISpecialArmor.java
+++ b/src/main/java/net/minecraftforge/common/ISpecialArmor.java
@@ -101,6 +101,11 @@ public interface ISpecialArmor
         private static final boolean DEBUG = false; //Only enable this if you wish to be spammed with debugging information.
                                                     //Left it in because I figured it'd be useful for modders developing custom armor.
 
+        public ArmorProperties(int priority, double ratio, int max)
+        {
+            this(priority, ratio, 0, 0, max);
+        }
+        
         public ArmorProperties(int priority, double ratio, double armor, double toughness, int max)
         {
             Priority    = priority;

--- a/src/main/java/net/minecraftforge/common/ISpecialArmor.java
+++ b/src/main/java/net/minecraftforge/common/ISpecialArmor.java
@@ -64,7 +64,7 @@ public interface ISpecialArmor
      * @param slot The armor slot the item is in.
      * @return A ArmorProperties instance holding information about how the armor effects damage.
      */
-    public ArmorProperties getProperties(EntityLivingBase player, @Nonnull ItemStack armor, DamageSource source, double damage, EntityEquipmentSlot slot);
+    public ArmorProperties getProperties(EntityLivingBase player, @Nonnull ItemStack armor, DamageSource source, double damage, int slot);
 
     /**
      * Get the displayed effective armor.
@@ -74,7 +74,7 @@ public interface ISpecialArmor
      * @param slot The armor slot the item is in.
      * @return The number of armor points for display, 2 per shield.
      */
-    public abstract int getArmorDisplay(EntityPlayer player, @Nonnull ItemStack armor, EntityEquipmentSlot slot);
+    public abstract int getArmorDisplay(EntityPlayer player, @Nonnull ItemStack armor, int slot);
 
     /**
      * Applies damage to the ItemStack. The mod is responsible for reducing the
@@ -88,7 +88,7 @@ public interface ISpecialArmor
      * @param damage The amount of damage being applied to the armor
      * @param slot The armor slot the item is in.
      */
-    public abstract void damageArmor(EntityLivingBase entity, @Nonnull ItemStack stack, DamageSource source, int damage, EntityEquipmentSlot slot);
+    public abstract void damageArmor(EntityLivingBase entity, @Nonnull ItemStack stack, DamageSource source, int damage, int slot);
 
     public static class ArmorProperties implements Comparable<ArmorProperties>
     {
@@ -97,7 +97,7 @@ public interface ISpecialArmor
         public double AbsorbRatio       = 0;
         public double Armor             = 0;        //Additional armor, separate from the armor added by vanilla attributes.
         public double Toughness         = 0;        //Additional toughness, separate from the armor added by vanilla attributes.
-        public EntityEquipmentSlot Slot = EntityEquipmentSlot.CHEST;
+        public int Slot                 = 0;
         private static final boolean DEBUG = false; //Only enable this if you wish to be spammed with debugging information.
                                                     //Left it in because I figured it'd be useful for modders developing custom armor.
 
@@ -135,14 +135,15 @@ public interface ISpecialArmor
             double totalToughness = entity.getEntityAttribute(SharedMonsterAttributes.ARMOR_TOUGHNESS).getAttributeValue();
 
             ArrayList<ArmorProperties> dmgVals = new ArrayList<ArmorProperties>();
-            for (EntityEquipmentSlot slot : EntityEquipmentSlot.values())
+            for (int slot = 0; slot < inventory.size(); slot++)
             {
-                if (slot.getSlotType() != EntityEquipmentSlot.Type.ARMOR)
+                ItemStack stack = inventory.get(slot);
+                
+                if (stack.isEmpty())
                 {
                     continue;
                 }
                 
-                ItemStack stack = inventory.get(slot.getIndex());
                 ArmorProperties prop = null;
                 if (stack.getItem() instanceof ISpecialArmor)
                 {
@@ -181,7 +182,7 @@ public interface ISpecialArmor
                     double absorb = damage * prop.AbsorbRatio;
                     if (absorb > 0)
                     {
-                        ItemStack stack = inventory.get(prop.Slot.getIndex());
+                        ItemStack stack = inventory.get(prop.Slot);
                         int itemDamage = (int)Math.max(1, absorb);
                         if (stack.getItem() instanceof ISpecialArmor)
                         {
@@ -201,7 +202,7 @@ public interface ISpecialArmor
                             {
                                 stack.onItemDestroyedByUse((EntityPlayer)entity);
                             }*/
-                            inventory.set(prop.Slot.getIndex(), ItemStack.EMPTY);
+                            inventory.set(prop.Slot, ItemStack.EMPTY);
                         }
                     }
                 }

--- a/src/main/java/net/minecraftforge/common/ISpecialArmor.java
+++ b/src/main/java/net/minecraftforge/common/ISpecialArmor.java
@@ -101,17 +101,13 @@ public interface ISpecialArmor
         private static final boolean DEBUG = false; //Only enable this if you wish to be spammed with debugging information.
                                                     //Left it in because I figured it'd be useful for modders developing custom armor.
 
-        public ArmorProperties(int priority, double ratio, int max)
-        {
-            this(priority, ratio, 0, 0, max);
-        }
         
-        public ArmorProperties(int priority, double ratio, double armor, double toughness, int max)
+        public ArmorProperties(int priority, double ratio, int max)
         {
             Priority    = priority;
             AbsorbRatio = ratio;
-            Armor       = armor;
-            Toughness   = toughness;
+            Armor       = 0;
+            Toughness   = 0;
             AbsorbMax   = max;
         }
 

--- a/src/main/java/net/minecraftforge/common/ISpecialArmor.java
+++ b/src/main/java/net/minecraftforge/common/ISpecialArmor.java
@@ -151,7 +151,9 @@ public interface ISpecialArmor
                 else if (stack.getItem() instanceof ItemArmor && !source.isUnblockable())
                 {
                     ItemArmor armor = (ItemArmor)stack.getItem();
-                    prop = new ArmorProperties(0, 0, armor.damageReduceAmount, armor.toughness, Integer.MAX_VALUE);
+                    prop = new ArmorProperties(0, 0, Integer.MAX_VALUE);
+                    prop.Armor = armor.damageReduceAmount;
+                    prop.Toughness = armor.toughness;
                 }
                 if (prop != null)
                 {
@@ -370,7 +372,10 @@ public interface ISpecialArmor
 
         public ArmorProperties copy()
         {
-            return new ArmorProperties(Priority, AbsorbRatio, Armor, Toughness, AbsorbMax);
+            ArmorProperties copy = new ArmorProperties(Priority, AbsorbRatio, AbsorbMax);
+            copy.Armor = Armor;
+            copy.Toughness = Toughness;
+            return copy;
         }
     }
 }

--- a/src/test/java/net/minecraftforge/test/PlayerDamageReworkTest.java
+++ b/src/test/java/net/minecraftforge/test/PlayerDamageReworkTest.java
@@ -1,0 +1,47 @@
+package net.minecraftforge.test;
+
+import java.util.UUID;
+
+import net.minecraft.entity.SharedMonsterAttributes;
+import net.minecraft.entity.ai.attributes.AttributeModifier;
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraftforge.common.MinecraftForge;
+import net.minecraftforge.event.entity.living.LivingEvent.LivingUpdateEvent;
+import net.minecraftforge.fml.common.Mod;
+import net.minecraftforge.fml.common.Mod.EventHandler;
+import net.minecraftforge.fml.common.event.FMLInitializationEvent;
+import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
+
+@Mod(modid = "playerdamagereworktest", name = "PlayerDamageReworkTest", version = "0.0.0")
+public class PlayerDamageReworkTest
+{
+    private static final boolean ENABLE = false;
+    private static final UUID ARMOR_MODIFIER_UUID = UUID.fromString("23373DC8-1F3D-11E7-93AE-92361F002671");
+    private static final AttributeModifier mod = new AttributeModifier(ARMOR_MODIFIER_UUID, "Player Damage Rework Test", 20, 0);
+
+    @EventHandler
+    public void init(FMLInitializationEvent event)
+    {
+        if (ENABLE) MinecraftForge.EVENT_BUS.register(this);
+    }
+
+    @SubscribeEvent
+    public void checkForSneakEvent(LivingUpdateEvent event)
+    {
+        if (event.getEntityLiving() instanceof EntityPlayer)
+        {
+            EntityPlayer player = (EntityPlayer) event.getEntityLiving();
+            if (player.isSneaking())
+            {
+                if (!player.getEntityAttribute(SharedMonsterAttributes.ARMOR).hasModifier(mod))
+                {
+                    player.getEntityAttribute(SharedMonsterAttributes.ARMOR).applyModifier(mod);
+                }
+            }
+            else if (player.getEntityAttribute(SharedMonsterAttributes.ARMOR).hasModifier(mod))
+            {
+                player.getEntityAttribute(SharedMonsterAttributes.ARMOR).removeModifier(ARMOR_MODIFIER_UUID);
+            }
+        }
+    }
+}


### PR DESCRIPTION
This pull request resolves #3095 and #2720. This is an updated version of  #2765 for 1.11 with the inclusion of the 1.9.1 armor toughness attribute. The PR was updated in response to mezz's request on the original.

It implements three key changes.

First, the ISpecialArmor class now takes EntityEquipmentSlots as arguments instead of integers, modernizing the class to new inventory standards. These changes were a part of WayofTime's initial PR. If they are not desired, I can update the PR to remove them.

Second, ISpecialArmor's ArmorProperties now contains two additional constructor parameters, armor and toughness. These allow ISpecialArmor instances to grant armor points and toughness in the same manner as vanilla armor. This enables changes to the damage reduction formula and to allows armor to be created with a mixture of flat percentage reduction and vanilla armor.

ISpecialArmor now undergoes a two-step hybrid damage reduction / armor damage process. ISpecialArmor's flat percentage damage reduction is applied as before, and armor is damaged accordingly. Then, vanilla calculations are applied for any armor points and toughness assigned to each piece of armor, with armor pieces again damaged accordingly.

Until this point Forge does not handle armor toughness in any way, meaning that Diamond Armor does not operate to vanilla specifications in Forge after 1.9.1.

Finally, this new system enables player attribute modifiers for ARMOR and ARMOR_TOUGHNESS to take effect. This allows items from vanilla adventure maps which carry the attribute to function correctly. This also enables modders to affect the player's armor and armor toughness values, meaning that they could implement armor potions or spells.


A test mod (disabled by default) is included with this PR. It adds diamond-level armor protection to the player while sneaking.