### PR TITLE
Preserve original position for decoration events.

### DIFF
--- a/patches/minecraft/net/minecraft/world/biome/BiomeDecorator.java.patch
+++ b/patches/minecraft/net/minecraft/world/biome/BiomeDecorator.java.patch
@@ -1,139 +1,140 @@
 --- ../src-base/minecraft/net/minecraft/world/biome/BiomeDecorator.java
 +++ ../src-work/minecraft/net/minecraft/world/biome/BiomeDecorator.java
-@@ -92,8 +92,10 @@
+@@ -92,8 +92,11 @@
  
      protected void func_150513_a(Biome p_150513_1_, World p_150513_2_, Random p_150513_3_)
      {
-+        net.minecraftforge.common.MinecraftForge.EVENT_BUS.post(new net.minecraftforge.event.terraingen.DecorateBiomeEvent.Pre(p_150513_2_, p_150513_3_, field_180294_c));
++        net.minecraft.util.math.ChunkPos forgeChunkPos = new net.minecraft.util.math.ChunkPos(field_180294_c); // actual ChunkPos instead of BlockPos, used for events
++        net.minecraftforge.common.MinecraftForge.EVENT_BUS.post(new net.minecraftforge.event.terraingen.DecorateBiomeEvent.Pre(p_150513_2_, p_150513_3_, forgeChunkPos));
          this.func_76797_b(p_150513_2_, p_150513_3_);
  
-+        if(net.minecraftforge.event.terraingen.TerrainGen.decorate(p_150513_2_, p_150513_3_, field_180294_c, net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.SAND))
++        if(net.minecraftforge.event.terraingen.TerrainGen.decorate(p_150513_2_, p_150513_3_, forgeChunkPos, net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.SAND))
          for (int i = 0; i < this.field_76805_H; ++i)
          {
              int j = p_150513_3_.nextInt(16) + 8;
-@@ -101,6 +103,7 @@
+@@ -101,6 +104,7 @@
              this.field_76810_g.func_180709_b(p_150513_2_, p_150513_3_, p_150513_2_.func_175672_r(this.field_180294_c.func_177982_a(j, 0, k)));
          }
  
-+        if(net.minecraftforge.event.terraingen.TerrainGen.decorate(p_150513_2_, p_150513_3_, field_180294_c, net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.CLAY))
++        if(net.minecraftforge.event.terraingen.TerrainGen.decorate(p_150513_2_, p_150513_3_, forgeChunkPos, net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.CLAY))
          for (int i1 = 0; i1 < this.field_76806_I; ++i1)
          {
              int l1 = p_150513_3_.nextInt(16) + 8;
-@@ -108,6 +111,7 @@
+@@ -108,6 +112,7 @@
              this.field_76809_f.func_180709_b(p_150513_2_, p_150513_3_, p_150513_2_.func_175672_r(this.field_180294_c.func_177982_a(l1, 0, i6)));
          }
  
-+        if(net.minecraftforge.event.terraingen.TerrainGen.decorate(p_150513_2_, p_150513_3_, field_180294_c, net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.SAND_PASS2))
++        if(net.minecraftforge.event.terraingen.TerrainGen.decorate(p_150513_2_, p_150513_3_, forgeChunkPos, net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.SAND_PASS2))
          for (int j1 = 0; j1 < this.field_76801_G; ++j1)
          {
              int i2 = p_150513_3_.nextInt(16) + 8;
-@@ -122,6 +126,7 @@
+@@ -122,6 +127,7 @@
              ++k1;
          }
  
-+        if(net.minecraftforge.event.terraingen.TerrainGen.decorate(p_150513_2_, p_150513_3_, field_180294_c, net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.TREE))
++        if(net.minecraftforge.event.terraingen.TerrainGen.decorate(p_150513_2_, p_150513_3_, forgeChunkPos, net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.TREE))
          for (int j2 = 0; j2 < k1; ++j2)
          {
              int k6 = p_150513_3_.nextInt(16) + 8;
-@@ -136,6 +141,7 @@
+@@ -136,6 +142,7 @@
              }
          }
  
-+        if(net.minecraftforge.event.terraingen.TerrainGen.decorate(p_150513_2_, p_150513_3_, field_180294_c, net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.BIG_SHROOM))
++        if(net.minecraftforge.event.terraingen.TerrainGen.decorate(p_150513_2_, p_150513_3_, forgeChunkPos, net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.BIG_SHROOM))
          for (int k2 = 0; k2 < this.field_76807_J; ++k2)
          {
              int l6 = p_150513_3_.nextInt(16) + 8;
-@@ -143,6 +149,7 @@
+@@ -143,6 +150,7 @@
              this.field_76826_u.func_180709_b(p_150513_2_, p_150513_3_, p_150513_2_.func_175645_m(this.field_180294_c.func_177982_a(l6, 0, k10)));
          }
  
-+        if(net.minecraftforge.event.terraingen.TerrainGen.decorate(p_150513_2_, p_150513_3_, field_180294_c, net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.FLOWERS))
++        if(net.minecraftforge.event.terraingen.TerrainGen.decorate(p_150513_2_, p_150513_3_, forgeChunkPos, net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.FLOWERS))
          for (int l2 = 0; l2 < this.field_76802_A; ++l2)
          {
              int i7 = p_150513_3_.nextInt(16) + 8;
-@@ -164,6 +171,7 @@
+@@ -164,6 +172,7 @@
              }
          }
  
-+        if(net.minecraftforge.event.terraingen.TerrainGen.decorate(p_150513_2_, p_150513_3_, field_180294_c, net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.GRASS))
++        if(net.minecraftforge.event.terraingen.TerrainGen.decorate(p_150513_2_, p_150513_3_, forgeChunkPos, net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.GRASS))
          for (int i3 = 0; i3 < this.field_76803_B; ++i3)
          {
              int j7 = p_150513_3_.nextInt(16) + 8;
-@@ -177,6 +185,7 @@
+@@ -177,6 +186,7 @@
              }
          }
  
-+        if(net.minecraftforge.event.terraingen.TerrainGen.decorate(p_150513_2_, p_150513_3_, field_180294_c, net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.DEAD_BUSH))
++        if(net.minecraftforge.event.terraingen.TerrainGen.decorate(p_150513_2_, p_150513_3_, forgeChunkPos, net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.DEAD_BUSH))
          for (int j3 = 0; j3 < this.field_76804_C; ++j3)
          {
              int k7 = p_150513_3_.nextInt(16) + 8;
-@@ -190,6 +199,7 @@
+@@ -190,6 +200,7 @@
              }
          }
  
-+        if(net.minecraftforge.event.terraingen.TerrainGen.decorate(p_150513_2_, p_150513_3_, field_180294_c, net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.LILYPAD))
++        if(net.minecraftforge.event.terraingen.TerrainGen.decorate(p_150513_2_, p_150513_3_, forgeChunkPos, net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.LILYPAD))
          for (int k3 = 0; k3 < this.field_76833_y; ++k3)
          {
              int l7 = p_150513_3_.nextInt(16) + 8;
-@@ -216,6 +226,8 @@
+@@ -216,6 +227,8 @@
              }
          }
  
-+        if(net.minecraftforge.event.terraingen.TerrainGen.decorate(p_150513_2_, p_150513_3_, field_180294_c, net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.SHROOM))
++        if(net.minecraftforge.event.terraingen.TerrainGen.decorate(p_150513_2_, p_150513_3_, forgeChunkPos, net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.SHROOM))
 +        {
          for (int l3 = 0; l3 < this.field_76798_D; ++l3)
          {
              if (p_150513_3_.nextInt(4) == 0)
-@@ -266,7 +278,9 @@
+@@ -266,7 +279,9 @@
                  this.field_76827_t.func_180709_b(p_150513_2_, p_150513_3_, this.field_180294_c.func_177982_a(j4, l15, l8));
              }
          }
 -
 +        } // End of Mushroom generation
-+        if(net.minecraftforge.event.terraingen.TerrainGen.decorate(p_150513_2_, p_150513_3_, field_180294_c, net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.REED))
++        if(net.minecraftforge.event.terraingen.TerrainGen.decorate(p_150513_2_, p_150513_3_, forgeChunkPos, net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.REED))
 +        {
          for (int k4 = 0; k4 < this.field_76799_E; ++k4)
          {
              int i9 = p_150513_3_.nextInt(16) + 8;
-@@ -292,7 +306,8 @@
+@@ -292,7 +307,8 @@
                  this.field_76825_v.func_180709_b(p_150513_2_, p_150513_3_, this.field_180294_c.func_177982_a(j9, i19, i13));
              }
          }
 -
 +        } // End of Reed generation
-+        if(net.minecraftforge.event.terraingen.TerrainGen.decorate(p_150513_2_, p_150513_3_, field_180294_c, net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.PUMPKIN))
++        if(net.minecraftforge.event.terraingen.TerrainGen.decorate(p_150513_2_, p_150513_3_, forgeChunkPos, net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.PUMPKIN))
          if (p_150513_3_.nextInt(32) == 0)
          {
              int i5 = p_150513_3_.nextInt(16) + 8;
-@@ -306,6 +321,7 @@
+@@ -306,6 +322,7 @@
              }
          }
  
-+        if(net.minecraftforge.event.terraingen.TerrainGen.decorate(p_150513_2_, p_150513_3_, field_180294_c, net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.CACTUS))
++        if(net.minecraftforge.event.terraingen.TerrainGen.decorate(p_150513_2_, p_150513_3_, forgeChunkPos, net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.CACTUS))
          for (int j5 = 0; j5 < this.field_76800_F; ++j5)
          {
              int l9 = p_150513_3_.nextInt(16) + 8;
-@@ -321,6 +337,7 @@
+@@ -321,6 +338,7 @@
  
          if (this.field_76808_K)
          {
-+            if(net.minecraftforge.event.terraingen.TerrainGen.decorate(p_150513_2_, p_150513_3_, field_180294_c, net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.LAKE_WATER))
++            if(net.minecraftforge.event.terraingen.TerrainGen.decorate(p_150513_2_, p_150513_3_, forgeChunkPos, net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.LAKE_WATER))
              for (int k5 = 0; k5 < 50; ++k5)
              {
                  int i10 = p_150513_3_.nextInt(16) + 8;
-@@ -335,6 +352,7 @@
+@@ -335,6 +353,7 @@
                  }
              }
  
-+            if(net.minecraftforge.event.terraingen.TerrainGen.decorate(p_150513_2_, p_150513_3_, field_180294_c, net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.LAKE_LAVA))
++            if(net.minecraftforge.event.terraingen.TerrainGen.decorate(p_150513_2_, p_150513_3_, forgeChunkPos, net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.LAKE_LAVA))
              for (int l5 = 0; l5 < 20; ++l5)
              {
                  int j10 = p_150513_3_.nextInt(16) + 8;
-@@ -344,21 +362,35 @@
+@@ -344,21 +363,35 @@
                  (new WorldGenLiquids(Blocks.field_150356_k)).func_180709_b(p_150513_2_, p_150513_3_, blockpos3);
              }
          }
-+        net.minecraftforge.common.MinecraftForge.EVENT_BUS.post(new net.minecraftforge.event.terraingen.DecorateBiomeEvent.Post(p_150513_2_, p_150513_3_, field_180294_c));
++        net.minecraftforge.common.MinecraftForge.EVENT_BUS.post(new net.minecraftforge.event.terraingen.DecorateBiomeEvent.Post(p_150513_2_, p_150513_3_, forgeChunkPos));
      }
  
      protected void func_76797_b(World p_76797_1_, Random p_76797_2_)

--- a/patches/minecraft/net/minecraft/world/biome/BiomeDecorator.java.patch
+++ b/patches/minecraft/net/minecraft/world/biome/BiomeDecorator.java.patch
@@ -4,7 +4,7 @@
  
      protected void func_150513_a(Biome p_150513_1_, World p_150513_2_, Random p_150513_3_)
      {
-+        net.minecraftforge.event.terraingen.TerrainGen.decorateBiomePre(p_150513_2_, p_150513_3_, field_180294_c);
++        net.minecraftforge.common.MinecraftForge.EVENT_BUS.post(new net.minecraftforge.event.terraingen.DecorateBiomeEvent.Pre(p_150513_2_, p_150513_3_, field_180294_c));
          this.func_76797_b(p_150513_2_, p_150513_3_);
  
 +        if(net.minecraftforge.event.terraingen.TerrainGen.decorate(p_150513_2_, p_150513_3_, field_180294_c, net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.SAND))
@@ -133,7 +133,7 @@
                  (new WorldGenLiquids(Blocks.field_150356_k)).func_180709_b(p_150513_2_, p_150513_3_, blockpos3);
              }
          }
-+        net.minecraftforge.event.terraingen.TerrainGen.decorateBiomePost(p_150513_2_, p_150513_3_, field_180294_c);
++        net.minecraftforge.common.MinecraftForge.EVENT_BUS.post(new net.minecraftforge.event.terraingen.DecorateBiomeEvent.Post(p_150513_2_, p_150513_3_, field_180294_c));
      }
  
      protected void func_76797_b(World p_76797_1_, Random p_76797_2_)

--- a/patches/minecraft/net/minecraft/world/biome/BiomeDecorator.java.patch
+++ b/patches/minecraft/net/minecraft/world/biome/BiomeDecorator.java.patch
@@ -4,10 +4,10 @@
  
      protected void func_150513_a(Biome p_150513_1_, World p_150513_2_, Random p_150513_3_)
      {
-+        net.minecraftforge.common.MinecraftForge.EVENT_BUS.post(new net.minecraftforge.event.terraingen.DecorateBiomeEvent.Pre(p_150513_2_, p_150513_3_, field_180294_c));
++        net.minecraftforge.common.MinecraftForge.EVENT_BUS.post(new net.minecraftforge.event.terraingen.DecorateBiomeEvent.Pre(p_150513_2_, p_150513_3_, field_180294_c, field_180294_c));
          this.func_76797_b(p_150513_2_, p_150513_3_);
  
-+        if(net.minecraftforge.event.terraingen.TerrainGen.decorate(p_150513_2_, p_150513_3_, field_180294_c, net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.SAND))
++        if(net.minecraftforge.event.terraingen.TerrainGen.decorate(p_150513_2_, p_150513_3_, field_180294_c, net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.SAND, field_180294_c))
          for (int i = 0; i < this.field_76805_H; ++i)
          {
              int j = p_150513_3_.nextInt(16) + 8;
@@ -15,7 +15,7 @@
              this.field_76810_g.func_180709_b(p_150513_2_, p_150513_3_, p_150513_2_.func_175672_r(this.field_180294_c.func_177982_a(j, 0, k)));
          }
  
-+        if(net.minecraftforge.event.terraingen.TerrainGen.decorate(p_150513_2_, p_150513_3_, field_180294_c, net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.CLAY))
++        if(net.minecraftforge.event.terraingen.TerrainGen.decorate(p_150513_2_, p_150513_3_, field_180294_c, net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.CLAY, field_180294_c))
          for (int i1 = 0; i1 < this.field_76806_I; ++i1)
          {
              int l1 = p_150513_3_.nextInt(16) + 8;
@@ -23,7 +23,7 @@
              this.field_76809_f.func_180709_b(p_150513_2_, p_150513_3_, p_150513_2_.func_175672_r(this.field_180294_c.func_177982_a(l1, 0, i6)));
          }
  
-+        if(net.minecraftforge.event.terraingen.TerrainGen.decorate(p_150513_2_, p_150513_3_, field_180294_c, net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.SAND_PASS2))
++        if(net.minecraftforge.event.terraingen.TerrainGen.decorate(p_150513_2_, p_150513_3_, field_180294_c, net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.SAND_PASS2, field_180294_c))
          for (int j1 = 0; j1 < this.field_76801_G; ++j1)
          {
              int i2 = p_150513_3_.nextInt(16) + 8;
@@ -31,7 +31,7 @@
              ++k1;
          }
  
-+        if(net.minecraftforge.event.terraingen.TerrainGen.decorate(p_150513_2_, p_150513_3_, field_180294_c, net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.TREE))
++        if(net.minecraftforge.event.terraingen.TerrainGen.decorate(p_150513_2_, p_150513_3_, field_180294_c, net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.TREE, field_180294_c))
          for (int j2 = 0; j2 < k1; ++j2)
          {
              int k6 = p_150513_3_.nextInt(16) + 8;
@@ -39,7 +39,7 @@
              }
          }
  
-+        if(net.minecraftforge.event.terraingen.TerrainGen.decorate(p_150513_2_, p_150513_3_, field_180294_c, net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.BIG_SHROOM))
++        if(net.minecraftforge.event.terraingen.TerrainGen.decorate(p_150513_2_, p_150513_3_, field_180294_c, net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.BIG_SHROOM, field_180294_c))
          for (int k2 = 0; k2 < this.field_76807_J; ++k2)
          {
              int l6 = p_150513_3_.nextInt(16) + 8;
@@ -47,7 +47,7 @@
              this.field_76826_u.func_180709_b(p_150513_2_, p_150513_3_, p_150513_2_.func_175645_m(this.field_180294_c.func_177982_a(l6, 0, k10)));
          }
  
-+        if(net.minecraftforge.event.terraingen.TerrainGen.decorate(p_150513_2_, p_150513_3_, field_180294_c, net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.FLOWERS))
++        if(net.minecraftforge.event.terraingen.TerrainGen.decorate(p_150513_2_, p_150513_3_, field_180294_c, net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.FLOWERS, field_180294_c))
          for (int l2 = 0; l2 < this.field_76802_A; ++l2)
          {
              int i7 = p_150513_3_.nextInt(16) + 8;
@@ -55,7 +55,7 @@
              }
          }
  
-+        if(net.minecraftforge.event.terraingen.TerrainGen.decorate(p_150513_2_, p_150513_3_, field_180294_c, net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.GRASS))
++        if(net.minecraftforge.event.terraingen.TerrainGen.decorate(p_150513_2_, p_150513_3_, field_180294_c, net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.GRASS, field_180294_c))
          for (int i3 = 0; i3 < this.field_76803_B; ++i3)
          {
              int j7 = p_150513_3_.nextInt(16) + 8;
@@ -63,7 +63,7 @@
              }
          }
  
