### PR TITLE
Add PickBlockEvent, creating event to override getPickBlock as an event.

### DIFF
--- a/src/main/java/net/minecraftforge/client/event/PickBlockEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/PickBlockEvent.java
@@ -1,0 +1,64 @@
+package net.minecraftforge.client.event;
+
+import javax.annotation.Nonnull;
+
+import net.minecraft.block.state.IBlockState;
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.item.ItemStack;
+import net.minecraft.util.math.RayTraceResult;
+import net.minecraft.world.World;
+import net.minecraftforge.event.entity.player.PlayerEvent;
+import net.minecraftforge.fml.common.eventhandler.Cancelable;
+
+/**
+ * This event is fired when a player attempts to pick a block, can be canceled or its result can be changed.
+ */
+@Cancelable
+public class PickBlockEvent extends PlayerEvent
+{
+    private final IBlockState state;
+    private final RayTraceResult target;
+    private final World world;
+    private final ItemStack originalResult;
+    private ItemStack result;
+
+    public PickBlockEvent(@Nonnull IBlockState state, @Nonnull RayTraceResult target, @Nonnull World world, @Nonnull EntityPlayer player, @Nonnull ItemStack originalResult)
+    {
+        super(player);
+        this.state = state;
+        this.target = target;
+        this.world = world;
+        this.originalResult = result = originalResult;
+    }
+
+    public @Nonnull IBlockState getTargtedBlockState()
+    {
+        return state;
+    }
+
+    public @Nonnull RayTraceResult getRayTraceResult()
+    {
+        return target;
+    }
+
+    public @Nonnull World getWorld()
+    {
+        return world;
+    }
+
+    public @Nonnull ItemStack getOriginalPickResult()
+    {
+        return originalResult;
+    }
+
+    public @Nonnull ItemStack getPickResult()
+    {
+        return result;
+    }
+
+    public void setPickResult(@Nonnull ItemStack result)
+    {
+        this.result = result;
+    }
+
+}

--- a/src/main/java/net/minecraftforge/common/ForgeHooks.java
+++ b/src/main/java/net/minecraftforge/common/ForgeHooks.java
@@ -104,6 +104,7 @@ import net.minecraft.world.storage.loot.LootEntry;
 import net.minecraft.world.storage.loot.LootTable;
 import net.minecraft.world.storage.loot.LootTableManager;
 import net.minecraft.world.storage.loot.conditions.LootCondition;
+import net.minecraftforge.client.event.PickBlockEvent;
 import net.minecraftforge.common.crafting.CraftingHelper;
 import net.minecraftforge.common.util.BlockSnapshot;
 import net.minecraftforge.event.AnvilUpdateEvent;
@@ -497,6 +498,17 @@ public class ForgeHooks
                 te = world.getTileEntity(target.getBlockPos());
 
             result = state.getBlock().getPickBlock(state, target, world, target.getBlockPos(), player);
+
+            PickBlockEvent pickBlockEvent =  new PickBlockEvent( state, target, world, player, result);
+
+            if (MinecraftForge.EVENT_BUS.post(pickBlockEvent))
+            {
+                return false;
+            }
+            else
+            {
+                result = pickBlockEvent.getPickResult();
+            }
         }
         else
         {

--- a/src/test/java/net/minecraftforge/debug/PickBlockEventTest.java
+++ b/src/test/java/net/minecraftforge/debug/PickBlockEventTest.java
@@ -1,0 +1,54 @@
+package net.minecraftforge.debug;
+
+import org.apache.logging.log4j.Logger;
+
+import net.minecraft.init.Items;
+import net.minecraft.item.ItemStack;
+import net.minecraftforge.client.event.PickBlockEvent;
+import net.minecraftforge.common.MinecraftForge;
+import net.minecraftforge.fml.common.Mod;
+import net.minecraftforge.fml.common.event.FMLPreInitializationEvent;
+import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
+
+@Mod(modid = "pickblockeventtest", name = "Pick Block Event Test", version = "0.0.0", clientSideOnly = true)
+public class PickBlockEventTest
+{
+    static final boolean ENABLED = true;
+    private static Logger logger;
+
+    @Mod.EventHandler
+    public void preInit(FMLPreInitializationEvent event)
+    {
+        if (ENABLED)
+        {
+            logger = event.getModLog();
+            MinecraftForge.EVENT_BUS.register(this);
+        }
+    }
+
+    int testCycle = 0;
+
+    @SubscribeEvent
+    public void onPickBlockEvent(PickBlockEvent event)
+    {
+        switch( testCycle )
+        {
+            case 0:
+                logger.info("Canceled, nothing should have been picked.");
+                event.setCanceled( true );
+                break;
+
+            case 1:
+                event.setPickResult(new ItemStack(Items.APPLE));
+                logger.info("Overwritten with {}", event.getPickResult().getDisplayName());
+                logger.info("OriginalResult: {}", event.getOriginalPickResult().getDisplayName());
+                break;
+
+            case 2:
+                logger.info("No Change, default behavior.");
+                break;
+        }
+
+        testCycle =  (testCycle + 1 ) % 3;
+    }
+}


### PR DESCRIPTION
Allow mods to create specific results depending on other factors, for instance for C&B it makes sense to pick bits of a block when holding a chisel. At the moment C&B can only do this for chiseled blocks, and not other mod or vanilla blocks.