### PR TITLE
Fixed Share Tag causing NBT data loss

### DIFF
--- a/jsons/1.12.2.json
+++ b/jsons/1.12.2.json
@@ -1,10 +1,10 @@
 {
     "assetIndex": {
         "id": "1.12",
-        "sha1": "c2ba0c4da30cce204c70db2ebc32a942cea8c7dd",
-        "size": 169015,
-        "url": "https://launchermeta.mojang.com/mc/assets/1.12/c2ba0c4da30cce204c70db2ebc32a942cea8c7dd/1.12.json",
-        "totalSize": 127300317
+        "sha1": "3b666765bafa02e84e24b371d9efd7a4d1b6e188",
+        "size": 169254,
+        "url": "https://launchermeta.mojang.com/mc/assets/1.12/3b666765bafa02e84e24b371d9efd7a4d1b6e188/1.12.json",
+        "totalSize": 127589960
     },
     "assets": "1.12",
     "downloads": {
@@ -719,6 +719,6 @@
     "minecraftArguments": "--username ${auth_player_name} --version ${version_name} --gameDir ${game_directory} --assetsDir ${assets_root} --assetIndex ${assets_index_name} --uuid ${auth_uuid} --accessToken ${auth_access_token} --userType ${user_type} --versionType ${version_type}",
     "minimumLauncherVersion": 18,
     "releaseTime": "2017-09-18T08:39:46+00:00",
-    "time": "2017-09-18T08:41:11+00:00",
+    "time": "2017-12-07T09:55:13+00:00",
     "type": "release"
 }

--- a/patches/minecraft/net/minecraft/client/multiplayer/PlayerControllerMP.java.patch
+++ b/patches/minecraft/net/minecraft/client/multiplayer/PlayerControllerMP.java.patch
@@ -212,3 +212,30 @@
          return this.field_78779_k == GameType.SPECTATOR ? EnumActionResult.PASS : p_187102_2_.func_184199_a(p_187102_1_, vec3d, p_187102_4_);
      }
  
+@@ -516,7 +564,7 @@
+     {
+         short short1 = p_187098_5_.field_71070_bA.func_75136_a(p_187098_5_.field_71071_by);
+         ItemStack itemstack = p_187098_5_.field_71070_bA.func_184996_a(p_187098_2_, p_187098_3_, p_187098_4_, p_187098_5_);
+-        this.field_78774_b.func_147297_a(new CPacketClickWindow(p_187098_1_, p_187098_2_, p_187098_3_, p_187098_4_, itemstack, short1));
++        this.field_78774_b.func_147297_a(new CPacketClickWindow(p_187098_5_, p_187098_1_, p_187098_2_, p_187098_3_, p_187098_4_, itemstack, short1));
+         return itemstack;
+     }
+ 
+@@ -534,7 +582,7 @@
+     {
+         if (this.field_78779_k.func_77145_d())
+         {
+-            this.field_78774_b.func_147297_a(new CPacketCreativeInventoryAction(p_78761_2_, p_78761_1_));
++            this.field_78774_b.func_147297_a(new CPacketCreativeInventoryAction(field_78776_a.field_71439_g, p_78761_2_, p_78761_1_));
+         }
+     }
+ 
+@@ -542,7 +590,7 @@
+     {
+         if (this.field_78779_k.func_77145_d() && !p_78752_1_.func_190926_b())
+         {
+-            this.field_78774_b.func_147297_a(new CPacketCreativeInventoryAction(-1, p_78752_1_));
++            this.field_78774_b.func_147297_a(new CPacketCreativeInventoryAction(field_78776_a.field_71439_g, -1, p_78752_1_));
+         }
+     }
+ 

--- a/patches/minecraft/net/minecraft/entity/EntityLivingBase.java.patch
+++ b/patches/minecraft/net/minecraft/entity/EntityLivingBase.java.patch
@@ -277,8 +277,9 @@
  
                  if (!ItemStack.func_77989_b(itemstack1, itemstack))
                  {
+-                    ((WorldServer)this.field_70170_p).func_73039_n().func_151247_a(this, new SPacketEntityEquipment(this.func_145782_y(), entityequipmentslot, itemstack1));
 +                    if (!ItemStack.areItemStacksEqualUsingNBTShareTag(itemstack1, itemstack))
-                     ((WorldServer)this.field_70170_p).func_73039_n().func_151247_a(this, new SPacketEntityEquipment(this.func_145782_y(), entityequipmentslot, itemstack1));
++                    ((WorldServer)this.field_70170_p).func_73039_n().func_151247_a(this, new SPacketEntityEquipment(this instanceof EntityPlayerMP ? (EntityPlayerMP) this : null, this.func_145782_y(), entityequipmentslot, itemstack1));
 +                    net.minecraftforge.common.MinecraftForge.EVENT_BUS.post(new net.minecraftforge.event.entity.living.LivingEquipmentChangeEvent(this, entityequipmentslot, itemstack, itemstack1));
  
                      if (!itemstack.func_190926_b())

--- a/patches/minecraft/net/minecraft/entity/EntityTrackerEntry.java.patch
+++ b/patches/minecraft/net/minecraft/entity/EntityTrackerEntry.java.patch
@@ -16,6 +16,15 @@
  
                      if (packet != null)
                      {
+@@ -420,7 +420,7 @@
+ 
+                             if (!itemstack.func_190926_b())
+                             {
+-                                p_73117_1_.field_71135_a.func_147359_a(new SPacketEntityEquipment(this.field_73132_a.func_145782_y(), entityequipmentslot, itemstack));
++                                p_73117_1_.field_71135_a.func_147359_a(new SPacketEntityEquipment(field_73132_a instanceof EntityPlayerMP ? (EntityPlayerMP) field_73132_a : null, this.field_73132_a.func_145782_y(), entityequipmentslot, itemstack));
+                             }
+                         }
+                     }
 @@ -457,6 +457,7 @@
  
                      this.field_73132_a.func_184178_b(p_73117_1_);