-+        if(net.minecraftforge.event.terraingen.TerrainGen.decorate(p_150513_2_, p_150513_3_, field_180294_c, net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.DEAD_BUSH))
++        if(net.minecraftforge.event.terraingen.TerrainGen.decorate(p_150513_2_, p_150513_3_, field_180294_c, net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.DEAD_BUSH, field_180294_c))
          for (int j3 = 0; j3 < this.field_76804_C; ++j3)
          {
              int k7 = p_150513_3_.nextInt(16) + 8;
@@ -71,7 +71,7 @@
              }
          }
  
-+        if(net.minecraftforge.event.terraingen.TerrainGen.decorate(p_150513_2_, p_150513_3_, field_180294_c, net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.LILYPAD))
++        if(net.minecraftforge.event.terraingen.TerrainGen.decorate(p_150513_2_, p_150513_3_, field_180294_c, net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.LILYPAD, field_180294_c))
          for (int k3 = 0; k3 < this.field_76833_y; ++k3)
          {
              int l7 = p_150513_3_.nextInt(16) + 8;
@@ -79,7 +79,7 @@
              }
          }
  
-+        if(net.minecraftforge.event.terraingen.TerrainGen.decorate(p_150513_2_, p_150513_3_, field_180294_c, net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.SHROOM))
++        if(net.minecraftforge.event.terraingen.TerrainGen.decorate(p_150513_2_, p_150513_3_, field_180294_c, net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.SHROOM, field_180294_c))
 +        {
          for (int l3 = 0; l3 < this.field_76798_D; ++l3)
          {
@@ -90,7 +90,7 @@
          }
 -
 +        } // End of Mushroom generation
-+        if(net.minecraftforge.event.terraingen.TerrainGen.decorate(p_150513_2_, p_150513_3_, field_180294_c, net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.REED))
++        if(net.minecraftforge.event.terraingen.TerrainGen.decorate(p_150513_2_, p_150513_3_, field_180294_c, net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.REED, field_180294_c))
 +        {
          for (int k4 = 0; k4 < this.field_76799_E; ++k4)
          {
@@ -101,7 +101,7 @@
          }
 -
 +        } // End of Reed generation
-+        if(net.minecraftforge.event.terraingen.TerrainGen.decorate(p_150513_2_, p_150513_3_, field_180294_c, net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.PUMPKIN))
++        if(net.minecraftforge.event.terraingen.TerrainGen.decorate(p_150513_2_, p_150513_3_, field_180294_c, net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.PUMPKIN, field_180294_c))
          if (p_150513_3_.nextInt(32) == 0)
          {
              int i5 = p_150513_3_.nextInt(16) + 8;
@@ -109,7 +109,7 @@
              }
          }
  
-+        if(net.minecraftforge.event.terraingen.TerrainGen.decorate(p_150513_2_, p_150513_3_, field_180294_c, net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.CACTUS))
++        if(net.minecraftforge.event.terraingen.TerrainGen.decorate(p_150513_2_, p_150513_3_, field_180294_c, net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.CACTUS, field_180294_c))
          for (int j5 = 0; j5 < this.field_76800_F; ++j5)
          {
              int l9 = p_150513_3_.nextInt(16) + 8;
@@ -117,7 +117,7 @@
  
          if (this.field_76808_K)
          {
-+            if(net.minecraftforge.event.terraingen.TerrainGen.decorate(p_150513_2_, p_150513_3_, field_180294_c, net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.LAKE_WATER))
++            if(net.minecraftforge.event.terraingen.TerrainGen.decorate(p_150513_2_, p_150513_3_, field_180294_c, net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.LAKE_WATER, field_180294_c))
              for (int k5 = 0; k5 < 50; ++k5)
              {
                  int i10 = p_150513_3_.nextInt(16) + 8;
@@ -125,7 +125,7 @@
                  }
              }
  
-+            if(net.minecraftforge.event.terraingen.TerrainGen.decorate(p_150513_2_, p_150513_3_, field_180294_c, net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.LAKE_LAVA))
++            if(net.minecraftforge.event.terraingen.TerrainGen.decorate(p_150513_2_, p_150513_3_, field_180294_c, net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.LAKE_LAVA, field_180294_c))
              for (int l5 = 0; l5 < 20; ++l5)
              {
                  int j10 = p_150513_3_.nextInt(16) + 8;
@@ -133,7 +133,7 @@
                  (new WorldGenLiquids(Blocks.field_150356_k)).func_180709_b(p_150513_2_, p_150513_3_, blockpos3);
              }
          }
-+        net.minecraftforge.common.MinecraftForge.EVENT_BUS.post(new net.minecraftforge.event.terraingen.DecorateBiomeEvent.Post(p_150513_2_, p_150513_3_, field_180294_c));
++        net.minecraftforge.common.MinecraftForge.EVENT_BUS.post(new net.minecraftforge.event.terraingen.DecorateBiomeEvent.Post(p_150513_2_, p_150513_3_, field_180294_c, field_180294_c));
      }
  
      protected void func_76797_b(World p_76797_1_, Random p_76797_2_)

--- a/patches/minecraft/net/minecraft/world/biome/BiomeDecorator.java.patch
+++ b/patches/minecraft/net/minecraft/world/biome/BiomeDecorator.java.patch
@@ -4,10 +4,10 @@
  
      protected void func_150513_a(Biome p_150513_1_, World p_150513_2_, Random p_150513_3_)
      {
-+        net.minecraftforge.common.MinecraftForge.EVENT_BUS.post(new net.minecraftforge.event.terraingen.DecorateBiomeEvent.Pre(p_150513_2_, p_150513_3_, field_180294_c, new net.minecraft.util.math.ChunkPos(field_180294_c)));
++        net.minecraftforge.event.terraingen.TerrainGen.decorateBiomePre(p_150513_2_, p_150513_3_, field_180294_c);
          this.func_76797_b(p_150513_2_, p_150513_3_);
  
-+        if(net.minecraftforge.event.terraingen.TerrainGen.decorate(p_150513_2_, p_150513_3_, field_180294_c, net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.SAND, new net.minecraft.util.math.ChunkPos(field_180294_c)))
++        if(net.minecraftforge.event.terraingen.TerrainGen.decorate(p_150513_2_, p_150513_3_, field_180294_c, net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.SAND))
          for (int i = 0; i < this.field_76805_H; ++i)
          {
              int j = p_150513_3_.nextInt(16) + 8;
@@ -15,7 +15,7 @@
              this.field_76810_g.func_180709_b(p_150513_2_, p_150513_3_, p_150513_2_.func_175672_r(this.field_180294_c.func_177982_a(j, 0, k)));
          }
  
-+        if(net.minecraftforge.event.terraingen.TerrainGen.decorate(p_150513_2_, p_150513_3_, field_180294_c, net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.CLAY, new net.minecraft.util.math.ChunkPos(field_180294_c)))
++        if(net.minecraftforge.event.terraingen.TerrainGen.decorate(p_150513_2_, p_150513_3_, field_180294_c, net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.CLAY))
          for (int i1 = 0; i1 < this.field_76806_I; ++i1)
          {
              int l1 = p_150513_3_.nextInt(16) + 8;
@@ -23,7 +23,7 @@
              this.field_76809_f.func_180709_b(p_150513_2_, p_150513_3_, p_150513_2_.func_175672_r(this.field_180294_c.func_177982_a(l1, 0, i6)));
          }
  
-+        if(net.minecraftforge.event.terraingen.TerrainGen.decorate(p_150513_2_, p_150513_3_, field_180294_c, net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.SAND_PASS2, new net.minecraft.util.math.ChunkPos(field_180294_c)))
++        if(net.minecraftforge.event.terraingen.TerrainGen.decorate(p_150513_2_, p_150513_3_, field_180294_c, net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.SAND_PASS2))
          for (int j1 = 0; j1 < this.field_76801_G; ++j1)
          {
              int i2 = p_150513_3_.nextInt(16) + 8;
@@ -31,7 +31,7 @@
              ++k1;
          }
  
-+        if(net.minecraftforge.event.terraingen.TerrainGen.decorate(p_150513_2_, p_150513_3_, field_180294_c, net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.TREE, new net.minecraft.util.math.ChunkPos(field_180294_c)))
++        if(net.minecraftforge.event.terraingen.TerrainGen.decorate(p_150513_2_, p_150513_3_, field_180294_c, net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.TREE))
          for (int j2 = 0; j2 < k1; ++j2)
          {
              int k6 = p_150513_3_.nextInt(16) + 8;
@@ -39,7 +39,7 @@
              }
          }
  
-+        if(net.minecraftforge.event.terraingen.TerrainGen.decorate(p_150513_2_, p_150513_3_, field_180294_c, net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.BIG_SHROOM, new net.minecraft.util.math.ChunkPos(field_180294_c)))
++        if(net.minecraftforge.event.terraingen.TerrainGen.decorate(p_150513_2_, p_150513_3_, field_180294_c, net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.BIG_SHROOM))
          for (int k2 = 0; k2 < this.field_76807_J; ++k2)
          {
              int l6 = p_150513_3_.nextInt(16) + 8;
@@ -47,7 +47,7 @@
              this.field_76826_u.func_180709_b(p_150513_2_, p_150513_3_, p_150513_2_.func_175645_m(this.field_180294_c.func_177982_a(l6, 0, k10)));
          }
  
-+        if(net.minecraftforge.event.terraingen.TerrainGen.decorate(p_150513_2_, p_150513_3_, field_180294_c, net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.FLOWERS, new net.minecraft.util.math.ChunkPos(field_180294_c)))
++        if(net.minecraftforge.event.terraingen.TerrainGen.decorate(p_150513_2_, p_150513_3_, field_180294_c, net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.FLOWERS))
          for (int l2 = 0; l2 < this.field_76802_A; ++l2)
          {
              int i7 = p_150513_3_.nextInt(16) + 8;
@@ -55,7 +55,7 @@
              }
          }
  
-+        if(net.minecraftforge.event.terraingen.TerrainGen.decorate(p_150513_2_, p_150513_3_, field_180294_c, net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.GRASS, new net.minecraft.util.math.ChunkPos(field_180294_c)))
++        if(net.minecraftforge.event.terraingen.TerrainGen.decorate(p_150513_2_, p_150513_3_, field_180294_c, net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.GRASS))
          for (int i3 = 0; i3 < this.field_76803_B; ++i3)
          {
              int j7 = p_150513_3_.nextInt(16) + 8;
@@ -63,7 +63,7 @@
              }
          }
  
-+        if(net.minecraftforge.event.terraingen.TerrainGen.decorate(p_150513_2_, p_150513_3_, field_180294_c, net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.DEAD_BUSH, new net.minecraft.util.math.ChunkPos(field_180294_c)))
++        if(net.minecraftforge.event.terraingen.TerrainGen.decorate(p_150513_2_, p_150513_3_, field_180294_c, net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.DEAD_BUSH))
          for (int j3 = 0; j3 < this.field_76804_C; ++j3)
          {
              int k7 = p_150513_3_.nextInt(16) + 8;
@@ -71,7 +71,7 @@
              }
          }
  
-+        if(net.minecraftforge.event.terraingen.TerrainGen.decorate(p_150513_2_, p_150513_3_, field_180294_c, net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.LILYPAD, new net.minecraft.util.math.ChunkPos(field_180294_c)))
++        if(net.minecraftforge.event.terraingen.TerrainGen.decorate(p_150513_2_, p_150513_3_, field_180294_c, net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.LILYPAD))
          for (int k3 = 0; k3 < this.field_76833_y; ++k3)
          {
              int l7 = p_150513_3_.nextInt(16) + 8;
@@ -79,7 +79,7 @@
              }
          }
  
-+        if(net.minecraftforge.event.terraingen.TerrainGen.decorate(p_150513_2_, p_150513_3_, field_180294_c, net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.SHROOM, new net.minecraft.util.math.ChunkPos(field_180294_c)))
++        if(net.minecraftforge.event.terraingen.TerrainGen.decorate(p_150513_2_, p_150513_3_, field_180294_c, net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.SHROOM))
 +        {
          for (int l3 = 0; l3 < this.field_76798_D; ++l3)
          {
@@ -90,7 +90,7 @@
          }
 -
 +        } // End of Mushroom generation
-+        if(net.minecraftforge.event.terraingen.TerrainGen.decorate(p_150513_2_, p_150513_3_, field_180294_c, net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.REED, new net.minecraft.util.math.ChunkPos(field_180294_c)))
++        if(net.minecraftforge.event.terraingen.TerrainGen.decorate(p_150513_2_, p_150513_3_, field_180294_c, net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.REED))
 +        {
          for (int k4 = 0; k4 < this.field_76799_E; ++k4)
          {
@@ -101,7 +101,7 @@
          }
 -
 +        } // End of Reed generation
-+        if(net.minecraftforge.event.terraingen.TerrainGen.decorate(p_150513_2_, p_150513_3_, field_180294_c, net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.PUMPKIN, new net.minecraft.util.math.ChunkPos(field_180294_c)))
++        if(net.minecraftforge.event.terraingen.TerrainGen.decorate(p_150513_2_, p_150513_3_, field_180294_c, net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.PUMPKIN))
          if (p_150513_3_.nextInt(32) == 0)
          {
              int i5 = p_150513_3_.nextInt(16) + 8;
@@ -109,7 +109,7 @@
              }
          }
  
-+        if(net.minecraftforge.event.terraingen.TerrainGen.decorate(p_150513_2_, p_150513_3_, field_180294_c, net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.CACTUS, new net.minecraft.util.math.ChunkPos(field_180294_c)))
++        if(net.minecraftforge.event.terraingen.TerrainGen.decorate(p_150513_2_, p_150513_3_, field_180294_c, net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.CACTUS))
          for (int j5 = 0; j5 < this.field_76800_F; ++j5)
          {
              int l9 = p_150513_3_.nextInt(16) + 8;
@@ -117,7 +117,7 @@
  
          if (this.field_76808_K)
          {
-+            if(net.minecraftforge.event.terraingen.TerrainGen.decorate(p_150513_2_, p_150513_3_, field_180294_c, net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.LAKE_WATER, new net.minecraft.util.math.ChunkPos(field_180294_c)))
++            if(net.minecraftforge.event.terraingen.TerrainGen.decorate(p_150513_2_, p_150513_3_, field_180294_c, net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.LAKE_WATER))
              for (int k5 = 0; k5 < 50; ++k5)
              {
                  int i10 = p_150513_3_.nextInt(16) + 8;
@@ -125,7 +125,7 @@
                  }
              }
  
-+            if(net.minecraftforge.event.terraingen.TerrainGen.decorate(p_150513_2_, p_150513_3_, field_180294_c, net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.LAKE_LAVA, new net.minecraft.util.math.ChunkPos(field_180294_c)))
++            if(net.minecraftforge.event.terraingen.TerrainGen.decorate(p_150513_2_, p_150513_3_, field_180294_c, net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.LAKE_LAVA))
              for (int l5 = 0; l5 < 20; ++l5)
              {
                  int j10 = p_150513_3_.nextInt(16) + 8;
@@ -133,7 +133,7 @@
                  (new WorldGenLiquids(Blocks.field_150356_k)).func_180709_b(p_150513_2_, p_150513_3_, blockpos3);
              }
          }
-+        net.minecraftforge.common.MinecraftForge.EVENT_BUS.post(new net.minecraftforge.event.terraingen.DecorateBiomeEvent.Post(p_150513_2_, p_150513_3_, field_180294_c, new net.minecraft.util.math.ChunkPos(field_180294_c)));
++        net.minecraftforge.event.terraingen.TerrainGen.decorateBiomePost(p_150513_2_, p_150513_3_, field_180294_c);
      }
  
      protected void func_76797_b(World p_76797_1_, Random p_76797_2_)

--- a/patches/minecraft/net/minecraft/world/biome/BiomeDecorator.java.patch
+++ b/patches/minecraft/net/minecraft/world/biome/BiomeDecorator.java.patch
@@ -4,10 +4,10 @@
  
      protected void func_150513_a(Biome p_150513_1_, World p_150513_2_, Random p_150513_3_)
      {
-+        net.minecraftforge.common.MinecraftForge.EVENT_BUS.post(new net.minecraftforge.event.terraingen.DecorateBiomeEvent.Pre(p_150513_2_, p_150513_3_, field_180294_c, field_180294_c));
++        net.minecraftforge.common.MinecraftForge.EVENT_BUS.post(new net.minecraftforge.event.terraingen.DecorateBiomeEvent.Pre(p_150513_2_, p_150513_3_, field_180294_c, new net.minecraft.util.math.ChunkPos(field_180294_c)));
          this.func_76797_b(p_150513_2_, p_150513_3_);
  
-+        if(net.minecraftforge.event.terraingen.TerrainGen.decorate(p_150513_2_, p_150513_3_, field_180294_c, net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.SAND, field_180294_c))
++        if(net.minecraftforge.event.terraingen.TerrainGen.decorate(p_150513_2_, p_150513_3_, field_180294_c, net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.SAND, new net.minecraft.util.math.ChunkPos(field_180294_c)))
          for (int i = 0; i < this.field_76805_H; ++i)
          {
              int j = p_150513_3_.nextInt(16) + 8;
@@ -15,7 +15,7 @@
              this.field_76810_g.func_180709_b(p_150513_2_, p_150513_3_, p_150513_2_.func_175672_r(this.field_180294_c.func_177982_a(j, 0, k)));
          }
  
-+        if(net.minecraftforge.event.terraingen.TerrainGen.decorate(p_150513_2_, p_150513_3_, field_180294_c, net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.CLAY, field_180294_c))
++        if(net.minecraftforge.event.terraingen.TerrainGen.decorate(p_150513_2_, p_150513_3_, field_180294_c, net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.CLAY, new net.minecraft.util.math.ChunkPos(field_180294_c)))
          for (int i1 = 0; i1 < this.field_76806_I; ++i1)
          {
              int l1 = p_150513_3_.nextInt(16) + 8;
@@ -23,7 +23,7 @@
              this.field_76809_f.func_180709_b(p_150513_2_, p_150513_3_, p_150513_2_.func_175672_r(this.field_180294_c.func_177982_a(l1, 0, i6)));
          }
  
-+        if(net.minecraftforge.event.terraingen.TerrainGen.decorate(p_150513_2_, p_150513_3_, field_180294_c, net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.SAND_PASS2, field_180294_c))
++        if(net.minecraftforge.event.terraingen.TerrainGen.decorate(p_150513_2_, p_150513_3_, field_180294_c, net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.SAND_PASS2, new net.minecraft.util.math.ChunkPos(field_180294_c)))
          for (int j1 = 0; j1 < this.field_76801_G; ++j1)
          {
              int i2 = p_150513_3_.nextInt(16) + 8;
@@ -31,7 +31,7 @@
              ++k1;
          }
  
-+        if(net.minecraftforge.event.terraingen.TerrainGen.decorate(p_150513_2_, p_150513_3_, field_180294_c, net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.TREE, field_180294_c))
++        if(net.minecraftforge.event.terraingen.TerrainGen.decorate(p_150513_2_, p_150513_3_, field_180294_c, net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.TREE, new net.minecraft.util.math.ChunkPos(field_180294_c)))
          for (int j2 = 0; j2 < k1; ++j2)
          {
              int k6 = p_150513_3_.nextInt(16) + 8;
@@ -39,7 +39,7 @@
              }
          }
  
