### PR TITLE
Fire RenderGameOverlayEvent for vignette

### DIFF
--- a/src/main/java/net/minecraftforge/client/GuiIngameForge.java
+++ b/src/main/java/net/minecraftforge/client/GuiIngameForge.java
@@ -71,6 +71,7 @@ public class GuiIngameForge extends GuiIngame
     //Flags to toggle the rendering of certain aspects of the HUD, valid conditions
     //must be met for them to render normally. If those conditions are met, but this flag
     //is false, they will not be rendered.
+    public static boolean renderVignette = true;
     public static boolean renderHelmet = true;
     public static boolean renderPortal = true;
     public static boolean renderHotbar = true;
@@ -120,7 +121,7 @@ public class GuiIngameForge extends GuiIngame
         mc.entityRenderer.setupOverlayRendering();
         GlStateManager.enableBlend();
 
-        if (Minecraft.isFancyGraphicsEnabled())
+        if (renderVignette && Minecraft.isFancyGraphicsEnabled())
         {
             renderVignette(mc.player.getBrightness(), res);
         }
@@ -250,7 +251,13 @@ public class GuiIngameForge extends GuiIngame
     @Override
     protected void renderVignette(float lightLevel, ScaledResolution scaledRes)
     {
-        if (pre(VIGNETTE)) return;
+        if (pre(VIGNETTE))
+        {
+            // Need to put this here, since Vanilla assumes this state after the vignette was rendered.
+            GlStateManager.enableDepth();
+            GlStateManager.tryBlendFuncSeparate(GlStateManager.SourceFactor.SRC_ALPHA, GlStateManager.DestFactor.ONE_MINUS_SRC_ALPHA, GlStateManager.SourceFactor.ONE, GlStateManager.DestFactor.ZERO);
+            return;
+        }
         super.renderVignette(lightLevel, scaledRes);
         post(VIGNETTE);
     }

--- a/src/main/java/net/minecraftforge/client/GuiIngameForge.java
+++ b/src/main/java/net/minecraftforge/client/GuiIngameForge.java
@@ -247,6 +247,14 @@ public class GuiIngameForge extends GuiIngame
         post(BOSSHEALTH);
     }
 
+    @Override
+    protected void renderVignette(float lightLevel, ScaledResolution scaledRes)
+    {
+        if (pre(VIGNETTE)) return;
+        super.renderVignette(lightLevel, scaledRes);
+        post(VIGNETTE);
+    }
+
     private void renderHelmet(ScaledResolution res, float partialTicks)
     {
         if (pre(HELMET)) return;

--- a/src/main/java/net/minecraftforge/client/event/RenderGameOverlayEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/RenderGameOverlayEvent.java
@@ -66,7 +66,8 @@ public class RenderGameOverlayEvent extends Event
         DEBUG,
         POTION_ICONS,
         SUBTITLES,
-        FPS_GRAPH
+        FPS_GRAPH,
+        VIGNETTE
     }
 
     private final float partialTicks;


### PR DESCRIPTION
While helping someone, I've noticed that there is `RenderGameOverlayEvent.ElementType.VIGNETTE` and that accordingly there is no event fired for it, either. One might say that simply subscribing to `RenderGameOverlayEvent.Pre` and checking for the `ALL` type might suffice, but in that case you'd have to apply the overlay transformations first.
Hence, for completeness' sake and for being able to control the vignette, I've added an element type for it and the events are now fired for it.

I have *not* added a static field `renderVignette` which could be used to specify whether the event should even be called since I don't really see a use in it (nor the existing fields) when the Pre event can just be cancelled. I've also not moved the condition (in this case fancy graphics enabled) between the event firings like it was done for the other elements, since I don't see the point in that, either. The elemtn types (imo) shouldn't be there simply for their order, but for the element they actually represent.
If you want me to change either the existing elements (which would definitely be breaking compatibility in some cases) or make the vignette align with the others, just say so.

I also haven't included a test mod, but if you want me to, I can ship with a minimal example that just renders something in addition to the vignette or cancels its rendering. The changes should be self-explanatory enough, though :D