### PR TITLE
Maintain deterministic order in deserialised Forge blockstates

### DIFF
--- a/src/main/java/net/minecraftforge/client/model/BlockStateLoader.java
+++ b/src/main/java/net/minecraftforge/client/model/BlockStateLoader.java
@@ -82,7 +82,7 @@ public class BlockStateLoader
             {
                 case 1: // Version 1
                     ForgeBlockStateV1 v1 = GSON.fromJson(reader, ForgeBlockStateV1.class);
-                    Map<String, VariantList> variants = Maps.newHashMap();
+                    Map<String, VariantList> variants = Maps.newLinkedHashMap();
 
                     for (Entry<String, Collection<ForgeBlockStateV1.Variant>> entry : v1.variants.asMap().entrySet())
                     {   // Convert Version1 variants into vanilla variants for the ModelBlockDefinition.

--- a/src/main/java/net/minecraftforge/client/model/ForgeBlockStateV1.java
+++ b/src/main/java/net/minecraftforge/client/model/ForgeBlockStateV1.java
@@ -24,8 +24,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.EnumMap;
-import java.util.HashMap;
-import java.util.Iterator;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -48,8 +47,9 @@ import net.minecraftforge.fml.common.FMLLog;
 
 import java.util.Objects;
 import java.util.Optional;
-import com.google.common.collect.HashMultimap;
+
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.LinkedHashMultimap;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Multimap;
@@ -63,7 +63,7 @@ import com.google.gson.JsonParseException;
 public class ForgeBlockStateV1 extends Marker
 {
     ForgeBlockStateV1.Variant defaults;
-    Multimap<String, ForgeBlockStateV1.Variant> variants = HashMultimap.create();
+    Multimap<String, ForgeBlockStateV1.Variant> variants = LinkedHashMultimap.create();
 
     public static class Deserializer implements JsonDeserializer<ForgeBlockStateV1>
     {
@@ -83,8 +83,8 @@ public class ForgeBlockStateV1 extends Marker
                     throw new RuntimeException("\"defaults\" variant cannot contain a simple \"submodel\" definition.");
             }
 
-            Map<String, Map<String, ForgeBlockStateV1.Variant>> condensed = Maps.newHashMap();    // map(property name -> map(property value -> variant))
-            Multimap<String, ForgeBlockStateV1.Variant> specified = HashMultimap.create();    // Multimap containing all the states specified with "property=value".
+            Map<String, Map<String, ForgeBlockStateV1.Variant>> condensed = Maps.newLinkedHashMap();    // map(property name -> map(property value -> variant))
+            Multimap<String, ForgeBlockStateV1.Variant> specified = LinkedHashMultimap.create();    // Multimap containing all the states specified with "property=value".
 
             for (Entry<String, JsonElement> e : JsonUtils.getJsonObject(json, "variants").entrySet())
             {
@@ -103,7 +103,7 @@ public class ForgeBlockStateV1 extends Marker
                     if(obj.entrySet().iterator().next().getValue().isJsonObject())
                     {
                         // first value is a json object, so we know it's not a fully-defined variant
-                        Map<String, ForgeBlockStateV1.Variant> subs = Maps.newHashMap();
+                        Map<String, ForgeBlockStateV1.Variant> subs = Maps.newLinkedHashMap();
                         condensed.put(e.getKey(), subs);
                         for (Entry<String, JsonElement> se : e.getValue().getAsJsonObject().entrySet())
                         {
@@ -236,7 +236,7 @@ public class ForgeBlockStateV1 extends Marker
         {
             List<String> sorted = Lists.newArrayList(base.keySet());
             Collections.sort(sorted);   // Sort to get consistent results.
-            return getPermutations(sorted, base, 0, "", HashMultimap.create(), null);
+            return getPermutations(sorted, base, 0, "", LinkedHashMultimap.create(), null);
         }
 
         private List<ForgeBlockStateV1.Variant> getSubmodelPermutations(ForgeBlockStateV1.Variant baseVar, List<String> sorted, Map<String, List<ForgeBlockStateV1.Variant>> map, int depth, Map<String, ForgeBlockStateV1.Variant> parts, List<ForgeBlockStateV1.Variant> ret)
@@ -277,7 +277,7 @@ public class ForgeBlockStateV1 extends Marker
         {
             List<String> sorted = Lists.newArrayList(variants.keySet());
             Collections.sort(sorted);   // Sort to get consistent results.
-            return getSubmodelPermutations(baseVar, sorted, variants, 0, new HashMap<>(), new ArrayList<>());
+            return getSubmodelPermutations(baseVar, sorted, variants, 0, new LinkedHashMap<>(), new ArrayList<>());
         }
     }
 


### PR DESCRIPTION
The current Forge blockstate loader has some issues with handling random model variants.

As an example, changing the test cobblestone wall blockstate from this:
https://github.com/MinecraftForge/MinecraftForge/blob/bf50f8bc30f8893f206ef026349b19126b680708/src/test/resources/assets/forgeblockstatesloader/blockstates/cobblestone_wall.json#L27-L28

to this:
```json
"east=false,north=true,south=true,up=false,west=false": [{"model": null}, {"model": "cobblestone_wall_post"}],
"east=true,north=false,south=false,up=false,west=true": [{"model": null}, {"model": "cobblestone_wall_post"}],
```

to create random variants with/without a post, can cause the following change to occur between resource reloads:
![2018-02-16_02 36 35](https://user-images.githubusercontent.com/1447117/36291567-9dbfc022-12c3-11e8-8d9a-cf923f401d35.png)
![2018-02-16_02 36 49](https://user-images.githubusercontent.com/1447117/36291569-a095c21a-12c3-11e8-9465-00ef16302dfe.png)

While the random variant index selected for each position remains consistent, the actual submodel differs due to the nondeterministic ordering.

Changing the blockstate deserialising code to use structures with consistent ordering prevents this "swapping" of variants.