### PR TITLE
Support oredicted dyes for various recipes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+#macos stuff
+.DS_Store
+
 #eclipse
 /bin
 /.settings

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,3 @@
-#macos stuff
-.DS_Store
-
 #eclipse
 /bin
 /.settings

--- a/patches/minecraft/net/minecraft/item/crafting/RecipeFireworks.java.patch
+++ b/patches/minecraft/net/minecraft/item/crafting/RecipeFireworks.java.patch
@@ -29,7 +29,7 @@
 +                        if (net.minecraftforge.oredict.DyeUtils.isDye(itemstack2))
                          {
 -                            list.add(Integer.valueOf(ItemDye.field_150922_c[itemstack2.func_77960_j() & 15]));
-+                            list.add(Integer.valueOf(ItemDye.field_150922_c[net.minecraftforge.oredict.DyeUtils.dyeDamageFromStack(itemstack2).getAsInt() & 15]));
++                            list.add(Integer.valueOf(ItemDye.field_150922_c[net.minecraftforge.oredict.DyeUtils.rawDyeDamageFromStack(itemstack2) & 15]));
                          }
                          else if (itemstack2.func_77973_b() == Items.field_151114_aO)
                          {
@@ -41,7 +41,7 @@
 +                        if (net.minecraftforge.oredict.DyeUtils.isDye(itemstack1))
                          {
 -                            list1.add(Integer.valueOf(ItemDye.field_150922_c[itemstack1.func_77960_j() & 15]));
-+                            list1.add(Integer.valueOf(ItemDye.field_150922_c[net.minecraftforge.oredict.DyeUtils.dyeDamageFromStack(itemstack1).getAsInt() & 15]));
++                            list1.add(Integer.valueOf(ItemDye.field_150922_c[net.minecraftforge.oredict.DyeUtils.rawDyeDamageFromStack(itemstack1) & 15]));
                          }
                          else if (itemstack1.func_77973_b() == Items.field_151154_bQ)
                          {

--- a/patches/minecraft/net/minecraft/item/crafting/RecipeFireworks.java.patch
+++ b/patches/minecraft/net/minecraft/item/crafting/RecipeFireworks.java.patch
@@ -12,6 +12,39 @@
  {
      private ItemStack field_92102_a = ItemStack.field_190927_a;
  
+@@ -41,7 +39,7 @@
+                 {
+                     ++l;
+                 }
+-                else if (itemstack.func_77973_b() == Items.field_151100_aR)
++                else if (net.minecraftforge.oredict.DyeUtils.metaFromStack(itemstack).isPresent())
+                 {
+                     ++k;
+                 }
+@@ -127,9 +125,9 @@
+ 
+                     if (!itemstack2.func_190926_b())
+                     {
+-                        if (itemstack2.func_77973_b() == Items.field_151100_aR)
++                        if (net.minecraftforge.oredict.DyeUtils.metaFromStack(itemstack2).isPresent())
+                         {
+-                            list.add(Integer.valueOf(ItemDye.field_150922_c[itemstack2.func_77960_j() & 15]));
++                            list.add(Integer.valueOf(ItemDye.field_150922_c[net.minecraftforge.oredict.DyeUtils.dyeDamageFromStack(itemstack2).getAsInt() & 15]));
+                         }
+                         else if (itemstack2.func_77973_b() == Items.field_151114_aO)
+                         {
+@@ -181,9 +179,9 @@
+ 
+                     if (!itemstack1.func_190926_b())
+                     {
+-                        if (itemstack1.func_77973_b() == Items.field_151100_aR)
++                        if (net.minecraftforge.oredict.DyeUtils.metaFromStack(itemstack1).isPresent())
+                         {
+-                            list1.add(Integer.valueOf(ItemDye.field_150922_c[itemstack1.func_77960_j() & 15]));
++                            list1.add(Integer.valueOf(ItemDye.field_150922_c[net.minecraftforge.oredict.DyeUtils.dyeDamageFromStack(itemstack1).getAsInt() & 15]));
+                         }
+                         else if (itemstack1.func_77973_b() == Items.field_151154_bQ)
+                         {
 @@ -248,10 +246,7 @@
          {
              ItemStack itemstack = p_179532_1_.func_70301_a(i);

--- a/patches/minecraft/net/minecraft/item/crafting/RecipeFireworks.java.patch
+++ b/patches/minecraft/net/minecraft/item/crafting/RecipeFireworks.java.patch
@@ -17,7 +17,7 @@
                      ++l;
                  }
 -                else if (itemstack.func_77973_b() == Items.field_151100_aR)
-+                else if (net.minecraftforge.oredict.DyeUtils.metaFromStack(itemstack).isPresent())
++                else if (net.minecraftforge.oredict.DyeUtils.isDye(itemstack))
                  {
                      ++k;
                  }
@@ -26,7 +26,7 @@
                      if (!itemstack2.func_190926_b())
                      {
 -                        if (itemstack2.func_77973_b() == Items.field_151100_aR)
-+                        if (net.minecraftforge.oredict.DyeUtils.metaFromStack(itemstack2).isPresent())
++                        if (net.minecraftforge.oredict.DyeUtils.isDye(itemstack2))
                          {
 -                            list.add(Integer.valueOf(ItemDye.field_150922_c[itemstack2.func_77960_j() & 15]));
 +                            list.add(Integer.valueOf(ItemDye.field_150922_c[net.minecraftforge.oredict.DyeUtils.dyeDamageFromStack(itemstack2).getAsInt() & 15]));
@@ -38,7 +38,7 @@
                      if (!itemstack1.func_190926_b())
                      {
 -                        if (itemstack1.func_77973_b() == Items.field_151100_aR)
-+                        if (net.minecraftforge.oredict.DyeUtils.metaFromStack(itemstack1).isPresent())
++                        if (net.minecraftforge.oredict.DyeUtils.isDye(itemstack1))
                          {
 -                            list1.add(Integer.valueOf(ItemDye.field_150922_c[itemstack1.func_77960_j() & 15]));
 +                            list1.add(Integer.valueOf(ItemDye.field_150922_c[net.minecraftforge.oredict.DyeUtils.dyeDamageFromStack(itemstack1).getAsInt() & 15]));

--- a/patches/minecraft/net/minecraft/item/crafting/RecipesArmorDyes.java.patch
+++ b/patches/minecraft/net/minecraft/item/crafting/RecipesArmorDyes.java.patch
@@ -12,6 +12,30 @@
  {
      public boolean func_77569_a(InventoryCrafting p_77569_1_, World p_77569_2_)
      {
+@@ -38,7 +36,7 @@
+                 }
+                 else
+                 {
+-                    if (itemstack1.func_77973_b() != Items.field_151100_aR)
++                    if (!net.minecraftforge.oredict.DyeUtils.metaFromStack(itemstack1).isPresent())
+                     {
+                         return false;
+                     }
+@@ -92,12 +90,12 @@
+                 }
+                 else
+                 {
+-                    if (itemstack1.func_77973_b() != Items.field_151100_aR)
++                    if (!net.minecraftforge.oredict.DyeUtils.metaFromStack(itemstack1).isPresent())
+                     {
+                         return ItemStack.field_190927_a;
+                     }
+ 
+-                    float[] afloat = EnumDyeColor.func_176766_a(itemstack1.func_77960_j()).func_193349_f();
++                    float[] afloat = EnumDyeColor.func_176764_b(net.minecraftforge.oredict.DyeUtils.metaFromStack(itemstack1).getAsInt()).func_193349_f();
+                     int l1 = (int)(afloat[0] * 255.0F);
+                     int i2 = (int)(afloat[1] * 255.0F);
+                     int j2 = (int)(afloat[2] * 255.0F);
 @@ -143,11 +141,7 @@
          for (int i = 0; i < nonnulllist.size(); ++i)
          {

--- a/patches/minecraft/net/minecraft/item/crafting/RecipesArmorDyes.java.patch
+++ b/patches/minecraft/net/minecraft/item/crafting/RecipesArmorDyes.java.patch
@@ -17,7 +17,7 @@
                  else
                  {
 -                    if (itemstack1.func_77973_b() != Items.field_151100_aR)
-+                    if (!net.minecraftforge.oredict.DyeUtils.metaFromStack(itemstack1).isPresent())
++                    if (!net.minecraftforge.oredict.DyeUtils.isDye(itemstack1))
                      {
                          return false;
                      }
@@ -26,13 +26,13 @@
                  else
                  {
 -                    if (itemstack1.func_77973_b() != Items.field_151100_aR)
-+                    if (!net.minecraftforge.oredict.DyeUtils.metaFromStack(itemstack1).isPresent())
++                    if (!net.minecraftforge.oredict.DyeUtils.isDye(itemstack1))
                      {
                          return ItemStack.field_190927_a;
                      }
  
 -                    float[] afloat = EnumDyeColor.func_176766_a(itemstack1.func_77960_j()).func_193349_f();
-+                    float[] afloat = EnumDyeColor.func_176764_b(net.minecraftforge.oredict.DyeUtils.metaFromStack(itemstack1).getAsInt()).func_193349_f();
++                    float[] afloat = net.minecraftforge.oredict.DyeUtils.colorFromStack(itemstack1).get().func_193349_f();
                      int l1 = (int)(afloat[0] * 255.0F);
                      int i2 = (int)(afloat[1] * 255.0F);
                      int j2 = (int)(afloat[2] * 255.0F);

--- a/patches/minecraft/net/minecraft/item/crafting/RecipesBanners.java.patch
+++ b/patches/minecraft/net/minecraft/item/crafting/RecipesBanners.java.patch
@@ -45,7 +45,7 @@
                                  if (!itemstack.func_190926_b() && itemstack.func_77973_b() != Items.field_179564_cE)
                                  {
 -                                    if (itemstack.func_77973_b() == Items.field_151100_aR)
-+                                    if (net.minecraftforge.oredict.DyeUtils.metaFromStack(itemstack).isPresent())
++                                    if (net.minecraftforge.oredict.DyeUtils.isDye(itemstack))
                                      {
                                          if (flag2)
                                          {
@@ -54,7 +54,7 @@
                                  if (!itemstack1.func_190926_b() && itemstack1.func_77973_b() != Items.field_179564_cE)
                                  {
 -                                    if (itemstack1.func_77973_b() != Items.field_151100_aR)
-+                                    if (!net.minecraftforge.oredict.DyeUtils.metaFromStack(itemstack1).isPresent())
++                                    if (!net.minecraftforge.oredict.DyeUtils.isDye(itemstack1))
                                      {
                                          flag = false;
                                          break;

--- a/patches/minecraft/net/minecraft/item/crafting/RecipesBanners.java.patch
+++ b/patches/minecraft/net/minecraft/item/crafting/RecipesBanners.java.patch
@@ -19,11 +19,11 @@
                          ItemStack itemstack2 = p_77572_1_.func_70301_a(j);
  
 -                        if (itemstack2.func_77973_b() == Items.field_151100_aR)
-+                        int color = getColor(itemstack2);
-+                        if (color != -1)
++                        final java.util.OptionalInt color = net.minecraftforge.oredict.DyeUtils.dyeDamageFromStack(itemstack2);
++                        if (color.isPresent())
                          {
 -                            k = itemstack2.func_77960_j();
-+                            k = color;
++                            k = color.getAsInt();
                              break;
                          }
                      }
@@ -45,7 +45,7 @@
                                  if (!itemstack.func_190926_b() && itemstack.func_77973_b() != Items.field_179564_cE)
                                  {
 -                                    if (itemstack.func_77973_b() == Items.field_151100_aR)
-+                                    if (isDye(itemstack))
++                                    if (net.minecraftforge.oredict.DyeUtils.metaFromStack(itemstack).isPresent())
                                      {
                                          if (flag2)
                                          {
@@ -54,11 +54,11 @@
                                  if (!itemstack1.func_190926_b() && itemstack1.func_77973_b() != Items.field_179564_cE)
                                  {
 -                                    if (itemstack1.func_77973_b() != Items.field_151100_aR)
-+                                    if (!isDye(itemstack1))
++                                    if (!net.minecraftforge.oredict.DyeUtils.metaFromStack(itemstack1).isPresent())
                                      {
                                          flag = false;
                                          break;
-@@ -237,14 +232,45 @@
+@@ -237,14 +232,13 @@
                  return true;
              }
  
@@ -67,38 +67,6 @@
              {
                  return p_194133_1_ >= 3 && p_194133_2_ >= 3;
              }
-+
-+            private static String[] colors = { "Black", "Red", "Green", "Brown", "Blue", "Purple", "Cyan", "LightGray", "Gray", "Pink", "Lime", "Yellow", "LightBlue", "Magenta", "Orange", "White" };
-+            @SuppressWarnings("unchecked") //Why java...
-+            private static java.util.List<ItemStack>[] colored = new java.util.List[colors.length];
-+            private static java.util.List<ItemStack> dyes;
-+            private static boolean hasInit = false;
-+            private static void init()
-+            {
-+                if (hasInit) return;
-+                for (int x = 0; x < colors.length; x++)
-+                    colored[x] = net.minecraftforge.oredict.OreDictionary.getOres("dye" + colors[x]);
-+                dyes = net.minecraftforge.oredict.OreDictionary.getOres("dye");
-+                hasInit = true;
-+            }
-+            private boolean isDye(ItemStack stack)
-+            {
-+                init();
-+                for (ItemStack ore : dyes)
-+                    if (net.minecraftforge.oredict.OreDictionary.itemMatches(ore, stack, false))
-+                        return true;
-+                return false;
-+            }
-+            private int getColor(ItemStack stack)
-+            {
-+                init();
-+                if (stack == null) return -1;
-+                for (int x = 0; x < colored.length; x++)
-+                    for (ItemStack ore : colored[x])
-+                        if (net.minecraftforge.oredict.OreDictionary.itemMatches(ore, stack, true))
-+                            return x;
-+                return -1;
-+            }
          }
  
 -    public static class RecipeDuplicatePattern implements IRecipe
@@ -106,7 +74,7 @@
          {
              public boolean func_77569_a(InventoryCrafting p_77569_1_, World p_77569_2_)
              {
-@@ -344,9 +370,9 @@
+@@ -344,9 +338,9 @@
  
                      if (!itemstack.func_190926_b())
                      {
@@ -118,7 +86,7 @@
                          }
                          else if (itemstack.func_77942_o() && TileEntityBanner.func_175113_c(itemstack) > 0)
                          {
-@@ -365,7 +391,6 @@
+@@ -365,7 +359,6 @@
                  return true;
              }
  

--- a/patches/minecraft/net/minecraft/item/crafting/RecipesBanners.java.patch
+++ b/patches/minecraft/net/minecraft/item/crafting/RecipesBanners.java.patch
@@ -19,11 +19,11 @@
                          ItemStack itemstack2 = p_77572_1_.func_70301_a(j);
  
 -                        if (itemstack2.func_77973_b() == Items.field_151100_aR)
-+                        final java.util.OptionalInt color = net.minecraftforge.oredict.DyeUtils.dyeDamageFromStack(itemstack2);
-+                        if (color.isPresent())
++                        int color = net.minecraftforge.oredict.DyeUtils.rawDyeDamageFromStack(itemstack2);
++                        if (color != -1)
                          {
 -                            k = itemstack2.func_77960_j();
-+                            k = color.getAsInt();
++                            k = color;
                              break;
                          }
                      }

--- a/patches/minecraft/net/minecraft/item/crafting/ShulkerBoxRecipes.java.patch
+++ b/patches/minecraft/net/minecraft/item/crafting/ShulkerBoxRecipes.java.patch
@@ -19,7 +19,7 @@
                          else
                          {
 -                            if (itemstack.func_77973_b() != Items.field_151100_aR)
-+                            if (!net.minecraftforge.oredict.DyeUtils.metaFromStack(itemstack).isPresent())
++                            if (!net.minecraftforge.oredict.DyeUtils.isDye(itemstack))
                              {
                                  return false;
                              }
@@ -28,7 +28,7 @@
                              itemstack = itemstack2;
                          }
 -                        else if (itemstack2.func_77973_b() == Items.field_151100_aR)
-+                        else if (net.minecraftforge.oredict.DyeUtils.metaFromStack(itemstack2).isPresent())
++                        else if (net.minecraftforge.oredict.DyeUtils.isDye(itemstack2))
                          {
                              itemstack1 = itemstack2;
                          }
@@ -36,7 +36,7 @@
                  }
  
 -                ItemStack itemstack3 = BlockShulkerBox.func_190953_b(EnumDyeColor.func_176766_a(itemstack1.func_77960_j()));
-+                ItemStack itemstack3 = BlockShulkerBox.func_190953_b(EnumDyeColor.func_176764_b(net.minecraftforge.oredict.DyeUtils.metaFromStack(itemstack1).getAsInt()));
++                ItemStack itemstack3 = BlockShulkerBox.func_190953_b(net.minecraftforge.oredict.DyeUtils.colorFromStack(itemstack1).get());
  
                  if (itemstack.func_77942_o())
                  {

--- a/patches/minecraft/net/minecraft/item/crafting/ShulkerBoxRecipes.java.patch
+++ b/patches/minecraft/net/minecraft/item/crafting/ShulkerBoxRecipes.java.patch
@@ -14,6 +14,32 @@
          {
              public boolean func_77569_a(InventoryCrafting p_77569_1_, World p_77569_2_)
              {
+@@ -32,7 +30,7 @@
+                         }
+                         else
+                         {
+-                            if (itemstack.func_77973_b() != Items.field_151100_aR)
++                            if (!net.minecraftforge.oredict.DyeUtils.metaFromStack(itemstack).isPresent())
+                             {
+                                 return false;
+                             }
+@@ -65,14 +63,14 @@
+                         {
+                             itemstack = itemstack2;
+                         }
+-                        else if (itemstack2.func_77973_b() == Items.field_151100_aR)
++                        else if (net.minecraftforge.oredict.DyeUtils.metaFromStack(itemstack2).isPresent())
+                         {
+                             itemstack1 = itemstack2;
+                         }
+                     }
+                 }
+ 
+-                ItemStack itemstack3 = BlockShulkerBox.func_190953_b(EnumDyeColor.func_176766_a(itemstack1.func_77960_j()));
++                ItemStack itemstack3 = BlockShulkerBox.func_190953_b(EnumDyeColor.func_176764_b(net.minecraftforge.oredict.DyeUtils.metaFromStack(itemstack1).getAsInt()));
+ 
+                 if (itemstack.func_77942_o())
+                 {
 @@ -109,7 +107,6 @@
                  return true;
              }

--- a/src/main/java/net/minecraftforge/oredict/DyeUtils.java
+++ b/src/main/java/net/minecraftforge/oredict/DyeUtils.java
@@ -1,0 +1,39 @@
+package net.minecraftforge.oredict;
+
+import net.minecraft.item.ItemStack;
+import org.apache.commons.lang3.ArrayUtils;
+
+import java.util.Arrays;
+import java.util.OptionalInt;
+
+public class DyeUtils
+{
+    private static final String[] dyeOredicts = new String[]
+    {
+        "dyeWhite",
+        "dyeOrange",
+        "dyeMagenta",
+        "dyeLightBlue",
+        "dyeYellow",
+        "dyeLime",
+        "dyePink",
+        "dyeGray",
+        "dyeLightGray",
+        "dyeCyan",
+        "dyePurple",
+        "dyeBlue",
+        "dyeBrown",
+        "dyeGreen",
+        "dyeRed",
+        "dyeBlack"
+    };
+
+    public static OptionalInt metaFromStack(ItemStack stack)
+    {
+        return Arrays.stream(OreDictionary.getOreIDs(stack))
+                .mapToObj(OreDictionary::getOreName)
+                .mapToInt(name -> ArrayUtils.indexOf(dyeOredicts, name))
+                .filter(id -> id >= 0)
+                .findFirst();
+    }
+}

--- a/src/main/java/net/minecraftforge/oredict/DyeUtils.java
+++ b/src/main/java/net/minecraftforge/oredict/DyeUtils.java
@@ -1,3 +1,22 @@
+/*
+ * Minecraft Forge
+ * Copyright (c) 2016.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation version 2.1
+ * of the License.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
 package net.minecraftforge.oredict;
 
 import net.minecraft.item.ItemStack;

--- a/src/main/java/net/minecraftforge/oredict/DyeUtils.java
+++ b/src/main/java/net/minecraftforge/oredict/DyeUtils.java
@@ -29,7 +29,6 @@ import java.util.OptionalInt;
 
 /**
  * Utility class for working with ore dictionary dyes.
- * To check if an item is a dye, use {@code DyeUtils.metaFromStack(stack).isPresent()}.
  */
 public class DyeUtils
 {
@@ -52,6 +51,16 @@ public class DyeUtils
         "dyeRed",
         "dyeBlack"
     };
+
+    /**
+     * Check if an item stack is a dye.
+     * @param stack the item stack
+     * @return whether the stack is a dye
+     */
+    public static boolean isDye(ItemStack stack)
+    {
+        return metaFromStack(stack).isPresent();
+    }
 
     /**
      * Get the dye metadata from the stack, which can be passed into {@link EnumDyeColor#byMetadata(int)}.

--- a/src/main/java/net/minecraftforge/oredict/DyeUtils.java
+++ b/src/main/java/net/minecraftforge/oredict/DyeUtils.java
@@ -19,12 +19,18 @@
 
 package net.minecraftforge.oredict;
 
+import net.minecraft.item.EnumDyeColor;
 import net.minecraft.item.ItemStack;
 import org.apache.commons.lang3.ArrayUtils;
 
 import java.util.Arrays;
+import java.util.Optional;
 import java.util.OptionalInt;
 
+/**
+ * Utility class for working with ore dictionary dyes.
+ * To check if an item is a dye, use {@code DyeUtils.metaFromStack(stack).isPresent()}.
+ */
 public class DyeUtils
 {
     private static final String[] dyeOredicts = new String[]
@@ -47,6 +53,11 @@ public class DyeUtils
         "dyeBlack"
     };
 
+    /**
+     * Get the dye metadata from the stack, which can be passed into {@link EnumDyeColor#byMetadata(int)}.
+     * @param stack the item stack
+     * @return an {@link OptionalInt} holding the dye metadata for a dye, or an empty {@link OptionalInt} otherwise
+     */
     public static OptionalInt metaFromStack(ItemStack stack)
     {
         return Arrays.stream(OreDictionary.getOreIDs(stack))
@@ -54,5 +65,27 @@ public class DyeUtils
                 .mapToInt(name -> ArrayUtils.indexOf(dyeOredicts, name))
                 .filter(id -> id >= 0)
                 .findFirst();
+    }
+
+    /**
+     * Get the dye damage from the stack, which can be passed into {@link EnumDyeColor#byDyeDamage(int)}.
+     * @param stack the item stack
+     * @return an {@link OptionalInt} holding the dye damage for a dye, or an empty {@link OptionalInt} otherwise
+     */
+    public static OptionalInt dyeDamageFromStack(ItemStack stack)
+    {
+        final OptionalInt meta = metaFromStack(stack);
+        return meta.isPresent() ? OptionalInt.of(0xF - meta.getAsInt()) : OptionalInt.empty();
+    }
+
+    /**
+     * Get a dye's color.
+     * @param stack the item stack
+     * @return an {@link Optional} holding the dye color if present, or an empty {@link Optional} otherwise
+     */
+    public static Optional<EnumDyeColor> colorFromStack(ItemStack stack)
+    {
+        final OptionalInt meta = metaFromStack(stack);
+        return meta.isPresent() ? Optional.of(EnumDyeColor.byMetadata(meta.getAsInt())) : Optional.empty();
     }
 }

--- a/src/main/java/net/minecraftforge/oredict/DyeUtils.java
+++ b/src/main/java/net/minecraftforge/oredict/DyeUtils.java
@@ -60,6 +60,7 @@ public class DyeUtils
      */
     public static OptionalInt metaFromStack(ItemStack stack)
     {
+        if (stack.isEmpty()) return OptionalInt.empty();
         return Arrays.stream(OreDictionary.getOreIDs(stack))
                 .mapToObj(OreDictionary::getOreName)
                 .mapToInt(name -> ArrayUtils.indexOf(dyeOredicts, name))

--- a/src/main/java/net/minecraftforge/oredict/DyeUtils.java
+++ b/src/main/java/net/minecraftforge/oredict/DyeUtils.java
@@ -20,6 +20,7 @@
 package net.minecraftforge.oredict;
 
 import net.minecraft.item.EnumDyeColor;
+import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import org.apache.commons.lang3.ArrayUtils;
 
@@ -78,6 +79,17 @@ public class DyeUtils
     }
 
     /**
+     * Similar to {@link #metaFromStack(ItemStack)}, except that it returns the raw integer (with a {@code -1} sentinel);
+     * this follows vanilla conventions.
+     * @param stack the item stack
+     * @return the dye metadata for a dye, or {@code -1} otherwise
+     */
+    public static int rawMetaFromStack(ItemStack stack)
+    {
+        return metaFromStack(stack).orElse(-1);
+    }
+
+    /**
      * Get the dye damage from the stack, which can be passed into {@link EnumDyeColor#byDyeDamage(int)}.
      * @param stack the item stack
      * @return an {@link OptionalInt} holding the dye damage for a dye, or an empty {@link OptionalInt} otherwise
@@ -86,6 +98,17 @@ public class DyeUtils
     {
         final OptionalInt meta = metaFromStack(stack);
         return meta.isPresent() ? OptionalInt.of(0xF - meta.getAsInt()) : OptionalInt.empty();
+    }
+
+    /**
+     * Similar to {@link #dyeDamageFromStack(ItemStack)}, except that it returns the raw integer (with a {@code -1} sentinel);
+     * this follows vanilla conventions.
+     * @param stack the item stack
+     * @return the dye damage for a dye, or {@code -1} otherwise
+     */
+    public static int rawDyeDamageFromStack(ItemStack stack)
+    {
+        return dyeDamageFromStack(stack).orElse(-1);
     }
 
     /**


### PR DESCRIPTION
This fixes #4222 by slightly modifying a few recipes so that they convert ore-dicted dye itemstacks to metadata values, which are then converted to dye colors; the code for detecting the validity of a dye for those recipes recipe was updated as well.

Tested with Actually Additions dyes.