### PR TITLE
Fix UnknownFormatConversionException during TE/Entity removal

### DIFF
--- a/patches/minecraft/net/minecraft/world/World.java.patch
+++ b/patches/minecraft/net/minecraft/world/World.java.patch
@@ -421,7 +421,7 @@
                          tileentity.func_145828_a(crashreportcategory2);
 +                        if (net.minecraftforge.common.ForgeModContainer.removeErroringTileEntities)
 +                        {
-+                            net.minecraftforge.fml.common.FMLLog.log.fatal(crashreport2.func_71502_e());
++                            net.minecraftforge.fml.common.FMLLog.log.fatal("{}", crashreport2.func_71502_e());
 +                            tileentity.func_145843_s();
 +                            this.func_175713_t(tileentity.func_174877_v());
 +                        }

--- a/patches/minecraft/net/minecraft/world/World.java.patch
+++ b/patches/minecraft/net/minecraft/world/World.java.patch
@@ -386,7 +386,7 @@
  
 +                if (net.minecraftforge.common.ForgeModContainer.removeErroringEntities)
 +                {
-+                    net.minecraftforge.fml.common.FMLLog.log.fatal(crashreport.func_71502_e());
++                    net.minecraftforge.fml.common.FMLLog.log.fatal("{}", crashreport.func_71502_e());
 +                    func_72900_e(entity);
 +                }
 +                else
@@ -399,7 +399,7 @@
                      entity2.func_85029_a(crashreportcategory1);
 +                    if (net.minecraftforge.common.ForgeModContainer.removeErroringEntities)
 +                    {
-+                        net.minecraftforge.fml.common.FMLLog.log.fatal(crashreport1.func_71502_e());
++                        net.minecraftforge.fml.common.FMLLog.log.fatal("{}", crashreport1.func_71502_e());
 +                        func_72900_e(entity2);
 +                    }
 +                    else


### PR DESCRIPTION
Fixes an exception that may be thrown while logging the exception that caused an erroring Tile Entity to be removed.

Example exception:

```
java.util.UnknownFormatConversionException: Conversion = 'p'
	at java.util.Formatter$FormatSpecifier.conversion(Unknown Source)
	at java.util.Formatter$FormatSpecifier.<init>(Unknown Source)
	at java.util.Formatter.parse(Unknown Source)
	at java.util.Formatter.format(Unknown Source)
	at java.util.Formatter.format(Unknown Source)
	at java.lang.String.format(Unknown Source)
	at net.minecraftforge.fml.relauncher.FMLRelaunchLog.log(FMLRelaunchLog.java:78)
	at net.minecraftforge.fml.common.FMLLog.log(FMLLog.java:37)
	at net.minecraftforge.fml.common.FMLLog.severe(FMLLog.java:52)
	at net.minecraft.world.World.func_72939_s(World.java:1814)
	at net.minecraft.world.WorldServer.func_72939_s(WorldServer.java:620)
	at net.minecraft.server.MinecraftServer.func_71190_q(MinecraftServer.java:709)
	at net.minecraft.server.MinecraftServer.func_71217_p(MinecraftServer.java:613)
	at net.minecraft.server.integrated.IntegratedServer.func_71217_p(IntegratedServer.java:149)
	at net.minecraft.server.MinecraftServer.run(MinecraftServer.java:471)
	at java.lang.Thread.run(Unknown Source)
```