### PR TITLE
Fix dimension data not being saved

### DIFF
--- a/patches/minecraft/net/minecraft/world/storage/WorldInfo.java.patch
+++ b/patches/minecraft/net/minecraft/world/storage/WorldInfo.java.patch
@@ -36,7 +36,7 @@
 +        for (Entry<Integer, NBTTagCompound> entry : this.field_186348_N.entrySet())
          {
 -            nbttagcompound1.func_74782_a(String.valueOf(((DimensionType)entry.getKey()).func_186068_a()), entry.getValue());
-+            if (entry.getValue() != null || entry.getValue().func_82582_d()) continue;
++            if (entry.getValue() == null || entry.getValue().func_82582_d()) continue;
 +            nbttagcompound1.func_74782_a(String.valueOf(entry.getKey()), entry.getValue());
          }
  


### PR DESCRIPTION
The patch here was originally introduced by c1a38c541a824261d3e20f8ad812a11eb09504d2, but it seems to have been broken by the 1.12 update (f1cca475eadea9d15c996e521bf9b6b5970425e9).

Currently the code will skip all non-null NBT tags, and NPE on null ones. This results in the dimension data not being saved.