### PR TITLE
Fix uncaught ClassCastException from invalid recipe file

### DIFF
--- a/src/main/java/net/minecraftforge/common/crafting/CraftingHelper.java
+++ b/src/main/java/net/minecraftforge/common/crafting/CraftingHelper.java
@@ -735,7 +735,7 @@ public class CraftingHelper {
                 {
                     reader = Files.newBufferedReader(f);
                     JsonObject json = JsonUtils.fromJson(GSON, reader, JsonObject.class);
-                    if (json.has("conditions") && !CraftingHelper.processConditions(json.getAsJsonArray("conditions"), ctx))
+                    if (json.has("conditions") && !CraftingHelper.processConditions(JsonUtils.getJsonArray(json, "conditions"), ctx))
                         continue;
                     IRecipe recipe = CraftingHelper.getRecipe(json, ctx);
                     ForgeRegistries.RECIPES.register(recipe.setRegistryName(key));

--- a/src/test/resources/assets/crafting_system_test/recipes/conditions_property_not_array.json
+++ b/src/test/resources/assets/crafting_system_test/recipes/conditions_property_not_array.json
@@ -1,0 +1,21 @@
+{
+  "conditions": {
+    "not an array": "conditions property must be an array"
+  },
+  "type": "crafting_shaped",
+  "group": "planks",
+  "pattern": [
+    "#"
+  ],
+  "key": {
+    "#": {
+      "item": "minecraft:log2",
+      "data": 0
+    }
+  },
+  "result": {
+    "item": "minecraft:planks",
+    "data": 4,
+    "count": 4
+  }
+}


### PR DESCRIPTION
`CraftingHelper.loadRecipes(ModContainer)` uses `JsonObject#getAsJsonArray` to get the `conditions` property of the recipe, but this throws a `ClassCastException` if the specified property isn't an array. This exception isn't caught by `CraftingHelper` and crashes the game.

This PR replaces the call  to `JsonObject#getAsJsonArray` with a call to `JsonUtils.getAsJsonArray`, which throws a `JsonSyntaxException` if the specified property isn't an array. This exception is caught and logged, so it no longer crashes the game.

The **conditions_property_not_array.json** recipe file demonstrates this behaviour because its `conditions` property is an object rather than an array.

This was originally reported by KrimsonTM [on the forums](http://www.minecraftforge.net/forum/topic/58765-forge-112-142102340/).