### PR TITLE
[1.11.2] Removing deprecated registerEntityRenderingHandler method (#4201)

### DIFF
--- a/src/main/java/net/minecraftforge/fml/client/FMLClientHandler.java
+++ b/src/main/java/net/minecraftforge/fml/client/FMLClientHandler.java
@@ -371,7 +371,6 @@ public class FMLClientHandler implements IFMLSidedHandler
 
         // Reload resources
         client.refreshResources();
-        RenderingRegistry.loadEntityRenderers(Minecraft.getMinecraft().getRenderManager().entityRenderMap);
         guiFactories = HashBiMap.create();
         for (ModContainer mc : Loader.instance().getActiveModList())
         {

--- a/src/main/java/net/minecraftforge/fml/client/registry/RenderingRegistry.java
+++ b/src/main/java/net/minecraftforge/fml/client/registry/RenderingRegistry.java
@@ -31,12 +31,6 @@ public class RenderingRegistry
     private static final RenderingRegistry INSTANCE = new RenderingRegistry();
 
     private Map<Class<? extends Entity>, IRenderFactory<? extends Entity>> entityRenderers = Maps.newHashMap();
-    private Map<Class<? extends Entity>, Render<? extends Entity>> entityRenderersOld = Maps.newHashMap();
-
-    public static void loadEntityRenderers(Map<Class<? extends Entity>, Render<? extends Entity>> entityRenderMap)
-    {
-        entityRenderMap.putAll(INSTANCE.entityRenderersOld);
-    }
 
     /**
      * Register an entity rendering handler. This will, after mod initialization, be inserted into the main

--- a/src/main/java/net/minecraftforge/fml/client/registry/RenderingRegistry.java
+++ b/src/main/java/net/minecraftforge/fml/client/registry/RenderingRegistry.java
@@ -33,20 +33,6 @@ public class RenderingRegistry
     private Map<Class<? extends Entity>, IRenderFactory<? extends Entity>> entityRenderers = Maps.newHashMap();
     private Map<Class<? extends Entity>, Render<? extends Entity>> entityRenderersOld = Maps.newHashMap();
 
-    /**
-     * Register an entity rendering handler. This will, after mod initialization, be inserted into the main
-     * render map for entities.
-     * Call this during Initialization phase.
-     *
-     * @deprecated use the factory version during Preinitialization.
-     * TODO Will be removed in 1.11.
-     */
-    @Deprecated
-    public static void registerEntityRenderingHandler(Class<? extends Entity> entityClass, Render<? extends Entity> renderer)
-    {
-        INSTANCE.entityRenderersOld.put(entityClass, renderer);
-    }
-
     public static void loadEntityRenderers(Map<Class<? extends Entity>, Render<? extends Entity>> entityRenderMap)
     {
         entityRenderMap.putAll(INSTANCE.entityRenderersOld);


### PR DESCRIPTION
Same as #4204 but for 1.11.2