### PR TITLE
[1.12] Remove deprecated backupWorld

### DIFF
--- a/src/main/java/net/minecraftforge/fml/common/ZipperUtil.java
+++ b/src/main/java/net/minecraftforge/fml/common/ZipperUtil.java
@@ -85,12 +85,6 @@ public class ZipperUtil {
         backupWorld(dirName);
     }
 
-    @Deprecated
-    public static void backupWorld(String dirName, String saveName) throws IOException
-    {
-        backupWorld(dirName);
-    }
-
     public static void backupWorld(String dirName) throws IOException
     {
         File dstFolder = FMLCommonHandler.instance().getSavesDirectory();


### PR DESCRIPTION
Is there a reason for this to exist ?