### PR TITLE
Cleaned up Chunk.relightBlock

### DIFF
--- a/patches/minecraft/net/minecraft/world/chunk/Chunk.java.patch
+++ b/patches/minecraft/net/minecraft/world/chunk/Chunk.java.patch
@@ -9,31 +9,32 @@
                      {
                          this.field_76634_f[k << 4 | j] = l;
  
-@@ -358,13 +358,14 @@
+@@ -358,13 +358,15 @@
  
          if (j != i)
          {
 -            this.field_76637_e.func_72975_g(p_76615_1_ + this.field_76635_g * 16, p_76615_3_ + this.field_76647_h * 16, j, i);
++            if (false) this.field_76637_e.func_72975_g(p_76615_1_ + this.field_76635_g * 16, p_76615_3_ + this.field_76647_h * 16, j, i); //Forge: Useless, since heightMap is not updated yet (See #3871)
              this.field_76634_f[p_76615_3_ << 4 | p_76615_1_] = j;
              int k = this.field_76635_g * 16 + p_76615_1_;
              int l = this.field_76647_h * 16 + p_76615_3_;
  
              if (this.field_76637_e.field_73011_w.func_191066_m())
              {
-+                net.minecraftforge.common.lighting.LightingHooks.relightSkylightColumn(field_76637_e, this, p_76615_1_, p_76615_3_, i, j);
-+            } else if (false) {
++                net.minecraftforge.common.lighting.LightingHooks.relightSkylightColumn(field_76637_e, this, p_76615_1_, p_76615_3_, i, j); //Forge: Optimized version of World.markBlocksDirtyVertical; heightMap is now updated (See #3871)
++            } else if (false) { //Forge: Don't mess up the light cache; World.checkLight already does all necessary steps (See #3871)
                  if (j < i)
                  {
                      for (int j1 = j; j1 < i; ++j1)
-@@ -434,6 +435,7 @@
+@@ -434,6 +436,7 @@
              {
                  this.field_82912_p = l1;
              }
-+            if (true) return;
++            if (true) return; //Forge: Following checks are not needed if the light cache is not messed up (See #3871)
  
              if (this.field_76637_e.field_73011_w.func_191066_m())
              {
-@@ -451,12 +453,13 @@
+@@ -451,12 +454,13 @@
  
      public int func_177437_b(BlockPos p_177437_1_)
      {
@@ -49,7 +50,7 @@
      }
  
      public IBlockState func_177435_g(BlockPos p_177435_1_)
-@@ -538,6 +541,7 @@
+@@ -538,6 +542,7 @@
          {
              Block block = p_177436_2_.func_177230_c();
              Block block1 = iblockstate.func_177230_c();
@@ -57,7 +58,7 @@
              ExtendedBlockStorage extendedblockstorage = this.field_76652_q[j >> 4];
              boolean flag = false;
  
-@@ -555,14 +559,19 @@
+@@ -555,14 +560,19 @@
  
              extendedblockstorage.func_177484_a(i, j & 15, k, p_177436_2_);
  
@@ -79,7 +80,7 @@
                      this.field_76637_e.func_175713_t(p_177436_1_);
                  }
              }
-@@ -579,8 +588,7 @@
+@@ -579,8 +589,7 @@
                  }
                  else
                  {
@@ -89,12 +90,12 @@
  
                      if (j1 > 0)
                      {
-@@ -594,34 +602,25 @@
+@@ -594,34 +603,25 @@
                          this.func_76615_h(i, j, k);
                      }
  
 -                    if (j1 != k1 && (j1 < k1 || this.func_177413_a(EnumSkyBlock.SKY, p_177436_1_) > 0 || this.func_177413_a(EnumSkyBlock.BLOCK, p_177436_1_) > 0))
-+                    if (false)
++                    if (false) //Forge: Error correction is unnecessary as these are fixed (See #3871)
                      {
                          this.func_76595_e(i, k);
                      }
@@ -129,7 +130,7 @@
                          this.field_76637_e.func_175690_a(p_177436_1_, tileentity1);
                      }
  
-@@ -725,6 +724,7 @@
+@@ -725,6 +725,7 @@
              k = this.field_76645_j.length - 1;
          }
  
@@ -137,7 +138,7 @@
          p_76612_1_.field_70175_ag = true;
          p_76612_1_.field_70176_ah = this.field_76635_g;
          p_76612_1_.field_70162_ai = k;
-@@ -765,7 +765,7 @@
+@@ -765,7 +766,7 @@
      {
          IBlockState iblockstate = this.func_177435_g(p_177422_1_);
          Block block = iblockstate.func_177230_c();
@@ -146,7 +147,7 @@
      }
  
      @Nullable
-@@ -773,6 +773,12 @@
+@@ -773,6 +774,12 @@
      {
          TileEntity tileentity = (TileEntity)this.field_150816_i.get(p_177424_1_);
  
@@ -159,7 +160,7 @@
          if (tileentity == null)
          {
              if (p_177424_2_ == Chunk.EnumCreateEntityType.IMMEDIATE)
-@@ -782,14 +788,9 @@
+@@ -782,14 +789,9 @@
              }
              else if (p_177424_2_ == Chunk.EnumCreateEntityType.QUEUED)
              {
@@ -175,7 +176,7 @@
  
          return tileentity;
      }
-@@ -806,10 +807,11 @@
+@@ -806,10 +808,11 @@
  
      public void func_177426_a(BlockPos p_177426_1_, TileEntity p_177426_2_)
      {
@@ -188,7 +189,7 @@
          {
              if (this.field_150816_i.containsKey(p_177426_1_))
              {
-@@ -841,8 +843,9 @@
+@@ -841,8 +844,9 @@
  
          for (ClassInheritanceMultiMap<Entity> classinheritancemultimap : this.field_76645_j)
          {
@@ -199,7 +200,7 @@
      }
  
      public void func_76623_d()
-@@ -858,6 +861,7 @@
+@@ -858,6 +862,7 @@
          {
              this.field_76637_e.func_175681_c(classinheritancemultimap);
          }
@@ -207,7 +208,7 @@
      }
  
      public void func_76630_e()
-@@ -867,8 +871,8 @@
+@@ -867,8 +872,8 @@
  
      public void func_177414_a(@Nullable Entity p_177414_1_, AxisAlignedBB p_177414_2_, List<Entity> p_177414_3_, Predicate <? super Entity > p_177414_4_)
      {
@@ -218,7 +219,7 @@
          i = MathHelper.func_76125_a(i, 0, this.field_76645_j.length - 1);
          j = MathHelper.func_76125_a(j, 0, this.field_76645_j.length - 1);
  
-@@ -905,8 +909,8 @@
+@@ -905,8 +910,8 @@
  
      public <T extends Entity> void func_177430_a(Class <? extends T > p_177430_1_, AxisAlignedBB p_177430_2_, List<T> p_177430_3_, Predicate <? super T > p_177430_4_)
      {
@@ -229,7 +230,7 @@
          i = MathHelper.func_76125_a(i, 0, this.field_76645_j.length - 1);
          j = MathHelper.func_76125_a(j, 0, this.field_76645_j.length - 1);
  
-@@ -984,6 +988,8 @@
+@@ -984,6 +989,8 @@
  
      protected void func_186034_a(IChunkGenerator p_186034_1_)
      {
@@ -238,7 +239,7 @@
          if (this.func_177419_t())
          {
              if (p_186034_1_.func_185933_a(this, this.field_76635_g, this.field_76647_h))
-@@ -995,8 +1001,10 @@
+@@ -995,8 +1002,10 @@
          {
              this.func_150809_p();
              p_186034_1_.func_185931_b(this.field_76635_g, this.field_76647_h);
@@ -249,7 +250,7 @@
      }
  
      public BlockPos func_177440_h(BlockPos p_177440_1_)
-@@ -1051,7 +1059,7 @@
+@@ -1051,7 +1060,7 @@
          {
              BlockPos blockpos = (BlockPos)this.field_177447_w.poll();
  
@@ -258,7 +259,7 @@
              {
                  TileEntity tileentity = this.func_177422_i(blockpos);
                  this.field_76637_e.func_175690_a(blockpos, tileentity);
-@@ -1115,6 +1123,13 @@
+@@ -1115,6 +1124,13 @@
      @SideOnly(Side.CLIENT)
      public void func_186033_a(PacketBuffer p_186033_1_, int p_186033_2_, boolean p_186033_3_)
      {
@@ -272,7 +273,7 @@
          boolean flag = this.field_76637_e.field_73011_w.func_191066_m();
  
          for (int i = 0; i < this.field_76652_q.length; ++i)
-@@ -1163,10 +1178,16 @@
+@@ -1163,10 +1179,16 @@
          this.field_76646_k = true;
          this.func_76590_a();
  
@@ -289,7 +290,7 @@
      }
  
      public Biome func_177411_a(BlockPos p_177411_1_, BiomeProvider p_177411_2_)
-@@ -1231,13 +1252,13 @@
+@@ -1231,13 +1253,13 @@
                      BlockPos blockpos1 = blockpos.func_177982_a(k, (j << 4) + i1, l);
                      boolean flag = i1 == 0 || i1 == 15 || k == 0 || k == 15 || l == 0 || l == 15;
  
@@ -305,7 +306,7 @@
                              {
                                  this.field_76637_e.func_175664_x(blockpos2);
                              }
-@@ -1368,7 +1389,7 @@
+@@ -1368,7 +1390,7 @@
          {
              blockpos$mutableblockpos.func_181079_c(blockpos$mutableblockpos.func_177958_n(), l, blockpos$mutableblockpos.func_177952_p());
  
@@ -314,7 +315,7 @@
              {
                  this.field_76637_e.func_175664_x(blockpos$mutableblockpos);
              }
-@@ -1476,4 +1497,34 @@
+@@ -1476,4 +1498,34 @@
          QUEUED,
          CHECK;
      }

--- a/patches/minecraft/net/minecraft/world/chunk/Chunk.java.patch
+++ b/patches/minecraft/net/minecraft/world/chunk/Chunk.java.patch
@@ -9,7 +9,31 @@
                      {
                          this.field_76634_f[k << 4 | j] = l;
  
-@@ -451,12 +451,13 @@
+@@ -358,13 +358,14 @@
+ 
+         if (j != i)
+         {
+-            this.field_76637_e.func_72975_g(p_76615_1_ + this.field_76635_g * 16, p_76615_3_ + this.field_76647_h * 16, j, i);
+             this.field_76634_f[p_76615_3_ << 4 | p_76615_1_] = j;
+             int k = this.field_76635_g * 16 + p_76615_1_;
+             int l = this.field_76647_h * 16 + p_76615_3_;
+ 
+             if (this.field_76637_e.field_73011_w.func_191066_m())
+             {
++                net.minecraftforge.common.lighting.LightingHooks.relightSkylightColumn(field_76637_e, this, p_76615_1_, p_76615_3_, i, j);
++            } else if (false) {
+                 if (j < i)
+                 {
+                     for (int j1 = j; j1 < i; ++j1)
+@@ -434,6 +435,7 @@
+             {
+                 this.field_82912_p = l1;
+             }
++            if (true) return;
+ 
+             if (this.field_76637_e.field_73011_w.func_191066_m())
+             {
+@@ -451,12 +453,13 @@
  
      public int func_177437_b(BlockPos p_177437_1_)
      {
@@ -25,7 +49,7 @@
      }
  
      public IBlockState func_177435_g(BlockPos p_177435_1_)
-@@ -538,6 +539,7 @@
+@@ -538,6 +541,7 @@
          {
              Block block = p_177436_2_.func_177230_c();
              Block block1 = iblockstate.func_177230_c();
@@ -33,7 +57,7 @@
              ExtendedBlockStorage extendedblockstorage = this.field_76652_q[j >> 4];
              boolean flag = false;
  
-@@ -555,14 +557,19 @@
+@@ -555,14 +559,19 @@
  
              extendedblockstorage.func_177484_a(i, j & 15, k, p_177436_2_);
  
@@ -55,7 +79,7 @@
                      this.field_76637_e.func_175713_t(p_177436_1_);
                  }
              }
-@@ -579,8 +586,7 @@
+@@ -579,8 +588,7 @@
                  }
                  else
                  {
@@ -65,7 +89,14 @@
  
                      if (j1 > 0)
                      {
-@@ -600,28 +606,19 @@
+@@ -594,34 +602,25 @@
+                         this.func_76615_h(i, j, k);
+                     }
+ 
+-                    if (j1 != k1 && (j1 < k1 || this.func_177413_a(EnumSkyBlock.SKY, p_177436_1_) > 0 || this.func_177413_a(EnumSkyBlock.BLOCK, p_177436_1_) > 0))
++                    if (false)
+                     {
+                         this.func_76595_e(i, k);
                      }
                  }
  
@@ -98,7 +129,7 @@
                          this.field_76637_e.func_175690_a(p_177436_1_, tileentity1);
                      }
  
-@@ -725,6 +722,7 @@
+@@ -725,6 +724,7 @@
              k = this.field_76645_j.length - 1;
          }
  
@@ -106,7 +137,7 @@
          p_76612_1_.field_70175_ag = true;
          p_76612_1_.field_70176_ah = this.field_76635_g;
          p_76612_1_.field_70162_ai = k;
-@@ -765,7 +763,7 @@
+@@ -765,7 +765,7 @@
      {
          IBlockState iblockstate = this.func_177435_g(p_177422_1_);
          Block block = iblockstate.func_177230_c();
@@ -115,7 +146,7 @@
      }
  
      @Nullable
-@@ -773,6 +771,12 @@
+@@ -773,6 +773,12 @@
      {
          TileEntity tileentity = (TileEntity)this.field_150816_i.get(p_177424_1_);
  
@@ -128,7 +159,7 @@
          if (tileentity == null)
          {
              if (p_177424_2_ == Chunk.EnumCreateEntityType.IMMEDIATE)
-@@ -782,14 +786,9 @@
+@@ -782,14 +788,9 @@
              }
              else if (p_177424_2_ == Chunk.EnumCreateEntityType.QUEUED)
              {
@@ -144,7 +175,7 @@
  
          return tileentity;
      }
-@@ -806,10 +805,11 @@
+@@ -806,10 +807,11 @@
  
      public void func_177426_a(BlockPos p_177426_1_, TileEntity p_177426_2_)
      {
@@ -157,7 +188,7 @@
          {
              if (this.field_150816_i.containsKey(p_177426_1_))
              {
-@@ -841,8 +841,9 @@
+@@ -841,8 +843,9 @@
  
          for (ClassInheritanceMultiMap<Entity> classinheritancemultimap : this.field_76645_j)
          {
@@ -168,7 +199,7 @@
      }
  
      public void func_76623_d()
-@@ -858,6 +859,7 @@
+@@ -858,6 +861,7 @@
          {
              this.field_76637_e.func_175681_c(classinheritancemultimap);
          }
@@ -176,7 +207,7 @@
      }
  
      public void func_76630_e()
-@@ -867,8 +869,8 @@
+@@ -867,8 +871,8 @@
  
      public void func_177414_a(@Nullable Entity p_177414_1_, AxisAlignedBB p_177414_2_, List<Entity> p_177414_3_, Predicate <? super Entity > p_177414_4_)
      {
@@ -187,7 +218,7 @@
          i = MathHelper.func_76125_a(i, 0, this.field_76645_j.length - 1);
          j = MathHelper.func_76125_a(j, 0, this.field_76645_j.length - 1);
  
-@@ -905,8 +907,8 @@
+@@ -905,8 +909,8 @@
  
      public <T extends Entity> void func_177430_a(Class <? extends T > p_177430_1_, AxisAlignedBB p_177430_2_, List<T> p_177430_3_, Predicate <? super T > p_177430_4_)
      {
@@ -198,7 +229,7 @@
          i = MathHelper.func_76125_a(i, 0, this.field_76645_j.length - 1);
          j = MathHelper.func_76125_a(j, 0, this.field_76645_j.length - 1);
  
-@@ -984,6 +986,8 @@
+@@ -984,6 +988,8 @@
  
      protected void func_186034_a(IChunkGenerator p_186034_1_)
      {
@@ -207,7 +238,7 @@
          if (this.func_177419_t())
          {
              if (p_186034_1_.func_185933_a(this, this.field_76635_g, this.field_76647_h))
-@@ -995,8 +999,10 @@
+@@ -995,8 +1001,10 @@
          {
              this.func_150809_p();
              p_186034_1_.func_185931_b(this.field_76635_g, this.field_76647_h);
@@ -218,7 +249,7 @@
      }
  
      public BlockPos func_177440_h(BlockPos p_177440_1_)
-@@ -1051,7 +1057,7 @@
+@@ -1051,7 +1059,7 @@
          {
              BlockPos blockpos = (BlockPos)this.field_177447_w.poll();
  
@@ -227,7 +258,7 @@
              {
                  TileEntity tileentity = this.func_177422_i(blockpos);
                  this.field_76637_e.func_175690_a(blockpos, tileentity);
-@@ -1115,6 +1121,13 @@
+@@ -1115,6 +1123,13 @@
      @SideOnly(Side.CLIENT)
      public void func_186033_a(PacketBuffer p_186033_1_, int p_186033_2_, boolean p_186033_3_)
      {
@@ -241,7 +272,7 @@
          boolean flag = this.field_76637_e.field_73011_w.func_191066_m();
  
          for (int i = 0; i < this.field_76652_q.length; ++i)
-@@ -1163,10 +1176,16 @@
+@@ -1163,10 +1178,16 @@
          this.field_76646_k = true;
          this.func_76590_a();
  
@@ -258,7 +289,7 @@
      }
  
      public Biome func_177411_a(BlockPos p_177411_1_, BiomeProvider p_177411_2_)
-@@ -1231,13 +1250,13 @@
+@@ -1231,13 +1252,13 @@
                      BlockPos blockpos1 = blockpos.func_177982_a(k, (j << 4) + i1, l);
                      boolean flag = i1 == 0 || i1 == 15 || k == 0 || k == 15 || l == 0 || l == 15;
  
@@ -274,7 +305,7 @@
                              {
                                  this.field_76637_e.func_175664_x(blockpos2);
                              }
-@@ -1368,7 +1387,7 @@
+@@ -1368,7 +1389,7 @@
          {
              blockpos$mutableblockpos.func_181079_c(blockpos$mutableblockpos.func_177958_n(), l, blockpos$mutableblockpos.func_177952_p());
  
@@ -283,7 +314,7 @@
              {
                  this.field_76637_e.func_175664_x(blockpos$mutableblockpos);
              }
-@@ -1476,4 +1495,34 @@
+@@ -1476,4 +1497,34 @@
          QUEUED,
          CHECK;
      }

--- a/src/main/java/net/minecraftforge/common/lighting/LightingHooks.java
+++ b/src/main/java/net/minecraftforge/common/lighting/LightingHooks.java
@@ -38,9 +38,12 @@ public class LightingHooks
         final int xBase = (chunk.xPosition << 4) + x;
         final int zBase = (chunk.zPosition << 4) + z;
 
-        for (int y = yMax; y >= yMin; --y)
+        int y;
+        ExtendedBlockStorage section = null;
+
+        for (y = yMax; y >= yMin; --y)
         {
-            final ExtendedBlockStorage section = sections[y >> 4];
+            section = sections[y >> 4];
 
             if (section == Chunk.NULL_BLOCK_STORAGE)
             {
@@ -50,6 +53,11 @@ public class LightingHooks
                 }
             }
 
+            world.checkLightFor(EnumSkyBlock.SKY, new BlockPos(xBase, y, zBase));
+        }
+
+        if (section == Chunk.NULL_BLOCK_STORAGE && y >= 0)
+        {
             world.checkLightFor(EnumSkyBlock.SKY, new BlockPos(xBase, y, zBase));
         }
     }

--- a/src/main/java/net/minecraftforge/common/lighting/LightingHooks.java
+++ b/src/main/java/net/minecraftforge/common/lighting/LightingHooks.java
@@ -1,0 +1,56 @@
+/*
+ * Minecraft Forge
+ * Copyright (c) 2016.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation version 2.1
+ * of the License.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+package net.minecraftforge.common.lighting;
+
+import net.minecraft.util.EnumFacing;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.EnumSkyBlock;
+import net.minecraft.world.World;
+import net.minecraft.world.chunk.Chunk;
+import net.minecraft.world.chunk.storage.ExtendedBlockStorage;
+
+public class LightingHooks
+{
+    public static void relightSkylightColumn(final World world, final Chunk chunk, final int x, final int z, final int height1, final int height2)
+    {
+        final int yMin = Math.min(height1, height2);
+        final int yMax = Math.max(height1, height2) - 1;
+
+        final ExtendedBlockStorage[] sections = chunk.getBlockStorageArray();
+
+        final int xBase = (chunk.xPosition << 4) + x;
+        final int zBase = (chunk.zPosition << 4) + z;
+
+        for (int y = yMax; y >= yMin; --y)
+        {
+            final ExtendedBlockStorage section = sections[y >> 4];
+
+            if (section == Chunk.NULL_BLOCK_STORAGE)
+            {
+                for (final EnumFacing dir : EnumFacing.HORIZONTALS)
+                {
+                    world.checkLightFor(EnumSkyBlock.SKY, new BlockPos(xBase + dir.getFrontOffsetX(), y, zBase + dir.getFrontOffsetZ()));
+                }
+            }
+
+            world.checkLightFor(EnumSkyBlock.SKY, new BlockPos(xBase, y, zBase));
+        }
+    }
+}


### PR DESCRIPTION
This PR is the second one in our attempt to fix and optimize the vanilla lighting engine (first one: #3870). For more details see #3848. As suggested there, we'll try to break the changes into as many PRs as possible.

This particular PR speeds up `Chunk.relightBlock` by removing some unnecessary stuff and fixes part of the issue described in [MC-46129](https://bugs.mojang.com/browse/MC-46129) (see the second image: placing a platform over a forest causes the leaves of the trees to stay bright; another part of the issue is fixed by #3870) **[Edit]** See [MC-117067](https://bugs.mojang.com/browse/MC-117067) for an issue describing only this bug **[/Edit]**

| | What vanilla does | What we do | Remarks/Description |
| --- | ---- | ---- | ---- |
| 1. | Recalculate the height of the column |  |  |
| 2. | Call to `World` `.markBlocksDirtyVertical` | Remove it | This marks the block for rendering (which is already done for light updates) and recalculates the light for the affected part of the column (which is useless, as the `heightMap` is only updated after the call)|
| 3. | | Call the new `LightingHooks` `.relightSkylightColumn` | See below |
| 4. | Try to guess the light values of the columns | Bypass it | This essentially breaks the checks that come afterwards, which is part of the cause of [MC-117067](https://bugs.mojang.com/browse/MC-117067) |
| 5. | Schedule checks for column + 4 neighbors | Bypass it | It suffices to recalculate the column, provided the light map is not messed up by the above. Since the light values are wrong, the fact that the block below is not checked causes [MC-117067](https://bugs.mojang.com/browse/MC-117067) |

The lighting engine correctly calculates the source light values for the sky light (i.e. 15 above the first non-transparent block, and 0 below) - this means that nothing needs to be calculated manually.

What `LightingHooks.relightSkylightColumn` does:
* Just let the affected part of the column be rechecked by the lighting engine, which handles everything correctly
* For empty sections, we need to look at the neighboring blocks too, as there are no old light values to be checked against (since `chunk.getLightFor` simply looks at the `heightMap` for empty sections, light changes won't be detected)

Regarding [line 97](https://github.com/MinecraftForge/MinecraftForge/compare/1.11.x...Mathe172:lighting_cleanup?expand=1#diff-496aa22ea49bec02cab69d859142959dR97):
`Chunk.propagateSkylightOcclusion` indirectly calls `recheckGaps`, which is supposed to (as far as we can judge) fix issues in the light map. Those can be caused by one of the following:
* Neighboring chunks are not loaded. `recheckGaps` can't do anything in this case - while it would wait for the neighboring chunks to be loaded, it forgets this as soon as the chunk itself is unloaded, which makes the "fix" very unreliable in the first place. During world-gen, this call is irrelevant, as the checks are scheduled by `Chunk.checkLight`. Also, the condition above the call is hard to achieve and doesn't apply in many of the cases where it should.
* `Chunk.generateSkylightMap` is called - since that is broken anyway (and fixed in #3870) and isn't fully fixed by `recheckGaps`, this is also irrelevant
* `Chunk.relightBlock` is called, which is fixed in this PR.

Remarks:
* This PR removes 5/6 of the checks of `Chunk.relightBlock` and all of `recheckGaps`, while also making it more understandable. (We know the checks are very cheap, but they take a big part of the time of the lighting engine)
* We created LightingHooks as we plan to add a few more fixes in the near future (see e.g. #3870). If needed, we can move it to somewhere else until there's enough for a new file.
* In order to see the correct result for [MC-117067](https://bugs.mojang.com/browse/MC-117067), you need to relog (because of some client syncing bugs, which we plan to address later)
* If you spawn a platform over a forest, there will be bright spots on the ceiling (and in the column below) (fixed by #3870)
* The commits are incompatible with #3870, as we didn't want them to depend on each other. We will regen them should one be accepted.