### PR TITLE
[1.12] Update ISpecialArmor to use EntityEquipmentSlot

### DIFF
--- a/patches/minecraft/net/minecraft/enchantment/EnchantmentThorns.java.patch
+++ b/patches/minecraft/net/minecraft/enchantment/EnchantmentThorns.java.patch
@@ -23,7 +23,6 @@
 +    private void damageArmor(ItemStack stack, int amount, EntityLivingBase entity)
 +    {
 +        EntityEquipmentSlot targetSlot = null;
-+        int x = 0;
 +        for (EntityEquipmentSlot slot : EntityEquipmentSlot.values())
 +        {
 +            if (slot.func_188453_a() == EntityEquipmentSlot.Type.ARMOR)
@@ -33,7 +32,6 @@
 +                    targetSlot = slot;
 +                    break;
 +                }
-+                x++;
 +            }
 +        }
 +        if (targetSlot == null || !(stack.func_77973_b() instanceof net.minecraftforge.common.ISpecialArmor))

--- a/patches/minecraft/net/minecraft/enchantment/EnchantmentThorns.java.patch
+++ b/patches/minecraft/net/minecraft/enchantment/EnchantmentThorns.java.patch
@@ -22,22 +22,26 @@
 +
 +    private void damageArmor(ItemStack stack, int amount, EntityLivingBase entity)
 +    {
-+        int slot = -1;
++        EntityEquipmentSlot targetSlot = null;
 +        int x = 0;
-+        for (ItemStack i : entity.func_184193_aE())
++        for (EntityEquipmentSlot slot : EntityEquipmentSlot.values())
 +        {
-+            if (i == stack){
-+                slot = x;
-+                break;
++            if (slot.func_188453_a() == EntityEquipmentSlot.Type.ARMOR)
++            {
++                if (entity.func_184582_a(slot) == stack)
++                {
++                    targetSlot = slot;
++                    break;
++                }
++                x++;
 +            }
-+            x++;
 +        }
-+        if (slot == -1 || !(stack.func_77973_b() instanceof net.minecraftforge.common.ISpecialArmor))
++        if (targetSlot == null || !(stack.func_77973_b() instanceof net.minecraftforge.common.ISpecialArmor))
 +        {
 +            stack.func_77972_a(1, entity);
 +            return;
 +        }
 +        net.minecraftforge.common.ISpecialArmor armor = (net.minecraftforge.common.ISpecialArmor)stack.func_77973_b();
-+        armor.damageArmor(entity, stack, DamageSource.func_92087_a(entity), amount, slot);
++        armor.damageArmor(entity, stack, DamageSource.func_92087_a(entity), amount, targetSlot);
 +    }
  }

--- a/src/main/java/net/minecraftforge/common/ForgeHooks.java
+++ b/src/main/java/net/minecraftforge/common/ForgeHooks.java
@@ -269,7 +269,7 @@ public class ForgeHooks
 
     public static int getTotalArmorValue(EntityPlayer player)
     {
-        int ret = 0;
+        int ret = player.getTotalArmorValue();
         for (EntityEquipmentSlot slot : EntityEquipmentSlot.values())
         {
             if (slot.getSlotType() == EntityEquipmentSlot.Type.ARMOR)
@@ -278,10 +278,6 @@ public class ForgeHooks
                 if (stack.getItem() instanceof ISpecialArmor)
                 {
                     ret += ((ISpecialArmor)stack.getItem()).getArmorDisplay(player, stack, slot);
-                }
-                else if (stack.getItem() instanceof ItemArmor)
-                {
-                    ret += ((ItemArmor)stack.getItem()).damageReduceAmount;
                 }
             }
         }

--- a/src/main/java/net/minecraftforge/common/ForgeHooks.java
+++ b/src/main/java/net/minecraftforge/common/ForgeHooks.java
@@ -55,6 +55,7 @@ import net.minecraft.entity.projectile.EntityThrowable;
 import net.minecraft.init.Blocks;
 import net.minecraft.init.Items;
 import net.minecraft.inventory.ContainerRepair;
+import net.minecraft.inventory.EntityEquipmentSlot;
 import net.minecraft.inventory.IInventory;
 import net.minecraft.inventory.InventoryCrafting;
 import net.minecraft.item.ItemArmor;
