### PR TITLE
Allow registration of custom MapGenStructures

### DIFF
--- a/patches/minecraft/net/minecraft/world/gen/ChunkGeneratorEnd.java.patch
+++ b/patches/minecraft/net/minecraft/world/gen/ChunkGeneratorEnd.java.patch
@@ -25,7 +25,7 @@
 +        this.field_73212_b = ctx.getScale();
 +        this.field_185973_o = ctx.getIsland();
 +        this.field_185972_n = (MapGenEndCity) net.minecraftforge.event.terraingen.TerrainGen.getModdedMapGen(this.field_185972_n, net.minecraftforge.event.terraingen.InitMapGenEvent.EventType.END_CITY);
-+        this.structureManager = net.minecraftforge.event.terraingen.TerrainGen.getAddedStructures(ChunkGeneratorHell.class);
++        this.structureManager = net.minecraftforge.event.terraingen.TerrainGen.getAddedStructures(ChunkGeneratorEnd.class);
      }
  
      public void func_180518_a(int p_180518_1_, int p_180518_2_, ChunkPrimer p_180518_3_)
@@ -86,12 +86,12 @@
          BlockFalling.field_149832_M = false;
      }
  
-@@ -404,21 +429,28 @@
+@@ -404,21 +429,27 @@
  
      public List<Biome.SpawnListEntry> func_177458_a(EnumCreatureType p_177458_1_, BlockPos p_177458_2_)
      {
-+        if(structureManager.shouldSpawn(p_177458_1_, p_177458_2_)) return structureManager.getSpawns(this.field_73230_p, p_177458_1_, p_177458_2_);
-         return this.field_73230_p.func_180494_b(p_177458_2_).func_76747_a(p_177458_1_);
+-        return this.field_73230_p.func_180494_b(p_177458_2_).func_76747_a(p_177458_1_);
++        return structureManager.getSpawns(this.field_73230_p.func_180494_b(p_177458_2_).func_76747_a(p_177458_1_), this.field_73230_p, p_177458_1_, p_177458_2_);
      }
  
      @Nullable
@@ -114,6 +114,6 @@
 +
 +    /* ======================================== FORGE START =====================================*/
 +
-+    private final net.minecraftforge.common.MapGenStructureManager structureManager;
++    protected final net.minecraftforge.common.MapGenStructureManager structureManager;
 +    /* ========================================= FORGE END ======================================*/
  }

--- a/patches/minecraft/net/minecraft/world/gen/ChunkGeneratorEnd.java.patch
+++ b/patches/minecraft/net/minecraft/world/gen/ChunkGeneratorEnd.java.patch
@@ -10,7 +10,7 @@
  
      public ChunkGeneratorEnd(World p_i47241_1_, boolean p_i47241_2_, long p_i47241_3_, BlockPos p_i47241_5_)
      {
-@@ -56,6 +59,17 @@
+@@ -56,6 +59,18 @@
          this.field_73214_a = new NoiseGeneratorOctaves(this.field_73220_k, 10);
          this.field_73212_b = new NoiseGeneratorOctaves(this.field_73220_k, 16);
          this.field_185973_o = new NoiseGeneratorSimplex(this.field_73220_k);
@@ -25,10 +25,11 @@
 +        this.field_73212_b = ctx.getScale();
 +        this.field_185973_o = ctx.getIsland();
 +        this.field_185972_n = (MapGenEndCity) net.minecraftforge.event.terraingen.TerrainGen.getModdedMapGen(this.field_185972_n, net.minecraftforge.event.terraingen.InitMapGenEvent.EventType.END_CITY);
++        this.structureManager = net.minecraftforge.event.terraingen.TerrainGen.getAddedStructures(ChunkGeneratorHell.class);
      }
  
      public void func_180518_a(int p_180518_1_, int p_180518_2_, ChunkPrimer p_180518_3_)
-@@ -128,6 +142,7 @@
+@@ -128,6 +143,7 @@
  
      public void func_185962_a(ChunkPrimer p_185962_1_)
      {
@@ -36,7 +37,7 @@
          for (int i = 0; i < 16; ++i)
          {
              for (int j = 0; j < 16; ++j)
-@@ -173,6 +188,7 @@
+@@ -173,6 +189,7 @@
  
      public Chunk func_185932_a(int p_185932_1_, int p_185932_2_)
      {
@@ -44,7 +45,15 @@
          this.field_73220_k.setSeed((long)p_185932_1_ * 341873128712L + (long)p_185932_2_ * 132897987541L);
          ChunkPrimer chunkprimer = new ChunkPrimer();
          this.field_73231_z = this.field_73230_p.func_72959_q().func_76933_b(this.field_73231_z, p_185932_1_ * 16, p_185932_2_ * 16, 16, 16);
-@@ -254,6 +270,10 @@
+@@ -182,6 +199,7 @@
+         if (this.field_73229_q)
+         {
+             this.field_185972_n.func_186125_a(this.field_73230_p, p_185932_1_, p_185932_2_, chunkprimer);
++            this.structureManager.generate(this.field_73230_p, p_185932_1_, p_185932_2_, chunkprimer);
+         }
+ 
+         Chunk chunk = new Chunk(this.field_73230_p, chunkprimer, p_185932_1_, p_185932_2_);
+@@ -254,6 +272,10 @@
  
      private double[] func_185963_a(double[] p_185963_1_, int p_185963_2_, int p_185963_3_, int p_185963_4_, int p_185963_5_, int p_185963_6_, int p_185963_7_)
      {
@@ -55,7 +64,7 @@
          if (p_185963_1_ == null)
          {
              p_185963_1_ = new double[p_185963_5_ * p_185963_6_ * p_185963_7_];
-@@ -326,6 +346,7 @@
+@@ -326,11 +348,13 @@
      public void func_185931_b(int p_185931_1_, int p_185931_2_)
      {
          BlockFalling.field_149832_M = true;
@@ -63,7 +72,13 @@
          BlockPos blockpos = new BlockPos(p_185931_1_ * 16, 0, p_185931_2_ * 16);
  
          if (this.field_73229_q)
-@@ -394,6 +415,7 @@
+         {
+             this.field_185972_n.func_175794_a(this.field_73230_p, this.field_73220_k, new ChunkPos(p_185931_1_, p_185931_2_));
++            this.structureManager.generateStructure(this.field_73230_p, this.field_73220_k, new ChunkPos(p_185931_1_, p_185931_2_));
+         }
+ 
+         this.field_73230_p.func_180494_b(blockpos.func_177982_a(16, 0, 16)).func_180624_a(this.field_73230_p, this.field_73230_p.field_73012_v, blockpos);
+@@ -394,6 +418,7 @@
              }
          }
  
@@ -71,3 +86,34 @@
          BlockFalling.field_149832_M = false;
      }
  
+@@ -404,21 +429,28 @@
+ 
+     public List<Biome.SpawnListEntry> func_177458_a(EnumCreatureType p_177458_1_, BlockPos p_177458_2_)
+     {
++        if(structureManager.shouldSpawn(p_177458_1_, p_177458_2_)) return structureManager.getSpawns(this.field_73230_p, p_177458_1_, p_177458_2_);
+         return this.field_73230_p.func_180494_b(p_177458_2_).func_76747_a(p_177458_1_);
+     }
+ 
+     @Nullable
+     public BlockPos func_180513_a(World p_180513_1_, String p_180513_2_, BlockPos p_180513_3_, boolean p_180513_4_)
+     {
+-        return "EndCity".equals(p_180513_2_) && this.field_185972_n != null ? this.field_185972_n.func_180706_b(p_180513_1_, p_180513_3_, p_180513_4_) : null;
++        return "EndCity".equals(p_180513_2_) && this.field_185972_n != null ? this.field_185972_n.func_180706_b(p_180513_1_, p_180513_3_, p_180513_4_) : structureManager.getNearestStructurePos(p_180513_1_, p_180513_2_, p_180513_3_, p_180513_4_);
+     }
+ 
+     public boolean func_193414_a(World p_193414_1_, String p_193414_2_, BlockPos p_193414_3_)
+     {
+-        return "EndCity".equals(p_193414_2_) && this.field_185972_n != null ? this.field_185972_n.func_175795_b(p_193414_3_) : false;
++        return "EndCity".equals(p_193414_2_) && this.field_185972_n != null ? this.field_185972_n.func_175795_b(p_193414_3_) : structureManager.isInsideStructure(p_193414_1_, p_193414_2_, p_193414_3_);
+     }
+ 
+     public void func_180514_a(Chunk p_180514_1_, int p_180514_2_, int p_180514_3_)
+     {
++        structureManager.generate(this.field_73230_p, p_180514_2_, p_180514_3_, null);
+     }
++
++    /* ======================================== FORGE START =====================================*/
++
++    private final net.minecraftforge.common.MapGenStructureManager structureManager;
++    /* ========================================= FORGE END ======================================*/
+ }

--- a/patches/minecraft/net/minecraft/world/gen/ChunkGeneratorEnd.java.patch
+++ b/patches/minecraft/net/minecraft/world/gen/ChunkGeneratorEnd.java.patch
@@ -78,7 +78,7 @@
          }
  
          this.field_73230_p.func_180494_b(blockpos.func_177982_a(16, 0, 16)).func_180624_a(this.field_73230_p, this.field_73230_p.field_73012_v, blockpos);
-@@ -394,6 +418,7 @@
+@@ -394,31 +418,38 @@
              }
          }
  
@@ -86,7 +86,11 @@
          BlockFalling.field_149832_M = false;
      }
  
