### PR TITLE
Added Block::getFogColor.

### DIFF
--- a/patches/minecraft/net/minecraft/block/Block.java.patch
+++ b/patches/minecraft/net/minecraft/block/Block.java.patch
@@ -227,7 +227,7 @@
      public SoundType func_185467_w()
      {
          return this.field_149762_H;
-@@ -936,6 +951,1218 @@
+@@ -936,6 +951,1234 @@
      {
      }
  
@@ -1400,6 +1400,22 @@
 +    }
 +
 +    /**
++     * Use this to change the fog color used when the entity is "inside" a material.
++     * Vec3d is used here as "r/g/b" 0 - 1 values.
++     *
++     * @param state         The state at the entity viewport.
++     * @param world         The world.
++     * @param pos           The position at the entity viewport.
++     * @param entity        the entity
++     * @param originalColor The current fog color, You are not expected to use this, just here.
++     * @return The new fog color.
++     */
++    @SideOnly (Side.CLIENT)
++    public Vec3d getFogColor(World world, BlockPos pos, IBlockState state, Entity entity, Vec3d originalColor, float partialTicks) {
++        return originalColor;
++    }
++
++    /**
 +     * Gets the {@link IBlockState} to place
 +     * @param world The world the block is being placed in
 +     * @param pos The position the block is being placed at
@@ -1446,7 +1462,7 @@
      public static void func_149671_p()
      {
          func_176215_a(0, field_176230_a, (new BlockAir()).func_149663_c("air"));
-@@ -1247,14 +2474,7 @@
+@@ -1247,14 +2490,7 @@
              }
              else
              {

--- a/patches/minecraft/net/minecraft/block/Block.java.patch
+++ b/patches/minecraft/net/minecraft/block/Block.java.patch
@@ -227,7 +227,7 @@
      public SoundType func_185467_w()
      {
          return this.field_149762_H;
-@@ -936,6 +951,1254 @@
+@@ -936,6 +951,1255 @@
      {
      }
  
@@ -1403,15 +1403,16 @@
 +     * Use this to change the fog color used when the entity is "inside" a material.
 +     * Vec3d is used here as "r/g/b" 0 - 1 values.
 +     *
-+     * @param state         The state at the entity viewport.
 +     * @param world         The world.
 +     * @param pos           The position at the entity viewport.
++     * @param state         The state at the entity viewport.
 +     * @param entity        the entity
-+     * @param originalColor The current fog color, You are not expected to use this, just here.
++     * @param originalColor The current fog color, You are not expected to use this, Return as the default if applicable.
 +     * @return The new fog color.
 +     */
 +    @SideOnly (Side.CLIENT)
