### PR TITLE
Remove unnecessary GetCollisionBoxesEvent calls in World.collidesWithAnyBlock.

### DIFF
--- a/patches/minecraft/net/minecraft/world/World.java.patch
+++ b/patches/minecraft/net/minecraft/world/World.java.patch
@@ -218,15 +218,26 @@
              this.func_72964_e(i, j).func_76612_a(p_72838_1_);
              this.field_72996_f.add(p_72838_1_);
              this.func_72923_a(p_72838_1_);
-@@ -1262,6 +1325,7 @@
-                                 }
+@@ -1221,6 +1284,9 @@
+         IBlockState iblockstate = Blocks.field_150348_b.func_176223_P();
+         BlockPos.PooledMutableBlockPos blockpos$pooledmutableblockpos = BlockPos.PooledMutableBlockPos.func_185346_s();
  
-                                 iblockstate1.func_185908_a(this, blockpos$pooledmutableblockpos, p_191504_2_, p_191504_4_, p_191504_1_, false);
-+                                net.minecraftforge.common.MinecraftForge.EVENT_BUS.post(new net.minecraftforge.event.world.GetCollisionBoxesEvent(this, null, p_191504_2_, p_191504_4_));
++        if (p_191504_3_) net.minecraftforge.common.MinecraftForge.EVENT_BUS.post(new net.minecraftforge.event.world.GetCollisionBoxesEvent(this, null, p_191504_2_, p_191504_4_));
++        if (p_191504_3_ && !p_191504_4_.isEmpty()) return true;
++
+         try
+         {
+             for (int k1 = i; k1 < j; ++k1)
+@@ -1265,6 +1331,8 @@
  
                                  if (p_191504_3_ && !p_191504_4_.isEmpty())
                                  {
-@@ -1313,11 +1377,10 @@
++                                    net.minecraftforge.common.MinecraftForge.EVENT_BUS.post(new net.minecraftforge.event.world.GetCollisionBoxesEvent(this, null, p_191504_2_, p_191504_4_));
++                                    if (p_191504_4_.isEmpty()) continue;
+                                     boolean flag5 = true;
+                                     return flag5;
+                                 }
+@@ -1313,11 +1381,10 @@
                  }
              }
          }
