### PR TITLE
Fixed lag spike caused by unloading tileentities

### DIFF
--- a/patches/minecraft/net/minecraft/world/World.java.patch
+++ b/patches/minecraft/net/minecraft/world/World.java.patch
@@ -1,6 +1,18 @@
 --- ../src-base/minecraft/net/minecraft/world/World.java
 +++ ../src-work/minecraft/net/minecraft/world/World.java
-@@ -62,8 +62,15 @@
+@@ -44,6 +44,7 @@
+ import net.minecraft.util.SoundEvent;
+ import net.minecraft.util.math.AxisAlignedBB;
+ import net.minecraft.util.math.BlockPos;
++import net.minecraft.util.math.ChunkPos;
+ import net.minecraft.util.math.MathHelper;
+ import net.minecraft.util.math.RayTraceResult;
+ import net.minecraft.util.math.Vec3d;
+@@ -59,19 +60,28 @@
+ import net.minecraft.world.storage.WorldInfo;
+ import net.minecraft.world.storage.WorldSavedData;
+ import net.minecraft.world.storage.loot.LootTableManager;
++import net.minecraftforge.common.util.ChunkedTileEntityList;
  import net.minecraftforge.fml.relauncher.Side;
  import net.minecraftforge.fml.relauncher.SideOnly;
  
@@ -17,7 +29,18 @@
      private int field_181546_a = 63;
      protected boolean field_72999_e;
      public final List<Entity> field_72996_f = Lists.<Entity>newArrayList();
-@@ -107,6 +114,12 @@
+     protected final List<Entity> field_72997_g = Lists.<Entity>newArrayList();
+-    public final List<TileEntity> field_147482_g = Lists.<TileEntity>newArrayList();
+-    public final List<TileEntity> field_175730_i = Lists.<TileEntity>newArrayList();
++    public final ChunkedTileEntityList field_147482_g = new ChunkedTileEntityList();
++    public final ChunkedTileEntityList field_175730_i = new ChunkedTileEntityList();
+     private final List<TileEntity> field_147484_a = Lists.<TileEntity>newArrayList();
+     private final List<TileEntity> field_147483_b = Lists.<TileEntity>newArrayList();
++    public List<ChunkPos> tileEntitiesChunkToBeRemoved = Lists.<ChunkPos>newArrayList();
+     public final List<EntityPlayer> field_73010_i = Lists.<EntityPlayer>newArrayList();
+     public final List<Entity> field_73007_j = Lists.<Entity>newArrayList();
+     protected final IntHashMap<Entity> field_175729_l = new IntHashMap<Entity>();
+@@ -107,6 +117,12 @@
      private final WorldBorder field_175728_M;
      int[] field_72994_J;
  
@@ -30,7 +53,7 @@
      protected World(ISaveHandler p_i45749_1_, WorldInfo p_i45749_2_, WorldProvider p_i45749_3_, Profiler p_i45749_4_, boolean p_i45749_5_)
      {
          this.field_73021_x = Lists.newArrayList(this.field_184152_t);
-@@ -121,6 +134,7 @@
+@@ -121,6 +137,7 @@
          this.field_73011_w = p_i45749_3_;
          this.field_72995_K = p_i45749_5_;
          this.field_175728_M = p_i45749_3_.func_177501_r();
@@ -38,7 +61,7 @@
      }
  
      public World func_175643_b()
-@@ -130,6 +144,11 @@
+@@ -130,6 +147,11 @@
  
      public Biome func_180494_b(final BlockPos p_180494_1_)
      {
@@ -50,7 +73,7 @@
          if (this.func_175667_e(p_180494_1_))
          {
              Chunk chunk = this.func_175726_f(p_180494_1_);
-@@ -206,7 +225,7 @@
+@@ -206,7 +228,7 @@
  
      public boolean func_175623_d(BlockPos p_175623_1_)
      {
@@ -59,7 +82,7 @@
      }
  
      public boolean func_175667_e(BlockPos p_175667_1_)
-@@ -307,24 +326,50 @@
+@@ -307,24 +329,50 @@
          else
          {
              Chunk chunk = this.func_175726_f(p_180501_1_);
@@ -113,7 +136,7 @@
                      this.func_184138_a(p_180501_1_, iblockstate, p_180501_2_, p_180501_3_);
                  }
  
-@@ -341,8 +386,6 @@
+@@ -341,8 +389,6 @@
                  {
                      this.func_190522_c(p_180501_1_, block);
                  }
@@ -122,7 +145,7 @@
              }
          }
      }
-@@ -357,7 +400,7 @@
+@@ -357,7 +403,7 @@
          IBlockState iblockstate = this.func_180495_p(p_175655_1_);
          Block block = iblockstate.func_177230_c();
  
@@ -131,7 +154,7 @@
          {
              return false;
          }
