### PR TITLE
Allow the server to handle item-block interaction if onItemUse doesn not return PASS

### DIFF
--- a/patches/minecraft/net/minecraft/client/multiplayer/PlayerControllerMP.java.patch
+++ b/patches/minecraft/net/minecraft/client/multiplayer/PlayerControllerMP.java.patch
@@ -103,7 +103,7 @@
          }
  
          return p_178893_1_.equals(this.field_178895_c) && flag;
-@@ -373,13 +384,33 @@
+@@ -373,13 +384,34 @@
          }
          else
          {
@@ -122,6 +122,7 @@
 +                EnumActionResult ret = itemstack.onItemUseFirst(p_187099_1_, p_187099_2_, p_187099_3_, p_187099_6_, p_187099_4_, f, f1, f2);
 +                if (ret != EnumActionResult.PASS)
 +                {
++                    // The server needs to process the item use as well. Otherwise onItemUseFirst won't ever be called on the server without causing weird bugs
 +                    this.field_78774_b.func_147297_a(new CPacketPlayerTryUseItemOnBlock(p_187099_3_, p_187099_4_, p_187099_6_, f, f1, f2));
 +                    return ret;
 +                }
@@ -139,7 +140,7 @@
                  }
  
                  if (!flag && itemstack.func_77973_b() instanceof ItemBlock)
-@@ -395,7 +426,7 @@
+@@ -395,7 +427,7 @@
  
              this.field_78774_b.func_147297_a(new CPacketPlayerTryUseItemOnBlock(p_187099_3_, p_187099_4_, p_187099_6_, f, f1, f2));
  
@@ -148,7 +149,7 @@
              {
                  if (itemstack.func_190926_b())
                  {
-@@ -421,14 +452,20 @@
+@@ -421,14 +453,20 @@
                      {
                          int i = itemstack.func_77960_j();
                          int j = itemstack.func_190916_E();
@@ -170,7 +171,7 @@
                      }
                  }
              }
-@@ -457,6 +494,8 @@
+@@ -457,6 +495,8 @@
              }
              else
              {
@@ -179,7 +180,7 @@
                  int i = itemstack.func_190916_E();
                  ActionResult<ItemStack> actionresult = itemstack.func_77957_a(p_187101_2_, p_187101_1_, p_187101_3_);
                  ItemStack itemstack1 = (ItemStack)actionresult.func_188398_b();
-@@ -464,6 +503,10 @@
+@@ -464,6 +504,10 @@
                  if (itemstack1 != itemstack || itemstack1.func_190916_E() != i)
                  {
                      p_187101_1_.func_184611_a(p_187101_3_, itemstack1);
@@ -190,7 +191,7 @@
                  }
  
                  return actionresult.func_188397_a();
-@@ -500,6 +543,9 @@
+@@ -500,6 +544,9 @@
          this.func_78750_j();
          Vec3d vec3d = new Vec3d(p_187102_3_.field_72307_f.field_72450_a - p_187102_2_.field_70165_t, p_187102_3_.field_72307_f.field_72448_b - p_187102_2_.field_70163_u, p_187102_3_.field_72307_f.field_72449_c - p_187102_2_.field_70161_v);
          this.field_78774_b.func_147297_a(new CPacketUseEntity(p_187102_2_, p_187102_4_, vec3d));

--- a/patches/minecraft/net/minecraft/client/multiplayer/PlayerControllerMP.java.patch
+++ b/patches/minecraft/net/minecraft/client/multiplayer/PlayerControllerMP.java.patch
@@ -103,7 +103,7 @@
          }
  
          return p_178893_1_.equals(this.field_178895_c) && flag;
