### PR TITLE
Fix dragon fight not initialising correctly under some circumstances

### DIFF
--- a/patches/minecraft/net/minecraft/world/end/DragonFightManager.java.patch
+++ b/patches/minecraft/net/minecraft/world/end/DragonFightManager.java.patch
@@ -1,20 +1,20 @@
 --- ../src-base/minecraft/net/minecraft/world/end/DragonFightManager.java
 +++ ../src-work/minecraft/net/minecraft/world/end/DragonFightManager.java
-@@ -72,6 +72,7 @@
-     public DragonFightManager(WorldServer p_i46669_1_, NBTTagCompound p_i46669_2_)
-     {
-         this.field_186110_d = p_i46669_1_;
-+        this.field_186120_n = p_i46669_2_.func_82582_d(); // Forge: fix MC-105080
+@@ -82,6 +82,7 @@
  
-         if (p_i46669_2_.func_150297_b("DragonKilled", 99))
-         {
-@@ -120,6 +121,7 @@
-     public NBTTagCompound func_186088_a()
-     {
-         NBTTagCompound nbttagcompound = new NBTTagCompound();
-+        if (this.field_186120_n) return nbttagcompound; // Forge: fix MC-105080
+             this.field_186117_k = p_i46669_2_.func_74767_n("DragonKilled");
+             this.field_186118_l = p_i46669_2_.func_74767_n("PreviouslyKilled");
++            this.field_186120_n = !p_i46669_2_.func_74767_n("LegacyScanPerformed"); // Forge: fix MC-105080
  
-         if (this.field_186119_m != null)
+             if (p_i46669_2_.func_74767_n("IsRespawning"))
+             {
+@@ -128,6 +129,7 @@
+ 
+         nbttagcompound.func_74757_a("DragonKilled", this.field_186117_k);
+         nbttagcompound.func_74757_a("PreviouslyKilled", this.field_186118_l);
++        nbttagcompound.func_74757_a("LegacyScanPerformed", !this.field_186120_n); // Forge: fix MC-105080
+ 
+         if (this.field_186121_o != null)
          {
 @@ -582,4 +584,14 @@
              }

--- a/patches/minecraft/net/minecraft/world/end/DragonFightManager.java.patch
+++ b/patches/minecraft/net/minecraft/world/end/DragonFightManager.java.patch
@@ -8,7 +8,15 @@
  
          if (p_i46669_2_.func_150297_b("DragonKilled", 99))
          {
-@@ -582,4 +583,14 @@
+@@ -120,6 +121,7 @@
+     public NBTTagCompound func_186088_a()
+     {
+         NBTTagCompound nbttagcompound = new NBTTagCompound();
++        if (this.field_186120_n) return nbttagcompound; // Forge: fix MC-105080
+ 
+         if (this.field_186119_m != null)
+         {
+@@ -582,4 +584,14 @@
              }
          }
      }


### PR DESCRIPTION
Patches `DragonFightManager.getCompound` to return early (with an empty tag) if `scanForLegacyFight` is still true.

This is needed to ensure that the fight is correctly initialised - vanilla only runs most logic in `tick` if there is at least one player in the dimension. As a result, if the dimension was loaded, altered, and saved without a player entering it, the dragon would not spawn when a player did join. This can be most easily seen by  pregenerating chunks in the End dimension.

The reason for this is that vanilla defaults the flags `dragonKilled` and `previouslyKilled` to true, relying on `scanForLegacyFight` to fix things. If these flags got saved without the fight actually being processed, then on the next load, these flags would be mistaken for an actual dragon kill, due to no dragon being alive in the dimension.

The issue here became possible due to #4602, which fixed the issue of the dragon fight being reset when leaving and re-entering the End, as the (potentially incorrect) saved data was mostly ignored by vanilla's forced reset.

This fixes the regression here by returning an empty tag if `scanForLegacyFight` is still true. This would be set to false during the `tick` logic, so it being true here means that we know this hasn't run and so the data hasn't been set to anything but the default values. Leaving the default values out of the data makes it clear that a proper scan is still required, fixing the issue.