### PR TITLE
Fix invalid rendering of single-frame B3D models

### DIFF
--- a/src/main/java/net/minecraftforge/client/model/ModelLoader.java
+++ b/src/main/java/net/minecraftforge/client/model/ModelLoader.java
@@ -791,7 +791,7 @@ public final class ModelLoader extends ModelBakery
                 textures.addAll(model.getTextures()); // Kick this, just in case.
 
                 models.add(model);
-                builder.add(Pair.of(model, v.getState()));
+                builder.add(Pair.<IModel, IModelState>of(model, new ModelStateComposition(v.getState(), model.getDefaultState())));
             }
 
             if (models.size() == 0) //If all variants are missing, add one with the missing model and default rotation.

--- a/src/main/java/net/minecraftforge/client/model/b3d/B3DLoader.java
+++ b/src/main/java/net/minecraftforge/client/model/b3d/B3DLoader.java
@@ -533,6 +533,9 @@ public enum B3DLoader implements ICustomModelLoader
         @Override
         public ModelWrapper process(ImmutableMap<String, String> data)
         {
+            ImmutableSet<String> newMeshes = this.meshes;
+            int newDefaultKey = this.defaultKey;
+            boolean hasChanged = false;
             if(data.containsKey("mesh"))
             {
                 JsonElement e = new JsonParser().parse(data.get("mesh"));
@@ -555,7 +558,8 @@ public enum B3DLoader implements ICustomModelLoader
                             return this;
                         }
                     }
-                    return new ModelWrapper(modelLocation, model, builder.build(), smooth, gui3d, defaultKey, textures);
+                    newMeshes = builder.build();
+                    hasChanged = true;
                 }
                 else
                 {
@@ -568,7 +572,8 @@ public enum B3DLoader implements ICustomModelLoader
                 JsonElement e = new JsonParser().parse(data.get("key"));
                 if(e.isJsonPrimitive() && e.getAsJsonPrimitive().isNumber())
                 {
-                    return new ModelWrapper(modelLocation, model, meshes, smooth, gui3d, e.getAsNumber().intValue(), textures);
+                    newDefaultKey = e.getAsNumber().intValue();
+                    hasChanged = true;
                 }
                 else
                 {
@@ -576,7 +581,7 @@ public enum B3DLoader implements ICustomModelLoader
                     return this;
                 }
             }
-            return this;
+            return hasChanged ? new ModelWrapper(modelLocation, model, newMeshes, smooth, gui3d, newDefaultKey, textures) : this;
         }
 
         public Optional<IClip> getClip(String name)


### PR DESCRIPTION
1. Changes B3D `ModelWrapper.process` to apply both custom keys
2. In `WeightedRandomModel` composes state from variant and state from model itself.