### PR TITLE
Fix some test mods crashing server caused by model loading

### DIFF
--- a/src/test/java/net/minecraftforge/debug/DynBucketTest.java
+++ b/src/test/java/net/minecraftforge/debug/DynBucketTest.java
@@ -59,6 +59,7 @@ import net.minecraftforge.fml.common.eventhandler.Event.Result;
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
 import net.minecraftforge.fml.common.registry.GameRegistry;
 import net.minecraftforge.fml.common.registry.GameRegistry.ObjectHolder;
+import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.items.IItemHandler;
 import net.minecraftforge.items.ItemStackHandler;
 import net.minecraftforge.items.wrapper.CombinedInvWrapper;
@@ -92,25 +93,6 @@ public class DynBucketTest
         {
             FluidRegistry.enableUniversalBucket();
         }
-    }
-
-    @SubscribeEvent
-    public void setupModels(ModelRegistryEvent event)
-    {
-        ModelLoader.setBucketModelDefinition(DYN_BOTTLE);
-
-        final ModelResourceLocation bottle = new ModelResourceLocation(new ResourceLocation(ForgeVersion.MOD_ID, "dynbottle"), "inventory");
-        ModelLoader.setCustomMeshDefinition(DYN_BOTTLE, new ItemMeshDefinition()
-        {
-            @Override
-            public ModelResourceLocation getModelLocation(@Nonnull ItemStack stack)
-            {
-                return bottle;
-            }
-        });
-        ModelBakery.registerItemVariants(DYN_BOTTLE, bottle);
-        ModelLoader.setCustomModelResourceLocation(Item.REGISTRY.getObject(simpleTankName), 0, new ModelResourceLocation(simpleTankName, "normal"));
-        ModelLoader.setCustomModelResourceLocation(Item.REGISTRY.getObject(testItemName), 0, new ModelResourceLocation(new ResourceLocation("minecraft", "stick"), "inventory"));
     }
 
     @SubscribeEvent
@@ -177,6 +159,29 @@ public class DynBucketTest
                     }
                 }
             }
+        }
+    }
+
+    @Mod.EventBusSubscriber(value = Side.CLIENT, modid = MODID)
+    public static class ClientEventHandler
+    {
+        @SubscribeEvent
+        public static void setupModels(ModelRegistryEvent event)
+        {
+            ModelLoader.setBucketModelDefinition(DYN_BOTTLE);
+
+            final ModelResourceLocation bottle = new ModelResourceLocation(new ResourceLocation(ForgeVersion.MOD_ID, "dynbottle"), "inventory");
+            ModelLoader.setCustomMeshDefinition(DYN_BOTTLE, new ItemMeshDefinition()
+            {
+                @Override
+                public ModelResourceLocation getModelLocation(@Nonnull ItemStack stack)
+                {
+                    return bottle;
+                }
+            });
+            ModelBakery.registerItemVariants(DYN_BOTTLE, bottle);
+            ModelLoader.setCustomModelResourceLocation(Item.REGISTRY.getObject(simpleTankName), 0, new ModelResourceLocation(simpleTankName, "normal"));
+            ModelLoader.setCustomModelResourceLocation(Item.REGISTRY.getObject(testItemName), 0, new ModelResourceLocation(new ResourceLocation("minecraft", "stick"), "inventory"));
         }
     }
 

--- a/src/test/java/net/minecraftforge/debug/FluidPlacementTest.java
+++ b/src/test/java/net/minecraftforge/debug/FluidPlacementTest.java
@@ -80,7 +80,11 @@ public class FluidPlacementTest
             );
             MinecraftForge.EVENT_BUS.register(FluidContainer.instance);
         }
+    }
 
