### PR TITLE
Fixed the reach distance to work with entities as well as blocks.

### DIFF
--- a/patches/minecraft/net/minecraft/client/multiplayer/PlayerControllerMP.java.patch
+++ b/patches/minecraft/net/minecraft/client/multiplayer/PlayerControllerMP.java.patch
@@ -95,17 +95,16 @@
                      this.field_78776_a.func_147118_V().func_147682_a(new PositionedSoundRecord(soundtype.func_185846_f(), SoundCategory.NEUTRAL, (soundtype.func_185843_a() + 1.0F) / 8.0F, soundtype.func_185847_b() * 0.5F, p_180512_1_));
                  }
  
-@@ -326,7 +337,8 @@
+@@ -326,7 +337,7 @@
  
      public float func_78757_d()
      {
 -        return this.field_78779_k.func_77145_d() ? 5.0F : 4.5F;
-+        float attrib = (float) field_78776_a.field_71439_g.func_110148_a(EntityPlayer.REACH_DISTANCE).func_111126_e();
-+        return this.field_78779_k.func_77145_d() ? attrib : attrib - 0.5F;
++        return net.minecraftforge.common.ForgeHooks.getPlayerReachDistance(this.field_78776_a.field_71439_g);
      }
  
      public void func_78765_e()
-@@ -350,7 +362,7 @@
+@@ -350,7 +361,7 @@
  
          if (!this.field_85183_f.func_190926_b() && !itemstack.func_190926_b())
          {
@@ -114,7 +113,7 @@
          }
  
          return p_178893_1_.equals(this.field_178895_c) && flag;
-@@ -382,13 +394,34 @@
+@@ -382,13 +393,34 @@
          }
          else
          {
@@ -151,7 +150,7 @@
                  }
  
                  if (!flag && itemstack.func_77973_b() instanceof ItemBlock)
-@@ -404,7 +437,7 @@
+@@ -404,7 +436,7 @@
  
              this.field_78774_b.func_147297_a(new CPacketPlayerTryUseItemOnBlock(p_187099_3_, p_187099_4_, p_187099_6_, f, f1, f2));
  
@@ -160,7 +159,7 @@
              {
                  if (itemstack.func_190926_b())
                  {
-@@ -430,14 +463,20 @@
+@@ -430,14 +462,20 @@
                      {
                          int i = itemstack.func_77960_j();
                          int j = itemstack.func_190916_E();
@@ -182,7 +181,7 @@
                      }
                  }
              }
