### PR TITLE
Don't allow field to be of same type annotated by @Config

### DIFF
--- a/src/main/java/net/minecraftforge/common/config/ConfigManager.java
+++ b/src/main/java/net/minecraftforge/common/config/ConfigManager.java
@@ -224,6 +224,8 @@ public class ConfigManager
                 continue;
             if (f.isAnnotationPresent(Config.Ignore.class))
                 continue;
+            if (f.getType().equals(cls))
+                continue;
 
             String comment = null;
             Comment ca = f.getAnnotation(Comment.class);


### PR DESCRIPTION
This PR is meant to address an issue where an annotated config can potentially cause a stack overflow error.

Given a config defined as
```java
@Config(modid = ID)
class MyConfig {
    public static MyConfig config = new MyConfig();
    public MyConfig recurse = new MyConfig();
}
```
a `StackOverFlowError` will be thrown.

This fixes this by ignoring a field in the config of the same type. For example:

```java
@Config(modid = "ex")
public class MyConfig {
    public static MyConfig myConfig = new MyConfig(); // Will be skipped

    public static Category category = new Category(); // Will not be skipped
    private static class Category {
        (...)
    }
}
```
Although this has little bearing on people who use java, since they're not often going to be using a singleton pattern like this, it fixes an issue for those who use Kotlin in their mods where the following:
```kotlin
@Config(modid = ID)
object MyConfig {
    @JvmField
    var test: Int = 1
}
```
produces roughly the equivalent java:
```java
@Config(modid = ID)
public final class MyConfig {
    static {
        MyConfig localMyConfig = new MyConfig();
        INSTANCE = localMyConfig;
    }
 

    public static int test = 1;

    public static final MyConfig INSTANCE;
}
```

In this case, it results in an unwanted/empty `instance` block in the config file:
```
general {
    I:test=1
    instance {
    }
}
```
  
  
  