### PR TITLE
make IngredientNBT constructor public

### DIFF
--- a/src/main/java/net/minecraftforge/common/crafting/IngredientNBT.java
+++ b/src/main/java/net/minecraftforge/common/crafting/IngredientNBT.java
@@ -26,7 +26,7 @@ import net.minecraft.item.crafting.Ingredient;
 public class IngredientNBT extends Ingredient
 {
     private final ItemStack stack;
-    protected IngredientNBT(ItemStack stack)
+    public IngredientNBT(ItemStack stack)
     {
         super(stack);
         this.stack = stack;


### PR DESCRIPTION
This allows mods to create an IngredientNBT from code for recipes that are dynamicaly generated but have ingredients that are NBT sensitive.

In this case it would be for dynamicaly generating recipes for crafting gates for all combinations of registered materials and logic modifiers