### PR TITLE
Added missing MapGen types to the InitMapGenEvent

### DIFF
--- a/patches/minecraft/net/minecraft/world/gen/ChunkGeneratorEnd.java.patch
+++ b/patches/minecraft/net/minecraft/world/gen/ChunkGeneratorEnd.java.patch
@@ -10,7 +10,7 @@
  
      public ChunkGeneratorEnd(World p_i47241_1_, boolean p_i47241_2_, long p_i47241_3_, BlockPos p_i47241_5_)
      {
-@@ -56,6 +59,16 @@
+@@ -56,6 +59,17 @@
          this.field_73214_a = new NoiseGeneratorOctaves(this.field_73220_k, 10);
          this.field_73212_b = new NoiseGeneratorOctaves(this.field_73220_k, 16);
          this.field_185973_o = new NoiseGeneratorSimplex(this.field_73220_k);
@@ -24,10 +24,11 @@
 +        this.field_73214_a = ctx.getDepth();
 +        this.field_73212_b = ctx.getScale();
 +        this.field_185973_o = ctx.getIsland();
++        this.field_185972_n = (MapGenEndCity) net.minecraftforge.event.terraingen.TerrainGen.getModdedMapGen(this.field_185972_n, net.minecraftforge.event.terraingen.InitMapGenEvent.EventType.END_CITY);
      }
  
      public void func_180518_a(int p_180518_1_, int p_180518_2_, ChunkPrimer p_180518_3_)
