### PR TITLE
Add an event to control nether portal formation

### DIFF
--- a/patches/minecraft/net/minecraft/block/BlockPortal.java.patch
+++ b/patches/minecraft/net/minecraft/block/BlockPortal.java.patch
@@ -1,0 +1,11 @@
+--- ../src-base/minecraft/net/minecraft/block/BlockPortal.java
++++ ../src-work/minecraft/net/minecraft/block/BlockPortal.java
+@@ -109,6 +109,8 @@
+ 
+     public boolean func_176548_d(World p_176548_1_, BlockPos p_176548_2_)
+     {
++        if (net.minecraftforge.event.ForgeEventFactory.onTrySpawnPortal(p_176548_1_, p_176548_2_)) return false;
++
+         BlockPortal.Size blockportal$size = new BlockPortal.Size(p_176548_1_, p_176548_2_, EnumFacing.Axis.X);
+ 
+         if (blockportal$size.func_150860_b() && blockportal$size.field_150864_e == 0)

--- a/patches/minecraft/net/minecraft/block/BlockPortal.java.patch
+++ b/patches/minecraft/net/minecraft/block/BlockPortal.java.patch
@@ -1,11 +1,20 @@
 --- ../src-base/minecraft/net/minecraft/block/BlockPortal.java
 +++ ../src-work/minecraft/net/minecraft/block/BlockPortal.java
-@@ -109,6 +109,8 @@
- 
-     public boolean func_176548_d(World p_176548_1_, BlockPos p_176548_2_)
+@@ -111,7 +111,7 @@
      {
-+        if (net.minecraftforge.event.ForgeEventFactory.onTrySpawnPortal(p_176548_1_, p_176548_2_)) return false;
-+
          BlockPortal.Size blockportal$size = new BlockPortal.Size(p_176548_1_, p_176548_2_, EnumFacing.Axis.X);
  
-         if (blockportal$size.func_150860_b() && blockportal$size.field_150864_e == 0)
+-        if (blockportal$size.func_150860_b() && blockportal$size.field_150864_e == 0)
++        if (blockportal$size.func_150860_b() && blockportal$size.field_150864_e == 0 && !net.minecraftforge.event.ForgeEventFactory.onTrySpawnPortal(p_176548_1_, p_176548_2_, blockportal$size))
+         {
+             blockportal$size.func_150859_c();
+             return true;
+@@ -120,7 +120,7 @@
+         {
+             BlockPortal.Size blockportal$size1 = new BlockPortal.Size(p_176548_1_, p_176548_2_, EnumFacing.Axis.Z);
+ 
+-            if (blockportal$size1.func_150860_b() && blockportal$size1.field_150864_e == 0)
++            if (blockportal$size1.func_150860_b() && blockportal$size1.field_150864_e == 0 && !net.minecraftforge.event.ForgeEventFactory.onTrySpawnPortal(p_176548_1_, p_176548_2_, blockportal$size1))
+             {
+                 blockportal$size1.func_150859_c();
+                 return true;

--- a/src/main/java/net/minecraftforge/event/ForgeEventFactory.java
+++ b/src/main/java/net/minecraftforge/event/ForgeEventFactory.java
@@ -24,6 +24,7 @@ import java.util.EnumSet;
 import java.util.List;
 import java.util.Random;
 
+import net.minecraft.block.BlockPortal;
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.client.util.ITooltipFlag;
 import net.minecraft.entity.Entity;
@@ -739,9 +740,9 @@ public class ForgeEventFactory
         return result == Result.DEFAULT ? def : result == Result.ALLOW;
     }
 
-    public static boolean onTrySpawnPortal(World world, BlockPos pos)
+    public static boolean onTrySpawnPortal(World world, BlockPos pos, BlockPortal.Size size)
     {
-        return MinecraftForge.EVENT_BUS.post(new BlockEvent.PortalSpawnEvent(world, pos, world.getBlockState(pos)));
+        return MinecraftForge.EVENT_BUS.post(new BlockEvent.PortalSpawnEvent(world, pos, world.getBlockState(pos), size));
     }
 
     public static int onEnchantmentLevelSet(World world, BlockPos pos, int enchantRow, int power, ItemStack itemStack, int level)

--- a/src/main/java/net/minecraftforge/event/ForgeEventFactory.java
+++ b/src/main/java/net/minecraftforge/event/ForgeEventFactory.java
@@ -739,6 +739,11 @@ public class ForgeEventFactory
         return result == Result.DEFAULT ? def : result == Result.ALLOW;
     }
 
+    public static boolean onTrySpawnPortal(World world, BlockPos pos)
+    {
+        return MinecraftForge.EVENT_BUS.post(new BlockEvent.PortalSpawnEvent(world, pos, world.getBlockState(pos)));
+    }
+
     public static int onEnchantmentLevelSet(World world, BlockPos pos, int enchantRow, int power, ItemStack itemStack, int level)
     {
         net.minecraftforge.event.enchanting.EnchantmentLevelSetEvent e = new net.minecraftforge.event.enchanting.EnchantmentLevelSetEvent(world, pos, enchantRow, power, itemStack, level);

--- a/src/main/java/net/minecraftforge/event/world/BlockEvent.java
+++ b/src/main/java/net/minecraftforge/event/world/BlockEvent.java
@@ -22,6 +22,7 @@ package net.minecraftforge.event.world;
 import java.util.EnumSet;
 import java.util.List;
 
+import net.minecraft.block.BlockPortal;
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.enchantment.EnchantmentHelper;
 import net.minecraft.entity.player.EntityPlayer;
@@ -348,9 +349,17 @@ public class BlockEvent extends Event
     @Cancelable
     public static class PortalSpawnEvent extends BlockEvent
     {
-        public PortalSpawnEvent(World world, BlockPos pos, IBlockState state)
+        private final BlockPortal.Size size;
+
+        public PortalSpawnEvent(World world, BlockPos pos, IBlockState state, BlockPortal.Size size)
         {
             super(world, pos, state);
+            this.size = size;
+        }
+
+        public BlockPortal.Size getPortalSize()
+        {
+            return size;
         }
     }
 }

--- a/src/main/java/net/minecraftforge/event/world/BlockEvent.java
+++ b/src/main/java/net/minecraftforge/event/world/BlockEvent.java
@@ -338,4 +338,19 @@ public class BlockEvent extends Event
             }
         }
     }
