### PR TITLE
[1.12.x] Added block model flag to allow exceeding of the default JSON model size limits.

### DIFF
--- a/patches/minecraft/net/minecraft/client/renderer/block/model/BlockPart.java.patch
+++ b/patches/minecraft/net/minecraft/client/renderer/block/model/BlockPart.java.patch
@@ -1,0 +1,20 @@
+--- ../src-base/minecraft/net/minecraft/client/renderer/block/model/BlockPart.java
++++ ../src-work/minecraft/net/minecraft/client/renderer/block/model/BlockPart.java
+@@ -110,16 +110,7 @@
+ 
+             private float func_178255_b(JsonObject p_178255_1_)
+             {
+-                float f = JsonUtils.func_151217_k(p_178255_1_, "angle");
+-
+-                if (f != 0.0F && MathHelper.func_76135_e(f) != 22.5F && MathHelper.func_76135_e(f) != 45.0F)
+-                {
+-                    throw new JsonParseException("Invalid rotation " + f + " found, only -45/-22.5/0/22.5/45 allowed");
+-                }
+-                else
+-                {
+-                    return f;
+-                }
++                return JsonUtils.func_151217_k(p_178255_1_, "angle");
+             }
+ 
+             private EnumFacing.Axis func_178252_c(JsonObject p_178252_1_)

--- a/patches/minecraft/net/minecraft/client/renderer/block/model/BlockPart.java.patch
+++ b/patches/minecraft/net/minecraft/client/renderer/block/model/BlockPart.java.patch
@@ -1,20 +1,20 @@
 --- ../src-base/minecraft/net/minecraft/client/renderer/block/model/BlockPart.java
 +++ ../src-work/minecraft/net/minecraft/client/renderer/block/model/BlockPart.java
-@@ -110,16 +110,7 @@
- 
-             private float func_178255_b(JsonObject p_178255_1_)
+@@ -183,7 +183,7 @@
              {
--                float f = JsonUtils.func_151217_k(p_178255_1_, "angle");
--
--                if (f != 0.0F && MathHelper.func_76135_e(f) != 22.5F && MathHelper.func_76135_e(f) != 45.0F)
--                {
--                    throw new JsonParseException("Invalid rotation " + f + " found, only -45/-22.5/0/22.5/45 allowed");
--                }
--                else
--                {
--                    return f;
--                }
-+                return JsonUtils.func_151217_k(p_178255_1_, "angle");
-             }
+                 Vector3f vector3f = this.func_178251_a(p_178247_1_, "to");
  
-             private EnumFacing.Axis func_178252_c(JsonObject p_178252_1_)
+-                if (vector3f.x >= -16.0F && vector3f.y >= -16.0F && vector3f.z >= -16.0F && vector3f.x <= 32.0F && vector3f.y <= 32.0F && vector3f.z <= 32.0F)
++                if (!ModelBlock.limitSize || vector3f.x >= -16.0F && vector3f.y >= -16.0F && vector3f.z >= -16.0F && vector3f.x <= 32.0F && vector3f.y <= 32.0F && vector3f.z <= 32.0F)
+                 {
+                     return vector3f;
+                 }
+@@ -197,7 +197,7 @@
+             {
+                 Vector3f vector3f = this.func_178251_a(p_178249_1_, "from");
+ 
+-                if (vector3f.x >= -16.0F && vector3f.y >= -16.0F && vector3f.z >= -16.0F && vector3f.x <= 32.0F && vector3f.y <= 32.0F && vector3f.z <= 32.0F)
++                if (!ModelBlock.limitSize || vector3f.x >= -16.0F && vector3f.y >= -16.0F && vector3f.z >= -16.0F && vector3f.x <= 32.0F && vector3f.y <= 32.0F && vector3f.z <= 32.0F)
+                 {
+                     return vector3f;
+                 }

--- a/patches/minecraft/net/minecraft/client/renderer/block/model/ModelBlock.java.patch
+++ b/patches/minecraft/net/minecraft/client/renderer/block/model/ModelBlock.java.patch
@@ -1,0 +1,43 @@
+--- ../src-base/minecraft/net/minecraft/client/renderer/block/model/ModelBlock.java
++++ ../src-work/minecraft/net/minecraft/client/renderer/block/model/ModelBlock.java
+@@ -238,6 +238,8 @@
+                 this.field_178324_a = p_i46223_1_;
+             }
+         }
++    
++    protected static boolean limitSize = true;
+ 
+     @SideOnly(Side.CLIENT)
+     public static class Deserializer implements JsonDeserializer<ModelBlock>
+@@ -299,6 +301,11 @@
+                 return JsonUtils.func_151219_a(p_178326_1_, "parent", "");
+             }
+ 
++            protected boolean getSizeLimited(JsonObject object)
++            {
++                return JsonUtils.func_151209_a(object, "limitsize", true);
++            }
++
+             protected boolean func_178328_a(JsonObject p_178328_1_)
+             {
+                 return JsonUtils.func_151209_a(p_178328_1_, "ambientocclusion", true);
+@@ -306,6 +313,11 @@
+ 
+             protected List<BlockPart> func_178325_a(JsonDeserializationContext p_178325_1_, JsonObject p_178325_2_)
+             {
++            	limitSize = getSizeLimited(p_178325_2_);
++                boolean flag = this.func_178328_a(p_178325_2_);
++                if (!limitSize && flag)
++                	throw new JsonParseException("Ambient occlusion cannot be enabled for model of unlimited size, it causes lighting issues with large models.");
++				
+                 List<BlockPart> list = Lists.<BlockPart>newArrayList();
+ 
+                 if (p_178325_2_.has("elements"))
+@@ -315,6 +327,7 @@
+                         list.add((BlockPart)p_178325_1_.deserialize(jsonelement, BlockPart.class));
+                     }
+                 }
++                limitSize = true;
+ 
+                 return list;
+             }

