### PR TITLE
Fix IngredientNBT comparing stackSize when checking if ingredient is valid

### DIFF
--- a/src/main/java/net/minecraftforge/common/crafting/IngredientNBT.java
+++ b/src/main/java/net/minecraftforge/common/crafting/IngredientNBT.java
@@ -37,6 +37,7 @@ public class IngredientNBT extends Ingredient
     {
         if (input == null)
             return false;
-        return ItemStack.areItemStacksEqualUsingNBTShareTag(this.stack, input);
+        //Can't use areItemStacksEqualUsingNBTShareTag because it compares stack size as well
+        return this.stack.getItem() == input.getItem() && this.stack.getItemDamage() == input.getItemDamage() && ItemStack.areItemStackShareTagsEqual(this.stack, input);
     }
 }


### PR DESCRIPTION
This fixes #4417 by ignoring the stackSize of items