### PR TITLE
Make the lead-breaking distance a variable instead of hardcoding it

### DIFF
--- a/patches/minecraft/net/minecraft/entity/EntityCreature.java.patch
+++ b/patches/minecraft/net/minecraft/entity/EntityCreature.java.patch
@@ -4,7 +4,7 @@
      private BlockPos field_70775_bC = BlockPos.field_177992_a;
      private float field_70772_bD = -1.0F;
      private final float field_184661_bw = PathNodeType.WATER.func_186289_a();
-+    /** Forge: make maxLeashDistance a field instead of hard-coded */
++    /** Forge: make the distance between entities at which a leash breaks a field instead of hard-coded */
 +    protected float maxLeashDistance = 10.0F;
  
      public EntityCreature(World p_i1602_1_)
@@ -31,8 +31,8 @@
      protected void func_142017_o(float p_142017_1_)
      {
      }
-+    /** Returns the maximum leash distance for this entity */
++    /** Returns the maximum length of a leash before it breaks for this entity */
 +    public float getMaxLeashDistance() { return maxLeashDistance; }
-+    /** Sets the maximum leash distance for this entity */
++    /** Sets the maximum length of a leash before it breakss for this entity */
 +    public void setMaxLeashDistance(float distance) { maxLeashDistance = distance; }
  }

--- a/patches/minecraft/net/minecraft/entity/EntityCreature.java.patch
+++ b/patches/minecraft/net/minecraft/entity/EntityCreature.java.patch
@@ -4,7 +4,7 @@
      private BlockPos field_70775_bC = BlockPos.field_177992_a;
      private float field_70772_bD = -1.0F;
      private final float field_184661_bw = PathNodeType.WATER.func_186289_a();
-+    protected float maxLeashDistance = 10.0F;
++    protected float maxLeashDistance = 10.0F; // forge: make maxLeashDistance a field instead of hard-coded
  
      public EntityCreature(World p_i1602_1_)
      {

--- a/patches/minecraft/net/minecraft/entity/EntityCreature.java.patch
+++ b/patches/minecraft/net/minecraft/entity/EntityCreature.java.patch
@@ -1,14 +1,16 @@
 --- ../src-base/minecraft/net/minecraft/entity/EntityCreature.java
 +++ ../src-work/minecraft/net/minecraft/entity/EntityCreature.java
-@@ -15,6 +15,7 @@
+@@ -15,6 +15,9 @@
      private BlockPos field_70775_bC = BlockPos.field_177992_a;
      private float field_70772_bD = -1.0F;
      private final float field_184661_bw = PathNodeType.WATER.func_186289_a();
 +    protected float maxLeashDistance = 10.0F; // forge: make maxLeashDistance a field instead of hard-coded
++    public float getMaxLeashDistance() { return maxLeashDistance; }
++    public void setMaxLeashDistance(float distance) { maxLeashDistance = distance; }
  
      public EntityCreature(World p_i1602_1_)
      {
-@@ -91,7 +92,7 @@
+@@ -91,7 +94,7 @@
  
              if (this instanceof EntityTameable && ((EntityTameable)this).func_70906_o())
              {
@@ -17,7 +19,7 @@
                  {
                      this.func_110160_i(true, true);
                  }
-@@ -101,7 +102,7 @@
+@@ -101,7 +104,7 @@
  
              this.func_142017_o(f);
  

--- a/patches/minecraft/net/minecraft/entity/EntityCreature.java.patch
+++ b/patches/minecraft/net/minecraft/entity/EntityCreature.java.patch
@@ -4,7 +4,7 @@
      private BlockPos field_70775_bC = BlockPos.field_177992_a;
      private float field_70772_bD = -1.0F;
      private final float field_184661_bw = PathNodeType.WATER.func_186289_a();
-+    protected static float maxLeashDistance = 10.0F;
++    protected float maxLeashDistance = 10.0F;
  
      public EntityCreature(World p_i1602_1_)
      {

--- a/patches/minecraft/net/minecraft/entity/EntityCreature.java.patch
+++ b/patches/minecraft/net/minecraft/entity/EntityCreature.java.patch
@@ -1,16 +1,15 @@
 --- ../src-base/minecraft/net/minecraft/entity/EntityCreature.java
 +++ ../src-work/minecraft/net/minecraft/entity/EntityCreature.java
-@@ -15,6 +15,9 @@
+@@ -15,6 +15,8 @@
      private BlockPos field_70775_bC = BlockPos.field_177992_a;
      private float field_70772_bD = -1.0F;
      private final float field_184661_bw = PathNodeType.WATER.func_186289_a();
-+    protected float maxLeashDistance = 10.0F; // forge: make maxLeashDistance a field instead of hard-coded
-+    public float getMaxLeashDistance() { return maxLeashDistance; }
-+    public void setMaxLeashDistance(float distance) { maxLeashDistance = distance; }
++    /** Forge: make maxLeashDistance a field instead of hard-coded */
++    protected float maxLeashDistance = 10.0F;
  
      public EntityCreature(World p_i1602_1_)
      {
-@@ -91,7 +94,7 @@
+@@ -91,7 +93,7 @@
  
              if (this instanceof EntityTameable && ((EntityTameable)this).func_70906_o())
              {
@@ -19,7 +18,7 @@
                  {
                      this.func_110160_i(true, true);
                  }
-@@ -101,7 +104,7 @@
+@@ -101,7 +103,7 @@
  
              this.func_142017_o(f);
  
@@ -28,3 +27,12 @@
              {
                  this.func_110160_i(true, true);
                  this.field_70714_bg.func_188526_c(1);
+@@ -133,4 +135,8 @@
+     protected void func_142017_o(float p_142017_1_)
+     {
+     }
++    /** Returns the maximum leash distance for this entity */
++    public float getMaxLeashDistance() { return maxLeashDistance; }
++    /** Sets the maximum leash distance for this entity */
++    public void setMaxLeashDistance(float distance) { maxLeashDistance = distance; }
+ }

--- a/patches/minecraft/net/minecraft/entity/EntityCreature.java.patch
+++ b/patches/minecraft/net/minecraft/entity/EntityCreature.java.patch
@@ -1,0 +1,28 @@
+--- ../src-base/minecraft/net/minecraft/entity/EntityCreature.java
++++ ../src-work/minecraft/net/minecraft/entity/EntityCreature.java
+@@ -15,6 +15,7 @@
+     private BlockPos field_70775_bC = BlockPos.field_177992_a;
+     private float field_70772_bD = -1.0F;
+     private final float field_184661_bw = PathNodeType.WATER.func_186289_a();
++    protected static float maxLeashDistance = 10.0F;
+ 
+     public EntityCreature(World p_i1602_1_)
+     {
+@@ -91,7 +92,7 @@
+ 
+             if (this instanceof EntityTameable && ((EntityTameable)this).func_70906_o())
+             {
+-                if (f > 10.0F)
++                if (f > maxLeashDistance)
+                 {
+                     this.func_110160_i(true, true);
+                 }
+@@ -101,7 +102,7 @@
+ 
+             this.func_142017_o(f);
+ 
+-            if (f > 10.0F)
++            if (f > maxLeashDistance)
+             {
+                 this.func_110160_i(true, true);
+                 this.field_70714_bg.func_188526_c(1);


### PR DESCRIPTION
This allows for modification using setters upon spawn. 

I'm fully aware that this is kindof dirty but creating a whole event/hook for this seems like unnecessary effort. If creating such an event/hook would enable this to be merged I'd be happy to *try* and add that (although I've never done that before).