### PR TITLE
Fix CustomModLoadingErrorDisplayScreen not being handled during init or preinit.

### DIFF
--- a/src/main/java/net/minecraftforge/fml/client/FMLClientHandler.java
+++ b/src/main/java/net/minecraftforge/fml/client/FMLClientHandler.java
@@ -267,11 +267,14 @@ public class FMLClientHandler implements IFMLSidedHandler
         }
         catch (LoaderException le)
         {
-            if(le.getCause() instanceof CustomModLoadingErrorDisplayException){
+            if (le.getCause() instanceof CustomModLoadingErrorDisplayException)
+            {
                 CustomModLoadingErrorDisplayException custom = (CustomModLoadingErrorDisplayException) le.getCause();
                 FMLLog.log.error("A custom exception was thrown by a mod, the game will now halt", custom);
                 customError = custom;
-            } else {
+            }
+            else
+            {
                 haltGame("There was a severe problem during mod loading that has caused the game to fail", le);
                 return;
             }
@@ -346,11 +349,14 @@ public class FMLClientHandler implements IFMLSidedHandler
         }
         catch (LoaderException le)
         {
-            if(le.getCause() instanceof CustomModLoadingErrorDisplayException){
+            if (le.getCause() instanceof CustomModLoadingErrorDisplayException)
+            {
                 CustomModLoadingErrorDisplayException custom = (CustomModLoadingErrorDisplayException) le.getCause();
                 FMLLog.log.error("A custom exception was thrown by a mod, the game will now halt", custom);
                 customError = custom;
-            } else {
+            }
+            else
+            {
                 haltGame("There was a severe problem during mod loading that has caused the game to fail", le);
                 return;
             }
@@ -391,7 +397,7 @@ public class FMLClientHandler implements IFMLSidedHandler
         }
         loading = false;
         client.gameSettings.loadOptions(); //Reload options to load any mod added keybindings.
-        if(customError == null)
+        if (customError == null)
             Loader.instance().loadingComplete();
         SplashProgress.finish();
     }

--- a/src/main/java/net/minecraftforge/fml/client/FMLClientHandler.java
+++ b/src/main/java/net/minecraftforge/fml/client/FMLClientHandler.java
@@ -265,16 +265,18 @@ public class FMLClientHandler implements IFMLSidedHandler
         {
             Loader.instance().preinitializeMods();
         }
-        catch (CustomModLoadingErrorDisplayException custom)
-        {
-            FMLLog.log.error("A custom exception was thrown by a mod, the game will now halt", custom);
-            customError = custom;
-        }
         catch (LoaderException le)
         {
-            haltGame("There was a severe problem during mod loading that has caused the game to fail", le);
-            return;
+            if(le.getCause() instanceof CustomModLoadingErrorDisplayException){
+                CustomModLoadingErrorDisplayException custom = (CustomModLoadingErrorDisplayException) le.getCause();
+                FMLLog.log.error("A custom exception was thrown by a mod, the game will now halt", custom);
+                customError = custom;
+            } else {
+                haltGame("There was a severe problem during mod loading that has caused the game to fail", le);
+                return;
+            }
         }
+
         Map<String,Map<String,String>> sharedModList = (Map<String, Map<String, String>>) Launch.blackboard.get("modList");
         if (sharedModList == null)
         {

--- a/src/main/java/net/minecraftforge/fml/client/FMLClientHandler.java
+++ b/src/main/java/net/minecraftforge/fml/client/FMLClientHandler.java
@@ -344,17 +344,16 @@ public class FMLClientHandler implements IFMLSidedHandler
         {
             Loader.instance().initializeMods();
         }
-        catch (CustomModLoadingErrorDisplayException custom)
-        {
-            FMLLog.log.error("A custom exception was thrown by a mod, the game will now halt", custom);
-            customError = custom;
-            SplashProgress.finish();
-            return;
-        }
         catch (LoaderException le)
         {
-            haltGame("There was a severe problem during mod loading that has caused the game to fail", le);
-            return;
+            if(le.getCause() instanceof CustomModLoadingErrorDisplayException){
+                CustomModLoadingErrorDisplayException custom = (CustomModLoadingErrorDisplayException) le.getCause();
+                FMLLog.log.error("A custom exception was thrown by a mod, the game will now halt", custom);
+                customError = custom;
+            } else {
+                haltGame("There was a severe problem during mod loading that has caused the game to fail", le);
+                return;
+            }
         }
 
         // This call is being phased out for performance reasons in 1.12,
@@ -392,7 +391,8 @@ public class FMLClientHandler implements IFMLSidedHandler
         }
         loading = false;
         client.gameSettings.loadOptions(); //Reload options to load any mod added keybindings.
-        Loader.instance().loadingComplete();
+        if(customError == null)
+            Loader.instance().loadingComplete();
         SplashProgress.finish();
     }
 

