### PR TITLE
Extend Forge Blockstate Permutation Feature

### DIFF
--- a/src/main/java/net/minecraftforge/client/model/ForgeBlockStateV1.java
+++ b/src/main/java/net/minecraftforge/client/model/ForgeBlockStateV1.java
@@ -25,10 +25,13 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.EnumMap;
 import java.util.HashMap;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import javax.annotation.Nullable;
 import javax.vecmath.AxisAngle4d;
@@ -46,19 +49,19 @@ import net.minecraftforge.common.model.IModelState;
 import net.minecraftforge.common.model.TRSRTransformation;
 import net.minecraftforge.fml.common.FMLLog;
 
-import java.util.Objects;
-import java.util.Optional;
 import com.google.common.collect.HashMultimap;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Multimap;
+import com.google.common.collect.Multimaps;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonDeserializationContext;
 import com.google.gson.JsonDeserializer;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParseException;
+import org.apache.commons.lang3.tuple.Pair;
 
 public class ForgeBlockStateV1 extends Marker
 {
@@ -83,8 +86,8 @@ public class ForgeBlockStateV1 extends Marker
                     throw new RuntimeException("\"defaults\" variant cannot contain a simple \"submodel\" definition.");
             }
 
-            Map<String, Map<String, ForgeBlockStateV1.Variant>> condensed = Maps.newHashMap();    // map(property name -> map(property value -> variant))
-            Multimap<String, ForgeBlockStateV1.Variant> specified = HashMultimap.create();    // Multimap containing all the states specified with "property=value".
+            Map<String, Multimap<String, ForgeBlockStateV1.Variant>> condensed = Maps.newHashMap(); // map(property name -> map(property value -> variant fragment))
+            Multimap<String, ForgeBlockStateV1.Variant> specified = HashMultimap.create(); // Multimap containing all the states specified with "property=value".
 
             for (Entry<String, JsonElement> e : JsonUtils.getJsonObject(json, "variants").entrySet())
             {
@@ -99,23 +102,23 @@ public class ForgeBlockStateV1 extends Marker
                 }
                 else
                 {
-                    JsonObject obj = e.getValue().getAsJsonObject();
-                    if(obj.entrySet().iterator().next().getValue().isJsonObject())
+                    Multimap<String, ForgeBlockStateV1.Variant> subs = HashMultimap.create();
+                    condensed.put(e.getKey(), subs);
+                    for (Entry<String, JsonElement> se : e.getValue().getAsJsonObject().entrySet())
                     {
-                        // first value is a json object, so we know it's not a fully-defined variant
-                        Map<String, ForgeBlockStateV1.Variant> subs = Maps.newHashMap();
-                        condensed.put(e.getKey(), subs);
-                        for (Entry<String, JsonElement> se : e.getValue().getAsJsonObject().entrySet())
+                        if (se.getValue().isJsonArray())
+                        {
+                            for (JsonElement var : se.getValue().getAsJsonArray())
+                            {
+                                Variant.Deserializer.INSTANCE.simpleSubmodelKey = e.getKey() + "=" + se.getKey();
+                                subs.put(se.getKey(), context.deserialize(var, Variant.class));
+                            }
+                        }
+                        else
                         {
                             Variant.Deserializer.INSTANCE.simpleSubmodelKey = e.getKey() + "=" + se.getKey();
                             subs.put(se.getKey(), context.deserialize(se.getValue(), Variant.class));
                         }
-                    }
-                    else
-                    {
-                        // fully-defined variant
-                        Variant.Deserializer.INSTANCE.simpleSubmodelKey = e.getKey();
-                        specified.put(e.getKey(), context.deserialize(e.getValue(), Variant.class));
                     }
                 }
             }
@@ -212,31 +215,35 @@ public class ForgeBlockStateV1 extends Marker
             return ret;
         }
 