-@@ -440,6 +483,9 @@
+@@ -440,6 +486,9 @@
  
      public void func_175685_c(BlockPos p_175685_1_, Block p_175685_2_, boolean p_175685_3_)
      {
@@ -141,7 +164,7 @@
          this.func_190524_a(p_175685_1_.func_177976_e(), p_175685_2_, p_175685_1_);
          this.func_190524_a(p_175685_1_.func_177974_f(), p_175685_2_, p_175685_1_);
          this.func_190524_a(p_175685_1_.func_177977_b(), p_175685_2_, p_175685_1_);
-@@ -455,6 +501,11 @@
+@@ -455,6 +504,11 @@
  
      public void func_175695_a(BlockPos p_175695_1_, Block p_175695_2_, EnumFacing p_175695_3_)
      {
@@ -153,7 +176,7 @@
          if (p_175695_3_ != EnumFacing.WEST)
          {
              this.func_190524_a(p_175695_1_.func_177976_e(), p_175695_2_, p_175695_1_);
-@@ -526,11 +577,11 @@
+@@ -526,11 +580,11 @@
          {
              IBlockState iblockstate = this.func_180495_p(p_190529_1_);
  
@@ -167,7 +190,7 @@
                  }
                  catch (Throwable throwable)
                  {
-@@ -587,7 +638,7 @@
+@@ -587,7 +641,7 @@
                  {
                      IBlockState iblockstate = this.func_180495_p(blockpos1);
  
@@ -176,7 +199,7 @@
                      {
                          return false;
                      }
-@@ -861,7 +912,7 @@
+@@ -861,7 +915,7 @@
  
      public boolean func_72935_r()
      {
@@ -185,7 +208,7 @@
      }
  
      @Nullable
-@@ -1064,6 +1115,13 @@
+@@ -1064,6 +1118,13 @@
  
      public void func_184148_a(@Nullable EntityPlayer p_184148_1_, double p_184148_2_, double p_184148_4_, double p_184148_6_, SoundEvent p_184148_8_, SoundCategory p_184148_9_, float p_184148_10_, float p_184148_11_)
      {
@@ -199,7 +222,7 @@
          for (int i = 0; i < this.field_73021_x.size(); ++i)
          {
              ((IWorldEventListener)this.field_73021_x.get(i)).func_184375_a(p_184148_1_, p_184148_8_, p_184148_9_, p_184148_2_, p_184148_4_, p_184148_6_, p_184148_10_, p_184148_11_);
-@@ -1117,6 +1175,9 @@
+@@ -1117,6 +1178,9 @@
  
      public boolean func_72838_d(Entity p_72838_1_)
      {
@@ -209,7 +232,7 @@
          int i = MathHelper.func_76128_c(p_72838_1_.field_70165_t / 16.0D);
          int j = MathHelper.func_76128_c(p_72838_1_.field_70161_v / 16.0D);
          boolean flag = p_72838_1_.field_98038_p;
-@@ -1139,6 +1200,8 @@
+@@ -1139,6 +1203,8 @@
                  this.func_72854_c();
              }
  
@@ -218,7 +241,7 @@
              this.func_72964_e(i, j).func_76612_a(p_72838_1_);
              this.field_72996_f.add(p_72838_1_);
              this.func_72923_a(p_72838_1_);
-@@ -1267,6 +1330,7 @@
+@@ -1267,6 +1333,7 @@
                                  }
  
                                  iblockstate1.func_185908_a(this, blockpos$pooledmutableblockpos, p_191504_2_, p_191504_4_, p_191504_1_, false);
@@ -226,7 +249,7 @@
  
                                  if (p_191504_3_ && !p_191504_4_.isEmpty())
                                  {
-@@ -1318,11 +1382,10 @@
+@@ -1318,11 +1385,10 @@
                  }
              }
          }
@@ -239,7 +262,7 @@
      public void func_72848_b(IWorldEventListener p_72848_1_)
      {
          this.field_73021_x.remove(p_72848_1_);
-@@ -1360,19 +1423,38 @@
+@@ -1360,19 +1426,38 @@
  
      public int func_72967_a(float p_72967_1_)
      {
@@ -280,7 +303,7 @@
          float f = this.func_72826_c(p_72971_1_);
          float f1 = 1.0F - (MathHelper.func_76134_b(f * ((float)Math.PI * 2F)) * 2.0F + 0.2F);
          f1 = MathHelper.func_76131_a(f1, 0.0F, 1.0F);
-@@ -1385,6 +1467,12 @@
+@@ -1385,6 +1470,12 @@
      @SideOnly(Side.CLIENT)
      public Vec3d func_72833_a(Entity p_72833_1_, float p_72833_2_)
      {
@@ -293,7 +316,7 @@
          float f = this.func_72826_c(p_72833_2_);
          float f1 = MathHelper.func_76134_b(f * ((float)Math.PI * 2F)) * 2.0F + 0.5F;
          f1 = MathHelper.func_76131_a(f1, 0.0F, 1.0F);
-@@ -1392,9 +1480,7 @@
+@@ -1392,9 +1483,7 @@
          int j = MathHelper.func_76128_c(p_72833_1_.field_70163_u);
          int k = MathHelper.func_76128_c(p_72833_1_.field_70161_v);
          BlockPos blockpos = new BlockPos(i, j, k);
@@ -304,7 +327,7 @@
          float f3 = (float)(l >> 16 & 255) / 255.0F;
          float f4 = (float)(l >> 8 & 255) / 255.0F;
          float f5 = (float)(l & 255) / 255.0F;
-@@ -1443,20 +1529,25 @@
+@@ -1443,20 +1532,25 @@
  
      public float func_72826_c(float p_72826_1_)
      {
@@ -333,7 +356,7 @@
      public float func_72929_e(float p_72929_1_)
      {
          float f = this.func_72826_c(p_72929_1_);
-@@ -1466,6 +1557,12 @@
+@@ -1466,6 +1560,12 @@
      @SideOnly(Side.CLIENT)
      public Vec3d func_72824_f(float p_72824_1_)
      {
@@ -346,7 +369,7 @@
          float f = this.func_72826_c(p_72824_1_);
          float f1 = MathHelper.func_76134_b(f * ((float)Math.PI * 2F)) * 2.0F + 0.5F;
          f1 = MathHelper.func_76131_a(f1, 0.0F, 1.0F);
-@@ -1521,9 +1618,9 @@
+@@ -1521,9 +1621,9 @@
          for (blockpos = new BlockPos(p_175672_1_.func_177958_n(), chunk.func_76625_h() + 16, p_175672_1_.func_177952_p()); blockpos.func_177956_o() >= 0; blockpos = blockpos1)
          {
              blockpos1 = blockpos.func_177977_b();
@@ -358,7 +381,7 @@
              {
                  break;
              }
-@@ -1535,6 +1632,12 @@
+@@ -1535,6 +1635,12 @@
      @SideOnly(Side.CLIENT)
      public float func_72880_h(float p_72880_1_)
      {
@@ -371,7 +394,7 @@
          float f = this.func_72826_c(p_72880_1_);
          float f1 = 1.0F - (MathHelper.func_76134_b(f * ((float)Math.PI * 2F)) * 2.0F + 0.25F);
          f1 = MathHelper.func_76131_a(f1, 0.0F, 1.0F);
-@@ -1569,6 +1672,7 @@
+@@ -1569,6 +1675,7 @@
  
              try
              {
@@ -379,7 +402,7 @@
                  ++entity.field_70173_aa;
                  entity.func_70071_h_();
              }
-@@ -1586,6 +1690,12 @@
+@@ -1586,6 +1693,12 @@
                      entity.func_85029_a(crashreportcategory);
                  }
  
@@ -392,7 +415,7 @@
                  throw new ReportedException(crashreport);
              }
  
-@@ -1647,6 +1757,12 @@
+@@ -1647,6 +1760,12 @@
                      CrashReport crashreport1 = CrashReport.func_85055_a(throwable1, "Ticking entity");
                      CrashReportCategory crashreportcategory1 = crashreport1.func_85058_a("Entity being ticked");
                      entity2.func_85029_a(crashreportcategory1);
@@ -405,7 +428,7 @@
                      throw new ReportedException(crashreport1);
                  }
              }
-@@ -1683,11 +1799,11 @@
+@@ -1683,11 +1802,11 @@
              {
                  BlockPos blockpos = tileentity.func_174877_v();
  
@@ -419,7 +442,7 @@
                          ((ITickable)tileentity).func_73660_a();
                          this.field_72984_F.func_76319_b();
                      }
-@@ -1696,6 +1812,13 @@
+@@ -1696,6 +1815,13 @@
                          CrashReport crashreport2 = CrashReport.func_85055_a(throwable, "Ticking block entity");
                          CrashReportCategory crashreportcategory2 = crashreport2.func_85058_a("Block entity being ticked");
                          tileentity.func_145828_a(crashreportcategory2);
@@ -433,7 +456,7 @@
                          throw new ReportedException(crashreport2);
                      }
                  }
-@@ -1708,20 +1831,28 @@
+@@ -1708,20 +1834,40 @@
  
                  if (this.func_175667_e(tileentity.func_174877_v()))
                  {
@@ -458,14 +481,26 @@
              this.field_175730_i.removeAll(this.field_147483_b);
              this.field_147482_g.removeAll(this.field_147483_b);
              this.field_147483_b.clear();
++            
          }
++        
++        if (!this.tileEntitiesChunkToBeRemoved.isEmpty())
++        {
++    		for (Iterator<ChunkPos> iterator2 = tileEntitiesChunkToBeRemoved.iterator(); iterator2.hasNext();) {
++    			ChunkPos pos = iterator2.next();
++    			field_175730_i.removeChunk(this, pos, false);
++    			field_147482_g.removeChunk(this, pos, true);
++    		}
  
++    		tileEntitiesChunkToBeRemoved.clear();
++        }
++
 +        this.field_147481_N = false;  //FML Move below remove to prevent CMEs
 +
          this.field_72984_F.func_76318_c("pendingBlockEntities");
  
          if (!this.field_147484_a.isEmpty())
-@@ -1760,12 +1891,18 @@
+@@ -1760,12 +1906,18 @@
  
      public boolean func_175700_a(TileEntity p_175700_1_)
      {
@@ -484,7 +519,7 @@
  
          if (this.field_72995_K)
          {
-@@ -1781,6 +1918,11 @@
+@@ -1781,6 +1933,11 @@
      {
          if (this.field_147481_N)
          {
@@ -496,7 +531,7 @@
              this.field_147484_a.addAll(p_147448_1_);
          }
          else
-@@ -1803,9 +1945,12 @@
+@@ -1803,9 +1960,12 @@
          {
              int i = MathHelper.func_76128_c(p_72866_1_.field_70165_t);
              int j = MathHelper.func_76128_c(p_72866_1_.field_70161_v);
@@ -511,7 +546,7 @@
              {
                  return;
              }
-@@ -1827,6 +1972,7 @@
+@@ -1827,6 +1987,7 @@
              }
              else
              {
@@ -519,7 +554,7 @@
                  p_72866_1_.func_70071_h_();
              }
          }
-@@ -2007,6 +2153,11 @@
+@@ -2007,6 +2168,11 @@
                              blockpos$pooledmutableblockpos.func_185344_t();
                              return true;
                          }
@@ -531,7 +566,7 @@
                      }
                  }
              }
-@@ -2046,6 +2197,16 @@
+@@ -2046,6 +2212,16 @@
                          IBlockState iblockstate = this.func_180495_p(blockpos$pooledmutableblockpos);
                          Block block = iblockstate.func_177230_c();
  
@@ -548,7 +583,7 @@
                          if (iblockstate.func_185904_a() == p_72918_2_)
                          {
                              double d0 = (double)((float)(l1 + 1) - BlockLiquid.func_149801_b(((Integer)iblockstate.func_177229_b(BlockLiquid.field_176367_b)).intValue()));
-@@ -2112,6 +2273,7 @@
+@@ -2112,6 +2288,7 @@
      public Explosion func_72885_a(@Nullable Entity p_72885_1_, double p_72885_2_, double p_72885_4_, double p_72885_6_, float p_72885_8_, boolean p_72885_9_, boolean p_72885_10_)
      {
          Explosion explosion = new Explosion(this, p_72885_1_, p_72885_2_, p_72885_4_, p_72885_6_, p_72885_8_, p_72885_9_, p_72885_10_);
@@ -556,7 +591,7 @@
          explosion.func_77278_a();
          explosion.func_77279_a(true);
          return explosion;
-@@ -2234,6 +2396,7 @@
+@@ -2234,6 +2411,7 @@
  
      public void func_175690_a(BlockPos p_175690_1_, @Nullable TileEntity p_175690_2_)
      {
@@ -564,7 +599,7 @@
          if (!this.func_189509_E(p_175690_1_))
          {
              if (p_175690_2_ != null && !p_175690_2_.func_145837_r())
-@@ -2241,6 +2404,8 @@
+@@ -2241,6 +2419,8 @@
                  if (this.field_147481_N)
                  {
                      p_175690_2_.func_174878_a(p_175690_1_);
@@ -573,7 +608,7 @@
                      Iterator<TileEntity> iterator = this.field_147484_a.iterator();
  
                      while (iterator.hasNext())
-@@ -2258,7 +2423,8 @@
+@@ -2258,7 +2438,8 @@
                  }
                  else
                  {
@@ -583,7 +618,7 @@
                      this.func_175700_a(p_175690_2_);
                  }
              }
-@@ -2273,6 +2439,8 @@
+@@ -2273,6 +2454,8 @@
          {
              tileentity.func_145843_s();
              this.field_147484_a.remove(tileentity);
@@ -592,15 +627,21 @@
          }
          else
          {
-@@ -2285,6 +2453,7 @@
+@@ -2285,7 +2468,13 @@
  
              this.func_175726_f(p_175713_1_).func_177425_e(p_175713_1_);
          }
 +        this.func_175666_e(p_175713_1_, func_180495_p(p_175713_1_).func_177230_c()); //Notify neighbors of changes
      }
++    
++    public void markChunkForRemoval(Chunk chunk)
++    {
++    	this.tileEntitiesChunkToBeRemoved.add(chunk.func_76632_l());
++    }
  
      public void func_147457_a(TileEntity p_147457_1_)
-@@ -2311,7 +2480,7 @@
+     {
+@@ -2311,7 +2500,7 @@
              if (chunk != null && !chunk.func_76621_g())
              {
                  IBlockState iblockstate = this.func_180495_p(p_175677_1_);
@@ -609,7 +650,7 @@
              }
              else
              {
-@@ -2334,6 +2503,7 @@
+@@ -2334,6 +2523,7 @@
      {
          this.field_72985_G = p_72891_1_;
          this.field_72992_H = p_72891_2_;
@@ -617,7 +658,7 @@
      }
  
      public void func_72835_b()
-@@ -2343,6 +2513,11 @@
+@@ -2343,6 +2533,11 @@
  
      protected void func_72947_a()
      {
@@ -629,7 +670,7 @@
          if (this.field_72986_A.func_76059_o())
          {
              this.field_73004_o = 1.0F;
-@@ -2356,6 +2531,11 @@
+@@ -2356,6 +2551,11 @@
  
      protected void func_72979_l()
      {
@@ -641,7 +682,7 @@
          if (this.field_73011_w.func_191066_m())
          {
              if (!this.field_72995_K)
-@@ -2480,6 +2660,11 @@
+@@ -2480,6 +2680,11 @@
  
      public boolean func_175670_e(BlockPos p_175670_1_, boolean p_175670_2_)
      {
@@ -653,7 +694,7 @@
          Biome biome = this.func_180494_b(p_175670_1_);
          float f = biome.func_180626_a(p_175670_1_);
  
-@@ -2521,6 +2706,11 @@
+@@ -2521,6 +2726,11 @@
  
      public boolean func_175708_f(BlockPos p_175708_1_, boolean p_175708_2_)
      {
@@ -665,7 +706,7 @@
          Biome biome = this.func_180494_b(p_175708_1_);
          float f = biome.func_180626_a(p_175708_1_);
  
-@@ -2538,7 +2728,7 @@
+@@ -2538,7 +2748,7 @@
              {
                  IBlockState iblockstate = this.func_180495_p(p_175708_1_);
  
@@ -674,7 +715,7 @@
                  {
                      return true;
                  }
-@@ -2570,10 +2760,11 @@
+@@ -2570,10 +2780,11 @@
          else
          {
              IBlockState iblockstate = this.func_180495_p(p_175638_1_);
@@ -689,7 +730,7 @@
              {
                  j = 1;
              }
-@@ -2679,7 +2870,7 @@
+@@ -2679,7 +2890,7 @@
                                      int j4 = j2 + enumfacing.func_96559_d();
                                      int k4 = k2 + enumfacing.func_82599_e();
                                      blockpos$pooledmutableblockpos.func_181079_c(i4, j4, k4);
@@ -698,7 +739,7 @@
                                      i3 = this.func_175642_b(p_180500_1_, blockpos$pooledmutableblockpos);
  
                                      if (i3 == l2 - l4 && j < this.field_72994_J.length)
-@@ -2787,10 +2978,10 @@
+@@ -2787,10 +2998,10 @@
      public List<Entity> func_175674_a(@Nullable Entity p_175674_1_, AxisAlignedBB p_175674_2_, @Nullable Predicate <? super Entity > p_175674_3_)
      {
          List<Entity> list = Lists.<Entity>newArrayList();
@@ -713,7 +754,7 @@
  
          for (int i1 = i; i1 <= j; ++i1)
          {
-@@ -2843,10 +3034,10 @@
+@@ -2843,10 +3054,10 @@
  
      public <T extends Entity> List<T> func_175647_a(Class <? extends T > p_175647_1_, AxisAlignedBB p_175647_2_, @Nullable Predicate <? super T > p_175647_3_)
      {
@@ -728,7 +769,7 @@
          List<T> list = Lists.<T>newArrayList();
  
          for (int i1 = i; i1 < j; ++i1)
-@@ -2926,11 +3117,13 @@
+@@ -2926,11 +3137,13 @@
  
      public void func_175650_b(Collection<Entity> p_175650_1_)
      {
@@ -745,7 +786,7 @@
          }
      }
  
-@@ -2954,7 +3147,7 @@
+@@ -2954,7 +3167,7 @@
          }
          else
          {
@@ -754,7 +795,7 @@
          }
      }
  
-@@ -3038,7 +3231,7 @@
+@@ -3038,7 +3251,7 @@
      public int func_175651_c(BlockPos p_175651_1_, EnumFacing p_175651_2_)
      {
          IBlockState iblockstate = this.func_180495_p(p_175651_1_);
@@ -763,7 +804,7 @@
      }
  
      public boolean func_175640_z(BlockPos p_175640_1_)
-@@ -3204,6 +3397,8 @@
+@@ -3204,6 +3417,8 @@
                      d2 *= ((Double)MoreObjects.firstNonNull(p_184150_11_.apply(entityplayer1), Double.valueOf(1.0D))).doubleValue();
                  }
  
@@ -772,7 +813,7 @@
                  if ((p_184150_9_ < 0.0D || Math.abs(entityplayer1.field_70163_u - p_184150_3_) < p_184150_9_ * p_184150_9_) && (p_184150_7_ < 0.0D || d1 < d2 * d2) && (d0 == -1.0D || d1 < d0))
                  {
                      d0 = d1;
-@@ -3265,7 +3460,7 @@
+@@ -3265,7 +3480,7 @@
  
      public long func_72905_C()
      {
@@ -781,7 +822,7 @@
      }
  
      public long func_82737_E()
-@@ -3275,17 +3470,17 @@
+@@ -3275,17 +3490,17 @@
  
      public long func_72820_D()
      {
@@ -802,7 +843,7 @@
  
          if (!this.func_175723_af().func_177746_a(blockpos))
          {
-@@ -3297,7 +3492,7 @@
+@@ -3297,7 +3512,7 @@
  
      public void func_175652_B(BlockPos p_175652_1_)
      {
@@ -811,7 +852,7 @@
      }
  
      @SideOnly(Side.CLIENT)
-@@ -3317,12 +3512,18 @@
+@@ -3317,12 +3532,18 @@
  
          if (!this.field_72996_f.contains(p_72897_1_))
          {
@@ -830,7 +871,7 @@
          return true;
      }
  
-@@ -3424,8 +3625,7 @@
+@@ -3424,8 +3645,7 @@
  
      public boolean func_180502_D(BlockPos p_180502_1_)
      {
@@ -840,7 +881,7 @@
      }
  
      @Nullable
-@@ -3486,12 +3686,12 @@
+@@ -3486,12 +3706,12 @@
  
      public int func_72800_K()
      {
@@ -855,7 +896,7 @@
      }
  
      public Random func_72843_D(int p_72843_1_, int p_72843_2_, int p_72843_3_)
-@@ -3535,7 +3735,7 @@
+@@ -3535,7 +3755,7 @@
      @SideOnly(Side.CLIENT)
      public double func_72919_O()
      {
@@ -864,7 +905,7 @@
      }
  
      public void func_175715_c(int p_175715_1_, BlockPos p_175715_2_, int p_175715_3_)
-@@ -3569,7 +3769,7 @@
+@@ -3569,7 +3789,7 @@
  
      public void func_175666_e(BlockPos p_175666_1_, Block p_175666_2_)
      {
@@ -873,7 +914,7 @@
          {
              BlockPos blockpos = p_175666_1_.func_177972_a(enumfacing);
  
-@@ -3577,18 +3777,14 @@
+@@ -3577,18 +3797,14 @@
              {
                  IBlockState iblockstate = this.func_180495_p(blockpos);
  
@@ -896,7 +937,7 @@
                      }
                  }
              }
-@@ -3654,6 +3850,115 @@
+@@ -3654,6 +3870,115 @@
          return i >= -128 && i <= 128 && j >= -128 && j <= 128;
      }
  

--- a/patches/minecraft/net/minecraft/world/World.java.patch
+++ b/patches/minecraft/net/minecraft/world/World.java.patch
@@ -20,8 +20,8 @@
      protected final List<Entity> field_72997_g = Lists.<Entity>newArrayList();
 -    public final List<TileEntity> field_147482_g = Lists.<TileEntity>newArrayList();
 -    public final List<TileEntity> field_175730_i = Lists.<TileEntity>newArrayList();
-+    public final net.minecraftforge.common.util.ChunkedTileEntityList field_147482_g = new net.minecraftforge.common.util.ChunkedTileEntityList();
-+    public final net.minecraftforge.common.util.ChunkedTileEntityList field_175730_i = new net.minecraftforge.common.util.ChunkedTileEntityList();
++    public final List<TileEntity> field_147482_g = new net.minecraftforge.common.util.ChunkedTileEntityList();
++    public final List<TileEntity> field_175730_i = new net.minecraftforge.common.util.ChunkedTileEntityList();
      private final List<TileEntity> field_147484_a = Lists.<TileEntity>newArrayList();
      private final List<TileEntity> field_147483_b = Lists.<TileEntity>newArrayList();
 +    public Collection<net.minecraft.util.math.ChunkPos> tileEntitiesChunkToBeRemoved = new java.util.ArrayDeque<>();
@@ -475,8 +475,8 @@
 +        if (!this.tileEntitiesChunkToBeRemoved.isEmpty())
 +        {
 +            for (net.minecraft.util.math.ChunkPos pos : tileEntitiesChunkToBeRemoved) {
-+    			field_175730_i.removeChunk(this, pos, false);
-+    			field_147482_g.removeChunk(this, pos, true);
++    			((net.minecraftforge.common.util.ChunkedTileEntityList) field_175730_i).removeChunk(this, pos, false);
++    			((net.minecraftforge.common.util.ChunkedTileEntityList) field_147482_g).removeChunk(this, pos, true);
 +    		}
  
 +    		tileEntitiesChunkToBeRemoved.clear();

--- a/patches/minecraft/net/minecraft/world/World.java.patch
+++ b/patches/minecraft/net/minecraft/world/World.java.patch
@@ -24,7 +24,7 @@
 +    public final net.minecraftforge.common.util.ChunkedTileEntityList field_175730_i = new net.minecraftforge.common.util.ChunkedTileEntityList();
      private final List<TileEntity> field_147484_a = Lists.<TileEntity>newArrayList();
      private final List<TileEntity> field_147483_b = Lists.<TileEntity>newArrayList();
-+    public List<net.minecraft.util.math.ChunkPos> tileEntitiesChunkToBeRemoved = Lists.<net.minecraft.util.math.ChunkPos>newArrayList();
++    public Collection<net.minecraft.util.math.ChunkPos> tileEntitiesChunkToBeRemoved = new java.util.ArrayDeque<>();
      public final List<EntityPlayer> field_73010_i = Lists.<EntityPlayer>newArrayList();
      public final List<Entity> field_73007_j = Lists.<Entity>newArrayList();
      protected final IntHashMap<Entity> field_175729_l = new IntHashMap<Entity>();
@@ -444,7 +444,7 @@
                          throw new ReportedException(crashreport2);
                      }
                  }
-@@ -1708,20 +1832,40 @@
+@@ -1708,20 +1832,39 @@
  
                  if (this.func_175667_e(tileentity.func_174877_v()))
                  {
@@ -474,8 +474,7 @@
 +        
 +        if (!this.tileEntitiesChunkToBeRemoved.isEmpty())
 +        {
-+    		for (Iterator<net.minecraft.util.math.ChunkPos> iterator2 = tileEntitiesChunkToBeRemoved.iterator(); iterator2.hasNext();) {
-+    			net.minecraft.util.math.ChunkPos pos = iterator2.next();
++            for (net.minecraft.util.math.ChunkPos pos : tileEntitiesChunkToBeRemoved) {
 +    			field_175730_i.removeChunk(this, pos, false);
 +    			field_147482_g.removeChunk(this, pos, true);
 +    		}
@@ -488,7 +487,7 @@
          this.field_72984_F.func_76318_c("pendingBlockEntities");
  
          if (!this.field_147484_a.isEmpty())
-@@ -1760,12 +1904,18 @@
+@@ -1760,12 +1903,18 @@
  
      public boolean func_175700_a(TileEntity p_175700_1_)
      {
@@ -507,7 +506,7 @@
  
          if (this.field_72995_K)
          {
-@@ -1781,6 +1931,11 @@
+@@ -1781,6 +1930,11 @@
      {
          if (this.field_147481_N)
          {
@@ -519,7 +518,7 @@
              this.field_147484_a.addAll(p_147448_1_);
          }
          else
-@@ -1803,9 +1958,12 @@
+@@ -1803,9 +1957,12 @@
          {
              int i = MathHelper.func_76128_c(p_72866_1_.field_70165_t);
              int j = MathHelper.func_76128_c(p_72866_1_.field_70161_v);
@@ -534,7 +533,7 @@
              {
                  return;
              }
-@@ -1827,6 +1985,7 @@
+@@ -1827,6 +1984,7 @@
              }
              else
              {
@@ -542,7 +541,7 @@
                  p_72866_1_.func_70071_h_();
              }
          }
-@@ -2007,6 +2166,11 @@
+@@ -2007,6 +2165,11 @@
                              blockpos$pooledmutableblockpos.func_185344_t();
                              return true;
                          }
@@ -554,7 +553,7 @@
                      }
                  }
              }
-@@ -2046,6 +2210,16 @@
+@@ -2046,6 +2209,16 @@
                          IBlockState iblockstate = this.func_180495_p(blockpos$pooledmutableblockpos);
                          Block block = iblockstate.func_177230_c();
  
@@ -571,7 +570,7 @@
                          if (iblockstate.func_185904_a() == p_72918_2_)
                          {
                              double d0 = (double)((float)(l1 + 1) - BlockLiquid.func_149801_b(((Integer)iblockstate.func_177229_b(BlockLiquid.field_176367_b)).intValue()));
-@@ -2112,6 +2286,7 @@
+@@ -2112,6 +2285,7 @@
      public Explosion func_72885_a(@Nullable Entity p_72885_1_, double p_72885_2_, double p_72885_4_, double p_72885_6_, float p_72885_8_, boolean p_72885_9_, boolean p_72885_10_)
      {
          Explosion explosion = new Explosion(this, p_72885_1_, p_72885_2_, p_72885_4_, p_72885_6_, p_72885_8_, p_72885_9_, p_72885_10_);
@@ -579,7 +578,7 @@
          explosion.func_77278_a();
          explosion.func_77279_a(true);
          return explosion;
-@@ -2234,6 +2409,7 @@
+@@ -2234,6 +2408,7 @@
  
      public void func_175690_a(BlockPos p_175690_1_, @Nullable TileEntity p_175690_2_)
      {
@@ -587,7 +586,7 @@
          if (!this.func_189509_E(p_175690_1_))
          {
              if (p_175690_2_ != null && !p_175690_2_.func_145837_r())
-@@ -2241,6 +2417,8 @@
+@@ -2241,6 +2416,8 @@
                  if (this.field_147481_N)
                  {
                      p_175690_2_.func_174878_a(p_175690_1_);
@@ -596,7 +595,7 @@
                      Iterator<TileEntity> iterator = this.field_147484_a.iterator();
  
                      while (iterator.hasNext())
-@@ -2258,7 +2436,8 @@
+@@ -2258,7 +2435,8 @@
                  }
                  else
                  {
@@ -606,7 +605,7 @@
                      this.func_175700_a(p_175690_2_);
                  }
              }
-@@ -2273,6 +2452,8 @@
+@@ -2273,6 +2451,8 @@
          {
              tileentity.func_145843_s();
              this.field_147484_a.remove(tileentity);
@@ -615,7 +614,7 @@
          }
          else
          {
-@@ -2285,7 +2466,13 @@
+@@ -2285,7 +2465,13 @@
  
              this.func_175726_f(p_175713_1_).func_177425_e(p_175713_1_);
          }
@@ -629,7 +628,7 @@
  
      public void func_147457_a(TileEntity p_147457_1_)
      {
-@@ -2311,7 +2498,7 @@
+@@ -2311,7 +2497,7 @@
              if (chunk != null && !chunk.func_76621_g())
              {
                  IBlockState iblockstate = this.func_180495_p(p_175677_1_);
@@ -638,7 +637,7 @@
              }
              else
              {
-@@ -2334,6 +2521,7 @@
+@@ -2334,6 +2520,7 @@
      {
          this.field_72985_G = p_72891_1_;
          this.field_72992_H = p_72891_2_;
@@ -646,7 +645,7 @@
      }
  
      public void func_72835_b()
-@@ -2343,6 +2531,11 @@
+@@ -2343,6 +2530,11 @@
  
      protected void func_72947_a()
      {
@@ -658,7 +657,7 @@
          if (this.field_72986_A.func_76059_o())
          {
              this.field_73004_o = 1.0F;
-@@ -2356,6 +2549,11 @@
+@@ -2356,6 +2548,11 @@
  
      protected void func_72979_l()
      {
@@ -670,7 +669,7 @@
          if (this.field_73011_w.func_191066_m())
          {
              if (!this.field_72995_K)
-@@ -2480,6 +2678,11 @@
+@@ -2480,6 +2677,11 @@
  
      public boolean func_175670_e(BlockPos p_175670_1_, boolean p_175670_2_)
      {
@@ -682,7 +681,7 @@
          Biome biome = this.func_180494_b(p_175670_1_);
          float f = biome.func_180626_a(p_175670_1_);
  
-@@ -2521,6 +2724,11 @@
+@@ -2521,6 +2723,11 @@
  
      public boolean func_175708_f(BlockPos p_175708_1_, boolean p_175708_2_)
      {
@@ -694,7 +693,7 @@
          Biome biome = this.func_180494_b(p_175708_1_);
          float f = biome.func_180626_a(p_175708_1_);
  
-@@ -2538,7 +2746,7 @@
+@@ -2538,7 +2745,7 @@
              {
                  IBlockState iblockstate = this.func_180495_p(p_175708_1_);
  
@@ -703,7 +702,7 @@
                  {
                      return true;
                  }
-@@ -2570,10 +2778,11 @@
+@@ -2570,10 +2777,11 @@
          else
          {
              IBlockState iblockstate = this.func_180495_p(p_175638_1_);
@@ -718,7 +717,7 @@
              {
                  j = 1;
              }
-@@ -2679,7 +2888,7 @@
+@@ -2679,7 +2887,7 @@
                                      int j4 = j2 + enumfacing.func_96559_d();
                                      int k4 = k2 + enumfacing.func_82599_e();
                                      blockpos$pooledmutableblockpos.func_181079_c(i4, j4, k4);
@@ -727,7 +726,7 @@
                                      i3 = this.func_175642_b(p_180500_1_, blockpos$pooledmutableblockpos);
  
                                      if (i3 == l2 - l4 && j < this.field_72994_J.length)
-@@ -2787,10 +2996,10 @@
+@@ -2787,10 +2995,10 @@
      public List<Entity> func_175674_a(@Nullable Entity p_175674_1_, AxisAlignedBB p_175674_2_, @Nullable Predicate <? super Entity > p_175674_3_)
      {
          List<Entity> list = Lists.<Entity>newArrayList();
@@ -742,7 +741,7 @@
  
          for (int i1 = i; i1 <= j; ++i1)
          {
-@@ -2843,10 +3052,10 @@
+@@ -2843,10 +3051,10 @@
  
      public <T extends Entity> List<T> func_175647_a(Class <? extends T > p_175647_1_, AxisAlignedBB p_175647_2_, @Nullable Predicate <? super T > p_175647_3_)
      {
@@ -757,7 +756,7 @@
          List<T> list = Lists.<T>newArrayList();
  
          for (int i1 = i; i1 < j; ++i1)
-@@ -2926,11 +3135,13 @@
+@@ -2926,11 +3134,13 @@
  
      public void func_175650_b(Collection<Entity> p_175650_1_)
      {
@@ -774,7 +773,7 @@
          }
      }
  
-@@ -2954,7 +3165,7 @@
+@@ -2954,7 +3164,7 @@
          }
          else
          {
@@ -783,7 +782,7 @@
          }
      }
  
-@@ -3038,7 +3249,7 @@
+@@ -3038,7 +3248,7 @@
      public int func_175651_c(BlockPos p_175651_1_, EnumFacing p_175651_2_)
      {
          IBlockState iblockstate = this.func_180495_p(p_175651_1_);
@@ -792,7 +791,7 @@
      }
  
      public boolean func_175640_z(BlockPos p_175640_1_)
-@@ -3204,6 +3415,8 @@
+@@ -3204,6 +3414,8 @@
                      d2 *= ((Double)MoreObjects.firstNonNull(p_184150_11_.apply(entityplayer1), Double.valueOf(1.0D))).doubleValue();
                  }
  
@@ -801,7 +800,7 @@
                  if ((p_184150_9_ < 0.0D || Math.abs(entityplayer1.field_70163_u - p_184150_3_) < p_184150_9_ * p_184150_9_) && (p_184150_7_ < 0.0D || d1 < d2 * d2) && (d0 == -1.0D || d1 < d0))
                  {
                      d0 = d1;
-@@ -3265,7 +3478,7 @@
+@@ -3265,7 +3477,7 @@
  
      public long func_72905_C()
      {
@@ -810,7 +809,7 @@
      }
  
      public long func_82737_E()
-@@ -3275,17 +3488,17 @@
+@@ -3275,17 +3487,17 @@
  
      public long func_72820_D()
      {
@@ -831,7 +830,7 @@
  
          if (!this.func_175723_af().func_177746_a(blockpos))
          {
-@@ -3297,7 +3510,7 @@
+@@ -3297,7 +3509,7 @@
  
      public void func_175652_B(BlockPos p_175652_1_)
      {
@@ -840,7 +839,7 @@
      }
  
      @SideOnly(Side.CLIENT)
-@@ -3317,12 +3530,18 @@
+@@ -3317,12 +3529,18 @@
  
          if (!this.field_72996_f.contains(p_72897_1_))
          {
@@ -859,7 +858,7 @@
          return true;
      }
  
-@@ -3424,8 +3643,7 @@
+@@ -3424,8 +3642,7 @@
  
      public boolean func_180502_D(BlockPos p_180502_1_)
      {
@@ -869,7 +868,7 @@
      }
  
      @Nullable
-@@ -3486,12 +3704,12 @@
+@@ -3486,12 +3703,12 @@
  
      public int func_72800_K()
      {
@@ -884,7 +883,7 @@
      }
  
      public Random func_72843_D(int p_72843_1_, int p_72843_2_, int p_72843_3_)
-@@ -3535,7 +3753,7 @@
+@@ -3535,7 +3752,7 @@
      @SideOnly(Side.CLIENT)
      public double func_72919_O()
      {
@@ -893,7 +892,7 @@
      }
  
      public void func_175715_c(int p_175715_1_, BlockPos p_175715_2_, int p_175715_3_)
-@@ -3569,7 +3787,7 @@
+@@ -3569,7 +3786,7 @@
  
      public void func_175666_e(BlockPos p_175666_1_, Block p_175666_2_)
      {
@@ -902,7 +901,7 @@
          {
              BlockPos blockpos = p_175666_1_.func_177972_a(enumfacing);
  
-@@ -3577,18 +3795,14 @@
+@@ -3577,18 +3794,14 @@
              {
                  IBlockState iblockstate = this.func_180495_p(blockpos);
  
@@ -925,7 +924,7 @@
                      }
                  }
              }
-@@ -3654,6 +3868,115 @@
+@@ -3654,6 +3867,115 @@
          return i >= -128 && i <= 128 && j >= -128 && j <= 128;
      }
  

--- a/patches/minecraft/net/minecraft/world/World.java.patch
+++ b/patches/minecraft/net/minecraft/world/World.java.patch
@@ -1,18 +1,6 @@
 --- ../src-base/minecraft/net/minecraft/world/World.java
 +++ ../src-work/minecraft/net/minecraft/world/World.java
-@@ -44,6 +44,7 @@
- import net.minecraft.util.SoundEvent;
- import net.minecraft.util.math.AxisAlignedBB;
- import net.minecraft.util.math.BlockPos;
-+import net.minecraft.util.math.ChunkPos;
- import net.minecraft.util.math.MathHelper;
- import net.minecraft.util.math.RayTraceResult;
- import net.minecraft.util.math.Vec3d;
-@@ -59,19 +60,28 @@
- import net.minecraft.world.storage.WorldInfo;
- import net.minecraft.world.storage.WorldSavedData;
- import net.minecraft.world.storage.loot.LootTableManager;
-+import net.minecraftforge.common.util.ChunkedTileEntityList;
+@@ -62,16 +62,24 @@
  import net.minecraftforge.fml.relauncher.Side;
  import net.minecraftforge.fml.relauncher.SideOnly;
  
@@ -32,15 +20,15 @@
      protected final List<Entity> field_72997_g = Lists.<Entity>newArrayList();
 -    public final List<TileEntity> field_147482_g = Lists.<TileEntity>newArrayList();
 -    public final List<TileEntity> field_175730_i = Lists.<TileEntity>newArrayList();
-+    public final ChunkedTileEntityList field_147482_g = new ChunkedTileEntityList();
-+    public final ChunkedTileEntityList field_175730_i = new ChunkedTileEntityList();
++    public final net.minecraftforge.common.util.ChunkedTileEntityList field_147482_g = new net.minecraftforge.common.util.ChunkedTileEntityList();
++    public final net.minecraftforge.common.util.ChunkedTileEntityList field_175730_i = new net.minecraftforge.common.util.ChunkedTileEntityList();
      private final List<TileEntity> field_147484_a = Lists.<TileEntity>newArrayList();
      private final List<TileEntity> field_147483_b = Lists.<TileEntity>newArrayList();
-+    public List<ChunkPos> tileEntitiesChunkToBeRemoved = Lists.<ChunkPos>newArrayList();
++    public List<net.minecraft.util.math.ChunkPos> tileEntitiesChunkToBeRemoved = Lists.<net.minecraft.util.math.ChunkPos>newArrayList();
      public final List<EntityPlayer> field_73010_i = Lists.<EntityPlayer>newArrayList();
      public final List<Entity> field_73007_j = Lists.<Entity>newArrayList();
      protected final IntHashMap<Entity> field_175729_l = new IntHashMap<Entity>();
-@@ -107,6 +117,12 @@
+@@ -107,6 +115,12 @@
      private final WorldBorder field_175728_M;
      int[] field_72994_J;
  
@@ -53,7 +41,7 @@
      protected World(ISaveHandler p_i45749_1_, WorldInfo p_i45749_2_, WorldProvider p_i45749_3_, Profiler p_i45749_4_, boolean p_i45749_5_)
      {
          this.field_73021_x = Lists.newArrayList(this.field_184152_t);
-@@ -121,6 +137,7 @@
+@@ -121,6 +135,7 @@
          this.field_73011_w = p_i45749_3_;
          this.field_72995_K = p_i45749_5_;
          this.field_175728_M = p_i45749_3_.func_177501_r();
@@ -61,7 +49,7 @@
      }
  
      public World func_175643_b()
-@@ -130,6 +147,11 @@
+@@ -130,6 +145,11 @@
  
      public Biome func_180494_b(final BlockPos p_180494_1_)
      {
@@ -73,7 +61,7 @@
          if (this.func_175667_e(p_180494_1_))
          {
              Chunk chunk = this.func_175726_f(p_180494_1_);
-@@ -206,7 +228,7 @@
+@@ -206,7 +226,7 @@
  
      public boolean func_175623_d(BlockPos p_175623_1_)
      {
@@ -82,7 +70,7 @@
      }
  
      public boolean func_175667_e(BlockPos p_175667_1_)
-@@ -307,24 +329,50 @@
+@@ -307,24 +327,50 @@
          else
          {
              Chunk chunk = this.func_175726_f(p_180501_1_);
@@ -136,7 +124,7 @@
                      this.func_184138_a(p_180501_1_, iblockstate, p_180501_2_, p_180501_3_);
                  }
  
-@@ -341,8 +389,6 @@
+@@ -341,8 +387,6 @@
                  {
                      this.func_190522_c(p_180501_1_, block);
                  }
@@ -145,7 +133,7 @@
              }
          }
      }
-@@ -357,7 +403,7 @@
+@@ -357,7 +401,7 @@
          IBlockState iblockstate = this.func_180495_p(p_175655_1_);
          Block block = iblockstate.func_177230_c();
  
@@ -154,7 +142,7 @@
          {
              return false;
          }
-@@ -440,6 +486,9 @@
+@@ -440,6 +484,9 @@
  
      public void func_175685_c(BlockPos p_175685_1_, Block p_175685_2_, boolean p_175685_3_)
      {
@@ -164,7 +152,7 @@
          this.func_190524_a(p_175685_1_.func_177976_e(), p_175685_2_, p_175685_1_);
          this.func_190524_a(p_175685_1_.func_177974_f(), p_175685_2_, p_175685_1_);
          this.func_190524_a(p_175685_1_.func_177977_b(), p_175685_2_, p_175685_1_);
-@@ -455,6 +504,11 @@
+@@ -455,6 +502,11 @@
  
      public void func_175695_a(BlockPos p_175695_1_, Block p_175695_2_, EnumFacing p_175695_3_)
      {
@@ -176,7 +164,7 @@
          if (p_175695_3_ != EnumFacing.WEST)
          {
              this.func_190524_a(p_175695_1_.func_177976_e(), p_175695_2_, p_175695_1_);
-@@ -526,11 +580,11 @@
+@@ -526,11 +578,11 @@
          {
              IBlockState iblockstate = this.func_180495_p(p_190529_1_);
  
@@ -190,7 +178,7 @@
                  }
                  catch (Throwable throwable)
                  {
-@@ -587,7 +641,7 @@
+@@ -587,7 +639,7 @@
                  {
                      IBlockState iblockstate = this.func_180495_p(blockpos1);
  
@@ -199,7 +187,7 @@
                      {
                          return false;
                      }
-@@ -861,7 +915,7 @@
+@@ -861,7 +913,7 @@
  
      public boolean func_72935_r()
      {
@@ -208,7 +196,7 @@
      }
  
      @Nullable
-@@ -1064,6 +1118,13 @@
+@@ -1064,6 +1116,13 @@
  
      public void func_184148_a(@Nullable EntityPlayer p_184148_1_, double p_184148_2_, double p_184148_4_, double p_184148_6_, SoundEvent p_184148_8_, SoundCategory p_184148_9_, float p_184148_10_, float p_184148_11_)
      {
@@ -222,7 +210,7 @@
          for (int i = 0; i < this.field_73021_x.size(); ++i)
          {
              ((IWorldEventListener)this.field_73021_x.get(i)).func_184375_a(p_184148_1_, p_184148_8_, p_184148_9_, p_184148_2_, p_184148_4_, p_184148_6_, p_184148_10_, p_184148_11_);
-@@ -1117,6 +1178,9 @@
+@@ -1117,6 +1176,9 @@
  
      public boolean func_72838_d(Entity p_72838_1_)
      {
@@ -232,7 +220,7 @@
          int i = MathHelper.func_76128_c(p_72838_1_.field_70165_t / 16.0D);
          int j = MathHelper.func_76128_c(p_72838_1_.field_70161_v / 16.0D);
          boolean flag = p_72838_1_.field_98038_p;
-@@ -1139,6 +1203,8 @@
+@@ -1139,6 +1201,8 @@
                  this.func_72854_c();
              }
  
@@ -241,7 +229,7 @@
              this.func_72964_e(i, j).func_76612_a(p_72838_1_);
              this.field_72996_f.add(p_72838_1_);
              this.func_72923_a(p_72838_1_);
-@@ -1267,6 +1333,7 @@
+@@ -1267,6 +1331,7 @@
                                  }
  
                                  iblockstate1.func_185908_a(this, blockpos$pooledmutableblockpos, p_191504_2_, p_191504_4_, p_191504_1_, false);
@@ -249,7 +237,7 @@
  
                                  if (p_191504_3_ && !p_191504_4_.isEmpty())
                                  {
-@@ -1318,11 +1385,10 @@
+@@ -1318,11 +1383,10 @@
                  }
              }
          }
@@ -262,7 +250,7 @@
      public void func_72848_b(IWorldEventListener p_72848_1_)
      {
          this.field_73021_x.remove(p_72848_1_);
-@@ -1360,19 +1426,38 @@
+@@ -1360,19 +1424,38 @@
  
      public int func_72967_a(float p_72967_1_)
      {
@@ -303,7 +291,7 @@
          float f = this.func_72826_c(p_72971_1_);
          float f1 = 1.0F - (MathHelper.func_76134_b(f * ((float)Math.PI * 2F)) * 2.0F + 0.2F);
          f1 = MathHelper.func_76131_a(f1, 0.0F, 1.0F);
-@@ -1385,6 +1470,12 @@
+@@ -1385,6 +1468,12 @@
      @SideOnly(Side.CLIENT)
      public Vec3d func_72833_a(Entity p_72833_1_, float p_72833_2_)
      {
@@ -316,7 +304,7 @@
          float f = this.func_72826_c(p_72833_2_);
          float f1 = MathHelper.func_76134_b(f * ((float)Math.PI * 2F)) * 2.0F + 0.5F;
          f1 = MathHelper.func_76131_a(f1, 0.0F, 1.0F);
-@@ -1392,9 +1483,7 @@
+@@ -1392,9 +1481,7 @@
          int j = MathHelper.func_76128_c(p_72833_1_.field_70163_u);
          int k = MathHelper.func_76128_c(p_72833_1_.field_70161_v);
          BlockPos blockpos = new BlockPos(i, j, k);
@@ -327,7 +315,7 @@
          float f3 = (float)(l >> 16 & 255) / 255.0F;
          float f4 = (float)(l >> 8 & 255) / 255.0F;
          float f5 = (float)(l & 255) / 255.0F;
-@@ -1443,20 +1532,25 @@
+@@ -1443,20 +1530,25 @@
  
      public float func_72826_c(float p_72826_1_)
      {
@@ -356,7 +344,7 @@
      public float func_72929_e(float p_72929_1_)
      {
          float f = this.func_72826_c(p_72929_1_);
-@@ -1466,6 +1560,12 @@
+@@ -1466,6 +1558,12 @@
      @SideOnly(Side.CLIENT)
      public Vec3d func_72824_f(float p_72824_1_)
      {
@@ -369,7 +357,7 @@
          float f = this.func_72826_c(p_72824_1_);
          float f1 = MathHelper.func_76134_b(f * ((float)Math.PI * 2F)) * 2.0F + 0.5F;
          f1 = MathHelper.func_76131_a(f1, 0.0F, 1.0F);
-@@ -1521,9 +1621,9 @@
+@@ -1521,9 +1619,9 @@
          for (blockpos = new BlockPos(p_175672_1_.func_177958_n(), chunk.func_76625_h() + 16, p_175672_1_.func_177952_p()); blockpos.func_177956_o() >= 0; blockpos = blockpos1)
          {
              blockpos1 = blockpos.func_177977_b();
@@ -381,7 +369,7 @@
              {
                  break;
              }
-@@ -1535,6 +1635,12 @@
+@@ -1535,6 +1633,12 @@
      @SideOnly(Side.CLIENT)
      public float func_72880_h(float p_72880_1_)
      {
@@ -394,7 +382,7 @@
          float f = this.func_72826_c(p_72880_1_);
          float f1 = 1.0F - (MathHelper.func_76134_b(f * ((float)Math.PI * 2F)) * 2.0F + 0.25F);
          f1 = MathHelper.func_76131_a(f1, 0.0F, 1.0F);
-@@ -1569,6 +1675,7 @@
+@@ -1569,6 +1673,7 @@
  
              try
              {
@@ -402,7 +390,7 @@
                  ++entity.field_70173_aa;
                  entity.func_70071_h_();
              }
-@@ -1586,6 +1693,12 @@
+@@ -1586,6 +1691,12 @@
                      entity.func_85029_a(crashreportcategory);
                  }
  
@@ -415,7 +403,7 @@
                  throw new ReportedException(crashreport);
              }
  
-@@ -1647,6 +1760,12 @@
+@@ -1647,6 +1758,12 @@
                      CrashReport crashreport1 = CrashReport.func_85055_a(throwable1, "Ticking entity");
                      CrashReportCategory crashreportcategory1 = crashreport1.func_85058_a("Entity being ticked");
                      entity2.func_85029_a(crashreportcategory1);
@@ -428,7 +416,7 @@
                      throw new ReportedException(crashreport1);
                  }
              }
-@@ -1683,11 +1802,11 @@
+@@ -1683,11 +1800,11 @@
              {
                  BlockPos blockpos = tileentity.func_174877_v();
  
@@ -442,7 +430,7 @@
                          ((ITickable)tileentity).func_73660_a();
                          this.field_72984_F.func_76319_b();
                      }
-@@ -1696,6 +1815,13 @@
+@@ -1696,6 +1813,13 @@
                          CrashReport crashreport2 = CrashReport.func_85055_a(throwable, "Ticking block entity");
                          CrashReportCategory crashreportcategory2 = crashreport2.func_85058_a("Block entity being ticked");
                          tileentity.func_145828_a(crashreportcategory2);
@@ -456,7 +444,7 @@
                          throw new ReportedException(crashreport2);
                      }
                  }
-@@ -1708,20 +1834,40 @@
+@@ -1708,20 +1832,40 @@
  
                  if (this.func_175667_e(tileentity.func_174877_v()))
                  {
@@ -486,8 +474,8 @@
 +        
 +        if (!this.tileEntitiesChunkToBeRemoved.isEmpty())
 +        {
-+    		for (Iterator<ChunkPos> iterator2 = tileEntitiesChunkToBeRemoved.iterator(); iterator2.hasNext();) {
-+    			ChunkPos pos = iterator2.next();
++    		for (Iterator<net.minecraft.util.math.ChunkPos> iterator2 = tileEntitiesChunkToBeRemoved.iterator(); iterator2.hasNext();) {
++    			net.minecraft.util.math.ChunkPos pos = iterator2.next();
 +    			field_175730_i.removeChunk(this, pos, false);
 +    			field_147482_g.removeChunk(this, pos, true);
 +    		}
@@ -500,7 +488,7 @@
          this.field_72984_F.func_76318_c("pendingBlockEntities");
  
          if (!this.field_147484_a.isEmpty())
-@@ -1760,12 +1906,18 @@
+@@ -1760,12 +1904,18 @@
  
      public boolean func_175700_a(TileEntity p_175700_1_)
      {
@@ -519,7 +507,7 @@
  
          if (this.field_72995_K)
          {
-@@ -1781,6 +1933,11 @@
+@@ -1781,6 +1931,11 @@
      {
          if (this.field_147481_N)
          {
@@ -531,7 +519,7 @@
              this.field_147484_a.addAll(p_147448_1_);
          }
          else
-@@ -1803,9 +1960,12 @@
+@@ -1803,9 +1958,12 @@
          {
              int i = MathHelper.func_76128_c(p_72866_1_.field_70165_t);
              int j = MathHelper.func_76128_c(p_72866_1_.field_70161_v);
@@ -546,7 +534,7 @@
              {
                  return;
              }
-@@ -1827,6 +1987,7 @@
+@@ -1827,6 +1985,7 @@
              }
              else
              {
@@ -554,7 +542,7 @@
                  p_72866_1_.func_70071_h_();
              }
          }
-@@ -2007,6 +2168,11 @@
+@@ -2007,6 +2166,11 @@
                              blockpos$pooledmutableblockpos.func_185344_t();
                              return true;
                          }
@@ -566,7 +554,7 @@
                      }
                  }
              }
-@@ -2046,6 +2212,16 @@
+@@ -2046,6 +2210,16 @@
                          IBlockState iblockstate = this.func_180495_p(blockpos$pooledmutableblockpos);
                          Block block = iblockstate.func_177230_c();
  
@@ -583,7 +571,7 @@
                          if (iblockstate.func_185904_a() == p_72918_2_)
                          {
                              double d0 = (double)((float)(l1 + 1) - BlockLiquid.func_149801_b(((Integer)iblockstate.func_177229_b(BlockLiquid.field_176367_b)).intValue()));
-@@ -2112,6 +2288,7 @@
+@@ -2112,6 +2286,7 @@
      public Explosion func_72885_a(@Nullable Entity p_72885_1_, double p_72885_2_, double p_72885_4_, double p_72885_6_, float p_72885_8_, boolean p_72885_9_, boolean p_72885_10_)
      {
          Explosion explosion = new Explosion(this, p_72885_1_, p_72885_2_, p_72885_4_, p_72885_6_, p_72885_8_, p_72885_9_, p_72885_10_);
@@ -591,7 +579,7 @@
          explosion.func_77278_a();
          explosion.func_77279_a(true);
          return explosion;
-@@ -2234,6 +2411,7 @@
+@@ -2234,6 +2409,7 @@
  
      public void func_175690_a(BlockPos p_175690_1_, @Nullable TileEntity p_175690_2_)
      {
@@ -599,7 +587,7 @@
          if (!this.func_189509_E(p_175690_1_))
          {
              if (p_175690_2_ != null && !p_175690_2_.func_145837_r())
-@@ -2241,6 +2419,8 @@
+@@ -2241,6 +2417,8 @@
                  if (this.field_147481_N)
                  {
                      p_175690_2_.func_174878_a(p_175690_1_);
@@ -608,7 +596,7 @@
                      Iterator<TileEntity> iterator = this.field_147484_a.iterator();
  
                      while (iterator.hasNext())
-@@ -2258,7 +2438,8 @@
+@@ -2258,7 +2436,8 @@
                  }
                  else
                  {
@@ -618,7 +606,7 @@
                      this.func_175700_a(p_175690_2_);
                  }
              }
-@@ -2273,6 +2454,8 @@
+@@ -2273,6 +2452,8 @@
          {
              tileentity.func_145843_s();
              this.field_147484_a.remove(tileentity);
@@ -627,7 +615,7 @@
          }
          else
          {
-@@ -2285,7 +2468,13 @@
+@@ -2285,7 +2466,13 @@
  
              this.func_175726_f(p_175713_1_).func_177425_e(p_175713_1_);
          }
@@ -641,7 +629,7 @@
  
      public void func_147457_a(TileEntity p_147457_1_)
      {
-@@ -2311,7 +2500,7 @@
+@@ -2311,7 +2498,7 @@
              if (chunk != null && !chunk.func_76621_g())
              {
                  IBlockState iblockstate = this.func_180495_p(p_175677_1_);
@@ -650,7 +638,7 @@
              }
              else
              {
-@@ -2334,6 +2523,7 @@
+@@ -2334,6 +2521,7 @@
      {
          this.field_72985_G = p_72891_1_;
          this.field_72992_H = p_72891_2_;
@@ -658,7 +646,7 @@
      }
  
      public void func_72835_b()
-@@ -2343,6 +2533,11 @@
+@@ -2343,6 +2531,11 @@
  
      protected void func_72947_a()
      {
@@ -670,7 +658,7 @@
          if (this.field_72986_A.func_76059_o())
          {
              this.field_73004_o = 1.0F;
-@@ -2356,6 +2551,11 @@
+@@ -2356,6 +2549,11 @@
  
      protected void func_72979_l()
      {
@@ -682,7 +670,7 @@
          if (this.field_73011_w.func_191066_m())
          {
              if (!this.field_72995_K)
-@@ -2480,6 +2680,11 @@
+@@ -2480,6 +2678,11 @@
  
      public boolean func_175670_e(BlockPos p_175670_1_, boolean p_175670_2_)
      {
@@ -694,7 +682,7 @@
          Biome biome = this.func_180494_b(p_175670_1_);
          float f = biome.func_180626_a(p_175670_1_);
  
-@@ -2521,6 +2726,11 @@
+@@ -2521,6 +2724,11 @@
  
      public boolean func_175708_f(BlockPos p_175708_1_, boolean p_175708_2_)
      {
@@ -706,7 +694,7 @@
          Biome biome = this.func_180494_b(p_175708_1_);
          float f = biome.func_180626_a(p_175708_1_);
  
-@@ -2538,7 +2748,7 @@
+@@ -2538,7 +2746,7 @@
              {
                  IBlockState iblockstate = this.func_180495_p(p_175708_1_);
  
@@ -715,7 +703,7 @@
                  {
                      return true;
                  }
-@@ -2570,10 +2780,11 @@
+@@ -2570,10 +2778,11 @@
          else
          {
              IBlockState iblockstate = this.func_180495_p(p_175638_1_);
@@ -730,7 +718,7 @@
              {
                  j = 1;
              }
-@@ -2679,7 +2890,7 @@
+@@ -2679,7 +2888,7 @@
                                      int j4 = j2 + enumfacing.func_96559_d();
                                      int k4 = k2 + enumfacing.func_82599_e();
                                      blockpos$pooledmutableblockpos.func_181079_c(i4, j4, k4);
@@ -739,7 +727,7 @@
                                      i3 = this.func_175642_b(p_180500_1_, blockpos$pooledmutableblockpos);
  
                                      if (i3 == l2 - l4 && j < this.field_72994_J.length)
-@@ -2787,10 +2998,10 @@
+@@ -2787,10 +2996,10 @@
      public List<Entity> func_175674_a(@Nullable Entity p_175674_1_, AxisAlignedBB p_175674_2_, @Nullable Predicate <? super Entity > p_175674_3_)
      {
          List<Entity> list = Lists.<Entity>newArrayList();
@@ -754,7 +742,7 @@
  
          for (int i1 = i; i1 <= j; ++i1)
          {
-@@ -2843,10 +3054,10 @@
+@@ -2843,10 +3052,10 @@
  
      public <T extends Entity> List<T> func_175647_a(Class <? extends T > p_175647_1_, AxisAlignedBB p_175647_2_, @Nullable Predicate <? super T > p_175647_3_)
      {
@@ -769,7 +757,7 @@
          List<T> list = Lists.<T>newArrayList();
  
          for (int i1 = i; i1 < j; ++i1)
-@@ -2926,11 +3137,13 @@
+@@ -2926,11 +3135,13 @@
  
      public void func_175650_b(Collection<Entity> p_175650_1_)
      {
@@ -786,7 +774,7 @@
          }
      }
  
-@@ -2954,7 +3167,7 @@
+@@ -2954,7 +3165,7 @@
          }
          else
          {
@@ -795,7 +783,7 @@
          }
      }
  
-@@ -3038,7 +3251,7 @@
+@@ -3038,7 +3249,7 @@
      public int func_175651_c(BlockPos p_175651_1_, EnumFacing p_175651_2_)
      {
          IBlockState iblockstate = this.func_180495_p(p_175651_1_);
@@ -804,7 +792,7 @@
      }
  
      public boolean func_175640_z(BlockPos p_175640_1_)
-@@ -3204,6 +3417,8 @@
+@@ -3204,6 +3415,8 @@
                      d2 *= ((Double)MoreObjects.firstNonNull(p_184150_11_.apply(entityplayer1), Double.valueOf(1.0D))).doubleValue();
                  }
  
@@ -813,7 +801,7 @@
                  if ((p_184150_9_ < 0.0D || Math.abs(entityplayer1.field_70163_u - p_184150_3_) < p_184150_9_ * p_184150_9_) && (p_184150_7_ < 0.0D || d1 < d2 * d2) && (d0 == -1.0D || d1 < d0))
                  {
                      d0 = d1;
-@@ -3265,7 +3480,7 @@
+@@ -3265,7 +3478,7 @@
  
      public long func_72905_C()
      {
@@ -822,7 +810,7 @@
      }
  
      public long func_82737_E()
-@@ -3275,17 +3490,17 @@
+@@ -3275,17 +3488,17 @@
  
      public long func_72820_D()
      {
@@ -843,7 +831,7 @@
  
          if (!this.func_175723_af().func_177746_a(blockpos))
          {
-@@ -3297,7 +3512,7 @@
+@@ -3297,7 +3510,7 @@
  
      public void func_175652_B(BlockPos p_175652_1_)
      {
@@ -852,7 +840,7 @@
      }
  
      @SideOnly(Side.CLIENT)
-@@ -3317,12 +3532,18 @@
+@@ -3317,12 +3530,18 @@
  
          if (!this.field_72996_f.contains(p_72897_1_))
          {
@@ -871,7 +859,7 @@
          return true;
      }
  
-@@ -3424,8 +3645,7 @@
+@@ -3424,8 +3643,7 @@
  
      public boolean func_180502_D(BlockPos p_180502_1_)
      {
@@ -881,7 +869,7 @@
      }
  
      @Nullable
-@@ -3486,12 +3706,12 @@
+@@ -3486,12 +3704,12 @@
  
      public int func_72800_K()
      {
@@ -896,7 +884,7 @@
      }
  
      public Random func_72843_D(int p_72843_1_, int p_72843_2_, int p_72843_3_)
-@@ -3535,7 +3755,7 @@
+@@ -3535,7 +3753,7 @@
      @SideOnly(Side.CLIENT)
      public double func_72919_O()
      {
@@ -905,7 +893,7 @@
      }
  
      public void func_175715_c(int p_175715_1_, BlockPos p_175715_2_, int p_175715_3_)
-@@ -3569,7 +3789,7 @@
+@@ -3569,7 +3787,7 @@
  
      public void func_175666_e(BlockPos p_175666_1_, Block p_175666_2_)
      {
@@ -914,7 +902,7 @@
          {
              BlockPos blockpos = p_175666_1_.func_177972_a(enumfacing);
  
-@@ -3577,18 +3797,14 @@
+@@ -3577,18 +3795,14 @@
              {
                  IBlockState iblockstate = this.func_180495_p(blockpos);
  
@@ -937,7 +925,7 @@
                      }
                  }
              }
-@@ -3654,6 +3870,115 @@
+@@ -3654,6 +3868,115 @@
          return i >= -128 && i <= 128 && j >= -128 && j <= 128;
      }
  

--- a/patches/minecraft/net/minecraft/world/chunk/Chunk.java.patch
+++ b/patches/minecraft/net/minecraft/world/chunk/Chunk.java.patch
@@ -157,7 +157,7 @@
          {
              if (this.field_150816_i.containsKey(p_177426_1_))
              {
-@@ -854,8 +854,9 @@
+@@ -854,23 +854,22 @@
  
          for (ClassInheritanceMultiMap<Entity> classinheritancemultimap : this.field_76645_j)
          {
@@ -168,7 +168,16 @@
      }
  
      public void func_76623_d()
-@@ -871,6 +872,7 @@
+     {
+         this.field_76636_d = false;
+ 
+-        for (TileEntity tileentity : this.field_150816_i.values())
+-        {
+-            this.field_76637_e.func_147457_a(tileentity);
+-        }
++        field_76637_e.markChunkForRemoval(this);
+ 
+         for (ClassInheritanceMultiMap<Entity> classinheritancemultimap : this.field_76645_j)
          {
              this.field_76637_e.func_175681_c(classinheritancemultimap);
          }
@@ -176,7 +185,7 @@
      }
  
      public void func_76630_e()
-@@ -880,8 +882,8 @@
+@@ -880,8 +879,8 @@
  
      public void func_177414_a(@Nullable Entity p_177414_1_, AxisAlignedBB p_177414_2_, List<Entity> p_177414_3_, Predicate <? super Entity > p_177414_4_)
      {
@@ -187,7 +196,7 @@
          i = MathHelper.func_76125_a(i, 0, this.field_76645_j.length - 1);
          j = MathHelper.func_76125_a(j, 0, this.field_76645_j.length - 1);
  
-@@ -918,8 +920,8 @@
+@@ -918,8 +917,8 @@
  
      public <T extends Entity> void func_177430_a(Class <? extends T > p_177430_1_, AxisAlignedBB p_177430_2_, List<T> p_177430_3_, Predicate <? super T > p_177430_4_)
      {
@@ -198,7 +207,7 @@
          i = MathHelper.func_76125_a(i, 0, this.field_76645_j.length - 1);
          j = MathHelper.func_76125_a(j, 0, this.field_76645_j.length - 1);
  
-@@ -997,6 +999,8 @@
+@@ -997,6 +996,8 @@
  
      protected void func_186034_a(IChunkGenerator p_186034_1_)
      {
@@ -207,7 +216,7 @@
          if (this.func_177419_t())
          {
              if (p_186034_1_.func_185933_a(this, this.field_76635_g, this.field_76647_h))
-@@ -1008,8 +1012,10 @@
+@@ -1008,8 +1009,10 @@
          {
              this.func_150809_p();
              p_186034_1_.func_185931_b(this.field_76635_g, this.field_76647_h);
@@ -218,7 +227,7 @@
      }
  
      public BlockPos func_177440_h(BlockPos p_177440_1_)
-@@ -1064,7 +1070,7 @@
+@@ -1064,7 +1067,7 @@
          {
              BlockPos blockpos = this.field_177447_w.poll();
  
@@ -227,7 +236,7 @@
              {
                  TileEntity tileentity = this.func_177422_i(blockpos);
                  this.field_76637_e.func_175690_a(blockpos, tileentity);
-@@ -1128,6 +1134,13 @@
+@@ -1128,6 +1131,13 @@
      @SideOnly(Side.CLIENT)
      public void func_186033_a(PacketBuffer p_186033_1_, int p_186033_2_, boolean p_186033_3_)
      {
@@ -241,7 +250,7 @@
          boolean flag = this.field_76637_e.field_73011_w.func_191066_m();
  
          for (int i = 0; i < this.field_76652_q.length; ++i)
-@@ -1176,10 +1189,16 @@
+@@ -1176,10 +1186,16 @@
          this.field_76646_k = true;
          this.func_76590_a();
  
@@ -258,7 +267,7 @@
      }
  
      public Biome func_177411_a(BlockPos p_177411_1_, BiomeProvider p_177411_2_)
-@@ -1244,13 +1263,13 @@
+@@ -1244,13 +1260,13 @@
                      BlockPos blockpos1 = blockpos.func_177982_a(k, (j << 4) + i1, l);
                      boolean flag = i1 == 0 || i1 == 15 || k == 0 || k == 15 || l == 0 || l == 15;
  
@@ -274,7 +283,7 @@
                              {
                                  this.field_76637_e.func_175664_x(blockpos2);
                              }
-@@ -1381,7 +1400,7 @@
+@@ -1381,7 +1397,7 @@
          {
              blockpos$mutableblockpos.func_181079_c(blockpos$mutableblockpos.func_177958_n(), l, blockpos$mutableblockpos.func_177952_p());
  
@@ -283,7 +292,7 @@
              {
                  this.field_76637_e.func_175664_x(blockpos$mutableblockpos);
              }
-@@ -1489,4 +1508,34 @@
+@@ -1489,4 +1505,34 @@
          QUEUED,
          CHECK;
      }

--- a/src/main/java/net/minecraftforge/common/util/ChunkedTileEntityList.java
+++ b/src/main/java/net/minecraftforge/common/util/ChunkedTileEntityList.java
@@ -1,0 +1,213 @@
+package net.minecraftforge.common.util;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map.Entry;
+import java.util.Set;
+
+import net.minecraft.tileentity.TileEntity;
+import net.minecraft.util.math.ChunkPos;
+import net.minecraft.world.World;
+import net.minecraft.world.chunk.Chunk;
+
+public class ChunkedTileEntityList {
+	
+	private static ChunkPos getChunkPos(TileEntity te)
+	{
+		return new ChunkPos(te.getPos());
+	}
+	
+	private HashMap<ChunkPos, List<TileEntity>> content;
+	
+	public ChunkedTileEntityList()
+	{
+		this.content = new HashMap<>();
+	}
+	
+	public ChunkedTileEntityList(ChunkedTileEntityList list)
+	{
+		this();
+		for (Iterator<Entry<ChunkPos, List<TileEntity>>> iterator = list.entrySet().iterator(); iterator.hasNext();) {
+			Entry<ChunkPos, List<TileEntity>> entry = iterator.next();
+			content.put(entry.getKey(), new ArrayList<>(entry.getValue()));
+		}
+	}
+	
+	public List<TileEntity> getChunkTEList(ChunkPos key)
+	{
+		return content.get(key);
+	}
+	
+	public Set<ChunkPos> keySet()
+	{
+		return content.keySet();
+	}
+	
+	public Collection<List<TileEntity>> values()
+	{
+		return content.values();
+	}
+	
+	public Set<Entry<ChunkPos, List<TileEntity>>> entrySet()
+	{
+		return content.entrySet();
+	}
+	
+	public boolean containsAll(Collection<TileEntity> tileEntities)
+	{
+		for (Iterator<TileEntity> iterator = tileEntities.iterator(); iterator.hasNext();) {
+			if(!contains(iterator.next()))
+				return false;
+		}
+		return true;
+	}
+	
+	public boolean contains(TileEntity te)
+	{
+		List<TileEntity> list = getChunkTEList(getChunkPos(te));
+		if(list != null)
+			return list.contains(te);
+		return false;
+	}
+	
+	public void add(TileEntity[] tileEntities)
+	{
+		for (int i = 0; i < tileEntities.length; i++) {
+			add(tileEntities[i]);
+		}
+	}
+	
+	public void add(Collection<TileEntity> tileEntities)
+	{
+		for (Iterator<TileEntity> iterator = tileEntities.iterator(); iterator.hasNext();) {
+			add(iterator.next());
+		}
+	}
+	
+	public boolean add(TileEntity te)
+	{
+		ChunkPos pos = getChunkPos(te);
+		List<TileEntity> list = getChunkTEList(pos);
+		if(list == null)
+		{
+			list = new ArrayList<>();
+			list.add(te);
+			content.put(pos, list);
+			return true;
+		}
+		else
+			return list.add(te);
+	}
+	
+	public void removeAll(Collection<TileEntity> tileEntities)
+	{
+		for (Iterator<TileEntity> iterator = tileEntities.iterator(); iterator.hasNext();) {
+			remove(iterator.next());
+		}
+	}
+	
+	public boolean remove(TileEntity te)
+	{
+		ChunkPos pos = getChunkPos(te);
+		List<TileEntity> values = getChunkTEList(pos);
+		if(values != null)
+			if(values.remove(te))
+			{
+				if(values.isEmpty())
+					removeChunk(pos);
+				return true;
+			}
+		return false;
+	}
+	
+	private boolean removeChunk(ChunkPos key)
+	{
+		return content.remove(key) != null;
+	}
+	
+	public boolean removeChunk(World world, ChunkPos pos, boolean notify)
+	{
+		if(notify)
+		{
+			for (TileEntity te : getChunkTEList(pos))
+	        {
+				te.onChunkUnload();
+	        }
+		}
+		
+		return removeChunk(pos);
+	}
+	
+	public int totalCount()
+	{
+		int size = 0;
+		for (List<TileEntity> values : content.values()) {
+			size += values.size();
+		}
+		return size;
+	}
+	
+	public int chunkCount()
+	{
+		return content.size();
+	}
+	
+	public void clear()
+	{
+		content.clear();
+	}
+	
+	@Override
+	public String toString()
+	{
+		return content.toString();
+	}
+
+	public boolean isEmpty() {
+		return totalCount() > 0;
+	}
+	
+	public Iterator<TileEntity> iterator()
+	{
+		return new Iterator<TileEntity>() {
+			
+			int index = 0;
+			
+			Iterator<List<TileEntity>> iterator = values().iterator();
+			
+			List<TileEntity> currentList;
+			
+			@Override
+			public boolean hasNext() {
+				while(currentList == null || currentList.size() <= index)
+				{
+					if(iterator.hasNext())
+					{
+						currentList = iterator.next();
+						index = 0;
+					}
+					else
+						return false;
+				}
+				
+				return true;
+			}
+
+			@Override
+			public TileEntity next() {
+				TileEntity value = currentList.get(index);
+				index++;
+				return value;
+			}
+			
+			@Override
+			public void remove() {
+				currentList.remove(index-1);
+			}
+		};
+	}
+	
+}

--- a/src/main/java/net/minecraftforge/common/util/ChunkedTileEntityList.java
+++ b/src/main/java/net/minecraftforge/common/util/ChunkedTileEntityList.java
@@ -20,10 +20,10 @@ package net.minecraftforge.common.util;
 
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.HashMap;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.ListIterator;
 import java.util.Map.Entry;
 import java.util.Set;
 
@@ -31,7 +31,7 @@ import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.math.ChunkPos;
 import net.minecraft.world.World;
 
-public class ChunkedTileEntityList implements Collection<TileEntity>
+public class ChunkedTileEntityList implements List<TileEntity>
 {
 	
 	private static ChunkPos getChunkPos(TileEntity te)
@@ -75,6 +75,7 @@ public class ChunkedTileEntityList implements Collection<TileEntity>
 		return content.entrySet();
 	}
 	
+	@Override
 	public boolean containsAll(Collection<?> tileEntities)
 	{
 		for (Iterator<?> iterator = tileEntities.iterator(); iterator.hasNext();) {
@@ -84,6 +85,7 @@ public class ChunkedTileEntityList implements Collection<TileEntity>
 		return true;
 	}
 	
+	@Override
 	public boolean contains(Object te)
 	{
 		if(!(te instanceof TileEntity))
@@ -126,6 +128,17 @@ public class ChunkedTileEntityList implements Collection<TileEntity>
 			return list.add(te);
 	}
 	
+	@Override
+	public void add(int index, TileEntity te) {
+		add(te);
+	}
+	
+	@Override
+	public boolean addAll(int index, Collection<? extends TileEntity> tileEntities) {
+		return addAll(tileEntities);
+	}
+	
+	@Override
 	public boolean removeAll(Collection<?> tileEntities)
 	{
 		boolean removedAll = true;
@@ -136,6 +149,7 @@ public class ChunkedTileEntityList implements Collection<TileEntity>
 		return removedAll;
 	}
 	
+	@Override
 	public boolean remove(Object te)
 	{
 		if(!(te instanceof TileEntity))
@@ -184,6 +198,7 @@ public class ChunkedTileEntityList implements Collection<TileEntity>
 		return content.size();
 	}
 	
+	@Override
 	public void clear()
 	{
 		content.clear();
@@ -194,11 +209,13 @@ public class ChunkedTileEntityList implements Collection<TileEntity>
 	{
 		return content.toString();
 	}
-
+	
+	@Override
 	public boolean isEmpty() {
 		return totalCount() > 0;
 	}
 	
+	@Override
 	public Iterator<TileEntity> iterator()
 	{
 		return new Iterator<TileEntity>() {
@@ -279,6 +296,48 @@ public class ChunkedTileEntityList implements Collection<TileEntity>
 			}
 		}
 		return paramArrayOfT;
+	}
+	
+	//Not supported methods
+
+	@Override
+	public TileEntity get(int index) {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public int indexOf(Object o) {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public int lastIndexOf(Object o) {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public ListIterator<TileEntity> listIterator() {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public ListIterator<TileEntity> listIterator(int index) {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public TileEntity remove(int index) {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public TileEntity set(int index, TileEntity element) {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public List<TileEntity> subList(int fromIndex, int toIndex) {
+		throw new UnsupportedOperationException();
 	}
 	
 }

--- a/src/main/java/net/minecraftforge/common/util/ChunkedTileEntityList.java
+++ b/src/main/java/net/minecraftforge/common/util/ChunkedTileEntityList.java
@@ -1,3 +1,21 @@
+/*
+ * Minecraft Forge
+ * Copyright (c) 2017.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation version 2.1
+ * of the License.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
 package net.minecraftforge.common.util;
 
 import java.util.ArrayList;
@@ -11,9 +29,9 @@ import java.util.Set;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.math.ChunkPos;
 import net.minecraft.world.World;
-import net.minecraft.world.chunk.Chunk;
 
-public class ChunkedTileEntityList {
+public class ChunkedTileEntityList
+{
 	
 	private static ChunkPos getChunkPos(TileEntity te)
 	{

--- a/src/main/java/net/minecraftforge/common/util/ChunkedTileEntityList.java
+++ b/src/main/java/net/minecraftforge/common/util/ChunkedTileEntityList.java
@@ -22,6 +22,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Iterator;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map.Entry;
 import java.util.Set;
@@ -38,11 +39,11 @@ public class ChunkedTileEntityList implements Collection<TileEntity>
 		return new ChunkPos(te.getPos());
 	}
 	
-	private HashMap<ChunkPos, List<TileEntity>> content;
+	private LinkedHashMap<ChunkPos, List<TileEntity>> content;
 	
 	public ChunkedTileEntityList()
 	{
-		this.content = new HashMap<>();
+		this.content = new LinkedHashMap<>();
 	}
 	
 	public ChunkedTileEntityList(ChunkedTileEntityList list)

--- a/src/main/java/net/minecraftforge/common/util/ChunkedTileEntityList.java
+++ b/src/main/java/net/minecraftforge/common/util/ChunkedTileEntityList.java
@@ -30,7 +30,7 @@ import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.math.ChunkPos;
 import net.minecraft.world.World;
 
-public class ChunkedTileEntityList
+public class ChunkedTileEntityList implements Collection<TileEntity>
 {
 	
 	private static ChunkPos getChunkPos(TileEntity te)
@@ -74,18 +74,20 @@ public class ChunkedTileEntityList
 		return content.entrySet();
 	}
 	
-	public boolean containsAll(Collection<TileEntity> tileEntities)
+	public boolean containsAll(Collection<?> tileEntities)
 	{
-		for (Iterator<TileEntity> iterator = tileEntities.iterator(); iterator.hasNext();) {
+		for (Iterator<?> iterator = tileEntities.iterator(); iterator.hasNext();) {
 			if(!contains(iterator.next()))
 				return false;
 		}
 		return true;
 	}
 	
-	public boolean contains(TileEntity te)
+	public boolean contains(Object te)
 	{
-		List<TileEntity> list = getChunkTEList(getChunkPos(te));
+		if(!(te instanceof TileEntity))
+			return false;
+		List<TileEntity> list = getChunkTEList(getChunkPos((TileEntity) te));
 		if(list != null)
 			return list.contains(te);
 		return false;
@@ -98,13 +100,16 @@ public class ChunkedTileEntityList
 		}
 	}
 	
-	public void add(Collection<TileEntity> tileEntities)
+	@Override
+	public boolean addAll(Collection<? extends TileEntity> tileEntities)
 	{
-		for (Iterator<TileEntity> iterator = tileEntities.iterator(); iterator.hasNext();) {
+		for (Iterator<? extends TileEntity> iterator = tileEntities.iterator(); iterator.hasNext();) {
 			add(iterator.next());
 		}
+		return true;
 	}
 	
+	@Override
 	public boolean add(TileEntity te)
 	{
 		ChunkPos pos = getChunkPos(te);
@@ -120,16 +125,21 @@ public class ChunkedTileEntityList
 			return list.add(te);
 	}
 	
-	public void removeAll(Collection<TileEntity> tileEntities)
+	public boolean removeAll(Collection<?> tileEntities)
 	{
-		for (Iterator<TileEntity> iterator = tileEntities.iterator(); iterator.hasNext();) {
-			remove(iterator.next());
+		boolean removedAll = true;
+		for (Iterator<?> iterator = tileEntities.iterator(); iterator.hasNext();) {
+			if(!remove(iterator.next()))
+				removedAll = false;
 		}
+		return removedAll;
 	}
 	
-	public boolean remove(TileEntity te)
+	public boolean remove(Object te)
 	{
-		ChunkPos pos = getChunkPos(te);
+		if(!(te instanceof TileEntity))
+			return false;
+		ChunkPos pos = getChunkPos((TileEntity) te);
 		List<TileEntity> values = getChunkTEList(pos);
 		if(values != null)
 			if(values.remove(te))
@@ -226,6 +236,48 @@ public class ChunkedTileEntityList
 				currentList.remove(index-1);
 			}
 		};
+	}
+
+	@Override
+	public boolean retainAll(Collection<?> paramCollection) {
+		boolean changed = false;
+		for (List<TileEntity> values : content.values()) {
+			if(values.retainAll(paramCollection))
+				changed = true;
+		}
+		return changed;
+	}
+
+	@Override
+	public int size() {
+		return totalCount();
+	}
+
+	@Override
+	public Object[] toArray() {
+		Object[] array = new Object[totalCount()];
+		int i = 0;
+		for (List<TileEntity> values : content.values()) {
+			for (int j = 0; j < values.size(); j++) {
+				array[i] = values.get(j);
+				i++;
+			}
+		}
+		return array;
+	}
+
+	@Override
+	public <T> T[] toArray(T[] paramArrayOfT) {
+		if(paramArrayOfT.length < totalCount())
+			paramArrayOfT = (T[]) java.lang.reflect.Array.newInstance(paramArrayOfT.getClass().getComponentType(), totalCount());
+		int i = 0;
+		for (List<TileEntity> values : content.values()) {
+			for (int j = 0; j < values.size(); j++) {
+				paramArrayOfT[i] = (T) values.get(j);
+				i++;
+			}
+		}
+		return paramArrayOfT;
 	}
 	
 }

--- a/src/main/java/net/minecraftforge/common/util/ChunkedTileEntityList.java
+++ b/src/main/java/net/minecraftforge/common/util/ChunkedTileEntityList.java
@@ -18,6 +18,7 @@
  */
 package net.minecraftforge.common.util;
 
+import java.lang.reflect.Array;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Iterator;
@@ -33,311 +34,336 @@ import net.minecraft.world.World;
 
 public class ChunkedTileEntityList implements List<TileEntity>
 {
-	
-	private static ChunkPos getChunkPos(TileEntity te)
-	{
-		return new ChunkPos(te.getPos());
-	}
-	
-	private LinkedHashMap<ChunkPos, List<TileEntity>> content;
-	
-	public ChunkedTileEntityList()
-	{
-		this.content = new LinkedHashMap<>();
-	}
-	
-	public ChunkedTileEntityList(ChunkedTileEntityList list)
-	{
-		this();
-		for (Iterator<Entry<ChunkPos, List<TileEntity>>> iterator = list.entrySet().iterator(); iterator.hasNext();) {
-			Entry<ChunkPos, List<TileEntity>> entry = iterator.next();
-			content.put(entry.getKey(), new ArrayList<>(entry.getValue()));
-		}
-	}
-	
-	public List<TileEntity> getChunkTEList(ChunkPos key)
-	{
-		return content.get(key);
-	}
-	
-	public Set<ChunkPos> keySet()
-	{
-		return content.keySet();
-	}
-	
-	public Collection<List<TileEntity>> values()
-	{
-		return content.values();
-	}
-	
-	public Set<Entry<ChunkPos, List<TileEntity>>> entrySet()
-	{
-		return content.entrySet();
-	}
-	
-	@Override
-	public boolean containsAll(Collection<?> tileEntities)
-	{
-		for (Iterator<?> iterator = tileEntities.iterator(); iterator.hasNext();) {
-			if(!contains(iterator.next()))
-				return false;
-		}
-		return true;
-	}
-	
-	@Override
-	public boolean contains(Object te)
-	{
-		if(!(te instanceof TileEntity))
-			return false;
-		List<TileEntity> list = getChunkTEList(getChunkPos((TileEntity) te));
-		if(list != null)
-			return list.contains(te);
-		return false;
-	}
-	
-	public void add(TileEntity[] tileEntities)
-	{
-		for (int i = 0; i < tileEntities.length; i++) {
-			add(tileEntities[i]);
-		}
-	}
-	
-	@Override
-	public boolean addAll(Collection<? extends TileEntity> tileEntities)
-	{
-		for (Iterator<? extends TileEntity> iterator = tileEntities.iterator(); iterator.hasNext();) {
-			add(iterator.next());
-		}
-		return true;
-	}
-	
-	@Override
-	public boolean add(TileEntity te)
-	{
-		ChunkPos pos = getChunkPos(te);
-		List<TileEntity> list = getChunkTEList(pos);
-		if(list == null)
-		{
-			list = new ArrayList<>();
-			list.add(te);
-			content.put(pos, list);
-			return true;
-		}
-		else
-			return list.add(te);
-	}
-	
-	@Override
-	public void add(int index, TileEntity te) {
-		add(te);
-	}
-	
-	@Override
-	public boolean addAll(int index, Collection<? extends TileEntity> tileEntities) {
-		return addAll(tileEntities);
-	}
-	
-	@Override
-	public boolean removeAll(Collection<?> tileEntities)
-	{
-		boolean removedAll = true;
-		for (Iterator<?> iterator = tileEntities.iterator(); iterator.hasNext();) {
-			if(!remove(iterator.next()))
-				removedAll = false;
-		}
-		return removedAll;
-	}
-	
-	@Override
-	public boolean remove(Object te)
-	{
-		if(!(te instanceof TileEntity))
-			return false;
-		ChunkPos pos = getChunkPos((TileEntity) te);
-		List<TileEntity> values = getChunkTEList(pos);
-		if(values != null)
-			if(values.remove(te))
-			{
-				if(values.isEmpty())
-					removeChunk(pos);
-				return true;
-			}
-		return false;
-	}
-	
-	private boolean removeChunk(ChunkPos key)
-	{
-		return content.remove(key) != null;
-	}
-	
-	public boolean removeChunk(World world, ChunkPos pos, boolean notify)
-	{
-		if(notify)
-		{
-			for (TileEntity te : getChunkTEList(pos))
-	        {
-				te.onChunkUnload();
-	        }
-		}
-		
-		return removeChunk(pos);
-	}
-	
-	public int totalCount()
-	{
-		int size = 0;
-		for (List<TileEntity> values : content.values()) {
-			size += values.size();
-		}
-		return size;
-	}
-	
-	public int chunkCount()
-	{
-		return content.size();
-	}
-	
-	@Override
-	public void clear()
-	{
-		content.clear();
-	}
-	
-	@Override
-	public String toString()
-	{
-		return content.toString();
-	}
-	
-	@Override
-	public boolean isEmpty() {
-		return totalCount() > 0;
-	}
-	
-	@Override
-	public Iterator<TileEntity> iterator()
-	{
-		return new Iterator<TileEntity>() {
-			
-			int index = 0;
-			
-			Iterator<List<TileEntity>> iterator = values().iterator();
-			
-			List<TileEntity> currentList;
-			
-			@Override
-			public boolean hasNext() {
-				while(currentList == null || currentList.size() <= index)
-				{
-					if(iterator.hasNext())
-					{
-						currentList = iterator.next();
-						index = 0;
-					}
-					else
-						return false;
-				}
-				
-				return true;
-			}
 
-			@Override
-			public TileEntity next() {
-				TileEntity value = currentList.get(index);
-				index++;
-				return value;
-			}
-			
-			@Override
-			public void remove() {
-				currentList.remove(index-1);
-			}
-		};
-	}
+    private static ChunkPos getChunkPos(TileEntity te)
+    {
+        return new ChunkPos(te.getPos());
+    }
 
-	@Override
-	public boolean retainAll(Collection<?> paramCollection) {
-		boolean changed = false;
-		for (List<TileEntity> values : content.values()) {
-			if(values.retainAll(paramCollection))
-				changed = true;
-		}
-		return changed;
-	}
+    private LinkedHashMap<ChunkPos, List<TileEntity>> content;
 
-	@Override
-	public int size() {
-		return totalCount();
-	}
+    public ChunkedTileEntityList()
+    {
+        this.content = new LinkedHashMap<>();
+    }
 
-	@Override
-	public Object[] toArray() {
-		Object[] array = new Object[totalCount()];
-		int i = 0;
-		for (List<TileEntity> values : content.values()) {
-			for (int j = 0; j < values.size(); j++) {
-				array[i] = values.get(j);
-				i++;
-			}
-		}
-		return array;
-	}
+    public ChunkedTileEntityList(ChunkedTileEntityList list)
+    {
+        this();
+        for (Entry<ChunkPos, List<TileEntity>> entry : list.entrySet())
+        {
+            content.put(entry.getKey(), new ArrayList<>(entry.getValue()));
+        }
+    }
 
-	@Override
-	public <T> T[] toArray(T[] paramArrayOfT) {
-		if(paramArrayOfT.length < totalCount())
-			paramArrayOfT = (T[]) java.lang.reflect.Array.newInstance(paramArrayOfT.getClass().getComponentType(), totalCount());
-		int i = 0;
-		for (List<TileEntity> values : content.values()) {
-			for (int j = 0; j < values.size(); j++) {
-				paramArrayOfT[i] = (T) values.get(j);
-				i++;
-			}
-		}
-		return paramArrayOfT;
-	}
-	
-	//Not supported methods
+    public List<TileEntity> getChunkTEList(ChunkPos key)
+    {
+        return content.get(key);
+    }
 
-	@Override
-	public TileEntity get(int index) {
-		throw new UnsupportedOperationException();
-	}
+    public Set<ChunkPos> keySet()
+    {
+        return content.keySet();
+    }
 
-	@Override
-	public int indexOf(Object o) {
-		throw new UnsupportedOperationException();
-	}
+    public Collection<List<TileEntity>> values()
+    {
+        return content.values();
+    }
 
-	@Override
-	public int lastIndexOf(Object o) {
-		throw new UnsupportedOperationException();
-	}
+    public Set<Entry<ChunkPos, List<TileEntity>>> entrySet()
+    {
+        return content.entrySet();
+    }
 
-	@Override
-	public ListIterator<TileEntity> listIterator() {
-		throw new UnsupportedOperationException();
-	}
+    @Override
+    public boolean containsAll(Collection<?> tileEntities)
+    {
+        for (Object object : tileEntities)
+        {
+            if (!contains(object))
+                return false;
+        }
+        return true;
+    }
 
-	@Override
-	public ListIterator<TileEntity> listIterator(int index) {
-		throw new UnsupportedOperationException();
-	}
+    @Override
+    public boolean contains(Object te)
+    {
+        if (!(te instanceof TileEntity))
+            return false;
+        List<TileEntity> list = getChunkTEList(getChunkPos((TileEntity) te));
+        if (list != null)
+            return list.contains(te);
+        return false;
+    }
 
-	@Override
-	public TileEntity remove(int index) {
-		throw new UnsupportedOperationException();
-	}
+    public void add(TileEntity... tileEntities)
+    {
+        for (int i = 0; i < tileEntities.length; i++)
+        {
+            add(tileEntities[i]);
+        }
+    }
 
-	@Override
-	public TileEntity set(int index, TileEntity element) {
-		throw new UnsupportedOperationException();
-	}
+    @Override
+    public boolean addAll(Collection<? extends TileEntity> tileEntities)
+    {
+        for (TileEntity tileEntity : tileEntities)
+        {
+            add(tileEntity);
+        }
+        return true;
+    }
 
-	@Override
-	public List<TileEntity> subList(int fromIndex, int toIndex) {
-		throw new UnsupportedOperationException();
-	}
-	
+    @Override
+    public boolean add(TileEntity te)
+    {
+        ChunkPos pos = getChunkPos(te);
+        List<TileEntity> list = getChunkTEList(pos);
+        if (list == null)
+        {
+            list = new ArrayList<>();
+            list.add(te);
+            content.put(pos, list);
+            return true;
+        }
+        else
+            return list.add(te);
+    }
+
+    @Override
+    public void add(int index, TileEntity te)
+    {
+        add(te);
+    }
+
+    @Override
+    public boolean addAll(int index, Collection<? extends TileEntity> tileEntities)
+    {
+        return addAll(tileEntities);
+    }
+
+    @Override
+    public boolean removeAll(Collection<?> tileEntities)
+    {
+        boolean removedAll = true;
+        for (Object object : tileEntities)
+        {
+            if (!remove(object))
+                removedAll = false;
+        }
+        return removedAll;
+    }
+
+    @Override
+    public boolean remove(Object te)
+    {
+        if (!(te instanceof TileEntity))
+            return false;
+        ChunkPos pos = getChunkPos((TileEntity) te);
+        List<TileEntity> values = getChunkTEList(pos);
+        if (values != null)
+            if (values.remove(te))
+            {
+                if (values.isEmpty())
+                    removeChunk(pos);
+                return true;
+            }
+        return false;
+    }
+
+    private boolean removeChunk(ChunkPos key)
+    {
+        return content.remove(key) != null;
+    }
+
+    public boolean removeChunk(World world, ChunkPos pos, boolean notify)
+    {
+        if (notify)
+        {
+            for (TileEntity te : getChunkTEList(pos))
+            {
+                te.onChunkUnload();
+            }
+        }
+
+        return removeChunk(pos);
+    }
+
+    public int totalCount()
+    {
+        int size = 0;
+        for (List<TileEntity> values : content.values())
+        {
+            size += values.size();
+        }
+        return size;
+    }
+
+    public int chunkCount()
+    {
+        return content.size();
+    }
+
+    @Override
+    public void clear()
+    {
+        content.clear();
+    }
+
+    @Override
+    public String toString()
+    {
+        return content.toString();
+    }
+
+    @Override
+    public boolean isEmpty()
+    {
+        return chunkCount() == 0;
+    }
+
+    @Override
+    public Iterator<TileEntity> iterator()
+    {
+        return new Iterator<TileEntity>() {
+
+            int index = 0;
+
+            Iterator<List<TileEntity>> iterator = values().iterator();
+
+            List<TileEntity> currentList;
+
+            @Override
+            public boolean hasNext()
+            {
+                while (currentList == null || currentList.size() <= index)
+                {
+                    if (iterator.hasNext())
+                    {
+                        currentList = iterator.next();
+                        index = 0;
+                    }
+                    else
+                        return false;
+                }
+
+                return true;
+            }
+
+            @Override
+            public TileEntity next()
+            {
+                TileEntity value = currentList.get(index);
+                index++;
+                return value;
+            }
+
+            @Override
+            public void remove()
+            {
+                currentList.remove(index - 1);
+            }
+        };
+    }
+
+    @Override
+    public boolean retainAll(Collection<?> paramCollection)
+    {
+        boolean changed = false;
+        for (List<TileEntity> values : content.values())
+        {
+            if (values.retainAll(paramCollection))
+                changed = true;
+        }
+        return changed;
+    }
+
+    @Override
+    public int size()
+    {
+        return totalCount();
+    }
+
+    @Override
+    public Object[] toArray()
+    {
+        Object[] array = new Object[totalCount()];
+        int i = 0;
+        for (List<TileEntity> values : content.values())
+        {
+            for (int j = 0; j < values.size(); j++)
+            {
+                array[i] = values.get(j);
+                i++;
+            }
+        }
+        return array;
+    }
+
+    @Override
+    public <T> T[] toArray(T[] paramArrayOfT)
+    {
+        if (paramArrayOfT.length < totalCount())
+            paramArrayOfT = (T[]) Array.newInstance(paramArrayOfT.getClass().getComponentType(), totalCount());
+        int i = 0;
+        for (List<TileEntity> values : content.values())
+        {
+            for (TileEntity te : values)
+                paramArrayOfT[i++] = (T) te;
+        }
+        return paramArrayOfT;
+    }
+
+    // Not supported methods
+
+    @Override
+    public TileEntity get(int index)
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public int indexOf(Object o)
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public int lastIndexOf(Object o)
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public ListIterator<TileEntity> listIterator()
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public ListIterator<TileEntity> listIterator(int index)
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public TileEntity remove(int index)
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public TileEntity set(int index, TileEntity element)
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public List<TileEntity> subList(int fromIndex, int toIndex)
+    {
+        throw new UnsupportedOperationException();
+    }
+
 }


### PR DESCRIPTION
Hey there,

I'm the author of LittleTiles/CreativeCore and recently I found out that Minecraft has a huge lag spike during unloading chunks if the world contains a lot of tileentities.

**How did I find it?**
Although the performance of LittleTiles was not bad there used to be quite horrible lag spikes, which occurred rather frequently while the player was moving. It became more and more unbearable. So I made several attempts to fix it, but unfortunately without any success. I couldn't find anything in my code.
A few months later I tried it again, but this time I was ignoring my code, since I suspected it to be an issue caused by Minecraft itself.

**The issue itself**
Eventually I found that the lag spike was not caused by loading new chunks, but instead while unloading the old ones. After some further investigations I saw those two suspicious looking lines in `World.updateEntities()`:
```java
this.tickableTileEntities.removeAll(this.tileEntitiesToBeRemoved);
this.loadedTileEntityList.removeAll(this.tileEntitiesToBeRemoved);
```
So I debugged it and ... yes ... wow. There were 20,000 tileentities in `tickableTileEntities` and `loadedTileEntityList` while `tileEntitiesToBeRemoved` had a size of 3,000. Stepping over it using the debugger took quite a long time.

I finally had found the issue. It's not caused by the amount of traffic or the complexity of tileentities, but caused by the amount of tileentities no matter if there are furnaces or more complicated ones.

This video demonstrates this issue: https://www.youtube.com/watch?v=vTCJbp45pWM

I also reported this issue to Mojang: https://bugs.mojang.com/browse/MC-119686

**How did i fix it?**
I replaced those two lists with `HashMap<ChunkPos, List<TileEntity>>`. So once a chunk will unload one key will be removed instead of iterating through the whole list several times. This completely solved the lag spikes (as shown in the video).

I implemented it in CreativeCore v1.8 and eventually decided to create this pr.

**About this PR**
I changed `tickableTileEntities` and `loadedTileEntityList` from an ArrayList to a `ChunkedTileEntityList`, which basically saves all tileentities in a `HashMap<ChunkPos, List<TileEntity>>`. Furthermore I added another list to the world (`tileEntitiesChunkToBeRemoved`), which contains all chunk positions of unloaded chunks. During each tick those will be removed from `tickableTileEntities` and `loadedTileEntityList`.
It's still possible unloading a tileentity using the old way, but I changed it for the chunk. A chunk will now call `markChunkForRemoval` instead of calling `markTileEntityForRemoval` (func_147457_a) for each tileentity.

If there is anything to complain about my naming or the formatting style, just let me know.

**Possible mod conflicts**
Since CreativeCore changed it already I can ensure that there is currently only one mod it is conflicting with https://github.com/RootsTeam/Embers/issues/237.
As long the iterator is used there are no changes required.

**Last words**
This issue must have existed for several years now. It probably caused a lot of headaches and definitely ruined the experience for many players, especially if you have build a lot of machines or other stuff close together. So I really hope this improves our modding situation. It affects the server in the same way as the client, only that it might be worse for the server (more loaded tileentities).

I'm looking forward to smoother gameplay and hope this PR will be merged soon. Once that is done I will create another one for 1.11.2.

**UPDATE**
All the indexed methods have been implemented. There are bad at performance, but the game will no longer crash of a mod is using them (like Embers).

In Regards
CreativeMD