### PR TITLE
Optimise adding normal element to vertex formats

### DIFF
--- a/src/main/java/net/minecraftforge/client/model/pipeline/VertexLighterFlat.java
+++ b/src/main/java/net/minecraftforge/client/model/pipeline/VertexLighterFlat.java
@@ -31,11 +31,15 @@ import net.minecraft.util.EnumFacing;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.IBlockAccess;
 
-import com.google.common.base.Objects;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
 
 public class VertexLighterFlat extends QuadGatheringTransformer
 {
     protected static final VertexFormatElement NORMAL_4F = new VertexFormatElement(0, VertexFormatElement.EnumType.FLOAT, VertexFormatElement.EnumUsage.NORMAL, 4);
+
+    private final Map<VertexFormat, VertexFormat> formatMap = new HashMap<>();
 
     protected final BlockInfo blockInfo;
     private int tint = -1;
@@ -56,7 +60,7 @@ public class VertexLighterFlat extends QuadGatheringTransformer
     {
         super.setParent(parent);
         VertexFormat format = getVertexFormat(parent);
-        if(Objects.equal(format, getVertexFormat())) return;
+        if (Objects.equals(format, getVertexFormat())) return;
         setVertexFormat(format);
         for(int i = 0; i < getVertexFormat().getElementCount(); i++)
         {
@@ -94,13 +98,11 @@ public class VertexLighterFlat extends QuadGatheringTransformer
         }
     }
 
-    private static VertexFormat getVertexFormat(IVertexConsumer parent)
+    private VertexFormat getVertexFormat(IVertexConsumer parent)
     {
         VertexFormat format = parent.getVertexFormat();
-        if(format == null || format.hasNormal()) return format;
-        format = new VertexFormat(format);
-        format.addElement(NORMAL_4F);
-        return format;
+        if (format == null || format.hasNormal()) return format;
+        return formatMap.computeIfAbsent(format, original -> new VertexFormat(original).addElement(NORMAL_4F));
     }
 
     @Override


### PR DESCRIPTION
Sort of a followup to #3771, this ~~caches~~ optimises the vertex format remapping done by `VertexLighterFlat`, which requires a format containing normal data, for a small increase in performance.

Partly related to #4697, in that this is also mostly an issue due to changing render layers.
~~Also benefits from the `hashCode` caching introduced by #4370.~~

More VisualVM snapshots (note that these both include the changes made by #4698):

* Before:
![snapshot_pre](https://user-images.githubusercontent.com/1447117/35451716-0ab501a0-02bc-11e8-8bb7-b5a693ce6e1a.png)

* After:
![snapshot_post](https://user-images.githubusercontent.com/1447117/35451728-122a2b54-02bc-11e8-8a50-10eaa2bfa58b.png)
