### PR TITLE
[1.12] Add amount and contextual data to DecorateBiomeEvent.Decorate

### DIFF
--- a/patches/minecraft/net/minecraft/world/biome/BiomeDecorator.java.patch
+++ b/patches/minecraft/net/minecraft/world/biome/BiomeDecorator.java.patch
@@ -1,139 +1,197 @@
 --- ../src-base/minecraft/net/minecraft/world/biome/BiomeDecorator.java
 +++ ../src-work/minecraft/net/minecraft/world/biome/BiomeDecorator.java
-@@ -92,8 +92,10 @@
+@@ -23,6 +23,13 @@
+ import net.minecraft.world.gen.feature.WorldGenWaterlily;
+ import net.minecraft.world.gen.feature.WorldGenerator;
+ 
++import net.minecraftforge.event.terraingen.TerrainGen;
++import net.minecraftforge.event.terraingen.DecorateBiomeEvent;
++import static net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.*;
++
++import net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType;
++import net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.Generator;
++
+ public class BiomeDecorator
+ {
+     public boolean field_185425_a;
+@@ -92,23 +99,24 @@
  
      protected void func_150513_a(Biome p_150513_1_, World p_150513_2_, Random p_150513_3_)
      {
-+        net.minecraftforge.common.MinecraftForge.EVENT_BUS.post(new net.minecraftforge.event.terraingen.DecorateBiomeEvent.Pre(p_150513_2_, p_150513_3_, field_180294_c));
++        net.minecraftforge.common.MinecraftForge.EVENT_BUS.post(new DecorateBiomeEvent.Pre(p_150513_2_, p_150513_3_, field_180294_c));
          this.func_76797_b(p_150513_2_, p_150513_3_);
  
-+        if(net.minecraftforge.event.terraingen.TerrainGen.decorate(p_150513_2_, p_150513_3_, field_180294_c, net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.SAND))
-         for (int i = 0; i < this.field_76805_H; ++i)
+-        for (int i = 0; i < this.field_76805_H; ++i)
++        for (int f_i = TerrainGen.decorate(p_150513_2_, p_150513_3_, field_180294_c, EventType.SAND, field_76805_H, field_76810_g, Generator.Position.SURFACE); f_i > 0; f_i--)
          {
              int j = p_150513_3_.nextInt(16) + 8;
-@@ -101,6 +103,7 @@
+             int k = p_150513_3_.nextInt(16) + 8;
              this.field_76810_g.func_180709_b(p_150513_2_, p_150513_3_, p_150513_2_.func_175672_r(this.field_180294_c.func_177982_a(j, 0, k)));
          }
  
-+        if(net.minecraftforge.event.terraingen.TerrainGen.decorate(p_150513_2_, p_150513_3_, field_180294_c, net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.CLAY))
-         for (int i1 = 0; i1 < this.field_76806_I; ++i1)
+-        for (int i1 = 0; i1 < this.field_76806_I; ++i1)
++        for (int f_i = TerrainGen.decorate(p_150513_2_, p_150513_3_, field_180294_c, EventType.CLAY, field_76806_I, field_76809_f, Generator.Position.SURFACE); f_i > 0; f_i--)
          {
              int l1 = p_150513_3_.nextInt(16) + 8;
-@@ -108,6 +111,7 @@
+             int i6 = p_150513_3_.nextInt(16) + 8;
              this.field_76809_f.func_180709_b(p_150513_2_, p_150513_3_, p_150513_2_.func_175672_r(this.field_180294_c.func_177982_a(l1, 0, i6)));
          }
  
-+        if(net.minecraftforge.event.terraingen.TerrainGen.decorate(p_150513_2_, p_150513_3_, field_180294_c, net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.SAND_PASS2))
-         for (int j1 = 0; j1 < this.field_76801_G; ++j1)
+-        for (int j1 = 0; j1 < this.field_76801_G; ++j1)
++        for (int f_i = TerrainGen.decorate(p_150513_2_, p_150513_3_, field_180294_c, EventType.SAND_PASS2, field_76801_G, field_76822_h, Generator.Position.SURFACE); f_i > 0; f_i--)
          {
              int i2 = p_150513_3_.nextInt(16) + 8;
-@@ -122,6 +126,7 @@
+             int j6 = p_150513_3_.nextInt(16) + 8;
+@@ -122,6 +130,7 @@
              ++k1;
          }
  
-+        if(net.minecraftforge.event.terraingen.TerrainGen.decorate(p_150513_2_, p_150513_3_, field_180294_c, net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.TREE))
++        k1 = TerrainGen.decorate(p_150513_2_, p_150513_3_, field_180294_c, EventType.TREE, k1);
          for (int j2 = 0; j2 < k1; ++j2)
          {
              int k6 = p_150513_3_.nextInt(16) + 8;
-@@ -136,6 +141,7 @@
+@@ -136,14 +145,14 @@
              }
          }
  
-+        if(net.minecraftforge.event.terraingen.TerrainGen.decorate(p_150513_2_, p_150513_3_, field_180294_c, net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.BIG_SHROOM))
-         for (int k2 = 0; k2 < this.field_76807_J; ++k2)
+-        for (int k2 = 0; k2 < this.field_76807_J; ++k2)
++        for (int f_i = TerrainGen.decorate(p_150513_2_, p_150513_3_, field_180294_c, EventType.BIG_SHROOM, field_76807_J, field_76826_u, Generator.Position.SURFACE); f_i > 0; f_i--)
          {
              int l6 = p_150513_3_.nextInt(16) + 8;
-@@ -143,6 +149,7 @@
+             int k10 = p_150513_3_.nextInt(16) + 8;
              this.field_76826_u.func_180709_b(p_150513_2_, p_150513_3_, p_150513_2_.func_175645_m(this.field_180294_c.func_177982_a(l6, 0, k10)));
          }
  
-+        if(net.minecraftforge.event.terraingen.TerrainGen.decorate(p_150513_2_, p_150513_3_, field_180294_c, net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.FLOWERS))
-         for (int l2 = 0; l2 < this.field_76802_A; ++l2)
+-        for (int l2 = 0; l2 < this.field_76802_A; ++l2)
++        for (int f_i = TerrainGen.decorate(p_150513_2_, p_150513_3_, field_180294_c, EventType.FLOWERS, field_76802_A); f_i > 0; f_i--)
          {
              int i7 = p_150513_3_.nextInt(16) + 8;
-@@ -164,6 +171,7 @@
+             int l10 = p_150513_3_.nextInt(16) + 8;
+@@ -164,7 +173,7 @@
              }
          }
  
