### PR TITLE
Fix MC-88179 in a better way that avoids and closes #4824

### DIFF
--- a/patches/minecraft/net/minecraft/client/Minecraft.java.patch
+++ b/patches/minecraft/net/minecraft/client/Minecraft.java.patch
@@ -334,25 +334,7 @@
          }
  
          this.field_147127_av.func_147690_c();
-@@ -2488,6 +2550,17 @@
-         EntityPlayerSP entityplayersp = this.field_71439_g;
-         this.field_71439_g = this.field_71442_b.func_192830_a(this.field_71441_e, this.field_71439_g == null ? new StatisticsManager() : this.field_71439_g.func_146107_m(), this.field_71439_g == null ? new RecipeBook() : this.field_71439_g.func_192035_E());
-         this.field_71439_g.func_184212_Q().func_187218_a(entityplayersp.func_184212_Q().func_187231_c());
-+        // Forge - Fix MC-88179 attributes not being copied to new player
-+        for (net.minecraft.entity.ai.attributes.IAttributeInstance oldInst : entityplayersp.func_110140_aT().func_111146_a())
-+        {
-+            net.minecraft.entity.ai.attributes.IAttribute attrib = oldInst.func_111123_a();
-+            net.minecraft.entity.ai.attributes.IAttributeInstance newInst = field_71439_g.func_110140_aT().func_111151_a(attrib);
-+            newInst.func_111128_a(oldInst.func_111125_b());
-+            for (net.minecraft.entity.ai.attributes.AttributeModifier modifier : oldInst.func_111122_c())
-+            {
-+                newInst.func_111121_a(modifier);
-+            }
-+        }
-         this.field_71439_g.field_71093_bK = p_71354_1_;
-         this.field_175622_Z = this.field_71439_g;
-         this.field_71439_g.func_70065_x();
-@@ -2535,159 +2608,8 @@
+@@ -2535,159 +2597,8 @@
      {
          if (this.field_71476_x != null && this.field_71476_x.field_72313_a != RayTraceResult.Type.MISS)
          {
@@ -514,7 +496,7 @@
          }
      }
  
-@@ -3009,18 +2931,8 @@
+@@ -3009,18 +2920,8 @@
  
      public static int func_71369_N()
      {
@@ -535,7 +517,7 @@
      }
  
      public boolean func_70002_Q()
-@@ -3152,6 +3064,9 @@
+@@ -3152,6 +3053,9 @@
          }
          else if (this.field_71439_g != null)
          {
@@ -545,7 +527,7 @@
              if (this.field_71439_g.field_70170_p.field_73011_w instanceof WorldProviderHell)
              {
                  return MusicTicker.MusicType.NETHER;
-@@ -3181,11 +3096,11 @@
+@@ -3181,11 +3085,11 @@
              {
                  if (Keyboard.getEventKeyState())
                  {
@@ -559,7 +541,7 @@
                      {
                          this.field_71456_v.func_146158_b().func_146227_a(ScreenShotHelper.func_148260_a(this.field_71412_D, this.field_71443_c, this.field_71440_d, this.field_147124_at));
                      }
-@@ -3199,6 +3114,7 @@
+@@ -3199,6 +3103,7 @@
                          }
                      }
                  }
@@ -567,7 +549,7 @@
              }
          }
      }
-@@ -3328,6 +3244,12 @@
+@@ -3328,6 +3233,12 @@
          return this.field_184127_aH;
      }
  
