### PR TITLE
1.7.10: Implement event handler hooks

### DIFF
--- a/fml/src/main/java/cpw/mods/fml/common/FMLModContainer.java
+++ b/fml/src/main/java/cpw/mods/fml/common/FMLModContainer.java
@@ -529,6 +529,7 @@ public class FMLModContainer implements ModContainer
         {
             for (Method m : eventMethods.get(event.getClass()))
             {
+                this.getLanguageAdapter().callEventHandler(m, event);
                 m.invoke(modInstance, event);
             }
         }

--- a/fml/src/main/java/cpw/mods/fml/common/FMLModContainer.java
+++ b/fml/src/main/java/cpw/mods/fml/common/FMLModContainer.java
@@ -530,7 +530,6 @@ public class FMLModContainer implements ModContainer
             for (Method m : eventMethods.get(event.getClass()))
             {
                 this.getLanguageAdapter().callEventHandler(m, event);
-                m.invoke(modInstance, event);
             }
         }
         catch (Throwable t)

--- a/fml/src/main/java/cpw/mods/fml/common/ILanguageAdapter.java
+++ b/fml/src/main/java/cpw/mods/fml/common/ILanguageAdapter.java
@@ -3,6 +3,8 @@ package cpw.mods.fml.common;
 import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
+
+import cpw.mods.fml.common.event.FMLEvent;
 import org.apache.logging.log4j.Level;
 
 import cpw.mods.fml.relauncher.Side;
@@ -12,6 +14,13 @@ public interface ILanguageAdapter {
     public boolean supportsStatics();
     public void setProxy(Field target, Class<?> proxyTarget, Object proxy) throws IllegalArgumentException, IllegalAccessException, NoSuchFieldException, SecurityException;
     public void setInternalProxies(ModContainer mod, Side side, ClassLoader loader);
+
+    /**
+     * This method provides means to hook into the execution of event handlers to alter the behaviour
+     * @param method the handler that should be executed
+     * @param event the event that was fired
+     */
+    public void callEventHandler(Method method, FMLEvent event) throws InvocationTargetException, IllegalAccessException;
 
     public static class ScalaAdapter implements ILanguageAdapter {
         @Override
@@ -158,6 +167,13 @@ public interface ILanguageAdapter {
                 FMLLog.finer("Mod does not appear to be a singleton.");
             }
         }
+
+        @Override
+        public void callEventHandler(Method method, FMLEvent event) throws InvocationTargetException, IllegalAccessException
+        {
+            // Just pass the call through
+            method.invoke(event);
+        }
     }
 
     public static class JavaAdapter implements ILanguageAdapter {
@@ -191,6 +207,13 @@ public interface ILanguageAdapter {
         public void setInternalProxies(ModContainer mod, Side side, ClassLoader loader)
         {
             // Nothing to do here.
+        }
+
+        @Override
+        public void callEventHandler(Method method, FMLEvent event) throws InvocationTargetException, IllegalAccessException
+        {
+            // Just pass the call through
+            method.invoke(event);
         }
     }
 }


### PR DESCRIPTION
The idea is for language adapters to be able to hook into the execution of event handlers to provide more efficient execution. As the loading handlers can consume quite some time I think it would be convenient to provide more efficient execution methods. Sadly though, I know no way Java 6 could benefit from that (Futures came too late...) and I don't know whether Scala has something like async/await or something comparable. But Forgelin/Kotlin for instance could benefit from that using suspend functions. I've created a gist to show how this could look like:
https://gist.github.com/Haringat/878847744dd0d73849eafb563fd3e6b2