### PR TITLE
Fix for the player inadvertently being removed from the Entity Tracke…

### DIFF
--- a/patches/minecraft/net/minecraft/world/chunk/Chunk.java.patch
+++ b/patches/minecraft/net/minecraft/world/chunk/Chunk.java.patch
@@ -174,7 +174,7 @@
          {
              if (this.field_150816_i.containsKey(p_177426_1_))
              {
-@@ -854,12 +855,17 @@
+@@ -854,12 +855,15 @@
  
          for (ClassInheritanceMultiMap<Entity> classinheritancemultimap : this.field_76645_j)
          {
@@ -187,13 +187,11 @@
      public void func_76623_d()
      {
 +        // FORGE - Fix for MC-92916
-+        final List<net.minecraft.entity.player.EntityPlayer> players = new java.util.ArrayList<net.minecraft.entity.player.EntityPlayer>();
-+        java.util.Arrays.stream(field_76645_j).forEach(multimap -> multimap.func_180215_b(net.minecraft.entity.player.EntityPlayer.class).forEach(players::add));
-+        players.forEach(player -> field_76637_e.func_72866_a(player, false));
++        java.util.Arrays.stream(field_76645_j).forEach(multimap -> com.google.common.collect.Lists.newArrayList(multimap.func_180215_b(net.minecraft.entity.player.EntityPlayer.class)).forEach(player -> field_76637_e.func_72866_a(player, false)));
          this.field_76636_d = false;
  
          for (TileEntity tileentity : this.field_150816_i.values())
-@@ -871,6 +877,7 @@
+@@ -871,6 +875,7 @@
          {
              this.field_76637_e.func_175681_c(classinheritancemultimap);
          }
@@ -201,7 +199,7 @@
      }
  
      public void func_76630_e()
-@@ -880,8 +887,8 @@
+@@ -880,8 +885,8 @@
  
      public void func_177414_a(@Nullable Entity p_177414_1_, AxisAlignedBB p_177414_2_, List<Entity> p_177414_3_, Predicate <? super Entity > p_177414_4_)
      {
@@ -212,7 +210,7 @@
          i = MathHelper.func_76125_a(i, 0, this.field_76645_j.length - 1);
          j = MathHelper.func_76125_a(j, 0, this.field_76645_j.length - 1);
  
-@@ -918,8 +925,8 @@
+@@ -918,8 +923,8 @@
  
      public <T extends Entity> void func_177430_a(Class <? extends T > p_177430_1_, AxisAlignedBB p_177430_2_, List<T> p_177430_3_, Predicate <? super T > p_177430_4_)
      {
@@ -223,7 +221,7 @@
          i = MathHelper.func_76125_a(i, 0, this.field_76645_j.length - 1);
          j = MathHelper.func_76125_a(j, 0, this.field_76645_j.length - 1);
  
-@@ -997,6 +1004,8 @@
+@@ -997,6 +1002,8 @@
  
      protected void func_186034_a(IChunkGenerator p_186034_1_)
      {
@@ -232,7 +230,7 @@
          if (this.func_177419_t())
          {
              if (p_186034_1_.func_185933_a(this, this.field_76635_g, this.field_76647_h))
-@@ -1008,8 +1017,10 @@
+@@ -1008,8 +1015,10 @@
          {
              this.func_150809_p();
              p_186034_1_.func_185931_b(this.field_76635_g, this.field_76647_h);
@@ -243,7 +241,7 @@
      }
  
      public BlockPos func_177440_h(BlockPos p_177440_1_)
-@@ -1064,7 +1075,7 @@
+@@ -1064,7 +1073,7 @@
          {
              BlockPos blockpos = this.field_177447_w.poll();
  
@@ -252,7 +250,7 @@
              {
                  TileEntity tileentity = this.func_177422_i(blockpos);
                  this.field_76637_e.func_175690_a(blockpos, tileentity);
-@@ -1128,6 +1139,13 @@
+@@ -1128,6 +1137,13 @@
      @SideOnly(Side.CLIENT)
      public void func_186033_a(PacketBuffer p_186033_1_, int p_186033_2_, boolean p_186033_3_)
      {
@@ -266,7 +264,7 @@
          boolean flag = this.field_76637_e.field_73011_w.func_191066_m();
  
          for (int i = 0; i < this.field_76652_q.length; ++i)
-@@ -1176,10 +1194,16 @@
+@@ -1176,10 +1192,16 @@
          this.field_76646_k = true;
          this.func_76590_a();
  
@@ -283,7 +281,7 @@
      }
  
      public Biome func_177411_a(BlockPos p_177411_1_, BiomeProvider p_177411_2_)
-@@ -1244,13 +1268,13 @@
+@@ -1244,13 +1266,13 @@
                      BlockPos blockpos1 = blockpos.func_177982_a(k, (j << 4) + i1, l);
                      boolean flag = i1 == 0 || i1 == 15 || k == 0 || k == 15 || l == 0 || l == 15;
  
@@ -299,7 +297,7 @@
                              {
                                  this.field_76637_e.func_175664_x(blockpos2);
                              }
-@@ -1381,7 +1405,7 @@
+@@ -1381,7 +1403,7 @@
          {
              blockpos$mutableblockpos.func_181079_c(blockpos$mutableblockpos.func_177958_n(), l, blockpos$mutableblockpos.func_177952_p());
  
@@ -308,7 +306,7 @@
              {
                  this.field_76637_e.func_175664_x(blockpos$mutableblockpos);
              }
-@@ -1420,6 +1444,7 @@
+@@ -1420,6 +1442,7 @@
          else
          {
              System.arraycopy(p_177420_1_, 0, this.field_76634_f, 0, this.field_76634_f.length);
@@ -316,7 +314,7 @@
          }
      }
  
-@@ -1489,4 +1514,52 @@
+@@ -1489,4 +1512,52 @@
          QUEUED,
          CHECK;
      }

--- a/patches/minecraft/net/minecraft/world/chunk/Chunk.java.patch
+++ b/patches/minecraft/net/minecraft/world/chunk/Chunk.java.patch
@@ -174,7 +174,7 @@
          {
              if (this.field_150816_i.containsKey(p_177426_1_))
              {
-@@ -854,12 +855,15 @@
+@@ -854,12 +855,14 @@
  
          for (ClassInheritanceMultiMap<Entity> classinheritancemultimap : this.field_76645_j)
          {
@@ -186,12 +186,11 @@
  
      public void func_76623_d()
      {
-+        // FORGE - Fix for MC-92916
-+        java.util.Arrays.stream(field_76645_j).forEach(multimap -> com.google.common.collect.Lists.newArrayList(multimap.func_180215_b(net.minecraft.entity.player.EntityPlayer.class)).forEach(player -> field_76637_e.func_72866_a(player, false)));
++        java.util.Arrays.stream(field_76645_j).forEach(multimap -> com.google.common.collect.Lists.newArrayList(multimap.func_180215_b(net.minecraft.entity.player.EntityPlayer.class)).forEach(player -> field_76637_e.func_72866_a(player, false))); // FORGE - Fix for MC-92916
          this.field_76636_d = false;
  
          for (TileEntity tileentity : this.field_150816_i.values())
-@@ -871,6 +875,7 @@
+@@ -871,6 +874,7 @@
          {
              this.field_76637_e.func_175681_c(classinheritancemultimap);
          }
@@ -199,7 +198,7 @@
      }
  
      public void func_76630_e()
-@@ -880,8 +885,8 @@
+@@ -880,8 +884,8 @@
  
      public void func_177414_a(@Nullable Entity p_177414_1_, AxisAlignedBB p_177414_2_, List<Entity> p_177414_3_, Predicate <? super Entity > p_177414_4_)
      {
@@ -210,7 +209,7 @@
          i = MathHelper.func_76125_a(i, 0, this.field_76645_j.length - 1);
          j = MathHelper.func_76125_a(j, 0, this.field_76645_j.length - 1);
  
-@@ -918,8 +923,8 @@
+@@ -918,8 +922,8 @@
  
      public <T extends Entity> void func_177430_a(Class <? extends T > p_177430_1_, AxisAlignedBB p_177430_2_, List<T> p_177430_3_, Predicate <? super T > p_177430_4_)
      {
@@ -221,7 +220,7 @@
          i = MathHelper.func_76125_a(i, 0, this.field_76645_j.length - 1);
          j = MathHelper.func_76125_a(j, 0, this.field_76645_j.length - 1);
  
-@@ -997,6 +1002,8 @@
+@@ -997,6 +1001,8 @@
  
      protected void func_186034_a(IChunkGenerator p_186034_1_)
      {
@@ -230,7 +229,7 @@
          if (this.func_177419_t())
          {
              if (p_186034_1_.func_185933_a(this, this.field_76635_g, this.field_76647_h))
-@@ -1008,8 +1015,10 @@
+@@ -1008,8 +1014,10 @@
          {
              this.func_150809_p();
              p_186034_1_.func_185931_b(this.field_76635_g, this.field_76647_h);
@@ -241,7 +240,7 @@
      }
  
      public BlockPos func_177440_h(BlockPos p_177440_1_)
-@@ -1064,7 +1073,7 @@
+@@ -1064,7 +1072,7 @@
          {
              BlockPos blockpos = this.field_177447_w.poll();
  
@@ -250,7 +249,7 @@
              {
                  TileEntity tileentity = this.func_177422_i(blockpos);
                  this.field_76637_e.func_175690_a(blockpos, tileentity);
-@@ -1128,6 +1137,13 @@
+@@ -1128,6 +1136,13 @@
      @SideOnly(Side.CLIENT)
      public void func_186033_a(PacketBuffer p_186033_1_, int p_186033_2_, boolean p_186033_3_)
      {
@@ -264,7 +263,7 @@
          boolean flag = this.field_76637_e.field_73011_w.func_191066_m();
  
          for (int i = 0; i < this.field_76652_q.length; ++i)
-@@ -1176,10 +1192,16 @@
+@@ -1176,10 +1191,16 @@
          this.field_76646_k = true;
          this.func_76590_a();
  
@@ -281,7 +280,7 @@
      }
  
      public Biome func_177411_a(BlockPos p_177411_1_, BiomeProvider p_177411_2_)
-@@ -1244,13 +1266,13 @@
+@@ -1244,13 +1265,13 @@
                      BlockPos blockpos1 = blockpos.func_177982_a(k, (j << 4) + i1, l);
                      boolean flag = i1 == 0 || i1 == 15 || k == 0 || k == 15 || l == 0 || l == 15;
  
@@ -297,7 +296,7 @@
                              {
                                  this.field_76637_e.func_175664_x(blockpos2);
                              }
-@@ -1381,7 +1403,7 @@
+@@ -1381,7 +1402,7 @@
          {
              blockpos$mutableblockpos.func_181079_c(blockpos$mutableblockpos.func_177958_n(), l, blockpos$mutableblockpos.func_177952_p());
  
@@ -306,7 +305,7 @@
              {
                  this.field_76637_e.func_175664_x(blockpos$mutableblockpos);
              }
-@@ -1420,6 +1442,7 @@
+@@ -1420,6 +1441,7 @@
          else
          {
              System.arraycopy(p_177420_1_, 0, this.field_76634_f, 0, this.field_76634_f.length);
@@ -314,7 +313,7 @@
          }
      }
  
-@@ -1489,4 +1512,52 @@
+@@ -1489,4 +1511,52 @@
          QUEUED,
          CHECK;
      }

--- a/patches/minecraft/net/minecraft/world/chunk/Chunk.java.patch
+++ b/patches/minecraft/net/minecraft/world/chunk/Chunk.java.patch
@@ -174,7 +174,7 @@
          {
              if (this.field_150816_i.containsKey(p_177426_1_))
              {
-@@ -854,12 +855,25 @@
+@@ -854,12 +855,26 @@
  
          for (ClassInheritanceMultiMap<Entity> classinheritancemultimap : this.field_76645_j)
          {
@@ -186,6 +186,7 @@
  
      public void func_76623_d()
      {
++        // FORGE - Fix for MC-92916
 +        final List<net.minecraft.entity.player.EntityPlayer> players = new java.util.ArrayList<net.minecraft.entity.player.EntityPlayer>();
 +        for (final ClassInheritanceMultiMap<Entity> multimap : field_76645_j)
 +        {
@@ -201,7 +202,7 @@
          this.field_76636_d = false;
  
          for (TileEntity tileentity : this.field_150816_i.values())
-@@ -871,6 +885,7 @@
+@@ -871,6 +886,7 @@
          {
              this.field_76637_e.func_175681_c(classinheritancemultimap);
          }
@@ -209,7 +210,7 @@
      }
  
      public void func_76630_e()
-@@ -880,8 +895,8 @@
+@@ -880,8 +896,8 @@
  
      public void func_177414_a(@Nullable Entity p_177414_1_, AxisAlignedBB p_177414_2_, List<Entity> p_177414_3_, Predicate <? super Entity > p_177414_4_)
      {
@@ -220,7 +221,7 @@
          i = MathHelper.func_76125_a(i, 0, this.field_76645_j.length - 1);
          j = MathHelper.func_76125_a(j, 0, this.field_76645_j.length - 1);
  
-@@ -918,8 +933,8 @@
+@@ -918,8 +934,8 @@
  
      public <T extends Entity> void func_177430_a(Class <? extends T > p_177430_1_, AxisAlignedBB p_177430_2_, List<T> p_177430_3_, Predicate <? super T > p_177430_4_)
      {
@@ -231,7 +232,7 @@
          i = MathHelper.func_76125_a(i, 0, this.field_76645_j.length - 1);
          j = MathHelper.func_76125_a(j, 0, this.field_76645_j.length - 1);
  
-@@ -997,6 +1012,8 @@
+@@ -997,6 +1013,8 @@
  
      protected void func_186034_a(IChunkGenerator p_186034_1_)
      {
@@ -240,7 +241,7 @@
          if (this.func_177419_t())
          {
              if (p_186034_1_.func_185933_a(this, this.field_76635_g, this.field_76647_h))
-@@ -1008,8 +1025,10 @@
+@@ -1008,8 +1026,10 @@
          {
              this.func_150809_p();
              p_186034_1_.func_185931_b(this.field_76635_g, this.field_76647_h);
@@ -251,7 +252,7 @@
      }
  
      public BlockPos func_177440_h(BlockPos p_177440_1_)
-@@ -1064,7 +1083,7 @@
+@@ -1064,7 +1084,7 @@
          {
              BlockPos blockpos = this.field_177447_w.poll();
  
@@ -260,7 +261,7 @@
              {
                  TileEntity tileentity = this.func_177422_i(blockpos);
                  this.field_76637_e.func_175690_a(blockpos, tileentity);
-@@ -1128,6 +1147,13 @@
+@@ -1128,6 +1148,13 @@
      @SideOnly(Side.CLIENT)
      public void func_186033_a(PacketBuffer p_186033_1_, int p_186033_2_, boolean p_186033_3_)
      {
@@ -274,7 +275,7 @@
          boolean flag = this.field_76637_e.field_73011_w.func_191066_m();
  
          for (int i = 0; i < this.field_76652_q.length; ++i)
-@@ -1176,10 +1202,16 @@
+@@ -1176,10 +1203,16 @@
          this.field_76646_k = true;
          this.func_76590_a();
  
@@ -291,7 +292,7 @@
      }
  
      public Biome func_177411_a(BlockPos p_177411_1_, BiomeProvider p_177411_2_)
-@@ -1244,13 +1276,13 @@
+@@ -1244,13 +1277,13 @@
                      BlockPos blockpos1 = blockpos.func_177982_a(k, (j << 4) + i1, l);
                      boolean flag = i1 == 0 || i1 == 15 || k == 0 || k == 15 || l == 0 || l == 15;
  
@@ -307,7 +308,7 @@
                              {
                                  this.field_76637_e.func_175664_x(blockpos2);
                              }
-@@ -1381,7 +1413,7 @@
+@@ -1381,7 +1414,7 @@
          {
              blockpos$mutableblockpos.func_181079_c(blockpos$mutableblockpos.func_177958_n(), l, blockpos$mutableblockpos.func_177952_p());
  
@@ -316,7 +317,7 @@
              {
                  this.field_76637_e.func_175664_x(blockpos$mutableblockpos);
              }
-@@ -1420,6 +1452,7 @@
+@@ -1420,6 +1453,7 @@
          else
          {
              System.arraycopy(p_177420_1_, 0, this.field_76634_f, 0, this.field_76634_f.length);
@@ -324,7 +325,7 @@
          }
      }
  
-@@ -1489,4 +1522,52 @@
+@@ -1489,4 +1523,52 @@
          QUEUED,
          CHECK;
      }

--- a/patches/minecraft/net/minecraft/world/chunk/Chunk.java.patch
+++ b/patches/minecraft/net/minecraft/world/chunk/Chunk.java.patch
@@ -174,7 +174,7 @@
          {
              if (this.field_150816_i.containsKey(p_177426_1_))
              {
-@@ -854,12 +855,26 @@
+@@ -854,12 +855,14 @@
  
          for (ClassInheritanceMultiMap<Entity> classinheritancemultimap : this.field_76645_j)
          {
@@ -186,23 +186,11 @@
  
      public void func_76623_d()
      {
-+        // FORGE - Fix for MC-92916
-+        final List<net.minecraft.entity.player.EntityPlayer> players = new java.util.ArrayList<net.minecraft.entity.player.EntityPlayer>();
-+        for (final ClassInheritanceMultiMap<Entity> multimap : field_76645_j)
-+        {
-+            for(final net.minecraft.entity.player.EntityPlayer player : multimap.func_180215_b(net.minecraft.entity.player.EntityPlayer.class))
-+            {
-+                players.add(player);
-+            }
-+        }
-+        for (final net.minecraft.entity.player.EntityPlayer player : players)
-+        {
-+            field_76637_e.func_72866_a(player, false);
-+        }
++        net.minecraftforge.common.ForgeHooks.updatePlayersOnChunkUnload(field_76637_e, field_76645_j); // FORGE - Fix for MC-92916
          this.field_76636_d = false;
  
          for (TileEntity tileentity : this.field_150816_i.values())
-@@ -871,6 +886,7 @@
+@@ -871,6 +874,7 @@
          {
              this.field_76637_e.func_175681_c(classinheritancemultimap);
          }
@@ -210,7 +198,7 @@
      }
  
      public void func_76630_e()
-@@ -880,8 +896,8 @@
+@@ -880,8 +884,8 @@
  
      public void func_177414_a(@Nullable Entity p_177414_1_, AxisAlignedBB p_177414_2_, List<Entity> p_177414_3_, Predicate <? super Entity > p_177414_4_)
      {
@@ -221,7 +209,7 @@
          i = MathHelper.func_76125_a(i, 0, this.field_76645_j.length - 1);
          j = MathHelper.func_76125_a(j, 0, this.field_76645_j.length - 1);
  
-@@ -918,8 +934,8 @@
+@@ -918,8 +922,8 @@
  
      public <T extends Entity> void func_177430_a(Class <? extends T > p_177430_1_, AxisAlignedBB p_177430_2_, List<T> p_177430_3_, Predicate <? super T > p_177430_4_)
      {
@@ -232,7 +220,7 @@
          i = MathHelper.func_76125_a(i, 0, this.field_76645_j.length - 1);
          j = MathHelper.func_76125_a(j, 0, this.field_76645_j.length - 1);
  
-@@ -997,6 +1013,8 @@
+@@ -997,6 +1001,8 @@
  
      protected void func_186034_a(IChunkGenerator p_186034_1_)
      {
@@ -241,7 +229,7 @@
          if (this.func_177419_t())
          {
              if (p_186034_1_.func_185933_a(this, this.field_76635_g, this.field_76647_h))
-@@ -1008,8 +1026,10 @@
+@@ -1008,8 +1014,10 @@
          {
              this.func_150809_p();
              p_186034_1_.func_185931_b(this.field_76635_g, this.field_76647_h);
@@ -252,7 +240,7 @@
      }
  
      public BlockPos func_177440_h(BlockPos p_177440_1_)
-@@ -1064,7 +1084,7 @@
+@@ -1064,7 +1072,7 @@
          {
              BlockPos blockpos = this.field_177447_w.poll();
  
@@ -261,7 +249,7 @@
              {
                  TileEntity tileentity = this.func_177422_i(blockpos);
                  this.field_76637_e.func_175690_a(blockpos, tileentity);
-@@ -1128,6 +1148,13 @@
+@@ -1128,6 +1136,13 @@
      @SideOnly(Side.CLIENT)
      public void func_186033_a(PacketBuffer p_186033_1_, int p_186033_2_, boolean p_186033_3_)
      {
@@ -275,7 +263,7 @@
          boolean flag = this.field_76637_e.field_73011_w.func_191066_m();
  
          for (int i = 0; i < this.field_76652_q.length; ++i)
-@@ -1176,10 +1203,16 @@
+@@ -1176,10 +1191,16 @@
          this.field_76646_k = true;
          this.func_76590_a();
  
@@ -292,7 +280,7 @@
      }
  
      public Biome func_177411_a(BlockPos p_177411_1_, BiomeProvider p_177411_2_)
-@@ -1244,13 +1277,13 @@
+@@ -1244,13 +1265,13 @@
                      BlockPos blockpos1 = blockpos.func_177982_a(k, (j << 4) + i1, l);
                      boolean flag = i1 == 0 || i1 == 15 || k == 0 || k == 15 || l == 0 || l == 15;
  
@@ -308,7 +296,7 @@
                              {
                                  this.field_76637_e.func_175664_x(blockpos2);
                              }
-@@ -1381,7 +1414,7 @@
+@@ -1381,7 +1402,7 @@
          {
              blockpos$mutableblockpos.func_181079_c(blockpos$mutableblockpos.func_177958_n(), l, blockpos$mutableblockpos.func_177952_p());
  
@@ -317,7 +305,7 @@
              {
                  this.field_76637_e.func_175664_x(blockpos$mutableblockpos);
              }
-@@ -1420,6 +1453,7 @@
+@@ -1420,6 +1441,7 @@
          else
          {
              System.arraycopy(p_177420_1_, 0, this.field_76634_f, 0, this.field_76634_f.length);
@@ -325,7 +313,7 @@
          }
      }
  
-@@ -1489,4 +1523,52 @@
+@@ -1489,4 +1511,52 @@
          QUEUED,
          CHECK;
      }

--- a/patches/minecraft/net/minecraft/world/chunk/Chunk.java.patch
+++ b/patches/minecraft/net/minecraft/world/chunk/Chunk.java.patch
@@ -174,7 +174,7 @@
          {
              if (this.field_150816_i.containsKey(p_177426_1_))
              {
-@@ -854,8 +855,9 @@
+@@ -854,12 +855,25 @@
  
          for (ClassInheritanceMultiMap<Entity> classinheritancemultimap : this.field_76645_j)
          {
@@ -185,7 +185,23 @@
      }
  
      public void func_76623_d()
-@@ -871,6 +873,7 @@
+     {
++        final List<net.minecraft.entity.player.EntityPlayer> players = new java.util.ArrayList<net.minecraft.entity.player.EntityPlayer>();
++        for (final ClassInheritanceMultiMap<Entity> multimap : field_76645_j)
++        {
++            for(final net.minecraft.entity.player.EntityPlayer player : multimap.func_180215_b(net.minecraft.entity.player.EntityPlayer.class))
++            {
++                players.add(player);
++            }
++        }
++        for (final net.minecraft.entity.player.EntityPlayer player : players)
++        {
++            field_76637_e.func_72866_a(player, false);
++        }
+         this.field_76636_d = false;
+ 
+         for (TileEntity tileentity : this.field_150816_i.values())
+@@ -871,6 +885,7 @@
          {
              this.field_76637_e.func_175681_c(classinheritancemultimap);
          }
@@ -193,7 +209,7 @@
      }
  
      public void func_76630_e()
-@@ -880,8 +883,8 @@
+@@ -880,8 +895,8 @@
  
      public void func_177414_a(@Nullable Entity p_177414_1_, AxisAlignedBB p_177414_2_, List<Entity> p_177414_3_, Predicate <? super Entity > p_177414_4_)
      {
@@ -204,7 +220,7 @@
          i = MathHelper.func_76125_a(i, 0, this.field_76645_j.length - 1);
          j = MathHelper.func_76125_a(j, 0, this.field_76645_j.length - 1);
  
-@@ -918,8 +921,8 @@
+@@ -918,8 +933,8 @@
  
      public <T extends Entity> void func_177430_a(Class <? extends T > p_177430_1_, AxisAlignedBB p_177430_2_, List<T> p_177430_3_, Predicate <? super T > p_177430_4_)
      {
@@ -215,7 +231,7 @@
          i = MathHelper.func_76125_a(i, 0, this.field_76645_j.length - 1);
          j = MathHelper.func_76125_a(j, 0, this.field_76645_j.length - 1);
  
-@@ -997,6 +1000,8 @@
+@@ -997,6 +1012,8 @@
  
      protected void func_186034_a(IChunkGenerator p_186034_1_)
      {
@@ -224,7 +240,7 @@
          if (this.func_177419_t())
          {
              if (p_186034_1_.func_185933_a(this, this.field_76635_g, this.field_76647_h))
-@@ -1008,8 +1013,10 @@
+@@ -1008,8 +1025,10 @@
          {
              this.func_150809_p();
              p_186034_1_.func_185931_b(this.field_76635_g, this.field_76647_h);
@@ -235,7 +251,7 @@
      }
  
      public BlockPos func_177440_h(BlockPos p_177440_1_)
-@@ -1064,7 +1071,7 @@
+@@ -1064,7 +1083,7 @@
          {
              BlockPos blockpos = this.field_177447_w.poll();
  
@@ -244,7 +260,7 @@
              {
                  TileEntity tileentity = this.func_177422_i(blockpos);
                  this.field_76637_e.func_175690_a(blockpos, tileentity);
-@@ -1128,6 +1135,13 @@
+@@ -1128,6 +1147,13 @@
      @SideOnly(Side.CLIENT)
      public void func_186033_a(PacketBuffer p_186033_1_, int p_186033_2_, boolean p_186033_3_)
      {
@@ -258,7 +274,7 @@
          boolean flag = this.field_76637_e.field_73011_w.func_191066_m();
  
          for (int i = 0; i < this.field_76652_q.length; ++i)
-@@ -1176,10 +1190,16 @@
+@@ -1176,10 +1202,16 @@
          this.field_76646_k = true;
          this.func_76590_a();
  
@@ -275,7 +291,7 @@
      }
  
      public Biome func_177411_a(BlockPos p_177411_1_, BiomeProvider p_177411_2_)
-@@ -1244,13 +1264,13 @@
+@@ -1244,13 +1276,13 @@
                      BlockPos blockpos1 = blockpos.func_177982_a(k, (j << 4) + i1, l);
                      boolean flag = i1 == 0 || i1 == 15 || k == 0 || k == 15 || l == 0 || l == 15;
  
@@ -291,7 +307,7 @@
                              {
                                  this.field_76637_e.func_175664_x(blockpos2);
                              }
-@@ -1381,7 +1401,7 @@
+@@ -1381,7 +1413,7 @@
          {
              blockpos$mutableblockpos.func_181079_c(blockpos$mutableblockpos.func_177958_n(), l, blockpos$mutableblockpos.func_177952_p());
  
@@ -300,7 +316,7 @@
              {
                  this.field_76637_e.func_175664_x(blockpos$mutableblockpos);
              }
-@@ -1420,6 +1440,7 @@
+@@ -1420,6 +1452,7 @@
          else
          {
              System.arraycopy(p_177420_1_, 0, this.field_76634_f, 0, this.field_76634_f.length);
@@ -308,7 +324,7 @@
          }
      }
  
-@@ -1489,4 +1510,52 @@
+@@ -1489,4 +1522,52 @@
          QUEUED,
          CHECK;
      }

--- a/patches/minecraft/net/minecraft/world/chunk/Chunk.java.patch
+++ b/patches/minecraft/net/minecraft/world/chunk/Chunk.java.patch
@@ -174,7 +174,7 @@
          {
              if (this.field_150816_i.containsKey(p_177426_1_))
              {
-@@ -854,12 +855,14 @@
+@@ -854,12 +855,17 @@
  
          for (ClassInheritanceMultiMap<Entity> classinheritancemultimap : this.field_76645_j)
          {
@@ -186,11 +186,14 @@
  
      public void func_76623_d()
      {
-+        net.minecraftforge.common.ForgeHooks.updatePlayersOnChunkUnload(field_76637_e, field_76645_j); // FORGE - Fix for MC-92916
++        // FORGE - Fix for MC-92916
++        final List<net.minecraft.entity.player.EntityPlayer> players = new java.util.ArrayList<net.minecraft.entity.player.EntityPlayer>();
++        java.util.Arrays.stream(field_76645_j).forEach(multimap -> multimap.func_180215_b(net.minecraft.entity.player.EntityPlayer.class).forEach(players::add));
++        players.forEach(player -> field_76637_e.func_72866_a(player, false));
          this.field_76636_d = false;
  
          for (TileEntity tileentity : this.field_150816_i.values())
-@@ -871,6 +874,7 @@
+@@ -871,6 +877,7 @@
          {
              this.field_76637_e.func_175681_c(classinheritancemultimap);
          }
@@ -198,7 +201,7 @@
      }
  
      public void func_76630_e()
-@@ -880,8 +884,8 @@
+@@ -880,8 +887,8 @@
  
      public void func_177414_a(@Nullable Entity p_177414_1_, AxisAlignedBB p_177414_2_, List<Entity> p_177414_3_, Predicate <? super Entity > p_177414_4_)
      {
@@ -209,7 +212,7 @@
          i = MathHelper.func_76125_a(i, 0, this.field_76645_j.length - 1);
          j = MathHelper.func_76125_a(j, 0, this.field_76645_j.length - 1);
  
-@@ -918,8 +922,8 @@
+@@ -918,8 +925,8 @@
  
      public <T extends Entity> void func_177430_a(Class <? extends T > p_177430_1_, AxisAlignedBB p_177430_2_, List<T> p_177430_3_, Predicate <? super T > p_177430_4_)
      {
@@ -220,7 +223,7 @@
          i = MathHelper.func_76125_a(i, 0, this.field_76645_j.length - 1);
          j = MathHelper.func_76125_a(j, 0, this.field_76645_j.length - 1);
  
-@@ -997,6 +1001,8 @@
+@@ -997,6 +1004,8 @@
  
      protected void func_186034_a(IChunkGenerator p_186034_1_)
      {
@@ -229,7 +232,7 @@
          if (this.func_177419_t())
          {
              if (p_186034_1_.func_185933_a(this, this.field_76635_g, this.field_76647_h))
-@@ -1008,8 +1014,10 @@
+@@ -1008,8 +1017,10 @@
          {
              this.func_150809_p();
              p_186034_1_.func_185931_b(this.field_76635_g, this.field_76647_h);
@@ -240,7 +243,7 @@
      }
  
      public BlockPos func_177440_h(BlockPos p_177440_1_)
-@@ -1064,7 +1072,7 @@
+@@ -1064,7 +1075,7 @@
          {
              BlockPos blockpos = this.field_177447_w.poll();
  
@@ -249,7 +252,7 @@
              {
                  TileEntity tileentity = this.func_177422_i(blockpos);
                  this.field_76637_e.func_175690_a(blockpos, tileentity);
-@@ -1128,6 +1136,13 @@
+@@ -1128,6 +1139,13 @@
      @SideOnly(Side.CLIENT)
      public void func_186033_a(PacketBuffer p_186033_1_, int p_186033_2_, boolean p_186033_3_)
      {
@@ -263,7 +266,7 @@
          boolean flag = this.field_76637_e.field_73011_w.func_191066_m();
  
          for (int i = 0; i < this.field_76652_q.length; ++i)
-@@ -1176,10 +1191,16 @@
+@@ -1176,10 +1194,16 @@
          this.field_76646_k = true;
          this.func_76590_a();
  
@@ -280,7 +283,7 @@
      }
  
      public Biome func_177411_a(BlockPos p_177411_1_, BiomeProvider p_177411_2_)
-@@ -1244,13 +1265,13 @@
+@@ -1244,13 +1268,13 @@
                      BlockPos blockpos1 = blockpos.func_177982_a(k, (j << 4) + i1, l);
                      boolean flag = i1 == 0 || i1 == 15 || k == 0 || k == 15 || l == 0 || l == 15;
  
@@ -296,7 +299,7 @@
                              {
                                  this.field_76637_e.func_175664_x(blockpos2);
                              }
-@@ -1381,7 +1402,7 @@
+@@ -1381,7 +1405,7 @@
          {
              blockpos$mutableblockpos.func_181079_c(blockpos$mutableblockpos.func_177958_n(), l, blockpos$mutableblockpos.func_177952_p());
  
@@ -305,7 +308,7 @@
              {
                  this.field_76637_e.func_175664_x(blockpos$mutableblockpos);
              }
-@@ -1420,6 +1441,7 @@
+@@ -1420,6 +1444,7 @@
          else
          {
              System.arraycopy(p_177420_1_, 0, this.field_76634_f, 0, this.field_76634_f.length);
@@ -313,7 +316,7 @@
          }
      }
  
-@@ -1489,4 +1511,52 @@
+@@ -1489,4 +1514,52 @@
          QUEUED,
          CHECK;
      }

--- a/src/main/java/net/minecraftforge/common/ForgeHooks.java
+++ b/src/main/java/net/minecraftforge/common/ForgeHooks.java
@@ -79,7 +79,6 @@ import net.minecraft.network.play.server.SPacketRecipeBook.State;
 import net.minecraft.stats.StatList;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.tileentity.TileEntityNote;
-import net.minecraft.util.ClassInheritanceMultiMap;
 import net.minecraft.util.DamageSource;
 import net.minecraft.util.EnumActionResult;
 import net.minecraft.util.EnumFacing;
@@ -1386,22 +1385,5 @@ public class ForgeHooks
     public static void onAdvancement(EntityPlayerMP player, Advancement advancement)
     {
         MinecraftForge.EVENT_BUS.post(new AdvancementEvent(player, advancement));
-    }
-    
-    // FORGE - Fix for MC-92916
-    public static void updatePlayersOnChunkUnload(World world, ClassInheritanceMultiMap<Entity>[] entityLists)
-    {
-        final List<EntityPlayer> players = new ArrayList<EntityPlayer>();
-        for (final ClassInheritanceMultiMap<Entity> multimap : entityLists)
-        {
-            for(final EntityPlayer player : multimap.getByClass(EntityPlayer.class))
-            {
-                players.add(player);
-            }
-        }
-        for (final EntityPlayer player : players)
-        {
-            world.updateEntityWithOptionalForce(player, false);
-        }
     }
 }

--- a/src/main/java/net/minecraftforge/common/ForgeHooks.java
+++ b/src/main/java/net/minecraftforge/common/ForgeHooks.java
@@ -79,6 +79,7 @@ import net.minecraft.network.play.server.SPacketRecipeBook.State;
 import net.minecraft.stats.StatList;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.tileentity.TileEntityNote;
+import net.minecraft.util.ClassInheritanceMultiMap;
 import net.minecraft.util.DamageSource;
 import net.minecraft.util.EnumActionResult;
 import net.minecraft.util.EnumFacing;
@@ -1385,5 +1386,22 @@ public class ForgeHooks
     public static void onAdvancement(EntityPlayerMP player, Advancement advancement)
     {
         MinecraftForge.EVENT_BUS.post(new AdvancementEvent(player, advancement));
+    }
+    
+    // FORGE - Fix for MC-92916
+    public static void updatePlayersOnChunkUnload(World world, ClassInheritanceMultiMap<Entity>[] entityLists)
+    {
+        final List<EntityPlayer> players = new ArrayList<EntityPlayer>();
+        for (final ClassInheritanceMultiMap<Entity> multimap : entityLists)
+        {
+            for(final EntityPlayer player : multimap.getByClass(EntityPlayer.class))
+            {
+                players.add(player);
+            }
+        }
+        for (final EntityPlayer player : players)
+        {
+            world.updateEntityWithOptionalForce(player, false);
+        }
     }
 }


### PR DESCRIPTION
…r when the chunk they were in unloads after they teleport out of it.

This changes the chunk unload to send a forced update to any players that are listed as being in the chunk. If the player is no longer in the chunk this will cause them to update their location and properly register with the chunk they are in.

This is needed because in 1.10 the order things were done during a tick was changed. Prior to this, entities got an update prior to any chunks unloading, which gave them a chance to "move out" of the chunk and into a new one. As of 1.10, chunk unloads happen prior to updating entities, so any entity still listed as being in an unloading chunk will be removed from the entity tracker.

This causes a variety of issues including players being unable to get out of beds, and invisible players.

It is possible this needs to be extended to all entities rather than just players, but player entities are the ones with the most noticeable issues due to the change in tick order.