### PR TITLE
Add events for loading advancements, functions, and structures

### DIFF
--- a/patches/minecraft/net/minecraft/advancements/AdvancementManager.java.patch
+++ b/patches/minecraft/net/minecraft/advancements/AdvancementManager.java.patch
@@ -1,10 +1,10 @@
 --- ../src-base/minecraft/net/minecraft/advancements/AdvancementManager.java
 +++ ../src-work/minecraft/net/minecraft/advancements/AdvancementManager.java
-@@ -66,6 +66,7 @@
+@@ -65,6 +65,7 @@
+         this.field_193768_e = false;
          field_192784_c.func_192087_a();
          Map<ResourceLocation, Advancement.Builder> map = this.func_192781_c();
-         this.func_192777_a(map);
 +        this.field_193768_e |= net.minecraftforge.common.ForgeHooks.loadAdvancements(map);
+         this.func_192777_a(map);
          field_192784_c.func_192083_a(map);
  
-         for (Advancement advancement : field_192784_c.func_192088_b())

--- a/patches/minecraft/net/minecraft/advancements/FunctionManager.java.patch
+++ b/patches/minecraft/net/minecraft/advancements/FunctionManager.java.patch
@@ -1,0 +1,10 @@
+--- ../src-base/minecraft/net/minecraft/advancements/FunctionManager.java
++++ ../src-work/minecraft/net/minecraft/advancements/FunctionManager.java
+@@ -160,6 +160,7 @@
+ 
+     private void func_193061_h()
+     {
++        net.minecraftforge.common.ForgeHooks.loadFunctions(this.field_193070_d);
+         if (this.field_193068_b != null)
+         {
+             this.field_193068_b.mkdirs();

--- a/patches/minecraft/net/minecraft/world/gen/structure/template/TemplateManager.java.patch
+++ b/patches/minecraft/net/minecraft/world/gen/structure/template/TemplateManager.java.patch
@@ -1,0 +1,20 @@
+--- ../src-base/minecraft/net/minecraft/world/gen/structure/template/TemplateManager.java
++++ ../src-work/minecraft/net/minecraft/world/gen/structure/template/TemplateManager.java
+@@ -110,7 +110,7 @@
+         {
+             inputstream = MinecraftServer.class.getResourceAsStream("/assets/" + s + "/structures/" + s1 + ".nbt");
+             this.func_186239_a(s1, inputstream);
+-            return true;
++            flag = true;
+         }
+         catch (Throwable var10)
+         {
+@@ -121,7 +121,7 @@
+             IOUtils.closeQuietly(inputstream);
+         }
+ 
+-        return flag;
++        return net.minecraftforge.common.ForgeHooks.loadStructure(p_186236_1_, this.field_186240_a, flag);
+     }
+ 
+     private void func_186239_a(String p_186239_1_, InputStream p_186239_2_) throws IOException

--- a/src/main/java/net/minecraftforge/event/AdvancementLoadEvent.java
+++ b/src/main/java/net/minecraftforge/event/AdvancementLoadEvent.java
@@ -1,0 +1,51 @@
+/*
+ * Minecraft Forge
+ * Copyright (c) 2016.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation version 2.1
+ * of the License.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+package net.minecraftforge.event;
+
+import java.util.Map;
+import net.minecraft.advancements.Advancement;
+import net.minecraft.util.ResourceLocation;
+import net.minecraftforge.fml.common.eventhandler.Event;
+
+/**
+ * This event is fired when advancements load.
+ * This event is fired when the server loads, or when the /reload command runs.
+ * The advancements will not override advancements loaded from the world folder,
+ * as these are considered configurations files and should not be modified by mods.
+ */
+public class AdvancementLoadEvent extends Event
+{
+    private Map<ResourceLocation, Advancement.Builder> advancements;
+
+    public AdvancementLoadEvent(Map<ResourceLocation, Advancement.Builder> advancements)
+    {
+        this.advancements = advancements;
+    }
+
+    public Map<ResourceLocation, Advancement.Builder> getAdvancements()
+    {
+        return this.advancements;
+    }
+
+    public void addAdvancement(ResourceLocation name, Advancement.Builder builder)
+    {
+        this.advancements.put(name, builder);
+    }
+}

--- a/src/main/java/net/minecraftforge/event/FunctionLoadEvent.java
+++ b/src/main/java/net/minecraftforge/event/FunctionLoadEvent.java
@@ -1,0 +1,52 @@
+/*
+ * Minecraft Forge
+ * Copyright (c) 2016.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation version 2.1
+ * of the License.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+package net.minecraftforge.event;
+
+import java.util.Map;
+
+import net.minecraft.command.FunctionObject;
+import net.minecraft.util.ResourceLocation;
+import net.minecraftforge.fml.common.eventhandler.Event;
+
+/**
+ * Event fired when a FunctionObject tries to load.
+ * This event is fired when the server loads, or when the /reload command runs.
+ * This event will not be fired for functions loaded from the world folder, as these
+ * are considered configurations files and should not be modified by mods.
+ */
+public class FunctionLoadEvent extends Event
+{
+	private Map<ResourceLocation, FunctionObject> functions;
+
+    public FunctionLoadEvent(Map<ResourceLocation, FunctionObject> functions)
+    {
+        this.functions = functions;
+    }
+
+    public Map<ResourceLocation, FunctionObject> getFunctions()
+    {
+        return this.functions;
+    }
+
+    public void addFunction(ResourceLocation name, FunctionObject function)
+    {
+        this.functions.put(name, function);
+    }
+}

--- a/src/main/java/net/minecraftforge/event/StructureLoadEvent.java
+++ b/src/main/java/net/minecraftforge/event/StructureLoadEvent.java
@@ -1,0 +1,61 @@
+/*
+ * Minecraft Forge
+ * Copyright (c) 2016.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation version 2.1
+ * of the License.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+package net.minecraftforge.event;
+
+import net.minecraft.util.ResourceLocation;
+import net.minecraft.world.gen.structure.template.Template;
+import net.minecraftforge.fml.common.eventhandler.Cancelable;
+import net.minecraftforge.fml.common.eventhandler.Event;
+
+/**
+ * This event is fired when a structure loads.
+ * This event is fired when the server loads, or when a structure tries to load.
+ * The structure will not override structures loaded from the world folder,
+ * as these are considered configurations files and should not be modified by mods.
+ *
+ * Canceling the event will remove the structure.
+ *
+ */
+@Cancelable
+public class StructureLoadEvent extends Event
+{
+    private ResourceLocation name;
+    private Template structure;
+
+    public StructureLoadEvent(ResourceLocation name, Template structure)
+    {
+        this.name = name;
+        this.structure = structure;
+    }
+
+    public ResourceLocation getName()
+    {
+        return this.name;
+    }
+    
+    public Template getStructure() {
+        return this.structure;
+    }
+
+    public void setStructure(Template structure)
+    {
+        this.structure = structure;
+    }
+}

--- a/src/test/java/net/minecraftforge/debug/AdvancementLoadEventTest.java
+++ b/src/test/java/net/minecraftforge/debug/AdvancementLoadEventTest.java
@@ -18,9 +18,9 @@ import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
 public class AdvancementLoadEventTest
 {
     static final String MOD_ID = "advancement_load_event_test";
-    private static final boolean ENABLED = true;
+    private static final boolean ENABLED = false;
     private static final ResourceLocation TEST_ADVANCEMENT_NAME = new ResourceLocation(MOD_ID, "test/root");
-//    private static final ResourceLocation TEST_ADVANCEMENT_NAME = new ResourceLocation("story/root"); //Uncomment to test overriding a built-in advancement
+//    private static final ResourceLocation TEST_ADVANCEMENT_NAME = new ResourceLocation("story/root"); //Uncomment and comment line above to test overriding a built-in advancement
     private static final String TEST_ADVANCEMENT_JSON = 
               "{\n"
             + "  \"display\": {\n"

--- a/src/test/java/net/minecraftforge/debug/AdvancementLoadEventTest.java
+++ b/src/test/java/net/minecraftforge/debug/AdvancementLoadEventTest.java
@@ -1,0 +1,73 @@
+package net.minecraftforge.debug;
+
+import org.apache.logging.log4j.Logger;
+
+import com.google.gson.JsonParseException;
+
+import net.minecraft.advancements.Advancement;
+import net.minecraft.advancements.AdvancementManager;
+import net.minecraft.util.JsonUtils;
+import net.minecraft.util.ResourceLocation;
+import net.minecraftforge.common.MinecraftForge;
+import net.minecraftforge.event.AdvancementLoadEvent;
+import net.minecraftforge.fml.common.Mod;
+import net.minecraftforge.fml.common.event.FMLPreInitializationEvent;
+import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
+
+@Mod(modid = AdvancementLoadEventTest.MOD_ID, name = "AdvancementLoadEvent test mod", version = "1.0.0", acceptableRemoteVersions = "*")
+public class AdvancementLoadEventTest
+{
+    static final String MOD_ID = "advancement_load_event_test";
+    private static final boolean ENABLED = true;
+    private static final ResourceLocation TEST_ADVANCEMENT_NAME = new ResourceLocation(MOD_ID, "test/root");
+//    private static final ResourceLocation TEST_ADVANCEMENT_NAME = new ResourceLocation("story/root"); //Uncomment to test overriding a built-in advancement
+    private static final String TEST_ADVANCEMENT_JSON = 
+              "{\n"
+            + "  \"display\": {\n"
+            + "    \"icon\": {\n"
+            + "      \"item\": \"minecraft:stone\"\n"
+            + "    },\n"
+            + "    \"title\": \"Test Advancement\",\n"
+            + "    \"description\":  \"Test Advancement Description\",\n"
+            + "    \"background\": \"minecraft:textures/gui/advancements/backgrounds/stone.png\"\n"
+            + "  },\n"
+            + "  \"criteria\": {\n"
+            + "    \"stone\": {\n"
+            + "      \"trigger\": \"minecraft:inventory_changed\",\n"
+            + "      \"conditions\": {\n"
+            + "        \"items\": [\n"
+            + "          {\n"
+            + "            \"item\": \"minecraft:stone\""
+            + "          }\n"
+            + "        ]\n"
+            + "      }\n"
+            + "    }\n"
+            + "  }\n"
+            + "}";
+
+    private static Logger logger;
+
+    @Mod.EventHandler
+    public void preInit(FMLPreInitializationEvent event)
+    {
+        logger = event.getModLog();
+        if (ENABLED)
+        {
+            MinecraftForge.EVENT_BUS.register(AdvancementLoadEventTest.class);
+        }
+    }
+
+    @SubscribeEvent
+    public static void onAdvancementLoadEvent(AdvancementLoadEvent event)
+    {
+        try
+        {
+            Advancement.Builder builder = JsonUtils.fromJson(AdvancementManager.GSON, TEST_ADVANCEMENT_JSON, Advancement.Builder.class, false);
+            event.addAdvancement(TEST_ADVANCEMENT_NAME, builder);
+        }
+        catch (JsonParseException jsonparseexception)
+        {
+            logger.error("Parsing error loading test advancement", jsonparseexception);
+        }
+    }
+}

--- a/src/test/java/net/minecraftforge/debug/FunctionLoadEventTest.java
+++ b/src/test/java/net/minecraftforge/debug/FunctionLoadEventTest.java
@@ -12,7 +12,7 @@ import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
 public class FunctionLoadEventTest
 {
     static final String MOD_ID = "function_load_event_test";
-    private static final boolean ENABLED = true;
+    private static final boolean ENABLED = false;
     private static final ResourceLocation TEST_FUNCTION_NAME = new ResourceLocation(MOD_ID, "test");
     private static final String TEST_COMMAND = "say Test";
 

--- a/src/test/java/net/minecraftforge/debug/FunctionLoadEventTest.java
+++ b/src/test/java/net/minecraftforge/debug/FunctionLoadEventTest.java
@@ -1,0 +1,34 @@
+package net.minecraftforge.debug;
+
+import net.minecraft.command.FunctionObject;
+import net.minecraft.util.ResourceLocation;
+import net.minecraftforge.common.MinecraftForge;
+import net.minecraftforge.event.FunctionLoadEvent;
+import net.minecraftforge.fml.common.Mod;
+import net.minecraftforge.fml.common.event.FMLPreInitializationEvent;
+import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
+
+@Mod(modid = FunctionLoadEventTest.MOD_ID, name = "FunctionLoadEvent test mod", version = "1.0.0", acceptableRemoteVersions = "*")
+public class FunctionLoadEventTest
+{
+    static final String MOD_ID = "function_load_event_test";
+    private static final boolean ENABLED = true;
+    private static final ResourceLocation TEST_FUNCTION_NAME = new ResourceLocation(MOD_ID, "test");
+    private static final String TEST_COMMAND = "say Test";
+
+    @Mod.EventHandler
+    public void preInit(FMLPreInitializationEvent event)
+    {
+        if (ENABLED)
+        {
+            MinecraftForge.EVENT_BUS.register(FunctionLoadEventTest.class);
+        }
+    }
+
+    @SubscribeEvent
+    public static void onFunctionLoadEvent(FunctionLoadEvent event)
+    {
+        FunctionObject function = new FunctionObject(new FunctionObject.Entry[]{new FunctionObject.CommandEntry(TEST_COMMAND)});
+        event.addFunction(TEST_FUNCTION_NAME, function);
+    }
+}

--- a/src/test/java/net/minecraftforge/debug/StructureLoadEventTest.java
+++ b/src/test/java/net/minecraftforge/debug/StructureLoadEventTest.java
@@ -17,9 +17,9 @@ import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
 public class StructureLoadEventTest
 {
     static final String MOD_ID = "structure_load_event_test";
-    private static final boolean ENABLED = true;
+    private static final boolean ENABLED = false;
     private static final ResourceLocation TEST_STRUCTURE_NAME = new ResourceLocation(MOD_ID, "test");
-//    private static final ResourceLocation TEST_STRUCTURE_NAME = new ResourceLocation("igloo/igloo_top"); //Uncomment to test overriding a built-in structure
+//    private static final ResourceLocation TEST_STRUCTURE_NAME = new ResourceLocation("igloo/igloo_top"); //Uncomment and comment line above to test overriding a built-in structure
 
     @Mod.EventHandler
     public void preInit(FMLPreInitializationEvent event)
@@ -40,22 +40,22 @@ public class StructureLoadEventTest
             event.setStructure(structure);
         }
     }
-    
+
     // Creates a structure that is one stone block
     private static NBTTagCompound createTestStructureTag()
     {
         NBTTagCompound testStructureTag = new NBTTagCompound();
-        
+
         NBTTagList size = new NBTTagList();
         size.appendTag(new NBTTagInt(1));
         size.appendTag(new NBTTagInt(1));
         size.appendTag(new NBTTagInt(1));
         testStructureTag.setTag("size", size);
-        
+
         NBTTagList palette = new NBTTagList();
         palette.appendTag(NBTUtil.writeBlockState(new NBTTagCompound(), Blocks.STONE.getDefaultState()));
         testStructureTag.setTag("palette", palette);
-        
+
         NBTTagList blocks = new NBTTagList();
         NBTTagCompound blockTag = new NBTTagCompound();
         NBTTagList pos = new NBTTagList();
@@ -66,7 +66,7 @@ public class StructureLoadEventTest
         blockTag.setInteger("state", 0);
         blocks.appendTag(blockTag);
         testStructureTag.setTag("blocks", blocks);
-        
+
         return testStructureTag;
     }
 }

--- a/src/test/java/net/minecraftforge/debug/StructureLoadEventTest.java
+++ b/src/test/java/net/minecraftforge/debug/StructureLoadEventTest.java
@@ -1,0 +1,72 @@
+package net.minecraftforge.debug;
+
+import net.minecraft.init.Blocks;
+import net.minecraft.nbt.NBTTagCompound;
+import net.minecraft.nbt.NBTTagInt;
+import net.minecraft.nbt.NBTTagList;
+import net.minecraft.nbt.NBTUtil;
+import net.minecraft.util.ResourceLocation;
+import net.minecraft.world.gen.structure.template.Template;
+import net.minecraftforge.common.MinecraftForge;
+import net.minecraftforge.event.StructureLoadEvent;
+import net.minecraftforge.fml.common.Mod;
+import net.minecraftforge.fml.common.event.FMLPreInitializationEvent;
+import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
+
+@Mod(modid = StructureLoadEventTest.MOD_ID, name = "StructureLoadEvent test mod", version = "1.0.0", acceptableRemoteVersions = "*")
+public class StructureLoadEventTest
+{
+    static final String MOD_ID = "structure_load_event_test";
+    private static final boolean ENABLED = true;
+    private static final ResourceLocation TEST_STRUCTURE_NAME = new ResourceLocation(MOD_ID, "test");
+//    private static final ResourceLocation TEST_STRUCTURE_NAME = new ResourceLocation("igloo/igloo_top"); //Uncomment to test overriding a built-in structure
+
+    @Mod.EventHandler
+    public void preInit(FMLPreInitializationEvent event)
+    {
+        if (ENABLED)
+        {
+            MinecraftForge.EVENT_BUS.register(StructureLoadEventTest.class);
+        }
+    }
+
+    @SubscribeEvent
+    public static void onStructureLoadEvent(StructureLoadEvent event)
+    {
+        if (event.getName().equals(TEST_STRUCTURE_NAME))
+        {
+            Template structure = new Template();
+            structure.read(createTestStructureTag());
+            event.setStructure(structure);
+        }
+    }
+    
+    // Creates a structure that is one stone block
+    private static NBTTagCompound createTestStructureTag()
+    {
+        NBTTagCompound testStructureTag = new NBTTagCompound();
+        
+        NBTTagList size = new NBTTagList();
+        size.appendTag(new NBTTagInt(1));
+        size.appendTag(new NBTTagInt(1));
+        size.appendTag(new NBTTagInt(1));
+        testStructureTag.setTag("size", size);
+        
+        NBTTagList palette = new NBTTagList();
+        palette.appendTag(NBTUtil.writeBlockState(new NBTTagCompound(), Blocks.STONE.getDefaultState()));
+        testStructureTag.setTag("palette", palette);
+        
+        NBTTagList blocks = new NBTTagList();
+        NBTTagCompound blockTag = new NBTTagCompound();
+        NBTTagList pos = new NBTTagList();
+        pos.appendTag(new NBTTagInt(0));
+        pos.appendTag(new NBTTagInt(0));
+        pos.appendTag(new NBTTagInt(0));
+        blockTag.setTag("pos", pos);
+        blockTag.setInteger("state", 0);
+        blocks.appendTag(blockTag);
+        testStructureTag.setTag("blocks", blocks);
+        
+        return testStructureTag;
+    }
+}


### PR DESCRIPTION
**Problem:**
There is an event to load loot tables, as well as add to them when they try to load, but there is no way to do so with advancements, functions, or structures. 

It could be possible to use reflection to forcibly load the advancements, functions, or structures into their respective lists, but they are not registered nicely and don't respect the /reload command, since they will disappear whenever that command is run. They also would override the ones loaded from the world save files, which they shouldn't since those are like configuration files. An event would be much nicer and cleaner.

In particular, in the mod I'm writing, my goal is to allow players to put loot tables, structures, advancements, and functions in a shareable zip file they can place in a certain folder to load in all worlds. Loot tables are easy to load because of the event, but there is no way to load the others nicely.

**Solution:**
I've created three new events, StructureLoadEvent, AdvancementLoadEvent, and FunctionLoadEvent, which will fire when the respective objects load.

The structure event works the same as the loot table event, with the Template object that can be overridden or canceled to make it not load.

The advancement and function events have a list which modders can add new advancements and functions to, since they are loaded all at once, not individually. If you see a better way to do it, please let me know!

**Tests:**
I also added a test mod for each event. The structure and advancement ones have a commented out line for testing that it can override built-in structures and advancements.

I have a test world with a structure, advancement, and function set up to show the test mods won't override world save structures, advancements, and functions. Let me know the best way to share that world.