### PR TITLE
Fixed sound engine crash when stopping streaming sounds

### DIFF
--- a/src/main/java/net/minecraftforge/fml/common/asm/transformers/SoundEngineFixTransformer.java
+++ b/src/main/java/net/minecraftforge/fml/common/asm/transformers/SoundEngineFixTransformer.java
@@ -1,3 +1,22 @@
+/*
+ * Minecraft Forge
+ * Copyright (c) 2016.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation version 2.1
+ * of the License.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
 package net.minecraftforge.fml.common.asm.transformers;
 
 import java.util.Iterator;

--- a/src/main/java/net/minecraftforge/fml/common/asm/transformers/SoundEngineFixTransformer.java
+++ b/src/main/java/net/minecraftforge/fml/common/asm/transformers/SoundEngineFixTransformer.java
@@ -1,0 +1,137 @@
+package net.minecraftforge.fml.common.asm.transformers;
+
+import java.util.Iterator;
+
+import org.objectweb.asm.ClassReader;
+import org.objectweb.asm.ClassWriter;
+import org.objectweb.asm.Opcodes;
+import org.objectweb.asm.tree.AbstractInsnNode;
+import org.objectweb.asm.tree.ClassNode;
+import org.objectweb.asm.tree.FieldInsnNode;
+import org.objectweb.asm.tree.FieldNode;
+import org.objectweb.asm.tree.InsnNode;
+import org.objectweb.asm.tree.JumpInsnNode;
+import org.objectweb.asm.tree.LabelNode;
+import org.objectweb.asm.tree.MethodInsnNode;
+import org.objectweb.asm.tree.MethodNode;
+import org.objectweb.asm.tree.VarInsnNode;
+
+import net.minecraft.launchwrapper.IClassTransformer;
+
+public class SoundEngineFixTransformer implements IClassTransformer
+{
+    @Override
+    public byte[] transform(String name, String transformedName, byte[] basicClass)
+    {
+        if (transformedName.equals("paulscode.sound.Source"))
+        {
+            ClassNode classNode = new ClassNode();
+            ClassReader classReader = new ClassReader(basicClass);
+            classReader.accept(classNode, 0);
+
+            classNode.fields.add(new FieldNode(Opcodes.ACC_PUBLIC, "removed", "Z", null, null));
+
+            ClassWriter writer = new ClassWriter(ClassWriter.COMPUTE_MAXS);
+            classNode.accept(writer);
+            return writer.toByteArray();
+        }
+        else if (transformedName.equals("paulscode.sound.Library"))
+        {
+            ClassNode classNode = new ClassNode();
+            ClassReader classReader = new ClassReader(basicClass);
+            classReader.accept(classNode, 0);
+
+            MethodNode method = null;
+            for (MethodNode m : classNode.methods)
+            {
+                if (m.name.equals("removeSource") && m.desc.equals("(Ljava/lang/String;)V"))
+                {
+                    method = m;
+                    break;
+                }
+            }
+            if (method == null)
+                throw new RuntimeException("Error processing " + transformedName + " - no removeSource method found");
+
+            for (Iterator<AbstractInsnNode> iterator = method.instructions.iterator(); iterator.hasNext();)
+            {
+                AbstractInsnNode insn = iterator.next();
+                if (insn instanceof MethodInsnNode && ((MethodInsnNode) insn).owner.equals("paulscode/sound/Source")
+                        && ((MethodInsnNode) insn).name.equals("cleanup"))
+                {
+                    LabelNode after = (LabelNode) insn.getNext();
+
+                    AbstractInsnNode beginning = insn.getPrevious();
+
+                    int varIndex = ((VarInsnNode) beginning).var;
+
+                    method.instructions.insertBefore(beginning, new VarInsnNode(Opcodes.ALOAD, varIndex));
+                    method.instructions.insertBefore(beginning, new FieldInsnNode(Opcodes.GETFIELD, "paulscode/sound/Source", "toStream", "Z"));
+                    LabelNode elseNode = new LabelNode();
+                    method.instructions.insertBefore(beginning, new JumpInsnNode(Opcodes.IFEQ, elseNode));
+
+                    method.instructions.insertBefore(beginning, new VarInsnNode(Opcodes.ALOAD, varIndex));
+                    method.instructions.insertBefore(beginning, new InsnNode(Opcodes.ICONST_1));
+                    method.instructions.insertBefore(beginning, new FieldInsnNode(Opcodes.PUTFIELD, "paulscode/sound/Source", "removed", "Z"));
+
+                    method.instructions.insertBefore(beginning, new JumpInsnNode(Opcodes.GOTO, after));
+
+                    method.instructions.insertBefore(beginning, elseNode);
+                    break;
+                }
+            }
+
+            ClassWriter writer = new ClassWriter(ClassWriter.COMPUTE_MAXS);
+            classNode.accept(writer);
+            return writer.toByteArray();
+        }
+        else if (transformedName.equals("paulscode.sound.StreamThread"))
+        {
+            ClassNode classNode = new ClassNode();
+            ClassReader classReader = new ClassReader(basicClass);
+            classReader.accept(classNode, 0);
+
+            MethodNode method = null;
+            for (MethodNode m : classNode.methods)
+            {
+                if (m.name.equals("run") && m.desc.equals("()V"))
+                {
+                    method = m;
+                    break;
+                }
+            }
+            if (method == null)
+                throw new RuntimeException("Error processing " + transformedName + " - no run method found");
+
+            for (Iterator<AbstractInsnNode> iterator = method.instructions.iterator(); iterator.hasNext();)
+            {
+                AbstractInsnNode insn = iterator.next();
+                if (insn instanceof MethodInsnNode && ((MethodInsnNode) insn).owner.equals("java/util/ListIterator")
+                        && ((MethodInsnNode) insn).name.equals("next"))
+                {
+                    insn = insn.getNext().getNext();
+
+                    int varIndex = ((VarInsnNode) insn).var;
+
+                    LabelNode after = (LabelNode) insn.getNext();
+                    method.instructions.insertBefore(after, new VarInsnNode(Opcodes.ALOAD, varIndex));
+                    method.instructions.insertBefore(after, new FieldInsnNode(Opcodes.GETFIELD, "paulscode/sound/Source", "removed", "Z"));
+                    method.instructions.insertBefore(after, new JumpInsnNode(Opcodes.IFEQ, after));
+
+                    method.instructions.insertBefore(after, new VarInsnNode(Opcodes.ALOAD, varIndex));
+                    method.instructions.insertBefore(after, new MethodInsnNode(Opcodes.INVOKEVIRTUAL, "paulscode/sound/Source", "cleanup", "()V", false));
+                    method.instructions.insertBefore(after, new InsnNode(Opcodes.ACONST_NULL));
+                    method.instructions.insertBefore(after, new VarInsnNode(Opcodes.ASTORE, varIndex));
+                    break;
+                }
+            }
+
+            ClassWriter writer = new ClassWriter(ClassWriter.COMPUTE_MAXS);
+            classNode.accept(writer);
+            return writer.toByteArray();
+        }
+
+        return basicClass;
+    }
+
+}

--- a/src/main/java/net/minecraftforge/fml/relauncher/FMLCorePlugin.java
+++ b/src/main/java/net/minecraftforge/fml/relauncher/FMLCorePlugin.java
@@ -31,6 +31,7 @@ public class FMLCorePlugin implements IFMLLoadingPlugin
                              "net.minecraftforge.fml.common.asm.transformers.SideTransformer",
                              "net.minecraftforge.fml.common.asm.transformers.EventSubscriptionTransformer",
                              "net.minecraftforge.fml.common.asm.transformers.EventSubscriberTransformer",
+                             "net.minecraftforge.fml.common.asm.transformers.SoundEngineFixTransformer"
                             };
     }
 


### PR DESCRIPTION
Fixes a threading issue the paulscode sound engine has, which causes it to crash. This issue occurs from time to time when stopping streaming sounds.

**Summary**
I'm the author of [AmbientSounds](https://minecraft.curseforge.com/projects/ambientsounds). A mod which plays streaming sounds to make minecraft feel more immersive. Eventually users reported an [issue ](https://github.com/CreativeMD/AmbientSounds/issues/7) which occurred from time to time and stopped all sounds of my mod. Only a restart of the sound engine fixed it (reloading all resources).

So I contacted the author of the sound engine ([source](http://www.paulscode.com/forum/index.php?topic=14927.msg30087#msg30087)) and he confirmed this being an issue caused by a missing synchronization between the StreamThread and the Library. In rare cases the sound will be cleaned up while the streaming thread is still reading the file, which caused the thread to terminate meaning only non-streaming sounds could be played afterwards.

Unfortunately the author couldn't find any time to fix it himself, so implemented a fix for AmbientSounds myself using an asm ([transformer](https://github.com/CreativeMD/AmbientSounds/blob/1.12/src/main/java/com/creativemd/ambientsounds/soundfix/SoundFixTransformer.java), [methods](https://github.com/CreativeMD/AmbientSounds/blob/1.12/src/main/java/com/creativemd/ambientsounds/soundfix/SoundFixMethods.java)). This fix is confirmed to be functional and is also included in @OreCruncher's mod [DynamicSurroundings](https://minecraft.curseforge.com/projects/dynamic-surroundings).

**What it does**
`paulscode.sound.Source`: This field servers as an indicator which tells the streaming thread to cleanup and remove the given source.
```java
public boolean removed = false; //Added by transformer
```

`paulscode.sound.Library`: Instead of cleaning up streaming sources they will be marked as being removed, so the streaming thread can delete them.
```java
    public void removeSource( String sourcename )
    {
        Source mySource = sourceMap.get( sourcename );
        if( mySource != null )
        {
            if(mySource.toStream ) //Added by transformer
                mySource.removed = true; //Added by transformer
            else //Added by transformer
                mySource.cleanup(); // end the source, free memory
        }
        sourceMap.remove( sourcename );
    }
```

`paulscode.sound.StreamThread`: Checks if the source has been removed, if that is the case the source will be cleaned up and removed from the list.

Inside `StreamThread.run();`
```java
                [ ... ]
                synchronized( listLock )
                {
                    iter = streamingSources.listIterator();
                    while( !dying() && iter.hasNext() )
                    {
                        src = iter.next();
                        if( src.removed ) //Added by transformer
                        { 
                            src.cleanup(); //Added by transformer
                            src = null; //Added by transformer
                        }
                        if( src == null )
                        {
                            iter.remove();
                        }
                        else if( src.stopped() )
                        {
                            if( !src.rawDataStream )
                                iter.remove();
                        }
                        [ ... ]
```

**How it is implemented**
Unfortunately there is no way to patch the sound engine directly, so I added an asm transformer. It is loaded on both sides (client & server), but it will have no affect server side (as the classes simply don't exist). I'm not sure whether this is the right way to do so, just let me know if and how to implement it better.

In Regards
CreativeMD