### PR TITLE
Clean up uses of deprecated library functions

### DIFF
--- a/src/main/java/net/minecraftforge/client/model/BlockStateLoader.java
+++ b/src/main/java/net/minecraftforge/client/model/BlockStateLoader.java
@@ -23,6 +23,7 @@ import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.Reader;
+import java.nio.charset.StandardCharsets;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
@@ -37,11 +38,9 @@ import net.minecraftforge.common.model.IModelState;
 import net.minecraftforge.common.model.TRSRTransformation;
 
 import net.minecraftforge.fml.common.FMLLog;
-import org.apache.commons.io.Charsets;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.tuple.Pair;
 
-import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
@@ -74,8 +73,8 @@ public class BlockStateLoader
     {
         try
         {
-            byte[] data = IOUtils.toByteArray(reader);
-            reader = new InputStreamReader(new ByteArrayInputStream(data), Charsets.UTF_8);
+            byte[] data = IOUtils.toByteArray(reader, StandardCharsets.UTF_8);
+            reader = new InputStreamReader(new ByteArrayInputStream(data), StandardCharsets.UTF_8);
 
             Marker marker = GSON.fromJson(new String(data), Marker.class);  // Read "forge_marker" to determine what to load.
 
@@ -111,9 +110,8 @@ public class BlockStateLoader
         }
         catch (IOException e)
         {
-            Throwables.propagate(e);
+            throw new RuntimeException(e);
         }
-        return null;
     }
 
     public static class Marker
@@ -215,7 +213,7 @@ public class BlockStateLoader
                 final IModel model;
                 if (modelLocation == null)
                 {
-                    FMLLog.getLogger().error("model not found for variant " + entry.getKey() + "for blockstate " + blockstateLocation);
+                    FMLLog.log.error("model not found for variant {} for blockstate {}", entry.getKey(), blockstateLocation);
                     model = ModelLoaderRegistry.getMissingModel(blockstateLocation, new Throwable());
                 }
                 else

--- a/src/main/java/net/minecraftforge/client/model/obj/OBJModel.java
+++ b/src/main/java/net/minecraftforge/client/model/obj/OBJModel.java
@@ -22,6 +22,7 @@ package net.minecraftforge.client.model.obj;
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
@@ -43,7 +44,6 @@ import javax.vecmath.Vector4f;
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.client.renderer.block.model.BakedQuad;
 import net.minecraft.client.renderer.block.model.IBakedModel;
-import net.minecraft.client.renderer.block.model.ItemCameraTransforms;
 import net.minecraft.client.renderer.block.model.ItemCameraTransforms.TransformType;
 import net.minecraft.client.renderer.block.model.ItemOverrideList;
 import net.minecraft.client.renderer.texture.TextureAtlasSprite;
@@ -65,7 +65,6 @@ import net.minecraftforge.fml.common.FMLLog;
 
 import org.apache.commons.lang3.tuple.Pair;
 
-import com.google.common.base.Charsets;
 import java.util.function.Function;
 import com.google.common.base.Objects;
 import java.util.Optional;
@@ -206,7 +205,7 @@ public class OBJModel implements IModel
         {
             this.manager = manager;
             this.objFrom = from.getResourceLocation();
-            this.objStream = new InputStreamReader(from.getInputStream(), Charsets.UTF_8);
+            this.objStream = new InputStreamReader(from.getInputStream(), StandardCharsets.UTF_8);
             this.objReader = new BufferedReader(objStream);
         }
 
@@ -499,7 +498,7 @@ public class OBJModel implements IModel
             String domain = from.getResourceDomain();
             if (!path.contains("/"))
                 path = from.getResourcePath().substring(0, from.getResourcePath().lastIndexOf("/") + 1) + path;
-            mtlStream = new InputStreamReader(manager.getResource(new ResourceLocation(domain, path)).getInputStream(), Charsets.UTF_8);
+            mtlStream = new InputStreamReader(manager.getResource(new ResourceLocation(domain, path)).getInputStream(), StandardCharsets.UTF_8);
             mtlReader = new BufferedReader(mtlStream);
 
             String currentLine = "";

--- a/src/main/java/net/minecraftforge/common/UsernameCache.java
+++ b/src/main/java/net/minecraftforge/common/UsernameCache.java
@@ -25,6 +25,7 @@ import java.io.File;
 import java.io.IOException;
 import java.lang.reflect.Type;
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.Map;
 import java.util.UUID;
 
@@ -33,7 +34,6 @@ import javax.annotation.Nullable;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
-import com.google.common.base.Charsets;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Maps;
 import com.google.common.io.Files;
@@ -56,7 +56,7 @@ public final class UsernameCache {
 
     private static Map<UUID, String> map = Maps.newHashMap();
 
-    private static final Charset charset = Charsets.UTF_8;
+    private static final Charset charset = StandardCharsets.UTF_8;
 
     private static final File saveFile = new File( /* The minecraft dir */(File) FMLInjectionData.data()[6], "usernamecache.json");
     private static final Gson gson = new GsonBuilder().setPrettyPrinting().create();

--- a/src/main/java/net/minecraftforge/common/capabilities/Capability.java
+++ b/src/main/java/net/minecraftforge/common/capabilities/Capability.java
@@ -130,9 +130,9 @@ public class Capability<T>
         }
         catch (Exception e)
         {
-            Throwables.propagate(e);
+            Throwables.throwIfUnchecked(e);
+            throw new RuntimeException(e);
         }
