### PR TITLE
Added a new getDrops method to Block to give modders the ability to ues the TileEntity and the Player for calculating the drops too. Renewal of #4717 Closes #4674

### DIFF
--- a/patches/minecraft/net/minecraft/block/Block.java.patch
+++ b/patches/minecraft/net/minecraft/block/Block.java.patch
@@ -99,7 +99,7 @@
      }
  
      public final void func_176226_b(World p_176226_1_, BlockPos p_176226_2_, IBlockState p_176226_3_, int p_176226_4_)
-@@ -568,20 +566,16 @@
+@@ -568,20 +566,18 @@
  
      public void func_180653_a(World p_180653_1_, BlockPos p_180653_2_, IBlockState p_180653_3_, float p_180653_4_, int p_180653_5_)
      {
@@ -107,10 +107,12 @@
 +        if (!p_180653_1_.field_72995_K && !p_180653_1_.restoringBlockSnapshots) // do not drop items while restoring blockstates, prevents item dupe
          {
 -            int i = this.func_149679_a(p_180653_5_, p_180653_1_.field_73012_v);
-+            List<ItemStack> drops = getDrops(p_180653_1_, p_180653_2_, p_180653_3_, p_180653_5_); // use the old method until it gets removed, for backward compatibility
-+            p_180653_4_ = net.minecraftforge.event.ForgeEventFactory.fireBlockHarvesting(drops, p_180653_1_, p_180653_2_, p_180653_3_, p_180653_5_, p_180653_4_, false, harvesters.get());
++            NonNullList<ItemStack> drops = NonNullList.func_191196_a();
++            this.getDrops(drops, p_180653_1_, p_180653_2_, p_180653_3_, p_180653_5_, harvesters.get(), harvestTileEntity.get());
  
 -            for (int j = 0; j < i; ++j)
++            p_180653_4_ = net.minecraftforge.event.ForgeEventFactory.fireBlockHarvesting(drops, p_180653_1_, p_180653_2_, p_180653_3_, p_180653_5_, p_180653_4_, false, harvesters.get(), harvestTileEntity.get());
++
 +            for (ItemStack drop : drops)
              {
                  if (p_180653_1_.field_73012_v.nextFloat() <= p_180653_4_)
@@ -125,7 +127,7 @@
                  }
              }
          }
-@@ -589,8 +583,13 @@
+@@ -589,8 +585,13 @@
  
      public static void func_180635_a(World p_180635_0_, BlockPos p_180635_1_, ItemStack p_180635_2_)
      {
@@ -140,7 +142,7 @@
              float f = 0.5F;
              double d0 = (double)(p_180635_0_.field_73012_v.nextFloat() * 0.5F) + 0.25D;
              double d1 = (double)(p_180635_0_.field_73012_v.nextFloat() * 0.5F) + 0.25D;
-@@ -619,6 +618,7 @@
+@@ -619,6 +620,7 @@
          return 0;
      }
  
@@ -148,7 +150,7 @@
      public float func_149638_a(Entity p_149638_1_)
      {
          return this.field_149781_w / 5.0F;
-@@ -657,7 +657,7 @@
+@@ -657,7 +659,7 @@
  
      public boolean func_176196_c(World p_176196_1_, BlockPos p_176196_2_)
      {
@@ -157,7 +159,7 @@
      }
  
      public boolean func_180639_a(World p_180639_1_, BlockPos p_180639_2_, IBlockState p_180639_3_, EntityPlayer p_180639_4_, EnumHand p_180639_5_, EnumFacing p_180639_6_, float p_180639_7_, float p_180639_8_, float p_180639_9_)
-@@ -669,6 +669,8 @@
+@@ -669,6 +671,8 @@
      {
      }
  
@@ -166,7 +168,7 @@
      public IBlockState func_180642_a(World p_180642_1_, BlockPos p_180642_2_, EnumFacing p_180642_3_, float p_180642_4_, float p_180642_5_, float p_180642_6_, int p_180642_7_, EntityLivingBase p_180642_8_)
      {
          return this.func_176203_a(p_180642_7_);
-@@ -710,21 +712,35 @@
+@@ -710,21 +714,37 @@
          p_180657_2_.func_71029_a(StatList.func_188055_a(this));
          p_180657_2_.func_71020_j(0.005F);
  
@@ -182,7 +184,7 @@
 +                items.add(itemstack);
 +            }
 +
-+            net.minecraftforge.event.ForgeEventFactory.fireBlockHarvesting(items, p_180657_1_, p_180657_3_, p_180657_4_, 0, 1.0f, true, p_180657_2_);
++            net.minecraftforge.event.ForgeEventFactory.fireBlockHarvesting(items, p_180657_1_, p_180657_3_, p_180657_4_, 0, 1.0f, true, p_180657_2_, p_180657_5_);
 +            for (ItemStack item : items)
 +            {
 +                func_180635_a(p_180657_1_, p_180657_3_, item);
@@ -191,8 +193,10 @@
          else
          {
 +            harvesters.set(p_180657_2_);
++            harvestTileEntity.set(p_180657_5_);
              int i = EnchantmentHelper.func_77506_a(Enchantments.field_185308_t, p_180657_6_);
              this.func_176226_b(p_180657_1_, p_180657_3_, p_180657_4_, i);
++            harvestTileEntity.set(null);
 +            harvesters.set(null);
          }
      }
@@ -205,7 +209,7 @@
      }
  
      protected ItemStack func_180643_i(IBlockState p_180643_1_)
