### PR TITLE
Prevent a mutable BlockPos leak in World#setBlockState

### DIFF
--- a/patches/minecraft/net/minecraft/world/World.java.patch
+++ b/patches/minecraft/net/minecraft/world/World.java.patch
@@ -59,12 +59,13 @@
      }
  
      public boolean func_175667_e(BlockPos p_175667_1_)
-@@ -308,24 +327,50 @@
+@@ -308,24 +327,51 @@
          else
          {
              Chunk chunk = this.func_175726_f(p_180501_1_);
 -            Block block = p_180501_2_.func_177230_c();
 +
++            p_180501_1_ = p_180501_1_.func_185334_h(); // Forge - prevent mutable BlockPos leaks
 +            net.minecraftforge.common.util.BlockSnapshot blockSnapshot = null;
 +            if (this.captureBlockSnapshots && !this.field_72995_K)
 +            {
@@ -113,7 +114,7 @@
                      this.func_184138_a(p_180501_1_, iblockstate, p_180501_2_, p_180501_3_);
                  }
  
-@@ -342,8 +387,6 @@
+@@ -342,8 +388,6 @@
                  {
                      this.func_190522_c(p_180501_1_, block);
                  }
@@ -122,7 +123,7 @@
              }
          }
      }
-@@ -358,7 +401,7 @@
+@@ -358,7 +402,7 @@
          IBlockState iblockstate = this.func_180495_p(p_175655_1_);
          Block block = iblockstate.func_177230_c();
  
@@ -131,7 +132,7 @@
          {
              return false;
          }
