### PR TITLE
Specify use of weight in registerWorldGenerator

### DIFF
--- a/src/main/java/net/minecraftforge/fml/common/registry/GameRegistry.java
+++ b/src/main/java/net/minecraftforge/fml/common/registry/GameRegistry.java
@@ -88,8 +88,9 @@ public class GameRegistry
      * Register a world generator - something that inserts new block types into the world
      *
      * @param generator           the generator
-     * @param modGenerationWeight a weight to assign to this generator. Heavy weights tend to sink to the bottom of
-     *                            list of world generators (i.e. they run later)
+     * @param modGenerationWeight a weight to assign to the generator. The generators will be run in order
+     *                            from least to greatest. The order of generators with the same weight is
+     *                            arbitrary
      */
     public static void registerWorldGenerator(IWorldGenerator generator, int modGenerationWeight)
     {


### PR DESCRIPTION
The previous docs left it a little unclear what effect weight actually had on the generators.
This makes it clear that if you need your generators to run in a specific order (relative to each other) the weight will have that effect.