### PR TITLE
Fix an incorrect conflict merge

### DIFF
--- a/src/main/resources/assets/forge/lang/en_US.lang
+++ b/src/main/resources/assets/forge/lang/en_US.lang
@@ -63,7 +63,6 @@ forge.configgui.zombieBabyChance=Zombie Baby Chance
 forge.configgui.zombieBaseSummonChance.tooltip=Base zombie summoning spawn chance. Allows changing the bonus zombie summoning mechanic.
 forge.configgui.zombieBaseSummonChance=Zombie Summon Chance
 forge.configgui.stencilbits=Enable GL Stencil Bits
-forge.configgui.replaceBuckets=Use Forge's bucket model
 forge.configgui.forgeCloudsEnabled=Use Forge's cloud renderer
 forge.configgui.forgeCloudsEnabled.tooltip=Enable uploading cloud geometry to the GPU for faster rendering.
 forge.configgui.forgeLightPipelineEnabled=Forge Light Pipeline Enabled


### PR DESCRIPTION
forge.configgui.replaceBuckets was correctly removed in b5e88dd (#4435), but
was incorrectly re-added by the merge of 9c7538d (#4143). Re-remove it.