### PR TITLE
Allow for MapDecoration to use alternate rendering, for example a custom spritesheet

### DIFF
--- a/patches/minecraft/net/minecraft/client/gui/MapItemRenderer.java.patch
+++ b/patches/minecraft/net/minecraft/client/gui/MapItemRenderer.java.patch
@@ -1,0 +1,11 @@
+--- ../src-base/minecraft/net/minecraft/client/gui/MapItemRenderer.java
++++ ../src-work/minecraft/net/minecraft/client/gui/MapItemRenderer.java
+@@ -139,6 +139,8 @@
+             {
+                 if (!p_148237_1_ || mapdecoration.func_191180_f())
+                 {
++                    if (mapdecoration.render(k)) { k++; continue; }
++                    MapItemRenderer.this.field_148251_b.func_110577_a(MapItemRenderer.field_148253_a); // Rebind in case custom render changes it
+                     GlStateManager.func_179094_E();
+                     GlStateManager.func_179109_b(0.0F + (float)mapdecoration.func_176112_b() / 2.0F + 64.0F, 0.0F + (float)mapdecoration.func_176113_c() / 2.0F + 64.0F, -0.02F);
+                     GlStateManager.func_179114_b((float)(mapdecoration.func_176111_d() * 360) / 16.0F, 0.0F, 0.0F, 1.0F);

--- a/patches/minecraft/net/minecraft/world/storage/MapDecoration.java.patch
+++ b/patches/minecraft/net/minecraft/world/storage/MapDecoration.java.patch
@@ -1,0 +1,20 @@
+--- ../src-base/minecraft/net/minecraft/world/storage/MapDecoration.java
++++ ../src-work/minecraft/net/minecraft/world/storage/MapDecoration.java
+@@ -92,6 +92,17 @@
+         return i;
+     }
+ 
++    /**
++     * Renders this decoration, useful for custom sprite sheets.
++     * @param index The index of this icon in the MapData's list. Used by vanilla to offset the Z-coordinate to prevent Z-fighting
++     * @return false to run vanilla logic for this decoration, true to skip it
++     */
++    @SideOnly(Side.CLIENT)
++    public boolean render(int index)
++    {
++        return false;
++    }
++
+     public static enum Type
+     {
+         PLAYER(false),


### PR DESCRIPTION
Maps currently don't have a way to specify alternate rendering of the icons on them, since `MapDecoration` uses the vanilla spritesheet, and enums which are weird to sync properly.

The intended use case for this is if you have a custom map (aka subclass of ItemMap and MapData), you will also subclass MapDecoration and implement your own icon there. Handling syncing of the subclass data is up to you, as the vanilla packet only handles MapDecoration's fields.

An alternative solution is to allow all map decoration rendering to be handled by `MapData` (basically moving this up out of the for loop in MapItemRenderer. That probably makes syncing less weird since you control the MapData subclass on both sides.