### PR TITLE
[1.12] Check both hands for sneak interaction bypass

### DIFF
--- a/patches/minecraft/net/minecraft/client/multiplayer/PlayerControllerMP.java.patch
+++ b/patches/minecraft/net/minecraft/client/multiplayer/PlayerControllerMP.java.patch
@@ -129,7 +129,7 @@
 +                }
 +
                  IBlockState iblockstate = p_187099_2_.func_180495_p(p_187099_3_);
-+                boolean bypass = p_187099_1_.func_184614_ca().func_190926_b() && p_187099_1_.func_184592_cb().func_190926_b() || itemstack.func_77973_b().doesSneakBypassUse(itemstack, p_187099_2_, p_187099_3_, p_187099_1_);
++                boolean bypass = p_187099_1_.func_184614_ca().doesSneakBypassUse(p_187099_2_, p_187099_3_, p_187099_1_) && p_187099_1_.func_184592_cb().doesSneakBypassUse(p_187099_2_, p_187099_3_, p_187099_1_);
  
 -                if ((!p_187099_1_.func_70093_af() || p_187099_1_.func_184614_ca().func_190926_b() && p_187099_1_.func_184592_cb().func_190926_b()) && iblockstate.func_177230_c().func_180639_a(p_187099_2_, p_187099_3_, iblockstate, p_187099_1_, p_187099_6_, p_187099_4_, f, f1, f2))
 +                if ((!p_187099_1_.func_70093_af() || bypass || event.getUseBlock() == net.minecraftforge.fml.common.eventhandler.Event.Result.ALLOW))

--- a/patches/minecraft/net/minecraft/client/multiplayer/PlayerControllerMP.java.patch
+++ b/patches/minecraft/net/minecraft/client/multiplayer/PlayerControllerMP.java.patch
@@ -129,7 +129,7 @@
 +                }
 +
                  IBlockState iblockstate = p_187099_2_.func_180495_p(p_187099_3_);
-+                boolean bypass = itemstack.func_190926_b() || itemstack.func_77973_b().doesSneakBypassUse(itemstack, p_187099_2_, p_187099_3_, p_187099_1_);
++                boolean bypass = p_187099_1_.func_184614_ca().func_190926_b() && p_187099_1_.func_184592_cb().func_190926_b() || itemstack.func_77973_b().doesSneakBypassUse(itemstack, p_187099_2_, p_187099_3_, p_187099_1_);
  
 -                if ((!p_187099_1_.func_70093_af() || p_187099_1_.func_184614_ca().func_190926_b() && p_187099_1_.func_184592_cb().func_190926_b()) && iblockstate.func_177230_c().func_180639_a(p_187099_2_, p_187099_3_, iblockstate, p_187099_1_, p_187099_6_, p_187099_4_, f, f1, f2))
 +                if ((!p_187099_1_.func_70093_af() || bypass || event.getUseBlock() == net.minecraftforge.fml.common.eventhandler.Event.Result.ALLOW))

--- a/patches/minecraft/net/minecraft/item/ItemStack.java.patch
+++ b/patches/minecraft/net/minecraft/item/ItemStack.java.patch
@@ -232,7 +232,7 @@
          }
  
          return multimap;
-@@ -1130,4 +1155,113 @@
+@@ -1130,4 +1155,127 @@
      {
          this.func_190917_f(-p_190918_1_);
      }
@@ -344,5 +344,19 @@
 +            return shareTagB == null;
 +        else
 +            return shareTagB != null && shareTagA.equals(shareTagB);
++    }
++
++    /**
++     *
++     * Should this item, when held, allow sneak-clicks to pass through to the underlying block?
++     *
++     * @param world The world
++     * @param pos Block position in world
++     * @param player The Player that is wielding the item
++     * @return
++     */
++    public boolean doesSneakBypassUse(net.minecraft.world.IBlockAccess world, BlockPos pos, EntityPlayer player)
++    {
++        return this.func_190926_b() || this.func_77973_b().doesSneakBypassUse(this, world, pos, player);
 +    }
  }

--- a/patches/minecraft/net/minecraft/server/management/PlayerInteractionManager.java.patch
+++ b/patches/minecraft/net/minecraft/server/management/PlayerInteractionManager.java.patch
@@ -232,7 +232,7 @@
 +            EnumActionResult ret = p_187251_3_.onItemUseFirst(p_187251_1_, p_187251_2_, p_187251_5_, p_187251_4_, p_187251_6_, p_187251_7_, p_187251_8_, p_187251_9_);
 +            if (ret != EnumActionResult.PASS) return ret;
 +