-@@ -128,6 +141,7 @@
+@@ -128,6 +142,7 @@
  
      public void func_185962_a(ChunkPrimer p_185962_1_)
      {
@@ -35,7 +36,7 @@
          for (int i = 0; i < 16; ++i)
          {
              for (int j = 0; j < 16; ++j)
-@@ -173,6 +187,7 @@
+@@ -173,6 +188,7 @@
  
      public Chunk func_185932_a(int p_185932_1_, int p_185932_2_)
      {
@@ -43,7 +44,7 @@
          this.field_73220_k.setSeed((long)p_185932_1_ * 341873128712L + (long)p_185932_2_ * 132897987541L);
          ChunkPrimer chunkprimer = new ChunkPrimer();
          this.field_73231_z = this.field_73230_p.func_72959_q().func_76933_b(this.field_73231_z, p_185932_1_ * 16, p_185932_2_ * 16, 16, 16);
-@@ -254,6 +269,10 @@
+@@ -254,6 +270,10 @@
  
      private double[] func_185963_a(double[] p_185963_1_, int p_185963_2_, int p_185963_3_, int p_185963_4_, int p_185963_5_, int p_185963_6_, int p_185963_7_)
      {
@@ -54,7 +55,7 @@
          if (p_185963_1_ == null)
          {
              p_185963_1_ = new double[p_185963_5_ * p_185963_6_ * p_185963_7_];
-@@ -326,6 +345,7 @@
+@@ -326,6 +346,7 @@
      public void func_185931_b(int p_185931_1_, int p_185931_2_)
      {
          BlockFalling.field_149832_M = true;
@@ -62,7 +63,7 @@
          BlockPos blockpos = new BlockPos(p_185931_1_ * 16, 0, p_185931_2_ * 16);
  
          if (this.field_73229_q)
-@@ -394,6 +414,7 @@
+@@ -394,6 +415,7 @@
              }
          }
  

--- a/patches/minecraft/net/minecraft/world/gen/ChunkGeneratorOverworld.java.patch
+++ b/patches/minecraft/net/minecraft/world/gen/ChunkGeneratorOverworld.java.patch
@@ -1,6 +1,6 @@
 --- ../src-base/minecraft/net/minecraft/world/gen/ChunkGeneratorOverworld.java
 +++ ../src-work/minecraft/net/minecraft/world/gen/ChunkGeneratorOverworld.java
-@@ -61,6 +61,15 @@
+@@ -61,6 +61,16 @@
  
      public ChunkGeneratorOverworld(World p_i46668_1_, long p_i46668_2_, boolean p_i46668_4_, String p_i46668_5_)
      {
@@ -12,11 +12,12 @@
 +            field_186007_z = (MapGenScatteredFeature)net.minecraftforge.event.terraingen.TerrainGen.getModdedMapGen(field_186007_z, net.minecraftforge.event.terraingen.InitMapGenEvent.EventType.SCATTERED_FEATURE);
 +            field_185979_A = net.minecraftforge.event.terraingen.TerrainGen.getModdedMapGen(field_185979_A, net.minecraftforge.event.terraingen.InitMapGenEvent.EventType.RAVINE);
 +            field_185980_B = (StructureOceanMonument)net.minecraftforge.event.terraingen.TerrainGen.getModdedMapGen(field_185980_B, net.minecraftforge.event.terraingen.InitMapGenEvent.EventType.OCEAN_MONUMENT);
++            field_191060_C = (WoodlandMansion)net.minecraftforge.event.terraingen.TerrainGen.getModdedMapGen(field_191060_C, net.minecraftforge.event.terraingen.InitMapGenEvent.EventType.WOODLAND_MANSION);
 +        }
          this.field_185995_n = p_i46668_1_;
          this.field_185996_o = p_i46668_4_;
          this.field_185997_p = p_i46668_1_.func_72912_H().func_76067_t();
-@@ -90,6 +99,17 @@
+@@ -90,6 +100,17 @@
              this.field_186001_t = this.field_186000_s.field_177778_E ? Blocks.field_150353_l.func_176223_P() : Blocks.field_150355_j.func_176223_P();
              p_i46668_1_.func_181544_b(this.field_186000_s.field_177841_q);
          }
@@ -34,7 +35,7 @@
      }
  
      public void func_185976_a(int p_185976_1_, int p_185976_2_, ChunkPrimer p_185976_3_)
-@@ -163,6 +183,7 @@
+@@ -163,6 +184,7 @@
  
      public void func_185977_a(int p_185977_1_, int p_185977_2_, ChunkPrimer p_185977_3_, Biome[] p_185977_4_)
      {
@@ -42,7 +43,7 @@
          double d0 = 0.03125D;
          this.field_186002_u = this.field_185994_m.func_151599_a(this.field_186002_u, (double)(p_185977_1_ * 16), (double)(p_185977_2_ * 16), 16, 16, 0.0625D, 0.0625D, 1.0D);
  
-@@ -370,6 +391,8 @@
+@@ -370,6 +392,8 @@
          boolean flag = false;
          ChunkPos chunkpos = new ChunkPos(p_185931_1_, p_185931_2_);
  
@@ -51,7 +52,7 @@
          if (this.field_185996_o)
          {
              if (this.field_186000_s.field_177829_w)
-@@ -404,6 +427,7 @@
+@@ -404,6 +428,7 @@
          }
  
          if (biome != Biomes.field_76769_d && biome != Biomes.field_76786_s && this.field_186000_s.field_177781_A && !flag && this.field_185990_i.nextInt(this.field_186000_s.field_177782_B) == 0)
@@ -59,7 +60,7 @@
          {
              int i1 = this.field_185990_i.nextInt(16) + 8;
              int j1 = this.field_185990_i.nextInt(256);
-@@ -412,6 +436,7 @@
+@@ -412,6 +437,7 @@
          }
  
          if (!flag && this.field_185990_i.nextInt(this.field_186000_s.field_177777_D / 10) == 0 && this.field_186000_s.field_177783_C)
@@ -67,7 +68,7 @@
          {
              int i2 = this.field_185990_i.nextInt(16) + 8;
              int l2 = this.field_185990_i.nextInt(this.field_185990_i.nextInt(248) + 8);
-@@ -424,6 +449,7 @@
+@@ -424,6 +450,7 @@
          }
  
          if (this.field_186000_s.field_177837_s)
@@ -75,7 +76,7 @@
          {
              for (int j2 = 0; j2 < this.field_186000_s.field_177835_t; ++j2)
              {
-@@ -435,9 +461,12 @@
+@@ -435,9 +462,12 @@
          }
  
          biome.func_180624_a(this.field_185995_n, this.field_185990_i, new BlockPos(i, 0, j));
@@ -88,7 +89,7 @@
          for (int k2 = 0; k2 < 16; ++k2)
          {
              for (int j3 = 0; j3 < 16; ++j3)
-@@ -456,7 +485,10 @@
+@@ -456,7 +486,10 @@
                  }
              }
          }

--- a/src/main/java/net/minecraftforge/event/terraingen/InitMapGenEvent.java
+++ b/src/main/java/net/minecraftforge/event/terraingen/InitMapGenEvent.java
@@ -26,7 +26,7 @@ public class InitMapGenEvent extends Event
 {
     /** Use CUSTOM to filter custom event types
      */
-    public static enum EventType { CAVE, MINESHAFT, NETHER_BRIDGE, NETHER_CAVE, RAVINE, SCATTERED_FEATURE, STRONGHOLD, VILLAGE, OCEAN_MONUMENT, CUSTOM }
+    public static enum EventType { CAVE, MINESHAFT, NETHER_BRIDGE, NETHER_CAVE, RAVINE, SCATTERED_FEATURE, STRONGHOLD, VILLAGE, OCEAN_MONUMENT, WOODLAND_MANSION, END_CITY, CUSTOM }
 
     private final EventType type;
     private final MapGenBase originalGen;

--- a/src/main/resources/forge_at.cfg
+++ b/src/main/resources/forge_at.cfg
@@ -235,6 +235,7 @@ private-f net.minecraft.world.gen.ChunkGeneratorEnd field_185969_i #lperlin1
 private-f net.minecraft.world.gen.ChunkGeneratorEnd field_185970_j #lperlin2
 private-f net.minecraft.world.gen.ChunkGeneratorEnd field_185971_k #perlin
 private-f net.minecraft.world.gen.ChunkGeneratorEnd field_185973_o #island
+private-f net.minecraft.world.gen.ChunkGeneratorEnd field_185972_n #endCityGen
 
 # ChunkGeneratorOverworld
 private-f net.minecraft.world.gen.ChunkGeneratorOverworld field_185991_j #lperlin1
@@ -248,6 +249,7 @@ private-f net.minecraft.world.gen.ChunkGeneratorOverworld field_186004_w #strong
 private-f net.minecraft.world.gen.ChunkGeneratorOverworld field_186005_x #villageGenerator
 private-f net.minecraft.world.gen.ChunkGeneratorOverworld field_186006_y #mineshaftGenerator
 private-f net.minecraft.world.gen.ChunkGeneratorOverworld field_186007_z #scatteredFeatureGenerator
+private-f net.minecraft.world.gen.ChunkGeneratorOverworld field_191060_C #woodlandMansionGenerator
 
 # ChunkGeneratorHell
 private-f net.minecraft.world.gen.ChunkGeneratorHell field_185957_u #lperlin1


### PR DESCRIPTION
This PR adds support for the Woodland mansion and the end cities in InitMapGenEvent. Due to the nature of this event, it needs to be manually updated every time a new MapGen is added by vanilla. 