-        private Multimap<String, ForgeBlockStateV1.Variant> getPermutations(List<String> sorted, Map<String, Map<String, ForgeBlockStateV1.Variant>> base, int depth, String prefix, Multimap<String, ForgeBlockStateV1.Variant> ret, @Nullable ForgeBlockStateV1.Variant parent)
+        private Multimap<String, ForgeBlockStateV1.Variant> getPermutations(Map<String, Multimap<String, ForgeBlockStateV1.Variant>> base)
         {
-            if (depth == sorted.size())
-            {
-                if(parent != null)
-                    ret.put(prefix, parent);
-                return ret;
-            }
+            // Turn a map(prop -> map(val -> variantfrags)) into a list(list((prop,val1), (prop,val2), ...)) where the pairs are grouped by prop
+            List<List<Pair<String, String>>> variantIDs = base.entrySet().stream()
+                    .map(e -> e.getValue().keySet().stream()
+                            .map(value -> Pair.of(e.getKey(), value))
+                            .collect(Collectors.toList())
+                    )
+                    .collect(Collectors.toList());
+            return Lists.cartesianProduct(variantIDs).stream() // Product is a list(list((prop,val), (prop2, val), ...)) where each inner list IDs a unique variant
+                    .map(variantID ->
+                            {
+                                List<List<Variant>> variantFragsGroupedByStateFrag = variantID.stream()
+                                        .map(stateFrag -> Lists.newArrayList(base.get(stateFrag.getKey()).get(stateFrag.getValue()))) // Take each state fragment into all the variant frags it is linked to
+                                        .collect(Collectors.toList());
+                                Stream<Variant> variants = Lists.cartesianProduct(variantFragsGroupedByStateFrag).stream() // Each inner list of the product is a bunch of frags that define a real variant
+                                        .map(variantFrags -> variantFrags.stream()
+                                                .reduce(new Variant(), (l, r) -> new Variant(l).syncCombiningWeight(r)) // Fold the frags together, and we're almost done!
+                                        );
+                                List<Pair<String, String>> variantIDMut = Lists.newArrayList(variantID);
+                                Collections.sort(variantIDMut);
+                                String variantName = variantIDMut.stream()
+                                        .map(pair -> pair.getKey() + "=" + pair.getValue())
+                                        .collect(Collectors.joining(",")); // Turn the variant ID into a String
+                                return Pair.of(variantName, variants);
+                            }
+                    )
+                    .collect(Multimaps.flatteningToMultimap(Pair::getKey, Pair::getValue, HashMultimap::create));
 
-            String name = sorted.get(depth);
-            for (Entry<String, ForgeBlockStateV1.Variant> e : base.get(name).entrySet())
-            {
-                ForgeBlockStateV1.Variant newHead = parent == null ? new Variant(e.getValue()) : new Variant(parent).sync(e.getValue());
-
-                getPermutations(sorted, base, depth + 1, prefix + (depth == 0 ? "" : ",") + name + "=" + e.getKey(), ret, newHead);
-            }
-
-            return ret;
-        }
-
-        private Multimap<String, ForgeBlockStateV1.Variant> getPermutations(Map<String, Map<String, ForgeBlockStateV1.Variant>> base)
-        {
-            List<String> sorted = Lists.newArrayList(base.keySet());
-            Collections.sort(sorted);   // Sort to get consistent results.
-            return getPermutations(sorted, base, 0, "", HashMultimap.create(), null);
         }
 
         private List<ForgeBlockStateV1.Variant> getSubmodelPermutations(ForgeBlockStateV1.Variant baseVar, List<String> sorted, Map<String, List<ForgeBlockStateV1.Variant>> map, int depth, Map<String, ForgeBlockStateV1.Variant> parts, List<ForgeBlockStateV1.Variant> ret)
@@ -355,6 +362,12 @@ public class ForgeBlockStateV1 extends Marker
             }
 
             return this;
