### PR TITLE
Better handling on MC error screen for version ranges

### DIFF
--- a/src/main/java/net/minecraftforge/fml/common/versioning/Restriction.java
+++ b/src/main/java/net/minecraftforge/fml/common/versioning/Restriction.java
@@ -215,10 +215,25 @@ public class Restriction
             if ( getLowerBound().getVersionString().equals(getUpperBound().getVersionString()) )
             {
                 return getLowerBound().getVersionString();
-            }
-            else
+            } 
+            else 
             {
-                return I18n.format("fml.messages.version.restriction.bounded", getLowerBound(), getUpperBound());
+                if (isLowerBoundInclusive() && isUpperBoundInclusive()) 
+                {
+                    return I18n.format("fml.messages.version.restriction.bounded.inclusive", getLowerBound(), getUpperBound());
+                } 
+                else if (isLowerBoundInclusive()) 
+                {
+                    return I18n.format("fml.messages.version.restriction.bounded.upperexclusive", getLowerBound(), getUpperBound());
+                } 
+                else if (isUpperBoundInclusive()) 
+                {
+                    return I18n.format("fml.messages.version.restriction.bounded.lowerexclusive", getLowerBound(), getUpperBound());
+                } 
+                else 
+                {
+                    return I18n.format("fml.messages.version.restriction.bounded.exclusive", getLowerBound(), getUpperBound());
+                }
             }
         }
         else if ( getLowerBound() != null )

--- a/src/main/resources/assets/forge/lang/en_US.lang
+++ b/src/main/resources/assets/forge/lang/en_US.lang
@@ -181,6 +181,10 @@ fml.messages.version.restriction.lower.exclusive=above %s
 fml.messages.version.restriction.upper.inclusive=%s or below
 fml.messages.version.restriction.upper.exclusive=below %s
 fml.messages.version.restriction.bounded=between %s and %s
+fml.messages.version.restriction.bounded.inclusive=between %s and %s (inclusive)
+fml.messages.version.restriction.bounded.exclusive=between %s and %s (exclusive)
+fml.messages.version.restriction.bounded.lowerexclusive=above %s, and %s or below
+fml.messages.version.restriction.bounded.upperexclusive=%s or above, and below %s
 
 fml.button.continue=Continue
 fml.button.open.mods.folder=Open Mods Folder


### PR DESCRIPTION
Previously there was ambiguity for version ranges which included exclusive ends, resulting in screens like the following:

![](http://i.imgur.com/fSZOlgp.png)

This commit improves the language for these special cases:

![](http://i.imgur.com/MiDmnrF.png)