### PR TITLE
Clean up some dimension manager code and add a command to list dimensions

### DIFF
--- a/patches/minecraft/net/minecraft/server/MinecraftServer.java.patch
+++ b/patches/minecraft/net/minecraft/server/MinecraftServer.java.patch
@@ -243,7 +243,7 @@
      public WorldServer func_71218_a(int p_71218_1_)
      {
 -        if (p_71218_1_ == -1)
-+        WorldServer ret = net.minecraftforge.common.DimensionManager.getWorld(p_71218_1_);
++        WorldServer ret = net.minecraftforge.common.DimensionManager.getWorld(p_71218_1_, true);
 +        if (ret == null)
          {
 -            return this.field_71305_c[1];

--- a/src/main/java/net/minecraftforge/common/DimensionManager.java
+++ b/src/main/java/net/minecraftforge/common/DimensionManager.java
@@ -273,6 +273,15 @@ public class DimensionManager
 
     public static WorldServer getWorld(int id)
     {
+        return getWorld(id, false);
+    }
+
+    public static WorldServer getWorld(int id, boolean resetUnloadDelay)
+    {
+        if (resetUnloadDelay && unloadQueue.contains(id))
+        {
+            dimensions.get(id).ticksWaited = 0;
+        }
         return worlds.get(id);
     }
 
@@ -339,7 +348,6 @@ public class DimensionManager
 
     /**
      * Queues a dimension to unload, if it can be unloaded.
-     * If the dimension is already queued, it will reset the delay to unload.
      * @param id The id of the dimension
      */
     public static void unloadWorld(int id)
@@ -350,10 +358,6 @@ public class DimensionManager
         if (unloadQueue.add(id))
         {
             FMLLog.log.debug("Queueing dimension {} to unload", id);
-        }
-        else
-        {
-            dimensions.get(id).ticksWaited = 0;
         }
     }
 

--- a/src/main/java/net/minecraftforge/common/DimensionManager.java
+++ b/src/main/java/net/minecraftforge/common/DimensionManager.java
@@ -24,8 +24,10 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.BitSet;
 import java.util.Hashtable;
+import java.util.IdentityHashMap;
 import java.util.List;
 import java.util.ListIterator;
+import java.util.Map;
 import java.util.concurrent.ConcurrentMap;
 
 import it.unimi.dsi.fastutil.ints.Int2ObjectMap;
@@ -34,8 +36,10 @@ import it.unimi.dsi.fastutil.ints.Int2ObjectOpenHashMap;
 import it.unimi.dsi.fastutil.ints.IntIterator;
 import it.unimi.dsi.fastutil.ints.IntLinkedOpenHashSet;
 import it.unimi.dsi.fastutil.ints.IntOpenHashSet;
+import it.unimi.dsi.fastutil.ints.IntRBTreeSet;
 import it.unimi.dsi.fastutil.ints.IntSet;
 import it.unimi.dsi.fastutil.ints.IntSets;
+import it.unimi.dsi.fastutil.ints.IntSortedSet;
 
 import com.google.common.collect.HashMultiset;
 import com.google.common.collect.Lists;
@@ -96,6 +100,16 @@ public class DimensionManager
         }
 
         return Arrays.copyOf(ret, x);
+    }
+
+    public static Map<DimensionType, IntSortedSet> getRegisteredDimensions()
+    {
+        Map<DimensionType, IntSortedSet> map = new IdentityHashMap<>();
+        for (Int2ObjectMap.Entry<Dimension> entry : dimensions.int2ObjectEntrySet())
+        {
+            map.computeIfAbsent(entry.getValue().type, k -> new IntRBTreeSet()).add(entry.getIntKey());
+        }
+        return map;
     }
 
     public static void init()

--- a/src/main/java/net/minecraftforge/common/DimensionManager.java
+++ b/src/main/java/net/minecraftforge/common/DimensionManager.java
@@ -30,9 +30,9 @@ import java.util.ListIterator;
 import java.util.Map;
 import java.util.concurrent.ConcurrentMap;
 
