### PR TITLE
[1.12] Made substitutions possible for all registries

### DIFF
--- a/src/main/java/net/minecraftforge/fml/common/registry/GameRegistry.java
+++ b/src/main/java/net/minecraftforge/fml/common/registry/GameRegistry.java
@@ -346,6 +346,7 @@ public class GameRegistry
         return fuelValue;
     }
 
+
     public enum Type
     {
         BLOCK,
@@ -354,6 +355,9 @@ public class GameRegistry
         ENCHANTMENT,
         POTION,
         POTION_TYPE,
+        /**
+         * Registering substitutions for this does not affect vanilla block sounds as they use SoundTypes
+         */
         SOUND_EVENT,
         ENTITY;
     }

--- a/src/main/java/net/minecraftforge/fml/common/registry/GameRegistry.java
+++ b/src/main/java/net/minecraftforge/fml/common/registry/GameRegistry.java
@@ -349,7 +349,13 @@ public class GameRegistry
     public enum Type
     {
         BLOCK,
-        ITEM;
+        ITEM,
+        BIOME,
+        ENCHANTMENT,
+        POTION,
+        POTION_TYPE,
+        SOUND_EVENT,
+        ENTITY;
     }
 
     /**

--- a/src/main/java/net/minecraftforge/fml/common/registry/ObjectHolderRegistry.java
+++ b/src/main/java/net/minecraftforge/fml/common/registry/ObjectHolderRegistry.java
@@ -77,6 +77,11 @@ public enum ObjectHolderRegistry {
         }
         scanTarget(classModIds, classCache, "net.minecraft.init.Blocks", null, "minecraft", true, true);
         scanTarget(classModIds, classCache, "net.minecraft.init.Items", null, "minecraft", true, true);
+        scanTarget(classModIds, classCache, "net.minecraft.init.MobEffects", null, "minecraft", true, true);
+        scanTarget(classModIds, classCache, "net.minecraft.init.Biomes", null, "minecraft", true, true);
+        scanTarget(classModIds, classCache, "net.minecraft.init.Enchantments", null, "minecraft", true, true);
+        scanTarget(classModIds, classCache, "net.minecraft.init.SoundEvents", null, "minecraft", true, true);
+        scanTarget(classModIds, classCache, "net.minecraft.init.PotionTypes", null, "minecraft", true, true);
         FMLLog.info("Found %d ObjectHolder annotations", objectHolders.size());
     }
 
@@ -96,7 +101,7 @@ public enum ObjectHolderRegistry {
             }
             catch (Exception ex)
             {
-                // unpossible?
+                // Is the field public?
                 throw Throwables.propagate(ex);
             }
         }
@@ -123,7 +128,7 @@ public enum ObjectHolderRegistry {
             }
             catch (Exception ex)
             {
-                // unpossible?
+                // Is the field public?
                 throw Throwables.propagate(ex);
             }
         }

--- a/src/test/java/net/minecraftforge/debug/SubstitutionTest.java
+++ b/src/test/java/net/minecraftforge/debug/SubstitutionTest.java
@@ -1,0 +1,194 @@
+package net.minecraftforge.debug;
+
+import net.minecraft.block.BlockGravel;
+import net.minecraft.block.SoundType;
+import net.minecraft.enchantment.Enchantment;
+import net.minecraft.enchantment.EnchantmentArrowDamage;
+import net.minecraft.enchantment.EnchantmentDamage;
+import net.minecraft.enchantment.EnchantmentDigging;
+import net.minecraft.entity.passive.EntityCow;
+import net.minecraft.init.MobEffects;
+import net.minecraft.init.PotionTypes;
+import net.minecraft.inventory.EntityEquipmentSlot;
+import net.minecraft.potion.Potion;
+import net.minecraft.potion.PotionEffect;
+import net.minecraft.potion.PotionType;
+import net.minecraft.util.ResourceLocation;
+import net.minecraft.util.SoundEvent;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.World;
+import net.minecraft.world.biome.Biome;
+import net.minecraft.world.biome.BiomeOcean;
+import net.minecraft.world.biome.BiomePlains;
+import net.minecraftforge.fml.common.FMLLog;
+import net.minecraftforge.fml.common.Mod;
+import net.minecraftforge.fml.common.event.FMLPreInitializationEvent;
+import net.minecraftforge.fml.common.registry.*;
+import org.apache.logging.log4j.Logger;
+
+/**
+ * TODO maybe check ExistingSubstitutionException as well as IncompatibleSubstitutionException (probably in a test test)
+ * To verify this is working
+ * 1. Check the log for 'Substitution tests successful' resp. 'One or more substitution tests failed'
+ * 2. Check the following replacements:
+ * a) '/effect <player> minecraft:slowness' -> You should get 'test_substitution' effect
+ * b) Select a speed potion out of the creative tab and drink it -> You should get swiftness and absorption
+ * c) Equip a pickaxe and use '/enchant <player> minecraft:efficiency' -> You should get a 'test_substitution' enchantment
+ * d) Summon a cow and hit it. It should make a glass break sound
+ * e) Summon a cow. It should always render a name tag
+ * d) Look for an ocean biome. The water should be red
+ */
+@Mod(modid = "forge.testsubmod", name = "Forge Substitution Test", version = "1.0", acceptableRemoteVersions = "*")
+public class SubstitutionTest
+{
+    public static boolean enabled=true;
+
+    private static Logger logger;
+
+    @Mod.EventHandler
+    public void preInit(FMLPreInitializationEvent evt){
+        logger=evt.getModLog();
+        if(enabled){
+            boolean success= testPotion() && testPotionType() && testEnchantment() && testSoundEvent() && testEntity() && testBiome() && testBlock();
+
+            if(success){
+                logger.info("Substitution tests successful");
+            }
+            else{
+                FMLLog.bigWarning("One or more substitution tests failed");
+            }
+        }
+    }
+
+
+
+    private boolean testPotion(){
+        return replace(GameRegistry.Type.POTION,GameData.getPotionRegistry(),new ResourceLocation("minecraft:slowness"),new TestPotion() );
+    }
+
+    private boolean testPotionType(){
+        ResourceLocation typeId=new ResourceLocation("minecraft:swiftness");
+        return replace(GameRegistry.Type.POTION_TYPE, GameData.getPotionTypesRegistry(),typeId,new PotionType(typeId.getResourcePath(),new PotionEffect(MobEffects.SPEED,600),new PotionEffect(MobEffects.ABSORPTION,600)));
+    }
+
+    private boolean testEnchantment(){
+        return replace(GameRegistry.Type.ENCHANTMENT, GameData.getEnchantmentRegistry(),new ResourceLocation("minecraft:efficiency"),new TestEnchantment());
+    }
+
+    private boolean testSoundEvent(){
+        return replace(GameRegistry.Type.SOUND_EVENT, GameData.getSoundEventRegistry(),new ResourceLocation("minecraft:entity.cow.hurt"),new SoundEvent(new ResourceLocation("minecraft:block.glass.break")));
+    }
+
+    private boolean testEntity(){
+        return replace(GameRegistry.Type.ENTITY, GameData.getEntityRegistry(), new ResourceLocation("minecraft:cow"),new EntityEntry(TestCow.class,"Cow"));
+    }
+
+    private boolean testBiome(){
+        return replace(GameRegistry.Type.BIOME, GameData.getBiomeRegistry(), new ResourceLocation("minecraft:ocean"),new TestBiome());
+    }
+
+    private boolean testBlock(){
+        return replace(GameRegistry.Type.BLOCK, GameData.getBlockRegistry(), new ResourceLocation("minecraft:gravel"),new TestBlock());
+    }
+
+
+    /**
+     * Try to register a substitution and verify the success. Logs any problems.
+     * @return Success
+     */
+    private <T extends IForgeRegistryEntry<T>> boolean replace(GameRegistry.Type type, IForgeRegistry<T> registry, ResourceLocation id, T testObject){
+        T oldEntry = registry.getValue(id);
+        try
+        {
+            GameRegistry.addSubstitutionAlias(id.toString(),type,testObject);
+            T newEntry = registry.getValue(id);
+            if(oldEntry.equals(newEntry)){
+                logger.warn("[%s]Did not replace %s(%s) with %s",type,oldEntry,id,testObject);
+                return false;
+            }
+            else if(testObject.equals(newEntry)){
+                return true;
+            }
+            else{
+                //To make sure we are not missing anything here
+                logger.warn("[%s]Something went wrong while replacing %s(%s) with %s. Got %s",type,oldEntry,id,testObject,newEntry);
+                return false;
+            }
+        }
+        catch (ExistingSubstitutionException e)
+        {
+            logger.error("[%s]Failed to register substitution for %s",type,id);
+            logger.catching(e);
+        }
+        return false;
+    }
+
+
+    private class TestEnchantment extends EnchantmentDigging{
+
+        protected TestEnchantment()
+        {
+            super(Enchantment.Rarity.COMMON, EntityEquipmentSlot.MAINHAND);
+            this.setName("test_substitution");
+        }
+
+    }
+
+
+    private class TestPotion extends Potion{
+
+        protected TestPotion()
+        {
+            super(false, 0x000000);
+            this.setPotionName("test_substitution");
+        }
+    }
+
+    /**
+     * Has to be public. Otherwise EntityEntry cannot find/use the constructor.
+     *
+     * If newly registered and a existing world is loaded, all existent cows will be substituted with this class.
+     * If removed from mod code, all substituted entities will be removed TODO Test without PersistentRegistryManager
+     */
+    public static class TestCow extends EntityCow{
+
+        public TestCow(World worldIn)
+        {
+            super(worldIn);
+        }
+
+        @Override
+        public boolean getAlwaysRenderNameTagForRender()
+        {
+            return true;
+        }
+
+        @Override
+        public String getCustomNameTag()
+        {
+            return "Test_Cow";
+        }
+
+        @Override public boolean hasCustomName()
+        {
+            return true;
+        }
+    }
+
+    private class TestBiome extends BiomeOcean{
+
+        public TestBiome()
+        {
+            super(new Biome.BiomeProperties("Ocean").setBaseHeight(-1.0F).setHeightVariation(0.1F).setWaterColor(0xFF0000));
+        }
+
+    }
+
+    private class TestBlock extends BlockGravel{
+        public TestBlock()
+        {
+            setBlockUnbreakable();
+            setUnlocalizedName("gravel");
+        }
+    }
+}

