### PR TITLE
Add custom Elytra support

### DIFF
--- a/jsons/1.12.2.json
+++ b/jsons/1.12.2.json
@@ -719,6 +719,6 @@
     "minecraftArguments": "--username ${auth_player_name} --version ${version_name} --gameDir ${game_directory} --assetsDir ${assets_root} --assetIndex ${assets_index_name} --uuid ${auth_uuid} --accessToken ${auth_access_token} --userType ${user_type} --versionType ${version_type}",
     "minimumLauncherVersion": 18,
     "releaseTime": "2017-09-18T08:39:46+00:00",
-    "time": "2018-04-02T07:39:26+00:00",
+    "time": "2018-02-15T16:26:45+00:00",
     "type": "release"
 }

--- a/jsons/1.12.2.json
+++ b/jsons/1.12.2.json
@@ -1,10 +1,10 @@
 {
     "assetIndex": {
         "id": "1.12",
-        "sha1": "98c430c16a705f18a58a281b27caabf3ef09d40d",
-        "size": 169253,
-        "url": "https://launchermeta.mojang.com/mc/assets/1.12/98c430c16a705f18a58a281b27caabf3ef09d40d/1.12.json",
-        "totalSize": 127453671
+        "sha1": "e75e9535754c6f2158b0b18b35660f45c4495d78",
+        "size": 169257,
+        "url": "https://launchermeta.mojang.com/mc/assets/1.12/e75e9535754c6f2158b0b18b35660f45c4495d78/1.12.json",
+        "totalSize": 127722338
     },
     "assets": "1.12",
     "downloads": {
@@ -719,6 +719,6 @@
     "minecraftArguments": "--username ${auth_player_name} --version ${version_name} --gameDir ${game_directory} --assetsDir ${assets_root} --assetIndex ${assets_index_name} --uuid ${auth_uuid} --accessToken ${auth_access_token} --userType ${user_type} --versionType ${version_type}",
     "minimumLauncherVersion": 18,
     "releaseTime": "2017-09-18T08:39:46+00:00",
-    "time": "2018-02-15T16:26:45+00:00",
+    "time": "2018-04-02T07:39:26+00:00",
     "type": "release"
 }

--- a/jsons/1.12.2.json
+++ b/jsons/1.12.2.json
@@ -719,6 +719,6 @@
     "minecraftArguments": "--username ${auth_player_name} --version ${version_name} --gameDir ${game_directory} --assetsDir ${assets_root} --assetIndex ${assets_index_name} --uuid ${auth_uuid} --accessToken ${auth_access_token} --userType ${user_type} --versionType ${version_type}",
     "minimumLauncherVersion": 18,
     "releaseTime": "2017-09-18T08:39:46+00:00",
-    "time": "2018-02-15T16:26:45+00:00",
+    "time": "2018-04-02T07:39:26+00:00",
     "type": "release"
 }

--- a/patches/minecraft/net/minecraft/client/entity/EntityPlayerSP.java.patch
+++ b/patches/minecraft/net/minecraft/client/entity/EntityPlayerSP.java.patch
@@ -111,3 +111,12 @@
          boolean flag4 = (float)this.func_71024_bL().func_75116_a() > 6.0F || this.field_71075_bZ.field_75101_c;
  
          if (this.field_70122_E && !flag1 && !flag2 && this.field_71158_b.field_192832_b >= 0.8F && !this.func_70051_ag() && flag4 && !this.func_184587_cr() && !this.func_70644_a(MobEffects.field_76440_q))
+@@ -916,7 +941,7 @@
+         {
+             ItemStack itemstack = this.func_184582_a(EntityEquipmentSlot.CHEST);
+ 
+-            if (itemstack.func_77973_b() == Items.field_185160_cR && ItemElytra.func_185069_d(itemstack))
++            if ((itemstack.func_77973_b() == Items.field_185160_cR && ItemElytra.func_185069_d(itemstack)) || itemstack.func_77973_b() instanceof net.minecraftforge.items.IElytra)
+             {
+                 this.field_71174_a.func_147297_a(new CPacketEntityAction(this, CPacketEntityAction.Action.START_FALL_FLYING));
+             }

--- a/patches/minecraft/net/minecraft/entity/EntityLiving.java.patch
+++ b/patches/minecraft/net/minecraft/entity/EntityLiving.java.patch
@@ -61,7 +61,7 @@
                  return ((ItemArmor)p_184640_0_.func_77973_b()).field_77881_a;
              }
 -            else if (p_184640_0_.func_77973_b() == Items.field_185160_cR)
-+            else if (p_184640_0_.func_77973_b() == Items.field_185160_cR || p_184640_0_.func_77973_b() instanceof net.minecraftforge.items.IElytra)
++            else if (p_184640_0_.func_77973_b() instanceof net.minecraftforge.items.IElytra)
              {
                  return EntityEquipmentSlot.CHEST;
              }

