### PR TITLE
Reduce memory usage of model transforms

### DIFF
--- a/patches/minecraft/net/minecraft/client/renderer/block/model/ModelRotation.java.patch
+++ b/patches/minecraft/net/minecraft/client/renderer/block/model/ModelRotation.java.patch
@@ -14,8 +14,8 @@
          }
      }
 +
-+    public java.util.Optional<net.minecraftforge.common.model.TRSRTransformation> apply(java.util.Optional<? extends net.minecraftforge.common.model.IModelPart> part) { return net.minecraftforge.client.ForgeHooksClient.applyTransform(getMatrix(), part); }
-+    public javax.vecmath.Matrix4f getMatrix() { return net.minecraftforge.client.ForgeHooksClient.getMatrix(this); }
++    public java.util.Optional<net.minecraftforge.common.model.TRSRTransformation> apply(java.util.Optional<? extends net.minecraftforge.common.model.IModelPart> part) { return net.minecraftforge.client.ForgeHooksClient.applyTransform(this, part); }
++    public javax.vecmath.Matrix4f getMatrix() { return net.minecraftforge.common.model.TRSRTransformation.from(this).getMatrix(); }
 +    public EnumFacing rotate(EnumFacing facing) { return func_177523_a(facing); }
 +    public int rotate(EnumFacing facing, int vertexIndex) { return func_177520_a(facing, vertexIndex); }
  }

--- a/src/main/java/net/minecraftforge/client/ForgeHooksClient.java
+++ b/src/main/java/net/minecraftforge/client/ForgeHooksClient.java
@@ -57,6 +57,7 @@ import net.minecraft.client.renderer.block.model.BakedQuad;
 import net.minecraft.client.renderer.block.model.BlockFaceUV;
 import net.minecraft.client.renderer.block.model.IBakedModel;
 import net.minecraft.client.renderer.block.model.ItemCameraTransforms;
+import net.minecraft.client.renderer.block.model.ItemTransformVec3f;
 import net.minecraft.client.renderer.block.model.ModelManager;
 import net.minecraft.client.renderer.block.model.ModelResourceLocation;
 import net.minecraft.client.renderer.block.model.ModelRotation;
@@ -76,7 +77,6 @@ import net.minecraft.client.settings.GameSettings;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.entity.passive.EntityHorse;
-import net.minecraft.entity.passive.HorseArmorType;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.inventory.EntityEquipmentSlot;
 import net.minecraft.item.Item;
@@ -388,7 +388,7 @@ public class ForgeHooksClient
     }
 
     @SuppressWarnings("deprecation")
-    public static Matrix4f getMatrix(net.minecraft.client.renderer.block.model.ItemTransformVec3f transform)
+    public static Matrix4f getMatrix(ItemTransformVec3f transform)
     {
         javax.vecmath.Matrix4f m = new javax.vecmath.Matrix4f(), t = new javax.vecmath.Matrix4f();
         m.setIdentity();
@@ -627,10 +627,16 @@ public class ForgeHooksClient
     }
 
     @SuppressWarnings("deprecation")
-    public static Optional<TRSRTransformation> applyTransform(net.minecraft.client.renderer.block.model.ItemTransformVec3f transform, Optional<? extends IModelPart> part)
+    public static Optional<TRSRTransformation> applyTransform(ItemTransformVec3f transform, Optional<? extends IModelPart> part)
     {
         if(part.isPresent()) return Optional.empty();
         return Optional.of(TRSRTransformation.blockCenterToCorner(TRSRTransformation.from(transform)));
+    }
+
+    public static Optional<TRSRTransformation> applyTransform(ModelRotation rotation, Optional<? extends IModelPart> part)
+    {
+        if(part.isPresent()) return Optional.empty();
+        return Optional.of(TRSRTransformation.from(rotation));
     }
 
     public static Optional<TRSRTransformation> applyTransform(Matrix4f matrix, Optional<? extends IModelPart> part)

--- a/src/main/java/net/minecraftforge/client/ForgeHooksClient.java
+++ b/src/main/java/net/minecraftforge/client/ForgeHooksClient.java
@@ -630,7 +630,7 @@ public class ForgeHooksClient
     public static Optional<TRSRTransformation> applyTransform(net.minecraft.client.renderer.block.model.ItemTransformVec3f transform, Optional<? extends IModelPart> part)
     {
         if(part.isPresent()) return Optional.empty();
-        return Optional.of(TRSRTransformation.blockCenterToCorner(new TRSRTransformation(transform)));
+        return Optional.of(TRSRTransformation.blockCenterToCorner(TRSRTransformation.from(transform)));
     }
 
     public static Optional<TRSRTransformation> applyTransform(Matrix4f matrix, Optional<? extends IModelPart> part)
