### PR TITLE
Fix enum inlining & remove a couple of internal sun class usages

### DIFF
--- a/src/main/java/net/minecraftforge/common/util/EnumHelper.java
+++ b/src/main/java/net/minecraftforge/common/util/EnumHelper.java
@@ -26,6 +26,7 @@ import com.google.common.base.Predicate;
 import com.google.common.collect.Lists;
 
 import net.minecraft.entity.passive.IAnimals;
+import net.minecraft.launchwrapper.LaunchClassLoader;
 import net.minecraftforge.fml.common.EnhancedRuntimeException;
 import net.minecraftforge.fml.common.FMLLog;
 import net.minecraft.block.BlockPressurePlate.Sensitivity;
@@ -230,6 +231,8 @@ public class EnumHelper
     //Tests an enum is compatible with these args, throws an error if not.
     public static void testEnum(Class<? extends Enum<?>> enumType, Class<?>[] paramTypes)
     {
+        if (!(EnumHelper.class.getClassLoader() instanceof LaunchClassLoader))
+            return;
         addEnum(true, enumType, null, paramTypes, (Object[])null);
     }
 

--- a/src/main/java/net/minecraftforge/fml/common/asm/transformers/EnumConstructorTransformer.java
+++ b/src/main/java/net/minecraftforge/fml/common/asm/transformers/EnumConstructorTransformer.java
@@ -1,0 +1,110 @@
+/*
+ * Minecraft Forge
+ * Copyright (c) 2017.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation version 2.1
+ * of the License.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+package net.minecraftforge.fml.common.asm.transformers;
+
+import net.minecraft.launchwrapper.IClassTransformer;
+import org.objectweb.asm.ClassReader;
+import org.objectweb.asm.ClassVisitor;
+import org.objectweb.asm.ClassWriter;
+import org.objectweb.asm.FieldVisitor;
+import org.objectweb.asm.MethodVisitor;
+import org.objectweb.asm.Opcodes;
+import org.objectweb.asm.Type;
+import org.objectweb.asm.commons.GeneratorAdapter;
+import org.objectweb.asm.commons.Method;
+
+/**
+ * Transforms all Enum classes to expose a <code>public static T $$newInstance</code> method for each constructor,
+ * with matching arguments, for use via reflection in {@link net.minecraftforge.common.util.EnumHelper}.
+ * This solves the whole 'enum constructors are forcibly private' issue. Even transforming the constructors
+ * to public does not work.
+ * <p>
+ * Also sets the $VALUES field to non-final, to prevent JVM optimisation and because at least on Java 9,
+ * even with changing the Field object's modifiers, setting will still fail otherwise.
+ */
+public class EnumConstructorTransformer implements IClassTransformer
+{
+
+    @Override
+    public byte[] transform(String name, String transformedName, byte[] basicClass)
+    {
+        ClassReader cr = new ClassReader(basicClass);
+        if ((cr.getAccess() & Opcodes.ACC_ENUM) == 0)
+        {
+            return basicClass;
+        }
+        Visitor visitor = new Visitor();
+        cr.accept(visitor, 0);
+        return visitor.toByteArray();
+    }
+
+    private static class Visitor extends ClassVisitor
+    {
+        private ClassWriter cw;
+        private Type thisType;
+
+        Visitor()
+        {
+            super(Opcodes.ASM5);
+            this.cv = this.cw = new ClassWriter(ClassWriter.COMPUTE_MAXS);
+        }
+
+        @Override
+        public void visit(int version, int access, String name, String signature, String superName, String[] interfaces)
+        {
+            super.visit(version, access, name, signature, superName, interfaces);
+            this.thisType = Type.getObjectType(name);
+        }
+
+        @Override
+        public MethodVisitor visitMethod(int access, String name, String desc, String signature, String[] exceptions)
+        {
+            if (name.equals("<init>"))
+            {
+                Method thisConstructor = new Method(name, desc);
+                Method delegate = new Method("$$newInstance", this.thisType, thisConstructor.getArgumentTypes());
+                int delegateAccess = Opcodes.ACC_PUBLIC | Opcodes.ACC_STATIC;
+                MethodVisitor mv = super.visitMethod(delegateAccess, delegate.getName(), delegate.getDescriptor(), null, null);
+                GeneratorAdapter generated = new GeneratorAdapter(mv, delegateAccess, delegate.getName(), delegate.getDescriptor());
+                generated.newInstance(this.thisType);
+                generated.dup();
+                generated.loadArgs();
+                generated.invokeConstructor(this.thisType, thisConstructor);
+                generated.returnValue();
+                generated.endMethod();
+            }
+            return super.visitMethod(access, name, desc, signature, exceptions);
+        }
+
+        @Override
+        public FieldVisitor visitField(int access, String name, String desc, String signature, Object value)
+        {
+            if ((name.equals("$VALUES") || name.equals("ENUM$VALUES")) && desc.equals("[" + this.thisType.getDescriptor()))
+            {
+                access &= ~Opcodes.ACC_FINAL;
+            }
+            return super.visitField(access, name, desc, signature, value);
+        }
+
+        public byte[] toByteArray()
+        {
+            return this.cw.toByteArray();
+        }
+    }
+}