+
+    /**
+     * Fired when an attempt is made to spawn a nether portal from
+     * {@link net.minecraft.block.BlockPortal#trySpawnPortal(World, BlockPos)}.
+     *
+     * If cancelled, the portal will not be spawned.
+     */
+    @Cancelable
+    public static class PortalSpawnEvent extends BlockEvent
+    {
+        public PortalSpawnEvent(World world, BlockPos pos, IBlockState state)
+        {
+            super(world, pos, state);
+        }
+    }
 }

--- a/src/test/java/net/minecraftforge/debug/PortalSpawnEventTest.java
+++ b/src/test/java/net/minecraftforge/debug/PortalSpawnEventTest.java
@@ -1,0 +1,27 @@
+package net.minecraftforge.debug;
+
+import net.minecraft.init.Biomes;
+import net.minecraft.world.World;
+import net.minecraftforge.event.world.BlockEvent;
+import net.minecraftforge.fml.common.Mod;
+import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
+
+@Mod(modid = PortalSpawnEventTest.MOD_ID, name = "PortalSpawnEvent test mod", version = "1.0", acceptableRemoteVersions = "*")
+@Mod.EventBusSubscriber
+public class PortalSpawnEventTest
+{
+    static final String MOD_ID = "portal_spawn_event_test";
+    static final boolean ENABLED = false;
+
+    @SubscribeEvent
+    public static void onTrySpawnPortal(BlockEvent.PortalSpawnEvent event)
+    {
+        if (!ENABLED) return;
+
+        World world = event.getWorld();
+        if (world.provider.getDimension() == 0 && world.getBiome(event.getPos()) != Biomes.EXTREME_HILLS)
+        {
+            event.setCanceled(true);
+        }
+    }
+}


### PR DESCRIPTION
This allows mods to control nether portal formation, which can be used, for example, to restrict access to the nether until some condition is met.

A small test mod is included to demonstrate this.