### PR TITLE
Add advancement reload hook for dynamically generated advancements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+#macos stuff
+**/.DS_Store
+
 #eclipse
 /bin
 /.settings
@@ -9,6 +12,7 @@
 #idea
 /.idea
 /classes
+/out
 *.iml
 
 #gradle

--- a/patches/minecraft/net/minecraft/advancements/AdvancementManager.java.patch
+++ b/patches/minecraft/net/minecraft/advancements/AdvancementManager.java.patch
@@ -1,10 +1,11 @@
 --- ../src-base/minecraft/net/minecraft/advancements/AdvancementManager.java
 +++ ../src-work/minecraft/net/minecraft/advancements/AdvancementManager.java
-@@ -66,6 +66,7 @@
+@@ -66,6 +66,8 @@
          field_192784_c.func_192087_a();
          Map<ResourceLocation, Advancement.Builder> map = this.func_192781_c();
          this.func_192777_a(map);
 +        this.field_193768_e |= net.minecraftforge.common.ForgeHooks.loadAdvancements(map);
++        net.minecraftforge.common.MinecraftForge.EVENT_BUS.post(new net.minecraftforge.event.advancements.AdvancementManagerReloadEvent(this, map));
          field_192784_c.func_192083_a(map);
  
          for (Advancement advancement : field_192784_c.func_192088_b())

--- a/src/main/java/net/minecraftforge/event/advancements/AdvancementManagerReloadEvent.java
+++ b/src/main/java/net/minecraftforge/event/advancements/AdvancementManagerReloadEvent.java
@@ -38,7 +38,7 @@ public class AdvancementManagerReloadEvent extends Event
     }
 
     /**
-     * 
+     * <strong>NOTE: Do not use {@code event.getAdvManager().getAdvancement(rl)}; use {@code event.getAdvMap().get(rl).build(rl)} instead</strong>
      * @return the advancement manager
      */
     public AdvancementManager getAdvManager()

--- a/src/main/java/net/minecraftforge/event/advancements/AdvancementManagerReloadEvent.java
+++ b/src/main/java/net/minecraftforge/event/advancements/AdvancementManagerReloadEvent.java
@@ -1,0 +1,57 @@
+package net.minecraftforge.event.advancements;
+
+import java.util.Map;
+
+import net.minecraft.advancements.Advancement;
+import net.minecraft.advancements.AdvancementManager;
+import net.minecraft.util.ResourceLocation;
+import net.minecraftforge.fml.common.eventhandler.Event;
+
+/**
+ * This is fired in {@link AdvancementManager#reload()} after JSON advancements have been (re)loaded.
+ * Add dynamically generated advancements to the map returned by {@link #getAdvMap()}.<br>
+ * <br>
+ * Ex.
+ * <code>
+ * <pre>
+ * &#064;Mod.EventBusSubscriber(modid = "randommodid")
+ * public static class LoremIpsum {
+ *   &#064;SubscribeEvent
+ *   public static void onAdvReload(AdvancementManagerReloadEvent event) {
+ *     event.getAdvMap().add(YOUR_ADVANCEMENT_ID, YOUR_ADVANCEMENT_BUILDER); // An advancement builder for an advancement can be obtained using {@link Advancement#copy()}.
+ *   }
+ * }
+ * </pre>
+ * </code>
+ * 
+ * @author Landmaster
+ */
+public class AdvancementManagerReloadEvent extends Event
+{
+    private final AdvancementManager instance;
+    private final Map<ResourceLocation, Advancement.Builder> advMap;
+
+    public AdvancementManagerReloadEvent(AdvancementManager instance, Map<ResourceLocation, Advancement.Builder> advMap)
+    {
+        this.instance = instance;
+        this.advMap = advMap;
+    }
+
+    /**
+     * 
+     * @return the advancement manager
+     */
+    public AdvancementManager getAdvManager()
+    {
+        return this.instance;
+    }
+
+    /**
+     * Add your advancements, each as an {@link Advancement.Builder} (obtainable via {@link Advancement#copy()}), to this map.
+     * @return a mutable {@link Map} of advancement ids to advancement builders
+     */
+    public Map<ResourceLocation, Advancement.Builder> getAdvMap()
+    {
+        return this.advMap;
+    }
+}