-+        if(net.minecraftforge.event.terraingen.TerrainGen.decorate(p_150513_2_, p_150513_3_, field_180294_c, net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.GRASS))
-         for (int i3 = 0; i3 < this.field_76803_B; ++i3)
+-        for (int i3 = 0; i3 < this.field_76803_B; ++i3)
++        for (int f_i = TerrainGen.decorate(p_150513_2_, p_150513_3_, field_180294_c, EventType.GRASS, field_76803_B); f_i > 0; f_i--)
          {
              int j7 = p_150513_3_.nextInt(16) + 8;
-@@ -177,6 +185,7 @@
+             int i11 = p_150513_3_.nextInt(16) + 8;
+@@ -177,7 +186,7 @@
              }
          }
  
-+        if(net.minecraftforge.event.terraingen.TerrainGen.decorate(p_150513_2_, p_150513_3_, field_180294_c, net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.DEAD_BUSH))
-         for (int j3 = 0; j3 < this.field_76804_C; ++j3)
+-        for (int j3 = 0; j3 < this.field_76804_C; ++j3)
++        for (int f_i = TerrainGen.decorate(p_150513_2_, p_150513_3_, field_180294_c, EventType.DEAD_BUSH, field_76804_C); f_i > 0; f_i--)
          {
              int k7 = p_150513_3_.nextInt(16) + 8;
-@@ -190,6 +199,7 @@
+             int j11 = p_150513_3_.nextInt(16) + 8;
+@@ -190,7 +199,7 @@
              }
          }
  
-+        if(net.minecraftforge.event.terraingen.TerrainGen.decorate(p_150513_2_, p_150513_3_, field_180294_c, net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.LILYPAD))
-         for (int k3 = 0; k3 < this.field_76833_y; ++k3)
+-        for (int k3 = 0; k3 < this.field_76833_y; ++k3)
++        for (int f_i = TerrainGen.decorate(p_150513_2_, p_150513_3_, field_180294_c, EventType.LILYPAD, field_76833_y, field_76834_x, Generator.Position.SURFACE); f_i > 0; f_i--)
          {
              int l7 = p_150513_3_.nextInt(16) + 8;
-@@ -216,6 +226,8 @@
+             int k11 = p_150513_3_.nextInt(16) + 8;
+@@ -216,9 +225,9 @@
              }
          }
  
-+        if(net.minecraftforge.event.terraingen.TerrainGen.decorate(p_150513_2_, p_150513_3_, field_180294_c, net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.SHROOM))
-+        {
-         for (int l3 = 0; l3 < this.field_76798_D; ++l3)
+-        for (int l3 = 0; l3 < this.field_76798_D; ++l3)
++        for (int f_i_o = TerrainGen.decorate(p_150513_2_, p_150513_3_, field_180294_c, EventType.SHROOM, field_76798_D); f_i_o > 0; f_i_o--)
          {
-             if (p_150513_3_.nextInt(4) == 0)
-@@ -266,7 +278,9 @@
-                 this.field_76827_t.func_180709_b(p_150513_2_, p_150513_3_, this.field_180294_c.func_177982_a(j4, l15, l8));
+-            if (p_150513_3_.nextInt(4) == 0)
++            for (int f_i = TerrainGen.mushroom(p_150513_2_, p_150513_3_, field_180294_c, this.field_76828_s, Generator.Position.SURFACE, p_150513_3_.nextInt(4) == 0 ? 1 : 0); f_i > 0; f_i--)
+             {
+                 int i8 = p_150513_3_.nextInt(16) + 8;
+                 int l11 = p_150513_3_.nextInt(16) + 8;
+@@ -226,7 +235,7 @@
+                 this.field_76828_s.func_180709_b(p_150513_2_, p_150513_3_, blockpos2);
+             }
+ 
+-            if (p_150513_3_.nextInt(8) == 0)
++            for (int f_i = TerrainGen.mushroom(p_150513_2_, p_150513_3_, field_180294_c, this.field_76827_t, Generator.Position.SURFACE, p_150513_3_.nextInt(8) == 0 ? 1 : 0); f_i > 0; f_i--)
+             {
+                 int j8 = p_150513_3_.nextInt(16) + 8;
+                 int i12 = p_150513_3_.nextInt(16) + 8;
+@@ -241,7 +250,7 @@
              }
          }
--
-+        } // End of Mushroom generation
-+        if(net.minecraftforge.event.terraingen.TerrainGen.decorate(p_150513_2_, p_150513_3_, field_180294_c, net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.REED))
-+        {
-         for (int k4 = 0; k4 < this.field_76799_E; ++k4)
+ 
+-        if (p_150513_3_.nextInt(4) == 0)
++        for (int f_i = TerrainGen.mushroom(p_150513_2_, p_150513_3_, field_180294_c, this.field_76828_s, Generator.Position.ANYWHERE, p_150513_3_.nextInt(4) == 0 ? 1 : 0); f_i > 0; f_i--)
+         {
+             int i4 = p_150513_3_.nextInt(16) + 8;
+             int k8 = p_150513_3_.nextInt(16) + 8;
+@@ -254,7 +263,7 @@
+             }
+         }
+ 
+-        if (p_150513_3_.nextInt(8) == 0)
++        for (int f_i = TerrainGen.mushroom(p_150513_2_, p_150513_3_, field_180294_c, this.field_76827_t, Generator.Position.ANYWHERE, p_150513_3_.nextInt(8) == 0 ? 1 : 0); f_i > 0; f_i--)
+         {
+             int j4 = p_150513_3_.nextInt(16) + 8;
+             int l8 = p_150513_3_.nextInt(16) + 8;
+@@ -267,7 +276,7 @@
+             }
+         }
+ 
+-        for (int k4 = 0; k4 < this.field_76799_E; ++k4)
++        for (int f_i_o = TerrainGen.decorate(p_150513_2_, p_150513_3_, field_180294_c, EventType.REED, field_76799_E + 10, field_76825_v, Generator.Position.SURFACE); f_i_o > 0; f_i_o--)
          {
              int i9 = p_150513_3_.nextInt(16) + 8;
-@@ -292,7 +306,8 @@
-                 this.field_76825_v.func_180709_b(p_150513_2_, p_150513_3_, this.field_180294_c.func_177982_a(j9, i19, i13));
-             }
-         }
--
-+        } // End of Reed generation
-+        if(net.minecraftforge.event.terraingen.TerrainGen.decorate(p_150513_2_, p_150513_3_, field_180294_c, net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.PUMPKIN))
-         if (p_150513_3_.nextInt(32) == 0)
-         {
-             int i5 = p_150513_3_.nextInt(16) + 8;
-@@ -306,6 +321,7 @@
+             int l12 = p_150513_3_.nextInt(16) + 8;
+@@ -280,7 +289,7 @@
              }
          }
  