+import it.unimi.dsi.fastutil.ints.Int2ObjectLinkedOpenHashMap;
 import it.unimi.dsi.fastutil.ints.Int2ObjectMap;
 import it.unimi.dsi.fastutil.ints.Int2ObjectMaps;
-import it.unimi.dsi.fastutil.ints.Int2ObjectOpenHashMap;
 import it.unimi.dsi.fastutil.ints.IntIterator;
 import it.unimi.dsi.fastutil.ints.IntLinkedOpenHashSet;
 import it.unimi.dsi.fastutil.ints.IntOpenHashSet;
@@ -76,10 +76,10 @@ public class DimensionManager
 
     private static boolean hasInit = false;
 
-    private static final Int2ObjectMap<WorldServer> worlds = Int2ObjectMaps.synchronize(new Int2ObjectOpenHashMap<>());
-    private static final Int2ObjectMap<Dimension> dimensions = Int2ObjectMaps.synchronize(new Int2ObjectOpenHashMap<>());
+    private static final Int2ObjectMap<WorldServer> worlds = Int2ObjectMaps.synchronize(new Int2ObjectLinkedOpenHashMap<>());
+    private static final Int2ObjectMap<Dimension> dimensions = Int2ObjectMaps.synchronize(new Int2ObjectLinkedOpenHashMap<>());
     private static final IntSet keepLoaded = IntSets.synchronize(new IntOpenHashSet());
-    private static final IntSet unloadQueue = new IntLinkedOpenHashSet();
+    private static final IntSet unloadQueue = IntSets.synchronize(new IntLinkedOpenHashSet());
     private static final BitSet dimensionMap = new BitSet(Long.SIZE << 4);
     private static final ConcurrentMap<World, World> weakWorldMap = new MapMaker().weakKeys().weakValues().makeMap();
     private static final Multiset<Integer> leakedWorlds = HashMultiset.create();

--- a/src/main/java/net/minecraftforge/common/DimensionManager.java
+++ b/src/main/java/net/minecraftforge/common/DimensionManager.java
@@ -26,12 +26,13 @@ import java.util.BitSet;
 import java.util.Hashtable;
 import java.util.List;
 import java.util.ListIterator;
-import java.util.Map;
-import java.util.Map.Entry;
 import java.util.concurrent.ConcurrentMap;
 
-import it.unimi.dsi.fastutil.ints.IntArrayList;
-import it.unimi.dsi.fastutil.ints.IntListIterator;
+import it.unimi.dsi.fastutil.ints.Int2ObjectMap;
+import it.unimi.dsi.fastutil.ints.Int2ObjectMaps;
+import it.unimi.dsi.fastutil.ints.Int2ObjectOpenHashMap;
+import it.unimi.dsi.fastutil.ints.IntIterator;
+import it.unimi.dsi.fastutil.ints.IntLinkedOpenHashSet;
 import it.unimi.dsi.fastutil.ints.IntOpenHashSet;
 import it.unimi.dsi.fastutil.ints.IntSet;
 import it.unimi.dsi.fastutil.ints.IntSets;
@@ -71,10 +72,10 @@ public class DimensionManager
 
     private static boolean hasInit = false;
 
-    private static final Hashtable<Integer, WorldServer> worlds = new Hashtable<>();
-    private static final Hashtable<Integer, Dimension> dimensions = new Hashtable<>();
+    private static final Int2ObjectMap<WorldServer> worlds = Int2ObjectMaps.synchronize(new Int2ObjectOpenHashMap<>());
+    private static final Int2ObjectMap<Dimension> dimensions = Int2ObjectMaps.synchronize(new Int2ObjectOpenHashMap<>());
     private static final IntSet keepLoaded = IntSets.synchronize(new IntOpenHashSet());
