### PR TITLE
Deprecate vanilla getExplosionResistance and add @Nullable to the forge replacement

### DIFF
--- a/patches/minecraft/net/minecraft/block/Block.java.patch
+++ b/patches/minecraft/net/minecraft/block/Block.java.patch
@@ -125,7 +125,15 @@
              float f = 0.5F;
              double d0 = (double)(p_180635_0_.field_73012_v.nextFloat() * 0.5F) + 0.25D;
              double d1 = (double)(p_180635_0_.field_73012_v.nextFloat() * 0.5F) + 0.25D;
-@@ -636,7 +643,7 @@
+@@ -598,6 +605,7 @@
+         return 0;
+     }
+ 
++    @Deprecated //Forge: State sensitive version
+     public float func_149638_a(Entity p_149638_1_)
+     {
+         return this.field_149781_w / 5.0F;
+@@ -636,7 +644,7 @@
  
      public boolean func_176196_c(World p_176196_1_, BlockPos p_176196_2_)
      {
@@ -134,7 +142,7 @@
      }
  
      public boolean func_180639_a(World p_180639_1_, BlockPos p_180639_2_, IBlockState p_180639_3_, EntityPlayer p_180639_4_, EnumHand p_180639_5_, EnumFacing p_180639_6_, float p_180639_7_, float p_180639_8_, float p_180639_9_)
-@@ -648,6 +655,8 @@
+@@ -648,6 +656,8 @@
      {
      }
  
@@ -143,7 +151,7 @@
      public IBlockState func_180642_a(World p_180642_1_, BlockPos p_180642_2_, EnumFacing p_180642_3_, float p_180642_4_, float p_180642_5_, float p_180642_6_, int p_180642_7_, EntityLivingBase p_180642_8_)
      {
          return this.func_176203_a(p_180642_7_);
-@@ -689,21 +698,35 @@
+@@ -689,21 +699,35 @@
          p_180657_2_.func_71029_a(StatList.func_188055_a(this));
          p_180657_2_.func_71020_j(0.005F);
  
@@ -182,7 +190,7 @@
      }
  
      protected ItemStack func_180643_i(IBlockState p_180643_1_)
-@@ -789,6 +812,7 @@
+@@ -789,6 +813,7 @@
          p_176216_2_.field_70181_x = 0.0D;
      }
  
@@ -190,7 +198,7 @@
      public ItemStack func_185473_a(World p_185473_1_, BlockPos p_185473_2_, IBlockState p_185473_3_)
      {
          return new ItemStack(Item.func_150898_a(this), 1, this.func_180651_a(p_185473_3_));
-@@ -893,6 +917,7 @@
+@@ -893,6 +918,7 @@
          }
      }
  
@@ -198,7 +206,7 @@
      public SoundType func_185467_w()
      {
          return this.field_149762_H;
-@@ -908,6 +933,1217 @@
+@@ -908,6 +934,1217 @@
      {
      }
  
@@ -721,7 +729,7 @@
 +    }
 +
 +    /**
-+     * Location sensitive version of getExplosionRestance
++     * Location sensitive version of getExplosionResistance
 +     *
 +     * @param world The current world
 +     * @param pos Block position in world
@@ -729,7 +737,7 @@
 +     * @param explosion The explosion
 +     * @return The amount of the explosion absorbed.
 +     */
-+    public float getExplosionResistance(World world, BlockPos pos, Entity exploder, Explosion explosion)
++    public float getExplosionResistance(World world, BlockPos pos, @Nullable Entity exploder, Explosion explosion)
 +    {
 +        return func_149638_a(exploder);
 +    }
@@ -1416,7 +1424,7 @@
      public static void func_149671_p()
      {
          func_176215_a(0, field_176230_a, (new BlockAir()).func_149663_c("air"));
-@@ -1201,14 +2437,7 @@
+@@ -1201,14 +2438,7 @@
              }
              else
              {


### PR DESCRIPTION
#3484 but for 1.11.x. Completely forgot to update the PR.