### PR TITLE
Add InputUpdateEvent

### DIFF
--- a/patches/minecraft/net/minecraft/client/entity/EntityPlayerSP.java.patch
+++ b/patches/minecraft/net/minecraft/client/entity/EntityPlayerSP.java.patch
@@ -89,7 +89,15 @@
      }
  
      public boolean func_70613_aW()
-@@ -859,10 +880,13 @@
+@@ -840,6 +861,7 @@
+         float f = 0.8F;
+         boolean flag2 = this.field_71158_b.field_192832_b >= 0.8F;
+         this.field_71158_b.func_78898_a();
++        net.minecraftforge.client.ForgeHooksClient.onInputUpdate(this, this.field_71158_b);
+         this.field_71159_c.func_193032_ao().func_193293_a(this.field_71158_b);
+ 
+         if (this.func_184587_cr() && !this.func_184218_aH())
+@@ -859,10 +881,13 @@
          }
  
          AxisAlignedBB axisalignedbb = this.func_174813_aQ();

--- a/src/main/java/net/minecraftforge/client/ForgeHooksClient.java
+++ b/src/main/java/net/minecraftforge/client/ForgeHooksClient.java
@@ -81,6 +81,7 @@ import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.BlockRenderLayer;
 import net.minecraft.util.EnumFacing;
 import net.minecraft.util.EnumHand;
+import net.minecraft.util.MovementInput;
 import net.minecraft.util.ResourceLocation;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.MathHelper;
@@ -94,6 +95,7 @@ import net.minecraftforge.client.event.DrawBlockHighlightEvent;
 import net.minecraftforge.client.event.EntityViewRenderEvent;
 import net.minecraftforge.client.event.FOVUpdateEvent;
 import net.minecraftforge.client.event.GuiScreenEvent;
+import net.minecraftforge.client.event.InputUpdateEvent;
 import net.minecraftforge.client.event.ModelBakeEvent;
 import net.minecraftforge.client.event.MouseEvent;
 import net.minecraftforge.client.event.RenderGameOverlayEvent;
@@ -727,5 +729,10 @@ public class ForgeHooksClient
         Matrix4f mat = null;
         if(!tr.equals(TRSRTransformation.identity())) mat = tr.getMatrix();
         return Pair.of(model, mat);
+    }
+
+    public static void onInputUpdate(EntityPlayer player, MovementInput movementInput)
+    {
+        MinecraftForge.EVENT_BUS.post(new InputUpdateEvent(player, movementInput));
     }
 }

--- a/src/main/java/net/minecraftforge/client/event/InputUpdateEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/InputUpdateEvent.java
@@ -1,0 +1,26 @@
+package net.minecraftforge.client.event;
+
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.util.MovementInput;
+import net.minecraftforge.event.entity.player.PlayerEvent;
+
+/**
+ * This event is fired after player movement inputs are updated.<br>
+ * Handlers can freely manipulate {@link MovementInput} to cancel movement.<br>
+ */
+public class InputUpdateEvent extends PlayerEvent
+{
+    private final MovementInput movementInput;
+
+    public InputUpdateEvent(EntityPlayer player, MovementInput movementInput)
+    {
+        super(player);
+        this.movementInput = movementInput;
+    }
+
+    public MovementInput getMovementInput()
+    {
+        return movementInput;
+    }
+
+}

--- a/src/test/java/net/minecraftforge/debug/InputUpdateEventTest.java
+++ b/src/test/java/net/minecraftforge/debug/InputUpdateEventTest.java
@@ -1,0 +1,48 @@
+package net.minecraftforge.debug;
+
+import net.minecraft.block.state.IBlockState;
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.init.Blocks;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.math.MathHelper;
+import net.minecraft.util.text.TextComponentString;
+import net.minecraftforge.client.event.InputUpdateEvent;
+import net.minecraftforge.fml.common.Mod;
+import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
+import net.minecraftforge.fml.relauncher.Side;
+
+@Mod(modid = InputUpdateEventTest.MODID, name = "InputUpdateTest", version = "1.0", acceptableRemoteVersions = "*")
+public class InputUpdateEventTest
+{
+    static final String MODID = "input_update_test";
+
+    @Mod.EventBusSubscriber(value = Side.CLIENT, modid = MODID)
+    public static class Registration
+    {
+        @SubscribeEvent
+        public static void onInputUpdate(InputUpdateEvent evt)
+        {
+            EntityPlayer player = evt.getEntityPlayer();
+            final int x = MathHelper.floor(player.posX);
+            final int y = MathHelper.floor(player.getEntityBoundingBox().minY) - 1;
+            final int z = MathHelper.floor(player.posZ);
+            final BlockPos pos = new BlockPos(x, y, z);
+            IBlockState blockUnder = player.world.getBlockState(pos);
+            if (blockUnder.getBlock() == Blocks.BLACK_GLAZED_TERRACOTTA)
+            {
+                if (evt.getMovementInput().jump)
+                {
+                    player.sendMessage(new TextComponentString("NO JUMPING!"));
+                    evt.getMovementInput().jump = false;
+                }
+
+                if (evt.getMovementInput().sneak)
+                {
+                    player.sendMessage(new TextComponentString("NO SNEAKING!"));
+                    evt.getMovementInput().sneak = false;
+                }
+            }
+        }
+    }
+
+}


### PR DESCRIPTION
This new event allows modders to change state of inputs before any action is taken. This may be used to cleanly capture (and cancel) events like jumping or sneaking.

This is quite cleaner than operating on KeyInputEvent and 'unpressing' bindings.

Note: this hook was used for OpenBlock's elevator for quite some time. We've tested multiple methods, like testing `motionY` in entity update or constantly checking `isSneaking`, but this approach seems to be most reliable one.