-        return null;
     }
 
     /**

--- a/src/main/java/net/minecraftforge/common/capabilities/CapabilityManager.java
+++ b/src/main/java/net/minecraftforge/common/capabilities/CapabilityManager.java
@@ -26,20 +26,16 @@ import java.util.IdentityHashMap;
 import java.util.List;
 import java.util.concurrent.Callable;
 
-import org.apache.logging.log4j.Level;
 import org.objectweb.asm.Type;
 
 import java.util.function.Function;
 import com.google.common.base.Preconditions;
-import com.google.common.base.Throwables;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 
 import net.minecraftforge.common.util.EnumHelper;
 import net.minecraftforge.fml.common.FMLLog;
 import net.minecraftforge.fml.common.discovery.ASMDataTable;
-
-import javax.annotation.Nullable;
 
 public enum CapabilityManager
 {
@@ -62,7 +58,7 @@ public enum CapabilityManager
             try {
                 return implementation.newInstance();
             } catch (InstantiationException | IllegalAccessException e) {
-                throw Throwables.propagate(e);
+                throw new RuntimeException(e);
             }
         });
     }

--- a/src/main/java/net/minecraftforge/common/config/ConfigManager.java
+++ b/src/main/java/net/minecraftforge/common/config/ConfigManager.java
@@ -28,7 +28,6 @@ import java.util.Set;
 
 import com.google.common.base.Joiner;
 import com.google.common.base.Strings;
-import com.google.common.base.Throwables;
 import com.google.common.collect.ArrayListMultimap;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Multimap;
@@ -305,10 +304,9 @@ public class ConfigManager
                 {
                     newInstance = f.get(instance);
                 }
-                catch (Exception e)
+                catch (IllegalAccessException e)
                 {
                     //This should never happen. Previous checks should eliminate this.
-                    Throwables.throwIfUnchecked(e);
                     throw new RuntimeException(e);
                 }
 

--- a/src/main/java/net/minecraftforge/common/config/ConfigManager.java
+++ b/src/main/java/net/minecraftforge/common/config/ConfigManager.java
@@ -26,8 +26,6 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 
-import org.apache.logging.log4j.Level;
-
 import com.google.common.base.Joiner;
 import com.google.common.base.Strings;
 import com.google.common.base.Throwables;
@@ -310,7 +308,8 @@ public class ConfigManager
                 catch (Exception e)
                 {
                     //This should never happen. Previous checks should eliminate this.
-                    Throwables.propagate(e);
+                    Throwables.throwIfUnchecked(e);
+                    throw new RuntimeException(e);
                 }
 
                 String sub = (category.isEmpty() ? "" : category + ".") + getName(f).toLowerCase(Locale.ENGLISH);

--- a/src/main/java/net/minecraftforge/common/config/Configuration.java
+++ b/src/main/java/net/minecraftforge/common/config/Configuration.java
@@ -76,7 +76,7 @@ public class Configuration
     private static final String CONFIG_VERSION_MARKER = "~CONFIG_VERSION";
     private static final Pattern CONFIG_START = Pattern.compile("START: \"([^\\\"]+)\"");
     private static final Pattern CONFIG_END = Pattern.compile("END: \"([^\\\"]+)\"");
-    public static final CharMatcher allowedProperties = CharMatcher.JAVA_LETTER_OR_DIGIT.or(CharMatcher.anyOf(ALLOWED_CHARS));
+    public static final CharMatcher allowedProperties = CharMatcher.javaLetterOrDigit().or(CharMatcher.anyOf(ALLOWED_CHARS));
     private static Configuration PARENT = null;
 
     File file;

--- a/src/main/java/net/minecraftforge/common/config/FieldWrapper.java
+++ b/src/main/java/net/minecraftforge/common/config/FieldWrapper.java
@@ -11,7 +11,6 @@ import java.util.Map.Entry;
 import java.util.regex.Pattern;
 import java.util.Set;
 
-import com.google.common.base.Throwables;
 import com.google.common.collect.Lists;
 
 import net.minecraftforge.common.config.Config.RangeDouble;
@@ -84,9 +83,8 @@ public abstract class FieldWrapper implements IFieldWrapper
                 throw new IllegalArgumentException(String.format("The map '%s' of class '%s' must have the key type String!", field.getName(),
                         field.getDeclaringClass().getCanonicalName()), cce);
             }
-            catch (Exception e)
+            catch (IllegalAccessException e)
             {
-                Throwables.throwIfUnchecked(e);
                 throw new RuntimeException(e);
             }
 
@@ -201,9 +199,8 @@ public abstract class FieldWrapper implements IFieldWrapper
                 Enum enu = (Enum) field.get(instance);
                 return enu.name();
             }
-            catch (Exception e)
+            catch (IllegalAccessException e)
             {
-                Throwables.throwIfUnchecked(e);
                 throw new RuntimeException(e);
             }
         }
@@ -219,9 +216,8 @@ public abstract class FieldWrapper implements IFieldWrapper
             {
                 field.set(instance, enu);
             }
-            catch (Exception e)
+            catch (IllegalAccessException e)
             {
-                Throwables.throwIfUnchecked(e);
                 throw new RuntimeException(e);
             }
         }
@@ -273,9 +269,8 @@ public abstract class FieldWrapper implements IFieldWrapper
             {
                 return field.get(instance);
             }
-            catch (Exception e)
+            catch (IllegalAccessException e)
             {
-                Throwables.throwIfUnchecked(e);
                 throw new RuntimeException(e);
             }
         }
@@ -289,9 +284,8 @@ public abstract class FieldWrapper implements IFieldWrapper
             {
                 field.set(instance, value);
             }
-            catch (Exception e)
+            catch (IllegalAccessException e)
             {
-                Throwables.throwIfUnchecked(e);
                 throw new RuntimeException(e);
             }
         }

--- a/src/main/java/net/minecraftforge/common/config/FieldWrapper.java
+++ b/src/main/java/net/minecraftforge/common/config/FieldWrapper.java
@@ -86,7 +86,8 @@ public abstract class FieldWrapper implements IFieldWrapper
             }
             catch (Exception e)
             {
-                Throwables.propagate(e);
+                Throwables.throwIfUnchecked(e);
+                throw new RuntimeException(e);
             }
 
             ParameterizedType type = (ParameterizedType) field.getGenericType();
@@ -202,9 +203,9 @@ public abstract class FieldWrapper implements IFieldWrapper
             }
             catch (Exception e)
             {
-                Throwables.propagate(e);
+                Throwables.throwIfUnchecked(e);
+                throw new RuntimeException(e);
             }
-            return null;
         }
 
         @Override
@@ -220,7 +221,8 @@ public abstract class FieldWrapper implements IFieldWrapper
             }
             catch (Exception e)
             {
-                Throwables.propagate(e);
+                Throwables.throwIfUnchecked(e);
+                throw new RuntimeException(e);
             }
         }
 
@@ -273,9 +275,9 @@ public abstract class FieldWrapper implements IFieldWrapper
             }
             catch (Exception e)
             {
-                Throwables.propagate(e);
+                Throwables.throwIfUnchecked(e);
+                throw new RuntimeException(e);
             }
-            return null;
         }
 
         @Override
@@ -289,7 +291,8 @@ public abstract class FieldWrapper implements IFieldWrapper
             }
             catch (Exception e)
             {
-                Throwables.propagate(e);
+                Throwables.throwIfUnchecked(e);
+                throw new RuntimeException(e);
             }
         }
 

--- a/src/main/java/net/minecraftforge/common/network/ForgeMessage.java
+++ b/src/main/java/net/minecraftforge/common/network/ForgeMessage.java
@@ -19,15 +19,13 @@
 
 package net.minecraftforge.common.network;
 
+import java.nio.charset.StandardCharsets;
 import java.util.Map;
 import java.util.Set;
-
-import org.apache.logging.log4j.Level;
 
 import net.minecraftforge.fluids.Fluid;
 import net.minecraftforge.fluids.FluidRegistry;
 
-import com.google.common.base.Charsets;
 import com.google.common.collect.BiMap;
 import com.google.common.collect.HashBiMap;
 import com.google.common.collect.Sets;
@@ -54,7 +52,7 @@ public abstract class ForgeMessage {
         void toBytes(ByteBuf bytes)
         {
             bytes.writeInt(this.dimensionId);
-            byte[] data = this.providerId.getBytes(Charsets.UTF_8);
+            byte[] data = this.providerId.getBytes(StandardCharsets.UTF_8);
             bytes.writeShort(data.length);
             bytes.writeBytes(data);
         }
@@ -65,7 +63,7 @@ public abstract class ForgeMessage {
             dimensionId = bytes.readInt();
             byte[] data = new byte[bytes.readShort()];
             bytes.readBytes(data);
-            providerId = new String(data, Charsets.UTF_8);
+            providerId = new String(data, StandardCharsets.UTF_8);
         }
     }
 

--- a/src/main/java/net/minecraftforge/fml/client/FMLClientHandler.java
+++ b/src/main/java/net/minecraftforge/fml/client/FMLClientHandler.java
@@ -664,7 +664,6 @@ public class FMLClientHandler implements IFMLSidedHandler
             catch (NoSuchMethodException e)
             {
                 FMLLog.log.error("The container {} (type {}) returned an invalid class for it's resource pack.", container.getName(), container.getClass().getName());
-                return;
             }
             catch (Exception e)
             {

--- a/src/main/java/net/minecraftforge/fml/client/FMLClientHandler.java
+++ b/src/main/java/net/minecraftforge/fml/client/FMLClientHandler.java
@@ -667,9 +667,7 @@ public class FMLClientHandler implements IFMLSidedHandler
             }
             catch (Exception e)
             {
-                FMLLog.log.error("An unexpected exception occurred constructing the custom resource pack for {}", container.getName(), e);
-                Throwables.throwIfUnchecked(e);
-                throw new RuntimeException(e);
+                throw new RuntimeException("An unexpected exception occurred constructing the custom resource pack for " + container.getName(), e);
             }
         }
     }

--- a/src/main/java/net/minecraftforge/fml/client/FMLClientHandler.java
+++ b/src/main/java/net/minecraftforge/fml/client/FMLClientHandler.java
@@ -669,7 +669,8 @@ public class FMLClientHandler implements IFMLSidedHandler
             catch (Exception e)
             {
                 FMLLog.log.error("An unexpected exception occurred constructing the custom resource pack for {}", container.getName(), e);
-                throw Throwables.propagate(e);
+                Throwables.throwIfUnchecked(e);
+                throw new RuntimeException(e);
             }
         }
     }

--- a/src/main/java/net/minecraftforge/fml/client/FMLFileResourcePack.java
+++ b/src/main/java/net/minecraftforge/fml/client/FMLFileResourcePack.java
@@ -23,6 +23,7 @@ import java.awt.image.BufferedImage;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
 
 import org.apache.logging.log4j.LogManager;
 
@@ -31,8 +32,6 @@ import javax.imageio.ImageIO;
 import net.minecraft.client.resources.FileResourcePack;
 import net.minecraftforge.fml.common.FMLContainerHolder;
 import net.minecraftforge.fml.common.ModContainer;
-
-import com.google.common.base.Charsets;
 
 public class FMLFileResourcePack extends FileResourcePack implements FMLContainerHolder {
 
@@ -66,7 +65,7 @@ public class FMLFileResourcePack extends FileResourcePack implements FMLContaine
                         "   \"description\": \"dummy FML pack for "+container.getName()+"\",\n"+
                         "   \"pack_format\": 2\n"+
                         "}\n" +
-                        "}").getBytes(Charsets.UTF_8));
+                        "}").getBytes(StandardCharsets.UTF_8));
             }
             else throw ioe;
         }

--- a/src/main/java/net/minecraftforge/fml/client/FMLFolderResourcePack.java
+++ b/src/main/java/net/minecraftforge/fml/client/FMLFolderResourcePack.java
@@ -23,6 +23,7 @@ import java.awt.image.BufferedImage;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
 
 import org.apache.logging.log4j.LogManager;
 
@@ -31,8 +32,6 @@ import javax.imageio.ImageIO;
 import net.minecraft.client.resources.FolderResourcePack;
 import net.minecraftforge.fml.common.FMLContainerHolder;
 import net.minecraftforge.fml.common.ModContainer;
-
-import com.google.common.base.Charsets;
 
 public class FMLFolderResourcePack extends FolderResourcePack implements FMLContainerHolder {
 
@@ -71,7 +70,7 @@ public class FMLFolderResourcePack extends FolderResourcePack implements FMLCont
                         "   \"description\": \"dummy FML pack for "+container.getName()+"\",\n"+
                         "   \"pack_format\": 2\n"+
                         "}\n" +
-                        "}").getBytes(Charsets.UTF_8));
+                        "}").getBytes(StandardCharsets.UTF_8));
             }
             else throw ioe;
         }

--- a/src/main/java/net/minecraftforge/fml/common/FMLCommonHandler.java
+++ b/src/main/java/net/minecraftforge/fml/common/FMLCommonHandler.java
@@ -25,6 +25,8 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.lang.ref.WeakReference;
+import java.nio.charset.StandardCharsets;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -57,7 +59,6 @@ import net.minecraft.world.storage.WorldInfo;
 import net.minecraftforge.client.model.animation.Animation;
 import net.minecraftforge.common.ForgeVersion;
 import net.minecraftforge.common.MinecraftForge;
-import net.minecraftforge.common.crafting.CraftingHelper;
 import net.minecraftforge.common.util.CompoundDataFixer;
 import net.minecraftforge.fml.common.event.FMLPreInitializationEvent;
 import net.minecraftforge.fml.common.eventhandler.EventBus;
@@ -67,14 +68,11 @@ import net.minecraftforge.fml.common.gameevent.TickEvent;
 import net.minecraftforge.fml.common.gameevent.TickEvent.Phase;
 import net.minecraftforge.fml.common.network.NetworkRegistry;
 import net.minecraftforge.fml.common.thread.SidedThreadGroup;
-import net.minecraftforge.fml.common.thread.SidedThreadGroups;
 import net.minecraftforge.fml.relauncher.CoreModManager;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.server.FMLServerHandler;
 
-import org.apache.commons.io.Charsets;
 import org.apache.commons.io.IOUtils;
-import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.Logger;
 
 import com.google.common.base.Joiner;
@@ -83,10 +81,8 @@ import com.google.common.collect.ImmutableList.Builder;
 import com.google.common.collect.Lists;
 import com.google.common.collect.MapMaker;
 import com.google.common.collect.Maps;
-import com.google.common.collect.Sets;
 
 import javax.annotation.Nullable;
-
 
 /**
  * The main class for non-obfuscated hook handling code
@@ -116,7 +112,7 @@ public class FMLCommonHandler
     private List<String> brandings;
     private List<String> brandingsNoMC;
     private List<ICrashCallable> crashCallables = Lists.newArrayList(Loader.instance().getCallableCrashInformation());
-    private Set<SaveHandler> handlerSet = Sets.newSetFromMap(new MapMaker().weakKeys().<SaveHandler,Boolean>makeMap());
+    private Set<SaveHandler> handlerSet = Collections.newSetFromMap(new MapMaker().weakKeys().<SaveHandler,Boolean>makeMap());
     private WeakReference<SaveHandler> handlerToCheck;
     private EventBus eventBus = MinecraftForge.EVENT_BUS;
     private volatile CountDownLatch exitLatch = null;
@@ -722,7 +718,7 @@ public class FMLCommonHandler
         byte[] data = IOUtils.toByteArray(inputstream);
 
         boolean isEnhanced = false;
-        for (String line : IOUtils.readLines(new ByteArrayInputStream(data), Charsets.UTF_8))
+        for (String line : IOUtils.readLines(new ByteArrayInputStream(data), StandardCharsets.UTF_8))
         {
             if (!line.isEmpty() && line.charAt(0) == '#')
             {
@@ -739,7 +735,7 @@ public class FMLCommonHandler
             return new ByteArrayInputStream(data);
 
         Properties props = new Properties();
-        props.load(new InputStreamReader(new ByteArrayInputStream(data), Charsets.UTF_8));
+        props.load(new InputStreamReader(new ByteArrayInputStream(data), StandardCharsets.UTF_8));
         for (Entry<Object, Object> e : props.entrySet())
         {
             table.put((String)e.getKey(), (String)e.getValue());

--- a/src/main/java/net/minecraftforge/fml/common/FMLModContainer.java
+++ b/src/main/java/net/minecraftforge/fml/common/FMLModContainer.java
@@ -55,7 +55,6 @@ import net.minecraftforge.fml.common.versioning.VersionRange;
 import net.minecraftforge.fml.relauncher.Side;
 
 import org.apache.commons.io.IOUtils;
-import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -330,7 +329,7 @@ public class FMLModContainer implements ModContainer
         }
         catch (Exception e)
         {
-            Throwables.propagateIfPossible(e);
+            Throwables.throwIfUnchecked(e);
             modLog.trace("Failed to find a usable version.properties file");
             return null;
         }
@@ -496,7 +495,7 @@ public class FMLModContainer implements ModContainer
                 }
                 catch (Exception e)
                 {
-                    Throwables.propagateIfPossible(e);
+                    Throwables.throwIfUnchecked(e);
                     modLog.warn("Attempting to load @{} in class {} for {} and failing", annotationName, targets.getClassName(), mc.getModId(), e);
                 }
             }

--- a/src/main/java/net/minecraftforge/fml/common/FMLModContainer.java
+++ b/src/main/java/net/minecraftforge/fml/common/FMLModContainer.java
@@ -20,6 +20,7 @@ package net.minecraftforge.fml.common;
 
 import java.io.File;
 import java.io.FileInputStream;
+import java.io.IOException;
 import java.io.InputStream;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Field;
@@ -64,7 +65,6 @@ import java.util.zip.ZipFile;
 
 import java.util.function.Function;
 import com.google.common.base.Strings;
-import com.google.common.base.Throwables;
 import com.google.common.collect.ArrayListMultimap;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableList.Builder;
@@ -327,9 +327,8 @@ public class FMLModContainer implements ModContainer
             }
             return version;
         }
-        catch (Exception e)
+        catch (IOException e)
         {
-            Throwables.throwIfUnchecked(e);
             modLog.trace("Failed to find a usable version.properties file");
             return null;
         }
@@ -493,9 +492,8 @@ public class FMLModContainer implements ModContainer
                     isStatic = Modifier.isStatic(f.getModifiers());
                     injectedMod = retriever.apply(mc);
                 }
-                catch (Exception e)
+                catch (ReflectiveOperationException e)
                 {
-                    Throwables.throwIfUnchecked(e);
                     modLog.warn("Attempting to load @{} in class {} for {} and failing", annotationName, targets.getClassName(), mc.getModId(), e);
                 }
             }

--- a/src/main/java/net/minecraftforge/fml/common/LoaderState.java
+++ b/src/main/java/net/minecraftforge/fml/common/LoaderState.java
@@ -91,7 +91,8 @@ public enum LoaderState
         }
         catch (Exception e)
         {
-            throw Throwables.propagate(e);
+            Throwables.throwIfUnchecked(e);
+            throw new RuntimeException(e);
         }
     }
     public LoaderState requiredState()

--- a/src/main/java/net/minecraftforge/fml/common/LoaderState.java
+++ b/src/main/java/net/minecraftforge/fml/common/LoaderState.java
@@ -31,8 +31,6 @@ import net.minecraftforge.fml.common.event.FMLServerStoppedEvent;
 import net.minecraftforge.fml.common.event.FMLServerStoppingEvent;
 import net.minecraftforge.fml.common.event.FMLStateEvent;
 
-import com.google.common.base.Throwables;
-
 /**
  * The state enum used to help track state progression for the loader
  * @author cpw
@@ -89,9 +87,8 @@ public enum LoaderState
         {
             return eventClass.getConstructor(Object[].class).newInstance((Object)eventData);
         }
-        catch (Exception e)
+        catch (ReflectiveOperationException e)
         {
-            Throwables.throwIfUnchecked(e);
             throw new RuntimeException(e);
         }
     }

--- a/src/main/java/net/minecraftforge/fml/common/MetadataCollection.java
+++ b/src/main/java/net/minecraftforge/fml/common/MetadataCollection.java
@@ -27,7 +27,6 @@ import java.util.Map;
 import net.minecraftforge.fml.common.versioning.ArtifactVersion;
 import net.minecraftforge.fml.common.versioning.VersionParser;
 
-import com.google.common.base.Throwables;
 import com.google.common.collect.Maps;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
@@ -84,13 +83,7 @@ public class MetadataCollection
             FMLLog.log.error("The mcmod.info file in {} cannot be parsed as valid JSON. It will be ignored", sourceName, e);
             return new MetadataCollection();
         }
-        catch (Exception e)
-        {
-            Throwables.throwIfUnchecked(e);
-            throw new RuntimeException(e);
-        }
     }
-
 
     private void parseModMetadataList()
     {

--- a/src/main/java/net/minecraftforge/fml/common/MetadataCollection.java
+++ b/src/main/java/net/minecraftforge/fml/common/MetadataCollection.java
@@ -27,8 +27,6 @@ import java.util.Map;
 import net.minecraftforge.fml.common.versioning.ArtifactVersion;
 import net.minecraftforge.fml.common.versioning.VersionParser;
 
-import org.apache.logging.log4j.Level;
-
 import com.google.common.base.Throwables;
 import com.google.common.collect.Maps;
 import com.google.gson.Gson;
@@ -88,7 +86,8 @@ public class MetadataCollection
         }
         catch (Exception e)
         {
-            throw Throwables.propagate(e);
+            Throwables.throwIfUnchecked(e);
+            throw new RuntimeException(e);
         }
     }
 

--- a/src/main/java/net/minecraftforge/fml/common/ModContainerFactory.java
+++ b/src/main/java/net/minecraftforge/fml/common/ModContainerFactory.java
@@ -30,7 +30,6 @@ import net.minecraftforge.fml.common.discovery.asm.ModAnnotation;
 
 import org.objectweb.asm.Type;
 
-import com.google.common.base.Throwables;
 import com.google.common.collect.Maps;
 
 import javax.annotation.Nullable;
@@ -58,9 +57,7 @@ public class ModContainerFactory
         }
         catch (Exception e)
         {
-            FMLLog.log.error("Critical error : cannot register mod container type {}, it has an invalid constructor", container.getName(), e);
-            Throwables.throwIfUnchecked(e);
-            throw new RuntimeException(e);
+            throw new RuntimeException("Critical error : cannot register mod container type " + container.getName() + ", it has an invalid constructor", e);
         }
     }
 

--- a/src/main/java/net/minecraftforge/fml/common/ModContainerFactory.java
+++ b/src/main/java/net/minecraftforge/fml/common/ModContainerFactory.java
@@ -28,7 +28,6 @@ import net.minecraftforge.fml.common.discovery.ModCandidate;
 import net.minecraftforge.fml.common.discovery.asm.ASMModParser;
 import net.minecraftforge.fml.common.discovery.asm.ModAnnotation;
 
-import org.apache.logging.log4j.Level;
 import org.objectweb.asm.Type;
 
 import com.google.common.base.Throwables;
@@ -52,12 +51,16 @@ public class ModContainerFactory
 
     public void registerContainerType(Type type, Class<? extends ModContainer> container)
     {
-        try {
+        try
+        {
             Constructor<? extends ModContainer> constructor = container.getConstructor(new Class<?>[] { String.class, ModCandidate.class, Map.class });
             modTypes.put(type, constructor);
-        } catch (Exception e) {
+        }
+        catch (Exception e)
+        {
             FMLLog.log.error("Critical error : cannot register mod container type {}, it has an invalid constructor", container.getName(), e);
-            Throwables.propagate(e);
+            Throwables.throwIfUnchecked(e);
+            throw new RuntimeException(e);
         }
     }
 

--- a/src/main/java/net/minecraftforge/fml/common/asm/FMLSanityChecker.java
+++ b/src/main/java/net/minecraftforge/fml/common/asm/FMLSanityChecker.java
@@ -22,6 +22,7 @@ package net.minecraftforge.fml.common.asm;
 import java.io.File;
 import java.io.InputStream;
 import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
 import java.security.CodeSource;
 import java.security.cert.Certificate;
 import java.util.Map;
@@ -39,7 +40,6 @@ import net.minecraftforge.fml.relauncher.FMLLaunchHandler;
 import net.minecraftforge.fml.relauncher.IFMLCallHook;
 import net.minecraftforge.fml.relauncher.Side;
 
-import com.google.common.base.Charsets;
 import com.google.common.io.ByteStreams;
 
 import static net.minecraftforge.fml.common.FMLLog.log;
@@ -110,7 +110,7 @@ public class FMLSanityChecker implements IFMLCallHook
             {
                 String mcPath = codeSource.getLocation().getPath().substring(5);
                 mcPath = mcPath.substring(0, mcPath.lastIndexOf('!'));
-                mcPath = URLDecoder.decode(mcPath, Charsets.UTF_8.name());
+                mcPath = URLDecoder.decode(mcPath, StandardCharsets.UTF_8.name());
                 mcJarFile = new JarFile(mcPath,true);
                 mcJarFile.getManifest();
                 JarEntry cbrEntry = mcJarFile.getJarEntry("net/minecraft/client/ClientBrandRetriever.class");

--- a/src/main/java/net/minecraftforge/fml/common/asm/transformers/AccessTransformer.java
+++ b/src/main/java/net/minecraftforge/fml/common/asm/transformers/AccessTransformer.java
@@ -36,6 +36,7 @@ import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
 import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
@@ -54,7 +55,6 @@ import org.objectweb.asm.tree.FieldNode;
 import org.objectweb.asm.tree.MethodInsnNode;
 import org.objectweb.asm.tree.MethodNode;
 
-import com.google.common.base.Charsets;
 import com.google.common.base.Splitter;
 import com.google.common.collect.ArrayListMultimap;
 import com.google.common.collect.Iterables;
@@ -124,7 +124,7 @@ public class AccessTransformer implements IClassTransformer
         {
             rulesResource = Resources.getResource(rulesFile);
         }
-        processATFile(Resources.asCharSource(rulesResource, Charsets.UTF_8));
+        processATFile(Resources.asCharSource(rulesResource, StandardCharsets.UTF_8));
         FMLLog.log.debug("Loaded {} rules from AccessTransformer config file {}", modifiers.size(), rulesFile);
     }
     protected void processATFile(CharSource rulesResource) throws IOException

--- a/src/main/java/net/minecraftforge/fml/common/asm/transformers/MarkerTransformer.java
+++ b/src/main/java/net/minecraftforge/fml/common/asm/transformers/MarkerTransformer.java
@@ -28,6 +28,7 @@ import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipInputStream;
@@ -40,7 +41,6 @@ import org.objectweb.asm.ClassReader;
 import org.objectweb.asm.ClassWriter;
 import org.objectweb.asm.tree.ClassNode;
 
-import com.google.common.base.Charsets;
 import com.google.common.base.Splitter;
 import com.google.common.collect.ArrayListMultimap;
 import com.google.common.collect.Iterables;
@@ -74,7 +74,7 @@ public class MarkerTransformer implements IClassTransformer
         {
             rulesResource = Resources.getResource(rulesFile);
         }
-        Resources.readLines(rulesResource, Charsets.UTF_8, new LineProcessor<Void>()
+        Resources.readLines(rulesResource, StandardCharsets.UTF_8, new LineProcessor<Void>()
         {
             @Override
             public Void getResult()

--- a/src/main/java/net/minecraftforge/fml/common/asm/transformers/ModAccessTransformer.java
+++ b/src/main/java/net/minecraftforge/fml/common/asm/transformers/ModAccessTransformer.java
@@ -22,6 +22,7 @@ package net.minecraftforge.fml.common.asm.transformers;
 import java.io.IOException;
 import java.io.InputStream;
 import java.lang.reflect.Field;
+import java.nio.charset.StandardCharsets;
 import java.util.Map;
 import java.util.jar.JarEntry;
 import java.util.jar.JarFile;
@@ -29,7 +30,6 @@ import java.util.jar.Manifest;
 
 import net.minecraftforge.fml.common.FMLLog;
 
-import com.google.common.base.Charsets;
 import com.google.common.collect.Maps;
 import com.google.common.io.ByteSource;
 import com.google.common.io.CharSource;
@@ -70,7 +70,7 @@ public class ModAccessTransformer extends AccessTransformer {
             if (jarEntry != null)
             {
                 embedded.put(String.format("%s!META-INF/%s", jar.getName(), at),
-                        new JarByteSource(jar,jarEntry).asCharSource(Charsets.UTF_8).read());
+                        new JarByteSource(jar,jarEntry).asCharSource(StandardCharsets.UTF_8).read());
             }
         }
     }

--- a/src/main/java/net/minecraftforge/fml/common/asm/transformers/deobf/FMLDeobfuscatingRemapper.java
+++ b/src/main/java/net/minecraftforge/fml/common/asm/transformers/deobf/FMLDeobfuscatingRemapper.java
@@ -23,6 +23,7 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
@@ -38,7 +39,6 @@ import org.objectweb.asm.tree.ClassNode;
 import org.objectweb.asm.tree.FieldNode;
 
 import com.google.common.base.CharMatcher;
-import com.google.common.base.Charsets;
 import com.google.common.base.Splitter;
 import com.google.common.base.Strings;
 import com.google.common.collect.BiMap;
@@ -84,7 +84,7 @@ public class FMLDeobfuscatingRemapper extends Remapper {
         {
             File mapData = new File(deobfFileName);
             LZMAInputSupplier zis = new LZMAInputSupplier(new FileInputStream(mapData));
-            CharSource srgSource = zis.asCharSource(Charsets.UTF_8);
+            CharSource srgSource = zis.asCharSource(StandardCharsets.UTF_8);
             List<String> srgList = srgSource.readLines();
             rawMethodMaps = Maps.newHashMap();
             rawFieldMaps = Maps.newHashMap();
@@ -130,13 +130,13 @@ public class FMLDeobfuscatingRemapper extends Remapper {
                 // get as a resource
                 InputStream classData = getClass().getResourceAsStream(deobfFileName);
                 LZMAInputSupplier zis = new LZMAInputSupplier(classData);
-                CharSource srgSource = zis.asCharSource(Charsets.UTF_8);
+                CharSource srgSource = zis.asCharSource(StandardCharsets.UTF_8);
                 srgList = srgSource.readLines();
                 FMLLog.log.debug("Loading deobfuscation resource {} with {} records", deobfFileName, srgList.size());
             }
             else
             {
-                srgList = Files.readLines(new File(gradleStartProp), Charsets.UTF_8);
+                srgList = Files.readLines(new File(gradleStartProp), StandardCharsets.UTF_8);
                 FMLLog.log.debug("Loading deobfuscation resource {} with {} records", gradleStartProp, srgList.size());
             }
 

--- a/src/main/java/net/minecraftforge/fml/common/discovery/ContainerType.java
+++ b/src/main/java/net/minecraftforge/fml/common/discovery/ContainerType.java
@@ -23,8 +23,6 @@ import java.util.List;
 
 import net.minecraftforge.fml.common.ModContainer;
 
-import com.google.common.base.Throwables;
-
 public enum ContainerType
 {
     JAR(JarDiscoverer.class),
@@ -38,9 +36,8 @@ public enum ContainerType
         {
             this.discoverer = discovererClass.newInstance();
         }
-        catch (Exception e)
+        catch (ReflectiveOperationException e)
         {
-            Throwables.throwIfUnchecked(e);
             throw new RuntimeException(e);
         }
     }

--- a/src/main/java/net/minecraftforge/fml/common/discovery/ContainerType.java
+++ b/src/main/java/net/minecraftforge/fml/common/discovery/ContainerType.java
@@ -40,7 +40,8 @@ public enum ContainerType
         }
         catch (Exception e)
         {
-            throw Throwables.propagate(e);
+            Throwables.throwIfUnchecked(e);
+            throw new RuntimeException(e);
         }
     }
 

--- a/src/main/java/net/minecraftforge/fml/common/discovery/DirectoryDiscoverer.java
+++ b/src/main/java/net/minecraftforge/fml/common/discovery/DirectoryDiscoverer.java
@@ -22,6 +22,7 @@ package net.minecraftforge.fml.common.discovery;
 import java.io.File;
 import java.io.FileFilter;
 import java.io.FileInputStream;
+import java.io.IOException;
 import java.util.Arrays;
 import java.util.List;
 import java.util.regex.Matcher;
@@ -35,7 +36,6 @@ import net.minecraftforge.fml.common.discovery.asm.ASMModParser;
 
 import org.apache.commons.io.IOUtils;
 
-import com.google.common.base.Throwables;
 import com.google.common.collect.Lists;
 
 import javax.annotation.Nullable;
@@ -121,9 +121,8 @@ public class DirectoryDiscoverer implements ITypeDiscoverer
                     FMLLog.log.error("There was a problem reading the file {} - probably this is a corrupt file", file.getPath(), e);
                     throw e;
                 }
-                catch (Exception e)
+                catch (IOException e)
                 {
-                    Throwables.throwIfUnchecked(e);
                     throw new RuntimeException(e);
                 }
                 finally

--- a/src/main/java/net/minecraftforge/fml/common/discovery/DirectoryDiscoverer.java
+++ b/src/main/java/net/minecraftforge/fml/common/discovery/DirectoryDiscoverer.java
@@ -34,7 +34,6 @@ import net.minecraftforge.fml.common.ModContainerFactory;
 import net.minecraftforge.fml.common.discovery.asm.ASMModParser;
 
 import org.apache.commons.io.IOUtils;
-import org.apache.logging.log4j.Level;
 
 import com.google.common.base.Throwables;
 import com.google.common.collect.Lists;
@@ -124,7 +123,8 @@ public class DirectoryDiscoverer implements ITypeDiscoverer
                 }
                 catch (Exception e)
                 {
-                    throw Throwables.propagate(e);
+                    Throwables.throwIfUnchecked(e);
+                    throw new RuntimeException(e);
                 }
                 finally
                 {

--- a/src/main/java/net/minecraftforge/fml/common/discovery/ModDiscoverer.java
+++ b/src/main/java/net/minecraftforge/fml/common/discovery/ModDiscoverer.java
@@ -31,7 +31,6 @@ import net.minecraftforge.fml.common.ModContainer;
 import net.minecraftforge.fml.relauncher.CoreModManager;
 import net.minecraftforge.fml.relauncher.FileListHelper;
 
-import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 import com.google.common.collect.ObjectArrays;
@@ -149,11 +148,6 @@ public class ModDiscoverer
             catch (LoaderException le)
             {
                 FMLLog.log.warn("Identified a problem with the mod candidate {}, ignoring this source", candidate.getModContainer(), le);
-            }
-            catch (Throwable t)
-            {
-                Throwables.throwIfUnchecked(t);
-                throw new RuntimeException(t);
             }
         }
 

--- a/src/main/java/net/minecraftforge/fml/common/discovery/ModDiscoverer.java
+++ b/src/main/java/net/minecraftforge/fml/common/discovery/ModDiscoverer.java
@@ -31,8 +31,6 @@ import net.minecraftforge.fml.common.ModContainer;
 import net.minecraftforge.fml.relauncher.CoreModManager;
 import net.minecraftforge.fml.relauncher.FileListHelper;
 
-import org.apache.logging.log4j.Level;
-
 import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
@@ -154,7 +152,8 @@ public class ModDiscoverer
             }
             catch (Throwable t)
             {
-                Throwables.propagate(t);
+                Throwables.throwIfUnchecked(t);
+                throw new RuntimeException(t);
             }
         }
 

--- a/src/main/java/net/minecraftforge/fml/common/eventhandler/EventBus.java
+++ b/src/main/java/net/minecraftforge/fml/common/eventhandler/EventBus.java
@@ -182,7 +182,8 @@ public class EventBus implements IEventExceptionHandler
         catch (Throwable throwable)
         {
             exceptionHandler.handleException(this, event, listeners, index, throwable);
-            Throwables.propagate(throwable);
+            Throwables.throwIfUnchecked(throwable);
+            throw new RuntimeException(throwable);
         }
         return (event.isCancelable() ? event.isCanceled() : false);
     }

--- a/src/main/java/net/minecraftforge/fml/common/launcher/FMLTweaker.java
+++ b/src/main/java/net/minecraftforge/fml/common/launcher/FMLTweaker.java
@@ -35,7 +35,6 @@ import net.minecraftforge.fml.relauncher.FMLSecurityManager;
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.LogManager;
 
-import com.google.common.base.Throwables;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 
@@ -128,7 +127,7 @@ public class FMLTweaker implements ITweaker {
         catch (URISyntaxException e)
         {
             LogManager.getLogger("FMLTWEAK").log(Level.ERROR, "Missing URI information for FML tweak");
-            throw Throwables.propagate(e);
+            throw new RuntimeException(e);
         }
     }
 

--- a/src/main/java/net/minecraftforge/fml/common/launcher/Yggdrasil.java
+++ b/src/main/java/net/minecraftforge/fml/common/launcher/Yggdrasil.java
@@ -24,7 +24,6 @@ import java.util.Map;
 
 import org.apache.logging.log4j.LogManager;
 
-import com.google.common.base.Throwables;
 import com.mojang.authlib.Agent;
 import com.mojang.authlib.exceptions.AuthenticationException;
 import com.mojang.authlib.yggdrasil.YggdrasilAuthenticationService;
@@ -50,8 +49,7 @@ public class Yggdrasil
         catch (AuthenticationException e)
         {
             LogManager.getLogger("FMLTWEAK").error("-- Login failed! {}", e.getMessage(), e);
-            Throwables.propagate(e);
-            return; // don't set other variables
+            throw new RuntimeException(e); // don't set other variables
         }
 
         args.put("--username",       auth.getSelectedProfile().getName());

--- a/src/main/java/net/minecraftforge/fml/common/network/ByteBufUtils.java
+++ b/src/main/java/net/minecraftforge/fml/common/network/ByteBufUtils.java
@@ -20,6 +20,7 @@
 package net.minecraftforge.fml.common.network;
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
@@ -35,9 +36,6 @@ import net.minecraftforge.registries.IForgeRegistryEntry;
 import net.minecraftforge.registries.RegistryManager;
 
 import org.apache.commons.lang3.Validate;
-
-import com.google.common.base.Charsets;
-import com.google.common.base.Throwables;
 
 import io.netty.buffer.ByteBuf;
 
@@ -151,7 +149,7 @@ public class ByteBufUtils {
     public static String readUTF8String(ByteBuf from)
     {
         int len = readVarInt(from,2);
-        String str = from.toString(from.readerIndex(), len, Charsets.UTF_8);
+        String str = from.toString(from.readerIndex(), len, StandardCharsets.UTF_8);
         from.readerIndex(from.readerIndex() + len);
         return str;
     }
@@ -164,7 +162,7 @@ public class ByteBufUtils {
      */
     public static void writeUTF8String(ByteBuf to, String string)
     {
-        byte[] utf8Bytes = string.getBytes(Charsets.UTF_8);
+        byte[] utf8Bytes = string.getBytes(StandardCharsets.UTF_8);
         Validate.isTrue(varIntByteCount(utf8Bytes.length) < 3, "The string is too long for this encoding.");
         writeVarInt(to, utf8Bytes.length, 2);
         to.writeBytes(utf8Bytes);
@@ -194,10 +192,11 @@ public class ByteBufUtils {
         try
         {
             return pb.readItemStack();
-        } catch (IOException e)
+        }
+        catch (IOException e)
         {
             // Unpossible?
-            throw Throwables.propagate(e);
+            throw new RuntimeException(e);
         }
     }
 

