### PR TITLE
[1.12] Account for the space character used as an empty slot in crafting

### DIFF
--- a/src/main/java/net/minecraftforge/common/crafting/CraftingHelper.java
+++ b/src/main/java/net/minecraftforge/common/crafting/CraftingHelper.java
@@ -308,6 +308,7 @@ public class CraftingHelper {
         }
 
         HashMap<Character, Ingredient> itemMap = Maps.newHashMap();
+        itemMap.put(' ', Ingredient.field_193370_a);
 
         for (; idx < recipe.length; idx += 2)
         {


### PR DESCRIPTION
`CraftingHelper.parseShaped` currently does not account for the space character that is normally used to indicate an empty slot in a crafting recipe, [complaining that a symbol was missing.](https://github.com/Landmaster/MinecraftForge/blob/c3ddff58b27175c04e4e1828d878feffaa24f542/src/main/java/net/minecraftforge/common/crafting/CraftingHelper.java#L344) This pull request solves this issue by adding the space character key and empty ingredient value to `itemMap`. In addition, due to the [`keys.remove(' ');`](https://github.com/Landmaster/MinecraftForge/blob/c3ddff58b27175c04e4e1828d878feffaa24f542/src/main/java/net/minecraftforge/common/crafting/CraftingHelper.java#L337) statement that was already present, even if there are no spaces used in the recipe, [the extra characters error later in the method does not result.](https://github.com/Landmaster/MinecraftForge/blob/c3ddff58b27175c04e4e1828d878feffaa24f542/src/main/java/net/minecraftforge/common/crafting/CraftingHelper.java#L350)

`ShapedOreRecipe` [uses this technique](https://github.com/Landmaster/MinecraftForge/blob/1.12.x/src/main/java/net/minecraftforge/oredict/ShapedOreRecipe.java#L194), but it did not carry over to Forge's `CraftingHelper` for some reason, which this PR seeks to rectify.