-@@ -810,6 +826,7 @@
+@@ -810,6 +830,7 @@
          p_176216_2_.field_70181_x = 0.0D;
      }
  
@@ -213,7 +217,7 @@
      public ItemStack func_185473_a(World p_185473_1_, BlockPos p_185473_2_, IBlockState p_185473_3_)
      {
          return new ItemStack(Item.func_150898_a(this), 1, this.func_180651_a(p_185473_3_));
-@@ -919,6 +936,7 @@
+@@ -919,6 +940,7 @@
          }
      }
  
@@ -221,13 +225,14 @@
      public SoundType func_185467_w()
      {
          return this.field_149762_H;
-@@ -934,6 +952,1345 @@
+@@ -934,6 +956,1365 @@
      {
      }
  
 +    /* ======================================== FORGE START =====================================*/
 +    //For ForgeInternal use Only!
 +    protected ThreadLocal<EntityPlayer> harvesters = new ThreadLocal();
++    protected ThreadLocal<TileEntity> harvestTileEntity = new ThreadLocal<>();
 +    private ThreadLocal<IBlockState> silk_check_state = new ThreadLocal();
 +    protected static java.util.Random RANDOM = new java.util.Random(); // Useful for random things without a seed.
 +
@@ -564,7 +569,7 @@
 +    }
 +
 +    /**
-+     * @deprecated use {@link #getDrops(NonNullList, IBlockAccess, BlockPos, IBlockState, int)}
++     * @deprecated use {@link #getDrops(NonNullList, IBlockAccess, BlockPos, IBlockState, int, EntityPlayer, TileEntity)}
 +     */
 +    @Deprecated
 +    public List<ItemStack> getDrops(IBlockAccess world, BlockPos pos, IBlockState state, int fortune)
@@ -582,7 +587,10 @@
 +     * @param pos Block position in world
 +     * @param state Current state
 +     * @param fortune Breakers fortune level
++     *
++     * @deprecated use {@link #getDrops(NonNullList, IBlockAccess, BlockPos, IBlockState, int, EntityPlayer, TileEntity)}
 +     */
++    @Deprecated
 +    public void getDrops(NonNullList<ItemStack> drops, IBlockAccess world, BlockPos pos, IBlockState state, int fortune)
 +    {
 +        Random rand = world instanceof World ? ((World)world).field_73012_v : RANDOM;
@@ -596,6 +604,22 @@
 +                drops.add(new ItemStack(item, 1, this.func_180651_a(state)));
 +            }
 +        }
