### PR TITLE
Add GuiContainer Foreground render event.

### DIFF
--- a/patches/minecraft/net/minecraft/client/gui/inventory/GuiContainer.java.patch
+++ b/patches/minecraft/net/minecraft/client/gui/inventory/GuiContainer.java.patch
@@ -1,6 +1,14 @@
 --- ../src-base/minecraft/net/minecraft/client/gui/inventory/GuiContainer.java
 +++ ../src-work/minecraft/net/minecraft/client/gui/inventory/GuiContainer.java
-@@ -180,8 +180,10 @@
+@@ -116,6 +116,7 @@
+         RenderHelper.func_74518_a();
+         this.func_146979_b(p_73863_1_, p_73863_2_);
+         RenderHelper.func_74520_c();
++        net.minecraftforge.common.MinecraftForge.EVENT_BUS.post(new net.minecraftforge.client.event.GuiContainerEvent.DrawForeground(this, p_73863_1_, p_73863_2_));
+         InventoryPlayer inventoryplayer = this.field_146297_k.field_71439_g.field_71071_by;
+         ItemStack itemstack = this.field_147012_x.func_190926_b() ? inventoryplayer.func_70445_o() : this.field_147012_x;
+ 
+@@ -180,8 +181,10 @@
          GlStateManager.func_179109_b(0.0F, 0.0F, 32.0F);
          this.field_73735_i = 200.0F;
          this.field_146296_j.field_77023_b = 200.0F;
@@ -12,7 +20,7 @@
          this.field_73735_i = 0.0F;
          this.field_146296_j.field_77023_b = 0.0F;
      }
