### PR TITLE
Fix some shapeless recipes using damageable items not working

### DIFF
--- a/patches/minecraft/net/minecraft/item/crafting/Ingredient.java.patch
+++ b/patches/minecraft/net/minecraft/item/crafting/Ingredient.java.patch
@@ -14,7 +14,7 @@
      public static final Ingredient field_193370_a = new Ingredient(new ItemStack[0])
      {
          public boolean apply(@Nullable ItemStack p_apply_1_)
-@@ -21,17 +21,41 @@
+@@ -21,17 +21,39 @@
          }
      };
      private final ItemStack[] field_193371_b;
@@ -36,12 +36,10 @@
 +        {
 +            if (s.func_190926_b())
 +                continue;
++            if (s.func_77973_b().func_77645_m())
++                simple = false;
 +            if (s.func_77960_j() == net.minecraftforge.oredict.OreDictionary.WILDCARD_VALUE)
-+            {
-+                if (s.func_77973_b().func_77645_m())
-+                    simple = false;
 +                s.func_77973_b().func_150895_a(net.minecraft.creativetab.CreativeTabs.field_78027_g, lst);
-+            }
 +            else
 +                lst.add(s);
 +        }
@@ -58,7 +56,7 @@
      }
  
      public boolean apply(@Nullable ItemStack p_apply_1_)
-@@ -63,9 +87,9 @@
+@@ -63,9 +85,9 @@
      {
          if (this.field_194140_c == null)
          {
@@ -70,7 +68,7 @@
              {
                  this.field_194140_c.add(RecipeItemHelper.func_194113_b(itemstack));
              }
-@@ -76,6 +100,18 @@
+@@ -76,6 +98,18 @@
          return this.field_194140_c;
      }
  
@@ -89,7 +87,7 @@
      public static Ingredient func_193367_a(Item p_193367_0_)
      {
          return func_193369_a(new ItemStack(p_193367_0_, 1, 32767));
-@@ -108,4 +144,22 @@
+@@ -108,4 +142,22 @@
  
          return field_193370_a;
      }


### PR DESCRIPTION
Moves the check for `if (s.getItem().isDamageable())` outside of the check for wildcard metadata (in the `Ingredient` constructor).

`ShapelessRecipes.matches` has the following logic:
```java
if (this.isSimple)
	recipeItemHelper.accountStack(itemstack, 1);
else
	inputs.add(itemstack);
```

However, `RecipeItemHelper.accountStack` checks:
```java
if (!stack.isEmpty() && !stack.isItemDamaged() && !stack.isItemEnchanted() && !stack.hasDisplayName())
```

This prevents damaged items from being used, which means they can't work in a "simple" recipe.
The change here makes those recipes considered not simple, so they use Forge's logic, which works here.

Example case of a broken recipe (ref https://github.com/TeamTwilight/twilightforest/issues/391):
```json
{
  "result": {
    "item": "twilightforest:lifedrain_scepter"
  },
  "ingredients": [
    {
      "item": "twilightforest:lifedrain_scepter",
      "data": 99
    },
    {
      "item": "minecraft:fermented_spider_eye"
    }
  ],
  "type": "minecraft:crafting_shapeless"
}
```