### PR TITLE
Fix unblockable damage being blocked by armor. (#3933)

### DIFF
--- a/src/main/java/net/minecraftforge/common/ISpecialArmor.java
+++ b/src/main/java/net/minecraftforge/common/ISpecialArmor.java
@@ -118,6 +118,11 @@ public interface ISpecialArmor
          */
         public static float applyArmor(EntityLivingBase entity, NonNullList<ItemStack> inventory, DamageSource source, double damage)
         {
+            if (source.isUnblockable())
+            {
+                return (float)damage;
+            }
+
             if (DEBUG)
             {
                 System.out.println("Start: " + damage);
@@ -144,7 +149,7 @@ public interface ISpecialArmor
                     totalArmor += prop.Armor;
                     totalToughness += prop.Toughness;
                 }
-                else if (stack.getItem() instanceof ItemArmor && !source.isUnblockable())
+                else if (stack.getItem() instanceof ItemArmor)
                 {
                     ItemArmor armor = (ItemArmor)stack.getItem();
                     prop = new ArmorProperties(0, 0, Integer.MAX_VALUE);


### PR DESCRIPTION
Fix #3933 for 1.12.

This causes unblockable damage to not perform any armor calculations. This is similar to how the vanilla call EntityPlayer::applyArmorCalculations does nothing if the damage is marked as unblockable.

The bug exists in both 1.11 and 1.12, and so this should be merged back into 1.11.  Reference pull request #4103 for why this is being reopened.