### PR TITLE
[1.12] Fix wood plank ore dictionary recipes

### DIFF
--- a/src/main/java/net/minecraftforge/oredict/OreDictionary.java
+++ b/src/main/java/net/minecraftforge/oredict/OreDictionary.java
@@ -335,8 +335,8 @@ public class OreDictionary
             new ItemStack(Blocks.SPRUCE_FENCE),
             new ItemStack(Blocks.SPRUCE_FENCE_GATE),
             new ItemStack(Blocks.SPRUCE_STAIRS),
-            new ItemStack(Blocks.BIRCH_STAIRS),
             new ItemStack(Blocks.BIRCH_FENCE_GATE),
+            new ItemStack(Blocks.BIRCH_FENCE),
             new ItemStack(Blocks.BIRCH_STAIRS),
             new ItemStack(Blocks.JUNGLE_FENCE),
             new ItemStack(Blocks.JUNGLE_FENCE_GATE),
@@ -351,7 +351,17 @@ public class OreDictionary
             new ItemStack(Blocks.GLASS_PANE),
             new ItemStack(Blocks.BONE_BLOCK), // Bone Block, to prevent conversion of dyes into bone meal.
             new ItemStack(Items.BOAT),
+            new ItemStack(Items.SPRUCE_BOAT),
+            new ItemStack(Items.BIRCH_BOAT),
+            new ItemStack(Items.JUNGLE_BOAT),
+            new ItemStack(Items.ACACIA_BOAT),
+            new ItemStack(Items.DARK_OAK_BOAT),
             new ItemStack(Items.OAK_DOOR),
+            new ItemStack(Items.SPRUCE_DOOR),
+            new ItemStack(Items.BIRCH_DOOR),
+            new ItemStack(Items.JUNGLE_DOOR),
+            new ItemStack(Items.ACACIA_DOOR),
+            new ItemStack(Items.DARK_OAK_DOOR),
             ItemStack.EMPTY //So the above can have a comma and we don't have to keep editing extra lines.
         };
 

--- a/src/main/java/net/minecraftforge/oredict/OreDictionary.java
+++ b/src/main/java/net/minecraftforge/oredict/OreDictionary.java
@@ -60,6 +60,7 @@ import javax.annotation.Nonnull;
 
 public class OreDictionary
 {
+    private static final boolean DEBUG = false;
     private static boolean hasInit = false;
     private static List<String>          idToName = new ArrayList<String>();
     private static Map<String, Integer>  nameToId = new HashMap<String, Integer>(128);
@@ -347,7 +348,7 @@ public class OreDictionary
             new ItemStack(Blocks.DARK_OAK_FENCE),
             new ItemStack(Blocks.DARK_OAK_FENCE_GATE),
             new ItemStack(Blocks.DARK_OAK_STAIRS),
-            new ItemStack(Blocks.WOODEN_SLAB),
+            new ItemStack(Blocks.WOODEN_SLAB, 1, WILDCARD_VALUE),
             new ItemStack(Blocks.GLASS_PANE),
             new ItemStack(Blocks.BONE_BLOCK), // Bone Block, to prevent conversion of dyes into bone meal.
             new ItemStack(Items.BOAT),
@@ -365,6 +366,7 @@ public class OreDictionary
             ItemStack.EMPTY //So the above can have a comma and we don't have to keep editing extra lines.
         };
 
+        FMLLog.log.info("Starts to replace vanilla recipe ingredients with ore ingredients.");
         int replaced = 0;
         // Search vanilla recipes for recipes to replace
         for(IRecipe obj : CraftingManager.REGISTRY)
@@ -372,11 +374,12 @@ public class OreDictionary
             if(obj.getClass() == ShapedRecipes.class || obj.getClass() == ShapelessRecipes.class)
             {
                 ItemStack output = obj.getRecipeOutput();
-                if (!output.isEmpty() && containsMatch(false, exclusions, output))
+                if (!output.isEmpty() && containsMatch(false, new ItemStack[]{ output }, exclusions))
                 {
                     continue;
                 }
 
+                Set<Ingredient> replacedIngs = new HashSet<>();
                 NonNullList<Ingredient> lst = obj.getIngredients();
                 for (int x = 0; x < lst.size(); x++)
                 {
@@ -420,6 +423,11 @@ public class OreDictionary
                         //Replace!
                         lst.set(x, new OreIngredient(oreName));
                         replaced++;
+                        if(DEBUG && replacedIngs.add(ing))
+                        {
+                            String recipeName = obj.getRegistryName().getResourcePath();
+                            FMLLog.log.debug("Replaced {} of the recipe \'{}\' with \"{}\".", ing.getMatchingStacks(), recipeName, oreName);
+                        }
                     }
                 }
             }

--- a/src/main/java/net/minecraftforge/oredict/OreDictionary.java
+++ b/src/main/java/net/minecraftforge/oredict/OreDictionary.java
@@ -222,7 +222,12 @@ public class OreDictionary
 
         // wood-related things
         replacements.put(new ItemStack(Items.STICK), "stickWood");
