### PR TITLE
Add missing nullability annotations to some Forge-added methods

### DIFF
--- a/patches/minecraft/net/minecraft/block/state/BlockStateBase.java.patch
+++ b/patches/minecraft/net/minecraft/block/state/BlockStateBase.java.patch
@@ -1,10 +1,11 @@
 --- ../src-base/minecraft/net/minecraft/block/state/BlockStateBase.java
 +++ ../src-work/minecraft/net/minecraft/block/state/BlockStateBase.java
-@@ -73,4 +73,9 @@
+@@ -73,4 +73,10 @@
  
          return stringbuilder.toString();
      }
 +
++    @Nullable
 +    public com.google.common.collect.ImmutableTable<IProperty<?>, Comparable<?>, IBlockState> getPropertyValueTable()
 +    {
 +        return null;

--- a/patches/minecraft/net/minecraft/client/gui/inventory/GuiContainerCreative.java.patch
+++ b/patches/minecraft/net/minecraft/client/gui/inventory/GuiContainerCreative.java.patch
@@ -264,7 +264,7 @@
      }
  
      public int func_147056_g()
-@@ -1031,6 +1145,38 @@
+@@ -1031,6 +1145,39 @@
          {
              return this.field_148332_b.func_82869_a(p_82869_1_);
          }
@@ -280,11 +280,12 @@
 +            this.field_148332_b.setBackgroundLocation(texture);
 +        }
 +
-+        public void setBackgroundName(String name)
++        public void setBackgroundName(@Nullable String name)
 +        {
 +            this.field_148332_b.setBackgroundName(name);
 +        }
 +
++        @Nullable
 +        public net.minecraft.client.renderer.texture.TextureAtlasSprite getBackgroundSprite()
 +        {
 +            return this.field_148332_b.getBackgroundSprite();

--- a/patches/minecraft/net/minecraft/entity/EntityList.java.patch
+++ b/patches/minecraft/net/minecraft/entity/EntityList.java.patch
@@ -12,7 +12,7 @@
  
      @Nullable
      public static ResourceLocation func_191301_a(Entity p_191301_0_)
-@@ -121,37 +119,52 @@
+@@ -121,38 +119,54 @@
      @Nullable
      public static ResourceLocation func_191306_a(Class <? extends Entity > p_191306_0_)
      {
@@ -63,16 +63,18 @@
 +        return entry == null ? -1 : net.minecraftforge.registries.GameData.getEntityRegistry().getID(entry);
 +    }
 +
+     @Nullable
 +    public static Class<? extends Entity> getClass(ResourceLocation key)
 +    {
 +        net.minecraftforge.fml.common.registry.EntityEntry entry = net.minecraftforge.fml.common.registry.ForgeRegistries.ENTITIES.getValue(key);
 +        return entry == null ? null : entry.getEntityClass();
 +    }
 +
-     @Nullable
++    @Nullable
      public static Entity func_191304_a(@Nullable Class <? extends Entity > p_191304_0_, World p_191304_1_)
      {
-@@ -163,6 +176,8 @@
+         if (p_191304_0_ == null)
+@@ -163,6 +177,8 @@
          {
              try
              {
@@ -81,7 +83,7 @@
                  return p_191304_0_.getConstructor(World.class).newInstance(p_191304_1_);
              }
              catch (Exception exception)
-@@ -177,13 +192,15 @@
+@@ -177,13 +193,15 @@
      @SideOnly(Side.CLIENT)
      public static Entity func_75616_a(int p_75616_0_, World p_75616_1_)
      {
@@ -99,7 +101,7 @@
      }
  
      @Nullable
-@@ -198,7 +215,16 @@
+@@ -198,7 +216,16 @@
          }
          else
          {
@@ -116,7 +118,7 @@
          }
  
          return entity;
-@@ -206,7 +232,7 @@
+@@ -206,7 +233,7 @@
  
      public static Set<ResourceLocation> func_180124_b()
      {
@@ -125,7 +127,7 @@
      }
  
      public static boolean func_180123_a(Entity p_180123_0_, ResourceLocation p_180123_1_)
-@@ -373,7 +399,7 @@
+@@ -373,7 +400,7 @@
          func_191305_a("zombie_horse", 3232308, 9945732);
          func_191305_a("zombie_pigman", 15373203, 5009705);
          func_191305_a("zombie_villager", 5651507, 7969893);
@@ -134,7 +136,7 @@
      }
  
      private static void func_191303_a(int p_191303_0_, String p_191303_1_, Class <? extends Entity > p_191303_2_, String p_191303_3_)
-@@ -394,22 +420,17 @@
+@@ -394,22 +421,17 @@
          else
          {
              ResourceLocation resourcelocation = new ResourceLocation(p_191303_1_);

--- a/patches/minecraft/net/minecraft/entity/item/EntityMinecart.java.patch
+++ b/patches/minecraft/net/minecraft/entity/item/EntityMinecart.java.patch
@@ -254,7 +254,7 @@
                              {
                                  p_70108_1_.field_70159_w *= 0.20000000298023224D;
                                  p_70108_1_.field_70179_y *= 0.20000000298023224D;
-@@ -1015,6 +1047,229 @@
+@@ -1015,6 +1047,230 @@
          this.func_184212_Q().func_187227_b(field_184270_f, Boolean.valueOf(p_94096_1_));
      }
  
@@ -306,6 +306,7 @@
 +     * is registered, returns null
 +     * @return The collision handler or null
 +     */
++    @Nullable
 +    public static net.minecraftforge.common.IMinecartCollisionHandler getCollisionHandler()
 +    {
 +        return collisionHandler;

--- a/patches/minecraft/net/minecraft/inventory/Slot.java.patch
+++ b/patches/minecraft/net/minecraft/inventory/Slot.java.patch
@@ -9,7 +9,7 @@
      }
  
      public ItemStack func_75209_a(int p_75209_1_)
-@@ -113,4 +113,73 @@
+@@ -113,4 +113,74 @@
      {
          return true;
      }
@@ -42,11 +42,12 @@
 +     * Sets which icon index to use as the background image of the slot when it's empty.
 +     * @param name The icon to use, null for none
 +     */
-+    public void setBackgroundName(String name)
++    public void setBackgroundName(@Nullable String name)
 +    {
 +        this.backgroundName = name;
 +    }
 +
++    @Nullable
 +    @SideOnly(Side.CLIENT)
 +    public net.minecraft.client.renderer.texture.TextureAtlasSprite getBackgroundSprite()
 +    {

--- a/patches/minecraft/net/minecraft/item/ItemStack.java.patch
+++ b/patches/minecraft/net/minecraft/item/ItemStack.java.patch
@@ -232,7 +232,7 @@
          }
  
          return multimap;
-@@ -1130,4 +1155,127 @@
+@@ -1130,4 +1155,128 @@
      {
          this.func_190917_f(-p_190918_1_);
      }
@@ -303,6 +303,7 @@
 +     * Internal call to get the actual item, not the delegate.
 +     * In all other methods, FML replaces calls to this.item with the item delegate.
 +     */
++    @Nullable
 +    private Item getItemRaw()
 +    {
 +        return this.field_151002_e;

--- a/patches/minecraft/net/minecraft/tileentity/TileEntityBrewingStand.java.patch
+++ b/patches/minecraft/net/minecraft/tileentity/TileEntityBrewingStand.java.patch
@@ -58,7 +58,7 @@
              }
          }
      }
