### PR TITLE
Don't force IPv4 network stack if IPv6 is specifically requested

### DIFF
--- a/patches/minecraft/net/minecraft/network/NetworkSystem.java.patch
+++ b/patches/minecraft/net/minecraft/network/NetworkSystem.java.patch
@@ -25,7 +25,15 @@
          }
      };
      private final MinecraftServer field_151273_d;
-@@ -110,7 +110,7 @@
+@@ -79,6 +79,7 @@
+ 
+     public void func_151265_a(InetAddress p_151265_1_, int p_151265_2_) throws IOException
+     {
++        if (p_151265_1_ instanceof java.net.Inet6Address) System.setProperty("java.net.preferIPv4Stack", "false");
+         synchronized (this.field_151274_e)
+         {
+             Class <? extends ServerSocketChannel > oclass;
+@@ -110,7 +111,7 @@
                          ;
                      }
  

--- a/src/main/java/net/minecraftforge/fml/common/launcher/FMLTweaker.java
+++ b/src/main/java/net/minecraftforge/fml/common/launcher/FMLTweaker.java
@@ -46,7 +46,10 @@ public class FMLTweaker implements ITweaker {
 
     public FMLTweaker()
     {
-        System.setProperty("java.net.preferIPv4Stack", "true");
+        if (System.getProperty("java.net.preferIPv4Stack") == null)
+        {
+            System.setProperty("java.net.preferIPv4Stack", "true");
+        }
         try
         {
             System.setSecurityManager(new FMLSecurityManager());

--- a/src/main/java/net/minecraftforge/fml/common/launcher/FMLTweaker.java
+++ b/src/main/java/net/minecraftforge/fml/common/launcher/FMLTweaker.java
@@ -46,6 +46,7 @@ public class FMLTweaker implements ITweaker {
 
     public FMLTweaker()
     {
+        System.setProperty("java.net.preferIPv4Stack", "true");
         try
         {
             System.setSecurityManager(new FMLSecurityManager());

--- a/src/main/java/net/minecraftforge/fml/common/launcher/FMLTweaker.java
+++ b/src/main/java/net/minecraftforge/fml/common/launcher/FMLTweaker.java
@@ -46,7 +46,6 @@ public class FMLTweaker implements ITweaker {
 
     public FMLTweaker()
     {
-        System.setProperty("java.net.preferIPv4Stack", "true"); //Lets do this as early as possible. Vanilla does it in Main.main
         try
         {
             System.setSecurityManager(new FMLSecurityManager());


### PR DESCRIPTION
See [this thread](http://www.minecraftforge.net/forum/topic/61760-no-ipv6-with-112-and-above/) from the forums for an explanation.

This code ~~doesn't seem to be needed any more, and it~~ appears to be causing issues with IPv6-only connections.

~~Does this removal seem safe to everyone?~~

**Update:**
The code in `FMLTweaker` is kept, but `NetworkSystem` is patched to undo this if an IPv6 address is specifically requested.