### PR TITLE
Fixed non vanilla tabs with search losing their contents. 

### DIFF
--- a/patches/minecraft/net/minecraft/client/gui/inventory/GuiContainerCreative.java.patch
+++ b/patches/minecraft/net/minecraft/client/gui/inventory/GuiContainerCreative.java.patch
@@ -32,15 +32,14 @@
          {
              if (GameSettings.func_100015_a(this.field_146297_k.field_71474_y.field_74310_D))
              {
-@@ -346,6 +355,35 @@
+@@ -346,6 +355,34 @@
          GuiContainerCreative.ContainerCreative guicontainercreative$containercreative = (GuiContainerCreative.ContainerCreative)this.field_147002_h;
          guicontainercreative$containercreative.field_148330_a.clear();
  
 +        CreativeTabs tab = CreativeTabs.field_78032_a[field_147058_w];
 +        if (tab.hasSearchBar() && tab != CreativeTabs.field_78027_g)
 +        {
-+            for (Item item : Item.field_150901_e)
-+                item.func_150895_a(tab, guicontainercreative$containercreative.field_148330_a);
++            tab.func_78018_a(guicontainercreative$containercreative.field_148330_a);
 +            if (!this.field_147062_A.func_146179_b().isEmpty())
 +            {
 +                //TODO: Make this a SearchTree not a manual search
@@ -68,7 +67,7 @@
          if (this.field_147062_A.func_146179_b().isEmpty())
          {
              for (Item item : Item.field_150901_e)
-@@ -366,7 +404,7 @@
+@@ -366,7 +403,7 @@
      {
          CreativeTabs creativetabs = CreativeTabs.field_78032_a[field_147058_w];
  
@@ -77,7 +76,7 @@
          {
              GlStateManager.func_179084_k();
              this.field_146289_q.func_78276_b(I18n.func_135052_a(creativetabs.func_78024_c()), 8, 6, 4210752);
-@@ -401,7 +439,7 @@
+@@ -401,7 +438,7 @@
  
              for (CreativeTabs creativetabs : CreativeTabs.field_78032_a)
              {
@@ -86,7 +85,7 @@
                  {
                      this.func_147050_b(creativetabs);
                      return;
-@@ -414,11 +452,13 @@
+@@ -414,11 +451,13 @@
  
      private boolean func_147055_p()
      {
@@ -100,7 +99,7 @@
          int i = field_147058_w;
          field_147058_w = p_147050_1_.func_78021_a();
          GuiContainerCreative.ContainerCreative guicontainercreative$containercreative = (GuiContainerCreative.ContainerCreative)this.field_147002_h;
-@@ -524,12 +564,14 @@
+@@ -524,12 +563,14 @@
  
          if (this.field_147062_A != null)
          {
@@ -116,7 +115,7 @@
                  this.func_147053_i();
              }
              else
-@@ -601,19 +643,43 @@
+@@ -601,19 +642,43 @@
  
          super.func_73863_a(p_73863_1_, p_73863_2_, p_73863_3_);
  
@@ -161,7 +160,7 @@
          GlStateManager.func_179131_c(1.0F, 1.0F, 1.0F, 1.0F);
          GlStateManager.func_179140_f();
          this.func_191948_b(p_73863_1_, p_73863_2_);
-@@ -662,7 +728,10 @@
+@@ -662,7 +727,10 @@
                  }
              }
  
@@ -173,7 +172,7 @@
          }
          else
          {
-@@ -676,16 +745,35 @@
+@@ -676,16 +744,35 @@
          RenderHelper.func_74520_c();
          CreativeTabs creativetabs = CreativeTabs.field_78032_a[field_147058_w];
  
@@ -210,7 +209,7 @@
          this.field_146297_k.func_110434_K().func_110577_a(new ResourceLocation("textures/gui/container/creative_inventory/tab_" + creativetabs.func_78015_f()));
          this.func_73729_b(this.field_147003_i, this.field_147009_r, 0, 0, this.field_146999_f, this.field_147000_g);
          this.field_147062_A.func_146194_f();
-@@ -700,6 +788,14 @@
+@@ -700,6 +787,14 @@
              this.func_73729_b(i, j + (int)((float)(k - j - 17) * this.field_147067_x), 232 + (this.func_147055_p() ? 0 : 12), 0, 12, 15);
          }
  
@@ -225,7 +224,7 @@
          this.func_147051_a(creativetabs);
  
          if (creativetabs == CreativeTabs.field_78036_m)
-@@ -710,6 +806,14 @@
+@@ -710,6 +805,14 @@
  
      protected boolean func_147049_a(CreativeTabs p_147049_1_, int p_147049_2_, int p_147049_3_)
      {
@@ -240,7 +239,7 @@
          int i = p_147049_1_.func_78020_k();
          int j = 28 * i;
          int k = 0;
-@@ -806,6 +910,8 @@
+@@ -806,6 +909,8 @@
          }
  
          GlStateManager.func_179140_f();
@@ -249,7 +248,7 @@
          this.func_73729_b(l, i1, j, k, 28, 32);
          this.field_73735_i = 100.0F;
          this.field_146296_j.field_77023_b = 100.0F;
-@@ -827,6 +933,15 @@
+@@ -827,6 +932,15 @@
          {
              this.field_146297_k.func_147108_a(new GuiStats(this, this.field_146297_k.field_71439_g.func_146107_m()));
          }
@@ -265,7 +264,7 @@
      }
  
      public int func_147056_g()
-@@ -1031,6 +1146,38 @@
+@@ -1031,6 +1145,38 @@
          {
              return this.field_148332_b.func_82869_a(p_82869_1_);
          }

--- a/src/test/java/net/minecraftforge/debug/DebugSearchTabs.java
+++ b/src/test/java/net/minecraftforge/debug/DebugSearchTabs.java
@@ -1,0 +1,42 @@
+package net.minecraftforge.debug;
+
+import net.minecraft.creativetab.CreativeTabs;
+import net.minecraft.init.Blocks;
+import net.minecraft.init.Items;
+import net.minecraft.item.ItemStack;
+import net.minecraft.util.NonNullList;
+import net.minecraftforge.fml.common.Mod;
+import net.minecraftforge.fml.relauncher.Side;
+import net.minecraftforge.fml.relauncher.SideOnly;
+
+@Mod(modid = DebugSearchTabs.MODID, name = "Debug Search Tab", version = "1.0")
+public class DebugSearchTabs
+{
+    public static final String MODID = "debugsearchtab";
+
+    public static final CreativeTabs SEARCH_TAB = new CreativeTabs(1, "searchtab")
+    {
+        @SideOnly(Side.CLIENT)
+        public ItemStack getTabIconItem()
+        {
+            return new ItemStack(Items.TOTEM_OF_UNDYING);
+        }
+        
+        @Override
+        public boolean hasSearchBar() {
+        	
+        	return true;
+        }
+        
+        @Override
+        @SideOnly(Side.CLIENT)
+        public void displayAllRelevantItems(NonNullList<ItemStack> items)
+        {
+        	super.displayAllRelevantItems(items);
+        	items.add(new ItemStack(Blocks.BARRIER));
+        	items.add(new ItemStack(Blocks.COMMAND_BLOCK));
+        	items.add(new ItemStack(Blocks.CHAIN_COMMAND_BLOCK));
+        	items.add(new ItemStack(Blocks.REPEATING_COMMAND_BLOCK));
+        }
+    };
+}


### PR DESCRIPTION
I had noticed that some of my creative tabs had messed up contents when search was enabled. This is because the contents of the tab (provided by displayAllRelevantItems in CreativeTabs) was being replaced with the contents of the item registry. This resulted in a few weird errors, like the tab being empty, or entries added by displayAllRelevantItems being completely disregarded. 