### PR TITLE
Update ItemHandlerHelper.giveItemToPlayer to allow player who picked up the item to hear the sound as well

### DIFF
--- a/src/main/java/net/minecraftforge/items/ItemHandlerHelper.java
+++ b/src/main/java/net/minecraftforge/items/ItemHandlerHelper.java
@@ -181,7 +181,7 @@ public class ItemHandlerHelper
         // play sound if something got picked up
         if (remainder.isEmpty() || remainder.getCount() != stack.getCount())
         {
-            world.playSound(null, player.posX, player.posY, player.posZ,
+            world.playSound(null, player.posX, player.posY + 0.5, player.posZ,
                     SoundEvents.ENTITY_ITEM_PICKUP, SoundCategory.PLAYERS, 0.2F, ((world.rand.nextFloat() - world.rand.nextFloat()) * 0.7F + 1.0F) * 2.0F);
         }
 

--- a/src/main/java/net/minecraftforge/items/ItemHandlerHelper.java
+++ b/src/main/java/net/minecraftforge/items/ItemHandlerHelper.java
@@ -181,7 +181,7 @@ public class ItemHandlerHelper
         // play sound if something got picked up
         if (remainder.isEmpty() || remainder.getCount() != stack.getCount())
         {
-            world.playSound(player, player.posX, player.posY, player.posZ,
+            world.playSound(null, player.posX, player.posY, player.posZ,
                     SoundEvents.ENTITY_ITEM_PICKUP, SoundCategory.PLAYERS, 0.2F, ((world.rand.nextFloat() - world.rand.nextFloat()) * 0.7F + 1.0F) * 2.0F);
         }
 

--- a/src/test/java/net/minecraftforge/debug/GiveItemToPlayerTest.java
+++ b/src/test/java/net/minecraftforge/debug/GiveItemToPlayerTest.java
@@ -1,0 +1,41 @@
+package net.minecraftforge.debug;
+
+import net.minecraft.item.ItemStack;
+import net.minecraft.util.EnumActionResult;
+import net.minecraftforge.common.MinecraftForge;
+import net.minecraftforge.event.entity.player.PlayerInteractEvent;
+import net.minecraftforge.fml.common.Mod;
+import net.minecraftforge.fml.common.event.FMLPreInitializationEvent;
+import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
+import net.minecraftforge.fml.common.registry.GameRegistry;
+import net.minecraftforge.items.ItemHandlerHelper;
+
+/**
+ * A mod to test that ItemHandlerHelper.giveItemToPlayer works.
+ * More specifically, that all players, including the one receiving the item, can hear the pickup sound when it happens.
+ * This mod makes it so when you right click the air with a piece of dirt in your hand, you get another piece of dirt.
+ * It's not a dupe glitch...it's a dupe "feature"...
+ */
+@Mod(modid = "giveitemtoplayertest", name = "ItemHandlerHelper.giveItemToPlayer Test", version = "1.0")
+public class GiveItemToPlayerTest {
+    private static final boolean ENABLED = false;
+
+    @GameRegistry.ItemStackHolder("minecraft:dirt")
+    public static final ItemStack dirt = null;
+
+    @Mod.EventHandler
+    public void preInit(FMLPreInitializationEvent event) {
+        if (ENABLED) {
+            MinecraftForge.EVENT_BUS.register(this);
+        }
+    }
+
+    @SubscribeEvent
+    public void rightClick(PlayerInteractEvent.RightClickItem event) {
+        if (!event.getWorld().isRemote && event.getItemStack().isItemEqual(dirt)) {
+            ItemHandlerHelper.giveItemToPlayer(event.getEntityPlayer(), dirt);
+        }
+        event.setCanceled(true);
+        event.setCancellationResult(EnumActionResult.SUCCESS);
+    }
+}


### PR DESCRIPTION
Before, this method would only play the sound for surrounding players, and mods using this method would need to fire the sound again for the client player (like [here in Botania](https://github.com/Vazkii/Botania/blob/bcead7ad7d0bb479799715b67fffcc95fc527fdd/src/main/java/vazkii/botania/common/item/material/ItemManaResource.java#L69-L73), which I was referencing for something I'm doing). This would generally result in the surrounding players hearing the sound twice. To me, this seemed a little sub-optimal. Besides the "others hear the sound twice thing", since I can't think of a reason why a mod developer would want the pickup sound to be played for surrounding players and not the player who actually picked it up, I did this.

I also included a test mod, because everyone loves those. It has the good side-effect of also testing if the method as a whole is working. So that's a plus.