### PR TITLE
Some fixes for extracted dependencies

### DIFF
--- a/src/main/java/net/minecraftforge/fml/relauncher/libraries/LinkRepository.java
+++ b/src/main/java/net/minecraftforge/fml/relauncher/libraries/LinkRepository.java
@@ -97,6 +97,6 @@ public class LinkRepository extends Repository
     @Override
     public File getFile(String path)
     {
-        return filesystem.containsKey(path) ? super.getFile(path) : filesystem.get(path);
+        return filesystem.containsKey(path) ? filesystem.get(path) : super.getFile(path);
     }
 }

--- a/src/main/java/net/minecraftforge/fml/relauncher/libraries/SnapshotJson.java
+++ b/src/main/java/net/minecraftforge/fml/relauncher/libraries/SnapshotJson.java
@@ -54,7 +54,7 @@ public class SnapshotJson implements Comparable<SnapshotJson>
     public static final DateFormat TIMESTAMP = new SimpleDateFormat("yyyymmdd.hhmmss");
     public static final String META_JSON_FILE = "maven-metadata.json";
     private static final Gson GSON = new GsonBuilder().create();
-    private static final Comparator<Entry> SORTER = (o1, o2) -> o2.timestamp.compareTo(o2.timestamp);
+    private static final Comparator<Entry> SORTER = (o1, o2) -> o2.timestamp.compareTo(o1.timestamp);
 
     public static SnapshotJson create(File target)
     {


### PR DESCRIPTION
LinkRepository contains a tiny mistake which results in an NPE.

The timestamp handling was not completely repaired in the previous PR. This is the rest of it.

The new dependency extraction still has deeper issues. They will be easier to investigate when these crashes are removed.