### PR TITLE
Fix serverside startup failure when checking for vanilla acceptance

### DIFF
--- a/src/main/java/net/minecraftforge/fml/common/versioning/Restriction.java
+++ b/src/main/java/net/minecraftforge/fml/common/versioning/Restriction.java
@@ -19,7 +19,7 @@
 
 package net.minecraftforge.fml.common.versioning;
 
-import net.minecraft.client.resources.I18n;
+import net.minecraft.util.text.translation.I18n;
 
 import javax.annotation.Nullable;
 
@@ -208,31 +208,31 @@ public class Restriction
     {
         if ( getLowerBound() == null && getUpperBound() == null )
         {
-            return I18n.format("fml.messages.version.restriction.any");
+            return I18n.translateToLocal("fml.messages.version.restriction.any");
         }
         else if ( getLowerBound() != null && getUpperBound() != null )
         {
             if ( getLowerBound().getVersionString().equals(getUpperBound().getVersionString()) )
             {
                 return getLowerBound().getVersionString();
-            } 
-            else 
+            }
+            else
             {
-                if (isLowerBoundInclusive() && isUpperBoundInclusive()) 
+                if (isLowerBoundInclusive() && isUpperBoundInclusive())
                 {
-                    return I18n.format("fml.messages.version.restriction.bounded.inclusive", getLowerBound(), getUpperBound());
-                } 
-                else if (isLowerBoundInclusive()) 
+                    return I18n.translateToLocalFormatted("fml.messages.version.restriction.bounded.inclusive", getLowerBound(), getUpperBound());
+                }
+                else if (isLowerBoundInclusive())
                 {
-                    return I18n.format("fml.messages.version.restriction.bounded.upperexclusive", getLowerBound(), getUpperBound());
-                } 
-                else if (isUpperBoundInclusive()) 
+                    return I18n.translateToLocalFormatted("fml.messages.version.restriction.bounded.upperexclusive", getLowerBound(), getUpperBound());
+                }
+                else if (isUpperBoundInclusive())
                 {
-                    return I18n.format("fml.messages.version.restriction.bounded.lowerexclusive", getLowerBound(), getUpperBound());
-                } 
-                else 
+                    return I18n.translateToLocalFormatted("fml.messages.version.restriction.bounded.lowerexclusive", getLowerBound(), getUpperBound());
+                }
+                else
                 {
-                    return I18n.format("fml.messages.version.restriction.bounded.exclusive", getLowerBound(), getUpperBound());
+                    return I18n.translateToLocalFormatted("fml.messages.version.restriction.bounded.exclusive", getLowerBound(), getUpperBound());
                 }
             }
         }
@@ -240,22 +240,22 @@ public class Restriction
         {
             if ( isLowerBoundInclusive() )
             {
-                return I18n.format("fml.messages.version.restriction.lower.inclusive", getLowerBound());
+                return I18n.translateToLocalFormatted("fml.messages.version.restriction.lower.inclusive", getLowerBound());
             }
             else
             {
-                return I18n.format("fml.messages.version.restriction.lower.exclusive", getLowerBound());
+                return I18n.translateToLocalFormatted("fml.messages.version.restriction.lower.exclusive", getLowerBound());
             }
         }
         else
         {
             if ( isUpperBoundInclusive() )
             {
-                return I18n.format("fml.messages.version.restriction.upper.inclusive", getUpperBound());
+                return I18n.translateToLocalFormatted("fml.messages.version.restriction.upper.inclusive", getUpperBound());
             }
             else
             {
-                return I18n.format("fml.messages.version.restriction.upper.exclusive", getUpperBound());
+                return I18n.translateToLocalFormatted("fml.messages.version.restriction.upper.exclusive", getUpperBound());
             }
         }
     }


### PR DESCRIPTION
This was caused by a change done in #4761 to call toStringFriendly, which uses the client side translation methods.
See iChun/Sync#201 for a possible crash