### PR TITLE
[1.12] Add isSpawner parameter to the CheckSpawn event

### DIFF
--- a/patches/minecraft/net/minecraft/world/WorldEntitySpawner.java.patch
+++ b/patches/minecraft/net/minecraft/world/WorldEntitySpawner.java.patch
@@ -34,7 +34,7 @@
                                                  entityliving.func_70012_b((double)f, (double)i3, (double)f1, p_77192_1_.field_73012_v.nextFloat() * 360.0F, 0.0F);
  
 -                                                if (entityliving.func_70601_bi() && entityliving.func_70058_J())
-+                                                net.minecraftforge.fml.common.eventhandler.Event.Result canSpawn = net.minecraftforge.event.ForgeEventFactory.canEntitySpawn(entityliving, p_77192_1_, f, i3, f1);
++                                                net.minecraftforge.fml.common.eventhandler.Event.Result canSpawn = net.minecraftforge.event.ForgeEventFactory.canEntitySpawn(entityliving, p_77192_1_, f, i3, f1, false);
 +                                                if (canSpawn == net.minecraftforge.fml.common.eventhandler.Event.Result.ALLOW || (canSpawn == net.minecraftforge.fml.common.eventhandler.Event.Result.DEFAULT && (entityliving.func_70601_bi() && entityliving.func_70058_J())))
                                                  {
 +                                                    if (!net.minecraftforge.event.ForgeEventFactory.doSpecialSpawn(entityliving, p_77192_1_, f, i3, f1))

--- a/src/main/java/net/minecraftforge/event/ForgeEventFactory.java
+++ b/src/main/java/net/minecraftforge/event/ForgeEventFactory.java
@@ -169,6 +169,12 @@ public class ForgeEventFactory
         MinecraftForge.EVENT_BUS.post(new PlayerDestroyItemEvent(player, stack, hand));
     }
 
+    @Deprecated
+    public static Result canEntitySpawn(EntityLiving entity, World world, float x, float y, float z)
+    {
+        return canEntitySpawn(entity, world, x, y, z, true);
+    }
+
     public static Result canEntitySpawn(EntityLiving entity, World world, float x, float y, float z, boolean isSpawner)
     {
         if (entity == null)

--- a/src/main/java/net/minecraftforge/event/ForgeEventFactory.java
+++ b/src/main/java/net/minecraftforge/event/ForgeEventFactory.java
@@ -169,18 +169,18 @@ public class ForgeEventFactory
         MinecraftForge.EVENT_BUS.post(new PlayerDestroyItemEvent(player, stack, hand));
     }
 
