### PR TITLE
Added chunk instance to ChunkWatchEvent

### DIFF
--- a/patches/minecraft/net/minecraft/server/management/PlayerChunkMapEntry.java.patch
+++ b/patches/minecraft/net/minecraft/server/management/PlayerChunkMapEntry.java.patch
@@ -28,7 +28,7 @@
              {
                  this.func_187278_c(p_187276_1_);
 +                // chunk watch event - the chunk is ready
-+                net.minecraftforge.common.MinecraftForge.EVENT_BUS.post(new net.minecraftforge.event.world.ChunkWatchEvent.Watch(this.field_187284_d, p_187276_1_, this.field_187282_b.func_72688_a()));
++                net.minecraftforge.common.MinecraftForge.EVENT_BUS.post(new net.minecraftforge.event.world.ChunkWatchEvent.Watch(this.field_187286_f, p_187276_1_));
              }
          }
      }
@@ -57,7 +57,7 @@
  
              this.field_187283_c.remove(p_187277_1_);
  
-+            net.minecraftforge.common.MinecraftForge.EVENT_BUS.post(new net.minecraftforge.event.world.ChunkWatchEvent.UnWatch(this.field_187284_d, p_187277_1_, this.field_187282_b.func_72688_a()));
++            net.minecraftforge.common.MinecraftForge.EVENT_BUS.post(new net.minecraftforge.event.world.ChunkWatchEvent.UnWatch(this.field_187286_f, p_187277_1_));
 +
              if (this.field_187283_c.isEmpty())
              {
@@ -82,7 +82,7 @@
                  entityplayermp.field_71135_a.func_147359_a(packet);
                  this.field_187282_b.func_72688_a().func_73039_n().func_85172_a(entityplayermp, this.field_187286_f);
 +                // chunk watch event - delayed to here as the chunk wasn't ready in addPlayer
-+                net.minecraftforge.common.MinecraftForge.EVENT_BUS.post(new net.minecraftforge.event.world.ChunkWatchEvent.Watch(this.field_187284_d, entityplayermp, this.field_187282_b.func_72688_a()));
++                net.minecraftforge.common.MinecraftForge.EVENT_BUS.post(new net.minecraftforge.event.world.ChunkWatchEvent.Watch(this.field_187286_f, entityplayermp));
              }
  
              return true;

--- a/patches/minecraft/net/minecraft/server/management/PlayerChunkMapEntry.java.patch
+++ b/patches/minecraft/net/minecraft/server/management/PlayerChunkMapEntry.java.patch
@@ -28,7 +28,7 @@
              {
                  this.func_187278_c(p_187276_1_);
 +                // chunk watch event - the chunk is ready
-+                net.minecraftforge.common.MinecraftForge.EVENT_BUS.post(new net.minecraftforge.event.world.ChunkWatchEvent.Watch(this.field_187284_d, p_187276_1_));
++                net.minecraftforge.common.MinecraftForge.EVENT_BUS.post(new net.minecraftforge.event.world.ChunkWatchEvent.Watch(this.field_187284_d, p_187276_1_, this.field_187282_b.func_72688_a()));
              }
          }
      }
@@ -57,7 +57,7 @@
  
              this.field_187283_c.remove(p_187277_1_);
  
-+            net.minecraftforge.common.MinecraftForge.EVENT_BUS.post(new net.minecraftforge.event.world.ChunkWatchEvent.UnWatch(this.field_187284_d, p_187277_1_));
++            net.minecraftforge.common.MinecraftForge.EVENT_BUS.post(new net.minecraftforge.event.world.ChunkWatchEvent.UnWatch(this.field_187284_d, p_187277_1_, this.field_187282_b.func_72688_a()));
 +
              if (this.field_187283_c.isEmpty())
              {
@@ -82,7 +82,7 @@
                  entityplayermp.field_71135_a.func_147359_a(packet);
                  this.field_187282_b.func_72688_a().func_73039_n().func_85172_a(entityplayermp, this.field_187286_f);
 +                // chunk watch event - delayed to here as the chunk wasn't ready in addPlayer
-+                net.minecraftforge.common.MinecraftForge.EVENT_BUS.post(new net.minecraftforge.event.world.ChunkWatchEvent.Watch(this.field_187284_d, entityplayermp));
++                net.minecraftforge.common.MinecraftForge.EVENT_BUS.post(new net.minecraftforge.event.world.ChunkWatchEvent.Watch(this.field_187284_d, entityplayermp, this.field_187282_b.func_72688_a()));
              }
  
              return true;

