### PR TITLE
Improve performance of World.collidesWithAnyBlock

### DIFF
--- a/patches/minecraft/net/minecraft/world/World.java.patch
+++ b/patches/minecraft/net/minecraft/world/World.java.patch
@@ -232,7 +232,7 @@
                                  iblockstate1.func_185908_a(this, blockpos$pooledmutableblockpos, p_191504_2_, p_191504_4_, p_191504_1_, false);
  
 -                                if (p_191504_3_ && !p_191504_4_.isEmpty())
-+                                if (p_191504_3_ && !net.minecraftforge.event.ForgeEventFactory.gatherCollisionBoxes(this, p_191504_1_, p_191504_2_, p_191504_4_))
++                                if (p_191504_3_)
                                  {
 +                                    if (net.minecraftforge.event.ForgeEventFactory.gatherCollisionBoxes(this, p_191504_1_, p_191504_2_, p_191504_4_)) continue;
                                      boolean flag5 = true;

--- a/patches/minecraft/net/minecraft/world/World.java.patch
+++ b/patches/minecraft/net/minecraft/world/World.java.patch
@@ -219,7 +219,15 @@
              this.func_72964_e(i, j).func_76612_a(p_72838_1_);
              this.field_72996_f.add(p_72838_1_);
              this.func_72923_a(p_72838_1_);
-@@ -1268,6 +1332,7 @@
+@@ -1227,6 +1291,7 @@
+         IBlockState iblockstate = Blocks.field_150348_b.func_176223_P();
+         BlockPos.PooledMutableBlockPos blockpos$pooledmutableblockpos = BlockPos.PooledMutableBlockPos.func_185346_s();
+ 
++        if (p_191504_3_ && !net.minecraftforge.event.ForgeEventFactory.gatherCollisionBoxes(this, p_191504_1_, p_191504_2_, p_191504_4_)) return true;
+         try
+         {
+             for (int k1 = i; k1 < j; ++k1)
+@@ -1268,9 +1333,11 @@
                                  }
  
                                  iblockstate1.func_185908_a(this, blockpos$pooledmutableblockpos, p_191504_2_, p_191504_4_, p_191504_1_, false);
@@ -227,7 +235,11 @@
  
                                  if (p_191504_3_ && !p_191504_4_.isEmpty())
                                  {
-@@ -1319,11 +1384,10 @@
++                                    if (net.minecraftforge.event.ForgeEventFactory.gatherCollisionBoxes(this, p_191504_1_, p_191504_2_, p_191504_4_)) continue;
+                                     boolean flag5 = true;
+                                     return flag5;
+                                 }
+@@ -1319,11 +1386,10 @@
                  }
              }
          }