--- a/src/main/java/net/minecraftforge/fml/common/network/handshake/ChannelRegistrationHandler.java
+++ b/src/main/java/net/minecraftforge/fml/common/network/handshake/ChannelRegistrationHandler.java
@@ -22,6 +22,7 @@ package net.minecraftforge.fml.common.network.handshake;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.SimpleChannelInboundHandler;
 
+import java.nio.charset.StandardCharsets;
 import java.util.Set;
 
 import net.minecraft.network.NetworkManager;
@@ -30,9 +31,6 @@ import net.minecraftforge.fml.common.FMLLog;
 import net.minecraftforge.fml.common.network.internal.FMLProxyPacket;
 import net.minecraftforge.fml.relauncher.Side;
 
-import org.apache.logging.log4j.Level;
-
-import com.google.common.base.Charsets;
 import com.google.common.collect.ImmutableSet;
 
 public class ChannelRegistrationHandler extends SimpleChannelInboundHandler<FMLProxyPacket> {
@@ -45,7 +43,7 @@ public class ChannelRegistrationHandler extends SimpleChannelInboundHandler<FMLP
         {
             byte[] data = new byte[msg.payload().readableBytes()];
             msg.payload().readBytes(data);
-            String channels = new String(data,Charsets.UTF_8);
+            String channels = new String(data, StandardCharsets.UTF_8);
             String[] split = channels.split("\0");
             Set<String> channelSet = ImmutableSet.copyOf(split);
             FMLCommonHandler.instance().fireNetRegistrationEvent(manager, channelSet, msg.channel(), side);

--- a/src/main/java/net/minecraftforge/fml/common/network/handshake/FMLHandshakeMessage.java
+++ b/src/main/java/net/minecraftforge/fml/common/network/handshake/FMLHandshakeMessage.java
@@ -22,6 +22,7 @@ package net.minecraftforge.fml.common.network.handshake;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 
+import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
@@ -37,7 +38,6 @@ import net.minecraftforge.fml.common.network.NetworkRegistry;
 import net.minecraftforge.fml.common.network.internal.FMLProxyPacket;
 import net.minecraftforge.registries.ForgeRegistry;
 
-import com.google.common.base.Charsets;
 import com.google.common.base.Joiner;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Maps;
@@ -47,7 +47,7 @@ public abstract class FMLHandshakeMessage {
     public static FMLProxyPacket makeCustomChannelRegistration(Set<String> channels)
     {
         String salutation = Joiner.on('\0').join(Iterables.concat(Arrays.asList("FML|HS","FML", "FML|MP"),channels));
-        FMLProxyPacket proxy = new FMLProxyPacket(new PacketBuffer(Unpooled.wrappedBuffer(salutation.getBytes(Charsets.UTF_8))), "REGISTER");
+        FMLProxyPacket proxy = new FMLProxyPacket(new PacketBuffer(Unpooled.wrappedBuffer(salutation.getBytes(StandardCharsets.UTF_8))), "REGISTER");
         return proxy;
     }
     public static class ServerHello extends FMLHandshakeMessage {

--- a/src/main/java/net/minecraftforge/fml/common/network/internal/EntitySpawnHandler.java
+++ b/src/main/java/net/minecraftforge/fml/common/network/internal/EntitySpawnHandler.java
@@ -41,8 +41,6 @@ import net.minecraftforge.fml.common.registry.IEntityAdditionalSpawnData;
 import net.minecraftforge.fml.common.registry.IThrowableEntity;
 import net.minecraftforge.fml.common.registry.EntityRegistry.EntityRegistration;
 
-import com.google.common.base.Throwables;
-
 public class EntitySpawnHandler extends SimpleChannelInboundHandler<FMLMessage.EntityMessage> {
     @Override
     protected void channelRead0(ChannelHandlerContext ctx, final EntityMessage msg) throws Exception
@@ -133,9 +131,7 @@ public class EntitySpawnHandler extends SimpleChannelInboundHandler<FMLMessage.E
         }
         catch (Exception e)
         {
-            FMLLog.log.error("A severe problem occurred during the spawning of an entity at ({}, {}, {})", spawnMsg.rawX, spawnMsg.rawY, spawnMsg.rawZ, e);
-            Throwables.throwIfUnchecked(e);
-            throw new RuntimeException(e);
+            throw new RuntimeException("A severe problem occurred during the spawning of an entity at (" + spawnMsg.rawX + ", " + spawnMsg.rawY + ", " + spawnMsg.rawZ + ")", e);
         }
     }
 

--- a/src/main/java/net/minecraftforge/fml/common/network/internal/EntitySpawnHandler.java
+++ b/src/main/java/net/minecraftforge/fml/common/network/internal/EntitySpawnHandler.java
@@ -22,8 +22,6 @@ package net.minecraftforge.fml.common.network.internal;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.SimpleChannelInboundHandler;
 
-import org.apache.logging.log4j.Level;
-
 import net.minecraft.client.entity.EntityPlayerSP;
 import net.minecraft.client.multiplayer.WorldClient;
 import net.minecraft.entity.Entity;
@@ -132,10 +130,12 @@ public class EntitySpawnHandler extends SimpleChannelInboundHandler<FMLMessage.E
                 ((IEntityAdditionalSpawnData) entity).readSpawnData(spawnMsg.dataStream);
             }
             wc.addEntityToWorld(spawnMsg.entityId, entity);
-        } catch (Exception e)
+        }
+        catch (Exception e)
         {
             FMLLog.log.error("A severe problem occurred during the spawning of an entity at ({}, {}, {})", spawnMsg.rawX, spawnMsg.rawY, spawnMsg.rawZ, e);
-            throw Throwables.propagate(e);
+            Throwables.throwIfUnchecked(e);
+            throw new RuntimeException(e);
         }
     }
 

