### PR TITLE
Make getSubBlocks non-client only

### DIFF
--- a/patches/minecraft/net/minecraft/block/Block.java.patch
+++ b/patches/minecraft/net/minecraft/block/Block.java.patch
@@ -197,7 +197,7 @@
      }
  
      protected ItemStack func_180643_i(IBlockState p_180643_1_)
-@@ -810,6 +825,7 @@
+@@ -810,12 +825,12 @@
          p_176216_2_.field_70181_x = 0.0D;
      }
  
@@ -205,7 +205,13 @@
      public ItemStack func_185473_a(World p_185473_1_, BlockPos p_185473_2_, IBlockState p_185473_3_)
      {
          return new ItemStack(Item.func_150898_a(this), 1, this.func_180651_a(p_185473_3_));
-@@ -831,7 +847,6 @@
+     }
+ 
+-    @SideOnly(Side.CLIENT)
+     public void func_149666_a(CreativeTabs p_149666_1_, NonNullList<ItemStack> p_149666_2_)
+     {
+         p_149666_2_.add(new ItemStack(this));
+@@ -831,7 +846,6 @@
      {
      }
  
@@ -213,7 +219,7 @@
      public CreativeTabs func_149708_J()
      {
          return this.field_149772_a;
-@@ -921,6 +936,7 @@
+@@ -921,6 +935,7 @@
          }
      }
  
