### PR TITLE
Allow custom GuiEditArrayEntries

### DIFF
--- a/src/main/java/net/minecraftforge/fml/client/config/GuiEditArray.java
+++ b/src/main/java/net/minecraftforge/fml/client/config/GuiEditArray.java
@@ -103,7 +103,7 @@ public class GuiEditArray extends GuiScreen
     @Override
     public void initGui()
     {
-        this.entryList = new GuiEditArrayEntries(this, this.mc, this.configElement, this.beforeValues, this.currentValues);
+        this.entryList = createEditArrayEntries();
 
         int undoGlyphWidth = mc.fontRenderer.getStringWidth(UNDO_CHAR) * 2;
         int resetGlyphWidth = mc.fontRenderer.getStringWidth(RESET_CHAR) * 2;
@@ -136,13 +136,18 @@ public class GuiEditArray extends GuiScreen
         else if (button.id == 2001)
         {
             this.currentValues = configElement.getDefaults();
-            this.entryList = new GuiEditArrayEntries(this, this.mc, this.configElement, this.beforeValues, this.currentValues);
+            this.entryList = createEditArrayEntries();
         }
         else if (button.id == 2002)
         {
             this.currentValues = Arrays.copyOf(beforeValues, beforeValues.length);
-            this.entryList = new GuiEditArrayEntries(this, this.mc, this.configElement, this.beforeValues, this.currentValues);
+            this.entryList = createEditArrayEntries();
         }
+    }
+
+    protected GuiEditArrayEntries createEditArrayEntries()
+    {
+        return new GuiEditArrayEntries(this, this.mc, this.configElement, this.beforeValues, this.currentValues);
     }
 
     @Override


### PR DESCRIPTION
This allows modders to specify a custom GuiEditArrayEntries class without having to recreate the object in several places after it was created already (currently in initGui and actionPerformed).

`GuiEditArray` can already be customized by using a custom `IConfigEntry`, but `GuiEditArrayEntries` is the class doing the actual `GuiListExtended` stuff.

You can currently achieve this already, but only through ugly [workarounds](https://github.com/blay09/ChatTweaks/blob/1.12.1/src/main/java/net/blay09/mods/chattweaks/gui/config/GuiChatViewsConfig.java#L24-L44).

Example use case is reacting to [newly added entries](https://github.com/blay09/ChatTweaks/blob/1.12.1/src/main/java/net/blay09/mods/chattweaks/gui/config/GuiChatViewsConfig.java#L73-L77) or removals, as the parent `GuiEditArray` is not notified of those.