### PR TITLE
Fix Chest patches for checking if they're blocked

### DIFF
--- a/patches/minecraft/net/minecraft/block/Block.java.patch
+++ b/patches/minecraft/net/minecraft/block/Block.java.patch
@@ -221,7 +221,7 @@
      public SoundType func_185467_w()
      {
          return this.field_149762_H;
-@@ -934,6 +952,1287 @@
+@@ -934,6 +952,1305 @@
      {
      }
  
@@ -1504,12 +1504,30 @@
 +        return isBurning(world, pos) ? net.minecraft.pathfinding.PathNodeType.DAMAGE_FIRE : null;
 +    }
 +
++    /**
++     * @param blockState The state for this block
++     * @param world The world this block is in
++     * @param pos The position of this block
++     * @param side The side of this block that the chest lid is trying to open into
++     * @return true if the chest should be prevented from opening by this block
++     */
++    public boolean doesSideBlockChestOpening(IBlockState blockState, IBlockAccess world, BlockPos pos, EnumFacing side)
++    {
++        ResourceLocation registryName = this.getRegistryName();
++        if (registryName != null && "minecraft".equals(registryName.func_110624_b()))
++        {
++            // maintain the vanilla behavior of https://bugs.mojang.com/browse/MC-378
++            return isNormalCube(blockState, world, pos);
++        }
++        return isSideSolid(blockState, world, pos, side);
++    }
++
 +    /* ========================================= FORGE END ======================================*/
 +
      public static void func_149671_p()
      {
          func_176215_a(0, field_176230_a, (new BlockAir()).func_149663_c("air"));
-@@ -1230,31 +2529,6 @@
+@@ -1230,31 +2547,6 @@
                  block15.field_149783_u = flag;
              }
          }

--- a/patches/minecraft/net/minecraft/block/BlockChest.java.patch
+++ b/patches/minecraft/net/minecraft/block/BlockChest.java.patch
@@ -5,7 +5,7 @@
      private boolean func_176456_n(World p_176456_1_, BlockPos p_176456_2_)
      {
 -        return p_176456_1_.func_180495_p(p_176456_2_.func_177984_a()).func_185915_l();
-+        return p_176456_1_.func_180495_p(p_176456_2_.func_177984_a()).isSideSolid(p_176456_1_, p_176456_2_.func_177984_a(), EnumFacing.DOWN);
++        return p_176456_1_.func_180495_p(p_176456_2_.func_177984_a()).doesSideBlockChestOpening(p_176456_1_, p_176456_2_.func_177984_a(), EnumFacing.DOWN);
      }
  
      private boolean func_176453_o(World p_176453_1_, BlockPos p_176453_2_)

--- a/patches/minecraft/net/minecraft/block/BlockEnderChest.java.patch
+++ b/patches/minecraft/net/minecraft/block/BlockEnderChest.java.patch
@@ -1,0 +1,11 @@
+--- ../src-base/minecraft/net/minecraft/block/BlockEnderChest.java
++++ ../src-work/minecraft/net/minecraft/block/BlockEnderChest.java
+@@ -100,7 +100,7 @@
+ 
+         if (inventoryenderchest != null && tileentity instanceof TileEntityEnderChest)
+         {
+-            if (p_180639_1_.func_180495_p(p_180639_2_.func_177984_a()).func_185915_l())
++            if (p_180639_1_.func_180495_p(p_180639_2_.func_177984_a()).doesSideBlockChestOpening(p_180639_1_, p_180639_2_.func_177984_a(), EnumFacing.DOWN))
+             {
+                 return true;
+             }

--- a/patches/minecraft/net/minecraft/block/state/BlockStateContainer.java.patch
+++ b/patches/minecraft/net/minecraft/block/state/BlockStateContainer.java.patch
@@ -49,12 +49,13 @@
              public Collection < IProperty<? >> func_177227_a()
              {
                  return Collections. < IProperty<? >> unmodifiableCollection(this.field_177237_b.keySet());
-@@ -473,5 +490,86 @@
+@@ -473,5 +490,94 @@
              {
                  return this.field_177239_a.func_193383_a(p_193401_1_, this, p_193401_2_, p_193401_3_);
              }
 +
 +            //Forge Start
++            @Override
 +            public ImmutableTable<IProperty<?>, Comparable<?>, IBlockState> getPropertyValueTable()
 +            {
 +                return field_177238_c;
@@ -72,9 +73,16 @@
 +                return this.field_177239_a.getLightValue(this, world, pos);
 +            }
 +
++            @Override
 +            public boolean isSideSolid(IBlockAccess world, BlockPos pos, EnumFacing side)
 +            {
 +                return this.field_177239_a.isSideSolid(this, world, pos, side);
++            }
++
++            @Override
++            public boolean doesSideBlockChestOpening(IBlockAccess world, BlockPos pos, EnumFacing side)
++            {
++                return this.field_177239_a.doesSideBlockChestOpening(this, world, pos, side);
 +            }
 +
 +            @Override

--- a/patches/minecraft/net/minecraft/block/state/IBlockProperties.java.patch
+++ b/patches/minecraft/net/minecraft/block/state/IBlockProperties.java.patch
@@ -14,7 +14,7 @@
  
      @SideOnly(Side.CLIENT)
      boolean func_185895_e();
-@@ -95,8 +99,13 @@
+@@ -95,8 +99,14 @@
  
      RayTraceResult func_185910_a(World p_185910_1_, BlockPos p_185910_2_, Vec3d p_185910_3_, Vec3d p_185910_4_);
  
@@ -24,6 +24,7 @@
 +    //Forge added functions
 +    boolean doesSideBlockRendering(IBlockAccess world, BlockPos pos, EnumFacing side);
 +    boolean isSideSolid(IBlockAccess world, BlockPos pos, EnumFacing side);
++    boolean doesSideBlockChestOpening(IBlockAccess world, BlockPos pos, EnumFacing side);
 +
      Vec3d func_191059_e(IBlockAccess p_191059_1_, BlockPos p_191059_2_);
  


### PR DESCRIPTION
~~The makes the chest and trapped chest match the behavior of the ender chest and vanilla.~~
Edit: This makes a block method for checking if it blocks a chest from opening. This maintains the weird vanilla behavior, while making forge blocks use the more reasonable `isSideSolid` by default.

Can't say I agree with the [vanilla reasoning](https://bugs.mojang.com/browse/MC-378), but this very old patch is currently weird for players with forge clients when playing vanilla adventure maps that use decorative slabs or stairs over chests.