### PR TITLE
Use relative time offset, rather than absolute value, for animations

### DIFF
--- a/src/main/java/net/minecraftforge/client/model/animation/Animation.java
+++ b/src/main/java/net/minecraftforge/client/model/animation/Animation.java
@@ -21,11 +21,16 @@ package net.minecraftforge.client.model.animation;
 
 import net.minecraft.world.World;
 
+import java.lang.ref.WeakReference;
+
 public enum Animation
 {
     INSTANCE;
 
     private float clientPartialTickTime;
+
+    private static long epochTime;
+    private static WeakReference<World> worldRef;
 
     /**
      * Get the global world time for the current tick, in seconds.
@@ -40,7 +45,12 @@ public enum Animation
      */
     public static float getWorldTime(World world, float tickProgress)
     {
-        return (world.getTotalWorldTime() + tickProgress) / 20;
+        if (worldRef == null || worldRef.get() != world)
+        {
+            epochTime = world.getTotalWorldTime();
+            worldRef = new WeakReference<>(world);
+        }
+        return (world.getTotalWorldTime() - epochTime + tickProgress) / 20;
     }
 
     /**


### PR DESCRIPTION
Should resolve #4121.

Based on the updated approach proposed by #4122.

Using the `World` here instead of the dimension ID for a couple of reasons:
1) Using an `int` has the problem of there being no good 'unset' value.
2) Even using a nullable `Integer`, we'd miss the case of changing between servers/savefiles if the dimension ID was the same.

A `WeakReference` is used, so the world shouldn't be leaked.
