### PR TITLE
Adjust vanilla advancements to consider ore dictionary entries

### DIFF
--- a/src/main/resources/assets/forge/advancements/recipes/brewing/glass_bottle.json
+++ b/src/main/resources/assets/forge/advancements/recipes/brewing/glass_bottle.json
@@ -1,0 +1,32 @@
+{
+  "parent": "minecraft:recipes/root",
+  "rewards": {
+    "recipes": [
+      "minecraft:glass_bottle"
+    ]
+  },
+  "criteria": {
+    "has_glass": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "item": "minecraft:glass"
+          }
+        ]
+      }
+    },
+    "has_the_recipe": {
+      "trigger": "minecraft:recipe_unlocked",
+      "conditions": {
+        "recipe": "glass_bottle"
+      }
+    }
+  },
+  "requirements": [
+    [
+      "has_glass",
+      "has_the_recipe"
+    ]
+  ]
+}

--- a/src/main/resources/assets/forge/advancements/recipes/brewing/golden_carrot.json
+++ b/src/main/resources/assets/forge/advancements/recipes/brewing/golden_carrot.json
@@ -1,0 +1,32 @@
+{
+  "parent": "minecraft:recipes/root",
+  "rewards": {
+    "recipes": [
+      "minecraft:golden_carrot"
+    ]
+  },
+  "criteria": {
+    "has_gold_nugget": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "item": "minecraft:gold_nugget"
+          }
+        ]
+      }
+    },
+    "has_the_recipe": {
+      "trigger": "minecraft:recipe_unlocked",
+      "conditions": {
+        "recipe": "golden_carrot"
+      }
+    }
+  },
+  "requirements": [
+    [
+      "has_gold_nugget",
+      "has_the_recipe"
+    ]
+  ]
+}

--- a/src/main/resources/assets/forge/advancements/recipes/combat/wooden_sword.json
+++ b/src/main/resources/assets/forge/advancements/recipes/combat/wooden_sword.json
@@ -1,0 +1,33 @@
+{
+  "parent": "minecraft:recipes/root",
+  "rewards": {
+    "recipes": [
+      "minecraft:wooden_sword"
+    ]
+  },
+  "criteria": {
+    "has_stick": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "type": "forge:ore_dict",
+            "ore": "stickWood"
+          }
+        ]
+      }
+    },
+    "has_the_recipe": {
+      "trigger": "minecraft:recipe_unlocked",
+      "conditions": {
+        "recipe": "wooden_sword"
+      }
+    }
+  },
+  "requirements": [
+    [
+      "has_stick",
+      "has_the_recipe"
+    ]
+  ]
+}

--- a/src/main/resources/assets/forge/advancements/recipes/decorations/crafting_table.json
+++ b/src/main/resources/assets/forge/advancements/recipes/decorations/crafting_table.json
@@ -1,0 +1,33 @@
+{
+  "parent": "minecraft:recipes/root",
+  "rewards": {
+    "recipes": [
+      "minecraft:crafting_table"
+    ]
+  },
+  "criteria": {
+    "has_the_recipe": {
+      "trigger": "minecraft:recipe_unlocked",
+      "conditions": {
+        "recipe": "crafting_table"
+      }
+    },
+    "has_planks": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "type": "forge:ore_dict",
+            "ore": "plankWood"
+          }
+        ]
+      }
+    }
+  },
+  "requirements": [
+    [
+      "has_the_recipe",
+      "has_planks"
+    ]
+  ]
+}

--- a/src/main/resources/assets/forge/advancements/recipes/decorations/glass_pane.json
+++ b/src/main/resources/assets/forge/advancements/recipes/decorations/glass_pane.json
@@ -1,0 +1,32 @@
+{
+  "parent": "minecraft:recipes/root",
+  "rewards": {
+    "recipes": [
+      "minecraft:glass_pane"
+    ]
+  },
+  "criteria": {
+    "has_glass": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "item": "minecraft:glass"
+          }
+        ]
+      }
+    },
+    "has_the_recipe": {
+      "trigger": "minecraft:recipe_unlocked",
+      "conditions": {
+        "recipe": "glass_pane"
+      }
+    }
+  },
+  "requirements": [
+    [
+      "has_glass",
+      "has_the_recipe"
+    ]
+  ]
+}