-@@ -373,13 +384,29 @@
+@@ -373,13 +384,33 @@
          }
          else
          {
@@ -120,7 +120,11 @@
              if (this.field_78779_k != GameType.SPECTATOR)
              {
 +                EnumActionResult ret = itemstack.onItemUseFirst(p_187099_1_, p_187099_2_, p_187099_3_, p_187099_6_, p_187099_4_, f, f1, f2);
-+                if (ret != EnumActionResult.PASS) return ret;
++                if (ret != EnumActionResult.PASS)
++                {
++                    this.field_78774_b.func_147297_a(new CPacketPlayerTryUseItemOnBlock(p_187099_3_, p_187099_4_, p_187099_6_, f, f1, f2));
++                    return ret;
++                }
 +
                  IBlockState iblockstate = p_187099_2_.func_180495_p(p_187099_3_);
 +                boolean bypass = itemstack.func_190926_b() || itemstack.func_77973_b().doesSneakBypassUse(itemstack, p_187099_2_, p_187099_3_, p_187099_1_);
@@ -135,7 +139,7 @@
                  }
  
                  if (!flag && itemstack.func_77973_b() instanceof ItemBlock)
-@@ -395,7 +422,7 @@
+@@ -395,7 +426,7 @@
  
              this.field_78774_b.func_147297_a(new CPacketPlayerTryUseItemOnBlock(p_187099_3_, p_187099_4_, p_187099_6_, f, f1, f2));
  
@@ -144,7 +148,7 @@
              {
                  if (itemstack.func_190926_b())
                  {
-@@ -421,14 +448,20 @@
+@@ -421,14 +452,20 @@
                      {
                          int i = itemstack.func_77960_j();
                          int j = itemstack.func_190916_E();
@@ -166,7 +170,7 @@
                      }
                  }
              }
-@@ -457,6 +490,8 @@
+@@ -457,6 +494,8 @@
              }
              else
              {
@@ -175,7 +179,7 @@
                  int i = itemstack.func_190916_E();
                  ActionResult<ItemStack> actionresult = itemstack.func_77957_a(p_187101_2_, p_187101_1_, p_187101_3_);
                  ItemStack itemstack1 = (ItemStack)actionresult.func_188398_b();
-@@ -464,6 +499,10 @@
+@@ -464,6 +503,10 @@
                  if (itemstack1 != itemstack || itemstack1.func_190916_E() != i)
                  {
                      p_187101_1_.func_184611_a(p_187101_3_, itemstack1);
@@ -186,7 +190,7 @@
                  }
  
                  return actionresult.func_188397_a();
-@@ -500,6 +539,9 @@
+@@ -500,6 +543,9 @@
          this.func_78750_j();
          Vec3d vec3d = new Vec3d(p_187102_3_.field_72307_f.field_72450_a - p_187102_2_.field_70165_t, p_187102_3_.field_72307_f.field_72448_b - p_187102_2_.field_70163_u, p_187102_3_.field_72307_f.field_72449_c - p_187102_2_.field_70161_v);
          this.field_78774_b.func_147297_a(new CPacketUseEntity(p_187102_2_, p_187102_4_, vec3d));

--- a/src/test/java/net/minecraftforge/debug/OnItemUseFirstTest.java
+++ b/src/test/java/net/minecraftforge/debug/OnItemUseFirstTest.java
@@ -1,0 +1,96 @@
+package net.minecraftforge.debug;
+
+import net.minecraft.client.renderer.block.model.ModelResourceLocation;
+import net.minecraft.creativetab.CreativeTabs;
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.item.Item;
+import net.minecraft.item.ItemStack;
+import net.minecraft.util.*;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.text.TextComponentString;
+import net.minecraft.world.World;
+import net.minecraftforge.client.model.ModelLoader;
+import net.minecraftforge.fml.common.Mod;
+import net.minecraftforge.fml.common.SidedProxy;
+import net.minecraftforge.fml.common.event.FMLPreInitializationEvent;
+import net.minecraftforge.fml.common.registry.GameRegistry;
+
+import javax.annotation.Nonnull;
+
+@Mod(modid = OnItemUseFirstTest.MODID, name = "OnItemUseFirstTest", version = "0.0.0", acceptableRemoteVersions = "*")
+public class OnItemUseFirstTest
+{
+    public static final boolean ENABLE = false;
+    public static final String MODID = "onitemusefirsttest";
+    @SidedProxy
+    public static CommonProxy proxy = null;
+
+    public static abstract class CommonProxy
+    {
+        public void preInit(FMLPreInitializationEvent event)
+        {
+            ItemTest.instance = new ItemTest();
+            GameRegistry.register(ItemTest.instance, new ResourceLocation("onitemusefirsttest", "test_item"));
+        }
+    }
+
+    public static final class ServerProxy extends CommonProxy
+    {
+    }
+
+    public static final class ClientProxy extends CommonProxy
+    {
+        @Override
+        public void preInit(FMLPreInitializationEvent event)
+        {
+            super.preInit(event);
+            ModelLoader.setCustomModelResourceLocation(ItemTest.instance, 0, new ModelResourceLocation(new ResourceLocation(MODID, "test_item"), "inventory"));
+            ModelLoader.setCustomModelResourceLocation(ItemTest.instance, 1, new ModelResourceLocation(new ResourceLocation(MODID, "test_item"), "inventory"));
+        }
+    }
+
+    @Mod.EventHandler
+    public void preInit(FMLPreInitializationEvent event)
+    {
+        if (ENABLE)
+        {
+            proxy.preInit(event);
+        }
+    }
+
+    public static class ItemTest extends Item
+    {
+        static Item instance;
+        @Nonnull
+        @Override
+        public EnumActionResult onItemUseFirst(EntityPlayer player, World world, BlockPos pos, EnumFacing side, float hitX, float hitY, float hitZ, EnumHand hand)
+        {
+            ItemStack stack = player.getHeldItem(hand);
+            player.sendMessage(new TextComponentString("Called onItemUseFirst in thread " + Thread.currentThread().getName() + " with meta " + stack.getMetadata() + " in hand " + hand.name()));
+            if (stack.getMetadata() == 1 && world.isRemote)
+            {
+                return EnumActionResult.PASS;
+            }
+            return EnumActionResult.SUCCESS;
+        }
+
+        @Override
+        public CreativeTabs getCreativeTab()
+        {
+            return CreativeTabs.MISC;
+        }
+
+        @Override
+        public void getSubItems(@Nonnull Item itemIn, CreativeTabs tab, NonNullList<ItemStack> subItems)
+        {
+            subItems.add(new ItemStack(itemIn, 1, 0));
+            subItems.add(new ItemStack(itemIn, 1, 1));
+        }
+
+        @Override
+        public String getItemStackDisplayName(ItemStack stack)
+        {
+            return "OnItemUseFirst Test Item: " + stack.getMetadata();
+        }
+    }
+}

--- a/src/test/resources/assets/onitemusefirsttest/models/item/test_item.json
+++ b/src/test/resources/assets/onitemusefirsttest/models/item/test_item.json
@@ -1,0 +1,6 @@
+{
+  "parent": "item/generated",
+  "textures": {
+    "layer0": "items/shulker_shell"
+  }
+}


### PR DESCRIPTION
I have made a small mod to demonstrate the issue fixed by this PR: [Source code](https://gist.github.com/malte0811/f926f97039f5f6c9c65d73cd1170b697), [Build](https://www.dropbox.com/s/j8rqfold2dagvdv/TestMod-1.0.jar?dl=0). It adds one item (in the misc creative tab, please don't complain about missing models) demonstrating 2 different `onItemUseFirst` implementations. When `onItemUseFirst` is called on this item, it will log some info to the chat: current thread, item stack metadata and hand.
The current behavior: If `onItemUseFirst` returns anything but PASS, the code won't ever run server-side. This does not match the behavior of `onItemUse`. The 2 different `onItemUseFirst` implementations demonstrated by the test item:
 - Meta 0: `onItemUseFirst` is implemented as one would implement `onItemUse`. It returns the same value on both client and server, `SUCCESS`. When this version is right-clicked only one call from the client thread is logged.
 - Meta 1: `onItemUseFirst` returns `PASS` on the client side, but the actual intended (`SUCCESS`) value on the server. This results in one call on both client and server. When another of these test items is in the offhand, this implementation breaks: Both the item in the Main- and the Offhand have `onItemUseFirst` called on both sides.

This fix may be considered a breaking change since some mods work around this by manually sending the packet: I have an open PR with ImmersiveEngineering to implement this workaround (but I could still remove it from the PR if this will be pulled in 1.11), @mallrat208 says he implemented this workaround in one of his mods and I assume some other mods already contain this workaround. Those workarounds would break to some degree since `onItemUseFirst` would be called twice on the server.
There is an empty patched-in line directly after my edit. Should I remove that line or just leave it?