-@@ -404,21 +429,27 @@
+     public boolean func_185933_a(Chunk p_185933_1_, int p_185933_2_, int p_185933_3_)
+     {
+-        return false;
++        return this.structureManager.retroGenerateStructures(this.field_73230_p, this.field_73220_k, new ChunkPos(p_185933_2_, p_185933_3_), p_185933_1_);
+     }
  
      public List<Biome.SpawnListEntry> func_177458_a(EnumCreatureType p_177458_1_, BlockPos p_177458_2_)
      {

--- a/patches/minecraft/net/minecraft/world/gen/ChunkGeneratorEnd.java.patch
+++ b/patches/minecraft/net/minecraft/world/gen/ChunkGeneratorEnd.java.patch
@@ -25,7 +25,7 @@
 +        this.field_73212_b = ctx.getScale();
 +        this.field_185973_o = ctx.getIsland();
 +        this.field_185972_n = (MapGenEndCity) net.minecraftforge.event.terraingen.TerrainGen.getModdedMapGen(this.field_185972_n, net.minecraftforge.event.terraingen.InitMapGenEvent.EventType.END_CITY);
-+        this.structureManager = net.minecraftforge.event.terraingen.TerrainGen.getAddedStructures(ChunkGeneratorEnd.class);
++        this.structureManager = net.minecraftforge.event.terraingen.TerrainGen.getAddedStructures(ChunkGeneratorEnd.class,this);
      }
  
      public void func_180518_a(int p_180518_1_, int p_180518_2_, ChunkPrimer p_180518_3_)

--- a/patches/minecraft/net/minecraft/world/gen/ChunkGeneratorHell.java.patch
+++ b/patches/minecraft/net/minecraft/world/gen/ChunkGeneratorHell.java.patch
@@ -128,15 +128,14 @@
          BlockFalling.field_149832_M = false;
      }
  
-@@ -435,6 +476,7 @@
-                 return this.field_73172_c.func_75059_a();
-             }
+@@ -437,22 +478,28 @@
          }
-+        if(structureManager.shouldSpawn(p_177458_1_, p_177458_2_)) return structureManager.getSpawns(this.field_185952_n, p_177458_1_, p_177458_2_);
  
          Biome biome = this.field_185952_n.func_180494_b(p_177458_2_);
-         return biome.func_76747_a(p_177458_1_);
-@@ -443,16 +485,22 @@
+-        return biome.func_76747_a(p_177458_1_);
++        return structureManager.getSpawns(biome.func_76747_a(p_177458_1_), this.field_185952_n, p_177458_1_, p_177458_2_);
+     }
+ 
      @Nullable
      public BlockPos func_180513_a(World p_180513_1_, String p_180513_2_, BlockPos p_180513_3_, boolean p_180513_4_)
      {
@@ -158,6 +157,6 @@
 +
 +    /* ======================================== FORGE START =====================================*/
 +
-+    private final net.minecraftforge.common.MapGenStructureManager structureManager;
++    protected final net.minecraftforge.common.MapGenStructureManager structureManager;
 +    /* ========================================= FORGE END ======================================*/
  }

--- a/patches/minecraft/net/minecraft/world/gen/ChunkGeneratorHell.java.patch
+++ b/patches/minecraft/net/minecraft/world/gen/ChunkGeneratorHell.java.patch
@@ -1,6 +1,6 @@
 --- ../src-base/minecraft/net/minecraft/world/gen/ChunkGeneratorHell.java
 +++ ../src-work/minecraft/net/minecraft/world/gen/ChunkGeneratorHell.java
-@@ -77,6 +77,19 @@
+@@ -77,6 +77,20 @@
          this.field_185946_g = new NoiseGeneratorOctaves(this.field_185954_p, 10);
          this.field_185947_h = new NoiseGeneratorOctaves(this.field_185954_p, 16);
          p_i45637_1_.func_181544_b(63);
@@ -17,10 +17,11 @@
 +        this.field_185947_h = ctx.getDepth();
 +        this.field_73172_c = (MapGenNetherBridge)net.minecraftforge.event.terraingen.TerrainGen.getModdedMapGen(field_73172_c, net.minecraftforge.event.terraingen.InitMapGenEvent.EventType.NETHER_BRIDGE);
 +        this.field_185939_I = net.minecraftforge.event.terraingen.TerrainGen.getModdedMapGen(field_185939_I, net.minecraftforge.event.terraingen.InitMapGenEvent.EventType.NETHER_CAVE);
++        this.structureManager = net.minecraftforge.event.terraingen.TerrainGen.getAddedStructures(ChunkGeneratorHell.class);
      }
  
      public void func_185936_a(int p_185936_1_, int p_185936_2_, ChunkPrimer p_185936_3_)
-@@ -155,6 +168,7 @@
+@@ -155,6 +169,7 @@
  
      public void func_185937_b(int p_185937_1_, int p_185937_2_, ChunkPrimer p_185937_3_)
      {
@@ -28,7 +29,15 @@
          int i = this.field_185952_n.func_181545_F() + 1;
          double d0 = 0.03125D;
          this.field_73185_q = this.field_73177_m.func_76304_a(this.field_73185_q, p_185937_1_ * 16, p_185937_2_ * 16, 0, 16, 16, 1, 0.03125D, 0.03125D, 1.0D);
-@@ -277,6 +291,10 @@
+@@ -255,6 +270,7 @@
+         if (this.field_185953_o)
+         {
+             this.field_73172_c.func_186125_a(this.field_185952_n, p_185932_1_, p_185932_2_, chunkprimer);
++            this.structureManager.generate(this.field_185952_n, p_185932_1_, p_185932_2_, chunkprimer);
+         }
+ 
+         Chunk chunk = new Chunk(this.field_185952_n, chunkprimer, p_185932_1_, p_185932_2_);
+@@ -277,6 +293,10 @@
              p_185938_1_ = new double[p_185938_5_ * p_185938_6_ * p_185938_7_];
          }
  
@@ -39,7 +48,7 @@
          double d0 = 684.412D;
          double d1 = 2053.236D;
          this.field_73168_g = this.field_185946_g.func_76304_a(this.field_73168_g, p_185938_2_, p_185938_3_, p_185938_4_, p_185938_5_, 1, p_185938_7_, 1.0D, 0.0D, 1.0D);
-@@ -358,6 +376,7 @@
+@@ -358,23 +378,29 @@
      public void func_185931_b(int p_185931_1_, int p_185931_2_)
      {
          BlockFalling.field_149832_M = true;
@@ -47,9 +56,10 @@
          int i = p_185931_1_ * 16;
          int j = p_185931_2_ * 16;
          BlockPos blockpos = new BlockPos(i, 0, j);
-@@ -365,16 +384,20 @@
+         Biome biome = this.field_185952_n.func_180494_b(blockpos.func_177982_a(16, 0, 16));
          ChunkPos chunkpos = new ChunkPos(p_185931_1_, p_185931_2_);
          this.field_73172_c.func_175794_a(this.field_185952_n, this.field_185954_p, chunkpos);
++        this.structureManager.generateStructure(this.field_185952_n, this.field_185954_p, chunkpos);
  
 +        if (net.minecraftforge.event.terraingen.TerrainGen.populate(this, this.field_185952_n, this.field_185954_p, p_185931_1_, p_185931_2_, false, net.minecraftforge.event.terraingen.PopulateChunkEvent.Populate.EventType.NETHER_LAVA))
          for (int k = 0; k < 8; ++k)
@@ -68,7 +78,7 @@
          for (int j1 = 0; j1 < this.field_185954_p.nextInt(this.field_185954_p.nextInt(10) + 1); ++j1)
          {
              this.field_177469_u.func_180709_b(this.field_185952_n, this.field_185954_p, blockpos.func_177982_a(this.field_185954_p.nextInt(16) + 8, this.field_185954_p.nextInt(120) + 4, this.field_185954_p.nextInt(16) + 8));
-@@ -384,7 +407,13 @@
+@@ -384,7 +410,13 @@
          {
              this.field_177468_v.func_180709_b(this.field_185952_n, this.field_185954_p, blockpos.func_177982_a(this.field_185954_p.nextInt(16) + 8, this.field_185954_p.nextInt(128), this.field_185954_p.nextInt(16) + 8));
          }
@@ -82,7 +92,7 @@
          if (this.field_185954_p.nextBoolean())
          {
              this.field_177471_z.func_180709_b(this.field_185952_n, this.field_185954_p, blockpos.func_177982_a(this.field_185954_p.nextInt(16) + 8, this.field_185954_p.nextInt(128), this.field_185954_p.nextInt(16) + 8));
-@@ -394,7 +423,10 @@
+@@ -394,7 +426,10 @@
          {
              this.field_177465_A.func_180709_b(this.field_185952_n, this.field_185954_p, blockpos.func_177982_a(this.field_185954_p.nextInt(16) + 8, this.field_185954_p.nextInt(128), this.field_185954_p.nextInt(16) + 8));
          }
@@ -93,7 +103,7 @@
          for (int l1 = 0; l1 < 16; ++l1)
          {
              this.field_177467_w.func_180709_b(this.field_185952_n, this.field_185954_p, blockpos.func_177982_a(this.field_185954_p.nextInt(16), this.field_185954_p.nextInt(108) + 10, this.field_185954_p.nextInt(16)));
-@@ -402,17 +434,23 @@
+@@ -402,17 +437,23 @@
  
          int i2 = this.field_185952_n.func_181545_F() / 2 + 1;
  
@@ -118,3 +128,36 @@
          BlockFalling.field_149832_M = false;
      }
  
+@@ -435,6 +476,7 @@
+                 return this.field_73172_c.func_75059_a();
+             }
+         }
++        if(structureManager.shouldSpawn(p_177458_1_, p_177458_2_)) return structureManager.getSpawns(this.field_185952_n, p_177458_1_, p_177458_2_);
+ 
+         Biome biome = this.field_185952_n.func_180494_b(p_177458_2_);
+         return biome.func_76747_a(p_177458_1_);
+@@ -443,16 +485,22 @@
+     @Nullable
+     public BlockPos func_180513_a(World p_180513_1_, String p_180513_2_, BlockPos p_180513_3_, boolean p_180513_4_)
+     {
+-        return "Fortress".equals(p_180513_2_) && this.field_73172_c != null ? this.field_73172_c.func_180706_b(p_180513_1_, p_180513_3_, p_180513_4_) : null;
++        return "Fortress".equals(p_180513_2_) && this.field_73172_c != null ? this.field_73172_c.func_180706_b(p_180513_1_, p_180513_3_, p_180513_4_) : structureManager.getNearestStructurePos(p_180513_1_, p_180513_2_, p_180513_3_, p_180513_4_);
+     }
+ 
+     public boolean func_193414_a(World p_193414_1_, String p_193414_2_, BlockPos p_193414_3_)
+     {
+-        return "Fortress".equals(p_193414_2_) && this.field_73172_c != null ? this.field_73172_c.func_175795_b(p_193414_3_) : false;
++        return "Fortress".equals(p_193414_2_) && this.field_73172_c != null ? this.field_73172_c.func_175795_b(p_193414_3_) : structureManager.isInsideStructure(p_193414_1_, p_193414_2_, p_193414_3_);
+     }
+ 
+     public void func_180514_a(Chunk p_180514_1_, int p_180514_2_, int p_180514_3_)
+     {
+         this.field_73172_c.func_186125_a(this.field_185952_n, p_180514_2_, p_180514_3_, (ChunkPrimer)null);
++        structureManager.generate(this.field_185952_n, p_180514_2_, p_180514_3_, null);
+     }
++
++    /* ======================================== FORGE START =====================================*/
++
++    private final net.minecraftforge.common.MapGenStructureManager structureManager;
++    /* ========================================= FORGE END ======================================*/
+ }

