### PR TITLE
Fix exception in ShapedOreRecipe.checkMatch for non-3x3 recipes

### DIFF
--- a/src/main/java/net/minecraftforge/oredict/ShapedOreRecipe.java
+++ b/src/main/java/net/minecraftforge/oredict/ShapedOreRecipe.java
@@ -127,7 +127,7 @@ public class ShapedOreRecipe extends IForgeRegistryEntry.Impl<IRecipe> implement
                     }
                 }
 
-                if (!target.apply(inv.getStackInRowAndColumn(x, y)))
+                if (target != null && !target.apply(inv.getStackInRowAndColumn(x, y)))
                 {
                     return false;
                 }

--- a/src/main/java/net/minecraftforge/oredict/ShapedOreRecipe.java
+++ b/src/main/java/net/minecraftforge/oredict/ShapedOreRecipe.java
@@ -125,11 +125,11 @@ public class ShapedOreRecipe extends IForgeRegistryEntry.Impl<IRecipe> implement
                     {
                         target = input.get(subX + subY * width);
                     }
-                }
-
-                if (target != null && !target.apply(inv.getStackInRowAndColumn(x, y)))
-                {
-                    return false;
+                    
+                    if (!target.apply(inv.getStackInRowAndColumn(x, y)))
+                    {
+                        return false;
+                    }
                 }
             }
         }


### PR DESCRIPTION
In 1.11 and below, target was only ever used in `instanceof` checks, so a null value would just fall through and never be checked. Due to ingredients being added, an explicit null check is now required.