### PR TITLE
Allow advancement icons to have nbt

### DIFF
--- a/patches/minecraft/net/minecraft/advancements/DisplayInfo.java.patch
+++ b/patches/minecraft/net/minecraft/advancements/DisplayInfo.java.patch
@@ -1,21 +1,12 @@
 --- ../src-base/minecraft/net/minecraft/advancements/DisplayInfo.java
 +++ ../src-work/minecraft/net/minecraft/advancements/DisplayInfo.java
-@@ -132,7 +132,18 @@
+@@ -132,7 +132,9 @@
          {
              Item item = JsonUtils.func_188180_i(p_193221_0_, "item");
              int i = JsonUtils.func_151208_a(p_193221_0_, "data", 0);
 -            return new ItemStack(item, 1, i);
 +            ItemStack ret = new ItemStack(item, 1, i);
-+            if (JsonUtils.func_151204_g(p_193221_0_, "nbt"))
-+            {
-+                try
-+                {
-+                    ret.func_77982_d(net.minecraft.nbt.JsonToNBT.func_180713_a(JsonUtils.func_151200_h(p_193221_0_, "nbt")));
-+                } catch (net.minecraft.nbt.NBTException ex)
-+                {
-+                    throw new JsonSyntaxException("Malformed nbt tag", ex);
-+                }
-+            }
++            ret.func_77982_d(net.minecraftforge.common.util.JsonUtils.readNBT(p_193221_0_, "nbt"));
 +            return ret;
          }
      }

--- a/patches/minecraft/net/minecraft/advancements/DisplayInfo.java.patch
+++ b/patches/minecraft/net/minecraft/advancements/DisplayInfo.java.patch
@@ -1,0 +1,22 @@
+--- ../src-base/minecraft/net/minecraft/advancements/DisplayInfo.java
++++ ../src-work/minecraft/net/minecraft/advancements/DisplayInfo.java
+@@ -132,7 +132,18 @@
+         {
+             Item item = JsonUtils.func_188180_i(p_193221_0_, "item");
+             int i = JsonUtils.func_151208_a(p_193221_0_, "data", 0);
+-            return new ItemStack(item, 1, i);
++            ItemStack ret = new ItemStack(item, 1, i);
++            if (JsonUtils.func_151204_g(p_193221_0_, "nbt"))
++            {
++                try
++                {
++                    ret.func_77982_d(net.minecraft.nbt.JsonToNBT.func_180713_a(JsonUtils.func_151200_h(p_193221_0_, "nbt")));
++                } catch (net.minecraft.nbt.NBTException ex)
++                {
++                    throw new JsonSyntaxException("Malformed nbt tag", ex);
++                }
++            }
++            return ret;
+         }
+     }
+ 

--- a/src/main/java/net/minecraftforge/common/util/JsonUtils.java
+++ b/src/main/java/net/minecraftforge/common/util/JsonUtils.java
@@ -31,9 +31,16 @@ import com.google.common.reflect.TypeToken;
 import com.google.gson.JsonDeserializationContext;
 import com.google.gson.JsonDeserializer;
 import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
 import com.google.gson.JsonParseException;
 import com.google.gson.JsonSerializationContext;
 import com.google.gson.JsonSerializer;
+import com.google.gson.JsonSyntaxException;
+import net.minecraft.nbt.JsonToNBT;
+import net.minecraft.nbt.NBTException;
+import net.minecraft.nbt.NBTTagCompound;
+
+import javax.annotation.Nullable;
 
 public class JsonUtils
 {
@@ -85,6 +92,24 @@ public class JsonUtils
             final Type[] typeArguments = ((ParameterizedType) type).getActualTypeArguments();
             final Type parameterizedType = mapOf(typeArguments[1]).getType();
             return context.serialize(src, parameterizedType);
+        }
+    }
+
+    @Nullable
+    public static NBTTagCompound readNBT(JsonObject json, String key)
+    {
+        if (net.minecraft.util.JsonUtils.hasField(json, key))
+        {
+            try
+            {
+                return JsonToNBT.getTagFromJson(net.minecraft.util.JsonUtils.getString(json, key));
+            } catch (NBTException e)
+            {
+                throw new JsonSyntaxException("Malformed NBT tag", e);
+            }
+        } else
+        {
+            return null;
         }
     }
 


### PR DESCRIPTION
Why doesn't Mojang standardize this -.-
Uses the format `"nbt": "{k: v, k: v}"`, the same as vanilla loot tables, advancement predicates, tellraw, etc.