-@@ -466,6 +505,8 @@
+@@ -466,6 +504,8 @@
              }
              else
              {
@@ -191,7 +190,7 @@
                  int i = itemstack.func_190916_E();
                  ActionResult<ItemStack> actionresult = itemstack.func_77957_a(p_187101_2_, p_187101_1_, p_187101_3_);
                  ItemStack itemstack1 = actionresult.func_188398_b();
-@@ -473,6 +514,10 @@
+@@ -473,6 +513,10 @@
                  if (itemstack1 != itemstack || itemstack1.func_190916_E() != i)
                  {
                      p_187101_1_.func_184611_a(p_187101_3_, itemstack1);
@@ -202,7 +201,7 @@
                  }
  
                  return actionresult.func_188397_a();
-@@ -509,6 +554,9 @@
+@@ -509,6 +553,9 @@
          this.func_78750_j();
          Vec3d vec3d = new Vec3d(p_187102_3_.field_72307_f.field_72450_a - p_187102_2_.field_70165_t, p_187102_3_.field_72307_f.field_72448_b - p_187102_2_.field_70163_u, p_187102_3_.field_72307_f.field_72449_c - p_187102_2_.field_70161_v);
          this.field_78774_b.func_147297_a(new CPacketUseEntity(p_187102_2_, p_187102_4_, vec3d));

--- a/patches/minecraft/net/minecraft/client/renderer/EntityRenderer.java.patch
+++ b/patches/minecraft/net/minecraft/client/renderer/EntityRenderer.java.patch
@@ -17,7 +17,40 @@
          float f4 = (float)this.field_78531_r.field_71474_y.field_151451_c / 32.0F;
          float f2 = f3 * (1.0F - f4) + f4;
          this.field_78539_ae += (f2 - this.field_78539_ae) * 0.1F;
-@@ -412,7 +413,7 @@
+@@ -355,23 +356,9 @@
+                 double d0 = (double)this.field_78531_r.field_71442_b.func_78757_d();
+                 this.field_78531_r.field_71476_x = entity.func_174822_a(d0, p_78473_1_);
+                 Vec3d vec3d = entity.func_174824_e(p_78473_1_);
+-                boolean flag = false;
+                 int i = 3;
+                 double d1 = d0;
+ 
+-                if (this.field_78531_r.field_71442_b.func_78749_i())
+-                {
+-                    d1 = 6.0D;
+-                    d0 = d1;
+-                }
+-                else
+-                {
+-                    if (d0 > 3.0D)
+-                    {
+-                        flag = true;
+-                    }
+-                }
+-
+                 if (this.field_78531_r.field_71476_x != null)
+                 {
+                     d1 = this.field_78531_r.field_71476_x.field_72307_f.func_72438_d(vec3d);
+@@ -389,7 +376,7 @@
+                         return p_apply_1_ != null && p_apply_1_.func_70067_L();
+                     }
+                 }));
+-                double d2 = d1;
++                double d2 = d0;
+ 
+                 for (int j = 0; j < list.size(); ++j)
+                 {
+@@ -412,7 +399,7 @@
  
                          if (d3 < d2 || d2 == 0.0D)
                          {
@@ -26,7 +59,23 @@
                              {
                                  if (d2 == 0.0D)
                                  {
-@@ -505,7 +506,7 @@
+@@ -430,13 +417,13 @@
+                     }
+                 }
+ 
+-                if (this.field_78528_u != null && flag && vec3d.func_72438_d(vec3d3) > 3.0D)
++                if (this.field_78528_u != null && vec3d.func_72438_d(vec3d3) > d0)
+                 {
+                     this.field_78528_u = null;
+                     this.field_78531_r.field_71476_x = new RayTraceResult(RayTraceResult.Type.MISS, vec3d3, (EnumFacing)null, new BlockPos(vec3d3));
+                 }
+ 
+-                if (this.field_78528_u != null && (d2 < d1 || this.field_78531_r.field_71476_x == null))
++                if (this.field_78528_u != null && (d2 < d0 || this.field_78531_r.field_71476_x == null))
+                 {
+                     this.field_78531_r.field_71476_x = new RayTraceResult(this.field_78528_u, vec3d3);
+ 
+@@ -505,7 +492,7 @@
                  f = f * 60.0F / 70.0F;
              }
  
@@ -35,7 +84,7 @@
          }
      }
  
-@@ -569,14 +570,8 @@
+@@ -569,14 +556,8 @@
              {
                  BlockPos blockpos = new BlockPos(entity);
                  IBlockState iblockstate = this.field_78531_r.field_71441_e.func_180495_p(blockpos);
@@ -51,7 +100,7 @@
                  GlStateManager.func_179114_b(entity.field_70126_B + (entity.field_70177_z - entity.field_70126_B) * p_78467_1_ + 180.0F, 0.0F, -1.0F, 0.0F);
                  GlStateManager.func_179114_b(entity.field_70127_C + (entity.field_70125_A - entity.field_70127_C) * p_78467_1_, -1.0F, 0.0F, 0.0F);
              }
-@@ -643,17 +638,20 @@
+@@ -643,17 +624,20 @@
  
          if (!this.field_78531_r.field_71474_y.field_74325_U)
          {
@@ -79,7 +128,7 @@
          }
  
          GlStateManager.func_179109_b(0.0F, -f, 0.0F);
-@@ -771,6 +769,7 @@
+@@ -771,6 +755,7 @@
  
              boolean flag = this.field_78531_r.func_175606_aa() instanceof EntityLivingBase && ((EntityLivingBase)this.field_78531_r.func_175606_aa()).func_70608_bn();
  
