### PR TITLE
Add MD5 checksums and certificate fingerprints to crash reports

### DIFF
--- a/src/main/java/net/minecraftforge/fml/common/LoadController.java
+++ b/src/main/java/net/minecraftforge/fml/common/LoadController.java
@@ -19,6 +19,8 @@
 
 package net.minecraftforge.fml.common;
 
+import java.io.FileInputStream;
+import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
 import java.util.Collection;
 import java.util.HashMap;
@@ -37,6 +39,7 @@ import net.minecraftforge.fml.common.event.FMLPreInitializationEvent;
 import net.minecraftforge.fml.common.event.FMLStateEvent;
 import net.minecraftforge.fml.common.versioning.ArtifactVersion;
 
+import org.apache.commons.codec.digest.DigestUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.ThreadContext;
 
@@ -317,6 +320,34 @@ public class LoadController
                 ret.append(state.getMarker());
 
             ret.append("\t").append(mc.getModId()).append("{").append(mc.getVersion()).append("} [").append(mc.getName()).append("] (").append(mc.getSource().getName()).append(") ");
+
+            boolean needsParens = false;
+            try (FileInputStream input = new FileInputStream(mc.getSource()))
+            {
+                ret.append("(MD5 Checksum: ").append(DigestUtils.md5Hex(input));
+                needsParens = true;
+            }
+            catch (IOException e)
+            {
+                if (mc.getSource().isFile())
+                {
+                    ret.append("(Failed to compute checksum");
+                    needsParens = true;
+                }
+            }
+            if (mc.getSigningCertificate() != null)
+            {
+                if (needsParens)
+                {
+                    ret.append(", ");
+                }
+                ret.append("Certificate fingerprint: ").append(CertificateHelper.getFingerprint(mc.getSigningCertificate()));
+                needsParens = true;
+            }
+            if (needsParens)
+            {
+                ret.append(") ");
+            }
         }
     }
 

--- a/src/main/java/net/minecraftforge/fml/common/LoadController.java
+++ b/src/main/java/net/minecraftforge/fml/common/LoadController.java
@@ -319,35 +319,35 @@ public class LoadController
             for (ModState state : modStates.get(mc.getModId()))
                 ret.append(state.getMarker());
 
-            ret.append("\t").append(mc.getModId()).append("{").append(mc.getVersion()).append("} [").append(mc.getName()).append("] (").append(mc.getSource().getName()).append(") ");
+            ret.append("\t").append(mc.getModId()).append("{").append(mc.getVersion()).append("} [").append(mc.getName()).append("] (").append(mc.getSource().getName());
 
-            boolean needsParens = false;
+            boolean checksumMessage = false;
             try (FileInputStream input = new FileInputStream(mc.getSource()))
             {
-                ret.append("(MD5 Checksum: ").append(DigestUtils.md5Hex(input));
-                needsParens = true;
+                ret.append(" - MD5 Checksum: ").append(DigestUtils.md5Hex(input));
+                checksumMessage = true;
             }
             catch (IOException e)
             {
                 if (mc.getSource().isFile())
                 {
-                    ret.append("(Failed to compute checksum");
-                    needsParens = true;
+                    ret.append(" - Failed to compute checksum: ").append(e.getMessage());
+                    checksumMessage = true;
                 }
             }
             if (mc.getSigningCertificate() != null)
             {
-                if (needsParens)
+                if (checksumMessage)
                 {
                     ret.append(", ");
                 }
+                else
+                {
+                    ret.append(" - ");
+                }
                 ret.append("Certificate fingerprint: ").append(CertificateHelper.getFingerprint(mc.getSigningCertificate()));
-                needsParens = true;
             }
-            if (needsParens)
-            {
-                ret.append(") ");
-            }
+            ret.append(") ");
         }
     }
 


### PR DESCRIPTION
*Ignore this description, I've opted for a new PR after changing it xD*
There have been cases of mod rehosting sites tampering with mod JARs recently. The changes were causing the game to crash, but the author only found out about the modified files after some troubleshooting with the users. This PR tries to leverage information signing information available about mods and displays it next to the mod file name in crash reports. Although all mods' fingerprints are already written to the log, this information is only available if you get a full log file (i.e. `fml-client/server-latest.log`).
With this PR, a modder can get a basic gist of whether his file has been modified.
Additionally, this PR changes the dumped mod list to be a table instead of a simple list. The generated output can be interpreted as markdown and will yield nice results. If there's no mod with a signature, the column is dropped. If I can gather information about invalid signatures easily, I'll add it to the table under the signature column.