### PR TITLE
[1.12.x] Bumped the biome limit to 65,536

### DIFF
--- a/patches/minecraft/net/minecraft/network/play/server/SPacketChunkData.java.patch
+++ b/patches/minecraft/net/minecraft/network/play/server/SPacketChunkData.java.patch
@@ -9,7 +9,7 @@
 +            Short[] localBiomeIds = p_189555_2_.getLocalBiomeIds();
 +            for (int k = 0; k < localBiomeCount; k++)
 +            {
-+                p_189555_1_.writeShort(localBiomeIds[i]);
++                p_189555_1_.writeShort(localBiomeIds[k]);
 +            }
          }
  

--- a/patches/minecraft/net/minecraft/network/play/server/SPacketChunkData.java.patch
+++ b/patches/minecraft/net/minecraft/network/play/server/SPacketChunkData.java.patch
@@ -1,0 +1,18 @@
+--- ../src-base/minecraft/net/minecraft/network/play/server/SPacketChunkData.java
++++ ../src-work/minecraft/net/minecraft/network/play/server/SPacketChunkData.java
+@@ -140,6 +140,7 @@
+         if (this.func_149274_i())
+         {
+             p_189555_1_.writeBytes(p_189555_2_.func_76605_m());
++            int localBiomeCount = p_189555_2_.getLocalBiomes().size(); p_189555_1_.writeByte((byte)(localBiomeCount & 255)); Short[] localBiomeIds = p_189555_2_.getLocalBiomeIds(); for (int k = 0; k < localBiomeCount; k++) p_189555_1_.writeShort(localBiomeIds[i]);
+         }
+ 
+         return i;
+@@ -170,6 +171,7 @@
+         if (this.func_149274_i())
+         {
+             i += p_189556_1_.func_76605_m().length;
++            i += p_189556_1_.getLocalBiomes().size() * 2 + 1;
+         }
+ 
+         return i;

--- a/patches/minecraft/net/minecraft/network/play/server/SPacketChunkData.java.patch
+++ b/patches/minecraft/net/minecraft/network/play/server/SPacketChunkData.java.patch
@@ -1,14 +1,20 @@
 --- ../src-base/minecraft/net/minecraft/network/play/server/SPacketChunkData.java
 +++ ../src-work/minecraft/net/minecraft/network/play/server/SPacketChunkData.java
-@@ -140,6 +140,7 @@
+@@ -140,6 +140,13 @@
          if (this.func_149274_i())
          {
              p_189555_1_.writeBytes(p_189555_2_.func_76605_m());
-+            int localBiomeCount = p_189555_2_.getLocalBiomes().size(); p_189555_1_.writeByte((byte)(localBiomeCount & 255)); Short[] localBiomeIds = p_189555_2_.getLocalBiomeIds(); for (int k = 0; k < localBiomeCount; k++) p_189555_1_.writeShort(localBiomeIds[i]);
++            int localBiomeCount = p_189555_2_.getLocalBiomes().size();
++            p_189555_1_.writeByte((byte)(localBiomeCount & 255));
++            Short[] localBiomeIds = p_189555_2_.getLocalBiomeIds();
++            for (int k = 0; k < localBiomeCount; k++)
++            {
++                p_189555_1_.writeShort(localBiomeIds[i]);
++            }
          }
  
          return i;
-@@ -170,6 +171,7 @@
+@@ -170,6 +177,7 @@
          if (this.func_149274_i())
          {
              i += p_189556_1_.func_76605_m().length;

--- a/patches/minecraft/net/minecraft/world/chunk/Chunk.java.patch
+++ b/patches/minecraft/net/minecraft/world/chunk/Chunk.java.patch
@@ -258,15 +258,26 @@
          boolean flag = this.field_76637_e.field_73011_w.func_191066_m();
  
          for (int i = 0; i < this.field_76652_q.length; ++i)
-@@ -1162,6 +1176,7 @@
+@@ -1162,6 +1176,18 @@
          if (p_186033_3_)
          {
              p_186033_1_.readBytes(this.field_76651_r);
-+            this.localBiomeIds = new Short[256]; this.localBiomes.clear(); if (p_186033_1_.readableBytes() > 0) { int localBiomeCount = p_186033_1_.readByte() + 128; for (int j = 0; j < localBiomeCount; j++) { short localBiomeId = p_186033_1_.readShort(); this.localBiomeIds[this.localBiomes.size()] = localBiomeId; this.localBiomes.add(Biome.func_150568_d(localBiomeId & 65535)); } }
++            this.localBiomeIds = new Short[256];
++            this.localBiomes.clear();
++            if (p_186033_1_.readableBytes() > 0)
++            {
++                int localBiomeCount = p_186033_1_.readByte() + 128;
++                for (int j = 0; j < localBiomeCount; j++)
++                {
++                    short localBiomeId = p_186033_1_.readShort(); 
++                    this.localBiomeIds[this.localBiomes.size()] = localBiomeId;
++                    this.localBiomes.add(Biome.func_150568_d(localBiomeId & 65535));
++                }
++            }
          }
  
          for (int j = 0; j < this.field_76652_q.length; ++j)
-@@ -1176,10 +1191,16 @@
+@@ -1176,10 +1202,16 @@
          this.field_76646_k = true;
          this.func_76590_a();
  
@@ -283,11 +294,18 @@
      }
  
      public Biome func_177411_a(BlockPos p_177411_1_, BiomeProvider p_177411_2_)
-@@ -1192,10 +1213,11 @@
+@@ -1192,10 +1224,18 @@
          {
              Biome biome = p_177411_2_.func_180300_a(p_177411_1_, Biomes.field_76772_c);
              k = Biome.func_185362_a(biome);
-+            int localBiomeIndex = this.localBiomes.indexOf(biome); if (localBiomeIndex < 0) { localBiomeIndex = this.localBiomes.size(); this.localBiomes.add(biome); this.localBiomeIds[localBiomeIndex] = (short)(localBiomeIndex); } k = localBiomeIndex;
++            int localBiomeIndex = this.localBiomes.indexOf(biome);
++            if (localBiomeIndex < 0)
++            {
++                localBiomeIndex = this.localBiomes.size();
++                this.localBiomes.add(biome);
++                this.localBiomeIds[localBiomeIndex] = (short)(localBiomeIndex);
++            }
++            k = localBiomeIndex;
              this.field_76651_r[j << 4 | i] = (byte)(k & 255);
          }
  
@@ -296,7 +314,7 @@
          return biome1 == null ? Biomes.field_76772_c : biome1;
      }
  
-@@ -1244,13 +1266,13 @@
+@@ -1244,13 +1284,13 @@
                      BlockPos blockpos1 = blockpos.func_177982_a(k, (j << 4) + i1, l);
                      boolean flag = i1 == 0 || i1 == 15 || k == 0 || k == 15 || l == 0 || l == 15;
  
@@ -312,7 +330,7 @@
                              {
                                  this.field_76637_e.func_175664_x(blockpos2);
                              }
-@@ -1381,7 +1403,7 @@
+@@ -1381,7 +1421,7 @@
          {
              blockpos$mutableblockpos.func_181079_c(blockpos$mutableblockpos.func_177958_n(), l, blockpos$mutableblockpos.func_177952_p());
  
@@ -321,7 +339,7 @@
              {
                  this.field_76637_e.func_175664_x(blockpos$mutableblockpos);
              }
-@@ -1420,6 +1442,7 @@
+@@ -1420,6 +1460,7 @@
          else
          {
              System.arraycopy(p_177420_1_, 0, this.field_76634_f, 0, this.field_76634_f.length);
@@ -329,7 +347,7 @@
          }
      }
  
-@@ -1489,4 +1512,65 @@
+@@ -1489,4 +1530,65 @@
          QUEUED,
          CHECK;
      }
@@ -387,11 +405,11 @@
 +
 +    public List<Biome> getLocalBiomes()
 +    {
-+    	return this.localBiomes;
++        return this.localBiomes;
 +    }
 +
 +    public Short[] getLocalBiomeIds()
 +    {
-+    	return this.localBiomeIds;
++        return this.localBiomeIds;
 +    }
  }

