### PR TITLE
Prevent various vanilla blocks from loading unloaded chunks

### DIFF
--- a/patches/minecraft/net/minecraft/block/BlockCactus.java.patch
+++ b/patches/minecraft/net/minecraft/block/BlockCactus.java.patch
@@ -9,7 +9,15 @@
  {
      public static final PropertyInteger field_176587_a = PropertyInteger.func_177719_a("age", 0, 15);
      protected static final AxisAlignedBB field_185593_b = new AxisAlignedBB(0.0625D, 0.0D, 0.0625D, 0.9375D, 0.9375D, 0.9375D);
-@@ -51,6 +51,8 @@
+@@ -36,6 +36,7 @@
+ 
+     public void func_180650_b(World p_180650_1_, BlockPos p_180650_2_, IBlockState p_180650_3_, Random p_180650_4_)
+     {
++        if (!p_180650_1_.func_175697_a(p_180650_2_, 1)) return; // Forge: prevent growing cactus from loading unloaded chunks with block update
+         BlockPos blockpos = p_180650_2_.func_177984_a();
+ 
+         if (p_180650_1_.func_175623_d(blockpos))
+@@ -51,6 +52,8 @@
              {
                  int j = ((Integer)p_180650_3_.func_177229_b(field_176587_a)).intValue();
  
@@ -18,7 +26,7 @@
                  if (j == 15)
                  {
                      p_180650_1_.func_175656_a(blockpos, this.func_176223_P());
-@@ -62,6 +64,8 @@
+@@ -62,6 +65,8 @@
                  {
                      p_180650_1_.func_180501_a(p_180650_2_, p_180650_3_.func_177226_a(field_176587_a, Integer.valueOf(j + 1)), 4);
                  }
@@ -27,7 +35,7 @@
              }
          }
      }
-@@ -112,8 +116,8 @@
+@@ -112,8 +117,8 @@
              }
          }
  
@@ -38,7 +46,7 @@
      }
  
      public void func_180634_a(World p_180634_1_, BlockPos p_180634_2_, IBlockState p_180634_3_, Entity p_180634_4_)
-@@ -137,6 +141,18 @@
+@@ -137,6 +142,18 @@
          return ((Integer)p_176201_1_.func_177229_b(field_176587_a)).intValue();
      }
  

--- a/patches/minecraft/net/minecraft/block/BlockCrops.java.patch
+++ b/patches/minecraft/net/minecraft/block/BlockCrops.java.patch
@@ -1,6 +1,14 @@
 --- ../src-base/minecraft/net/minecraft/block/BlockCrops.java
 +++ ../src-work/minecraft/net/minecraft/block/BlockCrops.java
-@@ -78,9 +78,10 @@
+@@ -70,6 +70,7 @@
+     {
+         super.func_180650_b(p_180650_1_, p_180650_2_, p_180650_3_, p_180650_4_);
+ 
++        if (!p_180650_1_.func_175697_a(p_180650_2_, 1)) return; // Forge: prevent loading unloaded chunks when checking neighbor's light
+         if (p_180650_1_.func_175671_l(p_180650_2_.func_177984_a()) >= 9)
+         {
+             int i = this.func_185527_x(p_180650_3_);
+@@ -78,9 +79,10 @@
              {
                  float f = func_180672_a(this, p_180650_1_, p_180650_2_);
  
@@ -12,7 +20,7 @@
                  }
              }
          }
-@@ -116,11 +117,11 @@
+@@ -116,11 +118,11 @@
                  float f1 = 0.0F;
                  IBlockState iblockstate = p_180672_1_.func_180495_p(blockpos.func_177982_a(i, 0, j));
  
@@ -26,7 +34,7 @@
                      {
                          f1 = 3.0F;
                      }
-@@ -161,7 +162,8 @@
+@@ -161,7 +163,8 @@
  
      public boolean func_180671_f(World p_180671_1_, BlockPos p_180671_2_, IBlockState p_180671_3_)
      {
@@ -36,7 +44,7 @@
      }
  
      protected Item func_149866_i()
-@@ -174,11 +176,32 @@
+@@ -174,11 +177,32 @@
          return Items.field_151015_O;
      }
  

--- a/patches/minecraft/net/minecraft/block/BlockDynamicLiquid.java.patch
+++ b/patches/minecraft/net/minecraft/block/BlockDynamicLiquid.java.patch
@@ -1,6 +1,14 @@
 --- ../src-base/minecraft/net/minecraft/block/BlockDynamicLiquid.java
 +++ ../src-work/minecraft/net/minecraft/block/BlockDynamicLiquid.java
