### PR TITLE
Fix vanilla pixel data being used for custom maps when rendering and in item frames

### DIFF
--- a/patches/minecraft/net/minecraft/client/renderer/ItemRenderer.java.patch
+++ b/patches/minecraft/net/minecraft/client/renderer/ItemRenderer.java.patch
@@ -1,5 +1,14 @@
 --- ../src-base/minecraft/net/minecraft/client/renderer/ItemRenderer.java
 +++ ../src-work/minecraft/net/minecraft/client/renderer/ItemRenderer.java
+@@ -215,7 +215,7 @@
+         vertexbuffer.func_181662_b(135.0D, -7.0D, 0.0D).func_187315_a(1.0D, 0.0D).func_181675_d();
+         vertexbuffer.func_181662_b(-7.0D, -7.0D, 0.0D).func_187315_a(0.0D, 0.0D).func_181675_d();
+         tessellator.func_78381_a();
+-        MapData mapdata = Items.field_151098_aY.func_77873_a(p_187461_1_, this.field_78455_a.field_71441_e);
++        MapData mapdata = ((net.minecraft.item.ItemMap) p_187461_1_.func_77973_b()).func_77873_a(p_187461_1_, this.field_78455_a.field_71441_e);
+ 
+         if (mapdata != null)
+         {
 @@ -311,7 +311,7 @@
          {
              ItemStack itemstack = abstractclientplayer.func_184607_cu();

--- a/patches/minecraft/net/minecraft/client/renderer/tileentity/RenderItemFrame.java.patch
+++ b/patches/minecraft/net/minecraft/client/renderer/tileentity/RenderItemFrame.java.patch
@@ -1,6 +1,15 @@
 --- ../src-base/minecraft/net/minecraft/client/renderer/tileentity/RenderItemFrame.java
 +++ ../src-work/minecraft/net/minecraft/client/renderer/tileentity/RenderItemFrame.java
-@@ -106,15 +106,18 @@
+@@ -53,7 +53,7 @@
+         ModelManager modelmanager = blockrendererdispatcher.func_175023_a().func_178126_b();
+         IBakedModel ibakedmodel;
+ 
+-        if (!p_76986_1_.func_82335_i().func_190926_b() && p_76986_1_.func_82335_i().func_77973_b() == Items.field_151098_aY)
++        if (!p_76986_1_.func_82335_i().func_190926_b() && p_76986_1_.func_82335_i().func_77973_b() instanceof net.minecraft.item.ItemMap)
+         {
+             ibakedmodel = modelmanager.func_174953_a(this.field_177073_g);
+         }
+@@ -106,21 +106,24 @@
              GlStateManager.func_179140_f();
              int i = p_82402_1_.func_82333_j();
  
@@ -21,6 +30,13 @@
                  this.field_76990_c.field_78724_e.func_110577_a(field_110789_a);
                  GlStateManager.func_179114_b(180.0F, 0.0F, 0.0F, 1.0F);
                  float f = 0.0078125F;
+                 GlStateManager.func_179152_a(0.0078125F, 0.0078125F, 0.0078125F);
+                 GlStateManager.func_179109_b(-64.0F, -64.0F, 0.0F);
+-                MapData mapdata = Items.field_151098_aY.func_77873_a(entityitem.func_92059_d(), p_82402_1_.field_70170_p);
++                MapData mapdata = ((net.minecraft.item.ItemMap)item).func_77873_a(entityitem.func_92059_d(), p_82402_1_.field_70170_p);
+                 GlStateManager.func_179109_b(0.0F, 0.0F, -1.0F);
+ 
+                 if (mapdata != null)
 @@ -137,6 +140,7 @@
                  RenderHelper.func_74518_a();
                  GlStateManager.func_179099_b();

--- a/patches/minecraft/net/minecraft/entity/EntityTrackerEntry.java.patch
+++ b/patches/minecraft/net/minecraft/entity/EntityTrackerEntry.java.patch
@@ -1,5 +1,21 @@
 --- ../src-base/minecraft/net/minecraft/entity/EntityTrackerEntry.java
 +++ ../src-work/minecraft/net/minecraft/entity/EntityTrackerEntry.java
+@@ -151,13 +151,13 @@
+ 
+             if (itemstack.func_77973_b() instanceof ItemMap)
+             {
+-                MapData mapdata = Items.field_151098_aY.func_77873_a(itemstack, this.field_73132_a.field_70170_p);
++                MapData mapdata = ((ItemMap)itemstack.func_77973_b()).func_77873_a(itemstack, this.field_73132_a.field_70170_p);
+ 
+                 for (EntityPlayer entityplayer : p_73122_1_)
+                 {
+                     EntityPlayerMP entityplayermp = (EntityPlayerMP)entityplayer;
+                     mapdata.func_76191_a(entityplayermp, itemstack);
+-                    Packet<?> packet = Items.field_151098_aY.func_150911_c(itemstack, this.field_73132_a.field_70170_p, entityplayermp);
++                    Packet<?> packet = ((ItemMap)itemstack.func_77973_b()).func_150911_c(itemstack, this.field_73132_a.field_70170_p, entityplayermp);
+ 
+                     if (packet != null)
+                     {
 @@ -450,6 +450,7 @@
  
                      this.field_73132_a.func_184178_b(p_73117_1_);


### PR DESCRIPTION
The existing renderer calls `Items.FILLED_MAP.getMapData`, which retrieves a `WorldSavedData` of type `MapData`. 

However, custom maps may subclass `MapData`, for example in order to attach extra NBT tags to it. 
For example, twilight forest maze maps are sensitive to the depth they are activated at, and save it in an NBT tag on a `MapData` subclass. This means the maze map has to save to its own WSD, of type `MazeMapData`

This code then, e.g., only retrieves the vanilla pixel data for "map_0" instead of the maze map pixel data for "mazemap_0"

It's fixed by just casting and calling getMapData polymorphically instead of hardcoding `Items.FILLED_MAP`. The item is already checked to be an instance of `ItemMap` before this point in the code.