### PR TITLE
Fix some more test mod warnings

### DIFF
--- a/src/test/java/net/minecraftforge/debug/CraftingSystemTest.java
+++ b/src/test/java/net/minecraftforge/debug/CraftingSystemTest.java
@@ -9,9 +9,10 @@ import net.minecraftforge.common.crafting.IIngredientFactory;
 import net.minecraftforge.common.crafting.IRecipeFactory;
 import net.minecraftforge.common.crafting.JsonContext;
 import net.minecraftforge.event.RegistryEvent;
-import net.minecraftforge.fml.common.FMLLog;
 import net.minecraftforge.fml.common.Mod;
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import java.util.function.BooleanSupplier;
 
@@ -22,10 +23,12 @@ public class CraftingSystemTest
     static final String MOD_ID = "crafting_system_test";
     static final boolean ENABLED = false;
 
+    static final Logger logger = LogManager.getLogger(MOD_ID);
+
     @SubscribeEvent
     public static void registerRecipes(RegistryEvent.Register<IRecipe> event)
     {
-        FMLLog.log.info("Registering Test Recipes:");
+        logger.info("Registering Test Recipes:");
     }
 
     public static class IngredientFactory implements IIngredientFactory
@@ -44,7 +47,6 @@ public class CraftingSystemTest
         {
             return null;
         }
-
     }
 
     public static class ConditionFactory implements IConditionFactory

--- a/src/test/java/net/minecraftforge/debug/FogColorInsideMaterialTest.java
+++ b/src/test/java/net/minecraftforge/debug/FogColorInsideMaterialTest.java
@@ -7,6 +7,7 @@ import net.minecraft.client.renderer.block.model.ModelResourceLocation;
 import net.minecraft.client.renderer.block.statemap.StateMapperBase;
 import net.minecraft.creativetab.CreativeTabs;
 import net.minecraft.entity.Entity;
+import net.minecraft.init.Blocks;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemBlock;
 import net.minecraft.util.ResourceLocation;
@@ -17,6 +18,7 @@ import net.minecraftforge.client.event.ModelRegistryEvent;
 import net.minecraftforge.client.model.ModelLoader;
 import net.minecraftforge.event.RegistryEvent;
 import net.minecraftforge.fluids.BlockFluidClassic;
+import net.minecraftforge.fluids.Fluid;
 import net.minecraftforge.fluids.FluidRegistry;
 import net.minecraftforge.fml.common.Mod;
 import net.minecraftforge.fml.common.Mod.EventBusSubscriber;
@@ -41,7 +43,9 @@ public class FogColorInsideMaterialTest
     @SubscribeEvent
     public static void registerBlocks(RegistryEvent.Register<Block> event)
     {
-        Block fluid = new BlockFluidClassic(FluidRegistry.WATER, Material.WATER)
+        Fluid fluid = new Fluid("fog_test", Blocks.WATER.getRegistryName(), Blocks.FLOWING_WATER.getRegistryName());
+        FluidRegistry.registerFluid(fluid);
+        Block fluidBlock = new BlockFluidClassic(fluid, Material.WATER)
         {
             @Override
             public Vec3d getFogColor(World world, BlockPos pos, IBlockState state, Entity entity, Vec3d originalColor, float partialTicks)
@@ -49,10 +53,10 @@ public class FogColorInsideMaterialTest
                 return new Vec3d(0.6F, 0.1F, 0.0F);
             }
         };
-        fluid.setCreativeTab(CreativeTabs.BUILDING_BLOCKS);
-        fluid.setUnlocalizedName(testFluidRegistryName.toString());
-        fluid.setRegistryName(testFluidRegistryName);
-        event.getRegistry().register(fluid);
+        fluidBlock.setCreativeTab(CreativeTabs.BUILDING_BLOCKS);
+        fluidBlock.setUnlocalizedName(MOD_ID + ".test_fluid");
+        fluidBlock.setRegistryName(testFluidRegistryName);
+        event.getRegistry().register(fluidBlock);
     }
 
     @SubscribeEvent

