### PR TITLE
Fix FMLCommonHandler#exitJava printing useless/wrong calling info

### DIFF
--- a/src/main/java/net/minecraftforge/fml/common/FMLCommonHandler.java
+++ b/src/main/java/net/minecraftforge/fml/common/FMLCommonHandler.java
@@ -663,18 +663,17 @@ public class FMLCommonHandler
      */
     public void exitJava(int exitCode, boolean hardExit)
     {
-        FMLLog.log.info("Java has been asked to exit (code {}) by {}.", exitCode, Thread.currentThread().getStackTrace()[2]);
+        FMLLog.log.warn("Java has been asked to exit (code {})", exitCode);
         if (hardExit)
         {
-            FMLLog.log.info("This is an abortive exit and could cause world corruption or other things");
+            FMLLog.log.warn("This is an abortive exit and could cause world corruption or other things");
         }
-        if (Boolean.parseBoolean(System.getProperty("fml.debugExit", "false")))
+        StackTraceElement[] stack = Thread.currentThread().getStackTrace();
+        FMLLog.log.warn("Exit trace:");
+        //The first 2 elements are Thread#getStackTrace and FMLCommonHandler#exitJava and aren't relevant
+        for (int i = 2;i<stack.length;i++)
         {
-            FMLLog.log.info("Exit trace", new Throwable());
-        }
-        else
-        {
-            FMLLog.log.info("If this was an unexpected exit, use -Dfml.debugExit=true as a JVM argument to find out where it was called");
+            FMLLog.log.warn("\t"+stack[i]);
         }
         if (hardExit)
         {

--- a/src/main/java/net/minecraftforge/fml/common/FMLCommonHandler.java
+++ b/src/main/java/net/minecraftforge/fml/common/FMLCommonHandler.java
@@ -663,7 +663,7 @@ public class FMLCommonHandler
      */
     public void exitJava(int exitCode, boolean hardExit)
     {
-        FMLLog.log.info("Java has been asked to exit (code {}) by {}.", exitCode, Thread.currentThread().getStackTrace()[1]);
+        FMLLog.log.info("Java has been asked to exit (code {}) by {}.", exitCode, Thread.currentThread().getStackTrace()[2]);
         if (hardExit)
         {
             FMLLog.log.info("This is an abortive exit and could cause world corruption or other things");

--- a/src/main/java/net/minecraftforge/fml/common/FMLCommonHandler.java
+++ b/src/main/java/net/minecraftforge/fml/common/FMLCommonHandler.java
@@ -671,9 +671,9 @@ public class FMLCommonHandler
         StackTraceElement[] stack = Thread.currentThread().getStackTrace();
         FMLLog.log.warn("Exit trace:");
         //The first 2 elements are Thread#getStackTrace and FMLCommonHandler#exitJava and aren't relevant
-        for (int i = 2;i<stack.length;i++)
+        for (int i = 2; i < stack.length; i++)
         {
-            FMLLog.log.warn("\t"+stack[i]);
+            FMLLog.log.warn("\t{}", stack[i]);
         }
         if (hardExit)
         {


### PR DESCRIPTION
Old output
`Java has been asked to exit (code 0) by net.minecraftforge.fml.common.FMLCommonHandler.exitJava(FMLCommonHandler.java:666).`
New output:
`Java has been asked to exit (code 0) by net.minecraftforge.debug.AdvancementCriterionTest.preinit(AdvancementCriterionTest.java:23).` (That's where I put the call for testing)
The stack element at position 0 is `Thread#getStackTrace` itself, the element at 1 is the method calling `getStackTrace`: `exitJava`. The caller (which I assume is what this is meant to print) is at index 2.
As before, if you don't want mini-PR's, feel free to fix this yourself.