--- a/patches/minecraft/net/minecraft/world/gen/ChunkGeneratorHell.java.patch
+++ b/patches/minecraft/net/minecraft/world/gen/ChunkGeneratorHell.java.patch
@@ -17,7 +17,7 @@
 +        this.field_185947_h = ctx.getDepth();
 +        this.field_73172_c = (MapGenNetherBridge)net.minecraftforge.event.terraingen.TerrainGen.getModdedMapGen(field_73172_c, net.minecraftforge.event.terraingen.InitMapGenEvent.EventType.NETHER_BRIDGE);
 +        this.field_185939_I = net.minecraftforge.event.terraingen.TerrainGen.getModdedMapGen(field_185939_I, net.minecraftforge.event.terraingen.InitMapGenEvent.EventType.NETHER_CAVE);
-+        this.structureManager = net.minecraftforge.event.terraingen.TerrainGen.getAddedStructures(ChunkGeneratorHell.class);
++        this.structureManager = net.minecraftforge.event.terraingen.TerrainGen.getAddedStructures(ChunkGeneratorHell.class,this);
      }
  
      public void func_185936_a(int p_185936_1_, int p_185936_2_, ChunkPrimer p_185936_3_)

--- a/patches/minecraft/net/minecraft/world/gen/ChunkGeneratorHell.java.patch
+++ b/patches/minecraft/net/minecraft/world/gen/ChunkGeneratorHell.java.patch
@@ -103,7 +103,7 @@
          for (int l1 = 0; l1 < 16; ++l1)
          {
              this.field_177467_w.func_180709_b(this.field_185952_n, this.field_185954_p, blockpos.func_177982_a(this.field_185954_p.nextInt(16), this.field_185954_p.nextInt(108) + 10, this.field_185954_p.nextInt(16)));
-@@ -402,17 +437,23 @@
+@@ -402,23 +437,29 @@
  
          int i2 = this.field_185952_n.func_181545_F() / 2 + 1;
  
@@ -128,6 +128,13 @@
          BlockFalling.field_149832_M = false;
      }
  
+     public boolean func_185933_a(Chunk p_185933_1_, int p_185933_2_, int p_185933_3_)
+     {
+-        return false;
++        return this.structureManager.retroGenerateStructures(this.field_185952_n, this.field_185954_p, new ChunkPos(p_185933_2_, p_185933_3_), p_185933_1_);
+     }
+ 
+     public List<Biome.SpawnListEntry> func_177458_a(EnumCreatureType p_177458_1_, BlockPos p_177458_2_)
 @@ -437,22 +478,28 @@
          }
  

--- a/patches/minecraft/net/minecraft/world/gen/ChunkGeneratorOverworld.java.patch
+++ b/patches/minecraft/net/minecraft/world/gen/ChunkGeneratorOverworld.java.patch
@@ -113,15 +113,16 @@
          BlockFalling.field_149832_M = false;
      }
  
-@@ -487,6 +523,7 @@
-             {
-                 return this.field_185980_B.func_175799_b();
+@@ -489,7 +525,7 @@
              }
-+            if(structureManager.shouldSpawn(p_177458_1_, p_177458_2_)) return structureManager.getSpawns(this.field_185995_n, p_177458_1_, p_177458_2_);
          }
  
-         return biome.func_76747_a(p_177458_1_);
-@@ -520,7 +557,7 @@
+-        return biome.func_76747_a(p_177458_1_);
++        return structureManager.getSpawns(biome.func_76747_a(p_177458_1_), this.field_185995_n, p_177458_1_, p_177458_2_);
+     }
+ 
+     public boolean func_193414_a(World p_193414_1_, String p_193414_2_, BlockPos p_193414_3_)
+@@ -520,7 +556,7 @@
          }
          else
          {
@@ -130,7 +131,7 @@
          }
      }
  
-@@ -553,7 +590,7 @@
+@@ -553,7 +589,7 @@
          }
          else
          {
@@ -139,7 +140,7 @@
          }
      }
  
-@@ -590,6 +627,12 @@
+@@ -590,6 +626,12 @@
              {
                  this.field_191060_C.func_186125_a(this.field_185995_n, p_180514_2_, p_180514_3_, (ChunkPrimer)null);
              }
@@ -149,6 +150,6 @@
 +
 +    /* ======================================== FORGE START =====================================*/
 +
-+    private final net.minecraftforge.common.MapGenStructureManager structureManager;
++    protected final net.minecraftforge.common.MapGenStructureManager structureManager;
 +    /* ========================================= FORGE END ======================================*/
  }

--- a/patches/minecraft/net/minecraft/world/gen/ChunkGeneratorOverworld.java.patch
+++ b/patches/minecraft/net/minecraft/world/gen/ChunkGeneratorOverworld.java.patch
@@ -17,7 +17,7 @@
          this.field_185995_n = p_i46668_1_;
          this.field_185996_o = p_i46668_4_;
          this.field_185997_p = p_i46668_1_.func_72912_H().func_76067_t();
-@@ -90,6 +100,17 @@
+@@ -90,6 +100,18 @@
              this.field_186001_t = this.field_186000_s.field_177778_E ? Blocks.field_150353_l.func_176223_P() : Blocks.field_150355_j.func_176223_P();
              p_i46668_1_.func_181544_b(this.field_186000_s.field_177841_q);
          }
@@ -32,10 +32,11 @@
 +        this.field_185983_b = ctx.getScale();
 +        this.field_185984_c = ctx.getDepth();
 +        this.field_185985_d = ctx.getForest();
++        this.structureManager = net.minecraftforge.event.terraingen.TerrainGen.getAddedStructures(ChunkGeneratorOverworld.class);
      }
  
      public void func_185976_a(int p_185976_1_, int p_185976_2_, ChunkPrimer p_185976_3_)
-@@ -163,6 +184,7 @@
+@@ -163,6 +185,7 @@
  
      public void func_185977_a(int p_185977_1_, int p_185977_2_, ChunkPrimer p_185977_3_, Biome[] p_185977_4_)
      {
@@ -43,7 +44,15 @@
          double d0 = 0.03125D;
          this.field_186002_u = this.field_185994_m.func_151599_a(this.field_186002_u, (double)(p_185977_1_ * 16), (double)(p_185977_2_ * 16), 16, 16, 0.0625D, 0.0625D, 1.0D);
  
-@@ -370,6 +392,8 @@
+@@ -225,6 +248,7 @@
+             {
+                 this.field_191060_C.func_186125_a(this.field_185995_n, p_185932_1_, p_185932_2_, chunkprimer);
+             }
++            structureManager.generate(this.field_185995_n, p_185932_1_, p_185932_2_, chunkprimer);
+         }
+ 
+         Chunk chunk = new Chunk(this.field_185995_n, chunkprimer, p_185932_1_, p_185932_2_);
+@@ -370,6 +394,8 @@
          boolean flag = false;
          ChunkPos chunkpos = new ChunkPos(p_185931_1_, p_185931_2_);
  
@@ -52,7 +61,11 @@
          if (this.field_185996_o)
          {
              if (this.field_186000_s.field_177829_w)
-@@ -404,6 +428,7 @@
+@@ -401,9 +427,11 @@
+             {
+                 this.field_191060_C.func_175794_a(this.field_185995_n, this.field_185990_i, chunkpos);
+             }
++            structureManager.generateStructure(this.field_185995_n, this.field_185990_i, chunkpos);
          }
  
          if (biome != Biomes.field_76769_d && biome != Biomes.field_76786_s && this.field_186000_s.field_177781_A && !flag && this.field_185990_i.nextInt(this.field_186000_s.field_177782_B) == 0)
@@ -60,7 +73,7 @@
          {
              int i1 = this.field_185990_i.nextInt(16) + 8;
              int j1 = this.field_185990_i.nextInt(256);
-@@ -412,6 +437,7 @@
+@@ -412,6 +440,7 @@
          }
  
          if (!flag && this.field_185990_i.nextInt(this.field_186000_s.field_177777_D / 10) == 0 && this.field_186000_s.field_177783_C)
@@ -68,7 +81,7 @@
          {
              int i2 = this.field_185990_i.nextInt(16) + 8;
              int l2 = this.field_185990_i.nextInt(this.field_185990_i.nextInt(248) + 8);
-@@ -424,6 +450,7 @@
+@@ -424,6 +453,7 @@
          }
  
          if (this.field_186000_s.field_177837_s)
@@ -76,7 +89,7 @@
          {
              for (int j2 = 0; j2 < this.field_186000_s.field_177835_t; ++j2)
              {
-@@ -435,9 +462,12 @@
+@@ -435,9 +465,12 @@
          }
  
          biome.func_180624_a(this.field_185995_n, this.field_185990_i, new BlockPos(i, 0, j));
@@ -89,7 +102,7 @@
          for (int k2 = 0; k2 < 16; ++k2)
          {
              for (int j3 = 0; j3 < 16; ++j3)
-@@ -456,7 +486,10 @@
+@@ -456,7 +489,10 @@
                  }
              }
          }
