### PR TITLE
Feature/programmatic advancements

### DIFF
--- a/src/main/java/net/minecraftforge/common/ForgeHooks.java
+++ b/src/main/java/net/minecraftforge/common/ForgeHooks.java
@@ -106,6 +106,7 @@ import net.minecraft.world.storage.loot.LootTableManager;
 import net.minecraft.world.storage.loot.conditions.LootCondition;
 import net.minecraftforge.common.crafting.CraftingHelper;
 import net.minecraftforge.common.util.BlockSnapshot;
+import net.minecraftforge.event.AdvancementRegisterEvent;
 import net.minecraftforge.event.AnvilUpdateEvent;
 import net.minecraftforge.event.DifficultyChangeEvent;
 import net.minecraftforge.event.ForgeEventFactory;
@@ -1276,6 +1277,8 @@ public class ForgeHooks
         boolean errored = false;
         setActiveModContainer(null);
         //Loader.instance().getActiveModList().forEach((mod) -> loadFactories(mod));
+	AdvancementRegisterEvent ev = new AdvancementRegisterEvent(map);
+	MinecraftForge.EVENT_BUS.post(ev);
         for (ModContainer mod : Loader.instance().getActiveModList())
         {
             errored |= !loadAdvancements(map, mod);

--- a/src/main/java/net/minecraftforge/common/ForgeHooks.java
+++ b/src/main/java/net/minecraftforge/common/ForgeHooks.java
@@ -1277,8 +1277,8 @@ public class ForgeHooks
         boolean errored = false;
         setActiveModContainer(null);
         //Loader.instance().getActiveModList().forEach((mod) -> loadFactories(mod));
-	AdvancementRegisterEvent ev = new AdvancementRegisterEvent(map);
-	MinecraftForge.EVENT_BUS.post(ev);
+        AdvancementRegisterEvent ev = new AdvancementRegisterEvent(map);
+        MinecraftForge.EVENT_BUS.post(ev);
         for (ModContainer mod : Loader.instance().getActiveModList())
         {
             errored |= !loadAdvancements(map, mod);

--- a/src/main/java/net/minecraftforge/event/AdvancementRegisterEvent.java
+++ b/src/main/java/net/minecraftforge/event/AdvancementRegisterEvent.java
@@ -41,8 +41,9 @@ public class AdvancementRegisterEvent extends Event implements IContextSetter
 {
     public final Map<ResourceLocation, Advancement.Builder> advancements;
 
-    public AdvancementRegisterEvent(Map<ResourceLocation, Advancement.Builder> map) {
+    public AdvancementRegisterEvent(Map<ResourceLocation, Advancement.Builder> map) 
+    {
         super();
-	this.advancements = map;
+        this.advancements = map;
     }
 }

--- a/src/main/java/net/minecraftforge/event/AdvancementRegisterEvent.java
+++ b/src/main/java/net/minecraftforge/event/AdvancementRegisterEvent.java
@@ -1,0 +1,48 @@
+/*
+ * Minecraft Forge
+ * Marcel Sondaar
+ * Copyright (c) 2017.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation version 2.1
+ * of the License.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+package net.minecraftforge.event;
+
+import java.util.Collection;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import org.apache.commons.lang3.Validate;
+
+import com.google.common.collect.ImmutableList;
+import net.minecraft.advancements.Advancement;
+import net.minecraft.util.ResourceLocation;
+import net.minecraftforge.fml.common.ModContainer;
+import net.minecraftforge.fml.common.eventhandler.Event;
+import net.minecraftforge.fml.common.eventhandler.IContextSetter;
+
+
+/**
+ * Programmatic installation of advancements.
+ */
+public class AdvancementRegisterEvent extends Event implements IContextSetter
+{
+    public final Map<ResourceLocation, Advancement.Builder> advancements;
+
+    public AdvancementRegisterEvent(Map<ResourceLocation, Advancement.Builder> map) {
+        super();
+	this.advancements = map;
+    }
+}


### PR DESCRIPTION
This hook should be sufficient to allow any mod developer to register advancements dynamically - without having to resort to files. I currently have to coremod this, where an almost identical hook is installed.
I added an excerpt from my codebase - irrelevant classes have been stripped: http://fuzzycraft.net/downloads/example-mod-integration.tar.gz
Currently the coremod part installs the hook. This is to be wrapped into an forge event through this patch. The coremod currently maintains a list of achievements which can be freely modified during init. Child mods can fill this list of advancements during their initialisation steps - currently shown inline with IRecipe registration to create the recipe unlocks with minimal boiler-plate code.
When the hook is called halfway into server start, the coremod clones its internal advancement list into Minecraft's database. 