--- a/src/main/resources/assets/forge/advancements/recipes/decorations/ladder.json
+++ b/src/main/resources/assets/forge/advancements/recipes/decorations/ladder.json
@@ -1,0 +1,33 @@
+{
+  "parent": "minecraft:recipes/root",
+  "rewards": {
+    "recipes": [
+      "minecraft:ladder"
+    ]
+  },
+  "criteria": {
+    "has_stick": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "type": "forge:ore_dict",
+            "ore": "stickWood"
+          }
+        ]
+      }
+    },
+    "has_the_recipe": {
+      "trigger": "minecraft:recipe_unlocked",
+      "conditions": {
+        "recipe": "ladder"
+      }
+    }
+  },
+  "requirements": [
+    [
+      "has_stick",
+      "has_the_recipe"
+    ]
+  ]
+}

--- a/src/main/resources/assets/forge/advancements/recipes/decorations/sign.json
+++ b/src/main/resources/assets/forge/advancements/recipes/decorations/sign.json
@@ -1,0 +1,33 @@
+{
+  "parent": "minecraft:recipes/root",
+  "rewards": {
+    "recipes": [
+      "minecraft:sign"
+    ]
+  },
+  "criteria": {
+    "has_the_recipe": {
+      "trigger": "minecraft:recipe_unlocked",
+      "conditions": {
+        "recipe": "sign"
+      }
+    },
+    "has_planks": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "type": "forge:ore_dict",
+            "ore": "plankWood"
+          }
+        ]
+      }
+    }
+  },
+  "requirements": [
+    [
+      "has_the_recipe",
+      "has_planks"
+    ]
+  ]
+}

--- a/src/main/resources/assets/forge/advancements/recipes/misc/beacon.json
+++ b/src/main/resources/assets/forge/advancements/recipes/misc/beacon.json
@@ -1,0 +1,32 @@
+{
+  "parent": "minecraft:recipes/root",
+  "rewards": {
+    "recipes": [
+      "minecraft:beacon"
+    ]
+  },
+  "criteria": {
+    "has_nether_star": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "item": "minecraft:nether_star"
+          }
+        ]
+      }
+    },
+    "has_the_recipe": {
+      "trigger": "minecraft:recipe_unlocked",
+      "conditions": {
+        "recipe": "beacon"
+      }
+    }
+  },
+  "requirements": [
+    [
+      "has_nether_star",
+      "has_the_recipe"
+    ]
+  ]
+}

--- a/src/main/resources/assets/forge/advancements/recipes/misc/book.json
+++ b/src/main/resources/assets/forge/advancements/recipes/misc/book.json
@@ -1,0 +1,32 @@
+{
+  "parent": "minecraft:recipes/root",
+  "rewards": {
+    "recipes": [
+      "minecraft:book"
+    ]
+  },
+  "criteria": {
+    "has_paper": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "item": "minecraft:paper"
+          }
+        ]
+      }
+    },
+    "has_the_recipe": {
+      "trigger": "minecraft:recipe_unlocked",
+      "conditions": {
+        "recipe": "book"
+      }
+    }
+  },
+  "requirements": [
+    [
+      "has_paper",
+      "has_the_recipe"
+    ]
+  ]
+}

--- a/src/main/resources/assets/forge/advancements/recipes/misc/stick.json
+++ b/src/main/resources/assets/forge/advancements/recipes/misc/stick.json
@@ -1,0 +1,33 @@
+{
+  "parent": "minecraft:recipes/root",
+  "rewards": {
+    "recipes": [
+      "minecraft:stick"
+    ]
+  },
+  "criteria": {
+    "has_the_recipe": {
+      "trigger": "minecraft:recipe_unlocked",
+      "conditions": {
+        "recipe": "stick"
+      }
+    },
+    "has_planks": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "type": "forge:ore_dict",
+            "ore": "plankWood"
+          }
+        ]
+      }
+    }
+  },
+  "requirements": [
+    [
+      "has_the_recipe",
+      "has_planks"
+    ]
+  ]
+}

--- a/src/main/resources/assets/forge/advancements/recipes/redstone/trapdoor.json
+++ b/src/main/resources/assets/forge/advancements/recipes/redstone/trapdoor.json
@@ -1,0 +1,33 @@
+{
+  "parent": "minecraft:recipes/root",
+  "rewards": {
+    "recipes": [
+      "minecraft:trapdoor"
+    ]
+  },
+  "criteria": {
+    "has_the_recipe": {
+      "trigger": "minecraft:recipe_unlocked",
+      "conditions": {
+        "recipe": "trapdoor"
+      }
+    },
+    "has_planks": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "type": "forge:ore_dict",
+            "ore": "plankWood"
+          }
+        ]
+      }
+    }
+  },
+  "requirements": [
+    [
+      "has_the_recipe",
+      "has_planks"
+    ]
+  ]
+}

