### PR TITLE
Issue 2236. Fixed property losing state after rename.

### DIFF
--- a/src/main/java/net/minecraftforge/common/config/Configuration.java
+++ b/src/main/java/net/minecraftforge/common/config/Configuration.java
@@ -1412,10 +1412,12 @@ public class Configuration
     {
         if (hasCategory(category))
         {
-            if (getCategory(category).containsKey(oldPropName) && !oldPropName.equalsIgnoreCase(newPropName))
+            ConfigCategory cat = getCategory(category);
+            if (cat.containsKey(oldPropName) && !oldPropName.equalsIgnoreCase(newPropName))
             {
-                get(category, newPropName, getCategory(category).get(oldPropName).getString(), "");
-                getCategory(category).remove(oldPropName);
+                Property prop = cat.remove(oldPropName);
+                prop.setName(newPropName);
+                cat.put(newPropName, prop);
                 return true;
             }
         }

--- a/src/test/java/net/minecraftforge/test/ConfigurationTest.java
+++ b/src/test/java/net/minecraftforge/test/ConfigurationTest.java
@@ -1,0 +1,79 @@
+package net.minecraftforge.test;
+
+
+import net.minecraft.init.Bootstrap;
+import net.minecraftforge.common.config.ConfigCategory;
+import net.minecraftforge.common.config.Configuration;
+import net.minecraftforge.common.config.Property;
+import net.minecraftforge.fml.common.Loader;
+import net.minecraftforge.fml.common.registry.ForgeTestRunner;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import static junit.framework.TestCase.assertNull;
+import static org.junit.Assert.*;
+
+@RunWith(ForgeTestRunner.class)
+public class ConfigurationTest {
+
+    private Configuration config;
+    private ConfigCategory category;
+
+    @BeforeClass
+    public static void setupClass()
+    {
+        Loader.instance();
+        Bootstrap.register();
+    }
+
+    @Before
+    public void setup()
+    {
+        Property enabledProperty = new Property("enabled", "true", Property.Type.BOOLEAN);
+        enabledProperty.setComment("enabled property comment");
+
+        Property backgroundProperty = new Property("background", "0xFFFFFF", Property.Type.COLOR);
+        backgroundProperty.setComment("background property comment");
+
+        config = new Configuration();
+        category = config.getCategory("defaults");
+        category.put(enabledProperty.getName(), enabledProperty);
+        category.put(backgroundProperty.getName(), backgroundProperty);
+    }
+
+    @Test
+    public void testRenameProperty_newNameNotInUse()
+    {
+        boolean propertyRenamed = config.renameProperty("defaults", "enabled", "defaultEnabled");
+
+        Property enabledProperty = category.get("enabled");
+        Property defaultEnabledProperty = category.get("defaultEnabled");
+
+        assertTrue("Property was not renamed", propertyRenamed);
+        assertNull("Old property was not removed", enabledProperty);
+        assertNotNull("New property was not added", defaultEnabledProperty);
+        assertEquals("The property's name was not changed", "defaultEnabled", defaultEnabledProperty.getName());
+        assertEquals("The property's value changed", "true", defaultEnabledProperty.getString());
+        assertEquals("The property's type was changed", Property.Type.BOOLEAN, defaultEnabledProperty.getType());
+        assertEquals("The property's comment was changed", "enabled property comment", defaultEnabledProperty.getComment());
+    }
+
+    @Test
+    public void testRenameProperty_newNameInUse_replaceExistingProperty()
+    {
+        boolean propertyRenamed = config.renameProperty("defaults", "enabled", "background");
+
+        Property enabledProperty = category.get("enabled");
+        Property backgroundProperty = category.get("background");
+
+        assertTrue("Property was not renamed", propertyRenamed);
+        assertNull("Old property was not removed", enabledProperty);
+        assertNotNull("New property was not added", backgroundProperty);
+        assertEquals("The property's name was not changed", "background", backgroundProperty.getName());
+        assertEquals("The property's value changed", "true", backgroundProperty.getString());
+        assertEquals("The property's type was changed", Property.Type.BOOLEAN, backgroundProperty.getType());
+        assertEquals("The property's comment was changed", "enabled property comment", backgroundProperty.getComment());
+    }
+}


### PR DESCRIPTION
This PR fixes https://github.com/MinecraftForge/MinecraftForge/issues/2236

In addition to the property changing its type to a String during a rename to an unused property name, this bug would also cause its state such as comment, showInGui, etc... to be lost.  By removing the property, renaming it, then placing it back under the new name all original state is preserved.

Please note however if the new name is already used by an existing property this will replace the existing property with the renamed one.  The original code handles this scenario differently.  The original code more or less favors the existing property.  It places an empty string in the existing property's comment and changes the existing property's default value to the value of the old property.   To me this is part of the bug as it, I believe, would be a surprise.  If I renamed a Boolean property with a value of "true" to a name that was taken by a Color property with a value of "blue" then the original code would rename the Color property, keep it's type of Color and value as "blue" and set it's default value to "true".  The Boolean property would be gone.  The code in this PR fully replaces the Color property with the Boolean one.  The other option I can think of in this scenario would be to simply do nothing and return false from the rename request.

Also note that in the scenario where the new name is not in use by another property... this PR does not set the internal "changed" flag in the Property.  The original code does in effect by calling Property.setValue.  I'm not sure if Property.setName should set the changed flag as well.  I left it alone reasoning that Property.setName works as it should.  If this is not the case I can look at setting the changed flag in Property.setName or tickle Property.setValue even though the value does not change. 

I verified with a JUnit test and can include it in the PR if you'd like.  It was left out because I wasn't sure of the projects test direction.  It looks like the FML package has some unit tests but after reading some Git comments I got the impression that FML was on its way out.

Please let me know if you have any questions or concerns.