### PR TITLE
Delay unloading chunks until later in the tick cycle

### DIFF
--- a/patches/minecraft/net/minecraft/world/WorldServer.java.patch
+++ b/patches/minecraft/net/minecraft/world/WorldServer.java.patch
@@ -62,7 +62,16 @@
              }
  
              this.func_73053_d();
-@@ -200,7 +210,7 @@
+@@ -187,8 +197,6 @@
+             this.field_175742_R.func_77192_a(this, this.field_72985_G, this.field_72992_H, this.field_72986_A.func_82573_f() % 400L == 0L);
+         }
+ 
+-        this.field_72984_F.func_76318_c("chunkSource");
+-        this.field_73020_y.func_73156_b();
+         int j = this.func_72967_a(1.0F);
+ 
+         if (j != this.func_175657_ab())
+@@ -200,7 +208,7 @@
  
          if (this.func_82736_K().func_82766_b("doDaylightCycle"))
          {
@@ -71,7 +80,7 @@
          }
  
          this.field_72984_F.func_76318_c("tickPending");
-@@ -214,6 +224,10 @@
+@@ -214,6 +222,12 @@
          this.field_175740_d.func_75528_a();
          this.field_72984_F.func_76318_c("portalForcer");
          this.field_85177_Q.func_85189_a(this.func_82737_E());
@@ -79,6 +88,8 @@
 +        {
 +            tele.func_85189_a(func_82737_E());
 +        }
++        this.field_72984_F.func_76318_c("chunkSource");
++        this.field_73020_y.func_73156_b();
          this.field_72984_F.func_76319_b();
          this.func_147488_Z();
      }


### PR DESCRIPTION
One possible fix for #3897.

There is a race condition of sorts in vanilla, involving chunk loading/unloading.
When a chunk is unloaded, the entities and tile entities it contains are marked for removal. The actual removal (from the world) occurs later, when the world ticks its entities.
Conversely, when a chunk is loaded, it generally adds its entities to the world promptly, without queuing.

Here's the normal sequence of events:
1. Chunk unloaded
2. Old entities removed
3. Chunk loaded
4. New entities added

However, what can happen:
1. Chunk unloaded
2. Chunk loaded
3. New entities added
4. Old entities removed

This occurs when an unloaded chunk is reloaded before its corresponding entities have been removed.

The (add new, remove old) ordering is particularly problematic when the dormant chunk cache is used, as, in this case, the 'old' and 'new' entities are actually the same.

This is one solution. The aim here is to close the gap between the chunk unload and the entity removal phases of the tick cycle by delaying the chunk unload processing.

This should both reduce bugs caused by using the dormant chunk cache, and also improve performance a little in general, due to avoiding unnecessary rapid chunk unload/load cycling.
