### PR TITLE
Give immediate and complete error messages when there is a crash during startup

### DIFF
--- a/src/main/java/com/google/common/eventbus/FMLThrowingEventBus.java
+++ b/src/main/java/com/google/common/eventbus/FMLThrowingEventBus.java
@@ -1,0 +1,43 @@
+/*
+ * Minecraft Forge
+ * Copyright (c) 2016.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation version 2.1
+ * of the License.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+package com.google.common.eventbus;
+
+import com.google.common.base.Preconditions;
+
+/**
+ * Event bus that allows exceptions thrown by the exception handler to propagate.
+ */
+public class FMLThrowingEventBus extends EventBus
+{
+    private final SubscriberExceptionHandler exceptionHandler;
+
+    public FMLThrowingEventBus(SubscriberExceptionHandler exceptionHandler)
+    {
+        this.exceptionHandler = Preconditions.checkNotNull(exceptionHandler);
+    }
+
+    @Override
+    void handleSubscriberException(Throwable e, SubscriberExceptionContext context)
+    {
+        Preconditions.checkNotNull(e);
+        Preconditions.checkNotNull(context);
+        exceptionHandler.handleException(e, context);
+    }
+}

--- a/src/main/java/com/google/common/eventbus/FMLThrowingEventBus.java
+++ b/src/main/java/com/google/common/eventbus/FMLThrowingEventBus.java
@@ -23,6 +23,7 @@ import com.google.common.base.Preconditions;
 
 /**
  * Event bus that allows exceptions thrown by the exception handler to propagate.
+ * TODO remove this in 1.13 and stop using the guava event bus
  */
 public class FMLThrowingEventBus extends EventBus
 {

--- a/src/main/java/net/minecraftforge/fml/client/CustomModLoadingErrorDisplayException.java
+++ b/src/main/java/net/minecraftforge/fml/client/CustomModLoadingErrorDisplayException.java
@@ -21,6 +21,7 @@ package net.minecraftforge.fml.client;
 
 import net.minecraft.client.gui.FontRenderer;
 import net.minecraft.client.gui.GuiErrorScreen;
+import net.minecraft.client.gui.GuiScreen;
 import net.minecraftforge.fml.common.EnhancedRuntimeException;
 import net.minecraftforge.fml.common.IFMLHandledException;
 import net.minecraftforge.fml.relauncher.Side;
@@ -37,7 +38,7 @@ import net.minecraftforge.fml.relauncher.SideOnly;
  *
  */
 @SideOnly(Side.CLIENT)
-public abstract class CustomModLoadingErrorDisplayException extends EnhancedRuntimeException implements IFMLHandledException
+public abstract class CustomModLoadingErrorDisplayException extends EnhancedRuntimeException implements IFMLHandledException, IDisplayableError
 {
     public CustomModLoadingErrorDisplayException() {
     }
@@ -72,4 +73,10 @@ public abstract class CustomModLoadingErrorDisplayException extends EnhancedRunt
     public abstract void drawScreen(GuiErrorScreen errorScreen, FontRenderer fontRenderer, int mouseRelX, int mouseRelY, float tickTime);
 
     @Override public void printStackTrace(EnhancedRuntimeException.WrappedPrintStream s){}; // Do Nothing unless the modder wants to.
+
+    @Override
+    public final GuiScreen createGui()
+    {
+        return new GuiCustomModLoadingErrorScreen(this);
+    }
 }

--- a/src/main/java/net/minecraftforge/fml/client/IDisplayableError.java
+++ b/src/main/java/net/minecraftforge/fml/client/IDisplayableError.java
@@ -1,0 +1,11 @@
+package net.minecraftforge.fml.client;
+
+import net.minecraft.client.gui.GuiScreen;
+import net.minecraftforge.fml.relauncher.Side;
+import net.minecraftforge.fml.relauncher.SideOnly;
+
+public interface IDisplayableError
+{
+    @SideOnly(Side.CLIENT)
+    GuiScreen createGui();
+}

--- a/src/main/java/net/minecraftforge/fml/common/DuplicateModsFoundException.java
+++ b/src/main/java/net/minecraftforge/fml/common/DuplicateModsFoundException.java
@@ -23,8 +23,14 @@ import java.io.File;
 import java.util.Map.Entry;
 
 import com.google.common.collect.SetMultimap;
+import net.minecraft.client.gui.GuiScreen;
+import net.minecraftforge.fml.client.GuiDupesFound;
+import net.minecraftforge.fml.client.IDisplayableError;
+import net.minecraftforge.fml.relauncher.Side;
+import net.minecraftforge.fml.relauncher.SideOnly;
 
-public class DuplicateModsFoundException extends LoaderException {
+public class DuplicateModsFoundException extends LoaderException implements IDisplayableError
+{
     private static final long serialVersionUID = 1L;
     public SetMultimap<ModContainer,File> dupes;
 
@@ -41,5 +47,12 @@ public class DuplicateModsFoundException extends LoaderException {
             stream.println(String.format("\t%s : %s", e.getKey().getModId(), e.getValue().getAbsolutePath()));
         }
         stream.println("");
+    }
+
+    @Override
+    @SideOnly(Side.CLIENT)
+    public GuiScreen createGui()
+    {
+        return new GuiDupesFound(this);
     }
 }

--- a/src/main/java/net/minecraftforge/fml/common/FMLModContainer.java
+++ b/src/main/java/net/minecraftforge/fml/common/FMLModContainer.java
@@ -545,11 +545,7 @@ public class FMLModContainer implements ModContainer
         {
             if (!sourceFingerprints.contains(expectedFingerprint))
             {
-                Level warnLevel = Level.ERROR;
-                if (source.isDirectory())
-                {
-                    warnLevel = Level.TRACE;
-                }
+                Level warnLevel = source.isDirectory() ? Level.TRACE : Level.ERROR;
                 FMLLog.log.log(warnLevel, "The mod {} is expecting signature {} for source {}, however there is no signature matching that description", getModId(), expectedFingerprint, source.getName());
             }
             else
@@ -560,13 +556,13 @@ public class FMLModContainer implements ModContainer
         }
 
         @SuppressWarnings("unchecked")
-        List<Map<String, Object>> props = (List<Map<String, Object>>)descriptor.get("customProperties");
+        List<Map<String, String>> props = (List<Map<String, String>>)descriptor.get("customProperties");
         if (props != null)
         {
             ImmutableMap.Builder<String, String> builder = ImmutableMap.builder();
-            for (Map<String, Object> p : props)
+            for (Map<String, String> p : props)
             {
-                builder.put((String)p.get("k"), (String)p.get("v"));
+                builder.put(p.get("k"), p.get("v"));
             }
             customModProperties = builder.build();
         }

--- a/src/main/java/net/minecraftforge/fml/common/FMLModContainer.java
+++ b/src/main/java/net/minecraftforge/fml/common/FMLModContainer.java
@@ -36,6 +36,7 @@ import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
 
+import com.google.common.base.Throwables;
 import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.common.config.Config;
 import net.minecraftforge.common.config.ConfigManager;
@@ -73,6 +74,7 @@ import com.google.common.collect.Maps;
 import com.google.common.collect.SetMultimap;
 import com.google.common.eventbus.EventBus;
 import com.google.common.eventbus.Subscribe;
+import org.apache.logging.log4j.message.FormattedMessage;
 
 import javax.annotation.Nullable;
 
@@ -380,8 +382,7 @@ public class FMLModContainer implements ModContainer
     }
 
     @Nullable
