### PR TITLE
Provide owner string for dummy blocks

### DIFF
--- a/src/main/java/net/minecraftforge/registries/ForgeRegistry.java
+++ b/src/main/java/net/minecraftforge/registries/ForgeRegistry.java
@@ -705,7 +705,7 @@ public class ForgeRegistry<V extends IForgeRegistryEntry<V>> implements IForgeRe
         //It was blocked before so we need to unset the blocking map
         this.availabilityMap.clear(id);
 
-        int realId = this.add(id, dummy);
+        int realId = this.add(id, dummy, dummy.getRegistryName().getResourceDomain());
         if (realId != id)
             FMLLog.log.warn("Registry {}: Object did not get ID it asked for. Name: {} Expected: {} Got: {}", this.superType.getSimpleName(), key, id, realId);
         this.dummies.add(key);


### PR DESCRIPTION
This fixes the error related to https://gist.github.com/Shadows-of-Fire/103fe774841b050c8575449196d806bc.
Specifically, from Line 288,   
`throw new IllegalStateException(String.format("Could not determine owner for the override on %s. Value: %s", key, value));`   
This happens because the owner on dummy blocks is null due to this being fired during login, so  
`String owner = mc == null || (mc instanceof InjectedModContainer && ((InjectedModContainer)mc).wrappedContainer instanceof FMLContainer) ? null : mc.getModId().toLowerCase();`   
this returns null.  This error will not crash the client, but it is seemingly completely random, and it causes clients to fail to login for no apparent reason.