### PR TITLE
[1.12] Fixes Exception when getting modlist for a vanilla client

### DIFF
--- a/src/main/java/net/minecraftforge/fml/common/network/handshake/NetworkDispatcher.java
+++ b/src/main/java/net/minecraftforge/fml/common/network/handshake/NetworkDispatcher.java
@@ -35,6 +35,7 @@ import java.lang.reflect.Field;
 import java.net.SocketAddress;
 import java.nio.channels.ClosedChannelException;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -122,6 +123,7 @@ public class NetworkDispatcher extends SimpleChannelInboundHandler<Packet<?>> im
         this.manager = manager;
         this.scm = null;
         this.side = Side.CLIENT;
+        this.modList = new HashMap<>();
         this.handshakeChannel = new EmbeddedChannel(new HandshakeInjector(this), new ChannelRegistrationHandler(), new FMLHandshakeCodec(), new HandshakeMessageHandler<FMLHandshakeClientState>(FMLHandshakeClientState.class));
         this.handshakeChannel.attr(FML_DISPATCHER).set(this);
         this.handshakeChannel.attr(NetworkRegistry.CHANNEL_SOURCE).set(Side.SERVER);
@@ -137,6 +139,7 @@ public class NetworkDispatcher extends SimpleChannelInboundHandler<Packet<?>> im
         this.manager = manager;
         this.scm = scm;
         this.side = Side.SERVER;
+        this.modList = new HashMap<>();
         this.handshakeChannel = new EmbeddedChannel(new HandshakeInjector(this), new ChannelRegistrationHandler(), new FMLHandshakeCodec(), new HandshakeMessageHandler<FMLHandshakeServerState>(FMLHandshakeServerState.class));
         this.handshakeChannel.attr(FML_DISPATCHER).set(this);
         this.handshakeChannel.attr(NetworkRegistry.CHANNEL_SOURCE).set(Side.CLIENT);

--- a/src/main/java/net/minecraftforge/fml/common/network/handshake/NetworkDispatcher.java
+++ b/src/main/java/net/minecraftforge/fml/common/network/handshake/NetworkDispatcher.java
@@ -122,7 +122,7 @@ public class NetworkDispatcher extends SimpleChannelInboundHandler<Packet<?>> im
         this.manager = manager;
         this.scm = null;
         this.side = Side.CLIENT;
-        this.modList = Collections.EMPTY_MAP;
+        this.modList = Collections.emptyMap();
         this.handshakeChannel = new EmbeddedChannel(new HandshakeInjector(this), new ChannelRegistrationHandler(), new FMLHandshakeCodec(), new HandshakeMessageHandler<FMLHandshakeClientState>(FMLHandshakeClientState.class));
         this.handshakeChannel.attr(FML_DISPATCHER).set(this);
         this.handshakeChannel.attr(NetworkRegistry.CHANNEL_SOURCE).set(Side.SERVER);
@@ -138,7 +138,7 @@ public class NetworkDispatcher extends SimpleChannelInboundHandler<Packet<?>> im
         this.manager = manager;
         this.scm = scm;
         this.side = Side.SERVER;
-        this.modList = Collections.EMPTY_MAP;
+        this.modList = Collections.emptyMap();
         this.handshakeChannel = new EmbeddedChannel(new HandshakeInjector(this), new ChannelRegistrationHandler(), new FMLHandshakeCodec(), new HandshakeMessageHandler<FMLHandshakeServerState>(FMLHandshakeServerState.class));
         this.handshakeChannel.attr(FML_DISPATCHER).set(this);
         this.handshakeChannel.attr(NetworkRegistry.CHANNEL_SOURCE).set(Side.CLIENT);

--- a/src/main/java/net/minecraftforge/fml/common/network/handshake/NetworkDispatcher.java
+++ b/src/main/java/net/minecraftforge/fml/common/network/handshake/NetworkDispatcher.java
@@ -113,7 +113,7 @@ public class NetworkDispatcher extends SimpleChannelInboundHandler<Packet<?>> im
     private final EmbeddedChannel handshakeChannel;
     private NetHandlerPlayServer serverHandler;
     private INetHandler netHandler;
