### PR TITLE
Fix splitting big packets skipping one byte per additional part

### DIFF
--- a/src/main/java/net/minecraftforge/fml/common/network/handshake/NetworkDispatcher.java
+++ b/src/main/java/net/minecraftforge/fml/common/network/handshake/NetworkDispatcher.java
@@ -644,7 +644,7 @@ public class NetworkDispatcher extends SimpleChannelInboundHandler<Packet<?>> im
             {
                 throw new IOException("Received FML MultiPart packet out of order, Expected " + part_expected + " Got " + part);
             }
-            int len = input.readableBytes() - 1;
+            int len = input.readableBytes();
             input.readBytes(data, offset, len);
             part_expected++;
             offset += len;

--- a/src/test/java/net/minecraftforge/debug/BigNetworkMessageTest.java
+++ b/src/test/java/net/minecraftforge/debug/BigNetworkMessageTest.java
@@ -1,0 +1,67 @@
+package net.minecraftforge.debug;
+
+import io.netty.buffer.ByteBuf;
+import net.minecraft.entity.player.EntityPlayerMP;
+import net.minecraftforge.fml.common.FMLLog;
+import net.minecraftforge.fml.common.Mod;
+import net.minecraftforge.fml.common.event.FMLPreInitializationEvent;
+import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
+import net.minecraftforge.fml.common.gameevent.PlayerEvent;
+import net.minecraftforge.fml.common.network.NetworkRegistry;
+import net.minecraftforge.fml.common.network.simpleimpl.IMessage;
+import net.minecraftforge.fml.common.network.simpleimpl.SimpleNetworkWrapper;
+import net.minecraftforge.fml.relauncher.Side;
+
+@Mod(modid = BigNetworkMessageTest.MOD_ID, name = "Big network message test mod", version = "1.0", acceptableRemoteVersions = "*")
+@Mod.EventBusSubscriber
+public class BigNetworkMessageTest
+{
+    static final boolean ENABLED = true;
+    static final String MOD_ID = "big_packet_test";
+    public static final SimpleNetworkWrapper INSTANCE = NetworkRegistry.INSTANCE.newSimpleChannel(MOD_ID);
+
+    @Mod.EventHandler
+    public void preInit(FMLPreInitializationEvent e)
+    {
+        if (ENABLED)
+        {
+            INSTANCE.registerMessage((msg, ctx) -> null, BigMessage.class, 0, Side.SERVER);
+        }
+    }
+
+    @SubscribeEvent
+    public static void onPlayerJoin(PlayerEvent.PlayerLoggedInEvent evt)
+    {
+        if (ENABLED)
+        {
+            INSTANCE.sendTo(new BigMessage(), (EntityPlayerMP) evt.player);
+        }
+    }
+
+    public static class BigMessage implements IMessage
+    {
+        private static final int BYTE_COUNT = 0x200000;// 2MB
+
+        @Override public void toBytes(ByteBuf buf)
+        {
+            // write consecutive bytes, overflowing back to zero as necessary
+            for (int i = 0; i < BYTE_COUNT; i++)
+            {
+                buf.writeByte(i & 0xFF);
+            }
+        }
+
+        @Override public void fromBytes(ByteBuf buf)
+        {
+            for (int i = 0; i < BYTE_COUNT; i++)
+            {
+                int read = buf.readUnsignedByte();
+                int expected = i & 0xFF;
+                if (read != expected)
+                {
+                    throw new RuntimeException("Found incorrect byte at " + (i + 1) + " expected " + expected + " but found " + read);
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
This fixes splitting of big (>1MB) packets. I will also submit 1.11.x version because I need it there too (this commit won't be good on 1.11 because it uses a lambda).

Also added a test mod to verify that it works correctly. It sends 2MB of data, with each byte being previous+1, overflowing to 0 as necessary. Then the receiving end verifies that it matches the expected values.

The exception thrown by the text mod before applying the fix:
```
Caused by: java.lang.RuntimeException: Found incorrect byte at 1048494 expected 173 but found 174
	at net.minecraftforge.debug.BigNetworkMessageTest$BigMessage.fromBytes(BigNetworkMessageTest.java:61) ~[BigNetworkMessageTest$BigMessage.class:?]
	at net.minecraftforge.fml.common.network.simpleimpl.SimpleIndexedCodec.decodeInto(SimpleIndexedCodec.java:36) ~[SimpleIndexedCodec.class:?]
	at net.minecraftforge.fml.common.network.simpleimpl.SimpleIndexedCodec.decodeInto(SimpleIndexedCodec.java:26) ~[SimpleIndexedCodec.class:?]
	at net.minecraftforge.fml.common.network.FMLIndexedMessageToMessageCodec.decode(FMLIndexedMessageToMessageCodec.java:103) ~[FMLIndexedMessageToMessageCodec.class:?]
	at net.minecraftforge.fml.common.network.FMLIndexedMessageToMessageCodec.decode(FMLIndexedMessageToMessageCodec.java:40) ~[FMLIndexedMessageToMessageCodec.class:?]
	at io.netty.handler.codec.MessageToMessageCodec$2.decode(MessageToMessageCodec.java:81) ~[MessageToMessageCodec$2.class:4.1.9.Final]
	at io.netty.handler.codec.MessageToMessageDecoder.channelRead(MessageToMessageDecoder.java:88) ~[MessageToMessageDecoder.class:4.1.9.Final]
	... 33 more
```
I'm not sure if it could be done as normal junit test, but if it's possible I can try to do it.