### PR TITLE
Replace calls to getLightValue inside rendering with lightmap lookup

### DIFF
--- a/patches/minecraft/net/minecraft/block/Block.java.patch
+++ b/patches/minecraft/net/minecraft/block/Block.java.patch
@@ -37,22 +37,18 @@
      }
  
      @Deprecated
-@@ -372,13 +374,13 @@
+@@ -372,9 +374,9 @@
      @SideOnly(Side.CLIENT)
      public int func_185484_c(IBlockState p_185484_1_, IBlockAccess p_185484_2_, BlockPos p_185484_3_)
      {
 -        int i = p_185484_2_.func_175626_b(p_185484_3_, p_185484_1_.func_185906_d());
-+        int i = p_185484_2_.func_175626_b(p_185484_3_, p_185484_1_.getLightValue(p_185484_2_, p_185484_3_));
++        int i = p_185484_2_.func_175626_b(p_185484_3_, 0);
  
-         if (i == 0 && p_185484_1_.func_177230_c() instanceof BlockSlab)
+-        if (i == 0 && p_185484_1_.func_177230_c() instanceof BlockSlab)
++        if (false) //Slabs already use neighbor brightness.
          {
              p_185484_3_ = p_185484_3_.func_177977_b();
              p_185484_1_ = p_185484_2_.func_180495_p(p_185484_3_);
--            return p_185484_2_.func_175626_b(p_185484_3_, p_185484_1_.func_185906_d());
-+            return p_185484_2_.func_175626_b(p_185484_3_, p_185484_1_.getLightValue(p_185484_2_, p_185484_3_));
-         }
-         else
-         {
 @@ -442,7 +444,7 @@
                  }
          }

