### PR TITLE
Fix integrated server crash not stopping client

### DIFF
--- a/patches/minecraft/net/minecraft/client/Minecraft.java.patch
+++ b/patches/minecraft/net/minecraft/client/Minecraft.java.patch
@@ -256,9 +256,12 @@
          this.func_71403_a((WorldClient)null);
          System.gc();
          ISaveHandler isavehandler = this.field_71469_aa.func_75804_a(p_71371_1_, false);
-@@ -2346,6 +2381,12 @@
+@@ -2344,8 +2379,14 @@
  
-         while (!this.field_71437_Z.func_71200_ad())
+         this.field_71461_s.func_73720_a(I18n.func_135052_a("menu.loadingLevel"));
+ 
+-        while (!this.field_71437_Z.func_71200_ad())
++        while (!this.field_71437_Z.func_71200_ad() && !this.field_71437_Z.func_71241_aa())
          {
 +            if (!net.minecraftforge.fml.common.StartupQuery.check())
 +            {

--- a/src/test/java/net/minecraftforge/debug/ClientExceptionTestMod.java
+++ b/src/test/java/net/minecraftforge/debug/ClientExceptionTestMod.java
@@ -10,6 +10,7 @@ import net.minecraftforge.fml.common.Mod;
 import net.minecraftforge.fml.common.event.FMLInitializationEvent;
 import net.minecraftforge.fml.common.event.FMLLoadCompleteEvent;
 import net.minecraftforge.fml.common.event.FMLPreInitializationEvent;
+import net.minecraftforge.fml.common.event.FMLServerStartedEvent;
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
 
 @Mod(modid = "clientexceptiontest", version = "1.0", name = "Client Exception Test", clientSideOnly = true)
@@ -20,6 +21,7 @@ public class ClientExceptionTestMod
     public static boolean ENABLE_PREINIT = false;
     public static boolean ENABLE_INIT = false;
     public static boolean ENABLE_LOAD_COMPLETE = false;
+    public static boolean ENABLE_SERVER_STARTED = false;
 
     @Mod.EventHandler
     public void onPreInit(FMLPreInitializationEvent e)
@@ -52,6 +54,15 @@ public class ClientExceptionTestMod
         if (ENABLE_LOAD_COMPLETE)
         {
             throwException("Thrown in load complete");
+        }
+    }
+
+    @Mod.EventHandler
+    public void onServerStarted(FMLServerStartedEvent e)
+    {
+        if (ENABLE_SERVER_STARTED)
+        {
+            throw new RuntimeException("Server thread exception - should stop client");
         }
     }
 


### PR DESCRIPTION
Fixes #4794.

Basically what was suggested there, adding a check for `isServerStopped` to the loop condition so it will fall through in the event the integrated server crashes on startup.

See [this gist](https://gist.github.com/bs2609/04b2d5b549d733d6be1a0bbde05a7fb6) of the relevant console output.