### PR TITLE
Change item model alpha tests to match values used for rendering

### DIFF
--- a/src/main/java/net/minecraftforge/client/model/ItemLayerModel.java
+++ b/src/main/java/net/minecraftforge/client/model/ItemLayerModel.java
@@ -142,7 +142,7 @@ public final class ItemLayerModel implements IModel
                 for(int u = 0; u < uMax; u++)
                 {
                     int alpha = getAlpha(pixels, uMax, vMax, u, v);
-                    boolean t = alpha == 0;
+                    boolean t = alpha / 255f <= 0.1f;
 
                     if (!t && alpha < 255)
                     {

--- a/src/main/java/net/minecraftforge/client/model/ItemTextureQuadConverter.java
+++ b/src/main/java/net/minecraftforge/client/model/ItemTextureQuadConverter.java
@@ -206,10 +206,9 @@ public final class ItemTextureQuadConverter
         return quads;
     }
 
-    // true if alpha != 0
     private static boolean isVisible(int color)
     {
-        return (color >> 24 & 255) > 0;
+        return (color >> 24 & 255) / 255f > 0.1f;
     }
 
     /**


### PR DESCRIPTION
Currently Forge's item model handling uses the vanilla logic, which treats only pixels with an alpha value of 0 as transparent.

However, this logic is inconsistent with the logic used for rendering the items, which will only render pixels with an opacity > 0.1.

This PR changes the item model generation code to match the rendering logic, which fixes the appearance of some item models generated from textures with translucency.

As an example:

* Before:
![before](https://user-images.githubusercontent.com/1447117/32260555-8ce1a2fe-bec0-11e7-9ef1-f08b78b8f9a1.png)

* After:
![after](https://user-images.githubusercontent.com/1447117/32260560-941b9570-bec0-11e7-8617-9d8a0e5e52ee.png)