-+        if(net.minecraftforge.event.terraingen.TerrainGen.decorate(p_150513_2_, p_150513_3_, field_180294_c, net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.CACTUS))
-         for (int j5 = 0; j5 < this.field_76800_F; ++j5)
+-        for (int l4 = 0; l4 < 10; ++l4)
++        if (false) // The 10 iterations are accounted for in the previous block
+         {
+             int j9 = p_150513_3_.nextInt(16) + 8;
+             int i13 = p_150513_3_.nextInt(16) + 8;
+@@ -293,7 +302,7 @@
+             }
+         }
+ 
+-        if (p_150513_3_.nextInt(32) == 0)
++        for (int f_i_o = TerrainGen.decorate(p_150513_2_, p_150513_3_, field_180294_c, EventType.PUMPKIN, p_150513_3_.nextInt(32) == 0 ? 1 : 0); f_i_o > 0; f_i_o--)
+         {
+             int i5 = p_150513_3_.nextInt(16) + 8;
+             int k9 = p_150513_3_.nextInt(16) + 8;
+@@ -306,7 +315,7 @@
+             }
+         }
+ 
+-        for (int j5 = 0; j5 < this.field_76800_F; ++j5)
++        for (int f_i_o = TerrainGen.decorate(p_150513_2_, p_150513_3_, field_180294_c, EventType.CACTUS, field_76800_F, field_76824_w, Generator.Position.SURFACE); f_i_o > 0; f_i_o--)
          {
              int l9 = p_150513_3_.nextInt(16) + 8;
-@@ -321,6 +337,7 @@
+             int k13 = p_150513_3_.nextInt(16) + 8;
+@@ -321,7 +330,7 @@
  
          if (this.field_76808_K)
          {
-+            if(net.minecraftforge.event.terraingen.TerrainGen.decorate(p_150513_2_, p_150513_3_, field_180294_c, net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.LAKE_WATER))
-             for (int k5 = 0; k5 < 50; ++k5)
+-            for (int k5 = 0; k5 < 50; ++k5)
++            for (int f_i_o = TerrainGen.decorate(p_150513_2_, p_150513_3_, field_180294_c, EventType.LAKE_WATER, 50); f_i_o > 0; f_i_o--)
              {
                  int i10 = p_150513_3_.nextInt(16) + 8;
-@@ -335,6 +352,7 @@
+                 int l13 = p_150513_3_.nextInt(16) + 8;
+@@ -335,7 +344,7 @@
                  }
              }
  
-+            if(net.minecraftforge.event.terraingen.TerrainGen.decorate(p_150513_2_, p_150513_3_, field_180294_c, net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.LAKE_LAVA))
-             for (int l5 = 0; l5 < 20; ++l5)
+-            for (int l5 = 0; l5 < 20; ++l5)
++            for (int f_i_o = TerrainGen.decorate(p_150513_2_, p_150513_3_, field_180294_c, EventType.LAKE_LAVA, 20); f_i_o > 0; f_i_o--)
              {
                  int j10 = p_150513_3_.nextInt(16) + 8;
-@@ -344,21 +362,35 @@
+                 int i14 = p_150513_3_.nextInt(16) + 8;
+@@ -344,21 +353,35 @@
                  (new WorldGenLiquids(Blocks.field_150356_k)).func_180709_b(p_150513_2_, p_150513_3_, blockpos3);
              }
          }