@@ -87,7 +136,7 @@
              if (this.field_78531_r.field_71474_y.field_74320_O == 0 && !flag && !this.field_78531_r.field_71474_y.field_74319_N && !this.field_78531_r.field_71442_b.func_78747_a())
              {
                  this.func_180436_i();
-@@ -875,6 +874,15 @@
+@@ -875,6 +860,15 @@
                          f10 = 0.25F + f7 * 0.75F;
                      }
  
@@ -103,7 +152,7 @@
                      if (this.field_78531_r.field_71439_g.func_70644_a(MobEffects.field_76439_r))
                      {
                          float f15 = this.func_180438_a(this.field_78531_r.field_71439_g, p_78472_1_);
-@@ -1101,6 +1109,10 @@
+@@ -1101,6 +1095,10 @@
                  GlStateManager.func_179096_D();
                  this.func_78478_c();
                  this.field_78510_Z = System.nanoTime();
@@ -114,7 +163,7 @@
              }
  
              if (this.field_78531_r.field_71462_r != null)
-@@ -1109,7 +1121,7 @@
+@@ -1109,7 +1107,7 @@
  
                  try
                  {
@@ -123,7 +172,7 @@
                  }
                  catch (Throwable throwable)
                  {
-@@ -1204,7 +1216,7 @@
+@@ -1204,7 +1202,7 @@
  
                      if (this.field_78531_r.field_71442_b.func_178889_l() == GameType.SPECTATOR)
                      {
@@ -132,7 +181,7 @@
                      }
                      else
                      {
-@@ -1329,7 +1341,9 @@
+@@ -1329,7 +1327,9 @@
              GlStateManager.func_179094_E();
              RenderHelper.func_74519_b();
              this.field_78531_r.field_71424_I.func_76318_c("entities");
@@ -142,7 +191,7 @@
              RenderHelper.func_74518_a();
              this.func_175072_h();
          }
-@@ -1342,6 +1356,7 @@
+@@ -1342,6 +1342,7 @@
              EntityPlayer entityplayer = (EntityPlayer)entity;
              GlStateManager.func_179118_c();
              this.field_78531_r.field_71424_I.func_76318_c("outline");
@@ -150,7 +199,7 @@
              renderglobal.func_72731_b(entityplayer, this.field_78531_r.field_71476_x, 0, p_175068_2_);
              GlStateManager.func_179141_d();
          }
-@@ -1388,6 +1403,17 @@
+@@ -1388,6 +1389,17 @@
          GlStateManager.func_179103_j(7425);
          this.field_78531_r.field_71424_I.func_76318_c("translucent");
          renderglobal.func_174977_a(BlockRenderLayer.TRANSLUCENT, (double)p_175068_2_, p_175068_1_, entity);
@@ -168,7 +217,7 @@
          GlStateManager.func_179103_j(7424);
          GlStateManager.func_179132_a(true);
          GlStateManager.func_179089_o();
-@@ -1400,6 +1426,9 @@
+@@ -1400,6 +1412,9 @@
              this.func_180437_a(renderglobal, p_175068_2_, p_175068_1_, d0, d1, d2);
          }
  
@@ -178,7 +227,7 @@
          this.field_78531_r.field_71424_I.func_76318_c("hand");
  
          if (this.field_175074_C)
-@@ -1515,6 +1544,13 @@
+@@ -1515,6 +1530,13 @@
  
      protected void func_78474_d(float p_78474_1_)
      {
@@ -192,7 +241,7 @@
          float f = this.field_78531_r.field_71441_e.func_72867_j(p_78474_1_);
  
          if (f > 0.0F)
-@@ -1749,30 +1785,17 @@
+@@ -1749,30 +1771,17 @@
              this.field_175082_R = (float)vec3d3.field_72448_b;
              this.field_175081_S = (float)vec3d3.field_72449_c;
          }
