### PR TITLE
Add missing information to instances of LootContext

### DIFF
--- a/patches/minecraft/net/minecraft/advancements/AdvancementRewards.java.patch
+++ b/patches/minecraft/net/minecraft/advancements/AdvancementRewards.java.patch
@@ -1,0 +1,11 @@
+--- ../src-base/minecraft/net/minecraft/advancements/AdvancementRewards.java
++++ ../src-work/minecraft/net/minecraft/advancements/AdvancementRewards.java
+@@ -49,7 +49,7 @@
+     public void func_192113_a(final EntityPlayerMP p_192113_1_)
+     {
+         p_192113_1_.func_71023_q(this.field_192115_b);
+-        LootContext lootcontext = (new LootContext.Builder(p_192113_1_.func_71121_q())).func_186472_a(p_192113_1_).func_186471_a();
++        LootContext lootcontext = (new LootContext.Builder(p_192113_1_.func_71121_q())).func_186472_a(p_192113_1_).func_186470_a(p_192113_1_).func_186469_a(p_192113_1_.func_184817_da()).func_186471_a(); // Forge: add player & luck to LootContext
+         boolean flag = false;
+ 
+         for (ResourceLocation resourcelocation : this.field_192116_c)

--- a/patches/minecraft/net/minecraft/entity/item/EntityMinecartContainer.java.patch
+++ b/patches/minecraft/net/minecraft/entity/item/EntityMinecartContainer.java.patch
@@ -8,7 +8,21 @@
          if (!this.field_70170_p.field_72995_K)
          {
              p_184230_1_.func_71007_a(this);
-@@ -281,6 +282,26 @@
+@@ -270,17 +271,37 @@
+                 random = new Random(this.field_184291_d);
+             }
+ 
+-            LootContext.Builder lootcontext$builder = new LootContext.Builder((WorldServer)this.field_70170_p);
+-
++            LootContext.Builder lootcontext$builder = new LootContext.Builder((WorldServer)this.field_70170_p).func_186472_a(this); // Forge: add looted entity to LootContext
++            
+             if (p_184288_1_ != null)
+             {
+-                lootcontext$builder.func_186469_a(p_184288_1_.func_184817_da());
++                lootcontext$builder.func_186469_a(p_184288_1_.func_184817_da()).func_186470_a(p_184288_1_); // Forge: add player to LootContext
+             }
+ 
+             loottable.func_186460_a(this, random, lootcontext$builder.func_186471_a());
          }
      }
  

--- a/patches/minecraft/net/minecraft/entity/item/EntityMinecartContainer.java.patch
+++ b/patches/minecraft/net/minecraft/entity/item/EntityMinecartContainer.java.patch
@@ -13,9 +13,8 @@
              }
  
 -            LootContext.Builder lootcontext$builder = new LootContext.Builder((WorldServer)this.field_70170_p);
--
 +            LootContext.Builder lootcontext$builder = new LootContext.Builder((WorldServer)this.field_70170_p).func_186472_a(this); // Forge: add looted entity to LootContext
