### PR TITLE
Add World#isFakeWorld() for modded customized worlds

### DIFF
--- a/patches/minecraft/net/minecraft/world/World.java.patch
+++ b/patches/minecraft/net/minecraft/world/World.java.patch
@@ -1020,3 +1020,27 @@
      public void func_184135_a(Packet<?> p_184135_1_)
      {
          throw new UnsupportedOperationException("Can\'t send packets to server unless you\'re on the client.");
+@@ -3609,4 +3915,23 @@
+     {
+         return null;
+     }
++
++    /**
++     * Gets whether this world is to be considered a "fake" world where normal block
++     * processing may need to take place, but certain operations, such as block tracking,
++     * or other "expectations" of a world being a traditional dimension in which players
++     * are exposed to visiting (like the nether) are invalid. Since {@link #isRemote} only
++     * dictates whether a world is considered the "server" or processing world, sometimes,
++     * a "fake" world needs to return {@code false}, but still remain ignored by other mods
++     * for this specific processing. By default, {@link World} and {@link WorldServer},
++     * {@link WorldServerMulti}, and in the client context, {@code WorldClient} are to return
++     * {@code false}.
++     *
++     * @return True if this world is to be considered fake, but still can be utilized for
++     *     traditional mechanics without modification
++     */
++    public boolean isFakeWorld()
++    {
++        return false;
++    }
+ }


### PR DESCRIPTION
This patch is to provide a useful cross mod understanding when a custom `World` is not to be considered for various processing and what not where `Player` objects are traditionally not exposed to traveling to, and therefor not associated with the `DimensionManager`. In the specific case with SpongeForge and Buildcraft, there is an issue where Sponge's internal processing to track block changes and other transactions taking place in a `World` are being tracked because Buildcraft has no way to signify the world is a "fake" world if only to manually perform block changes and gather other information based on pre-existing block mechanics, such as block drops, or performing pastes, and what have you, such that Sponge cannot sanely determine that their `FakeWorld` is not to be tracked for those transactions.

An excerpt from SpongePowered/SpongeForge#1527:
>for now there is no ticking going on so there should be no real issues atm yet
>the current use of the fake world is to check requirements of blocks for the snapshots in what blocks are required to place them (getting pickblock) but this world is also used for displaying the content of them in your inventory
>as for possible compat modifications: since 1.12 is arround the corner it might be worth adding a function to world in forge: isRealWorld or something like that, would default to true but mods with fake worlds that are completely not accesable by players could return false there, this would allow other mods and things like spongeforge to know this and addapt (for example any permission and logging mods/plugins could just disregard that world)

Tagging the possibly interested parties: @AlexIIL @AEnterprise @Zidane @bloodmc 

Of course, since 1.12 has not yet been released, this could do with some discussion.