### PR TITLE
Improve performance of some ExtendedBlockState methods

### DIFF
--- a/src/main/java/net/minecraftforge/common/property/ExtendedBlockState.java
+++ b/src/main/java/net/minecraftforge/common/property/ExtendedBlockState.java
@@ -23,6 +23,7 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.util.Collection;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
@@ -102,11 +103,16 @@ public class ExtendedBlockState extends BlockStateContainer
         @Override
         public <V> IExtendedBlockState withProperty(IUnlistedProperty<V> property, V value)
         {
-            if(!this.unlistedProperties.containsKey(property))
+            Optional<?> oldValue = unlistedProperties.get(property);
+            if (oldValue == null)
             {
                 throw new IllegalArgumentException("Cannot set unlisted property " + property + " as it does not exist in " + getBlock().getBlockState());
             }
-            if(!property.isValid(value))
+            if (Objects.equals(oldValue.orElse(null), value))
+            {
+                return this;
+            }
+            if (!property.isValid(value))
             {
                 throw new IllegalArgumentException("Cannot set unlisted property " + property + " to " + value + " on block " + Block.REGISTRY.getNameForObject(getBlock()) + ", it is not an allowed value");
             }

--- a/src/main/java/net/minecraftforge/common/property/ExtendedBlockState.java
+++ b/src/main/java/net/minecraftforge/common/property/ExtendedBlockState.java
@@ -101,7 +101,7 @@ public class ExtendedBlockState extends BlockStateContainer
         }
 
         @Override
-        public <V> IExtendedBlockState withProperty(IUnlistedProperty<V> property, V value)
+        public <V> IExtendedBlockState withProperty(IUnlistedProperty<V> property, @Nullable V value)
         {
             Optional<?> oldValue = unlistedProperties.get(property);
             if (oldValue == null)

--- a/src/main/java/net/minecraftforge/common/property/ExtendedBlockState.java
+++ b/src/main/java/net/minecraftforge/common/property/ExtendedBlockState.java
@@ -119,12 +119,11 @@ public class ExtendedBlockState extends BlockStateContainer
                 if (newValue.isPresent()) clean = false;
                 builder.put(key, newValue);
             }
-            ImmutableMap<IUnlistedProperty<?>, Optional<?>> newMap = builder.build();
             if (clean)
             { // no dynamic properties, lookup normal state
                 return (IExtendedBlockState) cleanState;
             }
-            return new ExtendedStateImplementation(getBlock(), getProperties(), newMap, propertyValueTable, this.cleanState);
+            return new ExtendedStateImplementation(getBlock(), getProperties(), builder.build(), propertyValueTable, this.cleanState);
         }
 
         @Override

--- a/src/main/java/net/minecraftforge/common/property/ExtendedBlockState.java
+++ b/src/main/java/net/minecraftforge/common/property/ExtendedBlockState.java
@@ -22,7 +22,6 @@ package net.minecraftforge.common.property;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.Map;
 import java.util.Optional;
 import com.google.common.collect.ImmutableMap;
@@ -131,7 +130,7 @@ public class ExtendedBlockState extends BlockStateContainer
         @Override
         public Collection<IUnlistedProperty<?>> getUnlistedNames()
         {
-            return Collections.unmodifiableCollection(unlistedProperties.keySet());
+            return unlistedProperties.keySet();
         }
 
         @Override


### PR DESCRIPTION
Just a few small changes to improve the performance of extended block states.

* `withProperty(IUnlistedProperty<V>, V)` is changed to build only a single map with the new properties. The old behaviour copied the old properties into a new `HashMap` instance, set the new property, and then took an immutable copy of that map to use.

* `getValue(IUnlistedProperty<V>)` is changed to only call `get` and null-check the return, instead of calling both `containsKey` and `get`.

* `withProperty(IProperty<T>, V)` is changed back to using a foreach loop (via `Iterables`) instead of a stream, as streams are slower here, especially with the small number of properties involved.

Some VisualVM snapshots to demonstrate:

* Forge 2577:
![snapshot_2577](https://user-images.githubusercontent.com/1447117/35441206-87a31df4-029a-11e8-86cd-241660010444.png)

* This PR:
![snapshot_post](https://user-images.githubusercontent.com/1447117/35441224-98e9e584-029a-11e8-932e-ec86535d39bb.png)
