### PR TITLE
Add a mechanic for server-side-only dimensions

### DIFF
--- a/patches/minecraft/net/minecraft/network/play/server/SPacketJoinGame.java.patch
+++ b/patches/minecraft/net/minecraft/network/play/server/SPacketJoinGame.java.patch
@@ -1,0 +1,11 @@
+--- ../src-base/minecraft/net/minecraft/network/play/server/SPacketJoinGame.java
++++ ../src-work/minecraft/net/minecraft/network/play/server/SPacketJoinGame.java
+@@ -28,7 +28,7 @@
+     public SPacketJoinGame(int p_i46938_1_, GameType p_i46938_2_, boolean p_i46938_3_, int p_i46938_4_, EnumDifficulty p_i46938_5_, int p_i46938_6_, WorldType p_i46938_7_, boolean p_i46938_8_)
+     {
+         this.field_149206_a = p_i46938_1_;
+-        this.field_149202_d = p_i46938_4_;
++        this.field_149202_d = net.minecraftforge.common.DimensionManager.getIdForClient(p_i46938_4_);
+         this.field_149203_e = p_i46938_5_;
+         this.field_149205_c = p_i46938_2_;
+         this.field_149200_f = p_i46938_6_;

--- a/patches/minecraft/net/minecraft/network/play/server/SPacketRespawn.java.patch
+++ b/patches/minecraft/net/minecraft/network/play/server/SPacketRespawn.java.patch
@@ -1,0 +1,11 @@
+--- ../src-base/minecraft/net/minecraft/network/play/server/SPacketRespawn.java
++++ ../src-work/minecraft/net/minecraft/network/play/server/SPacketRespawn.java
+@@ -23,7 +23,7 @@
+ 
+     public SPacketRespawn(int p_i46923_1_, EnumDifficulty p_i46923_2_, WorldType p_i46923_3_, GameType p_i46923_4_)
+     {
+-        this.field_149088_a = p_i46923_1_;
++        this.field_149088_a = net.minecraftforge.common.DimensionManager.getIdForClient(p_i46923_1_);
+         this.field_149086_b = p_i46923_2_;
+         this.field_149087_c = p_i46923_4_;
+         this.field_149085_d = p_i46923_3_;

--- a/src/main/java/net/minecraftforge/common/DimensionManager.java
+++ b/src/main/java/net/minecraftforge/common/DimensionManager.java
@@ -60,10 +60,12 @@ public class DimensionManager
     private static class Dimension
     {
         private final DimensionType type;
+        private final int clientDimId;
         private int ticksWaited;
-        private Dimension(DimensionType type)
+        private Dimension(DimensionType type, int clientDimId)
         {
             this.type = type;
+            this.clientDimId = clientDimId;
             this.ticksWaited = 0;
         }
     }
@@ -110,12 +112,17 @@ public class DimensionManager
 
     public static void registerDimension(int id, DimensionType type)
     {
+        registerDimension(id, type, id);
+    }
+
+    public static void registerDimension(int id, DimensionType type, int clientDimensionId)
+    {
         DimensionType.getById(type.getId()); //Check if type is invalid {will throw an error} No clue how it would be invalid tho...
         if (dimensions.containsKey(id))
         {
             throw new IllegalArgumentException(String.format("Failed to register dimension for id %d, One is already registered", id));
         }
-        dimensions.put(id, new Dimension(type));
+        dimensions.put(id, new Dimension(type, clientDimensionId));
         if (id >= 0)
         {
             dimensionMap.set(id);
@@ -182,6 +189,11 @@ public class DimensionManager
     public static Integer[] getIDs()
     {
         return worlds.keySet().toArray(new Integer[worlds.size()]); //Only loaded dims, since usually used to cycle through loaded worlds
+    }
+
+    public static int getIdForClient(int id)
+    {
+        return dimensions.get(id).clientDimId;
     }
 
     public static void setWorld(int id, @Nullable WorldServer world, MinecraftServer server)

--- a/src/main/java/net/minecraftforge/fml/common/network/handshake/NetworkDispatcher.java
+++ b/src/main/java/net/minecraftforge/fml/common/network/handshake/NetworkDispatcher.java
@@ -225,7 +225,7 @@ public class NetworkDispatcher extends SimpleChannelInboundHandler<Packet<?>> im
             int dimension = playerNBT.getInteger("Dimension");
             if (DimensionManager.isDimensionRegistered(dimension))
             {
-                return dimension;
+                return DimensionManager.getIdForClient(dimension);
             }
         }
         return 0;

--- a/src/test/java/net/minecraftforge/debug/ServerOnlyDimensionTest.java
+++ b/src/test/java/net/minecraftforge/debug/ServerOnlyDimensionTest.java
@@ -1,0 +1,141 @@
+package net.minecraftforge.debug;
+
+import net.minecraft.command.CommandBase;
+import net.minecraft.command.CommandException;
+import net.minecraft.command.ICommandSender;
+import net.minecraft.entity.Entity;
+import net.minecraft.entity.player.EntityPlayerMP;
+import net.minecraft.server.MinecraftServer;
+import net.minecraft.util.DamageSource;
+import net.minecraft.util.text.TextComponentString;
+import net.minecraft.world.DimensionType;
+import net.minecraft.world.Teleporter;
+import net.minecraft.world.WorldProviderSurface;
+import net.minecraft.world.WorldServer;
+import net.minecraftforge.common.DimensionManager;
+import net.minecraftforge.fml.common.Mod;
+import net.minecraftforge.fml.common.event.FMLPreInitializationEvent;
+import net.minecraftforge.fml.common.event.FMLServerStartingEvent;
+
+@Mod(modid = "forge.serveronlydimensiontest", serverSideOnly = true, acceptableRemoteVersions = "*")
+public class ServerOnlyDimensionTest
+{
+
+    private static final boolean ENABLED = Boolean.TRUE;
+    private static final int DIMENSION_ID = 100;
+
+    @Mod.EventHandler
+    public void preInit(FMLPreInitializationEvent event)
+    {
+        if (!ENABLED)
+        {
+            return;
+        }
+
+        DimensionType dimensionType = DimensionType.register("forge_serveronlytest", "_serveronlytest", 100, ServerOnlyOverworldClone.class, false);
+        DimensionManager.registerDimension(DIMENSION_ID, dimensionType, 0);
+    }
+
+    @Mod.EventHandler
+    public void serverStart(FMLServerStartingEvent event)
+    {
+        if (!ENABLED)
+        {
+            return;
+        }
+
+        event.registerServerCommand(new CommandBase()
+        {
+            @Override
+            public String getName()
+            {
+                return "serveronlytestdim";
+            }
+
+            @Override
+            public boolean checkPermission(MinecraftServer server, ICommandSender sender)
+            {
+                return true;
+            }
+
+            @Override
+            public String getUsage(ICommandSender sender)
+            {
+                return "";
+            }
+
+            @Override
+            public void execute(MinecraftServer server, ICommandSender sender, String[] args) throws CommandException
+            {
+                if (sender instanceof EntityPlayerMP)
+                {
+                    EntityPlayerMP player = (EntityPlayerMP)sender;
+                    Teleporter teleporter = new Teleporter(((WorldServer)player.world))
+                    {
+                        @Override
+                        public void placeInPortal(Entity entityIn, float rotationYaw)
+                        {
+                            if (entityIn instanceof EntityPlayerMP)
+                            {
+                                ((EntityPlayerMP)entityIn).connection.setPlayerLocation(0, 70, 0, entityIn.rotationYaw, entityIn.rotationPitch);
+                            }
+                            else
+                            {
+                                entityIn.attackEntityFrom(DamageSource.OUT_OF_WORLD, 10000);
+                            }
+                        }
+                    };
+                    server.getPlayerList().transferPlayerToDimension(player, DIMENSION_ID, teleporter);
+                    player.changeDimension(DIMENSION_ID);
+                }
+            }
+        });
+
+        event.registerServerCommand(new CommandBase()
+        {
+            @Override
+            public String getName()
+            {
+                return "getmydimension";
+            }
+
+            @Override
+            public boolean checkPermission(MinecraftServer server, ICommandSender sender)
+            {
+                return true;
+            }
+
+            @Override
+            public String getUsage(ICommandSender sender)
+            {
+                return "";
+            }
+
+            @Override
+            public void execute(MinecraftServer server, ICommandSender sender, String[] args) throws CommandException
+            {
+                if (sender instanceof EntityPlayerMP)
+                {
+                    sender.sendMessage(new TextComponentString(String.valueOf(((EntityPlayerMP)sender).dimension)));
+                }
+            }
+        });
+    }
+
+    public static class ServerOnlyOverworldClone extends WorldProviderSurface
+    {
+
+        @Override
+        public boolean canRespawnHere()
+        {
+            return false;
+        }
+
+        @Override
+        public int getRespawnDimension(EntityPlayerMP player)
+        {
+            return 0;
+        }
+    }
+
+}

--- a/src/test/java/net/minecraftforge/debug/ServerOnlyDimensionTest.java
+++ b/src/test/java/net/minecraftforge/debug/ServerOnlyDimensionTest.java
@@ -86,7 +86,6 @@ public class ServerOnlyDimensionTest
                         }
                     };
                     server.getPlayerList().transferPlayerToDimension(player, DIMENSION_ID, teleporter);
-                    player.changeDimension(DIMENSION_ID);
                 }
             }
         });

--- a/src/test/java/net/minecraftforge/debug/ServerOnlyDimensionTest.java
+++ b/src/test/java/net/minecraftforge/debug/ServerOnlyDimensionTest.java
@@ -32,7 +32,7 @@ public class ServerOnlyDimensionTest
             return;
         }
 
-        DimensionType dimensionType = DimensionType.register("forge_serveronlytest", "_serveronlytest", 100, ServerOnlyOverworldClone.class, false);
+        DimensionType dimensionType = DimensionType.register("forge_serveronlytest", "_serveronlytest", DIMENSION_ID, ServerOnlyOverworldClone.class, false);
         DimensionManager.registerDimension(DIMENSION_ID, dimensionType, 0);
     }
 


### PR DESCRIPTION
Allows an alternative dimension-ID to be specified for the client. This allows to create a dimension that will e.g. appear as the overworld to the client, but using a different (internal) dimension ID on the server.
One application is so called "multiverse" mods, where a server can host multiple worlds and players can switch using commands. Using this method even vanilla clients could join such servers.