### PR TITLE
Allow recipes to be synced between the client and server

### DIFF
--- a/patches/minecraft/net/minecraft/item/crafting/IRecipe.java.patch
+++ b/patches/minecraft/net/minecraft/item/crafting/IRecipe.java.patch
@@ -1,6 +1,6 @@
 --- ../src-base/minecraft/net/minecraft/item/crafting/IRecipe.java
 +++ ../src-work/minecraft/net/minecraft/item/crafting/IRecipe.java
-@@ -4,35 +4,33 @@
+@@ -4,36 +4,45 @@
  import net.minecraft.item.ItemStack;
  import net.minecraft.util.NonNullList;
  import net.minecraft.world.World;
@@ -44,3 +44,15 @@
      {
          return "";
      }
++
++    /* ======================================== FORGE START =====================================*/
++    default com.google.gson.JsonObject toJson()
++    {
++        com.google.gson.JsonObject json = new com.google.gson.JsonObject();
++        json.addProperty("type", "minecraft:builtin");
++        json.addProperty("class", this.getClass().getName());
++        return json;
++    }
++
++    /* ======================================== FORGE END   =====================================*/
+ }

--- a/patches/minecraft/net/minecraft/item/crafting/Ingredient.java.patch
+++ b/patches/minecraft/net/minecraft/item/crafting/Ingredient.java.patch
@@ -31,7 +31,7 @@
      public ItemStack[] func_193365_a()
      {
          return this.field_193371_b;
-@@ -110,4 +116,16 @@
+@@ -110,4 +116,37 @@
  
          return this.field_194140_c;
      }
@@ -47,4 +47,25 @@
 +    {
 +        this.field_194140_c = null;
 +    }
++
++    /* ======================================== FORGE START =====================================*/
++    public com.google.gson.JsonElement toJson()
++    {
++        if (this.field_193371_b.length > 0)
++        {
++            if (this.field_193371_b.length == 1)
++            {
++                com.google.gson.JsonObject json = net.minecraftforge.common.crafting.CraftingHelper.serializeItem(this.field_193371_b[0]);
++                json.addProperty("type", "minecraft:item");
++                return json;
++            }
++            com.google.gson.JsonArray json = new com.google.gson.JsonArray();
++            for (ItemStack stack : this.field_193371_b)
++                json.add(net.minecraftforge.common.crafting.CraftingHelper.serializeItemBasic(stack));
++            return json;
++        }
++        return field_193370_a.toJson();
++    }
++
++    /* ======================================== FORGE END   =====================================*/
  }

