### PR TITLE
CloseApplicationEvent

### DIFF
--- a/patches/minecraft/net/minecraft/client/Minecraft.java.patch
+++ b/patches/minecraft/net/minecraft/client/Minecraft.java.patch
@@ -165,7 +165,24 @@
          }
  
          this.field_71424_I.func_76319_b();
-@@ -1399,9 +1419,9 @@
+@@ -1342,9 +1362,15 @@
+ 
+     public void func_71400_g()
+     {
+-        this.field_71425_J = false;
++        this.field_71425_J = net.minecraftforge.common.ForgeHooks.onApplicationClosed(true);
+     }
+ 
++    public void shutdown(boolean ignoreEvent)
++    {
++        if(ignoreEvent) this.field_71425_J = false;
++        else this.func_71400_g();
++    }
++
+     public void func_71381_h()
+     {
+         if (Display.isActive())
+@@ -1399,9 +1425,9 @@
              {
                  BlockPos blockpos = this.field_71476_x.func_178782_a();
  
@@ -177,7 +194,7 @@
                      this.field_71439_g.func_184609_a(EnumHand.MAIN_HAND);
                  }
              }
-@@ -1435,7 +1455,7 @@
+@@ -1435,7 +1461,7 @@
                      case BLOCK:
                          BlockPos blockpos = this.field_71476_x.func_178782_a();
  
@@ -186,7 +203,7 @@
                          {
                              this.field_71442_b.func_180511_b(blockpos, this.field_71476_x.field_178784_b);
                              break;
-@@ -1449,6 +1469,7 @@
+@@ -1449,6 +1475,7 @@
                          }
  
                          this.field_71439_g.func_184821_cY();
@@ -194,7 +211,7 @@
                  }
  
                  this.field_71439_g.func_184609_a(EnumHand.MAIN_HAND);
-@@ -1514,6 +1535,7 @@
+@@ -1514,6 +1541,7 @@
                          }
                      }
  
@@ -202,7 +219,7 @@
                      if (!itemstack.func_190926_b() && this.field_71442_b.func_187101_a(this.field_71439_g, this.field_71441_e, enumhand) == EnumActionResult.SUCCESS)
                      {
                          this.field_71460_t.field_78516_c.func_187460_a(enumhand);
-@@ -1620,6 +1642,8 @@
+@@ -1620,6 +1648,8 @@
              --this.field_71467_ac;
          }
  
@@ -211,7 +228,7 @@
          this.field_71424_I.func_76320_a("gui");
  
          if (!this.field_71445_n)
-@@ -1731,6 +1755,7 @@
+@@ -1731,6 +1761,7 @@
                      this.field_71457_ai = 0;
                      this.field_71441_e.func_72897_h(this.field_71439_g);
                  }
@@ -219,7 +236,7 @@
              }
  
              this.field_71424_I.func_76318_c("gameRenderer");
-@@ -1819,6 +1844,7 @@
+@@ -1819,6 +1850,7 @@
          }
  
          this.field_71424_I.func_76319_b();
@@ -227,7 +244,7 @@
          this.field_71423_H = func_71386_F();
      }
  
-@@ -1924,6 +1950,7 @@
+@@ -1924,6 +1956,7 @@
                      }
                  }
              }
@@ -235,7 +252,7 @@
          }
  
          this.func_184117_aA();