--- a/src/main/java/net/minecraftforge/fml/client/GuiCustomModLoadingErrorScreen.java
+++ b/src/main/java/net/minecraftforge/fml/client/GuiCustomModLoadingErrorScreen.java
@@ -24,7 +24,6 @@ public class GuiCustomModLoadingErrorScreen extends GuiErrorBase
     private CustomModLoadingErrorDisplayException customException;
     public GuiCustomModLoadingErrorScreen(CustomModLoadingErrorDisplayException customException)
     {
-        super();
         this.customException = customException;
     }
     @Override

--- a/src/main/java/net/minecraftforge/fml/client/GuiCustomModLoadingErrorScreen.java
+++ b/src/main/java/net/minecraftforge/fml/client/GuiCustomModLoadingErrorScreen.java
@@ -19,27 +19,25 @@
 
 package net.minecraftforge.fml.client;
 
-import net.minecraft.client.gui.GuiErrorScreen;
-
-public class GuiCustomModLoadingErrorScreen extends GuiErrorScreen
+public class GuiCustomModLoadingErrorScreen extends GuiErrorBase
 {
     private CustomModLoadingErrorDisplayException customException;
     public GuiCustomModLoadingErrorScreen(CustomModLoadingErrorDisplayException customException)
     {
-        super(null,null);
+        super();
         this.customException = customException;
     }
     @Override
     public void initGui()
     {
         super.initGui();
-        this.buttonList.clear();
         this.customException.initGui(this, fontRenderer);
     }
     @Override
     public void drawScreen(int mouseX, int mouseY, float partialTicks)
     {
         this.drawDefaultBackground();
+        super.drawScreen(mouseX, mouseY, partialTicks);
         this.customException.drawScreen(this, fontRenderer, mouseX, mouseY, partialTicks);
     }
 }

--- a/src/test/java/net/minecraftforge/debug/ClientExceptionTestMod.java
+++ b/src/test/java/net/minecraftforge/debug/ClientExceptionTestMod.java
@@ -6,10 +6,8 @@ import net.minecraftforge.fml.client.CustomModLoadingErrorDisplayException;
 import net.minecraftforge.fml.common.Mod;
 import net.minecraftforge.fml.common.event.FMLInitializationEvent;
 import net.minecraftforge.fml.common.event.FMLPreInitializationEvent;
-import net.minecraftforge.fml.relauncher.Side;
-import net.minecraftforge.fml.relauncher.SideOnly;
 
-@Mod(modid = "clientexceptiontest", version = "0", name = "Client Exception Test")
+@Mod(modid = "clientexceptiontest", version = "0", name = "Client Exception Test", clientSideOnly = true)
 public class ClientExceptionTestMod
 {
 
@@ -18,44 +16,36 @@ public class ClientExceptionTestMod
     private static String LOREM_IPSUM = "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.";
 
     @Mod.EventHandler
-    @SideOnly(Side.CLIENT)
     public void onPreInit(FMLPreInitializationEvent e)
     {
         if (ENABLE_PREINIT)
         {
-            throw new CustomModLoadingErrorDisplayException("Custom Test Exception", new RuntimeException("Thrown in Pre-Init"))
-            {
-                @Override
-                public void initGui(GuiErrorScreen parent, FontRenderer fontRenderer) {}
-
-                @Override
-                public void drawScreen(GuiErrorScreen parent, FontRenderer fontRenderer, int mouseRelX, int mouseRelY, float tickTime)
-                {
-                    parent.drawCenteredString(parent.mc.fontRenderer, "Custom Test Exception", parent.width / 2, 90, 16777215);
-                    parent.drawCenteredString(parent.mc.fontRenderer, LOREM_IPSUM, parent.width / 2, 110, 16777215);
-                }
-            };
+            throwException("Thrown in Pre-Init");
         }
     }
 
     @Mod.EventHandler
-    @SideOnly(Side.CLIENT)
     public void onInit(FMLInitializationEvent e)
     {
         if (ENABLE_INIT)
         {
-            throw new CustomModLoadingErrorDisplayException("Custom Test Exception", new RuntimeException("Thrown in Initialization"))
-            {
-                @Override
-                public void initGui(GuiErrorScreen parent, FontRenderer fontRenderer) {}
-
-                @Override
-                public void drawScreen(GuiErrorScreen parent, FontRenderer fontRenderer, int mouseRelX, int mouseRelY, float tickTime)
-                {
-                    parent.drawCenteredString(parent.mc.fontRenderer, "Custom Test Exception", parent.width / 2, 90, 16777215);
-                    parent.drawCenteredString(parent.mc.fontRenderer, LOREM_IPSUM, parent.width / 2, 110, 16777215);
-                }
-            };
+            throwException("Thrown in Init");
         }
+    }
+
+    private void throwException(String runtimeMessage)
+    {
+        throw new CustomModLoadingErrorDisplayException("Custom Test Exception", new RuntimeException(runtimeMessage))
+        {
+            @Override
+            public void initGui(GuiErrorScreen parent, FontRenderer fontRenderer) {}
+
+            @Override
+            public void drawScreen(GuiErrorScreen parent, FontRenderer fontRenderer, int mouseRelX, int mouseRelY, float tickTime)
+            {
+                parent.drawCenteredString(parent.mc.fontRenderer, "Custom Test Exception", parent.width / 2, 90, 16777215);
+                parent.drawCenteredString(parent.mc.fontRenderer, LOREM_IPSUM, parent.width / 2, 110, 16777215);
+            }
+        };
     }
 }