--- a/patches/minecraft/net/minecraft/item/crafting/ShapedRecipes.java.patch
+++ b/patches/minecraft/net/minecraft/item/crafting/ShapedRecipes.java.patch
@@ -59,3 +59,64 @@
      public int func_192404_g()
      {
          return this.field_77577_c;
+@@ -382,4 +371,60 @@
+             return new ItemStack(item, j, i);
+         }
+     }
++
++    /* ======================================== FORGE START =====================================*/
++    public JsonObject toJson()
++    {
++        JsonObject json = new JsonObject();
++        json.addProperty("type", "minecraft:crafting_shaped");
++        json.addProperty("group", this.func_193358_e());
++        char[][] rows = new char[this.field_77577_c][this.field_77576_b];
++        int x = 0;
++        int y = 0;
++        Map<Ingredient, Character> ingredients = Maps.newHashMap();
++        JsonObject key = new JsonObject();
++        char c = Character.MIN_VALUE;
++        for (Ingredient ingredient : this.field_77574_d)
++        {
++            if (ingredient.func_193365_a().length > 0)
++            {
++                if (c == ' ')
++                    c++;
++                char k = c;
++                ingredients.computeIfAbsent(ingredient, (ing) -> 
++                {
++                    key.add(String.valueOf(k), ingredient.toJson());
++                    return k;
++                });
++                c++;
++            }
++            rows[y][x++] = ingredient.func_193365_a().length > 0 ? ingredients.get(ingredient) : ' ';
++            if (x == this.field_77576_b)
++            {
++                y++;
++                x = 0;
++            }
++        }
++        JsonArray pattern = new JsonArray();
++        for (char[] row : rows)
++            pattern.add(String.copyValueOf(row));
++        json.add("pattern", pattern);
++        json.add("key", key);
++        JsonObject result = new JsonObject();
++        ItemStack output = this.func_77571_b();
++        result.addProperty("item", output.func_77973_b().getRegistryName().toString());
++        net.minecraft.nbt.NBTTagCompound tmp = new net.minecraft.nbt.NBTTagCompound();
++        output.func_77955_b(tmp);
++        result.addProperty("count", tmp.func_74771_c("Count"));
++        result.addProperty("data", tmp.func_74771_c("Damage"));
++        net.minecraft.nbt.NBTTagCompound compound = tmp.func_74764_b("tag") ? tmp.func_74775_l("tag") : new net.minecraft.nbt.NBTTagCompound();
++        if (tmp.func_74764_b("ForgeCaps"))
++            compound.func_74782_a("ForgeCaps", tmp.func_74775_l("ForgeCaps"));
++        if (compound.func_186856_d() > 0)
++            result.add("nbt", net.minecraftforge.common.crafting.CraftingHelper.getJsonFromTagCompound(compound));
++        json.add("result", result);
++        return json;
++    }
++
++    /* ======================================== FORGE END =====================================*/
+ }

--- a/patches/minecraft/net/minecraft/item/crafting/ShapelessRecipes.java.patch
+++ b/patches/minecraft/net/minecraft/item/crafting/ShapelessRecipes.java.patch
@@ -39,7 +39,7 @@
      public NonNullList<Ingredient> func_192400_c()
      {
          return this.field_77579_b;
-@@ -137,7 +129,6 @@
+@@ -137,9 +129,36 @@
          return nonnulllist;
      }
  
@@ -47,3 +47,33 @@
      public boolean func_194133_a(int p_194133_1_, int p_194133_2_)
      {
          return p_194133_1_ * p_194133_2_ >= this.field_77579_b.size();
+     }
++
++    /* ======================================== FORGE START =====================================*/
++    public JsonObject toJson()
++    {
++        JsonObject json = new JsonObject();
++        json.addProperty("type", "minecraft:crafting_shapeless");
++        json.addProperty("group", this.func_193358_e());
++        JsonArray ingredients = new JsonArray();
++        for (Ingredient ingredient : this.field_77579_b)
++            ingredients.add(ingredient.toJson());
++        json.add("ingredients", ingredients);
++        JsonObject result = new JsonObject();
++        ItemStack output = this.func_77571_b();
++        result.addProperty("item", output.func_77973_b().getRegistryName().toString());
++        net.minecraft.nbt.NBTTagCompound tmp = new net.minecraft.nbt.NBTTagCompound();
++        output.func_77955_b(tmp);
++        result.addProperty("count", tmp.func_74771_c("Count"));
++        result.addProperty("data", tmp.func_74771_c("Damage"));
++        net.minecraft.nbt.NBTTagCompound compound = tmp.func_74764_b("tag") ? tmp.func_74775_l("tag") : new net.minecraft.nbt.NBTTagCompound();
++        if (tmp.func_74764_b("ForgeCaps"))
++            compound.func_74782_a("ForgeCaps", tmp.func_74775_l("ForgeCaps"));
++        if (compound.func_186856_d() > 0)
++            result.add("nbt", net.minecraftforge.common.crafting.CraftingHelper.getJsonFromTagCompound(compound));
++        json.add("result", result);
++        return json;
++    }
++
++    /* ======================================== FORGE END =====================================*/
+ }

