### PR TITLE
Clean up capability checking for entities

### DIFF
--- a/patches/minecraft/net/minecraft/entity/Entity.java.patch
+++ b/patches/minecraft/net/minecraft/entity/Entity.java.patch
@@ -177,7 +177,7 @@
      }
  
      public boolean func_174816_a(Explosion p_174816_1_, World p_174816_2_, BlockPos p_174816_3_, IBlockState p_174816_4_, float p_174816_5_)
-@@ -2901,6 +2929,185 @@
+@@ -2901,6 +2929,183 @@
          EnchantmentHelper.func_151385_b(p_174815_1_, p_174815_2_);
      }
  
@@ -318,9 +318,7 @@
 +    @Override
 +    public boolean hasCapability(net.minecraftforge.common.capabilities.Capability<?> capability, @Nullable net.minecraft.util.EnumFacing facing)
 +    {
-+        if (getCapability(capability, facing) != null)
-+            return true;
-+        return capabilities == null ? false : capabilities.hasCapability(capability, facing);
++        return capabilities != null && capabilities.hasCapability(capability, facing);
 +    }
 +
 +    @Override


### PR DESCRIPTION
Fixes #4589.

As mentioned there, the call to `getCapability` isn't really needed, so this PR removes it.