--- a/patches/minecraft/net/minecraft/client/renderer/BlockFluidRenderer.java.patch
+++ b/patches/minecraft/net/minecraft/client/renderer/BlockFluidRenderer.java.patch
@@ -1,0 +1,26 @@
+--- ../src-base/minecraft/net/minecraft/client/renderer/BlockFluidRenderer.java
++++ ../src-work/minecraft/net/minecraft/client/renderer/BlockFluidRenderer.java
+@@ -73,6 +73,7 @@
+             double d1 = (double)p_178270_3_.func_177956_o();
+             double d2 = (double)p_178270_3_.func_177952_p();
+             float f11 = 0.001F;
++            final int lightIn = net.minecraftforge.client.ForgeHooksClient.getBasePackedLightmapCoords(p_178270_1_, p_178270_3_);
+ 
+             if (flag1)
+             {
+@@ -145,6 +146,7 @@
+                 float f37 = atextureatlassprite[0].func_94206_g();
+                 float f38 = atextureatlassprite[0].func_94210_h();
+                 int l1 = p_178270_2_.func_185889_a(p_178270_1_, p_178270_3_.func_177977_b());
++                l1 = net.minecraftforge.client.ForgeHooksClient.combinePackedLightmapCoords(l1, lightIn);
+                 int i2 = l1 >> 16 & 65535;
+                 int j2 = l1 & 65535;
+                 p_178270_4_.func_181662_b(d0, d1, d2 + 1.0D).func_181666_a(0.5F, 0.5F, 0.5F, 1.0F).func_187315_a((double)f35, (double)f38).func_187314_a(i2, j2).func_181675_d();
+@@ -245,6 +247,7 @@
+                     float f29 = textureatlassprite1.func_94207_b((double)((1.0F - f40) * 16.0F * 0.5F));
+                     float f30 = textureatlassprite1.func_94207_b(8.0D);
+                     int j = p_178270_2_.func_185889_a(p_178270_1_, blockpos);
++                    j = net.minecraftforge.client.ForgeHooksClient.combinePackedLightmapCoords(j, lightIn);
+                     int k = j >> 16 & 65535;
+                     int l = j & 65535;
+                     float f31 = i1 < 2 ? 0.8F : 0.6F;

--- a/patches/minecraft/net/minecraft/client/renderer/BlockModelRenderer.java.patch
+++ b/patches/minecraft/net/minecraft/client/renderer/BlockModelRenderer.java.patch
@@ -1,6 +1,22 @@
 --- ../src-base/minecraft/net/minecraft/client/renderer/BlockModelRenderer.java
 +++ ../src-work/minecraft/net/minecraft/client/renderer/BlockModelRenderer.java
-@@ -128,7 +128,14 @@
+@@ -89,6 +89,7 @@
+     {
+         boolean flag = false;
+         BitSet bitset = new BitSet(3);
++        final int lightIn = net.minecraftforge.client.ForgeHooksClient.getBasePackedLightmapCoords(p_187497_1_, p_187497_4_);
+ 
+         for (EnumFacing enumfacing : EnumFacing.values())
+         {
+@@ -97,6 +98,7 @@
+             if (!list.isEmpty() && (!p_187497_6_ || p_187497_3_.func_185894_c(p_187497_1_, p_187497_4_, enumfacing)))
+             {
+                 int i = p_187497_3_.func_185889_a(p_187497_1_, p_187497_4_.func_177972_a(enumfacing));
++                i = net.minecraftforge.client.ForgeHooksClient.combinePackedLightmapCoords(i, lightIn);
+                 this.func_187496_a(p_187497_1_, p_187497_3_, p_187497_4_, i, false, p_187497_5_, list, bitset);
+                 flag = true;
+             }
+@@ -128,7 +130,14 @@
              p_187492_8_.func_187491_a(p_187492_1_, p_187492_2_, p_187492_3_, bakedquad.func_178210_d(), p_187492_6_, p_187492_7_);
              p_187492_4_.func_178981_a(bakedquad.func_178209_a());
              p_187492_4_.func_178962_a(p_187492_8_.field_178207_c[0], p_187492_8_.field_178207_c[1], p_187492_8_.field_178207_c[2], p_187492_8_.field_178207_c[3]);
@@ -16,7 +32,23 @@
              if (bakedquad.func_178212_b())
              {
                  int k = this.field_187499_a.func_186724_a(p_187492_2_, p_187492_1_, p_187492_3_, bakedquad.func_178211_c());
-@@ -262,11 +269,26 @@
+@@ -235,6 +244,7 @@
+         double d1 = (double)p_187496_3_.func_177956_o() + vec3d.field_72448_b;
+         double d2 = (double)p_187496_3_.func_177952_p() + vec3d.field_72449_c;
+         int i = 0;
++        final int baseBrightness = p_187496_5_ ? net.minecraftforge.client.ForgeHooksClient.getBasePackedLightmapCoords(p_187496_1_, p_187496_3_) : 0;
+ 
+         for (int j = p_187496_7_.size(); i < j; ++i)
+         {
+@@ -245,6 +255,7 @@
+                 this.func_187494_a(p_187496_2_, bakedquad.func_178209_a(), bakedquad.func_178210_d(), (float[])null, p_187496_8_);
+                 BlockPos blockpos = p_187496_8_.get(0) ? p_187496_3_.func_177972_a(bakedquad.func_178210_d()) : p_187496_3_;
+                 p_187496_4_ = p_187496_2_.func_185889_a(p_187496_1_, blockpos);
++                p_187496_4_ = net.minecraftforge.client.ForgeHooksClient.combinePackedLightmapCoords(p_187496_4_, baseBrightness);
+             }
+ 
+             p_187496_6_.func_178981_a(bakedquad.func_178209_a());
+@@ -262,11 +273,26 @@
                  float f = (float)(k >> 16 & 255) / 255.0F;
                  float f1 = (float)(k >> 8 & 255) / 255.0F;
                  float f2 = (float)(k & 255) / 255.0F;
@@ -43,3 +75,62 @@
  
              p_187496_6_.func_178987_a(d0, d1, d2);
          }
+@@ -345,6 +371,7 @@
+ 
+         public void func_187491_a(IBlockAccess p_187491_1_, IBlockState p_187491_2_, BlockPos p_187491_3_, EnumFacing p_187491_4_, float[] p_187491_5_, BitSet p_187491_6_)
+         {
++            final int lightIn = net.minecraftforge.client.ForgeHooksClient.getBasePackedLightmapCoords(p_187491_1_, p_187491_3_);
+             BlockPos blockpos = p_187491_6_.get(0) ? p_187491_3_.func_177972_a(p_187491_4_) : p_187491_3_;
+             BlockPos.PooledMutableBlockPos blockpos$pooledmutableblockpos = BlockPos.PooledMutableBlockPos.func_185346_s();
+             BlockModelRenderer.EnumNeighborInfo blockmodelrenderer$enumneighborinfo = BlockModelRenderer.EnumNeighborInfo.func_178273_a(p_187491_4_);
+@@ -356,6 +383,10 @@
+             int j = p_187491_2_.func_185889_a(p_187491_1_, blockpos$pooledmutableblockpos2);
+             int k = p_187491_2_.func_185889_a(p_187491_1_, blockpos$pooledmutableblockpos3);
+             int l = p_187491_2_.func_185889_a(p_187491_1_, blockpos$pooledmutableblockpos4);
++            i = net.minecraftforge.client.ForgeHooksClient.combinePackedLightmapCoords(i, lightIn);
++            j = net.minecraftforge.client.ForgeHooksClient.combinePackedLightmapCoords(j, lightIn);
++            k = net.minecraftforge.client.ForgeHooksClient.combinePackedLightmapCoords(k, lightIn);
++            l = net.minecraftforge.client.ForgeHooksClient.combinePackedLightmapCoords(l, lightIn);
+             float f = p_187491_1_.func_180495_p(blockpos$pooledmutableblockpos1).func_185892_j();
+             float f1 = p_187491_1_.func_180495_p(blockpos$pooledmutableblockpos2).func_185892_j();
+             float f2 = p_187491_1_.func_180495_p(blockpos$pooledmutableblockpos3).func_185892_j();
+@@ -377,6 +408,7 @@
+                 BlockPos blockpos1 = blockpos$pooledmutableblockpos.func_189533_g(blockpos$pooledmutableblockpos1).func_189536_c(blockmodelrenderer$enumneighborinfo.field_178276_g[2]);
+                 f4 = p_187491_1_.func_180495_p(blockpos1).func_185892_j();
+                 i1 = p_187491_2_.func_185889_a(p_187491_1_, blockpos1);
++                i1 = net.minecraftforge.client.ForgeHooksClient.combinePackedLightmapCoords(i1, lightIn);
+             }
+ 
+             float f5;
+@@ -392,6 +424,7 @@
+                 BlockPos blockpos2 = blockpos$pooledmutableblockpos.func_189533_g(blockpos$pooledmutableblockpos1).func_189536_c(blockmodelrenderer$enumneighborinfo.field_178276_g[3]);
+                 f5 = p_187491_1_.func_180495_p(blockpos2).func_185892_j();
+                 j1 = p_187491_2_.func_185889_a(p_187491_1_, blockpos2);
++                j1 = net.minecraftforge.client.ForgeHooksClient.combinePackedLightmapCoords(j1, lightIn);
+             }
+ 
+             float f6;
+@@ -407,6 +440,7 @@
+                 BlockPos blockpos3 = blockpos$pooledmutableblockpos.func_189533_g(blockpos$pooledmutableblockpos2).func_189536_c(blockmodelrenderer$enumneighborinfo.field_178276_g[2]);
+                 f6 = p_187491_1_.func_180495_p(blockpos3).func_185892_j();
+                 k1 = p_187491_2_.func_185889_a(p_187491_1_, blockpos3);
++                k1 = net.minecraftforge.client.ForgeHooksClient.combinePackedLightmapCoords(k1, lightIn);
+             }
+ 
+             float f7;
+@@ -422,6 +456,7 @@
+                 BlockPos blockpos4 = blockpos$pooledmutableblockpos.func_189533_g(blockpos$pooledmutableblockpos2).func_189536_c(blockmodelrenderer$enumneighborinfo.field_178276_g[3]);
+                 f7 = p_187491_1_.func_180495_p(blockpos4).func_185892_j();
+                 l1 = p_187491_2_.func_185889_a(p_187491_1_, blockpos4);
++                l1 = net.minecraftforge.client.ForgeHooksClient.combinePackedLightmapCoords(l1, lightIn);
+             }
+ 
+             int i3 = p_187491_2_.func_185889_a(p_187491_1_, p_187491_3_);
+@@ -429,6 +464,7 @@
+             if (p_187491_6_.get(0) || !p_187491_1_.func_180495_p(p_187491_3_.func_177972_a(p_187491_4_)).func_185914_p())
+             {
+                 i3 = p_187491_2_.func_185889_a(p_187491_1_, p_187491_3_.func_177972_a(p_187491_4_));
++                i3 = net.minecraftforge.client.ForgeHooksClient.combinePackedLightmapCoords(i3, lightIn);
+             }
+ 
+             float f8 = p_187491_6_.get(0) ? p_187491_1_.func_180495_p(blockpos).func_185892_j() : p_187491_1_.func_180495_p(p_187491_3_).func_185892_j();

