### PR TITLE
Throw a more clear exception when the user does use java 9

### DIFF
--- a/jsons/1.12.2-rel.json
+++ b/jsons/1.12.2-rel.json
@@ -17,7 +17,7 @@
   "releaseTime": "1960-01-01T00:00:00-0700",
   "type": "release",
   "minecraftArguments": "--username ${auth_player_name} --version ${version_name} --gameDir ${game_directory} --assetsDir ${assets_root} --assetIndex ${assets_index_name} --uuid ${auth_uuid} --accessToken ${auth_access_token} --userType ${user_type} --tweakClass net.minecraftforge.fml.common.launcher.FMLTweaker --versionType Forge",
-  "mainClass": "net.minecraft.launchwrapper.Launch",
+  "mainClass": "net.minecraftforge.fml.relauncher.ClientLaunchWrapper",
   "inheritsFrom": "1.12.2",
   "jar": "1.12.2",
   "logging": {},

--- a/src/main/java/net/minecraftforge/fml/relauncher/ClientLaunchWrapper.java
+++ b/src/main/java/net/minecraftforge/fml/relauncher/ClientLaunchWrapper.java
@@ -1,0 +1,30 @@
+package net.minecraftforge.fml.relauncher;
+
+import net.minecraft.launchwrapper.Launch;
+
+import javax.swing.*;
+
+/**
+ * Called before Launchwrapper, so we can check the java version first
+ * TODO remove in 1.13 when ModLauncher supports J9
+ */
+@Deprecated
+public class ClientLaunchWrapper {
+
+    public static void main(String[] args) {
+        //Check java version, as we don't support java 9 yet
+        String javaVersion = System.getProperty("java.specification.version");
+        if (javaVersion == null) //should never happen, but let's be safe
+        {
+            System.out.println("Could not determine java version, things may not work!");
+        }
+        else if (!javaVersion.startsWith("1.8") && !"true".equalsIgnoreCase(System.getProperty("fml.disableJavaVersionCheck")))
+        {
+            String msg = String.format("Your java version (%s) is not supported with this version of minecraft! Please use Java 8!", javaVersion);
+            JOptionPane.showMessageDialog(null, msg, "Error launching minecraft", JOptionPane.ERROR_MESSAGE);
+            throw new RuntimeException(msg);
+        }
+
+        Launch.main(args);
+    }
+}

--- a/src/main/java/net/minecraftforge/fml/relauncher/ServerLaunchWrapper.java
+++ b/src/main/java/net/minecraftforge/fml/relauncher/ServerLaunchWrapper.java
@@ -38,15 +38,26 @@ public class ServerLaunchWrapper {
 
     private void run(String[] args)
     {
+        //Check java version, as we don't support java 9 yet
+        String javaVersion = System.getProperty("java.specification.version");
+        if (javaVersion == null) //should never happen, but let's be safe
+        {
+            System.out.println("Could not determine java version, things may not work!");
+        }
+        else if (!javaVersion.startsWith("1.8") && !"true".equalsIgnoreCase(System.getProperty("fml.disableJavaVersionCheck")))
+        {
+            throw new RuntimeException(String.format("Your java version (%s) is not supported with this version of minecraft! Please use Java 8!", javaVersion));
+        }
+
         Class<?> launchwrapper = null;
         try
         {
             launchwrapper = Class.forName("net.minecraft.launchwrapper.Launch",true,getClass().getClassLoader());
-            Class.forName("org.objectweb.asm.Type",true,getClass().getClassLoader());
+            Class.forName("org.objectweb.asm.Type",true, getClass().getClassLoader());
         }
         catch (Exception e)
         {
-            System.err.printf("We appear to be missing one or more essential library files.\n" +
+            System.err.println("We appear to be missing one or more essential library files.\n" +
             		"You will need to add them to your server before FML and Forge will run successfully.");
             e.printStackTrace(System.err);
             System.exit(1);
@@ -63,7 +74,7 @@ public class ServerLaunchWrapper {
         }
         catch (Exception e)
         {
-            System.err.printf("A problem occurred running the Server launcher.");
+            System.err.println("A problem occurred running the Server launcher.");
             e.printStackTrace(System.err);
             System.exit(1);
         }

--- a/src/main/java/net/minecraftforge/fml/relauncher/ServerLaunchWrapper.java
+++ b/src/main/java/net/minecraftforge/fml/relauncher/ServerLaunchWrapper.java
@@ -23,9 +23,6 @@ import java.lang.reflect.Method;
 
 public class ServerLaunchWrapper {
 
-    /**
-     * @param args
-     */
     public static void main(String[] args)
     {
         new ServerLaunchWrapper().run(args);
@@ -39,6 +36,7 @@ public class ServerLaunchWrapper {
     private void run(String[] args)
     {
         //Check java version, as we don't support java 9 yet
+        //TODO remove this check in 1.13 when ModLauncher supports J9
         String javaVersion = System.getProperty("java.specification.version");
         if (javaVersion == null) //should never happen, but let's be safe
         {
@@ -52,7 +50,7 @@ public class ServerLaunchWrapper {
         Class<?> launchwrapper = null;
         try
         {
-            launchwrapper = Class.forName("net.minecraft.launchwrapper.Launch",true,getClass().getClassLoader());
+            launchwrapper = Class.forName("net.minecraft.launchwrapper.Launch", true, getClass().getClassLoader());
             Class.forName("org.objectweb.asm.Type",true, getClass().getClassLoader());
         }
         catch (Exception e)


### PR DESCRIPTION
Previously, the exception messages were something like [this](http://www.minecraftforge.net/forum/topic/61413-we-appear-to-be-missing-one-or-more-essential-library-files) or [this](http://www.minecraftforge.net/forum/topic/61323-unable-to-start-forge-server).
The message is a lot more clear now: Your java version (9) is not supported with this version of minecraft! Please use Java 8!