### PR TITLE
Fix dormant chunk cache allowing entity data to be overwritten

### DIFF
--- a/src/main/java/net/minecraftforge/common/ForgeChunkManager.java
+++ b/src/main/java/net/minecraftforge/common/ForgeChunkManager.java
@@ -1009,6 +1009,7 @@ public class ForgeChunkManager
 
         loadChunkEntities(entry.chunk, entry.nbt, world);
 
+        cache.invalidate(coords);
         return entry.chunk;
     }
 


### PR DESCRIPTION
See https://github.com/MinecraftForge/MinecraftForge/issues/3325#issuecomment-344954151.

While the (tile) entities are now being saved/restored correctly, due to a derp on my part, it was possible for the loaded chunk's data to be overwritten afterwards.

It's fixed here by invalidating the cached entry after loading the chunk.