### PR TITLE
Change objectholders to be applied immediately after firing registry events

### DIFF
--- a/src/main/java/net/minecraftforge/fml/common/Loader.java
+++ b/src/main/java/net/minecraftforge/fml/common/Loader.java
@@ -603,7 +603,6 @@ public class Loader
         modController.checkErrors();
         GameData.fireRegistryEvents(rl -> !rl.equals(GameData.RECIPES));
         FMLCommonHandler.instance().fireSidedRegistryEvents();
-        ObjectHolderRegistry.INSTANCE.applyObjectHolders();
         ItemStackHolderInjector.INSTANCE.inject();
         modController.transition(LoaderState.INITIALIZATION, false);
         progressBar.step("Initializing Minecraft Engine");

--- a/src/main/java/net/minecraftforge/registries/ForgeRegistry.java
+++ b/src/main/java/net/minecraftforge/registries/ForgeRegistry.java
@@ -78,12 +78,14 @@ public class ForgeRegistry<V extends IForgeRegistryEntry<V>> implements IForgeRe
     private final int max;
     private final boolean allowOverrides;
     private final boolean isModifiable;
+    public final ResourceLocation registryName;
 
     private V defaultValue = null;
     boolean isFrozen = false;
 
-    ForgeRegistry(Class<V> superType, ResourceLocation defaultKey, int min, int max, @Nullable CreateCallback<V> create, @Nullable AddCallback<V> add, @Nullable ClearCallback<V> clear, RegistryManager stage, boolean allowOverrides, boolean isModifiable, @Nullable DummyFactory<V> dummyFactory, @Nullable MissingFactory<V> missing)
+    ForgeRegistry(ResourceLocation registryName, Class<V> superType, ResourceLocation defaultKey, int min, int max, @Nullable CreateCallback<V> create, @Nullable AddCallback<V> add, @Nullable ClearCallback<V> clear, RegistryManager stage, boolean allowOverrides, boolean isModifiable, @Nullable DummyFactory<V> dummyFactory, @Nullable MissingFactory<V> missing)
     {
+        this.registryName = registryName;
         this.stage = stage;
         this.superType = superType;
         this.defaultKey = defaultKey;
@@ -265,7 +267,7 @@ public class ForgeRegistry<V extends IForgeRegistryEntry<V>> implements IForgeRe
 
     ForgeRegistry<V> copy(RegistryManager stage)
     {
-        return new ForgeRegistry<V>(superType, defaultKey, min, max, create, add, clear, stage, allowOverrides, isModifiable, dummyFactory, missing);
+        return new ForgeRegistry<V>(registryName, superType, defaultKey, min, max, create, add, clear, stage, allowOverrides, isModifiable, dummyFactory, missing);
     }
 
     int add(int id, V value)

--- a/src/main/java/net/minecraftforge/registries/GameData.java
+++ b/src/main/java/net/minecraftforge/registries/GameData.java
@@ -731,21 +731,23 @@ public class GameData
 
         if (filter.test(BLOCKS))
         {
-            MinecraftForge.EVENT_BUS.post(RegistryManager.ACTIVE.getRegistry(BLOCKS).getRegisterEvent(BLOCKS));
-            ObjectHolderRegistry.INSTANCE.applyObjectHolders(); // inject any blocks
+            ForgeRegistry<Block> registry = RegistryManager.ACTIVE.getRegistry(BLOCKS);
+            MinecraftForge.EVENT_BUS.post(registry.getRegisterEvent(BLOCKS));
+            ObjectHolderRegistry.INSTANCE.applyObjectHolderFor(registry.registryName); // inject any blocks
         }
         if (filter.test(ITEMS))
         {
-            MinecraftForge.EVENT_BUS.post(RegistryManager.ACTIVE.getRegistry(ITEMS).getRegisterEvent(ITEMS));
-            ObjectHolderRegistry.INSTANCE.applyObjectHolders(); // inject any items
+            ForgeRegistry<Item> registry = RegistryManager.ACTIVE.getRegistry(ITEMS);
+            MinecraftForge.EVENT_BUS.post(registry.getRegisterEvent(ITEMS));
+            ObjectHolderRegistry.INSTANCE.applyObjectHolderFor(registry.registryName); // inject any items
         }
         for (ResourceLocation rl : keys)
         {
             if (!filter.test(rl)) continue;
             if (rl == BLOCKS || rl == ITEMS) continue;
             MinecraftForge.EVENT_BUS.post(RegistryManager.ACTIVE.getRegistry(rl).getRegisterEvent(rl));
+            ObjectHolderRegistry.INSTANCE.applyObjectHolderFor(rl);
         }
-        ObjectHolderRegistry.INSTANCE.applyObjectHolders(); // inject everything else
 
 
         /*

--- a/src/main/java/net/minecraftforge/registries/ObjectHolderRef.java
+++ b/src/main/java/net/minecraftforge/registries/ObjectHolderRef.java
@@ -43,7 +43,7 @@ class ObjectHolderRef
     private Field field;
     private ResourceLocation injectedObject;
     private boolean isValid;
-    private ForgeRegistry<?> registry;
+    ForgeRegistry<?> registry;
 
     @SuppressWarnings("unchecked")
     ObjectHolderRef(Field field, ResourceLocation injectedObject, boolean extractFromExistingValues)

--- a/src/main/java/net/minecraftforge/registries/RegistryManager.java
+++ b/src/main/java/net/minecraftforge/registries/RegistryManager.java
@@ -87,7 +87,7 @@ public class RegistryManager
             FMLLog.log.error("Found existing registry of type {} named {}, you cannot create a new registry ({}) with type {}, as {} has a parent of that type", foundType, superTypes.get(foundType), name, type, type);
             throw new IllegalArgumentException("Duplicate registry parent type found - you can only have one registry for a particular super type");
         }
-        ForgeRegistry<V> reg = new ForgeRegistry<V>(type, defaultKey, min, max, create, add, clear, this, allowOverrides, isModifiable, dummyFactory, missing);
+        ForgeRegistry<V> reg = new ForgeRegistry<V>(name, type, defaultKey, min, max, create, add, clear, this, allowOverrides, isModifiable, dummyFactory, missing);
         registries.put(name, reg);
         superTypes.put(type, name);
         if (persisted)


### PR DESCRIPTION
It is now possible to use an objectholders other than items/blocks in other registry events.
This was confusing some people (including me), and now it is consistent with the rest of the registries,

Objectholders now get applied after each register event, and only the objectholders for these fields will be applied.

Special casing for blocks and items is still present as they should be the first registires that are fired.