### PR TITLE
Tabulate crash report mod list and add signature information

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ install:
   - ./gradlew --refresh-dependencies
   - ./gradlew ciWriteBuildNumber
 script:
-  - travis_wait 30 ./gradlew build -x createExe -S
+  - travis_wait ./gradlew build -x createExe -S
   - ./gradlew -p projects/Forge test -S -i
 
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ install:
   - ./gradlew --refresh-dependencies
   - ./gradlew ciWriteBuildNumber
 script:
-  - travis_wait ./gradlew build -x createExe -S
+  - travis_wait 30 ./gradlew build -x createExe -S
   - ./gradlew -p projects/Forge test -S -i
 
 notifications:

--- a/src/main/java/net/minecraftforge/common/ForgeModContainer.java
+++ b/src/main/java/net/minecraftforge/common/ForgeModContainer.java
@@ -400,6 +400,11 @@ public class ForgeModContainer extends DummyModContainer implements WorldAccessC
             all.add(asm.getClassName());
         for (ASMData asm : evt.getASMHarvestedData().getAll(ICrashCallable.class.getName().replace('.', '/')))
             all.add(asm.getClassName());
+        // Add table classes for mod list tabulation
+        all.add("net/minecraftforge/common/util/TextTable");
+        all.add("net/minecraftforge/common/util/TextTable$Column");
+        all.add("net/minecraftforge/common/util/TextTable$Row");
+        all.add("net/minecraftforge/common/util/TextTable$Alignment");
 
         all.removeIf(cls -> !cls.startsWith("net/minecraft/") && !cls.startsWith("net/minecraftforge/"));
 

