### PR TITLE
Fix incorrect lighting of item models

### DIFF
--- a/src/main/java/net/minecraftforge/client/model/ItemLayerModel.java
+++ b/src/main/java/net/minecraftforge/client/model/ItemLayerModel.java
@@ -382,7 +382,7 @@ public final class ItemLayerModel implements IModel
 
     private static EnumFacing remap(EnumFacing side)
     {
-        // getOpposite is related either to the swapping of V direction, or something else
+        // getOpposite is related to the swapping of V direction
         return side.getAxis() == EnumFacing.Axis.Y ? side.getOpposite() : side;
     }
 

--- a/src/main/java/net/minecraftforge/client/model/ItemLayerModel.java
+++ b/src/main/java/net/minecraftforge/client/model/ItemLayerModel.java
@@ -372,7 +372,7 @@ public final class ItemLayerModel implements IModel
         float v1 = 16f * (1f - y1 - dy);
 
         return buildQuad(
-            format, transform, side.getOpposite(), sprite, tint, // getOpposite is related either to the swapping of V direction, or something else
+            format, transform, remap(side), sprite, tint,
             x0, y0, z0, sprite.getInterpolatedU(u0), sprite.getInterpolatedV(v0),
             x1, y1, z0, sprite.getInterpolatedU(u1), sprite.getInterpolatedV(v1),
             x1, y1, z1, sprite.getInterpolatedU(u1), sprite.getInterpolatedV(v1),
@@ -380,7 +380,13 @@ public final class ItemLayerModel implements IModel
         );
     }
 
-    private static final BakedQuad buildQuad(
+    private static EnumFacing remap(EnumFacing side)
+    {
+        // getOpposite is related either to the swapping of V direction, or something else
+        return side.getAxis() == EnumFacing.Axis.Y ? side.getOpposite() : side;
+    }
+
+    private static BakedQuad buildQuad(
         VertexFormat format, Optional<TRSRTransformation> transform, EnumFacing side, TextureAtlasSprite sprite, int tint,
         float x0, float y0, float z0, float u0, float v0,
         float x1, float y1, float z1, float u1, float v1,


### PR DESCRIPTION
Should fix #4401, see there for screenshot examples.

This just changes the code to only call `getOpposite` for y-oriented sides, fixing the current incorrect lighting of quads with sides on the X axis.