+        }
+
+        ForgeBlockStateV1.Variant syncCombiningWeight(ForgeBlockStateV1.Variant parent)
+        {
+            weight = Optional.of(weight.orElse(1) * parent.weight.orElse(1));
+            return sync(parent);
         }
 
         /**

--- a/src/main/java/net/minecraftforge/client/model/ForgeBlockStateV1.java
+++ b/src/main/java/net/minecraftforge/client/model/ForgeBlockStateV1.java
@@ -213,6 +213,9 @@ public class ForgeBlockStateV1 extends Marker
             return ret;
         }
 
+        /**
+         * Flatten all the possible combinations of variant choices into a map(full state -> list(possible variants)).
+         */
         private Multimap<String, ForgeBlockStateV1.Variant> getPermutations(Map<String, Multimap<String, ForgeBlockStateV1.Variant>> base)
         {
             // Turn a map(prop -> map(val -> variantfrags)) into a list(list((prop,val1), (prop,val2), ...)) where the state fragments are grouped by prop
@@ -244,6 +247,9 @@ public class ForgeBlockStateV1 extends Marker
 
         }
 
+        /**
+         * Flatten all possible combinations of submodel choices into a sequence, and then take each combination to the base variant plus those submodels.
+         */
         private List<ForgeBlockStateV1.Variant> getSubmodelPermutations(ForgeBlockStateV1.Variant base, Map<String, List<ForgeBlockStateV1.Variant>> variants)
         {
             // Turn a map(subname -> list(submodel)) list(list(subname, submodel)) where the pairs are grouped by the subname

--- a/src/main/java/net/minecraftforge/client/model/ForgeBlockStateV1.java
+++ b/src/main/java/net/minecraftforge/client/model/ForgeBlockStateV1.java
@@ -133,7 +133,7 @@ public class ForgeBlockStateV1 extends Marker
                     if (!baseVars.isEmpty())
                     {
                         for (ForgeBlockStateV1.Variant baseVar : baseVars)
-                            addVars.add(new Variant(specVar).sync(baseVar));
+                            addVars.add(new Variant(specVar).syncCombiningWeight(baseVar));
                     }
                     else
                         addVars.add(specVar);
@@ -266,6 +266,9 @@ public class ForgeBlockStateV1 extends Marker
                         Variant ret = new Variant(base);
                         Map<String, List<Variant>> subMap = subs.stream()
                                 .collect(Collectors.toMap(Pair::getKey, kv -> Collections.singletonList(kv.getValue())));
+                        ret.weight = Optional.of(subs.stream()
+                                .mapToInt(kv -> kv.getValue().getWeight().orElse(1))
+                                .reduce(1, (l, r) -> l * r));
                         ret.submodels.putAll(subMap);
                         return ret;
                     })