@@ -232,7 +281,7 @@
  
          float f13 = this.field_78535_ad + (this.field_78539_ae - this.field_78535_ad) * p_78466_1_;
          this.field_175080_Q *= f13;
-@@ -1830,6 +1853,9 @@
+@@ -1830,6 +1839,9 @@
                  f6 = 1.0F / this.field_175081_S;
              }
  
@@ -242,7 +291,7 @@
              this.field_175080_Q = this.field_175080_Q * (1.0F - f15) + this.field_175080_Q * f6 * f15;
              this.field_175082_R = this.field_175082_R * (1.0F - f15) + this.field_175082_R * f6 * f15;
              this.field_175081_S = this.field_175081_S * (1.0F - f15) + this.field_175081_S * f6 * f15;
-@@ -1845,6 +1871,13 @@
+@@ -1845,6 +1857,13 @@
              this.field_175081_S = f7;
          }
  
@@ -256,7 +305,7 @@
          GlStateManager.func_179082_a(this.field_175080_Q, this.field_175082_R, this.field_175081_S, 0.0F);
      }
  
-@@ -1855,7 +1888,9 @@
+@@ -1855,7 +1874,9 @@
          GlStateManager.func_187432_a(0.0F, -1.0F, 0.0F);
          GlStateManager.func_179131_c(1.0F, 1.0F, 1.0F, 1.0F);
          IBlockState iblockstate = ActiveRenderInfo.func_186703_a(this.field_78531_r.field_71441_e, entity, p_78468_2_);
@@ -267,7 +316,7 @@
          if (entity instanceof EntityLivingBase && ((EntityLivingBase)entity).func_70644_a(MobEffects.field_76440_q))
          {
              float f1 = 5.0F;
-@@ -1940,6 +1975,7 @@
+@@ -1940,6 +1961,7 @@
                  GlStateManager.func_179102_b(f * 0.05F);
                  GlStateManager.func_179153_c(Math.min(f, 192.0F) * 0.5F);
              }

--- a/patches/minecraft/net/minecraft/client/renderer/EntityRenderer.java.patch
+++ b/patches/minecraft/net/minecraft/client/renderer/EntityRenderer.java.patch
@@ -17,31 +17,15 @@
          float f4 = (float)this.field_78531_r.field_71474_y.field_151451_c / 32.0F;
          float f2 = f3 * (1.0F - f4) + f4;
          this.field_78539_ae += (f2 - this.field_78539_ae) * 0.1F;
-@@ -355,23 +356,9 @@
-                 double d0 = (double)this.field_78531_r.field_71442_b.func_78757_d();
-                 this.field_78531_r.field_71476_x = entity.func_174822_a(d0, p_78473_1_);
-                 Vec3d vec3d = entity.func_174824_e(p_78473_1_);
--                boolean flag = false;
+@@ -359,6 +360,7 @@
                  int i = 3;
                  double d1 = d0;
  
--                if (this.field_78531_r.field_71442_b.func_78749_i())
--                {
--                    d1 = 6.0D;
--                    d0 = d1;
--                }
--                else
--                {
--                    if (d0 > 3.0D)
--                    {
--                        flag = true;
--                    }
--                }
--
-                 if (this.field_78531_r.field_71476_x != null)
++                if (false)
+                 if (this.field_78531_r.field_71442_b.func_78749_i())
                  {
-                     d1 = this.field_78531_r.field_71476_x.field_72307_f.func_72438_d(vec3d);
-@@ -389,7 +376,7 @@
+                     d1 = 6.0D;
+@@ -389,7 +391,7 @@
                          return p_apply_1_ != null && p_apply_1_.func_70067_L();
                      }
                  }));
