### PR TITLE
Fix entity spawn messages not handling buffer correctly

### DIFF
--- a/src/main/java/net/minecraftforge/fml/common/network/internal/EntitySpawnHandler.java
+++ b/src/main/java/net/minecraftforge/fml/common/network/internal/EntitySpawnHandler.java
@@ -60,7 +60,9 @@ public class EntitySpawnHandler extends SimpleChannelInboundHandler<FMLMessage.E
     {
         if (msg.getClass().equals(FMLMessage.EntitySpawnMessage.class))
         {
-            spawnEntity((FMLMessage.EntitySpawnMessage)msg);
+            FMLMessage.EntitySpawnMessage spawnMsg = (FMLMessage.EntitySpawnMessage) msg;
+            spawnEntity(spawnMsg);
+            spawnMsg.dataStream.release();
         }
     }
 

--- a/src/main/java/net/minecraftforge/fml/common/network/internal/FMLMessage.java
+++ b/src/main/java/net/minecraftforge/fml/common/network/internal/FMLMessage.java
@@ -244,7 +244,7 @@ public abstract class FMLMessage {
                 speedScaledY = dat.readInt() / 8000D;
                 speedScaledZ = dat.readInt() / 8000D;
             }
-            this.dataStream = dat;
+            this.dataStream = dat.retain();
         }
     }
     abstract void toBytes(ByteBuf buf);


### PR DESCRIPTION
Fixes #4523.

Adds missing `retain`/`release` calls for the buffer used by entity spawn packets.

I checked `FMLHandshakeMessage`, `FMLMessage` and `ForgeMessage`, and this was the only packet I could see that stores a `ByteBuf`.