### PR TITLE
Allow for custom elytra

### DIFF
--- a/patches/minecraft/net/minecraft/client/entity/EntityPlayerSP.java.patch
+++ b/patches/minecraft/net/minecraft/client/entity/EntityPlayerSP.java.patch
@@ -94,7 +94,7 @@
              ItemStack itemstack = this.func_184582_a(EntityEquipmentSlot.CHEST);
  
 -            if (itemstack.func_77973_b() == Items.field_185160_cR && ItemElytra.func_185069_d(itemstack))
-+            if (itemstack.func_77973_b() instanceof net.minecraft.item.ItemElytra && ((net.minecraft.item.ItemElytra) itemstack.func_77973_b()).func_185069_d(itemstack))
++            if (itemstack.func_77973_b() instanceof ItemElytra && ItemElytra.func_185069_d(itemstack))
              {
                  this.field_71174_a.func_147297_a(new CPacketEntityAction(this, CPacketEntityAction.Action.START_FALL_FLYING));
              }

--- a/patches/minecraft/net/minecraft/client/entity/EntityPlayerSP.java.patch
+++ b/patches/minecraft/net/minecraft/client/entity/EntityPlayerSP.java.patch
@@ -89,3 +89,12 @@
      }
  
      public boolean func_70613_aW()