@@ -50,7 +34,7 @@
  
                  for (int j = 0; j < list.size(); ++j)
                  {
-@@ -412,7 +399,7 @@
+@@ -412,7 +414,7 @@
  
                          if (d3 < d2 || d2 == 0.0D)
                          {
@@ -59,7 +43,7 @@
                              {
                                  if (d2 == 0.0D)
                                  {
-@@ -430,13 +417,13 @@
+@@ -430,13 +432,13 @@
                      }
                  }
  
@@ -75,7 +59,7 @@
                  {
                      this.field_78531_r.field_71476_x = new RayTraceResult(this.field_78528_u, vec3d3);
  
-@@ -505,7 +492,7 @@
+@@ -505,7 +507,7 @@
                  f = f * 60.0F / 70.0F;
              }
  
@@ -84,7 +68,7 @@
          }
      }
  
-@@ -569,14 +556,8 @@
+@@ -569,14 +571,8 @@
              {
                  BlockPos blockpos = new BlockPos(entity);
                  IBlockState iblockstate = this.field_78531_r.field_71441_e.func_180495_p(blockpos);
@@ -100,7 +84,7 @@
                  GlStateManager.func_179114_b(entity.field_70126_B + (entity.field_70177_z - entity.field_70126_B) * p_78467_1_ + 180.0F, 0.0F, -1.0F, 0.0F);
                  GlStateManager.func_179114_b(entity.field_70127_C + (entity.field_70125_A - entity.field_70127_C) * p_78467_1_, -1.0F, 0.0F, 0.0F);
              }
-@@ -643,17 +624,20 @@
+@@ -643,17 +639,20 @@
  
          if (!this.field_78531_r.field_71474_y.field_74325_U)
          {
@@ -128,7 +112,7 @@
          }
  
          GlStateManager.func_179109_b(0.0F, -f, 0.0F);
-@@ -771,6 +755,7 @@
+@@ -771,6 +770,7 @@
  
              boolean flag = this.field_78531_r.func_175606_aa() instanceof EntityLivingBase && ((EntityLivingBase)this.field_78531_r.func_175606_aa()).func_70608_bn();
  
@@ -136,7 +120,7 @@
              if (this.field_78531_r.field_71474_y.field_74320_O == 0 && !flag && !this.field_78531_r.field_71474_y.field_74319_N && !this.field_78531_r.field_71442_b.func_78747_a())
              {
                  this.func_180436_i();
-@@ -875,6 +860,15 @@
+@@ -875,6 +875,15 @@
                          f10 = 0.25F + f7 * 0.75F;
                      }
  
@@ -152,7 +136,7 @@
                      if (this.field_78531_r.field_71439_g.func_70644_a(MobEffects.field_76439_r))
                      {
                          float f15 = this.func_180438_a(this.field_78531_r.field_71439_g, p_78472_1_);
-@@ -1101,6 +1095,10 @@
+@@ -1101,6 +1110,10 @@
                  GlStateManager.func_179096_D();
                  this.func_78478_c();
                  this.field_78510_Z = System.nanoTime();
@@ -163,7 +147,7 @@
              }
  
              if (this.field_78531_r.field_71462_r != null)
-@@ -1109,7 +1107,7 @@
+@@ -1109,7 +1122,7 @@
  
                  try
                  {
@@ -172,7 +156,7 @@
                  }
                  catch (Throwable throwable)
                  {
-@@ -1204,7 +1202,7 @@
+@@ -1204,7 +1217,7 @@
  
                      if (this.field_78531_r.field_71442_b.func_178889_l() == GameType.SPECTATOR)
                      {
@@ -181,7 +165,7 @@
                      }
                      else
                      {
-@@ -1329,7 +1327,9 @@
+@@ -1329,7 +1342,9 @@
              GlStateManager.func_179094_E();
              RenderHelper.func_74519_b();
              this.field_78531_r.field_71424_I.func_76318_c("entities");
@@ -191,7 +175,7 @@
              RenderHelper.func_74518_a();
              this.func_175072_h();
          }
-@@ -1342,6 +1342,7 @@
+@@ -1342,6 +1357,7 @@
              EntityPlayer entityplayer = (EntityPlayer)entity;
              GlStateManager.func_179118_c();
              this.field_78531_r.field_71424_I.func_76318_c("outline");
@@ -199,7 +183,7 @@
              renderglobal.func_72731_b(entityplayer, this.field_78531_r.field_71476_x, 0, p_175068_2_);
              GlStateManager.func_179141_d();
          }
