### PR TITLE
Fix NBT data loss when shift-clicking stacked items in the enchantment table (MC-17431)

### DIFF
--- a/patches/minecraft/net/minecraft/inventory/ContainerEnchantment.java.patch
+++ b/patches/minecraft/net/minecraft/inventory/ContainerEnchantment.java.patch
@@ -83,19 +83,16 @@
                      }
  
                      for (int j1 = 0; j1 < 3; ++j1)
-@@ -400,10 +382,12 @@
+@@ -400,10 +382,9 @@
                      return ItemStack.field_190927_a;
                  }
  
 -                if (itemstack1.func_77942_o() && itemstack1.func_190916_E() == 1)
-+                if (itemstack1.func_77942_o()) // Fix MC-17431 (Stacked items with NBT losing data)
++                if (itemstack1.func_77942_o())// Forge: Fix MC-17431
                  {
 -                    ((Slot)this.field_75151_b.get(0)).func_75215_d(itemstack1.func_77946_l());
 -                    itemstack1.func_190920_e(0);
-+                    ItemStack toBeEnchanted = itemstack1.func_77946_l();
-+                    toBeEnchanted.func_190920_e(1);
-+                    ((Slot)this.field_75151_b.get(0)).func_75215_d(toBeEnchanted);
-+                    itemstack1.func_190918_g(1);
++                    ((Slot)this.field_75151_b.get(0)).func_75215_d(itemstack1.func_77979_a(1));
                  }
                  else if (!itemstack1.func_190926_b())
                  {

--- a/patches/minecraft/net/minecraft/inventory/ContainerEnchantment.java.patch
+++ b/patches/minecraft/net/minecraft/inventory/ContainerEnchantment.java.patch
@@ -83,3 +83,19 @@
                      }
  
                      for (int j1 = 0; j1 < 3; ++j1)
+@@ -400,10 +382,12 @@
+                     return ItemStack.field_190927_a;
+                 }
+ 
+-                if (itemstack1.func_77942_o() && itemstack1.func_190916_E() == 1)
++                if (itemstack1.func_77942_o()) // Fix MC-17431 (Stacked items with NBT losing data)
+                 {
+-                    ((Slot)this.field_75151_b.get(0)).func_75215_d(itemstack1.func_77946_l());
+-                    itemstack1.func_190920_e(0);
++                    ItemStack toBeEnchanted = itemstack1.func_77946_l();
++                    toBeEnchanted.func_190920_e(1);
++                    ((Slot)this.field_75151_b.get(0)).func_75215_d(toBeEnchanted);
++                    itemstack1.func_190918_g(1);
+                 }
+                 else if (!itemstack1.func_190926_b())
+                 {


### PR DESCRIPTION
https://bugs.mojang.com/browse/MC-17431
Original report: BluSunrize/ImmersiveEngineering#2906
Ignore the first commit, I forgot about `splitStack`.
Vanilla test case (at least the one I used): Enchant some (>1) sticks. Open an enchantment table's GUI. Shift-click the enchanted sticks into the enchantment slot (where the pickaxe/sword/etc would usually be). Notice that without this PR the enchantment on the stick that went into the enchantment slot vanishes.