-@@ -377,6 +377,26 @@
+@@ -377,6 +377,27 @@
          }
      }
  
@@ -68,6 +68,7 @@
 +
 +    @SuppressWarnings("unchecked")
 +    @Override
++    @javax.annotation.Nullable
 +    public <T> T getCapability(net.minecraftforge.common.capabilities.Capability<T> capability, @javax.annotation.Nullable net.minecraft.util.EnumFacing facing)
 +    {
 +        if (facing != null && capability == net.minecraftforge.items.CapabilityItemHandler.ITEM_HANDLER_CAPABILITY)

--- a/patches/minecraft/net/minecraft/tileentity/TileEntityChest.java.patch
+++ b/patches/minecraft/net/minecraft/tileentity/TileEntityChest.java.patch
@@ -8,7 +8,7 @@
      }
  
      @SuppressWarnings("incomplete-switch")
-@@ -349,6 +350,30 @@
+@@ -349,6 +350,29 @@
          }
      }
  
@@ -29,7 +29,6 @@
 +        return super.getCapability(capability, facing);
 +    }
 +
-+    @Nullable
 +    public net.minecraftforge.items.IItemHandler getSingleChestHandler()
 +    {
 +        return super.getCapability(net.minecraftforge.items.CapabilityItemHandler.ITEM_HANDLER_CAPABILITY, null);

--- a/patches/minecraft/net/minecraft/tileentity/TileEntityChest.java.patch
+++ b/patches/minecraft/net/minecraft/tileentity/TileEntityChest.java.patch
@@ -8,7 +8,7 @@
      }
  
      @SuppressWarnings("incomplete-switch")
