### PR TITLE
[1.12] Add PlayerSPPushOutOfBlocksEvent.

### DIFF
--- a/patches/minecraft/net/minecraft/client/entity/EntityPlayerSP.java.patch
+++ b/patches/minecraft/net/minecraft/client/entity/EntityPlayerSP.java.patch
@@ -89,3 +89,17 @@
      }
  
      public boolean func_70613_aW()
+@@ -853,10 +874,13 @@
+         }
+ 
+         AxisAlignedBB axisalignedbb = this.func_174813_aQ();
++        net.minecraftforge.client.event.PlayerSPPushOutOfBlocksEvent event = new net.minecraftforge.client.event.PlayerSPPushOutOfBlocksEvent(this, axisalignedbb);
++        if(!net.minecraftforge.common.MinecraftForge.EVENT_BUS.post(event)) { axisalignedbb = event.getEntityBoundingBox();
+         this.func_145771_j(this.field_70165_t - (double)this.field_70130_N * 0.35D, axisalignedbb.field_72338_b + 0.5D, this.field_70161_v + (double)this.field_70130_N * 0.35D);
+         this.func_145771_j(this.field_70165_t - (double)this.field_70130_N * 0.35D, axisalignedbb.field_72338_b + 0.5D, this.field_70161_v - (double)this.field_70130_N * 0.35D);
+         this.func_145771_j(this.field_70165_t + (double)this.field_70130_N * 0.35D, axisalignedbb.field_72338_b + 0.5D, this.field_70161_v - (double)this.field_70130_N * 0.35D);
+         this.func_145771_j(this.field_70165_t + (double)this.field_70130_N * 0.35D, axisalignedbb.field_72338_b + 0.5D, this.field_70161_v + (double)this.field_70130_N * 0.35D);
++        }
+         boolean flag4 = (float)this.func_71024_bL().func_75116_a() > 6.0F || this.field_71075_bZ.field_75101_c;
+ 
+         if (this.field_70122_E && !flag1 && !flag2 && this.field_71158_b.field_192832_b >= 0.8F && !this.func_70051_ag() && flag4 && !this.func_184587_cr() && !this.func_70644_a(MobEffects.field_76440_q))

--- a/src/main/java/net/minecraftforge/client/event/PlayerSPPushOutOfBlocksEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/PlayerSPPushOutOfBlocksEvent.java
@@ -1,0 +1,47 @@
+/*
+ * Minecraft Forge
+ * Copyright (c) 2016.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation version 2.1
+ * of the License.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+package net.minecraftforge.client.event;
+
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.util.math.AxisAlignedBB;
+import net.minecraftforge.event.entity.player.PlayerEvent;
+import net.minecraftforge.fml.common.eventhandler.Cancelable;
+
+import javax.annotation.Nonnull;
+
+/**
+ * This event is called before the pushOutOfBlocks calls in EntityPlayerSP.
+ *
+ * Cancelling the event will prevent pushOutOfBlocks from being called.
+ */
+@Cancelable
+public class PlayerSPPushOutOfBlocksEvent extends PlayerEvent
+{
+    private AxisAlignedBB entityBoundingBox;
+
+    public PlayerSPPushOutOfBlocksEvent(EntityPlayer player, AxisAlignedBB entityBoundingBox)
+    {
+        super(player);
+        this.entityBoundingBox = entityBoundingBox;
+    }
+
+    public AxisAlignedBB getEntityBoundingBox() { return entityBoundingBox; }
+    public void setEntityBoundingBox(@Nonnull AxisAlignedBB entityBoundingBox) { this.entityBoundingBox = entityBoundingBox; }
+}


### PR DESCRIPTION
The pushOutOfBlocks method was overriden for the MC player on the client side and uses different methods that will not allow for any form of manipulation with other events. 

This PR allows mods to cancel those calls and to do their own calculations if required.