### PR TITLE
Adjust float (un)packing functions to be slightly more accurate

### DIFF
--- a/src/main/java/net/minecraftforge/client/model/pipeline/LightUtil.java
+++ b/src/main/java/net/minecraftforge/client/model/pipeline/LightUtil.java
@@ -194,15 +194,15 @@ public class LightUtil
                 }
                 else if(type == VertexFormatElement.EnumType.BYTE)
                 {
-                    to[i] = ((float)(byte)bits) / mask * 2;
+                    to[i] = ((float)(byte)bits) / (mask >> 1);
                 }
                 else if(type == VertexFormatElement.EnumType.SHORT)
                 {
-                    to[i] = ((float)(short)bits) / mask * 2;
+                    to[i] = ((float)(short)bits) / (mask >> 1);
                 }
                 else if(type == VertexFormatElement.EnumType.INT)
                 {
-                    to[i] = ((float)(bits & 0xFFFFFFFFL)) / 0xFFFFFFFFL * 2;
+                    to[i] = (float)((double)(bits & 0xFFFFFFFFL) / (0xFFFFFFFFL >> 1));
                 }
             }
             else
@@ -239,11 +239,11 @@ public class LightUtil
                     type == VertexFormatElement.EnumType.UINT
                 )
                 {
-                    bits = (int)(f * mask);
+                    bits = Math.round(f * mask);
                 }
                 else
                 {
-                    bits = (int)(f * mask / 2);
+                    bits = Math.round(f * (mask >> 1));
                 }
                 to[index] &= ~(mask << (offset * 8));
                 to[index] |= (((bits & mask) << (offset * 8)));


### PR DESCRIPTION
Main changes here are rounding to the nearest value when packing values, and using the correct divisor when unpacking them.

This helps to preserve, for instance, a value of ~1 (say 0.999997). After converting to/from a signed byte It should come out as 1 with these changes, whereas previously it would be 254/255, or even 252/255 (~0.988). The resulting difference can lead to noticeable effects (as shown in #4313), especially as the values are often later squared during processing.