--- a/src/test/java/net/minecraftforge/debug/SubstitutionTest.java
+++ b/src/test/java/net/minecraftforge/debug/SubstitutionTest.java
@@ -1,25 +1,19 @@
 package net.minecraftforge.debug;
 
 import net.minecraft.block.BlockGravel;
-import net.minecraft.block.SoundType;
 import net.minecraft.enchantment.Enchantment;
-import net.minecraft.enchantment.EnchantmentArrowDamage;
-import net.minecraft.enchantment.EnchantmentDamage;
 import net.minecraft.enchantment.EnchantmentDigging;
 import net.minecraft.entity.passive.EntityCow;
 import net.minecraft.init.MobEffects;
-import net.minecraft.init.PotionTypes;
 import net.minecraft.inventory.EntityEquipmentSlot;
 import net.minecraft.potion.Potion;
 import net.minecraft.potion.PotionEffect;
 import net.minecraft.potion.PotionType;
 import net.minecraft.util.ResourceLocation;
 import net.minecraft.util.SoundEvent;
-import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.World;
 import net.minecraft.world.biome.Biome;
 import net.minecraft.world.biome.BiomeOcean;
-import net.minecraft.world.biome.BiomePlains;
 import net.minecraftforge.fml.common.FMLLog;
 import net.minecraftforge.fml.common.Mod;
 import net.minecraftforge.fml.common.event.FMLPreInitializationEvent;
