### PR TITLE
Add fuelTime to Fluids

### DIFF
--- a/src/main/java/net/minecraftforge/fluids/Fluid.java
+++ b/src/main/java/net/minecraftforge/fluids/Fluid.java
@@ -358,7 +358,7 @@ public class Fluid
         return this.fuelEnergy;
     }
 	
-    public final boolean isCombustible()
+    public boolean isCombustible()
     {
         return (this.fuelEnergy > 0);
     }

--- a/src/main/java/net/minecraftforge/fluids/Fluid.java
+++ b/src/main/java/net/minecraftforge/fluids/Fluid.java
@@ -104,6 +104,18 @@ public class Fluid
      *
      */
     protected int viscosity = 1000;
+	
+    /**
+     * Amount of energy the fluid can produce in a fluid-fueled generator.
+     * 
+     * Default value is 0; anything above is considered a combustible fluid.
+     * Hot fluids are hot, not combustible, so their value should be 0.
+     * If fuelEnergy > 0, isCombustible will return true.
+     *
+     * Energy is measured in fuel ticks per bucket of fluid.
+     * For reference, one piece of coal = 200 ticks.
+     */
+    protected int fuelEnergy = 0;
 
     /**
      * This indicates if the fluid is gaseous.
@@ -199,6 +211,12 @@ public class Fluid
     public Fluid setViscosity(int viscosity)
     {
         this.viscosity = viscosity;
+        return this;
+    }
+    
+    public Fluid setFuelEnergy(int fuelEnergy)
+    {
+        this.fuelEnergy = fuelEnergy;
         return this;
     }
 
@@ -333,6 +351,16 @@ public class Fluid
     public final int getViscosity()
     {
         return this.viscosity;
+    }
+
+    public final int getFuelEnergy()
+    {
+        return this.fuelEnergy;
+    }
+	
+    public final boolean isCombustible()
+    {
+        return (this.fuelEnergy > 0);
     }
 
     public final boolean isGaseous()

--- a/src/main/java/net/minecraftforge/fluids/Fluid.java
+++ b/src/main/java/net/minecraftforge/fluids/Fluid.java
@@ -113,7 +113,7 @@ public class Fluid
      * If fuelEnergy > 0, isCombustible will return true.
      *
      * Energy is measured in fuel ticks per bucket of fluid.
-     * For reference, one piece of coal = 200 ticks.
+     * For reference, smelting one item takes 200 ticks, one piece of coal = 1600 ticks.
      */
     protected int fuelEnergy = 0;
 

--- a/src/main/java/net/minecraftforge/fluids/Fluid.java
+++ b/src/main/java/net/minecraftforge/fluids/Fluid.java
@@ -427,6 +427,8 @@ public class Fluid
     public int getDensity(FluidStack stack){ return getDensity(); }
     public int getTemperature(FluidStack stack){ return getTemperature(); }
     public int getViscosity(FluidStack stack){ return getViscosity(); }
+    public int getFuelTime(FluidStack stack){ return getFuelTime(); }
+    public boolean isCombustible(FluidStack stack){ return isCombustible(); }
     public boolean isGaseous(FluidStack stack){ return isGaseous(); }
     public EnumRarity getRarity(FluidStack stack){ return getRarity(); }
     public int getColor(FluidStack stack){ return getColor(); }
@@ -440,6 +442,8 @@ public class Fluid
     public int getDensity(World world, BlockPos pos){ return getDensity(); }
     public int getTemperature(World world, BlockPos pos){ return getTemperature(); }
     public int getViscosity(World world, BlockPos pos){ return getViscosity(); }
+    public int getFuelTime(FluidStack stack){ return getFuelTime(); }
+    public boolean isCombustible(FluidStack stack){ return isCombustible(); }
     public boolean isGaseous(World world, BlockPos pos){ return isGaseous(); }
     public EnumRarity getRarity(World world, BlockPos pos){ return getRarity(); }
     public int getColor(World world, BlockPos pos){ return getColor(); }

--- a/src/main/java/net/minecraftforge/fluids/Fluid.java
+++ b/src/main/java/net/minecraftforge/fluids/Fluid.java
@@ -106,16 +106,16 @@ public class Fluid
     protected int viscosity = 1000;
 	
     /**
-     * Amount of energy the fluid can produce in a fluid-fueled generator.
+     * Amount of time a fluid will burn for in a fluid-fueled generator.
+     * Measured in fuel ticks per bucket of fluid.
      * 
      * Default value is 0; anything above is considered a combustible fluid.
      * Hot fluids are hot, not combustible, so their value should be 0.
      * If fuelEnergy > 0, isCombustible will return true.
      *
-     * Energy is measured in fuel ticks per bucket of fluid.
      * For reference, smelting one item takes 200 ticks, one piece of coal = 1600 ticks.
      */
