### PR TITLE
WIP / Request for comments: Player extra equipment slots API

### DIFF
--- a/src/main/java/net/minecraftforge/common/ForgeModContainer.java
+++ b/src/main/java/net/minecraftforge/common/ForgeModContainer.java
@@ -31,10 +31,10 @@ import java.security.cert.Certificate;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 
+import net.minecraftforge.items.customslots.CapabilityExtensionSlotItem;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -462,6 +462,7 @@ public class ForgeModContainer extends DummyModContainer implements WorldAccessC
         CapabilityFluidHandler.register();
         CapabilityAnimation.register();
         CapabilityEnergy.register();
+        CapabilityExtensionSlotItem.register();
         MinecraftForge.EVENT_BUS.register(MinecraftForge.INTERNAL_HANDLER);
         ForgeChunkManager.captureConfig(evt.getModConfigurationDirectory());
         MinecraftForge.EVENT_BUS.register(this);

--- a/src/main/java/net/minecraftforge/common/ForgeModContainer.java
+++ b/src/main/java/net/minecraftforge/common/ForgeModContainer.java
@@ -35,6 +35,8 @@ import java.util.List;
 import java.util.Map;
 
 import net.minecraftforge.items.customslots.CapabilityExtensionSlotItem;
+import net.minecraftforge.items.customslots.ExtensionSlotContainer;
+import net.minecraftforge.items.customslots.VanillaEquipment;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -463,6 +465,8 @@ public class ForgeModContainer extends DummyModContainer implements WorldAccessC
         CapabilityAnimation.register();
         CapabilityEnergy.register();
         CapabilityExtensionSlotItem.register();
+        ExtensionSlotContainer.register();
+        VanillaEquipment.register();
         MinecraftForge.EVENT_BUS.register(MinecraftForge.INTERNAL_HANDLER);
         ForgeChunkManager.captureConfig(evt.getModConfigurationDirectory());
         MinecraftForge.EVENT_BUS.register(this);

--- a/src/main/java/net/minecraftforge/items/customslots/CapabilityExtensionSlotItem.java
+++ b/src/main/java/net/minecraftforge/items/customslots/CapabilityExtensionSlotItem.java
@@ -1,0 +1,73 @@
+/*
+ * Minecraft Forge
+ * Copyright (c) 2017.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation version 2.1
+ * of the License.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+package net.minecraftforge.items.customslots;
+
+import com.google.common.collect.ImmutableSet;
+import net.minecraft.nbt.NBTBase;
+import net.minecraft.util.EnumFacing;
+import net.minecraft.util.ResourceLocation;
+import net.minecraftforge.common.capabilities.Capability;
+import net.minecraftforge.common.capabilities.CapabilityInject;
+import net.minecraftforge.common.capabilities.CapabilityManager;
+
+import javax.annotation.Nullable;
+
+/**
+ * To be exposed by items
+ */
+public class CapabilityExtensionSlotItem
+{
+    // Special slot IDs
+    public static final ResourceLocation ANY_SLOT = new ResourceLocation("forge:any");
+    public static final ImmutableSet<ResourceLocation> ANY_SLOT_SET = ImmutableSet.of(ANY_SLOT);
+
+    // The Capability
+    @CapabilityInject(IExtensionSlotItem.class)
+    public static Capability<IExtensionSlotItem> INSTANCE = null;
+
+    public static void register()
+    {
+        CapabilityManager.INSTANCE.register(IExtensionSlotItem.class, new Storage(), DefaultImplementation::new);
+    }
+
+    // Dummy storage -- there is nothing to save for this capability
+    static class Storage implements Capability.IStorage<IExtensionSlotItem>
+    {
+
+        @Nullable
+        @Override
+        public NBTBase writeNBT(Capability<IExtensionSlotItem> capability, IExtensionSlotItem instance, EnumFacing side)
+        {
+            return null;
+        }
+
+        @Override
+        public void readNBT(Capability<IExtensionSlotItem> capability, IExtensionSlotItem instance, EnumFacing side, NBTBase nbt)
+        {
+
+        }
+    }
+
+    // Dummy default instance -- the interface provides all the boilerplate as default methods
+    private static class DefaultImplementation implements IExtensionSlotItem
+    {
+    }
+}
+

