### PR TITLE
[1.12] Added sneak right click placement of milk to milk bucket.

### DIFF
--- a/patches/minecraft/net/minecraft/item/ItemBucketMilk.java.patch
+++ b/patches/minecraft/net/minecraft/item/ItemBucketMilk.java.patch
@@ -20,7 +20,7 @@
          return p_77654_1_.func_190926_b() ? new ItemStack(Items.field_151133_ar) : p_77654_1_;
      }
  
-@@ -52,6 +48,11 @@
+@@ -52,8 +48,17 @@
          return EnumAction.DRINK;
      }
  
@@ -31,4 +31,10 @@
 +
      public ActionResult<ItemStack> func_77659_a(World p_77659_1_, EntityPlayer p_77659_2_, EnumHand p_77659_3_)
      {
++        if (p_77659_2_.func_70093_af()) {
++            ActionResult<ItemStack> ret = net.minecraftforge.common.ForgeHooks.placeMilkBucket(p_77659_1_, p_77659_2_, p_77659_3_, this.func_77621_a(p_77659_1_, p_77659_2_, false));
++            if (ret != null) return ret;
++        }
          p_77659_2_.func_184598_c(p_77659_3_);
+         return new ActionResult<ItemStack>(EnumActionResult.SUCCESS, p_77659_2_.func_184586_b(p_77659_3_));
+     }

--- a/src/main/java/net/minecraftforge/common/ForgeHooks.java
+++ b/src/main/java/net/minecraftforge/common/ForgeHooks.java
@@ -43,6 +43,7 @@ import com.google.gson.JsonParseException;
 
 import net.minecraft.advancements.Advancement;
 import net.minecraft.advancements.AdvancementManager;
+import net.minecraft.advancements.CriteriaTriggers;
 import net.minecraft.block.Block;
 import net.minecraft.block.BlockLiquid;
 import net.minecraft.block.material.Material;
@@ -75,6 +76,7 @@ import net.minecraft.network.play.server.SPacketBlockChange;
 import net.minecraft.stats.StatList;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.tileentity.TileEntityNote;
+import net.minecraft.util.ActionResult;
 import net.minecraft.util.DamageSource;
 import net.minecraft.util.EnumActionResult;
 import net.minecraft.util.EnumFacing;
@@ -124,6 +126,10 @@ import net.minecraftforge.event.entity.player.PlayerEvent;
 import net.minecraftforge.event.entity.player.PlayerInteractEvent;
 import net.minecraftforge.event.world.BlockEvent;
 import net.minecraftforge.event.world.NoteBlockEvent;
+import net.minecraftforge.fluids.Fluid;
+import net.minecraftforge.fluids.FluidRegistry;
+import net.minecraftforge.fluids.FluidStack;
+import net.minecraftforge.fluids.FluidUtil;
 import net.minecraftforge.fluids.IFluidBlock;
 import net.minecraftforge.fml.common.FMLLog;
 import net.minecraftforge.fml.common.Loader;
@@ -1308,5 +1314,57 @@ public class ForgeHooks
             },
             true
         );
+    }
+
+    public static ActionResult<ItemStack> placeMilkBucket(World world, EntityPlayer player, EnumHand hand, RayTraceResult rayTraceResult)
+    {
+        if (FluidRegistry.isFluidRegistered("milk") && FluidRegistry.getFluid("milk").canBePlacedInWorld())
+        {
+            ItemStack itemstack = player.getHeldItem(hand);
+
+            if (rayTraceResult == null)
+            {
+                return new ActionResult<ItemStack>(EnumActionResult.PASS, itemstack);
+            }
+            else if (rayTraceResult.typeOfHit != RayTraceResult.Type.BLOCK)
+            {
+                return new ActionResult<ItemStack>(EnumActionResult.PASS, itemstack);
+            }
+            else
+            {
+                BlockPos blockpos = rayTraceResult.getBlockPos();
+
+                if (!world.isBlockModifiable(player, blockpos))
+                {
+                    return new ActionResult<ItemStack>(EnumActionResult.FAIL, itemstack);
+                }
+                else
+                {
+                    boolean flag1 = world.getBlockState(blockpos).getBlock().isReplaceable(world, blockpos);
+                    BlockPos blockpos1 = flag1 && rayTraceResult.sideHit == EnumFacing.UP ? blockpos : blockpos.offset(rayTraceResult.sideHit);
+
+                    if (!player.canPlayerEdit(blockpos1, rayTraceResult.sideHit, itemstack))
+                    {
+                        return new ActionResult<ItemStack>(EnumActionResult.FAIL, itemstack);
+                    }
+                    else if (FluidUtil.tryPlaceFluid(player, world, blockpos1, itemstack, new FluidStack(FluidRegistry.getFluid("milk"), Fluid.BUCKET_VOLUME)).isSuccess())
+                    {
+                        if (player instanceof EntityPlayerMP)
+                        {
+                            CriteriaTriggers.PLACED_BLOCK.trigger((EntityPlayerMP)player, blockpos1, itemstack);
+                        }
+
+                        player.addStat(StatList.getObjectUseStats(Items.MILK_BUCKET));
+                        return !player.capabilities.isCreativeMode ? new ActionResult(EnumActionResult.SUCCESS, new ItemStack(Items.BUCKET)) : new ActionResult(EnumActionResult.SUCCESS, itemstack);
+                    }
+                    else
+                    {
+                        return new ActionResult<ItemStack>(EnumActionResult.FAIL, itemstack);
+                    }
+                }
+            }
+        }
+
+        return null;
     }
 }


### PR DESCRIPTION
As the name states this adds shift right click placement of place-able milk fluid to milk bucket. The fluid and its block variant needs to be added by mods (as well as they need to enable universal bucket if they want to be able to pick it back up), but this takes care of the need to add custom milk buckets in mods if those want buckets to be able to place milk in world.