### PR TITLE
Fix MC-51150 In some situations the sky darkens when it shouldn't

### DIFF
--- a/patches/minecraft/net/minecraft/client/renderer/EntityRenderer.java.patch
+++ b/patches/minecraft/net/minecraft/client/renderer/EntityRenderer.java.patch
@@ -8,6 +8,15 @@
          }
      }
  
+@@ -290,7 +291,7 @@
+             this.field_78531_r.func_175607_a(this.field_78531_r.field_71439_g);
+         }
+ 
+-        float f3 = this.field_78531_r.field_71441_e.func_175724_o(new BlockPos(this.field_78531_r.func_175606_aa()));
++        float f3 = this.field_78531_r.field_71441_e.func_175724_o(new BlockPos(this.field_78531_r.func_175606_aa().func_174824_e(1F))); // Forge: fix MC-51150
+         float f4 = (float)this.field_78531_r.field_71474_y.field_151451_c / 32.0F;
+         float f2 = f3 * (1.0F - f4) + f4;
+         this.field_78539_ae += (f2 - this.field_78539_ae) * 0.1F;
 @@ -412,7 +413,7 @@
  
                          if (d3 < d2 || d2 == 0.0D)


### PR DESCRIPTION
Fixes Mojang bug [MC-51150](https://bugs.mojang.com/browse/MC-51150) where the sky will darken in certain circumstances where it shouldn't (like riding in a minecart). The bug was introduced in 1.8 (according to the bug report comments) where they changed the client to track entities by their feet location instead of their eye location. This bug fix does the sky light calculation (for determining fog color) at the entity's eye location where it should be instead of their feet.