### PR TITLE
Fix server-side data not being released

### DIFF
--- a/patches/minecraft/net/minecraft/server/MinecraftServer.java.patch
+++ b/patches/minecraft/net/minecraft/server/MinecraftServer.java.patch
@@ -70,7 +70,7 @@
          BlockPos blockpos = worldserver.func_175694_M();
          long k1 = func_130071_aq();
  
-@@ -434,9 +449,16 @@
+@@ -434,15 +449,24 @@
              {
                  if (worldserver1 != null)
                  {
@@ -87,7 +87,15 @@
          }
  
          if (this.field_71307_n.func_76468_d())
-@@ -461,6 +483,7 @@
+         {
+             this.field_71307_n.func_76470_e();
+         }
++
++        CommandBase.func_71529_a(null); // Forge: fix MC-128561
+     }
+ 
+     public boolean func_71278_l()
+@@ -461,6 +485,7 @@
          {
              if (this.func_71197_b())
              {
@@ -95,7 +103,7 @@
                  this.field_175591_ab = func_130071_aq();
                  long i = 0L;
                  this.field_147147_p.func_151315_a(new TextComponentString(this.field_71286_C));
-@@ -505,12 +528,20 @@
+@@ -505,12 +530,20 @@
                      Thread.sleep(Math.max(1L, 50L - i));
                      this.field_71296_Q = true;
                  }
@@ -116,7 +124,7 @@
          catch (Throwable throwable1)
          {
              field_147145_h.error("Encountered an unexpected exception", throwable1);
-@@ -536,13 +567,13 @@
+@@ -536,13 +569,13 @@
                  field_147145_h.error("We were unable to save this crash report to disk.");
              }
  
@@ -131,7 +139,7 @@
                  this.func_71260_j();
              }
              catch (Throwable throwable)
-@@ -551,6 +582,8 @@
+@@ -551,6 +584,8 @@
              }
              finally
              {
@@ -140,7 +148,7 @@
                  this.func_71240_o();
              }
          }
-@@ -577,6 +610,7 @@
+@@ -577,6 +612,7 @@
                  ImageIO.write(bufferedimage, "PNG", new ByteBufOutputStream(bytebuf));
                  ByteBuf bytebuf1 = Base64.encode(bytebuf);
                  p_184107_1_.func_151320_a("data:image/png;base64," + bytebuf1.toString(StandardCharsets.UTF_8));
@@ -148,7 +156,7 @@
              }
              catch (Exception exception)
              {
-@@ -618,6 +652,7 @@
+@@ -618,6 +654,7 @@
      public void func_71217_p()
      {
          long i = System.nanoTime();
@@ -156,7 +164,7 @@
          ++this.field_71315_w;
  
          if (this.field_71295_T)
-@@ -644,6 +679,7 @@
+@@ -644,6 +681,7 @@
  
              Collections.shuffle(Arrays.asList(agameprofile));
              this.field_147147_p.func_151318_b().func_151330_a(agameprofile);
@@ -164,7 +172,7 @@
          }
  
          if (this.field_71315_w % 900 == 0)
-@@ -671,6 +707,7 @@
+@@ -671,6 +709,7 @@
  
          this.field_71304_b.func_76319_b();
          this.field_71304_b.func_76319_b();
@@ -172,7 +180,7 @@
      }
  
      public void func_71190_q()
-@@ -686,14 +723,17 @@
+@@ -686,14 +725,17 @@
          }
  
          this.field_71304_b.func_76318_c("levels");