+@@ -890,7 +911,7 @@
+         {
+             ItemStack itemstack = this.func_184582_a(EntityEquipmentSlot.CHEST);
+ 
+-            if (itemstack.func_77973_b() == Items.field_185160_cR && ItemElytra.func_185069_d(itemstack))
++            if (itemstack.func_77973_b() instanceof net.minecraft.item.ItemElytra && ((net.minecraft.item.ItemElytra) itemstack.func_77973_b()).func_185069_d(itemstack))
+             {
+                 this.field_71174_a.func_147297_a(new CPacketEntityAction(this, CPacketEntityAction.Action.START_FALL_FLYING));
+             }

--- a/patches/minecraft/net/minecraft/client/renderer/entity/layers/LayerCape.java.patch
+++ b/patches/minecraft/net/minecraft/client/renderer/entity/layers/LayerCape.java.patch
@@ -1,0 +1,11 @@
+--- ../src-base/minecraft/net/minecraft/client/renderer/entity/layers/LayerCape.java
++++ ../src-work/minecraft/net/minecraft/client/renderer/entity/layers/LayerCape.java
+@@ -27,7 +27,7 @@
+         {
+             ItemStack itemstack = p_177141_1_.func_184582_a(EntityEquipmentSlot.CHEST);
+ 
+-            if (itemstack.func_77973_b() != Items.field_185160_cR)
++            if (!(itemstack.func_77973_b() instanceof net.minecraft.item.ItemElytra))
+             {
+                 GlStateManager.func_179131_c(1.0F, 1.0F, 1.0F, 1.0F);
+                 this.field_177167_a.func_110776_a(p_177141_1_.func_110303_q());

--- a/patches/minecraft/net/minecraft/client/renderer/entity/layers/LayerElytra.java.patch
+++ b/patches/minecraft/net/minecraft/client/renderer/entity/layers/LayerElytra.java.patch
@@ -1,0 +1,11 @@
+--- ../src-base/minecraft/net/minecraft/client/renderer/entity/layers/LayerElytra.java
++++ ../src-work/minecraft/net/minecraft/client/renderer/entity/layers/LayerElytra.java
+@@ -29,7 +29,7 @@
+     {
+         ItemStack itemstack = p_177141_1_.func_184582_a(EntityEquipmentSlot.CHEST);
+ 
+-        if (itemstack.func_77973_b() == Items.field_185160_cR)
++        if (itemstack.func_77973_b() instanceof net.minecraft.item.ItemElytra)
+         {
+             GlStateManager.func_179131_c(1.0F, 1.0F, 1.0F, 1.0F);
+             GlStateManager.func_179147_l();

--- a/patches/minecraft/net/minecraft/entity/EntityLivingBase.java.patch
+++ b/patches/minecraft/net/minecraft/entity/EntityLivingBase.java.patch
@@ -244,7 +244,7 @@
              ItemStack itemstack = this.func_184582_a(EntityEquipmentSlot.CHEST);
  
 -            if (itemstack.func_77973_b() == Items.field_185160_cR && ItemElytra.func_185069_d(itemstack))
-+            if (itemstack.func_77973_b() instanceof ItemElytra && ((ItemElytra) itemstack.func_77973_b()).func_185069_d(itemstack))
++            if (itemstack.func_77973_b() instanceof ItemElytra && ItemElytra.func_185069_d(itemstack))
              {
                  flag = true;
  

--- a/patches/minecraft/net/minecraft/entity/EntityLivingBase.java.patch
+++ b/patches/minecraft/net/minecraft/entity/EntityLivingBase.java.patch
@@ -239,6 +239,15 @@
  
                      if (!itemstack.func_190926_b())
                      {
+@@ -2272,7 +2304,7 @@
+         {
+             ItemStack itemstack = this.func_184582_a(EntityEquipmentSlot.CHEST);
+ 
+-            if (itemstack.func_77973_b() == Items.field_185160_cR && ItemElytra.func_185069_d(itemstack))
++            if (itemstack.func_77973_b() instanceof ItemElytra && ((ItemElytra) itemstack.func_77973_b()).func_185069_d(itemstack))
+             {
+                 flag = true;
+ 
 @@ -2488,6 +2520,40 @@
          this.field_70752_e = true;
      }

--- a/patches/minecraft/net/minecraft/item/ItemElytra.java.patch
+++ b/patches/minecraft/net/minecraft/item/ItemElytra.java.patch
@@ -1,0 +1,18 @@
+--- ../src-base/minecraft/net/minecraft/item/ItemElytra.java
++++ ../src-work/minecraft/net/minecraft/item/ItemElytra.java
+@@ -28,13 +28,13 @@
+             @SideOnly(Side.CLIENT)
+             public float func_185085_a(ItemStack p_185085_1_, @Nullable World p_185085_2_, @Nullable EntityLivingBase p_185085_3_)
+             {
+-                return ItemElytra.func_185069_d(p_185085_1_) ? 0.0F : 1.0F;
++                return ((net.minecraft.item.ItemElytra) p_185085_1_.func_77973_b()).func_185069_d(p_185085_1_) ? 0.0F : 1.0F;
+             }
+         });
+         BlockDispenser.field_149943_a.func_82595_a(this, ItemArmor.field_96605_cw);
+     }
+ 
+-    public static boolean func_185069_d(ItemStack p_185069_0_)
++    public boolean func_185069_d(ItemStack p_185069_0_)
+     {
+         return p_185069_0_.func_77952_i() < p_185069_0_.func_77958_k() - 1;
+     }

--- a/patches/minecraft/net/minecraft/item/ItemElytra.java.patch
+++ b/patches/minecraft/net/minecraft/item/ItemElytra.java.patch
@@ -15,7 +15,7 @@
      }
 +
 +    // FORGE
-+    public boolean isElytraBroken(ItemStack stack)
++    public boolean isElytraUsable(ItemStack stack)
 +    {
 +        return stack.func_77952_i() < stack.func_77958_k() - 1;
 +    }

--- a/patches/minecraft/net/minecraft/item/ItemElytra.java.patch
+++ b/patches/minecraft/net/minecraft/item/ItemElytra.java.patch
@@ -5,7 +5,7 @@
      public static boolean func_185069_d(ItemStack p_185069_0_)
      {
 -        return p_185069_0_.func_77952_i() < p_185069_0_.func_77958_k() - 1;
-+        return p_185069_0_.func_77973_b() instanceof ItemElytra && ((ItemElytra) p_185069_0_.func_77973_b()).isElytraBroken(p_185069_0_);
++        return p_185069_0_.func_77973_b() instanceof ItemElytra && ((ItemElytra) p_185069_0_.func_77973_b()).isElytraUsable(p_185069_0_);
      }
  
      public boolean func_82789_a(ItemStack p_82789_1_, ItemStack p_82789_2_)

--- a/patches/minecraft/net/minecraft/item/ItemElytra.java.patch
+++ b/patches/minecraft/net/minecraft/item/ItemElytra.java.patch
@@ -1,18 +1,22 @@
 --- ../src-base/minecraft/net/minecraft/item/ItemElytra.java
 +++ ../src-work/minecraft/net/minecraft/item/ItemElytra.java
-@@ -28,13 +28,13 @@
-             @SideOnly(Side.CLIENT)
-             public float func_185085_a(ItemStack p_185085_1_, @Nullable World p_185085_2_, @Nullable EntityLivingBase p_185085_3_)
-             {
--                return ItemElytra.func_185069_d(p_185085_1_) ? 0.0F : 1.0F;
-+                return ((net.minecraft.item.ItemElytra) p_185085_1_.func_77973_b()).func_185069_d(p_185085_1_) ? 0.0F : 1.0F;
-             }
-         });
-         BlockDispenser.field_149943_a.func_82595_a(this, ItemArmor.field_96605_cw);
+@@ -36,7 +36,7 @@
+ 
+     public static boolean func_185069_d(ItemStack p_185069_0_)
+     {
+-        return p_185069_0_.func_77952_i() < p_185069_0_.func_77958_k() - 1;
++        return p_185069_0_.func_77973_b() instanceof ItemElytra && ((ItemElytra) p_185069_0_.func_77973_b()).isElytraBroken(p_185069_0_);
      }
  
--    public static boolean func_185069_d(ItemStack p_185069_0_)
-+    public boolean func_185069_d(ItemStack p_185069_0_)
-     {
-         return p_185069_0_.func_77952_i() < p_185069_0_.func_77958_k() - 1;
+     public boolean func_82789_a(ItemStack p_82789_1_, ItemStack p_82789_2_)
+@@ -61,4 +61,10 @@
+             return new ActionResult(EnumActionResult.FAIL, itemstack);
+         }
      }
++
++    // FORGE
++    public boolean isElytraBroken(ItemStack stack)
++    {
++        return stack.func_77952_i() < stack.func_77958_k() - 1;
++    }
+ }

