### PR TITLE
Fix for the EntityItemPickupEvent

### DIFF
--- a/patches/minecraft/net/minecraft/entity/item/EntityItem.java.patch
+++ b/patches/minecraft/net/minecraft/entity/item/EntityItem.java.patch
@@ -84,7 +84,7 @@
  
          if (this.func_145800_j() != null)
          {
-@@ -358,18 +381,24 @@
+@@ -358,18 +381,25 @@
          {
              this.func_70106_y();
          }
@@ -103,14 +103,15 @@
 -            if (this.field_145804_b == 0 && (this.field_145802_g == null || 6000 - this.field_70292_b <= 200 || this.field_145802_g.equals(p_70100_1_.func_70005_c_())) && p_70100_1_.field_71071_by.func_70441_a(itemstack))
 +            int hook = net.minecraftforge.event.ForgeEventFactory.onItemPickup(this, p_70100_1_);
 +            if (hook < 0) return;
++            EntityItem clone = new EntityItem(field_70170_p, field_70165_t, field_70163_u, field_70161_v, itemstack.func_77946_l());
 +
 +            if (this.field_145804_b <= 0 && (this.field_145802_g == null || lifespan - this.field_70292_b <= 200 || this.field_145802_g.equals(p_70100_1_.func_70005_c_())) && (hook == 1 || i <= 0 || p_70100_1_.field_71071_by.func_70441_a(itemstack)))
              {
-+                net.minecraftforge.fml.common.FMLCommonHandler.instance().firePlayerItemPickupEvent(p_70100_1_, this);
++                net.minecraftforge.fml.common.FMLCommonHandler.instance().firePlayerItemPickupEvent(p_70100_1_, clone);
                  p_70100_1_.func_71001_a(this, i);
  
                  if (itemstack.func_190926_b())
-@@ -476,6 +505,6 @@
+@@ -476,6 +506,6 @@
      public void func_174870_v()
      {
          this.func_174871_r();

--- a/patches/minecraft/net/minecraft/entity/item/EntityItem.java.patch
+++ b/patches/minecraft/net/minecraft/entity/item/EntityItem.java.patch
@@ -84,7 +84,7 @@
  
          if (this.func_145800_j() != null)
          {
-@@ -358,18 +381,25 @@
+@@ -358,22 +381,30 @@
          {
              this.func_70106_y();
          }
@@ -103,15 +103,21 @@
 -            if (this.field_145804_b == 0 && (this.field_145802_g == null || 6000 - this.field_70292_b <= 200 || this.field_145802_g.equals(p_70100_1_.func_70005_c_())) && p_70100_1_.field_71071_by.func_70441_a(itemstack))
 +            int hook = net.minecraftforge.event.ForgeEventFactory.onItemPickup(this, p_70100_1_);
 +            if (hook < 0) return;
-+            EntityItem clone = new EntityItem(field_70170_p, field_70165_t, field_70163_u, field_70161_v, itemstack.func_77946_l());
++            ItemStack clone = itemstack.func_77946_l();
 +
-+            if (this.field_145804_b <= 0 && (this.field_145802_g == null || lifespan - this.field_70292_b <= 200 || this.field_145802_g.equals(p_70100_1_.func_70005_c_())) && (hook == 1 || i <= 0 || p_70100_1_.field_71071_by.func_70441_a(itemstack)))
++            if (this.field_145804_b <= 0 && (this.field_145802_g == null || lifespan - this.field_70292_b <= 200 || this.field_145802_g.equals(p_70100_1_.func_70005_c_())) && (hook == 1 || i <= 0 || p_70100_1_.field_71071_by.func_70441_a(itemstack) || clone.func_190916_E() > this.func_92059_d().func_190916_E()))
              {
-+                net.minecraftforge.fml.common.FMLCommonHandler.instance().firePlayerItemPickupEvent(p_70100_1_, clone);
-                 p_70100_1_.func_71001_a(this, i);
+-                p_70100_1_.func_71001_a(this, i);
++                clone.func_190920_e(clone.func_190916_E() - this.func_92059_d().func_190916_E());
++                net.minecraftforge.fml.common.FMLCommonHandler.instance().firePlayerItemPickupEvent(p_70100_1_, this, clone);
  
                  if (itemstack.func_190926_b())
-@@ -476,6 +506,6 @@
+                 {
++                    p_70100_1_.func_71001_a(this, i);
+                     this.func_70106_y();
+                     itemstack.func_190920_e(i);
+                 }
+@@ -476,6 +507,6 @@
      public void func_174870_v()
      {
          this.func_174871_r();

--- a/patches/minecraft/net/minecraft/item/Item.java.patch
+++ b/patches/minecraft/net/minecraft/item/Item.java.patch
@@ -68,7 +68,7 @@
          CreativeTabs creativetabs = this.func_77640_w();
          return creativetabs != null && (p_194125_1_ == CreativeTabs.field_78027_g || p_194125_1_ == creativetabs);
      }
-@@ -435,11 +441,704 @@
+@@ -435,11 +445,704 @@
          return false;
      }
  
@@ -773,7 +773,7 @@
      public static void func_150900_l()
      {
          func_179214_a(Blocks.field_150350_a, new ItemAir(Blocks.field_150350_a));
-@@ -999,6 +1698,8 @@
+@@ -999,6 +1702,8 @@
          private final float field_78010_h;
          private final float field_78011_i;
          private final int field_78008_j;
@@ -782,7 +782,7 @@
  
          private ToolMaterial(int p_i1874_3_, int p_i1874_4_, float p_i1874_5_, float p_i1874_6_, int p_i1874_7_)
          {
-@@ -1034,6 +1735,7 @@
+@@ -1034,6 +1739,7 @@
              return this.field_78008_j;
          }
  
@@ -790,7 +790,7 @@
          public Item func_150995_f()
          {
              if (this == WOOD)
-@@ -1057,5 +1759,21 @@
+@@ -1057,5 +1763,21 @@
                  return this == DIAMOND ? Items.field_151045_i : null;
              }
          }

--- a/patches/minecraft/net/minecraft/item/Item.java.patch
+++ b/patches/minecraft/net/minecraft/item/Item.java.patch
@@ -68,7 +68,7 @@
          CreativeTabs creativetabs = this.func_77640_w();
          return creativetabs != null && (p_194125_1_ == CreativeTabs.field_78027_g || p_194125_1_ == creativetabs);
      }
-@@ -435,11 +445,704 @@
+@@ -435,11 +441,704 @@
          return false;
      }
  
@@ -773,7 +773,7 @@
      public static void func_150900_l()
      {
          func_179214_a(Blocks.field_150350_a, new ItemAir(Blocks.field_150350_a));
-@@ -999,6 +1702,8 @@
+@@ -999,6 +1698,8 @@
          private final float field_78010_h;
          private final float field_78011_i;
          private final int field_78008_j;
@@ -782,7 +782,7 @@
  
          private ToolMaterial(int p_i1874_3_, int p_i1874_4_, float p_i1874_5_, float p_i1874_6_, int p_i1874_7_)
          {
-@@ -1034,6 +1739,7 @@
+@@ -1034,6 +1735,7 @@
              return this.field_78008_j;
          }
  
@@ -790,7 +790,7 @@
          public Item func_150995_f()
          {
              if (this == WOOD)
-@@ -1057,5 +1763,21 @@
+@@ -1057,5 +1759,21 @@
                  return this == DIAMOND ? Items.field_151045_i : null;
              }
          }

--- a/src/main/java/net/minecraftforge/fml/common/FMLCommonHandler.java
+++ b/src/main/java/net/minecraftforge/fml/common/FMLCommonHandler.java
@@ -583,9 +583,9 @@ public class FMLCommonHandler
         bus().post(new PlayerEvent.PlayerRespawnEvent(player, endConquered));
     }
 
-    public void firePlayerItemPickupEvent(EntityPlayer player, EntityItem item)
+    public void firePlayerItemPickupEvent(EntityPlayer player, EntityItem item, ItemStack clone)
     {
-        bus().post(new PlayerEvent.ItemPickupEvent(player, item));
+        bus().post(new PlayerEvent.ItemPickupEvent(player, item, clone));
     }
 
     public void firePlayerCraftingEvent(EntityPlayer player, ItemStack crafted, IInventory craftMatrix)

--- a/src/main/java/net/minecraftforge/fml/common/gameevent/PlayerEvent.java
+++ b/src/main/java/net/minecraftforge/fml/common/gameevent/PlayerEvent.java
@@ -38,11 +38,13 @@ public class PlayerEvent extends Event {
     	/**
     	 * This entity is a clone of what the player picked up, containing intact ItemStack information.
     	 */
-        public final EntityItem pickedUp;
-        public ItemPickupEvent(EntityPlayer player, EntityItem pickedUp)
+        public final EntityItem originalEntity;
+        public final ItemStack pickedUp;
+        public ItemPickupEvent(EntityPlayer player, EntityItem entPickedUp, ItemStack stack)
         {
             super(player);
-            this.pickedUp = pickedUp;
+            originalEntity = entPickedUp;
+            pickedUp = stack;
         }
     }
 

--- a/src/main/java/net/minecraftforge/fml/common/gameevent/PlayerEvent.java
+++ b/src/main/java/net/minecraftforge/fml/common/gameevent/PlayerEvent.java
@@ -42,16 +42,16 @@ public class PlayerEvent extends Event {
         /**
          * Clone item stack, containing the item and amount picked up
          */
-        private final ItemStack pickedUp;
+        private final ItemStack stack;
         public ItemPickupEvent(EntityPlayer player, EntityItem entPickedUp, ItemStack stack)
         {
             super(player);
             originalEntity = entPickedUp;
-            pickedUp = stack;
+            this.stack = stack;
         }
         
         public ItemStack getStack() {
-        	return pickedUp;
+        	return stack;
         }
         
         public EntityItem getOriginalEntity() {

--- a/src/main/java/net/minecraftforge/fml/common/gameevent/PlayerEvent.java
+++ b/src/main/java/net/minecraftforge/fml/common/gameevent/PlayerEvent.java
@@ -35,6 +35,9 @@ public class PlayerEvent extends Event {
     }
 
     public static class ItemPickupEvent extends PlayerEvent {
+    	/**
+    	 * This entity is a clone of what the player picked up, containing intact ItemStack information.
+    	 */
         public final EntityItem pickedUp;
         public ItemPickupEvent(EntityPlayer player, EntityItem pickedUp)
         {

--- a/src/main/java/net/minecraftforge/fml/common/gameevent/PlayerEvent.java
+++ b/src/main/java/net/minecraftforge/fml/common/gameevent/PlayerEvent.java
@@ -36,15 +36,26 @@ public class PlayerEvent extends Event {
 
     public static class ItemPickupEvent extends PlayerEvent {
     	/**
-    	 * This entity is a clone of what the player picked up, containing intact ItemStack information.
+    	 * Original EntityItem with current remaining stack size
     	 */
-        public final EntityItem originalEntity;
-        public final ItemStack pickedUp;
+        private final EntityItem originalEntity;
+        /**
+         * Clone item stack, containing the item and amount picked up
+         */
+        private final ItemStack pickedUp;
         public ItemPickupEvent(EntityPlayer player, EntityItem entPickedUp, ItemStack stack)
         {
             super(player);
             originalEntity = entPickedUp;
             pickedUp = stack;
+        }
+        
+        public ItemStack getStack() {
+        	return pickedUp;
+        }
+        
+        public EntityItem getOriginalEntity() {
+        	return originalEntity;
         }
     }
 

--- a/src/test/java/net/minecraftforge/debug/PlayerItemPickupEventDebug.java
+++ b/src/test/java/net/minecraftforge/debug/PlayerItemPickupEventDebug.java
@@ -1,0 +1,38 @@
+package net.minecraftforge.debug;
+
+import org.apache.logging.log4j.Logger;
+
+import net.minecraftforge.common.MinecraftForge;
+import net.minecraftforge.event.entity.player.EntityItemPickupEvent;
+import net.minecraftforge.fml.common.Mod;
+import net.minecraftforge.fml.common.Mod.EventHandler;
+import net.minecraftforge.fml.common.event.FMLPreInitializationEvent;
+import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
+import net.minecraftforge.fml.common.gameevent.PlayerEvent;
+
+@Mod(modid = PlayerItemPickupEventDebug.MODID, name = PlayerItemPickupEventDebug.NAME, version = PlayerItemPickupEventDebug.VERSION, acceptableRemoteVersions = "*")
+public class PlayerItemPickupEventDebug
+{
+
+    private static final boolean ENABLED = true;
+    public static final String MODID = "playeritempickupeventdebug";
+    public static final String NAME = "Player.ItemPickup Event Debug";
+    public static final String VERSION = "1.0.0";
+    private static Logger logger;
+
+    @EventHandler
+    public void init(FMLPreInitializationEvent event)
+    {
+        logger = event.getModLog();
+        if (ENABLED)
+        {
+            MinecraftForge.EVENT_BUS.register(this);
+        }
+    }
+
+    @SubscribeEvent
+    public void itemPickupEvent(PlayerEvent.ItemPickupEvent event)
+    {
+    	logger.info("Item picked up: " + event.pickedUp.getItem().getDisplayName());
+    }
+}

--- a/src/test/java/net/minecraftforge/debug/PlayerItemPickupEventDebug.java
+++ b/src/test/java/net/minecraftforge/debug/PlayerItemPickupEventDebug.java
@@ -33,6 +33,6 @@ public class PlayerItemPickupEventDebug
     @SubscribeEvent
     public void itemPickupEvent(PlayerEvent.ItemPickupEvent event)
     {
-    	logger.info("Item picked up: " + event.pickedUp.getItem().getDisplayName());
+    	logger.info("Item picked up: " + event.pickedUp.getDisplayName() + "x" + event.pickedUp.getCount());
     }
 }

--- a/src/test/java/net/minecraftforge/debug/PlayerItemPickupEventDebug.java
+++ b/src/test/java/net/minecraftforge/debug/PlayerItemPickupEventDebug.java
@@ -14,7 +14,7 @@ import net.minecraftforge.fml.common.gameevent.PlayerEvent;
 public class PlayerItemPickupEventDebug
 {
 
-    private static final boolean ENABLED = true;
+    private static final boolean ENABLED = false;
     public static final String MODID = "playeritempickupeventdebug";
     public static final String NAME = "Player.ItemPickup Event Debug";
     public static final String VERSION = "1.0.0";

--- a/src/test/java/net/minecraftforge/debug/PlayerItemPickupEventDebug.java
+++ b/src/test/java/net/minecraftforge/debug/PlayerItemPickupEventDebug.java
@@ -14,7 +14,7 @@ import net.minecraftforge.fml.common.gameevent.PlayerEvent;
 public class PlayerItemPickupEventDebug
 {
 
-    private static final boolean ENABLED = false;
+    private static final boolean ENABLED = true;
     public static final String MODID = "playeritempickupeventdebug";
     public static final String NAME = "Player.ItemPickup Event Debug";
     public static final String VERSION = "1.0.0";
@@ -33,6 +33,6 @@ public class PlayerItemPickupEventDebug
     @SubscribeEvent
     public void itemPickupEvent(PlayerEvent.ItemPickupEvent event)
     {
-    	logger.info("Item picked up: " + event.pickedUp.getDisplayName() + "x" + event.pickedUp.getCount());
+    	logger.info("Item picked up: " + event.getStack().getDisplayName() + "x" + event.getStack().getCount());
     }
 }


### PR DESCRIPTION
Clones the item entity prior to allowing the player to pick it up, allowing the post-added-to-inventory event supply data about the item that was picked up (which is also cloned), rather than TileAir x0 (due to the original being an empty stack). Addresses issue #3419