### PR TITLE
Change composite models to fetch quads from submodels using full context

### DIFF
--- a/src/main/java/net/minecraftforge/client/model/MultiLayerModel.java
+++ b/src/main/java/net/minecraftforge/client/model/MultiLayerModel.java
@@ -153,11 +153,8 @@ public final class MultiLayerModel implements IModel
                 }
                 return builder.build();
             }
-            else
-            {
-                // assumes that child model will handle this state properly. FIXME?
-                return models.getOrDefault(Optional.of(layer), missing).getQuads(state, side, rand);
-            }
+            // assumes that child model will handle this state properly. FIXME?
+            return models.getOrDefault(Optional.of(layer), missing).getQuads(state, side, rand);
         }
 
         @Override

--- a/src/main/java/net/minecraftforge/client/model/MultiModel.java
+++ b/src/main/java/net/minecraftforge/client/model/MultiModel.java
@@ -47,10 +47,8 @@ import net.minecraftforge.common.model.TRSRTransformation;
 import net.minecraftforge.fml.common.FMLLog;
 
 import org.apache.commons.lang3.tuple.Pair;
-import org.apache.logging.log4j.Level;
 
 import java.util.function.Function;
-import java.util.Optional;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
@@ -68,7 +66,6 @@ public final class MultiModel implements IModel
         private final ImmutableMap<String, IBakedModel> parts;
 
         private final IBakedModel internalBase;
-        private ImmutableMap<Optional<EnumFacing>, ImmutableList<BakedQuad>> quads;
         private final ImmutableMap<TransformType, Pair<Baked, TRSRTransformation>> transforms;
         private final ItemOverrideList overrides = new ItemOverrideList(Lists.newArrayList())
         {
@@ -177,36 +174,16 @@ public final class MultiModel implements IModel
         @Override
         public List<BakedQuad> getQuads(@Nullable IBlockState state, @Nullable EnumFacing side, long rand)
         {
-            if(quads == null)
+            ImmutableList.Builder<BakedQuad> quads = ImmutableList.builder();
+            if (base != null)
             {
-                ImmutableMap.Builder<Optional<EnumFacing>, ImmutableList<BakedQuad>> builder = ImmutableMap.builder();
-
-                for (EnumFacing face : EnumFacing.values())
-                {
-                    ImmutableList.Builder<BakedQuad> quads = ImmutableList.builder();
-                    if (base != null)
-                    {
-                        quads.addAll(base.getQuads(state, face, 0));
-                    }
-                    for (IBakedModel bakedPart : parts.values())
-                    {
-                        quads.addAll(bakedPart.getQuads(state, face, 0));
-                    }
-                    builder.put(Optional.of(face), quads.build());
-                }
-                ImmutableList.Builder<BakedQuad> quads = ImmutableList.builder();
-                if (base != null)
-                {
-                    quads.addAll(base.getQuads(state, null, 0));
-                }
-                for (IBakedModel bakedPart : parts.values())
-                {
-                    quads.addAll(bakedPart.getQuads(state, null, 0));
-                }
-                builder.put(Optional.empty(), quads.build());
-                this.quads = builder.build();
+                quads.addAll(base.getQuads(state, side, rand));
             }
-            return quads.get(Optional.ofNullable(side));
+            for (IBakedModel bakedPart : parts.values())
+            {
+                quads.addAll(bakedPart.getQuads(state, side, rand));
+            }
+            return quads.build();
         }
 
         @Override


### PR DESCRIPTION
This changes Forge's composite models to pass the parameters given to `getQuads` through to submodels, combining the results into a single list. This matches the implementation used by vanilla's `MultipartBakedModel`.

At present, submodels are only queried for their quads using a fixed set of parameters, so any baked model implementations that rely on getting changeable values here aren't supported.

The original code here was written in 1.8, when instead of `getQuads(IBlockState, EnumFacing, long)`, there was `getFaceQuads(EnumFacing)` and `getGeneralQuads()`. At that point there was no other context to pass here, so the approach taken made more sense.