### PR TITLE
Fix OreDictionary.doesOreNameExist returning true for empty entry

### DIFF
--- a/src/main/java/net/minecraftforge/oredict/OreDictionary.java
+++ b/src/main/java/net/minecraftforge/oredict/OreDictionary.java
@@ -517,7 +517,8 @@ public class OreDictionary
      */
     public static boolean doesOreNameExist(String name)
     {
-        return nameToId.containsKey(name) && nameToId.get(name) > 0;
+        Integer count = nameToId.get(name);
+        return count != null && count > 0;
     }
 
     /**

--- a/src/main/java/net/minecraftforge/oredict/OreDictionary.java
+++ b/src/main/java/net/minecraftforge/oredict/OreDictionary.java
@@ -517,7 +517,7 @@ public class OreDictionary
      */
     public static boolean doesOreNameExist(String name)
     {
-        return nameToId.get(name) != null;
+        return nameToId.containsKey(name) && nameToId.get(name) > 0;
     }
 
     /**


### PR DESCRIPTION
OreDictionary.getOreID will populate the map with a value of 0, and since this method only checks != null it will improperly return true for names which have no ores assigned. This commit fixes this inconsistency by checking for 0-size entries.