### PR TITLE
Fix being unable to see with night vision under some conditions (MC-4647, MC-10480)

### DIFF
--- a/patches/minecraft/net/minecraft/client/renderer/EntityRenderer.java.patch
+++ b/patches/minecraft/net/minecraft/client/renderer/EntityRenderer.java.patch
@@ -223,7 +223,17 @@
  
          float f13 = this.field_78535_ad + (this.field_78539_ae - this.field_78535_ad) * p_78466_1_;
          this.field_175080_Q *= f13;
-@@ -1845,6 +1868,13 @@
+@@ -1830,6 +1853,9 @@
+                 f6 = 1.0F / this.field_175081_S;
+             }
+ 
++            // Forge: fix MC-4647 and MC-10480
++            if (Float.isInfinite(f6)) f6 = Math.nextAfter(f6, 0.0);
++
+             this.field_175080_Q = this.field_175080_Q * (1.0F - f15) + this.field_175080_Q * f6 * f15;
+             this.field_175082_R = this.field_175082_R * (1.0F - f15) + this.field_175082_R * f6 * f15;
+             this.field_175081_S = this.field_175081_S * (1.0F - f15) + this.field_175081_S * f6 * f15;
+@@ -1845,6 +1871,13 @@
              this.field_175081_S = f7;
          }
  
@@ -237,7 +247,7 @@
          GlStateManager.func_179082_a(this.field_175080_Q, this.field_175082_R, this.field_175081_S, 0.0F);
      }
  
-@@ -1855,7 +1885,9 @@
+@@ -1855,7 +1888,9 @@
          GlStateManager.func_187432_a(0.0F, -1.0F, 0.0F);
          GlStateManager.func_179131_c(1.0F, 1.0F, 1.0F, 1.0F);
          IBlockState iblockstate = ActiveRenderInfo.func_186703_a(this.field_78531_r.field_71441_e, entity, p_78468_2_);
@@ -248,7 +258,7 @@
          if (entity instanceof EntityLivingBase && ((EntityLivingBase)entity).func_70644_a(MobEffects.field_76440_q))
          {
              float f1 = 5.0F;
-@@ -1940,6 +1972,7 @@
+@@ -1940,6 +1975,7 @@
                  GlStateManager.func_179102_b(f * 0.05F);
                  GlStateManager.func_179153_c(Math.min(f, 192.0F) * 0.5F);
              }


### PR DESCRIPTION
Vanilla bugs:
* [MC-4647](https://bugs.mojang.com/browse/MC-4647)
* [MC-10480](https://bugs.mojang.com/browse/MC-10480)

Basically, if the fog colour values in `EntityRenderer.updateFogColor()` end up as 0, then the night vision code will first get infinity from 1/0, and then NaN from 0 * infinity. The NaN values get passed through to OpenGL fog functions, which causes the player to be unable to see anything.

This PR fixes the issue by handling the case of an infinite multiplier, reducing it to a finite value. This prevents invalid values being produced by the following calculations, fixing the bugs.

Screenshots (taken at night, with both night vision and blindness effects applied):

* Before:
![2017-09-09_014428](https://user-images.githubusercontent.com/1447117/30235607-19fe4a90-9502-11e7-9350-b3032457d672.png)

* After:
![2017-09-09_014604](https://user-images.githubusercontent.com/1447117/30235609-22b11ac8-9502-11e7-94b2-ee80792ec396.png)

Another set of screenshots, taken from the void:

* Before:
![2017-09-09_041311](https://user-images.githubusercontent.com/1447117/30236639-d88cdb94-9515-11e7-84e9-edfce1a76f7b.png)

* After:
![2017-09-09_041357](https://user-images.githubusercontent.com/1447117/30236640-de511a5e-9515-11e7-96e1-2effd3a26ee5.png)

