### PR TITLE
Don't parse category names as regular expressions in FieldWrapper.MapWrapper

### DIFF
--- a/src/main/java/net/minecraftforge/common/config/FieldWrapper.java
+++ b/src/main/java/net/minecraftforge/common/config/FieldWrapper.java
@@ -15,6 +15,7 @@ import com.google.common.collect.Lists;
 
 import net.minecraftforge.common.config.Config.RangeDouble;
 import net.minecraftforge.common.config.Config.RangeInt;
+import org.apache.commons.lang3.StringUtils;
 
 import static net.minecraftforge.common.config.ConfigManager.*;
 
@@ -131,13 +132,13 @@ public abstract class FieldWrapper implements IFieldWrapper
         @Override
         public Object getValue(String key)
         {
-            return theMap.get(key.replaceFirst(category + "." + name + ".", ""));
+            return theMap.get(StringUtils.replaceOnce(key, category + "." + name + ".", ""));
         }
 
         @Override
         public void setValue(String key, Object value)
         {
-            String suffix = key.replaceFirst(category + "." + name + ".", "");
+            String suffix = StringUtils.replaceOnce(key, category + "." + name + ".", "");
             theMap.put(suffix, value);
         }
 

--- a/src/test/java/net/minecraftforge/debug/ConfigTest.java
+++ b/src/test/java/net/minecraftforge/debug/ConfigTest.java
@@ -18,6 +18,7 @@ import net.minecraftforge.fml.common.event.FMLPreInitializationEvent;
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
 import org.apache.logging.log4j.Logger;
 
+import java.util.HashMap;
 import java.util.Map;
 
 @Mod(modid = ConfigTest.MODID, name = "ConfigTest", version = "1.0", acceptableRemoteVersions = "*")
@@ -150,6 +151,9 @@ public class ConfigTest
         @RequiresMcRestart
         public static Map<String, Integer[]> theMap;
 
+        @Name("regex(test]")
+        public static Map<String, String> regexText = new HashMap<>();
+
         static
         {
             theMap = Maps.newHashMap();
@@ -161,6 +165,7 @@ public class ConfigTest
                     array[x] = i + x;
                 }
                 theMap.put("" + i, array);
+                regexText.put("" + i, "" + i);
             }
         }
     }


### PR DESCRIPTION
This fixes #4326.