### PR TITLE
Allow modded situations to bypass vanilla movement checks. 

### DIFF
--- a/patches/minecraft/net/minecraft/network/NetHandlerPlayServer.java.patch
+++ b/patches/minecraft/net/minecraft/network/NetHandlerPlayServer.java.patch
@@ -1,5 +1,23 @@
 --- ../src-base/minecraft/net/minecraft/network/NetHandlerPlayServer.java
 +++ ../src-work/minecraft/net/minecraft/network/NetHandlerPlayServer.java
+@@ -345,7 +345,7 @@
+                 double d9 = entity.field_70159_w * entity.field_70159_w + entity.field_70181_x * entity.field_70181_x + entity.field_70179_y * entity.field_70179_y;
+                 double d10 = d6 * d6 + d7 * d7 + d8 * d8;
+ 
+-                if (d10 - d9 > 100.0D && (!this.field_147367_d.func_71264_H() || !this.field_147367_d.func_71214_G().equals(entity.func_70005_c_())))
++                if (net.minecraftforge.common.ForgeHooks.onMovementCheck(entity, true) && d10 - d9 > 100.0D && (!this.field_147367_d.func_71264_H() || !this.field_147367_d.func_71214_G().equals(entity.func_70005_c_())))
+                 {
+                     field_147370_c.warn("{} (vehicle of {}) moved too quickly! {},{},{}", entity.func_70005_c_(), this.field_147369_b.func_70005_c_(), Double.valueOf(d6), Double.valueOf(d7), Double.valueOf(d8));
+                     this.field_147371_a.func_179290_a(new SPacketMoveVehicle(entity));
+@@ -518,7 +518,7 @@
+                                 i = 1;
+                             }
+ 
+-                            if (!this.field_147369_b.func_184850_K() && (!this.field_147369_b.func_71121_q().func_82736_K().func_82766_b("disableElytraMovementCheck") || !this.field_147369_b.func_184613_cA()))
++                            if (net.minecraftforge.common.ForgeHooks.onMovementCheck(field_147369_b, false) && !this.field_147369_b.func_184850_K() && (!this.field_147369_b.func_71121_q().func_82736_K().func_82766_b("disableElytraMovementCheck") || !this.field_147369_b.func_184613_cA()))
+                             {
+                                 float f2 = this.field_147369_b.func_184613_cA() ? 300.0F : 100.0F;
+ 
 @@ -671,7 +671,10 @@
                  double d2 = this.field_147369_b.field_70161_v - ((double)blockpos.func_177952_p() + 0.5D);
                  double d3 = d0 * d0 + d1 * d1 + d2 * d2;

--- a/src/main/java/net/minecraftforge/common/ForgeHooks.java
+++ b/src/main/java/net/minecraftforge/common/ForgeHooks.java
@@ -1376,6 +1376,6 @@ public class ForgeHooks
     
     public static boolean onMovementCheck(Entity entity, boolean isVehicle)
     {
-    	return !MinecraftForge.EVENT_BUS.post(new MovementCheckEvent(entity, isVehicle));
+        return !MinecraftForge.EVENT_BUS.post(new MovementCheckEvent(entity, isVehicle));
     }
 }

--- a/src/main/java/net/minecraftforge/common/ForgeHooks.java
+++ b/src/main/java/net/minecraftforge/common/ForgeHooks.java
@@ -111,6 +111,7 @@ import net.minecraftforge.event.DifficultyChangeEvent;
 import net.minecraftforge.event.ForgeEventFactory;
 import net.minecraftforge.event.ServerChatEvent;
 import net.minecraftforge.event.entity.EntityTravelToDimensionEvent;
+import net.minecraftforge.event.entity.MovementCheckEvent;
 import net.minecraftforge.event.entity.item.ItemTossEvent;
 import net.minecraftforge.event.entity.living.LivingAttackEvent;
 import net.minecraftforge.event.entity.living.LivingDamageEvent;
@@ -1371,5 +1372,10 @@ public class ForgeHooks
 
         if (recipes.size() > 0 || display.size() > 0)
             connection.sendPacket(new SPacketRecipeBook(state, recipes, display, isGuiOpen, isFilteringCraftable));
+    }
+    
+    public static boolean onMovementCheck(Entity entity, boolean isVehicle)
+    {
+    	return !MinecraftForge.EVENT_BUS.post(new MovementCheckEvent(entity, isVehicle));
     }
 }

