### PR TITLE
Add ALLOW_FLYING player entity attribute

### DIFF
--- a/patches/minecraft/net/minecraft/client/Minecraft.java.patch
+++ b/patches/minecraft/net/minecraft/client/Minecraft.java.patch
@@ -1,54 +1,6 @@
 --- ../src-base/minecraft/net/minecraft/client/Minecraft.java
 +++ ../src-work/minecraft/net/minecraft/client/Minecraft.java
-@@ -21,7 +21,6 @@
- import java.net.SocketAddress;
- import java.nio.ByteBuffer;
- import java.nio.ByteOrder;
--import java.nio.IntBuffer;
- import java.text.DecimalFormat;
- import java.text.SimpleDateFormat;
- import java.util.Collections;
-@@ -37,9 +36,8 @@
- import java.util.concurrent.FutureTask;
- import javax.annotation.Nullable;
- import javax.imageio.ImageIO;
--import net.minecraft.block.Block;
-+
- import net.minecraft.block.material.Material;
--import net.minecraft.block.state.IBlockState;
- import net.minecraft.client.audio.MusicTicker;
- import net.minecraft.client.audio.SoundHandler;
- import net.minecraft.client.entity.EntityPlayerSP;
-@@ -60,7 +58,6 @@
- import net.minecraft.client.gui.achievement.GuiAchievement;
- import net.minecraft.client.gui.inventory.GuiInventory;
- import net.minecraft.client.main.GameConfiguration;
--import net.minecraft.client.multiplayer.GuiConnecting;
- import net.minecraft.client.multiplayer.PlayerControllerMP;
- import net.minecraft.client.multiplayer.ServerData;
- import net.minecraft.client.multiplayer.WorldClient;
-@@ -116,20 +113,9 @@
- import net.minecraft.crash.CrashReportCategory;
- import net.minecraft.crash.ICrashReportDetail;
- import net.minecraft.entity.Entity;
--import net.minecraft.entity.EntityLeashKnot;
--import net.minecraft.entity.EntityList;
--import net.minecraft.entity.item.EntityArmorStand;
--import net.minecraft.entity.item.EntityBoat;
--import net.minecraft.entity.item.EntityEnderCrystal;
--import net.minecraft.entity.item.EntityItemFrame;
--import net.minecraft.entity.item.EntityMinecart;
--import net.minecraft.entity.item.EntityPainting;
- import net.minecraft.entity.player.EntityPlayer;
--import net.minecraft.entity.player.InventoryPlayer;
- import net.minecraft.init.Bootstrap;
- import net.minecraft.init.Items;
--import net.minecraft.item.Item;
--import net.minecraft.item.ItemMonsterPlacer;
- import net.minecraft.item.ItemStack;
- import net.minecraft.nbt.NBTTagCompound;
- import net.minecraft.nbt.NBTTagList;
-@@ -322,7 +308,6 @@
+@@ -322,7 +322,6 @@
          this.field_152355_az = (new YggdrasilAuthenticationService(this.field_110453_aa, UUID.randomUUID().toString())).createMinecraftSessionService();
          this.field_71449_j = p_i45547_1_.field_178745_a.field_178752_a;
          field_147123_G.info("Setting user: {}", new Object[] {this.field_71449_j.func_111285_a()});
@@ -56,7 +8,7 @@
          this.field_71459_aj = p_i45547_1_.field_178741_d.field_178756_a;
          this.field_71443_c = p_i45547_1_.field_178743_b.field_178764_a > 0 ? p_i45547_1_.field_178743_b.field_178764_a : 1;
          this.field_71440_d = p_i45547_1_.field_178743_b.field_178762_b > 0 ? p_i45547_1_.field_178743_b.field_178762_b : 1;
-@@ -438,10 +423,10 @@
+@@ -438,10 +437,10 @@
          this.field_110451_am = new SimpleReloadableResourceManager(this.field_110452_an);
          this.field_135017_as = new LanguageManager(this.field_110452_an, this.field_71474_y.field_74363_ab);
          this.field_110451_am.func_110542_a(this.field_135017_as);
@@ -69,7 +21,7 @@
          this.field_152350_aA = new SkinManager(this.field_71446_o, new File(this.field_110446_Y, "skins"), this.field_152355_az);
          this.field_71469_aa = new AnvilSaveConverter(new File(this.field_71412_D, "saves"), this.field_184131_U);
          this.field_147127_av = new SoundHandler(this.field_110451_am, this.field_71474_y);
-@@ -466,7 +451,7 @@
+@@ -466,7 +465,7 @@
              {
                  try
                  {
@@ -78,7 +30,7 @@
                  }
                  catch (Exception exception)
                  {
-@@ -475,6 +460,8 @@
+@@ -475,6 +474,8 @@
              }
          });
          this.field_71417_B = new MouseHelper();
@@ -87,7 +39,7 @@
          this.func_71361_d("Pre startup");
          GlStateManager.func_179098_w();
          GlStateManager.func_179103_j(7425);
-@@ -488,19 +475,24 @@
+@@ -488,19 +489,24 @@
          GlStateManager.func_179096_D();
          GlStateManager.func_179128_n(5888);
          this.func_71361_d("Startup");
@@ -113,7 +65,7 @@
          this.field_71460_t = new EntityRenderer(this, this.field_110451_am);
          this.field_110451_am.func_110542_a(this.field_71460_t);
          this.field_175618_aM = new BlockRendererDispatcher(this.field_175617_aL.func_174954_c(), this.field_184127_aH);
-@@ -510,23 +502,27 @@
+@@ -510,23 +516,27 @@
          this.field_71458_u = new GuiAchievement(this);
          GlStateManager.func_179083_b(0, 0, this.field_71443_c, this.field_71440_d);
          this.field_71452_i = new ParticleManager(this.field_71441_e, this.field_71446_o);
@@ -144,7 +96,7 @@
          if (this.field_71474_y.field_74353_u && !this.field_71431_Q)
          {
              this.func_71352_k();
-@@ -698,21 +694,23 @@
+@@ -698,21 +708,23 @@
          File file2 = new File(file1, "crash-" + (new SimpleDateFormat("yyyy-MM-dd_HH.mm.ss")).format(new Date()) + "-client.txt");
          Bootstrap.func_179870_a(p_71377_1_.func_71502_e());
  
@@ -171,7 +123,7 @@
      }
  
      public boolean func_152349_b()
-@@ -905,11 +903,6 @@
+@@ -905,11 +917,6 @@
  
      public void func_147108_a(@Nullable GuiScreen p_147108_1_)
      {
@@ -183,7 +135,7 @@
          if (p_147108_1_ == null && this.field_71441_e == null)
          {
              p_147108_1_ = new GuiMainMenu();
-@@ -919,6 +912,17 @@
+@@ -919,6 +926,17 @@
              p_147108_1_ = new GuiGameOver((ITextComponent)null);
          }
  
@@ -201,7 +153,7 @@
          if (p_147108_1_ instanceof GuiMainMenu || p_147108_1_ instanceof GuiMultiplayer)
          {
              this.field_71474_y.field_74330_P = false;
-@@ -1054,9 +1058,11 @@
+@@ -1054,9 +1072,11 @@
  
          if (!this.field_71454_w)
          {
@@ -213,7 +165,7 @@
          }
  
          this.field_71424_I.func_76319_b();
-@@ -1399,9 +1405,9 @@
+@@ -1399,9 +1419,9 @@
              {
                  BlockPos blockpos = this.field_71476_x.func_178782_a();
  
@@ -225,7 +177,7 @@
                      this.field_71439_g.func_184609_a(EnumHand.MAIN_HAND);
                  }
              }
-@@ -1435,7 +1441,7 @@
+@@ -1435,7 +1455,7 @@
                      case BLOCK:
                          BlockPos blockpos = this.field_71476_x.func_178782_a();
  
@@ -234,7 +186,7 @@
                          {
                              this.field_71442_b.func_180511_b(blockpos, this.field_71476_x.field_178784_b);
                              break;
-@@ -1449,6 +1455,7 @@
+@@ -1449,6 +1469,7 @@
                          }
  
                          this.field_71439_g.func_184821_cY();
@@ -242,7 +194,7 @@
                  }
  
                  this.field_71439_g.func_184609_a(EnumHand.MAIN_HAND);
