### PR TITLE
Fix entities sometimes not rendering when out-of-world (MC-73139)

### DIFF
--- a/patches/minecraft/net/minecraft/client/renderer/RenderGlobal.java.patch
+++ b/patches/minecraft/net/minecraft/client/renderer/RenderGlobal.java.patch
@@ -84,6 +84,15 @@
  
              this.func_180443_s();
  
+@@ -895,7 +910,7 @@
+                     {
+                         RenderChunk renderchunk1 = this.field_175008_n.func_178161_a(new BlockPos((j << 4) + 8, i, (k << 4) + 8));
+ 
+-                        if (renderchunk1 != null && p_174970_4_.func_78546_a(renderchunk1.field_178591_c))
++                        if (renderchunk1 != null && p_174970_4_.func_78546_a(renderchunk1.field_178591_c.func_72321_a(0.0, blockpos1.func_177956_o() > 0 ? Double.POSITIVE_INFINITY : Double.NEGATIVE_INFINITY, 0.0))) // Forge: fix MC-73139
+                         {
+                             renderchunk1.func_178577_a(p_174970_5_);
+                             queue.add(new RenderGlobal.ContainerLocalRenderInformation(renderchunk1, (EnumFacing)null, 0));
 @@ -951,7 +966,7 @@
                  BlockPos blockpos2 = renderchunk4.func_178568_j().func_177982_a(8, 8, 8);
                  boolean flag3 = blockpos2.func_177951_i(blockpos1) < 768.0D;


### PR DESCRIPTION
Fixes vanilla bug [MC-73139](https://bugs.mojang.com/browse/MC-73139).

When rendering regular entities, `RenderGlobal.renderEntities` loops over the entity lists for each visible chunk section, considering each contained entity for rendering.

This can cause entities that exist outside of the normal world bounds to not be rendered, as the chunk sections that they are considered to belong to (the top/bottom ones) may fall outside of the view frustum, even though the entity itself is at a visible position.

This can easily be seen by flying above the world height in creative mode and positioning the third-person camera to face upwards. When the top of the chunk the player is above ceases to be visible, the player disappears.

The fix here is in `RenderGlobal.setupTerrain`. The game has a case for the view entity being out-of world already here, beginning visibility checks on the topmost/bottommost chunk sections within view distance.
For these chunks, the call to `isBoundingBoxInFrustum` is altered to extend the bounding box checked out to infinity in the 'out-of-world' direction, as entities in those sections could exist anywhere in that area.