-        replacements.put(new ItemStack(Blocks.PLANKS), "plankWood");
+        replacements.put(new ItemStack(Blocks.PLANKS, 1, 0), "plankWood");
+        replacements.put(new ItemStack(Blocks.PLANKS, 1, 1), "plankWood");
+        replacements.put(new ItemStack(Blocks.PLANKS, 1, 2), "plankWood");
+        replacements.put(new ItemStack(Blocks.PLANKS, 1, 3), "plankWood");
+        replacements.put(new ItemStack(Blocks.PLANKS, 1, 4), "plankWood");
+        replacements.put(new ItemStack(Blocks.PLANKS, 1, 5), "plankWood");
         replacements.put(new ItemStack(Blocks.PLANKS, 1, WILDCARD_VALUE), "plankWood");
         replacements.put(new ItemStack(Blocks.WOODEN_SLAB, 1, WILDCARD_VALUE), "slabWood");
 

--- a/src/main/java/net/minecraftforge/oredict/OreDictionary.java
+++ b/src/main/java/net/minecraftforge/oredict/OreDictionary.java
@@ -222,7 +222,12 @@ public class OreDictionary
 
         // wood-related things
         replacements.put(new ItemStack(Items.STICK), "stickWood");
-        replacements.put(new ItemStack(Blocks.PLANKS), "plankWood");
+        replacements.put(new ItemStack(Blocks.PLANKS, 1, 0), "plankWood");
+        replacements.put(new ItemStack(Blocks.PLANKS, 1, 1), "plankWood");
+        replacements.put(new ItemStack(Blocks.PLANKS, 1, 2), "plankWood");
+        replacements.put(new ItemStack(Blocks.PLANKS, 1, 3), "plankWood");
+        replacements.put(new ItemStack(Blocks.PLANKS, 1, 4), "plankWood");
+        replacements.put(new ItemStack(Blocks.PLANKS, 1, 5), "plankWood");
         replacements.put(new ItemStack(Blocks.PLANKS, 1, WILDCARD_VALUE), "plankWood");
         replacements.put(new ItemStack(Blocks.WOODEN_SLAB, 1, WILDCARD_VALUE), "slabWood");
 
@@ -330,8 +335,8 @@ public class OreDictionary
             new ItemStack(Blocks.SPRUCE_FENCE),
             new ItemStack(Blocks.SPRUCE_FENCE_GATE),
             new ItemStack(Blocks.SPRUCE_STAIRS),
-            new ItemStack(Blocks.BIRCH_STAIRS),
             new ItemStack(Blocks.BIRCH_FENCE_GATE),
+            new ItemStack(Blocks.BIRCH_FENCE),
             new ItemStack(Blocks.BIRCH_STAIRS),
             new ItemStack(Blocks.JUNGLE_FENCE),
             new ItemStack(Blocks.JUNGLE_FENCE_GATE),
@@ -346,7 +351,17 @@ public class OreDictionary
             new ItemStack(Blocks.GLASS_PANE),
             new ItemStack(Blocks.BONE_BLOCK), // Bone Block, to prevent conversion of dyes into bone meal.
             new ItemStack(Items.BOAT),
+            new ItemStack(Items.SPRUCE_BOAT),
+            new ItemStack(Items.BIRCH_BOAT),
+            new ItemStack(Items.JUNGLE_BOAT),
+            new ItemStack(Items.ACACIA_BOAT),
+            new ItemStack(Items.DARK_OAK_BOAT),
             new ItemStack(Items.OAK_DOOR),
+            new ItemStack(Items.SPRUCE_DOOR),
+            new ItemStack(Items.BIRCH_DOOR),
+            new ItemStack(Items.JUNGLE_DOOR),
+            new ItemStack(Items.ACACIA_DOOR),
+            new ItemStack(Items.DARK_OAK_DOOR),
             ItemStack.EMPTY //So the above can have a comma and we don't have to keep editing extra lines.
         };
 


### PR DESCRIPTION
This fixes the OreDictionary recipe replacement system for vanilla recipes that are containing wood planks. 
The OreDictionary recipe replacements system that recplaces the minecarft ingridient with a ore dict ingridient skips the recipe if one ingridient of the recipe has one item that is not in the replacement map or if the item is in the map but has not the same metadata like the item in the map.
https://github.com/MinecraftForge/MinecraftForge/blob/1.12.x/src/main/java/net/minecraftforge/oredict/OreDictionary.java#L371-L402
The wood recipes are containing a ingridient that contains all 6 minecraft wood plank blocks.
`[
      {
        "item": "minecraft:planks",
        "data": 0
      },
      {
        "item": "minecraft:planks",
        "data": 1
      },
      {
        "item": "minecraft:planks",
        "data": 2
      },
      {
        "item": "minecraft:planks",
        "data": 3
      },
      {
        "item": "minecraft:planks",
        "data": 4
      },
      {
        "item": "minecraft:planks",
        "data": 5
      }
    ]`
But the replacement map only contains the plank with the meta 0 and not the other five blocks with the metadatas from 1 to 5. 
https://github.com/MinecraftForge/MinecraftForge/blob/1.12.x/src/main/java/net/minecraftforge/oredict/OreDictionary.java#L225
According to this all vanilla recipes that are containing a wood plank as an ingedient don't using a ore dict ingridient. Because of this all wood planks that are added by mods and registered with the name 
`"plankWood"` in the ore dictionary can't be used to create crafting tables or sticks.
Sorry for my bad english.