-@@ -1514,6 +1521,7 @@
+@@ -1514,6 +1535,7 @@
                          }
                      }
  
@@ -250,7 +202,7 @@
                      if (!itemstack.func_190926_b() && this.field_71442_b.func_187101_a(this.field_71439_g, this.field_71441_e, enumhand) == EnumActionResult.SUCCESS)
                      {
                          this.field_71460_t.field_78516_c.func_187460_a(enumhand);
-@@ -1620,6 +1628,8 @@
+@@ -1620,6 +1642,8 @@
              --this.field_71467_ac;
          }
  
@@ -259,7 +211,7 @@
          this.field_71424_I.func_76320_a("gui");
  
          if (!this.field_71445_n)
-@@ -1731,6 +1741,7 @@
+@@ -1731,6 +1755,7 @@
                      this.field_71457_ai = 0;
                      this.field_71441_e.func_72897_h(this.field_71439_g);
                  }
@@ -267,7 +219,7 @@
              }
  
              this.field_71424_I.func_76318_c("gameRenderer");
-@@ -1819,6 +1830,7 @@
+@@ -1819,6 +1844,7 @@
          }
  
          this.field_71424_I.func_76319_b();
@@ -275,7 +227,7 @@
          this.field_71423_H = func_71386_F();
      }
  
-@@ -1924,6 +1936,7 @@
+@@ -1924,6 +1950,7 @@
                      }
                  }
              }
@@ -283,7 +235,7 @@
          }
  
          this.func_184117_aA();