-@@ -67,7 +67,7 @@
+@@ -26,6 +26,7 @@
+ 
+     public void func_180650_b(World p_180650_1_, BlockPos p_180650_2_, IBlockState p_180650_3_, Random p_180650_4_)
+     {
++        if (!p_180650_1_.func_175697_a(p_180650_2_, this.func_185698_b(p_180650_1_))) return; // Forge: avoid loading unloaded chunks
+         int i = ((Integer)p_180650_3_.func_177229_b(field_176367_b)).intValue();
+         int j = 1;
+ 
+@@ -67,7 +68,7 @@
                  }
              }
  
@@ -9,7 +17,7 @@
              {
                  IBlockState iblockstate = p_180650_1_.func_180495_p(p_180650_2_.func_177977_b());
  
-@@ -166,6 +166,7 @@
+@@ -166,6 +167,7 @@
                  }
                  else
                  {
@@ -17,7 +25,7 @@
                      p_176375_3_.func_177230_c().func_176226_b(p_176375_1_, p_176375_2_, p_176375_3_, 0);
                  }
              }
-@@ -187,7 +188,7 @@
+@@ -187,7 +189,7 @@
  
                  if (!this.func_176372_g(p_176374_1_, blockpos, iblockstate) && (iblockstate.func_185904_a() != this.field_149764_J || ((Integer)iblockstate.func_177229_b(field_176367_b)).intValue() > 0))
                  {
@@ -26,7 +34,7 @@
                      {
                          return p_176374_3_;
                      }
-@@ -254,11 +255,12 @@
+@@ -254,11 +256,12 @@
  
      private boolean func_176372_g(World p_176372_1_, BlockPos p_176372_2_, IBlockState p_176372_3_)
      {

--- a/patches/minecraft/net/minecraft/block/BlockFire.java.patch
+++ b/patches/minecraft/net/minecraft/block/BlockFire.java.patch
@@ -29,7 +29,7 @@
      {
          if (p_180650_1_.func_82736_K().func_82766_b("doFireTick"))
          {
-+            if (!p_180650_1_.func_175697_a(p_180650_2_, 1)) return; // Forge: prevent loading unloaded chunks when spreading fire
++            if (!p_180650_1_.func_175697_a(p_180650_2_, 2)) return; // Forge: prevent loading unloaded chunks when spreading fire
              if (!this.func_176196_c(p_180650_1_, p_180650_2_))
              {
                  p_180650_1_.func_175698_g(p_180650_2_);

--- a/patches/minecraft/net/minecraft/block/BlockFire.java.patch
+++ b/patches/minecraft/net/minecraft/block/BlockFire.java.patch
@@ -25,7 +25,14 @@
          this.field_149849_a.put(p_180686_1_, Integer.valueOf(p_180686_2_));
          this.field_149848_b.put(p_180686_1_, Integer.valueOf(p_180686_3_));
      }
-@@ -132,13 +141,8 @@
+@@ -126,19 +135,15 @@
+     {
+         if (p_180650_1_.func_82736_K().func_82766_b("doFireTick"))
+         {
++            if (!p_180650_1_.func_175697_a(p_180650_2_, 1)) return; // Forge: prevent loading unloaded chunks when spreading fire
+             if (!this.func_176196_c(p_180650_1_, p_180650_2_))
+             {
+                 p_180650_1_.func_175698_g(p_180650_2_);
              }
  
              Block block = p_180650_1_.func_180495_p(p_180650_2_.func_177977_b()).func_177230_c();
@@ -40,7 +47,7 @@
              int i = ((Integer)p_180650_3_.func_177229_b(field_176543_a)).intValue();
  
              if (!flag && p_180650_1_.func_72896_J() && this.func_176537_d(p_180650_1_, p_180650_2_) && p_180650_4_.nextFloat() < 0.2F + (float)i * 0.03F)
-@@ -159,7 +163,7 @@
+@@ -159,7 +164,7 @@
                  {
                      if (!this.func_176533_e(p_180650_1_, p_180650_2_))
                      {
@@ -49,7 +56,7 @@
                          {
                              p_180650_1_.func_175698_g(p_180650_2_);
                          }
-@@ -167,7 +171,7 @@
+@@ -167,7 +172,7 @@
                          return;
                      }
  
@@ -58,7 +65,7 @@
                      {
                          p_180650_1_.func_175698_g(p_180650_2_);
                          return;
-@@ -182,12 +186,12 @@
+@@ -182,12 +187,12 @@
                      j = -50;
                  }
  
@@ -77,7 +84,7 @@
  
                  for (int k = -1; k <= 1; ++k)
                  {
-@@ -246,22 +250,30 @@
+@@ -246,22 +251,30 @@
          return false;
      }
  
@@ -109,7 +116,7 @@
          if (p_176536_4_.nextInt(p_176536_3_) < i)
          {
              IBlockState iblockstate = p_176536_1_.func_180495_p(p_176536_2_);
-@@ -293,7 +305,7 @@
+@@ -293,7 +306,7 @@
      {
          for (EnumFacing enumfacing : EnumFacing.values())
          {
@@ -118,7 +125,7 @@
              {
                  return true;
              }
-@@ -314,7 +326,7 @@
+@@ -314,7 +327,7 @@
  
              for (EnumFacing enumfacing : EnumFacing.values())
              {
@@ -127,7 +134,7 @@
              }
  
              return i;
-@@ -326,9 +338,10 @@
+@@ -326,9 +339,10 @@
          return false;
      }
  
@@ -139,7 +146,7 @@
      }
  
      public boolean func_176196_c(World p_176196_1_, BlockPos p_176196_2_)
-@@ -372,9 +385,9 @@
+@@ -372,9 +386,9 @@
              p_180655_2_.func_184134_a((double)((float)p_180655_3_.func_177958_n() + 0.5F), (double)((float)p_180655_3_.func_177956_o() + 0.5F), (double)((float)p_180655_3_.func_177952_p() + 0.5F), SoundEvents.field_187643_bs, SoundCategory.BLOCKS, 1.0F + p_180655_4_.nextFloat(), p_180655_4_.nextFloat() * 0.7F + 0.3F, false);
          }
  
@@ -151,7 +158,7 @@
              {
                  for (int j = 0; j < 2; ++j)
                  {
-@@ -385,7 +398,7 @@
+@@ -385,7 +399,7 @@
                  }
              }
  
@@ -160,7 +167,7 @@
              {
                  for (int k = 0; k < 2; ++k)
                  {
-@@ -396,7 +409,7 @@
+@@ -396,7 +410,7 @@
                  }
              }
  
@@ -169,7 +176,7 @@
              {
                  for (int l = 0; l < 2; ++l)
                  {
-@@ -407,7 +420,7 @@
+@@ -407,7 +421,7 @@
                  }
              }
  
@@ -178,7 +185,7 @@
              {
                  for (int i1 = 0; i1 < 2; ++i1)
                  {
-@@ -418,7 +431,7 @@
+@@ -418,7 +432,7 @@
                  }
              }
  
@@ -187,7 +194,7 @@
              {
                  for (int j1 = 0; j1 < 2; ++j1)
                  {
-@@ -462,6 +475,21 @@
+@@ -462,6 +476,21 @@
          return new BlockStateContainer(this, new IProperty[] {field_176543_a, field_176545_N, field_176546_O, field_176541_P, field_176539_Q, field_176542_R});
      }
  

--- a/patches/minecraft/net/minecraft/block/BlockGrass.java.patch
+++ b/patches/minecraft/net/minecraft/block/BlockGrass.java.patch
@@ -1,15 +1,16 @@
 --- ../src-base/minecraft/net/minecraft/block/BlockGrass.java
 +++ ../src-work/minecraft/net/minecraft/block/BlockGrass.java
-@@ -38,7 +38,7 @@
+@@ -38,7 +38,8 @@
      {
          if (!p_180650_1_.field_72995_K)
          {
 -            if (p_180650_1_.func_175671_l(p_180650_2_.func_177984_a()) < 4 && p_180650_1_.func_180495_p(p_180650_2_.func_177984_a()).func_185891_c() > 2)
++            if (!p_180650_1_.func_175697_a(p_180650_2_, 3)) return; // Forge: prevent loading unloaded chunks when checking neighbor's light and spreading
 +            if (p_180650_1_.func_175671_l(p_180650_2_.func_177984_a()) < 4 && p_180650_1_.func_180495_p(p_180650_2_.func_177984_a()).getLightOpacity(p_180650_1_, p_180650_2_.func_177984_a()) > 2)
              {
                  p_180650_1_.func_175656_a(p_180650_2_, Blocks.field_150346_d.func_176223_P());
              }
-@@ -58,7 +58,7 @@
+@@ -58,7 +59,7 @@
                          IBlockState iblockstate = p_180650_1_.func_180495_p(blockpos.func_177984_a());
                          IBlockState iblockstate1 = p_180650_1_.func_180495_p(blockpos);
  
@@ -18,7 +19,7 @@
                          {
                              p_180650_1_.func_175656_a(blockpos, Blocks.field_150349_c.func_176223_P());
                          }
-@@ -96,18 +96,11 @@
+@@ -96,18 +97,11 @@
              {
                  if (j >= i / 16)
                  {

--- a/patches/minecraft/net/minecraft/block/BlockLeaves.java.patch
+++ b/patches/minecraft/net/minecraft/block/BlockLeaves.java.patch
@@ -21,7 +21,17 @@
                          }
                      }
                  }
-@@ -96,9 +96,9 @@
+@@ -83,7 +83,8 @@
+                     this.field_150128_a = new int[32768];
+                 }
+ 
+-                if (p_180650_1_.func_175707_a(new BlockPos(k - 5, l - 5, i1 - 5), new BlockPos(k + 5, l + 5, i1 + 5)))
++                if (!p_180650_1_.func_175697_a(p_180650_2_, 1)) return; // Forge: prevent decaying leaves from updating neighbors and loading unloaded chunks
++                if (p_180650_1_.func_175697_a(p_180650_2_, 6)) // Forge: extend range from 5 to 6 to account for neighbor checks in world.markAndNotifyBlock -> world.updateObservingBlocksAt
+                 {
+                     BlockPos.MutableBlockPos blockpos$mutableblockpos = new BlockPos.MutableBlockPos();
+ 
+@@ -96,9 +97,9 @@
                                  IBlockState iblockstate = p_180650_1_.func_180495_p(blockpos$mutableblockpos.func_181079_c(k + i2, l + j2, i1 + k2));
                                  Block block = iblockstate.func_177230_c();
  
@@ -33,7 +43,7 @@
                                      {
                                          this.field_150128_a[(i2 + 16) * 1024 + (j2 + 16) * 32 + k2 + 16] = -2;
                                      }
-@@ -205,40 +205,7 @@
+@@ -205,40 +206,7 @@
  
      public void func_180653_a(World p_180653_1_, BlockPos p_180653_2_, IBlockState p_180653_3_, float p_180653_4_, int p_180653_5_)
      {
@@ -75,7 +85,7 @@
      }
  
      protected void func_176234_a(World p_176234_1_, BlockPos p_176234_2_, IBlockState p_176234_3_, int p_176234_4_)
-@@ -274,6 +241,51 @@
+@@ -274,6 +242,51 @@
  
      public abstract BlockPlanks.EnumType func_176233_b(int p_176233_1_);
  

--- a/patches/minecraft/net/minecraft/block/BlockMycelium.java.patch
+++ b/patches/minecraft/net/minecraft/block/BlockMycelium.java.patch
@@ -1,15 +1,16 @@
 --- ../src-base/minecraft/net/minecraft/block/BlockMycelium.java
 +++ ../src-work/minecraft/net/minecraft/block/BlockMycelium.java
-@@ -39,7 +39,7 @@
+@@ -39,7 +39,8 @@
      {
          if (!p_180650_1_.field_72995_K)
          {
 -            if (p_180650_1_.func_175671_l(p_180650_2_.func_177984_a()) < 4 && p_180650_1_.func_180495_p(p_180650_2_.func_177984_a()).func_185891_c() > 2)
++            if (!p_180650_1_.func_175697_a(p_180650_2_, 2)) return; // Forge: prevent loading unloaded chunks when checking neighbor's light and spreading
 +            if (p_180650_1_.func_175671_l(p_180650_2_.func_177984_a()) < 4 && p_180650_1_.func_180495_p(p_180650_2_.func_177984_a()).getLightOpacity(p_180650_1_, p_180650_2_.func_177984_a()) > 2)
              {
                  p_180650_1_.func_175656_a(p_180650_2_, Blocks.field_150346_d.func_176223_P().func_177226_a(BlockDirt.field_176386_a, BlockDirt.DirtType.DIRT));
              }
-@@ -53,7 +53,7 @@
+@@ -53,7 +54,7 @@
                          IBlockState iblockstate = p_180650_1_.func_180495_p(blockpos);
                          IBlockState iblockstate1 = p_180650_1_.func_180495_p(blockpos.func_177984_a());
  

--- a/patches/minecraft/net/minecraft/block/BlockSapling.java.patch
+++ b/patches/minecraft/net/minecraft/block/BlockSapling.java.patch
@@ -1,6 +1,14 @@
 --- ../src-base/minecraft/net/minecraft/block/BlockSapling.java
 +++ ../src-work/minecraft/net/minecraft/block/BlockSapling.java
-@@ -74,6 +74,7 @@
+@@ -53,6 +53,7 @@
+         {
+             super.func_180650_b(p_180650_1_, p_180650_2_, p_180650_3_, p_180650_4_);
+ 
++            if (!p_180650_1_.func_175697_a(p_180650_2_, 1)) return; // Forge: prevent loading unloaded chunks when checking neighbor's light
+             if (p_180650_1_.func_175671_l(p_180650_2_.func_177984_a()) >= 9 && p_180650_4_.nextInt(7) == 0)
+             {
+                 this.func_176478_d(p_180650_1_, p_180650_2_, p_180650_3_, p_180650_4_);
+@@ -74,6 +75,7 @@
  
      public void func_176476_e(World p_176476_1_, BlockPos p_176476_2_, IBlockState p_176476_3_, Random p_176476_4_)
      {

--- a/patches/minecraft/net/minecraft/block/BlockStem.java.patch
+++ b/patches/minecraft/net/minecraft/block/BlockStem.java.patch
@@ -1,6 +1,11 @@
 --- ../src-base/minecraft/net/minecraft/block/BlockStem.java
 +++ ../src-work/minecraft/net/minecraft/block/BlockStem.java
-@@ -70,14 +70,14 @@
+@@ -66,18 +66,19 @@
+     {
+         super.func_180650_b(p_180650_1_, p_180650_2_, p_180650_3_, p_180650_4_);
+ 
++        if (!p_180650_1_.func_175697_a(p_180650_2_, 1)) return; // Forge: prevent loading unloaded chunks when checking neighbor's light
+         if (p_180650_1_.func_175671_l(p_180650_2_.func_177984_a()) >= 9)
          {
              float f = BlockCrops.func_180672_a(this, p_180650_1_, p_180650_2_);
  
@@ -18,7 +23,7 @@
                  }
                  else
                  {
-@@ -90,13 +90,15 @@
+@@ -90,13 +91,15 @@
                      }
  
                      p_180650_2_ = p_180650_2_.func_177972_a(EnumFacing.Plane.HORIZONTAL.func_179518_a(p_180650_4_));
@@ -36,7 +41,7 @@
              }
          }
      }
-@@ -110,20 +112,23 @@
+@@ -110,20 +113,23 @@
      public void func_180653_a(World p_180653_1_, BlockPos p_180653_2_, IBlockState p_180653_3_, float p_180653_4_, int p_180653_5_)
      {
          super.func_180653_a(p_180653_1_, p_180653_2_, p_180653_3_, p_180653_4_, p_180653_5_);

--- a/patches/minecraft/net/minecraft/block/BlockVine.java.patch
+++ b/patches/minecraft/net/minecraft/block/BlockVine.java.patch
@@ -9,6 +9,15 @@
  {
      public static final PropertyBool field_176277_a = PropertyBool.func_177716_a("up");
      public static final PropertyBool field_176273_b = PropertyBool.func_177716_a("north");
+@@ -185,7 +185,7 @@
+     {
+         if (!p_180650_1_.field_72995_K)
+         {
+-            if (p_180650_1_.field_73012_v.nextInt(4) == 0)
++            if (p_180650_1_.field_73012_v.nextInt(4) == 0 && p_180650_1_.func_175697_a(p_180650_2_, 4)) // Forge: check area to prevent loading unloaded chunks
+             {
+                 int i = 4;
+                 int j = 5;
 @@ -244,7 +244,7 @@
                          IBlockState iblockstate3 = p_180650_1_.func_180495_p(blockpos4);
                          Block block1 = iblockstate3.func_177230_c();

--- a/patches/minecraft/net/minecraft/tileentity/TileEntityChest.java.patch
+++ b/patches/minecraft/net/minecraft/tileentity/TileEntityChest.java.patch
@@ -8,7 +8,15 @@
      }
  
      @SuppressWarnings("incomplete-switch")
-@@ -349,6 +350,29 @@
+@@ -167,6 +168,7 @@
+     {
+         if (!this.field_145984_a)
+         {
++            if (this.field_145850_b == null || !this.field_145850_b.func_175697_a(this.field_174879_c, 1)) return; // Forge: prevent loading unloaded chunks when checking neighbors
+             this.field_145984_a = true;
+             this.field_145991_k = this.func_174911_a(EnumFacing.WEST);
+             this.field_145990_j = this.func_174911_a(EnumFacing.EAST);
+@@ -349,6 +351,29 @@
          }
      }
  

--- a/patches/minecraft/net/minecraft/village/Village.java.patch
+++ b/patches/minecraft/net/minecraft/village/Village.java.patch
@@ -50,7 +50,7 @@
              }
  
 -            if (!this.func_179860_f(villagedoorinfo.func_179852_d()) || Math.abs(this.field_75581_g - villagedoorinfo.func_75473_b()) > 1200)
-+            if (!field_75586_a.func_175667_e(villagedoorinfo.func_179852_d()) || !this.func_179860_f(villagedoorinfo.func_179852_d()) || Math.abs(this.field_75581_g - villagedoorinfo.func_75473_b()) > 1200) // Forge: check that the block is loaded to a void loading chunks
++            if (!field_75586_a.func_175667_e(villagedoorinfo.func_179852_d()) || !this.func_179860_f(villagedoorinfo.func_179852_d()) || Math.abs(this.field_75581_g - villagedoorinfo.func_75473_b()) > 1200) // Forge: check that the door block is loaded to avoid loading chunks
              {
                  this.field_75585_c = this.field_75585_c.func_177973_b(villagedoorinfo.func_179852_d());
                  flag = true;

--- a/patches/minecraft/net/minecraft/village/Village.java.patch
+++ b/patches/minecraft/net/minecraft/village/Village.java.patch
@@ -45,16 +45,15 @@
  
                  if (entityplayer1 != null)
                  {
-@@ -362,7 +364,7 @@
+@@ -362,6 +364,7 @@
                  villagedoorinfo.func_75466_d();
              }
  
--            if (!this.func_179860_f(villagedoorinfo.func_179852_d()) || Math.abs(this.field_75581_g - villagedoorinfo.func_75473_b()) > 1200)
-+            if (!field_75586_a.func_175667_e(villagedoorinfo.func_179852_d()) || !this.func_179860_f(villagedoorinfo.func_179852_d()) || Math.abs(this.field_75581_g - villagedoorinfo.func_75473_b()) > 1200) // Forge: check that the door block is loaded to avoid loading chunks
++            if (field_75586_a.func_175667_e(villagedoorinfo.func_179852_d())) // Forge: check that the door block is loaded to avoid loading chunks
+             if (!this.func_179860_f(villagedoorinfo.func_179852_d()) || Math.abs(this.field_75581_g - villagedoorinfo.func_75473_b()) > 1200)
              {
                  this.field_75585_c = this.field_75585_c.func_177973_b(villagedoorinfo.func_179852_d());
-                 flag = true;
-@@ -415,25 +417,51 @@
+@@ -415,25 +418,51 @@
          }
      }
  
@@ -108,7 +107,7 @@
      public void func_82690_a(NBTTagCompound p_82690_1_)
      {
          this.field_75588_h = p_82690_1_.func_74762_e("PopSize");
-@@ -459,21 +487,17 @@
+@@ -459,21 +488,17 @@
          {
              NBTTagCompound nbttagcompound1 = nbttaglist1.func_150305_b(j);
  
@@ -135,7 +134,7 @@
      }
  
      public void func_82689_b(NBTTagCompound p_82689_1_)
-@@ -507,18 +531,14 @@
+@@ -507,18 +532,14 @@
          p_82689_1_.func_74782_a("Doors", nbttaglist);
          NBTTagList nbttaglist1 = new NBTTagList();
  
@@ -156,7 +155,7 @@
                      nbttagcompound1.func_74768_a("S", ((Integer)this.field_82693_j.get(s)).intValue());
                      nbttaglist1.func_74742_a(nbttagcompound1);
                  }
-@@ -530,6 +550,7 @@
+@@ -530,6 +551,7 @@
          }
  
          p_82689_1_.func_74782_a("Players", nbttaglist1);
@@ -164,7 +163,7 @@
      }
  
      public void func_82692_h()
-@@ -544,9 +565,9 @@
+@@ -544,9 +566,9 @@
  
      public void func_82683_b(int p_82683_1_)
      {
@@ -176,7 +175,7 @@
          }
      }
  
-@@ -561,4 +582,31 @@
+@@ -561,4 +583,31 @@
              this.field_75590_b = p_i1674_3_;
          }
      }

--- a/patches/minecraft/net/minecraft/village/Village.java.patch
+++ b/patches/minecraft/net/minecraft/village/Village.java.patch
@@ -45,6 +45,15 @@
  
                  if (entityplayer1 != null)
                  {
+@@ -362,7 +364,7 @@
+                 villagedoorinfo.func_75466_d();
+             }
+ 
+-            if (!this.func_179860_f(villagedoorinfo.func_179852_d()) || Math.abs(this.field_75581_g - villagedoorinfo.func_75473_b()) > 1200)
++            if (!field_75586_a.func_175667_e(villagedoorinfo.func_179852_d()) || !this.func_179860_f(villagedoorinfo.func_179852_d()) || Math.abs(this.field_75581_g - villagedoorinfo.func_75473_b()) > 1200) // Forge: check that the block is loaded to a void loading chunks
+             {
+                 this.field_75585_c = this.field_75585_c.func_177973_b(villagedoorinfo.func_179852_d());
+                 flag = true;
 @@ -415,25 +417,51 @@
          }
      }

--- a/patches/minecraft/net/minecraft/village/VillageCollection.java.patch
+++ b/patches/minecraft/net/minecraft/village/VillageCollection.java.patch
@@ -1,0 +1,10 @@
+--- ../src-base/minecraft/net/minecraft/village/VillageCollection.java
++++ ../src-work/minecraft/net/minecraft/village/VillageCollection.java
+@@ -151,6 +151,7 @@
+ 
+     private void func_180609_b(BlockPos p_180609_1_)
+     {
++        if (!this.field_75556_a.func_175697_a(p_180609_1_, 16)) return; // Forge: prevent loading unloaded chunks when checking for doors
+         int i = 16;
+         int j = 4;
+         int k = 16;

--- a/patches/minecraft/net/minecraft/world/WorldServer.java.patch
+++ b/patches/minecraft/net/minecraft/world/WorldServer.java.patch
@@ -127,7 +127,7 @@
                  {
                      this.field_73005_l = this.field_73005_l * 3 + 1013904223;
                      int l = this.field_73005_l >> 2;
-@@ -415,7 +428,7 @@
+@@ -415,13 +428,14 @@
  
                  this.field_72984_F.func_76318_c("iceandsnow");
  
@@ -136,7 +136,14 @@
                  {
                      this.field_73005_l = this.field_73005_l * 3 + 1013904223;
                      int j2 = this.field_73005_l >> 2;
-@@ -525,7 +538,10 @@
+                     BlockPos blockpos1 = this.func_175725_q(new BlockPos(j + (j2 & 15), 0, k + (j2 >> 8 & 15)));
+                     BlockPos blockpos2 = blockpos1.func_177977_b();
+ 
++                    if (this.func_175697_a(blockpos2, 1)) // Forge: check area to avoid loading neighbors in unloaded chunks
+                     if (this.func_175662_w(blockpos2))
+                     {
+                         this.func_175656_a(blockpos2, Blocks.field_150432_aD.func_176223_P());
+@@ -525,7 +539,10 @@
          {
              if (p_175654_2_.func_149698_L())
              {
@@ -148,7 +155,7 @@
                  {
                      IBlockState iblockstate = this.func_180495_p(p_175654_1_);
  
-@@ -561,6 +577,7 @@
+@@ -561,6 +578,7 @@
  
      public void func_180497_b(BlockPos p_180497_1_, Block p_180497_2_, int p_180497_3_, int p_180497_4_)
      {
@@ -156,7 +163,7 @@
          NextTickListEntry nextticklistentry = new NextTickListEntry(p_180497_1_, p_180497_2_);
          nextticklistentry.func_82753_a(p_180497_4_);
          Material material = p_180497_2_.func_176223_P().func_185904_a();
-@@ -579,7 +596,7 @@
+@@ -579,7 +597,7 @@
  
      public void func_72939_s()
      {
@@ -165,7 +172,7 @@
          {
              if (this.field_80004_Q++ >= 300)
              {
-@@ -703,6 +720,9 @@
+@@ -703,6 +721,9 @@
                  {
                      NextTickListEntry nextticklistentry1 = iterator.next();
                      iterator.remove();
@@ -175,7 +182,7 @@
                      int k = 0;
  
                      if (this.func_175707_a(nextticklistentry1.field_180282_a.func_177982_a(0, 0, 0), nextticklistentry1.field_180282_a.func_177982_a(0, 0, 0)))
-@@ -829,6 +849,10 @@
+@@ -829,6 +850,10 @@
  
      public boolean func_175660_a(EntityPlayer p_175660_1_, BlockPos p_175660_2_)
      {
@@ -186,7 +193,7 @@
          return !this.field_73061_a.func_175579_a(this, p_175660_2_, p_175660_1_) && this.func_175723_af().func_177746_a(p_175660_2_);
      }
  
-@@ -894,6 +918,7 @@
+@@ -894,6 +919,7 @@
          }
          else
          {
@@ -194,7 +201,7 @@
              this.field_72987_B = true;
              BiomeProvider biomeprovider = this.field_73011_w.func_177499_m();
              List<Biome> list = biomeprovider.func_76932_a();
-@@ -979,6 +1004,7 @@
+@@ -979,6 +1005,7 @@
              }
  
              chunkproviderserver.func_186027_a(p_73044_1_);
@@ -202,7 +209,7 @@
  
              for (Chunk chunk : Lists.newArrayList(chunkproviderserver.func_189548_a()))
              {
-@@ -1023,6 +1049,7 @@
+@@ -1023,6 +1050,7 @@
          this.field_72986_A.func_176135_e(this.func_175723_af().func_177732_i());
          this.field_73019_z.func_75755_a(this.field_72986_A, this.field_73061_a.func_184103_al().func_72378_q());
          this.field_72988_C.func_75744_a();
@@ -210,7 +217,7 @@
      }
  
      public boolean func_72838_d(Entity p_72838_1_)
-@@ -1034,7 +1061,7 @@
+@@ -1034,7 +1062,7 @@
      {
          for (Entity entity : Lists.newArrayList(p_175650_1_))
          {
@@ -219,7 +226,7 @@
              {
                  this.field_72996_f.add(entity);
                  this.func_72923_a(entity);
-@@ -1115,7 +1142,7 @@
+@@ -1115,7 +1143,7 @@
      {
          if (super.func_72942_c(p_72942_1_))
          {
@@ -228,7 +235,7 @@
              return true;
          }
          else
-@@ -1137,6 +1164,7 @@
+@@ -1137,6 +1165,7 @@
      public Explosion func_72885_a(@Nullable Entity p_72885_1_, double p_72885_2_, double p_72885_4_, double p_72885_6_, float p_72885_8_, boolean p_72885_9_, boolean p_72885_10_)
      {
          Explosion explosion = new Explosion(this, p_72885_1_, p_72885_2_, p_72885_4_, p_72885_6_, p_72885_8_, p_72885_9_, p_72885_10_);
@@ -236,7 +243,7 @@
          explosion.func_77278_a();
          explosion.func_77279_a(false);
  
-@@ -1182,7 +1210,7 @@
+@@ -1182,7 +1211,7 @@
              {
                  if (this.func_147485_a(blockeventdata))
                  {
@@ -245,7 +252,7 @@
                  }
              }
  
-@@ -1208,27 +1236,31 @@
+@@ -1208,27 +1237,31 @@
  
          if (this.field_73003_n != this.field_73004_o)
          {
@@ -283,7 +290,7 @@
          }
      }
  
-@@ -1323,6 +1355,11 @@
+@@ -1323,6 +1356,11 @@
          return this.field_193036_D;
      }
  


### PR DESCRIPTION
I ran across these by using [Sampler](https://forum.industrial-craft.net/thread/10820-wip-1-7-10-fastcraft-1-25-note-all-posts-of-new-members-need-to-be-approved-firs/)'s `/sampler loads show` command.
It logs whenever anything (including the player) loads a chunk, so it's easy to see when something is loading a chunk when it shouldn't be.

None of these are extremely high impact, but they are definitely bugs and cause chunks to load. Either on their own or combined with mods that have similar problems, these can cause chunks to stay loaded forever. With just vanilla alone I think it would not have much impact, so I am considering this as a performance enhancement for modded unless someone wants to make a case for it being a vanilla bug.

The biggest remaining chunk loaders I found are ~~`BlockDynamicLiquid.getSlopeDistance`~~, `EntityAIWander.startExecuting`, and `WorldGenFossils.generate` but they seem like they would be more complicated to fix.