@@ -746,9 +746,9 @@ public class ForgeHooksClient
     @SuppressWarnings("deprecation")
     public static Pair<? extends IBakedModel,Matrix4f> handlePerspective(IBakedModel model, ItemCameraTransforms.TransformType type)
     {
-        TRSRTransformation tr = new TRSRTransformation(model.getItemCameraTransforms().getTransform(type));
+        TRSRTransformation tr = TRSRTransformation.from(model.getItemCameraTransforms().getTransform(type));
         Matrix4f mat = null;
-        if(!tr.equals(TRSRTransformation.identity())) mat = tr.getMatrix();
+        if (!tr.isIdentity()) mat = tr.getMatrix();
         return Pair.of(model, mat);
     }
 

--- a/src/main/java/net/minecraftforge/client/model/BakedItemModel.java
+++ b/src/main/java/net/minecraftforge/client/model/BakedItemModel.java
@@ -55,7 +55,7 @@ public class BakedItemModel implements IBakedModel
     private static boolean hasGuiIdentity(ImmutableMap<TransformType, TRSRTransformation> transforms)
     {
         TRSRTransformation guiTransform = transforms.get(TransformType.GUI);
-        return guiTransform == null || guiTransform.equals(TRSRTransformation.identity());
+        return guiTransform == null || guiTransform.isIdentity();
     }
 
     @Override public boolean isAmbientOcclusion() { return true; }

--- a/src/main/java/net/minecraftforge/client/model/BlockStateLoader.java
+++ b/src/main/java/net/minecraftforge/client/model/BlockStateLoader.java
@@ -94,8 +94,8 @@ public class BlockStateLoader
                             boolean gui3d = var.getGui3d().orElse(true);
                             int weight = var.getWeight().orElse(1);
 
-                            if (var.getModel() != null && var.getSubmodels().size() == 0 && var.getTextures().size() == 0 && var.getCustomData().size() == 0 && var.getState().orElse(null) instanceof ModelRotation)
-                                mcVars.add(new Variant(var.getModel(), (ModelRotation)var.getState().get(), uvLock, weight));
+                            if (var.getModel() != null && var.getSubmodels().size() == 0 && var.getTextures().size() == 0 && var.getCustomData().size() == 0 && var.getState().orElse(ModelRotation.X0_Y0) instanceof ModelRotation)
+                                mcVars.add(new Variant(var.getModel(), (ModelRotation)var.getState().orElse(ModelRotation.X0_Y0), uvLock, weight));
                             else
                                 mcVars.add(new ForgeVariant(location, var.getModel(), var.getState().orElse(TRSRTransformation.identity()), uvLock, smooth, gui3d, weight, var.getTextures(), var.getOnlyPartsVariant(), var.getCustomData()));
                         }

--- a/src/main/java/net/minecraftforge/client/model/ForgeBlockStateV1.java
+++ b/src/main/java/net/minecraftforge/client/model/ForgeBlockStateV1.java
@@ -497,9 +497,10 @@ public class ForgeBlockStateV1 extends Marker
                 {   // Load rotation values.
                     int x = JsonUtils.getInt(json, "x", 0);
                     int y = JsonUtils.getInt(json, "y", 0);
-                    ret.state = Optional.of(new TRSRTransformation(ModelRotation.getModelRotation(x, y)));
-                    if (!ret.state.isPresent())
+                    ModelRotation rotation = ModelRotation.getModelRotation(x, y);
+                    if (rotation == null)
                         throw new JsonParseException("Invalid BlockModelRotation x: " + x + " y: " + y);
+                    ret.state = Optional.of(TRSRTransformation.from(rotation));
                 }
 
                 if (json.has("transform"))

--- a/src/main/java/net/minecraftforge/client/model/ForgeBlockStateV1.java
+++ b/src/main/java/net/minecraftforge/client/model/ForgeBlockStateV1.java
@@ -552,10 +552,9 @@ public class ForgeBlockStateV1 extends Marker
                 {   // Load rotation values.
                     int x = JsonUtils.getInt(json, "x", 0);
                     int y = JsonUtils.getInt(json, "y", 0);
-                    ModelRotation rotation = ModelRotation.getModelRotation(x, y);
-                    if (rotation == null)
+                    ret.state = Optional.ofNullable(ModelRotation.getModelRotation(x, y));
+                    if (!ret.state.isPresent())
                         throw new JsonParseException("Invalid BlockModelRotation x: " + x + " y: " + y);
-                    ret.state = Optional.of(TRSRTransformation.from(rotation));
                 }
 
                 if (json.has("transform"))

