### PR TITLE
Fix GameData#revert ignoring RegistryManager parameter

### DIFF
--- a/src/main/java/net/minecraftforge/registries/GameData.java
+++ b/src/main/java/net/minecraftforge/registries/GameData.java
@@ -258,7 +258,7 @@ public class GameData
     {
         FMLLog.log.debug("Reverting {} to {}", registry, state.getName());
         final Class<? extends IForgeRegistryEntry> clazz = RegistryManager.ACTIVE.getSuperType(registry);
-        loadRegistry(registry, RegistryManager.FROZEN, RegistryManager.ACTIVE, clazz, lock);
+        loadRegistry(registry, state, RegistryManager.ACTIVE, clazz, lock);
         FMLLog.log.debug("Reverting complete");
     }
 


### PR DESCRIPTION
This makes it possible to revert a registry to another RegistryManager, like RegistryManager.VANILLA