-+        if(net.minecraftforge.event.terraingen.TerrainGen.decorate(p_150513_2_, p_150513_3_, field_180294_c, net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.BIG_SHROOM, field_180294_c))
++        if(net.minecraftforge.event.terraingen.TerrainGen.decorate(p_150513_2_, p_150513_3_, field_180294_c, net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.BIG_SHROOM, new net.minecraft.util.math.ChunkPos(field_180294_c)))
          for (int k2 = 0; k2 < this.field_76807_J; ++k2)
          {
              int l6 = p_150513_3_.nextInt(16) + 8;
@@ -47,7 +47,7 @@
              this.field_76826_u.func_180709_b(p_150513_2_, p_150513_3_, p_150513_2_.func_175645_m(this.field_180294_c.func_177982_a(l6, 0, k10)));
          }
  
-+        if(net.minecraftforge.event.terraingen.TerrainGen.decorate(p_150513_2_, p_150513_3_, field_180294_c, net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.FLOWERS, field_180294_c))
++        if(net.minecraftforge.event.terraingen.TerrainGen.decorate(p_150513_2_, p_150513_3_, field_180294_c, net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.FLOWERS, new net.minecraft.util.math.ChunkPos(field_180294_c)))
          for (int l2 = 0; l2 < this.field_76802_A; ++l2)
          {
              int i7 = p_150513_3_.nextInt(16) + 8;
@@ -55,7 +55,7 @@
              }
          }
  
-+        if(net.minecraftforge.event.terraingen.TerrainGen.decorate(p_150513_2_, p_150513_3_, field_180294_c, net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.GRASS, field_180294_c))
++        if(net.minecraftforge.event.terraingen.TerrainGen.decorate(p_150513_2_, p_150513_3_, field_180294_c, net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.GRASS, new net.minecraft.util.math.ChunkPos(field_180294_c)))
          for (int i3 = 0; i3 < this.field_76803_B; ++i3)
          {
              int j7 = p_150513_3_.nextInt(16) + 8;
@@ -63,7 +63,7 @@
              }
          }
  
-+        if(net.minecraftforge.event.terraingen.TerrainGen.decorate(p_150513_2_, p_150513_3_, field_180294_c, net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.DEAD_BUSH, field_180294_c))
++        if(net.minecraftforge.event.terraingen.TerrainGen.decorate(p_150513_2_, p_150513_3_, field_180294_c, net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.DEAD_BUSH, new net.minecraft.util.math.ChunkPos(field_180294_c)))
          for (int j3 = 0; j3 < this.field_76804_C; ++j3)
          {
              int k7 = p_150513_3_.nextInt(16) + 8;
@@ -71,7 +71,7 @@
              }
          }
  
-+        if(net.minecraftforge.event.terraingen.TerrainGen.decorate(p_150513_2_, p_150513_3_, field_180294_c, net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.LILYPAD, field_180294_c))
++        if(net.minecraftforge.event.terraingen.TerrainGen.decorate(p_150513_2_, p_150513_3_, field_180294_c, net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.LILYPAD, new net.minecraft.util.math.ChunkPos(field_180294_c)))
          for (int k3 = 0; k3 < this.field_76833_y; ++k3)
          {
              int l7 = p_150513_3_.nextInt(16) + 8;
@@ -79,7 +79,7 @@
              }
          }
  
-+        if(net.minecraftforge.event.terraingen.TerrainGen.decorate(p_150513_2_, p_150513_3_, field_180294_c, net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.SHROOM, field_180294_c))
++        if(net.minecraftforge.event.terraingen.TerrainGen.decorate(p_150513_2_, p_150513_3_, field_180294_c, net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.SHROOM, new net.minecraft.util.math.ChunkPos(field_180294_c)))
 +        {
          for (int l3 = 0; l3 < this.field_76798_D; ++l3)
          {
@@ -90,7 +90,7 @@
          }
 -
 +        } // End of Mushroom generation
-+        if(net.minecraftforge.event.terraingen.TerrainGen.decorate(p_150513_2_, p_150513_3_, field_180294_c, net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.REED, field_180294_c))
++        if(net.minecraftforge.event.terraingen.TerrainGen.decorate(p_150513_2_, p_150513_3_, field_180294_c, net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.REED, new net.minecraft.util.math.ChunkPos(field_180294_c)))
 +        {
          for (int k4 = 0; k4 < this.field_76799_E; ++k4)
          {
@@ -101,7 +101,7 @@
          }
 -
 +        } // End of Reed generation
-+        if(net.minecraftforge.event.terraingen.TerrainGen.decorate(p_150513_2_, p_150513_3_, field_180294_c, net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.PUMPKIN, field_180294_c))
++        if(net.minecraftforge.event.terraingen.TerrainGen.decorate(p_150513_2_, p_150513_3_, field_180294_c, net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.PUMPKIN, new net.minecraft.util.math.ChunkPos(field_180294_c)))
          if (p_150513_3_.nextInt(32) == 0)
          {
              int i5 = p_150513_3_.nextInt(16) + 8;
@@ -109,7 +109,7 @@
              }
          }
  
-+        if(net.minecraftforge.event.terraingen.TerrainGen.decorate(p_150513_2_, p_150513_3_, field_180294_c, net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.CACTUS, field_180294_c))
++        if(net.minecraftforge.event.terraingen.TerrainGen.decorate(p_150513_2_, p_150513_3_, field_180294_c, net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.CACTUS, new net.minecraft.util.math.ChunkPos(field_180294_c)))
          for (int j5 = 0; j5 < this.field_76800_F; ++j5)
          {
              int l9 = p_150513_3_.nextInt(16) + 8;
@@ -117,7 +117,7 @@
  
          if (this.field_76808_K)
          {
-+            if(net.minecraftforge.event.terraingen.TerrainGen.decorate(p_150513_2_, p_150513_3_, field_180294_c, net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.LAKE_WATER, field_180294_c))
++            if(net.minecraftforge.event.terraingen.TerrainGen.decorate(p_150513_2_, p_150513_3_, field_180294_c, net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.LAKE_WATER, new net.minecraft.util.math.ChunkPos(field_180294_c)))
              for (int k5 = 0; k5 < 50; ++k5)
              {
                  int i10 = p_150513_3_.nextInt(16) + 8;
@@ -125,7 +125,7 @@
                  }
              }
  
-+            if(net.minecraftforge.event.terraingen.TerrainGen.decorate(p_150513_2_, p_150513_3_, field_180294_c, net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.LAKE_LAVA, field_180294_c))
++            if(net.minecraftforge.event.terraingen.TerrainGen.decorate(p_150513_2_, p_150513_3_, field_180294_c, net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.LAKE_LAVA, new net.minecraft.util.math.ChunkPos(field_180294_c)))
              for (int l5 = 0; l5 < 20; ++l5)
              {
                  int j10 = p_150513_3_.nextInt(16) + 8;
@@ -133,7 +133,7 @@
                  (new WorldGenLiquids(Blocks.field_150356_k)).func_180709_b(p_150513_2_, p_150513_3_, blockpos3);
              }
          }
-+        net.minecraftforge.common.MinecraftForge.EVENT_BUS.post(new net.minecraftforge.event.terraingen.DecorateBiomeEvent.Post(p_150513_2_, p_150513_3_, field_180294_c, field_180294_c));
++        net.minecraftforge.common.MinecraftForge.EVENT_BUS.post(new net.minecraftforge.event.terraingen.DecorateBiomeEvent.Post(p_150513_2_, p_150513_3_, field_180294_c, new net.minecraft.util.math.ChunkPos(field_180294_c)));
      }
  
      protected void func_76797_b(World p_76797_1_, Random p_76797_2_)