-    protected int fuelEnergy = 0;
+    protected int fuelTime = 0;
 
     /**
      * This indicates if the fluid is gaseous.
@@ -214,9 +214,9 @@ public class Fluid
         return this;
     }
     
-    public Fluid setFuelEnergy(int fuelEnergy)
+    public Fluid setFuelTime(int fuelTime)
     {
-        this.fuelEnergy = fuelEnergy;
+        this.fuelTime = fuelTime;
         return this;
     }
 
@@ -353,14 +353,14 @@ public class Fluid
         return this.viscosity;
     }
 
-    public final int getFuelEnergy()
+    public final int getFuelTime()
     {
-        return this.fuelEnergy;
+        return this.fuelTime;
     }
 	
     public boolean isCombustible()
     {
-        return (this.fuelEnergy > 0);
+        return (this.fuelTime > 0);
     }
 
     public final boolean isGaseous()

--- a/src/main/java/net/minecraftforge/fluids/Fluid.java
+++ b/src/main/java/net/minecraftforge/fluids/Fluid.java
@@ -442,8 +442,8 @@ public class Fluid
     public int getDensity(World world, BlockPos pos){ return getDensity(); }
     public int getTemperature(World world, BlockPos pos){ return getTemperature(); }
     public int getViscosity(World world, BlockPos pos){ return getViscosity(); }
-    public int getFuelTime(FluidStack stack){ return getFuelTime(); }
-    public boolean isCombustible(FluidStack stack){ return isCombustible(); }
+    public int getFuelTime(World world, BlockPos pos){ return getFuelTime(); }
+    public boolean isCombustible(World world, BlockPos pos){ return isCombustible(); }
     public boolean isGaseous(World world, BlockPos pos){ return isGaseous(); }
     public EnumRarity getRarity(World world, BlockPos pos){ return getRarity(); }
     public int getColor(World world, BlockPos pos){ return getColor(); }

--- a/src/main/java/net/minecraftforge/fluids/Fluid.java
+++ b/src/main/java/net/minecraftforge/fluids/Fluid.java
@@ -111,7 +111,7 @@ public class Fluid
      * 
      * Default value is 0; anything above is considered a combustible fluid.
      * Hot fluids are hot, not combustible, so their value should be 0.
-     * If fuelEnergy > 0, isCombustible will return true.
+     * If fuelTime > 0, isCombustible will return true.
      *
      * For reference, smelting one item takes 200 ticks, one piece of coal = 1600 ticks.
      */


### PR DESCRIPTION
At the moment, if you want to make something fueled by combustible fluids (like Thermal Expansion's Combustion Dynamo or Immersive Engineering's Diesel Generator), you need to either provide your own fluid fuels or explicitly code in each external fluid, how fast it's consumed, and how much power you get out of it.

This pull request adds a new property to Fluids, called `fuelTime`. This functions exactly like the `itemBurnTime` for furnace fuel, being the amount of ticks taken to consume 1 bucket of fuel. A boolean property is added called `isCombustible()` which returns true if `fuelTime` is greater than 0, to be used for input validators. Anything with a `fuelTime` of 0 is considered non-combustible and should not be accepted into fluid-fueled generators.

The advantage of the Fluid fuelTime system is that it removes the need to adapt for any mod that adds in edge cases of combustible fuels; a dev can just use `getFuelTime()` like they would `TileEntityFurnace.getItemBurnTime(usedFuel());`. Almost all mods that have fluid-fueled machines have a furnace-like solid-fuel machine, so code from the solid-fuel machine can easily be adapted to fluid-fuel. For example, this is the code I use for fuel consumption in a solid-fueled generator I have:
```java
private boolean consumeFuel() {
        if (currentFuelTime <= 0) {
            ItemStack usedFuel = inv.extractItem(SLOT_FUEL, 1, false);
            if (!usedFuel.isEmpty()) {
                int newFuelTicks = TileEntityFurnace.getItemBurnTime(usedFuel);
                maxFuelTime = newFuelTicks;
                currentFuelTime = newFuelTicks;
            } else {
                return false;
            }
        }
        currentFuelTime--;
        return true;
    }
```

And this is the code adapted for fluid fuel:
```java
private boolean consumeFuel() {
        if (currentFuelTime <= 0) {
            FluidStack usedFuel = tank.drain(1000, true);
            if (usedFuel != null) {
                int newFuelTicks = tank.getFluid().getFuelTime();
                maxFuelTime = newFuelTicks;
                currentFuelTime = newFuelTicks;
            } else {
                return false;
            }
        }
        currentFuelTime--;
        return true;
    }
```

Adding the fuelTime property *is not a breaking change*, so there are no downsides to adding it to Forge. Mods are free to use it if they want, and since it's such a simple change, it's easy for devs to implement safely.