### PR TITLE
Don't try to render removed tile entities (MC-123363)

### DIFF
--- a/patches/minecraft/net/minecraft/client/renderer/tileentity/TileEntityRendererDispatcher.java.patch
+++ b/patches/minecraft/net/minecraft/client/renderer/tileentity/TileEntityRendererDispatcher.java.patch
@@ -1,5 +1,14 @@
 --- ../src-base/minecraft/net/minecraft/client/renderer/tileentity/TileEntityRendererDispatcher.java
 +++ ../src-work/minecraft/net/minecraft/client/renderer/tileentity/TileEntityRendererDispatcher.java
+@@ -92,7 +92,7 @@
+     @Nullable
+     public <T extends TileEntity> TileEntitySpecialRenderer<T> func_147547_b(@Nullable TileEntity p_147547_1_)
+     {
+-        return p_147547_1_ == null ? null : this.func_147546_a(p_147547_1_.getClass());
++        return p_147547_1_ == null || p_147547_1_.func_145837_r() ? null : this.func_147546_a(p_147547_1_.getClass()); // Forge: fix MC-123363
+     }
+ 
+     public void func_190056_a(World p_190056_1_, TextureManager p_190056_2_, FontRenderer p_190056_3_, Entity p_190056_4_, RayTraceResult p_190056_5_, float p_190056_6_)
 @@ -117,12 +117,15 @@
      {
          if (p_180546_1_.func_145835_a(this.field_147560_j, this.field_147561_k, this.field_147558_l) < p_180546_1_.func_145833_n())


### PR DESCRIPTION
Fixes vanilla issue [MC-123363](https://bugs.mojang.com/browse/MC-123363), which affects the 1.13 snapshots, but also applies to modded TESRs that use blockstate properties currently.

When rendering tile entities, `RenderGlobal.renderEntities` loops over the list given by `CompiledChunk.getTileEntities` for each chunk section, and calls `TileEntityRendererDispatcher.render` on each one.

The list of tile entities with custom renderers is populated from `RenderChunk.rebuildChunk`, while looping over block positions and rendering regular block models.

As `rebuildChunk` may be running on a worker thread, it is possible for a tile entity that is added to that list to subsequently be removed from the world by the main thread.
Then, when `renderEntities` is called, it may try to render a tile entity that no longer exists at that position, which causes a crash if the `render` method attempts to access any property of the no-longer-present blockstate.

Vanilla's TESR implementations are generally unaffected in 1.12 because they tend to use `TileEntity.getBlockMetadata` instead of direct property value lookups. It seems that the removal of metadata in the 1.13 snapshots caused the problem to become visible there.

This is resolved here by adding a check for `TileEntity.isInvalid` to the renderer lookup. Tile entities that have been removed from the world will have been invalidated, so adding this check prevents attempts to render them from causing crashes.