### PR TITLE
Fix random FML handshake crash, fixes #4285 and #3974

### DIFF
--- a/src/main/java/net/minecraftforge/fml/common/network/handshake/FMLHandshakeClientState.java
+++ b/src/main/java/net/minecraftforge/fml/common/network/handshake/FMLHandshakeClientState.java
@@ -24,6 +24,7 @@ import io.netty.channel.ChannelHandlerContext;
 
 import java.util.List;
 import java.util.Map;
+import java.util.function.Consumer;
 
 import com.google.common.collect.Maps;
 import com.google.common.collect.Multimap;
@@ -55,26 +56,36 @@ enum FMLHandshakeClientState implements IHandshakeState<FMLHandshakeClientState>
     START
     {
         @Override
-        public FMLHandshakeClientState accept(ChannelHandlerContext ctx, FMLHandshakeMessage msg)
+        public void accept(ChannelHandlerContext ctx, FMLHandshakeMessage msg, Consumer<? super FMLHandshakeClientState> cons)
         {
+            cons.accept(HELLO);
             NetworkDispatcher dispatcher = ctx.channel().attr(NetworkDispatcher.FML_DISPATCHER).get();
             dispatcher.clientListenForServerHandshake();
-            return HELLO;
         }
     },
     HELLO
     {
         @Override
-        public FMLHandshakeClientState accept(ChannelHandlerContext ctx, FMLHandshakeMessage msg)
+        public void accept(ChannelHandlerContext ctx, FMLHandshakeMessage msg, Consumer<? super FMLHandshakeClientState> cons)
         {
+            System.out.println("Test2");
+            boolean isVanilla = msg == null;
+            if (isVanilla)
+            {
+                cons.accept(DONE);
+            }
+            else
+            {
+                cons.accept(WAITINGSERVERDATA);
+            }
             // write our custom packet registration, always
             ctx.writeAndFlush(FMLHandshakeMessage.makeCustomChannelRegistration(NetworkRegistry.INSTANCE.channelNamesFor(Side.CLIENT)));
-            if (msg == null)
+            if (isVanilla)
             {
                 NetworkDispatcher dispatcher = ctx.channel().attr(NetworkDispatcher.FML_DISPATCHER).get();
                 dispatcher.abortClientHandshake("VANILLA");
                 // VANILLA login
-                return DONE;
+                return;
             }
 
             ServerHello serverHelloPacket = (FMLHandshakeMessage.ServerHello)msg;
@@ -87,37 +98,38 @@ enum FMLHandshakeClientState implements IHandshakeState<FMLHandshakeClientState>
             }
             ctx.writeAndFlush(new FMLHandshakeMessage.ClientHello()).addListener(ChannelFutureListener.FIRE_EXCEPTION_ON_FAILURE);
             ctx.writeAndFlush(new FMLHandshakeMessage.ModList(Loader.instance().getActiveModList())).addListener(ChannelFutureListener.FIRE_EXCEPTION_ON_FAILURE);
-            return WAITINGSERVERDATA;
         }
     },
 
     WAITINGSERVERDATA
     {
         @Override
-        public FMLHandshakeClientState accept(ChannelHandlerContext ctx, FMLHandshakeMessage msg)
+        public void accept(ChannelHandlerContext ctx, FMLHandshakeMessage msg, Consumer<? super FMLHandshakeClientState> cons)
         {
             String result = FMLNetworkHandler.checkModList((FMLHandshakeMessage.ModList) msg, Side.SERVER);
             if (result != null)
             {
+                cons.accept(ERROR);
                 NetworkDispatcher dispatcher = ctx.channel().attr(NetworkDispatcher.FML_DISPATCHER).get();
                 dispatcher.rejectHandshake(result);
-                return ERROR;
+                return;
             }
-            ctx.writeAndFlush(new FMLHandshakeMessage.HandshakeAck(ordinal())).addListener(ChannelFutureListener.FIRE_EXCEPTION_ON_FAILURE);
             if (!ctx.channel().attr(NetworkDispatcher.IS_LOCAL).get())
             {
-                return WAITINGSERVERCOMPLETE;
+                cons.accept(WAITINGSERVERCOMPLETE);
             }
             else
             {
-                return PENDINGCOMPLETE;
+                cons.accept(PENDINGCOMPLETE);
             }
+            ctx.writeAndFlush(new FMLHandshakeMessage.HandshakeAck(ordinal())).addListener(ChannelFutureListener.FIRE_EXCEPTION_ON_FAILURE);
+
         }
     },
     WAITINGSERVERCOMPLETE
     {
         @Override
-        public FMLHandshakeClientState accept(ChannelHandlerContext ctx, FMLHandshakeMessage msg)
+        public void accept(ChannelHandlerContext ctx, FMLHandshakeMessage msg, Consumer<? super FMLHandshakeClientState> cons)
         {
             FMLHandshakeMessage.RegistryData pkt = (FMLHandshakeMessage.RegistryData)msg;
             Map<ResourceLocation, ForgeRegistry.Snapshot> snap = ctx.channel().attr(NetworkDispatcher.FML_GAMEDATA_SNAPSHOT).get();
@@ -135,8 +147,9 @@ enum FMLHandshakeClientState implements IHandshakeState<FMLHandshakeClientState>
 
             if (pkt.hasMore())
             {
+                cons.accept(WAITINGSERVERCOMPLETE);
                 FMLLog.log.debug("Received Mod Registry mapping for {}: {} IDs {} overrides {} dummied", pkt.getName(), entry.ids.size(), entry.overrides.size(), entry.dummied.size());
-                return WAITINGSERVERCOMPLETE;
+                return;
             }
 
             ctx.channel().attr(NetworkDispatcher.FML_GAMEDATA_SNAPSHOT).set(null);
@@ -144,57 +157,56 @@ enum FMLHandshakeClientState implements IHandshakeState<FMLHandshakeClientState>
             Multimap<ResourceLocation, ResourceLocation> locallyMissing = GameData.injectSnapshot(snap, false, false);
             if (!locallyMissing.isEmpty())
             {
+                cons.accept(ERROR);
                 NetworkDispatcher dispatcher = ctx.channel().attr(NetworkDispatcher.FML_DISPATCHER).get();
                 dispatcher.rejectHandshake("Fatally missing blocks and items");
                 FMLLog.log.fatal("Failed to connect to server: there are {} missing blocks and items", locallyMissing.size());
                 locallyMissing.asMap().forEach((key, value) ->  FMLLog.log.debug("Missing {} Entries: {}", key, value));
-                return ERROR;
+                return;
             }
+            cons.accept(PENDINGCOMPLETE);
             ctx.writeAndFlush(new FMLHandshakeMessage.HandshakeAck(ordinal())).addListener(ChannelFutureListener.FIRE_EXCEPTION_ON_FAILURE);
-            return PENDINGCOMPLETE;
         }
     },
     PENDINGCOMPLETE
     {
         @Override
-        public FMLHandshakeClientState accept(ChannelHandlerContext ctx, FMLHandshakeMessage msg)
+        public void accept(ChannelHandlerContext ctx, FMLHandshakeMessage msg, Consumer<? super FMLHandshakeClientState> cons)
         {
+            cons.accept(COMPLETE);
             ctx.writeAndFlush(new FMLHandshakeMessage.HandshakeAck(ordinal())).addListener(ChannelFutureListener.FIRE_EXCEPTION_ON_FAILURE);
-            return COMPLETE;
         }
     },
     COMPLETE
     {
         @Override
-        public FMLHandshakeClientState accept(ChannelHandlerContext ctx, FMLHandshakeMessage msg)
+        public void accept(ChannelHandlerContext ctx, FMLHandshakeMessage msg, Consumer<? super FMLHandshakeClientState> cons)
         {
+            cons.accept(DONE);
             NetworkDispatcher dispatcher = ctx.channel().attr(NetworkDispatcher.FML_DISPATCHER).get();
             dispatcher.completeClientHandshake();
             FMLMessage.CompleteHandshake complete = new FMLMessage.CompleteHandshake(Side.CLIENT);
             ctx.fireChannelRead(complete);
             ctx.writeAndFlush(new FMLHandshakeMessage.HandshakeAck(ordinal())).addListener(ChannelFutureListener.FIRE_EXCEPTION_ON_FAILURE);
-            return DONE;
         }
     },
     DONE
     {
         @Override
-        public FMLHandshakeClientState accept(ChannelHandlerContext ctx, FMLHandshakeMessage msg)
+        public void accept(ChannelHandlerContext ctx, FMLHandshakeMessage msg, Consumer<? super FMLHandshakeClientState> cons)
         {
             if (msg instanceof FMLHandshakeMessage.HandshakeReset)
             {
+                cons.accept(HELLO);
                 GameData.revertToFrozen();
-                return HELLO;
             }
-            return this;
         }
     },
     ERROR
     {
         @Override
-        public FMLHandshakeClientState accept(ChannelHandlerContext ctx, FMLHandshakeMessage msg)
+        public void accept(ChannelHandlerContext ctx, FMLHandshakeMessage msg, Consumer<? super FMLHandshakeClientState> cons)
         {
-            return this;
         }
     };
 }