@@ -221,7 +227,7 @@
      public SoundType func_185467_w()
      {
          return this.field_149762_H;
-@@ -936,6 +952,1218 @@
+@@ -936,6 +951,1218 @@
      {
      }
  
@@ -1440,7 +1446,7 @@
      public static void func_149671_p()
      {
          func_176215_a(0, field_176230_a, (new BlockAir()).func_149663_c("air"));
-@@ -1247,14 +2475,7 @@
+@@ -1247,14 +2474,7 @@
              }
              else
              {

--- a/patches/minecraft/net/minecraft/block/BlockAnvil.java.patch
+++ b/patches/minecraft/net/minecraft/block/BlockAnvil.java.patch
@@ -1,0 +1,10 @@
+--- ../src-base/minecraft/net/minecraft/block/BlockAnvil.java
++++ ../src-work/minecraft/net/minecraft/block/BlockAnvil.java
+@@ -108,7 +108,6 @@
+         return enumfacing.func_176740_k() == EnumFacing.Axis.X ? field_185760_c : field_185761_d;
+     }
+ 
+-    @SideOnly(Side.CLIENT)
+     public void func_149666_a(CreativeTabs p_149666_1_, NonNullList<ItemStack> p_149666_2_)
+     {
+         p_149666_2_.add(new ItemStack(this));

--- a/patches/minecraft/net/minecraft/block/BlockCarpet.java.patch
+++ b/patches/minecraft/net/minecraft/block/BlockCarpet.java.patch
@@ -1,0 +1,10 @@
+--- ../src-base/minecraft/net/minecraft/block/BlockCarpet.java
++++ ../src-work/minecraft/net/minecraft/block/BlockCarpet.java
+@@ -99,7 +99,6 @@
+         return ((EnumDyeColor)p_180651_1_.func_177229_b(field_176330_a)).func_176765_a();
+     }
+ 
+-    @SideOnly(Side.CLIENT)
+     public void func_149666_a(CreativeTabs p_149666_1_, NonNullList<ItemStack> p_149666_2_)
+     {
+         for (int i = 0; i < 16; ++i)

--- a/patches/minecraft/net/minecraft/block/BlockColored.java.patch
+++ b/patches/minecraft/net/minecraft/block/BlockColored.java.patch
@@ -1,0 +1,10 @@
+--- ../src-base/minecraft/net/minecraft/block/BlockColored.java
++++ ../src-work/minecraft/net/minecraft/block/BlockColored.java
+@@ -31,7 +31,6 @@
+         return ((EnumDyeColor)p_180651_1_.func_177229_b(field_176581_a)).func_176765_a();
+     }
+ 
+-    @SideOnly(Side.CLIENT)
+     public void func_149666_a(CreativeTabs p_149666_1_, NonNullList<ItemStack> p_149666_2_)
+     {
+         for (EnumDyeColor enumdyecolor : EnumDyeColor.values())

--- a/patches/minecraft/net/minecraft/block/BlockConcretePowder.java.patch
+++ b/patches/minecraft/net/minecraft/block/BlockConcretePowder.java.patch
@@ -1,0 +1,10 @@
+--- ../src-base/minecraft/net/minecraft/block/BlockConcretePowder.java
++++ ../src-work/minecraft/net/minecraft/block/BlockConcretePowder.java
+@@ -84,7 +84,6 @@
+         return ((EnumDyeColor)p_180651_1_.func_177229_b(field_192426_a)).func_176765_a();
+     }
+ 
+-    @SideOnly(Side.CLIENT)
+     public void func_149666_a(CreativeTabs p_149666_1_, NonNullList<ItemStack> p_149666_2_)
+     {
+         for (EnumDyeColor enumdyecolor : EnumDyeColor.values())

--- a/patches/minecraft/net/minecraft/block/BlockDaylightDetector.java.patch
+++ b/patches/minecraft/net/minecraft/block/BlockDaylightDetector.java.patch
@@ -1,0 +1,10 @@
+--- ../src-base/minecraft/net/minecraft/block/BlockDaylightDetector.java
++++ ../src-work/minecraft/net/minecraft/block/BlockDaylightDetector.java
+@@ -163,7 +163,6 @@
+         return new BlockStateContainer(this, new IProperty[] {field_176436_a});
+     }
+ 
+-    @SideOnly(Side.CLIENT)
+     public void func_149666_a(CreativeTabs p_149666_1_, NonNullList<ItemStack> p_149666_2_)
+     {
+         if (!this.field_176435_b)

--- a/patches/minecraft/net/minecraft/block/BlockDirt.java.patch
+++ b/patches/minecraft/net/minecraft/block/BlockDirt.java.patch
@@ -1,0 +1,10 @@
+--- ../src-base/minecraft/net/minecraft/block/BlockDirt.java
++++ ../src-work/minecraft/net/minecraft/block/BlockDirt.java
+@@ -46,7 +46,6 @@
+         return p_176221_1_;
+     }
+ 
+-    @SideOnly(Side.CLIENT)
+     public void func_149666_a(CreativeTabs p_149666_1_, NonNullList<ItemStack> p_149666_2_)
+     {
+         p_149666_2_.add(new ItemStack(this, 1, BlockDirt.DirtType.DIRT.func_176925_a()));

--- a/patches/minecraft/net/minecraft/block/BlockDoublePlant.java.patch
+++ b/patches/minecraft/net/minecraft/block/BlockDoublePlant.java.patch
@@ -45,7 +45,7 @@
          {
              super.func_180657_a(p_180657_1_, p_180657_2_, p_180657_3_, p_180657_4_, p_180657_5_, p_180657_6_);
          }
-@@ -222,8 +219,6 @@
+@@ -222,13 +219,10 @@
          else
          {
              p_176489_4_.func_71029_a(StatList.func_188055_a(this));
@@ -54,7 +54,12 @@
              return true;
          }
      }
-@@ -293,6 +288,33 @@
+ 
+-    @SideOnly(Side.CLIENT)
+     public void func_149666_a(CreativeTabs p_149666_1_, NonNullList<ItemStack> p_149666_2_)
+     {
+         for (BlockDoublePlant.EnumPlantType blockdoubleplant$enumplanttype : BlockDoublePlant.EnumPlantType.values())
+@@ -293,6 +287,33 @@
          return Block.EnumOffsetType.XZ;
      }
  

--- a/patches/minecraft/net/minecraft/block/BlockFlower.java.patch
+++ b/patches/minecraft/net/minecraft/block/BlockFlower.java.patch
@@ -1,0 +1,10 @@
+--- ../src-base/minecraft/net/minecraft/block/BlockFlower.java
++++ ../src-work/minecraft/net/minecraft/block/BlockFlower.java
+@@ -39,7 +39,6 @@
+         return ((BlockFlower.EnumFlowerType)p_180651_1_.func_177229_b(this.func_176494_l())).func_176968_b();
+     }
+ 
+-    @SideOnly(Side.CLIENT)
+     public void func_149666_a(CreativeTabs p_149666_1_, NonNullList<ItemStack> p_149666_2_)
+     {
+         for (BlockFlower.EnumFlowerType blockflower$enumflowertype : BlockFlower.EnumFlowerType.func_176966_a(this.func_176495_j()))

--- a/patches/minecraft/net/minecraft/block/BlockFlower.java.patch
+++ b/patches/minecraft/net/minecraft/block/BlockFlower.java.patch
@@ -8,3 +8,11 @@
      public void func_149666_a(CreativeTabs p_149666_1_, NonNullList<ItemStack> p_149666_2_)
      {
          for (BlockFlower.EnumFlowerType blockflower$enumflowertype : BlockFlower.EnumFlowerType.func_176966_a(this.func_176495_j()))
+@@ -151,7 +150,6 @@
+             return ablockflower$enumflowertype[p_176967_1_];
+         }
+ 
+-        @SideOnly(Side.CLIENT)
+         public static BlockFlower.EnumFlowerType[] func_176966_a(BlockFlower.EnumFlowerColor p_176966_0_)
+         {
+             return field_176981_k[p_176966_0_.ordinal()];

--- a/patches/minecraft/net/minecraft/block/BlockNewLeaf.java.patch
+++ b/patches/minecraft/net/minecraft/block/BlockNewLeaf.java.patch
@@ -1,6 +1,14 @@
 --- ../src-base/minecraft/net/minecraft/block/BlockNewLeaf.java
 +++ ../src-work/minecraft/net/minecraft/block/BlockNewLeaf.java
-@@ -109,4 +109,10 @@
+@@ -52,7 +52,6 @@
+         return new ItemStack(this, 1, p_185473_3_.func_177230_c().func_176201_c(p_185473_3_) & 3);
+     }
+ 
+-    @SideOnly(Side.CLIENT)
+     public void func_149666_a(CreativeTabs p_149666_1_, NonNullList<ItemStack> p_149666_2_)
+     {
+         p_149666_2_.add(new ItemStack(this, 1, 0));
+@@ -109,4 +108,10 @@
              super.func_180657_a(p_180657_1_, p_180657_2_, p_180657_3_, p_180657_4_, p_180657_5_, p_180657_6_);
          }
      }