--- a/patches/minecraft/net/minecraft/server/MinecraftServer.java.patch
+++ b/patches/minecraft/net/minecraft/server/MinecraftServer.java.patch
@@ -259,7 +259,15 @@
      }
  
      public CrashReport func_71230_b(CrashReport p_71230_1_)
-@@ -1594,4 +1638,9 @@
+@@ -1374,6 +1418,7 @@
+     {
+         if (this.func_152345_ab())
+         {
++            net.minecraftforge.common.crafting.CraftingHelper.reload(this.field_71305_c[0]);
+             this.func_184103_al().func_72389_g();
+             this.field_71305_c[0].func_184146_ak().func_186522_a();
+             this.func_191949_aK().func_192779_a();
+@@ -1594,4 +1639,9 @@
      {
          return this.field_175590_aa;
      }

--- a/patches/minecraft/net/minecraft/world/WorldServer.java.patch
+++ b/patches/minecraft/net/minecraft/world/WorldServer.java.patch
@@ -43,7 +43,15 @@
          }
          else
          {
-@@ -160,6 +169,7 @@
+@@ -142,6 +151,7 @@
+ 
+         scoreboardsavedata.func_96499_a(this.field_96442_D);
+         ((ServerScoreboard)this.field_96442_D).func_186684_a(new WorldSavedDataCallableSave(scoreboardsavedata));
++        net.minecraftforge.common.crafting.CraftingHelper.reload(this);
+         this.field_184151_B = new LootTableManager(new File(new File(this.field_73019_z.func_75765_b(), "data"), "loot_tables"));
+         this.field_191951_C = new AdvancementManager(new File(new File(this.field_73019_z.func_75765_b(), "data"), "advancements"));
+         this.field_193036_D = new FunctionManager(new File(new File(this.field_73019_z.func_75765_b(), "data"), "functions"), this.field_73061_a);
+@@ -160,6 +170,7 @@
              this.func_175723_af().func_177750_a(this.field_72986_A.func_176137_E());
          }
  
@@ -51,7 +59,7 @@
          return this;
      }
  
-@@ -178,8 +188,8 @@
+@@ -178,8 +189,8 @@
          {
              if (this.func_82736_K().func_82766_b("doDaylightCycle"))
              {
@@ -62,7 +70,7 @@
              }
  
              this.func_73053_d();
-@@ -205,7 +215,7 @@
+@@ -205,7 +216,7 @@
  
          if (this.func_82736_K().func_82766_b("doDaylightCycle"))
          {
@@ -71,7 +79,7 @@
          }
  
          this.field_72984_F.func_76318_c("tickPending");
-@@ -219,6 +229,10 @@
+@@ -219,6 +230,10 @@
          this.field_175740_d.func_75528_a();
          this.field_72984_F.func_76318_c("portalForcer");
          this.field_85177_Q.func_85189_a(this.func_82737_E());
@@ -82,7 +90,7 @@
          this.field_72984_F.func_76319_b();
          this.func_147488_Z();
      }
-@@ -227,12 +241,14 @@
+@@ -227,12 +242,14 @@
      public Biome.SpawnListEntry func_175734_a(EnumCreatureType p_175734_1_, BlockPos p_175734_2_)
      {
          List<Biome.SpawnListEntry> list = this.func_72863_F().func_177458_a(p_175734_1_, p_175734_2_);
@@ -97,7 +105,7 @@
          return list != null && !list.isEmpty() ? list.contains(p_175732_2_) : false;
      }
  
-@@ -281,10 +297,7 @@
+@@ -281,10 +298,7 @@
  
      private void func_73051_P()
      {
@@ -109,7 +117,7 @@
      }
  
      public boolean func_73056_e()
-@@ -377,7 +390,7 @@
+@@ -377,7 +391,7 @@
              boolean flag1 = this.func_72911_I();
              this.field_72984_F.func_76320_a("pollingChunks");
  
