### PR TITLE
[1.12] Add a World argument to WorldtypeEvent

### DIFF
--- a/patches/minecraft/net/minecraft/world/WorldType.java.patch
+++ b/patches/minecraft/net/minecraft/world/WorldType.java.patch
@@ -26,7 +26,7 @@
 +        }
 +        else
 +        {
-+            return new net.minecraft.world.biome.BiomeProvider(world.func_72912_H());
++            return new net.minecraft.world.biome.BiomeProvider(world.func_72912_H(), world);
 +        }
 +    }
 +

--- a/patches/minecraft/net/minecraft/world/biome/BiomeProvider.java.patch
+++ b/patches/minecraft/net/minecraft/world/biome/BiomeProvider.java.patch
@@ -1,6 +1,6 @@
 --- ../src-base/minecraft/net/minecraft/world/biome/BiomeProvider.java
 +++ ../src-work/minecraft/net/minecraft/world/biome/BiomeProvider.java
-@@ -22,11 +22,12 @@
+@@ -22,14 +22,19 @@
      private GenLayer field_76945_e;
      private final BiomeCache field_76942_f;
      private final List<Biome> field_76943_g;
@@ -14,21 +14,30 @@
      }
  
      private BiomeProvider(long p_i45744_1_, WorldType p_i45744_3_, String p_i45744_4_)
-@@ -39,6 +40,7 @@
++    { this(p_i45744_1_, p_i45744_3_, p_i45744_4_, null); }
++    public BiomeProvider(WorldInfo p_i46712_1_, net.minecraft.world.World world) // Forge: Added a World argument
++    { this(p_i46712_1_.func_76063_b(), p_i46712_1_.func_76067_t(), p_i46712_1_.func_82571_y(), world); }
++    private BiomeProvider(long p_i45744_1_, WorldType p_i45744_3_, String p_i45744_4_, net.minecraft.world.World world) // Forge: Added a World argument
+     {
+         this();
+ 
+@@ -38,7 +43,8 @@
+             this.field_190945_a = ChunkGeneratorSettings.Factory.func_177865_a(p_i45744_4_).func_177864_b();
          }
  
-         GenLayer[] agenlayer = GenLayer.func_180781_a(p_i45744_1_, p_i45744_3_, this.field_190945_a);
-+        agenlayer = getModdedBiomeGenerators(p_i45744_3_, p_i45744_1_, agenlayer);
+-        GenLayer[] agenlayer = GenLayer.func_180781_a(p_i45744_1_, p_i45744_3_, this.field_190945_a);
++        GenLayer[] agenlayer = GenLayer.initializeAllBiomeGenerators(p_i45744_1_, p_i45744_3_, this.field_190945_a, world);
++        agenlayer = getModdedBiomeGenerators(null, p_i45744_3_, p_i45744_1_, agenlayer);
          this.field_76944_d = agenlayer[0];
          this.field_76945_e = agenlayer[1];
      }
-@@ -207,6 +209,13 @@
+@@ -207,6 +213,13 @@
          this.field_76942_f.func_76838_a();
      }
  
-+    public GenLayer[] getModdedBiomeGenerators(WorldType worldType, long seed, GenLayer[] original)
++    public GenLayer[] getModdedBiomeGenerators(@javax.annotation.Nullable net.minecraft.world.World world, WorldType worldType, long seed, GenLayer[] original)
 +    {
-+        net.minecraftforge.event.terraingen.WorldTypeEvent.InitBiomeGens event = new net.minecraftforge.event.terraingen.WorldTypeEvent.InitBiomeGens(worldType, seed, original);
++        net.minecraftforge.event.terraingen.WorldTypeEvent.InitBiomeGens event = new net.minecraftforge.event.terraingen.WorldTypeEvent.InitBiomeGens(world, worldType, seed, original);
 +        net.minecraftforge.common.MinecraftForge.TERRAIN_GEN_BUS.post(event);
 +        return event.getNewBiomeGens();
 +    }

--- a/patches/minecraft/net/minecraft/world/gen/layer/GenLayer.java.patch
+++ b/patches/minecraft/net/minecraft/world/gen/layer/GenLayer.java.patch
@@ -1,10 +1,19 @@
 --- ../src-base/minecraft/net/minecraft/world/gen/layer/GenLayer.java
 +++ ../src-work/minecraft/net/minecraft/world/gen/layer/GenLayer.java
