### PR TITLE
Added isHostileTo method to EntityLivingBase

### DIFF
--- a/patches/minecraft/net/minecraft/entity/EntityLivingBase.java.patch
+++ b/patches/minecraft/net/minecraft/entity/EntityLivingBase.java.patch
@@ -375,3 +375,23 @@
      public boolean func_190631_cK()
      {
          return true;
+@@ -2861,4 +2957,19 @@
+     public void func_191987_a(BlockPos p_191987_1_, boolean p_191987_2_)
+     {
+     }
++
++    /* ================================== Forge Start =====================================*/
++    /**
++     * If this entity is hostile towards the given subject in general.
++     * This does not reflect the entity's AI behaviour exactly nor does it respect things like HurtByTarget or Scoreboard Teams.
++     * This is meant to give you an idea what this entity might do and should be more specific than checks like 'entity instanceof IMob'
++     *
++     * @return If this entity is hostile towards the given entity
++     */
++    public boolean isHostileTo(EntityLivingBase subject)
++    {
++        return this instanceof net.minecraft.entity.monster.IMob && subject instanceof net.minecraft.entity.player.EntityPlayer;
++    }
++    /* ================================== Forge End =====================================*/
++
+ }

--- a/patches/minecraft/net/minecraft/entity/EntityLivingBase.java.patch
+++ b/patches/minecraft/net/minecraft/entity/EntityLivingBase.java.patch
@@ -375,7 +375,7 @@
      public boolean func_190631_cK()
      {
          return true;
-@@ -2861,4 +2957,19 @@
+@@ -2861,4 +2957,20 @@
      public void func_191987_a(BlockPos p_191987_1_, boolean p_191987_2_)
      {
      }
@@ -383,12 +383,13 @@
 +    /* ================================== Forge Start =====================================*/
 +    /**
 +     * If this entity is hostile towards the given subject in general.
-+     * This does not reflect the entity's AI behaviour exactly nor does it respect things like HurtByTarget or Scoreboard Teams.
++     * This does not exactly reflect the entity's AI behaviour nor does it respect things like HurtByTarget or Scoreboard Teams.
 +     * This is meant to give you an idea what this entity might do and should be more specific than checks like 'entity instanceof IMob'
 +     *
++     * If you do not have a entity instance you can check against, you can pass null, though the result will be rather unspecific, only saying if the entity is a hostile character or not.
 +     * @return If this entity is hostile towards the given entity
 +     */
-+    public boolean isHostileTo(EntityLivingBase subject)
++    public boolean isHostileTo(@javax.annotation.Nullable EntityLivingBase subject)
 +    {
 +        return this instanceof net.minecraft.entity.monster.IMob && subject instanceof net.minecraft.entity.player.EntityPlayer;
 +    }

--- a/patches/minecraft/net/minecraft/entity/EntityLivingBase.java.patch
+++ b/patches/minecraft/net/minecraft/entity/EntityLivingBase.java.patch
@@ -391,7 +391,7 @@
 +     */
 +    public boolean isHostileTo(@javax.annotation.Nullable EntityLivingBase subject)
 +    {
-+        return this instanceof net.minecraft.entity.monster.IMob && subject instanceof net.minecraft.entity.player.EntityPlayer;
++        return this instanceof net.minecraft.entity.monster.IMob && ( subject == null || subject instanceof net.minecraft.entity.player.EntityPlayer);
 +    }
 +    /* ================================== Forge End =====================================*/
 +

--- a/patches/minecraft/net/minecraft/entity/monster/AbstractIllager.java.patch
+++ b/patches/minecraft/net/minecraft/entity/monster/AbstractIllager.java.patch
@@ -5,7 +5,7 @@
      }
  
 +    /* ================================== Forge Start =====================================*/
-+    public boolean isHostileTo(net.minecraft.entity.EntityLivingBase subject)
++    public boolean isHostileTo(@javax.annotation.Nullable net.minecraft.entity.EntityLivingBase subject)
 +    {
 +        return subject instanceof net.minecraft.entity.player.EntityPlayer || subject instanceof net.minecraft.entity.passive.EntityVillager || subject instanceof EntityIronGolem;
 +    }