@@ -41,90 +35,106 @@ import org.apache.logging.log4j.Logger;
 @Mod(modid = "forge.testsubmod", name = "Forge Substitution Test", version = "1.0", acceptableRemoteVersions = "*")
 public class SubstitutionTest
 {
-    public static boolean enabled=true;
+    public static boolean enabled = true;
 
     private static Logger logger;
 
     @Mod.EventHandler
-    public void preInit(FMLPreInitializationEvent evt){
-        logger=evt.getModLog();
-        if(enabled){
-            boolean success= testPotion() && testPotionType() && testEnchantment() && testSoundEvent() && testEntity() && testBiome() && testBlock();
+    public void preInit(FMLPreInitializationEvent evt)
+    {
+        logger = evt.getModLog();
+        if (enabled)
+        {
+            boolean success = testPotion() && testPotionType() && testEnchantment() && testSoundEvent() && testEntity() && testBiome() && testBlock();
 
-            if(success){
+            if (success)
+            {
                 logger.info("Substitution tests successful");
             }
-            else{
+            else
+            {
                 FMLLog.bigWarning("One or more substitution tests failed");
             }
         }
     }
 
-
-
-    private boolean testPotion(){
-        return replace(GameRegistry.Type.POTION,GameData.getPotionRegistry(),new ResourceLocation("minecraft:slowness"),new TestPotion() );
+    private boolean testPotion()
+    {
+        return replace(GameRegistry.Type.POTION, GameData.getPotionRegistry(), new ResourceLocation("minecraft:slowness"), new TestPotion());
     }
 
-    private boolean testPotionType(){
-        ResourceLocation typeId=new ResourceLocation("minecraft:swiftness");
-        return replace(GameRegistry.Type.POTION_TYPE, GameData.getPotionTypesRegistry(),typeId,new PotionType(typeId.getResourcePath(),new PotionEffect(MobEffects.SPEED,600),new PotionEffect(MobEffects.ABSORPTION,600)));
+    private boolean testPotionType()
+    {
+        ResourceLocation typeId = new ResourceLocation("minecraft:swiftness");
+        return replace(GameRegistry.Type.POTION_TYPE, GameData.getPotionTypesRegistry(), typeId,
+                new PotionType(typeId.getResourcePath(), new PotionEffect(MobEffects.SPEED, 600), new PotionEffect(MobEffects.ABSORPTION, 600)));
     }
 
-    private boolean testEnchantment(){
-        return replace(GameRegistry.Type.ENCHANTMENT, GameData.getEnchantmentRegistry(),new ResourceLocation("minecraft:efficiency"),new TestEnchantment());
+    private boolean testEnchantment()
+    {
+        return replace(GameRegistry.Type.ENCHANTMENT, GameData.getEnchantmentRegistry(), new ResourceLocation("minecraft:efficiency"), new TestEnchantment());
     }
 
-    private boolean testSoundEvent(){
-        return replace(GameRegistry.Type.SOUND_EVENT, GameData.getSoundEventRegistry(),new ResourceLocation("minecraft:entity.cow.hurt"),new SoundEvent(new ResourceLocation("minecraft:block.glass.break")));
+    private boolean testSoundEvent()
+    {
+        return replace(GameRegistry.Type.SOUND_EVENT, GameData.getSoundEventRegistry(), new ResourceLocation("minecraft:entity.cow.hurt"),
+                new SoundEvent(new ResourceLocation("minecraft:block.glass.break")));
     }
 
-    private boolean testEntity(){
-        return replace(GameRegistry.Type.ENTITY, GameData.getEntityRegistry(), new ResourceLocation("minecraft:cow"),new EntityEntry(TestCow.class,"Cow"));
+    private boolean testEntity()
+    {
+        return replace(GameRegistry.Type.ENTITY, GameData.getEntityRegistry(), new ResourceLocation("minecraft:cow"), new EntityEntry(TestCow.class, "Cow"));
     }
 
-    private boolean testBiome(){
-        return replace(GameRegistry.Type.BIOME, GameData.getBiomeRegistry(), new ResourceLocation("minecraft:ocean"),new TestBiome());
+    private boolean testBiome()
+    {
+        return replace(GameRegistry.Type.BIOME, GameData.getBiomeRegistry(), new ResourceLocation("minecraft:ocean"), new TestBiome());
     }
 
-    private boolean testBlock(){
-        return replace(GameRegistry.Type.BLOCK, GameData.getBlockRegistry(), new ResourceLocation("minecraft:gravel"),new TestBlock());
+    private boolean testBlock()
+    {
+        return replace(GameRegistry.Type.BLOCK, GameData.getBlockRegistry(), new ResourceLocation("minecraft:gravel"),
+                new TestBlock().setRegistryName("minecraft:gravel"));
     }
-
 
     /**
      * Try to register a substitution and verify the success. Logs any problems.
+     *
      * @return Success
      */
-    private <T extends IForgeRegistryEntry<T>> boolean replace(GameRegistry.Type type, IForgeRegistry<T> registry, ResourceLocation id, T testObject){
+    private <T extends IForgeRegistryEntry<T>> boolean replace(GameRegistry.Type type, IForgeRegistry<T> registry, ResourceLocation id, T testObject)
+    {
         T oldEntry = registry.getValue(id);
         try
         {
-            GameRegistry.addSubstitutionAlias(id.toString(),type,testObject);
+            GameRegistry.addSubstitutionAlias(id.toString(), type, testObject);
             T newEntry = registry.getValue(id);
-            if(oldEntry.equals(newEntry)){
-                logger.warn("[%s]Did not replace %s(%s) with %s",type,oldEntry,id,testObject);
+            if (oldEntry.equals(newEntry))
+            {
+                logger.warn("[%s]Did not replace %s(%s) with %s", type, oldEntry, id, testObject);
                 return false;
             }
-            else if(testObject.equals(newEntry)){
+            else if (testObject.equals(newEntry))
+            {
                 return true;
             }
-            else{
+            else
+            {
                 //To make sure we are not missing anything here
-                logger.warn("[%s]Something went wrong while replacing %s(%s) with %s. Got %s",type,oldEntry,id,testObject,newEntry);
+                logger.warn("[%s]Something went wrong while replacing %s(%s) with %s. Got %s", type, oldEntry, id, testObject, newEntry);
                 return false;
             }
         }
         catch (ExistingSubstitutionException e)
         {
-            logger.error("[%s]Failed to register substitution for %s",type,id);
+            logger.error("[%s]Failed to register substitution for %s", type, id);
             logger.catching(e);
         }
         return false;
     }
 
-
-    private class TestEnchantment extends EnchantmentDigging{
+    private class TestEnchantment extends EnchantmentDigging
+    {
 
         protected TestEnchantment()
         {
@@ -134,8 +144,8 @@ public class SubstitutionTest
 
     }
 
-
-    private class TestPotion extends Potion{
+    private class TestPotion extends Potion
+    {
 
         protected TestPotion()
         {
@@ -146,11 +156,12 @@ public class SubstitutionTest
 
     /**
      * Has to be public. Otherwise EntityEntry cannot find/use the constructor.
-     *
+     * <p>
      * If newly registered and a existing world is loaded, all existent cows will be substituted with this class.
      * If removed from mod code, all substituted entities will be removed TODO Test without PersistentRegistryManager
      */
-    public static class TestCow extends EntityCow{
+    public static class TestCow extends EntityCow
+    {
 
         public TestCow(World worldIn)
         {
@@ -169,13 +180,15 @@ public class SubstitutionTest
             return "Test_Cow";
         }
 
-        @Override public boolean hasCustomName()
+        @Override
+        public boolean hasCustomName()
         {
             return true;
         }
     }
 
-    private class TestBiome extends BiomeOcean{
+    private class TestBiome extends BiomeOcean
+    {
 
         public TestBiome()
         {
@@ -184,7 +197,8 @@ public class SubstitutionTest
 
     }
 
-    private class TestBlock extends BlockGravel{
+    private class TestBlock extends BlockGravel
+    {
         public TestBlock()
         {
             setBlockUnbreakable();


### PR DESCRIPTION
Updated version of #3462 

This was meant to be a "proof of concept" that the substitution system works for all registries, but after some testing it seems to work just fine this way.

**Description:**
As I found out in #3230 the substitution system of Forge/FML is really powerful.
Unfortunately it is still limited to blocks and items, but I did not find a real reason for this.
The main problem is that GameRegistry#addSubstitutionAlias only accepts blocks and items and that ObjectHolderRegistry#findObjectHolders only adds ObjectHolders to net.minecraft.init.Blocks and net.minecraft.init.Items.

I've extended the system to accept all GameRegistry.Type and tested it for potions. It works.
Maybe I missed some possible issues since the whole registry stuff is quite complex.
But if you can not see any issue, maybe the system could be activated for all registries, or at least for potions and enchantments (I could imagine that biome substitution could cause problems, don't know).
Also not sure about the Entity registry.

I could extend the SubstitutionInjectionTest with all the other types, but I think this would not help a lot since the other registries work exactly the same (except the entity one maybe). If there are any issues with this, they are outside of the registry code I think.