### PR TITLE
Fix some IResources being leaked

### DIFF
--- a/src/main/java/net/minecraftforge/client/model/ModelDynBucket.java
+++ b/src/main/java/net/minecraftforge/client/model/ModelDynBucket.java
@@ -61,6 +61,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Maps;
+import net.minecraftforge.fml.common.FMLLog;
 import org.apache.commons.io.IOUtils;
 
 public final class ModelDynBucket implements IModel
@@ -347,12 +348,10 @@ public final class ModelDynBucket implements IModel
             final int[][] pixels = new int[Minecraft.getMinecraft().gameSettings.mipmapLevels + 1][];
             pixels[0] = new int[width * height];
 
-            IResource empty = null;
-            IResource mask = null;
-            try
-            {
-                empty = getResource(new ResourceLocation("textures/items/bucket_empty.png"));
-                mask = getResource(new ResourceLocation(ForgeVersion.MOD_ID, "textures/items/vanilla_bucket_cover_mask.png"));
+            try (
+                 IResource empty = getResource(new ResourceLocation("textures/items/bucket_empty.png"));
+                 IResource mask = getResource(new ResourceLocation(ForgeVersion.MOD_ID, "textures/items/vanilla_bucket_cover_mask.png"))
+            ) {
                 // use the alpha mask if it fits, otherwise leave the cover texture blank
                 if (empty != null && mask != null && Objects.equals(empty.getResourcePackName(), mask.getResourcePackName()) &&
                         alphaMask.getIconWidth() == width && alphaMask.getIconHeight() == height)
@@ -370,10 +369,9 @@ public final class ModelDynBucket implements IModel
                     }
                 }
             }
-            finally
+            catch (IOException e)
             {
-                IOUtils.closeQuietly(empty);
-                IOUtils.closeQuietly(mask);
+                FMLLog.log.error("Failed to close resource", e);
             }
 
             this.clearFramesTextureData();

--- a/src/main/java/net/minecraftforge/client/model/animation/ModelBlockAnimation.java
+++ b/src/main/java/net/minecraftforge/client/model/animation/ModelBlockAnimation.java
@@ -35,6 +35,7 @@ import javax.vecmath.Matrix4f;
 import javax.vecmath.Quat4f;
 import javax.vecmath.Vector3f;
 
+import org.apache.commons.io.IOUtils;
 import org.apache.logging.log4j.Level;
 
 import net.minecraft.client.renderer.block.model.BlockPart;
@@ -558,15 +559,19 @@ public class ModelBlockAnimation
             try
             {
                 resource = manager.getResource(armatureLocation);
+                ModelBlockAnimation mba = mbaGson.fromJson(new InputStreamReader(resource.getInputStream(), "UTF-8"), ModelBlockAnimation.class);
+                //String json = mbaGson.toJson(mba);
+                return mba;
             }
             catch(FileNotFoundException e)
             {
                 // this is normal. FIXME: error reporting?
                 return defaultModelBlockAnimation;
             }