--- a/patches/minecraft/net/minecraft/entity/monster/AbstractIllager.java.patch
+++ b/patches/minecraft/net/minecraft/entity/monster/AbstractIllager.java.patch
@@ -1,0 +1,16 @@
+--- ../src-base/minecraft/net/minecraft/entity/monster/AbstractIllager.java
++++ ../src-work/minecraft/net/minecraft/entity/monster/AbstractIllager.java
+@@ -57,6 +57,13 @@
+         return AbstractIllager.IllagerArmPose.CROSSED;
+     }
+ 
++    /* ================================== Forge Start =====================================*/
++    public boolean isHostileTo(net.minecraft.entity.EntityLivingBase subject)
++    {
++        return subject instanceof net.minecraft.entity.player.EntityPlayer || subject instanceof net.minecraft.entity.passive.EntityVillager || subject instanceof EntityIronGolem;
++    }
++    /* ================================== Forge END =======================================*/
++
+     @SideOnly(Side.CLIENT)
+     public static enum IllagerArmPose
+     {

--- a/patches/minecraft/net/minecraft/entity/monster/AbstractIllager.java.patch
+++ b/patches/minecraft/net/minecraft/entity/monster/AbstractIllager.java.patch
@@ -7,7 +7,7 @@
 +    /* ================================== Forge Start =====================================*/
 +    public boolean isHostileTo(@javax.annotation.Nullable net.minecraft.entity.EntityLivingBase subject)
 +    {
-+        return subject instanceof net.minecraft.entity.player.EntityPlayer || subject instanceof net.minecraft.entity.passive.EntityVillager || subject instanceof EntityIronGolem;
++        return subject == null || subject instanceof net.minecraft.entity.player.EntityPlayer || subject instanceof net.minecraft.entity.passive.EntityVillager || subject instanceof EntityIronGolem;
 +    }
 +    /* ================================== Forge END =======================================*/
 +

--- a/patches/minecraft/net/minecraft/entity/monster/EntityZombie.java.patch
+++ b/patches/minecraft/net/minecraft/entity/monster/EntityZombie.java.patch
@@ -72,7 +72,7 @@
 +    /* ================================== Forge Start =====================================*/
 +    public boolean isHostileTo(@javax.annotation.Nullable EntityLivingBase subject)
 +    {
-+        return subject instanceof EntityPlayer || subject instanceof EntityVillager || subject instanceof EntityIronGolem;
++        return subject == null || subject instanceof EntityPlayer || subject instanceof EntityVillager || subject instanceof EntityIronGolem;
 +    }
 +    /* ================================== Forge END =======================================*/
 +

--- a/patches/minecraft/net/minecraft/entity/monster/EntityZombie.java.patch
+++ b/patches/minecraft/net/minecraft/entity/monster/EntityZombie.java.patch
@@ -65,3 +65,17 @@
          }
  
          if (p_180482_2_ instanceof EntityZombie.GroupData)
+@@ -555,6 +567,13 @@
+         return new ItemStack(Items.field_151144_bL, 1, 2);
+     }
+ 
++    /* ================================== Forge Start =====================================*/
++    public boolean isHostileTo(EntityLivingBase subject)
++    {
++        return subject instanceof EntityPlayer || subject instanceof EntityVillager || subject instanceof EntityIronGolem;
++    }
++    /* ================================== Forge END =======================================*/
++
+     class GroupData implements IEntityLivingData
+     {
+         public boolean field_142048_a;

--- a/patches/minecraft/net/minecraft/entity/monster/EntityZombie.java.patch
+++ b/patches/minecraft/net/minecraft/entity/monster/EntityZombie.java.patch
@@ -70,7 +70,7 @@
      }
  
 +    /* ================================== Forge Start =====================================*/
-+    public boolean isHostileTo(EntityLivingBase subject)
++    public boolean isHostileTo(@javax.annotation.Nullable EntityLivingBase subject)
 +    {
 +        return subject instanceof EntityPlayer || subject instanceof EntityVillager || subject instanceof EntityIronGolem;
 +    }

--- a/patches/minecraft/net/minecraft/entity/passive/EntityRabbit.java.patch
+++ b/patches/minecraft/net/minecraft/entity/passive/EntityRabbit.java.patch
@@ -5,7 +5,7 @@
      }
  
 +    /* ================================== Forge Start =====================================*/
-+    public boolean isHostileTo(EntityLivingBase subject)
++    public boolean isHostileTo(@javax.annotation.Nullable EntityLivingBase subject)
 +    {
 +        return this.func_175531_cl()==99&& (subject instanceof EntityPlayer || subject instanceof EntityWolf);
 +    }