-+        net.minecraftforge.common.MinecraftForge.EVENT_BUS.post(new net.minecraftforge.event.terraingen.DecorateBiomeEvent.Post(p_150513_2_, p_150513_3_, field_180294_c));
++        net.minecraftforge.common.MinecraftForge.EVENT_BUS.post(new DecorateBiomeEvent.Post(p_150513_2_, p_150513_3_, field_180294_c));
      }
  
      protected void func_76797_b(World p_76797_1_, Random p_76797_2_)

--- a/patches/minecraft/net/minecraft/world/biome/BiomeDesert.java.patch
+++ b/patches/minecraft/net/minecraft/world/biome/BiomeDesert.java.patch
@@ -1,18 +1,20 @@
 --- ../src-base/minecraft/net/minecraft/world/biome/BiomeDesert.java
 +++ ../src-work/minecraft/net/minecraft/world/biome/BiomeDesert.java
-@@ -47,6 +47,7 @@
+@@ -47,7 +47,7 @@
      {
          super.func_180624_a(p_180624_1_, p_180624_2_, p_180624_3_);
  
-+        if(net.minecraftforge.event.terraingen.TerrainGen.decorate(p_180624_1_, p_180624_2_, p_180624_3_, net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.DESERT_WELL))
-         if (p_180624_2_.nextInt(1000) == 0)
+-        if (p_180624_2_.nextInt(1000) == 0)
++        for (int f_i_o = net.minecraftforge.event.terraingen.TerrainGen.decorate(p_180624_1_, p_180624_2_, p_180624_3_, net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.DESERT_WELL, p_180624_2_.nextInt(1000) == 0 ? 1 : 0); f_i_o > 0; f_i_o--)
          {
              int i = p_180624_2_.nextInt(16) + 8;
-@@ -55,6 +56,7 @@
+             int j = p_180624_2_.nextInt(16) + 8;
+@@ -55,7 +55,7 @@
              (new WorldGenDesertWells()).func_180709_b(p_180624_1_, p_180624_2_, blockpos);
          }
  
-+        if(net.minecraftforge.event.terraingen.TerrainGen.decorate(p_180624_1_, p_180624_2_, p_180624_3_, net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.FOSSIL))
-         if (p_180624_2_.nextInt(64) == 0)
+-        if (p_180624_2_.nextInt(64) == 0)
++        for (int f_i_o = net.minecraftforge.event.terraingen.TerrainGen.decorate(p_180624_1_, p_180624_2_, p_180624_3_, net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.FOSSIL, p_180624_2_.nextInt(64) == 0 ? 1 : 0); f_i_o > 0; f_i_o--)
          {
              (new WorldGenFossils()).func_180709_b(p_180624_1_, p_180624_2_, p_180624_3_);
+         }

--- a/patches/minecraft/net/minecraft/world/biome/BiomeForest.java.patch
+++ b/patches/minecraft/net/minecraft/world/biome/BiomeForest.java.patch
@@ -18,20 +18,12 @@
      }
  
      public WorldGenAbstractTree func_150567_a(Random p_150567_1_)
-@@ -85,6 +96,8 @@
-             this.func_185379_b(p_180624_1_, p_180624_2_, p_180624_3_);
+@@ -92,12 +103,14 @@
+             i += 2;
          }
  
-+        if(net.minecraftforge.event.terraingen.TerrainGen.decorate(p_180624_1_, p_180624_2_, p_180624_3_, net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.FLOWERS))
-+        { // no tab for patch
-         int i = p_180624_2_.nextInt(5) - 3;
- 
-         if (this.field_150632_aF == BiomeForest.Type.FLOWER)
-@@ -93,11 +106,13 @@
-         }
- 
++        i = net.minecraftforge.event.terraingen.TerrainGen.decorate(p_180624_1_, p_180624_2_, p_180624_3_, net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.FLOWERS, i);
          this.func_185378_a(p_180624_1_, p_180624_2_, p_180624_3_, i);
-+        }
          super.func_180624_a(p_180624_1_, p_180624_2_, p_180624_3_);
      }
  
