### PR TITLE
Fix #4904 Prevent world corruption when a WorldEvent.Unload handler crashes

### DIFF
--- a/patches/minecraft/net/minecraft/client/Minecraft.java.patch
+++ b/patches/minecraft/net/minecraft/client/Minecraft.java.patch
@@ -302,7 +302,7 @@
  
      public void func_71353_a(@Nullable WorldClient p_71353_1_, String p_71353_2_)
      {
-+        if (field_71441_e != null) net.minecraftforge.common.MinecraftForge.EVENT_BUS.post(new net.minecraftforge.event.world.WorldEvent.Unload(field_71441_e));
++        if (field_71441_e != null) net.minecraftforge.common.ForgeHooks.onWorldUnload(field_71441_e, false);
 +
          if (p_71353_1_ == null)
          {

--- a/patches/minecraft/net/minecraft/client/Minecraft.java.patch
+++ b/patches/minecraft/net/minecraft/client/Minecraft.java.patch
@@ -302,7 +302,7 @@
  
      public void func_71353_a(@Nullable WorldClient p_71353_1_, String p_71353_2_)
      {
-+        if (field_71441_e != null) net.minecraftforge.common.ForgeHooks.onWorldUnload(field_71441_e, false);
++        if (field_71441_e != null) net.minecraftforge.event.ForgeEventFactory.onWorldUnload(field_71441_e, false);
 +
          if (p_71353_1_ == null)
          {

--- a/patches/minecraft/net/minecraft/server/MinecraftServer.java.patch
+++ b/patches/minecraft/net/minecraft/server/MinecraftServer.java.patch
@@ -74,7 +74,7 @@
              {
                  if (worldserver1 != null)
                  {
-+                    net.minecraftforge.common.MinecraftForge.EVENT_BUS.post(new net.minecraftforge.event.world.WorldEvent.Unload(worldserver1));
++                    net.minecraftforge.common.ForgeHooks.onWorldUnload(worldserver1, true);
                      worldserver1.func_73041_k();
                  }
              }

--- a/patches/minecraft/net/minecraft/server/MinecraftServer.java.patch
+++ b/patches/minecraft/net/minecraft/server/MinecraftServer.java.patch
@@ -74,7 +74,7 @@
              {
                  if (worldserver1 != null)
                  {
-+                    net.minecraftforge.common.ForgeHooks.onWorldUnload(worldserver1, true);
++                    net.minecraftforge.event.ForgeEventFactory.onWorldUnload(worldserver1, true);
                      worldserver1.func_73041_k();
                  }
              }

--- a/src/main/java/net/minecraftforge/common/DimensionManager.java
+++ b/src/main/java/net/minecraftforge/common/DimensionManager.java
@@ -51,6 +51,7 @@ import net.minecraft.world.WorldProvider;
 import net.minecraft.world.WorldServer;
 import net.minecraft.world.WorldServerMulti;
 import net.minecraft.world.storage.ISaveHandler;
+import net.minecraftforge.event.ForgeEventFactory;
 import net.minecraftforge.event.world.WorldEvent;
 import net.minecraftforge.fml.common.FMLLog;
 
@@ -378,7 +379,7 @@ public class DimensionManager
             }
             finally
             {
-                ForgeHooks.onWorldUnload(w, true);
+                ForgeEventFactory.onWorldUnload(w, true);
                 w.flush();
                 setWorld(id, null, w.getMinecraftServer());
             }

--- a/src/main/java/net/minecraftforge/common/DimensionManager.java
+++ b/src/main/java/net/minecraftforge/common/DimensionManager.java
@@ -378,7 +378,7 @@ public class DimensionManager
             }
             finally
             {
-                MinecraftForge.EVENT_BUS.post(new WorldEvent.Unload(w));
+                ForgeHooks.onWorldUnload(w, true);
                 w.flush();
                 setWorld(id, null, w.getMinecraftServer());
             }

--- a/src/main/java/net/minecraftforge/common/ForgeHooks.java
+++ b/src/main/java/net/minecraftforge/common/ForgeHooks.java
@@ -1451,25 +1451,4 @@ public class ForgeHooks
         }
         return modId;
     }
