### PR TITLE
Fix BlockDynamicLiquid using mismatched state/position pair

### DIFF
--- a/patches/minecraft/net/minecraft/block/BlockDynamicLiquid.java.patch
+++ b/patches/minecraft/net/minecraft/block/BlockDynamicLiquid.java.patch
@@ -17,6 +17,15 @@
                      p_176375_3_.func_177230_c().func_176226_b(p_176375_1_, p_176375_2_, p_176375_3_, 0);
                  }
              }
+@@ -187,7 +188,7 @@
+ 
+                 if (!this.func_176372_g(p_176374_1_, blockpos, iblockstate) && (iblockstate.func_185904_a() != this.field_149764_J || ((Integer)iblockstate.func_177229_b(field_176367_b)).intValue() > 0))
+                 {
+-                    if (!this.func_176372_g(p_176374_1_, blockpos.func_177977_b(), iblockstate))
++                    if (!this.func_176372_g(p_176374_1_, blockpos.func_177977_b(), p_176374_1_.func_180495_p(blockpos.func_177977_b())))
+                     {
+                         return p_176374_3_;
+                     }
 @@ -254,11 +255,12 @@
  
      private boolean func_176372_g(World p_176372_1_, BlockPos p_176372_2_, IBlockState p_176372_3_)


### PR DESCRIPTION
Fixes #4499.

57e6559fa4da168e22df807e4cb5f4de688ab886 changed `isBlocked` to use the provided state, rather than looking it up from the world (see [here](https://github.com/MinecraftForge/MinecraftForge/commit/57e6559fa4da168e22df807e4cb5f4de688ab886#diff-749f031b38c923daee9ddc76373449b2R25)).

As the comment there notes, this requires the state to be correct for the given position.

This PR patches `getSlopeDistance` to ensure that this is the case, as it currently is not. (Currently it passes the state at `blockpos`, but `blockpos.down()` as the position)

The other calls to `isBlocked` all pass a matching state/position pair, so this does seem to be a vanilla bug. As the vanilla code always fetches the state from the world at the given position, the state parameter is unused, which means there's no intentional behaviour a mismatched state could be used for here.