### PR TITLE
Insert FML handler before Vanilla connection handshake completes

### DIFF
--- a/src/main/java/net/minecraftforge/fml/common/network/handshake/NetworkDispatcher.java
+++ b/src/main/java/net/minecraftforge/fml/common/network/handshake/NetworkDispatcher.java
@@ -157,8 +157,8 @@ public class NetworkDispatcher extends SimpleChannelInboundHandler<Packet<?>> im
         {
             serverInitiateHandshake();
             FMLLog.log.info("Connection received without FML marker, assuming vanilla.");
-            this.completeServerSideConnection(ConnectionType.VANILLA);
             insertIntoChannel();
+            this.completeServerSideConnection(ConnectionType.VANILLA);
         }
     }
 


### PR DESCRIPTION
This bug was originally discovered through https://github.com/SpongePowered/SpongeForge/issues/1677.

When establishing a modded connection, Forge inserts it's packet handler way before doing anything to establish the modded connection - certainly before `PlayerList#initializeConnectionToPlayer` is called. However, when establishing a Vanilla connection, Forge only inserts it's packet handler _after_  `PlayerList#initializeConnectionToPlayer` has been called, that is, a vanilla connection has been completely established and a `JoinGame` packet has been sent. This is enough for some systems to send back a `REGISTER` packet, which can arrive before Forge has inserted it's packet handler into the pipeline to catch the message. As a result, Forge won't register the channel, and will discard plugin messages from systems that have sent the packet early.

By inserting the packet handler before completing the vanilla handshake, these `REGISTER` and other very early plugin messages can be captured as expected. `insertIntoChannel` still correctly detects the user as a Vanilla user, as `serverInitiateHandshake` sets a state, which is what the method looks for.

See the two comments from https://github.com/SpongePowered/SpongeForge/issues/1677#issuecomment-321652617 for the original diagnosis.