### PR TITLE
Remove unnecessary restrictions on the stack to be brewed

### DIFF
--- a/src/main/java/net/minecraftforge/common/brewing/AbstractBrewingRecipe.java
+++ b/src/main/java/net/minecraftforge/common/brewing/AbstractBrewingRecipe.java
@@ -36,11 +36,6 @@ public abstract class AbstractBrewingRecipe<T> implements IBrewingRecipe
         this.input = input;
         this.ingredient = ingredient;
         this.output = output;
-
-        if (this.getInput().getMaxStackSize() != 1)
-        {
-            throw new IllegalArgumentException("Inputs must have a max size of 1 just like water bottles. Brewing Stands override the input with the output when the brewing is done, items that stack would end up getting lost.");
-        }
     }
 
     @Override

--- a/src/main/java/net/minecraftforge/common/brewing/BrewingRecipeRegistry.java
+++ b/src/main/java/net/minecraftforge/common/brewing/BrewingRecipeRegistry.java
@@ -90,7 +90,7 @@ public class BrewingRecipeRegistry {
     @Nonnull
     public static ItemStack getOutput(@Nonnull ItemStack input, @Nonnull ItemStack ingredient)
     {
-        if (input.isEmpty() || input.getMaxStackSize() != 1 || input.getCount() != 1) return ItemStack.EMPTY;
+        if (input.isEmpty() || input.getCount() != 1) return ItemStack.EMPTY;
         if (ingredient.isEmpty()) return ItemStack.EMPTY;
 
         for (IBrewingRecipe recipe : recipes)
@@ -172,7 +172,7 @@ public class BrewingRecipeRegistry {
      */
     public static boolean isValidInput(@Nonnull ItemStack stack)
     {
-        if (stack.getMaxStackSize() != 1 || stack.getCount() != 1) return false;
+        if (stack.getCount() != 1) return false;
 
         for (IBrewingRecipe recipe : recipes)
         {


### PR DESCRIPTION
(This is resubmitted pr, the previous one is #1937)
ContainerBrewingStand$Potion#getSlotStackLimit limits stack size, so the limitation of max stack size is unnecessary.