### PR TITLE
Clean up Reader/Writer handling to use a specified charset

### DIFF
--- a/src/main/java/net/minecraftforge/client/model/BlockStateLoader.java
+++ b/src/main/java/net/minecraftforge/client/model/BlockStateLoader.java
@@ -76,7 +76,7 @@ public class BlockStateLoader
             byte[] data = IOUtils.toByteArray(reader, StandardCharsets.UTF_8);
             reader = new InputStreamReader(new ByteArrayInputStream(data), StandardCharsets.UTF_8);
 
-            Marker marker = GSON.fromJson(new String(data), Marker.class);  // Read "forge_marker" to determine what to load.
+            Marker marker = GSON.fromJson(new String(data, StandardCharsets.UTF_8), Marker.class);  // Read "forge_marker" to determine what to load.
 
             switch (marker.forge_marker)
             {

--- a/src/main/java/net/minecraftforge/client/model/animation/ModelBlockAnimation.java
+++ b/src/main/java/net/minecraftforge/client/model/animation/ModelBlockAnimation.java
@@ -22,11 +22,13 @@ package net.minecraftforge.client.model.animation;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
 import java.util.Collections;
 import java.util.EnumSet;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.NoSuchElementException;
+import java.util.Optional;
 import java.util.TreeMap;
 
 import javax.annotation.Nullable;
@@ -34,9 +36,6 @@ import javax.vecmath.AxisAngle4f;
 import javax.vecmath.Matrix4f;
 import javax.vecmath.Quat4f;
 import javax.vecmath.Vector3f;
-
-import org.apache.commons.io.IOUtils;
-import org.apache.logging.log4j.Level;
 
 import net.minecraft.client.renderer.block.model.BlockPart;
 import net.minecraft.client.resources.IResource;
@@ -56,7 +55,6 @@ import net.minecraftforge.common.model.animation.JointClips;
 import net.minecraftforge.common.util.JsonUtils;
 import net.minecraftforge.fml.common.FMLLog;
 
-import java.util.Optional;
 import com.google.common.collect.ImmutableCollection;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -557,7 +555,7 @@ public class ModelBlockAnimation
         {
             try (IResource resource = manager.getResource(armatureLocation))
             {
-                ModelBlockAnimation mba = mbaGson.fromJson(new InputStreamReader(resource.getInputStream(), "UTF-8"), ModelBlockAnimation.class);
+                ModelBlockAnimation mba = mbaGson.fromJson(new InputStreamReader(resource.getInputStream(), StandardCharsets.UTF_8), ModelBlockAnimation.class);
                 //String json = mbaGson.toJson(mba);
                 return mba;
             }

--- a/src/main/java/net/minecraftforge/common/model/animation/AnimationStateMachine.java
+++ b/src/main/java/net/minecraftforge/common/model/animation/AnimationStateMachine.java
@@ -51,7 +51,6 @@ import net.minecraftforge.common.util.JsonUtils;
 import net.minecraftforge.fml.common.FMLLog;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
-import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.commons.lang3.tuple.Triple;
 
@@ -60,6 +59,7 @@ import java.io.IOException;
 import java.io.InputStreamReader;
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
+import java.nio.charset.StandardCharsets;
 import java.util.Collection;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
@@ -222,7 +222,7 @@ public final class AnimationStateMachine implements IAnimationStateMachine
             ParameterResolver parameterResolver = new ParameterResolver(customParameters);
             Clips.CommonClipTypeAdapterFactory.INSTANCE.setClipResolver(clipResolver);
             TimeValues.CommonTimeValueTypeAdapterFactory.INSTANCE.setValueResolver(parameterResolver);
-            AnimationStateMachine asm = asmGson.fromJson(new InputStreamReader(resource.getInputStream(), "UTF-8"), AnimationStateMachine.class);
+            AnimationStateMachine asm = asmGson.fromJson(new InputStreamReader(resource.getInputStream(), StandardCharsets.UTF_8), AnimationStateMachine.class);
             clipResolver.asm = asm;
             parameterResolver.asm = asm;
             asm.initialize();

--- a/src/main/java/net/minecraftforge/fml/client/SplashProgress.java
+++ b/src/main/java/net/minecraftforge/fml/client/SplashProgress.java
@@ -24,12 +24,17 @@ import static org.lwjgl.opengl.GL12.*;
 
 import java.awt.image.BufferedImage;
 import java.io.File;
-import java.io.FileReader;
-import java.io.FileWriter;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.OutputStreamWriter;
+import java.io.Reader;
+import java.io.Writer;
 import java.lang.Thread.UncaughtExceptionHandler;
 import java.nio.IntBuffer;
+import java.nio.charset.StandardCharsets;
 import java.util.Iterator;
 import java.util.Properties;
 import java.util.concurrent.Semaphore;
@@ -149,7 +154,7 @@ public class SplashProgress
             parent.mkdirs();
 
         config = new Properties();
-        try (FileReader r = new FileReader(configFile))
+        try (Reader r = new InputStreamReader(new FileInputStream(configFile), StandardCharsets.UTF_8))
         {
             config.load(r);
         }
@@ -184,7 +189,7 @@ public class SplashProgress
 
         File miscPackFile = new File(Minecraft.getMinecraft().mcDataDir, getString("resourcePackPath", "resources"));
 
-        try (FileWriter w = new FileWriter(configFile))
+        try (Writer w = new OutputStreamWriter(new FileOutputStream(configFile), StandardCharsets.UTF_8))
         {
             config.store(w, "Splash screen properties");
         }
@@ -707,7 +712,7 @@ public class SplashProgress
         enabled = false;
         config.setProperty("enabled", "false");
 
-        try (FileWriter w = new FileWriter(configFile))
+        try (Writer w = new OutputStreamWriter(new FileOutputStream(configFile), StandardCharsets.UTF_8))
         {
             config.store(w, "Splash screen properties");
         }

--- a/src/main/java/net/minecraftforge/fml/common/Loader.java
+++ b/src/main/java/net/minecraftforge/fml/common/Loader.java
@@ -20,11 +20,14 @@
 package net.minecraftforge.fml.common;
 
 import java.io.File;
-import java.io.FileReader;
-import java.io.FileWriter;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.OutputStreamWriter;
 import java.net.MalformedURLException;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.Iterator;
@@ -32,10 +35,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
-import java.util.regex.Matcher;
 
 import net.minecraft.util.ResourceLocation;
-import net.minecraftforge.classloading.FMLForgePlugin;
 import net.minecraftforge.common.ForgeVersion;
 import net.minecraftforge.common.capabilities.CapabilityManager;
 import net.minecraftforge.common.config.ConfigManager;
@@ -657,7 +658,7 @@ public class Loader
             FMLLog.log.trace("Found a mod state file {}", forcedModFile.getName());
             try
             {
-                forcedModListProperties.load(new FileReader(forcedModFile));
+                forcedModListProperties.load(new InputStreamReader(new FileInputStream(forcedModFile), StandardCharsets.UTF_8));
                 FMLLog.log.trace("Loaded states for {} mods from file", forcedModListProperties.size());
             }
             catch (Exception e)
@@ -960,9 +961,9 @@ public class Loader
         try
         {
             Properties props = new Properties();
-            props.load(new FileReader(forcedModFile));
+            props.load(new InputStreamReader(new FileInputStream(forcedModFile), StandardCharsets.UTF_8));
             props.put(modId, "false");
-            props.store(new FileWriter(forcedModFile), null);
+            props.store(new OutputStreamWriter(new FileOutputStream(forcedModFile), StandardCharsets.UTF_8), null);
         }
         catch (Exception e)
         {
@@ -991,7 +992,7 @@ public class Loader
         JsonElement injectedDeps;
         try
         {
-            injectedDeps = parser.parse(new FileReader(injectedDepFile));
+            injectedDeps = parser.parse(new InputStreamReader(new FileInputStream(injectedDepFile), StandardCharsets.UTF_8));
             for (JsonElement el : injectedDeps.getAsJsonArray())
             {
                 JsonObject jo = el.getAsJsonObject();

--- a/src/main/java/net/minecraftforge/fml/common/MetadataCollection.java
+++ b/src/main/java/net/minecraftforge/fml/common/MetadataCollection.java
@@ -22,6 +22,7 @@ package net.minecraftforge.fml.common;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
 import java.util.Map;
 
 import net.minecraftforge.fml.common.versioning.ArtifactVersion;
@@ -53,7 +54,7 @@ public class MetadataCollection
             return new MetadataCollection();
         }
 
-        InputStreamReader reader = new InputStreamReader(inputStream);
+        InputStreamReader reader = new InputStreamReader(inputStream, StandardCharsets.UTF_8);
         try
         {
             MetadataCollection collection;

--- a/src/main/java/net/minecraftforge/fml/common/discovery/json/JsonAnnotationLoader.java
+++ b/src/main/java/net/minecraftforge/fml/common/discovery/json/JsonAnnotationLoader.java
@@ -21,6 +21,7 @@ package net.minecraftforge.fml.common.discovery.json;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.lang.reflect.Type;
+import java.nio.charset.StandardCharsets;
 import java.util.Map;
 import java.util.Map.Entry;
 
@@ -43,7 +44,7 @@ public class JsonAnnotationLoader
 
     public static Multimap<String, ASMData> loadJson(InputStream data, ModCandidate candidate, ASMDataTable table)
     {
-        Map<String, ASMInfo> map = GSON.fromJson(new InputStreamReader(data), INFO_TABLE);
+        Map<String, ASMInfo> map = GSON.fromJson(new InputStreamReader(data, StandardCharsets.UTF_8), INFO_TABLE);
         Multimap<String, ASMData> ret = HashMultimap.create();
 
         for (Entry<String, ASMInfo> entry : map.entrySet())


### PR DESCRIPTION
As per the title, this cleans up various uses of `Reader`/`Writer` instances which don't specify a charset (or look up one by name).

It's better to explicitly specify a charset to use, as the default can vary depending on the system. This helps prevent issues caused by mismatched encodings.