### PR TITLE
Clean up broken aliases caused by 4894 bug.

### DIFF
--- a/src/main/java/net/minecraftforge/registries/ForgeRegistry.java
+++ b/src/main/java/net/minecraftforge/registries/ForgeRegistry.java
@@ -856,7 +856,16 @@ public class ForgeRegistry<V extends IForgeRegistryEntry<V>> implements IForgeRe
                 }
                 else
                 {
-                    ret.aliases.put(new ResourceLocation(comp.getString("K")), new ResourceLocation(v));
+                    ResourceLocation aliask = new ResourceLocation(comp.getString("K"));
+                    ResourceLocation aliasv = new ResourceLocation(v);
+                    if (aliasv.equals(aliask))
+                    {
+                        FMLLog.log.warn("Found unrecoverable 4894 bugged alias/override: {} -> {}, skipping.", aliask, aliasv);
+                    }
+                    else
+                    {
+                        ret.aliases.put(aliask, aliasv);
+                    }
                 }
             });
 


### PR DESCRIPTION
Worlds repeatedly loaded and saved with the 4894 bug present will have accumulated a list of unusual aliases that don't really load properly. With the fix to 4894 in place, those aliases become self-referential, causing an infinite loop during world loading. They were never valid in the first place, let's just remove them.