### PR TITLE
Remove the call to client.refreshResources during loading

### DIFF
--- a/patches/minecraft/net/minecraft/client/Minecraft.java.patch
+++ b/patches/minecraft/net/minecraft/client/Minecraft.java.patch
@@ -34,9 +34,8 @@
          GlStateManager.func_179096_D();
          GlStateManager.func_179128_n(5888);
          this.func_71361_d("Startup");
--        this.field_147128_au = new TextureMap("textures");
 +        bar.step("Loading Texture Map");
-+        this.field_147128_au = new TextureMap("textures", true);
+         this.field_147128_au = new TextureMap("textures");
          this.field_147128_au.func_147633_a(this.field_71474_y.field_151442_I);
          this.field_71446_o.func_110580_a(TextureMap.field_110575_b, this.field_147128_au);
          this.field_71446_o.func_110577_a(TextureMap.field_110575_b);
@@ -87,15 +86,6 @@
          if (this.field_71474_y.field_74353_u && !this.field_71431_Q)
          {
              this.func_71352_k();
-@@ -581,7 +591,7 @@
-         {
-             return (List)p_193990_0_.func_192711_b().stream().flatMap((p_193993_0_) -> {
-                 return p_193993_0_.func_77571_b().func_82840_a((EntityPlayer)null, ITooltipFlag.TooltipFlags.NORMAL).stream();
--            }).map(TextFormatting::func_110646_a).map(String::trim).filter((p_193994_0_) -> {
-+            }).map(TextFormatting::getTextWithoutFormattingCodes).map(String::trim).filter((p_193994_0_) -> {
-                 return !p_193994_0_.isEmpty();
-             }).collect(Collectors.toList());
-         }, (p_193991_0_) ->
 @@ -748,21 +758,23 @@
          File file2 = new File(file1, "crash-" + (new SimpleDateFormat("yyyy-MM-dd_HH.mm.ss")).format(new Date()) + "-client.txt");
          Bootstrap.func_179870_a(p_71377_1_.func_71502_e());

--- a/patches/minecraft/net/minecraft/client/renderer/texture/TextureMap.java.patch
+++ b/patches/minecraft/net/minecraft/client/renderer/texture/TextureMap.java.patch
@@ -164,21 +164,16 @@
              {
                  String s = textureatlassprite1.func_94215_i();
                  map.remove(s);
-@@ -186,6 +257,13 @@
+@@ -186,6 +257,8 @@
          {
              textureatlassprite2.func_94217_a(this.field_94249_f);
          }
-+
 +        net.minecraftforge.client.ForgeHooksClient.onTextureStitchedPost(this);
-+
-+        // TextureUtil.saveGlTexture is gone, FIXME
-+        //if (!net.minecraftforge.common.ForgeModContainer.disableStitchedFileSaving)
-+        //TextureUtil.saveGlTexture(this.basePath.replaceAll("/", "_"), this.getGlTextureId(), this.mipmapLevels, stitcher.getCurrentWidth(), stitcher.getCurrentHeight());
 +        net.minecraftforge.fml.common.ProgressManager.pop(bar);
      }
  
      private boolean func_184397_a(IResourceManager p_184397_1_, final TextureAtlasSprite p_184397_2_)
-@@ -195,7 +273,7 @@
+@@ -195,7 +268,7 @@
          label62:
          {
              boolean flag;
@@ -187,7 +182,7 @@
              try
              {
                  iresource = p_184397_1_.func_110536_a(resourcelocation);
-@@ -292,7 +370,7 @@
+@@ -292,7 +365,7 @@
          }
          else
          {
@@ -196,7 +191,7 @@
  
              if (textureatlassprite == null)
              {
-@@ -318,4 +396,52 @@
+@@ -318,4 +391,52 @@
      {
          return this.field_94249_f;
      }

--- a/patches/minecraft/net/minecraft/client/renderer/texture/TextureMap.java.patch
+++ b/patches/minecraft/net/minecraft/client/renderer/texture/TextureMap.java.patch
@@ -1,6 +1,6 @@
 --- ../src-base/minecraft/net/minecraft/client/renderer/texture/TextureMap.java
 +++ ../src-work/minecraft/net/minecraft/client/renderer/texture/TextureMap.java
-@@ -45,12 +45,23 @@
+@@ -45,6 +45,16 @@
  
      public TextureMap(String p_i46100_1_, @Nullable ITextureMapPopulator p_i46100_2_)
      {
@@ -17,14 +17,7 @@
          this.field_94258_i = Lists.<TextureAtlasSprite>newArrayList();
          this.field_110574_e = Maps.<String, TextureAtlasSprite>newHashMap();
          this.field_94252_e = Maps.<String, TextureAtlasSprite>newHashMap();
-         this.field_94249_f = new TextureAtlasSprite("missingno");
-         this.field_94254_c = p_i46100_1_;
-         this.field_174946_m = p_i46100_2_;
-+        this.skipFirst = skipFirst && ENABLE_SKIP;
-     }
- 
-     private void func_110569_e()
-@@ -74,6 +85,7 @@
+@@ -74,6 +84,7 @@
      public void func_174943_a(IResourceManager p_174943_1_, ITextureMapPopulator p_174943_2_)
      {
          this.field_110574_e.clear();
@@ -32,26 +25,23 @@
          p_174943_2_.func_177059_a(this);
          this.func_110569_e();
          this.func_147631_c();
-@@ -88,13 +100,58 @@
+@@ -88,13 +99,55 @@
          this.field_94258_i.clear();
          int j = Integer.MAX_VALUE;
          int k = 1 << this.field_147636_j;
 +        net.minecraftforge.fml.common.FMLLog.log.info("Max texture size: {}", i);
-+        net.minecraftforge.fml.common.ProgressManager.ProgressBar bar = net.minecraftforge.fml.common.ProgressManager.push("Texture stitching", skipFirst ? 0 : this.field_110574_e.size());
++        net.minecraftforge.fml.common.ProgressManager.ProgressBar bar = net.minecraftforge.fml.common.ProgressManager.push("Texture stitching", this.field_110574_e.size());
 +        loadedSprites.clear();
  
 -        for (Entry<String, TextureAtlasSprite> entry : this.field_110574_e.entrySet())
-+        if (!skipFirst)
++        for (Entry<String, TextureAtlasSprite> entry : Maps.newHashMap(this.field_110574_e).entrySet())
          {
 -            TextureAtlasSprite textureatlassprite = entry.getValue();
 -            ResourceLocation resourcelocation = this.func_184396_a(textureatlassprite);
 -            IResource iresource = null;
-+            for (Entry<String, TextureAtlasSprite> entry : Maps.newHashMap(this.field_110574_e).entrySet())
-+            {
-+                final ResourceLocation location = new ResourceLocation(entry.getKey());
-+                bar.step(location.toString());
-+                j = loadTexture(stitcher, p_110571_1_, location, entry.getValue(), bar, j, k);
-+            }
++            final ResourceLocation location = new ResourceLocation(entry.getKey());
++            bar.step(location.toString());
++            j = loadTexture(stitcher, p_110571_1_, location, entry.getValue(), bar, j, k);
 +        }
 +        finishLoading(stitcher, bar, j, k);
 +    }
@@ -95,7 +85,7 @@
              try
              {
                  PngSizeInfo pngsizeinfo = PngSizeInfo.func_188532_a(p_110571_1_.func_110536_a(resourcelocation));
-@@ -104,13 +161,13 @@
+@@ -104,13 +157,13 @@
              }
              catch (RuntimeException runtimeexception)
              {
@@ -113,7 +103,7 @@
              }
              finally
              {
-@@ -122,16 +179,28 @@
+@@ -122,16 +175,28 @@
  
              if (j1 < k)
              {
@@ -144,11 +134,10 @@
          if (i1 < this.field_147636_j)
          {
              field_147635_d.warn("{}: dropping miplevel from {} to {}, because of minimum power of two: {}", this.field_94254_c, Integer.valueOf(this.field_147636_j), Integer.valueOf(i1), Integer.valueOf(l));
-@@ -140,9 +209,12 @@
+@@ -140,9 +205,11 @@
  
          this.field_94249_f.func_147963_d(this.field_147636_j);
          stitcher.func_110934_a(this.field_94249_f);
-+        skipFirst = false;
 +        bar = net.minecraftforge.fml.common.ProgressManager.push("Texture creation", 2);
  
          try
@@ -157,7 +146,7 @@
              stitcher.func_94305_f();
          }
          catch (StitcherException stitcherexception)
-@@ -151,12 +223,16 @@
+@@ -151,12 +218,16 @@
          }
  
          field_147635_d.info("Created: {}x{} {}-atlas", Integer.valueOf(stitcher.func_110935_a()), Integer.valueOf(stitcher.func_110936_b()), this.field_94254_c);
@@ -175,7 +164,7 @@
              {
                  String s = textureatlassprite1.func_94215_i();
                  map.remove(s);
-@@ -186,6 +262,13 @@
+@@ -186,6 +257,13 @@
          {
              textureatlassprite2.func_94217_a(this.field_94249_f);
          }
@@ -189,7 +178,7 @@
      }
  
      private boolean func_184397_a(IResourceManager p_184397_1_, final TextureAtlasSprite p_184397_2_)
-@@ -195,7 +278,7 @@
+@@ -195,7 +273,7 @@
          label62:
          {
              boolean flag;
@@ -198,7 +187,7 @@
              try
              {
                  iresource = p_184397_1_.func_110536_a(resourcelocation);
-@@ -292,7 +375,7 @@
+@@ -292,7 +370,7 @@
          }
          else
          {
@@ -207,7 +196,7 @@
  
              if (textureatlassprite == null)
              {
-@@ -318,4 +401,54 @@
+@@ -318,4 +396,52 @@
      {
          return this.field_94249_f;
      }
@@ -216,8 +205,6 @@
 +    //                                           Forge Start
 +    //===================================================================================================
 +
-+    private static final boolean ENABLE_SKIP = Boolean.parseBoolean(System.getProperty("fml.skipFirstTextureLoad", "true"));
-+    private boolean skipFirst = false;
 +    private final java.util.Deque<ResourceLocation> loadingSprites = new java.util.ArrayDeque<>();
 +    private final java.util.Set<ResourceLocation> loadedSprites = new java.util.HashSet<>();
 +

--- a/src/main/java/net/minecraftforge/client/model/ModelLoader.java
+++ b/src/main/java/net/minecraftforge/client/model/ModelLoader.java
@@ -63,7 +63,6 @@ import net.minecraft.client.renderer.block.model.multipart.Multipart;
 import net.minecraft.client.renderer.block.model.multipart.Selector;
 import net.minecraft.client.renderer.block.statemap.BlockStateMapper;
 import net.minecraft.client.renderer.block.statemap.IStateMapper;
-import net.minecraft.client.renderer.texture.ITextureMapPopulator;
 import net.minecraft.client.renderer.texture.TextureAtlasSprite;
 import net.minecraft.client.renderer.texture.TextureMap;
 import net.minecraft.client.renderer.vertex.DefaultVertexFormats;
@@ -126,8 +125,8 @@ import javax.annotation.Nullable;
 
 public final class ModelLoader extends ModelBakery
 {
-    private static boolean firstLoad = Boolean.parseBoolean(System.getProperty("fml.skipFirstModelBake", "true"));
     private final Map<ModelResourceLocation, IModel> stateModels = Maps.newHashMap();
+    // TODO: nothing adds to missingVariants, remove it?
     private final Set<ModelResourceLocation> missingVariants = Sets.newHashSet();
     private final Map<ResourceLocation, Exception> loadingExceptions = Maps.newHashMap();
     private IModel missingModel = null;
@@ -149,6 +148,7 @@ public final class ModelLoader extends ModelBakery
         ModelLoaderRegistry.clearModelCache(manager);
     }
 
+    @Nonnull
     @Override
     public IRegistry<ModelResourceLocation, IBakedModel> setupModelRegistry()
     {
@@ -171,16 +171,6 @@ public final class ModelLoader extends ModelBakery
         Map<IModel, IBakedModel> bakedModels = Maps.newHashMap();
         HashMultimap<IModel, ModelResourceLocation> models = HashMultimap.create();
         Multimaps.invertFrom(Multimaps.forMap(stateModels), models);
-
-        if (firstLoad)
-        {
-            firstLoad = false;
-            for (ModelResourceLocation mrl : stateModels.keySet())
-            {
-                bakedRegistry.putObject(mrl, missingBaked);
-            }
-            return bakedRegistry;
-        }
 
         ProgressBar bakeBar = ProgressManager.push("ModelLoader: baking", models.keySet().size());
 

--- a/src/main/java/net/minecraftforge/fml/client/FMLClientHandler.java
+++ b/src/main/java/net/minecraftforge/fml/client/FMLClientHandler.java
@@ -361,6 +361,14 @@ public class FMLClientHandler implements IFMLSidedHandler
             return;
         }
 
+        // This call is being phased out for performance reasons in 1.12,
+        // but we are keeping an option here in case something needs it for a little longer.
+        // See https://github.com/MinecraftForge/MinecraftForge/pull/4032
+        if (Boolean.parseBoolean(System.getProperty("fml.reloadResourcesOnStart", "false")))
+        {
+            client.refreshResources();
+        }
+
         RenderingRegistry.loadEntityRenderers(Minecraft.getMinecraft().getRenderManager().entityRenderMap);
         guiFactories = HashBiMap.create();
         for (ModContainer mc : Loader.instance().getActiveModList())

--- a/src/main/java/net/minecraftforge/fml/client/FMLClientHandler.java
+++ b/src/main/java/net/minecraftforge/fml/client/FMLClientHandler.java
@@ -361,8 +361,6 @@ public class FMLClientHandler implements IFMLSidedHandler
             return;
         }
 
-        // Reload resources
-        client.refreshResources();
         RenderingRegistry.loadEntityRenderers(Minecraft.getMinecraft().getRenderManager().entityRenderMap);
         guiFactories = HashBiMap.create();
         for (ModContainer mc : Loader.instance().getActiveModList())


### PR DESCRIPTION
Loading the resources takes a very significant part of the startup time.
Vanilla only loads resources once, but Forge effectively loads resources twice at startup.
This PR removes the call to `client.refreshResources` during loading so they are only loaded once.

This PR also removes some associated performance hacks that skip some things on the first resource load. Not everything can be skipped, for instance models must be done on the first pass so they are available at the appropriate time. After this PR there will only be one load, the early one.

This call has been there since the beginning of the git history so I don't know its purpose, so hopefully this PR can attract some discussion about the issue and its solution.