--- a/src/main/java/net/minecraftforge/items/customslots/ExtensionSlotContainer.java
+++ b/src/main/java/net/minecraftforge/items/customslots/ExtensionSlotContainer.java
@@ -1,0 +1,268 @@
+/*
+ * Minecraft Forge
+ * Copyright (c) 2017.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation version 2.1
+ * of the License.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+package net.minecraftforge.items.customslots;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Maps;
+import net.minecraft.entity.Entity;
+import net.minecraft.entity.EntityLivingBase;
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.nbt.NBTBase;
+import net.minecraft.nbt.NBTTagCompound;
+import net.minecraft.util.EnumFacing;
+import net.minecraft.util.ResourceLocation;
+import net.minecraftforge.common.MinecraftForge;
+import net.minecraftforge.common.capabilities.Capability;
+import net.minecraftforge.common.capabilities.CapabilityInject;
+import net.minecraftforge.common.capabilities.CapabilityManager;
+import net.minecraftforge.common.capabilities.ICapabilitySerializable;
+import net.minecraftforge.common.util.INBTSerializable;
+import net.minecraftforge.event.AttachCapabilitiesEvent;
+import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
+import net.minecraftforge.fml.common.gameevent.TickEvent;
+import org.apache.commons.lang3.tuple.Pair;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.util.Map;
+import java.util.function.BiFunction;
+import java.util.function.Supplier;
+
+/**
+ * Provides a way for mods to register equipment slots, and share them with other mods.
+ * <p>
+ * This class also manages storage for the slots (can be opted out).
+ */
+public class ExtensionSlotContainer implements IExtensionContainer, INBTSerializable<NBTTagCompound>
+{
+    ////////////////////////////////////////////////////////////
+    // Global slot registry
+    //
+
+    public interface SlotFactory extends BiFunction<EntityLivingBase, IExtensionContainer, IExtensionSlot>
+    {
+    }
+
+    public static class SlotEntry
+    {
+        final String id;
+        final SlotFactory factory;
+
+        public SlotEntry(String id, SlotFactory factory)
+        {
+            this.id = id;
+            this.factory = factory;
+        }
+    }
+
+    private static final Map<String, SlotEntry> REGISTRY = Maps.newHashMap();
+
+    /**
+     * Obtains a previously-registered slot.
+     *
+     * @param id The id of the slot.
+     * @return A functional interface that can be used to create new slots
+     */
+    @Nullable
+    public static SlotFactory get(String id)
+    {
+        return REGISTRY.get(id).factory;
+    }
+
+    /**
+     * Registers a slot with a given id. If it already exists, it does nothing.
+     *
+     * @param id      Id to register with
+     * @param factory An extension slot factory to use by the FlexibleExtensionContainer
+     * @return
+     */
+    public static boolean tryRegister(String id, SlotFactory factory)
+    {
+        if (REGISTRY.containsKey(id))
+            return false;
+
+        REGISTRY.put(id, new SlotEntry(id, factory));
+        return true;
+    }
+
+    ////////////////////////////////////////////////////////////
+    // Capability support code
+    //
+
+    private static final ResourceLocation CAPABILITY_ID = new ResourceLocation("forge", "extra_slots");
+
+    @CapabilityInject(ExtensionSlotContainer.class)
+    public static Capability<ExtensionSlotContainer> CAPABILITY = null;
+
+    public static void register()
+    {
+        // Internal capability, IStorage and default instances are meaningless.
+        CapabilityManager.INSTANCE.register(ExtensionSlotContainer.class, new Capability.IStorage<ExtensionSlotContainer>()
+        {
+            @Nullable
+            @Override
+            public NBTBase writeNBT(Capability<ExtensionSlotContainer> capability, ExtensionSlotContainer instance, EnumFacing side)
+            {
+                return null;
+            }
+
+            @Override
+            public void readNBT(Capability<ExtensionSlotContainer> capability, ExtensionSlotContainer instance, EnumFacing side, NBTBase nbt)
+            {
+
+            }
+        }, () -> null);
+
+        MinecraftForge.EVENT_BUS.register(new EventHandlers());
+    }
+
+    public static ExtensionSlotContainer get(EntityLivingBase player)
+    {
+        return player.getCapability(CAPABILITY, null);
+    }
+
+    static class EventHandlers
+    {
+        @SubscribeEvent
+        public void attachCapabilities(AttachCapabilitiesEvent<Entity> event)
+        {
+            if (!(event.getObject() instanceof EntityPlayer))
+                return;
+
+            event.addCapability(CAPABILITY_ID, new ICapabilitySerializable<NBTTagCompound>()
+            {
+                final ExtensionSlotContainer extensionContainer = new ExtensionSlotContainer((EntityPlayer) event.getObject(), REGISTRY);
+
+                @Override
+                public NBTTagCompound serializeNBT()
+                {
+                    return extensionContainer.serializeNBT();
+                }
+
+                @Override
+                public void deserializeNBT(NBTTagCompound nbt)
+                {
+                    extensionContainer.deserializeNBT(nbt);
+                }
+
+                @Override
+                public boolean hasCapability(@Nonnull Capability<?> capability, @Nullable EnumFacing facing)
+                {
+                    if (capability == CAPABILITY)
+                        return true;
+                    return false;
+                }
+
+                @Nullable
+                @SuppressWarnings("unchecked")
+                @Override
+                public <T> T getCapability(@Nonnull Capability<T> capability, @Nullable EnumFacing facing)
+                {
+                    if (capability == CAPABILITY)
+                        return (T) extensionContainer;
+                    return null;
+                }
+            });
+        }
+
+        @SubscribeEvent
+        public void entityTick(TickEvent.PlayerTickEvent event)
+        {
+            ExtensionSlotContainer instance = get(event.player);
+            if (instance == null) return;
+            instance.tickAllSlots();
+        }
+    }
+
+    ////////////////////////////////////////////////////////////
+    // Equipment container implementation
+    //
+
+    private final EntityLivingBase owner;
+    private final ImmutableMap<String, IExtensionSlot> slotsMap;
+    private final ImmutableList<IExtensionSlot> slots;
+
+    private ExtensionSlotContainer(EntityLivingBase owner, Map<String, SlotEntry> slotEntries)
+    {
+        this.owner = owner;
+        this.slotsMap = slotEntries.entrySet().stream()
+                .map((e) -> Pair.of(e.getKey(), e.getValue().factory.apply(owner, this)))
+                .collect(ImmutableMap.toImmutableMap(Pair::getKey, Pair::getValue));
+        this.slots = ImmutableList.copyOf(this.slotsMap.values());
+    }
+
+    @Nonnull
+    @Override
+    public EntityLivingBase getOwner()
+    {
+        return owner;
+    }
+
+    @Nonnull
+    @Override
+    public ImmutableList<IExtensionSlot> getSlots()
+    {
+        return slots;
+    }
+
+    @Nullable
+    @Override
+    public IExtensionSlot getSlot(String slotId)
+    {
+        return slotsMap.get(slotId);
+    }
+
+    private void tickAllSlots()
+    {
+        for (IExtensionSlot slot : slots)
+        {
+            slot.onWornTick();
+        }
+    }
+
+    @Override
+    public NBTTagCompound serializeNBT()
+    {
+        NBTTagCompound nbt = new NBTTagCompound();
+        for (Map.Entry<String, IExtensionSlot> entry : slotsMap.entrySet())
+        {
+            String id = entry.getKey();
+            IExtensionSlot slot = entry.getValue();
+            if (slot.skipStorage()) continue;
+            nbt.setTag(id.toString(), slot.serializeNBT());
+        }
+        return nbt;
+    }
+
+    @Override
+    public void deserializeNBT(NBTTagCompound nbt)
+    {
+        for (Map.Entry<String, IExtensionSlot> entry : slotsMap.entrySet())
+        {
+            String id = entry.getKey();
+            IExtensionSlot slot = entry.getValue();
+            if (slot.skipStorage()) continue;
+            NBTTagCompound tag = nbt.getCompoundTag(id.toString());
+            if (tag != null)
+                slot.deserializeNBT(tag);
+        }
+    }
+}

--- a/src/main/java/net/minecraftforge/items/customslots/ExtensionSlotItemHandler.java
+++ b/src/main/java/net/minecraftforge/items/customslots/ExtensionSlotItemHandler.java
@@ -23,20 +23,20 @@ import net.minecraft.item.ItemStack;
 import net.minecraft.util.ResourceLocation;
 import net.minecraftforge.items.IItemHandlerModifiable;
 
-import javax.annotation.Nonnull;
-
 public class ExtensionSlotItemHandler implements IExtensionSlot
 {
-    private final ResourceLocation slotType;
+    private final String id;
+    private String slotType;
 
     protected final IExtensionContainer owner;
     protected final IItemHandlerModifiable inventory;
     protected final int slot;
 
-    public ExtensionSlotItemHandler(IExtensionContainer owner, ResourceLocation slotType, IItemHandlerModifiable inventory, int slot)
+    public ExtensionSlotItemHandler(IExtensionContainer owner, String id, IItemHandlerModifiable inventory, int slot)
     {
         this.owner = owner;
-        this.slotType = slotType;
+        this.id = id;
+        this.slotType = id; // Call setType to change from default!
         this.inventory = inventory;
         this.slot = slot;
     }
@@ -48,9 +48,21 @@ public class ExtensionSlotItemHandler implements IExtensionSlot
     }
 
     @Override
-    public ResourceLocation getType()
+    public String getId()
+    {
+        return id;
+    }
+
+    @Override
+    public String getType()
     {
         return slotType;
+    }
+
+    public ExtensionSlotItemHandler setType(String typeId)
+    {
+        this.slotType = typeId;
+        return this;
     }
 
     /**
@@ -95,19 +107,5 @@ public class ExtensionSlotItemHandler implements IExtensionSlot
         if (extItem == null)
             return;
         extItem.onUnequipped(stack, this);
-    }
-
-    /**
-     * Calls the tick handler for the contained item.
-     */
-    public void onWornTick()
-    {
-        ItemStack stack = getContents();
-        if (stack.isEmpty())
-            return;
-        IExtensionSlotItem extItem = stack.getCapability(CapabilityExtensionSlotItem.INSTANCE, null);
-        if (extItem == null)
-            return;
-        extItem.onWornTick(stack, this);
     }
 }

