### PR TITLE
Make World.isValid and World.isOutsideBuildHeight public

### DIFF
--- a/src/main/resources/forge_at.cfg
+++ b/src/main/resources/forge_at.cfg
@@ -62,6 +62,8 @@ public net.minecraft.world.WorldServer func_72923_a(Lnet/minecraft/entity/Entity
 public net.minecraft.world.WorldServer func_72847_b(Lnet/minecraft/entity/Entity;)V #onEntityRemoved
 public net.minecraft.client.multiplayer.WorldClient func_72923_a(Lnet/minecraft/entity/Entity;)V #onEntityAdded
 public net.minecraft.client.multiplayer.WorldClient func_72847_b(Lnet/minecraft/entity/Entity;)V #onEntityRemoved
+public net.minecraft.world.World func_175701_a(Lnet/minecraft/util/math/BlockPos;)Z # isValid
+public net.minecraft.world.World func_189509_E(Lnet/minecraft/util/math/BlockPos;)Z # isOutsideBuildHeight
 # GuiIngame
 protected net.minecraft.client.gui.GuiIngame *
 protected net.minecraft.client.gui.GuiIngame *()


### PR DESCRIPTION
This will allow mods to check for min/max world height and for valid world coordinates without hardcoding the values.

The reason I want this:

I'm working on [cubic chunks](https://github.com/OpenCubicChunks/CubicChunks) mod which extends Minecraft world height end depth far beyond 0-256. Many mods currently have hardcoded height checks because there really is no better option (like [BuildCraft does](https://github.com/BuildCraft/BuildCraft/issues/3609) for example, there is `world.getHeight()` which could and sometimes is already used, but there is no equivalent for minimum height). Making these methods public will make compatibility much easier without resorting to access transformers or reflectively accessing these methods, or using mod-specific API. Example mod that has hardcoded height checks

I know it wouldn't really benefit other mods that much as the Minecraft world depth is unlikely to ever change. But even taking the cubic chunks mod aside, hardcoding world min and max height in every mod seems like a bad thing anyway.

I also thought adding `getMinHeight` may be a good idea, should I add that too?