### PR TITLE
Improve error message on server when a vanilla client connects

### DIFF
--- a/src/main/java/net/minecraftforge/fml/common/FMLCommonHandler.java
+++ b/src/main/java/net/minecraftforge/fml/common/FMLCommonHandler.java
@@ -26,6 +26,7 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.lang.ref.WeakReference;
 import java.nio.charset.StandardCharsets;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -635,8 +636,9 @@ public class FMLCommonHandler
         if (packet.getRequestedState() == EnumConnectionState.LOGIN && (!NetworkRegistry.INSTANCE.isVanillaAccepted(Side.CLIENT) && !packet.hasFMLMarker()))
         {
             manager.setConnectionState(EnumConnectionState.LOGIN);
-            TextComponentString text = new TextComponentString("This server requires FML/Forge to be installed. Contact your server admin for more details.");
-            FMLLog.log.info("Disconnecting Player: {}", text.getUnformattedText());
+            TextComponentString text = new TextComponentString("This server has mods that require FML/Forge to be installed on the client. Contact your server admin for more details.");
+            Collection<String> modNames = NetworkRegistry.INSTANCE.getModNamesThatDoNotAcceptVanilla(Side.CLIENT);
+            FMLLog.log.info("Disconnecting Player: This server has mods that require FML/Forge to be installed on the client:\n{}", modNames);
             manager.sendPacket(new SPacketDisconnect(text));
             manager.closeChannel(text);
             return false;

--- a/src/main/java/net/minecraftforge/fml/common/FMLCommonHandler.java
+++ b/src/main/java/net/minecraftforge/fml/common/FMLCommonHandler.java
@@ -637,8 +637,8 @@ public class FMLCommonHandler
         {
             manager.setConnectionState(EnumConnectionState.LOGIN);
             TextComponentString text = new TextComponentString("This server has mods that require FML/Forge to be installed on the client. Contact your server admin for more details.");
-            Collection<String> modNames = NetworkRegistry.INSTANCE.getModNamesThatDoNotAcceptVanilla(Side.CLIENT);
-            FMLLog.log.info("Disconnecting Player: This server has mods that require FML/Forge to be installed on the client:\n{}", modNames);
+            Collection<String> modNames = NetworkRegistry.INSTANCE.getRequiredMods(Side.CLIENT);
+            FMLLog.log.info("Disconnecting Player: This server has mods that require FML/Forge to be installed on the client: {}", modNames);
             manager.sendPacket(new SPacketDisconnect(text));
             manager.closeChannel(text);
             return false;

--- a/src/main/java/net/minecraftforge/fml/common/network/NetworkRegistry.java
+++ b/src/main/java/net/minecraftforge/fml/common/network/NetworkRegistry.java
@@ -310,11 +310,12 @@ public enum NetworkRegistry
                 .allMatch(mod -> mod.acceptsVanilla(from));
     }
 
-    public Collection<String> getModNamesThatDoNotAcceptVanilla(Side from)
+    public Collection<String> getRequiredMods(Side from)
     {
         return registry.values().stream()
                 .filter(mod -> !mod.acceptsVanilla(from))
                 .map(mod -> mod.getContainer().getName())
+                .sorted()
                 .collect(Collectors.toList());
     }
 

--- a/src/main/java/net/minecraftforge/fml/common/network/NetworkRegistry.java
+++ b/src/main/java/net/minecraftforge/fml/common/network/NetworkRegistry.java
@@ -24,10 +24,12 @@ import io.netty.channel.ChannelHandlerContext;
 import io.netty.handler.codec.MessageToMessageCodec;
 import io.netty.util.AttributeKey;
 
+import java.util.Collection;
 import java.util.EnumMap;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import org.apache.logging.log4j.Level;
 
@@ -304,13 +306,18 @@ public enum NetworkRegistry
 
     public boolean isVanillaAccepted(Side from)
     {
-        boolean result = true;
-        for (Entry<ModContainer, NetworkModHolder> e : registry.entrySet())
-        {
-            result &= e.getValue().acceptsVanilla(from);
-        }
-        return result;
+        return registry.values().stream()
+                .allMatch(mod -> mod.acceptsVanilla(from));
     }
+
+    public Collection<String> getModNamesThatDoNotAcceptVanilla(Side from)
+    {
+        return registry.values().stream()
+                .filter(mod -> !mod.acceptsVanilla(from))
+                .map(mod -> mod.getContainer().getName())
+                .collect(Collectors.toList());
+    }
+
     public Map<ModContainer,NetworkModHolder> registry()
     {
         return ImmutableMap.copyOf(registry);


### PR DESCRIPTION
When a vanilla client connection to a Forge server fails, this lists the mods that are incompatible with vanilla.

This helps the situation here, where someone wants to create a Forge server that is compatible with vanilla clients:
https://www.reddit.com/r/feedthebeast/comments/7rukv2/not_sure_why_vanilla_users_have_to_download_forge/