### PR TITLE
Fix potential deadlock when chunkload raises non-IO exception

### DIFF
--- a/src/main/java/net/minecraftforge/common/chunkio/ChunkIOExecutor.java
+++ b/src/main/java/net/minecraftforge/common/chunkio/ChunkIOExecutor.java
@@ -29,7 +29,6 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 import com.google.common.collect.Maps;
 
-import net.minecraft.crash.CrashReportCategory;
 import net.minecraft.world.World;
 import net.minecraft.world.chunk.Chunk;
 import net.minecraft.world.chunk.storage.AnvilChunkLoader;
@@ -42,7 +41,7 @@ public class ChunkIOExecutor
     private static final int PLAYERS_PER_THREAD = 50;
 
     private static final Map<QueuedChunk, ChunkIOProvider> tasks = Maps.newConcurrentMap();
-    private static final ThreadPoolExecutor pool = new ThreadPoolExecutor(BASE_THREADS, Integer.MAX_VALUE, 60L, TimeUnit.SECONDS,
+    private static final ThreadPoolExecutor pool = new ChunkIOThreadPoolExecutor(BASE_THREADS, Integer.MAX_VALUE, 60L, TimeUnit.SECONDS,
         new LinkedBlockingQueue<Runnable>(),
         new ThreadFactory()
         {
@@ -55,32 +54,7 @@ public class ChunkIOExecutor
                 return thread;
             }
         }
-    ){
-        
-        @Override
-        protected void afterExecute(Runnable r, Throwable t)
-        {
-            if (t != null)
-            {
-                try
-                {
-                    FMLLog.log.error("Unhandled exception loading chunk:", t);
-                    QueuedChunk queuedChunk = ((ChunkIOProvider) r).getChunkInfo();
-                    FMLLog.log.error(queuedChunk);
-                    FMLLog.log.error(CrashReportCategory.getCoordinateInfo(queuedChunk.x << 4, 64, queuedChunk.z << 4));
-                }
-                catch (Throwable t2)
-                {
-                    FMLLog.log.error(t2);
-                }
-                finally
-                {
-                    // Make absolutely sure that we do not leave any deadlock case
-                    r.notifyAll();
-                }
-            }
-        }
-    };
+    );
 
     //Load the chunk completely in this thread. Dequeue as needed...
     public static Chunk syncChunkLoad(World world, AnvilChunkLoader loader, ChunkProviderServer provider, int x, int z)

--- a/src/main/java/net/minecraftforge/common/chunkio/ChunkIOProvider.java
+++ b/src/main/java/net/minecraftforge/common/chunkio/ChunkIOProvider.java
@@ -26,7 +26,6 @@ import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.util.math.ChunkPos;
 import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.event.world.ChunkDataEvent;
-import net.minecraftforge.fml.common.FMLLog;
 
 import java.io.IOException;
 import java.util.concurrent.ConcurrentLinkedQueue;
@@ -72,7 +71,7 @@ class ChunkIOProvider implements Runnable
                 }
                 catch (IOException e)
                 {
-                    FMLLog.log.error("Failed to load chunk async.", e);
+                    throw new RuntimeException(e); // Allow exception to bubble up to afterExecute
                 }
     
                 if (data != null)

--- a/src/main/java/net/minecraftforge/common/chunkio/ChunkIOProvider.java
+++ b/src/main/java/net/minecraftforge/common/chunkio/ChunkIOProvider.java
@@ -63,24 +63,29 @@ class ChunkIOProvider implements Runnable
     {
         synchronized(this)
         {
-            Object[] data = null;
             try
             {
-                data = this.loader.loadChunk__Async(chunkInfo.world, chunkInfo.x, chunkInfo.z);
+                Object[] data = null;
+                try
+                {
+                    data = this.loader.loadChunk__Async(chunkInfo.world, chunkInfo.x, chunkInfo.z);
+                }
+                catch (IOException e)
+                {
+                    FMLLog.log.error("Failed to load chunk async.", e);
+                }
+    
+                if (data != null)
+                {
+                    this.nbt   = (NBTTagCompound)data[1];
+                    this.chunk = (Chunk)data[0];
+                }
             }
-            catch (IOException e)
+            finally 
             {
-                FMLLog.log.error("Failed to load chunk async.", e);
+                this.ran = true;
+                this.notifyAll();
             }
-
-            if (data != null)
-            {
-                this.nbt   = (NBTTagCompound)data[1];
-                this.chunk = (Chunk)data[0];
-            }
-
-            this.ran = true;
-            this.notifyAll();
         }
     }
 
