### PR TITLE
Fix resource loading on some systems when SplashProgress is enabled

### DIFF
--- a/patches/minecraft/net/minecraft/client/renderer/texture/TextureMap.java.patch
+++ b/patches/minecraft/net/minecraft/client/renderer/texture/TextureMap.java.patch
@@ -164,16 +164,17 @@
              {
                  String s = textureatlassprite1.func_94215_i();
                  map.remove(s);
-@@ -186,6 +257,8 @@
+@@ -186,6 +257,9 @@
          {
              textureatlassprite2.func_94217_a(this.field_94249_f);
          }
++        org.lwjgl.opengl.GL11.glFlush(); // Some systems (mainly macs) need this to make sure the texture map creation finishes before moving on
 +        net.minecraftforge.client.ForgeHooksClient.onTextureStitchedPost(this);
 +        net.minecraftforge.fml.common.ProgressManager.pop(bar);
      }
  
      private boolean func_184397_a(IResourceManager p_184397_1_, final TextureAtlasSprite p_184397_2_)
-@@ -195,7 +268,7 @@
+@@ -195,7 +269,7 @@
          label62:
          {
              boolean flag;
@@ -182,7 +183,7 @@
              try
              {
                  iresource = p_184397_1_.func_110536_a(resourcelocation);
-@@ -292,7 +365,7 @@
+@@ -292,7 +366,7 @@
          }
          else
          {
@@ -191,7 +192,7 @@
  
              if (textureatlassprite == null)
              {
-@@ -318,4 +391,52 @@
+@@ -318,4 +392,52 @@
      {
          return this.field_94249_f;
      }

--- a/src/main/java/net/minecraftforge/fml/client/SplashProgress.java
+++ b/src/main/java/net/minecraftforge/fml/client/SplashProgress.java
@@ -651,7 +651,6 @@ public class SplashProgress
             checkThreadState();
             done = true;
             thread.join();
-            glFlush();              // process any remaining commands in the buffer before final releaseContext
             d.releaseContext();
             Display.getDrawable().makeCurrent();
             fontTexture.delete();

--- a/src/main/java/net/minecraftforge/fml/client/SplashProgress.java
+++ b/src/main/java/net/minecraftforge/fml/client/SplashProgress.java
@@ -158,10 +158,9 @@ public class SplashProgress
             FMLLog.log.info("Could not load splash.properties, will create a default one");
         }
 
-        //Some system do not support this and have weird effects so we need to detect and disable by default.
+        //Some systems do not support this and have weird effects, so we need to detect and disable them by default.
         //The user can always force enable it if they want to take the responsibility for bugs.
-        //For now macs derp so disable them.
-        boolean defaultEnabled = !System.getProperty("os.name").toLowerCase().contains("mac");
+        boolean defaultEnabled = true;
 
         // Enable if we have the flag, and there's either no optifine, or optifine has added a key to the blackboard ("optifine.ForgeSplashCompatible")
         // Optifine authors - add this key to the blackboard if you feel your modifications are now compatible with this code.
@@ -652,6 +651,7 @@ public class SplashProgress
             checkThreadState();
             done = true;
             thread.join();
+            glFlush();              // process any remaining commands in the buffer before final releaseContext
             d.releaseContext();
             Display.getDrawable().makeCurrent();
             fontTexture.delete();


### PR DESCRIPTION
I believe this should fix missing textures on some systems (mainly mac) when using the Forge splash screen.

How this problem occurs:
The GL context on the main thread is set to using a `SharedDrawable` object, which is created when the splash screen is initialized. This allows the main thread and the thread drawing the splash screen to share the same GL context. However, the command buffers for both threads remain separate. This creates a problem at the end of the loading process when resources are reloaded. Creating the texture map requires a bunch of GL calls, and basically, some of the calls at the end get stuck in the command buffer. This is normal and is fine for vanilla MC as other GL calls will be made which will push them along. However, with Forge, there is no GL calls before `SplashProgress.finish()` is called which resets the GL context of the main thread using `Display.getDrawable()`. This switches the GL command buffer for the thread and now the commands in the previous buffer will never get processed. Therefore, missing textures on the texture map.

~~The solution is a simple `glFlush` before the context is switched in `SplashProgress.finish()`.~~
The solution is a simple `glFlush` after the texture map creation in `TextureMap.loadTextureAtlas()`.