### PR TITLE
Add a WorldProvider#canSleepHere() method

### DIFF
--- a/patches/minecraft/net/minecraft/block/BlockBed.java.patch
+++ b/patches/minecraft/net/minecraft/block/BlockBed.java.patch
@@ -1,11 +1,14 @@
 --- ../src-base/minecraft/net/minecraft/block/BlockBed.java
 +++ ../src-work/minecraft/net/minecraft/block/BlockBed.java
-@@ -84,7 +84,7 @@
+@@ -84,8 +84,10 @@
                  }
              }
  
 -            if (p_180639_1_.field_73011_w.func_76567_e() && p_180639_1_.func_180494_b(p_180639_2_) != Biomes.field_76778_j)
-+            if (p_180639_1_.field_73011_w.canSleepHere(p_180639_4_, p_180639_2_))
++            net.minecraft.world.WorldProvider.WorldSleepResult sleepResult = p_180639_1_.field_73011_w.canSleepAt(p_180639_4_, p_180639_2_);
++            if (sleepResult != net.minecraft.world.WorldProvider.WorldSleepResult.BED_EXPLODES)
              {
++                if (sleepResult == net.minecraft.world.WorldProvider.WorldSleepResult.DO_NOTHING) return true;
                  if (((Boolean)p_180639_3_.func_177229_b(field_176471_b)).booleanValue())
                  {
+                     EntityPlayer entityplayer = this.func_176470_e(p_180639_1_, p_180639_2_);

--- a/patches/minecraft/net/minecraft/block/BlockBed.java.patch
+++ b/patches/minecraft/net/minecraft/block/BlockBed.java.patch
@@ -8,7 +8,7 @@
 +            net.minecraft.world.WorldProvider.WorldSleepResult sleepResult = p_180639_1_.field_73011_w.canSleepAt(p_180639_4_, p_180639_2_);
 +            if (sleepResult != net.minecraft.world.WorldProvider.WorldSleepResult.BED_EXPLODES)
              {
-+                if (sleepResult == net.minecraft.world.WorldProvider.WorldSleepResult.DO_NOTHING) return true;
++                if (sleepResult == net.minecraft.world.WorldProvider.WorldSleepResult.DENY) return true;
                  if (((Boolean)p_180639_3_.func_177229_b(field_176471_b)).booleanValue())
                  {
                      EntityPlayer entityplayer = this.func_176470_e(p_180639_1_, p_180639_2_);

--- a/patches/minecraft/net/minecraft/block/BlockBed.java.patch
+++ b/patches/minecraft/net/minecraft/block/BlockBed.java.patch
@@ -1,0 +1,11 @@
+--- ../src-base/minecraft/net/minecraft/block/BlockBed.java
++++ ../src-work/minecraft/net/minecraft/block/BlockBed.java
+@@ -84,7 +84,7 @@
+                 }
+             }
+ 
+-            if (p_180639_1_.field_73011_w.func_76567_e() && p_180639_1_.func_180494_b(p_180639_2_) != Biomes.field_76778_j)
++            if (p_180639_1_.field_73011_w.canSleepHere(p_180639_4_, p_180639_2_))
+             {
+                 if (((Boolean)p_180639_3_.func_177229_b(field_176471_b)).booleanValue())
+                 {

--- a/patches/minecraft/net/minecraft/world/WorldProvider.java.patch
+++ b/patches/minecraft/net/minecraft/world/WorldProvider.java.patch
@@ -65,7 +65,7 @@
      }
  
      @SideOnly(Side.CLIENT)
-@@ -241,6 +216,363 @@
+@@ -241,6 +216,370 @@
          return new WorldBorder();
      }
  
@@ -231,17 +231,6 @@
 +    }
 +
 +    /**
-+     * Determines if the player can sleep in this world (or if the bed should explode for example).
-+     *
-+     * @param player The player that is attempting to sleep
-+     * @return true if the player can sleep in a bed without it exploding
-+     */
-+    public boolean canSleepHere(net.minecraft.entity.player.EntityPlayer player, BlockPos pos)
-+    {
-+        return this.func_76567_e() && this.field_76579_a.func_180494_b(pos) != net.minecraft.init.Biomes.field_76778_j;
-+    }
-+
-+    /**
 +     * Called from {@link World#initCapabilities()}, to gather capabilities for this world.
 +     * It's safe to access world here since this is called after world is registered.
 +     *
@@ -265,6 +254,24 @@
 +    public net.minecraft.client.audio.MusicTicker.MusicType getMusicType()
 +    {
 +        return null;
++    }
++
++    /**
++     * Determines if the player can sleep in this world (or if the bed should explode for example).
++     *
++     * @param player The player that is attempting to sleep
++     * @return true if the player can sleep in a bed without it exploding
++     */
++    public WorldSleepResult canSleepAt(net.minecraft.entity.player.EntityPlayer player, BlockPos pos)
++    {
++        return (this.func_76567_e() && this.field_76579_a.func_180494_b(pos) != net.minecraft.init.Biomes.field_76778_j) ? WorldSleepResult.OK : WorldSleepResult.BED_EXPLODES;
++    }
++
++    public static enum WorldSleepResult
++    {
++        OK,
++        DO_NOTHING,
++        BED_EXPLODES;
 +    }
 +
 +    /*======================================= Start Moved From World =========================================*/

--- a/patches/minecraft/net/minecraft/world/WorldProvider.java.patch
+++ b/patches/minecraft/net/minecraft/world/WorldProvider.java.patch
@@ -65,7 +65,7 @@
      }
  
      @SideOnly(Side.CLIENT)