--- a/src/main/java/net/minecraftforge/fml/common/asm/transformers/EnumConstructorTransformer.java
+++ b/src/main/java/net/minecraftforge/fml/common/asm/transformers/EnumConstructorTransformer.java
@@ -44,6 +44,8 @@ public class EnumConstructorTransformer implements IClassTransformer
     @Override
     public byte[] transform(String name, String transformedName, byte[] basicClass)
     {
+        if (basicClass == null)
+            return null;
         ClassReader cr = new ClassReader(basicClass);
         if ((cr.getAccess() & Opcodes.ACC_ENUM) == 0)
         {

--- a/src/main/java/net/minecraftforge/fml/relauncher/FMLCorePlugin.java
+++ b/src/main/java/net/minecraftforge/fml/relauncher/FMLCorePlugin.java
@@ -31,6 +31,7 @@ public class FMLCorePlugin implements IFMLLoadingPlugin
                              "net.minecraftforge.fml.common.asm.transformers.SideTransformer",
                              "net.minecraftforge.fml.common.asm.transformers.EventSubscriptionTransformer",
                              "net.minecraftforge.fml.common.asm.transformers.EventSubscriberTransformer",
+                             "net.minecraftforge.fml.common.asm.transformers.EnumConstructorTransformer"
                             };
     }
 

--- a/src/main/java/net/minecraftforge/registries/ObjectHolderRef.java
+++ b/src/main/java/net/minecraftforge/registries/ObjectHolderRef.java
@@ -154,19 +154,12 @@ class ObjectHolderRef
     private static class FinalFieldHelper
     {
         private static Field modifiersField;
-        private static Object reflectionFactory;
-        private static Method newFieldAccessor;
-        private static Method fieldAccessorSet;
 
         static Field makeWritable(Field f) throws ReflectiveOperationException
         {
             f.setAccessible(true);
             if (modifiersField == null)
             {
-                Method getReflectionFactory = Class.forName("sun.reflect.ReflectionFactory").getDeclaredMethod("getReflectionFactory");
-                reflectionFactory = getReflectionFactory.invoke(null);
-                newFieldAccessor = Class.forName("sun.reflect.ReflectionFactory").getDeclaredMethod("newFieldAccessor", Field.class, boolean.class);
-                fieldAccessorSet = Class.forName("sun.reflect.FieldAccessor").getDeclaredMethod("set", Object.class, Object.class);
                 modifiersField = Field.class.getDeclaredField("modifiers");
                 modifiersField.setAccessible(true);
             }
@@ -176,8 +169,7 @@ class ObjectHolderRef
 
         static void setField(Field field, @Nullable Object instance, Object thing) throws ReflectiveOperationException
         {
-            Object fieldAccessor = newFieldAccessor.invoke(reflectionFactory, field, false);
-            fieldAccessorSet.invoke(fieldAccessor, instance, thing);
+            field.set(instance, thing);
         }
     }
 }