-+            
+ 
              if (p_184288_1_ != null)
              {
 -                lootcontext$builder.func_186469_a(p_184288_1_.func_184817_da());

--- a/patches/minecraft/net/minecraft/entity/projectile/EntityFishHook.java.patch
+++ b/patches/minecraft/net/minecraft/entity/projectile/EntityFishHook.java.patch
@@ -19,10 +19,12 @@
              if (this.field_146043_c != null)
              {
                  this.func_184527_k();
-@@ -516,8 +517,16 @@
+@@ -515,9 +516,17 @@
+             else if (this.field_146045_ax > 0)
              {
                  LootContext.Builder lootcontext$builder = new LootContext.Builder((WorldServer)this.field_70170_p);
-                 lootcontext$builder.func_186469_a((float)this.field_191518_aw + this.field_146042_b.func_184817_da());
+-                lootcontext$builder.func_186469_a((float)this.field_191518_aw + this.field_146042_b.func_184817_da());
++                lootcontext$builder.func_186469_a((float)this.field_191518_aw + this.field_146042_b.func_184817_da()).func_186470_a(this.field_146042_b).func_186472_a(this); // Forge: add player & looted entity to LootContext
 +                List<ItemStack> result = this.field_70170_p.func_184146_ak().func_186521_a(LootTableList.field_186387_al).func_186462_a(this.field_70146_Z, lootcontext$builder.func_186471_a());
 +                event = new net.minecraftforge.event.entity.player.ItemFishedEvent(result, this.field_146051_au ? 2 : 1, this);
 +                net.minecraftforge.common.MinecraftForge.EVENT_BUS.post(event);

--- a/patches/minecraft/net/minecraft/tileentity/TileEntityLockableLoot.java.patch
+++ b/patches/minecraft/net/minecraft/tileentity/TileEntityLockableLoot.java.patch
@@ -1,0 +1,11 @@
+--- ../src-base/minecraft/net/minecraft/tileentity/TileEntityLockableLoot.java
++++ ../src-work/minecraft/net/minecraft/tileentity/TileEntityLockableLoot.java
+@@ -73,7 +73,7 @@
+ 
+             if (p_184281_1_ != null)
+             {
+-                lootcontext$builder.func_186469_a(p_184281_1_.func_184817_da());
++                lootcontext$builder.func_186469_a(p_184281_1_.func_184817_da()).func_186470_a(p_184281_1_); // Forge: add player to LootContext
+             }
+ 
+             loottable.func_186460_a(this, random, lootcontext$builder.func_186471_a());

--- a/src/test/java/net/minecraftforge/debug/LootContextTweaksTest.java
+++ b/src/test/java/net/minecraftforge/debug/LootContextTweaksTest.java
@@ -40,20 +40,20 @@ public class LootContextTweaksTest
     @Mod.EventHandler
     public void preInit(FMLPreInitializationEvent event)
     {
-        if(!ENABLED) return; 
+        if (!ENABLED) return; 
         LootConditionManager.registerCondition(new InBiome.Serialiser());
     }
 
     @SubscribeEvent
     public static void onLootTableLoad(LootTableLoadEvent event)
     {
-        if(!ENABLED) return;
-        if(event.getName().equals(LootTableList.GAMEPLAY_FISHING))
+        if (!ENABLED) return;
+        if (event.getName().equals(LootTableList.GAMEPLAY_FISHING))
         {
             LootPool main = event.getTable().getPool("main");
             main.addEntry(new LootEntryItem(Items.ACACIA_BOAT, 100, 1, new LootFunction[0], new LootCondition[] {new InBiome(Biomes.SAVANNA)}, "fishing_test"));
         }
-        else if(event.getName().equals(LootTableList.CHESTS_SIMPLE_DUNGEON))
+        else if (event.getName().equals(LootTableList.CHESTS_SIMPLE_DUNGEON))
         {
             LootPool main = event.getTable().getPool("main");
             LootCondition onFire = new EntityHasProperty(new EntityProperty[] {new EntityOnFire(true)}, LootContext.EntityTarget.KILLER_PLAYER);
@@ -73,7 +73,7 @@ public class LootContextTweaksTest
         @Override
         public boolean testCondition(Random rand, LootContext context) 
         {
-            if(context.getLootedEntity() == null) return false;
+            if (context.getLootedEntity() == null) return false;
             Biome biome = context.getWorld().getBiome(context.getLootedEntity().getPosition());
             return biome == requiredBiome;
         }
@@ -94,10 +94,10 @@ public class LootContextTweaksTest
             @Override
             public InBiome deserialize(JsonObject json, JsonDeserializationContext context) 
             {
-                if(!json.has("biome")) throw new JsonSyntaxException("Missing biome tag, expected to find a biome registry name");
+                if (!json.has("biome")) throw new JsonSyntaxException("Missing biome tag, expected to find a biome registry name");
                 ResourceLocation biomeResLoc = new ResourceLocation(json.get("biome").getAsString());
                 Biome biome = ForgeRegistries.BIOMES.getValue(biomeResLoc);
-                if(biome == null) throw new JsonSyntaxException("Invalid biome tag. " + biomeResLoc + " does not exist in the biome registry.");
+                if (biome == null) throw new JsonSyntaxException("Invalid biome tag. " + biomeResLoc + " does not exist in the biome registry.");
                 return new InBiome(biome);
             }
         }

--- a/src/test/java/net/minecraftforge/debug/LootContextTweaksTest.java
+++ b/src/test/java/net/minecraftforge/debug/LootContextTweaksTest.java
@@ -1,0 +1,105 @@
+package net.minecraftforge.debug;
+
+import java.util.Random;
+
+import com.google.gson.JsonDeserializationContext;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonSerializationContext;
+import com.google.gson.JsonSyntaxException;
+
+import net.minecraft.init.Biomes;
+import net.minecraft.init.Items;
+import net.minecraft.util.ResourceLocation;
+import net.minecraft.world.biome.Biome;
+import net.minecraft.world.storage.loot.LootContext;
+import net.minecraft.world.storage.loot.LootEntryItem;
+import net.minecraft.world.storage.loot.LootPool;
+import net.minecraft.world.storage.loot.LootTableList;
+import net.minecraft.world.storage.loot.RandomValueRange;
+import net.minecraft.world.storage.loot.conditions.EntityHasProperty;
+import net.minecraft.world.storage.loot.conditions.LootCondition;
+import net.minecraft.world.storage.loot.conditions.LootConditionManager;
+import net.minecraft.world.storage.loot.functions.LootFunction;
+import net.minecraft.world.storage.loot.functions.SetCount;
+import net.minecraft.world.storage.loot.properties.EntityOnFire;
+import net.minecraft.world.storage.loot.properties.EntityProperty;
+import net.minecraftforge.event.LootTableLoadEvent;
+import net.minecraftforge.fml.common.Mod;
+import net.minecraftforge.fml.common.Mod.EventBusSubscriber;
+import net.minecraftforge.fml.common.event.FMLPreInitializationEvent;
+import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
+import net.minecraftforge.fml.common.registry.ForgeRegistries;
+
+@EventBusSubscriber
+@Mod(modid = LootContextTweaksTest.MODID, name = "LootContextTweaksTest", version = "1.0", acceptableRemoteVersions = "*")
+public class LootContextTweaksTest 
+{
+    public static final String MODID = "loot_context_tweaks_test";
+    public static final boolean ENABLED = false;
+
+    @Mod.EventHandler
+    public void preInit(FMLPreInitializationEvent event)
+    {
+        if(!ENABLED) return; 
+        LootConditionManager.registerCondition(new InBiome.Serialiser());
+    }
+
+    @SubscribeEvent
+    public static void onLootTableLoad(LootTableLoadEvent event)
+    {
+        if(!ENABLED) return;
+        if(event.getName().equals(LootTableList.GAMEPLAY_FISHING))
+        {
+            LootPool main = event.getTable().getPool("main");
+            main.addEntry(new LootEntryItem(Items.ACACIA_BOAT, 100, 1, new LootFunction[0], new LootCondition[] {new InBiome(Biomes.SAVANNA)}, "fishing_test"));
+        }
+        else if(event.getName().equals(LootTableList.CHESTS_SIMPLE_DUNGEON))
+        {
+            LootPool main = event.getTable().getPool("main");
+            LootCondition onFire = new EntityHasProperty(new EntityProperty[] {new EntityOnFire(true)}, LootContext.EntityTarget.KILLER_PLAYER);
+            main.addEntry(new LootEntryItem(Items.BLAZE_POWDER, 100, 1, new LootFunction[] {new SetCount(new LootCondition[0], new RandomValueRange(64))}, new LootCondition[] {onFire}, "minecart_test"));
+        }
+    }
+
+    private static class InBiome implements LootCondition
+    {
+        private final Biome requiredBiome;
+
+        public InBiome(Biome requiredBiome) 
+        {
+            this.requiredBiome = requiredBiome;
+        }
+
+        @Override
+        public boolean testCondition(Random rand, LootContext context) 
+        {
+            if(context.getLootedEntity() == null) return false;
+            Biome biome = context.getWorld().getBiome(context.getLootedEntity().getPosition());
+            return biome == requiredBiome;
+        }
+
+        private static class Serialiser extends LootCondition.Serializer<InBiome>
+        {
+            protected Serialiser() 
+            {
+                super(new ResourceLocation(MODID, "in_biome"), InBiome.class);
+            }
+
+            @Override
+            public void serialize(JsonObject json, InBiome value, JsonSerializationContext context) 
+            {
+                json.addProperty("biome", value.requiredBiome.getRegistryName().toString());
+            }
+
+            @Override
+            public InBiome deserialize(JsonObject json, JsonDeserializationContext context) 
+            {
+                if(!json.has("biome")) throw new JsonSyntaxException("Missing biome tag, expected to find a biome registry name");
+                ResourceLocation biomeResLoc = new ResourceLocation(json.get("biome").getAsString());
+                Biome biome = ForgeRegistries.BIOMES.getValue(biomeResLoc);
+                if(biome == null) throw new JsonSyntaxException("Invalid biome tag. " + biomeResLoc + " does not exist in the biome registry.");
+                return new InBiome(biome);
+            }
+        }
+    }
+}

--- a/src/test/resources/assets/loot_context_tweaks_test/advancements/test/root.json
+++ b/src/test/resources/assets/loot_context_tweaks_test/advancements/test/root.json
@@ -18,6 +18,5 @@
 	"rewards": 
 	{
 		"loot": ["minecraft:chests/simple_dungeon"]
-	},
-	"requirements": [["no"]]
+	}
 }

--- a/src/test/resources/assets/loot_context_tweaks_test/advancements/test/root.json
+++ b/src/test/resources/assets/loot_context_tweaks_test/advancements/test/root.json
@@ -1,0 +1,23 @@
+{
+	"display": 
+	{
+        "icon": {
+            "item": "minecraft:stone"
+        },
+		"description": "From LootContextTweaksTest",
+		"title": "Test",
+		"background": "minecraft:textures/blocks/stone.png"
+	},
+	"criteria": 
+	{
+           "no": 
+           {
+               "trigger": "minecraft:impossible"
+           }
+     },
+	"rewards": 
+	{
+		"loot": ["minecraft:chests/simple_dungeon"]
+	},
+	"requirements": [["no"]]
+}


### PR DESCRIPTION
**Changes in this PR**  
This PR adds any missing info to LootContext instances if that info is available. For example, the minecart loot context does not provide the player, though the player may be available. A list of the changes made to each LootContext follows:  
* AdvancementRewards LootContext - Added player and luck  
* EntityMinecartContainer LootContext - Added looted entity (the minecart) and player  
* EntityFishHook LootContext - Added looted entity (the fish hook) and player  
* TileEntityLockableLoot LootContext - Added player

**Usecases**  
The additional information allows LootFunctions and LootConditions to provide functionality that they could not provide before, or expands the range of scenarios they can work in. For example, biome dependent fishing loot is made possible by this PR and is demonstrated in the test mod. Additional use cases include depth dependent loot in loot containers and minecarts, and items that change loot from loot containers, minecarts and fishing when in the inventory.

**Testing**  
This PR includes a test mod(disabled by default) which:
* Adds acacia boats to the fishing loot table, with a high weight and a condition that makes the loot only appear in a Savannah biome.
* Adds blaze powder to the simple_dungeon chest loot table, with a high weight and a condition that makes the loot only appear if the player is on fire.
* Adds an advancement that gives the player loot from the simple_dungeon loot table.

A test world is attached to this post. It contains command blocks that help test that this PR works correctly, as well as a pond in the savannah biome. All the command blocks are labeled with their function using signs. Note that the in biome condition checks that biome that the looted entity is in, with fishing the looted entity is the fish hook.

**Vanilla Compatibility**  
As loot tables are solely server-side, this PR does not compromise compatibility between Forge and Vanilla Minecraft. However due to the additional information provided, it does cause certain vanilla loot conditions to work in scenarios that they would not work in in Vanilla MC. By "work" I mean that they will not return early, or they will have a visible effect. A list of these conditions and the scenarios in which their behaviour will change follows:
 * `entity_scores` and `entity_properties` conditions with "killer_player" as the target will work for advancement loot rewards, minecart loot, chest loot and fishing loot.
 * `entity_scores` and `entity_properties` conditions with "this" as the target will work for advancement loot rewards, minecart loot and fishing loot.
 * `killed_by_player` will work for advancement loot rewards, minecart loot, chest loot and fishing loot.

Are these changes in behaviour an issue?
[Improved Loot Contexts Test World.zip](https://github.com/MinecraftForge/MinecraftForge/files/1355303/Improved.Loot.Contexts.Test.World.zip)