--- a/src/main/java/net/minecraftforge/fml/common/network/internal/FMLMessage.java
+++ b/src/main/java/net/minecraftforge/fml/common/network/internal/FMLMessage.java
@@ -38,10 +38,6 @@ import net.minecraftforge.fml.common.registry.IEntityAdditionalSpawnData;
 import net.minecraftforge.fml.common.registry.IThrowableEntity;
 import net.minecraftforge.fml.relauncher.Side;
 
-import org.apache.logging.log4j.Level;
-
-import com.google.common.base.Throwables;
-
 public abstract class FMLMessage {
     public static class CompleteHandshake extends FMLMessage {
         Side target;
@@ -181,10 +177,11 @@ public abstract class FMLMessage {
             try
             {
                 entity.getDataManager().writeEntries(pb);
-            } catch (IOException e)
+            }
+            catch (IOException e)
             {
                 FMLLog.log.fatal("Encountered fatal exception trying to send entity spawn data watchers", e);
-                throw Throwables.propagate(e);
+                throw new RuntimeException(e);
             }
             buf.writeBytes(tmpBuf);
 
@@ -233,10 +230,11 @@ public abstract class FMLMessage {
             try
             {
                 dataWatcherList = EntityDataManager.readEntries(new PacketBuffer(dat));
-            } catch (IOException e)
+            }
+            catch (IOException e)
             {
                 FMLLog.log.fatal("There was a critical error decoding the datawatcher stream for a mod entity.", e);
-                throw Throwables.propagate(e);
+                throw new RuntimeException(e);
             }
 
             throwerId = dat.readInt();

--- a/src/main/java/net/minecraftforge/fml/common/network/simpleimpl/SimpleNetworkWrapper.java
+++ b/src/main/java/net/minecraftforge/fml/common/network/simpleimpl/SimpleNetworkWrapper.java
@@ -171,9 +171,8 @@ public class SimpleNetworkWrapper {
         {
             return handler.newInstance();
         }
-        catch (Exception e)
+        catch (ReflectiveOperationException e)
         {
-            Throwables.throwIfUnchecked(e);
             throw new RuntimeException(e);
         }
     }

--- a/src/main/java/net/minecraftforge/fml/common/network/simpleimpl/SimpleNetworkWrapper.java
+++ b/src/main/java/net/minecraftforge/fml/common/network/simpleimpl/SimpleNetworkWrapper.java
@@ -27,7 +27,6 @@ import java.util.EnumMap;
 import com.google.common.base.Throwables;
 
 import net.minecraft.util.IThreadListener;
-import org.apache.logging.log4j.Level;
 
 import io.netty.channel.ChannelHandler;
 import io.netty.channel.ChannelPipeline;
@@ -129,7 +128,8 @@ public class SimpleNetworkWrapper {
         {
             // How is this possible?
             FMLLog.log.fatal("What? Netty isn't installed, what magic is this?", e);
-            throw Throwables.propagate(e);
+            Throwables.throwIfUnchecked(e);
+            throw new RuntimeException(e);
         }
     }
     public SimpleNetworkWrapper(String channelName)
@@ -147,7 +147,8 @@ public class SimpleNetworkWrapper {
         catch (Exception e)
         {
             FMLLog.log.fatal("It appears we somehow have a not-standard pipeline. Huh", e);
-            throw Throwables.propagate(e);
+            Throwables.throwIfUnchecked(e);
+            throw new RuntimeException(e);
         }
     }
     /**
@@ -169,9 +170,11 @@ public class SimpleNetworkWrapper {
         try
         {
             return handler.newInstance();
-        } catch (Exception e)
+        }
+        catch (Exception e)
         {
-            throw Throwables.propagate(e);
+            Throwables.throwIfUnchecked(e);
+            throw new RuntimeException(e);
         }
     }
     

--- a/src/main/java/net/minecraftforge/fml/common/network/simpleimpl/SimpleNetworkWrapper.java
+++ b/src/main/java/net/minecraftforge/fml/common/network/simpleimpl/SimpleNetworkWrapper.java
@@ -24,8 +24,6 @@ import io.netty.channel.ChannelFutureListener;
 import java.lang.reflect.Method;
 import java.util.EnumMap;
 
-import com.google.common.base.Throwables;
-
 import net.minecraft.util.IThreadListener;
 
 import io.netty.channel.ChannelHandler;
@@ -34,7 +32,6 @@ import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraft.network.INetHandler;
 import net.minecraft.network.Packet;
 import net.minecraft.tileentity.TileEntity;
-import net.minecraftforge.fml.common.FMLLog;
 import net.minecraftforge.fml.common.event.FMLInitializationEvent;
 import net.minecraftforge.fml.common.event.FMLPreInitializationEvent;
 import net.minecraftforge.fml.common.network.FMLEmbeddedChannel;
@@ -127,9 +124,7 @@ public class SimpleNetworkWrapper {
         catch (Exception e)
         {
             // How is this possible?
-            FMLLog.log.fatal("What? Netty isn't installed, what magic is this?", e);
-            Throwables.throwIfUnchecked(e);
-            throw new RuntimeException(e);
+            throw new RuntimeException("What? Netty isn't installed, what magic is this?", e);
         }
     }
     public SimpleNetworkWrapper(String channelName)
@@ -146,9 +141,7 @@ public class SimpleNetworkWrapper {
         }
         catch (Exception e)
         {
-            FMLLog.log.fatal("It appears we somehow have a not-standard pipeline. Huh", e);
-            Throwables.throwIfUnchecked(e);
-            throw new RuntimeException(e);
+            throw new RuntimeException("It appears we somehow have a not-standard pipeline. Huh", e);
         }
     }
     /**

--- a/src/main/java/net/minecraftforge/fml/common/patcher/ClassPatchManager.java
+++ b/src/main/java/net/minecraftforge/fml/common/patcher/ClassPatchManager.java
@@ -183,7 +183,8 @@ public class ClassPatchManager {
         catch (Exception e)
         {
             FMLLog.log.error("Error occurred reading binary patches. Expect severe problems!", e);
-            throw Throwables.propagate(e);
+            Throwables.throwIfUnchecked(e);
+            throw new RuntimeException(e);
         }
 
         patches = ArrayListMultimap.create();

--- a/src/main/java/net/minecraftforge/fml/common/patcher/ClassPatchManager.java
+++ b/src/main/java/net/minecraftforge/fml/common/patcher/ClassPatchManager.java
@@ -40,7 +40,6 @@ import net.minecraftforge.fml.repackage.com.nothome.delta.GDiffPatcher;
 import LZMA.LzmaInputStream;
 
 import com.google.common.base.Joiner;
-import com.google.common.base.Throwables;
 import com.google.common.collect.ArrayListMultimap;
 import com.google.common.collect.ListMultimap;
 import com.google.common.collect.Maps;
@@ -182,9 +181,7 @@ public class ClassPatchManager {
         }
         catch (Exception e)
         {
-            FMLLog.log.error("Error occurred reading binary patches. Expect severe problems!", e);
-            Throwables.throwIfUnchecked(e);
-            throw new RuntimeException(e);
+            throw new RuntimeException("Error occurred reading binary patches. Expect severe problems!", e);
         }
 
         patches = ArrayListMultimap.create();

--- a/src/main/java/net/minecraftforge/fml/common/registry/EntityEntry.java
+++ b/src/main/java/net/minecraftforge/fml/common/registry/EntityEntry.java
@@ -19,9 +19,6 @@
 package net.minecraftforge.fml.common.registry;
 
 import java.lang.reflect.Constructor;
-import java.lang.reflect.InvocationTargetException;
-
-import com.google.common.base.Throwables;
 
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.EntityList;
@@ -54,10 +51,6 @@ public class EntityEntry extends Impl<EntityEntry>
         catch (NoSuchMethodException e)
         {
             throw new RuntimeException("Invalid class " + this.cls + " no constructor taking " + World.class.getName());
-        }
-        catch (SecurityException e)
-        {
-            Throwables.propagate(e);
         }
     }
 

--- a/src/main/java/net/minecraftforge/fml/common/registry/GameRegistry.java
+++ b/src/main/java/net/minecraftforge/fml/common/registry/GameRegistry.java
@@ -352,7 +352,8 @@ public class GameRegistry
             try
             {
                 nbttag = JsonToNBT.getTagFromJson(nbtString);
-            } catch (NBTException e)
+            }
+            catch (NBTException e)
             {
                 FMLLog.log.warn("Encountered an exception parsing ItemStack NBT string {}", nbtString, e);
                 Throwables.throwIfUnchecked(e);

--- a/src/main/java/net/minecraftforge/fml/common/registry/GameRegistry.java
+++ b/src/main/java/net/minecraftforge/fml/common/registry/GameRegistry.java
@@ -24,7 +24,6 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
@@ -43,9 +42,7 @@ import net.minecraft.item.crafting.Ingredient;
 import net.minecraft.item.crafting.ShapedRecipes;
 import net.minecraft.item.crafting.ShapelessRecipes;
 import net.minecraft.nbt.JsonToNBT;
-import net.minecraft.nbt.NBTBase;
 import net.minecraft.nbt.NBTException;
-import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.NonNullList;
 import net.minecraft.util.ResourceLocation;
@@ -67,12 +64,10 @@ import net.minecraftforge.registries.RegistryManager;
 import net.minecraftforge.fml.common.IEntitySelectorFactory;
 
 import com.google.common.base.Strings;
-import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
-import com.google.common.primitives.Ints;
 
 import javax.annotation.Nonnull;
 
@@ -348,25 +343,13 @@ public class GameRegistry
         ItemStack is = new ItemStack(item, stackSize, meta);
         if (!Strings.isNullOrEmpty(nbtString))
         {
-            NBTBase nbttag = null;
             try
             {
-                nbttag = JsonToNBT.getTagFromJson(nbtString);
+                is.setTagCompound(JsonToNBT.getTagFromJson(nbtString));
             }
             catch (NBTException e)
             {
-                FMLLog.log.warn("Encountered an exception parsing ItemStack NBT string {}", nbtString, e);
-                Throwables.throwIfUnchecked(e);
-                throw new RuntimeException(e);
-            }
-            if (!(nbttag instanceof NBTTagCompound))
-            {
-                FMLLog.log.warn("Unexpected NBT string - multiple values {}", nbtString);
-                throw new RuntimeException("Invalid NBT JSON");
-            }
-            else
-            {
-                is.setTagCompound((NBTTagCompound)nbttag);
+                throw new RuntimeException("Encountered an exception parsing ItemStack NBT string " + nbtString, e);
             }
         }
         return is;

--- a/src/main/java/net/minecraftforge/fml/common/registry/ItemStackHolderInjector.java
+++ b/src/main/java/net/minecraftforge/fml/common/registry/ItemStackHolderInjector.java
@@ -28,7 +28,6 @@ import net.minecraftforge.fml.common.FMLLog;
 import net.minecraftforge.fml.common.discovery.ASMDataTable;
 import net.minecraftforge.fml.common.discovery.ASMDataTable.ASMData;
 
-import com.google.common.base.Throwables;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 
@@ -77,10 +76,9 @@ public enum ItemStackHolderInjector
                 clazz = Class.forName(className, true, getClass().getClassLoader());
                 classCache.put(className, clazz);
             }
-            catch (Exception ex)
+            catch (ClassNotFoundException ex)
             {
                 // unpossible?
-                Throwables.throwIfUnchecked(ex);
                 throw new RuntimeException(ex);
             }
         }
@@ -89,10 +87,9 @@ public enum ItemStackHolderInjector
             Field f = clazz.getField(annotationTarget);
             itemStackHolders.add(new ItemStackHolderRef(f, value, meta, nbt));
         }
-        catch (Exception ex)
+        catch (NoSuchFieldException ex)
         {
             // unpossible?
-            Throwables.throwIfUnchecked(ex);
             throw new RuntimeException(ex);
         }
     }

--- a/src/main/java/net/minecraftforge/fml/common/registry/ItemStackHolderInjector.java
+++ b/src/main/java/net/minecraftforge/fml/common/registry/ItemStackHolderInjector.java
@@ -28,12 +28,9 @@ import net.minecraftforge.fml.common.FMLLog;
 import net.minecraftforge.fml.common.discovery.ASMDataTable;
 import net.minecraftforge.fml.common.discovery.ASMDataTable.ASMData;
 
-import org.apache.logging.log4j.Level;
-
 import com.google.common.base.Throwables;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
-
 
 public enum ItemStackHolderInjector
 {
@@ -83,7 +80,8 @@ public enum ItemStackHolderInjector
             catch (Exception ex)
             {
                 // unpossible?
-                throw Throwables.propagate(ex);
+                Throwables.throwIfUnchecked(ex);
+                throw new RuntimeException(ex);
             }
         }
         try
@@ -94,7 +92,8 @@ public enum ItemStackHolderInjector
         catch (Exception ex)
         {
             // unpossible?
-            throw Throwables.propagate(ex);
+            Throwables.throwIfUnchecked(ex);
+            throw new RuntimeException(ex);
         }
     }
 }

--- a/src/main/java/net/minecraftforge/fml/common/registry/ItemStackHolderRef.java
+++ b/src/main/java/net/minecraftforge/fml/common/registry/ItemStackHolderRef.java
@@ -26,8 +26,6 @@ import java.lang.reflect.Modifier;
 import net.minecraft.item.ItemStack;
 import net.minecraftforge.fml.common.FMLLog;
 
-import com.google.common.base.Throwables;
-
 /**
  * Internal class used in tracking {@link GameRegistry.ItemStackHolder} references
  *
@@ -69,9 +67,8 @@ class ItemStackHolderRef {
             }
             modifiersField.setInt(f, f.getModifiers() & ~Modifier.FINAL);
         }
-        catch (Exception e)
+        catch (ReflectiveOperationException e)
         {
-            Throwables.throwIfUnchecked(e);
             throw new RuntimeException(e);
         }
     }

--- a/src/main/java/net/minecraftforge/fml/common/registry/ItemStackHolderRef.java
+++ b/src/main/java/net/minecraftforge/fml/common/registry/ItemStackHolderRef.java
@@ -26,11 +26,7 @@ import java.lang.reflect.Modifier;
 import net.minecraft.item.ItemStack;
 import net.minecraftforge.fml.common.FMLLog;
 
-import org.apache.logging.log4j.Level;
-
 import com.google.common.base.Throwables;
-
-
 
 /**
  * Internal class used in tracking {@link GameRegistry.ItemStackHolder} references
@@ -72,9 +68,11 @@ class ItemStackHolderRef {
                 modifiersField.setAccessible(true);
             }
             modifiersField.setInt(f, f.getModifiers() & ~Modifier.FINAL);
-        } catch (Exception e)
+        }
+        catch (Exception e)
         {
-            throw Throwables.propagate(e);
+            Throwables.throwIfUnchecked(e);
+            throw new RuntimeException(e);
         }
     }
 

--- a/src/main/java/net/minecraftforge/fml/relauncher/CoreModManager.java
+++ b/src/main/java/net/minecraftforge/fml/relauncher/CoreModManager.java
@@ -58,7 +58,6 @@ import net.minecraftforge.fml.relauncher.IFMLLoadingPlugin.SortingIndex;
 import net.minecraftforge.fml.relauncher.IFMLLoadingPlugin.TransformerExclusions;
 
 import com.google.common.base.Strings;
-import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
@@ -222,9 +221,7 @@ public class CoreModManager {
         }
         catch (Exception e)
         {
-            FMLLog.log.error("The patch transformer failed to load! This is critical, loading cannot continue!", e);
-            Throwables.throwIfUnchecked(e);
-            throw new RuntimeException(e);
+            throw new RuntimeException("The patch transformer failed to load! This is critical, loading cannot continue!", e);
         }
 
         loadPlugins = new ArrayList<FMLPluginWrapper>();

--- a/src/main/java/net/minecraftforge/fml/relauncher/CoreModManager.java
+++ b/src/main/java/net/minecraftforge/fml/relauncher/CoreModManager.java
@@ -57,8 +57,6 @@ import net.minecraftforge.fml.relauncher.IFMLLoadingPlugin.Name;
 import net.minecraftforge.fml.relauncher.IFMLLoadingPlugin.SortingIndex;
 import net.minecraftforge.fml.relauncher.IFMLLoadingPlugin.TransformerExclusions;
 
-import org.apache.commons.io.IOUtils;
-
 import com.google.common.base.Strings;
 import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableList;
@@ -225,7 +223,8 @@ public class CoreModManager {
         catch (Exception e)
         {
             FMLLog.log.error("The patch transformer failed to load! This is critical, loading cannot continue!", e);
-            throw Throwables.propagate(e);
+            Throwables.throwIfUnchecked(e);
+            throw new RuntimeException(e);
         }
 
         loadPlugins = new ArrayList<FMLPluginWrapper>();

--- a/src/main/java/net/minecraftforge/fml/relauncher/FMLLaunchHandler.java
+++ b/src/main/java/net/minecraftforge/fml/relauncher/FMLLaunchHandler.java
@@ -21,8 +21,6 @@ package net.minecraftforge.fml.relauncher;
 
 import java.io.File;
 
-import org.apache.logging.log4j.Level;
-
 import net.minecraft.launchwrapper.LaunchClassLoader;
 import net.minecraftforge.fml.common.FMLLog;
 import net.minecraftforge.fml.common.launcher.FMLTweaker;
@@ -102,7 +100,8 @@ public class FMLLaunchHandler
         catch (Throwable t)
         {
             FMLLog.log.error("An error occurred trying to configure the minecraft home at {} for Forge Mod Loader", minecraftHome.getAbsolutePath(), t);
-            throw Throwables.propagate(t);
+            Throwables.throwIfUnchecked(t);
+            throw new RuntimeException(t);
         }
     }
 

--- a/src/main/java/net/minecraftforge/fml/relauncher/FMLLaunchHandler.java
+++ b/src/main/java/net/minecraftforge/fml/relauncher/FMLLaunchHandler.java
@@ -25,8 +25,6 @@ import net.minecraft.launchwrapper.LaunchClassLoader;
 import net.minecraftforge.fml.common.FMLLog;
 import net.minecraftforge.fml.common.launcher.FMLTweaker;
 
-import com.google.common.base.Throwables;
-
 public class FMLLaunchHandler
 {
     private static FMLLaunchHandler INSTANCE;
@@ -99,9 +97,7 @@ public class FMLLaunchHandler
         }
         catch (Throwable t)
         {
-            FMLLog.log.error("An error occurred trying to configure the minecraft home at {} for Forge Mod Loader", minecraftHome.getAbsolutePath(), t);
-            Throwables.throwIfUnchecked(t);
-            throw new RuntimeException(t);
+            throw new RuntimeException("An error occurred trying to configure the Minecraft home at " + minecraftHome.getAbsolutePath() + " for Forge Mod Loader", t);
         }
     }
 

--- a/src/main/java/net/minecraftforge/fml/relauncher/ModListHelper.java
+++ b/src/main/java/net/minecraftforge/fml/relauncher/ModListHelper.java
@@ -21,14 +21,13 @@ package net.minecraftforge.fml.relauncher;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import net.minecraft.launchwrapper.Launch;
 import net.minecraftforge.fml.common.FMLLog;
 
-import org.apache.logging.log4j.Level;
-import com.google.common.base.Charsets;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 import com.google.common.io.Files;
@@ -105,7 +104,7 @@ public class ModListHelper {
         }
         String json;
         try {
-            json = Files.asCharSource(f, Charsets.UTF_8).read();
+            json = Files.asCharSource(f, StandardCharsets.UTF_8).read();
         } catch (IOException e1) {
             FMLLog.log.info(FMLLog.log.getMessageFactory().newMessage("Failed to read modList json file {}.", listFile), e1);
             return;

--- a/src/main/java/net/minecraftforge/registries/ObjectHolderRef.java
+++ b/src/main/java/net/minecraftforge/registries/ObjectHolderRef.java
@@ -27,9 +27,6 @@ import java.util.LinkedList;
 import java.util.Queue;
 
 import net.minecraft.util.ResourceLocation;
-import org.apache.logging.log4j.Level;
-
-import com.google.common.base.Throwables;
 
 import net.minecraftforge.fml.common.FMLLog;
 import net.minecraftforge.fml.common.registry.GameRegistry;
@@ -73,9 +70,8 @@ class ObjectHolderRef
                     this.injectedObject = ((IForgeRegistryEntry)existing).getRegistryName();
                 }
             }
-            catch (Exception e)
+            catch (IllegalAccessException e)
             {
-                Throwables.throwIfUnchecked(e);
                 throw new RuntimeException(e);
             }
         }
@@ -92,9 +88,8 @@ class ObjectHolderRef
         {
             FinalFieldHelper.makeWritable(field);
         }
-        catch (Exception e)
+        catch (ReflectiveOperationException e)
         {
-            Throwables.throwIfUnchecked(e);
             throw new RuntimeException(e);
         }
     }
@@ -150,7 +145,7 @@ class ObjectHolderRef
         {
             FinalFieldHelper.setField(field, null, thing);
         }
-        catch (Exception e)
+        catch (IllegalArgumentException | ReflectiveOperationException e)
         {
             FMLLog.log.warn("Unable to set {} with value {} ({})", this.field, thing, this.injectedObject, e);
         }
@@ -162,7 +157,8 @@ class ObjectHolderRef
         private static Object reflectionFactory;
         private static Method newFieldAccessor;
         private static Method fieldAccessorSet;
-        static Field makeWritable(Field f) throws Exception
+
+        static Field makeWritable(Field f) throws ReflectiveOperationException
         {
             f.setAccessible(true);
             if (modifiersField == null)
@@ -178,8 +174,7 @@ class ObjectHolderRef
             return f;
         }
 
-
-        static void setField(Field field, @Nullable Object instance, Object thing) throws Exception
+        static void setField(Field field, @Nullable Object instance, Object thing) throws ReflectiveOperationException
         {
             Object fieldAccessor = newFieldAccessor.invoke(reflectionFactory, field, false);
             fieldAccessorSet.invoke(fieldAccessor, instance, thing);

--- a/src/main/java/net/minecraftforge/registries/ObjectHolderRegistry.java
+++ b/src/main/java/net/minecraftforge/registries/ObjectHolderRegistry.java
@@ -33,7 +33,6 @@ import net.minecraftforge.fml.common.discovery.ASMDataTable.ASMData;
 import net.minecraftforge.fml.common.registry.GameRegistry;
 import net.minecraftforge.fml.common.registry.GameRegistry.ObjectHolder;
 
-import com.google.common.base.Throwables;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 
@@ -105,10 +104,9 @@ public enum ObjectHolderRegistry
                 clazz = Class.forName(className, extractFromValue, getClass().getClassLoader());
                 classCache.put(className, clazz);
             }
-            catch (Exception ex)
+            catch (ClassNotFoundException ex)
             {
                 // unpossible?
-                Throwables.throwIfUnchecked(ex);
                 throw new RuntimeException(ex);
             }
         }
@@ -133,10 +131,9 @@ public enum ObjectHolderRegistry
                 Field f = clazz.getDeclaredField(annotationTarget);
                 addHolderReference(new ObjectHolderRef(f, new ResourceLocation(value), extractFromValue));
             }
-            catch (Exception ex)
+            catch (NoSuchFieldException ex)
             {
                 // unpossible?
-                Throwables.throwIfUnchecked(ex);
                 throw new RuntimeException(ex);
             }
         }


### PR DESCRIPTION
Another cleanup PR, this time addressing the use of library functions that are now deprecated due to the updates made by 1.12.

Mainly moving to Java's own `StandardCharsets` and the many uses of `Throwables.propagate()`.

There are some deprecated APIs used that this PR doesn't address, mainly to do with Netty and ASM. This should cover all the simple changes, though.