--- a/patches/minecraft/net/minecraft/entity/passive/EntityRabbit.java.patch
+++ b/patches/minecraft/net/minecraft/entity/passive/EntityRabbit.java.patch
@@ -7,7 +7,7 @@
 +    /* ================================== Forge Start =====================================*/
 +    public boolean isHostileTo(@javax.annotation.Nullable EntityLivingBase subject)
 +    {
-+        return this.func_175531_cl()==99&& (subject instanceof EntityPlayer || subject instanceof EntityWolf);
++        return this.func_175531_cl()==99 && (subject == null || subject instanceof EntityPlayer || subject instanceof EntityWolf);
 +    }
 +    /* ================================== Forge END =======================================*/
 +

--- a/patches/minecraft/net/minecraft/entity/passive/EntityRabbit.java.patch
+++ b/patches/minecraft/net/minecraft/entity/passive/EntityRabbit.java.patch
@@ -1,0 +1,16 @@
+--- ../src-base/minecraft/net/minecraft/entity/passive/EntityRabbit.java
++++ ../src-work/minecraft/net/minecraft/entity/passive/EntityRabbit.java
+@@ -489,6 +489,13 @@
+         }
+     }
+ 
++    /* ================================== Forge Start =====================================*/
++    public boolean isHostileTo(EntityLivingBase subject)
++    {
++        return this.func_175531_cl()==99&& (subject instanceof EntityPlayer || subject instanceof EntityWolf);
++    }
++    /* ================================== Forge END =======================================*/
++
+     static class AIAvoidEntity<T extends Entity> extends EntityAIAvoidEntity<T>
+         {
+             private final EntityRabbit field_179511_d;

--- a/patches/minecraft/net/minecraft/entity/passive/EntityTameable.java.patch
+++ b/patches/minecraft/net/minecraft/entity/passive/EntityTameable.java.patch
@@ -1,0 +1,8 @@
+--- ../src-base/minecraft/net/minecraft/entity/passive/EntityTameable.java
++++ ../src-work/minecraft/net/minecraft/entity/passive/EntityTameable.java
+@@ -272,4 +272,5 @@
+ 
+         super.func_70645_a(p_70645_1_);
+     }
++
+ }

--- a/patches/minecraft/net/minecraft/entity/passive/EntityTameable.java.patch
+++ b/patches/minecraft/net/minecraft/entity/passive/EntityTameable.java.patch
@@ -1,8 +1,0 @@
---- ../src-base/minecraft/net/minecraft/entity/passive/EntityTameable.java
-+++ ../src-work/minecraft/net/minecraft/entity/passive/EntityTameable.java
-@@ -272,4 +272,5 @@
- 
-         super.func_70645_a(p_70645_1_);
-     }
-+
- }

--- a/patches/minecraft/net/minecraft/entity/passive/EntityWolf.java.patch
+++ b/patches/minecraft/net/minecraft/entity/passive/EntityWolf.java.patch
@@ -16,7 +16,7 @@
 +    /* ================================== Forge Start =====================================*/
 +    public boolean isHostileTo(@javax.annotation.Nullable EntityLivingBase subject)
 +    {
-+        return subject instanceof AbstractSkeleton || (!this.func_70909_n()&&subject instanceof EntityAnimal);
++        return subject instanceof AbstractSkeleton || (!this.func_70909_n() && subject instanceof EntityAnimal);
 +    }
 +    /* ================================== Forge END =======================================*/
 +

--- a/patches/minecraft/net/minecraft/entity/passive/EntityWolf.java.patch
+++ b/patches/minecraft/net/minecraft/entity/passive/EntityWolf.java.patch
@@ -9,3 +9,17 @@
                  {
                      this.func_193101_c(p_184645_1_);
                      this.field_70699_by.func_75499_g();
+@@ -615,6 +615,13 @@
+         return !this.func_70919_bu() && super.func_184652_a(p_184652_1_);
+     }
+ 
++    /* ================================== Forge Start =====================================*/
++    public boolean isHostileTo(EntityLivingBase subject)
++    {
++        return subject instanceof AbstractSkeleton || (!this.func_70909_n()&&subject instanceof EntityAnimal);
++    }
++    /* ================================== Forge END =======================================*/
++
+     class AIAvoidEntity<T extends Entity> extends EntityAIAvoidEntity<T>
+     {
+         private final EntityWolf field_190856_d;

--- a/patches/minecraft/net/minecraft/entity/passive/EntityWolf.java.patch
+++ b/patches/minecraft/net/minecraft/entity/passive/EntityWolf.java.patch
@@ -14,7 +14,7 @@
      }
  
 +    /* ================================== Forge Start =====================================*/