--- a/src/main/java/net/minecraftforge/event/entity/MovementCheckEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/MovementCheckEvent.java
@@ -4,32 +4,30 @@ import net.minecraft.entity.Entity;
 import net.minecraftforge.fml.common.eventhandler.Cancelable;
 
 /**
- * This event is fired when the server does a movement check. There are two
- * movement checks, one for players and one for vehicles. The type can be
- * determined using {@link #isVehicleCheck()}. If canceled, the check will be
- * skipped and no corrective action will be applied.
+ * This event is fired when the server does a movement check. There are two movement checks, one for players and one for vehicles. The type can be determined using
+ * {@link #isVehicleCheck()}. If canceled, the check will be skipped and no corrective action will be applied.
  */
 @Cancelable
-public class MovementCheckEvent extends EntityEvent 
+public class MovementCheckEvent extends EntityEvent
 {
-	/**
-	 * Whether or not the check is for a vehicle.
-	 */
-	private final boolean vehicle;
+    /**
+     * Whether or not the check is for a vehicle.
+     */
+    private final boolean vehicle;
 
-	public MovementCheckEvent(Entity entity, boolean vehicle) 
-	{
-		super(entity);
-		this.vehicle = vehicle;
-	}
+    public MovementCheckEvent(Entity entity, boolean vehicle)
+    {
+        super(entity);
+        this.vehicle = vehicle;
+    }
 
-	/**
-	 * Allows differentiation between vehicle and player checks. 
-	 * 
-	 * @return Whether or not the check is for a vehicle. 
-	 */
-	public boolean isVehicleCheck() 
-	{
-		return this.vehicle;
-	}
+    /**
+     * Allows differentiation between vehicle and player checks.
+     * 
+     * @return Whether or not the check is for a vehicle.
+     */
+    public boolean isVehicleCheck()
+    {
+        return this.vehicle;
+    }
 }

--- a/src/main/java/net/minecraftforge/event/entity/MovementCheckEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/MovementCheckEvent.java
@@ -1,0 +1,35 @@
+package net.minecraftforge.event.entity;
+
+import net.minecraft.entity.Entity;
+import net.minecraftforge.fml.common.eventhandler.Cancelable;
+
+/**
+ * This event is fired when the server does a movement check. There are two
+ * movement checks, one for players and one for vehicles. The type can be
+ * determined using {@link #isVehicleCheck()}. If canceled, the check will be
+ * skipped and no corrective action will be applied.
+ */
+@Cancelable
+public class MovementCheckEvent extends EntityEvent 
+{
+	/**
+	 * Whether or not the check is for a vehicle.
+	 */
+	private final boolean vehicle;
+
+	public MovementCheckEvent(Entity entity, boolean vehicle) 
+	{
+		super(entity);
+		this.vehicle = vehicle;
+	}
+
+	/**
+	 * Allows differentiation between vehicle and player checks. 
+	 * 
+	 * @return Whether or not the check is for a vehicle. 
+	 */
+	public boolean isVehicleCheck() 
+	{
+		return this.vehicle;
+	}
+}

