### PR TITLE
[1.11] Added sneak right click placement of milk fluid to milk bucket

### DIFF
--- a/patches/minecraft/net/minecraft/item/ItemBucketMilk.java.patch
+++ b/patches/minecraft/net/minecraft/item/ItemBucketMilk.java.patch
@@ -14,7 +14,14 @@
          if (!p_77654_2_.field_72995_K)
          {
              p_77654_3_.func_70674_bp();
-@@ -53,4 +55,9 @@
+@@ -50,7 +52,16 @@
+ 
+     public ActionResult<ItemStack> func_77659_a(World p_77659_1_, EntityPlayer p_77659_2_, EnumHand p_77659_3_)
+     {
++        if (p_77659_2_.func_70093_af()) {
++            ActionResult<ItemStack> ret = net.minecraftforge.common.ForgeHooks.placeMilkBucket(p_77659_1_, p_77659_2_, p_77659_3_, this.func_77621_a(p_77659_1_, p_77659_2_, false));
++            if (ret != null) return ret;
++        }
          p_77659_2_.func_184598_c(p_77659_3_);
          return new ActionResult(EnumActionResult.SUCCESS, p_77659_2_.func_184586_b(p_77659_3_));
      }


### PR DESCRIPTION
As the name states this adds shift right click placement of place-able milk fluid to milk bucket. The fluid and its block variant needs to be added by mods (as well as they need to enable universal bucket if they want to be able to pick it back up), but this takes care of the need to add custom milk buckets in mods if those want buckets to be able to place milk in world.

This is 1.11 version of #4249