### PR TITLE
Fix hoppers being unable to extract items from some double chests (MC-99321)

### DIFF
--- a/patches/minecraft/net/minecraft/block/BlockChest.java.patch
+++ b/patches/minecraft/net/minecraft/block/BlockChest.java.patch
@@ -1,5 +1,14 @@
 --- ../src-base/minecraft/net/minecraft/block/BlockChest.java
 +++ ../src-work/minecraft/net/minecraft/block/BlockChest.java
+@@ -470,7 +470,7 @@
+ 
+                     if (block == this)
+                     {
+-                        if (this.func_176457_m(p_189418_1_, blockpos))
++                        if (!p_189418_3_ && this.func_176457_m(p_189418_1_, blockpos)) // Forge: fix MC-99321
+                         {
+                             return null;
+                         }
 @@ -538,7 +538,7 @@
  
      private boolean func_176456_n(World p_176456_1_, BlockPos p_176456_2_)


### PR DESCRIPTION
While we're looking at chests, it'd be nice to fix this vanilla issue ([MC-99321](https://bugs.mojang.com/browse/MC-99321)).

Seems like it'll be fixed for 1.13, so I don't mind if this is rejected in favour of waiting, but as it's a very small patch I felt I might as well submit it.