@@ -100,3 +113,42 @@
          BlockFalling.field_149832_M = false;
      }
  
+@@ -487,6 +523,7 @@
+             {
+                 return this.field_185980_B.func_175799_b();
+             }
++            if(structureManager.shouldSpawn(p_177458_1_, p_177458_2_)) return structureManager.getSpawns(this.field_185995_n, p_177458_1_, p_177458_2_);
+         }
+ 
+         return biome.func_76747_a(p_177458_1_);
+@@ -520,7 +557,7 @@
+         }
+         else
+         {
+-            return "Temple".equals(p_193414_2_) && this.field_186007_z != null ? this.field_186007_z.func_175795_b(p_193414_3_) : false;
++            return "Temple".equals(p_193414_2_) && this.field_186007_z != null ? this.field_186007_z.func_175795_b(p_193414_3_) : structureManager.isInsideStructure(p_193414_1_, p_193414_2_, p_193414_3_);
+         }
+     }
+ 
+@@ -553,7 +590,7 @@
+         }
+         else
+         {
+-            return "Temple".equals(p_180513_2_) && this.field_186007_z != null ? this.field_186007_z.func_180706_b(p_180513_1_, p_180513_3_, p_180513_4_) : null;
++            return "Temple".equals(p_180513_2_) && this.field_186007_z != null ? this.field_186007_z.func_180706_b(p_180513_1_, p_180513_3_, p_180513_4_) : structureManager.getNearestStructurePos(p_180513_1_, p_180513_2_, p_180513_3_, p_180513_4_);
+         }
+     }
+ 
+@@ -590,6 +627,12 @@
+             {
+                 this.field_191060_C.func_186125_a(this.field_185995_n, p_180514_2_, p_180514_3_, (ChunkPrimer)null);
+             }
++            structureManager.generate(this.field_185995_n, p_180514_2_, p_180514_3_, null);
+         }
+     }
++
++    /* ======================================== FORGE START =====================================*/
++
++    private final net.minecraftforge.common.MapGenStructureManager structureManager;
++    /* ========================================= FORGE END ======================================*/
+ }

--- a/patches/minecraft/net/minecraft/world/gen/ChunkGeneratorOverworld.java.patch
+++ b/patches/minecraft/net/minecraft/world/gen/ChunkGeneratorOverworld.java.patch
@@ -32,7 +32,7 @@
 +        this.field_185983_b = ctx.getScale();
 +        this.field_185984_c = ctx.getDepth();
 +        this.field_185985_d = ctx.getForest();
-+        this.structureManager = net.minecraftforge.event.terraingen.TerrainGen.getAddedStructures(ChunkGeneratorOverworld.class);
++        this.structureManager = net.minecraftforge.event.terraingen.TerrainGen.getAddedStructures(ChunkGeneratorOverworld.class,this);
      }
  
      public void func_185976_a(int p_185976_1_, int p_185976_2_, ChunkPrimer p_185976_3_)

--- a/patches/minecraft/net/minecraft/world/gen/ChunkGeneratorOverworld.java.patch
+++ b/patches/minecraft/net/minecraft/world/gen/ChunkGeneratorOverworld.java.patch
@@ -113,7 +113,15 @@
          BlockFalling.field_149832_M = false;
      }
  
-@@ -489,7 +525,7 @@
+@@ -469,6 +505,7 @@
+             flag |= this.field_185980_B.func_175794_a(this.field_185995_n, this.field_185990_i, new ChunkPos(p_185933_2_, p_185933_3_));
+         }
+ 
++        flag |= this.structureManager.retroGenerateStructures(this.field_185995_n, this.field_185990_i, new ChunkPos(p_185933_2_, p_185933_3_), p_185933_1_);
+         return flag;
+     }
+ 
+@@ -489,7 +526,7 @@
              }
          }
  
@@ -122,7 +130,7 @@
      }
  
      public boolean func_193414_a(World p_193414_1_, String p_193414_2_, BlockPos p_193414_3_)
-@@ -520,7 +556,7 @@
+@@ -520,7 +557,7 @@
          }
          else
          {
@@ -131,7 +139,7 @@
          }
      }
  
-@@ -553,7 +589,7 @@
+@@ -553,7 +590,7 @@
          }
          else
          {
@@ -140,7 +148,7 @@
          }
      }
  
-@@ -590,6 +626,12 @@
+@@ -590,6 +627,12 @@
              {
                  this.field_191060_C.func_186125_a(this.field_185995_n, p_180514_2_, p_180514_3_, (ChunkPrimer)null);
              }

--- a/src/main/java/net/minecraftforge/common/MapGenStructureManager.java
+++ b/src/main/java/net/minecraftforge/common/MapGenStructureManager.java
@@ -32,6 +32,7 @@ import org.apache.commons.lang3.ArrayUtils;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Random;
@@ -54,6 +55,7 @@ public class MapGenStructureManager
             addStructureName(name);
         }
         structureMap = builder.build();
+        Collections.sort(allStructureNames);
     }
 
     /**
@@ -108,22 +110,22 @@ public class MapGenStructureManager
 
     /**
      * Get the creatures of the given type the structure at the given position would like to spawn.
-     * <p>
-     * Returns the defaults list if no structure is found
      *
-     * @param defaults Returns this if no spawning structure is found
+     * @param defaults List of spawn entries. Should contain the (biome's) default entries. Won't be modified
      */
     @Nonnull
     public List<Biome.SpawnListEntry> getSpawns(List<Biome.SpawnListEntry> defaults, World world, EnumCreatureType creatureType, BlockPos pos)
     {
+        List<Biome.SpawnListEntry> spawnEntries = Lists.newArrayList(defaults);//Don't modify the biome's list
         for (MapGenStructure structure : structureMap.values())
         {
             if (structure instanceof ISpawningStructure && structure.isInsideStructure(pos))
             {
-                return ((ISpawningStructure) structure).getSpawns(defaults, world, creatureType, pos);
+                ((ISpawningStructure) structure).getSpawns(spawnEntries, world, creatureType, pos);
+                return spawnEntries;
             }
         }
-        return defaults;
+        return spawnEntries;
     }
 
     public void generateStructure(World world, Random rand, ChunkPos chunkPos)
@@ -148,12 +150,11 @@ public class MapGenStructureManager
     public interface ISpawningStructure
     {
         /**
-         * Return the list of creatures of the given type that should spawn within the structures bounding box.
+         * Collect the list of creatures of the given type that should spawn within the structures bounding box.
          * <p>
-         * You should return the given defaults list if you don't want to affect the spawn behaviour
+         * @param spawnEntries Contains the biome's default spawn entries. Modify this list to add your own spawns and/or clear the biome's ones.
          */
-        @Nonnull
-        List<Biome.SpawnListEntry> getSpawns(List<Biome.SpawnListEntry> defaults, World world, EnumCreatureType creatureType, BlockPos pos);
+        void getSpawns(List<Biome.SpawnListEntry> spawnEntries, World world, EnumCreatureType creatureType, BlockPos pos);
     }
 
 }

--- a/src/main/java/net/minecraftforge/common/MapGenStructureManager.java
+++ b/src/main/java/net/minecraftforge/common/MapGenStructureManager.java
@@ -156,8 +156,17 @@ public class MapGenStructureManager
      */
     public interface ISpawningStructure
     {
+        /**
+         * If you want to replace creature spawn list of the biome with your own list within the bounding box of your structure.
+         */
         boolean shouldSpawn(EnumCreatureType creatureType);
 
+        /**
+         * Called when shouldSpawn returns true.
+         *
+         * Used instead of the biome's creature spawn list
+         */
+        @Nonnull
         List<Biome.SpawnListEntry> getSpawns(World world, EnumCreatureType creatureType, BlockPos pos);
     }
 

--- a/src/main/java/net/minecraftforge/common/MapGenStructureManager.java
+++ b/src/main/java/net/minecraftforge/common/MapGenStructureManager.java
@@ -152,6 +152,8 @@ public class MapGenStructureManager
         /**
          * Collect the list of creatures of the given type that should spawn within the structures bounding box.
          * <p>
+         * If this method is called repeatedly you should always return exactly the same (equals) objects otherwise the spawning will not work.
+         *
          * @param spawnEntries Contains the biome's default spawn entries. Modify this list to add your own spawns and/or clear the biome's ones.
          */
         void getSpawns(List<Biome.SpawnListEntry> spawnEntries, World world, EnumCreatureType creatureType, BlockPos pos);