--- a/patches/minecraft/net/minecraft/block/BlockNewLog.java.patch
+++ b/patches/minecraft/net/minecraft/block/BlockNewLog.java.patch
@@ -1,0 +1,10 @@
+--- ../src-base/minecraft/net/minecraft/block/BlockNewLog.java
++++ ../src-work/minecraft/net/minecraft/block/BlockNewLog.java
+@@ -56,7 +56,6 @@
+         }
+     }
+ 
+-    @SideOnly(Side.CLIENT)
+     public void func_149666_a(CreativeTabs p_149666_1_, NonNullList<ItemStack> p_149666_2_)
+     {
+         p_149666_2_.add(new ItemStack(this, 1, BlockPlanks.EnumType.ACACIA.func_176839_a() - 4));

--- a/patches/minecraft/net/minecraft/block/BlockOldLeaf.java.patch
+++ b/patches/minecraft/net/minecraft/block/BlockOldLeaf.java.patch
@@ -1,6 +1,14 @@
 --- ../src-base/minecraft/net/minecraft/block/BlockOldLeaf.java
 +++ ../src-work/minecraft/net/minecraft/block/BlockOldLeaf.java
-@@ -104,11 +104,16 @@
+@@ -47,7 +47,6 @@
+         return p_176232_1_.func_177229_b(field_176239_P) == BlockPlanks.EnumType.JUNGLE ? 40 : super.func_176232_d(p_176232_1_);
+     }
+ 
+-    @SideOnly(Side.CLIENT)
+     public void func_149666_a(CreativeTabs p_149666_1_, NonNullList<ItemStack> p_149666_2_)
+     {
+         p_149666_2_.add(new ItemStack(this, 1, BlockPlanks.EnumType.OAK.func_176839_a()));
+@@ -104,11 +103,16 @@
          if (!p_180657_1_.field_72995_K && p_180657_6_.func_77973_b() == Items.field_151097_aZ)
          {
              p_180657_2_.func_71029_a(StatList.func_188055_a(this));

--- a/patches/minecraft/net/minecraft/block/BlockOldLog.java.patch
+++ b/patches/minecraft/net/minecraft/block/BlockOldLog.java.patch
@@ -1,0 +1,10 @@
+--- ../src-base/minecraft/net/minecraft/block/BlockOldLog.java
++++ ../src-work/minecraft/net/minecraft/block/BlockOldLog.java
+@@ -60,7 +60,6 @@
+         }
+     }
+ 
+-    @SideOnly(Side.CLIENT)
+     public void func_149666_a(CreativeTabs p_149666_1_, NonNullList<ItemStack> p_149666_2_)
+     {
+         p_149666_2_.add(new ItemStack(this, 1, BlockPlanks.EnumType.OAK.func_176839_a()));

--- a/patches/minecraft/net/minecraft/block/BlockPlanks.java.patch
+++ b/patches/minecraft/net/minecraft/block/BlockPlanks.java.patch
@@ -1,0 +1,10 @@
+--- ../src-base/minecraft/net/minecraft/block/BlockPlanks.java
++++ ../src-work/minecraft/net/minecraft/block/BlockPlanks.java
+@@ -31,7 +31,6 @@
+         return ((BlockPlanks.EnumType)p_180651_1_.func_177229_b(field_176383_a)).func_176839_a();
+     }
+ 
+-    @SideOnly(Side.CLIENT)
+     public void func_149666_a(CreativeTabs p_149666_1_, NonNullList<ItemStack> p_149666_2_)
+     {
+         for (BlockPlanks.EnumType blockplanks$enumtype : BlockPlanks.EnumType.values())

--- a/patches/minecraft/net/minecraft/block/BlockPrismarine.java.patch
+++ b/patches/minecraft/net/minecraft/block/BlockPrismarine.java.patch
@@ -1,0 +1,10 @@
+--- ../src-base/minecraft/net/minecraft/block/BlockPrismarine.java
++++ ../src-work/minecraft/net/minecraft/block/BlockPrismarine.java
+@@ -60,7 +60,6 @@
+         return this.func_176223_P().func_177226_a(field_176332_a, BlockPrismarine.EnumType.func_176810_a(p_176203_1_));
+     }
+ 
+-    @SideOnly(Side.CLIENT)
+     public void func_149666_a(CreativeTabs p_149666_1_, NonNullList<ItemStack> p_149666_2_)
+     {
+         p_149666_2_.add(new ItemStack(this, 1, field_176331_b));

--- a/patches/minecraft/net/minecraft/block/BlockQuartz.java.patch
+++ b/patches/minecraft/net/minecraft/block/BlockQuartz.java.patch
@@ -1,6 +1,14 @@
 --- ../src-base/minecraft/net/minecraft/block/BlockQuartz.java
 +++ ../src-work/minecraft/net/minecraft/block/BlockQuartz.java
-@@ -111,6 +111,26 @@
+@@ -61,7 +61,6 @@
+         return blockquartz$enumtype != BlockQuartz.EnumType.LINES_X && blockquartz$enumtype != BlockQuartz.EnumType.LINES_Z ? super.func_180643_i(p_180643_1_) : new ItemStack(Item.func_150898_a(this), 1, BlockQuartz.EnumType.LINES_Y.func_176796_a());
+     }
+ 
+-    @SideOnly(Side.CLIENT)
+     public void func_149666_a(CreativeTabs p_149666_1_, NonNullList<ItemStack> p_149666_2_)
+     {
+         p_149666_2_.add(new ItemStack(this, 1, BlockQuartz.EnumType.DEFAULT.func_176796_a()));
+@@ -111,6 +110,26 @@
          return new BlockStateContainer(this, new IProperty[] {field_176335_a});
      }
  

