### PR TITLE
Fix NPE in EntityHorse constructor

### DIFF
--- a/patches/minecraft/net/minecraft/entity/passive/AbstractHorse.java.patch
+++ b/patches/minecraft/net/minecraft/entity/passive/AbstractHorse.java.patch
@@ -1,6 +1,6 @@
 --- ../src-base/minecraft/net/minecraft/entity/passive/AbstractHorse.java
 +++ ../src-work/minecraft/net/minecraft/entity/passive/AbstractHorse.java
-@@ -312,6 +312,7 @@
+@@ -312,11 +312,12 @@
  
          this.field_110296_bG.func_110134_a(this);
          this.func_110232_cE();
@@ -8,6 +8,12 @@
      }
  
      protected void func_110232_cE()
+     {
+-        if (!this.field_70170_p.field_72995_K)
++        if (this.field_70170_p != null && !this.field_70170_p.field_72995_K)
+         {
+             this.func_110251_o(!this.field_110296_bG.func_70301_a(0).func_190926_b() && this.func_190685_dA());
+         }
 @@ -1227,4 +1228,22 @@
  
          return p_180482_2_;

--- a/patches/minecraft/net/minecraft/entity/passive/EntityHorse.java.patch
+++ b/patches/minecraft/net/minecraft/entity/passive/EntityHorse.java.patch
@@ -1,0 +1,11 @@
+--- ../src-base/minecraft/net/minecraft/entity/passive/EntityHorse.java
++++ ../src-work/minecraft/net/minecraft/entity/passive/EntityHorse.java
+@@ -151,7 +151,7 @@
+         this.field_70180_af.func_187227_b(field_184791_bI, Integer.valueOf(horsearmortype.func_188579_a()));
+         this.func_110230_cF();
+ 
+-        if (!this.field_70170_p.field_72995_K)
++        if (this.field_70170_p != null && !this.field_70170_p.field_72995_K)
+         {
+             this.func_110148_a(SharedMonsterAttributes.field_188791_g).func_188479_b(field_184786_bD);
+             int i = horsearmortype.func_188578_c();

--- a/patches/minecraft/net/minecraft/entity/passive/EntityLlama.java.patch
+++ b/patches/minecraft/net/minecraft/entity/passive/EntityLlama.java.patch
@@ -1,0 +1,11 @@
+--- ../src-base/minecraft/net/minecraft/entity/passive/EntityLlama.java
++++ ../src-work/minecraft/net/minecraft/entity/passive/EntityLlama.java
+@@ -349,7 +349,7 @@
+ 
+     protected void func_110232_cE()
+     {
+-        if (!this.field_70170_p.field_72995_K)
++        if (this.field_70170_p != null && !this.field_70170_p.field_72995_K)
+         {
+             super.func_110232_cE();
+             this.func_190702_g(this.field_110296_bG.func_70301_a(1));


### PR DESCRIPTION
This PR allows to safely call `AbstractHorse(World)` (and descendants) with `null`.

This method has been used for creation of dummy entities for rendering (for example, OpenBlocks trophy) - it seems to be most reliable way to do that. Any other vanilla entities can be instantiated this way (most of them already have explicit null checks, though I'm not sure what's the purpose of those). Note: this change (via core mod) is already been present in OpenBlocks.