### PR TITLE
Fix incorrect .toString() when instantiating custom config array entries

### DIFF
--- a/src/main/java/net/minecraftforge/fml/client/config/GuiEditArrayEntries.java
+++ b/src/main/java/net/minecraftforge/fml/client/config/GuiEditArrayEntries.java
@@ -76,7 +76,7 @@ public class GuiEditArrayEntries extends GuiListExtended
                 try
                 {
                     listEntries.add(clazz.getConstructor(GuiEditArray.class, GuiEditArrayEntries.class, IConfigElement.class, Object.class)
-                            .newInstance(this.owningGui, this, configElement, value.toString()));
+                            .newInstance(this.owningGui, this, configElement, value));
                 }
                 catch (Throwable e)
                 {


### PR DESCRIPTION
The constructor signatur is expected to accept an Object as you can see [in the line above](https://github.com/MinecraftForge/MinecraftForge/blob/1.12.x/src/main/java/net/minecraftforge/fml/client/config/GuiEditArrayEntries.java#L78). 

The call to `.toString()` is unnecessary and makes it harder to use custom array entries for anything other than strings, since you then always have to convert back from the string form to the original type.

The fix introduced in #3697 already [calls the constructor without](https://github.com/MinecraftForge/MinecraftForge/blob/1.12.x/src/main/java/net/minecraftforge/fml/client/config/GuiEditArrayEntries.java#L154) the `.toString()`, I just hadn't notice it being wrong here back then.

Technically a breaking change for fixed-length lists if someone blindly assumes the `Object value` parameter to always be a string, so this may be a candidate for before the release build on wednesday.