### PR TITLE
Fix some test mods preventing Forge server-Vanilla client connections

### DIFF
--- a/src/test/java/net/minecraftforge/debug/CheckSpawnTest.java
+++ b/src/test/java/net/minecraftforge/debug/CheckSpawnTest.java
@@ -8,7 +8,7 @@ import net.minecraftforge.fml.common.event.FMLPreInitializationEvent;
 import net.minecraftforge.fml.common.eventhandler.Event.Result;
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
 
-@Mod(modid = CheckSpawnTest.MODID, name = "CheckSpawnTest", version = "1.0")
+@Mod(modid = CheckSpawnTest.MODID, name = "CheckSpawnTest", version = "1.0", acceptableRemoteVersions = "*")
 public class CheckSpawnTest
 {
     public static final String MODID = "checkspawntest";

--- a/src/test/java/net/minecraftforge/debug/ChunkCapabilityPollutionTest.java
+++ b/src/test/java/net/minecraftforge/debug/ChunkCapabilityPollutionTest.java
@@ -28,7 +28,7 @@ import javax.annotation.Nullable;
  * Simple mod to test chunk capabilities.
  * Use flint and steel to increase pollution in a chunk and saplings to decrease pollution in a chunk.
  */
-@Mod(modid = ChunkCapabilityPollutionTest.MODID, name = "Chunk Capability Test", version = "0.0.0")
+@Mod(modid = ChunkCapabilityPollutionTest.MODID, name = "Chunk Capability Test", version = "0.0.0", acceptableRemoteVersions = "*")
 public class ChunkCapabilityPollutionTest {
     public static final String MODID = "chunkcapabilitypollutiontest";
     public static final boolean ENABLE = false;

--- a/src/test/java/net/minecraftforge/debug/DebugSearchTabs.java
+++ b/src/test/java/net/minecraftforge/debug/DebugSearchTabs.java
@@ -9,7 +9,7 @@ import net.minecraftforge.fml.common.Mod;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
 
-@Mod(modid = DebugSearchTabs.MODID, name = "Debug Search Tab", version = "1.0")
+@Mod(modid = DebugSearchTabs.MODID, name = "Debug Search Tab", version = "1.0", acceptableRemoteVersions = "*")
 public class DebugSearchTabs
 {
     public static final String MODID = "debugsearchtab";

--- a/src/test/java/net/minecraftforge/debug/FluidAdditionalFieldsTest.java
+++ b/src/test/java/net/minecraftforge/debug/FluidAdditionalFieldsTest.java
@@ -17,7 +17,7 @@ import net.minecraftforge.fml.common.event.FMLPreInitializationEvent;
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
 import net.minecraftforge.fml.common.registry.GameRegistry.ObjectHolder;
 
-@Mod(modid = FluidAdditionalFieldsTest.MODID, name = "Test Mod", version = "1.0.0", acceptedMinecraftVersions = "*")
+@Mod(modid = FluidAdditionalFieldsTest.MODID, name = "Test Mod", version = "1.0.0", acceptedMinecraftVersions = "*", acceptableRemoteVersions = "*")
 @EventBusSubscriber
 public class FluidAdditionalFieldsTest
 {

--- a/src/test/java/net/minecraftforge/debug/ItemModelGenerationTest.java
+++ b/src/test/java/net/minecraftforge/debug/ItemModelGenerationTest.java
@@ -12,7 +12,7 @@ import net.minecraftforge.fml.common.registry.GameRegistry;
 import net.minecraftforge.fml.relauncher.Side;
 
 @Mod.EventBusSubscriber
-@Mod(modid = ItemModelGenerationTest.MOD_ID, name = "Item model generation test", version = "1.0")
+@Mod(modid = ItemModelGenerationTest.MOD_ID, name = "Item model generation test", version = "1.0", acceptableRemoteVersions = "*")
 public class ItemModelGenerationTest
 {
     static final String MOD_ID = "item_model_generation_test";

--- a/src/test/java/net/minecraftforge/debug/KnockBackHookTest.java
+++ b/src/test/java/net/minecraftforge/debug/KnockBackHookTest.java
@@ -6,7 +6,7 @@ import net.minecraftforge.event.entity.living.LivingKnockBackEvent;
 import net.minecraftforge.fml.common.Mod;
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
 
-@Mod(modid = "kbhtest", name = "Knock Back Hook Test", version = "1.0")
+@Mod(modid = "kbhtest", name = "Knock Back Hook Test", version = "1.0", acceptableRemoteVersions = "*")
 @Mod.EventBusSubscriber
 public class KnockBackHookTest
 {

--- a/src/test/java/net/minecraftforge/debug/ReachDistanceAttributeTest.java
+++ b/src/test/java/net/minecraftforge/debug/ReachDistanceAttributeTest.java
@@ -15,7 +15,7 @@ import net.minecraftforge.fml.common.Mod;
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
 import net.minecraftforge.fml.relauncher.Side;
 
-@Mod(modid = ReachDistanceAttributeTest.MODID, name = ReachDistanceAttributeTest.MODID, version = "1.0")
+@Mod(modid = ReachDistanceAttributeTest.MODID, name = ReachDistanceAttributeTest.MODID, version = "1.0", acceptableRemoteVersions = "*")
 @Mod.EventBusSubscriber
 public class ReachDistanceAttributeTest
 {

--- a/src/test/java/net/minecraftforge/debug/RegistryOverrideTest.java
+++ b/src/test/java/net/minecraftforge/debug/RegistryOverrideTest.java
@@ -34,7 +34,7 @@ import net.minecraftforge.event.RegistryEvent;
 import net.minecraftforge.fml.common.Mod;
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
 
-@Mod(modid = RegistryOverrideTest.MODID, name = "Registry override test mod", version = "1.0")
+@Mod(modid = RegistryOverrideTest.MODID, name = "Registry override test mod", version = "1.0", acceptableRemoteVersions = "*")
 @Mod.EventBusSubscriber
 public class RegistryOverrideTest
 {

--- a/src/test/java/net/minecraftforge/debug/SlipperinessTest.java
+++ b/src/test/java/net/minecraftforge/debug/SlipperinessTest.java
@@ -21,7 +21,7 @@ import net.minecraftforge.fml.relauncher.Side;
 
 import java.util.Collections;
 
-@Mod(modid = SlipperinessTest.MOD_ID, name = "Slipperiness Test", version = "0.0.0")
+@Mod(modid = SlipperinessTest.MOD_ID, name = "Slipperiness Test", version = "0.0.0", acceptableRemoteVersions = "*")
 @EventBusSubscriber
 public class SlipperinessTest
 {

--- a/src/test/java/net/minecraftforge/debug/TransparentFastTesrTest.java
+++ b/src/test/java/net/minecraftforge/debug/TransparentFastTesrTest.java
@@ -41,7 +41,7 @@ import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
 import net.minecraftforge.fml.common.registry.GameRegistry;
 import net.minecraftforge.fml.relauncher.Side;
 
-@Mod(modid = TransparentFastTesrTest.MODID, name = "TransparentFastTESRTest", version = "1.0")
+@Mod(modid = TransparentFastTesrTest.MODID, name = "TransparentFastTESRTest", version = "1.0", acceptableRemoteVersions = "*")
 public class TransparentFastTesrTest
 {
 

--- a/src/test/java/net/minecraftforge/test/SelectorHandlerTest.java
+++ b/src/test/java/net/minecraftforge/test/SelectorHandlerTest.java
@@ -12,7 +12,7 @@ import net.minecraftforge.fml.common.Mod;
 import net.minecraftforge.fml.common.Mod.EventHandler;
 import net.minecraftforge.fml.common.event.FMLInitializationEvent;
 
-@Mod(modid = "selectorhandlertest", name = "Selector Handler Test", version = "0.0.0")
+@Mod(modid = "selectorhandlertest", name = "Selector Handler Test", version = "0.0.0", acceptableRemoteVersions = "*")
 public class SelectorHandlerTest
 {
     @EventHandler


### PR DESCRIPTION
Several of the test mods do not have acceptableRemoteVersions set to "*" and are not serverside only or clientside only. This prevents a vanilla client from connecting to a Forge server launched from a Forge dev env (That is, a workspace for working on Forge itself), which makes testing that changes do not break vanilla compatibility difficult. This PR adds `acceptableRemoteVersions = "*"` to the `@Mod` annotations of all the current test mods that are missing it, so that they accept vanilla clients.