### PR TITLE
Fix some warnings produced by test mods

### DIFF
--- a/src/test/java/net/minecraftforge/debug/SlipperinessTest.java
+++ b/src/test/java/net/minecraftforge/debug/SlipperinessTest.java
@@ -3,21 +3,29 @@ package net.minecraftforge.debug;
 import net.minecraft.block.Block;
 import net.minecraft.block.material.Material;
 import net.minecraft.block.state.IBlockState;
+import net.minecraft.creativetab.CreativeTabs;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.item.EntityBoat;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemBlock;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.IBlockAccess;
+import net.minecraftforge.client.event.ModelRegistryEvent;
+import net.minecraftforge.client.model.ModelLoader;
 import net.minecraftforge.event.RegistryEvent;
 import net.minecraftforge.fml.common.Mod;
 import net.minecraftforge.fml.common.Mod.EventBusSubscriber;
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
+import net.minecraftforge.fml.relauncher.Side;
 
-@Mod(modid = "slipperiness_test", name = "Slipperiness Test", version = "0.0.0")
+import java.util.Collections;
+
+@Mod(modid = SlipperinessTest.MOD_ID, name = "Slipperiness Test", version = "0.0.0")
 @EventBusSubscriber
 public class SlipperinessTest
 {
+    static final String MOD_ID = "slipperiness_test";
+
     public static final Block BB_BLOCK = new Block(Material.PACKED_ICE)
     {
         @Override
@@ -25,12 +33,15 @@ public class SlipperinessTest
         {
             return entity instanceof EntityBoat ? 2 : super.getSlipperiness(state, world, pos, entity);
         }
-    }.setUnlocalizedName("boat_blaster").setRegistryName("boat_blaster");
+    };
 
     @SubscribeEvent
     public static void registerBlocks(RegistryEvent.Register<Block> e)
     {
-        e.getRegistry().register(BB_BLOCK);
+        e.getRegistry().register(BB_BLOCK
+                .setUnlocalizedName("boat_blaster")
+                .setRegistryName("boat_blaster")
+                .setCreativeTab(CreativeTabs.BUILDING_BLOCKS));
     }
 
     @SubscribeEvent
@@ -38,5 +49,14 @@ public class SlipperinessTest
     {
         e.getRegistry().register(new ItemBlock(BB_BLOCK).setRegistryName(BB_BLOCK.getRegistryName()));
     }
-}
 
+    @Mod.EventBusSubscriber(value = Side.CLIENT, modid = MOD_ID)
+    public static class ClientEventHandler
+    {
+        @SubscribeEvent
+        public static void registerModels(ModelRegistryEvent event)
+        {
+            ModelLoader.setCustomStateMapper(BB_BLOCK, block -> Collections.emptyMap());
+        }
+    }
+}

--- a/src/test/java/net/minecraftforge/debug/TransparentFastTesrTest.java
+++ b/src/test/java/net/minecraftforge/debug/TransparentFastTesrTest.java
@@ -1,5 +1,6 @@
 package net.minecraftforge.debug;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import net.minecraft.block.Block;
@@ -25,6 +26,7 @@ import net.minecraft.util.ResourceLocation;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.World;
 import net.minecraftforge.client.event.ModelRegistryEvent;
+import net.minecraftforge.client.model.ModelLoader;
 import net.minecraftforge.client.model.animation.FastTESR;
 import net.minecraftforge.event.RegistryEvent;
 import net.minecraftforge.fluids.Fluid;
@@ -232,12 +234,13 @@ public class TransparentFastTesrTest
         GameRegistry.registerTileEntity(TransparentFastTE.class, "fast-tesr-te");
     }
 
-    @Mod.EventBusSubscriber(value = Side.CLIENT, modid = MODID)
+    @EventBusSubscriber(value = Side.CLIENT, modid = MODID)
     public static class ClientLoader
     {
         @SubscribeEvent
         public static void registerModels(ModelRegistryEvent event)
         {
+            ModelLoader.setCustomStateMapper(testBlock, block -> Collections.emptyMap());
             ClientRegistry.bindTileEntitySpecialRenderer(TransparentFastTE.class, new TransparentFastTESR());
         }
     }


### PR DESCRIPTION
See #4455.

This fixes some missing model errors by setting an empty state mapper.