### PR TITLE
Enable support for modded Fishing Rods.

### DIFF
--- a/patches/minecraft/net/minecraft/client/renderer/entity/RenderFish.java.patch
+++ b/patches/minecraft/net/minecraft/client/renderer/entity/RenderFish.java.patch
@@ -1,0 +1,11 @@
+--- ../src-base/minecraft/net/minecraft/client/renderer/entity/RenderFish.java
++++ ../src-work/minecraft/net/minecraft/client/renderer/entity/RenderFish.java
+@@ -75,7 +75,7 @@
+             int k = entityplayer.func_184591_cq() == EnumHandSide.RIGHT ? 1 : -1;
+             ItemStack itemstack = entityplayer.func_184614_ca();
+ 
+-            if (itemstack.func_77973_b() != Items.field_151112_aM)
++            if (!(itemstack.func_77973_b() instanceof net.minecraft.item.ItemFishingRod))
+             {
+                 k = -k;
+             }

--- a/patches/minecraft/net/minecraft/entity/projectile/EntityFishHook.java.patch
+++ b/patches/minecraft/net/minecraft/entity/projectile/EntityFishHook.java.patch
@@ -6,8 +6,8 @@
          ItemStack itemstack1 = this.field_146042_b.func_184592_cb();
 -        boolean flag = itemstack.func_77973_b() == Items.field_151112_aM;
 -        boolean flag1 = itemstack1.func_77973_b() == Items.field_151112_aM;
-+	    boolean flag = itemstack.func_77973_b() instanceof net.minecraft.item.ItemFishingRod;
-+	    boolean flag1 = itemstack1.func_77973_b() instanceof net.minecraft.item.ItemFishingRod;
++        boolean flag = itemstack.func_77973_b() instanceof net.minecraft.item.ItemFishingRod;
++        boolean flag1 = itemstack1.func_77973_b() instanceof net.minecraft.item.ItemFishingRod;
  
          if (!this.field_146042_b.field_70128_L && this.field_146042_b.func_70089_S() && (flag || flag1) && this.func_70068_e(this.field_146042_b) <= 1024.0D)
          {

--- a/patches/minecraft/net/minecraft/entity/projectile/EntityFishHook.java.patch
+++ b/patches/minecraft/net/minecraft/entity/projectile/EntityFishHook.java.patch
@@ -1,5 +1,16 @@
 --- ../src-base/minecraft/net/minecraft/entity/projectile/EntityFishHook.java
 +++ ../src-work/minecraft/net/minecraft/entity/projectile/EntityFishHook.java
+@@ -269,8 +269,8 @@
+     {
+         ItemStack itemstack = this.field_146042_b.func_184614_ca();
+         ItemStack itemstack1 = this.field_146042_b.func_184592_cb();
+-        boolean flag = itemstack.func_77973_b() == Items.field_151112_aM;
+-        boolean flag1 = itemstack1.func_77973_b() == Items.field_151112_aM;
++	    boolean flag = itemstack.func_77973_b() instanceof net.minecraft.item.ItemFishingRod;
++	    boolean flag1 = itemstack1.func_77973_b() instanceof net.minecraft.item.ItemFishingRod;
+ 
+         if (!this.field_146042_b.field_70128_L && this.field_146042_b.func_70089_S() && (flag || flag1) && this.func_70068_e(this.field_146042_b) <= 1024.0D)
+         {
 @@ -506,6 +506,7 @@
          {
              int i = 0;


### PR DESCRIPTION
This patch allows support for modded Fishing Rods. It does assume that a Fishing Rod necessarily *extends* ItemFishingRod, but realistically this is a completely fair assumption, as extending the class does not mean that any part of it is necessarily required.

See https://github.com/CoFH/CoFHCore/blob/master/src/main/java/cofh/core/item/tool/ItemFishingRodCore.java for an example of a modded fishing rod for which this patch will correctly allow.

Prior to 1.11.x, a custom Fish Hook Entity was used. This is no longer feasible given the changes to EntityFishHook. This is an absolute minimal patch as required to support modded fishing rods.

Signed-off-by: King Lemming <kinglemming@gmail.com>