### PR TITLE
Fix the unsuitable implementation of shapeless recipes

### DIFF
--- a/patches/minecraft/net/minecraft/client/util/RecipeItemHelper.java.patch
+++ b/patches/minecraft/net/minecraft/client/util/RecipeItemHelper.java.patch
@@ -1,0 +1,103 @@
+--- ../src-base/minecraft/net/minecraft/client/util/RecipeItemHelper.java
++++ ../src-work/minecraft/net/minecraft/client/util/RecipeItemHelper.java
+@@ -20,18 +20,21 @@
+ 
+ public class RecipeItemHelper
+ {
++    private final List<ItemStack> itemStackDictionary = new java.util.ArrayList<>();
+     public final Int2IntMap field_194124_a = new Int2IntOpenHashMap();
+ 
+     public void func_194112_a(ItemStack p_194112_1_)
+     {
+         if (!p_194112_1_.func_190926_b() && !p_194112_1_.func_77951_h() && !p_194112_1_.func_77948_v() && !p_194112_1_.func_82837_s())
+         {
+-            int i = func_194113_b(p_194112_1_);
+             int j = p_194112_1_.func_190916_E();
++            int i = this.itemStackDictionary.size();
++            this.itemStackDictionary.add(p_194112_1_);
+             this.func_194117_b(i, j);
+         }
+     }
+ 
++    @Deprecated
+     public static int func_194113_b(ItemStack p_194113_0_)
+     {
+         Item item = p_194113_0_.func_77973_b();
+@@ -84,6 +87,12 @@
+         return (new RecipeItemHelper.RecipePicker(p_194121_1_)).func_194102_b(p_194121_2_, p_194121_3_);
+     }
+ 
++    public ItemStack getItemStack(int packedInteger)
++    {
++        return packedInteger >= this.itemStackDictionary.size() ? ItemStack.field_190927_a : this.itemStackDictionary.get(packedInteger);
++    }
++
++    @Deprecated
+     public static ItemStack func_194115_b(int p_194115_0_)
+     {
+         return p_194115_0_ == 0 ? ItemStack.field_190927_a : new ItemStack(Item.func_150899_d(p_194115_0_ >> 16 & 65535), 1, p_194115_0_ & 65535);
+@@ -92,6 +101,7 @@
+     public void func_194119_a()
+     {
+         this.field_194124_a.clear();
++        this.itemStackDictionary.clear();
+     }
+ 
+     class RecipePicker
+@@ -119,11 +129,9 @@
+ 
+             for (int i = 0; i < this.field_194106_c.size(); ++i)
+             {
+-                IntList intlist = ((Ingredient)this.field_194106_c.get(i)).func_194139_b();
+-
+                 for (int j = 0; j < this.field_194109_f; ++j)
+                 {
+-                    if (intlist.contains(this.field_194108_e[j]))
++                    if (this.field_194106_c.get(i).apply(RecipeItemHelper.this.itemStackDictionary.get(this.field_194108_e[j])))
+                     {
+                         this.field_194110_g.set(this.func_194095_d(true, j, i));
+                     }
+@@ -202,18 +210,15 @@
+         {
+             IntCollection intcollection = new IntAVLTreeSet();
+ 
+-            for (Ingredient ingredient : this.field_194106_c)
++            for (int i = 0; i < RecipeItemHelper.this.itemStackDictionary.size(); ++i)
+             {
+-                intcollection.addAll(ingredient.func_194139_b());
+-            }
+-
+-            IntIterator intiterator = intcollection.iterator();
+-
+-            while (intiterator.hasNext())
+-            {
+-                if (!RecipeItemHelper.this.func_194120_a(intiterator.nextInt()))
++                ItemStack stack = RecipeItemHelper.this.itemStackDictionary.get(i);
++                for (Ingredient ingredient : this.field_194106_c)
+                 {
+-                    intiterator.remove();
++                    if (ingredient.apply(stack))
++                    {
++                        intcollection.add(i);
++                    }
+                 }
+             }
+ 
+@@ -359,11 +364,14 @@
+             for (Ingredient ingredient : this.field_194106_c)
+             {
+                 int l = 0;
+-                int i1;
+ 
+-                for (IntListIterator intlistiterator = ingredient.func_194139_b().iterator(); intlistiterator.hasNext(); l = Math.max(l, RecipeItemHelper.this.field_194124_a.get(i1)))
++                for (int i = 0; i < RecipeItemHelper.this.itemStackDictionary.size(); ++i)
+                 {
+-                    i1 = ((Integer)intlistiterator.next()).intValue();
++                    ItemStack stack = RecipeItemHelper.this.itemStackDictionary.get(i);
++                    if (ingredient.apply(stack))
++                    {
++                        l = Math.max(l, RecipeItemHelper.this.field_194124_a.get(i));
++                    }
+                 }
+ 
+                 if (k > 0)

--- a/patches/minecraft/net/minecraft/item/crafting/Ingredient.java.patch
+++ b/patches/minecraft/net/minecraft/item/crafting/Ingredient.java.patch
@@ -28,7 +28,15 @@
      public ItemStack[] func_193365_a()
      {
          return this.field_193371_b;
-@@ -76,6 +83,18 @@
+@@ -59,6 +66,7 @@
+         }
+     }
+ 
++    @Deprecated
+     public IntList func_194139_b()
+     {
+         if (this.field_194140_c == null)
+@@ -76,6 +84,18 @@
          return this.field_194140_c;
      }
  

--- a/patches/minecraft/net/minecraft/util/ServerRecipeBookHelper.java.patch
+++ b/patches/minecraft/net/minecraft/util/ServerRecipeBookHelper.java.patch
@@ -12,6 +12,15 @@
  
              if (this.field_194335_f != null && this.field_194336_g != null)
              {
+@@ -147,7 +152,7 @@
+             while (intlistiterator.hasNext())
+             {
+                 int k = ((Integer)intlistiterator.next()).intValue();
+-                int l = RecipeItemHelper.func_194115_b(k).func_77976_d();
++                int l = this.field_194331_b.getItemStack(k).func_77958_k();
+ 
+                 if (l < j1)
+                 {
 @@ -199,11 +204,11 @@
          int i = this.field_194336_g.func_174922_i();
          int j = this.field_194336_g.func_174923_h();
@@ -28,3 +37,12 @@
          }
  
          int j1 = 1;
+@@ -220,7 +225,7 @@
+                 }
+ 
+                 Slot slot = this.field_194337_h.get(j1);
+-                ItemStack itemstack = RecipeItemHelper.func_194115_b(((Integer)iterator.next()).intValue());
++                ItemStack itemstack = this.field_194331_b.getItemStack(iterator.next());
+ 
+                 if (itemstack.func_190926_b())
+                 {

--- a/src/main/java/net/minecraftforge/common/crafting/CompoundIngredient.java
+++ b/src/main/java/net/minecraftforge/common/crafting/CompoundIngredient.java
@@ -44,6 +44,7 @@ public class CompoundIngredient extends Ingredient
         return stacks;
     }
 
+    @Deprecated
     @Override
     @Nonnull
     @SideOnly(Side.CLIENT)

--- a/src/main/java/net/minecraftforge/oredict/OreIngredient.java
+++ b/src/main/java/net/minecraftforge/oredict/OreIngredient.java
@@ -64,6 +64,7 @@ public class OreIngredient extends Ingredient
     }
 
 
+    @Deprecated
     @Override
     @Nonnull
     public IntList getValidItemStacksPacked()


### PR DESCRIPTION
Fix #4516, and the following recipe works properly:
```json
{
  "result": {
    "item": "minecraft:diamond"
  },
  "ingredients": [
    {
      "item": "minecraft:dirt",
      "data": 0
    },
    {
      "item": "minecraft:dye",
      "data": 32767
    },
    {
      "item": "minecraft:dye",
      "data": 32767
    },
    {
      "item": "minecraft:dye",
      "data": 32767
    },
    {
      "item": "minecraft:dye",
      "data": 32767
    }
  ],
  "type": "minecraft:crafting_shapeless"
}
```