@@ -131,5 +136,10 @@ class ChunkIOProvider implements Runnable
         }
 
         this.callbacks.clear();
+    }
+
+    public QueuedChunk getChunkInfo() 
+    {
+    	return chunkInfo;
     }
 }

--- a/src/main/java/net/minecraftforge/common/chunkio/ChunkIOThreadPoolExecutor.java
+++ b/src/main/java/net/minecraftforge/common/chunkio/ChunkIOThreadPoolExecutor.java
@@ -27,7 +27,7 @@ import java.util.concurrent.TimeUnit;
 import net.minecraft.crash.CrashReportCategory;
 import net.minecraftforge.fml.common.FMLLog;
 
-public class ChunkIOThreadPoolExecutor extends ThreadPoolExecutor {
+class ChunkIOThreadPoolExecutor extends ThreadPoolExecutor {
 
     public ChunkIOThreadPoolExecutor(int corePoolSize, int maximumPoolSize, long keepAliveTime, TimeUnit unit, BlockingQueue<Runnable> workQueue, ThreadFactory threadFactory)
     {

--- a/src/main/java/net/minecraftforge/common/chunkio/ChunkIOThreadPoolExecutor.java
+++ b/src/main/java/net/minecraftforge/common/chunkio/ChunkIOThreadPoolExecutor.java
@@ -1,0 +1,41 @@
+package net.minecraftforge.common.chunkio;
+
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+
+import net.minecraft.crash.CrashReportCategory;
+import net.minecraftforge.fml.common.FMLLog;
+
+public class ChunkIOThreadPoolExecutor extends ThreadPoolExecutor {
+
+    public ChunkIOThreadPoolExecutor(int corePoolSize, int maximumPoolSize, long keepAliveTime, TimeUnit unit, BlockingQueue<Runnable> workQueue, ThreadFactory threadFactory)
+    {
+        super(corePoolSize, maximumPoolSize, keepAliveTime, unit, workQueue, threadFactory);
+    }
+
+    @Override
+    protected void afterExecute(Runnable r, Throwable t)
+    {
+        if (t != null)
+        {
+            try
+            {
+                FMLLog.log.error("Unhandled exception loading chunk:", t);
+                QueuedChunk queuedChunk = ((ChunkIOProvider) r).getChunkInfo();
+                FMLLog.log.error(queuedChunk);
+                FMLLog.log.error(CrashReportCategory.getCoordinateInfo(queuedChunk.x << 4, 64, queuedChunk.z << 4));
+            }
+            catch (Throwable t2)
+            {
+                FMLLog.log.error(t2);
+            }
+            finally
+            {
+                // Make absolutely sure that we do not leave any deadlock case
+                r.notifyAll();
+            }
+        }
+    }
+}

--- a/src/main/java/net/minecraftforge/common/chunkio/ChunkIOThreadPoolExecutor.java
+++ b/src/main/java/net/minecraftforge/common/chunkio/ChunkIOThreadPoolExecutor.java
@@ -1,3 +1,22 @@
+/*
+ * Minecraft Forge
+ * Copyright (c) 2016.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation version 2.1
+ * of the License.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
 package net.minecraftforge.common.chunkio;
 
 import java.util.concurrent.BlockingQueue;


### PR DESCRIPTION
This fixes a rare but deadly bug that can be caused by a chunkload throwing an exception that does not inherit from IOException. The main fix is the change to ChunkIOProvider, that uses a `finally` block to assure that `run = true` and `notifyAll()` are always called before the task terminates. This removes the possible case where `task.wait()` in ChunkIOExecutor can be waiting on a dead task, causing server deadlock.

Code in question:
https://github.com/MinecraftForge/MinecraftForge/blob/1.12.x/src/main/java/net/minecraftforge/common/chunkio/ChunkIOProvider.java#L64-L84

I have also added an override to `ThreadPoolExecutor`'s `afterExecute` method, which detects any uncaught exceptions and logs them, and then makes extra sure to wake up any threads blocking on the task.

I am aware there are other ways to solve this, and also that the ChunkIOExecutor changes are unnecessary, but I think the extra logging will help users pin down any errors and repair them. It would be nice if these exceptions bubbled up to cause a normal crash report, but I don't see an easy way to do that. Open to suggestions in that regard.