@@ -239,7 +250,7 @@
      public void func_72848_b(IWorldEventListener p_72848_1_)
      {
          this.field_73021_x.remove(p_72848_1_);
-@@ -1355,19 +1418,38 @@
+@@ -1355,19 +1422,38 @@
  
      public int func_72967_a(float p_72967_1_)
      {
@@ -280,7 +291,7 @@
          float f = this.func_72826_c(p_72971_1_);
          float f1 = 1.0F - (MathHelper.func_76134_b(f * ((float)Math.PI * 2F)) * 2.0F + 0.2F);
          f1 = MathHelper.func_76131_a(f1, 0.0F, 1.0F);
-@@ -1380,6 +1462,12 @@
+@@ -1380,6 +1466,12 @@
      @SideOnly(Side.CLIENT)
      public Vec3d func_72833_a(Entity p_72833_1_, float p_72833_2_)
      {
@@ -293,7 +304,7 @@
          float f = this.func_72826_c(p_72833_2_);
          float f1 = MathHelper.func_76134_b(f * ((float)Math.PI * 2F)) * 2.0F + 0.5F;
          f1 = MathHelper.func_76131_a(f1, 0.0F, 1.0F);
-@@ -1387,9 +1475,7 @@
+@@ -1387,9 +1479,7 @@
          int j = MathHelper.func_76128_c(p_72833_1_.field_70163_u);
          int k = MathHelper.func_76128_c(p_72833_1_.field_70161_v);
          BlockPos blockpos = new BlockPos(i, j, k);
@@ -304,7 +315,7 @@
          float f3 = (float)(l >> 16 & 255) / 255.0F;
          float f4 = (float)(l >> 8 & 255) / 255.0F;
          float f5 = (float)(l & 255) / 255.0F;
-@@ -1438,20 +1524,25 @@
+@@ -1438,20 +1528,25 @@
  
      public float func_72826_c(float p_72826_1_)
      {
@@ -333,7 +344,7 @@
      public float func_72929_e(float p_72929_1_)
      {
          float f = this.func_72826_c(p_72929_1_);
-@@ -1461,6 +1552,12 @@
+@@ -1461,6 +1556,12 @@
      @SideOnly(Side.CLIENT)
      public Vec3d func_72824_f(float p_72824_1_)
      {
@@ -346,7 +357,7 @@
          float f = this.func_72826_c(p_72824_1_);
          float f1 = MathHelper.func_76134_b(f * ((float)Math.PI * 2F)) * 2.0F + 0.5F;
          f1 = MathHelper.func_76131_a(f1, 0.0F, 1.0F);
-@@ -1516,9 +1613,9 @@
+@@ -1516,9 +1617,9 @@
          for (blockpos = new BlockPos(p_175672_1_.func_177958_n(), chunk.func_76625_h() + 16, p_175672_1_.func_177952_p()); blockpos.func_177956_o() >= 0; blockpos = blockpos1)
          {
              blockpos1 = blockpos.func_177977_b();
@@ -358,7 +369,7 @@
              {
                  break;
              }
-@@ -1530,6 +1627,12 @@
+@@ -1530,6 +1631,12 @@
      @SideOnly(Side.CLIENT)
      public float func_72880_h(float p_72880_1_)
      {
@@ -371,7 +382,7 @@
          float f = this.func_72826_c(p_72880_1_);
          float f1 = 1.0F - (MathHelper.func_76134_b(f * ((float)Math.PI * 2F)) * 2.0F + 0.25F);
          f1 = MathHelper.func_76131_a(f1, 0.0F, 1.0F);
-@@ -1564,6 +1667,7 @@
+@@ -1564,6 +1671,7 @@
  
              try
              {
@@ -379,7 +390,7 @@
                  ++entity.field_70173_aa;
                  entity.func_70071_h_();
              }
-@@ -1581,6 +1685,12 @@
+@@ -1581,6 +1689,12 @@
                      entity.func_85029_a(crashreportcategory);
                  }
  
@@ -392,7 +403,7 @@
                  throw new ReportedException(crashreport);
              }
  
-@@ -1642,6 +1752,12 @@
+@@ -1642,6 +1756,12 @@
                      CrashReport crashreport1 = CrashReport.func_85055_a(throwable1, "Ticking entity");
                      CrashReportCategory crashreportcategory1 = crashreport1.func_85058_a("Entity being ticked");
                      entity2.func_85029_a(crashreportcategory1);
@@ -405,7 +416,7 @@
                      throw new ReportedException(crashreport1);
                  }
              }
-@@ -1678,11 +1794,11 @@
+@@ -1678,11 +1798,11 @@
              {
                  BlockPos blockpos = tileentity.func_174877_v();
  
@@ -419,7 +430,7 @@
                          ((ITickable)tileentity).func_73660_a();
                          this.field_72984_F.func_76319_b();
                      }
-@@ -1691,6 +1807,13 @@
+@@ -1691,6 +1811,13 @@
                          CrashReport crashreport2 = CrashReport.func_85055_a(throwable, "Ticking block entity");
                          CrashReportCategory crashreportcategory2 = crashreport2.func_85058_a("Block entity being ticked");
                          tileentity.func_145828_a(crashreportcategory2);
@@ -433,7 +444,7 @@
                          throw new ReportedException(crashreport2);
                      }
                  }
-@@ -1703,20 +1826,28 @@
+@@ -1703,20 +1830,28 @@
  
                  if (this.func_175667_e(tileentity.func_174877_v()))
                  {
@@ -465,7 +476,7 @@
          this.field_72984_F.func_76318_c("pendingBlockEntities");
  
          if (!this.field_147484_a.isEmpty())
-@@ -1755,12 +1886,18 @@
+@@ -1755,12 +1890,18 @@
  
      public boolean func_175700_a(TileEntity p_175700_1_)
      {
@@ -484,7 +495,7 @@
  
          if (this.field_72995_K)
          {
-@@ -1776,6 +1913,11 @@
+@@ -1776,6 +1917,11 @@
      {
          if (this.field_147481_N)
          {
@@ -496,7 +507,7 @@
              this.field_147484_a.addAll(p_147448_1_);
          }
          else
-@@ -1796,9 +1938,12 @@
+@@ -1796,9 +1942,12 @@
      {
          int i = MathHelper.func_76128_c(p_72866_1_.field_70165_t);
          int j = MathHelper.func_76128_c(p_72866_1_.field_70161_v);
@@ -511,7 +522,7 @@
          {
              p_72866_1_.field_70142_S = p_72866_1_.field_70165_t;
              p_72866_1_.field_70137_T = p_72866_1_.field_70163_u;
-@@ -1816,6 +1961,7 @@
+@@ -1816,6 +1965,7 @@
                  }
                  else
                  {
@@ -519,7 +530,7 @@
                      p_72866_1_.func_70071_h_();
                  }
              }
-@@ -1997,6 +2143,11 @@
+@@ -1997,6 +2147,11 @@
                              blockpos$pooledmutableblockpos.func_185344_t();
                              return true;
                          }
@@ -531,7 +542,7 @@
                      }
                  }
              }
-@@ -2036,6 +2187,16 @@
+@@ -2036,6 +2191,16 @@
                          IBlockState iblockstate = this.func_180495_p(blockpos$pooledmutableblockpos);
                          Block block = iblockstate.func_177230_c();
  
@@ -548,7 +559,7 @@
                          if (iblockstate.func_185904_a() == p_72918_2_)
                          {
                              double d0 = (double)((float)(l1 + 1) - BlockLiquid.func_149801_b(((Integer)iblockstate.func_177229_b(BlockLiquid.field_176367_b)).intValue()));
-@@ -2102,6 +2263,7 @@
+@@ -2102,6 +2267,7 @@
      public Explosion func_72885_a(@Nullable Entity p_72885_1_, double p_72885_2_, double p_72885_4_, double p_72885_6_, float p_72885_8_, boolean p_72885_9_, boolean p_72885_10_)
      {
          Explosion explosion = new Explosion(this, p_72885_1_, p_72885_2_, p_72885_4_, p_72885_6_, p_72885_8_, p_72885_9_, p_72885_10_);
@@ -556,7 +567,7 @@
          explosion.func_77278_a();
          explosion.func_77279_a(true);
          return explosion;
-@@ -2224,6 +2386,7 @@
+@@ -2224,6 +2390,7 @@
  
      public void func_175690_a(BlockPos p_175690_1_, @Nullable TileEntity p_175690_2_)
      {
@@ -564,7 +575,7 @@
          if (!this.func_189509_E(p_175690_1_))
          {
              if (p_175690_2_ != null && !p_175690_2_.func_145837_r())
-@@ -2231,6 +2394,8 @@
+@@ -2231,6 +2398,8 @@
                  if (this.field_147481_N)
                  {
                      p_175690_2_.func_174878_a(p_175690_1_);
@@ -573,7 +584,7 @@
                      Iterator<TileEntity> iterator = this.field_147484_a.iterator();
  
                      while (iterator.hasNext())
-@@ -2248,7 +2413,8 @@
+@@ -2248,7 +2417,8 @@
                  }
                  else
                  {
@@ -583,7 +594,7 @@
                      this.func_175700_a(p_175690_2_);
                  }
              }
-@@ -2263,6 +2429,8 @@
+@@ -2263,6 +2433,8 @@
          {
              tileentity.func_145843_s();
              this.field_147484_a.remove(tileentity);
@@ -592,7 +603,7 @@
          }
          else
          {
-@@ -2275,6 +2443,7 @@
+@@ -2275,6 +2447,7 @@
  
              this.func_175726_f(p_175713_1_).func_177425_e(p_175713_1_);
          }
@@ -600,7 +611,7 @@
      }
  
      public void func_147457_a(TileEntity p_147457_1_)
-@@ -2301,7 +2470,7 @@
+@@ -2301,7 +2474,7 @@
              if (chunk != null && !chunk.func_76621_g())
              {
                  IBlockState iblockstate = this.func_180495_p(p_175677_1_);
@@ -609,7 +620,7 @@
              }
              else
              {
-@@ -2324,6 +2493,7 @@
+@@ -2324,6 +2497,7 @@
      {
          this.field_72985_G = p_72891_1_;
          this.field_72992_H = p_72891_2_;
@@ -617,7 +628,7 @@
      }
  
      public void func_72835_b()
-@@ -2333,6 +2503,11 @@
+@@ -2333,6 +2507,11 @@
  
      protected void func_72947_a()
      {
@@ -629,7 +640,7 @@
          if (this.field_72986_A.func_76059_o())
          {
              this.field_73004_o = 1.0F;
-@@ -2346,6 +2521,11 @@
+@@ -2346,6 +2525,11 @@
  
      protected void func_72979_l()
      {
@@ -641,7 +652,7 @@
          if (this.field_73011_w.func_191066_m())
          {
              if (!this.field_72995_K)
-@@ -2470,6 +2650,11 @@
+@@ -2470,6 +2654,11 @@
  
      public boolean func_175670_e(BlockPos p_175670_1_, boolean p_175670_2_)
      {
@@ -653,7 +664,7 @@
          Biome biome = this.func_180494_b(p_175670_1_);
          float f = biome.func_180626_a(p_175670_1_);
  
-@@ -2511,6 +2696,11 @@
+@@ -2511,6 +2700,11 @@
  
      public boolean func_175708_f(BlockPos p_175708_1_, boolean p_175708_2_)
      {
@@ -665,7 +676,7 @@
          Biome biome = this.func_180494_b(p_175708_1_);
          float f = biome.func_180626_a(p_175708_1_);
  
-@@ -2528,7 +2718,7 @@
+@@ -2528,7 +2722,7 @@
              {
                  IBlockState iblockstate = this.func_180495_p(p_175708_1_);
  
@@ -674,7 +685,7 @@
                  {
                      return true;
                  }
-@@ -2560,10 +2750,11 @@
+@@ -2560,10 +2754,11 @@
          else
          {
              IBlockState iblockstate = this.func_180495_p(p_175638_1_);
@@ -689,7 +700,7 @@
              {
                  j = 1;
              }
-@@ -2597,6 +2788,7 @@
+@@ -2597,6 +2792,7 @@
  
                      if (i >= 14)
                      {
@@ -697,7 +708,7 @@
                          return i;
                      }
                  }
-@@ -2662,7 +2854,7 @@
+@@ -2662,7 +2858,7 @@
                                      int j4 = j2 + enumfacing.func_96559_d();
                                      int k4 = k2 + enumfacing.func_82599_e();
                                      blockpos$pooledmutableblockpos.func_181079_c(i4, j4, k4);
@@ -706,7 +717,7 @@
                                      i3 = this.func_175642_b(p_180500_1_, blockpos$pooledmutableblockpos);
  
                                      if (i3 == l2 - l4 && j < this.field_72994_J.length)
-@@ -2770,10 +2962,10 @@
+@@ -2770,10 +2966,10 @@
      public List<Entity> func_175674_a(@Nullable Entity p_175674_1_, AxisAlignedBB p_175674_2_, @Nullable Predicate <? super Entity > p_175674_3_)
      {
          List<Entity> list = Lists.<Entity>newArrayList();
@@ -721,7 +732,7 @@
  
          for (int i1 = i; i1 <= j; ++i1)
          {
-@@ -2826,10 +3018,10 @@
+@@ -2826,10 +3022,10 @@
  
      public <T extends Entity> List<T> func_175647_a(Class <? extends T > p_175647_1_, AxisAlignedBB p_175647_2_, @Nullable Predicate <? super T > p_175647_3_)
      {
@@ -736,7 +747,7 @@
          List<T> list = Lists.<T>newArrayList();
  
          for (int i1 = i; i1 < j; ++i1)
-@@ -2909,11 +3101,13 @@
+@@ -2909,11 +3105,13 @@
  
      public void func_175650_b(Collection<Entity> p_175650_1_)
      {
@@ -753,7 +764,7 @@
          }
      }
  
-@@ -2926,7 +3120,7 @@
+@@ -2926,7 +3124,7 @@
      {
          IBlockState iblockstate = this.func_180495_p(p_190527_2_);
          AxisAlignedBB axisalignedbb = p_190527_3_ ? null : p_190527_1_.func_176223_P().func_185890_d(this, p_190527_2_);
@@ -762,7 +773,7 @@
      }
  
      public int func_181545_F()
-@@ -3009,7 +3203,7 @@
+@@ -3009,7 +3207,7 @@
      public int func_175651_c(BlockPos p_175651_1_, EnumFacing p_175651_2_)
      {
          IBlockState iblockstate = this.func_180495_p(p_175651_1_);
@@ -771,7 +782,7 @@
      }
  
      public boolean func_175640_z(BlockPos p_175640_1_)
-@@ -3152,6 +3346,8 @@
+@@ -3152,6 +3350,8 @@
                      d2 *= ((Double)Objects.firstNonNull(p_184150_11_.apply(entityplayer1), Double.valueOf(1.0D))).doubleValue();
                  }
  
@@ -780,7 +791,7 @@
                  if ((p_184150_9_ < 0.0D || Math.abs(entityplayer1.field_70163_u - p_184150_3_) < p_184150_9_ * p_184150_9_) && (p_184150_7_ < 0.0D || d1 < d2 * d2) && (d0 == -1.0D || d1 < d0))
                  {
                      d0 = d1;
-@@ -3213,7 +3409,7 @@
+@@ -3213,7 +3413,7 @@
  
      public long func_72905_C()
      {
@@ -789,7 +800,7 @@
      }
  
      public long func_82737_E()
-@@ -3223,17 +3419,17 @@
+@@ -3223,17 +3423,17 @@
  
      public long func_72820_D()
      {
@@ -810,7 +821,7 @@
  
          if (!this.func_175723_af().func_177746_a(blockpos))
          {
-@@ -3245,7 +3441,7 @@
+@@ -3245,7 +3445,7 @@
  
      public void func_175652_B(BlockPos p_175652_1_)
      {
@@ -819,7 +830,7 @@
      }
  
      @SideOnly(Side.CLIENT)
-@@ -3265,12 +3461,18 @@
+@@ -3265,12 +3465,18 @@
  
          if (!this.field_72996_f.contains(p_72897_1_))
          {
@@ -838,7 +849,7 @@
          return true;
      }
  
-@@ -3364,8 +3566,7 @@
+@@ -3364,8 +3570,7 @@
  
      public boolean func_180502_D(BlockPos p_180502_1_)
      {
@@ -848,7 +859,7 @@
      }
  
      @Nullable
-@@ -3426,12 +3627,12 @@
+@@ -3426,12 +3631,12 @@
  
      public int func_72800_K()
      {
@@ -863,7 +874,7 @@
      }
  
      public Random func_72843_D(int p_72843_1_, int p_72843_2_, int p_72843_3_)
-@@ -3475,7 +3676,7 @@
+@@ -3475,7 +3680,7 @@
      @SideOnly(Side.CLIENT)
      public double func_72919_O()
      {
@@ -872,7 +883,7 @@
      }
  
      public void func_175715_c(int p_175715_1_, BlockPos p_175715_2_, int p_175715_3_)
-@@ -3509,7 +3710,7 @@
+@@ -3509,7 +3714,7 @@
  
      public void func_175666_e(BlockPos p_175666_1_, Block p_175666_2_)
      {
@@ -881,7 +892,7 @@
          {
              BlockPos blockpos = p_175666_1_.func_177972_a(enumfacing);
  
-@@ -3517,18 +3718,14 @@
+@@ -3517,18 +3722,14 @@
              {
                  IBlockState iblockstate = this.func_180495_p(blockpos);
  
@@ -904,7 +915,7 @@
                      }
                  }
              }
-@@ -3594,6 +3791,115 @@
+@@ -3594,6 +3795,115 @@
          return i >= -128 && i <= 128 && j >= -128 && j <= 128;
      }
  


### PR DESCRIPTION
In 1.11, an event called "GetCollisionBoxesEvent" has been added to Forge with the purpose of being able to modify the list of detected collision boxes in World.getCollisionBoxes(). In order to faciliate the addition and removal of collision boxes, a similar hook for this event was added to World.collideWithAnyBlock(), by moving the event to a private method in World only called by these two methods. Sadly, the way in which it was added left a few problems:

* The event was now being posted for each iterated block, not just for each attempt of collision detection. This can add up quickly, especially for large entities, ending in dozens, if not hundreds of extraneous calls.
* The event can no longer guarantee to provide *all* of the collision boxes, as Mojang's code will return on the first block found with a valid collision box.

The solution to the second problem lies in a redesign of the event itself which cannot be done in 1.11.2 due to the breaking changes necessary. However, the first problem can be mitigated after making the following changes:

* World.getCollisionBoxes() will call GetCollisionBoxesEvent separately when *p_191504_3_* is false and is the only method which can call the function if it is false. Therefore, we do not need to call it in *func_191504_a* when that parameter is false.
* When the parameter is true, the list which GetCollisionBoxesEvent may modify is used for returning if a valid collision box has been found. This parameter is only true in World.collidesWithAnyBlock, where the list is discarded after the method finished operation. In addition, the event itself does not have any parameters which rely on the iteration of collidable blocks. Therefore, there are two cases of meaningful modifications available here: (a) the addition of a new bounding box to collide with or (b) the removal of an added bounding box to ignore it during the iteration. This patch ensures that the event is posted only in those two cases.

Those two changes will reduce the amount of calls to a potentially time-consuming event.

Ideally, this event's use in World.collidesWithAnyBlock should be replaced with a new event returning a Result (for example, CollisionCheckEvent) - that way, multiple calls and unnecessary additional computations of entity collisions can be avoided. However, that has a chance of breaking mods which rely on GetCollisionBoxesEvent to do the same thing, so I believe it should be done in 1.12 instead. (If necessary, I can provide a pull request for that as well. The event could be introduced in 1.11.2, as the addition of it is not a breaking change - it's only the removal of GetCollisionBoxesEvent's role in collision checks which would be.)