--- a/src/test/java/net/minecraftforge/debug/AdvancementManagerReloadEventTest.java
+++ b/src/test/java/net/minecraftforge/debug/AdvancementManagerReloadEventTest.java
@@ -1,0 +1,51 @@
+package net.minecraftforge.debug;
+
+import org.apache.commons.lang3.ArrayUtils;
+
+import com.google.common.collect.ImmutableMap;
+
+import net.minecraft.advancements.Advancement;
+import net.minecraft.advancements.AdvancementRewards;
+import net.minecraft.advancements.Criterion;
+import net.minecraft.advancements.critereon.InventoryChangeTrigger;
+import net.minecraft.advancements.critereon.ItemPredicate;
+import net.minecraft.advancements.critereon.MinMaxBounds;
+import net.minecraft.command.FunctionObject;
+import net.minecraft.item.ItemStack;
+import net.minecraft.util.ResourceLocation;
+import net.minecraftforge.event.advancements.AdvancementManagerReloadEvent;
+import net.minecraftforge.fml.common.Mod;
+import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
+import net.minecraftforge.oredict.OreDictionary;
+
+@Mod.EventBusSubscriber
+@Mod(modid = AdvancementManagerReloadEventTest.MODID, name = "Advancement Manager reload event test", version = "1.0", acceptableRemoteVersions = "*")
+public class AdvancementManagerReloadEventTest
+{
+    public static final String MODID = "adv_reload_test";
+    static final boolean ENABLED = true;
+
+    @SubscribeEvent
+    public static void onAdvReload(AdvancementManagerReloadEvent event) {
+        final ResourceLocation ID_WOOD_UNLOCK_TNT = new ResourceLocation(MODID, "wood_unlock_tnt");
+        final Advancement.Builder woodUnlockTNT = new Advancement(
+                ID_WOOD_UNLOCK_TNT,
+                event.getAdvManager().getAdvancement(new ResourceLocation("recipes/root")),
+                null,
+                new AdvancementRewards(0, new ResourceLocation[0], new ResourceLocation[] {
+                        new ResourceLocation("tnt")
+                }, FunctionObject.CacheableFunction.EMPTY),
+                ImmutableMap.of("has_wood", new Criterion(new InventoryChangeTrigger.Instance(
+                        MinMaxBounds.UNBOUNDED, MinMaxBounds.UNBOUNDED, MinMaxBounds.UNBOUNDED,
+                        new ItemPredicate[] { new ItemPredicate() {
+                            @Override public boolean test(ItemStack stack) {
+                                return ArrayUtils.contains(OreDictionary.getOreIDs(stack), OreDictionary.getOreID("plankWood")); // test the oredict for wood planks
+                            }
+                        } }))),
+                new String[][] {{"has_wood"}}).copy();
+
+        if (ENABLED) {
+            event.getAdvMap().put(ID_WOOD_UNLOCK_TNT, woodUnlockTNT);
+        }
+    }
+}