--- a/src/main/resources/assets/forge/advancements/recipes/redstone/wooden_button.json
+++ b/src/main/resources/assets/forge/advancements/recipes/redstone/wooden_button.json
@@ -1,0 +1,33 @@
+{
+  "parent": "minecraft:recipes/root",
+  "rewards": {
+    "recipes": [
+      "minecraft:wooden_button"
+    ]
+  },
+  "criteria": {
+    "has_the_recipe": {
+      "trigger": "minecraft:recipe_unlocked",
+      "conditions": {
+        "recipe": "wooden_button"
+      }
+    },
+    "has_planks": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "type": "forge:ore_dict",
+            "ore": "plankWood"
+          }
+        ]
+      }
+    }
+  },
+  "requirements": [
+    [
+      "has_the_recipe",
+      "has_planks"
+    ]
+  ]
+}

--- a/src/main/resources/assets/forge/advancements/recipes/redstone/wooden_door.json
+++ b/src/main/resources/assets/forge/advancements/recipes/redstone/wooden_door.json
@@ -1,0 +1,33 @@
+{
+  "parent": "minecraft:recipes/root",
+  "rewards": {
+    "recipes": [
+      "minecraft:wooden_door"
+    ]
+  },
+  "criteria": {
+    "has_the_recipe": {
+      "trigger": "minecraft:recipe_unlocked",
+      "conditions": {
+        "recipe": "wooden_door"
+      }
+    },
+    "has_planks": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "item": "minecraft:planks",
+            "data": 0
+          }
+        ]
+      }
+    }
+  },
+  "requirements": [
+    [
+      "has_the_recipe",
+      "has_planks"
+    ]
+  ]
+}

--- a/src/main/resources/assets/forge/advancements/recipes/redstone/wooden_pressure_plate.json
+++ b/src/main/resources/assets/forge/advancements/recipes/redstone/wooden_pressure_plate.json
@@ -1,0 +1,33 @@
+{
+  "parent": "minecraft:recipes/root",
+  "rewards": {
+    "recipes": [
+      "minecraft:wooden_pressure_plate"
+    ]
+  },
+  "criteria": {
+    "has_the_recipe": {
+      "trigger": "minecraft:recipe_unlocked",
+      "conditions": {
+        "recipe": "wooden_pressure_plate"
+      }
+    },
+    "has_planks": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "type": "forge:ore_dict",
+            "ore": "plankWood"
+          }
+        ]
+      }
+    }
+  },
+  "requirements": [
+    [
+      "has_the_recipe",
+      "has_planks"
+    ]
+  ]
+}

--- a/src/main/resources/assets/forge/advancements/recipes/root.json
+++ b/src/main/resources/assets/forge/advancements/recipes/root.json
@@ -1,0 +1,7 @@
+{
+    "criteria": {
+        "impossible": {
+            "trigger": "minecraft:impossible"
+        }
+    }
+}

--- a/src/main/resources/assets/forge/advancements/recipes/tools/wooden_axe.json
+++ b/src/main/resources/assets/forge/advancements/recipes/tools/wooden_axe.json
@@ -1,0 +1,33 @@
+{
+  "parent": "minecraft:recipes/root",
+  "rewards": {
+    "recipes": [
+      "minecraft:wooden_axe"
+    ]
+  },
+  "criteria": {
+    "has_stick": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "type": "forge:ore_dict",
+            "ore": "stickWood"
+          }
+        ]
+      }
+    },
+    "has_the_recipe": {
+      "trigger": "minecraft:recipe_unlocked",
+      "conditions": {
+        "recipe": "wooden_axe"
+      }
+    }
+  },
+  "requirements": [
+    [
+      "has_stick",
+      "has_the_recipe"
+    ]
+  ]
+}

--- a/src/main/resources/assets/forge/advancements/recipes/tools/wooden_hoe.json
+++ b/src/main/resources/assets/forge/advancements/recipes/tools/wooden_hoe.json
@@ -1,0 +1,33 @@
+{
+  "parent": "minecraft:recipes/root",
+  "rewards": {
+    "recipes": [
+      "minecraft:wooden_hoe"
+    ]
+  },
+  "criteria": {
+    "has_stick": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "type": "forge:ore_dict",
+            "ore": "stickWood"
+          }
+        ]
+      }
+    },
+    "has_the_recipe": {
+      "trigger": "minecraft:recipe_unlocked",
+      "conditions": {
+        "recipe": "wooden_hoe"
+      }
+    }
+  },
+  "requirements": [
+    [
+      "has_stick",
+      "has_the_recipe"
+    ]
+  ]
+}

