### PR TITLE
Remove texture loads from SimpleModelFontRenderer

### DIFF
--- a/src/main/java/net/minecraftforge/client/model/SimpleModelFontRenderer.java
+++ b/src/main/java/net/minecraftforge/client/model/SimpleModelFontRenderer.java
@@ -14,7 +14,6 @@ import net.minecraft.client.gui.FontRenderer;
 import net.minecraft.client.renderer.block.model.BakedQuad;
 import net.minecraft.client.renderer.texture.TextureAtlasSprite;
 import net.minecraft.client.renderer.texture.TextureManager;
-import net.minecraft.client.renderer.texture.TextureMap;
 import net.minecraft.client.renderer.vertex.VertexFormat;
 import net.minecraft.client.resources.IResourceManager;
 import net.minecraft.client.settings.GameSettings;
@@ -36,7 +35,6 @@ public abstract class SimpleModelFontRenderer extends FontRenderer {
     public SimpleModelFontRenderer(GameSettings settings, ResourceLocation font, TextureManager manager, boolean isUnicode, Matrix4f matrix, VertexFormat format)
     {
         super(settings, font, manager, isUnicode);
-        manager.bindTexture(TextureMap.LOCATION_BLOCKS_TEXTURE);
         this.matrix = new Matrix4f(matrix);
         Matrix3f nm = new Matrix3f();
         this.matrix.getRotationScale(nm);
@@ -170,6 +168,11 @@ public abstract class SimpleModelFontRenderer extends FontRenderer {
     }
 
     @Override public void enableAlpha()
+    {
+    }
+
+    @Override
+    protected void bindTexture(ResourceLocation location)
     {
     }
 


### PR DESCRIPTION
`SimpleModelFontRenderer` tries to restore texture change done by `FontRenderer` constructor by binding block atlas texture after super call. This is not always valid, as:
- original texture is not guaranteed to be block atlas
- thread where model is build may not have access to GL context (and attempt to bind causes crash).

Since there is no point in messing texture state in model building, this PR tries different approach and prevents original bind.