### PR TITLE
Fix FML handshake race condition

### DIFF
--- a/patches/minecraft/net/minecraft/client/network/NetHandlerLoginClient.java.patch
+++ b/patches/minecraft/net/minecraft/client/network/NetHandlerLoginClient.java.patch
@@ -5,10 +5,10 @@
          this.field_175091_e = p_147390_1_.func_179730_a();
          this.field_147393_d.func_150723_a(EnumConnectionState.PLAY);
 -        this.field_147393_d.func_150719_a(new NetHandlerPlayClient(this.field_147394_b, this.field_147395_c, this.field_147393_d, this.field_175091_e));
-+        net.minecraftforge.fml.common.network.internal.FMLNetworkHandler.fmlClientHandshake(this.field_147393_d);
 +        NetHandlerPlayClient nhpc = new NetHandlerPlayClient(this.field_147394_b, this.field_147395_c, this.field_147393_d, this.field_175091_e);
 +        this.field_147393_d.func_150719_a(nhpc);
 +        net.minecraftforge.fml.client.FMLClientHandler.instance().setPlayClient(nhpc);
++        net.minecraftforge.fml.common.network.internal.FMLNetworkHandler.fmlClientHandshake(this.field_147393_d);
      }
  
      public void func_147231_a(ITextComponent p_147231_1_)


### PR DESCRIPTION
Fixes #4219. Explanation:

> This bug was introduced in commit 3fee319. NetworkDispatcher::insertIntoChannel now calls setAutoRead(true), which causes the channel to immediately process incoming messages. But insertIntoChannel is (via some bouncer methods) called from NetHandlerLoginClient::handleLoginSuccess before that methods sets the net handler to NetHandlerPlayClient. This will work, only if the client has not received messages here yet, so that setAutoRead has nothing to process. Otherwise FML will try to process it's handshake using the login net handler. The fix should be to first set the net handler in handleLoginSuccess and then call fmlClientHandshake.

I have tested this a few times with a client and a locally hosted server and not seen the issue ([example](https://hastebin.com/ozayoponoj.rb)) once. Not sure how frequent it is, comments/tests welcome.