### PR TITLE
Fix killing blow causing combat tracker to lose data (MC-121048)

### DIFF
--- a/patches/minecraft/net/minecraft/entity/EntityLivingBase.java.patch
+++ b/patches/minecraft/net/minecraft/entity/EntityLivingBase.java.patch
@@ -186,6 +186,16 @@
              p_70665_2_ = this.func_70655_b(p_70665_1_, p_70665_2_);
              p_70665_2_ = this.func_70672_c(p_70665_1_, p_70665_2_);
              float f = p_70665_2_;
+@@ -1389,8 +1406,8 @@
+             if (p_70665_2_ != 0.0F)
+             {
+                 float f1 = this.func_110143_aJ();
+-                this.func_70606_j(f1 - p_70665_2_);
+                 this.func_110142_aN().func_94547_a(p_70665_1_, f1, p_70665_2_);
++                this.func_70606_j(f1 - p_70665_2_); // Forge: moved to fix MC-121048
+                 this.func_110149_m(this.func_110139_bj() - p_70665_2_);
+             }
+         }
 @@ -1447,6 +1464,11 @@
  
      public void func_184609_a(EnumHand p_184609_1_)


### PR DESCRIPTION
Filed as [MC-121048](https://bugs.mojang.com/browse/MC-121048) on the vanilla bug tracker.

The issue is in `EntityLivingBase.damageEntity`. As the entity's health is updated before `trackDamage` is called, when the killing blow is processed, the entity will have <= 0 health. This will cause the existing combat history to be deleted (due to `isEntityAlive` returning false). When the entity's death is later processed by `onDeath`, only the killing blow will exist in the combat history.

Moving the call to `setHealth` after the call to `trackDamage` fixes the issue.