--- a/patches/minecraft/net/minecraft/client/renderer/block/model/ModelBlock.java.patch
+++ b/patches/minecraft/net/minecraft/client/renderer/block/model/ModelBlock.java.patch
@@ -13,7 +13,7 @@
                  return JsonUtils.func_151219_a(p_178326_1_, "parent", "");
              }
  
-+            protected boolean getSizeLimited(JsonObject object)
++            protected boolean isSizeLimited(JsonObject object)
 +            {
 +                return JsonUtils.func_151209_a(object, "limitsize", true);
 +            }
@@ -25,7 +25,7 @@
  
              protected List<BlockPart> func_178325_a(JsonDeserializationContext p_178325_1_, JsonObject p_178325_2_)
              {
-+            	limitSize = getSizeLimited(p_178325_2_);
++            	 limitSize = isSizeLimited(p_178325_2_);
 +                boolean flag = this.func_178328_a(p_178325_2_);
 +                if (!limitSize && flag)
 +                	throw new JsonParseException("Ambient occlusion cannot be enabled for model of unlimited size, it causes lighting issues with large models.");

--- a/patches/minecraft/net/minecraft/client/renderer/block/model/ModelBlock.java.patch
+++ b/patches/minecraft/net/minecraft/client/renderer/block/model/ModelBlock.java.patch
@@ -9,31 +9,19 @@
  
      @SideOnly(Side.CLIENT)
      public static class Deserializer implements JsonDeserializer<ModelBlock>
-@@ -299,6 +301,11 @@
-                 return JsonUtils.func_151219_a(p_178326_1_, "parent", "");
-             }
- 
-+            protected boolean isSizeLimited(JsonObject object)
-+            {
-+                return JsonUtils.func_151209_a(object, "limitsize", true);
-+            }
-+
-             protected boolean func_178328_a(JsonObject p_178328_1_)
-             {
-                 return JsonUtils.func_151209_a(p_178328_1_, "ambientocclusion", true);
-@@ -306,6 +313,11 @@
+@@ -306,6 +308,11 @@
  
              protected List<BlockPart> func_178325_a(JsonDeserializationContext p_178325_1_, JsonObject p_178325_2_)
              {
-+            	 limitSize = isSizeLimited(p_178325_2_);
++                limitSize = JsonUtils.func_151209_a(p_178325_2_, "limitsize", true);
 +                boolean flag = this.func_178328_a(p_178325_2_);
 +                if (!limitSize && flag)
-+                	throw new JsonParseException("Ambient occlusion cannot be enabled for model of unlimited size, it causes lighting issues with large models.");
++                    throw new JsonParseException("Ambient occlusion cannot be enabled for model of unlimited size, it causes lighting issues with large models.");
 +				
                  List<BlockPart> list = Lists.<BlockPart>newArrayList();
  
                  if (p_178325_2_.has("elements"))
-@@ -315,6 +327,7 @@
+@@ -315,6 +322,7 @@
                          list.add((BlockPart)p_178325_1_.deserialize(jsonelement, BlockPart.class));
                      }
                  }


### PR DESCRIPTION
By default, the JSON block model format restricts models to a 3x3x3 blockspace. This patch modifies the deserializer classes in both ModelBlock and BlockPart to introduce a new JSON boolean flag "limitsize" that can allow these restrictions to be bypassed for certain models.

Similar to controlling ambient occlusion on a model, "limitsize" defaults to true, and will result default vanilla behavior when true. When false, ModelBlock.limitSize is appropriately assigned within the deserializer's getModelElements call. This field is checked in BlockPart, and if false, each point being checked will bypass the normal size restrictions. After getModelElements, ModelBlock.limitSize is reset to the default value and will uphold vanilla size restrictions.

Since large block models have several caveats, particularly regarding lighting, and _especially_ regarding ambient occlusion, if the "ambientocclusion" flag is true and the "limitsize" flag is false in a block model, the block model will throw an appropriate exception and fail to load.

For a specific use case for this functionality, the ability to use larger JSON models should allow for their much more effective use in multiblock structures. Mods like Immersive Engineering or Magneticraft have become hugely popular for their use of multiblocks but make use of OBJ models. With this size restriction out of the way, JSON models should become a viable way to accomplish similar visuals, in a much more modding-adjacent and accessible format.

Screenshot of a large JSON model making use of the code in this PR:

![image](https://user-images.githubusercontent.com/9532786/30779933-beb6c7d0-a0cc-11e7-9d6f-1fe0a312b8dd.png)
