### PR TITLE
Add additional ChunkGenerator events

### DIFF
--- a/patches/minecraft/net/minecraft/world/gen/ChunkGeneratorEnd.java.patch
+++ b/patches/minecraft/net/minecraft/world/gen/ChunkGeneratorEnd.java.patch
@@ -36,7 +36,7 @@
          for (int i = 0; i < 16; ++i)
          {
              for (int j = 0; j < 16; ++j)
-@@ -173,6 +188,7 @@
+@@ -173,12 +188,14 @@
  
      public Chunk func_185932_a(int p_185932_1_, int p_185932_2_)
      {
@@ -44,7 +44,14 @@
          this.field_73220_k.setSeed((long)p_185932_1_ * 341873128712L + (long)p_185932_2_ * 132897987541L);
          ChunkPrimer chunkprimer = new ChunkPrimer();
          this.field_73231_z = this.field_73230_p.func_72959_q().func_76933_b(this.field_73231_z, p_185932_1_ * 16, p_185932_2_ * 16, 16, 16);
-@@ -254,6 +270,10 @@
+         this.func_180518_a(p_185932_1_, p_185932_2_, chunkprimer);
+         this.func_185962_a(chunkprimer);
+ 
++        net.minecraftforge.event.ForgeEventFactory.onChunkGenerate(this, this.field_73230_p, p_185932_1_, p_185932_2_, chunkprimer);
+         if (this.field_73229_q)
+         {
+             this.field_185972_n.func_186125_a(this.field_73230_p, p_185932_1_, p_185932_2_, chunkprimer);
+@@ -254,6 +271,10 @@
  
      private double[] func_185963_a(double[] p_185963_1_, int p_185963_2_, int p_185963_3_, int p_185963_4_, int p_185963_5_, int p_185963_6_, int p_185963_7_)
      {
@@ -55,7 +62,7 @@
          if (p_185963_1_ == null)
          {
              p_185963_1_ = new double[p_185963_5_ * p_185963_6_ * p_185963_7_];
-@@ -326,6 +346,7 @@
+@@ -326,6 +347,7 @@
      public void func_185931_b(int p_185931_1_, int p_185931_2_)
      {
          BlockFalling.field_149832_M = true;
@@ -63,7 +70,7 @@
          BlockPos blockpos = new BlockPos(p_185931_1_ * 16, 0, p_185931_2_ * 16);
  
          if (this.field_73229_q)
-@@ -394,6 +415,7 @@
+@@ -394,6 +416,7 @@
              }
          }
  
@@ -71,3 +78,32 @@
          BlockFalling.field_149832_M = false;
      }
  
+@@ -404,21 +427,28 @@
+ 
+     public List<Biome.SpawnListEntry> func_177458_a(EnumCreatureType p_177458_1_, BlockPos p_177458_2_)
+     {
++        net.minecraftforge.event.terraingen.ChunkGeneratorEvent.GetPossibleCreatures event = new net.minecraftforge.event.terraingen.ChunkGeneratorEvent.GetPossibleCreatures(this, field_73230_p, p_177458_1_, p_177458_2_);
++        if(net.minecraftforge.common.MinecraftForge.EVENT_BUS.post(event)) return event.getPossibleCreatures();
+         return this.field_73230_p.func_180494_b(p_177458_2_).func_76747_a(p_177458_1_);
+     }
+ 
+     @Nullable
+     public BlockPos func_180513_a(World p_180513_1_, String p_180513_2_, BlockPos p_180513_3_, boolean p_180513_4_)
+     {
++        net.minecraftforge.event.terraingen.ChunkGeneratorEvent.FindStructure event = new net.minecraftforge.event.terraingen.ChunkGeneratorEvent.FindStructure(this, p_180513_1_, p_180513_2_, p_180513_3_, p_180513_4_);
++        if(net.minecraftforge.common.MinecraftForge.EVENT_BUS.post(event)) return event.getFoundPos();
+         return "EndCity".equals(p_180513_2_) && this.field_185972_n != null ? this.field_185972_n.func_180706_b(p_180513_1_, p_180513_3_, p_180513_4_) : null;
+     }
+ 
+     public boolean func_193414_a(World p_193414_1_, String p_193414_2_, BlockPos p_193414_3_)
+     {
++        net.minecraftforge.event.terraingen.ChunkGeneratorEvent.StructureCheck event = new net.minecraftforge.event.terraingen.ChunkGeneratorEvent.StructureCheck(this, field_73230_p, p_193414_2_, p_193414_3_);
++        if(net.minecraftforge.common.MinecraftForge.EVENT_BUS.post(event)) return event.isInStructure();
+         return "EndCity".equals(p_193414_2_) && this.field_185972_n != null ? this.field_185972_n.func_175795_b(p_193414_3_) : false;
+     }
+ 
+     public void func_180514_a(Chunk p_180514_1_, int p_180514_2_, int p_180514_3_)
+     {
++        net.minecraftforge.event.ForgeEventFactory.onChunkGenerate(this, this.field_73230_p, p_180514_2_, p_180514_3_, (ChunkPrimer) null);
+     }
+ }

--- a/patches/minecraft/net/minecraft/world/gen/ChunkGeneratorHell.java.patch
+++ b/patches/minecraft/net/minecraft/world/gen/ChunkGeneratorHell.java.patch
@@ -28,7 +28,15 @@
          int i = this.field_185952_n.func_181545_F() + 1;
          double d0 = 0.03125D;
          this.field_73185_q = this.field_73177_m.func_76304_a(this.field_73185_q, p_185937_1_ * 16, p_185937_2_ * 16, 0, 16, 16, 1, 0.03125D, 0.03125D, 1.0D);
-@@ -277,6 +291,10 @@
+@@ -252,6 +266,7 @@
+         this.func_185937_b(p_185932_1_, p_185932_2_, chunkprimer);
+         this.field_185939_I.func_186125_a(this.field_185952_n, p_185932_1_, p_185932_2_, chunkprimer);
+ 
++        net.minecraftforge.event.ForgeEventFactory.onChunkGenerate(this, this.field_185952_n, p_185932_1_, p_185932_2_, chunkprimer);
+         if (this.field_185953_o)
+         {
+             this.field_73172_c.func_186125_a(this.field_185952_n, p_185932_1_, p_185932_2_, chunkprimer);
+@@ -277,6 +292,10 @@
              p_185938_1_ = new double[p_185938_5_ * p_185938_6_ * p_185938_7_];
          }
  
@@ -39,7 +47,7 @@
          double d0 = 684.412D;
          double d1 = 2053.236D;
          this.field_73168_g = this.field_185946_g.func_76304_a(this.field_73168_g, p_185938_2_, p_185938_3_, p_185938_4_, p_185938_5_, 1, p_185938_7_, 1.0D, 0.0D, 1.0D);
-@@ -358,6 +376,7 @@
+@@ -358,6 +377,7 @@
      public void func_185931_b(int p_185931_1_, int p_185931_2_)
      {
          BlockFalling.field_149832_M = true;
@@ -47,7 +55,7 @@
          int i = p_185931_1_ * 16;
          int j = p_185931_2_ * 16;
          BlockPos blockpos = new BlockPos(i, 0, j);
-@@ -365,16 +384,20 @@
+@@ -365,16 +385,20 @@
          ChunkPos chunkpos = new ChunkPos(p_185931_1_, p_185931_2_);
          this.field_73172_c.func_175794_a(this.field_185952_n, this.field_185954_p, chunkpos);
  
@@ -68,7 +76,7 @@
          for (int j1 = 0; j1 < this.field_185954_p.nextInt(this.field_185954_p.nextInt(10) + 1); ++j1)
          {
              this.field_177469_u.func_180709_b(this.field_185952_n, this.field_185954_p, blockpos.func_177982_a(this.field_185954_p.nextInt(16) + 8, this.field_185954_p.nextInt(120) + 4, this.field_185954_p.nextInt(16) + 8));
-@@ -384,7 +407,13 @@
+@@ -384,7 +408,13 @@
          {
              this.field_177468_v.func_180709_b(this.field_185952_n, this.field_185954_p, blockpos.func_177982_a(this.field_185954_p.nextInt(16) + 8, this.field_185954_p.nextInt(128), this.field_185954_p.nextInt(16) + 8));
          }
@@ -82,7 +90,7 @@
          if (this.field_185954_p.nextBoolean())
          {
              this.field_177471_z.func_180709_b(this.field_185952_n, this.field_185954_p, blockpos.func_177982_a(this.field_185954_p.nextInt(16) + 8, this.field_185954_p.nextInt(128), this.field_185954_p.nextInt(16) + 8));
-@@ -394,7 +423,10 @@
+@@ -394,7 +424,10 @@
          {
              this.field_177465_A.func_180709_b(this.field_185952_n, this.field_185954_p, blockpos.func_177982_a(this.field_185954_p.nextInt(16) + 8, this.field_185954_p.nextInt(128), this.field_185954_p.nextInt(16) + 8));
          }
@@ -93,7 +101,7 @@
          for (int l1 = 0; l1 < 16; ++l1)
          {
              this.field_177467_w.func_180709_b(this.field_185952_n, this.field_185954_p, blockpos.func_177982_a(this.field_185954_p.nextInt(16), this.field_185954_p.nextInt(108) + 10, this.field_185954_p.nextInt(16)));
-@@ -402,17 +434,23 @@
+@@ -402,17 +435,23 @@
  
          int i2 = this.field_185952_n.func_181545_F() / 2 + 1;
  
@@ -118,3 +126,34 @@
          BlockFalling.field_149832_M = false;
      }
  
+@@ -423,6 +462,8 @@
+ 
+     public List<Biome.SpawnListEntry> func_177458_a(EnumCreatureType p_177458_1_, BlockPos p_177458_2_)
+     {
++        net.minecraftforge.event.terraingen.ChunkGeneratorEvent.GetPossibleCreatures event = new net.minecraftforge.event.terraingen.ChunkGeneratorEvent.GetPossibleCreatures(this, field_185952_n, p_177458_1_, p_177458_2_);
++        if(net.minecraftforge.common.MinecraftForge.EVENT_BUS.post(event)) return event.getPossibleCreatures();
+         if (p_177458_1_ == EnumCreatureType.MONSTER)
+         {
+             if (this.field_73172_c.func_175795_b(p_177458_2_))
+@@ -443,16 +484,21 @@
+     @Nullable
+     public BlockPos func_180513_a(World p_180513_1_, String p_180513_2_, BlockPos p_180513_3_, boolean p_180513_4_)
+     {
++        net.minecraftforge.event.terraingen.ChunkGeneratorEvent.FindStructure event = new net.minecraftforge.event.terraingen.ChunkGeneratorEvent.FindStructure(this, p_180513_1_, p_180513_2_, p_180513_3_, p_180513_4_);
++        if(net.minecraftforge.common.MinecraftForge.EVENT_BUS.post(event)) return event.getFoundPos();
+         return "Fortress".equals(p_180513_2_) && this.field_73172_c != null ? this.field_73172_c.func_180706_b(p_180513_1_, p_180513_3_, p_180513_4_) : null;
+     }
+ 
+     public boolean func_193414_a(World p_193414_1_, String p_193414_2_, BlockPos p_193414_3_)
+     {
++        net.minecraftforge.event.terraingen.ChunkGeneratorEvent.StructureCheck event = new net.minecraftforge.event.terraingen.ChunkGeneratorEvent.StructureCheck(this, field_185952_n, p_193414_2_, p_193414_3_);
++        if(net.minecraftforge.common.MinecraftForge.EVENT_BUS.post(event)) return event.isInStructure();
+         return "Fortress".equals(p_193414_2_) && this.field_73172_c != null ? this.field_73172_c.func_175795_b(p_193414_3_) : false;
+     }
+ 
+     public void func_180514_a(Chunk p_180514_1_, int p_180514_2_, int p_180514_3_)
+     {
++        net.minecraftforge.event.ForgeEventFactory.onChunkGenerate(this, this.field_185952_n, p_180514_2_, p_180514_3_, (ChunkPrimer) null);
+         this.field_73172_c.func_186125_a(this.field_185952_n, p_180514_2_, p_180514_3_, (ChunkPrimer)null);
+     }
+ }

--- a/patches/minecraft/net/minecraft/world/gen/ChunkGeneratorOverworld.java.patch
+++ b/patches/minecraft/net/minecraft/world/gen/ChunkGeneratorOverworld.java.patch
@@ -43,16 +43,15 @@
          double d0 = 0.03125D;
          this.field_186002_u = this.field_185994_m.func_151599_a(this.field_186002_u, (double)(p_185977_1_ * 16), (double)(p_185977_2_ * 16), 16, 16, 0.0625D, 0.0625D, 1.0D);
  
-@@ -183,7 +205,7 @@
-         this.func_185976_a(p_185932_1_, p_185932_2_, chunkprimer);
+@@ -184,6 +206,7 @@
          this.field_185981_C = this.field_185995_n.func_72959_q().func_76933_b(this.field_185981_C, p_185932_1_ * 16, p_185932_2_ * 16, 16, 16);
          this.func_185977_a(p_185932_1_, p_185932_2_, chunkprimer, this.field_185981_C);
--
+ 
 +        net.minecraftforge.event.ForgeEventFactory.onChunkGenerate(this, this.field_185995_n, p_185932_1_, p_185932_2_, chunkprimer);
          if (this.field_186000_s.field_177839_r)
          {
              this.field_186003_v.func_186125_a(this.field_185995_n, p_185932_1_, p_185932_2_, chunkprimer);
-@@ -370,6 +392,8 @@
+@@ -370,6 +393,8 @@
          boolean flag = false;
          ChunkPos chunkpos = new ChunkPos(p_185931_1_, p_185931_2_);
  
@@ -61,7 +60,7 @@
          if (this.field_185996_o)
          {
              if (this.field_186000_s.field_177829_w)
-@@ -404,6 +428,7 @@
+@@ -404,6 +429,7 @@
          }
  
          if (biome != Biomes.field_76769_d && biome != Biomes.field_76786_s && this.field_186000_s.field_177781_A && !flag && this.field_185990_i.nextInt(this.field_186000_s.field_177782_B) == 0)
@@ -69,7 +68,7 @@
          {
              int i1 = this.field_185990_i.nextInt(16) + 8;
              int j1 = this.field_185990_i.nextInt(256);
-@@ -412,6 +437,7 @@
+@@ -412,6 +438,7 @@
          }
  
          if (!flag && this.field_185990_i.nextInt(this.field_186000_s.field_177777_D / 10) == 0 && this.field_186000_s.field_177783_C)
@@ -77,7 +76,7 @@
          {
              int i2 = this.field_185990_i.nextInt(16) + 8;
              int l2 = this.field_185990_i.nextInt(this.field_185990_i.nextInt(248) + 8);
-@@ -424,6 +450,7 @@
+@@ -424,6 +451,7 @@
          }
  
          if (this.field_186000_s.field_177837_s)
@@ -85,7 +84,7 @@
          {
              for (int j2 = 0; j2 < this.field_186000_s.field_177835_t; ++j2)
              {
-@@ -435,9 +462,12 @@
+@@ -435,9 +463,12 @@
          }
  
          biome.func_180624_a(this.field_185995_n, this.field_185990_i, new BlockPos(i, 0, j));
@@ -98,7 +97,7 @@
          for (int k2 = 0; k2 < 16; ++k2)
          {
              for (int j3 = 0; j3 < 16; ++j3)
-@@ -456,7 +486,10 @@
+@@ -456,7 +487,10 @@
                  }
              }
          }
@@ -109,17 +108,16 @@
          BlockFalling.field_149832_M = false;
      }
  
-@@ -475,7 +508,8 @@
-     public List<Biome.SpawnListEntry> func_177458_a(EnumCreatureType p_177458_1_, BlockPos p_177458_2_)
+@@ -476,6 +510,8 @@
      {
          Biome biome = this.field_185995_n.func_180494_b(p_177458_2_);
--
-+        net.minecraftforge.event.terraingen.ChunkGeneratorEvent.GetPossibleCreatures event=new net.minecraftforge.event.terraingen.ChunkGeneratorEvent.GetPossibleCreatures(this, field_185995_n, p_177458_1_, p_177458_2_);
+ 
++        net.minecraftforge.event.terraingen.ChunkGeneratorEvent.GetPossibleCreatures event = new net.minecraftforge.event.terraingen.ChunkGeneratorEvent.GetPossibleCreatures(this, field_185995_n, p_177458_1_, p_177458_2_);
 +        if(net.minecraftforge.common.MinecraftForge.EVENT_BUS.post(event)) return event.getPossibleCreatures();
          if (this.field_185996_o)
          {
              if (p_177458_1_ == EnumCreatureType.MONSTER && this.field_186007_z.func_175798_a(p_177458_2_))
-@@ -494,6 +528,8 @@
+@@ -494,6 +530,8 @@
  
      public boolean func_193414_a(World p_193414_1_, String p_193414_2_, BlockPos p_193414_3_)
      {
@@ -128,7 +126,7 @@
          if (!this.field_185996_o)
          {
              return false;
-@@ -527,6 +563,8 @@
+@@ -527,6 +565,8 @@
      @Nullable
      public BlockPos func_180513_a(World p_180513_1_, String p_180513_2_, BlockPos p_180513_3_, boolean p_180513_4_)
      {
@@ -137,7 +135,7 @@
          if (!this.field_185996_o)
          {
              return null;
-@@ -559,6 +597,7 @@
+@@ -559,6 +599,7 @@
  
      public void func_180514_a(Chunk p_180514_1_, int p_180514_2_, int p_180514_3_)
      {

--- a/patches/minecraft/net/minecraft/world/gen/ChunkGeneratorOverworld.java.patch
+++ b/patches/minecraft/net/minecraft/world/gen/ChunkGeneratorOverworld.java.patch
@@ -43,6 +43,15 @@
          double d0 = 0.03125D;
          this.field_186002_u = this.field_185994_m.func_151599_a(this.field_186002_u, (double)(p_185977_1_ * 16), (double)(p_185977_2_ * 16), 16, 16, 0.0625D, 0.0625D, 1.0D);
  
+@@ -183,7 +205,7 @@
+         this.func_185976_a(p_185932_1_, p_185932_2_, chunkprimer);
+         this.field_185981_C = this.field_185995_n.func_72959_q().func_76933_b(this.field_185981_C, p_185932_1_ * 16, p_185932_2_ * 16, 16, 16);
+         this.func_185977_a(p_185932_1_, p_185932_2_, chunkprimer, this.field_185981_C);
+-
++        net.minecraftforge.event.ForgeEventFactory.onChunkGenerate(this, this.field_185995_n, p_185932_1_, p_185932_2_, chunkprimer);
+         if (this.field_186000_s.field_177839_r)
+         {
+             this.field_186003_v.func_186125_a(this.field_185995_n, p_185932_1_, p_185932_2_, chunkprimer);
 @@ -370,6 +392,8 @@
          boolean flag = false;
          ChunkPos chunkpos = new ChunkPos(p_185931_1_, p_185931_2_);
@@ -100,3 +109,39 @@
          BlockFalling.field_149832_M = false;
      }
  
+@@ -475,7 +508,8 @@
+     public List<Biome.SpawnListEntry> func_177458_a(EnumCreatureType p_177458_1_, BlockPos p_177458_2_)
+     {
+         Biome biome = this.field_185995_n.func_180494_b(p_177458_2_);
+-
++        net.minecraftforge.event.terraingen.ChunkGeneratorEvent.GetPossibleCreatures event=new net.minecraftforge.event.terraingen.ChunkGeneratorEvent.GetPossibleCreatures(this, field_185995_n, p_177458_1_, p_177458_2_);
++        if(net.minecraftforge.common.MinecraftForge.EVENT_BUS.post(event)) return event.getPossibleCreatures();
+         if (this.field_185996_o)
+         {
+             if (p_177458_1_ == EnumCreatureType.MONSTER && this.field_186007_z.func_175798_a(p_177458_2_))
+@@ -494,6 +528,8 @@
+ 
+     public boolean func_193414_a(World p_193414_1_, String p_193414_2_, BlockPos p_193414_3_)
+     {
++        net.minecraftforge.event.terraingen.ChunkGeneratorEvent.StructureCheck event = new net.minecraftforge.event.terraingen.ChunkGeneratorEvent.StructureCheck(this, field_185995_n, p_193414_2_, p_193414_3_);
++        if(net.minecraftforge.common.MinecraftForge.EVENT_BUS.post(event)) return event.isInStructure();
+         if (!this.field_185996_o)
+         {
+             return false;
+@@ -527,6 +563,8 @@
+     @Nullable
+     public BlockPos func_180513_a(World p_180513_1_, String p_180513_2_, BlockPos p_180513_3_, boolean p_180513_4_)
+     {
++        net.minecraftforge.event.terraingen.ChunkGeneratorEvent.FindStructure event = new net.minecraftforge.event.terraingen.ChunkGeneratorEvent.FindStructure(this, p_180513_1_, p_180513_2_, p_180513_3_, p_180513_4_);
++        if(net.minecraftforge.common.MinecraftForge.EVENT_BUS.post(event)) return event.getFoundPos();
+         if (!this.field_185996_o)
+         {
+             return null;
+@@ -559,6 +597,7 @@
+ 
+     public void func_180514_a(Chunk p_180514_1_, int p_180514_2_, int p_180514_3_)
+     {
++        net.minecraftforge.event.ForgeEventFactory.onChunkGenerate(this, this.field_185995_n, p_180514_2_, p_180514_3_, (ChunkPrimer) null);
+         if (this.field_185996_o)
+         {
+             if (this.field_186000_s.field_177829_w)

--- a/src/main/java/net/minecraftforge/event/ForgeEventFactory.java
+++ b/src/main/java/net/minecraftforge/event/ForgeEventFactory.java
@@ -683,6 +683,12 @@ public class ForgeEventFactory
         MinecraftForge.EVENT_BUS.post(pre ? new PopulateChunkEvent.Pre(gen, world, rand, x, z, hasVillageGenerated) : new PopulateChunkEvent.Post(gen, world, rand, x, z, hasVillageGenerated));
     }
 
+    public static void onChunkGenerate(IChunkGenerator gen, World world, int x, int z, ChunkPrimer primer)
+    {
+        MinecraftForge.EVENT_BUS.post(new ChunkGeneratorEvent.Generate(gen,world,x,z,primer));
+    }
+
+
     public static LootTable loadLootTable(ResourceLocation name, LootTable table, LootTableManager lootTableManager)
     {
         LootTableLoadEvent event = new LootTableLoadEvent(name, table, lootTableManager);

--- a/src/main/java/net/minecraftforge/event/ForgeEventFactory.java
+++ b/src/main/java/net/minecraftforge/event/ForgeEventFactory.java
@@ -688,7 +688,6 @@ public class ForgeEventFactory
         MinecraftForge.EVENT_BUS.post(new ChunkGeneratorEvent.Generate(gen, world, x, z, primer));
     }
 
-
     public static LootTable loadLootTable(ResourceLocation name, LootTable table, LootTableManager lootTableManager)
     {
         LootTableLoadEvent event = new LootTableLoadEvent(name, table, lootTableManager);

--- a/src/main/java/net/minecraftforge/event/ForgeEventFactory.java
+++ b/src/main/java/net/minecraftforge/event/ForgeEventFactory.java
@@ -685,7 +685,7 @@ public class ForgeEventFactory
 
     public static void onChunkGenerate(IChunkGenerator gen, World world, int x, int z, ChunkPrimer primer)
     {
-        MinecraftForge.EVENT_BUS.post(new ChunkGeneratorEvent.Generate(gen,world,x,z,primer));
+        MinecraftForge.EVENT_BUS.post(new ChunkGeneratorEvent.Generate(gen, world, x, z, primer));
     }
 
 

--- a/src/main/java/net/minecraftforge/event/terraingen/ChunkGeneratorEvent.java
+++ b/src/main/java/net/minecraftforge/event/terraingen/ChunkGeneratorEvent.java
@@ -19,10 +19,18 @@
 
 package net.minecraftforge.event.terraingen;
 
+import com.google.common.collect.Lists;
+import net.minecraft.entity.EnumCreatureType;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.biome.Biome;
+import net.minecraftforge.fml.common.eventhandler.Cancelable;
 import net.minecraftforge.fml.common.eventhandler.Event;
 import net.minecraft.world.World;
 import net.minecraft.world.chunk.ChunkPrimer;
 import net.minecraft.world.gen.IChunkGenerator;
+
+import javax.annotation.Nullable;
+import java.util.List;
 
 public class ChunkGeneratorEvent extends Event
 {
@@ -106,4 +114,200 @@ public class ChunkGeneratorEvent extends Event
         public int getSizeY() { return sizeY; }
         public int getSizeZ() { return sizeZ; }
     }
+
+    /**
+     * This event is fired during chunk generation as well as structure regeneration before any of the vanilla structure gens are executed.
+     * If fired during recreateStructures the chunkprimer will be null
+     * This event is fired regardless of mapFeaturesEnabled.
+     */
+    public static class Generate extends ChunkGeneratorEvent
+    {
+        private final World world;
+        private final @Nullable ChunkPrimer primer;
+        private final int x, z;
+
+        public World getWorld()
+        {
+            return world;
+        }
+
+        public @Nullable ChunkPrimer getPrimer()
+        {
+            return primer;
+        }
+
+        public int getX()
+        {
+            return x;
+        }
+
+        public int getZ()
+        {
+            return z;
+        }
+
+        public Generate(IChunkGenerator gen, World world, int x, int z, @Nullable ChunkPrimer primer)
+        {
+            super(gen);
+            this.world = world;
+            this.x = x;
+            this.z = z;
+            this.primer = primer;
+        }
+    }
+
+    /**
+     * This event is fired when the chunk generator is ask for a list of possible creatures for a specific location.
+     * (Vanilla checks if there is a structure which wants to spawn special creatures at the location.
+     * <p>
+     * To return your own spawn entries, add them to the list and cancel this event.
+     */
+    @Cancelable
+    public static class GetPossibleCreatures extends ChunkGeneratorEvent
+    {
+        private final EnumCreatureType creatureType;
+        private final List<Biome.SpawnListEntry> possibleCreatures;
+
+        public World getWorld()
+        {
+            return world;
+        }
+
+        private final World world;
+
+        public EnumCreatureType getCreatureType()
+        {
+            return creatureType;
+        }
+
+        public BlockPos getPos()
+        {
+            return pos;
+        }
+
+        private final BlockPos pos;
+
+        public GetPossibleCreatures(IChunkGenerator gen, World world, EnumCreatureType creatureType, BlockPos pos)
+        {
+            super(gen);
+            this.creatureType = creatureType;
+            this.pos = pos;
+            this.world = world;
+            possibleCreatures = Lists.newArrayList();
+        }
+
+        public List<Biome.SpawnListEntry> getPossibleCreatures()
+        {
+            return possibleCreatures;
+        }
+
+    }
+
+    /**
+     * This event is fired if the chunk generator is asked if there is a structure at a specific location.
+     * <p>
+     * To return your own value set isInStructure and cancel this event.
+     */
+    @Cancelable
+    public static class StructureCheck extends ChunkGeneratorEvent
+    {
+        public World getWorldIn()
+        {
+            return worldIn;
+        }
+
+        public String getStructureName()
+        {
+            return structureName;
+        }
+
+        public BlockPos getPos()
+        {
+            return pos;
+        }
+
+        private final World worldIn;
+        private final String structureName;
+        private final BlockPos pos;
+
+        public void setInStructure(boolean inStructure)
+        {
+            this.inStructure = inStructure;
+        }
+
+        private boolean inStructure;
+
+        public StructureCheck(IChunkGenerator gen, World worldIn, String structureName, BlockPos pos)
+        {
+            super(gen);
+            this.worldIn = worldIn;
+            this.structureName = structureName;
+            this.pos = pos;
+            inStructure = false;
+        }
+
+        public boolean isInStructure()
+        {
+            return inStructure;
+        }
+    }
+
+    /**
+     * This event is fired if the chunk generator is asked for a nearby structure.
+     * <p>
+     * To return your own location set the found pos and cancel this event.
+     */
+    @Cancelable
+    public static class FindStructure extends ChunkGeneratorEvent
+    {
+        public World getWorldIn()
+        {
+            return worldIn;
+        }
+
+        public String getStructureName()
+        {
+            return structureName;
+        }
+
+        public BlockPos getPos()
+        {
+            return pos;
+        }
+
+        private final World worldIn;
+        private final String structureName;
+        private final BlockPos pos;
+
+        @Nullable
+        private BlockPos foundPos;
+
+        public boolean isFindUnexplored()
+        {
+            return findUnexplored;
+        }
+
+        private final boolean findUnexplored;
+
+        public FindStructure(IChunkGenerator gen, World worldIn, String structureName, BlockPos pos, boolean findUnexplored)
+        {
+            super(gen);
+            this.worldIn = worldIn;
+            this.structureName = structureName;
+            this.pos = pos;
+            this.findUnexplored = findUnexplored;
+            foundPos = null;
+        }
+
+        @Nullable public BlockPos getFoundPos()
+        {
+            return foundPos;
+        }
+
+        public void setFoundPos(@Nullable BlockPos foundPos)
+        {
+            this.foundPos = foundPos;
+        }
+    }
+
 }

--- a/src/main/java/net/minecraftforge/event/terraingen/ChunkGeneratorEvent.java
+++ b/src/main/java/net/minecraftforge/event/terraingen/ChunkGeneratorEvent.java
@@ -126,6 +126,15 @@ public class ChunkGeneratorEvent extends Event
         private final @Nullable ChunkPrimer primer;
         private final int x, z;
 
+        public Generate(IChunkGenerator gen, World world, int x, int z, @Nullable ChunkPrimer primer)
+        {
+            super(gen);
+            this.world = world;
+            this.x = x;
+            this.z = z;
+            this.primer = primer;
+        }
+
         public World getWorld()
         {
             return world;
@@ -145,20 +154,11 @@ public class ChunkGeneratorEvent extends Event
         {
             return z;
         }
-
-        public Generate(IChunkGenerator gen, World world, int x, int z, @Nullable ChunkPrimer primer)
-        {
-            super(gen);
-            this.world = world;
-            this.x = x;
-            this.z = z;
-            this.primer = primer;
-        }
     }
 
     /**
-     * This event is fired when the chunk generator is ask for a list of possible creatures for a specific location.
-     * (Vanilla checks if there is a structure which wants to spawn special creatures at the location.
+     * This event is fired when the chunk generator is asked for a list of possible creatures for a specific location.
+     * (Vanilla checks if there is a structure which wants to spawn special creatures at the location)
      * <p>
      * To return your own spawn entries, add them to the list and cancel this event.
      */
@@ -167,24 +167,7 @@ public class ChunkGeneratorEvent extends Event
     {
         private final EnumCreatureType creatureType;
         private final List<Biome.SpawnListEntry> possibleCreatures;
-
-        public World getWorld()
-        {
-            return world;
-        }
-
         private final World world;
-
-        public EnumCreatureType getCreatureType()
-        {
-            return creatureType;
-        }
-
-        public BlockPos getPos()
-        {
-            return pos;
-        }
-
         private final BlockPos pos;
 
         public GetPossibleCreatures(IChunkGenerator gen, World world, EnumCreatureType creatureType, BlockPos pos)
@@ -194,6 +177,21 @@ public class ChunkGeneratorEvent extends Event
             this.pos = pos;
             this.world = world;
             possibleCreatures = Lists.newArrayList();
+        }
+
+        public World getWorld()
+        {
+            return world;
+        }
+
+        public EnumCreatureType getCreatureType()
+        {
+            return creatureType;
+        }
+
+        public BlockPos getPos()
+        {
+            return pos;
         }
 
         public List<Biome.SpawnListEntry> getPossibleCreatures()
@@ -211,30 +209,9 @@ public class ChunkGeneratorEvent extends Event
     @Cancelable
     public static class StructureCheck extends ChunkGeneratorEvent
     {
-        public World getWorldIn()
-        {
-            return worldIn;
-        }
-
-        public String getStructureName()
-        {
-            return structureName;
-        }
-
-        public BlockPos getPos()
-        {
-            return pos;
-        }
-
         private final World worldIn;
         private final String structureName;
         private final BlockPos pos;
-
-        public void setInStructure(boolean inStructure)
-        {
-            this.inStructure = inStructure;
-        }
-
         private boolean inStructure;
 
         public StructureCheck(IChunkGenerator gen, World worldIn, String structureName, BlockPos pos)
@@ -246,20 +223,6 @@ public class ChunkGeneratorEvent extends Event
             inStructure = false;
         }
 
-        public boolean isInStructure()
-        {
-            return inStructure;
-        }
-    }
-
-    /**
-     * This event is fired if the chunk generator is asked for a nearby structure.
-     * <p>
-     * To return your own location set the found pos and cancel this event.
-     */
-    @Cancelable
-    public static class FindStructure extends ChunkGeneratorEvent
-    {
         public World getWorldIn()
         {
             return worldIn;
@@ -275,19 +238,31 @@ public class ChunkGeneratorEvent extends Event
             return pos;
         }
 
+        public boolean isInStructure()
+        {
+            return inStructure;
+        }
+
+        public void setInStructure(boolean inStructure)
+        {
+            this.inStructure = inStructure;
+        }
+    }
+
+    /**
+     * This event is fired if the chunk generator is asked for a nearby structure.
+     * <p>
+     * To return your own location set the found pos and cancel this event.
+     */
+    @Cancelable
+    public static class FindStructure extends ChunkGeneratorEvent
+    {
         private final World worldIn;
         private final String structureName;
         private final BlockPos pos;
-
+        private final boolean findUnexplored;
         @Nullable
         private BlockPos foundPos;
-
-        public boolean isFindUnexplored()
-        {
-            return findUnexplored;
-        }
-
-        private final boolean findUnexplored;
 
         public FindStructure(IChunkGenerator gen, World worldIn, String structureName, BlockPos pos, boolean findUnexplored)
         {
@@ -297,6 +272,26 @@ public class ChunkGeneratorEvent extends Event
             this.pos = pos;
             this.findUnexplored = findUnexplored;
             foundPos = null;
+        }
+
+        public World getWorldIn()
+        {
+            return worldIn;
+        }
+
+        public String getStructureName()
+        {
+            return structureName;
+        }
+
+        public BlockPos getPos()
+        {
+            return pos;
+        }
+
+        public boolean isFindUnexplored()
+        {
+            return findUnexplored;
         }
 
         @Nullable public BlockPos getFoundPos()


### PR DESCRIPTION
## What:
This simple PR adds several new events to the ChunkGeneratorOverworld.
_Generate_
_FindStructure_ (allows  returning a  custom result)
_StructureCheck_ (allows returning a custom result)
_GetPossibleCreatures_ (allows returning a custom result)

## Why
Currently it is quite time consuming and not nicely (without hacky code) possible to add structures similar to the Vanilla ones (villages, temples, igloos ...) to the standard Overworld.
It is possible to this with a custom chunk generator (in a custom dimension), but not every mod wants to add it's one dimension.

With these events it is possible to create generated structures on the same quality level as Vanilla ones. This also allows to built on top of the solid Vanilla methods and avoids duplicate code.
This includes support for custom spawn entries inside structures and inside structure/find structure checks (allowing location based achievements as well as simple villager trades for a treasure map.

## Test(mod)
I did not create a debug/test mod as I would think it is not really worth it for simple events. Also I think it is quite difficult to properly (automatically) check for success. I could add some simple test(commands), but those would have to be manually verified.
Creating a test with actual generation not practicable I think.
Let me know what you think.

Outside of Forge (in a mod of mine, [commit](https://github.com/TeamLapen/Vampirism/commit/a07388790df54a6c0bba8373b8fc1665a7e71cf5)) I have verified that these events work and allow what they are intended for.

## Notes/Things to discuss

- Names. Pls let me know if you come up with a better naming for the events
- Support for Nether/End as well? Would probably be reasonable. **Edit**: Added
- Create a seperate event for recreateStructures instead of using Generate with a null ChunkPrimer
- Position of events. Currently they are thrown regardless of mapGenFeaturesEnabled, so modders have to check/decide on their own
- To avoid all these events it would also be possible to add some way to register MapGenStructure events to the ChunkGenerator, but this would require larger patches
- Patch style (Newline or not) 
- Should I reduce the line count of the events by skipping some newlines similar to the the existing Populate event (at least in IntelliJ they are shorted anyway)
- Support for vanilla locate command? Probably not worth the patch as mods can simply add their own