### PR TITLE
Refactor/Enhance Entity Drop Captures

### DIFF
--- a/patches/minecraft/net/minecraft/entity/Entity.java.patch
+++ b/patches/minecraft/net/minecraft/entity/Entity.java.patch
@@ -39,8 +39,8 @@
  
 +    /** Forge: Used to store custom data for each entity. */
 +    private NBTTagCompound customEntityData;
-+    public boolean captureDrops = false;
-+    public java.util.ArrayList<EntityItem> capturedDrops = new java.util.ArrayList<EntityItem>();
++    private List<EntityItem> capturedDrops = new java.util.ArrayList<EntityItem>();
++    private boolean performingDropCaptures = false;
 +    private net.minecraftforge.common.capabilities.CapabilityDispatcher capabilities;
 +
      public int func_145782_y()
@@ -107,7 +107,7 @@
              EntityItem entityitem = new EntityItem(this.field_70170_p, this.field_70165_t, this.field_70163_u + (double)p_70099_2_, this.field_70161_v, p_70099_1_);
              entityitem.func_174869_p();
 -            this.field_70170_p.func_72838_d(entityitem);
-+            if (captureDrops)
++            if (this.performingDropCaptures)
 +                this.capturedDrops.add(entityitem);
 +            else
 +                this.field_70170_p.func_72838_d(entityitem);
@@ -177,7 +177,7 @@
      }
  
      public boolean func_174816_a(Explosion p_174816_1_, World p_174816_2_, BlockPos p_174816_3_, IBlockState p_174816_4_, float p_174816_5_)
-@@ -2901,6 +2929,183 @@
+@@ -2901,6 +2929,234 @@
          EnchantmentHelper.func_151385_b(p_174815_1_, p_174815_2_);
      }
  
@@ -356,6 +356,57 @@
 +            && (this instanceof EntityPlayer || world.func_82736_K().func_82766_b("mobGriefing"))
 +            && this.field_70130_N * this.field_70130_N * this.field_70131_O > 0.512F;
 +    }
++
++    /**
++     * A functional call to consume a shared list of item drops, usually
++     * to collect all drops, modify, and or clear, before throwing an event.
++     * This is to be used instead of manually flipping fields. The provided
++     * list is always cleared on each call. If an event is to be thrown, the
++     * event should be thrown in the provided {@link java.util.function.Consumer}
++     * @param droppedItems
++     */
++    @SuppressWarnings("deprecation")
++    public void captureDrops(java.util.function.Consumer<List<EntityItem>> droppedItems)
++    {
++        if (this.performingDropCaptures) {
++            // verify someone isn't already using the field
++            // If they are, pass the same field over as technically
++            // the list will clear after the previous usage is completed.
++            droppedItems.accept(this.capturedDrops);
++            return;
++        }
++        this.performingDropCaptures = true; // actual used field
++        this.capturedDrops.clear(); // always clear for preparation,
++        // consumer code should always use the provided list
++        droppedItems.accept(this.capturedDrops);
++        // clear again, just in case. Can't
++        this.capturedDrops.clear();
++        this.performingDropCaptures = false; // actual used field
++    }
++
++    public boolean isCapturingItemDrops()
++    {
++        return this.performingDropCaptures;
++    }
++
++    /**
++     * Uses the provided supplier to artificially capture and remove the capture.
++     * Use this method in the case where something can provide an {@link EntityItem},
++     * such as {@link net.minecraft.entity.player.EntityPlayer#dropItem(Item, int)}
++     * where the item dropped needs to be provided, but not actually spawned, and
++     * therefor "captured"; however, the intention is to simply provide the entity
++     * without capturing the entity, for later spawning.
++     *
++     * @param supplier The supplier of the entity item
++     * @return The entity item from the supplier, without spawning or capturing
++     */
++    public EntityItem captureDrop(java.util.function.Supplier<EntityItem> supplier)
++    {
++        final EntityItem item = supplier.get();
++        captureDrops(list -> list.add(item));
++        return item;
++    }
++
 +    /* ================================== Forge End =====================================*/
 +
      public void func_184178_b(EntityPlayerMP p_184178_1_)

