### PR TITLE
Fixed pumpkins passing the wrong position to isSideSolid on placement

### DIFF
--- a/patches/minecraft/net/minecraft/block/BlockPumpkin.java.patch
+++ b/patches/minecraft/net/minecraft/block/BlockPumpkin.java.patch
@@ -5,7 +5,7 @@
      public boolean func_176196_c(World p_176196_1_, BlockPos p_176196_2_)
      {
 -        return p_176196_1_.func_180495_p(p_176196_2_).func_177230_c().field_149764_J.func_76222_j() && p_176196_1_.func_180495_p(p_176196_2_.func_177977_b()).func_185896_q();
-+        return p_176196_1_.func_180495_p(p_176196_2_).func_177230_c().func_176200_f(p_176196_1_, p_176196_2_) && p_176196_1_.func_180495_p(p_176196_2_.func_177977_b()).isSideSolid(p_176196_1_, p_176196_2_, EnumFacing.UP);
++        return p_176196_1_.func_180495_p(p_176196_2_).func_177230_c().func_176200_f(p_176196_1_, p_176196_2_) && p_176196_1_.isSideSolid(p_176196_2_.func_177977_b(), EnumFacing.UP);
      }
  
      public IBlockState func_185499_a(IBlockState p_185499_1_, Rotation p_185499_2_)


### PR DESCRIPTION
Exactly as the title says. The passed position was the position the pumpkin was going to be placed in, rather than the one of the block with a potentially solid side. I checked all other calls to `Block.isSideSolid`, they seem to pass the correct position.
It may be a good idea to move all of the calls to `world.isSideSolid` since it prevents this problem, as well as slightly reducing new allocations caused by `BlockPos.down()` etc. The deprecation note on `Block.isSideSolid` says `IBlockState.getBlockFaceShape` should be used instead, is that a copy-paste error? (I'm asking since a lot of patches still seem to use `isSideSolid`, and `getBlockFaceShape` doesn't default to `isSideSolid`)
If you don't want single-line PR's, feel free to close this and push the fix yourself.
Linking BluSunrize/ImmersiveEngineering#2743.