--- a/src/main/java/net/minecraftforge/event/world/ChunkWatchEvent.java
+++ b/src/main/java/net/minecraftforge/event/world/ChunkWatchEvent.java
@@ -93,7 +93,7 @@ public class ChunkWatchEvent extends Event
     public static class Watch extends ChunkWatchEvent
     {
         @Deprecated //TODO: Remove in 1.13
-    	public Watch(ChunkPos chunk, EntityPlayerMP player) { super(chunk, player); }
+        public Watch(ChunkPos chunk, EntityPlayerMP player) { super(chunk, player); }
 
         public Watch(ChunkPos chunk, EntityPlayerMP player, World world) { super(chunk, player, world); }
     }
@@ -112,7 +112,7 @@ public class ChunkWatchEvent extends Event
     public static class UnWatch extends ChunkWatchEvent
     {
         @Deprecated //TODO: Remove in 1.13
-    	public UnWatch(ChunkPos chunkLocation, EntityPlayerMP player) { super(chunkLocation, player); }
+        public UnWatch(ChunkPos chunkLocation, EntityPlayerMP player) { super(chunkLocation, player); }
 
         public UnWatch(ChunkPos chunkLocation, EntityPlayerMP player, World world) { super(chunkLocation, player, world); }
     }

--- a/src/main/java/net/minecraftforge/event/world/ChunkWatchEvent.java
+++ b/src/main/java/net/minecraftforge/event/world/ChunkWatchEvent.java
@@ -27,6 +27,7 @@ import javax.annotation.Nullable;
 import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraft.util.math.ChunkPos;
 import net.minecraft.world.World;
+import net.minecraft.world.chunk.Chunk;
 
 /**
  * ChunkWatchEvent is fired when an event involving a chunk being watched occurs.<br>
@@ -35,32 +36,36 @@ import net.minecraft.world.World;
  * <br>
  * {@link #chunk} contains the ChunkPos of the Chunk this event is affecting.<br>
  * {@link #player} contains the EntityPlayer that is involved with this chunk being watched. <br>
- * {@link #world} contains the World of the Chunk. <br>
+ * {@link #chunkInstance} contains the instance of the Chunk. <br>
  * <br>
  * The {@link #player}'s world may not be the same as the world of the chunk
  * when the player is teleporting to another dimension.<br>
  * <br>
  * All children of this event are fired on the {@link MinecraftForge#EVENT_BUS}.<br>
  **/