-@@ -47,11 +47,11 @@
+@@ -13,6 +13,8 @@
+     protected long field_75906_d;
+ 
+     public static GenLayer[] func_180781_a(long p_180781_0_, WorldType p_180781_2_, ChunkGeneratorSettings p_180781_3_)
++    { return initializeAllBiomeGenerators(p_180781_0_, p_180781_2_, p_180781_3_, null); }
++    public static GenLayer[] initializeAllBiomeGenerators(long p_180781_0_, WorldType p_180781_2_, ChunkGeneratorSettings p_180781_3_, net.minecraft.world.World world) // Forge: Added a World argument
+     {
+         GenLayer genlayer = new GenLayerIsland(1L);
+         genlayer = new GenLayerFuzzyZoom(2000L, genlayer);
+@@ -47,11 +49,11 @@
              i = 6;
          }
  
-+        i = getModdedBiomeSize(p_180781_2_, i);
++        i = getModdedBiomeSize(world, p_180781_2_, i);
 +
          GenLayer lvt_7_1_ = GenLayerZoom.func_75915_a(1000L, genlayer4, 0);
          GenLayer genlayerriverinit = new GenLayerRiverInit(100L, lvt_7_1_);
@@ -15,7 +24,7 @@
          GenLayer lvt_9_1_ = GenLayerZoom.func_75915_a(1000L, genlayerriverinit, 2);
          GenLayer genlayerhills = new GenLayerHills(1000L, genlayerbiomeedge, lvt_9_1_);
          GenLayer genlayer5 = GenLayerZoom.func_75915_a(1000L, genlayerriverinit, 2);
-@@ -171,10 +171,32 @@
+@@ -171,10 +173,32 @@
  
      protected static boolean func_151618_b(int p_151618_0_)
      {
@@ -39,9 +48,9 @@
 +        return j;
 +    }
 +
-+    public static int getModdedBiomeSize(WorldType worldType, int original)
++    public static int getModdedBiomeSize(@javax.annotation.Nullable net.minecraft.world.World world, WorldType worldType, int original)
 +    {
-+        net.minecraftforge.event.terraingen.WorldTypeEvent.BiomeSize event = new net.minecraftforge.event.terraingen.WorldTypeEvent.BiomeSize(worldType, original);
++        net.minecraftforge.event.terraingen.WorldTypeEvent.BiomeSize event = new net.minecraftforge.event.terraingen.WorldTypeEvent.BiomeSize(world, worldType, original);
 +        net.minecraftforge.common.MinecraftForge.TERRAIN_GEN_BUS.post(event);
 +        return event.getNewSize();
 +    }

--- a/src/main/java/net/minecraftforge/event/terraingen/WorldTypeEvent.java
+++ b/src/main/java/net/minecraftforge/event/terraingen/WorldTypeEvent.java
@@ -19,29 +19,41 @@
 
 package net.minecraftforge.event.terraingen;
 
+import javax.annotation.Nullable;
+import net.minecraft.world.World;
+import net.minecraft.world.WorldType;
 import net.minecraft.world.biome.BiomeProvider;
+import net.minecraft.world.gen.layer.GenLayer;
 import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.fml.common.eventhandler.Cancelable;
 import net.minecraftforge.fml.common.eventhandler.Event;