--- a/patches/minecraft/net/minecraft/world/ChunkCache.java.patch
+++ b/patches/minecraft/net/minecraft/world/ChunkCache.java.patch
@@ -9,7 +9,7 @@
      }
  
      @Nullable
-@@ -69,6 +69,7 @@
+@@ -69,14 +69,15 @@
      {
          int i = (p_190300_1_.func_177958_n() >> 4) - this.field_72818_a;
          int j = (p_190300_1_.func_177952_p() >> 4) - this.field_72816_b;
@@ -17,6 +17,16 @@
          return this.field_72817_c[i][j].func_177424_a(p_190300_1_, p_190300_2_);
      }
  
+     @SideOnly(Side.CLIENT)
+     public int func_175626_b(BlockPos p_175626_1_, int p_175626_2_)
+     {
+-        int i = this.func_175629_a(EnumSkyBlock.SKY, p_175626_1_);
+-        int j = this.func_175629_a(EnumSkyBlock.BLOCK, p_175626_1_);
++        int i = p_175626_2_ == -1 ? this.func_175628_b(EnumSkyBlock.SKY, p_175626_1_) : this.func_175629_a(EnumSkyBlock.SKY, p_175626_1_);
++        int j = p_175626_2_ == -1 ? this.func_175628_b(EnumSkyBlock.BLOCK, p_175626_1_) : this.func_175629_a(EnumSkyBlock.BLOCK, p_175626_1_);
+ 
+         if (j < p_175626_2_)
+         {
 @@ -112,6 +113,7 @@
      {
          int i = (p_180494_1_.func_177958_n() >> 4) - this.field_72818_a;
@@ -25,7 +35,19 @@
          return this.field_72817_c[i][j].func_177411_a(p_180494_1_, this.field_72815_e.func_72959_q());
      }
  
-@@ -149,6 +151,7 @@
+@@ -127,6 +129,11 @@
+             if (this.func_180495_p(p_175629_2_).func_185916_f())
+             {
+                 int l = 0;
++                int i = (p_175629_2_.func_177958_n() >> 4) - this.field_72818_a;
++                int j = (p_175629_2_.func_177952_p() >> 4) - this.field_72816_b;
++                if (!withinBounds(i, j)) l = p_175629_1_.field_77198_c;
++                else l = this.field_72817_c[i][j].func_177413_a(p_175629_1_, p_175629_2_);
++                if (l >= 14) return l;
+ 
+                 for (EnumFacing enumfacing : EnumFacing.values())
+                 {
+@@ -149,6 +156,7 @@
              {
                  int i = (p_175629_2_.func_177958_n() >> 4) - this.field_72818_a;
                  int j = (p_175629_2_.func_177952_p() >> 4) - this.field_72816_b;
@@ -33,7 +55,7 @@
                  return this.field_72817_c[i][j].func_177413_a(p_175629_1_, p_175629_2_);
              }
          }
-@@ -160,7 +163,8 @@
+@@ -160,7 +168,8 @@
  
      public boolean func_175623_d(BlockPos p_175623_1_)
      {
@@ -43,7 +65,7 @@
      }
  
      @SideOnly(Side.CLIENT)
-@@ -170,6 +174,7 @@
+@@ -170,6 +179,7 @@
          {
              int i = (p_175628_2_.func_177958_n() >> 4) - this.field_72818_a;
              int j = (p_175628_2_.func_177952_p() >> 4) - this.field_72816_b;
@@ -51,7 +73,7 @@
              return this.field_72817_c[i][j].func_177413_a(p_175628_1_, p_175628_2_);
          }
          else
-@@ -188,4 +193,21 @@
+@@ -188,4 +198,21 @@
      {
          return this.field_72815_e.func_175624_G();
      }

--- a/patches/minecraft/net/minecraft/world/World.java.patch
+++ b/patches/minecraft/net/minecraft/world/World.java.patch
@@ -176,7 +176,52 @@
                      {
                          return false;
                      }
-@@ -861,7 +912,7 @@
+@@ -626,12 +677,16 @@
+         {
+             if (p_175721_2_ && this.func_180495_p(p_175721_1_).func_185916_f())
+             {
++                Chunk chunk = this.func_175726_f(p_175721_1_);
++                final int ownLight = chunk.func_177443_a(p_175721_1_, this.field_73008_k);
++                if (ownLight >= 14) return ownLight;
+                 int i1 = this.func_175721_c(p_175721_1_.func_177984_a(), false);
+                 int i = this.func_175721_c(p_175721_1_.func_177974_f(), false);
+                 int j = this.func_175721_c(p_175721_1_.func_177976_e(), false);
+                 int k = this.func_175721_c(p_175721_1_.func_177968_d(), false);
+                 int l = this.func_175721_c(p_175721_1_.func_177978_c(), false);
+ 
++                if (ownLight > i) i = ownLight;
+                 if (i > i1)
+                 {
+                     i1 = i;
+@@ -748,12 +803,16 @@
+             }
+             else if (this.func_180495_p(p_175705_2_).func_185916_f())
+             {
++                Chunk chunk = this.func_175726_f(p_175705_2_);
++                final int ownLight = chunk.func_177443_a(p_175705_2_, this.field_73008_k);
++                if (ownLight >= 14) return ownLight;
+                 int i1 = this.func_175642_b(p_175705_1_, p_175705_2_.func_177984_a());
+                 int i = this.func_175642_b(p_175705_1_, p_175705_2_.func_177974_f());
+                 int j = this.func_175642_b(p_175705_1_, p_175705_2_.func_177976_e());
+                 int k = this.func_175642_b(p_175705_1_, p_175705_2_.func_177968_d());
+                 int l = this.func_175642_b(p_175705_1_, p_175705_2_.func_177978_c());
+ 
++                if (ownLight > i) i = ownLight;
+                 if (i > i1)
+                 {
+                     i1 = i;
+@@ -830,8 +889,8 @@
+     @SideOnly(Side.CLIENT)
+     public int func_175626_b(BlockPos p_175626_1_, int p_175626_2_)
+     {
+-        int i = this.func_175705_a(EnumSkyBlock.SKY, p_175626_1_);
+-        int j = this.func_175705_a(EnumSkyBlock.BLOCK, p_175626_1_);
++        int i = p_175626_2_ == -1 ? this.func_175642_b(EnumSkyBlock.SKY, p_175626_1_) : this.func_175705_a(EnumSkyBlock.SKY, p_175626_1_);
++        int j = p_175626_2_ == -1 ? this.func_175642_b(EnumSkyBlock.BLOCK, p_175626_1_) : this.func_175705_a(EnumSkyBlock.BLOCK, p_175626_1_);
+ 
+         if (j < p_175626_2_)
+         {
+@@ -861,7 +920,7 @@
  
      public boolean func_72935_r()
      {
@@ -185,7 +230,7 @@
      }
  
      @Nullable
-@@ -1064,6 +1115,13 @@
+@@ -1064,6 +1123,13 @@
  
      public void func_184148_a(@Nullable EntityPlayer p_184148_1_, double p_184148_2_, double p_184148_4_, double p_184148_6_, SoundEvent p_184148_8_, SoundCategory p_184148_9_, float p_184148_10_, float p_184148_11_)
      {
@@ -199,7 +244,7 @@
          for (int i = 0; i < this.field_73021_x.size(); ++i)
          {
              ((IWorldEventListener)this.field_73021_x.get(i)).func_184375_a(p_184148_1_, p_184148_8_, p_184148_9_, p_184148_2_, p_184148_4_, p_184148_6_, p_184148_10_, p_184148_11_);
-@@ -1117,6 +1175,9 @@
+@@ -1117,6 +1183,9 @@
  
      public boolean func_72838_d(Entity p_72838_1_)
      {
@@ -209,7 +254,7 @@
          int i = MathHelper.func_76128_c(p_72838_1_.field_70165_t / 16.0D);
          int j = MathHelper.func_76128_c(p_72838_1_.field_70161_v / 16.0D);
          boolean flag = p_72838_1_.field_98038_p;
-@@ -1139,6 +1200,8 @@
+@@ -1139,6 +1208,8 @@
                  this.func_72854_c();
              }
  
@@ -218,7 +263,7 @@
              this.func_72964_e(i, j).func_76612_a(p_72838_1_);
              this.field_72996_f.add(p_72838_1_);
              this.func_72923_a(p_72838_1_);
-@@ -1267,6 +1330,7 @@
+@@ -1267,6 +1338,7 @@
                                  }
  
                                  iblockstate1.func_185908_a(this, blockpos$pooledmutableblockpos, p_191504_2_, p_191504_4_, p_191504_1_, false);
@@ -226,7 +271,7 @@
  
                                  if (p_191504_3_ && !p_191504_4_.isEmpty())
                                  {
-@@ -1318,11 +1382,10 @@
+@@ -1318,11 +1390,10 @@
                  }
              }
          }
@@ -239,7 +284,7 @@
      public void func_72848_b(IWorldEventListener p_72848_1_)
      {
          this.field_73021_x.remove(p_72848_1_);
-@@ -1360,19 +1423,38 @@
+@@ -1360,19 +1431,38 @@
  
      public int func_72967_a(float p_72967_1_)
      {
@@ -280,7 +325,7 @@
          float f = this.func_72826_c(p_72971_1_);
          float f1 = 1.0F - (MathHelper.func_76134_b(f * ((float)Math.PI * 2F)) * 2.0F + 0.2F);
          f1 = MathHelper.func_76131_a(f1, 0.0F, 1.0F);
-@@ -1385,6 +1467,12 @@
+@@ -1385,6 +1475,12 @@
      @SideOnly(Side.CLIENT)
      public Vec3d func_72833_a(Entity p_72833_1_, float p_72833_2_)
      {
@@ -293,7 +338,7 @@
          float f = this.func_72826_c(p_72833_2_);
          float f1 = MathHelper.func_76134_b(f * ((float)Math.PI * 2F)) * 2.0F + 0.5F;
          f1 = MathHelper.func_76131_a(f1, 0.0F, 1.0F);
-@@ -1392,9 +1480,7 @@
+@@ -1392,9 +1488,7 @@
          int j = MathHelper.func_76128_c(p_72833_1_.field_70163_u);
          int k = MathHelper.func_76128_c(p_72833_1_.field_70161_v);
          BlockPos blockpos = new BlockPos(i, j, k);
@@ -304,7 +349,7 @@
          float f3 = (float)(l >> 16 & 255) / 255.0F;
          float f4 = (float)(l >> 8 & 255) / 255.0F;
          float f5 = (float)(l & 255) / 255.0F;
-@@ -1443,20 +1529,25 @@
+@@ -1443,20 +1537,25 @@
  
      public float func_72826_c(float p_72826_1_)
      {
@@ -333,7 +378,7 @@
      public float func_72929_e(float p_72929_1_)
      {
          float f = this.func_72826_c(p_72929_1_);
-@@ -1466,6 +1557,12 @@
+@@ -1466,6 +1565,12 @@
      @SideOnly(Side.CLIENT)
      public Vec3d func_72824_f(float p_72824_1_)
      {
@@ -346,7 +391,7 @@
          float f = this.func_72826_c(p_72824_1_);
          float f1 = MathHelper.func_76134_b(f * ((float)Math.PI * 2F)) * 2.0F + 0.5F;
          f1 = MathHelper.func_76131_a(f1, 0.0F, 1.0F);
-@@ -1521,9 +1618,9 @@
+@@ -1521,9 +1626,9 @@
          for (blockpos = new BlockPos(p_175672_1_.func_177958_n(), chunk.func_76625_h() + 16, p_175672_1_.func_177952_p()); blockpos.func_177956_o() >= 0; blockpos = blockpos1)
          {
              blockpos1 = blockpos.func_177977_b();
@@ -358,7 +403,7 @@
              {
                  break;
              }
-@@ -1535,6 +1632,12 @@
+@@ -1535,6 +1640,12 @@
      @SideOnly(Side.CLIENT)
      public float func_72880_h(float p_72880_1_)
      {
@@ -371,7 +416,7 @@
          float f = this.func_72826_c(p_72880_1_);
          float f1 = 1.0F - (MathHelper.func_76134_b(f * ((float)Math.PI * 2F)) * 2.0F + 0.25F);
          f1 = MathHelper.func_76131_a(f1, 0.0F, 1.0F);
-@@ -1569,6 +1672,7 @@
+@@ -1569,6 +1680,7 @@
  
              try
              {
@@ -379,7 +424,7 @@
                  ++entity.field_70173_aa;
                  entity.func_70071_h_();
              }
-@@ -1586,6 +1690,12 @@
+@@ -1586,6 +1698,12 @@
                      entity.func_85029_a(crashreportcategory);
                  }
  
@@ -392,7 +437,7 @@
                  throw new ReportedException(crashreport);
              }
  
-@@ -1647,6 +1757,12 @@
+@@ -1647,6 +1765,12 @@
                      CrashReport crashreport1 = CrashReport.func_85055_a(throwable1, "Ticking entity");
                      CrashReportCategory crashreportcategory1 = crashreport1.func_85058_a("Entity being ticked");
                      entity2.func_85029_a(crashreportcategory1);
@@ -405,7 +450,7 @@
                      throw new ReportedException(crashreport1);
                  }
              }
-@@ -1683,11 +1799,11 @@
+@@ -1683,11 +1807,11 @@
              {
                  BlockPos blockpos = tileentity.func_174877_v();
  
@@ -419,7 +464,7 @@
                          ((ITickable)tileentity).func_73660_a();
                          this.field_72984_F.func_76319_b();
                      }
-@@ -1696,6 +1812,13 @@
+@@ -1696,6 +1820,13 @@
                          CrashReport crashreport2 = CrashReport.func_85055_a(throwable, "Ticking block entity");
                          CrashReportCategory crashreportcategory2 = crashreport2.func_85058_a("Block entity being ticked");
                          tileentity.func_145828_a(crashreportcategory2);
@@ -433,7 +478,7 @@
                          throw new ReportedException(crashreport2);
                      }
                  }
-@@ -1708,20 +1831,28 @@
+@@ -1708,20 +1839,28 @@
  
                  if (this.func_175667_e(tileentity.func_174877_v()))
                  {
@@ -465,7 +510,7 @@
          this.field_72984_F.func_76318_c("pendingBlockEntities");
  
          if (!this.field_147484_a.isEmpty())
-@@ -1760,12 +1891,18 @@
+@@ -1760,12 +1899,18 @@
  
      public boolean func_175700_a(TileEntity p_175700_1_)
      {
@@ -484,7 +529,7 @@
  
          if (this.field_72995_K)
          {
-@@ -1781,6 +1918,11 @@
+@@ -1781,6 +1926,11 @@
      {
          if (this.field_147481_N)
          {
@@ -496,7 +541,7 @@
              this.field_147484_a.addAll(p_147448_1_);
          }
          else
-@@ -1803,9 +1945,12 @@
+@@ -1803,9 +1953,12 @@
          {
              int i = MathHelper.func_76128_c(p_72866_1_.field_70165_t);
              int j = MathHelper.func_76128_c(p_72866_1_.field_70161_v);
@@ -511,7 +556,7 @@
              {
                  return;
              }
-@@ -1827,6 +1972,7 @@
+@@ -1827,6 +1980,7 @@
              }
              else
              {
@@ -519,7 +564,7 @@
                  p_72866_1_.func_70071_h_();
              }
          }
-@@ -2007,6 +2153,11 @@
+@@ -2007,6 +2161,11 @@
                              blockpos$pooledmutableblockpos.func_185344_t();
                              return true;
                          }
@@ -531,7 +576,7 @@
                      }
                  }
              }
-@@ -2046,6 +2197,16 @@
+@@ -2046,6 +2205,16 @@
                          IBlockState iblockstate = this.func_180495_p(blockpos$pooledmutableblockpos);
                          Block block = iblockstate.func_177230_c();
  
@@ -548,7 +593,7 @@
                          if (iblockstate.func_185904_a() == p_72918_2_)
                          {
                              double d0 = (double)((float)(l1 + 1) - BlockLiquid.func_149801_b(((Integer)iblockstate.func_177229_b(BlockLiquid.field_176367_b)).intValue()));
-@@ -2112,6 +2273,7 @@
+@@ -2112,6 +2281,7 @@
      public Explosion func_72885_a(@Nullable Entity p_72885_1_, double p_72885_2_, double p_72885_4_, double p_72885_6_, float p_72885_8_, boolean p_72885_9_, boolean p_72885_10_)
      {
          Explosion explosion = new Explosion(this, p_72885_1_, p_72885_2_, p_72885_4_, p_72885_6_, p_72885_8_, p_72885_9_, p_72885_10_);
@@ -556,7 +601,7 @@
          explosion.func_77278_a();
          explosion.func_77279_a(true);
          return explosion;
-@@ -2234,6 +2396,7 @@
+@@ -2234,6 +2404,7 @@
  
      public void func_175690_a(BlockPos p_175690_1_, @Nullable TileEntity p_175690_2_)
      {
@@ -564,7 +609,7 @@
          if (!this.func_189509_E(p_175690_1_))
          {
              if (p_175690_2_ != null && !p_175690_2_.func_145837_r())
-@@ -2241,6 +2404,8 @@
+@@ -2241,6 +2412,8 @@
                  if (this.field_147481_N)
                  {
                      p_175690_2_.func_174878_a(p_175690_1_);
@@ -573,7 +618,7 @@
                      Iterator<TileEntity> iterator = this.field_147484_a.iterator();
  
                      while (iterator.hasNext())
-@@ -2258,7 +2423,8 @@
+@@ -2258,7 +2431,8 @@
                  }
                  else
                  {
@@ -583,7 +628,7 @@
                      this.func_175700_a(p_175690_2_);
                  }
              }
-@@ -2273,6 +2439,8 @@
+@@ -2273,6 +2447,8 @@
          {
              tileentity.func_145843_s();
              this.field_147484_a.remove(tileentity);
@@ -592,7 +637,7 @@
          }
          else
          {
-@@ -2285,6 +2453,7 @@
+@@ -2285,6 +2461,7 @@
  
              this.func_175726_f(p_175713_1_).func_177425_e(p_175713_1_);
          }
@@ -600,7 +645,7 @@
      }
  
      public void func_147457_a(TileEntity p_147457_1_)
-@@ -2311,7 +2480,7 @@
+@@ -2311,7 +2488,7 @@
              if (chunk != null && !chunk.func_76621_g())
              {
                  IBlockState iblockstate = this.func_180495_p(p_175677_1_);
@@ -609,7 +654,7 @@
              }
              else
              {
-@@ -2334,6 +2503,7 @@
+@@ -2334,6 +2511,7 @@
      {
          this.field_72985_G = p_72891_1_;
          this.field_72992_H = p_72891_2_;
@@ -617,7 +662,7 @@
      }
  
      public void func_72835_b()
-@@ -2343,6 +2513,11 @@
+@@ -2343,6 +2521,11 @@
  
      protected void func_72947_a()
      {
@@ -629,7 +674,7 @@
          if (this.field_72986_A.func_76059_o())
          {
              this.field_73004_o = 1.0F;
-@@ -2356,6 +2531,11 @@
+@@ -2356,6 +2539,11 @@
  
      protected void func_72979_l()
      {
@@ -641,7 +686,7 @@
          if (this.field_73011_w.func_191066_m())
          {
              if (!this.field_72995_K)
-@@ -2480,6 +2660,11 @@
+@@ -2480,6 +2668,11 @@
  
      public boolean func_175670_e(BlockPos p_175670_1_, boolean p_175670_2_)
      {
@@ -653,7 +698,7 @@
          Biome biome = this.func_180494_b(p_175670_1_);
          float f = biome.func_180626_a(p_175670_1_);
  
-@@ -2521,6 +2706,11 @@
+@@ -2521,6 +2714,11 @@
  
      public boolean func_175708_f(BlockPos p_175708_1_, boolean p_175708_2_)
      {
@@ -665,7 +710,7 @@
          Biome biome = this.func_180494_b(p_175708_1_);
          float f = biome.func_180626_a(p_175708_1_);
  
-@@ -2538,7 +2728,7 @@
+@@ -2538,7 +2736,7 @@
              {
                  IBlockState iblockstate = this.func_180495_p(p_175708_1_);
  
@@ -674,7 +719,7 @@
                  {
                      return true;
                  }
-@@ -2570,10 +2760,11 @@
+@@ -2570,10 +2768,11 @@
          else
          {
              IBlockState iblockstate = this.func_180495_p(p_175638_1_);
@@ -689,7 +734,7 @@
              {
                  j = 1;
              }
-@@ -2679,7 +2870,7 @@
+@@ -2679,7 +2878,7 @@
                                      int j4 = j2 + enumfacing.func_96559_d();
                                      int k4 = k2 + enumfacing.func_82599_e();
                                      blockpos$pooledmutableblockpos.func_181079_c(i4, j4, k4);
@@ -698,7 +743,7 @@
                                      i3 = this.func_175642_b(p_180500_1_, blockpos$pooledmutableblockpos);
  
                                      if (i3 == l2 - l4 && j < this.field_72994_J.length)
-@@ -2787,10 +2978,10 @@
+@@ -2787,10 +2986,10 @@
      public List<Entity> func_175674_a(@Nullable Entity p_175674_1_, AxisAlignedBB p_175674_2_, @Nullable Predicate <? super Entity > p_175674_3_)
      {
          List<Entity> list = Lists.<Entity>newArrayList();
@@ -713,7 +758,7 @@
  
          for (int i1 = i; i1 <= j; ++i1)
          {
-@@ -2843,10 +3034,10 @@
+@@ -2843,10 +3042,10 @@
  
      public <T extends Entity> List<T> func_175647_a(Class <? extends T > p_175647_1_, AxisAlignedBB p_175647_2_, @Nullable Predicate <? super T > p_175647_3_)
      {
@@ -728,7 +773,7 @@
          List<T> list = Lists.<T>newArrayList();
  
          for (int i1 = i; i1 < j; ++i1)
-@@ -2926,11 +3117,13 @@
+@@ -2926,11 +3125,13 @@
  
      public void func_175650_b(Collection<Entity> p_175650_1_)
      {
@@ -745,7 +790,7 @@
          }
      }
  
-@@ -2954,7 +3147,7 @@
+@@ -2954,7 +3155,7 @@
          }
          else
          {
@@ -754,7 +799,7 @@
          }
      }
  
-@@ -3038,7 +3231,7 @@
+@@ -3038,7 +3239,7 @@
      public int func_175651_c(BlockPos p_175651_1_, EnumFacing p_175651_2_)
      {
          IBlockState iblockstate = this.func_180495_p(p_175651_1_);
@@ -763,7 +808,7 @@
      }
  
      public boolean func_175640_z(BlockPos p_175640_1_)
-@@ -3204,6 +3397,8 @@
+@@ -3204,6 +3405,8 @@
                      d2 *= ((Double)MoreObjects.firstNonNull(p_184150_11_.apply(entityplayer1), Double.valueOf(1.0D))).doubleValue();
                  }
  
@@ -772,7 +817,7 @@
                  if ((p_184150_9_ < 0.0D || Math.abs(entityplayer1.field_70163_u - p_184150_3_) < p_184150_9_ * p_184150_9_) && (p_184150_7_ < 0.0D || d1 < d2 * d2) && (d0 == -1.0D || d1 < d0))
                  {
                      d0 = d1;
-@@ -3265,7 +3460,7 @@
+@@ -3265,7 +3468,7 @@
  
      public long func_72905_C()
      {
@@ -781,7 +826,7 @@
      }
  
      public long func_82737_E()
-@@ -3275,17 +3470,17 @@
+@@ -3275,17 +3478,17 @@
  
      public long func_72820_D()
      {
@@ -802,7 +847,7 @@
  
          if (!this.func_175723_af().func_177746_a(blockpos))
          {
-@@ -3297,7 +3492,7 @@
+@@ -3297,7 +3500,7 @@
  
      public void func_175652_B(BlockPos p_175652_1_)
      {
@@ -811,7 +856,7 @@
      }
  
      @SideOnly(Side.CLIENT)
-@@ -3317,12 +3512,18 @@
+@@ -3317,12 +3520,18 @@
  
          if (!this.field_72996_f.contains(p_72897_1_))
          {
@@ -830,7 +875,7 @@
          return true;
      }
  
-@@ -3424,8 +3625,7 @@
+@@ -3424,8 +3633,7 @@
  
      public boolean func_180502_D(BlockPos p_180502_1_)
      {
@@ -840,7 +885,7 @@
      }
  
      @Nullable
-@@ -3486,12 +3686,12 @@
+@@ -3486,12 +3694,12 @@
  
      public int func_72800_K()
      {
@@ -855,7 +900,7 @@
      }
  
      public Random func_72843_D(int p_72843_1_, int p_72843_2_, int p_72843_3_)
-@@ -3535,7 +3735,7 @@
+@@ -3535,7 +3743,7 @@
      @SideOnly(Side.CLIENT)
      public double func_72919_O()
      {
@@ -864,7 +909,7 @@
      }
  
      public void func_175715_c(int p_175715_1_, BlockPos p_175715_2_, int p_175715_3_)
-@@ -3569,7 +3769,7 @@
+@@ -3569,7 +3777,7 @@
  
      public void func_175666_e(BlockPos p_175666_1_, Block p_175666_2_)
      {
@@ -873,7 +918,7 @@
          {
              BlockPos blockpos = p_175666_1_.func_177972_a(enumfacing);
  
-@@ -3577,18 +3777,14 @@
+@@ -3577,18 +3785,14 @@
              {
                  IBlockState iblockstate = this.func_180495_p(blockpos);
  
@@ -896,7 +941,7 @@
                      }
                  }
              }
-@@ -3654,6 +3850,115 @@
+@@ -3654,6 +3858,115 @@
          return i >= -128 && i <= 128 && j >= -128 && j <= 128;
      }
  

--- a/src/main/java/net/minecraftforge/client/ForgeHooksClient.java
+++ b/src/main/java/net/minecraftforge/client/ForgeHooksClient.java
@@ -714,4 +714,14 @@ public class ForgeHooksClient
         if(!tr.equals(TRSRTransformation.identity())) mat = tr.getMatrix();
         return Pair.of(model, mat);
     }
+
+    public static int getBasePackedLightmapCoords(IBlockAccess worldIn, BlockPos pos)
+    {
+        return worldIn.getCombinedLight(pos, -1);
+    }
+
+    public static int combinePackedLightmapCoords(int light1, int light2)
+    {
+        return Math.max(light1 >> 20 & 15, light2 >> 20 & 15) << 20 | Math.max(light1 >> 4 & 15, light2 >> 4 & 15) << 4;
+    }
 }

--- a/src/main/java/net/minecraftforge/client/model/pipeline/VertexLighterFlat.java
+++ b/src/main/java/net/minecraftforge/client/model/pipeline/VertexLighterFlat.java
@@ -30,6 +30,7 @@ import net.minecraft.client.renderer.vertex.VertexFormatElement;
 import net.minecraft.util.EnumFacing;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.IBlockAccess;
+import net.minecraftforge.client.ForgeHooksClient;
 
 import com.google.common.base.Objects;
 
@@ -237,6 +238,8 @@ public class VertexLighterFlat extends QuadGatheringTransformer
 
         boolean full = blockInfo.getState().isFullCube();
 
+        final BlockPos posIn = pos;
+
         if((full || y < -e1) && normal[1] < -e2) pos = pos.down();
         if((full || y >  e1) && normal[1] >  e2) pos = pos.up();
         if((full || z < -e1) && normal[2] < -e2) pos = pos.north();
@@ -245,6 +248,9 @@ public class VertexLighterFlat extends QuadGatheringTransformer
         if((full || x >  e1) && normal[0] >  e2) pos = pos.east();
 
         int brightness = blockInfo.getState().getPackedLightmapCoords(blockInfo.getWorld(), pos);
+
+        if (!posIn.equals(pos))
+            brightness = ForgeHooksClient.combinePackedLightmapCoords(brightness, ForgeHooksClient.getBasePackedLightmapCoords(this.blockInfo.getWorld(), posIn));
 
         lightmap[0] = ((float)((brightness >> 0x04) & 0xF) * 0x20) / 0xFFFF;
         lightmap[1] = ((float)((brightness >> 0x14) & 0xF) * 0x20) / 0xFFFF;


### PR DESCRIPTION
I already posted this as comment on #3754.
The main purpose of this PR is to solve #2773. It should also partially solve #3754, as potentially slow calls to `Block.getLightValue(...)` are replaceed with cheaper lightmap lookups (There is still room for further optimizations through caching).

The problem described in #2773 is the following:
`Block.getLightValue(IBlockAccess, BlockPos, IBlockState)` is sometimes called with non matching `position` and `state` arguments (ie. the block at the specified `position` is not the one passed in the `state` argument). Those calls come from rendering, where `getPackedLightmapCoords` is called with the original `state` but a shifted `position` in order to determine the brightness of faces. The reason for this is probably, that faces should not have the brightness of the neighbor block, but should also take into account the brightness of the block itself, ie. faces of `sea_lantern`s should not have a brightness of 14 (light value of the neighbor air block), but the correct value of 15. Vanilla achieves this by taking `Block.getLightValue()` of the sea lantern as minimum brightness value.
In my opinion, it would make more sense to take the overall light value, calculated by the lighting engine, as minimum brightness, instead of just the source light. It shouldn't matter whether the block is bright because it is a light source or because its inside is lit up by the nighbors.
This PR removes the calls to `Block.getLightValue(...)` (and hence solves #2773) and instead uses the result of the lighting engine as base brightness. The two values (base value and brightness of the neighbor block) are combined at call site (via `ForgeHooksClient.combinePackedLightmapCoords(...)`), because we cannot pass the relevant information to `Block.getPackedLightmapCoords(...)`.
The base value can be computed by `ForgeHooksClient.getBasePackedLightmapCoords(...)`. In order to determine the base value, we shouldn't take into account `Block.useNeighborBrightness()` as otherwise faces might be too bright (From the lighting engine's  point of view, the light emitted by the block also doesn't directly use neighbor brightness). Unfortunately, `IBlockAccess` doesn't give direct access to the cached lightmap. I've implemented this by passing a `lightValue` of `-1` to `getCombinedLight()` and use that as indicator to ignore neighbor brightness. This way, we are binary compatible, at least.

One thing that is not possible with this approach:
Vanilla renders falling light sources bright. As they don't influence the lightmap, they would be rendered dark with this approach. However, I'm not sure what the intended behavior should be: While light sources should somehow be bright, they don't really emit light for the lighting engine. So it would also make sense to render them dark. Furthermore, Forge currently also renders them dark (because `Block.getLightValue()` looks up the actual block). This implementation exists for a couple of years now and no one has complained yet, so I think this wouldn't be too much of an issue.

I also patched `World.getLightFromNeighbors(...)` (and the corresponding method for `ChunkCache`) to include the light value of the block itself. Otherwise torches might be too dark. (Thanks Mojang for writing out the code 3 times... xD)

Remarks:
* There is also another place, where `Block.getLightValue(...)` is called with non matching arguments: `World.setBlockState(...)` can be called recursively for fluids during worldgen. Hence the block may be replaced by the recursive call, before `getLightValue(...)` is called (see #4199). That issue should however be addressed in another PR, if at all.
* I'm not very familiar with the rendering code, so don't be to hard on me if there is an error :)
* The current version of the PR is merely a draft for discussion. All sort of styling issues can be addressed in the end.