### PR TITLE
[1.12] add support for vanilla "nbt strings" in json recipe ingredients

### DIFF
--- a/src/main/java/net/minecraftforge/common/crafting/CraftingHelper.java
+++ b/src/main/java/net/minecraftforge/common/crafting/CraftingHelper.java
@@ -218,7 +218,13 @@ public class CraftingHelper {
             // Lets hope this works? Needs test
             try
             {
-                NBTTagCompound nbt = JsonToNBT.getTagFromJson(GSON.toJson(json.get("nbt")));
+                JsonElement element = json.get("nbt");
+                NBTTagCompound nbt;
+                if(element.isJsonObject())
+                    nbt = JsonToNBT.getTagFromJson(GSON.toJson(element));
+                else
+                    nbt = JsonToNBT.getTagFromJson(element.getAsString());
+
                 NBTTagCompound tmp = new NBTTagCompound();
                 if (nbt.hasKey("ForgeCaps"))
                 {


### PR DESCRIPTION
## Why
The `IngredientNBT` currently requires the `nbt` json element to be a json object. Due to the limitations of JSON, it is only possible to create elements with either string or number primitives.

Some mods require the parsed NBT to have certain NBT Tag types, like byte instead of int, which is not possible with the current parsing behavior. `Ingredient#apply()` will return false If the NBT Tag Types do not match. (see `net.minecraft.nbt.NBTBase#equals()` and NBTTagByte for example)

## How
The JsonToNBT class handles parsing specific tag types if the values have a certain value suffix, i.e. `b` for byte, `f` for floats, etc. Those values must not be in quotation marks, otherwise the value is parsed as a string.

To allow the `IngredientNBT` class to generate proper nbt types, we need to pass a string without leading/trailing quotes to `JsonToNBT.getTagFromJson()`. This is achieved by calling element.getAsString() because converting a string element `toJson` will produce a quoted string which cannot be parsed by `getTagFromJson()`

This PR adds support for those "Vanilla NBT Json Strings" while preserving the support for object based NBT definitions.