### PR TITLE
Prevent EntityPlayer.attackEntityFrom from firing LivingAttackEvent twice

### DIFF
--- a/patches/minecraft/net/minecraft/client/entity/EntityOtherPlayerMP.java.patch
+++ b/patches/minecraft/net/minecraft/client/entity/EntityOtherPlayerMP.java.patch
@@ -4,7 +4,7 @@
  
      public boolean func_70097_a(DamageSource p_70097_1_, float p_70097_2_)
      {
-+        net.minecraftforge.common.ForgeHooks.onLivingAttack(this, p_70097_1_, p_70097_2_);
++        net.minecraftforge.common.ForgeHooks.onPlayerAttack(this, p_70097_1_, p_70097_2_);
          return true;
      }
  

--- a/patches/minecraft/net/minecraft/client/entity/EntityPlayerSP.java.patch
+++ b/patches/minecraft/net/minecraft/client/entity/EntityPlayerSP.java.patch
@@ -4,7 +4,7 @@
  
      public boolean func_70097_a(DamageSource p_70097_1_, float p_70097_2_)
      {
-+        net.minecraftforge.common.ForgeHooks.onLivingAttack(this, p_70097_1_, p_70097_2_);
++        net.minecraftforge.common.ForgeHooks.onPlayerAttack(this, p_70097_1_, p_70097_2_);
          return false;
      }
  

--- a/patches/minecraft/net/minecraft/entity/player/EntityPlayer.java.patch
+++ b/patches/minecraft/net/minecraft/entity/player/EntityPlayer.java.patch
@@ -202,7 +202,7 @@
  
      public boolean func_70097_a(DamageSource p_70097_1_, float p_70097_2_)
      {
-+        if (!net.minecraftforge.common.ForgeHooks.onLivingAttack(this, p_70097_1_, p_70097_2_)) return false;
++        if (!net.minecraftforge.common.ForgeHooks.onPlayerAttack(this, p_70097_1_, p_70097_2_)) return false;
          if (this.func_180431_b(p_70097_1_))
          {
              return false;

--- a/src/main/java/net/minecraftforge/common/ForgeHooks.java
+++ b/src/main/java/net/minecraftforge/common/ForgeHooks.java
@@ -558,6 +558,11 @@ public class ForgeHooks
 
     public static boolean onLivingAttack(EntityLivingBase entity, DamageSource src, float amount)
     {
+        return entity instanceof EntityPlayer || !MinecraftForge.EVENT_BUS.post(new LivingAttackEvent(entity, src, amount));
+    }
+
+    public static boolean onPlayerAttack(EntityLivingBase entity, DamageSource src, float amount)
+    {
         return !MinecraftForge.EVENT_BUS.post(new LivingAttackEvent(entity, src, amount));
     }
 

--- a/src/test/java/net/minecraftforge/debug/LivingAttackEventTest.java
+++ b/src/test/java/net/minecraftforge/debug/LivingAttackEventTest.java
@@ -10,18 +10,22 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 @Mod(modid = LivingAttackEventTest.MODID, name = LivingAttackEventTest.NAME, version = "1.0.0", acceptableRemoteVersions = "*")
-public class LivingAttackEventTest {
+public class LivingAttackEventTest
+{
 
     public static final String MODID = "livingattackeventtest";
     public static final String NAME = "LivingAttackEventTest";
     private static final Logger LOGGER = LogManager.getLogger(NAME);
 
     @EventBusSubscriber
-    public static class LivingAttackEventHandler {
+    public static class LivingAttackEventHandler
+    {
 
         @SubscribeEvent
-        public static void onLivingAttack(LivingAttackEvent event) {
-            if (event.getSource() == DamageSource.ANVIL) {
+        public static void onLivingAttack(LivingAttackEvent event)
+        {
+            if (event.getSource() == DamageSource.ANVIL)
+            {
                 LOGGER.info("{} was hit by an anvil!", event.getEntityLiving().getName());
             }
         }

--- a/src/test/java/net/minecraftforge/debug/LivingAttackEventTest.java
+++ b/src/test/java/net/minecraftforge/debug/LivingAttackEventTest.java
@@ -1,0 +1,29 @@
+package net.minecraftforge.debug;
+
+import net.minecraft.util.DamageSource;
+import net.minecraftforge.event.entity.living.LivingAttackEvent;
+import net.minecraftforge.fml.common.Mod;
+import net.minecraftforge.fml.common.Mod.EventBusSubscriber;
+import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+@Mod(modid = LivingAttackEventTest.MODID, name = LivingAttackEventTest.NAME, version = "1.0.0", acceptableRemoteVersions = "*")
+public class LivingAttackEventTest {
+
+    public static final String MODID = "livingattackeventtest";
+    public static final String NAME = "LivingAttackEventTest";
+    private static final Logger LOGGER = LogManager.getLogger(NAME);
+
+    @EventBusSubscriber
+    public static class LivingAttackEventHandler {
+
+        @SubscribeEvent
+        public static void onLivingAttack(LivingAttackEvent event) {
+            if (event.getSource() == DamageSource.ANVIL) {
+                LOGGER.info("{} was hit by an anvil!", event.getEntityLiving().getName());
+            }
+        }
+    }
+}


### PR DESCRIPTION
Solves the bug described by #4171:
>EntityPlayer.attackEntityFrom calls net.minecraftforge.common.ForgeHooks.onLivingAttack but at the end of the method, if the damage amount is greater than 0, it calls super.attackEntityFrom (EntityLivingBase) which calls it again.

This pull requests adds a new hook, `onPlayerAttack`, which is called by the `EntityPlayer`, `EntityPlayerSP`, and `EntityOtherPlayerMP` implementations of the `attackEntityFrom` method, instead of the current `onLivingAttack` calls. The `onPlayerAttack` hook fires a `LivingAttackEvent`.

The `onLivingAttack` hook is still called from `EntityLivingBase.attackEntityFrom`, but returns immediately if the entity is a player, preventing the `LivingAttackEvent` from being fired by the `super.attackEntityFrom` call in `EntityPlayer`.

The pull request contains a test mod that logs the name of any living entity that is attacked by a falling anvil. To verify that the bug has been fixed, place an anvil in the air above a player, and let it fall on the player. The player will receive the usual "falling anvil"-damage, and a message will be printed to the log. If the message is printed once, the issue has been solved. If the message is printed twice, the bug is still present.
  