@@ -269,16 +270,19 @@ public class ForgeHooks
     public static int getTotalArmorValue(EntityPlayer player)
     {
         int ret = 0;
-        for (int x = 0; x < player.inventory.armorInventory.size(); x++)
+        for (EntityEquipmentSlot slot : EntityEquipmentSlot.values())
         {
-            ItemStack stack = player.inventory.armorInventory.get(x);
-            if (stack.getItem() instanceof ISpecialArmor)
+            if (slot.getSlotType() == EntityEquipmentSlot.Type.ARMOR)
             {
-                ret += ((ISpecialArmor)stack.getItem()).getArmorDisplay(player, stack, x);
-            }
-            else if (stack.getItem() instanceof ItemArmor)
-            {
-                ret += ((ItemArmor)stack.getItem()).damageReduceAmount;
+                ItemStack stack = player.getItemStackFromSlot(slot);
+                if (stack.getItem() instanceof ISpecialArmor)
+                {
+                    ret += ((ISpecialArmor)stack.getItem()).getArmorDisplay(player, stack, slot);
+                }
+                else if (stack.getItem() instanceof ItemArmor)
+                {
+                    ret += ((ItemArmor)stack.getItem()).damageReduceAmount;
+                }
             }
         }
         return ret;

--- a/src/main/java/net/minecraftforge/common/ISpecialArmor.java
+++ b/src/main/java/net/minecraftforge/common/ISpecialArmor.java
@@ -92,12 +92,12 @@ public interface ISpecialArmor
 
     public static class ArmorProperties implements Comparable<ArmorProperties>
     {
-        public int    Priority          = 0;
-        public int    AbsorbMax         = Integer.MAX_VALUE;
-        public double AbsorbRatio       = 0;
-        public double Armor             = 0;        //Additional armor, separate from the armor added by vanilla attributes.
-        public double Toughness         = 0;        //Additional toughness, separate from the armor added by vanilla attributes.
-        public EntityEquipmentSlot Slot = EntityEquipmentSlot.CHEST;
+        public int    priority          = 0;
+        public int    absorbMax         = Integer.MAX_VALUE;
+        public double absorbRatio       = 0;
+        public double armor             = 0;        //Additional armor, separate from the armor added by vanilla attributes.
+        public double toughness         = 0;        //Additional toughness, separate from the armor added by vanilla attributes.
+        public EntityEquipmentSlot slot = EntityEquipmentSlot.CHEST;
         private static final boolean DEBUG = false; //Only enable this if you wish to be spammed with debugging information.
                                                     //Left it in because I figured it'd be useful for modders developing custom armor.
 
@@ -108,11 +108,11 @@ public interface ISpecialArmor
         
         public ArmorProperties(int priority, double ratio, double armor, double toughness, int max)
         {
-            Priority    = priority;
-            AbsorbRatio = ratio;
-            Armor       = armor;
-            Toughness   = toughness;
-            AbsorbMax   = max;
+            this.priority    = priority;
+            this.absorbRatio = ratio;
+            this.armor       = armor;
+            this.toughness   = toughness;
+            this.absorbMax   = max;
         }
 
         /**
@@ -148,8 +148,8 @@ public interface ISpecialArmor
                 {
                     ISpecialArmor armor = (ISpecialArmor)stack.getItem();
                     prop = armor.getProperties(entity, stack, source, damage, slot).copy();
-                    totalArmor += prop.Armor;
-                    totalToughness += prop.Toughness;
+                    totalArmor += prop.armor;
+                    totalToughness += prop.toughness;
                 }
                 else if (stack.getItem() instanceof ItemArmor && !source.isUnblockable())
                 {
@@ -158,34 +158,34 @@ public interface ISpecialArmor
                 }
                 if (prop != null)
                 {
-                    prop.Slot = slot;
+                    prop.slot = slot;
                     dmgVals.add(prop);
                 }
             }
             if (dmgVals.size() > 0)
             {
                 ArmorProperties[] props = dmgVals.toArray(new ArmorProperties[dmgVals.size()]);
-                StandardizeList(props, damage);
-                int level = props[0].Priority;
+                standardizeList(props, damage);
+                int level = props[0].priority;
                 double ratio = 0;
                 for (ArmorProperties prop : props)
                 {
-                    if (level != prop.Priority)
+                    if (level != prop.priority)
                     {
                         damage -= (damage * ratio);
                         ratio = 0;
-                        level = prop.Priority;
+                        level = prop.priority;
                     }
-                    ratio += prop.AbsorbRatio;
+                    ratio += prop.absorbRatio;
 
-                    double absorb = damage * prop.AbsorbRatio;
+                    double absorb = damage * prop.absorbRatio;
                     if (absorb > 0)
                     {
-                        ItemStack stack = inventory.get(prop.Slot.getIndex());
+                        ItemStack stack = inventory.get(prop.slot.getIndex());
                         int itemDamage = (int)Math.max(1, absorb);
                         if (stack.getItem() instanceof ISpecialArmor)
                         {
-                            ((ISpecialArmor)stack.getItem()).damageArmor(entity, stack, source, itemDamage, prop.Slot);
+                            ((ISpecialArmor)stack.getItem()).damageArmor(entity, stack, source, itemDamage, prop.slot);
                         }
                         else
                         {
@@ -197,11 +197,7 @@ public interface ISpecialArmor
                         }
                         if (stack.isEmpty())
                         {
-                            /*if (entity instanceof EntityPlayer)
-                            {
-                                stack.onItemDestroyedByUse((EntityPlayer)entity);
-                            }*/
-                            inventory.set(prop.Slot.getIndex(), ItemStack.EMPTY);
+                            inventory.set(prop.slot.getIndex(), ItemStack.EMPTY);
                         }
                     }
                 }
