### PR TITLE
Throw packet encoding exceptions instead of suppressing them, to prevent corrupt packets

### DIFF
--- a/patches/minecraft/net/minecraft/network/NettyPacketEncoder.java.patch
+++ b/patches/minecraft/net/minecraft/network/NettyPacketEncoder.java.patch
@@ -1,0 +1,11 @@
+--- ../src-base/minecraft/net/minecraft/network/NettyPacketEncoder.java
++++ ../src-work/minecraft/net/minecraft/network/NettyPacketEncoder.java
+@@ -52,7 +52,7 @@
+                 }
+                 catch (Throwable throwable)
+                 {
+-                    field_150798_a.error(throwable);
++                    throw throwable; // Forge: throw this instead of logging it, to prevent corrupt packets from being sent to the client where they are much harder to debug.
+                 }
+             }
+         }


### PR DESCRIPTION
I spent a few hours debugging this issue: https://github.com/MinecraftForge/MinecraftForge/issues/4141 aka https://github.com/raoulvdberge/refinedstorage/issues/1345
And then @pau101 spent even more time working from where I left off.

He eventually found that the packet encoder was crashing on the server, but only logging a single line:
```
[21:16:09] [Netty Server IO #2/ERROR] [net.minecraft.network.NettyPacketEncoder]: java.lang.NullPointerException
```

This quiet log, combined with the server continuing and sending a corrupted packet, created an extremely difficult issue to debug.

This PR will propagate the exception instead of logging, so you get a full stack trace logged on the server.
This will kill the connection and cause the client to disconnect, instead of sending it a corrupted packet.