### PR TITLE
Make Teleporter fields accessible to subclasses

### DIFF
--- a/src/main/resources/forge_at.cfg
+++ b/src/main/resources/forge_at.cfg
@@ -308,3 +308,8 @@ protected net.minecraft.entity.monster.EntitySkeleton func_190727_o()Lnet/minecr
 
 # EntitySelector
 public net.minecraft.command.EntitySelector func_190826_c(Ljava/lang/String;)Ljava/lang/String; # addArgument
+
+# Teleporter
+protected net.minecraft.world.Teleporter field_85192_a # world
+protected net.minecraft.world.Teleporter field_77187_a # random
+protected net.minecraft.world.Teleporter field_85191_c # destinationCoordinateCache


### PR DESCRIPTION
As it's generally required to subclass `Teleporter` if you want to implement any kind of dimension changing, it'd be good to have the fields accessible there.

Not strictly necessary, but it's a common enough use case that I thought it'd be worth considering for Forge.