### PR TITLE
Implemented LivingKnockBackEvent event and hook

### DIFF
--- a/patches/minecraft/net/minecraft/entity/EntityLivingBase.java.patch
+++ b/patches/minecraft/net/minecraft/entity/EntityLivingBase.java.patch
@@ -24,27 +24,15 @@
  import net.minecraft.advancements.CriteriaTriggers;
  import net.minecraft.block.Block;
  import net.minecraft.block.BlockLadder;
-@@ -28,7 +34,6 @@
- import net.minecraft.entity.item.EntityItem;
- import net.minecraft.entity.item.EntityXPOrb;
- import net.minecraft.entity.passive.AbstractHorse;
--import net.minecraft.entity.passive.EntityWolf;
- import net.minecraft.entity.player.EntityPlayer;
- import net.minecraft.entity.player.EntityPlayerMP;
- import net.minecraft.entity.projectile.EntityArrow;
-@@ -72,10 +77,9 @@
+@@ -72,6 +78,7 @@
  import net.minecraft.util.math.Vec3d;
  import net.minecraft.world.World;
  import net.minecraft.world.WorldServer;
 +import net.minecraftforge.event.entity.living.LivingKnockBackEvent;
  import net.minecraftforge.fml.relauncher.Side;
  import net.minecraftforge.fml.relauncher.SideOnly;
--import org.apache.logging.log4j.LogManager;
--import org.apache.logging.log4j.Logger;
- 
- public abstract class EntityLivingBase extends Entity
- {
-@@ -201,10 +205,11 @@
+ import org.apache.logging.log4j.LogManager;
+@@ -201,10 +208,11 @@
          {
              float f = (float)MathHelper.func_76123_f(this.field_70143_R - 3.0F);
  
@@ -57,7 +45,7 @@
                  ((WorldServer)this.field_70170_p).func_175739_a(EnumParticleTypes.BLOCK_DUST, this.field_70165_t, this.field_70163_u, this.field_70161_v, i, 0.0D, 0.0D, 0.0D, 0.15000000596046448D, Block.func_176210_f(p_184231_4_));
              }
          }
-@@ -281,7 +286,7 @@
+@@ -281,7 +289,7 @@
                      }
                  }
  
@@ -66,7 +54,7 @@
                  {
                      this.func_184210_p();
                  }
