### PR TITLE
Add checks for undefined packet discriminators when sending messages

### DIFF
--- a/src/main/java/net/minecraftforge/fml/common/network/FMLIndexedMessageToMessageCodec.java
+++ b/src/main/java/net/minecraftforge/fml/common/network/FMLIndexedMessageToMessageCodec.java
@@ -75,7 +75,7 @@ public abstract class FMLIndexedMessageToMessageCodec<A> extends MessageToMessag
         PacketBuffer buffer = new PacketBuffer(Unpooled.buffer());
         buffer.writeByte(discriminator);
         encodeInto(ctx, msg, buffer);
-        FMLProxyPacket proxy = new FMLProxyPacket(buffer/*.copy()*/, channel);
+        FMLProxyPacket proxy = new FMLProxyPacket(buffer, channel);
         WeakReference<FMLProxyPacket> ref = ctx.channel().attr(INBOUNDPACKETTRACKER).get().get();
         FMLProxyPacket old = ref == null ? null : ref.get();
         if (old != null)


### PR DESCRIPTION
Adds a check to `FMLIndexedMessageToMessageCodec.encode` to ensure that a discriminator byte is defined for the message type, similar to the existing check in `decode`.

At present, an unregistered message type will get a default discriminator of 0, which can cause confusing errors on the receiving side, especially as mods may well be expecting packets with a discriminator of 0.