--- a/src/main/java/net/minecraftforge/fml/common/network/handshake/FMLHandshakeClientState.java
+++ b/src/main/java/net/minecraftforge/fml/common/network/handshake/FMLHandshakeClientState.java
@@ -68,7 +68,6 @@ enum FMLHandshakeClientState implements IHandshakeState<FMLHandshakeClientState>
         @Override
         public void accept(ChannelHandlerContext ctx, FMLHandshakeMessage msg, Consumer<? super FMLHandshakeClientState> cons)
         {
-            System.out.println("Test2");
             boolean isVanilla = msg == null;
             if (isVanilla)
             {

--- a/src/main/java/net/minecraftforge/fml/common/network/handshake/FMLHandshakeMessage.java
+++ b/src/main/java/net/minecraftforge/fml/common/network/handshake/FMLHandshakeMessage.java
@@ -65,6 +65,7 @@ public abstract class FMLHandshakeMessage {
         @Override
         public void toBytes(ByteBuf buffer)
         {
+            System.out.println("SEND");
             buffer.writeByte(NetworkRegistry.FML_PROTOCOL);
             buffer.writeInt(overrideDimension);
         }
@@ -72,6 +73,7 @@ public abstract class FMLHandshakeMessage {
         @Override
         public void fromBytes(ByteBuf buffer)
         {
+            System.out.println("READ");
             serverProtocolVersion = buffer.readByte();
             // Extended dimension support during login
             if (serverProtocolVersion > 1)

--- a/src/main/java/net/minecraftforge/fml/common/network/handshake/FMLHandshakeMessage.java
+++ b/src/main/java/net/minecraftforge/fml/common/network/handshake/FMLHandshakeMessage.java
@@ -65,7 +65,6 @@ public abstract class FMLHandshakeMessage {
         @Override
         public void toBytes(ByteBuf buffer)
         {
-            System.out.println("SEND");
             buffer.writeByte(NetworkRegistry.FML_PROTOCOL);
             buffer.writeInt(overrideDimension);
         }
@@ -73,7 +72,6 @@ public abstract class FMLHandshakeMessage {
         @Override
         public void fromBytes(ByteBuf buffer)
         {
-            System.out.println("READ");
             serverProtocolVersion = buffer.readByte();
             // Extended dimension support during login
             if (serverProtocolVersion > 1)

--- a/src/main/java/net/minecraftforge/fml/common/network/handshake/HandshakeMessageHandler.java
+++ b/src/main/java/net/minecraftforge/fml/common/network/handshake/HandshakeMessageHandler.java
@@ -43,26 +43,30 @@ public class HandshakeMessageHandler<S extends Enum<S> & IHandshakeState<S>> ext
     @Override
     protected void channelRead0(ChannelHandlerContext ctx, FMLHandshakeMessage msg) throws Exception
     {
-        S state = ctx.attr(fmlHandshakeState).get();
+        S state = ctx.channel().attr(fmlHandshakeState).get();
         FMLLog.log.debug("{}: {}->{}:{}", stateType.getSimpleName(), msg.toString(stateType), state.getClass().getName().substring(state.getClass().getName().lastIndexOf('.')+1), state);
-        S newState = state.accept(ctx, msg);
-        FMLLog.log.debug("  Next: {}", newState.name());
-        ctx.attr(fmlHandshakeState).set(newState);
+        state.accept(ctx, msg, s ->
+        {
+            FMLLog.log.debug("  Next: {}", s.name());
+            ctx.channel().attr(fmlHandshakeState).set(s);
+        });
     }
 
     @Override
     public void channelActive(ChannelHandlerContext ctx) throws Exception
     {
-        ctx.attr(fmlHandshakeState).set(initialState);
+        ctx.channel().attr(fmlHandshakeState).set(initialState);
     }
     @Override
     public void userEventTriggered(ChannelHandlerContext ctx, Object evt) throws Exception
     {
         S state = ctx.attr(fmlHandshakeState).get();
         FMLLog.log.debug("{}: null->{}:{}", stateType.getSimpleName(), state.getClass().getName().substring(state.getClass().getName().lastIndexOf('.')+1), state);
-        S newState = state.accept(ctx, null);
-        FMLLog.log.debug("  Next: {}", newState.name());
-        ctx.attr(fmlHandshakeState).set(newState);
+        state.accept(ctx, null, s ->
+        {
+            FMLLog.log.debug("  Next: {}", s.name());
+            ctx.channel().attr(fmlHandshakeState).set(s);
+        });
     }
 
     @Override

--- a/src/main/java/net/minecraftforge/fml/common/network/handshake/IHandshakeState.java
+++ b/src/main/java/net/minecraftforge/fml/common/network/handshake/IHandshakeState.java
@@ -21,8 +21,16 @@ package net.minecraftforge.fml.common.network.handshake;
 
 import io.netty.channel.ChannelHandlerContext;
 
+import java.util.function.Consumer;
+
 import javax.annotation.Nullable;
 
 public interface IHandshakeState<S> {
-    S accept(ChannelHandlerContext ctx, @Nullable FMLHandshakeMessage msg);
+    /**
+     * Accepts FML handshake message for this state, and if needed - switches to another handshake state
+     * using the provided consumer.
+     *
+     * The consumer allows to set new state before sending any messages to avoid race conditions.
+     */
+    void accept(ChannelHandlerContext ctx, @Nullable FMLHandshakeMessage msg, Consumer<? super S> cons);
 }


### PR DESCRIPTION
~~This fixes a race condition introduced in 3fee319. I fixed it by running the code previously in `handlerAdded` on the netty thread (using the same way netty does it for running `handlerAdded`).~~

~~I described a few other ways it could be fixed in #4285, but I think this is the best one, without changing a lot of code.~~

There are 2 parts to make sure it's fixed:
 * Make sure that when processing handshake messages, new state is set before sending any packets.

I think setting autoRead to false should be enough to fix it, but I don't understand enough of netty to make that work (and it may be a bug in netty)

The issue in #4285 is that the `START` handshake state handler is called from server thread, which makes it possible to server to receive reply before the method returns.

The issue in #3974 is that the client `START` handler calls `clientListenForServerHandshake` which may read messages from server before setting new state.

Both should be fixed just my making sure the new state is set before doing anything important.