### PR TITLE
Make hopper update accessible to subclasses

### DIFF
--- a/patches/minecraft/net/minecraft/tileentity/TileEntityHopper.java.patch
+++ b/patches/minecraft/net/minecraft/tileentity/TileEntityHopper.java.patch
@@ -1,14 +1,5 @@
 --- ../src-base/minecraft/net/minecraft/tileentity/TileEntityHopper.java
 +++ ../src-work/minecraft/net/minecraft/tileentity/TileEntityHopper.java
-@@ -124,7 +124,7 @@
-         }
-     }
- 
--    private boolean func_145887_i()
-+    protected boolean func_145887_i()
-     {
-         if (this.field_145850_b != null && !this.field_145850_b.field_72995_K)
-         {
 @@ -191,6 +191,7 @@
  
      private boolean func_145883_k()

--- a/patches/minecraft/net/minecraft/tileentity/TileEntityHopper.java.patch
+++ b/patches/minecraft/net/minecraft/tileentity/TileEntityHopper.java.patch
@@ -1,5 +1,14 @@
 --- ../src-base/minecraft/net/minecraft/tileentity/TileEntityHopper.java
 +++ ../src-work/minecraft/net/minecraft/tileentity/TileEntityHopper.java
+@@ -124,7 +124,7 @@
+         }
+     }
+ 
+-    private boolean func_145887_i()
++    protected boolean func_145887_i()
+     {
+         if (this.field_145850_b != null && !this.field_145850_b.field_72995_K)
+         {
 @@ -191,6 +191,7 @@
  
      private boolean func_145883_k()

--- a/src/main/resources/forge_at.cfg
+++ b/src/main/resources/forge_at.cfg
@@ -289,7 +289,7 @@ public net.minecraft.potion.PotionHelper func_185204_a(Lnet/minecraft/potion/Pot
 # TileEntityHopper
 public net.minecraft.tileentity.TileEntityHopper func_174914_o()Z # mayTransfer
 public net.minecraft.tileentity.TileEntityHopper func_145896_c(I)V # setTransferCooldown
-protected net.minecraft.tileentity.TileEntityHopper func_145887_i # updateHopper
+protected net.minecraft.tileentity.TileEntityHopper func_145887_i()Z # updateHopper
 
 # DataFixer
 public net.minecraft.util.datafix.DataFixer field_188262_d # version

--- a/src/main/resources/forge_at.cfg
+++ b/src/main/resources/forge_at.cfg
@@ -289,6 +289,7 @@ public net.minecraft.potion.PotionHelper func_185204_a(Lnet/minecraft/potion/Pot
 # TileEntityHopper
 public net.minecraft.tileentity.TileEntityHopper func_174914_o()Z # mayTransfer
 public net.minecraft.tileentity.TileEntityHopper func_145896_c(I)V # setTransferCooldown
+protected net.minecraft.tileentity.TileEntityHopper func_145887_i # updateHopper
 
 # DataFixer
 public net.minecraft.util.datafix.DataFixer field_188262_d # version


### PR DESCRIPTION
Having to re-create hopper base functionality in order to create hopper-like blocks by copying over multiple methods (`updateHopper`, `isOnTransferCooldown`, `isInventoryEmpty`, `transferItemsOut`, `isInventoryFull` `getInventoryForHopperTransfer` as well as the `transferCooldown` and inventory fields) is just dumb.

It was public in 1.10 and I was utilizing it for one of my mods to create several variant hoppers.  I can see the need to revoke public access (other classes should not be able to call it) but sublcasses should have access.