-@@ -2170,6 +2183,8 @@
+@@ -2170,6 +2197,8 @@
      {
          while (Mouse.next())
          {
@@ -292,7 +244,7 @@
              int i = Mouse.getEventButton();
              KeyBinding.func_74510_a(i - 100, Mouse.getEventButtonState());
  
-@@ -2235,6 +2250,7 @@
+@@ -2235,6 +2264,7 @@
  
      public void func_71371_a(String p_71371_1_, String p_71371_2_, @Nullable WorldSettings p_71371_3_)
      {
@@ -300,7 +252,7 @@
          this.func_71403_a((WorldClient)null);
          System.gc();
          ISaveHandler isavehandler = this.field_71469_aa.func_75804_a(p_71371_1_, false);
-@@ -2277,6 +2293,12 @@
+@@ -2277,6 +2307,12 @@
  
          while (!this.field_71437_Z.func_71200_ad())
          {
@@ -313,7 +265,7 @@
              String s = this.field_71437_Z.func_71195_b_();
  
              if (s != null)
-@@ -2302,8 +2324,14 @@
+@@ -2302,8 +2338,14 @@
          SocketAddress socketaddress = this.field_71437_Z.func_147137_ag().func_151270_a();
          NetworkManager networkmanager = NetworkManager.func_150722_a(socketaddress);
          networkmanager.func_150719_a(new NetHandlerLoginClient(networkmanager, this, (GuiScreen)null));
@@ -330,7 +282,7 @@
          this.field_71453_ak = networkmanager;
      }
  
-@@ -2314,6 +2342,8 @@
+@@ -2314,6 +2356,8 @@
  
      public void func_71353_a(@Nullable WorldClient p_71353_1_, String p_71353_2_)
      {
@@ -339,7 +291,7 @@
          if (p_71353_1_ == null)
          {
              NetHandlerPlayClient nethandlerplayclient = this.func_147114_u();
-@@ -2326,6 +2356,18 @@
+@@ -2326,6 +2370,18 @@
              if (this.field_71437_Z != null && this.field_71437_Z.func_175578_N())
              {
                  this.field_71437_Z.func_71263_m();
@@ -358,7 +310,7 @@
              }
  
              this.field_71437_Z = null;
-@@ -2349,6 +2391,7 @@
+@@ -2349,6 +2405,7 @@
              this.field_71456_v.func_181029_i();
              this.func_71351_a((ServerData)null);
              this.field_71455_al = false;
@@ -366,7 +318,7 @@
          }
  
          this.field_147127_av.func_147690_c();
-@@ -2466,159 +2509,8 @@
+@@ -2466,159 +2523,8 @@
      {
          if (this.field_71476_x != null && this.field_71476_x.field_72313_a != RayTraceResult.Type.MISS)
          {
@@ -528,7 +480,7 @@
          }
      }
  
-@@ -2921,18 +2813,8 @@
+@@ -2921,18 +2827,8 @@
  
      public static int func_71369_N()
      {
@@ -549,7 +501,7 @@
      }
  
      public boolean func_70002_Q()
-@@ -3058,7 +2940,7 @@
+@@ -3058,7 +2954,7 @@
  
      public MusicTicker.MusicType func_147109_W()
      {
@@ -558,7 +510,7 @@
      }
  
      public void func_152348_aa()
-@@ -3071,15 +2953,16 @@
+@@ -3071,15 +2967,16 @@
              {
                  if (Keyboard.getEventKeyState())
                  {
@@ -577,7 +529,7 @@
              }
          }
      }
-@@ -3199,6 +3082,12 @@
+@@ -3199,6 +3096,12 @@
          return this.field_184127_aH;
      }
  

--- a/patches/minecraft/net/minecraft/client/Minecraft.java.patch
+++ b/patches/minecraft/net/minecraft/client/Minecraft.java.patch
@@ -1,6 +1,54 @@
 --- ../src-base/minecraft/net/minecraft/client/Minecraft.java
 +++ ../src-work/minecraft/net/minecraft/client/Minecraft.java
-@@ -322,7 +322,6 @@
+@@ -21,7 +21,6 @@
+ import java.net.SocketAddress;
+ import java.nio.ByteBuffer;
+ import java.nio.ByteOrder;
+-import java.nio.IntBuffer;
+ import java.text.DecimalFormat;
+ import java.text.SimpleDateFormat;
+ import java.util.Collections;
+@@ -37,9 +36,8 @@
+ import java.util.concurrent.FutureTask;
+ import javax.annotation.Nullable;
+ import javax.imageio.ImageIO;
+-import net.minecraft.block.Block;
++
+ import net.minecraft.block.material.Material;
+-import net.minecraft.block.state.IBlockState;
+ import net.minecraft.client.audio.MusicTicker;
+ import net.minecraft.client.audio.SoundHandler;
+ import net.minecraft.client.entity.EntityPlayerSP;
+@@ -60,7 +58,6 @@
+ import net.minecraft.client.gui.achievement.GuiAchievement;
+ import net.minecraft.client.gui.inventory.GuiInventory;
+ import net.minecraft.client.main.GameConfiguration;
+-import net.minecraft.client.multiplayer.GuiConnecting;
+ import net.minecraft.client.multiplayer.PlayerControllerMP;
+ import net.minecraft.client.multiplayer.ServerData;
+ import net.minecraft.client.multiplayer.WorldClient;
+@@ -116,20 +113,9 @@
+ import net.minecraft.crash.CrashReportCategory;
+ import net.minecraft.crash.ICrashReportDetail;
+ import net.minecraft.entity.Entity;
+-import net.minecraft.entity.EntityLeashKnot;
+-import net.minecraft.entity.EntityList;
+-import net.minecraft.entity.item.EntityArmorStand;
+-import net.minecraft.entity.item.EntityBoat;
+-import net.minecraft.entity.item.EntityEnderCrystal;
+-import net.minecraft.entity.item.EntityItemFrame;
+-import net.minecraft.entity.item.EntityMinecart;
+-import net.minecraft.entity.item.EntityPainting;
+ import net.minecraft.entity.player.EntityPlayer;
+-import net.minecraft.entity.player.InventoryPlayer;
+ import net.minecraft.init.Bootstrap;
+ import net.minecraft.init.Items;
+-import net.minecraft.item.Item;
+-import net.minecraft.item.ItemMonsterPlacer;
+ import net.minecraft.item.ItemStack;
+ import net.minecraft.nbt.NBTTagCompound;
+ import net.minecraft.nbt.NBTTagList;
+@@ -322,7 +308,6 @@
          this.field_152355_az = (new YggdrasilAuthenticationService(this.field_110453_aa, UUID.randomUUID().toString())).createMinecraftSessionService();
          this.field_71449_j = p_i45547_1_.field_178745_a.field_178752_a;
          field_147123_G.info("Setting user: {}", new Object[] {this.field_71449_j.func_111285_a()});
@@ -8,7 +56,7 @@
          this.field_71459_aj = p_i45547_1_.field_178741_d.field_178756_a;
          this.field_71443_c = p_i45547_1_.field_178743_b.field_178764_a > 0 ? p_i45547_1_.field_178743_b.field_178764_a : 1;
          this.field_71440_d = p_i45547_1_.field_178743_b.field_178762_b > 0 ? p_i45547_1_.field_178743_b.field_178762_b : 1;
-@@ -438,10 +437,10 @@
+@@ -438,10 +423,10 @@
          this.field_110451_am = new SimpleReloadableResourceManager(this.field_110452_an);
          this.field_135017_as = new LanguageManager(this.field_110452_an, this.field_71474_y.field_74363_ab);
          this.field_110451_am.func_110542_a(this.field_135017_as);
@@ -21,7 +69,7 @@
          this.field_152350_aA = new SkinManager(this.field_71446_o, new File(this.field_110446_Y, "skins"), this.field_152355_az);
          this.field_71469_aa = new AnvilSaveConverter(new File(this.field_71412_D, "saves"), this.field_184131_U);
          this.field_147127_av = new SoundHandler(this.field_110451_am, this.field_71474_y);
-@@ -466,7 +465,7 @@
+@@ -466,7 +451,7 @@
              {
                  try
                  {
@@ -30,7 +78,7 @@
                  }
                  catch (Exception exception)
                  {
-@@ -475,6 +474,8 @@
+@@ -475,6 +460,8 @@
              }
          });
          this.field_71417_B = new MouseHelper();
@@ -39,7 +87,7 @@
          this.func_71361_d("Pre startup");
          GlStateManager.func_179098_w();
          GlStateManager.func_179103_j(7425);
-@@ -488,19 +489,24 @@
+@@ -488,19 +475,24 @@
          GlStateManager.func_179096_D();
          GlStateManager.func_179128_n(5888);
          this.func_71361_d("Startup");
@@ -65,7 +113,7 @@
          this.field_71460_t = new EntityRenderer(this, this.field_110451_am);
          this.field_110451_am.func_110542_a(this.field_71460_t);
          this.field_175618_aM = new BlockRendererDispatcher(this.field_175617_aL.func_174954_c(), this.field_184127_aH);
-@@ -510,23 +516,27 @@
+@@ -510,23 +502,27 @@
          this.field_71458_u = new GuiAchievement(this);
          GlStateManager.func_179083_b(0, 0, this.field_71443_c, this.field_71440_d);
          this.field_71452_i = new ParticleManager(this.field_71441_e, this.field_71446_o);
@@ -96,7 +144,7 @@
          if (this.field_71474_y.field_74353_u && !this.field_71431_Q)
          {
              this.func_71352_k();
-@@ -698,21 +708,23 @@
+@@ -698,21 +694,23 @@
          File file2 = new File(file1, "crash-" + (new SimpleDateFormat("yyyy-MM-dd_HH.mm.ss")).format(new Date()) + "-client.txt");
          Bootstrap.func_179870_a(p_71377_1_.func_71502_e());
  
@@ -123,7 +171,7 @@
      }
  
      public boolean func_152349_b()
-@@ -905,11 +917,6 @@
+@@ -905,11 +903,6 @@
  
      public void func_147108_a(@Nullable GuiScreen p_147108_1_)
      {
@@ -135,7 +183,7 @@
          if (p_147108_1_ == null && this.field_71441_e == null)
          {
              p_147108_1_ = new GuiMainMenu();
-@@ -919,6 +926,17 @@
+@@ -919,6 +912,17 @@
              p_147108_1_ = new GuiGameOver((ITextComponent)null);
          }
  
@@ -153,7 +201,7 @@
          if (p_147108_1_ instanceof GuiMainMenu || p_147108_1_ instanceof GuiMultiplayer)
          {
              this.field_71474_y.field_74330_P = false;
-@@ -1054,9 +1072,11 @@
+@@ -1054,9 +1058,11 @@
  
          if (!this.field_71454_w)
          {
@@ -165,7 +213,7 @@
          }
  
          this.field_71424_I.func_76319_b();
-@@ -1399,9 +1419,9 @@
+@@ -1399,9 +1405,9 @@
              {
                  BlockPos blockpos = this.field_71476_x.func_178782_a();
  
@@ -177,7 +225,7 @@
                      this.field_71439_g.func_184609_a(EnumHand.MAIN_HAND);
                  }
              }
-@@ -1435,7 +1455,7 @@
+@@ -1435,7 +1441,7 @@
                      case BLOCK:
                          BlockPos blockpos = this.field_71476_x.func_178782_a();
  
@@ -186,7 +234,7 @@
                          {
                              this.field_71442_b.func_180511_b(blockpos, this.field_71476_x.field_178784_b);
                              break;
-@@ -1449,6 +1469,7 @@
+@@ -1449,6 +1455,7 @@
                          }
  
                          this.field_71439_g.func_184821_cY();
@@ -194,7 +242,7 @@
                  }
  
                  this.field_71439_g.func_184609_a(EnumHand.MAIN_HAND);
-@@ -1514,6 +1535,7 @@
+@@ -1514,6 +1521,7 @@
                          }
                      }
  
@@ -202,7 +250,7 @@
                      if (!itemstack.func_190926_b() && this.field_71442_b.func_187101_a(this.field_71439_g, this.field_71441_e, enumhand) == EnumActionResult.SUCCESS)
                      {
                          this.field_71460_t.field_78516_c.func_187460_a(enumhand);
-@@ -1620,6 +1642,8 @@
+@@ -1620,6 +1628,8 @@
              --this.field_71467_ac;
          }
  
@@ -211,7 +259,7 @@
          this.field_71424_I.func_76320_a("gui");
  
          if (!this.field_71445_n)
-@@ -1731,6 +1755,7 @@
+@@ -1731,6 +1741,7 @@
                      this.field_71457_ai = 0;
                      this.field_71441_e.func_72897_h(this.field_71439_g);
                  }
@@ -219,7 +267,7 @@
              }
  
              this.field_71424_I.func_76318_c("gameRenderer");
-@@ -1819,6 +1844,7 @@
+@@ -1819,6 +1830,7 @@
          }
  
          this.field_71424_I.func_76319_b();
@@ -227,7 +275,7 @@
          this.field_71423_H = func_71386_F();
      }
  
-@@ -1924,6 +1950,7 @@
+@@ -1924,6 +1936,7 @@
                      }
                  }
              }
@@ -235,7 +283,7 @@
          }
  
          this.func_184117_aA();
