### PR TITLE
Fix default GUIConfig displaying child categories multiple times

### DIFF
--- a/src/main/java/net/minecraftforge/common/config/ConfigElement.java
+++ b/src/main/java/net/minecraftforge/common/config/ConfigElement.java
@@ -396,6 +396,8 @@ public class ConfigElement implements IConfigElement
                 if (catName.isEmpty())
                     continue;
                 ConfigCategory category = config.getCategory(catName);
+                if (category.isChild())
+                    continue;
                 DummyCategoryElement element = new DummyCategoryElement(category.getName(), category.getLanguagekey(), new ConfigElement(category).getChildElements());
                 element.setRequiresMcRestart(category.requiresMcRestart());
                 element.setRequiresWorldRestart(category.requiresWorldRestart());

--- a/src/test/java/net/minecraftforge/debug/ConfigTest.java
+++ b/src/test/java/net/minecraftforge/debug/ConfigTest.java
@@ -130,6 +130,8 @@ public class ConfigTest
         public static SubCat sub1 = new SubCat("Hello");
         @Name("test_b")
         public static SubCat sub2 = new SubCat("Goodbye");
+        @Name("test_c")
+        public static SubCat2 sub3 = new SubCat2("Hi");
 
         public static class SubCat
         {
@@ -139,6 +141,17 @@ public class ConfigTest
             public SubCat(String value)
             {
                 this.value = value;
+            }
+        }
+
+        public static class SubCat2
+        {
+            @Name("child_cat")
+            public SubCat child;
+
+            public SubCat2(String value)
+            {
+                this.child = new SubCat(value);
             }
         }
     }


### PR DESCRIPTION
The list of category names for each config file also includes child categories. These are not filtered out when constructing the `ConfigElement` for the GUI. This results in child categories being displayed at the top category level when they should not be.

Added a test case to `ConfigTest` to demonstrate the issue and fix.