### PR TITLE
Prevent NPE in ConfigManager and fix config gui being enabled for all mods. Fixes #3856.

### DIFF
--- a/src/main/java/net/minecraftforge/common/config/ConfigManager.java
+++ b/src/main/java/net/minecraftforge/common/config/ConfigManager.java
@@ -202,7 +202,12 @@ public class ConfigManager
 
     public static Class<?>[] getModConfigClasses(String modid)
     {
-        return MOD_CONFIG_CLASSES.get(modid).toArray(new Class<?>[0]);
+        return (MOD_CONFIG_CLASSES.containsKey(modid) ? MOD_CONFIG_CLASSES.get(modid).toArray(new Class<?>[0]) : new Class<?>[0]);
+    }
+
+    public static boolean hasConfigForMod(String modid)
+    {
+        return asm_data.containsKey(modid);
     }
 
     // =======================================================

--- a/src/main/java/net/minecraftforge/fml/client/FMLClientHandler.java
+++ b/src/main/java/net/minecraftforge/fml/client/FMLClientHandler.java
@@ -83,6 +83,7 @@ import net.minecraft.world.storage.SaveFormatOld;
 import net.minecraftforge.client.event.ModelRegistryEvent;
 import net.minecraftforge.common.ForgeModContainer;
 import net.minecraftforge.common.MinecraftForge;
+import net.minecraftforge.common.config.ConfigManager;
 import net.minecraftforge.common.util.CompoundDataFixer;
 import net.minecraftforge.fml.client.registry.RenderingRegistry;
 import net.minecraftforge.fml.common.DummyModContainer;
@@ -377,7 +378,10 @@ public class FMLClientHandler implements IFMLSidedHandler
             String className = mc.getGuiClassName();
             if (Strings.isNullOrEmpty(className))
             {
-                guiFactories.put(mc, DefaultGuiFactory.forMod(mc));
+                if (ConfigManager.hasConfigForMod(mc.getModId()))
+                {
+                    guiFactories.put(mc, DefaultGuiFactory.forMod(mc));
+                }
                 continue;
             }
             try


### PR DESCRIPTION
- Prevents an NPE from occurring when trying to get the config classes for a mod that does not have an annotated config.

- Only register a `DefaultGuiFactory` for mods that have annotated configs.