### PR TITLE
Fix: Anvil Bug with Custom Damage Items.

### DIFF
--- a/patches/minecraft/net/minecraft/inventory/ContainerRepair.java.patch
+++ b/patches/minecraft/net/minecraft/inventory/ContainerRepair.java.patch
@@ -32,6 +32,15 @@
  
                  if (itemstack1.func_77984_f() && itemstack1.func_77973_b().func_82789_a(itemstack, itemstack2))
                  {
+@@ -213,7 +217,7 @@
+                             l1 = 0;
+                         }
+ 
+-                        if (l1 < itemstack1.func_77960_j())
++                        if (l1 < itemstack1.func_77952_i()) // vanilla uses metadata here instead of damage.
+                         {
+                             itemstack1.func_77964_b(l1);
+                             i += 2;
 @@ -317,6 +321,7 @@
                  i += k;
                  itemstack1.func_151001_c(this.field_82857_m);


### PR DESCRIPTION
In anvil, changes if (l1 < itemstack1.getMetadata()) to if (l1 < itemstack1.getItemDamage())

This makes it so item stacks that use custom damage implementations can to merged in anvil properly. This  is probably a long standing vanilla goof considering that everything else in the file uses damage, and only this one line refers to metadata.