### PR TITLE
Make async chunk loading a config option

### DIFF
--- a/patches/minecraft/net/minecraft/world/chunk/storage/AnvilChunkLoader.java.patch
+++ b/patches/minecraft/net/minecraft/world/chunk/storage/AnvilChunkLoader.java.patch
@@ -1,6 +1,6 @@
 --- ../src-base/minecraft/net/minecraft/world/chunk/storage/AnvilChunkLoader.java
 +++ ../src-work/minecraft/net/minecraft/world/chunk/storage/AnvilChunkLoader.java
-@@ -49,9 +49,30 @@
+@@ -49,9 +49,31 @@
          this.field_193416_e = p_i46673_2_;
      }
  
@@ -26,12 +26,13 @@
 +        return null;
 +    }
 +
++    @Nullable
 +    public Object[] loadChunk__Async(World p_75815_1_, int p_75815_2_, int p_75815_3_) throws IOException
 +    {
          ChunkPos chunkpos = new ChunkPos(p_75815_2_, p_75815_3_);
          NBTTagCompound nbttagcompound = this.field_75828_a.get(chunkpos);
  
-@@ -67,7 +88,7 @@
+@@ -67,7 +89,7 @@
              nbttagcompound = this.field_193416_e.func_188257_a(FixTypes.CHUNK, CompressedStreamTools.func_74794_a(datainputstream));
          }
  
@@ -40,7 +41,7 @@
      }
  
      public boolean func_191063_a(int p_191063_1_, int p_191063_2_)
-@@ -80,6 +101,12 @@
+@@ -80,6 +102,13 @@
      @Nullable
      protected Chunk func_75822_a(World p_75822_1_, int p_75822_2_, int p_75822_3_, NBTTagCompound p_75822_4_)
      {
@@ -48,12 +49,13 @@
 +        return data != null ? (Chunk)data[0] : null;
 +    }
 +
++    @Nullable
 +    protected Object[] checkedReadChunkFromNBT__Async(World p_75822_1_, int p_75822_2_, int p_75822_3_, NBTTagCompound p_75822_4_)
 +    {
          if (!p_75822_4_.func_150297_b("Level", 10))
          {
              field_151505_a.error("Chunk file at {},{} is missing level data, skipping", Integer.valueOf(p_75822_2_), Integer.valueOf(p_75822_3_));
-@@ -103,10 +130,29 @@
+@@ -103,10 +132,29 @@
                      field_151505_a.error("Chunk file at {},{} is in the wrong location; relocating. (Expected {}, {}, got {}, {})", Integer.valueOf(p_75822_2_), Integer.valueOf(p_75822_3_), Integer.valueOf(p_75822_2_), Integer.valueOf(p_75822_3_), Integer.valueOf(chunk.field_76635_g), Integer.valueOf(chunk.field_76647_h));
                      nbttagcompound.func_74768_a("xPos", p_75822_2_);
                      nbttagcompound.func_74768_a("zPos", p_75822_3_);
@@ -84,7 +86,7 @@
              }
          }
      }
-@@ -121,7 +167,10 @@
+@@ -121,7 +169,10 @@
              NBTTagCompound nbttagcompound1 = new NBTTagCompound();
              nbttagcompound.func_74782_a("Level", nbttagcompound1);
              nbttagcompound.func_74768_a("DataVersion", 1343);
@@ -95,7 +97,7 @@
              this.func_75824_a(p_75816_2_.func_76632_l(), nbttagcompound);
          }
          catch (Exception exception)
-@@ -305,11 +354,19 @@
+@@ -305,11 +356,19 @@
              {
                  NBTTagCompound nbttagcompound2 = new NBTTagCompound();
  
@@ -115,7 +117,7 @@
              }
          }
  
-@@ -318,8 +375,16 @@
+@@ -318,8 +377,16 @@
  
          for (TileEntity tileentity : p_75820_1_.func_177434_r().values())
          {
@@ -132,7 +134,7 @@
          }
  
          p_75820_3_.func_74782_a("TileEntities", nbttaglist2);
-@@ -345,6 +410,18 @@
+@@ -345,6 +412,18 @@
  
              p_75820_3_.func_74782_a("TileTicks", nbttaglist3);
          }
@@ -151,7 +153,7 @@
      }
  
      private Chunk func_75823_a(World p_75823_1_, NBTTagCompound p_75823_2_)
-@@ -388,6 +465,16 @@
+@@ -388,6 +467,16 @@
              chunk.func_76616_a(p_75823_2_.func_74770_j("Biomes"));
          }
  
@@ -168,7 +170,7 @@
          NBTTagList nbttaglist1 = p_75823_2_.func_150295_c("Entities", 10);
  
          for (int j1 = 0; j1 < nbttaglist1.func_74745_c(); ++j1)
