### PR TITLE
Fix light sources rendering wrongly with night vision (MC-58177)

### DIFF
--- a/patches/minecraft/net/minecraft/client/renderer/EntityRenderer.java.patch
+++ b/patches/minecraft/net/minecraft/client/renderer/EntityRenderer.java.patch
@@ -78,7 +78,7 @@
              if (this.field_78531_r.field_71474_y.field_74320_O == 0 && !flag && !this.field_78531_r.field_71474_y.field_74319_N && !this.field_78531_r.field_71442_b.func_78747_a())
              {
                  this.func_180436_i();
-@@ -875,6 +874,10 @@
+@@ -875,6 +874,15 @@
                          f10 = 0.25F + f7 * 0.75F;
                      }
  
@@ -86,10 +86,15 @@
 +                    world.field_73011_w.getLightmapColors(p_78472_1_, f, f2, f3, colors);
 +                    f8 = colors[0]; f9 = colors[1]; f10 = colors[2];
 +
++                    // Forge: fix MC-58177
++                    f8 = MathHelper.func_76131_a(f8, 0f, 1f);
++                    f9 = MathHelper.func_76131_a(f9, 0f, 1f);
++                    f10 = MathHelper.func_76131_a(f10, 0f, 1f);
++
                      if (this.field_78531_r.field_71439_g.func_70644_a(MobEffects.field_76439_r))
                      {
                          float f15 = this.func_180438_a(this.field_78531_r.field_71439_g, p_78472_1_);
-@@ -1101,6 +1104,10 @@
+@@ -1101,6 +1109,10 @@
                  GlStateManager.func_179096_D();
                  this.func_78478_c();
                  this.field_78510_Z = System.nanoTime();
@@ -100,7 +105,7 @@
              }
  
              if (this.field_78531_r.field_71462_r != null)
-@@ -1109,7 +1116,7 @@
+@@ -1109,7 +1121,7 @@
  
                  try
                  {
@@ -109,7 +114,7 @@
                  }
                  catch (Throwable throwable)
                  {
-@@ -1204,7 +1211,7 @@
+@@ -1204,7 +1216,7 @@
  
                      if (this.field_78531_r.field_71442_b.func_178889_l() == GameType.SPECTATOR)
                      {
@@ -118,7 +123,7 @@
                      }
                      else
                      {
-@@ -1329,7 +1336,9 @@
+@@ -1329,7 +1341,9 @@
              GlStateManager.func_179094_E();
              RenderHelper.func_74519_b();
              this.field_78531_r.field_71424_I.func_76318_c("entities");
@@ -128,7 +133,7 @@
              RenderHelper.func_74518_a();
              this.func_175072_h();
          }
-@@ -1342,6 +1351,7 @@
+@@ -1342,6 +1356,7 @@
              EntityPlayer entityplayer = (EntityPlayer)entity;
              GlStateManager.func_179118_c();
              this.field_78531_r.field_71424_I.func_76318_c("outline");
@@ -136,7 +141,7 @@
              renderglobal.func_72731_b(entityplayer, this.field_78531_r.field_71476_x, 0, p_175068_2_);
              GlStateManager.func_179141_d();
          }
-@@ -1388,6 +1398,17 @@
+@@ -1388,6 +1403,17 @@
          GlStateManager.func_179103_j(7425);
          this.field_78531_r.field_71424_I.func_76318_c("translucent");
          renderglobal.func_174977_a(BlockRenderLayer.TRANSLUCENT, (double)p_175068_2_, p_175068_1_, entity);
@@ -154,7 +159,7 @@
          GlStateManager.func_179103_j(7424);
          GlStateManager.func_179132_a(true);
          GlStateManager.func_179089_o();
-@@ -1400,6 +1421,9 @@
+@@ -1400,6 +1426,9 @@
              this.func_180437_a(renderglobal, p_175068_2_, p_175068_1_, d0, d1, d2);
          }
  
@@ -164,7 +169,7 @@
          this.field_78531_r.field_71424_I.func_76318_c("hand");
  
          if (this.field_175074_C)
-@@ -1515,6 +1539,13 @@
+@@ -1515,6 +1544,13 @@
  
      protected void func_78474_d(float p_78474_1_)
      {
@@ -178,7 +183,7 @@
          float f = this.field_78531_r.field_71441_e.func_72867_j(p_78474_1_);
  
          if (f > 0.0F)
-@@ -1749,30 +1780,17 @@
+@@ -1749,30 +1785,17 @@
              this.field_175082_R = (float)vec3d3.field_72448_b;
              this.field_175081_S = (float)vec3d3.field_72449_c;
          }
@@ -218,7 +223,7 @@
  
          float f13 = this.field_78535_ad + (this.field_78539_ae - this.field_78535_ad) * p_78466_1_;
          this.field_175080_Q *= f13;
-@@ -1845,6 +1863,13 @@
+@@ -1845,6 +1868,13 @@
              this.field_175081_S = f7;
          }
  
@@ -232,7 +237,7 @@
          GlStateManager.func_179082_a(this.field_175080_Q, this.field_175082_R, this.field_175081_S, 0.0F);
      }
  
-@@ -1855,7 +1880,9 @@
+@@ -1855,7 +1885,9 @@
          GlStateManager.func_187432_a(0.0F, -1.0F, 0.0F);
          GlStateManager.func_179131_c(1.0F, 1.0F, 1.0F, 1.0F);
          IBlockState iblockstate = ActiveRenderInfo.func_186703_a(this.field_78531_r.field_71441_e, entity, p_78468_2_);
@@ -243,7 +248,7 @@
          if (entity instanceof EntityLivingBase && ((EntityLivingBase)entity).func_70644_a(MobEffects.field_76440_q))
          {
              float f1 = 5.0F;
-@@ -1940,6 +1967,7 @@
+@@ -1940,6 +1972,7 @@
                  GlStateManager.func_179102_b(f * 0.05F);
                  GlStateManager.func_179153_c(Math.min(f, 192.0F) * 0.5F);
              }


### PR DESCRIPTION
Vanilla bug [MC-58177](https://bugs.mojang.com/browse/MC-58177).

Occasionally, a colour value here can be greater than 1, which causes night-vision to make things darker, rather than brighter.

Clamping the colour values to [0, 1] before applying the night-vision effect fixes the bug.
See the following example screenshots:

* Before:
![2017-08-30_072734](https://user-images.githubusercontent.com/1447117/29859184-c2626be6-8d58-11e7-8458-f6d988cd90a7.png)

* After:
![2017-08-30_072856](https://user-images.githubusercontent.com/1447117/29859197-d23bb2a2-8d58-11e7-853d-fea835bba237.png)
