### PR TITLE
Add language fallbacks to match java ResourceBundle fallbacks

### DIFF
--- a/patches/minecraft/net/minecraft/client/resources/LanguageManager.java.patch
+++ b/patches/minecraft/net/minecraft/client/resources/LanguageManager.java.patch
@@ -4,7 +4,7 @@
              list.add(this.field_135048_c);
          }
  
-+        list = net.minecraftforge.common.ForgeHooks.expandLanguageFallbacks(list);
++        list = net.minecraftforge.client.ForgeHooksClient.expandLanguageFallbacks(list);
          field_135049_a.func_135022_a(p_110549_1_, list);
          LanguageMap.func_135063_a(field_135049_a.field_135032_a);
      }

--- a/patches/minecraft/net/minecraft/client/resources/LanguageManager.java.patch
+++ b/patches/minecraft/net/minecraft/client/resources/LanguageManager.java.patch
@@ -1,0 +1,10 @@
+--- ../src-base/minecraft/net/minecraft/client/resources/LanguageManager.java
++++ ../src-work/minecraft/net/minecraft/client/resources/LanguageManager.java
+@@ -72,6 +72,7 @@
+             list.add(this.field_135048_c);
+         }
+ 
++        list = net.minecraftforge.common.ForgeHooks.expandLanguageFallbacks(list);
+         field_135049_a.func_135022_a(p_110549_1_, list);
+         LanguageMap.func_135063_a(field_135049_a.field_135032_a);
+     }

--- a/src/main/java/net/minecraftforge/common/ForgeHooks.java
+++ b/src/main/java/net/minecraftforge/common/ForgeHooks.java
@@ -28,15 +28,12 @@ import java.util.ArrayList;
 import java.util.Deque;
 import java.util.HashSet;
 import java.util.List;
-import java.util.Locale;
 import java.util.Map;
 import java.util.Random;
-import java.util.ResourceBundle;
 import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import com.google.common.base.Joiner;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Queues;
 import com.google.common.collect.Sets;
@@ -139,7 +136,6 @@ import javax.annotation.Nullable;
 
 import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.io.IOUtils;
-import org.apache.commons.lang3.LocaleUtils;
 
 public class ForgeHooks
 {

--- a/src/main/java/net/minecraftforge/common/ForgeHooks.java
+++ b/src/main/java/net/minecraftforge/common/ForgeHooks.java
@@ -36,6 +36,7 @@ import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import com.google.common.base.Joiner;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Queues;
 import com.google.common.collect.Sets;
@@ -1311,51 +1312,5 @@ public class ForgeHooks
             },
             true
         );
-    }
-
-    private static final ResourceBundle.Control RESOURCE_CONTROL_HELPER = new ResourceBundle.Control() {};
-
-    /**
-     * Takes a list of locales with fallbacks like ["en_us", "es_es"] and expands it to include more fallbacks, ["en", "en_us", "es", "es_es"].
-     * The list is ordered least specific to most specific.
-     * When there is a duplicate the one from the more specific locale is kept, so ["en_us", "en_gb"] becomes ["en_us", "en", "en_gb"]
-     */
-    public static List<String> expandLanguageFallbacks(List<String> localeStrings)
-    {
-        List<String> expandedFallbacks = new ArrayList<>();
-        for (String localeString : localeStrings)
-        {
-            Locale locale = stringToLocale(localeString);
-            List<Locale> candidates = RESOURCE_CONTROL_HELPER.getCandidateLocales("", locale);
-            candidates = Lists.reverse(candidates);
-            for (Locale candidate : candidates)
-            {
-                if (!candidate.equals(Locale.ROOT))
-                {
-                    String candidateLocaleString = candidate.toString().toLowerCase(Locale.ENGLISH);
-                    expandedFallbacks.remove(candidateLocaleString);
-                    expandedFallbacks.add(candidateLocaleString);
-                }
-            }
-        }
-        return expandedFallbacks;
-    }
-
-    private static Locale stringToLocale(String localeString)
-    {
-        if (localeString.length() >= 5)
-        {
-            String language = localeString.substring(0, 2);
-            String country = localeString.substring(3, 5).toUpperCase(Locale.ENGLISH);
-            if (localeString.length() > 5)
-            {
-                localeString = language + "_" + country + localeString.substring(5);
-            }
-            else
-            {
-                localeString = language + "_" + country;
-            }
-        }
-        return LocaleUtils.toLocale(localeString);
     }
 }

