### PR TITLE
[WIP] Make "static access" language independent.

### DIFF
--- a/src/main/java/net/minecraftforge/fml/common/AutomaticEventSubscriber.java
+++ b/src/main/java/net/minecraftforge/fml/common/AutomaticEventSubscriber.java
@@ -40,7 +40,7 @@ import java.util.Set;
 public class AutomaticEventSubscriber
 {
     private static final EnumSet<Side> DEFAULT = EnumSet.allOf(Side.class);
-    public static void inject(ModContainer mod, ASMDataTable data, Side side)
+    public static void inject(ModContainer mod, ASMDataTable data, Side side, ILanguageAdapter langAdapter)
     {
         FMLLog.log.debug("Attempting to inject @EventBusSubscriber classes into the eventbus for {}", mod.getModId());
         SetMultimap<String, ASMData> modData = data.getAnnotationsFor(mod);
@@ -79,7 +79,7 @@ public class AutomaticEventSubscriber
                     }
                     FMLLog.log.debug("Registering @EventBusSubscriber for {} for mod {}", targ.getClassName(), mod.getModId());
                     Class<?> subscriptionTarget = Class.forName(targ.getClassName(), true, mcl);
-                    MinecraftForge.EVENT_BUS.register(subscriptionTarget);
+                    MinecraftForge.EVENT_BUS.register(langAdapter.getStaticContainer(subscriptionTarget, mcl).getInstance());
                     FMLLog.log.debug("Injected @EventBusSubscriber class {}", targ.getClassName());
                 }
             }

--- a/src/main/java/net/minecraftforge/fml/common/FMLModContainer.java
+++ b/src/main/java/net/minecraftforge/fml/common/FMLModContainer.java
@@ -622,7 +622,7 @@ public class FMLModContainer implements ModContainer
                 eventBus.post(new FMLFingerprintViolationEvent(source.isDirectory(), source, ImmutableSet.copyOf(this.sourceFingerprints), expectedFingerprint));
             }
             ProxyInjector.inject(this, event.getASMHarvestedData(), FMLCommonHandler.instance().getSide(), getLanguageAdapter());
-            AutomaticEventSubscriber.inject(this, event.getASMHarvestedData(), FMLCommonHandler.instance().getSide());
+            AutomaticEventSubscriber.inject(this, event.getASMHarvestedData(), FMLCommonHandler.instance().getSide(), languageAdapter);
             ConfigManager.sync(this.getModId(), Config.Type.INSTANCE);
 
             processFieldAnnotations(event.getASMHarvestedData());

--- a/src/main/java/net/minecraftforge/fml/common/ILanguageAdapter.java
+++ b/src/main/java/net/minecraftforge/fml/common/ILanguageAdapter.java
@@ -23,6 +23,7 @@ import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 
+import net.minecraftforge.fml.common.langsupport.IStaticContainer;
 import net.minecraftforge.fml.relauncher.Side;
 
 import org.apache.logging.log4j.Level;
