### PR TITLE
Added hook for night vision brightness

### DIFF
--- a/patches/minecraft/net/minecraft/client/renderer/EntityRenderer.java.patch
+++ b/patches/minecraft/net/minecraft/client/renderer/EntityRenderer.java.patch
@@ -103,7 +103,18 @@
                      if (this.field_78531_r.field_71439_g.func_70644_a(MobEffects.field_76439_r))
                      {
                          float f15 = this.func_180438_a(this.field_78531_r.field_71439_g, p_78472_1_);
-@@ -1101,6 +1109,10 @@
+@@ -971,7 +979,9 @@
+     private float func_180438_a(EntityLivingBase p_180438_1_, float p_180438_2_)
+     {
+         int i = p_180438_1_.func_70660_b(MobEffects.field_76439_r).func_76459_b();
+-        return i > 200 ? 1.0F : 0.7F + MathHelper.func_76126_a(((float)i - p_180438_2_) * (float)Math.PI * 0.2F) * 0.3F;
++        float brightness = i > 200 ? 1.0F : 0.7F + MathHelper.func_76126_a(((float)i - p_180438_2_) * (float)Math.PI * 0.2F) * 0.3F;
++        IBlockState iblockstate = ActiveRenderInfo.func_186703_a(Minecraft.func_71410_x().field_71441_e, p_180438_1_, p_180438_2_);
++        return net.minecraftforge.client.ForgeHooksClient.getNightVisionBrightness(this, p_180438_1_, iblockstate, p_180438_2_, brightness);
+     }
+ 
+     public void func_181560_a(float p_181560_1_, long p_181560_2_)
+@@ -1101,6 +1111,10 @@
                  GlStateManager.func_179096_D();
                  this.func_78478_c();
                  this.field_78510_Z = System.nanoTime();
@@ -114,7 +125,7 @@
              }
  
              if (this.field_78531_r.field_71462_r != null)
-@@ -1109,7 +1121,7 @@
+@@ -1109,7 +1123,7 @@
  
                  try
                  {
@@ -123,7 +134,7 @@
                  }
                  catch (Throwable throwable)
                  {
-@@ -1204,7 +1216,7 @@
+@@ -1204,7 +1218,7 @@
  
                      if (this.field_78531_r.field_71442_b.func_178889_l() == GameType.SPECTATOR)
                      {
@@ -132,7 +143,7 @@
                      }
                      else
                      {
-@@ -1262,7 +1274,7 @@
+@@ -1262,7 +1276,7 @@
          GlStateManager.func_179086_m(16640);
          this.field_78531_r.field_71424_I.func_76318_c("camera");
          this.func_78479_a(p_175068_2_, p_175068_1_);
@@ -141,7 +152,7 @@
          this.field_78531_r.field_71424_I.func_76318_c("frustum");
          ClippingHelperImpl.func_78558_a();
          this.field_78531_r.field_71424_I.func_76318_c("culling");
-@@ -1329,7 +1341,9 @@
+@@ -1329,7 +1343,9 @@
              GlStateManager.func_179094_E();
              RenderHelper.func_74519_b();
              this.field_78531_r.field_71424_I.func_76318_c("entities");
@@ -151,7 +162,7 @@
              RenderHelper.func_74518_a();
              this.func_175072_h();
          }
-@@ -1342,6 +1356,7 @@
+@@ -1342,6 +1358,7 @@
              EntityPlayer entityplayer = (EntityPlayer)entity;
              GlStateManager.func_179118_c();
              this.field_78531_r.field_71424_I.func_76318_c("outline");
@@ -159,7 +170,7 @@
              renderglobal.func_72731_b(entityplayer, this.field_78531_r.field_71476_x, 0, p_175068_2_);
              GlStateManager.func_179141_d();
          }
-@@ -1388,6 +1403,17 @@
+@@ -1388,6 +1405,17 @@
          GlStateManager.func_179103_j(7425);
          this.field_78531_r.field_71424_I.func_76318_c("translucent");
          renderglobal.func_174977_a(BlockRenderLayer.TRANSLUCENT, (double)p_175068_2_, p_175068_1_, entity);
@@ -177,7 +188,7 @@
          GlStateManager.func_179103_j(7424);
          GlStateManager.func_179132_a(true);
          GlStateManager.func_179089_o();
-@@ -1400,6 +1426,9 @@
+@@ -1400,6 +1428,9 @@
              this.func_180437_a(renderglobal, p_175068_2_, p_175068_1_, d0, d1, d2);
          }
  
@@ -187,7 +198,7 @@
          this.field_78531_r.field_71424_I.func_76318_c("hand");
  
          if (this.field_175074_C)
-@@ -1515,6 +1544,13 @@
+@@ -1515,6 +1546,13 @@
  
      protected void func_78474_d(float p_78474_1_)
      {
@@ -201,7 +212,7 @@
          float f = this.field_78531_r.field_71441_e.func_72867_j(p_78474_1_);
  
          if (f > 0.0F)
-@@ -1749,30 +1785,17 @@
+@@ -1749,30 +1787,17 @@
              this.field_175082_R = (float)vec3d3.field_72448_b;
              this.field_175081_S = (float)vec3d3.field_72449_c;
          }
