### PR TITLE
Added CrashEvent

### DIFF
--- a/patches/minecraft/net/minecraft/crash/CrashReport.java.patch
+++ b/patches/minecraft/net/minecraft/crash/CrashReport.java.patch
@@ -1,6 +1,14 @@
 --- ../src-base/minecraft/net/minecraft/crash/CrashReport.java
 +++ ../src-work/minecraft/net/minecraft/crash/CrashReport.java
-@@ -116,6 +116,7 @@
+@@ -38,6 +38,7 @@
+         this.field_71513_a = p_i1348_1_;
+         this.field_71511_b = p_i1348_2_;
+         this.func_71504_g();
++        net.minecraftforge.common.MinecraftForge.EVENT_BUS.post(new net.minecraftforge.event.CrashEvent(this));
+     }
+ 
+     private void func_71504_g()
+@@ -116,6 +117,7 @@
                  return IntCache.func_85144_b();
              }
          });
@@ -8,7 +16,7 @@
      }
  
      public String func_71501_a()
-@@ -205,6 +206,8 @@
+@@ -205,6 +207,8 @@
      {
          StringBuilder stringbuilder = new StringBuilder();
          stringbuilder.append("---- Minecraft Crash Report ----\n");

--- a/src/main/java/net/minecraftforge/event/CrashEvent.java
+++ b/src/main/java/net/minecraftforge/event/CrashEvent.java
@@ -1,0 +1,31 @@
+package net.minecraftforge.event;
+
+import javax.annotation.Nonnull;
+
+import net.minecraft.crash.CrashReport;
+import net.minecraftforge.common.MinecraftForge;
+import net.minecraftforge.fml.common.eventhandler.Cancelable;
+/**
+ * CrashEvent is fired whenever a new {@link CrashReport} is constructed.<br>
+ * <br>
+ * Be careful not to raise any exception when subscribing to this event<br>
+ * in order to prevent recursive calls.<br>
+ * <br>
+ * {@link #report} contains the instance of CrashReport just generated.<br>
+ * <br>
+ * This event is not {@link Cancelable}. <br>
+ * <br>
+ * This event does not have a result. {@link HasResult}<br>
+ * <br>
+ * This event is fired on the {@link MinecraftForge#EVENT_BUS}.<br>
+ * <br>
+ **/
+public class CrashEvent extends net.minecraftforge.fml.common.eventhandler.Event 
+{
+    private final CrashReport report;
+    public CrashEvent(@Nonnull CrashReport report)
+    {
+        this.report = report;
+    }
+    public CrashReport getReport() { return this.report; }
+}

--- a/src/test/java/net/minecraftforge/debug/CrashEventTest.java
+++ b/src/test/java/net/minecraftforge/debug/CrashEventTest.java
@@ -1,0 +1,20 @@
+package net.minecraftforge.debug;
+
+import net.minecraftforge.event.CrashEvent;
+import net.minecraftforge.fml.common.Mod;
+import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
+
+//This test mod will print any crash log to console a second time when they are created.
+//This shows how to intercept crash logs to provide modders a way to generate reports and maybe 
+//some features for autoreporting them automatically if they believe it was caused by their mod
+@Mod(modid="testcrashevent", version="1.0", name="Test Crash Event", acceptableRemoteVersions="*")
+@Mod.EventBusSubscriber
+public class CrashEventTest 
+{
+    @SubscribeEvent
+    public static void onCrash(CrashEvent evt) 
+    {
+        //This could easily be used for posting the log to pastebin and returning the link to the user
+        System.out.println(evt.getReport().getCompleteReport());
+    }
+}


### PR DESCRIPTION
Added `CrashEvent`, a _non_ `@Cancelable` event that gets called everytime a new `CrashReport` object is created.
Example usage:
- automatic crash-reporting features (this is what I'm trying to achieve in my mod)
- showing a message with instructions to the user.

The test mod that I included in the commit simply prints the log to sysout a second time.
The forge fake crash printed during startup is not a problem since it's created before any mod is loaded.

---
This is my first commit to this project, I hope I did everything right