### PR TITLE
Fix netty warning spam when sending >1MB packets

### DIFF
--- a/src/main/java/net/minecraftforge/fml/common/network/handshake/NetworkDispatcher.java
+++ b/src/main/java/net/minecraftforge/fml/common/network/handshake/NetworkDispatcher.java
@@ -526,10 +526,12 @@ public class NetworkDispatcher extends SimpleChannelInboundHandler<Packet<?>> im
             else
             {
                 List<Packet<INetHandlerPlayClient>> parts = ((FMLProxyPacket)msg).toS3FPackets();
-                for (Packet<INetHandlerPlayClient> pkt : parts)
+                int sizeMinusOne = parts.size() - 1;
+                for (int i = 0; i < sizeMinusOne; i++)
                 {
-                    ctx.write(pkt, promise);
+                    ctx.write(parts.get(i), ctx.voidPromise());
                 }
+                ctx.write(parts.get(sizeMinusOne), promise);
             }
         }
         else


### PR DESCRIPTION
It has never been an issue until I fixed sending big packets in #4302.

Forge re-used the same promise for sending all the message parts, which ended up marking that promise as success many times. Fixed it by using void promise for all messages except the last one.

I also noticed that netty's `MessageToMessageEncoder` could be easily used to accomplish similar thing (and I don't know why forge doesn't use it). If requested I can try to change it to use `MessageToMessageEncoder`.