### PR TITLE
Fix FluidUtil.getFluidHandler skipping fluid based tile entities

### DIFF
--- a/src/main/java/net/minecraftforge/fluids/FluidUtil.java
+++ b/src/main/java/net/minecraftforge/fluids/FluidUtil.java
@@ -531,7 +531,7 @@ public class FluidUtil
                 return tileEntity.getCapability(CapabilityFluidHandler.FLUID_HANDLER_CAPABILITY, side);
             }
         }
-        else if (block instanceof IFluidBlock)
+        if (block instanceof IFluidBlock)
         {
             return new FluidBlockWrapper((IFluidBlock) block, world, blockPos);
         }


### PR DESCRIPTION
This fixes a case where a fluid block is an instance of `IFluidBlock` or `BlockLiquid` and is also a tile entity, but doesn't expose a fluid capability. (Most likely due to not allowing connections to modded pipes or tubes (or etc) that shouldn't be allowed to drain directly from a fluid block). As far as I can tell the original behaviour (returning null even if it is a tile entity) probably wasn't intended.