### PR TITLE
[1.12] Allow enchantments to modify damage based on the entity hit

### DIFF
--- a/patches/minecraft/net/minecraft/enchantment/Enchantment.java.patch
+++ b/patches/minecraft/net/minecraft/enchantment/Enchantment.java.patch
@@ -12,7 +12,22 @@
      private final EntityEquipmentSlot[] field_185263_a;
      private final Enchantment.Rarity field_77333_a;
      @Nullable
-@@ -134,7 +134,7 @@
+@@ -94,6 +94,14 @@
+         return 0;
+     }
+ 
++    public float calcDamageByEntity(int level, @javax.annotation.Nullable Entity entity)
++    {
++        return func_152376_a(level,entity instanceof EntityLivingBase?((EntityLivingBase) entity).func_70668_bt():EnumCreatureAttribute.UNDEFINED);
++    }
++
++    /**
++     * Consider using Forge's entity sensitive version
++     */
+     public float func_152376_a(int p_152376_1_, EnumCreatureAttribute p_152376_2_)
+     {
+         return 0.0F;
+@@ -134,7 +142,7 @@
  
      public boolean func_92089_a(ItemStack p_92089_1_)
      {
@@ -21,7 +36,7 @@
      }
  
      public void func_151368_a(EntityLivingBase p_151368_1_, Entity p_151368_2_, int p_151368_3_)
-@@ -155,6 +155,26 @@
+@@ -155,6 +163,26 @@
          return false;
      }
  

--- a/patches/minecraft/net/minecraft/enchantment/Enchantment.java.patch
+++ b/patches/minecraft/net/minecraft/enchantment/Enchantment.java.patch
@@ -12,22 +12,18 @@
      private final EntityEquipmentSlot[] field_185263_a;
      private final Enchantment.Rarity field_77333_a;
      @Nullable
-@@ -94,6 +94,14 @@
+@@ -94,6 +94,10 @@
          return 0;
      }
  
-+    public float calcDamageByEntity(int level, @javax.annotation.Nullable Entity entity)
-+    {
-+        return func_152376_a(level,entity instanceof EntityLivingBase?((EntityLivingBase) entity).func_70668_bt():EnumCreatureAttribute.UNDEFINED);
-+    }
-+
 +    /**
 +     * Consider using Forge's entity sensitive version
 +     */
++    @Deprecated
      public float func_152376_a(int p_152376_1_, EnumCreatureAttribute p_152376_2_)
      {
          return 0.0F;
-@@ -134,7 +142,7 @@
+@@ -134,7 +138,7 @@
  
      public boolean func_92089_a(ItemStack p_92089_1_)
      {
@@ -36,7 +32,7 @@
      }
  
      public void func_151368_a(EntityLivingBase p_151368_1_, Entity p_151368_2_, int p_151368_3_)
-@@ -155,6 +163,26 @@
+@@ -155,6 +159,26 @@
          return false;
      }
  
@@ -63,3 +59,20 @@
      public static void func_185257_f()
      {
          EntityEquipmentSlot[] aentityequipmentslot = new EntityEquipmentSlot[] {EntityEquipmentSlot.HEAD, EntityEquipmentSlot.CHEST, EntityEquipmentSlot.LEGS, EntityEquipmentSlot.FEET};
+@@ -209,4 +233,16 @@
+             return this.field_185275_e;
+         }
+     }
++
++    /* ======================================== FORGE START =====================================*/
++
++    /**
++     * Calculate the damage this enchantment adds to an attack on the given entity
++     */
++    public float calcDamageByEntity(int level, @javax.annotation.Nullable Entity entity)
++    {
++        return func_152376_a(level,entity instanceof EntityLivingBase?((EntityLivingBase) entity).func_70668_bt():EnumCreatureAttribute.UNDEFINED);
++    }
++
++    /* ======================================== FORGE END   =====================================*/
+ }

--- a/patches/minecraft/net/minecraft/enchantment/Enchantment.java.patch
+++ b/patches/minecraft/net/minecraft/enchantment/Enchantment.java.patch
@@ -12,18 +12,15 @@
      private final EntityEquipmentSlot[] field_185263_a;
      private final Enchantment.Rarity field_77333_a;
      @Nullable
-@@ -94,6 +94,10 @@
+@@ -94,6 +94,7 @@
          return 0;
      }
  
-+    /**
-+     * Consider using Forge's entity sensitive version
-+     */
-+    @Deprecated
++    @Deprecated //Consider using Forge's entity sensitive version
      public float func_152376_a(int p_152376_1_, EnumCreatureAttribute p_152376_2_)
      {
          return 0.0F;
-@@ -134,7 +138,7 @@
+@@ -134,7 +135,7 @@
  
      public boolean func_92089_a(ItemStack p_92089_1_)
      {
@@ -32,10 +29,21 @@
      }
  
      public void func_151368_a(EntityLivingBase p_151368_1_, Entity p_151368_2_, int p_151368_3_)
-@@ -155,6 +159,26 @@
+@@ -155,6 +156,7 @@
          return false;
      }
  
