### PR TITLE
[1.12.x] Removed limits on JSON BlockPart rotation angles.

### DIFF
--- a/patches/minecraft/net/minecraft/client/renderer/block/model/BlockPart.java.patch
+++ b/patches/minecraft/net/minecraft/client/renderer/block/model/BlockPart.java.patch
@@ -1,0 +1,20 @@
+--- ../src-base/minecraft/net/minecraft/client/renderer/block/model/BlockPart.java
++++ ../src-work/minecraft/net/minecraft/client/renderer/block/model/BlockPart.java
+@@ -110,16 +110,7 @@
+ 
+             private float func_178255_b(JsonObject p_178255_1_)
+             {
+-                float f = JsonUtils.func_151217_k(p_178255_1_, "angle");
+-
+-                if (f != 0.0F && MathHelper.func_76135_e(f) != 22.5F && MathHelper.func_76135_e(f) != 45.0F)
+-                {
+-                    throw new JsonParseException("Invalid rotation " + f + " found, only -45/-22.5/0/22.5/45 allowed");
+-                }
+-                else
+-                {
+-                    return f;
+-                }
++                return JsonUtils.func_151217_k(p_178255_1_, "angle");
+             }
+ 
+             private EnumFacing.Axis func_178252_c(JsonObject p_178252_1_)

--- a/patches/minecraft/net/minecraft/client/renderer/block/model/BlockPart.java.patch
+++ b/patches/minecraft/net/minecraft/client/renderer/block/model/BlockPart.java.patch
@@ -1,20 +1,11 @@
 --- ../src-base/minecraft/net/minecraft/client/renderer/block/model/BlockPart.java
 +++ ../src-work/minecraft/net/minecraft/client/renderer/block/model/BlockPart.java
-@@ -110,16 +110,7 @@
- 
+@@ -111,7 +111,7 @@
              private float func_178255_b(JsonObject p_178255_1_)
              {
--                float f = JsonUtils.func_151217_k(p_178255_1_, "angle");
+                 float f = JsonUtils.func_151217_k(p_178255_1_, "angle");
 -
--                if (f != 0.0F && MathHelper.func_76135_e(f) != 22.5F && MathHelper.func_76135_e(f) != 45.0F)
--                {
--                    throw new JsonParseException("Invalid rotation " + f + " found, only -45/-22.5/0/22.5/45 allowed");
--                }
--                else
--                {
--                    return f;
--                }
-+                return JsonUtils.func_151217_k(p_178255_1_, "angle");
-             }
- 
-             private EnumFacing.Axis func_178252_c(JsonObject p_178252_1_)
++                if (true) return f;
+                 if (f != 0.0F && MathHelper.func_76135_e(f) != 22.5F && MathHelper.func_76135_e(f) != 45.0F)
+                 {
+                     throw new JsonParseException("Invalid rotation " + f + " found, only -45/-22.5/0/22.5/45 allowed");


### PR DESCRIPTION
This PR removes a check in BlockPart$Deserializer that restricts the angles JSON models can use. Originally, of course, JSON model parts can only rotate in increments of 22.5 degrees. This is one of the most common issues people cite with the JSON model system and I have long seen players question why the limitation exists.

Removing the check allows for arbitrary angles for rotation. This should not break or change existing behavior regarding model element rotations -- the only lines removed are the check for whether or not the angle is one of the previously allowed values and the exception in the event that the angle is invalid.

Adding this behavior should add a fair amount of additional versatility to the JSON system, which I believe is especially useful considering the wealth of editors available for the JSON format which are already used extensively for most mods, many of which (notably Cubik and BlockBench) already support angles outside of the vanilla-permitted set.

Screenshot of previously illegal rotations being used:

![image](https://user-images.githubusercontent.com/9532786/30779795-6f1d54f4-a0c8-11e7-931e-6a69f72e7c3e.png)
