### PR TITLE
Add event to allow for rendering additional overlays on items in guis

### DIFF
--- a/patches/minecraft/net/minecraft/client/renderer/RenderItem.java.patch
+++ b/patches/minecraft/net/minecraft/client/renderer/RenderItem.java.patch
@@ -63,22 +63,8 @@
          this.func_180454_a(p_191962_1_, p_191962_4_);
          GlStateManager.func_179118_c();
          GlStateManager.func_179101_C();
-@@ -402,20 +387,21 @@
- 
-     public void func_180453_a(FontRenderer p_180453_1_, ItemStack p_180453_2_, int p_180453_3_, int p_180453_4_, @Nullable String p_180453_5_)
-     {
--        if (!p_180453_2_.func_190926_b())
--        {
--            if (p_180453_2_.func_190916_E() != 1 || p_180453_5_ != null)
--            {
-+        if (!p_180453_2_.func_190926_b()) {
-+            if (p_180453_2_.func_190916_E() != 1 || p_180453_5_ != null) {
-                 String s = p_180453_5_ == null ? String.valueOf(p_180453_2_.func_190916_E()) : p_180453_5_;
-                 GlStateManager.func_179140_f();
-                 GlStateManager.func_179097_i();
-                 GlStateManager.func_179084_k();
--                p_180453_1_.func_175063_a(s, (float)(p_180453_3_ + 19 - 2 - p_180453_1_.func_78256_a(s)), (float)(p_180453_4_ + 6 + 3), 16777215);
-+                p_180453_1_.func_175063_a(s, (float) (p_180453_3_ + 19 - 2 - p_180453_1_.func_78256_a(s)), (float) (p_180453_4_ + 6 + 3), 16777215);
+@@ -413,9 +398,12 @@
+                 p_180453_1_.func_175063_a(s, (float)(p_180453_3_ + 19 - 2 - p_180453_1_.func_78256_a(s)), (float)(p_180453_4_ + 6 + 3), 16777215);
                  GlStateManager.func_179145_e();
                  GlStateManager.func_179126_j();
 +                // Fixes opaque cooldown overlay a bit lower
@@ -91,7 +77,7 @@
              {
                  GlStateManager.func_179140_f();
                  GlStateManager.func_179097_i();
-@@ -424,11 +410,10 @@
+@@ -424,11 +412,10 @@
                  GlStateManager.func_179084_k();
                  Tessellator tessellator = Tessellator.func_178181_a();
                  BufferBuilder bufferbuilder = tessellator.func_178180_c();
@@ -107,7 +93,7 @@
                  this.func_181565_a(bufferbuilder, p_180453_3_ + 2, p_180453_4_ + 13, 13, 2, 0, 0, 0, 255);
                  this.func_181565_a(bufferbuilder, p_180453_3_ + 2, p_180453_4_ + 13, i, 1, j >> 16 & 255, j >> 8 & 255, j & 255, 255);
                  GlStateManager.func_179147_l();
-@@ -438,6 +423,11 @@
+@@ -438,6 +425,11 @@
                  GlStateManager.func_179126_j();
              }
  
@@ -119,7 +105,7 @@
              EntityPlayerSP entityplayersp = Minecraft.func_71410_x().field_71439_g;
              float f3 = entityplayersp == null ? 0.0F : entityplayersp.func_184811_cZ().func_185143_a(p_180453_2_.func_77973_b(), Minecraft.func_71410_x().func_184121_ak());
  
-@@ -1099,6 +1089,7 @@
+@@ -1099,6 +1091,7 @@
          this.func_175029_a(Blocks.field_185779_df, TileEntityStructure.Mode.LOAD.func_185110_a(), "structure_block");
          this.func_175029_a(Blocks.field_185779_df, TileEntityStructure.Mode.CORNER.func_185110_a(), "structure_block");
          this.func_175029_a(Blocks.field_185779_df, TileEntityStructure.Mode.DATA.func_185110_a(), "structure_block");

--- a/patches/minecraft/net/minecraft/client/renderer/RenderItem.java.patch
+++ b/patches/minecraft/net/minecraft/client/renderer/RenderItem.java.patch
@@ -63,8 +63,22 @@
          this.func_180454_a(p_191962_1_, p_191962_4_);
          GlStateManager.func_179118_c();
          GlStateManager.func_179101_C();
-@@ -413,9 +398,12 @@
-                 p_180453_1_.func_175063_a(s, (float)(p_180453_3_ + 19 - 2 - p_180453_1_.func_78256_a(s)), (float)(p_180453_4_ + 6 + 3), 16777215);
+@@ -402,20 +387,21 @@
+ 
+     public void func_180453_a(FontRenderer p_180453_1_, ItemStack p_180453_2_, int p_180453_3_, int p_180453_4_, @Nullable String p_180453_5_)
+     {
+-        if (!p_180453_2_.func_190926_b())
+-        {
+-            if (p_180453_2_.func_190916_E() != 1 || p_180453_5_ != null)
+-            {
++        if (!p_180453_2_.func_190926_b()) {
++            if (p_180453_2_.func_190916_E() != 1 || p_180453_5_ != null) {
+                 String s = p_180453_5_ == null ? String.valueOf(p_180453_2_.func_190916_E()) : p_180453_5_;
+                 GlStateManager.func_179140_f();
+                 GlStateManager.func_179097_i();
+                 GlStateManager.func_179084_k();
+-                p_180453_1_.func_175063_a(s, (float)(p_180453_3_ + 19 - 2 - p_180453_1_.func_78256_a(s)), (float)(p_180453_4_ + 6 + 3), 16777215);
++                p_180453_1_.func_175063_a(s, (float) (p_180453_3_ + 19 - 2 - p_180453_1_.func_78256_a(s)), (float) (p_180453_4_ + 6 + 3), 16777215);
                  GlStateManager.func_179145_e();
                  GlStateManager.func_179126_j();
 +                // Fixes opaque cooldown overlay a bit lower
@@ -77,7 +91,7 @@
              {
                  GlStateManager.func_179140_f();
                  GlStateManager.func_179097_i();
-@@ -424,11 +412,10 @@
+@@ -424,11 +410,10 @@
                  GlStateManager.func_179084_k();
                  Tessellator tessellator = Tessellator.func_178181_a();
                  BufferBuilder bufferbuilder = tessellator.func_178180_c();
@@ -93,7 +107,19 @@
                  this.func_181565_a(bufferbuilder, p_180453_3_ + 2, p_180453_4_ + 13, 13, 2, 0, 0, 0, 255);
                  this.func_181565_a(bufferbuilder, p_180453_3_ + 2, p_180453_4_ + 13, i, 1, j >> 16 & 255, j >> 8 & 255, j & 255, 255);
                  GlStateManager.func_179147_l();
-@@ -1099,6 +1086,7 @@
+@@ -438,6 +423,11 @@
+                 GlStateManager.func_179126_j();
+             }
+ 
++            if (p_180453_2_.func_77973_b().shouldRenderAdditionalOverlay(p_180453_2_))
++            {
++                net.minecraftforge.client.ForgeHooksClient.renderItemOverlayIntoGUI(p_180453_1_, p_180453_2_, p_180453_3_, p_180453_4_);
++            }
++
+             EntityPlayerSP entityplayersp = Minecraft.func_71410_x().field_71439_g;
+             float f3 = entityplayersp == null ? 0.0F : entityplayersp.func_184811_cZ().func_185143_a(p_180453_2_.func_77973_b(), Minecraft.func_71410_x().func_184121_ak());
+ 
+@@ -1099,6 +1089,7 @@
          this.func_175029_a(Blocks.field_185779_df, TileEntityStructure.Mode.LOAD.func_185110_a(), "structure_block");
          this.func_175029_a(Blocks.field_185779_df, TileEntityStructure.Mode.CORNER.func_185110_a(), "structure_block");
          this.func_175029_a(Blocks.field_185779_df, TileEntityStructure.Mode.DATA.func_185110_a(), "structure_block");

--- a/patches/minecraft/net/minecraft/item/Item.java.patch
+++ b/patches/minecraft/net/minecraft/item/Item.java.patch
@@ -68,7 +68,7 @@
          CreativeTabs creativetabs = this.func_77640_w();
          return creativetabs != null && (p_194125_1_ == CreativeTabs.field_78027_g || p_194125_1_ == creativetabs);
      }
-@@ -435,11 +441,728 @@
+@@ -435,11 +441,737 @@
          return false;
      }
  
@@ -470,6 +470,15 @@
 +    }
 +
 +    /**
++     * Determines if the item has any additional overlays it should render.
++     * @param stack The current Item Stack
++     * @return True if it should fire {@link net.minecraftforge.client.event.RenderItemOverlayEvent} for this stack.
++     */
++    public boolean shouldRenderAdditionalOverlay(ItemStack stack) {
++        return false;
++    }
++
++    /**
 +     * Determines if the durability bar should be rendered for this item.
 +     * Defaults to vanilla stack.isDamaged behavior.
 +     * But modders can use this for any data they wish.
@@ -797,7 +806,7 @@
      public static void func_150900_l()
      {
          func_179214_a(Blocks.field_150350_a, new ItemAir(Blocks.field_150350_a));
-@@ -999,6 +1722,8 @@
+@@ -999,6 +1731,8 @@
          private final float field_78010_h;
          private final float field_78011_i;
          private final int field_78008_j;
@@ -806,7 +815,7 @@
  
          private ToolMaterial(int p_i1874_3_, int p_i1874_4_, float p_i1874_5_, float p_i1874_6_, int p_i1874_7_)
          {
-@@ -1034,6 +1759,7 @@
+@@ -1034,6 +1768,7 @@
              return this.field_78008_j;
          }
  
@@ -814,7 +823,7 @@
          public Item func_150995_f()
          {
              if (this == WOOD)
-@@ -1057,5 +1783,21 @@
+@@ -1057,5 +1792,21 @@
                  return this == DIAMOND ? Items.field_151045_i : null;
              }
          }

--- a/src/main/java/net/minecraftforge/client/ForgeHooksClient.java
+++ b/src/main/java/net/minecraftforge/client/ForgeHooksClient.java
@@ -105,6 +105,7 @@ import net.minecraftforge.client.event.ModelBakeEvent;
 import net.minecraftforge.client.event.MouseEvent;
 import net.minecraftforge.client.event.RenderGameOverlayEvent;
 import net.minecraftforge.client.event.RenderHandEvent;
+import net.minecraftforge.client.event.RenderItemOverlayEvent;
 import net.minecraftforge.client.event.RenderSpecificHandEvent;
 import net.minecraftforge.client.event.RenderWorldLastEvent;
 import net.minecraftforge.client.event.ScreenshotEvent;
@@ -156,6 +157,11 @@ public class ForgeHooksClient
         {
             glRotatef((float)(block.getBedDirection(state, world, pos).getHorizontalIndex() * 90), 0.0F, 1.0F, 0.0F);
         }
+    }
+
+    public static void renderItemOverlayIntoGUI(FontRenderer fr, ItemStack stack, int xPosition, int yPosition)
+    {
+        MinecraftForge.EVENT_BUS.post(new RenderItemOverlayEvent(fr, stack, xPosition, yPosition));
     }
 
     public static boolean onDrawBlockHighlight(RenderGlobal context, EntityPlayer player, RayTraceResult target, int subID, float partialTicks)

--- a/src/main/java/net/minecraftforge/client/event/RenderItemOverlayEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/RenderItemOverlayEvent.java
@@ -1,0 +1,42 @@
+package net.minecraftforge.client.event;
+
+import net.minecraft.client.gui.FontRenderer;
+import net.minecraft.item.ItemStack;
+import net.minecraftforge.fml.common.eventhandler.Event;
+
+import javax.annotation.Nonnull;
+
+/**
+ * This event is called whenever {@link net.minecraft.item.Item#shouldRenderAdditionalOverlay(ItemStack)} returns true
+ */
+public class RenderItemOverlayEvent extends Event
+{
+    private final FontRenderer fr;
+    private final ItemStack item;
+    private final int xPosition;
+    private final int yPosition;
+
+    public RenderItemOverlayEvent(FontRenderer fr, ItemStack item, int xPosition, int yPosition) {
+        this.fr = fr;
+        this.item = item;
+        this.xPosition = xPosition;
+        this.yPosition = yPosition;
+    }
+
+    @Nonnull
+    public ItemStack getItem() {
+        return item;
+    }
+
+    public int getxPosition() {
+        return xPosition;
+    }
+
+    public int getyPosition() {
+        return yPosition;
+    }
+
+    public FontRenderer getFontRenderer() {
+        return fr;
+    }
+}

--- a/src/main/java/net/minecraftforge/client/event/RenderItemOverlayEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/RenderItemOverlayEvent.java
@@ -1,3 +1,22 @@
+/*
+ * Minecraft Forge
+ * Copyright (c) 2018.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation version 2.1
+ * of the License.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
 package net.minecraftforge.client.event;
 
 import net.minecraft.client.gui.FontRenderer;

--- a/src/test/java/net/minecraftforge/debug/RenderItemOverlayEventTest.java
+++ b/src/test/java/net/minecraftforge/debug/RenderItemOverlayEventTest.java
@@ -1,0 +1,141 @@
+package net.minecraftforge.debug;
+
+import net.minecraft.client.renderer.BufferBuilder;
+import net.minecraft.client.renderer.GlStateManager;
+import net.minecraft.client.renderer.Tessellator;
+import net.minecraft.client.renderer.block.model.ModelResourceLocation;
+import net.minecraft.client.renderer.vertex.DefaultVertexFormats;
+import net.minecraft.creativetab.CreativeTabs;
+import net.minecraft.entity.Entity;
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.item.Item;
+import net.minecraft.item.ItemStack;
+import net.minecraft.item.ItemSword;
+import net.minecraft.nbt.NBTTagCompound;
+import net.minecraft.util.ActionResult;
+import net.minecraft.util.EnumActionResult;
+import net.minecraft.util.EnumHand;
+import net.minecraft.util.ResourceLocation;
+import net.minecraft.world.World;
+import net.minecraftforge.client.event.RenderItemOverlayEvent;
+import net.minecraftforge.client.model.ModelLoader;
+import net.minecraftforge.event.RegistryEvent;
+import net.minecraftforge.fml.common.Mod;
+import net.minecraftforge.fml.common.SidedProxy;
+import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
+
+@Mod(modid = RenderItemOverlayEventTest.MODID, name = "RenderItemOverlayEventTest", version = "1.0", acceptableRemoteVersions = "*")
+@Mod.EventBusSubscriber
+public class RenderItemOverlayEventTest {
+    public static final boolean ENABLE = true;
+    public static final String MODID = "renderitemoverlayeventtest";
+    @SidedProxy
+    public static CommonProxy proxy = null;
+
+    public static abstract class CommonProxy
+    {
+        public void registerItem(RegistryEvent.Register<Item> event)
+        {
+            ItemTest.instance = new ItemTest();
+            event.getRegistry().register(ItemTest.instance);
+        }
+    }
+
+    public static final class ServerProxy extends CommonProxy
+    {
+    }
+
+    public static final class ClientProxy extends CommonProxy
+    {
+        @Override
+        public void registerItem(RegistryEvent.Register<Item> event)
+        {
+            super.registerItem(event);
+            ModelLoader.setCustomModelResourceLocation(ItemTest.instance, 0, new ModelResourceLocation(new ResourceLocation(MODID, "test_item"), "inventory"));
+
+        }
+    }
+
+    @SubscribeEvent
+    public static void registerItem(RegistryEvent.Register<Item> event)
+    {
+        if (ENABLE)
+        {
+            proxy.registerItem(event);
+        }
+    }
+
+    @SubscribeEvent
+    public static void renderItemOverlay(RenderItemOverlayEvent event) {
+        if (event.getItem().getItem() == ItemTest.instance) {
+            ItemStack stack = event.getItem();
+            GlStateManager.disableLighting();
+            GlStateManager.disableDepth();
+            GlStateManager.disableTexture2D();
+            GlStateManager.disableAlpha();
+            GlStateManager.disableBlend();
+            Tessellator tessellator = Tessellator.getInstance();
+            BufferBuilder bufferbuilder = tessellator.getBuffer();
+            int testValue = stack.getTagCompound().getInteger("test");
+            int rgbfordisplay = stack.getItem().getRGBDurabilityForDisplay(stack);
+            int i = Math.min(testValue, 13);
+            int j = rgbfordisplay;
+            draw(bufferbuilder, event.getxPosition() + 2, event.getyPosition() + 10, 13, 2, 0, 0, 0, 255);
+            draw(bufferbuilder, event.getxPosition() + 2, event.getyPosition() + 10, i, 1, j >> 16 & 255, j >> 8 & 255, j & 255, 255);
+            GlStateManager.enableBlend();
+            GlStateManager.enableAlpha();
+            GlStateManager.enableTexture2D();
+            GlStateManager.enableLighting();
+            GlStateManager.enableDepth();
+        }
+    }
+
+    private static void draw(BufferBuilder renderer, int x, int y, int width, int height, int red, int green, int blue, int alpha)
+    {
+        renderer.begin(7, DefaultVertexFormats.POSITION_COLOR);
+        renderer.pos((double)(x + 0), (double)(y + 0), 0.0D).color(red, green, blue, alpha).endVertex();
+        renderer.pos((double)(x + 0), (double)(y + height), 0.0D).color(red, green, blue, alpha).endVertex();
+        renderer.pos((double)(x + width), (double)(y + height), 0.0D).color(red, green, blue, alpha).endVertex();
+        renderer.pos((double)(x + width), (double)(y + 0), 0.0D).color(red, green, blue, alpha).endVertex();
+        Tessellator.getInstance().draw();
+    }
+
+    public static class ItemTest extends ItemSword {
+
+        public static ItemTest instance = null;
+
+        public ItemTest() {
+            super(ToolMaterial.DIAMOND);
+            setCreativeTab(CreativeTabs.TOOLS);
+            setRegistryName(MODID, "test_sword");
+            setUnlocalizedName(MODID + ":test_sword");
+        }
+
+        @Override
+        public ActionResult<ItemStack> onItemRightClick(World worldIn, EntityPlayer playerIn, EnumHand handIn) {
+            ItemStack stack = playerIn.getHeldItem(handIn);
+            int x = 0;
+            NBTTagCompound tag = new NBTTagCompound();
+            if (stack.hasTagCompound()) {
+                x = stack.getTagCompound().getInteger("test");
+            }
+            x++;
+            tag.setInteger("test", x);
+            stack.setTagCompound(tag);
+            return new ActionResult<>(EnumActionResult.SUCCESS, stack);
+        }
+
+        @Override
+        public boolean onLeftClickEntity(ItemStack stack, EntityPlayer player, Entity entity) {
+            if (stack.hasTagCompound()) {
+                stack.setTagCompound(null);
+            }
+            return super.onLeftClickEntity(stack, player, entity);
+        }
+
+        @Override
+        public boolean shouldRenderAdditionalOverlay(ItemStack stack) {
+            return stack.hasTagCompound();
+        }
+    }
+}

--- a/src/test/resources/assets/renderitemoverlayeventtest.models.item/test_item.json
+++ b/src/test/resources/assets/renderitemoverlayeventtest.models.item/test_item.json
@@ -1,0 +1,6 @@
+{
+  "parent": "item/generated",
+  "textures": {
+    "layer0": "minecraft:items/diamond_sword"
+  }
+}


### PR DESCRIPTION
I have a tool which needs to have two durability bars. In order to draw the second one, I would have to ASM my own hook into `RenderItem`, or do some wonky rendering on the `GuiContainerEvent.DrawForeground` and `RenderGameOverlayEvent.Post` events. This prompted a PR for the hook instead.