### PR TITLE
Fix canRiderInteract being called on the wrong entity

### DIFF
--- a/patches/minecraft/net/minecraft/client/renderer/EntityRenderer.java.patch
+++ b/patches/minecraft/net/minecraft/client/renderer/EntityRenderer.java.patch
@@ -13,7 +13,7 @@
                          if (d3 < d2 || d2 == 0.0D)
                          {
 -                            if (entity1.func_184208_bv() == entity.func_184208_bv())
-+                            if (entity1.func_184208_bv() == entity.func_184208_bv() && !entity.canRiderInteract())
++                            if (entity1.func_184208_bv() == entity.func_184208_bv() && !entity1.canRiderInteract())
                              {
                                  if (d2 == 0.0D)
                                  {


### PR DESCRIPTION
`canRiderInteract` is a Forge-added method that is supposed to return true on mounts that want the rider to be able to attack/right click them. 

In the current patch, it instead is being called on the rider instead of the mount. The mount is `entity1`, the rider/view entity is `entity`.

This is simply an incorrectly ported patch, the proper behaviour can be seen in the [1.7 patch](https://github.com/MinecraftForge/MinecraftForge/blob/1.7.10/patches/minecraft/net/minecraft/client/renderer/EntityRenderer.java.patch#L21). In that patch, `entity` was the mount and `field_70154_o` was the rider/view entity.

Simple typo fix.