### PR TITLE
Avoid copying Forge Registry keys, values, and entries

### DIFF
--- a/src/main/java/net/minecraftforge/common/ForgeModContainer.java
+++ b/src/main/java/net/minecraftforge/common/ForgeModContainer.java
@@ -494,7 +494,7 @@ public class ForgeModContainer extends DummyModContainer implements WorldAccessC
 
     private static void registerAllBiomesAndGenerateEvents()
     {
-        for (Biome biome : ForgeRegistries.BIOMES.getValues())
+        for (Biome biome : ForgeRegistries.BIOMES.getValuesCollection())
         {
             if (biome.decorator instanceof DeferredBiomeDecorator)
             {

--- a/src/main/java/net/minecraftforge/registries/ForgeRegistry.java
+++ b/src/main/java/net/minecraftforge/registries/ForgeRegistry.java
@@ -26,6 +26,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 
+import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
 import org.apache.commons.lang3.Validate;
@@ -188,19 +189,27 @@ public class ForgeRegistry<V extends IForgeRegistryEntry<V>> implements IForgeRe
     @Override
     public Set<ResourceLocation> getKeys()
     {
-        return ImmutableSet.copyOf(this.names.keySet());
+        return Collections.unmodifiableSet(this.names.keySet());
     }
 
+    @Deprecated
     @Override
     public List<V> getValues()
     {
         return ImmutableList.copyOf(this.names.values());
     }
 
+    @Nonnull
+    @Override
+    public Collection<V> getValuesCollection()
+    {
+        return Collections.unmodifiableSet(this.names.values());
+    }
+
     @Override
     public Set<Entry<ResourceLocation, V>> getEntries()
     {
-        return ImmutableSet.copyOf(this.names.entrySet());
+        return Collections.unmodifiableSet(this.names.entrySet());
     }
 
     @SuppressWarnings("unchecked")

--- a/src/main/java/net/minecraftforge/registries/ForgeRegistry.java
+++ b/src/main/java/net/minecraftforge/registries/ForgeRegistry.java
@@ -192,6 +192,9 @@ public class ForgeRegistry<V extends IForgeRegistryEntry<V>> implements IForgeRe
         return Collections.unmodifiableSet(this.names.keySet());
     }
 
+    /**
+     * @deprecated use {@link #getValuesCollection} to avoid copying
+     */
     @Deprecated
     @Override
     public List<V> getValues()

--- a/src/main/java/net/minecraftforge/registries/IForgeRegistry.java
+++ b/src/main/java/net/minecraftforge/registries/IForgeRegistry.java
@@ -19,6 +19,7 @@
 
 package net.minecraftforge.registries;
 
+import java.util.Collection;
 import java.util.List;
 import java.util.Map.Entry;
 import java.util.Set;
@@ -48,7 +49,12 @@ public interface IForgeRegistry<V extends IForgeRegistryEntry<V>> extends Iterab
     @Nullable ResourceLocation getKey(V value);
 
     @Nonnull Set<ResourceLocation>           getKeys();
+    @Deprecated // TODO: remove in 1.13
     @Nonnull List<V>                         getValues();
+    @Nonnull
+    default Collection<V>                    getValuesCollection() {
+        return getValues();
+    }
     @Nonnull Set<Entry<ResourceLocation, V>> getEntries();
 
     /**

--- a/src/main/java/net/minecraftforge/registries/IForgeRegistry.java
+++ b/src/main/java/net/minecraftforge/registries/IForgeRegistry.java
@@ -49,10 +49,11 @@ public interface IForgeRegistry<V extends IForgeRegistryEntry<V>> extends Iterab
     @Nullable ResourceLocation getKey(V value);
 
     @Nonnull Set<ResourceLocation>           getKeys();
+    /** @deprecated use {@link #getValuesCollection} */
     @Deprecated // TODO: remove in 1.13
     @Nonnull List<V>                         getValues();
     @Nonnull
-    default Collection<V>                    getValuesCollection() {
+    default Collection<V>                    getValuesCollection() { // TODO rename this to getValues in 1.13
         return getValues();
     }
     @Nonnull Set<Entry<ResourceLocation, V>> getEntries();

--- a/src/main/java/net/minecraftforge/registries/NamespacedDefaultedWrapper.java
+++ b/src/main/java/net/minecraftforge/registries/NamespacedDefaultedWrapper.java
@@ -1,5 +1,6 @@
 package net.minecraftforge.registries;
 
+import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -104,10 +105,8 @@ class NamespacedDefaultedWrapper<V extends IForgeRegistryEntry<V>> extends Regis
     @Nullable
     public V getRandomObject(Random random)
     {
-        List<V> lst = this.delegate.getValues();
-        if (lst.isEmpty())
-            return null;
-        return lst.get(random.nextInt(lst.size()));
+        Collection<V> values = this.delegate.getValuesCollection();
+        return values.stream().skip(random.nextInt(values.size())).findFirst().orElse(null);
     }
 
     //internal

--- a/src/main/java/net/minecraftforge/registries/NamespacedWrapper.java
+++ b/src/main/java/net/minecraftforge/registries/NamespacedWrapper.java
@@ -1,5 +1,7 @@
 package net.minecraftforge.registries;
 
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -97,10 +99,8 @@ class NamespacedWrapper<V extends IForgeRegistryEntry<V>> extends RegistryNamesp
     @Nullable
     public V getRandomObject(Random random)
     {
-        List<V> lst = this.delegate.getValues();
-        if (lst.isEmpty())
-            return null;
-        return lst.get(random.nextInt(lst.size()));
+        Collection<V> values = this.delegate.getValuesCollection();
+        return values.stream().skip(random.nextInt(values.size())).findFirst().orElse(null);
     }
 
     //internal

--- a/src/test/java/net/minecraftforge/debug/FluidHandlerTest.java
+++ b/src/test/java/net/minecraftforge/debug/FluidHandlerTest.java
@@ -130,7 +130,7 @@ public class FluidHandlerTest
     private static List<ItemStack> getAllItems()
     {
         NonNullList<ItemStack> list = NonNullList.create();
-        for (Item item : ForgeRegistries.ITEMS.getValues())
+        for (Item item : ForgeRegistries.ITEMS.getValuesCollection())
         {
             for (CreativeTabs tab : item.getCreativeTabs())
             {


### PR DESCRIPTION
This improves performance when mods get the keys, values, or entries from a Forge registry.

This also adds a `Collection` version of `getValues` and deprecates the old `getValues` because it was copying a `Set` into a `List`. By making the new method return a `Collection` it doesn't restrict the implementation from changes in the future, and we can avoid copying the values.

I came across this performance problem when profiling some big packs. It's not a huge hotspot but it is easy to fix so might as well.