### PR TITLE
Add an ability to prevent blocks' particles from coloring

### DIFF
--- a/patches/minecraft/net/minecraft/block/Block.java.patch
+++ b/patches/minecraft/net/minecraft/block/Block.java.patch
@@ -1411,6 +1411,18 @@
 +        return isBurning(world, pos) ? net.minecraft.pathfinding.PathNodeType.DAMAGE_FIRE : null;
 +    }
 +
++    /**
++     * Used to prevent block’s digging & hitting particles from coloring
++     * @param blockState Block’s state
++     * @param pos Block’s position
++     * @return Whether to colour block’s particles or not
++     */
++    @SideOnly(Side.CLIENT)
++    public boolean preventParticleColoring(IBlockState blockState, BlockPos pos)
++    {
++        return false;
++    }
++
 +    /* ========================================= FORGE END ======================================*/
 +
      public static void func_149671_p()

--- a/patches/minecraft/net/minecraft/client/particle/ParticleDigging.java.patch
+++ b/patches/minecraft/net/minecraft/client/particle/ParticleDigging.java.patch
@@ -1,0 +1,11 @@
+--- ../src-base/minecraft/net/minecraft/client/particle/ParticleDigging.java
++++ ../src-work/minecraft/net/minecraft/client/particle/ParticleDigging.java
+@@ -37,7 +37,7 @@
+     {
+         this.sourcePos = pos;
+ 
+-        if (this.sourceState.getBlock() == Blocks.GRASS)
++        if (this.sourceState.getBlock() == Blocks.GRASS || this.sourceState.getBlock().preventParticleColoring(sourceState, sourcePos))
+         {
+             return this;
+         }


### PR DESCRIPTION
I added an ability to prevent blocks' particles from coloring in case you color blocks using BlockColors. Here is the example: [modfile](https://gist.github.com/Nullcaller/0cc79c319e3c9f0fd4500aa2fdb2d0aa), [blockfile](https://gist.github.com/Nullcaller/a85e74080059c956be73969bf40b08e5). And assets, if you like: [assets.zip](https://github.com/MinecraftForge/MinecraftForge/files/999391/assets.zip).