### PR TITLE
Fix uvlock not preserving order of inputs

### DIFF
--- a/src/main/java/net/minecraftforge/client/ForgeHooksClient.java
+++ b/src/main/java/net/minecraftforge/client/ForgeHooksClient.java
@@ -653,25 +653,29 @@ public class ForgeHooksClient
         TRSRTransformation global = new TRSRTransformation(rotation.getMatrix());
         Matrix4f uv = global.getUVLockTransform(originalSide).getMatrix();
         Vector4f vec = new Vector4f(0, 0, 0, 1);
-        vec.x = blockFaceUV.getVertexU(blockFaceUV.getVertexRotatedRev(0)) / 16;
-        vec.y = blockFaceUV.getVertexV(blockFaceUV.getVertexRotatedRev(0)) / 16;
+        float u0 = blockFaceUV.getVertexU(blockFaceUV.getVertexRotatedRev(0));
+        float v0 = blockFaceUV.getVertexV(blockFaceUV.getVertexRotatedRev(0));
+        vec.x = u0 / 16;
+        vec.y = v0 / 16;
         uv.transform(vec);
         float uMin = 16 * vec.x; // / vec.w;
         float vMin = 16 * vec.y; // / vec.w;
-        vec.x = blockFaceUV.getVertexU(blockFaceUV.getVertexRotatedRev(2)) / 16;
-        vec.y = blockFaceUV.getVertexV(blockFaceUV.getVertexRotatedRev(2)) / 16;
+        float u1 = blockFaceUV.getVertexU(blockFaceUV.getVertexRotatedRev(2));
+        float v1 = blockFaceUV.getVertexV(blockFaceUV.getVertexRotatedRev(2));
+        vec.x = u1 / 16;
+        vec.y = v1 / 16;
         vec.z = 0;
         vec.w = 1;
         uv.transform(vec);
         float uMax = 16 * vec.x; // / vec.w;
         float vMax = 16 * vec.y; // / vec.w;
-        if(uMin > uMax)
+        if (uMin > uMax && u0 < u1 || uMin < uMax && u0 > u1)
         {
             float t = uMin;
             uMin = uMax;
             uMax = t;
         }
-        if(vMin > vMax)
+        if (vMin > vMax && v0 < v1 || vMin < vMax && v0 > v1)
         {
             float t = vMin;
             vMin = vMax;


### PR DESCRIPTION
Fixes #3040. 

Previously the transformed uvs were swapped if they were out of order, but they should instead be swapped if they are ordered differently to the pre-transform uvs.

Usual set of comparison screenshots; vanilla buttons make for a good test case here.

* Vanilla:
![vanilla](https://user-images.githubusercontent.com/1447117/29577064-01ed3afe-8762-11e7-91cb-16729030c1e3.png)

* Forge, before changes:
![forge_pre](https://user-images.githubusercontent.com/1447117/29577074-0d5ae1f2-8762-11e7-8b97-0d65a513a770.png)

* Forge, after changes:
![forge_post](https://user-images.githubusercontent.com/1447117/29577087-1b985ef2-8762-11e7-8e48-d27e74712185.png)
