### PR TITLE
Fix incorrectly-typed comparisons in biome dictionary

### DIFF
--- a/src/main/java/net/minecraftforge/common/BiomeDictionary.java
+++ b/src/main/java/net/minecraftforge/common/BiomeDictionary.java
@@ -347,20 +347,20 @@ public class BiomeDictionary
             BiomeDictionary.addTypes(biome, SNOWY);
         }
 
-        if (biome.topBlock != Blocks.SAND && biome.getDefaultTemperature() >= 1.0f && biome.getRainfall() < 0.2f)
+        if (biome.topBlock.getBlock() != Blocks.SAND && biome.getDefaultTemperature() >= 1.0f && biome.getRainfall() < 0.2f)
         {
             BiomeDictionary.addTypes(biome, SAVANNA);
         }
 
-        if (biome.topBlock == Blocks.SAND)
+        if (biome.topBlock.getBlock() == Blocks.SAND)
         {
             BiomeDictionary.addTypes(biome, SANDY);
         }
-        else if (biome.topBlock == Blocks.MYCELIUM)
+        else if (biome.topBlock.getBlock() == Blocks.MYCELIUM)
         {
             BiomeDictionary.addTypes(biome, MUSHROOM);
         }
-        if (biome.fillerBlock == Blocks.HARDENED_CLAY)
+        if (biome.fillerBlock.getBlock() == Blocks.HARDENED_CLAY)
         {
             BiomeDictionary.addTypes(biome, MESA);
         }


### PR DESCRIPTION
Small PR to fix `BiomeDictionary.makeBestGuess`, which currently incorrectly performs equality checks between `IBlockState` and `Block` instances.