### PR TITLE
Don't cull generated item models with non-default GUI transform

### DIFF
--- a/src/main/java/net/minecraftforge/client/model/BakedItemModel.java
+++ b/src/main/java/net/minecraftforge/client/model/BakedItemModel.java
@@ -49,7 +49,13 @@ public class BakedItemModel implements IBakedModel
         this.particle = particle;
         this.transforms = transforms;
         this.overrides = overrides;
-        this.guiModel = new BakedGuiItemModel<>(this);
+        this.guiModel = hasGuiIdentity(transforms) ? new BakedGuiItemModel<>(this) : null;
+    }
+
+    private static boolean hasGuiIdentity(ImmutableMap<TransformType, TRSRTransformation> transforms)
+    {
+        TRSRTransformation guiTransform = transforms.get(TransformType.GUI);
+        return guiTransform == null || guiTransform.equals(TRSRTransformation.identity());
     }
 
     @Override public boolean isAmbientOcclusion() { return true; }
@@ -71,7 +77,7 @@ public class BakedItemModel implements IBakedModel
     @Override
     public Pair<? extends IBakedModel, Matrix4f> handlePerspective(TransformType type)
     {
-        if (type == TransformType.GUI)
+        if (type == TransformType.GUI && this.guiModel != null)
         {
             return this.guiModel.handlePerspective(type);
         }


### PR DESCRIPTION
Fixes [this issue](http://www.minecraftforge.net/forum/topic/62146-forge-for-112-fails-to-display-glass-panes-in-gui-with-lithoscore/) from the forums.

See the `item/generated_pane` model from the pack mentioned:
```json
{
    "parent": "builtin/generated",
    "display": {
    	"gui": {
            "rotation": [ 30, 225, 0 ],
            "translation": [ 0, 0, 0],
            "scale":[ 0.75, 0.75, 0.75 ]
        },
        "ground": {
            "rotation": [ 0, 0, 0 ],
            "translation": [ 0, 2, 0],
            "scale":[ 0.5, 0.5, 0.5 ]
        },
        "head": {
            "rotation": [ 0, 180, 0 ],
            "translation": [ 0, 13, 7],
            "scale":[ 1, 1, 1]
        },
        "thirdperson_righthand": {
            "rotation": [ 0, 0, 0 ],
            "translation": [ 0, 3, 1 ],
            "scale": [ 0.55, 0.55, 0.55 ]
        },
        "firstperson_righthand": {
            "rotation": [ 0, -90, 25 ],
            "translation": [ 1.13, 3.2, 1.13],
            "scale": [ 0.68, 0.68, 0.68 ]
        }
    }
}
```

The issue is that a non-default "gui" transform is specified here, which breaks with Forge's culling of item models.

This is fixed here by checking the transforms in the model constructor and only using a culled submodel if the default transform is being used.

Also, in future, it might be nicer to use an `Optional` for the `guiModel` field here, instead of a null value.