--- a/src/main/java/net/minecraftforge/common/ForgeHooks.java
+++ b/src/main/java/net/minecraftforge/common/ForgeHooks.java
@@ -28,8 +28,10 @@ import java.util.ArrayList;
 import java.util.Deque;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Random;
+import java.util.ResourceBundle;
 import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -136,6 +138,7 @@ import javax.annotation.Nullable;
 
 import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.io.IOUtils;
+import org.apache.commons.lang3.LocaleUtils;
 
 public class ForgeHooks
 {
@@ -1308,5 +1311,51 @@ public class ForgeHooks
             },
             true
         );
+    }
+
+    private static final ResourceBundle.Control RESOURCE_CONTROL_HELPER = new ResourceBundle.Control() {};
+
+    /**
+     * Takes a list of locales with fallbacks like ["en_us", "es_es"] and expands it to include more fallbacks, ["en", "en_us", "es", "es_es"].
+     * The list is ordered least specific to most specific.
+     * When there is a duplicate the one from the more specific locale is kept, so ["en_us", "en_gb"] becomes ["en_us", "en", "en_gb"]
+     */
+    public static List<String> expandLanguageFallbacks(List<String> localeStrings)
+    {
+        List<String> expandedFallbacks = new ArrayList<>();
+        for (String localeString : localeStrings)
+        {
+            Locale locale = stringToLocale(localeString);
+            List<Locale> candidates = RESOURCE_CONTROL_HELPER.getCandidateLocales("", locale);
+            candidates = Lists.reverse(candidates);
+            for (Locale candidate : candidates)
+            {
+                if (!candidate.equals(Locale.ROOT))
+                {
+                    String candidateLocaleString = candidate.toString().toLowerCase(Locale.ENGLISH);
+                    expandedFallbacks.remove(candidateLocaleString);
+                    expandedFallbacks.add(candidateLocaleString);
+                }
+            }
+        }
+        return expandedFallbacks;
+    }
+
+    private static Locale stringToLocale(String localeString)
+    {
+        if (localeString.length() >= 5)
+        {
+            String language = localeString.substring(0, 2);
+            String country = localeString.substring(3, 5).toUpperCase(Locale.ENGLISH);
+            if (localeString.length() > 5)
+            {
+                localeString = language + "_" + country + localeString.substring(5);
+            }
+            else
+            {
+                localeString = language + "_" + country;
+            }
+        }
+        return LocaleUtils.toLocale(localeString);
     }
 }