--- a/src/main/java/net/minecraftforge/client/model/ForgeBlockStateV1.java
+++ b/src/main/java/net/minecraftforge/client/model/ForgeBlockStateV1.java
@@ -217,14 +217,14 @@ public class ForgeBlockStateV1 extends Marker
 
         private Multimap<String, ForgeBlockStateV1.Variant> getPermutations(Map<String, Multimap<String, ForgeBlockStateV1.Variant>> base)
         {
-            // Turn a map(prop -> map(val -> variantfrags)) into a list(list((prop,val1), (prop,val2), ...)) where the pairs are grouped by prop
+            // Turn a map(prop -> map(val -> variantfrags)) into a list(list((prop,val1), (prop,val2), ...)) where the state fragments are grouped by prop
             List<List<Pair<String, String>>> variantIDs = base.entrySet().stream()
                     .map(e -> e.getValue().keySet().stream()
                             .map(value -> Pair.of(e.getKey(), value))
                             .collect(Collectors.toList())
                     )
                     .collect(Collectors.toList());
-            return Lists.cartesianProduct(variantIDs).stream() // Product is a list(list((prop,val), (prop2, val), ...)) where each inner list IDs a unique variant
+            return Lists.cartesianProduct(variantIDs).stream() // Product is a list(list((prop,val), (prop2, val), ...)) where each inner list of frags IDs a unique full state
                     .map(variantID ->
                             {
                                 List<List<Variant>> variantFragsGroupedByStateFrag = variantID.stream()

--- a/src/test/java/net/minecraftforge/debug/RandomVariantFragmentTest.java
+++ b/src/test/java/net/minecraftforge/debug/RandomVariantFragmentTest.java
@@ -66,6 +66,18 @@ public class RandomVariantFragmentTest
         {
             return BlockRenderLayer.TRANSLUCENT;
         }
+
+        @Override
+        public boolean isOpaqueCube(IBlockState state)
+        {
+            return false;
+        }
+
+        @Override
+        public boolean isFullCube(IBlockState state)
+        {
+            return false;
+        }
     };
 
     @SubscribeEvent

--- a/src/test/java/net/minecraftforge/debug/RandomVariantFragmentTest.java
+++ b/src/test/java/net/minecraftforge/debug/RandomVariantFragmentTest.java
@@ -1,0 +1,87 @@
+package net.minecraftforge.debug;
+
+import net.minecraft.block.Block;
+import net.minecraft.block.material.Material;
+import net.minecraft.block.properties.PropertyBool;
+import net.minecraft.block.state.BlockStateContainer;
+import net.minecraft.block.state.IBlockState;
+import net.minecraft.client.renderer.block.model.ModelResourceLocation;
+import net.minecraft.entity.EntityLivingBase;
+import net.minecraft.item.Item;
+import net.minecraft.item.ItemBlock;
+import net.minecraft.util.BlockRenderLayer;
+import net.minecraft.util.EnumBlockRenderType;
+import net.minecraft.util.EnumFacing;
+import net.minecraft.util.EnumHand;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.World;
+import net.minecraftforge.client.event.ModelRegistryEvent;
+import net.minecraftforge.client.model.ModelLoader;
+import net.minecraftforge.event.RegistryEvent;
+import net.minecraftforge.fml.common.Mod;
+import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
+
+import static net.minecraftforge.fml.common.Mod.EventBusSubscriber;
+
+@Mod(modid = "random_variant_fragment_test", name = "Random Variant Fragment Test", version = "0.0.0.0")
+@EventBusSubscriber
+public class RandomVariantFragmentTest
+{
+    public static final PropertyBool PROP_A = PropertyBool.create("a");
+    public static final PropertyBool PROP_B = PropertyBool.create("b");
+    public static final Block RVFT_BLOCK = new Block(Material.ROCK)
+    {
+        {
+            setDefaultState(getDefaultState().withProperty(PROP_A, false).withProperty(PROP_B, false));
+            setUnlocalizedName("rvft");
+            setRegistryName("rvft");
+        }
+
+        @Override
+        public BlockStateContainer createBlockState()
+        {
+            return new BlockStateContainer(this, PROP_A, PROP_B);
+        }
+
+        @Override
+        public int getMetaFromState(IBlockState state)
+        {
+            return (state.getValue(PROP_A) ? 0b0001 : 0) | (state.getValue(PROP_B) ? 0b0010 : 0);
+        }
+
+        @Override
+        public IBlockState getStateFromMeta(int meta)
+        {
+            return getDefaultState().withProperty(PROP_A, (meta & 0b0001) != 0).withProperty(PROP_B, (meta & 0b0010) != 0);
+        }
+
+        @Override
+        public IBlockState getStateForPlacement(World world, BlockPos pos, EnumFacing facing, float hitX, float hitY, float hitZ, int meta, EntityLivingBase placer, EnumHand hand)
+        {
+            return getStateFromMeta(((int)pos.toLong()));
+        }
+
+        @Override
+        public BlockRenderLayer getBlockLayer()
+        {
+            return BlockRenderLayer.TRANSLUCENT;
+        }
+    };
+
+    @SubscribeEvent
+    public static void registerBlocks(RegistryEvent.Register<Block> e)
+    {
+        e.getRegistry().register(RVFT_BLOCK);
+    }
+
+    @SubscribeEvent
+    public static void registerItems(RegistryEvent.Register<Item> e)
+    {
+        e.getRegistry().register(new ItemBlock(RVFT_BLOCK).setRegistryName(RVFT_BLOCK.getRegistryName()));
+    }
+
+    @SubscribeEvent
+    public static void registerModels(ModelRegistryEvent e) {
+        ModelLoader.setCustomModelResourceLocation(Item.getItemFromBlock(RVFT_BLOCK), 0, new ModelResourceLocation(RVFT_BLOCK.getRegistryName(), "inventory"));
+    }
+}

--- a/src/test/java/net/minecraftforge/debug/RandomVariantFragmentTest.java
+++ b/src/test/java/net/minecraftforge/debug/RandomVariantFragmentTest.java
@@ -81,7 +81,8 @@ public class RandomVariantFragmentTest
     }
 
     @SubscribeEvent
-    public static void registerModels(ModelRegistryEvent e) {
+    public static void registerModels(ModelRegistryEvent e)
+    {
         ModelLoader.setCustomModelResourceLocation(Item.getItemFromBlock(RVFT_BLOCK), 0, new ModelResourceLocation(RVFT_BLOCK.getRegistryName(), "inventory"));
     }
 }

--- a/src/test/resources/assets/random_variant_fragment_test/blockstates/rvft.json
+++ b/src/test/resources/assets/random_variant_fragment_test/blockstates/rvft.json
@@ -1,0 +1,49 @@
+{
+  "forge_marker": 1,
+  "__comment": [
+    "Expected behavior:",
+    "a=true,b=true -> 75% [ladder + carpet + slab] + 25% [glass + carpet + slab]",
+    "a=true,b=false -> 37.5% [ladder + torch] + 37.5% [ladder + lily] + 12.5% [glass + torch] + 12.5% [glass + lily]",
+    "a=false,b=true -> 100% [carpet + slab]",
+    "a=false,b=false -> 50% [torch] + 50% [lily]"
+  ],
+  "variants": {
+    "inventory": [{ "model": "minecraft:grass_normal" }],
+    "a": {
+      "true": [
+        {
+          "weight": 3,
+          "model": "minecraft:ladder"
+        },
+        {
+          "__comment": "Implicit weight: 1",
+          "model": "minecraft:glass"
+        }
+      ],
+      "false": {}
+    },
+    "b": {
+      "true": {
+        "submodel": {
+          "carpet": {
+            "model": "minecraft:carpet_blue"
+          },
+          "slab": {
+            "textures": {
+              "top": "minecraft:blocks/grass_top"
+            },
+            "model": "minecraft:upper_slab_stone"
+          }
+        }
+      },
+      "false": [
+        {
+          "submodel": "minecraft:normal_torch"
+        },
+        {
+          "submodel": "minecraft:waterlily"
+        }
+      ]
+    }
+  }
+}

--- a/src/test/resources/assets/random_variant_fragment_test/blockstates/rvft.json
+++ b/src/test/resources/assets/random_variant_fragment_test/blockstates/rvft.json
@@ -4,7 +4,7 @@
     "Expected behavior:",
     "a=true,b=true -> 3/4 [ladder + carpet + slab] + 1/4 [glass + carpet + slab]",
     "a=true,b=false -> 3/8 [ladder + torch] + 3/8 [ladder + lily] + 1/8 [glass + torch] + 1/8 [glass + lily]",
-    "a=false,b=true -> [carpet + slab]",
+    "a=false,b=true -> 3/4 [carpet + slab + allium] + 1/4 [carpet]",
     "a=false,b=false -> 1/2 [torch] + 1/2 [lily]",
     "where carpet = 2/3 [blue carpet] + 1/3 [red carpet]"
   ],
