### PR TITLE
Allow Items to specify movement speed and sprinting ability when in use

### DIFF
--- a/patches/minecraft/net/minecraft/client/entity/EntityPlayerSP.java.patch
+++ b/patches/minecraft/net/minecraft/client/entity/EntityPlayerSP.java.patch
@@ -89,3 +89,34 @@
      }
  
      public boolean func_70613_aW()
+@@ -818,9 +839,9 @@
+ 
+         if (this.func_184587_cr() && !this.func_184218_aH())
+         {
+-            this.field_71158_b.field_78902_a *= 0.2F;
+-            this.field_71158_b.field_78900_b *= 0.2F;
+-            this.field_71156_d = 0;
++            this.field_71158_b.field_78902_a *= func_184607_cu().func_77973_b().getItemUseMovementSpeed(func_184607_cu(), this);
++            this.field_71158_b.field_78900_b *= func_184607_cu().func_77973_b().getItemUseMovementSpeed(func_184607_cu(), this);
++            if (func_184607_cu().func_77973_b().shouldItemUsePreventSprinting(func_184607_cu(), this)) this.field_71156_d = 0;
+         }
+ 
+         boolean flag3 = false;
+@@ -839,7 +860,7 @@
+         this.func_145771_j(this.field_70165_t + (double)this.field_70130_N * 0.35D, axisalignedbb.field_72338_b + 0.5D, this.field_70161_v + (double)this.field_70130_N * 0.35D);
+         boolean flag4 = (float)this.func_71024_bL().func_75116_a() > 6.0F || this.field_71075_bZ.field_75101_c;
+ 
+-        if (this.field_70122_E && !flag1 && !flag2 && this.field_71158_b.field_78900_b >= 0.8F && !this.func_70051_ag() && flag4 && !this.func_184587_cr() && !this.func_70644_a(MobEffects.field_76440_q))
++        if (this.field_70122_E && !flag1 && !flag2 && this.field_71158_b.field_78900_b >= 0.8F && !this.func_70051_ag() && flag4 && !(this.func_184587_cr() && func_184607_cu().func_77973_b().shouldItemUsePreventSprinting(func_184607_cu(), this)) && !this.func_70644_a(MobEffects.field_76440_q))
+         {
+             if (this.field_71156_d <= 0 && !this.field_71159_c.field_71474_y.field_151444_V.func_151470_d())
+             {
+@@ -851,7 +872,7 @@
+             }
+         }
+ 
+-        if (!this.func_70051_ag() && this.field_71158_b.field_78900_b >= 0.8F && flag4 && !this.func_184587_cr() && !this.func_70644_a(MobEffects.field_76440_q) && this.field_71159_c.field_71474_y.field_151444_V.func_151470_d())
++        if (!this.func_70051_ag() && this.field_71158_b.field_78900_b >= 0.8F && flag4 && !(this.func_184587_cr() && func_184607_cu().func_77973_b().shouldItemUsePreventSprinting(func_184607_cu(), this)) && !this.func_70644_a(MobEffects.field_76440_q) && this.field_71159_c.field_71474_y.field_151444_V.func_151470_d())
+         {
+             this.func_70031_b(true);
+         }

--- a/patches/minecraft/net/minecraft/item/Item.java.patch
+++ b/patches/minecraft/net/minecraft/item/Item.java.patch
@@ -60,7 +60,7 @@
          return p_77621_1_.func_147447_a(vec3d, vec3d1, p_77621_3_, !p_77621_3_, false);
      }
  
-@@ -433,11 +440,625 @@
+@@ -433,11 +440,647 @@
          return false;
      }
  
@@ -681,12 +681,34 @@
 +        return builder.build();
 +    }
 +
++    /**
++     * Get a movement speed multiplier applied when the item is being used (drawing bow, eating food, etc.).
++     * @param stack The ItemStack
++     * @param entity The entity that is using the item
++     * @return A float between 0.0F and 1.0F
++     */
++    public float getItemUseMovementSpeed(ItemStack stack, EntityLivingBase entity)
++    {
++        return 0.2F;
++    }
++
++    /**
++     * Whether this item should prevent sprinting when being used (drawing bow, eating food, etc.).
++     * @param stack The ItemStack
++     * @param entity The entity that is using the item
++     * @return True if using the item should prevent sprinting
++     */
++    public boolean shouldItemUsePreventSprinting(ItemStack stack, EntityLivingBase entity)
++    {
++        return true;
++    }
++
 +    /* ======================================== FORGE END   =====================================*/
 +
      public static void func_150900_l()
      {
          func_179214_a(Blocks.field_150350_a, new ItemAir(Blocks.field_150350_a));
-@@ -972,6 +1593,8 @@
+@@ -972,6 +1615,8 @@
          private final float field_78010_h;
          private final float field_78011_i;
          private final int field_78008_j;
@@ -695,7 +717,7 @@
  
          private ToolMaterial(int p_i1874_3_, int p_i1874_4_, float p_i1874_5_, float p_i1874_6_, int p_i1874_7_)
          {
-@@ -1007,9 +1630,26 @@
+@@ -1007,9 +1652,26 @@
              return this.field_78008_j;
          }
  

--- a/src/test/java/net/minecraftforge/test/ItemUseMovementTest.java
+++ b/src/test/java/net/minecraftforge/test/ItemUseMovementTest.java
@@ -1,0 +1,39 @@
+package net.minecraftforge.test;
+
+import net.minecraft.entity.EntityLivingBase;
+import net.minecraft.item.Item;
+import net.minecraft.item.ItemBow;
+import net.minecraft.item.ItemStack;
+import net.minecraftforge.event.RegistryEvent;
+import net.minecraftforge.fml.common.Mod;
+import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
+
+/** Adds a light bow that does not hinder player movement when drawn */
+@Mod(modid = ItemUseMovementTest.MODID, name = "ItemUseMovementTest", version = "1.0")
+@Mod.EventBusSubscriber
+public class ItemUseMovementTest
+{
+    public static final String MODID = "itemusemovementtest";
+
+    public static class ItemLightBow extends ItemBow {
+        @Override
+        public boolean shouldItemUsePreventSprinting(ItemStack stack, EntityLivingBase entity)
+        {
+            return false;
+        }
+
+        @Override
+        public float getItemUseMovementSpeed(ItemStack stack, EntityLivingBase entity)
+        {
+            return 1.0F;
+        }
+    }
+
+    private static final Item LIGHT_BOW = new ItemLightBow().setRegistryName(MODID, "light_bow").setUnlocalizedName(MODID + ".lightBow");
+
+    @SubscribeEvent
+    public static void onRegisterItems(RegistryEvent.Register<Item> e)
+    {
+        e.getRegistry().register(LIGHT_BOW);
+    }
+}


### PR DESCRIPTION
When an item is in use such as bows being drawn, food being eaten, shielding, etc., it slows player movement by 80% and disables sprinting.

This PR makes it possible for items to modify this behaviour. Possible use cases for this is "fast food" that can be eaten on the go, lightweight bows that do not slow down the player, items that prevent player movement when used, etc.

Literal Construction already adds this hook. [It is used as a way of doing item interaction without hindering movement.](http://i.imgur.com/VbRkPzZ.gifv) The item is in use (holding right click) and player movement is not affected.