### PR TITLE
Allow custom models to have per-state lighting

### DIFF
--- a/patches/minecraft/net/minecraft/client/renderer/BlockModelRenderer.java.patch
+++ b/patches/minecraft/net/minecraft/client/renderer/BlockModelRenderer.java.patch
@@ -5,7 +5,7 @@
      public boolean func_187493_a(IBlockAccess p_187493_1_, IBakedModel p_187493_2_, IBlockState p_187493_3_, BlockPos p_187493_4_, BufferBuilder p_187493_5_, boolean p_187493_6_, long p_187493_7_)
      {
 -        boolean flag = Minecraft.func_71379_u() && p_187493_3_.func_185906_d() == 0 && p_187493_2_.func_177555_b();
-+        boolean flag = Minecraft.func_71379_u() && p_187493_3_.getLightValue(p_187493_1_, p_187493_4_) == 0 && p_187493_2_.func_177555_b();
++        boolean flag = Minecraft.func_71379_u() && p_187493_3_.getLightValue(p_187493_1_, p_187493_4_) == 0 && p_187493_2_.isAmbientOcclusion(p_187493_3_);
  
          try
          {

--- a/patches/minecraft/net/minecraft/client/renderer/block/model/IBakedModel.java.patch
+++ b/patches/minecraft/net/minecraft/client/renderer/block/model/IBakedModel.java.patch
@@ -1,6 +1,6 @@
 --- ../src-base/minecraft/net/minecraft/client/renderer/block/model/IBakedModel.java
 +++ ../src-work/minecraft/net/minecraft/client/renderer/block/model/IBakedModel.java
-@@ -21,7 +21,16 @@
+@@ -21,7 +21,18 @@
  
      TextureAtlasSprite func_177554_e();
  
@@ -9,6 +9,8 @@
 +    default ItemCameraTransforms func_177552_f() { return ItemCameraTransforms.field_178357_a; }
  
      ItemOverrideList func_188617_f();
++
++    default boolean isAmbientOcclusion(IBlockState state) { return func_177555_b(); }
 +
 +    /*
 +     * Returns the pair of the model for the given perspective, and the matrix

--- a/patches/minecraft/net/minecraft/client/renderer/block/model/SimpleBakedModel.java.patch
+++ b/patches/minecraft/net/minecraft/client/renderer/block/model/SimpleBakedModel.java.patch
@@ -1,0 +1,11 @@
+--- ../src-base/minecraft/net/minecraft/client/renderer/block/model/SimpleBakedModel.java
++++ ../src-work/minecraft/net/minecraft/client/renderer/block/model/SimpleBakedModel.java
+@@ -88,7 +88,7 @@
+ 
+             public Builder(IBlockState p_i46989_1_, IBakedModel p_i46989_2_, TextureAtlasSprite p_i46989_3_, BlockPos p_i46989_4_)
+             {
+-                this(p_i46989_2_.func_177555_b(), p_i46989_2_.func_177556_c(), p_i46989_2_.func_177552_f(), p_i46989_2_.func_188617_f());
++                this(p_i46989_2_.isAmbientOcclusion(p_i46989_1_), p_i46989_2_.func_177556_c(), p_i46989_2_.func_177552_f(), p_i46989_2_.func_188617_f());
+                 this.field_177652_d = p_i46989_2_.func_177554_e();
+                 long i = MathHelper.func_180186_a(p_i46989_4_);
+ 

--- a/patches/minecraft/net/minecraft/client/renderer/block/model/WeightedBakedModel.java.patch
+++ b/patches/minecraft/net/minecraft/client/renderer/block/model/WeightedBakedModel.java.patch
@@ -1,0 +1,11 @@
+--- ../src-base/minecraft/net/minecraft/client/renderer/block/model/WeightedBakedModel.java
++++ ../src-work/minecraft/net/minecraft/client/renderer/block/model/WeightedBakedModel.java
+@@ -41,6 +41,8 @@
+         return this.field_177566_c.func_177555_b();
+     }
+ 
++    public boolean isAmbientOcclusion(IBlockState state) { return this.field_177566_c.isAmbientOcclusion(state); }
++
+     public boolean func_177556_c()
+     {
+         return this.field_177566_c.func_177556_c();

--- a/src/main/java/net/minecraftforge/client/model/BakedModelWrapper.java
+++ b/src/main/java/net/minecraftforge/client/model/BakedModelWrapper.java
@@ -53,6 +53,12 @@ public abstract class BakedModelWrapper<T extends IBakedModel> implements IBaked
     }
 
     @Override
+    public boolean isAmbientOcclusion(IBlockState state)
+    {
+        return originalModel.isAmbientOcclusion(state);
+    }
+
+    @Override
     public boolean isGui3d()
     {
         return originalModel.isGui3d();

--- a/src/main/java/net/minecraftforge/client/model/MultiLayerModel.java
+++ b/src/main/java/net/minecraftforge/client/model/MultiLayerModel.java
@@ -182,6 +182,12 @@ public final class MultiLayerModel implements IModel
         }
 
         @Override
+        public boolean isAmbientOcclusion(IBlockState state)
+        {
+            return base.isAmbientOcclusion(state);
+        }
+
+        @Override
         public boolean isGui3d()
         {
             return base.isGui3d();

--- a/src/main/java/net/minecraftforge/client/model/MultiModel.java
+++ b/src/main/java/net/minecraftforge/client/model/MultiModel.java
@@ -151,6 +151,12 @@ public final class MultiModel implements IModel
         }
 
         @Override
+        public boolean isAmbientOcclusion(IBlockState state)
+        {
+            return internalBase.isAmbientOcclusion(state);
+        }
+
+        @Override
         public boolean isGui3d()
         {
             return internalBase.isGui3d();

--- a/src/main/java/net/minecraftforge/client/model/PerspectiveMapWrapper.java
+++ b/src/main/java/net/minecraftforge/client/model/PerspectiveMapWrapper.java
@@ -76,14 +76,15 @@ public class PerspectiveMapWrapper implements IBakedModel
         return Pair.of(model, null);
     }
 
-    public boolean isAmbientOcclusion() { return parent.isAmbientOcclusion(); }
-    public boolean isGui3d() { return parent.isGui3d(); }
-    public boolean isBuiltInRenderer() { return parent.isBuiltInRenderer(); }
-    public TextureAtlasSprite getParticleTexture() { return parent.getParticleTexture(); }
+    @Override public boolean isAmbientOcclusion() { return parent.isAmbientOcclusion(); }
+    @Override public boolean isAmbientOcclusion(IBlockState state) { return parent.isAmbientOcclusion(state); }
+    @Override public boolean isGui3d() { return parent.isGui3d(); }
+    @Override public boolean isBuiltInRenderer() { return parent.isBuiltInRenderer(); }
+    @Override public TextureAtlasSprite getParticleTexture() { return parent.getParticleTexture(); }
     @SuppressWarnings("deprecation")
-    public ItemCameraTransforms getItemCameraTransforms() { return parent.getItemCameraTransforms(); }
-    public List<BakedQuad> getQuads(@Nullable IBlockState state, @Nullable EnumFacing side, long rand) { return parent.getQuads(state, side, rand); }
-    public ItemOverrideList getOverrides() { return parent.getOverrides(); }
+    @Override public ItemCameraTransforms getItemCameraTransforms() { return parent.getItemCameraTransforms(); }
+    @Override public List<BakedQuad> getQuads(@Nullable IBlockState state, @Nullable EnumFacing side, long rand) { return parent.getQuads(state, side, rand); }
+    @Override public ItemOverrideList getOverrides() { return parent.getOverrides(); }
 
     @Override
     public Pair<? extends IBakedModel, Matrix4f> handlePerspective(ItemCameraTransforms.TransformType cameraTransformType)


### PR DESCRIPTION
Intended for custom `IBakedModel` implementations, to make it easy to support flat/smooth lighting depending on the blockstate. Mainly to make things like having a general "mimic" model easier.

Not strictly necessary, but it only requires a few changes, so it's hopefully still worthwhile.