-
-    /**
-     * Posts the world unload event.
-     * Optionally catches and suppresses any exceptions to allow the game to safely finish unloading the world.
-     */
-    public static boolean onWorldUnload(World world, boolean suppressExceptions)
-    {
-        if (!suppressExceptions)
-        {
-            return MinecraftForge.EVENT_BUS.post(new WorldEvent.Unload(world));
-        }
-        try
-        {
-            return MinecraftForge.EVENT_BUS.post(new WorldEvent.Unload(world));
-        }
-        catch (Throwable e)
-        {
-            FMLLog.log.error("A WorldEvent.Unload event handler has crashed. Please report this to the mod author, it is a very serious error. This may result in data loss because other unload event handlers could be skipped.", e);
-            return false;
-        }
-    }
 }

--- a/src/main/java/net/minecraftforge/common/ForgeHooks.java
+++ b/src/main/java/net/minecraftforge/common/ForgeHooks.java
@@ -140,6 +140,7 @@ import net.minecraftforge.event.entity.player.PlayerInteractEvent;
 import net.minecraftforge.event.entity.player.AdvancementEvent;
 import net.minecraftforge.event.world.BlockEvent;
 import net.minecraftforge.event.world.NoteBlockEvent;
+import net.minecraftforge.event.world.WorldEvent;
 import net.minecraftforge.fluids.IFluidBlock;
 import net.minecraftforge.fml.common.FMLLog;
 import net.minecraftforge.fml.common.Loader;
@@ -1449,5 +1450,26 @@ public class ForgeHooks
             }
         }
         return modId;
+    }
+
+    /**
+     * Posts the world unload event.
+     * Optionally catches and suppresses any exceptions to allow the game to safely finish unloading the world.
+     */
+    public static boolean onWorldUnload(World world, boolean suppressExceptions)
+    {
+        if (!suppressExceptions)
+        {
+            return MinecraftForge.EVENT_BUS.post(new WorldEvent.Unload(world));
+        }
+        try
+        {
+            return MinecraftForge.EVENT_BUS.post(new WorldEvent.Unload(world));
+        }
+        catch (Throwable e)
+        {
+            FMLLog.log.error("A WorldEvent.Unload event handler has crashed. Please report this to the mod author, it is a very serious error. This may result in data loss because other unload event handlers could be skipped.", e);
+            return false;
+        }
     }
 }

--- a/src/main/java/net/minecraftforge/event/ForgeEventFactory.java
+++ b/src/main/java/net/minecraftforge/event/ForgeEventFactory.java
@@ -128,12 +128,15 @@ import net.minecraftforge.fml.common.ObfuscationReflectionHelper;
 import net.minecraftforge.fml.common.eventhandler.Event;
 import net.minecraftforge.fml.common.eventhandler.Event.Result;
 import net.minecraftforge.fml.common.registry.GameRegistry;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
 public class ForgeEventFactory
 {
+    private static Logger LOGGER = LogManager.getLogger("forge.EventFactory");
 
     public static MultiPlaceEvent onPlayerMultiBlockPlace(EntityPlayer player, List<BlockSnapshot> blockSnapshots, EnumFacing direction, EnumHand hand)
     {
@@ -765,5 +768,27 @@ public class ForgeEventFactory
 
         Result result = event.getResult();
         return result == Result.DEFAULT ? world.getGameRules().getBoolean("mobGriefing") : result == Result.ALLOW;
+    }
+
+    /**
+     * Posts the world unload event.
+     * Optionally catches and suppresses any exceptions to allow the game to safely finish unloading the world.
+     */
+    public static boolean onWorldUnload(World world, boolean suppressExceptions)
+    {
+        WorldEvent.Unload event = new WorldEvent.Unload(world);
+        try
+        {
+            return MinecraftForge.EVENT_BUS.post(event);
+        }
+        catch (Throwable e)
+        {
+            LOGGER.error("A WorldEvent.Unload event handler has crashed. Please report this to the mod author, it is a very serious error. This may result in data loss because other unload event handlers could be skipped.", e);
+            if (suppressExceptions)
+            {
+                return false;
+            }
+            throw e;
+        }
     }
 }


### PR DESCRIPTION
When a WorldEvent.Unload handler crashes, it will skip the `world.flush()` and some other important calls, and will entirely skip unloading other worlds that would normally unload after.

This PR catches exceptions from world unload handlers, logging them as errors so that the game can try to continue unloading the world properly.
Any handlers after the one that crashes will still be skipped (which is a severe problem if they are trying to save data) but I think that could be dealt with in a separate PR because fixing it would involve messing with the way the event bus works.

Tested with the setup described in #4904, I was able to replicate the problem and confirmed it is fixed with this PR.