@@ -223,9 +219,7 @@ public interface ISpecialArmor
                         }
                     }
                 }
-                System.out.println(damage);
                 damage = CombatRules.getDamageAfterAbsorb((float)damage, (float)totalArmor, (float)totalToughness);
-                System.out.println(damage);
             }
             if (DEBUG)
             {
@@ -240,13 +234,13 @@ public interface ISpecialArmor
          * @param armor The armor information
          * @param damage The total damage being received
          */
-        private static void StandardizeList(ArmorProperties[] armor, double damage)
+        private static void standardizeList(ArmorProperties[] armor, double damage)
         {
             Arrays.sort(armor);
 
             int     start     = 0;
             double  total     = 0;
-            int     priority  = armor[0].Priority;
+            int     priority  = armor[0].priority;
             int     pStart    = 0;
             boolean pChange   = false;
             boolean pFinished = false;
@@ -262,12 +256,12 @@ public interface ISpecialArmor
 
             for (int x = 0; x < armor.length; x++)
             {
-                total += armor[x].AbsorbRatio;
-                if (x == armor.length - 1 || armor[x].Priority != priority)
+                total += armor[x].absorbRatio;
+                if (x == armor.length - 1 || armor[x].priority != priority)
                 {
-                    if (armor[x].Priority != priority)
+                    if (armor[x].priority != priority)
                     {
-                        total -= armor[x].AbsorbRatio;
+                        total -= armor[x].absorbRatio;
                         x--;
                         pChange = true;
                     }
@@ -275,14 +269,14 @@ public interface ISpecialArmor
                     {
                         for (int y = start; y <= x; y++)
                         {
-                            double newRatio = armor[y].AbsorbRatio / total;
-                            if (newRatio * damage > armor[y].AbsorbMax)
+                            double newRatio = armor[y].absorbRatio / total;
+                            if (newRatio * damage > armor[y].absorbMax)
                             {
-                                armor[y].AbsorbRatio = (double)armor[y].AbsorbMax / damage;
+                                armor[y].absorbRatio = (double)armor[y].absorbMax / damage;
                                 total = 0;
                                 for (int z = pStart; z <= y; z++)
                                 {
-                                    total += armor[z].AbsorbRatio;
+                                    total += armor[z].absorbRatio;
                                 }
                                 start = y + 1;
                                 x = y;
@@ -290,7 +284,7 @@ public interface ISpecialArmor
                             }
                             else
                             {
-                                armor[y].AbsorbRatio = newRatio;
+                                armor[y].absorbRatio = newRatio;
                                 pFinished = true;
                             }
                         }
@@ -299,7 +293,7 @@ public interface ISpecialArmor
                             damage -= (damage * total);
                             total = 0;
                             start = x + 1;
-                            priority = armor[start].Priority;
+                            priority = armor[start].priority;
                             pStart = start;
                             pChange = false;
                             pFinished = false;
@@ -307,7 +301,7 @@ public interface ISpecialArmor
                             {
                                 for (int y = x + 1; y < armor.length; y++)
                                 {
-                                    armor[y].AbsorbRatio = 0;
+                                    armor[y].absorbRatio = 0;
                                 }
                                 break;
                             }
@@ -317,26 +311,26 @@ public interface ISpecialArmor
                     {
                         for (int y = start; y <= x; y++)
                         {
-                            total -= armor[y].AbsorbRatio;
-                            if (damage * armor[y].AbsorbRatio > armor[y].AbsorbMax)
+                            total -= armor[y].absorbRatio;
+                            if (damage * armor[y].absorbRatio > armor[y].absorbMax)
                             {
-                                armor[y].AbsorbRatio = (double)armor[y].AbsorbMax / damage;
+                                armor[y].absorbRatio = (double)armor[y].absorbMax / damage;
                             }
-                            total += armor[y].AbsorbRatio;
+                            total += armor[y].absorbRatio;
                         }
                         damage -= (damage * total);
                         total = 0;
                         if (x != armor.length - 1)
                         {
                             start = x + 1;
-                            priority = armor[start].Priority;
+                            priority = armor[start].priority;
                             pStart = start;
                             pChange = false;
                             if (damage <= 0)
                             {
                                 for (int y = x + 1; y < armor.length; y++)
                                 {
-                                    armor[y].AbsorbRatio = 0;
+                                    armor[y].absorbRatio = 0;
                                 }
                                 break;
                             }
@@ -356,24 +350,24 @@ public interface ISpecialArmor
         @Override
         public int compareTo(ArmorProperties o)
         {
-            if (o.Priority != Priority)
+            if (o.priority != priority)
             {
-                return o.Priority - Priority;
+                return o.priority - priority;
             }
-            double left =  (  AbsorbRatio == 0 ? 0 :   AbsorbMax * 100.0D /   AbsorbRatio);
-            double right = (o.AbsorbRatio == 0 ? 0 : o.AbsorbMax * 100.0D / o.AbsorbRatio);
+            double left =  (  absorbRatio == 0 ? 0 :   absorbMax * 100.0D /   absorbRatio);
+            double right = (o.absorbRatio == 0 ? 0 : o.absorbMax * 100.0D / o.absorbRatio);
             return (int)(left - right);
         }
 
         @Override
         public String toString()
         {
-            return String.format("%d, %d, %f, %d", Priority, AbsorbMax, AbsorbRatio, (AbsorbRatio == 0 ? 0 : (int)(AbsorbMax * 100.0D / AbsorbRatio)));
+            return String.format("%d, %d, %f, %d", priority, absorbMax, absorbRatio, (absorbRatio == 0 ? 0 : (int)(absorbMax * 100.0D / absorbRatio)));
         }
 
         public ArmorProperties copy()
         {
-            return new ArmorProperties(Priority, AbsorbRatio, Armor, Toughness, AbsorbMax);
+            return new ArmorProperties(priority, absorbRatio, armor, toughness, absorbMax);
         }
     }
 }

--- a/src/main/java/net/minecraftforge/common/ISpecialArmor.java
+++ b/src/main/java/net/minecraftforge/common/ISpecialArmor.java
@@ -201,26 +201,26 @@ public interface ISpecialArmor
                     }
                 }
                 damage -= (damage * ratio);
+            }
+            if (damage > 0 && (totalArmor > 0 || totalToughness > 0))
+            {
+                double armorDamage = Math.max(1.0F, damage / 4.0F);
                 
-                if (damage > 0)
+                for (int i = 0; i < inventory.size(); i++)
                 {
-                    double armorDamage = Math.max(1.0F, damage / 4.0F);
-                    
-                    for (int i = 0; i < inventory.size(); i++)
+                    if (inventory.get(i).getItem() instanceof ItemArmor)
                     {
-                        if (inventory.get(i).getItem() instanceof ItemArmor)
+                        inventory.get(i).damageItem((int)armorDamage, entity);
+                        
+                        if (inventory.get(i).getCount() == 0)
                         {
-                            inventory.get(i).damageItem((int)armorDamage, entity);
-                            
-                            if (inventory.get(i).getCount() == 0)
-                            {
-                                inventory.set(i, ItemStack.EMPTY);
-                            }
+                            inventory.set(i, ItemStack.EMPTY);
                         }
                     }
-                    
-                    damage = CombatRules.getDamageAfterAbsorb((float)damage, (float)totalArmor, (float)totalToughness);
                 }
+                System.out.println(damage);
+                damage = CombatRules.getDamageAfterAbsorb((float)damage, (float)totalArmor, (float)totalToughness);
+                System.out.println(damage);
             }
             if (DEBUG)
             {

--- a/src/main/java/net/minecraftforge/common/ISpecialArmor.java
+++ b/src/main/java/net/minecraftforge/common/ISpecialArmor.java
@@ -101,6 +101,11 @@ public interface ISpecialArmor
         private static final boolean DEBUG = false; //Only enable this if you wish to be spammed with debugging information.
                                                     //Left it in because I figured it'd be useful for modders developing custom armor.
 
+        public ArmorProperties(int priority, double ratio, int max)
+        {
+            this(priority, ratio, 0, 0, max);
+        }
+        
         public ArmorProperties(int priority, double ratio, double armor, double toughness, int max)
         {
             Priority    = priority;

--- a/src/main/java/net/minecraftforge/common/ISpecialArmor.java
+++ b/src/main/java/net/minecraftforge/common/ISpecialArmor.java
@@ -362,7 +362,7 @@ public interface ISpecialArmor
         @Override
         public String toString()
         {
-            return String.format("%d, %d, %f, %d", priority, absorbMax, absorbRatio, (absorbRatio == 0 ? 0 : (int)(absorbMax * 100.0D / absorbRatio)));
+            return String.format("%d, %d, %f, %d, %f, %f", priority, absorbMax, absorbRatio, (absorbRatio == 0 ? 0 : (int)(absorbMax * 100.0D / absorbRatio)), armor, toughness);
         }
 
         public ArmorProperties copy()

--- a/src/test/java/net/minecraftforge/test/PlayerDamageReworkTest.java
+++ b/src/test/java/net/minecraftforge/test/PlayerDamageReworkTest.java
@@ -1,0 +1,47 @@
+package net.minecraftforge.test;
+
+import java.util.UUID;
+
+import net.minecraft.entity.SharedMonsterAttributes;
+import net.minecraft.entity.ai.attributes.AttributeModifier;
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraftforge.common.MinecraftForge;
+import net.minecraftforge.event.entity.living.LivingEvent.LivingUpdateEvent;
+import net.minecraftforge.fml.common.Mod;
+import net.minecraftforge.fml.common.Mod.EventHandler;
+import net.minecraftforge.fml.common.event.FMLInitializationEvent;
+import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
+
+@Mod(modid = "playerdamagereworktest", name = "PlayerDamageReworkTest", version = "0.0.0")
+public class PlayerDamageReworkTest
+{
+    private static final boolean ENABLE = false;
+    private static final UUID ARMOR_MODIFIER_UUID = UUID.fromString("23373DC8-1F3D-11E7-93AE-92361F002671");
+    private static final AttributeModifier mod = new AttributeModifier(ARMOR_MODIFIER_UUID, "Player Damage Rework Test", 20, 0);
+
+    @EventHandler
+    public void init(FMLInitializationEvent event)
+    {
+        if (ENABLE) MinecraftForge.EVENT_BUS.register(this);
+    }
+
+    @SubscribeEvent
+    public void checkForSneakEvent(LivingUpdateEvent event)
+    {
+        if (event.getEntityLiving() instanceof EntityPlayer)
+        {
+            EntityPlayer player = (EntityPlayer) event.getEntityLiving();
+            if (player.isSneaking())
+            {
+                if (!player.getEntityAttribute(SharedMonsterAttributes.ARMOR).hasModifier(mod))
+                {
+                    player.getEntityAttribute(SharedMonsterAttributes.ARMOR).applyModifier(mod);
+                }
+            }
+            else if (player.getEntityAttribute(SharedMonsterAttributes.ARMOR).hasModifier(mod))
+            {
+                player.getEntityAttribute(SharedMonsterAttributes.ARMOR).removeModifier(ARMOR_MODIFIER_UUID);
+            }
+        }
+    }
+}


### PR DESCRIPTION
Breaking component of what was originally included in #3838.

Reworks ISpecialArmor to use EntityEquipmentSlot instead of ints to designate which slot armor pieces occupy. Also does a little cleaning of field names.