### PR TITLE
Modified skylight areacheck fix

### DIFF
--- a/patches/minecraft/net/minecraft/world/chunk/Chunk.java.patch
+++ b/patches/minecraft/net/minecraft/world/chunk/Chunk.java.patch
@@ -291,6 +291,15 @@
                              {
                                  this.field_76637_e.func_175664_x(blockpos2);
                              }
+@@ -1271,7 +1291,7 @@
+ 
+         if (this.field_76637_e.field_73011_w.func_191066_m())
+         {
+-            if (this.field_76637_e.func_175707_a(blockpos.func_177982_a(-1, 0, -1), blockpos.func_177982_a(16, this.field_76637_e.func_181545_F(), 16)))
++            if (this.field_76637_e.func_175707_a(blockpos.func_177982_a(-17, 0, -17), blockpos.func_177982_a(32, this.field_76637_e.func_181545_F(), 32))) // FORGE: require 5x5 loaded chunks (issue #4723)
+             {
+                 label44:
+ 
 @@ -1381,7 +1401,7 @@
          {
              blockpos$mutableblockpos.func_181079_c(blockpos$mutableblockpos.func_177958_n(), l, blockpos$mutableblockpos.func_177952_p());

--- a/patches/minecraft/net/minecraft/world/chunk/Chunk.java.patch
+++ b/patches/minecraft/net/minecraft/world/chunk/Chunk.java.patch
@@ -296,7 +296,7 @@
          if (this.field_76637_e.field_73011_w.func_191066_m())
          {
 -            if (this.field_76637_e.func_175707_a(blockpos.func_177982_a(-1, 0, -1), blockpos.func_177982_a(16, this.field_76637_e.func_181545_F(), 16)))
-+            if (this.field_76637_e.func_175707_a(blockpos.func_177982_a(-17, 0, -17), blockpos.func_177982_a(32, this.field_76637_e.func_181545_F(), 32))) // FORGE: require 5x5 loaded chunks (issue #4723)
++            if (net.minecraftforge.common.ForgeModContainer.loadLargerAreaBeforeLighting ? this.field_76637_e.func_175707_a(blockpos.func_177982_a(-17, 0, -17), blockpos.func_177982_a(32, this.field_76637_e.func_181545_F(), 32)) : this.field_76637_e.func_175707_a(blockpos.func_177982_a(-1, 0, -1), blockpos.func_177982_a(16, this.field_76637_e.func_181545_F(), 16))) // FORGE: require 5x5 loaded chunks (issue #4723)
              {
                  label44:
  

--- a/src/main/java/net/minecraftforge/common/ForgeModContainer.java
+++ b/src/main/java/net/minecraftforge/common/ForgeModContainer.java
@@ -111,7 +111,8 @@ public class ForgeModContainer extends DummyModContainer implements WorldAccessC
     public static float zombieBabyChance = 0.05f;
     public static boolean shouldSortRecipies = true;
     public static boolean disableVersionCheck = false;
-    public static boolean forgeLightPipelineEnabled = true;
+    public static boolean forgeLightPipelineEnabled = true; // Optimized client lighting
+    public static boolean loadLargerAreaBeforeLighting = false; // Fixes both-sided lighting issues
     @Deprecated // TODO remove in 1.13
     public static boolean replaceVanillaBucketModel = true;
     public static boolean zoomInMissingModelTextInGui = false;
@@ -305,6 +306,12 @@ public class ForgeModContainer extends DummyModContainer implements WorldAccessC
                         "This can be useful when rapidly loading and unloading dimensions, like e.g. throwing items through a nether portal a few time per second.");
         dimensionUnloadQueueDelay = prop.getInt(0);
         prop.setLanguageKey("forge.configgui.dimensionUnloadQueueDelay");
+        propOrder.add(prop.getName());
+
+        prop = config.get(Configuration.CATEGORY_GENERAL, "loadLargerAreaBeforeLighting", false,
+                "Requires 5x5 chunks to be loaded instead of 3x3 before starting skylight initialization.");
+        loadLargerAreaBeforeLighting = prop.getBoolean(false);
+        prop.setLanguageKey("forge.configgui.loadLargerAreaBeforeLighting");
         propOrder.add(prop.getName());
 
         config.setCategoryPropertyOrder(CATEGORY_GENERAL, propOrder);


### PR DESCRIPTION
This PR is a modification to PR #4729, which fixes #4723. This makes the requirement of chunks loaded the same before this PR, until the user enables the fix in config. Enabling the fix increases the requirement of chunks to be loaded to be 5x5 instead of 3x3. 

From @sfPlayer1 in original PR:

>This fixes the linked issue.
>
>With the change applied Twilight Forest snaps right back to 20 TPS with 10 ms tick time after the initial lag spike instead of spending over 30 minutes at less than 10 TPS.
>
>There should be no user observable behavior changes besides better performance, none were observed during testing.