--- a/src/test/java/net/minecraftforge/debug/ForgeBlockStatesLoaderDebug.java
+++ b/src/test/java/net/minecraftforge/debug/ForgeBlockStatesLoaderDebug.java
@@ -10,23 +10,19 @@ import net.minecraft.client.renderer.block.statemap.StateMap;
 import net.minecraft.init.Blocks;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemMultiTexture;
-import net.minecraft.item.ItemStack;
 import net.minecraftforge.client.event.ModelRegistryEvent;
 import net.minecraftforge.client.model.ModelLoader;
-import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.event.RegistryEvent;
 import net.minecraftforge.fml.common.Mod;
-import net.minecraftforge.fml.common.Mod.EventHandler;
-import net.minecraftforge.fml.common.event.FMLPreInitializationEvent;
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
 import net.minecraftforge.fml.common.registry.GameRegistry.ObjectHolder;
 import net.minecraftforge.fml.relauncher.Side;
-import net.minecraftforge.fml.relauncher.SideOnly;
 
 import java.util.Map;
 import java.util.Map.Entry;
 
 @Mod(modid = ForgeBlockStatesLoaderDebug.MODID, name = "ForgeBlockStatesLoader", version = "1.0", acceptableRemoteVersions = "*")
+@Mod.EventBusSubscriber
 public class ForgeBlockStatesLoaderDebug
 {
     public static final String MODID = "forgeblockstatesloader";
@@ -45,43 +41,33 @@ public class ForgeBlockStatesLoaderDebug
     }
 
     @SubscribeEvent
-    public void registerBlocks(RegistryEvent.Register<Block> event)
+    public static void registerBlocks(RegistryEvent.Register<Block> event)
     {
         event.getRegistry().registerAll(
-            new BlockWall(Blocks.COBBLESTONE).setUnlocalizedName(MODID + ".customWall").setRegistryName(MODID, "custom_wall")
+                new BlockWall(Blocks.COBBLESTONE)
+                        .setUnlocalizedName(MODID + ".customWall")
+                        .setRegistryName(MODID, "custom_wall")
         );
     }
 
     @SubscribeEvent
-    public void registerItems(RegistryEvent.Register<Item> event)
+    public static void registerItems(RegistryEvent.Register<Item> event)
     {
         event.getRegistry().registerAll(
-            new ItemMultiTexture(BLOCKS.custom_wall, BLOCKS.custom_wall, new ItemMultiTexture.Mapper()
-            {
-                @Override
-                public String apply(ItemStack stack)
-                {
-                    return BlockWall.EnumType.byMetadata(stack.getMetadata()).getUnlocalizedName();
-                }
-            }).setRegistryName(BLOCKS.custom_wall.getRegistryName())
+                new ItemMultiTexture(
+                        BLOCKS.custom_wall, BLOCKS.custom_wall,
+                        stack -> BlockWall.EnumType.byMetadata(stack.getMetadata()).getUnlocalizedName()
+                ).setRegistryName(BLOCKS.custom_wall.getRegistryName())
         );
     }
 
     //public static final Block blockCustom = new CustomMappedBlock();
 
