### PR TITLE
Fix incorrect dimension ID being used for maps

### DIFF
--- a/patches/minecraft/net/minecraft/item/ItemMap.java.patch
+++ b/patches/minecraft/net/minecraft/item/ItemMap.java.patch
@@ -27,7 +27,7 @@
          {
              int i = 1 << p_77872_3_.field_76197_d;
              int j = p_77872_3_.field_76201_a;
-@@ -251,9 +251,9 @@
+@@ -251,13 +251,13 @@
  
      public static void func_190905_a(World p_190905_0_, ItemStack p_190905_1_)
      {
@@ -39,3 +39,8 @@
  
              if (mapdata != null)
              {
+-                if (p_190905_0_.field_73011_w.func_186058_p().func_186068_a() == mapdata.field_76200_c)
++                if (p_190905_0_.field_73011_w.getDimension() == mapdata.field_76200_c)
+                 {
+                     int i = 1 << mapdata.field_76197_d;
+                     int j = mapdata.field_76201_a;


### PR DESCRIPTION
Pretty simple, just fixes a location in `ItemMap` that was missing a patch to use the correct dimension ID.