### PR TITLE
Ignore neighbor changes for comparators on the client

### DIFF
--- a/patches/minecraft/net/minecraft/block/BlockRedstoneComparator.java.patch
+++ b/patches/minecraft/net/minecraft/block/BlockRedstoneComparator.java.patch
@@ -7,7 +7,7 @@
 +    @Override
 +    public void onNeighborChange(IBlockAccess world, BlockPos pos, BlockPos neighbor)
 +    {
-+        if (pos.func_177956_o() == neighbor.func_177956_o() && world instanceof World)
++        if (pos.func_177956_o() == neighbor.func_177956_o() && world instanceof net.minecraft.world.WorldServer)
 +        {
 +            func_189540_a(world.func_180495_p(pos), (World)world, pos, world.func_180495_p(neighbor).func_177230_c(), neighbor);
 +        }

--- a/patches/minecraft/net/minecraft/block/BlockRedstoneComparator.java.patch
+++ b/patches/minecraft/net/minecraft/block/BlockRedstoneComparator.java.patch
@@ -7,7 +7,7 @@
 +    @Override
 +    public void onNeighborChange(IBlockAccess world, BlockPos pos, BlockPos neighbor)
 +    {
-+        if (pos.func_177956_o() == neighbor.func_177956_o() && world instanceof net.minecraft.world.WorldServer)
++        if (pos.func_177956_o() == neighbor.func_177956_o() && world instanceof World && !((World) world).field_72995_K)
 +        {
 +            func_189540_a(world.func_180495_p(pos), (World)world, pos, world.func_180495_p(neighbor).func_177230_c(), neighbor);
 +        }


### PR DESCRIPTION
This restores vanilla behavior.

Reported on the forums: http://www.minecraftforge.net/forum/topic/59467-comparators-disappearing-when-placed-on-special-blocks/