### PR TITLE
Add a hook to allow world providers to change the lightmap colours.

### DIFF
--- a/patches/minecraft/net/minecraft/client/renderer/EntityRenderer.java.patch
+++ b/patches/minecraft/net/minecraft/client/renderer/EntityRenderer.java.patch
@@ -78,7 +78,18 @@
              if (this.field_78531_r.field_71474_y.field_74320_O == 0 && !flag && !this.field_78531_r.field_71474_y.field_74319_N && !this.field_78531_r.field_71442_b.func_78747_a())
              {
                  this.func_180436_i();
-@@ -1101,6 +1100,10 @@
+@@ -876,6 +875,10 @@
+                         f10 = 0.25F + f7 * 0.75F;
+                     }
+ 
++                    float[] colors = new float[] {f8, f9, f10};
++                    world.field_73011_w.getLightmapColors(f, f2, f3, colors);
++                    f8 = colors[0]; f9 = colors[1]; f10 = colors[2];
++
+                     if (this.field_78531_r.field_71439_g.func_70644_a(MobEffects.field_76439_r))
+                     {
+                         float f15 = this.func_180438_a(this.field_78531_r.field_71439_g, p_78472_1_);
+@@ -1101,6 +1104,10 @@
                  GlStateManager.func_179096_D();
                  this.func_78478_c();
                  this.field_78510_Z = System.nanoTime();
@@ -89,7 +100,7 @@
              }
  
              if (this.field_78531_r.field_71462_r != null)
-@@ -1109,7 +1112,7 @@
+@@ -1109,7 +1116,7 @@
  
                  try
                  {
@@ -98,7 +109,7 @@
                  }
                  catch (Throwable throwable)
                  {
-@@ -1204,7 +1207,7 @@
+@@ -1204,7 +1211,7 @@
  
                      if (this.field_78531_r.field_71442_b.func_178889_l() == GameType.SPECTATOR)
                      {
@@ -107,7 +118,7 @@
                      }
                      else
                      {
-@@ -1329,7 +1332,9 @@
+@@ -1329,7 +1336,9 @@
              GlStateManager.func_179094_E();
              RenderHelper.func_74519_b();
              this.field_78531_r.field_71424_I.func_76318_c("entities");
@@ -117,7 +128,7 @@
              RenderHelper.func_74518_a();
              this.func_175072_h();
          }
-@@ -1342,6 +1347,7 @@
+@@ -1342,6 +1351,7 @@
              EntityPlayer entityplayer = (EntityPlayer)entity;
              GlStateManager.func_179118_c();
              this.field_78531_r.field_71424_I.func_76318_c("outline");
@@ -125,7 +136,7 @@
              renderglobal.func_72731_b(entityplayer, this.field_78531_r.field_71476_x, 0, p_175068_2_);
              GlStateManager.func_179141_d();
          }
-@@ -1388,6 +1394,17 @@
+@@ -1388,6 +1398,17 @@
          GlStateManager.func_179103_j(7425);
          this.field_78531_r.field_71424_I.func_76318_c("translucent");
          renderglobal.func_174977_a(BlockRenderLayer.TRANSLUCENT, (double)p_175068_2_, p_175068_1_, entity);
@@ -143,7 +154,7 @@
          GlStateManager.func_179103_j(7424);
          GlStateManager.func_179132_a(true);
          GlStateManager.func_179089_o();
-@@ -1400,6 +1417,9 @@
+@@ -1400,6 +1421,9 @@
              this.func_180437_a(renderglobal, p_175068_2_, p_175068_1_, d0, d1, d2);
          }
  
@@ -153,7 +164,7 @@
          this.field_78531_r.field_71424_I.func_76318_c("hand");
  
          if (this.field_175074_C)
-@@ -1515,6 +1535,13 @@
+@@ -1515,6 +1539,13 @@
  
      protected void func_78474_d(float p_78474_1_)
      {
@@ -167,7 +178,7 @@
          float f = this.field_78531_r.field_71441_e.func_72867_j(p_78474_1_);
  
          if (f > 0.0F)
-@@ -1845,6 +1872,13 @@
+@@ -1845,6 +1876,13 @@
              this.field_175081_S = f7;
          }
  
@@ -181,7 +192,7 @@
          GlStateManager.func_179082_a(this.field_175080_Q, this.field_175082_R, this.field_175081_S, 0.0F);
      }
  
-@@ -1855,7 +1889,9 @@
+@@ -1855,7 +1893,9 @@
          GlStateManager.func_187432_a(0.0F, -1.0F, 0.0F);
          GlStateManager.func_179131_c(1.0F, 1.0F, 1.0F, 1.0F);
          IBlockState iblockstate = ActiveRenderInfo.func_186703_a(this.field_78531_r.field_71441_e, entity, p_78468_2_);
