### PR TITLE
Fix normals not being generated for formats without normals

### DIFF
--- a/src/main/java/net/minecraftforge/client/model/pipeline/VertexLighterFlat.java
+++ b/src/main/java/net/minecraftforge/client/model/pipeline/VertexLighterFlat.java
@@ -108,7 +108,7 @@ public class VertexLighterFlat extends QuadGatheringTransformer
         float[][] lightmap = quadData[lightmapIndex];
         float[][] color = quadData[colorIndex];
 
-        // If all three normal values are either 0 or 1, normals must be generated
+        // If all three normal values are either -1 or 0, normals must be generated
         if(quadData[normalIndex][0][0] != quadData[normalIndex][0][1] ||
             quadData[normalIndex][0][1] != quadData[normalIndex][0][2] ||
            (quadData[normalIndex][0][0] != -1 && quadData[normalIndex][0][0] != 0))

--- a/src/main/java/net/minecraftforge/client/model/pipeline/VertexLighterFlat.java
+++ b/src/main/java/net/minecraftforge/client/model/pipeline/VertexLighterFlat.java
@@ -108,10 +108,10 @@ public class VertexLighterFlat extends QuadGatheringTransformer
         float[][] lightmap = quadData[lightmapIndex];
         float[][] color = quadData[colorIndex];
 
-        if(normalIndex != -1 && (
-            quadData[normalIndex][0][0] != -1 ||
-            quadData[normalIndex][0][1] != -1 ||
-            quadData[normalIndex][0][2] != -1))
+        // If all three normal values are either 0 or 1, normals must be generated
+        if(quadData[normalIndex][0][0] != quadData[normalIndex][0][1] ||
+            quadData[normalIndex][0][1] != quadData[normalIndex][0][2] ||
+           (quadData[normalIndex][0][0] != -1 && quadData[normalIndex][0][0] != 0))
         {
             normal = quadData[normalIndex];
         }


### PR DESCRIPTION
This fixes quads with no normal data being rendered with the light values of their current position (which for solid blocks, is always 0).

Before:
![](http://i.imgur.com/lM5D0pf.png)

After:
![](http://i.imgur.com/mV3dLBq.png)

These blocks have their models overriden to apply lightmap values, and the normal data was dropped. Without this patch, they render according to their own light value, instead of that which affects the face.

Here is the bug in action on chisel's blocks:
![](https://cdn.discordapp.com/attachments/176563404218171392/311738360106582018/2017-05-09_22.36.11.png)