--- a/patches/minecraft/net/minecraft/world/chunk/Chunk.java.patch
+++ b/patches/minecraft/net/minecraft/world/chunk/Chunk.java.patch
@@ -258,15 +258,14 @@
          boolean flag = this.field_76637_e.field_73011_w.func_191066_m();
  
          for (int i = 0; i < this.field_76652_q.length; ++i)
-@@ -1162,6 +1176,18 @@
+@@ -1162,6 +1176,17 @@
          if (p_186033_3_)
          {
              p_186033_1_.readBytes(this.field_76651_r);
-+            this.localBiomeIds = new Short[256];
 +            this.localBiomes.clear();
 +            if (p_186033_1_.readableBytes() > 0)
 +            {
-+                int localBiomeCount = p_186033_1_.readByte() + 128;
++                int localBiomeCount = p_186033_1_.readByte() & 255;
 +                for (int j = 0; j < localBiomeCount; j++)
 +                {
 +                    short localBiomeId = p_186033_1_.readShort(); 
@@ -277,7 +276,7 @@
          }
  
          for (int j = 0; j < this.field_76652_q.length; ++j)
-@@ -1176,10 +1202,16 @@
+@@ -1176,10 +1201,16 @@
          this.field_76646_k = true;
          this.func_76590_a();
  
@@ -294,27 +293,26 @@
      }
  
      public Biome func_177411_a(BlockPos p_177411_1_, BiomeProvider p_177411_2_)
-@@ -1192,10 +1224,18 @@
+@@ -1192,10 +1223,17 @@
          {
              Biome biome = p_177411_2_.func_180300_a(p_177411_1_, Biomes.field_76772_c);
              k = Biome.func_185362_a(biome);
 +            int localBiomeIndex = this.localBiomes.indexOf(biome);
 +            if (localBiomeIndex < 0)
 +            {
-+                localBiomeIndex = this.localBiomes.size();
++                this.localBiomeIds[localBiomeIndex = this.localBiomes.size()] = (short)(k & 65535);
 +                this.localBiomes.add(biome);
-+                this.localBiomeIds[localBiomeIndex] = (short)(localBiomeIndex);
 +            }
 +            k = localBiomeIndex;
              this.field_76651_r[j << 4 | i] = (byte)(k & 255);
          }
  
 -        Biome biome1 = Biome.func_150568_d(k);
-+        Biome biome1 = Biome.func_150568_d(this.localBiomes.size() > 0 ? this.localBiomeIds[k] : k);
++        Biome biome1 = Biome.func_150568_d(this.localBiomes.size() > k ? this.localBiomeIds[k] : k);
          return biome1 == null ? Biomes.field_76772_c : biome1;
      }
  
-@@ -1244,13 +1284,13 @@
+@@ -1244,13 +1282,13 @@
                      BlockPos blockpos1 = blockpos.func_177982_a(k, (j << 4) + i1, l);
                      boolean flag = i1 == 0 || i1 == 15 || k == 0 || k == 15 || l == 0 || l == 15;
  
@@ -330,7 +328,7 @@
                              {
                                  this.field_76637_e.func_175664_x(blockpos2);
                              }
-@@ -1381,7 +1421,7 @@
+@@ -1381,7 +1419,7 @@
          {
              blockpos$mutableblockpos.func_181079_c(blockpos$mutableblockpos.func_177958_n(), l, blockpos$mutableblockpos.func_177952_p());
  
@@ -339,7 +337,7 @@
              {
                  this.field_76637_e.func_175664_x(blockpos$mutableblockpos);
              }
-@@ -1420,6 +1460,7 @@
+@@ -1420,6 +1458,7 @@
          else
          {
              System.arraycopy(p_177420_1_, 0, this.field_76634_f, 0, this.field_76634_f.length);
@@ -347,7 +345,7 @@
          }
      }
  
-@@ -1489,4 +1530,65 @@
+@@ -1489,4 +1528,65 @@
          QUEUED,
          CHECK;
      }

--- a/patches/minecraft/net/minecraft/world/chunk/Chunk.java.patch
+++ b/patches/minecraft/net/minecraft/world/chunk/Chunk.java.patch
@@ -258,7 +258,15 @@
          boolean flag = this.field_76637_e.field_73011_w.func_191066_m();
  
          for (int i = 0; i < this.field_76652_q.length; ++i)
-@@ -1176,10 +1190,16 @@
+@@ -1162,6 +1176,7 @@
+         if (p_186033_3_)
+         {
+             p_186033_1_.readBytes(this.field_76651_r);
++            this.localBiomeIds = new Short[256]; this.localBiomes.clear(); if (p_186033_1_.readableBytes() > 0) { int localBiomeCount = p_186033_1_.readByte() + 128; for (int j = 0; j < localBiomeCount; j++) { short localBiomeId = p_186033_1_.readShort(); this.localBiomeIds[this.localBiomes.size()] = localBiomeId; this.localBiomes.add(Biome.func_150568_d(localBiomeId & 65535)); } }
+         }
+ 
+         for (int j = 0; j < this.field_76652_q.length; ++j)
+@@ -1176,10 +1191,16 @@
          this.field_76646_k = true;
          this.func_76590_a();
  
@@ -275,7 +283,20 @@
      }
  
      public Biome func_177411_a(BlockPos p_177411_1_, BiomeProvider p_177411_2_)
-@@ -1244,13 +1264,13 @@
+@@ -1192,10 +1213,11 @@
+         {
+             Biome biome = p_177411_2_.func_180300_a(p_177411_1_, Biomes.field_76772_c);
+             k = Biome.func_185362_a(biome);
++            int localBiomeIndex = this.localBiomes.indexOf(biome); if (localBiomeIndex < 0) { localBiomeIndex = this.localBiomes.size(); this.localBiomes.add(biome); this.localBiomeIds[localBiomeIndex] = (short)(localBiomeIndex); } k = localBiomeIndex;
+             this.field_76651_r[j << 4 | i] = (byte)(k & 255);
+         }
+ 
+-        Biome biome1 = Biome.func_150568_d(k);
++        Biome biome1 = Biome.func_150568_d(this.localBiomes.size() > 0 ? this.localBiomeIds[k] : k);
+         return biome1 == null ? Biomes.field_76772_c : biome1;
+     }
+ 
+@@ -1244,13 +1266,13 @@
                      BlockPos blockpos1 = blockpos.func_177982_a(k, (j << 4) + i1, l);
                      boolean flag = i1 == 0 || i1 == 15 || k == 0 || k == 15 || l == 0 || l == 15;
  
@@ -291,7 +312,7 @@
                              {
                                  this.field_76637_e.func_175664_x(blockpos2);
                              }
-@@ -1381,7 +1401,7 @@
+@@ -1381,7 +1403,7 @@
          {
              blockpos$mutableblockpos.func_181079_c(blockpos$mutableblockpos.func_177958_n(), l, blockpos$mutableblockpos.func_177952_p());
  
@@ -300,7 +321,7 @@
              {
                  this.field_76637_e.func_175664_x(blockpos$mutableblockpos);
              }
-@@ -1420,6 +1440,7 @@
+@@ -1420,6 +1442,7 @@
          else
          {
              System.arraycopy(p_177420_1_, 0, this.field_76634_f, 0, this.field_76634_f.length);
@@ -308,7 +329,7 @@
          }
      }
  
-@@ -1489,4 +1510,52 @@
+@@ -1489,4 +1512,65 @@
          QUEUED,
          CHECK;
      }
@@ -359,5 +380,18 @@
 +    public <T> T getCapability(net.minecraftforge.common.capabilities.Capability<T> capability, @Nullable EnumFacing facing)
 +    {
 +        return capabilities == null ? null : capabilities.getCapability(capability, facing);
++    }
++
++    private final List<Biome> localBiomes = new java.util.ArrayList<Biome>();
++    private Short[] localBiomeIds = new Short[256];
++
++    public List<Biome> getLocalBiomes()
++    {
++    	return this.localBiomes;
++    }
++
++    public Short[] getLocalBiomeIds()
++    {
++    	return this.localBiomeIds;
 +    }
  }