--- a/src/test/java/net/minecraftforge/debug/ClientExceptionTestMod.java
+++ b/src/test/java/net/minecraftforge/debug/ClientExceptionTestMod.java
@@ -14,7 +14,7 @@ public class ClientExceptionTestMod
 {
 
     // Disabled so other test mods can still work.
-    public static boolean ENABLE_PREINIT = false, ENABLE_INIT = true;
+    public static boolean ENABLE_PREINIT = false, ENABLE_INIT = false;
     private static String LOREM_IPSUM = "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.";
 
     @Mod.EventHandler

--- a/src/test/java/net/minecraftforge/debug/ClientExceptionTestMod.java
+++ b/src/test/java/net/minecraftforge/debug/ClientExceptionTestMod.java
@@ -1,0 +1,34 @@
+package net.minecraftforge.debug;
+
+import net.minecraft.client.gui.FontRenderer;
+import net.minecraft.client.gui.GuiErrorScreen;
+import net.minecraftforge.fml.client.CustomModLoadingErrorDisplayException;
+import net.minecraftforge.fml.common.Mod;
+import net.minecraftforge.fml.common.event.FMLPreInitializationEvent;
+import net.minecraftforge.fml.relauncher.Side;
+import net.minecraftforge.fml.relauncher.SideOnly;
+
+@Mod(modid = "clientexceptiontest", version = "0", name = "Client Exception Test")
+public class ClientExceptionTestMod {
+
+    // Disabled so other test mods can still work.
+    public static boolean ENABLED = false;
+
+    @Mod.EventHandler
+    @SideOnly(Side.CLIENT)
+    public void onPreInit(FMLPreInitializationEvent e) {
+        if (ENABLED) {
+            throw new CustomModLoadingErrorDisplayException("Custom Test Exception", new RuntimeException("Backing Exception")) {
+                @Override
+                public void initGui(GuiErrorScreen parent, FontRenderer fontRenderer) {
+                }
+
+                @Override
+                public void drawScreen(GuiErrorScreen parent, FontRenderer fontRenderer, int mouseRelX, int mouseRelY, float tickTime) {
+                    parent.drawCenteredString(parent.mc.fontRenderer, "Custom Test Exception", parent.width / 2, 90, 16777215);
+                    parent.drawCenteredString(parent.mc.fontRenderer, "Exception Message!", parent.width / 2, 110, 16777215);
+                }
+            };
+        }
+    }
+}

--- a/src/test/java/net/minecraftforge/debug/ClientExceptionTestMod.java
+++ b/src/test/java/net/minecraftforge/debug/ClientExceptionTestMod.java
@@ -4,6 +4,7 @@ import net.minecraft.client.gui.FontRenderer;
 import net.minecraft.client.gui.GuiErrorScreen;
 import net.minecraftforge.fml.client.CustomModLoadingErrorDisplayException;
 import net.minecraftforge.fml.common.Mod;
+import net.minecraftforge.fml.common.event.FMLInitializationEvent;
 import net.minecraftforge.fml.common.event.FMLPreInitializationEvent;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
@@ -12,13 +13,14 @@ import net.minecraftforge.fml.relauncher.SideOnly;
 public class ClientExceptionTestMod {
 
     // Disabled so other test mods can still work.
-    public static boolean ENABLED = false;
+    public static boolean ENABLE_PREINIT = false, ENABLE_INIT = false;
+    private static String LOREM_IPSUM = "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.";
 
     @Mod.EventHandler
     @SideOnly(Side.CLIENT)
     public void onPreInit(FMLPreInitializationEvent e) {
-        if (ENABLED) {
-            throw new CustomModLoadingErrorDisplayException("Custom Test Exception", new RuntimeException("Backing Exception")) {
+        if (ENABLE_PREINIT) {
+            throw new CustomModLoadingErrorDisplayException("Custom Test Exception", new RuntimeException("Thrown in Pre-Init")) {
                 @Override
                 public void initGui(GuiErrorScreen parent, FontRenderer fontRenderer) {
                 }
@@ -26,7 +28,25 @@ public class ClientExceptionTestMod {
                 @Override
                 public void drawScreen(GuiErrorScreen parent, FontRenderer fontRenderer, int mouseRelX, int mouseRelY, float tickTime) {
                     parent.drawCenteredString(parent.mc.fontRenderer, "Custom Test Exception", parent.width / 2, 90, 16777215);
-                    parent.drawCenteredString(parent.mc.fontRenderer, "Exception Message!", parent.width / 2, 110, 16777215);
+                    parent.drawCenteredString(parent.mc.fontRenderer, LOREM_IPSUM, parent.width / 2, 110, 16777215);
+                }
+            };
+        }
+    }
+
+    @Mod.EventHandler
+    @SideOnly(Side.CLIENT)
+    public void onInit(FMLInitializationEvent e) {
+        if (ENABLE_INIT) {
+            throw new CustomModLoadingErrorDisplayException("Custom Test Exception", new RuntimeException("Thrown in Initialization")) {
+                @Override
+                public void initGui(GuiErrorScreen parent, FontRenderer fontRenderer) {
+                }
+
+                @Override
+                public void drawScreen(GuiErrorScreen parent, FontRenderer fontRenderer, int mouseRelX, int mouseRelY, float tickTime) {
+                    parent.drawCenteredString(parent.mc.fontRenderer, "Custom Test Exception", parent.width / 2, 90, 16777215);
+                    parent.drawCenteredString(parent.mc.fontRenderer, LOREM_IPSUM, parent.width / 2, 110, 16777215);
                 }
             };
         }

--- a/src/test/java/net/minecraftforge/debug/ClientExceptionTestMod.java
+++ b/src/test/java/net/minecraftforge/debug/ClientExceptionTestMod.java
@@ -13,17 +13,18 @@ import net.minecraftforge.fml.relauncher.SideOnly;
 public class ClientExceptionTestMod {
 
     // Disabled so other test mods can still work.
-    public static boolean ENABLE_PREINIT = false, ENABLE_INIT = false;
+    public static boolean ENABLE_PREINIT = false, ENABLE_INIT = true;
     private static String LOREM_IPSUM = "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.";
 
     @Mod.EventHandler
     @SideOnly(Side.CLIENT)
     public void onPreInit(FMLPreInitializationEvent e) {
-        if (ENABLE_PREINIT) {
-            throw new CustomModLoadingErrorDisplayException("Custom Test Exception", new RuntimeException("Thrown in Pre-Init")) {
+        if (ENABLE_PREINIT)
+        {
+            throw new CustomModLoadingErrorDisplayException("Custom Test Exception", new RuntimeException("Thrown in Pre-Init"))
+            {
                 @Override
-                public void initGui(GuiErrorScreen parent, FontRenderer fontRenderer) {
-                }
+                public void initGui(GuiErrorScreen parent, FontRenderer fontRenderer) {}
 
                 @Override
                 public void drawScreen(GuiErrorScreen parent, FontRenderer fontRenderer, int mouseRelX, int mouseRelY, float tickTime) {
@@ -37,11 +38,12 @@ public class ClientExceptionTestMod {
     @Mod.EventHandler
     @SideOnly(Side.CLIENT)
     public void onInit(FMLInitializationEvent e) {
-        if (ENABLE_INIT) {
-            throw new CustomModLoadingErrorDisplayException("Custom Test Exception", new RuntimeException("Thrown in Initialization")) {
+        if (ENABLE_INIT)
+        {
+            throw new CustomModLoadingErrorDisplayException("Custom Test Exception", new RuntimeException("Thrown in Initialization"))
+            {
                 @Override
-                public void initGui(GuiErrorScreen parent, FontRenderer fontRenderer) {
-                }
+                public void initGui(GuiErrorScreen parent, FontRenderer fontRenderer) {}
 
                 @Override
                 public void drawScreen(GuiErrorScreen parent, FontRenderer fontRenderer, int mouseRelX, int mouseRelY, float tickTime) {

--- a/src/test/java/net/minecraftforge/debug/ClientExceptionTestMod.java
+++ b/src/test/java/net/minecraftforge/debug/ClientExceptionTestMod.java
@@ -7,7 +7,7 @@ import net.minecraftforge.fml.common.Mod;
 import net.minecraftforge.fml.common.event.FMLInitializationEvent;
 import net.minecraftforge.fml.common.event.FMLPreInitializationEvent;
 
-@Mod(modid = "clientexceptiontest", version = "0", name = "Client Exception Test", clientSideOnly = true)
+@Mod(modid = "clientexceptiontest", version = "1.0", name = "Client Exception Test", clientSideOnly = true)
 public class ClientExceptionTestMod
 {
 

--- a/src/test/java/net/minecraftforge/debug/ClientExceptionTestMod.java
+++ b/src/test/java/net/minecraftforge/debug/ClientExceptionTestMod.java
@@ -10,7 +10,8 @@ import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
 
 @Mod(modid = "clientexceptiontest", version = "0", name = "Client Exception Test")
-public class ClientExceptionTestMod {
+public class ClientExceptionTestMod
+{
 
     // Disabled so other test mods can still work.
     public static boolean ENABLE_PREINIT = false, ENABLE_INIT = true;
@@ -18,7 +19,8 @@ public class ClientExceptionTestMod {
 
     @Mod.EventHandler
     @SideOnly(Side.CLIENT)
-    public void onPreInit(FMLPreInitializationEvent e) {
+    public void onPreInit(FMLPreInitializationEvent e)
+    {
         if (ENABLE_PREINIT)
         {
             throw new CustomModLoadingErrorDisplayException("Custom Test Exception", new RuntimeException("Thrown in Pre-Init"))
@@ -27,7 +29,8 @@ public class ClientExceptionTestMod {
                 public void initGui(GuiErrorScreen parent, FontRenderer fontRenderer) {}
 
                 @Override
-                public void drawScreen(GuiErrorScreen parent, FontRenderer fontRenderer, int mouseRelX, int mouseRelY, float tickTime) {
+                public void drawScreen(GuiErrorScreen parent, FontRenderer fontRenderer, int mouseRelX, int mouseRelY, float tickTime)
+                {
                     parent.drawCenteredString(parent.mc.fontRenderer, "Custom Test Exception", parent.width / 2, 90, 16777215);
                     parent.drawCenteredString(parent.mc.fontRenderer, LOREM_IPSUM, parent.width / 2, 110, 16777215);
                 }
@@ -37,7 +40,8 @@ public class ClientExceptionTestMod {
 
     @Mod.EventHandler
     @SideOnly(Side.CLIENT)
-    public void onInit(FMLInitializationEvent e) {
+    public void onInit(FMLInitializationEvent e)
+    {
         if (ENABLE_INIT)
         {
             throw new CustomModLoadingErrorDisplayException("Custom Test Exception", new RuntimeException("Thrown in Initialization"))
@@ -46,7 +50,8 @@ public class ClientExceptionTestMod {
                 public void initGui(GuiErrorScreen parent, FontRenderer fontRenderer) {}
 
                 @Override
-                public void drawScreen(GuiErrorScreen parent, FontRenderer fontRenderer, int mouseRelX, int mouseRelY, float tickTime) {
+                public void drawScreen(GuiErrorScreen parent, FontRenderer fontRenderer, int mouseRelX, int mouseRelY, float tickTime)
+                {
                     parent.drawCenteredString(parent.mc.fontRenderer, "Custom Test Exception", parent.width / 2, 90, 16777215);
                     parent.drawCenteredString(parent.mc.fontRenderer, LOREM_IPSUM, parent.width / 2, 110, 16777215);
                 }


### PR DESCRIPTION
Also adds missing buttons to GuiCustomModLoadingErrorScreen.

This fixes #4319