-@@ -1388,6 +1389,17 @@
+@@ -1388,6 +1404,17 @@
          GlStateManager.func_179103_j(7425);
          this.field_78531_r.field_71424_I.func_76318_c("translucent");
          renderglobal.func_174977_a(BlockRenderLayer.TRANSLUCENT, (double)p_175068_2_, p_175068_1_, entity);
@@ -217,7 +201,7 @@
          GlStateManager.func_179103_j(7424);
          GlStateManager.func_179132_a(true);
          GlStateManager.func_179089_o();
-@@ -1400,6 +1412,9 @@
+@@ -1400,6 +1427,9 @@
              this.func_180437_a(renderglobal, p_175068_2_, p_175068_1_, d0, d1, d2);
          }
  
@@ -227,7 +211,7 @@
          this.field_78531_r.field_71424_I.func_76318_c("hand");
  
          if (this.field_175074_C)
-@@ -1515,6 +1530,13 @@
+@@ -1515,6 +1545,13 @@
  
      protected void func_78474_d(float p_78474_1_)
      {
@@ -241,7 +225,7 @@
          float f = this.field_78531_r.field_71441_e.func_72867_j(p_78474_1_);
  
          if (f > 0.0F)
-@@ -1749,30 +1771,17 @@
+@@ -1749,30 +1786,17 @@
              this.field_175082_R = (float)vec3d3.field_72448_b;
              this.field_175081_S = (float)vec3d3.field_72449_c;
          }
@@ -281,7 +265,7 @@
  
          float f13 = this.field_78535_ad + (this.field_78539_ae - this.field_78535_ad) * p_78466_1_;
          this.field_175080_Q *= f13;
-@@ -1830,6 +1839,9 @@
+@@ -1830,6 +1854,9 @@
                  f6 = 1.0F / this.field_175081_S;
              }
  
@@ -291,7 +275,7 @@
              this.field_175080_Q = this.field_175080_Q * (1.0F - f15) + this.field_175080_Q * f6 * f15;
              this.field_175082_R = this.field_175082_R * (1.0F - f15) + this.field_175082_R * f6 * f15;
              this.field_175081_S = this.field_175081_S * (1.0F - f15) + this.field_175081_S * f6 * f15;
-@@ -1845,6 +1857,13 @@
+@@ -1845,6 +1872,13 @@
              this.field_175081_S = f7;
          }
  
@@ -305,7 +289,7 @@
          GlStateManager.func_179082_a(this.field_175080_Q, this.field_175082_R, this.field_175081_S, 0.0F);
      }
  
-@@ -1855,7 +1874,9 @@
+@@ -1855,7 +1889,9 @@
          GlStateManager.func_187432_a(0.0F, -1.0F, 0.0F);
          GlStateManager.func_179131_c(1.0F, 1.0F, 1.0F, 1.0F);
          IBlockState iblockstate = ActiveRenderInfo.func_186703_a(this.field_78531_r.field_71441_e, entity, p_78468_2_);
@@ -316,7 +300,7 @@
          if (entity instanceof EntityLivingBase && ((EntityLivingBase)entity).func_70644_a(MobEffects.field_76440_q))
          {
              float f1 = 5.0F;
-@@ -1940,6 +1961,7 @@
+@@ -1940,6 +1976,7 @@
                  GlStateManager.func_179102_b(f * 0.05F);
                  GlStateManager.func_179153_c(Math.min(f, 192.0F) * 0.5F);
              }

--- a/patches/minecraft/net/minecraft/network/NetHandlerPlayServer.java.patch
+++ b/patches/minecraft/net/minecraft/network/NetHandlerPlayServer.java.patch
@@ -34,6 +34,24 @@
                  this.field_147367_d.func_184103_al().func_148544_a(itextcomponent, false);
              }
  