--- a/patches/minecraft/net/minecraft/entity/player/EntityPlayerMP.java.patch
+++ b/patches/minecraft/net/minecraft/entity/player/EntityPlayerMP.java.patch
@@ -91,7 +91,35 @@
          IInventory iinventory = ((ContainerMerchant)this.field_71070_bA).func_75174_d();
          ITextComponent itextcomponent = p_180472_1_.func_145748_c_();
          this.field_71135_a.func_147359_a(new SPacketOpenWindow(this.field_71139_cq, "minecraft:villager", itextcomponent, iinventory.func_70302_i_()));
-@@ -1003,6 +1020,7 @@
+@@ -957,7 +974,7 @@
+ 
+             if (!this.field_71137_h)
+             {
+-                this.field_71135_a.func_147359_a(new SPacketSetSlot(p_71111_1_.field_75152_c, p_71111_2_, p_71111_3_));
++                this.field_71135_a.func_147359_a(new SPacketSetSlot(this, p_71111_1_.field_75152_c, p_71111_2_, p_71111_3_));
+             }
+         }
+     }
+@@ -969,8 +986,8 @@
+ 
+     public void func_71110_a(Container p_71110_1_, NonNullList<ItemStack> p_71110_2_)
+     {
+-        this.field_71135_a.func_147359_a(new SPacketWindowItems(p_71110_1_.field_75152_c, p_71110_2_));
+-        this.field_71135_a.func_147359_a(new SPacketSetSlot(-1, -1, this.field_71071_by.func_70445_o()));
++        this.field_71135_a.func_147359_a(new SPacketWindowItems(this, p_71110_1_.field_75152_c, p_71110_2_));
++        this.field_71135_a.func_147359_a(new SPacketSetSlot(this, -1, -1, this.field_71071_by.func_70445_o()));
+     }
+ 
+     public void func_71112_a(Container p_71112_1_, int p_71112_2_, int p_71112_3_)
+@@ -996,13 +1013,14 @@
+     {
+         if (!this.field_71137_h)
+         {
+-            this.field_71135_a.func_147359_a(new SPacketSetSlot(-1, -1, this.field_71071_by.func_70445_o()));
++            this.field_71135_a.func_147359_a(new SPacketSetSlot(this, -1, -1, this.field_71071_by.func_70445_o()));
+         }
+     }
+ 
      public void func_71128_l()
      {
          this.field_71070_bA.func_75134_a(this);
@@ -118,3 +146,16 @@
      }
  
      protected void func_70670_a(PotionEffect p_70670_1_)
+@@ -1214,6 +1244,12 @@
+         this.field_71134_c.func_73076_a(p_71033_1_);
+         this.field_71135_a.func_147359_a(new SPacketChangeGameState(3, (float)p_71033_1_.func_77148_a()));
+ 
++        // Only need to send if the player changes to creative mode
++        if(p_71033_1_ == GameType.CREATIVE)
++        {
++            this.func_71120_a(this.field_71069_bz);
++        }
++
+         if (p_71033_1_ == GameType.SPECTATOR)
+         {
+             this.func_192030_dh();

--- a/patches/minecraft/net/minecraft/entity/player/InventoryPlayer.java.patch
+++ b/patches/minecraft/net/minecraft/entity/player/InventoryPlayer.java.patch
@@ -24,3 +24,13 @@
      }
  
      public boolean func_70441_a(ItemStack p_70441_1_)
+@@ -479,7 +487,8 @@
+ 
+                 if (this.func_191971_c(i, p_191975_2_.func_77979_a(j)))
+                 {
+-                    ((EntityPlayerMP)this.field_70458_d).field_71135_a.func_147359_a(new SPacketSetSlot(-2, i, this.func_70301_a(i)));
++                    EntityPlayerMP playerMP = (EntityPlayerMP) this.field_70458_d;
++                    playerMP.field_71135_a.func_147359_a(new SPacketSetSlot(playerMP, -2, i, this.func_70301_a(i)));
+                 }
+             }
+         }