-    private Map<String,String> modList;
+    private Map<String,String> modList = Collections.emptyMap();
     private int overrideLoginDim;
 
     public NetworkDispatcher(NetworkManager manager)
@@ -122,7 +122,6 @@ public class NetworkDispatcher extends SimpleChannelInboundHandler<Packet<?>> im
         this.manager = manager;
         this.scm = null;
         this.side = Side.CLIENT;
-        this.modList = Collections.emptyMap();
         this.handshakeChannel = new EmbeddedChannel(new HandshakeInjector(this), new ChannelRegistrationHandler(), new FMLHandshakeCodec(), new HandshakeMessageHandler<FMLHandshakeClientState>(FMLHandshakeClientState.class));
         this.handshakeChannel.attr(FML_DISPATCHER).set(this);
         this.handshakeChannel.attr(NetworkRegistry.CHANNEL_SOURCE).set(Side.SERVER);
@@ -138,7 +137,6 @@ public class NetworkDispatcher extends SimpleChannelInboundHandler<Packet<?>> im
         this.manager = manager;
         this.scm = scm;
         this.side = Side.SERVER;
-        this.modList = Collections.emptyMap();
         this.handshakeChannel = new EmbeddedChannel(new HandshakeInjector(this), new ChannelRegistrationHandler(), new FMLHandshakeCodec(), new HandshakeMessageHandler<FMLHandshakeServerState>(FMLHandshakeServerState.class));
         this.handshakeChannel.attr(FML_DISPATCHER).set(this);
         this.handshakeChannel.attr(NetworkRegistry.CHANNEL_SOURCE).set(Side.CLIENT);

--- a/src/main/java/net/minecraftforge/fml/common/network/handshake/NetworkDispatcher.java
+++ b/src/main/java/net/minecraftforge/fml/common/network/handshake/NetworkDispatcher.java
@@ -35,7 +35,6 @@ import java.lang.reflect.Field;
 import java.net.SocketAddress;
 import java.nio.channels.ClosedChannelException;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -123,7 +122,7 @@ public class NetworkDispatcher extends SimpleChannelInboundHandler<Packet<?>> im
         this.manager = manager;
         this.scm = null;
         this.side = Side.CLIENT;
-        this.modList = new HashMap<>();
+        this.modList = Collections.EMPTY_MAP;
         this.handshakeChannel = new EmbeddedChannel(new HandshakeInjector(this), new ChannelRegistrationHandler(), new FMLHandshakeCodec(), new HandshakeMessageHandler<FMLHandshakeClientState>(FMLHandshakeClientState.class));
         this.handshakeChannel.attr(FML_DISPATCHER).set(this);
         this.handshakeChannel.attr(NetworkRegistry.CHANNEL_SOURCE).set(Side.SERVER);
@@ -139,7 +138,7 @@ public class NetworkDispatcher extends SimpleChannelInboundHandler<Packet<?>> im
         this.manager = manager;
         this.scm = scm;
         this.side = Side.SERVER;
-        this.modList = new HashMap<>();
+        this.modList = Collections.EMPTY_MAP;
         this.handshakeChannel = new EmbeddedChannel(new HandshakeInjector(this), new ChannelRegistrationHandler(), new FMLHandshakeCodec(), new HandshakeMessageHandler<FMLHandshakeServerState>(FMLHandshakeServerState.class));
         this.handshakeChannel.attr(FML_DISPATCHER).set(this);
         this.handshakeChannel.attr(NetworkRegistry.CHANNEL_SOURCE).set(Side.CLIENT);


### PR DESCRIPTION
For a Vanilla Client NetworkDispatcher.modList is null so NetworkDispatcher.getModList() throws an exception because Collections.unmodifiableMap can't be called with null. Setting NetworkDispatcher.modList to an empty map in the constructor instead results in an empty map for vanilla clients.