@@ -52,6 +52,25 @@
           "submodel": "minecraft:waterlily"
         }
       ]
-    }
+    },
+    "a=false,b=true": [
+      {
+        "__comment": "Should merge into the permutation based variant",
+        "weight": 3,
+        "submodel": {
+          "flower": {
+            "model": "minecraft:allium"
+          }
+        }
+      },
+      {
+        "submodel": {
+          "slab": {
+            "__comment": "Remove the slab",
+            "model": "minecraft:builtin/generated"
+          }
+        }
+      }
+    ]
   }
 }

--- a/src/test/resources/assets/random_variant_fragment_test/blockstates/rvft.json
+++ b/src/test/resources/assets/random_variant_fragment_test/blockstates/rvft.json
@@ -5,7 +5,8 @@
     "a=true,b=true -> 75% [ladder + carpet + slab] + 25% [glass + carpet + slab]",
     "a=true,b=false -> 37.5% [ladder + torch] + 37.5% [ladder + lily] + 12.5% [glass + torch] + 12.5% [glass + lily]",
     "a=false,b=true -> 100% [carpet + slab]",
-    "a=false,b=false -> 50% [torch] + 50% [lily]"
+    "a=false,b=false -> 50% [torch] + 50% [lily]",
+    "where carpet = 50% [blue carpet] + 50% [red carpet]"
   ],
   "variants": {
     "inventory": [{ "model": "minecraft:grass_normal" }],
@@ -25,9 +26,14 @@
     "b": {
       "true": {
         "submodel": {
-          "carpet": {
-            "model": "minecraft:carpet_blue"
-          },
+          "carpet": [
+            {
+              "model": "minecraft:carpet_blue"
+            },
+            {
+              "model": "minecraft:carpet_red"
+            }
+          ],
           "slab": {
             "textures": {
               "top": "minecraft:blocks/grass_top"

--- a/src/test/resources/assets/random_variant_fragment_test/blockstates/rvft.json
+++ b/src/test/resources/assets/random_variant_fragment_test/blockstates/rvft.json
@@ -2,11 +2,11 @@
   "forge_marker": 1,
   "__comment": [
     "Expected behavior:",
-    "a=true,b=true -> 75% [ladder + carpet + slab] + 25% [glass + carpet + slab]",
-    "a=true,b=false -> 37.5% [ladder + torch] + 37.5% [ladder + lily] + 12.5% [glass + torch] + 12.5% [glass + lily]",
-    "a=false,b=true -> 100% [carpet + slab]",
-    "a=false,b=false -> 50% [torch] + 50% [lily]",
-    "where carpet = 50% [blue carpet] + 50% [red carpet]"
+    "a=true,b=true -> 3/4 [ladder + carpet + slab] + 1/4 [glass + carpet + slab]",
+    "a=true,b=false -> 3/8 [ladder + torch] + 3/8 [ladder + lily] + 1/8 [glass + torch] + 1/8 [glass + lily]",
+    "a=false,b=true -> [carpet + slab]",
+    "a=false,b=false -> 1/2 [torch] + 1/2 [lily]",
+    "where carpet = 2/3 [blue carpet] + 1/3 [red carpet]"
   ],
   "variants": {
     "inventory": [{ "model": "minecraft:grass_normal" }],
@@ -28,9 +28,11 @@
         "submodel": {
           "carpet": [
             {
+              "weight": 2,
               "model": "minecraft:carpet_blue"
             },
             {
+              "weight": 1,
               "model": "minecraft:carpet_red"
             }
           ],


### PR DESCRIPTION
Make `"variants": { "property": { "value": [{}] } }` valid
Make `"variants": { "variant": { "model": "simple:def" } }` invalid
Add Random Variant Fragment Test

I didn't increment the version number for this yet because this is *mostly* backwards compatible. If a blockstate defines a straight-out "raw" variant like `"variants": { "inventory": { "model": "some:model" } }`, this will break it. I think it can be restored with a bit of elbow grease, but I think most people do `"variants": { "inventory": [{ "model": "some:model" }] }` anyway (with an explicit array). Everything else should remain unexploded.

The general idea is given in the included test mod. Instead of only allowing fully named variant definitions to be randomly selected from a list, a list of variant fragments can be defined as the value of a property's value. Like how a Cartesian product is performed to turn `"prop1": { "val11": {}, "val12": {} }, "prop2": { "val21": {}, "val22": {} }` into `"prop1=val11,prop2=val21": {}, "prop1=val12,prop2=val21": {}, "prop1=val11,prop2=val22": {}, "prop1=val12,prop2=val22": {}`, another Cartesian product is performed to turn `"prop1": { "val11": [a, b], "val12": [c, d] }, "prop2": { "val21": [e, f], "val22": [g, h] }` into `"prop1=val11,prop2=val21": [ae, af, be, bf], "prop1=val12,prop2=val21": [ce, cf, de, df], "prop1=val11,prop2=val22": [ag, ah, bg, bh], "prop1=val12,prop2=val22": [cg, ch, dg, dh]`. `"weight"` tags are handled by multiplication, and @gigaherz assures me the math works out.

~~I didn't give submodels any special treatment, because a) they seem to work anyway, and b) I haven't fully grokked how they work. `getSubmodelPermutations` also remains in its old recursive form instead of using `Lists.cartesianProduct` like the rewritten `getPermutations`.~~

(In order to run the test, `/fill ~ ~ ~ ~10 ~ ~10 random_variant_fragment_test:rvft a=bool,b=bool` and count the states of the resulting 100 blocks.)

<details>
<summary><a href="http://sbnc.khobbits.co.uk/log/logs/old/minecraftforge_%5B2017-07-08%5D.htm">Motivation</a></summary>
<pre><code>
[14:47:46] &lt;howtonotwin&gt; Oh waaait you're doing variants { variant { xxx [{}] } }?
[14:47:52] &lt;howtonotwin&gt; I'm not sure if that will work
[14:48:00] &lt;howtonotwin&gt; You can try, but it might just explode
[14:48:22] &lt;ghz|afk&gt; it should work
[14:48:24] &lt;Raycoms&gt; its exploding
[14:48:25] &lt;ghz|afk&gt; it's in the spec ;p
[14:48:32] &lt;howtonotwin&gt; welp
[14:48:39] &lt;ghz|afk&gt; no wait
[14:48:44] &lt;Raycoms&gt; <a href="https://pastebin.com/xkpRWect">https://pastebin.com/xkpRWect</a>
[14:48:44] &lt;ghz|afk&gt; it's int he spec for full variant strings
[14:48:46] &lt;ghz|afk&gt; not the split ones
[14:49:02] &lt;howtonotwin&gt; Oh dear...
[14:49:11] &lt;howtonotwin&gt; Your workload just got multiplied by 4
[14:49:28] &lt;Raycoms&gt; I don't like the sound of that
[14:49:41] &lt;howtonotwin&gt; You need to define full variants, including the rotation thingy
[14:49:46] &lt;howtonotwin&gt; Actually more like 6
[14:50:15] &lt;Raycoms&gt; You mean I have to put the rotation in every variant as well? =/
[14:50:46] &lt;ghz|afk&gt; it would appear you ahve to use vanilla-style variant strings, so yes
[14:51:04] &lt;howtonotwin&gt; So now you do { variants { facing=x,variant=xxx: [{}, {}, ...], facing=y,variant=xxx: [], ..., facing: { ... }, variant: { ... } } }
[14:51:55] &lt;howtonotwin&gt; You can still use the property-value mergy feature for the other variants, but you need to define full variant strings for variant=blockrackfull
</code></pre>
</details>