-import net.minecraft.world.gen.layer.GenLayer;
-import net.minecraft.world.WorldType;
 
 /**
  * WorldTypeEvent is fired when an event involving the world occurs.<br>
  * If a method utilizes this {@link Event} as its parameter, the method will
  * receive every child event of this class.<br>
  * <br>
+ * {@link #world} the world for which the event is being fired. Can be null in some cases, for example when converting an old map to Anvil format. <br>
  * {@link #worldType} contains the WorldType of the world this event is occurring in.<br>
  * <br>
  * All children of this event are fired on the {@link MinecraftForge#TERRAIN_GEN_BUS}.<br>
  **/
 public class WorldTypeEvent extends Event
 {
+    @Nullable
+    private final World world;
     private final WorldType worldType;
 
-    public WorldTypeEvent(WorldType worldType)
+    public WorldTypeEvent(@Nullable World world, WorldType worldType)
     {
+        this.world = world;
         this.worldType = worldType;
+    }
+
+    @Nullable
+    public World getWorld()
+    {
+        return this.world;
     }
 
     public WorldType getWorldType()
@@ -54,9 +66,10 @@ public class WorldTypeEvent extends Event
      * This event is fired during biome generation in
      * {@link GenLayer#initializeAllBiomeGenerators(long, WorldType, ChunkProviderSettings)}. <br>
      * <br>
-     * {@link #originalSize} the original size of the Biome. <br>
-     * {@link #newSize} the new size of the biome. Initially set to the {@link #originalSize}. <br>
-     * If {@link #newSize} is set to a new value, that value will be used for the Biome size. <br>
+     * {@link #world} the world for which the event is being fired. Can be null in some cases. <br>
+     * {@link #worldType} the WorldType of the world for which the event is being fired. <br>
+     * {@link #original} the original size of the Biome. <br>
+     * If {@link #setNewSize()} is called with a new value, that value will be used for the Biome size. <br>
      * <br>
      * This event is not {@link Cancelable}.<br>
      * <br>
@@ -69,9 +82,9 @@ public class WorldTypeEvent extends Event
         private final int originalSize;
         private int newSize;
 
-        public BiomeSize(WorldType worldType, int original)
+        public BiomeSize(@Nullable World world, WorldType worldType, int original)
         {
-            super(worldType);
+            super(world, worldType);
             originalSize = original;
             setNewSize(original);
         }
@@ -95,12 +108,13 @@ public class WorldTypeEvent extends Event
     /**
      * InitBiomeGens is fired when vanilla Minecraft attempts to initialize the biome providers.<br>
      * This event is fired just during biome provider initialization in
-     * {@link BiomeProvider#BiomeProvider(long, WorldType, String)}. <br>
+     * {@link BiomeProvider#BiomeProvider(World, long, WorldType, String)}. <br>
      * <br>
+     * {@link #world} the world for which the event is being fired. Can be null in some cases. <br>
+     * {@link #worldType} the WorldType of the world for which the event is being fired. <br>
      * {@link #seed} the seed of the world. <br>
-     * {@link #originalBiomeGens} the array of GenLayers original intended for this Biome generation. <br>
-     * {@link #newBiomeGens} the array of GenLayers that will now be used for this Biome generation. <br>
-     * If {@link #newBiomeGens} is set to a new value, that value will be used for the Biome generator. <br>
+     * {@link #original} the array of GenLayers originally intended for this Biome generation. <br>
+     * If {@link #setNewBiomeGens()} is called with an array of GenLayers, those will then be used for the Biome generator. <br>
      * <br>
      * This event is not {@link Cancelable}.<br>
      * <br>
@@ -114,9 +128,9 @@ public class WorldTypeEvent extends Event
         private final GenLayer[] originalBiomeGens;
         private GenLayer[] newBiomeGens;
 
-        public InitBiomeGens(WorldType worldType, long seed, GenLayer[] original)
+        public InitBiomeGens(@Nullable World world, WorldType worldType, long seed, GenLayer[] original)
         {
-            super(worldType);
+            super(world, worldType);
             this.seed = seed;
             originalBiomeGens = original;
             setNewBiomeGens(original.clone());

--- a/src/main/resources/forge.exc
+++ b/src/main/resources/forge.exc
@@ -61,3 +61,7 @@ net/minecraft/world/storage/loot/LootEntryEmpty.<init>(II[Lnet/minecraft/world/s
 net/minecraft/world/chunk/BlockStateContainer.setBits(IZ)V=|p_186012_1_,forceBits
 net/minecraft/village/Village.getPlayerReputation(Ljava/util/UUID;)I=|p_82684_1_
 net/minecraft/village/Village.modifyPlayerReputation(Ljava/util/UUID;I)I=|p_82688_1_,p_82688_2_
+
+net/minecraft/world/biome/BiomeProvider.<init>(Lnet/minecraft/world/storage/WorldInfo;Lnet/minecraft/world/World;)V=|p_i46712_1_,world
+net/minecraft/world/biome/BiomeProvider.<init>(JLnet/minecraft/world/WorldType;Ljava/lang/String;Lnet/minecraft/world/World;)V=|p_i45744_1_,p_i45744_3_,p_i45744_4_,world
+net/minecraft/world/gen/layer/GenLayer.initializeAllBiomeGenerators(JLnet/minecraft/world/WorldType;Lnet/minecraft/world/gen/ChunkGeneratorSettings;Lnet/minecraft/world/World;)[Lnet/minecraft/world/gen/layer/GenLayer;=|p_180781_0_,p_180781_2_,p_180781_3_,world


### PR DESCRIPTION
This adds a World argument to WorldTypeEvent.BiomeSize and WorldTypeEvent.InitBiomeGens, so that those events can be targeted to specific dimensions by mods.

The argument is optional (Nullable), because the BiomeProvider is sometimes created without access to a World, such as from the AnvilSaveConverter when converting pre-Anvil worlds to Anvil format.

Offtopic:
The patch still looks a bit funky because the constructor/method bodies changed to different methods. How should these be handled? Should those params be named to their srg names to keep the patches smaller?