--- a/src/main/java/net/minecraftforge/client/model/ForgeBlockStateV1.java
+++ b/src/main/java/net/minecraftforge/client/model/ForgeBlockStateV1.java
@@ -509,10 +509,13 @@ public class ForgeBlockStateV1 extends Marker
                 // item/handheld
                 {
                     EnumMap<TransformType, TRSRTransformation> map = new EnumMap<>(TransformType.class);
+                    map.put(TransformType.GROUND,                  get(0, 2, 0, 0, 0, 0, 0.5f));
+                    map.put(TransformType.HEAD,                    get(0, 13, 7, 0, 180, 0, 1));
                     map.put(TransformType.THIRD_PERSON_RIGHT_HAND, get(0, 4, 0.5f,         0, -90, 55, 0.85f));
                     map.put(TransformType.THIRD_PERSON_LEFT_HAND,  get(0, 4, 0.5f,         0, 90, -55, 0.85f));
                     map.put(TransformType.FIRST_PERSON_RIGHT_HAND, get(1.13f, 3.2f, 1.13f, 0, -90, 25, 0.68f));
                     map.put(TransformType.FIRST_PERSON_LEFT_HAND,  get(1.13f, 3.2f, 1.13f, 0, 90, -25, 0.68f));
+                    map.put(TransformType.FIXED,                   get(0, 0, 0, 0, 180, 0, 1));
                     builder.put("forge:default-tool", new SimpleModelState(ImmutableMap.copyOf(map)));
                 }
 

--- a/src/main/java/net/minecraftforge/client/model/ForgeBlockStateV1.java
+++ b/src/main/java/net/minecraftforge/client/model/ForgeBlockStateV1.java
@@ -467,6 +467,58 @@ public class ForgeBlockStateV1 extends Marker
                 return TRSRTransformation.blockCenterToCorner(flipX.compose(TRSRTransformation.blockCornerToCenter(transform)).compose(flipX));
             }
 
