### PR TITLE
[1.12] Deprecated ITileEntityProvider

### DIFF
--- a/patches/minecraft/net/minecraft/block/ITileEntityProvider.java.patch
+++ b/patches/minecraft/net/minecraft/block/ITileEntityProvider.java.patch
@@ -1,0 +1,10 @@
+--- ../src-base/minecraft/net/minecraft/block/ITileEntityProvider.java
++++ ../src-work/minecraft/net/minecraft/block/ITileEntityProvider.java
+@@ -4,6 +4,7 @@
+ import net.minecraft.tileentity.TileEntity;
+ import net.minecraft.world.World;
+ 
++@Deprecated // Use Block#hasTileEntity and Block#createTileEntity(World world, IBlockState state)
+ public interface ITileEntityProvider
+ {
+     @Nullable


### PR DESCRIPTION
Deprecated ITileEntityProvider, modders should use Block#hasTileEntity and Block#createTileEntity(World world, IBlockState state).
As well because of the 1.13 change that will remove meta ids.
