### PR TITLE
Improved arrow functionality.

### DIFF
--- a/patches/minecraft/net/minecraft/item/Item.java.patch
+++ b/patches/minecraft/net/minecraft/item/Item.java.patch
@@ -87,7 +87,7 @@
      public CreativeTabs func_77640_w()
      {
          return this.field_77701_a;
-@@ -438,11 +445,642 @@
+@@ -438,11 +445,652 @@
          return false;
      }
  
@@ -566,6 +566,16 @@
 +        return func_150897_b(state);
 +    }
 +
++	/**
++	 * Checked from {@link net.minecraft.item.ItemBow#isArrow(ItemStack stack)}
++	 * when looking for a valid arrow item.
++	 * @return true if the provided stack may be treated as an arrow at the time of query.
++	 */
++	public boolean isValidArrow(ItemStack stack)
++	{
++		return this instanceof ItemArrow;
++	}
++
 +    /**
 +     * Gets the maximum number of items that this stack should be able to hold.
 +     * This is a ItemStack (and thus NBT) sensitive version of Item.getItemStackLimit()
@@ -730,7 +740,7 @@
      public static void func_150900_l()
      {
          func_179214_a(Blocks.field_150350_a, new ItemAir(Blocks.field_150350_a));
-@@ -1002,6 +1640,8 @@
+@@ -1002,6 +1650,8 @@
          private final float field_78010_h;
          private final float field_78011_i;
          private final int field_78008_j;
@@ -739,7 +749,7 @@
  
          private ToolMaterial(int p_i1874_3_, int p_i1874_4_, float p_i1874_5_, float p_i1874_6_, int p_i1874_7_)
          {
-@@ -1037,6 +1677,7 @@
+@@ -1037,6 +1687,7 @@
              return this.field_78008_j;
          }
  
@@ -747,7 +757,7 @@
          public Item func_150995_f()
          {
              if (this == WOOD)
-@@ -1060,5 +1701,21 @@
+@@ -1060,5 +1711,21 @@
                  return this == DIAMOND ? Items.field_151045_i : null;
              }
          }

--- a/patches/minecraft/net/minecraft/item/ItemBow.java.patch
+++ b/patches/minecraft/net/minecraft/item/ItemBow.java.patch
@@ -1,5 +1,14 @@
 --- ../src-base/minecraft/net/minecraft/item/ItemBow.java
 +++ ../src-work/minecraft/net/minecraft/item/ItemBow.java
+@@ -79,7 +79,7 @@
+ 
+     protected boolean func_185058_h_(ItemStack p_185058_1_)
+     {
+-        return p_185058_1_.func_77973_b() instanceof ItemArrow;
++        return p_185058_1_.func_77973_b().isValidArrow(p_185058_1_);
+     }
+ 
+     public void func_77615_a(ItemStack p_77615_1_, World p_77615_2_, EntityLivingBase p_77615_3_, int p_77615_4_)
 @@ -90,6 +90,10 @@
              boolean flag = entityplayer.field_71075_bZ.field_75098_d || EnchantmentHelper.func_77506_a(Enchantments.field_185312_x, p_77615_1_) > 0;
              ItemStack itemstack = this.func_185060_a(entityplayer);


### PR DESCRIPTION
This patch basically allows for an itemstack which is an "arrow" to determine if it is indeed valid, rather than a hard check for instanceof ItemArrow.

The use case for this is a Quiver, which would "look" like an arrow by returning true when it had arrows, and false when it did not.

Existing bow logic is already sufficient to prevent the Quiver from being deleted (isInfinite) and creating the correct arrows (createArrow).