### PR TITLE
Tweak Event.setCanceled To Match Convention

### DIFF
--- a/src/main/java/net/minecraftforge/fml/common/eventhandler/Event.java
+++ b/src/main/java/net/minecraftforge/fml/common/eventhandler/Event.java
@@ -78,7 +78,7 @@ public class Event
         return isCanceled;
     }
 
-    /*
+    /**
      * Sets the cancel state of this event. Note, not all events are cancelable, and any attempt to
      * invoke this method on an event that is not cancelable (as determined by {@link #isCancelable}
      * will result in an {@link UnsupportedOperationException}.
@@ -92,8 +92,8 @@ public class Event
         if (!isCancelable())
         {
             throw new UnsupportedOperationException(
-                "Attempted to modify the unmodifiable canceled state of a non-cancelable event of type: "
-                + this.getClass().getCanonicalName() 
+                "Attempted to call Event#setCanceled() on a non-cancelable event of type: "
+                + this.getClass().getCanonicalName()
             );
         }
         isCanceled = cancel;
@@ -130,6 +130,7 @@ public class Event
     {
         result = value;
     }
+
     /**
      * Called by the base constructor, this is used by ASM generated
      * event classes to setup various functionality such as the listener list.

--- a/src/main/java/net/minecraftforge/fml/common/eventhandler/Event.java
+++ b/src/main/java/net/minecraftforge/fml/common/eventhandler/Event.java
@@ -78,9 +78,10 @@ public class Event
         return isCanceled;
     }
 
-    /**
-     * Sets the state of this event, not all events are cancelable, and any attempt to
-     * cancel a event that can't be will result in a IllegalArgumentException.
+    /*
+     * Sets the cancel state of this event. Note, not all events are cancelable, and any attempt to
+     * invoke this method on an event that is not cancelable (as determined by {@link #isCancelable}
+     * will result in an {@link UnsupportedOperationException}.
      *
      * The functionality of setting the canceled state is defined on a per-event bases.
      *
@@ -90,7 +91,10 @@ public class Event
     {
         if (!isCancelable())
         {
-            throw new IllegalArgumentException("Attempted to cancel a non cancellable event");
+            throw new UnsupportedOperationException(
+                "Attempted to modify the unmodifiable canceled state of a non-cancelable event of type: "
+                + this.getClass().getCanonicalName() 
+            );
         }
         isCanceled = cancel;
     }


### PR DESCRIPTION
It is generalized Java convention to throw a UnsupportedOperationException whenever an operation is not supported, as in the case of Event.setCanceled() being called on an event where Event.isCancelable() returns false. The prior implementation threw an IllegalArgumentException, which did not make sense, given that it was not the argument that was the issue, but the fact that the method was even called (given that the method, as per its current implementation ignores the value of its parameter when determining if the exception should be thrown). Also, in the hopes of improving logs, the exception message has been changed as to include the canonical name of the Event subclass instance that was not cancelable. Thus, these changes should aid modders in determining the exact path (or mod interaction) that caused the given event instance as to be spawned and then subsequently attempted as to be canceled.