++
+     public static void func_185257_f()
+     {
+         EntityEquipmentSlot[] aentityequipmentslot = new EntityEquipmentSlot[] {EntityEquipmentSlot.HEAD, EntityEquipmentSlot.CHEST, EntityEquipmentSlot.LEGS, EntityEquipmentSlot.FEET};
+@@ -209,4 +211,41 @@
+             return this.field_185275_e;
+         }
+     }
++
++    /* ======================================== FORGE START ===================================== */
++
 +    /**
 +     * This applies specifically to applying at the enchanting table. The other method {@link #canApply(ItemStack)}
 +     * applies for <i>all possible</i> enchantments.
@@ -56,23 +64,18 @@
 +        return true;
 +    }
 +
-     public static void func_185257_f()
-     {
-         EntityEquipmentSlot[] aentityequipmentslot = new EntityEquipmentSlot[] {EntityEquipmentSlot.HEAD, EntityEquipmentSlot.CHEST, EntityEquipmentSlot.LEGS, EntityEquipmentSlot.FEET};
-@@ -209,4 +233,16 @@
-             return this.field_185275_e;
-         }
-     }
-+
-+    /* ======================================== FORGE START =====================================*/
-+
 +    /**
-+     * Calculate the damage this enchantment adds to an attack on the given entity
++     * Calculate the damage this enchantment adds to an attack on the given entity.
++     *
++     * @param level  the level of this enchantment on the item doing the attack
++     * @param entity the entity being attacked
++     * @return the additional damage to do
 +     */
 +    public float calcDamageByEntity(int level, @javax.annotation.Nullable Entity entity)
 +    {
-+        return func_152376_a(level,entity instanceof EntityLivingBase?((EntityLivingBase) entity).func_70668_bt():EnumCreatureAttribute.UNDEFINED);
++        return func_152376_a(level,
++                entity instanceof EntityLivingBase ? ((EntityLivingBase) entity).func_70668_bt() : EnumCreatureAttribute.UNDEFINED);
 +    }
 +
-+    /* ======================================== FORGE END   =====================================*/
++    /* ======================================== FORGE END   ===================================== */
  }

--- a/patches/minecraft/net/minecraft/enchantment/Enchantment.java.patch
+++ b/patches/minecraft/net/minecraft/enchantment/Enchantment.java.patch
@@ -29,15 +29,7 @@
      }
  
      public void func_151368_a(EntityLivingBase p_151368_1_, Entity p_151368_2_, int p_151368_3_)
-@@ -155,6 +156,7 @@
-         return false;
-     }
- 
-+
-     public static void func_185257_f()
-     {
-         EntityEquipmentSlot[] aentityequipmentslot = new EntityEquipmentSlot[] {EntityEquipmentSlot.HEAD, EntityEquipmentSlot.CHEST, EntityEquipmentSlot.LEGS, EntityEquipmentSlot.FEET};
-@@ -209,4 +211,41 @@
+@@ -209,4 +210,41 @@
              return this.field_185275_e;
          }
      }

--- a/patches/minecraft/net/minecraft/enchantment/EnchantmentHelper.java.patch
+++ b/patches/minecraft/net/minecraft/enchantment/EnchantmentHelper.java.patch
@@ -1,6 +1,6 @@
 --- ../src-base/minecraft/net/minecraft/enchantment/EnchantmentHelper.java
 +++ ../src-work/minecraft/net/minecraft/enchantment/EnchantmentHelper.java
-@@ -143,12 +143,14 @@
+@@ -143,10 +143,15 @@
          return field_77520_b.field_77497_a;
      }
  
@@ -11,15 +11,13 @@
 +    @Deprecated
      public static float func_152377_a(ItemStack p_152377_0_, EnumCreatureAttribute p_152377_1_)
      {
--        field_77521_c.field_77495_a = 0.0F;
+         field_77521_c.field_77495_a = 0.0F;
 -        field_77521_c.field_77494_b = p_152377_1_;
--        func_77518_a(field_77521_c, p_152377_0_);
--        return field_77521_c.field_77495_a;
-+        return 0.0F;
++        field_77521_c.attribute = p_152377_1_;
+         func_77518_a(field_77521_c, p_152377_0_);
+         return field_77521_c.field_77495_a;
      }
