### PR TITLE
Patch button/lever placement code to use method call instead of hardcoded block check

### DIFF
--- a/patches/minecraft/net/minecraft/block/BlockButton.java.patch
+++ b/patches/minecraft/net/minecraft/block/BlockButton.java.patch
@@ -1,0 +1,11 @@
+--- ../src-base/minecraft/net/minecraft/block/BlockButton.java
++++ ../src-work/minecraft/net/minecraft/block/BlockButton.java
+@@ -98,7 +98,7 @@
+ 
+         if (p_181088_2_ == EnumFacing.UP)
+         {
+-            return block == Blocks.field_150438_bZ || !func_193384_b(block) && flag;
++            return iblockstate.func_185896_q() || !func_193384_b(block) && flag;
+         }
+         else
+         {


### PR DESCRIPTION
Slightly related to #4210.
Buttons (and levers, which share this code), now have a hardcoded check for `Blocks.HOPPER` when allowing block placement.
This patches this to use `isTopSolid()` instead, which is already overridden by hoppers to return true, and allows other blocks to be able to control this behaviour.