### PR TITLE
Use the entity constructor cache

### DIFF
--- a/patches/minecraft/net/minecraft/entity/EntityList.java.patch
+++ b/patches/minecraft/net/minecraft/entity/EntityList.java.patch
@@ -63,7 +63,24 @@
      @Nullable
      public static Entity func_191304_a(@Nullable Class <? extends Entity > p_191304_0_, World p_191304_1_)
      {
-@@ -168,13 +180,15 @@
+@@ -150,8 +162,16 @@
+         {
+             return null;
+         }
++        net.minecraftforge.fml.common.registry.EntityEntry entry = net.minecraftforge.fml.common.registry.EntityRegistry.getEntry(p_191304_0_);
++        if (entry != null)
++        {
++            return entry.newInstance(p_191304_1_);
++        }
+         else
+         {
++            net.minecraftforge.fml.common.FMLLog.warning(
++                    "An attempt was made to construct an unregistered entity %s. Report this to the mod author",
++                    p_191304_0_.getClass().getName());
+             try
+             {
+                 return (Entity)p_191304_0_.getConstructor(new Class[] {World.class}).newInstance(new Object[] {p_191304_1_});
+@@ -168,13 +188,15 @@
      @SideOnly(Side.CLIENT)
      public static Entity func_75616_a(int p_75616_0_, World p_75616_1_)
      {
@@ -81,7 +98,7 @@
      }
  
      @Nullable
-@@ -189,7 +203,17 @@
+@@ -189,7 +211,17 @@
          }
          else
          {
@@ -99,7 +116,7 @@
          }
  
          return entity;
-@@ -197,7 +221,7 @@
+@@ -197,7 +229,7 @@
  
      public static Set<ResourceLocation> func_180124_b()
      {
@@ -108,7 +125,7 @@
      }
  
      public static boolean func_180123_a(Entity p_180123_0_, ResourceLocation p_180123_1_)
-@@ -336,7 +360,7 @@
+@@ -336,7 +368,7 @@
          func_191305_a("zombie_horse", 3232308, 9945732);
          func_191305_a("zombie_pigman", 15373203, 5009705);
          func_191305_a("zombie_villager", 5651507, 7969893);
@@ -117,7 +134,7 @@
      }
  
      private static void func_191303_a(int p_191303_0_, String p_191303_1_, Class <? extends Entity > p_191303_2_, String p_191303_3_)
-@@ -357,22 +381,19 @@
+@@ -357,22 +389,19 @@
          else
          {
              ResourceLocation resourcelocation = new ResourceLocation(p_191303_1_);


### PR DESCRIPTION
This pr alters Entity#newEntity() to use the constructor cache introduced in https://github.com/MinecraftForge/MinecraftForge/commit/50bf03b82b72866bd54e796a37707d45bcbf3d80.