### PR TITLE
Non-player entities now respect WorldProvider.getMovementFactor (+ bonus bug)

### DIFF
--- a/patches/minecraft/net/minecraft/entity/Entity.java.patch
+++ b/patches/minecraft/net/minecraft/entity/Entity.java.patch
@@ -146,7 +146,29 @@
              this.field_70170_p.field_72984_F.func_76320_a("changeDimension");
              MinecraftServer minecraftserver = this.func_184102_h();
              int i = this.field_71093_bK;
-@@ -2604,7 +2631,7 @@
+@@ -2535,16 +2562,17 @@
+             }
+             else
+             {
+-                double d0 = this.field_70165_t;
+-                double d1 = this.field_70161_v;
++                double moveFactor = worldserver.field_73011_w.getMovementFactor() / worldserver1.field_73011_w.getMovementFactor();
++                double d0 = MathHelper.func_151237_a(this.field_70165_t * moveFactor, worldserver1.func_175723_af().func_177726_b() + 16.0D, worldserver1.func_175723_af().func_177728_d() - 16.0D);
++                double d1 = MathHelper.func_151237_a(this.field_70161_v * moveFactor, worldserver1.func_175723_af().func_177736_c() + 16.0D, worldserver1.func_175723_af().func_177733_e() - 16.0D);
+                 double d2 = 8.0D;
+ 
+-                if (p_184204_1_ == -1)
++                if (false && p_184204_1_ == -1)
+                 {
+                     d0 = MathHelper.func_151237_a(d0 / 8.0D, worldserver1.func_175723_af().func_177726_b() + 16.0D, worldserver1.func_175723_af().func_177728_d() - 16.0D);
+                     d1 = MathHelper.func_151237_a(d1 / 8.0D, worldserver1.func_175723_af().func_177736_c() + 16.0D, worldserver1.func_175723_af().func_177733_e() - 16.0D);
+                 }
+-                else if (p_184204_1_ == 0)
++                else if (false && p_184204_1_ == 0)
+                 {
+                     d0 = MathHelper.func_151237_a(d0 * 8.0D, worldserver1.func_175723_af().func_177726_b() + 16.0D, worldserver1.func_175723_af().func_177728_d() - 16.0D);
+                     d1 = MathHelper.func_151237_a(d1 * 8.0D, worldserver1.func_175723_af().func_177736_c() + 16.0D, worldserver1.func_175723_af().func_177733_e() - 16.0D);
+@@ -2604,7 +2632,7 @@
  
      public float func_180428_a(Explosion p_180428_1_, World p_180428_2_, BlockPos p_180428_3_, IBlockState p_180428_4_)
      {
@@ -155,7 +177,7 @@
      }
  
      public boolean func_174816_a(Explosion p_174816_1_, World p_174816_2_, BlockPos p_174816_3_, IBlockState p_174816_4_, float p_174816_5_)
-@@ -2901,6 +2928,185 @@
+@@ -2901,6 +2929,185 @@
          EnchantmentHelper.func_151385_b(p_174815_1_, p_174815_2_);
      }
  

--- a/patches/minecraft/net/minecraft/server/management/PlayerList.java.patch
+++ b/patches/minecraft/net/minecraft/server/management/PlayerList.java.patch
@@ -189,8 +189,8 @@
 +        net.minecraft.world.WorldProvider pOld = p_82448_3_.field_73011_w;
 +        net.minecraft.world.WorldProvider pNew = p_82448_4_.field_73011_w;
 +        double moveFactor = pOld.getMovementFactor() / pNew.getMovementFactor();
-+        double d0 = p_82448_1_.field_70165_t * moveFactor;
-+        double d1 = p_82448_1_.field_70161_v * moveFactor;
++        double d0 = MathHelper.func_151237_a(p_82448_1_.field_70165_t * moveFactor, p_82448_4_.func_175723_af().func_177726_b() + 16.0D, p_82448_4_.func_175723_af().func_177728_d() - 16.0D);
++        double d1 = MathHelper.func_151237_a(p_82448_1_.field_70161_v * moveFactor, p_82448_4_.func_175723_af().func_177736_c() + 16.0D, p_82448_4_.func_175723_af().func_177733_e() - 16.0D);
          double d2 = 8.0D;
          float f = p_82448_1_.field_70177_z;
          p_82448_3_.field_72984_F.func_76320_a("moving");

--- a/patches/minecraft/net/minecraft/world/WorldProvider.java.patch
+++ b/patches/minecraft/net/minecraft/world/WorldProvider.java.patch
@@ -65,7 +65,7 @@
      }
  
      @SideOnly(Side.CLIENT)
-@@ -241,6 +216,317 @@
+@@ -241,6 +216,318 @@
          return new WorldBorder();
      }
  
@@ -102,9 +102,10 @@
 +    }
 +
 +    /**
-+     * The dimensions movement factor. Relative to normal overworld.
-+     * It is applied to the players position when they transfer dimensions.
-+     * Exa: Nether movement is 8.0
++     * The dimension's movement factor.
++     * Whenever a player or entity changes dimension from world A to world B, their coordinates are multiplied by
++     * worldA.provider.getMovementFactor() / worldB.provider.getMovementFactor()
++     * Example: Overworld factor is 1, nether factor is 8. Traveling from overworld to nether multiplies coordinates by 1/8.
 +     * @return The movement factor
 +     */
 +    public double getMovementFactor()


### PR DESCRIPTION
closes #4470 

Previously, getMovementFactor was used for players but non-players used the vanilla hardcoded cases / 8 and * 8 for the nether and returning from nether, respectively. As @mezz noted in #4470 this is probably because entities traveling through portals was introduced in 1.4, after getMovementFactor was added.

Since this logic now runs for all entities, it can be tested by simply tossing items/pushing mobs through a nether portal and making sure they end up where you end up.