-+            boolean bypass = p_187251_3_.func_190926_b() || p_187251_3_.func_77973_b().doesSneakBypassUse(p_187251_3_, p_187251_2_, p_187251_5_, p_187251_1_);
++            boolean bypass = p_187251_1_.func_184614_ca().func_190926_b() && p_187251_1_.func_184592_cb().func_190926_b() || p_187251_3_.func_77973_b().doesSneakBypassUse(p_187251_3_, p_187251_2_, p_187251_5_, p_187251_1_);
 +            EnumActionResult result = EnumActionResult.PASS;
 +
 +            if (!p_187251_1_.func_70093_af() || bypass || event.getUseBlock() == net.minecraftforge.fml.common.eventhandler.Event.Result.ALLOW)

--- a/patches/minecraft/net/minecraft/server/management/PlayerInteractionManager.java.patch
+++ b/patches/minecraft/net/minecraft/server/management/PlayerInteractionManager.java.patch
@@ -232,7 +232,7 @@
 +            EnumActionResult ret = p_187251_3_.onItemUseFirst(p_187251_1_, p_187251_2_, p_187251_5_, p_187251_4_, p_187251_6_, p_187251_7_, p_187251_8_, p_187251_9_);
 +            if (ret != EnumActionResult.PASS) return ret;
 +
-+            boolean bypass = p_187251_1_.func_184614_ca().func_190926_b() && p_187251_1_.func_184592_cb().func_190926_b() || p_187251_3_.func_77973_b().doesSneakBypassUse(p_187251_3_, p_187251_2_, p_187251_5_, p_187251_1_);
++            boolean bypass = p_187251_1_.func_184614_ca().doesSneakBypassUse(p_187251_2_, p_187251_5_, p_187251_1_) && p_187251_1_.func_184592_cb().doesSneakBypassUse(p_187251_2_, p_187251_5_, p_187251_1_);
 +            EnumActionResult result = EnumActionResult.PASS;
 +
 +            if (!p_187251_1_.func_70093_af() || bypass || event.getUseBlock() == net.minecraftforge.fml.common.eventhandler.Event.Result.ALLOW)


### PR DESCRIPTION
Closes #4254 

This passes all tests of `PlayerInteractEventTest` and makes the behavior consistent with vanilla. Most notably, it makes sneak right clicking the top of a chest with a torch do nothing instead of open the chest GUI.

The fix probably requires some context and explanation:
Right click interaction is called once per hand, main hand first, off hand second. For each hand, block interactions are processed first, then item interactions second. When sneaking, Minecraft will ignore block interactions _unless the player's hands are empty_. This is where the slipup happened, it's only checking the item the _current hand_. This causes an invalid assumption that triggers a block interaction when it should not.

What is happening with the current incorrect implementation:
1. **With item in main hand:**
    1. Main hand pass: The player will interact with the item in this hand so the block interaction is not called.
    2. Off hand pass: The player cannot interact with the item in this hand so the block interaction is called.
2. **With item in off hand:**
    1. Main hand pass: The player cannot interact with the item in this hand so the block interaction is called.
    2. Off hand pass: The player will interact with the item in this hand so the block interaction is not called.
3. **With items in neither hand:**
    1. Main hand pass: The player cannot interact with the item in this hand so the block interaction is called.
    2. Off hand pass: The player will interact with the item in this hand so the block interaction is not called.

What should happen:
1. **With item in main hand:**
    1. Main hand pass: The player will interact with the item in this hand so the block interaction is not called.
    2. Off hand pass: The player interacted with the item in the other hand so the block interaction is not called.
2. **With item in off hand:**
    1. Main hand pass: The player will interact with the item in the other hand so the block interaction is not called.
    2. Off hand pass: The player will interact with the item in this hand so the block interaction is not called.
3. **With items in neither hand:**
    1. Main hand pass: The player cannot interact with items in either hand so the block interaction is called.
    2. Off hand pass: The player cannot interact with items in either hand so the block interaction is called.

I changed the semantics from itemstacks being empty to itemstacks being able to bypass sneak use. Itemstacks can bypass sneak use by being empty or by having an item that bypasses sneak use.

This could break interactions from some mods, though I find it highly unlikely. In the unlikely event that it does it is possible to achieve the previous behavior by simply implementing `Item#doesSneakBypassUse` and returning true.