--- a/src/main/java/net/minecraftforge/items/customslots/ExtensionSlotItemHandler.java
+++ b/src/main/java/net/minecraftforge/items/customslots/ExtensionSlotItemHandler.java
@@ -1,0 +1,113 @@
+/*
+ * Minecraft Forge
+ * Copyright (c) 2017.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation version 2.1
+ * of the License.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+package net.minecraftforge.items.customslots;
+
+import net.minecraft.item.ItemStack;
+import net.minecraft.util.ResourceLocation;
+import net.minecraftforge.items.IItemHandlerModifiable;
+
+import javax.annotation.Nonnull;
+
+public class ExtensionSlotItemHandler implements IExtensionSlot
+{
+    private final ResourceLocation slotType;
+
+    protected final IExtensionContainer owner;
+    protected final IItemHandlerModifiable inventory;
+    protected final int slot;
+
+    public ExtensionSlotItemHandler(IExtensionContainer owner, ResourceLocation slotType, IItemHandlerModifiable inventory, int slot)
+    {
+        this.owner = owner;
+        this.slotType = slotType;
+        this.inventory = inventory;
+        this.slot = slot;
+    }
+
+    @Override
+    public IExtensionContainer getContainer()
+    {
+        return owner;
+    }
+
+    @Override
+    public ResourceLocation getType()
+    {
+        return slotType;
+    }
+
+    /**
+     * Gets the contents of the slot. The stack is *NOT* required to be of an IExtensionSlotItem!
+     *
+     * @return The contained stack
+     */
+    @Override
+    public ItemStack getContents()
+    {
+        return inventory.getStackInSlot(slot);
+    }
+
+    /**
+     * Sets the contents of the slot. The stack is *NOT* required to be of an IExtensionSlotItem!
+     *
+     * @param stack The stack to be assigned to the slot
+     */
+    @Override
+    public void setContents(ItemStack stack)
+    {
+        ItemStack oldStack = getContents();
+        if (oldStack == stack) return;
+        if (!oldStack.isEmpty())
+            notifyUnequip(oldStack);
+        inventory.setStackInSlot(slot, stack);
+        if (!stack.isEmpty())
+            notifyEquip(stack);
+    }
+
+    private void notifyEquip(ItemStack stack)
+    {
+        IExtensionSlotItem extItem = stack.getCapability(CapabilityExtensionSlotItem.INSTANCE, null);
+        if (extItem == null)
+            return;
+        extItem.onEquipped(stack, this);
+    }
+
+    private void notifyUnequip(ItemStack stack)
+    {
+        IExtensionSlotItem extItem = stack.getCapability(CapabilityExtensionSlotItem.INSTANCE, null);
+        if (extItem == null)
+            return;
+        extItem.onUnequipped(stack, this);
+    }
+
+    /**
+     * Calls the tick handler for the contained item.
+     */
+    public void onWornTick()
+    {
+        ItemStack stack = getContents();
+        if (stack.isEmpty())
+            return;
+        IExtensionSlotItem extItem = stack.getCapability(CapabilityExtensionSlotItem.INSTANCE, null);
+        if (extItem == null)
+            return;
+        extItem.onWornTick(stack, this);
+    }
+}

--- a/src/main/java/net/minecraftforge/items/customslots/IExtensionContainer.java
+++ b/src/main/java/net/minecraftforge/items/customslots/IExtensionContainer.java
@@ -21,8 +21,9 @@ package net.minecraftforge.items.customslots;
 
 import com.google.common.collect.ImmutableList;
 import net.minecraft.entity.EntityLivingBase;
+import net.minecraft.util.ResourceLocation;
 
-import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 
 /**
  * Gives access to information about a provider of extension slots.
@@ -42,4 +43,13 @@ public interface IExtensionContainer
      * @return The list of extension slots
      */
     ImmutableList<IExtensionSlot> getSlots();
+
+    /**
+     * Gets a slot by its unique id.
+     *
+     * @param slotId A resource location identifying the slot within this container.
+     * @return The slot matching the requested id.
+     */
+    @Nullable
+    IExtensionSlot getSlot(String slotId);
 }

--- a/src/main/java/net/minecraftforge/items/customslots/IExtensionContainer.java
+++ b/src/main/java/net/minecraftforge/items/customslots/IExtensionContainer.java
@@ -1,0 +1,45 @@
+/*
+ * Minecraft Forge
+ * Copyright (c) 2017.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation version 2.1
+ * of the License.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+package net.minecraftforge.items.customslots;
+
+import com.google.common.collect.ImmutableList;
+import net.minecraft.entity.EntityLivingBase;
+
+import javax.annotation.Nonnull;
+
+/**
+ * Gives access to information about a provider of extension slots.
+ */
+public interface IExtensionContainer
+{
+    /**
+     * Gets the entity this container is extending
+     *
+     * @return The living entity
+     */
+    EntityLivingBase getOwner();
+
+    /**
+     * Gets the list of slots contained within this extension
+     *
+     * @return The list of extension slots
+     */
+    ImmutableList<IExtensionSlot> getSlots();
+}

--- a/src/main/java/net/minecraftforge/items/customslots/IExtensionSlot.java
+++ b/src/main/java/net/minecraftforge/items/customslots/IExtensionSlot.java
@@ -1,0 +1,103 @@
+/*
+ * Minecraft Forge
+ * Copyright (c) 2017.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation version 2.1
+ * of the License.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+package net.minecraftforge.items.customslots;
+
+import com.google.common.collect.ImmutableSet;
+import net.minecraft.enchantment.EnchantmentHelper;
+import net.minecraft.init.Enchantments;
+import net.minecraft.item.ItemStack;
+import net.minecraft.util.ResourceLocation;
+
+import javax.annotation.Nonnull;
+
+/**
+ * Describes an extension slot and its contents.
+ */
+public interface IExtensionSlot
+{
+    /**
+     * Gets the container that is managing this slot.
+     *
+     * @return The owning container.
+     */
+    IExtensionContainer getContainer();
+
+    /**
+     * Gets the slot type identifier for this slot.
+     *
+     * @return The resource name serving as a namespaced identifier
+     */
+    ResourceLocation getType();
+
+    /**
+     * Gets the contents of the slot. The stack is *NOT* required to be of an IExtensionSlotItem!
+     *
+     * @return The contained stack
+     */
+    ItemStack getContents();
+
+    /**
+     * Sets the contents of the slot. The stack is *NOT* required to be of an IExtensionSlotItem!
+     *
+     * @param stack The stack to be assigned to the slot
+     */
+    void setContents(ItemStack stack);
+
+    // Permissions
+
+    /**
+     * Queries whether or not the stack can be placed in this slot.
+     *
+     * @param stack The ItemStack in the slot.
+     */
+    default boolean canEquip(ItemStack stack)
+    {
+        IExtensionSlotItem extItem = stack.getCapability(CapabilityExtensionSlotItem.INSTANCE, null);
+        return extItem != null
+                && IExtensionSlot.isAcceptableSlot(this, extItem, stack)
+                && extItem.canEquip(stack, this);
+    }
+
+    /**
+     * Queries whether or not the stack can be removed from this slot.
+     *
+     * @param stack The ItemStack in the slot.
+     */
+    default boolean canUnequip(ItemStack stack)
+    {
+        IExtensionSlotItem extItem = stack.getCapability(CapabilityExtensionSlotItem.INSTANCE, null);
+        return (extItem == null || extItem.canUnequip(stack, this))
+                && EnchantmentHelper.getEnchantmentLevel(Enchantments.BINDING_CURSE, stack) <= 0;
+    }
+
+    /**
+     * Helper method to decide if a slot should accept a certain item
+     *
+     * @param slot The slot we are testing
+     * @param extItem The extension item representing the stack
+     * @param stack The stack being tested
+     * @return True if the item acceptable slots contains the slot id, or the ANY id.
+     */
+    static boolean isAcceptableSlot(IExtensionSlot slot, IExtensionSlotItem extItem, ItemStack stack)
+    {
+        ImmutableSet<ResourceLocation> slots = extItem.getAcceptableSlots(stack);
+        return slots.contains(CapabilityExtensionSlotItem.ANY_SLOT) || slots.contains(slot.getType());
+    }
+}

--- a/src/main/java/net/minecraftforge/items/customslots/IExtensionSlotItem.java
+++ b/src/main/java/net/minecraftforge/items/customslots/IExtensionSlotItem.java
@@ -25,8 +25,6 @@ import net.minecraft.init.Enchantments;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.ResourceLocation;
 
-import javax.annotation.Nonnull;
-
 /**
  * Exposed as a CAPABILITY by items that want to be accepted in special equipment slots, and optionally to provide
  * custom processing for insertion, ticking, etc.
@@ -37,8 +35,11 @@ public interface IExtensionSlotItem
      * Returns the list of slot IDs for extension containers. "forge:any" should be accepted by all extension containers
      * and is the default return type. Should be used by extension containers to test for equipability, and to display
      * in tooltips.
+     * <p>
+     * Ideally, the value would be stored in a field somewhere, and only returned here
+     * <p>
      * Example:
-     * return ImmutableList.of(new ResourceLocation("baubles:belt"), new ResourceLocation("toolbelt:pocket"))
+     * ImmutableSet.of(new ResourceLocation("baubles:belt"), new ResourceLocation("toolbelt:pocket"));
      *
      * @param stack The ItemStack for which the acceptable slots are being requested.
      * @return An immutable list with the ResourceLocations of the slots.
@@ -92,11 +93,13 @@ public interface IExtensionSlotItem
     /**
      * Queries whether or not the stack can be removed from the slot.
      *
+     * Curse of Binding is handled by the slot, so it is not needed here.
+     *
      * @param stack The ItemStack in the slot.
      * @param slot  The slot being referenced.
      */
     default boolean canUnequip(ItemStack stack, IExtensionSlot slot)
     {
-        return EnchantmentHelper.getEnchantmentLevel(Enchantments.BINDING_CURSE, stack) <= 0;
+        return true;
     }
 }

