### PR TITLE
Changed BlockInfo to run #doesSideBlockRendering on the state instead of the block

### DIFF
--- a/src/main/java/net/minecraftforge/client/model/pipeline/BlockInfo.java
+++ b/src/main/java/net/minecraftforge/client/model/pipeline/BlockInfo.java
@@ -123,7 +123,7 @@ public class BlockInfo
         }
         for(EnumFacing side : SIDES)
         {
-            if(!state.getBlock().doesSideBlockRendering(state, world, blockPos, side))
+            if(!state.doesSideBlockRendering(world, blockPos, side))
             {
                 int x = side.getFrontOffsetX() + 1;
                 int y = side.getFrontOffsetY() + 1;


### PR DESCRIPTION
This usually wouldn't be an issue, but in some instances, like for me, it can cause rendering errors. 
# Example
During the rendering of blocks in the ChunkCache, for certian blocks, I would return another block state registered to the tile entity at that position. However this wouldnt be the block that was being used to get the model. This means that the model from one state was being rendered, but the IBlockAccess returns a diffrent state. (Which is how I wanted it). The only problem with this is that I had to proxy/delegate the returned state, as to make `#doesSideBlockRendering` return the right value, so the blocks where culling correctly. This all works, apart from in `BlockInfo#updateLightMatrix`, as it doesnt call `state#doesSideBlockRendering`, it calls `block#doesSideBlockRendering`. This pull would just ensure that it gets called correctly, and its more consistent.