### PR TITLE
Fix animation of rotated block parts

### DIFF
--- a/src/main/java/net/minecraftforge/client/model/animation/ModelBlockAnimation.java
+++ b/src/main/java/net/minecraftforge/client/model/animation/ModelBlockAnimation.java
@@ -405,43 +405,16 @@ public class ModelBlockAnimation
     protected static class MBJoint implements IJoint
     {
         private final String name;
-        private final TRSRTransformation invBindPose;
 
-        public MBJoint(String name, BlockPart part)
+        public MBJoint(String name)
         {
             this.name = name;
-            if(part.partRotation != null)
-            {
-                float x = 0, y = 0, z = 0;
-                switch(part.partRotation.axis)
-                {
-                    case X:
-                        x = 1;
-                    case Y:
-                        y = 1;
-                    case Z:
-                        z = 1;
-                }
-                Quat4f rotation = new Quat4f();
-                rotation.set(new AxisAngle4f(x, y, z, 0));
-                Matrix4f m = new TRSRTransformation(
-                    TRSRTransformation.toVecmath(part.partRotation.origin),
-                    rotation,
-                    null,
-                    null).getMatrix();
-                m.invert();
-                invBindPose = new TRSRTransformation(m);
-            }
-            else
-            {
-                invBindPose = TRSRTransformation.identity();
-            }
         }
 
         @Override
         public TRSRTransformation getInvBindPose()
         {
-            return invBindPose;
+            return TRSRTransformation.identity();
         }
 
         @Override
@@ -533,7 +506,7 @@ public class ModelBlockAnimation
             {
                 if(info.getWeights().containsKey(i))
                 {
-                    ModelBlockAnimation.MBJoint joint = new ModelBlockAnimation.MBJoint(info.getName(), part);
+                    ModelBlockAnimation.MBJoint joint = new ModelBlockAnimation.MBJoint(info.getName());
                     Optional<TRSRTransformation> trOp = state.apply(Optional.of(joint));
                     if(trOp.isPresent() && trOp.get() != TRSRTransformation.identity())
                     {


### PR DESCRIPTION
**How to reproduce**
Add following entry to first cube ("ring" in armature) of `engine.json` and `engine_ring.json` models from `forgedebugmodelanimation` test:
```json
"rotation": {
  "origin": [8, 8, 8],
  "axis": "y",
  "angle": 45
}
```

**What I expect**
Animated block model parts should behave same way as static parts.
![2017-07-09_12 05 52](https://user-images.githubusercontent.com/754542/27993012-ffcf575e-64a0-11e7-9da5-a33c6e215223.png)

**What actually happens**
Animated part is rotated, but also offset by rotation origin:
![2017-07-09_12 08 31](https://user-images.githubusercontent.com/754542/27993020-22f4b882-64a1-11e7-9c2c-a4f6957b483d.png)

**Why I think this code is faulty**
In case of ModelBlockAnimations joints have no intrinsic orientation - it comes either from block part (since rotation and other transformations are applied on quad level in `FaceBakery`) or clip.

Extra quirk: there are no breaks in switch, but it doesn't matter, since angle is always 0.

