### PR TITLE
Allow for sleeping without a bed

### DIFF
--- a/patches/minecraft/net/minecraft/entity/player/EntityPlayer.java.patch
+++ b/patches/minecraft/net/minecraft/entity/player/EntityPlayer.java.patch
@@ -281,8 +281,8 @@
 -        EnumFacing enumfacing = (EnumFacing)this.field_70170_p.func_180495_p(p_180469_1_).func_177229_b(BlockHorizontal.field_185512_D);
 +        EntityPlayer.SleepResult ret = net.minecraftforge.event.ForgeEventFactory.onPlayerSleepInBed(this, p_180469_1_);
 +        if (ret != null) return ret;
-+        IBlockState state = this.field_70170_p.func_175667_e(p_180469_1_) ? this.field_70170_p.func_180495_p(p_180469_1_) : null;
-+        EnumFacing enumfacing = state.func_177230_c() instanceof BlockHorizontal ? (EnumFacing)state.func_177229_b(BlockHorizontal.field_185512_D) : null;
++        IBlockState bedState = this.field_70170_p.func_175667_e(p_180469_1_) ? this.field_70170_p.func_180495_p(p_180469_1_) : null;
++        EnumFacing enumfacing = bedState != null && bedState.func_177230_c() instanceof BlockHorizontal ? (EnumFacing)bedState.func_177229_b(BlockHorizontal.field_185512_D) : null;
  
          if (!this.field_70170_p.field_72995_K)
          {
@@ -295,17 +295,19 @@
              {
                  return EntityPlayer.SleepResult.TOO_FAR_AWAY;
              }
-@@ -1484,8 +1569,7 @@
+@@ -1484,8 +1569,9 @@
          this.func_192030_dh();
          this.func_70105_a(0.2F, 0.2F);
  
 -        if (this.field_70170_p.func_175667_e(p_180469_1_))
 -        {
++        IBlockState state = null;
++        if (this.field_70170_p.func_175667_e(p_180469_1_)) state = this.field_70170_p.func_180495_p(p_180469_1_);
 +        if (state != null && enumfacing != null && state.func_177230_c().isBed(state, this.field_70170_p, p_180469_1_, this)) {
              float f1 = 0.5F + (float)enumfacing.func_82601_c() * 0.4F;
              float f = 0.5F + (float)enumfacing.func_82599_e() * 0.4F;
              this.func_175139_a(enumfacing);
-@@ -1532,13 +1616,14 @@
+@@ -1532,13 +1618,14 @@
  
      public void func_70999_a(boolean p_70999_1_, boolean p_70999_2_, boolean p_70999_3_)
      {
@@ -323,7 +325,7 @@
  
              if (blockpos == null)
              {
-@@ -1547,6 +1632,10 @@
+@@ -1547,6 +1634,10 @@
  
              this.func_70107_b((double)((float)blockpos.func_177958_n() + 0.5F), (double)((float)blockpos.func_177956_o() + 0.1F), (double)((float)blockpos.func_177952_p() + 0.5F));
          }
@@ -334,7 +336,7 @@
  
          this.field_71083_bS = false;
  
-@@ -1565,15 +1654,16 @@
+@@ -1565,15 +1656,16 @@
  
      private boolean func_175143_p()
      {
@@ -354,7 +356,7 @@
          {
              if (!p_180467_2_)
              {
-@@ -1588,16 +1678,17 @@
+@@ -1588,16 +1680,17 @@
          }
          else
          {
@@ -375,7 +377,7 @@
  
              switch (enumfacing)
              {
-@@ -1637,16 +1728,24 @@
+@@ -1637,16 +1730,24 @@
  
      public BlockPos func_180470_cg()
      {
@@ -402,7 +404,7 @@
          if (p_180473_1_ != null)
          {
              this.field_71077_c = p_180473_1_;
-@@ -1839,6 +1938,10 @@
+@@ -1839,6 +1940,10 @@
  
              super.func_180430_e(p_180430_1_, p_180430_2_);
          }
@@ -413,7 +415,7 @@
      }
  
      protected void func_71061_d_()
-@@ -2176,7 +2279,10 @@
+@@ -2176,7 +2281,10 @@
  
      public ITextComponent func_145748_c_()
      {
@@ -425,7 +427,7 @@
          itextcomponent.func_150256_b().func_150241_a(new ClickEvent(ClickEvent.Action.SUGGEST_COMMAND, "/msg " + this.func_70005_c_() + " "));
          itextcomponent.func_150256_b().func_150209_a(this.func_174823_aP());
          itextcomponent.func_150256_b().func_179989_a(this.func_70005_c_());
-@@ -2185,7 +2291,7 @@
+@@ -2185,7 +2293,7 @@
  
      public float func_70047_e()
      {
@@ -434,7 +436,7 @@
  
          if (this.func_70608_bn())
          {
-@@ -2421,6 +2527,168 @@
+@@ -2421,6 +2529,168 @@
          return this.field_71075_bZ.field_75098_d && this.func_70003_b(2, "");
      }
  

--- a/patches/minecraft/net/minecraft/entity/player/EntityPlayer.java.patch
+++ b/patches/minecraft/net/minecraft/entity/player/EntityPlayer.java.patch
@@ -274,35 +274,44 @@
                                  this.func_184611_a(EnumHand.MAIN_HAND, ItemStack.field_190927_a);
                              }
                          }
-@@ -1442,6 +1524,8 @@
+@@ -1442,7 +1524,10 @@
  
      public EntityPlayer.SleepResult func_180469_a(BlockPos p_180469_1_)
      {
+-        EnumFacing enumfacing = (EnumFacing)this.field_70170_p.func_180495_p(p_180469_1_).func_177229_b(BlockHorizontal.field_185512_D);
 +        EntityPlayer.SleepResult ret = net.minecraftforge.event.ForgeEventFactory.onPlayerSleepInBed(this, p_180469_1_);
 +        if (ret != null) return ret;
-         EnumFacing enumfacing = (EnumFacing)this.field_70170_p.func_180495_p(p_180469_1_).func_177229_b(BlockHorizontal.field_185512_D);
++        IBlockState state = this.field_70170_p.func_175667_e(p_180469_1_) ? this.field_70170_p.func_180495_p(p_180469_1_) : null;
++        EnumFacing enumfacing = state.func_177230_c() instanceof BlockHorizontal ? (EnumFacing)state.func_177229_b(BlockHorizontal.field_185512_D) : null;
  
          if (!this.field_70170_p.field_72995_K)
-@@ -1484,8 +1568,9 @@
+         {
+@@ -1461,7 +1546,7 @@
+                 return EntityPlayer.SleepResult.NOT_POSSIBLE_NOW;
+             }
+ 
+-            if (!this.func_190774_a(p_180469_1_, enumfacing))
++            if (enumfacing != null && !this.func_190774_a(p_180469_1_, enumfacing))
+             {
+                 return EntityPlayer.SleepResult.TOO_FAR_AWAY;
+             }
+@@ -1484,8 +1569,7 @@
          this.func_192030_dh();
          this.func_70105_a(0.2F, 0.2F);
  
 -        if (this.field_70170_p.func_175667_e(p_180469_1_))
 -        {
-+        IBlockState state = null;
-+        if (this.field_70170_p.func_175667_e(p_180469_1_)) state = this.field_70170_p.func_180495_p(p_180469_1_);
-+        if (state != null && state.func_177230_c().isBed(state, this.field_70170_p, p_180469_1_, this)) {
++        if (state != null && enumfacing != null && state.func_177230_c().isBed(state, this.field_70170_p, p_180469_1_, this)) {
              float f1 = 0.5F + (float)enumfacing.func_82601_c() * 0.4F;
              float f = 0.5F + (float)enumfacing.func_82599_e() * 0.4F;
              this.func_175139_a(enumfacing);
-@@ -1532,13 +1617,14 @@
+@@ -1532,13 +1616,14 @@
  
      public void func_70999_a(boolean p_70999_1_, boolean p_70999_2_, boolean p_70999_3_)
      {
 +        net.minecraftforge.event.ForgeEventFactory.onPlayerWakeup(this, p_70999_1_, p_70999_2_, p_70999_3_);
          this.func_70105_a(0.6F, 1.8F);
--        IBlockState iblockstate = this.field_70170_p.func_180495_p(this.field_71081_bT);
-+        IBlockState iblockstate = this.field_71081_bT != null ? this.field_70170_p.func_180495_p(this.field_71081_bT) : null;
+         IBlockState iblockstate = this.field_70170_p.func_180495_p(this.field_71081_bT);
  
 -        if (this.field_71081_bT != null && iblockstate.func_177230_c() == Blocks.field_150324_C)
 +        if (this.field_71081_bT != null && iblockstate.func_177230_c().isBed(iblockstate, field_70170_p, field_71081_bT, this))
@@ -314,7 +323,7 @@
  
              if (blockpos == null)
              {
-@@ -1547,6 +1633,10 @@
+@@ -1547,6 +1632,10 @@
  
              this.func_70107_b((double)((float)blockpos.func_177958_n() + 0.5F), (double)((float)blockpos.func_177956_o() + 0.1F), (double)((float)blockpos.func_177952_p() + 0.5F));
          }
@@ -325,7 +334,7 @@
  
          this.field_71083_bS = false;
  
-@@ -1565,15 +1655,16 @@
+@@ -1565,15 +1654,16 @@
  
      private boolean func_175143_p()
      {
@@ -345,7 +354,7 @@
          {
              if (!p_180467_2_)
              {
-@@ -1588,16 +1679,17 @@
+@@ -1588,16 +1678,17 @@
          }
          else
          {
@@ -366,7 +375,7 @@
  
              switch (enumfacing)
              {
-@@ -1637,16 +1729,24 @@
+@@ -1637,16 +1728,24 @@
  
      public BlockPos func_180470_cg()
      {
@@ -393,7 +402,7 @@
          if (p_180473_1_ != null)
          {
              this.field_71077_c = p_180473_1_;
-@@ -1839,6 +1939,10 @@
+@@ -1839,6 +1938,10 @@
  
              super.func_180430_e(p_180430_1_, p_180430_2_);
          }
@@ -404,7 +413,7 @@
      }
  
      protected void func_71061_d_()
-@@ -2176,7 +2280,10 @@
+@@ -2176,7 +2279,10 @@
  
      public ITextComponent func_145748_c_()
      {
@@ -416,7 +425,7 @@
          itextcomponent.func_150256_b().func_150241_a(new ClickEvent(ClickEvent.Action.SUGGEST_COMMAND, "/msg " + this.func_70005_c_() + " "));
          itextcomponent.func_150256_b().func_150209_a(this.func_174823_aP());
          itextcomponent.func_150256_b().func_179989_a(this.func_70005_c_());
-@@ -2185,7 +2292,7 @@
+@@ -2185,7 +2291,7 @@
  
      public float func_70047_e()
      {
@@ -425,7 +434,7 @@
  
          if (this.func_70608_bn())
          {
-@@ -2421,6 +2528,168 @@
+@@ -2421,6 +2527,168 @@
          return this.field_71075_bZ.field_75098_d && this.func_70003_b(2, "");
      }
  

--- a/patches/minecraft/net/minecraft/entity/player/EntityPlayer.java.patch
+++ b/patches/minecraft/net/minecraft/entity/player/EntityPlayer.java.patch
@@ -301,7 +301,8 @@
      {
 +        net.minecraftforge.event.ForgeEventFactory.onPlayerWakeup(this, p_70999_1_, p_70999_2_, p_70999_3_);
          this.func_70105_a(0.6F, 1.8F);
-         IBlockState iblockstate = this.field_70170_p.func_180495_p(this.field_71081_bT);
+-        IBlockState iblockstate = this.field_70170_p.func_180495_p(this.field_71081_bT);
++        IBlockState iblockstate = this.field_71081_bT != null ? this.field_70170_p.func_180495_p(this.field_71081_bT) : null;
  
 -        if (this.field_71081_bT != null && iblockstate.func_177230_c() == Blocks.field_150324_C)
 +        if (this.field_71081_bT != null && iblockstate.func_177230_c().isBed(iblockstate, field_70170_p, field_71081_bT, this))


### PR DESCRIPTION
~~As of 1.12, the game will crash in EntityPlayer#wakeUpPlayer if no bed location has been set. This breaks items like sleeping bags, and is clearly not the intended behavior, as there is a null check for bedLocation just two lines later.~~

~~This PR adds a null check to the assignment of the iblockstate location variable, only calling `world.getBlockState(bedLocation)` if bedLocation is not null (otherwise assigning iblockstate to null). All usages of iblockstate are already wrapped in a `bedLocation != null`-if, so this should not cause any unintended errors.~~

As of 1.12, the game crashes if EntityPlayer#trySleep is called with a bed location whose block is not an instance of BlockHorizontal. This PR prevents this by adding an instanceof check before calling BlockHorizontal-specific code.

As a result, the "too far away" sleep result will never be returned for non-bed sleep, and the positioning logic will be somewhat different. Mods will have to account for this.