### PR TITLE
[1.12] Continue loading mod recipes and advancements after encountering an error

### DIFF
--- a/src/main/java/net/minecraftforge/common/ForgeHooks.java
+++ b/src/main/java/net/minecraftforge/common/ForgeHooks.java
@@ -1334,7 +1334,7 @@ public class ForgeHooks
 
                 return true;
             },
-            true
+            true, true
         );
     }
 }

--- a/src/main/java/net/minecraftforge/common/crafting/CraftingHelper.java
+++ b/src/main/java/net/minecraftforge/common/crafting/CraftingHelper.java
@@ -726,16 +726,30 @@ public class CraftingHelper {
                     IOUtils.closeQuietly(reader);
                 }
                 return true;
-            }
+            },
+            true, true
         );
     }
 
-
+    /**
+     * @deprecated Use {@link CraftingHelper#findFiles(ModContainer, String, Function, BiFunction, boolean, boolean)} instead.
+     */
+    @Deprecated
     public static boolean findFiles(ModContainer mod, String base, Function<Path, Boolean> preprocessor, BiFunction<Path, Path, Boolean> processor)
     {
-        return findFiles(mod, base, preprocessor, processor, false);
+        return findFiles(mod, base, preprocessor, processor, false, false);
     }
+
+    /**
+     * @deprecated Use {@link CraftingHelper#findFiles(ModContainer, String, Function, BiFunction, boolean, boolean)} instead.
+     */
+    @Deprecated
     public static boolean findFiles(ModContainer mod, String base, Function<Path, Boolean> preprocessor, BiFunction<Path, Path, Boolean> processor, boolean defaultUnfoundRoot)
+    {
+        return findFiles(mod, base, preprocessor, processor, defaultUnfoundRoot, false);
+    }
+
+    public static boolean findFiles(ModContainer mod, String base, Function<Path, Boolean> preprocessor, BiFunction<Path, Path, Boolean> processor, boolean defaultUnfoundRoot, boolean visitAllFiles)
     {
         FileSystem fs = null;
         try
@@ -805,8 +819,16 @@ public class CraftingHelper {
 
                 while (itr != null && itr.hasNext())
                 {
-                    Boolean ret = processor.apply(root, itr.next());
-                    success &= ret != null && ret;
+                    Boolean cont = processor.apply(root, itr.next());
+
+                    if (visitAllFiles)
+                    {
+                        success &= cont != null && cont;
+                    }
+                    else if (cont == null || !cont)
+                    {
+                        return false;
+                    }
                 }
             }
 

--- a/src/main/java/net/minecraftforge/common/crafting/CraftingHelper.java
+++ b/src/main/java/net/minecraftforge/common/crafting/CraftingHelper.java
@@ -806,7 +806,7 @@ public class CraftingHelper {
                 while (itr != null && itr.hasNext())
                 {
                     Boolean ret = processor.apply(root, itr.next());
-                    success &= ret == null ? false : ret;
+                    success &= ret != null && ret;
                 }
             }
 

--- a/src/main/java/net/minecraftforge/common/crafting/CraftingHelper.java
+++ b/src/main/java/net/minecraftforge/common/crafting/CraftingHelper.java
@@ -788,6 +788,8 @@ public class CraftingHelper {
                     return false;
             }
 
+            boolean success = true;
+
             if (processor != null)
             {
                 Iterator<Path> itr = null;
@@ -803,13 +805,12 @@ public class CraftingHelper {
 
                 while (itr != null && itr.hasNext())
                 {
-                    Boolean cont = processor.apply(root, itr.next());
-                    if (cont == null || !cont.booleanValue())
-                        return false;
+                    Boolean ret = processor.apply(root, itr.next());
+                    success &= ret == null ? false : ret;
                 }
             }
 
-            return true;
+            return success;
         }
         finally
         {

--- a/src/test/resources/assets/crafting_system_test/recipes/oak_planks_from_logs.json
+++ b/src/test/resources/assets/crafting_system_test/recipes/oak_planks_from_logs.json
@@ -1,0 +1,22 @@
+{
+  "_comment": [
+    "Cut an Oak Log into two Oak Planks with a Wooden Axe"
+  ],
+  "type": "minecraft:crafting_shapeless",
+  "group": "minecraft:planks",
+  "ingredients": [
+    {
+      "item": "minecraft:wooden_axe",
+      "data": 32767
+    },
+    {
+      "item": "minecraft:log",
+      "data": 0
+    }
+  ],
+  "result": {
+    "item": "minecraft:planks",
+    "data": 0,
+    "count": 2
+  }
+}


### PR DESCRIPTION
This fixes #4013.

Currently, `CraftingHelper.findFiles` exits after the `processor` function returns `false`;
which means that it stops loading recipes or advancements for a mod as soon as one of them has a syntax error or is otherwise invalid.

This PR changes `CraftingHelper.findFiles` to always call `processor` for every file and only return `true` if every call to `processor` returned `true`.

`CraftingHelper.findFiles` still exits early under every other failure condition (couldn't find Minecraft JAR, couldn't get filesystem iterator, `preprocessor` returned `false`), as it did previously.

To demonstrate this, I've added a recipe that should be loaded after the `conditions_property_not_array` recipe. The syntax exception in `conditions_property_not_array` would previously prevent the new recipe from loading, but the changes made in this PR allow the new recipe to be loaded and used in-game.