--- a/src/main/java/net/minecraftforge/common/util/TextTable.java
+++ b/src/main/java/net/minecraftforge/common/util/TextTable.java
@@ -1,0 +1,220 @@
+/*
+ * Minecraft Forge
+ * Copyright (c) 2016.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation version 2.1
+ * of the License.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+package net.minecraftforge.common.util;
+
+import com.google.common.collect.Streams;
+import org.apache.commons.lang3.StringUtils;
+
+import javax.annotation.Nonnull;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+/**
+ * Utility to format data into a textual (markdown-compliant) table.
+ */
+public class TextTable
+{
+    public static Column column(String header)
+    {
+        return new Column(header);
+    }
+
+    public static Column column(String header, Alignment alignment)
+    {
+        return new Column(header, alignment);
+    }
+
+    private final List<Column> columns;
+    private final List<Row> rows = new ArrayList<>();
+
+    public TextTable(List<Column> columns)
+    {
+        this.columns = columns;
+    }
+
+    public String build(String lineEnding)
+    {
+        StringBuilder destination = new StringBuilder();
+        append(destination, lineEnding);
+        return destination.toString();
+    }
+
+    /**
+     * Appends the data formatted as a table to the given string builder.
+     * The padding character used for the column alignments is a single space (' '),
+     * the separate between column headers and values is a dash ('-').
+     * Note that you *have* to specify a line ending, '\n' isn't used by default.
+     * <p>
+     * The generated table is compliant with the markdown file format.
+     *
+     * @param destination a string builder to append the table to
+     * @param lineEnding  the line ending to use for each row of the table
+     */
+    public void append(StringBuilder destination, String lineEnding)
+    {
+        List<String> headers = columns.stream().map(c -> c.formatHeader(" ")).collect(Collectors.toList());
+        printRow(destination, headers);
+        destination.append(lineEnding);
+        printSeparators(destination);
+        for (Row row : rows)
+        {
+            destination.append(lineEnding);
+            printRow(destination, row.format(columns, " "));
+        }
+    }
+
+    private void printSeparators(StringBuilder destination)
+    {
+        destination.append('|');
+        for (Column column : columns)
+        {
+            destination.append(column.alignment != Alignment.RIGHT ? ':' : ' ');
+            destination.append(column.getSeparator('-'));
+            destination.append(column.alignment != Alignment.LEFT ? ':' : ' ');
+            destination.append('|');
+        }
+    }
+
+    private void printRow(StringBuilder destination, List<String> values)
+    {
+        destination.append('|');
+        for (String value : values)
+        {
+            destination.append(' ');
+            destination.append(value);
+            destination.append(' ');
+            destination.append('|');
+        }
+    }
+
+    public void add(@Nonnull Object... values)
+    {
+        if (values.length != columns.size())
+        {
+            throw new IllegalArgumentException("Received wrong amount of values for table row, expected " + columns.size() + ", received " + columns.size() + ".");
+        }
+        Row row = new Row();
+        for (int i = 0; i < values.length; i++)
+        {
+            String value = Objects.toString(values[i]);
+            row.values.add(value);
+            columns.get(i).fit(value);
+        }
+        rows.add(row);
+    }
+
+    public void clear()
+    {
+        for (Column column : columns)
+        {
+            column.resetWidth();
+        }
+        rows.clear();
+    }
+
+    public List<Column> getColumns()
+    {
+        return Collections.unmodifiableList(columns);
+    }
+
+    public static class Column
+    {
+        private String header;
+        private int width;
+        private Alignment alignment;
+
+        public Column(String header)
+        {
+            this(header, Alignment.LEFT);
+        }
+
+        public Column(String header, Alignment alignment)
+        {
+            this.header = header;
+            this.width = header.length();
+            this.alignment = alignment;
+        }
+
+        public String formatHeader(String padding)
+        {
+            return format(header, padding);
+        }
+
+        public String format(String value, String padding)
+        {
+            switch (alignment)
+            {
+                case LEFT:
+                    return StringUtils.rightPad(value, width, padding);
+                case RIGHT:
+                    return StringUtils.leftPad(value, width, padding);
+                default:
+                    int length = value.length();
+                    int left = (width - length) / 2;
+                    int leftWidth = left + length;
+                    return StringUtils.rightPad(StringUtils.leftPad(value, leftWidth, padding), width, padding);
+            }
+        }
+
+        public String getSeparator(char character)
+        {
+            return StringUtils.leftPad("", width, character);
+        }
+
+        public void fit(String value)
+        {
+            if (value.length() > width)
+            {
+                width = value.length();
+            }
+        }
+
+        public void resetWidth()
+        {
+            this.width = header.length();
+        }
+
+        public int getWidth()
+        {
+            return width;
+        }
+    }
+
+    public static class Row
+    {
+        private final ArrayList<String> values = new ArrayList<>();
+
+        public List<String> format(List<Column> columns, String padding)
+        {
+            if (columns.size() != values.size())
+            {
+                throw new IllegalArgumentException("Received wrong amount of columns for table row, expected " + columns.size() + ", received " + columns.size() + ".");
+            }
+            return Streams.zip(values.stream(), columns.stream(), (v, c) -> c.format(v, padding)).collect(Collectors.toList());
+        }
+    }
+
+    public enum Alignment
+    {
+        LEFT, CENTER, RIGHT
+    }
+}

--- a/src/main/java/net/minecraftforge/fml/common/LoadController.java
+++ b/src/main/java/net/minecraftforge/fml/common/LoadController.java
@@ -420,27 +420,4 @@ public class LoadController
     {
         return state;
     }
-
-    private static class ModStateData
-    {
-        private String state;
-        private String id;
-        private String version;
-        private String source;
-        private String signature;
-
-        private ModStateData(String state, String id, String version, String source, String signature)
-        {
-            this.state = state;
-            this.id = id;
-            this.version = version;
-            this.source = source;
-            this.signature = signature;
-        }
-
-        private String format(String format)
-        {
-            return String.format(format, state, id, version, source, signature);
-        }
-    }
 }

--- a/src/main/java/net/minecraftforge/fml/common/LoadController.java
+++ b/src/main/java/net/minecraftforge/fml/common/LoadController.java
@@ -341,11 +341,11 @@ public class LoadController
 
         ModData header = new ModData("State", "ID", "Version", "Source", "Signature");
         ModData widths = data.stream().reduce(header, (acc, m) -> new ModData(
-            acc.state.length() > m.state.length() ? acc.state : m.state,
-            acc.id.length() > m.id.length() ? acc.id : m.id,
-            acc.version.length() > m.version.length() ? acc.version : m.version,
-            acc.source.length() > m.source.length() ? acc.source : m.source,
-            acc.signature.length() > m.signature.length() ? acc.signature : m.signature
+            m.state.length() > acc.state.length() ? m.state : acc.state,
+            m.id.length() > acc.id.length() ? m.id : acc.id,
+            m.version.length() > acc.version.length() ? m.version : acc.version,
+            m.source.length() > acc.source.length() ? m.source : acc.source,
+            m.signature.length() > acc.signature.length() ? m.signature : acc.signature
         ));
 
         String baseFormat = "| %%-%ds | %%-%ds | %%-%ds | %%-%ds |";