-@@ -349,6 +350,28 @@
+@@ -349,6 +350,30 @@
          }
      }
  
@@ -16,6 +16,7 @@
 +
 +    @SuppressWarnings("unchecked")
 +    @Override
++    @Nullable
 +    public <T> T getCapability(net.minecraftforge.common.capabilities.Capability<T> capability, @Nullable net.minecraft.util.EnumFacing facing)
 +    {
 +        if (capability == net.minecraftforge.items.CapabilityItemHandler.ITEM_HANDLER_CAPABILITY)
@@ -28,6 +29,7 @@
 +        return super.getCapability(capability, facing);
 +    }
 +
++    @Nullable
 +    public net.minecraftforge.items.IItemHandler getSingleChestHandler()
 +    {
 +        return super.getCapability(net.minecraftforge.items.CapabilityItemHandler.ITEM_HANDLER_CAPABILITY, null);

--- a/patches/minecraft/net/minecraft/tileentity/TileEntityFurnace.java.patch
+++ b/patches/minecraft/net/minecraft/tileentity/TileEntityFurnace.java.patch
@@ -71,7 +71,7 @@
              Item item = p_145952_0_.func_77973_b();
  
              if (item == Item.func_150898_a(Blocks.field_150376_bx))
-@@ -530,4 +532,22 @@
+@@ -530,4 +532,23 @@
      {
          this.field_145957_n.clear();
      }
@@ -82,6 +82,7 @@
 +
 +    @SuppressWarnings("unchecked")
 +    @Override
++    @javax.annotation.Nullable
 +    public <T> T getCapability(net.minecraftforge.common.capabilities.Capability<T> capability, @javax.annotation.Nullable net.minecraft.util.EnumFacing facing)
 +    {
 +        if (facing != null && capability == net.minecraftforge.items.CapabilityItemHandler.ITEM_HANDLER_CAPABILITY)

--- a/patches/minecraft/net/minecraft/village/Village.java.patch
+++ b/patches/minecraft/net/minecraft/village/Village.java.patch
@@ -167,7 +167,7 @@
          }
      }
  
-@@ -561,4 +582,30 @@
+@@ -561,4 +582,31 @@
              this.field_75590_b = p_i1674_3_;
          }
      }
@@ -179,6 +179,7 @@
 +        return capabilities == null ? false : capabilities.hasCapability(capability, facing);
 +    }
 +
++    @Nullable
 +    public <T> T getCapability(net.minecraftforge.common.capabilities.Capability<T> capability, @Nullable net.minecraft.util.EnumFacing facing)
 +    {
 +        return capabilities == null ? null : capabilities.getCapability(capability, facing);

--- a/patches/minecraft/net/minecraft/world/WorldProvider.java.patch
+++ b/patches/minecraft/net/minecraft/world/WorldProvider.java.patch
@@ -65,7 +65,7 @@
      }
  
      @SideOnly(Side.CLIENT)
-@@ -241,6 +216,318 @@
+@@ -241,6 +216,323 @@
          return new WorldBorder();
      }
  
@@ -96,6 +96,7 @@
 +     * EXA: DIM1, DIM-1
 +     * @return The sub-folder name to save this world's chunks to.
 +     */
++    @Nullable
 +    public String getSaveFolder()
 +    {
 +        return (dimensionId == 0 ? null : "DIM" + dimensionId);
@@ -117,6 +118,7 @@
 +        return 1.0;
 +    }
 +
++    @Nullable
 +    @SideOnly(Side.CLIENT)
 +    public net.minecraftforge.client.IRenderHandler getSkyRenderer()
 +    {
@@ -129,6 +131,7 @@
 +        this.skyRenderer = skyRenderer;
 +    }
 +
++    @Nullable
 +    @SideOnly(Side.CLIENT)
 +    public net.minecraftforge.client.IRenderHandler getCloudRenderer()
 +    {
@@ -141,6 +144,7 @@
 +        cloudRenderer = renderer;
 +    }
 +
++    @Nullable
 +    @SideOnly(Side.CLIENT)
 +    public net.minecraftforge.client.IRenderHandler getWeatherRenderer()
 +    {
@@ -219,6 +223,7 @@
 +     * Note that this method is always called before the world load event.
 +     * @return initial holder for capabilities on the world
 +     */
++    @Nullable
 +    public net.minecraftforge.common.capabilities.ICapabilityProvider initCapabilities() {
 +        return null;
 +    }


### PR DESCRIPTION
Fairly self-explanatory cleanup PR, just adding `@Nullable` annotations to some methods that are patched in by Forge.