--- a/src/main/java/net/minecraftforge/items/customslots/IExtensionSlotItem.java
+++ b/src/main/java/net/minecraftforge/items/customslots/IExtensionSlotItem.java
@@ -1,0 +1,102 @@
+/*
+ * Minecraft Forge
+ * Copyright (c) 2017.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation version 2.1
+ * of the License.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+package net.minecraftforge.items.customslots;
+
+import com.google.common.collect.ImmutableSet;
+import net.minecraft.enchantment.EnchantmentHelper;
+import net.minecraft.init.Enchantments;
+import net.minecraft.item.ItemStack;
+import net.minecraft.util.ResourceLocation;
+
+import javax.annotation.Nonnull;
+
+/**
+ * Exposed as a CAPABILITY by items that want to be accepted in special equipment slots, and optionally to provide
+ * custom processing for insertion, ticking, etc.
+ */
+public interface IExtensionSlotItem
+{
+    /**
+     * Returns the list of slot IDs for extension containers. "forge:any" should be accepted by all extension containers
+     * and is the default return type. Should be used by extension containers to test for equipability, and to display
+     * in tooltips.
+     * Example:
+     * return ImmutableList.of(new ResourceLocation("baubles:belt"), new ResourceLocation("toolbelt:pocket"))
+     *
+     * @param stack The ItemStack for which the acceptable slots are being requested.
+     * @return An immutable list with the ResourceLocations of the slots.
+     */
+    default ImmutableSet<ResourceLocation> getAcceptableSlots(ItemStack stack)
+    {
+        return CapabilityExtensionSlotItem.ANY_SLOT_SET;
+    }
+
+    /**
+     * Runs once per tick for as long as the item remains equipped in the given slot.
+     *
+     * @param stack The ItemStack in the slot.
+     * @param slot  The slot being referenced.
+     */
+    default void onWornTick(ItemStack stack, IExtensionSlot slot)
+    {
+    }
+
+    /**
+     * Called when the item is equipped to an extension slot.
+     *
+     * @param stack The ItemStack in the slot.
+     * @param slot  The slot being referenced.
+     */
+    default void onEquipped(ItemStack stack, IExtensionSlot slot)
+    {
+    }
+
+    /**
+     * Called when the item is removed from an extension slot.
+     *
+     * @param stack The ItemStack in the slot.
+     * @param slot  The slot being referenced.
+     */
+    default void onUnequipped(ItemStack stack, IExtensionSlot slot)
+    {
+    }
+
+    /**
+     * Queries whether or not the stack can be placed in the slot.
+     *
+     * @param stack The ItemStack in the slot.
+     * @param slot  The slot being referenced.
+     */
+    default boolean canEquip(ItemStack stack, IExtensionSlot slot)
+    {
+        return true;
+    }
+
+    /**
+     * Queries whether or not the stack can be removed from the slot.
+     *
+     * @param stack The ItemStack in the slot.
+     * @param slot  The slot being referenced.
+     */
+    default boolean canUnequip(ItemStack stack, IExtensionSlot slot)
+    {
+        return EnchantmentHelper.getEnchantmentLevel(Enchantments.BINDING_CURSE, stack) <= 0;
+    }
+}

--- a/src/main/java/net/minecraftforge/items/customslots/SlotExtension.java
+++ b/src/main/java/net/minecraftforge/items/customslots/SlotExtension.java
@@ -60,7 +60,6 @@ public class SlotExtension extends Slot
         return slot.getContents();
     }
 
-    // Override if your IItemHandler does not implement IItemHandlerModifiable
     /**
      * Helper method to put a stack in the slot.
      */

--- a/src/main/java/net/minecraftforge/items/customslots/SlotExtension.java
+++ b/src/main/java/net/minecraftforge/items/customslots/SlotExtension.java
@@ -1,0 +1,142 @@
+/*
+ * Minecraft Forge
+ * Copyright (c) 2017.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation version 2.1
+ * of the License.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+package net.minecraftforge.items.customslots;
+
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.inventory.IInventory;
+import net.minecraft.inventory.InventoryBasic;
+import net.minecraft.inventory.Slot;
+import net.minecraft.item.ItemStack;
+
+/**
+ * To be used in Containers.
+ */
+public class SlotExtension extends Slot
+{
+    private static IInventory emptyInventory = new InventoryBasic("[Null]", true, 0);
+    private final IExtensionSlot slot;
+
+    public SlotExtension(IExtensionSlot slot, int x, int y)
+    {
+        super(emptyInventory, 0, x, y);
+        this.slot = slot;
+    }
+
+    /**
+     * Check if the stack is allowed to be placed in this slot, used for armor slots as well as furnace fuel.
+     */
+    @Override
+    public boolean isItemValid(ItemStack stack)
+    {
+        if (stack.isEmpty())
+            return false;
+
+        return slot.canEquip(stack);
+    }
+
+    /**
+     * Helper fnct to get the stack in the slot.
+     */
+    @Override
+    public ItemStack getStack()
+    {
+        return slot.getContents();
+    }
+
+    // Override if your IItemHandler does not implement IItemHandlerModifiable
+    /**
+     * Helper method to put a stack in the slot.
+     */
+    @Override
+    public void putStack(ItemStack stack)
+    {
+        slot.setContents(stack);
+        this.onSlotChanged();
+    }
+
+    /**
+     * if par2 has more items than par1, onCrafting(item,countIncrease) is called
+     */
+    @Override
+    public void onSlotChange(ItemStack p_75220_1_, ItemStack p_75220_2_)
+    {
+
+    }
+
+    /**
+     * Returns the maximum stack size for a given slot (usually the same as getInventoryStackLimit(), but 1 in the case
+     * of armor slots)
+     */
+    @Override
+    public int getSlotStackLimit()
+    {
+        return 1;
+    }
+
+    @Override
+    public int getItemStackLimit(ItemStack stack)
+    {
+        return 1;
+    }
+
+    /**
+     * Return whether this slot's stack can be taken from this slot.
+     */
+    @Override
+    public boolean canTakeStack(EntityPlayer playerIn)
+    {
+        return slot.canUnequip(slot.getContents());
+    }
+
+    /**
+     * Decrease the size of the stack in slot (first int arg) by the amount of the second int arg. Returns the new
+     * stack.
+     */
+    @Override
+    public ItemStack decrStackSize(int amount)
+    {
+        ItemStack itemstack = slot.getContents();
+
+        int available = Math.min(itemstack.getCount(), amount);
+        int remaining = itemstack.getCount() - available;
+
+        ItemStack split = itemstack.copy();
+        split.setCount(available);
+        itemstack.setCount(remaining);
+
+        if (remaining <= 0)
+            slot.setContents(ItemStack.EMPTY);
+
+        this.onSlotChanged();
+
+        return split;
+    }
+
+    public IExtensionSlot getExtensionSlot()
+    {
+        return slot;
+    }
+
+    @Override
+    public boolean isSameInventory(Slot other)
+    {
+        return other instanceof SlotExtension && ((SlotExtension) other).getExtensionSlot() == this.slot;
+    }
+}