--- a/patches/minecraft/net/minecraft/world/chunk/storage/AnvilChunkLoader.java.patch
+++ b/patches/minecraft/net/minecraft/world/chunk/storage/AnvilChunkLoader.java.patch
@@ -106,8 +106,8 @@
 +        byte[] localBiomeArray = new byte[localBiomeCount * 2];
 +        for (int i = 0; i < localBiomeCount; i++)
 +        {
-+            localBiomeArray[i] = (byte)(localBiomeIds[i] / 256);
-+            localBiomeArray[i] = (byte)(localBiomeIds[i] & 255);
++            localBiomeArray[i * 2] = (byte)(localBiomeIds[i] >> 8);
++            localBiomeArray[i * 2 + 1] = (byte)(localBiomeIds[i] & 255);
 +        }
 +        p_75820_3_.func_74773_a("LocalBiomes", localBiomeArray);
          p_75820_1_.func_177409_g(false);
@@ -181,7 +181,7 @@
 +            byte[] localBiomeArray = p_75823_2_.func_74770_j("LocalBiomes");
 +            for (int i1 = 0; i1 < localBiomeArray.length / 2; i1++)
 +            {
-+                localBiomes.add(net.minecraft.world.biome.Biome.func_180276_a((localBiomeIds[i1] = (short)(localBiomeArray[i1] * 256 + localBiomeArray[i1])) & 65535, net.minecraft.init.Biomes.field_76771_b));
++                localBiomes.add(net.minecraft.world.biome.Biome.func_180276_a((localBiomeIds[i1] = (short)(localBiomeArray[i1 * 2] << 8 + localBiomeArray[i1 * 2 + 1] & 255)) & 65535, net.minecraft.init.Biomes.field_76771_b));
 +            }
 +        }
 +        if (chunk.getCapabilities() != null && p_75823_2_.func_74764_b("ForgeCaps")) {

--- a/patches/minecraft/net/minecraft/world/chunk/storage/AnvilChunkLoader.java.patch
+++ b/patches/minecraft/net/minecraft/world/chunk/storage/AnvilChunkLoader.java.patch
@@ -97,15 +97,23 @@
              this.func_75824_a(p_75816_2_.func_76632_l(), nbttagcompound);
          }
          catch (Exception exception)
-@@ -296,6 +347,7 @@
+@@ -296,6 +347,15 @@
  
          p_75820_3_.func_74782_a("Sections", nbttaglist);
          p_75820_3_.func_74773_a("Biomes", p_75820_1_.func_76605_m());
-+        int localBiomeCount = p_75820_1_.getLocalBiomes().size(); Short[] localBiomeIds = p_75820_1_.getLocalBiomeIds(); byte[] localBiomeArray = new byte[localBiomeCount * 2]; for (int i = 0; i < localBiomeCount; i++) { localBiomeArray[i] = (byte)(localBiomeIds[i] / 256); localBiomeArray[i] = (byte)(localBiomeIds[i] & 255); } p_75820_3_.func_74773_a("LocalBiomes", localBiomeArray);
++        int localBiomeCount = p_75820_1_.getLocalBiomes().size();
++        Short[] localBiomeIds = p_75820_1_.getLocalBiomeIds();
++        byte[] localBiomeArray = new byte[localBiomeCount * 2];
++        for (int i = 0; i < localBiomeCount; i++)
++        {
++            localBiomeArray[i] = (byte)(localBiomeIds[i] / 256);
++            localBiomeArray[i] = (byte)(localBiomeIds[i] & 255);
++        }
++        p_75820_3_.func_74773_a("LocalBiomes", localBiomeArray);
          p_75820_1_.func_177409_g(false);
          NBTTagList nbttaglist1 = new NBTTagList();
  
-@@ -305,11 +357,19 @@
+@@ -305,11 +365,19 @@
              {
                  NBTTagCompound nbttagcompound2 = new NBTTagCompound();
  
@@ -125,7 +133,7 @@
              }
          }
  
-@@ -318,8 +378,16 @@
+@@ -318,8 +386,16 @@
  
          for (TileEntity tileentity : p_75820_1_.func_177434_r().values())
          {
@@ -142,7 +150,7 @@
          }
  
          p_75820_3_.func_74782_a("TileEntities", nbttaglist2);
-@@ -345,6 +413,18 @@
+@@ -345,6 +421,18 @@
  
              p_75820_3_.func_74782_a("TileTicks", nbttaglist3);
          }
@@ -161,11 +169,21 @@
      }
  
      private Chunk func_75823_a(World p_75823_1_, NBTTagCompound p_75823_2_)
-@@ -388,6 +468,17 @@
+@@ -388,6 +476,27 @@
              chunk.func_76616_a(p_75823_2_.func_74770_j("Biomes"));
          }
  
-+        if (p_75823_2_.func_150297_b("LocalBiomes", 7)) { List<net.minecraft.world.biome.Biome> localBiomes = chunk.getLocalBiomes(); localBiomes.clear(); Short[] localBiomeIds = chunk.getLocalBiomeIds(); byte[] localBiomeArray = p_75823_2_.func_74770_j("LocalBiomes"); for (int i1 = 0; i1 < localBiomeArray.length / 2; i1++) { localBiomes.add(net.minecraft.world.biome.Biome.func_180276_a((localBiomeIds[i1] = (short)(localBiomeArray[i1] * 256 + localBiomeArray[i1])) & 65535, net.minecraft.init.Biomes.field_76771_b)); } }
++        if (p_75823_2_.func_150297_b("LocalBiomes", 7))
++        {
++            List<net.minecraft.world.biome.Biome> localBiomes = chunk.getLocalBiomes();
++            localBiomes.clear();
++            Short[] localBiomeIds = chunk.getLocalBiomeIds();
++            byte[] localBiomeArray = p_75823_2_.func_74770_j("LocalBiomes");
++            for (int i1 = 0; i1 < localBiomeArray.length / 2; i1++)
++            {
++                localBiomes.add(net.minecraft.world.biome.Biome.func_180276_a((localBiomeIds[i1] = (short)(localBiomeArray[i1] * 256 + localBiomeArray[i1])) & 65535, net.minecraft.init.Biomes.field_76771_b));
++            }
++        }
 +        if (chunk.getCapabilities() != null && p_75823_2_.func_74764_b("ForgeCaps")) {
 +            chunk.getCapabilities().deserializeNBT(p_75823_2_.func_74775_l("ForgeCaps"));
 +        }
@@ -179,7 +197,7 @@
          NBTTagList nbttaglist1 = p_75823_2_.func_150295_c("Entities", 10);
  
          for (int j1 = 0; j1 < nbttaglist1.func_74745_c(); ++j1)
-@@ -431,8 +522,6 @@
+@@ -431,8 +540,6 @@
                  p_75823_1_.func_180497_b(new BlockPos(nbttagcompound3.func_74762_e("x"), nbttagcompound3.func_74762_e("y"), nbttagcompound3.func_74762_e("z")), block, nbttagcompound3.func_74762_e("t"), nbttagcompound3.func_74762_e("p"));
              }
          }

--- a/patches/minecraft/net/minecraft/world/chunk/storage/AnvilChunkLoader.java.patch
+++ b/patches/minecraft/net/minecraft/world/chunk/storage/AnvilChunkLoader.java.patch
@@ -97,7 +97,15 @@
              this.func_75824_a(p_75816_2_.func_76632_l(), nbttagcompound);
          }
          catch (Exception exception)
-@@ -305,11 +356,19 @@
+@@ -296,6 +347,7 @@
+ 
+         p_75820_3_.func_74782_a("Sections", nbttaglist);
+         p_75820_3_.func_74773_a("Biomes", p_75820_1_.func_76605_m());
++        int localBiomeCount = p_75820_1_.getLocalBiomes().size(); Short[] localBiomeIds = p_75820_1_.getLocalBiomeIds(); byte[] localBiomeArray = new byte[localBiomeCount * 2]; for (int i = 0; i < localBiomeCount; i++) { localBiomeArray[i] = (byte)(localBiomeIds[i] / 256); localBiomeArray[i] = (byte)(localBiomeIds[i] & 255); } p_75820_3_.func_74773_a("LocalBiomes", localBiomeArray);
+         p_75820_1_.func_177409_g(false);
+         NBTTagList nbttaglist1 = new NBTTagList();
+ 
+@@ -305,11 +357,19 @@
              {
                  NBTTagCompound nbttagcompound2 = new NBTTagCompound();
  
@@ -117,7 +125,7 @@
              }
          }
  
