### PR TITLE
Added a tooltip color event.

### DIFF
--- a/src/main/java/net/minecraftforge/client/event/RenderTooltipEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/RenderTooltipEvent.java
@@ -241,4 +241,74 @@ public abstract class RenderTooltipEvent extends Event
         public PostText(@Nonnull ItemStack stack, @Nonnull List<String> textLines, int x, int y, @Nonnull FontRenderer fr, int width, int height)
             { super(stack, textLines, x, y, fr, width, height); }
     }
+    
+    /**
+     * This event is fired when the colours for the tooltip background are determined. 
+     */
+    public static class Color extends RenderTooltipEvent
+    {
+        private final int originalBackground;
+        private final int originalBorderStart;
+        private final int originalBorderEnd;
+        private int background;
+        private int borderStart;
+        private int borderEnd;
+
+        public Color(@Nonnull ItemStack stack, @Nonnull List<String> textLines, int x, int y, @Nonnull FontRenderer fr, int background, int borderStart,
+                int borderEnd)
+        {
+            super(stack, textLines, x, y, fr);
+            this.originalBackground = background;
+            this.originalBorderStart = borderStart;
+            this.originalBorderEnd = borderEnd;
+            this.background = background;
+            this.borderStart = borderStart;
+            this.borderEnd = borderEnd;
+        }
+
+        public int getBackground()
+        {
+            return background;
+        }
+
+        public void setBackground(int background)
+        {
+            this.background = background;
+        }
+
+        public int getBorderStart()
+        {
+            return borderStart;
+        }
+
+        public void setBorderStart(int borderStart)
+        {
+            this.borderStart = borderStart;
+        }
+
+        public int getBorderEnd()
+        {
+            return borderEnd;
+        }
+
+        public void setBorderEnd(int borderEnd)
+        {
+            this.borderEnd = borderEnd;
+        }
+
+        public int getOriginalBackground()
+        {
+            return originalBackground;
+        }
+
+        public int getOriginalBorderStart()
+        {
+            return originalBorderStart;
+        }
+
+        public int getOriginalBorderEnd()
+        {
+            return originalBorderEnd;
+        }
+    }
 }

--- a/src/main/java/net/minecraftforge/fml/client/config/GuiUtils.java
+++ b/src/main/java/net/minecraftforge/fml/client/config/GuiUtils.java
@@ -371,14 +371,19 @@ public class GuiUtils
             }
 
             final int zLevel = 300;
-            final int backgroundColor = 0xF0100010;
+            int backgroundColor = 0xF0100010;
+            int borderColorStart = 0x505000FF;
+            int borderColorEnd = (borderColorStart & 0xFEFEFE) >> 1 | borderColorStart & 0xFF000000;
+            RenderTooltipEvent.Color colorEvent = new RenderTooltipEvent.Color(stack, textLines, tooltipX, tooltipY, font, backgroundColor, borderColorStart, borderColorEnd);
+            MinecraftForge.EVENT_BUS.post(colorEvent);
+            backgroundColor = colorEvent.getBackground();
+            borderColorStart = colorEvent.getBorderStart();
+            borderColorEnd = colorEvent.getBorderEnd();
             drawGradientRect(zLevel, tooltipX - 3, tooltipY - 4, tooltipX + tooltipTextWidth + 3, tooltipY - 3, backgroundColor, backgroundColor);
             drawGradientRect(zLevel, tooltipX - 3, tooltipY + tooltipHeight + 3, tooltipX + tooltipTextWidth + 3, tooltipY + tooltipHeight + 4, backgroundColor, backgroundColor);
             drawGradientRect(zLevel, tooltipX - 3, tooltipY - 3, tooltipX + tooltipTextWidth + 3, tooltipY + tooltipHeight + 3, backgroundColor, backgroundColor);
             drawGradientRect(zLevel, tooltipX - 4, tooltipY - 3, tooltipX - 3, tooltipY + tooltipHeight + 3, backgroundColor, backgroundColor);
             drawGradientRect(zLevel, tooltipX + tooltipTextWidth + 3, tooltipY - 3, tooltipX + tooltipTextWidth + 4, tooltipY + tooltipHeight + 3, backgroundColor, backgroundColor);