--- a/src/main/java/net/minecraftforge/common/MapGenStructureManager.java
+++ b/src/main/java/net/minecraftforge/common/MapGenStructureManager.java
@@ -1,0 +1,164 @@
+/*
+ * Minecraft Forge
+ * Copyright (c) 2016.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation version 2.1
+ * of the License.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+package net.minecraftforge.common;
+
+import com.google.common.collect.Lists;
+import net.minecraft.entity.EnumCreatureType;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.math.ChunkPos;
+import net.minecraft.world.World;
+import net.minecraft.world.biome.Biome;
+import net.minecraft.world.chunk.ChunkPrimer;
+import net.minecraft.world.gen.structure.MapGenStructure;
+import org.apache.commons.lang3.ArrayUtils;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.util.List;
+import java.util.Random;
+
+/**
+ * Manage MapGenStructure for the ChunkGenerators.
+ */
+public class MapGenStructureManager
+{
+    private static final List<String> allStructureNames = Lists.newArrayList();
+    private final List<MapGenStructure> structures;
+
+    public MapGenStructureManager(List<MapGenStructure> structures)
+    {
+        this.structures = structures;
+    }
+
+    /**
+     * Add a structure name to the locate command autocomplete list.
+     * <p>
+     * Is automatically done when registering your structure in {@link net.minecraftforge.event.terraingen.InitStructureGensEvent}
+     *
+     * @param structure Name of the structure
+     */
+    public static void addStructureName(String structure)
+    {
+        if(!allStructureNames.contains(structure))allStructureNames.add(structure);
+    }
+
+    /**
+     * @return A new array containing both the given strings as well as the registered structure names
+     */
+    public static String[] appendStructureNames(String[] vanilla)
+    {
+        return ArrayUtils.addAll(vanilla, allStructureNames.toArray(new String[0]));
+    }
+
+    /**
+     * Get the nearest structure with the given name to the given world position.
+     * Returns null if the structure is not found
+     */
+    @Nullable
+    public BlockPos getNearestStructurePos(World worldIn, String structureName, BlockPos position, boolean findUnexplored)
+    {
+        for (MapGenStructure struct : structures)
+        {
+            if (struct.getStructureName().equals(structureName))
+            {
+                return struct.getNearestStructurePos(worldIn, position, findUnexplored);
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Check if the given world position is within a structure with the given name.
+     * Returns false if the structure is not found
+     */
+    public boolean isInsideStructure(World worldIn, String structureName, BlockPos pos)
+    {
+        for (MapGenStructure struct : structures)
+        {
+            if (struct.getStructureName().equals(structureName))
+            {
+                return struct.isInsideStructure(pos);
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Check if there is a given structure at the given position that would like to spawn creatures of the given type.
+     */
+    public boolean shouldSpawn(EnumCreatureType creatureType, BlockPos pos)
+    {
+        for (MapGenStructure structure : structures)
+        {
+            if (structure instanceof ISpawningStructure && structure.isInsideStructure(pos))
+            {
+                return ((ISpawningStructure) structure).shouldSpawn(creatureType);
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Get the creatures of the given type the structure at the given position would like to spawn.
+     * <p>
+     * Only call if {@link MapGenStructureManager#shouldSpawn(EnumCreatureType, BlockPos)} returns true.
+     * <p>
+     * Returns an empty list if no structure is found
+     */
+    @Nonnull
+    public List<Biome.SpawnListEntry> getSpawns(World world, EnumCreatureType creatureType, BlockPos pos)
+    {
+        for (MapGenStructure structure : structures)
+        {
+            if (structure instanceof ISpawningStructure && structure.isInsideStructure(pos))
+            {
+                return ((ISpawningStructure) structure).getSpawns(world, creatureType, pos);
+            }
+        }
+        return Lists.newArrayList();
+    }
+
+    public void generateStructure(World world, Random rand, ChunkPos chunkPos)
+    {
+        for (MapGenStructure structure : structures)
+        {
+            structure.generateStructure(world, rand, chunkPos);
+        }
+    }
+
+    public void generate(World worldIn, int x, int z, ChunkPrimer primer)
+    {
+        for (MapGenStructure structure : structures)
+        {
+            structure.generate(worldIn, x, z, primer);
+        }
+    }
+
+    /**
+     * Should be implemented by any {@link MapGenStructure} that would like to spawn creatures within it's area
+     */
+    public interface ISpawningStructure
+    {
+        boolean shouldSpawn(EnumCreatureType creatureType);
+
+        List<Biome.SpawnListEntry> getSpawns(World world, EnumCreatureType creatureType, BlockPos pos);
+    }
+
+}

--- a/src/main/java/net/minecraftforge/common/MapGenStructureManager.java
+++ b/src/main/java/net/minecraftforge/common/MapGenStructureManager.java
@@ -116,16 +116,14 @@ public class MapGenStructureManager
     @Nonnull
     public List<Biome.SpawnListEntry> getSpawns(List<Biome.SpawnListEntry> defaults, World world, EnumCreatureType creatureType, BlockPos pos)
     {
-        List<Biome.SpawnListEntry> spawnEntries = Lists.newArrayList(defaults);//Don't modify the biome's list
         for (MapGenStructure structure : structureMap.values())
         {
             if (structure instanceof ISpawningStructure && structure.isInsideStructure(pos))
             {
-                ((ISpawningStructure) structure).getSpawns(spawnEntries, world, creatureType, pos);
-                return spawnEntries;
+                return ((ISpawningStructure) structure).getSpawns(Collections.unmodifiableList(defaults), world, creatureType, pos);//Ensure mods don't accidentally modify the biomes spawn list itself
             }
         }
-        return spawnEntries;
+        return defaults;
     }
 
     public void generateStructure(World world, Random rand, ChunkPos chunkPos)
@@ -150,13 +148,14 @@ public class MapGenStructureManager
     public interface ISpawningStructure
     {
         /**
-         * Collect the list of creatures of the given type that should spawn within the structures bounding box.
+         * Collect a list of creatures of the given type that should spawn within the structures bounding box.
          * <p>
-         * If this method is called repeatedly you should always return exactly the same (equals) objects otherwise the spawning will not work.
+         * This method is called twice in a row by {@link net.minecraft.world.WorldEntitySpawner}. If the elements returned are not the same (equals) both times the spawning will be canceled
          *
-         * @param spawnEntries Contains the biome's default spawn entries. Modify this list to add your own spawns and/or clear the biome's ones.
+         * @param defaults Unmodifiable. Contains the biome's default spawn entries. Return this if you don't want to affect spawn. You can also add the contained elements to your own list
+         * @return The spawn entries that should be used for spawning
          */
-        void getSpawns(List<Biome.SpawnListEntry> spawnEntries, World world, EnumCreatureType creatureType, BlockPos pos);
+        List<Biome.SpawnListEntry> getSpawns(List<Biome.SpawnListEntry> defaults, World world, EnumCreatureType creatureType, BlockPos pos);
     }
 
 }

--- a/src/main/java/net/minecraftforge/common/MapGenStructureManager.java
+++ b/src/main/java/net/minecraftforge/common/MapGenStructureManager.java
@@ -26,6 +26,7 @@ import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.ChunkPos;
 import net.minecraft.world.World;
 import net.minecraft.world.biome.Biome;
+import net.minecraft.world.chunk.Chunk;
 import net.minecraft.world.chunk.ChunkPrimer;
 import net.minecraft.world.gen.structure.MapGenStructure;
 import org.apache.commons.lang3.ArrayUtils;
@@ -132,6 +133,16 @@ public class MapGenStructureManager
         }
     }
 
+    public boolean retroGenerateStructures(World world, Random rand, ChunkPos chunkPos, Chunk chunk){
+        boolean flag=false;
+        for(MapGenStructure structure : structureMap.values()){
+            if(structure instanceof IRetroGenStructure){
+                flag = flag | ((IRetroGenStructure) structure).retroGenerateStructure(world,rand,chunkPos,chunk);
+            }
+        }
+        return flag;
+    }
+
     public void generate(World worldIn, int x, int z, ChunkPrimer primer)
     {
         for (MapGenStructure structure : structureMap.values())
@@ -154,6 +165,20 @@ public class MapGenStructureManager
          * @return The spawn entries that should be used for spawning
          */
         List<Biome.SpawnListEntry> getSpawns(List<Biome.SpawnListEntry> defaults, World world, EnumCreatureType creatureType, BlockPos pos);
+    }
+
+    /**
+     * Should be implemented by any {@link MapGenStructure} that would like to retroactively generate structures after the terrain has already been populated like the ocean monument does
+     * Used in {@link net.minecraft.world.gen.IChunkGenerator#generateStructures(Chunk, int, int)}
+     */
+    public interface IRetroGenStructure
+    {
+        /**
+         * Retroactively generate structures after the terrain has already been populated
+         * @param chunk The chunk being processed
+         * @return If something in the world has been changed
+         */
+        boolean retroGenerateStructure(World worldIn, Random randomIn, ChunkPos chunkCoord, Chunk chunk);
     }
 
 }

--- a/src/main/java/net/minecraftforge/common/MapGenStructureManager.java
+++ b/src/main/java/net/minecraftforge/common/MapGenStructureManager.java
@@ -36,13 +36,15 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Random;
+import java.util.Set;
+import java.util.TreeSet;
 
 /**
  * Manage MapGenStructure for the ChunkGenerators.
  */
 public class MapGenStructureManager
 {
-    private static final List<String> allStructureNames = Lists.newArrayList();
+    private static final Set<String> allStructureNames = new TreeSet<>();
     private final Map<String, MapGenStructure> structureMap;
 
     public MapGenStructureManager(List<MapGenStructure> structures)
@@ -55,7 +57,6 @@ public class MapGenStructureManager
             addStructureName(name);
         }
         structureMap = builder.build();
-        Collections.sort(allStructureNames);
     }
 
     /**
@@ -67,10 +68,7 @@ public class MapGenStructureManager
      */
     protected static void addStructureName(String structure)
     {
-        if (!allStructureNames.contains(structure))
-        {
             allStructureNames.add(structure);
-        }
     }
 
     /**

--- a/src/main/java/net/minecraftforge/common/MapGenStructureManager.java
+++ b/src/main/java/net/minecraftforge/common/MapGenStructureManager.java
@@ -20,7 +20,6 @@
 package net.minecraftforge.common;
 
 import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.Lists;
 import net.minecraft.entity.EnumCreatureType;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.ChunkPos;
@@ -69,7 +68,7 @@ public class MapGenStructureManager
      */
     protected static void addStructureName(String structure)
     {
-            allStructureNames.add(structure);
+        allStructureNames.add(structure);
     }
 
     /**
@@ -87,9 +86,10 @@ public class MapGenStructureManager
     @Nullable
     public BlockPos getNearestStructurePos(World worldIn, String structureName, BlockPos position, boolean findUnexplored)
     {
-        if (structureMap.containsKey(structureName))
+        MapGenStructure structure = structureMap.get(structureName);
+        if (structure != null)
         {
-            return structureMap.get(structureName).getNearestStructurePos(worldIn, position, findUnexplored);
+            return structure.getNearestStructurePos(worldIn, position, findUnexplored);
         }
         return null;
     }
@@ -100,11 +100,8 @@ public class MapGenStructureManager
      */
     public boolean isInsideStructure(World worldIn, String structureName, BlockPos pos)
     {
-        if (structureMap.containsKey(structureName))
-        {
-            return structureMap.get(structureName).isInsideStructure(pos);
-        }
-        return false;
+        MapGenStructure structure = structureMap.get(structureName);
+        return structure != null && structureMap.get(structureName).isInsideStructure(pos);
     }
 
     /**
@@ -133,11 +130,14 @@ public class MapGenStructureManager
         }
     }
 
-    public boolean retroGenerateStructures(World world, Random rand, ChunkPos chunkPos, Chunk chunk){
-        boolean flag=false;
-        for(MapGenStructure structure : structureMap.values()){
-            if(structure instanceof IRetroGenStructure){
-                flag = flag | ((IRetroGenStructure) structure).retroGenerateStructure(world,rand,chunkPos,chunk);
+    public boolean retroGenerateStructures(World world, Random rand, ChunkPos chunkPos, Chunk chunk)
+    {
+        boolean flag = false;
+        for (MapGenStructure structure : structureMap.values())
+        {
+            if (structure instanceof IRetroGenStructure)
+            {
+                flag = flag | ((IRetroGenStructure) structure).retroGenerateStructure(world, rand, chunkPos, chunk);
             }
         }
         return flag;

--- a/src/main/java/net/minecraftforge/common/MapGenStructureManager.java
+++ b/src/main/java/net/minecraftforge/common/MapGenStructureManager.java
@@ -117,7 +117,7 @@ public class MapGenStructureManager
     {
         for (MapGenStructure structure : structureMap.values())
         {
-            if (structure instanceof ISpawningStructure && structure.isInsideStructure(pos))
+            if (structure instanceof ISpawningStructure && structure.isPositionInStructure(world,pos))
             {
                 return ((ISpawningStructure) structure).getSpawns(Collections.unmodifiableList(defaults), world, creatureType, pos);//Ensure mods don't accidentally modify the biomes spawn list itself
             }

--- a/src/main/java/net/minecraftforge/event/terraingen/InitStructureGensEvent.java
+++ b/src/main/java/net/minecraftforge/event/terraingen/InitStructureGensEvent.java
@@ -27,6 +27,7 @@ import net.minecraftforge.common.MapGenStructureManager;
 import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.fml.common.eventhandler.GenericEvent;
 
+import java.util.Collections;
 import java.util.List;
 
 /**
@@ -48,11 +49,10 @@ public class InitStructureGensEvent<T extends IChunkGenerator> extends GenericEv
     public void addStructure(MapGenStructure struct)
     {
         structureList.add(struct);
-        MapGenStructureManager.addStructureName(struct.getStructureName());
     }
 
     public List<MapGenStructure> getStructuresImmutable()
     {
-        return ImmutableList.copyOf(structureList);
+        return Collections.unmodifiableList(structureList);
     }
 }

--- a/src/main/java/net/minecraftforge/event/terraingen/InitStructureGensEvent.java
+++ b/src/main/java/net/minecraftforge/event/terraingen/InitStructureGensEvent.java
@@ -1,0 +1,58 @@
+/*
+ * Minecraft Forge
+ * Copyright (c) 2016.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation version 2.1
+ * of the License.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+package net.minecraftforge.event.terraingen;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Lists;
+import net.minecraft.world.gen.IChunkGenerator;
+import net.minecraft.world.gen.structure.MapGenStructure;
+import net.minecraftforge.common.MapGenStructureManager;
+import net.minecraftforge.common.MinecraftForge;
+import net.minecraftforge.fml.common.eventhandler.GenericEvent;
+
+import java.util.List;
+
+/**
+ * Used to collect {@link MapGenStructure}s.
+ * <p>
+ * This event is posted on {@link MinecraftForge#TERRAIN_GEN_BUS} in the ChunkGenerator constructors to allow mods to register their own (additional) structures
+ *
+ * @param <T> Type of ChunkGenerator
+ */
+public class InitStructureGensEvent<T extends IChunkGenerator> extends GenericEvent<T>
+{
+    private final List<MapGenStructure> structureList = Lists.newArrayList();
+
+    public InitStructureGensEvent(Class<T> generatorClass)
+    {
+        super(generatorClass);
+    }
+
+    public void addStructure(MapGenStructure struct)
+    {
+        structureList.add(struct);
+        MapGenStructureManager.addStructureName(struct.getStructureName());
+    }
+
+    public List<MapGenStructure> getStructuresImmutable()
+    {
+        return ImmutableList.copyOf(structureList);
+    }
+}

--- a/src/main/java/net/minecraftforge/event/terraingen/InitStructureGensEvent.java
+++ b/src/main/java/net/minecraftforge/event/terraingen/InitStructureGensEvent.java
@@ -40,10 +40,12 @@ import java.util.List;
 public class InitStructureGensEvent<T extends IChunkGenerator> extends GenericEvent<T>
 {
     private final List<MapGenStructure> structureList = Lists.newArrayList();
+    private final T generator;
 
-    public InitStructureGensEvent(Class<T> generatorClass)
+    public InitStructureGensEvent(Class<T> generatorClass, T generatorInstance)
     {
         super(generatorClass);
+        this.generator=generatorInstance;
     }
 
     public void addStructure(MapGenStructure struct)
@@ -54,5 +56,10 @@ public class InitStructureGensEvent<T extends IChunkGenerator> extends GenericEv
     public List<MapGenStructure> getStructuresImmutable()
     {
         return Collections.unmodifiableList(structureList);
+    }
+
+    public T getGenerator()
+    {
+        return generator;
     }
 }

--- a/src/main/java/net/minecraftforge/event/terraingen/InitStructureGensEvent.java
+++ b/src/main/java/net/minecraftforge/event/terraingen/InitStructureGensEvent.java
@@ -58,6 +58,10 @@ public class InitStructureGensEvent<T extends IChunkGenerator> extends GenericEv
         return Collections.unmodifiableList(structureList);
     }
 
+    /**
+     * Careful, the generator object is not fully initialized yet because the event is posted from within its constructor
+     * @return The generator collecting the MapGenStructures.
+     */
     public T getGenerator()
     {
         return generator;

--- a/src/main/java/net/minecraftforge/event/terraingen/TerrainGen.java
+++ b/src/main/java/net/minecraftforge/event/terraingen/TerrainGen.java
@@ -19,18 +19,19 @@
 
 package net.minecraftforge.event.terraingen;
 
-import java.util.Random;
-
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.World;
 import net.minecraft.world.gen.IChunkGenerator;
 import net.minecraft.world.gen.MapGenBase;
 import net.minecraft.world.gen.feature.WorldGenerator;
+import net.minecraftforge.common.MapGenStructureManager;
 import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate;
 import net.minecraftforge.event.terraingen.OreGenEvent.GenerateMinable;
 import net.minecraftforge.event.terraingen.PopulateChunkEvent.Populate;
 import net.minecraftforge.fml.common.eventhandler.Event.Result;
+
+import java.util.Random;
 
 public abstract class TerrainGen
 {
@@ -74,5 +75,12 @@ public abstract class TerrainGen
         SaplingGrowTreeEvent event = new SaplingGrowTreeEvent(world, rand, pos);
         MinecraftForge.TERRAIN_GEN_BUS.post(event);
         return event.getResult() != Result.DENY;
+    }
+
+    public static <T extends IChunkGenerator> MapGenStructureManager getAddedStructures(Class<T> generatorClazz)
+    {
+        InitStructureGensEvent<T> event = new InitStructureGensEvent<>(generatorClazz);
+        MinecraftForge.TERRAIN_GEN_BUS.post(event);
+        return new MapGenStructureManager(event.getStructuresImmutable());
     }
 }

--- a/src/main/java/net/minecraftforge/event/terraingen/TerrainGen.java
+++ b/src/main/java/net/minecraftforge/event/terraingen/TerrainGen.java
@@ -77,9 +77,9 @@ public abstract class TerrainGen
         return event.getResult() != Result.DENY;
     }
 
-    public static <T extends IChunkGenerator> MapGenStructureManager getAddedStructures(Class<T> generatorClazz)
+    public static <T extends IChunkGenerator> MapGenStructureManager getAddedStructures(Class<T> generatorClazz, T generatorInstance)
     {
-        InitStructureGensEvent<T> event = new InitStructureGensEvent<>(generatorClazz);
+        InitStructureGensEvent<T> event = new InitStructureGensEvent<>(generatorClazz, generatorInstance);
         MinecraftForge.TERRAIN_GEN_BUS.post(event);
         return new MapGenStructureManager(event.getStructuresImmutable());
     }

--- a/src/test/java/net/minecraftforge/debug/StructureGenTest.java
+++ b/src/test/java/net/minecraftforge/debug/StructureGenTest.java
@@ -1,0 +1,216 @@
+package net.minecraftforge.debug;
+
+import com.google.common.collect.Lists;
+import net.minecraft.entity.EnumCreatureType;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.math.ChunkPos;
+import net.minecraft.world.World;
+import net.minecraft.world.biome.Biome;
+import net.minecraft.world.chunk.ChunkPrimer;
+import net.minecraft.world.gen.ChunkGeneratorEnd;
+import net.minecraft.world.gen.ChunkGeneratorHell;
+import net.minecraft.world.gen.ChunkGeneratorOverworld;
+import net.minecraft.world.gen.structure.MapGenStructure;
+import net.minecraft.world.gen.structure.MapGenStructureIO;
+import net.minecraft.world.gen.structure.StructureStart;
+import net.minecraftforge.common.MapGenStructureManager;
+import net.minecraftforge.common.MinecraftForge;
+import net.minecraftforge.event.terraingen.InitStructureGensEvent;
+import net.minecraftforge.fml.common.FMLLog;
+import net.minecraftforge.fml.common.Mod;
+import net.minecraftforge.fml.common.event.FMLPreInitializationEvent;
+import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
+import org.apache.logging.log4j.Logger;
+
+import javax.annotation.Nullable;
+import java.util.List;
+import java.util.Random;
+
+/**
+ * Test the feature to add custom MapGenStructures to the ChunkGenerators.
+ * To verify the function:
+ * 1) Enable this mod
+ * 2) Generate a new world
+ * 3) Tp to 64 * 64
+ * 4) run "/locate forge-test-structure"
+ * 5) Check the console for result
+ * 6) Repeat in Hell and End
+ */
+@Mod(modid = StructureGenTest.MODID, name = StructureGenTest.MODID, version = "1.0")
+public class StructureGenTest
+{
+    public final static String MODID = "structure_gen_test";
+    private final static boolean ENABLED = false;
+    private static Logger logger;
+
+    @Mod.EventHandler
+    public void preinit(FMLPreInitializationEvent evt)
+    {
+        logger = evt.getModLog();
+
+        if (ENABLED)
+        {
+            MapGenStructureIO.registerStructure(Start.class, "forge-test-structure");
+            MinecraftForge.TERRAIN_GEN_BUS.register(this);
+
+        }
+    }
+
+    @SubscribeEvent
+    public void onCollectStructuresOverworld(InitStructureGensEvent<ChunkGeneratorOverworld> event)
+    {
+        logger.info("Collecting structures for Overworld");
+        event.addStructure(new TestStructure("overworld"));
+    }
+
+    @SubscribeEvent
+    public void onCollectStructuresEnd(InitStructureGensEvent<ChunkGeneratorEnd> event)
+    {
+        logger.info("Collecting structures for End");
+        event.addStructure(new TestStructure("end"));
+    }
+
+    @SubscribeEvent
+    public void onCollectStructuresHell(InitStructureGensEvent<ChunkGeneratorHell> event)
+    {
+        logger.info("Collecting structures for Hell");
+        event.addStructure(new TestStructure("hell"));
+    }
+
+    @SubscribeEvent
+    public void onCollectStructures(InitStructureGensEvent event)
+    {
+        logger.info("Collecting structures for {}", event.getGenericType());
+    }
+
+    private class TestStructure extends MapGenStructure implements MapGenStructureManager.ISpawningStructure
+    {
+
+        private final String generator;
+        private boolean spawn = true;
+        private boolean isAt = true;
+        private boolean generate = true;
+        private boolean generateStructure = true;
+
+        private TestStructure(String generator)
+        {
+            this.generator = generator;
+        }
+
+        @Override
+        public String getStructureName()
+        {
+            return "forge-test-structure";
+        }
+
+        @Override
+        public void generate(World worldIn, int x, int z, ChunkPrimer primer)
+        {
+            if (generate)
+            {
+                logger.info("Generating {}", generator);
+                generate = false;
+            }
+            super.generate(worldIn, x, z, primer);
+        }
+
+        @Override
+        public synchronized boolean generateStructure(World worldIn, Random randomIn, ChunkPos chunkCoord)
+        {
+            if (generateStructure)
+            {
+                logger.info("Generating structure {}", generator);
+                generateStructure = false;
+            }
+            return super.generateStructure(worldIn, randomIn, chunkCoord);
+        }
+
+        @Nullable @Override
+        public BlockPos getNearestStructurePos(World worldIn, BlockPos pos, boolean findUnexplored)
+        {
+            logger.info("Getting nearest structure {}", generator);
+            if (isComplete())
+            {
+                FMLLog.bigWarning("Structure Gen Test in {} successful", generator);
+            }
+            else
+            {
+                FMLLog.bigWarning("Structure Gen Test not successful. Spawn {}, isAt {}, generate {}, generateStructure {}", spawn, isAt, generate,
+                        generateStructure);
+            }
+            return new BlockPos(64,0,64);
+        }
+
+        @Override
+        protected boolean canSpawnStructureAtCoords(int chunkX, int chunkZ)
+        {
+            return chunkX == 4 && chunkZ == 4;
+        }
+
+        @Override
+        protected StructureStart getStructureStart(int chunkX, int chunkZ)
+        {
+            logger.info("Starting structure in {}", generator);
+            return new Start(chunkX, chunkZ);
+        }
+
+        @Override
+        public boolean shouldSpawn(EnumCreatureType creatureType)
+        {
+            if (spawn)
+            {
+                logger.info("Checking for spawn {}", generator);
+                //spawn is disabled in getSpawns
+            }
+            return spawn;
+        }
+
+        @Override
+        public boolean isInsideStructure(BlockPos pos)
+        {
+            if (isAt)
+            {
+                logger.info("Checking for structure {}", generator);
+                isAt = false;
+            }
+            return pos.getX() /16 == 4 && pos.getZ() /16 == 4;
+        }
+
+        @Override
+        public List<Biome.SpawnListEntry> getSpawns(World world, EnumCreatureType creatureType, BlockPos pos)
+        {
+            if (spawn)
+            {
+                logger.info("Getting spawns {}", generator);
+                spawn = false;
+            }
+            return Lists.newArrayList();
+        }
+
+        private boolean isComplete()
+        {
+            return !spawn && !generate && !generateStructure && !isAt;
+        }
+
+    }
+
+    /**
+     * Has to be public due to the MapGenStructureIO system
+     */
+    public static class Start extends StructureStart
+    {
+        Start(int x, int z)
+        {
+            super(x, z);
+            this.updateBoundingBox();
+        }
+
+        /**
+         * Required. Don't use. Used internally
+         */
+        public Start()
+        {
+            super();
+        }
+    }
+}

--- a/src/test/java/net/minecraftforge/debug/StructureGenTest.java
+++ b/src/test/java/net/minecraftforge/debug/StructureGenTest.java
@@ -1,10 +1,8 @@
 package net.minecraftforge.debug;
 
+import com.google.common.collect.Lists;
 import net.minecraft.entity.EnumCreatureType;
 import net.minecraft.entity.monster.EntityBlaze;
-import net.minecraft.entity.monster.EntityGiantZombie;
-import net.minecraft.entity.monster.EntitySilverfish;
-import net.minecraft.entity.monster.EntityWitherSkeleton;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.ChunkPos;
 import net.minecraft.world.World;
@@ -38,6 +36,8 @@ import java.util.Random;
  * 4) run "/locate forge-test-structure"
  * 5) Check the console for result
  * 6) Repeat in Hell and End