+    @Mod.EventBusSubscriber(value = Side.CLIENT, modid = MODID)
+    public static class ClientEventHandler
+    {
         @SubscribeEvent
         public static void registerModels(ModelRegistryEvent event)
         {

--- a/src/test/java/net/minecraftforge/debug/FogColorInsideMaterialTest.java
+++ b/src/test/java/net/minecraftforge/debug/FogColorInsideMaterialTest.java
@@ -22,6 +22,7 @@ import net.minecraftforge.fml.common.Mod;
 import net.minecraftforge.fml.common.Mod.EventBusSubscriber;
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
 import net.minecraftforge.fml.common.registry.GameRegistry.ObjectHolder;
+import net.minecraftforge.fml.relauncher.Side;
 
 @EventBusSubscriber
 @Mod (modid = FogColorInsideMaterialTest.MOD_ID, name = "FogColor inside material debug.", version = "1.0", acceptableRemoteVersions = "*")
@@ -60,20 +61,24 @@ public class FogColorInsideMaterialTest
         event.getRegistry().register(new ItemBlock(FLUID_BLOCK).setRegistryName(testFluidRegistryName));
     }
 
-    @SubscribeEvent
-    public static void registerModels(ModelRegistryEvent event)
+    @EventBusSubscriber(value = Side.CLIENT, modid = MOD_ID)
+    public static class ClientEventHandler
     {
-        ModelResourceLocation fluidLocation = new ModelResourceLocation(testFluidRegistryName, "fluid");
-        ModelLoader.registerItemVariants(FLUID_ITEM);
-        ModelLoader.setCustomMeshDefinition(FLUID_ITEM, stack -> fluidLocation);
-        ModelLoader.setCustomStateMapper(FLUID_BLOCK, new StateMapperBase()
+        @SubscribeEvent
+        public static void registerModels(ModelRegistryEvent event)
         {
-            @Override
-            protected ModelResourceLocation getModelResourceLocation(IBlockState state)
+            ModelResourceLocation fluidLocation = new ModelResourceLocation(testFluidRegistryName, "fluid");
+            ModelLoader.registerItemVariants(FLUID_ITEM);
+            ModelLoader.setCustomMeshDefinition(FLUID_ITEM, stack -> fluidLocation);
+            ModelLoader.setCustomStateMapper(FLUID_BLOCK, new StateMapperBase()
             {
-                return fluidLocation;
-            }
-        });
+                @Override
+                protected ModelResourceLocation getModelResourceLocation(IBlockState state)
+                {
+                    return fluidLocation;
+                }
+            });
+        }
     }
 
 }

--- a/src/test/java/net/minecraftforge/debug/ForgeBlockStatesLoaderDebug.java
+++ b/src/test/java/net/minecraftforge/debug/ForgeBlockStatesLoaderDebug.java
@@ -77,32 +77,36 @@ public class ForgeBlockStatesLoaderDebug
         MinecraftForge.EVENT_BUS.register(this);
     }
 
-    @SubscribeEvent
-    public void registerModels(ModelRegistryEvent event)
+    @Mod.EventBusSubscriber(value = Side.CLIENT, modid = MODID)
+    public static class ClientEventHandler
     {
-        //ModelLoader.setCustomStateMapper(blockCustom, new StateMap.Builder().withName(CustomMappedBlock.VARIANT).build());
-
-        ModelLoader.setCustomStateMapper(BLOCKS.custom_wall, new IStateMapper()
+        @SubscribeEvent
+        public void registerModels(ModelRegistryEvent event)
         {
-            StateMap stateMap = new StateMap.Builder().withName(BlockWall.VARIANT).withSuffix("_wall").build();
+            //ModelLoader.setCustomStateMapper(blockCustom, new StateMap.Builder().withName(CustomMappedBlock.VARIANT).build());
 
-            @Override
-            public Map<IBlockState, ModelResourceLocation> putStateModelLocations(Block block)
+            ModelLoader.setCustomStateMapper(BLOCKS.custom_wall, new IStateMapper()
             {
-                Map<IBlockState, ModelResourceLocation> map = stateMap.putStateModelLocations(block);
-                Map<IBlockState, ModelResourceLocation> newMap = Maps.newHashMap();
+                StateMap stateMap = new StateMap.Builder().withName(BlockWall.VARIANT).withSuffix("_wall").build();
 
-                for (Entry<IBlockState, ModelResourceLocation> e : map.entrySet())
+                @Override
+                public Map<IBlockState, ModelResourceLocation> putStateModelLocations(Block block)
                 {
-                    ModelResourceLocation loc = e.getValue();
-                    newMap.put(e.getKey(), new ModelResourceLocation(ASSETS + loc.getResourcePath(), loc.getVariant()));
-                }
+                    Map<IBlockState, ModelResourceLocation> map = stateMap.putStateModelLocations(block);
+                    Map<IBlockState, ModelResourceLocation> newMap = Maps.newHashMap();
 
-                return newMap;
-            }
-        });
-        ModelLoader.setCustomModelResourceLocation(ITEMS.custom_wall, 0, new ModelResourceLocation(ASSETS + "cobblestone_wall", "inventory"));
-        ModelLoader.setCustomModelResourceLocation(ITEMS.custom_wall, 1, new ModelResourceLocation(ASSETS + "mossy_cobblestone_wall", "inventory"));
+                    for (Entry<IBlockState, ModelResourceLocation> e : map.entrySet())
+                    {
+                        ModelResourceLocation loc = e.getValue();
+                        newMap.put(e.getKey(), new ModelResourceLocation(ASSETS + loc.getResourcePath(), loc.getVariant()));
+                    }
+
+                    return newMap;
+                }
+            });
+            ModelLoader.setCustomModelResourceLocation(ITEMS.custom_wall, 0, new ModelResourceLocation(ASSETS + "cobblestone_wall", "inventory"));
+            ModelLoader.setCustomModelResourceLocation(ITEMS.custom_wall, 1, new ModelResourceLocation(ASSETS + "mossy_cobblestone_wall", "inventory"));
+        }
     }
 
     // this block is never actually used, it's only needed for the error message on load to see the variant it maps to