-    @SuppressWarnings("unchecked")
-    private Method gatherAnnotations(Class<?> clazz) throws Exception
+    private Method gatherAnnotations(Class<?> clazz)
     {
         Method factoryMethod = null;
         for (Method m : clazz.getDeclaredMethods())
@@ -393,7 +394,9 @@ public class FMLModContainer implements ModContainer
                     if (m.getParameterTypes().length == 1 && FMLEvent.class.isAssignableFrom(m.getParameterTypes()[0]))
                     {
                         m.setAccessible(true);
-                        eventMethods.put((Class<? extends FMLEvent>)m.getParameterTypes()[0], m);
+                        @SuppressWarnings("unchecked")
+                        Class<? extends FMLEvent> parameterType = (Class<? extends FMLEvent>) m.getParameterTypes()[0];
+                        eventMethods.put(parameterType, m);
                     }
                     else
                     {
@@ -421,7 +424,7 @@ public class FMLModContainer implements ModContainer
         return factoryMethod;
     }
 
-    private void processFieldAnnotations(ASMDataTable asmDataTable) throws Exception
+    private void processFieldAnnotations(ASMDataTable asmDataTable) throws IllegalAccessException
     {
         SetMultimap<String, ASMData> annotations = asmDataTable.getAnnotationsFor(this);
 
@@ -503,86 +506,114 @@ public class FMLModContainer implements ModContainer
     @Subscribe
     public void constructMod(FMLConstructionEvent event)
     {
+        BlamingTransformer.addClasses(getModId(), candidate.getClassList());
+        ModClassLoader modClassLoader = event.getModClassLoader();
         try
         {
-            BlamingTransformer.addClasses(getModId(), candidate.getClassList());
-            ModClassLoader modClassLoader = event.getModClassLoader();
             modClassLoader.addFile(source);
-            modClassLoader.clearNegativeCacheFor(candidate.getClassList());
+        }
+        catch (MalformedURLException e)
+        {
+            FormattedMessage message = new FormattedMessage("{} Failed to add file to classloader: {}", getModId(), source);
+            throw new LoaderException(message.getFormattedMessage(), e);
+        }
+        modClassLoader.clearNegativeCacheFor(candidate.getClassList());
 
-            //Only place I could think to add this...
-            MinecraftForge.preloadCrashClasses(event.getASMHarvestedData(), getModId(), candidate.getClassList());
+        //Only place I could think to add this...
+        MinecraftForge.preloadCrashClasses(event.getASMHarvestedData(), getModId(), candidate.getClassList());
 
-            Class<?> clazz = Class.forName(className, true, modClassLoader);
+        Class<?> clazz;
+        try
+        {
+            clazz = Class.forName(className, true, modClassLoader);
+        }
+        catch (ClassNotFoundException e)
+        {
+            FormattedMessage message = new FormattedMessage("{} Failed load class: {}", getModId(), className);
+            throw new LoaderException(message.getFormattedMessage(), e);
+        }
 
-            Certificate[] certificates = clazz.getProtectionDomain().getCodeSource().getCertificates();
-            ImmutableList<String> certList = CertificateHelper.getFingerprints(certificates);
-            sourceFingerprints = ImmutableSet.copyOf(certList);
+        Certificate[] certificates = clazz.getProtectionDomain().getCodeSource().getCertificates();
+        ImmutableList<String> certList = CertificateHelper.getFingerprints(certificates);
+        sourceFingerprints = ImmutableSet.copyOf(certList);
 
-            String expectedFingerprint = (String)descriptor.get("certificateFingerprint");
+        String expectedFingerprint = (String)descriptor.get("certificateFingerprint");
 
-            fingerprintNotPresent = true;
+        fingerprintNotPresent = true;
 
-            if (expectedFingerprint != null && !expectedFingerprint.isEmpty())
+        if (expectedFingerprint != null && !expectedFingerprint.isEmpty())
+        {
+            if (!sourceFingerprints.contains(expectedFingerprint))
             {
-                if (!sourceFingerprints.contains(expectedFingerprint))
+                Level warnLevel = Level.ERROR;
+                if (source.isDirectory())
                 {
-                    Level warnLevel = Level.ERROR;
-                    if (source.isDirectory())
-                    {
-                        warnLevel = Level.TRACE;
-                    }
-                    FMLLog.log.log(warnLevel, "The mod {} is expecting signature {} for source {}, however there is no signature matching that description", getModId(), expectedFingerprint, source.getName());
+                    warnLevel = Level.TRACE;
                 }
-                else
-                {
-                    certificate = certificates[certList.indexOf(expectedFingerprint)];
-                    fingerprintNotPresent = false;
-                }
-            }
-
-            @SuppressWarnings("unchecked")
-            List<Map<String, Object>> props = (List<Map<String, Object>>)descriptor.get("customProperties");
-            if (props != null)
-            {
-                com.google.common.collect.ImmutableMap.Builder<String, String> builder = ImmutableMap.builder();
-                for (Map<String, Object> p : props)
-                {
-                    builder.put((String)p.get("k"), (String)p.get("v"));
-                }
-                customModProperties = builder.build();
+                FMLLog.log.log(warnLevel, "The mod {} is expecting signature {} for source {}, however there is no signature matching that description", getModId(), expectedFingerprint, source.getName());
             }
             else
             {
-                customModProperties = EMPTY_PROPERTIES;
+                certificate = certificates[certList.indexOf(expectedFingerprint)];
+                fingerprintNotPresent = false;
             }
+        }
 
-            Boolean hasDisableableFlag = (Boolean)descriptor.get("canBeDeactivated");
-            boolean hasReverseDepends = !event.getReverseDependencies().get(getModId()).isEmpty();
-            if (hasDisableableFlag != null && hasDisableableFlag)
+        @SuppressWarnings("unchecked")
+        List<Map<String, Object>> props = (List<Map<String, Object>>)descriptor.get("customProperties");
+        if (props != null)
+        {
+            ImmutableMap.Builder<String, String> builder = ImmutableMap.builder();
+            for (Map<String, Object> p : props)
             {
-                disableability = hasReverseDepends ? Disableable.DEPENDENCIES : Disableable.YES;
+                builder.put((String)p.get("k"), (String)p.get("v"));
             }
-            else
-            {
-                disableability = hasReverseDepends ? Disableable.DEPENDENCIES : Disableable.RESTART;
-            }
-            Method factoryMethod = gatherAnnotations(clazz);
-            modInstance = getLanguageAdapter().getNewInstance(this, clazz, modClassLoader, factoryMethod);
-            NetworkRegistry.INSTANCE.register(this, clazz, (String)(descriptor.getOrDefault("acceptableRemoteVersions", null)), event.getASMHarvestedData());
-            if (fingerprintNotPresent)
-            {
-                eventBus.post(new FMLFingerprintViolationEvent(source.isDirectory(), source, ImmutableSet.copyOf(this.sourceFingerprints), expectedFingerprint));
-            }
-            ProxyInjector.inject(this, event.getASMHarvestedData(), FMLCommonHandler.instance().getSide(), getLanguageAdapter());
-            AutomaticEventSubscriber.inject(this, event.getASMHarvestedData(), FMLCommonHandler.instance().getSide());
-            ConfigManager.sync(this.getModId(), Config.Type.INSTANCE);
+            customModProperties = builder.build();
+        }
+        else
+        {
+            customModProperties = EMPTY_PROPERTIES;
+        }
 
+        Boolean hasDisableableFlag = (Boolean)descriptor.get("canBeDeactivated");
+        boolean hasReverseDepends = !event.getReverseDependencies().get(getModId()).isEmpty();
+        if (hasDisableableFlag != null && hasDisableableFlag)
+        {
+            disableability = hasReverseDepends ? Disableable.DEPENDENCIES : Disableable.YES;
+        }
+        else
+        {
+            disableability = hasReverseDepends ? Disableable.DEPENDENCIES : Disableable.RESTART;
+        }
+        Method factoryMethod = gatherAnnotations(clazz);
+        ILanguageAdapter languageAdapter = getLanguageAdapter();
+        try
+        {
+            modInstance = languageAdapter.getNewInstance(this, clazz, modClassLoader, factoryMethod);
+        }
+        catch (Exception e)
+        {
+            Throwables.throwIfUnchecked(e);
+            FormattedMessage message = new FormattedMessage("{} Failed to load new mod instance.", getModId());
+            throw new LoaderException(message.getFormattedMessage(), e);
+        }
+        NetworkRegistry.INSTANCE.register(this, clazz, (String)(descriptor.getOrDefault("acceptableRemoteVersions", null)), event.getASMHarvestedData());
+        if (fingerprintNotPresent)
+        {
+            eventBus.post(new FMLFingerprintViolationEvent(source.isDirectory(), source, ImmutableSet.copyOf(this.sourceFingerprints), expectedFingerprint));
+        }
+        ProxyInjector.inject(this, event.getASMHarvestedData(), FMLCommonHandler.instance().getSide(), languageAdapter);
+        AutomaticEventSubscriber.inject(this, event.getASMHarvestedData(), FMLCommonHandler.instance().getSide());
+        ConfigManager.sync(this.getModId(), Config.Type.INSTANCE);
+
+        try
+        {
             processFieldAnnotations(event.getASMHarvestedData());
         }
-        catch (Throwable e)
+        catch (IllegalAccessException e)
         {
-            controller.errorOccurred(this, e);
+            FormattedMessage message = new FormattedMessage("{} Failed to process field annotations.", getModId());
+            throw new LoaderException(message.getFormattedMessage(), e);
         }
     }
 

--- a/src/main/java/net/minecraftforge/fml/common/LoadController.java
+++ b/src/main/java/net/minecraftforge/fml/common/LoadController.java
@@ -20,15 +20,14 @@
 package net.minecraftforge.fml.common;
 
 import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
-import java.util.Map;
-import java.util.Map.Entry;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
-import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.common.util.TextTable;
 import net.minecraftforge.fml.common.LoaderState.ModState;
 import net.minecraftforge.fml.common.ProgressManager.ProgressBar;
@@ -39,9 +38,10 @@ import net.minecraftforge.fml.common.event.FMLPreInitializationEvent;
 import net.minecraftforge.fml.common.event.FMLStateEvent;
 import net.minecraftforge.fml.common.versioning.ArtifactVersion;
 
-import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.ThreadContext;
+import org.apache.logging.log4j.message.FormattedMessage;
 
+import com.google.common.base.Throwables;
 import com.google.common.collect.ArrayListMultimap;
 import com.google.common.collect.BiMap;
 import com.google.common.collect.ImmutableBiMap;
@@ -53,9 +53,8 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Multimap;
 import com.google.common.eventbus.EventBus;
+import com.google.common.eventbus.FMLThrowingEventBus;
 import com.google.common.eventbus.Subscribe;
-import com.google.common.eventbus.SubscriberExceptionHandler;
-import com.google.common.eventbus.SubscriberExceptionContext;
 
 import javax.annotation.Nullable;
 
@@ -63,11 +62,9 @@ public class LoadController
 {
     private Loader loader;
     private EventBus masterChannel;
-    private ImmutableMap<String,EventBus> eventChannels;
+    private ImmutableMap<String, EventBus> eventChannels;
     private LoaderState state;
     private Multimap<String, ModState> modStates = ArrayListMultimap.create();
-    private Multimap<String, Throwable> errors = ArrayListMultimap.create();
-    private Map<String, String> modNames = Maps.newHashMap();
     private List<ModContainer> activeModList = Lists.newArrayList();
     private ModContainer activeContainer;
     private BiMap<ModContainer, Object> modObjectList;
@@ -76,13 +73,13 @@ public class LoadController
     public LoadController(Loader loader)
     {
         this.loader = loader;
-        this.masterChannel = new EventBus(new SubscriberExceptionHandler()
-        {
-            @Override
-            public void handleException(Throwable exception, SubscriberExceptionContext context)
-            {
-                FMLLog.log.error("Could not dispatch event: {} to {}", context.getSubscriberMethod(), exception);
-            }
+        this.masterChannel = new FMLThrowingEventBus((exception, context) -> {
+            Throwables.throwIfUnchecked(exception);
+            // should not happen, but add some extra context for checked exceptions
+            Method method = context.getSubscriberMethod();
+            String parameterNames = Stream.of(method.getParameterTypes()).map(Class::getName).collect(Collectors.joining(", "));
+            String message = "Exception thrown during LoadController." + method.getName() + '(' + parameterNames + ')';
+            throw new LoaderExceptionModCrash(message, exception);
         });
         this.masterChannel.register(this);
 
@@ -97,14 +94,12 @@ public class LoadController
         String modId = mod.getModId();
         EventBus bus = temporary.remove(modId);
         bus.post(new FMLModDisabledEvent());
-        if (errors.get(modId).isEmpty())
-        {
-            eventChannels = ImmutableMap.copyOf(temporary);
-            modStates.put(modId, ModState.DISABLED);
-            modObjectList.remove(mod);
-            activeModList.remove(mod);
-        }
+        eventChannels = ImmutableMap.copyOf(temporary);
+        modStates.put(modId, ModState.DISABLED);
+        modObjectList.remove(mod);
+        activeModList.remove(mod);
     }
+
     @Subscribe
     public void buildModList(FMLLoadEvent event)
     {
@@ -112,15 +107,7 @@ public class LoadController
 
         for (final ModContainer mod : loader.getModList())
         {
-            //Create mod logger, and make the EventBus logger a child of it.
-            EventBus bus = new EventBus(new SubscriberExceptionHandler()
-            {
-                @Override
-                public void handleException(final Throwable exception, final SubscriberExceptionContext context)
-                {
-                    LoadController.this.errorOccurred(mod, exception);
-                }
-            });
+            EventBus bus = new FMLThrowingEventBus((exception, context) -> this.errorOccurred(mod, exception));
 
             boolean isActive = mod.registerBus(bus, this);
             if (isActive)
@@ -136,7 +123,6 @@ public class LoadController
                 modStates.put(mod.getModId(), ModState.UNLOADED);
                 modStates.put(mod.getModId(), ModState.DISABLED);
             }
-            modNames.put(mod.getModId(), mod.getName());
         }
 
         eventChannels = eventBus.build();
@@ -159,13 +145,13 @@ public class LoadController
         }
 
         LoaderState oldState = state;
-        state = state.transition(!errors.isEmpty());
+        state = state.transition(false);
         if (state != desiredState)
         {
             if (!forceState)
             {
-                FMLLog.log.fatal("Fatal errors were detected during the transition from {} to {}. Loading cannot continue", oldState, desiredState);
-                throw throwStoredErrors();
+                FormattedMessage message = new FormattedMessage("A fatal error occurred during the state transition from {} to {}. State became {} instead. Loading cannot continue.", oldState, desiredState, state);
+                throw new LoaderException(message.getFormattedMessage());
             }
             else
             {
@@ -178,60 +164,11 @@ public class LoadController
     @Deprecated // TODO remove in 1.13
     public void checkErrorsAfterAvailable()
     {
-        checkErrors();
     }
 
+    @Deprecated // TODO remove in 1.13
     public void checkErrors()
     {
-        if (errors.size() > 0)
-        {
-            FMLLog.log.fatal("Fatal errors were detected during {}. Loading cannot continue.", state);
-            MinecraftForge.EVENT_BUS.shutdown();
-            state = state.transition(true);
-            throw throwStoredErrors();
-        }
-    }
-
-    private RuntimeException throwStoredErrors()
-    {
-        Entry<String, Throwable> toThrow = null;
-        StringBuilder sb = new StringBuilder();
-        printModStates(sb);
-        FMLLog.log.fatal(sb.toString());
-        if (errors.size() > 0)
-        {
-            FMLLog.log.fatal("The following problems were captured during this phase");
-            for (Entry<String, Throwable> entry : errors.entries())
-            {
-                String modId = entry.getKey();
-                String modName = modNames.get(modId);
-                Throwable error = entry.getValue();
-                FMLLog.log.error("Caught exception from {} ({})", modId, modName, error);
-                if (error instanceof IFMLHandledException)
-                {
-                    toThrow = entry;
-                }
-                else if (toThrow == null)
-                {
-                    toThrow = entry;
-                }
-            }
-        }
-
-        if (toThrow == null)
-        {
-            FMLLog.log.fatal("The ForgeModLoader state engine has become corrupted. Probably, a state was missed by and invalid modification to a base class" +
-                    "ForgeModLoader depends on. This is a critical error and not recoverable. Investigate any modifications to base classes outside of" +
-                    "ForgeModLoader, especially Optifine, to see if there are fixes available.");
-            throw new RuntimeException("The ForgeModLoader state engine is invalid");
-        }
-        else
-        {
-            String modId = toThrow.getKey();
-            String modName = modNames.get(modId);
-            String errMsg = String.format("Caught exception from %s (%s)", modName, modId);
-            throw new LoaderExceptionModCrash(errMsg, toThrow.getValue());
-        }
     }
 
     @Nullable
@@ -244,6 +181,7 @@ public class LoadController
     {
         activeContainer = container;
     }
+
     @Subscribe
     public void propogateStateMessage(FMLEvent stateEvent)
     {
@@ -263,10 +201,10 @@ public class LoadController
     private void sendEventToModContainer(FMLEvent stateEvent, ModContainer mc)
     {
         String modId = mc.getModId();
-        Collection<String> requirements =  mc.getRequirements().stream().map(ArtifactVersion::getLabel).collect(Collectors.toCollection(HashSet::new));
+        Collection<String> requirements = mc.getRequirements().stream().map(ArtifactVersion::getLabel).collect(Collectors.toCollection(HashSet::new));
         for (ArtifactVersion av : mc.getDependencies())
         {
-            if (av.getLabel()!= null && requirements.contains(av.getLabel()) && modStates.containsEntry(av.getLabel(),ModState.ERRORED))
+            if (av.getLabel() != null && requirements.contains(av.getLabel()) && modStates.containsEntry(av.getLabel(), ModState.ERRORED))
             {
                 FMLLog.log.error("Skipping event {} and marking errored mod {} since required dependency {} has errored", stateEvent.getEventType(), modId, av.getLabel());
                 modStates.put(modId, ModState.ERRORED);
@@ -283,14 +221,7 @@ public class LoadController
         activeContainer = null;
         if (stateEvent instanceof FMLStateEvent)
         {
-            if (!errors.containsKey(modId))
-            {
-                modStates.put(modId, ((FMLStateEvent)stateEvent).getModState());
-            }
-            else
-            {
-                modStates.put(modId, ModState.ERRORED);
-            }
+            modStates.put(modId, ((FMLStateEvent) stateEvent).getModState());
         }
     }
 
@@ -299,7 +230,7 @@ public class LoadController
         ImmutableBiMap.Builder<ModContainer, Object> builder = ImmutableBiMap.builder();
         for (ModContainer mc : activeModList)
         {
-            if (!mc.isImmutable() && mc.getMod()!=null)
+            if (!mc.isImmutable() && mc.getMod() != null)
             {
                 builder.put(mc, mc.getMod());
                 List<String> packages = mc.getOwnedPackages();
@@ -308,13 +239,10 @@ public class LoadController
                     packageOwners.put(pkg, mc);
                 }
             }
-            if (mc.getMod()==null && !mc.isImmutable() && state!=LoaderState.CONSTRUCTING)
+            if (mc.getMod() == null && !mc.isImmutable() && state != LoaderState.CONSTRUCTING)
             {
-                FMLLog.log.fatal("There is a severe problem with {} - it appears not to have constructed correctly", mc.getModId());
-                if (state != LoaderState.CONSTRUCTING)
-                {
-                    this.errorOccurred(mc, new RuntimeException());
-                }
+                FormattedMessage message = new FormattedMessage("There is a severe problem with {} ({}) - it appears not to have constructed correctly", mc.getName(), mc.getModId());
+                this.errorOccurred(mc, new RuntimeException(message.getFormattedMessage()));
             }
         }
         return builder.build();
@@ -322,14 +250,19 @@ public class LoadController
 
     public void errorOccurred(ModContainer modContainer, Throwable exception)
     {
+        String modId = modContainer.getModId();
+        String modName = modContainer.getName();
+        modStates.put(modId, ModState.ERRORED);
         if (exception instanceof InvocationTargetException)
         {
-            errors.put(modContainer.getModId(), exception.getCause());
+            exception = exception.getCause();
         }
-        else
+        if (exception instanceof LoaderException) // avoid wrapping loader exceptions multiple times
         {
-            errors.put(modContainer.getModId(), exception);
+            throw (LoaderException) exception;
         }
+        FormattedMessage message = new FormattedMessage("Caught exception from {} ({})", modName, modId);
+        throw new LoaderExceptionModCrash(message.getFormattedMessage(), exception);
     }
 
     public void printModStates(StringBuilder ret)
@@ -374,15 +307,16 @@ public class LoadController
 
     public void distributeStateMessage(Class<?> customEvent)
     {
+        Object eventInstance;
         try
         {
-            masterChannel.post(customEvent.newInstance());
+            eventInstance = customEvent.newInstance();
         }
-        catch (Exception e)
+        catch (InstantiationException | IllegalAccessException e)
         {
-            FMLLog.log.error("An unexpected exception", e);
-            throw new LoaderException(e);
+            throw new LoaderException("Failed to create new event instance for " + customEvent.getName(), e);
         }
+        masterChannel.post(eventInstance);
     }
 
     public BiMap<ModContainer, Object> getModObjectList()
@@ -400,8 +334,9 @@ public class LoadController
         return this.state == state;
     }
 
-    boolean hasReachedState(LoaderState state) {
-        return this.state.ordinal()>=state.ordinal() && this.state!=LoaderState.ERRORED;
+    boolean hasReachedState(LoaderState state)
+    {
+        return this.state.ordinal() >= state.ordinal() && this.state != LoaderState.ERRORED;
     }
 
     void forceState(LoaderState newState)
@@ -419,7 +354,7 @@ public class LoadController
             {
                 continue;
             }
-            String pkg = c.getName().substring(0,idx);
+            String pkg = c.getName().substring(0, idx);
             if (packageOwners.containsKey(pkg))
             {
                 return packageOwners.get(pkg).get(0);
@@ -428,6 +363,7 @@ public class LoadController
 
         return null;
     }
+
     private FMLSecurityManager accessibleManager = new FMLSecurityManager();
 
     class FMLSecurityManager extends SecurityManager

--- a/src/main/java/net/minecraftforge/fml/common/Loader.java
+++ b/src/main/java/net/minecraftforge/fml/common/Loader.java
@@ -554,9 +554,10 @@ public class Loader
         ObjectHolderRegistry.INSTANCE.findObjectHolders(new ASMDataTable());
         modController.forceActiveContainer(containers[0]);
     }
+
     /**
      * Called from the hook to start mod loading. We trigger the
-     * {@link #identifyMods()} and Constructing, Preinitalization, and Initalization phases here. Finally,
+     * {@link #identifyMods(List)} and Constructing, Preinitalization, and Initalization phases here. Finally,
      * the mod list is frozen completely and is consider immutable from then on.
      * @param injectedModContainers containers to inject
      */
@@ -631,7 +632,6 @@ public class Loader
         ItemStackHolderInjector.INSTANCE.findHolders(discoverer.getASMTable());
         CapabilityManager.INSTANCE.injectCapabilities(discoverer.getASMTable());
         modController.distributeStateMessage(LoaderState.PREINITIALIZATION, discoverer.getASMTable(), canonicalConfigDir);
-        modController.checkErrors();
         GameData.fireRegistryEvents(rl -> !rl.equals(GameData.RECIPES));
         FMLCommonHandler.instance().fireSidedRegistryEvents();
         ObjectHolderRegistry.INSTANCE.applyObjectHolders();
@@ -757,7 +757,6 @@ public class Loader
         progressBar.step("Finishing up");
         modController.transition(LoaderState.AVAILABLE, false);
         modController.distributeStateMessage(LoaderState.AVAILABLE);
-        modController.checkErrors();
         GameData.freezeData();
         FMLLog.log.info("Forge Mod Loader has successfully loaded {} mod{}", mods.size(), mods.size() == 1 ? "" : "s");
         progressBar.step("Completing Minecraft initialization");

--- a/src/main/java/net/minecraftforge/fml/common/MissingModsException.java
+++ b/src/main/java/net/minecraftforge/fml/common/MissingModsException.java
@@ -21,9 +21,14 @@ package net.minecraftforge.fml.common;
 
 import java.util.Set;
 
+import net.minecraft.client.gui.GuiScreen;
+import net.minecraftforge.fml.client.GuiModsMissing;
+import net.minecraftforge.fml.client.IDisplayableError;
 import net.minecraftforge.fml.common.versioning.ArtifactVersion;
+import net.minecraftforge.fml.relauncher.Side;
+import net.minecraftforge.fml.relauncher.SideOnly;
 
-public class MissingModsException extends EnhancedRuntimeException
+public class MissingModsException extends EnhancedRuntimeException implements IDisplayableError
 {
     private static final long serialVersionUID = 1L;
     public final Set<ArtifactVersion> missingMods;
@@ -50,5 +55,12 @@ public class MissingModsException extends EnhancedRuntimeException
             stream.println(String.format("\t%s : %s", v.getLabel(), v.getRangeString()));
         }
         stream.println("");
+    }
+
+    @Override
+    @SideOnly(Side.CLIENT)
+    public GuiScreen createGui()
+    {
+        return new GuiModsMissing(this);
     }
 }

--- a/src/main/java/net/minecraftforge/fml/common/MultipleModsErrored.java
+++ b/src/main/java/net/minecraftforge/fml/common/MultipleModsErrored.java
@@ -21,7 +21,13 @@ package net.minecraftforge.fml.common;
 
 import java.util.List;
 
-public class MultipleModsErrored extends RuntimeException
+import net.minecraft.client.gui.GuiScreen;
+import net.minecraftforge.fml.client.GuiMultipleModsErrored;
+import net.minecraftforge.fml.client.IDisplayableError;
+import net.minecraftforge.fml.relauncher.Side;
+import net.minecraftforge.fml.relauncher.SideOnly;
+
+public class MultipleModsErrored extends RuntimeException implements IDisplayableError
 {
     public final List<WrongMinecraftVersionException> wrongMinecraftExceptions;
     public final List<MissingModsException>missingModsExceptions;
@@ -29,5 +35,12 @@ public class MultipleModsErrored extends RuntimeException
     {
         this.wrongMinecraftExceptions = wrongMinecraftExceptions;
         this.missingModsExceptions = missingModsExceptions;
+    }
+
+    @Override
+    @SideOnly(Side.CLIENT)
+    public GuiScreen createGui()
+    {
+        return new GuiMultipleModsErrored(this);
     }
 }

--- a/src/main/java/net/minecraftforge/fml/common/WrongMinecraftVersionException.java
+++ b/src/main/java/net/minecraftforge/fml/common/WrongMinecraftVersionException.java
@@ -19,7 +19,13 @@
 
 package net.minecraftforge.fml.common;
 
-public class WrongMinecraftVersionException extends EnhancedRuntimeException
+import net.minecraft.client.gui.GuiScreen;
+import net.minecraftforge.fml.client.GuiWrongMinecraft;
+import net.minecraftforge.fml.client.IDisplayableError;
+import net.minecraftforge.fml.relauncher.Side;
+import net.minecraftforge.fml.relauncher.SideOnly;
+
+public class WrongMinecraftVersionException extends EnhancedRuntimeException implements IDisplayableError
 {
     private static final long serialVersionUID = 1L;
     public ModContainer mod;
@@ -42,4 +48,10 @@ public class WrongMinecraftVersionException extends EnhancedRuntimeException
         stream.println("");
     }
 
+    @Override
+    @SideOnly(Side.CLIENT)
+    public GuiScreen createGui()
+    {
+        return new GuiWrongMinecraft(this);
+    }
 }

--- a/src/main/java/net/minecraftforge/fml/common/toposort/ModSortingException.java
+++ b/src/main/java/net/minecraftforge/fml/common/toposort/ModSortingException.java
@@ -21,10 +21,15 @@ package net.minecraftforge.fml.common.toposort;
 
 import java.util.Set;
 
+import net.minecraft.client.gui.GuiScreen;
+import net.minecraftforge.fml.client.GuiSortingProblem;
+import net.minecraftforge.fml.client.IDisplayableError;
 import net.minecraftforge.fml.common.EnhancedRuntimeException;
 import net.minecraftforge.fml.common.ModContainer;
+import net.minecraftforge.fml.relauncher.Side;
+import net.minecraftforge.fml.relauncher.SideOnly;
 
-public class ModSortingException extends EnhancedRuntimeException
+public class ModSortingException extends EnhancedRuntimeException implements IDisplayableError
 {
     private static final long serialVersionUID = 1L;
 
@@ -76,4 +81,11 @@ public class ModSortingException extends EnhancedRuntimeException
         }
     }
 
+
+    @Override
+    @SideOnly(Side.CLIENT)
+    public GuiScreen createGui()
+    {
+        return new GuiSortingProblem(this);
+    }
 }


### PR DESCRIPTION
Fixes #4847 

## Changes:

This change makes it so that fatal mod errors (errors that are not waiting to show an error screen on client) will crash immediately. They are not stored and then thrown later any more. This reduces the cases where errors are swallowed when they cause other errors further along. It means that the first error is always the one shown, and that the game does not try to keep running after mods have put it into a bad state.

## Testing:

Tested with the Direwolf20 1.12.2 pack and the SevTech pack.

Tested with `ClientLoadingExceptionTest`.

Tested with a version of JEI with a broken pack.mcmeta file like in #4847:

**Before:**
```
---- Minecraft Crash Report ----
// Ouch. That hurt :(

Time: 4/12/18 11:56 PM
Description: There was a severe problem during mod loading that has caused the game to fail

net.minecraftforge.fml.common.LoaderExceptionModCrash: Caught exception from null (jei)
Caused by: java.lang.RuntimeException
	at net.minecraftforge.fml.common.LoadController.buildModObjectList(LoadController.java:316)
	at net.minecraftforge.fml.common.LoadController.propogateStateMessage(LoadController.java:252)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at com.google.common.eventbus.Subscriber.invokeSubscriberMethod(Subscriber.java:91)
	at com.google.common.eventbus.Subscriber$SynchronizedSubscriber.invokeSubscriberMethod(Subscriber.java:150)
	at com.google.common.eventbus.Subscriber$1.run(Subscriber.java:76)
	at com.google.common.util.concurrent.MoreExecutors$DirectExecutor.execute(MoreExecutors.java:399)
	at com.google.common.eventbus.Subscriber.dispatchEvent(Subscriber.java:71)
	at com.google.common.eventbus.Dispatcher$PerThreadQueuedDispatcher.dispatch(Dispatcher.java:116)
	at com.google.common.eventbus.EventBus.post(EventBus.java:217)
	at net.minecraftforge.fml.common.LoadController.distributeStateMessage(LoadController.java:149)
	at net.minecraftforge.fml.common.Loader.preinitializeMods(Loader.java:633)
	at net.minecraftforge.fml.client.FMLClientHandler.beginMinecraftLoading(FMLClientHandler.java:270)
	at net.minecraft.client.Minecraft.init(Minecraft.java:466)
	at net.minecraft.client.Minecraft.run(Minecraft.java:377)
	at net.minecraft.client.main.Main.main(Main.java:118)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at net.minecraft.launchwrapper.Launch.launch(Launch.java:135)
	at net.minecraft.launchwrapper.Launch.main(Launch.java:28)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at net.minecraftforge.gradle.GradleStartCommon.launch(GradleStartCommon.java:97)
	at GradleStart.main(GradleStart.java:25)


A detailed walkthrough of the error, its code path and all known details is as follows:
---------------------------------------------------------------------------------------

-- System Details --
Details:
	Minecraft Version: 1.12.2
	Operating System: Windows 10 (amd64) version 10.0
	Java Version: 1.8.0_151, Oracle Corporation
	Java VM Version: Java HotSpot(TM) 64-Bit Server VM (mixed mode), Oracle Corporation
	Memory: 502844728 bytes (479 MB) / 703594496 bytes (671 MB) up to 3808428032 bytes (3632 MB)
	JVM Flags: 0 total; 
	IntCache: cache: 0, tcache: 0, allocated: 0, tallocated: 0
	FML: MCP 9.42 Powered by Forge 14.23.3.0 5 mods loaded, 5 mods active
	States: 'U' = Unloaded 'L' = Loaded 'C' = Constructed 'H' = Pre-initialized 'I' = Initialized 'J' = Post-initialized 'A' = Available 'D' = Disabled 'E' = Errored

	| State | ID        | Version   | Source               | Signature |
	|:----- |:--------- |:--------- |:-------------------- |:--------- |
	| U     | minecraft | 1.12.2    | minecraft.jar        | None      |
	| U     | mcp       | 9.42      | minecraft.jar        | None      |
	| U     | FML       | 8.0.99.99 | Forge_main           | None      |
	| U     | forge     | 14.23.3.0 | Forge_main           | None      |
	| U     | jei       | 4.8.5     | jei_1.12.2-4.8.5.jar | None      |

	Loaded coremods (and transformers): 
	GL info: ' Vendor: 'NVIDIA Corporation' Version: '4.6.0 NVIDIA 388.43' Renderer: 'GeForce GTX 680/PCIe/SSE2'
```

**After:**
```
---- Minecraft Crash Report ----
// I feel sad now :(

Time: 4/12/18 11:58 PM
Description: Initializing game

java.lang.RuntimeException: An unexpected exception occurred constructing the custom resource pack for Just Enough Items (jei)
	at net.minecraftforge.fml.client.FMLClientHandler.addModAsResource(FMLClientHandler.java:644)
	at net.minecraftforge.fml.common.FMLCommonHandler.addModToResourcePack(FMLCommonHandler.java:539)
	at net.minecraftforge.fml.common.LoadController.buildModList(LoadController.java:118)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at com.google.common.eventbus.Subscriber.invokeSubscriberMethod(Subscriber.java:91)
	at com.google.common.eventbus.Subscriber$SynchronizedSubscriber.invokeSubscriberMethod(Subscriber.java:150)
	at com.google.common.eventbus.Subscriber$1.run(Subscriber.java:76)
	at com.google.common.util.concurrent.MoreExecutors$DirectExecutor.execute(MoreExecutors.java:399)
	at com.google.common.eventbus.Subscriber.dispatchEvent(Subscriber.java:71)
	at com.google.common.eventbus.Dispatcher$PerThreadQueuedDispatcher.dispatch(Dispatcher.java:116)
	at com.google.common.eventbus.EventBus.post(EventBus.java:217)
	at net.minecraftforge.fml.common.LoadController.distributeStateMessage(LoadController.java:319)
	at net.minecraftforge.fml.common.Loader.loadMods(Loader.java:576)
	at net.minecraftforge.fml.client.FMLClientHandler.beginMinecraftLoading(FMLClientHandler.java:222)
	at net.minecraft.client.Minecraft.init(Minecraft.java:466)
	at net.minecraft.client.Minecraft.run(Minecraft.java:377)
	at net.minecraft.client.main.Main.main(Main.java:118)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at net.minecraft.launchwrapper.Launch.launch(Launch.java:135)
	at net.minecraft.launchwrapper.Launch.main(Launch.java:28)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at net.minecraftforge.gradle.GradleStartCommon.launch(GradleStartCommon.java:97)
	at GradleStart.main(GradleStart.java:25)
Caused by: com.google.gson.JsonParseException: com.google.gson.JsonSyntaxException: com.google.gson.stream.MalformedJsonException: Expected name at line 5 column 5 path $.pack.description
	at net.minecraft.client.resources.AbstractResourcePack.readMetadata(AbstractResourcePack.java:81)
	at net.minecraft.client.resources.AbstractResourcePack.getPackMetadata(AbstractResourcePack.java:66)
	at net.minecraftforge.fml.client.FMLClientHandler.addModAsResource(FMLClientHandler.java:627)
	... 31 more
Caused by: com.google.gson.JsonSyntaxException: com.google.gson.stream.MalformedJsonException: Expected name at line 5 column 5 path $.pack.description
	at com.google.gson.internal.Streams.parse(Streams.java:60)
	at com.google.gson.JsonParser.parse(JsonParser.java:84)
	at com.google.gson.JsonParser.parse(JsonParser.java:59)
	at net.minecraft.client.resources.AbstractResourcePack.readMetadata(AbstractResourcePack.java:77)
	... 33 more
Caused by: com.google.gson.stream.MalformedJsonException: Expected name at line 5 column 5 path $.pack.description
	at com.google.gson.stream.JsonReader.syntaxError(JsonReader.java:1559)
	at com.google.gson.stream.JsonReader.doPeek(JsonReader.java:505)
	at com.google.gson.stream.JsonReader.hasNext(JsonReader.java:414)
	at com.google.gson.internal.bind.TypeAdapters$29.read(TypeAdapters.java:738)
	at com.google.gson.internal.bind.TypeAdapters$29.read(TypeAdapters.java:739)
	at com.google.gson.internal.bind.TypeAdapters$29.read(TypeAdapters.java:714)
	at com.google.gson.internal.Streams.parse(Streams.java:48)
	... 36 more


A detailed walkthrough of the error, its code path and all known details is as follows:
---------------------------------------------------------------------------------------

-- Head --
Thread: Client thread
Stacktrace:
	at net.minecraftforge.fml.client.FMLClientHandler.addModAsResource(FMLClientHandler.java:644)
	at net.minecraftforge.fml.common.FMLCommonHandler.addModToResourcePack(FMLCommonHandler.java:539)
	at net.minecraftforge.fml.common.LoadController.buildModList(LoadController.java:118)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at com.google.common.eventbus.Subscriber.invokeSubscriberMethod(Subscriber.java:91)
	at com.google.common.eventbus.Subscriber$SynchronizedSubscriber.invokeSubscriberMethod(Subscriber.java:150)
	at com.google.common.eventbus.Subscriber$1.run(Subscriber.java:76)
	at com.google.common.util.concurrent.MoreExecutors$DirectExecutor.execute(MoreExecutors.java:399)
	at com.google.common.eventbus.Subscriber.dispatchEvent(Subscriber.java:71)
	at com.google.common.eventbus.Dispatcher$PerThreadQueuedDispatcher.dispatch(Dispatcher.java:116)
	at com.google.common.eventbus.EventBus.post(EventBus.java:217)
	at net.minecraftforge.fml.common.LoadController.distributeStateMessage(LoadController.java:319)
	at net.minecraftforge.fml.common.Loader.loadMods(Loader.java:576)
	at net.minecraftforge.fml.client.FMLClientHandler.beginMinecraftLoading(FMLClientHandler.java:222)
	at net.minecraft.client.Minecraft.init(Minecraft.java:466)

-- Initialization --
Details:
Stacktrace:
	at net.minecraft.client.Minecraft.run(Minecraft.java:377)
	at net.minecraft.client.main.Main.main(Main.java:118)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at net.minecraft.launchwrapper.Launch.launch(Launch.java:135)
	at net.minecraft.launchwrapper.Launch.main(Launch.java:28)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at net.minecraftforge.gradle.GradleStartCommon.launch(GradleStartCommon.java:97)
	at GradleStart.main(GradleStart.java:25)

-- System Details --
Details:
	Minecraft Version: 1.12.2
	Operating System: Windows 10 (amd64) version 10.0
	Java Version: 1.8.0_151, Oracle Corporation
	Java VM Version: Java HotSpot(TM) 64-Bit Server VM (mixed mode), Oracle Corporation
	Memory: 458398568 bytes (437 MB) / 677904384 bytes (646 MB) up to 3808428032 bytes (3632 MB)
	JVM Flags: 0 total; 
	IntCache: cache: 0, tcache: 0, allocated: 0, tallocated: 0
	FML: MCP 9.42 Powered by Forge 14.23.3.0 5 mods loaded, 5 mods active
	States: 'U' = Unloaded 'L' = Loaded 'C' = Constructed 'H' = Pre-initialized 'I' = Initialized 'J' = Post-initialized 'A' = Available 'D' = Disabled 'E' = Errored

	| State | ID        | Version   | Source               | Signature |
	|:----- |:--------- |:--------- |:-------------------- |:--------- |
	| U     | minecraft | 1.12.2    | minecraft.jar        | None      |
	| U     | mcp       | 9.42      | minecraft.jar        | None      |
	| U     | FML       | 8.0.99.99 | Forge_main           | None      |
	| U     | forge     | 14.23.3.0 | Forge_main           | None      |
	| U     | jei       | 4.8.5     | jei_1.12.2-4.8.5.jar | None      |

	Loaded coremods (and transformers): 
	GL info: ' Vendor: 'NVIDIA Corporation' Version: '4.6.0 NVIDIA 388.43' Renderer: 'GeForce GTX 680/PCIe/SSE2'
	Launched Version: @@MCVERSION@@
	LWJGL: 2.9.4
	OpenGL: GeForce GTX 680/PCIe/SSE2 GL version 4.6.0 NVIDIA 388.43, NVIDIA Corporation
	GL Caps: Using GL 1.3 multitexturing.
Using GL 1.3 texture combiners.
Using framebuffer objects because OpenGL 3.0 is supported and separate blending is supported.
Shaders are available because OpenGL 2.1 is supported.
VBOs are available because OpenGL 1.5 is supported.

	Using VBOs: Yes
	Is Modded: Definitely; Client brand changed to 'fml,forge'
	Type: Client (map_client.txt)
	Resource Packs: 
	Current Language: English (US)
	Profiler Position: N/A (disabled)
	CPU: 8x Intel(R) Core(TM) i7-7700K CPU @ 4.20GHz
```