### PR TITLE
Allow events to track who canceled them.

### DIFF
--- a/src/main/java/net/minecraftforge/fml/common/eventhandler/ASMEventHandler.java
+++ b/src/main/java/net/minecraftforge/fml/common/eventhandler/ASMEventHandler.java
@@ -88,6 +88,11 @@ public class ASMEventHandler implements IEventListener
                 if (filter == null || filter == ((IGenericEvent)event).getGenericType())
                 {
                     handler.invoke(event);
+                    
+                    if (event.getCanceler() == null && event.isCanceled()) 
+                    {
+                        event.setCanceler(this.owner);
+                    }
                 }
             }
         }

--- a/src/main/java/net/minecraftforge/fml/common/eventhandler/Event.java
+++ b/src/main/java/net/minecraftforge/fml/common/eventhandler/Event.java
@@ -30,6 +30,8 @@ import javax.annotation.Nullable;
 
 import com.google.common.base.Preconditions;
 
+import net.minecraftforge.fml.common.ModContainer;
+
 
 /**
  * Base Event class that all other events are derived from
@@ -51,6 +53,7 @@ public class Event
     private Result result = Result.DEFAULT;
     private static ListenerList listeners = new ListenerList();
     private EventPriority phase = null;
+    private ModContainer canceler;
 
     public Event()
     {
@@ -162,5 +165,27 @@ public class Event
         int prev = phase == null ? -1 : phase.ordinal();
         Preconditions.checkArgument(prev < value.ordinal(), "Attempted to set event phase to %s when already %s", value, phase);
         phase = value;
+    }
+    
+    /**
+     * Gets the owner of the event listener that canceled this event.
+     * If the event has not been cancelled, this will be null.
+     * 
+     * @return The mod that canceled this event.
+     */
+    @Nullable
+    public ModContainer getCanceler() 
+    {
+        return this.canceler;
+    }
+    
+    /**
+     * Sets the mod that canceled the event.
+     * 
+     * @param container The mod that canceled the event.
+     */
+    protected void setCanceler(ModContainer container) 
+    {
+        this.canceler = container;
     }
 }

--- a/src/main/java/net/minecraftforge/fml/common/eventhandler/Event.java
+++ b/src/main/java/net/minecraftforge/fml/common/eventhandler/Event.java
@@ -53,6 +53,7 @@ public class Event
     private Result result = Result.DEFAULT;
     private static ListenerList listeners = new ListenerList();
     private EventPriority phase = null;
+    @Nullable
     private ModContainer canceler;
 
     public Event()

--- a/src/test/java/net/minecraftforge/debug/EventCancelTest.java
+++ b/src/test/java/net/minecraftforge/debug/EventCancelTest.java
@@ -1,0 +1,44 @@
+package net.minecraftforge.debug;
+
+import org.apache.logging.log4j.Logger;
+
+import net.minecraftforge.common.MinecraftForge;
+import net.minecraftforge.event.entity.EntityTravelToDimensionEvent;
+import net.minecraftforge.fml.common.Mod;
+import net.minecraftforge.fml.common.Mod.EventHandler;
+import net.minecraftforge.fml.common.event.FMLPreInitializationEvent;
+import net.minecraftforge.fml.common.eventhandler.EventPriority;
+import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
+
+@Mod(modid = EventCancelTest.MODID, name = "EventCancelTest", version = "1.0")
+public class EventCancelTest
+{
+    public static final String MODID = "eventcanceltest";
+    public static final boolean ENABLED = false;
+    public static Logger log;
+    
+    @EventHandler
+    public void onPreInit(FMLPreInitializationEvent event)
+    {       
+        if (ENABLED) 
+        {         
+            log = event.getModLog();
+            MinecraftForge.EVENT_BUS.register(this);
+        }
+    }
+    
+    @SubscribeEvent(priority = EventPriority.HIGHEST)
+    public void canDimensionChangeFirst(EntityTravelToDimensionEvent event) 
+    {       
+        event.setCanceled(true);
+    }
+    
+    @SubscribeEvent(priority = EventPriority.LOWEST, receiveCanceled = true)
+    public void canDimensionChangeLast(EntityTravelToDimensionEvent event) 
+    {       
+        if (event.isCanceled())
+        {
+            log.info("EntityTravelToDimensionEvent was canceled by {}", event.getCanceler().getModId());
+        }
+    }
+}


### PR DESCRIPTION
This PR allows events to track what mod had canceled them. One example of where this is useful is providing context for debug information when an event you post has been canceled. In my latest mod I am posting the `EntityTravelToDimensionEvent` event when a player travels to my dimension, but an unknown mod is canceling this event without providing any information to the player. I would like to be able to be able to print a log message so players are not confused and help track the actual issue down. 

This PR also adds a debug mod. When enabled it will cancel the EntityTravelToDimensionEvent event, and a second event is going to print debug info about it. 