### PR TITLE
Fix BufferBuilder not expanding under some conditions.

### DIFF
--- a/patches/minecraft/net/minecraft/client/renderer/BufferBuilder.java.patch
+++ b/patches/minecraft/net/minecraft/client/renderer/BufferBuilder.java.patch
@@ -14,7 +14,7 @@
      public void func_178981_a(int[] p_178981_1_)
      {
 -        this.func_181670_b(p_178981_1_.length * 4);
-+        this.func_181670_b(p_178981_1_.length * 4 + this.field_179011_q.func_177338_f());
++        this.func_181670_b(p_178981_1_.length * 4 + this.field_179011_q.func_177338_f());//Forge, fix MC-122110
          this.field_178999_b.position(this.func_181664_j());
          this.field_178999_b.put(p_178981_1_);
          this.field_178997_d += p_178981_1_.length / this.field_179011_q.func_181719_f();

--- a/patches/minecraft/net/minecraft/client/renderer/BufferBuilder.java.patch
+++ b/patches/minecraft/net/minecraft/client/renderer/BufferBuilder.java.patch
@@ -9,6 +9,15 @@
      }
  
      public BufferBuilder.State func_181672_a()
+@@ -415,7 +417,7 @@
+ 
+     public void func_178981_a(int[] p_178981_1_)
+     {
+-        this.func_181670_b(p_178981_1_.length * 4);
++        this.func_181670_b(p_178981_1_.length * 4 + this.field_179011_q.func_177338_f());
+         this.field_178999_b.position(this.func_181664_j());
+         this.field_178999_b.put(p_178981_1_);
+         this.field_178997_d += p_178981_1_.length / this.field_179011_q.func_181719_f();
 @@ -506,15 +508,15 @@
                  break;
              case USHORT:

--- a/src/test/java/net/minecraftforge/test/BufferBuilderExpansionTest.java
+++ b/src/test/java/net/minecraftforge/test/BufferBuilderExpansionTest.java
@@ -1,0 +1,85 @@
+package net.minecraftforge.test;
+
+import net.minecraft.client.renderer.BufferBuilder;
+import net.minecraft.client.renderer.vertex.DefaultVertexFormats;
+import net.minecraft.client.renderer.vertex.VertexFormat;
+import org.junit.Test;
+
+import java.util.Arrays;
+
+import static org.junit.Assert.assertTrue;
+
+public class BufferBuilderExpansionTest
+{
+
+    public VertexFormat format = DefaultVertexFormats.POSITION;
+    // 4 quads.
+    public int num_quads = 4;
+    public int BUFFER_SIZE = format.getNextOffset() * (num_quads * 4);
+
+    @Test//Test the expansion of the buffer with addVertexData
+    public void testAddVertexExpansion()
+    {
+        BufferBuilder buffer = new BufferBuilder(BUFFER_SIZE / 4);
+        int prevCap = buffer.getByteBuffer().capacity();
+
+        int[] ints = new int[3 * 4];// 3 floats per the 4 vertices.
+        Arrays.fill(ints, Float.floatToIntBits(1.233F));//Just a random value.
+
+        buffer.begin(0x07, format);
+        for (int i = 0; i < num_quads + 2; i++)
+        {
+            buffer.addVertexData(ints);
+        }
+        buffer.finishDrawing();
+
+        assertTrue("BufferBuilder's capacity didn't change.", buffer.getByteBuffer().capacity() > prevCap);
+    }
+
+    @Test//Test the expansion of the buffer with endVertex.
+    public void testEndVertexExpansion()
+    {
+        BufferBuilder buffer = new BufferBuilder(BUFFER_SIZE / 4);
+        int prevCap = buffer.getByteBuffer().capacity();
+
+        buffer.begin(0x07, format);
+        for (int i = 0; i < num_quads + 2; i++)
+        {
+            for (int j = 0; j < 4; j++)
+            {
+                buffer.pos(1.233, 1.233, 1.233).endVertex();
+            }
+        }
+        buffer.finishDrawing();
+
+        assertTrue("BufferBuilder's capacity didn't change.", buffer.getByteBuffer().capacity() > prevCap);
+    }
+
+    @Test//Test the expansion of the buffer if addVertexData fills it and pos / tex / endVertex is used.
+    public void testMixedExpansion()
+    {
+        BufferBuilder buffer = new BufferBuilder(BUFFER_SIZE / 4);
+        int prevCap = buffer.getByteBuffer().capacity();
+
+        int[] ints = new int[3 * 4];
+        Arrays.fill(ints, Float.floatToIntBits(1.233F));
+
+        buffer.begin(0x07, format);
+        for (int i = 0; i < num_quads; i++)
+        {
+            buffer.addVertexData(ints);
+        }
+
+        for (int i = 0; i < num_quads + 2; i++)
+        {
+            for (int j = 0; j < 4; j++)
+            {
+                buffer.pos(1.233, 1.233, 1.233).endVertex();
+            }
+        }
+        buffer.finishDrawing();
+
+        assertTrue("BufferBuilder's capacity didn't change.", buffer.getByteBuffer().capacity() > prevCap);
+    }
+
+}


### PR DESCRIPTION
This PR fixes an issue where BufferBuilder does not expand under certain conditions. For example, `addVertexData` checks to see if there is enough space for the current quad being added, whilst `endVertex` checks to see if there is enough space for the _next_ vertex, The issue here is when the buffer is filled or extremely close to using `addVertexData` calls to `pos`, `tex` and so on will cause the buffer to overflow. This pr fixes that issue by modifying `addVertexData`'s call to `growBuffer`, checking if there is enough room for the data provided and the next vertex. The included JUnit test checks for multiple instances of buffer expansion and makes sure it indeed does when full.