@@ -118,7 +126,7 @@
              {
                  this.field_72984_F.func_76320_a("getChunk");
                  Chunk chunk = iterator.next();
-@@ -389,7 +402,7 @@
+@@ -389,7 +403,7 @@
                  chunk.func_150804_b(false);
                  this.field_72984_F.func_76318_c("thunder");
  
@@ -127,7 +135,7 @@
                  {
                      this.field_73005_l = this.field_73005_l * 3 + 1013904223;
                      int l = this.field_73005_l >> 2;
-@@ -417,7 +430,7 @@
+@@ -417,7 +431,7 @@
  
                  this.field_72984_F.func_76318_c("iceandsnow");
  
@@ -136,7 +144,7 @@
                  {
                      this.field_73005_l = this.field_73005_l * 3 + 1013904223;
                      int j2 = this.field_73005_l >> 2;
-@@ -527,7 +540,10 @@
+@@ -527,7 +541,10 @@
          {
              if (p_175654_2_.func_149698_L())
              {
@@ -148,7 +156,7 @@
                  {
                      IBlockState iblockstate = this.func_180495_p(p_175654_1_);
  
-@@ -563,6 +579,7 @@
+@@ -563,6 +580,7 @@
  
      public void func_180497_b(BlockPos p_180497_1_, Block p_180497_2_, int p_180497_3_, int p_180497_4_)
      {
@@ -156,7 +164,7 @@
          NextTickListEntry nextticklistentry = new NextTickListEntry(p_180497_1_, p_180497_2_);
          nextticklistentry.func_82753_a(p_180497_4_);
          Material material = p_180497_2_.func_176223_P().func_185904_a();
-@@ -581,7 +598,7 @@
+@@ -581,7 +599,7 @@
  
      public void func_72939_s()
      {
@@ -165,7 +173,7 @@
          {
              if (this.field_80004_Q++ >= 300)
              {
-@@ -705,6 +722,9 @@
+@@ -705,6 +723,9 @@
                  {
                      NextTickListEntry nextticklistentry1 = iterator.next();
                      iterator.remove();
@@ -175,7 +183,7 @@
                      int k = 0;
  
                      if (this.func_175707_a(nextticklistentry1.field_180282_a.func_177982_a(0, 0, 0), nextticklistentry1.field_180282_a.func_177982_a(0, 0, 0)))
-@@ -831,6 +851,10 @@
+@@ -831,6 +852,10 @@
  
      public boolean func_175660_a(EntityPlayer p_175660_1_, BlockPos p_175660_2_)
      {
@@ -186,7 +194,7 @@
          return !this.field_73061_a.func_175579_a(this, p_175660_2_, p_175660_1_) && this.func_175723_af().func_177746_a(p_175660_2_);
      }
  
-@@ -896,6 +920,7 @@
+@@ -896,6 +921,7 @@
          }
          else
          {
@@ -194,7 +202,7 @@
              this.field_72987_B = true;
              BiomeProvider biomeprovider = this.field_73011_w.func_177499_m();
              List<Biome> list = biomeprovider.func_76932_a();
-@@ -981,6 +1006,7 @@
+@@ -981,6 +1007,7 @@
              }
  
              chunkproviderserver.func_186027_a(p_73044_1_);
@@ -202,7 +210,7 @@
  
              for (Chunk chunk : Lists.newArrayList(chunkproviderserver.func_189548_a()))
              {
-@@ -1025,6 +1051,7 @@
+@@ -1025,6 +1052,7 @@
          this.field_72986_A.func_176135_e(this.func_175723_af().func_177732_i());
          this.field_73019_z.func_75755_a(this.field_72986_A, this.field_73061_a.func_184103_al().func_72378_q());
          this.field_72988_C.func_75744_a();
@@ -210,7 +218,7 @@
      }
  
      public boolean func_72838_d(Entity p_72838_1_)
-@@ -1036,7 +1063,7 @@
+@@ -1036,7 +1064,7 @@
      {
          for (Entity entity : Lists.newArrayList(p_175650_1_))
          {
@@ -219,7 +227,7 @@
              {
                  this.field_72996_f.add(entity);
                  this.func_72923_a(entity);
-@@ -1117,7 +1144,7 @@
+@@ -1117,7 +1145,7 @@
      {
          if (super.func_72942_c(p_72942_1_))
          {
@@ -228,7 +236,7 @@
              return true;
          }
          else
-@@ -1139,6 +1166,7 @@
+@@ -1139,6 +1167,7 @@
      public Explosion func_72885_a(@Nullable Entity p_72885_1_, double p_72885_2_, double p_72885_4_, double p_72885_6_, float p_72885_8_, boolean p_72885_9_, boolean p_72885_10_)
      {
          Explosion explosion = new Explosion(this, p_72885_1_, p_72885_2_, p_72885_4_, p_72885_6_, p_72885_8_, p_72885_9_, p_72885_10_);
@@ -236,7 +244,7 @@
          explosion.func_77278_a();
          explosion.func_77279_a(false);
  
-@@ -1184,7 +1212,7 @@
+@@ -1184,7 +1213,7 @@
              {
                  if (this.func_147485_a(blockeventdata))
                  {
@@ -245,7 +253,7 @@
                  }
              }
  
-@@ -1210,27 +1238,31 @@
+@@ -1210,27 +1239,31 @@
  
          if (this.field_73003_n != this.field_73004_o)
          {
@@ -283,7 +291,7 @@
          }
      }
  
-@@ -1325,6 +1357,11 @@
+@@ -1325,6 +1358,11 @@
          return this.field_193036_D;
      }
  

--- a/src/main/java/net/minecraftforge/common/ForgeHooks.java
+++ b/src/main/java/net/minecraftforge/common/ForgeHooks.java
@@ -1267,7 +1267,7 @@ public class ForgeHooks
 
     private static boolean loadAdvancements(Map<ResourceLocation, Advancement.Builder> map, ModContainer mod)
     {
-        return CraftingHelper.findFiles(mod, "assets/" + mod.getModId() + "/advancements", null,
+        return CraftingHelper.findFiles(mod.getSource(), mod.getModId(), "assets/" + mod.getModId() + "/advancements", null,
             (root, file) ->
             {
 

--- a/src/main/java/net/minecraftforge/common/crafting/CompoundIngredient.java
+++ b/src/main/java/net/minecraftforge/common/crafting/CompoundIngredient.java
@@ -8,6 +8,8 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
 import com.google.common.collect.Lists;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
 
 import it.unimi.dsi.fastutil.ints.IntArrayList;
 import it.unimi.dsi.fastutil.ints.IntComparators;
@@ -80,5 +82,14 @@ public class CompoundIngredient extends Ingredient
         this.itemIds = null;
         this.stacks = null;
         //Shouldn't need to invalidate children as this is only called form invalidateAll..
+    }
+    
+    @Override
+    public JsonElement toJson()
+    {
+        JsonArray json = new JsonArray();
+        for (Ingredient ingredient : this.children)
+            json.add(ingredient.toJson());
+        return json;
     }
 }

--- a/src/main/java/net/minecraftforge/common/crafting/ConstantIngredient.java
+++ b/src/main/java/net/minecraftforge/common/crafting/ConstantIngredient.java
@@ -1,0 +1,46 @@
+package net.minecraftforge.common.crafting;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+
+import it.unimi.dsi.fastutil.ints.IntList;
+import net.minecraft.item.ItemStack;
+import net.minecraft.item.crafting.Ingredient;
+import net.minecraftforge.fml.relauncher.Side;
+import net.minecraftforge.fml.relauncher.SideOnly;
+
+public class ConstantIngredient extends Ingredient
+{
+    public final Ingredient parent;
+    public final String constant;
+    
+    public ConstantIngredient(Ingredient parent, String constant)
+    {
+        super(parent.getMatchingStacks());
+        this.parent = parent;
+        this.constant = constant;
+    }
+    
+    @Override
+    public boolean apply(ItemStack stack)
+    {
+        return this.parent.apply(stack);
+    }
+
+    @SideOnly(Side.CLIENT)
+    public IntList getValidItemStacksPacked()
+    {
+        return this.parent.getValidItemStacksPacked();
+    }
+    
+    @Override
+    public JsonElement toJson()
+    {
+        JsonObject json = new JsonObject();
+
+        json.addProperty("type", "minecraft:item");
+        json.addProperty("item", "#" + this.constant);
+        
+        return json;
+    }
+}

--- a/src/main/java/net/minecraftforge/common/crafting/IngredientNBT.java
+++ b/src/main/java/net/minecraftforge/common/crafting/IngredientNBT.java
@@ -20,6 +20,9 @@ package net.minecraftforge.common.crafting;
 
 import javax.annotation.Nullable;
 
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+
 import net.minecraft.item.ItemStack;
 import net.minecraft.item.crafting.Ingredient;
 
@@ -38,5 +41,15 @@ public class IngredientNBT extends Ingredient
         if (input == null)
             return false;
         return ItemStack.areItemStacksEqualUsingNBTShareTag(this.stack, input);
+    }
+    
+    @Override
+    public JsonElement toJson()
+    {
+        JsonObject json = CraftingHelper.serializeItem(this.stack);
+        
+        json.addProperty("type", "minecraft:item_nbt");
+        
+        return json;
     }
 }

--- a/src/main/java/net/minecraftforge/fml/common/Loader.java
+++ b/src/main/java/net/minecraftforge/fml/common/Loader.java
@@ -776,7 +776,6 @@ public class Loader
     public void initializeMods()
     {
         progressBar.step("Initializing mods Phase 2");
-        CraftingHelper.loadRecipes(false);
         // Mod controller should be in the initialization state here
         modController.distributeStateMessage(LoaderState.INITIALIZATION);
         progressBar.step("Initializing mods Phase 3");

--- a/src/main/java/net/minecraftforge/fml/common/network/handshake/FMLHandshakeClientState.java
+++ b/src/main/java/net/minecraftforge/fml/common/network/handshake/FMLHandshakeClientState.java
@@ -38,6 +38,7 @@ import net.minecraftforge.fml.common.network.internal.FMLNetworkHandler;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.registries.ForgeRegistry;
 import net.minecraftforge.registries.GameData;
+import net.minecraftforge.registries.RegistryManager;
 
 /**
  * Packet handshake sequence manager- client side (responding to remote server)
@@ -126,6 +127,8 @@ enum FMLHandshakeClientState implements IHandshakeState<FMLHandshakeClientState>
                 snap = Maps.newHashMap();
                 ctx.channel().attr(NetworkDispatcher.FML_GAMEDATA_SNAPSHOT).set(snap);
             }
+            
+            RegistryManager.ACTIVE.getRegistry(pkt.getName()).syncCallback(RegistryManager.ACTIVE, pkt.getExtra(), Side.CLIENT, true);
 
             ForgeRegistry.Snapshot entry = new ForgeRegistry.Snapshot();
             entry.ids.putAll(pkt.getIdMap());

--- a/src/main/java/net/minecraftforge/oredict/OreIngredient.java
+++ b/src/main/java/net/minecraftforge/oredict/OreIngredient.java
@@ -21,6 +21,8 @@ package net.minecraftforge.oredict;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
+import com.google.gson.JsonObject;
+
 import it.unimi.dsi.fastutil.ints.IntArrayList;
 import it.unimi.dsi.fastutil.ints.IntComparators;
 import it.unimi.dsi.fastutil.ints.IntList;
@@ -34,6 +36,7 @@ import net.minecraftforge.fml.relauncher.SideOnly;
 
 public class OreIngredient extends Ingredient
 {
+    private final String ore;
     private NonNullList<ItemStack> ores;
     private IntList itemIds = null;
     private ItemStack[] array = null;
@@ -41,6 +44,7 @@ public class OreIngredient extends Ingredient
     public OreIngredient(String ore)
     {
         super(0);
+        this.ore = ore;
         ores = OreDictionary.getOres(ore);
     }
 
@@ -112,5 +116,16 @@ public class OreIngredient extends Ingredient
     protected void invalidate()
     {
         this.itemIds = null;
+    }
+
+    @Override
+    public JsonObject toJson()
+    {
+        JsonObject json = new JsonObject();
+        
+        json.addProperty("type", "forge:ore_dict");
+        json.addProperty("ore", this.ore);
+        
+        return json;
     }
 }

--- a/src/main/java/net/minecraftforge/oredict/ShapedOreRecipe.java
+++ b/src/main/java/net/minecraftforge/oredict/ShapedOreRecipe.java
@@ -29,7 +29,6 @@ import net.minecraft.util.JsonUtils;
 import net.minecraft.util.NonNullList;
 import net.minecraft.util.ResourceLocation;
 import net.minecraft.world.World;
-import net.minecraftforge.common.ForgeHooks;
 import net.minecraftforge.common.crafting.CraftingHelper;
 import net.minecraftforge.common.crafting.CraftingHelper.ShapedPrimer;
 import net.minecraftforge.registries.IForgeRegistryEntry;
@@ -40,7 +39,6 @@ import java.util.Set;
 import java.util.Map.Entry;
 
 import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
@@ -175,6 +173,14 @@ public class ShapedOreRecipe extends IForgeRegistryEntry.Impl<IRecipe> implement
     public boolean canFit(int p_194133_1_, int p_194133_2_)
     {
         return p_194133_1_ >= this.width && p_194133_2_ >= this.height;
+    }
+    
+    @Override
+    public JsonObject toJson()
+    {
+        JsonObject json = new JsonObject();
+        
+        return json;
     }
 
     public static ShapedOreRecipe factory(JsonContext context, JsonObject json)

--- a/src/main/java/net/minecraftforge/oredict/ShapelessOreRecipe.java
+++ b/src/main/java/net/minecraftforge/oredict/ShapelessOreRecipe.java
@@ -23,7 +23,6 @@ import java.util.Iterator;
 import net.minecraft.block.Block;
 import net.minecraft.item.crafting.IRecipe;
 import net.minecraft.item.crafting.Ingredient;
-import net.minecraft.item.crafting.ShapedRecipes;
 import net.minecraft.inventory.InventoryCrafting;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
@@ -31,7 +30,6 @@ import net.minecraft.util.JsonUtils;
 import net.minecraft.util.NonNullList;
 import net.minecraft.util.ResourceLocation;
 import net.minecraft.world.World;
-import net.minecraftforge.common.ForgeHooks;
 import net.minecraftforge.common.crafting.CraftingHelper;
 import net.minecraftforge.common.crafting.JsonContext;
 import net.minecraftforge.registries.IForgeRegistryEntry;
@@ -142,6 +140,14 @@ public class ShapelessOreRecipe extends IForgeRegistryEntry.Impl<IRecipe> implem
     public boolean canFit(int p_194133_1_, int p_194133_2_)
     {
         return p_194133_1_ * p_194133_2_ >= this.input.size();
+    }
+
+    @Override
+    public JsonObject toJson()
+    {
+        JsonObject json = new JsonObject();
+        
+        return json;
     }
 
     public static ShapelessOreRecipe factory(JsonContext context, JsonObject json)

--- a/src/main/java/net/minecraftforge/registries/IForgeRegistry.java
+++ b/src/main/java/net/minecraftforge/registries/IForgeRegistry.java
@@ -28,6 +28,9 @@ import net.minecraft.util.ResourceLocation;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
+import io.netty.buffer.ByteBuf;
+import net.minecraftforge.fml.relauncher.Side;
+
 /**
  * Main interface for the registry system. Use this to query the registry system.
  *
@@ -85,6 +88,14 @@ public interface IForgeRegistry<V extends IForgeRegistryEntry<V>> extends Iterab
     interface CreateCallback<V extends IForgeRegistryEntry<V>>
     {
         void onCreate(IForgeRegistryInternal<V> owner, RegistryManager stage);
+    }
+
+    /**
+     * Callback fired when the registry attempting to sync between the client and server.
+     */
+    interface SyncCallback<V extends IForgeRegistryEntry<V>>
+    {
+        void onSync(IForgeRegistryInternal<V> owner, RegistryManager stage, ByteBuf buffer, Side side, boolean reading);
     }
 
     /**

--- a/src/main/java/net/minecraftforge/registries/RegistryManager.java
+++ b/src/main/java/net/minecraftforge/registries/RegistryManager.java
@@ -75,7 +75,7 @@ public class RegistryManager
     }
 
     <V extends IForgeRegistryEntry<V>> ForgeRegistry<V> createRegistry(ResourceLocation name, Class<V> type, ResourceLocation defaultKey, int min, int max,
-            @Nullable AddCallback<V> add, @Nullable ClearCallback<V> clear, @Nullable CreateCallback<V> create,
+            @Nullable AddCallback<V> add, @Nullable ClearCallback<V> clear, @Nullable CreateCallback<V> create, @Nullable SyncCallback<V> sync,
             boolean persisted, boolean allowOverrides, boolean isModifiable, @Nullable DummyFactory<V> dummyFactory)
     {
         Set<Class<?>> parents = Sets.newHashSet();
@@ -87,7 +87,7 @@ public class RegistryManager
             FMLLog.log.error("Found existing registry of type {} named {}, you cannot create a new registry ({}) with type {}, as {} has a parent of that type", foundType, superTypes.get(foundType), name, type, type);
             throw new IllegalArgumentException("Duplicate registry parent type found - you can only have one registry for a particular super type");
         }
-        ForgeRegistry<V> reg = new ForgeRegistry<V>(type, defaultKey, min, max, create, add, clear, this, allowOverrides, isModifiable, dummyFactory);
+        ForgeRegistry<V> reg = new ForgeRegistry<V>(type, defaultKey, min, max, create, add, clear, sync, this, allowOverrides, isModifiable, dummyFactory);
         registries.put(name, reg);
         superTypes.put(type, name);
         if (persisted)


### PR DESCRIPTION
Simply put, this pr allows recipes to be synced between the client and server and adds support for custom recipes and overriding existing recipes by putting recipes in the `data/recipes/modid` folder.

For this to happen, there needed to be a few additions, fixes, and breaking changes.

- `IForgeRegistry#SyncCallback` has been added, so registries can actually sync registry entries, or in the case recipes, from the server and inject them into the client.

- `Ingredient` and `IRecipe` now have `toJson()` methods, allowing them to be sent to the client in a json format.

- `CraftingHelper#loadRecipes` has been renamed to `CraftingHelper#reload`, and has a `WorldServer` parameter.

- `CraftingHelper#reload` is now called in `MinecraftServer#reload` instead of `Loader#initializeMods`.

- GameData#revert uses the `RegistryManager` parameter that is passed instead of `RegistryManager.FROZEN`.

- When loading from the world, if the mod owner is unknown, then it will switch the registry name to minecraft:custom/modid/path/to/recipe to prevent console spam.

- And a few other minor changes to make sure the recipes sync properly.

EDIT 1:

This pr also allows server-side only mods to have their recipes injected into the client connecting to the server, though there will be some console spam on the client.