### PR TITLE
Add an event for changing block hardness when mining a block.

### DIFF
--- a/src/main/java/net/minecraftforge/common/ForgeHooks.java
+++ b/src/main/java/net/minecraftforge/common/ForgeHooks.java
@@ -199,6 +199,7 @@ public class ForgeHooks
     public static float blockStrength(@Nonnull IBlockState state, @Nonnull EntityPlayer player, @Nonnull World world, @Nonnull BlockPos pos)
     {
         float hardness = state.getBlockHardness(world, pos);
+        hardness = ForgeEventFactory.getBlockHardness(player, state, hardness, pos);
         if (hardness < 0.0F)
         {
             return 0.0F;

--- a/src/main/java/net/minecraftforge/event/ForgeEventFactory.java
+++ b/src/main/java/net/minecraftforge/event/ForgeEventFactory.java
@@ -179,6 +179,13 @@ public class ForgeEventFactory
         PlayerEvent.BreakSpeed event = new PlayerEvent.BreakSpeed(player, state, original, pos);
         return (MinecraftForge.EVENT_BUS.post(event) ? -1 : event.getNewSpeed());
     }
+    
+    public static float getBlockHardness(EntityPlayer player, IBlockState state, float original, BlockPos pos) 
+    {
+        PlayerEvent.BlockHardness event = new PlayerEvent.BlockHardness(player, state, original, pos);
+        MinecraftForge.EVENT_BUS.post(event);
+        return event.getNewHardness();
+    }
 
     public static void onPlayerDestroyItem(EntityPlayer player, @Nonnull ItemStack stack, @Nullable EnumHand hand)
     {

--- a/src/main/java/net/minecraftforge/event/entity/player/PlayerEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/player/PlayerEvent.java
@@ -128,7 +128,56 @@ public class PlayerEvent extends LivingEvent
         public void setNewSpeed(float newSpeed) { this.newSpeed = newSpeed; }
         public BlockPos getPos() { return pos; }
     }
-
+    
+    /**
+     * This event is fired when a player attempts to harvest a block. Specifically through 
+     * {@link ForgeEventFactory#getBlockHardness(EntityPlayer, IBlockState, float, BlockPos)}. 
+     * It allows for the hardness of the block when being mined by a player to be modified.
+     * 
+     * This event does not have a result and can not be cancelled. 
+     */
+    public static class BlockHardness extends PlayerEvent
+    {
+        private final IBlockState state;
+        private final float originalHardness;
+        private final BlockPos pos;
+        private float newHardness = 0.0f;
+        
+        public BlockHardness (EntityPlayer player, IBlockState state, float original, BlockPos pos)
+        {
+            super(player);
+            this.state = state;
+            this.originalHardness = original;
+            this.setNewHardness(original);
+            this.pos = pos;
+        }
+        
+        public IBlockState getStats() 
+        {
+            return this.state;
+        }
+        
+        public float getOriginalHardness()
+        {
+            return this.originalHardness;
+        }
+        
+        public BlockPos getPos()
+        {
+            return this.pos;
+        }
+        
+        public float getNewHardness()
+        {
+            return this.newHardness;
+        }
+        
+        public void setNewHardness(float hardness)
+        {
+            this.newHardness = hardness;
+        }
+    }
+    
     /**
      * NameFormat is fired when a player's display name is retrieved.<br>
      * This event is fired whenever a player's name is retrieved in

--- a/src/test/java/net/minecraftforge/debug/BlockHardnessTest.java
+++ b/src/test/java/net/minecraftforge/debug/BlockHardnessTest.java
@@ -1,0 +1,29 @@
+package net.minecraftforge.debug;
+
+import net.minecraft.init.Blocks;
+import net.minecraftforge.common.MinecraftForge;
+import net.minecraftforge.event.entity.player.PlayerEvent;
+import net.minecraftforge.fml.common.Mod;
+import net.minecraftforge.fml.common.event.FMLPreInitializationEvent;
+import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
+
+@Mod(modid = "blockhardnesstest", name = "Block Hardness Event Test", version = "1.0", acceptableRemoteVersions = "*")
+public class BlockHardnessTest
+{
+    static final boolean ENABLED = true;
+
+    @Mod.EventHandler
+    public void onPreIn(FMLPreInitializationEvent event) 
+    {      
+        MinecraftForge.EVENT_BUS.register(this);
+    }
+    
+    @SubscribeEvent
+    public void onBlockBreakHardness(PlayerEvent.BlockHardness event)
+    {
+        if (ENABLED && event.getStats().getBlock() == Blocks.OBSIDIAN)
+        {
+            event.setNewHardness(Blocks.STONE.getDefaultState().getBlockHardness(event.getEntityPlayer().world, event.getPos()));
+        }
+    }
+}

--- a/src/test/java/net/minecraftforge/debug/BlockHardnessTest.java
+++ b/src/test/java/net/minecraftforge/debug/BlockHardnessTest.java
@@ -10,7 +10,7 @@ import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
 @Mod(modid = "blockhardnesstest", name = "Block Hardness Event Test", version = "1.0", acceptableRemoteVersions = "*")
 public class BlockHardnessTest
 {
-    static final boolean ENABLED = true;
+    static final boolean ENABLED = false;
 
     @Mod.EventHandler
     public void onPreIn(FMLPreInitializationEvent event) 


### PR DESCRIPTION
This PR adds a new PlayerEvent called BlockHardness. The goal of this new event is to allow modders to have better control over the mining speed when breaking blocks. Forge already has a hook for changing the break speed, and the result of this hook has three factors. The first is the block hardness, which was not modifiable through event before this PR, the second is the player dig speed which is controlled using the DigSpeed event, and the last part is a modifier based on if the player can harvest the block or not. To get a better understanding of this, please look at ForgeHooks.blockStrength. 

There are a few different use cases for this, such as allowing enchantments or potions to hook in to the hardness. I personally want this so I can make vanilla blocks perfectly mimic the break time of other blocks based on the player mining them. 

This PR also adds a test mod, which sets hardness of obsidian to be the same as stone. It's disabled by default. 