### PR TITLE
Make registries persist by default, fixes #3989

### DIFF
--- a/src/main/java/net/minecraftforge/fml/common/registry/RegistryBuilder.java
+++ b/src/main/java/net/minecraftforge/fml/common/registry/RegistryBuilder.java
@@ -42,7 +42,7 @@ public class RegistryBuilder<T extends IForgeRegistryEntry<T>>
     private List<ClearCallback<T>> clearCallback = Lists.newArrayList();
     private List<CreateCallback<T>> createCallback = Lists.newArrayList();
     private List<SubstitutionCallback<T>> substitutionCallback = Lists.newArrayList();
-    private boolean saveToDisc;
+    private boolean saveToDisc = true;
 
     public RegistryBuilder<T> setName(ResourceLocation name)
     {


### PR DESCRIPTION
When I saw a lot of people encountering #3989, I started investigating the problem, first by looking at the changes introduced with the recipe stuff. Turns out that Lex made persistence of registries optional and forgot restoring the original behaviour (i.e. persisting by default).