### PR TITLE
Made setComment return Property instance

### DIFF
--- a/src/main/java/net/minecraftforge/common/config/Property.java
+++ b/src/main/java/net/minecraftforge/common/config/Property.java
@@ -43,9 +43,10 @@ public class Property
         return comment;
     }
 
-    public void setComment(String comment)
+    public Property setComment(String comment)
     {
         this.comment = comment;
+        return this;
     }
 
     public enum Type


### PR DESCRIPTION
This allows more fluent interaction with properties. Example:

```java
prop.setDefaultValue(25)
        .setRequiresWorldRestart(true)
        .setMinValue(0)
        .setComment("Some comment")
        .getInt();
```

At the moment, `setComment` returns void, making this not work without doing a separate `prop.setComment()` call.