- 
-     public static float func_191527_a(EntityLivingBase p_191527_0_)
-@@ -302,7 +304,7 @@
+@@ -302,7 +307,7 @@
      public static int func_77514_a(Random p_77514_0_, int p_77514_1_, int p_77514_2_, ItemStack p_77514_3_)
      {
          Item item = p_77514_3_.func_77973_b();
@@ -28,7 +26,7 @@
  
          if (i <= 0)
          {
-@@ -357,7 +359,7 @@
+@@ -357,7 +362,7 @@
      {
          List<EnchantmentData> list = Lists.<EnchantmentData>newArrayList();
          Item item = p_77513_1_.func_77973_b();
@@ -37,7 +35,7 @@
  
          if (i <= 0)
          {
-@@ -413,7 +415,7 @@
+@@ -413,7 +418,7 @@
  
          for (Enchantment enchantment : Enchantment.field_185264_b)
          {
@@ -46,7 +44,7 @@
              {
                  for (int i = enchantment.func_77325_b(); i > enchantment.func_77319_d() - 1; --i)
                  {
-@@ -429,6 +431,19 @@
+@@ -429,6 +434,19 @@
          return list;
      }
  
@@ -66,21 +64,22 @@
      static final class DamageIterator implements EnchantmentHelper.IModifier
          {
              public EntityLivingBase field_151366_a;
-@@ -482,7 +497,7 @@
+@@ -482,7 +500,8 @@
      static final class ModifierLiving implements EnchantmentHelper.IModifier
          {
              public float field_77495_a;
 -            public EnumCreatureAttribute field_77494_b;
 +            public @javax.annotation.Nullable Entity entity;
++            public @javax.annotation.Nullable EnumCreatureAttribute attribute;
  
              private ModifierLiving()
              {
-@@ -490,7 +505,7 @@
+@@ -490,7 +509,7 @@
  
              public void func_77493_a(Enchantment p_77493_1_, int p_77493_2_)
              {
 -                this.field_77495_a += p_77493_1_.func_152376_a(p_77493_2_, this.field_77494_b);
-+                this.field_77495_a += p_77493_1_.calcDamageByEntity(p_77493_2_, this.entity);
++                this.field_77495_a += attribute == null? p_77493_1_.calcDamageByEntity(p_77493_2_, this.entity):p_77493_1_.func_152376_a(p_77493_2_,attribute);//Check attribute instead of entity if set for compatibility
              }
          }
  }

--- a/patches/minecraft/net/minecraft/enchantment/EnchantmentHelper.java.patch
+++ b/patches/minecraft/net/minecraft/enchantment/EnchantmentHelper.java.patch
@@ -1,6 +1,6 @@
 --- ../src-base/minecraft/net/minecraft/enchantment/EnchantmentHelper.java
 +++ ../src-work/minecraft/net/minecraft/enchantment/EnchantmentHelper.java
-@@ -143,10 +143,12 @@
+@@ -143,11 +143,14 @@
          return field_77520_b.field_77497_a;
      }
  
@@ -12,9 +12,11 @@
 -        field_77521_c.field_77494_b = p_152377_1_;
 +        field_77521_c.attribute = p_152377_1_;
          func_77518_a(field_77521_c, p_152377_0_);
++        field_77521_c.attribute = null;
          return field_77521_c.field_77495_a;
      }
-@@ -302,7 +304,7 @@
+ 
+@@ -302,7 +305,7 @@
      public static int func_77514_a(Random p_77514_0_, int p_77514_1_, int p_77514_2_, ItemStack p_77514_3_)
      {
          Item item = p_77514_3_.func_77973_b();
@@ -23,7 +25,7 @@
  
          if (i <= 0)
          {
-@@ -357,7 +359,7 @@
+@@ -357,7 +360,7 @@
      {
          List<EnchantmentData> list = Lists.<EnchantmentData>newArrayList();
          Item item = p_77513_1_.func_77973_b();
@@ -32,7 +34,7 @@
  
          if (i <= 0)
          {
-@@ -413,7 +415,7 @@
+@@ -413,7 +416,7 @@
  
          for (Enchantment enchantment : Enchantment.field_185264_b)
          {
@@ -41,7 +43,7 @@
              {
                  for (int i = enchantment.func_77325_b(); i > enchantment.func_77319_d() - 1; --i)
                  {
-@@ -429,6 +431,26 @@
+@@ -429,6 +432,26 @@
          return list;
      }
  
@@ -68,7 +70,7 @@
      static final class DamageIterator implements EnchantmentHelper.IModifier
          {
              public EntityLivingBase field_151366_a;
-@@ -482,7 +504,8 @@
+@@ -482,7 +505,8 @@
      static final class ModifierLiving implements EnchantmentHelper.IModifier
          {
              public float field_77495_a;
@@ -78,7 +80,7 @@
  
              private ModifierLiving()
              {
-@@ -490,7 +513,7 @@
+@@ -490,7 +514,7 @@
  
              public void func_77493_a(Enchantment p_77493_1_, int p_77493_2_)
              {

--- a/patches/minecraft/net/minecraft/enchantment/EnchantmentHelper.java.patch
+++ b/patches/minecraft/net/minecraft/enchantment/EnchantmentHelper.java.patch
@@ -10,9 +10,9 @@
          field_77521_c.field_77495_a = 0.0F;
 -        field_77521_c.field_77494_b = p_152377_1_;
 -        func_77518_a(field_77521_c, p_152377_0_);
-+        field_77521_c.field_77494_b = entity;
++        field_77521_c.entity = entity;
 +        func_77518_a(field_77521_c, stack);
-+        field_77521_c.field_77494_b = null;
++        field_77521_c.entity = null;
          return field_77521_c.field_77495_a;
      }
  
@@ -48,7 +48,7 @@
          {
              public float field_77495_a;
 -            public EnumCreatureAttribute field_77494_b;
-+            public @javax.annotation.Nullable Entity field_77494_b;
++            public @javax.annotation.Nullable Entity entity;
  
              private ModifierLiving()
              {
@@ -57,7 +57,7 @@
              public void func_77493_a(Enchantment p_77493_1_, int p_77493_2_)
              {
 -                this.field_77495_a += p_77493_1_.func_152376_a(p_77493_2_, this.field_77494_b);
-+                this.field_77495_a += p_77493_1_.calcDamageByEntity(p_77493_2_, this.field_77494_b);
++                this.field_77495_a += p_77493_1_.calcDamageByEntity(p_77493_2_, this.entity);
              }
          }
  }

--- a/patches/minecraft/net/minecraft/enchantment/EnchantmentHelper.java.patch
+++ b/patches/minecraft/net/minecraft/enchantment/EnchantmentHelper.java.patch
@@ -1,10 +1,9 @@
 --- ../src-base/minecraft/net/minecraft/enchantment/EnchantmentHelper.java
 +++ ../src-work/minecraft/net/minecraft/enchantment/EnchantmentHelper.java
-@@ -143,11 +143,14 @@
+@@ -143,11 +143,13 @@
          return field_77520_b.field_77497_a;
      }
  
-+
 +    @Deprecated //Use #getModifierForCreature(ItemStack, Entity) instead
      public static float func_152377_a(ItemStack p_152377_0_, EnumCreatureAttribute p_152377_1_)
      {
@@ -15,7 +14,7 @@
          return field_77521_c.field_77495_a;
      }
  
-@@ -302,7 +305,7 @@
+@@ -302,7 +304,7 @@
      public static int func_77514_a(Random p_77514_0_, int p_77514_1_, int p_77514_2_, ItemStack p_77514_3_)
      {
          Item item = p_77514_3_.func_77973_b();
@@ -24,7 +23,7 @@
  
          if (i <= 0)
          {
-@@ -357,7 +360,7 @@
+@@ -357,7 +359,7 @@
      {
          List<EnchantmentData> list = Lists.<EnchantmentData>newArrayList();
          Item item = p_77513_1_.func_77973_b();
@@ -33,7 +32,7 @@
  
          if (i <= 0)
          {
-@@ -413,7 +416,7 @@
+@@ -413,7 +415,7 @@
  
          for (Enchantment enchantment : Enchantment.field_185264_b)
          {
@@ -42,7 +41,7 @@
              {
                  for (int i = enchantment.func_77325_b(); i > enchantment.func_77319_d() - 1; --i)
                  {
-@@ -429,6 +432,26 @@
+@@ -429,6 +431,26 @@
          return list;
      }
  
@@ -69,13 +68,13 @@
      static final class DamageIterator implements EnchantmentHelper.IModifier
          {
              public EntityLivingBase field_151366_a;
-@@ -482,7 +505,8 @@
+@@ -482,7 +504,9 @@
      static final class ModifierLiving implements EnchantmentHelper.IModifier
          {
              public float field_77495_a;
--            public EnumCreatureAttribute field_77494_b;
++            @javax.annotation.Nullable
+             public EnumCreatureAttribute field_77494_b;
 +            public @javax.annotation.Nullable Entity entity;
-+            public @javax.annotation.Nullable EnumCreatureAttribute field_77494_b;
  
              private ModifierLiving()
              {

--- a/patches/minecraft/net/minecraft/enchantment/EnchantmentHelper.java.patch
+++ b/patches/minecraft/net/minecraft/enchantment/EnchantmentHelper.java.patch
@@ -1,14 +1,11 @@
 --- ../src-base/minecraft/net/minecraft/enchantment/EnchantmentHelper.java
 +++ ../src-work/minecraft/net/minecraft/enchantment/EnchantmentHelper.java
-@@ -143,10 +143,15 @@
+@@ -143,10 +143,12 @@
          return field_77520_b.field_77497_a;
      }
  
-+    /**
-+     * Does nothing
-+     * Use {@link EnchantmentHelper#getModifierForCreature(ItemStack, Entity)} instead
-+     */
-+    @Deprecated
++
++    @Deprecated //Use #getModifierForCreature(ItemStack, Entity) instead
      public static float func_152377_a(ItemStack p_152377_0_, EnumCreatureAttribute p_152377_1_)
      {
          field_77521_c.field_77495_a = 0.0F;
@@ -17,7 +14,7 @@
          func_77518_a(field_77521_c, p_152377_0_);
          return field_77521_c.field_77495_a;
      }
-@@ -302,7 +307,7 @@
+@@ -302,7 +304,7 @@
      public static int func_77514_a(Random p_77514_0_, int p_77514_1_, int p_77514_2_, ItemStack p_77514_3_)
      {
          Item item = p_77514_3_.func_77973_b();
@@ -26,7 +23,7 @@
  
          if (i <= 0)
          {
-@@ -357,7 +362,7 @@
+@@ -357,7 +359,7 @@
      {
          List<EnchantmentData> list = Lists.<EnchantmentData>newArrayList();
          Item item = p_77513_1_.func_77973_b();
@@ -35,7 +32,7 @@
  
          if (i <= 0)
          {
-@@ -413,7 +418,7 @@
+@@ -413,7 +415,7 @@
  
          for (Enchantment enchantment : Enchantment.field_185264_b)
          {
@@ -44,12 +41,19 @@
              {
                  for (int i = enchantment.func_77325_b(); i > enchantment.func_77319_d() - 1; --i)
                  {
-@@ -429,6 +434,19 @@
+@@ -429,6 +431,26 @@
          return list;
      }
  
 +    /* ======================================== FORGE START =====================================*/
 +
++    /**
++     * Calculate the damage the enchantments of the given ItemStack add to the attack on the given entity.
++     *
++     * @param stack the itemstack used for attacking
++     * @param entity the entity being attacked
++     * @return the additional damage to do
++     */
 +    public static float getModifierForCreature(ItemStack stack, @javax.annotation.Nullable Entity entity)
 +    {
 +        field_77521_c.field_77495_a = 0.0F;
@@ -64,7 +68,7 @@
      static final class DamageIterator implements EnchantmentHelper.IModifier
          {
              public EntityLivingBase field_151366_a;
-@@ -482,7 +500,8 @@
+@@ -482,7 +504,8 @@
      static final class ModifierLiving implements EnchantmentHelper.IModifier
          {
              public float field_77495_a;
@@ -74,7 +78,7 @@
  
              private ModifierLiving()
              {
-@@ -490,7 +509,7 @@
+@@ -490,7 +513,7 @@
  
              public void func_77493_a(Enchantment p_77493_1_, int p_77493_2_)
              {

--- a/patches/minecraft/net/minecraft/enchantment/EnchantmentHelper.java.patch
+++ b/patches/minecraft/net/minecraft/enchantment/EnchantmentHelper.java.patch
@@ -9,10 +9,9 @@
      public static float func_152377_a(ItemStack p_152377_0_, EnumCreatureAttribute p_152377_1_)
      {
          field_77521_c.field_77495_a = 0.0F;
--        field_77521_c.field_77494_b = p_152377_1_;
-+        field_77521_c.attribute = p_152377_1_;
+         field_77521_c.field_77494_b = p_152377_1_;
          func_77518_a(field_77521_c, p_152377_0_);
-+        field_77521_c.attribute = null;
++        field_77521_c.field_77494_b = null;
          return field_77521_c.field_77495_a;
      }
  
@@ -76,7 +75,7 @@
              public float field_77495_a;
 -            public EnumCreatureAttribute field_77494_b;
 +            public @javax.annotation.Nullable Entity entity;
-+            public @javax.annotation.Nullable EnumCreatureAttribute attribute;
++            public @javax.annotation.Nullable EnumCreatureAttribute field_77494_b;
  
              private ModifierLiving()
              {
@@ -85,7 +84,7 @@
              public void func_77493_a(Enchantment p_77493_1_, int p_77493_2_)
              {
 -                this.field_77495_a += p_77493_1_.func_152376_a(p_77493_2_, this.field_77494_b);
-+                this.field_77495_a += attribute == null ? p_77493_1_.calcDamageByEntity(p_77493_2_, this.entity) : p_77493_1_.func_152376_a(p_77493_2_,attribute);//Check attribute instead of entity if set for compatibility
++                this.field_77495_a += field_77494_b == null ? p_77493_1_.calcDamageByEntity(p_77493_2_, this.entity) : p_77493_1_.func_152376_a(p_77493_2_,field_77494_b);//Check attribute instead of entity if set for compatibility
              }
          }
  }

--- a/patches/minecraft/net/minecraft/enchantment/EnchantmentHelper.java.patch
+++ b/patches/minecraft/net/minecraft/enchantment/EnchantmentHelper.java.patch
@@ -1,22 +1,25 @@
 --- ../src-base/minecraft/net/minecraft/enchantment/EnchantmentHelper.java
 +++ ../src-work/minecraft/net/minecraft/enchantment/EnchantmentHelper.java
-@@ -143,11 +143,12 @@
+@@ -143,12 +143,14 @@
          return field_77520_b.field_77497_a;
      }
  
--    public static float func_152377_a(ItemStack p_152377_0_, EnumCreatureAttribute p_152377_1_)
-+    public static float getModifierForCreature(ItemStack stack, @javax.annotation.Nullable Entity entity)
++    /**
++     * Does nothing
++     * Use {@link EnchantmentHelper#getModifierForCreature(ItemStack, Entity)} instead
++     */
++    @Deprecated
+     public static float func_152377_a(ItemStack p_152377_0_, EnumCreatureAttribute p_152377_1_)
      {
-         field_77521_c.field_77495_a = 0.0F;
+-        field_77521_c.field_77495_a = 0.0F;
 -        field_77521_c.field_77494_b = p_152377_1_;
 -        func_77518_a(field_77521_c, p_152377_0_);
-+        field_77521_c.entity = entity;
-+        func_77518_a(field_77521_c, stack);
-+        field_77521_c.entity = null;
-         return field_77521_c.field_77495_a;
+-        return field_77521_c.field_77495_a;
++        return 0.0F;
      }
  
-@@ -302,7 +303,7 @@
+     public static float func_191527_a(EntityLivingBase p_191527_0_)
+@@ -302,7 +304,7 @@
      public static int func_77514_a(Random p_77514_0_, int p_77514_1_, int p_77514_2_, ItemStack p_77514_3_)
      {
          Item item = p_77514_3_.func_77973_b();
@@ -25,7 +28,7 @@
  
          if (i <= 0)
          {
-@@ -357,7 +358,7 @@
+@@ -357,7 +359,7 @@
      {
          List<EnchantmentData> list = Lists.<EnchantmentData>newArrayList();
          Item item = p_77513_1_.func_77973_b();
@@ -34,7 +37,7 @@
  
          if (i <= 0)
          {
-@@ -413,7 +414,7 @@
+@@ -413,7 +415,7 @@
  
          for (Enchantment enchantment : Enchantment.field_185264_b)
          {
@@ -43,7 +46,27 @@
              {
                  for (int i = enchantment.func_77325_b(); i > enchantment.func_77319_d() - 1; --i)
                  {
-@@ -482,7 +483,7 @@
+@@ -429,6 +431,19 @@
+         return list;
+     }
+ 
++    /* ======================================== FORGE START =====================================*/
++
++    public static float getModifierForCreature(ItemStack stack, @javax.annotation.Nullable Entity entity)
++    {
++        field_77521_c.field_77495_a = 0.0F;
++        field_77521_c.entity = entity;
++        func_77518_a(field_77521_c, stack);
++        field_77521_c.entity = null;
++        return field_77521_c.field_77495_a;
++    }
++
++    /* ======================================== FORGE END =====================================*/
++
+     static final class DamageIterator implements EnchantmentHelper.IModifier
+         {
+             public EntityLivingBase field_151366_a;
+@@ -482,7 +497,7 @@
      static final class ModifierLiving implements EnchantmentHelper.IModifier
          {
              public float field_77495_a;
@@ -52,7 +75,7 @@
  
              private ModifierLiving()
              {
-@@ -490,7 +491,7 @@
+@@ -490,7 +505,7 @@
  
              public void func_77493_a(Enchantment p_77493_1_, int p_77493_2_)
              {

--- a/patches/minecraft/net/minecraft/enchantment/EnchantmentHelper.java.patch
+++ b/patches/minecraft/net/minecraft/enchantment/EnchantmentHelper.java.patch
@@ -1,6 +1,22 @@
 --- ../src-base/minecraft/net/minecraft/enchantment/EnchantmentHelper.java
 +++ ../src-work/minecraft/net/minecraft/enchantment/EnchantmentHelper.java
-@@ -302,7 +302,7 @@
+@@ -143,11 +143,12 @@
+         return field_77520_b.field_77497_a;
+     }
+ 
+-    public static float func_152377_a(ItemStack p_152377_0_, EnumCreatureAttribute p_152377_1_)
++    public static float getModifierForCreature(ItemStack stack, @javax.annotation.Nullable Entity entity)
+     {
+         field_77521_c.field_77495_a = 0.0F;
+-        field_77521_c.field_77494_b = p_152377_1_;
+-        func_77518_a(field_77521_c, p_152377_0_);
++        field_77521_c.field_77494_b = entity;
++        func_77518_a(field_77521_c, stack);
++        field_77521_c.field_77494_b = null;
+         return field_77521_c.field_77495_a;
+     }
+ 
+@@ -302,7 +303,7 @@
      public static int func_77514_a(Random p_77514_0_, int p_77514_1_, int p_77514_2_, ItemStack p_77514_3_)
      {
          Item item = p_77514_3_.func_77973_b();
@@ -9,7 +25,7 @@
  
          if (i <= 0)
          {
-@@ -357,7 +357,7 @@
+@@ -357,7 +358,7 @@
      {
          List<EnchantmentData> list = Lists.<EnchantmentData>newArrayList();
          Item item = p_77513_1_.func_77973_b();
@@ -18,7 +34,7 @@
  
          if (i <= 0)
          {
-@@ -413,7 +413,7 @@
+@@ -413,7 +414,7 @@
  
          for (Enchantment enchantment : Enchantment.field_185264_b)
          {
@@ -27,3 +43,21 @@
              {
                  for (int i = enchantment.func_77325_b(); i > enchantment.func_77319_d() - 1; --i)
                  {
+@@ -482,7 +483,7 @@
+     static final class ModifierLiving implements EnchantmentHelper.IModifier
+         {
+             public float field_77495_a;
+-            public EnumCreatureAttribute field_77494_b;
++            public @javax.annotation.Nullable Entity field_77494_b;
+ 
+             private ModifierLiving()
+             {
+@@ -490,7 +491,7 @@
+ 
+             public void func_77493_a(Enchantment p_77493_1_, int p_77493_2_)
+             {
+-                this.field_77495_a += p_77493_1_.func_152376_a(p_77493_2_, this.field_77494_b);
++                this.field_77495_a += p_77493_1_.calcDamageByEntity(p_77493_2_, this.field_77494_b);
+             }
+         }
+ }

--- a/patches/minecraft/net/minecraft/enchantment/EnchantmentHelper.java.patch
+++ b/patches/minecraft/net/minecraft/enchantment/EnchantmentHelper.java.patch
@@ -83,7 +83,7 @@
              public void func_77493_a(Enchantment p_77493_1_, int p_77493_2_)
              {
 -                this.field_77495_a += p_77493_1_.func_152376_a(p_77493_2_, this.field_77494_b);
-+                this.field_77495_a += attribute == null? p_77493_1_.calcDamageByEntity(p_77493_2_, this.entity):p_77493_1_.func_152376_a(p_77493_2_,attribute);//Check attribute instead of entity if set for compatibility
++                this.field_77495_a += attribute == null ? p_77493_1_.calcDamageByEntity(p_77493_2_, this.entity) : p_77493_1_.func_152376_a(p_77493_2_,attribute);//Check attribute instead of entity if set for compatibility
              }
          }
  }

--- a/patches/minecraft/net/minecraft/entity/monster/EntityMob.java.patch
+++ b/patches/minecraft/net/minecraft/entity/monster/EntityMob.java.patch
@@ -1,5 +1,14 @@
 --- ../src-base/minecraft/net/minecraft/entity/monster/EntityMob.java
 +++ ../src-work/minecraft/net/minecraft/entity/monster/EntityMob.java
+@@ -92,7 +92,7 @@
+ 
+         if (p_70652_1_ instanceof EntityLivingBase)
+         {
+-            f += EnchantmentHelper.func_152377_a(this.func_184614_ca(), ((EntityLivingBase)p_70652_1_).func_70668_bt());
++            f += EnchantmentHelper.getModifierForCreature(this.func_184614_ca(), p_70652_1_);
+             i += EnchantmentHelper.func_77501_a(this);
+         }
+ 
 @@ -120,13 +120,13 @@
                  ItemStack itemstack = this.func_184614_ca();
                  ItemStack itemstack1 = entityplayer.func_184587_cr() ? entityplayer.func_184607_cu() : ItemStack.field_190927_a;

--- a/patches/minecraft/net/minecraft/entity/player/EntityPlayer.java.patch
+++ b/patches/minecraft/net/minecraft/entity/player/EntityPlayer.java.patch
@@ -287,6 +287,15 @@
          if (p_71059_1_.func_70075_an())
          {
              if (!p_71059_1_.func_85031_j(this))
+@@ -1180,7 +1263,7 @@
+                 {
+                     f1 = EnchantmentHelper.func_152377_a(this.func_184614_ca(), EnumCreatureAttribute.UNDEFINED);
+                 }
+-
++                f += EnchantmentHelper.getModifierForCreature(this.func_184614_ca(), p_71059_1_);
+                 float f2 = this.func_184825_o(0.5F);
+                 f = f * (0.2F + f2 * f2 * 0.8F);
+                 f1 = f1 * f2;
 @@ -1203,9 +1286,11 @@
                      boolean flag2 = flag && this.field_70143_R > 0.0F && !this.field_70122_E && !this.func_70617_f_() && !this.func_70090_H() && !this.func_70644_a(MobEffects.field_76440_q) && !this.func_184218_aH() && p_71059_1_ instanceof EntityLivingBase;
                      flag2 = flag2 && !this.func_70051_ag();

--- a/patches/minecraft/net/minecraft/entity/player/EntityPlayer.java.patch
+++ b/patches/minecraft/net/minecraft/entity/player/EntityPlayer.java.patch
@@ -287,16 +287,15 @@
          if (p_71059_1_.func_70075_an())
          {
              if (!p_71059_1_.func_85031_j(this))
-@@ -1180,7 +1263,7 @@
-                 {
+@@ -1181,6 +1264,7 @@
                      f1 = EnchantmentHelper.func_152377_a(this.func_184614_ca(), EnumCreatureAttribute.UNDEFINED);
                  }
--
+ 
 +                f += EnchantmentHelper.getModifierForCreature(this.func_184614_ca(), p_71059_1_);
                  float f2 = this.func_184825_o(0.5F);
                  f = f * (0.2F + f2 * f2 * 0.8F);
                  f1 = f1 * f2;
-@@ -1203,9 +1286,11 @@
+@@ -1203,9 +1287,11 @@
                      boolean flag2 = flag && this.field_70143_R > 0.0F && !this.field_70122_E && !this.func_70617_f_() && !this.func_70090_H() && !this.func_70644_a(MobEffects.field_76440_q) && !this.func_184218_aH() && p_71059_1_ instanceof EntityLivingBase;
                      flag2 = flag2 && !this.func_70051_ag();
  
@@ -309,7 +308,7 @@
                      }
  
                      f = f + f1;
-@@ -1332,10 +1417,12 @@
+@@ -1332,10 +1418,12 @@
  
                          if (!itemstack1.func_190926_b() && entity instanceof EntityLivingBase)
                          {
@@ -322,7 +321,7 @@
                                  this.func_184611_a(EnumHand.MAIN_HAND, ItemStack.field_190927_a);
                              }
                          }
-@@ -1384,7 +1471,7 @@
+@@ -1384,7 +1472,7 @@
  
          if (this.field_70146_Z.nextFloat() < f)
          {
@@ -331,7 +330,7 @@
              this.func_184602_cy();
              this.field_70170_p.func_72960_a(this, (byte)30);
          }
-@@ -1442,6 +1529,8 @@
+@@ -1442,6 +1530,8 @@
  
      public EntityPlayer.SleepResult func_180469_a(BlockPos p_180469_1_)
      {
@@ -340,7 +339,7 @@
          EnumFacing enumfacing = (EnumFacing)this.field_70170_p.func_180495_p(p_180469_1_).func_177229_b(BlockHorizontal.field_185512_D);
  
          if (!this.field_70170_p.field_72995_K)
-@@ -1484,8 +1573,9 @@
+@@ -1484,8 +1574,9 @@
          this.func_192030_dh();
          this.func_70105_a(0.2F, 0.2F);
  
@@ -352,7 +351,7 @@
              float f1 = 0.5F + (float)enumfacing.func_82601_c() * 0.4F;
              float f = 0.5F + (float)enumfacing.func_82599_e() * 0.4F;
              this.func_175139_a(enumfacing);
-@@ -1532,13 +1622,14 @@
+@@ -1532,13 +1623,14 @@
  
      public void func_70999_a(boolean p_70999_1_, boolean p_70999_2_, boolean p_70999_3_)
      {
@@ -370,7 +369,7 @@
  
              if (blockpos == null)
              {
-@@ -1547,6 +1638,10 @@
+@@ -1547,6 +1639,10 @@
  
              this.func_70107_b((double)((float)blockpos.func_177958_n() + 0.5F), (double)((float)blockpos.func_177956_o() + 0.1F), (double)((float)blockpos.func_177952_p() + 0.5F));
          }
@@ -381,7 +380,7 @@
  
          this.field_71083_bS = false;
  
-@@ -1565,15 +1660,16 @@
+@@ -1565,15 +1661,16 @@
  
      private boolean func_175143_p()
      {
@@ -401,7 +400,7 @@
          {
              if (!p_180467_2_)
              {
-@@ -1588,16 +1684,17 @@
+@@ -1588,16 +1685,17 @@
          }
          else
          {
@@ -422,7 +421,7 @@
  
              switch (enumfacing)
              {
-@@ -1637,16 +1734,24 @@
+@@ -1637,16 +1735,24 @@
  
      public BlockPos func_180470_cg()
      {
@@ -449,7 +448,7 @@
          if (p_180473_1_ != null)
          {
              this.field_71077_c = p_180473_1_;
-@@ -1839,6 +1944,10 @@
+@@ -1839,6 +1945,10 @@
  
              super.func_180430_e(p_180430_1_, p_180430_2_);
          }
@@ -460,7 +459,7 @@
      }
  
      protected void func_71061_d_()
-@@ -2176,7 +2285,10 @@
+@@ -2176,7 +2286,10 @@
  
      public ITextComponent func_145748_c_()
      {
@@ -472,7 +471,7 @@
          itextcomponent.func_150256_b().func_150241_a(new ClickEvent(ClickEvent.Action.SUGGEST_COMMAND, "/msg " + this.func_70005_c_() + " "));
          itextcomponent.func_150256_b().func_150209_a(this.func_174823_aP());
          itextcomponent.func_150256_b().func_179989_a(this.func_70005_c_());
-@@ -2185,7 +2297,7 @@
+@@ -2185,7 +2298,7 @@
  
      public float func_70047_e()
      {
@@ -481,7 +480,7 @@
  
          if (this.func_70608_bn())
          {
-@@ -2421,6 +2533,168 @@
+@@ -2421,6 +2534,168 @@
          return this.field_71075_bZ.field_75098_d && this.func_70003_b(2, "");
      }
  

--- a/patches/minecraft/net/minecraft/item/ItemStack.java.patch
+++ b/patches/minecraft/net/minecraft/item/ItemStack.java.patch
@@ -220,7 +220,7 @@
                          {
                              d0 = d0 + p_82840_1_.func_110148_a(SharedMonsterAttributes.field_111264_e).func_111125_b();
 -                            d0 = d0 + (double)EnchantmentHelper.func_152377_a(this, EnumCreatureAttribute.UNDEFINED);
-+                            d0 = d0 + (double)EnchantmentHelper.getModifierForCreature(this, null);
++                            d0 = d0 + (double)EnchantmentHelper.getModifierForCreature(this, (Entity) null);
                              flag = true;
                          }
                          else if (attributemodifier.func_111167_a() == Item.field_185050_h)

--- a/patches/minecraft/net/minecraft/item/ItemStack.java.patch
+++ b/patches/minecraft/net/minecraft/item/ItemStack.java.patch
@@ -215,6 +215,15 @@
          }
      }
  
+@@ -754,7 +778,7 @@
+                         if (attributemodifier.func_111167_a() == Item.field_111210_e)
+                         {
+                             d0 = d0 + p_82840_1_.func_110148_a(SharedMonsterAttributes.field_111264_e).func_111125_b();
+-                            d0 = d0 + (double)EnchantmentHelper.func_152377_a(this, EnumCreatureAttribute.UNDEFINED);
++                            d0 = d0 + (double)EnchantmentHelper.getModifierForCreature(this, null);
+                             flag = true;
+                         }
+                         else if (attributemodifier.func_111167_a() == Item.field_185050_h)
 @@ -862,6 +886,7 @@
              }
          }

--- a/src/test/java/net/minecraftforge/debug/EnchantmentDamageTest.java
+++ b/src/test/java/net/minecraftforge/debug/EnchantmentDamageTest.java
@@ -1,0 +1,94 @@
+package net.minecraftforge.debug;
+
+import net.minecraft.enchantment.Enchantment;
+import net.minecraft.enchantment.EnumEnchantmentType;
+import net.minecraft.entity.Entity;
+import net.minecraft.entity.EnumCreatureAttribute;
+import net.minecraft.entity.monster.EntityZombie;
+import net.minecraft.inventory.EntityEquipmentSlot;
+import net.minecraftforge.event.RegistryEvent;
+import net.minecraftforge.fml.common.Mod;
+import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
+
+import javax.annotation.Nullable;
+
+/**
+ * Test for calculating enchantment damage modifier based on the entity object instead of the creature attribute.
+ * <p>
+ * HowTo Test:
+ * <p>
+ * a) Grab yourself a wooden sword and enchant it with "enchantmentdamagetest.new_enchantment"
+ * Spawn a Zombie and any other animal (e.g. a cow)
+ * The Zombie should be one hit with this sword, the cow should take multiple hits (as normal)
+ * <p>
+ * b) To verify that the old (deprecated/vanilla) way/method still works
+ * enchant a wooden sword with "enchantmentdamagetest.old_enchantment"
+ * and repeat the test with a undead creature (Zombie) and a non undead creature (cow).
+ * It should have the same result
+ */
+@Mod(modid = EnchantmentDamageTest.MODID, name = "EnchantmentDamageTest", version = "0.0.0", acceptableRemoteVersions = "*")
+@Mod.EventBusSubscriber
+public class EnchantmentDamageTest
+{
+
+    public static final boolean ENABLE = true;
+    public static final String MODID = "enchantmentdamagetest";
+
+    @SubscribeEvent
+    public static void registerEnchantment(RegistryEvent.Register<Enchantment> event)
+    {
+        if (ENABLE)
+        {
+            event.getRegistry().register(new NewEnchantment());
+            event.getRegistry().register(new OldEnchantment());
+        }
+    }
+
+    /**
+     * Only affects Zombies. Uses the new entity object based method.
+     */
+    public static class NewEnchantment extends Enchantment
+    {
+
+        protected NewEnchantment()
+        {
+            super(Rarity.RARE, EnumEnchantmentType.WEAPON, new EntityEquipmentSlot[] { EntityEquipmentSlot.MAINHAND });
+            setRegistryName(MODID, "new_enchantment");
+            setName("EnchantmentDamageTest-New");
+        }
+
+        @Override
+        public float calcDamageByEntity(int level, @Nullable Entity entity)
+        {
+            if (entity instanceof EntityZombie)
+            {
+                return 100f;
+            }
+            return 0f;
+        }
+    }
+
+    /**
+     * Only affects Zombies. Uses the old creature attribute based method.
+     */
+    public static class OldEnchantment extends Enchantment
+    {
+
+        protected OldEnchantment()
+        {
+            super(Rarity.RARE, EnumEnchantmentType.WEAPON, new EntityEquipmentSlot[] { EntityEquipmentSlot.MAINHAND });
+            setRegistryName(MODID, "old_enchantment");
+            setName("EnchantmentDamageTest-New");
+        }
+
+        @Override
+        public float calcDamageByCreature(int level, EnumCreatureAttribute creatureType)
+        {
+            if (creatureType == EnumCreatureAttribute.UNDEAD)
+            {
+                return 100f;
+            }
+            return 0f;
+        }
+    }
+}

--- a/src/test/java/net/minecraftforge/debug/EnchantmentDamageTest.java
+++ b/src/test/java/net/minecraftforge/debug/EnchantmentDamageTest.java
@@ -18,13 +18,14 @@ import javax.annotation.Nullable;
  * HowTo Test:
  * <p>
  * a) Grab yourself a wooden sword and enchant it with "enchantmentdamagetest.new_enchantment"
- * Spawn a Zombie and any other animal (e.g. a cow)
+ * Spawn a Zombie and any other creature (e.g. a cow)
  * The Zombie should be one hit with this sword, the cow should take multiple hits (as normal)
  * <p>
  * b) To verify that the old (deprecated/vanilla) way/method still works
  * enchant a wooden sword with "enchantmentdamagetest.old_enchantment"
- * and repeat the test with a undead creature (Zombie) and a non undead creature (cow).
- * It should have the same result
+ * and repeat the test with an undead creature (Zombie) and a non undead creature (cow).
+ * It should have the same result.
+ *
  */
 @Mod(modid = EnchantmentDamageTest.MODID, name = "EnchantmentDamageTest", version = "0.0.0", acceptableRemoteVersions = "*")
 @Mod.EventBusSubscriber


### PR DESCRIPTION
## Why
Enchantments are currently able to make enchanted weapons deal more damaged based on the hit entity's `EnumCreatureAttribute`.
However, it might be interesting to change this based on the entity's attributes. For example I would like to create an enchantment that only deals extra damage do vampire players, therefore I need to check the player entity's capabilities. 
I've tried to use the `Enchantment#onEntityDamaged` (attack the player again in there) for this, but this does not really work as some of the damage calculation is ignored then. Also it is called twice after attacking somehow.

## What
This PR adds an additional method (`calcDamageByEntity`), which calls the 'old' (`calcDamageByCreature`) by default, to the Enchantment class.
`EnchantmentHelper` calls the new method instead of the old one now.
Unfortunately a few more classes had be modified to pass the `Entity` parameter instead of the `EnumCreatureAttribute`.

The entity parameter can be null (ItemStacks use this to generate a damage value for the description). I've added a `Nullable` annotation to make this clear.

## Addendum
I was not sure if I should deprecate the `calcDamageByCreature` method as it might still be interesting for modders to override, but should not be called. (While writing this I decided that it would probably be a good idea)

Also not sure about commenting in patches, so I only added ones where they are necessary.

