### PR TITLE
Parse contained dependency Timestamp as long instead of int

### DIFF
--- a/src/main/java/net/minecraftforge/fml/relauncher/libraries/LibraryManager.java
+++ b/src/main/java/net/minecraftforge/fml/relauncher/libraries/LibraryManager.java
@@ -320,7 +320,7 @@ public class LibraryManager
                     {
                         String timestamp = meta.getValue(TIMESTAMP);
                         if (timestamp != null)
-                            timestamp = SnapshotJson.TIMESTAMP.format(new Date(Integer.parseInt(timestamp)));
+                            timestamp = SnapshotJson.TIMESTAMP.format(new Date(Long.parseLong(timestamp)));
 
                         Artifact artifact = new Artifact(modlist.getRepository(), meta.getValue(MAVEN_ARTIFACT), timestamp);
                         File target = artifact.getFile();


### PR DESCRIPTION
As pointed out in https://github.com/MinecraftForge/MinecraftForge/pull/4841#discussion_r180900132

I have a contained snapshot dependency. Its Timestamp manifest attribute is set as milliseconds since the epoch [like this](https://github.com/JamiesWhiteShirt/clothesline-hooks/blob/6fee5dc2bc072671a1c7f85f5b89ea39a175558b/build.gradle#L38). I determined it should be milliseconds by looking at the Date handling in LibraryManager.

[It fails to launch with this debug.log](https://pastebin.com/4SwAfyu5). Parsing the string as a long resolves this issue.