### PR TITLE
Fix stacked entity item rendering

### DIFF
--- a/patches/minecraft/net/minecraft/client/renderer/entity/RenderEntityItem.java.patch
+++ b/patches/minecraft/net/minecraft/client/renderer/entity/RenderEntityItem.java.patch
@@ -29,7 +29,7 @@
              GlStateManager.func_179109_b(f3, f4, f5);
          }
  
-@@ -134,10 +131,10 @@
+@@ -134,11 +131,11 @@
                      float f7 = (this.field_177079_e.nextFloat() * 2.0F - 1.0F) * 0.15F;
                      float f9 = (this.field_177079_e.nextFloat() * 2.0F - 1.0F) * 0.15F;
                      float f6 = (this.field_177079_e.nextFloat() * 2.0F - 1.0F) * 0.15F;
@@ -38,17 +38,20 @@
                  }
  
 -                ibakedmodel.func_177552_f().func_181689_a(ItemCameraTransforms.TransformType.GROUND);
-+                ibakedmodel = net.minecraftforge.client.ForgeHooksClient.handleCameraTransforms(ibakedmodel, ItemCameraTransforms.TransformType.GROUND, false);
-                 this.field_177080_a.func_180454_a(itemstack, ibakedmodel);
+-                this.field_177080_a.func_180454_a(itemstack, ibakedmodel);
++                IBakedModel transformedModel = net.minecraftforge.client.ForgeHooksClient.handleCameraTransforms(ibakedmodel, ItemCameraTransforms.TransformType.GROUND, false);
++                this.field_177080_a.func_180454_a(itemstack, transformedModel);
                  GlStateManager.func_179121_F();
              }
+             else
 @@ -152,10 +149,10 @@
                      GlStateManager.func_179109_b(f8, f10, 0.0F);
                  }
  
 -                ibakedmodel.func_177552_f().func_181689_a(ItemCameraTransforms.TransformType.GROUND);
-+                ibakedmodel = net.minecraftforge.client.ForgeHooksClient.handleCameraTransforms(ibakedmodel, ItemCameraTransforms.TransformType.GROUND, false);
-                 this.field_177080_a.func_180454_a(itemstack, ibakedmodel);
+-                this.field_177080_a.func_180454_a(itemstack, ibakedmodel);
++                IBakedModel transformedModel = net.minecraftforge.client.ForgeHooksClient.handleCameraTransforms(ibakedmodel, ItemCameraTransforms.TransformType.GROUND, false);
++                this.field_177080_a.func_180454_a(itemstack, transformedModel);
                  GlStateManager.func_179121_F();
 -                GlStateManager.func_179109_b(0.0F * f, 0.0F * f1, 0.09375F * f2);
 +                GlStateManager.func_179109_b(0.0F, 0.0F, 0.09375F);


### PR DESCRIPTION
Fixes problem with rendering stacked entity items - first item is rendered with correct transform and all others are rendered with identity one.

![fault](https://i.imgur.com/j6PNgj9.png)

Basically, after first rendering loop original baked model may be replaced with one that has no transforms (which happens in case of Forge's [MultiModel](https://github.com/MinecraftForge/MinecraftForge/blob/1.11.x/src/main/java/net/minecraftforge/client/model/MultiModel.java#L140), since `perspective=false` causes transformed models to have empty transformations).

Problem is also present in 1.10.X.

Model used in screenshot:
```json
{
    "forge_marker" : 1,
    "variants" : {
        "inventory" : [{
            "model" : "block_test:tank_frame",
            "submodel" : {
                "bottom" : { "model": "block_test:tank_empty" }
            },
            "transform": "forge:default-block"
        }],
        "normal" : [{
            "model" : "block_test:paintcan_top"
        }]
    }
}
```
Models copied from [here](https://github.com/OpenMods/OpenBlocks/blob/1.10.X/src/main/resources/assets/openblocks/models/block/tank_empty.json) and [here](https://github.com/OpenMods/OpenBlocks/blob/1.10.X/src/main/resources/assets/openblocks/models/block/tank_frame.json).