+@@ -1049,14 +1056,14 @@
+         if (entity != null)
+         {
+             boolean flag = this.field_147369_b.func_70685_l(entity);
+-            double d0 = 36.0D;
++            float d0 = net.minecraftforge.common.ForgeHooks.getPlayerReachDistance(this.field_147369_b);
+ 
+             if (!flag)
+             {
+-                d0 = 9.0D;
++                d0 = 3.0F;
+             }
+ 
+-            if (this.field_147369_b.func_70068_e(entity) < d0)
++            if (this.field_147369_b.func_70032_d(entity) - entity.func_174813_aQ().func_72320_b() < d0)
+             {
+                 if (p_147340_1_.func_149565_c() == CPacketUseEntity.Action.INTERACT)
+                 {
 @@ -1066,6 +1073,7 @@
                  else if (p_147340_1_.func_149565_c() == CPacketUseEntity.Action.INTERACT_AT)
                  {

--- a/patches/minecraft/net/minecraft/network/NetHandlerPlayServer.java.patch
+++ b/patches/minecraft/net/minecraft/network/NetHandlerPlayServer.java.patch
@@ -34,24 +34,15 @@
                  this.field_147367_d.func_184103_al().func_148544_a(itextcomponent, false);
              }
  
-@@ -1049,14 +1056,14 @@
+@@ -1049,7 +1056,7 @@
          if (entity != null)
          {
              boolean flag = this.field_147369_b.func_70685_l(entity);
 -            double d0 = 36.0D;
-+            float d0 = net.minecraftforge.common.ForgeHooks.getPlayerReachDistance(this.field_147369_b) + this.field_147369_b.func_70047_e() + (float)Math.max(entity.func_174813_aQ().field_72336_d - entity.func_174813_aQ().field_72340_a, Math.max(entity.func_174813_aQ().field_72337_e - entity.func_174813_aQ().field_72338_b, entity.func_174813_aQ().field_72334_f - entity.func_174813_aQ().field_72339_c));
++            double d0 = Math.pow(net.minecraftforge.common.ForgeHooks.getPlayerReachDistance(this.field_147369_b) + this.field_147369_b.func_70047_e() + (float)Math.max(entity.func_174813_aQ().field_72336_d - entity.func_174813_aQ().field_72340_a, Math.max(entity.func_174813_aQ().field_72337_e - entity.func_174813_aQ().field_72338_b, entity.func_174813_aQ().field_72334_f - entity.func_174813_aQ().field_72339_c)), 2);
  
              if (!flag)
              {
--                d0 = 9.0D;
-+                d0 = 3.0F;
-             }
- 
--            if (this.field_147369_b.func_70068_e(entity) < d0)
-+            if (this.field_147369_b.func_70032_d(entity) < d0)
-             {
-                 if (p_147340_1_.func_149565_c() == CPacketUseEntity.Action.INTERACT)
-                 {
 @@ -1066,6 +1073,7 @@
                  else if (p_147340_1_.func_149565_c() == CPacketUseEntity.Action.INTERACT_AT)
                  {

--- a/patches/minecraft/net/minecraft/network/NetHandlerPlayServer.java.patch
+++ b/patches/minecraft/net/minecraft/network/NetHandlerPlayServer.java.patch
@@ -39,7 +39,7 @@
          {
              boolean flag = this.field_147369_b.func_70685_l(entity);
 -            double d0 = 36.0D;
-+            float d0 = net.minecraftforge.common.ForgeHooks.getPlayerReachDistance(this.field_147369_b);
++            float d0 = net.minecraftforge.common.ForgeHooks.getPlayerReachDistance(this.field_147369_b) + this.field_147369_b.func_70047_e() + (float)Math.max(entity.func_174813_aQ().field_72336_d - entity.func_174813_aQ().field_72340_a, Math.max(entity.func_174813_aQ().field_72337_e - entity.func_174813_aQ().field_72338_b, entity.func_174813_aQ().field_72334_f - entity.func_174813_aQ().field_72339_c));
  
              if (!flag)
              {
@@ -48,7 +48,7 @@
              }
  
 -            if (this.field_147369_b.func_70068_e(entity) < d0)
-+            if (this.field_147369_b.func_70032_d(entity) - entity.func_174813_aQ().func_72320_b() < d0)
++            if (this.field_147369_b.func_70032_d(entity) < d0)
              {
                  if (p_147340_1_.func_149565_c() == CPacketUseEntity.Action.INTERACT)
                  {

--- a/src/main/java/net/minecraftforge/common/ForgeHooks.java
+++ b/src/main/java/net/minecraftforge/common/ForgeHooks.java
@@ -1386,9 +1386,9 @@ public class ForgeHooks
     {
         MinecraftForge.EVENT_BUS.post(new AdvancementEvent(player, advancement));
     }
-    
+
     public static float getPlayerReachDistance(EntityPlayer player) {
-    	float reach = (float) player.getEntityAttribute(EntityPlayer.REACH_DISTANCE).getAttributeValue();
+        float reach = (float) player.getEntityAttribute(EntityPlayer.REACH_DISTANCE).getAttributeValue();
         return player.isCreative() ? reach : reach - 0.5F;
     }
 }

--- a/src/main/java/net/minecraftforge/common/ForgeHooks.java
+++ b/src/main/java/net/minecraftforge/common/ForgeHooks.java
@@ -1387,7 +1387,8 @@ public class ForgeHooks
         MinecraftForge.EVENT_BUS.post(new AdvancementEvent(player, advancement));
     }
 
-    public static float getPlayerReachDistance(EntityPlayer player) {
+    public static float getPlayerReachDistance(EntityPlayer player)
+    {
         float reach = (float) player.getEntityAttribute(EntityPlayer.REACH_DISTANCE).getAttributeValue();
         return player.isCreative() ? reach : reach - 0.5F;
     }

--- a/src/main/java/net/minecraftforge/common/ForgeHooks.java
+++ b/src/main/java/net/minecraftforge/common/ForgeHooks.java
@@ -1386,4 +1386,9 @@ public class ForgeHooks
     {
         MinecraftForge.EVENT_BUS.post(new AdvancementEvent(player, advancement));
     }
+    
+    public static float getPlayerReachDistance(EntityPlayer player) {
+    	float reach = (float) player.getEntityAttribute(EntityPlayer.REACH_DISTANCE).getAttributeValue();
+        return player.isCreative() ? reach : reach - 0.5F;
+    }
 }


### PR DESCRIPTION
**Problem**

The new reach distance attribute works well with blocks, but doesn't work at all with entities.

In a mod I just updated, I used to add my own reach attribute, so seeing an official forge one is good. However, for the mod, I need it to work with entities. 

It would also generally be useful, for instance, for weapons that have a shorter and longer attack range, like daggers and spears.

**Solution**

I fixed the reach distance by fixing how the vanilla moused over entity is found. 

For client-server security, I also made sure the packet sent checks that the distance is valid server-side, to prevent reach hacks.

I did run into a small issue with that server-side check, since it checks the distance from the player to the entity from their positions (not from the player's eye height and the point on the entity's bounding box the player is looking at). So for large entities like ghasts, it didn't register that the ghast was close enough even though it was. 

To fix this, I made the check's distance the maximum it could be by adding the player's eye height and the biggest side of the entity's bounding box. If you can think of a better solution, let me know.

**Testing**

To test, you can give yourself an item like 
```/give @p diamond_chestplate 1 0 {AttributeModifiers:[{Name:reach, AttributeName:generic.reachDistance, Amount:10, Operation:0, Slot:chest, UUIDLeast:1, UUIDMost:1}]}```
and test that the reach works at the same distance for blocks and entities.

I also created a test world set up for testing it. If you want to see it, let me know the best way to share it.

**Compatability**

For forge clients connecting to a vanilla server, the packets will still work if the entity is within 6 blocks (or 3 without line of sight), as it normally works in vanilla.

The packets would also work for vanilla clients connecting to a forge server, but I'm not even sure if that's possible.