### PR TITLE
Make lookupFluidForBlock work for flowing water and lava

### DIFF
--- a/src/main/java/net/minecraftforge/fluids/FluidRegistry.java
+++ b/src/main/java/net/minecraftforge/fluids/FluidRegistry.java
@@ -316,6 +316,14 @@ public abstract class FluidRegistry
             }
             fluidBlocks = tmp;
         }
+        if (block == Blocks.FLOWING_WATER)
+        {
+            block = Blocks.WATER;
+        }
+        else if (block == Blocks.FLOWING_LAVA)
+        {
+            block = Blocks.LAVA;
+        }
         return fluidBlocks.get(block);
     }
 


### PR DESCRIPTION
Vanilla Minecraft has two blocks for each type of fluid: a static one (`Blocks.WATER` and `Blocks.LAVA`) and a dynamic one (`Blocks.FLOWING_WATER` and `Blocks.FLOWING_LAVA`). If you call `lookupFluidForBlock` with the static block, it returns the correct fluid. If you call `lookupFluidForBlock` with the dynamic block, it returns `null`. This commit changes it to return the correct fluid for the dynamic block too.