### PR TITLE
Improve performance of inserting into inventory wrappers

### DIFF
--- a/src/main/java/net/minecraftforge/items/wrapper/InvWrapper.java
+++ b/src/main/java/net/minecraftforge/items/wrapper/InvWrapper.java
@@ -80,6 +80,9 @@ public class InvWrapper implements IItemHandlerModifiable
         int m;
         if (!stackInSlot.isEmpty())
         {
+            if (stackInSlot.getCount() >= Math.min(stackInSlot.getMaxStackSize(), getSlotLimit(slot)))
+                return stack;
+
             if (!ItemHandlerHelper.canItemStacksStack(stack, stackInSlot))
                 return stack;
 

--- a/src/main/java/net/minecraftforge/items/wrapper/SidedInvWrapper.java
+++ b/src/main/java/net/minecraftforge/items/wrapper/SidedInvWrapper.java
@@ -98,10 +98,13 @@ public class SidedInvWrapper implements IItemHandlerModifiable
         int m;
         if (!stackInSlot.isEmpty())
         {
+            if (stackInSlot.getCount() >= Math.min(stackInSlot.getMaxStackSize(), getSlotLimit(slot)))
+                return stack;
+
             if (!ItemHandlerHelper.canItemStacksStack(stack, stackInSlot))
                 return stack;
 
-            if (!inv.isItemValidForSlot(slot1, stack) || !inv.canInsertItem(slot1, stack, side))
+            if (!inv.canInsertItem(slot1, stack, side) || !inv.isItemValidForSlot(slot1, stack))
                 return stack;
 
             m = Math.min(stack.getMaxStackSize(), getSlotLimit(slot)) - stackInSlot.getCount();
@@ -137,7 +140,7 @@ public class SidedInvWrapper implements IItemHandlerModifiable
         }
         else
         {
-            if (!inv.isItemValidForSlot(slot1, stack) || !inv.canInsertItem(slot1, stack, side))
+            if (!inv.canInsertItem(slot1, stack, side) || !inv.isItemValidForSlot(slot1, stack))
                 return stack;
 
             m = Math.min(stack.getMaxStackSize(), getSlotLimit(slot));


### PR DESCRIPTION
Should resolve #3658, see #3622 also.

This swaps the order of the `canInsertItem` and `isItemValidForSlot` checks to put the less expensive check first.

It also adds an early return if the stack currently in the target slot is full already.