### PR TITLE
Fix server incorrectly marked as stopped before forge's handleServerStopped()

### DIFF
--- a/patches/minecraft/net/minecraft/server/MinecraftServer.java.patch
+++ b/patches/minecraft/net/minecraft/server/MinecraftServer.java.patch
@@ -129,7 +129,6 @@
              {
 -                this.field_71316_v = true;
                  this.func_71260_j();
-+                this.field_71316_v = true;
              }
              catch (Throwable throwable)
              {


### PR DESCRIPTION
On big modpacks, this caused the error when internal server is not stopped but player could load the world, and then the game freezes at "Loading World" screen, with errors in log.
Details provided here:
http://www.minecraftforge.net/forum/topic/61613-cannot-reload-singleplayer-world-because-of-ongoing-internal-server-transition-is-in-progress/?_fromLogin=1

Patch was tested, and it really fixes that problem.