### PR TITLE
Implemented LightingEngine to improve multi light change handling

### DIFF
--- a/patches/minecraft/net/minecraft/client/Minecraft.java.patch
+++ b/patches/minecraft/net/minecraft/client/Minecraft.java.patch
@@ -219,7 +219,16 @@
              }
  
              this.field_71424_I.func_76318_c("gameRenderer");
-@@ -1819,6 +1844,7 @@
+@@ -1740,6 +1765,8 @@
+                 this.field_71460_t.func_78464_a();
+             }
+ 
++            this.field_71424_I.func_76318_c("lighting");
++            this.field_71441_e.lightingEngine.procLightUpdates();
+             this.field_71424_I.func_76318_c("levelRenderer");
+ 
+             if (!this.field_71445_n)
+@@ -1819,6 +1846,7 @@
          }
  
          this.field_71424_I.func_76319_b();
@@ -227,7 +236,7 @@
          this.field_71423_H = func_71386_F();
      }
  
-@@ -1924,6 +1950,7 @@
+@@ -1924,6 +1952,7 @@
                      }
                  }
              }
@@ -235,7 +244,7 @@
          }
  
          this.func_184117_aA();
-@@ -2170,6 +2197,8 @@
+@@ -2170,6 +2199,8 @@
      {
          while (Mouse.next())
          {
@@ -244,7 +253,7 @@
              int i = Mouse.getEventButton();
              KeyBinding.func_74510_a(i - 100, Mouse.getEventButtonState());
  
-@@ -2235,6 +2264,7 @@
+@@ -2235,6 +2266,7 @@
  
      public void func_71371_a(String p_71371_1_, String p_71371_2_, @Nullable WorldSettings p_71371_3_)
      {
@@ -252,7 +261,7 @@
          this.func_71403_a((WorldClient)null);
          System.gc();
          ISaveHandler isavehandler = this.field_71469_aa.func_75804_a(p_71371_1_, false);
-@@ -2277,6 +2307,12 @@
+@@ -2277,6 +2309,12 @@
  
          while (!this.field_71437_Z.func_71200_ad())
          {
@@ -265,7 +274,7 @@
              String s = this.field_71437_Z.func_71195_b_();
  
              if (s != null)
-@@ -2302,8 +2338,14 @@
+@@ -2302,8 +2340,14 @@
          SocketAddress socketaddress = this.field_71437_Z.func_147137_ag().func_151270_a();
          NetworkManager networkmanager = NetworkManager.func_150722_a(socketaddress);
          networkmanager.func_150719_a(new NetHandlerLoginClient(networkmanager, this, (GuiScreen)null));
@@ -282,7 +291,7 @@
          this.field_71453_ak = networkmanager;
      }
  
-@@ -2314,6 +2356,8 @@
+@@ -2314,6 +2358,8 @@
  
      public void func_71353_a(@Nullable WorldClient p_71353_1_, String p_71353_2_)
      {
@@ -291,7 +300,7 @@
          if (p_71353_1_ == null)
          {
              NetHandlerPlayClient nethandlerplayclient = this.func_147114_u();
-@@ -2326,6 +2370,18 @@
+@@ -2326,6 +2372,18 @@
              if (this.field_71437_Z != null && this.field_71437_Z.func_175578_N())
              {
                  this.field_71437_Z.func_71263_m();
@@ -310,7 +319,7 @@
              }
  
              this.field_71437_Z = null;
-@@ -2349,6 +2405,7 @@
+@@ -2349,6 +2407,7 @@
              this.field_71456_v.func_181029_i();
              this.func_71351_a((ServerData)null);
              this.field_71455_al = false;
@@ -318,7 +327,7 @@
          }
  
          this.field_147127_av.func_147690_c();
-@@ -2466,159 +2523,8 @@
+@@ -2466,159 +2525,8 @@
      {
          if (this.field_71476_x != null && this.field_71476_x.field_72313_a != RayTraceResult.Type.MISS)
          {
@@ -480,7 +489,7 @@
          }
      }
  
-@@ -2921,18 +2827,8 @@
+@@ -2921,18 +2829,8 @@
  
      public static int func_71369_N()
      {
@@ -501,7 +510,7 @@
      }
  
      public boolean func_70002_Q()
-@@ -3071,15 +2967,16 @@
+@@ -3071,15 +2969,16 @@
              {
                  if (Keyboard.getEventKeyState())
                  {
@@ -520,7 +529,7 @@
              }
          }
      }
-@@ -3199,6 +3096,12 @@
+@@ -3199,6 +3098,12 @@
          return this.field_184127_aH;
      }
  

--- a/patches/minecraft/net/minecraft/network/play/server/SPacketChunkData.java.patch
+++ b/patches/minecraft/net/minecraft/network/play/server/SPacketChunkData.java.patch
@@ -1,0 +1,10 @@
+--- ../src-base/minecraft/net/minecraft/network/play/server/SPacketChunkData.java
++++ ../src-work/minecraft/net/minecraft/network/play/server/SPacketChunkData.java
+@@ -32,6 +32,7 @@
+ 
+     public SPacketChunkData(Chunk p_i47124_1_, int p_i47124_2_)
+     {
++        p_i47124_1_.func_177412_p().lightingEngine.procLightUpdates();
+         this.field_149284_a = p_i47124_1_.field_76635_g;
+         this.field_149282_b = p_i47124_1_.field_76647_h;
+         this.field_149279_g = p_i47124_2_ == 65535;

--- a/patches/minecraft/net/minecraft/world/World.java.patch
+++ b/patches/minecraft/net/minecraft/world/World.java.patch
@@ -17,7 +17,7 @@
      private int field_181546_a = 63;
      protected boolean field_72999_e;
      public final List<Entity> field_72996_f = Lists.<Entity>newArrayList();
-@@ -102,6 +109,12 @@
+@@ -102,6 +109,13 @@
      private final WorldBorder field_175728_M;
      int[] field_72994_J;
  
@@ -26,19 +26,21 @@
 +    public java.util.ArrayList<net.minecraftforge.common.util.BlockSnapshot> capturedBlockSnapshots = new java.util.ArrayList<net.minecraftforge.common.util.BlockSnapshot>();
 +    private net.minecraftforge.common.capabilities.CapabilityDispatcher capabilities;
 +    private net.minecraftforge.common.util.WorldCapabilityData capabilityData;
++    public final net.minecraftforge.common.lighting.LightingEngine lightingEngine;
 +
      protected World(ISaveHandler p_i45749_1_, WorldInfo p_i45749_2_, WorldProvider p_i45749_3_, Profiler p_i45749_4_, boolean p_i45749_5_)
      {
          this.field_73021_x = Lists.newArrayList(new IWorldEventListener[] {this.field_184152_t});
-@@ -116,6 +129,7 @@
+@@ -116,6 +130,8 @@
          this.field_73011_w = p_i45749_3_;
          this.field_72995_K = p_i45749_5_;
          this.field_175728_M = p_i45749_3_.func_177501_r();
 +        perWorldStorage = new MapStorage((ISaveHandler)null);
++        this.lightingEngine = new net.minecraftforge.common.lighting.LightingEngine(this);
      }
  
      public World func_175643_b()
-@@ -125,6 +139,11 @@
+@@ -125,6 +141,11 @@
  
      public Biome func_180494_b(final BlockPos p_180494_1_)
      {
@@ -50,7 +52,7 @@
          if (this.func_175667_e(p_180494_1_))
          {
              Chunk chunk = this.func_175726_f(p_180494_1_);
-@@ -201,7 +220,7 @@
+@@ -201,7 +222,7 @@
  
      public boolean func_175623_d(BlockPos p_175623_1_)
      {
@@ -59,7 +61,7 @@
      }
  
      public boolean func_175667_e(BlockPos p_175667_1_)
-@@ -302,24 +321,50 @@
+@@ -302,24 +323,50 @@
          else
          {
              Chunk chunk = this.func_175726_f(p_180501_1_);
@@ -113,7 +115,7 @@
                      this.func_184138_a(p_180501_1_, iblockstate, p_180501_2_, p_180501_3_);
                  }
  
-@@ -336,8 +381,6 @@
+@@ -336,8 +383,6 @@
                  {
                      this.func_190522_c(p_180501_1_, block);
                  }
@@ -122,7 +124,7 @@
              }
          }
      }
-@@ -352,7 +395,7 @@
+@@ -352,7 +397,7 @@
          IBlockState iblockstate = this.func_180495_p(p_175655_1_);
          Block block = iblockstate.func_177230_c();
  
@@ -131,7 +133,7 @@
          {
              return false;
          }
-@@ -435,6 +478,9 @@
+@@ -435,6 +480,9 @@
  
      public void func_175685_c(BlockPos p_175685_1_, Block p_175685_2_, boolean p_175685_3_)
      {
@@ -141,7 +143,7 @@
          this.func_190524_a(p_175685_1_.func_177976_e(), p_175685_2_, p_175685_1_);
          this.func_190524_a(p_175685_1_.func_177974_f(), p_175685_2_, p_175685_1_);
          this.func_190524_a(p_175685_1_.func_177977_b(), p_175685_2_, p_175685_1_);
-@@ -450,6 +496,11 @@
+@@ -450,6 +498,11 @@
  
      public void func_175695_a(BlockPos p_175695_1_, Block p_175695_2_, EnumFacing p_175695_3_)
      {
@@ -153,7 +155,7 @@
          if (p_175695_3_ != EnumFacing.WEST)
          {
              this.func_190524_a(p_175695_1_.func_177976_e(), p_175695_2_, p_175695_1_);
-@@ -521,11 +572,11 @@
+@@ -521,11 +574,11 @@
          {
              IBlockState iblockstate = this.func_180495_p(p_190529_1_);
  
@@ -167,7 +169,7 @@
                  }
                  catch (Throwable throwable)
                  {
-@@ -582,7 +633,7 @@
+@@ -582,7 +635,7 @@
                  {
                      IBlockState iblockstate = this.func_180495_p(blockpos);
  
@@ -176,7 +178,7 @@
                      {
                          return false;
                      }
-@@ -856,7 +907,7 @@
+@@ -856,7 +909,7 @@
  
      public boolean func_72935_r()
      {
@@ -185,7 +187,7 @@
      }
  
      @Nullable
-@@ -1059,6 +1110,13 @@
+@@ -1059,6 +1112,13 @@
  
      public void func_184148_a(@Nullable EntityPlayer p_184148_1_, double p_184148_2_, double p_184148_4_, double p_184148_6_, SoundEvent p_184148_8_, SoundCategory p_184148_9_, float p_184148_10_, float p_184148_11_)
      {
@@ -199,7 +201,7 @@
          for (int i = 0; i < this.field_73021_x.size(); ++i)
          {
              ((IWorldEventListener)this.field_73021_x.get(i)).func_184375_a(p_184148_1_, p_184148_8_, p_184148_9_, p_184148_2_, p_184148_4_, p_184148_6_, p_184148_10_, p_184148_11_);
-@@ -1112,6 +1170,9 @@
+@@ -1112,6 +1172,9 @@
  
      public boolean func_72838_d(Entity p_72838_1_)
      {
@@ -209,7 +211,7 @@
          int i = MathHelper.func_76128_c(p_72838_1_.field_70165_t / 16.0D);
          int j = MathHelper.func_76128_c(p_72838_1_.field_70161_v / 16.0D);
          boolean flag = p_72838_1_.field_98038_p;
-@@ -1134,6 +1195,8 @@
+@@ -1134,6 +1197,8 @@
                  this.func_72854_c();
              }
  
@@ -218,7 +220,7 @@
              this.func_72964_e(i, j).func_76612_a(p_72838_1_);
              this.field_72996_f.add(p_72838_1_);
              this.func_72923_a(p_72838_1_);
-@@ -1262,6 +1325,7 @@
+@@ -1262,6 +1327,7 @@
                                  }
  
                                  iblockstate1.func_185908_a(this, blockpos$pooledmutableblockpos, p_191504_2_, p_191504_4_, p_191504_1_, false);
@@ -226,7 +228,7 @@
  
                                  if (p_191504_3_ && !p_191504_4_.isEmpty())
                                  {
-@@ -1313,11 +1377,10 @@
+@@ -1313,11 +1379,10 @@
                  }
              }
          }
@@ -239,7 +241,7 @@
      public void func_72848_b(IWorldEventListener p_72848_1_)
      {
          this.field_73021_x.remove(p_72848_1_);
-@@ -1355,19 +1418,38 @@
+@@ -1355,19 +1420,38 @@
  
      public int func_72967_a(float p_72967_1_)
      {
@@ -280,7 +282,7 @@
          float f = this.func_72826_c(p_72971_1_);
          float f1 = 1.0F - (MathHelper.func_76134_b(f * ((float)Math.PI * 2F)) * 2.0F + 0.2F);
          f1 = MathHelper.func_76131_a(f1, 0.0F, 1.0F);
-@@ -1380,6 +1462,12 @@
+@@ -1380,6 +1464,12 @@
      @SideOnly(Side.CLIENT)
      public Vec3d func_72833_a(Entity p_72833_1_, float p_72833_2_)
      {
@@ -293,7 +295,7 @@
          float f = this.func_72826_c(p_72833_2_);
          float f1 = MathHelper.func_76134_b(f * ((float)Math.PI * 2F)) * 2.0F + 0.5F;
          f1 = MathHelper.func_76131_a(f1, 0.0F, 1.0F);
-@@ -1387,9 +1475,7 @@
+@@ -1387,9 +1477,7 @@
          int j = MathHelper.func_76128_c(p_72833_1_.field_70163_u);
          int k = MathHelper.func_76128_c(p_72833_1_.field_70161_v);
          BlockPos blockpos = new BlockPos(i, j, k);
@@ -304,7 +306,7 @@
          float f3 = (float)(l >> 16 & 255) / 255.0F;
          float f4 = (float)(l >> 8 & 255) / 255.0F;
          float f5 = (float)(l & 255) / 255.0F;
-@@ -1438,20 +1524,25 @@
+@@ -1438,20 +1526,25 @@
  
      public float func_72826_c(float p_72826_1_)
      {
@@ -333,7 +335,7 @@
      public float func_72929_e(float p_72929_1_)
      {
          float f = this.func_72826_c(p_72929_1_);
-@@ -1461,6 +1552,12 @@
+@@ -1461,6 +1554,12 @@
      @SideOnly(Side.CLIENT)
      public Vec3d func_72824_f(float p_72824_1_)
      {
@@ -346,7 +348,7 @@
          float f = this.func_72826_c(p_72824_1_);
          float f1 = MathHelper.func_76134_b(f * ((float)Math.PI * 2F)) * 2.0F + 0.5F;
          f1 = MathHelper.func_76131_a(f1, 0.0F, 1.0F);
-@@ -1516,9 +1613,9 @@
+@@ -1516,9 +1615,9 @@
          for (blockpos = new BlockPos(p_175672_1_.func_177958_n(), chunk.func_76625_h() + 16, p_175672_1_.func_177952_p()); blockpos.func_177956_o() >= 0; blockpos = blockpos1)
          {
              blockpos1 = blockpos.func_177977_b();
@@ -358,7 +360,7 @@
              {
                  break;
              }
-@@ -1530,6 +1627,12 @@
+@@ -1530,6 +1629,12 @@
      @SideOnly(Side.CLIENT)
      public float func_72880_h(float p_72880_1_)
      {
@@ -371,7 +373,7 @@
          float f = this.func_72826_c(p_72880_1_);
          float f1 = 1.0F - (MathHelper.func_76134_b(f * ((float)Math.PI * 2F)) * 2.0F + 0.25F);
          f1 = MathHelper.func_76131_a(f1, 0.0F, 1.0F);
-@@ -1564,6 +1667,7 @@
+@@ -1564,6 +1669,7 @@
  
              try
              {
@@ -379,7 +381,7 @@
                  ++entity.field_70173_aa;
                  entity.func_70071_h_();
              }
-@@ -1581,6 +1685,12 @@
+@@ -1581,6 +1687,12 @@
                      entity.func_85029_a(crashreportcategory);
                  }
  
@@ -392,7 +394,7 @@
                  throw new ReportedException(crashreport);
              }
  
-@@ -1642,6 +1752,12 @@
+@@ -1642,6 +1754,12 @@
                      CrashReport crashreport1 = CrashReport.func_85055_a(throwable1, "Ticking entity");
                      CrashReportCategory crashreportcategory1 = crashreport1.func_85058_a("Entity being ticked");
                      entity2.func_85029_a(crashreportcategory1);
@@ -405,7 +407,7 @@
                      throw new ReportedException(crashreport1);
                  }
              }
-@@ -1678,11 +1794,11 @@
+@@ -1678,11 +1796,11 @@
              {
                  BlockPos blockpos = tileentity.func_174877_v();
  
@@ -419,7 +421,7 @@
                          ((ITickable)tileentity).func_73660_a();
                          this.field_72984_F.func_76319_b();
                      }
-@@ -1691,6 +1807,13 @@
+@@ -1691,6 +1809,13 @@
                          CrashReport crashreport2 = CrashReport.func_85055_a(throwable, "Ticking block entity");
                          CrashReportCategory crashreportcategory2 = crashreport2.func_85058_a("Block entity being ticked");
                          tileentity.func_145828_a(crashreportcategory2);
@@ -433,7 +435,7 @@
                          throw new ReportedException(crashreport2);
                      }
                  }
-@@ -1703,20 +1826,28 @@
+@@ -1703,20 +1828,28 @@
  
                  if (this.func_175667_e(tileentity.func_174877_v()))
                  {
@@ -465,7 +467,7 @@
          this.field_72984_F.func_76318_c("pendingBlockEntities");
  
          if (!this.field_147484_a.isEmpty())
-@@ -1755,12 +1886,18 @@
+@@ -1755,12 +1888,18 @@
  
      public boolean func_175700_a(TileEntity p_175700_1_)
      {
@@ -484,7 +486,7 @@
  
          if (this.field_72995_K)
          {
-@@ -1776,6 +1913,11 @@
+@@ -1776,6 +1915,11 @@
      {
          if (this.field_147481_N)
          {
@@ -496,7 +498,7 @@
              this.field_147484_a.addAll(p_147448_1_);
          }
          else
-@@ -1796,9 +1938,12 @@
+@@ -1796,9 +1940,12 @@
      {
          int i = MathHelper.func_76128_c(p_72866_1_.field_70165_t);
          int j = MathHelper.func_76128_c(p_72866_1_.field_70161_v);
@@ -511,7 +513,7 @@
          {
              p_72866_1_.field_70142_S = p_72866_1_.field_70165_t;
              p_72866_1_.field_70137_T = p_72866_1_.field_70163_u;
-@@ -1816,6 +1961,7 @@
+@@ -1816,6 +1963,7 @@
                  }
                  else
                  {
@@ -519,7 +521,7 @@
                      p_72866_1_.func_70071_h_();
                  }
              }
-@@ -1997,6 +2143,11 @@
+@@ -1997,6 +2145,11 @@
                              blockpos$pooledmutableblockpos.func_185344_t();
                              return true;
                          }
@@ -531,7 +533,7 @@
                      }
                  }
              }
-@@ -2036,6 +2187,16 @@
+@@ -2036,6 +2189,16 @@
                          IBlockState iblockstate = this.func_180495_p(blockpos$pooledmutableblockpos);
                          Block block = iblockstate.func_177230_c();
  
@@ -548,7 +550,7 @@
                          if (iblockstate.func_185904_a() == p_72918_2_)
                          {
                              double d0 = (double)((float)(l1 + 1) - BlockLiquid.func_149801_b(((Integer)iblockstate.func_177229_b(BlockLiquid.field_176367_b)).intValue()));
-@@ -2102,6 +2263,7 @@
+@@ -2102,6 +2265,7 @@
      public Explosion func_72885_a(@Nullable Entity p_72885_1_, double p_72885_2_, double p_72885_4_, double p_72885_6_, float p_72885_8_, boolean p_72885_9_, boolean p_72885_10_)
      {
          Explosion explosion = new Explosion(this, p_72885_1_, p_72885_2_, p_72885_4_, p_72885_6_, p_72885_8_, p_72885_9_, p_72885_10_);
@@ -556,7 +558,7 @@
          explosion.func_77278_a();
          explosion.func_77279_a(true);
          return explosion;
-@@ -2224,6 +2386,7 @@
+@@ -2224,6 +2388,7 @@
  
      public void func_175690_a(BlockPos p_175690_1_, @Nullable TileEntity p_175690_2_)
      {
@@ -564,7 +566,7 @@
          if (!this.func_189509_E(p_175690_1_))
          {
              if (p_175690_2_ != null && !p_175690_2_.func_145837_r())
-@@ -2231,6 +2394,8 @@
+@@ -2231,6 +2396,8 @@
                  if (this.field_147481_N)
                  {
                      p_175690_2_.func_174878_a(p_175690_1_);
@@ -573,7 +575,7 @@
                      Iterator<TileEntity> iterator = this.field_147484_a.iterator();
  
                      while (iterator.hasNext())
-@@ -2248,7 +2413,8 @@
+@@ -2248,7 +2415,8 @@
                  }
                  else
                  {
@@ -583,7 +585,7 @@
                      this.func_175700_a(p_175690_2_);
                  }
              }
-@@ -2263,6 +2429,8 @@
+@@ -2263,6 +2431,8 @@
          {
              tileentity.func_145843_s();
              this.field_147484_a.remove(tileentity);
@@ -592,7 +594,7 @@
          }
          else
          {
-@@ -2275,6 +2443,7 @@
+@@ -2275,6 +2445,7 @@
  
              this.func_175726_f(p_175713_1_).func_177425_e(p_175713_1_);
          }
@@ -600,7 +602,7 @@
      }
  
      public void func_147457_a(TileEntity p_147457_1_)
-@@ -2301,7 +2470,7 @@
+@@ -2301,7 +2472,7 @@
              if (chunk != null && !chunk.func_76621_g())
              {
                  IBlockState iblockstate = this.func_180495_p(p_175677_1_);
@@ -609,7 +611,7 @@
              }
              else
              {
-@@ -2324,6 +2493,7 @@
+@@ -2324,6 +2495,7 @@
      {
          this.field_72985_G = p_72891_1_;
          this.field_72992_H = p_72891_2_;
@@ -617,7 +619,7 @@
      }
  
      public void func_72835_b()
-@@ -2333,6 +2503,11 @@
+@@ -2333,6 +2505,11 @@
  
      protected void func_72947_a()
      {
@@ -629,7 +631,7 @@
          if (this.field_72986_A.func_76059_o())
          {
              this.field_73004_o = 1.0F;
-@@ -2346,6 +2521,11 @@
+@@ -2346,6 +2523,11 @@
  
      protected void func_72979_l()
      {
@@ -641,7 +643,7 @@
          if (this.field_73011_w.func_191066_m())
          {
              if (!this.field_72995_K)
-@@ -2470,6 +2650,11 @@
+@@ -2470,6 +2652,11 @@
  
      public boolean func_175670_e(BlockPos p_175670_1_, boolean p_175670_2_)
      {
@@ -653,7 +655,7 @@
          Biome biome = this.func_180494_b(p_175670_1_);
          float f = biome.func_180626_a(p_175670_1_);
  
-@@ -2511,6 +2696,11 @@
+@@ -2511,6 +2698,11 @@
  
      public boolean func_175708_f(BlockPos p_175708_1_, boolean p_175708_2_)
      {
@@ -665,7 +667,7 @@
          Biome biome = this.func_180494_b(p_175708_1_);
          float f = biome.func_180626_a(p_175708_1_);
  
-@@ -2528,7 +2718,7 @@
+@@ -2528,7 +2720,7 @@
              {
                  IBlockState iblockstate = this.func_180495_p(p_175708_1_);
  
@@ -674,7 +676,7 @@
                  {
                      return true;
                  }
-@@ -2560,10 +2750,11 @@
+@@ -2560,10 +2752,11 @@
          else
          {
              IBlockState iblockstate = this.func_180495_p(p_175638_1_);
@@ -689,7 +691,7 @@
              {
                  j = 1;
              }
-@@ -2597,6 +2788,7 @@
+@@ -2597,6 +2790,7 @@
  
                      if (i >= 14)
                      {
@@ -697,7 +699,19 @@
                          return i;
                      }
                  }
-@@ -2662,7 +2854,7 @@
+@@ -2609,6 +2803,11 @@
+ 
+     public boolean func_180500_c(EnumSkyBlock p_180500_1_, BlockPos p_180500_2_)
+     {
++        if (true)
++        {
++            this.lightingEngine.scheduleLightUpdate(p_180500_1_, p_180500_2_);
++            return true;
++        }
+         if (!this.func_175648_a(p_180500_2_, 17, false))
+         {
+             return false;
+@@ -2662,7 +2861,7 @@
                                      int j4 = j2 + enumfacing.func_96559_d();
                                      int k4 = k2 + enumfacing.func_82599_e();
                                      blockpos$pooledmutableblockpos.func_181079_c(i4, j4, k4);
@@ -706,7 +720,7 @@
                                      i3 = this.func_175642_b(p_180500_1_, blockpos$pooledmutableblockpos);
  
                                      if (i3 == l2 - l4 && j < this.field_72994_J.length)
-@@ -2770,10 +2962,10 @@
+@@ -2770,10 +2969,10 @@
      public List<Entity> func_175674_a(@Nullable Entity p_175674_1_, AxisAlignedBB p_175674_2_, @Nullable Predicate <? super Entity > p_175674_3_)
      {
          List<Entity> list = Lists.<Entity>newArrayList();
@@ -721,7 +735,7 @@
  
          for (int i1 = i; i1 <= j; ++i1)
          {
-@@ -2826,10 +3018,10 @@
+@@ -2826,10 +3025,10 @@
  
      public <T extends Entity> List<T> func_175647_a(Class <? extends T > p_175647_1_, AxisAlignedBB p_175647_2_, @Nullable Predicate <? super T > p_175647_3_)
      {
@@ -736,7 +750,7 @@
          List<T> list = Lists.<T>newArrayList();
  
          for (int i1 = i; i1 < j; ++i1)
-@@ -2909,11 +3101,13 @@
+@@ -2909,11 +3108,13 @@
  
      public void func_175650_b(Collection<Entity> p_175650_1_)
      {
@@ -753,7 +767,7 @@
          }
      }
  
-@@ -2926,7 +3120,7 @@
+@@ -2926,7 +3127,7 @@
      {
          IBlockState iblockstate = this.func_180495_p(p_190527_2_);
          AxisAlignedBB axisalignedbb = p_190527_3_ ? null : p_190527_1_.func_176223_P().func_185890_d(this, p_190527_2_);
@@ -762,7 +776,7 @@
      }
  
      public int func_181545_F()
-@@ -3009,7 +3203,7 @@
+@@ -3009,7 +3210,7 @@
      public int func_175651_c(BlockPos p_175651_1_, EnumFacing p_175651_2_)
      {
          IBlockState iblockstate = this.func_180495_p(p_175651_1_);
@@ -771,7 +785,7 @@
      }
  
      public boolean func_175640_z(BlockPos p_175640_1_)
-@@ -3152,6 +3346,8 @@
+@@ -3152,6 +3353,8 @@
                      d2 *= ((Double)Objects.firstNonNull(p_184150_11_.apply(entityplayer1), Double.valueOf(1.0D))).doubleValue();
                  }
  
@@ -780,7 +794,7 @@
                  if ((p_184150_9_ < 0.0D || Math.abs(entityplayer1.field_70163_u - p_184150_3_) < p_184150_9_ * p_184150_9_) && (p_184150_7_ < 0.0D || d1 < d2 * d2) && (d0 == -1.0D || d1 < d0))
                  {
                      d0 = d1;
-@@ -3213,7 +3409,7 @@
+@@ -3213,7 +3416,7 @@
  
      public long func_72905_C()
      {
@@ -789,7 +803,7 @@
      }
  
      public long func_82737_E()
-@@ -3223,17 +3419,17 @@
+@@ -3223,17 +3426,17 @@
  
      public long func_72820_D()
      {
@@ -810,7 +824,7 @@
  
          if (!this.func_175723_af().func_177746_a(blockpos))
          {
-@@ -3245,7 +3441,7 @@
+@@ -3245,7 +3448,7 @@
  
      public void func_175652_B(BlockPos p_175652_1_)
      {
@@ -819,7 +833,7 @@
      }
  
      @SideOnly(Side.CLIENT)
-@@ -3265,12 +3461,18 @@
+@@ -3265,12 +3468,18 @@
  
          if (!this.field_72996_f.contains(p_72897_1_))
          {
@@ -838,7 +852,7 @@
          return true;
      }
  
-@@ -3364,8 +3566,7 @@
+@@ -3364,8 +3573,7 @@
  
      public boolean func_180502_D(BlockPos p_180502_1_)
      {
@@ -848,7 +862,7 @@
      }
  
      @Nullable
-@@ -3426,12 +3627,12 @@
+@@ -3426,12 +3634,12 @@
  
      public int func_72800_K()
      {
@@ -863,7 +877,7 @@
      }
  
      public Random func_72843_D(int p_72843_1_, int p_72843_2_, int p_72843_3_)
-@@ -3475,7 +3676,7 @@
+@@ -3475,7 +3683,7 @@
      @SideOnly(Side.CLIENT)
      public double func_72919_O()
      {
@@ -872,7 +886,7 @@
      }
  
      public void func_175715_c(int p_175715_1_, BlockPos p_175715_2_, int p_175715_3_)
-@@ -3509,7 +3710,7 @@
+@@ -3509,7 +3717,7 @@
  
      public void func_175666_e(BlockPos p_175666_1_, Block p_175666_2_)
      {
@@ -881,7 +895,7 @@
          {
              BlockPos blockpos = p_175666_1_.func_177972_a(enumfacing);
  
-@@ -3517,18 +3718,14 @@
+@@ -3517,18 +3725,14 @@
              {
                  IBlockState iblockstate = this.func_180495_p(blockpos);
  
@@ -904,7 +918,7 @@
                      }
                  }
              }
-@@ -3594,6 +3791,115 @@
+@@ -3594,6 +3798,115 @@
          return i >= -128 && i <= 128 && j >= -128 && j <= 128;
      }
  

--- a/patches/minecraft/net/minecraft/world/chunk/Chunk.java.patch
+++ b/patches/minecraft/net/minecraft/world/chunk/Chunk.java.patch
@@ -65,7 +65,14 @@
  
                      if (j1 > 0)
                      {
-@@ -600,28 +606,19 @@
+@@ -594,34 +600,25 @@
+                         this.func_76615_h(i, j, k);
+                     }
+ 
+-                    if (j1 != k1 && (j1 < k1 || this.func_177413_a(EnumSkyBlock.SKY, p_177436_1_) > 0 || this.func_177413_a(EnumSkyBlock.BLOCK, p_177436_1_) > 0))
++                    if (false) //TODO: Wait for proper fix
+                     {
+                         this.func_76595_e(i, k);
                      }
                  }
  
@@ -98,7 +105,28 @@
                          this.field_76637_e.func_175690_a(p_177436_1_, tileentity1);
                      }
  
-@@ -725,6 +722,7 @@
+@@ -639,6 +636,12 @@
+ 
+     public int func_177413_a(EnumSkyBlock p_177413_1_, BlockPos p_177413_2_)
+     {
++        this.field_76637_e.lightingEngine.procLightUpdates(p_177413_1_);
++        return this.getCachedLightFor(p_177413_1_, p_177413_2_);
++    }
++
++    public int getCachedLightFor(EnumSkyBlock p_177413_1_, BlockPos p_177413_2_)
++    {
+         int i = p_177413_2_.func_177958_n() & 15;
+         int j = p_177413_2_.func_177956_o();
+         int k = p_177413_2_.func_177952_p() & 15;
+@@ -677,6 +680,7 @@
+ 
+     public int func_177443_a(BlockPos p_177443_1_, int p_177443_2_)
+     {
++        this.field_76637_e.lightingEngine.procLightUpdates();
+         int i = p_177443_1_.func_177958_n() & 15;
+         int j = p_177443_1_.func_177956_o();
+         int k = p_177443_1_.func_177952_p() & 15;
+@@ -725,6 +729,7 @@
              k = this.field_76645_j.length - 1;
          }
  
@@ -106,7 +134,7 @@
          p_76612_1_.field_70175_ag = true;
          p_76612_1_.field_70176_ah = this.field_76635_g;
          p_76612_1_.field_70162_ai = k;
-@@ -765,7 +763,7 @@
+@@ -765,7 +770,7 @@
      {
          IBlockState iblockstate = this.func_177435_g(p_177422_1_);
          Block block = iblockstate.func_177230_c();
@@ -115,7 +143,7 @@
      }
  
      @Nullable
-@@ -773,6 +771,12 @@
+@@ -773,6 +778,12 @@
      {
          TileEntity tileentity = (TileEntity)this.field_150816_i.get(p_177424_1_);
  
@@ -128,7 +156,7 @@
          if (tileentity == null)
          {
              if (p_177424_2_ == Chunk.EnumCreateEntityType.IMMEDIATE)
-@@ -782,14 +786,9 @@
+@@ -782,14 +793,9 @@
              }
              else if (p_177424_2_ == Chunk.EnumCreateEntityType.QUEUED)
              {
@@ -144,7 +172,7 @@
  
          return tileentity;
      }
-@@ -806,10 +805,11 @@
+@@ -806,10 +812,11 @@
  
      public void func_177426_a(BlockPos p_177426_1_, TileEntity p_177426_2_)
      {
@@ -157,7 +185,7 @@
          {
              if (this.field_150816_i.containsKey(p_177426_1_))
              {
-@@ -841,8 +841,9 @@
+@@ -841,8 +848,9 @@
  
          for (ClassInheritanceMultiMap<Entity> classinheritancemultimap : this.field_76645_j)
          {
@@ -168,7 +196,7 @@
      }
  
      public void func_76623_d()
-@@ -858,6 +859,7 @@
+@@ -858,6 +866,7 @@
          {
              this.field_76637_e.func_175681_c(classinheritancemultimap);
          }
@@ -176,7 +204,7 @@
      }
  
      public void func_76630_e()
-@@ -867,8 +869,8 @@
+@@ -867,8 +876,8 @@
  
      public void func_177414_a(@Nullable Entity p_177414_1_, AxisAlignedBB p_177414_2_, List<Entity> p_177414_3_, Predicate <? super Entity > p_177414_4_)
      {
@@ -187,7 +215,7 @@
          i = MathHelper.func_76125_a(i, 0, this.field_76645_j.length - 1);
          j = MathHelper.func_76125_a(j, 0, this.field_76645_j.length - 1);
  
-@@ -905,8 +907,8 @@
+@@ -905,8 +914,8 @@
  
      public <T extends Entity> void func_177430_a(Class <? extends T > p_177430_1_, AxisAlignedBB p_177430_2_, List<T> p_177430_3_, Predicate <? super T > p_177430_4_)
      {
@@ -198,7 +226,7 @@
          i = MathHelper.func_76125_a(i, 0, this.field_76645_j.length - 1);
          j = MathHelper.func_76125_a(j, 0, this.field_76645_j.length - 1);
  
-@@ -984,6 +986,8 @@
+@@ -984,6 +993,8 @@
  
      protected void func_186034_a(IChunkGenerator p_186034_1_)
      {
@@ -207,7 +235,7 @@
          if (this.func_177419_t())
          {
              if (p_186034_1_.func_185933_a(this, this.field_76635_g, this.field_76647_h))
-@@ -995,8 +999,10 @@
+@@ -995,8 +1006,10 @@
          {
              this.func_150809_p();
              p_186034_1_.func_185931_b(this.field_76635_g, this.field_76647_h);
@@ -218,7 +246,7 @@
      }
  
      public BlockPos func_177440_h(BlockPos p_177440_1_)
-@@ -1051,7 +1057,7 @@
+@@ -1051,7 +1064,7 @@
          {
              BlockPos blockpos = (BlockPos)this.field_177447_w.poll();
  
@@ -227,7 +255,7 @@
              {
                  TileEntity tileentity = this.func_177422_i(blockpos);
                  this.field_76637_e.func_175690_a(blockpos, tileentity);
-@@ -1115,6 +1121,13 @@
+@@ -1115,6 +1128,13 @@
      @SideOnly(Side.CLIENT)
      public void func_186033_a(PacketBuffer p_186033_1_, int p_186033_2_, boolean p_186033_3_)
      {
@@ -241,7 +269,7 @@
          boolean flag = this.field_76637_e.field_73011_w.func_191066_m();
  
          for (int i = 0; i < this.field_76652_q.length; ++i)
-@@ -1163,10 +1176,16 @@
+@@ -1163,10 +1183,16 @@
          this.field_76646_k = true;
          this.func_76590_a();
  
@@ -258,7 +286,7 @@
      }
  
      public Biome func_177411_a(BlockPos p_177411_1_, BiomeProvider p_177411_2_)
-@@ -1231,13 +1250,13 @@
+@@ -1231,13 +1257,13 @@
                      BlockPos blockpos1 = blockpos.func_177982_a(k, (j << 4) + i1, l);
                      boolean flag = i1 == 0 || i1 == 15 || k == 0 || k == 15 || l == 0 || l == 15;
  
@@ -274,7 +302,7 @@
                              {
                                  this.field_76637_e.func_175664_x(blockpos2);
                              }
-@@ -1368,7 +1387,7 @@
+@@ -1368,7 +1394,7 @@
          {
              blockpos$mutableblockpos.func_181079_c(blockpos$mutableblockpos.func_177958_n(), l, blockpos$mutableblockpos.func_177952_p());
  
@@ -283,7 +311,7 @@
              {
                  this.field_76637_e.func_175664_x(blockpos$mutableblockpos);
              }
-@@ -1476,4 +1495,34 @@
+@@ -1476,4 +1502,34 @@
          QUEUED,
          CHECK;
      }

--- a/patches/minecraft/net/minecraft/world/chunk/storage/AnvilChunkLoader.java.patch
+++ b/patches/minecraft/net/minecraft/world/chunk/storage/AnvilChunkLoader.java.patch
@@ -66,7 +66,7 @@
          if (!p_75822_4_.func_150297_b("Level", 10))
          {
              field_151505_a.error("Chunk file at {},{} is missing level data, skipping", new Object[] {Integer.valueOf(p_75822_2_), Integer.valueOf(p_75822_3_)});
-@@ -103,16 +143,36 @@
+@@ -103,10 +143,29 @@
                      field_151505_a.error("Chunk file at {},{} is in the wrong location; relocating. (Expected {}, {}, got {}, {})", new Object[] {Integer.valueOf(p_75822_2_), Integer.valueOf(p_75822_3_), Integer.valueOf(p_75822_2_), Integer.valueOf(p_75822_3_), Integer.valueOf(chunk.field_76635_g), Integer.valueOf(chunk.field_76647_h)});
                      nbttagcompound.func_74768_a("xPos", p_75822_2_);
                      nbttagcompound.func_74768_a("zPos", p_75822_3_);
@@ -97,14 +97,7 @@
              }
          }
      }
- 
-     public void func_75816_a(World p_75816_1_, Chunk p_75816_2_) throws MinecraftException, IOException
-     {
-+        p_75816_1_.lightingEngine.procLightUpdates();
-         p_75816_1_.func_72906_B();
- 
-         try
-@@ -121,7 +181,9 @@
+@@ -121,7 +180,9 @@
              NBTTagCompound nbttagcompound1 = new NBTTagCompound();
              nbttagcompound.func_74782_a("Level", nbttagcompound1);
              nbttagcompound.func_74768_a("DataVersion", 922);
@@ -114,7 +107,7 @@
              this.func_75824_a(p_75816_2_.func_76632_l(), nbttagcompound);
          }
          catch (Exception exception)
-@@ -305,11 +367,20 @@
+@@ -305,11 +366,20 @@
              {
                  NBTTagCompound nbttagcompound2 = new NBTTagCompound();
  
@@ -135,7 +128,7 @@
              }
          }
  
-@@ -318,8 +389,17 @@
+@@ -318,8 +388,17 @@
  
          for (TileEntity tileentity : p_75820_1_.func_177434_r().values())
          {
@@ -153,7 +146,7 @@
          }
  
          p_75820_3_.func_74782_a("TileEntities", nbttaglist2);
-@@ -388,6 +468,12 @@
+@@ -388,6 +467,12 @@
              chunk.func_76616_a(p_75823_2_.func_74770_j("Biomes"));
          }
  
@@ -166,7 +159,7 @@
          NBTTagList nbttaglist1 = p_75823_2_.func_150295_c("Entities", 10);
  
          for (int j1 = 0; j1 < nbttaglist1.func_74745_c(); ++j1)
-@@ -431,8 +517,6 @@
+@@ -431,8 +516,6 @@
                  p_75823_1_.func_180497_b(new BlockPos(nbttagcompound3.func_74762_e("x"), nbttagcompound3.func_74762_e("y"), nbttagcompound3.func_74762_e("z")), block, nbttagcompound3.func_74762_e("t"), nbttagcompound3.func_74762_e("p"));
              }
          }

--- a/patches/minecraft/net/minecraft/world/chunk/storage/AnvilChunkLoader.java.patch
+++ b/patches/minecraft/net/minecraft/world/chunk/storage/AnvilChunkLoader.java.patch
@@ -66,7 +66,7 @@
          if (!p_75822_4_.func_150297_b("Level", 10))
          {
              field_151505_a.error("Chunk file at {},{} is missing level data, skipping", new Object[] {Integer.valueOf(p_75822_2_), Integer.valueOf(p_75822_3_)});
-@@ -103,10 +143,29 @@
+@@ -103,16 +143,36 @@
                      field_151505_a.error("Chunk file at {},{} is in the wrong location; relocating. (Expected {}, {}, got {}, {})", new Object[] {Integer.valueOf(p_75822_2_), Integer.valueOf(p_75822_3_), Integer.valueOf(p_75822_2_), Integer.valueOf(p_75822_3_), Integer.valueOf(chunk.field_76635_g), Integer.valueOf(chunk.field_76647_h)});
                      nbttagcompound.func_74768_a("xPos", p_75822_2_);
                      nbttagcompound.func_74768_a("zPos", p_75822_3_);
@@ -97,7 +97,14 @@
              }
          }
      }
-@@ -121,7 +180,9 @@
+ 
+     public void func_75816_a(World p_75816_1_, Chunk p_75816_2_) throws MinecraftException, IOException
+     {
++        p_75816_1_.lightingEngine.procLightUpdates();
+         p_75816_1_.func_72906_B();
+ 
+         try
+@@ -121,7 +181,9 @@
              NBTTagCompound nbttagcompound1 = new NBTTagCompound();
              nbttagcompound.func_74782_a("Level", nbttagcompound1);
              nbttagcompound.func_74768_a("DataVersion", 922);
@@ -107,7 +114,7 @@
              this.func_75824_a(p_75816_2_.func_76632_l(), nbttagcompound);
          }
          catch (Exception exception)
-@@ -305,11 +366,20 @@
+@@ -305,11 +367,20 @@
              {
                  NBTTagCompound nbttagcompound2 = new NBTTagCompound();
  
@@ -128,7 +135,7 @@
              }
          }
  
-@@ -318,8 +388,17 @@
+@@ -318,8 +389,17 @@
  
          for (TileEntity tileentity : p_75820_1_.func_177434_r().values())
          {
@@ -146,7 +153,7 @@
          }
  
          p_75820_3_.func_74782_a("TileEntities", nbttaglist2);
-@@ -388,6 +467,12 @@
+@@ -388,6 +468,12 @@
              chunk.func_76616_a(p_75823_2_.func_74770_j("Biomes"));
          }
  
@@ -159,7 +166,7 @@
          NBTTagList nbttaglist1 = p_75823_2_.func_150295_c("Entities", 10);
  
          for (int j1 = 0; j1 < nbttaglist1.func_74745_c(); ++j1)
-@@ -431,8 +516,6 @@
+@@ -431,8 +517,6 @@
                  p_75823_1_.func_180497_b(new BlockPos(nbttagcompound3.func_74762_e("x"), nbttagcompound3.func_74762_e("y"), nbttagcompound3.func_74762_e("z")), block, nbttagcompound3.func_74762_e("t"), nbttagcompound3.func_74762_e("p"));
              }
          }

--- a/patches/minecraft/net/minecraft/world/gen/ChunkProviderServer.java.patch
+++ b/patches/minecraft/net/minecraft/world/gen/ChunkProviderServer.java.patch
@@ -60,10 +60,19 @@
          return chunk;
      }
  
-@@ -225,6 +253,11 @@
+@@ -186,6 +214,7 @@
+ 
+     public boolean func_186027_a(boolean p_186027_1_)
+     {
++        this.field_73251_h.lightingEngine.procLightUpdates();
+         int i = 0;
+         List<Chunk> list = Lists.newArrayList(this.field_73244_f.values());
+ 
+@@ -225,6 +254,12 @@
          {
              if (!this.field_73248_b.isEmpty())
              {
++                this.field_73251_h.lightingEngine.procLightUpdates();
 +                for (ChunkPos forced : this.field_73251_h.getPersistentChunks().keySet())
 +                {
 +                    this.field_73248_b.remove(ChunkPos.func_77272_a(forced.field_77276_a, forced.field_77275_b));
@@ -72,7 +81,7 @@
                  Iterator<Long> iterator = this.field_73248_b.iterator();
  
                  for (int i = 0; i < 100 && iterator.hasNext(); iterator.remove())
-@@ -239,6 +272,11 @@
+@@ -239,6 +274,11 @@
                          this.func_73243_a(chunk);
                          this.field_73244_f.remove(olong);
                          ++i;

--- a/src/main/java/net/minecraftforge/common/lighting/LightingEngine.java
+++ b/src/main/java/net/minecraftforge/common/lighting/LightingEngine.java
@@ -1,0 +1,630 @@
+/*
+ * Minecraft Forge
+ * Copyright (c) 2016.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation version 2.1
+ * of the License.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+package net.minecraftforge.common.lighting;
+
+import java.util.ArrayDeque;
+import java.util.Deque;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import net.minecraft.block.state.IBlockState;
+import net.minecraft.client.Minecraft;
+import net.minecraft.profiler.Profiler;
+import net.minecraft.util.EnumFacing;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.math.BlockPos.MutableBlockPos;
+import net.minecraft.util.math.MathHelper;
+import net.minecraft.world.EnumSkyBlock;
+import net.minecraft.world.World;
+import net.minecraft.world.chunk.Chunk;
+
+public class LightingEngine
+{
+    private static final int MAX_SCHEDULED_COUNT = 1 << 22;
+
+    private static final int MAX_LIGHT = 15;
+
+    private static final Logger logger = LogManager.getLogger();
+
+    private final World world;
+    private final Profiler profiler;
+
+    //Layout of longs: [padding(4)] [z(26)] [y(8)] [x(26)]
+    private final PooledLongQueue[] queuedLightUpdates = new PooledLongQueue[EnumSkyBlock.values().length];
+
+    //Layout of longs: see above
+    private final PooledLongQueue[] queuedDarkenings = new PooledLongQueue[MAX_LIGHT + 1];
+    private final PooledLongQueue[] queuedBrightenings = new PooledLongQueue[MAX_LIGHT + 1];
+
+    //Layout of longs: [newLight(4)] [pos(60)]
+    private final PooledLongQueue initialBrightenings = new PooledLongQueue();
+    //Layout of longs: [padding(4)] [pos(60)]
+    private final PooledLongQueue initialDarkenings = new PooledLongQueue();
+
+    private boolean updating = false;
+
+    //Layout parameters
+    //Length of bit segments
+    private static final int
+        lX = 26,
+        lY = 8,
+        lZ = 26,
+        lL = 4;
+
+    //Big segment shifts/positions
+    private static final int
+        sX = 0,
+        sY = sX + lX,
+        sZ = sY + lY,
+        sL = sZ + lZ;
+
+    //Bit segment masks
+    private static final long
+        mX = (1 << lX) - 1,
+        mY = (1 << lY) - 1,
+        mZ = (1 << lZ) - 1,
+        mL = (1 << lL) - 1;
+
+    //Stored light type to reduce amount of method parameters
+    private EnumSkyBlock lightType;
+
+    //Iteration state data
+    //Cache position to avoid allocation of new object each time
+    private final MutableBlockPos curPos = new MutableBlockPos();
+    private PooledLongQueue curQueue;
+    private Chunk curChunk;
+    private long curData;
+
+    //Cached data about neighboring blocks (of tempPos)
+    private boolean isNeighborDataValid = false;
+    private final Chunk[] neighborsChunk = new Chunk[EnumFacing.VALUES.length];
+    private final MutableBlockPos[] neighborsPos = new MutableBlockPos[EnumFacing.VALUES.length];
+    private final int[] neighborsLight = new int[EnumFacing.VALUES.length];
+
+    public LightingEngine(final World world)
+    {
+        this.world = world;
+        this.profiler = world.theProfiler;
+
+        for (int i = 0; i < EnumSkyBlock.values().length; ++i)
+        {
+            this.queuedLightUpdates[i] = new PooledLongQueue();
+        }
+
+        for (int i = 0; i < this.queuedDarkenings.length; ++i)
+        {
+            this.queuedDarkenings[i] = new PooledLongQueue();
+        }
+
+        for (int i = 0; i < this.queuedBrightenings.length; ++i)
+        {
+            this.queuedBrightenings[i] = new PooledLongQueue();
+        }
+
+        for (int i = 0; i < this.neighborsPos.length; ++i)
+        {
+            this.neighborsPos[i] = new MutableBlockPos();
+        }
+    }
+
+    /**
+     * Schedules a light update for the specified light type and position to be processed later by {@link #procLightUpdates(EnumSkyBlock)}
+     */
+    public void scheduleLightUpdate(final EnumSkyBlock lightType, final BlockPos pos)
+    {
+        this.scheduleLightUpdate(lightType, posToLong(pos));
+    }
+
+    /**
+     * Schedules a light update for the specified light type and position to be processed later by {@link #procLightUpdates()}
+     */
+    private void scheduleLightUpdate(final EnumSkyBlock lightType, final long pos)
+    {
+        final PooledLongQueue queue = this.queuedLightUpdates[lightType.ordinal()];
+
+        queue.add(pos);
+
+        //make sure there are not too many queued light updates
+        if (queue.size() >= MAX_SCHEDULED_COUNT)
+        {
+            this.procLightUpdates(lightType);
+        }
+    }
+
+    /**
+     * Calls {@link #procLightUpdates(EnumSkyBlock)} for both light types
+     */
+    public void procLightUpdates()
+    {
+        this.procLightUpdates(EnumSkyBlock.SKY);
+        this.procLightUpdates(EnumSkyBlock.BLOCK);
+    }
+
+    /**
+     * Processes light updates of the given light type
+     */
+    public void procLightUpdates(final EnumSkyBlock lightType)
+    {
+        final PooledLongQueue queue = this.queuedLightUpdates[lightType.ordinal()];
+
+        if (queue.isEmpty())
+        {
+            return;
+        }
+
+        //renderer accesses world unsynchronized, don't modify anything in that case
+        if (this.world.isRemote && !Minecraft.getMinecraft().isCallingFromMinecraftThread())
+        {
+            return;
+        }
+
+        //avoid nested calls
+        if (this.updating)
+        {
+            logger.warn("Trying to access light values during relighting");
+            return;
+        }
+
+        this.updating = true;
+
+        this.profiler.startSection("lighting");
+
+        this.lightType = lightType;
+
+        this.profiler.startSection("checking");
+
+        //process the queued updates and enqueue them for further processing
+        for (this.curQueue = queue; this.nextItem(); )
+        {
+            if (this.curChunk == null)
+            {
+                continue;
+            }
+
+            final int oldLight = this.curToCachedLight();
+            final int newLight = this.calcNewLightFromCur();
+
+            if (oldLight < newLight)
+            {
+                //don't enqueue directly for brightening in order to avoid duplicate scheduling
+                this.initialBrightenings.add(((long) newLight << sL) | this.curData);
+            }
+            else if (oldLight > newLight)
+            {
+                //don't enqueue directly for darkening in order to avoid duplicate scheduling
+                this.initialDarkenings.add(this.curData);
+            }
+        }
+
+        for (this.curQueue = this.initialBrightenings; this.nextItem(); )
+        {
+            final int newLight = (int) (this.curData >> sL & mL);
+
+            if (newLight > this.curToCachedLight())
+            {
+                //Sets the light to newLight to only schedule once
+                this.enqueueBrighteningFromCur(newLight);
+            }
+        }
+
+        for (this.curQueue = this.initialDarkenings; this.nextItem(); )
+        {
+            final int oldLight = this.curToCachedLight();
+
+            if (oldLight != 0)
+            {
+                //Sets the light to 0 to only schedule once
+                this.enqueueDarkening(this.curPos, this.curData, oldLight, this.curChunk);
+            }
+        }
+
+        this.profiler.endSection();
+
+        //Iterate through enqueued updates (brightening and darkening in parallel) from brightest to darkest so that we only need to iterate once
+        for (int curLight = MAX_LIGHT; curLight >= 0; --curLight)
+        {
+            this.profiler.startSection("brightening");
+
+            for (this.curQueue = this.queuedBrightenings[curLight]; this.nextItem(); )
+            {
+                final int oldLight = this.curToCachedLight();
+
+                if (oldLight == curLight) //only process this if nothing else has happened at this position since scheduling
+                {
+                    this.world.notifyLightSet(this.curPos);
+
+                    if (curLight > 1)
+                    {
+                        this.spreadLightFromCur(curLight);
+                    }
+                }
+            }
+
+            this.profiler.endStartSection("darkening");
+
+            for (this.curQueue = this.queuedDarkenings[curLight]; this.nextItem(); )
+            {
+                final IBlockState state = this.curToState();
+                final int luminosity = this.curToLuminosity(state);
+                final int opacity = luminosity >= MAX_LIGHT - 1 ? 1 : this.curToOpac(state); //if luminosity is high enough, opacity is irrelevant
+
+                //only darken neighbors if we indeed became darker
+                if (this.calcNewLightFromCur(luminosity, opacity) < curLight)
+                {
+                    //need to calculate new light value from neighbors IGNORING neighbors which are scheduled for darkening
+                    int newLight = luminosity;
+
+                    this.fetchNeighborDataFromCur();
+
+                    for (final EnumFacing dir : EnumFacing.VALUES)
+                    {
+                        final int index = dir.ordinal();
+
+                        final Chunk nChunk = this.neighborsChunk[index];
+
+                        if (nChunk == null)
+                        {
+                            continue;
+                        }
+
+                        final int nLight = this.neighborsLight[index];
+
+                        if (nLight == 0)
+                        {
+                            continue;
+                        }
+
+                        final MutableBlockPos nPos = this.neighborsPos[index];
+
+                        if (curLight - this.posToOpac(nPos, posToState(nPos, nChunk)) >= nLight) //schedule neighbor for darkening if we possibly light it
+                        {
+                            this.enqueueDarkening(nPos, posToLong(nPos), nLight, nChunk);
+                        }
+                        else //only use for new light calculation if not
+                        {
+                            //if we can't darken the neighbor, no one else can (because of processing order) -> safe to let us be illuminated by it
+                            newLight = Math.max(newLight, nLight - opacity);
+                        }
+                    }
+
+                    //schedule brightening since light level was set to 0
+                    this.enqueueBrighteningFromCur(newLight);
+                }
+                else //we didn't become darker, so we need to re-set our initial light value (was set to 0) and notify neighbors
+                {
+                    this.curChunk.setLightFor(lightType, this.curPos, curLight);
+                    this.spreadLightFromCur(curLight);
+                }
+            }
+
+            this.profiler.endSection();
+        }
+
+        this.profiler.endSection();
+
+        this.updating = false;
+    }
+
+    /**
+     * Gets data for neighbors of <code>curPos</code> and saves the results into neighbor state data members. If a neighbor can't be accessed/doesn't exist, the corresponding entry in <code>neighborChunks</code> is <code>null</code> - others are not reset
+     */
+    private void fetchNeighborDataFromCur()
+    {
+        //only update if curPos was changed
+        if (this.isNeighborDataValid)
+        {
+            return;
+        }
+
+        this.isNeighborDataValid = true;
+
+        for (final EnumFacing dir : EnumFacing.VALUES)
+        {
+            final int index = dir.ordinal();
+
+            final MutableBlockPos nPos = this.neighborsPos[index];
+
+            nPos.setPos(this.curPos);
+            nPos.move(dir);
+
+            if (nPos.getY() == -1 || nPos.getY() == 256)
+            {
+                this.neighborsChunk[index] = null;
+                continue;
+            }
+
+            final Chunk nChunk = this.neighborsChunk[index] = this.posToChunk(nPos);
+
+            if (nChunk != null)
+            {
+                this.neighborsLight[index] = this.posToCachedLight(nPos, nChunk);
+            }
+        }
+    }
+
+    private int calcNewLightFromCur()
+    {
+        final IBlockState state = this.curToState();
+        final int luminosity = this.curToLuminosity(state);
+
+        return this.calcNewLightFromCur(luminosity, luminosity >= MAX_LIGHT - 1 ? 1 : this.curToOpac(state));
+    }
+
+    private int calcNewLightFromCur(final int luminosity, final int opacity)
+    {
+        if (luminosity >= MAX_LIGHT - opacity)
+        {
+            return luminosity;
+        }
+
+        int newLight = luminosity;
+        this.fetchNeighborDataFromCur();
+
+        for (final EnumFacing dir : EnumFacing.VALUES)
+        {
+            final int index = dir.ordinal();
+
+            if (this.neighborsChunk[index] == null)
+            {
+                continue;
+            }
+
+            final int nLight = this.neighborsLight[index];
+
+            newLight = Math.max(nLight - opacity, newLight);
+        }
+
+        return newLight;
+    }
+
+    private void spreadLightFromCur(final int curLight)
+    {
+        this.fetchNeighborDataFromCur();
+
+        for (final EnumFacing dir : EnumFacing.VALUES)
+        {
+            final int index = dir.ordinal();
+
+            final MutableBlockPos nPos = this.neighborsPos[index];
+
+            final Chunk nChunk = this.posToChunk(nPos);
+
+            if (nChunk == null)
+            {
+                continue;
+            }
+
+            final int newLight = curLight - this.posToOpac(nPos, nChunk.getBlockState(nPos));
+
+            if (newLight > this.neighborsLight[index])
+            {
+                this.enqueueBrightening(nPos, posToLong(nPos), newLight, nChunk);
+            }
+        }
+    }
+
+    private void enqueueBrighteningFromCur(final int newLight)
+    {
+        this.enqueueBrightening(this.curPos, this.curData, newLight, this.curChunk);
+    }
+
+    /**
+     * Enqueues the pos for brightening and sets its light value to <code>newLight</code>
+     */
+    private void enqueueBrightening(final BlockPos pos, final long longPos, final int newLight, final Chunk chunk)
+    {
+        this.queuedBrightenings[newLight].add(longPos);
+        chunk.setLightFor(this.lightType, pos, newLight);
+    }
+
+    /**
+     * Enqueues the pos for darkening and sets its light value to 0
+     */
+    private void enqueueDarkening(final BlockPos pos, final long longPos, final int oldLight, final Chunk chunk)
+    {
+        this.queuedDarkenings[oldLight].add(longPos);
+        chunk.setLightFor(this.lightType, pos, 0);
+    }
+
+    private static BlockPos longToPos(final MutableBlockPos pos, final long longPos)
+    {
+        final int posX = (int) (longPos >> sX & mX) - (1 << lX - 1);
+        final int posY = (int) (longPos >> sY & mY);
+        final int posZ = (int) (longPos >> sZ & mZ) - (1 << lZ - 1);
+        return pos.setPos(posX, posY, posZ);
+    }
+
+    private static long posToLong(final BlockPos pos)
+    {
+        return posToLong(pos.getX(), pos.getY(), pos.getZ());
+    }
+
+    private static long posToLong(final long x, final long y, final long z)
+    {
+        return (z + (1 << lZ - 1) << sZ) | (y << sY) | (x + (1 << lX - 1) << sX);
+    }
+
+    /**
+     * Polls a new item from <code>curQueue</code> and fills in state data members
+     *
+     * @return If there was an item to poll
+     */
+    private boolean nextItem()
+    {
+        if (this.curQueue.isEmpty())
+        {
+            return false;
+        }
+
+        this.curData = this.curQueue.poll();
+        this.isNeighborDataValid = false;
+        longToPos(this.curPos, this.curData);
+        this.curChunk = this.curToChunk();
+
+        return true;
+    }
+
+    private int posToCachedLight(final MutableBlockPos pos, final Chunk chunk)
+    {
+        return chunk.getCachedLightFor(this.lightType, pos);
+    }
+
+    private int curToCachedLight()
+    {
+        return this.posToCachedLight(this.curPos, this.curChunk);
+    }
+
+    /**
+     * Calculates the luminosity for <code>curPos</code>, taking into account <code>lightType</code>
+     */
+    private int curToLuminosity(final IBlockState state)
+    {
+        return this.lightType == EnumSkyBlock.SKY
+            ? this.curChunk.canSeeSky(this.curPos)
+            ? EnumSkyBlock.SKY.defaultLightValue
+            : 0
+            : MathHelper.clamp(state.getLightValue(this.world, this.curPos), 0, MAX_LIGHT);
+    }
+
+    private int curToOpac(final IBlockState state)
+    {
+        return this.posToOpac(this.curPos, state);
+    }
+
+    private int posToOpac(final BlockPos pos, final IBlockState state)
+    {
+        return MathHelper.clamp(state.getLightOpacity(this.world, pos), 1, MAX_LIGHT);
+    }
+
+    private IBlockState curToState()
+    {
+        return posToState(this.curPos, this.curChunk);
+    }
+
+    private static IBlockState posToState(final BlockPos pos, final Chunk chunk)
+    {
+        return chunk.getBlockState(pos.getX(), pos.getY(), pos.getZ());
+    }
+
+    private Chunk posToChunk(final BlockPos pos)
+    {
+        return this.world.getChunkProvider().getLoadedChunk(pos.getX() >> 4, pos.getZ() >> 4);
+    }
+
+    private Chunk curToChunk()
+    {
+        return this.posToChunk(this.curPos);
+    }
+
+    //PooledLongQueue code
+    //Implement own queue with pooled segments to reduce allocation costs and reduce idle memory footprint
+
+    private static final int CACHED_QUEUE_SEGMENTS_COUNT = 1 << 12;
+    private static final int QUEUE_SEGMENT_SIZE = 1 << 10;
+
+    private final Deque<PooledLongQueueSegment> segmentPool = new ArrayDeque<PooledLongQueueSegment>();
+
+    private PooledLongQueueSegment getLongQueueSegment()
+    {
+        if (this.segmentPool.isEmpty())
+        {
+            return new PooledLongQueueSegment();
+        }
+
+        return this.segmentPool.pop();
+    }
+
+    private class PooledLongQueueSegment
+    {
+        private final long[] longArray = new long[QUEUE_SEGMENT_SIZE];
+        private int index = 0;
+        private PooledLongQueueSegment next;
+
+        private void release()
+        {
+            this.index = 0;
+            this.next = null;
+
+            if (LightingEngine.this.segmentPool.size() < CACHED_QUEUE_SEGMENTS_COUNT)
+            {
+                LightingEngine.this.segmentPool.push(this);
+            }
+        }
+
+        public PooledLongQueueSegment add(final long val)
+        {
+            PooledLongQueueSegment ret = this;
+
+            if (this.index == QUEUE_SEGMENT_SIZE)
+            {
+                ret = this.next = LightingEngine.this.getLongQueueSegment();
+            }
+
+            ret.longArray[ret.index++] = val;
+            return ret;
+        }
+    }
+
+    private class PooledLongQueue
+    {
+        private PooledLongQueueSegment cur, last;
+        private int size = 0;
+
+        private int index = 0;
+
+        public int size()
+        {
+            return this.size;
+        }
+
+        public boolean isEmpty()
+        {
+            return this.cur == null;
+        }
+
+        public void add(final long val)
+        {
+            if (this.cur == null)
+            {
+                this.cur = this.last = LightingEngine.this.getLongQueueSegment();
+            }
+
+            this.last = this.last.add(val);
+            ++this.size;
+        }
+
+        public long poll()
+        {
+            final long ret = this.cur.longArray[this.index++];
+            --this.size;
+
+            if (this.index == this.cur.index)
+            {
+                this.index = 0;
+                final PooledLongQueueSegment next = this.cur.next;
+                this.cur.release();
+                this.cur = next;
+            }
+
+            return ret;
+        }
+    }
+}

--- a/src/main/java/net/minecraftforge/common/lighting/LightingEngine.java
+++ b/src/main/java/net/minecraftforge/common/lighting/LightingEngine.java
@@ -311,6 +311,7 @@ public class LightingEngine
                 else //we didn't become darker, so we need to re-set our initial light value (was set to 0) and notify neighbors
                 {
                     this.curChunk.setLightFor(lightType, this.curPos, curLight);
+                    this.world.notifyLightSet(this.curPos); //Light didn't change, but asynchronous rendering thread could have seen the temporary 0 value
                     this.spreadLightFromCur(curLight);
                 }
             }

--- a/src/main/java/net/minecraftforge/common/lighting/LightingEngine.java
+++ b/src/main/java/net/minecraftforge/common/lighting/LightingEngine.java
@@ -26,7 +26,6 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import net.minecraft.block.state.IBlockState;
-import net.minecraft.client.Minecraft;
 import net.minecraft.profiler.Profiler;
 import net.minecraft.util.EnumFacing;
 import net.minecraft.util.math.BlockPos;
@@ -35,6 +34,7 @@ import net.minecraft.util.math.MathHelper;
 import net.minecraft.world.EnumSkyBlock;
 import net.minecraft.world.World;
 import net.minecraft.world.chunk.Chunk;
+import net.minecraftforge.fml.common.FMLCommonHandler;
 
 public class LightingEngine
 {
@@ -171,7 +171,7 @@ public class LightingEngine
         }
 
         //renderer accesses world unsynchronized, don't modify anything in that case
-        if (this.world.isRemote && !Minecraft.getMinecraft().isCallingFromMinecraftThread())
+        if (this.world.isRemote && !FMLCommonHandler.instance().getMinecraftThread().isCallingFromMinecraftThread())
         {
             return;
         }

--- a/src/main/java/net/minecraftforge/common/lighting/LightingEngine.java
+++ b/src/main/java/net/minecraftforge/common/lighting/LightingEngine.java
@@ -205,6 +205,7 @@ public class LightingEngine
         }
 
         this.updating = true;
+        this.curChunkIdentifier = -1; //reset chunk cache
 
         this.profiler.startSection("lighting");
 

--- a/src/main/java/net/minecraftforge/common/lighting/LightingEngine.java
+++ b/src/main/java/net/minecraftforge/common/lighting/LightingEngine.java
@@ -431,7 +431,7 @@ public class LightingEngine
 
             final MutableBlockPos nPos = this.neighborsPos[index];
 
-            final Chunk nChunk = this.posToChunk(nPos);
+            final Chunk nChunk = this.neighborsChunk[index];
 
             if (nChunk == null)
             {

--- a/src/main/java/net/minecraftforge/common/lighting/LightingEngine.java
+++ b/src/main/java/net/minecraftforge/common/lighting/LightingEngine.java
@@ -497,11 +497,12 @@ public class LightingEngine
      */
     private int curToLuminosity(final IBlockState state)
     {
-        return this.lightType == EnumSkyBlock.SKY
-            ? this.curChunk.canSeeSky(this.curPos)
-            ? EnumSkyBlock.SKY.defaultLightValue
-            : 0
-            : MathHelper.clamp(state.getLightValue(this.world, this.curPos), 0, MAX_LIGHT);
+        if (this.lightType == EnumSkyBlock.SKY)
+        {
+            return this.curChunk.canSeeSky(this.curPos) ? EnumSkyBlock.SKY.defaultLightValue : 0;
+        }
+
+        return MathHelper.clamp(state.getLightValue(this.world, this.curPos), 0, MAX_LIGHT);
     }
 
     private int curToOpac(final IBlockState state)

--- a/src/main/java/net/minecraftforge/fml/client/FMLClientHandler.java
+++ b/src/main/java/net/minecraftforge/fml/client/FMLClientHandler.java
@@ -973,6 +973,13 @@ public class FMLClientHandler implements IFMLSidedHandler
         throw new RuntimeException("Unknown INetHandler: " + net);
     }
 
+    @Override
+    @Nullable
+    public IThreadListener getMinecraftThread()
+    {
+        return Minecraft.getMinecraft();
+    }
+
     private SetMultimap<String,ResourceLocation> missingTextures = HashMultimap.create();
     private Set<String> badTextureDomains = Sets.newHashSet();
     private Table<String, String, Set<ResourceLocation>> brokenTextures = HashBasedTable.create();

--- a/src/main/java/net/minecraftforge/fml/common/FMLCommonHandler.java
+++ b/src/main/java/net/minecraftforge/fml/common/FMLCommonHandler.java
@@ -686,6 +686,12 @@ public class FMLCommonHandler
         return sidedDelegate.getWorldThread(net);
     }
 
+    @Nullable
+    public IThreadListener getMinecraftThread()
+    {
+        return sidedDelegate.getMinecraftThread();
+    }
+
     public static void callFuture(FutureTask<?> task)
     {
         try

--- a/src/main/java/net/minecraftforge/fml/common/IFMLSidedHandler.java
+++ b/src/main/java/net/minecraftforge/fml/common/IFMLSidedHandler.java
@@ -23,6 +23,8 @@ import java.io.File;
 import java.util.List;
 import java.util.Set;
 
+import javax.annotation.Nullable;
+
 import net.minecraft.network.INetHandler;
 import net.minecraft.network.NetworkManager;
 import net.minecraft.server.MinecraftServer;
@@ -72,6 +74,9 @@ public interface IFMLSidedHandler
     void allowLogins();
 
     IThreadListener getWorldThread(INetHandler net);
+
+    @Nullable
+    IThreadListener getMinecraftThread();
 
     void processWindowMessages();
 

--- a/src/main/java/net/minecraftforge/fml/server/FMLServerHandler.java
+++ b/src/main/java/net/minecraftforge/fml/server/FMLServerHandler.java
@@ -25,6 +25,8 @@ import java.util.Set;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipFile;
 
+import javax.annotation.Nullable;
+
 import net.minecraft.launchwrapper.Launch;
 import net.minecraft.network.INetHandler;
 import net.minecraft.network.NetHandlerPlayServer;
@@ -326,6 +328,13 @@ public class FMLServerHandler implements IFMLSidedHandler
     {
         // Always the server on the dedicated server, eventually add Per-World if Mojang adds world stuff.
         return getServer();
+    }
+
+    @Override
+    @Nullable
+    public IThreadListener getMinecraftThread()
+    {
+        return null;
     }
 
     @Override

--- a/src/main/resources/forge.exc
+++ b/src/main/resources/forge.exc
@@ -23,6 +23,7 @@ net/minecraft/world/chunk/storage/AnvilChunkLoader.loadChunk__Async(Lnet/minecra
 net/minecraft/world/chunk/storage/AnvilChunkLoader.checkedReadChunkFromNBT__Async(Lnet/minecraft/world/World;IILnet/minecraft/nbt/NBTTagCompound;)[Ljava/lang/Object;=|p_75822_1_,p_75822_2_,p_75822_3_,p_75822_4_
 net/minecraft/world/chunk/storage/AnvilChunkLoader.loadEntities(Lnet/minecraft/world/World;Lnet/minecraft/nbt/NBTTagCompound;Lnet/minecraft/world/chunk/Chunk;)V=|p_75823_1_,p_75823_2_,chunk
 net/minecraft/world/gen/ChunkProviderServer.loadChunk(IILjava/lang/Runnable;)Lnet/minecraft/world/chunk/Chunk;=|p_186028_1_,p_186028_2_,runnable
+net/minecraft/world/chunk/Chunk.getCachedLightFor(Lnet/minecraft/world/EnumSkyBlock;Lnet/minecraft/util/math/BlockPos;)I=|p_177413_1_,p_177413_2_
 
 net/minecraft/block/BlockFire.tryCatchFire(Lnet/minecraft/world/World;Lnet/minecraft/util/math/BlockPos;ILjava/util/Random;ILnet/minecraft/util/EnumFacing;)V=|p_176536_1_,p_176536_2_,p_176536_3_,p_176536_4_,p_176536_5_,face
 net/minecraft/block/BlockSkull.getDrops(Lnet/minecraft/world/IBlockAccess;Lnet/minecraft/util/math/BlockPos;Lnet/minecraft/block/state/IBlockState;I)Ljava/util/List;=|p_180663_1_,p_180663_2_,p_180663_3_,fortune


### PR DESCRIPTION
This PR is the third one in our attempt to fix and optimize the vanilla lighting engine. For more details see #3848 (the stuff done here is actually the main intent of the linked issue).

This particular PR has the following effects:
* Fixes [MC-102162](https://bugs.mojang.com/browse/MC-102162)
* Drastically improves the performance of multi-block changes like /fill commands

A quick overview of what it does:
* Processing light updates is postponed until the result is actually needed.
* We completely rewrote the lighting engine (following Vanilla logic). We think that replacing this methods completely shouldn't impose any compatibility issues, as the main logic behind the lighting model should never change.

To be more precise: (some additional comment on the implementation can be found in the code)
* Each `World` now has an instance of `LightingEngine`
* Calls to `World.checkLight` are redirected to `LightingEngine.scheduleLightUpdate`
* Light updates are actually processed at the following places:
  * `Chunk.getLightFor` and `.getLightForSubtracted`. This covers most accesses to the light values.
  * `AnvilChunkLoader.saveChunk`, to ensure that updates are not lost upon quitting the game
  * `SpacketChunkData`, to ensure that they are correctly synced to the client
  * `Minecraft.runTick`, to ensure that lighting updates are processed at least once a tick (before lighting notifications are processed)
* Processing the light updates sorts them by whether the block should get darker or brighter and filters out duplicate schedulings of the same block
* Brightenings and darkenings are processed simultaneously from brightest to darkest. This ensures a good order of updates, so that a single pass suffices and each block is typically updated only once or twice (because it has to be brightened again after darkening).
* The main logic behind this follows the Vanilla code. We just reordered the updates for better performance for multi-block updates.

Reasons why we didn't patch the Vanilla method:
* We need `long`s to store the update positions, while Vanilla uses ìnt`s (which assumes that updates are confined in a 32x32x32 area). Also the Vanilla queue has a fixed size of 32'768 which is too small in general. Patching this would require to change all the bit operations
* We reoder the order in which updates are processed to achieve better performance for multi-block changes. This can't really be patched in with a few lines.
* We cache chunk lookups where possible, as these are taking up ~30% of the exection time for the Vanilla engine.

Remarks:
* Client-side, we explicitly ensure that we are on the main thread. This is because the rendering threads access the world unsynchronized, so they shouldn't cause any modifications
* We bypassed the call to `Chunk.propagateSkylightOcclusion` as the check causes he light updates to be processed immediately, which negates the purpose of this PR. This patch is done properly in #3871, so that one should be merged first (in case this should be accepted).
* There are still some lighting bugs which we plan to fix by other PRs
* To check that we cover all places where we need to proc updates, simply search for accesses to `ExtendedBlockStorage.blockLightArray` and `.skylightArray`, as well as for implementations of `IWorldEventListener.notifyLightSet`
* We implemented a `PooledLongQueue` since the queues change sizes a lot. Not trimming them would result in a large amount of idle memory. On the other hand, trimming them to a small size would lead to frequent reallocations. As the queues are not filled up simultaneously, but the entries move as the algorithm proceeds, the `PooledLongQueue` effectively reduces the overall memory footprint by ~1/15 (compared to former alternative), while reducing allocations to (nearly) zero
* We change one thing w.r.t. to Vanilla: While Vanilla ensures that the neighbor chunks are loaded before light updates are done (which may create defects inside a chunk), we propagate them as far as possible (which moves any such defect to the chunk boundary). This has two upsides:
  * It might be the case that the light changes don't even propagate that far
  * If one tries to fix these glitches later (done in #4184), you only need to search the borders instead of the whole chunk
* World-gen performance (as well as single block changes) is not affected
  * What makes world-gen so expensive is `Chunk.checkLight` (~30% of the total world-gen time), which is actually spent checking the (mostly) dark underground. We may target this in a future PR building up on this one.
* Due to some of the optimizations, the new LightingEngine is less likely to fix lighting glitches "on-the-fly" (i.e. light defect in a region that is updated by some other change). However, this is not an issue if we fix all problems. Additionally, the fixing done by the Vanilla code is spotty at best.
* [EDIT] This PR also depends on #3870, since Vanilla does not initialize sections in `Chunk.setBlockState` when a block exists above them, which is fine if light updates are carried out immediately (because `Chunk.setLightFor` would have initialized them already if they were non-trivial), but not in our case (where `Chunk.setLightFor` is not immediately called). #3870 causes the sections to be initialized in any case, which fixes any possible issues[/EDIT]