-    private static final IntArrayList unloadQueue = new IntArrayList();
+    private static final IntSet unloadQueue = new IntLinkedOpenHashSet();
     private static final BitSet dimensionMap = new BitSet(Long.SIZE << 4);
     private static final ConcurrentMap<World, World> weakWorldMap = new MapMaker().weakKeys().weakValues().makeMap();
     private static final Multiset<Integer> leakedWorlds = HashMultiset.create();
@@ -86,11 +87,11 @@ public class DimensionManager
     {
         int[] ret = new int[dimensions.size()];
         int x = 0;
-        for (Map.Entry<Integer, Dimension> ent : dimensions.entrySet())
+        for (Int2ObjectMap.Entry<Dimension> ent : dimensions.int2ObjectEntrySet())
         {
             if (ent.getValue().type == type)
             {
-                ret[x++] = ent.getKey();
+                ret[x++] = ent.getIntKey();
             }
         }
 
@@ -182,9 +183,10 @@ public class DimensionManager
         }
         return getIDs();
     }
+
     public static Integer[] getIDs()
     {
-        return worlds.keySet().toArray(new Integer[worlds.size()]); //Only loaded dims, since usually used to cycle through loaded worlds
+        return worlds.keySet().toArray(new Integer[0]); // Only loaded dims, since usually used to cycle through loaded worlds
     }
 
     public static void setWorld(int id, @Nullable WorldServer world, MinecraftServer server)
@@ -211,9 +213,9 @@ public class DimensionManager
         if (worlds.get( 1) != null)
             tmp.add(worlds.get( 1));
 
-        for (Entry<Integer, WorldServer> entry : worlds.entrySet())
+        for (Int2ObjectMap.Entry<WorldServer> entry : worlds.int2ObjectEntrySet())
         {
-            int dim = entry.getKey();
+            int dim = entry.getIntKey();
             if (dim >= -1 && dim <= 1)
             {
                 continue;
@@ -221,7 +223,7 @@ public class DimensionManager
             tmp.add(entry.getValue());
         }
 
-        server.worlds = tmp.toArray(new WorldServer[tmp.size()]);
+        server.worlds = tmp.toArray(new WorldServer[0]);
     }
 
     public static void initDimension(int dim)
@@ -262,7 +264,7 @@ public class DimensionManager
 
     public static WorldServer[] getWorlds()
     {
-        return worlds.values().toArray(new WorldServer[worlds.size()]);
+        return worlds.values().toArray(new WorldServer[0]);
     }
 
     static
@@ -276,8 +278,9 @@ public class DimensionManager
      */
     public static Integer[] getStaticDimensionIDs()
     {
-        return dimensions.keySet().toArray(new Integer[dimensions.keySet().size()]);
+        return dimensions.keySet().toArray(new Integer[0]);
     }