+ *
+ * You should also notice that Blaze are spawning (at least during the night)
  */
 @Mod(modid = StructureGenTest.MODID, name = StructureGenTest.MODID, version = "1.0")
 public class StructureGenTest
@@ -114,10 +114,12 @@ public class StructureGenTest
         private boolean isAt = true;
         private boolean generate = true;
         private boolean generateStructure = true;
+        private final List<Biome.SpawnListEntry> spawnList = Lists.newArrayList();
 
         private TestStructure(String generator)
         {
             this.generator = generator;
+            spawnList.add(new Biome.SpawnListEntry(EntityBlaze.class, 100, 1 ,5));
         }
 
         @Override
@@ -199,7 +201,7 @@ public class StructureGenTest
             }
             if(creatureType==EnumCreatureType.MONSTER){
                 spawnListEntries.clear();
-                spawnListEntries.add(new Biome.SpawnListEntry(EntityBlaze.class, 100, 1, 10));
+                spawnListEntries.addAll(spawnList);
             }
         }
 

--- a/src/test/java/net/minecraftforge/debug/StructureGenTest.java
+++ b/src/test/java/net/minecraftforge/debug/StructureGenTest.java
@@ -37,7 +37,7 @@ import java.util.Random;
  * 5) Check the console for result
  * 6) Repeat in Hell and End
  *
