### PR TITLE
Fix cascading world gen in the Nether (MC-117810)

### DIFF
--- a/patches/minecraft/net/minecraft/world/gen/ChunkGeneratorHell.java.patch
+++ b/patches/minecraft/net/minecraft/world/gen/ChunkGeneratorHell.java.patch
@@ -93,7 +93,7 @@
          for (int l1 = 0; l1 < 16; ++l1)
          {
              this.field_177467_w.func_180709_b(this.field_185952_n, this.field_185954_p, blockpos.func_177982_a(this.field_185954_p.nextInt(16), this.field_185954_p.nextInt(108) + 10, this.field_185954_p.nextInt(16)));
-@@ -402,17 +434,22 @@
+@@ -402,17 +434,23 @@
  
          int i2 = this.field_185952_n.func_181545_F() / 2 + 1;
  
@@ -107,7 +107,8 @@
          for (int j2 = 0; j2 < 16; ++j2)
          {
 -            this.field_177473_x.func_180709_b(this.field_185952_n, this.field_185954_p, blockpos.func_177982_a(this.field_185954_p.nextInt(16), this.field_185954_p.nextInt(108) + 10, this.field_185954_p.nextInt(16)));
-+            this.field_177473_x.func_180709_b(this.field_185952_n, this.field_185954_p, blockpos.func_177982_a(this.field_185954_p.nextInt(16) + 8, this.field_185954_p.nextInt(108) + 10, this.field_185954_p.nextInt(16) + 8)); // Forge: fix MC-117810
++            int offset = net.minecraftforge.common.ForgeModContainer.fixCascadingWorldGenInNether ? 8 : 0; // Forge: fix MC-117810 (optional for strict vanilla compatibility)
++            this.field_177473_x.func_180709_b(this.field_185952_n, this.field_185954_p, blockpos.func_177982_a(this.field_185954_p.nextInt(16) + offset, this.field_185954_p.nextInt(108) + 10, this.field_185954_p.nextInt(16) + offset));
          }
  
          biome.func_180624_a(this.field_185952_n, this.field_185954_p, new BlockPos(i, 0, j));

--- a/patches/minecraft/net/minecraft/world/gen/ChunkGeneratorHell.java.patch
+++ b/patches/minecraft/net/minecraft/world/gen/ChunkGeneratorHell.java.patch
@@ -106,7 +106,8 @@
 +        if (net.minecraftforge.event.terraingen.TerrainGen.populate(this, this.field_185952_n, this.field_185954_p, p_185931_1_, p_185931_2_, false, net.minecraftforge.event.terraingen.PopulateChunkEvent.Populate.EventType.NETHER_LAVA2))
          for (int j2 = 0; j2 < 16; ++j2)
          {
-             this.field_177473_x.func_180709_b(this.field_185952_n, this.field_185954_p, blockpos.func_177982_a(this.field_185954_p.nextInt(16), this.field_185954_p.nextInt(108) + 10, this.field_185954_p.nextInt(16)));
+-            this.field_177473_x.func_180709_b(this.field_185952_n, this.field_185954_p, blockpos.func_177982_a(this.field_185954_p.nextInt(16), this.field_185954_p.nextInt(108) + 10, this.field_185954_p.nextInt(16)));
++            this.field_177473_x.func_180709_b(this.field_185952_n, this.field_185954_p, blockpos.func_177982_a(this.field_185954_p.nextInt(16) + 8, this.field_185954_p.nextInt(108) + 10, this.field_185954_p.nextInt(16) + 8)); // Forge: fix MC-117810
          }
  
          biome.func_180624_a(this.field_185952_n, this.field_185954_p, new BlockPos(i, 0, j));

--- a/src/main/java/net/minecraftforge/common/ForgeModContainer.java
+++ b/src/main/java/net/minecraftforge/common/ForgeModContainer.java
@@ -117,6 +117,7 @@ public class ForgeModContainer extends DummyModContainer implements WorldAccessC
     public static boolean alwaysSetupTerrainOffThread = false; // In RenderGlobal.setupTerrain, always force the chunk render updates to be queued to the thread
     public static int dimensionUnloadQueueDelay = 0;
     public static boolean logCascadingWorldGeneration = true; // see Chunk#logCascadingWorldGeneration()
+    public static boolean fixCascadingWorldGenInNether = false;
 
     static final Logger log = LogManager.getLogger(ForgeVersion.MOD_ID);
 
@@ -286,6 +287,13 @@ public class ForgeModContainer extends DummyModContainer implements WorldAccessC
                 "Log cascading chunk generation issues during terrain population.");
         logCascadingWorldGeneration = prop.getBoolean();
         prop.setLanguageKey("forge.configgui.logCascadingWorldGeneration");
+        propOrder.add(prop.getName());
+
+        prop = config.get(Configuration.CATEGORY_GENERAL, "fixCascadingWorldGenInNether", false,
+                "Adds missing offset to a Nether worldgen feature, fixing cascading chunk generation there (MC-117810). " +
+                        "Will cause slight deviation in the resulting terrain, don't enable if you're picky about your hidden lava blocks.");
+        fixCascadingWorldGenInNether = prop.getBoolean();
+        prop.setLanguageKey("forge.configgui.fixCascadingWorldGenInNether");
         propOrder.add(prop.getName());
 
         prop = config.get(Configuration.CATEGORY_GENERAL, "dimensionUnloadQueueDelay", 0,

--- a/src/main/resources/assets/forge/lang/en_US.lang
+++ b/src/main/resources/assets/forge/lang/en_US.lang
@@ -69,6 +69,8 @@ forge.configgui.playerTicketCount.tooltip=The number of tickets a player can be 
 forge.configgui.playerTicketCount=Player Ticket Limit
 forge.configgui.logCascadingWorldGeneration=Log Cascading World Gen
 forge.configgui.logCascadingWorldGeneration.tooltip=Log cascading chunk generation issues during terrain population.
+forge.configgui.fixCascadingWorldGenInNether=Fix Cascading World Gen in Nether
+forge.configgui.fixCascadingWorldGenInNether.tooltip=Adds missing offset to a Nether worldgen feature, fixing cascading chunk generation there (MC-117810). Will cause slight deviation in the resulting terrain, don't enable if you're picky about your hidden lava blocks.
 
 fml.config.sample.basicDouble.tooltip=A double property with no defined bounds.
 fml.config.sample.basicDouble=Unbounded Double


### PR DESCRIPTION
Fix for [MC-117810](https://bugs.mojang.com/browse/MC-117810), just adds a +8 offset to the x and z coordinates, same as all the other non-`WorldGenMineable` populators.