### PR TITLE
Make Optional.Interface repeatable

### DIFF
--- a/src/main/java/net/minecraftforge/fml/common/Optional.java
+++ b/src/main/java/net/minecraftforge/fml/common/Optional.java
@@ -40,13 +40,11 @@ public final class Optional {
 
     /**
      * Mark a list of interfaces as removable
-     * @deprecated Internal use only; use {@link Interface} multiple times for each interface instead.
      * @author cpw
      *
      */
     @Retention(RetentionPolicy.RUNTIME)
     @Target(ElementType.TYPE)
-    @Deprecated
     public @interface InterfaceList {
         /**
          * Mark a list of interfaces for optional removal.

--- a/src/main/java/net/minecraftforge/fml/common/Optional.java
+++ b/src/main/java/net/minecraftforge/fml/common/Optional.java
@@ -56,6 +56,7 @@ public final class Optional {
      * @author cpw
      *
      */
+    @Repeatable(InterfaceList.class)
     @Retention(RetentionPolicy.RUNTIME)
     @Target(ElementType.TYPE)
     public @interface Interface {

--- a/src/main/java/net/minecraftforge/fml/common/Optional.java
+++ b/src/main/java/net/minecraftforge/fml/common/Optional.java
@@ -20,6 +20,7 @@
 package net.minecraftforge.fml.common;
 
 import java.lang.annotation.ElementType;
+import java.lang.annotation.Repeatable;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;

--- a/src/main/java/net/minecraftforge/fml/common/Optional.java
+++ b/src/main/java/net/minecraftforge/fml/common/Optional.java
@@ -40,11 +40,13 @@ public final class Optional {
 
     /**
      * Mark a list of interfaces as removable
+     * @deprecated Internal use only; use {@link Interface} multiple times for each interface instead.
      * @author cpw
      *
      */
     @Retention(RetentionPolicy.RUNTIME)
     @Target(ElementType.TYPE)
+    @Deprecated
     public @interface InterfaceList {
         /**
          * Mark a list of interfaces for optional removal.


### PR DESCRIPTION
…now that Minecraft 1.12 is in Java 8. With this pull request, `Optional.InterfaceList` no longer needs to explicitly be used, as repeating `Optional.Interface` will internally use `Optional.InterfaceList`.