@@ -241,7 +252,7 @@
  
          float f13 = this.field_78535_ad + (this.field_78539_ae - this.field_78535_ad) * p_78466_1_;
          this.field_175080_Q *= f13;
-@@ -1830,6 +1853,9 @@
+@@ -1830,6 +1855,9 @@
                  f6 = 1.0F / this.field_175081_S;
              }
  
@@ -251,7 +262,7 @@
              this.field_175080_Q = this.field_175080_Q * (1.0F - f15) + this.field_175080_Q * f6 * f15;
              this.field_175082_R = this.field_175082_R * (1.0F - f15) + this.field_175082_R * f6 * f15;
              this.field_175081_S = this.field_175081_S * (1.0F - f15) + this.field_175081_S * f6 * f15;
-@@ -1845,6 +1871,13 @@
+@@ -1845,6 +1873,13 @@
              this.field_175081_S = f7;
          }
  
@@ -265,7 +276,7 @@
          GlStateManager.func_179082_a(this.field_175080_Q, this.field_175082_R, this.field_175081_S, 0.0F);
      }
  
-@@ -1855,7 +1888,9 @@
+@@ -1855,7 +1890,9 @@
          GlStateManager.func_187432_a(0.0F, -1.0F, 0.0F);
          GlStateManager.func_179131_c(1.0F, 1.0F, 1.0F, 1.0F);
          IBlockState iblockstate = ActiveRenderInfo.func_186703_a(this.field_78531_r.field_71441_e, entity, p_78468_2_);
@@ -276,7 +287,7 @@
          if (entity instanceof EntityLivingBase && ((EntityLivingBase)entity).func_70644_a(MobEffects.field_76440_q))
          {
              float f1 = 5.0F;
-@@ -1940,6 +1975,7 @@
+@@ -1940,6 +1977,7 @@
                  GlStateManager.func_179102_b(f * 0.05F);
                  GlStateManager.func_179153_c(Math.min(f, 192.0F) * 0.5F);
              }

--- a/src/main/java/net/minecraftforge/client/ForgeHooksClient.java
+++ b/src/main/java/net/minecraftforge/client/ForgeHooksClient.java
@@ -769,4 +769,11 @@ public class ForgeHooksClient
         if(texture == null) texture = horse.getHorseArmorType().getTextureName();
         return texture;
     }
+
+    public static float getNightVisionBrightness(EntityRenderer renderer, Entity entity, IBlockState state, float partial, float brightness)
+    {
+        EntityViewRenderEvent.NightVisionBrightness event = new EntityViewRenderEvent.NightVisionBrightness(renderer, entity, state, partial, brightness);
+        if (MinecraftForge.EVENT_BUS.post(event)) return event.getBrightness();
+        return brightness;
+    }
 }

--- a/src/main/java/net/minecraftforge/client/event/EntityViewRenderEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/EntityViewRenderEvent.java
@@ -189,4 +189,30 @@ public abstract class EntityViewRenderEvent extends Event
             this.fov = fov;
         }
     }
+
+    /**
+     * Event that allows any feature to customize the brightness of night vision effect.
+     * NOTE: In order to make this event have an effect, you must cancel the event
+     */
+    @Cancelable
+    public static class NightVisionBrightness extends EntityViewRenderEvent
+    {
+        private float brightness;
+
+        public NightVisionBrightness(EntityRenderer renderer, Entity entity, IBlockState state, double renderPartialTicks, float brightness)
+        {
+            super(renderer, entity, state, renderPartialTicks);
+            this.setBrightness(brightness);
+        }
+
+        public float getBrightness()
+        {
+            return brightness;
+        }
+
+        public void setBrightness(float brightness)
+        {
+            this.brightness = brightness;
+        }
+    }
 }

--- a/src/test/java/net/minecraftforge/debug/NightVisionBrightnessTest.java
+++ b/src/test/java/net/minecraftforge/debug/NightVisionBrightnessTest.java
@@ -1,0 +1,30 @@
+package net.minecraftforge.debug;
+
+import net.minecraftforge.client.event.EntityViewRenderEvent;
+import net.minecraftforge.common.MinecraftForge;
+import net.minecraftforge.fml.common.Mod;
+import net.minecraftforge.fml.common.Mod.EventHandler;
+import net.minecraftforge.fml.common.event.FMLPreInitializationEvent;
+import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
+
+@Mod(modid = "nightvisionbrightnesstest", name = "NightVisionBrightnessTest", version = "1.0", acceptableRemoteVersions = "*")
+public class NightVisionBrightnessTest
+{
+    public static final boolean ENABLED = false;
+
+    @EventHandler
+    public void onPreInit(FMLPreInitializationEvent event)
+    {
+        if (ENABLED)
+        {
+            MinecraftForge.EVENT_BUS.register(this);
+        }
+    }
+
+    @SubscribeEvent
+    public void nightVisionBrightness(EntityViewRenderEvent.NightVisionBrightness event)
+    {
+        event.setBrightness(1);
+        event.setCanceled(true);
+    }
+}


### PR DESCRIPTION
Simple event based hook to allow mods to override the default brightness value when the night vision effect is active.

**Use cases:**
* Disable decay blinking/flashing when night vision duration is under 200
* Create weakened versions of night vision
* Create odd effects based on item or block combinations with the effect 

**Test Mod**
Included is a test mod to show the event working by forcing brightness to 1f at all times.