### PR TITLE
Fixed chunk gen mobs not firing the CheckSpawn event. Closes #4394

### DIFF
--- a/patches/minecraft/net/minecraft/world/WorldEntitySpawner.java.patch
+++ b/patches/minecraft/net/minecraft/world/WorldEntitySpawner.java.patch
@@ -70,3 +70,11 @@
                              }
                              catch (Exception exception)
                              {
+@@ -281,6 +286,7 @@
+                                 continue;
+                             }
+ 
++                            if (net.minecraftforge.event.ForgeEventFactory.canEntitySpawn(entityliving, p_77191_0_, j + 0.5f, (float) blockpos.func_177956_o(), k +0.5f, false) == net.minecraftforge.fml.common.eventhandler.Event.Result.DENY) continue;
+                             entityliving.func_70012_b((double)((float)j + 0.5F), (double)blockpos.func_177956_o(), (double)((float)k + 0.5F), p_77191_6_.nextFloat() * 360.0F, 0.0F);
+                             p_77191_0_.func_72838_d(entityliving);
+                             ientitylivingdata = entityliving.func_180482_a(p_77191_0_.func_175649_E(new BlockPos(entityliving)), ientitylivingdata);

--- a/src/test/java/net/minecraftforge/debug/CheckSpawnTest.java
+++ b/src/test/java/net/minecraftforge/debug/CheckSpawnTest.java
@@ -1,0 +1,31 @@
+package net.minecraftforge.debug;
+
+import net.minecraftforge.common.MinecraftForge;
+import net.minecraftforge.event.entity.living.LivingSpawnEvent.CheckSpawn;
+import net.minecraftforge.fml.common.Mod;
+import net.minecraftforge.fml.common.Mod.EventHandler;
+import net.minecraftforge.fml.common.event.FMLPreInitializationEvent;
+import net.minecraftforge.fml.common.eventhandler.Event.Result;
+import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
+
+@Mod(modid = CheckSpawnTest.MODID, name = "CheckSpawnTest", version = "1.0")
+public class CheckSpawnTest
+{
+    public static final String MODID = "checkspawntest";
+    public static final boolean ENABLED = false;
+
+    @EventHandler
+    public void onPreInit(FMLPreInitializationEvent event)
+    {    	
+    	if (ENABLED) 
+    	{   		
+    		MinecraftForge.EVENT_BUS.register(this);
+    	}
+    }
+    
+    @SubscribeEvent
+    public void canMobSpawn(CheckSpawn event) 
+    {   	
+    	event.setResult(Result.DENY);
+    }
+}


### PR DESCRIPTION
When a chunk is populated, there is a populator which spawns some initial mobs as part of the chunk generation. Mobs spawned by the animal populator did not fire the CheckSpawn event, meaning that you could not prevent these mobs from spawning. This issue is fixed by this PR. 