--- a/patches/minecraft/net/minecraft/world/biome/BiomeDesert.java.patch
+++ b/patches/minecraft/net/minecraft/world/biome/BiomeDesert.java.patch
@@ -4,7 +4,7 @@
      {
          super.func_180624_a(p_180624_1_, p_180624_2_, p_180624_3_);
  
-+        if(net.minecraftforge.event.terraingen.TerrainGen.decorate(p_180624_1_, p_180624_2_, p_180624_3_, net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.DESERT_WELL, new net.minecraft.util.math.ChunkPos(p_180624_3_)))
++        if(net.minecraftforge.event.terraingen.TerrainGen.decorate(p_180624_1_, p_180624_2_, p_180624_3_, net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.DESERT_WELL))
          if (p_180624_2_.nextInt(1000) == 0)
          {
              int i = p_180624_2_.nextInt(16) + 8;
@@ -12,7 +12,7 @@
              (new WorldGenDesertWells()).func_180709_b(p_180624_1_, p_180624_2_, blockpos);
          }
  
-+        if(net.minecraftforge.event.terraingen.TerrainGen.decorate(p_180624_1_, p_180624_2_, p_180624_3_, net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.FOSSIL, new net.minecraft.util.math.ChunkPos(p_180624_3_)))
++        if(net.minecraftforge.event.terraingen.TerrainGen.decorate(p_180624_1_, p_180624_2_, p_180624_3_, net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.FOSSIL))
          if (p_180624_2_.nextInt(64) == 0)
          {
              (new WorldGenFossils()).func_180709_b(p_180624_1_, p_180624_2_, p_180624_3_);

--- a/patches/minecraft/net/minecraft/world/biome/BiomeDesert.java.patch
+++ b/patches/minecraft/net/minecraft/world/biome/BiomeDesert.java.patch
@@ -4,7 +4,7 @@
      {
          super.func_180624_a(p_180624_1_, p_180624_2_, p_180624_3_);
  
-+        if(net.minecraftforge.event.terraingen.TerrainGen.decorate(p_180624_1_, p_180624_2_, p_180624_3_, net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.DESERT_WELL))
++        if(net.minecraftforge.event.terraingen.TerrainGen.decorate(p_180624_1_, p_180624_2_, new net.minecraft.util.math.ChunkPos(p_180624_3_), net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.DESERT_WELL))
          if (p_180624_2_.nextInt(1000) == 0)
          {
              int i = p_180624_2_.nextInt(16) + 8;
@@ -12,7 +12,7 @@
              (new WorldGenDesertWells()).func_180709_b(p_180624_1_, p_180624_2_, blockpos);
          }
  
-+        if(net.minecraftforge.event.terraingen.TerrainGen.decorate(p_180624_1_, p_180624_2_, p_180624_3_, net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.FOSSIL))
++        if(net.minecraftforge.event.terraingen.TerrainGen.decorate(p_180624_1_, p_180624_2_, new net.minecraft.util.math.ChunkPos(p_180624_3_), net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.FOSSIL))
          if (p_180624_2_.nextInt(64) == 0)
          {
              (new WorldGenFossils()).func_180709_b(p_180624_1_, p_180624_2_, p_180624_3_);

--- a/patches/minecraft/net/minecraft/world/biome/BiomeDesert.java.patch
+++ b/patches/minecraft/net/minecraft/world/biome/BiomeDesert.java.patch
@@ -4,7 +4,7 @@
      {
          super.func_180624_a(p_180624_1_, p_180624_2_, p_180624_3_);
  
-+        if(net.minecraftforge.event.terraingen.TerrainGen.decorate(p_180624_1_, p_180624_2_, p_180624_3_, net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.DESERT_WELL))
++        if(net.minecraftforge.event.terraingen.TerrainGen.decorate(p_180624_1_, p_180624_2_, p_180624_3_, net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.DESERT_WELL, p_180624_3_))
          if (p_180624_2_.nextInt(1000) == 0)
          {
              int i = p_180624_2_.nextInt(16) + 8;
@@ -12,7 +12,7 @@
              (new WorldGenDesertWells()).func_180709_b(p_180624_1_, p_180624_2_, blockpos);
          }
  
-+        if(net.minecraftforge.event.terraingen.TerrainGen.decorate(p_180624_1_, p_180624_2_, p_180624_3_, net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.FOSSIL))
++        if(net.minecraftforge.event.terraingen.TerrainGen.decorate(p_180624_1_, p_180624_2_, p_180624_3_, net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.FOSSIL, p_180624_3_))
          if (p_180624_2_.nextInt(64) == 0)
          {
              (new WorldGenFossils()).func_180709_b(p_180624_1_, p_180624_2_, p_180624_3_);

--- a/patches/minecraft/net/minecraft/world/biome/BiomeDesert.java.patch
+++ b/patches/minecraft/net/minecraft/world/biome/BiomeDesert.java.patch
@@ -4,7 +4,7 @@
      {
          super.func_180624_a(p_180624_1_, p_180624_2_, p_180624_3_);
  
-+        if(net.minecraftforge.event.terraingen.TerrainGen.decorate(p_180624_1_, p_180624_2_, p_180624_3_, net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.DESERT_WELL, p_180624_3_))
++        if(net.minecraftforge.event.terraingen.TerrainGen.decorate(p_180624_1_, p_180624_2_, p_180624_3_, net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.DESERT_WELL, new net.minecraft.util.math.ChunkPos(p_180624_3_)))
          if (p_180624_2_.nextInt(1000) == 0)
          {
              int i = p_180624_2_.nextInt(16) + 8;
@@ -12,7 +12,7 @@
              (new WorldGenDesertWells()).func_180709_b(p_180624_1_, p_180624_2_, blockpos);
          }
  
-+        if(net.minecraftforge.event.terraingen.TerrainGen.decorate(p_180624_1_, p_180624_2_, p_180624_3_, net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.FOSSIL, p_180624_3_))
++        if(net.minecraftforge.event.terraingen.TerrainGen.decorate(p_180624_1_, p_180624_2_, p_180624_3_, net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.FOSSIL, new net.minecraft.util.math.ChunkPos(p_180624_3_)))
          if (p_180624_2_.nextInt(64) == 0)
          {
              (new WorldGenFossils()).func_180709_b(p_180624_1_, p_180624_2_, p_180624_3_);

--- a/patches/minecraft/net/minecraft/world/biome/BiomeForest.java.patch
+++ b/patches/minecraft/net/minecraft/world/biome/BiomeForest.java.patch
@@ -46,13 +46,13 @@
                  BlockPos blockpos = p_185379_1_.func_175645_m(p_185379_3_.func_177982_a(k, 0, l));
  
 -                if (p_185379_2_.nextInt(20) == 0)
-+                if (p_185379_2_.nextInt(20) == 0 && net.minecraftforge.event.terraingen.TerrainGen.decorate(p_185379_1_, p_185379_2_, p_185379_3_, blockpos, net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.BIG_SHROOM))
++                if (p_185379_2_.nextInt(20) == 0 && net.minecraftforge.event.terraingen.TerrainGen.decorateWithPlacementPos(p_185379_1_, p_185379_2_, p_185379_3_, blockpos, net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.BIG_SHROOM))
                  {
                      WorldGenBigMushroom worldgenbigmushroom = new WorldGenBigMushroom();
                      worldgenbigmushroom.func_180709_b(p_185379_1_, p_185379_2_, blockpos);
                  }
 -                else
-+                else if (net.minecraftforge.event.terraingen.TerrainGen.decorate(p_185379_1_, p_185379_2_, p_185379_3_, blockpos, net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.TREE))
++                else if (net.minecraftforge.event.terraingen.TerrainGen.decorateWithPlacementPos(p_185379_1_, p_185379_2_, p_185379_3_, blockpos, net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.TREE))
                  {
                      WorldGenAbstractTree worldgenabstracttree = this.func_150567_a(p_185379_2_);
                      worldgenabstracttree.func_175904_e();

--- a/patches/minecraft/net/minecraft/world/biome/BiomeForest.java.patch
+++ b/patches/minecraft/net/minecraft/world/biome/BiomeForest.java.patch
@@ -22,7 +22,7 @@
              this.func_185379_b(p_180624_1_, p_180624_2_, p_180624_3_);
          }
  
-+        if(net.minecraftforge.event.terraingen.TerrainGen.decorate(p_180624_1_, p_180624_2_, p_180624_3_, net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.FLOWERS, new net.minecraft.util.math.ChunkPos(p_180624_3_)))
++        if(net.minecraftforge.event.terraingen.TerrainGen.decorate(p_180624_1_, p_180624_2_, p_180624_3_, net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.FLOWERS))
 +        { // no tab for patch
          int i = p_180624_2_.nextInt(5) - 3;
  
@@ -46,13 +46,13 @@
                  BlockPos blockpos = p_185379_1_.func_175645_m(p_185379_3_.func_177982_a(k, 0, l));
  
 -                if (p_185379_2_.nextInt(20) == 0)
-+                if (p_185379_2_.nextInt(20) == 0 && net.minecraftforge.event.terraingen.TerrainGen.decorate(p_185379_1_, p_185379_2_, blockpos, net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.BIG_SHROOM, new net.minecraft.util.math.ChunkPos(p_185379_3_)))
++                if (p_185379_2_.nextInt(20) == 0 && net.minecraftforge.event.terraingen.TerrainGen.decorate(p_185379_1_, p_185379_2_, p_185379_3_, blockpos, net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.BIG_SHROOM))
                  {
                      WorldGenBigMushroom worldgenbigmushroom = new WorldGenBigMushroom();
                      worldgenbigmushroom.func_180709_b(p_185379_1_, p_185379_2_, blockpos);
                  }
 -                else
-+                else if (net.minecraftforge.event.terraingen.TerrainGen.decorate(p_185379_1_, p_185379_2_, blockpos, net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.TREE, new net.minecraft.util.math.ChunkPos(p_185379_3_)))
++                else if (net.minecraftforge.event.terraingen.TerrainGen.decorate(p_185379_1_, p_185379_2_, p_185379_3_, blockpos, net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.TREE))
                  {
                      WorldGenAbstractTree worldgenabstracttree = this.func_150567_a(p_185379_2_);
                      worldgenabstracttree.func_175904_e();

--- a/patches/minecraft/net/minecraft/world/biome/BiomeForest.java.patch
+++ b/patches/minecraft/net/minecraft/world/biome/BiomeForest.java.patch
@@ -22,7 +22,7 @@
              this.func_185379_b(p_180624_1_, p_180624_2_, p_180624_3_);
          }
  
-+        if(net.minecraftforge.event.terraingen.TerrainGen.decorate(p_180624_1_, p_180624_2_, p_180624_3_, net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.FLOWERS))
++        if(net.minecraftforge.event.terraingen.TerrainGen.decorate(p_180624_1_, p_180624_2_, new net.minecraft.util.math.ChunkPos(p_180624_3_), net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.FLOWERS))
 +        { // no tab for patch
          int i = p_180624_2_.nextInt(5) - 3;
  
@@ -46,13 +46,13 @@
                  BlockPos blockpos = p_185379_1_.func_175645_m(p_185379_3_.func_177982_a(k, 0, l));
  
 -                if (p_185379_2_.nextInt(20) == 0)
-+                if (p_185379_2_.nextInt(20) == 0 && net.minecraftforge.event.terraingen.TerrainGen.decorateWithPlacementPos(p_185379_1_, p_185379_2_, p_185379_3_, blockpos, net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.BIG_SHROOM))
++                if (p_185379_2_.nextInt(20) == 0 && net.minecraftforge.event.terraingen.TerrainGen.decorate(p_185379_1_, p_185379_2_, new net.minecraft.util.math.ChunkPos(p_185379_3_), blockpos, net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.BIG_SHROOM))
                  {
                      WorldGenBigMushroom worldgenbigmushroom = new WorldGenBigMushroom();
                      worldgenbigmushroom.func_180709_b(p_185379_1_, p_185379_2_, blockpos);
                  }
 -                else
-+                else if (net.minecraftforge.event.terraingen.TerrainGen.decorateWithPlacementPos(p_185379_1_, p_185379_2_, p_185379_3_, blockpos, net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.TREE))
++                else if (net.minecraftforge.event.terraingen.TerrainGen.decorate(p_185379_1_, p_185379_2_, new net.minecraft.util.math.ChunkPos(p_185379_3_), blockpos, net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.TREE))
                  {
                      WorldGenAbstractTree worldgenabstracttree = this.func_150567_a(p_185379_2_);
                      worldgenabstracttree.func_175904_e();

--- a/patches/minecraft/net/minecraft/world/biome/BiomeForest.java.patch
+++ b/patches/minecraft/net/minecraft/world/biome/BiomeForest.java.patch
@@ -22,7 +22,7 @@
              this.func_185379_b(p_180624_1_, p_180624_2_, p_180624_3_);
          }
  
-+        if(net.minecraftforge.event.terraingen.TerrainGen.decorate(p_180624_1_, p_180624_2_, p_180624_3_, net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.FLOWERS, p_180624_3_))
++        if(net.minecraftforge.event.terraingen.TerrainGen.decorate(p_180624_1_, p_180624_2_, p_180624_3_, net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.FLOWERS, new net.minecraft.util.math.ChunkPos(p_180624_3_)))
 +        { // no tab for patch
          int i = p_180624_2_.nextInt(5) - 3;
  
@@ -46,13 +46,13 @@
                  BlockPos blockpos = p_185379_1_.func_175645_m(p_185379_3_.func_177982_a(k, 0, l));
  
 -                if (p_185379_2_.nextInt(20) == 0)
-+                if (p_185379_2_.nextInt(20) == 0 && net.minecraftforge.event.terraingen.TerrainGen.decorate(p_185379_1_, p_185379_2_, blockpos, net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.BIG_SHROOM, p_185379_3_))
++                if (p_185379_2_.nextInt(20) == 0 && net.minecraftforge.event.terraingen.TerrainGen.decorate(p_185379_1_, p_185379_2_, blockpos, net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.BIG_SHROOM, new net.minecraft.util.math.ChunkPos(p_185379_3_)))
                  {
                      WorldGenBigMushroom worldgenbigmushroom = new WorldGenBigMushroom();
                      worldgenbigmushroom.func_180709_b(p_185379_1_, p_185379_2_, blockpos);
                  }
 -                else
-+                else if (net.minecraftforge.event.terraingen.TerrainGen.decorate(p_185379_1_, p_185379_2_, blockpos, net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.TREE, p_185379_3_))
++                else if (net.minecraftforge.event.terraingen.TerrainGen.decorate(p_185379_1_, p_185379_2_, blockpos, net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.TREE, new net.minecraft.util.math.ChunkPos(p_185379_3_)))
                  {
                      WorldGenAbstractTree worldgenabstracttree = this.func_150567_a(p_185379_2_);
                      worldgenabstracttree.func_175904_e();

--- a/patches/minecraft/net/minecraft/world/biome/BiomeForest.java.patch
+++ b/patches/minecraft/net/minecraft/world/biome/BiomeForest.java.patch
@@ -22,7 +22,7 @@
              this.func_185379_b(p_180624_1_, p_180624_2_, p_180624_3_);
          }
  
-+        if(net.minecraftforge.event.terraingen.TerrainGen.decorate(p_180624_1_, p_180624_2_, p_180624_3_, net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.FLOWERS))
++        if(net.minecraftforge.event.terraingen.TerrainGen.decorate(p_180624_1_, p_180624_2_, p_180624_3_, net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.FLOWERS, p_180624_3_))
 +        { // no tab for patch
          int i = p_180624_2_.nextInt(5) - 3;
  
@@ -46,13 +46,13 @@
                  BlockPos blockpos = p_185379_1_.func_175645_m(p_185379_3_.func_177982_a(k, 0, l));
  
 -                if (p_185379_2_.nextInt(20) == 0)
-+                if (p_185379_2_.nextInt(20) == 0 && net.minecraftforge.event.terraingen.TerrainGen.decorate(p_185379_1_, p_185379_2_, blockpos, net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.BIG_SHROOM))
++                if (p_185379_2_.nextInt(20) == 0 && net.minecraftforge.event.terraingen.TerrainGen.decorate(p_185379_1_, p_185379_2_, blockpos, net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.BIG_SHROOM, p_185379_3_))
                  {
                      WorldGenBigMushroom worldgenbigmushroom = new WorldGenBigMushroom();
                      worldgenbigmushroom.func_180709_b(p_185379_1_, p_185379_2_, blockpos);
                  }
 -                else
-+                else if (net.minecraftforge.event.terraingen.TerrainGen.decorate(p_185379_1_, p_185379_2_, blockpos, net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.TREE))
++                else if (net.minecraftforge.event.terraingen.TerrainGen.decorate(p_185379_1_, p_185379_2_, blockpos, net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.TREE, p_185379_3_))
                  {
                      WorldGenAbstractTree worldgenabstracttree = this.func_150567_a(p_185379_2_);
                      worldgenabstracttree.func_175904_e();

--- a/patches/minecraft/net/minecraft/world/biome/BiomeJungle.java.patch
+++ b/patches/minecraft/net/minecraft/world/biome/BiomeJungle.java.patch
@@ -8,11 +8,11 @@
 +        int height = p_180624_1_.func_175645_m(p_180624_3_.func_177982_a(i, 0, j)).func_177956_o() * 2; // could == 0, which crashes nextInt
 +        if (height < 1) height = 1;
 +        int k = p_180624_2_.nextInt(height);
-+        if(net.minecraftforge.event.terraingen.TerrainGen.decorate(p_180624_1_, p_180624_2_, p_180624_3_, net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.PUMPKIN))
++        if(net.minecraftforge.event.terraingen.TerrainGen.decorate(p_180624_1_, p_180624_2_, new net.minecraft.util.math.ChunkPos(p_180624_3_), p_180624_3_.func_177982_a(i, k, j), net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.PUMPKIN))
          (new WorldGenMelon()).func_180709_b(p_180624_1_, p_180624_2_, p_180624_3_.func_177982_a(i, k, j));
          WorldGenVines worldgenvines = new WorldGenVines();
  
-+        if(net.minecraftforge.event.terraingen.TerrainGen.decorate(p_180624_1_, p_180624_2_, p_180624_3_, net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.GRASS))
++        if(net.minecraftforge.event.terraingen.TerrainGen.decorate(p_180624_1_, p_180624_2_, new net.minecraft.util.math.ChunkPos(p_180624_3_), net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.GRASS))
          for (int j1 = 0; j1 < 50; ++j1)
          {
              k = p_180624_2_.nextInt(16) + 8;

--- a/patches/minecraft/net/minecraft/world/biome/BiomeJungle.java.patch
+++ b/patches/minecraft/net/minecraft/world/biome/BiomeJungle.java.patch
@@ -8,11 +8,11 @@
 +        int height = p_180624_1_.func_175645_m(p_180624_3_.func_177982_a(i, 0, j)).func_177956_o() * 2; // could == 0, which crashes nextInt
 +        if (height < 1) height = 1;
 +        int k = p_180624_2_.nextInt(height);
-+        if(net.minecraftforge.event.terraingen.TerrainGen.decorate(p_180624_1_, p_180624_2_, p_180624_3_, net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.PUMPKIN, p_180624_3_))
++        if(net.minecraftforge.event.terraingen.TerrainGen.decorate(p_180624_1_, p_180624_2_, p_180624_3_, net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.PUMPKIN, new net.minecraft.util.math.ChunkPos(p_180624_3_)))
          (new WorldGenMelon()).func_180709_b(p_180624_1_, p_180624_2_, p_180624_3_.func_177982_a(i, k, j));
          WorldGenVines worldgenvines = new WorldGenVines();
  
-+        if(net.minecraftforge.event.terraingen.TerrainGen.decorate(p_180624_1_, p_180624_2_, p_180624_3_, net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.GRASS, p_180624_3_))
++        if(net.minecraftforge.event.terraingen.TerrainGen.decorate(p_180624_1_, p_180624_2_, p_180624_3_, net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.GRASS, new net.minecraft.util.math.ChunkPos(p_180624_3_)))
          for (int j1 = 0; j1 < 50; ++j1)
          {
              k = p_180624_2_.nextInt(16) + 8;

--- a/patches/minecraft/net/minecraft/world/biome/BiomeJungle.java.patch
+++ b/patches/minecraft/net/minecraft/world/biome/BiomeJungle.java.patch
@@ -8,11 +8,11 @@
 +        int height = p_180624_1_.func_175645_m(p_180624_3_.func_177982_a(i, 0, j)).func_177956_o() * 2; // could == 0, which crashes nextInt
 +        if (height < 1) height = 1;
 +        int k = p_180624_2_.nextInt(height);
-+        if(net.minecraftforge.event.terraingen.TerrainGen.decorate(p_180624_1_, p_180624_2_, p_180624_3_, net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.PUMPKIN, new net.minecraft.util.math.ChunkPos(p_180624_3_)))
++        if(net.minecraftforge.event.terraingen.TerrainGen.decorate(p_180624_1_, p_180624_2_, p_180624_3_, net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.PUMPKIN))
          (new WorldGenMelon()).func_180709_b(p_180624_1_, p_180624_2_, p_180624_3_.func_177982_a(i, k, j));
          WorldGenVines worldgenvines = new WorldGenVines();
  
-+        if(net.minecraftforge.event.terraingen.TerrainGen.decorate(p_180624_1_, p_180624_2_, p_180624_3_, net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.GRASS, new net.minecraft.util.math.ChunkPos(p_180624_3_)))
++        if(net.minecraftforge.event.terraingen.TerrainGen.decorate(p_180624_1_, p_180624_2_, p_180624_3_, net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.GRASS))
          for (int j1 = 0; j1 < 50; ++j1)
          {
              k = p_180624_2_.nextInt(16) + 8;

--- a/patches/minecraft/net/minecraft/world/biome/BiomeJungle.java.patch
+++ b/patches/minecraft/net/minecraft/world/biome/BiomeJungle.java.patch
@@ -8,11 +8,11 @@
 +        int height = p_180624_1_.func_175645_m(p_180624_3_.func_177982_a(i, 0, j)).func_177956_o() * 2; // could == 0, which crashes nextInt
 +        if (height < 1) height = 1;
 +        int k = p_180624_2_.nextInt(height);
-+        if(net.minecraftforge.event.terraingen.TerrainGen.decorate(p_180624_1_, p_180624_2_, p_180624_3_, net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.PUMPKIN))
++        if(net.minecraftforge.event.terraingen.TerrainGen.decorate(p_180624_1_, p_180624_2_, p_180624_3_, net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.PUMPKIN, p_180624_3_))
          (new WorldGenMelon()).func_180709_b(p_180624_1_, p_180624_2_, p_180624_3_.func_177982_a(i, k, j));
          WorldGenVines worldgenvines = new WorldGenVines();
  
-+        if(net.minecraftforge.event.terraingen.TerrainGen.decorate(p_180624_1_, p_180624_2_, p_180624_3_, net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.GRASS))
++        if(net.minecraftforge.event.terraingen.TerrainGen.decorate(p_180624_1_, p_180624_2_, p_180624_3_, net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.GRASS, p_180624_3_))
          for (int j1 = 0; j1 < 50; ++j1)
          {
              k = p_180624_2_.nextInt(16) + 8;

--- a/patches/minecraft/net/minecraft/world/biome/BiomePlains.java.patch
+++ b/patches/minecraft/net/minecraft/world/biome/BiomePlains.java.patch
@@ -4,7 +4,7 @@
              this.field_76760_I.field_76803_B = 10;
              field_180280_ag.func_180710_a(BlockDoublePlant.EnumPlantType.GRASS);
  
-+            if(net.minecraftforge.event.terraingen.TerrainGen.decorate(p_180624_1_, p_180624_2_, p_180624_3_, net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.GRASS))
++            if(net.minecraftforge.event.terraingen.TerrainGen.decorate(p_180624_1_, p_180624_2_, p_180624_3_, net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.GRASS, p_180624_3_))
              for (int i = 0; i < 7; ++i)
              {
                  int j = p_180624_2_.nextInt(16) + 8;
@@ -13,7 +13,7 @@
          }
  
 -        if (this.field_150628_aC)
-+        if (this.field_150628_aC && net.minecraftforge.event.terraingen.TerrainGen.decorate(p_180624_1_, p_180624_2_, p_180624_3_, net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.FLOWERS))
++        if (this.field_150628_aC && net.minecraftforge.event.terraingen.TerrainGen.decorate(p_180624_1_, p_180624_2_, p_180624_3_, net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.FLOWERS, p_180624_3_))
          {
              field_180280_ag.func_180710_a(BlockDoublePlant.EnumPlantType.SUNFLOWER);
  

--- a/patches/minecraft/net/minecraft/world/biome/BiomePlains.java.patch
+++ b/patches/minecraft/net/minecraft/world/biome/BiomePlains.java.patch
@@ -4,7 +4,7 @@
              this.field_76760_I.field_76803_B = 10;
              field_180280_ag.func_180710_a(BlockDoublePlant.EnumPlantType.GRASS);
  
-+            if(net.minecraftforge.event.terraingen.TerrainGen.decorate(p_180624_1_, p_180624_2_, p_180624_3_, net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.GRASS, new net.minecraft.util.math.ChunkPos(p_180624_3_)))
++            if(net.minecraftforge.event.terraingen.TerrainGen.decorate(p_180624_1_, p_180624_2_, p_180624_3_, net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.GRASS))
              for (int i = 0; i < 7; ++i)
              {
                  int j = p_180624_2_.nextInt(16) + 8;
@@ -13,7 +13,7 @@
          }
  
 -        if (this.field_150628_aC)
-+        if (this.field_150628_aC && net.minecraftforge.event.terraingen.TerrainGen.decorate(p_180624_1_, p_180624_2_, p_180624_3_, net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.FLOWERS, new net.minecraft.util.math.ChunkPos(p_180624_3_)))
++        if (this.field_150628_aC && net.minecraftforge.event.terraingen.TerrainGen.decorate(p_180624_1_, p_180624_2_, p_180624_3_, net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.FLOWERS))
          {
              field_180280_ag.func_180710_a(BlockDoublePlant.EnumPlantType.SUNFLOWER);
  

--- a/patches/minecraft/net/minecraft/world/biome/BiomePlains.java.patch
+++ b/patches/minecraft/net/minecraft/world/biome/BiomePlains.java.patch
@@ -4,7 +4,7 @@
              this.field_76760_I.field_76803_B = 10;
              field_180280_ag.func_180710_a(BlockDoublePlant.EnumPlantType.GRASS);
  
-+            if(net.minecraftforge.event.terraingen.TerrainGen.decorate(p_180624_1_, p_180624_2_, p_180624_3_, net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.GRASS, p_180624_3_))
++            if(net.minecraftforge.event.terraingen.TerrainGen.decorate(p_180624_1_, p_180624_2_, p_180624_3_, net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.GRASS, new net.minecraft.util.math.ChunkPos(p_180624_3_)))
              for (int i = 0; i < 7; ++i)
              {
                  int j = p_180624_2_.nextInt(16) + 8;
@@ -13,7 +13,7 @@
          }
  
 -        if (this.field_150628_aC)
-+        if (this.field_150628_aC && net.minecraftforge.event.terraingen.TerrainGen.decorate(p_180624_1_, p_180624_2_, p_180624_3_, net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.FLOWERS, p_180624_3_))
++        if (this.field_150628_aC && net.minecraftforge.event.terraingen.TerrainGen.decorate(p_180624_1_, p_180624_2_, p_180624_3_, net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.FLOWERS, new net.minecraft.util.math.ChunkPos(p_180624_3_)))
          {
              field_180280_ag.func_180710_a(BlockDoublePlant.EnumPlantType.SUNFLOWER);
  

--- a/patches/minecraft/net/minecraft/world/biome/BiomePlains.java.patch
+++ b/patches/minecraft/net/minecraft/world/biome/BiomePlains.java.patch
@@ -4,7 +4,7 @@
              this.field_76760_I.field_76803_B = 10;
              field_180280_ag.func_180710_a(BlockDoublePlant.EnumPlantType.GRASS);
  
-+            if(net.minecraftforge.event.terraingen.TerrainGen.decorate(p_180624_1_, p_180624_2_, p_180624_3_, net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.GRASS))
++            if(net.minecraftforge.event.terraingen.TerrainGen.decorate(p_180624_1_, p_180624_2_, new net.minecraft.util.math.ChunkPos(p_180624_3_), net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.GRASS))
              for (int i = 0; i < 7; ++i)
              {
                  int j = p_180624_2_.nextInt(16) + 8;
@@ -13,7 +13,7 @@
          }
  
 -        if (this.field_150628_aC)
-+        if (this.field_150628_aC && net.minecraftforge.event.terraingen.TerrainGen.decorate(p_180624_1_, p_180624_2_, p_180624_3_, net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.FLOWERS))
++        if (this.field_150628_aC && net.minecraftforge.event.terraingen.TerrainGen.decorate(p_180624_1_, p_180624_2_, new net.minecraft.util.math.ChunkPos(p_180624_3_), net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.FLOWERS))
          {
              field_180280_ag.func_180710_a(BlockDoublePlant.EnumPlantType.SUNFLOWER);
  

--- a/patches/minecraft/net/minecraft/world/biome/BiomeSavanna.java.patch
+++ b/patches/minecraft/net/minecraft/world/biome/BiomeSavanna.java.patch
@@ -4,7 +4,7 @@
      {
          field_180280_ag.func_180710_a(BlockDoublePlant.EnumPlantType.GRASS);
  
-+        if(net.minecraftforge.event.terraingen.TerrainGen.decorate(p_180624_1_, p_180624_2_, p_180624_3_, net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.GRASS, p_180624_3_))
++        if(net.minecraftforge.event.terraingen.TerrainGen.decorate(p_180624_1_, p_180624_2_, p_180624_3_, net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.GRASS, new net.minecraft.util.math.ChunkPos(p_180624_3_)))
          for (int i = 0; i < 7; ++i)
          {
              int j = p_180624_2_.nextInt(16) + 8;

--- a/patches/minecraft/net/minecraft/world/biome/BiomeSavanna.java.patch
+++ b/patches/minecraft/net/minecraft/world/biome/BiomeSavanna.java.patch
@@ -4,7 +4,7 @@
      {
          field_180280_ag.func_180710_a(BlockDoublePlant.EnumPlantType.GRASS);
  
-+        if(net.minecraftforge.event.terraingen.TerrainGen.decorate(p_180624_1_, p_180624_2_, p_180624_3_, net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.GRASS))
++        if(net.minecraftforge.event.terraingen.TerrainGen.decorate(p_180624_1_, p_180624_2_, new net.minecraft.util.math.ChunkPos(p_180624_3_), net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.GRASS))
          for (int i = 0; i < 7; ++i)
          {
              int j = p_180624_2_.nextInt(16) + 8;

--- a/patches/minecraft/net/minecraft/world/biome/BiomeSavanna.java.patch
+++ b/patches/minecraft/net/minecraft/world/biome/BiomeSavanna.java.patch
@@ -4,7 +4,7 @@
      {
          field_180280_ag.func_180710_a(BlockDoublePlant.EnumPlantType.GRASS);
  
-+        if(net.minecraftforge.event.terraingen.TerrainGen.decorate(p_180624_1_, p_180624_2_, p_180624_3_, net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.GRASS, new net.minecraft.util.math.ChunkPos(p_180624_3_)))
++        if(net.minecraftforge.event.terraingen.TerrainGen.decorate(p_180624_1_, p_180624_2_, p_180624_3_, net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.GRASS))
          for (int i = 0; i < 7; ++i)
          {
              int j = p_180624_2_.nextInt(16) + 8;

--- a/patches/minecraft/net/minecraft/world/biome/BiomeSavanna.java.patch
+++ b/patches/minecraft/net/minecraft/world/biome/BiomeSavanna.java.patch
@@ -4,7 +4,7 @@
      {
          field_180280_ag.func_180710_a(BlockDoublePlant.EnumPlantType.GRASS);
  
-+        if(net.minecraftforge.event.terraingen.TerrainGen.decorate(p_180624_1_, p_180624_2_, p_180624_3_, net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.GRASS))
++        if(net.minecraftforge.event.terraingen.TerrainGen.decorate(p_180624_1_, p_180624_2_, p_180624_3_, net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.GRASS, p_180624_3_))
          for (int i = 0; i < 7; ++i)
          {
              int j = p_180624_2_.nextInt(16) + 8;

--- a/patches/minecraft/net/minecraft/world/biome/BiomeSnow.java.patch
+++ b/patches/minecraft/net/minecraft/world/biome/BiomeSnow.java.patch
@@ -5,7 +5,7 @@
      public void func_180624_a(World p_180624_1_, Random p_180624_2_, BlockPos p_180624_3_)
      {
 -        if (this.field_150615_aC)
-+        if (this.field_150615_aC && net.minecraftforge.event.terraingen.TerrainGen.decorate(p_180624_1_, p_180624_2_, p_180624_3_, net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.ICE))
++        if (this.field_150615_aC && net.minecraftforge.event.terraingen.TerrainGen.decorate(p_180624_1_, p_180624_2_, p_180624_3_, net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.ICE, p_180624_3_))
          {
              for (int i = 0; i < 3; ++i)
              {

--- a/patches/minecraft/net/minecraft/world/biome/BiomeSnow.java.patch
+++ b/patches/minecraft/net/minecraft/world/biome/BiomeSnow.java.patch
@@ -5,7 +5,7 @@
      public void func_180624_a(World p_180624_1_, Random p_180624_2_, BlockPos p_180624_3_)
      {
 -        if (this.field_150615_aC)
-+        if (this.field_150615_aC && net.minecraftforge.event.terraingen.TerrainGen.decorate(p_180624_1_, p_180624_2_, p_180624_3_, net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.ICE))
++        if (this.field_150615_aC && net.minecraftforge.event.terraingen.TerrainGen.decorate(p_180624_1_, p_180624_2_, new net.minecraft.util.math.ChunkPos(p_180624_3_), net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.ICE))
          {
              for (int i = 0; i < 3; ++i)
              {

--- a/patches/minecraft/net/minecraft/world/biome/BiomeSnow.java.patch
+++ b/patches/minecraft/net/minecraft/world/biome/BiomeSnow.java.patch
@@ -5,7 +5,7 @@
      public void func_180624_a(World p_180624_1_, Random p_180624_2_, BlockPos p_180624_3_)
      {
 -        if (this.field_150615_aC)
-+        if (this.field_150615_aC && net.minecraftforge.event.terraingen.TerrainGen.decorate(p_180624_1_, p_180624_2_, p_180624_3_, net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.ICE, new net.minecraft.util.math.ChunkPos(p_180624_3_)))
++        if (this.field_150615_aC && net.minecraftforge.event.terraingen.TerrainGen.decorate(p_180624_1_, p_180624_2_, p_180624_3_, net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.ICE))
          {
              for (int i = 0; i < 3; ++i)
              {

--- a/patches/minecraft/net/minecraft/world/biome/BiomeSnow.java.patch
+++ b/patches/minecraft/net/minecraft/world/biome/BiomeSnow.java.patch
@@ -5,7 +5,7 @@
      public void func_180624_a(World p_180624_1_, Random p_180624_2_, BlockPos p_180624_3_)
      {
 -        if (this.field_150615_aC)
-+        if (this.field_150615_aC && net.minecraftforge.event.terraingen.TerrainGen.decorate(p_180624_1_, p_180624_2_, p_180624_3_, net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.ICE, p_180624_3_))
++        if (this.field_150615_aC && net.minecraftforge.event.terraingen.TerrainGen.decorate(p_180624_1_, p_180624_2_, p_180624_3_, net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.ICE, new net.minecraft.util.math.ChunkPos(p_180624_3_)))
          {
              for (int i = 0; i < 3; ++i)
              {

--- a/patches/minecraft/net/minecraft/world/biome/BiomeSwamp.java.patch
+++ b/patches/minecraft/net/minecraft/world/biome/BiomeSwamp.java.patch
@@ -4,7 +4,7 @@
      {
          super.func_180624_a(p_180624_1_, p_180624_2_, p_180624_3_);
  
-+        if(net.minecraftforge.event.terraingen.TerrainGen.decorate(p_180624_1_, p_180624_2_, p_180624_3_, net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.FOSSIL, new net.minecraft.util.math.ChunkPos(p_180624_3_)))
++        if(net.minecraftforge.event.terraingen.TerrainGen.decorate(p_180624_1_, p_180624_2_, p_180624_3_, net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.FOSSIL))
          if (p_180624_2_.nextInt(64) == 0)
          {
              (new WorldGenFossils()).func_180709_b(p_180624_1_, p_180624_2_, p_180624_3_);

--- a/patches/minecraft/net/minecraft/world/biome/BiomeSwamp.java.patch
+++ b/patches/minecraft/net/minecraft/world/biome/BiomeSwamp.java.patch
@@ -4,7 +4,7 @@
      {
          super.func_180624_a(p_180624_1_, p_180624_2_, p_180624_3_);
  
-+        if(net.minecraftforge.event.terraingen.TerrainGen.decorate(p_180624_1_, p_180624_2_, p_180624_3_, net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.FOSSIL))
++        if(net.minecraftforge.event.terraingen.TerrainGen.decorate(p_180624_1_, p_180624_2_, p_180624_3_, net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.FOSSIL, p_180624_3_))
          if (p_180624_2_.nextInt(64) == 0)
          {
              (new WorldGenFossils()).func_180709_b(p_180624_1_, p_180624_2_, p_180624_3_);

--- a/patches/minecraft/net/minecraft/world/biome/BiomeSwamp.java.patch
+++ b/patches/minecraft/net/minecraft/world/biome/BiomeSwamp.java.patch
@@ -4,7 +4,7 @@
      {
          super.func_180624_a(p_180624_1_, p_180624_2_, p_180624_3_);
  
-+        if(net.minecraftforge.event.terraingen.TerrainGen.decorate(p_180624_1_, p_180624_2_, p_180624_3_, net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.FOSSIL))
++        if(net.minecraftforge.event.terraingen.TerrainGen.decorate(p_180624_1_, p_180624_2_, new net.minecraft.util.math.ChunkPos(p_180624_3_), net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.FOSSIL))
          if (p_180624_2_.nextInt(64) == 0)
          {
              (new WorldGenFossils()).func_180709_b(p_180624_1_, p_180624_2_, p_180624_3_);

--- a/patches/minecraft/net/minecraft/world/biome/BiomeSwamp.java.patch
+++ b/patches/minecraft/net/minecraft/world/biome/BiomeSwamp.java.patch
@@ -4,7 +4,7 @@
      {
          super.func_180624_a(p_180624_1_, p_180624_2_, p_180624_3_);
  
-+        if(net.minecraftforge.event.terraingen.TerrainGen.decorate(p_180624_1_, p_180624_2_, p_180624_3_, net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.FOSSIL, p_180624_3_))
++        if(net.minecraftforge.event.terraingen.TerrainGen.decorate(p_180624_1_, p_180624_2_, p_180624_3_, net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.FOSSIL, new net.minecraft.util.math.ChunkPos(p_180624_3_)))
          if (p_180624_2_.nextInt(64) == 0)
          {
              (new WorldGenFossils()).func_180709_b(p_180624_1_, p_180624_2_, p_180624_3_);

--- a/patches/minecraft/net/minecraft/world/biome/BiomeTaiga.java.patch
+++ b/patches/minecraft/net/minecraft/world/biome/BiomeTaiga.java.patch
@@ -5,7 +5,7 @@
      public void func_180624_a(World p_180624_1_, Random p_180624_2_, BlockPos p_180624_3_)
      {
 -        if (this.field_150644_aH == BiomeTaiga.Type.MEGA || this.field_150644_aH == BiomeTaiga.Type.MEGA_SPRUCE)
-+        if ((this.field_150644_aH == BiomeTaiga.Type.MEGA || this.field_150644_aH == BiomeTaiga.Type.MEGA_SPRUCE) && net.minecraftforge.event.terraingen.TerrainGen.decorate(p_180624_1_, p_180624_2_, p_180624_3_, net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.ROCK))
++        if ((this.field_150644_aH == BiomeTaiga.Type.MEGA || this.field_150644_aH == BiomeTaiga.Type.MEGA_SPRUCE) && net.minecraftforge.event.terraingen.TerrainGen.decorate(p_180624_1_, p_180624_2_, p_180624_3_, net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.ROCK, p_180624_3_))
          {
              int i = p_180624_2_.nextInt(3);
  
@@ -13,7 +13,7 @@
  
          field_180280_ag.func_180710_a(BlockDoublePlant.EnumPlantType.FERN);
  
-+        if(net.minecraftforge.event.terraingen.TerrainGen.decorate(p_180624_1_, p_180624_2_, p_180624_3_, net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.FLOWERS))
++        if(net.minecraftforge.event.terraingen.TerrainGen.decorate(p_180624_1_, p_180624_2_, p_180624_3_, net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.FLOWERS, p_180624_3_))
          for (int i1 = 0; i1 < 7; ++i1)
          {
              int j1 = p_180624_2_.nextInt(16) + 8;

--- a/patches/minecraft/net/minecraft/world/biome/BiomeTaiga.java.patch
+++ b/patches/minecraft/net/minecraft/world/biome/BiomeTaiga.java.patch
@@ -5,7 +5,7 @@
      public void func_180624_a(World p_180624_1_, Random p_180624_2_, BlockPos p_180624_3_)
      {
 -        if (this.field_150644_aH == BiomeTaiga.Type.MEGA || this.field_150644_aH == BiomeTaiga.Type.MEGA_SPRUCE)
-+        if ((this.field_150644_aH == BiomeTaiga.Type.MEGA || this.field_150644_aH == BiomeTaiga.Type.MEGA_SPRUCE) && net.minecraftforge.event.terraingen.TerrainGen.decorate(p_180624_1_, p_180624_2_, p_180624_3_, net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.ROCK, new net.minecraft.util.math.ChunkPos(p_180624_3_)))
++        if ((this.field_150644_aH == BiomeTaiga.Type.MEGA || this.field_150644_aH == BiomeTaiga.Type.MEGA_SPRUCE) && net.minecraftforge.event.terraingen.TerrainGen.decorate(p_180624_1_, p_180624_2_, p_180624_3_, net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.ROCK))
          {
              int i = p_180624_2_.nextInt(3);
  
@@ -13,7 +13,7 @@
  
          field_180280_ag.func_180710_a(BlockDoublePlant.EnumPlantType.FERN);
  
-+        if(net.minecraftforge.event.terraingen.TerrainGen.decorate(p_180624_1_, p_180624_2_, p_180624_3_, net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.FLOWERS, new net.minecraft.util.math.ChunkPos(p_180624_3_)))
++        if(net.minecraftforge.event.terraingen.TerrainGen.decorate(p_180624_1_, p_180624_2_, p_180624_3_, net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.FLOWERS))
          for (int i1 = 0; i1 < 7; ++i1)
          {
              int j1 = p_180624_2_.nextInt(16) + 8;

--- a/patches/minecraft/net/minecraft/world/biome/BiomeTaiga.java.patch
+++ b/patches/minecraft/net/minecraft/world/biome/BiomeTaiga.java.patch
@@ -5,7 +5,7 @@
      public void func_180624_a(World p_180624_1_, Random p_180624_2_, BlockPos p_180624_3_)
      {
 -        if (this.field_150644_aH == BiomeTaiga.Type.MEGA || this.field_150644_aH == BiomeTaiga.Type.MEGA_SPRUCE)
-+        if ((this.field_150644_aH == BiomeTaiga.Type.MEGA || this.field_150644_aH == BiomeTaiga.Type.MEGA_SPRUCE) && net.minecraftforge.event.terraingen.TerrainGen.decorate(p_180624_1_, p_180624_2_, p_180624_3_, net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.ROCK, p_180624_3_))
++        if ((this.field_150644_aH == BiomeTaiga.Type.MEGA || this.field_150644_aH == BiomeTaiga.Type.MEGA_SPRUCE) && net.minecraftforge.event.terraingen.TerrainGen.decorate(p_180624_1_, p_180624_2_, p_180624_3_, net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.ROCK, new net.minecraft.util.math.ChunkPos(p_180624_3_)))
          {
              int i = p_180624_2_.nextInt(3);
  
@@ -13,7 +13,7 @@
  
          field_180280_ag.func_180710_a(BlockDoublePlant.EnumPlantType.FERN);
  
-+        if(net.minecraftforge.event.terraingen.TerrainGen.decorate(p_180624_1_, p_180624_2_, p_180624_3_, net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.FLOWERS, p_180624_3_))
++        if(net.minecraftforge.event.terraingen.TerrainGen.decorate(p_180624_1_, p_180624_2_, p_180624_3_, net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.FLOWERS, new net.minecraft.util.math.ChunkPos(p_180624_3_)))
          for (int i1 = 0; i1 < 7; ++i1)
          {
              int j1 = p_180624_2_.nextInt(16) + 8;

--- a/patches/minecraft/net/minecraft/world/biome/BiomeTaiga.java.patch
+++ b/patches/minecraft/net/minecraft/world/biome/BiomeTaiga.java.patch
@@ -5,7 +5,7 @@
      public void func_180624_a(World p_180624_1_, Random p_180624_2_, BlockPos p_180624_3_)
      {
 -        if (this.field_150644_aH == BiomeTaiga.Type.MEGA || this.field_150644_aH == BiomeTaiga.Type.MEGA_SPRUCE)
-+        if ((this.field_150644_aH == BiomeTaiga.Type.MEGA || this.field_150644_aH == BiomeTaiga.Type.MEGA_SPRUCE) && net.minecraftforge.event.terraingen.TerrainGen.decorate(p_180624_1_, p_180624_2_, p_180624_3_, net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.ROCK))
++        if ((this.field_150644_aH == BiomeTaiga.Type.MEGA || this.field_150644_aH == BiomeTaiga.Type.MEGA_SPRUCE) && net.minecraftforge.event.terraingen.TerrainGen.decorate(p_180624_1_, p_180624_2_, new net.minecraft.util.math.ChunkPos(p_180624_3_), net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.ROCK))
          {
              int i = p_180624_2_.nextInt(3);
  
@@ -13,7 +13,7 @@
  
          field_180280_ag.func_180710_a(BlockDoublePlant.EnumPlantType.FERN);
  
-+        if(net.minecraftforge.event.terraingen.TerrainGen.decorate(p_180624_1_, p_180624_2_, p_180624_3_, net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.FLOWERS))
++        if(net.minecraftforge.event.terraingen.TerrainGen.decorate(p_180624_1_, p_180624_2_, new net.minecraft.util.math.ChunkPos(p_180624_3_), net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.FLOWERS))
          for (int i1 = 0; i1 < 7; ++i1)
          {
              int j1 = p_180624_2_.nextInt(16) + 8;

--- a/patches/minecraft/net/minecraft/world/gen/ChunkGeneratorHell.java.patch
+++ b/patches/minecraft/net/minecraft/world/gen/ChunkGeneratorHell.java.patch
@@ -75,9 +75,9 @@
 +        }//Forge: End doGLowstone
  
 +        net.minecraftforge.event.ForgeEventFactory.onChunkPopulate(false, this, this.field_185952_n, this.field_185954_p, p_185931_1_, p_185931_2_, false);
-+        net.minecraftforge.common.MinecraftForge.EVENT_BUS.post(new net.minecraftforge.event.terraingen.DecorateBiomeEvent.Pre(this.field_185952_n, this.field_185954_p, blockpos, new net.minecraft.util.math.ChunkPos(blockpos)));
++        net.minecraftforge.event.terraingen.TerrainGen.decorateBiomePre(this.field_185952_n, this.field_185954_p, blockpos);
 +
-+        if (net.minecraftforge.event.terraingen.TerrainGen.decorate(this.field_185952_n, this.field_185954_p, blockpos, net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.SHROOM, new net.minecraft.util.math.ChunkPos(blockpos)))
++        if (net.minecraftforge.event.terraingen.TerrainGen.decorate(this.field_185952_n, this.field_185954_p, blockpos, net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.SHROOM))
 +        {
          if (this.field_185954_p.nextBoolean())
          {
@@ -113,7 +113,7 @@
  
          biome.func_180624_a(this.field_185952_n, this.field_185954_p, new BlockPos(i, 0, j));
 +
-+        net.minecraftforge.common.MinecraftForge.EVENT_BUS.post(new net.minecraftforge.event.terraingen.DecorateBiomeEvent.Post(this.field_185952_n, this.field_185954_p, blockpos, new net.minecraft.util.math.ChunkPos(blockpos)));
++        net.minecraftforge.event.terraingen.TerrainGen.decorateBiomePost(this.field_185952_n, this.field_185954_p, blockpos);
 +
          BlockFalling.field_149832_M = false;
      }

--- a/patches/minecraft/net/minecraft/world/gen/ChunkGeneratorHell.java.patch
+++ b/patches/minecraft/net/minecraft/world/gen/ChunkGeneratorHell.java.patch
@@ -75,7 +75,7 @@
 +        }//Forge: End doGLowstone
  
 +        net.minecraftforge.event.ForgeEventFactory.onChunkPopulate(false, this, this.field_185952_n, this.field_185954_p, p_185931_1_, p_185931_2_, false);
-+        net.minecraftforge.event.terraingen.TerrainGen.decorateBiomePre(this.field_185952_n, this.field_185954_p, blockpos);
++        net.minecraftforge.common.MinecraftForge.EVENT_BUS.post(new net.minecraftforge.event.terraingen.DecorateBiomeEvent.Pre(this.field_185952_n, this.field_185954_p, blockpos));
 +
 +        if (net.minecraftforge.event.terraingen.TerrainGen.decorate(this.field_185952_n, this.field_185954_p, blockpos, net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.SHROOM))
 +        {
@@ -113,7 +113,7 @@
  
          biome.func_180624_a(this.field_185952_n, this.field_185954_p, new BlockPos(i, 0, j));
 +
-+        net.minecraftforge.event.terraingen.TerrainGen.decorateBiomePost(this.field_185952_n, this.field_185954_p, blockpos);
++        net.minecraftforge.common.MinecraftForge.EVENT_BUS.post(new net.minecraftforge.event.terraingen.DecorateBiomeEvent.Post(this.field_185952_n, this.field_185954_p, blockpos));
 +
          BlockFalling.field_149832_M = false;
      }

--- a/patches/minecraft/net/minecraft/world/gen/ChunkGeneratorHell.java.patch
+++ b/patches/minecraft/net/minecraft/world/gen/ChunkGeneratorHell.java.patch
@@ -75,9 +75,9 @@
 +        }//Forge: End doGLowstone
  
 +        net.minecraftforge.event.ForgeEventFactory.onChunkPopulate(false, this, this.field_185952_n, this.field_185954_p, p_185931_1_, p_185931_2_, false);
-+        net.minecraftforge.common.MinecraftForge.EVENT_BUS.post(new net.minecraftforge.event.terraingen.DecorateBiomeEvent.Pre(this.field_185952_n, this.field_185954_p, blockpos));
++        net.minecraftforge.common.MinecraftForge.EVENT_BUS.post(new net.minecraftforge.event.terraingen.DecorateBiomeEvent.Pre(this.field_185952_n, this.field_185954_p, blockpos, blockpos));
 +
-+        if (net.minecraftforge.event.terraingen.TerrainGen.decorate(this.field_185952_n, this.field_185954_p, blockpos, net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.SHROOM))
++        if (net.minecraftforge.event.terraingen.TerrainGen.decorate(this.field_185952_n, this.field_185954_p, blockpos, net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.SHROOM, blockpos))
 +        {
          if (this.field_185954_p.nextBoolean())
          {
@@ -113,7 +113,7 @@
  
          biome.func_180624_a(this.field_185952_n, this.field_185954_p, new BlockPos(i, 0, j));
 +
-+        net.minecraftforge.common.MinecraftForge.EVENT_BUS.post(new net.minecraftforge.event.terraingen.DecorateBiomeEvent.Post(this.field_185952_n, this.field_185954_p, blockpos));
++        net.minecraftforge.common.MinecraftForge.EVENT_BUS.post(new net.minecraftforge.event.terraingen.DecorateBiomeEvent.Post(this.field_185952_n, this.field_185954_p, blockpos, blockpos));
 +
          BlockFalling.field_149832_M = false;
      }

--- a/patches/minecraft/net/minecraft/world/gen/ChunkGeneratorHell.java.patch
+++ b/patches/minecraft/net/minecraft/world/gen/ChunkGeneratorHell.java.patch
@@ -75,9 +75,9 @@
 +        }//Forge: End doGLowstone
  
 +        net.minecraftforge.event.ForgeEventFactory.onChunkPopulate(false, this, this.field_185952_n, this.field_185954_p, p_185931_1_, p_185931_2_, false);
-+        net.minecraftforge.common.MinecraftForge.EVENT_BUS.post(new net.minecraftforge.event.terraingen.DecorateBiomeEvent.Pre(this.field_185952_n, this.field_185954_p, blockpos, blockpos));
++        net.minecraftforge.common.MinecraftForge.EVENT_BUS.post(new net.minecraftforge.event.terraingen.DecorateBiomeEvent.Pre(this.field_185952_n, this.field_185954_p, blockpos, new net.minecraft.util.math.ChunkPos(blockpos)));
 +
-+        if (net.minecraftforge.event.terraingen.TerrainGen.decorate(this.field_185952_n, this.field_185954_p, blockpos, net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.SHROOM, blockpos))
++        if (net.minecraftforge.event.terraingen.TerrainGen.decorate(this.field_185952_n, this.field_185954_p, blockpos, net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.SHROOM, new net.minecraft.util.math.ChunkPos(blockpos)))
 +        {
          if (this.field_185954_p.nextBoolean())
          {
@@ -113,7 +113,7 @@
  
          biome.func_180624_a(this.field_185952_n, this.field_185954_p, new BlockPos(i, 0, j));
 +
-+        net.minecraftforge.common.MinecraftForge.EVENT_BUS.post(new net.minecraftforge.event.terraingen.DecorateBiomeEvent.Post(this.field_185952_n, this.field_185954_p, blockpos, blockpos));
++        net.minecraftforge.common.MinecraftForge.EVENT_BUS.post(new net.minecraftforge.event.terraingen.DecorateBiomeEvent.Post(this.field_185952_n, this.field_185954_p, blockpos, new net.minecraft.util.math.ChunkPos(blockpos)));
 +
          BlockFalling.field_149832_M = false;
      }

--- a/patches/minecraft/net/minecraft/world/gen/ChunkGeneratorHell.java.patch
+++ b/patches/minecraft/net/minecraft/world/gen/ChunkGeneratorHell.java.patch
@@ -75,9 +75,9 @@
 +        }//Forge: End doGLowstone
  
 +        net.minecraftforge.event.ForgeEventFactory.onChunkPopulate(false, this, this.field_185952_n, this.field_185954_p, p_185931_1_, p_185931_2_, false);
-+        net.minecraftforge.common.MinecraftForge.EVENT_BUS.post(new net.minecraftforge.event.terraingen.DecorateBiomeEvent.Pre(this.field_185952_n, this.field_185954_p, blockpos));
++        net.minecraftforge.common.MinecraftForge.EVENT_BUS.post(new net.minecraftforge.event.terraingen.DecorateBiomeEvent.Pre(this.field_185952_n, this.field_185954_p, chunkpos));
 +
-+        if (net.minecraftforge.event.terraingen.TerrainGen.decorate(this.field_185952_n, this.field_185954_p, blockpos, net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.SHROOM))
++        if (net.minecraftforge.event.terraingen.TerrainGen.decorate(this.field_185952_n, this.field_185954_p, chunkpos, net.minecraftforge.event.terraingen.DecorateBiomeEvent.Decorate.EventType.SHROOM))
 +        {
          if (this.field_185954_p.nextBoolean())
          {

--- a/src/main/java/net/minecraftforge/event/terraingen/DecorateBiomeEvent.java
+++ b/src/main/java/net/minecraftforge/event/terraingen/DecorateBiomeEvent.java
@@ -52,12 +52,9 @@ public class DecorateBiomeEvent extends Event
 {
     private final World world;
     private final Random rand;
-    /**
-     * @deprecated use {@link #chunkPos}
-     */
-    @Deprecated
+    /** @deprecated use {@link #chunkPos} */
+    @Deprecated // TODO remove in 1.13
     private final BlockPos pos;
-    @Nullable // TODO: remove nullable in 1.13
     private final ChunkPos chunkPos;
 
     public DecorateBiomeEvent(World world, Random rand, ChunkPos chunkPos)
@@ -74,7 +71,7 @@ public class DecorateBiomeEvent extends Event
         this.world = world;
         this.rand = rand;
         this.pos = pos;
-        this.chunkPos = null;
+        this.chunkPos = new ChunkPos(pos);
     }
 
     public World getWorld()
@@ -88,9 +85,7 @@ public class DecorateBiomeEvent extends Event
     }
 
     /**
-     * Get the position used for original decoration generation.
-     * This may be anywhere randomly inside the 2x2 chunk area for generation.
-     * To get the original chunk position of the generation before a random location was chosen, use {@link #getChunkPos()}.
+     * @deprecated use {@link #getChunkPos()} or {@link Decorate#getPlacementPos} instead.
      */
     @Deprecated
     public BlockPos getPos()
@@ -98,7 +93,6 @@ public class DecorateBiomeEvent extends Event
         return pos;
     }
 
-    @Nullable // TODO: remove nullable in 1.13
     public ChunkPos getChunkPos()
     {
         return chunkPos;
@@ -155,13 +149,14 @@ public class DecorateBiomeEvent extends Event
         }
 
         private final EventType type;
-        private final BlockPos pos;
+        @Nullable
+        private final BlockPos placementPos;
 
-        public Decorate(World world, Random rand, ChunkPos chunkPos, BlockPos pos, EventType type)
+        public Decorate(World world, Random rand, ChunkPos chunkPos, @Nullable BlockPos placementPos, EventType type)
         {
             super(world, rand, chunkPos);
             this.type = type;
-            this.pos = pos;
+            this.placementPos = placementPos;
         }
 
         @Deprecated // TODO: remove in 1.13
@@ -169,7 +164,7 @@ public class DecorateBiomeEvent extends Event
         {
             super(world, rand, pos);
             this.type = type;
-            this.pos = pos;
+            this.placementPos = null;
         }
 
         public EventType getType()
@@ -178,14 +173,15 @@ public class DecorateBiomeEvent extends Event
         }
 
         /**
-         * Get the position used for original decoration generation.
-         * This may be the original chunk position, or anywhere inside the 2x2 chunk area for generation.
+         * This may be anywhere inside the 2x2 chunk area for generation.
          * To get the original chunk position of the generation before a random location was chosen, use {@link #getChunkPos()}.
+         *
+         * @return the position used for original decoration, or null if it is not specified.
          */
-        @Override // TODO 1.13: this should not be an override any more, it's specific to this event
-        public BlockPos getPos()
+        @Nullable
+        public BlockPos getPlacementPos()
         {
-            return this.pos;
+            return this.placementPos;
         }
     }
 }

--- a/src/main/java/net/minecraftforge/event/terraingen/DecorateBiomeEvent.java
+++ b/src/main/java/net/minecraftforge/event/terraingen/DecorateBiomeEvent.java
@@ -39,7 +39,7 @@ import net.minecraft.world.World;
  * {@link #world} contains the world that is being decorated. <br>
  * {@link #rand} contains an instance of Random to be used. <br>
  * {@link #pos} contains the coordinates of the Chunk being decorated. <br>
- * {@link #originalBlockPos} contains the original coordinates posted for the event. <br>
+ * {@link #originalPos} contains the original coordinates for the decorator. <br>
  * <br>
  * This event is not {@link Cancelable}.
  * <br>
@@ -53,14 +53,14 @@ public class DecorateBiomeEvent extends Event
     private final Random rand;
     private final BlockPos pos;
     @Nullable
-    private final BlockPos originalBlockPos;
+    private final BlockPos originalPos;
 
-    public DecorateBiomeEvent(World world, Random rand, BlockPos pos, BlockPos originalBlockPos)
+    public DecorateBiomeEvent(World world, Random rand, BlockPos pos, BlockPos originalPos)
     {
         this.world = world;
         this.rand = rand;
         this.pos = pos;
-        this.originalBlockPos = originalBlockPos;
+        this.originalPos = originalPos;
     }
     
     //TODO: remove in 1.13
@@ -70,7 +70,7 @@ public class DecorateBiomeEvent extends Event
         this.world = world;
         this.rand = rand;
         this.pos = pos;
-        originalBlockPos = null;
+        originalPos = null;
     }
 
     public World getWorld()
@@ -88,10 +88,10 @@ public class DecorateBiomeEvent extends Event
         return pos;
     }
     
-    @Nullable
-    public BlockPos getOriginalBlockPos()
+    @Nullable //TODO: Remove nullable in 1.13
+    public BlockPos getOriginalPos()
     {
-    	return originalBlockPos;
+    	return originalPos;
     }
 
     /**
@@ -99,12 +99,12 @@ public class DecorateBiomeEvent extends Event
      */
     public static class Pre extends DecorateBiomeEvent
     {
-        public Pre(World world, Random rand, BlockPos pos, BlockPos originalBlockPos)
+        public Pre(World world, Random rand, BlockPos pos, BlockPos originalPos)
         {
-            super(world, rand, pos, originalBlockPos);
+            super(world, rand, pos, originalPos);
         }
         
-      //TODO: remove in 1.13
+        //TODO: remove in 1.13
         @Deprecated
         public Pre(World world, Random rand, BlockPos pos)
         {
@@ -117,12 +117,12 @@ public class DecorateBiomeEvent extends Event
      */
     public static class Post extends DecorateBiomeEvent
     {
-        public Post(World world, Random rand, BlockPos pos, BlockPos originalBlockPos)
+        public Post(World world, Random rand, BlockPos pos, BlockPos originalPos)
         {
-            super(world, rand, pos, originalBlockPos);
+            super(world, rand, pos, originalPos);
         }
         
-      //TODO: remove in 1.13
+        //TODO: remove in 1.13
         @Deprecated
         public Post(World world, Random rand, BlockPos pos)
         {
@@ -149,13 +149,13 @@ public class DecorateBiomeEvent extends Event
 
         private final EventType type;
 
-        public Decorate(World world, Random rand, BlockPos pos, EventType type, BlockPos originalBlockPos)
+        public Decorate(World world, Random rand, BlockPos pos, EventType type, BlockPos originalPos)
         {
-            super(world, rand, pos, originalBlockPos);
+            super(world, rand, pos, originalPos);
             this.type = type;
         }
         
-      //TODO: remove in 1.13
+        //TODO: remove in 1.13
         @Deprecated
         public Decorate(World world, Random rand, BlockPos pos, EventType type)
         {

--- a/src/main/java/net/minecraftforge/event/terraingen/DecorateBiomeEvent.java
+++ b/src/main/java/net/minecraftforge/event/terraingen/DecorateBiomeEvent.java
@@ -49,12 +49,14 @@ public class DecorateBiomeEvent extends Event
     private final World world;
     private final Random rand;
     private final BlockPos pos;
+    private final BlockPos chunkPos;
 
-    public DecorateBiomeEvent(World world, Random rand, BlockPos pos)
+    public DecorateBiomeEvent(World world, Random rand, BlockPos pos, BlockPos chunkPos)
     {
         this.world = world;
         this.rand = rand;
         this.pos = pos;
+        this.chunkPos = chunkPos;
     }
 
     public World getWorld()
@@ -71,15 +73,20 @@ public class DecorateBiomeEvent extends Event
     {
         return pos;
     }
+    
+    public BlockPos getChunkPos()
+    {
+    	return chunkPos;
+    }
 
     /**
      * This event is fired before a chunk is decorated with a biome feature.
      */
     public static class Pre extends DecorateBiomeEvent
     {
-        public Pre(World world, Random rand, BlockPos pos)
+        public Pre(World world, Random rand, BlockPos pos, BlockPos chunkPos)
         {
-            super(world, rand, pos);
+            super(world, rand, pos, chunkPos);
         }
     }
 
@@ -88,9 +95,9 @@ public class DecorateBiomeEvent extends Event
      */
     public static class Post extends DecorateBiomeEvent
     {
-        public Post(World world, Random rand, BlockPos pos)
+        public Post(World world, Random rand, BlockPos pos, BlockPos chunkPos)
         {
-            super(world, rand, pos);
+            super(world, rand, pos, chunkPos);
         }
     }
 
@@ -113,9 +120,9 @@ public class DecorateBiomeEvent extends Event
 
         private final EventType type;
 
-        public Decorate(World world, Random rand, BlockPos pos, EventType type)
+        public Decorate(World world, Random rand, BlockPos pos, EventType type, BlockPos chunkPos)
         {
-            super(world, rand, pos);
+            super(world, rand, pos, chunkPos);
             this.type = type;
         }
     }

--- a/src/main/java/net/minecraftforge/event/terraingen/DecorateBiomeEvent.java
+++ b/src/main/java/net/minecraftforge/event/terraingen/DecorateBiomeEvent.java
@@ -52,26 +52,29 @@ public class DecorateBiomeEvent extends Event
 {
     private final World world;
     private final Random rand;
+    /**
+     * @deprecated use {@link #chunkPos}
+     */
+    @Deprecated
     private final BlockPos pos;
-    @Nullable
+    @Nullable // TODO: remove nullable in 1.13
     private final ChunkPos chunkPos;
 
-    public DecorateBiomeEvent(World world, Random rand, BlockPos pos, ChunkPos chunkPos)
+    public DecorateBiomeEvent(World world, Random rand, ChunkPos chunkPos)
     {
         this.world = world;
         this.rand = rand;
-        this.pos = pos;
+        this.pos = chunkPos.getBlock(0, 0, 0);
         this.chunkPos = chunkPos;
     }
 
-    //TODO: remove in 1.13
-    @Deprecated
+    @Deprecated // TODO: remove in 1.13
     public DecorateBiomeEvent(World world, Random rand, BlockPos pos)
     {
         this.world = world;
         this.rand = rand;
         this.pos = pos;
-        chunkPos = null;
+        this.chunkPos = null;
     }
 
     public World getWorld()
@@ -84,12 +87,18 @@ public class DecorateBiomeEvent extends Event
         return rand;
     }
 
+    /**
+     * Get the position used for original decoration generation.
+     * This may be anywhere randomly inside the 2x2 chunk area for generation.
+     * To get the original chunk position of the generation before a random location was chosen, use {@link #getChunkPos()}.
+     */
+    @Deprecated
     public BlockPos getPos()
     {
         return pos;
     }
 
-    @Nullable //TODO: Remove nullable in 1.13
+    @Nullable // TODO: remove nullable in 1.13
     public ChunkPos getChunkPos()
     {
         return chunkPos;
@@ -100,13 +109,12 @@ public class DecorateBiomeEvent extends Event
      */
     public static class Pre extends DecorateBiomeEvent
     {
-        public Pre(World world, Random rand, BlockPos pos, ChunkPos chunkPos)
+        public Pre(World world, Random rand, ChunkPos chunkPos)
         {
-            super(world, rand, pos, chunkPos);
+            super(world, rand, chunkPos);
         }
 
-        //TODO: remove in 1.13
-        @Deprecated
+        @Deprecated // TODO: remove in 1.13
         public Pre(World world, Random rand, BlockPos pos)
         {
             super(world, rand, pos);
@@ -118,13 +126,12 @@ public class DecorateBiomeEvent extends Event
      */
     public static class Post extends DecorateBiomeEvent
     {
-        public Post(World world, Random rand, BlockPos pos, ChunkPos chunkPos)
+        public Post(World world, Random rand, ChunkPos chunkPos)
         {
-            super(world, rand, pos, chunkPos);
+            super(world, rand, chunkPos);
         }
 
-        //TODO: remove in 1.13
-        @Deprecated
+        @Deprecated //TODO: remove in 1.13
         public Post(World world, Random rand, BlockPos pos)
         {
             super(world, rand, pos);
@@ -139,33 +146,46 @@ public class DecorateBiomeEvent extends Event
     @HasResult
     public static class Decorate extends DecorateBiomeEvent
     {
+        /**
+         * Use {@link EventType#CUSTOM} to filter custom event types
+         */
+        public enum EventType
+        {
+            BIG_SHROOM, CACTUS, CLAY, DEAD_BUSH, DESERT_WELL, LILYPAD, FLOWERS, FOSSIL, GRASS, ICE, LAKE_WATER, LAKE_LAVA, PUMPKIN, REED, ROCK, SAND, SAND_PASS2, SHROOM, TREE, CUSTOM
+        }
+
+        private final EventType type;
+        private final BlockPos pos;
+
+        public Decorate(World world, Random rand, ChunkPos chunkPos, BlockPos pos, EventType type)
+        {
+            super(world, rand, chunkPos);
+            this.type = type;
+            this.pos = pos;
+        }
+
+        @Deprecated // TODO: remove in 1.13
+        public Decorate(World world, Random rand, BlockPos pos, EventType type)
+        {
+            super(world, rand, pos);
+            this.type = type;
+            this.pos = pos;
+        }
+
         public EventType getType()
         {
             return type;
         }
 
         /**
-         * Use CUSTOM to filter custom event types
+         * Get the position used for original decoration generation.
+         * This may be the original chunk position, or anywhere inside the 2x2 chunk area for generation.
+         * To get the original chunk position of the generation before a random location was chosen, use {@link #getChunkPos()}.
          */
-        public static enum EventType
+        @Override // TODO 1.13: this should not be an override any more, it's specific to this event
+        public BlockPos getPos()
         {
-            BIG_SHROOM, CACTUS, CLAY, DEAD_BUSH, DESERT_WELL, LILYPAD, FLOWERS, FOSSIL, GRASS, ICE, LAKE_WATER, LAKE_LAVA, PUMPKIN, REED, ROCK, SAND, SAND_PASS2, SHROOM, TREE, CUSTOM
-        }
-
-        private final EventType type;
-
-        public Decorate(World world, Random rand, BlockPos pos, EventType type, ChunkPos chunkPos)
-        {
-            super(world, rand, pos, chunkPos);
-            this.type = type;
-        }
-
-        //TODO: remove in 1.13
-        @Deprecated
-        public Decorate(World world, Random rand, BlockPos pos, EventType type)
-        {
-            super(world, rand, pos);
-            this.type = type;
+            return this.pos;
         }
     }
 }

--- a/src/main/java/net/minecraftforge/event/terraingen/DecorateBiomeEvent.java
+++ b/src/main/java/net/minecraftforge/event/terraingen/DecorateBiomeEvent.java
@@ -39,7 +39,6 @@ import net.minecraftforge.fml.common.eventhandler.Event;
  * <br>
  * {@link #world} contains the world that is being decorated. <br>
  * {@link #rand} contains an instance of Random to be used. <br>
- * {@link #pos} contains the coordinates of the block in a Chunk being decorated. <br>
  * {@link #chunkPos} contains the original chunk for the decorator. <br>
  * <br>
  * This event is not {@link Cancelable}.

--- a/src/main/java/net/minecraftforge/event/terraingen/DecorateBiomeEvent.java
+++ b/src/main/java/net/minecraftforge/event/terraingen/DecorateBiomeEvent.java
@@ -23,23 +23,24 @@ import java.util.Random;
 
 import javax.annotation.Nullable;
 
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.math.ChunkPos;
+import net.minecraft.world.World;
 import net.minecraft.world.biome.Biome;
 import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.fml.common.eventhandler.Cancelable;
 import net.minecraftforge.fml.common.eventhandler.Event;
-import net.minecraftforge.fml.common.eventhandler.Event.HasResult;
-import net.minecraft.util.math.BlockPos;
-import net.minecraft.world.World;
 
-/**DecorateBiomeEvent is fired when a BiomeDecorator is created.
+/**
+ * DecorateBiomeEvent is fired when a BiomeDecorator is created.
  * <br>
  * This event is fired whenever a BiomeDecorator is created in
  * {@link DeferredBiomeDecorator#fireCreateEventAndReplace(Biome)}.<br>
  * <br>
  * {@link #world} contains the world that is being decorated. <br>
  * {@link #rand} contains an instance of Random to be used. <br>
- * {@link #pos} contains the coordinates of the Chunk being decorated. <br>
- * {@link #originalPos} contains the original coordinates for the decorator. <br>
+ * {@link #pos} contains the coordinates of the block in a Chunk being decorated. <br>
+ * {@link #chunkPos} contains the original chunk for the decorator. <br>
  * <br>
  * This event is not {@link Cancelable}.
  * <br>
@@ -53,16 +54,16 @@ public class DecorateBiomeEvent extends Event
     private final Random rand;
     private final BlockPos pos;
     @Nullable
-    private final BlockPos originalPos;
+    private final ChunkPos chunkPos;
 
-    public DecorateBiomeEvent(World world, Random rand, BlockPos pos, BlockPos originalPos)
+    public DecorateBiomeEvent(World world, Random rand, BlockPos pos, ChunkPos chunkPos)
     {
         this.world = world;
         this.rand = rand;
         this.pos = pos;
-        this.originalPos = originalPos;
+        this.chunkPos = chunkPos;
     }
-    
+
     //TODO: remove in 1.13
     @Deprecated
     public DecorateBiomeEvent(World world, Random rand, BlockPos pos)
@@ -70,7 +71,7 @@ public class DecorateBiomeEvent extends Event
         this.world = world;
         this.rand = rand;
         this.pos = pos;
-        originalPos = null;
+        chunkPos = null;
     }
 
     public World getWorld()
@@ -87,11 +88,11 @@ public class DecorateBiomeEvent extends Event
     {
         return pos;
     }
-    
+
     @Nullable //TODO: Remove nullable in 1.13
-    public BlockPos getOriginalPos()
+    public ChunkPos getChunkPos()
     {
-    	return originalPos;
+        return chunkPos;
     }
 
     /**
@@ -99,11 +100,11 @@ public class DecorateBiomeEvent extends Event
      */
     public static class Pre extends DecorateBiomeEvent
     {
-        public Pre(World world, Random rand, BlockPos pos, BlockPos originalPos)
+        public Pre(World world, Random rand, BlockPos pos, ChunkPos chunkPos)
         {
-            super(world, rand, pos, originalPos);
+            super(world, rand, pos, chunkPos);
         }
-        
+
         //TODO: remove in 1.13
         @Deprecated
         public Pre(World world, Random rand, BlockPos pos)
@@ -117,11 +118,11 @@ public class DecorateBiomeEvent extends Event
      */
     public static class Post extends DecorateBiomeEvent
     {
-        public Post(World world, Random rand, BlockPos pos, BlockPos originalPos)
+        public Post(World world, Random rand, BlockPos pos, ChunkPos chunkPos)
         {
-            super(world, rand, pos, originalPos);
+            super(world, rand, pos, chunkPos);
         }
-        
+
         //TODO: remove in 1.13
         @Deprecated
         public Post(World world, Random rand, BlockPos pos)
@@ -132,7 +133,7 @@ public class DecorateBiomeEvent extends Event
 
     /**
      * This event is fired when a chunk is decorated with a biome feature.
-     *
+     * <p>
      * You can set the result to DENY to prevent the default biome decoration.
      */
     @HasResult
@@ -143,18 +144,22 @@ public class DecorateBiomeEvent extends Event
             return type;
         }
 
-        /** Use CUSTOM to filter custom event types
+        /**
+         * Use CUSTOM to filter custom event types
          */
-        public static enum EventType { BIG_SHROOM, CACTUS, CLAY, DEAD_BUSH, DESERT_WELL, LILYPAD, FLOWERS, FOSSIL, GRASS, ICE, LAKE_WATER, LAKE_LAVA, PUMPKIN, REED, ROCK, SAND, SAND_PASS2, SHROOM, TREE, CUSTOM }
+        public static enum EventType
+        {
+            BIG_SHROOM, CACTUS, CLAY, DEAD_BUSH, DESERT_WELL, LILYPAD, FLOWERS, FOSSIL, GRASS, ICE, LAKE_WATER, LAKE_LAVA, PUMPKIN, REED, ROCK, SAND, SAND_PASS2, SHROOM, TREE, CUSTOM
+        }
 
         private final EventType type;
 
-        public Decorate(World world, Random rand, BlockPos pos, EventType type, BlockPos originalPos)
+        public Decorate(World world, Random rand, BlockPos pos, EventType type, ChunkPos chunkPos)
         {
-            super(world, rand, pos, originalPos);
+            super(world, rand, pos, chunkPos);
             this.type = type;
         }
-        
+
         //TODO: remove in 1.13
         @Deprecated
         public Decorate(World world, Random rand, BlockPos pos, EventType type)

--- a/src/main/java/net/minecraftforge/event/terraingen/DecorateBiomeEvent.java
+++ b/src/main/java/net/minecraftforge/event/terraingen/DecorateBiomeEvent.java
@@ -21,6 +21,8 @@ package net.minecraftforge.event.terraingen;
 
 import java.util.Random;
 
+import javax.annotation.Nullable;
+
 import net.minecraft.world.biome.Biome;
 import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.fml.common.eventhandler.Cancelable;
@@ -49,6 +51,7 @@ public class DecorateBiomeEvent extends Event
     private final World world;
     private final Random rand;
     private final BlockPos pos;
+    @Nullable
     private final BlockPos chunkPos;
 
     public DecorateBiomeEvent(World world, Random rand, BlockPos pos, BlockPos chunkPos)
@@ -59,12 +62,14 @@ public class DecorateBiomeEvent extends Event
         this.chunkPos = chunkPos;
     }
     
+    //TODO: remove in 1.13
+    @Deprecated
     public DecorateBiomeEvent(World world, Random rand, BlockPos pos)
     {
         this.world = world;
         this.rand = rand;
         this.pos = pos;
-        chunkPos = new BlockPos((pos.getX()/16)*16, (pos.getY()/16)*16, (pos.getZ()/16)*16);
+        chunkPos = null;
     }
 
     public World getWorld()
@@ -82,6 +87,7 @@ public class DecorateBiomeEvent extends Event
         return pos;
     }
     
+    @Nullable
     public BlockPos getChunkPos()
     {
     	return chunkPos;
@@ -97,6 +103,8 @@ public class DecorateBiomeEvent extends Event
             super(world, rand, pos, chunkPos);
         }
         
+      //TODO: remove in 1.13
+        @Deprecated
         public Pre(World world, Random rand, BlockPos pos)
         {
             super(world, rand, pos);
@@ -113,6 +121,8 @@ public class DecorateBiomeEvent extends Event
             super(world, rand, pos, chunkPos);
         }
         
+      //TODO: remove in 1.13
+        @Deprecated
         public Post(World world, Random rand, BlockPos pos)
         {
             super(world, rand, pos);
@@ -144,6 +154,8 @@ public class DecorateBiomeEvent extends Event
             this.type = type;
         }
         
+      //TODO: remove in 1.13
+        @Deprecated
         public Decorate(World world, Random rand, BlockPos pos, EventType type)
         {
             super(world, rand, pos);

--- a/src/main/java/net/minecraftforge/event/terraingen/DecorateBiomeEvent.java
+++ b/src/main/java/net/minecraftforge/event/terraingen/DecorateBiomeEvent.java
@@ -110,7 +110,7 @@ public class DecorateBiomeEvent extends Event
         @Deprecated // TODO: remove in 1.13
         public Pre(World world, Random rand, BlockPos pos)
         {
-            super(world, rand, pos);
+            this(world, rand, new ChunkPos(pos));
         }
     }
 
@@ -127,7 +127,7 @@ public class DecorateBiomeEvent extends Event
         @Deprecated //TODO: remove in 1.13
         public Post(World world, Random rand, BlockPos pos)
         {
-            super(world, rand, pos);
+            this(world, rand, new ChunkPos(pos));
         }
     }
 

--- a/src/main/java/net/minecraftforge/event/terraingen/DecorateBiomeEvent.java
+++ b/src/main/java/net/minecraftforge/event/terraingen/DecorateBiomeEvent.java
@@ -58,6 +58,14 @@ public class DecorateBiomeEvent extends Event
         this.pos = pos;
         this.chunkPos = chunkPos;
     }
+    
+    public DecorateBiomeEvent(World world, Random rand, BlockPos pos)
+    {
+        this.world = world;
+        this.rand = rand;
+        this.pos = pos;
+        chunkPos = new BlockPos((pos.getX()/16)*16, (pos.getY()/16)*16, (pos.getZ()/16)*16);
+    }
 
     public World getWorld()
     {
@@ -88,6 +96,11 @@ public class DecorateBiomeEvent extends Event
         {
             super(world, rand, pos, chunkPos);
         }
+        
+        public Pre(World world, Random rand, BlockPos pos)
+        {
+            super(world, rand, pos);
+        }
     }
 
     /**
@@ -98,6 +111,11 @@ public class DecorateBiomeEvent extends Event
         public Post(World world, Random rand, BlockPos pos, BlockPos chunkPos)
         {
             super(world, rand, pos, chunkPos);
+        }
+        
+        public Post(World world, Random rand, BlockPos pos)
+        {
+            super(world, rand, pos);
         }
     }
 
@@ -123,6 +141,12 @@ public class DecorateBiomeEvent extends Event
         public Decorate(World world, Random rand, BlockPos pos, EventType type, BlockPos chunkPos)
         {
             super(world, rand, pos, chunkPos);
+            this.type = type;
+        }
+        
+        public Decorate(World world, Random rand, BlockPos pos, EventType type)
+        {
+            super(world, rand, pos);
             this.type = type;
         }
     }

--- a/src/main/java/net/minecraftforge/event/terraingen/DecorateBiomeEvent.java
+++ b/src/main/java/net/minecraftforge/event/terraingen/DecorateBiomeEvent.java
@@ -39,6 +39,7 @@ import net.minecraft.world.World;
  * {@link #world} contains the world that is being decorated. <br>
  * {@link #rand} contains an instance of Random to be used. <br>
  * {@link #pos} contains the coordinates of the Chunk being decorated. <br>
+ * {@link #originalBlockPos} contains the original coordinates posted for the event. <br>
  * <br>
  * This event is not {@link Cancelable}.
  * <br>
@@ -52,14 +53,14 @@ public class DecorateBiomeEvent extends Event
     private final Random rand;
     private final BlockPos pos;
     @Nullable
-    private final BlockPos chunkPos;
+    private final BlockPos originalBlockPos;
 
-    public DecorateBiomeEvent(World world, Random rand, BlockPos pos, BlockPos chunkPos)
+    public DecorateBiomeEvent(World world, Random rand, BlockPos pos, BlockPos originalBlockPos)
     {
         this.world = world;
         this.rand = rand;
         this.pos = pos;
-        this.chunkPos = chunkPos;
+        this.originalBlockPos = originalBlockPos;
     }
     
     //TODO: remove in 1.13
@@ -69,7 +70,7 @@ public class DecorateBiomeEvent extends Event
         this.world = world;
         this.rand = rand;
         this.pos = pos;
-        chunkPos = null;
+        originalBlockPos = null;
     }
 
     public World getWorld()
@@ -88,9 +89,9 @@ public class DecorateBiomeEvent extends Event
     }
     
     @Nullable
-    public BlockPos getChunkPos()
+    public BlockPos getOriginalBlockPos()
     {
-    	return chunkPos;
+    	return originalBlockPos;
     }
 
     /**
@@ -98,9 +99,9 @@ public class DecorateBiomeEvent extends Event
      */
     public static class Pre extends DecorateBiomeEvent
     {
-        public Pre(World world, Random rand, BlockPos pos, BlockPos chunkPos)
+        public Pre(World world, Random rand, BlockPos pos, BlockPos originalBlockPos)
         {
-            super(world, rand, pos, chunkPos);
+            super(world, rand, pos, originalBlockPos);
         }
         
       //TODO: remove in 1.13
@@ -116,9 +117,9 @@ public class DecorateBiomeEvent extends Event
      */
     public static class Post extends DecorateBiomeEvent
     {
-        public Post(World world, Random rand, BlockPos pos, BlockPos chunkPos)
+        public Post(World world, Random rand, BlockPos pos, BlockPos originalBlockPos)
         {
-            super(world, rand, pos, chunkPos);
+            super(world, rand, pos, originalBlockPos);
         }
         
       //TODO: remove in 1.13
@@ -148,9 +149,9 @@ public class DecorateBiomeEvent extends Event
 
         private final EventType type;
 
-        public Decorate(World world, Random rand, BlockPos pos, EventType type, BlockPos chunkPos)
+        public Decorate(World world, Random rand, BlockPos pos, EventType type, BlockPos originalBlockPos)
         {
-            super(world, rand, pos, chunkPos);
+            super(world, rand, pos, originalBlockPos);
             this.type = type;
         }
         

--- a/src/main/java/net/minecraftforge/event/terraingen/TerrainGen.java
+++ b/src/main/java/net/minecraftforge/event/terraingen/TerrainGen.java
@@ -22,6 +22,7 @@ package net.minecraftforge.event.terraingen;
 import java.util.Random;
 
 import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.math.ChunkPos;
 import net.minecraft.world.World;
 import net.minecraft.world.gen.IChunkGenerator;
 import net.minecraft.world.gen.MapGenBase;
@@ -55,9 +56,9 @@ public abstract class TerrainGen
         return event.getResult() != Result.DENY;
     }
 
-    public static boolean decorate(World world, Random rand, BlockPos pos, Decorate.EventType type, BlockPos originalBlockPos)
+    public static boolean decorate(World world, Random rand, BlockPos pos, Decorate.EventType type, ChunkPos chunkPos)
     {
-        Decorate event = new Decorate(world, rand, pos, type, originalBlockPos);
+        Decorate event = new Decorate(world, rand, pos, type, chunkPos);
         MinecraftForge.TERRAIN_GEN_BUS.post(event);
         return event.getResult() != Result.DENY;
     }

--- a/src/main/java/net/minecraftforge/event/terraingen/TerrainGen.java
+++ b/src/main/java/net/minecraftforge/event/terraingen/TerrainGen.java
@@ -55,9 +55,9 @@ public abstract class TerrainGen
         return event.getResult() != Result.DENY;
     }
 
-    public static boolean decorate(World world, Random rand, BlockPos pos, Decorate.EventType type)
+    public static boolean decorate(World world, Random rand, BlockPos pos, Decorate.EventType type, BlockPos chunkPos)
     {
-        Decorate event = new Decorate(world, rand, pos, type);
+        Decorate event = new Decorate(world, rand, pos, type, chunkPos);
         MinecraftForge.TERRAIN_GEN_BUS.post(event);
         return event.getResult() != Result.DENY;
     }

--- a/src/main/java/net/minecraftforge/event/terraingen/TerrainGen.java
+++ b/src/main/java/net/minecraftforge/event/terraingen/TerrainGen.java
@@ -62,10 +62,10 @@ public abstract class TerrainGen
         return event.getResult() != Result.DENY;
     }
 
-    /*
-     *Use version with originalBlockPos instead
+    /**
+     * @deprecated Use version with originalBlockPos instead
      */
-    @Deprecated     //TODO - remove in 1.13
+    @Deprecated //TODO - remove in 1.13
     public static boolean decorate(World world, Random rand, BlockPos pos, Decorate.EventType type)
     {
         Decorate event = new Decorate(world, rand, pos, type);

--- a/src/main/java/net/minecraftforge/event/terraingen/TerrainGen.java
+++ b/src/main/java/net/minecraftforge/event/terraingen/TerrainGen.java
@@ -55,9 +55,20 @@ public abstract class TerrainGen
         return event.getResult() != Result.DENY;
     }
 
-    public static boolean decorate(World world, Random rand, BlockPos pos, Decorate.EventType type, BlockPos chunkPos)
+    public static boolean decorate(World world, Random rand, BlockPos pos, Decorate.EventType type, BlockPos originalBlockPos)
     {
-        Decorate event = new Decorate(world, rand, pos, type, chunkPos);
+        Decorate event = new Decorate(world, rand, pos, type, originalBlockPos);
+        MinecraftForge.TERRAIN_GEN_BUS.post(event);
+        return event.getResult() != Result.DENY;
+    }
+
+    /*
+     *Use version with originalBlockPos instead
+     */
+    @Deprecated     //TODO - remove in 1.13
+    public static boolean decorate(World world, Random rand, BlockPos pos, Decorate.EventType type)
+    {
+        Decorate event = new Decorate(world, rand, pos, type);
         MinecraftForge.TERRAIN_GEN_BUS.post(event);
         return event.getResult() != Result.DENY;
     }

--- a/src/main/java/net/minecraftforge/event/terraingen/TerrainGen.java
+++ b/src/main/java/net/minecraftforge/event/terraingen/TerrainGen.java
@@ -63,19 +63,19 @@ public abstract class TerrainGen
      * @param world the world being generated in
      * @param rand the random generator used for decoration
      * @param chunkPos the original chunk position used for generation, passed to the decorator
-     * @param blockPos the specific position used for generating a feature, somewhere in the 2x2 chunks used for decoration
+     * @param placementPos the specific position used for generating a feature, somewhere in the 2x2 chunks used for decoration
      * @param type the type of decoration
      */
-    public static boolean decorate(World world, Random rand, BlockPos chunkPos, BlockPos blockPos, Decorate.EventType type)
+    public static boolean decorateWithPlacementPos(World world, Random rand, BlockPos chunkPos, BlockPos placementPos, Decorate.EventType type)
     {
-        Decorate event = new Decorate(world, rand, new ChunkPos(chunkPos), blockPos, type);
+        Decorate event = new Decorate(world, rand, new ChunkPos(chunkPos), placementPos, type);
         MinecraftForge.TERRAIN_GEN_BUS.post(event);
         return event.getResult() != Result.DENY;
     }
 
     /**
      * Use this method when generation doesn't have a specific BlockPos location for generation in the chunk.
-     * If a specific BlockPos for generation is available, use {@link #decorate(World, Random, BlockPos, BlockPos, Decorate.EventType)} instead.
+     * If a specific BlockPos for generation is available, use {@link #decorateWithPlacementPos(World, Random, BlockPos, BlockPos, Decorate.EventType)} instead.
      *
      * @param world the world being generated in
      * @param rand the random generator used for decoration
@@ -84,7 +84,7 @@ public abstract class TerrainGen
      */
     public static boolean decorate(World world, Random rand, BlockPos pos, Decorate.EventType type)
     {
-        Decorate event = new Decorate(world, rand, new ChunkPos(pos), pos, type);
+        Decorate event = new Decorate(world, rand, new ChunkPos(pos), null, type);
         MinecraftForge.TERRAIN_GEN_BUS.post(event);
         return event.getResult() != Result.DENY;
     }

--- a/src/main/java/net/minecraftforge/event/terraingen/TerrainGen.java
+++ b/src/main/java/net/minecraftforge/event/terraingen/TerrainGen.java
@@ -102,30 +102,4 @@ public abstract class TerrainGen
         MinecraftForge.TERRAIN_GEN_BUS.post(event);
         return event.getResult() != Result.DENY;
     }
-
-    /**
-     * Fired before biome decoration.
-     *
-     * @param world the world being decorated
-     * @param random the random instance used for decoration
-     * @param pos the original chunk position used for generation, passed to the decorator
-     */
-    public static void decorateBiomePre(World world, Random random, BlockPos pos)
-    {
-        DecorateBiomeEvent.Pre event = new DecorateBiomeEvent.Pre(world, random, new ChunkPos(pos));
-        MinecraftForge.EVENT_BUS.post(event);
-    }
-
-    /**
-     * Fired after biome decoration.
-     *
-     * @param world the world being decorated
-     * @param random the random instance used for decoration
-     * @param pos the original chunk position used for generation, passed to the decorator
-     */
-    public static void decorateBiomePost(World world, Random random, BlockPos pos)
-    {
-        DecorateBiomeEvent.Post event = new DecorateBiomeEvent.Post(world, random, new ChunkPos(pos));
-        MinecraftForge.EVENT_BUS.post(event);
-    }
 }

--- a/src/main/java/net/minecraftforge/event/terraingen/TerrainGen.java
+++ b/src/main/java/net/minecraftforge/event/terraingen/TerrainGen.java
@@ -37,7 +37,7 @@ public abstract class TerrainGen
 {
     public static <T extends InitNoiseGensEvent.Context> T getModdedNoiseGenerators(World world, Random rand, T original)
     {
-        InitNoiseGensEvent<T> event = new InitNoiseGensEvent<T>(world, rand, original);
+        InitNoiseGensEvent<T> event = new InitNoiseGensEvent<>(world, rand, original);
         MinecraftForge.TERRAIN_GEN_BUS.post(event);
         return event.getNewValues();
     }
@@ -56,20 +56,35 @@ public abstract class TerrainGen
         return event.getResult() != Result.DENY;
     }
 
-    public static boolean decorate(World world, Random rand, BlockPos pos, Decorate.EventType type, ChunkPos chunkPos)
+    /**
+     * Use this method when there is a specific BlockPos location given for decoration.
+     * If only the chunk position is available, use {@link #decorate(World, Random, BlockPos, Decorate.EventType)} instead.
+     *
+     * @param world the world being generated in
+     * @param rand the random generator used for decoration
+     * @param chunkPos the original chunk position used for generation, passed to the decorator
+     * @param blockPos the specific position used for generating a feature, somewhere in the 2x2 chunks used for decoration
+     * @param type the type of decoration
+     */
+    public static boolean decorate(World world, Random rand, BlockPos chunkPos, BlockPos blockPos, Decorate.EventType type)
     {
-        Decorate event = new Decorate(world, rand, pos, type, chunkPos);
+        Decorate event = new Decorate(world, rand, new ChunkPos(chunkPos), blockPos, type);
         MinecraftForge.TERRAIN_GEN_BUS.post(event);
         return event.getResult() != Result.DENY;
     }
 
     /**
-     * @deprecated Use version with originalBlockPos instead
+     * Use this method when generation doesn't have a specific BlockPos location for generation in the chunk.
+     * If a specific BlockPos for generation is available, use {@link #decorate(World, Random, BlockPos, BlockPos, Decorate.EventType)} instead.
+     *
+     * @param world the world being generated in
+     * @param rand the random generator used for decoration
+     * @param pos the original chunk position used for generation, passed to the decorator
+     * @param type the type of decoration
      */
-    @Deprecated //TODO - remove in 1.13
     public static boolean decorate(World world, Random rand, BlockPos pos, Decorate.EventType type)
     {
-        Decorate event = new Decorate(world, rand, pos, type);
+        Decorate event = new Decorate(world, rand, new ChunkPos(pos), pos, type);
         MinecraftForge.TERRAIN_GEN_BUS.post(event);
         return event.getResult() != Result.DENY;
     }
@@ -86,5 +101,31 @@ public abstract class TerrainGen
         SaplingGrowTreeEvent event = new SaplingGrowTreeEvent(world, rand, pos);
         MinecraftForge.TERRAIN_GEN_BUS.post(event);
         return event.getResult() != Result.DENY;
+    }
+
+    /**
+     * Fired before biome decoration.
+     *
+     * @param world the world being decorated
+     * @param random the random instance used for decoration
+     * @param pos the original chunk position used for generation, passed to the decorator
+     */
+    public static void decorateBiomePre(World world, Random random, BlockPos pos)
+    {
+        DecorateBiomeEvent.Pre event = new DecorateBiomeEvent.Pre(world, random, new ChunkPos(pos));
+        MinecraftForge.EVENT_BUS.post(event);
+    }
+
+    /**
+     * Fired after biome decoration.
+     *
+     * @param world the world being decorated
+     * @param random the random instance used for decoration
+     * @param pos the original chunk position used for generation, passed to the decorator
+     */
+    public static void decorateBiomePost(World world, Random random, BlockPos pos)
+    {
+        DecorateBiomeEvent.Post event = new DecorateBiomeEvent.Post(world, random, new ChunkPos(pos));
+        MinecraftForge.EVENT_BUS.post(event);
     }
 }

--- a/src/main/java/net/minecraftforge/event/terraingen/TerrainGen.java
+++ b/src/main/java/net/minecraftforge/event/terraingen/TerrainGen.java
@@ -58,7 +58,7 @@ public abstract class TerrainGen
 
     /**
      * Use this method when there is a specific BlockPos location given for decoration.
-     * If only the chunk position is available, use {@link #decorate(World, Random, BlockPos, Decorate.EventType)} instead.
+     * If only the chunk position is available, use {@link #decorate(World, Random, ChunkPos, Decorate.EventType)} instead.
      *
      * @param world the world being generated in
      * @param rand the random generator used for decoration
@@ -66,27 +66,33 @@ public abstract class TerrainGen
      * @param placementPos the specific position used for generating a feature, somewhere in the 2x2 chunks used for decoration
      * @param type the type of decoration
      */
-    public static boolean decorateWithPlacementPos(World world, Random rand, BlockPos chunkPos, BlockPos placementPos, Decorate.EventType type)
+    public static boolean decorate(World world, Random rand, ChunkPos chunkPos, BlockPos placementPos, Decorate.EventType type)
     {
-        Decorate event = new Decorate(world, rand, new ChunkPos(chunkPos), placementPos, type);
+        Decorate event = new Decorate(world, rand, chunkPos, placementPos, type);
         MinecraftForge.TERRAIN_GEN_BUS.post(event);
         return event.getResult() != Result.DENY;
     }
 
     /**
      * Use this method when generation doesn't have a specific BlockPos location for generation in the chunk.
-     * If a specific BlockPos for generation is available, use {@link #decorateWithPlacementPos(World, Random, BlockPos, BlockPos, Decorate.EventType)} instead.
+     * If a specific BlockPos for generation is available, use {@link #decorate(World, Random, ChunkPos, BlockPos, Decorate.EventType)} instead.
      *
      * @param world the world being generated in
      * @param rand the random generator used for decoration
-     * @param pos the original chunk position used for generation, passed to the decorator
+     * @param chunkPos the original chunk position used for generation, passed to the decorator
      * @param type the type of decoration
      */
-    public static boolean decorate(World world, Random rand, BlockPos pos, Decorate.EventType type)
+    public static boolean decorate(World world, Random rand, ChunkPos chunkPos, Decorate.EventType type)
     {
-        Decorate event = new Decorate(world, rand, new ChunkPos(pos), null, type);
+        Decorate event = new Decorate(world, rand, chunkPos, null, type);
         MinecraftForge.TERRAIN_GEN_BUS.post(event);
         return event.getResult() != Result.DENY;
+    }
+
+    @Deprecated
+    public static boolean decorate(World world, Random rand, BlockPos pos, Decorate.EventType type)
+    {
+        return decorate(world, rand, new ChunkPos(pos), type);
     }
 
     public static boolean generateOre(World world, Random rand, WorldGenerator generator, BlockPos pos, GenerateMinable.EventType type)


### PR DESCRIPTION
From https://github.com/ForestryMC/ForestryMC/issues/1716.

If mods intercept a 'Decoration' event and replace it with their own decoration (eg-forestry does this for trees) then the position chosen by vanilla may not be suitable for a differently sized decoration from a mod. This PR adds an argument to the event to preserve the original position. For the moment the chunkPos is a normal coordinate but it could equally be a chunk coordinate. 

In quite a few cases this won't make a difference since the event is posted with the chunk coordinates but for some things eg - trees it isn't