-@@ -2170,6 +2197,8 @@
+@@ -2170,6 +2203,8 @@
      {
          while (Mouse.next())
          {
@@ -244,7 +261,7 @@
              int i = Mouse.getEventButton();
              KeyBinding.func_74510_a(i - 100, Mouse.getEventButtonState());
  
-@@ -2235,6 +2264,7 @@
+@@ -2235,6 +2270,7 @@
  
      public void func_71371_a(String p_71371_1_, String p_71371_2_, @Nullable WorldSettings p_71371_3_)
      {
@@ -252,7 +269,7 @@
          this.func_71403_a((WorldClient)null);
          System.gc();
          ISaveHandler isavehandler = this.field_71469_aa.func_75804_a(p_71371_1_, false);
-@@ -2277,6 +2307,12 @@
+@@ -2277,6 +2313,12 @@
  
          while (!this.field_71437_Z.func_71200_ad())
          {
@@ -265,7 +282,7 @@
              String s = this.field_71437_Z.func_71195_b_();
  
              if (s != null)
-@@ -2302,8 +2338,14 @@
+@@ -2302,8 +2344,14 @@
          SocketAddress socketaddress = this.field_71437_Z.func_147137_ag().func_151270_a();
          NetworkManager networkmanager = NetworkManager.func_150722_a(socketaddress);
          networkmanager.func_150719_a(new NetHandlerLoginClient(networkmanager, this, (GuiScreen)null));
@@ -282,7 +299,7 @@
          this.field_71453_ak = networkmanager;
      }
  
-@@ -2314,6 +2356,8 @@
+@@ -2314,6 +2362,8 @@
  
      public void func_71353_a(@Nullable WorldClient p_71353_1_, String p_71353_2_)
      {
@@ -291,7 +308,7 @@
          if (p_71353_1_ == null)
          {
              NetHandlerPlayClient nethandlerplayclient = this.func_147114_u();
-@@ -2326,6 +2370,18 @@
+@@ -2326,6 +2376,18 @@
              if (this.field_71437_Z != null && this.field_71437_Z.func_175578_N())
              {
                  this.field_71437_Z.func_71263_m();
@@ -310,7 +327,7 @@
              }
  
              this.field_71437_Z = null;
-@@ -2349,6 +2405,7 @@
+@@ -2349,6 +2411,7 @@
              this.field_71456_v.func_181029_i();
              this.func_71351_a((ServerData)null);
              this.field_71455_al = false;
@@ -318,7 +335,7 @@
          }
  
          this.field_147127_av.func_147690_c();
-@@ -2466,159 +2523,8 @@
+@@ -2466,159 +2529,8 @@
      {
          if (this.field_71476_x != null && this.field_71476_x.field_72313_a != RayTraceResult.Type.MISS)
          {
@@ -480,7 +497,7 @@
          }
      }
  
-@@ -2921,18 +2827,8 @@
+@@ -2921,18 +2833,8 @@
  
      public static int func_71369_N()
      {
@@ -501,7 +518,7 @@
      }
  
      public boolean func_70002_Q()
-@@ -3071,15 +2967,16 @@
+@@ -3071,15 +2973,16 @@
              {
                  if (Keyboard.getEventKeyState())
                  {
@@ -520,7 +537,7 @@
              }
          }
      }
-@@ -3199,6 +3096,12 @@
+@@ -3199,6 +3102,12 @@
          return this.field_184127_aH;
      }
  

--- a/patches/minecraft/net/minecraft/server/MinecraftServer.java.patch
+++ b/patches/minecraft/net/minecraft/server/MinecraftServer.java.patch
@@ -110,7 +110,23 @@
          }
  
          if (this.field_71307_n.func_76468_d())
-@@ -461,6 +441,7 @@
+@@ -452,15 +432,22 @@
+ 
+     public void func_71263_m()
+     {
+-        this.field_71317_u = false;
++        this.field_71317_u = net.minecraftforge.common.ForgeHooks.onApplicationClosed(false);
+     }
+ 
++    public void initiateShutdown(boolean ignoreEvent)
++    {
++        if(ignoreEvent) this.field_71317_u = false;
++        else this.func_71263_m();
++    }
++
+     public void run()
+     {
+         try
          {
              if (this.func_71197_b())
              {
@@ -118,7 +134,7 @@
                  this.field_175591_ab = func_130071_aq();
                  long i = 0L;
                  this.field_147147_p.func_151315_a(new TextComponentString(this.field_71286_C));
-@@ -505,12 +486,20 @@
+@@ -505,12 +492,20 @@
                      Thread.sleep(Math.max(1L, 50L - i));
                      this.field_71296_Q = true;
                  }
@@ -139,7 +155,7 @@
          catch (Throwable throwable1)
          {
              field_147145_h.error("Encountered an unexpected exception", throwable1);
-@@ -536,14 +525,15 @@
+@@ -536,14 +531,15 @@
                  field_147145_h.error("We were unable to save this crash report to disk.");
              }
  
@@ -156,7 +172,7 @@
              }
              catch (Throwable throwable)
              {
-@@ -551,6 +541,8 @@
+@@ -551,6 +547,8 @@
              }
              finally
              {
@@ -165,7 +181,7 @@
                  this.func_71240_o();
              }
          }
-@@ -618,6 +610,7 @@
+@@ -618,6 +616,7 @@
      public void func_71217_p()
      {
          long i = System.nanoTime();
@@ -173,7 +189,7 @@
          ++this.field_71315_w;
  
          if (this.field_71295_T)
-@@ -644,6 +637,7 @@
+@@ -644,6 +643,7 @@
  
              Collections.shuffle(Arrays.asList(agameprofile));
              this.field_147147_p.func_151318_b().func_151330_a(agameprofile);
@@ -181,7 +197,7 @@
          }
  
          if (this.field_71315_w % 900 == 0)
-@@ -671,6 +665,7 @@
+@@ -671,6 +671,7 @@
  
          this.field_71304_b.func_76319_b();
          this.field_71304_b.func_76319_b();
@@ -189,7 +205,7 @@
      }
  
      public void func_71190_q()
-@@ -686,24 +681,28 @@
+@@ -686,24 +687,28 @@
          }
  
          this.field_71304_b.func_76318_c("levels");
@@ -222,7 +238,7 @@
  
                  try
                  {
-@@ -727,6 +726,7 @@
+@@ -727,6 +732,7 @@
                      throw new ReportedException(crashreport1);
                  }
  
