### PR TITLE
Restore LOGIN_TIMEOUT field removed in 1.9 port

### DIFF
--- a/patches/minecraft/net/minecraft/server/network/NetHandlerLoginServer.java.patch
+++ b/patches/minecraft/net/minecraft/server/network/NetHandlerLoginServer.java.patch
@@ -1,6 +1,6 @@
 --- ../src-base/minecraft/net/minecraft/server/network/NetHandlerLoginServer.java
 +++ ../src-work/minecraft/net/minecraft/server/network/NetHandlerLoginServer.java
-@@ -69,7 +69,7 @@
+@@ -69,12 +69,12 @@
              if (entityplayermp == null)
              {
                  this.field_147328_g = NetHandlerLoginServer.LoginState.READY_TO_ACCEPT;
@@ -8,6 +8,12 @@
 +                net.minecraftforge.fml.common.network.internal.FMLNetworkHandler.fmlServerHandshake(this.field_147327_f.func_184103_al(), this.field_147333_a, this.field_181025_l);
                  this.field_181025_l = null;
              }
+         }
+ 
+-        if (this.field_147336_h++ == 600)
++        if (this.field_147336_h++ == net.minecraftforge.fml.common.network.internal.FMLNetworkHandler.LOGIN_TIMEOUT)
+         {
+             this.func_194026_b(new TextComponentTranslation("multiplayer.disconnect.slow_login", new Object[0]));
          }
 @@ -132,7 +132,7 @@
              }


### PR DESCRIPTION
Ref: https://github.com/MinecraftForge/MinecraftForge/commit/52e877bdd03d53848c824b7175906a8e76ed37c3#diff-af3abe3f60d20c841cec417419feff11L12

It seems in the 1.9 port the forge hook for changing the login timeout was removed (and the field has been unused since). This commit puts it back.