@@ -41,18 +33,17 @@
          for (int i = 0; i < 4; ++i)
          {
              for (int j = 0; j < 4; ++j)
-@@ -106,12 +121,12 @@
-                 int l = j * 4 + 1 + 8 + p_185379_2_.nextInt(3);
+@@ -107,11 +120,13 @@
                  BlockPos blockpos = p_185379_1_.func_175645_m(p_185379_3_.func_177982_a(k, 0, l));
  
--                if (p_185379_2_.nextInt(20) == 0)
-+                if (p_185379_2_.nextInt(20) == 0 && net.minecraftforge.event.terraingen.TerrainGen.decorate(p_185379_1_, p_185379_2_, blockpos, net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.BIG_SHROOM))
+                 if (p_185379_2_.nextInt(20) == 0)
++                for (int f_i_o = net.minecraftforge.event.terraingen.TerrainGen.decorate(p_185379_1_, p_185379_2_, p_185379_3_, net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.BIG_SHROOM, 1); f_i_o > 0; f_i_o--)
                  {
                      WorldGenBigMushroom worldgenbigmushroom = new WorldGenBigMushroom();
                      worldgenbigmushroom.func_180709_b(p_185379_1_, p_185379_2_, blockpos);
                  }
--                else
-+                else if (net.minecraftforge.event.terraingen.TerrainGen.decorate(p_185379_1_, p_185379_2_, blockpos, net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.TREE))
+                 else
++                for (int f_i_o = net.minecraftforge.event.terraingen.TerrainGen.decorate(p_185379_1_, p_185379_2_, p_185379_3_, net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.TREE, 1); f_i_o > 0; f_i_o--)
                  {
                      WorldGenAbstractTree worldgenabstracttree = this.func_150567_a(p_185379_2_);
                      worldgenabstracttree.func_175904_e();

--- a/patches/minecraft/net/minecraft/world/biome/BiomeJungle.java.patch
+++ b/patches/minecraft/net/minecraft/world/biome/BiomeJungle.java.patch
@@ -1,6 +1,6 @@
 --- ../src-base/minecraft/net/minecraft/world/biome/BiomeJungle.java
 +++ ../src-work/minecraft/net/minecraft/world/biome/BiomeJungle.java
-@@ -81,10 +81,14 @@
+@@ -81,11 +81,15 @@
          super.func_180624_a(p_180624_1_, p_180624_2_, p_180624_3_);
          int i = p_180624_2_.nextInt(16) + 8;
          int j = p_180624_2_.nextInt(16) + 8;
@@ -8,11 +8,13 @@
 +        int height = p_180624_1_.func_175645_m(p_180624_3_.func_177982_a(i, 0, j)).func_177956_o() * 2; // could == 0, which crashes nextInt
 +        if (height < 1) height = 1;
 +        int k = p_180624_2_.nextInt(height);
-+        if(net.minecraftforge.event.terraingen.TerrainGen.decorate(p_180624_1_, p_180624_2_, p_180624_3_, net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.PUMPKIN))
++
++        for (int f_i_o = net.minecraftforge.event.terraingen.TerrainGen.decorate(p_180624_1_, p_180624_2_, p_180624_3_, net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.PUMPKIN, 1); f_i_o > 0; f_i_o--)
          (new WorldGenMelon()).func_180709_b(p_180624_1_, p_180624_2_, p_180624_3_.func_177982_a(i, k, j));
          WorldGenVines worldgenvines = new WorldGenVines();
  
-+        if(net.minecraftforge.event.terraingen.TerrainGen.decorate(p_180624_1_, p_180624_2_, p_180624_3_, net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.GRASS))
-         for (int j1 = 0; j1 < 50; ++j1)
+-        for (int j1 = 0; j1 < 50; ++j1)
++        for (int f_i_o = net.minecraftforge.event.terraingen.TerrainGen.decorate(p_180624_1_, p_180624_2_, p_180624_3_, net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.GRASS, 50, worldgenvines, net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.Generator.Position.SURFACE); f_i_o > 0; f_i_o--)
          {
              k = p_180624_2_.nextInt(16) + 8;
+             int l = 128;

--- a/patches/minecraft/net/minecraft/world/biome/BiomePlains.java.patch
+++ b/patches/minecraft/net/minecraft/world/biome/BiomePlains.java.patch
@@ -1,23 +1,24 @@
 --- ../src-base/minecraft/net/minecraft/world/biome/BiomePlains.java
 +++ ../src-work/minecraft/net/minecraft/world/biome/BiomePlains.java
-@@ -80,6 +80,7 @@
+@@ -80,7 +80,7 @@
              this.field_76760_I.field_76803_B = 10;
              field_180280_ag.func_180710_a(BlockDoublePlant.EnumPlantType.GRASS);
  
-+            if(net.minecraftforge.event.terraingen.TerrainGen.decorate(p_180624_1_, p_180624_2_, p_180624_3_, net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.GRASS))
-             for (int i = 0; i < 7; ++i)
+-            for (int i = 0; i < 7; ++i)
++            for (int f_i_o = net.minecraftforge.event.terraingen.TerrainGen.decorate(p_180624_1_, p_180624_2_, p_180624_3_, net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.GRASS, 7, field_180280_ag, net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.Generator.Position.SURFACE); f_i_o > 0; f_i_o--)
              {
                  int j = p_180624_2_.nextInt(16) + 8;
-@@ -89,7 +90,7 @@
-             }
-         }
- 
--        if (this.field_150628_aC)
-+        if (this.field_150628_aC && net.minecraftforge.event.terraingen.TerrainGen.decorate(p_180624_1_, p_180624_2_, p_180624_3_, net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.FLOWERS))
+                 int k = p_180624_2_.nextInt(16) + 8;
+@@ -93,7 +93,7 @@
          {
              field_180280_ag.func_180710_a(BlockDoublePlant.EnumPlantType.SUNFLOWER);
  
-@@ -105,6 +106,21 @@
+-            for (int i1 = 0; i1 < 10; ++i1)
++            for (int f_i_o = net.minecraftforge.event.terraingen.TerrainGen.decorate(p_180624_1_, p_180624_2_, p_180624_3_, net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.FLOWERS, 10, field_180280_ag, net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.Generator.Position.SURFACE); f_i_o > 0; f_i_o--)
+             {
+                 int j1 = p_180624_2_.nextInt(16) + 8;
+                 int k1 = p_180624_2_.nextInt(16) + 8;
+@@ -105,6 +105,21 @@
          super.func_180624_a(p_180624_1_, p_180624_2_, p_180624_3_);
      }
  

--- a/patches/minecraft/net/minecraft/world/biome/BiomeSavanna.java.patch
+++ b/patches/minecraft/net/minecraft/world/biome/BiomeSavanna.java.patch
@@ -1,10 +1,11 @@
 --- ../src-base/minecraft/net/minecraft/world/biome/BiomeSavanna.java
 +++ ../src-work/minecraft/net/minecraft/world/biome/BiomeSavanna.java
-@@ -39,6 +39,7 @@
+@@ -39,7 +39,7 @@
      {
          field_180280_ag.func_180710_a(BlockDoublePlant.EnumPlantType.GRASS);
  
-+        if(net.minecraftforge.event.terraingen.TerrainGen.decorate(p_180624_1_, p_180624_2_, p_180624_3_, net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.GRASS))
-         for (int i = 0; i < 7; ++i)
+-        for (int i = 0; i < 7; ++i)
++        for (int f_i_o = net.minecraftforge.event.terraingen.TerrainGen.decorate(p_180624_1_, p_180624_2_, p_180624_3_, net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.GRASS, 7, field_180280_ag, net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.Generator.Position.SURFACE); f_i_o > 0; f_i_o--)
          {
              int j = p_180624_2_.nextInt(16) + 8;
+             int k = p_180624_2_.nextInt(16) + 8;

--- a/patches/minecraft/net/minecraft/world/biome/BiomeSnow.java.patch
+++ b/patches/minecraft/net/minecraft/world/biome/BiomeSnow.java.patch
@@ -1,11 +1,19 @@
 --- ../src-base/minecraft/net/minecraft/world/biome/BiomeSnow.java
 +++ ../src-work/minecraft/net/minecraft/world/biome/BiomeSnow.java
-@@ -56,7 +56,7 @@
- 
-     public void func_180624_a(World p_180624_1_, Random p_180624_2_, BlockPos p_180624_3_)
+@@ -58,14 +58,14 @@
      {
--        if (this.field_150615_aC)
-+        if (this.field_150615_aC && net.minecraftforge.event.terraingen.TerrainGen.decorate(p_180624_1_, p_180624_2_, p_180624_3_, net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.ICE))
+         if (this.field_150615_aC)
          {
-             for (int i = 0; i < 3; ++i)
+-            for (int i = 0; i < 3; ++i)
++            for (int f_i_o = net.minecraftforge.event.terraingen.TerrainGen.decorate(p_180624_1_, p_180624_2_, p_180624_3_, net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.ICE, 3, field_150616_aD, net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.Generator.Position.SURFACE); f_i_o > 0; f_i_o--)
              {
+                 int j = p_180624_2_.nextInt(16) + 8;
+                 int k = p_180624_2_.nextInt(16) + 8;
+                 this.field_150616_aD.func_180709_b(p_180624_1_, p_180624_2_, p_180624_1_.func_175645_m(p_180624_3_.func_177982_a(j, 0, k)));
+             }
+ 
+-            for (int l = 0; l < 2; ++l)
++            for (int f_i_o = net.minecraftforge.event.terraingen.TerrainGen.decorate(p_180624_1_, p_180624_2_, p_180624_3_, net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.ICE, 2, field_150617_aE, net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.Generator.Position.SURFACE); f_i_o > 0; f_i_o--)
+             {
+                 int i1 = p_180624_2_.nextInt(16) + 8;
+                 int j1 = p_180624_2_.nextInt(16) + 8;

--- a/patches/minecraft/net/minecraft/world/biome/BiomeSwamp.java.patch
+++ b/patches/minecraft/net/minecraft/world/biome/BiomeSwamp.java.patch
@@ -1,14 +1,15 @@
 --- ../src-base/minecraft/net/minecraft/world/biome/BiomeSwamp.java
 +++ ../src-work/minecraft/net/minecraft/world/biome/BiomeSwamp.java
-@@ -79,6 +79,7 @@
+@@ -79,7 +79,7 @@
      {
          super.func_180624_a(p_180624_1_, p_180624_2_, p_180624_3_);
  
-+        if(net.minecraftforge.event.terraingen.TerrainGen.decorate(p_180624_1_, p_180624_2_, p_180624_3_, net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.FOSSIL))
-         if (p_180624_2_.nextInt(64) == 0)
+-        if (p_180624_2_.nextInt(64) == 0)
++        for (int f_i_o = net.minecraftforge.event.terraingen.TerrainGen.decorate(p_180624_1_, p_180624_2_, p_180624_3_, net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.FOSSIL, p_180624_2_.nextInt(64) == 0 ? 1 : 0); f_i_o > 0; f_i_o--)
          {
              (new WorldGenFossils()).func_180709_b(p_180624_1_, p_180624_2_, p_180624_3_);
-@@ -97,4 +98,10 @@
+         }
+@@ -97,4 +97,10 @@
      {
          return 6975545;
      }

--- a/patches/minecraft/net/minecraft/world/biome/BiomeTaiga.java.patch
+++ b/patches/minecraft/net/minecraft/world/biome/BiomeTaiga.java.patch
@@ -1,19 +1,19 @@
 --- ../src-base/minecraft/net/minecraft/world/biome/BiomeTaiga.java
 +++ ../src-work/minecraft/net/minecraft/world/biome/BiomeTaiga.java
-@@ -67,7 +67,7 @@
- 
-     public void func_180624_a(World p_180624_1_, Random p_180624_2_, BlockPos p_180624_3_)
-     {
--        if (this.field_150644_aH == BiomeTaiga.Type.MEGA || this.field_150644_aH == BiomeTaiga.Type.MEGA_SPRUCE)
-+        if ((this.field_150644_aH == BiomeTaiga.Type.MEGA || this.field_150644_aH == BiomeTaiga.Type.MEGA_SPRUCE) && net.minecraftforge.event.terraingen.TerrainGen.decorate(p_180624_1_, p_180624_2_, p_180624_3_, net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.ROCK))
+@@ -71,6 +71,7 @@
          {
              int i = p_180624_2_.nextInt(3);
  
-@@ -82,6 +82,7 @@
++            i = net.minecraftforge.event.terraingen.TerrainGen.decorate(p_180624_1_, p_180624_2_, p_180624_3_, net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.ROCK, i, field_150643_aG, net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.Generator.Position.SURFACE);
+             for (int j = 0; j < i; ++j)
+             {
+                 int k = p_180624_2_.nextInt(16) + 8;
+@@ -82,7 +83,7 @@
  
          field_180280_ag.func_180710_a(BlockDoublePlant.EnumPlantType.FERN);
  
-+        if(net.minecraftforge.event.terraingen.TerrainGen.decorate(p_180624_1_, p_180624_2_, p_180624_3_, net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.FLOWERS))
-         for (int i1 = 0; i1 < 7; ++i1)
+-        for (int i1 = 0; i1 < 7; ++i1)
++        for (int f_i_o = net.minecraftforge.event.terraingen.TerrainGen.decorate(p_180624_1_, p_180624_2_, p_180624_3_, net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.FLOWERS, 7, field_180280_ag, net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.Generator.Position.SURFACE); f_i_o > 0; f_i_o--)
          {
              int j1 = p_180624_2_.nextInt(16) + 8;
+             int k1 = p_180624_2_.nextInt(16) + 8;

--- a/patches/minecraft/net/minecraft/world/gen/ChunkGeneratorHell.java.patch
+++ b/patches/minecraft/net/minecraft/world/gen/ChunkGeneratorHell.java.patch
@@ -68,25 +68,26 @@
          for (int j1 = 0; j1 < this.field_185954_p.nextInt(this.field_185954_p.nextInt(10) + 1); ++j1)
          {
              this.field_177469_u.func_180709_b(this.field_185952_n, this.field_185954_p, blockpos.func_177982_a(this.field_185954_p.nextInt(16) + 8, this.field_185954_p.nextInt(120) + 4, this.field_185954_p.nextInt(16) + 8));
-@@ -384,7 +407,13 @@
+@@ -384,17 +407,23 @@
          {
              this.field_177468_v.func_180709_b(this.field_185952_n, this.field_185954_p, blockpos.func_177982_a(this.field_185954_p.nextInt(16) + 8, this.field_185954_p.nextInt(128), this.field_185954_p.nextInt(16) + 8));
          }
 +        }//Forge: End doGLowstone
  
+-        if (this.field_185954_p.nextBoolean())
 +        net.minecraftforge.event.ForgeEventFactory.onChunkPopulate(false, this, this.field_185952_n, this.field_185954_p, p_185931_1_, p_185931_2_, false);
 +        net.minecraftforge.common.MinecraftForge.EVENT_BUS.post(new net.minecraftforge.event.terraingen.DecorateBiomeEvent.Pre(this.field_185952_n, this.field_185954_p, blockpos));
 +
-+        if (net.minecraftforge.event.terraingen.TerrainGen.decorate(this.field_185952_n, this.field_185954_p, blockpos, net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.SHROOM))
-+        {
-         if (this.field_185954_p.nextBoolean())
++        for (int f_i_o = net.minecraftforge.event.terraingen.TerrainGen.mushroom(field_185952_n, field_185954_p, blockpos, field_177471_z, net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.Generator.Position.UNDERGROUND, field_185954_p.nextBoolean() ? 1 : 0); f_i_o > 0; f_i_o--)
          {
              this.field_177471_z.func_180709_b(this.field_185952_n, this.field_185954_p, blockpos.func_177982_a(this.field_185954_p.nextInt(16) + 8, this.field_185954_p.nextInt(128), this.field_185954_p.nextInt(16) + 8));
-@@ -394,7 +423,10 @@
+         }
+ 
+-        if (this.field_185954_p.nextBoolean())
++        for (int f_i_o = net.minecraftforge.event.terraingen.TerrainGen.mushroom(field_185952_n, field_185954_p, blockpos, field_177465_A, net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.Generator.Position.UNDERGROUND, field_185954_p.nextBoolean() ? 1 : 0); f_i_o > 0; f_i_o--)
          {
              this.field_177465_A.func_180709_b(this.field_185952_n, this.field_185954_p, blockpos.func_177982_a(this.field_185954_p.nextInt(16) + 8, this.field_185954_p.nextInt(128), this.field_185954_p.nextInt(16) + 8));
          }
-+        }
  
 +
 +        if (net.minecraftforge.event.terraingen.TerrainGen.generateOre(this.field_185952_n, this.field_185954_p, field_177467_w, blockpos, net.minecraftforge.event.terraingen.OreGenEvent.GenerateMinable.EventType.QUARTZ))
@@ -94,7 +95,7 @@
          {
              this.field_177467_w.func_180709_b(this.field_185952_n, this.field_185954_p, blockpos.func_177982_a(this.field_185954_p.nextInt(16), this.field_185954_p.nextInt(108) + 10, this.field_185954_p.nextInt(16)));
 @@ -402,17 +434,23 @@
- 
+
          int i2 = this.field_185952_n.func_181545_F() / 2 + 1;
  
 +        if (net.minecraftforge.event.terraingen.TerrainGen.populate(this, this.field_185952_n, this.field_185954_p, p_185931_1_, p_185931_2_, false, net.minecraftforge.event.terraingen.PopulateChunkEvent.Populate.EventType.NETHER_MAGMA))

--- a/src/main/java/net/minecraftforge/event/terraingen/DecorateBiomeEvent.java
+++ b/src/main/java/net/minecraftforge/event/terraingen/DecorateBiomeEvent.java
@@ -22,12 +22,15 @@ package net.minecraftforge.event.terraingen;
 import java.util.Random;
 
 import net.minecraft.world.biome.Biome;
+import net.minecraft.world.gen.feature.WorldGenerator;
 import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.fml.common.eventhandler.Cancelable;
 import net.minecraftforge.fml.common.eventhandler.Event;
 import net.minecraftforge.fml.common.eventhandler.Event.HasResult;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.World;
+
+import javax.annotation.Nullable;
 
 /**DecorateBiomeEvent is fired when a BiomeDecorator is created.
  * <br>
@@ -107,16 +110,79 @@ public class DecorateBiomeEvent extends Event
             return type;
         }
 
+        public boolean hasAmountData()
+        {
+            return totalAmount != null && modifiedAmount != null;
+        }
+
+        public int getTotalAmount()
+        {
+            if (totalAmount == null)
+                throw new IllegalStateException();
+
+            return totalAmount;
+        }
+
+        public int getModifiedAmount()
+        {
+            if (modifiedAmount == null)
+                throw new IllegalStateException();
+
+            return modifiedAmount;
+        }
+
+        public void setModifiedAmount(int modifiedAmount)
+        {
+            this.modifiedAmount = modifiedAmount;
+        }
+
         /** Use CUSTOM to filter custom event types
          */
         public static enum EventType { BIG_SHROOM, CACTUS, CLAY, DEAD_BUSH, DESERT_WELL, LILYPAD, FLOWERS, FOSSIL, GRASS, ICE, LAKE_WATER, LAKE_LAVA, PUMPKIN, REED, ROCK, SAND, SAND_PASS2, SHROOM, TREE, CUSTOM }
 
         private final EventType type;
 
+        @Nullable
+        private final Integer totalAmount;
+        @Nullable
+        private Integer modifiedAmount;
+
         public Decorate(World world, Random rand, BlockPos pos, EventType type)
         {
             super(world, rand, pos);
             this.type = type;
+            this.totalAmount = null;
+            this.modifiedAmount = null;
+        }
+
+        public Decorate(World world, Random rand, BlockPos pos, EventType type, int amount)
+        {
+            super(world, rand, pos);
+            this.type = type;
+            this.totalAmount = amount;
+            this.modifiedAmount = amount;
+        }
+
+        public static class Generator extends Decorate
+        {
+            public final WorldGenerator generator;
+            public final Position position;
+
+            public enum Position
+            {
+                SURFACE,
+                UNDERGROUND,
+                AIR,
+                ANYWHERE,
+                OTHER
+            }
+
+            public Generator(World world, Random rand, BlockPos pos, EventType type, int amount, WorldGenerator generator, Position position)
+            {
+                super(world, rand, pos, type, amount);
+                this.generator = generator;
+                this.position = position;
+            }
         }
     }
 }

--- a/src/main/java/net/minecraftforge/event/terraingen/TerrainGen.java
+++ b/src/main/java/net/minecraftforge/event/terraingen/TerrainGen.java
@@ -55,11 +55,37 @@ public abstract class TerrainGen
         return event.getResult() != Result.DENY;
     }
 
+    /**
+     * This call lacks amount data and should not be used any longer.
+     * It's kept for legacy purposes.
+     */
+    @Deprecated
     public static boolean decorate(World world, Random rand, BlockPos pos, Decorate.EventType type)
     {
         Decorate event = new Decorate(world, rand, pos, type);
         MinecraftForge.TERRAIN_GEN_BUS.post(event);
         return event.getResult() != Result.DENY;
+    }
+
+    public static int decorate(Decorate event)
+    {
+        MinecraftForge.TERRAIN_GEN_BUS.post(event);
+        return event.getResult() != Result.DENY ? event.getModifiedAmount() : -1;
+    }
+
+    public static int mushroom(World world, Random rand, BlockPos pos, WorldGenerator generator, Decorate.Generator.Position position, int amount)
+    {
+        return decorate(new Decorate.Generator(world, rand, pos, Decorate.EventType.SHROOM, amount, generator, position));
+    }
+
+    public static int decorate(World world, Random rand, BlockPos pos, Decorate.EventType type, int amount, WorldGenerator generator, Decorate.Generator.Position position)
+    {
+        return decorate(new Decorate.Generator(world, rand, pos, type, amount, generator, position));
+    }
+
+    public static int decorate(World world, Random rand, BlockPos pos, Decorate.EventType type, int amount)
+    {
+        return decorate(new Decorate(world, rand, pos, type, amount));
     }
 
     public static boolean generateOre(World world, Random rand, WorldGenerator generator, BlockPos pos, GenerateMinable.EventType type)


### PR DESCRIPTION
Originally from https://github.com/MinecraftForge/MinecraftForge/pull/3318 - the PR didn't want to update anymore.

This PR adds amount and contextual data to the decoration events.

Examples:

With this PR, a decoration / world generation mod can now 
- Cancel only parts of a decoration aspect (e.g. replace only 5 out of 10 trees, effectively providing an opportunity to inject weighted decorations (e.g. different tree types while honouring default ones)) 
- Distinguish between more different decoration types using contextual information (e.g. cancel only red mushrooms, but not brown ones)
- Modify the amount of a decoration aspect (e.g. change plains to generate 10 instead of 4 trees per biome). This is different from overriding the decorator's amount field directly since some amounts are dynamically calculated, especially by world generation mods.

With the current event implementation, you can only cancel any whole decoration aspect of the biome. Since in various places (e.g. roofed forests) it is not guaranteed for an event to be fired just once per biome, you cannot act on these events and use them to decorate the biome yourself. 

This also greatly helps decoration mods and biome mods to interact, as many biome mods do not use the default decorator, and can now pass the actual calculated amount and context through the event.

Note that it keeps backwards compatibility by continuing to provide the old event constructor, fire method, and cancellation capability. 