-@@ -239,13 +241,12 @@
+@@ -239,13 +242,12 @@
  
          if (itemstack.func_190926_b() && p_146977_1_.func_111238_b())
          {
@@ -29,7 +37,7 @@
                  this.func_175175_a(i, j, textureatlassprite, 16, 16);
                  GlStateManager.func_179145_e();
                  flag1 = true;
-@@ -319,7 +320,7 @@
+@@ -319,7 +321,7 @@
      protected void func_73864_a(int p_73864_1_, int p_73864_2_, int p_73864_3_) throws IOException
      {
          super.func_73864_a(p_73864_1_, p_73864_2_, p_73864_3_);
@@ -38,7 +46,7 @@
          Slot slot = this.func_146975_c(p_73864_1_, p_73864_2_);
          long i = Minecraft.func_71386_F();
          this.field_146993_M = this.field_146998_K == slot && i - this.field_146997_J < 250L && this.field_146992_L == p_73864_3_;
-@@ -330,6 +331,7 @@
+@@ -330,6 +332,7 @@
              int j = this.field_147003_i;
              int k = this.field_147009_r;
              boolean flag1 = this.func_193983_c(p_73864_1_, p_73864_2_, j, k);
@@ -46,7 +54,7 @@
              int l = -1;
  
              if (slot != null)
-@@ -367,7 +369,7 @@
+@@ -367,7 +370,7 @@
                  {
                      if (this.field_146297_k.field_71439_g.field_71071_by.func_70445_o().func_190926_b())
                      {
@@ -55,7 +63,7 @@
                          {
                              this.func_184098_a(slot, l, p_73864_3_, ClickType.CLONE);
                          }
-@@ -405,7 +407,7 @@
+@@ -405,7 +408,7 @@
                          {
                              this.field_146987_F = 1;
                          }
@@ -64,7 +72,7 @@
                          {
                              this.field_146987_F = 2;
                          }
-@@ -472,10 +474,12 @@
+@@ -472,10 +475,12 @@
  
      protected void func_146286_b(int p_146286_1_, int p_146286_2_, int p_146286_3_)
      {
@@ -77,7 +85,7 @@
          int k = -1;
  
          if (slot != null)
-@@ -496,7 +500,7 @@
+@@ -496,7 +501,7 @@
                  {
                      for (Slot slot2 : this.field_147002_h.field_75151_b)
                      {
@@ -86,7 +94,7 @@
                          {
                              this.func_184098_a(slot2, slot2.field_75222_d, p_146286_3_, ClickType.QUICK_MOVE);
                          }
-@@ -583,7 +587,7 @@
+@@ -583,7 +588,7 @@
              }
              else if (!this.field_146297_k.field_71439_g.field_71071_by.func_70445_o().func_190926_b())
              {
@@ -95,7 +103,7 @@
                  {
                      this.func_184098_a(slot, k, p_146286_3_, ClickType.CLONE);
                  }
-@@ -635,7 +639,7 @@
+@@ -635,7 +640,7 @@
  
      protected void func_73869_a(char p_73869_1_, int p_73869_2_) throws IOException
      {
@@ -104,7 +112,7 @@
          {
              this.field_146297_k.field_71439_g.func_71053_j();
          }
-@@ -644,11 +648,11 @@
+@@ -644,11 +649,11 @@
  
          if (this.field_147006_u != null && this.field_147006_u.func_75216_d())
          {
@@ -118,7 +126,7 @@
              {
                  this.func_184098_a(this.field_147006_u, this.field_147006_u.field_75222_d, func_146271_m() ? 1 : 0, ClickType.THROW);
              }
-@@ -661,7 +665,7 @@
+@@ -661,7 +666,7 @@
          {
              for (int i = 0; i < 9; ++i)
              {
@@ -127,7 +135,7 @@
                  {
                      this.func_184098_a(this.field_147006_u, this.field_147006_u.field_75222_d, i, ClickType.SWAP);
                      return true;
-@@ -694,4 +698,18 @@
+@@ -694,4 +699,18 @@
              this.field_146297_k.field_71439_g.func_71053_j();
          }
      }

--- a/src/main/java/net/minecraftforge/client/event/GuiContainerEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/GuiContainerEvent.java
@@ -1,0 +1,78 @@
+/*
+ * Minecraft Forge
+ * Copyright (c) 2016.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation version 2.1
+ * of the License.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+package net.minecraftforge.client.event;
+
+import net.minecraft.client.gui.inventory.GuiContainer;
+import net.minecraftforge.fml.common.eventhandler.Event;
+
+/**
+ * Event class for handling GuiContainer specific events.
+ */
+public class GuiContainerEvent extends Event
+{
+
+    private final GuiContainer guiContainer;
+
+    public GuiContainerEvent(GuiContainer guiContainer)
+    {
+        this.guiContainer = guiContainer;
+    }
+
+    public GuiContainer getGuiContainer()
+    {
+        return guiContainer;
+    }
+
+    /**
+     * This event is fired directly after the GuiContainer has draw any foreground elements,
+     * But before the "dragged" stack, and before any tooltips.
+     * This is useful for any slot / item specific overlays.
+     * Things that need to be on top of All GUI elements but bellow tooltips and dragged stacks.
+     */
+    public static class DrawForeground extends GuiContainerEvent
+    {
+        private final int mouseX;
+        private final int mouseY;
+
+        /**
+         * Called directly after the GuiContainer has drawn any foreground elements.
+         *
+         * @param guiContainer The container.
+         * @param mouseX       The current X position of the players mouse.
+         * @param mouseY       The current Y position of the players mouse.
+         */
+        public DrawForeground(GuiContainer guiContainer, int mouseX, int mouseY)
+        {
+            super(guiContainer);
+            this.mouseX = mouseX;
+            this.mouseY = mouseY;
+        }
+
+        public int getMouseX()
+        {
+            return mouseX;
+        }
+
+        public int getMouseY()
+        {
+            return mouseY;
+        }
+    }
+}

--- a/src/test/java/net/minecraftforge/debug/GuiContainerEventTest.java
+++ b/src/test/java/net/minecraftforge/debug/GuiContainerEventTest.java
@@ -1,0 +1,56 @@
+/*
+ * Minecraft Forge
+ * Copyright (c) 2016.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation version 2.1
+ * of the License.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+package net.minecraftforge.debug;
+
+import net.minecraft.client.renderer.GlStateManager;
+import net.minecraft.inventory.Slot;
+import net.minecraft.item.Item;
+import net.minecraftforge.client.event.GuiContainerEvent;
+import net.minecraftforge.fml.client.config.GuiUtils;
+import net.minecraftforge.fml.common.Mod;
+import net.minecraftforge.fml.common.Mod.EventBusSubscriber;
+import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
+import net.minecraftforge.fml.common.registry.GameRegistry.ObjectHolder;
+
+@EventBusSubscriber
+@Mod (modid = "guicontainereventtest", name = "GuiContainer Event Tests!", version = "1.0", acceptableRemoteVersions = "*")
+public class GuiContainerEventTest
+{
+
+    @ObjectHolder("minecraft:stone")
+    public static final Item STONE_ITEM = null;
+
+    @SubscribeEvent
+    public static void onForegroundRender(GuiContainerEvent.DrawForeground event)
+    {
+        for (Slot slot : event.getGuiContainer().inventorySlots.inventorySlots)
+        {
+            if (slot.getStack().getItem() == STONE_ITEM)
+            {
+                GlStateManager.disableLighting();
+
+                GuiUtils.drawGradientRect(400, slot.xPos, slot.yPos, slot.xPos + 16, slot.yPos + 16, 0x80000000, 0x80000000);
+
+                GlStateManager.enableLighting();
+            }
+        }
+    }
+
+}


### PR DESCRIPTION
With the addition of this new event it is possible to render on top of all foreground elements inside a GuiContainer but underneath all tooltips and the draged stack.

### Uses
This can be used for NEI's Searching inventory feature, and probably other mods that do things similar.
The test mod highlights all Stone in any slot inside the GuiContainer.
![](http://ss.covers1624.net/tppax3x.png)