@@ -230,7 +246,7 @@
                  this.field_71304_b.func_76319_b();
                  this.field_71304_b.func_76320_a("tracker");
                  worldserver.func_73039_n().func_72788_a();
-@@ -734,9 +734,11 @@
+@@ -734,9 +740,11 @@
                  this.field_71304_b.func_76319_b();
              }
  
@@ -243,7 +259,7 @@
          this.field_71304_b.func_76318_c("connection");
          this.func_147137_ag().func_151269_c();
          this.field_71304_b.func_76318_c("players");
-@@ -758,7 +760,8 @@
+@@ -758,7 +766,8 @@
  
      public void func_71256_s()
      {
@@ -253,7 +269,7 @@
          this.field_175590_aa.start();
      }
  
-@@ -774,7 +777,13 @@
+@@ -774,7 +783,13 @@
  
      public WorldServer func_71218_a(int p_71218_1_)
      {
@@ -268,7 +284,7 @@
      }
  
      public String func_71249_w()
-@@ -804,7 +813,7 @@
+@@ -804,7 +819,7 @@
  
      public String getServerModName()
      {

--- a/src/main/java/net/minecraftforge/common/ForgeHooks.java
+++ b/src/main/java/net/minecraftforge/common/ForgeHooks.java
@@ -95,10 +95,7 @@ import net.minecraft.world.storage.loot.LootTable;
 import net.minecraft.world.storage.loot.LootTableManager;
 import net.minecraft.world.storage.loot.conditions.LootCondition;
 import net.minecraftforge.common.util.BlockSnapshot;
-import net.minecraftforge.event.AnvilUpdateEvent;
-import net.minecraftforge.event.DifficultyChangeEvent;
-import net.minecraftforge.event.ForgeEventFactory;
-import net.minecraftforge.event.ServerChatEvent;
+import net.minecraftforge.event.*;
 import net.minecraftforge.event.entity.EntityTravelToDimensionEvent;
 import net.minecraftforge.event.entity.ThrowableImpactEvent;
 import net.minecraftforge.event.entity.item.ItemTossEvent;
@@ -995,6 +992,12 @@ public class ForgeHooks
         {
             return eyes < pos.getY() + 1 + filled;
         }
+    }
+
+    public static boolean onApplicationClosed(boolean isClient)
+    {
+        ApplicationCloseEvent evt = new ApplicationCloseEvent(isClient);
+        return MinecraftForge.EVENT_BUS.post(evt);
     }
 
     public static boolean onPlayerAttackTarget(EntityPlayer player, Entity target)

--- a/src/main/java/net/minecraftforge/event/ApplicationCloseEvent.java
+++ b/src/main/java/net/minecraftforge/event/ApplicationCloseEvent.java
@@ -1,0 +1,45 @@
+package net.minecraftforge.event;
+
+import net.minecraft.client.Minecraft;
+import net.minecraft.server.MinecraftServer;
+import net.minecraftforge.fml.common.eventhandler.Cancelable;
+import net.minecraftforge.fml.common.eventhandler.Event;
+
+/**
+ * Fired whenever the client or server application is scheduled to be shut down.
+ * This event is fired during the invocation of either {@link Minecraft#shutdown()} (window closed, quit game button pressed)
+ * on the client or {@link MinecraftServer#initiateShutdown()} ({@link net.minecraft.command.server.CommandStop} run, window closed)
+ * on the server. <br>
+ * <br>
+ * {@link #isClient} check whether the client or the server is shutting down.<br>
+ * <br>
+ * This event is {@link Cancelable} <br>
+ * If the event is canceled the application will not close.<br>
+ * <br>
+ * This event does not have a result. {@link net.minecraftforge.fml.common.eventhandler.Event.HasResult}<br>
+ * <br>
+ * This event is fired on the {@link net.minecraftforge.common.MinecraftForge#EVENT_BUS}.<br>
+ * <br>
+ * Call {@link Minecraft#shutdown(boolean)} with true to ignore the firing of this event.
+ */
+@Cancelable
+public class ApplicationCloseEvent extends Event
+{
+  private final boolean isClient;
+
+  public ApplicationCloseEvent(boolean isClient)
+  {
+    this.isClient = isClient;
+  }
+
+  @Override
+  public void setCanceled(boolean canceled)
+  {
+    super.setCanceled(canceled);
+  }
+
+  public boolean isClient()
+  {
+    return isClient;
+  }
+}


### PR DESCRIPTION
An event which can be used to close libraries and save files before the application closes. The event is called in _Minecraft#shutdown_ and _MinecraftServer#initiateShutdown_. Canceling the event will cause the application to not close. To prevent a loophole it is possible to call _Minecraft#shutdown(true)_ and _MinecraftServer#initiateShutdown(true)_. These methods, if the parameter is true, will ignore the calling of the event and shutdown either way.

To present one of the uses with this event I have created an example mod that prompts the user on both sides, instead of shutting down immediately (linked [here](https://github.com/adudewithapc/ConfirmExitExample)). 