@@ -357,7 +357,8 @@ public class LoadController
             widths.state.length(),
             widths.id.length(),
             widths.version.length(),
-            widths.source.length());
+            widths.source.length(),
+            widths.signature.length());
         String separator = String.format(format,
             StringUtils.leftPad("", widths.state.length(), '-'),
             StringUtils.leftPad("", widths.state.length(), '-'),

--- a/src/main/java/net/minecraftforge/fml/common/LoadController.java
+++ b/src/main/java/net/minecraftforge/fml/common/LoadController.java
@@ -19,8 +19,6 @@
 
 package net.minecraftforge.fml.common;
 
-import java.io.FileInputStream;
-import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
 import java.util.Collection;
 import java.util.HashMap;
@@ -313,30 +311,7 @@ public class LoadController
         for (ModState state : ModState.values())
             ret.append(" '").append(state.getMarker()).append("' = ").append(state.toString());
 
-        class ModData
-        {
-            private String state;
-            private String id;
-            private String version;
-            private String source;
-            private String signature;
-
-            private ModData(String state, String id, String version, String source, String signature)
-            {
-                this.state = state;
-                this.id = id;
-                this.version = version;
-                this.source = source;
-                this.signature = signature;
-            }
-
-            private String format(String format)
-            {
-                return String.format(format, state, id, version, source, signature);
-            }
-        }
-
-        List<ModData> data = loader.getModList().stream().map(mc -> new ModData(
+        List<ModStateData> data = loader.getModList().stream().map(mc -> new ModStateData(
             modStates.get(mc.getModId()).stream().map(ModState::getMarker).reduce("", (a, b) -> a + b),
             mc.getModId(),
             mc.getVersion(),
@@ -344,8 +319,8 @@ public class LoadController
             mc.getSigningCertificate() != null ? CertificateHelper.getFingerprint(mc.getSigningCertificate()) : "None"
         )).collect(Collectors.toList());
 
-        ModData header = new ModData("State", "ID", "Version", "Source", "Signature");
-        ModData widths = data.stream().reduce(header, (acc, m) -> new ModData(
+        ModStateData header = new ModStateData("State", "ID", "Version", "Source", "Signature");
+        ModStateData widths = data.stream().reduce(header, (acc, m) -> new ModStateData(
             m.state.length() > acc.state.length() ? m.state : acc.state,
             m.id.length() > acc.id.length() ? m.id : acc.id,
             m.version.length() > acc.version.length() ? m.version : acc.version,
@@ -375,7 +350,7 @@ public class LoadController
         ret.append(header.format(format));
         ret.append("\n\t");
         ret.append(separator);
-        for (ModData mod : data)
+        for (ModStateData mod : data)
         {
             ret.append("\n\t");
             ret.append(mod.format(format));
@@ -467,5 +442,28 @@ public class LoadController
     LoaderState getState()
     {
         return state;
+    }
+
+    private static class ModStateData
+    {
+        private String state;
+        private String id;
+        private String version;
+        private String source;
+        private String signature;
+
+        private ModStateData(String state, String id, String version, String source, String signature)
+        {
+            this.state = state;
+            this.id = id;
+            this.version = version;
+            this.source = source;
+            this.signature = signature;
+        }
+
+        private String format(String format)
+        {
+            return String.format(format, state, id, version, source, signature);
+        }
     }
 }

--- a/src/main/java/net/minecraftforge/fml/common/LoadController.java
+++ b/src/main/java/net/minecraftforge/fml/common/LoadController.java
@@ -19,6 +19,8 @@
 
 package net.minecraftforge.fml.common;
 
+import java.io.FileInputStream;
+import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
 import java.util.Collection;
 import java.util.HashMap;
@@ -37,6 +39,7 @@ import net.minecraftforge.fml.common.event.FMLPreInitializationEvent;
 import net.minecraftforge.fml.common.event.FMLStateEvent;
 import net.minecraftforge.fml.common.versioning.ArtifactVersion;
 
+import org.apache.commons.codec.digest.DigestUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.ThreadContext;
 
@@ -317,6 +320,34 @@ public class LoadController
                 ret.append(state.getMarker());
 
             ret.append("\t").append(mc.getModId()).append("{").append(mc.getVersion()).append("} [").append(mc.getName()).append("] (").append(mc.getSource().getName()).append(") ");
+
+            boolean needsParens = false;
+            try (FileInputStream input = new FileInputStream(mc.getSource()))
+            {
+                ret.append("(MD5 Checksum: ").append(DigestUtils.md5Hex(input));
+                needsParens = true;
+            }
+            catch (IOException e)
+            {
+                if (mc.getSource().isFile())
+                {
+                    ret.append("(Failed to compute checksum");
+                    needsParens = true;
+                }
+            }
+            if (mc.getSigningCertificate() != null)
+            {
+                if (needsParens)
+                {
+                    ret.append(", ");
+                }
+                ret.append("Certificate fingerprint: ").append(CertificateHelper.getFingerprint(mc.getSigningCertificate()));
+                needsParens = true;
+            }
+            if (needsParens)
+            {
+                ret.append(") ");
+            }
         }
     }
 

--- a/src/main/java/net/minecraftforge/fml/common/LoadController.java
+++ b/src/main/java/net/minecraftforge/fml/common/LoadController.java
@@ -361,7 +361,7 @@ public class LoadController
             widths.signature.length());
         String separator = String.format(format,
             StringUtils.leftPad("", widths.state.length(), '-'),
-            StringUtils.leftPad("", widths.state.length(), '-'),
+            StringUtils.leftPad("", widths.id.length(), '-'),
             StringUtils.leftPad("", widths.version.length(), '-'),
             StringUtils.leftPad("", widths.source.length(), '-'),
             StringUtils.leftPad("", widths.signature.length(), '-'));

--- a/src/main/java/net/minecraftforge/fml/common/LoadController.java
+++ b/src/main/java/net/minecraftforge/fml/common/LoadController.java
@@ -319,35 +319,35 @@ public class LoadController
             for (ModState state : modStates.get(mc.getModId()))
                 ret.append(state.getMarker());
 
-            ret.append("\t").append(mc.getModId()).append("{").append(mc.getVersion()).append("} [").append(mc.getName()).append("] (").append(mc.getSource().getName()).append(") ");
+            ret.append("\t").append(mc.getModId()).append("{").append(mc.getVersion()).append("} [").append(mc.getName()).append("] (").append(mc.getSource().getName());
 
-            boolean needsParens = false;
+            boolean checksumMessage = false;
             try (FileInputStream input = new FileInputStream(mc.getSource()))
             {
-                ret.append("(MD5 Checksum: ").append(DigestUtils.md5Hex(input));
-                needsParens = true;
+                ret.append(" - MD5 Checksum: ").append(DigestUtils.md5Hex(input));
+                checksumMessage = true;
             }
             catch (IOException e)
             {
                 if (mc.getSource().isFile())
                 {
-                    ret.append("(Failed to compute checksum");
-                    needsParens = true;
+                    ret.append(" - Failed to compute checksum: ").append(e.getMessage());
+                    checksumMessage = true;
                 }
             }
             if (mc.getSigningCertificate() != null)
             {
-                if (needsParens)
+                if (checksumMessage)
                 {
                     ret.append(", ");
                 }
+                else
+                {
+                    ret.append(" - ");
+                }
                 ret.append("Certificate fingerprint: ").append(CertificateHelper.getFingerprint(mc.getSigningCertificate()));
-                needsParens = true;
             }
-            if (needsParens)
-            {
-                ret.append(") ");
-            }
+            ret.append(") ");
         }
     }
 

--- a/src/main/java/net/minecraftforge/fml/common/LoadController.java
+++ b/src/main/java/net/minecraftforge/fml/common/LoadController.java
@@ -19,6 +19,30 @@
 
 package net.minecraftforge.fml.common;
 
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.lang.reflect.InvocationTargetException;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.stream.Collectors;
+
+import net.minecraftforge.fml.common.LoaderState.ModState;
+import net.minecraftforge.fml.common.ProgressManager.ProgressBar;
+import net.minecraftforge.fml.common.event.FMLEvent;
+import net.minecraftforge.fml.common.event.FMLLoadEvent;
+import net.minecraftforge.fml.common.event.FMLModDisabledEvent;
+import net.minecraftforge.fml.common.event.FMLPreInitializationEvent;
+import net.minecraftforge.fml.common.event.FMLStateEvent;
+import net.minecraftforge.fml.common.versioning.ArtifactVersion;
+
+import org.apache.commons.lang3.StringUtils;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.ThreadContext;
+
 import com.google.common.collect.ArrayListMultimap;
 import com.google.common.collect.BiMap;
 import com.google.common.collect.ImmutableBiMap;
@@ -31,29 +55,10 @@ import com.google.common.collect.Maps;
 import com.google.common.collect.Multimap;
 import com.google.common.eventbus.EventBus;
 import com.google.common.eventbus.Subscribe;
-import com.google.common.eventbus.SubscriberExceptionContext;
 import com.google.common.eventbus.SubscriberExceptionHandler;
-import net.minecraftforge.fml.common.LoaderState.ModState;
-import net.minecraftforge.fml.common.ProgressManager.ProgressBar;
-import net.minecraftforge.fml.common.event.FMLEvent;
-import net.minecraftforge.fml.common.event.FMLLoadEvent;
-import net.minecraftforge.fml.common.event.FMLModDisabledEvent;
-import net.minecraftforge.fml.common.event.FMLPreInitializationEvent;
-import net.minecraftforge.fml.common.event.FMLStateEvent;
-import net.minecraftforge.fml.common.versioning.ArtifactVersion;
-import org.apache.commons.lang3.StringUtils;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.ThreadContext;
+import com.google.common.eventbus.SubscriberExceptionContext;
 
 import javax.annotation.Nullable;
-import java.lang.reflect.InvocationTargetException;
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Map.Entry;
-import java.util.stream.Collectors;
 
 public class LoadController
 {

--- a/src/test/java/net/minecraftforge/test/TextTableTest.java
+++ b/src/test/java/net/minecraftforge/test/TextTableTest.java
@@ -1,0 +1,119 @@
+/*
+ * Minecraft Forge
+ * Copyright (c) 2016.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation version 2.1
+ * of the License.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+package net.minecraftforge.test;
+
+import com.google.common.collect.Lists;
+import net.minecraftforge.common.util.TextTable;
+import net.minecraftforge.common.util.TextTable.Column;
+import org.junit.Assert;
+import org.junit.Test;
+
+import static net.minecraftforge.common.util.TextTable.column;
+
+public class TextTableTest
+{
+    private static final String WIDTH_REFERENCE = "StringOfWidth15";
+    private static final int WIDTH_REFERENCE_LENGTH = WIDTH_REFERENCE.length();
+
+    @Test
+    public void testColumnWidthAdjustment()
+    {
+        Column column = column("Column", TextTable.Alignment.LEFT);
+        column.fit(WIDTH_REFERENCE);
+        String paddedHeader = column.formatHeader("-");
+        Assert.assertEquals("Formatted column header didn't have correct length", WIDTH_REFERENCE_LENGTH, paddedHeader.length());
+        Assert.assertEquals("Formatted column header wasn't padded properly", "Column---------", paddedHeader);
+
+        String paddedReference = column.format(WIDTH_REFERENCE, "-");
+        Assert.assertEquals("Formatted width reference didn't have correct length", WIDTH_REFERENCE_LENGTH, paddedReference.length());
+        Assert.assertEquals("Formatted width reference was changed despite defining width", WIDTH_REFERENCE, paddedReference);
+    }
+
+    @Test
+    public void testLeftAlignment()
+    {
+        Column column = column("Left", TextTable.Alignment.LEFT);
+        column.fit(WIDTH_REFERENCE);
+
+        String paddedHeader = column.formatHeader("-");
+        Assert.assertEquals("Left-aligned header should be padded on the right", "Left-----------", paddedHeader);
+        String paddedReference = column.format(WIDTH_REFERENCE, "-");
+        Assert.assertEquals("Left-aligned reference should'nt be padded", WIDTH_REFERENCE, paddedReference);
+        String paddedValue = column.format("Value", "-");
+        Assert.assertEquals("Left-aligned value should be padded on the right", "Value----------", paddedValue);
+    }
+
+    @Test
+    public void testCenterAlignment()
+    {
+        Column column = column("Centered", TextTable.Alignment.CENTER);
+        column.fit(WIDTH_REFERENCE);
+
+        String paddedHeader = column.formatHeader("-");
+        Assert.assertEquals("Centered header should be padded equally on both sides", "---Centered----", paddedHeader);
+        String paddedReference = column.format(WIDTH_REFERENCE, "-");
+        Assert.assertEquals("Centered reference should'nt be padded", WIDTH_REFERENCE, paddedReference);
+        String paddedValue = column.format("Value", "-");
+        Assert.assertEquals("Centered value should be padded equally on both sides", "-----Value-----", paddedValue);
+        String paddedOffCenter = column.format("Value1", "-");
+        Assert.assertNotEquals("Center padding should be left-biased", "-----Value1----", paddedOffCenter);
+    }
+
+    @Test
+    public void testRightAlignment()
+    {
+        Column column = column("Right", TextTable.Alignment.RIGHT);
+        column.fit(WIDTH_REFERENCE);
+
+        String paddedHeader = column.formatHeader("-");
+        Assert.assertEquals("Right-aligned header should be padded on the left", "----------Right", paddedHeader);
+        String paddedReference = column.format(WIDTH_REFERENCE, "-");
+        Assert.assertEquals("Right-aligned reference should'nt be padded", WIDTH_REFERENCE, paddedReference);
+        String paddedValue = column.format("Value", "-");
+        Assert.assertEquals("Right-aligned value should be padded on the left", "----------Value", paddedValue);
+    }
+
+    @Test
+    public void testMarkdownCompliance()
+    {
+        TextTable table = new TextTable(Lists.newArrayList(
+            column("Left", TextTable.Alignment.LEFT),
+            column("Center", TextTable.Alignment.CENTER),
+            column("Right", TextTable.Alignment.RIGHT)
+        ));
+        table.add("Long Value 1", "Value 2", "Value 3");
+        table.add("Value 1", "Long Value 2", "Value 3");
+        table.add("Value 1", "Value 2", "Long Value 3");
+        int[] columnWidths = table.getColumns().stream().mapToInt(Column::getWidth).toArray();
+        Assert.assertArrayEquals("Column widths should adjust for long values", new int[]{12, 12, 12}, columnWidths);
+
+        String[] result = table.build("\n").split("\n");
+        Assert.assertEquals("Header row + separator row + value rows should result in 5 lines", 5, result.length);
+        Assert.assertEquals(
+            "Column headers should be properly formatted",
+            "| Left         |    Center    |        Right |",
+            result[0]);
+        Assert.assertEquals(
+            "Header-body separators should contain markdown alignment information",
+            "|:------------ |:------------:| ------------:|",
+            result[1]
+        );
+    }
+}


### PR DESCRIPTION
*Note: This is an updated version of #4244. I opted for a new PR since it is quite different in scope.*
There have been cases of mod rehosting sites tampering with mod JARs recently. The changes were causing the game to crash, but the author only found out about the modified files after some troubleshooting with the users. This PR tries to leverage information signing information available about mods and displays it next to the mod file name in crash reports. Although all mods' fingerprints are already written to the log, this information is only available if you get a full log file (i.e. `fml-client/server-latest.log`).
With this PR, a modder can get a basic gist of whether his file has been modified.
Additionally, this PR changes the dumped mod list to be a table instead of a simple list. The generated output can be interpreted as markdown and will yield nice results. If there's no mod with a signature, the column is dropped. If I can gather information about invalid signatures easily, I'll add it to the table under the signature column.
An example of the output can be found in [this gist](https://gist.github.com/PaleoCrafter/ff31c0fc3249ac9b64b219b6ed46bdd4).