+            // Note: these strings might change to a full-blown resource locations in the future, and move from here to some json somewhere
+            // TODO: vanilla now includes from parent, deprecate?
+            private static final ImmutableMap<String, IModelState> transforms;
+
+            static
+            {
+                ImmutableMap.Builder<String, IModelState> builder = ImmutableMap.builder();
+
+                builder.put("identity", TRSRTransformation.identity());
+
+                // block/block
+                {
+                    EnumMap<TransformType, TRSRTransformation> map = new EnumMap<>(TransformType.class);
+                    TRSRTransformation thirdperson = get(0, 2.5f, 0, 75, 45, 0, 0.375f);
+                    map.put(TransformType.GUI,                     get(0, 0, 0, 30, 225, 0, 0.625f));
+                    map.put(TransformType.GROUND,                  get(0, 3, 0, 0, 0, 0, 0.25f));
+                    map.put(TransformType.FIXED,                   get(0, 0, 0, 0, 0, 0, 0.5f));
+                    map.put(TransformType.THIRD_PERSON_RIGHT_HAND, thirdperson);
+                    map.put(TransformType.THIRD_PERSON_LEFT_HAND,  leftify(thirdperson));
+                    map.put(TransformType.FIRST_PERSON_RIGHT_HAND, get(0, 0, 0, 0, 45, 0, 0.4f));
+                    map.put(TransformType.FIRST_PERSON_LEFT_HAND,  get(0, 0, 0, 0, 225, 0, 0.4f));
+                    builder.put("forge:default-block", new SimpleModelState(ImmutableMap.copyOf(map)));
+                }
+
+                // item/generated
+                {
+                    EnumMap<TransformType, TRSRTransformation> map = new EnumMap<>(TransformType.class);
+                    TRSRTransformation thirdperson = get(0, 3, 1, 0, 0, 0, 0.55f);
+                    TRSRTransformation firstperson = get(1.13f, 3.2f, 1.13f, 0, -90, 25, 0.68f);
+                    map.put(TransformType.GROUND,                  get(0, 2, 0, 0, 0, 0, 0.5f));
+                    map.put(TransformType.HEAD,                    get(0, 13, 7, 0, 180, 0, 1));
+                    map.put(TransformType.THIRD_PERSON_RIGHT_HAND, thirdperson);
+                    map.put(TransformType.THIRD_PERSON_LEFT_HAND,  leftify(thirdperson));
+                    map.put(TransformType.FIRST_PERSON_RIGHT_HAND, firstperson);
+                    map.put(TransformType.FIRST_PERSON_LEFT_HAND,  leftify(firstperson));
+                    map.put(TransformType.FIXED,                   get(0, 0, 0, 0, 180, 0, 1));
+                    builder.put("forge:default-item", new SimpleModelState(ImmutableMap.copyOf(map)));
+                }
+
+                // item/handheld
+                {
+                    EnumMap<TransformType, TRSRTransformation> map = new EnumMap<>(TransformType.class);
+                    map.put(TransformType.THIRD_PERSON_RIGHT_HAND, get(0, 4, 0.5f,         0, -90, 55, 0.85f));
+                    map.put(TransformType.THIRD_PERSON_LEFT_HAND,  get(0, 4, 0.5f,         0, 90, -55, 0.85f));
+                    map.put(TransformType.FIRST_PERSON_RIGHT_HAND, get(1.13f, 3.2f, 1.13f, 0, -90, 25, 0.68f));
+                    map.put(TransformType.FIRST_PERSON_LEFT_HAND,  get(1.13f, 3.2f, 1.13f, 0, 90, -25, 0.68f));
+                    builder.put("forge:default-tool", new SimpleModelState(ImmutableMap.copyOf(map)));
+                }
+
+                transforms = builder.build();
+            }
+
             @Override
             public ForgeBlockStateV1.Variant deserialize(JsonElement element, Type typeOfT, JsonDeserializationContext context) throws JsonParseException
             {
@@ -508,51 +560,8 @@ public class ForgeBlockStateV1 extends Marker
                     if (json.get("transform").isJsonPrimitive() && json.get("transform").getAsJsonPrimitive().isString())
                     {
                         String transform = json.get("transform").getAsString();
-                        // Note: these strings might change to a full-blown resource locations in the future, and move from here to some json somewhere
-                        // TODO: vanilla now includes from parent, deprecate?
-                        if (transform.equals("identity"))
-                        {
-                            ret.state = Optional.of(TRSRTransformation.identity());
-                        }
-                        // block/block
-                        else if (transform.equals("forge:default-block"))
-                        {
-                            TRSRTransformation thirdperson = get(0, 2.5f, 0, 75, 45, 0, 0.375f);
-                            ImmutableMap.Builder<TransformType, TRSRTransformation> builder = ImmutableMap.builder();
-                            builder.put(TransformType.GUI,                     get(0, 0, 0, 30, 225, 0, 0.625f));
-                            builder.put(TransformType.GROUND,                  get(0, 3, 0, 0, 0, 0, 0.25f));
-                            builder.put(TransformType.FIXED,                   get(0, 0, 0, 0, 0, 0, 0.5f));
-                            builder.put(TransformType.THIRD_PERSON_RIGHT_HAND, thirdperson);
-                            builder.put(TransformType.THIRD_PERSON_LEFT_HAND,  leftify(thirdperson));
-                            builder.put(TransformType.FIRST_PERSON_RIGHT_HAND, get(0, 0, 0, 0, 45, 0, 0.4f));
-                            builder.put(TransformType.FIRST_PERSON_LEFT_HAND,  get(0, 0, 0, 0, 225, 0, 0.4f));
-                            ret.state = Optional.of(new SimpleModelState(builder.build()));
-                        }
-                        // item/generated
-                        else if (transform.equals("forge:default-item"))
-                        {
-                            TRSRTransformation thirdperson = get(0, 3, 1, 0, 0, 0, 0.55f);
-                            TRSRTransformation firstperson = get(1.13f, 3.2f, 1.13f, 0, -90, 25, 0.68f);
-                            ImmutableMap.Builder<TransformType, TRSRTransformation> builder = ImmutableMap.builder();
-                            builder.put(TransformType.GROUND,                  get(0, 2, 0, 0, 0, 0, 0.5f));
-                            builder.put(TransformType.HEAD,                    get(0, 13, 7, 0, 180, 0, 1));
-                            builder.put(TransformType.THIRD_PERSON_RIGHT_HAND, thirdperson);
-                            builder.put(TransformType.THIRD_PERSON_LEFT_HAND, leftify(thirdperson));
-                            builder.put(TransformType.FIRST_PERSON_RIGHT_HAND, firstperson);
-                            builder.put(TransformType.FIRST_PERSON_LEFT_HAND, leftify(firstperson));
-                            builder.put(TransformType.FIXED, get(0, 0, 0, 0, 180, 0, 1));
-                            ret.state = Optional.of(new SimpleModelState(builder.build()));
-                        }
-                        // item/handheld
-                        else if (transform.equals("forge:default-tool"))
-                        {
-                            ret.state = Optional.of(new SimpleModelState(ImmutableMap.of(
-                                TransformType.THIRD_PERSON_RIGHT_HAND, get(0, 4, 0.5f,         0, -90, 55, 0.85f),
-                                TransformType.THIRD_PERSON_LEFT_HAND,  get(0, 4, 0.5f,         0, 90, -55, 0.85f),
-                                TransformType.FIRST_PERSON_RIGHT_HAND, get(1.13f, 3.2f, 1.13f, 0, -90, 25, 0.68f),
-                                TransformType.FIRST_PERSON_LEFT_HAND,  get(1.13f, 3.2f, 1.13f, 0, 90, -25, 0.68f))));
-                        }
-                        else
+                        ret.state = Optional.ofNullable(transforms.get(transform));
+                        if (!ret.state.isPresent())
                         {
                             throw new JsonParseException("transform: unknown default string: " + transform);
                         }

--- a/src/main/java/net/minecraftforge/client/model/ItemTextureQuadConverter.java
+++ b/src/main/java/net/minecraftforge/client/model/ItemTextureQuadConverter.java
@@ -268,7 +268,7 @@ public final class ItemTextureQuadConverter
             switch (format.getElement(e).getUsage())
             {
                 case POSITION:
-                    if (transform == TRSRTransformation.identity())
+                    if (transform.isIdentity())
                     {
                         builder.put(e, x, y, z, 1);
                     }

--- a/src/main/java/net/minecraftforge/client/model/ModelFluid.java
+++ b/src/main/java/net/minecraftforge/client/model/ModelFluid.java
@@ -322,7 +322,7 @@ public final class ModelFluid implements IModel
                 {
                 case POSITION:
                     float[] data = new float[]{ x - side.getDirectionVec().getX() * eps, y, z - side.getDirectionVec().getZ() * eps, 1 };
-                    if(transformation.isPresent() && transformation.get() != TRSRTransformation.identity())
+                    if(transformation.isPresent() && !transformation.get().isIdentity())
                     {
                         Vector4f vec = new Vector4f(data);
                         transformation.get().getMatrix().transform(vec);

--- a/src/main/java/net/minecraftforge/client/model/ModelLoader.java
+++ b/src/main/java/net/minecraftforge/client/model/ModelLoader.java
@@ -461,7 +461,7 @@ public final class ModelLoader extends ModelBakery
             }
 
             ItemCameraTransforms transforms = model.getAllTransforms();
-            Map<TransformType, TRSRTransformation> tMap = Maps.newHashMap();
+            Map<TransformType, TRSRTransformation> tMap = Maps.newEnumMap(TransformType.class);
             tMap.putAll(PerspectiveMapWrapper.getTransforms(transforms));
             tMap.putAll(PerspectiveMapWrapper.getTransforms(state));
             IModelState perState = new SimpleModelState(ImmutableMap.copyOf(tMap));

--- a/src/main/java/net/minecraftforge/client/model/MultiModel.java
+++ b/src/main/java/net/minecraftforge/client/model/MultiModel.java
@@ -134,7 +134,11 @@ public final class MultiModel implements IModel
                 {
                     Pair<? extends IBakedModel, Matrix4f> p = base.handlePerspective(type);
                     IBakedModel newBase = p.getLeft();
-                    map.put(type, Pair.of(new Baked(location, false, newBase, parts), new TRSRTransformation(p.getRight())));
+                    Matrix4f matrix = p.getRight();
+                    if (newBase != base || matrix != null)
+                    {
+                        map.put(type, Pair.of(new Baked(location, false, newBase, parts), new TRSRTransformation(matrix)));
+                    }
                 }
                 transforms = ImmutableMap.copyOf(map);
             }
@@ -212,8 +216,8 @@ public final class MultiModel implements IModel
         @Override
         public Pair<? extends IBakedModel, Matrix4f> handlePerspective(TransformType cameraTransformType)
         {
-            if(transforms.isEmpty()) return Pair.of(this, null);
             Pair<Baked, TRSRTransformation> p = transforms.get(cameraTransformType);
+            if (p == null) return Pair.of(this, null);
             return Pair.of(p.getLeft(), p.getRight().getMatrix());
         }
 

--- a/src/main/java/net/minecraftforge/client/model/MultiModel.java
+++ b/src/main/java/net/minecraftforge/client/model/MultiModel.java
@@ -20,6 +20,7 @@
 package net.minecraftforge.client.model;
 
 import java.util.Collection;
+import java.util.EnumMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -47,7 +48,6 @@ import net.minecraftforge.common.model.TRSRTransformation;
 import net.minecraftforge.fml.common.FMLLog;
 
 import org.apache.commons.lang3.tuple.Pair;
-import org.apache.logging.log4j.Level;
 
 import java.util.function.Function;
 import java.util.Optional;
@@ -129,14 +129,14 @@ public final class MultiModel implements IModel
             // Only changes the base model based on perspective, may recurse for parts in the future.
             if(base != null && perspective)
             {
-                ImmutableMap.Builder<TransformType, Pair<Baked, TRSRTransformation>> builder = ImmutableMap.builder();
+                EnumMap<TransformType, Pair<Baked, TRSRTransformation>> map = new EnumMap<>(TransformType.class);
                 for(TransformType type : TransformType.values())
                 {
                     Pair<? extends IBakedModel, Matrix4f> p = base.handlePerspective(type);
                     IBakedModel newBase = p.getLeft();
-                    builder.put(type, Pair.of(new Baked(location, false, newBase, parts), new TRSRTransformation(p.getRight())));
+                    map.put(type, Pair.of(new Baked(location, false, newBase, parts), new TRSRTransformation(p.getRight())));
                 }
-                transforms = builder.build();
+                transforms = ImmutableMap.copyOf(map);
             }
             else
             {

--- a/src/main/java/net/minecraftforge/client/model/PerspectiveMapWrapper.java
+++ b/src/main/java/net/minecraftforge/client/model/PerspectiveMapWrapper.java
@@ -1,5 +1,6 @@
 package net.minecraftforge.client.model;
 
+import java.util.EnumMap;
 import java.util.Optional;
 import com.google.common.collect.ImmutableMap;
 import net.minecraft.block.state.IBlockState;
@@ -35,30 +36,30 @@ public class PerspectiveMapWrapper implements IBakedModel
 
     public static ImmutableMap<ItemCameraTransforms.TransformType, TRSRTransformation> getTransforms(IModelState state)
     {
-        ImmutableMap.Builder<ItemCameraTransforms.TransformType, TRSRTransformation> builder = ImmutableMap.builder();
+        EnumMap<ItemCameraTransforms.TransformType, TRSRTransformation> map = new EnumMap<>(ItemCameraTransforms.TransformType.class);
         for(ItemCameraTransforms.TransformType type : ItemCameraTransforms.TransformType.values())
         {
             Optional<TRSRTransformation> tr = state.apply(Optional.of(type));
             if(tr.isPresent())
             {
-                builder.put(type, tr.get());
+                map.put(type, tr.get());
             }
         }
-        return builder.build();
+        return ImmutableMap.copyOf(map);
     }
 
     @SuppressWarnings("deprecation")
     public static ImmutableMap<ItemCameraTransforms.TransformType, TRSRTransformation> getTransforms(ItemCameraTransforms transforms)
     {
-        ImmutableMap.Builder<ItemCameraTransforms.TransformType, TRSRTransformation> builder = ImmutableMap.builder();
+        EnumMap<ItemCameraTransforms.TransformType, TRSRTransformation> map = new EnumMap<>(ItemCameraTransforms.TransformType.class);
         for(ItemCameraTransforms.TransformType type : ItemCameraTransforms.TransformType.values())
         {
             if (transforms.hasCustomTransform(type))
             {
-                builder.put(type, TRSRTransformation.blockCenterToCorner(TRSRTransformation.from(transforms.getTransform(type))));
+                map.put(type, TRSRTransformation.blockCenterToCorner(TRSRTransformation.from(transforms.getTransform(type))));
             }
         }
-        return builder.build();
+        return ImmutableMap.copyOf(map);
     }
 
     public static Pair<? extends IBakedModel, Matrix4f> handlePerspective(IBakedModel model, ImmutableMap<ItemCameraTransforms.TransformType, TRSRTransformation> transforms, ItemCameraTransforms.TransformType cameraTransformType)

--- a/src/main/java/net/minecraftforge/client/model/animation/ModelBlockAnimation.java
+++ b/src/main/java/net/minecraftforge/client/model/animation/ModelBlockAnimation.java
@@ -528,7 +528,7 @@ public class ModelBlockAnimation
                 {
                     ModelBlockAnimation.MBJoint joint = new ModelBlockAnimation.MBJoint(info.getName());
                     Optional<TRSRTransformation> trOp = state.apply(Optional.of(joint));
-                    if(trOp.isPresent() && trOp.get() != TRSRTransformation.identity())
+                    if(trOp.isPresent() && !trOp.get().isIdentity())
                     {
                         float w = info.getWeights().get(i)[0];
                         tmp = trOp.get().getMatrix();

--- a/src/main/java/net/minecraftforge/common/model/TRSRTransformation.java
+++ b/src/main/java/net/minecraftforge/common/model/TRSRTransformation.java
@@ -132,22 +132,28 @@ public final class TRSRTransformation implements IModelState, ITransformation
     @SideOnly(Side.CLIENT)
     public static TRSRTransformation from(EnumFacing facing)
     {
-        return Cache.get(facing);
+        return Cache.get(getRotation(facing));
     }
 
     @SideOnly(Side.CLIENT)
     public static Matrix4f getMatrix(EnumFacing facing)
     {
-        switch(facing)
+        return getRotation(facing).getMatrix();
+    }
+
+    @SideOnly(Side.CLIENT)
+    public static ModelRotation getRotation(EnumFacing facing)
+    {
+        switch (facing)
         {
-        case DOWN: return ModelRotation.X90_Y0.getMatrix();
-        case UP: return ModelRotation.X270_Y0.getMatrix();
-        case NORTH: return TRSRTransformation.identity.matrix;
-        case SOUTH: return ModelRotation.X0_Y180.getMatrix();
-        case WEST: return ModelRotation.X0_Y270.getMatrix();
-        case EAST: return ModelRotation.X0_Y90.getMatrix();
-        default: return new Matrix4f();
+        case DOWN:  return ModelRotation.X90_Y0;
+        case UP:    return ModelRotation.X270_Y0;
+        case NORTH: return ModelRotation.X0_Y0;
+        case SOUTH: return ModelRotation.X0_Y180;
+        case WEST:  return ModelRotation.X0_Y270;
+        case EAST:  return ModelRotation.X0_Y90;
         }
+        throw new IllegalArgumentException(String.valueOf(facing));
     }
 
     private static final TRSRTransformation identity;
@@ -844,16 +850,15 @@ public final class TRSRTransformation implements IModelState, ITransformation
     private static final class Cache
     {
         private static final Map<ModelRotation, TRSRTransformation> rotations = new EnumMap<>(ModelRotation.class);
-        private static final Map<EnumFacing, TRSRTransformation> facings = new EnumMap<>(EnumFacing.class);
+
+        static
+        {
+            rotations.put(ModelRotation.X0_Y0, identity());
+        }
 
         static TRSRTransformation get(ModelRotation rotation)
         {
             return rotations.computeIfAbsent(rotation, r -> new TRSRTransformation(r.getMatrix()));
-        }
-
-        static TRSRTransformation get(EnumFacing facing)
-        {
-            return facings.computeIfAbsent(facing, f -> new TRSRTransformation(getMatrix(f)));
         }
     }
 }

--- a/src/main/java/net/minecraftforge/common/model/TRSRTransformation.java
+++ b/src/main/java/net/minecraftforge/common/model/TRSRTransformation.java
@@ -62,6 +62,12 @@ import com.google.common.collect.Maps;
  */
 public final class TRSRTransformation implements IModelState, ITransformation
 {
+    @SideOnly(Side.CLIENT)
+    private static final Map<ModelRotation, TRSRTransformation> rotations = new EnumMap<>(ModelRotation.class);
+
+    @SideOnly(Side.CLIENT)
+    private static final Map<EnumFacing, TRSRTransformation> facings = new EnumMap<>(EnumFacing.class);
+
     private final Matrix4f matrix;
 
     private boolean full;
@@ -159,12 +165,6 @@ public final class TRSRTransformation implements IModelState, ITransformation
         identity = new TRSRTransformation(m);
         identity.getLeftRot();
     }
-
-    @SideOnly(Side.CLIENT)
-    private static final Map<ModelRotation, TRSRTransformation> rotations = new EnumMap<>(ModelRotation.class);
-
-    @SideOnly(Side.CLIENT)
-    private static final Map<EnumFacing, TRSRTransformation> facings = new EnumMap<>(EnumFacing.class);
 
     public static TRSRTransformation identity()
     {

--- a/src/main/java/net/minecraftforge/common/model/TRSRTransformation.java
+++ b/src/main/java/net/minecraftforge/common/model/TRSRTransformation.java
@@ -62,12 +62,6 @@ import com.google.common.collect.Maps;
  */
 public final class TRSRTransformation implements IModelState, ITransformation
 {
-    @SideOnly(Side.CLIENT)
-    private static final Map<ModelRotation, TRSRTransformation> rotations = new EnumMap<>(ModelRotation.class);
-
-    @SideOnly(Side.CLIENT)
-    private static final Map<EnumFacing, TRSRTransformation> facings = new EnumMap<>(EnumFacing.class);
-
     private final Matrix4f matrix;
 
     private boolean full;
@@ -132,13 +126,13 @@ public final class TRSRTransformation implements IModelState, ITransformation
     @SideOnly(Side.CLIENT)
     public static TRSRTransformation from(ModelRotation rotation)
     {
-        return rotations.computeIfAbsent(rotation, r -> new TRSRTransformation(r.getMatrix()));
+        return Cache.get(rotation);
     }
 
     @SideOnly(Side.CLIENT)
     public static TRSRTransformation from(EnumFacing facing)
     {
-        return facings.computeIfAbsent(facing, f -> new TRSRTransformation(getMatrix(f)));
+        return Cache.get(facing);
     }
 
     @SideOnly(Side.CLIENT)
@@ -843,6 +837,23 @@ public final class TRSRTransformation implements IModelState, ITransformation
         catch(SingularMatrixException e)
         {
             return new TRSRTransformation(null, null, new Vector3f(0, 0, 0), null);
+        }
+    }
+
+    @SideOnly(Side.CLIENT)
+    private static final class Cache
+    {
+        private static final Map<ModelRotation, TRSRTransformation> rotations = new EnumMap<>(ModelRotation.class);
+        private static final Map<EnumFacing, TRSRTransformation> facings = new EnumMap<>(EnumFacing.class);
+
+        static TRSRTransformation get(ModelRotation rotation)
+        {
+            return rotations.computeIfAbsent(rotation, r -> new TRSRTransformation(r.getMatrix()));
+        }
+
+        static TRSRTransformation get(EnumFacing facing)
+        {
+            return facings.computeIfAbsent(facing, f -> new TRSRTransformation(getMatrix(f)));
         }
     }
 }

--- a/src/main/java/net/minecraftforge/common/model/TRSRTransformation.java
+++ b/src/main/java/net/minecraftforge/common/model/TRSRTransformation.java
@@ -39,6 +39,7 @@ import net.minecraft.client.renderer.block.model.ItemTransformVec3f;
 import net.minecraft.client.renderer.block.model.ModelRotation;
 import net.minecraft.util.EnumFacing;
 import net.minecraft.util.math.Vec3i;
+import net.minecraftforge.client.ForgeHooksClient;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
 
@@ -858,7 +859,7 @@ public final class TRSRTransformation implements IModelState, ITransformation
 
         static TRSRTransformation get(ModelRotation rotation)
         {
-            return rotations.computeIfAbsent(rotation, r -> new TRSRTransformation(r.getMatrix()));
+            return rotations.computeIfAbsent(rotation, r -> new TRSRTransformation(ForgeHooksClient.getMatrix(r)));
         }
     }
 }


### PR DESCRIPTION
This PR aims to save some more memory used by models, mainly by reducing the number of `TRSRTransformation` instances.

As `TRSRTransformation` instances are immutable, we can deduplicate the most common transforms to save memory.

This deprecates some of the constructors in favour of static methods which don't have to return new instances if it's not needed. Some of the mutating methods are also changed to avoid making new instances if there's no actual change.

Screenshots of heap dumps taken running Forge + test mods:

Before:
![pre](https://user-images.githubusercontent.com/1447117/36343612-3ca8f558-1406-11e8-82e3-8cbff31aed04.PNG)

After:
![post](https://user-images.githubusercontent.com/1447117/36343616-44d8d9c8-1406-11e8-989b-067f38d197e3.PNG)

The number of `TRSRTransformation` instances falls from 88,133 to 10,839 and there is also a reduction in the number of `ImmutableMapEntry` instances.

Overall the memory savings here are around 14.5MB, as can be seen by looking at the retained heap usage for `ModelLoader$VanillaModelWrapper$1`.
