### PR TITLE
Adjust diffuse light calculation to match vanilla facing values

### DIFF
--- a/src/main/java/net/minecraftforge/client/model/pipeline/LightUtil.java
+++ b/src/main/java/net/minecraftforge/client/model/pipeline/LightUtil.java
@@ -36,12 +36,9 @@ import com.google.common.cache.LoadingCache;
 
 public class LightUtil
 {
-    private static final float s2 = (float)Math.pow(2, .5);
-
     public static float diffuseLight(float x, float y, float z)
     {
-        float y1 = y + 3 - 2 * s2;
-        return (x * x * 0.6f + (y1 * y1 * (3 + 2 * s2)) / 8 + z * z * 0.8f);
+        return x * x * 0.6f + y * y * ((3f + y) / 4f) + z * z * 0.8f;
     }
 
     public static float diffuseLight(EnumFacing side)


### PR DESCRIPTION
This adjusts the calculation performed by `diffuseLight` to fix a small inconsistency between the Forge and vanilla lighting pipelines.

To illustrate the change, here's a plot of the resulting y component:
![diffuse](https://user-images.githubusercontent.com/1447117/29281918-b7cfed58-8118-11e7-8bc6-c202114cc41c.png)

The main issue is the non-zero value produced for an input of zero with the current function. As a result, `diffuseLight(1f, 0f, 0f) != diffuseLight(EnumFacing.EAST)`, etc.

As an example of the difference, see the following screenshots (taken with smooth lighting disabled).

* Forge pipeline, before changes:
![diffuse_forge_before](https://user-images.githubusercontent.com/1447117/29281688-ee2a89b8-8117-11e7-849f-2368efed5a55.png)

* Forge pipeline, after changes:
![diffuse_forge_after](https://user-images.githubusercontent.com/1447117/29282116-74637dae-8119-11e7-852b-00cda68831a3.png)

* Vanilla pipeline:
![diffuse_vanilla](https://user-images.githubusercontent.com/1447117/29281722-06b8e8a8-8118-11e7-870c-303584b068af.png)