@@ -193,7 +201,7 @@
                  this.field_71304_b.func_194340_a(() ->
                  {
                      return worldserver.func_72912_H().func_76065_j();
-@@ -702,11 +742,12 @@
+@@ -702,11 +744,12 @@
                  if (this.field_71315_w % 20 == 0)
                  {
                      this.field_71304_b.func_76320_a("timeSync");
@@ -207,7 +215,7 @@
  
                  try
                  {
-@@ -730,6 +771,7 @@
+@@ -730,6 +773,7 @@
                      throw new ReportedException(crashreport1);
                  }
  
@@ -215,7 +223,7 @@
                  this.field_71304_b.func_76319_b();
                  this.field_71304_b.func_76320_a("tracker");
                  worldserver.func_73039_n().func_72788_a();
-@@ -737,9 +779,11 @@
+@@ -737,9 +781,11 @@
                  this.field_71304_b.func_76319_b();
              }
  
@@ -228,7 +236,7 @@
          this.field_71304_b.func_76318_c("connection");
          this.func_147137_ag().func_151269_c();
          this.field_71304_b.func_76318_c("players");
-@@ -763,7 +807,8 @@
+@@ -763,7 +809,8 @@
  
      public void func_71256_s()
      {
@@ -238,7 +246,7 @@
          this.field_175590_aa.start();
      }
  
-@@ -779,14 +824,13 @@
+@@ -779,14 +826,13 @@
  
      public WorldServer func_71218_a(int p_71218_1_)
      {
@@ -258,7 +266,7 @@
      }
  
      public String func_71249_w()
-@@ -816,7 +860,7 @@
+@@ -816,7 +862,7 @@
  
      public String getServerModName()
      {
@@ -267,7 +275,7 @@
      }
  
      public CrashReport func_71230_b(CrashReport p_71230_1_)
-@@ -1598,4 +1642,9 @@
+@@ -1598,4 +1644,9 @@
      {
          return this.field_175590_aa;
      }

--- a/src/main/java/net/minecraftforge/fml/common/network/FMLEmbeddedChannel.java
+++ b/src/main/java/net/minecraftforge/fml/common/network/FMLEmbeddedChannel.java
@@ -28,6 +28,7 @@ import net.minecraft.network.Packet;
 import net.minecraftforge.fml.common.Loader;
 import net.minecraftforge.fml.common.ModContainer;
 import net.minecraftforge.fml.common.network.FMLOutboundHandler.OutboundTarget;
+import net.minecraftforge.fml.common.network.handshake.NetworkDispatcher;
 import net.minecraftforge.fml.common.network.internal.FMLProxyPacket;
 import net.minecraftforge.fml.relauncher.Side;
 
@@ -87,5 +88,12 @@ public class FMLEmbeddedChannel extends EmbeddedChannel {
             }
         }
         return targetName;
+    }
+
+    public void cleanAttributes()
+    {
+        this.attr(FMLOutboundHandler.FML_MESSAGETARGETARGS).set(null);
+        this.attr(NetworkRegistry.NET_HANDLER).set(null);
+        this.attr(NetworkDispatcher.FML_DISPATCHER).set(null);
     }
 }

--- a/src/main/java/net/minecraftforge/fml/common/network/NetworkRegistry.java
+++ b/src/main/java/net/minecraftforge/fml/common/network/NetworkRegistry.java
@@ -27,11 +27,8 @@ import io.netty.util.AttributeKey;
 import java.util.Collection;
 import java.util.EnumMap;
 import java.util.Map;
-import java.util.Map.Entry;
 import java.util.Set;
 import java.util.stream.Collectors;
-
-import org.apache.logging.log4j.Level;
 
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.entity.player.EntityPlayerMP;
@@ -342,11 +339,16 @@ public enum NetworkRegistry
     public void fireNetworkHandshake(NetworkDispatcher networkDispatcher, Side origin)
     {
         NetworkHandshakeEstablished handshake = new NetworkHandshakeEstablished(networkDispatcher, networkDispatcher.getNetHandler(), origin);
-        for (Entry<String, FMLEmbeddedChannel> channel : channels.get(origin).entrySet())
+        for (FMLEmbeddedChannel channel : channels.get(origin).values())
         {
-            channel.getValue().attr(FMLOutboundHandler.FML_MESSAGETARGET).set(OutboundTarget.DISPATCHER);
-            channel.getValue().attr(FMLOutboundHandler.FML_MESSAGETARGETARGS).set(networkDispatcher);
-            channel.getValue().pipeline().fireUserEventTriggered(handshake);
+            channel.attr(FMLOutboundHandler.FML_MESSAGETARGET).set(OutboundTarget.DISPATCHER);
+            channel.attr(FMLOutboundHandler.FML_MESSAGETARGETARGS).set(networkDispatcher);
+            channel.pipeline().fireUserEventTriggered(handshake);
         }
+    }
+
+    public void cleanAttributes()
+    {
+        channels.values().forEach(map -> map.values().forEach(FMLEmbeddedChannel::cleanAttributes));
     }
 }

--- a/src/main/java/net/minecraftforge/fml/common/network/handshake/NetworkDispatcher.java
+++ b/src/main/java/net/minecraftforge/fml/common/network/handshake/NetworkDispatcher.java
@@ -604,8 +604,8 @@ public class NetworkDispatcher extends SimpleChannelInboundHandler<Packet<?>> im
         super.exceptionCaught(ctx, cause);
     }
 
-    // if we add any attributes, we should force removal of them here so that
-    //they do not hold references to the world and causes it to leak.
+    // If we add any attributes, we should force removal of them here so that
+    // they do not hold references to the world and cause it to leak.
     private void cleanAttributes(ChannelHandlerContext ctx)
     {
         ctx.channel().attr(FMLOutboundHandler.FML_MESSAGETARGETARGS).set(null);
@@ -613,6 +613,7 @@ public class NetworkDispatcher extends SimpleChannelInboundHandler<Packet<?>> im
         ctx.channel().attr(NetworkDispatcher.FML_DISPATCHER).set(null);
         this.handshakeChannel.attr(FML_DISPATCHER).set(null);
         this.manager.channel().attr(FML_DISPATCHER).set(null);
+        NetworkRegistry.INSTANCE.cleanAttributes();
     }
 
     public void setOverrideDimension(int overrideDim) {


### PR DESCRIPTION
Server-side counterpart to #4881.

Fixes vanilla bug [MC-128561](https://bugs.mojang.com/browse/MC-128561) for 1.12 (1.13 is no longer affected), as well as ensuring 'leakable' channel attributes are cleared.