-@@ -318,8 +377,16 @@
+@@ -318,8 +378,16 @@
  
          for (TileEntity tileentity : p_75820_1_.func_177434_r().values())
          {
@@ -134,7 +142,7 @@
          }
  
          p_75820_3_.func_74782_a("TileEntities", nbttaglist2);
-@@ -345,6 +412,18 @@
+@@ -345,6 +413,18 @@
  
              p_75820_3_.func_74782_a("TileTicks", nbttaglist3);
          }
@@ -153,10 +161,11 @@
      }
  
      private Chunk func_75823_a(World p_75823_1_, NBTTagCompound p_75823_2_)
-@@ -388,6 +467,16 @@
+@@ -388,6 +468,17 @@
              chunk.func_76616_a(p_75823_2_.func_74770_j("Biomes"));
          }
  
++        if (p_75823_2_.func_150297_b("LocalBiomes", 7)) { List<net.minecraft.world.biome.Biome> localBiomes = chunk.getLocalBiomes(); localBiomes.clear(); Short[] localBiomeIds = chunk.getLocalBiomeIds(); byte[] localBiomeArray = p_75823_2_.func_74770_j("LocalBiomes"); for (int i1 = 0; i1 < localBiomeArray.length / 2; i1++) { localBiomes.add(net.minecraft.world.biome.Biome.func_180276_a((localBiomeIds[i1] = (short)(localBiomeArray[i1] * 256 + localBiomeArray[i1])) & 65535, net.minecraft.init.Biomes.field_76771_b)); } }
 +        if (chunk.getCapabilities() != null && p_75823_2_.func_74764_b("ForgeCaps")) {
 +            chunk.getCapabilities().deserializeNBT(p_75823_2_.func_74775_l("ForgeCaps"));
 +        }
@@ -170,7 +179,7 @@
          NBTTagList nbttaglist1 = p_75823_2_.func_150295_c("Entities", 10);
  
          for (int j1 = 0; j1 < nbttaglist1.func_74745_c(); ++j1)
-@@ -431,8 +520,6 @@
+@@ -431,8 +522,6 @@
                  p_75823_1_.func_180497_b(new BlockPos(nbttagcompound3.func_74762_e("x"), nbttagcompound3.func_74762_e("y"), nbttagcompound3.func_74762_e("z")), block, nbttagcompound3.func_74762_e("t"), nbttagcompound3.func_74762_e("p"));
              }
          }

--- a/patches/minecraft/net/minecraft/world/gen/ChunkGeneratorDebug.java.patch
+++ b/patches/minecraft/net/minecraft/world/gen/ChunkGeneratorDebug.java.patch
@@ -1,0 +1,16 @@
+--- ../src-base/minecraft/net/minecraft/world/gen/ChunkGeneratorDebug.java
++++ ../src-work/minecraft/net/minecraft/world/gen/ChunkGeneratorDebug.java
+@@ -52,10 +52,12 @@
+         chunk.func_76603_b();
+         Biome[] abiome = this.field_177463_c.func_72959_q().func_76933_b((Biome[])null, p_185932_1_ * 16, p_185932_2_ * 16, 16, 16);
+         byte[] abyte = chunk.func_76605_m();
++        List<Biome> localBiomes = chunk.getLocalBiomes(); localBiomes.clear(); Short[] localBiomeIds = chunk.getLocalBiomeIds();
+ 
+         for (int i1 = 0; i1 < abyte.length; ++i1)
+         {
+-            abyte[i1] = (byte)Biome.func_185362_a(abiome[i1]);
++        	localBiomeIds[i1] = null; int localBiomeIndex = localBiomes.indexOf(abiome[i1]); if(localBiomeIndex < 0) { localBiomeIds[localBiomeIndex = localBiomes.size()] = (short)Biome.func_185362_a(abiome[i1]); localBiomes.add(abiome[i1]); }
++            abyte[i1] = (byte)localBiomeIndex;
+         }
+ 
+         chunk.func_76603_b();

--- a/patches/minecraft/net/minecraft/world/gen/ChunkGeneratorDebug.java.patch
+++ b/patches/minecraft/net/minecraft/world/gen/ChunkGeneratorDebug.java.patch
@@ -1,16 +1,28 @@
 --- ../src-base/minecraft/net/minecraft/world/gen/ChunkGeneratorDebug.java
 +++ ../src-work/minecraft/net/minecraft/world/gen/ChunkGeneratorDebug.java
-@@ -52,10 +52,12 @@
+@@ -52,12 +52,25 @@
          chunk.func_76603_b();
          Biome[] abiome = this.field_177463_c.func_72959_q().func_76933_b((Biome[])null, p_185932_1_ * 16, p_185932_2_ * 16, 16, 16);
          byte[] abyte = chunk.func_76605_m();
-+        List<Biome> localBiomes = chunk.getLocalBiomes(); localBiomes.clear(); Short[] localBiomeIds = chunk.getLocalBiomeIds();
++        byte[] localizedBiomeArray = new byte[256]; int maxBiomeId = 0; List<Biome> localBiomes = chunk.getLocalBiomes(); localBiomes.clear(); Short[] localBiomeIds = chunk.getLocalBiomeIds();
  
          for (int i1 = 0; i1 < abyte.length; ++i1)
          {
--            abyte[i1] = (byte)Biome.func_185362_a(abiome[i1]);
-+        	localBiomeIds[i1] = null; int localBiomeIndex = localBiomes.indexOf(abiome[i1]); if(localBiomeIndex < 0) { localBiomeIds[localBiomeIndex = localBiomes.size()] = (short)Biome.func_185362_a(abiome[i1]); localBiomes.add(abiome[i1]); }
-+            abyte[i1] = (byte)localBiomeIndex;
++            int localBiomeIndex = localBiomes.indexOf(abiome[i1]);
++            if(localBiomeIndex < 0)
++            {
++                int biomeId = Biome.func_185362_a(abiome[i1]);
++                maxBiomeId = Math.max(maxBiomeId, biomeId);
++                localBiomeIds[localBiomeIndex = localBiomes.size()] = (short)(biomeId & 65535);
++                localBiomes.add(abiome[i1]);
++            }
++            localizedBiomeArray[i1] = (byte)localBiomeIndex;
+             abyte[i1] = (byte)Biome.func_185362_a(abiome[i1]);
          }
  
++        if (maxBiomeId > 255) chunk.func_76616_a(localizedBiomeArray);
++        else localBiomes.clear();
++
          chunk.func_76603_b();
+         return chunk;
+     }

--- a/patches/minecraft/net/minecraft/world/gen/ChunkGeneratorEnd.java.patch
+++ b/patches/minecraft/net/minecraft/world/gen/ChunkGeneratorEnd.java.patch
@@ -10,7 +10,7 @@
  
      public ChunkGeneratorEnd(World p_i47241_1_, boolean p_i47241_2_, long p_i47241_3_, BlockPos p_i47241_5_)
      {
-@@ -56,6 +59,17 @@
+@@ -56,6 +59,16 @@
          this.field_73214_a = new NoiseGeneratorOctaves(this.field_73220_k, 10);
          this.field_73212_b = new NoiseGeneratorOctaves(this.field_73220_k, 16);
          this.field_185973_o = new NoiseGeneratorSimplex(this.field_73220_k);
@@ -24,11 +24,10 @@
 +        this.field_73214_a = ctx.getDepth();
 +        this.field_73212_b = ctx.getScale();
 +        this.field_185973_o = ctx.getIsland();
-+        this.field_185972_n = (MapGenEndCity) net.minecraftforge.event.terraingen.TerrainGen.getModdedMapGen(this.field_185972_n, net.minecraftforge.event.terraingen.InitMapGenEvent.EventType.END_CITY);
      }
  
      public void func_180518_a(int p_180518_1_, int p_180518_2_, ChunkPrimer p_180518_3_)
