### PR TITLE
[1.13] Entity registry changes

### DIFF
--- a/src/main/java/net/minecraftforge/fml/common/network/internal/EntitySpawnHandler.java
+++ b/src/main/java/net/minecraftforge/fml/common/network/internal/EntitySpawnHandler.java
@@ -41,6 +41,8 @@ import net.minecraftforge.fml.common.registry.IEntityAdditionalSpawnData;
 import net.minecraftforge.fml.common.registry.IThrowableEntity;
 import net.minecraftforge.fml.common.registry.EntityRegistry.EntityRegistration;
 
+import java.util.function.Function;
+
 public class EntitySpawnHandler extends SimpleChannelInboundHandler<FMLMessage.EntityMessage> {
     @Override
     protected void channelRead0(ChannelHandlerContext ctx, final EntityMessage msg) throws Exception
@@ -76,7 +78,7 @@ public class EntitySpawnHandler extends SimpleChannelInboundHandler<FMLMessage.E
                     " at ( " + spawnMsg.rawX + "," + spawnMsg.rawY + ", " + spawnMsg.rawZ + ") Please contact mod author or server admin.");
         }
         WorldClient wc = FMLClientHandler.instance().getWorldClient();
-        Class<? extends Entity> cls = er.getEntityClass();
+        Function<World, ? extends Entity> factory = er.getEntityFactory();
         try
         {
             Entity entity;
@@ -85,7 +87,7 @@ public class EntitySpawnHandler extends SimpleChannelInboundHandler<FMLMessage.E
                 entity = er.doCustomSpawning(spawnMsg);
             } else
             {
-                entity = cls.getConstructor(World.class).newInstance(wc);
+                entity = factory.apply(wc);
 
                 int offset = spawnMsg.entityId - entity.getEntityId();
                 entity.setEntityId(spawnMsg.entityId);

--- a/src/main/java/net/minecraftforge/fml/common/registry/EntityEntry.java
+++ b/src/main/java/net/minecraftforge/fml/common/registry/EntityEntry.java
@@ -41,14 +41,12 @@ public class EntityEntry extends Impl<EntityEntry>
     }
 
     //Protected method, to make this optional, in case people subclass this to have a better factory.
+    /**
+     * @deprecated to be removed with 1.13
+     */
+    @Deprecated
     protected void init()
     {
-        this.factory = new EntityEntryBuilder.ConstructorFactory<Entity>(this.cls) {
-            @Override
-            protected String describeEntity() {
-                return String.valueOf(EntityEntry.this.getRegistryName());
-            }
-        };
     }
 
     public Class<? extends Entity> getEntityClass(){ return this.cls; }
@@ -64,6 +62,10 @@ public class EntityEntry extends Impl<EntityEntry>
 
     public Entity newInstance(World world)
     {
+        if (this.factory == null)
+        {
+            this.factory = new EntityEntryBuilder.ConstructorFactory<>(this.cls, String.valueOf(this.getRegistryName()));
+        }
         return this.factory.apply(world);
     }
 }

--- a/src/main/java/net/minecraftforge/fml/common/registry/EntityRegistry.java
+++ b/src/main/java/net/minecraftforge/fml/common/registry/EntityRegistry.java
@@ -21,6 +21,8 @@ package net.minecraftforge.fml.common.registry;
 
 import java.util.Iterator;
 import java.util.List;
+
+import net.minecraft.world.World;
 import org.apache.logging.log4j.Level;
 
 import net.minecraft.entity.Entity;
@@ -48,6 +50,7 @@ public class EntityRegistry
 {
     public class EntityRegistration
     {
+        private Function<World, ? extends Entity> entityFactory;
         private Class<? extends Entity> entityClass;
         private ModContainer container;
         private ResourceLocation regName;
@@ -60,9 +63,14 @@ public class EntityRegistry
         private boolean usesVanillaSpawning;
         public EntityRegistration(ModContainer mc, ResourceLocation registryName, Class<? extends Entity> entityClass, String entityName, int id, int trackingRange, int updateFrequency, boolean sendsVelocityUpdates)
         {
+            this(mc, registryName, entityClass, new EntityEntryBuilder.ConstructorFactory<>(entityClass, registryName.toString()), entityName, id, trackingRange, updateFrequency, sendsVelocityUpdates);
+        }
+        public EntityRegistration(ModContainer mc, ResourceLocation registryName, Class<? extends Entity> entityClass, Function<World, ? extends Entity> entityFactory, String entityName, int id, int trackingRange, int updateFrequency, boolean sendsVelocityUpdates)
+        {
             this.container = mc;
             this.regName = registryName;
             this.entityClass = entityClass;
+            this.entityFactory = entityFactory;
             this.entityName = entityName;
             this.modId = id;
             this.trackingRange = trackingRange;
@@ -72,6 +80,10 @@ public class EntityRegistry
         public ResourceLocation getRegistryName()
         {
             return regName;
+        }
+        public Function<World, ? extends Entity> getEntityFactory()
+        {
+            return this.entityFactory;
         }
         public Class<? extends Entity> getEntityClass()
         {
@@ -101,19 +113,34 @@ public class EntityRegistry
         {
             return sendsVelocityUpdates;
         }
-
+        /**
+         * @deprecated to be removed with 1.13
+         */
+        @Deprecated
         public boolean usesVanillaSpawning()
         {
             return usesVanillaSpawning;
         }
+        /**
+         * @deprecated to be removed with 1.13
+         */
+        @Deprecated
         public boolean hasCustomSpawning()
         {
             return customSpawnCallback != null;
         }
+        /**
+         * @deprecated to be removed with 1.13
+         */
+        @Deprecated
         public Entity doCustomSpawning(EntitySpawnMessage spawnMsg) throws Exception
         {
             return customSpawnCallback.apply(spawnMsg);
         }
+        /**
+         * @deprecated to be removed with 1.13
+         */
+        @Deprecated
         public void setCustomSpawning(Function<EntitySpawnMessage, Entity> callable, boolean usesVanillaSpawning)
         {
             this.customSpawnCallback = callable;


### PR DESCRIPTION
fixes #4845 

Some methods in `EntityRegistration` have been deprecated - they aren't usable, as the fields in the packet aren't accessible.