### PR TITLE
Block::addRunningEffects Closes #4246

### DIFF
--- a/patches/minecraft/net/minecraft/block/Block.java.patch
+++ b/patches/minecraft/net/minecraft/block/Block.java.patch
@@ -227,7 +227,7 @@
      public SoundType func_185467_w()
      {
          return this.field_149762_H;
-@@ -936,6 +951,1255 @@
+@@ -936,6 +951,1273 @@
      {
      }
  
@@ -861,6 +861,24 @@
 +    }
 +
 +    /**
++     * Allows a block to override the standard vanilla running particles.
++     * This is called from {@link Entity#spawnRunningParticles} and is called both,
++     * Client and server side, it's up to the implementor to client check / server check.
++     * By default vanilla spawns particles only on the client and the server methods no-op.
++     * Rabbits on the other hand only call this on the client side.
++     *
++     * @param state  The BlockState the entity is running on.
++     * @param world  The world.
++     * @param pos    The position at the entities feet.
++     * @param entity The entity running on the block.
++     * @return True to prevent vanilla running particles from spawning.
++     */
++    public boolean addRunningEffects(IBlockState state, World world, BlockPos pos, Entity entity)
++    {
++        return false;
++    }
++
++    /**
 +     * Spawn a digging particle effect in the world, this is a wrapper
 +     * around EffectRenderer.addBlockHitEffects to allow the block more
 +     * control over the particles. Useful when you have entirely different
@@ -1483,7 +1501,7 @@
      public static void func_149671_p()
      {
          func_176215_a(0, field_176230_a, (new BlockAir()).func_149663_c("air"));
-@@ -1247,14 +2511,7 @@
+@@ -1247,14 +2529,7 @@
              }
              else
              {

--- a/patches/minecraft/net/minecraft/entity/Entity.java.patch
+++ b/patches/minecraft/net/minecraft/entity/Entity.java.patch
@@ -55,7 +55,15 @@
  
          if (this.field_70170_p.func_180495_p(p_180429_1_.func_177984_a()).func_177230_c() == Blocks.field_150431_aC)
          {
-@@ -1277,12 +1289,12 @@
+@@ -1259,6 +1271,7 @@
+         BlockPos blockpos = new BlockPos(i, j, k);
+         IBlockState iblockstate = this.field_70170_p.func_180495_p(blockpos);
+ 
++        if(!iblockstate.func_177230_c().addRunningEffects(iblockstate, field_70170_p, blockpos, this))
+         if (iblockstate.func_185901_i() != EnumBlockRenderType.INVISIBLE)
+         {
+             this.field_70170_p.func_175688_a(EnumParticleTypes.BLOCK_CRACK, this.field_70165_t + ((double)this.field_70146_Z.nextFloat() - 0.5D) * (double)this.field_70130_N, this.func_174813_aQ().field_72338_b + 0.1D, this.field_70161_v + ((double)this.field_70146_Z.nextFloat() - 0.5D) * (double)this.field_70130_N, -this.field_70159_w * 4.0D, 1.5D, -this.field_70179_y * 4.0D, Block.func_176210_f(iblockstate));
+@@ -1277,12 +1290,12 @@
              BlockPos blockpos = new BlockPos(this.field_70165_t, d0, this.field_70161_v);
              IBlockState iblockstate = this.field_70170_p.func_180495_p(blockpos);
  
@@ -72,7 +80,7 @@
              }
              else
              {
-@@ -1707,6 +1719,7 @@
+@@ -1707,6 +1720,7 @@
              {
                  p_189511_1_.func_74757_a("Glowing", this.field_184238_ar);
              }
@@ -80,7 +88,7 @@
  
              if (!this.field_184236_aF.isEmpty())
              {
-@@ -1720,6 +1733,9 @@
+@@ -1720,6 +1734,9 @@
                  p_189511_1_.func_74782_a("Tags", nbttaglist);
              }
  
@@ -90,7 +98,7 @@
              this.func_70014_b(p_189511_1_);
  
              if (this.func_184207_aI())
-@@ -1826,7 +1842,11 @@
+@@ -1826,7 +1843,11 @@
              this.func_174810_b(p_70020_1_.func_74767_n("Silent"));
              this.func_189654_d(p_70020_1_.func_74767_n("NoGravity"));
              this.func_184195_f(p_70020_1_.func_74767_n("Glowing"));
@@ -102,7 +110,7 @@
              if (p_70020_1_.func_150297_b("Tags", 9))
              {
                  this.field_184236_aF.clear();
-@@ -1918,7 +1938,10 @@
+@@ -1918,7 +1939,10 @@
          {
              EntityItem entityitem = new EntityItem(this.field_70170_p, this.field_70165_t, this.field_70163_u + (double)p_70099_2_, this.field_70161_v, p_70099_1_);
              entityitem.func_174869_p();
@@ -114,7 +122,7 @@
              return entityitem;
          }
      }
-@@ -1985,6 +2008,7 @@
+@@ -1985,6 +2009,7 @@
              this.field_70159_w = 0.0D;
              this.field_70181_x = 0.0D;
              this.field_70179_y = 0.0D;
@@ -122,7 +130,7 @@
              this.func_70071_h_();
  
              if (this.func_184218_aH())
-@@ -2032,6 +2056,7 @@
+@@ -2032,6 +2057,7 @@
              }
          }
  
@@ -130,7 +138,7 @@
          if (p_184205_2_ || this.func_184228_n(p_184205_1_) && p_184205_1_.func_184219_q(this))
          {
              if (this.func_184218_aH())
-@@ -2067,6 +2092,7 @@
+@@ -2067,6 +2093,7 @@
          if (this.field_184239_as != null)
          {
              Entity entity = this.field_184239_as;
@@ -138,7 +146,7 @@
              this.field_184239_as = null;
              entity.func_184225_p(this);
          }
-@@ -2511,6 +2537,7 @@
+@@ -2511,6 +2538,7 @@
      {
          if (!this.field_70170_p.field_72995_K && !this.field_70128_L)
          {
@@ -146,7 +154,7 @@
              this.field_70170_p.field_72984_F.func_76320_a("changeDimension");
              MinecraftServer minecraftserver = this.func_184102_h();
              int i = this.field_71093_bK;
-@@ -2604,7 +2631,7 @@
+@@ -2604,7 +2632,7 @@
  
      public float func_180428_a(Explosion p_180428_1_, World p_180428_2_, BlockPos p_180428_3_, IBlockState p_180428_4_)
      {
@@ -155,7 +163,7 @@
      }
  
      public boolean func_174816_a(Explosion p_174816_1_, World p_174816_2_, BlockPos p_174816_3_, IBlockState p_174816_4_, float p_174816_5_)
-@@ -2901,6 +2928,184 @@
+@@ -2901,6 +2929,184 @@
          EnchantmentHelper.func_151385_b(p_174815_1_, p_174815_2_);
      }
  


### PR DESCRIPTION
Simple hook that allows blocks to customize running particles, be that with a completely different type of particle, or via some custom particle pipeline.