-@@ -441,6 +484,9 @@
+@@ -441,6 +485,9 @@
  
      public void func_175685_c(BlockPos p_175685_1_, Block p_175685_2_, boolean p_175685_3_)
      {
@@ -141,7 +142,7 @@
          this.func_190524_a(p_175685_1_.func_177976_e(), p_175685_2_, p_175685_1_);
          this.func_190524_a(p_175685_1_.func_177974_f(), p_175685_2_, p_175685_1_);
          this.func_190524_a(p_175685_1_.func_177977_b(), p_175685_2_, p_175685_1_);
-@@ -456,6 +502,11 @@
+@@ -456,6 +503,11 @@
  
      public void func_175695_a(BlockPos p_175695_1_, Block p_175695_2_, EnumFacing p_175695_3_)
      {
@@ -153,7 +154,7 @@
          if (p_175695_3_ != EnumFacing.WEST)
          {
              this.func_190524_a(p_175695_1_.func_177976_e(), p_175695_2_, p_175695_1_);
-@@ -527,11 +578,11 @@
+@@ -527,11 +579,11 @@
          {
              IBlockState iblockstate = this.func_180495_p(p_190529_1_);
  
@@ -167,7 +168,7 @@
                  }
                  catch (Throwable throwable)
                  {
-@@ -588,7 +639,7 @@
+@@ -588,7 +640,7 @@
                  {
                      IBlockState iblockstate = this.func_180495_p(blockpos1);
  
@@ -176,7 +177,7 @@
                      {
                          return false;
                      }
-@@ -862,7 +913,7 @@
+@@ -862,7 +914,7 @@
  
      public boolean func_72935_r()
      {
@@ -185,7 +186,7 @@
      }
  
      @Nullable
-@@ -1065,6 +1116,13 @@
+@@ -1065,6 +1117,13 @@
  
      public void func_184148_a(@Nullable EntityPlayer p_184148_1_, double p_184148_2_, double p_184148_4_, double p_184148_6_, SoundEvent p_184148_8_, SoundCategory p_184148_9_, float p_184148_10_, float p_184148_11_)
      {
@@ -199,7 +200,7 @@
          for (int i = 0; i < this.field_73021_x.size(); ++i)
          {
              ((IWorldEventListener)this.field_73021_x.get(i)).func_184375_a(p_184148_1_, p_184148_8_, p_184148_9_, p_184148_2_, p_184148_4_, p_184148_6_, p_184148_10_, p_184148_11_);
-@@ -1118,6 +1176,9 @@
+@@ -1118,6 +1177,9 @@
  
      public boolean func_72838_d(Entity p_72838_1_)
      {
@@ -209,7 +210,7 @@
          int i = MathHelper.func_76128_c(p_72838_1_.field_70165_t / 16.0D);
          int j = MathHelper.func_76128_c(p_72838_1_.field_70161_v / 16.0D);
          boolean flag = p_72838_1_.field_98038_p;
-@@ -1140,6 +1201,8 @@
+@@ -1140,6 +1202,8 @@
                  this.func_72854_c();
              }
  
@@ -218,7 +219,7 @@
              this.func_72964_e(i, j).func_76612_a(p_72838_1_);
              this.field_72996_f.add(p_72838_1_);
              this.func_72923_a(p_72838_1_);
-@@ -1268,6 +1331,7 @@
+@@ -1268,6 +1332,7 @@
                                  }
  
                                  iblockstate1.func_185908_a(this, blockpos$pooledmutableblockpos, p_191504_2_, p_191504_4_, p_191504_1_, false);
@@ -226,7 +227,7 @@
  
                                  if (p_191504_3_ && !p_191504_4_.isEmpty())
                                  {
-@@ -1319,11 +1383,10 @@
+@@ -1319,11 +1384,10 @@
                  }
              }
          }
@@ -239,7 +240,7 @@
      public void func_72848_b(IWorldEventListener p_72848_1_)
      {
          this.field_73021_x.remove(p_72848_1_);
-@@ -1361,19 +1424,38 @@
+@@ -1361,19 +1425,38 @@
  
      public int func_72967_a(float p_72967_1_)
      {
@@ -280,7 +281,7 @@
          float f = this.func_72826_c(p_72971_1_);
          float f1 = 1.0F - (MathHelper.func_76134_b(f * ((float)Math.PI * 2F)) * 2.0F + 0.2F);
          f1 = MathHelper.func_76131_a(f1, 0.0F, 1.0F);
-@@ -1386,6 +1468,12 @@
+@@ -1386,6 +1469,12 @@
      @SideOnly(Side.CLIENT)
      public Vec3d func_72833_a(Entity p_72833_1_, float p_72833_2_)
      {
@@ -293,7 +294,7 @@
          float f = this.func_72826_c(p_72833_2_);
          float f1 = MathHelper.func_76134_b(f * ((float)Math.PI * 2F)) * 2.0F + 0.5F;
          f1 = MathHelper.func_76131_a(f1, 0.0F, 1.0F);
-@@ -1393,9 +1481,7 @@
+@@ -1393,9 +1482,7 @@
          int j = MathHelper.func_76128_c(p_72833_1_.field_70163_u);
          int k = MathHelper.func_76128_c(p_72833_1_.field_70161_v);
          BlockPos blockpos = new BlockPos(i, j, k);
@@ -304,7 +305,7 @@
          float f3 = (float)(l >> 16 & 255) / 255.0F;
          float f4 = (float)(l >> 8 & 255) / 255.0F;
          float f5 = (float)(l & 255) / 255.0F;
-@@ -1444,20 +1530,25 @@
+@@ -1444,20 +1531,25 @@
  
      public float func_72826_c(float p_72826_1_)
      {
@@ -333,7 +334,7 @@
      public float func_72929_e(float p_72929_1_)
      {
          float f = this.func_72826_c(p_72929_1_);
-@@ -1467,6 +1558,12 @@
+@@ -1467,6 +1559,12 @@
      @SideOnly(Side.CLIENT)
      public Vec3d func_72824_f(float p_72824_1_)
      {
@@ -346,7 +347,7 @@
          float f = this.func_72826_c(p_72824_1_);
          float f1 = MathHelper.func_76134_b(f * ((float)Math.PI * 2F)) * 2.0F + 0.5F;
          f1 = MathHelper.func_76131_a(f1, 0.0F, 1.0F);
-@@ -1522,9 +1619,9 @@
+@@ -1522,9 +1620,9 @@
          for (blockpos = new BlockPos(p_175672_1_.func_177958_n(), chunk.func_76625_h() + 16, p_175672_1_.func_177952_p()); blockpos.func_177956_o() >= 0; blockpos = blockpos1)
          {
              blockpos1 = blockpos.func_177977_b();
@@ -358,7 +359,7 @@
              {
                  break;
              }
-@@ -1536,6 +1633,12 @@
+@@ -1536,6 +1634,12 @@
      @SideOnly(Side.CLIENT)
      public float func_72880_h(float p_72880_1_)
      {
@@ -371,7 +372,7 @@
          float f = this.func_72826_c(p_72880_1_);
          float f1 = 1.0F - (MathHelper.func_76134_b(f * ((float)Math.PI * 2F)) * 2.0F + 0.25F);
          f1 = MathHelper.func_76131_a(f1, 0.0F, 1.0F);
-@@ -1570,6 +1673,7 @@
+@@ -1570,6 +1674,7 @@
  
              try
              {
@@ -379,7 +380,7 @@
                  ++entity.field_70173_aa;
                  entity.func_70071_h_();
              }
-@@ -1587,6 +1691,12 @@
+@@ -1587,6 +1692,12 @@
                      entity.func_85029_a(crashreportcategory);
                  }
  
@@ -392,7 +393,7 @@
                  throw new ReportedException(crashreport);
              }
  
-@@ -1648,6 +1758,12 @@
+@@ -1648,6 +1759,12 @@
                      CrashReport crashreport1 = CrashReport.func_85055_a(throwable1, "Ticking entity");
                      CrashReportCategory crashreportcategory1 = crashreport1.func_85058_a("Entity being ticked");
                      entity2.func_85029_a(crashreportcategory1);
@@ -405,7 +406,7 @@
                      throw new ReportedException(crashreport1);
                  }
              }
-@@ -1674,14 +1790,23 @@
+@@ -1674,14 +1791,23 @@
  
          this.field_72984_F.func_76318_c("blockEntities");
  
@@ -432,7 +433,7 @@
          Iterator<TileEntity> iterator = this.field_175730_i.iterator();
  
          while (iterator.hasNext())
-@@ -1692,7 +1817,7 @@
+@@ -1692,7 +1818,7 @@
              {
                  BlockPos blockpos = tileentity.func_174877_v();
  
@@ -441,7 +442,7 @@
                  {
                      try
                      {
-@@ -1708,6 +1833,13 @@
+@@ -1708,6 +1834,13 @@
                          CrashReport crashreport2 = CrashReport.func_85055_a(throwable, "Ticking block entity");
                          CrashReportCategory crashreportcategory2 = crashreport2.func_85058_a("Block entity being ticked");
                          tileentity.func_145828_a(crashreportcategory2);
@@ -455,7 +456,7 @@
                          throw new ReportedException(crashreport2);
                      }
                  }
-@@ -1720,7 +1852,10 @@
+@@ -1720,7 +1853,10 @@
  
                  if (this.func_175667_e(tileentity.func_174877_v()))
                  {
@@ -467,7 +468,7 @@
                  }
              }
          }
-@@ -1764,12 +1899,18 @@
+@@ -1764,12 +1900,18 @@
  
      public boolean func_175700_a(TileEntity p_175700_1_)
      {
@@ -486,7 +487,7 @@
  
          if (this.field_72995_K)
          {
-@@ -1785,6 +1926,11 @@
+@@ -1785,6 +1927,11 @@
      {
          if (this.field_147481_N)
          {
@@ -498,7 +499,7 @@
              this.field_147484_a.addAll(p_147448_1_);
          }
          else
-@@ -1807,9 +1953,13 @@
+@@ -1807,9 +1954,13 @@
          {
              int j2 = MathHelper.func_76128_c(p_72866_1_.field_70165_t);
              int k2 = MathHelper.func_76128_c(p_72866_1_.field_70161_v);
@@ -514,7 +515,7 @@
              {
                  return;
              }
-@@ -1831,6 +1981,7 @@
+@@ -1831,6 +1982,7 @@
              }
              else
              {
@@ -522,7 +523,7 @@
                  p_72866_1_.func_70071_h_();
              }
          }
-@@ -2011,6 +2162,11 @@
+@@ -2011,6 +2163,11 @@
                              blockpos$pooledmutableblockpos.func_185344_t();
                              return true;
                          }
@@ -534,7 +535,7 @@
                      }
                  }
              }
-@@ -2050,6 +2206,16 @@
+@@ -2050,6 +2207,16 @@
                          IBlockState iblockstate1 = this.func_180495_p(blockpos$pooledmutableblockpos);
                          Block block = iblockstate1.func_177230_c();
  
@@ -551,7 +552,7 @@
                          if (iblockstate1.func_185904_a() == p_72918_2_)
                          {
                              double d0 = (double)((float)(i4 + 1) - BlockLiquid.func_149801_b(((Integer)iblockstate1.func_177229_b(BlockLiquid.field_176367_b)).intValue()));
-@@ -2116,6 +2282,7 @@
+@@ -2116,6 +2283,7 @@
      public Explosion func_72885_a(@Nullable Entity p_72885_1_, double p_72885_2_, double p_72885_4_, double p_72885_6_, float p_72885_8_, boolean p_72885_9_, boolean p_72885_10_)
      {
          Explosion explosion = new Explosion(this, p_72885_1_, p_72885_2_, p_72885_4_, p_72885_6_, p_72885_8_, p_72885_9_, p_72885_10_);
@@ -559,7 +560,7 @@
          explosion.func_77278_a();
          explosion.func_77279_a(true);
          return explosion;
-@@ -2238,6 +2405,7 @@
+@@ -2238,6 +2406,7 @@
  
      public void func_175690_a(BlockPos p_175690_1_, @Nullable TileEntity p_175690_2_)
      {
@@ -567,7 +568,7 @@
          if (!this.func_189509_E(p_175690_1_))
          {
              if (p_175690_2_ != null && !p_175690_2_.func_145837_r())
-@@ -2245,6 +2413,8 @@
+@@ -2245,6 +2414,8 @@
                  if (this.field_147481_N)
                  {
                      p_175690_2_.func_174878_a(p_175690_1_);
@@ -576,7 +577,7 @@
                      Iterator<TileEntity> iterator1 = this.field_147484_a.iterator();
  
                      while (iterator1.hasNext())
-@@ -2262,7 +2432,8 @@
+@@ -2262,7 +2433,8 @@
                  }
                  else
                  {
@@ -586,7 +587,7 @@
                      this.func_175700_a(p_175690_2_);
                  }
              }
-@@ -2277,6 +2448,8 @@
+@@ -2277,6 +2449,8 @@
          {
              tileentity2.func_145843_s();
              this.field_147484_a.remove(tileentity2);
@@ -595,7 +596,7 @@
          }
          else
          {
-@@ -2289,6 +2462,7 @@
+@@ -2289,6 +2463,7 @@
  
              this.func_175726_f(p_175713_1_).func_177425_e(p_175713_1_);
          }
@@ -603,7 +604,7 @@
      }
  
      public void func_147457_a(TileEntity p_147457_1_)
-@@ -2315,7 +2489,7 @@
+@@ -2315,7 +2490,7 @@
              if (chunk1 != null && !chunk1.func_76621_g())
              {
                  IBlockState iblockstate1 = this.func_180495_p(p_175677_1_);
@@ -612,7 +613,7 @@
              }
              else
              {
-@@ -2338,6 +2512,7 @@
+@@ -2338,6 +2513,7 @@
      {
          this.field_72985_G = p_72891_1_;
          this.field_72992_H = p_72891_2_;
@@ -620,7 +621,7 @@
      }
  
      public void func_72835_b()
-@@ -2347,6 +2522,11 @@
+@@ -2347,6 +2523,11 @@
  
      protected void func_72947_a()
      {
@@ -632,7 +633,7 @@
          if (this.field_72986_A.func_76059_o())
          {
              this.field_73004_o = 1.0F;
-@@ -2360,6 +2540,11 @@
+@@ -2360,6 +2541,11 @@
  
      protected void func_72979_l()
      {
@@ -644,7 +645,7 @@
          if (this.field_73011_w.func_191066_m())
          {
              if (!this.field_72995_K)
-@@ -2484,6 +2669,11 @@
+@@ -2484,6 +2670,11 @@
  
      public boolean func_175670_e(BlockPos p_175670_1_, boolean p_175670_2_)
      {
@@ -656,7 +657,7 @@
          Biome biome = this.func_180494_b(p_175670_1_);
          float f = biome.func_180626_a(p_175670_1_);
  
-@@ -2525,6 +2715,11 @@
+@@ -2525,6 +2716,11 @@
  
      public boolean func_175708_f(BlockPos p_175708_1_, boolean p_175708_2_)
      {
@@ -668,7 +669,7 @@
          Biome biome = this.func_180494_b(p_175708_1_);
          float f = biome.func_180626_a(p_175708_1_);
  
-@@ -2542,7 +2737,7 @@
+@@ -2542,7 +2738,7 @@
              {
                  IBlockState iblockstate1 = this.func_180495_p(p_175708_1_);
  
@@ -677,7 +678,7 @@
                  {
                      return true;
                  }
-@@ -2574,10 +2769,11 @@
+@@ -2574,10 +2770,11 @@
          else
          {
              IBlockState iblockstate1 = this.func_180495_p(p_175638_1_);
@@ -692,7 +693,7 @@
              {
                  k2 = 1;
              }
-@@ -2683,7 +2879,8 @@
+@@ -2683,7 +2880,8 @@
                                      int k6 = k4 + enumfacing.func_96559_d();
                                      int l6 = l4 + enumfacing.func_82599_e();
                                      blockpos$pooledmutableblockpos.func_181079_c(j6, k6, l6);
@@ -702,7 +703,7 @@
                                      j5 = this.func_175642_b(p_180500_1_, blockpos$pooledmutableblockpos);
  
                                      if (j5 == i5 - i7 && k2 < this.field_72994_J.length)
-@@ -2791,10 +2988,10 @@
+@@ -2791,10 +2989,10 @@
      public List<Entity> func_175674_a(@Nullable Entity p_175674_1_, AxisAlignedBB p_175674_2_, @Nullable Predicate <? super Entity > p_175674_3_)
      {
          List<Entity> list = Lists.<Entity>newArrayList();
@@ -717,7 +718,7 @@
  
          for (int j3 = j2; j3 <= k2; ++j3)
          {
-@@ -2847,10 +3044,10 @@
+@@ -2847,10 +3045,10 @@
  
      public <T extends Entity> List<T> func_175647_a(Class <? extends T > p_175647_1_, AxisAlignedBB p_175647_2_, @Nullable Predicate <? super T > p_175647_3_)
      {
@@ -732,7 +733,7 @@
          List<T> list = Lists.<T>newArrayList();
  
          for (int j3 = j2; j3 < k2; ++j3)
-@@ -2930,11 +3127,13 @@
+@@ -2930,11 +3128,13 @@
  
      public void func_175650_b(Collection<Entity> p_175650_1_)
      {
@@ -749,7 +750,7 @@
          }
      }
  
-@@ -2958,7 +3157,7 @@
+@@ -2958,7 +3158,7 @@
          }
          else
          {
@@ -758,7 +759,7 @@
          }
      }
  
-@@ -3042,7 +3241,7 @@
+@@ -3042,7 +3242,7 @@
      public int func_175651_c(BlockPos p_175651_1_, EnumFacing p_175651_2_)
      {
          IBlockState iblockstate1 = this.func_180495_p(p_175651_1_);
@@ -767,7 +768,7 @@
      }
  
      public boolean func_175640_z(BlockPos p_175640_1_)
-@@ -3208,6 +3407,8 @@
+@@ -3208,6 +3408,8 @@
                      d2 *= ((Double)MoreObjects.firstNonNull(p_184150_11_.apply(entityplayer1), Double.valueOf(1.0D))).doubleValue();
                  }
  
@@ -776,7 +777,7 @@
                  if ((p_184150_9_ < 0.0D || Math.abs(entityplayer1.field_70163_u - p_184150_3_) < p_184150_9_ * p_184150_9_) && (p_184150_7_ < 0.0D || d1 < d2 * d2) && (d0 == -1.0D || d1 < d0))
                  {
                      d0 = d1;
-@@ -3269,7 +3470,7 @@
+@@ -3269,7 +3471,7 @@
  
      public long func_72905_C()
      {
@@ -785,7 +786,7 @@
      }
  
      public long func_82737_E()
-@@ -3279,17 +3480,17 @@
+@@ -3279,17 +3481,17 @@
  
      public long func_72820_D()
      {
@@ -806,7 +807,7 @@
  
          if (!this.func_175723_af().func_177746_a(blockpos1))
          {
-@@ -3301,7 +3502,7 @@
+@@ -3301,7 +3503,7 @@
  
      public void func_175652_B(BlockPos p_175652_1_)
      {
@@ -815,7 +816,7 @@
      }
  
      @SideOnly(Side.CLIENT)
-@@ -3321,12 +3522,18 @@
+@@ -3321,12 +3523,18 @@
  
          if (!this.field_72996_f.contains(p_72897_1_))
          {
@@ -834,7 +835,7 @@
          return true;
      }
  
-@@ -3428,8 +3635,7 @@
+@@ -3428,8 +3636,7 @@
  
      public boolean func_180502_D(BlockPos p_180502_1_)
      {
@@ -844,7 +845,7 @@
      }
  
      @Nullable
-@@ -3490,12 +3696,12 @@
+@@ -3490,12 +3697,12 @@
  
      public int func_72800_K()
      {
@@ -859,7 +860,7 @@
      }
  
      public Random func_72843_D(int p_72843_1_, int p_72843_2_, int p_72843_3_)
-@@ -3539,7 +3745,7 @@
+@@ -3539,7 +3746,7 @@
      @SideOnly(Side.CLIENT)
      public double func_72919_O()
      {
@@ -868,7 +869,7 @@
      }
  
      public void func_175715_c(int p_175715_1_, BlockPos p_175715_2_, int p_175715_3_)
-@@ -3573,7 +3779,7 @@
+@@ -3573,7 +3780,7 @@
  
      public void func_175666_e(BlockPos p_175666_1_, Block p_175666_2_)
      {
@@ -877,7 +878,7 @@
          {
              BlockPos blockpos1 = p_175666_1_.func_177972_a(enumfacing);
  
-@@ -3581,18 +3787,15 @@
+@@ -3581,18 +3788,15 @@
              {
                  IBlockState iblockstate1 = this.func_180495_p(blockpos1);
  
@@ -900,7 +901,7 @@
                      }
                  }
              }
-@@ -3658,6 +3861,124 @@
+@@ -3658,6 +3862,124 @@
          return j2 >= -128 && j2 <= 128 && k2 >= -128 && k2 <= 128;
      }
  


### PR DESCRIPTION
Prevent a mutable `BlockPos` leak, similar to what was done with [`World#setTileEntity` (`func_175690_a`)](https://github.com/MinecraftForge/MinecraftForge/blob/1.12.x/patches/minecraft/net/minecraft/world/World.java.patch#L564) in [#2659](https://github.com/MinecraftForge/MinecraftForge/pull/2659/files#diff-0facadd57a1c485eed926033d315a5f0R557).

Previously, a mutable `BlockPos` could leak to a `BlockSnapshot`, among other things - especially if a mod decides to play dirty and use ASM to make call their own methods which aren't expecting mutable `BlockPos`es.