### PR TITLE
Fix MC-117087, prevent calling Class.getSimpleName on TEs unnecessarily

### DIFF
--- a/patches/minecraft/net/minecraft/profiler/Profiler.java.patch
+++ b/patches/minecraft/net/minecraft/profiler/Profiler.java.patch
@@ -1,0 +1,18 @@
+--- ../src-base/minecraft/net/minecraft/profiler/Profiler.java
++++ ../src-work/minecraft/net/minecraft/profiler/Profiler.java
+@@ -170,4 +170,15 @@
+                 return (this.field_76331_c.hashCode() & 11184810) + 4473924;
+             }
+         }
++
++    /**
++     * Forge: Fix for MC-117087, World.updateEntities is wasting time calling Class.getSimpleName() when the profiler is not active
++     */
++    public void startSection(Class<?> profiledClass)
++    {
++        if (this.field_76327_a)
++        {
++            func_76320_a(profiledClass.getSimpleName());
++        }
++    }
+ }

--- a/patches/minecraft/net/minecraft/world/World.java.patch
+++ b/patches/minecraft/net/minecraft/world/World.java.patch
@@ -405,7 +405,7 @@
                      throw new ReportedException(crashreport1);
                  }
              }
-@@ -1678,7 +1794,7 @@
+@@ -1678,11 +1794,11 @@
              {
                  BlockPos blockpos = tileentity.func_174877_v();
  
@@ -414,6 +414,11 @@
                  {
                      try
                      {
+-                        this.field_72984_F.func_76320_a(tileentity.getClass().getSimpleName());
++                        this.field_72984_F.startSection(tileentity.getClass()); // Fix for MC-117087
+                         ((ITickable)tileentity).func_73660_a();
+                         this.field_72984_F.func_76319_b();
+                     }
 @@ -1691,6 +1807,13 @@
                          CrashReport crashreport2 = CrashReport.func_85055_a(throwable, "Ticking block entity");
                          CrashReportCategory crashreportcategory2 = crashreport2.func_85058_a("Block entity being ticked");


### PR DESCRIPTION
Vanilla issue description is here: https://bugs.mojang.com/browse/MC-117087

With lots of inactive ticking tile entities, calls to `Class.getSimpleName` for the profiler can take a lot of time, even though the profiler is disabled.
This PR puts calls to `Class.getSimpleName` for the profiler behind `if (profilingEnabled)`.
This is a small optimization that saves CPU and some object allocations for new Strings from `getSimpleName`.

Based on profiling the PR, `World.updateEntities` takes a smaller percentage of the total time than before.

Before PR:
![getsimplename](https://cloud.githubusercontent.com/assets/916092/25769862/963e7fda-31d9-11e7-9c88-d2533e864888.png)

After PR:
![javaw_2017-05-05_21-27-25](https://cloud.githubusercontent.com/assets/916092/25769868/b6edea4a-31d9-11e7-9b65-bd7112dbba4b.png)