### PR TITLE
Fix recipe jsons not loading from jars, closes #4020

### DIFF
--- a/src/main/java/net/minecraftforge/common/crafting/CraftingHelper.java
+++ b/src/main/java/net/minecraftforge/common/crafting/CraftingHelper.java
@@ -23,6 +23,7 @@ import java.io.File;
 import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.net.URL;
 import java.nio.file.FileSystem;
 import java.nio.file.FileSystems;
 import java.nio.file.Files;
@@ -642,7 +643,7 @@ public class CraftingHelper {
         try
         {
             JsonContext ctx = new JsonContext(mod.getModId());
-            URI source = mod.getSource().toURI();
+            URI source = null;
 
             if ("minecraft".equals(mod.getModId()) && DEBUG_LOAD_MINECRAFT)
             {
@@ -658,13 +659,32 @@ public class CraftingHelper {
                 }
             }
 
+            if (mod.getMod() != null) {
+                URL assetDir = mod.getMod().getClass().getResource("/assets/" + mod.getModId() + "/");
+                if (assetDir != null)
+                {
+                    try
+                    {
+                        source = assetDir.toURI();
+                    } catch (URISyntaxException e)
+                    {
+                        e.printStackTrace();
+                    }
+                }
+            }
+
+            if (source == null)
+            {
+                return false;
+            }
+
             Path root = null;
             if ("jar".equals(source.getScheme()))
             {
                 try
                 {
                     fs = FileSystems.newFileSystem(source, Maps.newHashMap());
-                    root = fs.getPath("/assets/" + ctx.getModId() + "/recipes/");
+                    root = fs.getPath("/assets/" + ctx.getModId() + "/recipes");
                 }
                 catch (IOException e)
                 {
@@ -674,7 +694,7 @@ public class CraftingHelper {
             }
             else if ("file".equals(source.getScheme()))
             {
-                root = Paths.get(source).resolve("assets/" + ctx.getModId() + "/recipes/");
+                root = Paths.get(source).resolve("assets/" + ctx.getModId() + "/recipes");
             }
 
             if (root == null || !Files.exists(root))


### PR DESCRIPTION
Play a similar trick to vanilla, by using the mod's classpath to get a URL, then turn that into a URI, vanilla uses /assets/.mcassetsroot, we'll just use /assets/modid/.

Verified by compiling my in-dev version of [ProjectE](https://github.com/sinkillerj/ProjectE/tree/mc1.12.x) and loading it as a jar in the forge workspace - all my recipe jsons were able to be loaded. You need a 1.12 build of baubles to build, I hacked a compiling copy together and you can use it for testing purposes [here](https://www.dropbox.com/s/0fslhgzl8mit8vg/Baubles-1.11-1.4.5-deobf.jar?dl=0) (drop it in libs/ in the ProjectE repo then run gradle build).

Yes, I needed to remove those trailing slashes, or else the call to `Path.relativize` further below would freak out