### PR TITLE
Check OBJ material exists in map

### DIFF
--- a/src/main/java/net/minecraftforge/client/model/obj/OBJModel.java
+++ b/src/main/java/net/minecraftforge/client/model/obj/OBJModel.java
@@ -258,7 +258,7 @@ public class OBJModel implements IModel
                         }
                         else
                         {
-                            FMLLog.log.warn("OBJModel.Parser: (Model: '{}', Line: {}) material '{}' referenced but was not found", objFrom, lineNum, data);
+                            FMLLog.log.error("OBJModel.Parser: (Model: '{}', Line: {}) material '{}' referenced but was not found", objFrom, lineNum, data);
                         }
                         usemtlCounter++;
                     }

--- a/src/main/java/net/minecraftforge/client/model/obj/OBJModel.java
+++ b/src/main/java/net/minecraftforge/client/model/obj/OBJModel.java
@@ -252,7 +252,14 @@ public class OBJModel implements IModel
                     }
                     else if (key.equalsIgnoreCase("usemtl"))
                     {
-                        material = this.materialLibrary.materials.get(data);
+                        if (this.materialLibrary.materials.containsKey(data))
+                        {
+                            material = this.materialLibrary.materials.get(data);
+                        }
+                        else
+                        {
+                            FMLLog.log.warn("OBJModel.Parser: (Model: '{}', Line: {}) material '{}' referenced but was not found", objFrom, lineNum, data);
+                        }
                         usemtlCounter++;
                     }
                     else if (key.equalsIgnoreCase("v")) // Vertices: x y z [w] - w Defaults to 1.0


### PR DESCRIPTION
Fixes #4346

* If the material exists in the parsed map, proceeds as normal
* If it does not, logs an error and leaves it as default