--- a/src/test/java/net/minecraftforge/debug/AdvancementManagerReloadEventTest.java
+++ b/src/test/java/net/minecraftforge/debug/AdvancementManagerReloadEventTest.java
@@ -34,7 +34,8 @@ public class AdvancementManagerReloadEventTest
     @SubscribeEvent
     public static void onAdvReload(AdvancementManagerReloadEvent event)
     {
-        if (ENABLED) {
+        if (ENABLED)
+        {
             final Advancement.Builder woodUnlockTNT = new Advancement(
                     ID_WOOD_UNLOCK_TNT,
                     event.getAdvManager().getAdvancement(new ResourceLocation("recipes/root")),

--- a/src/test/java/net/minecraftforge/debug/AdvancementManagerReloadEventTest.java
+++ b/src/test/java/net/minecraftforge/debug/AdvancementManagerReloadEventTest.java
@@ -38,7 +38,7 @@ public class AdvancementManagerReloadEventTest
         {
             final Advancement.Builder woodUnlockTNT = new Advancement(
                     ID_WOOD_UNLOCK_TNT,
-                    event.getAdvManager().getAdvancement(new ResourceLocation("recipes/root")),
+                    event.getAdvMap().get(new ResourceLocation("recipes/root")).build(new ResourceLocation("recipes/root")),
                     null,
                     new AdvancementRewards(0, new ResourceLocation[0],
                                            new ResourceLocation[] { new ResourceLocation("tnt") }, FunctionObject.CacheableFunction.EMPTY),

--- a/src/test/java/net/minecraftforge/debug/AdvancementManagerReloadEventTest.java
+++ b/src/test/java/net/minecraftforge/debug/AdvancementManagerReloadEventTest.java
@@ -18,33 +18,41 @@ import net.minecraftforge.fml.common.Mod;
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
 import net.minecraftforge.oredict.OreDictionary;
 
+/**
+ * A bit of a proof-of-concept for dynamic advancements.
+ * @author Landmaster
+ */
 @Mod.EventBusSubscriber
 @Mod(modid = AdvancementManagerReloadEventTest.MODID, name = "Advancement Manager reload event test", version = "1.0", acceptableRemoteVersions = "*")
 public class AdvancementManagerReloadEventTest
 {
     public static final String MODID = "adv_reload_test";
-    static final boolean ENABLED = true;
+
+    static final boolean ENABLED = false;
+    static final ResourceLocation ID_WOOD_UNLOCK_TNT = new ResourceLocation(MODID, "wood_unlock_tnt");
 
     @SubscribeEvent
-    public static void onAdvReload(AdvancementManagerReloadEvent event) {
-        final ResourceLocation ID_WOOD_UNLOCK_TNT = new ResourceLocation(MODID, "wood_unlock_tnt");
-        final Advancement.Builder woodUnlockTNT = new Advancement(
-                ID_WOOD_UNLOCK_TNT,
-                event.getAdvManager().getAdvancement(new ResourceLocation("recipes/root")),
-                null,
-                new AdvancementRewards(0, new ResourceLocation[0], new ResourceLocation[] {
-                        new ResourceLocation("tnt")
-                }, FunctionObject.CacheableFunction.EMPTY),
-                ImmutableMap.of("has_wood", new Criterion(new InventoryChangeTrigger.Instance(
-                        MinMaxBounds.UNBOUNDED, MinMaxBounds.UNBOUNDED, MinMaxBounds.UNBOUNDED,
-                        new ItemPredicate[] { new ItemPredicate() {
-                            @Override public boolean test(ItemStack stack) {
-                                return ArrayUtils.contains(OreDictionary.getOreIDs(stack), OreDictionary.getOreID("plankWood")); // test the oredict for wood planks
-                            }
-                        } }))),
-                new String[][] {{"has_wood"}}).copy();
-
+    public static void onAdvReload(AdvancementManagerReloadEvent event)
+    {
         if (ENABLED) {
+            final Advancement.Builder woodUnlockTNT = new Advancement(
+                    ID_WOOD_UNLOCK_TNT,
+                    event.getAdvManager().getAdvancement(new ResourceLocation("recipes/root")),
+                    null,
+                    new AdvancementRewards(0, new ResourceLocation[0],
+                                           new ResourceLocation[] { new ResourceLocation("tnt") }, FunctionObject.CacheableFunction.EMPTY),
+                    ImmutableMap.of("has_wood", new Criterion(new InventoryChangeTrigger.Instance(
+                            MinMaxBounds.UNBOUNDED, MinMaxBounds.UNBOUNDED, MinMaxBounds.UNBOUNDED,
+                            new ItemPredicate[] { new ItemPredicate()
+                            {
+                                @Override public boolean test(ItemStack stack)
+                                {
+                                    return ArrayUtils.contains(OreDictionary.getOreIDs(stack), OreDictionary.getOreID("plankWood")); // test the oredict for wood planks
+                                }
+                            } }))),
+                    new String[][] {{"has_wood"}})
+                .copy();
+
             event.getAdvMap().put(ID_WOOD_UNLOCK_TNT, woodUnlockTNT);
         }
     }


### PR DESCRIPTION
This pull request adds an event hook in `AdvancementManager.reload()` that allows mods to *dynamically* generate and add advancements via Java, as opposed to statically via JSON.

`AdvancementManagerReloadEventTest.java` is a proof-of-concept for this: it is a test mod that adds an advancement, via Java, that allows the TNT recipe to be unlocked via a wood plank.