### PR TITLE
[1.11] Clean up Block.getLightValue(IBlockState, IBlockAccess, BlockPos)

### DIFF
--- a/patches/minecraft/net/minecraft/block/Block.java.patch
+++ b/patches/minecraft/net/minecraft/block/Block.java.patch
@@ -214,7 +214,7 @@
      public SoundType func_185467_w()
      {
          return this.field_149762_H;
-@@ -908,6 +935,1254 @@
+@@ -908,6 +935,1249 @@
      {
      }
  
@@ -261,7 +261,7 @@
 +    }
 +
 +    /**
-+     * Get a light value for the block at the specified coordinates, normal ranges are between 0 and 15
++     * Get a light value for this block, taking into account the given state and coordinates, normal ranges are between 0 and 15
 +     *
 +     * @param state Block state
 +     * @param world The current world
@@ -270,11 +270,6 @@
 +     */
 +    public int getLightValue(IBlockState state, IBlockAccess world, BlockPos pos)
 +    {
-+        IBlockState other = world.func_180495_p(pos);
-+        if (other.func_177230_c() != this)
-+        {
-+            return other.getLightValue(world, pos);
-+        }
 +        return state.func_185906_d();
 +    }
 +
@@ -1469,7 +1464,7 @@
      public static void func_149671_p()
      {
          func_176215_a(0, field_176230_a, (new BlockAir()).func_149663_c("air"));
-@@ -1201,14 +2476,7 @@
+@@ -1201,14 +2471,7 @@
              }
              else
              {


### PR DESCRIPTION
This reverts 3e484deafc7ff1c251e086783de080f6193a4b6e. The original issue cannot be reproduced.

As discussed in #4199, there are two places where the `state` and `position` parameter do not match:
* `World.setBlockState` can be called recursively for fluids during worldgen. `getLightValue` is only called to determine if `checkLight` has to be called. The outer calls may have non matching `state` and `position` since the block is replaced by the recursive calls in the meantime. This is however not a problem, since the innermost call already makes the right decision; the end result doesn't depend on whether the outer calls call `checkLight`.
* During rendering `getLightValue` can be called with shifted positions to determine the brightness of faces. As discussed in #4199, using the provided `state` instead of fetching the actual one, produces better results. This is also the Vanilla behavior.

This PR just fixes the default implementation of `Block.getLightValue` (mainly for performance, see #4199).
Reworking the Vanilla rendering to get rid of the strange calls to `getLightValue` at all is more complex and should be subject to a different PR, I think.