--- a/patches/minecraft/net/minecraft/inventory/Container.java.patch
+++ b/patches/minecraft/net/minecraft/inventory/Container.java.patch
@@ -45,3 +45,12 @@
          }
  
          p_94525_2_.func_190917_f(p_94525_3_);
+@@ -796,7 +799,7 @@
+             }
+ 
+             p_192389_4_.func_70299_a(0, itemstack);
+-            entityplayermp.field_71135_a.func_147359_a(new SPacketSetSlot(this.field_75152_c, 0, itemstack));
++            entityplayermp.field_71135_a.func_147359_a(new SPacketSetSlot(entityplayermp, this.field_75152_c, 0, itemstack));
+         }
+     }
+ }

--- a/patches/minecraft/net/minecraft/item/ItemWrittenBook.java.patch
+++ b/patches/minecraft/net/minecraft/item/ItemWrittenBook.java.patch
@@ -1,0 +1,12 @@
+--- ../src-base/minecraft/net/minecraft/item/ItemWrittenBook.java
++++ ../src-work/minecraft/net/minecraft/item/ItemWrittenBook.java
+@@ -137,7 +137,8 @@
+                     if (p_179229_2_ instanceof EntityPlayerMP && p_179229_2_.func_184614_ca() == p_179229_1_)
+                     {
+                         Slot slot = p_179229_2_.field_71070_bA.func_75147_a(p_179229_2_.field_71071_by, p_179229_2_.field_71071_by.field_70461_c);
+-                        ((EntityPlayerMP)p_179229_2_).field_71135_a.func_147359_a(new SPacketSetSlot(0, slot.field_75222_d, p_179229_1_));
++                        EntityPlayerMP playerMP = (EntityPlayerMP) p_179229_2_;
++                        playerMP.field_71135_a.func_147359_a(new SPacketSetSlot(playerMP, 0, slot.field_75222_d, p_179229_1_));
+                     }
+                 }
+             }

--- a/patches/minecraft/net/minecraft/network/NetHandlerPlayServer.java.patch
+++ b/patches/minecraft/net/minecraft/network/NetHandlerPlayServer.java.patch
@@ -60,3 +60,14 @@
                  {
                      this.field_147369_b.field_71135_a.func_147359_a(new SPacketConfirmTransaction(p_147351_1_.func_149548_c(), p_147351_1_.func_149547_f(), true));
                      this.field_147369_b.field_71137_h = true;
+@@ -1741,8 +1749,8 @@
+             {
+                 int j1 = packetbuffer6.func_150792_a();
+                 this.field_147369_b.field_71071_by.func_184430_d(j1);
+-                this.field_147369_b.field_71135_a.func_147359_a(new SPacketSetSlot(-2, this.field_147369_b.field_71071_by.field_70461_c, this.field_147369_b.field_71071_by.func_70301_a(this.field_147369_b.field_71071_by.field_70461_c)));
+-                this.field_147369_b.field_71135_a.func_147359_a(new SPacketSetSlot(-2, j1, this.field_147369_b.field_71071_by.func_70301_a(j1)));
++                this.field_147369_b.field_71135_a.func_147359_a(new SPacketSetSlot(this.field_147369_b, -2, this.field_147369_b.field_71071_by.field_70461_c, this.field_147369_b.field_71071_by.func_70301_a(this.field_147369_b.field_71071_by.field_70461_c)));
++                this.field_147369_b.field_71135_a.func_147359_a(new SPacketSetSlot(this.field_147369_b, -2, j1, this.field_147369_b.field_71071_by.func_70301_a(j1)));
+                 this.field_147369_b.field_71135_a.func_147359_a(new SPacketHeldItemChange(this.field_147369_b.field_71071_by.field_70461_c));
+             }
+             catch (Exception exception)

--- a/patches/minecraft/net/minecraft/network/play/client/CPacketClickWindow.java.patch
+++ b/patches/minecraft/net/minecraft/network/play/client/CPacketClickWindow.java.patch
@@ -1,11 +1,56 @@
 --- ../src-base/minecraft/net/minecraft/network/play/client/CPacketClickWindow.java
 +++ ../src-work/minecraft/net/minecraft/network/play/client/CPacketClickWindow.java
-@@ -55,7 +55,7 @@
+@@ -1,16 +1,21 @@
+ package net.minecraft.network.play.client;
+ 
+ import java.io.IOException;
++
++import net.minecraft.client.Minecraft;
++import net.minecraft.entity.player.EntityPlayer;
+ import net.minecraft.inventory.ClickType;
+ import net.minecraft.item.ItemStack;
+ import net.minecraft.network.Packet;
+ import net.minecraft.network.PacketBuffer;
+ import net.minecraft.network.play.INetHandlerPlayServer;
++import net.minecraftforge.common.util.PacketUtil;
+ import net.minecraftforge.fml.relauncher.Side;
+ import net.minecraftforge.fml.relauncher.SideOnly;
+ 
+ public class CPacketClickWindow implements Packet<INetHandlerPlayServer>
+ {
++    private EntityPlayer player;
+     private int field_149554_a;
+     private int field_149552_b;
+     private int field_149553_c;
+@@ -23,14 +28,15 @@
+     }
+ 
+     @SideOnly(Side.CLIENT)
+-    public CPacketClickWindow(int p_i46882_1_, int p_i46882_2_, int p_i46882_3_, ClickType p_i46882_4_, ItemStack p_i46882_5_, short p_i46882_6_)
++    public CPacketClickWindow(EntityPlayer player, int windowIdIn, int slotIdIn, int usedButtonIn, ClickType modeIn, ItemStack clickedItemIn, short actionNumberIn)
+     {
+-        this.field_149554_a = p_i46882_1_;
+-        this.field_149552_b = p_i46882_2_;
+-        this.field_149553_c = p_i46882_3_;
+-        this.field_149551_e = p_i46882_5_.func_77946_l();
+-        this.field_149550_d = p_i46882_6_;
+-        this.field_149549_f = p_i46882_4_;
++        this.player = player;
++        this.field_149554_a = windowIdIn;
++        this.field_149552_b = slotIdIn;
++        this.field_149553_c = usedButtonIn;
++        this.field_149551_e = clickedItemIn.func_77946_l();
++        this.field_149550_d = actionNumberIn;
++        this.field_149549_f = modeIn;
+     }
+ 
+     public void func_148833_a(INetHandlerPlayServer p_148833_1_)
+@@ -55,7 +61,7 @@
          p_148840_1_.writeByte(this.field_149553_c);
          p_148840_1_.writeShort(this.field_149550_d);
          p_148840_1_.func_179249_a(this.field_149549_f);
 -        p_148840_1_.func_150788_a(this.field_149551_e);
-+        net.minecraftforge.common.util.PacketUtil.writeItemStackFromClientToServer(p_148840_1_, this.field_149551_e);
++        PacketUtil.writeItemStackFromClientToServer(p_148840_1_, this.player, this.field_149551_e);
      }
  
      public int func_149548_c()