--- a/src/test/java/net/minecraftforge/debug/EnumValuesInlineTest.java
+++ b/src/test/java/net/minecraftforge/debug/EnumValuesInlineTest.java
@@ -1,0 +1,56 @@
+package net.minecraftforge.debug;
+
+import net.minecraftforge.common.util.EnumHelper;
+import net.minecraftforge.fml.common.Mod;
+import net.minecraftforge.fml.common.event.FMLInitializationEvent;
+import org.apache.logging.log4j.LogManager;
+
+import javax.annotation.Nullable;
+
+/**
+ * A test for {@link net.minecraftforge.fml.common.asm.transformers.EnumConstructorTransformer}.
+ * Also tests that the JVM does <i>not</i> inline the Enum.$VALUES field.
+ */
+@SuppressWarnings("unused")
+@Mod(modid = EnumValuesInlineTest.MOD_ID, name = "Enum Values Transformer Test", version = "0.1")
+public class EnumValuesInlineTest
+{
+    static final String MOD_ID = "enum_values_transformer_test";
+    static final boolean DISABLED = false;
+    static final Class<?>[] EMPTY_CLASSES = new Class<?>[0];
+    static final Object[] EMPTY_ARGS = new Object[0];
+    @Nullable
+    TestEnum last;
+
+    @Mod.EventHandler
+    public void init(FMLInitializationEvent event)
+    {
+        if (DISABLED)
+            return;
+
+        try {
+            TestEnum.class.getDeclaredMethod("$$newInstance", String.class, int.class);
+        } catch (NoSuchMethodException e){
+            throw new Error("$$newInstance method not present", e);
+        }
+
+        //10000 is big enough
+        for (int i = 1; i <= 10000; i++)
+        {
+            EnumHelper.addEnum(TestEnum.class, "V_" + i, EMPTY_CLASSES, EMPTY_ARGS);
+            TestEnum.values(); // trigger jvm inline
+        }
+        TestEnum[] arr = TestEnum.values();
+        last = arr[arr.length - 1];
+
+        if (!last.name().equals("V_10000"))
+            throw new Error("The enum values field was incorrectly inlined!");
+        LogManager.getLogger(EnumValuesInlineTest.class).info("EnumValuesInlineTest completed successfully.");
+    }
+
+    private enum TestEnum
+    {
+        V_0
+    }
+
+}

--- a/src/test/java/net/minecraftforge/debug/EnumValuesInlineTest.java
+++ b/src/test/java/net/minecraftforge/debug/EnumValuesInlineTest.java
@@ -12,10 +12,10 @@ import javax.annotation.Nullable;
  * Also tests that the JVM does <i>not</i> inline the Enum.$VALUES field.
  */
 @SuppressWarnings("unused")
-@Mod(modid = EnumValuesInlineTest.MOD_ID, name = "Enum Values Transformer Test", version = "0.1")
+@Mod(modid = EnumValuesInlineTest.MOD_ID, name = "Enum Values Constructor Test", version = "0.1")
 public class EnumValuesInlineTest
 {
-    static final String MOD_ID = "enum_values_transformer_test";
+    static final String MOD_ID = "enum_values_constructor_test";
     static final boolean DISABLED = false;
     static final Class<?>[] EMPTY_CLASSES = new Class<?>[0];
     static final Object[] EMPTY_ARGS = new Object[0];
@@ -45,7 +45,7 @@ public class EnumValuesInlineTest
 
         if (!last.name().equals("V_10000"))
             throw new Error("The enum values field was incorrectly inlined!");
-        LogManager.getLogger(EnumValuesInlineTest.class).info("EnumValuesInlineTest completed successfully.");
+        LogManager.getLogger(MOD_ID).info("EnumValuesInlineTest completed successfully.");
     }
 
     private enum TestEnum

--- a/src/test/java/net/minecraftforge/fml/common/registry/ForgeTestRunner.java
+++ b/src/test/java/net/minecraftforge/fml/common/registry/ForgeTestRunner.java
@@ -126,6 +126,11 @@ public class ForgeTestRunner extends Runner
                 }
             }
 