-+    public boolean isHostileTo(EntityLivingBase subject)
++    public boolean isHostileTo(@javax.annotation.Nullable EntityLivingBase subject)
 +    {
 +        return subject instanceof AbstractSkeleton || (!this.func_70909_n()&&subject instanceof EntityAnimal);
 +    }

--- a/patches/minecraft/net/minecraft/entity/player/EntityPlayer.java.patch
+++ b/patches/minecraft/net/minecraft/entity/player/EntityPlayer.java.patch
@@ -424,7 +424,7 @@
  
          if (this.func_70608_bn())
          {
-@@ -2421,6 +2528,168 @@
+@@ -2421,6 +2528,172 @@
          return this.field_71075_bZ.field_75098_d && this.func_70003_b(2, "");
      }
  
@@ -588,6 +588,10 @@
 +    public int getSpawnDimension() { return spawnDimension != null ? spawnDimension : 0; }
 +    public void setSpawnDimension(@Nullable Integer dimension) { this.spawnDimension = dimension; }
 +
++    public boolean isHostileTo(EntityLivingBase subject)
++    {
++        return subject instanceof net.minecraft.entity.monster.IMob;
++    }
 +    /* ======================================== FORGE END  =====================================*/
 +
      public static enum EnumChatVisibility

--- a/patches/minecraft/net/minecraft/entity/player/EntityPlayer.java.patch
+++ b/patches/minecraft/net/minecraft/entity/player/EntityPlayer.java.patch
@@ -588,7 +588,7 @@
 +    public int getSpawnDimension() { return spawnDimension != null ? spawnDimension : 0; }
 +    public void setSpawnDimension(@Nullable Integer dimension) { this.spawnDimension = dimension; }
 +
-+    public boolean isHostileTo(EntityLivingBase subject)
++    public boolean isHostileTo(@javax.annotation.Nullable EntityLivingBase subject)
 +    {
 +        return subject instanceof net.minecraft.entity.monster.IMob;
 +    }


### PR DESCRIPTION
This patch adds a `isHostileTo(EntityLivingBase)` method to `EntityLivingBase`
Looking for feedback.

## Why
Minecraft has a rather simple 'faction'/'hostile' system. Besides a few individual opponents (e.g. Zombies -> Villagers), basically, there are mobs which attack the player and there are passive animals which do nothing.  
However, some mods would like to extend beyond this system. For example my mod Vampirism adds a vampire and a vampire hunter faction in addition to the standard 'IMob faction', with both, players and mobs, being able to play on both sides. 
But since Minecraft cannot distinguish any further, there are, for example, many mods which add some kind of defensive gadget (like turrets or minions ...) and check for possible attack targets by instanceof IMob.

For my mod this means, that your friendly neighborhood vampire hunter, who protects your house against vampires, is attacked by your turret (if my entities implement IMob) or (if they don't) the turret does not care about the vampire that is trying to suck your blood. (Or the other way around if you are a vampire yourself)

## What
This PR adds a `isHostileTo(EntityLivingBase)` method to `EntityLivingBase`and overrides the default behaviuor for some special entities (Wolf, Zombie ...)
From JavaDoc:

>    If this entity is hostile towards the given subject in general.
This does not reflect the entity's AI behaviour exactly nor does it respect things like HurtByTarget or Scoreboard Teams.
This is meant to give you an idea what this entity might do and should be more specific than checks like 'entity instanceof IMob'

> If you do not have a entity instance you can check against, you can pass null, though the result will be rather unspecific, only saying if the entity is a hostile character or not.


Thereby other mods have a more exact way of telling if a entity is hostile towards the owner of a turret or minion and if it should be attacked. 
It's not always exact, but I think the only way to find out exactly what the entity would do, is to wait if it attacks.

## Problem
1) Due to the few individual enmities (Zombies-> Villagers, Wolf->Animal) there a few more patches required to reflect this.
2) Mods which change the AI of vanilla entities to attack more/less entity types can't modify the result of the added method

### Possible solutions?
1) Restrict the argument to EntityPlayer. This would require less patches, but would restrict the use cases of this method. 
2) Think of some kind of registration system, but I think that would become to complex.


Thank you for taking your time and reading through this. Looking forward to feedback