- * You should also notice that Blaze are spawning (at least during the night)
+ * You should also notice that Blaze are spawning (at least during the night and on suitable terrain)
  */
 @Mod(modid = StructureGenTest.MODID, name = StructureGenTest.MODID, version = "1.0")
 public class StructureGenTest
@@ -157,11 +157,11 @@ public class StructureGenTest
             logger.info("Getting nearest structure {}", generator);
             if (isComplete())
             {
-                FMLLog.bigWarning("Structure Gen Test in {} successful", generator);
+               logger.info("[STRUCTURE-GEN-TEST] Test in {} successful", generator);
             }
             else
             {
-                FMLLog.bigWarning("Structure Gen Test not successful. Spawn {}, isAt {}, generate {}, generateStructure {}", spawn, isAt, generate,
+                logger.info("[STRUCTURE-GEN-TEST] Test not successful. Spawn {}, isAt {}, generate {}, generateStructure {}", spawn, isAt, generate,
                         generateStructure);
             }
             return new BlockPos(64, 0, 64);
@@ -192,7 +192,7 @@ public class StructureGenTest
         }
 
         @Override
-        public void getSpawns(List<Biome.SpawnListEntry> spawnListEntries, World world, EnumCreatureType creatureType, BlockPos pos)
+        public List<Biome.SpawnListEntry> getSpawns(List<Biome.SpawnListEntry> defaults, World world, EnumCreatureType creatureType, BlockPos pos)
         {
             if (spawn)
             {
@@ -200,9 +200,9 @@ public class StructureGenTest
                 spawn = false;
             }
             if(creatureType==EnumCreatureType.MONSTER){
-                spawnListEntries.clear();
-                spawnListEntries.addAll(spawnList);
+                return spawnList;
             }
+            return defaults;
         }
 
         private boolean isComplete()

--- a/src/test/java/net/minecraftforge/debug/StructureGenTest.java
+++ b/src/test/java/net/minecraftforge/debug/StructureGenTest.java
@@ -1,6 +1,5 @@
 package net.minecraftforge.debug;
 
-import com.google.common.collect.Lists;
 import net.minecraft.entity.EnumCreatureType;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.ChunkPos;
@@ -40,11 +39,11 @@ import java.util.Random;
 public class StructureGenTest
 {
     public final static String MODID = "structure_gen_test";
-    private final static boolean ENABLED = false;
+    private final static boolean ENABLED = true;
     private static Logger logger;
 
     @Mod.EventHandler
-    public void preinit(FMLPreInitializationEvent evt)
+    public void preInit(FMLPreInitializationEvent evt)
     {
         logger = evt.getModLog();
 
@@ -81,6 +80,26 @@ public class StructureGenTest
     public void onCollectStructures(InitStructureGensEvent event)
     {
         logger.info("Collecting structures for {}", event.getGenericType());
+    }
+
+    /**
+     * Has to be public due to the MapGenStructureIO system
+     */
+    public static class Start extends StructureStart
+    {
+        Start(int x, int z)
+        {
+            super(x, z);
+            this.updateBoundingBox();
+        }
+
+        /**
+         * Required. Don't use. Used internally
+         */
+        public Start()
+        {
+            super();
+        }
     }
 
     private class TestStructure extends MapGenStructure implements MapGenStructureManager.ISpawningStructure
@@ -125,7 +144,8 @@ public class StructureGenTest
             return super.generateStructure(worldIn, randomIn, chunkCoord);
         }
 
-        @Nullable @Override
+        @Nullable
+        @Override
         public BlockPos getNearestStructurePos(World worldIn, BlockPos pos, boolean findUnexplored)
         {
             logger.info("Getting nearest structure {}", generator);
@@ -138,7 +158,7 @@ public class StructureGenTest
                 FMLLog.bigWarning("Structure Gen Test not successful. Spawn {}, isAt {}, generate {}, generateStructure {}", spawn, isAt, generate,
                         generateStructure);
             }
-            return new BlockPos(64,0,64);
+            return new BlockPos(64, 0, 64);
         }
 
         @Override
