### PR TITLE
Remove splash.properties option for Mojang logo (it has been disabled)

### DIFF
--- a/src/main/java/net/minecraftforge/fml/client/SplashProgress.java
+++ b/src/main/java/net/minecraftforge/fml/client/SplashProgress.java
@@ -188,7 +188,7 @@ public class SplashProgress
         memoryLowColor =     getHex("memoryLow",     0xE42F2F);
 
         final ResourceLocation fontLoc = new ResourceLocation(getString("fontTexture", "textures/font/ascii.png"));
-        final ResourceLocation logoLoc = new ResourceLocation(getString("logoTexture", "textures/gui/title/mojang.png"));
+        final ResourceLocation logoLoc = new ResourceLocation("textures/gui/title/mojang.png");
         final ResourceLocation forgeLoc = new ResourceLocation(getString("forgeTexture", "fml:textures/gui/forge.png"));
         final ResourceLocation forgeFallbackLoc = new ResourceLocation("fml:textures/gui/forge.png");
 
@@ -343,7 +343,7 @@ public class SplashProgress
                     angle += 1;
 
                     // forge logo
-                    setColor(backgroundColor);
+                    glColor4f(1, 1, 1, 1);
                     float fw = (float)forgeTexture.getWidth() / 2;
                     float fh = (float)forgeTexture.getHeight() / 2;
                     if(rotate)
@@ -953,9 +953,9 @@ public class SplashProgress
         }
     }
 
-    private static InputStream open(ResourceLocation loc, @Nullable ResourceLocation fallback, boolean allowRP) throws IOException
+    private static InputStream open(ResourceLocation loc, @Nullable ResourceLocation fallback, boolean allowResourcePack) throws IOException
     {
-        if (!allowRP)
+        if (!allowResourcePack)
             return mcPack.getInputStream(loc);
 
         if(miscPack.resourceExists(loc))


### PR DESCRIPTION
Also fixes the background color being applied to the Forge logo.

Before:
![java_2017-04-27_15-47-25](https://cloud.githubusercontent.com/assets/916092/25508655/7f366c0c-2b68-11e7-9574-1d0b4cd61b24.png)

After:
![java_2017-04-27_16-41-33](https://cloud.githubusercontent.com/assets/916092/25508656/8294626e-2b68-11e7-9012-ca6ab4f5b96c.png)