### PR TITLE
Resolve a crash relating to plantFlower

### DIFF
--- a/patches/minecraft/net/minecraft/world/biome/Biome.java.patch
+++ b/patches/minecraft/net/minecraft/world/biome/Biome.java.patch
@@ -147,8 +147,8 @@
 +
 +    public void plantFlower(World world, Random rand, BlockPos pos)
 +    {
-+    	if(flowers.isEmpty()) return;
-+    	
++        if (flowers.isEmpty()) return;
++
 +        FlowerEntry flower = (FlowerEntry)WeightedRandom.func_76271_a(rand, flowers);
 +        if (flower == null || flower.state == null ||
 +            (flower.state.func_177230_c() instanceof net.minecraft.block.BlockBush &&

--- a/patches/minecraft/net/minecraft/world/biome/Biome.java.patch
+++ b/patches/minecraft/net/minecraft/world/biome/Biome.java.patch
@@ -79,7 +79,7 @@
      }
  
      public final boolean func_150559_j()
-@@ -397,6 +402,83 @@
+@@ -397,6 +402,85 @@
          return this.field_76766_R;
      }
  
@@ -147,6 +147,8 @@
 +
 +    public void plantFlower(World world, Random rand, BlockPos pos)
 +    {
++    	if(flowers.isEmpty()) return;
++    	
 +        FlowerEntry flower = (FlowerEntry)WeightedRandom.func_76271_a(rand, flowers);
 +        if (flower == null || flower.state == null ||
 +            (flower.state.func_177230_c() instanceof net.minecraft.block.BlockBush &&
@@ -163,7 +165,7 @@
      public static void func_185358_q()
      {
          func_185354_a(0, "ocean", new BiomeOcean((new Biome.BiomeProperties("Ocean")).func_185398_c(-1.0F).func_185400_d(0.1F)));
-@@ -552,6 +634,7 @@
+@@ -552,6 +636,7 @@
              public Class <? extends EntityLiving > field_76300_b;
              public int field_76301_c;
              public int field_76299_d;
@@ -171,7 +173,7 @@
  
              public SpawnListEntry(Class <? extends EntityLiving > p_i1970_1_, int p_i1970_2_, int p_i1970_3_, int p_i1970_4_)
              {
-@@ -559,12 +642,28 @@
+@@ -559,12 +644,28 @@
                  this.field_76300_b = p_i1970_1_;
                  this.field_76301_c = p_i1970_3_;
                  this.field_76299_d = p_i1970_4_;

--- a/patches/minecraft/net/minecraft/world/biome/Biome.java.patch
+++ b/patches/minecraft/net/minecraft/world/biome/Biome.java.patch
@@ -79,7 +79,7 @@
      }
  
      public final boolean func_150559_j()
-@@ -397,6 +402,85 @@
+@@ -397,6 +402,84 @@
          return this.field_76766_R;
      }
  
@@ -148,7 +148,6 @@
 +    public void plantFlower(World world, Random rand, BlockPos pos)
 +    {
 +        if (flowers.isEmpty()) return;
-+
 +        FlowerEntry flower = (FlowerEntry)WeightedRandom.func_76271_a(rand, flowers);
 +        if (flower == null || flower.state == null ||
 +            (flower.state.func_177230_c() instanceof net.minecraft.block.BlockBush &&
@@ -165,7 +164,7 @@
      public static void func_185358_q()
      {
          func_185354_a(0, "ocean", new BiomeOcean((new Biome.BiomeProperties("Ocean")).func_185398_c(-1.0F).func_185400_d(0.1F)));
-@@ -552,6 +636,7 @@
+@@ -552,6 +635,7 @@
              public Class <? extends EntityLiving > field_76300_b;
              public int field_76301_c;
              public int field_76299_d;
@@ -173,7 +172,7 @@
  
              public SpawnListEntry(Class <? extends EntityLiving > p_i1970_1_, int p_i1970_2_, int p_i1970_3_, int p_i1970_4_)
              {
-@@ -559,12 +644,28 @@
+@@ -559,12 +643,28 @@
                  this.field_76300_b = p_i1970_1_;
                  this.field_76301_c = p_i1970_3_;
                  this.field_76299_d = p_i1970_4_;


### PR DESCRIPTION
If `flowers` is empty during this method call, the weight passed to `WeightedRandom` will be 0, and an `IllegalArgumentException` will be thrown.  This prevents said crash, as there is no way to check this field externally without reflection before calling `plantFlower`.

This crash would occur in any Biome in which bonemeal was used on grass while having an empty `flowers` list.