### PR TITLE
Reduce the number of quads generated by ItemLayerModel

### DIFF
--- a/src/main/java/net/minecraftforge/client/model/ItemLayerModel.java
+++ b/src/main/java/net/minecraftforge/client/model/ItemLayerModel.java
@@ -56,6 +56,9 @@ public final class ItemLayerModel implements IModel
 {
     public static final ItemLayerModel INSTANCE = new ItemLayerModel(ImmutableList.of());
 
+    private static final EnumFacing[] HORIZONTALS = {EnumFacing.UP, EnumFacing.DOWN};
+    private static final EnumFacing[] VERTICALS = {EnumFacing.WEST, EnumFacing.EAST};
+
     private final ImmutableList<ResourceLocation> textures;
     private final ItemOverrideList overrides;
 
@@ -240,7 +243,7 @@ public final class ItemLayerModel implements IModel
         }
 
         // horizontal quads
-        for (EnumFacing facing : Arrays.asList(EnumFacing.UP, EnumFacing.DOWN))
+        for (EnumFacing facing : HORIZONTALS)
         {
             for (int v = 0; v < vMax; v++)
             {
@@ -272,7 +275,7 @@ public final class ItemLayerModel implements IModel
         }
 
         // vertical quads
-        for (EnumFacing facing : Arrays.asList(EnumFacing.WEST, EnumFacing.EAST))
+        for (EnumFacing facing : VERTICALS)
         {
             for (int u = 0; u < uMax; u++)
             {
@@ -349,7 +352,7 @@ public final class ItemLayerModel implements IModel
 
         private int getIndex(int u, int v)
         {
-            return v*vMax + u;
+            return v * vMax + u;
         }
     }
 


### PR DESCRIPTION
As seen in #3246, item models are something that can potentially consume a lot of memory.

As well as moving from unpacked to packed quads, we can also just reduce the number of quads in total, which is what this PR sets out to achieve.

Rather than generating quads immediately, the original code now just marks which side faces will be visible. Then a second pass is made, using the collected data to combine adjacent faces into a single quad before building. The existing quad building logic is mostly unchanged, just tweaked to allow for quads of larger sizes.

Here's a [gist](https://gist.github.com/bs2609/8894e832012f7674e4c6fade9177ac01) of the reduction in generated quads for vanilla's item models. (~40% reduction across all item models)

Should also resolve #3460 for good measure.