### PR TITLE
Allow custom outbound targets for networking

### DIFF
--- a/src/main/java/net/minecraftforge/fml/common/network/IOutboundTarget.java
+++ b/src/main/java/net/minecraftforge/fml/common/network/IOutboundTarget.java
@@ -1,0 +1,35 @@
+package net.minecraftforge.fml.common.network;
+
+import io.netty.channel.ChannelHandlerContext;
+import net.minecraftforge.fml.common.network.handshake.NetworkDispatcher;
+import net.minecraftforge.fml.common.network.internal.FMLProxyPacket;
+import net.minecraftforge.fml.relauncher.Side;
+
+import javax.annotation.Nullable;
+import java.util.List;
+
+public interface IOutboundTarget {
+    /**
+     * Returns true if the side is allowed to use this as an outbound target.
+     * @param side The side
+     * @return true if the side is allowed to use this as an outbound target
+     */
+    boolean isSideAllowed(Side side);
+
+    /**
+     * Validates the arguments object and throws a RuntimeException if it is invalid.
+     * @param args The arguments object
+     */
+    void validateArgs(Object args);
+
+    /**
+     * Produces a list of NetworkDispatchers that the packet can be sent to.
+     * The list may be null, which is equivalent to an empty list.
+     * @param args The arguments object
+     * @param context The channel handler context
+     * @param packet The packet that will be sent
+     * @return A list of NetworkDispatchers. May be null
+     */
+    @Nullable
+    List<NetworkDispatcher> selectNetworks(Object args, ChannelHandlerContext context, FMLProxyPacket packet);
+}


### PR DESCRIPTION
This is a simplification of #3748. This discards the except-player functionality and leaves it up to the modder to implement it. It is relevant for both #3677 any my own use case described in the previous PR.

This is not one of those changes that are strictly necessary, but convenient and an improvement IMO. I fully understand if this is an unwanted change.

`IOutboundTarget` is intended as a replacement for `OutboundTarget` in `FMLOutboundHandler.FML_MESSAGETARGET`, but due to binary compatibility concerns it cannot be fully implemented the intended way before a breaking update.

I implemented a workaround for now. Modders can use the new `OutboundTarget.SPECIAL` and set the additional attribute `FMLOutboundHandler.FML_SPECIALMESSAGETARGET` to use a custom IOutboundTarget.

Here's an example of what an extension of `SimpleNetworkWrapper` could do:

```java
    public void sendToAllAroundExcept(IMessage message, NetworkRegistry.TargetPoint point, EntityPlayerMP except)
    {
        channels.get(Side.SERVER).attr(FMLOutboundHandler.FML_MESSAGETARGET).set(FMLOutboundHandler.OutboundTarget.SPECIAL);
        channels.get(Side.SERVER).attr(FMLOutboundHandler.FML_SPECIALMESSAGETARGET).set(new SomeOutboundTarget());
        channels.get(Side.SERVER).attr(FMLOutboundHandler.FML_MESSAGETARGETARGS).set(new TargetPointExcept(point, except));
        channels.get(Side.SERVER).writeAndFlush(message).addListener(ChannelFutureListener.FIRE_EXCEPTION_ON_FAILURE);
    }

```