### PR TITLE
Fix lightmap calculation vertex clamping

### DIFF
--- a/src/main/java/net/minecraftforge/client/model/pipeline/VertexLighterSmoothAo.java
+++ b/src/main/java/net/minecraftforge/client/model/pipeline/VertexLighterSmoothAo.java
@@ -71,18 +71,36 @@ public class VertexLighterSmoothAo extends VertexLighterFlat
         float e1 = 1 + 1e-4f;
         if(ax > 2 - 1e-4f && ay <= e1 && az <= e1)
         {
-            if(x < -2 + 1e-4f) x = -2 + 1e-4f;
-            if(x >  2 - 1e-4f) x =  2 - 1e-4f;
+            if(x < 0)
+            {
+                x = -2 + 1e-4f;
+            }
+            else
+            {
+                x = 2 - 1e-4f;
+            }
         }
         else if(ay > 2 - 1e-4f && az <= e1 && ax <= e1)
         {
-            if(y < -2 + 1e-4f) y = -2 + 1e-4f;
-            if(y >  2 - 1e-4f) y =  2 - 1e-4f;
+            if(y < 0)
+            {
+                y = -2 + 1e-4f;
+            }
+            else
+            {
+                y = 2 - 1e-4f;
+            }
         }
         else if(az > 2 - 1e-4f && ax <= e1 && ay <= e1)
         {
-            if(z < -2 + 1e-4f) z = -2 + 1e-4f;
-            if(z >  2 - 1e-4f) z =  2 - 1e-4f;
+            if(z < 0)
+            {
+                z = -2 + 1e-4f;
+            }
+            else
+            {
+                z = 2 - 1e-4f;
+            }
         }
         ax = x > 0 ? x : -x;
         ay = y > 0 ? y : -y;

--- a/src/main/java/net/minecraftforge/client/model/pipeline/VertexLighterSmoothAo.java
+++ b/src/main/java/net/minecraftforge/client/model/pipeline/VertexLighterSmoothAo.java
@@ -71,36 +71,15 @@ public class VertexLighterSmoothAo extends VertexLighterFlat
         float e1 = 1 + 1e-4f;
         if(ax > 2 - 1e-4f && ay <= e1 && az <= e1)
         {
-            if(x < 0)
-            {
-                x = -2 + 1e-4f;
-            }
-            else
-            {
-                x = 2 - 1e-4f;
-            }
+            x = x < 0 ? -2 + 1e-4f : 2 - 1e-4f;
         }
         else if(ay > 2 - 1e-4f && az <= e1 && ax <= e1)
         {
-            if(y < 0)
-            {
-                y = -2 + 1e-4f;
-            }
-            else
-            {
-                y = 2 - 1e-4f;
-            }
+            y = y < 0 ? -2 + 1e-4f : 2 - 1e-4f;
         }
         else if(az > 2 - 1e-4f && ax <= e1 && ay <= e1)
         {
-            if(z < 0)
-            {
-                z = -2 + 1e-4f;
-            }
-            else
-            {
-                z = 2 - 1e-4f;
-            }
+            z = z < 0 ? -2 + 1e-4f : 2 - 1e-4f;
         }
         ax = x > 0 ? x : -x;
         ay = y > 0 ? y : -y;

--- a/src/main/java/net/minecraftforge/client/model/pipeline/VertexLighterSmoothAo.java
+++ b/src/main/java/net/minecraftforge/client/model/pipeline/VertexLighterSmoothAo.java
@@ -71,18 +71,18 @@ public class VertexLighterSmoothAo extends VertexLighterFlat
         float e1 = 1 + 1e-4f;
         if(ax > 2 - 1e-4f && ay <= e1 && az <= e1)
         {
-            if(x > -2 + 1e-4f) x = -2 + 1e-4f;
-            if(x <  2 - 1e-4f) x =  2 - 1e-4f;
+            if(x < -2 + 1e-4f) x = -2 + 1e-4f;
+            if(x >  2 - 1e-4f) x =  2 - 1e-4f;
         }
         else if(ay > 2 - 1e-4f && az <= e1 && ax <= e1)
         {
-            if(y > -2 + 1e-4f) y = -2 + 1e-4f;
-            if(y <  2 - 1e-4f) y =  2 - 1e-4f;
+            if(y < -2 + 1e-4f) y = -2 + 1e-4f;
+            if(y >  2 - 1e-4f) y =  2 - 1e-4f;
         }
         else if(az > 2 - 1e-4f && ax <= e1 && ay <= e1)
         {
-            if(z > -2 + 1e-4f) z = -2 + 1e-4f;
-            if(z <  2 - 1e-4f) z =  2 - 1e-4f;
+            if(z < -2 + 1e-4f) z = -2 + 1e-4f;
+            if(z >  2 - 1e-4f) z =  2 - 1e-4f;
         }
         ax = x > 0 ? x : -x;
         ay = y > 0 ? y : -y;


### PR DESCRIPTION
Following #4316 an error in the lighting pipeline's ambient occlusion calculations was made visible on certain models such as stairs. This PR corrects the faulty clamping logic responsible for the issue.

Before:
![image](https://user-images.githubusercontent.com/5201207/30259437-35109304-9676-11e7-8314-ac718c224241.png)
(north face of stairs)

After:
![image](https://user-images.githubusercontent.com/5201207/30259465-4ebcc7b4-9676-11e7-8595-21c76d296d2b.png)