### PR TITLE
Fix buffer leak in vanilla custom payload packet handling (MC-121884)

### DIFF
--- a/patches/minecraft/net/minecraft/client/network/NetHandlerPlayClient.java.patch
+++ b/patches/minecraft/net/minecraft/client/network/NetHandlerPlayClient.java.patch
@@ -82,3 +82,11 @@
  
              if (potion != null)
              {
+@@ -1856,6 +1867,7 @@
+             }
+             finally
+             {
++                if (false) // Forge: let packet handle releasing buffer
+                 packetbuffer.release();
+             }
+         }

--- a/patches/minecraft/net/minecraft/network/play/server/SPacketCustomPayload.java.patch
+++ b/patches/minecraft/net/minecraft/network/play/server/SPacketCustomPayload.java.patch
@@ -1,6 +1,6 @@
 --- ../src-base/minecraft/net/minecraft/network/play/server/SPacketCustomPayload.java
 +++ ../src-work/minecraft/net/minecraft/network/play/server/SPacketCustomPayload.java
-@@ -46,7 +46,11 @@
+@@ -46,12 +46,18 @@
      public void func_148840_b(PacketBuffer p_148840_1_) throws IOException
      {
          p_148840_1_.func_180714_a(this.field_149172_a);
@@ -12,3 +12,10 @@
      }
  
      public void func_148833_a(INetHandlerPlayClient p_148833_1_)
+     {
+         p_148833_1_.func_147240_a(this);
++        // Forge: fix network buffer leaks (MC-121884)
++        if (this.field_149171_b != null) this.field_149171_b.release();
+     }
+ 
+     @SideOnly(Side.CLIENT)


### PR DESCRIPTION
Reported as [MC-121884](https://bugs.mojang.com/browse/MC-121884).

While `CPacketCustomPayload` releases the buffer it's holding before returning from `processPacket`, `SPacketCustomPayload` doesn't.

This PR adds the same logic to `SPacketCustomPayload`, preventing buffer leaks.

For some reason, the buffer can be released in `NetHandlerPlayClient.handleCustomPayload`, but this is only done as part of the handling for "MC|TrList" packets, and no others. To avoid calling `release` twice, that code is dummied out.
