### PR TITLE
Create event for overriding mob griefing behaviour

### DIFF
--- a/patches/minecraft/net/minecraft/entity/Entity.java.patch
+++ b/patches/minecraft/net/minecraft/entity/Entity.java.patch
@@ -185,7 +185,7 @@
      }
  
      public boolean func_174816_a(Explosion p_174816_1_, World p_174816_2_, BlockPos p_174816_3_, IBlockState p_174816_4_, float p_174816_5_)
-@@ -2901,6 +2929,183 @@
+@@ -2901,6 +2930,183 @@
          EnchantmentHelper.func_151385_b(p_174815_1_, p_174815_2_);
      }
  
@@ -361,7 +361,7 @@
 +    {
 +        return world.field_73012_v.nextFloat() < fallDistance - 0.5F
 +            && this instanceof EntityLivingBase
-+            && (this instanceof EntityPlayer || world.func_82736_K().func_82766_b("mobGriefing"))
++            && (this instanceof EntityPlayer || net.minecraftforge.event.ForgeEventFactory.getMobGriefingEvent(world, this))
 +            && this.field_70130_N * this.field_70130_N * this.field_70131_O > 0.512F;
 +    }
 +    /* ================================== Forge End =====================================*/

--- a/patches/minecraft/net/minecraft/entity/EntityLiving.java.patch
+++ b/patches/minecraft/net/minecraft/entity/EntityLiving.java.patch
@@ -8,6 +8,15 @@
      }
  
      public boolean func_70686_a(Class <? extends EntityLivingBase > p_70686_1_)