--- a/patches/minecraft/net/minecraft/block/BlockRedSandstone.java.patch
+++ b/patches/minecraft/net/minecraft/block/BlockRedSandstone.java.patch
@@ -1,0 +1,10 @@
+--- ../src-base/minecraft/net/minecraft/block/BlockRedSandstone.java
++++ ../src-work/minecraft/net/minecraft/block/BlockRedSandstone.java
+@@ -28,7 +28,6 @@
+         return ((BlockRedSandstone.EnumType)p_180651_1_.func_177229_b(field_176336_a)).func_176827_a();
+     }
+ 
+-    @SideOnly(Side.CLIENT)
+     public void func_149666_a(CreativeTabs p_149666_1_, NonNullList<ItemStack> p_149666_2_)
+     {
+         for (BlockRedSandstone.EnumType blockredsandstone$enumtype : BlockRedSandstone.EnumType.values())

--- a/patches/minecraft/net/minecraft/block/BlockSand.java.patch
+++ b/patches/minecraft/net/minecraft/block/BlockSand.java.patch
@@ -1,0 +1,10 @@
+--- ../src-base/minecraft/net/minecraft/block/BlockSand.java
++++ ../src-work/minecraft/net/minecraft/block/BlockSand.java
+@@ -28,7 +28,6 @@
+         return ((BlockSand.EnumType)p_180651_1_.func_177229_b(field_176504_a)).func_176688_a();
+     }
+ 
+-    @SideOnly(Side.CLIENT)
+     public void func_149666_a(CreativeTabs p_149666_1_, NonNullList<ItemStack> p_149666_2_)
+     {
+         for (BlockSand.EnumType blocksand$enumtype : BlockSand.EnumType.values())

--- a/patches/minecraft/net/minecraft/block/BlockSandStone.java.patch
+++ b/patches/minecraft/net/minecraft/block/BlockSandStone.java.patch
@@ -1,0 +1,10 @@
+--- ../src-base/minecraft/net/minecraft/block/BlockSandStone.java
++++ ../src-work/minecraft/net/minecraft/block/BlockSandStone.java
+@@ -31,7 +31,6 @@
+         return ((BlockSandStone.EnumType)p_180651_1_.func_177229_b(field_176297_a)).func_176675_a();
+     }
+ 
+-    @SideOnly(Side.CLIENT)
+     public void func_149666_a(CreativeTabs p_149666_1_, NonNullList<ItemStack> p_149666_2_)
+     {
+         for (BlockSandStone.EnumType blocksandstone$enumtype : BlockSandStone.EnumType.values())

--- a/patches/minecraft/net/minecraft/block/BlockSapling.java.patch
+++ b/patches/minecraft/net/minecraft/block/BlockSapling.java.patch
@@ -8,3 +8,11 @@
          WorldGenerator worldgenerator = (WorldGenerator)(p_176476_4_.nextInt(10) == 0 ? new WorldGenBigTree(true) : new WorldGenTrees(true));
          int i = 0;
          int j = 0;
+@@ -209,7 +210,6 @@
+         return ((BlockPlanks.EnumType)p_180651_1_.func_177229_b(field_176480_a)).func_176839_a();
+     }
+ 
+-    @SideOnly(Side.CLIENT)
+     public void func_149666_a(CreativeTabs p_149666_1_, NonNullList<ItemStack> p_149666_2_)
+     {
+         for (BlockPlanks.EnumType blockplanks$enumtype : BlockPlanks.EnumType.values())

--- a/patches/minecraft/net/minecraft/block/BlockSilverfish.java.patch
+++ b/patches/minecraft/net/minecraft/block/BlockSilverfish.java.patch
@@ -1,0 +1,10 @@
+--- ../src-base/minecraft/net/minecraft/block/BlockSilverfish.java
++++ ../src-work/minecraft/net/minecraft/block/BlockSilverfish.java
+@@ -75,7 +75,6 @@
+         return new ItemStack(this, 1, p_185473_3_.func_177230_c().func_176201_c(p_185473_3_));
+     }
+ 
+-    @SideOnly(Side.CLIENT)
+     public void func_149666_a(CreativeTabs p_149666_1_, NonNullList<ItemStack> p_149666_2_)
+     {
+         for (BlockSilverfish.EnumType blocksilverfish$enumtype : BlockSilverfish.EnumType.values())

--- a/patches/minecraft/net/minecraft/block/BlockSponge.java.patch
+++ b/patches/minecraft/net/minecraft/block/BlockSponge.java.patch
@@ -1,0 +1,10 @@
+--- ../src-base/minecraft/net/minecraft/block/BlockSponge.java
++++ ../src-work/minecraft/net/minecraft/block/BlockSponge.java
+@@ -107,7 +107,6 @@
+         return i > 0;
+     }
+ 
+-    @SideOnly(Side.CLIENT)
+     public void func_149666_a(CreativeTabs p_149666_1_, NonNullList<ItemStack> p_149666_2_)
+     {
+         p_149666_2_.add(new ItemStack(this, 1, 0));

--- a/patches/minecraft/net/minecraft/block/BlockStainedGlass.java.patch
+++ b/patches/minecraft/net/minecraft/block/BlockStainedGlass.java.patch
@@ -1,0 +1,10 @@
+--- ../src-base/minecraft/net/minecraft/block/BlockStainedGlass.java
++++ ../src-work/minecraft/net/minecraft/block/BlockStainedGlass.java
+@@ -34,7 +34,6 @@
+         return ((EnumDyeColor)p_180651_1_.func_177229_b(field_176547_a)).func_176765_a();
+     }
+ 
+-    @SideOnly(Side.CLIENT)
+     public void func_149666_a(CreativeTabs p_149666_1_, NonNullList<ItemStack> p_149666_2_)
+     {
+         for (EnumDyeColor enumdyecolor : EnumDyeColor.values())

--- a/patches/minecraft/net/minecraft/block/BlockStainedGlassPane.java.patch
+++ b/patches/minecraft/net/minecraft/block/BlockStainedGlassPane.java.patch
@@ -1,0 +1,10 @@
+--- ../src-base/minecraft/net/minecraft/block/BlockStainedGlassPane.java
++++ ../src-work/minecraft/net/minecraft/block/BlockStainedGlassPane.java
+@@ -35,7 +35,6 @@
+         return ((EnumDyeColor)p_180651_1_.func_177229_b(field_176245_a)).func_176765_a();
+     }
+ 
+-    @SideOnly(Side.CLIENT)
+     public void func_149666_a(CreativeTabs p_149666_1_, NonNullList<ItemStack> p_149666_2_)
+     {
+         for (int i = 0; i < EnumDyeColor.values().length; ++i)

--- a/patches/minecraft/net/minecraft/block/BlockStone.java.patch
+++ b/patches/minecraft/net/minecraft/block/BlockStone.java.patch
@@ -1,0 +1,10 @@
+--- ../src-base/minecraft/net/minecraft/block/BlockStone.java
++++ ../src-work/minecraft/net/minecraft/block/BlockStone.java
+@@ -50,7 +50,6 @@
+         return ((BlockStone.EnumType)p_180651_1_.func_177229_b(field_176247_a)).func_176642_a();
+     }
+ 
+-    @SideOnly(Side.CLIENT)
+     public void func_149666_a(CreativeTabs p_149666_1_, NonNullList<ItemStack> p_149666_2_)
+     {
+         for (BlockStone.EnumType blockstone$enumtype : BlockStone.EnumType.values())

--- a/patches/minecraft/net/minecraft/block/BlockStoneBrick.java.patch
+++ b/patches/minecraft/net/minecraft/block/BlockStoneBrick.java.patch
@@ -1,0 +1,10 @@
+--- ../src-base/minecraft/net/minecraft/block/BlockStoneBrick.java
++++ ../src-work/minecraft/net/minecraft/block/BlockStoneBrick.java
+@@ -32,7 +32,6 @@
+         return ((BlockStoneBrick.EnumType)p_180651_1_.func_177229_b(field_176249_a)).func_176612_a();
+     }
+ 
+-    @SideOnly(Side.CLIENT)
+     public void func_149666_a(CreativeTabs p_149666_1_, NonNullList<ItemStack> p_149666_2_)
+     {
+         for (BlockStoneBrick.EnumType blockstonebrick$enumtype : BlockStoneBrick.EnumType.values())

--- a/patches/minecraft/net/minecraft/block/BlockStoneSlab.java.patch
+++ b/patches/minecraft/net/minecraft/block/BlockStoneSlab.java.patch
@@ -1,0 +1,10 @@
+--- ../src-base/minecraft/net/minecraft/block/BlockStoneSlab.java
++++ ../src-work/minecraft/net/minecraft/block/BlockStoneSlab.java
+@@ -68,7 +68,6 @@
+         return BlockStoneSlab.EnumType.func_176625_a(p_185674_1_.func_77960_j() & 7);
+     }
+ 
+-    @SideOnly(Side.CLIENT)
+     public void func_149666_a(CreativeTabs p_149666_1_, NonNullList<ItemStack> p_149666_2_)
+     {
+         for (BlockStoneSlab.EnumType blockstoneslab$enumtype : BlockStoneSlab.EnumType.values())

--- a/patches/minecraft/net/minecraft/block/BlockStoneSlabNew.java.patch
+++ b/patches/minecraft/net/minecraft/block/BlockStoneSlabNew.java.patch
@@ -1,0 +1,10 @@
+--- ../src-base/minecraft/net/minecraft/block/BlockStoneSlabNew.java
++++ ../src-work/minecraft/net/minecraft/block/BlockStoneSlabNew.java
+@@ -74,7 +74,6 @@
+         return BlockStoneSlabNew.EnumType.func_176916_a(p_185674_1_.func_77960_j() & 7);
+     }
+ 
+-    @SideOnly(Side.CLIENT)
+     public void func_149666_a(CreativeTabs p_149666_1_, NonNullList<ItemStack> p_149666_2_)
+     {
+         for (BlockStoneSlabNew.EnumType blockstoneslabnew$enumtype : BlockStoneSlabNew.EnumType.values())

--- a/patches/minecraft/net/minecraft/block/BlockTallGrass.java.patch
+++ b/patches/minecraft/net/minecraft/block/BlockTallGrass.java.patch
@@ -27,7 +27,15 @@
      }
  
      public int func_149679_a(int p_149679_1_, Random p_149679_2_)
