### PR TITLE
Add option to use background color on splash screen logo. Fix #1987

### DIFF
--- a/src/main/java/net/minecraftforge/fml/client/SplashProgress.java
+++ b/src/main/java/net/minecraftforge/fml/client/SplashProgress.java
@@ -103,6 +103,7 @@ public class SplashProgress
 
     private static boolean enabled;
     private static boolean rotate;
+    private static boolean useBgColorOnLogo;
     private static int logoOffset;
     private static int backgroundColor;
     private static int fontColor;
@@ -177,6 +178,7 @@ public class SplashProgress
         enabled =            getBool("enabled",      defaultEnabled) && ( (!FMLClientHandler.instance().hasOptifine()) || Launch.blackboard.containsKey("optifine.ForgeSplashCompatible"));
         rotate =             getBool("rotate",       false);
         showMemory =         getBool("showMemory",   true);
+        useBgColorOnLogo =   getBool("useBgColorOnLogo", true);
         logoOffset =         getInt("logoOffset",    0);
         backgroundColor =    getHex("background",    0xFFFFFF);
         fontColor =          getHex("font",          0x000000);
@@ -297,7 +299,17 @@ public class SplashProgress
                     glLoadIdentity();
 
                     // mojang logo
-                    setColor(backgroundColor);
+
+                    // the default mojang logo has white background instead of transparency, we use this to change it
+                    if (useBgColorOnLogo)
+                    {
+                        setColor(backgroundColor);
+                    }
+                    else
+                    {
+                        clearColor();
+                    }
+
                     glEnable(GL_TEXTURE_2D);
                     logoTexture.bind();
                     glBegin(GL_QUADS);
@@ -343,7 +355,7 @@ public class SplashProgress
                     angle += 1;
 
                     // forge logo
-                    setColor(backgroundColor);
+                    clearColor();
                     float fw = (float)forgeTexture.getWidth() / 2;
                     float fh = (float)forgeTexture.getHeight() / 2;
                     if(rotate)
@@ -418,6 +430,11 @@ public class SplashProgress
             private void setColor(int color)
             {
                 glColor3ub((byte)((color >> 16) & 0xFF), (byte)((color >> 8) & 0xFF), (byte)(color & 0xFF));
+            }
+
+            private void clearColor()
+            {
+                glColor4f(1, 1, 1, 1);
             }
 
             private void drawBox(int w, int h)


### PR DESCRIPTION
Fixes issue #1987

**Problem:**

The Mojang logo has a white background, so the splash screen applies the background color to it. This is necessary, but it's a hack and the downside is that it causes a color cast to the whole logo.
Most custom logos will not have a white background, and should avoid being colored this way.

**Solution:**

This PR adds an option in `splash.properties` that chooses if the background color applied to the logo.
It also fixes the color of the Forge anvil, which should never have the background color applied.

**Before and After:**

**Mojang logo**, 
Before PR:
![java_2017-04-27_15-47-25](https://cloud.githubusercontent.com/assets/916092/25507440/ed024d9e-2b60-11e7-8877-84887f20df7d.png)


After PR with `useBgColorOnLogo=true`
![java_2017-04-27_15-35-38](https://cloud.githubusercontent.com/assets/916092/25507353/572c5c88-2b60-11e7-8cd3-7d8d3c9c55df.png)

**Custom logo** (picked a random texture)

Before PR:
![java_2017-04-27_15-46-17](https://cloud.githubusercontent.com/assets/916092/25507401/b6239e54-2b60-11e7-996a-db13c19d8320.png)

After PR, with `useBgColorOnLogo=false`
![java_2017-04-27_15-34-58](https://cloud.githubusercontent.com/assets/916092/25507361/6cc52944-2b60-11e7-889f-2f20063413ac.png)