+            //Avoid JVM duplicate class def error
+            if (name.equals("net.minecraft.launchwrapper.LaunchClassLoader")){
+                quarantine = false;
+            }
+
             if (quarantine)
             {
                 try

--- a/src/test/java/net/minecraftforge/test/BiomeSpawnableListTest.java
+++ b/src/test/java/net/minecraftforge/test/BiomeSpawnableListTest.java
@@ -7,14 +7,24 @@ import net.minecraft.entity.passive.AbstractHorse;
 import net.minecraft.entity.passive.EntityHorse;
 import net.minecraft.init.Biomes;
 import net.minecraft.init.Bootstrap;
+import net.minecraft.launchwrapper.LaunchClassLoader;
+import net.minecraft.launchwrapper.LogWrapper;
 import net.minecraft.world.biome.Biome;
 import net.minecraftforge.common.util.EnumHelper;
 import net.minecraftforge.fml.common.Loader;
 import net.minecraftforge.fml.common.registry.EntityRegistry;
 import net.minecraftforge.fml.common.registry.ForgeTestRunner;
+import org.apache.logging.log4j.Level;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+
+import java.io.File;
+import java.lang.reflect.Method;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.util.StringTokenizer;
 
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
@@ -22,51 +32,119 @@ import static org.junit.Assert.assertTrue;
 @RunWith(ForgeTestRunner.class)
 public class BiomeSpawnableListTest
 {
-    private static EnumCreatureType creatureTypeHorse;
+    private static Class<?> innerClass;
+    private static Object inner;
 
+    @SuppressWarnings("unchecked")
     @BeforeClass
     public static void setUp() throws Exception
     {
-        Loader.instance();
-        Bootstrap.register();
-        creatureTypeHorse = EnumHelper.addCreatureType("biomespawnablelisttest:horse", AbstractHorse.class, 20, Material.AIR, true, true);
-    }
-
-    private boolean spawnableListContainsEntry(Class<? extends EntityLiving> entityClass, int weightedProb, int minGroupCount, int maxGroupCount,
-                                               EnumCreatureType creatureType, Biome biome)
-    {
-        boolean found = false;
-
-        for (Biome.SpawnListEntry spawnListEntry : biome.getSpawnableList(creatureType))
-        {
-            if (spawnListEntry.entityClass == entityClass && spawnListEntry.itemWeight == weightedProb && spawnListEntry.minGroupCount == minGroupCount
-                    && spawnListEntry.maxGroupCount == maxGroupCount)
-            {
-                found = true;
-                break;
-            }
-        }
-
-        return found;
+        //Enumhelper uses ASM, need to load it with the LaunchClassLoader
+        LaunchClassLoader classLoader = new LaunchClassLoader(getClassloaderURLs());
+        classLoader.registerTransformer("net.minecraftforge.fml.common.asm.transformers.EnumConstructorTransformer");
+        innerClass = classLoader.findClass("net.minecraftforge.test.BiomeSpawnableListTest$LaunchclassLoaded");
+        inner = innerClass.getConstructors()[0].newInstance();
     }
 
     @Test
     public void testAddAndRemoveSpawn() throws Exception
     {
-        final Class<EntityHorse> entityClass = EntityHorse.class;
-        final int weightedProb = 1;
-        final int minGroupCount = 1;
-        final int maxGroupCount = 20;
-        final Biome biome = Biomes.PLAINS;
+        innerClass.getDeclaredMethod("testAddAndRemoveSpawn").invoke(inner);
+    }
 
-        // Test 1: We can add a spawn for the non-vanilla EnumCreatureType
-        EntityRegistry.addSpawn(entityClass, weightedProb, minGroupCount, maxGroupCount, creatureTypeHorse, biome);
-        final boolean containsEntryAfterAdd = spawnableListContainsEntry(entityClass, weightedProb, minGroupCount, maxGroupCount, creatureTypeHorse, biome);
-        assertTrue("The SpawnListEntry wasn't added", containsEntryAfterAdd);
+    private static URL[] getClassloaderURLs(){
+        URL[] urls;
+        if (BiomeSpawnableListTest.class.getClassLoader() instanceof URLClassLoader){
+            urls = ((URLClassLoader) BiomeSpawnableListTest.class.getClassLoader()).getURLs();
+        } else {
+            String classPath = appendPath(System.getProperty("java.class.path"), System.getProperty("env.class.path"));
+            urls = pathToURLs(classPath);
+        }
+        return urls;
+    }
 
-        // Test 2: We can remove a spawn for the non-vanilla EnumCreatureType
-        EntityRegistry.removeSpawn(entityClass, creatureTypeHorse, biome);
-        final boolean containsEntryAfterRemove = spawnableListContainsEntry(entityClass, weightedProb, minGroupCount, maxGroupCount, creatureTypeHorse, biome);
-        assertFalse("The SpawnListEntry wasn't removed", containsEntryAfterRemove);
+    private static URL fileToURL(File file) {
+        try {
+            return file.toURI().toURL();
+        } catch (MalformedURLException e) {
+            LogWrapper.log(Level.ERROR, e, "Could not convert {} to URL", file.toString());
+            return null;
+        }
+    }
+
+    //the following 2 methods are largely copied from internal sun.* classes
+    public static String appendPath(String pathTo, String pathFrom) {
+        if (pathTo == null || pathTo.length() == 0) {
+            return pathFrom;
+        } else if (pathFrom == null || pathFrom.length() == 0) {
+            return pathTo;
+        } else {
+            return pathTo  + File.pathSeparator + pathFrom;
+        }
+    }
+
+    public static URL[] pathToURLs(String path) {
+        StringTokenizer st = new StringTokenizer(path, File.pathSeparator);
+        URL[] urls = new URL[st.countTokens()];
+        int count = 0;
+        while (st.hasMoreTokens()) {
+            URL url = fileToURL(new File(st.nextToken()));
+            if (url != null) {
+                urls[count++] = url;
+            }
+        }
+        if (urls.length != count) {
+            URL[] tmp = new URL[count];
+            System.arraycopy(urls, 0, tmp, 0, count);
+            urls = tmp;
+        }
+        return urls;
+    }
+
+    public static class LaunchclassLoaded {
+        private EnumCreatureType creatureTypeHorse;
+
+        public LaunchclassLoaded(){
+            Loader.instance();
+            Bootstrap.register();
+            creatureTypeHorse = EnumHelper.addCreatureType("biomespawnablelisttest:horse", AbstractHorse.class, 20, Material.AIR, true, true);
+        }
+
+        private boolean spawnableListContainsEntry(Class<? extends EntityLiving> entityClass, int weightedProb, int minGroupCount, int maxGroupCount,
+                                                   EnumCreatureType creatureType, Biome biome)
+        {
+            boolean found = false;
+
+            for (Biome.SpawnListEntry spawnListEntry : biome.getSpawnableList(creatureType))
+            {
+                if (spawnListEntry.entityClass == entityClass && spawnListEntry.itemWeight == weightedProb && spawnListEntry.minGroupCount == minGroupCount
+                        && spawnListEntry.maxGroupCount == maxGroupCount)
+                {
+                    found = true;
+                    break;
+                }
+            }
+
+            return found;
+        }
+
+        public void testAddAndRemoveSpawn() throws Exception
+        {
+            final Class<EntityHorse> entityClass = EntityHorse.class;
+            final int weightedProb = 1;
+            final int minGroupCount = 1;
+            final int maxGroupCount = 20;
+            final Biome biome = Biomes.PLAINS;
+
+            // Test 1: We can add a spawn for the non-vanilla EnumCreatureType
+            EntityRegistry.addSpawn(entityClass, weightedProb, minGroupCount, maxGroupCount, creatureTypeHorse, biome);
+            final boolean containsEntryAfterAdd = spawnableListContainsEntry(entityClass, weightedProb, minGroupCount, maxGroupCount, creatureTypeHorse, biome);
+            assertTrue("The SpawnListEntry wasn't added", containsEntryAfterAdd);
+
+            // Test 2: We can remove a spawn for the non-vanilla EnumCreatureType
+            EntityRegistry.removeSpawn(entityClass, creatureTypeHorse, biome);
+            final boolean containsEntryAfterRemove = spawnableListContainsEntry(entityClass, weightedProb, minGroupCount, maxGroupCount, creatureTypeHorse, biome);
+            assertFalse("The SpawnListEntry wasn't removed", containsEntryAfterRemove);
+        }
     }
 }


### PR DESCRIPTION
- ObjectHolderRef: removes usage of the internal field accessor class as from all of my testing it is not required
- EnumHelper: changes to use an ASM added method to construct the new enum instance, and sets the `$VALUES` field to non-final, for JVM optimiser reasons and because it's forcibly non-settable via reflection otherwise
    - See #4655 which aimed to solve #3885 for JVM optimisation discussion

Bonus: this all works under Java 9, and I've not found anything else that prevents J9 usage