--- a/src/test/java/net/minecraftforge/debug/MovedTooQuicklyTest.java
+++ b/src/test/java/net/minecraftforge/debug/MovedTooQuicklyTest.java
@@ -31,16 +31,13 @@ public class MovedTooQuicklyTest
     @EventHandler
     public void onPreInit(FMLPreInitializationEvent event)
     {
-        if (ENABLED)
-        {
-            MinecraftForge.EVENT_BUS.register(this);
-        }
+        MinecraftForge.EVENT_BUS.register(this);
     }
 
     @SubscribeEvent
     public void onMovementCheck(MovementCheckEvent event)
     {
-        if (event.getEntity() instanceof EntityPlayer && ((EntityPlayer) event.getEntity()).getHeldItemMainhand().getItem() == pogostick)
+        if (ENABLED && event.getEntity() instanceof EntityPlayer && ((EntityPlayer) event.getEntity()).getHeldItemMainhand().getItem() == pogostick)
         {
             event.setCanceled(true);
         }

--- a/src/test/java/net/minecraftforge/debug/MovedTooQuicklyTest.java
+++ b/src/test/java/net/minecraftforge/debug/MovedTooQuicklyTest.java
@@ -1,0 +1,84 @@
+package net.minecraftforge.debug;
+
+import net.minecraft.client.renderer.block.model.ModelResourceLocation;
+import net.minecraft.creativetab.CreativeTabs;
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.item.Item;
+import net.minecraft.item.ItemStack;
+import net.minecraft.util.ActionResult;
+import net.minecraft.util.EnumActionResult;
+import net.minecraft.util.EnumHand;
+import net.minecraft.util.ResourceLocation;
+import net.minecraft.world.World;
+import net.minecraftforge.client.event.ModelRegistryEvent;
+import net.minecraftforge.client.model.ModelLoader;
+import net.minecraftforge.common.MinecraftForge;
+import net.minecraftforge.event.RegistryEvent;
+import net.minecraftforge.event.entity.MovementCheckEvent;
+import net.minecraftforge.fml.common.Mod;
+import net.minecraftforge.fml.common.Mod.EventHandler;
+import net.minecraftforge.fml.common.event.FMLPreInitializationEvent;
+import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
+import net.minecraftforge.fml.relauncher.Side;
+
+@Mod(modid = MovedTooQuicklyTest.MOD_ID, name = "Moved Too Quickly Test", version = "1.0")
+public class MovedTooQuicklyTest
+{
+    static final String MOD_ID = "movedtooquickly";
+    static final boolean ENABLED = false;
+    static Item pogostick = new ItemPogoStick();
+
+    @EventHandler
+    public void onPreInit(FMLPreInitializationEvent event)
+    {
+        if (ENABLED)
+        {
+            MinecraftForge.EVENT_BUS.register(this);
+        }
+    }
+
+    @SubscribeEvent
+    public void onMovementCheck(MovementCheckEvent event)
+    {
+        if (event.getEntity() instanceof EntityPlayer && ((EntityPlayer) event.getEntity()).getHeldItemMainhand().getItem() == pogostick)
+        {
+            event.setCanceled(true);
+        }
+    }
+
+    @SubscribeEvent
+    public void registerItem(RegistryEvent.Register<Item> event)
+    {
+        event.getRegistry().register(pogostick);
+    }
+
+    @Mod.EventBusSubscriber(value = Side.CLIENT, modid = MOD_ID)
+    public static class ClientEventHandler
+    {
+        @SubscribeEvent
+        public static void setupModels(ModelRegistryEvent event)
+        {
+            if (ENABLED)
+            {
+                ModelLoader.setCustomModelResourceLocation(pogostick, 0, new ModelResourceLocation(new ResourceLocation("minecraft", "stick"), "inventory"));
+            }
+        }
+    }
+
+    public static class ItemPogoStick extends Item
+    {
+        public ItemPogoStick()
+        {
+
+            this.setCreativeTab(CreativeTabs.MISC);
+            this.setUnlocalizedName(MOD_ID + ".pogostick");
+            this.setRegistryName("pogostick");
+        }
+
+        public ActionResult<ItemStack> onItemRightClick(World worldIn, EntityPlayer playerIn, EnumHand handIn)
+        {
+            playerIn.motionY += 5d;
+            return new ActionResult<ItemStack>(EnumActionResult.SUCCESS, playerIn.getHeldItem(handIn));
+        }
+    }
+}

--- a/src/test/resources/assets/movedtooquickly/lang/en_US.lang
+++ b/src/test/resources/assets/movedtooquickly/lang/en_US.lang
@@ -1,0 +1,1 @@
+item.movedtooquickly.pogostick.name=Pogo Stick (Movement Check)


### PR DESCRIPTION
The goal of this PR is to allow modded situations to bypass vanilla's movement speed checks. Many modded items and vehicles move faster than the vanilla check will allow, creating an effect similar to rubber-banding. Vanilla has implemented a bypass for the Elytra, however this check is not usable for modded situations. 

This PR fixes this issue by adding a new event which is fired when a movement speed check is done done. This allows mods authors to check for their situation, and cancel the event to bypass the vanilla check. 

This PR also includes a test mod which adds a stick item that will increase the user's Y motion when right clicked. This can be used to reproduce the rubber banding issue describe when connected to a server that you are not an operator of. Enabling the PR and the event will remove this rubber banding issue. 

Edit: One think to note is that the item I added will still trigger the flying kick if flying is not enabled on the server. Flying is not the same thing as moving too quickly, and modders already have the tools needed to account for that in their items. 