### PR TITLE
Fix some code holding client world references longer than needed

### DIFF
--- a/patches/minecraft/net/minecraft/client/Minecraft.java.patch
+++ b/patches/minecraft/net/minecraft/client/Minecraft.java.patch
@@ -334,7 +334,15 @@
          }
  
          this.field_147127_av.func_147690_c();
-@@ -2535,159 +2597,8 @@
+@@ -2434,6 +2496,7 @@
+         }
+ 
+         TileEntityRendererDispatcher.field_147556_a.func_147543_a(p_71353_1_);
++        net.minecraftforge.client.MinecraftForgeClient.clearRenderCache();
+ 
+         if (p_71353_1_ != null)
+         {
+@@ -2535,159 +2598,8 @@
      {
          if (this.field_71476_x != null && this.field_71476_x.field_72313_a != RayTraceResult.Type.MISS)
          {
@@ -496,7 +504,7 @@
          }
      }
  
-@@ -3009,18 +2920,8 @@
+@@ -3009,18 +2921,8 @@
  
      public static int func_71369_N()
      {
@@ -517,7 +525,7 @@
      }
  
      public boolean func_70002_Q()
-@@ -3152,6 +3053,9 @@
+@@ -3152,6 +3054,9 @@
          }
          else if (this.field_71439_g != null)
          {
@@ -527,7 +535,7 @@
              if (this.field_71439_g.field_70170_p.field_73011_w instanceof WorldProviderHell)
              {
                  return MusicTicker.MusicType.NETHER;
-@@ -3181,11 +3085,11 @@
+@@ -3181,11 +3086,11 @@
              {
                  if (Keyboard.getEventKeyState())
                  {
@@ -541,7 +549,7 @@
                      {
                          this.field_71456_v.func_146158_b().func_146227_a(ScreenShotHelper.func_148260_a(this.field_71412_D, this.field_71443_c, this.field_71440_d, this.field_147124_at));
                      }
-@@ -3199,6 +3103,7 @@
+@@ -3199,6 +3104,7 @@
                          }
                      }
                  }
@@ -549,7 +557,7 @@
              }
          }
      }
-@@ -3328,6 +3233,12 @@
+@@ -3328,6 +3234,12 @@
          return this.field_184127_aH;
      }
  
@@ -562,7 +570,7 @@
      public boolean func_189648_am()
      {
          return this.field_71439_g != null && this.field_71439_g.func_175140_cp() || this.field_71474_y.field_178879_v;
-@@ -3342,4 +3253,9 @@
+@@ -3342,4 +3254,9 @@
      {
          return this.field_193035_aW;
      }

--- a/src/main/java/net/minecraftforge/client/MinecraftForgeClient.java
+++ b/src/main/java/net/minecraftforge/client/MinecraftForgeClient.java
@@ -100,7 +100,7 @@ public class MinecraftForgeClient
         .build(new CacheLoader<Pair<World, BlockPos>, ChunkCache>()
         {
             @Override
-            public ChunkCache load(Pair<World, BlockPos> key) throws Exception
+            public ChunkCache load(Pair<World, BlockPos> key)
             {
                 return new ChunkCache(key.getLeft(), key.getRight().add(-1, -1, -1), key.getRight().add(16, 16, 16), 1);
             }
@@ -117,5 +117,11 @@ public class MinecraftForgeClient
         int y = pos.getY() & ~0xF;
         int z = pos.getZ() & ~0xF;
         return regionCache.getUnchecked(Pair.of(world, new BlockPos(x, y, z)));
+    }
+
+    public static void clearRenderCache()
+    {
+        regionCache.invalidateAll();
+        regionCache.cleanUp();
     }
 }

--- a/src/main/java/net/minecraftforge/client/model/pipeline/BlockInfo.java
+++ b/src/main/java/net/minecraftforge/client/model/pipeline/BlockInfo.java
@@ -94,6 +94,16 @@ public class BlockInfo
         shx = shy = shz = 0;
     }
 