--- a/patches/minecraft/net/minecraft/entity/EntityList.java.patch
+++ b/patches/minecraft/net/minecraft/entity/EntityList.java.patch
@@ -164,7 +164,7 @@
      }
  
      public static class EntityEggInfo
-@@ -428,5 +449,16 @@
+@@ -428,5 +450,16 @@
                  this.field_151512_d = StatList.func_151182_a(this);
                  this.field_151513_e = StatList.func_151176_b(this);
              }

--- a/patches/minecraft/net/minecraft/entity/EntityLivingBase.java.patch
+++ b/patches/minecraft/net/minecraft/entity/EntityLivingBase.java.patch
@@ -109,7 +109,7 @@
          if (!this.field_70729_aU)
          {
              Entity entity = p_70645_1_.func_76346_g();
-@@ -1165,18 +1177,26 @@
+@@ -1165,18 +1177,24 @@
  
              if (!this.field_70170_p.field_72995_K)
              {
@@ -120,8 +120,7 @@
 -                {
 -                    i = EnchantmentHelper.func_185283_h((EntityLivingBase)entity);
 -                }
-+                captureDrops = true;
-+                capturedDrops.clear();
++                this.captureDrops(list -> { // do not indent the body below, to reduce diffs
  
                  if (this.func_146066_aG() && this.field_70170_p.func_82736_K().func_82766_b("doMobLoot"))
                  {
@@ -129,19 +128,18 @@
                      this.func_184610_a(flag, i, p_70645_1_);
                  }
 +
-+                captureDrops = false;
-+
-+                if (!net.minecraftforge.common.ForgeHooks.onLivingDrops(this, p_70645_1_, capturedDrops, i, field_70718_bc > 0))
++                if (!net.minecraftforge.common.ForgeHooks.onLivingDrops(this, p_70645_1_, list, i, field_70718_bc > 0))
 +                {
-+                    for (EntityItem item : capturedDrops)
++                    for (EntityItem item : list)
 +                    {
 +                        field_70170_p.func_72838_d(item);
 +                    }
 +                }
++                }); // avoid indenting the above body
              }
  
              this.field_70170_p.func_72960_a(this, (byte)3);
-@@ -1195,6 +1215,9 @@
+@@ -1195,6 +1213,9 @@
  
      public void func_70653_a(Entity p_70653_1_, float p_70653_2_, double p_70653_3_, double p_70653_5_)
      {
@@ -151,7 +149,7 @@
          if (this.field_70146_Z.nextDouble() >= this.func_110148_a(SharedMonsterAttributes.field_111266_c).func_111126_e())
          {
              this.field_70160_al = true;
-@@ -1253,15 +1276,7 @@
+@@ -1253,15 +1274,7 @@
              BlockPos blockpos = new BlockPos(i, j, k);
              IBlockState iblockstate = this.field_70170_p.func_180495_p(blockpos);
              Block block = iblockstate.func_177230_c();
@@ -168,7 +166,7 @@
          }
      }
  
-@@ -1287,6 +1302,9 @@
+@@ -1287,6 +1300,9 @@
  
      public void func_180430_e(float p_180430_1_, float p_180430_2_)
      {
@@ -178,7 +176,7 @@
          super.func_180430_e(p_180430_1_, p_180430_2_);
          PotionEffect potioneffect = this.func_70660_b(MobEffects.field_76430_j);
          float f = potioneffect == null ? 0.0F : (float)(potioneffect.func_76458_c() + 1);
-@@ -1303,7 +1321,7 @@
+@@ -1303,7 +1319,7 @@
  
              if (iblockstate.func_185904_a() != Material.field_151579_a)
              {
@@ -187,7 +185,7 @@
                  this.func_184185_a(soundtype.func_185842_g(), soundtype.func_185843_a() * 0.5F, soundtype.func_185847_b() * 0.75F);
              }
          }
-@@ -1380,17 +1398,20 @@
+@@ -1380,17 +1396,20 @@
      {
          if (!this.func_180431_b(p_70665_1_))
          {
@@ -209,7 +207,7 @@
                  this.func_110149_m(this.func_110139_bj() - p_70665_2_);
              }
          }
-@@ -1447,6 +1468,11 @@
+@@ -1447,6 +1466,11 @@
  
      public void func_184609_a(EnumHand p_184609_1_)
      {
@@ -221,7 +219,7 @@
          if (!this.field_82175_bq || this.field_110158_av >= this.func_82166_i() / 2 || this.field_110158_av < 0)
          {
              this.field_110158_av = -1;
-@@ -1694,7 +1720,7 @@
+@@ -1694,7 +1718,7 @@
  
                      if (!this.field_70170_p.func_184143_b(axisalignedbb1))
                      {
@@ -230,7 +228,7 @@
                          {
                              this.func_70634_a(d11, this.field_70163_u + 1.0D, d12);
                              return;
-@@ -1702,14 +1728,14 @@
+@@ -1702,14 +1726,14 @@
  
                          BlockPos blockpos = new BlockPos(d11, this.field_70163_u - 1.0D, d12);
  
@@ -247,7 +245,7 @@
                      {
                          d1 = d11;
                          d13 = this.field_70163_u + 2.0D;
-@@ -1781,6 +1807,7 @@
+@@ -1781,6 +1805,7 @@
          }
  
          this.field_70160_al = true;
@@ -255,7 +253,7 @@
      }
  
      protected void func_70629_bd()
-@@ -1874,7 +1901,8 @@
+@@ -1874,7 +1899,8 @@
  
                          if (this.field_70122_E)
                          {
@@ -265,7 +263,7 @@
                          }
  
                          float f7 = 0.16277136F / (f6 * f6 * f6);
-@@ -1894,7 +1922,8 @@
+@@ -1894,7 +1920,8 @@
  
                          if (this.field_70122_E)
                          {
@@ -275,7 +273,7 @@
                          }
  
                          if (this.func_70617_f_())
-@@ -2054,6 +2083,7 @@
+@@ -2054,6 +2081,7 @@
  
      public void func_70071_h_()
      {
@@ -283,7 +281,7 @@
          super.func_70071_h_();
          this.func_184608_ct();
  
-@@ -2096,7 +2126,9 @@
+@@ -2096,7 +2124,9 @@
  
                  if (!ItemStack.func_77989_b(itemstack1, itemstack))
                  {
@@ -293,7 +291,7 @@
  
                      if (!itemstack.func_190926_b())
                      {
-@@ -2575,6 +2607,40 @@
+@@ -2575,6 +2605,40 @@
          this.field_70752_e = true;
      }
  
@@ -334,7 +332,7 @@
      public abstract EnumHandSide func_184591_cq();
  
      public boolean func_184587_cr()
-@@ -2595,12 +2661,19 @@
+@@ -2595,12 +2659,19 @@
  
              if (itemstack == this.field_184627_bm)
              {
@@ -355,7 +353,7 @@
                  {
                      this.func_71036_o();
                  }
-@@ -2618,8 +2691,10 @@
+@@ -2618,8 +2689,10 @@
  
          if (!itemstack.func_190926_b() && !this.func_184587_cr())
          {
@@ -367,7 +365,7 @@
  
              if (!this.field_70170_p.field_72995_K)
              {
-@@ -2700,7 +2775,9 @@
+@@ -2700,7 +2773,9 @@
          if (!this.field_184627_bm.func_190926_b() && this.func_184587_cr())
          {
              this.func_184584_a(this.field_184627_bm, 16);
@@ -378,7 +376,7 @@
              this.func_184602_cy();
          }
      }
-@@ -2724,7 +2801,8 @@
+@@ -2724,7 +2799,8 @@
      {
          if (!this.field_184627_bm.func_190926_b())
          {
@@ -388,7 +386,7 @@
          }
  
          this.func_184602_cy();
-@@ -2852,6 +2930,31 @@
+@@ -2852,6 +2928,31 @@
          return true;
      }
  

--- a/patches/minecraft/net/minecraft/entity/player/EntityPlayer.java.patch
+++ b/patches/minecraft/net/minecraft/entity/player/EntityPlayer.java.patch
@@ -51,33 +51,31 @@
              }
          }
      }
-@@ -609,11 +618,15 @@
+@@ -609,11 +618,13 @@
  
      public void func_70645_a(DamageSource p_70645_1_)
      {
-+        if (net.minecraftforge.common.ForgeHooks.onLivingDeath(this,  p_70645_1_)) return;
++        if (net.minecraftforge.common.ForgeHooks.onLivingDeath(this, p_70645_1_)) return;
          super.func_70645_a(p_70645_1_);
          this.func_70105_a(0.2F, 0.2F);
          this.func_70107_b(this.field_70165_t, this.field_70163_u, this.field_70161_v);
          this.field_70181_x = 0.10000000149011612D;
  
-+        captureDrops = true;
-+        capturedDrops.clear();
-+
++        this.captureDrops(list -> { // avoid an extra indent on the next block
          if ("Notch".equals(this.func_70005_c_()))
          {
              this.func_146097_a(new ItemStack(Items.field_151034_e, 1), true, false);
-@@ -625,6 +638,9 @@
+@@ -625,6 +636,9 @@
              this.field_71071_by.func_70436_m();
          }
  
-+        captureDrops = false;
-+        if (!field_70170_p.field_72995_K) net.minecraftforge.event.ForgeEventFactory.onPlayerDrops(this, p_70645_1_, capturedDrops, field_70718_bc > 0);
++        if (!field_70170_p.field_72995_K) net.minecraftforge.event.ForgeEventFactory.onPlayerDrops(this, p_70645_1_, list, field_70718_bc > 0);
++        }); // Avoid the indent from the above block
 +
          if (p_70645_1_ != null)
          {
              this.field_70159_w = (double)(-MathHelper.func_76134_b((this.field_70739_aP + this.field_70177_z) * 0.017453292F) * 0.1F);
-@@ -675,13 +691,24 @@
+@@ -675,13 +689,24 @@
      @Nullable
      public EntityItem func_71040_bB(boolean p_71040_1_)
      {
@@ -104,11 +102,11 @@
      }
  
      @Nullable
-@@ -741,14 +768,22 @@
+@@ -741,14 +766,22 @@
  
      public ItemStack func_184816_a(EntityItem p_184816_1_)
      {
-+        if (captureDrops) capturedDrops.add(p_184816_1_);
++        if (this.isCapturingItemDrops()) this.captureDrops(list -> list.add(p_184816_1_));
 +        else // Forge: Don't indent to keep patch smaller.
          this.field_70170_p.func_72838_d(p_184816_1_);
          return p_184816_1_.func_92059_d();
@@ -128,7 +126,7 @@
          if (f > 1.0F)
          {
              int i = EnchantmentHelper.func_185293_e(this);
-@@ -798,12 +833,13 @@
+@@ -798,12 +831,13 @@
              f /= 5.0F;
          }
  
@@ -144,7 +142,7 @@
      }
  
      public static void func_189806_a(DataFixer p_189806_0_)
-@@ -863,6 +899,17 @@
+@@ -863,6 +897,17 @@
              this.field_82248_d = p_70037_1_.func_74767_n("SpawnForced");
          }
  
@@ -162,7 +160,7 @@
          this.field_71100_bB.func_75112_a(p_70037_1_);
          this.field_71075_bZ.func_75095_b(p_70037_1_);
  
-@@ -896,6 +943,7 @@
+@@ -896,6 +941,7 @@
          p_70014_1_.func_74768_a("XpTotal", this.field_71067_cb);
          p_70014_1_.func_74768_a("XpSeed", this.field_175152_f);
          p_70014_1_.func_74768_a("Score", this.func_71037_bA());
@@ -170,7 +168,7 @@
  
          if (this.field_71077_c != null)
          {
-@@ -905,6 +953,27 @@
+@@ -905,6 +951,27 @@
              p_70014_1_.func_74757_a("SpawnForced", this.field_82248_d);
          }
  
@@ -198,7 +196,7 @@
          this.field_71100_bB.func_75117_b(p_70014_1_);
          this.field_71075_bZ.func_75091_a(p_70014_1_);
          p_70014_1_.func_74782_a("EnderItems", this.field_71078_a.func_70487_g());
-@@ -922,6 +991,7 @@
+@@ -922,6 +989,7 @@
  
      public boolean func_70097_a(DamageSource p_70097_1_, float p_70097_2_)
      {
@@ -206,7 +204,7 @@
          if (this.func_180431_b(p_70097_1_))
          {
              return false;
-@@ -974,7 +1044,7 @@
+@@ -974,7 +1042,7 @@
      {
          super.func_190629_c(p_190629_1_);
  
@@ -215,7 +213,7 @@
          {
              this.func_190777_m(true);
          }
-@@ -1002,14 +1072,16 @@
+@@ -1002,14 +1070,16 @@
  
      protected void func_184590_k(float p_184590_1_)
      {
@@ -233,7 +231,7 @@
  
                  if (enumhand == EnumHand.MAIN_HAND)
                  {
-@@ -1045,11 +1117,15 @@
+@@ -1045,11 +1115,15 @@
      {
          if (!this.func_180431_b(p_70665_1_))
          {
@@ -250,7 +248,7 @@
  
              if (p_70665_2_ != 0.0F)
              {
-@@ -1115,6 +1191,8 @@
+@@ -1115,6 +1189,8 @@
          }
          else
          {
@@ -259,7 +257,7 @@
              ItemStack itemstack = this.func_184586_b(p_190775_2_);
              ItemStack itemstack1 = itemstack.func_190926_b() ? ItemStack.field_190927_a : itemstack.func_77946_l();
  
-@@ -1124,7 +1202,10 @@
+@@ -1124,7 +1200,10 @@
                  {
                      itemstack.func_190920_e(itemstack1.func_190916_E());
                  }
@@ -271,7 +269,7 @@
                  return EnumActionResult.SUCCESS;
              }
              else
-@@ -1140,6 +1221,7 @@
+@@ -1140,6 +1219,7 @@
                      {
                          if (itemstack.func_190926_b() && !this.field_71075_bZ.field_75098_d)
                          {
@@ -279,7 +277,7 @@
                              this.func_184611_a(p_190775_2_, ItemStack.field_190927_a);
                          }
  
-@@ -1165,6 +1247,7 @@
+@@ -1165,6 +1245,7 @@
  
      public void func_71059_n(Entity p_71059_1_)
      {
@@ -287,7 +285,7 @@
          if (p_71059_1_.func_70075_an())
          {
              if (!p_71059_1_.func_85031_j(this))
-@@ -1203,9 +1286,11 @@
+@@ -1203,9 +1284,11 @@
                      boolean flag2 = flag && this.field_70143_R > 0.0F && !this.field_70122_E && !this.func_70617_f_() && !this.func_70090_H() && !this.func_70644_a(MobEffects.field_76440_q) && !this.func_184218_aH() && p_71059_1_ instanceof EntityLivingBase;
                      flag2 = flag2 && !this.func_70051_ag();
  
@@ -300,7 +298,7 @@
                      }
  
                      f = f + f1;
-@@ -1332,10 +1417,12 @@
+@@ -1332,10 +1415,12 @@
  
                          if (!itemstack1.func_190926_b() && entity instanceof EntityLivingBase)
                          {
@@ -313,7 +311,7 @@
                                  this.func_184611_a(EnumHand.MAIN_HAND, ItemStack.field_190927_a);
                              }
                          }
-@@ -1384,7 +1471,7 @@
+@@ -1384,7 +1469,7 @@
  
          if (this.field_70146_Z.nextFloat() < f)
          {
@@ -322,7 +320,7 @@
              this.func_184602_cy();
              this.field_70170_p.func_72960_a(this, (byte)30);
          }
-@@ -1442,7 +1529,11 @@
+@@ -1442,7 +1527,11 @@
  
      public EntityPlayer.SleepResult func_180469_a(BlockPos p_180469_1_)
      {
@@ -335,7 +333,7 @@
  
          if (!this.field_70170_p.field_72995_K)
          {
-@@ -1484,8 +1575,7 @@
+@@ -1484,8 +1573,7 @@
          this.func_192030_dh();
          this.func_70105_a(0.2F, 0.2F);
  
@@ -345,7 +343,7 @@
              float f1 = 0.5F + (float)enumfacing.func_82601_c() * 0.4F;
              float f = 0.5F + (float)enumfacing.func_82599_e() * 0.4F;
              this.func_175139_a(enumfacing);
-@@ -1517,6 +1607,7 @@
+@@ -1517,6 +1605,7 @@
          {
              return true;
          }
@@ -353,7 +351,7 @@
          else
          {
              BlockPos blockpos = p_190774_1_.func_177972_a(p_190774_2_.func_176734_d());
-@@ -1532,13 +1623,14 @@
+@@ -1532,13 +1621,14 @@
  
      public void func_70999_a(boolean p_70999_1_, boolean p_70999_2_, boolean p_70999_3_)
      {
@@ -371,7 +369,7 @@
  
              if (blockpos == null)
              {
-@@ -1547,6 +1639,10 @@
+@@ -1547,6 +1637,10 @@
  
              this.func_70107_b((double)((float)blockpos.func_177958_n() + 0.5F), (double)((float)blockpos.func_177956_o() + 0.1F), (double)((float)blockpos.func_177952_p() + 0.5F));
          }
@@ -382,7 +380,7 @@
  
          this.field_71083_bS = false;
  
-@@ -1565,15 +1661,16 @@
+@@ -1565,15 +1659,16 @@
  
      private boolean func_175143_p()
      {
@@ -402,7 +400,7 @@
          {
              if (!p_180467_2_)
              {
-@@ -1588,16 +1685,17 @@
+@@ -1588,16 +1683,17 @@
          }
          else
          {
@@ -423,7 +421,7 @@
  
              switch (enumfacing)
              {
-@@ -1637,16 +1735,24 @@
+@@ -1637,16 +1733,24 @@
  
      public BlockPos func_180470_cg()
      {
@@ -450,7 +448,7 @@
          if (p_180473_1_ != null)
          {
              this.field_71077_c = p_180473_1_;
-@@ -1839,6 +1945,10 @@
+@@ -1839,6 +1943,10 @@
  
              super.func_180430_e(p_180430_1_, p_180430_2_);
          }
@@ -461,7 +459,7 @@
      }
  
      protected void func_71061_d_()
-@@ -2176,7 +2286,10 @@
+@@ -2176,7 +2284,10 @@
  
      public ITextComponent func_145748_c_()
      {
@@ -473,7 +471,7 @@
          itextcomponent.func_150256_b().func_150241_a(new ClickEvent(ClickEvent.Action.SUGGEST_COMMAND, "/msg " + this.func_70005_c_() + " "));
          itextcomponent.func_150256_b().func_150209_a(this.func_174823_aP());
          itextcomponent.func_150256_b().func_179989_a(this.func_70005_c_());
-@@ -2185,7 +2298,7 @@
+@@ -2185,7 +2296,7 @@
  
      public float func_70047_e()
      {
@@ -482,7 +480,7 @@
  
          if (this.func_70608_bn())
          {
-@@ -2421,6 +2534,168 @@
+@@ -2421,6 +2532,168 @@
          return this.field_71075_bZ.field_75098_d && this.func_70003_b(2, "");
      }
  

--- a/patches/minecraft/net/minecraft/entity/player/EntityPlayerMP.java.patch
+++ b/patches/minecraft/net/minecraft/entity/player/EntityPlayerMP.java.patch
@@ -29,28 +29,27 @@
          boolean flag = this.field_70170_p.func_82736_K().func_82766_b("showDeathMessages");
          this.field_71135_a.func_147359_a(new SPacketCombatEvent(this.func_110142_aN(), SPacketCombatEvent.Event.ENTITY_DIED, flag));
  
-@@ -499,8 +500,20 @@
+@@ -499,8 +500,19 @@
  
          if (!this.field_70170_p.func_82736_K().func_82766_b("keepInventory") && !this.func_175149_v())
          {
-+            captureDrops = true;
-+            capturedDrops.clear();
++            this.captureDrops(list -> { // avoid indenting the next block
              this.func_190776_cN();
              this.field_71071_by.func_70436_m();
 +
-+            captureDrops = false;
-+            net.minecraftforge.event.entity.player.PlayerDropsEvent event = new net.minecraftforge.event.entity.player.PlayerDropsEvent(this, p_70645_1_, capturedDrops, field_70718_bc > 0);
++            net.minecraftforge.event.entity.player.PlayerDropsEvent event = new net.minecraftforge.event.entity.player.PlayerDropsEvent(this, p_70645_1_, list, field_70718_bc > 0);
 +            if (!net.minecraftforge.common.MinecraftForge.EVENT_BUS.post(event))
 +            {
-+                for (net.minecraft.entity.item.EntityItem item : capturedDrops)
++                for (net.minecraft.entity.item.EntityItem item : list)
 +                {
 +                    this.field_70170_p.func_72838_d(item);
 +                }
 +            }
++            }); // Avoid indenting the above block
          }
  
          for (ScoreObjective scoreobjective : this.field_70170_p.func_96441_U().func_96520_a(IScoreCriteria.field_96642_c))
-@@ -647,6 +660,7 @@
+@@ -647,6 +659,7 @@
      @Nullable
      public Entity func_184204_a(int p_184204_1_)
      {
@@ -58,7 +57,7 @@
          this.field_184851_cj = true;
  
          if (this.field_71093_bK == 0 && p_184204_1_ == -1)
-@@ -808,7 +822,7 @@
+@@ -808,7 +821,7 @@
          BlockPos blockpos = new BlockPos(i, j, k);
          IBlockState iblockstate = this.field_70170_p.func_180495_p(blockpos);
  
@@ -67,7 +66,7 @@
          {
              BlockPos blockpos1 = blockpos.func_177977_b();
              IBlockState iblockstate1 = this.field_70170_p.func_180495_p(blockpos1);
-@@ -848,6 +862,7 @@
+@@ -848,6 +861,7 @@
              this.field_71070_bA = p_180468_1_.func_174876_a(this.field_71071_by, this);
              this.field_71070_bA.field_75152_c = this.field_71139_cq;
              this.field_71070_bA.func_75132_a(this);
@@ -75,7 +74,7 @@
          }
      }
  
-@@ -891,6 +906,7 @@
+@@ -891,6 +905,7 @@
  
              this.field_71070_bA.field_75152_c = this.field_71139_cq;
              this.field_71070_bA.func_75132_a(this);
@@ -83,7 +82,7 @@
          }
      }
  
-@@ -900,6 +916,7 @@
+@@ -900,6 +915,7 @@
          this.field_71070_bA = new ContainerMerchant(this.field_71071_by, p_180472_1_, this.field_70170_p);
          this.field_71070_bA.field_75152_c = this.field_71139_cq;
          this.field_71070_bA.func_75132_a(this);
@@ -91,7 +90,7 @@
          IInventory iinventory = ((ContainerMerchant)this.field_71070_bA).func_75174_d();
          ITextComponent itextcomponent = p_180472_1_.func_145748_c_();
          this.field_71135_a.func_147359_a(new SPacketOpenWindow(this.field_71139_cq, "minecraft:villager", itextcomponent, iinventory.func_70302_i_()));
-@@ -1003,6 +1020,7 @@
+@@ -1003,6 +1019,7 @@
      public void func_71128_l()
      {
          this.field_71070_bA.func_75134_a(this);
@@ -99,7 +98,7 @@
          this.field_71070_bA = this.field_71069_bz;
      }
  
-@@ -1144,6 +1162,18 @@
+@@ -1144,6 +1161,18 @@
          this.field_193110_cw = p_193104_1_.field_193110_cw;
          this.func_192029_h(p_193104_1_.func_192023_dk());
          this.func_192031_i(p_193104_1_.func_192025_dl());

--- a/patches/minecraft/net/minecraft/item/Item.java.patch
+++ b/patches/minecraft/net/minecraft/item/Item.java.patch
@@ -68,7 +68,7 @@
          CreativeTabs creativetabs = this.func_77640_w();
          return creativetabs != null && (p_194125_1_ == CreativeTabs.field_78027_g || p_194125_1_ == creativetabs);
      }
-@@ -435,11 +445,704 @@
+@@ -435,11 +441,704 @@
          return false;
      }
  
@@ -773,7 +773,7 @@
      public static void func_150900_l()
      {
          func_179214_a(Blocks.field_150350_a, new ItemAir(Blocks.field_150350_a));
-@@ -999,6 +1702,8 @@
+@@ -999,6 +1698,8 @@
          private final float field_78010_h;
          private final float field_78011_i;
          private final int field_78008_j;
@@ -782,7 +782,7 @@
  
          private ToolMaterial(int p_i1874_3_, int p_i1874_4_, float p_i1874_5_, float p_i1874_6_, int p_i1874_7_)
          {
-@@ -1034,6 +1739,7 @@
+@@ -1034,6 +1735,7 @@
              return this.field_78008_j;
          }
  
@@ -790,7 +790,7 @@
          public Item func_150995_f()
          {
              if (this == WOOD)
-@@ -1057,5 +1763,21 @@
+@@ -1057,5 +1759,21 @@
                  return this == DIAMOND ? Items.field_151045_i : null;
              }
          }

--- a/src/main/java/net/minecraftforge/common/ForgeHooks.java
+++ b/src/main/java/net/minecraftforge/common/ForgeHooks.java
@@ -585,7 +585,7 @@ public class ForgeHooks
         return MinecraftForge.EVENT_BUS.post(new LivingDeathEvent(entity, src));
     }
 
-    public static boolean onLivingDrops(EntityLivingBase entity, DamageSource source, ArrayList<EntityItem> drops, int lootingLevel, boolean recentlyHit)
+    public static boolean onLivingDrops(EntityLivingBase entity, DamageSource source, List<EntityItem> drops, int lootingLevel, boolean recentlyHit)
     {
         return MinecraftForge.EVENT_BUS.post(new LivingDropsEvent(entity, source, drops, lootingLevel, recentlyHit));
     }
@@ -667,10 +667,8 @@ public class ForgeHooks
     @Nullable
     public static EntityItem onPlayerTossEvent(@Nonnull EntityPlayer player, @Nonnull ItemStack item, boolean includeName)
     {
-        player.captureDrops = true;
-        EntityItem ret = player.dropItem(item, false, includeName);
-        player.capturedDrops.clear();
-        player.captureDrops = false;
+        // We aren't really capturing the drop, we just want it captured and removed from the capture list.
+        EntityItem ret = player.captureDrop(() -> player.dropItem(item, false, includeName));
 
         if (ret == null)
         {


### PR DESCRIPTION
The original intention for the entity drop captures flag was to avoid issues with
spawning extra items outside of the loot table drops, even from before loot tables.
What this does is allows for drops to be captured, to the shared list with the
consumer, such that the list provided to the consumer is the culmination of said
captures, and can then be manipulated in any way necessary. This also aims to
reduce boilerplate code for usage of the drop captures.

Primarily, this is to move forward with 1.13 to where drop captures are consumer code specifically, and not to be micromanaged by mods having to "remember' to flip flags, and clear lists after use.

What this can achieve is a more streamlined approach to drop captures where exiting is always going to complete/clear the list and reset flags.

For those not informed, this does come into play for better interoperability with Sponge's systems, more than likely to be merged for 1.13 (where the legacy deprecated stuff is going to be removed in this PR).