### PR TITLE
Various animation system improvements

### DIFF
--- a/patches/minecraft/net/minecraft/client/renderer/tileentity/TileEntityRendererDispatcher.java.patch
+++ b/patches/minecraft/net/minecraft/client/renderer/tileentity/TileEntityRendererDispatcher.java.patch
@@ -4,7 +4,7 @@
      {
          if (p_180546_1_.func_145835_a(this.field_147560_j, this.field_147561_k, this.field_147558_l) < p_180546_1_.func_145833_n())
          {
-+            if(!drawingBatch || !p_180546_1_.hasFastRenderer())
++            if(!drawingBatch || !p_180546_1_.hasFastRenderer(net.minecraftforge.client.MinecraftForgeClient.getRenderPass()))
 +            {
              RenderHelper.func_74519_b();
              int i = this.field_147550_f.func_175626_b(p_180546_1_.func_174877_v(), 0);
@@ -20,7 +20,7 @@
          {
              try
              {
-+                if(drawingBatch && p_192854_1_.hasFastRenderer())
++                if(drawingBatch && p_192854_1_.hasFastRenderer(net.minecraftforge.client.MinecraftForgeClient.getRenderPass()))
 +                    tileentityspecialrenderer.renderTileEntityFast(p_192854_1_, p_192854_2_, p_192854_4_, p_192854_6_, p_192854_8_, p_192854_9_, p_192854_10_, batchBuffer.func_178180_c());
 +                else
                  tileentityspecialrenderer.func_192841_a(p_192854_1_, p_192854_2_, p_192854_4_, p_192854_6_, p_192854_8_, p_192854_9_, p_192854_10_);

--- a/patches/minecraft/net/minecraft/tileentity/TileEntity.java.patch
+++ b/patches/minecraft/net/minecraft/tileentity/TileEntity.java.patch
@@ -66,7 +66,7 @@
      public double func_145835_a(double p_145835_1_, double p_145835_3_, double p_145835_5_)
      {
          double d0 = (double)this.field_174879_c.func_177958_n() + 0.5D - p_145835_1_;
-@@ -297,6 +305,204 @@
+@@ -297,6 +305,218 @@
      {
      }
  
@@ -229,9 +229,23 @@
 +    }
 +
 +    /**
++     * If the TileEntitySpecialRenderer associated with this TileEntity can be batched in with another renderers in this pass, and won't access the GL state.
++     * If TileEntity returns true, then TESR should have the same functionality as (and probably extend) the FastTESR class.
++     *
++     * @param pass either 0 or 1, for opaque and translucent rendering pass respectively
++     */
++    public boolean hasFastRenderer(int pass)
++    {
++        return hasFastRenderer();
++    }
++
++    /**
 +     * If the TileEntitySpecialRenderer associated with this TileEntity can be batched in with another renderers, and won't access the GL state.
 +     * If TileEntity returns true, then TESR should have the same functionality as (and probably extend) the FastTESR class.
++     *
++     * @deprecated Use {@link TileEntity#hasFastRenderer(int)} instead. To be removed in 1.13.
 +     */
++    @Deprecated
 +    public boolean hasFastRenderer()
 +    {
 +        return false;

--- a/src/main/java/net/minecraftforge/client/model/animation/AnimationTESR.java
+++ b/src/main/java/net/minecraftforge/client/model/animation/AnimationTESR.java
@@ -55,7 +55,7 @@ public class AnimationTESR<T extends TileEntity> extends FastTESR<T> implements 
         if(blockRenderer == null) blockRenderer = Minecraft.getMinecraft().getBlockRendererDispatcher();
         BlockPos pos = te.getPos();
         IBlockAccess world = MinecraftForgeClient.getRegionRenderCache(te.getWorld(), pos);
-        IBlockState state = world.getBlockState(pos);
+        IBlockState state = world.getBlockState(pos).getActualState(world, pos);
         if(state.getPropertyKeys().contains(Properties.StaticProperty))
         {
             state = state.withProperty(Properties.StaticProperty, false);

--- a/src/main/java/net/minecraftforge/client/model/animation/FastTESR.java
+++ b/src/main/java/net/minecraftforge/client/model/animation/FastTESR.java
@@ -34,7 +34,7 @@ import net.minecraft.tileentity.TileEntity;
 public abstract class FastTESR<T extends TileEntity> extends TileEntitySpecialRenderer<T>
 {
     @Override
-    public final void render(T te, double x, double y, double z, float partialTicks, int destroyStage, float partial)
+    public void render(T te, double x, double y, double z, float partialTicks, int destroyStage, float partial)
     {
         Tessellator tessellator = Tessellator.getInstance();
         BufferBuilder buffer = tessellator.getBuffer();

--- a/src/main/java/net/minecraftforge/client/model/animation/ModelBlockAnimation.java
+++ b/src/main/java/net/minecraftforge/client/model/animation/ModelBlockAnimation.java
@@ -326,7 +326,14 @@ public class ModelBlockAnimation
             @Override
             public TRSRTransformation apply(float time)
             {
-                time -= Math.floor(time);
+                if (loop)
+                {
+                    time -= Math.floor(time);
+                }
+                else
+                {
+                    time = MathHelper.clamp(time, 0f, 1f);
+                }
                 Vector3f translation = new Vector3f(0, 0, 0);
                 Vector3f scale = new Vector3f(1, 1, 1);
                 Vector3f origin = new Vector3f(0, 0, 0);


### PR DESCRIPTION
While trying to use the animation system with a normal JSON model (i.e. with an 'armature'), I've come across some issues, which this PR addresses:

 - You cannot access the last frame of such an animation in your animation state machine (e.g. through `["apply", "<model>", 1]`). The fix here is to only perform the 'normalization' for looping animations and clamping to [0,1] for oneshot ones.
 - `AnimationTESR` does not use the actual state of the block, making using e.g. facing depend on TE properties impossible. This is mitigated by simply calling `getActualState` in `renderTileEntityFast`.
 - Mixing fast and 'normal' rendering in one TESR (through render passes, for instance) is cumbersome when deriving from `FastTESR`. To make this a little less inconvenient, I've made the normal `render` method non-final to make classes deriving from `FastTESR` reusable for mixed scenarios. Additionally, the `hasFastRenderer` method now gets passed the current render pass to make deciding when to use fast rendering easier. *Note: Technically not necessary (as can be seen in the patches), but nice for convenience and might make people more aware of render passes for TEs.*

I've decided against PRing these separately as they are all fairly minor and might add some more if I notice issues before this is merged.