### PR TITLE
Fixed UV contraction for the texture in the top-left corner of the texture map

### DIFF
--- a/src/main/java/net/minecraftforge/client/model/pipeline/UnpackedBakedQuad.java
+++ b/src/main/java/net/minecraftforge/client/model/pipeline/UnpackedBakedQuad.java
@@ -180,8 +180,8 @@ public class UnpackedBakedQuad extends BakedQuad
             }
             if(contractUVs)
             {
-                float tX = texture.getOriginX() / texture.getMinU();
-                float tY = texture.getOriginY() / texture.getMinV();
+                float tX = texture.getIconWidth() / (texture.getMaxU() - texture.getMinU());
+                float tY = texture.getIconHeight() / (texture.getMaxV() - texture.getMinV());
                 float tS = tX > tY ? tX : tY;
                 float ep = 1f / (tS * 0x100);
                 int uve = 0;


### PR DESCRIPTION
See sp614x/optifine#1024
The current behavior is broken with and without Optifine, but it only causes visible errors with Optifine. I described the behaviors in https://github.com/sp614x/optifine/issues/1024#issuecomment-357467573 (TL;DR is: With just forge `tX` and `tY` end up as `NaN` and don't do anything, with Optifine they are `+Infinity` and cause bugs). The code doesn't do what it's supposed to do in either case. This PR changes `tX` and `tY` to be calculated from just from the texture size (as opposed to the location of the texture in the map). This should work for all textures and positions in the texture map, assuming no one decides to add a texture of size 0 (if anyone can think of a reason anyone would do that and then use the texture in a model, I'll add a check for it).