### PR TITLE
Recalculate chunk heightmap minimum (MC-117412)

### DIFF
--- a/patches/minecraft/net/minecraft/world/chunk/Chunk.java.patch
+++ b/patches/minecraft/net/minecraft/world/chunk/Chunk.java.patch
@@ -283,7 +283,15 @@
              {
                  this.field_76637_e.func_175664_x(blockpos$mutableblockpos);
              }
-@@ -1476,4 +1495,34 @@
+@@ -1407,6 +1426,7 @@
+         else
+         {
+             System.arraycopy(p_177420_1_, 0, this.field_76634_f, 0, this.field_76634_f.length);
++            this.field_82912_p = com.google.common.primitives.Ints.min(this.field_76634_f); // Forge: update min height value
+         }
+     }
+ 
+@@ -1476,4 +1496,34 @@
          QUEUED,
          CHECK;
      }

--- a/patches/minecraft/net/minecraft/world/chunk/Chunk.java.patch
+++ b/patches/minecraft/net/minecraft/world/chunk/Chunk.java.patch
@@ -287,7 +287,7 @@
          else
          {
              System.arraycopy(p_177420_1_, 0, this.field_76634_f, 0, this.field_76634_f.length);
-+            this.field_82912_p = com.google.common.primitives.Ints.min(this.field_76634_f); // Forge: update min height value
++            this.field_82912_p = com.google.common.primitives.Ints.min(this.field_76634_f); // Forge: update min height value (MC-117412)
          }
      }
  


### PR DESCRIPTION
The minimum heightmap value for a chunk is currently set when the heightmap is populated either by chunk generation on the server, or by a chunk data packet being received by the client. However, it is not set when a chunk is read from NBT (see `AnvilChunkLoader#readChunkFromNBT()`).

This means that server side, any chunk not freshly generated will have a heightmap minimum of 0.
The main effect of this is that lighting checks performed by `Chunk#recheckGaps()` will call `World#checkLightFor()` for all y-values between 0 and the heightmap value for that column (+1), instead of a reduced range.

This PR patches `Chunk#setHeightMap()` to also update the value of `heightMapMinimum` to address this issue.