### PR TITLE
Clean up Logging

### DIFF
--- a/patches/minecraft/net/minecraft/client/renderer/texture/Stitcher.java.patch
+++ b/patches/minecraft/net/minecraft/client/renderer/texture/Stitcher.java.patch
@@ -12,9 +12,9 @@
              if (!this.func_94310_b(stitcher$holder))
              {
                  String s = String.format("Unable to fit: %s - size: %dx%d - Maybe try a lowerresolution resourcepack?", new Object[] {stitcher$holder.func_98150_a().func_94215_i(), Integer.valueOf(stitcher$holder.func_98150_a().func_94211_a()), Integer.valueOf(stitcher$holder.func_98150_a().func_94216_b())});
-+                net.minecraftforge.fml.common.FMLLog.info(s);
++                net.minecraftforge.fml.common.FMLLog.log.info(s);
 +                for (Stitcher.Holder h : astitcher$holder)
-+                    net.minecraftforge.fml.common.FMLLog.info("  %s", h);
++                    net.minecraftforge.fml.common.FMLLog.log.info("  {}", h);
                  throw new StitcherException(stitcher$holder, s);
              }
          }

--- a/patches/minecraft/net/minecraft/client/renderer/texture/TextureMap.java.patch
+++ b/patches/minecraft/net/minecraft/client/renderer/texture/TextureMap.java.patch
@@ -52,7 +52,7 @@
          int j = Integer.MAX_VALUE;
          int k = 1 << this.field_147636_j;
  
-+        net.minecraftforge.fml.common.FMLLog.info("Max texture size: %d", i);
++        net.minecraftforge.fml.common.FMLLog.log.info("Max texture size: {}", i);
 +        net.minecraftforge.fml.common.ProgressManager.ProgressBar bar = net.minecraftforge.fml.common.ProgressManager.push("Texture stitching", skipFirst ? 0 : this.field_110574_e.size());
 +
 +        if(!skipFirst)

--- a/patches/minecraft/net/minecraft/entity/EntityList.java.patch
+++ b/patches/minecraft/net/minecraft/entity/EntityList.java.patch
@@ -91,8 +91,8 @@
 +            }
 +            catch (Exception e)
 +            {
-+                net.minecraftforge.fml.common.FMLLog.log(org.apache.logging.log4j.Level.ERROR, e,
-+                        "An Entity %s(%s) has thrown an exception during loading, its state cannot be restored. Report this to the mod author",
++                net.minecraftforge.fml.common.FMLLog.error(e,
++                        "An Entity {}({}) has thrown an exception during loading, its state cannot be restored. Report this to the mod author",
 +                        p_75615_0_.func_74779_i("id"), entity.func_70005_c_());
 +                entity = null;
 +            }

--- a/patches/minecraft/net/minecraft/entity/EntityList.java.patch
+++ b/patches/minecraft/net/minecraft/entity/EntityList.java.patch
@@ -81,7 +81,7 @@
      }
  
      @Nullable
-@@ -189,7 +203,17 @@
+@@ -189,7 +203,16 @@
          }
          else
          {
@@ -91,15 +91,14 @@
 +            }
 +            catch (Exception e)
 +            {
-+                net.minecraftforge.fml.common.FMLLog.error(e,
-+                        "An Entity {}({}) has thrown an exception during loading, its state cannot be restored. Report this to the mod author",
-+                        p_75615_0_.func_74779_i("id"), entity.func_70005_c_());
++                net.minecraftforge.fml.common.FMLLog.log.error("An Entity {}({}) has thrown an exception during loading, its state cannot be restored. Report this to the mod author",
++                        p_75615_0_.func_74779_i("id"), entity.func_70005_c_(), e);
 +                entity = null;
 +            }
          }
  
          return entity;
-@@ -197,7 +221,7 @@
+@@ -197,7 +220,7 @@
  
      public static Set<ResourceLocation> func_180124_b()
      {
@@ -108,7 +107,7 @@
      }
  
      public static boolean func_180123_a(Entity p_180123_0_, ResourceLocation p_180123_1_)
-@@ -336,7 +360,7 @@
+@@ -336,7 +359,7 @@
          func_191305_a("zombie_horse", 3232308, 9945732);
          func_191305_a("zombie_pigman", 15373203, 5009705);
          func_191305_a("zombie_villager", 5651507, 7969893);
@@ -117,7 +116,7 @@
      }
  
      private static void func_191303_a(int p_191303_0_, String p_191303_1_, Class <? extends Entity > p_191303_2_, String p_191303_3_)
-@@ -357,22 +381,19 @@
+@@ -357,22 +380,19 @@
          else
          {
              ResourceLocation resourcelocation = new ResourceLocation(p_191303_1_);

--- a/patches/minecraft/net/minecraft/item/crafting/FurnaceRecipes.java.patch
+++ b/patches/minecraft/net/minecraft/item/crafting/FurnaceRecipes.java.patch
@@ -4,7 +4,7 @@
  
      public void func_151394_a(ItemStack p_151394_1_, ItemStack p_151394_2_, float p_151394_3_)
      {
-+        if (func_151395_a(p_151394_1_) != ItemStack.field_190927_a) { net.minecraftforge.fml.common.FMLLog.info("Ignored smelting recipe with conflicting input: " + p_151394_1_ + " = " + p_151394_2_); return; }
++        if (func_151395_a(p_151394_1_) != ItemStack.field_190927_a) { net.minecraftforge.fml.common.FMLLog.log.info("Ignored smelting recipe with conflicting input: {} = {}", p_151394_1_, p_151394_2_); return; }
          this.field_77604_b.put(p_151394_1_, p_151394_2_);
          this.field_77605_c.put(p_151394_2_, Float.valueOf(p_151394_3_));
      }

--- a/patches/minecraft/net/minecraft/tileentity/TileEntity.java.patch
+++ b/patches/minecraft/net/minecraft/tileentity/TileEntity.java.patch
@@ -44,27 +44,25 @@
  
              if (oclass != null)
              {
-@@ -103,6 +108,9 @@
+@@ -103,6 +108,8 @@
          catch (Throwable throwable1)
          {
              field_145852_a.error("Failed to create block entity {}", new Object[] {s, throwable1});
-+            net.minecraftforge.fml.common.FMLLog.error(throwable1,
-+                    "A TileEntity {}({}) has thrown an exception during loading, its state cannot be restored. Report this to the mod author",
-+                    s, oclass.getName());
++            net.minecraftforge.fml.common.FMLLog.log.error("A TileEntity {}({}) has thrown an exception during loading, its state cannot be restored. Report this to the mod author",
++                    s, oclass.getName(), throwable1);
          }
  
          if (tileentity != null)
-@@ -115,6 +123,9 @@
+@@ -115,6 +122,8 @@
              catch (Throwable throwable)
              {
                  field_145852_a.error("Failed to load data for block entity {}", new Object[] {s, throwable});
-+                net.minecraftforge.fml.common.FMLLog.error(throwable,
-+                        "A TileEntity {}({}) has thrown an exception during loading, its state cannot be restored. Report this to the mod author",
-+                        s, oclass.getName());
++                net.minecraftforge.fml.common.FMLLog.log.error("A TileEntity {}({}) has thrown an exception during loading, its state cannot be restored. Report this to the mod author",
++                        s, oclass.getName(), throwable);
                  tileentity = null;
              }
          }
-@@ -156,7 +167,6 @@
+@@ -156,7 +165,6 @@
          }
      }
  
@@ -72,7 +70,7 @@
      public double func_145835_a(double p_145835_1_, double p_145835_3_, double p_145835_5_)
      {
          double d0 = (double)this.field_174879_c.func_177958_n() + 0.5D - p_145835_1_;
-@@ -297,6 +307,204 @@
+@@ -297,6 +305,204 @@
      {
      }
  

--- a/patches/minecraft/net/minecraft/tileentity/TileEntity.java.patch
+++ b/patches/minecraft/net/minecraft/tileentity/TileEntity.java.patch
@@ -49,7 +49,7 @@
          {
              field_145852_a.error("Failed to create block entity {}", new Object[] {s, throwable1});
 +            net.minecraftforge.fml.common.FMLLog.log.error("A TileEntity {}({}) has thrown an exception during loading, its state cannot be restored. Report this to the mod author",
-+                    s, oclass.getName(), throwable1);
++                    s, oclass == null ? null : oclass.getName(), throwable1);
          }
  
          if (tileentity != null)

--- a/patches/minecraft/net/minecraft/tileentity/TileEntity.java.patch
+++ b/patches/minecraft/net/minecraft/tileentity/TileEntity.java.patch
@@ -48,8 +48,8 @@
          catch (Throwable throwable1)
          {
              field_145852_a.error("Failed to create block entity {}", new Object[] {s, throwable1});
-+            net.minecraftforge.fml.common.FMLLog.log(org.apache.logging.log4j.Level.ERROR, throwable1,
-+                    "A TileEntity %s(%s) has thrown an exception during loading, its state cannot be restored. Report this to the mod author",
++            net.minecraftforge.fml.common.FMLLog.error(throwable1,
++                    "A TileEntity {}({}) has thrown an exception during loading, its state cannot be restored. Report this to the mod author",
 +                    s, oclass.getName());
          }
  
@@ -58,8 +58,8 @@
              catch (Throwable throwable)
              {
                  field_145852_a.error("Failed to load data for block entity {}", new Object[] {s, throwable});
-+                net.minecraftforge.fml.common.FMLLog.log(org.apache.logging.log4j.Level.ERROR, throwable,
-+                        "A TileEntity %s(%s) has thrown an exception during loading, its state cannot be restored. Report this to the mod author",
++                net.minecraftforge.fml.common.FMLLog.error(throwable,
++                        "A TileEntity {}({}) has thrown an exception during loading, its state cannot be restored. Report this to the mod author",
 +                        s, oclass.getName());
                  tileentity = null;
              }

--- a/patches/minecraft/net/minecraft/util/Session.java.patch
+++ b/patches/minecraft/net/minecraft/util/Session.java.patch
@@ -13,7 +13,7 @@
 +        {
 +            p_i1098_1_ = "MissingName";
 +            p_i1098_2_ = p_i1098_3_ = "NotValid";
-+            org.apache.logging.log4j.Logger logger = net.minecraftforge.fml.common.FMLLog.getLogger();
++            org.apache.logging.log4j.Logger logger = net.minecraftforge.fml.common.FMLLog.log;
 +            logger.log(org.apache.logging.log4j.Level.WARN, "=========================================================");
 +            logger.log(org.apache.logging.log4j.Level.WARN, "WARNING!! the username was not set for this session, typically");
 +            logger.log(org.apache.logging.log4j.Level.WARN, "this means you installed Forge incorrectly. We have set your");

--- a/patches/minecraft/net/minecraft/world/World.java.patch
+++ b/patches/minecraft/net/minecraft/world/World.java.patch
@@ -385,7 +385,7 @@
  
 +                if (net.minecraftforge.common.ForgeModContainer.removeErroringEntities)
 +                {
-+                    net.minecraftforge.fml.common.FMLLog.severe(crashreport.func_71502_e());
++                    net.minecraftforge.fml.common.FMLLog.log.fatal(crashreport.func_71502_e());
 +                    func_72900_e(entity);
 +                }
 +                else
@@ -398,7 +398,7 @@
                      entity2.func_85029_a(crashreportcategory1);
 +                    if (net.minecraftforge.common.ForgeModContainer.removeErroringEntities)
 +                    {
-+                        net.minecraftforge.fml.common.FMLLog.severe(crashreport1.func_71502_e());
++                        net.minecraftforge.fml.common.FMLLog.log.fatal(crashreport1.func_71502_e());
 +                        func_72900_e(entity2);
 +                    }
 +                    else
@@ -425,7 +425,7 @@
                          tileentity.func_145828_a(crashreportcategory2);
 +                        if (net.minecraftforge.common.ForgeModContainer.removeErroringTileEntities)
 +                        {
-+                            net.minecraftforge.fml.common.FMLLog.severe(crashreport2.func_71502_e());
++                            net.minecraftforge.fml.common.FMLLog.log.fatal(crashreport2.func_71502_e());
 +                            tileentity.func_145843_s();
 +                            this.func_175713_t(tileentity.func_174877_v());
 +                        }

--- a/patches/minecraft/net/minecraft/world/chunk/Chunk.java.patch
+++ b/patches/minecraft/net/minecraft/world/chunk/Chunk.java.patch
@@ -310,11 +310,11 @@
 +    private void logCascadingWorldGeneration()
 +    {
 +        net.minecraftforge.fml.common.ModContainer activeModContainer = net.minecraftforge.fml.common.Loader.instance().activeModContainer();
-+        String format = "%s loaded a new chunk (%d, %d  Dimension: %d) during chunk population, causing cascading worldgen lag. Please report this to the mod's issue tracker. This log can be disabled in the Forge config.";
++        String format = "{} loaded a new chunk ({}, {}  Dimension: {}) during chunk population, causing cascading worldgen lag. Please report this to the mod's issue tracker. This log can be disabled in the Forge config.";
 +
 +        if (activeModContainer == null) // vanilla minecraft has problems too (MC-114332), log it at a quieter level.
-+            net.minecraftforge.fml.common.FMLLog.fine(format, "Minecraft", this.field_76635_g, this.field_76647_h, this.field_76637_e.field_73011_w.getDimension());
++            net.minecraftforge.fml.common.FMLLog.log.debug(format, "Minecraft", this.field_76635_g, this.field_76647_h, this.field_76637_e.field_73011_w.getDimension());
 +        else
-+            net.minecraftforge.fml.common.FMLLog.warning(format, activeModContainer.getName(), this.field_76635_g, this.field_76647_h, this.field_76637_e.field_73011_w.getDimension());
++            net.minecraftforge.fml.common.FMLLog.log.warn(format, activeModContainer.getName(), this.field_76635_g, this.field_76647_h, this.field_76637_e.field_73011_w.getDimension());
 +    }
  }

--- a/patches/minecraft/net/minecraft/world/chunk/storage/AnvilChunkLoader.java.patch
+++ b/patches/minecraft/net/minecraft/world/chunk/storage/AnvilChunkLoader.java.patch
@@ -107,7 +107,7 @@
              this.func_75824_a(p_75816_2_.func_76632_l(), nbttagcompound);
          }
          catch (Exception exception)
-@@ -305,11 +366,20 @@
+@@ -305,11 +366,19 @@
              {
                  NBTTagCompound nbttagcompound2 = new NBTTagCompound();
  
@@ -121,14 +121,13 @@
 +                }
 +                catch (Exception e)
 +                {
-+                    net.minecraftforge.fml.common.FMLLog.error(e,
-+                            "An Entity type {} has thrown an exception trying to write state. It will not persist. Report this to the mod author",
-+                            entity.getClass().getName());
++                    net.minecraftforge.fml.common.FMLLog.log.error("An Entity type {} has thrown an exception trying to write state. It will not persist. Report this to the mod author",
++                            entity.getClass().getName(), e);
 +                }
              }
          }
  
-@@ -318,8 +388,17 @@
+@@ -318,8 +387,16 @@
  
          for (TileEntity tileentity : p_75820_1_.func_177434_r().values())
          {
@@ -139,14 +138,13 @@
 +            }
 +            catch (Exception e)
 +            {
-+                net.minecraftforge.fml.common.FMLLog.error(e,
-+                        "A TileEntity type {} has throw an exception trying to write state. It will not persist. Report this to the mod author",
-+                        tileentity.getClass().getName());
++                net.minecraftforge.fml.common.FMLLog.log.error("A TileEntity type {} has throw an exception trying to write state. It will not persist. Report this to the mod author",
++                        tileentity.getClass().getName(), e);
 +            }
          }
  
          p_75820_3_.func_74782_a("TileEntities", nbttaglist2);
-@@ -388,6 +467,12 @@
+@@ -388,6 +465,12 @@
              chunk.func_76616_a(p_75823_2_.func_74770_j("Biomes"));
          }
  
@@ -159,7 +157,7 @@
          NBTTagList nbttaglist1 = p_75823_2_.func_150295_c("Entities", 10);
  
          for (int j1 = 0; j1 < nbttaglist1.func_74745_c(); ++j1)
-@@ -431,8 +516,6 @@
+@@ -431,8 +514,6 @@
                  p_75823_1_.func_180497_b(new BlockPos(nbttagcompound3.func_74762_e("x"), nbttagcompound3.func_74762_e("y"), nbttagcompound3.func_74762_e("z")), block, nbttagcompound3.func_74762_e("t"), nbttagcompound3.func_74762_e("p"));
              }
          }

--- a/patches/minecraft/net/minecraft/world/chunk/storage/AnvilChunkLoader.java.patch
+++ b/patches/minecraft/net/minecraft/world/chunk/storage/AnvilChunkLoader.java.patch
@@ -121,8 +121,8 @@
 +                }
 +                catch (Exception e)
 +                {
-+                    net.minecraftforge.fml.common.FMLLog.log(org.apache.logging.log4j.Level.ERROR, e,
-+                            "An Entity type %s has thrown an exception trying to write state. It will not persist. Report this to the mod author",
++                    net.minecraftforge.fml.common.FMLLog.error(e,
++                            "An Entity type {} has thrown an exception trying to write state. It will not persist. Report this to the mod author",
 +                            entity.getClass().getName());
 +                }
              }
@@ -139,8 +139,8 @@
 +            }
 +            catch (Exception e)
 +            {
-+                net.minecraftforge.fml.common.FMLLog.log(org.apache.logging.log4j.Level.ERROR, e,
-+                        "A TileEntity type %s has throw an exception trying to write state. It will not persist. Report this to the mod author",
++                net.minecraftforge.fml.common.FMLLog.error(e,
++                        "A TileEntity type {} has throw an exception trying to write state. It will not persist. Report this to the mod author",
 +                        tileentity.getClass().getName());
 +            }
          }

--- a/patches/minecraft/net/minecraft/world/gen/ChunkProviderServer.java.patch
+++ b/patches/minecraft/net/minecraft/world/gen/ChunkProviderServer.java.patch
@@ -29,7 +29,7 @@
 +            chunk = net.minecraftforge.common.ForgeChunkManager.fetchDormantChunk(pos, this.field_73251_h);
 +            if (chunk != null || !(this.field_73247_e instanceof net.minecraft.world.chunk.storage.AnvilChunkLoader))
              {
-+                if (!loadingChunks.add(pos)) net.minecraftforge.fml.common.FMLLog.bigWarning("There is an attempt to load a chunk (%d,%d) in dimension %d that is already being loaded. This will cause weird chunk breakages.", p_186028_1_, p_186028_2_, this.field_73251_h.field_73011_w.getDimension());
++                if (!loadingChunks.add(pos)) net.minecraftforge.fml.common.FMLLog.bigWarning("There is an attempt to load a chunk ({},{}) in dimension {} that is already being loaded. This will cause weird chunk breakages.", p_186028_1_, p_186028_2_, this.field_73251_h.field_73011_w.getDimension());
 +                if (chunk == null) chunk = this.func_73239_e(p_186028_1_, p_186028_2_);
 +
 +                if (chunk != null)

--- a/src/main/java/net/minecraftforge/client/ForgeHooksClient.java
+++ b/src/main/java/net/minecraftforge/client/ForgeHooksClient.java
@@ -512,7 +512,7 @@ public class ForgeHooksClient
                 glEnableVertexAttribArray(attr.getIndex());
                 glVertexAttribPointer(attr.getIndex(), count, constant, false, stride, buffer);
             default:
-                FMLLog.severe("Unimplemented vanilla attribute upload: %s", attrType.getDisplayName());
+                FMLLog.log.fatal("Unimplemented vanilla attribute upload: {}", attrType.getDisplayName());
         }
     }
 
@@ -542,7 +542,7 @@ public class ForgeHooksClient
             case GENERIC:
                 glDisableVertexAttribArray(attr.getIndex());
             default:
-                FMLLog.severe("Unimplemented vanilla attribute upload: %s", attrType.getDisplayName());
+                FMLLog.log.fatal("Unimplemented vanilla attribute upload: {}", attrType.getDisplayName());
         }
     }
 

--- a/src/main/java/net/minecraftforge/client/model/ForgeBlockStateV1.java
+++ b/src/main/java/net/minecraftforge/client/model/ForgeBlockStateV1.java
@@ -188,9 +188,9 @@ public class ForgeBlockStateV1 extends Marker
                             String value = v.textures.get(tex.getValue().substring(1));
                             if (value == null)
                             {
-                                FMLLog.severe("Could not resolve texture name \"" + tex.getValue() + "\" for permutation \"" + e.getKey() + "\"");
+                                FMLLog.log.fatal("Could not resolve texture name \"{}\" for permutation \"{}\"", tex.getValue(), e.getKey());
                                 for (Entry<String, String> t: v.textures.entrySet())
-                                    FMLLog.severe(t.getKey() + "=" + t.getValue());
+                                    FMLLog.log.fatal("{}={}", t.getKey(), t.getValue());
                                 throw new JsonParseException("Could not resolve texture name \"" + tex.getValue() + "\" for permutation \"" + e.getKey() + "\"");
                             }
                             v.textures.put(tex.getKey(), value);

--- a/src/main/java/net/minecraftforge/client/model/ModelFluid.java
+++ b/src/main/java/net/minecraftforge/client/model/ModelFluid.java
@@ -418,7 +418,7 @@ public final class ModelFluid implements IModelCustomData
         String fluid = e.getAsString();
         if(!FluidRegistry.isFluidRegistered(fluid))
         {
-            FMLLog.severe("fluid '%s' not found", fluid);
+            FMLLog.log.fatal("fluid '{}' not found", fluid);
             return WATER;
         }
         return new ModelFluid(FluidRegistry.getFluid(fluid));

--- a/src/main/java/net/minecraftforge/client/model/ModelLoader.java
+++ b/src/main/java/net/minecraftforge/client/model/ModelLoader.java
@@ -342,7 +342,7 @@ public final class ModelLoader extends ModelBakery
                 catch(Exception normalException)
                 {
                     // try blockstate json if the item model is missing
-                    FMLLog.fine("Item json isn't found for '" + memory + "', trying to load the variant from the blockstate json");
+                    FMLLog.log.debug("Item json isn't found for '{}', trying to load the variant from the blockstate json", memory);
                     try
                     {
                         model = ModelLoaderRegistry.getModel(memory);
@@ -375,7 +375,7 @@ public final class ModelLoader extends ModelBakery
                 }
                 catch (Exception exception)
                 {
-                    FMLLog.getLogger().error("Could not load the forge bucket model from the blockstate", exception);
+                    FMLLog.log.error("Could not load the forge bucket model from the blockstate", exception);
                     return;
                 }
             }
@@ -1083,17 +1083,17 @@ public final class ModelLoader extends ModelBakery
                         if(entry.getValue() instanceof ItemLoadingException)
                         {
                             ItemLoadingException ex = (ItemLoadingException)entry.getValue();
-                            FMLLog.getLogger().error(errorMsg + ", normal location exception: ", ex.normalException);
-                            FMLLog.getLogger().error(errorMsg + ", blockstate location exception: ", ex.blockstateException);
+                            FMLLog.error(ex.normalException, "{}, normal location exception: ", errorMsg);
+                            FMLLog.error(ex.blockstateException, "{}, blockstate location exception: ", errorMsg);
                         }
                         else
                         {
-                            FMLLog.getLogger().error(errorMsg, entry.getValue());
+                            FMLLog.log.error(errorMsg, entry.getValue());
                         }
                         ResourceLocation blockstateLocation = new ResourceLocation(location.getResourceDomain(), location.getResourcePath());
                         if(loadingExceptions.containsKey(blockstateLocation) && !printedBlockStateErrors.contains(blockstateLocation))
                         {
-                            FMLLog.getLogger().error("Exception loading blockstate for the variant " + location + ": ", loadingExceptions.get(blockstateLocation));
+                            FMLLog.error(loadingExceptions.get(blockstateLocation),"Exception loading blockstate for the variant {}: ", location);
                             printedBlockStateErrors.add(blockstateLocation);
                         }
                     }
@@ -1116,7 +1116,7 @@ public final class ModelLoader extends ModelBakery
                 errorCount++;
                 if(errorCount < verboseMissingInfoCount)
                 {
-                    FMLLog.severe("Model definition for location %s not found", missing);
+                    FMLLog.log.fatal("Model definition for location {} not found", missing);
                 }
                 modelErrors.put(domain, errorCount);
             }
@@ -1129,7 +1129,7 @@ public final class ModelLoader extends ModelBakery
         {
             if(e.getValue() >= verboseMissingInfoCount)
             {
-                FMLLog.severe("Suppressed additional %s model loading errors for domain %s", e.getValue() - verboseMissingInfoCount, e.getKey());
+                FMLLog.log.fatal("Suppressed additional {} model loading errors for domain {}", e.getValue() - verboseMissingInfoCount, e.getKey());
             }
         }
         isLoading = false;

--- a/src/main/java/net/minecraftforge/client/model/ModelLoader.java
+++ b/src/main/java/net/minecraftforge/client/model/ModelLoader.java
@@ -1083,8 +1083,8 @@ public final class ModelLoader extends ModelBakery
                         if(entry.getValue() instanceof ItemLoadingException)
                         {
                             ItemLoadingException ex = (ItemLoadingException)entry.getValue();
-                            FMLLog.error(ex.normalException, "{}, normal location exception: ", errorMsg);
-                            FMLLog.error(ex.blockstateException, "{}, blockstate location exception: ", errorMsg);
+                            FMLLog.log.error("{}, normal location exception: ", errorMsg, ex.normalException);
+                            FMLLog.log.error("{}, blockstate location exception: ", errorMsg, ex.blockstateException);
                         }
                         else
                         {
@@ -1093,7 +1093,7 @@ public final class ModelLoader extends ModelBakery
                         ResourceLocation blockstateLocation = new ResourceLocation(location.getResourceDomain(), location.getResourcePath());
                         if(loadingExceptions.containsKey(blockstateLocation) && !printedBlockStateErrors.contains(blockstateLocation))
                         {
-                            FMLLog.error(loadingExceptions.get(blockstateLocation),"Exception loading blockstate for the variant {}: ", location);
+                            FMLLog.log.error("Exception loading blockstate for the variant {}: ", location, loadingExceptions.get(blockstateLocation));
                             printedBlockStateErrors.add(blockstateLocation);
                         }
                     }

--- a/src/main/java/net/minecraftforge/client/model/ModelLoaderRegistry.java
+++ b/src/main/java/net/minecraftforge/client/model/ModelLoaderRegistry.java
@@ -204,7 +204,7 @@ public class ModelLoaderRegistry
         }
         catch(Exception e)
         {
-            FMLLog.getLogger().error(error, e);
+            FMLLog.log.error(error, e);
             return getMissingModel(location, e);
         }
     }

--- a/src/main/java/net/minecraftforge/client/model/MultiLayerModel.java
+++ b/src/main/java/net/minecraftforge/client/model/MultiLayerModel.java
@@ -134,7 +134,7 @@ public final class MultiLayerModel implements IModelCustomData
         {
             return new ModelResourceLocation(e.getAsString());
         }
-        FMLLog.severe("Expect ModelResourceLocation, got: ", json);
+        FMLLog.log.fatal("Expect ModelResourceLocation, got: {}", json);
         return new ModelResourceLocation("builtin/missing", "missing");
     }
 

--- a/src/main/java/net/minecraftforge/client/model/MultiModel.java
+++ b/src/main/java/net/minecraftforge/client/model/MultiModel.java
@@ -291,7 +291,7 @@ public final class MultiModel implements IModel
 
         if(bakedBase == null && parts.isEmpty())
         {
-            FMLLog.log(Level.ERROR, "MultiModel %s is empty (no base model or parts were provided/resolved)", location);
+            FMLLog.log.error("MultiModel {} is empty (no base model or parts were provided/resolved)", location);
             IModel missing = ModelLoaderRegistry.getMissingModel();
             return missing.bake(missing.getDefaultState(), format, bakedTextureGetter);
         }

--- a/src/main/java/net/minecraftforge/client/model/animation/ModelBlockAnimation.java
+++ b/src/main/java/net/minecraftforge/client/model/animation/ModelBlockAnimation.java
@@ -572,12 +572,12 @@ public class ModelBlockAnimation
         }
         catch(IOException e)
         {
-            FMLLog.error(e, "Exception loading vanilla model animation {}, skipping", armatureLocation);
+            FMLLog.log.error("Exception loading vanilla model animation {}, skipping", armatureLocation, e);
             return defaultModelBlockAnimation;
         }
         catch(JsonParseException e)
         {
-            FMLLog.error(e, "Exception loading vanilla model animation {}, skipping", armatureLocation);
+            FMLLog.log.error("Exception loading vanilla model animation {}, skipping", armatureLocation, e);
             return defaultModelBlockAnimation;
         }
     }

--- a/src/main/java/net/minecraftforge/client/model/animation/ModelBlockAnimation.java
+++ b/src/main/java/net/minecraftforge/client/model/animation/ModelBlockAnimation.java
@@ -572,12 +572,12 @@ public class ModelBlockAnimation
         }
         catch(IOException e)
         {
-            FMLLog.log(Level.ERROR, e, "Exception loading vanilla model animation %s, skipping", armatureLocation);
+            FMLLog.error(e, "Exception loading vanilla model animation {}, skipping", armatureLocation);
             return defaultModelBlockAnimation;
         }
         catch(JsonParseException e)
         {
-            FMLLog.log(Level.ERROR, e, "Exception loading vanilla model animation %s, skipping", armatureLocation);
+            FMLLog.error(e, "Exception loading vanilla model animation {}, skipping", armatureLocation);
             return defaultModelBlockAnimation;
         }
     }

--- a/src/main/java/net/minecraftforge/client/model/b3d/B3DLoader.java
+++ b/src/main/java/net/minecraftforge/client/model/b3d/B3DLoader.java
@@ -496,7 +496,7 @@ public enum B3DLoader implements ICustomModelLoader
             {
                 if(e.getValue().getResourcePath().startsWith("#"))
                 {
-                    FMLLog.severe("unresolved texture '%s' for b3d model '%s'", e.getValue().getResourcePath(), modelLocation);
+                    FMLLog.log.fatal("unresolved texture '{}' for b3d model '{}'", e.getValue().getResourcePath(), modelLocation);
                     builder.put(e.getKey(), missing);
                 }
                 else
@@ -551,7 +551,7 @@ public enum B3DLoader implements ICustomModelLoader
                         }
                         else
                         {
-                            FMLLog.severe("unknown mesh definition '%s' in array for b3d model '%s'", s.toString(), modelLocation);
+                            FMLLog.log.fatal("unknown mesh definition '{}' in array for b3d model '{}'", s.toString(), modelLocation);
                             return this;
                         }
                     }
@@ -559,7 +559,7 @@ public enum B3DLoader implements ICustomModelLoader
                 }
                 else
                 {
-                    FMLLog.severe("unknown mesh definition '%s' for b3d model '%s'", e.toString(), modelLocation);
+                    FMLLog.log.fatal("unknown mesh definition '{}' for b3d model '{}'", e.toString(), modelLocation);
                     return this;
                 }
             }
@@ -572,7 +572,7 @@ public enum B3DLoader implements ICustomModelLoader
                 }
                 else
                 {
-                    FMLLog.severe("unknown keyframe definition '%s' for b3d model '%s'", e.toString(), modelLocation);
+                    FMLLog.log.fatal("unknown keyframe definition '{}' for b3d model '{}'", e.toString(), modelLocation);
                     return this;
                 }
             }

--- a/src/main/java/net/minecraftforge/client/model/b3d/B3DModel.java
+++ b/src/main/java/net/minecraftforge/client/model/b3d/B3DModel.java
@@ -139,7 +139,7 @@ public class B3DModel
         {
             if(texture > textures.size())
             {
-                logger.error(String.format("texture %s is out of range", texture));
+                logger.error("texture {} is out of range", texture);
                 return null;
             }
             else if(texture == -1) return Texture.White;
@@ -152,7 +152,7 @@ public class B3DModel
         {
             if(brush > brushes.size())
             {
-                logger.error(String.format("brush %s is out of range", brush));
+                logger.error("brush {} is out of range", brush);
                 return null;
             }
             else if(brush == -1) return null;
@@ -165,7 +165,7 @@ public class B3DModel
         {
             if(vertex > vertices.size())
             {
-                logger.error(String.format("vertex %s is out of range", vertex));
+                logger.error("vertex {} is out of range", vertex);
                 return null;
             }
             return vertices.get(vertex);
@@ -408,17 +408,17 @@ public class B3DModel
                 {
                     if(pos != null)
                     {
-                        if(oldKey.getPos() != null) logger.error("Duplicate keys: %s and %s (ignored)", oldKey, key);
+                        if(oldKey.getPos() != null) logger.error("Duplicate keys: {} and {} (ignored)", oldKey, key);
                         else key = new Key(oldKey.getPos(), key.getScale(), key.getRot());
                     }
                     if(scale != null)
                     {
-                        if(oldKey.getScale() != null) logger.error("Duplicate keys: %s and %s (ignored)", oldKey, key);
+                        if(oldKey.getScale() != null) logger.error("Duplicate keys: {} and {} (ignored)", oldKey, key);
                         else key = new Key(key.getPos(), oldKey.getScale(), key.getRot());
                     }
                     if(rot != null)
                     {
-                        if(oldKey.getRot() != null) logger.error("Duplicate keys: %s and %s (ignored)", oldKey, key);
+                        if(oldKey.getRot() != null) logger.error("Duplicate keys: {} and {} (ignored)", oldKey, key);
                         else key = new Key(key.getPos(), key.getScale(), oldKey.getRot());
                     }
                 }

--- a/src/main/java/net/minecraftforge/client/model/obj/OBJLoader.java
+++ b/src/main/java/net/minecraftforge/client/model/obj/OBJLoader.java
@@ -51,7 +51,7 @@ public enum OBJLoader implements ICustomModelLoader {
     public void addDomain(String domain)
     {
         enabledDomains.add(domain.toLowerCase());
-        FMLLog.log(Level.INFO, "OBJLoader: Domain %s has been added.", domain.toLowerCase());
+        FMLLog.log.info("OBJLoader: Domain {} has been added.", domain.toLowerCase());
     }
 
     public void onResourceManagerReload(IResourceManager resourceManager)

--- a/src/main/java/net/minecraftforge/client/model/obj/OBJModel.java
+++ b/src/main/java/net/minecraftforge/client/model/obj/OBJModel.java
@@ -128,7 +128,7 @@ public class OBJModel implements IRetexturableModel, IModelCustomData
         {
             if (e.getValue().getTexture().getTextureLocation().getResourcePath().startsWith("#"))
             {
-                FMLLog.severe("OBJLoader: Unresolved texture '%s' for obj model '%s'", e.getValue().getTexture().getTextureLocation().getResourcePath(), modelLocation);
+                FMLLog.log.fatal("OBJLoader: Unresolved texture '{}' for obj model '{}'", e.getValue().getTexture().getTextureLocation().getResourcePath(), modelLocation);
                 builder.put(e.getKey(), missing);
             }
             else
@@ -285,7 +285,7 @@ public class OBJModel implements IRetexturableModel, IModelCustomData
                     else if (key.equalsIgnoreCase("f")) // Face Elements: f v1[/vt1][/vn1] ...
                     {
                         if (splitData.length > 4)
-                            FMLLog.warning("OBJModel.Parser: found a face ('f') with more than 4 vertices, only the first 4 of these vertices will be rendered!");
+                            FMLLog.log.warn("OBJModel.Parser: found a face ('f') with more than 4 vertices, only the first 4 of these vertices will be rendered!");
 
                         List<Vertex> v = Lists.newArrayListWithCapacity(splitData.length);
 
@@ -368,7 +368,7 @@ public class OBJModel implements IRetexturableModel, IModelCustomData
                         if (!unknownObjectCommands.contains(key))
                         {
                             unknownObjectCommands.add(key);
-                            FMLLog.info("OBJLoader.Parser: command '%s' (model: '%s') is not currently supported, skipping. Line: %d '%s'", key, objFrom, lineNum, currentLine);
+                            FMLLog.log.info("OBJLoader.Parser: command '{}' (model: '{}') is not currently supported, skipping. Line: {} '{}'", key, objFrom, lineNum, currentLine);
                         }
                     }
                 }
@@ -545,7 +545,7 @@ public class OBJModel implements IRetexturableModel, IModelCustomData
                     }
                     else
                     {
-                        FMLLog.info("OBJModel: A color has already been defined for material '%s' in '%s'. The color defined by key '%s' will not be applied!", material.getName(), new ResourceLocation(domain, path).toString(), key);
+                        FMLLog.log.info("OBJModel: A color has already been defined for material '{}' in '{}'. The color defined by key '{}' will not be applied!", material.getName(), new ResourceLocation(domain, path).toString(), key);
                     }
                 }
                 else if (key.equalsIgnoreCase("map_Ka") || key.equalsIgnoreCase("map_Kd") || key.equalsIgnoreCase("map_Ks"))
@@ -569,7 +569,7 @@ public class OBJModel implements IRetexturableModel, IModelCustomData
                     }
                     else
                     {
-                        FMLLog.info("OBJModel: A texture has already been defined for material '%s' in '%s'. The texture defined by key '%s' will not be applied!", material.getName(), new ResourceLocation(domain, path).toString(), key);
+                        FMLLog.log.info("OBJModel: A texture has already been defined for material '{}' in '{}'. The texture defined by key '{}' will not be applied!", material.getName(), new ResourceLocation(domain, path).toString(), key);
                     }
                 }
                 else if (key.equalsIgnoreCase("d") || key.equalsIgnoreCase("Tr"))
@@ -585,7 +585,7 @@ public class OBJModel implements IRetexturableModel, IModelCustomData
                     if (!unknownMaterialCommands.contains(key))
                     {
                         unknownMaterialCommands.add(key);
-                        FMLLog.info("OBJLoader.MaterialLibrary: key '%s' (model: '%s') is not currently supported, skipping", key, new ResourceLocation(domain, path));
+                        FMLLog.log.info("OBJLoader.MaterialLibrary: key '{}' (model: '{}') is not currently supported, skipping", key, new ResourceLocation(domain, path));
                     }
                 }
             }

--- a/src/main/java/net/minecraftforge/common/BiomeDictionary.java
+++ b/src/main/java/net/minecraftforge/common/BiomeDictionary.java
@@ -373,7 +373,7 @@ public class BiomeDictionary
         if (!hasAnyType(biome))
         {
             makeBestGuess(biome);
-            FMLLog.warning("No types have been added to Biome %s, types have been assigned on a best-effort guess: %s", biome.getRegistryName(), getTypes(biome));
+            FMLLog.log.warn("No types have been added to Biome {}, types have been assigned on a best-effort guess: {}", biome.getRegistryName(), getTypes(biome));
         }
     }
 

--- a/src/main/java/net/minecraftforge/common/DimensionManager.java
+++ b/src/main/java/net/minecraftforge/common/DimensionManager.java
@@ -169,11 +169,11 @@ public class DimensionManager
                 int leakCount = leakedWorlds.count(System.identityHashCode(w));
                 if (leakCount == 5)
                 {
-                    FMLLog.fine("The world %x (%s) may have leaked: first encounter (5 occurrences).\n", System.identityHashCode(w), w.getWorldInfo().getWorldName());
+                    FMLLog.log.debug("The world {} ({}) may have leaked: first encounter (5 occurrences).\n", Integer.toHexString(System.identityHashCode(w)), w.getWorldInfo().getWorldName());
                 }
                 else if (leakCount % 5 == 0)
                 {
-                    FMLLog.fine("The world %x (%s) may have leaked: seen %d times.\n", System.identityHashCode(w), w.getWorldInfo().getWorldName(), leakCount);
+                    FMLLog.log.debug("The world {} ({}) may have leaked: seen {} times.\n", Integer.toHexString(System.identityHashCode(w)), w.getWorldInfo().getWorldName(), leakCount);
                 }
             }
         }
@@ -191,13 +191,13 @@ public class DimensionManager
             worlds.put(id, world);
             weakWorldMap.put(world, world);
             server.worldTickTimes.put(id, new long[100]);
-            FMLLog.info("Loading dimension %d (%s) (%s)", id, world.getWorldInfo().getWorldName(), world.getMinecraftServer());
+            FMLLog.log.info("Loading dimension {} ({}) ({})", id, world.getWorldInfo().getWorldName(), world.getMinecraftServer());
         }
         else
         {
             worlds.remove(id);
             server.worldTickTimes.remove(id);
-            FMLLog.info("Unloading dimension %d", id);
+            FMLLog.log.info("Unloading dimension {}", id);
         }
 
         ArrayList<WorldServer> tmp = new ArrayList<WorldServer>();
@@ -292,8 +292,8 @@ public class DimensionManager
         }
         catch (Exception e)
         {
-            FMLCommonHandler.instance().getFMLLogger().log(Level.ERROR, String.format("An error occurred trying to create an instance of WorldProvider %d (%s)",
-                    dim, getProviderType(dim)),e);
+            FMLLog.error(e, "An error occurred trying to create an instance of WorldProvider {} ({})",
+                    dim, getProviderType(dim));
             throw new RuntimeException(e);
         }
     }
@@ -307,7 +307,7 @@ public class DimensionManager
     {
         if(!unloadQueue.contains(id))
         {
-            FMLLog.fine("Queueing dimension %s to unload", id);
+            FMLLog.log.debug("Queueing dimension {} to unload", id);
             unloadQueue.add(id);
         }
         else
@@ -339,7 +339,7 @@ public class DimensionManager
             dimension.ticksWaited = 0;
             if (w == null || !ForgeChunkManager.getPersistentChunksFor(w).isEmpty() || !w.playerEntities.isEmpty() || dimension.type.shouldLoadSpawn()) //Don't unload the world if the status changed
             {
-                FMLLog.fine("Aborting unload for dimension %s as status changed", id);
+                FMLLog.log.debug("Aborting unload for dimension {} as status changed", id);
                 continue;
             }
             try

--- a/src/main/java/net/minecraftforge/common/DimensionManager.java
+++ b/src/main/java/net/minecraftforge/common/DimensionManager.java
@@ -292,8 +292,8 @@ public class DimensionManager
         }
         catch (Exception e)
         {
-            FMLLog.error(e, "An error occurred trying to create an instance of WorldProvider {} ({})",
-                    dim, getProviderType(dim));
+            FMLLog.log.error("An error occurred trying to create an instance of WorldProvider {} ({})",
+                    dim, getProviderType(dim), e);
             throw new RuntimeException(e);
         }
     }

--- a/src/main/java/net/minecraftforge/common/ForgeChunkManager.java
+++ b/src/main/java/net/minecraftforge/common/ForgeChunkManager.java
@@ -263,7 +263,7 @@ public class ForgeChunkManager
             }
             else
             {
-                FMLLog.log(Level.ERROR, "Attempt to create a player ticket without a valid player");
+                FMLLog.log.error("Attempt to create a player ticket without a valid player");
                 throw new RuntimeException();
             }
         }
@@ -277,7 +277,7 @@ public class ForgeChunkManager
         {
             if (depth > getMaxChunkDepthFor(modId) || (depth <= 0 && getMaxChunkDepthFor(modId) > 0))
             {
-                FMLLog.warning("The mod %s tried to modify the chunk ticket depth to: %d, its allowed maximum is: %d", modId, depth, getMaxChunkDepthFor(modId));
+                FMLLog.log.warn("The mod {} tried to modify the chunk ticket depth to: {}, its allowed maximum is: {}", modId, depth, getMaxChunkDepthFor(modId));
             }
             else
             {
@@ -489,7 +489,7 @@ public class ForgeChunkManager
             }
             catch (IOException e)
             {
-                FMLLog.log(Level.WARN, e, "Unable to read forced chunk data at %s - it will be ignored", chunkLoaderData.getAbsolutePath());
+                FMLLog.warn(e, "Unable to read forced chunk data at {} - it will be ignored", chunkLoaderData.getAbsolutePath());
                 return;
             }
             NBTTagList ticketList = forcedChunkData.getTagList("TicketList", Constants.NBT.TAG_COMPOUND);
@@ -501,13 +501,13 @@ public class ForgeChunkManager
 
                 if (!isPlayer && !Loader.isModLoaded(modId))
                 {
-                    FMLLog.warning("Found chunkloading data for mod %s which is currently not available or active - it will be removed from the world save", modId);
+                    FMLLog.log.warn("Found chunkloading data for mod {} which is currently not available or active - it will be removed from the world save", modId);
                     continue;
                 }
 
                 if (!isPlayer && !callbacks.containsKey(modId))
                 {
-                    FMLLog.warning("The mod %s has registered persistent chunkloading data but doesn't seem to want to be called back with it - it will be removed from the world save", modId);
+                    FMLLog.log.warn("The mod {} has registered persistent chunkloading data but doesn't seem to want to be called back with it - it will be removed from the world save", modId);
                     continue;
                 }
 
@@ -561,7 +561,7 @@ public class ForgeChunkManager
             {
                 if (tick.ticketType == Type.ENTITY && tick.entity == null)
                 {
-                    FMLLog.warning("Failed to load persistent chunkloading entity %s from store.", pendingEntities.inverse().get(tick));
+                    FMLLog.log.warn("Failed to load persistent chunkloading entity {} from store.", pendingEntities.inverse().get(tick));
                     loadedTickets.remove(tick.modId, tick);
                 }
             }
@@ -583,7 +583,7 @@ public class ForgeChunkManager
                 }
                 if (tickets.size() > maxTicketLength)
                 {
-                    FMLLog.warning("The mod %s has too many open chunkloading tickets %d. Excess will be dropped", modId, tickets.size());
+                    FMLLog.log.warn("The mod {} has too many open chunkloading tickets {}. Excess will be dropped", modId, tickets.size());
                     tickets.subList(maxTicketLength, tickets.size()).clear();
                 }
                 ForgeChunkManager.tickets.get(world).putAll(modId, tickets);
@@ -641,7 +641,7 @@ public class ForgeChunkManager
         ModContainer container = getContainer(mod);
         if (container == null)
         {
-            FMLLog.warning("Unable to register a callback for an unknown mod %s (%s : %x)", mod, mod.getClass().getName(), System.identityHashCode(mod));
+            FMLLog.log.warn("Unable to register a callback for an unknown mod {} ({} : {})", mod, mod.getClass().getName(), Integer.toHexString(System.identityHashCode(mod)));
             return;
         }
 
@@ -699,12 +699,12 @@ public class ForgeChunkManager
         ModContainer mc = getContainer(mod);
         if (mc == null)
         {
-            FMLLog.log(Level.ERROR, "Failed to locate the container for mod instance %s (%s : %x)", mod, mod.getClass().getName(), System.identityHashCode(mod));
+            FMLLog.log.error("Failed to locate the container for mod instance {} ({} : {})", mod, mod.getClass().getName(), Integer.toHexString(System.identityHashCode(mod)));
             return null;
         }
         if (playerTickets.get(player).size()>playerTicketLength)
         {
-            FMLLog.warning("Unable to assign further chunkloading tickets to player %s (on behalf of mod %s)", player, mc.getModId());
+            FMLLog.log.warn("Unable to assign further chunkloading tickets to player {} (on behalf of mod {})", player, mc.getModId());
             return null;
         }
         Ticket ticket = new Ticket(mc.getModId(),type,world,player);
@@ -726,13 +726,13 @@ public class ForgeChunkManager
         ModContainer container = getContainer(mod);
         if (container == null)
         {
-            FMLLog.log(Level.ERROR, "Failed to locate the container for mod instance %s (%s : %x)", mod, mod.getClass().getName(), System.identityHashCode(mod));
+            FMLLog.log.error("Failed to locate the container for mod instance {} ({} : {})", mod, mod.getClass().getName(), Integer.toHexString(System.identityHashCode(mod)));
             return null;
         }
         String modId = container.getModId();
         if (!callbacks.containsKey(modId))
         {
-            FMLLog.severe("The mod %s has attempted to request a ticket without a listener in place", modId);
+            FMLLog.log.fatal("The mod {} has attempted to request a ticket without a listener in place", modId);
             throw new RuntimeException("Invalid ticket request");
         }
 
@@ -742,7 +742,7 @@ public class ForgeChunkManager
         {
             if (!warnedMods.contains(modId))
             {
-                FMLLog.info("The mod %s has attempted to allocate a chunkloading ticket beyond it's currently allocated maximum : %d", modId, allowedCount);
+                FMLLog.log.info("The mod {} has attempted to allocate a chunkloading ticket beyond it's currently allocated maximum: {}", modId, allowedCount);
                 warnedMods.add(modId);
             }
             return null;
@@ -806,7 +806,7 @@ public class ForgeChunkManager
         }
         if (ticket.isPlayerTicket() ? !playerTickets.containsValue(ticket) : !tickets.get(ticket.world).containsEntry(ticket.modId, ticket))
         {
-            FMLLog.severe("The mod %s attempted to force load a chunk with an invalid ticket. This is not permitted.", ticket.modId);
+            FMLLog.log.fatal("The mod {} attempted to force load a chunk with an invalid ticket. This is not permitted.", ticket.modId);
             return;
         }
         ticket.requestedChunks.add(chunk);
@@ -949,7 +949,7 @@ public class ForgeChunkManager
         }
         catch (IOException e)
         {
-            FMLLog.log(Level.WARN, e, "Unable to write forced chunk data to %s - chunkloading won't work", chunkLoaderData.getAbsolutePath());
+            FMLLog.warn(e, "Unable to write forced chunk data to {} - chunkloading won't work", chunkLoaderData.getAbsolutePath());
             return;
         }
     }
@@ -1015,7 +1015,7 @@ public class ForgeChunkManager
                 dest.delete();
             }
             cfgFile.renameTo(dest);
-            FMLLog.log(Level.ERROR, e, "A critical error occurred reading the forgeChunkLoading.cfg file, defaults will be used - the invalid file is backed up at forgeChunkLoading.cfg.bak");
+            FMLLog.error(e, "A critical error occurred reading the forgeChunkLoading.cfg file, defaults will be used - the invalid file is backed up at forgeChunkLoading.cfg.bak");
         }
         syncConfigDefaults();
     }
@@ -1068,7 +1068,7 @@ public class ForgeChunkManager
         temp.setMinValue(0);
         dormantChunkCacheSize = temp.getInt(0);
         propOrder.add("dormantChunkCacheSize");
-        FMLLog.info("Configured a dormant chunk cache size of %d", temp.getInt(0));
+        FMLLog.log.info("Configured a dormant chunk cache size of {}", temp.getInt(0));
 
         config.setCategoryPropertyOrder("defaults", propOrder);
 

--- a/src/main/java/net/minecraftforge/common/ForgeChunkManager.java
+++ b/src/main/java/net/minecraftforge/common/ForgeChunkManager.java
@@ -489,7 +489,7 @@ public class ForgeChunkManager
             }
             catch (IOException e)
             {
-                FMLLog.warn(e, "Unable to read forced chunk data at {} - it will be ignored", chunkLoaderData.getAbsolutePath());
+                FMLLog.log.warn("Unable to read forced chunk data at {} - it will be ignored", chunkLoaderData.getAbsolutePath(), e);
                 return;
             }
             NBTTagList ticketList = forcedChunkData.getTagList("TicketList", Constants.NBT.TAG_COMPOUND);
@@ -949,7 +949,7 @@ public class ForgeChunkManager
         }
         catch (IOException e)
         {
-            FMLLog.warn(e, "Unable to write forced chunk data to {} - chunkloading won't work", chunkLoaderData.getAbsolutePath());
+            FMLLog.log.warn("Unable to write forced chunk data to {} - chunkloading won't work", chunkLoaderData.getAbsolutePath(), e);
             return;
         }
     }
@@ -1015,7 +1015,7 @@ public class ForgeChunkManager
                 dest.delete();
             }
             cfgFile.renameTo(dest);
-            FMLLog.error(e, "A critical error occurred reading the forgeChunkLoading.cfg file, defaults will be used - the invalid file is backed up at forgeChunkLoading.cfg.bak");
+            FMLLog.log.error("A critical error occurred reading the forgeChunkLoading.cfg file, defaults will be used - the invalid file is backed up at forgeChunkLoading.cfg.bak", e);
         }
         syncConfigDefaults();
     }

--- a/src/main/java/net/minecraftforge/common/ForgeModContainer.java
+++ b/src/main/java/net/minecraftforge/common/ForgeModContainer.java
@@ -427,7 +427,7 @@ public class ForgeModContainer extends DummyModContainer implements WorldAccessC
         Collections.sort(all); //Sort it because I like pretty output ;)
         for (String name : all)
         {
-            log.debug("\t" + name);
+            log.debug("\t{}", name);
             try
             {
                 Class.forName(name.replace('/', '.'), false, MinecraftForge.class.getClassLoader());

--- a/src/main/java/net/minecraftforge/common/ForgeModContainer.java
+++ b/src/main/java/net/minecraftforge/common/ForgeModContainer.java
@@ -42,6 +42,8 @@ import java.util.List;
 import java.util.Map;
 
 import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import net.minecraft.crash.ICrashReportDetail;
 import net.minecraft.nbt.NBTBase;
@@ -118,6 +120,8 @@ public class ForgeModContainer extends DummyModContainer implements WorldAccessC
     public static boolean alwaysSetupTerrainOffThread = false; // In RenderGlobal.setupTerrain, always force the chunk render updates to be queued to the thread
     public static int dimensionUnloadQueueDelay = 0;
     public static boolean logCascadingWorldGeneration = true; // see Chunk#logCascadingWorldGeneration()
+
+    static final Logger log = LogManager.getLogger(ForgeVersion.MOD_ID);
 
     private static Configuration config;
     private static ForgeModContainer INSTANCE;
@@ -232,7 +236,7 @@ public class ForgeModContainer extends DummyModContainer implements WorldAccessC
 
         if (removeErroringEntities)
         {
-            FMLLog.warning("Enabling removal of erroring Entities - USE AT YOUR OWN RISK");
+            FMLLog.log.warn("Enabling removal of erroring Entities - USE AT YOUR OWN RISK");
         }
 
         prop = config.get(Configuration.CATEGORY_GENERAL, "removeErroringTileEntities", false);
@@ -243,7 +247,7 @@ public class ForgeModContainer extends DummyModContainer implements WorldAccessC
 
         if (removeErroringTileEntities)
         {
-            FMLLog.warning("Enabling removal of erroring Tile Entities - USE AT YOUR OWN RISK");
+            FMLLog.log.warn("Enabling removal of erroring Tile Entities - USE AT YOUR OWN RISK");
         }
 
         prop = config.get(Configuration.CATEGORY_GENERAL, "fullBoundingBoxLadders", false);
@@ -419,11 +423,11 @@ public class ForgeModContainer extends DummyModContainer implements WorldAccessC
                 itr.remove();
         }
 
-        FMLLog.log(ForgeVersion.MOD_ID, Level.DEBUG, "Preloading CrashReport Classes");
+        log.debug("Preloading CrashReport Classes");
         Collections.sort(all); //Sort it because I like pretty output ;)
         for (String name : all)
         {
-            FMLLog.log(ForgeVersion.MOD_ID, Level.DEBUG, "\t" + name);
+            log.debug("\t" + name);
             try
             {
                 Class.forName(name.replace('/', '.'), false, MinecraftForge.class.getClassLoader());

--- a/src/main/java/net/minecraftforge/common/ForgeVersion.java
+++ b/src/main/java/net/minecraftforge/common/ForgeVersion.java
@@ -37,6 +37,8 @@ import java.util.Map.Entry;
 import java.util.concurrent.ConcurrentHashMap;
 
 import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import com.google.common.io.ByteStreams;
 import com.google.gson.Gson;
@@ -69,6 +71,8 @@ public class ForgeVersion
     private static Status status = PENDING;
     @SuppressWarnings("unused")
     private static String target = null;
+
+    private static final Logger log = LogManager.getLogger("ForgeVersionCheck");
 
     public static int getMajorVersion()
     {
@@ -186,7 +190,7 @@ public class ForgeVersion
             {
                 if (!ForgeModContainer.getConfig().get(ForgeModContainer.VERSION_CHECK_CAT, "Global", true).getBoolean())
                 {
-                    FMLLog.log("ForgeVersionCheck", Level.INFO, "Global Forge version check system disabled, no further processing.");
+                    log.info("Global Forge version check system disabled, no further processing.");
                     return;
                 }
 
@@ -199,7 +203,7 @@ public class ForgeVersion
                     }
                     else
                     {
-                        FMLLog.log("ForgeVersionCheck", Level.INFO, "[%s] Skipped version check", mod.getModId());
+                        log.info("[{}] Skipped version check", mod.getModId());
                     }
                 }
             }
@@ -208,7 +212,7 @@ public class ForgeVersion
             {
                 try
                 {
-                    FMLLog.log("ForgeVersionCheck", Level.INFO, "[%s] Starting version check at %s", mod.getModId(), url.toString());
+                    log.info("[{}] Starting version check at {}", mod.getModId(), url.toString());
                     Status status = PENDING;
                     ComparableVersion target = null;
 
@@ -216,7 +220,7 @@ public class ForgeVersion
                     String data = new String(ByteStreams.toByteArray(con), "UTF-8");
                     con.close();
 
-                    FMLLog.log("ForgeVersionCheck", Level.DEBUG, "[%s] Received version check data:\n%s", mod.getModId(), data);
+                    log.debug("[{}] Received version check data:\n{}", mod.getModId(), data);
 
 
                     @SuppressWarnings("unchecked")
@@ -269,7 +273,7 @@ public class ForgeVersion
                     else
                         status = BETA;
 
-                    FMLLog.log("ForgeVersionCheck", Level.INFO, "[%s] Found status: %s Target: %s", mod.getModId(), status, target);
+                    log.info("[{}] Found status: {} Target: {}", mod.getModId(), status, target);
 
                     Map<ComparableVersion, String> changes = new LinkedHashMap<ComparableVersion, String>();
                     @SuppressWarnings("unchecked")
@@ -298,7 +302,7 @@ public class ForgeVersion
                 }
                 catch (Exception e)
                 {
-                    FMLLog.log("ForgeVersionCheck", Level.DEBUG, e, "Failed to process update information");
+                    log.debug("Failed to process update information", e);
                     status = FAILED;
                 }
             }

--- a/src/main/java/net/minecraftforge/common/MinecraftForge.java
+++ b/src/main/java/net/minecraftforge/common/MinecraftForge.java
@@ -83,7 +83,7 @@ public class MinecraftForge
     */
    public static void initialize()
    {
-       FMLLog.info("MinecraftForge v%s Initialized", ForgeVersion.getVersion());
+       FMLLog.log.info("MinecraftForge v{} Initialized", ForgeVersion.getVersion());
 
        OreDictionary.getOreName(0);
 
@@ -113,11 +113,11 @@ public class MinecraftForge
        if (all.size() == 0)
         return;
 
-       FMLLog.log(modID, Level.DEBUG, "Preloading CrashReport Classes");
+       ForgeModContainer.log.debug("Preloading CrashReport Classes");
        Collections.sort(all); //Sort it because I like pretty output ;)
        for (String name : all)
        {
-           FMLLog.log(modID, Level.DEBUG, "\t" + name);
+           ForgeModContainer.log.debug("\t" + name);
            try
            {
                Class.forName(name.replace('/', '.'), false, MinecraftForge.class.getClassLoader());

--- a/src/main/java/net/minecraftforge/common/MinecraftForge.java
+++ b/src/main/java/net/minecraftforge/common/MinecraftForge.java
@@ -117,7 +117,7 @@ public class MinecraftForge
        Collections.sort(all); //Sort it because I like pretty output ;)
        for (String name : all)
        {
-           ForgeModContainer.log.debug("\t" + name);
+           ForgeModContainer.log.debug("\t{}", name);
            try
            {
                Class.forName(name.replace('/', '.'), false, MinecraftForge.class.getClassLoader());

--- a/src/main/java/net/minecraftforge/common/WorldSpecificSaveHandler.java
+++ b/src/main/java/net/minecraftforge/common/WorldSpecificSaveHandler.java
@@ -95,7 +95,7 @@ public class WorldSpecificSaveHandler implements ISaveHandler
             }
             catch (IOException e)
             {
-                FMLLog.log(Level.ERROR, e, "A critical error occurred copying %s to world specific dat folder - new file will be created.", parentFile.getName());
+                FMLLog.error(e, "A critical error occurred copying {} to world specific dat folder - new file will be created.", parentFile.getName());
             }
         }
     }

--- a/src/main/java/net/minecraftforge/common/WorldSpecificSaveHandler.java
+++ b/src/main/java/net/minecraftforge/common/WorldSpecificSaveHandler.java
@@ -95,7 +95,7 @@ public class WorldSpecificSaveHandler implements ISaveHandler
             }
             catch (IOException e)
             {
-                FMLLog.error(e, "A critical error occurred copying {} to world specific dat folder - new file will be created.", parentFile.getName());
+                FMLLog.log.error("A critical error occurred copying {} to world specific dat folder - new file will be created.", parentFile.getName(), e);
             }
         }
     }

--- a/src/main/java/net/minecraftforge/common/capabilities/CapabilityManager.java
+++ b/src/main/java/net/minecraftforge/common/capabilities/CapabilityManager.java
@@ -155,7 +155,7 @@ public enum CapabilityManager
                         }
                         catch (Exception e)
                         {
-                            FMLLog.warn(e, "Unable to inject capability {} at {}.{}", capabilityName, targetClass, targetName);
+                            FMLLog.log.warn("Unable to inject capability {} at {}.{}", capabilityName, targetClass, targetName, e);
                         }
                         return null;
                     }
@@ -180,7 +180,7 @@ public enum CapabilityManager
                         }
                         catch (Exception e)
                         {
-                            FMLLog.warn(e, "Unable to inject capability {} at {}.{}", capabilityName, targetClass, targetName);
+                            FMLLog.log.warn("Unable to inject capability {} at {}.{}", capabilityName, targetClass, targetName, e);
                         }
                         return null;
                     }

--- a/src/main/java/net/minecraftforge/common/capabilities/CapabilityManager.java
+++ b/src/main/java/net/minecraftforge/common/capabilities/CapabilityManager.java
@@ -115,7 +115,7 @@ public enum CapabilityManager
             Type type = (Type)entry.getAnnotationInfo().get("value");
             if (type == null)
             {
-                FMLLog.log(Level.WARN, "Unable to inject capability at %s.%s (Invalid Annotation)", targetClass, targetName);
+                FMLLog.log.warn("Unable to inject capability at {}.{} (Invalid Annotation)", targetClass, targetName);
                 continue;
             }
             final String capabilityName = type.getInternalName().replace('/', '.').intern();
@@ -142,7 +142,7 @@ public enum CapabilityManager
                                 {
                                     if ((mtd.getModifiers() & Modifier.STATIC) != Modifier.STATIC)
                                     {
-                                        FMLLog.log(Level.WARN, "Unable to inject capability %s at %s.%s (Non-Static)", capabilityName, targetClass, targetName);
+                                        FMLLog.log.warn("Unable to inject capability {} at {}.{} (Non-Static)", capabilityName, targetClass, targetName);
                                         return null;
                                     }
 
@@ -151,11 +151,11 @@ public enum CapabilityManager
                                     return null;
                                 }
                             }
-                            FMLLog.log(Level.WARN, "Unable to inject capability %s at %s.%s (Method Not Found)", capabilityName, targetClass, targetName);
+                            FMLLog.log.warn("Unable to inject capability {} at {}.{} (Method Not Found)", capabilityName, targetClass, targetName);
                         }
                         catch (Exception e)
                         {
-                            FMLLog.log(Level.WARN, e, "Unable to inject capability %s at %s.%s", capabilityName, targetClass, targetName);
+                            FMLLog.warn(e, "Unable to inject capability {} at {}.{}", capabilityName, targetClass, targetName);
                         }
                         return null;
                     }
@@ -173,14 +173,14 @@ public enum CapabilityManager
                             Field field = Class.forName(targetClass).getDeclaredField(targetName);
                             if ((field.getModifiers() & Modifier.STATIC) != Modifier.STATIC)
                             {
-                                FMLLog.log(Level.WARN, "Unable to inject capability %s at %s.%s (Non-Static)", capabilityName, targetClass, targetName);
+                                FMLLog.log.warn("Unable to inject capability {} at {}.{} (Non-Static)", capabilityName, targetClass, targetName);
                                 return null;
                             }
                             EnumHelper.setFailsafeFieldValue(field, null, input);
                         }
                         catch (Exception e)
                         {
-                            FMLLog.log(Level.WARN, e, "Unable to inject capability %s at %s.%s", capabilityName, targetClass, targetName);
+                            FMLLog.warn(e, "Unable to inject capability {} at {}.{}", capabilityName, targetClass, targetName);
                         }
                         return null;
                     }

--- a/src/main/java/net/minecraftforge/common/chunkio/ChunkIOExecutor.java
+++ b/src/main/java/net/minecraftforge/common/chunkio/ChunkIOExecutor.java
@@ -120,7 +120,7 @@ public class ChunkIOExecutor
         ChunkIOProvider task = tasks.get(key);
         if (task == null)
         {
-            FMLLog.warning("Attempted to dequeue chunk that wasn't queued? %d @ (%d, %d)", world.provider.getDimension(), x, z);
+            FMLLog.log.warn("Attempted to dequeue chunk that wasn't queued? {} @ ({}, {})", world.provider.getDimension(), x, z);
             return;
         }
 

--- a/src/main/java/net/minecraftforge/common/config/ConfigManager.java
+++ b/src/main/java/net/minecraftforge/common/config/ConfigManager.java
@@ -104,7 +104,7 @@ public class ConfigManager
 
     public static void loadData(ASMDataTable data)
     {
-        FMLLog.fine("Loading @Config anotation data");
+        FMLLog.log.debug("Loading @Config anotation data");
         for (ASMData target : data.getAll(Config.class.getName()))
         {
             String modid = (String)target.getAnnotationInfo().get("modid");
@@ -150,7 +150,7 @@ public class ConfigManager
      */
     public static void sync(String modid, Config.Type type)
     {
-        FMLLog.fine("Attempting to inject @Config classes into %s for type %s", modid, type);
+        FMLLog.log.debug("Attempting to inject @Config classes into {} for type {}", modid, type);
         ClassLoader mcl = Loader.instance().getModClassLoader();
         File configDir = Loader.instance().getConfigDir();
         Multimap<Config.Type, ASMData> map = asm_data.get(modid);
@@ -194,7 +194,7 @@ public class ConfigManager
             }
             catch (Exception e)
             {
-                FMLLog.log(Level.ERROR, e, "An error occurred trying to load a config for %s into %s", modid, targ.getClassName());
+                FMLLog.error(e, "An error occurred trying to load a config for {} into {}", modid, targ.getClassName());
                 throw new LoaderException(e);
             }
         }

--- a/src/main/java/net/minecraftforge/common/config/ConfigManager.java
+++ b/src/main/java/net/minecraftforge/common/config/ConfigManager.java
@@ -194,7 +194,7 @@ public class ConfigManager
             }
             catch (Exception e)
             {
-                FMLLog.error(e, "An error occurred trying to load a config for {} into {}", modid, targ.getClassName());
+                FMLLog.log.error("An error occurred trying to load a config for {} into {}", targ.getClassName(), e);
                 throw new LoaderException(e);
             }
         }

--- a/src/main/java/net/minecraftforge/common/config/Configuration.java
+++ b/src/main/java/net/minecraftforge/common/config/Configuration.java
@@ -136,7 +136,7 @@ public class Configuration
             {
                 File fileBak = new File(file.getAbsolutePath() + "_" +
                         new SimpleDateFormat("yyyyMMdd_HHmmss").format(new Date()) + ".errored");
-                FMLLog.severe("An exception occurred while loading config file %s. This file will be renamed to %s " +
+                FMLLog.log.fatal("An exception occurred while loading config file {}. This file will be renamed to {} " +
                         "and a new config file will be generated.", file.getName(), fileBak.getName());
                 e.printStackTrace();
 

--- a/src/main/java/net/minecraftforge/common/model/animation/AnimationStateMachine.java
+++ b/src/main/java/net/minecraftforge/common/model/animation/AnimationStateMachine.java
@@ -233,12 +233,12 @@ public final class AnimationStateMachine implements IAnimationStateMachine
         }
         catch(IOException e)
         {
-            FMLLog.error(e, "Exception loading Animation State Machine {}, skipping", location);
+            FMLLog.log.error("Exception loading Animation State Machine {}, skipping", location, e);
             return missing;
         }
         catch(JsonParseException e)
         {
-            FMLLog.error(e, "Exception loading Animation State Machine {}, skipping", location);
+            FMLLog.log.error("Exception loading Animation State Machine {}, skipping", location, e);
             return missing;
         }
         finally

--- a/src/main/java/net/minecraftforge/common/model/animation/AnimationStateMachine.java
+++ b/src/main/java/net/minecraftforge/common/model/animation/AnimationStateMachine.java
@@ -233,12 +233,12 @@ public final class AnimationStateMachine implements IAnimationStateMachine
         }
         catch(IOException e)
         {
-            FMLLog.log(Level.ERROR, e, "Exception loading Animation State Machine %s, skipping", location);
+            FMLLog.error(e, "Exception loading Animation State Machine {}, skipping", location);
             return missing;
         }
         catch(JsonParseException e)
         {
-            FMLLog.log(Level.ERROR, e, "Exception loading Animation State Machine %s, skipping", location);
+            FMLLog.error(e, "Exception loading Animation State Machine {}, skipping", location);
             return missing;
         }
         finally

--- a/src/main/java/net/minecraftforge/common/model/animation/Clips.java
+++ b/src/main/java/net/minecraftforge/common/model/animation/Clips.java
@@ -97,7 +97,7 @@ public final class Clips
             {
                 return new ModelClip(clip.get(), modelLocation, clipName);
             }
-            FMLLog.getLogger().error("Unable to find clip " + clipName + " in the model " + modelLocation);
+            FMLLog.log.error("Unable to find clip {} in the model {}", clipName, modelLocation);
         }
         // FIXME: missing clip?
         return new ModelClip(IdentityClip.INSTANCE, modelLocation, clipName);

--- a/src/main/java/net/minecraftforge/common/network/DimensionMessageHandler.java
+++ b/src/main/java/net/minecraftforge/common/network/DimensionMessageHandler.java
@@ -39,7 +39,7 @@ public class DimensionMessageHandler extends SimpleChannelInboundHandler<ForgeMe
     @Override
     public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) throws Exception
     {
-        FMLLog.log(Level.ERROR, cause, "DimensionMessageHandler exception");
+        FMLLog.log.error("DimensionMessageHandler exception", cause);
         super.exceptionCaught(ctx, cause);
     }
 

--- a/src/main/java/net/minecraftforge/common/network/FluidIdRegistryMessageHandler.java
+++ b/src/main/java/net/minecraftforge/common/network/FluidIdRegistryMessageHandler.java
@@ -36,7 +36,7 @@ public class FluidIdRegistryMessageHandler extends SimpleChannelInboundHandler<F
     @Override
     public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) throws Exception
     {
-        FMLLog.log(Level.ERROR, cause, "FluidIdRegistryMessageHandler exception");
+        FMLLog.log.error("FluidIdRegistryMessageHandler exception", cause);
         super.exceptionCaught(ctx, cause);
     }
 

--- a/src/main/java/net/minecraftforge/common/network/ForgeMessage.java
+++ b/src/main/java/net/minecraftforge/common/network/ForgeMessage.java
@@ -110,7 +110,7 @@ public abstract class ForgeMessage {
             }
             else
             {
-                FMLLog.getLogger().log(Level.INFO, "Legacy server message contains no default fluid list - there may be problems with fluids");
+                FMLLog.log.info("Legacy server message contains no default fluid list - there may be problems with fluids");
                 defaultFluids.clear();
             }
         }

--- a/src/main/java/net/minecraftforge/common/util/EnumHelper.java
+++ b/src/main/java/net/minecraftforge/common/util/EnumHelper.java
@@ -310,7 +310,7 @@ public class EnumHelper
             }
 
             for (String line : lines)
-                FMLLog.severe(line);
+                FMLLog.log.fatal(line);
 
             if (test)
             {

--- a/src/main/java/net/minecraftforge/fluids/Fluid.java
+++ b/src/main/java/net/minecraftforge/fluids/Fluid.java
@@ -148,8 +148,8 @@ public class Fluid
         }
         else
         {
-            FMLLog.warning("A mod has attempted to assign Block " + block + " to the Fluid '" + fluidName + "' but this Fluid has already been linked to the Block "
-                    + this.block + ". You may have duplicate Fluid Blocks as a result. It *may* be possible to configure your mods to avoid this.");
+            FMLLog.log.warn("A mod has attempted to assign Block {} to the Fluid '{}' but this Fluid has already been linked to the Block {}. "
+                    + "You may have duplicate Fluid Blocks as a result. It *may* be possible to configure your mods to avoid this.", block, fluidName, this.block);
         }
         return this;
     }

--- a/src/main/java/net/minecraftforge/fluids/FluidRegistry.java
+++ b/src/main/java/net/minecraftforge/fluids/FluidRegistry.java
@@ -123,13 +123,13 @@ public abstract class FluidRegistry
                 String derivedName = defaultName.split(":",2)[1];
                 String localDefault = defaultFluidName.get(derivedName);
                 if (localDefault == null) {
-                    FMLLog.getLogger().log(Level.ERROR, "The fluid {} (specified as {}) is missing from this instance - it will be removed", derivedName, defaultName);
+                    FMLLog.log.error("The fluid {} (specified as {}) is missing from this instance - it will be removed", derivedName, defaultName);
                     continue;
                 }
                 fluid = masterFluidReference.get(localDefault);
-                FMLLog.getLogger().log(Level.ERROR, "The fluid {} specified as default is not present - it will be reverted to default {}", defaultName, localDefault);
+                FMLLog.log.error("The fluid {} specified as default is not present - it will be reverted to default {}", defaultName, localDefault);
             }
-            FMLLog.getLogger().log(Level.DEBUG, "The fluid {} has been selected as the default fluid for {}", defaultName, fluid.getName());
+            FMLLog.log.debug("The fluid {} has been selected as the default fluid for {}", defaultName, fluid.getName());
             Fluid oldFluid = localFluids.put(fluid.getName(), fluid);
             Integer id = localFluidIDs.remove(oldFluid);
             localFluidIDs.put(fluid, id);
@@ -260,7 +260,7 @@ public abstract class FluidRegistry
         {
             ModContainer modContainer = Loader.instance().activeModContainer();
             String modContainerName = modContainer == null ? null : modContainer.getName();
-            FMLLog.getLogger().log(Level.ERROR, "Trying to activate the universal filled bucket too late. Call it statically in your Mods class. Mod: {}", modContainerName);
+            FMLLog.log.error("Trying to activate the universal filled bucket too late. Call it statically in your Mods class. Mod: {}", modContainerName);
         }
         else
         {
@@ -350,7 +350,7 @@ public abstract class FluidRegistry
     {
         String name = masterFluidReference.inverse().get(key);
         if (Strings.isNullOrEmpty(name)) {
-            FMLLog.getLogger().log(Level.ERROR, "The fluid registry is corrupted. A fluid {} {} is not properly registered. The mod that registered this is broken", key.getClass().getName(), key.getName());
+            FMLLog.log.error("The fluid registry is corrupted. A fluid {} {} is not properly registered. The mod that registered this is broken", key.getClass().getName(), key.getName());
             throw new IllegalStateException("The fluid registry is corrupted");
         }
         return name;
@@ -361,7 +361,7 @@ public abstract class FluidRegistry
         Set<String> defaults = Sets.newHashSet();
         if (tag.hasKey("DefaultFluidList",9))
         {
-            FMLLog.getLogger().log(Level.DEBUG, "Loading persistent fluid defaults from world");
+            FMLLog.log.debug("Loading persistent fluid defaults from world");
             NBTTagList tl = tag.getTagList("DefaultFluidList", 8);
             for (int i = 0; i < tl.tagCount(); i++)
             {
@@ -370,7 +370,7 @@ public abstract class FluidRegistry
         }
         else
         {
-            FMLLog.getLogger().log(Level.DEBUG, "World is missing persistent fluid defaults - using local defaults");
+            FMLLog.log.debug("World is missing persistent fluid defaults - using local defaults");
         }
         loadFluidDefaults(HashBiMap.create(fluidIDs), defaults);
     }
@@ -400,13 +400,13 @@ public abstract class FluidRegistry
 
         if (!illegalFluids.isEmpty())
         {
-            FMLLog.getLogger().log(Level.FATAL, "The fluid registry is corrupted. Something has inserted a fluid without registering it");
-            FMLLog.getLogger().log(Level.FATAL, "There is {} unregistered fluids", illegalFluids.size());
+            FMLLog.log.fatal("The fluid registry is corrupted. Something has inserted a fluid without registering it");
+            FMLLog.log.fatal("There is {} unregistered fluids", illegalFluids.size());
             for (Fluid f: illegalFluids)
             {
-                FMLLog.getLogger().log(Level.FATAL, "  Fluid name : {}, type: {}", f.getName(), f.getClass().getName());
+                FMLLog.log.fatal("  Fluid name : {}, type: {}", f.getName(), f.getClass().getName());
             }
-            FMLLog.getLogger().log(Level.FATAL, "The mods that own these fluids need to register them properly");
+            FMLLog.log.fatal("The mods that own these fluids need to register them properly");
             throw new IllegalStateException("The fluid map contains fluids unknown to the master fluid registry");
         }
     }

--- a/src/main/java/net/minecraftforge/fluids/FluidStack.java
+++ b/src/main/java/net/minecraftforge/fluids/FluidStack.java
@@ -51,7 +51,7 @@ public class FluidStack
         }
         else if (!FluidRegistry.isFluidRegistered(fluid))
         {
-            FMLLog.bigWarning("Failed attempt to create a FluidStack for an unregistered Fluid %s (type %s)", fluid.getName(), fluid.getClass().getName());
+            FMLLog.bigWarning("Failed attempt to create a FluidStack for an unregistered Fluid {} (type {})", fluid.getName(), fluid.getClass().getName());
             throw new IllegalArgumentException("Cannot create a fluidstack from an unregistered fluid");
         }
         this.fluidDelegate = FluidRegistry.makeDelegate(fluid);

--- a/src/main/java/net/minecraftforge/fml/client/FMLClientHandler.java
+++ b/src/main/java/net/minecraftforge/fml/client/FMLClientHandler.java
@@ -393,7 +393,7 @@ public class FMLClientHandler implements IFMLSidedHandler
                 guiFactories.put(mc, guiFactory);
             } catch (Exception e)
             {
-                FMLLog.error(e, "A critical error occurred instantiating the gui factory for mod {}", mc.getModId());
+                FMLLog.log.error("A critical error occurred instantiating the gui factory for mod {}", mc.getModId(), e);
             }
         }
         loading = false;
@@ -688,7 +688,7 @@ public class FMLClientHandler implements IFMLSidedHandler
             }
             catch (Exception e)
             {
-                FMLLog.error(e, "An unexpected exception occurred constructing the custom resource pack for {}", container.getName());
+                FMLLog.log.error("An unexpected exception occurred constructing the custom resource pack for {}", container.getName(), e);
                 throw Throwables.propagate(e);
             }
         }

--- a/src/main/java/net/minecraftforge/fml/client/FMLClientHandler.java
+++ b/src/main/java/net/minecraftforge/fml/client/FMLClientHandler.java
@@ -222,7 +222,7 @@ public class FMLClientHandler implements IFMLSidedHandler
         this.resourcePackMap = Maps.newHashMap();
         if (minecraft.isDemo())
         {
-            FMLLog.severe("DEMO MODE DETECTED, FML will not work. Finishing now.");
+            FMLLog.log.fatal("DEMO MODE DETECTED, FML will not work. Finishing now.");
             haltGame("FML will not run in demo mode", new RuntimeException());
             return;
         }
@@ -254,7 +254,7 @@ public class FMLClientHandler implements IFMLSidedHandler
         }
         catch (CustomModLoadingErrorDisplayException custom)
         {
-            FMLLog.log(Level.ERROR, custom, "A custom exception was thrown by a mod, the game will now halt");
+            FMLLog.log.error("A custom exception was thrown by a mod, the game will now halt", custom);
             customError = custom;
         }
         catch (MultipleModsErrored multiple)
@@ -277,7 +277,7 @@ public class FMLClientHandler implements IFMLSidedHandler
         }
         catch (CustomModLoadingErrorDisplayException custom)
         {
-            FMLLog.log(Level.ERROR, custom, "A custom exception was thrown by a mod, the game will now halt");
+            FMLLog.log.error("A custom exception was thrown by a mod, the game will now halt", custom);
             customError = custom;
         }
         catch (LoaderException le)
@@ -314,7 +314,7 @@ public class FMLClientHandler implements IFMLSidedHandler
             {
                 ModMetadata optifineMetadata = MetadataCollection.from(optifineModInfoInputStream, "optifine").getMetadataForId("optifine", dummyOptifineMeta);
                 optifineContainer = new DummyModContainer(optifineMetadata);
-                FMLLog.info("Forge Mod Loader has detected optifine %s, enabling compatibility features", optifineContainer.getVersion());
+                FMLLog.log.info("Forge Mod Loader has detected optifine {}, enabling compatibility features", optifineContainer.getVersion());
             }
             finally
             {
@@ -358,7 +358,7 @@ public class FMLClientHandler implements IFMLSidedHandler
         }
         catch (CustomModLoadingErrorDisplayException custom)
         {
-            FMLLog.log(Level.ERROR, custom, "A custom exception was thrown by a mod, the game will now halt");
+            FMLLog.log.error("A custom exception was thrown by a mod, the game will now halt", custom);
             customError = custom;
             SplashProgress.finish();
             return;
@@ -393,7 +393,7 @@ public class FMLClientHandler implements IFMLSidedHandler
                 guiFactories.put(mc, guiFactory);
             } catch (Exception e)
             {
-                FMLLog.log(Level.ERROR, e, "A critical error occurred instantiating the gui factory for mod %s", mc.getModId());
+                FMLLog.error(e, "A critical error occurred instantiating the gui factory for mod {}", mc.getModId());
             }
         }
         loading = false;
@@ -683,12 +683,12 @@ public class FMLClientHandler implements IFMLSidedHandler
             }
             catch (NoSuchMethodException e)
             {
-                FMLLog.log(Level.ERROR, "The container %s (type %s) returned an invalid class for it's resource pack.", container.getName(), container.getClass().getName());
+                FMLLog.log.error("The container {} (type {}) returned an invalid class for it's resource pack.", container.getName(), container.getClass().getName());
                 return;
             }
             catch (Exception e)
             {
-                FMLLog.log(Level.ERROR, e, "An unexpected exception occurred constructing the custom resource pack for %s", container.getName());
+                FMLLog.error(e, "An unexpected exception occurred constructing the custom resource pack for {}", container.getName());
                 throw Throwables.propagate(e);
             }
         }
@@ -762,7 +762,7 @@ public class FMLClientHandler implements IFMLSidedHandler
             }
             catch (Exception e1)
             {
-                FMLLog.warning("There appears to be a problem loading the save %s, both level files are unreadable.", comparator.getFileName());
+                FMLLog.log.warn("There appears to be a problem loading the save {}, both level files are unreadable.", comparator.getFileName());
                 return;
             }
         }

--- a/src/main/java/net/minecraftforge/fml/client/FMLFileResourcePack.java
+++ b/src/main/java/net/minecraftforge/fml/client/FMLFileResourcePack.java
@@ -25,6 +25,7 @@ import java.io.IOException;
 import java.io.InputStream;
 
 import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.LogManager;
 
 import javax.imageio.ImageIO;
 
@@ -61,7 +62,7 @@ public class FMLFileResourcePack extends FileResourcePack implements FMLContaine
         {
             if ("pack.mcmeta".equals(resourceName))
             {
-                FMLLog.log(container.getName(), Level.DEBUG, "Mod %s is missing a pack.mcmeta file, substituting a dummy one", container.getName());
+                LogManager.getLogger(container.getName()).debug("Mod {} is missing a pack.mcmeta file, substituting a dummy one", container.getName());
                 return new ByteArrayInputStream(("{\n" +
                         " \"pack\": {\n"+
                         "   \"description\": \"dummy FML pack for "+container.getName()+"\",\n"+

--- a/src/main/java/net/minecraftforge/fml/client/FMLFolderResourcePack.java
+++ b/src/main/java/net/minecraftforge/fml/client/FMLFolderResourcePack.java
@@ -25,6 +25,7 @@ import java.io.IOException;
 import java.io.InputStream;
 
 import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.LogManager;
 
 import javax.imageio.ImageIO;
 
@@ -66,7 +67,7 @@ public class FMLFolderResourcePack extends FolderResourcePack implements FMLCont
         {
             if ("pack.mcmeta".equals(resourceName))
             {
-                FMLLog.log(container.getName(), Level.DEBUG, "Mod %s is missing a pack.mcmeta file, substituting a dummy one", container.getName());
+                LogManager.getLogger(container.getName()).debug("Mod {} is missing a pack.mcmeta file, substituting a dummy one", container.getName());
                 return new ByteArrayInputStream(("{\n" +
                         " \"pack\": {\n"+
                         "   \"description\": \"dummy FML pack for "+container.getName()+"\",\n"+

--- a/src/main/java/net/minecraftforge/fml/client/GuiErrorBase.java
+++ b/src/main/java/net/minecraftforge/fml/client/GuiErrorBase.java
@@ -65,7 +65,7 @@ public class GuiErrorBase extends GuiErrorScreen
             }
             catch (Exception e)
             {
-                FMLLog.log(Level.ERROR, e, "Problem opening mods folder");
+                FMLLog.log.error("Problem opening mods folder", e);
             }
         }
         else if (button.id == 11)
@@ -76,7 +76,7 @@ public class GuiErrorBase extends GuiErrorScreen
             }
             catch (Exception e)
             {
-                FMLLog.log(Level.ERROR, e, "Problem opening log file " + clientLog);
+                FMLLog.error(e, "Problem opening log file {}", clientLog);
             }
         }
     }

--- a/src/main/java/net/minecraftforge/fml/client/GuiErrorBase.java
+++ b/src/main/java/net/minecraftforge/fml/client/GuiErrorBase.java
@@ -76,7 +76,7 @@ public class GuiErrorBase extends GuiErrorScreen
             }
             catch (Exception e)
             {
-                FMLLog.error(e, "Problem opening log file {}", clientLog);
+                FMLLog.log.error("Problem opening log file {}", clientLog, e);
             }
         }
     }

--- a/src/main/java/net/minecraftforge/fml/client/GuiJava8Error.java
+++ b/src/main/java/net/minecraftforge/fml/client/GuiJava8Error.java
@@ -71,7 +71,7 @@ public class GuiJava8Error extends GuiErrorBase
             }
             catch (Exception e)
             {
-                FMLLog.log(Level.ERROR, e, "Problem launching browser");
+                FMLLog.log.error("Problem launching browser", e);
             }
         }
         else

--- a/src/main/java/net/minecraftforge/fml/client/GuiModList.java
+++ b/src/main/java/net/minecraftforge/fml/client/GuiModList.java
@@ -295,7 +295,7 @@ public class GuiModList extends GuiScreen
                         }
                         catch (Exception e)
                         {
-                            FMLLog.error(e, "There was a critical issue trying to build the config GUI for {}", selectedMod.getModId());
+                            FMLLog.log.error("There was a critical issue trying to build the config GUI for {}", selectedMod.getModId(), e);
                         }
                         return;
                     }

--- a/src/main/java/net/minecraftforge/fml/client/GuiModList.java
+++ b/src/main/java/net/minecraftforge/fml/client/GuiModList.java
@@ -295,7 +295,7 @@ public class GuiModList extends GuiScreen
                         }
                         catch (Exception e)
                         {
-                            FMLLog.log(Level.ERROR, e, "There was a critical issue trying to build the config GUI for %s", selectedMod.getModId());
+                            FMLLog.error(e, "There was a critical issue trying to build the config GUI for {}", selectedMod.getModId());
                         }
                         return;
                     }

--- a/src/main/java/net/minecraftforge/fml/client/GuiOldSaveLoadConfirm.java
+++ b/src/main/java/net/minecraftforge/fml/client/GuiOldSaveLoadConfirm.java
@@ -93,7 +93,7 @@ public class GuiOldSaveLoadConfirm extends GuiYesNo implements GuiYesNoCallback 
                 }
             } catch (IOException e)
             {
-                FMLLog.warn(e, "There was a problem saving the backup {}. Please fix and try again", zip.getName());
+                FMLLog.log.warn("There was a problem saving the backup {}. Please fix and try again", zip.getName(), e);
                 FMLClientHandler.instance().showGuiScreen(new GuiBackupFailed(parent, zip));
                 return;
             }

--- a/src/main/java/net/minecraftforge/fml/client/GuiOldSaveLoadConfirm.java
+++ b/src/main/java/net/minecraftforge/fml/client/GuiOldSaveLoadConfirm.java
@@ -78,7 +78,7 @@ public class GuiOldSaveLoadConfirm extends GuiYesNo implements GuiYesNoCallback 
         }
         else
         {
-            FMLLog.info("Capturing current state of world %s into file %s", saveName, zip.getAbsolutePath());
+            FMLLog.log.info("Capturing current state of world {} into file {}", saveName, zip.getAbsolutePath());
             try
             {
                 String skip = System.getProperty("fml.doNotBackup");
@@ -89,11 +89,11 @@ public class GuiOldSaveLoadConfirm extends GuiYesNo implements GuiYesNoCallback 
                 else
                 {
                     for (int x = 0; x < 10; x++)
-                        FMLLog.severe("!!!!!!!!!! UPDATING WORLD WITHOUT DOING BACKUP !!!!!!!!!!!!!!!!");
+                        FMLLog.log.fatal("!!!!!!!!!! UPDATING WORLD WITHOUT DOING BACKUP !!!!!!!!!!!!!!!!");
                 }
             } catch (IOException e)
             {
-                FMLLog.log(Level.WARN, e, "There was a problem saving the backup %s. Please fix and try again", zip.getName());
+                FMLLog.warn(e, "There was a problem saving the backup {}. Please fix and try again", zip.getName());
                 FMLClientHandler.instance().showGuiScreen(new GuiBackupFailed(parent, zip));
                 return;
             }

--- a/src/main/java/net/minecraftforge/fml/client/SplashProgress.java
+++ b/src/main/java/net/minecraftforge/fml/client/SplashProgress.java
@@ -160,7 +160,7 @@ public class SplashProgress
         }
         catch(IOException e)
         {
-            FMLLog.info("Could not load splash.properties, will create a default one");
+            FMLLog.log.info("Could not load splash.properties, will create a default one");
         }
         finally
         {
@@ -202,7 +202,7 @@ public class SplashProgress
         }
         catch(IOException e)
         {
-            FMLLog.log(Level.ERROR, e, "Could not save the splash.properties file");
+            FMLLog.log.error("Could not save the splash.properties file", e);
         }
         finally
         {
@@ -231,7 +231,7 @@ public class SplashProgress
         CrashReport report = CrashReport.makeCrashReport(new Throwable(), "Loading screen debug info");
         StringBuilder systemDetailsBuilder = new StringBuilder();
         report.getCategory().appendToStringBuilder(systemDetailsBuilder);
-        FMLLog.info(systemDetailsBuilder.toString());
+        FMLLog.log.info(systemDetailsBuilder.toString());
 
         try
         {
@@ -398,13 +398,13 @@ public class SplashProgress
                         if (!isDisplayVSyncForced)
                         {
                             isDisplayVSyncForced = true;
-                            FMLLog.log(Level.INFO, "Using alternative sync timing : %d frames of Display.update took %d nanos", TIMING_FRAME_COUNT, updateTiming);
+                            FMLLog.log.info("Using alternative sync timing : {} frames of Display.update took {} nanos", TIMING_FRAME_COUNT, updateTiming);
                         }
                         try { Thread.sleep(16); } catch (InterruptedException ie) {}
                     } else
                     {
                         if (framecount ==TIMING_FRAME_COUNT) {
-                            FMLLog.log(Level.INFO, "Using sync timing. %d frames of Display.update took %d nanos", TIMING_FRAME_COUNT, updateTiming);
+                            FMLLog.log.info("Using sync timing. {} frames of Display.update took {} nanos", TIMING_FRAME_COUNT, updateTiming);
                         }
                         Display.sync(100);
                     }
@@ -577,7 +577,7 @@ public class SplashProgress
         {
             public void uncaughtException(Thread t, Throwable e)
             {
-                FMLLog.log(Level.ERROR, e, "Splash thread Exception");
+                FMLLog.log.error("Splash thread Exception", e);
                 threadError = e;
             }
         });
@@ -726,7 +726,7 @@ public class SplashProgress
         }
         catch(IOException e)
         {
-            FMLLog.log(Level.ERROR, e, "Could not save the splash.properties file");
+            FMLLog.log.error("Could not save the splash.properties file", e);
             return false;
         }
         finally

--- a/src/main/java/net/minecraftforge/fml/client/config/GuiConfigEntries.java
+++ b/src/main/java/net/minecraftforge/fml/client/config/GuiConfigEntries.java
@@ -128,7 +128,7 @@ public class GuiConfigEntries extends GuiListExtended
                     }
                     catch (Throwable e)
                     {
-                        FMLLog.severe("There was a critical error instantiating the custom IConfigEntry for config element %s.", configElement.getName());
+                        FMLLog.log.fatal("There was a critical error instantiating the custom IConfigEntry for config element {}.", configElement.getName());
                         e.printStackTrace();
                     }
                 else if (configElement.isProperty())

--- a/src/main/java/net/minecraftforge/fml/client/config/GuiEditArrayEntries.java
+++ b/src/main/java/net/minecraftforge/fml/client/config/GuiEditArrayEntries.java
@@ -81,7 +81,7 @@ public class GuiEditArrayEntries extends GuiListExtended
                 }
                 catch (Throwable e)
                 {
-                    FMLLog.error(e, "There was a critical error instantiating the custom IGuiEditListEntry for property {}.", configElement.getName());
+                    FMLLog.log.error("There was a critical error instantiating the custom IGuiEditListEntry for property {}.", configElement.getName(), e);
                 }
             }
         }
@@ -156,7 +156,7 @@ public class GuiEditArrayEntries extends GuiListExtended
             }
             catch (Throwable e)
             {
-                FMLLog.error(e, "There was a critical error instantiating the custom IGuiEditListEntry for property {}.", configElement.getName());
+                FMLLog.log.error("There was a critical error instantiating the custom IGuiEditListEntry for property {}.", configElement.getName(), e);
             }
         }
         else if (configElement.isList() && configElement.getType() == ConfigGuiType.BOOLEAN)

--- a/src/main/java/net/minecraftforge/fml/client/config/GuiEditArrayEntries.java
+++ b/src/main/java/net/minecraftforge/fml/client/config/GuiEditArrayEntries.java
@@ -81,7 +81,7 @@ public class GuiEditArrayEntries extends GuiListExtended
                 }
                 catch (Throwable e)
                 {
-                    FMLLog.log(Level.ERROR, e, "There was a critical error instantiating the custom IGuiEditListEntry for property %s.", configElement.getName());
+                    FMLLog.error(e, "There was a critical error instantiating the custom IGuiEditListEntry for property {}.", configElement.getName());
                 }
             }
         }
@@ -156,7 +156,7 @@ public class GuiEditArrayEntries extends GuiListExtended
             }
             catch (Throwable e)
             {
-                FMLLog.log(Level.ERROR, e, "There was a critical error instantiating the custom IGuiEditListEntry for property %s.", configElement.getName());
+                FMLLog.error(e, "There was a critical error instantiating the custom IGuiEditListEntry for property {}.", configElement.getName());
             }
         }
         else if (configElement.isList() && configElement.getType() == ConfigGuiType.BOOLEAN)

--- a/src/main/java/net/minecraftforge/fml/common/AutomaticEventSubscriber.java
+++ b/src/main/java/net/minecraftforge/fml/common/AutomaticEventSubscriber.java
@@ -86,7 +86,7 @@ public class AutomaticEventSubscriber
             }
             catch (Exception e)
             {
-                FMLLog.error(e, "An error occurred trying to load an EventBusSubscriber {} for modid {}", targ.getClassName(), mod.getModId());
+                FMLLog.log.error("An error occurred trying to load an EventBusSubscriber {} for modid {}", mod.getModId(), e);
                 throw new LoaderException(e);
             }
         }

--- a/src/main/java/net/minecraftforge/fml/common/AutomaticEventSubscriber.java
+++ b/src/main/java/net/minecraftforge/fml/common/AutomaticEventSubscriber.java
@@ -45,7 +45,7 @@ public class AutomaticEventSubscriber
     private static final EnumSet<Side> DEFAULT = EnumSet.allOf(Side.class);
     public static void inject(ModContainer mod, ASMDataTable data, Side side)
     {
-        FMLLog.fine("Attempting to inject @EventBusSubscriber classes into the eventbus for %s", mod.getModId());
+        FMLLog.log.debug("Attempting to inject @EventBusSubscriber classes into the eventbus for {}", mod.getModId());
         SetMultimap<String, ASMData> modData = data.getAnnotationsFor(mod);
         Set<ASMDataTable.ASMData> mods = modData.get(Mod.class.getName());
         Set<ASMDataTable.ASMData> targets = modData.get(Mod.EventBusSubscriber.class.getName());
@@ -65,28 +65,28 @@ public class AutomaticEventSubscriber
                     }
                 }
                 if (sides == DEFAULT || sides.contains(side)) {
-                    FMLLog.fine("Found @EventBusSubscriber class %s", targ.getClassName());
+                    FMLLog.log.debug("Found @EventBusSubscriber class {}", targ.getClassName());
                     String amodid = (String)targ.getAnnotationInfo().get("modid");
                     if (Strings.isNullOrEmpty(amodid)) {
                         amodid = ASMDataTable.getOwnerModID(mods, targ);
                         if (Strings.isNullOrEmpty(amodid)) {
-                            FMLLog.bigWarning("Could not determine owning mod for @EventBusSubscriber on %s for mod %s", targ.getClassName(), mod.getModId());
+                            FMLLog.bigWarning("Could not determine owning mod for @EventBusSubscriber on {} for mod {}", targ.getClassName(), mod.getModId());
                             continue;
                         }
                     }
                     if (!mod.getModId().equals(amodid))
                     {
-                        FMLLog.fine("Skipping @EventBusSubscriber injection for %s since it is not for mod %s", targ.getClassName(), mod.getModId());
+                        FMLLog.log.debug("Skipping @EventBusSubscriber injection for {} since it is not for mod {}", targ.getClassName(), mod.getModId());
                         continue; //We're not injecting this guy
                     }
                     Class<?> subscriptionTarget = Class.forName(targ.getClassName(), true, mcl);
                     MinecraftForge.EVENT_BUS.register(subscriptionTarget);
-                    FMLLog.fine("Injected @EventBusSubscriber class %s", targ.getClassName());
+                    FMLLog.log.debug("Injected @EventBusSubscriber class {}", targ.getClassName());
                 }
             }
             catch (Exception e)
             {
-                FMLLog.log(Level.ERROR, e, "An error occurred trying to load an EventBusSubscriber %s for modid %s", targ.getClassName(), mod.getModId());
+                FMLLog.error(e, "An error occurred trying to load an EventBusSubscriber {} for modid {}", targ.getClassName(), mod.getModId());
                 throw new LoaderException(e);
             }
         }

--- a/src/main/java/net/minecraftforge/fml/common/FMLCommonHandler.java
+++ b/src/main/java/net/minecraftforge/fml/common/FMLCommonHandler.java
@@ -58,6 +58,7 @@ import net.minecraftforge.client.model.animation.Animation;
 import net.minecraftforge.common.ForgeVersion;
 import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.common.util.CompoundDataFixer;
+import net.minecraftforge.fml.common.event.FMLPreInitializationEvent;
 import net.minecraftforge.fml.common.eventhandler.EventBus;
 import net.minecraftforge.fml.common.gameevent.InputEvent;
 import net.minecraftforge.fml.common.gameevent.PlayerEvent;
@@ -185,10 +186,13 @@ public class FMLCommonHandler
     /**
      * Get the forge mod loader logging instance (goes to the forgemodloader log file)
      * @return The log instance for the FML log file
+     *
+     * @deprecated Not used in FML, Mods use your own logger, see {@link FMLPreInitializationEvent#getModLog()}
      */
+    @Deprecated
     public Logger getFMLLogger()
     {
-        return FMLLog.getLogger();
+        return FMLLog.log;
     }
 
     public Side getSide()
@@ -211,7 +215,7 @@ public class FMLCommonHandler
      */
     public void raiseException(Throwable exception, String message, boolean stopGame)
     {
-        FMLLog.log(Level.ERROR, exception, "Something raised an exception. The message was '%s'. 'stopGame' is %b", message, stopGame);
+        FMLLog.error(exception, "Something raised an exception. The message was '{}'. 'stopGame' is {}", message, stopGame);
         if (stopGame)
         {
             getSidedDelegate().haltGame(message,exception);
@@ -477,19 +481,19 @@ public class FMLCommonHandler
         {
             try
             {
-                FMLLog.info("Waiting for the server to terminate/save.");
+                FMLLog.log.info("Waiting for the server to terminate/save.");
                 if (!latch.await(10, TimeUnit.SECONDS))
                 {
-                    FMLLog.warning("The server didn't stop within 10 seconds, exiting anyway.");
+                    FMLLog.log.warn("The server didn't stop within 10 seconds, exiting anyway.");
                 }
                 else
                 {
-                    FMLLog.info("Server terminated.");
+                    FMLLog.log.info("Server terminated.");
                 }
             }
             catch (InterruptedException e)
             {
-                FMLLog.warning("Interrupted wait, exiting.");
+                FMLLog.log.warn("Interrupted wait, exiting.");
             }
         }
 
@@ -623,7 +627,7 @@ public class FMLCommonHandler
         if (!shouldAllowPlayerLogins())
         {
             TextComponentString text = new TextComponentString("Server is still starting! Please wait before reconnecting.");
-            FMLLog.info("Disconnecting Player: " + text.getUnformattedText());
+            FMLLog.log.info("Disconnecting Player: {}", text.getUnformattedText());
             manager.sendPacket(new SPacketDisconnect(text));
             manager.closeChannel(text);
             return false;
@@ -633,7 +637,7 @@ public class FMLCommonHandler
         {
             manager.setConnectionState(EnumConnectionState.LOGIN);
             TextComponentString text = new TextComponentString("This server requires FML/Forge to be installed. Contact your server admin for more details.");
-            FMLLog.info("Disconnecting Player: " + text.getUnformattedText());
+            FMLLog.log.info("Disconnecting Player: {}", text.getUnformattedText());
             manager.sendPacket(new SPacketDisconnect(text));
             manager.closeChannel(text);
             return false;
@@ -658,18 +662,18 @@ public class FMLCommonHandler
      */
     public void exitJava(int exitCode, boolean hardExit)
     {
-        FMLLog.log(Level.INFO, "Java has been asked to exit (code %d) by %s.", exitCode, Thread.currentThread().getStackTrace()[1]);
+        FMLLog.log.info("Java has been asked to exit (code {}) by {}.", exitCode, Thread.currentThread().getStackTrace()[1]);
         if (hardExit)
         {
-            FMLLog.log(Level.INFO, "This is an abortive exit and could cause world corruption or other things");
+            FMLLog.log.info("This is an abortive exit and could cause world corruption or other things");
         }
         if (Boolean.parseBoolean(System.getProperty("fml.debugExit", "false")))
         {
-            FMLLog.log(Level.INFO, new Throwable(), "Exit trace");
+            FMLLog.log.info("Exit trace", new Throwable());
         }
         else
         {
-            FMLLog.log(Level.INFO, "If this was an unexpected exit, use -Dfml.debugExit=true as a JVM argument to find out where it was called");
+            FMLLog.log.info("If this was an unexpected exit, use -Dfml.debugExit=true as a JVM argument to find out where it was called");
         }
         if (hardExit)
         {
@@ -695,11 +699,11 @@ public class FMLCommonHandler
         }
         catch (InterruptedException e)
         {
-            FMLLog.log(Level.FATAL, e, "Exception caught executing FutureTask: " + e.toString());
+            FMLLog.fatal(e, "Exception caught executing FutureTask: {}", e.toString());
         }
         catch (ExecutionException e)
         {
-            FMLLog.log(Level.FATAL, e, "Exception caught executing FutureTask: " + e.toString());
+            FMLLog.fatal(e, "Exception caught executing FutureTask: {}", e.toString());
         }
     }
 

--- a/src/main/java/net/minecraftforge/fml/common/FMLCommonHandler.java
+++ b/src/main/java/net/minecraftforge/fml/common/FMLCommonHandler.java
@@ -215,7 +215,7 @@ public class FMLCommonHandler
      */
     public void raiseException(Throwable exception, String message, boolean stopGame)
     {
-        FMLLog.error(exception, "Something raised an exception. The message was '{}'. 'stopGame' is {}", message, stopGame);
+        FMLLog.log.error("Something raised an exception. The message was '{}'. 'stopGame' is {}", stopGame, exception);
         if (stopGame)
         {
             getSidedDelegate().haltGame(message,exception);
@@ -699,11 +699,11 @@ public class FMLCommonHandler
         }
         catch (InterruptedException e)
         {
-            FMLLog.fatal(e, "Exception caught executing FutureTask: {}", e.toString());
+            FMLLog.log.fatal("Exception caught executing FutureTask: {}", e.toString(), e);
         }
         catch (ExecutionException e)
         {
-            FMLLog.fatal(e, "Exception caught executing FutureTask: {}", e.toString());
+            FMLLog.log.fatal("Exception caught executing FutureTask: {}", e.toString(), e);
         }
     }
 

--- a/src/main/java/net/minecraftforge/fml/common/FMLContainer.java
+++ b/src/main/java/net/minecraftforge/fml/common/FMLContainer.java
@@ -48,6 +48,7 @@ import net.minecraftforge.fml.common.registry.VillagerRegistry;
 import net.minecraftforge.fml.relauncher.Side;
 
 import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.LogManager;
 
 import com.google.common.eventbus.EventBus;
 import com.google.common.eventbus.Subscribe;
@@ -120,7 +121,7 @@ public final class FMLContainer extends DummyModContainer implements WorldAccess
 
         NBTTagCompound registries = new NBTTagCompound();
         fmlData.setTag("Registries", registries);
-        FMLLog.fine("Gathering id map for writing to world save %s", info.getWorldName());
+        FMLLog.log.debug("Gathering id map for writing to world save {}", info.getWorldName());
         PersistentRegistryManager.GameDataSnapshot dataSnapshot = PersistentRegistryManager.takeSnapshot();
 
         for (Map.Entry<ResourceLocation, PersistentRegistryManager.GameDataSnapshot.Entry> e : dataSnapshot.entries.entrySet())
@@ -190,12 +191,12 @@ public final class FMLContainer extends DummyModContainer implements WorldAccess
                 ModContainer container = Loader.instance().getIndexedModList().get(modId);
                 if (container == null)
                 {
-                    FMLLog.log("fml.ModTracker", Level.ERROR, "This world was saved with mod %s which appears to be missing, things may not work well", modId);
+                    LogManager.getLogger("fml.ModTracker").error("This world was saved with mod {} which appears to be missing, things may not work well", modId);
                     continue;
                 }
                 if (!modVersion.equals(container.getVersion()))
                 {
-                    FMLLog.log("fml.ModTracker", Level.INFO, "This world was saved with mod %s version %s and it is now at version %s, things may not work well", modId, modVersion, container.getVersion());
+                    LogManager.getLogger("fml.ModTracker").info("This world was saved with mod {} version {} and it is now at version {}, things may not work well", modId, modVersion, container.getVersion());
                 }
             }
         }

--- a/src/main/java/net/minecraftforge/fml/common/FMLLog.java
+++ b/src/main/java/net/minecraftforge/fml/common/FMLLog.java
@@ -19,73 +19,132 @@
 
 package net.minecraftforge.fml.common;
 
-import org.apache.logging.log4j.Level;
-import org.apache.logging.log4j.Logger;
+import java.util.Locale;
 
-@SuppressWarnings("static-access")
+import net.minecraftforge.fml.common.event.FMLPreInitializationEvent;
+import net.minecraftforge.fml.relauncher.FMLLaunchHandler;
+import net.minecraftforge.fml.relauncher.FMLRelaunchLog;
+import net.minecraftforge.fml.relauncher.Side;
+
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.ThreadContext;
+
+/**
+ * FMLs logging class. <b>Internal use only, NOT FOR MOD LOGGING!</b> Mods use your own log, see {@link FMLPreInitializationEvent#getModLog()}.
+ */
 public class FMLLog
 {
-    private static net.minecraftforge.fml.relauncher.FMLRelaunchLog coreLog = net.minecraftforge.fml.relauncher.FMLRelaunchLog.log;
 
-    public static void log(String targetLog, Level level, String format, Object... data)
-    {
-        coreLog.log(targetLog, level, format, data);
+    public static final Logger log;
+
+    static {
+        log = LogManager.getLogger("FML");
+        // Default side to client for test harness purposes
+        Side side = FMLLaunchHandler.side();
+        if (side == null) side = Side.CLIENT;
+        ThreadContext.put("side", side.name().toLowerCase(Locale.ENGLISH));
+
+        log.debug("Injecting tracing printstreams for STDOUT/STDERR.");
+        System.setOut(new TracingPrintStream(LogManager.getLogger("STDOUT"), System.out));
+        System.setErr(new TracingPrintStream(LogManager.getLogger("STDERR"), System.err));
     }
 
-    public static void log(Level level, String format, Object... data)
+    public static void info(Throwable x, String message, Object... args)
     {
-        coreLog.log(level, format, data);
+        logWithException(Level.INFO, x, message, args);
     }
 
-    public static void log(String targetLog, Level level, Throwable ex, String format, Object... data)
+    public static void warn(Throwable x, String message, Object... args)
     {
-        coreLog.log(targetLog, level, ex, format, data);
+        logWithException(Level.WARN, x, message, args);
     }
 
-    public static void log(Level level, Throwable ex, String format, Object... data)
+    public static void error(Throwable x, String message, Object... args)
     {
-        coreLog.log(level, ex, format, data);
+        logWithException(Level.ERROR, x, message, args);
     }
 
-    public static void severe(String format, Object... data)
+    public static void fatal(Throwable x, String message, Object... args)
     {
-        log(Level.ERROR, format, data);
+        logWithException(Level.FATAL, x, message, args);
+    }
+
+    private static void logWithException(Level level, Throwable x, String message, Object... args)
+    {
+        log.log(level, log.getMessageFactory().newMessage(message, args), x);
     }
 
     public static void bigWarning(String format, Object... data)
     {
         StackTraceElement[] trace = Thread.currentThread().getStackTrace();
-        log(Level.WARN, "****************************************");
-        log(Level.WARN, "* "+format, data);
+        log.warn("****************************************");
+        log.warn("* "+format, data);
         for (int i = 2; i < 8 && i < trace.length; i++)
         {
-            log(Level.WARN, "*  at %s%s", trace[i].toString(), i == 7 ? "..." : "");
+            log.warn("*  at {}{}", trace[i].toString(), i == 7 ? "..." : "");
         }
-        log(Level.WARN, "****************************************");
+        log.warn("****************************************");
     }
 
+    @Deprecated
+    public static void log(String targetLog, Level level, String format, Object... data)
+    {
+        FMLRelaunchLog.log(targetLog, level, format, data);
+    }
+
+    @Deprecated
+    public static void log(Level level, String format, Object... data)
+    {
+        FMLRelaunchLog.log(level, format, data);
+    }
+
+    @Deprecated
+    public static void log(String targetLog, Level level, Throwable ex, String format, Object... data)
+    {
+        FMLRelaunchLog.log(targetLog, level, ex, format, data);
+    }
+
+    @Deprecated
+    public static void log(Level level, Throwable ex, String format, Object... data)
+    {
+        FMLRelaunchLog.log(level, ex, format, data);
+    }
+
+    @Deprecated
+    public static void severe(String format, Object... data)
+    {
+        log(Level.ERROR, format, data);
+    }
+
+    @Deprecated
     public static void warning(String format, Object... data)
     {
         log(Level.WARN, format, data);
     }
 
+    @Deprecated
     public static void info(String format, Object... data)
     {
         log(Level.INFO, format, data);
     }
 
+    @Deprecated
     public static void fine(String format, Object... data)
     {
         log(Level.DEBUG, format, data);
     }
 
+    @Deprecated
     public static void finer(String format, Object... data)
     {
         log(Level.TRACE, format, data);
     }
 
+    @Deprecated
     public static Logger getLogger()
     {
-        return coreLog.getLogger();
+        return log;
     }
 }

--- a/src/main/java/net/minecraftforge/fml/common/FMLLog.java
+++ b/src/main/java/net/minecraftforge/fml/common/FMLLog.java
@@ -51,31 +51,6 @@ public class FMLLog
         System.setErr(new TracingPrintStream(LogManager.getLogger("STDERR"), System.err));
     }
 
-    public static void info(Throwable x, String message, Object... args)
-    {
-        logWithException(Level.INFO, x, message, args);
-    }
-
-    public static void warn(Throwable x, String message, Object... args)
-    {
-        logWithException(Level.WARN, x, message, args);
-    }
-
-    public static void error(Throwable x, String message, Object... args)
-    {
-        logWithException(Level.ERROR, x, message, args);
-    }
-
-    public static void fatal(Throwable x, String message, Object... args)
-    {
-        logWithException(Level.FATAL, x, message, args);
-    }
-
-    private static void logWithException(Level level, Throwable x, String message, Object... args)
-    {
-        log.log(level, log.getMessageFactory().newMessage(message, args), x);
-    }
-
     public static void bigWarning(String format, Object... data)
     {
         StackTraceElement[] trace = Thread.currentThread().getStackTrace();

--- a/src/main/java/net/minecraftforge/fml/common/FMLModContainer.java
+++ b/src/main/java/net/minecraftforge/fml/common/FMLModContainer.java
@@ -516,7 +516,7 @@ public class FMLModContainer implements ModContainer
                 catch (Exception e)
                 {
                     Throwables.propagateIfPossible(e);
-                    modLog.warn(modLog.getMessageFactory().newMessage("Attempting to load @%s in class %s for %s and failing", annotationName, targets.getClassName(), mc.getModId()), e);
+                    modLog.warn("Attempting to load @{} in class {} for {} and failing", annotationName, targets.getClassName(), mc.getModId(), e);
                 }
             }
             if (f != null)

--- a/src/main/java/net/minecraftforge/fml/common/FMLModContainer.java
+++ b/src/main/java/net/minecraftforge/fml/common/FMLModContainer.java
@@ -164,7 +164,7 @@ public class FMLModContainer implements ModContainer
             }
             catch (Exception ex)
             {
-                FMLLog.error(ex, "Error constructing custom mod language adapter referenced by {} (modid: {})", this.className, getModId());
+                FMLLog.log.error("Error constructing custom mod language adapter referenced by {} (modid: {})", getModId(), ex);
                 throw new RuntimeException(ex);
             }
         }

--- a/src/main/java/net/minecraftforge/fml/common/FMLModContainer.java
+++ b/src/main/java/net/minecraftforge/fml/common/FMLModContainer.java
@@ -57,6 +57,8 @@ import net.minecraftforge.fml.relauncher.Side;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipFile;
@@ -107,6 +109,8 @@ public class FMLModContainer implements ModContainer
     private URL updateJSONUrl;
     private int classVersion;
 
+    private final Logger modLog;
+
     public FMLModContainer(String className, ModCandidate container, Map<String, Object> modDescriptor)
     {
         this.className = className;
@@ -125,9 +129,11 @@ public class FMLModContainer implements ModContainer
         {
             // Delay loading of the adapter until the mod is on the classpath, in case the mod itself contains it.
             this.languageAdapter = null;
-            FMLLog.finer("Using custom language adapter %s for %s (modid: %s)", languageAdapterType, this.className, getModId());
+            FMLLog.log.trace("Using custom language adapter {} for {} (modid: {})", languageAdapterType, this.className, getModId());
         }
         sanityCheckModId();
+
+        modLog = LogManager.getLogger(getModId());
     }
 
     private void sanityCheckModId()
@@ -139,12 +145,12 @@ public class FMLModContainer implements ModContainer
         }
         if (modid.length() > 64)
         {
-            FMLLog.bigWarning("The modid %s is longer than the recommended maximum of 64 characters. Truncation is enforced in 1.11", modid);
+            FMLLog.bigWarning("The modid {} is longer than the recommended maximum of 64 characters. Truncation is enforced in 1.11", modid);
             throw new IllegalArgumentException(String.format("The modid %s is longer than the recommended maximum of 64 characters. Truncation is enforced in 1.11", modid));
         }
         if (!modid.equals(modid.toLowerCase(Locale.ENGLISH)))
         {
-            FMLLog.bigWarning("The modid %s is not the same as it's lowercase version. Lowercasing is enforced in 1.11", modid);
+            FMLLog.bigWarning("The modid {} is not the same as it's lowercase version. Lowercasing is enforced in 1.11", modid);
             throw new IllegalArgumentException(String.format("The modid %s is not the same as it's lowercase version. Lowercasing will be enforced in 1.11", modid));
         }
     }
@@ -158,7 +164,7 @@ public class FMLModContainer implements ModContainer
             }
             catch (Exception ex)
             {
-                FMLLog.log(Level.ERROR, ex, "Error constructing custom mod language adapter referenced by %s (modid: %s)", this.className, getModId());
+                FMLLog.error(ex, "Error constructing custom mod language adapter referenced by {} (modid: {})", this.className, getModId());
                 throw new RuntimeException(ex);
             }
         }
@@ -217,15 +223,15 @@ public class FMLModContainer implements ModContainer
             modMetadata.requiredMods = requirements;
             modMetadata.dependencies = dependencies;
             modMetadata.dependants = dependants;
-            FMLLog.log(getModId(), Level.TRACE, "Parsed dependency info : %s %s %s", requirements, dependencies, dependants);
+            modLog.trace("Parsed dependency info : {} {} {}", requirements, dependencies, dependants);
         }
         else
         {
-            FMLLog.log(getModId(), Level.TRACE, "Using mcmod dependency info : %s %s %s", modMetadata.requiredMods, modMetadata.dependencies, modMetadata.dependants);
+            modLog.trace("Using mcmod dependency info : {} {} {}", modMetadata.requiredMods, modMetadata.dependencies, modMetadata.dependants);
         }
         if (Strings.isNullOrEmpty(modMetadata.name))
         {
-            FMLLog.log(getModId(), Level.INFO, "Mod %s is missing the required element 'name'. Substituting %s", getModId(), getModId());
+            modLog.info("Mod {} is missing the required element 'name'. Substituting {}", getModId(), getModId());
             modMetadata.name = getModId();
         }
         internalVersion = (String)descriptor.get("version");
@@ -235,18 +241,18 @@ public class FMLModContainer implements ModContainer
             if (versionProps != null)
             {
                 internalVersion = versionProps.getProperty(getModId() + ".version");
-                FMLLog.log(getModId(), Level.DEBUG, "Found version %s for mod %s in version.properties, using", internalVersion, getModId());
+                modLog.debug("Found version {} for mod {} in version.properties, using", internalVersion, getModId());
             }
 
         }
         if (Strings.isNullOrEmpty(internalVersion) && !Strings.isNullOrEmpty(modMetadata.version))
         {
-            FMLLog.log(getModId(), Level.WARN, "Mod %s is missing the required element 'version' and a version.properties file could not be found. Falling back to metadata version %s", getModId(), modMetadata.version);
+            modLog.warn("Mod {} is missing the required element 'version' and a version.properties file could not be found. Falling back to metadata version {}", getModId(), modMetadata.version);
             internalVersion = modMetadata.version;
         }
         if (Strings.isNullOrEmpty(internalVersion))
         {
-            FMLLog.log(getModId(), Level.WARN, "Mod %s is missing the required element 'version' and no fallback can be found. Substituting '1.0'.", getModId());
+            modLog.warn("Mod {} is missing the required element 'version' and no fallback can be found. Substituting '1.0'.", getModId());
             modMetadata.version = internalVersion = "1.0";
         }
 
@@ -277,7 +283,7 @@ public class FMLModContainer implements ModContainer
             }
             catch (MalformedURLException e)
             {
-                FMLLog.log(getModId(), Level.DEBUG, "Specified json URL invalid: %s", jsonURL);
+                modLog.debug("Specified json URL invalid: {}", jsonURL);
             }
         }
     }
@@ -287,7 +293,7 @@ public class FMLModContainer implements ModContainer
     {
         try
         {
-            FMLLog.log(getModId(), Level.DEBUG, "Attempting to load the file version.properties from %s to locate a version number for %s", getSource().getName(), getModId());
+            modLog.debug("Attempting to load the file version.properties from {} to locate a version number for {}", getSource().getName(), getModId());
             Properties version = null;
             if (getSource().isFile())
             {
@@ -330,7 +336,7 @@ public class FMLModContainer implements ModContainer
         catch (Exception e)
         {
             Throwables.propagateIfPossible(e);
-            FMLLog.log(getModId(), Level.TRACE, "Failed to find a usable version.properties file");
+            modLog.trace("Failed to find a usable version.properties file");
             return null;
         }
     }
@@ -382,7 +388,7 @@ public class FMLModContainer implements ModContainer
     {
         if (this.enabled)
         {
-            FMLLog.log(getModId(), Level.DEBUG, "Enabling mod %s", getModId());
+            modLog.debug("Enabling mod {}", getModId());
             this.eventBus = bus;
             this.controller = controller;
             eventBus.register(this);
@@ -412,7 +418,7 @@ public class FMLModContainer implements ModContainer
                     }
                     else
                     {
-                        FMLLog.log(getModId(), Level.ERROR, "The mod %s appears to have an invalid event annotation %s. This annotation can only apply to methods with recognized event arguments - it will not be called", getModId(), a.annotationType().getSimpleName());
+                        modLog.error("The mod {} appears to have an invalid event annotation {}. This annotation can only apply to methods with recognized event arguments - it will not be called", getModId(), a.annotationType().getSimpleName());
                     }
                 }
                 else if (a.annotationType().equals(Mod.InstanceFactory.class))
@@ -424,11 +430,11 @@ public class FMLModContainer implements ModContainer
                     }
                     else if (!(Modifier.isStatic(m.getModifiers()) && m.getParameterTypes().length == 0))
                     {
-                        FMLLog.log(getModId(), Level.ERROR, "The InstanceFactory annotation can only apply to a static method, taking zero arguments - it will be ignored on %s(%s)", m.getName(), Arrays.asList(m.getParameterTypes()));
+                        modLog.error("The InstanceFactory annotation can only apply to a static method, taking zero arguments - it will be ignored on {}({})", m.getName(), Arrays.asList(m.getParameterTypes()));
                     }
                     else if (factoryMethod != null)
                     {
-                        FMLLog.log(getModId(), Level.ERROR, "The InstanceFactory annotation can only be used once, the application to %s(%s) will be ignored", m.getName(), Arrays.asList(m.getParameterTypes()));
+                        modLog.error("The InstanceFactory annotation can only be used once, the application to {}({}) will be ignored", m.getName(), Arrays.asList(m.getParameterTypes()));
                     }
                 }
             }
@@ -472,13 +478,13 @@ public class FMLModContainer implements ModContainer
                 owner = ASMDataTable.getOwnerModID(mods, targets);
                 if (Strings.isNullOrEmpty(owner))
                 {
-                    FMLLog.bigWarning("Could not determine owning mod for @%s on %s for mod %s", annotationClassName, targets.getClassName(), this.getModId());
+                    FMLLog.bigWarning("Could not determine owning mod for @{} on {} for mod {}", annotationClassName, targets.getClassName(), this.getModId());
                     continue;
                 }
             }
             if (!this.getModId().equals(owner))
             {
-                FMLLog.fine("Skipping @%s injection for %s.%s since it is not for mod %s", annotationClassName, targets.getClassName(), targets.getObjectName(), this.getModId());
+                FMLLog.log.debug("Skipping @{} injection for {}.{} since it is not for mod {}", annotationClassName, targets.getClassName(), targets.getObjectName(), this.getModId());
                 continue;
             }
             Field f = null;
@@ -510,7 +516,7 @@ public class FMLModContainer implements ModContainer
                 catch (Exception e)
                 {
                     Throwables.propagateIfPossible(e);
-                    FMLLog.log(getModId(), Level.WARN, e, "Attempting to load @%s in class %s for %s and failing", annotationName, targets.getClassName(), mc.getModId());
+                    modLog.warn(modLog.getMessageFactory().newMessage("Attempting to load @%s in class %s for %s and failing", annotationName, targets.getClassName(), mc.getModId()), e);
                 }
             }
             if (f != null)
@@ -521,7 +527,7 @@ public class FMLModContainer implements ModContainer
                     target = modInstance;
                     if (!modInstance.getClass().equals(clz))
                     {
-                        FMLLog.log(getModId(), Level.WARN, "Unable to inject @%s in non-static field %s.%s for %s as it is NOT the primary mod instance", annotationName, targets.getClassName(), targets.getObjectName(), mc.getModId());
+                        modLog.warn("Unable to inject @{} in non-static field {}.{} for {} as it is NOT the primary mod instance", annotationName, targets.getClassName(), targets.getObjectName(), mc.getModId());
                         continue;
                     }
                 }
@@ -573,7 +579,7 @@ public class FMLModContainer implements ModContainer
                     {
                         warnLevel = Level.TRACE;
                     }
-                    FMLLog.log(getModId(), warnLevel, "The mod %s is expecting signature %s for source %s, however there is no signature matching that description", getModId(), expectedFingerprint, source.getName());
+                    modLog.log(warnLevel, "The mod {} is expecting signature {} for source {}, however there is no signature matching that description", getModId(), expectedFingerprint, source.getName());
                 }
                 else
                 {
@@ -762,13 +768,13 @@ public class FMLModContainer implements ModContainer
 
         if (clientSideOnly && side != Side.CLIENT)
         {
-            FMLLog.info("Disabling mod %s it is client side only.", getModId());
+            FMLLog.log.info("Disabling mod {} it is client side only.", getModId());
             return false;
         }
 
         if (serverSideOnly && side != Side.SERVER)
         {
-            FMLLog.info("Disabling mod %s it is server side only.", getModId());
+            FMLLog.log.info("Disabling mod {} it is server side only.", getModId());
             return false;
         }
 

--- a/src/main/java/net/minecraftforge/fml/common/ILanguageAdapter.java
+++ b/src/main/java/net/minecraftforge/fml/common/ILanguageAdapter.java
@@ -74,7 +74,7 @@ public interface ILanguageAdapter {
             catch (ClassNotFoundException e)
             {
                 // Not a singleton, look for @Instance field as a fallback.
-                FMLLog.log(Level.INFO, e, "An error occurred trying to load a proxy into %s.%s. Did you declare your mod as 'class' instead of 'object'?", proxyTarget.getSimpleName(), target.getName());
+                FMLLog.info(e, "An error occurred trying to load a proxy into {}.{}. Did you declare your mod as 'class' instead of 'object'?", proxyTarget.getSimpleName(), target.getName());
                 return;
             }
 
@@ -110,12 +110,12 @@ public interface ILanguageAdapter {
             }
             catch (InvocationTargetException e)
             {
-                FMLLog.log(Level.ERROR, e, "An error occurred trying to load a proxy into %s.%s", proxyTarget.getSimpleName(), target.getName());
+                FMLLog.error(e, "An error occurred trying to load a proxy into {}.{}", proxyTarget.getSimpleName(), target.getName());
                 throw new LoaderException(e);
             }
 
             // If we come here we could not find a setter for this proxy.
-            FMLLog.severe("Failed loading proxy into %s.%s, could not find setter function. Did you declare the field with 'val' instead of 'var'?", proxyTarget.getSimpleName(), target.getName());
+            FMLLog.log.fatal("Failed loading proxy into {}.{}, could not find setter function. Did you declare the field with 'val' instead of 'var'?", proxyTarget.getSimpleName(), target.getName());
             throw new LoaderException(String.format("Failed loading proxy into %s.%s, could not find setter function. Did you declare the field with 'val' instead of 'var'?", proxyTarget.getSimpleName(), target.getName()));
         }
 
@@ -160,14 +160,14 @@ public interface ILanguageAdapter {
 
                             if (!target.getType().isAssignableFrom(proxy.getClass()))
                             {
-                                FMLLog.severe("Attempted to load a proxy type %s into %s.%s, but the types don't match", targetType, proxyTarget.getSimpleName(), target.getName());
+                                FMLLog.log.fatal("Attempted to load a proxy type {} into {}.{}, but the types don't match", targetType, proxyTarget.getSimpleName(), target.getName());
                                 throw new LoaderException(String.format("Attempted to load a proxy type %s into %s.%s, but the types don't match", targetType, proxyTarget.getSimpleName(), target.getName()));
                             }
 
                             setProxy(target, proxyTarget, proxy);
                         }
                         catch (Exception e) {
-                            FMLLog.log(Level.ERROR, e, "An error occurred trying to load a proxy into %s.%s", proxyTarget.getSimpleName(), target.getName());
+                            FMLLog.error(e, "An error occurred trying to load a proxy into {}.{}", proxyTarget.getSimpleName(), target.getName());
                             throw new LoaderException(e);
                         }
                     }
@@ -175,7 +175,7 @@ public interface ILanguageAdapter {
             }
             else
             {
-                FMLLog.finer("Mod does not appear to be a singleton.");
+                FMLLog.log.trace("Mod does not appear to be a singleton.");
             }
         }
     }

--- a/src/main/java/net/minecraftforge/fml/common/ILanguageAdapter.java
+++ b/src/main/java/net/minecraftforge/fml/common/ILanguageAdapter.java
@@ -74,7 +74,7 @@ public interface ILanguageAdapter {
             catch (ClassNotFoundException e)
             {
                 // Not a singleton, look for @Instance field as a fallback.
-                FMLLog.info(e, "An error occurred trying to load a proxy into {}.{}. Did you declare your mod as 'class' instead of 'object'?", proxyTarget.getSimpleName(), target.getName());
+                FMLLog.log.info("An error occurred trying to load a proxy into {}.{}. Did you declare your mod as 'class' instead of 'object'?", proxyTarget.getSimpleName(), target.getName(), e);
                 return;
             }
 
@@ -110,7 +110,7 @@ public interface ILanguageAdapter {
             }
             catch (InvocationTargetException e)
             {
-                FMLLog.error(e, "An error occurred trying to load a proxy into {}.{}", proxyTarget.getSimpleName(), target.getName());
+                FMLLog.log.error("An error occurred trying to load a proxy into {}.{}", target.getName(), e);
                 throw new LoaderException(e);
             }
 
@@ -167,7 +167,7 @@ public interface ILanguageAdapter {
                             setProxy(target, proxyTarget, proxy);
                         }
                         catch (Exception e) {
-                            FMLLog.error(e, "An error occurred trying to load a proxy into {}.{}", proxyTarget.getSimpleName(), target.getName());
+                            FMLLog.log.error("An error occurred trying to load a proxy into {}.{}", target.getName(), e);
                             throw new LoaderException(e);
                         }
                     }

--- a/src/main/java/net/minecraftforge/fml/common/LoadController.java
+++ b/src/main/java/net/minecraftforge/fml/common/LoadController.java
@@ -37,6 +37,7 @@ import net.minecraftforge.fml.common.functions.ArtifactVersionNameFunction;
 import net.minecraftforge.fml.common.versioning.ArtifactVersion;
 
 import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.ThreadContext;
 
 import com.google.common.collect.ArrayListMultimap;
@@ -79,7 +80,7 @@ public class LoadController
             @Override
             public void handleException(Throwable exception, SubscriberExceptionContext context)
             {
-                FMLLog.log("FMLMainChannel", Level.ERROR, exception, "Could not dispatch event: %s to %s", context.getEvent(), context.getSubscriberMethod());
+                FMLLog.error(exception, "Could not dispatch event: {} to {}", context.getEvent(), context.getSubscriberMethod());
             }
         });
         this.masterChannel.register(this);
@@ -130,7 +131,7 @@ public class LoadController
             }
             else
             {
-                FMLLog.log(mod.getModId(), Level.WARN, "Mod %s has been disabled through configuration", mod.getModId());
+                LogManager.getLogger(mod.getModId()).warn("Mod {} has been disabled through configuration", mod.getModId());
                 modStates.put(mod.getModId(), ModState.UNLOADED);
                 modStates.put(mod.getModId(), ModState.DISABLED);
             }
@@ -152,7 +153,7 @@ public class LoadController
     {
         if (FMLCommonHandler.instance().isDisplayCloseRequested())
         {
-            FMLLog.info("The game window is being closed by the player, exiting.");
+            FMLLog.log.info("The game window is being closed by the player, exiting.");
             FMLCommonHandler.instance().exitJava(0, false);
         }
 
@@ -161,18 +162,18 @@ public class LoadController
         if (state != desiredState && !forceState)
         {
             Entry<String, Throwable> toThrow = null;
-            FMLLog.severe("Fatal errors were detected during the transition from %s to %s. Loading cannot continue", oldState, desiredState);
+            FMLLog.log.fatal("Fatal errors were detected during the transition from {} to {}. Loading cannot continue", oldState, desiredState);
             StringBuilder sb = new StringBuilder();
             printModStates(sb);
-            FMLLog.severe("%s", sb.toString());
+            FMLLog.log.fatal(sb.toString());
             if (errors.size()>0)
             {
-                FMLLog.severe("The following problems were captured during this phase");
+                FMLLog.log.fatal("The following problems were captured during this phase");
                 for (Entry<String, Throwable> error : errors.entries())
                 {
                     String modId = error.getKey();
                     String modName = modNames.get(modId);
-                    FMLLog.log(Level.ERROR, error.getValue(), "Caught exception from %s (%s)", modName, modId);
+                    FMLLog.error(error.getValue(), "Caught exception from {} ({})", modName, modId);
                     if (error.getValue() instanceof IFMLHandledException)
                     {
                         toThrow = error;
@@ -185,7 +186,7 @@ public class LoadController
             }
             else
             {
-                FMLLog.severe("The ForgeModLoader state engine has become corrupted. Probably, a state was missed by and invalid modification to a base class" +
+                FMLLog.log.fatal("The ForgeModLoader state engine has become corrupted. Probably, a state was missed by and invalid modification to a base class" +
                         "ForgeModLoader depends on. This is a critical error and not recoverable. Investigate any modifications to base classes outside of" +
                         "ForgeModLoader, especially Optifine, to see if there are fixes available.");
                 throw new RuntimeException("The ForgeModLoader state engine is invalid");
@@ -200,7 +201,7 @@ public class LoadController
         }
         else if (state != desiredState && forceState)
         {
-            FMLLog.info("The state engine was in incorrect state %s and forced into state %s. Errors may have been discarded.", state, desiredState);
+            FMLLog.log.info("The state engine was in incorrect state {} and forced into state {}. Errors may have been discarded.", state, desiredState);
             forceState(desiredState);
         }
 
@@ -240,7 +241,7 @@ public class LoadController
         {
             if (av.getLabel()!= null && requirements.contains(av.getLabel()) && modStates.containsEntry(av.getLabel(),ModState.ERRORED))
             {
-                FMLLog.log(modId, Level.ERROR, "Skipping event %s and marking errored mod %s since required dependency %s has errored", stateEvent.getEventType(), modId, av.getLabel());
+                LogManager.getLogger(modId).error("Skipping event {} and marking errored mod {} since required dependency {} has errored", stateEvent.getEventType(), modId, av.getLabel());
                 modStates.put(modId, ModState.ERRORED);
                 return;
             }
@@ -248,9 +249,9 @@ public class LoadController
         activeContainer = mc;
         stateEvent.applyModContainer(mc);
         ThreadContext.put("mod", modId);
-        FMLLog.log(modId, Level.TRACE, "Sending event %s to mod %s", stateEvent.getEventType(), modId);
+        LogManager.getLogger(modId).trace("Sending event {} to mod {}", stateEvent.getEventType(), modId);
         eventChannels.get(modId).post(stateEvent);
-        FMLLog.log(modId, Level.TRACE, "Sent event %s to mod %s", stateEvent.getEventType(), modId);
+        LogManager.getLogger(modId).trace("Sent event {} to mod {}", stateEvent.getEventType(), modId);
         ThreadContext.remove("mod");
         activeContainer = null;
         if (stateEvent instanceof FMLStateEvent)
@@ -282,7 +283,7 @@ public class LoadController
             }
             if (mc.getMod()==null && !mc.isImmutable() && state!=LoaderState.CONSTRUCTING)
             {
-                FMLLog.severe("There is a severe problem with %s - it appears not to have constructed correctly", mc.getModId());
+                FMLLog.log.fatal("There is a severe problem with {} - it appears not to have constructed correctly", mc.getModId());
                 if (state != LoaderState.CONSTRUCTING)
                 {
                     this.errorOccurred(mc, new RuntimeException());
@@ -338,7 +339,7 @@ public class LoadController
         }
         catch (Exception e)
         {
-            FMLLog.log(Level.ERROR, e, "An unexpected exception");
+            FMLLog.log.error("An unexpected exception", e);
             throw new LoaderException(e);
         }
     }
@@ -347,7 +348,7 @@ public class LoadController
     {
         if (modObjectList == null)
         {
-            FMLLog.severe("Detected an attempt by a mod %s to perform game activity during mod construction. This is a serious programming error.", activeContainer);
+            FMLLog.log.fatal("Detected an attempt by a mod {} to perform game activity during mod construction. This is a serious programming error.", activeContainer);
             return buildModObjectList();
         }
         return ImmutableBiMap.copyOf(modObjectList);

--- a/src/main/java/net/minecraftforge/fml/common/LoadController.java
+++ b/src/main/java/net/minecraftforge/fml/common/LoadController.java
@@ -80,7 +80,7 @@ public class LoadController
             @Override
             public void handleException(Throwable exception, SubscriberExceptionContext context)
             {
-                FMLLog.error(exception, "Could not dispatch event: {} to {}", context.getEvent(), context.getSubscriberMethod());
+                FMLLog.log.error("Could not dispatch event: {} to {}", context.getSubscriberMethod(), exception);
             }
         });
         this.masterChannel.register(this);
@@ -173,7 +173,7 @@ public class LoadController
                 {
                     String modId = error.getKey();
                     String modName = modNames.get(modId);
-                    FMLLog.error(error.getValue(), "Caught exception from {} ({})", modName, modId);
+                    FMLLog.log.error("Caught exception from {} ({})", modId, error.getValue());
                     if (error.getValue() instanceof IFMLHandledException)
                     {
                         toThrow = error;

--- a/src/main/java/net/minecraftforge/fml/common/Loader.java
+++ b/src/main/java/net/minecraftforge/fml/common/Loader.java
@@ -391,7 +391,7 @@ public class Loader
             }
             catch (Exception e)
             {
-                FMLLog.error(e, "A problem occurred instantiating the injected mod container {}", cont);
+                FMLLog.log.error("A problem occurred instantiating the injected mod container {}", cont, e);
                 throw new LoaderException(e);
             }
             mods.add(new InjectedModContainer(mc,mc.getSource()));
@@ -473,8 +473,8 @@ public class Loader
         }
         catch (IOException ioe)
         {
-            FMLLog.error(ioe, "Failed to resolve loader directories: mods : {} ; config {}", canonicalModsDir.getAbsolutePath(),
-                            configDir.getAbsolutePath());
+            FMLLog.log.error("Failed to resolve loader directories: mods : {} ; config {}", canonicalModsDir.getAbsolutePath(),
+                            configDir.getAbsolutePath(), ioe);
             throw new LoaderException(ioe);
         }
 
@@ -571,7 +571,7 @@ public class Loader
                 }
                 catch (MalformedURLException e)
                 {
-                    FMLLog.error(e, "Encountered a weird problem with non-mod file injection : {}", nonMod.getName());
+                    FMLLog.log.error("Encountered a weird problem with non-mod file injection : {}", nonMod.getName(), e);
                 }
             }
         }

--- a/src/main/java/net/minecraftforge/fml/common/Loader.java
+++ b/src/main/java/net/minecraftforge/fml/common/Loader.java
@@ -206,13 +206,13 @@ public class Loader
         java8 = major > 7;
         if (!java8)
         {
-            FMLLog.severe("The game is not running with Java 8. Forge recommends Java 8 for maximum compatibility with mods");
+            FMLLog.log.fatal("The game is not running with Java 8. Forge recommends Java 8 for maximum compatibility with mods");
         }
 
         modClassLoader = new ModClassLoader(getClass().getClassLoader());
         if (mccversion !=null && !mccversion.equals(MC_VERSION))
         {
-            FMLLog.severe("This version of FML is built for Minecraft %s, we have detected Minecraft %s in your minecraft jar file", mccversion, MC_VERSION);
+            FMLLog.log.fatal("This version of FML is built for Minecraft {}, we have detected Minecraft {} in your minecraft jar file", mccversion, MC_VERSION);
             throw new LoaderException(String.format("This version of FML is built for Minecraft %s, we have detected Minecraft %s in your minecraft jar file", mccversion, MC_VERSION));
         }
 
@@ -235,7 +235,7 @@ public class Loader
      */
     private void sortModList()
     {
-        FMLLog.finer("Verifying mod requirements are satisfied");
+        FMLLog.log.trace("Verifying mod requirements are satisfied");
         List<WrongMinecraftVersionException> wrongMinecraftExceptions = new ArrayList<WrongMinecraftVersionException>();
         List<MissingModsException> missingModsExceptions = new ArrayList<MissingModsException>();
         try
@@ -251,9 +251,9 @@ public class Loader
             {
                 if (!mod.acceptableMinecraftVersionRange().containsVersion(minecraft.getProcessedVersion()))
                 {
-                    FMLLog.severe("The mod %s does not wish to run in Minecraft version %s. You will have to remove it to play.", mod.getModId(), getMCVersionString());
+                    FMLLog.log.fatal("The mod {} does not wish to run in Minecraft version {}. You will have to remove it to play.", mod.getModId(), getMCVersionString());
                     WrongMinecraftVersionException ret = new WrongMinecraftVersionException(mod, getMCVersionString());
-                    FMLLog.severe(ret.getMessage());
+                    FMLLog.log.fatal(ret.getMessage());
                     wrongMinecraftExceptions.add(ret);
                     continue;
                 }
@@ -263,13 +263,13 @@ public class Loader
                 Set<String> missingMods = Sets.difference(names.keySet(), modVersions.keySet());
                 if (!missingMods.isEmpty())
                 {
-                    FMLLog.severe("The mod %s (%s) requires mods %s to be available", mod.getModId(), mod.getName(), missingMods);
+                    FMLLog.log.fatal("The mod {} ({}) requires mods {} to be available", mod.getModId(), mod.getName(), missingMods);
                     for (String modid : missingMods)
                     {
                         versionMissingMods.add(names.get(modid));
                     }
                     MissingModsException ret = new MissingModsException(versionMissingMods, mod.getModId(), mod.getName());
-                    FMLLog.severe(ret.getMessage());
+                    FMLLog.log.fatal(ret.getMessage());
                     missingModsExceptions.add(ret);
                     continue;
                 }
@@ -287,16 +287,16 @@ public class Loader
                 }
                 if (!versionMissingMods.isEmpty())
                 {
-                    FMLLog.severe("The mod %s (%s) requires mod versions %s to be available", mod.getModId(), mod.getName(), versionMissingMods);
+                    FMLLog.log.fatal("The mod {} ({}) requires mod versions {} to be available", mod.getModId(), mod.getName(), versionMissingMods);
                     MissingModsException ret = new MissingModsException(versionMissingMods, mod.getModId(), mod.getName());
-                    FMLLog.severe(ret.toString());
+                    FMLLog.log.fatal(ret.toString());
                     missingModsExceptions.add(ret);
                 }
             }
 
             if (wrongMinecraftExceptions.isEmpty() && missingModsExceptions.isEmpty())
             {
-                FMLLog.finer("All mod requirements are satisfied");
+                FMLLog.log.trace("All mod requirements are satisfied");
             }
             else if (missingModsExceptions.size()==1 && wrongMinecraftExceptions.isEmpty())
             {
@@ -316,7 +316,7 @@ public class Loader
 
             try
             {
-                FMLLog.finer("Sorting mods into an ordered list");
+                FMLLog.log.trace("Sorting mods into an ordered list");
                 List<ModContainer> sortedMods = sorter.sort();
                 // Reset active list to the sorted list
                 modController.getActiveModList().clear();
@@ -325,37 +325,37 @@ public class Loader
                 mods.removeAll(sortedMods);
                 sortedMods.addAll(mods);
                 mods = sortedMods;
-                FMLLog.finer("Mod sorting completed successfully");
+                FMLLog.log.trace("Mod sorting completed successfully");
             }
             catch (ModSortingException sortException)
             {
-                FMLLog.severe("A dependency cycle was detected in the input mod set so an ordering cannot be determined");
+                FMLLog.log.fatal("A dependency cycle was detected in the input mod set so an ordering cannot be determined");
                 SortingExceptionData<ModContainer> exceptionData = sortException.getExceptionData();
-                FMLLog.severe("The first mod in the cycle is %s", exceptionData.getFirstBadNode());
-                FMLLog.severe("The mod cycle involves");
+                FMLLog.log.fatal("The first mod in the cycle is {}", exceptionData.getFirstBadNode());
+                FMLLog.log.fatal("The mod cycle involves");
                 for (ModContainer mc : exceptionData.getVisitedNodes())
                 {
-                    FMLLog.severe("%s : before: %s, after: %s", mc.toString(), mc.getDependants(), mc.getDependencies());
+                    FMLLog.log.fatal("{} : before: {}, after: {}", mc.toString(), mc.getDependants(), mc.getDependencies());
                 }
-                FMLLog.log(Level.ERROR, sortException, "The full error");
+                FMLLog.log.error("The full error", sortException);
                 throw sortException;
             }
         }
         finally
         {
-            FMLLog.fine("Mod sorting data");
+            FMLLog.log.debug("Mod sorting data");
             int unprintedMods = mods.size();
             for (ModContainer mod : getActiveModList())
             {
                 if (!mod.isImmutable())
                 {
-                    FMLLog.fine("\t%s(%s:%s): %s (%s)", mod.getModId(), mod.getName(), mod.getVersion(), mod.getSource().getName(), mod.getSortingRules());
+                    FMLLog.log.debug("\t{}({}:{}): {} ({})", mod.getModId(), mod.getName(), mod.getVersion(), mod.getSource().getName(), mod.getSortingRules());
                     unprintedMods--;
                 }
             }
             if (unprintedMods == mods.size())
             {
-                FMLLog.fine("No user mods found to sort");
+                FMLLog.log.debug("No user mods found to sort");
             }
         }
 
@@ -378,7 +378,7 @@ public class Loader
     private ModDiscoverer identifyMods(List<String> additionalContainers)
     {
         injectedContainers.addAll(additionalContainers);
-        FMLLog.fine("Building injected Mod Containers %s", injectedContainers);
+        FMLLog.log.debug("Building injected Mod Containers {}", injectedContainers);
         mods.add(minecraft);
         // Add in the MCP mod container
         mods.add(new InjectedModContainer(mcp,new File("minecraft.jar")));
@@ -391,30 +391,30 @@ public class Loader
             }
             catch (Exception e)
             {
-                FMLLog.log(Level.ERROR, e, "A problem occurred instantiating the injected mod container %s", cont);
+                FMLLog.error(e, "A problem occurred instantiating the injected mod container {}", cont);
                 throw new LoaderException(e);
             }
             mods.add(new InjectedModContainer(mc,mc.getSource()));
         }
         ModDiscoverer discoverer = new ModDiscoverer();
-        FMLLog.fine("Attempting to load mods contained in the minecraft jar file and associated classes");
+        FMLLog.log.debug("Attempting to load mods contained in the minecraft jar file and associated classes");
         discoverer.findClasspathMods(modClassLoader);
-        FMLLog.fine("Minecraft jar mods loaded successfully");
+        FMLLog.log.debug("Minecraft jar mods loaded successfully");
 
-        FMLLog.getLogger().log(Level.INFO, "Found {} mods from the command line. Injecting into mod discoverer",ModListHelper.additionalMods.size());
-        FMLLog.info("Searching %s for mods", canonicalModsDir.getAbsolutePath());
+        FMLLog.log.info("Found {} mods from the command line. Injecting into mod discoverer", ModListHelper.additionalMods.size());
+        FMLLog.log.info("Searching {} for mods", canonicalModsDir.getAbsolutePath());
         discoverer.findModDirMods(canonicalModsDir, ModListHelper.additionalMods.values().toArray(new File[0]));
         File versionSpecificModsDir = new File(canonicalModsDir,mccversion);
         if (versionSpecificModsDir.isDirectory())
         {
-            FMLLog.info("Also searching %s for mods", versionSpecificModsDir);
+            FMLLog.log.info("Also searching {} for mods", versionSpecificModsDir);
             discoverer.findModDirMods(versionSpecificModsDir);
         }
 
         mods.addAll(discoverer.identifyMods());
         identifyDuplicates(mods);
         namedMods = Maps.uniqueIndex(mods, new ModIdFunction());
-        FMLLog.info("Forge Mod Loader has identified %d mod%s to load", mods.size(), mods.size() != 1 ? "s" : "");
+        FMLLog.log.info("Forge Mod Loader has identified {} mod{} to load", mods.size(), mods.size() != 1 ? "s" : "");
         return discoverer;
     }
 
@@ -444,7 +444,7 @@ public class Loader
         {
             if (e.getCount() > 1)
             {
-                FMLLog.severe("Found a duplicate mod %s at %s", e.getElement().getModId(), dupsearch.get(e.getElement()));
+                FMLLog.log.fatal("Found a duplicate mod {} at {}", e.getElement().getModId(), dupsearch.get(e.getElement()));
                 dupes.putAll(e.getElement(),dupsearch.get(e.getElement()));
             }
         }
@@ -473,44 +473,44 @@ public class Loader
         }
         catch (IOException ioe)
         {
-            FMLLog.log(Level.ERROR, ioe, "Failed to resolve loader directories: mods : %s ; config %s", canonicalModsDir.getAbsolutePath(),
+            FMLLog.error(ioe, "Failed to resolve loader directories: mods : {} ; config {}", canonicalModsDir.getAbsolutePath(),
                             configDir.getAbsolutePath());
             throw new LoaderException(ioe);
         }
 
         if (!canonicalModsDir.exists())
         {
-            FMLLog.info("No mod directory found, creating one: %s", canonicalModsPath);
+            FMLLog.log.info("No mod directory found, creating one: {}", canonicalModsPath);
             boolean dirMade = canonicalModsDir.mkdir();
             if (!dirMade)
             {
-                FMLLog.severe("Unable to create the mod directory %s", canonicalModsPath);
+                FMLLog.log.fatal("Unable to create the mod directory {}", canonicalModsPath);
                 throw new LoaderException(String.format("Unable to create the mod directory %s", canonicalModsPath));
             }
-            FMLLog.info("Mod directory created successfully");
+            FMLLog.log.info("Mod directory created successfully");
         }
 
         if (!canonicalConfigDir.exists())
         {
-            FMLLog.fine("No config directory found, creating one: %s", canonicalConfigPath);
+            FMLLog.log.debug("No config directory found, creating one: {}", canonicalConfigPath);
             boolean dirMade = canonicalConfigDir.mkdir();
             if (!dirMade)
             {
-                FMLLog.severe("Unable to create the config directory %s", canonicalConfigPath);
+                FMLLog.log.fatal("Unable to create the config directory {}", canonicalConfigPath);
                 throw new LoaderException();
             }
-            FMLLog.info("Config directory created successfully");
+            FMLLog.log.info("Config directory created successfully");
         }
 
         if (!canonicalModsDir.isDirectory())
         {
-            FMLLog.severe("Attempting to load mods from %s, which is not a directory", canonicalModsPath);
+            FMLLog.log.fatal("Attempting to load mods from {}, which is not a directory", canonicalModsPath);
             throw new LoaderException();
         }
 
         if (!configDir.isDirectory())
         {
-            FMLLog.severe("Attempting to load configuration from %s, which is not a directory", canonicalConfigPath);
+            FMLLog.log.fatal("Attempting to load configuration from {}, which is not a directory", canonicalConfigPath);
             throw new LoaderException();
         }
 
@@ -564,14 +564,14 @@ public class Loader
         {
             if (nonMod.isFile())
             {
-                FMLLog.info("FML has found a non-mod file %s in your mods directory. It will now be injected into your classpath. This could severe stability issues, it should be removed if possible.", nonMod.getName());
+                FMLLog.log.info("FML has found a non-mod file {} in your mods directory. It will now be injected into your classpath. This could severe stability issues, it should be removed if possible.", nonMod.getName());
                 try
                 {
                     modClassLoader.addFile(nonMod);
                 }
                 catch (MalformedURLException e)
                 {
-                    FMLLog.log(Level.ERROR, e, "Encountered a weird problem with non-mod file injection : %s", nonMod.getName());
+                    FMLLog.error(e, "Encountered a weird problem with non-mod file injection : {}", nonMod.getName());
                 }
             }
         }
@@ -592,22 +592,22 @@ public class Loader
             }
         });
 
-        FMLLog.fine("Mod signature data");
-        FMLLog.fine(" \tValid Signatures:");
+        FMLLog.log.debug("Mod signature data");
+        FMLLog.log.debug(" \tValid Signatures:");
         for (ModContainer mod : getActiveModList())
         {
             if (mod.getSigningCertificate() != null)
-                FMLLog.fine("\t\t(%s) %s\t(%s\t%s)\t%s", CertificateHelper.getFingerprint(mod.getSigningCertificate()), mod.getModId(), mod.getName(), mod.getVersion(), mod.getSource().getName());
+                FMLLog.log.debug("\t\t({}) {}\t({}\t{})\t{}", CertificateHelper.getFingerprint(mod.getSigningCertificate()), mod.getModId(), mod.getName(), mod.getVersion(), mod.getSource().getName());
         }
-        FMLLog.fine(" \tMissing Signatures:");
+        FMLLog.log.debug(" \tMissing Signatures:");
         for (ModContainer mod : getActiveModList())
         {
             if (mod.getSigningCertificate() == null)
-                FMLLog.fine("\t\t%s\t(%s\t%s)\t%s", mod.getModId(), mod.getName(), mod.getVersion(), mod.getSource().getName());
+                FMLLog.log.debug("\t\t{}\t({}\t{})\t{}", mod.getModId(), mod.getName(), mod.getVersion(), mod.getSource().getName());
         }
         if (getActiveModList().isEmpty())
         {
-            FMLLog.fine("No user mod signature data found");
+            FMLLog.log.debug("No user mod signature data found");
         }
         progressBar.step("Initializing mods Phase 1");
         modController.transition(LoaderState.PREINITIALIZATION, false);
@@ -635,7 +635,7 @@ public class Loader
     {
         if (!modController.isInState(LoaderState.PREINITIALIZATION))
         {
-            FMLLog.warning("There were errors previously. Not beginning mod initialization phase");
+            FMLLog.log.warn("There were errors previously. Not beginning mod initialization phase");
             return;
         }
         PersistentRegistryManager.fireCreateRegistryEvents();
@@ -654,31 +654,31 @@ public class Loader
     private void disableRequestedMods()
     {
         String forcedModList = System.getProperty("fml.modStates", "");
-        FMLLog.finer("Received a system property request \'%s\'",forcedModList);
+        FMLLog.log.trace("Received a system property request \'{}\'",forcedModList);
         Map<String, String> sysPropertyStateList = Splitter.on(CharMatcher.anyOf(";:"))
                 .omitEmptyStrings().trimResults().withKeyValueSeparator("=")
                 .split(forcedModList);
-        FMLLog.finer("System property request managing the state of %d mods", sysPropertyStateList.size());
+        FMLLog.log.trace("System property request managing the state of {} mods", sysPropertyStateList.size());
         Map<String, String> modStates = Maps.newHashMap();
 
         forcedModFile = new File(canonicalConfigDir, "fmlModState.properties");
         Properties forcedModListProperties = new Properties();
         if (forcedModFile.exists() && forcedModFile.isFile())
         {
-            FMLLog.finer("Found a mod state file %s", forcedModFile.getName());
+            FMLLog.log.trace("Found a mod state file {}", forcedModFile.getName());
             try
             {
                 forcedModListProperties.load(new FileReader(forcedModFile));
-                FMLLog.finer("Loaded states for %d mods from file", forcedModListProperties.size());
+                FMLLog.log.trace("Loaded states for {} mods from file", forcedModListProperties.size());
             }
             catch (Exception e)
             {
-                FMLLog.log(Level.INFO, e, "An error occurred reading the fmlModState.properties file");
+                FMLLog.log.info("An error occurred reading the fmlModState.properties file", e);
             }
         }
         modStates.putAll(Maps.fromProperties(forcedModListProperties));
         modStates.putAll(sysPropertyStateList);
-        FMLLog.fine("After merging, found state information for %d mods", modStates.size());
+        FMLLog.log.debug("After merging, found state information for {} mods", modStates.size());
 
         Map<String, Boolean> isEnabled = Maps.transformValues(modStates, new Function<String, Boolean>()
         {
@@ -693,7 +693,7 @@ public class Loader
         {
             if (namedMods.containsKey(entry.getKey()))
             {
-                FMLLog.info("Setting mod %s to enabled state %b", entry.getKey(), entry.getValue());
+                FMLLog.log.info("Setting mod {} to enabled state {}", entry.getKey(), entry.getValue());
                 namedMods.get(entry.getKey()).setEnabledState(entry.getValue());
             }
         }
@@ -811,7 +811,7 @@ public class Loader
 
         if (parseFailure)
         {
-            FMLLog.log(Level.WARN, "Unable to parse dependency string %s", dependencyString);
+            FMLLog.log.warn("Unable to parse dependency string {}", dependencyString);
             throw new LoaderException(String.format("Unable to parse dependency string %s", dependencyString));
         }
     }
@@ -835,7 +835,7 @@ public class Loader
         modController.transition(LoaderState.AVAILABLE, false);
         modController.distributeStateMessage(LoaderState.AVAILABLE);
         PersistentRegistryManager.freezeData();
-        FMLLog.info("Forge Mod Loader has successfully loaded %d mod%s", mods.size(), mods.size() == 1 ? "" : "s");
+        FMLLog.log.info("Forge Mod Loader has successfully loaded {} mod{}", mods.size(), mods.size() == 1 ? "" : "s");
         progressBar.step("Completing Minecraft initialization");
     }
 
@@ -880,7 +880,7 @@ public class Loader
         }
         catch (Throwable t)
         {
-            FMLLog.log(Level.ERROR, t, "A fatal exception occurred during the server starting event");
+            FMLLog.log.error("A fatal exception occurred during the server starting event", t);
             return false;
         }
         return true;
@@ -951,7 +951,7 @@ public class Loader
         }
         catch (Throwable t)
         {
-            FMLLog.log(Level.ERROR, t, "A fatal exception occurred during the server about to start event");
+            FMLLog.log.error("A fatal exception occurred during the server about to start event", t);
             return false;
         }
         return true;
@@ -998,7 +998,7 @@ public class Loader
         }
 
         if (difference.size() > 0)
-            FMLLog.info("Attempting connection with missing mods %s at %s", difference, side);
+            FMLLog.log.info("Attempting connection with missing mods {} at {}", difference, side);
         return true;
     }
 
@@ -1020,7 +1020,7 @@ public class Loader
             return ImmutableList.of();
         }
 
-        FMLLog.fine("There are %d mappings missing - attempting a mod remap", missingBlocks.size() + missingItems.size());
+        FMLLog.log.debug("There are {} mappings missing - attempting a mod remap", missingBlocks.size() + missingItems.size());
         ArrayListMultimap<String, MissingMapping> missingMappings = ArrayListMultimap.create();
 
         for (Map.Entry<ResourceLocation, Integer> mapping : missingBlocks.entrySet())
@@ -1047,11 +1047,11 @@ public class Loader
                 {
                     if (!didWarn)
                     {
-                        FMLLog.severe("There are unidentified mappings in this world - we are going to attempt to process anyway");
+                        FMLLog.log.fatal("There are unidentified mappings in this world - we are going to attempt to process anyway");
                         didWarn = true;
                     }
 
-                    FMLLog.severe("Unidentified %s: %s, id %d", mapping.type == Type.BLOCK ? "block" : "item", mapping.name, mapping.id);
+                    FMLLog.log.fatal("Unidentified {}: {}, id {}", mapping.type == Type.BLOCK ? "block" : "item", mapping.name, mapping.id);
                 }
             }
         }
@@ -1090,17 +1090,17 @@ public class Loader
         Disableable disableable = mc.canBeDisabled();
         if (disableable == Disableable.NEVER)
         {
-            FMLLog.info("Cannot disable mod %s - it is never allowed to be disabled", modId);
+            FMLLog.log.info("Cannot disable mod {} - it is never allowed to be disabled", modId);
             return;
         }
         if (disableable == Disableable.DEPENDENCIES)
         {
-            FMLLog.info("Cannot disable mod %s - there are dependent mods that require its presence", modId);
+            FMLLog.log.info("Cannot disable mod {} - there are dependent mods that require its presence", modId);
             return;
         }
         if (disableable == Disableable.YES)
         {
-            FMLLog.info("Runtime disabling mod %s", modId);
+            FMLLog.log.info("Runtime disabling mod {}", modId);
             modController.disableMod(mc);
             List<ModContainer> localmods = Lists.newArrayList(mods);
             localmods.remove(mc);
@@ -1116,7 +1116,7 @@ public class Loader
         }
         catch (Exception e)
         {
-            FMLLog.log(Level.INFO, e, "An error occurred writing the fml mod states file, your disabled change won't persist");
+            FMLLog.log.info("An error occurred writing the fml mod states file, your disabled change won't persist", e);
         }
     }
 
@@ -1134,7 +1134,7 @@ public class Loader
         File injectedDepFile = new File(getConfigDir(),"injectedDependencies.json");
         if (!injectedDepFile.exists())
         {
-            FMLLog.getLogger().log(Level.DEBUG, "File {} not found. No dependencies injected", injectedDepFile.getAbsolutePath());
+            FMLLog.log.debug("File {} not found. No dependencies injected", injectedDepFile.getAbsolutePath());
             return;
         }
         JsonParser parser = new JsonParser();
@@ -1156,18 +1156,18 @@ public class Loader
                     } else if (type.equals("after")) {
                         injectedAfter.put(modId, VersionParser.parseVersionReference(depObj.get("target").getAsString()));
                     } else {
-                        FMLLog.getLogger().log(Level.ERROR, "Invalid dependency type {}", type);
+                        FMLLog.log.error("Invalid dependency type {}", type);
                         throw new RuntimeException("Unable to parse type");
                     }
                 }
             }
         } catch (Exception e)
         {
-            FMLLog.getLogger().log(Level.ERROR, "Unable to parse {} - skipping", injectedDepFile);
-            FMLLog.getLogger().throwing(Level.ERROR, e);
+            FMLLog.log.error("Unable to parse {} - skipping", injectedDepFile);
+            FMLLog.log.throwing(Level.ERROR, e);
             return;
         }
-        FMLLog.getLogger().log(Level.DEBUG, "Loaded {} injected dependencies on modIds: {}", injectedBefore.size(), injectedBefore.keySet());
+        FMLLog.log.debug("Loaded {} injected dependencies on modIds: {}", injectedBefore.size(), injectedBefore.keySet());
     }
 
     List<ArtifactVersion> getInjectedBefore(String modId)

--- a/src/main/java/net/minecraftforge/fml/common/MetadataCollection.java
+++ b/src/main/java/net/minecraftforge/fml/common/MetadataCollection.java
@@ -83,7 +83,7 @@ public class MetadataCollection
         }
         catch (JsonParseException e)
         {
-            FMLLog.log(Level.ERROR, e, "The mcmod.info file in %s cannot be parsed as valid JSON. It will be ignored", sourceName);
+            FMLLog.error(e, "The mcmod.info file in {} cannot be parsed as valid JSON. It will be ignored", sourceName);
             return new MetadataCollection();
         }
         catch (Exception e)

--- a/src/main/java/net/minecraftforge/fml/common/MetadataCollection.java
+++ b/src/main/java/net/minecraftforge/fml/common/MetadataCollection.java
@@ -83,7 +83,7 @@ public class MetadataCollection
         }
         catch (JsonParseException e)
         {
-            FMLLog.error(e, "The mcmod.info file in {} cannot be parsed as valid JSON. It will be ignored", sourceName);
+            FMLLog.log.error("The mcmod.info file in {} cannot be parsed as valid JSON. It will be ignored", sourceName, e);
             return new MetadataCollection();
         }
         catch (Exception e)

--- a/src/main/java/net/minecraftforge/fml/common/ModAPIManager.java
+++ b/src/main/java/net/minecraftforge/fml/common/ModAPIManager.java
@@ -110,7 +110,7 @@ public class ModAPIManager {
         public void validate(String providedAPI, String apiOwner, String apiVersion)
         {
             if (Loader.instance().getModClassLoader().containsSource(this.getSource())) {
-                FMLLog.bigWarning("The API %s from source %s is loaded from an incompatible classloader. THIS WILL NOT WORK!", providedAPI, this.getSource().getAbsolutePath());
+                FMLLog.bigWarning("The API {} from source {} is loaded from an incompatible classloader. THIS WILL NOT WORK!", providedAPI, this.getSource().getAbsolutePath());
             }
             // TODO Compare this annotation data to the one we first found. Maybe barf if there is inconsistency?
         }
@@ -180,7 +180,7 @@ public class ModAPIManager {
                 {
                     continue;
                 }
-                FMLLog.fine("Found API %s (owned by %s providing %s) embedded in %s",apiPackage, apiOwner, providedAPI, embeddedIn);
+                FMLLog.log.debug("Found API {} (owned by {} providing {}) embedded in {}",apiPackage, apiOwner, providedAPI, embeddedIn);
                 if (!embeddedIn.equals(apiOwner))
                 {
                     container.addAPIReference(embeddedIn);
@@ -198,7 +198,7 @@ public class ModAPIManager {
                     List<String> candidateIds = Lists.transform(candidate.getContainedMods(), new ModIdFunction());
                     if (!candidateIds.contains(container.ownerMod.getLabel()) && !container.currentReferents.containsAll(candidateIds))
                     {
-                        FMLLog.info("Found mod(s) %s containing declared API package %s (owned by %s) without associated API reference",candidateIds, pkg, container.ownerMod);
+                        FMLLog.log.info("Found mod(s) {} containing declared API package {} (owned by {}) without associated API reference",candidateIds, pkg, container.ownerMod);
                         container.addAPIReferences(candidateIds);
                     }
                 }
@@ -211,18 +211,18 @@ public class ModAPIManager {
                     APIContainer parent = apiContainers.get(owner.getLabel());
                     if (parent == container)
                     {
-                        FMLLog.finer("APIContainer %s is it's own parent. skipping", owner);
+                        FMLLog.log.trace("APIContainer {} is it's own parent. skipping", owner);
                         container.markSelfReferenced();
                         break;
                     }
-                    FMLLog.finer("Removing upstream parent %s from %s", parent.ownerMod.getLabel(), container);
+                    FMLLog.log.trace("Removing upstream parent {} from {}", parent.ownerMod.getLabel(), container);
                     container.currentReferents.remove(parent.ownerMod.getLabel());
                     container.referredMods.remove(parent.ownerMod);
                     owner = parent.ownerMod;
                 }
                 while (apiContainers.containsKey(owner.getLabel()));
             }
-            FMLLog.fine("Creating API container dummy for API %s: owner: %s, dependents: %s", container.providedAPI, container.ownerMod, container.referredMods);
+            FMLLog.log.debug("Creating API container dummy for API {}: owner: {}, dependents: {}", container.providedAPI, container.ownerMod, container.referredMods);
         }
     }
 

--- a/src/main/java/net/minecraftforge/fml/common/ModClassLoader.java
+++ b/src/main/java/net/minecraftforge/fml/common/ModClassLoader.java
@@ -91,7 +91,7 @@ public class ModClassLoader extends URLClassLoader
         }
         catch (URISyntaxException e)
         {
-            FMLLog.log(Level.ERROR, e, "Unable to process our input to locate the minecraft code");
+            FMLLog.log.error("Unable to process our input to locate the minecraft code", e);
             throw new LoaderException(e);
         }
     }

--- a/src/main/java/net/minecraftforge/fml/common/ModContainerFactory.java
+++ b/src/main/java/net/minecraftforge/fml/common/ModContainerFactory.java
@@ -56,7 +56,7 @@ public class ModContainerFactory
             Constructor<? extends ModContainer> constructor = container.getConstructor(new Class<?>[] { String.class, ModCandidate.class, Map.class });
             modTypes.put(type, constructor);
         } catch (Exception e) {
-            FMLLog.log.error("Critical error : cannot register mod container type {}, it has an invalid constructor", e);
+            FMLLog.log.error("Critical error : cannot register mod container type {}, it has an invalid constructor", container.getName(), e);
             Throwables.propagate(e);
         }
     }

--- a/src/main/java/net/minecraftforge/fml/common/ModContainerFactory.java
+++ b/src/main/java/net/minecraftforge/fml/common/ModContainerFactory.java
@@ -95,7 +95,7 @@ public class ModContainerFactory
                     }
                     return ret;
                 } catch (Exception e) {
-                    FMLLog.error(e, "Unable to construct {} container", ann.getASMType().getClassName());
+                    FMLLog.log.error("Unable to construct {} container", ann.getASMType().getClassName(), e);
                     return null;
                 }
             }

--- a/src/main/java/net/minecraftforge/fml/common/ModContainerFactory.java
+++ b/src/main/java/net/minecraftforge/fml/common/ModContainerFactory.java
@@ -56,7 +56,7 @@ public class ModContainerFactory
             Constructor<? extends ModContainer> constructor = container.getConstructor(new Class<?>[] { String.class, ModCandidate.class, Map.class });
             modTypes.put(type, constructor);
         } catch (Exception e) {
-            FMLLog.log(Level.ERROR, e, "Critical error : cannot register mod container type %s, it has an invalid constructor");
+            FMLLog.log.error("Critical error : cannot register mod container type {}, it has an invalid constructor", e);
             Throwables.propagate(e);
         }
     }
@@ -67,17 +67,17 @@ public class ModContainerFactory
         String className = modParser.getASMType().getClassName();
         if (modParser.isBaseMod(container.getRememberedBaseMods()) && modClass.matcher(className).find())
         {
-            FMLLog.severe("Found a BaseMod type mod %s", className);
-            FMLLog.severe("This will not be loaded and will be ignored. ModLoader mechanisms are no longer available.");
+            FMLLog.log.fatal("Found a BaseMod type mod {}", className);
+            FMLLog.log.fatal("This will not be loaded and will be ignored. ModLoader mechanisms are no longer available.");
         }
         else if (modClass.matcher(className).find())
         {
-            FMLLog.fine("Identified a class %s following modloader naming convention but not directly a BaseMod or currently seen subclass", className);
+            FMLLog.log.debug("Identified a class {} following modloader naming convention but not directly a BaseMod or currently seen subclass", className);
             container.rememberModCandidateType(modParser);
         }
         else if (modParser.isBaseMod(container.getRememberedBaseMods()))
         {
-            FMLLog.fine("Found a basemod %s of non-standard naming format", className);
+            FMLLog.log.debug("Found a basemod {} of non-standard naming format", className);
             container.rememberBaseModType(className);
         }
 
@@ -85,17 +85,17 @@ public class ModContainerFactory
         {
             if (modTypes.containsKey(ann.getASMType()))
             {
-                FMLLog.fine("Identified a mod of type %s (%s) - loading", ann.getASMType(), className);
+                FMLLog.log.debug("Identified a mod of type {} ({}) - loading", ann.getASMType(), className);
                 try {
                     ModContainer ret = modTypes.get(ann.getASMType()).newInstance(className, container, ann.getValues());
                     if (!ret.shouldLoadInEnvironment())
                     {
-                        FMLLog.fine("Skipping mod %s, container opted to not load.", className);
+                        FMLLog.log.debug("Skipping mod {}, container opted to not load.", className);
                         return null;
                     }
                     return ret;
                 } catch (Exception e) {
-                    FMLLog.log(Level.ERROR, e, "Unable to construct %s container", ann.getASMType().getClassName());
+                    FMLLog.error(e, "Unable to construct {} container", ann.getASMType().getClassName());
                     return null;
                 }
             }

--- a/src/main/java/net/minecraftforge/fml/common/ObfuscationReflectionHelper.java
+++ b/src/main/java/net/minecraftforge/fml/common/ObfuscationReflectionHelper.java
@@ -43,7 +43,7 @@ public class ObfuscationReflectionHelper
         }
         catch (UnableToAccessFieldException e)
         {
-            FMLLog.error(e, "There was a problem getting field index {} from {}", fieldIndex, classToAccess.getName());
+            FMLLog.log.error("There was a problem getting field index {} from {}", classToAccess.getName(), e);
             throw e;
         }
     }
@@ -68,12 +68,12 @@ public class ObfuscationReflectionHelper
         }
         catch (UnableToFindFieldException e)
         {
-            FMLLog.error(e,"Unable to locate any field {} on type {}", Arrays.toString(fieldNames), classToAccess.getName());
+            FMLLog.log.error("Unable to locate any field {} on type {}", Arrays.toString(fieldNames), classToAccess.getName(), e);
             throw e;
         }
         catch (UnableToAccessFieldException e)
         {
-            FMLLog.error(e, "Unable to access any field {} on type {}", Arrays.toString(fieldNames), classToAccess.getName());
+            FMLLog.log.error("Unable to access any field {} on type {}", classToAccess.getName(), e);
             throw e;
         }
     }
@@ -86,7 +86,7 @@ public class ObfuscationReflectionHelper
         }
         catch (UnableToAccessFieldException e)
         {
-            FMLLog.error(e, "There was a problem setting field index {} on type {}", fieldIndex, classToAccess.getName());
+            FMLLog.log.error("There was a problem setting field index {} on type {}", classToAccess.getName(), e);
             throw e;
         }
     }
@@ -99,12 +99,12 @@ public class ObfuscationReflectionHelper
         }
         catch (UnableToFindFieldException e)
         {
-            FMLLog.error(e, "Unable to locate any field {} on type {}", Arrays.toString(fieldNames), classToAccess.getName());
+            FMLLog.log.error("Unable to locate any field {} on type {}", classToAccess.getName(), e);
             throw e;
         }
         catch (UnableToAccessFieldException e)
         {
-            FMLLog.error(e, "Unable to set any field {} on type {}", Arrays.toString(fieldNames), classToAccess.getName());
+            FMLLog.log.error("Unable to set any field {} on type {}", classToAccess.getName(), e);
             throw e;
         }
     }

--- a/src/main/java/net/minecraftforge/fml/common/ObfuscationReflectionHelper.java
+++ b/src/main/java/net/minecraftforge/fml/common/ObfuscationReflectionHelper.java
@@ -43,7 +43,7 @@ public class ObfuscationReflectionHelper
         }
         catch (UnableToAccessFieldException e)
         {
-            FMLLog.log(Level.ERROR, e, "There was a problem getting field index %d from %s", fieldIndex, classToAccess.getName());
+            FMLLog.error(e, "There was a problem getting field index {} from {}", fieldIndex, classToAccess.getName());
             throw e;
         }
     }
@@ -68,12 +68,12 @@ public class ObfuscationReflectionHelper
         }
         catch (UnableToFindFieldException e)
         {
-            FMLLog.log(Level.ERROR,e,"Unable to locate any field %s on type %s", Arrays.toString(fieldNames), classToAccess.getName());
+            FMLLog.error(e,"Unable to locate any field {} on type {}", Arrays.toString(fieldNames), classToAccess.getName());
             throw e;
         }
         catch (UnableToAccessFieldException e)
         {
-            FMLLog.log(Level.ERROR, e, "Unable to access any field %s on type %s", Arrays.toString(fieldNames), classToAccess.getName());
+            FMLLog.error(e, "Unable to access any field {} on type {}", Arrays.toString(fieldNames), classToAccess.getName());
             throw e;
         }
     }
@@ -86,7 +86,7 @@ public class ObfuscationReflectionHelper
         }
         catch (UnableToAccessFieldException e)
         {
-            FMLLog.log(Level.ERROR, e, "There was a problem setting field index %d on type %s", fieldIndex, classToAccess.getName());
+            FMLLog.error(e, "There was a problem setting field index {} on type {}", fieldIndex, classToAccess.getName());
             throw e;
         }
     }
@@ -99,12 +99,12 @@ public class ObfuscationReflectionHelper
         }
         catch (UnableToFindFieldException e)
         {
-            FMLLog.log(Level.ERROR, e, "Unable to locate any field %s on type %s", Arrays.toString(fieldNames), classToAccess.getName());
+            FMLLog.error(e, "Unable to locate any field {} on type {}", Arrays.toString(fieldNames), classToAccess.getName());
             throw e;
         }
         catch (UnableToAccessFieldException e)
         {
-            FMLLog.log(Level.ERROR, e, "Unable to set any field %s on type %s", Arrays.toString(fieldNames), classToAccess.getName());
+            FMLLog.error(e, "Unable to set any field {} on type {}", Arrays.toString(fieldNames), classToAccess.getName());
             throw e;
         }
     }

--- a/src/main/java/net/minecraftforge/fml/common/ProgressManager.java
+++ b/src/main/java/net/minecraftforge/fml/common/ProgressManager.java
@@ -71,11 +71,11 @@ public class ProgressManager
         {
             long newTime = System.nanoTime();
             if (bar.timeEachStep)
-                FMLLog.fine("Bar Step: %s - %s took %.3fs", bar.getTitle(), bar.getMessage(), ((float)(newTime - bar.lastTime) / 1000000 / 1000));
+                FMLLog.log.debug(String.format("Bar Step: %s - %s took %.3fs", bar.getTitle(), bar.getMessage(), ((float)(newTime - bar.lastTime) / 1000000 / 1000)));
             if (bar.getSteps() == 1)
-                FMLLog.fine("Bar Finished: %s - %s took %.3fs", bar.getTitle(), bar.getMessage(), ((float)(newTime - bar.startTime) / 1000000 / 1000));
+                FMLLog.log.debug(String.format("Bar Finished: %s - %s took %.3fs", bar.getTitle(), bar.getMessage(), ((float)(newTime - bar.startTime) / 1000000 / 1000)));
             else
-                FMLLog.fine("Bar Finished: %s took %.3fs", bar.getTitle(), ((float)(newTime - bar.startTime) / 1000000 / 1000));
+                FMLLog.log.debug(String.format("Bar Finished: %s took %.3fs", bar.getTitle(), ((float)(newTime - bar.startTime) / 1000000 / 1000)));
         }
         FMLCommonHandler.instance().processWindowMessages();
     }
@@ -120,7 +120,7 @@ public class ProgressManager
             if (timeEachStep && step != 0)
             {
                 long newTime = System.nanoTime();
-                FMLLog.fine("Bar Step: %s - %s took %.3fs", getTitle(), getMessage(), ((float)(newTime - lastTime) / 1000000 / 1000));
+                FMLLog.log.debug(String.format("Bar Step: %s - %s took %.3fs", getTitle(), getMessage(), ((float)(newTime - lastTime) / 1000000 / 1000)));
                 lastTime = newTime;
             }
             step++;

--- a/src/main/java/net/minecraftforge/fml/common/ProxyInjector.java
+++ b/src/main/java/net/minecraftforge/fml/common/ProxyInjector.java
@@ -40,7 +40,7 @@ public class ProxyInjector
 {
     public static void inject(ModContainer mod, ASMDataTable data, Side side, ILanguageAdapter languageAdapter)
     {
-        FMLLog.fine("Attempting to inject @SidedProxy classes into %s", mod.getModId());
+        FMLLog.log.debug("Attempting to inject @SidedProxy classes into {}", mod.getModId());
         SetMultimap<String, ASMData> modData = data.getAnnotationsFor(mod);
         Set<ASMData> mods = modData.get(Mod.class.getName());
         Set<ASMData> targets = modData.get(SidedProxy.class.getName());
@@ -56,13 +56,13 @@ public class ProxyInjector
                     amodid = ASMDataTable.getOwnerModID(mods, targ);
                     if (Strings.isNullOrEmpty(amodid))
                     {
-                        FMLLog.bigWarning("Could not determine owning mod for @SidedProxy on %s for mod %s", targ.getClassName(), mod.getModId());
+                        FMLLog.bigWarning("Could not determine owning mod for @SidedProxy on {} for mod {}", targ.getClassName(), mod.getModId());
                         continue;
                     }
                 }
                 if (!mod.getModId().equals(amodid))
                 {
-                    FMLLog.fine("Skipping proxy injection for %s.%s since it is not for mod %s", targ.getClassName(), targ.getObjectName(), mod.getModId());
+                    FMLLog.log.debug("Skipping proxy injection for {}.{} since it is not for mod {}", targ.getClassName(), targ.getObjectName(), mod.getModId());
                     continue;
                 }
 
@@ -71,7 +71,7 @@ public class ProxyInjector
                 if (target == null)
                 {
                     // Impossible?
-                    FMLLog.severe("Attempted to load a proxy type into %s.%s but the field was not found", targ.getClassName(), targ.getObjectName());
+                    FMLLog.log.fatal("Attempted to load a proxy type into {}.{} but the field was not found", targ.getClassName(), targ.getObjectName());
                     throw new LoaderException(String.format("Attempted to load a proxy type into %s.%s but the field was not found", targ.getClassName(), targ.getObjectName()));
                 }
                 target.setAccessible(true);
@@ -86,19 +86,19 @@ public class ProxyInjector
 
                 if (languageAdapter.supportsStatics() && (target.getModifiers() & Modifier.STATIC) == 0 )
                 {
-                    FMLLog.severe("Attempted to load a proxy type %s into %s.%s, but the field is not static", targetType, targ.getClassName(), targ.getObjectName());
+                    FMLLog.log.fatal("Attempted to load a proxy type {} into {}.{}, but the field is not static", targetType, targ.getClassName(), targ.getObjectName());
                     throw new LoaderException(String.format("Attempted to load a proxy type %s into %s.%s, but the field is not static", targetType, targ.getClassName(), targ.getObjectName()));
                 }
                 if (!target.getType().isAssignableFrom(proxy.getClass()))
                 {
-                    FMLLog.severe("Attempted to load a proxy type %s into %s.%s, but the types don't match", targetType, targ.getClassName(), targ.getObjectName());
+                    FMLLog.log.fatal("Attempted to load a proxy type {} into {}.{}, but the types don't match", targetType, targ.getClassName(), targ.getObjectName());
                     throw new LoaderException(String.format("Attempted to load a proxy type %s into %s.%s, but the types don't match", targetType, targ.getClassName(), targ.getObjectName()));
                 }
                 languageAdapter.setProxy(target, proxyTarget, proxy);
             }
             catch (Exception e)
             {
-                FMLLog.log(Level.ERROR, e, "An error occurred trying to load a proxy into %s.%s", targ.getAnnotationInfo(), targ.getClassName(), targ.getObjectName());
+                FMLLog.error(e, "An error occurred trying to load a proxy into {}.{}", targ.getAnnotationInfo(), targ.getClassName(), targ.getObjectName());
                 throw new LoaderException(e);
             }
         }

--- a/src/main/java/net/minecraftforge/fml/common/ProxyInjector.java
+++ b/src/main/java/net/minecraftforge/fml/common/ProxyInjector.java
@@ -98,7 +98,7 @@ public class ProxyInjector
             }
             catch (Exception e)
             {
-                FMLLog.error(e, "An error occurred trying to load a proxy into {}.{}", targ.getAnnotationInfo(), targ.getClassName(), targ.getObjectName());
+                FMLLog.log.error("An error occurred trying to load a proxy into {}.{}", targ.getObjectName(), e);
                 throw new LoaderException(e);
             }
         }

--- a/src/main/java/net/minecraftforge/fml/common/StartupQuery.java
+++ b/src/main/java/net/minecraftforge/fml/common/StartupQuery.java
@@ -68,7 +68,7 @@ public class StartupQuery {
             }
             catch (InterruptedException e)
             {
-                FMLLog.warning("query interrupted");
+                FMLLog.log.warn("query interrupted");
                 abort();
             }
 
@@ -120,7 +120,7 @@ public class StartupQuery {
 
         if (result != null && prop != null)
         {
-            FMLLog.info("Using fml.queryResult %s to answer the following query:\n%s", prop, text);
+            FMLLog.log.info("Using fml.queryResult {} to answer the following query:\n{}", prop, text);
 
             if (prop.equalsIgnoreCase("confirm"))
             {
@@ -133,7 +133,7 @@ public class StartupQuery {
                 return;
             }
 
-            FMLLog.warning("Invalid value for fml.queryResult: %s, expected confirm or cancel", prop);
+            FMLLog.log.warn("Invalid value for fml.queryResult: {}, expected confirm or cancel", prop);
         }
 
         synchronous = false;
@@ -156,7 +156,7 @@ public class StartupQuery {
         }
         catch (InterruptedException e)
         {
-            FMLLog.warning("query interrupted");
+            FMLLog.log.warn("query interrupted");
             abort();
         }
     }

--- a/src/main/java/net/minecraftforge/fml/common/TracingPrintStream.java
+++ b/src/main/java/net/minecraftforge/fml/common/TracingPrintStream.java
@@ -40,12 +40,12 @@ public class TracingPrintStream extends PrintStream {
 
     @Override
     public void println(Object o) {
-        logger.info(getPrefix() + o);
+        logger.info("{}{}", getPrefix(), o);
     }
 
     @Override
     public void println(String s) {
-        logger.info(getPrefix() + s);
+        logger.info("{}{}", getPrefix(), s);
     }
 
     private String getPrefix() {

--- a/src/main/java/net/minecraftforge/fml/common/ZipperUtil.java
+++ b/src/main/java/net/minecraftforge/fml/common/ZipperUtil.java
@@ -102,10 +102,10 @@ public class ZipperUtil {
         }
         catch (IOException e)
         {
-            FMLLog.log(Level.WARN, e, "World backup failed.");
+            FMLLog.log.warn("World backup failed.", e);
             throw e;
         }
 
-        FMLLog.info("World backup created at %s.", zip.getCanonicalPath());
+        FMLLog.log.info("World backup created at {}.", zip.getCanonicalPath());
     }
 }

--- a/src/main/java/net/minecraftforge/fml/common/asm/FMLSanityChecker.java
+++ b/src/main/java/net/minecraftforge/fml/common/asm/FMLSanityChecker.java
@@ -168,7 +168,7 @@ public class FMLSanityChecker implements IFMLCallHook
             else
             {
                 log.error("FML has been ordered to ignore the invalid or missing minecraft certificate. This is very likely to cause a problem!");
-                log.error("Technical information: ClientBrandRetriever was at %s, there were {} certificates for it", codeSource.getLocation(), certCount);
+                log.error("Technical information: ClientBrandRetriever was at {}, there were {} certificates for it", codeSource.getLocation(), certCount);
             }
         }
         if (!goodFML)

--- a/src/main/java/net/minecraftforge/fml/common/asm/FMLSanityChecker.java
+++ b/src/main/java/net/minecraftforge/fml/common/asm/FMLSanityChecker.java
@@ -30,7 +30,6 @@ import java.util.jar.JarFile;
 
 import net.minecraftforge.common.util.Java6Utils;
 import org.apache.commons.io.IOUtils;
-import org.apache.logging.log4j.Level;
 
 import net.minecraft.launchwrapper.LaunchClassLoader;
 import net.minecraftforge.fml.common.CertificateHelper;
@@ -38,12 +37,13 @@ import net.minecraftforge.fml.common.FMLCommonHandler;
 import net.minecraftforge.fml.common.asm.transformers.deobf.FMLDeobfuscatingRemapper;
 import net.minecraftforge.fml.common.patcher.ClassPatchManager;
 import net.minecraftforge.fml.relauncher.FMLLaunchHandler;
-import net.minecraftforge.fml.relauncher.FMLRelaunchLog;
 import net.minecraftforge.fml.relauncher.IFMLCallHook;
 import net.minecraftforge.fml.relauncher.Side;
 
 import com.google.common.base.Charsets;
 import com.google.common.io.ByteStreams;
+
+import static net.minecraftforge.fml.common.FMLLog.log;
 
 public class FMLSanityChecker implements IFMLCallHook
 {
@@ -72,17 +72,17 @@ public class FMLSanityChecker implements IFMLCallHook
                     String fingerprint = CertificateHelper.getFingerprint(cert);
                     if (fingerprint.equals(FMLFINGERPRINT))
                     {
-                        FMLRelaunchLog.info("Found valid fingerprint for FML. Certificate fingerprint %s", fingerprint);
+                        log.info("Found valid fingerprint for FML. Certificate fingerprint {}", fingerprint);
                         goodFML = true;
                     }
                     else if (fingerprint.equals(FORGEFINGERPRINT))
                     {
-                        FMLRelaunchLog.info("Found valid fingerprint for Minecraft Forge. Certificate fingerprint %s", fingerprint);
+                        log.info("Found valid fingerprint for Minecraft Forge. Certificate fingerprint {}", fingerprint);
                         goodFML = true;
                     }
                     else
                     {
-                        FMLRelaunchLog.severe("Found invalid fingerprint for FML: %s", fingerprint);
+                        log.error("Found invalid fingerprint for FML: {}", fingerprint);
                     }
                 }
             }
@@ -134,7 +134,7 @@ public class FMLSanityChecker implements IFMLCallHook
                         String fingerprint = CertificateHelper.getFingerprint(cert);
                         if (fingerprint.equals(MCFINGERPRINT))
                         {
-                            FMLRelaunchLog.info("Found valid fingerprint for Minecraft. Certificate fingerprint %s", fingerprint);
+                            log.info("Found valid fingerprint for Minecraft. Certificate fingerprint {}", fingerprint);
                             goodMC = true;
                         }
                     }
@@ -142,7 +142,7 @@ public class FMLSanityChecker implements IFMLCallHook
             }
             catch (Throwable e)
             {
-                FMLRelaunchLog.log(Level.ERROR, e, "A critical error occurred trying to read the minecraft jar file");
+                log.error("A critical error occurred trying to read the minecraft jar file", e);
             }
             finally
             {
@@ -155,11 +155,11 @@ public class FMLSanityChecker implements IFMLCallHook
         }
         if (!goodMC)
         {
-            FMLRelaunchLog.severe("The minecraft jar %s appears to be corrupt! There has been CRITICAL TAMPERING WITH MINECRAFT, it is highly unlikely minecraft will work! STOP NOW, get a clean copy and try again!",codeSource.getLocation().getFile());
+            log.error("The minecraft jar {} appears to be corrupt! There has been CRITICAL TAMPERING WITH MINECRAFT, it is highly unlikely minecraft will work! STOP NOW, get a clean copy and try again!", codeSource.getLocation().getFile());
             if (!Boolean.parseBoolean(System.getProperty("fml.ignoreInvalidMinecraftCertificates","false")))
             {
-                FMLRelaunchLog.severe("For your safety, FML will not launch minecraft. You will need to fetch a clean version of the minecraft jar file");
-                FMLRelaunchLog.severe("Technical information: The class net.minecraft.client.ClientBrandRetriever should have been associated with the minecraft jar file, " +
+                log.error("For your safety, FML will not launch minecraft. You will need to fetch a clean version of the minecraft jar file");
+                log.error("Technical information: The class net.minecraft.client.ClientBrandRetriever should have been associated with the minecraft jar file, " +
                 		"and should have returned us a valid, intact minecraft jar location. This did not work. Either you have modified the minecraft jar file (if so " +
                 		"run the forge installer again), or you are using a base editing jar that is changing this class (and likely others too). If you REALLY " +
                 		"want to run minecraft in this configuration, add the flag -Dfml.ignoreInvalidMinecraftCertificates=true to the 'JVM settings' in your launcher profile.");
@@ -167,13 +167,13 @@ public class FMLSanityChecker implements IFMLCallHook
             }
             else
             {
-                FMLRelaunchLog.severe("FML has been ordered to ignore the invalid or missing minecraft certificate. This is very likely to cause a problem!");
-                FMLRelaunchLog.severe("Technical information: ClientBrandRetriever was at %s, there were %d certificates for it", codeSource.getLocation(), certCount);
+                log.error("FML has been ordered to ignore the invalid or missing minecraft certificate. This is very likely to cause a problem!");
+                log.error("Technical information: ClientBrandRetriever was at %s, there were {} certificates for it", codeSource.getLocation(), certCount);
             }
         }
         if (!goodFML)
         {
-            FMLRelaunchLog.severe("FML appears to be missing any signature data. This is not a good thing");
+            log.error("FML appears to be missing any signature data. This is not a good thing");
         }
         return null;
     }

--- a/src/main/java/net/minecraftforge/fml/common/asm/transformers/AccessTransformer.java
+++ b/src/main/java/net/minecraftforge/fml/common/asm/transformers/AccessTransformer.java
@@ -19,6 +19,7 @@
 
 package net.minecraftforge.fml.common.asm.transformers;
 
+import net.minecraftforge.fml.common.FMLLog;
 import static org.objectweb.asm.Opcodes.ACC_FINAL;
 import static org.objectweb.asm.Opcodes.ACC_PRIVATE;
 import static org.objectweb.asm.Opcodes.ACC_PROTECTED;
@@ -43,7 +44,6 @@ import java.util.zip.ZipInputStream;
 import java.util.zip.ZipOutputStream;
 
 import net.minecraft.launchwrapper.IClassTransformer;
-import net.minecraftforge.fml.relauncher.FMLRelaunchLog;
 
 import org.apache.commons.io.IOUtils;
 import org.objectweb.asm.ClassReader;
@@ -125,7 +125,7 @@ public class AccessTransformer implements IClassTransformer
             rulesResource = Resources.getResource(rulesFile);
         }
         processATFile(Resources.asCharSource(rulesResource, Charsets.UTF_8));
-        FMLRelaunchLog.fine("Loaded %d rules from AccessTransformer config file %s", modifiers.size(), rulesFile);
+        FMLLog.log.debug("Loaded {} rules from AccessTransformer config file {}", modifiers.size(), rulesFile);
     }
     protected void processATFile(CharSource rulesResource) throws IOException
     {
@@ -173,7 +173,7 @@ public class AccessTransformer implements IClassTransformer
                 }
                 String className = parts.get(1).replace('/', '.');
                 modifiers.put(className, m);
-                if (DEBUG) FMLRelaunchLog.fine("AT RULE: %s %s %s (type %s)", toBinary(m.targetAccess), m.name, m.desc, className);
+                if (DEBUG) FMLLog.log.debug("AT RULE: {} {} {} (type {})", toBinary(m.targetAccess), m.name, m.desc, className);
                 return true;
             }
         });
@@ -187,7 +187,7 @@ public class AccessTransformer implements IClassTransformer
 
         if (DEBUG)
         {
-            FMLRelaunchLog.fine("Considering all methods and fields on %s (%s)", transformedName, name);
+            FMLLog.log.debug("Considering all methods and fields on {} ({})", transformedName, name);
         }
 
         ClassNode classNode = new ClassNode();
@@ -202,7 +202,7 @@ public class AccessTransformer implements IClassTransformer
                 classNode.access = getFixedAccess(classNode.access, m);
                 if (DEBUG)
                 {
-                    FMLRelaunchLog.fine("Class: %s %s -> %s", name, toBinary(m.oldAccess), toBinary(m.newAccess));
+                    FMLLog.log.debug("Class: {} {} -> {}", name, toBinary(m.oldAccess), toBinary(m.newAccess));
                 }
                 continue;
             }
@@ -215,7 +215,7 @@ public class AccessTransformer implements IClassTransformer
                         n.access = getFixedAccess(n.access, m);
                         if (DEBUG)
                         {
-                            FMLRelaunchLog.fine("Field: %s.%s %s -> %s", name, n.name, toBinary(m.oldAccess), toBinary(m.newAccess));
+                            FMLLog.log.debug("Field: {}.{} {} -> {}", name, n.name, toBinary(m.oldAccess), toBinary(m.newAccess));
                         }
 
                         if (!m.name.equals("*"))
@@ -251,7 +251,7 @@ public class AccessTransformer implements IClassTransformer
 
                         if (DEBUG)
                         {
-                            FMLRelaunchLog.fine("Method: %s.%s%s %s -> %s", name, n.name, n.desc, toBinary(m.oldAccess), toBinary(m.newAccess));
+                            FMLLog.log.debug("Method: {}.{}{} {} -> {}", name, n.name, n.desc, toBinary(m.oldAccess), toBinary(m.newAccess));
                         }
 
                         if (!m.name.equals("*"))

--- a/src/main/java/net/minecraftforge/fml/common/asm/transformers/BlamingTransformer.java
+++ b/src/main/java/net/minecraftforge/fml/common/asm/transformers/BlamingTransformer.java
@@ -58,7 +58,7 @@ public class BlamingTransformer implements IClassTransformer
     {
         naughtyClasses.add(cls);
         naughtyMods.add(modId);
-        FMLLog.severe("Unsupported class format in mod %s: class %s", modId, cls);
+        FMLLog.log.fatal("Unsupported class format in mod {}: class {}", modId, cls);
     }
 
     public static class VersionVisitor extends ClassVisitor

--- a/src/main/java/net/minecraftforge/fml/common/asm/transformers/ModAPITransformer.java
+++ b/src/main/java/net/minecraftforge/fml/common/asm/transformers/ModAPITransformer.java
@@ -126,7 +126,7 @@ public class ModAPITransformer implements IClassTransformer {
             final RemovingSignatureWriter signatureWriter = new RemovingSignatureWriter(ifaceName);
             sr.accept(signatureWriter);
             classNode.signature = signatureWriter.toString();
-            if (logDebugInfo) FMLLog.log.debug("Optional removal - interface {} removed from type signature");
+            if (logDebugInfo) FMLLog.log.debug("Optional removal - interface {} removed from type signature", interfaceName);
         }
         if (found && logDebugInfo) FMLLog.log.debug("Optional removal - interface {} removed", interfaceName);
         if (!found && logDebugInfo) FMLLog.log.debug("Optional removal - interface {} NOT removed - not found", interfaceName);

--- a/src/main/java/net/minecraftforge/fml/common/asm/transformers/ModAPITransformer.java
+++ b/src/main/java/net/minecraftforge/fml/common/asm/transformers/ModAPITransformer.java
@@ -26,11 +26,11 @@ import java.util.Map;
 import java.util.Set;
 
 import net.minecraft.launchwrapper.IClassTransformer;
+import net.minecraftforge.fml.common.FMLLog;
 import net.minecraftforge.fml.common.Loader;
 import net.minecraftforge.fml.common.ModAPIManager;
 import net.minecraftforge.fml.common.discovery.ASMDataTable;
 import net.minecraftforge.fml.common.discovery.ASMDataTable.ASMData;
-import net.minecraftforge.fml.relauncher.FMLRelaunchLog;
 
 import org.objectweb.asm.ClassReader;
 import org.objectweb.asm.ClassWriter;
@@ -64,17 +64,17 @@ public class ModAPITransformer implements IClassTransformer {
         ClassReader classReader = new ClassReader(basicClass);
         classReader.accept(classNode, 0);
 
-        if (logDebugInfo) FMLRelaunchLog.finer("Optional removal - found optionals for class %s - processing", name);
+        if (logDebugInfo) FMLLog.log.trace("Optional removal - found optionals for class {} - processing", name);
         for (ASMData optional : optionals.get(lookupName))
         {
             String modId = (String) optional.getAnnotationInfo().get("modid");
 
             if (Loader.isModLoaded(modId) || ModAPIManager.INSTANCE.hasAPI(modId))
             {
-                if (logDebugInfo) FMLRelaunchLog.finer("Optional removal skipped - mod present %s", modId);
+                if (logDebugInfo) FMLLog.log.trace("Optional removal skipped - mod present {}", modId);
                 continue;
             }
-            if (logDebugInfo) FMLRelaunchLog.finer("Optional on %s triggered - mod missing %s", name, modId);
+            if (logDebugInfo) FMLLog.log.trace("Optional on {} triggered - mod missing {}", name, modId);
 
             if (optional.getAnnotationInfo().containsKey("iface"))
             {
@@ -88,7 +88,7 @@ public class ModAPITransformer implements IClassTransformer {
             }
 
         }
-        if (logDebugInfo) FMLRelaunchLog.finer("Optional removal - class %s processed", name);
+        if (logDebugInfo) FMLLog.log.trace("Optional removal - class {} processed", name);
 
         ClassWriter writer = new ClassWriter(ClassWriter.COMPUTE_MAXS);
         classNode.accept(writer);
@@ -109,11 +109,11 @@ public class ModAPITransformer implements IClassTransformer {
             if (methodDescriptor.equals(method.name+method.desc))
             {
                 iterator.remove();
-                if (logDebugInfo) FMLRelaunchLog.finer("Optional removal - method %s removed", methodDescriptor);
+                if (logDebugInfo) FMLLog.log.debug("Optional removal - method {} removed", methodDescriptor);
                 return;
             }
         }
-        if (logDebugInfo) FMLRelaunchLog.finer("Optional removal - method %s NOT removed - not found", methodDescriptor);
+        if (logDebugInfo) FMLLog.log.debug("Optional removal - method {} NOT removed - not found", methodDescriptor);
     }
 
     private void stripInterface(ClassNode classNode, String interfaceName, boolean stripRefs)
@@ -126,28 +126,28 @@ public class ModAPITransformer implements IClassTransformer {
             final RemovingSignatureWriter signatureWriter = new RemovingSignatureWriter(ifaceName);
             sr.accept(signatureWriter);
             classNode.signature = signatureWriter.toString();
-            if (logDebugInfo) FMLRelaunchLog.finer("Optional removal - interface %s removed from type signature");
+            if (logDebugInfo) FMLLog.log.debug("Optional removal - interface {} removed from type signature");
         }
-        if (found && logDebugInfo) FMLRelaunchLog.finer("Optional removal - interface %s removed", interfaceName);
-        if (!found && logDebugInfo) FMLRelaunchLog.finer("Optional removal - interface %s NOT removed - not found", interfaceName);
+        if (found && logDebugInfo) FMLLog.log.debug("Optional removal - interface {} removed", interfaceName);
+        if (!found && logDebugInfo) FMLLog.log.debug("Optional removal - interface {} NOT removed - not found", interfaceName);
 
         if (found && stripRefs)
         {
-            if (logDebugInfo) FMLRelaunchLog.finer("Optional removal - interface %s - stripping method signature references", interfaceName);
+            if (logDebugInfo) FMLLog.log.debug("Optional removal - interface {} - stripping method signature references", interfaceName);
             for (Iterator<MethodNode> iterator = classNode.methods.iterator(); iterator.hasNext();)
             {
                 MethodNode node = iterator.next();
                 if (node.desc.contains(ifaceName))
                 {
-                    if (logDebugInfo) FMLRelaunchLog.finer("Optional removal - interface %s - stripping method containing reference %s", interfaceName, node.name);
+                    if (logDebugInfo) FMLLog.log.debug("Optional removal - interface {} - stripping method containing reference {}", interfaceName, node.name);
                     iterator.remove();
                 }
             }
-            if (logDebugInfo) FMLRelaunchLog.finer("Optional removal - interface %s - all method signature references stripped", interfaceName);
+            if (logDebugInfo) FMLLog.log.debug("Optional removal - interface {} - all method signature references stripped", interfaceName);
         }
         else if (found)
         {
-            if (logDebugInfo) FMLRelaunchLog.finer("Optional removal - interface %s - NOT stripping method signature references", interfaceName);
+            if (logDebugInfo) FMLLog.log.debug("Optional removal - interface {} - NOT stripping method signature references", interfaceName);
         }
     }
 

--- a/src/main/java/net/minecraftforge/fml/common/asm/transformers/ModAccessTransformer.java
+++ b/src/main/java/net/minecraftforge/fml/common/asm/transformers/ModAccessTransformer.java
@@ -27,7 +27,7 @@ import java.util.jar.JarEntry;
 import java.util.jar.JarFile;
 import java.util.jar.Manifest;
 
-import net.minecraftforge.fml.relauncher.FMLRelaunchLog;
+import net.minecraftforge.fml.common.FMLLog;
 
 import com.google.common.base.Charsets;
 import com.google.common.collect.Maps;
@@ -54,7 +54,7 @@ public class ModAccessTransformer extends AccessTransformer {
             int added = getModifiers().size() - old_count;
             if (added > 0)
             {
-                FMLRelaunchLog.fine("Loaded %d rules from AccessTransformer mod jar file %s\n", added, e.getKey());
+                FMLLog.log.debug("Loaded {} rules from AccessTransformer mod jar file {}\n", added, e.getKey());
             }
         }
     }

--- a/src/main/java/net/minecraftforge/fml/common/asm/transformers/TerminalTransformer.java
+++ b/src/main/java/net/minecraftforge/fml/common/asm/transformers/TerminalTransformer.java
@@ -22,7 +22,7 @@ package net.minecraftforge.fml.common.asm.transformers;
 import org.objectweb.asm.*;
 
 import net.minecraft.launchwrapper.IClassTransformer;
-import net.minecraftforge.fml.relauncher.FMLRelaunchLog;
+import net.minecraftforge.fml.common.FMLLog;
 import net.minecraftforge.fml.relauncher.FMLSecurityManager.ExitTrappedException;
 
 public class TerminalTransformer implements IClassTransformer
@@ -81,11 +81,11 @@ public class TerminalTransformer implements IClassTransformer
                     {
                         if (warn)
                         {
-                            FMLRelaunchLog.warning("=============================================================");
-                            FMLRelaunchLog.warning("MOD HAS DIRECT REFERENCE System.exit() THIS IS NOT ALLOWED REROUTING TO FML!");
-                            FMLRelaunchLog.warning("Offender: %s.%s%s", ExitVisitor.this.clsName, mName, mDesc);
-                            FMLRelaunchLog.warning("Use FMLCommonHandler.exitJava instead");
-                            FMLRelaunchLog.warning("=============================================================");
+                            FMLLog.log.warn("=============================================================");
+                            FMLLog.log.warn("MOD HAS DIRECT REFERENCE System.exit() THIS IS NOT ALLOWED REROUTING TO FML!");
+                            FMLLog.log.warn("Offender: {}.{}{}", ExitVisitor.this.clsName, mName, mDesc);
+                            FMLLog.log.warn("Use FMLCommonHandler.exitJava instead");
+                            FMLLog.log.warn("=============================================================");
                         }
                         owner = ExitVisitor.callbackOwner;
                         name = "systemExitCalled";
@@ -94,11 +94,11 @@ public class TerminalTransformer implements IClassTransformer
                     {
                         if (warn)
                         {
-                            FMLRelaunchLog.warning("=============================================================");
-                            FMLRelaunchLog.warning("MOD HAS DIRECT REFERENCE Runtime.exit() THIS IS NOT ALLOWED REROUTING TO FML!");
-                            FMLRelaunchLog.warning("Offender: %s.%s%s", ExitVisitor.this.clsName, mName, mDesc);
-                            FMLRelaunchLog.warning("Use FMLCommonHandler.exitJava instead");
-                            FMLRelaunchLog.warning("=============================================================");
+                            FMLLog.log.warn("=============================================================");
+                            FMLLog.log.warn("MOD HAS DIRECT REFERENCE Runtime.exit() THIS IS NOT ALLOWED REROUTING TO FML!");
+                            FMLLog.log.warn("Offender: {}.{}{}", ExitVisitor.this.clsName, mName, mDesc);
+                            FMLLog.log.warn("Use FMLCommonHandler.exitJava instead");
+                            FMLLog.log.warn("=============================================================");
                         }
                         opcode = Opcodes.INVOKESTATIC;
                         owner = ExitVisitor.callbackOwner;
@@ -109,11 +109,11 @@ public class TerminalTransformer implements IClassTransformer
                     {
                         if (warn)
                         {
-                            FMLRelaunchLog.warning("=============================================================");
-                            FMLRelaunchLog.warning("MOD HAS DIRECT REFERENCE Runtime.halt() THIS IS NOT ALLOWED REROUTING TO FML!");
-                            FMLRelaunchLog.warning("Offendor: %s.%s%s", ExitVisitor.this.clsName, mName, mDesc);
-                            FMLRelaunchLog.warning("Use FMLCommonHandler.exitJava instead");
-                            FMLRelaunchLog.warning("=============================================================");
+                            FMLLog.log.warn("=============================================================");
+                            FMLLog.log.warn("MOD HAS DIRECT REFERENCE Runtime.halt() THIS IS NOT ALLOWED REROUTING TO FML!");
+                            FMLLog.log.warn("Offendor: {}.{}{}", ExitVisitor.this.clsName, mName, mDesc);
+                            FMLLog.log.warn("Use FMLCommonHandler.exitJava instead");
+                            FMLLog.log.warn("=============================================================");
                         }
                         opcode = Opcodes.INVOKESTATIC;
                         owner = ExitVisitor.callbackOwner;

--- a/src/main/java/net/minecraftforge/fml/common/asm/transformers/deobf/FMLDeobfuscatingRemapper.java
+++ b/src/main/java/net/minecraftforge/fml/common/asm/transformers/deobf/FMLDeobfuscatingRemapper.java
@@ -29,10 +29,10 @@ import java.util.Map;
 import java.util.Set;
 
 import net.minecraft.launchwrapper.LaunchClassLoader;
+import net.minecraftforge.fml.common.FMLLog;
 import net.minecraftforge.fml.common.patcher.ClassPatchManager;
-import net.minecraftforge.fml.relauncher.FMLRelaunchLog;
 
-import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.message.Message;
 import org.objectweb.asm.ClassReader;
 import org.objectweb.asm.commons.Remapper;
 import org.objectweb.asm.tree.ClassNode;
@@ -112,7 +112,7 @@ public class FMLDeobfuscatingRemapper extends Remapper {
         }
         catch (IOException ioe)
         {
-            FMLRelaunchLog.log(Level.ERROR, "An error occurred loading the deobfuscation map data", ioe);
+            FMLLog.log.error("An error occurred loading the deobfuscation map data", ioe);
         }
         methodNameMaps = Maps.newHashMapWithExpectedSize(rawMethodMaps.size());
         fieldNameMaps = Maps.newHashMapWithExpectedSize(rawFieldMaps.size());
@@ -133,12 +133,12 @@ public class FMLDeobfuscatingRemapper extends Remapper {
                 LZMAInputSupplier zis = new LZMAInputSupplier(classData);
                 CharSource srgSource = zis.asCharSource(Charsets.UTF_8);
                 srgList = srgSource.readLines();
-                FMLRelaunchLog.fine("Loading deobfuscation resource %s with %d records", deobfFileName, srgList.size());
+                FMLLog.log.debug("Loading deobfuscation resource {} with {} records", deobfFileName, srgList.size());
             }
             else
             {
                 srgList = Files.readLines(new File(gradleStartProp), Charsets.UTF_8);
-                FMLRelaunchLog.fine("Loading deobfuscation resource %s with %d records", gradleStartProp, srgList.size());
+                FMLLog.log.debug("Loading deobfuscation resource {} with {} records", gradleStartProp, srgList.size());
             }
 
             rawMethodMaps = Maps.newHashMap();
@@ -166,7 +166,7 @@ public class FMLDeobfuscatingRemapper extends Remapper {
         }
         catch (IOException ioe)
         {
-            FMLRelaunchLog.log(Level.ERROR, ioe, "An error occurred loading the deobfuscation map data");
+            FMLLog.log.error("An error occurred loading the deobfuscation map data", ioe);
         }
         methodNameMaps = Maps.newHashMapWithExpectedSize(rawMethodMaps.size());
         fieldNameMaps = Maps.newHashMapWithExpectedSize(rawFieldMaps.size());
@@ -234,7 +234,7 @@ public class FMLDeobfuscatingRemapper extends Remapper {
             }
             catch (IOException e)
             {
-                FMLRelaunchLog.log(Level.ERROR,e, "A critical exception occurred reading a class file %s", owner);
+                FMLLog.error(e, "A critical exception occurred reading a class file {}", owner);
             }
             return null;
         }
@@ -390,7 +390,7 @@ public class FMLDeobfuscatingRemapper extends Remapper {
 
             if (DUMP_FIELD_MAPS)
             {
-                FMLRelaunchLog.finer("Field map for %s : %s", className, fieldNameMaps.get(className));
+                FMLLog.log.trace("Field map for {} : {}", className, fieldNameMaps.get(className));
             }
         }
         return fieldNameMaps.get(className);
@@ -407,7 +407,7 @@ public class FMLDeobfuscatingRemapper extends Remapper {
             }
             if (DUMP_METHOD_MAPS)
             {
-                FMLRelaunchLog.finer("Method map for %s : %s", className, methodNameMaps.get(className));
+                FMLLog.log.trace("Method map for {} : {}", className, methodNameMaps.get(className));
             }
 
         }

--- a/src/main/java/net/minecraftforge/fml/common/asm/transformers/deobf/FMLDeobfuscatingRemapper.java
+++ b/src/main/java/net/minecraftforge/fml/common/asm/transformers/deobf/FMLDeobfuscatingRemapper.java
@@ -234,7 +234,7 @@ public class FMLDeobfuscatingRemapper extends Remapper {
             }
             catch (IOException e)
             {
-                FMLLog.error(e, "A critical exception occurred reading a class file {}", owner);
+                FMLLog.log.error("A critical exception occurred reading a class file {}", owner, e);
             }
             return null;
         }

--- a/src/main/java/net/minecraftforge/fml/common/discovery/DirectoryDiscoverer.java
+++ b/src/main/java/net/minecraftforge/fml/common/discovery/DirectoryDiscoverer.java
@@ -59,7 +59,7 @@ public class DirectoryDiscoverer implements ITypeDiscoverer
     {
         this.table = table;
         List<ModContainer> found = Lists.newArrayList();
-        FMLLog.fine("Examining directory %s for potential mods", candidate.getModContainer().getName());
+        FMLLog.log.debug("Examining directory {} for potential mods", candidate.getModContainer().getName());
         exploreFileSystem("", candidate.getModContainer(), found, candidate, null);
         for (ModContainer mc : found)
         {
@@ -84,12 +84,12 @@ public class DirectoryDiscoverer implements ITypeDiscoverer
                 {
                     IOUtils.closeQuietly(fis);
                 }
-                FMLLog.fine("Found an mcmod.info file in directory %s", modDir.getName());
+                FMLLog.log.debug("Found an mcmod.info file in directory {}", modDir.getName());
             }
             catch (Exception e)
             {
                 mc = MetadataCollection.from(null,"");
-                FMLLog.fine("No mcmod.info file found in directory %s", modDir.getName());
+                FMLLog.log.debug("No mcmod.info file found in directory {}", modDir.getName());
             }
         }
 
@@ -101,7 +101,7 @@ public class DirectoryDiscoverer implements ITypeDiscoverer
         {
             if (file.isDirectory())
             {
-                FMLLog.finer("Recursing into package %s", path + file.getName());
+                FMLLog.log.trace("Recursing into package {}", path + file.getName());
                 exploreFileSystem(path + file.getName() + "/", file, harvestedMods, candidate, mc);
                 continue;
             }
@@ -119,7 +119,7 @@ public class DirectoryDiscoverer implements ITypeDiscoverer
                 }
                 catch (LoaderException e)
                 {
-                    FMLLog.log(Level.ERROR, e, "There was a problem reading the file %s - probably this is a corrupt file", file.getPath());
+                    FMLLog.error(e, "There was a problem reading the file {} - probably this is a corrupt file", file.getPath());
                     throw e;
                 }
                 catch (Exception e)

--- a/src/main/java/net/minecraftforge/fml/common/discovery/DirectoryDiscoverer.java
+++ b/src/main/java/net/minecraftforge/fml/common/discovery/DirectoryDiscoverer.java
@@ -119,7 +119,7 @@ public class DirectoryDiscoverer implements ITypeDiscoverer
                 }
                 catch (LoaderException e)
                 {
-                    FMLLog.error(e, "There was a problem reading the file {} - probably this is a corrupt file", file.getPath());
+                    FMLLog.log.error("There was a problem reading the file {} - probably this is a corrupt file", file.getPath(), e);
                     throw e;
                 }
                 catch (Exception e)

--- a/src/main/java/net/minecraftforge/fml/common/discovery/JarDiscoverer.java
+++ b/src/main/java/net/minecraftforge/fml/common/discovery/JarDiscoverer.java
@@ -97,7 +97,7 @@ public class JarDiscoverer implements ITypeDiscoverer
                     }
                     catch (LoaderException e)
                     {
-                        FMLLog.error(e, "There was a problem reading the entry {} in the jar {} - probably a corrupt zip", ze.getName(), candidate.getModContainer().getPath());
+                        FMLLog.log.error("There was a problem reading the entry {} in the jar {} - probably a corrupt zip", candidate.getModContainer().getPath(), e);
                         jar.close();
                         throw e;
                     }
@@ -116,7 +116,7 @@ public class JarDiscoverer implements ITypeDiscoverer
         }
         catch (Exception e)
         {
-            FMLLog.warn(e, "Zip file {} failed to read properly, it will be ignored", candidate.getModContainer().getName());
+            FMLLog.log.warn("Zip file {} failed to read properly, it will be ignored", candidate.getModContainer().getName(), e);
         }
         finally
         {

--- a/src/main/java/net/minecraftforge/fml/common/discovery/JarDiscoverer.java
+++ b/src/main/java/net/minecraftforge/fml/common/discovery/JarDiscoverer.java
@@ -46,7 +46,7 @@ public class JarDiscoverer implements ITypeDiscoverer
     public List<ModContainer> discover(ModCandidate candidate, ASMDataTable table)
     {
         List<ModContainer> foundMods = Lists.newArrayList();
-        FMLLog.fine("Examining file %s for potential mods", candidate.getModContainer().getName());
+        FMLLog.log.debug("Examining file {} for potential mods", candidate.getModContainer().getName());
         JarFile jar = null;
         try
         {
@@ -56,7 +56,7 @@ public class JarDiscoverer implements ITypeDiscoverer
             MetadataCollection mc = null;
             if (modInfo != null)
             {
-                FMLLog.finer("Located mcmod.info file in file %s", candidate.getModContainer().getName());
+                FMLLog.log.trace("Located mcmod.info file in file {}", candidate.getModContainer().getName());
                 InputStream inputStream = jar.getInputStream(modInfo);
                 try
                 {
@@ -69,7 +69,7 @@ public class JarDiscoverer implements ITypeDiscoverer
             }
             else
             {
-                FMLLog.fine("The mod container %s appears to be missing an mcmod.info file", candidate.getModContainer().getName());
+                FMLLog.log.debug("The mod container {} appears to be missing an mcmod.info file", candidate.getModContainer().getName());
                 mc = MetadataCollection.from(null, "");
             }
             for (ZipEntry ze : Collections.list(jar.entries()))
@@ -97,7 +97,7 @@ public class JarDiscoverer implements ITypeDiscoverer
                     }
                     catch (LoaderException e)
                     {
-                        FMLLog.log(Level.ERROR, e, "There was a problem reading the entry %s in the jar %s - probably a corrupt zip", ze.getName(), candidate.getModContainer().getPath());
+                        FMLLog.error(e, "There was a problem reading the entry {} in the jar {} - probably a corrupt zip", ze.getName(), candidate.getModContainer().getPath());
                         jar.close();
                         throw e;
                     }
@@ -116,7 +116,7 @@ public class JarDiscoverer implements ITypeDiscoverer
         }
         catch (Exception e)
         {
-            FMLLog.log(Level.WARN, e, "Zip file %s failed to read properly, it will be ignored", candidate.getModContainer().getName());
+            FMLLog.warn(e, "Zip file {} failed to read properly, it will be ignored", candidate.getModContainer().getName());
         }
         finally
         {

--- a/src/main/java/net/minecraftforge/fml/common/discovery/ModCandidate.java
+++ b/src/main/java/net/minecraftforge/fml/common/discovery/ModCandidate.java
@@ -78,7 +78,7 @@ public class ModCandidate
         this.mods = sourceType.findMods(this, table);
         if (!baseModCandidateTypes.isEmpty())
         {
-            FMLLog.info("Attempting to reparse the mod container %s", getModContainer().getName());
+            FMLLog.log.info("Attempting to reparse the mod container {}", getModContainer().getName());
             this.mods = sourceType.findMods(this, table);
         }
         return this.mods;

--- a/src/main/java/net/minecraftforge/fml/common/discovery/ModDiscoverer.java
+++ b/src/main/java/net/minecraftforge/fml/common/discovery/ModDiscoverer.java
@@ -61,7 +61,7 @@ public class ModDiscoverer
         File[] minecraftSources = modClassLoader.getParentSources();
         if (minecraftSources.length == 1 && minecraftSources[0].isFile())
         {
-            FMLLog.fine("Minecraft is a file at %s, loading", minecraftSources[0].getAbsolutePath());
+            FMLLog.log.debug("Minecraft is a file at {}, loading", minecraftSources[0].getAbsolutePath());
             addCandidate(new ModCandidate(minecraftSources[0], minecraftSources[0], ContainerType.JAR, true, true));
         }
         else
@@ -73,17 +73,17 @@ public class ModDiscoverer
                 {
                     if (knownLibraries.contains(source.getName()) || modClassLoader.isDefaultLibrary(source))
                     {
-                        FMLLog.finer("Skipping known library file %s", source.getAbsolutePath());
+                        FMLLog.log.trace("Skipping known library file {}", source.getAbsolutePath());
                     }
                     else
                     {
-                        FMLLog.fine("Found a minecraft related file at %s, examining for mod candidates", source.getAbsolutePath());
+                        FMLLog.log.debug("Found a minecraft related file at {}, examining for mod candidates", source.getAbsolutePath());
                         addCandidate(new ModCandidate(source, source, ContainerType.JAR, i==0, true));
                     }
                 }
                 else if (minecraftSources[i].isDirectory())
                 {
-                    FMLLog.fine("Found a minecraft related directory at %s, examining for mod candidates", source.getAbsolutePath());
+                    FMLLog.log.debug("Found a minecraft related directory at {}, examining for mod candidates", source.getAbsolutePath());
                     addCandidate(new ModCandidate(source, source, ContainerType.DIR, i==0, true));
                 }
                 i++;
@@ -106,11 +106,11 @@ public class ModDiscoverer
             // skip loaded coremods
             if (CoreModManager.getIgnoredMods().contains(modFile.getName()))
             {
-                FMLLog.finer("Skipping already parsed coremod or tweaker %s", modFile.getName());
+                FMLLog.log.trace("Skipping already parsed coremod or tweaker {}", modFile.getName());
             }
             else if (modFile.isDirectory())
             {
-                FMLLog.fine("Found a candidate mod directory %s", modFile.getName());
+                FMLLog.log.debug("Found a candidate mod directory {}", modFile.getName());
                 addCandidate(new ModCandidate(modFile, modFile, ContainerType.DIR));
             }
             else
@@ -119,12 +119,12 @@ public class ModDiscoverer
 
                 if (matcher.matches())
                 {
-                    FMLLog.fine("Found a candidate zip or jar file %s", matcher.group(0));
+                    FMLLog.log.debug("Found a candidate zip or jar file {}", matcher.group(0));
                     addCandidate(new ModCandidate(modFile, modFile, ContainerType.JAR));
                 }
                 else
                 {
-                    FMLLog.fine("Ignoring unknown file %s in mods directory", modFile.getName());
+                    FMLLog.log.debug("Ignoring unknown file {} in mods directory", modFile.getName());
                 }
             }
         }
@@ -150,7 +150,7 @@ public class ModDiscoverer
             }
             catch (LoaderException le)
             {
-                FMLLog.log(Level.WARN, le, "Identified a problem with the mod candidate %s, ignoring this source", candidate.getModContainer());
+                FMLLog.warn(le, "Identified a problem with the mod candidate {}, ignoring this source", candidate.getModContainer());
             }
             catch (Throwable t)
             {
@@ -177,7 +177,7 @@ public class ModDiscoverer
         {
             if (c.getModContainer().equals(candidate.getModContainer()))
             {
-                FMLLog.finer("  Skipping already in list %s", candidate.getModContainer());
+                FMLLog.log.trace("  Skipping already in list {}", candidate.getModContainer());
                 return;
             }
         }

--- a/src/main/java/net/minecraftforge/fml/common/discovery/ModDiscoverer.java
+++ b/src/main/java/net/minecraftforge/fml/common/discovery/ModDiscoverer.java
@@ -150,7 +150,7 @@ public class ModDiscoverer
             }
             catch (LoaderException le)
             {
-                FMLLog.warn(le, "Identified a problem with the mod candidate {}, ignoring this source", candidate.getModContainer());
+                FMLLog.log.warn("Identified a problem with the mod candidate {}, ignoring this source", candidate.getModContainer(), le);
             }
             catch (Throwable t)
             {

--- a/src/main/java/net/minecraftforge/fml/common/discovery/asm/ASMModParser.java
+++ b/src/main/java/net/minecraftforge/fml/common/discovery/asm/ASMModParser.java
@@ -64,7 +64,7 @@ public class ASMModParser
         }
         catch (Exception ex)
         {
-            FMLLog.log(Level.ERROR, ex, "Unable to read a class file correctly");
+            FMLLog.log.error("Unable to read a class file correctly", ex);
             throw new LoaderException(ex);
         }
     }

--- a/src/main/java/net/minecraftforge/fml/common/event/FMLInterModComms.java
+++ b/src/main/java/net/minecraftforge/fml/common/event/FMLInterModComms.java
@@ -63,7 +63,7 @@ public class FMLInterModComms {
         {
             this.activeContainer = activeContainer;
             this.currentList = null;
-            FMLLog.finer("Attempting to deliver %d IMC messages to mod %s", modMessages.get(activeContainer.getModId()).size(), activeContainer.getModId());
+            FMLLog.log.trace("Attempting to deliver {} IMC messages to mod {}", modMessages.get(activeContainer.getModId()).size(), activeContainer.getModId());
         }
 
         private ImmutableList<IMCMessage> currentList;
@@ -192,7 +192,7 @@ public class FMLInterModComms {
                 Function<T,V> f = Class.forName((String) value).asSubclass(Function.class).newInstance();
                 return Optional.of(f);
             } catch (Exception e) {
-                FMLLog.getLogger().log(Level.INFO, "An error occurred instantiating the IMC function. key: {} value: {}, caller: {}", key,value,sender);
+                FMLLog.log.info("An error occurred instantiating the IMC function. key: {} value: {}, caller: {}", key,value,sender);
                 return Optional.absent();
             }
         }

--- a/src/main/java/net/minecraftforge/fml/common/event/FMLPostInitializationEvent.java
+++ b/src/main/java/net/minecraftforge/fml/common/event/FMLPostInitializationEvent.java
@@ -81,7 +81,7 @@ public class FMLPostInitializationEvent extends FMLStateEvent
             }
             catch (Exception e)
             {
-                FMLLog.getLogger().log(Level.INFO, "An error occurred trying to build a soft depend proxy",e);
+                FMLLog.log.info("An error occurred trying to build a soft depend proxy", e);
                 return Optional.absent();
             }
         }

--- a/src/main/java/net/minecraftforge/fml/common/eventhandler/EventBus.java
+++ b/src/main/java/net/minecraftforge/fml/common/eventhandler/EventBus.java
@@ -73,7 +73,7 @@ public class EventBus implements IEventExceptionHandler
         ModContainer activeModContainer = Loader.instance().activeModContainer();
         if (activeModContainer == null)
         {
-            FMLLog.error(new Throwable(), "Unable to determine registrant mod for {}. This is a critical error and should be impossible", target);
+            FMLLog.log.error("Unable to determine registrant mod for {}. This is a critical error and should be impossible", target, new Throwable());
             activeModContainer = Loader.instance().getMinecraftModContainer();
         }
         listenerOwners.put(target, activeModContainer);
@@ -196,7 +196,7 @@ public class EventBus implements IEventExceptionHandler
     @Override
     public void handleException(EventBus bus, Event event, IEventListener[] listeners, int index, Throwable throwable)
     {
-        FMLLog.error(throwable, "Exception caught during firing event {}:", event);
+        FMLLog.log.error("Exception caught during firing event {}:", event, throwable);
         FMLLog.log.error("Index: {} Listeners:", index);
         for (int x = 0; x < listeners.length; x++)
         {

--- a/src/main/java/net/minecraftforge/fml/common/eventhandler/EventBus.java
+++ b/src/main/java/net/minecraftforge/fml/common/eventhandler/EventBus.java
@@ -73,7 +73,7 @@ public class EventBus implements IEventExceptionHandler
         ModContainer activeModContainer = Loader.instance().activeModContainer();
         if (activeModContainer == null)
         {
-            FMLLog.log(Level.ERROR, new Throwable(), "Unable to determine registrant mod for %s. This is a critical error and should be impossible", target);
+            FMLLog.error(new Throwable(), "Unable to determine registrant mod for {}. This is a critical error and should be impossible", target);
             activeModContainer = Loader.instance().getMinecraftModContainer();
         }
         listenerOwners.put(target, activeModContainer);
@@ -196,11 +196,11 @@ public class EventBus implements IEventExceptionHandler
     @Override
     public void handleException(EventBus bus, Event event, IEventListener[] listeners, int index, Throwable throwable)
     {
-        FMLLog.log(Level.ERROR, throwable, "Exception caught during firing event %s:", event);
-        FMLLog.log(Level.ERROR, "Index: %d Listeners:", index);
+        FMLLog.error(throwable, "Exception caught during firing event {}:", event);
+        FMLLog.log.error("Index: {} Listeners:", index);
         for (int x = 0; x < listeners.length; x++)
         {
-            FMLLog.log(Level.ERROR, "%d: %s", x, listeners[x]);
+            FMLLog.log.error("{}: {}", x, listeners[x]);
         }
     }
 }

--- a/src/main/java/net/minecraftforge/fml/common/launcher/FMLDeobfTweaker.java
+++ b/src/main/java/net/minecraftforge/fml/common/launcher/FMLDeobfTweaker.java
@@ -25,9 +25,9 @@ import java.util.List;
 
 import net.minecraft.launchwrapper.ITweaker;
 import net.minecraft.launchwrapper.LaunchClassLoader;
+import net.minecraftforge.fml.common.FMLLog;
 import net.minecraftforge.fml.relauncher.CoreModManager;
 import net.minecraftforge.fml.relauncher.FMLInjectionData;
-import net.minecraftforge.fml.relauncher.FMLRelaunchLog;
 
 public class FMLDeobfTweaker implements ITweaker {
     @Override
@@ -49,13 +49,13 @@ public class FMLDeobfTweaker implements ITweaker {
         classLoader.registerTransformer("net.minecraftforge.fml.common.asm.transformers.ItemStackTransformer");
         try
         {
-            FMLRelaunchLog.fine("Validating minecraft");
+            FMLLog.log.debug("Validating minecraft");
             Class<?> loaderClazz = Class.forName("net.minecraftforge.fml.common.Loader", true, classLoader);
             Method m = loaderClazz.getMethod("injectData", Object[].class);
             m.invoke(null, (Object)FMLInjectionData.data());
             m = loaderClazz.getMethod("instance");
             m.invoke(null);
-            FMLRelaunchLog.fine("Minecraft validated, launching...");
+            FMLLog.log.debug("Minecraft validated, launching...");
         }
         catch (Exception e)
         {

--- a/src/main/java/net/minecraftforge/fml/common/launcher/Yggdrasil.java
+++ b/src/main/java/net/minecraftforge/fml/common/launcher/Yggdrasil.java
@@ -49,7 +49,7 @@ public class Yggdrasil
         }
         catch (AuthenticationException e)
         {
-            LogManager.getLogger("FMLTWEAK").error("-- Login failed!  " + e.getMessage());
+            LogManager.getLogger("FMLTWEAK").error("-- Login failed! {}", e.getMessage(), e);
             Throwables.propagate(e);
             return; // don't set other variables
         }

--- a/src/main/java/net/minecraftforge/fml/common/network/FMLIndexedMessageToMessageCodec.java
+++ b/src/main/java/net/minecraftforge/fml/common/network/FMLIndexedMessageToMessageCodec.java
@@ -90,7 +90,7 @@ public abstract class FMLIndexedMessageToMessageCodec<A> extends MessageToMessag
         ByteBuf payload = msg.payload().duplicate();
         if (payload.readableBytes() < 1)
         {
-            FMLLog.log(Level.ERROR, "The FMLIndexedCodec has received an empty buffer on channel %s, likely a result of a LAN server issue. Pipeline parts : %s", ctx.channel().attr(NetworkRegistry.FML_CHANNEL), ctx.pipeline().toString());
+            FMLLog.log.error("The FMLIndexedCodec has received an empty buffer on channel {}, likely a result of a LAN server issue. Pipeline parts : {}", ctx.channel().attr(NetworkRegistry.FML_CHANNEL), ctx.pipeline().toString());
         }
         byte discriminator = payload.readByte();
         Class<? extends A> clazz = discriminators.get(discriminator);
@@ -116,7 +116,7 @@ public abstract class FMLIndexedMessageToMessageCodec<A> extends MessageToMessag
     @Override
     public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) throws Exception
     {
-        FMLLog.log(Level.ERROR, cause, "FMLIndexedMessageCodec exception caught");
+        FMLLog.log.error("FMLIndexedMessageCodec exception caught", cause);
         super.exceptionCaught(ctx, cause);
     }
 }

--- a/src/main/java/net/minecraftforge/fml/common/network/NetworkEventFiringHandler.java
+++ b/src/main/java/net/minecraftforge/fml/common/network/NetworkEventFiringHandler.java
@@ -59,7 +59,7 @@ public class NetworkEventFiringHandler extends SimpleChannelInboundHandler<FMLPr
     @Override
     public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) throws Exception
     {
-        FMLLog.log(Level.ERROR, cause, "NetworkEventFiringHandler exception");
+        FMLLog.log.error("NetworkEventFiringHandler exception", cause);
         super.exceptionCaught(ctx, cause);
     }
 }

--- a/src/main/java/net/minecraftforge/fml/common/network/NetworkRegistry.java
+++ b/src/main/java/net/minecraftforge/fml/common/network/NetworkRegistry.java
@@ -226,7 +226,7 @@ public enum NetworkRegistry
         ModContainer mc = FMLCommonHandler.instance().findContainerFor(mod);
         if (mc == null)
         {
-            FMLLog.log(Level.ERROR, "Mod of type %s attempted to register a gui network handler during a construction phase", mod.getClass().getName());
+            FMLLog.log.error("Mod of type {} attempted to register a gui network handler during a construction phase", mod.getClass().getName());
             throw new RuntimeException("Invalid attempt to create a GUI during mod construction. Use an EventHandler instead");
         }
         serverGuiHandlers.put(mc, handler);

--- a/src/main/java/net/minecraftforge/fml/common/network/PacketLoggingHandler.java
+++ b/src/main/java/net/minecraftforge/fml/common/network/PacketLoggingHandler.java
@@ -56,7 +56,7 @@ public class PacketLoggingHandler
                 {
                     PacketBuffer buf = new PacketBuffer(Unpooled.buffer());
                     msg.writePacketData(buf);
-                    FMLLog.log(Level.DEBUG, "%s %s:\n%s", prefix, msg.getClass().getSimpleName(), ByteBufUtils.getContentDump(buf));
+                    FMLLog.log.debug("{} {}:\n{}", prefix, msg.getClass().getSimpleName(), ByteBufUtils.getContentDump(buf));
                     ctx.fireChannelRead(msg);
                 }
             });
@@ -70,7 +70,7 @@ public class PacketLoggingHandler
                     {
                         PacketBuffer buf = new PacketBuffer(Unpooled.buffer());
                         ((Packet<?>)msg).writePacketData(buf);
-                        FMLLog.log(Level.DEBUG, "%s %s:\n%s", prefix, msg.getClass().getSimpleName(), ByteBufUtils.getContentDump(buf));
+                        FMLLog.log.debug("{} {}:\n{}", prefix, msg.getClass().getSimpleName(), ByteBufUtils.getContentDump(buf));
                     }
                     ctx.write(msg, promise);
                 }
@@ -90,7 +90,7 @@ public class PacketLoggingHandler
                     {
                         ByteBuf pkt = (ByteBuf)itr.next();
                         pkt.markReaderIndex();
-                        FMLLog.log(Level.DEBUG, "%s:\n%s", prefix, ByteBufUtils.getContentDump(pkt));
+                        FMLLog.log.debug("{}:\n{}", prefix, ByteBufUtils.getContentDump(pkt));
                         pkt.resetReaderIndex();
                     }
                 }
@@ -102,7 +102,7 @@ public class PacketLoggingHandler
                 protected void encode(ChannelHandlerContext context, ByteBuf input, ByteBuf output) throws Exception
                 {
                     input.markReaderIndex();
-                    FMLLog.log(Level.DEBUG, "%s:\n%s", prefix, ByteBufUtils.getContentDump(input));
+                    FMLLog.log.debug("{}:\n{}", prefix, ByteBufUtils.getContentDump(input));
                     input.resetReaderIndex();
                     super.encode(context, input, output);
                 }

--- a/src/main/java/net/minecraftforge/fml/common/network/handshake/ChannelRegistrationHandler.java
+++ b/src/main/java/net/minecraftforge/fml/common/network/handshake/ChannelRegistrationHandler.java
@@ -59,7 +59,7 @@ public class ChannelRegistrationHandler extends SimpleChannelInboundHandler<FMLP
     @Override
     public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) throws Exception
     {
-        FMLLog.log(Level.ERROR, cause, "ChannelRegistrationHandler exception");
+        FMLLog.log.error("ChannelRegistrationHandler exception", cause);
         super.exceptionCaught(ctx, cause);
     }
 }

--- a/src/main/java/net/minecraftforge/fml/common/network/handshake/FMLHandshakeClientState.java
+++ b/src/main/java/net/minecraftforge/fml/common/network/handshake/FMLHandshakeClientState.java
@@ -72,7 +72,7 @@ enum FMLHandshakeClientState implements IHandshakeState<FMLHandshakeClientState>
             }
 
             ServerHello serverHelloPacket = (FMLHandshakeMessage.ServerHello)msg;
-            FMLLog.info("Server protocol version %x", serverHelloPacket.protocolVersion());
+            FMLLog.log.info("Server protocol version {}", Integer.toHexString(serverHelloPacket.protocolVersion()));
             if (serverHelloPacket.protocolVersion() > 1)
             {
                 // Server sent us an extra dimension for the logging in player - stash it for retrieval later
@@ -129,7 +129,7 @@ enum FMLHandshakeClientState implements IHandshakeState<FMLHandshakeClientState>
 
             if (pkt.hasMore())
             {
-                FMLLog.fine("Received Mod Registry mapping for %s: %d IDs %d subs %d dummied", pkt.getName(), entry.ids.size(), entry.substitutions.size(), entry.dummied.size());
+                FMLLog.log.debug("Received Mod Registry mapping for {}: {} IDs {} subs {} dummied", pkt.getName(), entry.ids.size(), entry.substitutions.size(), entry.dummied.size());
                 return WAITINGSERVERCOMPLETE;
             }
 
@@ -140,8 +140,8 @@ enum FMLHandshakeClientState implements IHandshakeState<FMLHandshakeClientState>
             {
                 NetworkDispatcher dispatcher = ctx.channel().attr(NetworkDispatcher.FML_DISPATCHER).get();
                 dispatcher.rejectHandshake("Fatally missing blocks and items");
-                FMLLog.severe("Failed to connect to server: there are %d missing blocks and items", locallyMissing.size());
-                FMLLog.fine("Missing list: %s", locallyMissing);
+                FMLLog.log.fatal("Failed to connect to server: there are {} missing blocks and items", locallyMissing.size());
+                FMLLog.log.debug("Missing list: {}", locallyMissing);
                 return ERROR;
             }
             ctx.writeAndFlush(new FMLHandshakeMessage.HandshakeAck(ordinal())).addListener(ChannelFutureListener.FIRE_EXCEPTION_ON_FAILURE);

--- a/src/main/java/net/minecraftforge/fml/common/network/handshake/FMLHandshakeMessage.java
+++ b/src/main/java/net/minecraftforge/fml/common/network/handshake/FMLHandshakeMessage.java
@@ -77,11 +77,11 @@ public abstract class FMLHandshakeMessage {
             if (serverProtocolVersion > 1)
             {
                 overrideDimension = buffer.readInt();
-                FMLLog.fine("Server FML protocol version %d, 4 byte dimension received %d", serverProtocolVersion, overrideDimension);
+                FMLLog.log.debug("Server FML protocol version {}, 4 byte dimension received {}", serverProtocolVersion, overrideDimension);
             }
             else
             {
-                FMLLog.info("Server FML protocol version %d, no additional data received", serverProtocolVersion);
+                FMLLog.log.info("Server FML protocol version {}, no additional data received", serverProtocolVersion);
             }
         }
 

--- a/src/main/java/net/minecraftforge/fml/common/network/handshake/FMLHandshakeServerState.java
+++ b/src/main/java/net/minecraftforge/fml/common/network/handshake/FMLHandshakeServerState.java
@@ -57,14 +57,14 @@ enum FMLHandshakeServerState implements IHandshakeState<FMLHandshakeServerState>
             // Hello packet first
             if (msg instanceof FMLHandshakeMessage.ClientHello)
             {
-                FMLLog.info("Client protocol version %x", ((FMLHandshakeMessage.ClientHello)msg).protocolVersion());
+                FMLLog.log.info("Client protocol version {}", Integer.toHexString(((FMLHandshakeMessage.ClientHello)msg).protocolVersion()));
                 return this;
             }
 
             FMLHandshakeMessage.ModList client = (FMLHandshakeMessage.ModList)msg;
             NetworkDispatcher dispatcher = ctx.channel().attr(NetworkDispatcher.FML_DISPATCHER).get();
             dispatcher.setModList(client.modList());
-            FMLLog.info("Client attempting to join with %d mods : %s", client.modListSize(), client.modListAsString());
+            FMLLog.log.info("Client attempting to join with {} mods : {}", client.modListSize(), client.modListAsString());
             String result = FMLNetworkHandler.checkModList(client, Side.CLIENT);
             if (result != null)
             {

--- a/src/main/java/net/minecraftforge/fml/common/network/handshake/HandshakeMessageHandler.java
+++ b/src/main/java/net/minecraftforge/fml/common/network/handshake/HandshakeMessageHandler.java
@@ -44,9 +44,9 @@ public class HandshakeMessageHandler<S extends Enum<S> & IHandshakeState<S>> ext
     protected void channelRead0(ChannelHandlerContext ctx, FMLHandshakeMessage msg) throws Exception
     {
         S state = ctx.attr(fmlHandshakeState).get();
-        FMLLog.log.debug(stateType.getSimpleName() + ": " + msg.toString(stateType) + "->" + state.getClass().getName().substring(state.getClass().getName().lastIndexOf('.')+1)+":"+state);
+        FMLLog.log.debug("{}: {}->{}:{}", stateType.getSimpleName(), msg.toString(stateType), state.getClass().getName().substring(state.getClass().getName().lastIndexOf('.')+1), state);
         S newState = state.accept(ctx, msg);
-        FMLLog.log.debug("  Next: " + newState.name());
+        FMLLog.log.debug("  Next: {}", newState.name());
         ctx.attr(fmlHandshakeState).set(newState);
     }
 
@@ -59,9 +59,9 @@ public class HandshakeMessageHandler<S extends Enum<S> & IHandshakeState<S>> ext
     public void userEventTriggered(ChannelHandlerContext ctx, Object evt) throws Exception
     {
         S state = ctx.attr(fmlHandshakeState).get();
-        FMLLog.log.debug(stateType.getSimpleName() + ": null->" + state.getClass().getName().substring(state.getClass().getName().lastIndexOf('.')+1)+":"+state);
+        FMLLog.log.debug("{}: null->{}:{}", stateType.getSimpleName(), state.getClass().getName().substring(state.getClass().getName().lastIndexOf('.')+1), state);
         S newState = state.accept(ctx, null);
-        FMLLog.log.debug("  Next: " + newState.name());
+        FMLLog.log.debug("  Next: {}", newState.name());
         ctx.attr(fmlHandshakeState).set(newState);
     }
 

--- a/src/main/java/net/minecraftforge/fml/common/network/handshake/HandshakeMessageHandler.java
+++ b/src/main/java/net/minecraftforge/fml/common/network/handshake/HandshakeMessageHandler.java
@@ -44,9 +44,9 @@ public class HandshakeMessageHandler<S extends Enum<S> & IHandshakeState<S>> ext
     protected void channelRead0(ChannelHandlerContext ctx, FMLHandshakeMessage msg) throws Exception
     {
         S state = ctx.attr(fmlHandshakeState).get();
-        FMLLog.fine(stateType.getSimpleName() + ": " + msg.toString(stateType) + "->" + state.getClass().getName().substring(state.getClass().getName().lastIndexOf('.')+1)+":"+state);
+        FMLLog.log.debug(stateType.getSimpleName() + ": " + msg.toString(stateType) + "->" + state.getClass().getName().substring(state.getClass().getName().lastIndexOf('.')+1)+":"+state);
         S newState = state.accept(ctx, msg);
-        FMLLog.fine("  Next: " + newState.name());
+        FMLLog.log.debug("  Next: " + newState.name());
         ctx.attr(fmlHandshakeState).set(newState);
     }
 
@@ -59,16 +59,16 @@ public class HandshakeMessageHandler<S extends Enum<S> & IHandshakeState<S>> ext
     public void userEventTriggered(ChannelHandlerContext ctx, Object evt) throws Exception
     {
         S state = ctx.attr(fmlHandshakeState).get();
-        FMLLog.fine(stateType.getSimpleName() + ": null->" + state.getClass().getName().substring(state.getClass().getName().lastIndexOf('.')+1)+":"+state);
+        FMLLog.log.debug(stateType.getSimpleName() + ": null->" + state.getClass().getName().substring(state.getClass().getName().lastIndexOf('.')+1)+":"+state);
         S newState = state.accept(ctx, null);
-        FMLLog.fine("  Next: " + newState.name());
+        FMLLog.log.debug("  Next: " + newState.name());
         ctx.attr(fmlHandshakeState).set(newState);
     }
 
     @Override
     public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) throws Exception
     {
-        FMLLog.log(Level.ERROR, cause, "HandshakeMessageHandler exception");
+        FMLLog.log.error("HandshakeMessageHandler exception", cause);
         super.exceptionCaught(ctx, cause);
     }
 }

--- a/src/main/java/net/minecraftforge/fml/common/network/handshake/NetworkDispatcher.java
+++ b/src/main/java/net/minecraftforge/fml/common/network/handshake/NetworkDispatcher.java
@@ -157,7 +157,7 @@ public class NetworkDispatcher extends SimpleChannelInboundHandler<Packet<?>> im
         else
         {
             serverInitiateHandshake();
-            FMLLog.info("Connection received without FML marker, assuming vanilla.");
+            FMLLog.log.info("Connection received without FML marker, assuming vanilla.");
             this.completeServerSideConnection(ConnectionType.VANILLA);
             insertIntoChannel();
         }
@@ -184,11 +184,11 @@ public class NetworkDispatcher extends SimpleChannelInboundHandler<Packet<?>> im
     public void handlerAdded(ChannelHandlerContext ctx) throws Exception
     {
         if (this.state != null) {
-            FMLLog.getLogger().log(Level.INFO, "Opening channel which already seems to have a state set. This is a vanilla connection. Handshake handler will stop now");
+            FMLLog.log.info("Opening channel which already seems to have a state set. This is a vanilla connection. Handshake handler will stop now");
             this.manager.channel().config().setAutoRead(true);
             return;
         }
-        FMLLog.getLogger().log(Level.TRACE, "Handshake channel activating");
+        FMLLog.log.trace("Handshake channel activating");
         this.state = ConnectionState.OPENING;
         // send ourselves as a user event, to kick the pipeline active
         this.handshakeChannel.pipeline().fireUserEventTriggered(this);
@@ -246,7 +246,7 @@ public class NetworkDispatcher extends SimpleChannelInboundHandler<Packet<?>> im
     private void completeClientSideConnection(ConnectionType type)
     {
         this.connectionType = type;
-        FMLLog.info("[%s] Client side %s connection established", Thread.currentThread().getName(), this.connectionType.name().toLowerCase(Locale.ENGLISH));
+        FMLLog.log.info("[{}] Client side {} connection established", Thread.currentThread().getName(), this.connectionType.name().toLowerCase(Locale.ENGLISH));
         this.state = ConnectionState.CONNECTED;
         MinecraftForge.EVENT_BUS.post(new FMLNetworkEvent.ClientConnectedToServerEvent(manager, this.connectionType.name()));
     }
@@ -254,7 +254,7 @@ public class NetworkDispatcher extends SimpleChannelInboundHandler<Packet<?>> im
     private synchronized void completeServerSideConnection(ConnectionType type)
     {
         this.connectionType = type;
-        FMLLog.info("[%s] Server side %s connection established", Thread.currentThread().getName(), this.connectionType.name().toLowerCase(Locale.ENGLISH));
+        FMLLog.log.info("[{}] Server side {} connection established", Thread.currentThread().getName(), this.connectionType.name().toLowerCase(Locale.ENGLISH));
         this.state = ConnectionState.CONNECTED;
         MinecraftForge.EVENT_BUS.post(new FMLNetworkEvent.ServerConnectionFromClientEvent(manager));
         if (DEBUG_HANDSHAKE)
@@ -292,7 +292,7 @@ public class NetworkDispatcher extends SimpleChannelInboundHandler<Packet<?>> im
         }
         else
         {
-            FMLLog.info("Unexpected packet during modded negotiation - assuming vanilla or keepalives : %s", msg.getClass().getName());
+            FMLLog.log.info("Unexpected packet during modded negotiation - assuming vanilla or keepalives : {}", msg.getClass().getName());
         }
         return false;
     }
@@ -317,7 +317,7 @@ public class NetworkDispatcher extends SimpleChannelInboundHandler<Packet<?>> im
     {
         if (evt instanceof ConnectionType && side == Side.SERVER)
         {
-            FMLLog.info("Timeout occurred, assuming a vanilla client");
+            FMLLog.log.info("Timeout occurred, assuming a vanilla client");
             kickVanilla();
         }
     }
@@ -329,7 +329,7 @@ public class NetworkDispatcher extends SimpleChannelInboundHandler<Packet<?>> im
 
     private void kickWithMessage(String message)
     {
-        FMLLog.log(Level.ERROR, "Network Disconnect: %s", message);
+        FMLLog.log.error("Network Disconnect: {}", message);
         final TextComponentString TextComponentString = new TextComponentString(message);
         if (side == Side.CLIENT)
         {
@@ -554,7 +554,7 @@ public class NetworkDispatcher extends SimpleChannelInboundHandler<Packet<?>> im
     {
         if (state == ConnectionState.CONNECTED)
         {
-            FMLLog.severe("Attempt to double complete the network connection!");
+            FMLLog.log.fatal("Attempt to double complete the network connection!");
             throw new FMLNetworkException("Attempt to double complete!");
         }
         if (side == Side.CLIENT)
@@ -574,7 +574,7 @@ public class NetworkDispatcher extends SimpleChannelInboundHandler<Packet<?>> im
 
     public void abortClientHandshake(String type)
     {
-        FMLLog.log(Level.INFO, "Aborting client handshake \"%s\"", type);
+        FMLLog.log.info("Aborting client handshake \"{}\"", type);
         //FMLCommonHandler.instance().waitForPlayClient();
         completeClientSideConnection(ConnectionType.valueOf(type));
     }
@@ -588,11 +588,11 @@ public class NetworkDispatcher extends SimpleChannelInboundHandler<Packet<?>> im
             // Mute the reset by peer exception - it's disconnection noise
             if (cause.getMessage() != null && cause.getMessage().contains("Connection reset by peer"))
             {
-                FMLLog.log(Level.DEBUG, cause, "Muted NetworkDispatcher exception");
+                FMLLog.log.debug("Muted NetworkDispatcher exception", cause);
             }
             else
             {
-                FMLLog.log(Level.ERROR, cause, "NetworkDispatcher exception");
+                FMLLog.log.error("NetworkDispatcher exception", cause);
             }
         }
         super.exceptionCaught(ctx, cause);
@@ -611,11 +611,11 @@ public class NetworkDispatcher extends SimpleChannelInboundHandler<Packet<?>> im
 
     public void setOverrideDimension(int overrideDim) {
         this.overrideLoginDim = overrideDim;
-        FMLLog.fine("Received override dimension %d", overrideDim);
+        FMLLog.log.debug("Received override dimension {}", overrideDim);
     }
 
     public int getOverrideDimension(SPacketJoinGame packetIn) {
-        FMLLog.fine("Overriding dimension: using %d", this.overrideLoginDim);
+        FMLLog.log.debug("Overriding dimension: using {}", this.overrideLoginDim);
         return this.overrideLoginDim != 0 ? this.overrideLoginDim : packetIn.getDimension();
     }
 

--- a/src/main/java/net/minecraftforge/fml/common/network/internal/EntitySpawnHandler.java
+++ b/src/main/java/net/minecraftforge/fml/common/network/internal/EntitySpawnHandler.java
@@ -140,7 +140,7 @@ public class EntitySpawnHandler extends SimpleChannelInboundHandler<FMLMessage.E
             wc.addEntityToWorld(spawnMsg.entityId, entity);
         } catch (Exception e)
         {
-            FMLLog.log.error("A severe problem occurred during the spawning of an entity at ({}, {}, {})", spawnMsg.rawZ, e);
+            FMLLog.log.error("A severe problem occurred during the spawning of an entity at ({}, {}, {})", spawnMsg.rawX, spawnMsg.rawY, spawnMsg.rawZ, e);
             throw Throwables.propagate(e);
         }
     }

--- a/src/main/java/net/minecraftforge/fml/common/network/internal/EntitySpawnHandler.java
+++ b/src/main/java/net/minecraftforge/fml/common/network/internal/EntitySpawnHandler.java
@@ -140,7 +140,7 @@ public class EntitySpawnHandler extends SimpleChannelInboundHandler<FMLMessage.E
             wc.addEntityToWorld(spawnMsg.entityId, entity);
         } catch (Exception e)
         {
-            FMLLog.log(Level.ERROR, e, "A severe problem occurred during the spawning of an entity at ( " + spawnMsg.rawX + "," + spawnMsg.rawY + ", " + spawnMsg.rawZ +")");
+            FMLLog.error(e, "A severe problem occurred during the spawning of an entity at ({}, {}, {})", spawnMsg.rawX, spawnMsg.rawY, spawnMsg.rawZ);
             throw Throwables.propagate(e);
         }
     }
@@ -148,7 +148,7 @@ public class EntitySpawnHandler extends SimpleChannelInboundHandler<FMLMessage.E
     @Override
     public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) throws Exception
     {
-        FMLLog.log(Level.ERROR, cause, "EntitySpawnHandler exception");
+        FMLLog.log.error("EntitySpawnHandler exception", cause);
         super.exceptionCaught(ctx, cause);
     }
 }

--- a/src/main/java/net/minecraftforge/fml/common/network/internal/EntitySpawnHandler.java
+++ b/src/main/java/net/minecraftforge/fml/common/network/internal/EntitySpawnHandler.java
@@ -140,7 +140,7 @@ public class EntitySpawnHandler extends SimpleChannelInboundHandler<FMLMessage.E
             wc.addEntityToWorld(spawnMsg.entityId, entity);
         } catch (Exception e)
         {
-            FMLLog.error(e, "A severe problem occurred during the spawning of an entity at ({}, {}, {})", spawnMsg.rawX, spawnMsg.rawY, spawnMsg.rawZ);
+            FMLLog.log.error("A severe problem occurred during the spawning of an entity at ({}, {}, {})", spawnMsg.rawZ, e);
             throw Throwables.propagate(e);
         }
     }

--- a/src/main/java/net/minecraftforge/fml/common/network/internal/FMLMessage.java
+++ b/src/main/java/net/minecraftforge/fml/common/network/internal/FMLMessage.java
@@ -183,7 +183,7 @@ public abstract class FMLMessage {
                 entity.getDataManager().writeEntries(pb);
             } catch (IOException e)
             {
-                FMLLog.log(Level.FATAL,e,"Encountered fatal exception trying to send entity spawn data watchers");
+                FMLLog.log.fatal("Encountered fatal exception trying to send entity spawn data watchers", e);
                 throw Throwables.propagate(e);
             }
             buf.writeBytes(tmpBuf);
@@ -235,7 +235,7 @@ public abstract class FMLMessage {
                 dataWatcherList = EntityDataManager.readEntries(new PacketBuffer(dat));
             } catch (IOException e)
             {
-                FMLLog.log(Level.FATAL, e, "There was a critical error decoding the datawatcher stream for a mod entity.");
+                FMLLog.log.fatal("There was a critical error decoding the datawatcher stream for a mod entity.", e);
                 throw Throwables.propagate(e);
             }
 

--- a/src/main/java/net/minecraftforge/fml/common/network/internal/FMLNetworkHandler.java
+++ b/src/main/java/net/minecraftforge/fml/common/network/internal/FMLNetworkHandler.java
@@ -114,7 +114,7 @@ public class FMLNetworkHandler
         }
         else
         {
-            FMLLog.fine("Invalid attempt to open a local GUI on a dedicated server. This is likely a bug. GUI ID: %s,%d", mc.getModId(), modGuiId);
+            FMLLog.log.debug("Invalid attempt to open a local GUI on a dedicated server. This is likely a bug. GUI ID: {},{}", mc.getModId(), modGuiId);
         }
 
     }
@@ -160,7 +160,7 @@ public class FMLNetworkHandler
         }
         else
         {
-            FMLLog.info("Rejecting connection %s: %s", side, rejects);
+            FMLLog.log.info("Rejecting connection {}: {}", side, rejects);
             return String.format("Mod rejections %s",rejects);
         }
     }

--- a/src/main/java/net/minecraftforge/fml/common/network/internal/FMLProxyPacket.java
+++ b/src/main/java/net/minecraftforge/fml/common/network/internal/FMLProxyPacket.java
@@ -104,12 +104,12 @@ public class FMLProxyPacket implements Packet<INetHandler> {
                     badPackets.add(this.channel);
                     if (badPackets.size() % packetCountWarning == 0)
                     {
-                        FMLLog.severe("Detected ongoing potential memory leak. %d packets have leaked. Top offenders", badPackets.size());
+                        FMLLog.log.fatal("Detected ongoing potential memory leak. {} packets have leaked. Top offenders", badPackets.size());
                         int i = 0;
                         for (Entry<String> s  : Multisets.copyHighestCountFirst(badPackets).entrySet())
                         {
                             if (i++ > 10) break;
-                            FMLLog.severe("\t %s : %d", s.getElement(), s.getCount());
+                            FMLLog.log.fatal("\t {} : {}", s.getElement(), s.getCount());
                         }
                     }
                 }
@@ -117,12 +117,12 @@ public class FMLProxyPacket implements Packet<INetHandler> {
             }
             catch (FMLNetworkException ne)
             {
-                FMLLog.log(Level.ERROR, ne, "There was a network exception handling a packet on channel %s", channel);
+                FMLLog.error(ne, "There was a network exception handling a packet on channel {}", channel);
                 dispatcher.rejectHandshake(ne.getMessage());
             }
             catch (Throwable t)
             {
-                FMLLog.log(Level.ERROR, t, "There was a critical exception handling a packet on channel %s", channel);
+                FMLLog.error(t, "There was a critical exception handling a packet on channel {}", channel);
                 dispatcher.rejectHandshake("A fatal error has occurred, this connection is terminated");
             }
         }

--- a/src/main/java/net/minecraftforge/fml/common/network/internal/FMLProxyPacket.java
+++ b/src/main/java/net/minecraftforge/fml/common/network/internal/FMLProxyPacket.java
@@ -117,12 +117,12 @@ public class FMLProxyPacket implements Packet<INetHandler> {
             }
             catch (FMLNetworkException ne)
             {
-                FMLLog.error(ne, "There was a network exception handling a packet on channel {}", channel);
+                FMLLog.log.error("There was a network exception handling a packet on channel {}", channel, ne);
                 dispatcher.rejectHandshake(ne.getMessage());
             }
             catch (Throwable t)
             {
-                FMLLog.error(t, "There was a critical exception handling a packet on channel {}", channel);
+                FMLLog.log.error("There was a critical exception handling a packet on channel {}", channel, t);
                 dispatcher.rejectHandshake("A fatal error has occurred, this connection is terminated");
             }
         }

--- a/src/main/java/net/minecraftforge/fml/common/network/internal/FMLRuntimeCodec.java
+++ b/src/main/java/net/minecraftforge/fml/common/network/internal/FMLRuntimeCodec.java
@@ -53,10 +53,10 @@ public class FMLRuntimeCodec extends FMLIndexedMessageToMessageCodec<FMLMessage>
     {
         if (msg.payload().getByte(0) == 0 && msg.payload().readableBytes() > 2)
         {
-            FMLLog.severe("The connection appears to have sent an invalid FML packet of type 0, this is likely because it think's it's talking to 1.6.4 FML");
-            FMLLog.info("Bad data :");
+            FMLLog.log.fatal("The connection appears to have sent an invalid FML packet of type 0, this is likely because it think's it's talking to 1.6.4 FML");
+            FMLLog.log.info("Bad data :");
             for (String l : Splitter.on('\n').split(ByteBufUtils.getContentDump(msg.payload()))) {
-                FMLLog.info("\t%s",l);
+                FMLLog.log.info("\t{}",l);
             }
             throw new FMLNetworkException("Invalid FML packet");
         }

--- a/src/main/java/net/minecraftforge/fml/common/network/internal/HandshakeCompletionHandler.java
+++ b/src/main/java/net/minecraftforge/fml/common/network/internal/HandshakeCompletionHandler.java
@@ -41,7 +41,7 @@ public class HandshakeCompletionHandler extends SimpleChannelInboundHandler<FMLM
     @Override
     public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) throws Exception
     {
-        FMLLog.log(Level.ERROR, cause, "HandshakeCompletionHandler exception");
+        FMLLog.log.error("HandshakeCompletionHandler exception", cause);
         super.exceptionCaught(ctx, cause);
     }
 }

--- a/src/main/java/net/minecraftforge/fml/common/network/internal/NetworkModHolder.java
+++ b/src/main/java/net/minecraftforge/fml/common/network/internal/NetworkModHolder.java
@@ -83,7 +83,7 @@ public class NetworkModHolder
             }
             catch (Exception e)
             {
-                FMLLog.log(Level.ERROR, e, "Error occurred invoking NetworkCheckHandler %s at %s", checkHandler.getName(), container);
+                FMLLog.error(e, "Error occurred invoking NetworkCheckHandler {} at {}", checkHandler.getName(), container);
                 return false;
             }
         }
@@ -118,7 +118,7 @@ public class NetworkModHolder
     {
         this(container);
         this.checker = Preconditions.checkNotNull(checker);
-        FMLLog.fine("The mod %s is using a custom checker %s", container.getModId(), checker.getClass().getName());
+        FMLLog.log.debug("The mod {} is using a custom checker {}", container.getModId(), checker.getClass().getName());
     }
     public NetworkModHolder(ModContainer container, Class<?> modClass, @Nullable String acceptableVersionRange, ASMDataTable table)
     {
@@ -156,7 +156,7 @@ public class NetworkModHolder
                     }
                     else
                     {
-                        FMLLog.severe("Found unexpected method signature for annotation NetworkCheckHandler");
+                        FMLLog.log.fatal("Found unexpected method signature for annotation NetworkCheckHandler");
                     }
                 }
             }
@@ -173,7 +173,7 @@ public class NetworkModHolder
             }
             catch (Exception e)
             {
-                FMLLog.log(Level.WARN, e, "The declared version check handler method %s on network mod id %s is not accessible", networkCheckHandlerMethod, container.getModId());
+                FMLLog.warn(e, "The declared version check handler method {} on network mod id {} is not accessible", networkCheckHandlerMethod, container.getModId());
             }
         }
         if (this.checkHandler != null)
@@ -192,20 +192,20 @@ public class NetworkModHolder
             }
             catch (InvalidVersionSpecificationException e)
             {
-                FMLLog.log(Level.WARN, e, "Invalid bounded range %s specified for network mod id %s", acceptableVersionRange, container.getModId());
+                FMLLog.warn(e, "Invalid bounded range {} specified for network mod id {}", acceptableVersionRange, container.getModId());
             }
             this.checker = new DefaultNetworkChecker();
         }
-        FMLLog.finer("Mod %s is using network checker : %s", container.getModId(), this.checker);
-        FMLLog.finer("Testing mod %s to verify it accepts its own version in a remote connection", container.getModId());
+        FMLLog.log.trace("Mod {} is using network checker : {}", container.getModId(), this.checker);
+        FMLLog.log.trace("Testing mod {} to verify it accepts its own version in a remote connection", container.getModId());
         boolean acceptsSelf = acceptVersion(container.getVersion());
         if (!acceptsSelf)
         {
-            FMLLog.severe("The mod %s appears to reject its own version number (%s) in its version handling. This is likely a severe bug in the mod!", container.getModId(), container.getVersion());
+            FMLLog.log.fatal("The mod {} appears to reject its own version number ({}) in its version handling. This is likely a severe bug in the mod!", container.getModId(), container.getVersion());
         }
         else
         {
-            FMLLog.finer("The mod %s accepts its own version (%s)", container.getModId(), container.getVersion());
+            FMLLog.log.trace("The mod {} accepts its own version ({})", container.getModId(), container.getVersion());
         }
     }
 

--- a/src/main/java/net/minecraftforge/fml/common/network/internal/NetworkModHolder.java
+++ b/src/main/java/net/minecraftforge/fml/common/network/internal/NetworkModHolder.java
@@ -83,7 +83,7 @@ public class NetworkModHolder
             }
             catch (Exception e)
             {
-                FMLLog.error(e, "Error occurred invoking NetworkCheckHandler {} at {}", checkHandler.getName(), container);
+                FMLLog.log.error("Error occurred invoking NetworkCheckHandler {} at {}", container, e);
                 return false;
             }
         }
@@ -173,7 +173,7 @@ public class NetworkModHolder
             }
             catch (Exception e)
             {
-                FMLLog.warn(e, "The declared version check handler method {} on network mod id {} is not accessible", networkCheckHandlerMethod, container.getModId());
+                FMLLog.log.warn("The declared version check handler method {} on network mod id {} is not accessible", networkCheckHandlerMethod, container.getModId(), e);
             }
         }
         if (this.checkHandler != null)
@@ -192,7 +192,7 @@ public class NetworkModHolder
             }
             catch (InvalidVersionSpecificationException e)
             {
-                FMLLog.warn(e, "Invalid bounded range {} specified for network mod id {}", acceptableVersionRange, container.getModId());
+                FMLLog.log.warn("Invalid bounded range {} specified for network mod id {}", acceptableVersionRange, container.getModId(), e);
             }
             this.checker = new DefaultNetworkChecker();
         }

--- a/src/main/java/net/minecraftforge/fml/common/network/internal/OpenGuiHandler.java
+++ b/src/main/java/net/minecraftforge/fml/common/network/internal/OpenGuiHandler.java
@@ -62,7 +62,7 @@ public class OpenGuiHandler extends SimpleChannelInboundHandler<FMLMessage.OpenG
     @Override
     public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) throws Exception
     {
-        FMLLog.log(Level.ERROR, cause, "OpenGuiHandler exception");
+        FMLLog.log.error("OpenGuiHandler exception", cause);
         super.exceptionCaught(ctx, cause);
     }
 

--- a/src/main/java/net/minecraftforge/fml/common/network/simpleimpl/SimpleChannelHandlerWrapper.java
+++ b/src/main/java/net/minecraftforge/fml/common/network/simpleimpl/SimpleChannelHandlerWrapper.java
@@ -64,7 +64,7 @@ public class SimpleChannelHandlerWrapper<REQ extends IMessage, REPLY extends IMe
     @Override
     public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) throws Exception
     {
-        FMLLog.log(Level.ERROR, cause, "SimpleChannelHandlerWrapper exception");
+        FMLLog.log.error("SimpleChannelHandlerWrapper exception", cause);
         super.exceptionCaught(ctx, cause);
     }
 }

--- a/src/main/java/net/minecraftforge/fml/common/network/simpleimpl/SimpleNetworkWrapper.java
+++ b/src/main/java/net/minecraftforge/fml/common/network/simpleimpl/SimpleNetworkWrapper.java
@@ -128,7 +128,7 @@ public class SimpleNetworkWrapper {
         catch (Exception e)
         {
             // How is this possible?
-            FMLLog.log(Level.FATAL, e, "What? Netty isn't installed, what magic is this?");
+            FMLLog.log.fatal("What? Netty isn't installed, what magic is this?", e);
             throw Throwables.propagate(e);
         }
     }
@@ -146,7 +146,7 @@ public class SimpleNetworkWrapper {
         }
         catch (Exception e)
         {
-            FMLLog.log(Level.FATAL, e, "It appears we somehow have a not-standard pipeline. Huh");
+            FMLLog.log.fatal("It appears we somehow have a not-standard pipeline. Huh", e);
             throw Throwables.propagate(e);
         }
     }

--- a/src/main/java/net/minecraftforge/fml/common/patcher/ClassPatchManager.java
+++ b/src/main/java/net/minecraftforge/fml/common/patcher/ClassPatchManager.java
@@ -33,10 +33,8 @@ import java.util.jar.JarOutputStream;
 import java.util.jar.Pack200;
 import java.util.regex.Pattern;
 
-import org.apache.logging.log4j.Level;
-
 import net.minecraft.launchwrapper.LaunchClassLoader;
-import net.minecraftforge.fml.relauncher.FMLRelaunchLog;
+import net.minecraftforge.fml.common.FMLLog;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.repackage.com.nothome.delta.GDiffPatcher;
 import LZMA.LzmaInputStream;
@@ -67,7 +65,7 @@ public class ClassPatchManager {
         if (dumpPatched)
         {
             tempDir = Files.createTempDir();
-            FMLRelaunchLog.info("Dumping patched classes to %s",tempDir.getAbsolutePath());
+            FMLLog.log.info("Dumping patched classes to {}",tempDir.getAbsolutePath());
         }
     }
 
@@ -93,12 +91,12 @@ public class ClassPatchManager {
         }
         boolean ignoredError = false;
         if (DEBUG)
-            FMLRelaunchLog.fine("Runtime patching class %s (input size %d), found %d patch%s", mappedName, (inputData == null ? 0 : inputData.length), list.size(), list.size()!=1 ? "es" : "");
+            FMLLog.log.debug("Runtime patching class {} (input size {}), found {} patch{}", mappedName, (inputData == null ? 0 : inputData.length), list.size(), list.size()!=1 ? "es" : "");
         for (ClassPatch patch: list)
         {
             if (!patch.targetClassName.equals(mappedName) && !patch.sourceClassName.equals(name))
             {
-                FMLRelaunchLog.warning("Binary patch found %s for wrong class %s", patch.targetClassName, mappedName);
+                FMLLog.log.warn("Binary patch found {} for wrong class {}", patch.targetClassName, mappedName);
             }
             if (!patch.existsAtTarget && (inputData == null || inputData.length == 0))
             {
@@ -106,11 +104,11 @@ public class ClassPatchManager {
             }
             else if (!patch.existsAtTarget)
             {
-                FMLRelaunchLog.warning("Patcher expecting empty class data file for %s, but received non-empty", patch.targetClassName);
+                FMLLog.log.warn("Patcher expecting empty class data file for {}, but received non-empty", patch.targetClassName);
             }
             else if (patch.existsAtTarget && (inputData == null || inputData.length == 0))
             {
-                FMLRelaunchLog.severe("Patcher expecting non-empty class data file for %s, but received empty.", patch.targetClassName);
+                FMLLog.log.fatal("Patcher expecting non-empty class data file for {}, but received empty.", patch.targetClassName);
                 throw new RuntimeException(String.format("Patcher expecting non-empty class data file for %s, but received empty, your vanilla jar may be corrupt.", patch.targetClassName));
             }
             else
@@ -118,15 +116,15 @@ public class ClassPatchManager {
                 int inputChecksum = Hashing.adler32().hashBytes(inputData).asInt();
                 if (patch.inputChecksum != inputChecksum)
                 {
-                    FMLRelaunchLog.severe("There is a binary discrepancy between the expected input class %s (%s) and the actual class. Checksum on disk is %x, in patch %x. Things are probably about to go very wrong. Did you put something into the jar file?", mappedName, name, inputChecksum, patch.inputChecksum);
+                    FMLLog.log.fatal("There is a binary discrepancy between the expected input class {} ({}) and the actual class. Checksum on disk is {}, in patch {}. Things are probably about to go very wrong. Did you put something into the jar file?", mappedName, name, Integer.toHexString(inputChecksum), Integer.toHexString(patch.inputChecksum));
                     if (!Boolean.parseBoolean(System.getProperty("fml.ignorePatchDiscrepancies","false")))
                     {
-                        FMLRelaunchLog.severe("The game is going to exit, because this is a critical error, and it is very improbable that the modded game will work, please obtain clean jar files.");
+                        FMLLog.log.fatal("The game is going to exit, because this is a critical error, and it is very improbable that the modded game will work, please obtain clean jar files.");
                         System.exit(1);
                     }
                     else
                     {
-                        FMLRelaunchLog.severe("FML is going to ignore this error, note that the patch will not be applied, and there is likely to be a malfunctioning behaviour, including not running at all");
+                        FMLLog.log.fatal("FML is going to ignore this error, note that the patch will not be applied, and there is likely to be a malfunctioning behaviour, including not running at all");
                         ignoredError = true;
                         continue;
                     }
@@ -140,14 +138,14 @@ public class ClassPatchManager {
                 }
                 catch (IOException e)
                 {
-                    FMLRelaunchLog.log(Level.ERROR, e, "Encountered problem runtime patching class %s", name);
+                    FMLLog.error(e, "Encountered problem runtime patching class {}", name);
                     continue;
                 }
             }
         }
         if (!ignoredError && DEBUG)
         {
-            FMLRelaunchLog.fine("Successfully applied runtime patches for %s (new size %d)", mappedName, inputData.length);
+            FMLLog.log.debug("Successfully applied runtime patches for {} (new size {})", mappedName, inputData.length);
         }
         if (dumpPatched)
         {
@@ -157,7 +155,7 @@ public class ClassPatchManager {
             }
             catch (IOException e)
             {
-                FMLRelaunchLog.log(Level.ERROR, e, "Failed to write %s to %s", mappedName, tempDir.getAbsolutePath());
+                FMLLog.log.error(FMLLog.log.getMessageFactory().newMessage("Failed to write {} to {}", mappedName, tempDir.getAbsolutePath()), e);
             }
         }
         patchedClasses.put(name,inputData);
@@ -173,7 +171,7 @@ public class ClassPatchManager {
             InputStream binpatchesCompressed = getClass().getResourceAsStream("/binpatches.pack.lzma");
             if (binpatchesCompressed==null)
             {
-                FMLRelaunchLog.log(Level.ERROR, "The binary patch set is missing. Either you are in a development environment, or things are not going to work!");
+                FMLLog.log.error("The binary patch set is missing. Either you are in a development environment, or things are not going to work!");
                 return;
             }
             LzmaInputStream binpatchesDecompressed = new LzmaInputStream(binpatchesCompressed);
@@ -184,7 +182,7 @@ public class ClassPatchManager {
         }
         catch (Exception e)
         {
-            FMLRelaunchLog.log(Level.ERROR, e, "Error occurred reading binary patches. Expect severe problems!");
+            FMLLog.log.error("Error occurred reading binary patches. Expect severe problems!", e);
             throw Throwables.propagate(e);
         }
 
@@ -216,16 +214,16 @@ public class ClassPatchManager {
             {
             }
         } while (true);
-        FMLRelaunchLog.fine("Read %d binary patches", patches.size());
+        FMLLog.log.debug("Read {} binary patches", patches.size());
         if (DEBUG)
-            FMLRelaunchLog.fine("Patch list :\n\t%s", Joiner.on("\t\n").join(patches.asMap().entrySet()));
+            FMLLog.log.debug("Patch list :\n\t{}", Joiner.on("\t\n").join(patches.asMap().entrySet()));
         patchedClasses.clear();
     }
 
     private ClassPatch readPatch(JarEntry patchEntry, JarInputStream jis)
     {
         if (DEBUG)
-            FMLRelaunchLog.finer("Reading patch data from %s", patchEntry.getName());
+            FMLLog.log.trace("Reading patch data from {}", patchEntry.getName());
         ByteArrayDataInput input;
         try
         {
@@ -233,7 +231,7 @@ public class ClassPatchManager {
         }
         catch (IOException e)
         {
-            FMLRelaunchLog.log(Level.WARN, e, "Unable to read binpatch file %s - ignoring", patchEntry.getName());
+            FMLLog.log.warn(FMLLog.log.getMessageFactory().newMessage("Unable to read binpatch file {} - ignoring", patchEntry.getName()), e);
             return null;
         }
         String name = input.readUTF();

--- a/src/main/java/net/minecraftforge/fml/common/patcher/ClassPatchManager.java
+++ b/src/main/java/net/minecraftforge/fml/common/patcher/ClassPatchManager.java
@@ -138,7 +138,7 @@ public class ClassPatchManager {
                 }
                 catch (IOException e)
                 {
-                    FMLLog.error(e, "Encountered problem runtime patching class {}", name);
+                    FMLLog.log.error("Encountered problem runtime patching class {}", name, e);
                     continue;
                 }
             }

--- a/src/main/java/net/minecraftforge/fml/common/registry/EntityRegistry.java
+++ b/src/main/java/net/minecraftforge/fml/common/registry/EntityRegistry.java
@@ -191,7 +191,7 @@ public class EntityRegistry
         }
         catch (IllegalArgumentException e)
         {
-            FMLLog.warn(e, "The mod {} tried to register the entity (registry,name,class) ({},{},{}) one or both of which are already registered", mc.getModId(), registryName, entityName, entityClass.getName());
+            FMLLog.log.warn("The mod {} tried to register the entity (registry,name,class) ({},{},{}) one or both of which are already registered", mc.getModId(), registryName, entityName, entityClass.getName(), e);
             return;
         }
         entityRegistrations.put(mc, er);

--- a/src/main/java/net/minecraftforge/fml/common/registry/EntityRegistry.java
+++ b/src/main/java/net/minecraftforge/fml/common/registry/EntityRegistry.java
@@ -182,16 +182,16 @@ public class EntityRegistry
             {
                 EntityEntry entry = new EntityEntry(entityClass, entityName).setRegistryName(registryName);
                 ForgeRegistries.ENTITIES.register(entry);
-                FMLLog.finer("Automatically registered mod %s entity %s as %s", mc.getModId(), entityName, entry.getRegistryName());
+                FMLLog.log.trace("Automatically registered mod {} entity {} as {}", mc.getModId(), entityName, entry.getRegistryName());
             }
             else
             {
-                FMLLog.fine("Skipping automatic mod %s entity registration for already registered entry %s class %s", mc.getModId(), registryName, entityClass.getName());
+                FMLLog.log.debug("Skipping automatic mod {} entity registration for already registered entry {} class {}", mc.getModId(), registryName, entityClass.getName());
             }
         }
         catch (IllegalArgumentException e)
         {
-            FMLLog.log(Level.WARN, e, "The mod %s tried to register the entity (registry,name,class) (%s,%s,%s) one or both of which are already registered", mc.getModId(), registryName, entityName, entityClass.getName());
+            FMLLog.warn(e, "The mod {} tried to register the entity (registry,name,class) ({},{},{}) one or both of which are already registered", mc.getModId(), registryName, entityName, entityClass.getName());
             return;
         }
         entityRegistrations.put(mc, er);
@@ -214,7 +214,7 @@ public class EntityRegistry
         EntityEntry entry = ForgeRegistries.ENTITIES.getValue(name);
         if (entry == null)
         {
-            FMLLog.bigWarning("Attempted to registry a entity egg for entity (%s) that is not in the Entity Registry", name);
+            FMLLog.bigWarning("Attempted to registry a entity egg for entity ({}) that is not in the Entity Registry", name);
             return;
         }
         entry.setEgg(new EntityEggInfo(name, primary, secondary));

--- a/src/main/java/net/minecraftforge/fml/common/registry/FMLControlledNamespacedRegistry.java
+++ b/src/main/java/net/minecraftforge/fml/common/registry/FMLControlledNamespacedRegistry.java
@@ -247,15 +247,15 @@ public class FMLControlledNamespacedRegistry<I extends IForgeRegistryEntry<I>> e
 
         if (existingName == null)
         {
-            FMLLog.bigWarning("Ignoring putObject(%s, %s), not resolvable", name, thing);
+            FMLLog.bigWarning("Ignoring putObject({}, {}), not resolvable", name, thing);
         }
         else if (existingName.equals(name))
         {
-            FMLLog.bigWarning("Ignoring putObject(%s, %s), already added", name, thing);
+            FMLLog.bigWarning("Ignoring putObject({}, {}), already added", name, thing);
         }
         else
         {
-            FMLLog.bigWarning("Ignoring putObject(%s, %s), adding alias to %s instead", name, thing, existingName);
+            FMLLog.bigWarning("Ignoring putObject({}, {}), adding alias to {} instead", name, thing, existingName);
             addAlias(name, existingName);
         }
     }
@@ -458,7 +458,7 @@ public class FMLControlledNamespacedRegistry<I extends IForgeRegistryEntry<I>> e
 
         if (getRaw(name) == thing) // already registered, return prev registration's id
         {
-            FMLLog.bigWarning("The object %s has been registered twice for the same name %s.", thing, name);
+            FMLLog.bigWarning("The object {} has been registered twice for the same name {}.", thing, name);
             return getId(thing);
         }
         if (getRaw(name) != null) // duplicate name
@@ -473,7 +473,7 @@ public class FMLControlledNamespacedRegistry<I extends IForgeRegistryEntry<I>> e
         }
         if (PersistentRegistryManager.isFrozen(this))
         {
-            FMLLog.bigWarning("The object %s (name %s) is being added too late.", thing, name);
+            FMLLog.bigWarning("The object {} (name {}) is being added too late.", thing, name);
         }
 
         if (activeSubstitutions.containsKey(name))
@@ -482,7 +482,7 @@ public class FMLControlledNamespacedRegistry<I extends IForgeRegistryEntry<I>> e
             thing = activeSubstitutions.get(name);
             if (DEBUG)
             {
-                FMLLog.getLogger().log(Level.DEBUG, "Active substitution: {} {}@{} -> {}@{}", name, oldThing.getClass().getName(), System.identityHashCode(oldThing), thing.getClass().getName(), System.identityHashCode(thing));
+                FMLLog.log.debug("Active substitution: {} {}@{} -> {}@{}", name, oldThing.getClass().getName(), System.identityHashCode(oldThing), thing.getClass().getName(), System.identityHashCode(thing));
             }
         }
 
@@ -495,12 +495,12 @@ public class FMLControlledNamespacedRegistry<I extends IForgeRegistryEntry<I>> e
 
         if (this.dummiedLocations.remove(name) && DEBUG)
         {
-            FMLLog.fine("Registry Dummy Remove: %s", name);
+            FMLLog.log.debug("Registry Dummy Remove: {}", name);
         }
 
         if (DEBUG)
         {
-            FMLLog.finer("Registry add: %s %d %s (req. id %d)", name, idToUse, thing, id);
+            FMLLog.log.trace("Registry add: {} {} {} (req. id {})", name, idToUse, thing, id);
         }
         return idToUse;
     }
@@ -509,7 +509,7 @@ public class FMLControlledNamespacedRegistry<I extends IForgeRegistryEntry<I>> e
     {
         if (DEBUG)
         {
-            FMLLog.finer("Registry Dummy Add: %s %d -> %s", rl, id, thing);
+            FMLLog.log.trace("Registry Dummy Add: {} {} -> {}", rl, id, thing);
         }
         this.dummiedLocations.add(rl);
         this.addObjectRaw(id, rl, thing);
@@ -520,7 +520,7 @@ public class FMLControlledNamespacedRegistry<I extends IForgeRegistryEntry<I>> e
         aliases.put(from, to);
         if (DEBUG)
         {
-            FMLLog.finer("Registry alias: %s -> %s", from, to);
+            FMLLog.log.trace("Registry alias: {} -> {}", from, to);
         }
     }
 
@@ -558,11 +558,11 @@ public class FMLControlledNamespacedRegistry<I extends IForgeRegistryEntry<I>> e
 
         // sort by id
         Collections.sort(ids);
-        FMLLog.finer("Registry Name : {}", registryName);
+        FMLLog.log.trace("Registry Name : {}", registryName);
         for (int id : ids)
         {
             I thing = getRaw(id);
-            FMLLog.finer("Registry: %d %s %s", id, getNameForObject(thing), thing);
+            FMLLog.log.trace("Registry: {} {} {}", id, getNameForObject(thing), thing);
         }
     }
 
@@ -633,7 +633,7 @@ public class FMLControlledNamespacedRegistry<I extends IForgeRegistryEntry<I>> e
     {
         if (getPersistentSubstitutions().containsKey(nameToReplace) || getPersistentSubstitutions().containsValue(replacement))
         {
-            FMLLog.severe("The substitution of %s has already occurred. You cannot duplicate substitutions", nameToReplace);
+            FMLLog.log.fatal("The substitution of {} has already occurred. You cannot duplicate substitutions", nameToReplace);
             throw new ExistingSubstitutionException(nameToReplace, replacement);
         }
         I original = getRaw(nameToReplace);
@@ -643,16 +643,16 @@ public class FMLControlledNamespacedRegistry<I extends IForgeRegistryEntry<I>> e
         }
         if (!original.getClass().isAssignableFrom(replacement.getClass()))
         {
-            FMLLog.severe("The substitute %s for %s (type %s) is type incompatible. This won't work", replacement.getClass().getName(), nameToReplace, original.getClass().getName());
+            FMLLog.log.fatal("The substitute {} for {} (type {}) is type incompatible. This won't work", replacement.getClass().getName(), nameToReplace, original.getClass().getName());
             throw new IncompatibleSubstitutionException(nameToReplace, replacement, original);
         }
         int existingId = getId(replacement);
         if (existingId != -1)
         {
-            FMLLog.severe("The substitute %s for %s is registered into the game independently. This won't work", replacement.getClass().getName(), nameToReplace);
+            FMLLog.log.fatal("The substitute {} for {} is registered into the game independently. This won't work", replacement.getClass().getName(), nameToReplace);
             throw new IllegalArgumentException("The object substitution is already registered. This won't work");
         }
-        FMLLog.log(Level.DEBUG, "Adding substitution %s with %s (name %s)", original, replacement, nameToReplace);
+        FMLLog.log.debug("Adding substitution {} with {} (name {})", original, replacement, nameToReplace);
         getPersistentSubstitutions().put(nameToReplace, replacement);
     }
 
@@ -745,7 +745,7 @@ public class FMLControlledNamespacedRegistry<I extends IForgeRegistryEntry<I>> e
     {
         if (DEBUG && dummied.size() > 0)
         {
-            FMLLog.fine("Registry Dummy Load: [%s]", Joiner.on(", ").join(dummied));
+            FMLLog.log.debug("Registry Dummy Load: [{}]", Joiner.on(", ").join(dummied));
         }
         this.dummiedLocations.addAll(dummied);
     }
@@ -760,13 +760,13 @@ public class FMLControlledNamespacedRegistry<I extends IForgeRegistryEntry<I>> e
 
             if (currId == -1)
             {
-                FMLLog.info("Found a missing id from the world %s", itemName);
+                FMLLog.log.info("Found a missing id from the world {}", itemName);
                 missingIds.put(itemName, newId);
                 continue; // no block/item -> nothing to add
             }
             else if (currId != newId)
             {
-                FMLLog.fine("Fixed %s id mismatch %s: %d (init) -> %d (map).", registryName, itemName, currId, newId);
+                FMLLog.log.debug("Fixed {} id mismatch {}: {} (init) -> {} (map).", registryName, itemName, currId, newId);
                 remappedIds.put(itemName, new Integer[] {currId, newId});
             }
             I obj = currentRegistry.getRaw(itemName);
@@ -828,7 +828,7 @@ public class FMLControlledNamespacedRegistry<I extends IForgeRegistryEntry<I>> e
         ResourceLocation key = value.getRegistryName();
         if (key == null)
         {
-            FMLLog.severe("Attempted to register a entry with a null name: %s", value);
+            FMLLog.log.fatal("Attempted to register a entry with a null name: {}", value);
             throw new NullPointerException(String.format("Attempted to register a entry with a null name: %s", value));
         }
         add(-1, key, value);

--- a/src/main/java/net/minecraftforge/fml/common/registry/GameData.java
+++ b/src/main/java/net/minecraftforge/fml/common/registry/GameData.java
@@ -89,7 +89,7 @@ public class GameData
         }
         catch (Exception e)
         {
-            FMLLog.log(Level.FATAL, e, "Cannot access the 'block' field from ItemBlock, this is fatal!");
+            FMLLog.log.fatal("Cannot access the 'block' field from ItemBlock, this is fatal!", e);
             throw Throwables.propagate(e);
         }
 
@@ -198,7 +198,7 @@ public class GameData
     {
         if (object == null)
         {
-            FMLLog.getLogger().log(Level.ERROR, "Attempt to register a null object");
+            FMLLog.log.error("Attempt to register a null object");
             throw new NullPointerException("Attempt to register a null object");
         }
         ((K)object).setRegistryName(location);
@@ -213,12 +213,12 @@ public class GameData
         K castedObj = (K)object;
         if (object == null)
         {
-            FMLLog.getLogger().log(Level.ERROR, "Attempt to register a null object");
+            FMLLog.log.error("Attempt to register a null object");
             throw new NullPointerException("Attempt to register a null object");
         }
         if (castedObj.getRegistryName() == null)
         {
-            FMLLog.getLogger().log(Level.ERROR, "Attempt to register object without having set a registry name {} (type {})", object, object.getClass().getName());
+            FMLLog.log.error("Attempt to register object without having set a registry name {} (type {})", object, object.getClass().getName());
             throw new IllegalArgumentException(String.format("No registry name set for object %s (%s)", object, object.getClass().getName()));
         }
         final IForgeRegistry<K> registry = PersistentRegistryManager.findRegistry(castedObj);

--- a/src/main/java/net/minecraftforge/fml/common/registry/GameRegistry.java
+++ b/src/main/java/net/minecraftforge/fml/common/registry/GameRegistry.java
@@ -137,7 +137,7 @@ public class GameRegistry
             }
             catch (Exception e)
             {
-                FMLLog.log(Level.ERROR, e, "Exception caught during entity selector creation with %s for argument map %s of %s for %s at %s", factory,
+                FMLLog.error(e, "Exception caught during entity selector creation with {} for argument map {} of {} for {} at {}", factory,
                         arguments, mainSelector, sender, position);
             }
         }
@@ -424,7 +424,7 @@ public class GameRegistry
         Item item = GameData.getItemRegistry().getObject(new ResourceLocation(itemName));
         if (item == null)
         {
-            FMLLog.getLogger().log(Level.TRACE, "Unable to find item with name {}", itemName);
+            FMLLog.log.trace("Unable to find item with name {}", itemName);
             return ItemStack.EMPTY;
         }
         ItemStack is = new ItemStack(item, stackSize, meta);
@@ -436,12 +436,12 @@ public class GameRegistry
                 nbttag = JsonToNBT.getTagFromJson(nbtString);
             } catch (NBTException e)
             {
-                FMLLog.getLogger().log(Level.WARN, "Encountered an exception parsing ItemStack NBT string {}", nbtString, e);
+                FMLLog.log.warn("Encountered an exception parsing ItemStack NBT string {}", nbtString, e);
                 throw Throwables.propagate(e);
             }
             if (!(nbttag instanceof NBTTagCompound))
             {
-                FMLLog.getLogger().log(Level.WARN, "Unexpected NBT string - multiple values {}", nbtString);
+                FMLLog.log.warn("Unexpected NBT string - multiple values {}", nbtString);
                 throw new RuntimeException("Invalid NBT JSON");
             }
             else

--- a/src/main/java/net/minecraftforge/fml/common/registry/GameRegistry.java
+++ b/src/main/java/net/minecraftforge/fml/common/registry/GameRegistry.java
@@ -137,8 +137,8 @@ public class GameRegistry
             }
             catch (Exception e)
             {
-                FMLLog.error(e, "Exception caught during entity selector creation with {} for argument map {} of {} for {} at {}", factory,
-                        arguments, mainSelector, sender, position);
+                FMLLog.log.error("Exception caught during entity selector creation with {} for argument map {} of {} for {} at {}", factory,
+                        arguments, mainSelector, sender, position, e);
             }
         }
         return selectors;

--- a/src/main/java/net/minecraftforge/fml/common/registry/IForgeRegistryEntry.java
+++ b/src/main/java/net/minecraftforge/fml/common/registry/IForgeRegistryEntry.java
@@ -82,7 +82,7 @@ public interface IForgeRegistryEntry<V>
             String prefix = mc == null || (mc instanceof InjectedModContainer && ((InjectedModContainer)mc).wrappedContainer instanceof FMLContainer) ? "minecraft" : mc.getModId().toLowerCase();
             if (!oldPrefix.equals(prefix) && oldPrefix.length() > 0)
             {
-                FMLLog.bigWarning("Dangerous alternative prefix `%s` for name `%s`, expected `%s` invalid registry invocation/invalid name?", oldPrefix, name, prefix);
+                FMLLog.bigWarning("Dangerous alternative prefix `{}` for name `{}`, expected `{}` invalid registry invocation/invalid name?", oldPrefix, name, prefix);
                 prefix = oldPrefix;
             }
             this.registryName = new ResourceLocation(prefix, name);

--- a/src/main/java/net/minecraftforge/fml/common/registry/ItemStackHolderInjector.java
+++ b/src/main/java/net/minecraftforge/fml/common/registry/ItemStackHolderInjector.java
@@ -42,15 +42,15 @@ public enum ItemStackHolderInjector
     private List<ItemStackHolderRef> itemStackHolders = Lists.newArrayList();
 
     public void inject() {
-        FMLLog.getLogger().log(Level.INFO, "Injecting itemstacks");
+        FMLLog.log.info("Injecting itemstacks");
         for (ItemStackHolderRef ishr: itemStackHolders) {
             ishr.apply();
         }
-        FMLLog.getLogger().log(Level.INFO, "Itemstack injection complete");
+        FMLLog.log.info("Itemstack injection complete");
     }
 
     public void findHolders(ASMDataTable table) {
-        FMLLog.info("Identifying ItemStackHolder annotations");
+        FMLLog.log.info("Identifying ItemStackHolder annotations");
         Set<ASMData> allItemStackHolders = table.getAll(GameRegistry.ItemStackHolder.class.getName());
         Map<String, Class<?>> classCache = Maps.newHashMap();
         for (ASMData data : allItemStackHolders)
@@ -62,7 +62,7 @@ public enum ItemStackHolderInjector
             String nbt = data.getAnnotationInfo().containsKey("nbt") ? (String) data.getAnnotationInfo().get("nbt") : "";
             addHolder(classCache, className, annotationTarget, value, meta, nbt);
         }
-        FMLLog.info("Found %d ItemStackHolder annotations", allItemStackHolders.size());
+        FMLLog.log.info("Found {} ItemStackHolder annotations", allItemStackHolders.size());
 
     }
 

--- a/src/main/java/net/minecraftforge/fml/common/registry/ItemStackHolderRef.java
+++ b/src/main/java/net/minecraftforge/fml/common/registry/ItemStackHolderRef.java
@@ -86,7 +86,7 @@ class ItemStackHolderRef {
             is = GameRegistry.makeItemStack(itemName, meta, 1, serializednbt);
         } catch (RuntimeException e)
         {
-            FMLLog.getLogger().log(Level.ERROR, "Caught exception processing itemstack {},{},{} in annotation at {}.{}", itemName, meta, serializednbt,field.getClass().getName(),field.getName());
+            FMLLog.log.error("Caught exception processing itemstack {},{},{} in annotation at {}.{}", itemName, meta, serializednbt,field.getClass().getName(),field.getName());
             throw e;
         }
         try
@@ -96,7 +96,7 @@ class ItemStackHolderRef {
         }
         catch (Exception e)
         {
-            FMLLog.getLogger().log(Level.WARN, "Unable to set {} with value {},{},{}", this.field, this.itemName, this.meta, this.serializednbt);
+            FMLLog.log.warn("Unable to set {} with value {},{},{}", this.field, this.itemName, this.meta, this.serializednbt);
         }
     }
 }

--- a/src/main/java/net/minecraftforge/fml/common/registry/ObjectHolderRef.java
+++ b/src/main/java/net/minecraftforge/fml/common/registry/ObjectHolderRef.java
@@ -152,7 +152,7 @@ class ObjectHolderRef {
         }
         catch (Exception e)
         {
-            FMLLog.warn(e, "Unable to set {} with value {} ({})", this.field, thing, this.injectedObject);
+            FMLLog.log.warn("Unable to set {} with value {} ({})", this.field, thing, this.injectedObject, e);
         }
     }
 }

--- a/src/main/java/net/minecraftforge/fml/common/registry/ObjectHolderRef.java
+++ b/src/main/java/net/minecraftforge/fml/common/registry/ObjectHolderRef.java
@@ -143,7 +143,7 @@ class ObjectHolderRef {
 
         if (thing == null)
         {
-            FMLLog.getLogger().log(Level.DEBUG, "Unable to lookup {} for {}. This means the object wasn't registered. It's likely just mod options.", injectedObject, field);
+            FMLLog.log.debug("Unable to lookup {} for {}. This means the object wasn't registered. It's likely just mod options.", injectedObject, field);
             return;
         }
         try
@@ -152,7 +152,7 @@ class ObjectHolderRef {
         }
         catch (Exception e)
         {
-            FMLLog.log(Level.WARN, e, "Unable to set %s with value %s (%s)", this.field, thing, this.injectedObject);
+            FMLLog.warn(e, "Unable to set {} with value {} ({})", this.field, thing, this.injectedObject);
         }
     }
 }

--- a/src/main/java/net/minecraftforge/fml/common/registry/ObjectHolderRegistry.java
+++ b/src/main/java/net/minecraftforge/fml/common/registry/ObjectHolderRegistry.java
@@ -48,7 +48,7 @@ public enum ObjectHolderRegistry {
 
     public void findObjectHolders(ASMDataTable table)
     {
-        FMLLog.info("Processing ObjectHolder annotations");
+        FMLLog.log.info("Processing ObjectHolder annotations");
         Set<ASMData> allObjectHolders = table.getAll(GameRegistry.ObjectHolder.class.getName());
         Map<String, String> classModIds = Maps.newHashMap();
         Map<String, Class<?>> classCache = Maps.newHashMap();
@@ -77,7 +77,7 @@ public enum ObjectHolderRegistry {
         }
         scanTarget(classModIds, classCache, "net.minecraft.init.Blocks", null, "minecraft", true, true);
         scanTarget(classModIds, classCache, "net.minecraft.init.Items", null, "minecraft", true, true);
-        FMLLog.info("Found %d ObjectHolder annotations", objectHolders.size());
+        FMLLog.log.info("Found {} ObjectHolder annotations", objectHolders.size());
     }
 
     private void scanTarget(Map<String, String> classModIds, Map<String, Class<?>> classCache, String className, @Nullable String annotationTarget, String value, boolean isClass, boolean extractFromValue)
@@ -111,7 +111,7 @@ public enum ObjectHolderRegistry {
                 String prefix = classModIds.get(className);
                 if (prefix == null)
                 {
-                    FMLLog.warning("Found an unqualified ObjectHolder annotation (%s) without a modid context at %s.%s, ignoring", value, className, annotationTarget);
+                    FMLLog.log.warn("Found an unqualified ObjectHolder annotation ({}) without a modid context at {}.{}, ignoring", value, className, annotationTarget);
                     throw new IllegalStateException("Unqualified reference to ObjectHolder");
                 }
                 value = prefix + ":" + value;
@@ -154,12 +154,12 @@ public enum ObjectHolderRegistry {
 
     public void applyObjectHolders()
     {
-        FMLLog.info("Applying holder lookups");
+        FMLLog.log.info("Applying holder lookups");
         for (ObjectHolderRef ohr : objectHolders)
         {
             ohr.apply();
         }
-        FMLLog.info("Holder lookups applied");
+        FMLLog.log.info("Holder lookups applied");
     }
 
 }

--- a/src/main/java/net/minecraftforge/fml/common/registry/PersistentRegistryManager.java
+++ b/src/main/java/net/minecraftforge/fml/common/registry/PersistentRegistryManager.java
@@ -137,7 +137,7 @@ public class PersistentRegistryManager
             if (!overlappedTypes.isEmpty())
             {
                 Class<?> foundType = overlappedTypes.iterator().next();
-                FMLLog.severe("Found existing registry of type %1s named %2s, you cannot create a new registry (%3s) with type %4s, as %4s has a parent of that type", foundType, registrySuperTypes.get(foundType), registryName, type);
+                FMLLog.log.fatal("Found existing registry of type {} named {}, you cannot create a new registry ({}) with type {}, as {} has a parent of that type", foundType, registrySuperTypes.get(foundType), registryName, type, type);
                 throw new IllegalArgumentException("Duplicate registry parent type found - you can only have one registry for a particular super type");
             }
             FMLControlledNamespacedRegistry<T> fmlControlledNamespacedRegistry = new FMLControlledNamespacedRegistry<T>(defaultObjectKey, minId, maxId, type, registries, addCallback, clearCallback, createCallback, substitutionCallback);
@@ -225,7 +225,7 @@ public class PersistentRegistryManager
         final FMLControlledNamespacedRegistry<V> registry = PersistentRegistry.ACTIVE.getRegistry(registryType);
         if (registry == null)
         {
-            FMLLog.getLogger().log(Level.ERROR, "Unable to locate registry for registered object of type {}", entry.getClass().getName());
+            FMLLog.log.error("Unable to locate registry for registered object of type {}", entry.getClass().getName());
             throw new IllegalArgumentException("Unable to locate registry for registered object");
         }
         return registry;
@@ -242,7 +242,7 @@ public class PersistentRegistryManager
 
     public static List<String> injectSnapshot(GameDataSnapshot snapshot, boolean injectFrozenData, boolean isLocalWorld)
     {
-        FMLLog.info("Injecting existing block and item data into this %s instance", FMLCommonHandler.instance().getEffectiveSide().isServer() ? "server" : "client");
+        FMLLog.log.info("Injecting existing block and item data into this {} instance", FMLCommonHandler.instance().getEffectiveSide().isServer() ? "server" : "client");
         final Map<ResourceLocation, Map<ResourceLocation, Integer[]>> remaps = Maps.newHashMap();
         final LinkedHashMap<ResourceLocation, Map<ResourceLocation, Integer>> missing = Maps.newLinkedHashMap();
 
@@ -301,7 +301,7 @@ public class PersistentRegistryManager
                 // Carry on, we resuscitated the block
                 if (FMLControlledNamespacedRegistry.DEBUG)
                 {
-                    FMLLog.log(Level.DEBUG, "Registry: Resuscitating dummy block %s", dummy);
+                    FMLLog.log.debug("Registry: Resuscitating dummy block {}", dummy);
                 }
             }
             else
@@ -309,7 +309,7 @@ public class PersistentRegistryManager
                 Integer id = PersistentRegistry.STAGING.getRegistry(BLOCKS, Block.class).getId(dummy);
                 // The server believes this is a dummy block identity, but we seem to have one locally. This is likely a conflict
                 // in mod setup - Mark this entry as a dummy
-                FMLLog.log(Level.WARN, "The ID %d is currently locally mapped - it will be replaced with air for this session", id);
+                FMLLog.log.warn("The ID {} is currently locally mapped - it will be replaced with air for this session", id);
                 PersistentRegistry.STAGING.getRegistry(BLOCKS, Block.class).markDummy(dummy, id, new BlockDummyAir());
             }
         }
@@ -330,7 +330,7 @@ public class PersistentRegistryManager
             {
                 ResourceLocation rl = missingBlock.getKey();
                 Integer id = missingBlock.getValue();
-                FMLLog.log(Level.DEBUG, "Replacing id %s named as %s with air block. If the mod becomes available again later, it can reload here", id, rl);
+                FMLLog.log.debug("Replacing id {} named as {} with air block. If the mod becomes available again later, it can reload here", id, rl);
                 // Mark this entry as a dummy
                 PersistentRegistry.STAGING.getRegistry(BLOCKS, Block.class).markDummy(rl, id, new BlockDummyAir());
             }
@@ -476,12 +476,12 @@ public class PersistentRegistryManager
     {
         if (!PersistentRegistry.FROZEN.isPopulated())
         {
-            FMLLog.warning("Can't revert to frozen GameData state without freezing first.");
+            FMLLog.log.warn("Can't revert to frozen GameData state without freezing first.");
             return;
         }
         else
         {
-            FMLLog.fine("Reverting to frozen data state.");
+            FMLLog.log.debug("Reverting to frozen data state.");
         }
         for (Map.Entry<ResourceLocation, FMLControlledNamespacedRegistry<?>> r : PersistentRegistry.ACTIVE.registries.entrySet())
         {
@@ -493,12 +493,12 @@ public class PersistentRegistryManager
 
         // the id mapping has reverted, ensure we sync up the object holders
         ObjectHolderRegistry.INSTANCE.applyObjectHolders();
-        FMLLog.fine("Frozen state restored.");
+        FMLLog.log.debug("Frozen state restored.");
     }
 
     public static void freezeData()
     {
-        FMLLog.fine("Freezing block and item id maps");
+        FMLLog.log.debug("Freezing block and item id maps");
         for (Map.Entry<ResourceLocation, FMLControlledNamespacedRegistry<?>> r : PersistentRegistry.ACTIVE.registries.entrySet())
         {
             // This has to be performed prior to invoking the method so the compiler can precompute the type bounds for the method
@@ -510,7 +510,7 @@ public class PersistentRegistryManager
 
     public static void freezeVanilla()
     {
-        FMLLog.fine("Creating vanilla freeze snapshot");
+        FMLLog.log.debug("Creating vanilla freeze snapshot");
         for (Map.Entry<ResourceLocation, FMLControlledNamespacedRegistry<?>> r : PersistentRegistry.ACTIVE.registries.entrySet())
         {
             // This has to be performed prior to invoking the method so the compiler can precompute the type bounds for the method
@@ -518,7 +518,7 @@ public class PersistentRegistryManager
             loadRegistry(r.getKey(), PersistentRegistry.ACTIVE, PersistentRegistry.VANILLA, registrySuperType);
         }
         forAllRegistries(PersistentRegistry.VANILLA, ValidateRegistryFunction.OPERATION);
-        FMLLog.fine("Vanilla freeze snapshot created");
+        FMLLog.log.debug("Vanilla freeze snapshot created");
     }
 
     public static List<String> processIdRematches(Iterable<FMLMissingMappingsEvent.MissingMapping> missedMappings, boolean isLocalWorld, Map<ResourceLocation, Integer> missingBlocks, Map<ResourceLocation, Integer> missingItems, Map<ResourceLocation, Integer[]> remapBlocks, Map<ResourceLocation, Integer[]> remapItems)
@@ -544,7 +544,7 @@ public class PersistentRegistryManager
                 {
                     currId = staging.getRegistry(BLOCKS, Block.class).getId((Block)remap.getTarget());
                     newName = active.getRegistry(BLOCKS, Block.class).getNameForObject((Block)remap.getTarget());
-                    FMLLog.fine("The Block %s is being remapped to %s.", remap.name, newName);
+                    FMLLog.log.debug("The Block {} is being remapped to {}.", remap.name, newName);
 
                     missingBlocks.remove(new ResourceLocation(remap.name));
                     newId = staging.getRegistry(BLOCKS, Block.class).add(remap.id, newName, (Block)remap.getTarget());
@@ -554,7 +554,7 @@ public class PersistentRegistryManager
                 {
                     currId = staging.getRegistry(ITEMS, Item.class).getId((Item)remap.getTarget());
                     newName = active.getRegistry(ITEMS, Item.class).getNameForObject((Item)remap.getTarget());
-                    FMLLog.fine("The Item %s is being remapped to %s.", remap.name, newName);
+                    FMLLog.log.debug("The Item {} is being remapped to {}.", remap.name, newName);
 
                     missingItems.remove(new ResourceLocation(remap.name));
                     newId = staging.getRegistry(ITEMS, Item.class).add(remap.id, newName, (Item)remap.getTarget());
@@ -573,7 +573,7 @@ public class PersistentRegistryManager
 
                 if (currId != newId)
                 {
-                    FMLLog.info("Fixed %s id mismatch %s: %d (init) -> %d (map).", remap.type == GameRegistry.Type.BLOCK ? "block" : "item", newName, currId, newId);
+                    FMLLog.log.info("Fixed {} id mismatch {}: {} (init) -> {} (map).", remap.type == GameRegistry.Type.BLOCK ? "block" : "item", newName, currId, newId);
                     (remap.type == GameRegistry.Type.BLOCK ? remapBlocks : remapItems).put(newName, new Integer[] {currId, newId});
                 }
             }
@@ -581,7 +581,7 @@ public class PersistentRegistryManager
             {
                 // Pulled out specifically so the block doesn't get reassigned a new ID just because it's
                 // Item block has gone away
-                FMLLog.fine("The ItemBlock %s is no longer present in the game. The residual block will remain", remap.name);
+                FMLLog.log.debug("The ItemBlock {} is no longer present in the game. The residual block will remain", remap.name);
             }
             else
             {
@@ -640,7 +640,7 @@ public class PersistentRegistryManager
                 else
                 {
                     for (int x = 0; x < 10; x++)
-                        FMLLog.severe("!!!!!!!!!! UPDATING WORLD WITHOUT DOING BACKUP !!!!!!!!!!!!!!!!");
+                        FMLLog.log.fatal("!!!!!!!!!! UPDATING WORLD WITHOUT DOING BACKUP !!!!!!!!!!!!!!!!");
                 }
             } catch (IOException e)
             {
@@ -652,17 +652,17 @@ public class PersistentRegistryManager
         }
         if (!failed.isEmpty())
         {
-            FMLLog.severe("This world contains blocks and items that refuse to be remapped. The world will not be loaded");
+            FMLLog.log.fatal("This world contains blocks and items that refuse to be remapped. The world will not be loaded");
             return failed;
         }
         if (!warned.isEmpty())
         {
-            FMLLog.warning("This world contains block and item mappings that may cause world breakage");
+            FMLLog.log.warn("This world contains block and item mappings that may cause world breakage");
             return failed;
         }
         else if (!ignored.isEmpty())
         {
-            FMLLog.fine("There were %d missing mappings that have been ignored", ignored.size());
+            FMLLog.log.debug("There were {} missing mappings that have been ignored", ignored.size());
         }
         return failed;
     }

--- a/src/main/java/net/minecraftforge/fml/common/toposort/TopologicalSort.java
+++ b/src/main/java/net/minecraftforge/fml/common/toposort/TopologicalSort.java
@@ -187,13 +187,13 @@ public class TopologicalSort
                 return;
             }
 
-            FMLLog.severe("Mod Sorting failed.");
-            FMLLog.severe("Visiting node %s", node);
-            FMLLog.severe("Current sorted list : %s", sortedResult);
-            FMLLog.severe("Visited set for this node : %s", visitedNodes);
-            FMLLog.severe("Explored node set : %s", expandedNodes);
+            FMLLog.log.fatal("Mod Sorting failed.");
+            FMLLog.log.fatal("Visiting node {}", node);
+            FMLLog.log.fatal("Current sorted list : {}", sortedResult);
+            FMLLog.log.fatal("Visited set for this node : {}", visitedNodes);
+            FMLLog.log.fatal("Explored node set : {}", expandedNodes);
             SetView<T> cycleList = Sets.difference(visitedNodes, expandedNodes);
-            FMLLog.severe("Likely cycle is in : %s", cycleList);
+            FMLLog.log.fatal("Likely cycle is in : {}", cycleList);
             throw new ModSortingException("There was a cycle detected in the input graph, sorting is not possible", node, cycleList);
         }
 

--- a/src/main/java/net/minecraftforge/fml/common/versioning/VersionParser.java
+++ b/src/main/java/net/minecraftforge/fml/common/versioning/VersionParser.java
@@ -76,7 +76,7 @@ public class VersionParser
         }
         catch (InvalidVersionSpecificationException e)
         {
-            FMLLog.error(e, "Unable to parse a version range specification successfully {}", range);
+            FMLLog.log.error("Unable to parse a version range specification successfully {}", range, e);
             throw new LoaderException(e);
         }
     }

--- a/src/main/java/net/minecraftforge/fml/common/versioning/VersionParser.java
+++ b/src/main/java/net/minecraftforge/fml/common/versioning/VersionParser.java
@@ -76,7 +76,7 @@ public class VersionParser
         }
         catch (InvalidVersionSpecificationException e)
         {
-            FMLLog.log(Level.ERROR, e, "Unable to parse a version range specification successfully %s", range);
+            FMLLog.error(e, "Unable to parse a version range specification successfully {}", range);
             throw new LoaderException(e);
         }
     }

--- a/src/main/java/net/minecraftforge/fml/relauncher/CoreModManager.java
+++ b/src/main/java/net/minecraftforge/fml/relauncher/CoreModManager.java
@@ -384,7 +384,7 @@ public class CoreModManager {
             }
             catch (IOException ioe)
             {
-                FMLLog.error(ioe, "Unable to read the jar file {} - ignoring", coreMod.getName());
+                FMLLog.log.error("Unable to read the jar file {} - ignoring", coreMod.getName(), ioe);
                 continue;
             }
             finally
@@ -508,7 +508,7 @@ public class CoreModManager {
         }
         catch (Exception e)
         {
-            FMLLog.info(e, "There was a problem trying to load the mod dir tweaker {}", coreMod.getAbsolutePath());
+            FMLLog.log.info("There was a problem trying to load the mod dir tweaker {}", coreMod.getAbsolutePath(), e);
         }
     }
 
@@ -617,21 +617,21 @@ public class CoreModManager {
         catch (ClassNotFoundException cnfe)
         {
             if (!Lists.newArrayList(rootPlugins).contains(coreModClass))
-                FMLLog.error(cnfe, "Coremod {}: Unable to class load the plugin {}", coreModName, coreModClass);
+                FMLLog.log.error("Coremod {}: Unable to class load the plugin {}", coreModClass, cnfe);
             else
                 FMLLog.log.debug("Skipping root plugin {}", coreModClass);
         }
         catch (ClassCastException cce)
         {
-            FMLLog.error(cce, "Coremod {}: The plugin {} is not an implementor of IFMLLoadingPlugin", coreModName, coreModClass);
+            FMLLog.log.error("Coremod {}: The plugin {} is not an implementor of IFMLLoadingPlugin", coreModClass, cce);
         }
         catch (InstantiationException ie)
         {
-            FMLLog.error(ie, "Coremod {}: The plugin class {} was not instantiable", coreModName, coreModClass);
+            FMLLog.log.error("Coremod {}: The plugin class {} was not instantiable", coreModClass, ie);
         }
         catch (IllegalAccessException iae)
         {
-            FMLLog.error(iae, "Coremod {}: The plugin class {} was not accessible", coreModName, coreModClass);
+            FMLLog.log.error("Coremod {}: The plugin class {} was not accessible", coreModClass, iae);
         }
         return null;
     }

--- a/src/main/java/net/minecraftforge/fml/relauncher/CoreModManager.java
+++ b/src/main/java/net/minecraftforge/fml/relauncher/CoreModManager.java
@@ -46,6 +46,7 @@ import com.google.common.io.Files;
 import net.minecraft.launchwrapper.ITweaker;
 import net.minecraft.launchwrapper.Launch;
 import net.minecraft.launchwrapper.LaunchClassLoader;
+import net.minecraftforge.fml.common.FMLLog;
 import net.minecraftforge.fml.common.asm.ASMTransformerWrapper;
 import net.minecraftforge.fml.common.asm.transformers.ModAccessTransformer;
 import net.minecraftforge.fml.common.launcher.FMLInjectionAndSortingTweaker;
@@ -57,7 +58,6 @@ import net.minecraftforge.fml.relauncher.IFMLLoadingPlugin.SortingIndex;
 import net.minecraftforge.fml.relauncher.IFMLLoadingPlugin.TransformerExclusions;
 
 import org.apache.commons.io.IOUtils;
-import org.apache.logging.log4j.Level;
 
 import com.google.common.base.Strings;
 import com.google.common.base.Throwables;
@@ -125,11 +125,11 @@ public class CoreModManager {
         @Override
         public void injectIntoClassLoader(LaunchClassLoader classLoader)
         {
-            FMLRelaunchLog.fine("Injecting coremod %s {%s} class transformers", name, coreModInstance.getClass().getName());
+            FMLLog.log.debug("Injecting coremod {} \\{{}\\} class transformers", name, coreModInstance.getClass().getName());
             List<String> ts = Lists.newArrayList();
             if (coreModInstance.getASMTransformerClass() != null) for (String transformer : coreModInstance.getASMTransformerClass())
             {
-                FMLRelaunchLog.finer("Registering transformer %s", transformer);
+                FMLLog.log.trace("Registering transformer {}", transformer);
                 classLoader.registerTransformer(ASMTransformerWrapper.getTransformerWrapper(classLoader, transformer, name));
                 ts.add(transformer);
             }
@@ -140,14 +140,14 @@ public class CoreModManager {
                 else loc = location.getName();
                 transformers.put(name + " (" + loc + ")", ts);
             }
-            FMLRelaunchLog.fine("Injection complete");
+            FMLLog.log.debug("Injection complete");
 
-            FMLRelaunchLog.fine("Running coremod plugin for %s {%s}", name, coreModInstance.getClass().getName());
+            FMLLog.log.debug("Running coremod plugin for {} \\{{}\\}", name, coreModInstance.getClass().getName());
             Map<String, Object> data = new HashMap<String, Object>();
             data.put("mcLocation", mcDir);
             data.put("coremodList", loadPlugins);
             data.put("runtimeDeobfuscationEnabled", !deobfuscatedEnvironment);
-            FMLRelaunchLog.fine("Running coremod plugin %s", name);
+            FMLLog.log.debug("Running coremod plugin {}", name);
             data.put("coremodLocation", location);
             coreModInstance.injectData(data);
             String setupClass = coreModInstance.getSetupClass();
@@ -170,7 +170,7 @@ public class CoreModManager {
                     throw new RuntimeException(e);
                 }
             }
-            FMLRelaunchLog.fine("Coremod plugin class %s run successfully", coreModInstance.getClass().getSimpleName());
+            FMLLog.log.debug("Coremod plugin class {} run successfully", coreModInstance.getClass().getSimpleName());
 
             String modContainer = coreModInstance.getModContainerClass();
             if (modContainer != null)
@@ -203,7 +203,7 @@ public class CoreModManager {
             byte[] bs = classLoader.getClassBytes("net.minecraft.world.World");
             if (bs != null)
             {
-                FMLRelaunchLog.info("Managed to load a deobfuscated Minecraft name- we are in a deobfuscated environment. Skipping runtime deobfuscation");
+                FMLLog.log.info("Managed to load a deobfuscated Minecraft name- we are in a deobfuscated environment. Skipping runtime deobfuscation");
                 deobfuscatedEnvironment = true;
             }
         }
@@ -214,7 +214,7 @@ public class CoreModManager {
 
         if (!deobfuscatedEnvironment)
         {
-            FMLRelaunchLog.fine("Enabling runtime deobfuscation");
+            FMLLog.log.debug("Enabling runtime deobfuscation");
         }
 
         tweaker.injectCascadingTweak("net.minecraftforge.fml.common.launcher.FMLInjectionAndSortingTweaker");
@@ -224,7 +224,7 @@ public class CoreModManager {
         }
         catch (Exception e)
         {
-            FMLRelaunchLog.log(Level.ERROR, e, "The patch transformer failed to load! This is critical, loading cannot continue!");
+            FMLLog.log.error("The patch transformer failed to load! This is critical, loading cannot continue!", e);
             throw Throwables.propagate(e);
         }
 
@@ -239,7 +239,7 @@ public class CoreModManager {
             throw new RuntimeException("A fatal error has occurred - no valid fml load plugin was found - this is a completely corrupt FML installation.");
         }
 
-        FMLRelaunchLog.fine("All fundamental core mods are successfully located");
+        FMLLog.log.debug("All fundamental core mods are successfully located");
         // Now that we have the root plugins loaded - lets see what else might
         // be around
         String commandLineCoremods = System.getProperty("fml.coreMods.load", "");
@@ -249,7 +249,7 @@ public class CoreModManager {
             {
                 continue;
             }
-            FMLRelaunchLog.info("Found a command line coremod : %s", coreModClassName);
+            FMLLog.log.info("Found a command line coremod : {}", coreModClassName);
             loadCoreMod(classLoader, coreModClassName, null);
         }
         discoverCoreMods(mcDir, classLoader);
@@ -259,7 +259,7 @@ public class CoreModManager {
     private static void discoverCoreMods(File mcDir, LaunchClassLoader classLoader)
     {
         ModListHelper.parseModList(mcDir);
-        FMLRelaunchLog.fine("Discovering coremods");
+        FMLLog.log.debug("Discovering coremods");
         File coreMods = setupCoreModDir(mcDir);
         FilenameFilter ff = new FilenameFilter() {
             @Override
@@ -278,10 +278,10 @@ public class CoreModManager {
         File[] derplist = coreMods.listFiles(derpfilter);
         if (derplist != null && derplist.length > 0)
         {
-            FMLRelaunchLog.severe("FML has detected several badly downloaded jar files,  which have been named as zip files. You probably need to download them again, or they may not work properly");
+            FMLLog.log.fatal("FML has detected several badly downloaded jar files,  which have been named as zip files. You probably need to download them again, or they may not work properly");
             for (File f : derplist)
             {
-                FMLRelaunchLog.severe("Problem file : %s", f.getName());
+                FMLLog.log.fatal("Problem file : {}", f.getName());
             }
         }
         FileFilter derpdirfilter = new FileFilter() {
@@ -295,13 +295,13 @@ public class CoreModManager {
         File[] derpdirlist = coreMods.listFiles(derpdirfilter);
         if (derpdirlist != null && derpdirlist.length > 0)
         {
-            FMLRelaunchLog.log.getLogger().log(Level.FATAL, "There appear to be jars extracted into the mods directory. This is VERY BAD and will almost NEVER WORK WELL");
-            FMLRelaunchLog.log.getLogger().log(Level.FATAL, "You should place original jars only in the mods directory. NEVER extract them to the mods directory.");
-            FMLRelaunchLog.log.getLogger().log(Level.FATAL, "The directories below appear to be extracted jar files. Fix this before you continue.");
+            FMLLog.log.fatal("There appear to be jars extracted into the mods directory. This is VERY BAD and will almost NEVER WORK WELL");
+            FMLLog.log.fatal("You should place original jars only in the mods directory. NEVER extract them to the mods directory.");
+            FMLLog.log.fatal("The directories below appear to be extracted jar files. Fix this before you continue.");
 
             for (File f : derpdirlist)
             {
-                FMLRelaunchLog.log.getLogger().log(Level.FATAL, "Directory {} contains {}", f.getName(), Arrays.asList(new File(f,"META-INF").list()));
+                FMLLog.log.fatal("Directory {} contains {}", f.getName(), Arrays.asList(new File(f,"META-INF").list()));
             }
 
             RuntimeException re = new RuntimeException("Extracted mod jars found, loading will NOT continue");
@@ -334,7 +334,7 @@ public class CoreModManager {
 
         for (File coreMod : coreModList)
         {
-            FMLRelaunchLog.fine("Examining for coremod candidacy %s", coreMod.getName());
+            FMLLog.log.debug("Examining for coremod candidacy {}", coreMod.getName());
             JarFile jar = null;
             Attributes mfAttributes;
             String fmlCorePlugin;
@@ -351,7 +351,7 @@ public class CoreModManager {
                 String cascadedTweaker = mfAttributes.getValue("TweakClass");
                 if (cascadedTweaker != null)
                 {
-                    FMLRelaunchLog.info("Loading tweaker %s from %s", cascadedTweaker, coreMod.getName());
+                    FMLLog.log.info("Loading tweaker {} from {}", cascadedTweaker, coreMod.getName());
                     Integer sortOrder = Ints.tryParse(Strings.nullToEmpty(mfAttributes.getValue("TweakOrder")));
                     sortOrder = (sortOrder == null ? Integer.valueOf(0) : sortOrder);
                     handleCascadingTweak(coreMod, jar, cascadedTweaker, classLoader, sortOrder);
@@ -362,14 +362,14 @@ public class CoreModManager {
 
                 if (!modTypes.contains("FML"))
                 {
-                    FMLRelaunchLog.fine("Adding %s to the list of things to skip. It is not an FML mod,  it has types %s", coreMod.getName(), modTypes);
+                    FMLLog.log.debug("Adding {} to the list of things to skip. It is not an FML mod, it has types {}", coreMod.getName(), modTypes);
                     ignoredModFiles.add(coreMod.getName());
                     continue;
                 }
                 String modSide = mfAttributes.containsKey(MODSIDE) ? mfAttributes.getValue(MODSIDE) : "BOTH";
                 if (! ("BOTH".equals(modSide) || FMLLaunchHandler.side.name().equals(modSide)))
                 {
-                    FMLRelaunchLog.fine("Mod %s has ModSide meta-inf value %s, and we're %s. It will be ignored", coreMod.getName(), modSide, FMLLaunchHandler.side.name());
+                    FMLLog.log.debug("Mod {} has ModSide meta-inf value {}, and we're {} It will be ignored", coreMod.getName(), modSide, FMLLaunchHandler.side.name());
                     ignoredModFiles.add(coreMod.getName());
                     continue;
                 }
@@ -378,13 +378,13 @@ public class CoreModManager {
                 if (fmlCorePlugin == null)
                 {
                     // Not a coremod
-                    FMLRelaunchLog.fine("Not found coremod data in %s", coreMod.getName());
+                    FMLLog.log.debug("Not found coremod data in {}", coreMod.getName());
                     continue;
                 }
             }
             catch (IOException ioe)
             {
-                FMLRelaunchLog.log(Level.ERROR, ioe, "Unable to read the jar file %s - ignoring", coreMod.getName());
+                FMLLog.error(ioe, "Unable to read the jar file {} - ignoring", coreMod.getName());
                 continue;
             }
             finally
@@ -407,19 +407,19 @@ public class CoreModManager {
                 classLoader.addURL(coreMod.toURI().toURL());
                 if (!mfAttributes.containsKey(COREMODCONTAINSFMLMOD))
                 {
-                    FMLRelaunchLog.finer("Adding %s to the list of known coremods, it will not be examined again", coreMod.getName());
+                    FMLLog.log.trace("Adding {} to the list of known coremods, it will not be examined again", coreMod.getName());
                     ignoredModFiles.add(coreMod.getName());
                 }
                 else
                 {
-                    FMLRelaunchLog.finer("Found FMLCorePluginContainsFMLMod marker in %s, it will be examined later for regular @Mod instances",
+                    FMLLog.log.trace("Found FMLCorePluginContainsFMLMod marker in {}, it will be examined later for regular @Mod instances",
                             coreMod.getName());
                     candidateModFiles.add(coreMod.getName());
                 }
             }
             catch (MalformedURLException e)
             {
-                FMLRelaunchLog.log(Level.ERROR, e, "Unable to convert file into a URL. weird");
+                FMLLog.log.error("Unable to convert file into a URL. weird", e);
                 continue;
             }
             loadCoreMod(classLoader, fmlCorePlugin, coreMod);
@@ -438,31 +438,31 @@ public class CoreModManager {
             String depEndName = new File(dep).getName(); // extract last part of name
             if (skipContainedDeps.contains(dep) || skipContainedDeps.contains(depEndName))
             {
-                FMLRelaunchLog.log(Level.ERROR, "Skipping dep at request: %s", dep);
+                FMLLog.log.error("Skipping dep at request: {}", dep);
                 continue;
             }
             final JarEntry jarEntry = jar.getJarEntry(dep);
             if (jarEntry == null)
             {
-                FMLRelaunchLog.log(Level.ERROR, "Found invalid ContainsDeps declaration %s in %s", dep, jar.getName());
+                FMLLog.log.error("Found invalid ContainsDeps declaration {} in {}", dep, jar.getName());
                 continue;
             }
             File target = new File(versionedModsDir, depEndName);
             File modTarget = new File(baseModsDir, depEndName);
             if (target.exists())
             {
-                FMLRelaunchLog.log(Level.DEBUG, "Found existing ContainsDep extracted to %s, skipping extraction", target.getCanonicalPath());
+                FMLLog.log.debug("Found existing ContainsDep extracted to {}, skipping extraction", target.getCanonicalPath());
                 result.put(dep,target);
                 continue;
             }
             else if (modTarget.exists())
             {
-                FMLRelaunchLog.log(Level.DEBUG, "Found ContainsDep in main mods directory at %s, skipping extraction", modTarget.getCanonicalPath());
+                FMLLog.log.debug("Found ContainsDep in main mods directory at {}, skipping extraction", modTarget.getCanonicalPath());
                 result.put(dep, modTarget);
                 continue;
             }
 
-            FMLRelaunchLog.log(Level.DEBUG, "Extracting ContainedDep %s from %s to %s", dep, jar.getName(), target.getCanonicalPath());
+            FMLLog.log.debug("Extracting ContainedDep {} from {} to {}", dep, jar.getName(), target.getCanonicalPath());
             try
             {
                 Files.createParentDirs(target);
@@ -479,11 +479,11 @@ public class CoreModManager {
                     IOUtils.closeQuietly(targetOutputStream);
                     IOUtils.closeQuietly(jarInputStream);
                 }
-                FMLRelaunchLog.log(Level.DEBUG, "Extracted ContainedDep %s from %s to %s", dep, jar.getName(), target.getCanonicalPath());
+                FMLLog.log.debug("Extracted ContainedDep {} from {} to {}", dep, jar.getName(), target.getCanonicalPath());
                 result.put(dep,target);
             } catch (IOException e)
             {
-                FMLRelaunchLog.log(Level.ERROR, e, "An error occurred extracting dependency");
+                FMLLog.log.error("An error occurred extracting dependency", e);
             }
         }
         return result;
@@ -508,7 +508,7 @@ public class CoreModManager {
         }
         catch (Exception e)
         {
-            FMLRelaunchLog.log(Level.INFO, e, "There was a problem trying to load the mod dir tweaker %s", coreMod.getAbsolutePath());
+            FMLLog.info(e, "There was a problem trying to load the mod dir tweaker {}", coreMod.getAbsolutePath());
         }
     }
 
@@ -559,30 +559,30 @@ public class CoreModManager {
         String coreModName = coreModClass.substring(coreModClass.lastIndexOf('.') + 1);
         try
         {
-            FMLRelaunchLog.fine("Instantiating coremod class %s", coreModName);
+            FMLLog.log.debug("Instantiating coremod class {}", coreModName);
             classLoader.addTransformerExclusion(coreModClass);
             Class<?> coreModClazz = Class.forName(coreModClass, true, classLoader);
             Name coreModNameAnn = coreModClazz.getAnnotation(IFMLLoadingPlugin.Name.class);
             if (coreModNameAnn != null && !Strings.isNullOrEmpty(coreModNameAnn.value()))
             {
                 coreModName = coreModNameAnn.value();
-                FMLRelaunchLog.finer("coremod named %s is loading", coreModName);
+                FMLLog.log.trace("coremod named {} is loading", coreModName);
             }
             MCVersion requiredMCVersion = coreModClazz.getAnnotation(IFMLLoadingPlugin.MCVersion.class);
             if (!Arrays.asList(rootPlugins).contains(coreModClass) && (requiredMCVersion == null || Strings.isNullOrEmpty(requiredMCVersion.value())))
             {
-                FMLRelaunchLog.log(Level.WARN, "The coremod %s does not have a MCVersion annotation, it may cause issues with this version of Minecraft",
+                FMLLog.log.warn("The coremod {} does not have a MCVersion annotation, it may cause issues with this version of Minecraft",
                         coreModClass);
             }
             else if (requiredMCVersion != null && !FMLInjectionData.mccversion.equals(requiredMCVersion.value()))
             {
-                FMLRelaunchLog.log(Level.ERROR, "The coremod %s is requesting minecraft version %s and minecraft is %s. It will be ignored.", coreModClass,
+                FMLLog.log.error("The coremod {} is requesting minecraft version {} and minecraft is {}. It will be ignored.", coreModClass,
                         requiredMCVersion.value(), FMLInjectionData.mccversion);
                 return null;
             }
             else if (requiredMCVersion != null)
             {
-                FMLRelaunchLog.log(Level.DEBUG, "The coremod %s requested minecraft version %s and minecraft is %s. It will be loaded.", coreModClass,
+                FMLLog.log.debug("The coremod {} requested minecraft version {} and minecraft is {}. It will be loaded.", coreModClass,
                         requiredMCVersion.value(), FMLInjectionData.mccversion);
             }
             TransformerExclusions trExclusions = coreModClazz.getAnnotation(IFMLLoadingPlugin.TransformerExclusions.class);
@@ -606,32 +606,32 @@ public class CoreModManager {
             String accessTransformerClass = plugin.getAccessTransformerClass();
             if (accessTransformerClass != null)
             {
-                FMLRelaunchLog.log(Level.DEBUG, "Added access transformer class %s to enqueued access transformers", accessTransformerClass);
+                FMLLog.log.debug("Added access transformer class {} to enqueued access transformers", accessTransformerClass);
                 accessTransformers.add(accessTransformerClass);
             }
             FMLPluginWrapper wrap = new FMLPluginWrapper(coreModName, plugin, location, sortIndex, dependencies);
             loadPlugins.add(wrap);
-            FMLRelaunchLog.fine("Enqueued coremod %s", coreModName);
+            FMLLog.log.debug("Enqueued coremod {}", coreModName);
             return wrap;
         }
         catch (ClassNotFoundException cnfe)
         {
             if (!Lists.newArrayList(rootPlugins).contains(coreModClass))
-                FMLRelaunchLog.log(Level.ERROR, cnfe, "Coremod %s: Unable to class load the plugin %s", coreModName, coreModClass);
+                FMLLog.error(cnfe, "Coremod {}: Unable to class load the plugin {}", coreModName, coreModClass);
             else
-                FMLRelaunchLog.fine("Skipping root plugin %s", coreModClass);
+                FMLLog.log.debug("Skipping root plugin {}", coreModClass);
         }
         catch (ClassCastException cce)
         {
-            FMLRelaunchLog.log(Level.ERROR, cce, "Coremod %s: The plugin %s is not an implementor of IFMLLoadingPlugin", coreModName, coreModClass);
+            FMLLog.error(cce, "Coremod {}: The plugin {} is not an implementor of IFMLLoadingPlugin", coreModName, coreModClass);
         }
         catch (InstantiationException ie)
         {
-            FMLRelaunchLog.log(Level.ERROR, ie, "Coremod %s: The plugin class %s was not instantiable", coreModName, coreModClass);
+            FMLLog.error(ie, "Coremod {}: The plugin class {} was not instantiable", coreModName, coreModClass);
         }
         catch (IllegalAccessException iae)
         {
-            FMLRelaunchLog.log(Level.ERROR, iae, "Coremod %s: The plugin class %s was not accessible", coreModName, coreModClass);
+            FMLLog.error(iae, "Coremod {}: The plugin class {} was not accessible", coreModName, coreModClass);
         }
         return null;
     }

--- a/src/main/java/net/minecraftforge/fml/relauncher/FMLLaunchHandler.java
+++ b/src/main/java/net/minecraftforge/fml/relauncher/FMLLaunchHandler.java
@@ -90,7 +90,7 @@ public class FMLLaunchHandler
     {
         FMLInjectionData.build(minecraftHome, classLoader);
         FMLLog.log.info("Forge Mod Loader version {}.{}.{}.{} for Minecraft {} loading", FMLInjectionData.major, FMLInjectionData.minor,
-                FMLInjectionData.rev, FMLInjectionData.build, FMLInjectionData.mccversion, FMLInjectionData.mcpversion);
+                FMLInjectionData.rev, FMLInjectionData.build, FMLInjectionData.mccversion);
         FMLLog.log.info("Java is {}, version {}, running on {}:{}:{}, installed at {}", System.getProperty("java.vm.name"), System.getProperty("java.version"), System.getProperty("os.name"), System.getProperty("os.arch"), System.getProperty("os.version"), System.getProperty("java.home"));
         FMLLog.log.debug("Java classpath at launch is {}", System.getProperty("java.class.path"));
         FMLLog.log.debug("Java library path at launch is {}", System.getProperty("java.library.path"));

--- a/src/main/java/net/minecraftforge/fml/relauncher/FMLLaunchHandler.java
+++ b/src/main/java/net/minecraftforge/fml/relauncher/FMLLaunchHandler.java
@@ -101,7 +101,7 @@ public class FMLLaunchHandler
         }
         catch (Throwable t)
         {
-            FMLLog.error(t, "An error occurred trying to configure the minecraft home at {} for Forge Mod Loader", minecraftHome.getAbsolutePath());
+            FMLLog.log.error("An error occurred trying to configure the minecraft home at {} for Forge Mod Loader", minecraftHome.getAbsolutePath(), t);
             throw Throwables.propagate(t);
         }
     }

--- a/src/main/java/net/minecraftforge/fml/relauncher/FMLLaunchHandler.java
+++ b/src/main/java/net/minecraftforge/fml/relauncher/FMLLaunchHandler.java
@@ -24,6 +24,7 @@ import java.io.File;
 import org.apache.logging.log4j.Level;
 
 import net.minecraft.launchwrapper.LaunchClassLoader;
+import net.minecraftforge.fml.common.FMLLog;
 import net.minecraftforge.fml.common.launcher.FMLTweaker;
 
 import com.google.common.base.Throwables;
@@ -74,14 +75,12 @@ public class FMLLaunchHandler
 
     private void setupClient()
     {
-        FMLRelaunchLog.side = Side.CLIENT;
         side = Side.CLIENT;
         setupHome();
     }
 
     private void setupServer()
     {
-        FMLRelaunchLog.side = Side.SERVER;
         side = Side.SERVER;
         setupHome();
 
@@ -90,12 +89,11 @@ public class FMLLaunchHandler
     private void setupHome()
     {
         FMLInjectionData.build(minecraftHome, classLoader);
-        FMLRelaunchLog.minecraftHome = minecraftHome;
-        FMLRelaunchLog.info("Forge Mod Loader version %s.%s.%s.%s for Minecraft %s loading", FMLInjectionData.major, FMLInjectionData.minor,
+        FMLLog.log.info("Forge Mod Loader version {}.{}.{}.{} for Minecraft {} loading", FMLInjectionData.major, FMLInjectionData.minor,
                 FMLInjectionData.rev, FMLInjectionData.build, FMLInjectionData.mccversion, FMLInjectionData.mcpversion);
-        FMLRelaunchLog.info("Java is %s, version %s, running on %s:%s:%s, installed at %s", System.getProperty("java.vm.name"), System.getProperty("java.version"), System.getProperty("os.name"), System.getProperty("os.arch"), System.getProperty("os.version"), System.getProperty("java.home"));
-        FMLRelaunchLog.fine("Java classpath at launch is %s", System.getProperty("java.class.path"));
-        FMLRelaunchLog.fine("Java library path at launch is %s", System.getProperty("java.library.path"));
+        FMLLog.log.info("Java is {}, version {}, running on {}:{}:{}, installed at {}", System.getProperty("java.vm.name"), System.getProperty("java.version"), System.getProperty("os.name"), System.getProperty("os.arch"), System.getProperty("os.version"), System.getProperty("java.home"));
+        FMLLog.log.debug("Java classpath at launch is {}", System.getProperty("java.class.path"));
+        FMLLog.log.debug("Java library path at launch is {}", System.getProperty("java.library.path"));
 
         try
         {
@@ -103,8 +101,7 @@ public class FMLLaunchHandler
         }
         catch (Throwable t)
         {
-            t.printStackTrace();
-            FMLRelaunchLog.log(Level.ERROR, t, "An error occurred trying to configure the minecraft home at %s for Forge Mod Loader", minecraftHome.getAbsolutePath());
+            FMLLog.error(t, "An error occurred trying to configure the minecraft home at {} for Forge Mod Loader", minecraftHome.getAbsolutePath());
             throw Throwables.propagate(t);
         }
     }

--- a/src/main/java/net/minecraftforge/fml/relauncher/FMLRelaunchLog.java
+++ b/src/main/java/net/minecraftforge/fml/relauncher/FMLRelaunchLog.java
@@ -19,16 +19,17 @@
 
 package net.minecraftforge.fml.relauncher;
 
-import java.io.File;
-import java.util.Locale;
-
-import net.minecraftforge.fml.common.TracingPrintStream;
+import net.minecraftforge.fml.common.FMLLog;
+import net.minecraftforge.fml.common.event.FMLPreInitializationEvent;
 
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.apache.logging.log4j.ThreadContext;
 
+/**
+ * Legacy FML logging class. Mods use {@link FMLPreInitializationEvent#getModLog()} instead, for Forge internal use use FMLLog.
+ */
+@Deprecated
 public class FMLRelaunchLog {
 
     /**
@@ -37,31 +38,8 @@ public class FMLRelaunchLog {
      */
     public static final FMLRelaunchLog log = new FMLRelaunchLog();
 
-    static File minecraftHome;
-    private static boolean configured;
-
-    private Logger myLog;
-
-    static Side side;
-
     private FMLRelaunchLog()
     {
-    }
-
-    /**
-     * Configure the FML logger and inject tracing printstreams.
-     */
-    private static void configureLogging()
-    {
-        log.myLog = LogManager.getLogger("FML");
-        // Default side to client for test harness purposes
-        if (side == null) side = Side.CLIENT;
-        ThreadContext.put("side", side.name().toLowerCase(Locale.ENGLISH));
-        configured = true;
-        
-        FMLRelaunchLog.fine("Injecting tracing printstreams for STDOUT/STDERR.");
-        System.setOut(new TracingPrintStream(LogManager.getLogger("STDOUT"), System.out));
-        System.setErr(new TracingPrintStream(LogManager.getLogger("STDERR"), System.err));
     }
 
     public static void log(String targetLog, Level level, String format, Object... data)
@@ -71,11 +49,7 @@ public class FMLRelaunchLog {
 
     public static void log(Level level, String format, Object... data)
     {
-        if (!configured)
-        {
-            configureLogging();
-        }
-        log.myLog.log(level, String.format(format, data));
+        FMLLog.log.log(level, String.format(format, data));
     }
 
     public static void log(String targetLog, Level level, Throwable ex, String format, Object... data)
@@ -85,11 +59,7 @@ public class FMLRelaunchLog {
 
     public static void log(Level level, Throwable ex, String format, Object... data)
     {
-        if (!configured)
-        {
-            configureLogging();
-        }
-        log.myLog.log(level, String.format(format, data), ex);
+        FMLLog.log.log(level, String.format(format, data), ex);
     }
 
     public static void severe(String format, Object... data)
@@ -119,6 +89,6 @@ public class FMLRelaunchLog {
 
     public Logger getLogger()
     {
-        return myLog;
+        return FMLLog.log;
     }
 }

--- a/src/main/java/net/minecraftforge/fml/relauncher/ModListHelper.java
+++ b/src/main/java/net/minecraftforge/fml/relauncher/ModListHelper.java
@@ -25,6 +25,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import net.minecraft.launchwrapper.Launch;
+import net.minecraftforge.fml.common.FMLLog;
+
 import org.apache.logging.log4j.Level;
 import com.google.common.base.Charsets;
 import com.google.common.collect.Maps;
@@ -46,7 +48,7 @@ public class ModListHelper {
     public static final Map<String,File> additionalMods = Maps.newLinkedHashMap();
     static void parseModList(File minecraftDirectory)
     {
-        FMLRelaunchLog.fine("Attempting to load commandline specified mods, relative to %s", minecraftDirectory.getAbsolutePath());
+        FMLLog.log.debug("Attempting to load commandline specified mods, relative to {}", minecraftDirectory.getAbsolutePath());
         mcDirectory = minecraftDirectory;
         @SuppressWarnings("unchecked")
         Map<String,String> args = (Map<String, String>) Launch.blackboard.get("launchArgs");
@@ -88,24 +90,24 @@ public class ModListHelper {
                 f = new File(mcDirectory, listFile).getCanonicalFile();
         } catch (IOException e2)
         {
-            FMLRelaunchLog.log(Level.INFO, e2, "Unable to canonicalize path %s relative to %s", listFile, mcDirectory.getAbsolutePath());
+            FMLLog.log.info(FMLLog.log.getMessageFactory().newMessage("Unable to canonicalize path {} relative to {}", listFile, mcDirectory.getAbsolutePath()), e2);
             return;
         }
         if (!f.exists())
         {
-            FMLRelaunchLog.info("Failed to find modList file %s", f.getAbsolutePath());
+            FMLLog.log.info("Failed to find modList file {}", f.getAbsolutePath());
             return;
         }
         if (visitedFiles.contains(f))
         {
-            FMLRelaunchLog.severe("There appears to be a loop in the modListFile hierarchy. You shouldn't do this!");
+            FMLLog.log.fatal("There appears to be a loop in the modListFile hierarchy. You shouldn't do this!");
             throw new RuntimeException("Loop detected, impossible to load modlistfile");
         }
         String json;
         try {
             json = Files.asCharSource(f, Charsets.UTF_8).read();
         } catch (IOException e1) {
-            FMLRelaunchLog.log(Level.INFO, e1, "Failed to read modList json file %s.", listFile);
+            FMLLog.log.info(FMLLog.log.getMessageFactory().newMessage("Failed to read modList json file {}.", listFile), e1);
             return;
         }
         Gson gsonParser = new Gson();
@@ -113,7 +115,7 @@ public class ModListHelper {
         try {
             modList = gsonParser.fromJson(json, JsonModList.class);
         } catch (JsonSyntaxException e) {
-            FMLRelaunchLog.log(Level.INFO, e, "Failed to parse modList json file %s.", listFile);
+            FMLLog.log.info(FMLLog.log.getMessageFactory().newMessage("Failed to parse modList json file {}.", listFile), e);
             return;
         }
         visitedFiles.add(f);
@@ -125,7 +127,7 @@ public class ModListHelper {
         File repoRoot = new File(modList.repositoryRoot);
         if (!repoRoot.exists())
         {
-            FMLRelaunchLog.info("Failed to find the specified repository root %s", modList.repositoryRoot);
+            FMLLog.log.info("Failed to find the specified repository root {}", modList.repositoryRoot);
             return;
         }
 
@@ -154,11 +156,11 @@ public class ModListHelper {
         File modFile = repoRoot != null ? new File(repoRoot,modFileName) : new File(mcDirectory, modFileName);
         if (!modFile.exists())
         {
-            FMLRelaunchLog.info("Failed to find mod file %s (%s)", descriptor, modFile.getAbsolutePath());
+            FMLLog.log.info("Failed to find mod file {} ({})", descriptor, modFile.getAbsolutePath());
         }
         else
         {
-            FMLRelaunchLog.fine("Adding %s (%s) to the mod list", descriptor, modFile.getAbsolutePath());
+            FMLLog.log.debug("Adding {} ({}) to the mod list", descriptor, modFile.getAbsolutePath());
             additionalMods.put(descriptor, modFile);
         }
     }

--- a/src/main/java/net/minecraftforge/fml/server/FMLServerHandler.java
+++ b/src/main/java/net/minecraftforge/fml/server/FMLServerHandler.java
@@ -265,7 +265,7 @@ public class FMLServerHandler implements IFMLSidedHandler
         }
         catch (FileNotFoundException e)
         {
-            FMLLog.warn(e, "Missing English translation for {}: {}", container.getModId(), e.getMessage());
+            FMLLog.log.warn("Missing English translation for {}: {}", container.getModId(), e.getMessage(), e);
         }
         catch (IOException e)
         {

--- a/src/main/java/net/minecraftforge/fml/server/FMLServerHandler.java
+++ b/src/main/java/net/minecraftforge/fml/server/FMLServerHandler.java
@@ -167,7 +167,7 @@ public class FMLServerHandler implements IFMLSidedHandler
     {
         if (query.getResult() == null)
         {
-            FMLLog.warning("%s", query.getText());
+            FMLLog.log.warn(query.getText());
             query.finish();
         }
         else
@@ -175,7 +175,7 @@ public class FMLServerHandler implements IFMLSidedHandler
             String text = query.getText() +
                     "\n\nRun the command /fml confirm or or /fml cancel to proceed." +
                     "\nAlternatively start the server with -Dfml.queryResult=confirm or -Dfml.queryResult=cancel to preselect the answer.";
-            FMLLog.warning("%s", text);
+            FMLLog.log.warn(text);
 
             if (!query.isSynchronous()) return; // no-op until mc does commands in another thread (if ever)
 
@@ -196,14 +196,14 @@ public class FMLServerHandler implements IFMLSidedHandler
 
                         if (cmd.equals("/fml confirm"))
                         {
-                            FMLLog.info("confirmed");
+                            FMLLog.log.info("confirmed");
                             query.setResult(true);
                             done = true;
                             it.remove();
                         }
                         else if (cmd.equals("/fml cancel"))
                         {
-                            FMLLog.info("cancelled");
+                            FMLLog.log.info("cancelled");
                             query.setResult(false);
                             done = true;
                             it.remove();
@@ -265,7 +265,7 @@ public class FMLServerHandler implements IFMLSidedHandler
         }
         catch (FileNotFoundException e)
         {
-            FMLLog.getLogger().warn("Missing English translation for " + container.getModId() + ": " + e.getMessage());
+            FMLLog.warn(e, "Missing English translation for {}: {}", container.getModId(), e.getMessage());
         }
         catch (IOException e)
         {
@@ -273,7 +273,7 @@ public class FMLServerHandler implements IFMLSidedHandler
         }
         catch(Exception e)
         {
-            FMLLog.getLogger().error(e);
+            FMLLog.log.error(e);
         }
         finally
         {

--- a/src/main/java/net/minecraftforge/oredict/OreDictionary.java
+++ b/src/main/java/net/minecraftforge/oredict/OreDictionary.java
@@ -391,7 +391,7 @@ public class OreDictionary
         recipes.addAll(recipesToAdd);
         if (recipesToRemove.size() > 0)
         {
-            FMLLog.info("Replaced %d ore recipes", recipesToRemove.size());
+            FMLLog.log.info("Replaced {} ore recipes", recipesToRemove.size());
         }
     }
 
@@ -448,7 +448,7 @@ public class OreDictionary
         int id;
         if (registryName == null)
         {
-            FMLLog.log(Level.DEBUG, "Attempted to find the oreIDs for an unregistered object (%s). This won't work very well.", stack);
+            FMLLog.log.debug("Attempted to find the oreIDs for an unregistered object ({}). This won't work very well.", stack);
             return new int[0];
         }
         else
@@ -598,7 +598,7 @@ public class OreDictionary
         if ("Unknown".equals(name)) return; //prevent bad IDs.
         if (ore.isEmpty())
         {
-            FMLLog.bigWarning("Invalid registration attempt for an Ore Dictionary item with name %s has occurred. The registration has been denied to prevent crashes. The mod responsible for the registration needs to correct this.", name);
+            FMLLog.bigWarning("Invalid registration attempt for an Ore Dictionary item with name {} has occurred. The registration has been denied to prevent crashes. The mod responsible for the registration needs to correct this.", name);
             return; //prevent bad ItemStacks.
         }
 
@@ -612,7 +612,7 @@ public class OreDictionary
         {
             ModContainer modContainer = Loader.instance().activeModContainer();
             String modContainerName = modContainer == null ? null : modContainer.getName();
-            FMLLog.bigWarning("A broken ore dictionary registration with name %s has occurred. It adds an item (type: %s) which is currently unknown to the game registry. This dictionary item can only support a single value when"
+            FMLLog.bigWarning("A broken ore dictionary registration with name {} has occurred. It adds an item (type: {}) which is currently unknown to the game registry. This dictionary item can only support a single value when"
                     + " registered with ores like this, and NO I am not going to turn this spam off. Just register your ore dictionary entries after the GameRegistry.\n"
                     + "TO USERS: YES this is a BUG in the mod " + modContainerName + " report it to them!", name, ore.getItem().getClass());
             hash = -1;
@@ -680,7 +680,7 @@ public class OreDictionary
                 int hash;
                 if (name == null)
                 {
-                    FMLLog.log(Level.DEBUG, "Defaulting unregistered ore dictionary entry for ore dictionary %s: type %s to -1", getOreName(id), ore.getItem().getClass());
+                    FMLLog.log.debug("Defaulting unregistered ore dictionary entry for ore dictionary {}: type {} to -1", getOreName(id), ore.getItem().getClass());
                     hash = -1;
                 }
                 else

--- a/src/main/java/net/minecraftforge/oredict/RecipeSorter.java
+++ b/src/main/java/net/minecraftforge/oredict/RecipeSorter.java
@@ -181,7 +181,7 @@ public class RecipeSorter implements Comparator<IRecipe>
     public static void sortCraftManager()
     {
         bake();
-        FMLLog.fine("Sorting recipes");
+        FMLLog.log.debug("Sorting recipes");
         warned.clear();
         Collections.sort(CraftingManager.getInstance().getRecipeList(), INSTANCE);
     }
@@ -238,7 +238,7 @@ public class RecipeSorter implements Comparator<IRecipe>
         {
             if (!warned.contains(cls))
             {
-                FMLLog.bigWarning("Unknown recipe class! %s Modders need to register their recipe types with %s", cls.getName(), RecipeSorter.class.getName());
+                FMLLog.bigWarning("Unknown recipe class! {} Modders need to register their recipe types with {}", cls.getName(), RecipeSorter.class.getName());
                 warned.add(cls);
             }
             cls = cls.getSuperclass();
@@ -248,7 +248,7 @@ public class RecipeSorter implements Comparator<IRecipe>
                 if (ret != null)
                 {
                     priorities.put(recipe.getClass(), ret);
-                    FMLLog.fine("    Parent Found: %d - %s", ret, cls.getName());
+                    FMLLog.log.debug("    Parent Found: {} - {}", ret, cls.getName());
                     return ret;
                 }
             }
@@ -260,7 +260,7 @@ public class RecipeSorter implements Comparator<IRecipe>
     private static void bake()
     {
         if (!isDirty) return;
-        FMLLog.fine("Forge RecipeSorter Baking:");
+        FMLLog.log.debug("Forge RecipeSorter Baking:");
         DirectedGraph<SortEntry> sorter = new DirectedGraph<SortEntry>();
         sorter.addNode(before);
         sorter.addNode(after);
@@ -306,7 +306,7 @@ public class RecipeSorter implements Comparator<IRecipe>
         int x = sorted.size();
         for (SortEntry entry : sorted)
         {
-            FMLLog.fine("  %d: %s", x, entry);
+            FMLLog.log.debug("  {}: {}", x, entry);
             priorities.put(entry.cls, x--);
         }
     }

--- a/src/main/java/net/minecraftforge/server/permission/PermissionAPI.java
+++ b/src/main/java/net/minecraftforge/server/permission/PermissionAPI.java
@@ -42,7 +42,7 @@ public class PermissionAPI
     {
         Preconditions.checkNotNull(handler, "Permission handler can't be null!");
         Preconditions.checkState(Loader.instance().getLoaderState().ordinal() <= LoaderState.PREINITIALIZATION.ordinal(), "Can't register after IPermissionHandler PreInit!");
-        FMLLog.log.warn("Replacing " + permissionHandler.getClass().getName() + " with " + handler.getClass().getName());
+        FMLLog.log.warn("Replacing {} with {}", permissionHandler.getClass().getName(), handler.getClass().getName());
         permissionHandler = handler;
     }
 

--- a/src/main/java/net/minecraftforge/server/permission/PermissionAPI.java
+++ b/src/main/java/net/minecraftforge/server/permission/PermissionAPI.java
@@ -42,7 +42,7 @@ public class PermissionAPI
     {
         Preconditions.checkNotNull(handler, "Permission handler can't be null!");
         Preconditions.checkState(Loader.instance().getLoaderState().ordinal() <= LoaderState.PREINITIALIZATION.ordinal(), "Can't register after IPermissionHandler PreInit!");
-        FMLLog.log(Level.WARN, "Replacing " + permissionHandler.getClass().getName() + " with " + handler.getClass().getName());
+        FMLLog.log.warn("Replacing " + permissionHandler.getClass().getName() + " with " + handler.getClass().getName());
         permissionHandler = handler;
     }
 

--- a/src/test/java/net/minecraftforge/debug/ConfigTest.java
+++ b/src/test/java/net/minecraftforge/debug/ConfigTest.java
@@ -36,11 +36,11 @@ public class ConfigTest
     @Mod.EventHandler
     public void init(FMLInitializationEvent event)
     {
-        logger.debug("Old: " + CONFIG_TYPES.bool);
+        logger.debug("Old: {}", CONFIG_TYPES.bool);
         CONFIG_TYPES.bool = !CONFIG_TYPES.bool;
-        logger.debug("New: " + CONFIG_TYPES.bool);
+        logger.debug("New: {}", CONFIG_TYPES.bool);
         ConfigManager.sync(MODID, Type.INSTANCE);
-        logger.debug("After sync: " + CONFIG_TYPES.bool);
+        logger.debug("After sync: {}", CONFIG_TYPES.bool);
     }
 
     @SubscribeEvent

--- a/src/test/java/net/minecraftforge/debug/DifficultyChangeEventTest.java
+++ b/src/test/java/net/minecraftforge/debug/DifficultyChangeEventTest.java
@@ -27,6 +27,6 @@ public class DifficultyChangeEventTest
     @SubscribeEvent
     public void onDifficultyChange(DifficultyChangeEvent event)
     {
-        logger.info("Difficulty changed from " + event.getOldDifficulty() + " to " + event.getDifficulty());
+        logger.info("Difficulty changed from {} to {}", event.getOldDifficulty(), event.getDifficulty());
     }
 }

--- a/src/test/java/net/minecraftforge/debug/DynBucketTest.java
+++ b/src/test/java/net/minecraftforge/debug/DynBucketTest.java
@@ -208,17 +208,17 @@ public class DynBucketTest
 
             for (int i = 0; i < handler.getSlots(); i++)
             {
-                logger.info("Expected 1: " + handler.getStackInSlot(i));
+                logger.info("Expected 1: {}", handler.getStackInSlot(i));
             }
 
             for (int i = 0; i < handler2.getSlots(); i++)
             {
-                logger.info("Expected 2: " + handler2.getStackInSlot(i));
+                logger.info("Expected 2: {}", handler2.getStackInSlot(i));
             }
 
             for (int i = 0; i < joined.getSlots(); i++)
             {
-                logger.info("Joined: " + joined.getStackInSlot(i));
+                logger.info("Joined: {}", joined.getStackInSlot(i));
             }
 
             return new ActionResult<ItemStack>(EnumActionResult.SUCCESS, itemStackIn);

--- a/src/test/java/net/minecraftforge/debug/EnchantmentLevelSetTest.java
+++ b/src/test/java/net/minecraftforge/debug/EnchantmentLevelSetTest.java
@@ -28,7 +28,7 @@ public class EnchantmentLevelSetTest
     public static void onEnchantmentLevelSet(EnchantmentLevelSetEvent event)
     {
         // invert enchantment level, just for fun
-        logger.info("Enchantment row: " + event.getEnchantRow() + ", level: " + event.getLevel());
+        logger.info("Enchantment row: {}, level: {}", event.getEnchantRow(), event.getLevel());
         event.setLevel(30 - event.getLevel());
     }
 }

--- a/src/test/java/net/minecraftforge/debug/EntityTravelToDimensionEventTest.java
+++ b/src/test/java/net/minecraftforge/debug/EntityTravelToDimensionEventTest.java
@@ -29,7 +29,7 @@ public class EntityTravelToDimensionEventTest
     {
         if (ENABLE)
         {
-            logger.info("Travelling to Dimension " + event.getDimension() + " Entity: " + event.getEntity());
+            logger.info("Travelling to Dimension {} Entity: {}", event.getDimension(), event.getEntity());
             event.setCanceled(true);
         }
     }

--- a/src/test/java/net/minecraftforge/debug/EquipmentChangeTest.java
+++ b/src/test/java/net/minecraftforge/debug/EquipmentChangeTest.java
@@ -50,8 +50,7 @@ public class EquipmentChangeTest
     public void onEquipmentChange(LivingEquipmentChangeEvent event)
     {
         //a debug console print
-        logger.info("[Equipment-Change] " + event.getEntity() + " changed his Equipment in "
-                + event.getSlot() + " from " + event.getFrom() + " to " + event.getTo());
+        logger.info("[Equipment-Change] {} changed their Equipment in {} from {} to {}", event.getEntity(), event.getSlot(), event.getFrom(), event.getTo());
     }
 
 }

--- a/src/test/java/net/minecraftforge/debug/FluidHandlerTest.java
+++ b/src/test/java/net/minecraftforge/debug/FluidHandlerTest.java
@@ -58,7 +58,7 @@ public class FluidHandlerTest
         {
             FluidStack drain = fluidHandler.drain(Integer.MAX_VALUE, true);
             ItemStack drainedStack = fluidHandler.getContainer();
-            logger.info("Draining " + stackString(stack) + " gives " + fluidString(drain) + " and " + stackString(drainedStack));
+            logger.info("Draining {} gives {} and {}", stackString(stack), fluidString(drain), stackString(drainedStack));
 
             if (drain == null && !ItemStack.areItemStacksEqual(originalStack, preDrainStack))
             {
@@ -76,7 +76,7 @@ public class FluidHandlerTest
 
                     if (filled > 0)
                     {
-                        logger.info("Filling " + stackString(stack) + " with " + fluidString(new FluidStack(fluid, filled)) + " gives " + stackString(filledStack));
+                        logger.info("Filling {} with {} gives {}", stackString(stack), fluidString(new FluidStack(fluid, filled)), stackString(filledStack));
                     }
                     else
                     {

--- a/src/test/java/net/minecraftforge/debug/ItemFishedTest.java
+++ b/src/test/java/net/minecraftforge/debug/ItemFishedTest.java
@@ -35,7 +35,7 @@ public class ItemFishedTest
         EntityFishHook hook = event.getHookEntity();
         BlockPos bobberPos = hook.getPosition();
         Biome biomeFishedAt = hook.getEntityWorld().getBiome(bobberPos);
-        logger.info("Item fished in Biome " + biomeFishedAt.getBiomeName());
+        logger.info("Item fished in Biome {}", biomeFishedAt.getBiomeName());
         if (biomeFishedAt.equals(Biomes.OCEAN))
         {
             logger.info("Canceling the event because biome is ocean");

--- a/src/test/java/net/minecraftforge/debug/ModelAnimationDebug.java
+++ b/src/test/java/net/minecraftforge/debug/ModelAnimationDebug.java
@@ -306,7 +306,7 @@ public class ModelAnimationDebug
         {
             for (Event event : pastEvents)
             {
-                logger.info("Event: " + event.event() + " " + event.offset() + " " + getPos() + " " + time);
+                logger.info("Event: {} {} {} {}", event.event(), event.offset(), getPos(), time);
             }
         }
 

--- a/src/test/java/net/minecraftforge/debug/ModelLoaderRegistryDebug.java
+++ b/src/test/java/net/minecraftforge/debug/ModelLoaderRegistryDebug.java
@@ -188,7 +188,7 @@ public class ModelLoaderRegistryDebug
         {
             if (world.isRemote)
             {
-                logger.info("click " + counter);
+                logger.info("click {}", counter);
                 if (player.isSneaking())
                 {
                     counter--;

--- a/src/test/java/net/minecraftforge/debug/ModelLoaderRegistryDebug.java
+++ b/src/test/java/net/minecraftforge/debug/ModelLoaderRegistryDebug.java
@@ -574,7 +574,7 @@ public class ModelLoaderRegistryDebug
         {
             if (this.world.isRemote)
             {
-                logger.info("%b", shouldIncrement);
+                logger.info(shouldIncrement);
                 /*
                 IBakedModel bakedModel = Minecraft.getMinecraft().getBlockRendererDispatcher().getModelFromBlockState(this.world.getBlockState(this.pos), this.world, this.pos);
                 if (bakedModel != null && bakedModel instanceof OBJBakedModel)

--- a/src/test/java/net/minecraftforge/debug/NeighborNotifyEventTest.java
+++ b/src/test/java/net/minecraftforge/debug/NeighborNotifyEventTest.java
@@ -28,7 +28,7 @@ public class NeighborNotifyEventTest
     @SubscribeEvent
     public void onNeighborNotify(NeighborNotifyEvent event)
     {
-        logger.info(event.getPos().toString() + " with face information: " + event.getNotifiedSides());
+        logger.info("{} with face information: {}", event.getPos().toString(), event.getNotifiedSides());
         event.setCanceled(true);
     }
 }

--- a/src/test/java/net/minecraftforge/debug/PlayerSetSpawnTest.java
+++ b/src/test/java/net/minecraftforge/debug/PlayerSetSpawnTest.java
@@ -27,7 +27,7 @@ public class PlayerSetSpawnTest
     @SubscribeEvent
     public void onPlayerSetSpawn(PlayerSetSpawnEvent event)
     {
-        logger.info(event.isForced() + " " + event.getNewSpawn().toString());
+        logger.info("{} {}", event.isForced(), event.getNewSpawn().toString());
         event.setCanceled(true);
     }
 }

--- a/src/test/java/net/minecraftforge/debug/TestCapabilityMod.java
+++ b/src/test/java/net/minecraftforge/debug/TestCapabilityMod.java
@@ -70,7 +70,7 @@ public class TestCapabilityMod
         {
             event.setCanceled(true);
             IExampleCapability inv = te.getCapability(TEST_CAP, event.getFace());
-            logger.info("Hi I'm a " + inv.getOwnerType());
+            logger.info("Hi I'm a {}", inv.getOwnerType());
         }
         if (event.getWorld().getBlockState(event.getPos()).getBlock() == Blocks.DIRT && event.getItemStack().hasCapability(TEST_CAP, null))
         {
@@ -92,7 +92,7 @@ public class TestCapabilityMod
         {
             IExampleCapability cap = event.getItemStack().getCapability(TEST_CAP, null);
             cap.toggleVal();
-            logger.info("Test value is now: " + (cap.getVal() ? "TRUE" : "FALSE"));
+            logger.info("Test value is now: {}", cap.getVal() ? "TRUE" : "FALSE");
         }
     }
 

--- a/src/test/java/net/minecraftforge/debug/TextureDump.java
+++ b/src/test/java/net/minecraftforge/debug/TextureDump.java
@@ -71,7 +71,7 @@ public class TextureDump
             try
             {
                 ImageIO.write(bufferedimage, "png", output);
-                logger.info("Exported png to: %s", output.getAbsolutePath());
+                logger.info("Exported png to: {}", output.getAbsolutePath());
             }
             catch (IOException ioexception)
             {

--- a/src/test/java/net/minecraftforge/debug/TileEntityLoadingTest.java
+++ b/src/test/java/net/minecraftforge/debug/TileEntityLoadingTest.java
@@ -67,7 +67,7 @@ public class TileEntityLoadingTest
         @Override
         public void onLoad()
         {
-            logger.info("World: " + world + ", Pos: " + pos + ", State: " + world.getBlockState(pos));
+            logger.info("World: {}, Pos: {}, State: {}", world, pos, world.getBlockState(pos));
             if (DEBUG)
             {
                 logger.trace("Stack trace:", new Exception());


### PR DESCRIPTION
Like discussed on IRC.

- FMLRelaunchLog is deprecated all FML logging goes through FMLLog now.
- The methods in FMLLog are deprecated, as they do not offer any additional value on top of log4j.
- All logging uses the log4j logger (`FMLLog.log`) directly.
- All reliance on `String.format` has been removed and replaced with log4j's default formatting using `"{}"` as the placeholder.

This fixes https://github.com/MinecraftForge/MinecraftForge/issues/3713 (and maybe others).