### PR TITLE
Handle the case when the default model is null for some reason

### DIFF
--- a/src/main/java/net/minecraftforge/client/model/ModelLoader.java
+++ b/src/main/java/net/minecraftforge/client/model/ModelLoader.java
@@ -670,7 +670,13 @@ public final class ModelLoader extends ModelBakery
                 textures.addAll(model.getTextures()); // Kick this, just in case.
 
                 models.add(model);
-                builder.add(Pair.of(model, new ModelStateComposition(v.getState(), model.getDefaultState())));
+                if (model.getDefaultState()==null) {
+                    FMLLog.log.error("Model {} (type : {}) has null defaultState", model, model.getClass().getName());
+                    builder.add(Pair.of(model, v.getState()));
+                } else
+                {
+                    builder.add(Pair.of(model, new ModelStateComposition(v.getState(), model.getDefaultState())));
+                }
             }
 
             if (models.size() == 0) //If all variants are missing, add one with the missing model and default rotation.


### PR DESCRIPTION
 (yes it's bad, but crashing is worse?).

See bug #4605 as well as a bunch of google hits for this error. (It makes DW20 unplayable with recent forge).