--- a/patches/minecraft/net/minecraft/network/NetHandlerPlayServer.java.patch
+++ b/patches/minecraft/net/minecraft/network/NetHandlerPlayServer.java.patch
@@ -34,6 +34,15 @@
                  this.field_147367_d.func_184103_al().func_148544_a(itextcomponent, false);
              }
  
+@@ -969,7 +976,7 @@
+                 {
+                     ItemStack itemstack = this.field_147369_b.func_184582_a(EntityEquipmentSlot.CHEST);
+ 
+-                    if (itemstack.func_77973_b() == Items.field_185160_cR && ItemElytra.func_185069_d(itemstack))
++                    if (itemstack.func_77973_b() instanceof ItemElytra && ((ItemElytra) itemstack.func_77973_b()).func_185069_d(itemstack))
+                     {
+                         this.field_147369_b.func_184847_M();
+                     }
 @@ -1012,6 +1019,7 @@
                  else if (p_147340_1_.func_149565_c() == CPacketUseEntity.Action.INTERACT_AT)
                  {

--- a/patches/minecraft/net/minecraft/network/NetHandlerPlayServer.java.patch
+++ b/patches/minecraft/net/minecraft/network/NetHandlerPlayServer.java.patch
@@ -39,7 +39,7 @@
                      ItemStack itemstack = this.field_147369_b.func_184582_a(EntityEquipmentSlot.CHEST);
  
 -                    if (itemstack.func_77973_b() == Items.field_185160_cR && ItemElytra.func_185069_d(itemstack))
-+                    if (itemstack.func_77973_b() instanceof ItemElytra && ((ItemElytra) itemstack.func_77973_b()).func_185069_d(itemstack))
++                    if (itemstack.func_77973_b() instanceof ItemElytra && ItemElytra.func_185069_d(itemstack))
                      {
                          this.field_147369_b.func_184847_M();
                      }


### PR DESCRIPTION
These changes replace all reference comparisons with Items.ELYTRA with instanceof checks against ItemElytra, so that modders can extend ItemElytra without having to replicate all the motion logic and rendering.
ItemElytra#isBroken has also been made non-static for it to be overridable; in all contexts where the static method was being called, an item to do the check is available, so it is used to call the newly non-static method.