+
     public static WorldProvider createProviderFor(int dim)
     {
         try
@@ -330,10 +333,9 @@ public class DimensionManager
         WorldServer world = worlds.get(id);
         if (world == null || !canUnloadWorld(world)) return;
 
-        if (!unloadQueue.contains(id))
+        if (unloadQueue.add(id))
         {
             FMLLog.log.debug("Queueing dimension {} to unload", id);
-            unloadQueue.add(id);
         }
         else
         {
@@ -347,12 +349,14 @@ public class DimensionManager
     }
 
     /*
-    * To be called by the server at the appropriate time, do not call from mod code.
-    */
-    public static void unloadWorlds(Hashtable<Integer, long[]> worldTickTimes) {
-        IntListIterator queueIterator = unloadQueue.iterator();
-        while (queueIterator.hasNext()) {
-            int id = queueIterator.next();
+     * To be called by the server at the appropriate time, do not call from mod code.
+     */
+    public static void unloadWorlds(Hashtable<Integer, long[]> worldTickTimes)
+    {
+        IntIterator queueIterator = unloadQueue.iterator();
+        while (queueIterator.hasNext())
+        {
+            int id = queueIterator.nextInt();
             Dimension dimension = dimensions.get(id);
             if (dimension.ticksWaited < ForgeModContainer.dimensionUnloadQueueDelay)
             {
@@ -428,8 +432,10 @@ public class DimensionManager
         dimensionMap.clear();
         if (compoundTag == null)
         {
-            for (Integer id : dimensions.keySet())
+            IntIterator iterator = dimensions.keySet().iterator();
+            while (iterator.hasNext())
             {
+                int id = iterator.nextInt();
                 if (id >= 0)
                 {
                     dimensionMap.set(id);

--- a/src/main/java/net/minecraftforge/server/command/CommandDimensions.java
+++ b/src/main/java/net/minecraftforge/server/command/CommandDimensions.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016.
+ * Copyright (c) 2018.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -19,34 +19,29 @@
 
 package net.minecraftforge.server.command;
 
-import net.minecraft.command.ICommand;
-
+import it.unimi.dsi.fastutil.ints.IntSortedSet;
+import net.minecraft.command.CommandBase;
+import net.minecraft.command.CommandException;
 import net.minecraft.command.ICommandSender;
 import net.minecraft.server.MinecraftServer;
+import net.minecraft.util.text.TextComponentString;
+import net.minecraft.world.DimensionType;
+import net.minecraftforge.common.DimensionManager;
 
-public class ForgeCommand extends CommandTreeBase
+import java.util.Map;
+
+public class CommandDimensions extends CommandBase
 {
-    public ForgeCommand()
-    {
-        super.addSubcommand(new CommandTps());
-        super.addSubcommand(new CommandTrack());
-        super.addSubcommand(new CommandGenerate());
-        super.addSubcommand(new CommandEntity());
-        super.addSubcommand(new CommandSetDimension());
-        super.addSubcommand(new CommandDimensions());
-        super.addSubcommand(new CommandTreeHelp(this));
-    }
-
     @Override
     public String getName()
     {
-        return "forge";
+        return "dimensions";
     }
 
     @Override
-    public void addSubcommand(ICommand command)
+    public String getUsage(ICommandSender sender)
     {
-        throw new UnsupportedOperationException("Don't add sub-commands to /forge, create your own command.");
+        return "commands.forge.dimensions.usage";
     }
 
     @Override
@@ -62,8 +57,12 @@ public class ForgeCommand extends CommandTreeBase
     }
 
     @Override
-    public String getUsage(ICommandSender icommandsender)
+    public void execute(MinecraftServer server, ICommandSender sender, String[] args) throws CommandException
     {
-        return "commands.forge.usage";
+        sender.sendMessage(TextComponentHelper.createComponentTranslation(sender, "commands.forge.dimensions.list"));
+        for (Map.Entry<DimensionType, IntSortedSet> entry : DimensionManager.getRegisteredDimensions().entrySet())
+        {
+            sender.sendMessage(new TextComponentString(entry.getKey().getName() + ": " + entry.getValue()));
+        }
     }
 }

--- a/src/main/resources/assets/forge/lang/en_US.lang
+++ b/src/main/resources/assets/forge/lang/en_US.lang
@@ -19,6 +19,8 @@ commands.forge.setdim.usage=Use /forge setdim <entity> <dimension> [<x> <y> <z>]
 commands.forge.setdim.invalid.entity=The entity selected (%s) is not valid.
 commands.forge.setdim.invalid.dim=The dimension ID specified (%d) is not valid.
 commands.forge.setdim.invalid.nochange=The entity selected (%s) is already in the dimension specified (%d).
+commands.forge.dimensions.usage=Use /forge dimensions
+commands.forge.dimensions.list=Currently registered dimensions by type:
 
 commands.forge.tracking.te.enabled=Tile Entity tracking enabled for %d seconds.
 commands.forge.tracking.entity.enabled=Entity tracking enabled for %d seconds.


### PR DESCRIPTION
This cleans up some legacy `Hashtable` usage in `DimensionManager` and, as an actual feature, adds a Forge command to list all registered dimensions, grouped by type.

This makes it easier to use dimension ids for e.g. commands, without having to look them up in mod config files.