--- a/src/main/java/net/minecraftforge/items/customslots/VanillaEquipment.java
+++ b/src/main/java/net/minecraftforge/items/customslots/VanillaEquipment.java
@@ -1,0 +1,260 @@
+/*
+ * Minecraft Forge
+ * Copyright (c) 2017.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation version 2.1
+ * of the License.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+package net.minecraftforge.items.customslots;
+
+import com.google.common.collect.ImmutableList;
+import net.minecraft.entity.Entity;
+import net.minecraft.entity.EntityLivingBase;
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.inventory.EntityEquipmentSlot;
+import net.minecraft.item.ItemStack;
+import net.minecraft.nbt.NBTBase;
+import net.minecraft.util.EnumFacing;
+import net.minecraft.util.ResourceLocation;
+import net.minecraftforge.common.MinecraftForge;
+import net.minecraftforge.common.capabilities.Capability;
+import net.minecraftforge.common.capabilities.CapabilityInject;
+import net.minecraftforge.common.capabilities.CapabilityManager;
+import net.minecraftforge.common.capabilities.ICapabilityProvider;
+import net.minecraftforge.event.AttachCapabilitiesEvent;
+import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.util.function.Supplier;
+
+public class VanillaEquipment implements IExtensionContainer
+{
+    public static final String HEAD = EntityEquipmentSlot.HEAD.getName();
+    public static final String CHEST = EntityEquipmentSlot.CHEST.getName();
+    public static final String LEGS = EntityEquipmentSlot.LEGS.getName();
+    public static final String FEET = EntityEquipmentSlot.FEET.getName();
+    public static final String OFFHAND = EntityEquipmentSlot.OFFHAND.getName();
+    public static final String MAINHAND = EntityEquipmentSlot.MAINHAND.getName();
+
+    public static void register()
+    {
+        registerCapability();
+        registerVanillaSlots();
+    }
+
+    ////////////////////////////////////////////////////////////
+    // Capability support code
+    //
+
+    private static final ResourceLocation CAPABILITY_ID = new ResourceLocation("forge", "vanilla_slots");
+
+    @CapabilityInject(VanillaEquipment.class)
+    public static Capability<VanillaEquipment> CAPABILITY = null;
+
+    public static void registerCapability()
+    {
+        // Internal capability, IStorage and default instances are meaningless.
+        CapabilityManager.INSTANCE.register(VanillaEquipment.class, new Capability.IStorage<VanillaEquipment>()
+        {
+            @Nullable
+            @Override
+            public NBTBase writeNBT(Capability<VanillaEquipment> capability, VanillaEquipment instance, EnumFacing side)
+            {
+                return null;
+            }
+
+            @Override
+            public void readNBT(Capability<VanillaEquipment> capability, VanillaEquipment instance, EnumFacing side, NBTBase nbt)
+            {
+
+            }
+        }, () -> null);
+
+        MinecraftForge.EVENT_BUS.register(new VanillaEquipment.EventHandlers());
+    }
+
+    public static VanillaEquipment get(EntityPlayer player)
+    {
+        return player.getCapability(CAPABILITY, null);
+    }
+
+    static class EventHandlers
+    {
+        @SubscribeEvent
+        public void attachCapabilities(AttachCapabilitiesEvent<Entity> event)
+        {
+            if (!(event.getObject() instanceof EntityPlayer))
+                return;
+
+            // No serialization needed
+            event.addCapability(CAPABILITY_ID, new ICapabilityProvider()
+            {
+                final VanillaEquipment extensionContainer = new VanillaEquipment((EntityPlayer) event.getObject());
+
+                @Override
+                public boolean hasCapability(@Nonnull Capability<?> capability, @Nullable EnumFacing facing)
+                {
+                    if (capability == CAPABILITY)
+                        return true;
+                    return false;
+                }
+
+                @Nullable
+                @SuppressWarnings("unchecked")
+                @Override
+                public <T> T getCapability(@Nonnull Capability<T> capability, @Nullable EnumFacing facing)
+                {
+                    if (capability == CAPABILITY)
+                        return (T) extensionContainer;
+                    return null;
+                }
+            });
+        }
+    }
+
+    ////////////////////////////////////////////////////////////
+    // Equipment container implementation
+    //
+
+    static void registerVanillaSlots()
+    {
+        registerVanillaSlot(HEAD, EntityEquipmentSlot.HEAD);
+        registerVanillaSlot(CHEST, EntityEquipmentSlot.CHEST);
+        registerVanillaSlot(LEGS, EntityEquipmentSlot.LEGS);
+        registerVanillaSlot(FEET, EntityEquipmentSlot.FEET);
+        registerVanillaSlot(OFFHAND, EntityEquipmentSlot.OFFHAND);
+        registerVanillaSlot(MAINHAND, EntityEquipmentSlot.MAINHAND);
+    }
+
+    private static void registerVanillaSlot(final String slot, final EntityEquipmentSlot source)
+    {
+        ExtensionSlotContainer.tryRegister(slot,
+                (entity, container) -> new Slot(container, slot, source));
+    }
+
+    private final EntityLivingBase owner;
+    private ImmutableList<IExtensionSlot> slots = null;
+
+    public VanillaEquipment(EntityLivingBase owner)
+    {
+        this.owner = owner;
+
+    }
+
+    @Nonnull
+    @Override
+    public ImmutableList<IExtensionSlot> getSlots()
+    {
+        if (slots == null)
+        {
+            IExtensionContainer container = ExtensionSlotContainer.get(owner);
+            this.slots = ImmutableList.of(
+                    container.getSlot(HEAD),
+                    container.getSlot(CHEST),
+                    container.getSlot(LEGS),
+                    container.getSlot(FEET),
+                    container.getSlot(OFFHAND),
+                    container.getSlot(MAINHAND)
+            );
+        }
+        return slots;
+    }
+
+    @Nullable
+    @Override
+    public IExtensionSlot getSlot(String slotId)
+    {
+        // Ensure we have loaded the list from the extension container
+        getSlots();
+        if (HEAD.equals(slotId)) return slots.get(0);
+        if (CHEST.equals(slotId)) return slots.get(1);
+        if (LEGS.equals(slotId)) return slots.get(2);
+        if (FEET.equals(slotId)) return slots.get(3);
+        if (OFFHAND.equals(slotId)) return slots.get(4);
+        if (MAINHAND.equals(slotId)) return slots.get(5);
+        return null;
+    }
+
+    @Nonnull
+    @Override
+    public EntityLivingBase getOwner()
+    {
+        return owner;
+    }
+
+    private static class Slot implements IExtensionSlot
+    {
+        private final String id;
+        private final EntityEquipmentSlot slot;
+        private final IExtensionContainer container;
+
+        private Slot(IExtensionContainer container, String id, EntityEquipmentSlot slot)
+        {
+            this.id = id;
+            this.slot = slot;
+            this.container = container;
+        }
+
+        @Nonnull
+        @Override
+        public IExtensionContainer getContainer()
+        {
+            return container;
+        }
+
+        @Override
+        public String getId()
+        {
+            return id;
+        }
+
+        @Nonnull
+        @Override
+        public String getType()
+        {
+            return id;
+        }
+
+        @Nonnull
+        @Override
+        public ItemStack getContents()
+        {
+            return container.getOwner().getItemStackFromSlot(slot);
+        }
+
+        @Override
+        public void setContents(@Nonnull ItemStack stack)
+        {
+            container.getOwner().setItemStackToSlot(slot, stack);
+        }
+
+        @Override
+        public boolean canEquip(@Nonnull ItemStack stack)
+        {
+            if (stack.getItem().isValidArmor(stack, slot, container.getOwner()))
+                return true;
+            return IExtensionSlot.super.canEquip(stack);
+        }
+
+        // Vanilla equipment slots already do their own saving,
+        // so storing in the FlexibleExtensionContainer is not needed.
+        @Override
+        public boolean skipStorage()
+        {
+            return true;
+        }
+    }
+}

--- a/src/main/java/net/minecraftforge/items/customslots/package-info.java
+++ b/src/main/java/net/minecraftforge/items/customslots/package-info.java
@@ -1,0 +1,7 @@
+@ParametersAreNonnullByDefault
+@MethodsReturnNonnullByDefault
+package net.minecraftforge.items.customslots;
+
+import mcp.MethodsReturnNonnullByDefault;
+
+import javax.annotation.ParametersAreNonnullByDefault;

--- a/src/test/java/net/minecraftforge/debug/ExtensionContainerTest.java
+++ b/src/test/java/net/minecraftforge/debug/ExtensionContainerTest.java
@@ -48,9 +48,12 @@ public class ExtensionContainerTest
     @SubscribeEvent
     public static void registerItems(RegistryEvent.Register<Item> event)
     {
-        event.getRegistry().register(new ExtensionSlotItemTest()
-                .setRegistryName("slot_item_test").setUnlocalizedName("forge.slot_item_test")
-                .setMaxStackSize(1).setMaxDamage(50).setCreativeTab(CreativeTabs.MISC));
+        if (ENABLED)
+        {
+            event.getRegistry().register(new ExtensionSlotItemTest()
+                    .setRegistryName("slot_item_test").setUnlocalizedName("forge.slot_item_test")
+                    .setMaxStackSize(1).setMaxDamage(50).setCreativeTab(CreativeTabs.MISC));
+        }
     }
 
     public static class ExtensionSlotItemTest extends Item implements IExtensionSlotItem
@@ -89,11 +92,7 @@ public class ExtensionContainerTest
         @Override
         public void onEquipped(@Nonnull ItemStack stack, @Nonnull IExtensionSlot slot)
         {
-            if (!onWornTick_received)
-            {
-                logger.debug("onWornTick Received!");
-                onWornTick_received = true;
-            }
+            logger.debug("onEquipped Received!");
         }
 
         @Override
@@ -235,19 +234,23 @@ public class ExtensionContainerTest
         // Equipment container implementation
         //
 
-        public static final ResourceLocation RING = new ResourceLocation("forge", "ring");
-        public static final ResourceLocation TRINKET = new ResourceLocation("forge", "trinket");
-        public static final ResourceLocation NECK = new ResourceLocation("forge", "neck");
-        public static final ResourceLocation BELT = new ResourceLocation("forge", "belt");
-        public static final ResourceLocation WRISTS = new ResourceLocation("forge", "wrists");
-        public static final ResourceLocation ANKLES = new ResourceLocation("forge", "ankles");
+        public static final String RING = "ring";
+        public static final String RING1 = "ring1";
+        public static final String RING2 = "ring2";
+        public static final String TRINKET = "trinket";
+        public static final String TRINKET1 = "trinket1";
+        public static final String TRINKET2 = "trinket2";
+        public static final String NECK = "neck";
+        public static final String BELT = "belt";
+        public static final String WRISTS = "wrists";
+        public static final String ANKLES = "ankles";
 
         private final EntityLivingBase owner;
         private final ItemStackHandler inventory = new ItemStackHandler(8);
-        private final ExtensionSlotItemHandler ring1 = new ExtensionSlotItemHandler(this, RING, inventory, 0);
-        private final ExtensionSlotItemHandler ring2 = new ExtensionSlotItemHandler(this, RING, inventory, 1);
-        private final ExtensionSlotItemHandler trinket1 = new ExtensionSlotItemHandler(this, TRINKET, inventory, 2);
-        private final ExtensionSlotItemHandler trinket2 = new ExtensionSlotItemHandler(this, TRINKET, inventory, 3);
+        private final ExtensionSlotItemHandler ring1 = new ExtensionSlotItemHandler(this, RING1, inventory, 0).setType(RING);
+        private final ExtensionSlotItemHandler ring2 = new ExtensionSlotItemHandler(this, RING2, inventory, 1).setType(RING);
+        private final ExtensionSlotItemHandler trinket1 = new ExtensionSlotItemHandler(this, TRINKET1, inventory, 2).setType(TRINKET);
+        private final ExtensionSlotItemHandler trinket2 = new ExtensionSlotItemHandler(this, TRINKET2, inventory, 3).setType(TRINKET);
         private final ExtensionSlotItemHandler neck = new ExtensionSlotItemHandler(this, NECK, inventory, 4);
         private final ExtensionSlotItemHandler belt = new ExtensionSlotItemHandler(this, BELT, inventory, 5);
         private final ExtensionSlotItemHandler wrists = new ExtensionSlotItemHandler(this, WRISTS, inventory, 6);
@@ -274,6 +277,21 @@ public class ExtensionContainerTest
         public ImmutableList<IExtensionSlot> getSlots()
         {
             return slots;
+        }
+
+        @Nullable
+        @Override
+        public IExtensionSlot getSlot(String slotId)
+        {
+            if (RING1.equals(slotId)) return ring1;
+            if (RING2.equals(slotId)) return ring2;
+            if (TRINKET1.equals(slotId)) return trinket1;
+            if (TRINKET2.equals(slotId)) return trinket2;
+            if (NECK.equals(slotId)) return neck;
+            if (BELT.equals(slotId)) return belt;
+            if (WRISTS.equals(slotId)) return wrists;
+            if (ANKLES.equals(slotId)) return ankles;
+            return null;
         }
 
         @Nonnull
@@ -328,7 +346,7 @@ public class ExtensionContainerTest
         {
             for (IExtensionSlot slot : slots)
             {
-                ((ExtensionSlotItemHandler) slot).onWornTick();
+                slot.onWornTick();
             }
         }
 

--- a/src/test/java/net/minecraftforge/debug/ExtensionContainerTest.java
+++ b/src/test/java/net/minecraftforge/debug/ExtensionContainerTest.java
@@ -1,0 +1,347 @@
+package net.minecraftforge.debug;
+
+import com.google.common.collect.ImmutableList;
+import net.minecraft.creativetab.CreativeTabs;
+import net.minecraft.entity.Entity;
+import net.minecraft.entity.EntityLivingBase;
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.item.Item;
+import net.minecraft.item.ItemStack;
+import net.minecraft.nbt.NBTBase;
+import net.minecraft.nbt.NBTTagCompound;
+import net.minecraft.util.*;
+import net.minecraft.world.World;
+import net.minecraftforge.common.MinecraftForge;
+import net.minecraftforge.common.capabilities.*;
+import net.minecraftforge.items.customslots.*;
+import net.minecraftforge.common.util.INBTSerializable;
+import net.minecraftforge.event.AttachCapabilitiesEvent;
+import net.minecraftforge.event.RegistryEvent;
+import net.minecraftforge.fml.common.Mod;
+import net.minecraftforge.fml.common.event.FMLPreInitializationEvent;
+import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
+import net.minecraftforge.fml.common.gameevent.TickEvent;
+import net.minecraftforge.items.ItemHandlerHelper;
+import net.minecraftforge.items.ItemStackHandler;
+import org.apache.logging.log4j.Logger;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+@Mod.EventBusSubscriber
+@Mod(modid = "extension_container_test", name = "Extension Container Test", version = "1.0.0")
+public class ExtensionContainerTest
+{
+    private static final boolean ENABLED = false;
+    private static Logger logger;
+
+    @Mod.EventHandler
+    public void preInit(FMLPreInitializationEvent event)
+    {
+        if (ENABLED)
+        {
+            logger = event.getModLog();
+            ExtensionContainer.register();
+        }
+    }
+
+    @SubscribeEvent
+    public static void registerItems(RegistryEvent.Register<Item> event)
+    {
+        event.getRegistry().register(new ExtensionSlotItemTest()
+                .setRegistryName("slot_item_test").setUnlocalizedName("forge.slot_item_test")
+                .setMaxStackSize(1).setMaxDamage(50).setCreativeTab(CreativeTabs.MISC));
+    }
+
+    public static class ExtensionSlotItemTest extends Item implements IExtensionSlotItem
+    {
+        private boolean onWornTick_received = false;
+
+        // Equivalent to ItemArmor#onItemRightclick
+        @Override
+        public ActionResult<ItemStack> onItemRightClick(World worldIn, EntityPlayer playerIn, EnumHand handIn)
+        {
+            ItemStack heldItem = playerIn.getHeldItem(handIn);
+
+            IExtensionSlot slot = ExtensionContainer.get(playerIn).getNeck();
+
+            ItemStack existing = slot.getContents();
+
+            if (existing.isEmpty())
+            {
+                slot.setContents(heldItem.copy());
+                heldItem.setCount(0);
+                return new ActionResult<>(EnumActionResult.SUCCESS, heldItem);
+            }
+            else
+            {
+                // For testing purposes only. A real implementation wouldn't do this. :P
+                ItemHandlerHelper.giveItemToPlayer(playerIn, existing);
+                slot.setContents(ItemStack.EMPTY);
+                return new ActionResult<>(EnumActionResult.SUCCESS, heldItem);
+                // End testing stuff.
+
+                // In reality, you would do this:
+                //return new ActionResult<>(EnumActionResult.FAIL, heldItem);
+            }
+        }
+
+        @Override
+        public void onEquipped(@Nonnull ItemStack stack, @Nonnull IExtensionSlot slot)
+        {
+            if (!onWornTick_received)
+            {
+                logger.debug("onWornTick Received!");
+                onWornTick_received = true;
+            }
+        }
+
+        @Override
+        public boolean canUnequip(@Nonnull ItemStack stack, @Nonnull IExtensionSlot slot)
+        {
+            // Prevents unequipping from the GUI
+            return false;
+        }
+
+        @Override
+        public void onWornTick(@Nonnull ItemStack stack, @Nonnull IExtensionSlot slot)
+        {
+            if (!onWornTick_received)
+            {
+                logger.debug("onWornTick Received!");
+                onWornTick_received = true;
+            }
+        }
+
+        @Nullable
+        @Override
+        public ICapabilityProvider initCapabilities(ItemStack stack, @Nullable NBTTagCompound nbt)
+        {
+            return new ICapabilityProvider()
+            {
+                @Override
+                public boolean hasCapability(@Nonnull Capability<?> capability, @Nullable EnumFacing facing)
+                {
+                    if (capability == CapabilityExtensionSlotItem.INSTANCE)
+                        return true;
+                    return false;
+                }
+
+                @SuppressWarnings("unchecked")
+                @Nullable
+                @Override
+                public <T> T getCapability(@Nonnull Capability<T> capability, @Nullable EnumFacing facing)
+                {
+                    if (capability == CapabilityExtensionSlotItem.INSTANCE)
+                        return (T)ExtensionSlotItemTest.this;
+                    return null;
+                }
+            };
+        }
+    }
+
+    public static class ExtensionContainer implements IExtensionContainer, INBTSerializable<NBTTagCompound>
+    {
+        ////////////////////////////////////////////////////////////
+        // Capability support code
+        //
+
+        private static final ResourceLocation CAPABILITY_ID = new ResourceLocation("forge", "extension_container_test");
+
+        @CapabilityInject(ExtensionContainer.class)
+        public static Capability<ExtensionContainer> CAPABILITY = null;
+
+        public static void register()
+        {
+            // Internal capability, IStorage and default instances are meaningless.
+            CapabilityManager.INSTANCE.register(ExtensionContainer.class, new Capability.IStorage<ExtensionContainer>()
+            {
+                @Nullable
+                @Override
+                public NBTBase writeNBT(Capability<ExtensionContainer> capability, ExtensionContainer instance, EnumFacing side)
+                {
+                    return null;
+                }
+
+                @Override
+                public void readNBT(Capability<ExtensionContainer> capability, ExtensionContainer instance, EnumFacing side, NBTBase nbt)
+                {
+
+                }
+            }, () -> null);
+
+            MinecraftForge.EVENT_BUS.register(new EventHandlers());
+        }
+
+        public static ExtensionContainer get(EntityPlayer player)
+        {
+            return player.getCapability(CAPABILITY, null);
+        }
+
+        static class EventHandlers
+        {
+            @SubscribeEvent
+            public void attachCapabilities(AttachCapabilitiesEvent<Entity> event)
+            {
+                if (event.getObject() instanceof EntityPlayer)
+                {
+                    event.addCapability(CAPABILITY_ID, new ICapabilitySerializable<NBTTagCompound>()
+                    {
+                        final ExtensionContainer extensionContainer = new ExtensionContainer((EntityPlayer) event.getObject());
+
+                        @Override
+                        public NBTTagCompound serializeNBT()
+                        {
+                            return extensionContainer.serializeNBT();
+                        }
+
+                        @Override
+                        public void deserializeNBT(NBTTagCompound nbt)
+                        {
+                            extensionContainer.deserializeNBT(nbt);
+                        }
+
+                        @Override
+                        public boolean hasCapability(@Nonnull Capability<?> capability, @Nullable EnumFacing facing)
+                        {
+                            if (capability == CAPABILITY)
+                                return true;
+                            return false;
+                        }
+
+                        @Nullable
+                        @SuppressWarnings("unchecked")
+                        @Override
+                        public <T> T getCapability(@Nonnull Capability<T> capability, @Nullable EnumFacing facing)
+                        {
+                            if (capability == CAPABILITY)
+                                return (T) extensionContainer;
+                            return null;
+                        }
+                    });
+                }
+            }
+
+            @SubscribeEvent
+            public void entityTick(TickEvent.PlayerTickEvent event)
+            {
+                ExtensionContainer instance = get(event.player);
+                if (instance == null) return;
+                instance.tickAllSlots();
+            }
+        }
+
+        ////////////////////////////////////////////////////////////
+        // Equipment container implementation
+        //
+
+        public static final ResourceLocation RING = new ResourceLocation("forge", "ring");
+        public static final ResourceLocation TRINKET = new ResourceLocation("forge", "trinket");
+        public static final ResourceLocation NECK = new ResourceLocation("forge", "neck");
+        public static final ResourceLocation BELT = new ResourceLocation("forge", "belt");
+        public static final ResourceLocation WRISTS = new ResourceLocation("forge", "wrists");
+        public static final ResourceLocation ANKLES = new ResourceLocation("forge", "ankles");
+
+        private final EntityLivingBase owner;
+        private final ItemStackHandler inventory = new ItemStackHandler(8);
+        private final ExtensionSlotItemHandler ring1 = new ExtensionSlotItemHandler(this, RING, inventory, 0);
+        private final ExtensionSlotItemHandler ring2 = new ExtensionSlotItemHandler(this, RING, inventory, 1);
+        private final ExtensionSlotItemHandler trinket1 = new ExtensionSlotItemHandler(this, TRINKET, inventory, 2);
+        private final ExtensionSlotItemHandler trinket2 = new ExtensionSlotItemHandler(this, TRINKET, inventory, 3);
+        private final ExtensionSlotItemHandler neck = new ExtensionSlotItemHandler(this, NECK, inventory, 4);
+        private final ExtensionSlotItemHandler belt = new ExtensionSlotItemHandler(this, BELT, inventory, 5);
+        private final ExtensionSlotItemHandler wrists = new ExtensionSlotItemHandler(this, WRISTS, inventory, 6);
+        private final ExtensionSlotItemHandler ankles = new ExtensionSlotItemHandler(this, ANKLES, inventory, 7);
+        private final ImmutableList<IExtensionSlot> slots = ImmutableList.of(
+                ring1, ring2, trinket1, trinket2,
+                neck, belt, wrists, ankles
+        );
+
+        private ExtensionContainer(EntityLivingBase owner)
+        {
+            this.owner = owner;
+        }
+
+        @Nonnull
+        @Override
+        public EntityLivingBase getOwner()
+        {
+            return owner;
+        }
+
+        @Nonnull
+        @Override
+        public ImmutableList<IExtensionSlot> getSlots()
+        {
+            return slots;
+        }
+
+        @Nonnull
+        public IExtensionSlot getRing1()
+        {
+            return ring1;
+        }
+
+        @Nonnull
+        public IExtensionSlot getRing2()
+        {
+            return ring2;
+        }
+
+        @Nonnull
+        public IExtensionSlot getTrinket1()
+        {
+            return trinket1;
+        }
+
+        @Nonnull
+        public IExtensionSlot getTrinket2()
+        {
+            return trinket2;
+        }
+
+        @Nonnull
+        public IExtensionSlot getNeck()
+        {
+            return neck;
+        }
+
+        @Nonnull
+        public IExtensionSlot getBelt()
+        {
+            return belt;
+        }
+
+        @Nonnull
+        public IExtensionSlot getWrists()
+        {
+            return wrists;
+        }
+
+        @Nonnull
+        public IExtensionSlot getAnkles()
+        {
+            return ankles;
+        }
+
+        private void tickAllSlots()
+        {
+            for (IExtensionSlot slot : slots)
+            {
+                ((ExtensionSlotItemHandler) slot).onWornTick();
+            }
+        }
+
+        @Override
+        public NBTTagCompound serializeNBT()
+        {
+            return inventory.serializeNBT();
+        }
+
+        @Override
+        public void deserializeNBT(NBTTagCompound nbt)
+        {
+            inventory.deserializeNBT(nbt);
+        }
+    }
+}

--- a/src/test/java/net/minecraftforge/debug/ExtensionSlotRegistryTest.java
+++ b/src/test/java/net/minecraftforge/debug/ExtensionSlotRegistryTest.java
@@ -1,0 +1,139 @@
+package net.minecraftforge.debug;
+
+import net.minecraft.creativetab.CreativeTabs;
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.item.Item;
+import net.minecraft.item.ItemStack;
+import net.minecraft.nbt.NBTTagCompound;
+import net.minecraft.util.ActionResult;
+import net.minecraft.util.EnumActionResult;
+import net.minecraft.util.EnumFacing;
+import net.minecraft.util.EnumHand;
+import net.minecraft.world.World;
+import net.minecraftforge.common.capabilities.Capability;
+import net.minecraftforge.common.capabilities.ICapabilityProvider;
+import net.minecraftforge.event.RegistryEvent;
+import net.minecraftforge.fml.common.Mod;
+import net.minecraftforge.fml.common.event.FMLPreInitializationEvent;
+import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
+import net.minecraftforge.items.ItemHandlerHelper;
+import net.minecraftforge.items.customslots.CapabilityExtensionSlotItem;
+import net.minecraftforge.items.customslots.IExtensionSlot;
+import net.minecraftforge.items.customslots.IExtensionSlotItem;
+import net.minecraftforge.items.customslots.VanillaEquipment;
+import org.apache.logging.log4j.Logger;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+@Mod.EventBusSubscriber
+@Mod(modid = "slot_registry_test", name = "Slot Registry Test", version = "1.0.0")
+public class ExtensionSlotRegistryTest
+{
+    private static final boolean ENABLED = true;
+    private static Logger logger;
+
+    @Mod.EventHandler
+    public void preInit(FMLPreInitializationEvent event)
+    {
+        if (ENABLED)
+        {
+            logger = event.getModLog();
+        }
+    }
+
+    @SubscribeEvent
+    public static void registerItems(RegistryEvent.Register<Item> event)
+    {
+        if (ENABLED)
+        {
+            event.getRegistry().register(new ExtensionSlotItemTest()
+                    .setRegistryName("flex_slot_item_test").setUnlocalizedName("forge.slot_registry_test_item")
+                    .setMaxStackSize(1).setMaxDamage(50).setCreativeTab(CreativeTabs.MISC));
+        }
+    }
+
+    public static class ExtensionSlotItemTest extends Item implements IExtensionSlotItem
+    {
+        private boolean onWornTick_received = false;
+
+        // Equivalent to ItemArmor#onItemRightclick
+        @Override
+        public ActionResult<ItemStack> onItemRightClick(World worldIn, EntityPlayer playerIn, EnumHand handIn)
+        {
+            ItemStack heldItem = playerIn.getHeldItem(handIn);
+
+            IExtensionSlot slot = VanillaEquipment.get(playerIn).getSlot(VanillaEquipment.HEAD);
+
+            ItemStack existing = slot.getContents();
+
+            if (existing.isEmpty())
+            {
+                slot.setContents(heldItem.copy());
+                heldItem.setCount(0);
+                return new ActionResult<>(EnumActionResult.SUCCESS, heldItem);
+            }
+            else
+            {
+                // For testing purposes only. A real implementation wouldn't do this. :P
+                ItemHandlerHelper.giveItemToPlayer(playerIn, existing);
+                slot.setContents(ItemStack.EMPTY);
+                return new ActionResult<>(EnumActionResult.SUCCESS, heldItem);
+                // End testing stuff.
+
+                // In reality, you would do this:
+                //return new ActionResult<>(EnumActionResult.FAIL, heldItem);
+            }
+        }
+
+        @Override
+        public void onEquipped(@Nonnull ItemStack stack, @Nonnull IExtensionSlot slot)
+        {
+            logger.debug("onEquipped Received!");
+        }
+
+        @Override
+        public boolean canUnequip(@Nonnull ItemStack stack, @Nonnull IExtensionSlot slot)
+        {
+            // Prevents unequipping from the GUI
+            return false;
+        }
+
+        @Override
+        public void onWornTick(@Nonnull ItemStack stack, @Nonnull IExtensionSlot slot)
+        {
+            if (!onWornTick_received)
+            {
+                logger.debug("onWornTick Received!");
+                onWornTick_received = true;
+            }
+        }
+
+        @Nullable
+        @Override
+        public ICapabilityProvider initCapabilities(ItemStack stack, @Nullable NBTTagCompound nbt)
+        {
+            return new ICapabilityProvider()
+            {
+                @Override
+                public boolean hasCapability(@Nonnull Capability<?> capability, @Nullable EnumFacing facing)
+                {
+                    if (capability == CapabilityExtensionSlotItem.INSTANCE)
+                        return true;
+                    return false;
+                }
+
+                @SuppressWarnings("unchecked")
+                @Nullable
+                @Override
+                public <T> T getCapability(@Nonnull Capability<T> capability, @Nullable EnumFacing facing)
+                {
+                    if (capability == CapabilityExtensionSlotItem.INSTANCE)
+                        return (T)ExtensionSlotItemTest.this;
+                    return null;
+                }
+            };
+        }
+    }
+
+}


### PR DESCRIPTION
## Motivation

It is currently rather annoying to have an item support arbitrary mods implementing extra equipment slots, and as a mod adding new slots, support existing items. This API provides a standardized capability interface for the task, which should allow easier interaction between the container mods, and the equipment mods.

## What this API does NOT do

This API does not add slots to the game. It does not provide GUI tabs, or a way to add slots by config, or by registry. In fact, it does not even attempt to dictate how to add slots to the game, at all. It only serves as communication between the slots, and the items.

## Design

The design is heavily inspired by the Baubles API, so it will look familiar to existing developers and will make it easy to adapt existing mods.

The API consists of 3 interfaces:

- `IExtensionSlotItem`: Exposed as a capability by items that can be placed in the slots, so that they can inform about their intended slots, and receive notifications for insertion, removal, and ticking.
- `IExtensionSlot`: A proxy interface representing a gear slot, with methods to retrieve and change the contained item, along with a way to obtain the owner of the slot.
- `IExtensionContainer`: An informational interface for listing the slots, and the owning entity for which it's holding items.

Alongside those interfaces, there are helper classes for standard `IItemHandler` container sources, and to bind a Gui/Container's Slots to an extension slot.

### How someone would implement a container

To implement a container, the modder would register a new capability to be attached to the players, with some internal item storage. Either the capability itself would extend `IExtensionContainer`, or an `IExtensionContainer` would be provided from it.

The contained items will expect to have the IExtensionSlotItem methods called for their capability, if they implement it, so containers should do so.

Auto-sync may or may not be expected, depending on the decisions taken based on feedback (see below).

### How someone would implement an item

To implement an extension-slot-aware item, it would return a capability provider from initCapabilities, that exposes an instance of `IExtensionSlotItem` as a capability.

## Things to consider
- Should the API users expect auto-sync of the slot contents to the client when the GUI isn't open?

  - If so, who should be responsible for handling this? The container implementations, or forge?
  - If so, should the items be allowed to choose wether or not they want auto-sync (akin to Baubles' `willAutoSync()` method)

- Should the API unify equivalent slots so that two "belt" providers end up with the same underlying content?

  - I believe the most sensible answer is "no", because doing so would make the API unreasonably messy.

- Should Forge provide events for others to intercept changes in the inventory?

  - Mostly thinking about an equivalent of `LivingEquipmentChangeEvent`.

Thoughts and opinions are welcome! All names are subject to change if better alternatives are suggested.