### PR TITLE
Adding tint index to fluid model, closes #3937

### DIFF
--- a/src/main/java/net/minecraftforge/client/model/ModelFluid.java
+++ b/src/main/java/net/minecraftforge/client/model/ModelFluid.java
@@ -236,6 +236,7 @@ public final class ModelFluid implements IModelCustomData
                     builder = new UnpackedBakedQuad.Builder(format);
                     builder.setQuadOrientation(side);
                     builder.setTexture(topSprite);
+                    builder.setQuadTint(0);
                     for (int i = gas ? 3 : 0; i != (gas ? -1 : 4); i += (gas ? -1 : 1))
                     {
                         int l = (k * 3) + (1 - 2 * k) * i;
@@ -255,6 +256,7 @@ public final class ModelFluid implements IModelCustomData
                 builder = new UnpackedBakedQuad.Builder(format);
                 builder.setQuadOrientation(side);
                 builder.setTexture(still);
+                builder.setQuadTint(0);
                 for(int i = gas ? 3 : 0; i != (gas ? -1 : 4); i+= (gas ? -1 : 1))
                 {
                     putVertex(
@@ -277,6 +279,7 @@ public final class ModelFluid implements IModelCustomData
                         builder = new UnpackedBakedQuad.Builder(format);
                         builder.setQuadOrientation(side);
                         builder.setTexture(flowing);
+                        builder.setQuadTint(0);
                         for(int j = 0; j < 4; j++)
                         {
                             int l = (k * 3) + (1 - 2 * k) * j;
@@ -299,6 +302,7 @@ public final class ModelFluid implements IModelCustomData
                 UnpackedBakedQuad.Builder builder = new UnpackedBakedQuad.Builder(format);
                 builder.setQuadOrientation(EnumFacing.UP);
                 builder.setTexture(still);
+                builder.setQuadTint(0); //I dont know if we also need this in inventory, but now it should be possible to color it here as well
                 for(int i = 0; i < 4; i++)
                 {
                     putVertex(


### PR DESCRIPTION
This fixes #3937, by adding missing tint index to fluid. @RainWarrior I guess its important you aprove this, since this is rendering related.