### PR TITLE
Fixed swapping of finite fluids with negative densities.

### DIFF
--- a/src/main/java/net/minecraftforge/fluids/BlockFluidFinite.java
+++ b/src/main/java/net/minecraftforge/fluids/BlockFluidFinite.java
@@ -233,9 +233,9 @@ public class BlockFluidFinite extends BlockFluidBase
                 {
                     IBlockState state = world.getBlockState(other);
                     world.setBlockState(other, myState.withProperty(LEVEL, amtToInput - 1), 3);
-                    world.setBlockState(other, state, 3);
+                    world.setBlockState(pos, state, 3);
                     world.scheduleUpdate(other, this,  tickRate);
-                    world.scheduleUpdate(other, state.getBlock(), state.getBlock().tickRate(world));
+                    world.scheduleUpdate(pos, state.getBlock(), state.getBlock().tickRate(world));
                     return 0;
                 }
             }


### PR DESCRIPTION
Fixes when two fluids with negative densities touch vertically, allowing the lower density one to pass though the higher one. The old code swapped the fluid block on top with its self duplicating the block.