### PR TITLE
Allow skylight areacheck to be configurable by world providers

### DIFF
--- a/patches/minecraft/net/minecraft/world/WorldProvider.java.patch
+++ b/patches/minecraft/net/minecraft/world/WorldProvider.java.patch
@@ -256,6 +256,16 @@
 +        return null;
 +    }
 +
++    /**
++     * Called from {@link net.minecraft.world.chunk.Chunk#checkLight()}, to get additional blocks in radius for checking.
++     * Confused? See issue MinecraftForge#4723
++     * @return Additional amount of chunks by amount of blocks required before checking light. Should be in increments of 16.
++     */
++    public int additionalBlocksForLightCheck()
++    {
++        return 0;
++    }
++
 +    /*======================================= Start Moved From World =========================================*/
 +
 +    public Biome getBiomeForCoords(BlockPos pos)

--- a/patches/minecraft/net/minecraft/world/chunk/Chunk.java.patch
+++ b/patches/minecraft/net/minecraft/world/chunk/Chunk.java.patch
@@ -291,16 +291,17 @@
                              {
                                  this.field_76637_e.func_175664_x(blockpos2);
                              }
-@@ -1271,7 +1291,7 @@
+@@ -1271,7 +1291,8 @@
  
          if (this.field_76637_e.field_73011_w.func_191066_m())
          {
 -            if (this.field_76637_e.func_175707_a(blockpos.func_177982_a(-1, 0, -1), blockpos.func_177982_a(16, this.field_76637_e.func_181545_F(), 16)))
-+            if (this.field_76637_e.func_175707_a(blockpos.func_177982_a(-17, 0, -17), blockpos.func_177982_a(32, this.field_76637_e.func_181545_F(), 32))) // FORGE: require 5x5 loaded chunks (issue #4723)
++            int chunkRange = this.field_76637_e.field_73011_w.additionalBlocksForLightCheck(); // Leaves the option for resolution of issue #4723 up to World Providers
++            if (this.field_76637_e.func_175707_a(blockpos.func_177982_a(-1 - chunkRange, 0, -1 - chunkRange), blockpos.func_177982_a(16 + chunkRange, this.field_76637_e.func_181545_F(), 16 + chunkRange)))
              {
                  label44:
  
-@@ -1381,7 +1401,7 @@
+@@ -1381,7 +1402,7 @@
          {
              blockpos$mutableblockpos.func_181079_c(blockpos$mutableblockpos.func_177958_n(), l, blockpos$mutableblockpos.func_177952_p());
  
@@ -309,7 +310,7 @@
              {
                  this.field_76637_e.func_175664_x(blockpos$mutableblockpos);
              }
-@@ -1420,6 +1440,7 @@
+@@ -1420,6 +1441,7 @@
          else
          {
              System.arraycopy(p_177420_1_, 0, this.field_76634_f, 0, this.field_76634_f.length);
@@ -317,7 +318,7 @@
          }
      }
  
-@@ -1489,4 +1510,52 @@
+@@ -1489,4 +1511,52 @@
          QUEUED,
          CHECK;
      }

--- a/patches/minecraft/net/minecraft/world/chunk/Chunk.java.patch
+++ b/patches/minecraft/net/minecraft/world/chunk/Chunk.java.patch
@@ -291,6 +291,15 @@
                              {
                                  this.field_76637_e.func_175664_x(blockpos2);
                              }
+@@ -1271,7 +1291,7 @@
+ 
+         if (this.field_76637_e.field_73011_w.func_191066_m())
+         {
+-            if (this.field_76637_e.func_175707_a(blockpos.func_177982_a(-1, 0, -1), blockpos.func_177982_a(16, this.field_76637_e.func_181545_F(), 16)))
++            if (this.field_76637_e.func_175707_a(blockpos.func_177982_a(-17, 0, -17), blockpos.func_177982_a(32, this.field_76637_e.func_181545_F(), 32))) // FORGE: require 5x5 loaded chunks (issue #4723)
+             {
+                 label44:
+ 
 @@ -1381,7 +1401,7 @@
          {
              blockpos$mutableblockpos.func_181079_c(blockpos$mutableblockpos.func_177958_n(), l, blockpos$mutableblockpos.func_177952_p());


### PR DESCRIPTION
This PR is a modification to PR #4729, which addresses #4723. This delegates the chunk-loading radius requirement to WorldProviders, which in turn will allow them to modify it if they wish to do so.

From @sfPlayer1 in original PR:

>This fixes the linked issue.
>
>With the change applied Twilight Forest snaps right back to 20 TPS with 10 ms tick time after the initial lag spike instead of spending over 30 minutes at less than 10 TPS.
>
>There should be no user observable behavior changes besides better performance, none were observed during testing.