### PR TITLE
Fix some placement logic not matching vanilla

### DIFF
--- a/patches/minecraft/net/minecraft/block/Block.java.patch
+++ b/patches/minecraft/net/minecraft/block/Block.java.patch
@@ -811,7 +811,7 @@
 +     */
 +    public boolean canPlaceTorchOnTop(IBlockState state, IBlockAccess world, BlockPos pos)
 +    {
-+        if (state.func_193401_d(world, pos, EnumFacing.UP) == BlockFaceShape.SOLID)
++        if (state.func_185896_q() || state.func_193401_d(world, pos, EnumFacing.UP) == BlockFaceShape.SOLID)
 +        {
 +            return this != Blocks.field_185775_db && this != Blocks.field_150428_aP;
 +        }

--- a/patches/minecraft/net/minecraft/block/BlockDoor.java.patch
+++ b/patches/minecraft/net/minecraft/block/BlockDoor.java.patch
@@ -9,7 +9,7 @@
              {
                  p_189540_2_.func_175698_g(p_189540_3_);
                  flag1 = true;
-@@ -247,13 +247,13 @@
+@@ -247,13 +247,14 @@
  
      public boolean func_176196_c(World p_176196_1_, BlockPos p_176196_2_)
      {
@@ -21,7 +21,8 @@
          else
          {
 -            return p_176196_1_.func_180495_p(p_176196_2_.func_177977_b()).func_185896_q() && super.func_176196_c(p_176196_1_, p_176196_2_) && super.func_176196_c(p_176196_1_, p_176196_2_.func_177984_a());
-+            return p_176196_1_.func_180495_p(p_176196_2_.func_177977_b()).func_193401_d(p_176196_1_, p_176196_2_.func_177977_b(), EnumFacing.UP) == BlockFaceShape.SOLID && super.func_176196_c(p_176196_1_, p_176196_2_) && super.func_176196_c(p_176196_1_, p_176196_2_.func_177984_a());
++            IBlockState state = p_176196_1_.func_180495_p(p_176196_2_.func_177977_b());
++            return (state.func_185896_q() || state.func_193401_d(p_176196_1_, p_176196_2_.func_177977_b(), EnumFacing.UP) == BlockFaceShape.SOLID) && super.func_176196_c(p_176196_1_, p_176196_2_) && super.func_176196_c(p_176196_1_, p_176196_2_.func_177984_a());
          }
      }
  


### PR DESCRIPTION
Resolves [this issue](http://www.minecraftforge.net/forum/topic/59559-redstone-torch-hopper-bug/) reported on the forums.

Forge used to use `isSideSolid` here, but changed to using `getBlockFaceShape` for 1.12.
The issue here is that `isSideSolid` had a short-circuiting check for `isTopSolid` if the side queried was `UP`. `getBlockFaceShape` doesn't have that check, so we need to add it here ourselves.

This is because hoppers return a shape of `BOWL` for the top face, but override `isTopSolid` to return true to allow things to be placed on them regardless.