--- a/src/test/java/net/minecraftforge/debug/ItemTileDebug.java
+++ b/src/test/java/net/minecraftforge/debug/ItemTileDebug.java
@@ -32,6 +32,8 @@ import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
 import net.minecraftforge.fml.common.registry.ForgeRegistries;
 import net.minecraftforge.fml.common.registry.GameRegistry;
 import net.minecraftforge.fml.common.registry.GameRegistry.ObjectHolder;
+import net.minecraftforge.fml.relauncher.Side;
+import net.minecraftforge.fml.relauncher.SideOnly;
 import net.minecraftforge.registries.RegistryBuilder;
 
 import static org.lwjgl.opengl.GL11.*;
@@ -58,6 +60,11 @@ public class ItemTileDebug
         {
             event.getRegistry().register(new ItemBlock(TEST_BLOCK).setRegistryName(TEST_BLOCK.getRegistryName()));
         }
+    }
+
+    @Mod.EventBusSubscriber(value = Side.CLIENT, modid = MODID)
+    public static class BakeEventHandler
+    {
         @SubscribeEvent
         public static void registerModels(ModelRegistryEvent event)
         {
@@ -66,52 +73,41 @@ public class ItemTileDebug
             Item item = ForgeRegistries.ITEMS.getValue(new ResourceLocation(MODID, TestBlock.name));
             ForgeHooksClient.registerTESRItemStack(item, 0, CustomTileEntity.class);
             ModelLoader.setCustomModelResourceLocation(item, 0, itemLocation);
-            MinecraftForge.EVENT_BUS.register(BakeEventHandler.instance);
             ClientRegistry.bindTileEntitySpecialRenderer(CustomTileEntity.class, TestTESR.instance);
-
-        }
-    }
-
-    public static class BakeEventHandler
-    {
-        public static final BakeEventHandler instance = new BakeEventHandler();
-
-        private BakeEventHandler()
-        {
         }
 
         @SubscribeEvent
-        public void onModelBakeEvent(ModelBakeEvent event)
+        public static void onModelBakeEvent(ModelBakeEvent event)
         {
             event.getModelManager().getBlockModelShapes().registerBuiltInBlocks(TEST_BLOCK);
         }
-    }
 
-    public static class TestTESR extends TileEntitySpecialRenderer<CustomTileEntity>
-    {
-        private static final TestTESR instance = new TestTESR();
-
-        private TestTESR()
+        public static class TestTESR extends TileEntitySpecialRenderer<CustomTileEntity>
         {
-        }
+            private static final TestTESR instance = new TestTESR();
 
-        @Override
-        public void render(CustomTileEntity p_180535_1_, double x, double y, double z, float p_180535_8_, int p_180535_9_, float partial)
-        {
-            glPushMatrix();
-            glTranslated(x, y, z);
-            GlStateManager.disableTexture2D();
-            GlStateManager.disableLighting();
-            glColor4f(.2f, 1, .1f, 1);
-            glBegin(GL_QUADS);
-            glVertex3f(0, .5f, 0);
-            glVertex3f(0, .5f, 1);
-            glVertex3f(1, .5f, 1);
-            glVertex3f(1, .5f, 0);
-            glEnd();
-            glPopMatrix();
-            GlStateManager.enableTexture2D();
-            GlStateManager.enableLighting();
+            private TestTESR()
+            {
+            }
+
+            @Override
+            public void render(CustomTileEntity p_180535_1_, double x, double y, double z, float p_180535_8_, int p_180535_9_, float partial)
+            {
+                glPushMatrix();
+                glTranslated(x, y, z);
+                GlStateManager.disableTexture2D();
+                GlStateManager.disableLighting();
+                glColor4f(.2f, 1, .1f, 1);
+                glBegin(GL_QUADS);
+                glVertex3f(0, .5f, 0);
+                glVertex3f(0, .5f, 1);
+                glVertex3f(1, .5f, 1);
+                glVertex3f(1, .5f, 0);
+                glEnd();
+                glPopMatrix();
+                GlStateManager.enableTexture2D();
+                GlStateManager.enableLighting();
+            }
         }
     }
 