-+    public Vec3d getFogColor(World world, BlockPos pos, IBlockState state, Entity entity, Vec3d originalColor, float partialTicks) {
++    public Vec3d getFogColor(World world, BlockPos pos, IBlockState state, Entity entity, Vec3d originalColor, float partialTicks)
++    {
 +        if (state.func_185904_a() == Material.field_151586_h)
 +        {
 +            float f12 = 0.0F;
@@ -1482,7 +1483,7 @@
      public static void func_149671_p()
      {
          func_176215_a(0, field_176230_a, (new BlockAir()).func_149663_c("air"));
-@@ -1247,14 +2510,7 @@
+@@ -1247,14 +2511,7 @@
              }
              else
              {

--- a/patches/minecraft/net/minecraft/block/Block.java.patch
+++ b/patches/minecraft/net/minecraft/block/Block.java.patch
@@ -227,7 +227,7 @@
      public SoundType func_185467_w()
      {
          return this.field_149762_H;
-@@ -936,6 +951,1234 @@
+@@ -936,6 +951,1254 @@
      {
      }
  
@@ -1412,6 +1412,26 @@
 +     */
 +    @SideOnly (Side.CLIENT)
 +    public Vec3d getFogColor(World world, BlockPos pos, IBlockState state, Entity entity, Vec3d originalColor, float partialTicks) {
++        if (state.func_185904_a() == Material.field_151586_h)
++        {
++            float f12 = 0.0F;
++
++            if (entity instanceof net.minecraft.entity.EntityLivingBase)
++            {
++                net.minecraft.entity.EntityLivingBase ent = (net.minecraft.entity.EntityLivingBase)entity;
++                f12 = (float)net.minecraft.enchantment.EnchantmentHelper.func_185292_c(ent) * 0.2F;
++
++                if (ent.func_70644_a(net.minecraft.init.MobEffects.field_76427_o))
++                {
++                    f12 = f12 * 0.3F + 0.6F;
++                }
++            }
++            return new Vec3d(0.02F + f12, 0.02F + f12, 0.2F + f12);
++        }
++        else if (state.func_185904_a() == Material.field_151587_i)
++        {
++            return new Vec3d(0.6F, 0.1F, 0.0F);
++        }
 +        return originalColor;
 +    }
 +
@@ -1462,7 +1482,7 @@
      public static void func_149671_p()
      {
          func_176215_a(0, field_176230_a, (new BlockAir()).func_149663_c("air"));
-@@ -1247,14 +2490,7 @@
+@@ -1247,14 +2510,7 @@
              }
              else
              {

--- a/patches/minecraft/net/minecraft/block/BlockLiquid.java.patch
+++ b/patches/minecraft/net/minecraft/block/BlockLiquid.java.patch
@@ -1,0 +1,38 @@
+--- ../src-base/minecraft/net/minecraft/block/BlockLiquid.java
++++ ../src-work/minecraft/net/minecraft/block/BlockLiquid.java
+@@ -452,4 +452,35 @@
+     {
+         return BlockFaceShape.UNDEFINED;
+     }
++
++    //Moved from EntityRenderer
++    @Override
++    @SideOnly (Side.CLIENT)
++    public Vec3d getFogColor(World world, BlockPos pos, IBlockState state, Entity entity, Vec3d originalColor, float partialTicks)
++    {
++        state = net.minecraft.client.renderer.ActiveRenderInfo.func_186703_a(world, entity, partialTicks);
++        if (state.func_185904_a() == Material.field_151586_h)
++        {
++            float f12 = 0.0F;
++
++            if (entity instanceof net.minecraft.entity.EntityLivingBase)
++            {
++                net.minecraft.entity.EntityLivingBase ent = (net.minecraft.entity.EntityLivingBase)entity;
++                f12 = (float)net.minecraft.enchantment.EnchantmentHelper.func_185292_c(ent) * 0.2F;
++
++                if (ent.func_70644_a(net.minecraft.init.MobEffects.field_76427_o))
++                {
++                    f12 = f12 * 0.3F + 0.6F;
++                }
++            }
++            return new Vec3d(0.02F + f12, 0.02F + f12, 0.2F + f12);
++        }
++        else if (state.func_185904_a() == Material.field_151587_i)
++        {
++            return new Vec3d(0.6F, 0.1F, 0.0F);
++        } else
++        {
++            return state.func_177230_c().getFogColor(world, pos, state, entity, originalColor, partialTicks);
++        }
++    }
+ }

--- a/patches/minecraft/net/minecraft/block/BlockLiquid.java.patch
+++ b/patches/minecraft/net/minecraft/block/BlockLiquid.java.patch
@@ -1,6 +1,6 @@
 --- ../src-base/minecraft/net/minecraft/block/BlockLiquid.java
 +++ ../src-work/minecraft/net/minecraft/block/BlockLiquid.java
-@@ -452,4 +452,24 @@
+@@ -452,4 +452,29 @@
      {
          return BlockFaceShape.UNDEFINED;
      }
@@ -11,14 +11,19 @@
 +    {
 +        Vec3d viewport = net.minecraft.client.renderer.ActiveRenderInfo.func_178806_a(entity, partialTicks);
 +
-+        if (state.func_185904_a().func_76224_d()) {
++        if (state.func_185904_a().func_76224_d())
++        {
 +            float height = 0.0F;
-+            if (state.func_177230_c() instanceof BlockLiquid) {
++            if (state.func_177230_c() instanceof BlockLiquid)
++            {
 +                height = func_149801_b(state.func_177229_b(field_176367_b)) - 0.11111111F;
 +            }
 +            float f1 = (float) (pos.func_177956_o() + 1) - height;
-+            if (viewport.field_72448_b > (double)f1) {
-+                return world.func_180495_p(pos.func_177984_a()).func_177230_c().getFogColor(world, pos, state, entity, originalColor, partialTicks);
++            if (viewport.field_72448_b > (double)f1)
++            {
++                BlockPos upPos = pos.func_177984_a();
++                IBlockState upState = world.func_180495_p(upPos);
++                return upState.func_177230_c().getFogColor(world, upPos, upState, entity, originalColor, partialTicks);
 +            }
 +        }
 +

--- a/patches/minecraft/net/minecraft/block/BlockLiquid.java.patch
+++ b/patches/minecraft/net/minecraft/block/BlockLiquid.java.patch
@@ -1,38 +1,27 @@
 --- ../src-base/minecraft/net/minecraft/block/BlockLiquid.java
 +++ ../src-work/minecraft/net/minecraft/block/BlockLiquid.java
-@@ -452,4 +452,35 @@
+@@ -452,4 +452,24 @@
      {
          return BlockFaceShape.UNDEFINED;
      }
 +
-+    //Moved from EntityRenderer
 +    @Override
 +    @SideOnly (Side.CLIENT)
 +    public Vec3d getFogColor(World world, BlockPos pos, IBlockState state, Entity entity, Vec3d originalColor, float partialTicks)
 +    {
-+        state = net.minecraft.client.renderer.ActiveRenderInfo.func_186703_a(world, entity, partialTicks);
-+        if (state.func_185904_a() == Material.field_151586_h)
-+        {
-+            float f12 = 0.0F;
++        Vec3d viewport = net.minecraft.client.renderer.ActiveRenderInfo.func_178806_a(entity, partialTicks);
 +
-+            if (entity instanceof net.minecraft.entity.EntityLivingBase)
-+            {
-+                net.minecraft.entity.EntityLivingBase ent = (net.minecraft.entity.EntityLivingBase)entity;
-+                f12 = (float)net.minecraft.enchantment.EnchantmentHelper.func_185292_c(ent) * 0.2F;
-+
-+                if (ent.func_70644_a(net.minecraft.init.MobEffects.field_76427_o))
-+                {
-+                    f12 = f12 * 0.3F + 0.6F;
-+                }
++        if (state.func_185904_a().func_76224_d()) {
++            float height = 0.0F;
++            if (state.func_177230_c() instanceof BlockLiquid) {
++                height = func_149801_b(state.func_177229_b(field_176367_b)) - 0.11111111F;
 +            }
-+            return new Vec3d(0.02F + f12, 0.02F + f12, 0.2F + f12);
++            float f1 = (float) (pos.func_177956_o() + 1) - height;
++            if (viewport.field_72448_b > (double)f1) {
++                return world.func_180495_p(pos.func_177984_a()).func_177230_c().getFogColor(world, pos, state, entity, originalColor, partialTicks);
++            }
 +        }
-+        else if (state.func_185904_a() == Material.field_151587_i)
-+        {
-+            return new Vec3d(0.6F, 0.1F, 0.0F);
-+        } else
-+        {
-+            return state.func_177230_c().getFogColor(world, pos, state, entity, originalColor, partialTicks);
-+        }
++
++        return super.getFogColor(world, pos, state, entity, originalColor, partialTicks);
 +    }
  }

--- a/patches/minecraft/net/minecraft/client/renderer/EntityRenderer.java.patch
+++ b/patches/minecraft/net/minecraft/client/renderer/EntityRenderer.java.patch
@@ -167,35 +167,48 @@
          float f = this.field_78531_r.field_71441_e.func_72867_j(p_78474_1_);
  
          if (f > 0.0F)
-@@ -1749,7 +1776,14 @@
+@@ -1749,30 +1776,13 @@
              this.field_175082_R = (float)vec3d3.field_72448_b;
              this.field_175081_S = (float)vec3d3.field_72449_c;
          }
 -        else if (iblockstate.func_185904_a() == Material.field_151586_h)
+-        {
+-            float f12 = 0.0F;
+-
+-            if (entity instanceof EntityLivingBase)
+-            {
+-                f12 = (float)EnchantmentHelper.func_185292_c((EntityLivingBase)entity) * 0.2F;
+-
+-                if (((EntityLivingBase)entity).func_70644_a(MobEffects.field_76427_o))
+-                {
+-                    f12 = f12 * 0.3F + 0.6F;
+-                }
+-            }
+-
+-            this.field_175080_Q = 0.02F + f12;
+-            this.field_175082_R = 0.02F + f12;
+-            this.field_175081_S = 0.2F + f12;
 +        else {
-+        net.minecraftforge.client.event.EntityViewRenderEvent.FogColorEvent.InsideMaterial event = new net.minecraftforge.client.event.EntityViewRenderEvent.FogColorEvent.InsideMaterial(this, entity, iblockstate, p_78466_1_, this.field_175080_Q, this.field_175082_R, this.field_175081_S);
-+        net.minecraftforge.common.MinecraftForge.EVENT_BUS.post(event);
-+        this.field_175080_Q = event.getRed();
-+        this.field_175082_R = event.getGreen();
-+        this.field_175081_S = event.getBlue();
-+        if (event.getResult() != net.minecraftforge.fml.common.eventhandler.Event.Result.DENY)
-+        if (iblockstate.func_185904_a() == Material.field_151586_h)
-         {
-             float f12 = 0.0F;
- 
-@@ -1773,6 +1807,7 @@
-             this.field_175082_R = 0.1F;
-             this.field_175081_S = 0.0F;
++            //Forge Moved to BlockLiquid && block hook added.
++            Vec3d inMaterialColor = iblockstate.func_177230_c().getFogColor(this.field_78531_r.field_71441_e, new BlockPos(ActiveRenderInfo.func_178806_a(entity, p_78466_1_)), iblockstate, entity, new Vec3d(field_175080_Q, field_175082_R, field_175081_S), p_78466_1_);
++            this.field_175080_Q = (float)inMaterialColor.field_72450_a;
++            this.field_175082_R = (float)inMaterialColor.field_72448_b;
++            this.field_175081_S = (float)inMaterialColor.field_72449_c;
          }
-+        }//End if cloudFog else
+-        else if (iblockstate.func_185904_a() == Material.field_151587_i)
+-        {
+-            this.field_175080_Q = 0.6F;
+-            this.field_175082_R = 0.1F;
+-            this.field_175081_S = 0.0F;
+-        }
  
          float f13 = this.field_78535_ad + (this.field_78539_ae - this.field_78535_ad) * p_78466_1_;
          this.field_175080_Q *= f13;
-@@ -1845,6 +1880,13 @@
+@@ -1845,6 +1855,13 @@
              this.field_175081_S = f7;
          }
  
-+        net.minecraftforge.client.event.EntityViewRenderEvent.FogColorEvent.Post event = new net.minecraftforge.client.event.EntityViewRenderEvent.FogColorEvent.Post(this, entity, iblockstate, p_78466_1_, this.field_175080_Q, this.field_175082_R, this.field_175081_S);
++        net.minecraftforge.client.event.EntityViewRenderEvent.FogColors event = new net.minecraftforge.client.event.EntityViewRenderEvent.FogColors(this, entity, iblockstate, p_78466_1_, this.field_175080_Q, this.field_175082_R, this.field_175081_S);
 +        net.minecraftforge.common.MinecraftForge.EVENT_BUS.post(event);
 +
 +        this.field_175080_Q = event.getRed();
@@ -205,7 +218,7 @@
          GlStateManager.func_179082_a(this.field_175080_Q, this.field_175082_R, this.field_175081_S, 0.0F);
      }
  
-@@ -1855,7 +1897,9 @@
+@@ -1855,7 +1872,9 @@
          GlStateManager.func_187432_a(0.0F, -1.0F, 0.0F);
          GlStateManager.func_179131_c(1.0F, 1.0F, 1.0F, 1.0F);
          IBlockState iblockstate = ActiveRenderInfo.func_186703_a(this.field_78531_r.field_71441_e, entity, p_78468_2_);
@@ -216,7 +229,7 @@
          if (entity instanceof EntityLivingBase && ((EntityLivingBase)entity).func_70644_a(MobEffects.field_76440_q))
          {
              float f1 = 5.0F;
-@@ -1940,6 +1984,7 @@
+@@ -1940,6 +1959,7 @@
                  GlStateManager.func_179102_b(f * 0.05F);
                  GlStateManager.func_179153_c(Math.min(f, 192.0F) * 0.5F);
              }

--- a/patches/minecraft/net/minecraft/client/renderer/EntityRenderer.java.patch
+++ b/patches/minecraft/net/minecraft/client/renderer/EntityRenderer.java.patch
@@ -167,13 +167,14 @@
          float f = this.field_78531_r.field_71441_e.func_72867_j(p_78474_1_);
  
          if (f > 0.0F)
-@@ -1749,7 +1776,13 @@
+@@ -1749,7 +1776,14 @@
              this.field_175082_R = (float)vec3d3.field_72448_b;
              this.field_175081_S = (float)vec3d3.field_72449_c;
          }
 -        else if (iblockstate.func_185904_a() == Material.field_151586_h)
 +        else {
 +        net.minecraftforge.client.event.EntityViewRenderEvent.FogColorEvent.InsideMaterial event = new net.minecraftforge.client.event.EntityViewRenderEvent.FogColorEvent.InsideMaterial(this, entity, iblockstate, p_78466_1_, this.field_175080_Q, this.field_175082_R, this.field_175081_S);
++        net.minecraftforge.common.MinecraftForge.EVENT_BUS.post(event);
 +        this.field_175080_Q = event.getRed();
 +        this.field_175082_R = event.getGreen();
 +        this.field_175081_S = event.getBlue();
@@ -182,7 +183,7 @@
          {
              float f12 = 0.0F;
  
-@@ -1773,6 +1806,7 @@
+@@ -1773,6 +1807,7 @@
              this.field_175082_R = 0.1F;
              this.field_175081_S = 0.0F;
          }
@@ -190,7 +191,7 @@
  
          float f13 = this.field_78535_ad + (this.field_78539_ae - this.field_78535_ad) * p_78466_1_;
          this.field_175080_Q *= f13;
-@@ -1845,6 +1879,13 @@
+@@ -1845,6 +1880,13 @@
              this.field_175081_S = f7;
          }
  
@@ -204,7 +205,7 @@
          GlStateManager.func_179082_a(this.field_175080_Q, this.field_175082_R, this.field_175081_S, 0.0F);
      }
  
-@@ -1855,7 +1896,9 @@
+@@ -1855,7 +1897,9 @@
          GlStateManager.func_187432_a(0.0F, -1.0F, 0.0F);
          GlStateManager.func_179131_c(1.0F, 1.0F, 1.0F, 1.0F);
          IBlockState iblockstate = ActiveRenderInfo.func_186703_a(this.field_78531_r.field_71441_e, entity, p_78468_2_);
@@ -215,7 +216,7 @@
          if (entity instanceof EntityLivingBase && ((EntityLivingBase)entity).func_70644_a(MobEffects.field_76440_q))
          {
              float f1 = 5.0F;
-@@ -1940,6 +1983,7 @@
+@@ -1940,6 +1984,7 @@
                  GlStateManager.func_179102_b(f * 0.05F);
                  GlStateManager.func_179153_c(Math.min(f, 192.0F) * 0.5F);
              }

--- a/patches/minecraft/net/minecraft/client/renderer/EntityRenderer.java.patch
+++ b/patches/minecraft/net/minecraft/client/renderer/EntityRenderer.java.patch
@@ -167,11 +167,34 @@
          float f = this.field_78531_r.field_71441_e.func_72867_j(p_78474_1_);
  
          if (f > 0.0F)
-@@ -1845,6 +1872,13 @@
+@@ -1749,7 +1776,13 @@
+             this.field_175082_R = (float)vec3d3.field_72448_b;
+             this.field_175081_S = (float)vec3d3.field_72449_c;
+         }
+-        else if (iblockstate.func_185904_a() == Material.field_151586_h)
++        else {
++        net.minecraftforge.client.event.EntityViewRenderEvent.FogColorEvent.InsideMaterial event = new net.minecraftforge.client.event.EntityViewRenderEvent.FogColorEvent.InsideMaterial(this, entity, iblockstate, p_78466_1_, this.field_175080_Q, this.field_175082_R, this.field_175081_S);
++        this.field_175080_Q = event.getRed();
++        this.field_175082_R = event.getGreen();
++        this.field_175081_S = event.getBlue();
++        if (event.getResult() != net.minecraftforge.fml.common.eventhandler.Event.Result.DENY)
++        if (iblockstate.func_185904_a() == Material.field_151586_h)
+         {
+             float f12 = 0.0F;
+ 
+@@ -1773,6 +1806,7 @@
+             this.field_175082_R = 0.1F;
+             this.field_175081_S = 0.0F;
+         }
++        }//End if cloudFog else
+ 
+         float f13 = this.field_78535_ad + (this.field_78539_ae - this.field_78535_ad) * p_78466_1_;
+         this.field_175080_Q *= f13;
+@@ -1845,6 +1879,13 @@
              this.field_175081_S = f7;
          }
  
-+        net.minecraftforge.client.event.EntityViewRenderEvent.FogColors event = new net.minecraftforge.client.event.EntityViewRenderEvent.FogColors(this, entity, iblockstate, p_78466_1_, this.field_175080_Q, this.field_175082_R, this.field_175081_S);
++        net.minecraftforge.client.event.EntityViewRenderEvent.FogColorEvent.Post event = new net.minecraftforge.client.event.EntityViewRenderEvent.FogColorEvent.Post(this, entity, iblockstate, p_78466_1_, this.field_175080_Q, this.field_175082_R, this.field_175081_S);
 +        net.minecraftforge.common.MinecraftForge.EVENT_BUS.post(event);
 +
 +        this.field_175080_Q = event.getRed();
@@ -181,7 +204,7 @@
          GlStateManager.func_179082_a(this.field_175080_Q, this.field_175082_R, this.field_175081_S, 0.0F);
      }
  
-@@ -1855,7 +1889,9 @@
+@@ -1855,7 +1896,9 @@
          GlStateManager.func_187432_a(0.0F, -1.0F, 0.0F);
          GlStateManager.func_179131_c(1.0F, 1.0F, 1.0F, 1.0F);
          IBlockState iblockstate = ActiveRenderInfo.func_186703_a(this.field_78531_r.field_71441_e, entity, p_78468_2_);
@@ -192,7 +215,7 @@
          if (entity instanceof EntityLivingBase && ((EntityLivingBase)entity).func_70644_a(MobEffects.field_76440_q))
          {
              float f1 = 5.0F;
-@@ -1940,6 +1976,7 @@
+@@ -1940,6 +1983,7 @@
                  GlStateManager.func_179102_b(f * 0.05F);
                  GlStateManager.func_179153_c(Math.min(f, 192.0F) * 0.5F);
              }

--- a/patches/minecraft/net/minecraft/client/renderer/EntityRenderer.java.patch
+++ b/patches/minecraft/net/minecraft/client/renderer/EntityRenderer.java.patch
@@ -167,7 +167,7 @@
          float f = this.field_78531_r.field_71441_e.func_72867_j(p_78474_1_);
  
          if (f > 0.0F)
-@@ -1749,30 +1776,13 @@
+@@ -1749,30 +1776,16 @@
              this.field_175082_R = (float)vec3d3.field_72448_b;
              this.field_175081_S = (float)vec3d3.field_72449_c;
          }
@@ -189,8 +189,11 @@
 -            this.field_175082_R = 0.02F + f12;
 -            this.field_175081_S = 0.2F + f12;
 +        else {
-+            //Forge Moved to BlockLiquid && block hook added.
-+            Vec3d inMaterialColor = iblockstate.func_177230_c().getFogColor(this.field_78531_r.field_71441_e, new BlockPos(ActiveRenderInfo.func_178806_a(entity, p_78466_1_)), iblockstate, entity, new Vec3d(field_175080_Q, field_175082_R, field_175081_S), p_78466_1_);
++            //Forge Moved to Block.
++            Vec3d viewport = ActiveRenderInfo.func_178806_a(entity, p_78466_1_);
++            BlockPos viewportPos = new BlockPos(viewport);
++            IBlockState viewportState = this.field_78531_r.field_71441_e.func_180495_p(viewportPos);
++            Vec3d inMaterialColor = viewportState.func_177230_c().getFogColor(this.field_78531_r.field_71441_e, viewportPos, viewportState, entity, new Vec3d(field_175080_Q, field_175082_R, field_175081_S), p_78466_1_);
 +            this.field_175080_Q = (float)inMaterialColor.field_72450_a;
 +            this.field_175082_R = (float)inMaterialColor.field_72448_b;
 +            this.field_175081_S = (float)inMaterialColor.field_72449_c;
@@ -204,7 +207,7 @@
  
          float f13 = this.field_78535_ad + (this.field_78539_ae - this.field_78535_ad) * p_78466_1_;
          this.field_175080_Q *= f13;
-@@ -1845,6 +1855,13 @@
+@@ -1845,6 +1858,13 @@
              this.field_175081_S = f7;
          }
  
@@ -218,7 +221,7 @@
          GlStateManager.func_179082_a(this.field_175080_Q, this.field_175082_R, this.field_175081_S, 0.0F);
      }
  
-@@ -1855,7 +1872,9 @@
+@@ -1855,7 +1875,9 @@
          GlStateManager.func_187432_a(0.0F, -1.0F, 0.0F);
          GlStateManager.func_179131_c(1.0F, 1.0F, 1.0F, 1.0F);
          IBlockState iblockstate = ActiveRenderInfo.func_186703_a(this.field_78531_r.field_71441_e, entity, p_78468_2_);
@@ -229,7 +232,7 @@
          if (entity instanceof EntityLivingBase && ((EntityLivingBase)entity).func_70644_a(MobEffects.field_76440_q))
          {
              float f1 = 5.0F;
-@@ -1940,6 +1959,7 @@
+@@ -1940,6 +1962,7 @@
                  GlStateManager.func_179102_b(f * 0.05F);
                  GlStateManager.func_179153_c(Math.min(f, 192.0F) * 0.5F);
              }

--- a/patches/minecraft/net/minecraft/client/renderer/EntityRenderer.java.patch
+++ b/patches/minecraft/net/minecraft/client/renderer/EntityRenderer.java.patch
@@ -167,12 +167,13 @@
          float f = this.field_78531_r.field_71441_e.func_72867_j(p_78474_1_);
  
          if (f > 0.0F)
-@@ -1749,30 +1776,16 @@
+@@ -1749,30 +1776,17 @@
              this.field_175082_R = (float)vec3d3.field_72448_b;
              this.field_175081_S = (float)vec3d3.field_72449_c;
          }
 -        else if (iblockstate.func_185904_a() == Material.field_151586_h)
