### PR TITLE
Initialize blocklight properly (Improves MC-3329)

### DIFF
--- a/patches/minecraft/net/minecraft/world/World.java.patch
+++ b/patches/minecraft/net/minecraft/world/World.java.patch
@@ -693,6 +693,24 @@
              {
                  k2 = 1;
              }
+@@ -2630,7 +2827,7 @@
+ 
+     public boolean func_180500_c(EnumSkyBlock p_180500_1_, BlockPos p_180500_2_)
+     {
+-        if (!this.func_175648_a(p_180500_2_, 17, false))
++        if (!this.func_175648_a(p_180500_2_, 16, false))
+         {
+             return false;
+         }
+@@ -2673,7 +2870,7 @@
+                             int l5 = MathHelper.func_76130_a(k4 - k3);
+                             int i6 = MathHelper.func_76130_a(l4 - l3);
+ 
+-                            if (k5 + l5 + i6 < 17)
++                            if (k5 + l5 + i6 < 16)
+                             {
+                                 BlockPos.PooledMutableBlockPos blockpos$pooledmutableblockpos = BlockPos.PooledMutableBlockPos.func_185346_s();
+ 
 @@ -2683,7 +2880,8 @@
                                      int k6 = k4 + enumfacing.func_96559_d();
                                      int l6 = l4 + enumfacing.func_82599_e();
@@ -703,6 +721,15 @@
                                      j5 = this.func_175642_b(p_180500_1_, blockpos$pooledmutableblockpos);
  
                                      if (j5 == i5 - i7 && k2 < this.field_72994_J.length)
+@@ -2725,7 +2923,7 @@
+                         int j9 = Math.abs(i8 - l3);
+                         boolean flag = k2 < this.field_72994_J.length - 6;
+ 
+-                        if (l8 + i9 + j9 < 17 && flag)
++                        if (l8 + i9 + j9 < 16 && flag)
+                         {
+                             if (this.func_175642_b(p_180500_1_, blockpos2.func_177976_e()) < k8)
+                             {
 @@ -2791,10 +2989,10 @@
      public List<Entity> func_175674_a(@Nullable Entity p_175674_1_, AxisAlignedBB p_175674_2_, @Nullable Predicate <? super Entity > p_175674_3_)
      {

--- a/patches/minecraft/net/minecraft/world/chunk/Chunk.java.patch
+++ b/patches/minecraft/net/minecraft/world/chunk/Chunk.java.patch
@@ -274,7 +274,16 @@
                              {
                                  this.field_76637_e.func_175664_x(blockpos2);
                              }
-@@ -1381,7 +1400,7 @@
+@@ -1266,6 +1285,8 @@
+     public void func_150809_p()
+     {
+         this.field_76646_k = true;
++        net.minecraftforge.common.lighting.LightingHooks.initChunkLighting(this, this.field_76637_e);
++        if (true) return;
+         this.field_150814_l = true;
+         BlockPos blockpos = new BlockPos(this.field_76635_g << 4, 0, this.field_76647_h << 4);
+ 
+@@ -1381,7 +1402,7 @@
          {
              blockpos$mutableblockpos.func_181079_c(blockpos$mutableblockpos.func_177958_n(), l, blockpos$mutableblockpos.func_177952_p());
  
@@ -283,7 +292,7 @@
              {
                  this.field_76637_e.func_175664_x(blockpos$mutableblockpos);
              }
-@@ -1489,4 +1508,34 @@
+@@ -1489,4 +1510,34 @@
          QUEUED,
          CHECK;
      }

--- a/patches/minecraft/net/minecraft/world/chunk/Chunk.java.patch
+++ b/patches/minecraft/net/minecraft/world/chunk/Chunk.java.patch
@@ -1,6 +1,14 @@
 --- ../src-base/minecraft/net/minecraft/world/chunk/Chunk.java
 +++ ../src-work/minecraft/net/minecraft/world/chunk/Chunk.java
-@@ -179,7 +179,7 @@
+@@ -68,6 +68,7 @@
+     private int field_76649_t;
+     private final ConcurrentLinkedQueue<BlockPos> field_177447_w;
+     public boolean field_189550_d;
++    private boolean isLightInitialized;
+ 
+     public Chunk(World p_i1995_1_, int p_i1995_2_, int p_i1995_3_)
+     {
+@@ -179,7 +180,7 @@
                  {
                      IBlockState iblockstate = this.func_186032_a(j, l - 1, k);
  
@@ -9,7 +17,7 @@
                      {
                          this.field_76634_f[k << 4 | j] = l;
  
-@@ -452,12 +452,13 @@
+@@ -452,12 +453,13 @@
  
      public int func_177437_b(BlockPos p_177437_1_)
      {
@@ -25,7 +33,7 @@
      }
  
      public IBlockState func_177435_g(BlockPos p_177435_1_)
-@@ -539,6 +540,7 @@
+@@ -539,6 +541,7 @@
          {
              Block block = p_177436_2_.func_177230_c();
              Block block1 = iblockstate.func_177230_c();
@@ -33,7 +41,7 @@
              ExtendedBlockStorage extendedblockstorage = this.field_76652_q[j >> 4];
              boolean flag = false;
  
-@@ -556,14 +558,19 @@
+@@ -556,14 +559,19 @@
  
              extendedblockstorage.func_177484_a(i, j & 15, k, p_177436_2_);
  
@@ -55,7 +63,7 @@
                      this.field_76637_e.func_175713_t(p_177436_1_);
                  }
              }
-@@ -580,8 +587,7 @@
+@@ -580,8 +588,7 @@
                  }
                  else
                  {
@@ -65,7 +73,7 @@
  
                      if (j1 > 0)
                      {
-@@ -601,28 +607,19 @@
+@@ -601,28 +608,19 @@
                      }
                  }
  
@@ -98,7 +106,7 @@
                          this.field_76637_e.func_175690_a(p_177436_1_, tileentity1);
                      }
  
-@@ -738,6 +735,7 @@
+@@ -738,6 +736,7 @@
              k = this.field_76645_j.length - 1;
          }
  
@@ -106,7 +114,7 @@
          p_76612_1_.field_70175_ag = true;
          p_76612_1_.field_70176_ah = this.field_76635_g;
          p_76612_1_.field_70162_ai = k;
-@@ -778,7 +776,7 @@
+@@ -778,7 +777,7 @@
      {
          IBlockState iblockstate = this.func_177435_g(p_177422_1_);
          Block block = iblockstate.func_177230_c();
@@ -115,7 +123,7 @@
      }
  
      @Nullable
-@@ -786,6 +784,12 @@
+@@ -786,6 +785,12 @@
      {
          TileEntity tileentity = this.field_150816_i.get(p_177424_1_);
  
@@ -128,7 +136,7 @@
          if (tileentity == null)
          {
              if (p_177424_2_ == Chunk.EnumCreateEntityType.IMMEDIATE)
-@@ -795,14 +799,9 @@
+@@ -795,14 +800,9 @@
              }
              else if (p_177424_2_ == Chunk.EnumCreateEntityType.QUEUED)
              {
@@ -144,7 +152,7 @@
  
          return tileentity;
      }
-@@ -819,10 +818,11 @@
+@@ -819,10 +819,11 @@
  
      public void func_177426_a(BlockPos p_177426_1_, TileEntity p_177426_2_)
      {
@@ -157,7 +165,7 @@
          {
              if (this.field_150816_i.containsKey(p_177426_1_))
              {
-@@ -854,8 +854,9 @@
+@@ -854,8 +855,9 @@
  
          for (ClassInheritanceMultiMap<Entity> classinheritancemultimap : this.field_76645_j)
          {
@@ -168,7 +176,7 @@
      }
  
      public void func_76623_d()
-@@ -871,6 +872,7 @@
+@@ -871,6 +873,7 @@
          {
              this.field_76637_e.func_175681_c(classinheritancemultimap);
          }
@@ -176,7 +184,7 @@
      }
  
      public void func_76630_e()
-@@ -880,8 +882,8 @@
+@@ -880,8 +883,8 @@
  
      public void func_177414_a(@Nullable Entity p_177414_1_, AxisAlignedBB p_177414_2_, List<Entity> p_177414_3_, Predicate <? super Entity > p_177414_4_)
      {
@@ -187,7 +195,7 @@
          i = MathHelper.func_76125_a(i, 0, this.field_76645_j.length - 1);
          j = MathHelper.func_76125_a(j, 0, this.field_76645_j.length - 1);
  
-@@ -918,8 +920,8 @@
+@@ -918,8 +921,8 @@
  
      public <T extends Entity> void func_177430_a(Class <? extends T > p_177430_1_, AxisAlignedBB p_177430_2_, List<T> p_177430_3_, Predicate <? super T > p_177430_4_)
      {
@@ -198,7 +206,7 @@
          i = MathHelper.func_76125_a(i, 0, this.field_76645_j.length - 1);
          j = MathHelper.func_76125_a(j, 0, this.field_76645_j.length - 1);
  
-@@ -997,6 +999,8 @@
+@@ -997,6 +1000,8 @@
  
      protected void func_186034_a(IChunkGenerator p_186034_1_)
      {
@@ -207,7 +215,7 @@
          if (this.func_177419_t())
          {
              if (p_186034_1_.func_185933_a(this, this.field_76635_g, this.field_76647_h))
-@@ -1008,8 +1012,10 @@
+@@ -1008,8 +1013,10 @@
          {
              this.func_150809_p();
              p_186034_1_.func_185931_b(this.field_76635_g, this.field_76647_h);
@@ -218,7 +226,7 @@
      }
  
      public BlockPos func_177440_h(BlockPos p_177440_1_)
-@@ -1064,7 +1070,7 @@
+@@ -1064,7 +1071,7 @@
          {
              BlockPos blockpos = this.field_177447_w.poll();
  
@@ -227,7 +235,7 @@
              {
                  TileEntity tileentity = this.func_177422_i(blockpos);
                  this.field_76637_e.func_175690_a(blockpos, tileentity);
-@@ -1128,6 +1134,13 @@
+@@ -1128,6 +1135,13 @@
      @SideOnly(Side.CLIENT)
      public void func_186033_a(PacketBuffer p_186033_1_, int p_186033_2_, boolean p_186033_3_)
      {
@@ -241,7 +249,7 @@
          boolean flag = this.field_76637_e.field_73011_w.func_191066_m();
  
          for (int i = 0; i < this.field_76652_q.length; ++i)
-@@ -1176,10 +1189,16 @@
+@@ -1176,10 +1190,16 @@
          this.field_76646_k = true;
          this.func_76590_a();
  
@@ -258,7 +266,7 @@
      }
  
      public Biome func_177411_a(BlockPos p_177411_1_, BiomeProvider p_177411_2_)
-@@ -1244,13 +1263,13 @@
+@@ -1244,13 +1264,13 @@
                      BlockPos blockpos1 = blockpos.func_177982_a(k, (j << 4) + i1, l);
                      boolean flag = i1 == 0 || i1 == 15 || k == 0 || k == 15 || l == 0 || l == 15;
  
@@ -274,16 +282,16 @@
                              {
                                  this.field_76637_e.func_175664_x(blockpos2);
                              }
-@@ -1266,6 +1285,8 @@
+@@ -1266,6 +1286,8 @@
      public void func_150809_p()
      {
          this.field_76646_k = true;
-+        net.minecraftforge.common.lighting.LightingHooks.initChunkLighting(this, this.field_76637_e);
++        net.minecraftforge.common.lighting.LightingHooks.checkChunkLighting(this, this.field_76637_e);
 +        if (true) return;
          this.field_150814_l = true;
          BlockPos blockpos = new BlockPos(this.field_76635_g << 4, 0, this.field_76647_h << 4);
  
-@@ -1381,7 +1402,7 @@
+@@ -1381,7 +1403,7 @@
          {
              blockpos$mutableblockpos.func_181079_c(blockpos$mutableblockpos.func_177958_n(), l, blockpos$mutableblockpos.func_177952_p());
  
@@ -292,7 +300,7 @@
              {
                  this.field_76637_e.func_175664_x(blockpos$mutableblockpos);
              }
-@@ -1489,4 +1510,34 @@
+@@ -1489,4 +1511,44 @@
          QUEUED,
          CHECK;
      }
@@ -325,5 +333,15 @@
 +            net.minecraftforge.fml.common.FMLLog.log.debug(format, "Minecraft", this.field_76635_g, this.field_76647_h, this.field_76637_e.field_73011_w.getDimension());
 +        else
 +            net.minecraftforge.fml.common.FMLLog.log.warn(format, activeModContainer.getName(), this.field_76635_g, this.field_76647_h, this.field_76637_e.field_73011_w.getDimension());
++    }
++
++    public boolean isLightInitialized()
++    {
++        return this.isLightInitialized;
++    }
++
++    public void setLightInitialized(boolean lightInitialized)
++    {
++        this.isLightInitialized = lightInitialized;
 +    }
  }

--- a/patches/minecraft/net/minecraft/world/chunk/storage/AnvilChunkLoader.java.patch
+++ b/patches/minecraft/net/minecraft/world/chunk/storage/AnvilChunkLoader.java.patch
@@ -94,6 +94,15 @@
              this.func_75824_a(p_75816_2_.func_76632_l(), nbttagcompound);
          }
          catch (Exception exception)
+@@ -256,7 +304,7 @@
+         p_75820_3_.func_74772_a("LastUpdate", p_75820_2_.func_82737_E());
+         p_75820_3_.func_74783_a("HeightMap", p_75820_1_.func_177445_q());
+         p_75820_3_.func_74757_a("TerrainPopulated", p_75820_1_.func_177419_t());
+-        p_75820_3_.func_74757_a("LightPopulated", p_75820_1_.func_177423_u());
++        p_75820_3_.func_74757_a("LightPopulated", p_75820_1_.isLightInitialized());
+         p_75820_3_.func_74772_a("InhabitedTime", p_75820_1_.func_177416_w());
+         ExtendedBlockStorage[] aextendedblockstorage = p_75820_1_.func_76587_i();
+         NBTTagList nbttaglist = new NBTTagList();
 @@ -305,11 +353,19 @@
              {
                  NBTTagCompound nbttagcompound2 = new NBTTagCompound();
@@ -131,6 +140,15 @@
          }
  
          p_75820_3_.func_74782_a("TileEntities", nbttaglist2);
+@@ -354,7 +418,7 @@
+         Chunk chunk = new Chunk(p_75823_1_, i, j);
+         chunk.func_177420_a(p_75823_2_.func_74759_k("HeightMap"));
+         chunk.func_177446_d(p_75823_2_.func_74767_n("TerrainPopulated"));
+-        chunk.func_177421_e(p_75823_2_.func_74767_n("LightPopulated"));
++        chunk.setLightInitialized(p_75823_2_.func_74767_n("LightPopulated"));
+         chunk.func_177415_c(p_75823_2_.func_74763_f("InhabitedTime"));
+         NBTTagList nbttaglist = p_75823_2_.func_150295_c("Sections", 10);
+         int k = 16;
 @@ -388,6 +452,12 @@
              chunk.func_76616_a(p_75823_2_.func_74770_j("Biomes"));
          }

--- a/src/main/java/net/minecraftforge/common/lighting/LightingHooks.java
+++ b/src/main/java/net/minecraftforge/common/lighting/LightingHooks.java
@@ -59,9 +59,31 @@ public class LightingHooks
             if (world.provider.hasSkyLight())
                 chunk.setSkylightUpdated();
 
-            chunk.setLightPopulated(true);
+            chunk.setLightInitialized(true);
         }
 
         pos.release();
+    }
+
+    public static void checkChunkLighting(final Chunk chunk, final World world)
+    {
+        if (!chunk.isLightInitialized())
+            initChunkLighting(chunk, world);
+
+        for (int x = -1; x <= 1; ++x)
+        {
+            for (int z = -1; z <= 1; ++z)
+            {
+                if (x != 0 || z != 0)
+                {
+                    Chunk nChunk = world.getChunkProvider().getLoadedChunk(chunk.x + x, chunk.z + z);
+
+                    if (nChunk == null || !nChunk.isLightInitialized())
+                        return;
+                }
+            }
+        }
+
+        chunk.setLightPopulated(true);
     }
 }

--- a/src/main/java/net/minecraftforge/common/lighting/LightingHooks.java
+++ b/src/main/java/net/minecraftforge/common/lighting/LightingHooks.java
@@ -1,0 +1,67 @@
+/*
+ * Minecraft Forge
+ * Copyright (c) 2016.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation version 2.1
+ * of the License.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+package net.minecraftforge.common.lighting;
+
+import net.minecraft.util.math.BlockPos.PooledMutableBlockPos;
+import net.minecraft.world.EnumSkyBlock;
+import net.minecraft.world.World;
+import net.minecraft.world.chunk.Chunk;
+import net.minecraft.world.chunk.storage.ExtendedBlockStorage;
+
+public class LightingHooks
+{
+    public static void initChunkLighting(final Chunk chunk, final World world)
+    {
+        final int xBase = chunk.x << 4;
+        final int zBase = chunk.z << 4;
+
+        final PooledMutableBlockPos pos = PooledMutableBlockPos.retain(xBase, 0, zBase);
+
+        if (world.isAreaLoaded(pos.add(-16, 0, -16), pos.add(31, 255, 31), false))
+        {
+            final ExtendedBlockStorage[] extendedBlockStorage = chunk.getBlockStorageArray();
+
+            for (int j = 0; j < extendedBlockStorage.length; ++j)
+            {
+                if (extendedBlockStorage[j] == Chunk.NULL_BLOCK_STORAGE)
+                    continue;
+
+                for (int x = 0; x < 16; ++x)
+                {
+                    for (int z = 0; z < 16; ++z)
+                    {
+                        for (int y = j << 4; y < (j + 1) << 4; ++y)
+                        {
+                            if (chunk.getBlockState(x, y, z).getLightValue(world, pos.setPos(xBase + x, y, zBase + z)) > 0)
+                                world.checkLightFor(EnumSkyBlock.BLOCK, pos);
+                        }
+                    }
+                }
+            }
+
+            if (world.provider.hasSkyLight())
+                chunk.setSkylightUpdated();
+
+            chunk.setLightPopulated(true);
+        }
+
+        pos.release();
+    }
+}

--- a/src/main/resources/forge_at.cfg
+++ b/src/main/resources/forge_at.cfg
@@ -25,6 +25,8 @@ public net.minecraft.world.chunk.storage.AnvilChunkLoader field_75825_d # chunkS
 public net.minecraft.world.gen.ChunkProviderServer field_73247_e # currentChunkLoader
 # World
 public-f net.minecraft.world.World field_72982_D #villageCollectionObj
+# Chunk
+public net.minecraft.world.chunk.Chunk func_177441_y()V #setSkylightUpdated
 # Biome
 public net.minecraft.world.biome.Biome *() #Everything protected->public
 public net.minecraft.world.biome.BiomeForest *()


### PR DESCRIPTION
This PR initializes the blocklight for all chunks properly.
Vanilla does some sort of (really convoluted) initialization of blocklight for worlds that do have skylight. This is done in `Chunk.checkLight()`. If the world doesn't have skylight, the chunks are sent to the client with empty blocklight and then corrected by `enqueueRelightChecks()`. This however produces quite derpy results in the Nether because it takes quite a while before all light sources are checked. This leaves dark spots everywhere.

This PR cleans up `Chunk.checkLight()` and calls `World.checkLightFor(...)` for all blocklight sources. This gives much better looking results for the Nether lighting.
I have rewritten the method completely (as `LightingHooks.initChunkLighting(...)` because the Vanilla version is quite convoluted, so the patches would have become quite messy. The skylight part is completely handled by `Chunk.setSkylightUpdated()`. (There are still some theoretical edgecases where `Chunk.setSkylightUpdated()` doesn't suffice, which has mainly to do with the fact that `Chunk.relightBlock(...)` and `Chunk.generateSkylightmap()` screw with the lightmap. But those theoretical examples are quite pathological and shouldn't occur in reality. So, I would consider this a good enough approximation for the moment.)

Because this PR adds some additional calls to `World.checkLightFor()` I profiled the code to see if anything got slowed down. The server thread took additional ~5% of the total time for the additional light checks in the Nether, which is ok in my opinion, given the much better looking lighting. Also, due to the removal of the convoluted logic of `Chunk.checkLight()` the code got actually ~15% faster for the Overworld. Moreover, `enqueueRelightChecks()` took ~15-20% less time on the client thread in the Nether, probably because the lighting engine had less work to do, as some of it was already done by the server thread.
So, the overall performance even increased.

There are still some lighting bugs left:
* Due to the 16 block spreading limitation of the Vanilla lighting engine (see #4263), the light will still be derpy above big lava lakes in the Nether. This is fixed by #4263
* The Vanilla lighting engine requires chunks in a 17 block radius to be loaded. The `isAreaLoaded(...)` check however only guarantees 16 blocks, so there may still be a few dark spots left. This is fixed by #4263 and #4264 
* When the chunk is marked as light populated, the light of the neighbor chunks may not have been initialized yet, so contributions from there may be missing.

Remarks:
* #4263 requires this PR as a prerequisite: The sloppy correction done by `enqueueRelightChecks()` does not work for our LightingEngine, because we don't correct errors on the fly to achieve better performance. (Tanks @mrgrim for pointing out the issue)
* Should I move `LightingHooks.initChunkLighting(...)` to `Chunk` to avoid the AT?

