### PR TITLE
Recheck light on chunk boundaries upon load when necessary

### DIFF
--- a/patches/minecraft/net/minecraft/client/Minecraft.java.patch
+++ b/patches/minecraft/net/minecraft/client/Minecraft.java.patch
@@ -219,7 +219,16 @@
              }
  
              this.field_71424_I.func_76318_c("gameRenderer");
-@@ -1819,6 +1844,7 @@
+@@ -1740,6 +1765,8 @@
+                 this.field_71460_t.func_78464_a();
+             }
+ 
++            this.field_71424_I.func_76318_c("lighting");
++            this.field_71441_e.lightingEngine.procLightUpdates();
+             this.field_71424_I.func_76318_c("levelRenderer");
+ 
+             if (!this.field_71445_n)
+@@ -1819,6 +1846,7 @@
          }
  
          this.field_71424_I.func_76319_b();
@@ -227,7 +236,7 @@
          this.field_71423_H = func_71386_F();
      }
  
-@@ -1924,6 +1950,7 @@
+@@ -1924,6 +1952,7 @@
                      }
                  }
              }
@@ -235,7 +244,7 @@
          }
  
          this.func_184117_aA();
-@@ -2170,6 +2197,8 @@
+@@ -2170,6 +2199,8 @@
      {
          while (Mouse.next())
          {
@@ -244,7 +253,7 @@
              int i = Mouse.getEventButton();
              KeyBinding.func_74510_a(i - 100, Mouse.getEventButtonState());
  
-@@ -2235,6 +2264,7 @@
+@@ -2235,6 +2266,7 @@
  
      public void func_71371_a(String p_71371_1_, String p_71371_2_, @Nullable WorldSettings p_71371_3_)
      {
@@ -252,7 +261,7 @@
          this.func_71403_a((WorldClient)null);
          System.gc();
          ISaveHandler isavehandler = this.field_71469_aa.func_75804_a(p_71371_1_, false);
-@@ -2277,6 +2307,12 @@
+@@ -2277,6 +2309,12 @@
  
          while (!this.field_71437_Z.func_71200_ad())
          {
@@ -265,7 +274,7 @@
              String s = this.field_71437_Z.func_71195_b_();
  
              if (s != null)
-@@ -2302,8 +2338,14 @@
+@@ -2302,8 +2340,14 @@
          SocketAddress socketaddress = this.field_71437_Z.func_147137_ag().func_151270_a();
          NetworkManager networkmanager = NetworkManager.func_150722_a(socketaddress);
          networkmanager.func_150719_a(new NetHandlerLoginClient(networkmanager, this, (GuiScreen)null));
@@ -282,7 +291,7 @@
          this.field_71453_ak = networkmanager;
      }
  
-@@ -2314,6 +2356,8 @@
+@@ -2314,6 +2358,8 @@
  
      public void func_71353_a(@Nullable WorldClient p_71353_1_, String p_71353_2_)
      {
@@ -291,7 +300,7 @@
          if (p_71353_1_ == null)
          {
              NetHandlerPlayClient nethandlerplayclient = this.func_147114_u();
-@@ -2326,6 +2370,18 @@
+@@ -2326,6 +2372,18 @@
              if (this.field_71437_Z != null && this.field_71437_Z.func_175578_N())
              {
                  this.field_71437_Z.func_71263_m();
@@ -310,7 +319,7 @@
              }
  
              this.field_71437_Z = null;
-@@ -2349,6 +2405,7 @@
+@@ -2349,6 +2407,7 @@
              this.field_71456_v.func_181029_i();
              this.func_71351_a((ServerData)null);
              this.field_71455_al = false;
@@ -318,7 +327,7 @@
          }
  
          this.field_147127_av.func_147690_c();
-@@ -2466,159 +2523,8 @@
+@@ -2466,159 +2525,8 @@
      {
          if (this.field_71476_x != null && this.field_71476_x.field_72313_a != RayTraceResult.Type.MISS)
          {
@@ -480,7 +489,7 @@
          }
      }
  
-@@ -2921,18 +2827,8 @@
+@@ -2921,18 +2829,8 @@
  
      public static int func_71369_N()
      {
@@ -501,7 +510,7 @@
      }
  
      public boolean func_70002_Q()
-@@ -3071,15 +2967,16 @@
+@@ -3071,15 +2969,16 @@
              {
                  if (Keyboard.getEventKeyState())
                  {
@@ -520,7 +529,7 @@
              }
          }
      }
-@@ -3199,6 +3096,12 @@
+@@ -3199,6 +3098,12 @@
          return this.field_184127_aH;
      }
  

--- a/patches/minecraft/net/minecraft/network/play/server/SPacketChunkData.java.patch
+++ b/patches/minecraft/net/minecraft/network/play/server/SPacketChunkData.java.patch
@@ -1,0 +1,10 @@
+--- ../src-base/minecraft/net/minecraft/network/play/server/SPacketChunkData.java
++++ ../src-work/minecraft/net/minecraft/network/play/server/SPacketChunkData.java
+@@ -32,6 +32,7 @@
+ 
+     public SPacketChunkData(Chunk p_i47124_1_, int p_i47124_2_)
+     {
++        p_i47124_1_.func_177412_p().lightingEngine.procLightUpdates();
+         this.field_149284_a = p_i47124_1_.field_76635_g;
+         this.field_149282_b = p_i47124_1_.field_76647_h;
+         this.field_149279_g = p_i47124_2_ == 65535;

--- a/patches/minecraft/net/minecraft/world/World.java.patch
+++ b/patches/minecraft/net/minecraft/world/World.java.patch
@@ -17,7 +17,7 @@
      private int field_181546_a = 63;
      protected boolean field_72999_e;
      public final List<Entity> field_72996_f = Lists.<Entity>newArrayList();
-@@ -102,6 +109,12 @@
+@@ -102,6 +109,13 @@
      private final WorldBorder field_175728_M;
      int[] field_72994_J;
  
@@ -26,19 +26,21 @@
 +    public java.util.ArrayList<net.minecraftforge.common.util.BlockSnapshot> capturedBlockSnapshots = new java.util.ArrayList<net.minecraftforge.common.util.BlockSnapshot>();
 +    private net.minecraftforge.common.capabilities.CapabilityDispatcher capabilities;
 +    private net.minecraftforge.common.util.WorldCapabilityData capabilityData;
++    public final net.minecraftforge.common.lighting.LightingEngine lightingEngine;
 +
      protected World(ISaveHandler p_i45749_1_, WorldInfo p_i45749_2_, WorldProvider p_i45749_3_, Profiler p_i45749_4_, boolean p_i45749_5_)
      {
          this.field_73021_x = Lists.newArrayList(new IWorldEventListener[] {this.field_184152_t});
-@@ -116,6 +129,7 @@
+@@ -116,6 +130,8 @@
          this.field_73011_w = p_i45749_3_;
          this.field_72995_K = p_i45749_5_;
          this.field_175728_M = p_i45749_3_.func_177501_r();
 +        perWorldStorage = new MapStorage((ISaveHandler)null);
++        this.lightingEngine = new net.minecraftforge.common.lighting.LightingEngine(this);
      }
  
      public World func_175643_b()
-@@ -125,6 +139,11 @@
+@@ -125,6 +141,11 @@
  
      public Biome func_180494_b(final BlockPos p_180494_1_)
      {
@@ -50,7 +52,7 @@
          if (this.func_175667_e(p_180494_1_))
          {
              Chunk chunk = this.func_175726_f(p_180494_1_);
-@@ -201,7 +220,7 @@
+@@ -201,7 +222,7 @@
  
      public boolean func_175623_d(BlockPos p_175623_1_)
      {
@@ -59,7 +61,7 @@
      }
  
      public boolean func_175667_e(BlockPos p_175667_1_)
-@@ -302,24 +321,50 @@
+@@ -302,24 +323,50 @@
          else
          {
              Chunk chunk = this.func_175726_f(p_180501_1_);
@@ -113,7 +115,7 @@
                      this.func_184138_a(p_180501_1_, iblockstate, p_180501_2_, p_180501_3_);
                  }
  
-@@ -336,8 +381,6 @@
+@@ -336,8 +383,6 @@
                  {
                      this.func_190522_c(p_180501_1_, block);
                  }
@@ -122,7 +124,7 @@
              }
          }
      }
-@@ -352,7 +395,7 @@
+@@ -352,7 +397,7 @@
          IBlockState iblockstate = this.func_180495_p(p_175655_1_);
          Block block = iblockstate.func_177230_c();
  
@@ -131,7 +133,7 @@
          {
              return false;
          }
-@@ -435,6 +478,9 @@
+@@ -435,6 +480,9 @@
  
      public void func_175685_c(BlockPos p_175685_1_, Block p_175685_2_, boolean p_175685_3_)
      {
@@ -141,7 +143,7 @@
          this.func_190524_a(p_175685_1_.func_177976_e(), p_175685_2_, p_175685_1_);
          this.func_190524_a(p_175685_1_.func_177974_f(), p_175685_2_, p_175685_1_);
          this.func_190524_a(p_175685_1_.func_177977_b(), p_175685_2_, p_175685_1_);
-@@ -450,6 +496,11 @@
+@@ -450,6 +498,11 @@
  
      public void func_175695_a(BlockPos p_175695_1_, Block p_175695_2_, EnumFacing p_175695_3_)
      {
@@ -153,7 +155,7 @@
          if (p_175695_3_ != EnumFacing.WEST)
          {
              this.func_190524_a(p_175695_1_.func_177976_e(), p_175695_2_, p_175695_1_);
-@@ -521,11 +572,11 @@
+@@ -521,11 +574,11 @@
          {
              IBlockState iblockstate = this.func_180495_p(p_190529_1_);
  
@@ -167,7 +169,7 @@
                  }
                  catch (Throwable throwable)
                  {
-@@ -582,7 +633,7 @@
+@@ -582,7 +635,7 @@
                  {
                      IBlockState iblockstate = this.func_180495_p(blockpos);
  
@@ -176,7 +178,7 @@
                      {
                          return false;
                      }
-@@ -856,7 +907,7 @@
+@@ -856,7 +909,7 @@
  
      public boolean func_72935_r()
      {
@@ -185,7 +187,7 @@
      }
  
      @Nullable
-@@ -1059,6 +1110,13 @@
+@@ -1059,6 +1112,13 @@
  
      public void func_184148_a(@Nullable EntityPlayer p_184148_1_, double p_184148_2_, double p_184148_4_, double p_184148_6_, SoundEvent p_184148_8_, SoundCategory p_184148_9_, float p_184148_10_, float p_184148_11_)
      {
@@ -199,7 +201,7 @@
          for (int i = 0; i < this.field_73021_x.size(); ++i)
          {
              ((IWorldEventListener)this.field_73021_x.get(i)).func_184375_a(p_184148_1_, p_184148_8_, p_184148_9_, p_184148_2_, p_184148_4_, p_184148_6_, p_184148_10_, p_184148_11_);
-@@ -1112,6 +1170,9 @@
+@@ -1112,6 +1172,9 @@
  
      public boolean func_72838_d(Entity p_72838_1_)
      {
@@ -209,7 +211,7 @@
          int i = MathHelper.func_76128_c(p_72838_1_.field_70165_t / 16.0D);
          int j = MathHelper.func_76128_c(p_72838_1_.field_70161_v / 16.0D);
          boolean flag = p_72838_1_.field_98038_p;
-@@ -1134,6 +1195,8 @@
+@@ -1134,6 +1197,8 @@
                  this.func_72854_c();
              }
  
@@ -218,7 +220,7 @@
              this.func_72964_e(i, j).func_76612_a(p_72838_1_);
              this.field_72996_f.add(p_72838_1_);
              this.func_72923_a(p_72838_1_);
-@@ -1262,6 +1325,7 @@
+@@ -1262,6 +1327,7 @@
                                  }
  
                                  iblockstate1.func_185908_a(this, blockpos$pooledmutableblockpos, p_191504_2_, p_191504_4_, p_191504_1_, false);
@@ -226,7 +228,7 @@
  
                                  if (p_191504_3_ && !p_191504_4_.isEmpty())
                                  {
-@@ -1313,11 +1377,10 @@
+@@ -1313,11 +1379,10 @@
                  }
              }
          }
@@ -239,7 +241,7 @@
      public void func_72848_b(IWorldEventListener p_72848_1_)
      {
          this.field_73021_x.remove(p_72848_1_);
-@@ -1355,19 +1418,38 @@
+@@ -1355,19 +1420,38 @@
  
      public int func_72967_a(float p_72967_1_)
      {
@@ -280,7 +282,7 @@
          float f = this.func_72826_c(p_72971_1_);
          float f1 = 1.0F - (MathHelper.func_76134_b(f * ((float)Math.PI * 2F)) * 2.0F + 0.2F);
          f1 = MathHelper.func_76131_a(f1, 0.0F, 1.0F);
-@@ -1380,6 +1462,12 @@
+@@ -1380,6 +1464,12 @@
      @SideOnly(Side.CLIENT)
      public Vec3d func_72833_a(Entity p_72833_1_, float p_72833_2_)
      {
@@ -293,7 +295,7 @@
          float f = this.func_72826_c(p_72833_2_);
          float f1 = MathHelper.func_76134_b(f * ((float)Math.PI * 2F)) * 2.0F + 0.5F;
          f1 = MathHelper.func_76131_a(f1, 0.0F, 1.0F);
-@@ -1387,9 +1475,7 @@
+@@ -1387,9 +1477,7 @@
          int j = MathHelper.func_76128_c(p_72833_1_.field_70163_u);
          int k = MathHelper.func_76128_c(p_72833_1_.field_70161_v);
          BlockPos blockpos = new BlockPos(i, j, k);
@@ -304,7 +306,7 @@
          float f3 = (float)(l >> 16 & 255) / 255.0F;
          float f4 = (float)(l >> 8 & 255) / 255.0F;
          float f5 = (float)(l & 255) / 255.0F;
-@@ -1438,20 +1524,25 @@
+@@ -1438,20 +1526,25 @@
  
      public float func_72826_c(float p_72826_1_)
      {
@@ -333,7 +335,7 @@
      public float func_72929_e(float p_72929_1_)
      {
          float f = this.func_72826_c(p_72929_1_);
-@@ -1461,6 +1552,12 @@
+@@ -1461,6 +1554,12 @@
      @SideOnly(Side.CLIENT)
      public Vec3d func_72824_f(float p_72824_1_)
      {
@@ -346,7 +348,7 @@
          float f = this.func_72826_c(p_72824_1_);
          float f1 = MathHelper.func_76134_b(f * ((float)Math.PI * 2F)) * 2.0F + 0.5F;
          f1 = MathHelper.func_76131_a(f1, 0.0F, 1.0F);
-@@ -1516,9 +1613,9 @@
+@@ -1516,9 +1615,9 @@
          for (blockpos = new BlockPos(p_175672_1_.func_177958_n(), chunk.func_76625_h() + 16, p_175672_1_.func_177952_p()); blockpos.func_177956_o() >= 0; blockpos = blockpos1)
          {
              blockpos1 = blockpos.func_177977_b();
@@ -358,7 +360,7 @@
              {
                  break;
              }
-@@ -1530,6 +1627,12 @@
+@@ -1530,6 +1629,12 @@
      @SideOnly(Side.CLIENT)
      public float func_72880_h(float p_72880_1_)
      {
@@ -371,7 +373,7 @@
          float f = this.func_72826_c(p_72880_1_);
          float f1 = 1.0F - (MathHelper.func_76134_b(f * ((float)Math.PI * 2F)) * 2.0F + 0.25F);
          f1 = MathHelper.func_76131_a(f1, 0.0F, 1.0F);
-@@ -1564,6 +1667,7 @@
+@@ -1564,6 +1669,7 @@
  
              try
              {
@@ -379,7 +381,7 @@
                  ++entity.field_70173_aa;
                  entity.func_70071_h_();
              }
-@@ -1581,6 +1685,12 @@
+@@ -1581,6 +1687,12 @@
                      entity.func_85029_a(crashreportcategory);
                  }
  
@@ -392,7 +394,7 @@
                  throw new ReportedException(crashreport);
              }
  
-@@ -1642,6 +1752,12 @@
+@@ -1642,6 +1754,12 @@
                      CrashReport crashreport1 = CrashReport.func_85055_a(throwable1, "Ticking entity");
                      CrashReportCategory crashreportcategory1 = crashreport1.func_85058_a("Entity being ticked");
                      entity2.func_85029_a(crashreportcategory1);
@@ -405,7 +407,7 @@
                      throw new ReportedException(crashreport1);
                  }
              }
-@@ -1678,11 +1794,11 @@
+@@ -1678,11 +1796,11 @@
              {
                  BlockPos blockpos = tileentity.func_174877_v();
  
@@ -419,7 +421,7 @@
                          ((ITickable)tileentity).func_73660_a();
                          this.field_72984_F.func_76319_b();
                      }
-@@ -1691,6 +1807,13 @@
+@@ -1691,6 +1809,13 @@
                          CrashReport crashreport2 = CrashReport.func_85055_a(throwable, "Ticking block entity");
                          CrashReportCategory crashreportcategory2 = crashreport2.func_85058_a("Block entity being ticked");
                          tileentity.func_145828_a(crashreportcategory2);
@@ -433,7 +435,7 @@
                          throw new ReportedException(crashreport2);
                      }
                  }
-@@ -1703,20 +1826,28 @@
+@@ -1703,20 +1828,28 @@
  
                  if (this.func_175667_e(tileentity.func_174877_v()))
                  {
@@ -465,7 +467,7 @@
          this.field_72984_F.func_76318_c("pendingBlockEntities");
  
          if (!this.field_147484_a.isEmpty())
-@@ -1755,12 +1886,18 @@
+@@ -1755,12 +1888,18 @@
  
      public boolean func_175700_a(TileEntity p_175700_1_)
      {
@@ -484,7 +486,7 @@
  
          if (this.field_72995_K)
          {
-@@ -1776,6 +1913,11 @@
+@@ -1776,6 +1915,11 @@
      {
          if (this.field_147481_N)
          {
@@ -496,7 +498,7 @@
              this.field_147484_a.addAll(p_147448_1_);
          }
          else
-@@ -1796,9 +1938,12 @@
+@@ -1796,9 +1940,12 @@
      {
          int i = MathHelper.func_76128_c(p_72866_1_.field_70165_t);
          int j = MathHelper.func_76128_c(p_72866_1_.field_70161_v);
@@ -511,7 +513,7 @@
          {
              p_72866_1_.field_70142_S = p_72866_1_.field_70165_t;
              p_72866_1_.field_70137_T = p_72866_1_.field_70163_u;
-@@ -1816,6 +1961,7 @@
+@@ -1816,6 +1963,7 @@
                  }
                  else
                  {
@@ -519,7 +521,7 @@
                      p_72866_1_.func_70071_h_();
                  }
              }
-@@ -1997,6 +2143,11 @@
+@@ -1997,6 +2145,11 @@
                              blockpos$pooledmutableblockpos.func_185344_t();
                              return true;
                          }
@@ -531,7 +533,7 @@
                      }
                  }
              }
-@@ -2036,6 +2187,16 @@
+@@ -2036,6 +2189,16 @@
                          IBlockState iblockstate = this.func_180495_p(blockpos$pooledmutableblockpos);
                          Block block = iblockstate.func_177230_c();
  
@@ -548,7 +550,7 @@
                          if (iblockstate.func_185904_a() == p_72918_2_)
                          {
                              double d0 = (double)((float)(l1 + 1) - BlockLiquid.func_149801_b(((Integer)iblockstate.func_177229_b(BlockLiquid.field_176367_b)).intValue()));
-@@ -2102,6 +2263,7 @@
+@@ -2102,6 +2265,7 @@
      public Explosion func_72885_a(@Nullable Entity p_72885_1_, double p_72885_2_, double p_72885_4_, double p_72885_6_, float p_72885_8_, boolean p_72885_9_, boolean p_72885_10_)
      {
          Explosion explosion = new Explosion(this, p_72885_1_, p_72885_2_, p_72885_4_, p_72885_6_, p_72885_8_, p_72885_9_, p_72885_10_);
@@ -556,7 +558,7 @@
          explosion.func_77278_a();
          explosion.func_77279_a(true);
          return explosion;
-@@ -2224,6 +2386,7 @@
+@@ -2224,6 +2388,7 @@
  
      public void func_175690_a(BlockPos p_175690_1_, @Nullable TileEntity p_175690_2_)
      {
@@ -564,7 +566,7 @@
          if (!this.func_189509_E(p_175690_1_))
          {
              if (p_175690_2_ != null && !p_175690_2_.func_145837_r())
-@@ -2231,6 +2394,8 @@
+@@ -2231,6 +2396,8 @@
                  if (this.field_147481_N)
                  {
                      p_175690_2_.func_174878_a(p_175690_1_);
@@ -573,7 +575,7 @@
                      Iterator<TileEntity> iterator = this.field_147484_a.iterator();
  
                      while (iterator.hasNext())
-@@ -2248,7 +2413,8 @@
+@@ -2248,7 +2415,8 @@
                  }
                  else
                  {
@@ -583,7 +585,7 @@
                      this.func_175700_a(p_175690_2_);
                  }
              }
-@@ -2263,6 +2429,8 @@
+@@ -2263,6 +2431,8 @@
          {
              tileentity.func_145843_s();
              this.field_147484_a.remove(tileentity);
@@ -592,7 +594,7 @@
          }
          else
          {
-@@ -2275,6 +2443,7 @@
+@@ -2275,6 +2445,7 @@
  
              this.func_175726_f(p_175713_1_).func_177425_e(p_175713_1_);
          }
@@ -600,7 +602,7 @@
      }
  
      public void func_147457_a(TileEntity p_147457_1_)
-@@ -2301,7 +2470,7 @@
+@@ -2301,7 +2472,7 @@
              if (chunk != null && !chunk.func_76621_g())
              {
                  IBlockState iblockstate = this.func_180495_p(p_175677_1_);
@@ -609,7 +611,7 @@
              }
              else
              {
-@@ -2324,6 +2493,7 @@
+@@ -2324,6 +2495,7 @@
      {
          this.field_72985_G = p_72891_1_;
          this.field_72992_H = p_72891_2_;
@@ -617,7 +619,7 @@
      }
  
      public void func_72835_b()
-@@ -2333,6 +2503,11 @@
+@@ -2333,6 +2505,11 @@
  
      protected void func_72947_a()
      {
@@ -629,7 +631,7 @@
          if (this.field_72986_A.func_76059_o())
          {
              this.field_73004_o = 1.0F;
-@@ -2346,6 +2521,11 @@
+@@ -2346,6 +2523,11 @@
  
      protected void func_72979_l()
      {
@@ -641,7 +643,7 @@
          if (this.field_73011_w.func_191066_m())
          {
              if (!this.field_72995_K)
-@@ -2470,6 +2650,11 @@
+@@ -2470,6 +2652,11 @@
  
      public boolean func_175670_e(BlockPos p_175670_1_, boolean p_175670_2_)
      {
@@ -653,7 +655,7 @@
          Biome biome = this.func_180494_b(p_175670_1_);
          float f = biome.func_180626_a(p_175670_1_);
  
-@@ -2511,6 +2696,11 @@
+@@ -2511,6 +2698,11 @@
  
      public boolean func_175708_f(BlockPos p_175708_1_, boolean p_175708_2_)
      {
@@ -665,7 +667,7 @@
          Biome biome = this.func_180494_b(p_175708_1_);
          float f = biome.func_180626_a(p_175708_1_);
  
-@@ -2528,7 +2718,7 @@
+@@ -2528,7 +2720,7 @@
              {
                  IBlockState iblockstate = this.func_180495_p(p_175708_1_);
  
@@ -674,7 +676,7 @@
                  {
                      return true;
                  }
-@@ -2560,10 +2750,11 @@
+@@ -2560,10 +2752,11 @@
          else
          {
              IBlockState iblockstate = this.func_180495_p(p_175638_1_);
@@ -689,7 +691,7 @@
              {
                  j = 1;
              }
-@@ -2597,6 +2788,7 @@
+@@ -2597,6 +2790,7 @@
  
                      if (i >= 14)
                      {
@@ -697,7 +699,19 @@
                          return i;
                      }
                  }
-@@ -2662,7 +2854,7 @@
+@@ -2609,6 +2803,11 @@
+ 
+     public boolean func_180500_c(EnumSkyBlock p_180500_1_, BlockPos p_180500_2_)
+     {
++        if (true)
++        {
++            this.lightingEngine.scheduleLightUpdate(p_180500_1_, p_180500_2_);
++            return true;
++        }
+         if (!this.func_175648_a(p_180500_2_, 17, false))
+         {
+             return false;
+@@ -2662,7 +2861,7 @@
                                      int j4 = j2 + enumfacing.func_96559_d();
                                      int k4 = k2 + enumfacing.func_82599_e();
                                      blockpos$pooledmutableblockpos.func_181079_c(i4, j4, k4);
@@ -706,7 +720,7 @@
                                      i3 = this.func_175642_b(p_180500_1_, blockpos$pooledmutableblockpos);
  
                                      if (i3 == l2 - l4 && j < this.field_72994_J.length)
-@@ -2770,10 +2962,10 @@
+@@ -2770,10 +2969,10 @@
      public List<Entity> func_175674_a(@Nullable Entity p_175674_1_, AxisAlignedBB p_175674_2_, @Nullable Predicate <? super Entity > p_175674_3_)
      {
          List<Entity> list = Lists.<Entity>newArrayList();
@@ -721,7 +735,7 @@
  
          for (int i1 = i; i1 <= j; ++i1)
          {
-@@ -2826,10 +3018,10 @@
+@@ -2826,10 +3025,10 @@
  
      public <T extends Entity> List<T> func_175647_a(Class <? extends T > p_175647_1_, AxisAlignedBB p_175647_2_, @Nullable Predicate <? super T > p_175647_3_)
      {
@@ -736,7 +750,7 @@
          List<T> list = Lists.<T>newArrayList();
  
          for (int i1 = i; i1 < j; ++i1)
-@@ -2909,11 +3101,13 @@
+@@ -2909,11 +3108,13 @@
  
      public void func_175650_b(Collection<Entity> p_175650_1_)
      {
@@ -753,7 +767,7 @@
          }
      }
  
-@@ -2926,7 +3120,7 @@
+@@ -2926,7 +3127,7 @@
      {
          IBlockState iblockstate = this.func_180495_p(p_190527_2_);
          AxisAlignedBB axisalignedbb = p_190527_3_ ? null : p_190527_1_.func_176223_P().func_185890_d(this, p_190527_2_);
@@ -762,7 +776,7 @@
      }
  
      public int func_181545_F()
-@@ -3009,7 +3203,7 @@
+@@ -3009,7 +3210,7 @@
      public int func_175651_c(BlockPos p_175651_1_, EnumFacing p_175651_2_)
      {
          IBlockState iblockstate = this.func_180495_p(p_175651_1_);
@@ -771,7 +785,7 @@
      }
  
      public boolean func_175640_z(BlockPos p_175640_1_)
-@@ -3152,6 +3346,8 @@
+@@ -3152,6 +3353,8 @@
                      d2 *= ((Double)Objects.firstNonNull(p_184150_11_.apply(entityplayer1), Double.valueOf(1.0D))).doubleValue();
                  }
  
@@ -780,7 +794,7 @@
                  if ((p_184150_9_ < 0.0D || Math.abs(entityplayer1.field_70163_u - p_184150_3_) < p_184150_9_ * p_184150_9_) && (p_184150_7_ < 0.0D || d1 < d2 * d2) && (d0 == -1.0D || d1 < d0))
                  {
                      d0 = d1;
-@@ -3213,7 +3409,7 @@
+@@ -3213,7 +3416,7 @@
  
      public long func_72905_C()
      {
@@ -789,7 +803,7 @@
      }
  
      public long func_82737_E()
-@@ -3223,17 +3419,17 @@
+@@ -3223,17 +3426,17 @@
  
      public long func_72820_D()
      {
@@ -810,7 +824,7 @@
  
          if (!this.func_175723_af().func_177746_a(blockpos))
          {
-@@ -3245,7 +3441,7 @@
+@@ -3245,7 +3448,7 @@
  
      public void func_175652_B(BlockPos p_175652_1_)
      {
@@ -819,7 +833,7 @@
      }
  
      @SideOnly(Side.CLIENT)
-@@ -3265,12 +3461,18 @@
+@@ -3265,12 +3468,18 @@
  
          if (!this.field_72996_f.contains(p_72897_1_))
          {
@@ -838,7 +852,7 @@
          return true;
      }
  
-@@ -3364,8 +3566,7 @@
+@@ -3364,8 +3573,7 @@
  
      public boolean func_180502_D(BlockPos p_180502_1_)
      {
@@ -848,7 +862,7 @@
      }
  
      @Nullable
-@@ -3426,12 +3627,12 @@
+@@ -3426,12 +3634,12 @@
  
      public int func_72800_K()
      {
@@ -863,7 +877,7 @@
      }
  
      public Random func_72843_D(int p_72843_1_, int p_72843_2_, int p_72843_3_)
-@@ -3475,7 +3676,7 @@
+@@ -3475,7 +3683,7 @@
      @SideOnly(Side.CLIENT)
      public double func_72919_O()
      {
@@ -872,7 +886,7 @@
      }
  
      public void func_175715_c(int p_175715_1_, BlockPos p_175715_2_, int p_175715_3_)
-@@ -3509,7 +3710,7 @@
+@@ -3509,7 +3717,7 @@
  
      public void func_175666_e(BlockPos p_175666_1_, Block p_175666_2_)
      {
@@ -881,7 +895,7 @@
          {
              BlockPos blockpos = p_175666_1_.func_177972_a(enumfacing);
  
-@@ -3517,18 +3718,14 @@
+@@ -3517,18 +3725,14 @@
              {
                  IBlockState iblockstate = this.func_180495_p(blockpos);
  
@@ -904,7 +918,7 @@
                      }
                  }
              }
-@@ -3594,6 +3791,115 @@
+@@ -3594,6 +3798,115 @@
          return i >= -128 && i <= 128 && j >= -128 && j <= 128;
      }
  

--- a/patches/minecraft/net/minecraft/world/chunk/Chunk.java.patch
+++ b/patches/minecraft/net/minecraft/world/chunk/Chunk.java.patch
@@ -65,7 +65,14 @@
  
                      if (j1 > 0)
                      {
-@@ -600,28 +606,19 @@
+@@ -594,34 +600,25 @@
+                         this.func_76615_h(i, j, k);
+                     }
+ 
+-                    if (j1 != k1 && (j1 < k1 || this.func_177413_a(EnumSkyBlock.SKY, p_177436_1_) > 0 || this.func_177413_a(EnumSkyBlock.BLOCK, p_177436_1_) > 0))
++                    if (false) //TODO: Wait for proper fix
+                     {
+                         this.func_76595_e(i, k);
                      }
                  }
  
@@ -98,7 +105,28 @@
                          this.field_76637_e.func_175690_a(p_177436_1_, tileentity1);
                      }
  
-@@ -725,6 +722,7 @@
+@@ -639,6 +636,12 @@
+ 
+     public int func_177413_a(EnumSkyBlock p_177413_1_, BlockPos p_177413_2_)
+     {
++        this.field_76637_e.lightingEngine.procLightUpdates(p_177413_1_);
++        return this.getCachedLightFor(p_177413_1_, p_177413_2_);
++    }
++
++    public int getCachedLightFor(EnumSkyBlock p_177413_1_, BlockPos p_177413_2_)
++    {
+         int i = p_177413_2_.func_177958_n() & 15;
+         int j = p_177413_2_.func_177956_o();
+         int k = p_177413_2_.func_177952_p() & 15;
+@@ -677,6 +680,7 @@
+ 
+     public int func_177443_a(BlockPos p_177443_1_, int p_177443_2_)
+     {
++        this.field_76637_e.lightingEngine.procLightUpdates();
+         int i = p_177443_1_.func_177958_n() & 15;
+         int j = p_177443_1_.func_177956_o();
+         int k = p_177443_1_.func_177952_p() & 15;
+@@ -725,6 +729,7 @@
              k = this.field_76645_j.length - 1;
          }
  
@@ -106,7 +134,7 @@
          p_76612_1_.field_70175_ag = true;
          p_76612_1_.field_70176_ah = this.field_76635_g;
          p_76612_1_.field_70162_ai = k;
-@@ -765,7 +763,7 @@
+@@ -765,7 +770,7 @@
      {
          IBlockState iblockstate = this.func_177435_g(p_177422_1_);
          Block block = iblockstate.func_177230_c();
@@ -115,7 +143,7 @@
      }
  
      @Nullable
-@@ -773,6 +771,12 @@
+@@ -773,6 +778,12 @@
      {
          TileEntity tileentity = (TileEntity)this.field_150816_i.get(p_177424_1_);
  
@@ -128,7 +156,7 @@
          if (tileentity == null)
          {
              if (p_177424_2_ == Chunk.EnumCreateEntityType.IMMEDIATE)
-@@ -782,14 +786,9 @@
+@@ -782,14 +793,9 @@
              }
              else if (p_177424_2_ == Chunk.EnumCreateEntityType.QUEUED)
              {
@@ -144,7 +172,7 @@
  
          return tileentity;
      }
-@@ -806,10 +805,11 @@
+@@ -806,10 +812,11 @@
  
      public void func_177426_a(BlockPos p_177426_1_, TileEntity p_177426_2_)
      {
@@ -157,7 +185,7 @@
          {
              if (this.field_150816_i.containsKey(p_177426_1_))
              {
-@@ -841,8 +841,9 @@
+@@ -841,8 +848,9 @@
  
          for (ClassInheritanceMultiMap<Entity> classinheritancemultimap : this.field_76645_j)
          {
@@ -168,7 +196,7 @@
      }
  
      public void func_76623_d()
-@@ -858,6 +859,7 @@
+@@ -858,6 +866,7 @@
          {
              this.field_76637_e.func_175681_c(classinheritancemultimap);
          }
@@ -176,7 +204,7 @@
      }
  
      public void func_76630_e()
-@@ -867,8 +869,8 @@
+@@ -867,8 +876,8 @@
  
      public void func_177414_a(@Nullable Entity p_177414_1_, AxisAlignedBB p_177414_2_, List<Entity> p_177414_3_, Predicate <? super Entity > p_177414_4_)
      {
@@ -187,7 +215,7 @@
          i = MathHelper.func_76125_a(i, 0, this.field_76645_j.length - 1);
          j = MathHelper.func_76125_a(j, 0, this.field_76645_j.length - 1);
  
-@@ -905,8 +907,8 @@
+@@ -905,8 +914,8 @@
  
      public <T extends Entity> void func_177430_a(Class <? extends T > p_177430_1_, AxisAlignedBB p_177430_2_, List<T> p_177430_3_, Predicate <? super T > p_177430_4_)
      {
@@ -198,7 +226,7 @@
          i = MathHelper.func_76125_a(i, 0, this.field_76645_j.length - 1);
          j = MathHelper.func_76125_a(j, 0, this.field_76645_j.length - 1);
  
-@@ -984,6 +986,8 @@
+@@ -984,6 +993,8 @@
  
      protected void func_186034_a(IChunkGenerator p_186034_1_)
      {
@@ -207,7 +235,7 @@
          if (this.func_177419_t())
          {
              if (p_186034_1_.func_185933_a(this, this.field_76635_g, this.field_76647_h))
-@@ -995,8 +999,10 @@
+@@ -995,8 +1006,10 @@
          {
              this.func_150809_p();
              p_186034_1_.func_185931_b(this.field_76635_g, this.field_76647_h);
@@ -218,7 +246,7 @@
      }
  
      public BlockPos func_177440_h(BlockPos p_177440_1_)
-@@ -1051,7 +1057,7 @@
+@@ -1051,7 +1064,7 @@
          {
              BlockPos blockpos = (BlockPos)this.field_177447_w.poll();
  
@@ -227,7 +255,7 @@
              {
                  TileEntity tileentity = this.func_177422_i(blockpos);
                  this.field_76637_e.func_175690_a(blockpos, tileentity);
-@@ -1115,6 +1121,13 @@
+@@ -1115,6 +1128,13 @@
      @SideOnly(Side.CLIENT)
      public void func_186033_a(PacketBuffer p_186033_1_, int p_186033_2_, boolean p_186033_3_)
      {
@@ -241,7 +269,7 @@
          boolean flag = this.field_76637_e.field_73011_w.func_191066_m();
  
          for (int i = 0; i < this.field_76652_q.length; ++i)
-@@ -1163,10 +1176,16 @@
+@@ -1163,10 +1183,16 @@
          this.field_76646_k = true;
          this.func_76590_a();
  
@@ -258,7 +286,7 @@
      }
  
      public Biome func_177411_a(BlockPos p_177411_1_, BiomeProvider p_177411_2_)
-@@ -1231,13 +1250,13 @@
+@@ -1231,13 +1257,13 @@
                      BlockPos blockpos1 = blockpos.func_177982_a(k, (j << 4) + i1, l);
                      boolean flag = i1 == 0 || i1 == 15 || k == 0 || k == 15 || l == 0 || l == 15;
  
@@ -274,7 +302,7 @@
                              {
                                  this.field_76637_e.func_175664_x(blockpos2);
                              }
-@@ -1368,7 +1387,7 @@
+@@ -1368,7 +1394,7 @@
          {
              blockpos$mutableblockpos.func_181079_c(blockpos$mutableblockpos.func_177958_n(), l, blockpos$mutableblockpos.func_177952_p());
  
@@ -283,7 +311,7 @@
              {
                  this.field_76637_e.func_175664_x(blockpos$mutableblockpos);
              }
-@@ -1476,4 +1495,34 @@
+@@ -1476,4 +1502,34 @@
          QUEUED,
          CHECK;
      }

--- a/patches/minecraft/net/minecraft/world/chunk/Chunk.java.patch
+++ b/patches/minecraft/net/minecraft/world/chunk/Chunk.java.patch
@@ -9,7 +9,32 @@
                      {
                          this.field_76634_f[k << 4 | j] = l;
  
-@@ -451,12 +451,13 @@
+@@ -358,13 +358,15 @@
+ 
+         if (j != i)
+         {
+-            this.field_76637_e.func_72975_g(p_76615_1_ + this.field_76635_g * 16, p_76615_3_ + this.field_76647_h * 16, j, i);
++            if (false) this.field_76637_e.func_72975_g(p_76615_1_ + this.field_76635_g * 16, p_76615_3_ + this.field_76647_h * 16, j, i); //Forge: Useless, since heightMap is not updated yet (See #3871)
+             this.field_76634_f[p_76615_3_ << 4 | p_76615_1_] = j;
+             int k = this.field_76635_g * 16 + p_76615_1_;
+             int l = this.field_76647_h * 16 + p_76615_3_;
+ 
+             if (this.field_76637_e.field_73011_w.func_191066_m())
+             {
++                net.minecraftforge.common.lighting.LightingHooks.relightSkylightColumn(this.field_76637_e, this, p_76615_1_, p_76615_3_, i, j);
++            } else if (false) { //Forge: Don't mess up the light cache; World.checkLight already does all necessary steps (See #3871)
+                 if (j < i)
+                 {
+                     for (int j1 = j; j1 < i; ++j1)
+@@ -434,6 +436,7 @@
+             {
+                 this.field_82912_p = l1;
+             }
++            if (true) return; //Forge: Following checks are not needed if the light cache is not messed up (See #3871)
+ 
+             if (this.field_76637_e.field_73011_w.func_191066_m())
+             {
+@@ -451,12 +454,13 @@
  
      public int func_177437_b(BlockPos p_177437_1_)
      {
@@ -25,7 +50,7 @@
      }
  
      public IBlockState func_177435_g(BlockPos p_177435_1_)
-@@ -538,6 +539,7 @@
+@@ -538,6 +542,7 @@
          {
              Block block = p_177436_2_.func_177230_c();
              Block block1 = iblockstate.func_177230_c();
@@ -33,7 +58,7 @@
              ExtendedBlockStorage extendedblockstorage = this.field_76652_q[j >> 4];
              boolean flag = false;
  
-@@ -555,14 +557,19 @@
+@@ -555,14 +560,19 @@
  
              extendedblockstorage.func_177484_a(i, j & 15, k, p_177436_2_);
  
@@ -55,7 +80,7 @@
                      this.field_76637_e.func_175713_t(p_177436_1_);
                  }
              }
-@@ -579,8 +586,7 @@
+@@ -579,8 +589,7 @@
                  }
                  else
                  {
@@ -65,12 +90,12 @@
  
                      if (j1 > 0)
                      {
-@@ -594,34 +600,25 @@
+@@ -594,34 +603,25 @@
                          this.func_76615_h(i, j, k);
                      }
  
 -                    if (j1 != k1 && (j1 < k1 || this.func_177413_a(EnumSkyBlock.SKY, p_177436_1_) > 0 || this.func_177413_a(EnumSkyBlock.BLOCK, p_177436_1_) > 0))
-+                    if (false) //TODO: Wait for proper fix
++                    if (false) //Forge: Error correction is unnecessary as these are fixed (See #3871)
                      {
                          this.func_76595_e(i, k);
                      }
@@ -105,7 +130,7 @@
                          this.field_76637_e.func_175690_a(p_177436_1_, tileentity1);
                      }
  
-@@ -639,6 +636,12 @@
+@@ -639,6 +639,12 @@
  
      public int func_177413_a(EnumSkyBlock p_177413_1_, BlockPos p_177413_2_)
      {
@@ -118,7 +143,7 @@
          int i = p_177413_2_.func_177958_n() & 15;
          int j = p_177413_2_.func_177956_o();
          int k = p_177413_2_.func_177952_p() & 15;
-@@ -677,6 +680,7 @@
+@@ -677,6 +683,7 @@
  
      public int func_177443_a(BlockPos p_177443_1_, int p_177443_2_)
      {
@@ -126,7 +151,7 @@
          int i = p_177443_1_.func_177958_n() & 15;
          int j = p_177443_1_.func_177956_o();
          int k = p_177443_1_.func_177952_p() & 15;
-@@ -725,6 +729,7 @@
+@@ -725,6 +732,7 @@
              k = this.field_76645_j.length - 1;
          }
  
@@ -134,7 +159,7 @@
          p_76612_1_.field_70175_ag = true;
          p_76612_1_.field_70176_ah = this.field_76635_g;
          p_76612_1_.field_70162_ai = k;
-@@ -765,7 +770,7 @@
+@@ -765,7 +773,7 @@
      {
          IBlockState iblockstate = this.func_177435_g(p_177422_1_);
          Block block = iblockstate.func_177230_c();
@@ -143,7 +168,7 @@
      }
  
      @Nullable
-@@ -773,6 +778,12 @@
+@@ -773,6 +781,12 @@
      {
          TileEntity tileentity = (TileEntity)this.field_150816_i.get(p_177424_1_);
  
@@ -156,7 +181,7 @@
          if (tileentity == null)
          {
              if (p_177424_2_ == Chunk.EnumCreateEntityType.IMMEDIATE)
-@@ -782,14 +793,9 @@
+@@ -782,14 +796,9 @@
              }
              else if (p_177424_2_ == Chunk.EnumCreateEntityType.QUEUED)
              {
@@ -172,7 +197,7 @@
  
          return tileentity;
      }
-@@ -806,10 +812,11 @@
+@@ -806,10 +815,11 @@
  
      public void func_177426_a(BlockPos p_177426_1_, TileEntity p_177426_2_)
      {
@@ -185,7 +210,7 @@
          {
              if (this.field_150816_i.containsKey(p_177426_1_))
              {
-@@ -841,8 +848,9 @@
+@@ -841,8 +851,9 @@
  
          for (ClassInheritanceMultiMap<Entity> classinheritancemultimap : this.field_76645_j)
          {
@@ -196,7 +221,7 @@
      }
  
      public void func_76623_d()
-@@ -858,6 +866,7 @@
+@@ -858,6 +869,7 @@
          {
              this.field_76637_e.func_175681_c(classinheritancemultimap);
          }
@@ -204,7 +229,7 @@
      }
  
      public void func_76630_e()
-@@ -867,8 +876,8 @@
+@@ -867,8 +879,8 @@
  
      public void func_177414_a(@Nullable Entity p_177414_1_, AxisAlignedBB p_177414_2_, List<Entity> p_177414_3_, Predicate <? super Entity > p_177414_4_)
      {
@@ -215,7 +240,7 @@
          i = MathHelper.func_76125_a(i, 0, this.field_76645_j.length - 1);
          j = MathHelper.func_76125_a(j, 0, this.field_76645_j.length - 1);
  
-@@ -905,8 +914,8 @@
+@@ -905,8 +917,8 @@
  
      public <T extends Entity> void func_177430_a(Class <? extends T > p_177430_1_, AxisAlignedBB p_177430_2_, List<T> p_177430_3_, Predicate <? super T > p_177430_4_)
      {
@@ -226,7 +251,7 @@
          i = MathHelper.func_76125_a(i, 0, this.field_76645_j.length - 1);
          j = MathHelper.func_76125_a(j, 0, this.field_76645_j.length - 1);
  
-@@ -984,6 +993,8 @@
+@@ -984,6 +996,8 @@
  
      protected void func_186034_a(IChunkGenerator p_186034_1_)
      {
@@ -235,7 +260,7 @@
          if (this.func_177419_t())
          {
              if (p_186034_1_.func_185933_a(this, this.field_76635_g, this.field_76647_h))
-@@ -995,8 +1006,10 @@
+@@ -995,8 +1009,10 @@
          {
              this.func_150809_p();
              p_186034_1_.func_185931_b(this.field_76635_g, this.field_76647_h);
@@ -246,7 +271,7 @@
      }
  
      public BlockPos func_177440_h(BlockPos p_177440_1_)
-@@ -1051,7 +1064,7 @@
+@@ -1051,7 +1067,7 @@
          {
              BlockPos blockpos = (BlockPos)this.field_177447_w.poll();
  
@@ -255,7 +280,7 @@
              {
                  TileEntity tileentity = this.func_177422_i(blockpos);
                  this.field_76637_e.func_175690_a(blockpos, tileentity);
-@@ -1115,6 +1128,13 @@
+@@ -1115,6 +1131,13 @@
      @SideOnly(Side.CLIENT)
      public void func_186033_a(PacketBuffer p_186033_1_, int p_186033_2_, boolean p_186033_3_)
      {
@@ -269,7 +294,7 @@
          boolean flag = this.field_76637_e.field_73011_w.func_191066_m();
  
          for (int i = 0; i < this.field_76652_q.length; ++i)
-@@ -1163,10 +1183,16 @@
+@@ -1163,10 +1186,16 @@
          this.field_76646_k = true;
          this.func_76590_a();
  
@@ -286,7 +311,7 @@
      }
  
      public Biome func_177411_a(BlockPos p_177411_1_, BiomeProvider p_177411_2_)
-@@ -1231,13 +1257,13 @@
+@@ -1231,13 +1260,13 @@
                      BlockPos blockpos1 = blockpos.func_177982_a(k, (j << 4) + i1, l);
                      boolean flag = i1 == 0 || i1 == 15 || k == 0 || k == 15 || l == 0 || l == 15;
  
@@ -302,7 +327,7 @@
                              {
                                  this.field_76637_e.func_175664_x(blockpos2);
                              }
-@@ -1368,7 +1394,7 @@
+@@ -1368,7 +1397,7 @@
          {
              blockpos$mutableblockpos.func_181079_c(blockpos$mutableblockpos.func_177958_n(), l, blockpos$mutableblockpos.func_177952_p());
  
@@ -311,7 +336,7 @@
              {
                  this.field_76637_e.func_175664_x(blockpos$mutableblockpos);
              }
-@@ -1476,4 +1502,34 @@
+@@ -1476,4 +1505,34 @@
          QUEUED,
          CHECK;
      }

--- a/patches/minecraft/net/minecraft/world/chunk/Chunk.java.patch
+++ b/patches/minecraft/net/minecraft/world/chunk/Chunk.java.patch
@@ -1,6 +1,14 @@
 --- ../src-base/minecraft/net/minecraft/world/chunk/Chunk.java
 +++ ../src-work/minecraft/net/minecraft/world/chunk/Chunk.java
-@@ -178,7 +178,7 @@
+@@ -67,6 +67,7 @@
+     private int field_76649_t;
+     private final ConcurrentLinkedQueue<BlockPos> field_177447_w;
+     public boolean field_189550_d;
++    public short[] neighborLightChecks = null;
+ 
+     public Chunk(World p_i1995_1_, int p_i1995_2_, int p_i1995_3_)
+     {
+@@ -178,7 +179,7 @@
                  {
                      IBlockState iblockstate = this.func_186032_a(j, l - 1, k);
  
@@ -9,7 +17,7 @@
                      {
                          this.field_76634_f[k << 4 | j] = l;
  
-@@ -358,13 +358,15 @@
+@@ -358,13 +359,15 @@
  
          if (j != i)
          {
@@ -26,7 +34,7 @@
                  if (j < i)
                  {
                      for (int j1 = j; j1 < i; ++j1)
-@@ -434,6 +436,7 @@
+@@ -434,6 +437,7 @@
              {
                  this.field_82912_p = l1;
              }
@@ -34,7 +42,7 @@
  
              if (this.field_76637_e.field_73011_w.func_191066_m())
              {
-@@ -451,12 +454,13 @@
+@@ -451,12 +455,13 @@
  
      public int func_177437_b(BlockPos p_177437_1_)
      {
@@ -50,7 +58,7 @@
      }
  
      public IBlockState func_177435_g(BlockPos p_177435_1_)
-@@ -538,6 +542,7 @@
+@@ -538,6 +543,7 @@
          {
              Block block = p_177436_2_.func_177230_c();
              Block block1 = iblockstate.func_177230_c();
@@ -58,7 +66,7 @@
              ExtendedBlockStorage extendedblockstorage = this.field_76652_q[j >> 4];
              boolean flag = false;
  
-@@ -555,14 +560,19 @@
+@@ -555,14 +561,19 @@
  
              extendedblockstorage.func_177484_a(i, j & 15, k, p_177436_2_);
  
@@ -80,7 +88,7 @@
                      this.field_76637_e.func_175713_t(p_177436_1_);
                  }
              }
-@@ -579,8 +589,7 @@
+@@ -579,8 +590,7 @@
                  }
                  else
                  {
@@ -90,7 +98,7 @@
  
                      if (j1 > 0)
                      {
-@@ -594,34 +603,25 @@
+@@ -594,34 +604,25 @@
                          this.func_76615_h(i, j, k);
                      }
  
@@ -130,7 +138,7 @@
                          this.field_76637_e.func_175690_a(p_177436_1_, tileentity1);
                      }
  
-@@ -639,6 +639,12 @@
+@@ -639,6 +640,12 @@
  
      public int func_177413_a(EnumSkyBlock p_177413_1_, BlockPos p_177413_2_)
      {
@@ -143,7 +151,7 @@
          int i = p_177413_2_.func_177958_n() & 15;
          int j = p_177413_2_.func_177956_o();
          int k = p_177413_2_.func_177952_p() & 15;
-@@ -677,6 +683,7 @@
+@@ -677,6 +684,7 @@
  
      public int func_177443_a(BlockPos p_177443_1_, int p_177443_2_)
      {
@@ -151,7 +159,7 @@
          int i = p_177443_1_.func_177958_n() & 15;
          int j = p_177443_1_.func_177956_o();
          int k = p_177443_1_.func_177952_p() & 15;
-@@ -725,6 +732,7 @@
+@@ -725,6 +733,7 @@
              k = this.field_76645_j.length - 1;
          }
  
@@ -159,7 +167,7 @@
          p_76612_1_.field_70175_ag = true;
          p_76612_1_.field_70176_ah = this.field_76635_g;
          p_76612_1_.field_70162_ai = k;
-@@ -765,7 +773,7 @@
+@@ -765,7 +774,7 @@
      {
          IBlockState iblockstate = this.func_177435_g(p_177422_1_);
          Block block = iblockstate.func_177230_c();
@@ -168,7 +176,7 @@
      }
  
      @Nullable
-@@ -773,6 +781,12 @@
+@@ -773,6 +782,12 @@
      {
          TileEntity tileentity = (TileEntity)this.field_150816_i.get(p_177424_1_);
  
@@ -181,7 +189,7 @@
          if (tileentity == null)
          {
              if (p_177424_2_ == Chunk.EnumCreateEntityType.IMMEDIATE)
-@@ -782,14 +796,9 @@
+@@ -782,14 +797,9 @@
              }
              else if (p_177424_2_ == Chunk.EnumCreateEntityType.QUEUED)
              {
@@ -197,7 +205,7 @@
  
          return tileentity;
      }
-@@ -806,10 +815,11 @@
+@@ -806,10 +816,11 @@
  
      public void func_177426_a(BlockPos p_177426_1_, TileEntity p_177426_2_)
      {
@@ -210,7 +218,7 @@
          {
              if (this.field_150816_i.containsKey(p_177426_1_))
              {
-@@ -841,8 +851,9 @@
+@@ -841,8 +852,10 @@
  
          for (ClassInheritanceMultiMap<Entity> classinheritancemultimap : this.field_76645_j)
          {
@@ -218,10 +226,11 @@
 +            this.field_76637_e.func_175650_b(com.google.common.collect.ImmutableList.copyOf(classinheritancemultimap));
          }
 +        net.minecraftforge.common.MinecraftForge.EVENT_BUS.post(new net.minecraftforge.event.world.ChunkEvent.Load(this));
++        net.minecraftforge.common.lighting.LightingHooks.scheduleRelightChecksForChunkBoundaries(this.field_76637_e, this);
      }
  
      public void func_76623_d()
-@@ -858,6 +869,7 @@
+@@ -858,6 +871,7 @@
          {
              this.field_76637_e.func_175681_c(classinheritancemultimap);
          }
@@ -229,7 +238,7 @@
      }
  
      public void func_76630_e()
-@@ -867,8 +879,8 @@
+@@ -867,8 +881,8 @@
  
      public void func_177414_a(@Nullable Entity p_177414_1_, AxisAlignedBB p_177414_2_, List<Entity> p_177414_3_, Predicate <? super Entity > p_177414_4_)
      {
@@ -240,7 +249,7 @@
          i = MathHelper.func_76125_a(i, 0, this.field_76645_j.length - 1);
          j = MathHelper.func_76125_a(j, 0, this.field_76645_j.length - 1);
  
-@@ -905,8 +917,8 @@
+@@ -905,8 +919,8 @@
  
      public <T extends Entity> void func_177430_a(Class <? extends T > p_177430_1_, AxisAlignedBB p_177430_2_, List<T> p_177430_3_, Predicate <? super T > p_177430_4_)
      {
@@ -251,7 +260,7 @@
          i = MathHelper.func_76125_a(i, 0, this.field_76645_j.length - 1);
          j = MathHelper.func_76125_a(j, 0, this.field_76645_j.length - 1);
  
-@@ -984,6 +996,8 @@
+@@ -984,6 +998,8 @@
  
      protected void func_186034_a(IChunkGenerator p_186034_1_)
      {
@@ -260,7 +269,7 @@
          if (this.func_177419_t())
          {
              if (p_186034_1_.func_185933_a(this, this.field_76635_g, this.field_76647_h))
-@@ -995,8 +1009,10 @@
+@@ -995,8 +1011,10 @@
          {
              this.func_150809_p();
              p_186034_1_.func_185931_b(this.field_76635_g, this.field_76647_h);
@@ -271,7 +280,7 @@
      }
  
      public BlockPos func_177440_h(BlockPos p_177440_1_)
-@@ -1051,7 +1067,7 @@
+@@ -1051,7 +1069,7 @@
          {
              BlockPos blockpos = (BlockPos)this.field_177447_w.poll();
  
@@ -280,7 +289,7 @@
              {
                  TileEntity tileentity = this.func_177422_i(blockpos);
                  this.field_76637_e.func_175690_a(blockpos, tileentity);
-@@ -1115,6 +1131,13 @@
+@@ -1115,6 +1133,13 @@
      @SideOnly(Side.CLIENT)
      public void func_186033_a(PacketBuffer p_186033_1_, int p_186033_2_, boolean p_186033_3_)
      {
@@ -294,7 +303,7 @@
          boolean flag = this.field_76637_e.field_73011_w.func_191066_m();
  
          for (int i = 0; i < this.field_76652_q.length; ++i)
-@@ -1163,10 +1186,16 @@
+@@ -1163,10 +1188,16 @@
          this.field_76646_k = true;
          this.func_76590_a();
  
@@ -311,7 +320,7 @@
      }
  
      public Biome func_177411_a(BlockPos p_177411_1_, BiomeProvider p_177411_2_)
-@@ -1231,13 +1260,13 @@
+@@ -1231,13 +1262,13 @@
                      BlockPos blockpos1 = blockpos.func_177982_a(k, (j << 4) + i1, l);
                      boolean flag = i1 == 0 || i1 == 15 || k == 0 || k == 15 || l == 0 || l == 15;
  
@@ -327,7 +336,7 @@
                              {
                                  this.field_76637_e.func_175664_x(blockpos2);
                              }
-@@ -1368,7 +1397,7 @@
+@@ -1368,7 +1399,7 @@
          {
              blockpos$mutableblockpos.func_181079_c(blockpos$mutableblockpos.func_177958_n(), l, blockpos$mutableblockpos.func_177952_p());
  
@@ -336,7 +345,7 @@
              {
                  this.field_76637_e.func_175664_x(blockpos$mutableblockpos);
              }
-@@ -1476,4 +1505,34 @@
+@@ -1476,4 +1507,34 @@
          QUEUED,
          CHECK;
      }

--- a/patches/minecraft/net/minecraft/world/chunk/storage/AnvilChunkLoader.java.patch
+++ b/patches/minecraft/net/minecraft/world/chunk/storage/AnvilChunkLoader.java.patch
@@ -114,7 +114,15 @@
              this.func_75824_a(p_75816_2_.func_76632_l(), nbttagcompound);
          }
          catch (Exception exception)
-@@ -305,11 +367,20 @@
+@@ -295,6 +357,7 @@
+         }
+ 
+         p_75820_3_.func_74782_a("Sections", nbttaglist);
++        net.minecraftforge.common.lighting.LightingHooks.writeNeighborLightChecksToNBT(p_75820_1_, p_75820_3_);
+         p_75820_3_.func_74773_a("Biomes", p_75820_1_.func_76605_m());
+         p_75820_1_.func_177409_g(false);
+         NBTTagList nbttaglist1 = new NBTTagList();
+@@ -305,11 +368,20 @@
              {
                  NBTTagCompound nbttagcompound2 = new NBTTagCompound();
  
@@ -135,7 +143,7 @@
              }
          }
  
-@@ -318,8 +389,17 @@
+@@ -318,8 +390,17 @@
  
          for (TileEntity tileentity : p_75820_1_.func_177434_r().values())
          {
@@ -153,7 +161,14 @@
          }
  
          p_75820_3_.func_74782_a("TileEntities", nbttaglist2);
-@@ -388,6 +468,12 @@
+@@ -382,12 +463,19 @@
+         }
+ 
+         chunk.func_76602_a(aextendedblockstorage);
++        net.minecraftforge.common.lighting.LightingHooks.readNeighborLightChecksFromNBT(chunk, p_75823_2_);
+ 
+         if (p_75823_2_.func_150297_b("Biomes", 7))
+         {
              chunk.func_76616_a(p_75823_2_.func_74770_j("Biomes"));
          }
  
@@ -166,7 +181,7 @@
          NBTTagList nbttaglist1 = p_75823_2_.func_150295_c("Entities", 10);
  
          for (int j1 = 0; j1 < nbttaglist1.func_74745_c(); ++j1)
-@@ -431,8 +517,6 @@
+@@ -431,8 +519,6 @@
                  p_75823_1_.func_180497_b(new BlockPos(nbttagcompound3.func_74762_e("x"), nbttagcompound3.func_74762_e("y"), nbttagcompound3.func_74762_e("z")), block, nbttagcompound3.func_74762_e("t"), nbttagcompound3.func_74762_e("p"));
              }
          }

--- a/patches/minecraft/net/minecraft/world/chunk/storage/AnvilChunkLoader.java.patch
+++ b/patches/minecraft/net/minecraft/world/chunk/storage/AnvilChunkLoader.java.patch
@@ -66,7 +66,7 @@
          if (!p_75822_4_.func_150297_b("Level", 10))
          {
              field_151505_a.error("Chunk file at {},{} is missing level data, skipping", new Object[] {Integer.valueOf(p_75822_2_), Integer.valueOf(p_75822_3_)});
-@@ -103,10 +143,29 @@
+@@ -103,16 +143,36 @@
                      field_151505_a.error("Chunk file at {},{} is in the wrong location; relocating. (Expected {}, {}, got {}, {})", new Object[] {Integer.valueOf(p_75822_2_), Integer.valueOf(p_75822_3_), Integer.valueOf(p_75822_2_), Integer.valueOf(p_75822_3_), Integer.valueOf(chunk.field_76635_g), Integer.valueOf(chunk.field_76647_h)});
                      nbttagcompound.func_74768_a("xPos", p_75822_2_);
                      nbttagcompound.func_74768_a("zPos", p_75822_3_);
@@ -97,7 +97,14 @@
              }
          }
      }
-@@ -121,7 +180,9 @@
+ 
+     public void func_75816_a(World p_75816_1_, Chunk p_75816_2_) throws MinecraftException, IOException
+     {
++        p_75816_1_.lightingEngine.procLightUpdates();
+         p_75816_1_.func_72906_B();
+ 
+         try
+@@ -121,7 +181,9 @@
              NBTTagCompound nbttagcompound1 = new NBTTagCompound();
              nbttagcompound.func_74782_a("Level", nbttagcompound1);
              nbttagcompound.func_74768_a("DataVersion", 922);
@@ -107,7 +114,7 @@
              this.func_75824_a(p_75816_2_.func_76632_l(), nbttagcompound);
          }
          catch (Exception exception)
-@@ -305,11 +366,20 @@
+@@ -305,11 +367,20 @@
              {
                  NBTTagCompound nbttagcompound2 = new NBTTagCompound();
  
@@ -128,7 +135,7 @@
              }
          }
  
-@@ -318,8 +388,17 @@
+@@ -318,8 +389,17 @@
  
          for (TileEntity tileentity : p_75820_1_.func_177434_r().values())
          {
@@ -146,7 +153,7 @@
          }
  
          p_75820_3_.func_74782_a("TileEntities", nbttaglist2);
-@@ -388,6 +467,12 @@
+@@ -388,6 +468,12 @@
              chunk.func_76616_a(p_75823_2_.func_74770_j("Biomes"));
          }
  
@@ -159,7 +166,7 @@
          NBTTagList nbttaglist1 = p_75823_2_.func_150295_c("Entities", 10);
  
          for (int j1 = 0; j1 < nbttaglist1.func_74745_c(); ++j1)
-@@ -431,8 +516,6 @@
+@@ -431,8 +517,6 @@
                  p_75823_1_.func_180497_b(new BlockPos(nbttagcompound3.func_74762_e("x"), nbttagcompound3.func_74762_e("y"), nbttagcompound3.func_74762_e("z")), block, nbttagcompound3.func_74762_e("t"), nbttagcompound3.func_74762_e("p"));
              }
          }

--- a/src/main/java/net/minecraftforge/common/lighting/LightingEngine.java
+++ b/src/main/java/net/minecraftforge/common/lighting/LightingEngine.java
@@ -1,0 +1,630 @@
+/*
+ * Minecraft Forge
+ * Copyright (c) 2016.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation version 2.1
+ * of the License.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+package net.minecraftforge.common.lighting;
+
+import java.util.ArrayDeque;
+import java.util.Deque;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import net.minecraft.block.state.IBlockState;
+import net.minecraft.client.Minecraft;
+import net.minecraft.profiler.Profiler;
+import net.minecraft.util.EnumFacing;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.math.BlockPos.MutableBlockPos;
+import net.minecraft.util.math.MathHelper;
+import net.minecraft.world.EnumSkyBlock;
+import net.minecraft.world.World;
+import net.minecraft.world.chunk.Chunk;
+
+public class LightingEngine
+{
+    private static final int MAX_SCHEDULED_COUNT = 1 << 22;
+
+    private static final int MAX_LIGHT = 15;
+
+    private static final Logger logger = LogManager.getLogger();
+
+    private final World world;
+    private final Profiler profiler;
+
+    //Layout of longs: [padding(4)] [z(26)] [y(8)] [x(26)]
+    private final PooledLongQueue[] queuedLightUpdates = new PooledLongQueue[EnumSkyBlock.values().length];
+
+    //Layout of longs: see above
+    private final PooledLongQueue[] queuedDarkenings = new PooledLongQueue[MAX_LIGHT + 1];
+    private final PooledLongQueue[] queuedBrightenings = new PooledLongQueue[MAX_LIGHT + 1];
+
+    //Layout of longs: [newLight(4)] [pos(60)]
+    private final PooledLongQueue initialBrightenings = new PooledLongQueue();
+    //Layout of longs: [padding(4)] [pos(60)]
+    private final PooledLongQueue initialDarkenings = new PooledLongQueue();
+
+    private boolean updating = false;
+
+    //Layout parameters
+    //Length of bit segments
+    private static final int
+        lX = 26,
+        lY = 8,
+        lZ = 26,
+        lL = 4;
+
+    //Big segment shifts/positions
+    private static final int
+        sX = 0,
+        sY = sX + lX,
+        sZ = sY + lY,
+        sL = sZ + lZ;
+
+    //Bit segment masks
+    private static final long
+        mX = (1 << lX) - 1,
+        mY = (1 << lY) - 1,
+        mZ = (1 << lZ) - 1,
+        mL = (1 << lL) - 1;
+
+    //Stored light type to reduce amount of method parameters
+    private EnumSkyBlock lightType;
+
+    //Iteration state data
+    //Cache position to avoid allocation of new object each time
+    private final MutableBlockPos curPos = new MutableBlockPos();
+    private PooledLongQueue curQueue;
+    private Chunk curChunk;
+    private long curData;
+
+    //Cached data about neighboring blocks (of tempPos)
+    private boolean isNeighborDataValid = false;
+    private final Chunk[] neighborsChunk = new Chunk[EnumFacing.VALUES.length];
+    private final MutableBlockPos[] neighborsPos = new MutableBlockPos[EnumFacing.VALUES.length];
+    private final int[] neighborsLight = new int[EnumFacing.VALUES.length];
+
+    public LightingEngine(final World world)
+    {
+        this.world = world;
+        this.profiler = world.theProfiler;
+
+        for (int i = 0; i < EnumSkyBlock.values().length; ++i)
+        {
+            this.queuedLightUpdates[i] = new PooledLongQueue();
+        }
+
+        for (int i = 0; i < this.queuedDarkenings.length; ++i)
+        {
+            this.queuedDarkenings[i] = new PooledLongQueue();
+        }
+
+        for (int i = 0; i < this.queuedBrightenings.length; ++i)
+        {
+            this.queuedBrightenings[i] = new PooledLongQueue();
+        }
+
+        for (int i = 0; i < this.neighborsPos.length; ++i)
+        {
+            this.neighborsPos[i] = new MutableBlockPos();
+        }
+    }
+
+    /**
+     * Schedules a light update for the specified light type and position to be processed later by {@link #procLightUpdates(EnumSkyBlock)}
+     */
+    public void scheduleLightUpdate(final EnumSkyBlock lightType, final BlockPos pos)
+    {
+        this.scheduleLightUpdate(lightType, posToLong(pos));
+    }
+
+    /**
+     * Schedules a light update for the specified light type and position to be processed later by {@link #procLightUpdates()}
+     */
+    private void scheduleLightUpdate(final EnumSkyBlock lightType, final long pos)
+    {
+        final PooledLongQueue queue = this.queuedLightUpdates[lightType.ordinal()];
+
+        queue.add(pos);
+
+        //make sure there are not too many queued light updates
+        if (queue.size() >= MAX_SCHEDULED_COUNT)
+        {
+            this.procLightUpdates(lightType);
+        }
+    }
+
+    /**
+     * Calls {@link #procLightUpdates(EnumSkyBlock)} for both light types
+     */
+    public void procLightUpdates()
+    {
+        this.procLightUpdates(EnumSkyBlock.SKY);
+        this.procLightUpdates(EnumSkyBlock.BLOCK);
+    }
+
+    /**
+     * Processes light updates of the given light type
+     */
+    public void procLightUpdates(final EnumSkyBlock lightType)
+    {
+        final PooledLongQueue queue = this.queuedLightUpdates[lightType.ordinal()];
+
+        if (queue.isEmpty())
+        {
+            return;
+        }
+
+        //renderer accesses world unsynchronized, don't modify anything in that case
+        if (this.world.isRemote && !Minecraft.getMinecraft().isCallingFromMinecraftThread())
+        {
+            return;
+        }
+
+        //avoid nested calls
+        if (this.updating)
+        {
+            logger.warn("Trying to access light values during relighting");
+            return;
+        }
+
+        this.updating = true;
+
+        this.profiler.startSection("lighting");
+
+        this.lightType = lightType;
+
+        this.profiler.startSection("checking");
+
+        //process the queued updates and enqueue them for further processing
+        for (this.curQueue = queue; this.nextItem(); )
+        {
+            if (this.curChunk == null)
+            {
+                continue;
+            }
+
+            final int oldLight = this.curToCachedLight();
+            final int newLight = this.calcNewLightFromCur();
+
+            if (oldLight < newLight)
+            {
+                //don't enqueue directly for brightening in order to avoid duplicate scheduling
+                this.initialBrightenings.add(((long) newLight << sL) | this.curData);
+            }
+            else if (oldLight > newLight)
+            {
+                //don't enqueue directly for darkening in order to avoid duplicate scheduling
+                this.initialDarkenings.add(this.curData);
+            }
+        }
+
+        for (this.curQueue = this.initialBrightenings; this.nextItem(); )
+        {
+            final int newLight = (int) (this.curData >> sL & mL);
+
+            if (newLight > this.curToCachedLight())
+            {
+                //Sets the light to newLight to only schedule once
+                this.enqueueBrighteningFromCur(newLight);
+            }
+        }
+
+        for (this.curQueue = this.initialDarkenings; this.nextItem(); )
+        {
+            final int oldLight = this.curToCachedLight();
+
+            if (oldLight != 0)
+            {
+                //Sets the light to 0 to only schedule once
+                this.enqueueDarkening(this.curPos, this.curData, oldLight, this.curChunk);
+            }
+        }
+
+        this.profiler.endSection();
+
+        //Iterate through enqueued updates (brightening and darkening in parallel) from brightest to darkest so that we only need to iterate once
+        for (int curLight = MAX_LIGHT; curLight >= 0; --curLight)
+        {
+            this.profiler.startSection("brightening");
+
+            for (this.curQueue = this.queuedBrightenings[curLight]; this.nextItem(); )
+            {
+                final int oldLight = this.curToCachedLight();
+
+                if (oldLight == curLight) //only process this if nothing else has happened at this position since scheduling
+                {
+                    this.world.notifyLightSet(this.curPos);
+
+                    if (curLight > 1)
+                    {
+                        this.spreadLightFromCur(curLight);
+                    }
+                }
+            }
+
+            this.profiler.endStartSection("darkening");
+
+            for (this.curQueue = this.queuedDarkenings[curLight]; this.nextItem(); )
+            {
+                final IBlockState state = this.curToState();
+                final int luminosity = this.curToLuminosity(state);
+                final int opacity = luminosity >= MAX_LIGHT - 1 ? 1 : this.curToOpac(state); //if luminosity is high enough, opacity is irrelevant
+
+                //only darken neighbors if we indeed became darker
+                if (this.calcNewLightFromCur(luminosity, opacity) < curLight)
+                {
+                    //need to calculate new light value from neighbors IGNORING neighbors which are scheduled for darkening
+                    int newLight = luminosity;
+
+                    this.fetchNeighborDataFromCur();
+
+                    for (final EnumFacing dir : EnumFacing.VALUES)
+                    {
+                        final int index = dir.ordinal();
+
+                        final Chunk nChunk = this.neighborsChunk[index];
+
+                        if (nChunk == null)
+                        {
+                            continue;
+                        }
+
+                        final int nLight = this.neighborsLight[index];
+
+                        if (nLight == 0)
+                        {
+                            continue;
+                        }
+
+                        final MutableBlockPos nPos = this.neighborsPos[index];
+
+                        if (curLight - this.posToOpac(nPos, posToState(nPos, nChunk)) >= nLight) //schedule neighbor for darkening if we possibly light it
+                        {
+                            this.enqueueDarkening(nPos, posToLong(nPos), nLight, nChunk);
+                        }
+                        else //only use for new light calculation if not
+                        {
+                            //if we can't darken the neighbor, no one else can (because of processing order) -> safe to let us be illuminated by it
+                            newLight = Math.max(newLight, nLight - opacity);
+                        }
+                    }
+
+                    //schedule brightening since light level was set to 0
+                    this.enqueueBrighteningFromCur(newLight);
+                }
+                else //we didn't become darker, so we need to re-set our initial light value (was set to 0) and notify neighbors
+                {
+                    this.curChunk.setLightFor(lightType, this.curPos, curLight);
+                    this.spreadLightFromCur(curLight);
+                }
+            }
+
+            this.profiler.endSection();
+        }
+
+        this.profiler.endSection();
+
+        this.updating = false;
+    }
+
+    /**
+     * Gets data for neighbors of <code>curPos</code> and saves the results into neighbor state data members. If a neighbor can't be accessed/doesn't exist, the corresponding entry in <code>neighborChunks</code> is <code>null</code> - others are not reset
+     */
+    private void fetchNeighborDataFromCur()
+    {
+        //only update if curPos was changed
+        if (this.isNeighborDataValid)
+        {
+            return;
+        }
+
+        this.isNeighborDataValid = true;
+
+        for (final EnumFacing dir : EnumFacing.VALUES)
+        {
+            final int index = dir.ordinal();
+
+            final MutableBlockPos nPos = this.neighborsPos[index];
+
+            nPos.setPos(this.curPos);
+            nPos.move(dir);
+
+            if (nPos.getY() == -1 || nPos.getY() == 256)
+            {
+                this.neighborsChunk[index] = null;
+                continue;
+            }
+
+            final Chunk nChunk = this.neighborsChunk[index] = this.posToChunk(nPos);
+
+            if (nChunk != null)
+            {
+                this.neighborsLight[index] = this.posToCachedLight(nPos, nChunk);
+            }
+        }
+    }
+
+    private int calcNewLightFromCur()
+    {
+        final IBlockState state = this.curToState();
+        final int luminosity = this.curToLuminosity(state);
+
+        return this.calcNewLightFromCur(luminosity, luminosity >= MAX_LIGHT - 1 ? 1 : this.curToOpac(state));
+    }
+
+    private int calcNewLightFromCur(final int luminosity, final int opacity)
+    {
+        if (luminosity >= MAX_LIGHT - opacity)
+        {
+            return luminosity;
+        }
+
+        int newLight = luminosity;
+        this.fetchNeighborDataFromCur();
+
+        for (final EnumFacing dir : EnumFacing.VALUES)
+        {
+            final int index = dir.ordinal();
+
+            if (this.neighborsChunk[index] == null)
+            {
+                continue;
+            }
+
+            final int nLight = this.neighborsLight[index];
+
+            newLight = Math.max(nLight - opacity, newLight);
+        }
+
+        return newLight;
+    }
+
+    private void spreadLightFromCur(final int curLight)
+    {
+        this.fetchNeighborDataFromCur();
+
+        for (final EnumFacing dir : EnumFacing.VALUES)
+        {
+            final int index = dir.ordinal();
+
+            final MutableBlockPos nPos = this.neighborsPos[index];
+
+            final Chunk nChunk = this.posToChunk(nPos);
+
+            if (nChunk == null)
+            {
+                continue;
+            }
+
+            final int newLight = curLight - this.posToOpac(nPos, nChunk.getBlockState(nPos));
+
+            if (newLight > this.neighborsLight[index])
+            {
+                this.enqueueBrightening(nPos, posToLong(nPos), newLight, nChunk);
+            }
+        }
+    }
+
+    private void enqueueBrighteningFromCur(final int newLight)
+    {
+        this.enqueueBrightening(this.curPos, this.curData, newLight, this.curChunk);
+    }
+
+    /**
+     * Enqueues the pos for brightening and sets its light value to <code>newLight</code>
+     */
+    private void enqueueBrightening(final BlockPos pos, final long longPos, final int newLight, final Chunk chunk)
+    {
+        this.queuedBrightenings[newLight].add(longPos);
+        chunk.setLightFor(this.lightType, pos, newLight);
+    }
+
+    /**
+     * Enqueues the pos for darkening and sets its light value to 0
+     */
+    private void enqueueDarkening(final BlockPos pos, final long longPos, final int oldLight, final Chunk chunk)
+    {
+        this.queuedDarkenings[oldLight].add(longPos);
+        chunk.setLightFor(this.lightType, pos, 0);
+    }
+
+    private static BlockPos longToPos(final MutableBlockPos pos, final long longPos)
+    {
+        final int posX = (int) (longPos >> sX & mX) - (1 << lX - 1);
+        final int posY = (int) (longPos >> sY & mY);
+        final int posZ = (int) (longPos >> sZ & mZ) - (1 << lZ - 1);
+        return pos.setPos(posX, posY, posZ);
+    }
+
+    private static long posToLong(final BlockPos pos)
+    {
+        return posToLong(pos.getX(), pos.getY(), pos.getZ());
+    }
+
+    private static long posToLong(final long x, final long y, final long z)
+    {
+        return (z + (1 << lZ - 1) << sZ) | (y << sY) | (x + (1 << lX - 1) << sX);
+    }
+
+    /**
+     * Polls a new item from <code>curQueue</code> and fills in state data members
+     *
+     * @return If there was an item to poll
+     */
+    private boolean nextItem()
+    {
+        if (this.curQueue.isEmpty())
+        {
+            return false;
+        }
+
+        this.curData = this.curQueue.poll();
+        this.isNeighborDataValid = false;
+        longToPos(this.curPos, this.curData);
+        this.curChunk = this.curToChunk();
+
+        return true;
+    }
+
+    private int posToCachedLight(final MutableBlockPos pos, final Chunk chunk)
+    {
+        return chunk.getCachedLightFor(this.lightType, pos);
+    }
+
+    private int curToCachedLight()
+    {
+        return this.posToCachedLight(this.curPos, this.curChunk);
+    }
+
+    /**
+     * Calculates the luminosity for <code>curPos</code>, taking into account <code>lightType</code>
+     */
+    private int curToLuminosity(final IBlockState state)
+    {
+        return this.lightType == EnumSkyBlock.SKY
+            ? this.curChunk.canSeeSky(this.curPos)
+            ? EnumSkyBlock.SKY.defaultLightValue
+            : 0
+            : MathHelper.clamp(state.getLightValue(this.world, this.curPos), 0, MAX_LIGHT);
+    }
+
+    private int curToOpac(final IBlockState state)
+    {
+        return this.posToOpac(this.curPos, state);
+    }
+
+    private int posToOpac(final BlockPos pos, final IBlockState state)
+    {
+        return MathHelper.clamp(state.getLightOpacity(this.world, pos), 1, MAX_LIGHT);
+    }
+
+    private IBlockState curToState()
+    {
+        return posToState(this.curPos, this.curChunk);
+    }
+
+    private static IBlockState posToState(final BlockPos pos, final Chunk chunk)
+    {
+        return chunk.getBlockState(pos.getX(), pos.getY(), pos.getZ());
+    }
+
+    private Chunk posToChunk(final BlockPos pos)
+    {
+        return this.world.getChunkProvider().getLoadedChunk(pos.getX() >> 4, pos.getZ() >> 4);
+    }
+
+    private Chunk curToChunk()
+    {
+        return this.posToChunk(this.curPos);
+    }
+
+    //PooledLongQueue code
+    //Implement own queue with pooled segments to reduce allocation costs and reduce idle memory footprint
+
+    private static final int CACHED_QUEUE_SEGMENTS_COUNT = 1 << 12;
+    private static final int QUEUE_SEGMENT_SIZE = 1 << 10;
+
+    private final Deque<PooledLongQueueSegment> segmentPool = new ArrayDeque<PooledLongQueueSegment>();
+
+    private PooledLongQueueSegment getLongQueueSegment()
+    {
+        if (this.segmentPool.isEmpty())
+        {
+            return new PooledLongQueueSegment();
+        }
+
+        return this.segmentPool.pop();
+    }
+
+    private class PooledLongQueueSegment
+    {
+        private final long[] longArray = new long[QUEUE_SEGMENT_SIZE];
+        private int index = 0;
+        private PooledLongQueueSegment next;
+
+        private void release()
+        {
+            this.index = 0;
+            this.next = null;
+
+            if (LightingEngine.this.segmentPool.size() < CACHED_QUEUE_SEGMENTS_COUNT)
+            {
+                LightingEngine.this.segmentPool.push(this);
+            }
+        }
+
+        public PooledLongQueueSegment add(final long val)
+        {
+            PooledLongQueueSegment ret = this;
+
+            if (this.index == QUEUE_SEGMENT_SIZE)
+            {
+                ret = this.next = LightingEngine.this.getLongQueueSegment();
+            }
+
+            ret.longArray[ret.index++] = val;
+            return ret;
+        }
+    }
+
+    private class PooledLongQueue
+    {
+        private PooledLongQueueSegment cur, last;
+        private int size = 0;
+
+        private int index = 0;
+
+        public int size()
+        {
+            return this.size;
+        }
+
+        public boolean isEmpty()
+        {
+            return this.cur == null;
+        }
+
+        public void add(final long val)
+        {
+            if (this.cur == null)
+            {
+                this.cur = this.last = LightingEngine.this.getLongQueueSegment();
+            }
+
+            this.last = this.last.add(val);
+            ++this.size;
+        }
+
+        public long poll()
+        {
+            final long ret = this.cur.longArray[this.index++];
+            --this.size;
+
+            if (this.index == this.cur.index)
+            {
+                this.index = 0;
+                final PooledLongQueueSegment next = this.cur.next;
+                this.cur.release();
+                this.cur = next;
+            }
+
+            return ret;
+        }
+    }
+}

--- a/src/main/java/net/minecraftforge/common/lighting/LightingEngine.java
+++ b/src/main/java/net/minecraftforge/common/lighting/LightingEngine.java
@@ -311,6 +311,7 @@ public class LightingEngine
                 else //we didn't become darker, so we need to re-set our initial light value (was set to 0) and notify neighbors
                 {
                     this.curChunk.setLightFor(lightType, this.curPos, curLight);
+                    this.world.notifyLightSet(this.curPos); //Light didn't change, but asynchronous rendering thread could have seen the temporary 0 value
                     this.spreadLightFromCur(curLight);
                 }
             }

--- a/src/main/java/net/minecraftforge/common/lighting/LightingEngine.java
+++ b/src/main/java/net/minecraftforge/common/lighting/LightingEngine.java
@@ -26,7 +26,6 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import net.minecraft.block.state.IBlockState;
-import net.minecraft.client.Minecraft;
 import net.minecraft.profiler.Profiler;
 import net.minecraft.util.EnumFacing;
 import net.minecraft.util.math.BlockPos;
@@ -35,6 +34,7 @@ import net.minecraft.util.math.MathHelper;
 import net.minecraft.world.EnumSkyBlock;
 import net.minecraft.world.World;
 import net.minecraft.world.chunk.Chunk;
+import net.minecraftforge.fml.common.FMLCommonHandler;
 
 public class LightingEngine
 {
@@ -171,7 +171,7 @@ public class LightingEngine
         }
 
         //renderer accesses world unsynchronized, don't modify anything in that case
-        if (this.world.isRemote && !Minecraft.getMinecraft().isCallingFromMinecraftThread())
+        if (this.world.isRemote && !FMLCommonHandler.instance().getMinecraftThread().isCallingFromMinecraftThread())
         {
             return;
         }

--- a/src/main/java/net/minecraftforge/common/lighting/LightingEngine.java
+++ b/src/main/java/net/minecraftforge/common/lighting/LightingEngine.java
@@ -35,6 +35,7 @@ import net.minecraft.util.math.Vec3i;
 import net.minecraft.world.EnumSkyBlock;
 import net.minecraft.world.World;
 import net.minecraft.world.chunk.Chunk;
+import net.minecraftforge.common.lighting.LightingHooks.EnumBoundaryFacing;
 import net.minecraftforge.fml.common.FMLCommonHandler;
 
 public class LightingEngine
@@ -291,6 +292,7 @@ public class LightingEngine
 
                         if (nChunk == null)
                         {
+                            LightingHooks.flagSecBoundaryForUpdate(this.curChunk, this.curPos, this.lightType, dir, EnumBoundaryFacing.OUT);
                             continue;
                         }
 
@@ -410,6 +412,7 @@ public class LightingEngine
 
             if (this.neighborsChunk[index] == null)
             {
+                LightingHooks.flagSecBoundaryForUpdate(this.curChunk, this.curPos, this.lightType, dir, EnumBoundaryFacing.IN);
                 continue;
             }
 
@@ -435,6 +438,7 @@ public class LightingEngine
 
             if (nChunk == null)
             {
+                LightingHooks.flagSecBoundaryForUpdate(this.curChunk, this.curPos, this.lightType, dir, EnumBoundaryFacing.OUT);
                 continue;
             }
 

--- a/src/main/java/net/minecraftforge/common/lighting/LightingEngine.java
+++ b/src/main/java/net/minecraftforge/common/lighting/LightingEngine.java
@@ -431,7 +431,7 @@ public class LightingEngine
 
             final MutableBlockPos nPos = this.neighborsPos[index];
 
-            final Chunk nChunk = this.posToChunk(nPos);
+            final Chunk nChunk = this.neighborsChunk[index];
 
             if (nChunk == null)
             {

--- a/src/main/java/net/minecraftforge/common/lighting/LightingEngine.java
+++ b/src/main/java/net/minecraftforge/common/lighting/LightingEngine.java
@@ -497,11 +497,12 @@ public class LightingEngine
      */
     private int curToLuminosity(final IBlockState state)
     {
-        return this.lightType == EnumSkyBlock.SKY
-            ? this.curChunk.canSeeSky(this.curPos)
-            ? EnumSkyBlock.SKY.defaultLightValue
-            : 0
-            : MathHelper.clamp(state.getLightValue(this.world, this.curPos), 0, MAX_LIGHT);
+        if (this.lightType == EnumSkyBlock.SKY)
+        {
+            return this.curChunk.canSeeSky(this.curPos) ? EnumSkyBlock.SKY.defaultLightValue : 0;
+        }
+
+        return MathHelper.clamp(state.getLightValue(this.world, this.curPos), 0, MAX_LIGHT);
     }
 
     private int curToOpac(final IBlockState state)

--- a/src/main/java/net/minecraftforge/common/lighting/LightingHooks.java
+++ b/src/main/java/net/minecraftforge/common/lighting/LightingHooks.java
@@ -19,15 +19,26 @@
 
 package net.minecraftforge.common.lighting;
 
+import net.minecraft.nbt.NBTTagCompound;
+import net.minecraft.nbt.NBTTagList;
+import net.minecraft.nbt.NBTTagShort;
 import net.minecraft.util.EnumFacing;
+import net.minecraft.util.EnumFacing.Axis;
+import net.minecraft.util.EnumFacing.AxisDirection;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.EnumSkyBlock;
 import net.minecraft.world.World;
 import net.minecraft.world.chunk.Chunk;
 import net.minecraft.world.chunk.storage.ExtendedBlockStorage;
+import net.minecraftforge.fml.common.FMLLog;
 
 public class LightingHooks
 {
+    private static final EnumSkyBlock[] ENUM_SKY_BLOCK_VALUES = EnumSkyBlock.values();
+    private static final AxisDirection[] ENUM_AXIS_DIRECTION_VALUES = AxisDirection.values();
+
+    public static final int FLAG_COUNT = 32; //2 light types * 4 directions * 2 halves * (inwards + outwards)
+    
     public static void relightSkylightColumn(final World world, final Chunk chunk, final int x, final int z, final int height1, final int height2)
     {
         final int yMin = Math.min(height1, height2);
@@ -38,27 +49,293 @@ public class LightingHooks
         final int xBase = (chunk.xPosition << 4) + x;
         final int zBase = (chunk.zPosition << 4) + z;
 
-        int y;
-        ExtendedBlockStorage section = null;
+        scheduleRelightChecksForColumn(world, EnumSkyBlock.SKY, xBase, zBase, yMin, yMax);
 
-        for (y = yMax; y >= yMin; --y)
+        if (sections[yMin >> 4] == Chunk.NULL_BLOCK_STORAGE && yMin > 0)
         {
-            section = sections[y >> 4];
-
-            if (section == Chunk.NULL_BLOCK_STORAGE)
-            {
-                for (final EnumFacing dir : EnumFacing.HORIZONTALS)
-                {
-                    world.checkLightFor(EnumSkyBlock.SKY, new BlockPos(xBase + dir.getFrontOffsetX(), y, zBase + dir.getFrontOffsetZ()));
-                }
-            }
-
-            world.checkLightFor(EnumSkyBlock.SKY, new BlockPos(xBase, y, zBase));
+            world.checkLightFor(EnumSkyBlock.SKY, new BlockPos(xBase, yMin - 1, zBase));
         }
 
-        if (section == Chunk.NULL_BLOCK_STORAGE && y >= 0)
+        short emptySections = 0;
+        
+        for (int sec = yMax >> 4; sec >= yMin >> 4; --sec)
         {
-            world.checkLightFor(EnumSkyBlock.SKY, new BlockPos(xBase, y, zBase));
+            if (sections[sec] == Chunk.NULL_BLOCK_STORAGE)
+            {
+                emptySections |= 1 << sec;
+            }
+        }
+
+        if (emptySections != 0)
+        {
+            for (final EnumFacing dir : EnumFacing.HORIZONTALS)
+            {
+                final int xOffset = dir.getFrontOffsetX();
+                final int zOffset = dir.getFrontOffsetZ();
+
+                final boolean neighborColumnExists =
+                    (((x + xOffset) | (z + zOffset)) & 16) == 0 //Checks whether the position is at the specified border (the 16 bit is set for both 15+1 and 0-1)
+                        || world.getChunkProvider().getLoadedChunk(chunk.xPosition + xOffset, chunk.zPosition + zOffset) != null;
+
+                if (neighborColumnExists)
+                {
+                    for (int sec = yMax >> 4; sec >= yMin >> 4; --sec)
+                    {
+                        if ((emptySections & (1 << sec)) != 0)
+                        {
+                            scheduleRelightChecksForColumn(world, EnumSkyBlock.SKY, xBase + xOffset, zBase + zOffset, sec << 4, (sec << 4) + 15);
+                        }
+                    }
+                }
+                else
+                {
+                    flagChunkBoundaryForUpdate(chunk, emptySections, EnumSkyBlock.SKY, dir, getAxisDirection(dir, x, z), EnumBoundaryFacing.OUT);
+                }
+            }
+        }
+    }
+
+    public static void scheduleRelightChecksForArea(final World world, final EnumSkyBlock lightType, final int xMin, final int yMin, final int zMin, final int xMax, final int yMax, final int zMax)
+    {
+        for (int x = xMin; x <= xMax; ++x)
+        {
+            for (int z = zMin; z <= zMax; ++z)
+            {
+                scheduleRelightChecksForColumn(world, lightType, x, z, yMin, yMax);
+            }
+        }
+    }
+
+    private static void scheduleRelightChecksForColumn(final World world, final EnumSkyBlock lightType, final int x, final int z, final int yMin, final int yMax)
+    {
+        for (int y = yMin; y <= yMax; ++y)
+        {
+            world.checkLightFor(lightType, new BlockPos(x, y, z));
+        }
+    }
+
+    public enum EnumBoundaryFacing
+    {
+        IN, OUT;
+
+        public EnumBoundaryFacing getOpposite()
+        {
+            return this == IN ? OUT : IN;
+        }
+    }
+
+    public static void flagSecBoundaryForUpdate(final Chunk chunk, final BlockPos pos, final EnumSkyBlock lightType, final EnumFacing dir, final EnumBoundaryFacing boundaryFacing)
+    {
+        flagChunkBoundaryForUpdate(chunk, (short) (1 << (pos.getY() >> 4)), lightType, dir, getAxisDirection(dir, pos.getX(), pos.getZ()), boundaryFacing);
+    }
+
+    public static void flagChunkBoundaryForUpdate(final Chunk chunk, final short sectionMask, final EnumSkyBlock lightType, final EnumFacing dir, final AxisDirection axisDirection, final EnumBoundaryFacing boundaryFacing)
+    {
+        initNeighborLightChecks(chunk);
+        chunk.neighborLightChecks[getFlagIndex(lightType, dir, axisDirection, boundaryFacing)] |= sectionMask;
+        chunk.setChunkModified();
+    }
+
+    public static int getFlagIndex(final EnumSkyBlock lightType, final int xOffset, final int zOffset, final AxisDirection axisDirection, final EnumBoundaryFacing boundaryFacing)
+    {
+        return (lightType == EnumSkyBlock.BLOCK ? 0 : 16) | ((xOffset + 1) << 2) | ((zOffset + 1) << 1) | (axisDirection.getOffset() + 1) | boundaryFacing.ordinal();
+    }
+
+    public static int getFlagIndex(final EnumSkyBlock lightType, final EnumFacing dir, final AxisDirection axisDirection, final EnumBoundaryFacing boundaryFacing)
+    {
+        return getFlagIndex(lightType, dir.getFrontOffsetX(), dir.getFrontOffsetZ(), axisDirection, boundaryFacing);
+    }
+
+    private static AxisDirection getAxisDirection(final EnumFacing dir, final int x, final int z)
+    {
+        return ((dir.getAxis() == Axis.X ? z : x) & 15) < 8 ? AxisDirection.NEGATIVE : AxisDirection.POSITIVE;
+    }
+    
+    public static void scheduleRelightChecksForChunkBoundaries(final World world, final Chunk chunk)
+    {
+        for (final EnumFacing dir : EnumFacing.HORIZONTALS)
+        {
+            final int xOffset = dir.getFrontOffsetX();
+            final int zOffset = dir.getFrontOffsetZ();
+
+            final Chunk nChunk = world.getChunkProvider().getLoadedChunk(chunk.xPosition + xOffset, chunk.zPosition + zOffset);
+
+            if (nChunk == null)
+            {
+                continue;
+            }
+
+            for (final EnumSkyBlock lightType : ENUM_SKY_BLOCK_VALUES)
+            {
+                for (final AxisDirection axisDir : ENUM_AXIS_DIRECTION_VALUES)
+                {
+                    //Merge flags upon loading of a chunk. This ensures that all flags are always already on the IN boundary below
+                    mergeFlags(lightType, chunk, nChunk, dir, axisDir);
+                    mergeFlags(lightType, nChunk, chunk, dir.getOpposite(), axisDir);
+
+                    //Check everything that might have been canceled due to this chunk not being loaded.
+                    //Also, pass in chunks if already known
+                    //The boundary to the neighbor chunk (both ways)
+                    scheduleRelightChecksForBoundary(world, chunk, nChunk, null, lightType, xOffset, zOffset, axisDir);
+                    scheduleRelightChecksForBoundary(world, nChunk, chunk, null, lightType, -xOffset, -zOffset, axisDir);
+                    //The boundary to the diagonal neighbor (since the checks in that chunk were aborted if this chunk wasn't loaded, see scheduleRelightChecksForBoundary)
+                    scheduleRelightChecksForBoundary(world, nChunk, null, chunk, lightType, (zOffset != 0 ? axisDir.getOffset() : 0), (xOffset != 0 ? axisDir.getOffset() : 0), dir.getAxisDirection() == AxisDirection.POSITIVE ? AxisDirection.NEGATIVE : AxisDirection.POSITIVE);
+                }
+            }
+        }
+    }
+
+    private static void mergeFlags(final EnumSkyBlock lightType, final Chunk inChunk, final Chunk outChunk, final EnumFacing dir, final AxisDirection axisDir)
+    {
+        if (outChunk.neighborLightChecks == null)
+        {
+            return;
+        }
+
+        initNeighborLightChecks(inChunk);
+        
+        final int inIndex = getFlagIndex(lightType, dir, axisDir, EnumBoundaryFacing.IN);
+        final int outIndex = getFlagIndex(lightType, dir.getOpposite(), axisDir, EnumBoundaryFacing.OUT);
+
+        inChunk.neighborLightChecks[inIndex] |= outChunk.neighborLightChecks[outIndex];
+        //no need to call Chunk.setModified() since checks are not deleted from outChunk
+    }
+
+    private static void scheduleRelightChecksForBoundary(final World world, final Chunk chunk, Chunk nChunk, Chunk sChunk, final EnumSkyBlock lightType, final int xOffset, final int zOffset, final AxisDirection axisDir)
+    {
+        if (chunk.neighborLightChecks == null)
+        {
+            return;
+        }
+
+        final int flagIndex = getFlagIndex(lightType, xOffset, zOffset, axisDir, EnumBoundaryFacing.IN); //OUT checks from neighbor are already merged
+
+        final int flags = chunk.neighborLightChecks[flagIndex];
+
+        if (flags == 0)
+        {
+            return;
+        }
+
+        if (nChunk == null)
+        {
+            nChunk = world.getChunkProvider().getLoadedChunk(chunk.xPosition + xOffset, chunk.zPosition + zOffset);
+
+            if (nChunk == null)
+            {
+                return;
+            }
+        }
+
+        if (sChunk == null)
+        {
+            sChunk = world.getChunkProvider().getLoadedChunk(chunk.xPosition + (zOffset != 0 ? axisDir.getOffset() : 0), chunk.zPosition + (xOffset != 0 ? axisDir.getOffset() : 0));
+
+            if (sChunk == null)
+            {
+                return; //Cancel, since the checks in the corner columns require the corner column of sChunk
+            }
+        }
+
+        final int reverseIndex = getFlagIndex(lightType, -xOffset, -zOffset, axisDir, EnumBoundaryFacing.OUT);
+
+        chunk.neighborLightChecks[flagIndex] = 0;
+
+        if (nChunk.neighborLightChecks != null)
+        {
+            nChunk.neighborLightChecks[reverseIndex] = 0; //Clear only now that it's clear that the checks are processed
+        }
+        
+        chunk.setChunkModified();
+        nChunk.setChunkModified();
+
+        //Get the area to check
+        //Start in the corner...
+        int xMin = chunk.xPosition << 4;
+        int zMin = chunk.zPosition << 4;
+
+        //move to other side of chunk if the direction is positive
+        if ((xOffset | zOffset) > 0)
+        {
+            xMin += 15 * xOffset;
+            zMin += 15 * zOffset;
+        }
+
+        //shift to other half if necessary (shift perpendicular to dir)
+        if (axisDir == AxisDirection.POSITIVE)
+        {
+            xMin += 8 * (zOffset & 1); //x & 1 is same as abs(x) for x=-1,0,1
+            zMin += 8 * (xOffset & 1);
+        }
+
+        //get maximal values (shift perpendicular to dir)
+        final int xMax = xMin + 7 * (zOffset & 1);
+        final int zMax = zMin + 7 * (xOffset & 1);
+
+        for (int y = 0; y < 16; ++y)
+        {
+            if ((flags & (1 << y)) != 0)
+            {
+                scheduleRelightChecksForArea(world, lightType, xMin, y << 4, zMin, xMax, (y << 4) + 15, zMax);
+            }
+        }
+    }
+
+    public static void initNeighborLightChecks(final Chunk chunk)
+    {
+        if (chunk.neighborLightChecks == null)
+        {
+            chunk.neighborLightChecks = new short[FLAG_COUNT];
+        }
+    }
+    
+    public static final String neighborLightChecksKey = "NeighborLightChecks";
+
+    public static void writeNeighborLightChecksToNBT(final Chunk chunk, final NBTTagCompound nbt)
+    {
+        if (chunk.neighborLightChecks == null)
+        {
+            return;
+        }
+        
+        boolean empty = true;
+        final NBTTagList list = new NBTTagList();
+
+        for (final short flags : chunk.neighborLightChecks)
+        {
+            list.appendTag(new NBTTagShort(flags));
+
+            if (flags != 0)
+            {
+                empty = false;
+            }
+        }
+
+        if (!empty)
+        {
+            nbt.setTag(neighborLightChecksKey, list);
+        }
+    }
+
+    public static void readNeighborLightChecksFromNBT(final Chunk chunk, final NBTTagCompound nbt)
+    {
+        if (nbt.hasKey(neighborLightChecksKey, 9))
+        {
+            final NBTTagList list = nbt.getTagList(neighborLightChecksKey, 2);
+
+            if (list.tagCount() == FLAG_COUNT)
+            {
+                initNeighborLightChecks(chunk);
+
+                for (int i = 0; i < FLAG_COUNT; ++i)
+                {
+                    chunk.neighborLightChecks[i] = ((NBTTagShort) list.get(i)).getShort();
+                }
+            }
+            else
+            {
+                FMLLog.warning("Chunk field %s had invalid length, ignoring it (chunk coordinates: %s %s)", neighborLightChecksKey, chunk.xPosition, chunk.zPosition);
+            }
         }
     }
 }

--- a/src/main/java/net/minecraftforge/common/lighting/LightingHooks.java
+++ b/src/main/java/net/minecraftforge/common/lighting/LightingHooks.java
@@ -1,0 +1,64 @@
+/*
+ * Minecraft Forge
+ * Copyright (c) 2016.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation version 2.1
+ * of the License.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+package net.minecraftforge.common.lighting;
+
+import net.minecraft.util.EnumFacing;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.EnumSkyBlock;
+import net.minecraft.world.World;
+import net.minecraft.world.chunk.Chunk;
+import net.minecraft.world.chunk.storage.ExtendedBlockStorage;
+
+public class LightingHooks
+{
+    public static void relightSkylightColumn(final World world, final Chunk chunk, final int x, final int z, final int height1, final int height2)
+    {
+        final int yMin = Math.min(height1, height2);
+        final int yMax = Math.max(height1, height2) - 1;
+
+        final ExtendedBlockStorage[] sections = chunk.getBlockStorageArray();
+
+        final int xBase = (chunk.xPosition << 4) + x;
+        final int zBase = (chunk.zPosition << 4) + z;
+
+        int y;
+        ExtendedBlockStorage section = null;
+
+        for (y = yMax; y >= yMin; --y)
+        {
+            section = sections[y >> 4];
+
+            if (section == Chunk.NULL_BLOCK_STORAGE)
+            {
+                for (final EnumFacing dir : EnumFacing.HORIZONTALS)
+                {
+                    world.checkLightFor(EnumSkyBlock.SKY, new BlockPos(xBase + dir.getFrontOffsetX(), y, zBase + dir.getFrontOffsetZ()));
+                }
+            }
+
+            world.checkLightFor(EnumSkyBlock.SKY, new BlockPos(xBase, y, zBase));
+        }
+
+        if (section == Chunk.NULL_BLOCK_STORAGE && y >= 0)
+        {
+            world.checkLightFor(EnumSkyBlock.SKY, new BlockPos(xBase, y, zBase));
+        }
+    }
+}

--- a/src/main/java/net/minecraftforge/fml/client/FMLClientHandler.java
+++ b/src/main/java/net/minecraftforge/fml/client/FMLClientHandler.java
@@ -973,6 +973,13 @@ public class FMLClientHandler implements IFMLSidedHandler
         throw new RuntimeException("Unknown INetHandler: " + net);
     }
 
+    @Override
+    @Nullable
+    public IThreadListener getMinecraftThread()
+    {
+        return Minecraft.getMinecraft();
+    }
+
     private SetMultimap<String,ResourceLocation> missingTextures = HashMultimap.create();
     private Set<String> badTextureDomains = Sets.newHashSet();
     private Table<String, String, Set<ResourceLocation>> brokenTextures = HashBasedTable.create();

--- a/src/main/java/net/minecraftforge/fml/common/FMLCommonHandler.java
+++ b/src/main/java/net/minecraftforge/fml/common/FMLCommonHandler.java
@@ -686,6 +686,12 @@ public class FMLCommonHandler
         return sidedDelegate.getWorldThread(net);
     }
 
+    @Nullable
+    public IThreadListener getMinecraftThread()
+    {
+        return sidedDelegate.getMinecraftThread();
+    }
+
     public static void callFuture(FutureTask<?> task)
     {
         try

--- a/src/main/java/net/minecraftforge/fml/common/IFMLSidedHandler.java
+++ b/src/main/java/net/minecraftforge/fml/common/IFMLSidedHandler.java
@@ -23,6 +23,8 @@ import java.io.File;
 import java.util.List;
 import java.util.Set;
 
+import javax.annotation.Nullable;
+
 import net.minecraft.network.INetHandler;
 import net.minecraft.network.NetworkManager;
 import net.minecraft.server.MinecraftServer;
@@ -72,6 +74,9 @@ public interface IFMLSidedHandler
     void allowLogins();
 
     IThreadListener getWorldThread(INetHandler net);
+
+    @Nullable
+    IThreadListener getMinecraftThread();
 
     void processWindowMessages();
 

--- a/src/main/java/net/minecraftforge/fml/server/FMLServerHandler.java
+++ b/src/main/java/net/minecraftforge/fml/server/FMLServerHandler.java
@@ -25,6 +25,8 @@ import java.util.Set;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipFile;
 
+import javax.annotation.Nullable;
+
 import net.minecraft.launchwrapper.Launch;
 import net.minecraft.network.INetHandler;
 import net.minecraft.network.NetHandlerPlayServer;
@@ -326,6 +328,13 @@ public class FMLServerHandler implements IFMLSidedHandler
     {
         // Always the server on the dedicated server, eventually add Per-World if Mojang adds world stuff.
         return getServer();
+    }
+
+    @Override
+    @Nullable
+    public IThreadListener getMinecraftThread()
+    {
+        return null;
     }
 
     @Override

--- a/src/main/resources/forge.exc
+++ b/src/main/resources/forge.exc
@@ -23,6 +23,7 @@ net/minecraft/world/chunk/storage/AnvilChunkLoader.loadChunk__Async(Lnet/minecra
 net/minecraft/world/chunk/storage/AnvilChunkLoader.checkedReadChunkFromNBT__Async(Lnet/minecraft/world/World;IILnet/minecraft/nbt/NBTTagCompound;)[Ljava/lang/Object;=|p_75822_1_,p_75822_2_,p_75822_3_,p_75822_4_
 net/minecraft/world/chunk/storage/AnvilChunkLoader.loadEntities(Lnet/minecraft/world/World;Lnet/minecraft/nbt/NBTTagCompound;Lnet/minecraft/world/chunk/Chunk;)V=|p_75823_1_,p_75823_2_,chunk
 net/minecraft/world/gen/ChunkProviderServer.loadChunk(IILjava/lang/Runnable;)Lnet/minecraft/world/chunk/Chunk;=|p_186028_1_,p_186028_2_,runnable
+net/minecraft/world/chunk/Chunk.getCachedLightFor(Lnet/minecraft/world/EnumSkyBlock;Lnet/minecraft/util/math/BlockPos;)I=|p_177413_1_,p_177413_2_
 
 net/minecraft/block/BlockFire.tryCatchFire(Lnet/minecraft/world/World;Lnet/minecraft/util/math/BlockPos;ILjava/util/Random;ILnet/minecraft/util/EnumFacing;)V=|p_176536_1_,p_176536_2_,p_176536_3_,p_176536_4_,p_176536_5_,face
 net/minecraft/block/BlockSkull.getDrops(Lnet/minecraft/world/IBlockAccess;Lnet/minecraft/util/math/BlockPos;Lnet/minecraft/block/state/IBlockState;I)Ljava/util/List;=|p_180663_1_,p_180663_2_,p_180663_3_,fortune


### PR DESCRIPTION
This PR is the last part (server side at least) of our rewrite/fix of the vanilla lighting system (others: #3870, #3871 #3879).
What it does:
* Fixes [MC-93132](https://bugs.mojang.com/browse/MC-93132)

Note: This PR depends on both #3871 and #3879.

How:
* Light in chunks is spread to the boundary, even if neighbors are not loaded (this is actually done by #3879)
* If a required block is not available, the corresponding boundary is flagged in `Chunk.neighborLightChecks` (`short[32]`). Boundaries are split up by section (the 16 bits of the shorts), direction, positive/negative half, light type and whether the blocks are on the "inside" or "outside" of the chunk (the 32 shorts in the array).
    * This array is stored to disk with the chunk (only if non-trivial)
    * This can happen in two places: `LightingHooks.relightSkylightColumn` & inside the `LightingEngine` code
        * To verify that this is complete: Check for calls to `Chunk.checkLight` - `LightingHooks.relightSkylightColumn` is the only one that checks a neighboring column (which might not be loaded) and fails if it's not loaded
* When a Chunk is loaded, the relevant boundaries of the chunk itself and its 4 neighbors are checked for any outstanding checks.
    * The checks might need to be delayed, since checking a boundary half requires 3 chunks (the two sides of the boundary + the chunk touching the corner block)
    * This is also the reason why boundaries are split in two halves - otherwise, 4 chunks would have to be present

Notes:
* As mentioned, this PR depends on #3871 and #3879 
* While the code might seem quite bloated, there's not much to it - it's mostly just rotating directions
* Together with the other PRs mentioned, there should be no server side lighting bugs (aside from temporary defects at the boundary of the loaded region)