### PR TITLE
[1.11.x] limit server>client ItemStack packet chattiness

### DIFF
--- a/patches/minecraft/net/minecraft/entity/EntityLivingBase.java.patch
+++ b/patches/minecraft/net/minecraft/entity/EntityLivingBase.java.patch
@@ -231,15 +231,17 @@
          super.func_70071_h_();
          this.func_184608_ct();
  
-@@ -2015,6 +2046,7 @@
+@@ -2014,7 +2045,9 @@
+ 
                  if (!ItemStack.func_77989_b(itemstack1, itemstack))
                  {
++                    if (!ItemStack.areItemStacksEqualUsingNBTShareTag(itemstack1, itemstack))
                      ((WorldServer)this.field_70170_p).func_73039_n().func_151247_a(this, new SPacketEntityEquipment(this.func_145782_y(), entityequipmentslot, itemstack1));
 +                    net.minecraftforge.common.MinecraftForge.EVENT_BUS.post(new net.minecraftforge.event.entity.living.LivingEquipmentChangeEvent(this, entityequipmentslot, itemstack, itemstack1));
  
                      if (!itemstack.func_190926_b())
                      {
-@@ -2488,6 +2520,40 @@
+@@ -2488,6 +2521,40 @@
          this.field_70752_e = true;
      }
  
@@ -280,7 +282,7 @@
      public abstract EnumHandSide func_184591_cq();
  
      public boolean func_184587_cr()
-@@ -2508,12 +2574,19 @@
+@@ -2508,12 +2575,19 @@
  
              if (itemstack == this.field_184627_bm)
              {
@@ -301,7 +303,7 @@
                  {
                      this.func_71036_o();
                  }
-@@ -2531,8 +2604,10 @@
+@@ -2531,8 +2605,10 @@
  
          if (!itemstack.func_190926_b() && !this.func_184587_cr())
          {
@@ -313,7 +315,7 @@
  
              if (!this.field_70170_p.field_72995_K)
              {
-@@ -2613,7 +2688,9 @@
+@@ -2613,7 +2689,9 @@
          if (!this.field_184627_bm.func_190926_b() && this.func_184587_cr())
          {
              this.func_184584_a(this.field_184627_bm, 16);
@@ -324,7 +326,7 @@
              this.func_184602_cy();
          }
      }
-@@ -2637,7 +2714,8 @@
+@@ -2637,7 +2715,8 @@
      {
          if (!this.field_184627_bm.func_190926_b())
          {
@@ -334,7 +336,7 @@
          }
  
          this.func_184602_cy();
-@@ -2761,4 +2839,29 @@
+@@ -2761,4 +2840,29 @@
      {
          return true;
      }

--- a/patches/minecraft/net/minecraft/inventory/Container.java.patch
+++ b/patches/minecraft/net/minecraft/inventory/Container.java.patch
@@ -1,6 +1,18 @@
 --- ../src-base/minecraft/net/minecraft/inventory/Container.java
 +++ ../src-work/minecraft/net/minecraft/inventory/Container.java
-@@ -578,18 +578,19 @@
+@@ -77,9 +77,11 @@
+ 
+             if (!ItemStack.func_77989_b(itemstack1, itemstack))
+             {
++                boolean clientStackChanged = !ItemStack.areItemStacksEqualUsingNBTShareTag(itemstack1, itemstack);
+                 itemstack1 = itemstack.func_190926_b() ? ItemStack.field_190927_a : itemstack.func_77946_l();
+                 this.field_75153_a.set(i, itemstack1);
+ 
++                if (clientStackChanged)
+                 for (int j = 0; j < this.field_75149_d.size(); ++j)
+                 {
+                     ((IContainerListener)this.field_75149_d.get(j)).func_71111_a(this, i, itemstack1);
+@@ -578,18 +580,19 @@
                  if (!itemstack.func_190926_b() && itemstack.func_77973_b() == p_75135_1_.func_77973_b() && (!p_75135_1_.func_77981_g() || p_75135_1_.func_77960_j() == itemstack.func_77960_j()) && ItemStack.func_77970_a(p_75135_1_, itemstack))
                  {
                      int j = itemstack.func_190916_E() + p_75135_1_.func_190916_E();
@@ -24,7 +36,7 @@
                          slot.func_75218_e();
                          flag = true;
                      }
-@@ -708,7 +709,7 @@
+@@ -708,7 +711,7 @@
                  p_94525_2_.func_190920_e(1);
                  break;
              case 2:


### PR DESCRIPTION
Change to prevent server only itemstack changes triggering SPacketEntityEquipment and SPacketSetSlot from being triggered.
Currently when an itemstack changes in any way it always sends these packets to client even in cases where the change may not have changed the client stack - data in cap nbt or data not included in NBTShareTag. 

So this change adds a condition in two places that checks if the client stack has actually changed and only in that case it allows the packets to be sent.

This is a 1.11 version of #3283, much smaller change as it uses a method that mezz added for another NBTShareTag PR.