-@@ -2170,6 +2197,8 @@
+@@ -2170,6 +2183,8 @@
      {
          while (Mouse.next())
          {
@@ -244,7 +292,7 @@
              int i = Mouse.getEventButton();
              KeyBinding.func_74510_a(i - 100, Mouse.getEventButtonState());
  
-@@ -2235,6 +2264,7 @@
+@@ -2235,6 +2250,7 @@
  
      public void func_71371_a(String p_71371_1_, String p_71371_2_, @Nullable WorldSettings p_71371_3_)
      {
@@ -252,7 +300,7 @@
          this.func_71403_a((WorldClient)null);
          System.gc();
          ISaveHandler isavehandler = this.field_71469_aa.func_75804_a(p_71371_1_, false);
-@@ -2277,6 +2307,12 @@
+@@ -2277,6 +2293,12 @@
  
          while (!this.field_71437_Z.func_71200_ad())
          {
@@ -265,7 +313,7 @@
              String s = this.field_71437_Z.func_71195_b_();
  
              if (s != null)
-@@ -2302,8 +2338,14 @@
+@@ -2302,8 +2324,14 @@
          SocketAddress socketaddress = this.field_71437_Z.func_147137_ag().func_151270_a();
          NetworkManager networkmanager = NetworkManager.func_150722_a(socketaddress);
          networkmanager.func_150719_a(new NetHandlerLoginClient(networkmanager, this, (GuiScreen)null));
@@ -282,7 +330,7 @@
          this.field_71453_ak = networkmanager;
      }
  
-@@ -2314,6 +2356,8 @@
+@@ -2314,6 +2342,8 @@
  
      public void func_71353_a(@Nullable WorldClient p_71353_1_, String p_71353_2_)
      {
@@ -291,7 +339,7 @@
          if (p_71353_1_ == null)
          {
              NetHandlerPlayClient nethandlerplayclient = this.func_147114_u();
-@@ -2326,6 +2370,18 @@
+@@ -2326,6 +2356,18 @@
              if (this.field_71437_Z != null && this.field_71437_Z.func_175578_N())
              {
                  this.field_71437_Z.func_71263_m();
@@ -310,7 +358,7 @@
              }
  
              this.field_71437_Z = null;
-@@ -2349,6 +2405,7 @@
+@@ -2349,6 +2391,7 @@
              this.field_71456_v.func_181029_i();
              this.func_71351_a((ServerData)null);
              this.field_71455_al = false;
@@ -318,7 +366,7 @@
          }
  
          this.field_147127_av.func_147690_c();
-@@ -2466,159 +2523,8 @@
+@@ -2466,159 +2509,8 @@
      {
          if (this.field_71476_x != null && this.field_71476_x.field_72313_a != RayTraceResult.Type.MISS)
          {
@@ -480,7 +528,7 @@
          }
      }
  
-@@ -2921,18 +2827,8 @@
+@@ -2921,18 +2813,8 @@
  
      public static int func_71369_N()
      {
@@ -501,7 +549,16 @@
      }
  
      public boolean func_70002_Q()
-@@ -3071,15 +2967,16 @@
+@@ -3058,7 +2940,7 @@
+ 
+     public MusicTicker.MusicType func_147109_W()
+     {
+-        return this.field_71439_g != null ? (this.field_71439_g.field_70170_p.field_73011_w instanceof WorldProviderHell ? MusicTicker.MusicType.NETHER : (this.field_71439_g.field_70170_p.field_73011_w instanceof WorldProviderEnd ? (this.field_71456_v.func_184046_j().func_184054_d() ? MusicTicker.MusicType.END_BOSS : MusicTicker.MusicType.END) : (this.field_71439_g.field_71075_bZ.field_75098_d && this.field_71439_g.field_71075_bZ.field_75101_c ? MusicTicker.MusicType.CREATIVE : MusicTicker.MusicType.GAME))) : MusicTicker.MusicType.MENU;
++        return this.field_71439_g != null ? (this.field_71439_g.field_70170_p.field_73011_w instanceof WorldProviderHell ? MusicTicker.MusicType.NETHER : (this.field_71439_g.field_70170_p.field_73011_w instanceof WorldProviderEnd ? (this.field_71456_v.func_184046_j().func_184054_d() ? MusicTicker.MusicType.END_BOSS : MusicTicker.MusicType.END) : (this.field_71439_g.field_71075_bZ.field_75098_d && this.field_71439_g.isAllowedToFly() ? MusicTicker.MusicType.CREATIVE : MusicTicker.MusicType.GAME))) : MusicTicker.MusicType.MENU;
+     }
+ 
+     public void func_152348_aa()
+@@ -3071,15 +2953,16 @@
              {
                  if (Keyboard.getEventKeyState())
                  {
@@ -520,7 +577,7 @@
              }
          }
      }
-@@ -3199,6 +3096,12 @@
+@@ -3199,6 +3082,12 @@
          return this.field_184127_aH;
      }
  

--- a/patches/minecraft/net/minecraft/client/entity/EntityPlayerSP.java.patch
+++ b/patches/minecraft/net/minecraft/client/entity/EntityPlayerSP.java.patch
@@ -89,3 +89,21 @@
      }
  
      public boolean func_70613_aW()
+@@ -837,7 +858,7 @@
+         this.func_145771_j(this.field_70165_t - (double)this.field_70130_N * 0.35D, axisalignedbb.field_72338_b + 0.5D, this.field_70161_v - (double)this.field_70130_N * 0.35D);
+         this.func_145771_j(this.field_70165_t + (double)this.field_70130_N * 0.35D, axisalignedbb.field_72338_b + 0.5D, this.field_70161_v - (double)this.field_70130_N * 0.35D);
+         this.func_145771_j(this.field_70165_t + (double)this.field_70130_N * 0.35D, axisalignedbb.field_72338_b + 0.5D, this.field_70161_v + (double)this.field_70130_N * 0.35D);
+-        boolean flag4 = (float)this.func_71024_bL().func_75116_a() > 6.0F || this.field_71075_bZ.field_75101_c;
++        boolean flag4 = (float)this.func_71024_bL().func_75116_a() > 6.0F || this.isAllowedToFly();
+ 
+         if (this.field_70122_E && !flag1 && !flag2 && this.field_71158_b.field_78900_b >= 0.8F && !this.func_70051_ag() && flag4 && !this.func_184587_cr() && !this.func_70644_a(MobEffects.field_76440_q))
+         {
+@@ -861,7 +882,7 @@
+             this.func_70031_b(false);
+         }
+ 
+-        if (this.field_71075_bZ.field_75101_c)
++        if (this.isAllowedToFly())
+         {
+             if (this.field_71159_c.field_71442_b.func_178887_k())
+             {

--- a/patches/minecraft/net/minecraft/entity/player/EntityPlayer.java.patch
+++ b/patches/minecraft/net/minecraft/entity/player/EntityPlayer.java.patch
@@ -1,22 +1,6 @@
 --- ../src-base/minecraft/net/minecraft/entity/player/EntityPlayer.java
 +++ ../src-work/minecraft/net/minecraft/entity/player/EntityPlayer.java
-@@ -8,7 +8,6 @@
- import java.util.UUID;
- import javax.annotation.Nullable;
- import net.minecraft.block.Block;
--import net.minecraft.block.BlockBed;
- import net.minecraft.block.BlockHorizontal;
- import net.minecraft.block.material.Material;
- import net.minecraft.block.state.IBlockState;
-@@ -31,7 +30,6 @@
- import net.minecraft.entity.passive.AbstractHorse;
- import net.minecraft.entity.passive.EntityPig;
- import net.minecraft.entity.projectile.EntityFishHook;
--import net.minecraft.init.Blocks;
- import net.minecraft.init.Items;
- import net.minecraft.init.MobEffects;
- import net.minecraft.init.SoundEvents;
-@@ -98,6 +96,13 @@
+@@ -98,6 +98,13 @@
  @SuppressWarnings("incomplete-switch")
  public abstract class EntityPlayer extends EntityLivingBase
  {
@@ -30,7 +14,7 @@
      private static final DataParameter<Float> field_184829_a = EntityDataManager.<Float>func_187226_a(EntityPlayer.class, DataSerializers.field_187193_c);
      private static final DataParameter<Integer> field_184830_b = EntityDataManager.<Integer>func_187226_a(EntityPlayer.class, DataSerializers.field_187192_b);
      protected static final DataParameter<Byte> field_184827_bp = EntityDataManager.<Byte>func_187226_a(EntityPlayer.class, DataSerializers.field_187191_a);
-@@ -167,6 +172,7 @@
+@@ -167,6 +174,7 @@
          this.func_110148_a(SharedMonsterAttributes.field_111263_d).func_111128_a(0.10000000149011612D);
          this.func_110140_aT().func_111150_b(SharedMonsterAttributes.field_188790_f);
          this.func_110140_aT().func_111150_b(SharedMonsterAttributes.field_188792_h);
@@ -38,7 +22,7 @@
      }
  
      protected void func_70088_a()
-@@ -180,6 +186,7 @@
+@@ -180,6 +188,7 @@
  
      public void func_70071_h_()
      {
@@ -46,7 +30,7 @@
          this.field_70145_X = this.func_175149_v();
  
          if (this.func_175149_v())
-@@ -372,6 +379,7 @@
+@@ -372,6 +381,7 @@
                  this.func_70105_a(f, f1);
              }
          }
@@ -54,7 +38,7 @@
      }
  
      public int func_82145_z()
-@@ -459,11 +467,11 @@
+@@ -459,11 +469,11 @@
              this.field_71109_bG = 0.0F;
              this.func_71015_k(this.field_70165_t - d0, this.field_70163_u - d1, this.field_70161_v - d2);
  
@@ -68,7 +52,7 @@
              }
          }
      }