--- a/patches/minecraft/net/minecraft/network/play/client/CPacketCreativeInventoryAction.java.patch
+++ b/patches/minecraft/net/minecraft/network/play/client/CPacketCreativeInventoryAction.java.patch
@@ -1,11 +1,47 @@
 --- ../src-base/minecraft/net/minecraft/network/play/client/CPacketCreativeInventoryAction.java
 +++ ../src-work/minecraft/net/minecraft/network/play/client/CPacketCreativeInventoryAction.java
-@@ -38,7 +38,7 @@
+@@ -1,15 +1,20 @@
+ package net.minecraft.network.play.client;
+ 
+ import java.io.IOException;
++
++import net.minecraft.client.Minecraft;
++import net.minecraft.entity.player.EntityPlayer;
+ import net.minecraft.item.ItemStack;
+ import net.minecraft.network.Packet;
+ import net.minecraft.network.PacketBuffer;
+ import net.minecraft.network.play.INetHandlerPlayServer;
++import net.minecraftforge.common.util.PacketUtil;
+ import net.minecraftforge.fml.relauncher.Side;
+ import net.minecraftforge.fml.relauncher.SideOnly;
+ 
+ public class CPacketCreativeInventoryAction implements Packet<INetHandlerPlayServer>
+ {
++    private EntityPlayer player;
+     private int field_149629_a;
+     private ItemStack field_149628_b = ItemStack.field_190927_a;
+ 
+@@ -18,10 +23,11 @@
+     }
+ 
+     @SideOnly(Side.CLIENT)
+-    public CPacketCreativeInventoryAction(int p_i46862_1_, ItemStack p_i46862_2_)
++    public CPacketCreativeInventoryAction(EntityPlayer player, int slotIdIn, ItemStack stackIn)
+     {
+-        this.field_149629_a = p_i46862_1_;
+-        this.field_149628_b = p_i46862_2_.func_77946_l();
++        this.player = player;
++        this.field_149629_a = slotIdIn;
++        this.field_149628_b = stackIn.func_77946_l();
+     }
+ 
+     public void func_148833_a(INetHandlerPlayServer p_148833_1_)
+@@ -38,7 +44,7 @@
      public void func_148840_b(PacketBuffer p_148840_1_) throws IOException
      {
          p_148840_1_.writeShort(this.field_149629_a);
 -        p_148840_1_.func_150788_a(this.field_149628_b);
-+        net.minecraftforge.common.util.PacketUtil.writeItemStackFromClientToServer(p_148840_1_, this.field_149628_b);
++        PacketUtil.writeItemStackFromClientToServer(p_148840_1_, this.player, this.field_149628_b);
      }
  
      public int func_149627_c()