--        {
++        else
+         {
 -            float f12 = 0.0F;
 -
 -            if (entity instanceof EntityLivingBase)
@@ -188,7 +189,6 @@
 -            this.field_175080_Q = 0.02F + f12;
 -            this.field_175082_R = 0.02F + f12;
 -            this.field_175081_S = 0.2F + f12;
-+        else {
 +            //Forge Moved to Block.
 +            Vec3d viewport = ActiveRenderInfo.func_178806_a(entity, p_78466_1_);
 +            BlockPos viewportPos = new BlockPos(viewport);
@@ -207,7 +207,7 @@
  
          float f13 = this.field_78535_ad + (this.field_78539_ae - this.field_78535_ad) * p_78466_1_;
          this.field_175080_Q *= f13;
-@@ -1845,6 +1858,13 @@
+@@ -1845,6 +1859,13 @@
              this.field_175081_S = f7;
          }
  
@@ -221,7 +221,7 @@
          GlStateManager.func_179082_a(this.field_175080_Q, this.field_175082_R, this.field_175081_S, 0.0F);
      }
  
-@@ -1855,7 +1875,9 @@
+@@ -1855,7 +1876,9 @@
          GlStateManager.func_187432_a(0.0F, -1.0F, 0.0F);
          GlStateManager.func_179131_c(1.0F, 1.0F, 1.0F, 1.0F);
          IBlockState iblockstate = ActiveRenderInfo.func_186703_a(this.field_78531_r.field_71441_e, entity, p_78468_2_);
@@ -232,7 +232,7 @@
          if (entity instanceof EntityLivingBase && ((EntityLivingBase)entity).func_70644_a(MobEffects.field_76440_q))
          {
              float f1 = 5.0F;
-@@ -1940,6 +1962,7 @@
+@@ -1940,6 +1963,7 @@
                  GlStateManager.func_179102_b(f * 0.05F);
                  GlStateManager.func_179153_c(Math.min(f, 192.0F) * 0.5F);
              }

--- a/src/main/java/net/minecraftforge/client/event/EntityViewRenderEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/EntityViewRenderEvent.java
@@ -118,15 +118,16 @@ public abstract class EntityViewRenderEvent extends Event
     }
 
     /**
-     * Abstract event for handling fog color.
+     * Event that allows any feature to customize the color of fog the player sees.
+     * NOTE: Any change made to one of the color variables will affect the result seen in-game.
      */