--- a/patches/minecraft/net/minecraft/entity/EntityLiving.java.patch
+++ b/patches/minecraft/net/minecraft/entity/EntityLiving.java.patch
@@ -48,7 +48,7 @@
      public float func_70603_bj()
      {
          return 1.0F;
-@@ -991,6 +1003,8 @@
+@@ -991,19 +1003,21 @@
  
      public static EntityEquipmentSlot func_184640_d(ItemStack p_184640_0_)
      {
@@ -57,7 +57,13 @@
          if (p_184640_0_.func_77973_b() != Item.func_150898_a(Blocks.field_150423_aK) && p_184640_0_.func_77973_b() != Items.field_151144_bL)
          {
              if (p_184640_0_.func_77973_b() instanceof ItemArmor)
-@@ -1003,7 +1017,7 @@
+             {
+                 return ((ItemArmor)p_184640_0_.func_77973_b()).field_77881_a;
+             }
+-            else if (p_184640_0_.func_77973_b() == Items.field_185160_cR)
++            else if (p_184640_0_.func_77973_b() == Items.field_185160_cR || p_184640_0_.func_77973_b() instanceof net.minecraftforge.items.IElytra)
+             {
+                 return EntityEquipmentSlot.CHEST;
              }
              else
              {

--- a/patches/minecraft/net/minecraft/entity/EntityLivingBase.java.patch
+++ b/patches/minecraft/net/minecraft/entity/EntityLivingBase.java.patch
@@ -1,6 +1,14 @@
 --- ../src-base/minecraft/net/minecraft/entity/EntityLivingBase.java
 +++ ../src-work/minecraft/net/minecraft/entity/EntityLivingBase.java
-@@ -201,10 +201,11 @@
+@@ -74,6 +74,7 @@
+ import net.minecraft.world.WorldServer;
+ import net.minecraftforge.fml.relauncher.Side;
+ import net.minecraftforge.fml.relauncher.SideOnly;
++
+ import org.apache.logging.log4j.LogManager;
+ import org.apache.logging.log4j.Logger;
+ 
+@@ -201,10 +202,11 @@
          {
              float f = (float)MathHelper.func_76123_f(this.field_70143_R - 3.0F);
  
@@ -13,7 +21,7 @@
                  ((WorldServer)this.field_70170_p).func_175739_a(EnumParticleTypes.BLOCK_DUST, this.field_70165_t, this.field_70163_u, this.field_70161_v, i, 0.0D, 0.0D, 0.0D, 0.15000000596046448D, Block.func_176210_f(p_184231_4_));
              }
          }
-@@ -281,7 +282,7 @@
+@@ -281,7 +283,7 @@
                      }
                  }
  
@@ -22,7 +30,7 @@
                  {
                      this.func_184210_p();
                  }
-@@ -380,7 +381,7 @@
+@@ -380,7 +382,7 @@
              if (!this.field_70170_p.field_72995_K && (this.func_70684_aJ() || this.field_70718_bc > 0 && this.func_146066_aG() && this.field_70170_p.func_82736_K().func_82766_b("doMobLoot")))
              {
                  int i = this.func_70693_a(this.field_70717_bb);
@@ -31,7 +39,7 @@
                  while (i > 0)
                  {
                      int j = EntityXPOrb.func_70527_a(i);
-@@ -442,6 +443,7 @@
+@@ -442,6 +444,7 @@
      {
          this.field_70755_b = p_70604_1_;
          this.field_70756_c = this.field_70173_aa;
@@ -39,7 +47,16 @@
      }
  
      public EntityLivingBase func_110144_aD()
-@@ -670,8 +672,10 @@
+@@ -484,7 +487,7 @@
+             {
+                 soundevent = ((ItemArmor)item).func_82812_d().func_185017_b();
+             }
+-            else if (item == Items.field_185160_cR)
++            else if (item == Items.field_185160_cR || item instanceof net.minecraftforge.items.IElytra)
+             {
+                 soundevent = SoundEvents.field_191258_p;
+             }
+@@ -670,8 +673,10 @@
          else
          {
              Collection<PotionEffect> collection = this.field_70713_bf.values();
@@ -52,7 +69,7 @@
              this.func_82142_c(this.func_70644_a(MobEffects.field_76441_p));
          }
      }
-@@ -819,6 +823,8 @@
+@@ -819,6 +824,8 @@
  
      public void func_70691_i(float p_70691_1_)
      {
@@ -61,7 +78,7 @@
          float f = this.func_110143_aJ();
  
          if (f > 0.0F)
-@@ -839,6 +845,7 @@
+@@ -839,6 +846,7 @@
  
      public boolean func_70097_a(DamageSource p_70097_1_, float p_70097_2_)
      {
@@ -69,7 +86,7 @@
          if (this.func_180431_b(p_70097_1_))
          {
              return false;
-@@ -927,9 +934,9 @@
+@@ -927,9 +935,9 @@
                          this.field_70718_bc = 100;
                          this.field_70717_bb = (EntityPlayer)entity1;
                      }
@@ -81,7 +98,7 @@
  
                          if (entitywolf.func_70909_n())
                          {
-@@ -1127,7 +1134,7 @@
+@@ -1127,7 +1135,7 @@
  
      public void func_70669_a(ItemStack p_70669_1_)
      {
@@ -90,7 +107,7 @@
  
          for (int i = 0; i < 5; ++i)
          {
-@@ -1139,12 +1146,17 @@
+@@ -1139,12 +1147,17 @@
              vec3d1 = vec3d1.func_178789_a(-this.field_70125_A * 0.017453292F);
              vec3d1 = vec3d1.func_178785_b(-this.field_70177_z * 0.017453292F);
              vec3d1 = vec3d1.func_72441_c(this.field_70165_t, this.field_70163_u + (double)this.func_70047_e(), this.field_70161_v);
@@ -109,7 +126,7 @@
          if (!this.field_70729_aU)
          {
              Entity entity = p_70645_1_.func_76346_g();
-@@ -1165,18 +1177,26 @@
+@@ -1165,18 +1178,26 @@
  
              if (!this.field_70170_p.field_72995_K)
              {
@@ -141,7 +158,7 @@
              }
  
              this.field_70170_p.func_72960_a(this, (byte)3);
-@@ -1195,6 +1215,9 @@
+@@ -1195,6 +1216,9 @@
  
      public void func_70653_a(Entity p_70653_1_, float p_70653_2_, double p_70653_3_, double p_70653_5_)
      {
@@ -151,7 +168,7 @@
          if (this.field_70146_Z.nextDouble() >= this.func_110148_a(SharedMonsterAttributes.field_111266_c).func_111126_e())
          {
              this.field_70160_al = true;
-@@ -1253,15 +1276,7 @@
+@@ -1253,15 +1277,7 @@
              BlockPos blockpos = new BlockPos(i, j, k);
              IBlockState iblockstate = this.field_70170_p.func_180495_p(blockpos);
              Block block = iblockstate.func_177230_c();
@@ -168,7 +185,7 @@
          }
      }
  
-@@ -1287,6 +1302,9 @@
+@@ -1287,6 +1303,9 @@
  
      public void func_180430_e(float p_180430_1_, float p_180430_2_)
      {
@@ -178,7 +195,7 @@
          super.func_180430_e(p_180430_1_, p_180430_2_);
          PotionEffect potioneffect = this.func_70660_b(MobEffects.field_76430_j);
          float f = potioneffect == null ? 0.0F : (float)(potioneffect.func_76458_c() + 1);
-@@ -1303,7 +1321,7 @@
+@@ -1303,7 +1322,7 @@
  
              if (iblockstate.func_185904_a() != Material.field_151579_a)
              {
@@ -187,7 +204,7 @@
                  this.func_184185_a(soundtype.func_185842_g(), soundtype.func_185843_a() * 0.5F, soundtype.func_185847_b() * 0.75F);
              }
          }
-@@ -1380,17 +1398,20 @@
+@@ -1380,17 +1399,20 @@
      {
          if (!this.func_180431_b(p_70665_1_))
          {
@@ -209,7 +226,7 @@
                  this.func_110149_m(this.func_110139_bj() - p_70665_2_);
              }
          }
-@@ -1447,6 +1468,11 @@
+@@ -1447,6 +1469,11 @@
  
      public void func_184609_a(EnumHand p_184609_1_)
      {
@@ -221,7 +238,7 @@
          if (!this.field_82175_bq || this.field_110158_av >= this.func_82166_i() / 2 || this.field_110158_av < 0)
          {
              this.field_110158_av = -1;
-@@ -1694,7 +1720,7 @@
+@@ -1694,7 +1721,7 @@
  
                      if (!this.field_70170_p.func_184143_b(axisalignedbb1))
                      {
@@ -230,7 +247,7 @@
                          {
                              this.func_70634_a(d11, this.field_70163_u + 1.0D, d12);
                              return;
-@@ -1702,14 +1728,14 @@
+@@ -1702,14 +1729,14 @@
  
                          BlockPos blockpos = new BlockPos(d11, this.field_70163_u - 1.0D, d12);
  
@@ -247,7 +264,7 @@
                      {
                          d1 = d11;
                          d13 = this.field_70163_u + 2.0D;
-@@ -1781,6 +1807,7 @@
+@@ -1781,6 +1808,7 @@
          }
  
          this.field_70160_al = true;
@@ -255,7 +272,46 @@
      }
  
      protected void func_70629_bd()
-@@ -1874,7 +1901,8 @@
+@@ -1808,9 +1836,12 @@
+                 {
+                     if (this.func_184613_cA())
+                     {
++                    	ItemStack itemstack = this.func_184582_a(EntityEquipmentSlot.CHEST);
+                         if (this.field_70181_x > -0.5D)
+                         {
+-                            this.field_70143_R = 1.0F;
++                        	if((itemstack.func_77973_b() instanceof net.minecraftforge.items.IElytra && ((net.minecraftforge.items.IElytra) itemstack.func_77973_b()).doesSlowOnUpwardsFlight(itemstack, field_70170_p)) || itemstack.func_77973_b() == Items.field_185160_cR){
++                        		this.field_70143_R = 1.0F;
++                        	}
+                         }
+ 
+                         Vec3d vec3d = this.func_70040_Z();
+@@ -1847,6 +1878,12 @@
+                         this.field_70159_w *= 0.9900000095367432D;
+                         this.field_70181_x *= 0.9800000190734863D;
+                         this.field_70179_y *= 0.9900000095367432D;
++                        if(itemstack.func_77973_b() instanceof net.minecraftforge.items.IElytra && ((net.minecraftforge.items.IElytra) itemstack.func_77973_b()).getAccelerationMultiplier(itemstack, field_70170_p) != 1){
++                        	field_70159_w *= ((net.minecraftforge.items.IElytra) itemstack.func_77973_b()).getAccelerationMultiplier(itemstack, field_70170_p);
++                        	field_70181_x *= ((net.minecraftforge.items.IElytra) itemstack.func_77973_b()).getAccelerationMultiplier(itemstack, field_70170_p);
++                        	field_70179_y *= ((net.minecraftforge.items.IElytra) itemstack.func_77973_b()).getAccelerationMultiplier(itemstack, field_70170_p);
++                        }
++                        
+                         this.func_70091_d(MoverType.SELF, this.field_70159_w, this.field_70181_x, this.field_70179_y);
+ 
+                         if (this.field_70123_F && !this.field_70170_p.field_72995_K)
+@@ -1858,7 +1895,10 @@
+                             if (f5 > 0.0F)
+                             {
+                                 this.func_184185_a(this.func_184588_d((int)f5), 1.0F, 1.0F);
+-                                this.func_70097_a(DamageSource.field_188406_j, f5);
++                                if((itemstack.func_77973_b() instanceof net.minecraftforge.items.IElytra && ((net.minecraftforge.items.IElytra) itemstack.func_77973_b()).doesDamageUponHittingWall(itemstack, field_70170_p)) || itemstack.func_77973_b() == Items.field_185160_cR) {
++                                	this.func_70097_a(DamageSource.field_188406_j, f5);
++                                	if(itemstack.func_77973_b() instanceof net.minecraftforge.items.IElytra) ((net.minecraftforge.items.IElytra) itemstack.func_77973_b()).onHitWall(itemstack, field_70170_p, new BlockPos(field_70165_t, field_70163_u, field_70161_v));
++                                }
+                             }
+                         }
+ 
+@@ -1874,7 +1914,8 @@
  
                          if (this.field_70122_E)
                          {
@@ -265,7 +321,7 @@
                          }
  
                          float f7 = 0.16277136F / (f6 * f6 * f6);
-@@ -1894,7 +1922,8 @@
+@@ -1894,7 +1935,8 @@
  
                          if (this.field_70122_E)
                          {
@@ -275,7 +331,7 @@
                          }
  
                          if (this.func_70617_f_())
-@@ -2054,6 +2083,7 @@
+@@ -2054,6 +2096,7 @@
  
      public void func_70071_h_()
      {
@@ -283,7 +339,7 @@
          super.func_70071_h_();
          this.func_184608_ct();
  
-@@ -2096,7 +2126,9 @@
+@@ -2096,7 +2139,9 @@
  
                  if (!ItemStack.func_77989_b(itemstack1, itemstack))
                  {
@@ -293,7 +349,24 @@
  
                      if (!itemstack.func_190926_b())
                      {
-@@ -2575,6 +2607,40 @@
+@@ -2364,12 +2409,15 @@
+         {
+             ItemStack itemstack = this.func_184582_a(EntityEquipmentSlot.CHEST);
+ 
+-            if (itemstack.func_77973_b() == Items.field_185160_cR && ItemElytra.func_185069_d(itemstack))
++            if (itemstack.func_77973_b() == Items.field_185160_cR && ItemElytra.func_185069_d(itemstack) || (itemstack.func_77973_b() instanceof net.minecraftforge.items.IElytra && ((net.minecraftforge.items.IElytra) itemstack.func_77973_b()).checkFlight(itemstack, field_70170_p)))
+             {
+                 flag = true;
+ 
+                 if (!this.field_70170_p.field_72995_K && (this.field_184629_bo + 1) % 20 == 0)
+                 {
++                	if((itemstack.func_77973_b() instanceof net.minecraftforge.items.IElytra && ((net.minecraftforge.items.IElytra) itemstack.func_77973_b()).doesDamageWhileFlying(itemstack, field_70170_p)) || itemstack.func_77973_b() == Items.field_185160_cR){
++                		
++                	}
+                     itemstack.func_77972_a(1, this);
+                 }
+             }
+@@ -2575,6 +2623,40 @@
          this.field_70752_e = true;
      }
  
@@ -334,7 +407,7 @@
      public abstract EnumHandSide func_184591_cq();
  
      public boolean func_184587_cr()
-@@ -2595,12 +2661,19 @@
+@@ -2595,12 +2677,19 @@
  
              if (itemstack == this.field_184627_bm)
              {
@@ -355,7 +428,7 @@
                  {
                      this.func_71036_o();
                  }
-@@ -2618,8 +2691,10 @@
+@@ -2618,8 +2707,10 @@
  
          if (!itemstack.func_190926_b() && !this.func_184587_cr())
          {
@@ -367,7 +440,7 @@
  
              if (!this.field_70170_p.field_72995_K)
              {
-@@ -2700,7 +2775,9 @@
+@@ -2700,7 +2791,9 @@
          if (!this.field_184627_bm.func_190926_b() && this.func_184587_cr())
          {
              this.func_184584_a(this.field_184627_bm, 16);
@@ -378,7 +451,7 @@
              this.func_184602_cy();
          }
      }
-@@ -2724,7 +2801,8 @@
+@@ -2724,7 +2817,8 @@
      {
          if (!this.field_184627_bm.func_190926_b())
          {
@@ -388,7 +461,7 @@
          }
  
          this.func_184602_cy();
-@@ -2852,6 +2930,31 @@
+@@ -2852,6 +2946,31 @@
          return true;
      }
  

--- a/patches/minecraft/net/minecraft/entity/EntityLivingBase.java.patch
+++ b/patches/minecraft/net/minecraft/entity/EntityLivingBase.java.patch
@@ -52,7 +52,7 @@
                  soundevent = ((ItemArmor)item).func_82812_d().func_185017_b();
              }
 -            else if (item == Items.field_185160_cR)
-+            else if (item == Items.field_185160_cR || item instanceof net.minecraftforge.items.IElytra)
++            else if (item instanceof net.minecraftforge.items.IElytra)
              {
                  soundevent = SoundEvents.field_191258_p;
              }
@@ -280,38 +280,34 @@
                          if (this.field_70181_x > -0.5D)
                          {
 -                            this.field_70143_R = 1.0F;
-+                        	if((itemstack.func_77973_b() instanceof net.minecraftforge.items.IElytra && ((net.minecraftforge.items.IElytra) itemstack.func_77973_b()).doesSlowOnUpwardsFlight(itemstack, field_70170_p)) || itemstack.func_77973_b() == Items.field_185160_cR){
++                        	if((itemstack.func_77973_b() instanceof net.minecraftforge.items.IElytra && ((net.minecraftforge.items.IElytra) itemstack.func_77973_b()).doesSlowOnUpwardsFlight(itemstack, this)) || itemstack.func_77973_b() == Items.field_185160_cR){
 +                        		this.field_70143_R = 1.0F;
 +                        	}
                          }
  
                          Vec3d vec3d = this.func_70040_Z();
-@@ -1847,6 +1878,12 @@
+@@ -1847,6 +1878,8 @@
                          this.field_70159_w *= 0.9900000095367432D;
                          this.field_70181_x *= 0.9800000190734863D;
                          this.field_70179_y *= 0.9900000095367432D;
-+                        if(itemstack.func_77973_b() instanceof net.minecraftforge.items.IElytra && ((net.minecraftforge.items.IElytra) itemstack.func_77973_b()).getAccelerationMultiplier(itemstack, field_70170_p) != 1){
-+                        	field_70159_w *= ((net.minecraftforge.items.IElytra) itemstack.func_77973_b()).getAccelerationMultiplier(itemstack, field_70170_p);
-+                        	field_70181_x *= ((net.minecraftforge.items.IElytra) itemstack.func_77973_b()).getAccelerationMultiplier(itemstack, field_70170_p);
-+                        	field_70179_y *= ((net.minecraftforge.items.IElytra) itemstack.func_77973_b()).getAccelerationMultiplier(itemstack, field_70170_p);
-+                        }
++                        if(itemstack.func_77973_b() instanceof net.minecraftforge.items.IElytra){((net.minecraftforge.items.IElytra) itemstack.func_77973_b()).changeAcceleration(itemstack, this, field_70159_w, field_70181_x, field_70179_y);}
 +                        
                          this.func_70091_d(MoverType.SELF, this.field_70159_w, this.field_70181_x, this.field_70179_y);
  
                          if (this.field_70123_F && !this.field_70170_p.field_72995_K)
-@@ -1858,7 +1895,10 @@
+@@ -1858,7 +1891,10 @@
                              if (f5 > 0.0F)
                              {
                                  this.func_184185_a(this.func_184588_d((int)f5), 1.0F, 1.0F);
 -                                this.func_70097_a(DamageSource.field_188406_j, f5);
-+                                if((itemstack.func_77973_b() instanceof net.minecraftforge.items.IElytra && ((net.minecraftforge.items.IElytra) itemstack.func_77973_b()).doesDamageUponHittingWall(itemstack, field_70170_p)) || itemstack.func_77973_b() == Items.field_185160_cR) {
++                                if((itemstack.func_77973_b() instanceof net.minecraftforge.items.IElytra && ((net.minecraftforge.items.IElytra) itemstack.func_77973_b()).doesDamageUponHittingWall(itemstack, this))) {
 +                                	this.func_70097_a(DamageSource.field_188406_j, f5);
-+                                	if(itemstack.func_77973_b() instanceof net.minecraftforge.items.IElytra) ((net.minecraftforge.items.IElytra) itemstack.func_77973_b()).onHitWall(itemstack, field_70170_p, new BlockPos(field_70165_t, field_70163_u, field_70161_v));
 +                                }
++                                if(itemstack.func_77973_b() instanceof net.minecraftforge.items.IElytra) ((net.minecraftforge.items.IElytra) itemstack.func_77973_b()).onHitWall(itemstack, this);
                              }
                          }
  
-@@ -1874,7 +1914,8 @@
+@@ -1874,7 +1910,8 @@
  
                          if (this.field_70122_E)
                          {
@@ -321,7 +317,7 @@
                          }
  
                          float f7 = 0.16277136F / (f6 * f6 * f6);
-@@ -1894,7 +1935,8 @@
+@@ -1894,7 +1931,8 @@
  
                          if (this.field_70122_E)
                          {
@@ -331,7 +327,7 @@
                          }
  
                          if (this.func_70617_f_())
-@@ -2054,6 +2096,7 @@
+@@ -2054,6 +2092,7 @@
  
      public void func_70071_h_()
      {
@@ -339,7 +335,7 @@
          super.func_70071_h_();
          this.func_184608_ct();
  
-@@ -2096,7 +2139,9 @@
+@@ -2096,7 +2135,9 @@
  
                  if (!ItemStack.func_77989_b(itemstack1, itemstack))
                  {
@@ -349,24 +345,24 @@
  
                      if (!itemstack.func_190926_b())
                      {
-@@ -2364,12 +2409,15 @@
+@@ -2364,13 +2405,13 @@
          {
              ItemStack itemstack = this.func_184582_a(EntityEquipmentSlot.CHEST);
  
 -            if (itemstack.func_77973_b() == Items.field_185160_cR && ItemElytra.func_185069_d(itemstack))
-+            if (itemstack.func_77973_b() == Items.field_185160_cR && ItemElytra.func_185069_d(itemstack) || (itemstack.func_77973_b() instanceof net.minecraftforge.items.IElytra && ((net.minecraftforge.items.IElytra) itemstack.func_77973_b()).checkFlight(itemstack, field_70170_p)))
++            if (itemstack.func_77973_b() == Items.field_185160_cR && ItemElytra.func_185069_d(itemstack) || (itemstack.func_77973_b() instanceof net.minecraftforge.items.IElytra && ((net.minecraftforge.items.IElytra) itemstack.func_77973_b()).checkFlight(itemstack, this)))
              {
                  flag = true;
  
-                 if (!this.field_70170_p.field_72995_K && (this.field_184629_bo + 1) % 20 == 0)
+-                if (!this.field_70170_p.field_72995_K && (this.field_184629_bo + 1) % 20 == 0)
++                if (!this.field_70170_p.field_72995_K && (this.field_184629_bo + 1) % ((net.minecraftforge.items.IElytra) itemstack.func_77973_b()).getDamageRate(itemstack, this) == 0)
                  {
-+                	if((itemstack.func_77973_b() instanceof net.minecraftforge.items.IElytra && ((net.minecraftforge.items.IElytra) itemstack.func_77973_b()).doesDamageWhileFlying(itemstack, field_70170_p)) || itemstack.func_77973_b() == Items.field_185160_cR){
-+                		
-+                	}
-                     itemstack.func_77972_a(1, this);
+-                    itemstack.func_77972_a(1, this);
++                	if((((net.minecraftforge.items.IElytra) itemstack.func_77973_b()).doesDamageWhileFlying(itemstack, this))){itemstack.func_77972_a(1, this);}
                  }
              }
-@@ -2575,6 +2623,40 @@
+             else
+@@ -2575,6 +2616,40 @@
          this.field_70752_e = true;
      }
  
@@ -407,7 +403,7 @@
      public abstract EnumHandSide func_184591_cq();
  
      public boolean func_184587_cr()
-@@ -2595,12 +2677,19 @@
+@@ -2595,12 +2670,19 @@
  
              if (itemstack == this.field_184627_bm)
              {
@@ -428,7 +424,7 @@
                  {
                      this.func_71036_o();
                  }
-@@ -2618,8 +2707,10 @@
+@@ -2618,8 +2700,10 @@
  
          if (!itemstack.func_190926_b() && !this.func_184587_cr())
          {
@@ -440,7 +436,7 @@
  
              if (!this.field_70170_p.field_72995_K)
              {
-@@ -2700,7 +2791,9 @@
+@@ -2700,7 +2784,9 @@
          if (!this.field_184627_bm.func_190926_b() && this.func_184587_cr())
          {
              this.func_184584_a(this.field_184627_bm, 16);
@@ -451,7 +447,7 @@
              this.func_184602_cy();
          }
      }
-@@ -2724,7 +2817,8 @@
+@@ -2724,7 +2810,8 @@
      {
          if (!this.field_184627_bm.func_190926_b())
          {
@@ -461,7 +457,7 @@
          }
  
          this.func_184602_cy();
-@@ -2852,6 +2946,31 @@
+@@ -2852,6 +2939,31 @@
          return true;
      }
  

--- a/patches/minecraft/net/minecraft/entity/EntityLivingBase.java.patch
+++ b/patches/minecraft/net/minecraft/entity/EntityLivingBase.java.patch
@@ -4,7 +4,6 @@
  import net.minecraft.world.WorldServer;
  import net.minecraftforge.fml.relauncher.Side;
  import net.minecraftforge.fml.relauncher.SideOnly;
-+
  import org.apache.logging.log4j.LogManager;
  import org.apache.logging.log4j.Logger;
  

--- a/patches/minecraft/net/minecraft/entity/player/EntityPlayer.java.patch
+++ b/patches/minecraft/net/minecraft/entity/player/EntityPlayer.java.patch
@@ -482,6 +482,15 @@
  
          if (this.func_70608_bn())
          {
+@@ -2322,7 +2435,7 @@
+             {
+                 if (!p_174820_2_.func_190926_b())
+                 {
+-                    if (!(p_174820_2_.func_77973_b() instanceof ItemArmor) && !(p_174820_2_.func_77973_b() instanceof ItemElytra))
++                    if (!(p_174820_2_.func_77973_b() instanceof ItemArmor) && !(p_174820_2_.func_77973_b() instanceof ItemElytra) && !(p_174820_2_.func_77973_b() instanceof net.minecraftforge.items.IElytra))
+                     {
+                         if (entityequipmentslot != EntityEquipmentSlot.HEAD)
+                         {
 @@ -2421,6 +2534,168 @@
          return this.field_71075_bZ.field_75098_d && this.func_70003_b(2, "");
      }

--- a/patches/minecraft/net/minecraft/item/ItemElytra.java.patch
+++ b/patches/minecraft/net/minecraft/item/ItemElytra.java.patch
@@ -1,0 +1,24 @@
+--- ../src-base/minecraft/net/minecraft/item/ItemElytra.java
++++ ../src-work/minecraft/net/minecraft/item/ItemElytra.java
+@@ -16,7 +16,7 @@
+ import net.minecraftforge.fml.relauncher.Side;
+ import net.minecraftforge.fml.relauncher.SideOnly;
+ 
+-public class ItemElytra extends Item
++public class ItemElytra extends Item implements net.minecraftforge.items.IElytra
+ {
+     public ItemElytra()
+     {
+@@ -61,4 +61,12 @@
+             return new ActionResult<ItemStack>(EnumActionResult.FAIL, itemstack);
+         }
+     }
++    // FORGE START
++    public boolean doesSlowOnUpwardsFlight(ItemStack stack, EntityLivingBase entity){return true;}
++    public boolean doesDamageWhileFlying(ItemStack stack, EntityLivingBase entity){return true;}
++    public boolean doesDamageUponHittingWall(ItemStack stack, EntityLivingBase entity){return true;}
++    public boolean checkFlight(ItemStack stack, EntityLivingBase entity){return true;}
++    public int getDamageRate(ItemStack stack, EntityLivingBase entity){return 20;}
++    public void changeAcceleration(ItemStack stack, EntityLivingBase entity, double motionX, double motionY, double motionZ){}
++    public void onHitWall(ItemStack stack, EntityLivingBase entity){}
+ }

--- a/patches/minecraft/net/minecraft/network/NetHandlerPlayServer.java.patch
+++ b/patches/minecraft/net/minecraft/network/NetHandlerPlayServer.java.patch
@@ -34,6 +34,15 @@
                  this.field_147367_d.func_184103_al().func_148544_a(itextcomponent, false);
              }
  
+@@ -1023,7 +1030,7 @@
+                 {
+                     ItemStack itemstack = this.field_147369_b.func_184582_a(EntityEquipmentSlot.CHEST);
+ 
+-                    if (itemstack.func_77973_b() == Items.field_185160_cR && ItemElytra.func_185069_d(itemstack))
++                    if ((itemstack.func_77973_b() == Items.field_185160_cR && ItemElytra.func_185069_d(itemstack)) || itemstack.func_77973_b() instanceof net.minecraftforge.items.IElytra)
+                     {
+                         this.field_147369_b.func_184847_M();
+                     }
 @@ -1066,6 +1073,7 @@
                  else if (p_147340_1_.func_149565_c() == CPacketUseEntity.Action.INTERACT_AT)
                  {

--- a/src/main/java/net/minecraftforge/items/IElytra.java
+++ b/src/main/java/net/minecraftforge/items/IElytra.java
@@ -1,0 +1,59 @@
+package net.minecraftforge.items;
+
+import net.minecraft.item.ItemStack;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.World;
+
+/**
+ * Implement this on your items to make them act as an Elytra
+ */
+public interface IElytra{
+    
+     /**
+     * True if this Elytra slos down when flying upwards
+     * @param stack The itemstack
+     * @param world The world
+     * @return
+     */
+    public boolean doesSlowOnUpwardsFlight(ItemStack stack, World world);
+    
+    /**
+     * True if this Elytra takes damage whilst flying
+     * @param stack The itemstack
+     * @param world The world
+     * @return
+     */
+    public boolean doesDamageWhileFlying(ItemStack stack, World world);
+    
+    /**
+     * True if this Elytra deals damage to it's wearer when hitting a wall
+     * @param stack The itemstack
+     * @param world The world
+     * @return
+     */
+    public boolean doesDamageUponHittingWall(ItemStack stack, World world);
+    
+    /**
+     * Called every tick to check if this Elytra can continue flying
+     * @param stack The itemstack
+     * @param world The world
+     * @return
+     */
+    public boolean checkFlight(ItemStack stack, World world);
+    
+    /**
+     * Multiplied by the user's motion when moving. Defaults to 1
+     * @param stack The itemstack
+     * @param world The world
+     * @return
+     */
+    public float getAccelerationMultiplier(ItemStack stack, World world);
+    
+    /**
+     * Called when the user hits the wall
+     * @param stack The itemstack
+     * @param world The world
+     * @param pos The position of the user when hitting the wall
+     */
+    public void onHitWall(ItemStack stack, World world, BlockPos pos);
+}

--- a/src/main/java/net/minecraftforge/items/IElytra.java
+++ b/src/main/java/net/minecraftforge/items/IElytra.java
@@ -1,59 +1,82 @@
 package net.minecraftforge.items;
 
+import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.item.ItemStack;
-import net.minecraft.util.math.BlockPos;
-import net.minecraft.world.World;
 
 /**
  * Implement this on your items to make them act as an Elytra
  */
-public interface IElytra{
-    
-     /**
+public interface IElytra
+{
+
+    /**
      * True if this Elytra slos down when flying upwards
-     * @param stack The itemstack
-     * @param world The world
+     * 
+     * @param stack
+     *            The itemstack
+     * @param entity
+     *            The user
      * @return
      */
-    public boolean doesSlowOnUpwardsFlight(ItemStack stack, World world);
-    
+    public boolean doesSlowOnUpwardsFlight(ItemStack stack, EntityLivingBase entity);
+
     /**
      * True if this Elytra takes damage whilst flying
-     * @param stack The itemstack
-     * @param world The world
+     * 
+     * @param stack
+     *            The itemstack
+     * @param entity
+     *            The user
      * @return
      */
-    public boolean doesDamageWhileFlying(ItemStack stack, World world);
-    
+    public boolean doesDamageWhileFlying(ItemStack stack, EntityLivingBase entity);
+
     /**
      * True if this Elytra deals damage to it's wearer when hitting a wall
-     * @param stack The itemstack
-     * @param world The world
+     * 
+     * @param stack
+     *            The itemstack
+     * @param entity
+     *            The user
      * @return
      */
-    public boolean doesDamageUponHittingWall(ItemStack stack, World world);
-    
+    public boolean doesDamageUponHittingWall(ItemStack stack, EntityLivingBase entity);
+
     /**
      * Called every tick to check if this Elytra can continue flying
-     * @param stack The itemstack
-     * @param world The world
+     * 
+     * @param stack
+     *            The itemstack
+     * @param entity
+     *            The user
      * @return
      */
-    public boolean checkFlight(ItemStack stack, World world);
-    
+    public boolean checkFlight(ItemStack stack, EntityLivingBase entity);
+
     /**
-     * Multiplied by the user's motion when moving. Defaults to 1
-     * @param stack The itemstack
-     * @param world The world
+     * If this elytra takes damage when flying, this returns how many ticks there is between each damage point. Don't set this to zero!
+     * 
      * @return
      */
-    public float getAccelerationMultiplier(ItemStack stack, World world);
-    
+    public int getDamageRate(ItemStack stack, EntityLivingBase entity);
+
+    /**
+     * Called every tick to change the user's acceleration.
+     * 
+     * @param stack
+     *            The itemstack
+     * @param entity
+     *            The user
+     */
+    public void changeAcceleration(ItemStack stack, EntityLivingBase entity, double motionX, double motionY, double motionZ);
+
     /**
      * Called when the user hits the wall
-     * @param stack The itemstack
-     * @param world The world
-     * @param pos The position of the user when hitting the wall
+     * 
+     * @param stack
+     *            The itemstack
+     * @param entity
+     *            The user
      */
-    public void onHitWall(ItemStack stack, World world, BlockPos pos);
+    public void onHitWall(ItemStack stack, EntityLivingBase entity);
 }

--- a/src/test/java/net/minecraftforge/debug/item/CustomElytraItemTest.java
+++ b/src/test/java/net/minecraftforge/debug/item/CustomElytraItemTest.java
@@ -12,6 +12,7 @@ import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.items.IElytra;
 
+@Mod.EventBusSubscriber(modid = CustomElytraItemTest.MODID)
 @Mod(modid = CustomElytraItemTest.MODID, name = "CustomElytraItemTest", version = "0.0.0", acceptableRemoteVersions = "*")
 public class CustomElytraItemTest{
     
@@ -64,15 +65,14 @@ public class CustomElytraItemTest{
 	};
 	
 	
-	@Mod.EventBusSubscriber(modid = MODID)
-    public static class Registration
-    {
+	
+    
         @SubscribeEvent
         public static void registerItems(RegistryEvent.Register<Item> event)
         {
                 event.getRegistry().register(TestItem.testItem.setRegistryName("custom_elytra_item").setUnlocalizedName("CustomElytraItem").setMaxStackSize(1));
         }
-    }
+    
 
     @Mod.EventBusSubscriber(value = Side.CLIENT, modid = MODID)
     public static class ClientEventHandler

--- a/src/test/java/net/minecraftforge/debug/item/CustomElytraItemTest.java
+++ b/src/test/java/net/minecraftforge/debug/item/CustomElytraItemTest.java
@@ -1,0 +1,86 @@
+package net.minecraftforge.debug.item;
+
+import net.minecraft.client.renderer.block.model.ModelBakery;
+import net.minecraft.item.Item;
+import net.minecraft.item.ItemStack;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.World;
+import net.minecraftforge.client.event.ModelRegistryEvent;
+import net.minecraftforge.event.RegistryEvent;
+import net.minecraftforge.fml.common.Mod;
+import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
+import net.minecraftforge.fml.relauncher.Side;
+import net.minecraftforge.items.IElytra;
+
+@Mod(modid = CustomElytraItemTest.MODID, name = "CustomElytraItemTest", version = "0.0.0", acceptableRemoteVersions = "*")
+public class CustomElytraItemTest{
+    
+	public static final String MODID = "custom_elytra_item_test";
+	
+	public static class TestItem extends Item implements IElytra
+	{
+		public static Item testItem = new TestItem();
+		
+		@Override
+		public boolean doesSlowOnUpwardsFlight(ItemStack stack, World world)
+        {
+			//Can fly upwards without slowing down
+			return false;
+		}
+
+		@Override
+		public boolean doesDamageWhileFlying(ItemStack stack, World world)
+		{
+			//Doesn't use durability upon flying
+			return false;
+		}
+
+		@Override
+		public boolean doesDamageUponHittingWall(ItemStack stack, World world)
+		{
+			//Doesn't deal damage when hitting a wall
+			return false;
+		}
+
+		@Override
+		public boolean checkFlight(ItemStack stack, World world)
+		{
+			//This just acts like a regular Elytra, but you could put custom fuel checks or something
+			return true;
+		}
+
+		@Override
+		public float getAccelerationMultiplier(ItemStack stack, World world)
+		{
+			//Goes a bit faster than normal. This escalates QUICKLY; it can be changed as you use it, but I'd recommend sticking to 1 for most things.
+			return 1.1F;
+		}
+
+		@Override
+		public void onHitWall(ItemStack stack, World world, BlockPos pos)
+		{
+			//I could put particle effects, explosions, fuel reductions, or really anything.
+		}
+	};
+	
+	
+	@Mod.EventBusSubscriber(modid = MODID)
+    public static class Registration
+    {
+        @SubscribeEvent
+        public static void registerItems(RegistryEvent.Register<Item> event)
+        {
+                event.getRegistry().register(TestItem.testItem.setRegistryName("custom_elytra_item").setUnlocalizedName("CustomElytraItem").setMaxStackSize(1));
+        }
+    }
+
+    @Mod.EventBusSubscriber(value = Side.CLIENT, modid = MODID)
+    public static class ClientEventHandler
+    {
+        @SubscribeEvent
+        public static void registerModels(ModelRegistryEvent event)
+        {
+                ModelBakery.registerItemVariants(TestItem.testItem);
+        }
+    }
+}

--- a/src/test/java/net/minecraftforge/debug/item/CustomElytraItemTest.java
+++ b/src/test/java/net/minecraftforge/debug/item/CustomElytraItemTest.java
@@ -1,10 +1,9 @@
 package net.minecraftforge.debug.item;
 
 import net.minecraft.client.renderer.block.model.ModelBakery;
+import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
-import net.minecraft.util.math.BlockPos;
-import net.minecraft.world.World;
 import net.minecraftforge.client.event.ModelRegistryEvent;
 import net.minecraftforge.event.RegistryEvent;
 import net.minecraftforge.fml.common.Mod;
@@ -14,65 +13,71 @@ import net.minecraftforge.items.IElytra;
 
 @Mod.EventBusSubscriber(modid = CustomElytraItemTest.MODID)
 @Mod(modid = CustomElytraItemTest.MODID, name = "CustomElytraItemTest", version = "0.0.0", acceptableRemoteVersions = "*")
-public class CustomElytraItemTest{
-    
-	public static final String MODID = "custom_elytra_item_test";
-	
-	public static class TestItem extends Item implements IElytra
-	{
-		public static Item testItem = new TestItem();
-		
-		@Override
-		public boolean doesSlowOnUpwardsFlight(ItemStack stack, World world)
+public class CustomElytraItemTest
+{
+
+    public static final String MODID = "custom_elytra_item_test";
+
+    public static class TestItem extends Item implements IElytra
+    {
+        public static Item testItem = new TestItem();
+
+        @Override
+        public boolean doesSlowOnUpwardsFlight(ItemStack stack, EntityLivingBase entity)
         {
-			//Can fly upwards without slowing down
-			return false;
-		}
-
-		@Override
-		public boolean doesDamageWhileFlying(ItemStack stack, World world)
-		{
-			//Doesn't use durability upon flying
-			return false;
-		}
-
-		@Override
-		public boolean doesDamageUponHittingWall(ItemStack stack, World world)
-		{
-			//Doesn't deal damage when hitting a wall
-			return false;
-		}
-
-		@Override
-		public boolean checkFlight(ItemStack stack, World world)
-		{
-			//This just acts like a regular Elytra, but you could put custom fuel checks or something
-			return true;
-		}
-
-		@Override
-		public float getAccelerationMultiplier(ItemStack stack, World world)
-		{
-			//Goes a bit faster than normal. This escalates QUICKLY; it can be changed as you use it, but I'd recommend sticking to 1 for most things.
-			return 1.1F;
-		}
-
-		@Override
-		public void onHitWall(ItemStack stack, World world, BlockPos pos)
-		{
-			//I could put particle effects, explosions, fuel reductions, or really anything.
-		}
-	};
-	
-	
-	
-    
-        @SubscribeEvent
-        public static void registerItems(RegistryEvent.Register<Item> event)
-        {
-                event.getRegistry().register(TestItem.testItem.setRegistryName("custom_elytra_item").setUnlocalizedName("CustomElytraItem").setMaxStackSize(1));
+            // Can fly upwards without slowing down
+            return false;
         }
-    
+
+        @Override
+        public boolean doesDamageWhileFlying(ItemStack stack, EntityLivingBase entity)
+        {
+            // Doesn't use durability upon flying
+            return false;
+        }
+
+        @Override
+        public boolean doesDamageUponHittingWall(ItemStack stack, EntityLivingBase entity)
+        {
+            // Doesn't deal damage when hitting a wall
+            return false;
+        }
+
+        @Override
+        public boolean checkFlight(ItemStack stack, EntityLivingBase entity)
+        {
+            // This just acts like a regular Elytra, but you could put custom fuel checks or something
+            return true;
+        }
+
+        @Override
+        public void changeAcceleration(ItemStack stack, EntityLivingBase entity, double motionX, double motionY, double motionZ)
+        {
+            // Goes a bit faster than normal. This escalates QUICKLY; it can be changed as you use it, but I'd recommend sticking to 1 for most things.
+            motionX *= 1.1;
+            motionY *= 1.1;
+            motionZ *= 1.1;
+        }
+
+        @Override
+        public void onHitWall(ItemStack stack, EntityLivingBase entity)
+        {
+            // I could put particle effects, explosions, fuel reductions, or really anything.
+        }
+
+        @Override
+        public int getDamageRate(ItemStack stack, EntityLivingBase entity)
+        {
+            // Doesn't take damage upon flying
+            return 1;
+        }
+    };
+
+    @SubscribeEvent
+    public static void registerItems(RegistryEvent.Register<Item> event)
+    {
+        event.getRegistry().register(TestItem.testItem.setRegistryName("custom_elytra_item").setUnlocalizedName("CustomElytraItem").setMaxStackSize(1));
+    }
 
     @Mod.EventBusSubscriber(value = Side.CLIENT, modid = MODID)
     public static class ClientEventHandler
@@ -80,7 +85,7 @@ public class CustomElytraItemTest{
         @SubscribeEvent
         public static void registerModels(ModelRegistryEvent event)
         {
-                ModelBakery.registerItemVariants(TestItem.testItem);
+            ModelBakery.registerItemVariants(TestItem.testItem);
         }
     }
 }


### PR DESCRIPTION
This adds support for items to act as custom Elytras via implementing IElytra on the item. 

I know that https://github.com/MinecraftForge/MinecraftForge/pull/4476 exists, but this makes creating Elytras with custom properties significantly easier.

One use-case is a RF-powered Elytra with can speed up at the cost of more energy.