### PR TITLE
Print system details on startup without printing a full crash report

### DIFF
--- a/src/main/java/net/minecraftforge/fml/client/SplashProgress.java
+++ b/src/main/java/net/minecraftforge/fml/client/SplashProgress.java
@@ -228,15 +228,10 @@ public class SplashProgress
                 return "GL info";
             }
         });
-        CrashReport report = CrashReport.makeCrashReport(new Throwable()
-        {
-            @Override public String getMessage(){ return "This is just a prompt for computer specs to be printed. THIS IS NOT A ERROR"; }
-            @Override public void printStackTrace(final PrintWriter s){ s.println(getMessage()); }
-            @Override public void printStackTrace(final PrintStream s) { s.println(getMessage()); }
-        }, "Loading screen debug info");
+        CrashReport report = CrashReport.makeCrashReport(new Throwable(), "Loading screen debug info");
         StringBuilder systemDetailsBuilder = new StringBuilder();
         report.getCategory().appendToStringBuilder(systemDetailsBuilder);
-        System.out.println(systemDetailsBuilder.toString());
+        FMLLog.info(systemDetailsBuilder.toString());
 
         try
         {

--- a/src/main/java/net/minecraftforge/fml/client/SplashProgress.java
+++ b/src/main/java/net/minecraftforge/fml/client/SplashProgress.java
@@ -234,7 +234,9 @@ public class SplashProgress
             @Override public void printStackTrace(final PrintWriter s){ s.println(getMessage()); }
             @Override public void printStackTrace(final PrintStream s) { s.println(getMessage()); }
         }, "Loading screen debug info");
-        System.out.println(report.getCompleteReport());
+        StringBuilder systemDetailsBuilder = new StringBuilder();
+        report.getCategory().appendToStringBuilder(systemDetailsBuilder);
+        System.out.println(systemDetailsBuilder.toString());
 
         try
         {


### PR DESCRIPTION
I always used to jump when I saw a "crash log" right away when loading Minecraft.
This PR prints just the relevant info without being confusing.

Before:
```
[23:47:39] [Client thread/INFO]: [STDOUT]: ---- Minecraft Crash Report ----
// Everything's going to plan. No, really, that was supposed to happen.

Time: 5/20/17 11:47 PM
Description: Loading screen debug info

This is just a prompt for computer specs to be printed. THIS IS NOT A ERROR


A detailed walkthrough of the error, its code path and all known details is as follows:
---------------------------------------------------------------------------------------

-- System Details --
Details:
	Minecraft Version: 1.11.2
	Operating System: Windows 10 (amd64) version 10.0
	Java Version: 1.8.0_102, Oracle Corporation
	Java VM Version: Java HotSpot(TM) 64-Bit Server VM (mixed mode), Oracle Corporation
	Memory: 1578275952 bytes (1505 MB) / 2058354688 bytes (1963 MB) up to 2058354688 bytes (1963 MB)
	JVM Flags: 2 total; -Xmx2g -Xms2g
	IntCache: cache: 0, tcache: 0, allocated: 0, tallocated: 0
	FML: 
	Loaded coremods (and transformers): 
	GL info: ' Vendor: 'NVIDIA Corporation' Version: '4.5.0 NVIDIA 376.53' Renderer: 'GeForce GTX 680/PCIe/SSE2'
```

After: [edit] see later comment
```
[23:47:39] [Client thread/INFO]: [STDOUT]: -- System Details --
Details:
	Minecraft Version: 1.11.2
	Operating System: Windows 10 (amd64) version 10.0
	Java Version: 1.8.0_102, Oracle Corporation
	Java VM Version: Java HotSpot(TM) 64-Bit Server VM (mixed mode), Oracle Corporation
	Memory: 1578275952 bytes (1505 MB) / 2058354688 bytes (1963 MB) up to 2058354688 bytes (1963 MB)
	JVM Flags: 2 total; -Xmx2g -Xms2g
	IntCache: cache: 0, tcache: 0, allocated: 0, tallocated: 0
	FML: 
	Loaded coremods (and transformers): 
	GL info: ' Vendor: 'NVIDIA Corporation' Version: '4.5.0 NVIDIA 376.53' Renderer: 'GeForce GTX 680/PCIe/SSE2'
```