### PR TITLE
Fix shaders not loading from mod domains

### DIFF
--- a/patches/minecraft/net/minecraft/client/shader/ShaderManager.java.patch
+++ b/patches/minecraft/net/minecraft/client/shader/ShaderManager.java.patch
@@ -1,0 +1,12 @@
+--- ../src-base/minecraft/net/minecraft/client/shader/ShaderManager.java
++++ ../src-work/minecraft/net/minecraft/client/shader/ShaderManager.java
+@@ -54,7 +54,8 @@
+     public ShaderManager(IResourceManager p_i45087_1_, String p_i45087_2_) throws JsonException, IOException
+     {
+         JsonParser jsonparser = new JsonParser();
+-        ResourceLocation resourcelocation = new ResourceLocation("shaders/program/" + p_i45087_2_ + ".json");
++        ResourceLocation resourcelocation = new ResourceLocation(p_i45087_2_ + ".json");
++        resourcelocation = new ResourceLocation(resourcelocation.func_110624_b(), "shaders/program/" + resourcelocation.func_110623_a());
+         this.field_148007_m = p_i45087_2_;
+         IResource iresource = null;
+ 


### PR DESCRIPTION
Vanilla has some dumb code here that doesn't care about domains in the string. This allows mod shaders (in /shaders/post/) to reference shader programs (in /shaders/program/) from their own domain.

This fix could be a bit cleaner, but I went for minimal patch size.