-@@ -380,7 +385,7 @@
+@@ -380,7 +388,7 @@
              if (!this.field_70170_p.field_72995_K && (this.func_70684_aJ() || this.field_70718_bc > 0 && this.func_146066_aG() && this.field_70170_p.func_82736_K().func_82766_b("doMobLoot")))
              {
                  int i = this.func_70693_a(this.field_70717_bb);
@@ -75,7 +63,7 @@
                  while (i > 0)
                  {
                      int j = EntityXPOrb.func_70527_a(i);
-@@ -442,6 +447,7 @@
+@@ -442,6 +450,7 @@
      {
          this.field_70755_b = p_70604_1_;
          this.field_70756_c = this.field_70173_aa;
@@ -83,7 +71,7 @@
      }
  
      public EntityLivingBase func_110144_aD()
-@@ -670,8 +676,10 @@
+@@ -670,8 +679,10 @@
          else
          {
              Collection<PotionEffect> collection = this.field_70713_bf.values();
@@ -96,7 +84,7 @@
              this.func_82142_c(this.func_70644_a(MobEffects.field_76441_p));
          }
      }
-@@ -819,6 +827,8 @@
+@@ -819,6 +830,8 @@
  
      public void func_70691_i(float p_70691_1_)
      {
@@ -105,7 +93,7 @@
          float f = this.func_110143_aJ();
  
          if (f > 0.0F)
-@@ -839,6 +849,7 @@
+@@ -839,6 +852,7 @@
  
      public boolean func_70097_a(DamageSource p_70097_1_, float p_70097_2_)
      {
@@ -113,7 +101,7 @@
          if (this.func_180431_b(p_70097_1_))
          {
              return false;
-@@ -927,9 +938,9 @@
+@@ -927,9 +941,9 @@
                          this.field_70718_bc = 100;
                          this.field_70717_bb = (EntityPlayer)entity1;
                      }
@@ -125,7 +113,7 @@
  
                          if (entitywolf.func_70909_n())
                          {
-@@ -1127,7 +1138,7 @@
+@@ -1127,7 +1141,7 @@
  
      public void func_70669_a(ItemStack p_70669_1_)
      {
@@ -134,7 +122,7 @@
  
          for (int i = 0; i < 5; ++i)
          {
-@@ -1139,12 +1150,17 @@
+@@ -1139,12 +1153,17 @@
              vec3d1 = vec3d1.func_178789_a(-this.field_70125_A * 0.017453292F);
              vec3d1 = vec3d1.func_178785_b(-this.field_70177_z * 0.017453292F);
              vec3d1 = vec3d1.func_72441_c(this.field_70165_t, this.field_70163_u + (double)this.func_70047_e(), this.field_70161_v);
@@ -153,7 +141,7 @@
          if (!this.field_70729_aU)
          {
              Entity entity = p_70645_1_.func_76346_g();
-@@ -1165,18 +1181,26 @@
+@@ -1165,18 +1184,26 @@
  
              if (!this.field_70170_p.field_72995_K)
              {
@@ -185,12 +173,12 @@
              }
  
              this.field_70170_p.func_72960_a(this, (byte)3);
-@@ -1195,19 +1219,21 @@
+@@ -1195,19 +1222,21 @@
  
      public void func_70653_a(Entity p_70653_1_, float p_70653_2_, double p_70653_3_, double p_70653_5_)
      {
-+    	LivingKnockBackEvent event = new LivingKnockBackEvent(this, p_70653_1_, p_70653_2_, p_70653_3_, p_70653_5_);
-+    	if (!net.minecraftforge.common.ForgeHooks.onLivingKnockBack(event)) return;
++        LivingKnockBackEvent event = new LivingKnockBackEvent(this, p_70653_1_, p_70653_2_, p_70653_3_, p_70653_5_);
++        if (net.minecraftforge.common.ForgeHooks.onLivingKnockBack(event)) return;
          if (this.field_70146_Z.nextDouble() >= this.func_110148_a(SharedMonsterAttributes.field_111266_c).func_111126_e())
          {
              this.field_70160_al = true;
@@ -211,7 +199,7 @@
  
                  if (this.field_70181_x > 0.4000000059604645D)
                  {
-@@ -1253,15 +1279,7 @@
+@@ -1253,15 +1282,7 @@
              BlockPos blockpos = new BlockPos(i, j, k);
              IBlockState iblockstate = this.field_70170_p.func_180495_p(blockpos);
              Block block = iblockstate.func_177230_c();
@@ -228,7 +216,7 @@
          }
      }
  
-@@ -1287,6 +1305,9 @@
+@@ -1287,6 +1308,9 @@
  
      public void func_180430_e(float p_180430_1_, float p_180430_2_)
      {
@@ -238,7 +226,7 @@
          super.func_180430_e(p_180430_1_, p_180430_2_);
          PotionEffect potioneffect = this.func_70660_b(MobEffects.field_76430_j);
          float f = potioneffect == null ? 0.0F : (float)(potioneffect.func_76458_c() + 1);
-@@ -1303,7 +1324,7 @@
+@@ -1303,7 +1327,7 @@
  
              if (iblockstate.func_185904_a() != Material.field_151579_a)
              {
@@ -247,7 +235,7 @@
                  this.func_184185_a(soundtype.func_185842_g(), soundtype.func_185843_a() * 0.5F, soundtype.func_185847_b() * 0.75F);
              }
          }
-@@ -1380,17 +1401,20 @@
+@@ -1380,17 +1404,20 @@
      {
          if (!this.func_180431_b(p_70665_1_))
          {
@@ -269,7 +257,7 @@
                  this.func_110149_m(this.func_110139_bj() - p_70665_2_);
              }
          }
-@@ -1447,6 +1471,11 @@
+@@ -1447,6 +1474,11 @@
  
      public void func_184609_a(EnumHand p_184609_1_)
      {
@@ -281,7 +269,7 @@
          if (!this.field_82175_bq || this.field_110158_av >= this.func_82166_i() / 2 || this.field_110158_av < 0)
          {
              this.field_110158_av = -1;
-@@ -1694,7 +1723,7 @@
+@@ -1694,7 +1726,7 @@
  
                      if (!this.field_70170_p.func_184143_b(axisalignedbb1))
                      {
@@ -290,7 +278,7 @@
                          {
                              this.func_70634_a(d11, this.field_70163_u + 1.0D, d12);
                              return;
-@@ -1702,14 +1731,14 @@
+@@ -1702,14 +1734,14 @@
  
                          BlockPos blockpos = new BlockPos(d11, this.field_70163_u - 1.0D, d12);
  
@@ -307,7 +295,7 @@
                      {
                          d1 = d11;
                          d13 = this.field_70163_u + 2.0D;
-@@ -1781,6 +1810,7 @@
+@@ -1781,6 +1813,7 @@
          }
  
          this.field_70160_al = true;
@@ -315,7 +303,7 @@
      }
  
      protected void func_70629_bd()
-@@ -1874,7 +1904,8 @@
+@@ -1874,7 +1907,8 @@
  
                          if (this.field_70122_E)
                          {
@@ -325,7 +313,7 @@
                          }
  
                          float f7 = 0.16277136F / (f6 * f6 * f6);
-@@ -1894,7 +1925,8 @@
+@@ -1894,7 +1928,8 @@
  
                          if (this.field_70122_E)
                          {
@@ -335,7 +323,7 @@
                          }
  
                          if (this.func_70617_f_())
-@@ -2054,6 +2086,7 @@
+@@ -2054,6 +2089,7 @@
  
      public void func_70071_h_()
      {
@@ -343,7 +331,7 @@
          super.func_70071_h_();
          this.func_184608_ct();
  
-@@ -2096,7 +2129,9 @@
+@@ -2096,7 +2132,9 @@
  
                  if (!ItemStack.func_77989_b(itemstack1, itemstack))
                  {
@@ -353,7 +341,7 @@
  
                      if (!itemstack.func_190926_b())
                      {
-@@ -2575,6 +2610,40 @@
+@@ -2575,6 +2613,40 @@
          this.field_70752_e = true;
      }
  
@@ -394,7 +382,7 @@
      public abstract EnumHandSide func_184591_cq();
  
      public boolean func_184587_cr()
-@@ -2595,12 +2664,19 @@
+@@ -2595,12 +2667,19 @@
  
              if (itemstack == this.field_184627_bm)
              {
@@ -415,7 +403,7 @@
                  {
                      this.func_71036_o();
                  }
-@@ -2618,8 +2694,10 @@
+@@ -2618,8 +2697,10 @@
  
          if (!itemstack.func_190926_b() && !this.func_184587_cr())
          {
@@ -427,7 +415,7 @@
  
              if (!this.field_70170_p.field_72995_K)
              {
-@@ -2700,7 +2778,9 @@
+@@ -2700,7 +2781,9 @@
          if (!this.field_184627_bm.func_190926_b() && this.func_184587_cr())
          {
              this.func_184584_a(this.field_184627_bm, 16);
@@ -438,7 +426,7 @@
              this.func_184602_cy();
          }
      }
-@@ -2724,7 +2804,8 @@
+@@ -2724,7 +2807,8 @@
      {
          if (!this.field_184627_bm.func_190926_b())
          {
@@ -448,7 +436,7 @@
          }
  
          this.func_184602_cy();
-@@ -2852,6 +2933,31 @@
+@@ -2852,6 +2936,31 @@
          return true;
      }
  

--- a/patches/minecraft/net/minecraft/entity/EntityLivingBase.java.patch
+++ b/patches/minecraft/net/minecraft/entity/EntityLivingBase.java.patch
@@ -1,39 +1,6 @@
 --- ../src-base/minecraft/net/minecraft/entity/EntityLivingBase.java
 +++ ../src-work/minecraft/net/minecraft/entity/EntityLivingBase.java
-@@ -1,7 +1,5 @@
- package net.minecraft.entity;
- 
--import com.google.common.base.Objects;
--import com.google.common.collect.Maps;
- import java.util.Collection;
- import java.util.ConcurrentModificationException;
- import java.util.Iterator;
-@@ -9,7 +7,15 @@
- import java.util.Map;
- import java.util.Random;
- import java.util.UUID;
-+
- import javax.annotation.Nullable;
-+
-+import org.apache.logging.log4j.LogManager;
-+import org.apache.logging.log4j.Logger;
-+
-+import com.google.common.base.Objects;
-+import com.google.common.collect.Maps;
-+
- import net.minecraft.advancements.CriteriaTriggers;
- import net.minecraft.block.Block;
- import net.minecraft.block.BlockLadder;
-@@ -74,8 +80,6 @@
- import net.minecraft.world.WorldServer;
- import net.minecraftforge.fml.relauncher.Side;
- import net.minecraftforge.fml.relauncher.SideOnly;
--import org.apache.logging.log4j.LogManager;
--import org.apache.logging.log4j.Logger;
- 
- public abstract class EntityLivingBase extends Entity
- {
-@@ -201,10 +205,11 @@
+@@ -201,10 +201,11 @@
          {
              float f = (float)MathHelper.func_76123_f(this.field_70143_R - 3.0F);
  
@@ -46,7 +13,7 @@
                  ((WorldServer)this.field_70170_p).func_175739_a(EnumParticleTypes.BLOCK_DUST, this.field_70165_t, this.field_70163_u, this.field_70161_v, i, 0.0D, 0.0D, 0.0D, 0.15000000596046448D, Block.func_176210_f(p_184231_4_));
              }
          }
-@@ -281,7 +286,7 @@
+@@ -281,7 +282,7 @@
                      }
                  }
  
@@ -55,7 +22,7 @@
                  {
                      this.func_184210_p();
                  }
-@@ -380,7 +385,7 @@
+@@ -380,7 +381,7 @@
              if (!this.field_70170_p.field_72995_K && (this.func_70684_aJ() || this.field_70718_bc > 0 && this.func_146066_aG() && this.field_70170_p.func_82736_K().func_82766_b("doMobLoot")))
              {
                  int i = this.func_70693_a(this.field_70717_bb);
@@ -64,7 +31,7 @@
                  while (i > 0)
                  {
                      int j = EntityXPOrb.func_70527_a(i);
-@@ -442,6 +447,7 @@
+@@ -442,6 +443,7 @@
      {
          this.field_70755_b = p_70604_1_;
          this.field_70756_c = this.field_70173_aa;
@@ -72,7 +39,7 @@
      }
  
      public EntityLivingBase func_110144_aD()
-@@ -670,8 +676,10 @@
+@@ -670,8 +672,10 @@
          else
          {
              Collection<PotionEffect> collection = this.field_70713_bf.values();
@@ -85,7 +52,7 @@
              this.func_82142_c(this.func_70644_a(MobEffects.field_76441_p));
          }
      }
-@@ -819,6 +827,8 @@
+@@ -819,6 +823,8 @@
  
      public void func_70691_i(float p_70691_1_)
      {
@@ -94,7 +61,7 @@
          float f = this.func_110143_aJ();
  
          if (f > 0.0F)
-@@ -839,6 +849,7 @@
+@@ -839,6 +845,7 @@
  
      public boolean func_70097_a(DamageSource p_70097_1_, float p_70097_2_)
      {
@@ -102,7 +69,7 @@
          if (this.func_180431_b(p_70097_1_))
          {
              return false;
-@@ -927,9 +938,9 @@
+@@ -927,9 +934,9 @@
                          this.field_70718_bc = 100;
                          this.field_70717_bb = (EntityPlayer)entity1;
                      }
@@ -114,7 +81,7 @@
  
                          if (entitywolf.func_70909_n())
                          {
-@@ -1127,7 +1138,7 @@
+@@ -1127,7 +1134,7 @@
  
      public void func_70669_a(ItemStack p_70669_1_)
      {
@@ -123,7 +90,7 @@
  
          for (int i = 0; i < 5; ++i)
          {
-@@ -1139,12 +1150,17 @@
+@@ -1139,12 +1146,17 @@
              vec3d1 = vec3d1.func_178789_a(-this.field_70125_A * 0.017453292F);
              vec3d1 = vec3d1.func_178785_b(-this.field_70177_z * 0.017453292F);
              vec3d1 = vec3d1.func_72441_c(this.field_70165_t, this.field_70163_u + (double)this.func_70047_e(), this.field_70161_v);
@@ -142,7 +109,7 @@
          if (!this.field_70729_aU)
          {
              Entity entity = p_70645_1_.func_76346_g();
-@@ -1165,18 +1181,26 @@
+@@ -1165,18 +1177,26 @@
  
              if (!this.field_70170_p.field_72995_K)
              {
@@ -174,7 +141,7 @@
              }
  
              this.field_70170_p.func_72960_a(this, (byte)3);
-@@ -1195,6 +1219,9 @@
+@@ -1195,6 +1215,9 @@
  
      public void func_70653_a(Entity p_70653_1_, float p_70653_2_, double p_70653_3_, double p_70653_5_)
      {
@@ -184,7 +151,7 @@
          if (this.field_70146_Z.nextDouble() >= this.func_110148_a(SharedMonsterAttributes.field_111266_c).func_111126_e())
          {
              this.field_70160_al = true;
-@@ -1253,15 +1280,7 @@
+@@ -1253,15 +1276,7 @@
              BlockPos blockpos = new BlockPos(i, j, k);
              IBlockState iblockstate = this.field_70170_p.func_180495_p(blockpos);
              Block block = iblockstate.func_177230_c();
@@ -201,7 +168,7 @@
          }
      }
  
-@@ -1287,6 +1306,9 @@
+@@ -1287,6 +1302,9 @@
  
      public void func_180430_e(float p_180430_1_, float p_180430_2_)
      {
@@ -211,7 +178,7 @@
          super.func_180430_e(p_180430_1_, p_180430_2_);
          PotionEffect potioneffect = this.func_70660_b(MobEffects.field_76430_j);
          float f = potioneffect == null ? 0.0F : (float)(potioneffect.func_76458_c() + 1);
-@@ -1303,7 +1325,7 @@
+@@ -1303,7 +1321,7 @@
  
              if (iblockstate.func_185904_a() != Material.field_151579_a)
              {
@@ -220,7 +187,7 @@
                  this.func_184185_a(soundtype.func_185842_g(), soundtype.func_185843_a() * 0.5F, soundtype.func_185847_b() * 0.75F);
              }
          }
-@@ -1380,17 +1402,20 @@
+@@ -1380,17 +1398,20 @@
      {
          if (!this.func_180431_b(p_70665_1_))
          {
@@ -242,7 +209,7 @@
                  this.func_110149_m(this.func_110139_bj() - p_70665_2_);
              }
          }
-@@ -1447,6 +1472,11 @@
+@@ -1447,6 +1468,11 @@
  
      public void func_184609_a(EnumHand p_184609_1_)
      {
@@ -254,7 +221,7 @@
          if (!this.field_82175_bq || this.field_110158_av >= this.func_82166_i() / 2 || this.field_110158_av < 0)
          {
              this.field_110158_av = -1;
-@@ -1694,7 +1724,7 @@
+@@ -1694,7 +1720,7 @@
  
                      if (!this.field_70170_p.func_184143_b(axisalignedbb1))
                      {
@@ -263,7 +230,7 @@
                          {
                              this.func_70634_a(d11, this.field_70163_u + 1.0D, d12);
                              return;
-@@ -1702,14 +1732,14 @@
+@@ -1702,14 +1728,14 @@
  
                          BlockPos blockpos = new BlockPos(d11, this.field_70163_u - 1.0D, d12);
  
@@ -280,7 +247,7 @@
                      {
                          d1 = d11;
                          d13 = this.field_70163_u + 2.0D;
-@@ -1781,6 +1811,7 @@
+@@ -1781,6 +1807,7 @@
          }
  
          this.field_70160_al = true;
@@ -288,7 +255,7 @@
      }
  
      protected void func_70629_bd()
-@@ -1874,7 +1905,8 @@
+@@ -1874,7 +1901,8 @@
  
                          if (this.field_70122_E)
                          {
@@ -298,7 +265,7 @@
                          }
  
                          float f7 = 0.16277136F / (f6 * f6 * f6);
-@@ -1894,7 +1926,8 @@
+@@ -1894,7 +1922,8 @@
  
                          if (this.field_70122_E)
                          {
@@ -308,7 +275,7 @@
                          }
  
                          if (this.func_70617_f_())
-@@ -2054,6 +2087,7 @@
+@@ -2054,6 +2083,7 @@
  
      public void func_70071_h_()
      {
@@ -316,7 +283,7 @@
          super.func_70071_h_();
          this.func_184608_ct();
  
-@@ -2096,7 +2130,9 @@
+@@ -2096,7 +2126,9 @@
  
                  if (!ItemStack.func_77989_b(itemstack1, itemstack))
                  {
@@ -326,7 +293,7 @@
  
                      if (!itemstack.func_190926_b())
                      {
-@@ -2575,6 +2611,40 @@
+@@ -2575,6 +2607,40 @@
          this.field_70752_e = true;
      }
  
@@ -367,7 +334,7 @@
      public abstract EnumHandSide func_184591_cq();
  
      public boolean func_184587_cr()
-@@ -2595,12 +2665,19 @@
+@@ -2595,12 +2661,19 @@
  
              if (itemstack == this.field_184627_bm)
              {
@@ -388,7 +355,7 @@
                  {
                      this.func_71036_o();
                  }
-@@ -2618,8 +2695,10 @@
+@@ -2618,8 +2691,10 @@
  
          if (!itemstack.func_190926_b() && !this.func_184587_cr())
          {
@@ -400,7 +367,7 @@
  
              if (!this.field_70170_p.field_72995_K)
              {
-@@ -2700,7 +2779,9 @@
+@@ -2700,7 +2775,9 @@
          if (!this.field_184627_bm.func_190926_b() && this.func_184587_cr())
          {
              this.func_184584_a(this.field_184627_bm, 16);
@@ -411,7 +378,7 @@
              this.func_184602_cy();
          }
      }
-@@ -2724,7 +2805,8 @@
+@@ -2724,7 +2801,8 @@
      {
          if (!this.field_184627_bm.func_190926_b())
          {
@@ -421,7 +388,7 @@
          }
  
          this.func_184602_cy();
-@@ -2852,6 +2934,31 @@
+@@ -2852,6 +2930,31 @@
          return true;
      }
  

--- a/patches/minecraft/net/minecraft/entity/EntityLivingBase.java.patch
+++ b/patches/minecraft/net/minecraft/entity/EntityLivingBase.java.patch
@@ -32,8 +32,11 @@
  import net.minecraft.entity.player.EntityPlayer;
  import net.minecraft.entity.player.EntityPlayerMP;
  import net.minecraft.entity.projectile.EntityArrow;
-@@ -74,8 +79,6 @@
+@@ -72,10 +77,9 @@
+ import net.minecraft.util.math.Vec3d;
+ import net.minecraft.world.World;
  import net.minecraft.world.WorldServer;
++import net.minecraftforge.event.entity.living.LivingKnockBackEvent;
  import net.minecraftforge.fml.relauncher.Side;
  import net.minecraftforge.fml.relauncher.SideOnly;
 -import org.apache.logging.log4j.LogManager;
@@ -41,7 +44,7 @@
  
  public abstract class EntityLivingBase extends Entity
  {
-@@ -201,10 +204,11 @@
+@@ -201,10 +205,11 @@
          {
              float f = (float)MathHelper.func_76123_f(this.field_70143_R - 3.0F);
  
@@ -54,7 +57,7 @@
                  ((WorldServer)this.field_70170_p).func_175739_a(EnumParticleTypes.BLOCK_DUST, this.field_70165_t, this.field_70163_u, this.field_70161_v, i, 0.0D, 0.0D, 0.0D, 0.15000000596046448D, Block.func_176210_f(p_184231_4_));
              }
          }
-@@ -281,7 +285,7 @@
+@@ -281,7 +286,7 @@
                      }
                  }
  
@@ -63,7 +66,7 @@
                  {
                      this.func_184210_p();
                  }
-@@ -380,7 +384,7 @@
+@@ -380,7 +385,7 @@
              if (!this.field_70170_p.field_72995_K && (this.func_70684_aJ() || this.field_70718_bc > 0 && this.func_146066_aG() && this.field_70170_p.func_82736_K().func_82766_b("doMobLoot")))
              {
                  int i = this.func_70693_a(this.field_70717_bb);
@@ -72,7 +75,7 @@
                  while (i > 0)
                  {
                      int j = EntityXPOrb.func_70527_a(i);
-@@ -442,6 +446,7 @@
+@@ -442,6 +447,7 @@
      {
          this.field_70755_b = p_70604_1_;
          this.field_70756_c = this.field_70173_aa;
@@ -80,7 +83,7 @@
      }
  
      public EntityLivingBase func_110144_aD()
-@@ -670,8 +675,10 @@
+@@ -670,8 +676,10 @@
          else
          {
              Collection<PotionEffect> collection = this.field_70713_bf.values();
@@ -93,7 +96,7 @@
              this.func_82142_c(this.func_70644_a(MobEffects.field_76441_p));
          }
      }
-@@ -819,6 +826,8 @@
+@@ -819,6 +827,8 @@
  
      public void func_70691_i(float p_70691_1_)
      {
@@ -102,7 +105,7 @@
          float f = this.func_110143_aJ();
  
          if (f > 0.0F)
-@@ -839,6 +848,7 @@
+@@ -839,6 +849,7 @@
  
      public boolean func_70097_a(DamageSource p_70097_1_, float p_70097_2_)
      {
@@ -110,7 +113,7 @@
          if (this.func_180431_b(p_70097_1_))
          {
              return false;
-@@ -927,9 +937,9 @@
+@@ -927,9 +938,9 @@
                          this.field_70718_bc = 100;
                          this.field_70717_bb = (EntityPlayer)entity1;
                      }
@@ -122,7 +125,7 @@
  
                          if (entitywolf.func_70909_n())
                          {
-@@ -1127,7 +1137,7 @@
+@@ -1127,7 +1138,7 @@
  
      public void func_70669_a(ItemStack p_70669_1_)
      {
@@ -131,7 +134,7 @@
  
          for (int i = 0; i < 5; ++i)
          {
-@@ -1139,12 +1149,17 @@
+@@ -1139,12 +1150,17 @@
              vec3d1 = vec3d1.func_178789_a(-this.field_70125_A * 0.017453292F);
              vec3d1 = vec3d1.func_178785_b(-this.field_70177_z * 0.017453292F);
              vec3d1 = vec3d1.func_72441_c(this.field_70165_t, this.field_70163_u + (double)this.func_70047_e(), this.field_70161_v);
@@ -150,7 +153,7 @@
          if (!this.field_70729_aU)
          {
              Entity entity = p_70645_1_.func_76346_g();
-@@ -1165,18 +1180,26 @@
+@@ -1165,18 +1181,26 @@
  
              if (!this.field_70170_p.field_72995_K)
              {
@@ -182,15 +185,33 @@
              }
  
              this.field_70170_p.func_72960_a(this, (byte)3);
-@@ -1195,6 +1218,7 @@
+@@ -1195,19 +1219,21 @@
  
      public void func_70653_a(Entity p_70653_1_, float p_70653_2_, double p_70653_3_, double p_70653_5_)
      {
-+    	if (!net.minecraftforge.common.ForgeHooks.onLivingKnockBack(this, p_70653_1_, p_70653_2_, p_70653_3_, p_70653_5_)) return;
++    	LivingKnockBackEvent event = new LivingKnockBackEvent(this, p_70653_1_, p_70653_2_, p_70653_3_, p_70653_5_);
++    	if (!net.minecraftforge.common.ForgeHooks.onLivingKnockBack(event)) return;
          if (this.field_70146_Z.nextDouble() >= this.func_110148_a(SharedMonsterAttributes.field_111266_c).func_111126_e())
          {
              this.field_70160_al = true;
-@@ -1253,15 +1277,7 @@
+-            float f = MathHelper.func_76133_a(p_70653_3_ * p_70653_3_ + p_70653_5_ * p_70653_5_);
++            float f = MathHelper.func_76133_a(event.getRatioX() * event.getRatioX() + event.getRatioZ() * event.getRatioZ());
+             this.field_70159_w /= 2.0D;
+             this.field_70179_y /= 2.0D;
+-            this.field_70159_w -= p_70653_3_ / (double)f * (double)p_70653_2_;
+-            this.field_70179_y -= p_70653_5_ / (double)f * (double)p_70653_2_;
++            this.field_70159_w -= event.getRatioX() / (double)f * (double) event.getStrength();
++            this.field_70179_y -= event.getRatioZ() / (double)f * (double) event.getStrength();
+ 
+             if (this.field_70122_E)
+             {
+                 this.field_70181_x /= 2.0D;
+-                this.field_70181_x += (double)p_70653_2_;
++                this.field_70181_x += (double) event.getStrength();
+ 
+                 if (this.field_70181_x > 0.4000000059604645D)
+                 {
+@@ -1253,15 +1279,7 @@
              BlockPos blockpos = new BlockPos(i, j, k);
              IBlockState iblockstate = this.field_70170_p.func_180495_p(blockpos);
              Block block = iblockstate.func_177230_c();
@@ -207,7 +228,7 @@
          }
      }
  
-@@ -1287,6 +1303,9 @@
+@@ -1287,6 +1305,9 @@
  
      public void func_180430_e(float p_180430_1_, float p_180430_2_)
      {
@@ -217,7 +238,7 @@
          super.func_180430_e(p_180430_1_, p_180430_2_);
          PotionEffect potioneffect = this.func_70660_b(MobEffects.field_76430_j);
          float f = potioneffect == null ? 0.0F : (float)(potioneffect.func_76458_c() + 1);
-@@ -1303,7 +1322,7 @@
+@@ -1303,7 +1324,7 @@
  
              if (iblockstate.func_185904_a() != Material.field_151579_a)
              {
@@ -226,7 +247,7 @@
                  this.func_184185_a(soundtype.func_185842_g(), soundtype.func_185843_a() * 0.5F, soundtype.func_185847_b() * 0.75F);
              }
          }
-@@ -1380,17 +1399,20 @@
+@@ -1380,17 +1401,20 @@
      {
          if (!this.func_180431_b(p_70665_1_))
          {
@@ -248,7 +269,7 @@
                  this.func_110149_m(this.func_110139_bj() - p_70665_2_);
              }
          }
-@@ -1447,6 +1469,11 @@
+@@ -1447,6 +1471,11 @@
  
      public void func_184609_a(EnumHand p_184609_1_)
      {
@@ -260,7 +281,7 @@
          if (!this.field_82175_bq || this.field_110158_av >= this.func_82166_i() / 2 || this.field_110158_av < 0)
          {
              this.field_110158_av = -1;
-@@ -1694,7 +1721,7 @@
+@@ -1694,7 +1723,7 @@
  
                      if (!this.field_70170_p.func_184143_b(axisalignedbb1))
                      {
@@ -269,7 +290,7 @@
                          {
                              this.func_70634_a(d11, this.field_70163_u + 1.0D, d12);
                              return;
-@@ -1702,14 +1729,14 @@
+@@ -1702,14 +1731,14 @@
  
                          BlockPos blockpos = new BlockPos(d11, this.field_70163_u - 1.0D, d12);
  
@@ -286,7 +307,7 @@
                      {
                          d1 = d11;
                          d13 = this.field_70163_u + 2.0D;
-@@ -1781,6 +1808,7 @@
+@@ -1781,6 +1810,7 @@
          }
  
          this.field_70160_al = true;
@@ -294,7 +315,7 @@
      }
  
      protected void func_70629_bd()
-@@ -1874,7 +1902,8 @@
+@@ -1874,7 +1904,8 @@
  
                          if (this.field_70122_E)
                          {
@@ -304,7 +325,7 @@
                          }
  
                          float f7 = 0.16277136F / (f6 * f6 * f6);
-@@ -1894,7 +1923,8 @@
+@@ -1894,7 +1925,8 @@
  
                          if (this.field_70122_E)
                          {
@@ -314,7 +335,7 @@
                          }
  
                          if (this.func_70617_f_())
-@@ -2054,6 +2084,7 @@
+@@ -2054,6 +2086,7 @@
  
      public void func_70071_h_()
      {
@@ -322,7 +343,7 @@
          super.func_70071_h_();
          this.func_184608_ct();
  
-@@ -2096,7 +2127,9 @@
+@@ -2096,7 +2129,9 @@
  
                  if (!ItemStack.func_77989_b(itemstack1, itemstack))
                  {
@@ -332,7 +353,7 @@
  
                      if (!itemstack.func_190926_b())
                      {
-@@ -2575,6 +2608,40 @@
+@@ -2575,6 +2610,40 @@
          this.field_70752_e = true;
      }
  
@@ -373,7 +394,7 @@
      public abstract EnumHandSide func_184591_cq();
  
      public boolean func_184587_cr()
-@@ -2595,12 +2662,19 @@
+@@ -2595,12 +2664,19 @@
  
              if (itemstack == this.field_184627_bm)
              {
@@ -394,7 +415,7 @@
                  {
                      this.func_71036_o();
                  }
-@@ -2618,8 +2692,10 @@
+@@ -2618,8 +2694,10 @@
  
          if (!itemstack.func_190926_b() && !this.func_184587_cr())
          {
@@ -406,7 +427,7 @@
  
              if (!this.field_70170_p.field_72995_K)
              {
-@@ -2700,7 +2776,9 @@
+@@ -2700,7 +2778,9 @@
          if (!this.field_184627_bm.func_190926_b() && this.func_184587_cr())
          {
              this.func_184584_a(this.field_184627_bm, 16);
@@ -417,7 +438,7 @@
              this.func_184602_cy();
          }
      }
-@@ -2724,7 +2802,8 @@
+@@ -2724,7 +2804,8 @@
      {
          if (!this.field_184627_bm.func_190926_b())
          {
@@ -427,7 +448,7 @@
          }
  
          this.func_184602_cy();
-@@ -2852,6 +2931,31 @@
+@@ -2852,6 +2933,31 @@
          return true;
      }
  

--- a/patches/minecraft/net/minecraft/entity/EntityLivingBase.java.patch
+++ b/patches/minecraft/net/minecraft/entity/EntityLivingBase.java.patch
@@ -1,6 +1,47 @@
 --- ../src-base/minecraft/net/minecraft/entity/EntityLivingBase.java
 +++ ../src-work/minecraft/net/minecraft/entity/EntityLivingBase.java
-@@ -201,10 +201,11 @@
+@@ -1,7 +1,5 @@
+ package net.minecraft.entity;
+ 
+-import com.google.common.base.Objects;
+-import com.google.common.collect.Maps;
+ import java.util.Collection;
+ import java.util.ConcurrentModificationException;
+ import java.util.Iterator;
+@@ -9,7 +7,15 @@
+ import java.util.Map;
+ import java.util.Random;
+ import java.util.UUID;
++
+ import javax.annotation.Nullable;
++
++import org.apache.logging.log4j.LogManager;
++import org.apache.logging.log4j.Logger;
++
++import com.google.common.base.Objects;
++import com.google.common.collect.Maps;
++
+ import net.minecraft.advancements.CriteriaTriggers;
+ import net.minecraft.block.Block;
+ import net.minecraft.block.BlockLadder;
+@@ -28,7 +34,6 @@
+ import net.minecraft.entity.item.EntityItem;
+ import net.minecraft.entity.item.EntityXPOrb;
+ import net.minecraft.entity.passive.AbstractHorse;
+-import net.minecraft.entity.passive.EntityWolf;
+ import net.minecraft.entity.player.EntityPlayer;
+ import net.minecraft.entity.player.EntityPlayerMP;
+ import net.minecraft.entity.projectile.EntityArrow;
+@@ -74,8 +79,6 @@
+ import net.minecraft.world.WorldServer;
+ import net.minecraftforge.fml.relauncher.Side;
+ import net.minecraftforge.fml.relauncher.SideOnly;
+-import org.apache.logging.log4j.LogManager;
+-import org.apache.logging.log4j.Logger;
+ 
+ public abstract class EntityLivingBase extends Entity
+ {
+@@ -201,10 +204,11 @@
          {
              float f = (float)MathHelper.func_76123_f(this.field_70143_R - 3.0F);
  
@@ -13,7 +54,7 @@
                  ((WorldServer)this.field_70170_p).func_175739_a(EnumParticleTypes.BLOCK_DUST, this.field_70165_t, this.field_70163_u, this.field_70161_v, i, 0.0D, 0.0D, 0.0D, 0.15000000596046448D, Block.func_176210_f(p_184231_4_));
              }
          }
-@@ -281,7 +282,7 @@
+@@ -281,7 +285,7 @@
                      }
                  }
  
@@ -22,7 +63,7 @@
                  {
                      this.func_184210_p();
                  }
-@@ -380,7 +381,7 @@
+@@ -380,7 +384,7 @@
              if (!this.field_70170_p.field_72995_K && (this.func_70684_aJ() || this.field_70718_bc > 0 && this.func_146066_aG() && this.field_70170_p.func_82736_K().func_82766_b("doMobLoot")))
              {
                  int i = this.func_70693_a(this.field_70717_bb);
@@ -31,7 +72,7 @@
                  while (i > 0)
                  {
                      int j = EntityXPOrb.func_70527_a(i);
-@@ -442,6 +443,7 @@
+@@ -442,6 +446,7 @@
      {
          this.field_70755_b = p_70604_1_;
          this.field_70756_c = this.field_70173_aa;
@@ -39,7 +80,7 @@
      }
  
      public EntityLivingBase func_110144_aD()
-@@ -670,8 +672,10 @@
+@@ -670,8 +675,10 @@
          else
          {
              Collection<PotionEffect> collection = this.field_70713_bf.values();
@@ -52,7 +93,7 @@
              this.func_82142_c(this.func_70644_a(MobEffects.field_76441_p));
          }
      }
-@@ -819,6 +823,8 @@
+@@ -819,6 +826,8 @@
  
      public void func_70691_i(float p_70691_1_)
      {
@@ -61,7 +102,7 @@
          float f = this.func_110143_aJ();
  
          if (f > 0.0F)
-@@ -839,6 +845,7 @@
+@@ -839,6 +848,7 @@
  
      public boolean func_70097_a(DamageSource p_70097_1_, float p_70097_2_)
      {
@@ -69,7 +110,7 @@
          if (this.func_180431_b(p_70097_1_))
          {
              return false;
-@@ -927,9 +934,9 @@
+@@ -927,9 +937,9 @@
                          this.field_70718_bc = 100;
                          this.field_70717_bb = (EntityPlayer)entity1;
                      }
@@ -81,7 +122,7 @@
  
                          if (entitywolf.func_70909_n())
                          {
-@@ -1127,7 +1134,7 @@
+@@ -1127,7 +1137,7 @@
  
      public void func_70669_a(ItemStack p_70669_1_)
      {
@@ -90,7 +131,7 @@
  
          for (int i = 0; i < 5; ++i)
          {
-@@ -1139,12 +1146,17 @@
+@@ -1139,12 +1149,17 @@
              vec3d1 = vec3d1.func_178789_a(-this.field_70125_A * 0.017453292F);
              vec3d1 = vec3d1.func_178785_b(-this.field_70177_z * 0.017453292F);
              vec3d1 = vec3d1.func_72441_c(this.field_70165_t, this.field_70163_u + (double)this.func_70047_e(), this.field_70161_v);
@@ -109,7 +150,7 @@
          if (!this.field_70729_aU)
          {
              Entity entity = p_70645_1_.func_76346_g();
-@@ -1165,18 +1177,26 @@
+@@ -1165,18 +1180,26 @@
  
              if (!this.field_70170_p.field_72995_K)
              {
@@ -141,7 +182,15 @@
              }
  
              this.field_70170_p.func_72960_a(this, (byte)3);
-@@ -1253,15 +1273,7 @@
+@@ -1195,6 +1218,7 @@
+ 
+     public void func_70653_a(Entity p_70653_1_, float p_70653_2_, double p_70653_3_, double p_70653_5_)
+     {
++    	if (!net.minecraftforge.common.ForgeHooks.onLivingKnockBack(this, p_70653_1_, p_70653_2_, p_70653_3_, p_70653_5_)) return;
+         if (this.field_70146_Z.nextDouble() >= this.func_110148_a(SharedMonsterAttributes.field_111266_c).func_111126_e())
+         {
+             this.field_70160_al = true;
+@@ -1253,15 +1277,7 @@
              BlockPos blockpos = new BlockPos(i, j, k);
              IBlockState iblockstate = this.field_70170_p.func_180495_p(blockpos);
              Block block = iblockstate.func_177230_c();
@@ -158,7 +207,7 @@
          }
      }
  
-@@ -1287,6 +1299,9 @@
+@@ -1287,6 +1303,9 @@
  
      public void func_180430_e(float p_180430_1_, float p_180430_2_)
      {
@@ -168,7 +217,7 @@
          super.func_180430_e(p_180430_1_, p_180430_2_);
          PotionEffect potioneffect = this.func_70660_b(MobEffects.field_76430_j);
          float f = potioneffect == null ? 0.0F : (float)(potioneffect.func_76458_c() + 1);
-@@ -1303,7 +1318,7 @@
+@@ -1303,7 +1322,7 @@
  
              if (iblockstate.func_185904_a() != Material.field_151579_a)
              {
@@ -177,7 +226,7 @@
                  this.func_184185_a(soundtype.func_185842_g(), soundtype.func_185843_a() * 0.5F, soundtype.func_185847_b() * 0.75F);
              }
          }
-@@ -1380,17 +1395,20 @@
+@@ -1380,17 +1399,20 @@
      {
          if (!this.func_180431_b(p_70665_1_))
          {
@@ -199,7 +248,7 @@
                  this.func_110149_m(this.func_110139_bj() - p_70665_2_);
              }
          }
-@@ -1447,6 +1465,11 @@
+@@ -1447,6 +1469,11 @@
  
      public void func_184609_a(EnumHand p_184609_1_)
      {
@@ -211,7 +260,7 @@
          if (!this.field_82175_bq || this.field_110158_av >= this.func_82166_i() / 2 || this.field_110158_av < 0)
          {
              this.field_110158_av = -1;
-@@ -1694,7 +1717,7 @@
+@@ -1694,7 +1721,7 @@
  
                      if (!this.field_70170_p.func_184143_b(axisalignedbb1))
                      {
@@ -220,7 +269,7 @@
                          {
                              this.func_70634_a(d11, this.field_70163_u + 1.0D, d12);
                              return;
-@@ -1702,14 +1725,14 @@
+@@ -1702,14 +1729,14 @@
  
                          BlockPos blockpos = new BlockPos(d11, this.field_70163_u - 1.0D, d12);
  
@@ -237,7 +286,7 @@
                      {
                          d1 = d11;
                          d13 = this.field_70163_u + 2.0D;
-@@ -1781,6 +1804,7 @@
+@@ -1781,6 +1808,7 @@
          }
  
          this.field_70160_al = true;
@@ -245,7 +294,7 @@
      }
  
      protected void func_70629_bd()
-@@ -1874,7 +1898,8 @@
+@@ -1874,7 +1902,8 @@
  
                          if (this.field_70122_E)
                          {
@@ -255,7 +304,7 @@
                          }
  
                          float f7 = 0.16277136F / (f6 * f6 * f6);
-@@ -1894,7 +1919,8 @@
+@@ -1894,7 +1923,8 @@
  
                          if (this.field_70122_E)
                          {
@@ -265,7 +314,7 @@
                          }
  
                          if (this.func_70617_f_())
-@@ -2054,6 +2080,7 @@
+@@ -2054,6 +2084,7 @@
  
      public void func_70071_h_()
      {
@@ -273,7 +322,7 @@
          super.func_70071_h_();
          this.func_184608_ct();
  
-@@ -2096,7 +2123,9 @@
+@@ -2096,7 +2127,9 @@
  
                  if (!ItemStack.func_77989_b(itemstack1, itemstack))
                  {
@@ -283,7 +332,7 @@
  
                      if (!itemstack.func_190926_b())
                      {
-@@ -2575,6 +2604,40 @@
+@@ -2575,6 +2608,40 @@
          this.field_70752_e = true;
      }
  
@@ -324,7 +373,7 @@
      public abstract EnumHandSide func_184591_cq();
  
      public boolean func_184587_cr()
-@@ -2595,12 +2658,19 @@
+@@ -2595,12 +2662,19 @@
  
              if (itemstack == this.field_184627_bm)
              {
@@ -345,7 +394,7 @@
                  {
                      this.func_71036_o();
                  }
-@@ -2618,8 +2688,10 @@
+@@ -2618,8 +2692,10 @@
  
          if (!itemstack.func_190926_b() && !this.func_184587_cr())
          {
@@ -357,7 +406,7 @@
  
              if (!this.field_70170_p.field_72995_K)
              {
-@@ -2700,7 +2772,9 @@
+@@ -2700,7 +2776,9 @@
          if (!this.field_184627_bm.func_190926_b() && this.func_184587_cr())
          {
              this.func_184584_a(this.field_184627_bm, 16);
@@ -368,7 +417,7 @@
              this.func_184602_cy();
          }
      }
-@@ -2724,7 +2798,8 @@
+@@ -2724,7 +2802,8 @@
      {
          if (!this.field_184627_bm.func_190926_b())
          {
@@ -378,7 +427,7 @@
          }
  
          this.func_184602_cy();
-@@ -2852,6 +2927,31 @@
+@@ -2852,6 +2931,31 @@
          return true;
      }
  

--- a/patches/minecraft/net/minecraft/entity/EntityLivingBase.java.patch
+++ b/patches/minecraft/net/minecraft/entity/EntityLivingBase.java.patch
@@ -24,15 +24,16 @@
  import net.minecraft.advancements.CriteriaTriggers;
  import net.minecraft.block.Block;
  import net.minecraft.block.BlockLadder;
-@@ -72,6 +78,7 @@
- import net.minecraft.util.math.Vec3d;
- import net.minecraft.world.World;
+@@ -74,8 +80,6 @@
  import net.minecraft.world.WorldServer;
-+import net.minecraftforge.event.entity.living.LivingKnockBackEvent;
  import net.minecraftforge.fml.relauncher.Side;
  import net.minecraftforge.fml.relauncher.SideOnly;
- import org.apache.logging.log4j.LogManager;
-@@ -201,10 +208,11 @@
+-import org.apache.logging.log4j.LogManager;
+-import org.apache.logging.log4j.Logger;
+ 
+ public abstract class EntityLivingBase extends Entity
+ {
+@@ -201,10 +205,11 @@
          {
              float f = (float)MathHelper.func_76123_f(this.field_70143_R - 3.0F);
  
@@ -45,7 +46,7 @@
                  ((WorldServer)this.field_70170_p).func_175739_a(EnumParticleTypes.BLOCK_DUST, this.field_70165_t, this.field_70163_u, this.field_70161_v, i, 0.0D, 0.0D, 0.0D, 0.15000000596046448D, Block.func_176210_f(p_184231_4_));
              }
          }
-@@ -281,7 +289,7 @@
+@@ -281,7 +286,7 @@
                      }
                  }
  
@@ -54,7 +55,7 @@
                  {
                      this.func_184210_p();
                  }
-@@ -380,7 +388,7 @@
+@@ -380,7 +385,7 @@
              if (!this.field_70170_p.field_72995_K && (this.func_70684_aJ() || this.field_70718_bc > 0 && this.func_146066_aG() && this.field_70170_p.func_82736_K().func_82766_b("doMobLoot")))
              {
                  int i = this.func_70693_a(this.field_70717_bb);
@@ -63,7 +64,7 @@
                  while (i > 0)
                  {
                      int j = EntityXPOrb.func_70527_a(i);
-@@ -442,6 +450,7 @@
+@@ -442,6 +447,7 @@
      {
          this.field_70755_b = p_70604_1_;
          this.field_70756_c = this.field_70173_aa;
@@ -71,7 +72,7 @@
      }
  
      public EntityLivingBase func_110144_aD()
-@@ -670,8 +679,10 @@
+@@ -670,8 +676,10 @@
          else
          {
              Collection<PotionEffect> collection = this.field_70713_bf.values();
@@ -84,7 +85,7 @@
              this.func_82142_c(this.func_70644_a(MobEffects.field_76441_p));
          }
      }
-@@ -819,6 +830,8 @@
+@@ -819,6 +827,8 @@
  
      public void func_70691_i(float p_70691_1_)
      {
@@ -93,7 +94,7 @@
          float f = this.func_110143_aJ();
  
          if (f > 0.0F)
-@@ -839,6 +852,7 @@
+@@ -839,6 +849,7 @@
  
      public boolean func_70097_a(DamageSource p_70097_1_, float p_70097_2_)
      {
@@ -101,7 +102,7 @@
          if (this.func_180431_b(p_70097_1_))
          {
              return false;
-@@ -927,9 +941,9 @@
+@@ -927,9 +938,9 @@
                          this.field_70718_bc = 100;
                          this.field_70717_bb = (EntityPlayer)entity1;
                      }
@@ -113,7 +114,7 @@
  
                          if (entitywolf.func_70909_n())
                          {
-@@ -1127,7 +1141,7 @@
+@@ -1127,7 +1138,7 @@
  
      public void func_70669_a(ItemStack p_70669_1_)
      {
@@ -122,7 +123,7 @@
  
          for (int i = 0; i < 5; ++i)
          {
-@@ -1139,12 +1153,17 @@
+@@ -1139,12 +1150,17 @@
              vec3d1 = vec3d1.func_178789_a(-this.field_70125_A * 0.017453292F);
              vec3d1 = vec3d1.func_178785_b(-this.field_70177_z * 0.017453292F);
              vec3d1 = vec3d1.func_72441_c(this.field_70165_t, this.field_70163_u + (double)this.func_70047_e(), this.field_70161_v);
@@ -141,7 +142,7 @@
          if (!this.field_70729_aU)
          {
              Entity entity = p_70645_1_.func_76346_g();
-@@ -1165,18 +1184,26 @@
+@@ -1165,18 +1181,26 @@
  
              if (!this.field_70170_p.field_72995_K)
              {
@@ -173,33 +174,17 @@
              }
  
              this.field_70170_p.func_72960_a(this, (byte)3);
-@@ -1195,19 +1222,22 @@
+@@ -1195,6 +1219,9 @@
  
      public void func_70653_a(Entity p_70653_1_, float p_70653_2_, double p_70653_3_, double p_70653_5_)
      {
-+        LivingKnockBackEvent event = net.minecraftforge.common.ForgeHooks.onLivingKnockBack(this, p_70653_1_, p_70653_2_, p_70653_3_, p_70653_5_);
++        net.minecraftforge.event.entity.living.LivingKnockBackEvent event = net.minecraftforge.common.ForgeHooks.onLivingKnockBack(this, p_70653_1_, p_70653_2_, p_70653_3_, p_70653_5_);
 +        if(event.isCanceled()) return;
 +        p_70653_2_ = event.getStrength(); p_70653_3_ = event.getRatioX(); p_70653_5_ = event.getRatioZ();
          if (this.field_70146_Z.nextDouble() >= this.func_110148_a(SharedMonsterAttributes.field_111266_c).func_111126_e())
          {
              this.field_70160_al = true;
-             float f = MathHelper.func_76133_a(p_70653_3_ * p_70653_3_ + p_70653_5_ * p_70653_5_);
-             this.field_70159_w /= 2.0D;
-             this.field_70179_y /= 2.0D;
--            this.field_70159_w -= p_70653_3_ / (double)f * (double)p_70653_2_;
--            this.field_70179_y -= p_70653_5_ / (double)f * (double)p_70653_2_;
-+            this.field_70159_w -= p_70653_3_ / (double)f * (double) p_70653_2_;
-+            this.field_70179_y -= p_70653_5_ / (double)f * (double) p_70653_2_;
- 
-             if (this.field_70122_E)
-             {
-                 this.field_70181_x /= 2.0D;
--                this.field_70181_x += (double)p_70653_2_;
-+                this.field_70181_x += (double) p_70653_2_;
- 
-                 if (this.field_70181_x > 0.4000000059604645D)
-                 {
-@@ -1253,15 +1283,7 @@
+@@ -1253,15 +1280,7 @@
              BlockPos blockpos = new BlockPos(i, j, k);
              IBlockState iblockstate = this.field_70170_p.func_180495_p(blockpos);
              Block block = iblockstate.func_177230_c();
@@ -216,7 +201,7 @@
          }
      }
  
-@@ -1287,6 +1309,9 @@
+@@ -1287,6 +1306,9 @@
  
      public void func_180430_e(float p_180430_1_, float p_180430_2_)
      {
@@ -226,7 +211,7 @@
          super.func_180430_e(p_180430_1_, p_180430_2_);
          PotionEffect potioneffect = this.func_70660_b(MobEffects.field_76430_j);
          float f = potioneffect == null ? 0.0F : (float)(potioneffect.func_76458_c() + 1);
-@@ -1303,7 +1328,7 @@
+@@ -1303,7 +1325,7 @@
  
              if (iblockstate.func_185904_a() != Material.field_151579_a)
              {
@@ -235,7 +220,7 @@
                  this.func_184185_a(soundtype.func_185842_g(), soundtype.func_185843_a() * 0.5F, soundtype.func_185847_b() * 0.75F);
              }
          }
-@@ -1380,17 +1405,20 @@
+@@ -1380,17 +1402,20 @@
      {
          if (!this.func_180431_b(p_70665_1_))
          {
@@ -257,7 +242,7 @@
                  this.func_110149_m(this.func_110139_bj() - p_70665_2_);
              }
          }
-@@ -1447,6 +1475,11 @@
+@@ -1447,6 +1472,11 @@
  
      public void func_184609_a(EnumHand p_184609_1_)
      {
@@ -269,7 +254,7 @@
          if (!this.field_82175_bq || this.field_110158_av >= this.func_82166_i() / 2 || this.field_110158_av < 0)
          {
              this.field_110158_av = -1;
-@@ -1694,7 +1727,7 @@
+@@ -1694,7 +1724,7 @@
  
                      if (!this.field_70170_p.func_184143_b(axisalignedbb1))
                      {
@@ -278,7 +263,7 @@
                          {
                              this.func_70634_a(d11, this.field_70163_u + 1.0D, d12);
                              return;
-@@ -1702,14 +1735,14 @@
+@@ -1702,14 +1732,14 @@
  
                          BlockPos blockpos = new BlockPos(d11, this.field_70163_u - 1.0D, d12);
  
@@ -295,7 +280,7 @@
                      {
                          d1 = d11;
                          d13 = this.field_70163_u + 2.0D;
-@@ -1781,6 +1814,7 @@
+@@ -1781,6 +1811,7 @@
          }
  
          this.field_70160_al = true;
@@ -303,7 +288,7 @@
      }
  
      protected void func_70629_bd()
-@@ -1874,7 +1908,8 @@
+@@ -1874,7 +1905,8 @@
  
                          if (this.field_70122_E)
                          {
@@ -313,7 +298,7 @@
                          }
  
                          float f7 = 0.16277136F / (f6 * f6 * f6);
-@@ -1894,7 +1929,8 @@
+@@ -1894,7 +1926,8 @@
  
                          if (this.field_70122_E)
                          {
@@ -323,7 +308,7 @@
                          }
  
                          if (this.func_70617_f_())
-@@ -2054,6 +2090,7 @@
+@@ -2054,6 +2087,7 @@
  
      public void func_70071_h_()
      {
@@ -331,7 +316,7 @@
          super.func_70071_h_();
          this.func_184608_ct();
  
-@@ -2096,7 +2133,9 @@
+@@ -2096,7 +2130,9 @@
  
                  if (!ItemStack.func_77989_b(itemstack1, itemstack))
                  {
@@ -341,7 +326,7 @@
  
                      if (!itemstack.func_190926_b())
                      {
-@@ -2575,6 +2614,40 @@
+@@ -2575,6 +2611,40 @@
          this.field_70752_e = true;
      }
  
@@ -382,7 +367,7 @@
      public abstract EnumHandSide func_184591_cq();
  
      public boolean func_184587_cr()
-@@ -2595,12 +2668,19 @@
+@@ -2595,12 +2665,19 @@
  
              if (itemstack == this.field_184627_bm)
              {
@@ -403,7 +388,7 @@
                  {
                      this.func_71036_o();
                  }
-@@ -2618,8 +2698,10 @@
+@@ -2618,8 +2695,10 @@
  
          if (!itemstack.func_190926_b() && !this.func_184587_cr())
          {
@@ -415,7 +400,7 @@
  
              if (!this.field_70170_p.field_72995_K)
              {
-@@ -2700,7 +2782,9 @@
+@@ -2700,7 +2779,9 @@
          if (!this.field_184627_bm.func_190926_b() && this.func_184587_cr())
          {
              this.func_184584_a(this.field_184627_bm, 16);
@@ -426,7 +411,7 @@
              this.func_184602_cy();
          }
      }
-@@ -2724,7 +2808,8 @@
+@@ -2724,7 +2805,8 @@
      {
          if (!this.field_184627_bm.func_190926_b())
          {
@@ -436,7 +421,7 @@
          }
  
          this.func_184602_cy();
-@@ -2852,6 +2937,31 @@
+@@ -2852,6 +2934,31 @@
          return true;
      }
  

--- a/patches/minecraft/net/minecraft/entity/EntityLivingBase.java.patch
+++ b/patches/minecraft/net/minecraft/entity/EntityLivingBase.java.patch
@@ -24,27 +24,15 @@
  import net.minecraft.advancements.CriteriaTriggers;
  import net.minecraft.block.Block;
  import net.minecraft.block.BlockLadder;
-@@ -28,7 +34,6 @@
- import net.minecraft.entity.item.EntityItem;
- import net.minecraft.entity.item.EntityXPOrb;
- import net.minecraft.entity.passive.AbstractHorse;
--import net.minecraft.entity.passive.EntityWolf;
- import net.minecraft.entity.player.EntityPlayer;
- import net.minecraft.entity.player.EntityPlayerMP;
- import net.minecraft.entity.projectile.EntityArrow;
-@@ -72,10 +77,9 @@
+@@ -72,6 +78,7 @@
  import net.minecraft.util.math.Vec3d;
  import net.minecraft.world.World;
  import net.minecraft.world.WorldServer;
 +import net.minecraftforge.event.entity.living.LivingKnockBackEvent;
  import net.minecraftforge.fml.relauncher.Side;
  import net.minecraftforge.fml.relauncher.SideOnly;
--import org.apache.logging.log4j.LogManager;
--import org.apache.logging.log4j.Logger;
- 
- public abstract class EntityLivingBase extends Entity
- {
-@@ -201,10 +205,11 @@
+ import org.apache.logging.log4j.LogManager;
+@@ -201,10 +208,11 @@
          {
              float f = (float)MathHelper.func_76123_f(this.field_70143_R - 3.0F);
  
@@ -57,7 +45,7 @@
                  ((WorldServer)this.field_70170_p).func_175739_a(EnumParticleTypes.BLOCK_DUST, this.field_70165_t, this.field_70163_u, this.field_70161_v, i, 0.0D, 0.0D, 0.0D, 0.15000000596046448D, Block.func_176210_f(p_184231_4_));
              }
          }
-@@ -281,7 +286,7 @@
+@@ -281,7 +289,7 @@
                      }
                  }
  
@@ -66,7 +54,7 @@
                  {
                      this.func_184210_p();
                  }
-@@ -380,7 +385,7 @@
+@@ -380,7 +388,7 @@
              if (!this.field_70170_p.field_72995_K && (this.func_70684_aJ() || this.field_70718_bc > 0 && this.func_146066_aG() && this.field_70170_p.func_82736_K().func_82766_b("doMobLoot")))
              {
                  int i = this.func_70693_a(this.field_70717_bb);
@@ -75,7 +63,7 @@
                  while (i > 0)
                  {
                      int j = EntityXPOrb.func_70527_a(i);
-@@ -442,6 +447,7 @@
+@@ -442,6 +450,7 @@
      {
          this.field_70755_b = p_70604_1_;
          this.field_70756_c = this.field_70173_aa;
@@ -83,7 +71,7 @@
      }
  
      public EntityLivingBase func_110144_aD()
-@@ -670,8 +676,10 @@
+@@ -670,8 +679,10 @@
          else
          {
              Collection<PotionEffect> collection = this.field_70713_bf.values();
@@ -96,7 +84,7 @@
              this.func_82142_c(this.func_70644_a(MobEffects.field_76441_p));
          }
      }
-@@ -819,6 +827,8 @@
+@@ -819,6 +830,8 @@
  
      public void func_70691_i(float p_70691_1_)
      {
@@ -105,7 +93,7 @@
          float f = this.func_110143_aJ();
  
          if (f > 0.0F)
-@@ -839,6 +849,7 @@
+@@ -839,6 +852,7 @@
  
      public boolean func_70097_a(DamageSource p_70097_1_, float p_70097_2_)
      {
@@ -113,7 +101,7 @@
          if (this.func_180431_b(p_70097_1_))
          {
              return false;
-@@ -927,9 +938,9 @@
+@@ -927,9 +941,9 @@
                          this.field_70718_bc = 100;
                          this.field_70717_bb = (EntityPlayer)entity1;
                      }
@@ -125,7 +113,7 @@
  
                          if (entitywolf.func_70909_n())
                          {
-@@ -1127,7 +1138,7 @@
+@@ -1127,7 +1141,7 @@
  
      public void func_70669_a(ItemStack p_70669_1_)
      {
@@ -134,7 +122,7 @@
  
          for (int i = 0; i < 5; ++i)
          {
-@@ -1139,12 +1150,17 @@
+@@ -1139,12 +1153,17 @@
              vec3d1 = vec3d1.func_178789_a(-this.field_70125_A * 0.017453292F);
              vec3d1 = vec3d1.func_178785_b(-this.field_70177_z * 0.017453292F);
              vec3d1 = vec3d1.func_72441_c(this.field_70165_t, this.field_70163_u + (double)this.func_70047_e(), this.field_70161_v);
@@ -153,7 +141,7 @@
          if (!this.field_70729_aU)
          {
              Entity entity = p_70645_1_.func_76346_g();
-@@ -1165,18 +1181,26 @@
+@@ -1165,18 +1184,26 @@
  
              if (!this.field_70170_p.field_72995_K)
              {
@@ -185,7 +173,7 @@
              }
  
              this.field_70170_p.func_72960_a(this, (byte)3);
-@@ -1195,19 +1219,22 @@
+@@ -1195,19 +1222,22 @@
  
      public void func_70653_a(Entity p_70653_1_, float p_70653_2_, double p_70653_3_, double p_70653_5_)
      {
@@ -211,7 +199,7 @@
  
                  if (this.field_70181_x > 0.4000000059604645D)
                  {
-@@ -1253,15 +1280,7 @@
+@@ -1253,15 +1283,7 @@
              BlockPos blockpos = new BlockPos(i, j, k);
              IBlockState iblockstate = this.field_70170_p.func_180495_p(blockpos);
              Block block = iblockstate.func_177230_c();
@@ -228,7 +216,7 @@
          }
      }
  
-@@ -1287,6 +1306,9 @@
+@@ -1287,6 +1309,9 @@
  
      public void func_180430_e(float p_180430_1_, float p_180430_2_)
      {
@@ -238,7 +226,7 @@
          super.func_180430_e(p_180430_1_, p_180430_2_);
          PotionEffect potioneffect = this.func_70660_b(MobEffects.field_76430_j);
          float f = potioneffect == null ? 0.0F : (float)(potioneffect.func_76458_c() + 1);
-@@ -1303,7 +1325,7 @@
+@@ -1303,7 +1328,7 @@
  
              if (iblockstate.func_185904_a() != Material.field_151579_a)
              {
@@ -247,7 +235,7 @@
                  this.func_184185_a(soundtype.func_185842_g(), soundtype.func_185843_a() * 0.5F, soundtype.func_185847_b() * 0.75F);
              }
          }
-@@ -1380,17 +1402,20 @@
+@@ -1380,17 +1405,20 @@
      {
          if (!this.func_180431_b(p_70665_1_))
          {
@@ -269,7 +257,7 @@
                  this.func_110149_m(this.func_110139_bj() - p_70665_2_);
              }
          }
-@@ -1447,6 +1472,11 @@
+@@ -1447,6 +1475,11 @@
  
      public void func_184609_a(EnumHand p_184609_1_)
      {
@@ -281,7 +269,7 @@
          if (!this.field_82175_bq || this.field_110158_av >= this.func_82166_i() / 2 || this.field_110158_av < 0)
          {
              this.field_110158_av = -1;
-@@ -1694,7 +1724,7 @@
+@@ -1694,7 +1727,7 @@
  
                      if (!this.field_70170_p.func_184143_b(axisalignedbb1))
                      {
@@ -290,7 +278,7 @@
                          {
                              this.func_70634_a(d11, this.field_70163_u + 1.0D, d12);
                              return;
-@@ -1702,14 +1732,14 @@
+@@ -1702,14 +1735,14 @@
  
                          BlockPos blockpos = new BlockPos(d11, this.field_70163_u - 1.0D, d12);
  
@@ -307,7 +295,7 @@
                      {
                          d1 = d11;
                          d13 = this.field_70163_u + 2.0D;
-@@ -1781,6 +1811,7 @@
+@@ -1781,6 +1814,7 @@
          }
  
          this.field_70160_al = true;
@@ -315,7 +303,7 @@
      }
  
      protected void func_70629_bd()
-@@ -1874,7 +1905,8 @@
+@@ -1874,7 +1908,8 @@
  
                          if (this.field_70122_E)
                          {
@@ -325,7 +313,7 @@
                          }
  
                          float f7 = 0.16277136F / (f6 * f6 * f6);
-@@ -1894,7 +1926,8 @@
+@@ -1894,7 +1929,8 @@
  
                          if (this.field_70122_E)
                          {
@@ -335,7 +323,7 @@
                          }
  
                          if (this.func_70617_f_())
-@@ -2054,6 +2087,7 @@
+@@ -2054,6 +2090,7 @@
  
      public void func_70071_h_()
      {
@@ -343,7 +331,7 @@
          super.func_70071_h_();
          this.func_184608_ct();
  
-@@ -2096,7 +2130,9 @@
+@@ -2096,7 +2133,9 @@
  
                  if (!ItemStack.func_77989_b(itemstack1, itemstack))
                  {
@@ -353,7 +341,7 @@
  
                      if (!itemstack.func_190926_b())
                      {
-@@ -2575,6 +2611,40 @@
+@@ -2575,6 +2614,40 @@
          this.field_70752_e = true;
      }
  
@@ -394,7 +382,7 @@
      public abstract EnumHandSide func_184591_cq();
  
      public boolean func_184587_cr()
-@@ -2595,12 +2665,19 @@
+@@ -2595,12 +2668,19 @@
  
              if (itemstack == this.field_184627_bm)
              {
@@ -415,7 +403,7 @@
                  {
                      this.func_71036_o();
                  }
-@@ -2618,8 +2695,10 @@
+@@ -2618,8 +2698,10 @@
  
          if (!itemstack.func_190926_b() && !this.func_184587_cr())
          {
@@ -427,7 +415,7 @@
  
              if (!this.field_70170_p.field_72995_K)
              {
-@@ -2700,7 +2779,9 @@
+@@ -2700,7 +2782,9 @@
          if (!this.field_184627_bm.func_190926_b() && this.func_184587_cr())
          {
              this.func_184584_a(this.field_184627_bm, 16);
@@ -438,7 +426,7 @@
              this.func_184602_cy();
          }
      }
-@@ -2724,7 +2805,8 @@
+@@ -2724,7 +2808,8 @@
      {
          if (!this.field_184627_bm.func_190926_b())
          {
@@ -448,7 +436,7 @@
          }
  
          this.func_184602_cy();
-@@ -2852,6 +2934,31 @@
+@@ -2852,6 +2937,31 @@
          return true;
      }
  

--- a/patches/minecraft/net/minecraft/entity/EntityLivingBase.java.patch
+++ b/patches/minecraft/net/minecraft/entity/EntityLivingBase.java.patch
@@ -24,15 +24,27 @@
  import net.minecraft.advancements.CriteriaTriggers;
  import net.minecraft.block.Block;
  import net.minecraft.block.BlockLadder;
-@@ -72,6 +78,7 @@
+@@ -28,7 +34,6 @@
+ import net.minecraft.entity.item.EntityItem;
+ import net.minecraft.entity.item.EntityXPOrb;
+ import net.minecraft.entity.passive.AbstractHorse;
+-import net.minecraft.entity.passive.EntityWolf;
+ import net.minecraft.entity.player.EntityPlayer;
+ import net.minecraft.entity.player.EntityPlayerMP;
+ import net.minecraft.entity.projectile.EntityArrow;
+@@ -72,10 +77,9 @@
  import net.minecraft.util.math.Vec3d;
  import net.minecraft.world.World;
  import net.minecraft.world.WorldServer;
 +import net.minecraftforge.event.entity.living.LivingKnockBackEvent;
  import net.minecraftforge.fml.relauncher.Side;
  import net.minecraftforge.fml.relauncher.SideOnly;
- import org.apache.logging.log4j.LogManager;
-@@ -201,10 +208,11 @@
+-import org.apache.logging.log4j.LogManager;
+-import org.apache.logging.log4j.Logger;
+ 
+ public abstract class EntityLivingBase extends Entity
+ {
+@@ -201,10 +205,11 @@
          {
              float f = (float)MathHelper.func_76123_f(this.field_70143_R - 3.0F);
  
@@ -45,7 +57,7 @@
                  ((WorldServer)this.field_70170_p).func_175739_a(EnumParticleTypes.BLOCK_DUST, this.field_70165_t, this.field_70163_u, this.field_70161_v, i, 0.0D, 0.0D, 0.0D, 0.15000000596046448D, Block.func_176210_f(p_184231_4_));
              }
          }
-@@ -281,7 +289,7 @@
+@@ -281,7 +286,7 @@
                      }
                  }
  
@@ -54,7 +66,7 @@
                  {
                      this.func_184210_p();
                  }
-@@ -380,7 +388,7 @@
+@@ -380,7 +385,7 @@
              if (!this.field_70170_p.field_72995_K && (this.func_70684_aJ() || this.field_70718_bc > 0 && this.func_146066_aG() && this.field_70170_p.func_82736_K().func_82766_b("doMobLoot")))
              {
                  int i = this.func_70693_a(this.field_70717_bb);
@@ -63,7 +75,7 @@
                  while (i > 0)
                  {
                      int j = EntityXPOrb.func_70527_a(i);
-@@ -442,6 +450,7 @@
+@@ -442,6 +447,7 @@
      {
          this.field_70755_b = p_70604_1_;
          this.field_70756_c = this.field_70173_aa;
@@ -71,7 +83,7 @@
      }
  
      public EntityLivingBase func_110144_aD()
-@@ -670,8 +679,10 @@
+@@ -670,8 +676,10 @@
          else
          {
              Collection<PotionEffect> collection = this.field_70713_bf.values();
@@ -84,7 +96,7 @@
              this.func_82142_c(this.func_70644_a(MobEffects.field_76441_p));
          }
      }
-@@ -819,6 +830,8 @@
+@@ -819,6 +827,8 @@
  
      public void func_70691_i(float p_70691_1_)
      {
@@ -93,7 +105,7 @@
          float f = this.func_110143_aJ();
  
          if (f > 0.0F)
-@@ -839,6 +852,7 @@
+@@ -839,6 +849,7 @@
  
      public boolean func_70097_a(DamageSource p_70097_1_, float p_70097_2_)
      {
@@ -101,7 +113,7 @@
          if (this.func_180431_b(p_70097_1_))
          {
              return false;
-@@ -927,9 +941,9 @@
+@@ -927,9 +938,9 @@
                          this.field_70718_bc = 100;
                          this.field_70717_bb = (EntityPlayer)entity1;
                      }
@@ -113,7 +125,7 @@
  
                          if (entitywolf.func_70909_n())
                          {
-@@ -1127,7 +1141,7 @@
+@@ -1127,7 +1138,7 @@
  
      public void func_70669_a(ItemStack p_70669_1_)
      {
@@ -122,7 +134,7 @@
  
          for (int i = 0; i < 5; ++i)
          {
-@@ -1139,12 +1153,17 @@
+@@ -1139,12 +1150,17 @@
              vec3d1 = vec3d1.func_178789_a(-this.field_70125_A * 0.017453292F);
              vec3d1 = vec3d1.func_178785_b(-this.field_70177_z * 0.017453292F);
              vec3d1 = vec3d1.func_72441_c(this.field_70165_t, this.field_70163_u + (double)this.func_70047_e(), this.field_70161_v);
@@ -141,7 +153,7 @@
          if (!this.field_70729_aU)
          {
              Entity entity = p_70645_1_.func_76346_g();
-@@ -1165,18 +1184,26 @@
+@@ -1165,18 +1181,26 @@
  
              if (!this.field_70170_p.field_72995_K)
              {
@@ -173,33 +185,33 @@
              }
  
              this.field_70170_p.func_72960_a(this, (byte)3);
-@@ -1195,19 +1222,21 @@
+@@ -1195,19 +1219,22 @@
  
      public void func_70653_a(Entity p_70653_1_, float p_70653_2_, double p_70653_3_, double p_70653_5_)
      {
-+        LivingKnockBackEvent event = new LivingKnockBackEvent(this, p_70653_1_, p_70653_2_, p_70653_3_, p_70653_5_);
-+        if (net.minecraftforge.common.ForgeHooks.onLivingKnockBack(event)) return;
++        LivingKnockBackEvent event = net.minecraftforge.common.ForgeHooks.onLivingKnockBack(this, p_70653_1_, p_70653_2_, p_70653_3_, p_70653_5_);
++        if(event.isCanceled()) return;
++        p_70653_2_ = event.getStrength(); p_70653_3_ = event.getRatioX(); p_70653_5_ = event.getRatioZ();
          if (this.field_70146_Z.nextDouble() >= this.func_110148_a(SharedMonsterAttributes.field_111266_c).func_111126_e())
          {
              this.field_70160_al = true;
--            float f = MathHelper.func_76133_a(p_70653_3_ * p_70653_3_ + p_70653_5_ * p_70653_5_);
-+            float f = MathHelper.func_76133_a(event.getRatioX() * event.getRatioX() + event.getRatioZ() * event.getRatioZ());
+             float f = MathHelper.func_76133_a(p_70653_3_ * p_70653_3_ + p_70653_5_ * p_70653_5_);
              this.field_70159_w /= 2.0D;
              this.field_70179_y /= 2.0D;
 -            this.field_70159_w -= p_70653_3_ / (double)f * (double)p_70653_2_;
 -            this.field_70179_y -= p_70653_5_ / (double)f * (double)p_70653_2_;
-+            this.field_70159_w -= event.getRatioX() / (double)f * (double) event.getStrength();
-+            this.field_70179_y -= event.getRatioZ() / (double)f * (double) event.getStrength();
++            this.field_70159_w -= p_70653_3_ / (double)f * (double) p_70653_2_;
++            this.field_70179_y -= p_70653_5_ / (double)f * (double) p_70653_2_;
  
              if (this.field_70122_E)
              {
                  this.field_70181_x /= 2.0D;
 -                this.field_70181_x += (double)p_70653_2_;
-+                this.field_70181_x += (double) event.getStrength();
++                this.field_70181_x += (double) p_70653_2_;
  
                  if (this.field_70181_x > 0.4000000059604645D)
                  {
-@@ -1253,15 +1282,7 @@
+@@ -1253,15 +1280,7 @@
              BlockPos blockpos = new BlockPos(i, j, k);
              IBlockState iblockstate = this.field_70170_p.func_180495_p(blockpos);
              Block block = iblockstate.func_177230_c();
@@ -216,7 +228,7 @@
          }
      }
  
-@@ -1287,6 +1308,9 @@
+@@ -1287,6 +1306,9 @@
  
      public void func_180430_e(float p_180430_1_, float p_180430_2_)
      {
@@ -226,7 +238,7 @@
          super.func_180430_e(p_180430_1_, p_180430_2_);
          PotionEffect potioneffect = this.func_70660_b(MobEffects.field_76430_j);
          float f = potioneffect == null ? 0.0F : (float)(potioneffect.func_76458_c() + 1);
-@@ -1303,7 +1327,7 @@
+@@ -1303,7 +1325,7 @@
  
              if (iblockstate.func_185904_a() != Material.field_151579_a)
              {
@@ -235,7 +247,7 @@
                  this.func_184185_a(soundtype.func_185842_g(), soundtype.func_185843_a() * 0.5F, soundtype.func_185847_b() * 0.75F);
              }
          }
-@@ -1380,17 +1404,20 @@
+@@ -1380,17 +1402,20 @@
      {
          if (!this.func_180431_b(p_70665_1_))
          {
@@ -257,7 +269,7 @@
                  this.func_110149_m(this.func_110139_bj() - p_70665_2_);
              }
          }
-@@ -1447,6 +1474,11 @@
+@@ -1447,6 +1472,11 @@
  
      public void func_184609_a(EnumHand p_184609_1_)
      {
@@ -269,7 +281,7 @@
          if (!this.field_82175_bq || this.field_110158_av >= this.func_82166_i() / 2 || this.field_110158_av < 0)
          {
              this.field_110158_av = -1;
-@@ -1694,7 +1726,7 @@
+@@ -1694,7 +1724,7 @@
  
                      if (!this.field_70170_p.func_184143_b(axisalignedbb1))
                      {
@@ -278,7 +290,7 @@
                          {
                              this.func_70634_a(d11, this.field_70163_u + 1.0D, d12);
                              return;
-@@ -1702,14 +1734,14 @@
+@@ -1702,14 +1732,14 @@
  
                          BlockPos blockpos = new BlockPos(d11, this.field_70163_u - 1.0D, d12);
  
@@ -295,7 +307,7 @@
                      {
                          d1 = d11;
                          d13 = this.field_70163_u + 2.0D;
-@@ -1781,6 +1813,7 @@
+@@ -1781,6 +1811,7 @@
          }
  
          this.field_70160_al = true;
@@ -303,7 +315,7 @@
      }
  
      protected void func_70629_bd()
-@@ -1874,7 +1907,8 @@
+@@ -1874,7 +1905,8 @@
  
                          if (this.field_70122_E)
                          {
@@ -313,7 +325,7 @@
                          }
  
                          float f7 = 0.16277136F / (f6 * f6 * f6);
-@@ -1894,7 +1928,8 @@
+@@ -1894,7 +1926,8 @@
  
                          if (this.field_70122_E)
                          {
@@ -323,7 +335,7 @@
                          }
  
                          if (this.func_70617_f_())
-@@ -2054,6 +2089,7 @@
+@@ -2054,6 +2087,7 @@
  
      public void func_70071_h_()
      {
@@ -331,7 +343,7 @@
          super.func_70071_h_();
          this.func_184608_ct();
  
-@@ -2096,7 +2132,9 @@
+@@ -2096,7 +2130,9 @@
  
                  if (!ItemStack.func_77989_b(itemstack1, itemstack))
                  {
@@ -341,7 +353,7 @@
  
                      if (!itemstack.func_190926_b())
                      {
-@@ -2575,6 +2613,40 @@
+@@ -2575,6 +2611,40 @@
          this.field_70752_e = true;
      }
  
@@ -382,7 +394,7 @@
      public abstract EnumHandSide func_184591_cq();
  
      public boolean func_184587_cr()
-@@ -2595,12 +2667,19 @@
+@@ -2595,12 +2665,19 @@
  
              if (itemstack == this.field_184627_bm)
              {
@@ -403,7 +415,7 @@
                  {
                      this.func_71036_o();
                  }
-@@ -2618,8 +2697,10 @@
+@@ -2618,8 +2695,10 @@
  
          if (!itemstack.func_190926_b() && !this.func_184587_cr())
          {
@@ -415,7 +427,7 @@
  
              if (!this.field_70170_p.field_72995_K)
              {
-@@ -2700,7 +2781,9 @@
+@@ -2700,7 +2779,9 @@
          if (!this.field_184627_bm.func_190926_b() && this.func_184587_cr())
          {
              this.func_184584_a(this.field_184627_bm, 16);
@@ -426,7 +438,7 @@
              this.func_184602_cy();
          }
      }
-@@ -2724,7 +2807,8 @@
+@@ -2724,7 +2805,8 @@
      {
          if (!this.field_184627_bm.func_190926_b())
          {
@@ -436,7 +448,7 @@
          }
  
          this.func_184602_cy();
-@@ -2852,6 +2936,31 @@
+@@ -2852,6 +2934,31 @@
          return true;
      }
  

--- a/patches/minecraft/net/minecraft/item/Item.java.patch
+++ b/patches/minecraft/net/minecraft/item/Item.java.patch
@@ -68,7 +68,7 @@
          CreativeTabs creativetabs = this.func_77640_w();
          return creativetabs != null && (p_194125_1_ == CreativeTabs.field_78027_g || p_194125_1_ == creativetabs);
      }
-@@ -435,11 +441,704 @@
+@@ -435,11 +445,704 @@
          return false;
      }
  
@@ -773,7 +773,7 @@
      public static void func_150900_l()
      {
          func_179214_a(Blocks.field_150350_a, new ItemAir(Blocks.field_150350_a));
-@@ -999,6 +1698,8 @@
+@@ -999,6 +1702,8 @@
          private final float field_78010_h;
          private final float field_78011_i;
          private final int field_78008_j;
@@ -782,7 +782,7 @@
  
          private ToolMaterial(int p_i1874_3_, int p_i1874_4_, float p_i1874_5_, float p_i1874_6_, int p_i1874_7_)
          {
-@@ -1034,6 +1735,7 @@
+@@ -1034,6 +1739,7 @@
              return this.field_78008_j;
          }
  
@@ -790,7 +790,7 @@
          public Item func_150995_f()
          {
              if (this == WOOD)
-@@ -1057,5 +1759,21 @@
+@@ -1057,5 +1763,21 @@
                  return this == DIAMOND ? Items.field_151045_i : null;
              }
          }

--- a/patches/minecraft/net/minecraft/item/Item.java.patch
+++ b/patches/minecraft/net/minecraft/item/Item.java.patch
@@ -68,7 +68,7 @@
          CreativeTabs creativetabs = this.func_77640_w();
          return creativetabs != null && (p_194125_1_ == CreativeTabs.field_78027_g || p_194125_1_ == creativetabs);
      }
-@@ -435,11 +445,704 @@
+@@ -435,11 +441,704 @@
          return false;
      }
  
@@ -773,7 +773,7 @@
      public static void func_150900_l()
      {
          func_179214_a(Blocks.field_150350_a, new ItemAir(Blocks.field_150350_a));
-@@ -999,6 +1702,8 @@
+@@ -999,6 +1698,8 @@
          private final float field_78010_h;
          private final float field_78011_i;
          private final int field_78008_j;
@@ -782,7 +782,7 @@
  
          private ToolMaterial(int p_i1874_3_, int p_i1874_4_, float p_i1874_5_, float p_i1874_6_, int p_i1874_7_)
          {
-@@ -1034,6 +1739,7 @@
+@@ -1034,6 +1735,7 @@
              return this.field_78008_j;
          }
  
@@ -790,7 +790,7 @@
          public Item func_150995_f()
          {
              if (this == WOOD)
-@@ -1057,5 +1763,21 @@
+@@ -1057,5 +1759,21 @@
                  return this == DIAMOND ? Items.field_151045_i : null;
              }
          }

--- a/src/main/java/net/minecraftforge/common/ForgeHooks.java
+++ b/src/main/java/net/minecraftforge/common/ForgeHooks.java
@@ -560,9 +560,11 @@ public class ForgeHooks
         return !MinecraftForge.EVENT_BUS.post(new LivingAttackEvent(entity, src, amount));
     }
 
-    public static boolean onLivingKnockBack(LivingKnockBackEvent event)
+    public static LivingKnockBackEvent onLivingKnockBack(EntityLivingBase target, Entity attacker, float strength, double ratioX, double ratioZ)
     {
-        return MinecraftForge.EVENT_BUS.post(event);
+        LivingKnockBackEvent event = new LivingKnockBackEvent(target, attacker, strength, ratioX, ratioZ);
+        MinecraftForge.EVENT_BUS.post(event);
+        return event;
     }
 
     public static float onLivingHurt(EntityLivingBase entity, DamageSource src, float amount)

--- a/src/main/java/net/minecraftforge/common/ForgeHooks.java
+++ b/src/main/java/net/minecraftforge/common/ForgeHooks.java
@@ -560,9 +560,9 @@ public class ForgeHooks
         return !MinecraftForge.EVENT_BUS.post(new LivingAttackEvent(entity, src, amount));
     }
 
-    public static boolean onLivingKnockBack(EntityLivingBase target, Entity attacker, float strength, double ratioX, double ratioZ)
+    public static boolean onLivingKnockBack(LivingKnockBackEvent event)
     {
-    	return !MinecraftForge.EVENT_BUS.post(new LivingKnockBackEvent(target, attacker, strength, ratioX, ratioZ));
+    	return !MinecraftForge.EVENT_BUS.post(event);
     }
 
     public static float onLivingHurt(EntityLivingBase entity, DamageSource src, float amount)

--- a/src/main/java/net/minecraftforge/common/ForgeHooks.java
+++ b/src/main/java/net/minecraftforge/common/ForgeHooks.java
@@ -35,12 +35,6 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
-
-import org.apache.commons.io.FilenameUtils;
-import org.apache.commons.io.IOUtils;
-
 import com.google.common.collect.Lists;
 import com.google.common.collect.Queues;
 import com.google.common.collect.Sets;
@@ -102,10 +96,10 @@ import net.minecraft.util.text.ITextComponent;
 import net.minecraft.util.text.TextComponentString;
 import net.minecraft.util.text.TextFormatting;
 import net.minecraft.util.text.event.ClickEvent;
-import net.minecraft.world.EnumDifficulty;
-import net.minecraft.world.GameType;
 import net.minecraft.world.IBlockAccess;
 import net.minecraft.world.World;
+import net.minecraft.world.EnumDifficulty;
+import net.minecraft.world.GameType;
 import net.minecraft.world.storage.loot.LootEntry;
 import net.minecraft.world.storage.loot.LootTable;
 import net.minecraft.world.storage.loot.LootTableManager;
@@ -147,6 +141,12 @@ import net.minecraftforge.fml.common.network.handshake.NetworkDispatcher.Connect
 import net.minecraftforge.fml.relauncher.ReflectionHelper;
 import net.minecraftforge.registries.IForgeRegistry;
 import net.minecraftforge.registries.RegistryManager;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+import org.apache.commons.io.FilenameUtils;
+import org.apache.commons.io.IOUtils;
 
 public class ForgeHooks
 {

--- a/src/main/java/net/minecraftforge/common/ForgeHooks.java
+++ b/src/main/java/net/minecraftforge/common/ForgeHooks.java
@@ -35,6 +35,12 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+import org.apache.commons.io.FilenameUtils;
+import org.apache.commons.io.IOUtils;
+
 import com.google.common.collect.Lists;
 import com.google.common.collect.Queues;
 import com.google.common.collect.Sets;
@@ -96,10 +102,10 @@ import net.minecraft.util.text.ITextComponent;
 import net.minecraft.util.text.TextComponentString;
 import net.minecraft.util.text.TextFormatting;
 import net.minecraft.util.text.event.ClickEvent;
-import net.minecraft.world.IBlockAccess;
-import net.minecraft.world.World;
 import net.minecraft.world.EnumDifficulty;
 import net.minecraft.world.GameType;
+import net.minecraft.world.IBlockAccess;
+import net.minecraft.world.World;
 import net.minecraft.world.storage.loot.LootEntry;
 import net.minecraft.world.storage.loot.LootTable;
 import net.minecraft.world.storage.loot.LootTableManager;
@@ -120,6 +126,7 @@ import net.minecraftforge.event.entity.living.LivingEvent.LivingJumpEvent;
 import net.minecraftforge.event.entity.living.LivingEvent.LivingUpdateEvent;
 import net.minecraftforge.event.entity.living.LivingFallEvent;
 import net.minecraftforge.event.entity.living.LivingHurtEvent;
+import net.minecraftforge.event.entity.living.LivingKnockBackEvent;
 import net.minecraftforge.event.entity.living.LivingSetAttackTargetEvent;
 import net.minecraftforge.event.entity.living.LootingLevelEvent;
 import net.minecraftforge.event.entity.player.AnvilRepairEvent;
@@ -140,12 +147,6 @@ import net.minecraftforge.fml.common.network.handshake.NetworkDispatcher.Connect
 import net.minecraftforge.fml.relauncher.ReflectionHelper;
 import net.minecraftforge.registries.IForgeRegistry;
 import net.minecraftforge.registries.RegistryManager;
-
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
-
-import org.apache.commons.io.FilenameUtils;
-import org.apache.commons.io.IOUtils;
 
 public class ForgeHooks
 {
@@ -557,6 +558,11 @@ public class ForgeHooks
     public static boolean onLivingAttack(EntityLivingBase entity, DamageSource src, float amount)
     {
         return !MinecraftForge.EVENT_BUS.post(new LivingAttackEvent(entity, src, amount));
+    }
+
+    public static boolean onLivingKnockBack(EntityLivingBase target, Entity attacker, float strength, double ratioX, double ratioZ)
+    {
+    	return !MinecraftForge.EVENT_BUS.post(new LivingKnockBackEvent(target, attacker, strength, ratioX, ratioZ));
     }
 
     public static float onLivingHurt(EntityLivingBase entity, DamageSource src, float amount)

--- a/src/main/java/net/minecraftforge/common/ForgeHooks.java
+++ b/src/main/java/net/minecraftforge/common/ForgeHooks.java
@@ -562,7 +562,7 @@ public class ForgeHooks
 
     public static boolean onLivingKnockBack(LivingKnockBackEvent event)
     {
-    	return !MinecraftForge.EVENT_BUS.post(event);
+        return MinecraftForge.EVENT_BUS.post(event);
     }
 
     public static float onLivingHurt(EntityLivingBase entity, DamageSource src, float amount)

--- a/src/main/java/net/minecraftforge/event/entity/living/LivingKnockBackEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/living/LivingKnockBackEvent.java
@@ -36,7 +36,7 @@ import net.minecraftforge.fml.common.eventhandler.Cancelable;
  * {@link EntityMob#attackEntityAsMob(Entity)} and 
  * {@link EntityPlayer#attackTargetEntityWithCurrentItem(Entity)} <br>
  * <br>
- * This event is fired via {@link ForgeHooks#onLivingKnockBack(LivingKnockBackEvent)}.<br>
+ * This event is fired via {@link ForgeHooks#onLivingKnockBack(EntityLivingBase, Entity, float, double, double)}.<br>
  * <br>
  * {@link #attacker} contains the Entity that caused the knock back. <br>
  * {@link #strength} contains the strength of the knock back. <br>

--- a/src/main/java/net/minecraftforge/event/entity/living/LivingKnockBackEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/living/LivingKnockBackEvent.java
@@ -56,14 +56,17 @@ public class LivingKnockBackEvent extends LivingEvent
     protected Entity attacker;
     protected float strength;
     protected double ratioX, ratioZ;
+    protected final Entity originalAttacker;
+    protected final float originalStrength;
+    protected final double originalRatioX, originalRatioZ;
 
     public LivingKnockBackEvent(EntityLivingBase target, Entity attacker, float strength, double ratioX, double ratioZ)
     {
         super(target);
-        this.attacker = attacker;
-        this.strength = strength;
-        this.ratioX = ratioX;
-        this.ratioZ = ratioZ;
+        this.attacker = this.originalAttacker = attacker;
+        this.strength = this.originalStrength = strength;
+        this.ratioX = this.originalRatioX = ratioX;
+        this.ratioZ = this.originalRatioZ = ratioZ;
     }
 
     public Entity getAttacker() {return this.attacker;}
@@ -73,6 +76,14 @@ public class LivingKnockBackEvent extends LivingEvent
     public double getRatioX() {return this.ratioX;}
 
     public double getRatioZ() {return this.ratioZ;}
+
+    public Entity getOriginalAttacker() {return this.originalAttacker;}
+
+    public float getOriginalStrength() {return this.originalStrength;}
+
+    public double getOriginalRatioX() {return this.originalRatioX;}
+
+    public double getOriginalRatioZ() {return this.originalRatioZ;}
 
     public void setAttacker(Entity attacker) {this.attacker = attacker;}
 

--- a/src/main/java/net/minecraftforge/event/entity/living/LivingKnockBackEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/living/LivingKnockBackEvent.java
@@ -34,9 +34,9 @@ import net.minecraftforge.fml.common.eventhandler.Cancelable;
 @Cancelable
 public class LivingKnockBackEvent extends LivingEvent
 {
-	private final Entity attacker;
-	private float strength;
-	private double ratioX, ratioZ;
+	protected Entity attacker;
+	protected float strength;
+	protected double ratioX, ratioZ;
 
 	public LivingKnockBackEvent(EntityLivingBase target, Entity attacker, float strength, double ratioX, double ratioZ)
 	{
@@ -54,4 +54,12 @@ public class LivingKnockBackEvent extends LivingEvent
 	public double getRatioX() {return this.ratioX;}
 
 	public double getRatioZ() {return this.ratioZ;}
+
+	public void setAttacker(Entity attacker) {this.attacker = attacker;}
+
+	public void setStrength(float strength) {this.strength = strength;}
+
+	public void setRatioX(double ratioX) {this.ratioX = ratioX;}
+
+	public void setRatioZ(double ratioZ) {this.ratioZ = ratioZ;}
 }

--- a/src/main/java/net/minecraftforge/event/entity/living/LivingKnockBackEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/living/LivingKnockBackEvent.java
@@ -1,0 +1,57 @@
+package net.minecraftforge.event.entity.living;
+
+import net.minecraft.entity.Entity;
+import net.minecraft.entity.EntityLivingBase;
+import net.minecraft.entity.monster.EntityMob;
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.util.DamageSource;
+import net.minecraftforge.common.ForgeHooks;
+import net.minecraftforge.common.MinecraftForge;
+import net.minecraftforge.fml.common.eventhandler.Cancelable;
+
+/**
+ * LivingAttackEvent is fired when a living entity is about to be knocked back. <br>
+ * This event is fired whenever an Entity is knocked back in
+ * {@link EntityLivingBase#attackEntityFrom(DamageSource, float)}, 
+ * {@link EntityLivingBase#blockWithShield(EntityLivingBase)}, 
+ * {@link EntityMob#attackEntityAsMob(Entity)} and 
+ * {@link EntityPlayer#attackTargetEntityWithCurrentItem(Entity)} <br>
+ * <br>
+ * This event is fired via {@link ForgeHooks#onLivingKnockBack(EntityLivingBase, Entity, float, double, double)}.<br>
+ * <br>
+ * {@link #attacker} contains the Entity that caused the knock back. <br>
+ * {@link #strength} contains the strength of the knock back. <br>
+ * {@link #ratioX} contains the x ratio of the knock back. <br>
+ * {@link #ratioZ} contains the z ratio of the knock back. <br>
+ * <br>
+ * This event is {@link Cancelable}.<br>
+ * If this event is canceled, the entity is not knocked back.<br>
+ * <br>
+ * This event does not have a result. {@link HasResult}<br>
+ *<br>
+ * This event is fired on the {@link MinecraftForge#EVENT_BUS}.
+ **/
+@Cancelable
+public class LivingKnockBackEvent extends LivingEvent
+{
+	private final Entity attacker;
+	private float strength;
+	private double ratioX, ratioZ;
+
+	public LivingKnockBackEvent(EntityLivingBase target, Entity attacker, float strength, double ratioX, double ratioZ)
+	{
+		super(target);
+		this.attacker = attacker;
+		this.strength = strength;
+		this.ratioX = ratioX;
+		this.ratioZ = ratioZ;
+	}
+
+	public Entity getAttacker() {return this.attacker;}
+
+	public float getStrength() {return this.strength;}
+
+	public double getRatioX() {return this.ratioX;}
+
+	public double getRatioZ() {return this.ratioZ;}
+}

--- a/src/main/java/net/minecraftforge/event/entity/living/LivingKnockBackEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/living/LivingKnockBackEvent.java
@@ -1,3 +1,22 @@
+/*
+ * Minecraft Forge
+ * Copyright (c) 2017.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation version 2.1
+ * of the License.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
 package net.minecraftforge.event.entity.living;
 
 import net.minecraft.entity.Entity;
@@ -10,14 +29,14 @@ import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.fml.common.eventhandler.Cancelable;
 
 /**
- * LivingAttackEvent is fired when a living entity is about to be knocked back. <br>
+ * LivingKnockBackEvent is fired when a living entity is about to be knocked back. <br>
  * This event is fired whenever an Entity is knocked back in
  * {@link EntityLivingBase#attackEntityFrom(DamageSource, float)}, 
  * {@link EntityLivingBase#blockWithShield(EntityLivingBase)}, 
  * {@link EntityMob#attackEntityAsMob(Entity)} and 
  * {@link EntityPlayer#attackTargetEntityWithCurrentItem(Entity)} <br>
  * <br>
- * This event is fired via {@link ForgeHooks#onLivingKnockBack(EntityLivingBase, Entity, float, double, double)}.<br>
+ * This event is fired via {@link ForgeHooks#onLivingKnockBack(LivingKnockBackEvent)}.<br>
  * <br>
  * {@link #attacker} contains the Entity that caused the knock back. <br>
  * {@link #strength} contains the strength of the knock back. <br>
@@ -34,32 +53,32 @@ import net.minecraftforge.fml.common.eventhandler.Cancelable;
 @Cancelable
 public class LivingKnockBackEvent extends LivingEvent
 {
-	protected Entity attacker;
-	protected float strength;
-	protected double ratioX, ratioZ;
+    protected Entity attacker;
+    protected float strength;
+    protected double ratioX, ratioZ;
 
-	public LivingKnockBackEvent(EntityLivingBase target, Entity attacker, float strength, double ratioX, double ratioZ)
-	{
-		super(target);
-		this.attacker = attacker;
-		this.strength = strength;
-		this.ratioX = ratioX;
-		this.ratioZ = ratioZ;
-	}
+    public LivingKnockBackEvent(EntityLivingBase target, Entity attacker, float strength, double ratioX, double ratioZ)
+    {
+        super(target);
+        this.attacker = attacker;
+        this.strength = strength;
+        this.ratioX = ratioX;
+        this.ratioZ = ratioZ;
+    }
 
-	public Entity getAttacker() {return this.attacker;}
+    public Entity getAttacker() {return this.attacker;}
 
-	public float getStrength() {return this.strength;}
+    public float getStrength() {return this.strength;}
 
-	public double getRatioX() {return this.ratioX;}
+    public double getRatioX() {return this.ratioX;}
 
-	public double getRatioZ() {return this.ratioZ;}
+    public double getRatioZ() {return this.ratioZ;}
 
-	public void setAttacker(Entity attacker) {this.attacker = attacker;}
+    public void setAttacker(Entity attacker) {this.attacker = attacker;}
 
-	public void setStrength(float strength) {this.strength = strength;}
+    public void setStrength(float strength) {this.strength = strength;}
 
-	public void setRatioX(double ratioX) {this.ratioX = ratioX;}
+    public void setRatioX(double ratioX) {this.ratioX = ratioX;}
 
-	public void setRatioZ(double ratioZ) {this.ratioZ = ratioZ;}
+    public void setRatioZ(double ratioZ) {this.ratioZ = ratioZ;}
 }

--- a/src/test/java/net/minecraftforge/debug/KnockBackHookTest.java
+++ b/src/test/java/net/minecraftforge/debug/KnockBackHookTest.java
@@ -1,11 +1,12 @@
 package net.minecraftforge.debug;
 
+import net.minecraft.entity.passive.EntityCow;
 import net.minecraft.entity.passive.EntitySheep;
 import net.minecraftforge.event.entity.living.LivingKnockBackEvent;
 import net.minecraftforge.fml.common.Mod;
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
 
-@Mod(modid = "kbhtest", name = "Knock Back Hook Test")
+@Mod(modid = "kbhtest", name = "Knock Back Hook Test", version = "1.0")
 @Mod.EventBusSubscriber
 public class KnockBackHookTest
 {
@@ -13,6 +14,10 @@ public class KnockBackHookTest
 	public static void onKnockBack(LivingKnockBackEvent event)
 	{
 		if(event.getEntityLiving() instanceof EntitySheep)
+		{
+			event.setStrength(0.1F);
+		}
+		else if(event.getEntityLiving() instanceof EntityCow)
 		{
 			event.setCanceled(true);
 		}

--- a/src/test/java/net/minecraftforge/debug/KnockBackHookTest.java
+++ b/src/test/java/net/minecraftforge/debug/KnockBackHookTest.java
@@ -10,16 +10,21 @@ import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
 @Mod.EventBusSubscriber
 public class KnockBackHookTest
 {
+	private static final boolean ENABLED = false;
+
 	@SubscribeEvent
 	public static void onKnockBack(LivingKnockBackEvent event)
 	{
-		if(event.getEntityLiving() instanceof EntitySheep)
+		if(ENABLED)
 		{
-			event.setStrength(0.1F);
-		}
-		else if(event.getEntityLiving() instanceof EntityCow)
-		{
-			event.setCanceled(true);
+			if(event.getEntityLiving() instanceof EntitySheep)
+			{
+				event.setStrength(0.2F);
+			}
+			else if(event.getEntityLiving() instanceof EntityCow)
+			{
+				event.setCanceled(true);
+			}
 		}
 	}
 }

--- a/src/test/java/net/minecraftforge/debug/KnockBackHookTest.java
+++ b/src/test/java/net/minecraftforge/debug/KnockBackHookTest.java
@@ -1,0 +1,20 @@
+package net.minecraftforge.debug;
+
+import net.minecraft.entity.passive.EntitySheep;
+import net.minecraftforge.event.entity.living.LivingKnockBackEvent;
+import net.minecraftforge.fml.common.Mod;
+import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
+
+@Mod(modid = "kbhtest", name = "Knock Back Hook Test")
+@Mod.EventBusSubscriber
+public class KnockBackHookTest
+{
+	@SubscribeEvent
+	public static void onKnockBack(LivingKnockBackEvent event)
+	{
+		if(event.getEntityLiving() instanceof EntitySheep)
+		{
+			event.setCanceled(true);
+		}
+	}
+}

--- a/src/test/java/net/minecraftforge/debug/KnockBackHookTest.java
+++ b/src/test/java/net/minecraftforge/debug/KnockBackHookTest.java
@@ -10,21 +10,21 @@ import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
 @Mod.EventBusSubscriber
 public class KnockBackHookTest
 {
-	private static final boolean ENABLED = false;
+    private static final boolean ENABLED = false;
 
-	@SubscribeEvent
-	public static void onKnockBack(LivingKnockBackEvent event)
-	{
-		if(ENABLED)
-		{
-			if(event.getEntityLiving() instanceof EntitySheep)
-			{
-				event.setStrength(0.2F);
-			}
-			else if(event.getEntityLiving() instanceof EntityCow)
-			{
-				event.setCanceled(true);
-			}
-		}
-	}
+    @SubscribeEvent
+    public static void onKnockBack(LivingKnockBackEvent event)
+    {
+        if(ENABLED)
+        {
+            if(event.getEntityLiving() instanceof EntitySheep)
+            {
+                event.setStrength(0.2F);
+            }
+            else if(event.getEntityLiving() instanceof EntityCow)
+            {
+                event.setCanceled(true);
+            }
+        }
+    }
 }


### PR DESCRIPTION
## **Changes**
Added _LivingKnockBackEvent_ event, added _onLivingKnockBack_ method to _ForgeHooks_, added _onLivingKnockBack_ check and values into _EntityLivingBase_ _knockBack_ method. Added _KnockBackHookTest_ test mod.

## **Why?**
This event fixes the problems with hard-coded vanilla knock back. Modders can now cancel, change or add their own knock back to entities with quite a few parameters at their disposal. I've seen a few threads asking for this type of event before.
This addition is absolutely necessary to me as currently I'm creating a mod that adds a few new attributes for items including a knock back attribute. Using events like _LivingAttackEvent_ to cancel knock back is very inefficient, sometimes inconsistent and potentially unstable.

## **How does it work?**
It's as simple as any other event in forge. The _LivingKnockBackEvent_ contains a few handy parameters like the attacker, strength and ratios which can be changed resulting in a highly flexible event.
I added a test mod _KnockBackHookTest_ for anyone doubting the hook's functionality.