++    }
++
++    /**
++     * This gets a complete list of items dropped from this block.
++     *
++     * @param drops add all items this block drops to this drops list
++     * @param world The current world
++     * @param pos Block position in world
++     * @param state Current state
++     * @param fortune Breakers fortune level
++     * @param player The harvester
++     * @param tileEntity The TileEntity of the harvested block. Even if world.getTileEntity(pos) equals null, this hasn't to be null too.
++     */
++    public void getDrops(NonNullList<ItemStack> drops, IBlockAccess world, BlockPos pos, IBlockState state, int fortune, EntityPlayer player, @Nullable TileEntity tileEntity)
++    {
++        drops.addAll(this.getDrops(world, pos, state, fortune)); // use the old method until it gets removed, for backward compatibility
 +    }
 +
 +    /**
@@ -1567,7 +1591,7 @@
      public static void func_149671_p()
      {
          func_176215_a(0, field_176230_a, (new BlockAir()).func_149663_c("air"));
-@@ -1230,31 +2587,6 @@
+@@ -1230,31 +2611,6 @@
                  block15.field_149783_u = flag;
              }
          }

--- a/patches/minecraft/net/minecraft/block/BlockIce.java.patch
+++ b/patches/minecraft/net/minecraft/block/BlockIce.java.patch
@@ -11,7 +11,7 @@
 +            java.util.List<ItemStack> items = new java.util.ArrayList<ItemStack>();
 +            items.add(this.func_180643_i(p_180657_4_));
 +
-+            net.minecraftforge.event.ForgeEventFactory.fireBlockHarvesting(items, p_180657_1_, p_180657_3_, p_180657_4_, 0, 1.0f, true, p_180657_2_);
++            net.minecraftforge.event.ForgeEventFactory.fireBlockHarvesting(items, p_180657_1_, p_180657_3_, p_180657_4_, 0, 1.0f, true, p_180657_2_, p_180657_5_);
 +            for (ItemStack is : items)
 +                func_180635_a(p_180657_1_, p_180657_3_, is);
          }

--- a/src/main/java/net/minecraftforge/event/ForgeEventFactory.java
+++ b/src/main/java/net/minecraftforge/event/ForgeEventFactory.java
@@ -310,9 +310,15 @@ public class ForgeEventFactory
         return event.getDisplayname();
     }
 
+    @Deprecated // Remove in 1.13
     public static float fireBlockHarvesting(List<ItemStack> drops, World world, BlockPos pos, IBlockState state, int fortune, float dropChance, boolean silkTouch, EntityPlayer player)
     {
-        BlockEvent.HarvestDropsEvent event = new BlockEvent.HarvestDropsEvent(world, pos, state, fortune, dropChance, drops, player, silkTouch);
+        return fireBlockHarvesting(drops, world, pos, state, fortune, dropChance, silkTouch, player, null);
+    }
+
+    public static float fireBlockHarvesting(List<ItemStack> drops, World world, BlockPos pos, IBlockState state, int fortune, float dropChance, boolean silkTouch, EntityPlayer player, @Nullable TileEntity tileEntity)
+    {
+        BlockEvent.HarvestDropsEvent event = new BlockEvent.HarvestDropsEvent(world, pos, state, fortune, dropChance, drops, player, silkTouch, tileEntity);
         MinecraftForge.EVENT_BUS.post(event);
         return event.getDropChance();
     }

--- a/src/main/java/net/minecraftforge/event/world/BlockEvent.java
+++ b/src/main/java/net/minecraftforge/event/world/BlockEvent.java
@@ -27,6 +27,7 @@ import net.minecraft.enchantment.EnchantmentHelper;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.init.Enchantments;
 import net.minecraft.item.ItemStack;
+import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.EnumHand;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.EnumFacing;
@@ -39,6 +40,7 @@ import net.minecraftforge.fml.common.eventhandler.Event;
 import com.google.common.collect.ImmutableList;
 
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 
 public class BlockEvent extends Event
 {
@@ -87,8 +89,14 @@ public class BlockEvent extends Event
         private final boolean isSilkTouching;
         private float dropChance; // Change to e.g. 1.0f, if you manipulate the list and want to guarantee it always drops
         private final EntityPlayer harvester; // May be null for non-player harvesting such as explosions or machines
+        private final TileEntity tileEntity;
 
         public HarvestDropsEvent(World world, BlockPos pos, IBlockState state, int fortuneLevel, float dropChance, List<ItemStack> drops, EntityPlayer harvester, boolean isSilkTouching)
+        {
+            this(world, pos, state, fortuneLevel, dropChance, drops, harvester, isSilkTouching, null);
+        }
+
+        public HarvestDropsEvent(World world, BlockPos pos, IBlockState state, int fortuneLevel, float dropChance, List<ItemStack> drops, EntityPlayer harvester, boolean isSilkTouching, @Nullable TileEntity tileEntity)
         {
             super(world, pos, state);
             this.fortuneLevel = fortuneLevel;
@@ -96,6 +104,7 @@ public class BlockEvent extends Event
             this.drops = drops;
             this.isSilkTouching = isSilkTouching;
             this.harvester = harvester;
+            this.tileEntity = tileEntity;
         }
 
         public int getFortuneLevel() { return fortuneLevel; }
@@ -104,6 +113,7 @@ public class BlockEvent extends Event
         public float getDropChance() { return dropChance; }
         public void setDropChance(float dropChance) { this.dropChance = dropChance; }
         public EntityPlayer getHarvester() { return harvester; }
+        @Nullable public TileEntity getTileEntity() { return tileEntity; }
     }
 
     /**


### PR DESCRIPTION
This pr is a new version of #4717 since my fork got fucked up completly.

This pr does add a TileEntity parameter to the Block.getDrops method. The old methods are still there to not break mods. It also adds a TileEntity variable to the HarvestBlock Event.
This is is important, cause like already tolded in #4674 , the trying to get the TileEntity with world.getTileEntity is null everytime. This is caused by Minecraft, who does remove the TileEntity before getDrops is called. This can be changed with some trickery, without this pr, but this would cause more or less a mess in all mods, since most mods wants to drop some things, depending on the TileEntity.