-public class ChunkWatchEvent extends Event
+public class ChunkWatchEvent extends Event //TODO: extend ChunkEvent in 1.13
 {
+    @Deprecated //TODO: Remove in 1.13
     private final ChunkPos chunk;
     private final EntityPlayerMP player;
-    private final World world;
+    private final Chunk chunkInstance;
 
     @Deprecated //TODO: Remove in 1.13
     public ChunkWatchEvent(ChunkPos chunk, EntityPlayerMP player)
     {
-        this(chunk, player, null);
-    }
-
-    public ChunkWatchEvent(ChunkPos chunk, EntityPlayerMP player, World world)
-    {
         this.chunk = chunk;
         this.player = player;
-        this.world = world;
+        this.chunkInstance = null;
     }
 
+    public ChunkWatchEvent(Chunk chunk, EntityPlayerMP player)
+    {
+        this.chunk = chunk.getPos();
+        this.player = player;
+        this.chunkInstance = chunk;
+    }
+
+    @Deprecated //TODO: Remove in 1.13
     public ChunkPos getChunk()
     {
         return chunk;
@@ -72,13 +77,13 @@ public class ChunkWatchEvent extends Event
     }
 
     /**
-     * The world of the chunk.
-     * @return
+     * The affected chunk.
+     * @return The affected chunk.
      */
-    @Nullable //TODO: Remove @Nullable when deprecated constructor is removed
-    public World getWorld()
+    @Nullable
+    public Chunk getChunkInstance()
     {
-        return world;
+        return chunkInstance;
     }
 
     /**
@@ -97,7 +102,7 @@ public class ChunkWatchEvent extends Event
         @Deprecated //TODO: Remove in 1.13
         public Watch(ChunkPos chunk, EntityPlayerMP player) { super(chunk, player); }
 
-        public Watch(ChunkPos chunk, EntityPlayerMP player, World world) { super(chunk, player, world); }
+        public Watch(Chunk chunk, EntityPlayerMP player) { super(chunk, player); }
     }
 
     /**
@@ -116,6 +121,6 @@ public class ChunkWatchEvent extends Event
         @Deprecated //TODO: Remove in 1.13
         public UnWatch(ChunkPos chunkLocation, EntityPlayerMP player) { super(chunkLocation, player); }
 
-        public UnWatch(ChunkPos chunkLocation, EntityPlayerMP player, World world) { super(chunkLocation, player, world); }
+        public UnWatch(Chunk chunk, EntityPlayerMP player) { super(chunk, player); }
     }
 }

--- a/src/main/java/net/minecraftforge/event/world/ChunkWatchEvent.java
+++ b/src/main/java/net/minecraftforge/event/world/ChunkWatchEvent.java
@@ -25,14 +25,19 @@ import net.minecraftforge.fml.common.eventhandler.Cancelable;
 import net.minecraftforge.fml.common.eventhandler.Event;
 import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraft.util.math.ChunkPos;
+import net.minecraft.world.World;
 
 /**
  * ChunkWatchEvent is fired when an event involving a chunk being watched occurs.<br>
  * If a method utilizes this {@link Event} as its parameter, the method will
  * receive every child event of this class.<br>
  * <br>
- * {@link #chunk} contains the ChunkCoordIntPair of the Chunk this event is affecting.<br>
+ * {@link #chunk} contains the ChunkPos of the Chunk this event is affecting.<br>
  * {@link #player} contains the EntityPlayer that is involved with this chunk being watched. <br>
+ * {@link #world} contains the World of the Chunk. <br>
+ * <br>
+ * The {@link #player}'s world may not be the same as the world of the chunk
+ * when the player is teleporting to another dimension.<br>
  * <br>
  * All children of this event are fired on the {@link MinecraftForge#EVENT_BUS}.<br>
  **/
@@ -40,11 +45,13 @@ public class ChunkWatchEvent extends Event
 {
     private final ChunkPos chunk;
     private final EntityPlayerMP player;
+    private final World world;
 
-    public ChunkWatchEvent(ChunkPos chunk, EntityPlayerMP player)
+    public ChunkWatchEvent(ChunkPos chunk, EntityPlayerMP player, World world)
     {
         this.chunk = chunk;
         this.player = player;
+        this.world = world;
     }
 
     public ChunkPos getChunk()
@@ -55,6 +62,15 @@ public class ChunkWatchEvent extends Event
     public EntityPlayerMP getPlayer()
     {
         return player;
+    }
+
+    /**
+     * The world of the chunk.
+     * @return
+     */
+    public World getWorld()
+    {
+        return world;
     }
 
     /**
@@ -70,7 +86,7 @@ public class ChunkWatchEvent extends Event
      **/
     public static class Watch extends ChunkWatchEvent
     {
-        public Watch(ChunkPos chunk, EntityPlayerMP player) { super(chunk, player); }
+        public Watch(ChunkPos chunk, EntityPlayerMP player, World world) { super(chunk, player, world); }
     }
 
     /**
@@ -86,6 +102,6 @@ public class ChunkWatchEvent extends Event
      **/
     public static class UnWatch extends ChunkWatchEvent
     {
-        public UnWatch(ChunkPos chunkLocation, EntityPlayerMP player) { super(chunkLocation, player); }
+        public UnWatch(ChunkPos chunkLocation, EntityPlayerMP player, World world) { super(chunkLocation, player, world); }
     }
 }

--- a/src/main/java/net/minecraftforge/event/world/ChunkWatchEvent.java
+++ b/src/main/java/net/minecraftforge/event/world/ChunkWatchEvent.java
@@ -47,6 +47,12 @@ public class ChunkWatchEvent extends Event
     private final EntityPlayerMP player;
     private final World world;
 
+    @Deprecated //TODO: Remove in 1.13
+    public ChunkWatchEvent(ChunkPos chunk, EntityPlayerMP player)
+    {
+        this(chunk, player, player.getEntityWorld());
+    }
+
     public ChunkWatchEvent(ChunkPos chunk, EntityPlayerMP player, World world)
     {
         this.chunk = chunk;
@@ -86,6 +92,9 @@ public class ChunkWatchEvent extends Event
      **/
     public static class Watch extends ChunkWatchEvent
     {
+        @Deprecated //TODO: Remove in 1.13
+    	public Watch(ChunkPos chunk, EntityPlayerMP player) { super(chunk, player); }
+
         public Watch(ChunkPos chunk, EntityPlayerMP player, World world) { super(chunk, player, world); }
     }
 
@@ -102,6 +111,9 @@ public class ChunkWatchEvent extends Event
      **/
     public static class UnWatch extends ChunkWatchEvent
     {
+        @Deprecated //TODO: Remove in 1.13
+    	public UnWatch(ChunkPos chunkLocation, EntityPlayerMP player) { super(chunkLocation, player); }
+
         public UnWatch(ChunkPos chunkLocation, EntityPlayerMP player, World world) { super(chunkLocation, player, world); }
     }
 }

--- a/src/main/java/net/minecraftforge/event/world/ChunkWatchEvent.java
+++ b/src/main/java/net/minecraftforge/event/world/ChunkWatchEvent.java
@@ -23,6 +23,7 @@ import net.minecraft.server.management.PlayerChunkMapEntry;
 import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.fml.common.eventhandler.Cancelable;
 import net.minecraftforge.fml.common.eventhandler.Event;
+import javax.annotation.Nullable;
 import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraft.util.math.ChunkPos;
 import net.minecraft.world.World;
@@ -50,7 +51,7 @@ public class ChunkWatchEvent extends Event
     @Deprecated //TODO: Remove in 1.13
     public ChunkWatchEvent(ChunkPos chunk, EntityPlayerMP player)
     {
-        this(chunk, player, player.getEntityWorld());
+        this(chunk, player, null);
     }
 
     public ChunkWatchEvent(ChunkPos chunk, EntityPlayerMP player, World world)
@@ -74,6 +75,7 @@ public class ChunkWatchEvent extends Event
      * The world of the chunk.
      * @return
      */
+    @Nullable //TODO: Remove @Nullable when deprecated constructor is removed
     public World getWorld()
     {
         return world;

--- a/src/test/java/net/minecraftforge/debug/ChunkWatchWorldTest.java
+++ b/src/test/java/net/minecraftforge/debug/ChunkWatchWorldTest.java
@@ -1,0 +1,41 @@
+package net.minecraftforge.debug;
+
+import org.apache.logging.log4j.Logger;
+
+import net.minecraftforge.common.MinecraftForge;
+import net.minecraftforge.event.world.ChunkWatchEvent;
+import net.minecraftforge.fml.common.Mod;
+import net.minecraftforge.fml.common.event.FMLPreInitializationEvent;
+import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
+
+@Mod(modid = ChunkWatchWorldTest.MODID, name = "Chunk Watch World Test", version = "1.0", acceptableRemoteVersions = "*")
+public class ChunkWatchWorldTest
+{
+    public static final String MODID = "chunkwatchworldtest";
+
+    private static final boolean ENABLED = false;
+    private static Logger logger;
+
+    @Mod.EventHandler
+    public void preInit(FMLPreInitializationEvent event)
+    {
+        logger = event.getModLog();
+
+        if (ENABLED)
+        {
+            MinecraftForge.EVENT_BUS.register(ChunkWatchWorldTest.class);
+        }
+    }
+
+    @SubscribeEvent
+    public static void onUnwatch(ChunkWatchEvent.UnWatch event)
+    {
+        logger.info("Unwatching chunk {} in dimension {}. Player's dimension: {} ", event.getChunk(), event.getWorld().provider.getDimension(), event.getPlayer().getEntityWorld().provider.getDimension());
+    }
+
+    @SubscribeEvent
+    public static void onWatch(ChunkWatchEvent.Watch event)
+    {
+        logger.info("Watching chunk {} in dimension {}. Player's dimension: {} ", event.getChunk(), event.getWorld().provider.getDimension(), event.getPlayer().getEntityWorld().provider.getDimension());
+    }
+}

--- a/src/test/java/net/minecraftforge/debug/ChunkWatchWorldTest.java
+++ b/src/test/java/net/minecraftforge/debug/ChunkWatchWorldTest.java
@@ -30,12 +30,12 @@ public class ChunkWatchWorldTest
     @SubscribeEvent
     public static void onUnwatch(ChunkWatchEvent.UnWatch event)
     {
-        logger.info("Unwatching chunk {} in dimension {}. Player's dimension: {} ", event.getChunk(), event.getWorld().provider.getDimension(), event.getPlayer().getEntityWorld().provider.getDimension());
+        logger.info("Unwatching chunk {} in dimension {}. Player's dimension: {} ", event.getChunk(), event.getChunkInstance().getWorld().provider.getDimension(), event.getPlayer().getEntityWorld().provider.getDimension());
     }
 
     @SubscribeEvent
     public static void onWatch(ChunkWatchEvent.Watch event)
     {
-        logger.info("Watching chunk {} in dimension {}. Player's dimension: {} ", event.getChunk(), event.getWorld().provider.getDimension(), event.getPlayer().getEntityWorld().provider.getDimension());
+        logger.info("Watching chunk {} in dimension {}. Player's dimension: {} ", event.getChunk(), event.getChunkInstance().getWorld().provider.getDimension(), event.getPlayer().getEntityWorld().provider.getDimension());
     }
 }


### PR DESCRIPTION
This PR adds a getter for the world of the chunk that was un-/watched.
This is useful because when the player is teleported to another dimension with `PlayerList#transferPlayerToDimension` the player's world is set to the new dimension before the ChunkWatchEvent.UnWatch events are called. Because of that there's no way of actually knowing in which world the chunk was unwatched by just using the event.
Specifically mods that need to keep track of which players are watching which chunks need this.
The additional getter and comment should also make it clear that the player's world may not be the same as the world of the chunk that was unwatched.