-    @EventHandler
-    public void preInit(FMLPreInitializationEvent event)
-    {
-        //blockCustom.setUnlocalizedName(MODID + ".customBlock").setRegistryName("customBlock");
-        //GameRegistry.registerBlock(blockCustom);
-        MinecraftForge.EVENT_BUS.register(this);
-    }
-
     @Mod.EventBusSubscriber(value = Side.CLIENT, modid = MODID)
     public static class ClientEventHandler
     {
         @SubscribeEvent
-        public void registerModels(ModelRegistryEvent event)
+        public static void registerModels(ModelRegistryEvent event)
         {
             //ModelLoader.setCustomStateMapper(blockCustom, new StateMap.Builder().withName(CustomMappedBlock.VARIANT).build());
 

--- a/src/test/java/net/minecraftforge/debug/MapDataTest.java
+++ b/src/test/java/net/minecraftforge/debug/MapDataTest.java
@@ -4,6 +4,7 @@ import io.netty.buffer.ByteBuf;
 import net.minecraft.block.material.MapColor;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.MapItemRenderer;
+import net.minecraft.client.renderer.block.model.ModelBakery;
 import net.minecraft.client.renderer.block.model.ModelResourceLocation;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.player.EntityPlayer;
@@ -63,6 +64,7 @@ public class MapDataTest
     {
         ModelLoader.setCustomModelResourceLocation(EMPTY_CUSTOM_MAP, 0, new ModelResourceLocation("map", "inventory"));
         ModelLoader.setCustomMeshDefinition(CUSTOM_MAP, s -> new ModelResourceLocation("filled_map", "inventory"));
+        ModelBakery.registerItemVariants(CUSTOM_MAP, new ModelResourceLocation("filled_map", "inventory"));
     }
 
     @SubscribeEvent

--- a/src/test/java/net/minecraftforge/debug/RecipeTestMod.java
+++ b/src/test/java/net/minecraftforge/debug/RecipeTestMod.java
@@ -15,7 +15,7 @@ import net.minecraftforge.fml.relauncher.FMLLaunchHandler;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.oredict.ShapedOreRecipe;
 
-@Mod(modid = "recipetest", version = "1.0", acceptableRemoteVersions = "*")
+@Mod(modid = "recipetest", name = "Recipe test mod", version = "1.0", acceptableRemoteVersions = "*")
 public class RecipeTestMod
 {
     @Mod.EventHandler

--- a/src/test/java/net/minecraftforge/debug/RegistryOverrideTest.java
+++ b/src/test/java/net/minecraftforge/debug/RegistryOverrideTest.java
@@ -34,7 +34,7 @@ import net.minecraftforge.event.RegistryEvent;
 import net.minecraftforge.fml.common.Mod;
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
 
-@Mod(modid = RegistryOverrideTest.MODID, version = "1.0")
+@Mod(modid = RegistryOverrideTest.MODID, name = "Registry override test mod", version = "1.0")
 @Mod.EventBusSubscriber
 public class RegistryOverrideTest
 {

--- a/src/test/java/net/minecraftforge/debug/RegistryOverrideTest.java
+++ b/src/test/java/net/minecraftforge/debug/RegistryOverrideTest.java
@@ -39,11 +39,15 @@ import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
 public class RegistryOverrideTest
 {
     public static final String MODID = "registry_override_test";
+    static final boolean ENABLED = false;
 
     @SubscribeEvent
     public static void registerBlocks(RegistryEvent.Register<Block> event)
     {
-        event.getRegistry().register(new BlockReplacement());
+        if (ENABLED)
+        {
+            event.getRegistry().register(new BlockReplacement());
+        }
     }
 
     private static class BlockReplacement extends Block

--- a/src/test/java/net/minecraftforge/debug/SlipperinessTest.java
+++ b/src/test/java/net/minecraftforge/debug/SlipperinessTest.java
@@ -3,21 +3,29 @@ package net.minecraftforge.debug;
 import net.minecraft.block.Block;
 import net.minecraft.block.material.Material;
 import net.minecraft.block.state.IBlockState;
+import net.minecraft.creativetab.CreativeTabs;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.item.EntityBoat;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemBlock;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.IBlockAccess;
+import net.minecraftforge.client.event.ModelRegistryEvent;
+import net.minecraftforge.client.model.ModelLoader;
 import net.minecraftforge.event.RegistryEvent;
 import net.minecraftforge.fml.common.Mod;
 import net.minecraftforge.fml.common.Mod.EventBusSubscriber;
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
+import net.minecraftforge.fml.relauncher.Side;
 
-@Mod(modid = "slipperiness_test", name = "Slipperiness Test", version = "0.0.0")
+import java.util.Collections;
+
+@Mod(modid = SlipperinessTest.MOD_ID, name = "Slipperiness Test", version = "0.0.0")
 @EventBusSubscriber
 public class SlipperinessTest
 {
+    static final String MOD_ID = "slipperiness_test";
+
     public static final Block BB_BLOCK = new Block(Material.PACKED_ICE)
     {
         @Override
@@ -25,12 +33,15 @@ public class SlipperinessTest
         {
             return entity instanceof EntityBoat ? 2 : super.getSlipperiness(state, world, pos, entity);
         }
-    }.setUnlocalizedName("boat_blaster").setRegistryName("boat_blaster");
+    };
 
     @SubscribeEvent
     public static void registerBlocks(RegistryEvent.Register<Block> e)
     {
-        e.getRegistry().register(BB_BLOCK);
+        e.getRegistry().register(BB_BLOCK
+                .setUnlocalizedName("boat_blaster")
+                .setRegistryName("boat_blaster")
+                .setCreativeTab(CreativeTabs.BUILDING_BLOCKS));
     }
 
     @SubscribeEvent
@@ -38,5 +49,14 @@ public class SlipperinessTest
     {
         e.getRegistry().register(new ItemBlock(BB_BLOCK).setRegistryName(BB_BLOCK.getRegistryName()));
     }
-}
 
+    @Mod.EventBusSubscriber(value = Side.CLIENT, modid = MOD_ID)
+    public static class ClientEventHandler
+    {
+        @SubscribeEvent
+        public static void registerModels(ModelRegistryEvent event)
+        {
+            ModelLoader.setCustomStateMapper(BB_BLOCK, block -> Collections.emptyMap());
+        }
+    }
+}

--- a/src/test/java/net/minecraftforge/debug/SlipperinessTest.java
+++ b/src/test/java/net/minecraftforge/debug/SlipperinessTest.java
@@ -3,6 +3,7 @@ package net.minecraftforge.debug;
 import net.minecraft.block.Block;
 import net.minecraft.block.material.Material;
 import net.minecraft.block.state.IBlockState;
+import net.minecraft.client.renderer.block.model.ModelBakery;
 import net.minecraft.creativetab.CreativeTabs;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.item.EntityBoat;
@@ -50,13 +51,14 @@ public class SlipperinessTest
         e.getRegistry().register(new ItemBlock(BB_BLOCK).setRegistryName(BB_BLOCK.getRegistryName()));
     }
 
-    @Mod.EventBusSubscriber(value = Side.CLIENT, modid = MOD_ID)
+    @EventBusSubscriber(value = Side.CLIENT, modid = MOD_ID)
     public static class ClientEventHandler
     {
         @SubscribeEvent
         public static void registerModels(ModelRegistryEvent event)
         {
             ModelLoader.setCustomStateMapper(BB_BLOCK, block -> Collections.emptyMap());
+            ModelBakery.registerItemVariants(Item.getItemFromBlock(BB_BLOCK));
         }
     }
 }

--- a/src/test/java/net/minecraftforge/debug/TransparentFastTesrTest.java
+++ b/src/test/java/net/minecraftforge/debug/TransparentFastTesrTest.java
@@ -1,5 +1,6 @@
 package net.minecraftforge.debug;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import net.minecraft.block.Block;
@@ -25,6 +26,7 @@ import net.minecraft.util.ResourceLocation;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.World;
 import net.minecraftforge.client.event.ModelRegistryEvent;
+import net.minecraftforge.client.model.ModelLoader;
 import net.minecraftforge.client.model.animation.FastTESR;
 import net.minecraftforge.event.RegistryEvent;
 import net.minecraftforge.fluids.Fluid;
@@ -232,12 +234,13 @@ public class TransparentFastTesrTest
         GameRegistry.registerTileEntity(TransparentFastTE.class, "fast-tesr-te");
     }
 
