### PR TITLE
Correctly reset entity IDs when fetching dormant chunks

### DIFF
--- a/src/main/java/net/minecraftforge/common/ForgeChunkManager.java
+++ b/src/main/java/net/minecraftforge/common/ForgeChunkManager.java
@@ -989,14 +989,31 @@ public class ForgeChunkManager
         {
             for (ClassInheritanceMultiMap<Entity> eList : chunk.getEntityLists())
             {
-                Iterator<Entity> itr = eList.iterator();
-                while (itr.hasNext())
+                for (Entity entity : eList)
                 {
-                    (itr.next()).resetEntityId();
+                    if (!entity.isRiding())
+                    {
+                        updateIDs(entity);
+                    }
                 }
             }
         }
         return chunk;
+    }
+
+    private static void updateIDs(Entity entity)
+    {
+        if (entity.isDead) return;
+
+        entity.resetEntityId();
+
+        if (entity.isBeingRidden())
+        {
+            for (Entity passenger : entity.getPassengers())
+            {
+                updateIDs(passenger);
+            }
+        }
     }
 
     static void captureConfig(File configDir)


### PR DESCRIPTION
Might help with #3897.

Entities have an ID, which is based off a global counter that is incremented every time an entity is constructed. This ID is used in many places as the identity for that entity, so it's important that it is as expected (see ae7e328228af47a8f1c792d45f65700674e94aae).

There is some special handling for these IDs in the case of dormant chunks; when loading a regular chunk, the chunk's entities will be constructed and then filled in from NBT, but when a dormant chunk is loaded, no new entities are created.
It is therefore important to reset the entity IDs to the values they would have, were they created in the normal way.

Currently the processing of entity IDs does not match vanilla. The vanilla way is as follows:
* Loop through chunk sections, and loop through the list of entities for each. (see `AnvilChunkLoader#writeChunkToNBT()`)
* For each entity, it is written to NBT only if it is not dead, has a nonnull resource location, and is not riding anything (see `Entity#writeToNBTOptional()`)
* When an entity is written to NBT, it also iterates over all its passengers (if it is being ridden).
* Each passenger is written if it is not dead and has a nonnull resource location. (`Entity#writeToNBTAtomically()`)
* The 'base' entities are added to a list tag, with the riding entities as sublists in the main entities compound tag.

When entities are read in from NBT, each entity in the main list is read in, followed by any passengers it had (and any passengers they have... and so on).

This patch adjusts the code resetting entity IDs to both:
* Do so in the same order (wrt ridden entities)
* Skip dead entities

This should result in more consistent behaviour, and hopefully prevent some issues caused by desynched entity IDs.