-    public static Result canEntitySpawn(EntityLiving entity, World world, float x, float y, float z)
+    public static Result canEntitySpawn(EntityLiving entity, World world, float x, float y, float z, boolean isSpawner)
     {
         if (entity == null)
             return Result.DEFAULT;
-        LivingSpawnEvent.CheckSpawn event = new LivingSpawnEvent.CheckSpawn(entity, world, x, y, z);
+        LivingSpawnEvent.CheckSpawn event = new LivingSpawnEvent.CheckSpawn(entity, world, x, y, z, isSpawner);
         MinecraftForge.EVENT_BUS.post(event);
         return event.getResult();
     }
 
     public static boolean canEntitySpawnSpawner(EntityLiving entity, World world, float x, float y, float z)
     {
-        Result result = canEntitySpawn(entity, world, x, y, z);
+        Result result = canEntitySpawn(entity, world, x, y, z, true);
         if (result == Result.DEFAULT)
         {
             return entity.getCanSpawnHere() && entity.isNotColliding(); // vanilla logic

--- a/src/main/java/net/minecraftforge/event/ForgeEventFactory.java
+++ b/src/main/java/net/minecraftforge/event/ForgeEventFactory.java
@@ -169,12 +169,6 @@ public class ForgeEventFactory
         MinecraftForge.EVENT_BUS.post(new PlayerDestroyItemEvent(player, stack, hand));
     }
 
-    @Deprecated
-    public static Result canEntitySpawn(EntityLiving entity, World world, float x, float y, float z)
-    {
-        return canEntitySpawn(entity, world, x, y, z, true);
-    }
-
     public static Result canEntitySpawn(EntityLiving entity, World world, float x, float y, float z, boolean isSpawner)
     {
         if (entity == null)

--- a/src/main/java/net/minecraftforge/event/ForgeEventFactory.java
+++ b/src/main/java/net/minecraftforge/event/ForgeEventFactory.java
@@ -169,6 +169,15 @@ public class ForgeEventFactory
         MinecraftForge.EVENT_BUS.post(new PlayerDestroyItemEvent(player, stack, hand));
     }
 
+    /**
+     * @deprecated use {@link #canEntitySpawn(EntityLiving, World, float, float, float, boolean)} instead
+     */
+    @Deprecated
+    public static Result canEntitySpawn(EntityLiving entity, World world, float x, float y, float z)
+    {
+        return canEntitySpawn(entity, world, x, y, z, true);
+    }
+
     public static Result canEntitySpawn(EntityLiving entity, World world, float x, float y, float z, boolean isSpawner)
     {
         if (entity == null)

--- a/src/main/java/net/minecraftforge/event/entity/living/LivingSpawnEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/living/LivingSpawnEvent.java
@@ -88,6 +88,15 @@ public class LivingSpawnEvent extends LivingEvent
             this.isSpawner = isSpawner;
         }
 
+        /**
+         * @deprecated Use {@link CheckSpawn#CheckSpawn(EntityLiving, World, float, float, float, boolean)} instead
+         */
+        @Deprecated
+        public CheckSpawn(EntityLiving entity, World world, float x, float y, float z)
+        {
+            this(entity, world, x, y, z, true);
+        }
+
         public boolean isSpawner() { return isSpawner; }
     }
 

--- a/src/main/java/net/minecraftforge/event/entity/living/LivingSpawnEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/living/LivingSpawnEvent.java
@@ -19,8 +19,6 @@
 
 package net.minecraftforge.event.entity.living;
 
-import net.minecraft.world.WorldEntitySpawner;
-import net.minecraft.world.WorldServer;
 import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.event.ForgeEventFactory;
 import net.minecraftforge.fml.common.eventhandler.Cancelable;
@@ -72,10 +70,25 @@ public class LivingSpawnEvent extends LivingEvent
     @HasResult
     public static class CheckSpawn extends LivingSpawnEvent
     {
-        public CheckSpawn(EntityLiving entity, World world, float x, float y, float z)
+        private final boolean isSpawner;
+
+        /**
+         * CheckSpawn is fired when an Entity is about to be spawned.
+         * @param entity the spawning entity
+         * @param world the world to spawn in
+         * @param x x coordinate
+         * @param y y coordinate
+         * @param z z coordinate
+         * @param isSpawner true if this spawn is done by a MobSpawner,
+         *                  false if it this spawn is coming from a WorldSpawner
+         */
+        public CheckSpawn(EntityLiving entity, World world, float x, float y, float z, boolean isSpawner)
         {
             super(entity, world, x, y, z);
+            this.isSpawner = isSpawner;
         }
+
+        public boolean isSpawner() { return isSpawner; }
     }
 
     /**

--- a/src/main/java/net/minecraftforge/event/entity/living/LivingSpawnEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/living/LivingSpawnEvent.java
@@ -88,15 +88,6 @@ public class LivingSpawnEvent extends LivingEvent
             this.isSpawner = isSpawner;
         }
 
-        /**
-         * @deprecated Use {@link CheckSpawn#CheckSpawn(EntityLiving, World, float, float, float, boolean)} instead
-         */
-        @Deprecated
-        public CheckSpawn(EntityLiving entity, World world, float x, float y, float z)
-        {
-            this(entity, world, x, y, z, true);
-        }
-
         public boolean isSpawner() { return isSpawner; }
     }
 


### PR DESCRIPTION
added isSpawner parameter to the CheckSpawn event which is set to:
- *true* if spawned by a MobSpawner
- *false* if spawned by the WorldSpawner

This addition should solve #3703 - atleast the part requested by @zlainsama

~~/Edit: I've added 2 overloaded methods which do not take the isSpawn parameter to maintain binary compatibility. The overloads call their counterpart with `isSpawner = true` since false is supposed to be used by the WorldSpawner.~~