@@ -155,17 +175,6 @@ public class StructureGenTest
         }
 
         @Override
-        public boolean shouldSpawn(EnumCreatureType creatureType)
-        {
-            if (spawn)
-            {
-                logger.info("Checking for spawn {}", generator);
-                //spawn is disabled in getSpawns
-            }
-            return spawn;
-        }
-
-        @Override
         public boolean isInsideStructure(BlockPos pos)
         {
             if (isAt)
@@ -173,18 +182,18 @@ public class StructureGenTest
                 logger.info("Checking for structure {}", generator);
                 isAt = false;
             }
-            return pos.getX() /16 == 4 && pos.getZ() /16 == 4;
+            return pos.getX() / 16 == 4 && pos.getZ() / 16 == 4;
         }
 
         @Override
-        public List<Biome.SpawnListEntry> getSpawns(World world, EnumCreatureType creatureType, BlockPos pos)
+        public List<Biome.SpawnListEntry> getSpawns(List<Biome.SpawnListEntry> defaults, World world, EnumCreatureType creatureType, BlockPos pos)
         {
             if (spawn)
             {
                 logger.info("Getting spawns {}", generator);
                 spawn = false;
             }
-            return Lists.newArrayList();
+            return defaults; //Don't change spawn behaviour
         }
 
         private boolean isComplete()
@@ -192,25 +201,5 @@ public class StructureGenTest
             return !spawn && !generate && !generateStructure && !isAt;
         }
 
-    }
-
-    /**
-     * Has to be public due to the MapGenStructureIO system
-     */
-    public static class Start extends StructureStart
-    {
-        Start(int x, int z)
-        {
-            super(x, z);
-            this.updateBoundingBox();
-        }
-
-        /**
-         * Required. Don't use. Used internally
-         */
-        public Start()
-        {
-            super();
-        }
     }
 }

--- a/src/test/java/net/minecraftforge/debug/StructureGenTest.java
+++ b/src/test/java/net/minecraftforge/debug/StructureGenTest.java
@@ -1,6 +1,10 @@
 package net.minecraftforge.debug;
 
 import net.minecraft.entity.EnumCreatureType;
+import net.minecraft.entity.monster.EntityBlaze;
+import net.minecraft.entity.monster.EntityGiantZombie;
+import net.minecraft.entity.monster.EntitySilverfish;
+import net.minecraft.entity.monster.EntityWitherSkeleton;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.ChunkPos;
 import net.minecraft.world.World;
@@ -39,7 +43,7 @@ import java.util.Random;
 public class StructureGenTest
 {
     public final static String MODID = "structure_gen_test";
-    private final static boolean ENABLED = true;
+    private final static boolean ENABLED = false;
     private static Logger logger;
 
     @Mod.EventHandler
@@ -186,14 +190,17 @@ public class StructureGenTest
         }
 
         @Override
-        public List<Biome.SpawnListEntry> getSpawns(List<Biome.SpawnListEntry> defaults, World world, EnumCreatureType creatureType, BlockPos pos)
+        public void getSpawns(List<Biome.SpawnListEntry> spawnListEntries, World world, EnumCreatureType creatureType, BlockPos pos)
         {
             if (spawn)
             {
                 logger.info("Getting spawns {}", generator);
                 spawn = false;
             }
-            return defaults; //Don't change spawn behaviour
+            if(creatureType==EnumCreatureType.MONSTER){
+                spawnListEntries.clear();
+                spawnListEntries.add(new Biome.SpawnListEntry(EntityBlaze.class, 100, 1, 10));
+            }
         }
 
         private boolean isComplete()

--- a/src/test/java/net/minecraftforge/debug/StructureGenTest.java
+++ b/src/test/java/net/minecraftforge/debug/StructureGenTest.java
@@ -36,16 +36,15 @@ import java.util.Random;
  * 3) Tp to 64 * 64
  * 4) run "/locate forge-test-structure"
  * 5) Check the console for result
- * 6) When reloading the chunk/world a log about retroactively generating should appear
- * 7) Repeat in Hell and End
+ * 6) Repeat in Hell and End
  *
- * You should also notice that Blaze are spawning (at least during the night and on suitable terrain)
+ * You should also notice that Blaze are spawning (at least during the night and on suitable terrain, e.g. desert, might take some time)
  */
 @Mod(modid = StructureGenTest.MODID, name = StructureGenTest.MODID, version = "1.0")
 public class StructureGenTest
 {
     public final static String MODID = "structure_gen_test";
-    private final static boolean ENABLED = false;
+    private final static boolean ENABLED = true;
     private static Logger logger;
 
     @Mod.EventHandler
@@ -202,10 +201,22 @@ public class StructureGenTest
                 logger.info("Getting spawns {}", generator);
                 spawn = false;
             }
-            if(creatureType==EnumCreatureType.MONSTER){
+            if(creatureType == EnumCreatureType.MONSTER){
                 return spawnList;
             }
             return defaults;
+        }
+
+
+        /**
+         * Need to trick the generator here for spawning checks.
+         * We are using a dummy structure without any content so the bounding box is too small for the real check.
+         * Don't do this in a real mod.
+         */
+        @Override
+        public boolean isPositionInStructure(World worldIn, BlockPos pos)
+        {
+            return this.isInsideStructure(pos);
         }
 
         private boolean isComplete()

--- a/src/test/java/net/minecraftforge/debug/StructureGenTest.java
+++ b/src/test/java/net/minecraftforge/debug/StructureGenTest.java
@@ -44,7 +44,7 @@ import java.util.Random;
 public class StructureGenTest
 {
     public final static String MODID = "structure_gen_test";
-    private final static boolean ENABLED = true;
+    private final static boolean ENABLED = false;
     private static Logger logger;
 
     @Mod.EventHandler

--- a/src/test/java/net/minecraftforge/debug/StructureGenTest.java
+++ b/src/test/java/net/minecraftforge/debug/StructureGenTest.java
@@ -7,6 +7,7 @@ import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.ChunkPos;
 import net.minecraft.world.World;
 import net.minecraft.world.biome.Biome;
+import net.minecraft.world.chunk.Chunk;
 import net.minecraft.world.chunk.ChunkPrimer;
 import net.minecraft.world.gen.ChunkGeneratorEnd;
 import net.minecraft.world.gen.ChunkGeneratorHell;
@@ -35,7 +36,8 @@ import java.util.Random;
  * 3) Tp to 64 * 64
  * 4) run "/locate forge-test-structure"
  * 5) Check the console for result
- * 6) Repeat in Hell and End
+ * 6) When reloading the chunk/world a log about retroactively generating should appear
+ * 7) Repeat in Hell and End
  *
  * You should also notice that Blaze are spawning (at least during the night and on suitable terrain)
  */
@@ -106,13 +108,14 @@ public class StructureGenTest
         }
     }
 
-    private class TestStructure extends MapGenStructure implements MapGenStructureManager.ISpawningStructure
+    private class TestStructure extends MapGenStructure implements MapGenStructureManager.ISpawningStructure, MapGenStructureManager.IRetroGenStructure
     {
 
         private final String generator;
         private boolean spawn = true;
         private boolean isAt = true;
         private boolean generate = true;
+        private boolean retroGenerate = true;
         private boolean generateStructure = true;
         private final List<Biome.SpawnListEntry> spawnList = Lists.newArrayList();
 
@@ -210,5 +213,14 @@ public class StructureGenTest
             return !spawn && !generate && !generateStructure && !isAt;
         }
 
+        @Override
+        public boolean retroGenerateStructure(World worldIn, Random randomIn, ChunkPos chunkCoord, Chunk chunk)
+        {
+            if(retroGenerate){
+                logger.info("Retroactively generating structure in {}", generator);
+                retroGenerate=false;
+            }
+            return false;
+        }
     }
 }


### PR DESCRIPTION
Replaces #4496.
Instead of posting events at the appropriate positions this PR adds a way to add additional MapGenStructures to the ChunkGenererators which are then treated in the same way the vanilla ones (Village, ...).

This approach is more complex as the event based one, but it is cleaner and does not post events frequently.

## General Concept
Each standard (vanilla) ChunkGenerator (Overworld, Hell, End) fires an InitStructuresGenEvent during construction. Mods can register their additional structures to the event. Each ChunkGenerator has it's one MapGenStructureManager which holds the registered structures and manages the method calls.

## Spawning creatures
Since some structures would like to spawn creatures within their area, but there is no method in MapGenStructure for that (only in some subclasses). I added an interface which has to be implemented by any structures planning to spawn creatures.
The interface has two seperate methods shouldSpawn and getSpawns which is slightly redundant, but as there are three possible options here (custom list, empty list or biome list) I think this is the cleanest solution. Alternatively we could do
```
List list = structureManager.getSpawns();
return list ==null? biome.getSpawns : list;
```
But I don't feel comfortable with allowing having both null and an empty list as return value.

## Locate
Registered structures are automatically added to the locate command autocomplete, but the autocomplete is not dimension/generator specific (vanilla isn't either) since this would require more patches

## Test mod
It is probably not a good idea to include a "real" structure as test mod, so there is a dummy structure (for each dimension) which makes sure all methods are called. It is always "generated" in chunk x=4,z=4. See test mod for details