### PR TITLE
Improve generation of normals for vanilla models

### DIFF
--- a/src/main/java/net/minecraftforge/client/ForgeHooksClient.java
+++ b/src/main/java/net/minecraftforge/client/ForgeHooksClient.java
@@ -575,11 +575,11 @@ public class ForgeHooksClient
      */
     public static void fillNormal(int[] faceData, EnumFacing facing)
     {
-        Vector3f v1 = new Vector3f(faceData[3 * 7 + 0], faceData[3 * 7 + 1], faceData[3 * 7 + 2]);
-        Vector3f t = new Vector3f(faceData[1 * 7 + 0], faceData[1 * 7 + 1], faceData[1 * 7 + 2]);
-        Vector3f v2 = new Vector3f(faceData[2 * 7 + 0], faceData[2 * 7 + 1], faceData[2 * 7 + 2]);
+        Vector3f v1 = getVertexPos(faceData, 3);
+        Vector3f t = getVertexPos(faceData, 1);
+        Vector3f v2 = getVertexPos(faceData, 2);
         v1.sub(t);
-        t.set(faceData[0 * 7 + 0], faceData[0 * 7 + 1], faceData[0 * 7 + 2]);
+        t.set(getVertexPos(faceData, 0));
         v2.sub(t);
         v1.cross(v2, v1);
         v1.normalize();
@@ -591,6 +591,17 @@ public class ForgeHooksClient
         {
             faceData[i * 7 + 6] = x | (y << 0x08) | (z << 0x10);
         }
+    }
+
+    private static Vector3f getVertexPos(int[] data, int vertex)
+    {
+        int idx = vertex * 7;
+
+        float x = Float.intBitsToFloat(data[idx]);
+        float y = Float.intBitsToFloat(data[idx + 1]);
+        float z = Float.intBitsToFloat(data[idx + 2]);
+
+        return new Vector3f(x, y, z);
     }
 
     @SuppressWarnings("deprecation")

--- a/src/main/java/net/minecraftforge/client/ForgeHooksClient.java
+++ b/src/main/java/net/minecraftforge/client/ForgeHooksClient.java
@@ -584,9 +584,9 @@ public class ForgeHooksClient
         v1.cross(v2, v1);
         v1.normalize();
 
-        int x = ((byte)(v1.x * 127)) & 0xFF;
-        int y = ((byte)(v1.y * 127)) & 0xFF;
-        int z = ((byte)(v1.z * 127)) & 0xFF;
+        int x = ((byte) Math.round(v1.x * 127)) & 0xFF;
+        int y = ((byte) Math.round(v1.y * 127)) & 0xFF;
+        int z = ((byte) Math.round(v1.z * 127)) & 0xFF;
         for(int i = 0; i < 4; i++)
         {
             faceData[i * 7 + 6] = x | (y << 0x08) | (z << 0x10);

--- a/src/main/java/net/minecraftforge/client/ForgeHooksClient.java
+++ b/src/main/java/net/minecraftforge/client/ForgeHooksClient.java
@@ -576,7 +576,7 @@ public class ForgeHooksClient
     public static void fillNormal(int[] faceData, EnumFacing facing)
     {
         Vector3f v1 = getVertexPos(faceData, 3);
-        Vector3f t = getVertexPos(faceData, 1);
+        Vector3f t  = getVertexPos(faceData, 1);
         Vector3f v2 = getVertexPos(faceData, 2);
         v1.sub(t);
         t.set(getVertexPos(faceData, 0));
@@ -587,9 +587,12 @@ public class ForgeHooksClient
         int x = ((byte) Math.round(v1.x * 127)) & 0xFF;
         int y = ((byte) Math.round(v1.y * 127)) & 0xFF;
         int z = ((byte) Math.round(v1.z * 127)) & 0xFF;
+
+        int normal = x | (y << 0x08) | (z << 0x10);
+
         for(int i = 0; i < 4; i++)
         {
-            faceData[i * 7 + 6] = x | (y << 0x08) | (z << 0x10);
+            faceData[i * 7 + 6] = normal;
         }
     }
 


### PR DESCRIPTION
Should fix #4178.

Because of how the conversion was handled here, any float values even slightly less than 1 would have produced an output value of 126 instead of 127. This is why the rotated models were the ones affected, due to being subject to potentially lossy floating point operations.

Rounding the values to the closest whole number instead of simply truncating them should solve the issue.