@@ -580,7 +562,7 @@
      public boolean func_189648_am()
      {
          return this.field_71439_g != null && this.field_71439_g.func_175140_cp() || this.field_71474_y.field_178879_v;
-@@ -3342,4 +3264,9 @@
+@@ -3342,4 +3253,9 @@
      {
          return this.field_193035_aW;
      }

--- a/patches/minecraft/net/minecraft/server/management/PlayerList.java.patch
+++ b/patches/minecraft/net/minecraft/server/management/PlayerList.java.patch
@@ -175,10 +175,14 @@
          this.func_72375_a(p_187242_1_, worldserver);
          p_187242_1_.field_71135_a.func_147364_a(p_187242_1_.field_70165_t, p_187242_1_.field_70163_u, p_187242_1_.field_70161_v, p_187242_1_.field_70177_z, p_187242_1_.field_70125_A);
          p_187242_1_.field_71134_c.func_73080_a(worldserver1);
-@@ -576,17 +632,30 @@
+@@ -576,17 +632,34 @@
          {
              p_187242_1_.field_71135_a.func_147359_a(new SPacketEntityEffect(p_187242_1_.func_145782_y(), potioneffect));
          }
++        // Fix MC-88179: on non-death SPacketRespawn, also resend attributes
++        net.minecraft.entity.ai.attributes.AttributeMap attributemap = (net.minecraft.entity.ai.attributes.AttributeMap) p_187242_1_.func_110140_aT();
++        java.util.Collection<net.minecraft.entity.ai.attributes.IAttributeInstance> watchedAttribs = attributemap.func_111160_c();
++        if (!watchedAttribs.isEmpty()) p_187242_1_.field_71135_a.func_147359_a(new net.minecraft.network.play.server.SPacketEntityProperties(p_187242_1_.func_145782_y(), watchedAttribs));
 +        net.minecraftforge.fml.common.FMLCommonHandler.instance().firePlayerChangedDimensionEvent(p_187242_1_, i, p_187242_2_);
      }
  
@@ -209,7 +213,7 @@
          {
              d0 = MathHelper.func_151237_a(d0 / 8.0D, p_82448_4_.func_175723_af().func_177726_b() + 16.0D, p_82448_4_.func_175723_af().func_177728_d() - 16.0D);
              d1 = MathHelper.func_151237_a(d1 / 8.0D, p_82448_4_.func_175723_af().func_177736_c() + 16.0D, p_82448_4_.func_175723_af().func_177733_e() - 16.0D);
-@@ -597,7 +666,7 @@
+@@ -597,7 +670,7 @@
                  p_82448_3_.func_72866_a(p_82448_1_, false);
              }
          }
@@ -218,7 +222,7 @@
          {
              d0 = MathHelper.func_151237_a(d0 * 8.0D, p_82448_4_.func_175723_af().func_177726_b() + 16.0D, p_82448_4_.func_175723_af().func_177728_d() - 16.0D);
              d1 = MathHelper.func_151237_a(d1 * 8.0D, p_82448_4_.func_175723_af().func_177736_c() + 16.0D, p_82448_4_.func_175723_af().func_177733_e() - 16.0D);
-@@ -608,7 +677,7 @@
+@@ -608,7 +681,7 @@
                  p_82448_3_.func_72866_a(p_82448_1_, false);
              }
          }
@@ -227,7 +231,7 @@
          {
              BlockPos blockpos;
  
-@@ -634,7 +703,7 @@
+@@ -634,7 +707,7 @@
  
          p_82448_3_.field_72984_F.func_76319_b();
  
@@ -236,7 +240,7 @@
          {
              p_82448_3_.field_72984_F.func_76320_a("placing");
              d0 = (double)MathHelper.func_76125_a((int)d0, -29999872, 29999872);
-@@ -643,7 +712,8 @@
+@@ -643,7 +716,8 @@
              if (p_82448_1_.func_70089_S())
              {
                  p_82448_1_.func_70012_b(d0, p_82448_1_.field_70163_u, d1, p_82448_1_.field_70177_z, p_82448_1_.field_70125_A);


### PR DESCRIPTION
This is a better version #4265 that avoids the problem shown in #4824.

## The original bug (MC-88179)
The original bug is that whenever the client receives a respawn packet (any dimension change, death, etc.), the client player is copied without any of its attribute modifiers. So if the respawn was a non-death teleportation, the client player would temporarily lose all of its attribute modifiers until the next time the server resynced them.

## Attempted fix in #4265 
I attempted to fix this by changing the client player copying code to always retain attributes. This appeared to fix MC-88179, but also caused #4824, because the same code path is run in the client when respawning from a death, where the player *should* lose all their attribute modifiers.

## Revised fix
I revise this fix by moving it to the serverside, because it's impossible for the client to know if a respawn packet it gets is due to a teleportation or death. I simply add a patch for non-death respawns to resend all attributes and attribute modifiers after the respawn. This avoids #4824 while still fixing MC-88179. Another benefit is this will also fix the issue for vanilla clients connecting to forge servers, whereas the previous fix required a forge client.