-    @Mod.EventBusSubscriber(value = Side.CLIENT, modid = MODID)
+    @EventBusSubscriber(value = Side.CLIENT, modid = MODID)
     public static class ClientLoader
     {
         @SubscribeEvent
         public static void registerModels(ModelRegistryEvent event)
         {
+            ModelLoader.setCustomStateMapper(testBlock, block -> Collections.emptyMap());
             ClientRegistry.bindTileEntitySpecialRenderer(TransparentFastTE.class, new TransparentFastTESR());
         }
     }

--- a/src/test/java/net/minecraftforge/debug/TransparentFastTesrTest.java
+++ b/src/test/java/net/minecraftforge/debug/TransparentFastTesrTest.java
@@ -11,6 +11,7 @@ import net.minecraft.block.state.BlockStateContainer;
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.renderer.BufferBuilder;
+import net.minecraft.client.renderer.block.model.ModelBakery;
 import net.minecraft.client.renderer.texture.TextureAtlasSprite;
 import net.minecraft.client.util.ITooltipFlag;
 import net.minecraft.creativetab.CreativeTabs;
@@ -241,6 +242,7 @@ public class TransparentFastTesrTest
         public static void registerModels(ModelRegistryEvent event)
         {
             ModelLoader.setCustomStateMapper(testBlock, block -> Collections.emptyMap());
+            ModelBakery.registerItemVariants(Item.getItemFromBlock(testBlock));
             ClientRegistry.bindTileEntitySpecialRenderer(TransparentFastTE.class, new TransparentFastTESR());
         }
     }

