### PR TITLE
When the window is closed during loading, exit the game quickly

### DIFF
--- a/src/main/java/net/minecraftforge/fml/client/FMLClientHandler.java
+++ b/src/main/java/net/minecraftforge/fml/client/FMLClientHandler.java
@@ -634,6 +634,12 @@ public class FMLClientHandler implements IFMLSidedHandler
     }
 
     @Override
+    public boolean isDisplayCloseRequested()
+    {
+        return Display.isCreated() && Display.isCloseRequested();
+    }
+
+    @Override
     public boolean shouldServerShouldBeKilledQuietly()
     {
         return serverShouldBeKilledQuietly;

--- a/src/main/java/net/minecraftforge/fml/common/FMLCommonHandler.java
+++ b/src/main/java/net/minecraftforge/fml/common/FMLCommonHandler.java
@@ -438,6 +438,11 @@ public class FMLCommonHandler
         if (!confirmed) StartupQuery.abort();
     }
 
+    public boolean isDisplayCloseRequested()
+    {
+        return sidedDelegate != null && sidedDelegate.isDisplayCloseRequested();
+    }
+
     public boolean shouldServerBeKilledQuietly()
     {
         if (sidedDelegate == null)

--- a/src/main/java/net/minecraftforge/fml/common/IFMLSidedHandler.java
+++ b/src/main/java/net/minecraftforge/fml/common/IFMLSidedHandler.java
@@ -51,6 +51,8 @@ public interface IFMLSidedHandler
 
     MinecraftServer getServer();
 
+    boolean isDisplayCloseRequested();
+
     boolean shouldServerShouldBeKilledQuietly();
 
     void addModAsResource(ModContainer container);

--- a/src/main/java/net/minecraftforge/fml/common/LoadController.java
+++ b/src/main/java/net/minecraftforge/fml/common/LoadController.java
@@ -54,7 +54,6 @@ import com.google.common.eventbus.EventBus;
 import com.google.common.eventbus.Subscribe;
 import com.google.common.eventbus.SubscriberExceptionHandler;
 import com.google.common.eventbus.SubscriberExceptionContext;
-import org.lwjgl.opengl.Display;
 
 import javax.annotation.Nullable;
 

--- a/src/main/java/net/minecraftforge/fml/common/LoadController.java
+++ b/src/main/java/net/minecraftforge/fml/common/LoadController.java
@@ -54,6 +54,7 @@ import com.google.common.eventbus.EventBus;
 import com.google.common.eventbus.Subscribe;
 import com.google.common.eventbus.SubscriberExceptionHandler;
 import com.google.common.eventbus.SubscriberExceptionContext;
+import org.lwjgl.opengl.Display;
 
 import javax.annotation.Nullable;
 
@@ -150,6 +151,12 @@ public class LoadController
 
     public void transition(LoaderState desiredState, boolean forceState)
     {
+        if (Display.isCreated() && Display.isCloseRequested())
+        {
+            FMLLog.info("The game window is being closed by the player, exiting.");
+            FMLCommonHandler.instance().exitJava(0, false);
+        }
+
         LoaderState oldState = state;
         state = state.transition(!errors.isEmpty());
         if (state != desiredState && !forceState)

--- a/src/main/java/net/minecraftforge/fml/common/LoadController.java
+++ b/src/main/java/net/minecraftforge/fml/common/LoadController.java
@@ -151,7 +151,7 @@ public class LoadController
 
     public void transition(LoaderState desiredState, boolean forceState)
     {
-        if (Display.isCreated() && Display.isCloseRequested())
+        if (FMLCommonHandler.instance().isDisplayCloseRequested())
         {
             FMLLog.info("The game window is being closed by the player, exiting.");
             FMLCommonHandler.instance().exitJava(0, false);

--- a/src/main/java/net/minecraftforge/fml/server/FMLServerHandler.java
+++ b/src/main/java/net/minecraftforge/fml/server/FMLServerHandler.java
@@ -223,6 +223,12 @@ public class FMLServerHandler implements IFMLSidedHandler
     }
 
     @Override
+    public boolean isDisplayCloseRequested()
+    {
+        return false;
+    }
+
+    @Override
     public boolean shouldServerShouldBeKilledQuietly()
     {
         return false;


### PR DESCRIPTION
Often when putting together a pack or adding mods in general, you start loading the game and immediately realize you messed something up and need to close the window.
Unfortunately, the window only closes after everything has loaded and the main menu appears, and that can take minutes on big packs.

This PR makes FML detect if the window is being closed. This is done every `LoaderState` transition because it seems like a reasonably clean place to stop the game, rather than halting things in the middle of something. This means the window will not close instantly, but it will be much faster than waiting for the whole game to load.

Here an example of the end of the log you get when closing the game window while it's loading:
```
[16:18:38] [Client thread/INFO] [FML]: Forge Mod Loader has identified 56 mods to load
[16:18:38] [Client thread/INFO] [FML]: Attempting connection with missing mods [minecraft, mcp, FML, forge, bonemealeventtest, breedingtest, config_test, decorateeventdebug, dynbuckettest, enumplanttypetest, equipment_change_test, forgedebugfluidplacement, forgeblockstatesloader, forgedebugitemlayermodel, forgedebugitemtile, loot_table_debug, forgedebugmodelanimation, forgedebugmodelbakeevent, forgedebugmodelfluid, forgedebugmodelloaderregistry, forgedebugmultilayermodel, nopotioneffect, objectholdertest, potion_curative_item_debug, forgepotionregistry, forge_texture_dump, wrenchrotatedebug, forgenetworktest, animal_tame_event_test, ainodetypetest, block_place_event_test, brewingreciperegistrytest, canapplyatenchantingtabletest, clientchateventtest, clientcommandtest, command_tree_base_test, createfluidsourcetest, customspawndimensiontest, custom_sprite_test, difficultychangeeventtest, enchantmentlevelsettest, entitytraveltodimensioneventtest, entityupdateblockedtest, fluidhandlertest, fovmodifiertest, is_book_enchantable_test, item_can_destroy_blocks_in_creative_test, loottable_load_event_test, neighbornotifyeventtest, forgedebugnobedsleeping, permission_test, playerinteracteventtest, playersetspawntest, forge.testcapmod, worldperiodicrainchecktest, wrnormal] at CLIENT
[16:18:38] [Client thread/INFO] [FML]: Attempting connection with missing mods [minecraft, mcp, FML, forge, bonemealeventtest, breedingtest, config_test, decorateeventdebug, dynbuckettest, enumplanttypetest, equipment_change_test, forgedebugfluidplacement, forgeblockstatesloader, forgedebugitemlayermodel, forgedebugitemtile, loot_table_debug, forgedebugmodelanimation, forgedebugmodelbakeevent, forgedebugmodelfluid, forgedebugmodelloaderregistry, forgedebugmultilayermodel, nopotioneffect, objectholdertest, potion_curative_item_debug, forgepotionregistry, forge_texture_dump, wrenchrotatedebug, forgenetworktest, animal_tame_event_test, ainodetypetest, block_place_event_test, brewingreciperegistrytest, canapplyatenchantingtabletest, clientchateventtest, clientcommandtest, command_tree_base_test, createfluidsourcetest, customspawndimensiontest, custom_sprite_test, difficultychangeeventtest, enchantmentlevelsettest, entitytraveltodimensioneventtest, entityupdateblockedtest, fluidhandlertest, fovmodifiertest, is_book_enchantable_test, item_can_destroy_blocks_in_creative_test, loottable_load_event_test, neighbornotifyeventtest, forgedebugnobedsleeping, permission_test, playerinteracteventtest, playersetspawntest, forge.testcapmod, worldperiodicrainchecktest, wrnormal] at SERVER
[16:18:39] [Client thread/INFO] [FML]: The game window is being closed by the player, exiting.
[16:18:39] [Client thread/INFO] [FML]: Java has been asked to exit (code 0) by net.minecraftforge.fml.common.FMLCommonHandler.exitJava(FMLCommonHandler.java:656).
[16:18:39] [Client thread/INFO] [FML]: If this was an unexpected exit, use -Dfml.debugExit=true as a JVM argument to find out where it was called
```