### PR TITLE
Make LivingEntityUseItemEvent not abstract

### DIFF
--- a/src/main/java/net/minecraftforge/event/entity/living/LivingEntityUseItemEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/living/LivingEntityUseItemEvent.java
@@ -25,7 +25,7 @@ import net.minecraftforge.fml.common.eventhandler.Cancelable;
 
 import javax.annotation.Nonnull;
 
-public abstract class LivingEntityUseItemEvent extends LivingEvent
+public class LivingEntityUseItemEvent extends LivingEvent
 {
     private final ItemStack item;
     private int duration;


### PR DESCRIPTION
In the context of creating a mod which adds a mechanic where the player can be invisible until performing an action, and not getting it to work, I stumbled upon the following exception in the log:

https://gist.github.com/InfinityRaider/dc583db95db83728dc6bd3d624a84a62

My event handler contains a method which is listening to any LivingEntityUseItemEvent , regardless of it being Start, Finish or End (or whatever modders might add in there..)
Because this is an abstract class, it throws this exception. For now I have simply made different methods for each of the LivingEntityUseItemEvent  subclasses. However I do believe the solution wihtout LivingEntityUseItemEvent  being abstract is the more elegant one.

There are similar event classes which have the same structure (enveloping class with private constructor and then implicitly declared subclasses defined in the same class), for example PlayerInteractEvent, which are not abstract either and allow the kind of functionality I require.