--- a/src/test/java/net/minecraftforge/debug/TransparentFastTesrTest.java
+++ b/src/test/java/net/minecraftforge/debug/TransparentFastTesrTest.java
@@ -40,7 +40,7 @@ import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
 import net.minecraftforge.fml.common.registry.GameRegistry;
 import net.minecraftforge.fml.relauncher.Side;
 
-@Mod(modid = TransparentFastTesrTest.MODID, name = "TransparentFastTESRTest")
+@Mod(modid = TransparentFastTesrTest.MODID, name = "TransparentFastTESRTest", version = "1.0")
 public class TransparentFastTesrTest
 {
 

--- a/src/test/resources/assets/forgeblockstatesloader/blockstates/cobblestone_wall.json
+++ b/src/test/resources/assets/forgeblockstatesloader/blockstates/cobblestone_wall.json
@@ -27,7 +27,7 @@
 		"east=false,north=true,south=true,up=false,west=false": {"model": null},	// Fully specified variant, will inherit from variants above, but remove the model set in "defaults", removing the wall post.
 		"east=true,north=false,south=false,up=false,west=true": {"model": null},
 		"inventory": [{  // inventory variant can be specified here too, and it will inherit properties from "defaults"
-		    submodel: {
+		    "submodel": {
 		        "north": { "model": "forgeblockstatesloader:wall_connect" },
 		        "south": { "model": "forgeblockstatesloader:wall_connect", "y": 180 }
 		    }

--- a/src/test/resources/assets/forgeblockstatesloader/blockstates/mossy_cobblestone_wall.json
+++ b/src/test/resources/assets/forgeblockstatesloader/blockstates/mossy_cobblestone_wall.json
@@ -27,7 +27,7 @@
 		"east=false,north=true,south=true,up=false,west=false": {"model": null},
 		"east=true,north=false,south=false,up=false,west=true": {"model": null},
 		"inventory": [{  // inventory variant can be specified here too, and it will inherit properties from "defaults"
-		    submodel: {
+		    "submodel": {
 		        "north": { "model": "forgeblockstatesloader:wall_connect" },
 		        "south": { "model": "forgeblockstatesloader:wall_connect", "y": 180 }
 		    }

--- a/src/test/resources/assets/forgedebugmultilayermodel/blockstates/test_layer_block.json
+++ b/src/test/resources/assets/forgedebugmultilayermodel/blockstates/test_layer_block.json
@@ -20,7 +20,7 @@
         "aux": [{
             "model": "cube_all",
             "textures": { "all": "blocks/slime" },
-            "transform": { "scale": .5 }
+            "transform": { "scale": 0.5 }
         }]
     }
 }


### PR DESCRIPTION
Further work on #4455, followup to #4456.

This adds some missing elements to a few `@Mod` annotations and fixes some errors related to missing item models.