### PR TITLE
Fix MC-117075 performance issue when unloading many tile entities.

### DIFF
--- a/patches/minecraft/net/minecraft/world/World.java.patch
+++ b/patches/minecraft/net/minecraft/world/World.java.patch
@@ -1,6 +1,6 @@
 --- ../src-base/minecraft/net/minecraft/world/World.java
 +++ ../src-work/minecraft/net/minecraft/world/World.java
-@@ -59,8 +59,15 @@
+@@ -59,14 +59,21 @@
  import net.minecraftforge.fml.relauncher.Side;
  import net.minecraftforge.fml.relauncher.SideOnly;
  
@@ -17,6 +17,14 @@
      private int field_181546_a = 63;
      protected boolean field_72999_e;
      public final List<Entity> field_72996_f = Lists.<Entity>newArrayList();
+     protected final List<Entity> field_72997_g = Lists.<Entity>newArrayList();
+-    public final List<TileEntity> field_147482_g = Lists.<TileEntity>newArrayList();
+-    public final List<TileEntity> field_175730_i = Lists.<TileEntity>newArrayList();
++    public final List<TileEntity> field_147482_g = new net.minecraftforge.common.util.SetBackedList<TileEntity>(); // MC-117075 performance issue when unloading many tile entities
++    public final List<TileEntity> field_175730_i = new net.minecraftforge.common.util.SetBackedList<TileEntity>(); // MC-117075 performance issue when unloading many tile entities
+     private final List<TileEntity> field_147484_a = Lists.<TileEntity>newArrayList();
+     private final List<TileEntity> field_147483_b = Lists.<TileEntity>newArrayList();
+     public final List<EntityPlayer> field_73010_i = Lists.<EntityPlayer>newArrayList();
 @@ -102,6 +109,12 @@
      private final WorldBorder field_175728_M;
      int[] field_72994_J;

--- a/src/main/java/net/minecraftforge/common/util/SetBackedList.java
+++ b/src/main/java/net/minecraftforge/common/util/SetBackedList.java
@@ -101,6 +101,11 @@ public class SetBackedList<T> extends AbstractList<T>
     @Override
     public T get(int index)
     {
+        if (index < 0)
+        {
+            throw new IndexOutOfBoundsException();
+        }
+
         for (T value : set)
         {
             if (index == 0)
@@ -112,6 +117,7 @@ public class SetBackedList<T> extends AbstractList<T>
                 index--;
             }
         }
+        
         throw new IndexOutOfBoundsException();
     }
 }

--- a/src/main/java/net/minecraftforge/common/util/SetBackedList.java
+++ b/src/main/java/net/minecraftforge/common/util/SetBackedList.java
@@ -27,7 +27,7 @@ import java.util.LinkedHashSet;
 /**
  * A List implementation with O(1) {@link #contains(Object)} and {@link #remove(Object)}.
  *
- * Sacrifices performance of ordered operations like {@link #get(int)} and {@link #remove(int)}.
+ * Sacrifices performance of ordered operations like {@link #get(int)}, {@link #remove(int)}, and ListIterator.
  * Does not support {@link #set(int, Object)} or {@link #add(int, Object)}.
  * Does not support duplicate elements.
  *
@@ -117,7 +117,7 @@ public class SetBackedList<T> extends AbstractList<T>
                 index--;
             }
         }
-        
+
         throw new IndexOutOfBoundsException();
     }
 }

--- a/src/main/java/net/minecraftforge/common/util/SetBackedList.java
+++ b/src/main/java/net/minecraftforge/common/util/SetBackedList.java
@@ -1,0 +1,117 @@
+/*
+ * Minecraft Forge
+ * Copyright (c) 2016.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation version 2.1
+ * of the License.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+package net.minecraftforge.common.util;
+
+import javax.annotation.Nonnull;
+import java.util.AbstractList;
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.LinkedHashSet;
+
+/**
+ * A List implementation with O(1) {@link #contains(Object)} and {@link #remove(Object)}.
+ *
+ * Sacrifices performance of ordered operations like {@link #get(int)} and {@link #remove(int)}.
+ * Does not support {@link #set(int, Object)} or {@link #add(int, Object)}.
+ * Does not support duplicate elements.
+ *
+ * Only useful for replacing vanilla Lists that are used exactly like Sets, without breaking binary compatibility.
+ * If you're making a mod and need an ordered collection with fast contains and remove, use {@link LinkedHashSet} instead.
+ */
+public class SetBackedList<T> extends AbstractList<T>
+{
+    private final LinkedHashSet<T> set = new LinkedHashSet<T>();
+
+    @Override
+    public boolean add(T element)
+    {
+        return set.add(element);
+    }
+
+    @Override
+    public boolean remove(Object o)
+    {
+        return set.remove(o);
+    }
+
+    @Override
+    public T remove(int index)
+    {
+        T value = get(index);
+        if (remove(value))
+        {
+            return value;
+        }
+        return null;
+    }
+
+    @Override
+    public boolean removeAll(@Nonnull Collection<?> c)
+    {
+        return set.removeAll(c);
+    }
+
+    @Override
+    public boolean contains(Object o)
+    {
+        return set.contains(o);
+    }
+
+    @Override
+    public boolean containsAll(@Nonnull Collection<?> c)
+    {
+        return set.containsAll(c);
+    }
+
+    @Override
+    public int size()
+    {
+        return set.size();
+    }
+
+    @Override
+    public void clear()
+    {
+        set.clear();
+    }
+
+    @Nonnull
+    @Override
+    public Iterator<T> iterator()
+    {
+        return set.iterator();
+    }
+
+    @Override
+    public T get(int index)
+    {
+        for (T value : set)
+        {
+            if (index == 0)
+            {
+                return value;
+            }
+            else
+            {
+                index--;
+            }
+        }
+        throw new IndexOutOfBoundsException();
+    }
+}


### PR DESCRIPTION
Vanilla issue explained here:
https://bugs.mojang.com/browse/MC-117075

This helps with lag from Forestry leaves, which are non-ticking tile entities. I think there are many similar decorative blocks in modded Minecraft from common mods like Chisel and Bits and Carpenter's Blocks.
https://github.com/ForestryMC/ForestryMC/issues/1661

The Forge fix can't actually change the fields to `Set` because of binary compatibility, so I created a `List` implementation that has the performance characteristics of `Set` and used it for these two fields.

Image of (some of) the trees I tested:
![2017-05-05_15 13 32](https://cloud.githubusercontent.com/assets/916092/25767204/3396222a-31ac-11e7-89e4-be17c8ee3bdf.png)

Performance test before PR (tons of time wasted in `List.removeAll`):
![javaw_2017-05-05_15-15-25](https://cloud.githubusercontent.com/assets/916092/25767215/4426746e-31ac-11e7-94ca-d6685edbef08.png)

Performance test after PR (`removeAll` is not even visible here):
![javaw_2017-05-05_15-15-34](https://cloud.githubusercontent.com/assets/916092/25767226/5c25fda0-31ac-11e7-8037-78f4500f97a7.png)

There is another set of tests in the vanilla issue using `Set` and vanilla furnaces instead, with similar results.