### PR TITLE
Add ReloadEvent. Resolves #4217

### DIFF
--- a/patches/minecraft/net/minecraft/server/MinecraftServer.java.patch
+++ b/patches/minecraft/net/minecraft/server/MinecraftServer.java.patch
@@ -259,7 +259,21 @@
      }
  
      public CrashReport func_71230_b(CrashReport p_71230_1_)
-@@ -1594,4 +1638,9 @@
+@@ -1374,11 +1418,13 @@
+     {
+         if (this.func_152345_ab())
+         {
++            if (net.minecraftforge.common.ForgeHooks.reloadPre(this.field_71305_c[0])) return;
+             this.func_184103_al().func_72389_g();
+             this.field_71305_c[0].func_184146_ak().func_186522_a();
+             this.func_191949_aK().func_192779_a();
+             this.func_193030_aL().func_193059_f();
+             this.func_184103_al().func_193244_w();
++            net.minecraftforge.common.ForgeHooks.reloadPost(this.field_71305_c[0]);
+         }
+         else
+         {
+@@ -1594,4 +1640,9 @@
      {
          return this.field_175590_aa;
      }

--- a/src/main/java/net/minecraftforge/common/ForgeHooks.java
+++ b/src/main/java/net/minecraftforge/common/ForgeHooks.java
@@ -34,6 +34,12 @@ import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+import org.apache.commons.io.FilenameUtils;
+import org.apache.commons.io.IOUtils;
+
 import com.google.common.collect.Lists;
 import com.google.common.collect.Queues;
 import com.google.common.collect.Sets;
@@ -92,10 +98,11 @@ import net.minecraft.util.text.ITextComponent;
 import net.minecraft.util.text.TextComponentString;
 import net.minecraft.util.text.TextFormatting;
 import net.minecraft.util.text.event.ClickEvent;
-import net.minecraft.world.IBlockAccess;
-import net.minecraft.world.World;
 import net.minecraft.world.EnumDifficulty;
 import net.minecraft.world.GameType;
+import net.minecraft.world.IBlockAccess;
+import net.minecraft.world.World;
+import net.minecraft.world.WorldServer;
 import net.minecraft.world.storage.loot.LootEntry;
 import net.minecraft.world.storage.loot.LootTable;
 import net.minecraft.world.storage.loot.LootTableManager;
@@ -105,6 +112,7 @@ import net.minecraftforge.common.util.BlockSnapshot;
 import net.minecraftforge.event.AnvilUpdateEvent;
 import net.minecraftforge.event.DifficultyChangeEvent;
 import net.minecraftforge.event.ForgeEventFactory;
+import net.minecraftforge.event.ReloadEvent;
 import net.minecraftforge.event.ServerChatEvent;
 import net.minecraftforge.event.entity.EntityTravelToDimensionEvent;
 import net.minecraftforge.event.entity.ThrowableImpactEvent;
@@ -131,11 +139,6 @@ import net.minecraftforge.fml.common.LoaderState;
 import net.minecraftforge.fml.common.ModContainer;
 import net.minecraftforge.fml.common.eventhandler.Event;
 import net.minecraftforge.fml.relauncher.ReflectionHelper;
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
-
-import org.apache.commons.io.FilenameUtils;
-import org.apache.commons.io.IOUtils;
 
 public class ForgeHooks
 {
@@ -1308,5 +1311,20 @@ public class ForgeHooks
             },
             true
         );
+    }
+
+    public static boolean reloadPre(WorldServer world)
+    {
+        if (MinecraftForge.EVENT_BUS.post(new ReloadEvent.Pre(world)))
+        {
+            return false;
+        }
+
+        return true;
+    }
+
+    public static void reloadPost(WorldServer world)
+    {
+        MinecraftForge.EVENT_BUS.post(new ReloadEvent.Post(world));
     }
 }

--- a/src/main/java/net/minecraftforge/event/ReloadEvent.java
+++ b/src/main/java/net/minecraftforge/event/ReloadEvent.java
@@ -1,0 +1,32 @@
+package net.minecraftforge.event;
+
+import net.minecraft.world.WorldServer;
+import net.minecraftforge.fml.common.eventhandler.Cancelable;
+import net.minecraftforge.fml.common.eventhandler.Event;
+
+public class ReloadEvent extends Event
+{ 
+    public final WorldServer world;
+
+    public ReloadEvent(WorldServer world)
+    {
+        this.world = world;
+    }
+
+    @Cancelable
+    public static class Pre extends ReloadEvent
+    {
+        public Pre(WorldServer world)
+        {
+            super(world);
+        }
+    }
+
+    public static class Post extends ReloadEvent
+    {
+        public Post(WorldServer world)
+        {
+            super(world);
+        }
+    }
+}

--- a/src/main/java/net/minecraftforge/event/ReloadEvent.java
+++ b/src/main/java/net/minecraftforge/event/ReloadEvent.java
@@ -1,3 +1,22 @@
+/*
+ * Minecraft Forge
+ * Copyright (c) 2016.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation version 2.1
+ * of the License.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
 package net.minecraftforge.event;
 
 import net.minecraft.world.WorldServer;


### PR DESCRIPTION
This actually adds two events, ReloadEvent.Pre, which is called before advancements, loot tables, functions, and ~~[recipes](https://github.com/MinecraftForge/MinecraftForge/pull/4229)~~ anything else is reloaded, and ReloadEvent.Post, which is called after everything has been reloaded.