-@@ -431,8 +518,6 @@
+@@ -431,8 +520,6 @@
                  p_75823_1_.func_180497_b(new BlockPos(nbttagcompound3.func_74762_e("x"), nbttagcompound3.func_74762_e("y"), nbttagcompound3.func_74762_e("z")), block, nbttagcompound3.func_74762_e("t"), nbttagcompound3.func_74762_e("p"));
              }
          }

--- a/patches/minecraft/net/minecraft/world/gen/ChunkProviderServer.java.patch
+++ b/patches/minecraft/net/minecraft/world/gen/ChunkProviderServer.java.patch
@@ -4,7 +4,7 @@
      public final IChunkLoader field_73247_e;
      public final Long2ObjectMap<Chunk> field_73244_f = new Long2ObjectOpenHashMap<Chunk>(8192);
      public final WorldServer field_73251_h;
-+    private Set<Long> loadingChunks = com.google.common.collect.Sets.newHashSet();
++    private final Set<Long> loadingChunks = com.google.common.collect.Sets.newHashSet();
  
      public ChunkProviderServer(WorldServer p_i46838_1_, IChunkLoader p_i46838_2_, IChunkGenerator p_i46838_3_)
      {
@@ -17,7 +17,7 @@
 +    }
  
 +    @Nullable
-+    public Chunk loadChunk(int p_186028_1_, int p_186028_2_, Runnable runnable)
++    public Chunk loadChunk(int p_186028_1_, int p_186028_2_, @Nullable Runnable runnable)
 +    {
 +        Chunk chunk = this.func_186026_b(p_186028_1_, p_186028_2_);
          if (chunk == null)
@@ -44,7 +44,7 @@
 +            else
 +            {
 +                net.minecraft.world.chunk.storage.AnvilChunkLoader loader = (net.minecraft.world.chunk.storage.AnvilChunkLoader) this.field_73247_e;
-+                if (runnable == null)
++                if (runnable == null || !net.minecraftforge.common.ForgeChunkManager.asyncChunkLoading)
 +                    chunk = net.minecraftforge.common.chunkio.ChunkIOExecutor.syncChunkLoad(this.field_73251_h, loader, this, p_186028_1_, p_186028_2_);
 +                else if (loader.func_191063_a(p_186028_1_, p_186028_2_))
 +                {

--- a/src/main/java/net/minecraftforge/common/ForgeChunkManager.java
+++ b/src/main/java/net/minecraftforge/common/ForgeChunkManager.java
@@ -113,6 +113,8 @@ public class ForgeChunkManager
     private static int playerTicketLength;
     private static int dormantChunkCacheSize;
 
+    public static boolean asyncChunkLoading;
+
     public static final List<String> MOD_PROP_ORDER = new ArrayList<String>(2);
 
     private static Set<String> warnedMods = Sets.newHashSet();
@@ -1099,6 +1101,13 @@ public class ForgeChunkManager
         dormantChunkCacheSize = temp.getInt(0);
         propOrder.add("dormantChunkCacheSize");
         FMLLog.log.info("Configured a dormant chunk cache size of {}", temp.getInt(0));
+
+        temp = config.get("defaults", "asyncChunkLoading", true);
+        temp.setComment("Load chunks asynchronously for players, reducing load on the server thread.\n" +
+                    "Can be disabled to help troubleshoot chunk loading issues.");
+        temp.setLanguageKey("forge.configgui.asyncChunkLoading");
+        asyncChunkLoading = temp.getBoolean(true);
+        propOrder.add("asyncChunkLoading");
 
         config.setCategoryPropertyOrder("defaults", propOrder);
 

--- a/src/main/resources/assets/forge/lang/en_US.lang
+++ b/src/main/resources/assets/forge/lang/en_US.lang
@@ -75,6 +75,8 @@ forge.configgui.alwaysSetupTerrainOffThread.tooltip=Enable forge to queue all ch
 
 forge.configgui.modID.tooltip=The mod ID that you want to define override settings for.
 forge.configgui.modID=Mod ID
+forge.configgui.asyncChunkLoading=Async Chunk Loading
+forge.configgui.asyncChunkLoading.tooltip=Load chunks asynchronously for players, reducing load on the server thread. Can be disabled to help troubleshoot chunk loading issues.
 forge.configgui.dormantChunkCacheSize.tooltip=Unloaded chunks can first be kept in a dormant cache for quicker loading times. Specify the size (in chunks) of that cache here.
 forge.configgui.dormantChunkCacheSize=Dormant Chunk Cache Size
 forge.configgui.enableModOverrides.tooltip=Enable this setting to allow custom per-mod settings to be defined.


### PR DESCRIPTION
As this is something in Forge that works differently from vanilla, it's good to have it be configurable, mainly because it makes troubleshooting issues easier.

This adds a boolean config entry that allows the async loading of player chunks to be disabled, causing all chunks to be loaded synchronously. The existing logic is otherwise unchanged.

Also, a few missing nullability annotations in Forge-added chunk loading methods are fixed.