### PR TITLE
Add Item.getCreatorModid to show which mod is associated with a subitem

### DIFF
--- a/patches/minecraft/net/minecraft/item/Item.java.patch
+++ b/patches/minecraft/net/minecraft/item/Item.java.patch
@@ -70,7 +70,7 @@
          CreativeTabs creativetabs = this.func_77640_w();
          return creativetabs != null && (p_194125_1_ == CreativeTabs.field_78027_g || p_194125_1_ == creativetabs);
      }
-@@ -435,11 +445,683 @@
+@@ -435,11 +445,704 @@
          return false;
      }
  
@@ -680,6 +680,27 @@
 +    }
 +
 +    /**
++     * Called to get the Mod ID of the mod that *created* the ItemStack,
++     * instead of the real Mod ID that *registered* it.
++     *
++     * For example the Forge Universal Bucket creates a subitem for each modded fluid,
++     * and it returns the modded fluid's Mod ID here.
++     *
++     * Mods that register subitems for other mods can override this.
++     * Informational mods can call it to show the mod that created the item.
++     *
++     * @param itemStack the ItemStack to check
++     * @return the Mod ID for the ItemStack, or
++     *         null when there is no specially associated mod and {@link #getRegistryName()} would return null.
++     */
++    @Nullable
++    public String getCreatorModId(ItemStack itemStack)
++    {
++        ResourceLocation registryName = getRegistryName();
++        return registryName == null ? null : registryName.func_110624_b();
++    }
++
++    /**
 +     * Called from ItemStack.setItem, will hold extra data for the life of this ItemStack.
 +     * Can be retrieved from stack.getCapabilities()
 +     * The NBT can be null if this is not called from readNBT or if the item the stack is
@@ -754,7 +775,7 @@
      public static void func_150900_l()
      {
          func_179214_a(Blocks.field_150350_a, new ItemAir(Blocks.field_150350_a));
-@@ -999,6 +1681,8 @@
+@@ -999,6 +1702,8 @@
          private final float field_78010_h;
          private final float field_78011_i;
          private final int field_78008_j;
@@ -763,7 +784,7 @@
  
          private ToolMaterial(int p_i1874_3_, int p_i1874_4_, float p_i1874_5_, float p_i1874_6_, int p_i1874_7_)
          {
-@@ -1034,6 +1718,7 @@
+@@ -1034,6 +1739,7 @@
              return this.field_78008_j;
          }
  
@@ -771,7 +792,7 @@
          public Item func_150995_f()
          {
              if (this == WOOD)
-@@ -1057,5 +1742,21 @@
+@@ -1057,5 +1763,21 @@
                  return this == DIAMOND ? Items.field_151045_i : null;
              }
          }

--- a/src/main/java/net/minecraftforge/fluids/FluidRegistry.java
+++ b/src/main/java/net/minecraftforge/fluids/FluidRegistry.java
@@ -356,6 +356,21 @@ public abstract class FluidRegistry
         return name;
     }
 
+    @Nullable
+    public static String getModId(@Nullable FluidStack fluidStack)
+    {
+        if (fluidStack != null)
+        {
+            String defaultFluidName = getDefaultFluidName(fluidStack.getFluid());
+            if (defaultFluidName != null)
+            {
+                ResourceLocation fluidResourceName = new ResourceLocation(defaultFluidName);
+                return fluidResourceName.getResourceDomain();
+            }
+        }
+        return null;
+    }
+
     public static void loadFluidDefaults(NBTTagCompound tag)
     {
         Set<String> defaults = Sets.newHashSet();

--- a/src/main/java/net/minecraftforge/fluids/UniversalBucket.java
+++ b/src/main/java/net/minecraftforge/fluids/UniversalBucket.java
@@ -42,8 +42,6 @@ import net.minecraftforge.fluids.capability.wrappers.FluidBucketWrapper;
 import net.minecraftforge.fml.common.eventhandler.Event;
 import net.minecraftforge.fml.common.eventhandler.EventPriority;
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
-import net.minecraftforge.fml.relauncher.Side;
-import net.minecraftforge.fml.relauncher.SideOnly;
 import net.minecraftforge.items.ItemHandlerHelper;
 
 import javax.annotation.Nonnull;
@@ -282,6 +280,15 @@ public class UniversalBucket extends Item
     public boolean isNbtSensitive()
     {
         return nbtSensitive;
+    }
+
+    @Nullable
+    @Override
+    public String getCreatorModId(@Nonnull ItemStack itemStack)
+    {
+        FluidStack fluidStack = getFluid(itemStack);
+        String modId = FluidRegistry.getModId(fluidStack);
+        return modId != null ? modId : super.getCreatorModId(itemStack);
     }
 
     @Override

--- a/src/test/java/net/minecraftforge/debug/ModNameTooltip.java
+++ b/src/test/java/net/minecraftforge/debug/ModNameTooltip.java
@@ -1,0 +1,48 @@
+package net.minecraftforge.debug;
+
+import javax.annotation.Nullable;
+import java.util.List;
+
+import net.minecraft.item.Item;
+import net.minecraft.item.ItemStack;
+import net.minecraft.util.text.TextFormatting;
+import net.minecraftforge.event.entity.player.ItemTooltipEvent;
+import net.minecraftforge.fml.common.Loader;
+import net.minecraftforge.fml.common.Mod;
+import net.minecraftforge.fml.common.ModContainer;
+import net.minecraftforge.fml.common.eventhandler.EventPriority;
+import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
+import net.minecraftforge.fml.relauncher.Side;
+
+@Mod(modid = "forgemodnametooltip", name = "ForgeModNameTooltip", version = "1.0", clientSideOnly = true)
+@Mod.EventBusSubscriber(Side.CLIENT)
+public class ModNameTooltip
+{
+    @SubscribeEvent(priority = EventPriority.LOW)
+    public static void onToolTip(ItemTooltipEvent event)
+    {
+        ItemStack itemStack = event.getItemStack();
+        String modName = getModName(itemStack);
+        if (modName != null)
+        {
+            List<String> toolTip = event.getToolTip();
+            toolTip.add(TextFormatting.BLUE.toString() + TextFormatting.ITALIC.toString() + modName);
+        }
+    }
+
+    @Nullable
+    private static String getModName(ItemStack itemStack)
+    {
+        if (!itemStack.isEmpty())
+        {
+            Item item = itemStack.getItem();
+            String modId = item.getCreatorModId(itemStack);
+            ModContainer modContainer = Loader.instance().getIndexedModList().get(modId);
+            if (modContainer != null)
+            {
+                return modContainer.getName();
+            }
+        }
+        return null;
+    }
+}


### PR DESCRIPTION
### Problem: 

Some mods have items that are generated from other mods, but tooltip addons only show the base mod in the tooltip.

### Examples: 

Forestry has bees, which have additional subitems created by addons. This causes a lot of confusion when there is a bug in an addon bee.
Guide-API creates book items for mods that use it.
Forge has the universal bucket, which creates more items based on the fluids registered.
JEI Issue: https://github.com/mezz/JustEnoughItems/issues/722

### This PR:

- Allows items to return what they think is the most appropriate Mod ID.
- implements the method for the Forge Bucket, so the Mod ID returned is based on the fluid inside.
- Adds a barebones mod-tooltip test mod.

If an advanced mod wants to show the "real" Mod ID like before, or both, it still can.

### Screenshots:
![2017-08-20_14 14 49](https://user-images.githubusercontent.com/916092/29498466-f62b46ae-85b1-11e7-820f-fbf42bbc6ed1.png)
![2017-08-20_14 14 57](https://user-images.githubusercontent.com/916092/29498467-f6319c3e-85b1-11e7-96bd-9dc3ef3d6b5c.png)