--- a/src/test/java/net/minecraftforge/debug/ModelAnimationDebug.java
+++ b/src/test/java/net/minecraftforge/debug/ModelAnimationDebug.java
@@ -60,6 +60,7 @@ import net.minecraftforge.fml.common.registry.EntityRegistry;
 import net.minecraftforge.fml.common.registry.GameRegistry;
 import net.minecraftforge.fml.common.registry.GameRegistry.ObjectHolder;
 
+import net.minecraftforge.fml.relauncher.Side;
 import org.apache.logging.log4j.Logger;
 
 import javax.annotation.Nonnull;
@@ -196,6 +197,24 @@ public class ModelAnimationDebug
             }.setRegistryName(TEST_BLOCK.getRegistryName())
             );
         }
+    }
+
+    public static abstract class CommonProxy
+    {
+        @Nullable
+        public IAnimationStateMachine load(ResourceLocation location, ImmutableMap<String, ITimeValue> parameters){ return null; };
+    }
+
+    public static class ServerProxy extends CommonProxy {}
+
+    @Mod.EventBusSubscriber(value = Side.CLIENT, modid = MODID)
+    public static class ClientProxy extends CommonProxy
+    {
+
+        public IAnimationStateMachine load(ResourceLocation location, ImmutableMap<String, ITimeValue> parameters)
+        {
+            return ModelLoaderRegistry.loadASM(location, parameters);
+        }
 
         @SubscribeEvent
         public static void registerModels(ModelRegistryEvent event)
@@ -245,24 +264,6 @@ public class ModelAnimationDebug
                 }
             });
         }
-    }
-
-    public static abstract class CommonProxy
-    {
-        @Nullable
-        public IAnimationStateMachine load(ResourceLocation location, ImmutableMap<String, ITimeValue> parameters){ return null; };
-    }
-
-    public static class ServerProxy extends CommonProxy {}
-
-    public static class ClientProxy extends CommonProxy
-    {
-
-        public IAnimationStateMachine load(ResourceLocation location, ImmutableMap<String, ITimeValue> parameters)
-        {
-            return ModelLoaderRegistry.loadASM(location, parameters);
-        }
-
     }
 
     private static class ItemAnimationHolder implements ICapabilityProvider

--- a/src/test/java/net/minecraftforge/debug/ModelFluidDebug.java
+++ b/src/test/java/net/minecraftforge/debug/ModelFluidDebug.java
@@ -22,6 +22,7 @@ import net.minecraftforge.fml.common.Mod.EventHandler;
 import net.minecraftforge.fml.common.event.FMLPreInitializationEvent;
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
 import net.minecraftforge.fml.common.registry.GameRegistry.ObjectHolder;
+import net.minecraftforge.fml.relauncher.Side;
 
 @Mod(modid = ModelFluidDebug.MODID, name = "ForgeDebugModelFluid", version = ModelFluidDebug.VERSION, acceptableRemoteVersions = "*")
 public class ModelFluidDebug
@@ -85,7 +86,11 @@ public class ModelFluidDebug
                 new ItemBlock(MILK_BLOCK).setRegistryName(MILK_BLOCK.getRegistryName())
             );
         }
+    }
 
+    @Mod.EventBusSubscriber(value = Side.CLIENT, modid = MODID)
+    public static class ClientEventHandler
+    {
         @SubscribeEvent
         public static void registerModels(ModelRegistryEvent event)
         {


### PR DESCRIPTION
While working on #4224, I've noticed that some crash mods (mostly related to model loading) would cause the server to crash. This was (in part, I have to assume at this point) caused by the changes to the registry introduced in 1.12. In the migration, it wasn't respected that `ModelRegistryEvent` handlers must only be registered on the client. This PR moves the handlers to a specific client-only class or to an existing one. In two cases (`ItemTileDebug` and `ModelBakeEventDebug`) I also had to move the inner client-only classes (the TESR and the IBakedModel, respectively) into the event handler one, otherwise the server would still try to load them, although I'm not sure why.