@@ -240,7 +252,7 @@
      public void func_72848_b(IWorldEventListener p_72848_1_)
      {
          this.field_73021_x.remove(p_72848_1_);
-@@ -1361,19 +1425,38 @@
+@@ -1361,19 +1427,38 @@
  
      public int func_72967_a(float p_72967_1_)
      {
@@ -281,7 +293,7 @@
          float f = this.func_72826_c(p_72971_1_);
          float f1 = 1.0F - (MathHelper.func_76134_b(f * ((float)Math.PI * 2F)) * 2.0F + 0.2F);
          f1 = MathHelper.func_76131_a(f1, 0.0F, 1.0F);
-@@ -1386,6 +1469,12 @@
+@@ -1386,6 +1471,12 @@
      @SideOnly(Side.CLIENT)
      public Vec3d func_72833_a(Entity p_72833_1_, float p_72833_2_)
      {
@@ -294,7 +306,7 @@
          float f = this.func_72826_c(p_72833_2_);
          float f1 = MathHelper.func_76134_b(f * ((float)Math.PI * 2F)) * 2.0F + 0.5F;
          f1 = MathHelper.func_76131_a(f1, 0.0F, 1.0F);
-@@ -1393,9 +1482,7 @@
+@@ -1393,9 +1484,7 @@
          int j = MathHelper.func_76128_c(p_72833_1_.field_70163_u);
          int k = MathHelper.func_76128_c(p_72833_1_.field_70161_v);
          BlockPos blockpos = new BlockPos(i, j, k);
@@ -305,7 +317,7 @@
          float f3 = (float)(l >> 16 & 255) / 255.0F;
          float f4 = (float)(l >> 8 & 255) / 255.0F;
          float f5 = (float)(l & 255) / 255.0F;
-@@ -1444,20 +1531,25 @@
+@@ -1444,20 +1533,25 @@
  
      public float func_72826_c(float p_72826_1_)
      {
@@ -334,7 +346,7 @@
      public float func_72929_e(float p_72929_1_)
      {
          float f = this.func_72826_c(p_72929_1_);
-@@ -1467,6 +1559,12 @@
+@@ -1467,6 +1561,12 @@
      @SideOnly(Side.CLIENT)
      public Vec3d func_72824_f(float p_72824_1_)
      {
@@ -347,7 +359,7 @@
          float f = this.func_72826_c(p_72824_1_);
          float f1 = MathHelper.func_76134_b(f * ((float)Math.PI * 2F)) * 2.0F + 0.5F;
          f1 = MathHelper.func_76131_a(f1, 0.0F, 1.0F);
-@@ -1522,9 +1620,9 @@
+@@ -1522,9 +1622,9 @@
          for (blockpos = new BlockPos(p_175672_1_.func_177958_n(), chunk.func_76625_h() + 16, p_175672_1_.func_177952_p()); blockpos.func_177956_o() >= 0; blockpos = blockpos1)
          {
              blockpos1 = blockpos.func_177977_b();
@@ -359,7 +371,7 @@
              {
                  break;
              }
-@@ -1536,6 +1634,12 @@
+@@ -1536,6 +1636,12 @@
      @SideOnly(Side.CLIENT)
      public float func_72880_h(float p_72880_1_)
      {
@@ -372,7 +384,7 @@
          float f = this.func_72826_c(p_72880_1_);
          float f1 = 1.0F - (MathHelper.func_76134_b(f * ((float)Math.PI * 2F)) * 2.0F + 0.25F);
          f1 = MathHelper.func_76131_a(f1, 0.0F, 1.0F);
-@@ -1570,6 +1674,7 @@
+@@ -1570,6 +1676,7 @@
  
              try
              {
@@ -380,7 +392,7 @@
                  ++entity.field_70173_aa;
                  entity.func_70071_h_();
              }
-@@ -1587,6 +1692,12 @@
+@@ -1587,6 +1694,12 @@
                      entity.func_85029_a(crashreportcategory);
                  }
  
@@ -393,7 +405,7 @@
                  throw new ReportedException(crashreport);
              }
  
-@@ -1648,6 +1759,12 @@
+@@ -1648,6 +1761,12 @@
                      CrashReport crashreport1 = CrashReport.func_85055_a(throwable1, "Ticking entity");
                      CrashReportCategory crashreportcategory1 = crashreport1.func_85058_a("Entity being ticked");
                      entity2.func_85029_a(crashreportcategory1);
@@ -406,7 +418,7 @@
                      throw new ReportedException(crashreport1);
                  }
              }
-@@ -1674,14 +1791,23 @@
+@@ -1674,14 +1793,23 @@
  
          this.field_72984_F.func_76318_c("blockEntities");
  
@@ -433,7 +445,7 @@
          Iterator<TileEntity> iterator = this.field_175730_i.iterator();
  
          while (iterator.hasNext())
-@@ -1692,7 +1818,7 @@
+@@ -1692,7 +1820,7 @@
              {
                  BlockPos blockpos = tileentity.func_174877_v();
  
@@ -442,7 +454,7 @@
                  {
                      try
                      {
-@@ -1708,6 +1834,13 @@
+@@ -1708,6 +1836,13 @@
                          CrashReport crashreport2 = CrashReport.func_85055_a(throwable, "Ticking block entity");
                          CrashReportCategory crashreportcategory2 = crashreport2.func_85058_a("Block entity being ticked");
                          tileentity.func_145828_a(crashreportcategory2);
@@ -456,7 +468,7 @@
                          throw new ReportedException(crashreport2);
                      }
                  }
-@@ -1720,7 +1853,10 @@
+@@ -1720,7 +1855,10 @@
  
                  if (this.func_175667_e(tileentity.func_174877_v()))
                  {
@@ -468,7 +480,7 @@
                  }
              }
          }
-@@ -1764,12 +1900,18 @@
+@@ -1764,12 +1902,18 @@
  
      public boolean func_175700_a(TileEntity p_175700_1_)
      {
@@ -487,7 +499,7 @@
  
          if (this.field_72995_K)
          {
-@@ -1785,6 +1927,11 @@
+@@ -1785,6 +1929,11 @@
      {
          if (this.field_147481_N)
          {
@@ -499,7 +511,7 @@
              this.field_147484_a.addAll(p_147448_1_);
          }
          else
-@@ -1807,9 +1954,13 @@
+@@ -1807,9 +1956,13 @@
          {
              int j2 = MathHelper.func_76128_c(p_72866_1_.field_70165_t);
              int k2 = MathHelper.func_76128_c(p_72866_1_.field_70161_v);
@@ -515,7 +527,7 @@
              {
                  return;
              }
-@@ -1831,6 +1982,7 @@
+@@ -1831,6 +1984,7 @@
              }
              else
              {
@@ -523,7 +535,7 @@
                  p_72866_1_.func_70071_h_();
              }
          }
-@@ -2011,6 +2163,11 @@
+@@ -2011,6 +2165,11 @@
                              blockpos$pooledmutableblockpos.func_185344_t();
                              return true;
                          }
@@ -535,7 +547,7 @@
                      }
                  }
              }
-@@ -2050,6 +2207,16 @@
+@@ -2050,6 +2209,16 @@
                          IBlockState iblockstate1 = this.func_180495_p(blockpos$pooledmutableblockpos);
                          Block block = iblockstate1.func_177230_c();
  
@@ -552,7 +564,7 @@
                          if (iblockstate1.func_185904_a() == p_72918_2_)
                          {
                              double d0 = (double)((float)(i4 + 1) - BlockLiquid.func_149801_b(((Integer)iblockstate1.func_177229_b(BlockLiquid.field_176367_b)).intValue()));
-@@ -2116,6 +2283,7 @@
+@@ -2116,6 +2285,7 @@
      public Explosion func_72885_a(@Nullable Entity p_72885_1_, double p_72885_2_, double p_72885_4_, double p_72885_6_, float p_72885_8_, boolean p_72885_9_, boolean p_72885_10_)
      {
          Explosion explosion = new Explosion(this, p_72885_1_, p_72885_2_, p_72885_4_, p_72885_6_, p_72885_8_, p_72885_9_, p_72885_10_);
@@ -560,7 +572,7 @@
          explosion.func_77278_a();
          explosion.func_77279_a(true);
          return explosion;
-@@ -2238,6 +2406,7 @@
+@@ -2238,6 +2408,7 @@
  
      public void func_175690_a(BlockPos p_175690_1_, @Nullable TileEntity p_175690_2_)
      {
@@ -568,7 +580,7 @@
          if (!this.func_189509_E(p_175690_1_))
          {
              if (p_175690_2_ != null && !p_175690_2_.func_145837_r())
-@@ -2245,6 +2414,8 @@
+@@ -2245,6 +2416,8 @@
                  if (this.field_147481_N)
                  {
                      p_175690_2_.func_174878_a(p_175690_1_);
@@ -577,7 +589,7 @@
                      Iterator<TileEntity> iterator1 = this.field_147484_a.iterator();
  
                      while (iterator1.hasNext())
-@@ -2262,7 +2433,8 @@
+@@ -2262,7 +2435,8 @@
                  }
                  else
                  {
@@ -587,7 +599,7 @@
                      this.func_175700_a(p_175690_2_);
                  }
              }
-@@ -2277,6 +2449,8 @@
+@@ -2277,6 +2451,8 @@
          {
              tileentity2.func_145843_s();
              this.field_147484_a.remove(tileentity2);
@@ -596,7 +608,7 @@
          }
          else
          {
-@@ -2289,6 +2463,7 @@
+@@ -2289,6 +2465,7 @@
  
              this.func_175726_f(p_175713_1_).func_177425_e(p_175713_1_);
          }
@@ -604,7 +616,7 @@
      }
  
      public void func_147457_a(TileEntity p_147457_1_)
-@@ -2315,7 +2490,7 @@
+@@ -2315,7 +2492,7 @@
              if (chunk1 != null && !chunk1.func_76621_g())
              {
                  IBlockState iblockstate1 = this.func_180495_p(p_175677_1_);
@@ -613,7 +625,7 @@
              }
              else
              {
-@@ -2338,6 +2513,7 @@
+@@ -2338,6 +2515,7 @@
      {
          this.field_72985_G = p_72891_1_;
          this.field_72992_H = p_72891_2_;
@@ -621,7 +633,7 @@
      }
  
      public void func_72835_b()
-@@ -2347,6 +2523,11 @@
+@@ -2347,6 +2525,11 @@
  
      protected void func_72947_a()
      {
@@ -633,7 +645,7 @@
          if (this.field_72986_A.func_76059_o())
          {
              this.field_73004_o = 1.0F;
-@@ -2360,6 +2541,11 @@
+@@ -2360,6 +2543,11 @@
  
      protected void func_72979_l()
      {
@@ -645,7 +657,7 @@
          if (this.field_73011_w.func_191066_m())
          {
              if (!this.field_72995_K)
-@@ -2484,6 +2670,11 @@
+@@ -2484,6 +2672,11 @@
  
      public boolean func_175670_e(BlockPos p_175670_1_, boolean p_175670_2_)
      {
@@ -657,7 +669,7 @@
          Biome biome = this.func_180494_b(p_175670_1_);
          float f = biome.func_180626_a(p_175670_1_);
  
-@@ -2525,6 +2716,11 @@
+@@ -2525,6 +2718,11 @@
  
      public boolean func_175708_f(BlockPos p_175708_1_, boolean p_175708_2_)
      {
@@ -669,7 +681,7 @@
          Biome biome = this.func_180494_b(p_175708_1_);
          float f = biome.func_180626_a(p_175708_1_);
  
-@@ -2542,7 +2738,7 @@
+@@ -2542,7 +2740,7 @@
              {
                  IBlockState iblockstate1 = this.func_180495_p(p_175708_1_);
  
@@ -678,7 +690,7 @@
                  {
                      return true;
                  }
-@@ -2574,10 +2770,11 @@
+@@ -2574,10 +2772,11 @@
          else
          {
              IBlockState iblockstate1 = this.func_180495_p(p_175638_1_);
@@ -693,7 +705,7 @@
              {
                  k2 = 1;
              }
-@@ -2683,7 +2880,8 @@
+@@ -2683,7 +2882,8 @@
                                      int k6 = k4 + enumfacing.func_96559_d();
                                      int l6 = l4 + enumfacing.func_82599_e();
                                      blockpos$pooledmutableblockpos.func_181079_c(j6, k6, l6);
@@ -703,7 +715,7 @@
                                      j5 = this.func_175642_b(p_180500_1_, blockpos$pooledmutableblockpos);
  
                                      if (j5 == i5 - i7 && k2 < this.field_72994_J.length)
-@@ -2791,10 +2989,10 @@
+@@ -2791,10 +2991,10 @@
      public List<Entity> func_175674_a(@Nullable Entity p_175674_1_, AxisAlignedBB p_175674_2_, @Nullable Predicate <? super Entity > p_175674_3_)
      {
          List<Entity> list = Lists.<Entity>newArrayList();
@@ -718,7 +730,7 @@
  
          for (int j3 = j2; j3 <= k2; ++j3)
          {
-@@ -2847,10 +3045,10 @@
+@@ -2847,10 +3047,10 @@
  
      public <T extends Entity> List<T> func_175647_a(Class <? extends T > p_175647_1_, AxisAlignedBB p_175647_2_, @Nullable Predicate <? super T > p_175647_3_)
      {
@@ -733,7 +745,7 @@
          List<T> list = Lists.<T>newArrayList();
  
          for (int j3 = j2; j3 < k2; ++j3)
-@@ -2930,11 +3128,13 @@
+@@ -2930,11 +3130,13 @@
  
      public void func_175650_b(Collection<Entity> p_175650_1_)
      {
@@ -750,7 +762,7 @@
          }
      }
  
-@@ -2958,7 +3158,7 @@
+@@ -2958,7 +3160,7 @@
          }
          else
          {
@@ -759,7 +771,7 @@
          }
      }
  
-@@ -3042,7 +3242,7 @@
+@@ -3042,7 +3244,7 @@
      public int func_175651_c(BlockPos p_175651_1_, EnumFacing p_175651_2_)
      {
          IBlockState iblockstate1 = this.func_180495_p(p_175651_1_);
@@ -768,7 +780,7 @@
      }
  
      public boolean func_175640_z(BlockPos p_175640_1_)
-@@ -3208,6 +3408,8 @@
+@@ -3208,6 +3410,8 @@
                      d2 *= ((Double)MoreObjects.firstNonNull(p_184150_11_.apply(entityplayer1), Double.valueOf(1.0D))).doubleValue();
                  }
  
@@ -777,7 +789,7 @@
                  if ((p_184150_9_ < 0.0D || Math.abs(entityplayer1.field_70163_u - p_184150_3_) < p_184150_9_ * p_184150_9_) && (p_184150_7_ < 0.0D || d1 < d2 * d2) && (d0 == -1.0D || d1 < d0))
                  {
                      d0 = d1;
-@@ -3269,7 +3471,7 @@
+@@ -3269,7 +3473,7 @@
  
      public long func_72905_C()
      {
@@ -786,7 +798,7 @@
      }
  
      public long func_82737_E()
-@@ -3279,17 +3481,17 @@
+@@ -3279,17 +3483,17 @@
  
      public long func_72820_D()
      {
@@ -807,7 +819,7 @@
  
          if (!this.func_175723_af().func_177746_a(blockpos1))
          {
-@@ -3301,7 +3503,7 @@
+@@ -3301,7 +3505,7 @@
  
      public void func_175652_B(BlockPos p_175652_1_)
      {
@@ -816,7 +828,7 @@
      }
  
      @SideOnly(Side.CLIENT)
-@@ -3321,12 +3523,18 @@
+@@ -3321,12 +3525,18 @@
  
          if (!this.field_72996_f.contains(p_72897_1_))
          {
@@ -835,7 +847,7 @@
          return true;
      }
  
-@@ -3428,8 +3636,7 @@
+@@ -3428,8 +3638,7 @@
  
      public boolean func_180502_D(BlockPos p_180502_1_)
      {
@@ -845,7 +857,7 @@
      }
  
      @Nullable
-@@ -3490,12 +3697,12 @@
+@@ -3490,12 +3699,12 @@
  
      public int func_72800_K()
      {
@@ -860,7 +872,7 @@
      }
  
      public Random func_72843_D(int p_72843_1_, int p_72843_2_, int p_72843_3_)
-@@ -3539,7 +3746,7 @@
+@@ -3539,7 +3748,7 @@
      @SideOnly(Side.CLIENT)
      public double func_72919_O()
      {
@@ -869,7 +881,7 @@
      }
  
      public void func_175715_c(int p_175715_1_, BlockPos p_175715_2_, int p_175715_3_)
-@@ -3573,7 +3780,7 @@
+@@ -3573,7 +3782,7 @@
  
      public void func_175666_e(BlockPos p_175666_1_, Block p_175666_2_)
      {
@@ -878,7 +890,7 @@
          {
              BlockPos blockpos1 = p_175666_1_.func_177972_a(enumfacing);
  
-@@ -3581,18 +3788,15 @@
+@@ -3581,18 +3790,15 @@
              {
                  IBlockState iblockstate1 = this.func_180495_p(blockpos1);
  
@@ -901,7 +913,7 @@
                      }
                  }
              }
-@@ -3658,6 +3862,124 @@
+@@ -3658,6 +3864,124 @@
          return j2 >= -128 && j2 <= 128 && k2 >= -128 && k2 <= 128;
      }
  

--- a/patches/minecraft/net/minecraft/world/World.java.patch
+++ b/patches/minecraft/net/minecraft/world/World.java.patch
@@ -227,18 +227,16 @@
          try
          {
              for (int k1 = i; k1 < j; ++k1)
-@@ -1269,8 +1334,9 @@
+@@ -1269,7 +1334,7 @@
  
                                  iblockstate1.func_185908_a(this, blockpos$pooledmutableblockpos, p_191504_2_, p_191504_4_, p_191504_1_, false);
  
 -                                if (p_191504_3_ && !p_191504_4_.isEmpty())
-+                                if (p_191504_3_)
++                                if (p_191504_3_ && !net.minecraftforge.event.ForgeEventFactory.gatherCollisionBoxes(this, p_191504_1_, p_191504_2_, p_191504_4_))
                                  {
-+                                    if (net.minecraftforge.event.ForgeEventFactory.gatherCollisionBoxes(this, p_191504_1_, p_191504_2_, p_191504_4_)) continue;
                                      boolean flag5 = true;
                                      return flag5;
-                                 }
-@@ -1319,11 +1385,10 @@
+@@ -1319,11 +1384,10 @@
                  }
              }
          }
@@ -251,7 +249,7 @@
      public void func_72848_b(IWorldEventListener p_72848_1_)
      {
          this.field_73021_x.remove(p_72848_1_);
-@@ -1361,19 +1426,38 @@
+@@ -1361,19 +1425,38 @@
  
      public int func_72967_a(float p_72967_1_)
      {
@@ -292,7 +290,7 @@
          float f = this.func_72826_c(p_72971_1_);
          float f1 = 1.0F - (MathHelper.func_76134_b(f * ((float)Math.PI * 2F)) * 2.0F + 0.2F);
          f1 = MathHelper.func_76131_a(f1, 0.0F, 1.0F);
-@@ -1386,6 +1470,12 @@
+@@ -1386,6 +1469,12 @@
      @SideOnly(Side.CLIENT)
      public Vec3d func_72833_a(Entity p_72833_1_, float p_72833_2_)
      {
@@ -305,7 +303,7 @@
          float f = this.func_72826_c(p_72833_2_);
          float f1 = MathHelper.func_76134_b(f * ((float)Math.PI * 2F)) * 2.0F + 0.5F;
          f1 = MathHelper.func_76131_a(f1, 0.0F, 1.0F);
-@@ -1393,9 +1483,7 @@
+@@ -1393,9 +1482,7 @@
          int j = MathHelper.func_76128_c(p_72833_1_.field_70163_u);
          int k = MathHelper.func_76128_c(p_72833_1_.field_70161_v);
          BlockPos blockpos = new BlockPos(i, j, k);
@@ -316,7 +314,7 @@
          float f3 = (float)(l >> 16 & 255) / 255.0F;
          float f4 = (float)(l >> 8 & 255) / 255.0F;
          float f5 = (float)(l & 255) / 255.0F;
-@@ -1444,20 +1532,25 @@
+@@ -1444,20 +1531,25 @@
  
      public float func_72826_c(float p_72826_1_)
      {
@@ -345,7 +343,7 @@
      public float func_72929_e(float p_72929_1_)
      {
          float f = this.func_72826_c(p_72929_1_);
-@@ -1467,6 +1560,12 @@
+@@ -1467,6 +1559,12 @@
      @SideOnly(Side.CLIENT)
      public Vec3d func_72824_f(float p_72824_1_)
      {
@@ -358,7 +356,7 @@
          float f = this.func_72826_c(p_72824_1_);
          float f1 = MathHelper.func_76134_b(f * ((float)Math.PI * 2F)) * 2.0F + 0.5F;
          f1 = MathHelper.func_76131_a(f1, 0.0F, 1.0F);
-@@ -1522,9 +1621,9 @@
+@@ -1522,9 +1620,9 @@
          for (blockpos = new BlockPos(p_175672_1_.func_177958_n(), chunk.func_76625_h() + 16, p_175672_1_.func_177952_p()); blockpos.func_177956_o() >= 0; blockpos = blockpos1)
          {
              blockpos1 = blockpos.func_177977_b();
@@ -370,7 +368,7 @@
              {
                  break;
              }
-@@ -1536,6 +1635,12 @@
+@@ -1536,6 +1634,12 @@
      @SideOnly(Side.CLIENT)
      public float func_72880_h(float p_72880_1_)
      {
@@ -383,7 +381,7 @@
          float f = this.func_72826_c(p_72880_1_);
          float f1 = 1.0F - (MathHelper.func_76134_b(f * ((float)Math.PI * 2F)) * 2.0F + 0.25F);
          f1 = MathHelper.func_76131_a(f1, 0.0F, 1.0F);
-@@ -1570,6 +1675,7 @@
+@@ -1570,6 +1674,7 @@
  
              try
              {
@@ -391,7 +389,7 @@
                  ++entity.field_70173_aa;
                  entity.func_70071_h_();
              }
-@@ -1587,6 +1693,12 @@
+@@ -1587,6 +1692,12 @@
                      entity.func_85029_a(crashreportcategory);
                  }
  
@@ -404,7 +402,7 @@
                  throw new ReportedException(crashreport);
              }
  
-@@ -1648,6 +1760,12 @@
+@@ -1648,6 +1759,12 @@
                      CrashReport crashreport1 = CrashReport.func_85055_a(throwable1, "Ticking entity");
                      CrashReportCategory crashreportcategory1 = crashreport1.func_85058_a("Entity being ticked");
                      entity2.func_85029_a(crashreportcategory1);
@@ -417,7 +415,7 @@
                      throw new ReportedException(crashreport1);
                  }
              }
-@@ -1674,14 +1792,23 @@
+@@ -1674,14 +1791,23 @@
  
          this.field_72984_F.func_76318_c("blockEntities");
  
@@ -444,7 +442,7 @@
          Iterator<TileEntity> iterator = this.field_175730_i.iterator();
  
          while (iterator.hasNext())
-@@ -1692,7 +1819,7 @@
+@@ -1692,7 +1818,7 @@
              {
                  BlockPos blockpos = tileentity.func_174877_v();
  
@@ -453,7 +451,7 @@
                  {
                      try
                      {
-@@ -1708,6 +1835,13 @@
+@@ -1708,6 +1834,13 @@
                          CrashReport crashreport2 = CrashReport.func_85055_a(throwable, "Ticking block entity");
                          CrashReportCategory crashreportcategory2 = crashreport2.func_85058_a("Block entity being ticked");
                          tileentity.func_145828_a(crashreportcategory2);
@@ -467,7 +465,7 @@
                          throw new ReportedException(crashreport2);
                      }
                  }
-@@ -1720,7 +1854,10 @@
+@@ -1720,7 +1853,10 @@
  
                  if (this.func_175667_e(tileentity.func_174877_v()))
                  {
@@ -479,7 +477,7 @@
                  }
              }
          }
-@@ -1764,12 +1901,18 @@
+@@ -1764,12 +1900,18 @@
  
      public boolean func_175700_a(TileEntity p_175700_1_)
      {
@@ -498,7 +496,7 @@
  
          if (this.field_72995_K)
          {
-@@ -1785,6 +1928,11 @@
+@@ -1785,6 +1927,11 @@
      {
          if (this.field_147481_N)
          {
@@ -510,7 +508,7 @@
              this.field_147484_a.addAll(p_147448_1_);
          }
          else
-@@ -1807,9 +1955,13 @@
+@@ -1807,9 +1954,13 @@
          {
              int j2 = MathHelper.func_76128_c(p_72866_1_.field_70165_t);
              int k2 = MathHelper.func_76128_c(p_72866_1_.field_70161_v);
@@ -526,7 +524,7 @@
              {
                  return;
              }
-@@ -1831,6 +1983,7 @@
+@@ -1831,6 +1982,7 @@
              }
              else
              {
@@ -534,7 +532,7 @@
                  p_72866_1_.func_70071_h_();
              }
          }
-@@ -2011,6 +2164,11 @@
+@@ -2011,6 +2163,11 @@
                              blockpos$pooledmutableblockpos.func_185344_t();
                              return true;
                          }
@@ -546,7 +544,7 @@
                      }
                  }
              }
-@@ -2050,6 +2208,16 @@
+@@ -2050,6 +2207,16 @@
                          IBlockState iblockstate1 = this.func_180495_p(blockpos$pooledmutableblockpos);
                          Block block = iblockstate1.func_177230_c();
  
@@ -563,7 +561,7 @@
                          if (iblockstate1.func_185904_a() == p_72918_2_)
                          {
                              double d0 = (double)((float)(i4 + 1) - BlockLiquid.func_149801_b(((Integer)iblockstate1.func_177229_b(BlockLiquid.field_176367_b)).intValue()));
-@@ -2116,6 +2284,7 @@
+@@ -2116,6 +2283,7 @@
      public Explosion func_72885_a(@Nullable Entity p_72885_1_, double p_72885_2_, double p_72885_4_, double p_72885_6_, float p_72885_8_, boolean p_72885_9_, boolean p_72885_10_)
      {
          Explosion explosion = new Explosion(this, p_72885_1_, p_72885_2_, p_72885_4_, p_72885_6_, p_72885_8_, p_72885_9_, p_72885_10_);
@@ -571,7 +569,7 @@
          explosion.func_77278_a();
          explosion.func_77279_a(true);
          return explosion;
-@@ -2238,6 +2407,7 @@
+@@ -2238,6 +2406,7 @@
  
      public void func_175690_a(BlockPos p_175690_1_, @Nullable TileEntity p_175690_2_)
      {
@@ -579,7 +577,7 @@
          if (!this.func_189509_E(p_175690_1_))
          {
              if (p_175690_2_ != null && !p_175690_2_.func_145837_r())
-@@ -2245,6 +2415,8 @@
+@@ -2245,6 +2414,8 @@
                  if (this.field_147481_N)
                  {
                      p_175690_2_.func_174878_a(p_175690_1_);
@@ -588,7 +586,7 @@
                      Iterator<TileEntity> iterator1 = this.field_147484_a.iterator();
  
                      while (iterator1.hasNext())
-@@ -2262,7 +2434,8 @@
+@@ -2262,7 +2433,8 @@
                  }
                  else
                  {
@@ -598,7 +596,7 @@
                      this.func_175700_a(p_175690_2_);
                  }
              }
-@@ -2277,6 +2450,8 @@
+@@ -2277,6 +2449,8 @@
          {
              tileentity2.func_145843_s();
              this.field_147484_a.remove(tileentity2);
@@ -607,7 +605,7 @@
          }
          else
          {
-@@ -2289,6 +2464,7 @@
+@@ -2289,6 +2463,7 @@
  
              this.func_175726_f(p_175713_1_).func_177425_e(p_175713_1_);
          }
@@ -615,7 +613,7 @@
      }
  
      public void func_147457_a(TileEntity p_147457_1_)
-@@ -2315,7 +2491,7 @@
+@@ -2315,7 +2490,7 @@
              if (chunk1 != null && !chunk1.func_76621_g())
              {
                  IBlockState iblockstate1 = this.func_180495_p(p_175677_1_);
@@ -624,7 +622,7 @@
              }
              else
              {
-@@ -2338,6 +2514,7 @@
+@@ -2338,6 +2513,7 @@
      {
          this.field_72985_G = p_72891_1_;
          this.field_72992_H = p_72891_2_;
@@ -632,7 +630,7 @@
      }
  
      public void func_72835_b()
-@@ -2347,6 +2524,11 @@
+@@ -2347,6 +2523,11 @@
  
      protected void func_72947_a()
      {
@@ -644,7 +642,7 @@
          if (this.field_72986_A.func_76059_o())
          {
              this.field_73004_o = 1.0F;
-@@ -2360,6 +2542,11 @@
+@@ -2360,6 +2541,11 @@
  
      protected void func_72979_l()
      {
@@ -656,7 +654,7 @@
          if (this.field_73011_w.func_191066_m())
          {
              if (!this.field_72995_K)
-@@ -2484,6 +2671,11 @@
+@@ -2484,6 +2670,11 @@
  
      public boolean func_175670_e(BlockPos p_175670_1_, boolean p_175670_2_)
      {
@@ -668,7 +666,7 @@
          Biome biome = this.func_180494_b(p_175670_1_);
          float f = biome.func_180626_a(p_175670_1_);
  
-@@ -2525,6 +2717,11 @@
+@@ -2525,6 +2716,11 @@
  
      public boolean func_175708_f(BlockPos p_175708_1_, boolean p_175708_2_)
      {
@@ -680,7 +678,7 @@
          Biome biome = this.func_180494_b(p_175708_1_);
          float f = biome.func_180626_a(p_175708_1_);
  
-@@ -2542,7 +2739,7 @@
+@@ -2542,7 +2738,7 @@
              {
                  IBlockState iblockstate1 = this.func_180495_p(p_175708_1_);
  
@@ -689,7 +687,7 @@
                  {
                      return true;
                  }
-@@ -2574,10 +2771,11 @@
+@@ -2574,10 +2770,11 @@
          else
          {
              IBlockState iblockstate1 = this.func_180495_p(p_175638_1_);
@@ -704,7 +702,7 @@
              {
                  k2 = 1;
              }
-@@ -2683,7 +2881,8 @@
+@@ -2683,7 +2880,8 @@
                                      int k6 = k4 + enumfacing.func_96559_d();
                                      int l6 = l4 + enumfacing.func_82599_e();
                                      blockpos$pooledmutableblockpos.func_181079_c(j6, k6, l6);
@@ -714,7 +712,7 @@
                                      j5 = this.func_175642_b(p_180500_1_, blockpos$pooledmutableblockpos);
  
                                      if (j5 == i5 - i7 && k2 < this.field_72994_J.length)
-@@ -2791,10 +2990,10 @@
+@@ -2791,10 +2989,10 @@
      public List<Entity> func_175674_a(@Nullable Entity p_175674_1_, AxisAlignedBB p_175674_2_, @Nullable Predicate <? super Entity > p_175674_3_)
      {
          List<Entity> list = Lists.<Entity>newArrayList();
@@ -729,7 +727,7 @@
  
          for (int j3 = j2; j3 <= k2; ++j3)
          {
-@@ -2847,10 +3046,10 @@
+@@ -2847,10 +3045,10 @@
  
      public <T extends Entity> List<T> func_175647_a(Class <? extends T > p_175647_1_, AxisAlignedBB p_175647_2_, @Nullable Predicate <? super T > p_175647_3_)
      {
@@ -744,7 +742,7 @@
          List<T> list = Lists.<T>newArrayList();
  
          for (int j3 = j2; j3 < k2; ++j3)
-@@ -2930,11 +3129,13 @@
+@@ -2930,11 +3128,13 @@
  
      public void func_175650_b(Collection<Entity> p_175650_1_)
      {
@@ -761,7 +759,7 @@
          }
      }
  
-@@ -2958,7 +3159,7 @@
+@@ -2958,7 +3158,7 @@
          }
          else
          {
@@ -770,7 +768,7 @@
          }
      }
  
-@@ -3042,7 +3243,7 @@
+@@ -3042,7 +3242,7 @@
      public int func_175651_c(BlockPos p_175651_1_, EnumFacing p_175651_2_)
      {
          IBlockState iblockstate1 = this.func_180495_p(p_175651_1_);
@@ -779,7 +777,7 @@
      }
  
      public boolean func_175640_z(BlockPos p_175640_1_)
-@@ -3208,6 +3409,8 @@
+@@ -3208,6 +3408,8 @@
                      d2 *= ((Double)MoreObjects.firstNonNull(p_184150_11_.apply(entityplayer1), Double.valueOf(1.0D))).doubleValue();
                  }
  
@@ -788,7 +786,7 @@
                  if ((p_184150_9_ < 0.0D || Math.abs(entityplayer1.field_70163_u - p_184150_3_) < p_184150_9_ * p_184150_9_) && (p_184150_7_ < 0.0D || d1 < d2 * d2) && (d0 == -1.0D || d1 < d0))
                  {
                      d0 = d1;
-@@ -3269,7 +3472,7 @@
+@@ -3269,7 +3471,7 @@
  
      public long func_72905_C()
      {
@@ -797,7 +795,7 @@
      }
  
      public long func_82737_E()
-@@ -3279,17 +3482,17 @@
+@@ -3279,17 +3481,17 @@
  
      public long func_72820_D()
      {
@@ -818,7 +816,7 @@
  
          if (!this.func_175723_af().func_177746_a(blockpos1))
          {
-@@ -3301,7 +3504,7 @@
+@@ -3301,7 +3503,7 @@
  
      public void func_175652_B(BlockPos p_175652_1_)
      {
@@ -827,7 +825,7 @@
      }
  
      @SideOnly(Side.CLIENT)
-@@ -3321,12 +3524,18 @@
+@@ -3321,12 +3523,18 @@
  
          if (!this.field_72996_f.contains(p_72897_1_))
          {
@@ -846,7 +844,7 @@
          return true;
      }
  
-@@ -3428,8 +3637,7 @@
+@@ -3428,8 +3636,7 @@
  
      public boolean func_180502_D(BlockPos p_180502_1_)
      {
@@ -856,7 +854,7 @@
      }
  
      @Nullable
-@@ -3490,12 +3698,12 @@
+@@ -3490,12 +3697,12 @@
  
      public int func_72800_K()
      {
@@ -871,7 +869,7 @@
      }
  
      public Random func_72843_D(int p_72843_1_, int p_72843_2_, int p_72843_3_)
-@@ -3539,7 +3747,7 @@
+@@ -3539,7 +3746,7 @@
      @SideOnly(Side.CLIENT)
      public double func_72919_O()
      {
@@ -880,7 +878,7 @@
      }
  
      public void func_175715_c(int p_175715_1_, BlockPos p_175715_2_, int p_175715_3_)
-@@ -3573,7 +3781,7 @@
+@@ -3573,7 +3780,7 @@
  
      public void func_175666_e(BlockPos p_175666_1_, Block p_175666_2_)
      {
@@ -889,7 +887,7 @@
          {
              BlockPos blockpos1 = p_175666_1_.func_177972_a(enumfacing);
  
-@@ -3581,18 +3789,15 @@
+@@ -3581,18 +3788,15 @@
              {
                  IBlockState iblockstate1 = this.func_180495_p(blockpos1);
  
@@ -912,7 +910,7 @@
                      }
                  }
              }
-@@ -3658,6 +3863,124 @@
+@@ -3658,6 +3862,124 @@
          return j2 >= -128 && j2 <= 128 && k2 >= -128 && k2 <= 128;
      }
  

--- a/patches/minecraft/net/minecraft/world/World.java.patch
+++ b/patches/minecraft/net/minecraft/world/World.java.patch
@@ -227,19 +227,18 @@
          try
          {
              for (int k1 = i; k1 < j; ++k1)
-@@ -1268,9 +1333,11 @@
-                                 }
+@@ -1269,8 +1334,9 @@
  
                                  iblockstate1.func_185908_a(this, blockpos$pooledmutableblockpos, p_191504_2_, p_191504_4_, p_191504_1_, false);
-+                                net.minecraftforge.common.MinecraftForge.EVENT_BUS.post(new net.minecraftforge.event.world.GetCollisionBoxesEvent(this, null, p_191504_2_, p_191504_4_));
  
-                                 if (p_191504_3_ && !p_191504_4_.isEmpty())
+-                                if (p_191504_3_ && !p_191504_4_.isEmpty())
++                                if (p_191504_3_ && !net.minecraftforge.event.ForgeEventFactory.gatherCollisionBoxes(this, p_191504_1_, p_191504_2_, p_191504_4_))
                                  {
 +                                    if (net.minecraftforge.event.ForgeEventFactory.gatherCollisionBoxes(this, p_191504_1_, p_191504_2_, p_191504_4_)) continue;
                                      boolean flag5 = true;
                                      return flag5;
                                  }
-@@ -1319,11 +1386,10 @@
+@@ -1319,11 +1385,10 @@
                  }
              }
          }
@@ -252,7 +251,7 @@
      public void func_72848_b(IWorldEventListener p_72848_1_)
      {
          this.field_73021_x.remove(p_72848_1_);
-@@ -1361,19 +1427,38 @@
+@@ -1361,19 +1426,38 @@
  
      public int func_72967_a(float p_72967_1_)
      {
@@ -293,7 +292,7 @@
          float f = this.func_72826_c(p_72971_1_);
          float f1 = 1.0F - (MathHelper.func_76134_b(f * ((float)Math.PI * 2F)) * 2.0F + 0.2F);
          f1 = MathHelper.func_76131_a(f1, 0.0F, 1.0F);
-@@ -1386,6 +1471,12 @@
+@@ -1386,6 +1470,12 @@
      @SideOnly(Side.CLIENT)
      public Vec3d func_72833_a(Entity p_72833_1_, float p_72833_2_)
      {
@@ -306,7 +305,7 @@
          float f = this.func_72826_c(p_72833_2_);
          float f1 = MathHelper.func_76134_b(f * ((float)Math.PI * 2F)) * 2.0F + 0.5F;
          f1 = MathHelper.func_76131_a(f1, 0.0F, 1.0F);
-@@ -1393,9 +1484,7 @@
+@@ -1393,9 +1483,7 @@
          int j = MathHelper.func_76128_c(p_72833_1_.field_70163_u);
          int k = MathHelper.func_76128_c(p_72833_1_.field_70161_v);
          BlockPos blockpos = new BlockPos(i, j, k);
@@ -317,7 +316,7 @@
          float f3 = (float)(l >> 16 & 255) / 255.0F;
          float f4 = (float)(l >> 8 & 255) / 255.0F;
          float f5 = (float)(l & 255) / 255.0F;
-@@ -1444,20 +1533,25 @@
+@@ -1444,20 +1532,25 @@
  
      public float func_72826_c(float p_72826_1_)
      {
@@ -346,7 +345,7 @@
      public float func_72929_e(float p_72929_1_)
      {
          float f = this.func_72826_c(p_72929_1_);
-@@ -1467,6 +1561,12 @@
+@@ -1467,6 +1560,12 @@
      @SideOnly(Side.CLIENT)
      public Vec3d func_72824_f(float p_72824_1_)
      {
@@ -359,7 +358,7 @@
          float f = this.func_72826_c(p_72824_1_);
          float f1 = MathHelper.func_76134_b(f * ((float)Math.PI * 2F)) * 2.0F + 0.5F;
          f1 = MathHelper.func_76131_a(f1, 0.0F, 1.0F);
-@@ -1522,9 +1622,9 @@
+@@ -1522,9 +1621,9 @@
          for (blockpos = new BlockPos(p_175672_1_.func_177958_n(), chunk.func_76625_h() + 16, p_175672_1_.func_177952_p()); blockpos.func_177956_o() >= 0; blockpos = blockpos1)
          {
              blockpos1 = blockpos.func_177977_b();
@@ -371,7 +370,7 @@
              {
                  break;
              }
-@@ -1536,6 +1636,12 @@
+@@ -1536,6 +1635,12 @@
      @SideOnly(Side.CLIENT)
      public float func_72880_h(float p_72880_1_)
      {
@@ -384,7 +383,7 @@
          float f = this.func_72826_c(p_72880_1_);
          float f1 = 1.0F - (MathHelper.func_76134_b(f * ((float)Math.PI * 2F)) * 2.0F + 0.25F);
          f1 = MathHelper.func_76131_a(f1, 0.0F, 1.0F);
-@@ -1570,6 +1676,7 @@
+@@ -1570,6 +1675,7 @@
  
              try
              {
@@ -392,7 +391,7 @@
                  ++entity.field_70173_aa;
                  entity.func_70071_h_();
              }
-@@ -1587,6 +1694,12 @@
+@@ -1587,6 +1693,12 @@
                      entity.func_85029_a(crashreportcategory);
                  }
  
@@ -405,7 +404,7 @@
                  throw new ReportedException(crashreport);
              }
  
-@@ -1648,6 +1761,12 @@
+@@ -1648,6 +1760,12 @@
                      CrashReport crashreport1 = CrashReport.func_85055_a(throwable1, "Ticking entity");
                      CrashReportCategory crashreportcategory1 = crashreport1.func_85058_a("Entity being ticked");
                      entity2.func_85029_a(crashreportcategory1);
@@ -418,7 +417,7 @@
                      throw new ReportedException(crashreport1);
                  }
              }
-@@ -1674,14 +1793,23 @@
+@@ -1674,14 +1792,23 @@
  
          this.field_72984_F.func_76318_c("blockEntities");
  
@@ -445,7 +444,7 @@
          Iterator<TileEntity> iterator = this.field_175730_i.iterator();
  
          while (iterator.hasNext())
-@@ -1692,7 +1820,7 @@
+@@ -1692,7 +1819,7 @@
              {
                  BlockPos blockpos = tileentity.func_174877_v();
  
@@ -454,7 +453,7 @@
                  {
                      try
                      {
-@@ -1708,6 +1836,13 @@
+@@ -1708,6 +1835,13 @@
                          CrashReport crashreport2 = CrashReport.func_85055_a(throwable, "Ticking block entity");
                          CrashReportCategory crashreportcategory2 = crashreport2.func_85058_a("Block entity being ticked");
                          tileentity.func_145828_a(crashreportcategory2);
@@ -468,7 +467,7 @@
                          throw new ReportedException(crashreport2);
                      }
                  }
-@@ -1720,7 +1855,10 @@
+@@ -1720,7 +1854,10 @@
  
                  if (this.func_175667_e(tileentity.func_174877_v()))
                  {
@@ -480,7 +479,7 @@
                  }
              }
          }
-@@ -1764,12 +1902,18 @@
+@@ -1764,12 +1901,18 @@
  
      public boolean func_175700_a(TileEntity p_175700_1_)
      {
@@ -499,7 +498,7 @@
  
          if (this.field_72995_K)
          {
-@@ -1785,6 +1929,11 @@
+@@ -1785,6 +1928,11 @@
      {
          if (this.field_147481_N)
          {
@@ -511,7 +510,7 @@
              this.field_147484_a.addAll(p_147448_1_);
          }
          else
-@@ -1807,9 +1956,13 @@
+@@ -1807,9 +1955,13 @@
          {
              int j2 = MathHelper.func_76128_c(p_72866_1_.field_70165_t);
              int k2 = MathHelper.func_76128_c(p_72866_1_.field_70161_v);
@@ -527,7 +526,7 @@
              {
                  return;
              }
-@@ -1831,6 +1984,7 @@
+@@ -1831,6 +1983,7 @@
              }
              else
              {
@@ -535,7 +534,7 @@
                  p_72866_1_.func_70071_h_();
              }
          }
-@@ -2011,6 +2165,11 @@
+@@ -2011,6 +2164,11 @@
                              blockpos$pooledmutableblockpos.func_185344_t();
                              return true;
                          }
@@ -547,7 +546,7 @@
                      }
                  }
              }
-@@ -2050,6 +2209,16 @@
+@@ -2050,6 +2208,16 @@
                          IBlockState iblockstate1 = this.func_180495_p(blockpos$pooledmutableblockpos);
                          Block block = iblockstate1.func_177230_c();
  
@@ -564,7 +563,7 @@
                          if (iblockstate1.func_185904_a() == p_72918_2_)
                          {
                              double d0 = (double)((float)(i4 + 1) - BlockLiquid.func_149801_b(((Integer)iblockstate1.func_177229_b(BlockLiquid.field_176367_b)).intValue()));
-@@ -2116,6 +2285,7 @@
+@@ -2116,6 +2284,7 @@
      public Explosion func_72885_a(@Nullable Entity p_72885_1_, double p_72885_2_, double p_72885_4_, double p_72885_6_, float p_72885_8_, boolean p_72885_9_, boolean p_72885_10_)
      {
          Explosion explosion = new Explosion(this, p_72885_1_, p_72885_2_, p_72885_4_, p_72885_6_, p_72885_8_, p_72885_9_, p_72885_10_);
@@ -572,7 +571,7 @@
          explosion.func_77278_a();
          explosion.func_77279_a(true);
          return explosion;
-@@ -2238,6 +2408,7 @@
+@@ -2238,6 +2407,7 @@
  
      public void func_175690_a(BlockPos p_175690_1_, @Nullable TileEntity p_175690_2_)
      {
@@ -580,7 +579,7 @@
          if (!this.func_189509_E(p_175690_1_))
          {
              if (p_175690_2_ != null && !p_175690_2_.func_145837_r())
-@@ -2245,6 +2416,8 @@
+@@ -2245,6 +2415,8 @@
                  if (this.field_147481_N)
                  {
                      p_175690_2_.func_174878_a(p_175690_1_);
@@ -589,7 +588,7 @@
                      Iterator<TileEntity> iterator1 = this.field_147484_a.iterator();
  
                      while (iterator1.hasNext())
-@@ -2262,7 +2435,8 @@
+@@ -2262,7 +2434,8 @@
                  }
                  else
                  {
@@ -599,7 +598,7 @@
                      this.func_175700_a(p_175690_2_);
                  }
              }
-@@ -2277,6 +2451,8 @@
+@@ -2277,6 +2450,8 @@
          {
              tileentity2.func_145843_s();
              this.field_147484_a.remove(tileentity2);
@@ -608,7 +607,7 @@
          }
          else
          {
-@@ -2289,6 +2465,7 @@
+@@ -2289,6 +2464,7 @@
  
              this.func_175726_f(p_175713_1_).func_177425_e(p_175713_1_);
          }
@@ -616,7 +615,7 @@
      }
  
      public void func_147457_a(TileEntity p_147457_1_)
-@@ -2315,7 +2492,7 @@
+@@ -2315,7 +2491,7 @@
              if (chunk1 != null && !chunk1.func_76621_g())
              {
                  IBlockState iblockstate1 = this.func_180495_p(p_175677_1_);
@@ -625,7 +624,7 @@
              }
              else
              {
-@@ -2338,6 +2515,7 @@
+@@ -2338,6 +2514,7 @@
      {
          this.field_72985_G = p_72891_1_;
          this.field_72992_H = p_72891_2_;
@@ -633,7 +632,7 @@
      }
  
      public void func_72835_b()
-@@ -2347,6 +2525,11 @@
+@@ -2347,6 +2524,11 @@
  
      protected void func_72947_a()
      {
@@ -645,7 +644,7 @@
          if (this.field_72986_A.func_76059_o())
          {
              this.field_73004_o = 1.0F;
-@@ -2360,6 +2543,11 @@
+@@ -2360,6 +2542,11 @@
  
      protected void func_72979_l()
      {
@@ -657,7 +656,7 @@
          if (this.field_73011_w.func_191066_m())
          {
              if (!this.field_72995_K)
-@@ -2484,6 +2672,11 @@
+@@ -2484,6 +2671,11 @@
  
      public boolean func_175670_e(BlockPos p_175670_1_, boolean p_175670_2_)
      {
@@ -669,7 +668,7 @@
          Biome biome = this.func_180494_b(p_175670_1_);
          float f = biome.func_180626_a(p_175670_1_);
  
-@@ -2525,6 +2718,11 @@
+@@ -2525,6 +2717,11 @@
  
      public boolean func_175708_f(BlockPos p_175708_1_, boolean p_175708_2_)
      {
@@ -681,7 +680,7 @@
          Biome biome = this.func_180494_b(p_175708_1_);
          float f = biome.func_180626_a(p_175708_1_);
  
-@@ -2542,7 +2740,7 @@
+@@ -2542,7 +2739,7 @@
              {
                  IBlockState iblockstate1 = this.func_180495_p(p_175708_1_);
  
@@ -690,7 +689,7 @@
                  {
                      return true;
                  }
-@@ -2574,10 +2772,11 @@
+@@ -2574,10 +2771,11 @@
          else
          {
              IBlockState iblockstate1 = this.func_180495_p(p_175638_1_);
@@ -705,7 +704,7 @@
              {
                  k2 = 1;
              }
-@@ -2683,7 +2882,8 @@
+@@ -2683,7 +2881,8 @@
                                      int k6 = k4 + enumfacing.func_96559_d();
                                      int l6 = l4 + enumfacing.func_82599_e();
                                      blockpos$pooledmutableblockpos.func_181079_c(j6, k6, l6);
@@ -715,7 +714,7 @@
                                      j5 = this.func_175642_b(p_180500_1_, blockpos$pooledmutableblockpos);
  
                                      if (j5 == i5 - i7 && k2 < this.field_72994_J.length)
-@@ -2791,10 +2991,10 @@
+@@ -2791,10 +2990,10 @@
      public List<Entity> func_175674_a(@Nullable Entity p_175674_1_, AxisAlignedBB p_175674_2_, @Nullable Predicate <? super Entity > p_175674_3_)
      {
          List<Entity> list = Lists.<Entity>newArrayList();
@@ -730,7 +729,7 @@
  
          for (int j3 = j2; j3 <= k2; ++j3)
          {
-@@ -2847,10 +3047,10 @@
+@@ -2847,10 +3046,10 @@
  
      public <T extends Entity> List<T> func_175647_a(Class <? extends T > p_175647_1_, AxisAlignedBB p_175647_2_, @Nullable Predicate <? super T > p_175647_3_)
      {
@@ -745,7 +744,7 @@
          List<T> list = Lists.<T>newArrayList();
  
          for (int j3 = j2; j3 < k2; ++j3)
-@@ -2930,11 +3130,13 @@
+@@ -2930,11 +3129,13 @@
  
      public void func_175650_b(Collection<Entity> p_175650_1_)
      {
@@ -762,7 +761,7 @@
          }
      }
  
-@@ -2958,7 +3160,7 @@
+@@ -2958,7 +3159,7 @@
          }
          else
          {
@@ -771,7 +770,7 @@
          }
      }
  
-@@ -3042,7 +3244,7 @@
+@@ -3042,7 +3243,7 @@
      public int func_175651_c(BlockPos p_175651_1_, EnumFacing p_175651_2_)
      {
          IBlockState iblockstate1 = this.func_180495_p(p_175651_1_);
@@ -780,7 +779,7 @@
      }
  
      public boolean func_175640_z(BlockPos p_175640_1_)
-@@ -3208,6 +3410,8 @@
+@@ -3208,6 +3409,8 @@
                      d2 *= ((Double)MoreObjects.firstNonNull(p_184150_11_.apply(entityplayer1), Double.valueOf(1.0D))).doubleValue();
                  }
  
@@ -789,7 +788,7 @@
                  if ((p_184150_9_ < 0.0D || Math.abs(entityplayer1.field_70163_u - p_184150_3_) < p_184150_9_ * p_184150_9_) && (p_184150_7_ < 0.0D || d1 < d2 * d2) && (d0 == -1.0D || d1 < d0))
                  {
                      d0 = d1;
-@@ -3269,7 +3473,7 @@
+@@ -3269,7 +3472,7 @@
  
      public long func_72905_C()
      {
@@ -798,7 +797,7 @@
      }
  
      public long func_82737_E()
-@@ -3279,17 +3483,17 @@
+@@ -3279,17 +3482,17 @@
  
      public long func_72820_D()
      {
@@ -819,7 +818,7 @@
  
          if (!this.func_175723_af().func_177746_a(blockpos1))
          {
-@@ -3301,7 +3505,7 @@
+@@ -3301,7 +3504,7 @@
  
      public void func_175652_B(BlockPos p_175652_1_)
      {
@@ -828,7 +827,7 @@
      }
  
      @SideOnly(Side.CLIENT)
-@@ -3321,12 +3525,18 @@
+@@ -3321,12 +3524,18 @@
  
          if (!this.field_72996_f.contains(p_72897_1_))
          {
@@ -847,7 +846,7 @@
          return true;
      }
  
-@@ -3428,8 +3638,7 @@
+@@ -3428,8 +3637,7 @@
  
      public boolean func_180502_D(BlockPos p_180502_1_)
      {
@@ -857,7 +856,7 @@
      }
  
      @Nullable
-@@ -3490,12 +3699,12 @@
+@@ -3490,12 +3698,12 @@
  
      public int func_72800_K()
      {
@@ -872,7 +871,7 @@
      }
  
      public Random func_72843_D(int p_72843_1_, int p_72843_2_, int p_72843_3_)
-@@ -3539,7 +3748,7 @@
+@@ -3539,7 +3747,7 @@
      @SideOnly(Side.CLIENT)
      public double func_72919_O()
      {
@@ -881,7 +880,7 @@
      }
  
      public void func_175715_c(int p_175715_1_, BlockPos p_175715_2_, int p_175715_3_)
-@@ -3573,7 +3782,7 @@
+@@ -3573,7 +3781,7 @@
  
      public void func_175666_e(BlockPos p_175666_1_, Block p_175666_2_)
      {
@@ -890,7 +889,7 @@
          {
              BlockPos blockpos1 = p_175666_1_.func_177972_a(enumfacing);
  
-@@ -3581,18 +3790,15 @@
+@@ -3581,18 +3789,15 @@
              {
                  IBlockState iblockstate1 = this.func_180495_p(blockpos1);
  
@@ -913,7 +912,7 @@
                      }
                  }
              }
-@@ -3658,6 +3864,124 @@
+@@ -3658,6 +3863,124 @@
          return j2 >= -128 && j2 <= 128 && k2 >= -128 && k2 <= 128;
      }
  

--- a/src/main/java/net/minecraftforge/event/ForgeEventFactory.java
+++ b/src/main/java/net/minecraftforge/event/ForgeEventFactory.java
@@ -49,6 +49,7 @@ import net.minecraft.util.NonNullList;
 import net.minecraft.util.ResourceLocation;
 import net.minecraft.util.SoundCategory;
 import net.minecraft.util.SoundEvent;
+import net.minecraft.util.math.AxisAlignedBB;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.RayTraceResult;
 import net.minecraft.util.text.ChatType;
@@ -114,6 +115,7 @@ import net.minecraftforge.event.world.BlockEvent.MultiPlaceEvent;
 import net.minecraftforge.event.world.BlockEvent.NeighborNotifyEvent;
 import net.minecraftforge.event.world.BlockEvent.PlaceEvent;
 import net.minecraftforge.event.world.ExplosionEvent;
+import net.minecraftforge.event.world.GetCollisionBoxesEvent;
 import net.minecraftforge.event.world.WorldEvent;
 import net.minecraftforge.fml.common.ObfuscationReflectionHelper;
 import net.minecraftforge.fml.common.eventhandler.Event;
@@ -681,5 +683,11 @@ public class ForgeEventFactory
     public static boolean onEntityDestroyBlock(EntityLivingBase entity, BlockPos pos, IBlockState state)
     {
         return !MinecraftForge.EVENT_BUS.post(new LivingDestroyBlockEvent(entity, pos, state));
+    }
+
+    public static boolean gatherCollisionBoxes(World world, Entity entity, AxisAlignedBB aabb, List<AxisAlignedBB> outList)
+    {
+        MinecraftForge.EVENT_BUS.post(new GetCollisionBoxesEvent(world, entity, aabb, outList));
+        return outList.isEmpty();
     }
 }

--- a/src/test/java/net/minecraftforge/debug/CollisionBoxesEventTest.java
+++ b/src/test/java/net/minecraftforge/debug/CollisionBoxesEventTest.java
@@ -2,12 +2,9 @@ package net.minecraftforge.debug;
 
 import java.util.ArrayList;
 
-import javax.annotation.Nullable;
-
 import net.minecraft.block.Block;
 import net.minecraft.block.material.Material;
 import net.minecraft.block.state.IBlockState;
-import net.minecraft.client.renderer.block.model.ModelResourceLocation;
 import net.minecraft.creativetab.CreativeTabs;
 import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.item.Item;
@@ -20,9 +17,6 @@ import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.Vec3d;
 import net.minecraft.world.World;
 
-import net.minecraftforge.client.event.ModelBakeEvent;
-import net.minecraftforge.client.event.ModelRegistryEvent;
-import net.minecraftforge.client.model.ModelLoader;
 import net.minecraftforge.event.RegistryEvent;
 import net.minecraftforge.event.world.GetCollisionBoxesEvent;
 import net.minecraftforge.fml.common.Mod;

--- a/src/test/java/net/minecraftforge/debug/CollisionBoxesEventTest.java
+++ b/src/test/java/net/minecraftforge/debug/CollisionBoxesEventTest.java
@@ -1,0 +1,93 @@
+package net.minecraftforge.debug;
+
+import java.util.ArrayList;
+
+import javax.annotation.Nullable;
+
+import net.minecraft.block.Block;
+import net.minecraft.block.material.Material;
+import net.minecraft.block.state.IBlockState;
+import net.minecraft.entity.EntityLivingBase;
+import net.minecraft.item.Item;
+import net.minecraft.item.ItemBlock;
+import net.minecraft.item.ItemStack;
+import net.minecraft.util.EnumFacing;
+import net.minecraft.util.ResourceLocation;
+import net.minecraft.util.math.AxisAlignedBB;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.math.Vec3d;
+import net.minecraft.world.World;
+
+import net.minecraftforge.event.RegistryEvent;
+import net.minecraftforge.event.world.GetCollisionBoxesEvent;
+import net.minecraftforge.fml.common.Mod;
+import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
+import net.minecraftforge.fml.common.registry.GameRegistry;
+
+@Mod(modid = CollisionBoxesEventTest.MODID, name = "CollisionBoxesEventTest", version = "1.0", acceptableRemoteVersions = "*")
+@Mod.EventBusSubscriber
+public class CollisionBoxesEventTest
+{
+    public static final String MODID = "collisionboxexeventtest";
+
+    public static final boolean ENABLED = false;
+    @GameRegistry.ObjectHolder("box_block")
+    private static final Block BOX_BLOCK = null;
+    private static final ArrayList<BlockPos> locations = new ArrayList<>();
+
+    @SubscribeEvent
+    public static void registerBlock(RegistryEvent.Register<Block> event)
+    {
+        if (ENABLED)
+        {
+            event.getRegistry().register(new BoxBlock());
+        }
+    }
+
+    @SubscribeEvent
+    public static void registerItem(RegistryEvent.Register<Item> event)
+    {
+        if (ENABLED)
+        {
+            event.getRegistry().register(new ItemBlock(BOX_BLOCK).setRegistryName(new ResourceLocation(MODID, "box_block")));
+        }
+    }
+
+    @SubscribeEvent
+    public static void getBoxes(GetCollisionBoxesEvent event)
+    {
+        AxisAlignedBB box = event.getAabb();
+
+        for (BlockPos pos: locations)
+        {
+            for (EnumFacing facing: EnumFacing.HORIZONTALS)
+            {
+                AxisAlignedBB temp = new AxisAlignedBB(pos).offset(new Vec3d(facing.getDirectionVec()));
+                if (box.intersects(temp))
+                    event.getCollisionBoxesList().add(temp);
+            }
+        }
+    }
+
+    private static class BoxBlock extends Block
+    {
+
+        public BoxBlock()
+        {
+            super(Material.ROCK);
+            setRegistryName(new ResourceLocation(MODID, "box_block"));
+        }
+
+        @Override
+        public void breakBlock(World worldIn, BlockPos pos, IBlockState state)
+        {
+            locations.remove(pos);
+        }
+
+        @Override
+        public void onBlockPlacedBy(World worldIn, BlockPos pos, IBlockState state, EntityLivingBase placer, ItemStack stack)
+        {
+            locations.add(pos);
+        }
+    }
+}

--- a/src/test/java/net/minecraftforge/debug/CollisionBoxesEventTest.java
+++ b/src/test/java/net/minecraftforge/debug/CollisionBoxesEventTest.java
@@ -7,6 +7,8 @@ import javax.annotation.Nullable;
 import net.minecraft.block.Block;
 import net.minecraft.block.material.Material;
 import net.minecraft.block.state.IBlockState;
+import net.minecraft.client.renderer.block.model.ModelResourceLocation;
+import net.minecraft.creativetab.CreativeTabs;
 import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemBlock;
@@ -18,6 +20,9 @@ import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.Vec3d;
 import net.minecraft.world.World;
 
+import net.minecraftforge.client.event.ModelBakeEvent;
+import net.minecraftforge.client.event.ModelRegistryEvent;
+import net.minecraftforge.client.model.ModelLoader;
 import net.minecraftforge.event.RegistryEvent;
 import net.minecraftforge.event.world.GetCollisionBoxesEvent;
 import net.minecraftforge.fml.common.Mod;
@@ -30,7 +35,7 @@ public class CollisionBoxesEventTest
 {
     public static final String MODID = "collisionboxexeventtest";
 
-    public static final boolean ENABLED = false;
+    public static final boolean ENABLED = true;
     @GameRegistry.ObjectHolder("box_block")
     private static final Block BOX_BLOCK = null;
     private static final ArrayList<BlockPos> locations = new ArrayList<>();
@@ -52,6 +57,7 @@ public class CollisionBoxesEventTest
             event.getRegistry().register(new ItemBlock(BOX_BLOCK).setRegistryName(new ResourceLocation(MODID, "box_block")));
         }
     }
+
 
     @SubscribeEvent
     public static void getBoxes(GetCollisionBoxesEvent event)
@@ -76,6 +82,7 @@ public class CollisionBoxesEventTest
         {
             super(Material.ROCK);
             setRegistryName(new ResourceLocation(MODID, "box_block"));
+            setCreativeTab(CreativeTabs.MISC);
         }
 
         @Override
@@ -89,5 +96,12 @@ public class CollisionBoxesEventTest
         {
             locations.add(pos);
         }
+
+
+        @Override
+        public String getUnlocalizedName() {
+            return "CollisionBoxes event test block";
+        }
+
     }
 }

--- a/src/test/resources/assets/collisionboxexeventtest/blockstates/box_block.json
+++ b/src/test/resources/assets/collisionboxexeventtest/blockstates/box_block.json
@@ -1,0 +1,10 @@
+{
+	"forge_marker": 1,
+	"defaults": {
+	    "model": "minecraft:bedrock"
+	},
+    "variants": {
+        "normal": [{}],
+		"inventory": [{}]
+    }
+}


### PR DESCRIPTION
#3916 for 1.12 with test mod

The test mod is not caching any boxes on purpose. This helps to highlight the issue in a minimal test case without any crazy special expesive checks. it is also very likely that not all mods using this event are caching these boxes (although they realy should, given that even with this it gets called multiple times every tick). The point of the event is to do special collision boxes (elevators, quarry drill arms, anything that moves realy)
Mods using the event might also be doing (expensive) extra checks like capabilities on the optional entity or the provided world

Without this patch and the test mod the memory pressure is very high, GC had to clean up 600MB every few seconds

![test1](https://user-images.githubusercontent.com/5206666/29022266-dc22eeea-7b68-11e7-9f0a-0f325a3e588e.PNG)

with this patch it only had to clean up about 200MB every minute
![test2](https://user-images.githubusercontent.com/5206666/29022292-fe4887fa-7b68-11e7-8bd3-77b7f7403644.PNG)