-    public abstract static class FogColorEvent extends EntityViewRenderEvent
+    public static class FogColors extends EntityViewRenderEvent
     {
         private float red;
         private float green;
         private float blue;
 
-        public FogColorEvent(EntityRenderer renderer, Entity entity, IBlockState state, double renderPartialTicks, float red, float green, float blue)
+        public FogColors(EntityRenderer renderer, Entity entity, IBlockState state, double renderPartialTicks, float red, float green, float blue)
         {
             super(renderer, entity, state, renderPartialTicks);
             this.setRed(red);
@@ -140,34 +141,6 @@ public abstract class EntityViewRenderEvent extends Event
         public void setGreen(float green) { this.green = green; }
         public float getBlue() { return blue; }
         public void setBlue(float blue) { this.blue = blue; }
-
-        /**
-         * Event that allows any feature to customize the color of fog the player sees.
-         * NOTE: Any change made to one of the color variables will affect the result seen in-game.
-         */
-        public static class Post extends FogColorEvent
-        {
-
-            public Post(EntityRenderer renderer, Entity entity, IBlockState state, double renderPartialTicks, float red, float green, float blue)
-            {
-                super(renderer, entity, state, renderPartialTicks, red, green, blue);
-            }
-        }
-
-        /**
-         * This event provides control over what vanilla does to modify fog color based on what material the entity is "inside".
-         * For Example: One could use this for custom Fluids, As the Post event is fired too late.
-         * Setting the event result to {@link Result#DENY} prevents vanillas fluid color logic from firing.
-         */
-        @HasResult
-        public static class InsideMaterial extends FogColorEvent
-        {
-
-            public InsideMaterial(EntityRenderer renderer, Entity entity, IBlockState state, double renderPartialTicks, float red, float green, float blue)
-            {
-                super(renderer, entity, state, renderPartialTicks, red, green, blue);
-            }
-        }
     }
     
     /** 

--- a/src/main/java/net/minecraftforge/client/event/EntityViewRenderEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/EntityViewRenderEvent.java
@@ -118,16 +118,15 @@ public abstract class EntityViewRenderEvent extends Event
     }
 
     /**
-     * Event that allows any feature to customize the color of fog the player sees.
-     * NOTE: Any change made to one of the color variables will affect the result seen in-game.
+     * Abstract event for handling fog color.
      */
-    public static class FogColors extends EntityViewRenderEvent
+    public abstract static class FogColorEvent extends EntityViewRenderEvent
     {
         private float red;
         private float green;
         private float blue;
 
-        public FogColors(EntityRenderer renderer, Entity entity, IBlockState state, double renderPartialTicks, float red, float green, float blue)
+        public FogColorEvent(EntityRenderer renderer, Entity entity, IBlockState state, double renderPartialTicks, float red, float green, float blue)
         {
             super(renderer, entity, state, renderPartialTicks);
             this.setRed(red);
@@ -141,6 +140,34 @@ public abstract class EntityViewRenderEvent extends Event
         public void setGreen(float green) { this.green = green; }
         public float getBlue() { return blue; }
         public void setBlue(float blue) { this.blue = blue; }
+
+        /**
+         * Event that allows any feature to customize the color of fog the player sees.
+         * NOTE: Any change made to one of the color variables will affect the result seen in-game.
+         */
+        public static class Post extends FogColorEvent
+        {
+
+            public Post(EntityRenderer renderer, Entity entity, IBlockState state, double renderPartialTicks, float red, float green, float blue)
+            {
+                super(renderer, entity, state, renderPartialTicks, red, green, blue);
+            }
+        }
+
+        /**
+         * This event provides control over what vanilla does to modify fog color based on what material the entity is "inside".
+         * For Example: One could use this for custom Fluids, As the Post event is fired too late.
+         * Setting the event result to {@link Result#DENY} prevents vanillas fluid color logic from firing.
+         */
+        @HasResult
+        public static class InsideMaterial extends FogColorEvent
+        {
+
+            public InsideMaterial(EntityRenderer renderer, Entity entity, IBlockState state, double renderPartialTicks, float red, float green, float blue)
+            {
+                super(renderer, entity, state, renderPartialTicks, red, green, blue);
+            }
+        }
     }
     
     /** 

--- a/src/test/java/net/minecraftforge/debug/FogColorInsideMaterialTest.java
+++ b/src/test/java/net/minecraftforge/debug/FogColorInsideMaterialTest.java
@@ -24,7 +24,8 @@ import net.minecraftforge.fml.common.registry.GameRegistry.ObjectHolder;
 
 @EventBusSubscriber
 @Mod (modid = FogColorInsideMaterialTest.MOD_ID, name = "FogColor inside material debug.", version = "1.0", acceptableRemoteVersions = "*")
-public class FogColorInsideMaterialTest {
+public class FogColorInsideMaterialTest
+{
 
     public static final String MOD_ID = "fogcolorinsidematerialtest";
 
@@ -34,10 +35,13 @@ public class FogColorInsideMaterialTest {
     public static final Item FLUID_ITEM = null;
 
     @SubscribeEvent
-    public static void registerBlocks(RegistryEvent.Register<Block> event) {
-        Block fluid = new BlockFluidClassic(FluidRegistry.WATER, Material.WATER) {
+    public static void registerBlocks(RegistryEvent.Register<Block> event)
+    {
+        Block fluid = new BlockFluidClassic(FluidRegistry.WATER, Material.WATER)
+        {
             @Override
-            public Vec3d getFogColor(World world, BlockPos pos, IBlockState state, Entity entity, Vec3d originalColor, float partialTicks) {
+            public Vec3d getFogColor(World world, BlockPos pos, IBlockState state, Entity entity, Vec3d originalColor, float partialTicks)
+            {
                 return new Vec3d(0.6F, 0.1F, 0.0F);
             }
         };
@@ -48,18 +52,22 @@ public class FogColorInsideMaterialTest {
     }
 
     @SubscribeEvent
-    public static void registerItems(RegistryEvent.Register<Item> event) {
+    public static void registerItems(RegistryEvent.Register<Item> event)
+    {
         event.getRegistry().register(new ItemBlock(FLUID_BLOCK).setRegistryName(FLUID_BLOCK.getRegistryName()));
     }
 
     @SubscribeEvent
-    public static void registerModels(ModelRegistryEvent event) {
+    public static void registerModels(ModelRegistryEvent event)
+    {
         ModelResourceLocation fluidLocation = new ModelResourceLocation(MOD_ID.toLowerCase() + ":test_fluid", "fluid");
         ModelLoader.registerItemVariants(FLUID_ITEM);
         ModelLoader.setCustomMeshDefinition(FLUID_ITEM, stack -> fluidLocation);
-        ModelLoader.setCustomStateMapper(FLUID_BLOCK, new StateMapperBase() {
+        ModelLoader.setCustomStateMapper(FLUID_BLOCK, new StateMapperBase()
+        {
             @Override
-            protected ModelResourceLocation getModelResourceLocation(IBlockState state) {
+            protected ModelResourceLocation getModelResourceLocation(IBlockState state)
+            {
                 return fluidLocation;
             }
         });

--- a/src/test/java/net/minecraftforge/debug/FogColorInsideMaterialTest.java
+++ b/src/test/java/net/minecraftforge/debug/FogColorInsideMaterialTest.java
@@ -6,9 +6,12 @@ import net.minecraft.block.state.IBlockState;
 import net.minecraft.client.renderer.block.model.ModelResourceLocation;
 import net.minecraft.client.renderer.block.statemap.StateMapperBase;
 import net.minecraft.creativetab.CreativeTabs;
+import net.minecraft.entity.Entity;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemBlock;
-import net.minecraftforge.client.event.EntityViewRenderEvent.FogColorEvent;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.math.Vec3d;
+import net.minecraft.world.World;
 import net.minecraftforge.client.event.ModelRegistryEvent;
 import net.minecraftforge.client.model.ModelLoader;
 import net.minecraftforge.event.RegistryEvent;
@@ -16,7 +19,6 @@ import net.minecraftforge.fluids.BlockFluidClassic;
 import net.minecraftforge.fluids.FluidRegistry;
 import net.minecraftforge.fml.common.Mod;
 import net.minecraftforge.fml.common.Mod.EventBusSubscriber;
-import net.minecraftforge.fml.common.eventhandler.Event.Result;
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
 import net.minecraftforge.fml.common.registry.GameRegistry.ObjectHolder;
 
@@ -32,18 +34,13 @@ public class FogColorInsideMaterialTest {
     public static final Item FLUID_ITEM = null;
 
     @SubscribeEvent
-    public static void onFogColorInsideMaterial(FogColorEvent.InsideMaterial event) {
-        if (event.getState().getBlock() == FLUID_BLOCK) {
-            event.setRed(0.6F);
-            event.setGreen(0.1F);
-            event.setBlue(0.1F);
-            event.setResult(Result.DENY);
-        }
-    }
-
-    @SubscribeEvent
     public static void registerBlocks(RegistryEvent.Register<Block> event) {
-        Block fluid = new BlockFluidClassic(FluidRegistry.WATER, Material.WATER);
+        Block fluid = new BlockFluidClassic(FluidRegistry.WATER, Material.WATER) {
+            @Override
+            public Vec3d getFogColor(World world, BlockPos pos, IBlockState state, Entity entity, Vec3d originalColor, float partialTicks) {
+                return new Vec3d(0.6F, 0.1F, 0.0F);
+            }
+        };
         fluid.setCreativeTab(CreativeTabs.BUILDING_BLOCKS);
         fluid.setUnlocalizedName(MOD_ID + ":" + "test_fluid");
         fluid.setRegistryName("test_fluid");

--- a/src/test/java/net/minecraftforge/debug/FogColorInsideMaterialTest.java
+++ b/src/test/java/net/minecraftforge/debug/FogColorInsideMaterialTest.java
@@ -1,0 +1,71 @@
+package net.minecraftforge.debug;
+
+import net.minecraft.block.Block;
+import net.minecraft.block.material.Material;
+import net.minecraft.block.state.IBlockState;
+import net.minecraft.client.renderer.block.model.ModelResourceLocation;
+import net.minecraft.client.renderer.block.statemap.StateMapperBase;
+import net.minecraft.creativetab.CreativeTabs;
+import net.minecraft.item.Item;
+import net.minecraft.item.ItemBlock;
+import net.minecraftforge.client.event.EntityViewRenderEvent.FogColorEvent;
+import net.minecraftforge.client.event.ModelRegistryEvent;
+import net.minecraftforge.client.model.ModelLoader;
+import net.minecraftforge.event.RegistryEvent;
+import net.minecraftforge.fluids.BlockFluidClassic;
+import net.minecraftforge.fluids.FluidRegistry;
+import net.minecraftforge.fml.common.Mod;
+import net.minecraftforge.fml.common.Mod.EventBusSubscriber;
+import net.minecraftforge.fml.common.eventhandler.Event.Result;
+import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
+import net.minecraftforge.fml.common.registry.GameRegistry.ObjectHolder;
+
+@EventBusSubscriber
+@Mod (modid = FogColorInsideMaterialTest.MOD_ID, name = "FogColor inside material debug.", version = "1.0", acceptableRemoteVersions = "*")
+public class FogColorInsideMaterialTest {
+
+    public static final String MOD_ID = "fogcolorinsidematerialtest";
+
+    @ObjectHolder ("test_fluid")
+    public static final Block FLUID_BLOCK = null;
+    @ObjectHolder ("test_fluid")
+    public static final Item FLUID_ITEM = null;
+
+    @SubscribeEvent
+    public static void onFogColorInsideMaterial(FogColorEvent.InsideMaterial event) {
+        if (event.getState().getBlock() == FLUID_BLOCK) {
+            event.setRed(0.6F);
+            event.setGreen(0.1F);
+            event.setBlue(0.1F);
+            event.setResult(Result.DENY);
+        }
+    }
+
+    @SubscribeEvent
+    public static void registerBlocks(RegistryEvent.Register<Block> event) {
+        Block fluid = new BlockFluidClassic(FluidRegistry.WATER, Material.WATER);
+        fluid.setCreativeTab(CreativeTabs.BUILDING_BLOCKS);
+        fluid.setUnlocalizedName(MOD_ID + ":" + "test_fluid");
+        fluid.setRegistryName("test_fluid");
+        event.getRegistry().register(fluid);
+    }
+
+    @SubscribeEvent
+    public static void registerItems(RegistryEvent.Register<Item> event) {
+        event.getRegistry().register(new ItemBlock(FLUID_BLOCK).setRegistryName(FLUID_BLOCK.getRegistryName()));
+    }
+
+    @SubscribeEvent
+    public static void registerModels(ModelRegistryEvent event) {
+        ModelResourceLocation fluidLocation = new ModelResourceLocation(MOD_ID.toLowerCase() + ":test_fluid", "fluid");
+        ModelLoader.registerItemVariants(FLUID_ITEM);
+        ModelLoader.setCustomMeshDefinition(FLUID_ITEM, stack -> fluidLocation);
+        ModelLoader.setCustomStateMapper(FLUID_BLOCK, new StateMapperBase() {
+            @Override
+            protected ModelResourceLocation getModelResourceLocation(IBlockState state) {
+                return fluidLocation;
+            }
+        });
+    }
+
+}

--- a/src/test/resources/assets/fogcolorinsidematerialtest/blockstates/test_fluid.json
+++ b/src/test/resources/assets/fogcolorinsidematerialtest/blockstates/test_fluid.json
@@ -1,0 +1,15 @@
+{
+	"forge_marker": 1,
+	"defaults": {
+		"model": "forge:fluid"
+	},
+	"variants": {
+		"fluid": [
+			{
+				"custom": {
+					"fluid": "test_fluid"
+				}
+			}
+		]
+	}
+}


### PR DESCRIPTION
With the addition of this new method it is possible for any block to override fog color based on the entity being "inside" it.

### Uses
This will allow for Modded fluids to easily change the fog color without fighting the rest of the logic above the location of the FogColors event. By default the test mod adds a fluid with the material of WATER with the fog color that of lava.