### PR TITLE
Fix network buffers not being released in some places

### DIFF
--- a/src/main/java/net/minecraftforge/fml/common/network/FMLIndexedMessageToMessageCodec.java
+++ b/src/main/java/net/minecraftforge/fml/common/network/FMLIndexedMessageToMessageCodec.java
@@ -100,6 +100,7 @@ public abstract class FMLIndexedMessageToMessageCodec<A> extends MessageToMessag
         ctx.channel().attr(INBOUNDPACKETTRACKER).get().set(new WeakReference<FMLProxyPacket>(msg));
         decodeInto(ctx, payload.slice(), newMsg);
         out.add(newMsg);
+        payload.release();
     }
 
     /**

--- a/src/main/java/net/minecraftforge/fml/common/network/handshake/ChannelRegistrationHandler.java
+++ b/src/main/java/net/minecraftforge/fml/common/network/handshake/ChannelRegistrationHandler.java
@@ -47,6 +47,7 @@ public class ChannelRegistrationHandler extends SimpleChannelInboundHandler<FMLP
             String[] split = channels.split("\0");
             Set<String> channelSet = ImmutableSet.copyOf(split);
             FMLCommonHandler.instance().fireNetRegistrationEvent(manager, channelSet, msg.channel(), side);
+            msg.payload().release();
         }
         else
         {


### PR DESCRIPTION
Fixes #4282.

No errors produced when connecting to a dedicated server while using `PARANOID` leak detection settings.

Not sure how this does/doesn't relate to #4509, but it may well help.