### PR TITLE
[1.12] Fixes Enum values field inlines

### DIFF
--- a/src/main/java/net/minecraftforge/classloading/EnumValuesTransformer.java
+++ b/src/main/java/net/minecraftforge/classloading/EnumValuesTransformer.java
@@ -39,12 +39,13 @@ public class EnumValuesTransformer implements IClassTransformer, Opcodes
     {
         if (basicClass == null)
             return null;
-        ClassNode classNode = new ClassNode();
-        ClassReader classReader = new ClassReader(basicClass);
-        classReader.accept(classNode, 0);
 
-        if ((classNode.access & ACC_ENUM) == 0)
+        ClassReader classReader = new ClassReader(basicClass);
+        if ((classReader.getAccess() & ACC_ENUM) == 0)
             return basicClass; // We only check enums
+
+        ClassNode classNode = new ClassNode();
+        classReader.accept(classNode, 0);
 
         for (FieldNode f : classNode.fields)
         {

--- a/src/main/java/net/minecraftforge/classloading/EnumValuesTransformer.java
+++ b/src/main/java/net/minecraftforge/classloading/EnumValuesTransformer.java
@@ -1,0 +1,61 @@
+/*
+ * Minecraft Forge
+ * Copyright (c) 2016.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation version 2.1
+ * of the License.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+package net.minecraftforge.classloading;
+
+import net.minecraft.launchwrapper.IClassTransformer;
+import org.objectweb.asm.ClassReader;
+import org.objectweb.asm.ClassWriter;
+import org.objectweb.asm.Opcodes;
+import org.objectweb.asm.tree.ClassNode;
+import org.objectweb.asm.tree.FieldNode;
+
+import javax.annotation.Nullable;
+
+/**
+ * Transforms the field {@code private static final Enum[] $VALUES} in enums so
+ * that it is not considered final and got inlined.
+ */
+public class EnumValuesTransformer implements IClassTransformer, Opcodes
+{
+    @Override
+    public byte[] transform(String name, String transformedName, @Nullable byte[] basicClass)
+    {
+        if (basicClass == null)
+            return null;
+        ClassNode classNode = new ClassNode();
+        ClassReader classReader = new ClassReader(basicClass);
+        classReader.accept(classNode, 0);
+
+        if ((classNode.access & ACC_ENUM) == 0)
+            return basicClass; // We only check enums
+
+        for (FieldNode f : classNode.fields)
+        {
+            if ((f.name.equals("$VALUES") || f.name.equals("ENUM$VALUES")) && (f.access & ACC_STATIC) != 0)
+            {
+                f.access &= ~ACC_FINAL;
+            }
+        }
+
+        ClassWriter writer = new ClassWriter(ClassWriter.COMPUTE_MAXS);
+        classNode.accept(writer);
+        return writer.toByteArray();
+    }
+}

--- a/src/main/java/net/minecraftforge/classloading/FMLForgePlugin.java
+++ b/src/main/java/net/minecraftforge/classloading/FMLForgePlugin.java
@@ -34,7 +34,7 @@ public class FMLForgePlugin implements IFMLLoadingPlugin
     @Override
     public String[] getASMTransformerClass()
     {
-        return new String[0];
+        return new String[] {"net.minecraftforge.classloading.EnumValuesTransformer"};
     }
 
     @Override

--- a/src/test/java/net/minecraftforge/debug/EnumValuesTransformerTest.java
+++ b/src/test/java/net/minecraftforge/debug/EnumValuesTransformerTest.java
@@ -14,7 +14,7 @@ import javax.annotation.Nullable;
 public class EnumValuesTransformerTest
 {
     static final String MOD_ID = "enum_values_transformer_test";
-    static final boolean DISABLED = false;
+    static final boolean DISABLED = true;
     static final Class<?>[] EMPTY_CLASSES = new Class<?>[0];
     static final Object[] EMPTY_ARGS = new Object[0];
     @Nullable

--- a/src/test/java/net/minecraftforge/debug/EnumValuesTransformerTest.java
+++ b/src/test/java/net/minecraftforge/debug/EnumValuesTransformerTest.java
@@ -1,0 +1,46 @@
+package net.minecraftforge.debug;
+
+import net.minecraftforge.common.util.EnumHelper;
+import net.minecraftforge.fml.common.Mod;
+import net.minecraftforge.fml.common.event.FMLInitializationEvent;
+
+import javax.annotation.Nullable;
+
+/**
+ * A test for {@link net.minecraftforge.classloading.EnumValuesTransformer}.
+ */
+@SuppressWarnings("unused")
+@Mod(modid = EnumValuesTransformerTest.MOD_ID, name = "Enum Values Transformer Test", version = "0.1")
+public class EnumValuesTransformerTest
+{
+    static final String MOD_ID = "enum_values_transformer_test";
+    static final boolean DISABLED = false;
+    static final Class<?>[] EMPTY_CLASSES = new Class<?>[0];
+    static final Object[] EMPTY_ARGS = new Object[0];
+    @Nullable
+    TestEnum last;
+
+    @Mod.EventHandler
+    public void init(FMLInitializationEvent event)
+    {
+        if (DISABLED)
+            return;
+        //10000 is big enough
+        for (int i = 1; i <= 10000; i++)
+        {
+            EnumHelper.addEnum(TestEnum.class, "V_" + i, EMPTY_CLASSES, EMPTY_ARGS);
+            TestEnum.values(); // trigger jvm inline
+        }
+        TestEnum[] arr = TestEnum.values();
+        last = arr[arr.length - 1];
+
+        if (!last.name().equals("V_10000"))
+            throw new Error("The enum values field was incorrectly inlined!");
+    }
+
+    private enum TestEnum
+    {
+        V_0
+    }
+
+}


### PR DESCRIPTION
Fixes #3885. This is not a breaking change.

Blast the final modifier on the enum `$VALUES` field in the bytecode so
that the field does not get inlined.

Test mod info:
Without blasting, the last element in the values array is typically around `V_6000`.
With blasting, the test mod works correctly (Loads without a crash).

The test mod crashes in init with an error if the last element in the values array is not `V_10000`.
The screenshot shows that the crash did not happen while the mod is loaded itself.

@mezz Would you mind testing?

![2018-01-05_13 26 25](https://user-images.githubusercontent.com/7806504/34629178-1f4054ea-f21c-11e7-9cf8-d491623eb623.png)