--- a/src/main/resources/assets/forge/advancements/recipes/tools/wooden_pickaxe.json
+++ b/src/main/resources/assets/forge/advancements/recipes/tools/wooden_pickaxe.json
@@ -1,0 +1,33 @@
+{
+  "parent": "minecraft:recipes/root",
+  "rewards": {
+    "recipes": [
+      "minecraft:wooden_pickaxe"
+    ]
+  },
+  "criteria": {
+    "has_stick": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "type": "forge:ore_dict",
+            "ore": "stickWood"
+          }
+        ]
+      }
+    },
+    "has_the_recipe": {
+      "trigger": "minecraft:recipe_unlocked",
+      "conditions": {
+        "recipe": "wooden_pickaxe"
+      }
+    }
+  },
+  "requirements": [
+    [
+      "has_stick",
+      "has_the_recipe"
+    ]
+  ]
+}

--- a/src/main/resources/assets/forge/advancements/recipes/tools/wooden_shovel.json
+++ b/src/main/resources/assets/forge/advancements/recipes/tools/wooden_shovel.json
@@ -1,0 +1,33 @@
+{
+  "parent": "minecraft:recipes/root",
+  "rewards": {
+    "recipes": [
+      "minecraft:wooden_shovel"
+    ]
+  },
+  "criteria": {
+    "has_stick": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "type": "forge:ore_dict",
+            "ore": "stickWood"
+          }
+        ]
+      }
+    },
+    "has_the_recipe": {
+      "trigger": "minecraft:recipe_unlocked",
+      "conditions": {
+        "recipe": "wooden_shovel"
+      }
+    }
+  },
+  "requirements": [
+    [
+      "has_stick",
+      "has_the_recipe"
+    ]
+  ]
+}


### PR DESCRIPTION
This PR overwrites some Vanilla advancements so that the ore dictionary entries are used for speicifc criteria. Currently the following advancements have been modified (devided by category):
This will resolve #4341.

## Changes made
### Combat
- Wooden Sword. Now uses `stickWood` instead of `stick`.
### Decorations
- Crafting Table. Now uses `plankWood` instead of `planks`.
- Ladder. Now uses `stickWood` instead of `stick`.
- Sign. Now uses `plankWood` instead of `planks`.
### Misc
- Stick. Now uses `plankWood` instead of `planks`.
### Redstone
- Trapdoor. Now uses `plankWood` instead of `planks`.
- Wooden Button. Now uses `plankWood` instead of `planks`.
- Wooden Pressure Plate. Now uses `plankWood` instead of `planks`.
### Tools
- Wooden Axe. Now uses `stickWood` instead of `stick`.
- Wooden Hoe. Now uses `stickWood` instead of `stick`.
- Wooden Pickaxe. Now uses `stickWood` instead of `stick`.
- Wooden Shovel. Now uses `stickWood` instead of `stick`.


I have found some other advancements that I didn't want to change before discussing them here:


## Potential Changes
### Brewing
- Glass Bottle. Uses `glass` as condition. Not sure if it is a good idea to change this to the ore dictionary entry for `glass panes`.
- Golden Carrot. Uses `gold_nugget` as condition. Might consider using `nuggetGold`. But to be honest, I do not know any mod that lets you craft the carrot with other gold ingots except vanilla ones. 
### Decorations
- Glass Pane. Uses `glass`. Changing the condition to use the ore dictionary entry might be a good idea (`blockGlass`). This would trigger the advancement if the player mines/finds colored glass too.
### Misc
- Beacon. Uses `nether_star`. The nether star has an ore dictionary entry called `netherStar`. Maybe use this one...?
- Book. Uses `paper`. Paper has an ore dictionary named `paper`. Not sure if other mods allow book crafting with custom paper but I think this change would be good. 
### Redstone
- Wooden Door. Is this the default oak wood door? Not sure though. The metadata looks to be zero though.


If you want an entry change for the above items listed under the potential changes category, just make annotation in the corresponding source file that I pushed to the branch. I'll update them accordingly. 
If I missed an advancement, let me know. I'll add it to the repo then.