-            final int borderColorStart = 0x505000FF;
-            final int borderColorEnd = (borderColorStart & 0xFEFEFE) >> 1 | borderColorStart & 0xFF000000;
             drawGradientRect(zLevel, tooltipX - 3, tooltipY - 3 + 1, tooltipX - 3 + 1, tooltipY + tooltipHeight + 3 - 1, borderColorStart, borderColorEnd);
             drawGradientRect(zLevel, tooltipX + tooltipTextWidth + 2, tooltipY - 3 + 1, tooltipX + tooltipTextWidth + 3, tooltipY + tooltipHeight + 3 - 1, borderColorStart, borderColorEnd);
             drawGradientRect(zLevel, tooltipX - 3, tooltipY - 3, tooltipX + tooltipTextWidth + 3, tooltipY - 3 + 1, borderColorStart, borderColorStart);

--- a/src/test/java/net/minecraftforge/debug/TooltipColorTest.java
+++ b/src/test/java/net/minecraftforge/debug/TooltipColorTest.java
@@ -1,0 +1,37 @@
+package net.minecraftforge.debug;
+
+import net.minecraft.init.Items;
+import net.minecraftforge.client.event.RenderTooltipEvent;
+import net.minecraftforge.common.MinecraftForge;
+import net.minecraftforge.fml.common.Mod;
+import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
+import net.minecraftforge.fml.relauncher.Side;
+import net.minecraftforge.fml.relauncher.SideOnly;
+
+@Mod(modid = TooltipColorTest.MODID, name = "Tooltip Color Test", version = "0.1", clientSideOnly = true)
+public class TooltipColorTest
+{
+    public static final String MODID = "tooltipcolortest";
+
+    private static final boolean ENABLE = false;
+
+    public TooltipColorTest()
+    {
+        if (ENABLE)
+        {
+            MinecraftForge.EVENT_BUS.register(this);
+        }
+    }
+
+    @SubscribeEvent
+    @SideOnly(Side.CLIENT)
+    public void enterDimension(RenderTooltipEvent.Color event)
+    {
+        if (event.getStack().getItem() == Items.APPLE)
+        {
+            event.setBackground(0xF0510404);
+            event.setBorderStart(0xF0bc0909);
+            event.setBorderEnd(0xF03f0f0f);
+        }
+    }
+}

--- a/src/test/java/net/minecraftforge/debug/TooltipColorTest.java
+++ b/src/test/java/net/minecraftforge/debug/TooltipColorTest.java
@@ -25,7 +25,7 @@ public class TooltipColorTest
 
     @SubscribeEvent
     @SideOnly(Side.CLIENT)
-    public void enterDimension(RenderTooltipEvent.Color event)
+    public void getTooltipColor(RenderTooltipEvent.Color event)
     {
         if (event.getStack().getItem() == Items.APPLE)
         {


### PR DESCRIPTION
This PR adds a new TooltipRenderEvent for modifying the colour of the tooltip. It also adds a simple debug mod that will make the tooltip for apples red. 

I feel some people may have an issue with how [this](https://github.com/Darkhax-Forked/MinecraftForge/blob/ceb7ddc9f895e46e3ffa71339ab216dbf3c21dec/src/main/java/net/minecraftforge/fml/client/config/GuiUtils.java#L374-L381) code was done. I wrote it in this way because this code parallels a vanilla method, and I felt that leaving it as similar to the original as possible would make it easier to compare with any changes made to the vanilla method in the future. If the general feedback is that it should be cleaned up, I have no problem doing that. 

![image](https://user-images.githubusercontent.com/2250798/34066505-e0ee5bba-e1cc-11e7-8027-4b028afd1c06.png)
