### PR TITLE
Add canPlaceSnowOnTop, allowing a block to control snow placement on itself.

### DIFF
--- a/patches/minecraft/net/minecraft/block/Block.java.patch
+++ b/patches/minecraft/net/minecraft/block/Block.java.patch
@@ -221,7 +221,7 @@
      public SoundType func_185467_w()
      {
          return this.field_149762_H;
-@@ -934,6 +952,1314 @@
+@@ -934,6 +952,1329 @@
      {
      }
  
@@ -1531,12 +1531,27 @@
 +        return state.func_177230_c() == Blocks.field_180399_cE;
 +    }
 +
++    /**
++     * Determines if a block will allow snow to be placed on it, this allows the implement to
++     * change the value to true or false overriding the behavior entirely.
++     * 
++     * @param the targeted block state
++     * @param world in question.
++     * @param position in world.
++     * @param the default return value, based on solid sides and isLeaves and other vanilla checks.
++     * @return true will allow snow to be placed, false will prevent it from being placed.
++     */
++    public boolean canPlaceSnowOnTop(IBlockState iblockstate, World worldIn, BlockPos pos, boolean vanillaDefaultBehavior)
++    {
++        return vanillaDefaultBehavior;
++    }
++
 +    /* ========================================= FORGE END ======================================*/
 +
      public static void func_149671_p()
      {
          func_176215_a(0, field_176230_a, (new BlockAir()).func_149663_c("air"));
-@@ -1230,31 +2556,6 @@
+@@ -1230,31 +2571,6 @@
                  block15.field_149783_u = flag;
              }
          }

--- a/patches/minecraft/net/minecraft/block/BlockSnow.java.patch
+++ b/patches/minecraft/net/minecraft/block/BlockSnow.java.patch
@@ -5,7 +5,7 @@
          {
              BlockFaceShape blockfaceshape = iblockstate.func_193401_d(p_176196_1_, p_176196_2_.func_177977_b(), EnumFacing.UP);
 -            return blockfaceshape == BlockFaceShape.SOLID || iblockstate.func_185904_a() == Material.field_151584_j || block == this && ((Integer)iblockstate.func_177229_b(field_176315_a)).intValue() == 8;
-+            return blockfaceshape == BlockFaceShape.SOLID || iblockstate.func_177230_c().isLeaves(iblockstate, p_176196_1_, p_176196_2_.func_177977_b()) || block == this && ((Integer)iblockstate.func_177229_b(field_176315_a)).intValue() == 8;
++            return block.canPlaceSnowOnTop(iblockstate,p_176196_1_,p_176196_2_,blockfaceshape == BlockFaceShape.SOLID || iblockstate.func_177230_c().isLeaves(iblockstate, p_176196_1_, p_176196_2_.func_177977_b()) || block == this && ((Integer)iblockstate.func_177229_b(field_176315_a)).intValue() == 8);
          }
          else
          {


### PR DESCRIPTION
Allow a block to override snow's placement on top of it self, solid side / face shape allow you to specify that your side is solid, but there may be cases that a solid side is "helpful" but placing snow on it will be inappropriate,

C&B has cases where it reports that a side is solid so you can place things on it, but snow will collect on the top looking quite bad.

This would allow mods to keep "solid behavior" while special casing snow.

I know it seems a little frivolous, but I'd thought I'd offer it up anyway since its fairly low foot print.