-@@ -593,11 +601,15 @@
+@@ -593,11 +603,15 @@
  
      public void func_70645_a(DamageSource p_70645_1_)
      {
@@ -84,7 +68,7 @@
          if ("Notch".equals(this.func_70005_c_()))
          {
              this.func_146097_a(new ItemStack(Items.field_151034_e, 1), true, false);
-@@ -609,6 +621,9 @@
+@@ -609,6 +623,9 @@
              this.field_71071_by.func_70436_m();
          }
  
@@ -94,7 +78,7 @@
          if (p_70645_1_ != null)
          {
              this.field_70159_w = (double)(-MathHelper.func_76134_b((this.field_70739_aP + this.field_70177_z) * 0.017453292F) * 0.1F);
-@@ -712,13 +727,24 @@
+@@ -712,13 +729,24 @@
      @Nullable
      public EntityItem func_71040_bB(boolean p_71040_1_)
      {
@@ -121,7 +105,7 @@
      }
  
      @Nullable
-@@ -778,14 +804,22 @@
+@@ -778,14 +806,22 @@
  
      public ItemStack func_184816_a(EntityItem p_184816_1_)
      {
@@ -145,7 +129,7 @@
          if (f > 1.0F)
          {
              int i = EnchantmentHelper.func_185293_e(this);
-@@ -835,12 +869,13 @@
+@@ -835,12 +871,13 @@
              f /= 5.0F;
          }
  
@@ -161,7 +145,7 @@
      }
  
      public static void func_189806_a(DataFixer p_189806_0_)
-@@ -889,6 +924,17 @@
+@@ -889,6 +926,17 @@
              this.field_82248_d = p_70037_1_.func_74767_n("SpawnForced");
          }
  
@@ -179,7 +163,7 @@
          this.field_71100_bB.func_75112_a(p_70037_1_);
          this.field_71075_bZ.func_75095_b(p_70037_1_);
  
-@@ -903,6 +949,7 @@
+@@ -903,6 +951,7 @@
      {
          super.func_70014_b(p_70014_1_);
          p_70014_1_.func_74768_a("DataVersion", 922);
@@ -187,7 +171,7 @@
          p_70014_1_.func_74782_a("Inventory", this.field_71071_by.func_70442_a(new NBTTagList()));
          p_70014_1_.func_74768_a("SelectedItemSlot", this.field_71071_by.field_70461_c);
          p_70014_1_.func_74757_a("Sleeping", this.field_71083_bS);
-@@ -921,6 +968,27 @@
+@@ -921,6 +970,27 @@
              p_70014_1_.func_74757_a("SpawnForced", this.field_82248_d);
          }
  
@@ -215,7 +199,7 @@
          this.field_71100_bB.func_75117_b(p_70014_1_);
          this.field_71075_bZ.func_75091_a(p_70014_1_);
          p_70014_1_.func_74782_a("EnderItems", this.field_71078_a.func_70487_g());
-@@ -928,6 +996,7 @@
+@@ -928,6 +998,7 @@
  
      public boolean func_70097_a(DamageSource p_70097_1_, float p_70097_2_)
      {
@@ -223,7 +207,7 @@
          if (this.func_180431_b(p_70097_1_))
          {
              return false;
-@@ -1000,12 +1069,14 @@
+@@ -1000,12 +1071,14 @@
      {
          if (p_184590_1_ >= 3.0F && this.field_184627_bm.func_77973_b() == Items.field_185159_cQ)
          {
@@ -238,7 +222,7 @@
  
                  if (enumhand == EnumHand.MAIN_HAND)
                  {
-@@ -1041,7 +1112,10 @@
+@@ -1041,7 +1114,10 @@
      {
          if (!this.func_180431_b(p_70665_1_))
          {
@@ -250,7 +234,7 @@
              p_70665_2_ = this.func_70672_c(p_70665_1_, p_70665_2_);
              float f = p_70665_2_;
              p_70665_2_ = Math.max(p_70665_2_ - this.func_110139_bj(), 0.0F);
-@@ -1111,6 +1185,8 @@
+@@ -1111,6 +1187,8 @@
          }
          else
          {
@@ -259,7 +243,7 @@
              ItemStack itemstack = this.func_184586_b(p_190775_2_);
              ItemStack itemstack1 = itemstack.func_190926_b() ? ItemStack.field_190927_a : itemstack.func_77946_l();
  
-@@ -1120,7 +1196,10 @@
+@@ -1120,7 +1198,10 @@
                  {
                      itemstack.func_190920_e(itemstack1.func_190916_E());
                  }
@@ -271,7 +255,7 @@
                  return EnumActionResult.SUCCESS;
              }
              else
-@@ -1136,6 +1215,7 @@
+@@ -1136,6 +1217,7 @@
                      {
                          if (itemstack.func_190926_b() && !this.field_71075_bZ.field_75098_d)
                          {
@@ -279,7 +263,7 @@
                              this.func_184611_a(p_190775_2_, ItemStack.field_190927_a);
                          }
  
-@@ -1161,6 +1241,7 @@
+@@ -1161,6 +1243,7 @@
  
      public void func_71059_n(Entity p_71059_1_)
      {
@@ -287,7 +271,7 @@
          if (p_71059_1_.func_70075_an())
          {
              if (!p_71059_1_.func_85031_j(this))
-@@ -1333,10 +1414,12 @@
+@@ -1333,10 +1416,12 @@
  
                          if (!itemstack1.func_190926_b() && entity instanceof EntityLivingBase)
                          {
@@ -300,7 +284,7 @@
                                  this.func_184611_a(EnumHand.MAIN_HAND, ItemStack.field_190927_a);
                              }
                          }
-@@ -1443,6 +1526,8 @@
+@@ -1443,6 +1528,8 @@
  
      public EntityPlayer.SleepResult func_180469_a(BlockPos p_180469_1_)
      {
@@ -309,7 +293,7 @@
          EnumFacing enumfacing = (EnumFacing)this.field_70170_p.func_180495_p(p_180469_1_).func_177229_b(BlockHorizontal.field_185512_D);
  
          if (!this.field_70170_p.field_72995_K)
-@@ -1484,8 +1569,9 @@
+@@ -1484,8 +1571,9 @@
  
          this.func_70105_a(0.2F, 0.2F);
  
@@ -321,7 +305,7 @@
              float f1 = 0.5F + (float)enumfacing.func_82601_c() * 0.4F;
              float f = 0.5F + (float)enumfacing.func_82599_e() * 0.4F;
              this.func_175139_a(enumfacing);
-@@ -1532,13 +1618,14 @@
+@@ -1532,13 +1620,14 @@
  
      public void func_70999_a(boolean p_70999_1_, boolean p_70999_2_, boolean p_70999_3_)
      {
@@ -339,7 +323,7 @@
  
              if (blockpos == null)
              {
-@@ -1547,6 +1634,10 @@
+@@ -1547,6 +1636,10 @@
  
              this.func_70107_b((double)((float)blockpos.func_177958_n() + 0.5F), (double)((float)blockpos.func_177956_o() + 0.1F), (double)((float)blockpos.func_177952_p() + 0.5F));
          }
@@ -350,7 +334,7 @@
  
          this.field_71083_bS = false;
  
-@@ -1565,15 +1656,16 @@
+@@ -1565,15 +1658,16 @@
  
      private boolean func_175143_p()
      {
@@ -370,7 +354,7 @@
          {
              if (!p_180467_2_)
              {
-@@ -1588,16 +1680,17 @@
+@@ -1588,16 +1682,17 @@
          }
          else
          {
@@ -391,7 +375,7 @@
  
              switch (enumfacing)
              {
-@@ -1637,16 +1730,24 @@
+@@ -1637,16 +1732,24 @@
  
      public BlockPos func_180470_cg()
      {
@@ -418,7 +402,7 @@
          if (p_180473_1_ != null)
          {
              this.field_71077_c = p_180473_1_;
-@@ -1832,7 +1933,7 @@
+@@ -1832,7 +1935,7 @@
  
      public void func_180430_e(float p_180430_1_, float p_180430_2_)
      {
@@ -427,7 +411,7 @@
          {
              if (p_180430_1_ >= 2.0F)
              {
-@@ -1841,6 +1942,10 @@
+@@ -1841,6 +1944,10 @@
  
              super.func_180430_e(p_180430_1_, p_180430_2_);
          }
@@ -438,7 +422,7 @@
      }
  
      protected void func_71061_d_()
-@@ -2041,6 +2146,18 @@
+@@ -2041,6 +2148,18 @@
          this.field_175152_f = p_71049_1_.field_175152_f;
          this.field_71078_a = p_71049_1_.field_71078_a;
          this.func_184212_Q().func_187227_b(field_184827_bp, p_71049_1_.func_184212_Q().func_187225_a(field_184827_bp));
@@ -457,7 +441,7 @@
      }
  
      protected boolean func_70041_e_()
-@@ -2145,7 +2262,10 @@
+@@ -2145,7 +2264,10 @@
  
      public ITextComponent func_145748_c_()
      {
@@ -469,7 +453,7 @@
          itextcomponent.func_150256_b().func_150241_a(new ClickEvent(ClickEvent.Action.SUGGEST_COMMAND, "/msg " + this.func_70005_c_() + " "));
          itextcomponent.func_150256_b().func_150209_a(this.func_174823_aP());
          itextcomponent.func_150256_b().func_179989_a(this.func_70005_c_());
-@@ -2154,7 +2274,7 @@
+@@ -2154,7 +2276,7 @@
  
      public float func_70047_e()
      {
@@ -478,7 +462,7 @@
  
          if (this.func_70608_bn())
          {
-@@ -2370,6 +2490,181 @@
+@@ -2370,6 +2492,181 @@
          return this.field_71075_bZ.field_75098_d && this.func_70003_b(2, "");
      }
  

--- a/patches/minecraft/net/minecraft/entity/player/EntityPlayer.java.patch
+++ b/patches/minecraft/net/minecraft/entity/player/EntityPlayer.java.patch
@@ -1,6 +1,22 @@
 --- ../src-base/minecraft/net/minecraft/entity/player/EntityPlayer.java
 +++ ../src-work/minecraft/net/minecraft/entity/player/EntityPlayer.java
-@@ -98,6 +98,11 @@
+@@ -8,7 +8,6 @@
+ import java.util.UUID;
+ import javax.annotation.Nullable;
+ import net.minecraft.block.Block;
+-import net.minecraft.block.BlockBed;
+ import net.minecraft.block.BlockHorizontal;
+ import net.minecraft.block.material.Material;
+ import net.minecraft.block.state.IBlockState;
+@@ -31,7 +30,6 @@
+ import net.minecraft.entity.passive.AbstractHorse;
+ import net.minecraft.entity.passive.EntityPig;
+ import net.minecraft.entity.projectile.EntityFishHook;
+-import net.minecraft.init.Blocks;
+ import net.minecraft.init.Items;
+ import net.minecraft.init.MobEffects;
+ import net.minecraft.init.SoundEvents;
+@@ -98,6 +96,13 @@
  @SuppressWarnings("incomplete-switch")
  public abstract class EntityPlayer extends EntityLivingBase
  {
@@ -8,11 +24,21 @@
 +    private java.util.HashMap<Integer, BlockPos> spawnChunkMap = new java.util.HashMap<Integer, BlockPos>();
 +    private java.util.HashMap<Integer, Boolean> spawnForcedMap = new java.util.HashMap<Integer, Boolean>();
 +    public float eyeHeight = this.getDefaultEyeHeight();
++    /** When the value >= 1, the player is allowed to fly. */
++    public static final net.minecraft.entity.ai.attributes.IAttribute ALLOW_FLYING = new net.minecraft.entity.ai.attributes.RangedAttribute(null, "forge.allowFlying", 0.0D, 0.0D, 1.0D).func_111112_a(true);
 +
      private static final DataParameter<Float> field_184829_a = EntityDataManager.<Float>func_187226_a(EntityPlayer.class, DataSerializers.field_187193_c);
      private static final DataParameter<Integer> field_184830_b = EntityDataManager.<Integer>func_187226_a(EntityPlayer.class, DataSerializers.field_187192_b);
      protected static final DataParameter<Byte> field_184827_bp = EntityDataManager.<Byte>func_187226_a(EntityPlayer.class, DataSerializers.field_187191_a);
-@@ -180,6 +185,7 @@
+@@ -167,6 +172,7 @@
+         this.func_110148_a(SharedMonsterAttributes.field_111263_d).func_111128_a(0.10000000149011612D);
+         this.func_110140_aT().func_111150_b(SharedMonsterAttributes.field_188790_f);
+         this.func_110140_aT().func_111150_b(SharedMonsterAttributes.field_188792_h);
++        this.func_110140_aT().func_111150_b(ALLOW_FLYING);
+     }
+ 
+     protected void func_70088_a()
+@@ -180,6 +186,7 @@
  
      public void func_70071_h_()
      {
@@ -20,7 +46,7 @@
          this.field_70145_X = this.func_175149_v();
  
          if (this.func_175149_v())
-@@ -372,6 +378,7 @@
+@@ -372,6 +379,7 @@
                  this.func_70105_a(f, f1);
              }
          }
@@ -28,7 +54,7 @@
      }
  
      public int func_82145_z()
-@@ -459,11 +466,11 @@
+@@ -459,11 +467,11 @@
              this.field_71109_bG = 0.0F;
              this.func_71015_k(this.field_70165_t - d0, this.field_70163_u - d1, this.field_70161_v - d2);
  
@@ -42,7 +68,7 @@
              }
          }
      }
-@@ -593,11 +600,15 @@
+@@ -593,11 +601,15 @@
  
      public void func_70645_a(DamageSource p_70645_1_)
      {
@@ -58,7 +84,7 @@
          if ("Notch".equals(this.func_70005_c_()))
          {
              this.func_146097_a(new ItemStack(Items.field_151034_e, 1), true, false);
-@@ -609,6 +620,9 @@
+@@ -609,6 +621,9 @@
              this.field_71071_by.func_70436_m();
          }
  
@@ -68,7 +94,7 @@
          if (p_70645_1_ != null)
          {
              this.field_70159_w = (double)(-MathHelper.func_76134_b((this.field_70739_aP + this.field_70177_z) * 0.017453292F) * 0.1F);
-@@ -712,13 +726,24 @@
+@@ -712,13 +727,24 @@
      @Nullable
      public EntityItem func_71040_bB(boolean p_71040_1_)
      {
@@ -95,7 +121,7 @@
      }
  
      @Nullable
-@@ -778,14 +803,22 @@
+@@ -778,14 +804,22 @@
  
      public ItemStack func_184816_a(EntityItem p_184816_1_)
      {
@@ -119,7 +145,7 @@
          if (f > 1.0F)
          {
              int i = EnchantmentHelper.func_185293_e(this);
-@@ -835,12 +868,13 @@
+@@ -835,12 +869,13 @@
              f /= 5.0F;
          }
  
@@ -135,7 +161,7 @@
      }
  
      public static void func_189806_a(DataFixer p_189806_0_)
-@@ -889,6 +923,17 @@
+@@ -889,6 +924,17 @@
              this.field_82248_d = p_70037_1_.func_74767_n("SpawnForced");
          }
  
@@ -153,7 +179,7 @@
          this.field_71100_bB.func_75112_a(p_70037_1_);
          this.field_71075_bZ.func_75095_b(p_70037_1_);
  
-@@ -903,6 +948,7 @@
+@@ -903,6 +949,7 @@
      {
          super.func_70014_b(p_70014_1_);
          p_70014_1_.func_74768_a("DataVersion", 922);
@@ -161,7 +187,7 @@
          p_70014_1_.func_74782_a("Inventory", this.field_71071_by.func_70442_a(new NBTTagList()));
          p_70014_1_.func_74768_a("SelectedItemSlot", this.field_71071_by.field_70461_c);
          p_70014_1_.func_74757_a("Sleeping", this.field_71083_bS);
-@@ -921,6 +967,27 @@
+@@ -921,6 +968,27 @@
              p_70014_1_.func_74757_a("SpawnForced", this.field_82248_d);
          }
  
@@ -189,7 +215,7 @@
          this.field_71100_bB.func_75117_b(p_70014_1_);
          this.field_71075_bZ.func_75091_a(p_70014_1_);
          p_70014_1_.func_74782_a("EnderItems", this.field_71078_a.func_70487_g());
-@@ -928,6 +995,7 @@
+@@ -928,6 +996,7 @@
  
      public boolean func_70097_a(DamageSource p_70097_1_, float p_70097_2_)
      {
@@ -197,7 +223,7 @@
          if (this.func_180431_b(p_70097_1_))
          {
              return false;
-@@ -1000,12 +1068,14 @@
+@@ -1000,12 +1069,14 @@
      {
          if (p_184590_1_ >= 3.0F && this.field_184627_bm.func_77973_b() == Items.field_185159_cQ)
          {
@@ -212,7 +238,7 @@
  
                  if (enumhand == EnumHand.MAIN_HAND)
                  {
-@@ -1041,7 +1111,10 @@
+@@ -1041,7 +1112,10 @@
      {
          if (!this.func_180431_b(p_70665_1_))
          {
@@ -224,7 +250,7 @@
              p_70665_2_ = this.func_70672_c(p_70665_1_, p_70665_2_);
              float f = p_70665_2_;
              p_70665_2_ = Math.max(p_70665_2_ - this.func_110139_bj(), 0.0F);
-@@ -1111,6 +1184,8 @@
+@@ -1111,6 +1185,8 @@
          }
          else
          {
@@ -233,7 +259,7 @@
              ItemStack itemstack = this.func_184586_b(p_190775_2_);
              ItemStack itemstack1 = itemstack.func_190926_b() ? ItemStack.field_190927_a : itemstack.func_77946_l();
  
-@@ -1120,7 +1195,10 @@
+@@ -1120,7 +1196,10 @@
                  {
                      itemstack.func_190920_e(itemstack1.func_190916_E());
                  }
@@ -245,7 +271,7 @@
                  return EnumActionResult.SUCCESS;
              }
              else
-@@ -1136,6 +1214,7 @@
+@@ -1136,6 +1215,7 @@
                      {
                          if (itemstack.func_190926_b() && !this.field_71075_bZ.field_75098_d)
                          {
@@ -253,7 +279,7 @@
                              this.func_184611_a(p_190775_2_, ItemStack.field_190927_a);
                          }
  
-@@ -1161,6 +1240,7 @@
+@@ -1161,6 +1241,7 @@
  
      public void func_71059_n(Entity p_71059_1_)
      {
@@ -261,7 +287,7 @@
          if (p_71059_1_.func_70075_an())
          {
              if (!p_71059_1_.func_85031_j(this))
-@@ -1333,10 +1413,12 @@
+@@ -1333,10 +1414,12 @@
  
                          if (!itemstack1.func_190926_b() && entity instanceof EntityLivingBase)
                          {
@@ -274,7 +300,7 @@
                                  this.func_184611_a(EnumHand.MAIN_HAND, ItemStack.field_190927_a);
                              }
                          }
-@@ -1443,6 +1525,8 @@
+@@ -1443,6 +1526,8 @@
  
      public EntityPlayer.SleepResult func_180469_a(BlockPos p_180469_1_)
      {
@@ -283,7 +309,7 @@
          EnumFacing enumfacing = (EnumFacing)this.field_70170_p.func_180495_p(p_180469_1_).func_177229_b(BlockHorizontal.field_185512_D);
  
          if (!this.field_70170_p.field_72995_K)
-@@ -1484,8 +1568,9 @@
+@@ -1484,8 +1569,9 @@
  
          this.func_70105_a(0.2F, 0.2F);
  
@@ -295,7 +321,7 @@
              float f1 = 0.5F + (float)enumfacing.func_82601_c() * 0.4F;
              float f = 0.5F + (float)enumfacing.func_82599_e() * 0.4F;
              this.func_175139_a(enumfacing);
-@@ -1532,13 +1617,14 @@
+@@ -1532,13 +1618,14 @@
  
      public void func_70999_a(boolean p_70999_1_, boolean p_70999_2_, boolean p_70999_3_)
      {
@@ -313,7 +339,7 @@
  
              if (blockpos == null)
              {
-@@ -1547,6 +1633,10 @@
+@@ -1547,6 +1634,10 @@
  
              this.func_70107_b((double)((float)blockpos.func_177958_n() + 0.5F), (double)((float)blockpos.func_177956_o() + 0.1F), (double)((float)blockpos.func_177952_p() + 0.5F));
          }
@@ -324,7 +350,7 @@
  
          this.field_71083_bS = false;
  
-@@ -1565,15 +1655,16 @@
+@@ -1565,15 +1656,16 @@
  
      private boolean func_175143_p()
      {
@@ -344,7 +370,7 @@
          {
              if (!p_180467_2_)
              {
-@@ -1588,16 +1679,17 @@
+@@ -1588,16 +1680,17 @@
          }
          else
          {
@@ -365,7 +391,7 @@
  
              switch (enumfacing)
              {
-@@ -1637,16 +1729,24 @@
+@@ -1637,16 +1730,24 @@
  
      public BlockPos func_180470_cg()
      {
@@ -392,7 +418,16 @@
          if (p_180473_1_ != null)
          {
              this.field_71077_c = p_180473_1_;
-@@ -1841,6 +1941,10 @@
+@@ -1832,7 +1933,7 @@
+ 
+     public void func_180430_e(float p_180430_1_, float p_180430_2_)
+     {
+-        if (!this.field_71075_bZ.field_75101_c)
++        if (!this.isAllowedToFly())
+         {
+             if (p_180430_1_ >= 2.0F)
+             {
+@@ -1841,6 +1942,10 @@
  
              super.func_180430_e(p_180430_1_, p_180430_2_);
          }
@@ -403,7 +438,7 @@
      }
  
      protected void func_71061_d_()
-@@ -2041,6 +2145,18 @@
+@@ -2041,6 +2146,18 @@
          this.field_175152_f = p_71049_1_.field_175152_f;
          this.field_71078_a = p_71049_1_.field_71078_a;
          this.func_184212_Q().func_187227_b(field_184827_bp, p_71049_1_.func_184212_Q().func_187225_a(field_184827_bp));
@@ -422,7 +457,7 @@
      }
  
      protected boolean func_70041_e_()
-@@ -2145,7 +2261,10 @@
+@@ -2145,7 +2262,10 @@
  
      public ITextComponent func_145748_c_()
      {
@@ -434,7 +469,7 @@
          itextcomponent.func_150256_b().func_150241_a(new ClickEvent(ClickEvent.Action.SUGGEST_COMMAND, "/msg " + this.func_70005_c_() + " "));
          itextcomponent.func_150256_b().func_150209_a(this.func_174823_aP());
          itextcomponent.func_150256_b().func_179989_a(this.func_70005_c_());
-@@ -2154,7 +2273,7 @@
+@@ -2154,7 +2274,7 @@
  
      public float func_70047_e()
      {
@@ -443,7 +478,7 @@
  
          if (this.func_70608_bn())
          {
-@@ -2370,6 +2489,168 @@
+@@ -2370,6 +2490,181 @@
          return this.field_71075_bZ.field_75098_d && this.func_70003_b(2, "");
      }
  
@@ -606,6 +641,19 @@
 +    public boolean hasSpawnDimension() { return spawnDimension != null; }
 +    public int getSpawnDimension() { return spawnDimension != null ? spawnDimension : 0; }
 +    public void setSpawnDimension(@Nullable Integer dimension) { this.spawnDimension = dimension; }
++
++    /**
++     * Returns true if the player is allowed to fly.
++     * True if {@link #ALLOW_FLYING} is >= 1 or if capabilities.allowFlying is true.
++     * @return True if the player is allowed to fly.
++     */
++    public boolean isAllowedToFly()
++    {
++        if (!field_70170_p.field_72995_K) {
++            int i = 0;
++        }
++        return func_110148_a(ALLOW_FLYING).func_111126_e() >= 1.0D || field_71075_bZ.field_75101_c;
++    }
 +
 +    /* ======================================== FORGE END  =====================================*/
 +

--- a/patches/minecraft/net/minecraft/network/NetHandlerPlayServer.java.patch
+++ b/patches/minecraft/net/minecraft/network/NetHandlerPlayServer.java.patch
@@ -1,5 +1,14 @@
 --- ../src-base/minecraft/net/minecraft/network/NetHandlerPlayServer.java
 +++ ../src-work/minecraft/net/minecraft/network/NetHandlerPlayServer.java
+@@ -522,7 +522,7 @@
+                             }
+ 
+                             this.field_184344_B = d12 >= -0.03125D;
+-                            this.field_184344_B &= !this.field_147367_d.func_71231_X() && !this.field_147369_b.field_71075_bZ.field_75101_c;
++                            this.field_184344_B &= !this.field_147367_d.func_71231_X() && !this.field_147369_b.isAllowedToFly();
+                             this.field_184344_B &= !this.field_147369_b.func_70644_a(MobEffects.field_188424_y) && !this.field_147369_b.func_184613_cA() && !worldserver.func_72829_c(this.field_147369_b.func_174813_aQ().func_186662_g(0.0625D).func_72321_a(0.0D, -0.55D, 0.0D));
+                             this.field_147369_b.field_70122_E = p_147347_1_.func_149465_i();
+                             this.field_147367_d.func_184103_al().func_72358_d(this.field_147369_b);
 @@ -617,7 +617,10 @@
                  double d2 = this.field_147369_b.field_70161_v - ((double)blockpos.func_177952_p() + 0.5D);
                  double d3 = d0 * d0 + d1 * d1 + d2 * d2;
@@ -51,3 +60,12 @@
  
                      if (this.field_147367_d.func_71199_h())
                      {
+@@ -1260,7 +1268,7 @@
+     public void func_147348_a(CPacketPlayerAbilities p_147348_1_)
+     {
+         PacketThreadUtil.func_180031_a(p_147348_1_, this, this.field_147369_b.func_71121_q());
+-        this.field_147369_b.field_71075_bZ.field_75100_b = p_147348_1_.func_149488_d() && this.field_147369_b.field_71075_bZ.field_75101_c;
++        this.field_147369_b.field_71075_bZ.field_75100_b = p_147348_1_.func_149488_d() && this.field_147369_b.isAllowedToFly();
+     }
+ 
+     public void func_147341_a(CPacketTabComplete p_147341_1_)

--- a/src/test/java/net/minecraftforge/test/FlyingAttributeTest.java
+++ b/src/test/java/net/minecraftforge/test/FlyingAttributeTest.java
@@ -1,0 +1,49 @@
+package net.minecraftforge.test;
+
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.potion.Potion;
+import net.minecraft.potion.PotionEffect;
+import net.minecraft.potion.PotionType;
+import net.minecraftforge.event.RegistryEvent;
+import net.minecraftforge.fml.common.Mod;
+import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
+
+/**
+ * Adds two potions, one that gives flight and one that prevents flight. Both potions use the ALLOW_FLYING attribute.
+ */
+@Mod(modid = FlyingAttributeTest.MODID, name = "FlyingAttributeTest", version = "1.0")
+@Mod.EventBusSubscriber
+public class FlyingAttributeTest
+{
+    public static final String MODID = "flyingattributetest";
+
+    public static final Potion FLYING_POTION = new TestPotion(false, 0)
+            .setPotionName("effect." + MODID + ".flying")
+            .registerPotionAttributeModifier(EntityPlayer.ALLOW_FLYING, "74DA1959-ECB7-43E1-A2F6-7426E390F331", 1.0D, 0)
+            .setBeneficial()
+            .setRegistryName(MODID, "flying");
+    public static final Potion EARTHBIND_POTION = new TestPotion(true, 0)
+            .setPotionName("effect." + MODID + ".earthbind")
+            .registerPotionAttributeModifier(EntityPlayer.ALLOW_FLYING, "915FD6BE-89DC-4480-A2F2-8EED01A00D67", -1.0D, 2)
+            .setRegistryName(MODID, "earthbind");
+
+    @SubscribeEvent
+    public static void registerPotions(RegistryEvent.Register<Potion> e)
+    {
+        e.getRegistry().register(FLYING_POTION);
+        e.getRegistry().register(EARTHBIND_POTION);
+    }
+
+    @SubscribeEvent
+    public static void registerPotionTypes(RegistryEvent.Register<PotionType> e)
+    {
+        e.getRegistry().register(new PotionType(new PotionEffect(FLYING_POTION, 3600)).setRegistryName(MODID, "flying_potion_type"));
+        e.getRegistry().register(new PotionType(new PotionEffect(EARTHBIND_POTION, 3600)).setRegistryName(MODID, "earthbind_potion_type"));
+    }
+
+    public static class TestPotion extends Potion {
+        public TestPotion(boolean isBadEffectIn, int liquidColorIn) {
+            super(isBadEffectIn, liquidColorIn);
+        }
+    }
+}


### PR DESCRIPTION
The motivation is to remove some pain points for mods that allow players to fly outside of creative mode, which is a surprisingly common feature. Mods can end up fighting over the `PlayerCapabilities#allowFlying` state.

This implementation allows a player to fly when the attribute value for ALLOW_FLYING is >= 1 or if `capabilities.allowFlying` is `true`. If a modder wants to enable flight, the modder should add an attribute modifier that adds 1 to the attribute value, and remove it to disable flight. If a modder wants to disable flight completely, they can add a -100% attribute modifier. The advantage here is that it can be done without conflict.

It also makes it simple to give armor and potions flight properties. The included test mod adds a flying potion and an "earthbind" potion that counteracts it.