### PR TITLE
Make IRecipe optionally force to be unlocked before use

### DIFF
--- a/patches/minecraft/net/minecraft/inventory/Container.java.patch
+++ b/patches/minecraft/net/minecraft/inventory/Container.java.patch
@@ -33,3 +33,11 @@
          }
  
          p_94525_2_.func_190917_f(p_94525_3_);
+@@ -803,6 +804,7 @@
+             ItemStack itemstack = ItemStack.field_190927_a;
+             IRecipe irecipe = CraftingManager.func_192413_b(p_192389_3_, p_192389_1_);
+ 
++            if(irecipe != null && (!irecipe.hasForcedLock() || entityplayermp.func_192037_E().func_193830_f(irecipe)))
+             if (irecipe != null && (irecipe.func_192399_d() || !p_192389_1_.func_82736_K().func_82766_b("doLimitedCrafting") || entityplayermp.func_192037_E().func_193830_f(irecipe)))
+             {
+                 p_192389_4_.func_193056_a(irecipe);

--- a/patches/minecraft/net/minecraft/item/crafting/IRecipe.java.patch
+++ b/patches/minecraft/net/minecraft/item/crafting/IRecipe.java.patch
@@ -1,6 +1,6 @@
 --- ../src-base/minecraft/net/minecraft/item/crafting/IRecipe.java
 +++ ../src-work/minecraft/net/minecraft/item/crafting/IRecipe.java
-@@ -4,35 +4,30 @@
+@@ -4,36 +4,32 @@
  import net.minecraft.item.ItemStack;
  import net.minecraft.util.NonNullList;
  import net.minecraft.world.World;
@@ -40,3 +40,5 @@
      {
          return "";
      }
++    default boolean hasForcedLock() { return false; } // If true the Recipe is forced to be unlocked in the Players RecipeBook
+ }

--- a/patches/minecraft/net/minecraft/item/crafting/IRecipe.java.patch
+++ b/patches/minecraft/net/minecraft/item/crafting/IRecipe.java.patch
@@ -1,6 +1,6 @@
 --- ../src-base/minecraft/net/minecraft/item/crafting/IRecipe.java
 +++ ../src-work/minecraft/net/minecraft/item/crafting/IRecipe.java
-@@ -4,36 +4,32 @@
+@@ -4,36 +4,33 @@
  import net.minecraft.item.ItemStack;
  import net.minecraft.util.NonNullList;
  import net.minecraft.world.World;
@@ -40,5 +40,6 @@
      {
          return "";
      }
-+    default boolean hasForcedLock() { return false; } // If true the Recipe is forced to be unlocked in the Players RecipeBook
++    /** If true this Recipe has to be unlocked in the Players RecipeBook to be usable (acts as if the "doLimitedCrafting" GameRule was set to true) */
++    default boolean hasForcedLock() { return false; }
  }


### PR DESCRIPTION
This allows custom recipes to act as if the corresponding gamerule was turned on

Example: Add a recipe that allows dirt>diamond after unlocking a certain advancement for it not to be usable from the beginning one would have to force the gamerule
Could also be usefull for mods like thaumcraft where you have to research things before crafting them