### PR TITLE
Add event to allow for mods to cancel the loading of advancements.

### DIFF
--- a/patches/minecraft/net/minecraft/advancements/AdvancementManager.java.patch
+++ b/patches/minecraft/net/minecraft/advancements/AdvancementManager.java.patch
@@ -8,3 +8,19 @@
          field_192784_c.func_192083_a(map);
  
          for (Advancement advancement : field_192784_c.func_192088_b())
+@@ -101,6 +102,7 @@
+                 if (astring.length == 2)
+                 {
+                     ResourceLocation resourcelocation = new ResourceLocation(astring[0], astring[1]);
++                    if (net.minecraftforge.common.MinecraftForge.EVENT_BUS.post(new net.minecraftforge.event.advancement.AdvancementAboutToLoadEvent(resourcelocation))) continue;
+ 
+                     try
+                     {
+@@ -172,6 +174,7 @@
+                         Path path2 = path.relativize(path1);
+                         String s = FilenameUtils.removeExtension(path2.toString()).replaceAll("\\\\", "/");
+                         ResourceLocation resourcelocation = new ResourceLocation("minecraft", s);
++                        if (net.minecraftforge.common.MinecraftForge.EVENT_BUS.post(new net.minecraftforge.event.advancement.AdvancementAboutToLoadEvent(resourcelocation))) continue;
+ 
+                         if (!p_192777_1_.containsKey(resourcelocation))
+                         {

--- a/src/main/java/net/minecraftforge/common/ForgeHooks.java
+++ b/src/main/java/net/minecraftforge/common/ForgeHooks.java
@@ -1322,6 +1322,7 @@ public class ForgeHooks
 
                 String name = FilenameUtils.removeExtension(relative).replaceAll("\\\\", "/");
                 ResourceLocation key = new ResourceLocation(mod.getModId(), name);
+                if (MinecraftForge.EVENT_BUS.post(new net.minecraftforge.event.advancement.AdvancementAboutToLoadEvent(key))) return true;
 
                 if (!map.containsKey(key))
                 {

--- a/src/main/java/net/minecraftforge/event/advancement/AdvancementAboutToLoadEvent.java
+++ b/src/main/java/net/minecraftforge/event/advancement/AdvancementAboutToLoadEvent.java
@@ -1,0 +1,32 @@
+package net.minecraftforge.event.advancement;
+
+import net.minecraft.util.ResourceLocation;
+import net.minecraftforge.fml.common.eventhandler.Cancelable;
+import net.minecraftforge.fml.common.eventhandler.Event;
+
+/**
+ * Fired when a script file is about to be read and used to construct an Advancement$Builder. <br>
+ * <br>
+ * {@link #location} is the {@link ResourceLocation} for the advancement. <br>
+ * <br>
+ * This event is {@link Cancelable}. <br>
+ * If canceled, the script file will not be read, and the Advancement$Builder will not be constructed. <br>
+ * 
+ * @author Blargerist
+ *
+ */
+@Cancelable
+public class AdvancementAboutToLoadEvent extends Event
+{
+    private final ResourceLocation location;
+
+    public AdvancementAboutToLoadEvent(final ResourceLocation location)
+    {
+        this.location = location;
+    }
+
+    public ResourceLocation getLocation()
+    {
+        return this.location;
+    }
+}

--- a/src/test/java/net/minecraftforge/debug/AdvancementRemovalTest.java
+++ b/src/test/java/net/minecraftforge/debug/AdvancementRemovalTest.java
@@ -1,0 +1,43 @@
+package net.minecraftforge.debug;
+
+import org.apache.logging.log4j.Logger;
+
+import net.minecraftforge.event.advancement.AdvancementAboutToLoadEvent;
+import net.minecraftforge.fml.common.Mod;
+import net.minecraftforge.fml.common.Mod.EventHandler;
+import net.minecraftforge.fml.common.event.FMLPreInitializationEvent;
+import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
+
+@Mod(modid = "advancementremovaltest", name = "Advancement removal test mod", version = "1.0", acceptableRemoteVersions = "*")
+@Mod.EventBusSubscriber
+public class AdvancementRemovalTest
+{
+    static final boolean ENABLED = false;
+    private static Logger logger;
+
+    @EventHandler
+    public static void preInit(final FMLPreInitializationEvent event)
+    {
+        if (!ENABLED)
+        {
+            return;
+        }
+
+        logger = event.getModLog();
+    }
+
+    @SubscribeEvent
+    public static void onAdvancementAboutToLoad(final AdvancementAboutToLoadEvent event)
+    {
+        if (!ENABLED)
+        {
+            return;
+        }
+
+        if (event.getLocation().getResourceDomain().equals("minecraft") && event.getLocation().getResourcePath().startsWith("nether"))
+        {
+            logger.info("Removing advancement: {}", event.getLocation().toString());
+            event.setCanceled(true);
+        }
+    }
+}


### PR DESCRIPTION
Adds a basic event, fired during the three loops which load advancement Json files and use them to build Advancement$Builder objects, immediately after the ResourceLocation is created. If canceled, the loop is continued, causing the advancement to not be loaded/built.

This is useful for removing advancements before they are even loaded, bypassing extreme log spam from advancement parsing errors, as seen in #4500.

Do note, the test mod has an enable boolean, which is currently set to off. If you're going to test it, please be sure to turn it on first. 