### PR TITLE
Fix override data being ignored from handshake

### DIFF
--- a/src/main/java/net/minecraftforge/fml/common/network/handshake/FMLHandshakeClientState.java
+++ b/src/main/java/net/minecraftforge/fml/common/network/handshake/FMLHandshakeClientState.java
@@ -130,6 +130,7 @@ enum FMLHandshakeClientState implements IHandshakeState<FMLHandshakeClientState>
             ForgeRegistry.Snapshot entry = new ForgeRegistry.Snapshot();
             entry.ids.putAll(pkt.getIdMap());
             entry.dummied.addAll(pkt.getDummied());
+            entry.overrides.putAll(pkt.getOverrides());
             snap.put(pkt.getName(), entry);
 
             if (pkt.hasMore())

--- a/src/main/java/net/minecraftforge/fml/common/network/handshake/FMLHandshakeMessage.java
+++ b/src/main/java/net/minecraftforge/fml/common/network/handshake/FMLHandshakeMessage.java
@@ -261,6 +261,11 @@ public abstract class FMLHandshakeMessage {
             return dummied;
         }
 
+        public Map<ResourceLocation, String> getOverrides()
+        {
+            return overrides;
+        }
+
         public ResourceLocation getName()
         {
             return this.name;

--- a/src/test/java/net/minecraftforge/debug/RegistryOverrideTest.java
+++ b/src/test/java/net/minecraftforge/debug/RegistryOverrideTest.java
@@ -21,8 +21,11 @@ package net.minecraftforge.debug;
 import net.minecraft.block.Block;
 import net.minecraft.block.SoundType;
 import net.minecraft.block.material.Material;
+import net.minecraft.block.state.IBlockState;
 import net.minecraft.creativetab.CreativeTabs;
 import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.util.EnumFacing;
+import net.minecraft.util.EnumHand;
 import net.minecraft.util.math.AxisAlignedBB;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.text.TextComponentString;
@@ -40,12 +43,13 @@ public class RegistryOverrideTest
     @SubscribeEvent
     public static void registerBlocks(RegistryEvent.Register<Block> event)
     {
-        event.getRegistry().register(new BlockReplacement() );
+        event.getRegistry().register(new BlockReplacement());
     }
 
     private static class BlockReplacement extends Block
     {
         AxisAlignedBB BB = FULL_BLOCK_AABB.contract(0.1, 0, 0.1);
+
         private BlockReplacement()
         {
             super(Material.ROCK);
@@ -62,9 +66,13 @@ public class RegistryOverrideTest
         }
 
         @Override
-        public void onBlockClicked(World worldIn, BlockPos pos, EntityPlayer playerIn)
+        public boolean onBlockActivated(World worldIn, BlockPos pos, IBlockState state, EntityPlayer playerIn, EnumHand hand, EnumFacing facing, float hitX, float hitY, float hitZ)
         {
-            playerIn.sendMessage(new TextComponentString("Debug Override Click!"));
+            if (hand == EnumHand.MAIN_HAND)
+            {
+                playerIn.sendMessage(new TextComponentString(worldIn.isRemote ? "Client" : "Server"));
+            }
+            return false;
         }
     }
 }


### PR DESCRIPTION
This fixes the override data from the server not being inserted back into the registry snapshot for the client, effectively desynchronizing the client and server registries if overrides are present. For simple cases, where client and server registry match already, this is related to #4140, which shouldn't occur anymore (given a matching configuration).
Additionally, this PR also changes the overrides test mod a little to be friendlier to use in creative mode and to show which side an action takes place on, helpful for testing these changes.