### PR TITLE
Fix errors caused by multi-target messages sent from LAN host

### DIFF
--- a/src/main/java/net/minecraftforge/fml/common/network/FMLOutboundHandler.java
+++ b/src/main/java/net/minecraftforge/fml/common/network/FMLOutboundHandler.java
@@ -304,8 +304,10 @@ public class FMLOutboundHandler extends ChannelOutboundHandlerAdapter {
         }
         for (NetworkDispatcher targetDispatcher : dispatchers)
         {
-            targetDispatcher.sendProxy((FMLProxyPacket) msg);
+            pkt.payload().retain();
+            targetDispatcher.sendProxy(pkt);
         }
+        pkt.payload().release();
     }
 
 }


### PR DESCRIPTION
Fix for [this issue](http://www.minecraftforge.net/forum/topic/61683-forge-11222537-sp-lan-disconnects/) reported on the forums.

The issue can be reproduced with the updated test mod seen in #4513, by changing the `sendTo` call to `sendToAll`.

Attempting to connect to a world opened to LAN from a second client will fail with an exception like this:
```
[17:06:01] [Netty Server IO #3/ERROR] [FML]: NetworkDispatcher exception
io.netty.util.IllegalReferenceCountException: refCnt: 0
	at io.netty.buffer.AbstractByteBuf.ensureAccessible(AbstractByteBuf.java:1408) ~[AbstractByteBuf.class:4.1.9.Final]
	at io.netty.buffer.UnpooledHeapByteBuf.array(UnpooledHeapByteBuf.java:154) ~[UnpooledHeapByteBuf.class:4.1.9.Final]
	at net.minecraft.network.PacketBuffer.array(PacketBuffer.java:1264) ~[PacketBuffer.class:?]
	at net.minecraftforge.fml.common.network.internal.FMLProxyPacket.toS3FPackets(FMLProxyPacket.java:151) ~[FMLProxyPacket.class:?]
	at net.minecraftforge.fml.common.network.handshake.NetworkDispatcher.write(NetworkDispatcher.java:538) ~[NetworkDispatcher.class:?]
	at io.netty.channel.AbstractChannelHandlerContext.invokeWrite0(AbstractChannelHandlerContext.java:738) ~[AbstractChannelHandlerContext.class:4.1.9.Final]
	at io.netty.channel.AbstractChannelHandlerContext.invokeWriteAndFlush(AbstractChannelHandlerContext.java:801) ~[AbstractChannelHandlerContext.class:4.1.9.Final]
	at io.netty.channel.AbstractChannelHandlerContext.write(AbstractChannelHandlerContext.java:814) ~[AbstractChannelHandlerContext.class:4.1.9.Final]
	at io.netty.channel.AbstractChannelHandlerContext.writeAndFlush(AbstractChannelHandlerContext.java:794) ~[AbstractChannelHandlerContext.class:4.1.9.Final]
	at io.netty.channel.AbstractChannelHandlerContext.writeAndFlush(AbstractChannelHandlerContext.java:831) ~[AbstractChannelHandlerContext.class:4.1.9.Final]
	at io.netty.channel.DefaultChannelPipeline.writeAndFlush(DefaultChannelPipeline.java:1032) ~[DefaultChannelPipeline.class:4.1.9.Final]
	at io.netty.channel.AbstractChannel.writeAndFlush(AbstractChannel.java:296) ~[AbstractChannel.class:4.1.9.Final]
	at net.minecraft.network.NetworkManager$4.run(NetworkManager.java:245) [NetworkManager$4.class:?]
	at io.netty.util.concurrent.AbstractEventExecutor.safeExecute(AbstractEventExecutor.java:163) [AbstractEventExecutor.class:4.1.9.Final]
	at io.netty.util.concurrent.SingleThreadEventExecutor.runAllTasks(SingleThreadEventExecutor.java:403) [SingleThreadEventExecutor.class:4.1.9.Final]
	at io.netty.channel.nio.NioEventLoop.run(NioEventLoop.java:442) [NioEventLoop.class:4.1.9.Final]
	at io.netty.util.concurrent.SingleThreadEventExecutor$5.run(SingleThreadEventExecutor.java:858) [SingleThreadEventExecutor$5.class:4.1.9.Final]
	at java.lang.Thread.run(Thread.java:748) [?:1.8.0_152]
```

In this instance, additional calls to `retain` are needed to keep the data accessible when sending to multiple targets. The call to `release` is to balance out the 'extra' `retain` call from the loop (e.g. so there is no change in the event of a single target).