+@@ -576,7 +577,7 @@
+         super.func_70636_d();
+         this.field_70170_p.field_72984_F.func_76320_a("looting");
+ 
+-        if (!this.field_70170_p.field_72995_K && this.func_98052_bS() && !this.field_70729_aU && this.field_70170_p.func_82736_K().func_82766_b("mobGriefing"))
++        if (!this.field_70170_p.field_72995_K && this.func_98052_bS() && !this.field_70729_aU && net.minecraftforge.event.ForgeEventFactory.getMobGriefingEvent(this.field_70170_p, this))
+         {
+             for (EntityItem entityitem : this.field_70170_p.func_72872_a(EntityItem.class, this.func_174813_aQ().func_72314_b(1.0D, 0.0D, 1.0D)))
+             {
 @@ -702,10 +703,22 @@
  
      protected void func_70623_bb()

--- a/patches/minecraft/net/minecraft/entity/ai/EntityAIBreakDoor.java.patch
+++ b/patches/minecraft/net/minecraft/entity/ai/EntityAIBreakDoor.java.patch
@@ -5,7 +5,7 @@
              return false;
          }
 -        else if (!this.field_75356_a.field_70170_p.func_82736_K().func_82766_b("mobGriefing"))
-+        else if (!this.field_75356_a.field_70170_p.func_82736_K().func_82766_b("mobGriefing") || !this.field_75356_a.field_70170_p.func_180495_p(this.field_179507_b).func_177230_c().canEntityDestroy(this.field_75356_a.field_70170_p.func_180495_p(this.field_179507_b), this.field_75356_a.field_70170_p, this.field_179507_b, this.field_75356_a) || !net.minecraftforge.event.ForgeEventFactory.onEntityDestroyBlock(this.field_75356_a, this.field_179507_b, this.field_75356_a.field_70170_p.func_180495_p(this.field_179507_b)))
++        else if (!net.minecraftforge.event.ForgeEventFactory.getMobGriefingEvent(this.field_75356_a.field_70170_p, this.field_75356_a) || !this.field_75356_a.field_70170_p.func_180495_p(this.field_179507_b).func_177230_c().canEntityDestroy(this.field_75356_a.field_70170_p.func_180495_p(this.field_179507_b), this.field_75356_a.field_70170_p, this.field_179507_b, this.field_75356_a) || !net.minecraftforge.event.ForgeEventFactory.onEntityDestroyBlock(this.field_75356_a, this.field_179507_b, this.field_75356_a.field_70170_p.func_180495_p(this.field_179507_b)))
          {
              return false;
          }

--- a/patches/minecraft/net/minecraft/entity/ai/EntityAIEatGrass.java.patch
+++ b/patches/minecraft/net/minecraft/entity/ai/EntityAIEatGrass.java.patch
@@ -1,0 +1,20 @@
+--- ../src-base/minecraft/net/minecraft/entity/ai/EntityAIEatGrass.java
++++ ../src-work/minecraft/net/minecraft/entity/ai/EntityAIEatGrass.java
+@@ -78,7 +78,7 @@
+ 
+             if (field_179505_b.apply(this.field_151501_c.func_180495_p(blockpos)))
+             {
+-                if (this.field_151501_c.func_82736_K().func_82766_b("mobGriefing"))
++                if (net.minecraftforge.event.ForgeEventFactory.getMobGriefingEvent(this.field_151501_c, this.field_151500_b))
+                 {
+                     this.field_151501_c.func_175655_b(blockpos, false);
+                 }
+@@ -91,7 +91,7 @@
+ 
+                 if (this.field_151501_c.func_180495_p(blockpos1).func_177230_c() == Blocks.field_150349_c)
+                 {
+-                    if (this.field_151501_c.func_82736_K().func_82766_b("mobGriefing"))
++                    if (net.minecraftforge.event.ForgeEventFactory.getMobGriefingEvent(this.field_151501_c, this.field_151500_b))
+                     {
+                         this.field_151501_c.func_175718_b(2001, blockpos1, Block.func_149682_b(Blocks.field_150349_c));
+                         this.field_151501_c.func_180501_a(blockpos1, Blocks.field_150346_d.func_176223_P(), 2);

--- a/patches/minecraft/net/minecraft/entity/ai/EntityAIHarvestFarmland.java.patch
+++ b/patches/minecraft/net/minecraft/entity/ai/EntityAIHarvestFarmland.java.patch
@@ -1,0 +1,11 @@
+--- ../src-base/minecraft/net/minecraft/entity/ai/EntityAIHarvestFarmland.java
++++ ../src-work/minecraft/net/minecraft/entity/ai/EntityAIHarvestFarmland.java
+@@ -29,7 +29,7 @@
+     {
+         if (this.field_179496_a <= 0)
+         {
+-            if (!this.field_179504_c.field_70170_p.func_82736_K().func_82766_b("mobGriefing"))
++            if (!net.minecraftforge.event.ForgeEventFactory.getMobGriefingEvent(this.field_179504_c.field_70170_p, this.field_179504_c))
+             {
+                 return false;
+             }

--- a/patches/minecraft/net/minecraft/entity/boss/EntityDragon.java.patch
+++ b/patches/minecraft/net/minecraft/entity/boss/EntityDragon.java.patch
@@ -7,7 +7,8 @@
 -                    if (iblockstate.func_185904_a() != Material.field_151579_a && iblockstate.func_185904_a() != Material.field_151581_o)
 +                    if (!block.isAir(iblockstate, this.field_70170_p, blockpos) && iblockstate.func_185904_a() != Material.field_151581_o)
                      {
-                         if (!this.field_70170_p.func_82736_K().func_82766_b("mobGriefing"))
+-                        if (!this.field_70170_p.func_82736_K().func_82766_b("mobGriefing"))
++                        if (!net.minecraftforge.event.ForgeEventFactory.getMobGriefingEvent(this.field_70170_p, this))
                          {
                              flag = true;
                          }

--- a/patches/minecraft/net/minecraft/entity/boss/EntityWither.java.patch
+++ b/patches/minecraft/net/minecraft/entity/boss/EntityWither.java.patch
@@ -1,5 +1,23 @@
 --- ../src-base/minecraft/net/minecraft/entity/boss/EntityWither.java
 +++ ../src-work/minecraft/net/minecraft/entity/boss/EntityWither.java
+@@ -255,7 +255,7 @@
+ 
+             if (j1 <= 0)
+             {
+-                this.field_70170_p.func_72885_a(this, this.field_70165_t, this.field_70163_u + (double)this.func_70047_e(), this.field_70161_v, 7.0F, false, this.field_70170_p.func_82736_K().func_82766_b("mobGriefing"));
++                this.field_70170_p.func_72885_a(this, this.field_70165_t, this.field_70163_u + (double)this.func_70047_e(), this.field_70161_v, 7.0F, false, net.minecraftforge.event.ForgeEventFactory.getMobGriefingEvent(this.field_70170_p, this));
+                 this.field_70170_p.func_175669_a(1023, new BlockPos(this), 0);
+             }
+ 
+@@ -362,7 +362,7 @@
+             {
+                 --this.field_82222_j;
+ 
+-                if (this.field_82222_j == 0 && this.field_70170_p.func_82736_K().func_82766_b("mobGriefing"))
++                if (this.field_82222_j == 0 && net.minecraftforge.event.ForgeEventFactory.getMobGriefingEvent(this.field_70170_p, this))
+                 {
+                     int i1 = MathHelper.func_76128_c(this.field_70163_u);
+                     int l1 = MathHelper.func_76128_c(this.field_70165_t);
 @@ -382,7 +382,7 @@
                                  IBlockState iblockstate = this.field_70170_p.func_180495_p(blockpos);
                                  Block block = iblockstate.func_177230_c();

--- a/patches/minecraft/net/minecraft/entity/monster/EntityCreeper.java.patch
+++ b/patches/minecraft/net/minecraft/entity/monster/EntityCreeper.java.patch
@@ -1,0 +1,11 @@
+--- ../src-base/minecraft/net/minecraft/entity/monster/EntityCreeper.java
++++ ../src-work/minecraft/net/minecraft/entity/monster/EntityCreeper.java
+@@ -265,7 +265,7 @@
+     {
+         if (!this.field_70170_p.field_72995_K)
+         {
+-            boolean flag = this.field_70170_p.func_82736_K().func_82766_b("mobGriefing");
++            boolean flag = net.minecraftforge.event.ForgeEventFactory.getMobGriefingEvent(this.field_70170_p, this);
+             float f = this.func_70830_n() ? 2.0F : 1.0F;
+             this.field_70729_aU = true;
+             this.field_70170_p.func_72876_a(this, this.field_70165_t, this.field_70163_u, this.field_70161_v, (float)this.field_82226_g * f, flag);

--- a/patches/minecraft/net/minecraft/entity/monster/EntityEnderman.java.patch
+++ b/patches/minecraft/net/minecraft/entity/monster/EntityEnderman.java.patch
@@ -30,3 +30,21 @@
      public boolean func_70823_r()
      {
          return ((Boolean)this.field_70180_af.func_187225_a(field_184719_bw)).booleanValue();
+@@ -486,7 +500,7 @@
+                 {
+                     return false;
+                 }
+-                else if (!this.field_179475_a.field_70170_p.func_82736_K().func_82766_b("mobGriefing"))
++                else if (!net.minecraftforge.event.ForgeEventFactory.getMobGriefingEvent(this.field_179475_a.field_70170_p, this.field_179475_a))
+                 {
+                     return false;
+                 }
+@@ -551,7 +565,7 @@
+                 {
+                     return false;
+                 }
+-                else if (!this.field_179473_a.field_70170_p.func_82736_K().func_82766_b("mobGriefing"))
++                else if (!net.minecraftforge.event.ForgeEventFactory.getMobGriefingEvent(this.field_179473_a.field_70170_p, this.field_179473_a))
+                 {
+                     return false;
+                 }

--- a/patches/minecraft/net/minecraft/entity/monster/EntityEvoker.java.patch
+++ b/patches/minecraft/net/minecraft/entity/monster/EntityEvoker.java.patch
@@ -1,0 +1,11 @@
+--- ../src-base/minecraft/net/minecraft/entity/monster/EntityEvoker.java
++++ ../src-work/minecraft/net/minecraft/entity/monster/EntityEvoker.java
+@@ -369,7 +369,7 @@
+             {
+                 return false;
+             }
+-            else if (!EntityEvoker.this.field_70170_p.func_82736_K().func_82766_b("mobGriefing"))
++            else if (!net.minecraftforge.event.ForgeEventFactory.getMobGriefingEvent(EntityEvoker.this.field_70170_p, EntityEvoker.this))
+             {
+                 return false;
+             }

--- a/patches/minecraft/net/minecraft/entity/monster/EntitySilverfish.java.patch
+++ b/patches/minecraft/net/minecraft/entity/monster/EntitySilverfish.java.patch
@@ -1,0 +1,20 @@
+--- ../src-base/minecraft/net/minecraft/entity/monster/EntitySilverfish.java
++++ ../src-work/minecraft/net/minecraft/entity/monster/EntitySilverfish.java
+@@ -184,7 +184,7 @@
+                 {
+                     Random random = this.field_75457_a.func_70681_au();
+ 
+-                    if (this.field_75457_a.field_70170_p.func_82736_K().func_82766_b("mobGriefing") && random.nextInt(10) == 0)
++                    if (net.minecraftforge.event.ForgeEventFactory.getMobGriefingEvent(this.field_75457_a.field_70170_p, this.field_75457_a) && random.nextInt(10) == 0)
+                     {
+                         this.field_179483_b = EnumFacing.func_176741_a(random);
+                         BlockPos blockpos = (new BlockPos(this.field_75457_a.field_70165_t, this.field_75457_a.field_70163_u + 0.5D, this.field_75457_a.field_70161_v)).func_177972_a(this.field_179483_b);
+@@ -273,7 +273,7 @@
+ 
+                                 if (iblockstate.func_177230_c() == Blocks.field_150418_aU)
+                                 {
+-                                    if (world.func_82736_K().func_82766_b("mobGriefing"))
++                                    if (net.minecraftforge.event.ForgeEventFactory.getMobGriefingEvent(world, this.field_179464_a))
+                                     {
+                                         world.func_175655_b(blockpos1, true);
+                                     }

--- a/patches/minecraft/net/minecraft/entity/monster/EntitySnowman.java.patch
+++ b/patches/minecraft/net/minecraft/entity/monster/EntitySnowman.java.patch
@@ -9,6 +9,15 @@
  {
      private static final DataParameter<Byte> field_184749_a = EntityDataManager.<Byte>func_187226_a(EntitySnowman.class, DataSerializers.field_187191_a);
  
+@@ -104,7 +104,7 @@
+                 this.func_70097_a(DamageSource.field_76370_b, 1.0F);
+             }
+ 
+-            if (!this.field_70170_p.func_82736_K().func_82766_b("mobGriefing"))
++            if (!net.minecraftforge.event.ForgeEventFactory.getMobGriefingEvent(this.field_70170_p, this))
+             {
+                 return;
+             }
 @@ -152,7 +152,7 @@
      {
          ItemStack itemstack = p_184645_1_.func_184586_b(p_184645_2_);

--- a/patches/minecraft/net/minecraft/entity/passive/EntityRabbit.java.patch
+++ b/patches/minecraft/net/minecraft/entity/passive/EntityRabbit.java.patch
@@ -1,0 +1,11 @@
+--- ../src-base/minecraft/net/minecraft/entity/passive/EntityRabbit.java
++++ ../src-work/minecraft/net/minecraft/entity/passive/EntityRabbit.java
+@@ -551,7 +551,7 @@
+             {
+                 if (this.field_179496_a <= 0)
+                 {
+-                    if (!this.field_179500_c.field_70170_p.func_82736_K().func_82766_b("mobGriefing"))
++                    if (!net.minecraftforge.event.ForgeEventFactory.getMobGriefingEvent(this.field_179500_c.field_70170_p, this.field_179500_c))
+                     {
+                         return false;
+                     }

--- a/patches/minecraft/net/minecraft/entity/projectile/EntityLargeFireball.java.patch
+++ b/patches/minecraft/net/minecraft/entity/projectile/EntityLargeFireball.java.patch
@@ -1,0 +1,11 @@
+--- ../src-base/minecraft/net/minecraft/entity/projectile/EntityLargeFireball.java
++++ ../src-work/minecraft/net/minecraft/entity/projectile/EntityLargeFireball.java
+@@ -40,7 +40,7 @@
+                 this.func_174815_a(this.field_70235_a, p_70227_1_.field_72308_g);
+             }
+ 
+-            boolean flag = this.field_70170_p.func_82736_K().func_82766_b("mobGriefing");
++            boolean flag = net.minecraftforge.event.ForgeEventFactory.getMobGriefingEvent(this.field_70170_p, this.field_70235_a);
+             this.field_70170_p.func_72885_a((Entity)null, this.field_70165_t, this.field_70163_u, this.field_70161_v, (float)this.field_92057_e, flag, flag);
+             this.func_70106_y();
+         }

--- a/patches/minecraft/net/minecraft/entity/projectile/EntitySmallFireball.java.patch
+++ b/patches/minecraft/net/minecraft/entity/projectile/EntitySmallFireball.java.patch
@@ -1,0 +1,11 @@
+--- ../src-base/minecraft/net/minecraft/entity/projectile/EntitySmallFireball.java
++++ ../src-work/minecraft/net/minecraft/entity/projectile/EntitySmallFireball.java
+@@ -57,7 +57,7 @@
+ 
+                 if (this.field_70235_a != null && this.field_70235_a instanceof EntityLiving)
+                 {
+-                    flag1 = this.field_70170_p.func_82736_K().func_82766_b("mobGriefing");
++                    flag1 = net.minecraftforge.event.ForgeEventFactory.getMobGriefingEvent(this.field_70170_p, this.field_70235_a);
+                 }
+ 
+                 if (flag1)

--- a/patches/minecraft/net/minecraft/entity/projectile/EntityWitherSkull.java.patch
+++ b/patches/minecraft/net/minecraft/entity/projectile/EntityWitherSkull.java.patch
@@ -9,3 +9,12 @@
          {
              f = Math.min(0.8F, f);
          }
+@@ -115,7 +115,7 @@
+                 }
+             }
+ 
+-            this.field_70170_p.func_72885_a(this, this.field_70165_t, this.field_70163_u, this.field_70161_v, 1.0F, false, this.field_70170_p.func_82736_K().func_82766_b("mobGriefing"));
++            this.field_70170_p.func_72885_a(this, this.field_70165_t, this.field_70163_u, this.field_70161_v, 1.0F, false, net.minecraftforge.event.ForgeEventFactory.getMobGriefingEvent(this.field_70170_p, this.field_70235_a));
+             this.func_70106_y();
+         }
+     }

--- a/src/main/java/net/minecraftforge/event/ForgeEventFactory.java
+++ b/src/main/java/net/minecraftforge/event/ForgeEventFactory.java
@@ -82,6 +82,7 @@ import net.minecraftforge.common.util.BlockSnapshot;
 import net.minecraftforge.event.brewing.PlayerBrewedPotionEvent;
 import net.minecraftforge.event.brewing.PotionBrewEvent;
 import net.minecraftforge.event.entity.EntityEvent;
+import net.minecraftforge.event.entity.EntityMobGriefingEvent;
 import net.minecraftforge.event.entity.EntityMountEvent;
 import net.minecraftforge.event.entity.EntityStruckByLightningEvent;
 import net.minecraftforge.event.entity.PlaySoundAtEntityEvent;
@@ -755,5 +756,14 @@ public class ForgeEventFactory
     {
         MinecraftForge.EVENT_BUS.post(new GetCollisionBoxesEvent(world, entity, aabb, outList));
         return outList.isEmpty();
+    }
+
+    public static boolean getMobGriefingEvent(World world, Entity entity)
+    {
+        EntityMobGriefingEvent event = new EntityMobGriefingEvent(entity);
+        MinecraftForge.EVENT_BUS.post(event);
+
+        Result result = event.getResult();
+        return result == Result.DEFAULT ? world.getGameRules().getBoolean("mobGriefing") : result == Result.ALLOW;
     }
 }

--- a/src/main/java/net/minecraftforge/event/entity/EntityMobGriefingEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/EntityMobGriefingEvent.java
@@ -1,0 +1,44 @@
+/*
+ * Minecraft Forge
+ * Copyright (c) 2018.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation version 2.1
+ * of the License.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+package net.minecraftforge.event.entity;
+
+import net.minecraft.entity.Entity;
+import net.minecraftforge.common.MinecraftForge;
+import net.minecraftforge.fml.common.eventhandler.Event.HasResult;
+import net.minecraftforge.fml.common.eventhandler.Event.Result;
+
+/**
+ * EntityMobGriefingEvent is fired when mob griefing is about to occur and allows an event listener to specify whether it should or not.<br>
+ * This event is fired when ever the {@code mobGriefing} game rule is checked.<br>
+ * <br>
+ * This event has a {@link HasResult result}:
+ * <li>{@link Result#ALLOW} means this instance of mob griefing is allowed.</li>
+ * <li>{@link Result#DEFAULT} means the {@code mobGriefing} game rule is used to determine the behaviour.</li>
+ * <li>{@link Result#DENY} means this instance of mob griefing is not allowed.</li><br>
+ * This event is fired on the {@link MinecraftForge#EVENT_BUS}.
+ */
+@HasResult
+public class EntityMobGriefingEvent extends EntityEvent
+{
+    public EntityMobGriefingEvent(Entity entity)
+    {
+        super(entity);
+    }
+}

--- a/src/test/java/net/minecraftforge/debug/EntityMobGriefingEventTest.java
+++ b/src/test/java/net/minecraftforge/debug/EntityMobGriefingEventTest.java
@@ -1,0 +1,51 @@
+/*
+ * Minecraft Forge
+ * Copyright (c) 2018.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation version 2.1
+ * of the License.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+package net.minecraftforge.debug;
+
+import net.minecraftforge.event.entity.EntityMobGriefingEvent;
+import net.minecraftforge.fml.common.Mod;
+import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
+import net.minecraftforge.fml.common.eventhandler.Event.Result;
+
+@Mod(modid = "entitymobgriefingeventtest", name = "EntityMobGriefingEventTest", version = "1.0", acceptableRemoteVersions = "*")
+@Mod.EventBusSubscriber
+public class EntityMobGriefingEventTest
+{
+    private static final boolean ENABLED = false;
+
+    @SubscribeEvent
+    public static void onMobGriefing(EntityMobGriefingEvent event)
+    {
+        if (ENABLED)
+        {
+            String customName = event.getEntity().getCustomNameTag();
+
+            try
+            {
+                Result result = Result.valueOf(customName);
+                event.setResult(result);
+            }
+            catch (IllegalArgumentException iae)
+            {
+                // Thrown if the name tag did not match a result value, can be ignored and DEFAULT will still be used.
+            }
+        }
+    }
+}


### PR DESCRIPTION
I have created a new event which will fire when ever the mobGriefing game rule value would normally be retrieved.
The event provides the entity instance which is currently attempting to grief to allow handlers to make decisions based on the entity's data. The event result can be used to force griefing to true, false or to simply use the game rule value as a default.

The primary reason for wanting this change is that I have a mod which allows the setting of mobGriefing rules for each type of entity, it currently involves a lot of ASM transformation which I would like to move away from due to maintenance overheads and potential compatibility issues.
This event would allow me to simply listen for the single event and use the entity instance to determine which rule to apply. 

That said, I do believe it could be a useful tool for others as well. For example it could be used to ensure that pet entities (those with name tags) were unable to destroy their housing without having to fully disable mob griefing.