### PR TITLE
Fix deobfuscator not regenerating super maps

### DIFF
--- a/src/main/java/net/minecraftforge/fml/common/asm/transformers/deobf/FMLDeobfuscatingRemapper.java
+++ b/src/main/java/net/minecraftforge/fml/common/asm/transformers/deobf/FMLDeobfuscatingRemapper.java
@@ -450,7 +450,7 @@ public class FMLDeobfuscatingRemapper extends Remapper {
         // generate maps for all parent objects
         for (String parentThing : allParents)
         {
-            if (!methodNameMaps.containsKey(parentThing))
+            if (!fieldNameMaps.containsKey(parentThing))
             {
                 findAndMergeSuperMaps(parentThing);
             }


### PR DESCRIPTION
Fixes #4852.

Changes the check in `FMLDeobfuscatingRemapper.mergeSuperMaps` to use the field map, rather than the method map. This is because while entries are inserted into both maps together, field map entries can also be removed - see here:
https://github.com/MinecraftForge/MinecraftForge/blob/bad83a303e6770d484aad0b0d891549dc273cf05/src/main/java/net/minecraftforge/fml/common/asm/transformers/deobf/FMLDeobfuscatingRemapper.java#L271-L285
