### PR TITLE
Add OptionalInterface and OptionalMethod to replace the Optional class

### DIFF
--- a/src/main/java/net/minecraftforge/fml/common/Optional.java
+++ b/src/main/java/net/minecraftforge/fml/common/Optional.java
@@ -29,8 +29,9 @@ import java.lang.annotation.Target;
  * if the modid specified is missing.
  *
  * @author cpw
- *
+ * @deprecated see {@link OptionalInterface} and {@link OptionalMethod}
  */
+@Deprecated
 public final class Optional {
     /**
      * Not constructable
@@ -40,8 +41,9 @@ public final class Optional {
     /**
      * Mark a list of interfaces as removable
      * @author cpw
-     *
+     * @deprecated use {@link OptionalInterface}, as it is repeatable
      */
+    @Deprecated
     @Retention(RetentionPolicy.RUNTIME)
     @Target(ElementType.TYPE)
     public @interface InterfaceList {
@@ -54,8 +56,9 @@ public final class Optional {
     /**
      * Used to remove optional interfaces
      * @author cpw
-     *
+     * @deprecated use {@link OptionalInterface}
      */
+    @Deprecated
     @Retention(RetentionPolicy.RUNTIME)
     @Target(ElementType.TYPE)
     public @interface Interface {
@@ -81,8 +84,9 @@ public final class Optional {
     /**
      * Used to remove optional methods
      * @author cpw
-     *
+     * @deprecated use {@link OptionalMethod}
      */
+    @Deprecated
     @Retention(RetentionPolicy.RUNTIME)
     @Target(ElementType.METHOD)
     public @interface Method {

--- a/src/main/java/net/minecraftforge/fml/common/OptionalInterface.java
+++ b/src/main/java/net/minecraftforge/fml/common/OptionalInterface.java
@@ -1,0 +1,70 @@
+/*
+ * Minecraft Forge
+ * Copyright (c) 2016.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation version 2.1
+ * of the License.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+package net.minecraftforge.fml.common;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Repeatable;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Used to remove optional interfaces
+ * @author cpw
+ *
+ */
+@Repeatable(OptionalInterface.OptionalInterfaceList.class)
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+public @interface OptionalInterface {
+    /**
+     * The fully qualified name of the interface to be stripped
+     * @return the interface name
+     */
+    public String iface();
+
+    /**
+     * The modid that is required to be present for stripping NOT to occur
+     * @return the modid
+     */
+    public String modid();
+
+    /**
+     * Strip references to this interface in method declarations? (Useful to kill synthetic methods from scala f.e.)
+     *
+     * @return if references should be stripped
+     */
+    public boolean striprefs() default false;
+
+    /**
+     * Mark a list of interfaces as removable
+     * @author cpw
+     *
+     */
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target(ElementType.TYPE)
+    public @interface OptionalInterfaceList {
+        /**
+         * Mark a list of interfaces for optional removal.
+         * @return
+         */
+        public OptionalInterface[] value();
+    }
+}

--- a/src/main/java/net/minecraftforge/fml/common/OptionalMethod.java
+++ b/src/main/java/net/minecraftforge/fml/common/OptionalMethod.java
@@ -1,0 +1,40 @@
+/*
+ * Minecraft Forge
+ * Copyright (c) 2016.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation version 2.1
+ * of the License.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+package net.minecraftforge.fml.common;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Used to remove optional methods
+ * @author cpw
+ *
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.METHOD)
+public @interface OptionalMethod {
+    /**
+     * The modid that is required to be present for stripping NOT to occur
+     * @return the modid
+     */
+    public String modid();
+}

--- a/src/main/java/net/minecraftforge/fml/common/asm/transformers/ModAPITransformer.java
+++ b/src/main/java/net/minecraftforge/fml/common/asm/transformers/ModAPITransformer.java
@@ -154,12 +154,20 @@ public class ModAPITransformer implements IClassTransformer {
     public void initTable(ASMDataTable dataTable)
     {
         optionals = ArrayListMultimap.create();
-        Set<ASMData> interfaceLists = dataTable.getAll("net.minecraftforge.fml.common.Optional$InterfaceList");
+        Set<ASMData> interfaceLists = dataTable.getAll("net.minecraftforge.fml.common.OptionalInterface$OptionalInterfaceList");
         addData(unpackInterfaces(interfaceLists));
-        Set<ASMData> interfaces = dataTable.getAll("net.minecraftforge.fml.common.Optional$Interface");
+        Set<ASMData> interfaces = dataTable.getAll("net.minecraftforge.fml.common.OptionalInterface");
         addData(interfaces);
-        Set<ASMData> methods = dataTable.getAll("net.minecraftforge.fml.common.Optional$Method");
+        Set<ASMData> methods = dataTable.getAll("net.minecraftforge.fml.common.OptionalMethod");
         addData(methods);
+
+        // TODO: remove
+        Set<ASMData> interfaceListsO = dataTable.getAll("net.minecraftforge.fml.common.Optional$InterfaceList");
+        addData(unpackInterfaces(interfaceListsO));
+        Set<ASMData> interfacesO = dataTable.getAll("net.minecraftforge.fml.common.Optional$Interface");
+        addData(interfacesO);
+        Set<ASMData> methodsO = dataTable.getAll("net.minecraftforge.fml.common.Optional$Method");
+        addData(methodsO);
     }
 
     private Set<ASMData> unpackInterfaces(Set<ASMData> packedInterfaces)


### PR DESCRIPTION
Java 8 and Guava both have an `Optional` class - moving these annotations outside of the `Optional` class removes the need to import them (importing `Optional.Method` will conflict with `java.lang.reflect.Method`, as well) or use fully-qualified class names.

This pull request:
- deprecates `net.minecraftforge.fml.common.Optional`, with no replacement
- deprecates `net.minecraftforge.fml.common.Optional$InterfaceList`, replaced by `net.minecraftforge.fml.common.OptionalInterface$OptionalInterfaceList` (though repeating `OptionalInterface` should be preferred now)
- deprecates `net.minecraftforge.fml.common.Optional$Interface`, replaced by `net.minecraftforge.fml.common.OptionalInterface`
- deprecates `net.minecraftforge.fml.common.Optional$Method`, replaced by`net.minecraftforge.fml.common.OptionalMethod`

Additionally, `net.minecraftforge.fml.common.OptionalInterface` is [repeatable](https://docs.oracle.com/javase/tutorial/java/annotations/repeating.html).