--- a/src/test/java/net/minecraftforge/debug/LocalizationFallbackTest.java
+++ b/src/test/java/net/minecraftforge/debug/LocalizationFallbackTest.java
@@ -1,0 +1,70 @@
+package net.minecraftforge.debug;
+
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.resources.I18n;
+import net.minecraft.client.resources.IResourceManager;
+import net.minecraft.client.resources.Language;
+import net.minecraft.client.resources.LanguageManager;
+import net.minecraftforge.fml.common.Mod;
+import net.minecraftforge.fml.common.event.FMLPreInitializationEvent;
+
+@Mod(modid = "localization_fallback_test", clientSideOnly = true, version = "1.0", acceptableRemoteVersions = "*")
+@Mod.EventBusSubscriber
+public class LocalizationFallbackTest
+{
+    public static final boolean ENABLED = false;
+
+    @Mod.EventHandler
+    public static void preInit(FMLPreInitializationEvent event)
+    {
+        if (!ENABLED) return;
+
+        Minecraft mc = Minecraft.getMinecraft();
+        LanguageManager mgr = mc.getLanguageManager();
+        IResourceManager resourceManager = mc.getResourceManager();
+
+        Language originalLanguage = mgr.getCurrentLanguage();
+        String string;
+
+        // test en_gb
+        mgr.setCurrentLanguage(mgr.getLanguage("en_gb"));
+        mgr.onResourceManagerReload(resourceManager);
+        string = I18n.format("localization_fallback_test.test_string");
+        expectString("Test String en_GB.lang", string);
+        string = I18n.format("localization_fallback_test.test_string_only_en");
+        expectString("Test String only in en.lang", string);
+        string = I18n.format("localization_fallback_test.test_string_only_en_us");
+        expectString("Test String only in en_US.lang", string);
+
+        // test en_us, which is the default fallback in vanilla
+        mgr.setCurrentLanguage(mgr.getLanguage("en_us"));
+        mgr.onResourceManagerReload(resourceManager);
+        string = I18n.format("localization_fallback_test.test_string");
+        expectString("Test String en_US.lang", string);
+        string = I18n.format("localization_fallback_test.test_string_only_en");
+        expectString("Test String only in en.lang", string);
+        string = I18n.format("localization_fallback_test.test_string_only_en_us");
+        expectString("Test String only in en_US.lang", string);
+
+        // test a language with no localization defined, it should fall back on "es", "en_us", and "en"
+        mgr.setCurrentLanguage(mgr.getLanguage("es_es"));
+        mgr.onResourceManagerReload(resourceManager);
+        string = I18n.format("localization_fallback_test.test_string");
+        expectString("Test String es.lang", string);
+        string = I18n.format("localization_fallback_test.test_string_only_en");
+        expectString("Test String only in en.lang", string);
+        string = I18n.format("localization_fallback_test.test_string_only_en_us");
+        expectString("Test String only in en_US.lang", string);
+
+        mgr.setCurrentLanguage(originalLanguage);
+        mgr.onResourceManagerReload(resourceManager);
+    }
+
+    private static void expectString(String expectedString, String string)
+    {
+        if (!expectedString.equals(string))
+        {
+            throw new IllegalStateException("Localization fallback failed, expected '" + expectedString + "' but got '" + string + "'.");
+        }
+    }
+}

--- a/src/test/resources/assets/localization_fallback_test/lang/en.lang
+++ b/src/test/resources/assets/localization_fallback_test/lang/en.lang
@@ -1,0 +1,2 @@
+localization_fallback_test.test_string=Test String en.lang
+localization_fallback_test.test_string_only_en=Test String only in en.lang

--- a/src/test/resources/assets/localization_fallback_test/lang/en_GB.lang
+++ b/src/test/resources/assets/localization_fallback_test/lang/en_GB.lang
@@ -1,0 +1,1 @@
+localization_fallback_test.test_string=Test String en_GB.lang

--- a/src/test/resources/assets/localization_fallback_test/lang/en_US.lang
+++ b/src/test/resources/assets/localization_fallback_test/lang/en_US.lang
@@ -1,0 +1,2 @@
+localization_fallback_test.test_string=Test String en_US.lang
+localization_fallback_test.test_string_only_en_us=Test String only in en_US.lang

--- a/src/test/resources/assets/localization_fallback_test/lang/es.lang
+++ b/src/test/resources/assets/localization_fallback_test/lang/es.lang
@@ -1,0 +1,1 @@
+localization_fallback_test.test_string=Test String es.lang


### PR DESCRIPTION
This PR add locale fallbacks for shared localization.
For example you can define `en.lang` and it can be a shared fallback for all `en_` languages.
This will simplify localization efforts for mods.
This is fully backward compatible, mods can continue localizing the same way they always have.

Thanks @pau101 for the partial implementation and idea.

### Examples:

Current fallback list for Spanish in Spain looks like this: `["en_us", "es_es"]`
(The list is ordered least specific to most specific.)
After this PR it will look like this: `["en", "en_us", "es", "es_es"]`

When there is a duplicate the one from the more specific locale is kept, 
so `["en_us", "en_gb"]` becomes `["en_us", "en", "en_gb"]`.