-@@ -181,4 +181,19 @@
+@@ -78,7 +78,6 @@
+         return new ItemStack(this, 1, p_185473_3_.func_177230_c().func_176201_c(p_185473_3_));
+     }
+ 
+-    @SideOnly(Side.CLIENT)
+     public void func_149666_a(CreativeTabs p_149666_1_, NonNullList<ItemStack> p_149666_2_)
+     {
+         for (int i = 1; i < 3; ++i)
+@@ -181,4 +180,19 @@
              }
          }
      }

--- a/patches/minecraft/net/minecraft/block/BlockWall.java.patch
+++ b/patches/minecraft/net/minecraft/block/BlockWall.java.patch
@@ -1,6 +1,14 @@
 --- ../src-base/minecraft/net/minecraft/block/BlockWall.java
 +++ ../src-work/minecraft/net/minecraft/block/BlockWall.java
-@@ -160,10 +160,10 @@
+@@ -128,7 +128,6 @@
+         return Block.func_193382_c(p_194143_0_) || p_194143_0_ == Blocks.field_180401_cv || p_194143_0_ == Blocks.field_150440_ba || p_194143_0_ == Blocks.field_150423_aK || p_194143_0_ == Blocks.field_150428_aP;
+     }
+ 
+-    @SideOnly(Side.CLIENT)
+     public void func_149666_a(CreativeTabs p_149666_1_, NonNullList<ItemStack> p_149666_2_)
+     {
+         for (BlockWall.EnumType blockwall$enumtype : BlockWall.EnumType.values())
+@@ -160,10 +159,10 @@
  
      public IBlockState func_176221_a(IBlockState p_176221_1_, IBlockAccess p_176221_2_, BlockPos p_176221_3_)
      {
@@ -15,7 +23,7 @@
          boolean flag4 = flag && !flag1 && flag2 && !flag3 || !flag && flag1 && !flag2 && flag3;
          return p_176221_1_.func_177226_a(field_176256_a, Boolean.valueOf(!flag4 || !p_176221_2_.func_175623_d(p_176221_3_.func_177984_a()))).func_177226_a(field_176254_b, Boolean.valueOf(flag)).func_177226_a(field_176257_M, Boolean.valueOf(flag1)).func_177226_a(field_176258_N, Boolean.valueOf(flag2)).func_177226_a(field_176259_O, Boolean.valueOf(flag3));
      }
-@@ -178,6 +178,24 @@
+@@ -178,6 +177,24 @@
          return p_193383_4_ != EnumFacing.UP && p_193383_4_ != EnumFacing.DOWN ? BlockFaceShape.MIDDLE_POLE_THICK : BlockFaceShape.CENTER_BIG;
      }
  

--- a/patches/minecraft/net/minecraft/block/BlockWoodSlab.java.patch
+++ b/patches/minecraft/net/minecraft/block/BlockWoodSlab.java.patch
@@ -1,0 +1,10 @@
+--- ../src-base/minecraft/net/minecraft/block/BlockWoodSlab.java
++++ ../src-work/minecraft/net/minecraft/block/BlockWoodSlab.java
+@@ -66,7 +66,6 @@
+         return BlockPlanks.EnumType.func_176837_a(p_185674_1_.func_77960_j() & 7);
+     }
+ 
+-    @SideOnly(Side.CLIENT)
+     public void func_149666_a(CreativeTabs p_149666_1_, NonNullList<ItemStack> p_149666_2_)
+     {
+         for (BlockPlanks.EnumType blockplanks$enumtype : BlockPlanks.EnumType.values())


### PR DESCRIPTION
Same as efd8b38be9fe7ce4521a0dfbe660f3167aa27e9f but for blocks. Makes it not crash server side if Item#getSubItems is called server side

If I missed something please let me know