### PR TITLE
[macOS] Fix missing text on loading error screens

### DIFF
--- a/patches/minecraft/net/minecraft/client/renderer/texture/TextureMap.java.patch
+++ b/patches/minecraft/net/minecraft/client/renderer/texture/TextureMap.java.patch
@@ -164,17 +164,16 @@
              {
                  String s = textureatlassprite1.func_94215_i();
                  map.remove(s);
-@@ -186,6 +257,9 @@
+@@ -186,6 +257,8 @@
          {
              textureatlassprite2.func_94217_a(this.field_94249_f);
          }
-+        org.lwjgl.opengl.GL11.glFlush(); // Some systems (mainly macs) need this to make sure the texture map creation finishes before moving on
 +        net.minecraftforge.client.ForgeHooksClient.onTextureStitchedPost(this);
 +        net.minecraftforge.fml.common.ProgressManager.pop(bar);
      }
  
      private boolean func_184397_a(IResourceManager p_184397_1_, final TextureAtlasSprite p_184397_2_)
-@@ -195,7 +269,7 @@
+@@ -195,7 +268,7 @@
          label62:
          {
              boolean flag;
@@ -183,7 +182,7 @@
              try
              {
                  iresource = p_184397_1_.func_110536_a(resourcelocation);
-@@ -292,7 +366,7 @@
+@@ -292,7 +365,7 @@
          }
          else
          {
@@ -192,7 +191,7 @@
  
              if (textureatlassprite == null)
              {
-@@ -318,4 +392,52 @@
+@@ -318,4 +391,52 @@
      {
          return this.field_94249_f;
      }

--- a/src/main/java/net/minecraftforge/fml/client/SplashProgress.java
+++ b/src/main/java/net/minecraftforge/fml/client/SplashProgress.java
@@ -651,6 +651,7 @@ public class SplashProgress
             checkThreadState();
             done = true;
             thread.join();
+            glFlush();              // process any remaining GL calls before releaseContext
             d.releaseContext();
             Display.getDrawable().makeCurrent();
             fontTexture.delete();

--- a/src/main/java/net/minecraftforge/fml/client/SplashProgress.java
+++ b/src/main/java/net/minecraftforge/fml/client/SplashProgress.java
@@ -651,7 +651,7 @@ public class SplashProgress
             checkThreadState();
             done = true;
             thread.join();
-            glFlush();              // process any remaining GL calls before releaseContext
+            glFlush();        // process any remaining GL calls before releaseContext (prevents missing textures on mac)
             d.releaseContext();
             Display.getDrawable().makeCurrent();
             fontTexture.delete();


### PR DESCRIPTION
This is a followup PR for #4082 as I discovered that loading error screens have no text when SplashProgress is enabled. This implements the original, broad fix proposed in the previous PR as the issue is not confined to just the texture atlas.