--- a/patches/minecraft/net/minecraft/network/play/server/SPacketEntityEquipment.java.patch
+++ b/patches/minecraft/net/minecraft/network/play/server/SPacketEntityEquipment.java.patch
@@ -1,0 +1,51 @@
+--- ../src-base/minecraft/net/minecraft/network/play/server/SPacketEntityEquipment.java
++++ ../src-work/minecraft/net/minecraft/network/play/server/SPacketEntityEquipment.java
+@@ -1,16 +1,22 @@
+ package net.minecraft.network.play.server;
+ 
+ import java.io.IOException;
++
++import net.minecraft.entity.player.EntityPlayerMP;
+ import net.minecraft.inventory.EntityEquipmentSlot;
+ import net.minecraft.item.ItemStack;
+ import net.minecraft.network.Packet;
+ import net.minecraft.network.PacketBuffer;
+ import net.minecraft.network.play.INetHandlerPlayClient;
++import net.minecraftforge.common.util.PacketUtil;
+ import net.minecraftforge.fml.relauncher.Side;
+ import net.minecraftforge.fml.relauncher.SideOnly;
+ 
++import javax.annotation.Nullable;
++
+ public class SPacketEntityEquipment implements Packet<INetHandlerPlayClient>
+ {
++    private EntityPlayerMP player;
+     private int field_149394_a;
+     private EntityEquipmentSlot field_149392_b;
+     private ItemStack field_149393_c = ItemStack.field_190927_a;
+@@ -19,11 +25,12 @@
+     {
+     }
+ 
+-    public SPacketEntityEquipment(int p_i46913_1_, EntityEquipmentSlot p_i46913_2_, ItemStack p_i46913_3_)
++    public SPacketEntityEquipment(@Nullable EntityPlayerMP player, int entityIdIn, EntityEquipmentSlot equipmentSlotIn, ItemStack itemStackIn)
+     {
+-        this.field_149394_a = p_i46913_1_;
+-        this.field_149392_b = p_i46913_2_;
+-        this.field_149393_c = p_i46913_3_.func_77946_l();
++        this.player = player;
++        this.field_149394_a = entityIdIn;
++        this.field_149392_b = equipmentSlotIn;
++        this.field_149393_c = itemStackIn.func_77946_l();
+     }
+ 
+     public void func_148837_a(PacketBuffer p_148837_1_) throws IOException
+@@ -37,7 +44,7 @@
+     {
+         p_148840_1_.func_150787_b(this.field_149394_a);
+         p_148840_1_.func_179249_a(this.field_149392_b);
+-        p_148840_1_.func_150788_a(this.field_149393_c);
++        PacketUtil.writeItemStackFromServerToClient(p_148840_1_, this.player, this.field_149393_c);
+     }
+ 
+     public void func_148833_a(INetHandlerPlayClient p_148833_1_)

--- a/patches/minecraft/net/minecraft/network/play/server/SPacketSetSlot.java.patch
+++ b/patches/minecraft/net/minecraft/network/play/server/SPacketSetSlot.java.patch
@@ -1,0 +1,48 @@
+--- ../src-base/minecraft/net/minecraft/network/play/server/SPacketSetSlot.java
++++ ../src-work/minecraft/net/minecraft/network/play/server/SPacketSetSlot.java
+@@ -1,15 +1,19 @@
+ package net.minecraft.network.play.server;
+ 
+ import java.io.IOException;
++
++import net.minecraft.entity.player.EntityPlayerMP;
+ import net.minecraft.item.ItemStack;
+ import net.minecraft.network.Packet;
+ import net.minecraft.network.PacketBuffer;
+ import net.minecraft.network.play.INetHandlerPlayClient;
++import net.minecraftforge.common.util.PacketUtil;
+ import net.minecraftforge.fml.relauncher.Side;
+ import net.minecraftforge.fml.relauncher.SideOnly;
+ 
+ public class SPacketSetSlot implements Packet<INetHandlerPlayClient>
+ {
++    private EntityPlayerMP player;
+     private int field_149179_a;
+     private int field_149177_b;
+     private ItemStack field_149178_c = ItemStack.field_190927_a;
+@@ -18,11 +22,12 @@
+     {
+     }
+ 
+-    public SPacketSetSlot(int p_i46951_1_, int p_i46951_2_, ItemStack p_i46951_3_)
++    public SPacketSetSlot(EntityPlayerMP player, int windowIdIn, int slotIn, ItemStack itemIn)
+     {
+-        this.field_149179_a = p_i46951_1_;
+-        this.field_149177_b = p_i46951_2_;
+-        this.field_149178_c = p_i46951_3_.func_77946_l();
++        this.player = player;
++        this.field_149179_a = windowIdIn;
++        this.field_149177_b = slotIn;
++        this.field_149178_c = itemIn.func_77946_l();
+     }
+ 
+     public void func_148833_a(INetHandlerPlayClient p_148833_1_)
+@@ -41,7 +46,7 @@
+     {
+         p_148840_1_.writeByte(this.field_149179_a);
+         p_148840_1_.writeShort(this.field_149177_b);
+-        p_148840_1_.func_150788_a(this.field_149178_c);
++        PacketUtil.writeItemStackFromServerToClient(p_148840_1_, this.player, this.field_149178_c);
+     }
+ 
+     @SideOnly(Side.CLIENT)

--- a/patches/minecraft/net/minecraft/network/play/server/SPacketWindowItems.java.patch
+++ b/patches/minecraft/net/minecraft/network/play/server/SPacketWindowItems.java.patch
@@ -1,0 +1,43 @@
+--- ../src-base/minecraft/net/minecraft/network/play/server/SPacketWindowItems.java
++++ ../src-work/minecraft/net/minecraft/network/play/server/SPacketWindowItems.java
+@@ -2,16 +2,20 @@
+ 
+ import java.io.IOException;
+ import java.util.List;
++
++import net.minecraft.entity.player.EntityPlayerMP;
+ import net.minecraft.item.ItemStack;
+ import net.minecraft.network.Packet;
+ import net.minecraft.network.PacketBuffer;
+ import net.minecraft.network.play.INetHandlerPlayClient;
+ import net.minecraft.util.NonNullList;
++import net.minecraftforge.common.util.PacketUtil;
+ import net.minecraftforge.fml.relauncher.Side;
+ import net.minecraftforge.fml.relauncher.SideOnly;
+ 
+ public class SPacketWindowItems implements Packet<INetHandlerPlayClient>
+ {
++    private EntityPlayerMP player;
+     private int field_148914_a;
+     private List<ItemStack> field_148913_b;
+ 
+@@ -19,8 +23,9 @@
+     {
+     }
+ 
+-    public SPacketWindowItems(int p_i47317_1_, NonNullList<ItemStack> p_i47317_2_)
++    public SPacketWindowItems(EntityPlayerMP player, int p_i47317_1_, NonNullList<ItemStack> p_i47317_2_)
+     {
++        this.player = player;
+         this.field_148914_a = p_i47317_1_;
+         this.field_148913_b = NonNullList.<ItemStack>func_191197_a(p_i47317_2_.size(), ItemStack.field_190927_a);
+ 
+@@ -50,7 +55,7 @@
+ 
+         for (ItemStack itemstack : this.field_148913_b)
+         {
+-            p_148840_1_.func_150788_a(itemstack);
++            PacketUtil.writeItemStackFromServerToClient(p_148840_1_, this.player, itemstack);
+         }
+     }
+ 

--- a/src/main/java/net/minecraftforge/common/util/PacketUtil.java
+++ b/src/main/java/net/minecraftforge/common/util/PacketUtil.java
@@ -18,23 +18,31 @@
  */
 package net.minecraftforge.common.util;
 
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.network.PacketBuffer;
+import net.minecraftforge.fml.common.FMLCommonHandler;
+import net.minecraftforge.fml.relauncher.Side;
+
+import javax.annotation.Nullable;
 
 public class PacketUtil
 {
     private PacketUtil() {}
 
     /**
-     * Most ItemStack serialization is Server to Client, and must go through PacketBuffer.writeItemStack which uses Item.getNBTShareTag.
-     * One exception is items from the creative menu, which must be sent from Client to Server with their full NBT.
-     * <br/>
-     * This method matches PacketBuffer.writeItemStack but without the Item.getNBTShareTag patch.
-     * It is compatible with PacketBuffer.readItemStack.
+     * Serializes an ItemStack to send to the client. If the player is in creative mode, all NBT
+     * data of the item is sent to the client. This prevents the NBT data of the ItemStack being lost
+     * due to the fact that creative serializes from Client to Server, rather than the opposite way.
+     *
+     * @param buffer the packet buffer
+     * @param player the player being sent the packet
+     * @param stack the itemstack to serialize
      */
-    public static void writeItemStackFromClientToServer(PacketBuffer buffer, ItemStack stack)
+    public static void writeItemStackFromServerToClient(PacketBuffer buffer, @Nullable EntityPlayerMP player, ItemStack stack)
     {
         if (stack.isEmpty())
         {
@@ -47,7 +55,40 @@ public class PacketUtil
             buffer.writeShort(stack.getMetadata());
             NBTTagCompound nbttagcompound = null;
 
-            if (stack.getItem().isDamageable() || stack.getItem().getShareTag())
+            if(player != null && player.interactionManager.isCreative())
+            {
+                nbttagcompound = stack.getTagCompound();
+            }
+            else if(stack.getItem().isDamageable() || stack.getItem().getShareTag())
+            {
+                nbttagcompound = stack.getItem().getNBTShareTag(stack);
+            }
+
+            buffer.writeCompoundTag(nbttagcompound);
+        }
+    }
+
+    /**
+     * Most ItemStack serialization is Server to Client, and must go through PacketBuffer.writeItemStack which uses Item.getNBTShareTag.
+     * One exception is items from the creative menu, which must be sent from Client to Server with their full NBT.
+     * <br/>
+     * This method matches PacketBuffer.writeItemStack but without the Item.getNBTShareTag patch.
+     * It is compatible with PacketBuffer.readItemStack.
+     */
+    public static void writeItemStackFromClientToServer(PacketBuffer buffer, EntityPlayer player, ItemStack stack)
+    {
+        if (stack.isEmpty())
+        {
+            buffer.writeShort(-1);
+        }
+        else
+        {
+            buffer.writeShort(Item.getIdFromItem(stack.getItem()));
+            buffer.writeByte(stack.getCount());
+            buffer.writeShort(stack.getMetadata());
+            NBTTagCompound nbttagcompound = null;
+
+            if (stack.getItem().isDamageable() || stack.getItem().getShareTag() || player.capabilities.isCreativeMode)
             {
                 nbttagcompound = stack.getTagCompound();
             }

--- a/src/main/java/net/minecraftforge/common/util/PacketUtil.java
+++ b/src/main/java/net/minecraftforge/common/util/PacketUtil.java
@@ -37,6 +37,7 @@ public class PacketUtil
      * Serializes an ItemStack to send to the client. If the player is in creative mode, all NBT
      * data of the item is sent to the client. This prevents the NBT data of the ItemStack being lost
      * due to the fact that creative serializes from Client to Server, rather than the opposite way.
+     * This still respects the original getShareTag() behavior in PacketBuffer#writeItemStack()
      *
      * @param buffer the packet buffer
      * @param player the player being sent the packet
@@ -87,6 +88,7 @@ public class PacketUtil
             buffer.writeByte(stack.getCount());
             buffer.writeShort(stack.getMetadata());
             NBTTagCompound nbttagcompound = null;
+
 
             if (stack.getItem().isDamageable() || stack.getItem().getShareTag() || player.capabilities.isCreativeMode)
             {

--- a/src/test/java/net/minecraftforge/debug/ItemClientTagTest.java
+++ b/src/test/java/net/minecraftforge/debug/ItemClientTagTest.java
@@ -1,0 +1,123 @@
+package net.minecraftforge.debug;
+
+import net.minecraft.client.renderer.block.model.ModelResourceLocation;
+import net.minecraft.client.util.ITooltipFlag;
+import net.minecraft.creativetab.CreativeTabs;
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.item.Item;
+import net.minecraft.item.ItemStack;
+import net.minecraft.nbt.NBTTagCompound;
+import net.minecraft.util.ActionResult;
+import net.minecraft.util.EnumActionResult;
+import net.minecraft.util.EnumHand;
+import net.minecraft.util.ResourceLocation;
+import net.minecraft.util.text.TextComponentString;
+import net.minecraft.util.text.TextFormatting;
+import net.minecraft.world.World;
+import net.minecraftforge.client.event.ModelRegistryEvent;
+import net.minecraftforge.client.model.ModelLoader;
+import net.minecraftforge.common.util.Constants;
+import net.minecraftforge.event.RegistryEvent;
+import net.minecraftforge.fml.common.Mod;
+import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
+import net.minecraftforge.fml.common.registry.GameRegistry;
+import net.minecraftforge.fml.relauncher.Side;
+import net.minecraftforge.fml.relauncher.SideOnly;
+
+import javax.annotation.Nullable;
+import java.util.List;
+
+@Mod(modid = ItemClientTagTest.MOD_ID, name = "Item Share Tag Creative Test", version = "1.0.0", acceptableRemoteVersions = "*")
+public class ItemClientTagTest
+{
+    public static final String MOD_ID = "share_tag_creative_test";
+
+    private static final ResourceLocation ITEM_NAME = new ResourceLocation(MOD_ID, "share_tag_item");
+
+    @GameRegistry.ObjectHolder("share_tag_item")
+    private static final Item TEST_ITEM = null;
+
+    @Mod.EventBusSubscriber(modid = MOD_ID)
+    public static class Registration
+    {
+        @SubscribeEvent
+        public static void registerItems(RegistryEvent.Register<Item> event)
+        {
+            event.getRegistry().register(new ItemClientTag().setRegistryName(ITEM_NAME));
+        }
+
+        @SubscribeEvent
+        public static void registerModels(ModelRegistryEvent event)
+        {
+            ModelLoader.setCustomModelResourceLocation(TEST_ITEM, 0, new ModelResourceLocation(ITEM_NAME, "inventory"));
+        }
+    }
+
+    public static class ItemClientTag extends Item
+    {
+        private ItemClientTag()
+        {
+            setCreativeTab(CreativeTabs.MISC);
+        }
+
+        @Override
+        public ActionResult<ItemStack> onItemRightClick(World worldIn, EntityPlayer playerIn, EnumHand handIn)
+        {
+            ItemStack heldItem = playerIn.getHeldItem(handIn);
+            if(!worldIn.isRemote)
+            {
+                NBTTagCompound tag = new NBTTagCompound();
+                tag.setBoolean("full_tag", true);
+                tag.setString("extra_data", "This is more data");
+                heldItem.setTagCompound(tag);
+                return new ActionResult<>(EnumActionResult.SUCCESS, heldItem.copy());
+            }
+            return new ActionResult<>(EnumActionResult.PASS, heldItem);
+        }
+
+        @Override
+        public void addInformation(ItemStack stack, @Nullable World worldIn, List<String> tooltip, ITooltipFlag flagIn)
+        {
+            NBTTagCompound tag = stack.getTagCompound();
+            if(tag != null && tag.hasKey("full_tag", Constants.NBT.TAG_BYTE))
+            {
+                if(tag.getBoolean("full_tag"))
+                {
+                    tooltip.add("You should only see this message");
+                    tooltip.add("if you are on an integrated server");
+                    tooltip.add("or you are in creative mode");
+                }
+                else
+                {
+                    tooltip.add("You should only see this message");
+                    tooltip.add("if you are on a server and you are");
+                    tooltip.add("in survival mode");
+                }
+
+                tooltip.add(TextFormatting.RED + "Full Tag: " + tag.getBoolean("full_tag"));
+                tooltip.add(TextFormatting.RED + "Extra data: " + tag.getString("extra_data"));
+            }
+        }
+
+        @Nullable
+        @Override
+        public NBTTagCompound getNBTShareTag(ItemStack stack)
+        {
+            NBTTagCompound tag = stack.getTagCompound();
+            if(tag != null)
+            {
+                NBTTagCompound clientTag = tag.copy();
+                clientTag.setBoolean("full_tag", false);
+                clientTag.removeTag("extra_data");
+                return clientTag;
+            }
+            return tag;
+        }
+
+        @Override
+        public String getItemStackDisplayName(ItemStack stack)
+        {
+            return "Share Tag Item";
+        }
+    }
+}

--- a/src/test/java/net/minecraftforge/debug/ItemShareTagTest.java
+++ b/src/test/java/net/minecraftforge/debug/ItemShareTagTest.java
@@ -11,7 +11,6 @@ import net.minecraft.util.ActionResult;
 import net.minecraft.util.EnumActionResult;
 import net.minecraft.util.EnumHand;
 import net.minecraft.util.ResourceLocation;
-import net.minecraft.util.text.TextComponentString;
 import net.minecraft.util.text.TextFormatting;
 import net.minecraft.world.World;
 import net.minecraftforge.client.event.ModelRegistryEvent;
@@ -21,14 +20,12 @@ import net.minecraftforge.event.RegistryEvent;
 import net.minecraftforge.fml.common.Mod;
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
 import net.minecraftforge.fml.common.registry.GameRegistry;
-import net.minecraftforge.fml.relauncher.Side;
-import net.minecraftforge.fml.relauncher.SideOnly;
 
 import javax.annotation.Nullable;
 import java.util.List;
 
-@Mod(modid = ItemClientTagTest.MOD_ID, name = "Item Share Tag Creative Test", version = "1.0.0", acceptableRemoteVersions = "*")
-public class ItemClientTagTest
+@Mod(modid = ItemShareTagTest.MOD_ID, name = "Item Share Tag Creative Test", version = "1.0.0", acceptableRemoteVersions = "*")
+public class ItemShareTagTest
 {
     public static final String MOD_ID = "share_tag_creative_test";
 


### PR DESCRIPTION
Fixes the problem (https://github.com/MinecraftForge/MinecraftForge/issues/4580) I submitted a week ago. When a player is in creative mode and they on a dedicated server, their inventory is serialized from client to server. This becomes a problem if the item overrides ItemStack#getShareTag() and returns false or ItemStack#getNBTShareTag() and returns a modified item tag compound for the client. The client receives a stripped version of the item's tag compound and in combination with syncing from client to server, results in the server's version of the item's tag compound to lose all or part of it's data.

This PR introduces that when a player is in creative mode that all of the item's tag compound is sent from the server to the client regardless if ItemStack#getShareTag() is false or ItemStack#getNBTShareTag() returns modified version for the client. The behavior applies too when serializing the items from client to server, it will send the full tag compound regardless. It also ensures that when changing game modes from survival to creative, that the items are updated with the full tag compound. These changes do not affect survival mode in any way.

This is my first ever PR for Forge and have read the contributing guidelines. There is an included test ItemShareTagTest in the debug package. I've also test this out in my own mod where I first discovered the problem (Original problem: https://youtu.be/tS8E0HGzaNs) and it work properly now.

Also where do I sign? Edit: Signed