### PR TITLE
Fix FastTESR quad sort (II)

### DIFF
--- a/patches/minecraft/net/minecraft/client/renderer/ActiveRenderInfo.java.patch
+++ b/patches/minecraft/net/minecraft/client/renderer/ActiveRenderInfo.java.patch
@@ -1,0 +1,17 @@
+--- ../src-base/minecraft/net/minecraft/client/renderer/ActiveRenderInfo.java
++++ ../src-work/minecraft/net/minecraft/client/renderer/ActiveRenderInfo.java
+@@ -108,4 +108,14 @@
+     {
+         return field_74596_h;
+     }
++
++    /* ======================================== FORGE START =====================================*/
++
++    /**
++     * Vector from render view entity position (corrected for partialTickTime) to the middle of screen
++     */
++    public static Vec3d getCameraPosition()
++    {
++        return field_178811_e;
++    }
+ }

--- a/patches/minecraft/net/minecraft/client/renderer/tileentity/TileEntityRendererDispatcher.java.patch
+++ b/patches/minecraft/net/minecraft/client/renderer/tileentity/TileEntityRendererDispatcher.java.patch
@@ -25,7 +25,7 @@
                  tileentityspecialrenderer.func_192841_a(p_192854_1_, p_192854_2_, p_192854_4_, p_192854_6_, p_192854_8_, p_192854_9_, p_192854_10_);
              }
              catch (Throwable throwable)
-@@ -172,4 +178,52 @@
+@@ -172,4 +178,53 @@
      {
          return this.field_147557_n;
      }
@@ -70,7 +70,8 @@
 +
 +        if(pass > 0)
 +        {
-+            batchBuffer.func_178180_c().func_181674_a(0, 0, 0);
++            net.minecraft.util.math.Vec3d cameraPos = net.minecraft.client.renderer.ActiveRenderInfo.getCameraPosition();
++            batchBuffer.func_178180_c().func_181674_a((float)cameraPos.field_72450_a, (float)cameraPos.field_72448_b, (float)cameraPos.field_72449_c);
 +        }
 +        batchBuffer.func_78381_a();
 +


### PR DESCRIPTION
This finished issue discussed in #4267. Sorry for double fix for single issue, but I missed the fact, that `staticPlayerX/Y/Z` (which is origin for TESR rendering) actually points to player feet, while camera can be somewhere else (on eyes in first person or somewhere around in third person). This patch adds correct (camera to player position/render origin) offsets.

Notes: 
- this solution works correctly for both first- and third-persion views
- `ActiveRenderInfo.java` patch could be replaced with AT entry for `field_178811_e`, but I think this field should be read-only. But if you think otherwise, I can change it.
- missed this issue in previous PR, since bottom quad was not rendered when there was block below

Screenshots (from TransparentFastTESRTest test mod)
Before:
![2017-08-11_19 57 31](https://user-images.githubusercontent.com/754542/29228830-aff1aef8-7edb-11e7-8e8c-7a061a740e67.png)
After:
![2017-08-11_19 57 35](https://user-images.githubusercontent.com/754542/29228835-b64b0be6-7edb-11e7-982e-515513d051ff.png)