-@@ -241,6 +216,370 @@
+@@ -241,6 +216,371 @@
          return new WorldBorder();
      }
  
@@ -260,6 +260,7 @@
 +     * Determines if the player can sleep in this world (or if the bed should explode for example).
 +     *
 +     * @param player The player that is attempting to sleep
++     * @param pos The location where the player tries to sleep at (the position of the clicked on bed for example)
 +     * @return the result of a player trying to sleep at the given location
 +     */
 +    public WorldSleepResult canSleepAt(net.minecraft.entity.player.EntityPlayer player, BlockPos pos)

--- a/patches/minecraft/net/minecraft/world/WorldProvider.java.patch
+++ b/patches/minecraft/net/minecraft/world/WorldProvider.java.patch
@@ -260,17 +260,17 @@
 +     * Determines if the player can sleep in this world (or if the bed should explode for example).
 +     *
 +     * @param player The player that is attempting to sleep
-+     * @return true if the player can sleep in a bed without it exploding
++     * @return the result of a player trying to sleep at the given location
 +     */
 +    public WorldSleepResult canSleepAt(net.minecraft.entity.player.EntityPlayer player, BlockPos pos)
 +    {
-+        return (this.func_76567_e() && this.field_76579_a.func_180494_b(pos) != net.minecraft.init.Biomes.field_76778_j) ? WorldSleepResult.OK : WorldSleepResult.BED_EXPLODES;
++        return (this.func_76567_e() && this.field_76579_a.func_180494_b(pos) != net.minecraft.init.Biomes.field_76778_j) ? WorldSleepResult.ALLOW : WorldSleepResult.BED_EXPLODES;
 +    }
 +
 +    public static enum WorldSleepResult
 +    {
-+        OK,
-+        DO_NOTHING,
++        ALLOW,
++        DENY,
 +        BED_EXPLODES;
 +    }
 +

--- a/patches/minecraft/net/minecraft/world/WorldProvider.java.patch
+++ b/patches/minecraft/net/minecraft/world/WorldProvider.java.patch
@@ -65,7 +65,7 @@
      }
  
      @SideOnly(Side.CLIENT)
-@@ -241,6 +216,352 @@
+@@ -241,6 +216,363 @@
          return new WorldBorder();
      }
  
@@ -228,6 +228,17 @@
 +    public int getRespawnDimension(net.minecraft.entity.player.EntityPlayerMP player)
 +    {
 +        return player.getSpawnDimension();
++    }
++
++    /**
++     * Determines if the player can sleep in this world (or if the bed should explode for example).
++     *
++     * @param player The player that is attempting to sleep
++     * @return true if the player can sleep in a bed without it exploding
++     */
++    public boolean canSleepHere(net.minecraft.entity.player.EntityPlayer player, BlockPos pos)
++    {
++        return this.func_76567_e() && this.field_76579_a.func_180494_b(pos) != net.minecraft.init.Biomes.field_76778_j;
 +    }
 +
 +    /**

--- a/src/test/java/net/minecraftforge/debug/CanSleepAtTest.java
+++ b/src/test/java/net/minecraftforge/debug/CanSleepAtTest.java
@@ -1,0 +1,50 @@
+package net.minecraftforge.debug;
+
+import org.apache.logging.log4j.Logger;
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.DimensionType;
+import net.minecraft.world.WorldProvider;
+import net.minecraftforge.common.DimensionManager;
+import net.minecraftforge.fml.common.Mod;
+import net.minecraftforge.fml.common.Mod.EventHandler;
+import net.minecraftforge.fml.common.event.FMLPreInitializationEvent;
+
+@Mod(modid = CanSleepAtTest.MODID, name = "CanSleepAtTest", version = "0.0.0", acceptableRemoteVersions = "*")
+public class CanSleepAtTest
+{
+    public static final String MODID = "can_sleep_at_test";
+    public static final boolean ENABLED = false;
+    public static DimensionType dimType = null;
+    public static int dimId;
+    private static Logger logger;
+
+    @EventHandler
+    public void onPreInit(FMLPreInitializationEvent event)
+    {
+        if (ENABLED)
+        {
+            logger = event.getModLog();
+            dimId = DimensionManager.getNextFreeDimId();
+            dimType = DimensionType.register("CanSleepAtTest", "_cansleepattest", dimId, WorldProviderTest.class, false);
+            DimensionManager.registerDimension(dimId, dimType);
+            logger.info("Registered CanSleepAtTest dimension as DIM {}", dimId);
+        }
+    }
+
+    public static class WorldProviderTest extends WorldProvider
+    {
+        @Override
+        public DimensionType getDimensionType()
+        {
+            return CanSleepAtTest.dimType;
+        }
+
+        @Override
+        public WorldSleepResult canSleepAt(EntityPlayer player, BlockPos pos)
+        {
+            // Creates a 5x5 blocks wide grid of the different sleep results
+            return WorldSleepResult.values()[((pos.getX() / 5) + (pos.getZ() / 5)) % WorldSleepResult.values().length];
+        }
+    }
+}


### PR DESCRIPTION
This allows custom WorldProviders to separate the "can sleep here" (= beds exploding or not) logic from the respawn dimension logic.

So basically it allows players to sleep in a bed and pass the night in a custom dimension, but still get respawned in another dimension if they die there. Or the other way around, so that they can't sleep there, but they would still respawn in that dimension.

Edit:
In the revised version, this PR now also allows the WorldProvider to control the sleep behaviour based on the location, and either allowing or gracefully denying sleeping or saying that the bed should explode (or maybe some other custom "punishment behaviour" to happen in that case).