### PR TITLE
Fix missing messages of missing models

### DIFF
--- a/src/main/java/net/minecraftforge/client/model/FancyMissingModel.java
+++ b/src/main/java/net/minecraftforge/client/model/FancyMissingModel.java
@@ -85,7 +85,7 @@ final class FancyMissingModel implements IModel
         return new BakedModel(bigMissing, smallMissing, fontCache.getUnchecked(format), message, bakedTextureGetter.apply(font2));
     }
 
-    private static final class BakedModel implements IBakedModel
+    static final class BakedModel implements IBakedModel
     {
         private final SimpleModelFontRenderer fontRenderer;
         private final String message;

--- a/src/main/java/net/minecraftforge/client/model/ModelLoader.java
+++ b/src/main/java/net/minecraftforge/client/model/ModelLoader.java
@@ -1000,7 +1000,7 @@ public final class ModelLoader extends ModelBakery
             {
                 ModelResourceLocation location = (ModelResourceLocation)entry.getKey();
                 IBakedModel model = modelRegistry.getObject(location);
-                if(model == null || model == missingModel)
+                if(model == null || model == missingModel || model instanceof FancyMissingModel.BakedModel)
                 {
                     String domain = entry.getKey().getResourceDomain();
                     Integer errorCountBox = modelErrors.get(domain);


### PR DESCRIPTION
Since dc043ac the fancy missing model is used more often for displaying missing models. While you see the missing models in game, the log message is missing, which makes debugging a lot more difficult.