@@ -32,6 +33,11 @@ public interface ILanguageAdapter {
     public boolean supportsStatics();
     public void setProxy(Field target, Class<?> proxyTarget, Object proxy) throws IllegalArgumentException, IllegalAccessException, NoSuchFieldException, SecurityException;
     public void setInternalProxies(ModContainer mod, Side side, ClassLoader loader);
+
+    default public IStaticContainer getStaticContainer(Class<?> clazz, ClassLoader classLoader) throws ClassNotFoundException, NoSuchFieldException, IllegalAccessException
+    {
+        return new IStaticContainer.ClassStaticContainer(clazz);
+    }
 
     public static class ScalaAdapter implements ILanguageAdapter {
         @Override

--- a/src/main/java/net/minecraftforge/fml/common/langsupport/IPropertyWrapper.java
+++ b/src/main/java/net/minecraftforge/fml/common/langsupport/IPropertyWrapper.java
@@ -54,6 +54,10 @@ public interface IPropertyWrapper
                 field.setAccessible(true);
                 removedAccessRestrictions = true;
             }
+            if (ignoreFinal)
+            {
+                removeFinal();
+            }
             if (reflectionFactory == null)
             {
                 Method getReflectionFactory = Class.forName("sun.reflect.ReflectionFactory").getDeclaredMethod("getReflectionFactory");

--- a/src/main/java/net/minecraftforge/fml/common/langsupport/IPropertyWrapper.java
+++ b/src/main/java/net/minecraftforge/fml/common/langsupport/IPropertyWrapper.java
@@ -1,0 +1,61 @@
+package net.minecraftforge.fml.common.langsupport;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Field;
+
+public interface IPropertyWrapper
+{
+    String getName();
+
+    Class<?> getType();
+
+    void set(Object value, boolean ignoreAccess) throws IllegalAccessException;
+
+    void get() throws IllegalAccessException;
+
+    boolean isAnnotationPresent(Class<? extends Annotation> annotationClass);
+
+    class FieldWrapper implements IPropertyWrapper
+    {
+        private Object instance;
+        private final Field field;
+
+        public FieldWrapper(Field field, Object instance)
+        {
+            this.field = field;
+            this.instance = instance;
+        }
+
+        @Override
+        public String getName()
+        {
+            return field.getName();
+        }
+
+        @Override
+        public Class<?> getType()
+        {
+            return field.getType();
+        }
+
+        @Override
+        public void set(Object value, boolean ignoreAccess) throws IllegalAccessException
+        {
+            if (ignoreAccess)
+                field.setAccessible(true);
+            field.set(instance, value);
+        }
+
+        @Override
+        public void get() throws IllegalAccessException
+        {
+            field.get(instance);
+        }
+
+        @Override
+        public boolean isAnnotationPresent(Class<? extends Annotation> annotationClass)
+        {
+            return field.isAnnotationPresent(annotationClass);
+        }
+    }
+}

--- a/src/main/java/net/minecraftforge/fml/common/langsupport/IPropertyWrapper.java
+++ b/src/main/java/net/minecraftforge/fml/common/langsupport/IPropertyWrapper.java
@@ -2,6 +2,8 @@ package net.minecraftforge.fml.common.langsupport;
 
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
 
 public interface IPropertyWrapper
 {
@@ -9,16 +11,22 @@ public interface IPropertyWrapper
 
     Class<?> getType();
 
-    void set(Object value, boolean ignoreAccess) throws IllegalAccessException;
+    void set(Object value, boolean ignoreAccess, boolean ignoreFinal) throws ReflectiveOperationException;
 
-    void get() throws IllegalAccessException;
+    Object get(boolean ignoreAccess) throws ReflectiveOperationException;
 
     boolean isAnnotationPresent(Class<? extends Annotation> annotationClass);
 
     class FieldWrapper implements IPropertyWrapper
     {
+        private static Field modifiersField;
+        private static Object reflectionFactory;
+        private static Method newFieldAccessor;
+        private static Method fieldAccessorSet;
         private Object instance;
         private final Field field;
+        private boolean removedAccessRestrictions;
+        private boolean removedFinal;
 
         public FieldWrapper(Field field, Object instance)
         {
@@ -39,23 +47,51 @@ public interface IPropertyWrapper
         }
 
         @Override
-        public void set(Object value, boolean ignoreAccess) throws IllegalAccessException
+        public void set(Object value, boolean ignoreAccess, boolean ignoreFinal) throws ReflectiveOperationException
         {
-            if (ignoreAccess)
+            if (ignoreAccess && !removedAccessRestrictions)
+            {
                 field.setAccessible(true);
-            field.set(instance, value);
+                removedAccessRestrictions = true;
+            }
+            if (reflectionFactory == null)
+            {
+                Method getReflectionFactory = Class.forName("sun.reflect.ReflectionFactory").getDeclaredMethod("getReflectionFactory");
+                reflectionFactory = getReflectionFactory.invoke(null);
+                newFieldAccessor = Class.forName("sun.reflect.ReflectionFactory").getDeclaredMethod("newFieldAccessor", Field.class, boolean.class);
+                fieldAccessorSet = Class.forName("sun.reflect.FieldAccessor").getDeclaredMethod("set", Object.class, Object.class);
+            }
+            Object fieldAccessor = newFieldAccessor.invoke(reflectionFactory, field, false);
+            fieldAccessorSet.invoke(fieldAccessor, instance, value);
         }
 
         @Override
-        public void get() throws IllegalAccessException
+        public Object get(boolean ignoreAccess) throws ReflectiveOperationException
         {
-            field.get(instance);
+            if (ignoreAccess && !removedAccessRestrictions)
+            {
+                field.setAccessible(true);
+                removedAccessRestrictions = true;
+            }
+            return field.get(instance);
         }
 
         @Override
         public boolean isAnnotationPresent(Class<? extends Annotation> annotationClass)
         {
             return field.isAnnotationPresent(annotationClass);
+        }
+
+        private void removeFinal() throws ReflectiveOperationException {
+            if (removedFinal)
+                return;
+            if (modifiersField == null)
+            {
+                modifiersField = Field.class.getDeclaredField("modifiers");
+                modifiersField.setAccessible(true);
+            }
+            removedFinal = true;
+            modifiersField.setInt(field, field.getModifiers() & ~Modifier.FINAL);
         }
     }
 }

--- a/src/main/java/net/minecraftforge/fml/common/langsupport/IStaticContainer.java
+++ b/src/main/java/net/minecraftforge/fml/common/langsupport/IStaticContainer.java
@@ -51,7 +51,7 @@ public interface IStaticContainer
         public IPropertyWrapper getProperty(String name)
         {
             buildPropertyMap();
-            return null;
+            return properties.get(name);
         }
 
         @Nonnull

--- a/src/main/java/net/minecraftforge/fml/common/langsupport/IStaticContainer.java
+++ b/src/main/java/net/minecraftforge/fml/common/langsupport/IStaticContainer.java
@@ -1,0 +1,119 @@
+package net.minecraftforge.fml.common.langsupport;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
+import java.util.HashMap;
+import java.util.Map;
+
+public interface IStaticContainer
+{
+    @Nonnull
+    Object getInstance();
+
+    @Nonnull
+    Class<?> getType();
+
+    @Nullable
+    IPropertyWrapper getProperty(String name);
+
+    @Nonnull
+    Iterable<IPropertyWrapper> getProperties();
+
+    class ClassStaticContainer implements IStaticContainer
+    {
+        private final Class<?> clazz;
+        private Map<String, IPropertyWrapper> properties;
+
+        public ClassStaticContainer(Class<?> clazz)
+        {
+            this.clazz = clazz;
+            this.properties = new HashMap<>();
+        }
+
+        @Nonnull
+        @Override
+        public Object getInstance()
+        {
+            return clazz;
+        }
+
+        @Nonnull
+        @Override
+        public Class<?> getType()
+        {
+            return clazz;
+        }
+
+        @Nullable
+        @Override
+        public IPropertyWrapper getProperty(String name)
+        {
+            buildPropertyMap();
+            return null;
+        }
+
+        @Nonnull
+        @Override
+        public Iterable<IPropertyWrapper> getProperties()
+        {
+            buildPropertyMap();
+            return properties.values();
+        }
+
+        protected void buildPropertyMap()
+        {
+            if (properties == null)
+            {
+                for (Field field : clazz.getDeclaredFields())
+                {
+                    if (isValidField(field))
+                    {
+                        properties.put(field.getName(), new IPropertyWrapper.FieldWrapper(field, getFieldHolder()));
+                    }
+                }
+            }
+        }
+
+        protected Object getFieldHolder()
+        {
+            return null;
+        }
+
+        protected boolean isValidField(Field field)
+        {
+            return Modifier.isStatic(field.getModifiers());
+        }
+    }
+
+    class SingletonStaticContainer extends ClassStaticContainer
+    {
+        private final Object singleton;
+
+        public SingletonStaticContainer(Object singleton)
+        {
+            super(singleton.getClass());
+            this.singleton = singleton;
+        }
+
+        @Nonnull
+        @Override
+        public Object getInstance()
+        {
+            return singleton;
+        }
+
+        @Override
+        protected Object getFieldHolder()
+        {
+            return singleton;
+        }
+
+        @Override
+        protected boolean isValidField(Field field)
+        {
+            return !Modifier.isStatic(field.getModifiers());
+        }
+    }
+}

--- a/src/main/java/net/minecraftforge/registries/ObjectHolderRegistry.java
+++ b/src/main/java/net/minecraftforge/registries/ObjectHolderRegistry.java
@@ -27,7 +27,9 @@ import java.util.Set;
 
 import net.minecraft.util.ResourceLocation;
 import net.minecraftforge.fml.common.FMLLog;
+import net.minecraftforge.fml.common.Loader;
 import net.minecraftforge.fml.common.Mod;
+import net.minecraftforge.fml.common.ModContainer;
 import net.minecraftforge.fml.common.discovery.ASMDataTable;
 import net.minecraftforge.fml.common.discovery.ASMDataTable.ASMData;
 import net.minecraftforge.fml.common.registry.GameRegistry;


### PR DESCRIPTION
This is an updated version of #3769, hopefully addressing any concerns introduced with the previous version. I'd obviously like this to get merged before Wednesday since this PR introduces some binary incompatible changes. Since we have access to Java 8 features now, existing language adapters should not be affected.

Implementation-wise I opted for providing a custom "reflection" API that wraps around the concept of "properties", with a default implementation that directly uses fields. This shoud allow for maximum flexibility and ease of use for other languages which might ship their own reflection facilities (e.g. Kotlin).

I'm open to suggestions for better names for the introduced interfaces and classes. `IStaticContainer` and `IPropertyWrapper` don't sound that nice. I personally would opt for `IModule` as a replacement for `IStaticContainer`, since that concept from the ML language of families (iirc) is what `object`s in Scala and Kotlin are based on.

*Note*: I'd like this PR to be merged in conjunction with #4029, considering they both affect language support in Forge. It's also the reason why I didn't change the Scala adapter in this iteration.

Implemented usages:
- [x] `@AutomaticEventSubscriber`
- [ ] Annotation-based config system (this needs some consideration, maybe `Config.Type` could be expanded, alternatively, the type could be replaced by the definition of some "loader" class)
- [ ] `@ObjectHolder` injection, which would need some way of getting a mod context in order to retrieve a language adapter or providing a custom "injector" (via a parameter to the annotation, for instance)