### PR TITLE
Fix multi-part model inventory rendering

### DIFF
--- a/src/main/java/net/minecraftforge/client/model/BlockStateLoader.java
+++ b/src/main/java/net/minecraftforge/client/model/BlockStateLoader.java
@@ -200,10 +200,6 @@ public class BlockStateLoader
                     return base;
             }
 
-            // Apply rotation of base model to sub-models.
-            // If baseRot is non-null, then that rotation will be applied instead of the base model's rotation.
-            // This is used to allow replacing base model with a sub-model when there is no base model for a variant.
-            IModelState baseTr = getState();
             ImmutableMap.Builder<String, Pair<IModel, IModelState>> models = ImmutableMap.builder();
             for (Entry<String, SubModel> entry : parts.entrySet())
             {
@@ -224,7 +220,7 @@ public class BlockStateLoader
                 models.put(entry.getKey(), Pair.of(runModelHooks(model, part.smooth, part.gui3d, part.uvLock, part.getTextures(), part.getCustomData()), part.getState()));
             }
 
-            return new MultiModel(getModelLocation(), hasBase ? base : null, baseTr, models.build());
+            return new MultiModel(getModelLocation(), hasBase ? base : null, models.build());
         }
 
         @Override

--- a/src/main/java/net/minecraftforge/client/model/MultiModel.java
+++ b/src/main/java/net/minecraftforge/client/model/MultiModel.java
@@ -227,20 +227,32 @@ public final class MultiModel implements IModel
     private final ResourceLocation location;
     @Nullable
     private final IModel base;
-    private final IModelState baseState;
     private final Map<String, Pair<IModel, IModelState>> parts;
 
+    // TODO 1.13 remove, kept for binary compatibility
+    @Deprecated
     public MultiModel(ResourceLocation location, @Nullable IModel base, IModelState baseState, ImmutableMap<String, Pair<IModel, IModelState>> parts)
+    {
+        this(location, base, parts);
+    }
+
+    public MultiModel(ResourceLocation location, @Nullable IModel base, ImmutableMap<String, Pair<IModel, IModelState>> parts)
     {
         this.location = location;
         this.base = base;
-        this.baseState = baseState;
         this.parts = parts;
     }
 
+    // TODO 1.13 remove, kept for binary compatibility
+    @Deprecated
     public MultiModel(ResourceLocation location, IModel base, IModelState baseState, Map<String, Pair<IModel, IModelState>> parts)
     {
-        this(location, base, baseState, ImmutableMap.copyOf(parts));
+        this(location, base, parts);
+    }
+
+    public MultiModel(ResourceLocation location, IModel base, Map<String, Pair<IModel, IModelState>> parts)
+    {
+        this(location, base, ImmutableMap.copyOf(parts));
     }
 
     @Override
@@ -294,11 +306,5 @@ public final class MultiModel implements IModel
             return missing.bake(missing.getDefaultState(), format, bakedTextureGetter);
         }
         return new Baked(location, true, bakedBase, mapBuilder.build());
-    }
-
-    @Override
-    public IModelState getDefaultState()
-    {
-        return baseState;
     }
 }


### PR DESCRIPTION
After #4268 multi-part models (ones with `submodels` entry in blockstate) are rendered with transformation applied twice. This can be observed for example with test models from animation debug mod (spinning engine-thing) - in inventory it's smaller than expected and rotated at weird angle. 

Variant state (defined in `transform` in JSON) currently is passed to model [here](https://github.com/MinecraftForge/MinecraftForge/blob/cfbcfeaf4b5d55d5fd1af70b84139ff0d205a9b8/src/main/java/net/minecraftforge/client/model/BlockStateLoader.java#L206) (comment is invalid, state is applied to sub-models much later, during baking) and later used as `IModel.getDefaultState` return, but is also applied [here](https://github.com/MinecraftForge/MinecraftForge/blob/cfbcfeaf4b5d55d5fd1af70b84139ff0d205a9b8/src/main/java/net/minecraftforge/client/model/ModelLoader.java#L677) - directly from variant.

Since other custom models don't know about variant transform, I'm removing that information from `MultiModel` and keep it applied during `WeightedRandomModel` construction - that way transform is applied to all models.

Other models (custom or vanilla) are unaffected, since they pass through `ForgeVariant.process` unaffected (see [here](https://github.com/MinecraftForge/MinecraftForge/blob/cfbcfeaf4b5d55d5fd1af70b84139ff0d205a9b8/src/main/java/net/minecraftforge/client/model/BlockStateLoader.java#L199)).

