### PR TITLE
Added RegistryEvent.PostRegister

### DIFF
--- a/src/main/java/net/minecraftforge/event/RegistryEvent.java
+++ b/src/main/java/net/minecraftforge/event/RegistryEvent.java
@@ -20,6 +20,7 @@
 package net.minecraftforge.event;
 
 import java.util.Collection;
+import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
 import org.apache.commons.lang3.Validate;
@@ -223,6 +224,24 @@ public class RegistryEvent<T extends IForgeRegistryEntry<T>> extends GenericEven
             {
                 return target;
             }
+        }
+    }
+
+    /**
+     * Perform additional registry related tasks
+     */
+    public static class PostRegister extends Event
+    {
+        private final Predicate<ResourceLocation> filter;
+        
+        public PostRegister(Predicate<ResourceLocation> filter)
+        {
+            this.filter = filter;
+        }
+        
+        public boolean includesRegistry(ResourceLocation name)
+        {
+            return this.filter.test(name);
         }
     }
 }

--- a/src/main/java/net/minecraftforge/registries/GameData.java
+++ b/src/main/java/net/minecraftforge/registries/GameData.java
@@ -698,6 +698,8 @@ public class GameData
             MinecraftForge.EVENT_BUS.post(RegistryManager.ACTIVE.getRegistry(rl).getRegisterEvent(rl));
         }
         ObjectHolderRegistry.INSTANCE.applyObjectHolders(); // inject everything else
+        MinecraftForge.EVENT_BUS.post(new RegistryEvent.PostRegister(filter));
+        ObjectHolderRegistry.INSTANCE.applyObjectHolders();
 
 
         /*


### PR DESCRIPTION
`RegistryEvent.PostRegister` can be used for registering blocks, items, or other registry entries that rely on other registries to be registered or for adding Items to the OreDictionary.