-            ModelBlockAnimation mba = mbaGson.fromJson(new InputStreamReader(resource.getInputStream(), "UTF-8"), ModelBlockAnimation.class);
-            //String json = mbaGson.toJson(mba);
-            return mba;
+            finally
+            {
+                IOUtils.closeQuietly(resource);
+            }
         }
         catch(IOException | JsonParseException e)
         {

--- a/src/main/java/net/minecraftforge/client/model/animation/ModelBlockAnimation.java
+++ b/src/main/java/net/minecraftforge/client/model/animation/ModelBlockAnimation.java
@@ -555,10 +555,8 @@ public class ModelBlockAnimation
     {
         try
         {
-            IResource resource = null;
-            try
+            try (IResource resource = manager.getResource(armatureLocation))
             {
-                resource = manager.getResource(armatureLocation);
                 ModelBlockAnimation mba = mbaGson.fromJson(new InputStreamReader(resource.getInputStream(), "UTF-8"), ModelBlockAnimation.class);
                 //String json = mbaGson.toJson(mba);
                 return mba;
@@ -567,10 +565,6 @@ public class ModelBlockAnimation
             {
                 // this is normal. FIXME: error reporting?
                 return defaultModelBlockAnimation;
-            }
-            finally
-            {
-                IOUtils.closeQuietly(resource);
             }
         }
         catch(IOException | JsonParseException e)

--- a/src/main/java/net/minecraftforge/client/model/b3d/B3DLoader.java
+++ b/src/main/java/net/minecraftforge/client/model/b3d/B3DLoader.java
@@ -70,6 +70,7 @@ import net.minecraftforge.common.property.IUnlistedProperty;
 import net.minecraftforge.common.property.Properties;
 import net.minecraftforge.fml.common.FMLLog;
 
+import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.commons.lang3.tuple.Triple;
 
@@ -126,9 +127,9 @@ public enum B3DLoader implements ICustomModelLoader
         ResourceLocation file = new ResourceLocation(modelLocation.getResourceDomain(), modelLocation.getResourcePath());
         if(!cache.containsKey(file))
         {
+            IResource resource = null;
             try
             {
-                IResource resource;
                 try
                 {
                     resource = manager.getResource(file);
@@ -149,6 +150,10 @@ public enum B3DLoader implements ICustomModelLoader
             {
                 cache.put(file, null);
                 throw e;
+            }
+            finally
+            {
+                IOUtils.closeQuietly(resource);
             }
         }
         B3DModel model = cache.get(file);

--- a/src/main/java/net/minecraftforge/client/model/obj/OBJLoader.java
+++ b/src/main/java/net/minecraftforge/client/model/obj/OBJLoader.java
@@ -33,6 +33,7 @@ import net.minecraftforge.client.model.IModel;
 import net.minecraftforge.client.model.ModelLoaderRegistry;
 import net.minecraftforge.fml.common.FMLLog;
 
+import org.apache.commons.io.IOUtils;
 import org.apache.logging.log4j.Level;
 
 /*
@@ -74,32 +75,39 @@ public enum OBJLoader implements ICustomModelLoader {
         ResourceLocation file = new ResourceLocation(modelLocation.getResourceDomain(), modelLocation.getResourcePath());
         if (!cache.containsKey(file))
         {
-            IResource resource;
+            IResource resource = null;
             try
             {
-                resource = manager.getResource(file);
-            }
-            catch (FileNotFoundException e)
-            {
-                if (modelLocation.getResourcePath().startsWith("models/block/"))
-                    resource = manager.getResource(new ResourceLocation(file.getResourceDomain(), "models/item/" + file.getResourcePath().substring("models/block/".length())));
-                else if (modelLocation.getResourcePath().startsWith("models/item/"))
-                    resource = manager.getResource(new ResourceLocation(file.getResourceDomain(), "models/block/" + file.getResourcePath().substring("models/item/".length())));
-                else throw e;
-            }
-            OBJModel.Parser parser = new OBJModel.Parser(resource, manager);
-            OBJModel model = null;
-            try
-            {
-                model = parser.parse();
-            }
-            catch (Exception e)
-            {
-                errors.put(modelLocation, e);
+                try
+                {
+                    resource = manager.getResource(file);
+                }
+                catch (FileNotFoundException e)
+                {
+                    if (modelLocation.getResourcePath().startsWith("models/block/"))
+                        resource = manager.getResource(new ResourceLocation(file.getResourceDomain(), "models/item/" + file.getResourcePath().substring("models/block/".length())));
+                    else if (modelLocation.getResourcePath().startsWith("models/item/"))
+                        resource = manager.getResource(new ResourceLocation(file.getResourceDomain(), "models/block/" + file.getResourcePath().substring("models/item/".length())));
+                    else throw e;
+                }
+                OBJModel.Parser parser = new OBJModel.Parser(resource, manager);
+                OBJModel model = null;
+                try
+                {
+                    model = parser.parse();
+                }
+                catch (Exception e)
+                {
+                    errors.put(modelLocation, e);
+                }
+                finally
+                {
+                    cache.put(modelLocation, model);
+                }
             }
             finally
             {
-                cache.put(modelLocation, model);
+                IOUtils.closeQuietly(resource);
             }
         }
         OBJModel model = cache.get(file);

--- a/src/main/java/net/minecraftforge/common/model/animation/AnimationStateMachine.java
+++ b/src/main/java/net/minecraftforge/common/model/animation/AnimationStateMachine.java
@@ -51,6 +51,7 @@ import net.minecraftforge.common.util.JsonUtils;
 import net.minecraftforge.fml.common.FMLLog;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
+import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.commons.lang3.tuple.Triple;
 
@@ -215,13 +216,14 @@ public final class AnimationStateMachine implements IAnimationStateMachine
     @SideOnly(Side.CLIENT)
     public static IAnimationStateMachine load(IResourceManager manager, ResourceLocation location, ImmutableMap<String, ITimeValue> customParameters)
     {
+        IResource resource = null;
         try
         {
             ClipResolver clipResolver = new ClipResolver();
             ParameterResolver parameterResolver = new ParameterResolver(customParameters);
             Clips.CommonClipTypeAdapterFactory.INSTANCE.setClipResolver(clipResolver);
             TimeValues.CommonTimeValueTypeAdapterFactory.INSTANCE.setValueResolver(parameterResolver);
-            IResource resource = manager.getResource(location);
+            resource = manager.getResource(location);
             AnimationStateMachine asm = asmGson.fromJson(new InputStreamReader(resource.getInputStream(), "UTF-8"), AnimationStateMachine.class);
             clipResolver.asm = asm;
             parameterResolver.asm = asm;
@@ -239,6 +241,7 @@ public final class AnimationStateMachine implements IAnimationStateMachine
         {
             Clips.CommonClipTypeAdapterFactory.INSTANCE.setClipResolver(null);
             TimeValues.CommonTimeValueTypeAdapterFactory.INSTANCE.setValueResolver(null);
+            IOUtils.closeQuietly(resource);
         }
     }
 

--- a/src/main/java/net/minecraftforge/common/model/animation/AnimationStateMachine.java
+++ b/src/main/java/net/minecraftforge/common/model/animation/AnimationStateMachine.java
@@ -216,14 +216,12 @@ public final class AnimationStateMachine implements IAnimationStateMachine
     @SideOnly(Side.CLIENT)
     public static IAnimationStateMachine load(IResourceManager manager, ResourceLocation location, ImmutableMap<String, ITimeValue> customParameters)
     {
-        IResource resource = null;
-        try
+        try (IResource resource = manager.getResource(location))
         {
             ClipResolver clipResolver = new ClipResolver();
             ParameterResolver parameterResolver = new ParameterResolver(customParameters);
             Clips.CommonClipTypeAdapterFactory.INSTANCE.setClipResolver(clipResolver);
             TimeValues.CommonTimeValueTypeAdapterFactory.INSTANCE.setValueResolver(parameterResolver);
-            resource = manager.getResource(location);
             AnimationStateMachine asm = asmGson.fromJson(new InputStreamReader(resource.getInputStream(), "UTF-8"), AnimationStateMachine.class);
             clipResolver.asm = asm;
             parameterResolver.asm = asm;
@@ -241,7 +239,6 @@ public final class AnimationStateMachine implements IAnimationStateMachine
         {
             Clips.CommonClipTypeAdapterFactory.INSTANCE.setClipResolver(null);
             TimeValues.CommonTimeValueTypeAdapterFactory.INSTANCE.setValueResolver(null);
-            IOUtils.closeQuietly(resource);
         }
     }
 


### PR DESCRIPTION
This can be observed when setting the logger to DEBUG level in the log4j xml config, as minecraft replaces the inputstream with a leak tracking input stream when their logger has debug enabled.