+    public void reset()
+    {
+        this.world = null;
+        this.state = null;
+        this.blockPos = null;
+        cachedTint = -1;
+        cachedMultiplier = -1;
+        shx = shy = shz = 0;
+    }
+
     private float combine(int c, int s1, int s2, int s3, boolean t0, boolean t1, boolean t2, boolean t3)
     {
         if (c  == 0 && !t0) c  = Math.max(0, Math.max(s1, s2) - 1);

--- a/src/main/java/net/minecraftforge/client/model/pipeline/ForgeBlockModelRenderer.java
+++ b/src/main/java/net/minecraftforge/client/model/pipeline/ForgeBlockModelRenderer.java
@@ -122,6 +122,7 @@ public class ForgeBlockModelRenderer extends BlockModelRenderer
                 }
             }
         }
+        lighter.resetBlockInfo();
         return !empty;
     }
 }

--- a/src/main/java/net/minecraftforge/client/model/pipeline/VertexLighterFlat.java
+++ b/src/main/java/net/minecraftforge/client/model/pipeline/VertexLighterFlat.java
@@ -302,6 +302,11 @@ public class VertexLighterFlat extends QuadGatheringTransformer
         blockInfo.setBlockPos(blockPos);
     }
 
+    public void resetBlockInfo()
+    {
+        blockInfo.reset();
+    }
+
     public void updateBlockInfo()
     {
         blockInfo.updateShift();

--- a/src/main/java/net/minecraftforge/common/ForgeInternalHandler.java
+++ b/src/main/java/net/minecraftforge/common/ForgeInternalHandler.java
@@ -19,17 +19,16 @@
 
 package net.minecraftforge.common;
 
-import net.minecraft.client.multiplayer.WorldClient;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.item.EntityItem;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraft.world.WorldServer;
-import net.minecraftforge.client.MinecraftForgeClient;
 import net.minecraftforge.common.util.FakePlayerFactory;
 import net.minecraftforge.event.entity.EntityJoinWorldEvent;
 import net.minecraftforge.event.world.WorldEvent;
 import net.minecraftforge.fml.client.FMLClientHandler;
+import net.minecraftforge.fml.common.FMLLog;
 import net.minecraftforge.fml.common.eventhandler.EventPriority;
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
 import net.minecraftforge.fml.common.gameevent.TickEvent;
@@ -83,8 +82,6 @@ public class ForgeInternalHandler
         ForgeChunkManager.unloadWorld(event.getWorld());
         if (event.getWorld() instanceof WorldServer)
             FakePlayerFactory.unloadWorld((WorldServer) event.getWorld());
-        else if (event.getWorld() instanceof WorldClient)
-            MinecraftForgeClient.clearRenderCache();
     }
 
     @SubscribeEvent

--- a/src/main/java/net/minecraftforge/common/ForgeInternalHandler.java
+++ b/src/main/java/net/minecraftforge/common/ForgeInternalHandler.java
@@ -19,16 +19,17 @@
 
 package net.minecraftforge.common;
 
+import net.minecraft.client.multiplayer.WorldClient;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.item.EntityItem;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraft.world.WorldServer;
+import net.minecraftforge.client.MinecraftForgeClient;
 import net.minecraftforge.common.util.FakePlayerFactory;
 import net.minecraftforge.event.entity.EntityJoinWorldEvent;
 import net.minecraftforge.event.world.WorldEvent;
 import net.minecraftforge.fml.client.FMLClientHandler;
-import net.minecraftforge.fml.common.FMLLog;
 import net.minecraftforge.fml.common.eventhandler.EventPriority;
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
 import net.minecraftforge.fml.common.gameevent.TickEvent;
@@ -82,6 +83,8 @@ public class ForgeInternalHandler
         ForgeChunkManager.unloadWorld(event.getWorld());
         if (event.getWorld() instanceof WorldServer)
             FakePlayerFactory.unloadWorld((WorldServer) event.getWorld());
+        else if (event.getWorld() instanceof WorldClient)
+            MinecraftForgeClient.clearRenderCache();
     }
 
     @SubscribeEvent


### PR DESCRIPTION
This fixes instances of Forge code holding on to `WorldClient` references for longer than necessary, preventing garbage collection.

While the worlds aren't permanently leaked, I think it's better to free up memory promptly where we can.