-@@ -128,6 +142,7 @@
+@@ -128,6 +141,7 @@
  
      public void func_185962_a(ChunkPrimer p_185962_1_)
      {
@@ -36,7 +35,7 @@
          for (int i = 0; i < 16; ++i)
          {
              for (int j = 0; j < 16; ++j)
-@@ -173,6 +188,7 @@
+@@ -173,6 +187,7 @@
  
      public Chunk func_185932_a(int p_185932_1_, int p_185932_2_)
      {
@@ -44,7 +43,21 @@
          this.field_73220_k.setSeed((long)p_185932_1_ * 341873128712L + (long)p_185932_2_ * 132897987541L);
          ChunkPrimer chunkprimer = new ChunkPrimer();
          this.field_73231_z = this.field_73230_p.func_72959_q().func_76933_b(this.field_73231_z, p_185932_1_ * 16, p_185932_2_ * 16, 16, 16);
-@@ -254,6 +270,10 @@
+@@ -186,10 +201,12 @@
+ 
+         Chunk chunk = new Chunk(this.field_73230_p, chunkprimer, p_185932_1_, p_185932_2_);
+         byte[] abyte = chunk.func_76605_m();
++        List<Biome> localBiomes = chunk.getLocalBiomes(); localBiomes.clear(); Short[] localBiomeIds = chunk.getLocalBiomeIds();
+ 
+         for (int i = 0; i < abyte.length; ++i)
+         {
+-            abyte[i] = (byte)Biome.func_185362_a(this.field_73231_z[i]);
++        	localBiomeIds[i] = null; int localBiomeIndex = localBiomes.indexOf(this.field_73231_z[i]); if(localBiomeIndex < 0) { localBiomeIds[localBiomeIndex = localBiomes.size()] = (short)Biome.func_185362_a(this.field_73231_z[i]); localBiomes.add(this.field_73231_z[i]); }
++            abyte[i] = (byte)localBiomeIndex;
+         }
+ 
+         chunk.func_76603_b();
+@@ -254,6 +271,10 @@
  
      private double[] func_185963_a(double[] p_185963_1_, int p_185963_2_, int p_185963_3_, int p_185963_4_, int p_185963_5_, int p_185963_6_, int p_185963_7_)
      {
@@ -55,7 +68,7 @@
          if (p_185963_1_ == null)
          {
              p_185963_1_ = new double[p_185963_5_ * p_185963_6_ * p_185963_7_];
-@@ -326,6 +346,7 @@
+@@ -326,6 +347,7 @@
      public void func_185931_b(int p_185931_1_, int p_185931_2_)
      {
          BlockFalling.field_149832_M = true;
@@ -63,7 +76,7 @@
          BlockPos blockpos = new BlockPos(p_185931_1_ * 16, 0, p_185931_2_ * 16);
  
          if (this.field_73229_q)
-@@ -394,6 +415,7 @@
+@@ -394,6 +416,7 @@
              }
          }
  

--- a/patches/minecraft/net/minecraft/world/gen/ChunkGeneratorEnd.java.patch
+++ b/patches/minecraft/net/minecraft/world/gen/ChunkGeneratorEnd.java.patch
@@ -43,21 +43,33 @@
          this.field_73220_k.setSeed((long)p_185932_1_ * 341873128712L + (long)p_185932_2_ * 132897987541L);
          ChunkPrimer chunkprimer = new ChunkPrimer();
          this.field_73231_z = this.field_73230_p.func_72959_q().func_76933_b(this.field_73231_z, p_185932_1_ * 16, p_185932_2_ * 16, 16, 16);
-@@ -186,10 +201,12 @@
+@@ -186,12 +201,25 @@
  
          Chunk chunk = new Chunk(this.field_73230_p, chunkprimer, p_185932_1_, p_185932_2_);
          byte[] abyte = chunk.func_76605_m();
-+        List<Biome> localBiomes = chunk.getLocalBiomes(); localBiomes.clear(); Short[] localBiomeIds = chunk.getLocalBiomeIds();
++        byte[] localizedBiomeArray = new byte[256]; int maxBiomeId = 0; List<Biome> localBiomes = chunk.getLocalBiomes(); localBiomes.clear(); Short[] localBiomeIds = chunk.getLocalBiomeIds();
  
          for (int i = 0; i < abyte.length; ++i)
          {
--            abyte[i] = (byte)Biome.func_185362_a(this.field_73231_z[i]);
-+        	localBiomeIds[i] = null; int localBiomeIndex = localBiomes.indexOf(this.field_73231_z[i]); if(localBiomeIndex < 0) { localBiomeIds[localBiomeIndex = localBiomes.size()] = (short)Biome.func_185362_a(this.field_73231_z[i]); localBiomes.add(this.field_73231_z[i]); }
-+            abyte[i] = (byte)localBiomeIndex;
++            int localBiomeIndex = localBiomes.indexOf(this.field_73231_z[i]);
++            if(localBiomeIndex < 0)
++            {
++                int biomeId = Biome.func_185362_a(this.field_73231_z[i]);
++                maxBiomeId = Math.max(maxBiomeId, biomeId);
++                localBiomeIds[localBiomeIndex = localBiomes.size()] = (short)(biomeId & 65535);
++                localBiomes.add(this.field_73231_z[i]);
++            }
++            localizedBiomeArray[i] = (byte)localBiomeIndex;
+             abyte[i] = (byte)Biome.func_185362_a(this.field_73231_z[i]);
          }
  
++        if (maxBiomeId > 255) chunk.func_76616_a(localizedBiomeArray);
++        else localBiomes.clear();
++
          chunk.func_76603_b();
-@@ -254,6 +271,10 @@
+         return chunk;
+     }
+@@ -254,6 +282,10 @@
  
      private double[] func_185963_a(double[] p_185963_1_, int p_185963_2_, int p_185963_3_, int p_185963_4_, int p_185963_5_, int p_185963_6_, int p_185963_7_)
      {
@@ -68,7 +80,7 @@
          if (p_185963_1_ == null)
          {
              p_185963_1_ = new double[p_185963_5_ * p_185963_6_ * p_185963_7_];
-@@ -326,6 +347,7 @@
+@@ -326,6 +358,7 @@
      public void func_185931_b(int p_185931_1_, int p_185931_2_)
      {
          BlockFalling.field_149832_M = true;
@@ -76,7 +88,7 @@
          BlockPos blockpos = new BlockPos(p_185931_1_ * 16, 0, p_185931_2_ * 16);
  
          if (this.field_73229_q)
-@@ -394,6 +416,7 @@
+@@ -394,6 +427,7 @@
              }
          }
  

--- a/patches/minecraft/net/minecraft/world/gen/ChunkGeneratorFlat.java.patch
+++ b/patches/minecraft/net/minecraft/world/gen/ChunkGeneratorFlat.java.patch
@@ -1,20 +1,31 @@
 --- ../src-base/minecraft/net/minecraft/world/gen/ChunkGeneratorFlat.java
 +++ ../src-work/minecraft/net/minecraft/world/gen/ChunkGeneratorFlat.java
-@@ -150,10 +150,12 @@
+@@ -150,18 +150,32 @@
          Chunk chunk = new Chunk(this.field_73163_a, chunkprimer, p_185932_1_, p_185932_2_);
          Biome[] abiome = this.field_73163_a.func_72959_q().func_76933_b((Biome[])null, p_185932_1_ * 16, p_185932_2_ * 16, 16, 16);
          byte[] abyte = chunk.func_76605_m();
-+        List<Biome> localBiomes = chunk.getLocalBiomes(); localBiomes.clear(); Short[] localBiomeIds = chunk.getLocalBiomeIds();
++        byte[] localizedBiomeArray = new byte[256]; int maxBiomeId = 0; List<Biome> localBiomes = chunk.getLocalBiomes(); localBiomes.clear(); Short[] localBiomeIds = chunk.getLocalBiomeIds();
  
          for (int l = 0; l < abyte.length; ++l)
          {
--            abyte[l] = (byte)Biome.func_185362_a(abiome[l]);
-+        	localBiomeIds[l] = null; int localBiomeIndex = localBiomes.indexOf(abiome[l]); if(localBiomeIndex < 0) { localBiomeIds[localBiomeIndex = localBiomes.size()] = (short)Biome.func_185362_a(abiome[l]); localBiomes.add(abiome[l]); }
-+            abyte[l] = (byte)localBiomeIndex;
++            int localBiomeIndex = localBiomes.indexOf(abiome[l]);
++            if(localBiomeIndex < 0)
++            {
++                int biomeId = Biome.func_185362_a(abiome[l]);
++                maxBiomeId = Math.max(maxBiomeId, biomeId);
++                localBiomeIds[localBiomeIndex = localBiomes.size()] = (short)(biomeId & 65535);
++                localBiomes.add(abiome[l]);
++            }
++            localizedBiomeArray[l] = (byte)localBiomeIndex;
+             abyte[l] = (byte)Biome.func_185362_a(abiome[l]);
          }
  
++        if (maxBiomeId > 255) chunk.func_76616_a(localizedBiomeArray);
++        else localBiomes.clear();
++
          chunk.func_76603_b();
-@@ -162,6 +164,7 @@
+         return chunk;
+     }
  
      public void func_185931_b(int p_185931_1_, int p_185931_2_)
      {
@@ -22,7 +33,7 @@
          int i = p_185931_1_ * 16;
          int j = p_185931_2_ * 16;
          BlockPos blockpos = new BlockPos(i, 0, j);
-@@ -173,6 +176,8 @@
+@@ -173,6 +187,8 @@
          this.field_73161_b.setSeed((long)p_185931_1_ * k + (long)p_185931_2_ * l ^ this.field_73163_a.func_72905_C());
          ChunkPos chunkpos = new ChunkPos(p_185931_1_, p_185931_2_);
  
@@ -31,7 +42,7 @@
          for (MapGenStructure mapgenstructure : this.field_82696_f.values())
          {
              boolean flag1 = mapgenstructure.func_175794_a(this.field_73163_a, this.field_73161_b, chunkpos);
-@@ -210,6 +215,9 @@
+@@ -210,6 +226,9 @@
          {
              biome.func_180624_a(this.field_73163_a, this.field_73161_b, blockpos);
          }

--- a/patches/minecraft/net/minecraft/world/gen/ChunkGeneratorFlat.java.patch
+++ b/patches/minecraft/net/minecraft/world/gen/ChunkGeneratorFlat.java.patch
@@ -1,6 +1,20 @@
 --- ../src-base/minecraft/net/minecraft/world/gen/ChunkGeneratorFlat.java
 +++ ../src-work/minecraft/net/minecraft/world/gen/ChunkGeneratorFlat.java
-@@ -162,6 +162,7 @@
+@@ -150,10 +150,12 @@
+         Chunk chunk = new Chunk(this.field_73163_a, chunkprimer, p_185932_1_, p_185932_2_);
+         Biome[] abiome = this.field_73163_a.func_72959_q().func_76933_b((Biome[])null, p_185932_1_ * 16, p_185932_2_ * 16, 16, 16);
+         byte[] abyte = chunk.func_76605_m();
++        List<Biome> localBiomes = chunk.getLocalBiomes(); localBiomes.clear(); Short[] localBiomeIds = chunk.getLocalBiomeIds();
+ 
+         for (int l = 0; l < abyte.length; ++l)
+         {
+-            abyte[l] = (byte)Biome.func_185362_a(abiome[l]);
++        	localBiomeIds[l] = null; int localBiomeIndex = localBiomes.indexOf(abiome[l]); if(localBiomeIndex < 0) { localBiomeIds[localBiomeIndex = localBiomes.size()] = (short)Biome.func_185362_a(abiome[l]); localBiomes.add(abiome[l]); }
++            abyte[l] = (byte)localBiomeIndex;
+         }
+ 
+         chunk.func_76603_b();
+@@ -162,6 +164,7 @@
  
      public void func_185931_b(int p_185931_1_, int p_185931_2_)
      {
@@ -8,7 +22,7 @@
          int i = p_185931_1_ * 16;
          int j = p_185931_2_ * 16;
          BlockPos blockpos = new BlockPos(i, 0, j);
-@@ -173,6 +174,8 @@
+@@ -173,6 +176,8 @@
          this.field_73161_b.setSeed((long)p_185931_1_ * k + (long)p_185931_2_ * l ^ this.field_73163_a.func_72905_C());
          ChunkPos chunkpos = new ChunkPos(p_185931_1_, p_185931_2_);
  
@@ -17,7 +31,7 @@
          for (MapGenStructure mapgenstructure : this.field_82696_f.values())
          {
              boolean flag1 = mapgenstructure.func_175794_a(this.field_73163_a, this.field_73161_b, chunkpos);
-@@ -210,6 +213,9 @@
+@@ -210,6 +215,9 @@
          {
              biome.func_180624_a(this.field_73163_a, this.field_73161_b, blockpos);
          }

--- a/patches/minecraft/net/minecraft/world/gen/ChunkGeneratorHell.java.patch
+++ b/patches/minecraft/net/minecraft/world/gen/ChunkGeneratorHell.java.patch
@@ -28,7 +28,21 @@
          int i = this.field_185952_n.func_181545_F() + 1;
          double d0 = 0.03125D;
          this.field_73185_q = this.field_73177_m.func_76304_a(this.field_73185_q, p_185937_1_ * 16, p_185937_2_ * 16, 0, 16, 16, 1, 0.03125D, 0.03125D, 1.0D);
-@@ -277,6 +291,10 @@
+@@ -260,10 +274,12 @@
+         Chunk chunk = new Chunk(this.field_185952_n, chunkprimer, p_185932_1_, p_185932_2_);
+         Biome[] abiome = this.field_185952_n.func_72959_q().func_76933_b((Biome[])null, p_185932_1_ * 16, p_185932_2_ * 16, 16, 16);
+         byte[] abyte = chunk.func_76605_m();
++        List<Biome> localBiomes = chunk.getLocalBiomes(); localBiomes.clear(); Short[] localBiomeIds = chunk.getLocalBiomeIds();
+ 
+         for (int i = 0; i < abyte.length; ++i)
+         {
+-            abyte[i] = (byte)Biome.func_185362_a(abiome[i]);
++        	localBiomeIds[i] = null; int localBiomeIndex = localBiomes.indexOf(abiome[i]); if(localBiomeIndex < 0) { localBiomeIds[localBiomeIndex = localBiomes.size()] = (short)Biome.func_185362_a(abiome[i]); localBiomes.add(abiome[i]); }
++        	abyte[i] = (byte)localBiomeIndex;
+         }
+ 
+         chunk.func_76613_n();
+@@ -277,6 +293,10 @@
              p_185938_1_ = new double[p_185938_5_ * p_185938_6_ * p_185938_7_];
          }
  
@@ -39,7 +53,7 @@
          double d0 = 684.412D;
          double d1 = 2053.236D;
          this.field_73168_g = this.field_185946_g.func_76304_a(this.field_73168_g, p_185938_2_, p_185938_3_, p_185938_4_, p_185938_5_, 1, p_185938_7_, 1.0D, 0.0D, 1.0D);
-@@ -358,6 +376,7 @@
+@@ -358,6 +378,7 @@
      public void func_185931_b(int p_185931_1_, int p_185931_2_)
      {
          BlockFalling.field_149832_M = true;
@@ -47,7 +61,7 @@
          int i = p_185931_1_ * 16;
          int j = p_185931_2_ * 16;
          BlockPos blockpos = new BlockPos(i, 0, j);
-@@ -365,16 +384,20 @@
+@@ -365,16 +386,20 @@
          ChunkPos chunkpos = new ChunkPos(p_185931_1_, p_185931_2_);
          this.field_73172_c.func_175794_a(this.field_185952_n, this.field_185954_p, chunkpos);
  
@@ -68,7 +82,7 @@
          for (int j1 = 0; j1 < this.field_185954_p.nextInt(this.field_185954_p.nextInt(10) + 1); ++j1)
          {
              this.field_177469_u.func_180709_b(this.field_185952_n, this.field_185954_p, blockpos.func_177982_a(this.field_185954_p.nextInt(16) + 8, this.field_185954_p.nextInt(120) + 4, this.field_185954_p.nextInt(16) + 8));
-@@ -384,7 +407,13 @@
+@@ -384,7 +409,13 @@
          {
              this.field_177468_v.func_180709_b(this.field_185952_n, this.field_185954_p, blockpos.func_177982_a(this.field_185954_p.nextInt(16) + 8, this.field_185954_p.nextInt(128), this.field_185954_p.nextInt(16) + 8));
          }
@@ -82,7 +96,7 @@
          if (this.field_185954_p.nextBoolean())
          {
              this.field_177471_z.func_180709_b(this.field_185952_n, this.field_185954_p, blockpos.func_177982_a(this.field_185954_p.nextInt(16) + 8, this.field_185954_p.nextInt(128), this.field_185954_p.nextInt(16) + 8));
-@@ -394,7 +423,10 @@
+@@ -394,7 +425,10 @@
          {
              this.field_177465_A.func_180709_b(this.field_185952_n, this.field_185954_p, blockpos.func_177982_a(this.field_185954_p.nextInt(16) + 8, this.field_185954_p.nextInt(128), this.field_185954_p.nextInt(16) + 8));
          }
@@ -93,7 +107,7 @@
          for (int l1 = 0; l1 < 16; ++l1)
          {
              this.field_177467_w.func_180709_b(this.field_185952_n, this.field_185954_p, blockpos.func_177982_a(this.field_185954_p.nextInt(16), this.field_185954_p.nextInt(108) + 10, this.field_185954_p.nextInt(16)));
-@@ -402,17 +434,23 @@
+@@ -402,17 +436,23 @@
  
          int i2 = this.field_185952_n.func_181545_F() / 2 + 1;
  

--- a/patches/minecraft/net/minecraft/world/gen/ChunkGeneratorHell.java.patch
+++ b/patches/minecraft/net/minecraft/world/gen/ChunkGeneratorHell.java.patch
@@ -28,21 +28,33 @@
          int i = this.field_185952_n.func_181545_F() + 1;
          double d0 = 0.03125D;
          this.field_73185_q = this.field_73177_m.func_76304_a(this.field_73185_q, p_185937_1_ * 16, p_185937_2_ * 16, 0, 16, 16, 1, 0.03125D, 0.03125D, 1.0D);
-@@ -260,10 +274,12 @@
+@@ -260,12 +274,25 @@
          Chunk chunk = new Chunk(this.field_185952_n, chunkprimer, p_185932_1_, p_185932_2_);
          Biome[] abiome = this.field_185952_n.func_72959_q().func_76933_b((Biome[])null, p_185932_1_ * 16, p_185932_2_ * 16, 16, 16);
          byte[] abyte = chunk.func_76605_m();
-+        List<Biome> localBiomes = chunk.getLocalBiomes(); localBiomes.clear(); Short[] localBiomeIds = chunk.getLocalBiomeIds();
++        byte[] localizedBiomeArray = new byte[256]; int maxBiomeId = 0; List<Biome> localBiomes = chunk.getLocalBiomes(); localBiomes.clear(); Short[] localBiomeIds = chunk.getLocalBiomeIds();
  
          for (int i = 0; i < abyte.length; ++i)
          {
--            abyte[i] = (byte)Biome.func_185362_a(abiome[i]);
-+        	localBiomeIds[i] = null; int localBiomeIndex = localBiomes.indexOf(abiome[i]); if(localBiomeIndex < 0) { localBiomeIds[localBiomeIndex = localBiomes.size()] = (short)Biome.func_185362_a(abiome[i]); localBiomes.add(abiome[i]); }
-+        	abyte[i] = (byte)localBiomeIndex;
++            int localBiomeIndex = localBiomes.indexOf(abiome[i]);
++            if(localBiomeIndex < 0)
++            {
++                int biomeId = Biome.func_185362_a(abiome[i]);
++                maxBiomeId = Math.max(maxBiomeId, biomeId);
++                localBiomeIds[localBiomeIndex = localBiomes.size()] = (short)(biomeId & 65535);
++                localBiomes.add(abiome[i]);
++            }
++            localizedBiomeArray[i] = (byte)localBiomeIndex;
+             abyte[i] = (byte)Biome.func_185362_a(abiome[i]);
          }
  
++        if (maxBiomeId > 255) chunk.func_76616_a(localizedBiomeArray);
++        else localBiomes.clear();
++
          chunk.func_76613_n();
-@@ -277,6 +293,10 @@
+         return chunk;
+     }
+@@ -277,6 +304,10 @@
              p_185938_1_ = new double[p_185938_5_ * p_185938_6_ * p_185938_7_];
          }
  
@@ -53,7 +65,7 @@
          double d0 = 684.412D;
          double d1 = 2053.236D;
          this.field_73168_g = this.field_185946_g.func_76304_a(this.field_73168_g, p_185938_2_, p_185938_3_, p_185938_4_, p_185938_5_, 1, p_185938_7_, 1.0D, 0.0D, 1.0D);
-@@ -358,6 +378,7 @@
+@@ -358,6 +389,7 @@
      public void func_185931_b(int p_185931_1_, int p_185931_2_)
      {
          BlockFalling.field_149832_M = true;
@@ -61,7 +73,7 @@
          int i = p_185931_1_ * 16;
          int j = p_185931_2_ * 16;
          BlockPos blockpos = new BlockPos(i, 0, j);
-@@ -365,16 +386,20 @@
+@@ -365,16 +397,20 @@
          ChunkPos chunkpos = new ChunkPos(p_185931_1_, p_185931_2_);
          this.field_73172_c.func_175794_a(this.field_185952_n, this.field_185954_p, chunkpos);
  
@@ -82,7 +94,7 @@
          for (int j1 = 0; j1 < this.field_185954_p.nextInt(this.field_185954_p.nextInt(10) + 1); ++j1)
          {
              this.field_177469_u.func_180709_b(this.field_185952_n, this.field_185954_p, blockpos.func_177982_a(this.field_185954_p.nextInt(16) + 8, this.field_185954_p.nextInt(120) + 4, this.field_185954_p.nextInt(16) + 8));
-@@ -384,7 +409,13 @@
+@@ -384,7 +420,13 @@
          {
              this.field_177468_v.func_180709_b(this.field_185952_n, this.field_185954_p, blockpos.func_177982_a(this.field_185954_p.nextInt(16) + 8, this.field_185954_p.nextInt(128), this.field_185954_p.nextInt(16) + 8));
          }
@@ -96,7 +108,7 @@
          if (this.field_185954_p.nextBoolean())
          {
              this.field_177471_z.func_180709_b(this.field_185952_n, this.field_185954_p, blockpos.func_177982_a(this.field_185954_p.nextInt(16) + 8, this.field_185954_p.nextInt(128), this.field_185954_p.nextInt(16) + 8));
-@@ -394,7 +425,10 @@
+@@ -394,7 +436,10 @@
          {
              this.field_177465_A.func_180709_b(this.field_185952_n, this.field_185954_p, blockpos.func_177982_a(this.field_185954_p.nextInt(16) + 8, this.field_185954_p.nextInt(128), this.field_185954_p.nextInt(16) + 8));
          }
@@ -107,7 +119,7 @@
          for (int l1 = 0; l1 < 16; ++l1)
          {
              this.field_177467_w.func_180709_b(this.field_185952_n, this.field_185954_p, blockpos.func_177982_a(this.field_185954_p.nextInt(16), this.field_185954_p.nextInt(108) + 10, this.field_185954_p.nextInt(16)));
-@@ -402,17 +436,23 @@
+@@ -402,17 +447,23 @@
  
          int i2 = this.field_185952_n.func_181545_F() / 2 + 1;
  

--- a/patches/minecraft/net/minecraft/world/gen/ChunkGeneratorOverworld.java.patch
+++ b/patches/minecraft/net/minecraft/world/gen/ChunkGeneratorOverworld.java.patch
@@ -43,7 +43,21 @@
          double d0 = 0.03125D;
          this.field_186002_u = this.field_185994_m.func_151599_a(this.field_186002_u, (double)(p_185977_1_ * 16), (double)(p_185977_2_ * 16), 16, 16, 0.0625D, 0.0625D, 1.0D);
  
-@@ -370,6 +392,8 @@
+@@ -229,10 +251,12 @@
+ 
+         Chunk chunk = new Chunk(this.field_185995_n, chunkprimer, p_185932_1_, p_185932_2_);
+         byte[] abyte = chunk.func_76605_m();
++        List<Biome> localBiomes = chunk.getLocalBiomes(); localBiomes.clear(); Short[] localBiomeIds = chunk.getLocalBiomeIds();
+ 
+         for (int i = 0; i < abyte.length; ++i)
+         {
+-            abyte[i] = (byte)Biome.func_185362_a(this.field_185981_C[i]);
++        	localBiomeIds[i] = null; int localBiomeIndex = localBiomes.indexOf(this.field_185981_C[i]); if(localBiomeIndex < 0) { localBiomeIds[localBiomeIndex = localBiomes.size()] = (short)Biome.func_185362_a(this.field_185981_C[i]); localBiomes.add(this.field_185981_C[i]); }
++            abyte[i] = (byte)localBiomeIndex;
+         }
+ 
+         chunk.func_76603_b();
+@@ -370,6 +394,8 @@
          boolean flag = false;
          ChunkPos chunkpos = new ChunkPos(p_185931_1_, p_185931_2_);
  
@@ -52,7 +66,7 @@
          if (this.field_185996_o)
          {
              if (this.field_186000_s.field_177829_w)
-@@ -404,6 +428,7 @@
+@@ -404,6 +430,7 @@
          }
  
          if (biome != Biomes.field_76769_d && biome != Biomes.field_76786_s && this.field_186000_s.field_177781_A && !flag && this.field_185990_i.nextInt(this.field_186000_s.field_177782_B) == 0)
@@ -60,7 +74,7 @@
          {
              int i1 = this.field_185990_i.nextInt(16) + 8;
              int j1 = this.field_185990_i.nextInt(256);
-@@ -412,6 +437,7 @@
+@@ -412,6 +439,7 @@
          }
  
          if (!flag && this.field_185990_i.nextInt(this.field_186000_s.field_177777_D / 10) == 0 && this.field_186000_s.field_177783_C)
@@ -68,7 +82,7 @@
          {
              int i2 = this.field_185990_i.nextInt(16) + 8;
              int l2 = this.field_185990_i.nextInt(this.field_185990_i.nextInt(248) + 8);
-@@ -424,6 +450,7 @@
+@@ -424,6 +452,7 @@
          }
  
          if (this.field_186000_s.field_177837_s)
@@ -76,7 +90,7 @@
          {
              for (int j2 = 0; j2 < this.field_186000_s.field_177835_t; ++j2)
              {
-@@ -435,9 +462,12 @@
+@@ -435,9 +464,12 @@
          }
  
          biome.func_180624_a(this.field_185995_n, this.field_185990_i, new BlockPos(i, 0, j));
@@ -89,7 +103,7 @@
          for (int k2 = 0; k2 < 16; ++k2)
          {
              for (int j3 = 0; j3 < 16; ++j3)
-@@ -456,7 +486,10 @@
+@@ -456,7 +488,10 @@
                  }
              }
          }

--- a/patches/minecraft/net/minecraft/world/gen/ChunkGeneratorOverworld.java.patch
+++ b/patches/minecraft/net/minecraft/world/gen/ChunkGeneratorOverworld.java.patch
@@ -43,21 +43,33 @@
          double d0 = 0.03125D;
          this.field_186002_u = this.field_185994_m.func_151599_a(this.field_186002_u, (double)(p_185977_1_ * 16), (double)(p_185977_2_ * 16), 16, 16, 0.0625D, 0.0625D, 1.0D);
  
-@@ -229,10 +251,12 @@
+@@ -229,12 +251,25 @@
  
          Chunk chunk = new Chunk(this.field_185995_n, chunkprimer, p_185932_1_, p_185932_2_);
          byte[] abyte = chunk.func_76605_m();
-+        List<Biome> localBiomes = chunk.getLocalBiomes(); localBiomes.clear(); Short[] localBiomeIds = chunk.getLocalBiomeIds();
++        byte[] localizedBiomeArray = new byte[256]; int maxBiomeId = 0; List<Biome> localBiomes = chunk.getLocalBiomes(); localBiomes.clear(); Short[] localBiomeIds = chunk.getLocalBiomeIds();
  
          for (int i = 0; i < abyte.length; ++i)
          {
--            abyte[i] = (byte)Biome.func_185362_a(this.field_185981_C[i]);
-+        	localBiomeIds[i] = null; int localBiomeIndex = localBiomes.indexOf(this.field_185981_C[i]); if(localBiomeIndex < 0) { localBiomeIds[localBiomeIndex = localBiomes.size()] = (short)Biome.func_185362_a(this.field_185981_C[i]); localBiomes.add(this.field_185981_C[i]); }
-+            abyte[i] = (byte)localBiomeIndex;
++            int localBiomeIndex = localBiomes.indexOf(this.field_185981_C[i]);
++            if(localBiomeIndex < 0)
++            {
++                int biomeId = Biome.func_185362_a(this.field_185981_C[i]);
++                maxBiomeId = Math.max(maxBiomeId, biomeId);
++                localBiomeIds[localBiomeIndex = localBiomes.size()] = (short)(biomeId & 65535);
++                localBiomes.add(this.field_185981_C[i]);
++            }
++            localizedBiomeArray[i] = (byte)localBiomeIndex;
+             abyte[i] = (byte)Biome.func_185362_a(this.field_185981_C[i]);
          }
  
++        if (maxBiomeId > 255) chunk.func_76616_a(localizedBiomeArray);
++        else localBiomes.clear();
++
          chunk.func_76603_b();
-@@ -370,6 +394,8 @@
+         return chunk;
+     }
+@@ -370,6 +405,8 @@
          boolean flag = false;
          ChunkPos chunkpos = new ChunkPos(p_185931_1_, p_185931_2_);
  
@@ -66,7 +78,7 @@
          if (this.field_185996_o)
          {
              if (this.field_186000_s.field_177829_w)
-@@ -404,6 +430,7 @@
+@@ -404,6 +441,7 @@
          }
  
          if (biome != Biomes.field_76769_d && biome != Biomes.field_76786_s && this.field_186000_s.field_177781_A && !flag && this.field_185990_i.nextInt(this.field_186000_s.field_177782_B) == 0)
@@ -74,7 +86,7 @@
          {
              int i1 = this.field_185990_i.nextInt(16) + 8;
              int j1 = this.field_185990_i.nextInt(256);
-@@ -412,6 +439,7 @@
+@@ -412,6 +450,7 @@
          }
  
          if (!flag && this.field_185990_i.nextInt(this.field_186000_s.field_177777_D / 10) == 0 && this.field_186000_s.field_177783_C)
@@ -82,7 +94,7 @@
          {
              int i2 = this.field_185990_i.nextInt(16) + 8;
              int l2 = this.field_185990_i.nextInt(this.field_185990_i.nextInt(248) + 8);
-@@ -424,6 +452,7 @@
+@@ -424,6 +463,7 @@
          }
  
          if (this.field_186000_s.field_177837_s)
@@ -90,7 +102,7 @@
          {
              for (int j2 = 0; j2 < this.field_186000_s.field_177835_t; ++j2)
              {
-@@ -435,9 +464,12 @@
+@@ -435,9 +475,12 @@
          }
  
          biome.func_180624_a(this.field_185995_n, this.field_185990_i, new BlockPos(i, 0, j));
@@ -103,7 +115,7 @@
          for (int k2 = 0; k2 < 16; ++k2)
          {
              for (int j3 = 0; j3 < 16; ++j3)
-@@ -456,7 +488,10 @@
+@@ -456,7 +499,10 @@
                  }
              }
          }

--- a/src/main/java/net/minecraftforge/registries/GameData.java
+++ b/src/main/java/net/minecraftforge/registries/GameData.java
@@ -99,7 +99,7 @@ public class GameData
     private static final int MIN_ITEM_ID = MAX_BLOCK_ID + 1;
     private static final int MAX_ITEM_ID = 31999;
     private static final int MAX_POTION_ID = 255; // SPacketEntityEffect sends bytes, we can only use 255
-    private static final int MAX_BIOME_ID = 255; // Maximum number in a byte in the chunk
+    private static final int MAX_BIOME_ID = Short.MAX_VALUE - Short.MIN_VALUE; // Maximum number in a byte in the chunk
     private static final int MAX_SOUND_ID = Integer.MAX_VALUE >> 5; // Varint (SPacketSoundEffect)
     private static final int MAX_POTIONTYPE_ID = Integer.MAX_VALUE >> 5; // Int (SPacketEffect)
     private static final int MAX_ENCHANTMENT_ID = Short.MAX_VALUE - 1; // Short - serialized as a short in ItemStack NBTs.


### PR DESCRIPTION
This pr _should_ maintain binary compatibility, so long as there aren't more than 256 biomes registered **_and_** there isn't a mod present that tinkers with biomes. Resolves #1704.