### PR TITLE
Minor fix to EnumHelper#addCreatureType

### DIFF
--- a/src/main/java/net/minecraftforge/common/util/EnumHelper.java
+++ b/src/main/java/net/minecraftforge/common/util/EnumHelper.java
@@ -25,6 +25,7 @@ import java.util.*;
 import com.google.common.base.Predicate;
 import com.google.common.collect.Lists;
 
+import net.minecraft.entity.passive.IAnimals;
 import net.minecraftforge.fml.common.EnhancedRuntimeException;
 import net.minecraftforge.fml.common.FMLLog;
 import net.minecraft.block.BlockPressurePlate.Sensitivity;
@@ -96,7 +97,7 @@ public class EnumHelper
         return addEnum(EnumCreatureAttribute.class, name);
     }
     @Nullable
-    public static EnumCreatureType addCreatureType(String name, Class<?> typeClass, int maxNumber, Material material, boolean peaceful, boolean animal)
+    public static EnumCreatureType addCreatureType(String name, Class<? extends IAnimals> typeClass, int maxNumber, Material material, boolean peaceful, boolean animal)
     {
         return addEnum(EnumCreatureType.class, name, typeClass, maxNumber, material, peaceful, animal);
     }


### PR DESCRIPTION
EnumCreatureType#creatureClass only accepts Class<? extends IAnimals>.
Forge's EnumHelper does not reflect this.

This patch makes EnumHelper#addCreatureType only accept such classes, so modders do not forget to implement this interface in their classes.

(Implementing IAnimals in a creature class should do no harm, since it does not have any methods and is implemented by all creature type vanilla entities.)