### PR TITLE
Fix startIndex for /forge generate position parsing

### DIFF
--- a/src/main/java/net/minecraftforge/server/command/CommandGenerate.java
+++ b/src/main/java/net/minecraftforge/server/command/CommandGenerate.java
@@ -65,7 +65,7 @@ class CommandGenerate extends CommandBase
             throw new WrongUsageException("commands.forge.gen.usage");
         }
 
-        BlockPos blockpos = parseBlockPos(sender, args, 1, false);
+        BlockPos blockpos = parseBlockPos(sender, args, 0, false);
         int count = parseInt(args[3], 10);
         int dim = args.length >= 5 ? parseInt(args[4]) : sender.getEntityWorld().provider.getDimension();
         int interval = args.length >= 6 ? parseInt(args[5]) : -1;


### PR DESCRIPTION
With startIndex at 1, the arguments to /forge generate were shifted one over from what they should be. Here is this change with debug output to prove this fixes it:
![](https://i.imgur.com/FsFcHgO.png)