### PR TITLE
Deprecate useless methods in IUnlistedProperty

### DIFF
--- a/src/main/java/net/minecraftforge/client/model/obj/OBJModel.java
+++ b/src/main/java/net/minecraftforge/client/model/obj/OBJModel.java
@@ -1261,18 +1261,6 @@ public class OBJModel implements IModel
         {
             return value instanceof OBJState;
         }
-
-        @Override
-        public Class<OBJState> getType()
-        {
-            return OBJState.class;
-        }
-
-        @Override
-        public String valueToString(OBJState value)
-        {
-            return value.toString();
-        }
     }
 
     public class OBJBakedModel implements IBakedModel

--- a/src/main/java/net/minecraftforge/common/property/ExtendedBlockState.java
+++ b/src/main/java/net/minecraftforge/common/property/ExtendedBlockState.java
@@ -133,13 +133,14 @@ public class ExtendedBlockState extends BlockStateContainer
         }
 
         @Override
+        @SuppressWarnings("unchecked")
         public <V>V getValue(IUnlistedProperty<V> property)
         {
             if(!this.unlistedProperties.containsKey(property))
             {
                 throw new IllegalArgumentException("Cannot get unlisted property " + property + " as it does not exist in " + getBlock().getBlockState());
             }
-            return property.getType().cast(this.unlistedProperties.get(property).orElse(null));
+            return (V) this.unlistedProperties.get(property).orElse(null);
         }
 
         public ImmutableMap<IUnlistedProperty<?>, Optional<?>> getUnlistedProperties()

--- a/src/main/java/net/minecraftforge/common/property/IUnlistedProperty.java
+++ b/src/main/java/net/minecraftforge/common/property/IUnlistedProperty.java
@@ -25,7 +25,13 @@ public interface IUnlistedProperty<V>
 
     boolean isValid(V value);
 
-    Class<V> getType();
+    @Deprecated
+    default Class<V> getType() {
+        return (Class<V>) Object.class;
+    }
 
-    String valueToString(V value);
+    @Deprecated
+    default String valueToString(V value) {
+        return value.toString();
+    }
 }

--- a/src/main/java/net/minecraftforge/common/property/IUnlistedProperty.java
+++ b/src/main/java/net/minecraftforge/common/property/IUnlistedProperty.java
@@ -26,12 +26,14 @@ public interface IUnlistedProperty<V>
     boolean isValid(V value);
 
     @Deprecated
-    default Class<V> getType() {
+    default Class<V> getType()
+    {
         return (Class<V>) Object.class;
     }
 
     @Deprecated
-    default String valueToString(V value) {
+    default String valueToString(V value)
+    {
         return value.toString();
     }
 }

--- a/src/main/java/net/minecraftforge/common/property/Properties.java
+++ b/src/main/java/net/minecraftforge/common/property/Properties.java
@@ -39,10 +39,6 @@ public class Properties
         public String getName() { return "forge_animation"; }
         @Override
         public boolean isValid(IModelState state) { return true; }
-        @Override
-        public Class<IModelState> getType() { return IModelState.class; }
-        @Override
-        public String valueToString(IModelState state) { return state.toString(); }
     };
 
     public static <V extends Comparable<V>> IUnlistedProperty<V> toUnlisted(IProperty<V> property)
@@ -69,18 +65,6 @@ public class Properties
         public boolean isValid(V value)
         {
             return parent.getAllowedValues().contains(value);
-        }
-
-        @Override
-        public Class<V> getType()
-        {
-            return parent.getValueClass();
-        }
-
-        @Override
-        public String valueToString(V value)
-        {
-            return parent.getName(value);
         }
     }
 }

--- a/src/main/java/net/minecraftforge/common/property/PropertyFloat.java
+++ b/src/main/java/net/minecraftforge/common/property/PropertyFloat.java
@@ -49,16 +49,4 @@ public class PropertyFloat implements IUnlistedProperty<Float>
     {
         return validator.apply(value);
     }
-
-    @Override
-    public Class<Float> getType()
-    {
-        return Float.class;
-    }
-
-    @Override
-    public String valueToString(Float value)
-    {
-        return value.toString();
-    }
 }


### PR DESCRIPTION
Does any reason exist?