@@ -192,7 +203,7 @@
          if (entity instanceof EntityLivingBase && ((EntityLivingBase)entity).func_70644_a(MobEffects.field_76440_q))
          {
              float f1 = 5.0F;
-@@ -1940,6 +1976,7 @@
+@@ -1940,6 +1980,7 @@
                  GlStateManager.func_179102_b(f * 0.05F);
                  GlStateManager.func_179153_c(Math.min(f, 192.0F) * 0.5F);
              }

--- a/patches/minecraft/net/minecraft/client/renderer/EntityRenderer.java.patch
+++ b/patches/minecraft/net/minecraft/client/renderer/EntityRenderer.java.patch
@@ -82,8 +82,8 @@
                          f10 = 0.25F + f7 * 0.75F;
                      }
  
-+                    float[] colors = new float[] {f8, f9, f10};
-+                    world.field_73011_w.getLightmapColors(f, f2, f3, colors);
++                    float[] colors = {f8, f9, f10};
++                    world.field_73011_w.getLightmapColors(p_78472_1_, f, f2, f3, colors);
 +                    f8 = colors[0]; f9 = colors[1]; f10 = colors[2];
 +
                      if (this.field_78531_r.field_71439_g.func_70644_a(MobEffects.field_76439_r))

--- a/patches/minecraft/net/minecraft/world/WorldProvider.java.patch
+++ b/patches/minecraft/net/minecraft/world/WorldProvider.java.patch
@@ -54,7 +54,7 @@
      }
  
      @SideOnly(Side.CLIENT)
-@@ -222,6 +208,339 @@
+@@ -222,6 +208,352 @@
          return new WorldBorder();
      }
  
@@ -176,6 +176,19 @@
 +    {
 +        weatherRenderer = renderer;
 +    }
++
++    /**
++     * Allows for manipulating the coloring of the lightmap texture.
++     * Will be called for each 16*16 combination of sky/block light values.
++     *
++     * @param sunBrightness Current sun brightness.
++     * @param skyLight Sky light brightness factor.
++     * @param blockLight Block light brightness factor.
++     * @param colors The color values that will be used: [r, g, b].
++     *
++     * @see net.minecraft.client.renderer.EntityRenderer#updateLightmap(float)
++     */
++    public void getLightmapColors(float sunBrightness, float skyLight, float blockLight, float[] colors) {}
 +
 +    public BlockPos getRandomizedSpawnPoint()
 +    {

--- a/patches/minecraft/net/minecraft/world/WorldProvider.java.patch
+++ b/patches/minecraft/net/minecraft/world/WorldProvider.java.patch
@@ -54,7 +54,7 @@
      }
  
      @SideOnly(Side.CLIENT)
-@@ -222,6 +208,352 @@
+@@ -222,6 +208,353 @@
          return new WorldBorder();
      }
  
@@ -181,6 +181,7 @@
 +     * Allows for manipulating the coloring of the lightmap texture.
 +     * Will be called for each 16*16 combination of sky/block light values.
 +     *
++     * @param partialTicks Progress between ticks.
 +     * @param sunBrightness Current sun brightness.
 +     * @param skyLight Sky light brightness factor.
 +     * @param blockLight Block light brightness factor.
@@ -188,7 +189,7 @@
 +     *
 +     * @see net.minecraft.client.renderer.EntityRenderer#updateLightmap(float)
 +     */
-+    public void getLightmapColors(float sunBrightness, float skyLight, float blockLight, float[] colors) {}
++    public void getLightmapColors(float partialTicks, float sunBrightness, float skyLight, float blockLight, float[] colors) {}
 +
 +    public BlockPos getRandomizedSpawnPoint()
 +    {


### PR DESCRIPTION
This PR patches in a hook to `EntityRenderer.updateLightmap()` to allow custom `WorldProvider` implementations to change the lightmap texture colouring.

Currently it's possible to alter the base brightness table used, but not change the colouring, or treat sky/block lighting differently. Vanilla already has a hardcoded check for the End dimension here to achieve this.

The method call is inserted just after the End dimension check, and before night vision and gamma adjustments.

As an example, here is the same world; first as vanilla, then with this hook used to apply something similar to the End's lighting.

Vanilla:
![2017-05-26_00 55 02](https://cloud.githubusercontent.com/assets/1447117/26475703/311b50b4-41b1-11e7-9643-90532d61d0c7.png)

Custom:
![2017-05-26_00 53 52](https://cloud.githubusercontent.com/assets/1447117/26475710/408953c0-41b1-11e7-8e2b-2c84d824764a.png)

