### PR TITLE
Fix light shining through slabs, stairs, etc.

### DIFF
--- a/patches/minecraft/net/minecraft/block/Block.java.patch
+++ b/patches/minecraft/net/minecraft/block/Block.java.patch
@@ -1621,7 +1621,13 @@
          func_176219_a(158, "dropper", (new BlockDropper()).func_149711_c(3.5F).func_149672_a(SoundType.field_185851_d).func_149663_c("dropper"));
          func_176219_a(159, "stained_hardened_clay", (new BlockStainedHardenedClay()).func_149711_c(1.25F).func_149752_b(7.0F).func_149672_a(SoundType.field_185851_d).func_149663_c("clayHardenedStained"));
          func_176219_a(160, "stained_glass_pane", (new BlockStainedGlassPane()).func_149711_c(0.3F).func_149672_a(SoundType.field_185853_f).func_149663_c("thinStainedGlass"));
-@@ -1230,31 +2632,6 @@
+@@ -1226,35 +2628,12 @@
+                 {
+                     flag = true;
+                 }
++                flag |= block15 instanceof net.minecraftforge.fluids.BlockFluidBase;
++                flag |= block15 instanceof BlockLiquid;
+ 
                  block15.field_149783_u = flag;
              }
          }

--- a/patches/minecraft/net/minecraft/block/Block.java.patch
+++ b/patches/minecraft/net/minecraft/block/Block.java.patch
@@ -45,13 +45,15 @@
      }
  
      @Deprecated
-@@ -372,13 +375,13 @@
+@@ -372,13 +375,15 @@
      @SideOnly(Side.CLIENT)
      public int func_185484_c(IBlockState p_185484_1_, IBlockAccess p_185484_2_, BlockPos p_185484_3_)
      {
 -        int i = p_185484_2_.func_175626_b(p_185484_3_, p_185484_1_.func_185906_d());
 +        int i = p_185484_2_.func_175626_b(p_185484_3_, p_185484_1_.getLightValue(p_185484_2_, p_185484_3_));
  
++
++        if (true) return i;
          if (i == 0 && p_185484_1_.func_177230_c() instanceof BlockSlab)
          {
              p_185484_3_ = p_185484_3_.func_177977_b();
@@ -61,7 +63,7 @@
          }
          else
          {
-@@ -442,7 +445,7 @@
+@@ -442,7 +447,7 @@
                  }
          }
  
@@ -70,7 +72,7 @@
      }
  
      @Deprecated
-@@ -534,6 +537,10 @@
+@@ -534,6 +539,10 @@
  
      public void func_180663_b(World p_180663_1_, BlockPos p_180663_2_, IBlockState p_180663_3_)
      {
@@ -81,7 +83,7 @@
      }
  
      public int func_149745_a(Random p_149745_1_)
-@@ -549,16 +556,7 @@
+@@ -549,16 +558,7 @@
      @Deprecated
      public float func_180647_a(IBlockState p_180647_1_, EntityPlayer p_180647_2_, World p_180647_3_, BlockPos p_180647_4_)
      {
@@ -99,7 +101,7 @@
      }
  
      public final void func_176226_b(World p_176226_1_, BlockPos p_176226_2_, IBlockState p_176226_3_, int p_176226_4_)
-@@ -568,20 +566,16 @@
+@@ -568,20 +568,16 @@
  
      public void func_180653_a(World p_180653_1_, BlockPos p_180653_2_, IBlockState p_180653_3_, float p_180653_4_, int p_180653_5_)
      {
@@ -125,7 +127,7 @@
                  }
              }
          }
-@@ -589,8 +583,13 @@
+@@ -589,8 +585,13 @@
  
      public static void func_180635_a(World p_180635_0_, BlockPos p_180635_1_, ItemStack p_180635_2_)
      {
@@ -140,7 +142,7 @@
              float f = 0.5F;
              double d0 = (double)(p_180635_0_.field_73012_v.nextFloat() * 0.5F) + 0.25D;
              double d1 = (double)(p_180635_0_.field_73012_v.nextFloat() * 0.5F) + 0.25D;
-@@ -619,6 +618,7 @@
+@@ -619,6 +620,7 @@
          return 0;
      }
  
@@ -148,7 +150,7 @@
      public float func_149638_a(Entity p_149638_1_)
      {
          return this.field_149781_w / 5.0F;
-@@ -657,7 +657,7 @@
+@@ -657,7 +659,7 @@
  
      public boolean func_176196_c(World p_176196_1_, BlockPos p_176196_2_)
      {
@@ -157,7 +159,7 @@
      }
  
      public boolean func_180639_a(World p_180639_1_, BlockPos p_180639_2_, IBlockState p_180639_3_, EntityPlayer p_180639_4_, EnumHand p_180639_5_, EnumFacing p_180639_6_, float p_180639_7_, float p_180639_8_, float p_180639_9_)
-@@ -669,6 +669,8 @@
+@@ -669,6 +671,8 @@
      {
      }
  
@@ -166,7 +168,7 @@
      public IBlockState func_180642_a(World p_180642_1_, BlockPos p_180642_2_, EnumFacing p_180642_3_, float p_180642_4_, float p_180642_5_, float p_180642_6_, int p_180642_7_, EntityLivingBase p_180642_8_)
      {
          return this.func_176203_a(p_180642_7_);
-@@ -710,21 +712,35 @@
+@@ -710,21 +714,35 @@
          p_180657_2_.func_71029_a(StatList.func_188055_a(this));
          p_180657_2_.func_71020_j(0.005F);
  
@@ -205,7 +207,7 @@
      }
  
      protected ItemStack func_180643_i(IBlockState p_180643_1_)
-@@ -810,6 +826,7 @@
+@@ -810,6 +828,7 @@
          p_176216_2_.field_70181_x = 0.0D;
      }
  
@@ -213,7 +215,7 @@
      public ItemStack func_185473_a(World p_185473_1_, BlockPos p_185473_2_, IBlockState p_185473_3_)
      {
          return new ItemStack(Item.func_150898_a(this), 1, this.func_180651_a(p_185473_3_));
-@@ -919,6 +936,7 @@
+@@ -919,6 +938,7 @@
          }
      }
  
@@ -221,7 +223,7 @@
      public SoundType func_185467_w()
      {
          return this.field_149762_H;
-@@ -934,6 +952,1345 @@
+@@ -934,6 +954,1388 @@
      {
      }
  
@@ -1562,12 +1564,55 @@
 +        return state.func_177230_c() == Blocks.field_180399_cE;
 +    }
 +
++    @SideOnly(Side.CLIENT)
++    public int getLightFor(final IBlockState state, final IBlockAccess world, final net.minecraft.world.EnumSkyBlock type, final BlockPos pos)
++    {
++        int light = world.getLight(type, pos);
++
++        if (light == 15)
++            return light;
++
++        if (!state.func_185916_f())
++            return light;
++
++        for (EnumFacing dir : EnumFacing.field_82609_l)
++        {
++            if (state.useNeighborBrightness(dir, world, pos))
++            {
++                int opac = state.getLightOpacity(dir, world, pos);
++                final int neighborLight = world.getLight(type, pos.func_177972_a(dir));
++
++                if (opac == 0 && (type != net.minecraft.world.EnumSkyBlock.SKY || neighborLight != net.minecraft.world.EnumSkyBlock.SKY.field_77198_c))
++                    opac = 1;
++
++                light = Math.max(light, neighborLight - opac);
++
++                if (light == 15)
++                    return light;
++            }
++        }
++
++        return light;
++    }
++
++    @SideOnly(Side.CLIENT)
++    public boolean useNeighborBrightness(final IBlockState state, final EnumFacing dir, final IBlockAccess world, final BlockPos pos)
++    {
++        return true;
++    }
++
++    @SideOnly(Side.CLIENT)
++    public int getLightOpacity(final IBlockState state, final EnumFacing dir, final IBlockAccess world, final BlockPos pos)
++    {
++        return 0;
++    }
++
 +    /* ========================================= FORGE END ======================================*/
 +
      public static void func_149671_p()
      {
          func_176215_a(0, field_176230_a, (new BlockAir()).func_149663_c("air"));
-@@ -1105,7 +2462,7 @@
+@@ -1105,7 +2507,7 @@
          Block block11 = (new BlockQuartz()).func_149672_a(SoundType.field_185851_d).func_149711_c(0.8F).func_149663_c("quartzBlock");
          func_176219_a(155, "quartz_block", block11);
          func_176219_a(156, "quartz_stairs", (new BlockStairs(block11.func_176223_P().func_177226_a(BlockQuartz.field_176335_a, BlockQuartz.EnumType.DEFAULT))).func_149663_c("stairsQuartz"));
@@ -1576,7 +1621,7 @@
          func_176219_a(158, "dropper", (new BlockDropper()).func_149711_c(3.5F).func_149672_a(SoundType.field_185851_d).func_149663_c("dropper"));
          func_176219_a(159, "stained_hardened_clay", (new BlockStainedHardenedClay()).func_149711_c(1.25F).func_149752_b(7.0F).func_149672_a(SoundType.field_185851_d).func_149663_c("clayHardenedStained"));
          func_176219_a(160, "stained_glass_pane", (new BlockStainedGlassPane()).func_149711_c(0.3F).func_149672_a(SoundType.field_185853_f).func_149663_c("thinStainedGlass"));
-@@ -1230,31 +2587,6 @@
+@@ -1230,31 +2632,6 @@
                  block15.field_149783_u = flag;
              }
          }

--- a/patches/minecraft/net/minecraft/block/Block.java.patch
+++ b/patches/minecraft/net/minecraft/block/Block.java.patch
@@ -1598,7 +1598,7 @@
 +    @SideOnly(Side.CLIENT)
 +    public boolean useNeighborBrightness(final IBlockState state, final EnumFacing dir, final IBlockAccess world, final BlockPos pos)
 +    {
-+        return true;
++        return dir == EnumFacing.UP;
 +    }
 +
 +    @SideOnly(Side.CLIENT)

--- a/patches/minecraft/net/minecraft/block/Block.java.patch
+++ b/patches/minecraft/net/minecraft/block/Block.java.patch
@@ -223,7 +223,7 @@
      public SoundType func_185467_w()
      {
          return this.field_149762_H;
-@@ -934,6 +954,1388 @@
+@@ -934,6 +954,1385 @@
      {
      }
  
@@ -1564,7 +1564,6 @@
 +        return state.func_177230_c() == Blocks.field_180399_cE;
 +    }
 +
-+    @SideOnly(Side.CLIENT)
 +    public int getLightFor(final IBlockState state, final IBlockAccess world, final net.minecraft.world.EnumSkyBlock type, final BlockPos pos)
 +    {
 +        int light = world.getLight(type, pos);
@@ -1595,13 +1594,11 @@
 +        return light;
 +    }
 +
-+    @SideOnly(Side.CLIENT)
 +    public boolean useNeighborBrightness(final IBlockState state, final EnumFacing dir, final IBlockAccess world, final BlockPos pos)
 +    {
 +        return dir == EnumFacing.UP;
 +    }
 +
-+    @SideOnly(Side.CLIENT)
 +    public int getLightOpacity(final IBlockState state, final EnumFacing dir, final IBlockAccess world, final BlockPos pos)
 +    {
 +        return 0;
@@ -1612,7 +1609,7 @@
      public static void func_149671_p()
      {
          func_176215_a(0, field_176230_a, (new BlockAir()).func_149663_c("air"));
-@@ -1105,7 +2507,7 @@
+@@ -1105,7 +2504,7 @@
          Block block11 = (new BlockQuartz()).func_149672_a(SoundType.field_185851_d).func_149711_c(0.8F).func_149663_c("quartzBlock");
          func_176219_a(155, "quartz_block", block11);
          func_176219_a(156, "quartz_stairs", (new BlockStairs(block11.func_176223_P().func_177226_a(BlockQuartz.field_176335_a, BlockQuartz.EnumType.DEFAULT))).func_149663_c("stairsQuartz"));
@@ -1621,7 +1618,7 @@
          func_176219_a(158, "dropper", (new BlockDropper()).func_149711_c(3.5F).func_149672_a(SoundType.field_185851_d).func_149663_c("dropper"));
          func_176219_a(159, "stained_hardened_clay", (new BlockStainedHardenedClay()).func_149711_c(1.25F).func_149752_b(7.0F).func_149672_a(SoundType.field_185851_d).func_149663_c("clayHardenedStained"));
          func_176219_a(160, "stained_glass_pane", (new BlockStainedGlassPane()).func_149711_c(0.3F).func_149672_a(SoundType.field_185853_f).func_149663_c("thinStainedGlass"));
-@@ -1226,35 +2628,12 @@
+@@ -1226,35 +2625,12 @@
                  {
                      flag = true;
                  }

--- a/patches/minecraft/net/minecraft/block/BlockSlab.java.patch
+++ b/patches/minecraft/net/minecraft/block/BlockSlab.java.patch
@@ -37,12 +37,11 @@
      }
  
      @SideOnly(Side.CLIENT)
-@@ -158,6 +172,19 @@
+@@ -158,6 +172,18 @@
          return block == Blocks.field_150333_U || block == Blocks.field_150376_bx || block == Blocks.field_180389_cP || block == Blocks.field_185771_cX;
      }
  
 +    @Override
-+    @SideOnly(Side.CLIENT)
 +    public boolean useNeighborBrightness(final IBlockState state, final EnumFacing dir, final IBlockAccess world, final BlockPos pos)
 +    {
 +        if (dir.func_176740_k() != EnumFacing.Axis.Y)

--- a/patches/minecraft/net/minecraft/block/BlockSlab.java.patch
+++ b/patches/minecraft/net/minecraft/block/BlockSlab.java.patch
@@ -37,3 +37,23 @@
      }
  
      @SideOnly(Side.CLIENT)
+@@ -158,6 +172,19 @@
+         return block == Blocks.field_150333_U || block == Blocks.field_150376_bx || block == Blocks.field_180389_cP || block == Blocks.field_185771_cX;
+     }
+ 
++    @Override
++    @SideOnly(Side.CLIENT)
++    public boolean useNeighborBrightness(final IBlockState state, final EnumFacing dir, final IBlockAccess world, final BlockPos pos)
++    {
++        if (dir.func_176740_k() != EnumFacing.Axis.Y)
++            return false;
++
++        if (this.func_149686_d(state))
++            return false;
++
++        return dir == (state.func_177229_b(field_176554_a) == EnumBlockHalf.TOP ? EnumFacing.DOWN : EnumFacing.UP);
++    }
++
+     public abstract String func_150002_b(int p_150002_1_);
+ 
+     public abstract boolean func_176552_j();

--- a/patches/minecraft/net/minecraft/block/BlockStairs.java.patch
+++ b/patches/minecraft/net/minecraft/block/BlockStairs.java.patch
@@ -1,6 +1,6 @@
 --- ../src-base/minecraft/net/minecraft/block/BlockStairs.java
 +++ ../src-work/minecraft/net/minecraft/block/BlockStairs.java
-@@ -483,6 +483,29 @@
+@@ -483,6 +483,39 @@
          return new BlockStateContainer(this, new IProperty[] {field_176309_a, field_176308_b, field_176310_M});
      }
  
@@ -25,6 +25,16 @@
 +        if (shape == EnumShape.INNER_LEFT && face.func_176746_e() == side) return true;
 +        if (shape == EnumShape.INNER_RIGHT && face.func_176735_f() == side) return true;
 +        return false;
++    }
++
++    @Override
++    @SideOnly(Side.CLIENT)
++    public boolean useNeighborBrightness(final IBlockState state, final EnumFacing dir, final IBlockAccess world, final BlockPos pos)
++    {
++        if (dir.func_176740_k() != EnumFacing.Axis.Y)
++            return false;
++
++        return dir == (state.func_177229_b(field_176308_b) == EnumHalf.TOP ? EnumFacing.DOWN : EnumFacing.UP);
 +    }
 +
      public static enum EnumHalf implements IStringSerializable

--- a/patches/minecraft/net/minecraft/block/BlockStairs.java.patch
+++ b/patches/minecraft/net/minecraft/block/BlockStairs.java.patch
@@ -1,6 +1,6 @@
 --- ../src-base/minecraft/net/minecraft/block/BlockStairs.java
 +++ ../src-work/minecraft/net/minecraft/block/BlockStairs.java
-@@ -483,6 +483,39 @@
+@@ -483,6 +483,38 @@
          return new BlockStateContainer(this, new IProperty[] {field_176309_a, field_176308_b, field_176310_M});
      }
  
@@ -28,7 +28,6 @@
 +    }
 +
 +    @Override
-+    @SideOnly(Side.CLIENT)
 +    public boolean useNeighborBrightness(final IBlockState state, final EnumFacing dir, final IBlockAccess world, final BlockPos pos)
 +    {
 +        if (dir.func_176740_k() != EnumFacing.Axis.Y)

--- a/patches/minecraft/net/minecraft/block/state/BlockStateContainer.java.patch
+++ b/patches/minecraft/net/minecraft/block/state/BlockStateContainer.java.patch
@@ -49,7 +49,7 @@
              public Collection < IProperty<? >> func_177227_a()
              {
                  return Collections. < IProperty<? >> unmodifiableCollection(this.field_177237_b.keySet());
-@@ -473,5 +490,94 @@
+@@ -473,5 +490,115 @@
              {
                  return this.field_177239_a.func_193383_a(p_193401_1_, this, p_193401_2_, p_193401_3_);
              }
@@ -89,6 +89,27 @@
 +            public boolean doesSideBlockRendering(IBlockAccess world, BlockPos pos, EnumFacing side)
 +            {
 +                return this.field_177239_a.doesSideBlockRendering(this, world, pos, side);
++            }
++
++            @Override
++            @SideOnly(Side.CLIENT)
++            public int getLightFor(final IBlockAccess world, final net.minecraft.world.EnumSkyBlock type, final BlockPos pos)
++            {
++                return this.field_177239_a.getLightFor(this, world, type, pos);
++            }
++
++            @Override
++            @SideOnly(Side.CLIENT)
++            public boolean useNeighborBrightness(EnumFacing dir, IBlockAccess world, BlockPos pos)
++            {
++                return this.field_177239_a.useNeighborBrightness(this, dir, world, pos);
++            }
++
++            @Override
++            @SideOnly(Side.CLIENT)
++            public int getLightOpacity(EnumFacing dir, IBlockAccess world, BlockPos pos)
++            {
++                return this.field_177239_a.getLightOpacity(this, dir, world, pos);
 +            }
          }
 +

--- a/patches/minecraft/net/minecraft/block/state/BlockStateContainer.java.patch
+++ b/patches/minecraft/net/minecraft/block/state/BlockStateContainer.java.patch
@@ -49,7 +49,7 @@
              public Collection < IProperty<? >> func_177227_a()
              {
                  return Collections. < IProperty<? >> unmodifiableCollection(this.field_177237_b.keySet());
-@@ -473,5 +490,115 @@
+@@ -473,5 +490,112 @@
              {
                  return this.field_177239_a.func_193383_a(p_193401_1_, this, p_193401_2_, p_193401_3_);
              }
@@ -92,21 +92,18 @@
 +            }
 +
 +            @Override
-+            @SideOnly(Side.CLIENT)
 +            public int getLightFor(final IBlockAccess world, final net.minecraft.world.EnumSkyBlock type, final BlockPos pos)
 +            {
 +                return this.field_177239_a.getLightFor(this, world, type, pos);
 +            }
 +
 +            @Override
-+            @SideOnly(Side.CLIENT)
 +            public boolean useNeighborBrightness(EnumFacing dir, IBlockAccess world, BlockPos pos)
 +            {
 +                return this.field_177239_a.useNeighborBrightness(this, dir, world, pos);
 +            }
 +
 +            @Override
-+            @SideOnly(Side.CLIENT)
 +            public int getLightOpacity(EnumFacing dir, IBlockAccess world, BlockPos pos)
 +            {
 +                return this.field_177239_a.getLightOpacity(this, dir, world, pos);

--- a/patches/minecraft/net/minecraft/block/state/IBlockProperties.java.patch
+++ b/patches/minecraft/net/minecraft/block/state/IBlockProperties.java.patch
@@ -14,7 +14,7 @@
  
      @SideOnly(Side.CLIENT)
      boolean func_185895_e();
-@@ -95,11 +99,28 @@
+@@ -95,11 +99,25 @@
  
      RayTraceResult func_185910_a(World p_185910_1_, BlockPos p_185910_2_, Vec3d p_185910_3_, Vec3d p_185910_4_);
  
@@ -34,12 +34,9 @@
 +
 +    /* ======================================== FORGE START =====================================*/
 +
-+    @SideOnly(Side.CLIENT)
 +    int getLightFor(IBlockAccess world, net.minecraft.world.EnumSkyBlock type, BlockPos pos);
 +
-+    @SideOnly(Side.CLIENT)
 +    boolean useNeighborBrightness(EnumFacing dir, IBlockAccess world, BlockPos pos);
 +
-+    @SideOnly(Side.CLIENT)
 +    int getLightOpacity(EnumFacing dir, IBlockAccess world, BlockPos pos);
  }

--- a/patches/minecraft/net/minecraft/block/state/IBlockProperties.java.patch
+++ b/patches/minecraft/net/minecraft/block/state/IBlockProperties.java.patch
@@ -14,7 +14,7 @@
  
      @SideOnly(Side.CLIENT)
      boolean func_185895_e();
-@@ -95,8 +99,14 @@
+@@ -95,11 +99,28 @@
  
      RayTraceResult func_185910_a(World p_185910_1_, BlockPos p_185910_2_, Vec3d p_185910_3_, Vec3d p_185910_4_);
  
@@ -29,3 +29,17 @@
      Vec3d func_191059_e(IBlockAccess p_191059_1_, BlockPos p_191059_2_);
  
      boolean func_191058_s();
+ 
+     BlockFaceShape func_193401_d(IBlockAccess p_193401_1_, BlockPos p_193401_2_, EnumFacing p_193401_3_);
++
++    /* ======================================== FORGE START =====================================*/
++
++    @SideOnly(Side.CLIENT)
++    int getLightFor(IBlockAccess world, net.minecraft.world.EnumSkyBlock type, BlockPos pos);
++
++    @SideOnly(Side.CLIENT)
++    boolean useNeighborBrightness(EnumFacing dir, IBlockAccess world, BlockPos pos);
++
++    @SideOnly(Side.CLIENT)
++    int getLightOpacity(EnumFacing dir, IBlockAccess world, BlockPos pos);
+ }

--- a/patches/minecraft/net/minecraft/world/ChunkCache.java.patch
+++ b/patches/minecraft/net/minecraft/world/ChunkCache.java.patch
@@ -40,7 +40,7 @@
                  return this.field_72817_c[i][j].func_177413_a(p_175629_1_, p_175629_2_);
              }
          }
-@@ -160,16 +164,25 @@
+@@ -160,16 +164,23 @@
  
      public boolean func_175623_d(BlockPos p_175623_1_)
      {
@@ -49,14 +49,13 @@
 +        return state.func_177230_c().isAir(state, this, p_175623_1_);
      }
  
+-    @SideOnly(Side.CLIENT)
 +    @Override
-     @SideOnly(Side.CLIENT)
 +    public int getLight(EnumSkyBlock type, BlockPos pos)
 +    {
 +        return this.func_175628_b(type, pos);
 +    }
 +
-+    @SideOnly(Side.CLIENT)
      public int func_175628_b(EnumSkyBlock p_175628_1_, BlockPos p_175628_2_)
      {
          if (p_175628_2_.func_177956_o() >= 0 && p_175628_2_.func_177956_o() < 256)
@@ -67,7 +66,7 @@
              return this.field_72817_c[i][j].func_177413_a(p_175628_1_, p_175628_2_);
          }
          else
-@@ -188,4 +201,21 @@
+@@ -188,4 +199,21 @@
      {
          return this.field_72815_e.func_175624_G();
      }

--- a/patches/minecraft/net/minecraft/world/ChunkCache.java.patch
+++ b/patches/minecraft/net/minecraft/world/ChunkCache.java.patch
@@ -17,7 +17,7 @@
          return this.field_72817_c[i][j].func_177424_a(p_190300_1_, p_190300_2_);
      }
  
-@@ -112,6 +113,7 @@
+@@ -112,12 +113,14 @@
      {
          int i = (p_180494_1_.func_177958_n() >> 4) - this.field_72818_a;
          int j = (p_180494_1_.func_177952_p() >> 4) - this.field_72816_b;
@@ -25,7 +25,14 @@
          return this.field_72817_c[i][j].func_177411_a(p_180494_1_, this.field_72815_e.func_72959_q());
      }
  
-@@ -149,6 +151,7 @@
+     @SideOnly(Side.CLIENT)
+     private int func_175629_a(EnumSkyBlock p_175629_1_, BlockPos p_175629_2_)
+     {
++        if (true) return this.func_180495_p(p_175629_2_).getLightFor(this, p_175629_1_, p_175629_2_);
+         if (p_175629_1_ == EnumSkyBlock.SKY && !this.field_72815_e.field_73011_w.func_191066_m())
+         {
+             return 0;
+@@ -149,6 +152,7 @@
              {
                  int i = (p_175629_2_.func_177958_n() >> 4) - this.field_72818_a;
                  int j = (p_175629_2_.func_177952_p() >> 4) - this.field_72816_b;
@@ -33,7 +40,7 @@
                  return this.field_72817_c[i][j].func_177413_a(p_175629_1_, p_175629_2_);
              }
          }
-@@ -160,7 +163,8 @@
+@@ -160,16 +164,25 @@
  
      public boolean func_175623_d(BlockPos p_175623_1_)
      {
@@ -42,8 +49,17 @@
 +        return state.func_177230_c().isAir(state, this, p_175623_1_);
      }
  
++    @Override
      @SideOnly(Side.CLIENT)
-@@ -170,6 +174,7 @@
++    public int getLight(EnumSkyBlock type, BlockPos pos)
++    {
++        return this.func_175628_b(type, pos);
++    }
++
++    @SideOnly(Side.CLIENT)
+     public int func_175628_b(EnumSkyBlock p_175628_1_, BlockPos p_175628_2_)
+     {
+         if (p_175628_2_.func_177956_o() >= 0 && p_175628_2_.func_177956_o() < 256)
          {
              int i = (p_175628_2_.func_177958_n() >> 4) - this.field_72818_a;
              int j = (p_175628_2_.func_177952_p() >> 4) - this.field_72816_b;
@@ -51,7 +67,7 @@
              return this.field_72817_c[i][j].func_177413_a(p_175628_1_, p_175628_2_);
          }
          else
-@@ -188,4 +193,21 @@
+@@ -188,4 +201,21 @@
      {
          return this.field_72815_e.func_175624_G();
      }

--- a/patches/minecraft/net/minecraft/world/IBlockAccess.java.patch
+++ b/patches/minecraft/net/minecraft/world/IBlockAccess.java.patch
@@ -1,6 +1,6 @@
 --- ../src-base/minecraft/net/minecraft/world/IBlockAccess.java
 +++ ../src-work/minecraft/net/minecraft/world/IBlockAccess.java
-@@ -28,4 +28,19 @@
+@@ -28,4 +28,18 @@
  
      @SideOnly(Side.CLIENT)
      WorldType func_175624_G();
@@ -17,6 +17,5 @@
 +
 +    /* ======================================== FORGE START =====================================*/
 +
-+    @SideOnly(Side.CLIENT)
 +    int getLight(EnumSkyBlock type, BlockPos pos);
  }

--- a/patches/minecraft/net/minecraft/world/IBlockAccess.java.patch
+++ b/patches/minecraft/net/minecraft/world/IBlockAccess.java.patch
@@ -1,6 +1,6 @@
 --- ../src-base/minecraft/net/minecraft/world/IBlockAccess.java
 +++ ../src-work/minecraft/net/minecraft/world/IBlockAccess.java
-@@ -28,4 +28,14 @@
+@@ -28,4 +28,19 @@
  
      @SideOnly(Side.CLIENT)
      WorldType func_175624_G();
@@ -14,4 +14,9 @@
 +     * @return if the block is solid on the side
 +     */
 +    boolean isSideSolid(BlockPos pos, EnumFacing side, boolean _default);
++
++    /* ======================================== FORGE START =====================================*/
++
++    @SideOnly(Side.CLIENT)
++    int getLight(EnumSkyBlock type, BlockPos pos);
  }

--- a/patches/minecraft/net/minecraft/world/World.java.patch
+++ b/patches/minecraft/net/minecraft/world/World.java.patch
@@ -177,7 +177,29 @@
                      {
                          return false;
                      }
-@@ -862,7 +914,7 @@
+@@ -728,6 +780,7 @@
+     @SideOnly(Side.CLIENT)
+     public int func_175705_a(EnumSkyBlock p_175705_1_, BlockPos p_175705_2_)
+     {
++        if (true) return this.func_180495_p(p_175705_2_).getLightFor(this, p_175705_1_, p_175705_2_);
+         if (!this.field_73011_w.func_191066_m() && p_175705_1_ == EnumSkyBlock.SKY)
+         {
+             return 0;
+@@ -785,6 +838,13 @@
+         }
+     }
+ 
++    @Override
++    @SideOnly(Side.CLIENT)
++    public int getLight(EnumSkyBlock type, BlockPos pos)
++    {
++        return this.func_175642_b(type, pos);
++    }
++
+     public int func_175642_b(EnumSkyBlock p_175642_1_, BlockPos p_175642_2_)
+     {
+         if (p_175642_2_.func_177956_o() < 0)
+@@ -862,7 +922,7 @@
  
      public boolean func_72935_r()
      {
@@ -186,7 +208,7 @@
      }
  
      @Nullable
-@@ -1065,6 +1117,13 @@
+@@ -1065,6 +1125,13 @@
  
      public void func_184148_a(@Nullable EntityPlayer p_184148_1_, double p_184148_2_, double p_184148_4_, double p_184148_6_, SoundEvent p_184148_8_, SoundCategory p_184148_9_, float p_184148_10_, float p_184148_11_)
      {
@@ -200,7 +222,7 @@
          for (int i = 0; i < this.field_73021_x.size(); ++i)
          {
              ((IWorldEventListener)this.field_73021_x.get(i)).func_184375_a(p_184148_1_, p_184148_8_, p_184148_9_, p_184148_2_, p_184148_4_, p_184148_6_, p_184148_10_, p_184148_11_);
-@@ -1118,6 +1177,9 @@
+@@ -1118,6 +1185,9 @@
  
      public boolean func_72838_d(Entity p_72838_1_)
      {
@@ -210,7 +232,7 @@
          int i = MathHelper.func_76128_c(p_72838_1_.field_70165_t / 16.0D);
          int j = MathHelper.func_76128_c(p_72838_1_.field_70161_v / 16.0D);
          boolean flag = p_72838_1_.field_98038_p;
-@@ -1140,6 +1202,8 @@
+@@ -1140,6 +1210,8 @@
                  this.func_72854_c();
              }
  
@@ -219,7 +241,7 @@
              this.func_72964_e(i, j).func_76612_a(p_72838_1_);
              this.field_72996_f.add(p_72838_1_);
              this.func_72923_a(p_72838_1_);
-@@ -1227,6 +1291,7 @@
+@@ -1227,6 +1299,7 @@
          IBlockState iblockstate = Blocks.field_150348_b.func_176223_P();
          BlockPos.PooledMutableBlockPos blockpos$pooledmutableblockpos = BlockPos.PooledMutableBlockPos.func_185346_s();
  
@@ -227,7 +249,7 @@
          try
          {
              for (int k1 = i; k1 < j; ++k1)
-@@ -1269,7 +1334,7 @@
+@@ -1269,7 +1342,7 @@
  
                                  iblockstate1.func_185908_a(this, blockpos$pooledmutableblockpos, p_191504_2_, p_191504_4_, p_191504_1_, false);
  
@@ -236,7 +258,7 @@
                                  {
                                      boolean flag5 = true;
                                      return flag5;
-@@ -1319,11 +1384,10 @@
+@@ -1319,11 +1392,10 @@
                  }
              }
          }
@@ -249,7 +271,7 @@
      public void func_72848_b(IWorldEventListener p_72848_1_)
      {
          this.field_73021_x.remove(p_72848_1_);
-@@ -1361,19 +1425,38 @@
+@@ -1361,19 +1433,38 @@
  
      public int func_72967_a(float p_72967_1_)
      {
@@ -290,7 +312,7 @@
          float f = this.func_72826_c(p_72971_1_);
          float f1 = 1.0F - (MathHelper.func_76134_b(f * ((float)Math.PI * 2F)) * 2.0F + 0.2F);
          f1 = MathHelper.func_76131_a(f1, 0.0F, 1.0F);
-@@ -1386,6 +1469,12 @@
+@@ -1386,6 +1477,12 @@
      @SideOnly(Side.CLIENT)
      public Vec3d func_72833_a(Entity p_72833_1_, float p_72833_2_)
      {
@@ -303,7 +325,7 @@
          float f = this.func_72826_c(p_72833_2_);
          float f1 = MathHelper.func_76134_b(f * ((float)Math.PI * 2F)) * 2.0F + 0.5F;
          f1 = MathHelper.func_76131_a(f1, 0.0F, 1.0F);
-@@ -1393,9 +1482,7 @@
+@@ -1393,9 +1490,7 @@
          int j = MathHelper.func_76128_c(p_72833_1_.field_70163_u);
          int k = MathHelper.func_76128_c(p_72833_1_.field_70161_v);
          BlockPos blockpos = new BlockPos(i, j, k);
@@ -314,7 +336,7 @@
          float f3 = (float)(l >> 16 & 255) / 255.0F;
          float f4 = (float)(l >> 8 & 255) / 255.0F;
          float f5 = (float)(l & 255) / 255.0F;
-@@ -1444,20 +1531,25 @@
+@@ -1444,20 +1539,25 @@
  
      public float func_72826_c(float p_72826_1_)
      {
@@ -343,7 +365,7 @@
      public float func_72929_e(float p_72929_1_)
      {
          float f = this.func_72826_c(p_72929_1_);
-@@ -1467,6 +1559,12 @@
+@@ -1467,6 +1567,12 @@
      @SideOnly(Side.CLIENT)
      public Vec3d func_72824_f(float p_72824_1_)
      {
@@ -356,7 +378,7 @@
          float f = this.func_72826_c(p_72824_1_);
          float f1 = MathHelper.func_76134_b(f * ((float)Math.PI * 2F)) * 2.0F + 0.5F;
          f1 = MathHelper.func_76131_a(f1, 0.0F, 1.0F);
-@@ -1522,9 +1620,9 @@
+@@ -1522,9 +1628,9 @@
          for (blockpos = new BlockPos(p_175672_1_.func_177958_n(), chunk.func_76625_h() + 16, p_175672_1_.func_177952_p()); blockpos.func_177956_o() >= 0; blockpos = blockpos1)
          {
              blockpos1 = blockpos.func_177977_b();
@@ -368,7 +390,7 @@
              {
                  break;
              }
-@@ -1536,6 +1634,12 @@
+@@ -1536,6 +1642,12 @@
      @SideOnly(Side.CLIENT)
      public float func_72880_h(float p_72880_1_)
      {
@@ -381,7 +403,7 @@
          float f = this.func_72826_c(p_72880_1_);
          float f1 = 1.0F - (MathHelper.func_76134_b(f * ((float)Math.PI * 2F)) * 2.0F + 0.25F);
          f1 = MathHelper.func_76131_a(f1, 0.0F, 1.0F);
-@@ -1570,6 +1674,7 @@
+@@ -1570,6 +1682,7 @@
  
              try
              {
@@ -389,7 +411,7 @@
                  ++entity.field_70173_aa;
                  entity.func_70071_h_();
              }
-@@ -1587,6 +1692,12 @@
+@@ -1587,6 +1700,12 @@
                      entity.func_85029_a(crashreportcategory);
                  }
  
@@ -402,7 +424,7 @@
                  throw new ReportedException(crashreport);
              }
  
-@@ -1641,13 +1752,21 @@
+@@ -1641,13 +1760,21 @@
              {
                  try
                  {
@@ -424,7 +446,7 @@
                      throw new ReportedException(crashreport1);
                  }
              }
-@@ -1674,14 +1793,23 @@
+@@ -1674,14 +1801,23 @@
  
          this.field_72984_F.func_76318_c("blockEntities");
  
@@ -451,7 +473,7 @@
          Iterator<TileEntity> iterator = this.field_175730_i.iterator();
  
          while (iterator.hasNext())
-@@ -1692,7 +1820,7 @@
+@@ -1692,7 +1828,7 @@
              {
                  BlockPos blockpos = tileentity.func_174877_v();
  
@@ -460,7 +482,7 @@
                  {
                      try
                      {
-@@ -1700,7 +1828,9 @@
+@@ -1700,7 +1836,9 @@
                          {
                              return String.valueOf((Object)TileEntity.func_190559_a(tileentity.getClass()));
                          });
@@ -470,7 +492,7 @@
                          this.field_72984_F.func_76319_b();
                      }
                      catch (Throwable throwable)
-@@ -1708,6 +1838,13 @@
+@@ -1708,6 +1846,13 @@
                          CrashReport crashreport2 = CrashReport.func_85055_a(throwable, "Ticking block entity");
                          CrashReportCategory crashreportcategory2 = crashreport2.func_85058_a("Block entity being ticked");
                          tileentity.func_145828_a(crashreportcategory2);
@@ -484,7 +506,7 @@
                          throw new ReportedException(crashreport2);
                      }
                  }
-@@ -1720,7 +1857,10 @@
+@@ -1720,7 +1865,10 @@
  
                  if (this.func_175667_e(tileentity.func_174877_v()))
                  {
@@ -496,7 +518,7 @@
                  }
              }
          }
-@@ -1764,12 +1904,18 @@
+@@ -1764,12 +1912,18 @@
  
      public boolean func_175700_a(TileEntity p_175700_1_)
      {
@@ -515,7 +537,7 @@
  
          if (this.field_72995_K)
          {
-@@ -1785,6 +1931,11 @@
+@@ -1785,6 +1939,11 @@
      {
          if (this.field_147481_N)
          {
@@ -527,7 +549,7 @@
              this.field_147484_a.addAll(p_147448_1_);
          }
          else
-@@ -1807,9 +1958,13 @@
+@@ -1807,9 +1966,13 @@
          {
              int j2 = MathHelper.func_76128_c(p_72866_1_.field_70165_t);
              int k2 = MathHelper.func_76128_c(p_72866_1_.field_70161_v);
@@ -543,7 +565,7 @@
              {
                  return;
              }
-@@ -1831,6 +1986,7 @@
+@@ -1831,6 +1994,7 @@
              }
              else
              {
@@ -551,7 +573,7 @@
                  p_72866_1_.func_70071_h_();
              }
          }
-@@ -1914,7 +2070,7 @@
+@@ -1914,7 +2078,7 @@
          {
              Entity entity4 = list.get(j2);
  
@@ -560,7 +582,7 @@
              {
                  return false;
              }
-@@ -1972,6 +2128,12 @@
+@@ -1972,6 +2136,12 @@
                  {
                      IBlockState iblockstate1 = this.func_180495_p(blockpos$pooledmutableblockpos.func_181079_c(l3, i4, j4));
  
@@ -573,7 +595,7 @@
                      if (iblockstate1.func_185904_a().func_76224_d())
                      {
                          blockpos$pooledmutableblockpos.func_185344_t();
-@@ -2011,6 +2173,11 @@
+@@ -2011,6 +2181,11 @@
                              blockpos$pooledmutableblockpos.func_185344_t();
                              return true;
                          }
@@ -585,7 +607,7 @@
                      }
                  }
              }
-@@ -2050,6 +2217,16 @@
+@@ -2050,6 +2225,16 @@
                          IBlockState iblockstate1 = this.func_180495_p(blockpos$pooledmutableblockpos);
                          Block block = iblockstate1.func_177230_c();
  
@@ -602,7 +624,7 @@
                          if (iblockstate1.func_185904_a() == p_72918_2_)
                          {
                              double d0 = (double)((float)(i4 + 1) - BlockLiquid.func_149801_b(((Integer)iblockstate1.func_177229_b(BlockLiquid.field_176367_b)).intValue()));
-@@ -2095,7 +2272,14 @@
+@@ -2095,7 +2280,14 @@
              {
                  for (int j4 = j3; j4 < k3; ++j4)
                  {
@@ -618,7 +640,7 @@
                      {
                          blockpos$pooledmutableblockpos.func_185344_t();
                          return true;
-@@ -2116,6 +2300,7 @@
+@@ -2116,6 +2308,7 @@
      public Explosion func_72885_a(@Nullable Entity p_72885_1_, double p_72885_2_, double p_72885_4_, double p_72885_6_, float p_72885_8_, boolean p_72885_9_, boolean p_72885_10_)
      {
          Explosion explosion = new Explosion(this, p_72885_1_, p_72885_2_, p_72885_4_, p_72885_6_, p_72885_8_, p_72885_9_, p_72885_10_);
@@ -626,7 +648,7 @@
          explosion.func_77278_a();
          explosion.func_77279_a(true);
          return explosion;
-@@ -2238,6 +2423,7 @@
+@@ -2238,6 +2431,7 @@
  
      public void func_175690_a(BlockPos p_175690_1_, @Nullable TileEntity p_175690_2_)
      {
@@ -634,7 +656,7 @@
          if (!this.func_189509_E(p_175690_1_))
          {
              if (p_175690_2_ != null && !p_175690_2_.func_145837_r())
-@@ -2245,6 +2431,8 @@
+@@ -2245,6 +2439,8 @@
                  if (this.field_147481_N)
                  {
                      p_175690_2_.func_174878_a(p_175690_1_);
@@ -643,7 +665,7 @@
                      Iterator<TileEntity> iterator1 = this.field_147484_a.iterator();
  
                      while (iterator1.hasNext())
-@@ -2262,7 +2450,8 @@
+@@ -2262,7 +2458,8 @@
                  }
                  else
                  {
@@ -653,7 +675,7 @@
                      this.func_175700_a(p_175690_2_);
                  }
              }
-@@ -2277,6 +2466,8 @@
+@@ -2277,6 +2474,8 @@
          {
              tileentity2.func_145843_s();
              this.field_147484_a.remove(tileentity2);
@@ -662,7 +684,7 @@
          }
          else
          {
-@@ -2289,6 +2480,7 @@
+@@ -2289,6 +2488,7 @@
  
              this.func_175726_f(p_175713_1_).func_177425_e(p_175713_1_);
          }
@@ -670,7 +692,7 @@
      }
  
      public void func_147457_a(TileEntity p_147457_1_)
-@@ -2315,7 +2507,7 @@
+@@ -2315,7 +2515,7 @@
              if (chunk1 != null && !chunk1.func_76621_g())
              {
                  IBlockState iblockstate1 = this.func_180495_p(p_175677_1_);
@@ -679,7 +701,7 @@
              }
              else
              {
-@@ -2338,6 +2530,7 @@
+@@ -2338,6 +2538,7 @@
      {
          this.field_72985_G = p_72891_1_;
          this.field_72992_H = p_72891_2_;
@@ -687,7 +709,7 @@
      }
  
      public void func_72835_b()
-@@ -2347,6 +2540,11 @@
+@@ -2347,6 +2548,11 @@
  
      protected void func_72947_a()
      {
@@ -699,7 +721,7 @@
          if (this.field_72986_A.func_76059_o())
          {
              this.field_73004_o = 1.0F;
-@@ -2360,6 +2558,11 @@
+@@ -2360,6 +2566,11 @@
  
      protected void func_72979_l()
      {
@@ -711,7 +733,7 @@
          if (this.field_73011_w.func_191066_m())
          {
              if (!this.field_72995_K)
-@@ -2484,6 +2687,11 @@
+@@ -2484,6 +2695,11 @@
  
      public boolean func_175670_e(BlockPos p_175670_1_, boolean p_175670_2_)
      {
@@ -723,7 +745,7 @@
          Biome biome = this.func_180494_b(p_175670_1_);
          float f = biome.func_180626_a(p_175670_1_);
  
-@@ -2525,6 +2733,11 @@
+@@ -2525,6 +2741,11 @@
  
      public boolean func_175708_f(BlockPos p_175708_1_, boolean p_175708_2_)
      {
@@ -735,7 +757,7 @@
          Biome biome = this.func_180494_b(p_175708_1_);
          float f = biome.func_180626_a(p_175708_1_);
  
-@@ -2542,7 +2755,7 @@
+@@ -2542,7 +2763,7 @@
              {
                  IBlockState iblockstate1 = this.func_180495_p(p_175708_1_);
  
@@ -744,7 +766,7 @@
                  {
                      return true;
                  }
-@@ -2574,10 +2787,11 @@
+@@ -2574,10 +2795,11 @@
          else
          {
              IBlockState iblockstate1 = this.func_180495_p(p_175638_1_);
@@ -759,7 +781,7 @@
              {
                  k2 = 1;
              }
-@@ -2630,12 +2844,13 @@
+@@ -2630,12 +2852,13 @@
  
      public boolean func_180500_c(EnumSkyBlock p_180500_1_, BlockPos p_180500_2_)
      {
@@ -774,7 +796,7 @@
              int j2 = 0;
              int k2 = 0;
              this.field_72984_F.func_76320_a("getBrightness");
-@@ -2673,7 +2888,7 @@
+@@ -2673,7 +2896,7 @@
                              int l5 = MathHelper.func_76130_a(k4 - k3);
                              int i6 = MathHelper.func_76130_a(l4 - l3);
  
@@ -783,7 +805,7 @@
                              {
                                  BlockPos.PooledMutableBlockPos blockpos$pooledmutableblockpos = BlockPos.PooledMutableBlockPos.func_185346_s();
  
-@@ -2683,7 +2898,8 @@
+@@ -2683,7 +2906,8 @@
                                      int k6 = k4 + enumfacing.func_96559_d();
                                      int l6 = l4 + enumfacing.func_82599_e();
                                      blockpos$pooledmutableblockpos.func_181079_c(j6, k6, l6);
@@ -793,7 +815,7 @@
                                      j5 = this.func_175642_b(p_180500_1_, blockpos$pooledmutableblockpos);
  
                                      if (j5 == i5 - i7 && k2 < this.field_72994_J.length)
-@@ -2725,7 +2941,7 @@
+@@ -2725,7 +2949,7 @@
                          int j9 = Math.abs(i8 - l3);
                          boolean flag = k2 < this.field_72994_J.length - 6;
  
@@ -802,7 +824,7 @@
                          {
                              if (this.func_175642_b(p_180500_1_, blockpos2.func_177976_e()) < k8)
                              {
-@@ -2791,10 +3007,10 @@
+@@ -2791,10 +3015,10 @@
      public List<Entity> func_175674_a(@Nullable Entity p_175674_1_, AxisAlignedBB p_175674_2_, @Nullable Predicate <? super Entity > p_175674_3_)
      {
          List<Entity> list = Lists.<Entity>newArrayList();
@@ -817,7 +839,7 @@
  
          for (int j3 = j2; j3 <= k2; ++j3)
          {
-@@ -2847,10 +3063,10 @@
+@@ -2847,10 +3071,10 @@
  
      public <T extends Entity> List<T> func_175647_a(Class <? extends T > p_175647_1_, AxisAlignedBB p_175647_2_, @Nullable Predicate <? super T > p_175647_3_)
      {
@@ -832,7 +854,7 @@
          List<T> list = Lists.<T>newArrayList();
  
          for (int j3 = j2; j3 < k2; ++j3)
-@@ -2930,11 +3146,13 @@
+@@ -2930,11 +3154,13 @@
  
      public void func_175650_b(Collection<Entity> p_175650_1_)
      {
@@ -849,7 +871,7 @@
          }
      }
  
-@@ -2958,7 +3176,7 @@
+@@ -2958,7 +3184,7 @@
          }
          else
          {
@@ -858,7 +880,7 @@
          }
      }
  
-@@ -3042,7 +3260,7 @@
+@@ -3042,7 +3268,7 @@
      public int func_175651_c(BlockPos p_175651_1_, EnumFacing p_175651_2_)
      {
          IBlockState iblockstate1 = this.func_180495_p(p_175651_1_);
@@ -867,7 +889,7 @@
      }
  
      public boolean func_175640_z(BlockPos p_175640_1_)
-@@ -3208,6 +3426,8 @@
+@@ -3208,6 +3434,8 @@
                      d2 *= ((Double)MoreObjects.firstNonNull(p_184150_11_.apply(entityplayer1), Double.valueOf(1.0D))).doubleValue();
                  }
  
@@ -876,7 +898,7 @@
                  if ((p_184150_9_ < 0.0D || Math.abs(entityplayer1.field_70163_u - p_184150_3_) < p_184150_9_ * p_184150_9_) && (p_184150_7_ < 0.0D || d1 < d2 * d2) && (d0 == -1.0D || d1 < d0))
                  {
                      d0 = d1;
-@@ -3269,7 +3489,7 @@
+@@ -3269,7 +3497,7 @@
  
      public long func_72905_C()
      {
@@ -885,7 +907,7 @@
      }
  
      public long func_82737_E()
-@@ -3279,17 +3499,17 @@
+@@ -3279,17 +3507,17 @@
  
      public long func_72820_D()
      {
@@ -906,7 +928,7 @@
  
          if (!this.func_175723_af().func_177746_a(blockpos1))
          {
-@@ -3301,7 +3521,7 @@
+@@ -3301,7 +3529,7 @@
  
      public void func_175652_B(BlockPos p_175652_1_)
      {
@@ -915,7 +937,7 @@
      }
  
      @SideOnly(Side.CLIENT)
-@@ -3321,12 +3541,18 @@
+@@ -3321,12 +3549,18 @@
  
          if (!this.field_72996_f.contains(p_72897_1_))
          {
@@ -934,7 +956,7 @@
          return true;
      }
  
-@@ -3428,8 +3654,7 @@
+@@ -3428,8 +3662,7 @@
  
      public boolean func_180502_D(BlockPos p_180502_1_)
      {
@@ -944,7 +966,7 @@
      }
  
      @Nullable
-@@ -3490,12 +3715,12 @@
+@@ -3490,12 +3723,12 @@
  
      public int func_72800_K()
      {
@@ -959,7 +981,7 @@
      }
  
      public Random func_72843_D(int p_72843_1_, int p_72843_2_, int p_72843_3_)
-@@ -3539,7 +3764,7 @@
+@@ -3539,7 +3772,7 @@
      @SideOnly(Side.CLIENT)
      public double func_72919_O()
      {
@@ -968,7 +990,7 @@
      }
  
      public void func_175715_c(int p_175715_1_, BlockPos p_175715_2_, int p_175715_3_)
-@@ -3573,7 +3798,7 @@
+@@ -3573,7 +3806,7 @@
  
      public void func_175666_e(BlockPos p_175666_1_, Block p_175666_2_)
      {
@@ -977,7 +999,7 @@
          {
              BlockPos blockpos1 = p_175666_1_.func_177972_a(enumfacing);
  
-@@ -3581,18 +3806,15 @@
+@@ -3581,18 +3814,15 @@
              {
                  IBlockState iblockstate1 = this.func_180495_p(blockpos1);
  
@@ -1000,7 +1022,7 @@
                      }
                  }
              }
-@@ -3658,6 +3880,124 @@
+@@ -3658,6 +3888,124 @@
          return j2 >= -128 && j2 <= 128 && k2 >= -128 && k2 <= 128;
      }
  

--- a/patches/minecraft/net/minecraft/world/World.java.patch
+++ b/patches/minecraft/net/minecraft/world/World.java.patch
@@ -177,7 +177,22 @@
                      {
                          return false;
                      }
-@@ -728,6 +780,7 @@
+@@ -623,6 +675,14 @@
+ 
+     public int func_175721_c(BlockPos p_175721_1_, boolean p_175721_2_)
+     {
++        if (true)
++        {
++            final IBlockState state = this.func_180495_p(p_175721_1_);
++            if (p_175721_2_)
++                return Math.max(state.getLightFor(this, EnumSkyBlock.BLOCK, p_175721_1_),  state.getLightFor(this, EnumSkyBlock.SKY, p_175721_1_) - this.field_73008_k);
++            else
++                return this.func_175699_k(p_175721_1_);
++        }
+         if (p_175721_1_.func_177958_n() >= -30000000 && p_175721_1_.func_177952_p() >= -30000000 && p_175721_1_.func_177958_n() < 30000000 && p_175721_1_.func_177952_p() < 30000000)
+         {
+             if (p_175721_2_ && this.func_180495_p(p_175721_1_).func_185916_f())
+@@ -728,6 +788,7 @@
      @SideOnly(Side.CLIENT)
      public int func_175705_a(EnumSkyBlock p_175705_1_, BlockPos p_175705_2_)
      {
@@ -185,12 +200,11 @@
          if (!this.field_73011_w.func_191066_m() && p_175705_1_ == EnumSkyBlock.SKY)
          {
              return 0;
-@@ -785,6 +838,13 @@
+@@ -785,6 +846,12 @@
          }
      }
  
 +    @Override
-+    @SideOnly(Side.CLIENT)
 +    public int getLight(EnumSkyBlock type, BlockPos pos)
 +    {
 +        return this.func_175642_b(type, pos);
@@ -199,7 +213,7 @@
      public int func_175642_b(EnumSkyBlock p_175642_1_, BlockPos p_175642_2_)
      {
          if (p_175642_2_.func_177956_o() < 0)
-@@ -862,7 +922,7 @@
+@@ -862,7 +929,7 @@
  
      public boolean func_72935_r()
      {
@@ -208,7 +222,7 @@
      }
  
      @Nullable
-@@ -1065,6 +1125,13 @@
+@@ -1065,6 +1132,13 @@
  
      public void func_184148_a(@Nullable EntityPlayer p_184148_1_, double p_184148_2_, double p_184148_4_, double p_184148_6_, SoundEvent p_184148_8_, SoundCategory p_184148_9_, float p_184148_10_, float p_184148_11_)
      {
@@ -222,7 +236,7 @@
          for (int i = 0; i < this.field_73021_x.size(); ++i)
          {
              ((IWorldEventListener)this.field_73021_x.get(i)).func_184375_a(p_184148_1_, p_184148_8_, p_184148_9_, p_184148_2_, p_184148_4_, p_184148_6_, p_184148_10_, p_184148_11_);
-@@ -1118,6 +1185,9 @@
+@@ -1118,6 +1192,9 @@
  
      public boolean func_72838_d(Entity p_72838_1_)
      {
@@ -232,7 +246,7 @@
          int i = MathHelper.func_76128_c(p_72838_1_.field_70165_t / 16.0D);
          int j = MathHelper.func_76128_c(p_72838_1_.field_70161_v / 16.0D);
          boolean flag = p_72838_1_.field_98038_p;
-@@ -1140,6 +1210,8 @@
+@@ -1140,6 +1217,8 @@
                  this.func_72854_c();
              }
  
@@ -241,7 +255,7 @@
              this.func_72964_e(i, j).func_76612_a(p_72838_1_);
              this.field_72996_f.add(p_72838_1_);
              this.func_72923_a(p_72838_1_);
-@@ -1227,6 +1299,7 @@
+@@ -1227,6 +1306,7 @@
          IBlockState iblockstate = Blocks.field_150348_b.func_176223_P();
          BlockPos.PooledMutableBlockPos blockpos$pooledmutableblockpos = BlockPos.PooledMutableBlockPos.func_185346_s();
  
@@ -249,7 +263,7 @@
          try
          {
              for (int k1 = i; k1 < j; ++k1)
-@@ -1269,7 +1342,7 @@
+@@ -1269,7 +1349,7 @@
  
                                  iblockstate1.func_185908_a(this, blockpos$pooledmutableblockpos, p_191504_2_, p_191504_4_, p_191504_1_, false);
  
@@ -258,7 +272,7 @@
                                  {
                                      boolean flag5 = true;
                                      return flag5;
-@@ -1319,11 +1392,10 @@
+@@ -1319,11 +1399,10 @@
                  }
              }
          }
@@ -271,7 +285,7 @@
      public void func_72848_b(IWorldEventListener p_72848_1_)
      {
          this.field_73021_x.remove(p_72848_1_);
-@@ -1361,19 +1433,38 @@
+@@ -1361,19 +1440,38 @@
  
      public int func_72967_a(float p_72967_1_)
      {
@@ -312,7 +326,7 @@
          float f = this.func_72826_c(p_72971_1_);
          float f1 = 1.0F - (MathHelper.func_76134_b(f * ((float)Math.PI * 2F)) * 2.0F + 0.2F);
          f1 = MathHelper.func_76131_a(f1, 0.0F, 1.0F);
-@@ -1386,6 +1477,12 @@
+@@ -1386,6 +1484,12 @@
      @SideOnly(Side.CLIENT)
      public Vec3d func_72833_a(Entity p_72833_1_, float p_72833_2_)
      {
@@ -325,7 +339,7 @@
          float f = this.func_72826_c(p_72833_2_);
          float f1 = MathHelper.func_76134_b(f * ((float)Math.PI * 2F)) * 2.0F + 0.5F;
          f1 = MathHelper.func_76131_a(f1, 0.0F, 1.0F);
-@@ -1393,9 +1490,7 @@
+@@ -1393,9 +1497,7 @@
          int j = MathHelper.func_76128_c(p_72833_1_.field_70163_u);
          int k = MathHelper.func_76128_c(p_72833_1_.field_70161_v);
          BlockPos blockpos = new BlockPos(i, j, k);
@@ -336,7 +350,7 @@
          float f3 = (float)(l >> 16 & 255) / 255.0F;
          float f4 = (float)(l >> 8 & 255) / 255.0F;
          float f5 = (float)(l & 255) / 255.0F;
-@@ -1444,20 +1539,25 @@
+@@ -1444,20 +1546,25 @@
  
      public float func_72826_c(float p_72826_1_)
      {
@@ -365,7 +379,7 @@
      public float func_72929_e(float p_72929_1_)
      {
          float f = this.func_72826_c(p_72929_1_);
-@@ -1467,6 +1567,12 @@
+@@ -1467,6 +1574,12 @@
      @SideOnly(Side.CLIENT)
      public Vec3d func_72824_f(float p_72824_1_)
      {
@@ -378,7 +392,7 @@
          float f = this.func_72826_c(p_72824_1_);
          float f1 = MathHelper.func_76134_b(f * ((float)Math.PI * 2F)) * 2.0F + 0.5F;
          f1 = MathHelper.func_76131_a(f1, 0.0F, 1.0F);
-@@ -1522,9 +1628,9 @@
+@@ -1522,9 +1635,9 @@
          for (blockpos = new BlockPos(p_175672_1_.func_177958_n(), chunk.func_76625_h() + 16, p_175672_1_.func_177952_p()); blockpos.func_177956_o() >= 0; blockpos = blockpos1)
          {
              blockpos1 = blockpos.func_177977_b();
@@ -390,7 +404,7 @@
              {
                  break;
              }
-@@ -1536,6 +1642,12 @@
+@@ -1536,6 +1649,12 @@
      @SideOnly(Side.CLIENT)
      public float func_72880_h(float p_72880_1_)
      {
@@ -403,7 +417,7 @@
          float f = this.func_72826_c(p_72880_1_);
          float f1 = 1.0F - (MathHelper.func_76134_b(f * ((float)Math.PI * 2F)) * 2.0F + 0.25F);
          f1 = MathHelper.func_76131_a(f1, 0.0F, 1.0F);
-@@ -1570,6 +1682,7 @@
+@@ -1570,6 +1689,7 @@
  
              try
              {
@@ -411,7 +425,7 @@
                  ++entity.field_70173_aa;
                  entity.func_70071_h_();
              }
-@@ -1587,6 +1700,12 @@
+@@ -1587,6 +1707,12 @@
                      entity.func_85029_a(crashreportcategory);
                  }
  
@@ -424,7 +438,7 @@
                  throw new ReportedException(crashreport);
              }
  
-@@ -1641,13 +1760,21 @@
+@@ -1641,13 +1767,21 @@
              {
                  try
                  {
@@ -446,7 +460,7 @@
                      throw new ReportedException(crashreport1);
                  }
              }
-@@ -1674,14 +1801,23 @@
+@@ -1674,14 +1808,23 @@
  
          this.field_72984_F.func_76318_c("blockEntities");
  
@@ -473,7 +487,7 @@
          Iterator<TileEntity> iterator = this.field_175730_i.iterator();
  
          while (iterator.hasNext())
-@@ -1692,7 +1828,7 @@
+@@ -1692,7 +1835,7 @@
              {
                  BlockPos blockpos = tileentity.func_174877_v();
  
@@ -482,7 +496,7 @@
                  {
                      try
                      {
-@@ -1700,7 +1836,9 @@
+@@ -1700,7 +1843,9 @@
                          {
                              return String.valueOf((Object)TileEntity.func_190559_a(tileentity.getClass()));
                          });
@@ -492,7 +506,7 @@
                          this.field_72984_F.func_76319_b();
                      }
                      catch (Throwable throwable)
-@@ -1708,6 +1846,13 @@
+@@ -1708,6 +1853,13 @@
                          CrashReport crashreport2 = CrashReport.func_85055_a(throwable, "Ticking block entity");
                          CrashReportCategory crashreportcategory2 = crashreport2.func_85058_a("Block entity being ticked");
                          tileentity.func_145828_a(crashreportcategory2);
@@ -506,7 +520,7 @@
                          throw new ReportedException(crashreport2);
                      }
                  }
-@@ -1720,7 +1865,10 @@
+@@ -1720,7 +1872,10 @@
  
                  if (this.func_175667_e(tileentity.func_174877_v()))
                  {
@@ -518,7 +532,7 @@
                  }
              }
          }
-@@ -1764,12 +1912,18 @@
+@@ -1764,12 +1919,18 @@
  
      public boolean func_175700_a(TileEntity p_175700_1_)
      {
@@ -537,7 +551,7 @@
  
          if (this.field_72995_K)
          {
-@@ -1785,6 +1939,11 @@
+@@ -1785,6 +1946,11 @@
      {
          if (this.field_147481_N)
          {
@@ -549,7 +563,7 @@
              this.field_147484_a.addAll(p_147448_1_);
          }
          else
-@@ -1807,9 +1966,13 @@
+@@ -1807,9 +1973,13 @@
          {
              int j2 = MathHelper.func_76128_c(p_72866_1_.field_70165_t);
              int k2 = MathHelper.func_76128_c(p_72866_1_.field_70161_v);
@@ -565,7 +579,7 @@
              {
                  return;
              }
-@@ -1831,6 +1994,7 @@
+@@ -1831,6 +2001,7 @@
              }
              else
              {
@@ -573,7 +587,7 @@
                  p_72866_1_.func_70071_h_();
              }
          }
-@@ -1914,7 +2078,7 @@
+@@ -1914,7 +2085,7 @@
          {
              Entity entity4 = list.get(j2);
  
@@ -582,7 +596,7 @@
              {
                  return false;
              }
-@@ -1972,6 +2136,12 @@
+@@ -1972,6 +2143,12 @@
                  {
                      IBlockState iblockstate1 = this.func_180495_p(blockpos$pooledmutableblockpos.func_181079_c(l3, i4, j4));
  
@@ -595,7 +609,7 @@
                      if (iblockstate1.func_185904_a().func_76224_d())
                      {
                          blockpos$pooledmutableblockpos.func_185344_t();
-@@ -2011,6 +2181,11 @@
+@@ -2011,6 +2188,11 @@
                              blockpos$pooledmutableblockpos.func_185344_t();
                              return true;
                          }
@@ -607,7 +621,7 @@
                      }
                  }
              }
-@@ -2050,6 +2225,16 @@
+@@ -2050,6 +2232,16 @@
                          IBlockState iblockstate1 = this.func_180495_p(blockpos$pooledmutableblockpos);
                          Block block = iblockstate1.func_177230_c();
  
@@ -624,7 +638,7 @@
                          if (iblockstate1.func_185904_a() == p_72918_2_)
                          {
                              double d0 = (double)((float)(i4 + 1) - BlockLiquid.func_149801_b(((Integer)iblockstate1.func_177229_b(BlockLiquid.field_176367_b)).intValue()));
-@@ -2095,7 +2280,14 @@
+@@ -2095,7 +2287,14 @@
              {
                  for (int j4 = j3; j4 < k3; ++j4)
                  {
@@ -640,7 +654,7 @@
                      {
                          blockpos$pooledmutableblockpos.func_185344_t();
                          return true;
-@@ -2116,6 +2308,7 @@
+@@ -2116,6 +2315,7 @@
      public Explosion func_72885_a(@Nullable Entity p_72885_1_, double p_72885_2_, double p_72885_4_, double p_72885_6_, float p_72885_8_, boolean p_72885_9_, boolean p_72885_10_)
      {
          Explosion explosion = new Explosion(this, p_72885_1_, p_72885_2_, p_72885_4_, p_72885_6_, p_72885_8_, p_72885_9_, p_72885_10_);
@@ -648,7 +662,7 @@
          explosion.func_77278_a();
          explosion.func_77279_a(true);
          return explosion;
-@@ -2238,6 +2431,7 @@
+@@ -2238,6 +2438,7 @@
  
      public void func_175690_a(BlockPos p_175690_1_, @Nullable TileEntity p_175690_2_)
      {
@@ -656,7 +670,7 @@
          if (!this.func_189509_E(p_175690_1_))
          {
              if (p_175690_2_ != null && !p_175690_2_.func_145837_r())
-@@ -2245,6 +2439,8 @@
+@@ -2245,6 +2446,8 @@
                  if (this.field_147481_N)
                  {
                      p_175690_2_.func_174878_a(p_175690_1_);
@@ -665,7 +679,7 @@
                      Iterator<TileEntity> iterator1 = this.field_147484_a.iterator();
  
                      while (iterator1.hasNext())
-@@ -2262,7 +2458,8 @@
+@@ -2262,7 +2465,8 @@
                  }
                  else
                  {
@@ -675,7 +689,7 @@
                      this.func_175700_a(p_175690_2_);
                  }
              }
-@@ -2277,6 +2474,8 @@
+@@ -2277,6 +2481,8 @@
          {
              tileentity2.func_145843_s();
              this.field_147484_a.remove(tileentity2);
@@ -684,7 +698,7 @@
          }
          else
          {
-@@ -2289,6 +2488,7 @@
+@@ -2289,6 +2495,7 @@
  
              this.func_175726_f(p_175713_1_).func_177425_e(p_175713_1_);
          }
@@ -692,7 +706,7 @@
      }
  
      public void func_147457_a(TileEntity p_147457_1_)
-@@ -2315,7 +2515,7 @@
+@@ -2315,7 +2522,7 @@
              if (chunk1 != null && !chunk1.func_76621_g())
              {
                  IBlockState iblockstate1 = this.func_180495_p(p_175677_1_);
@@ -701,7 +715,7 @@
              }
              else
              {
-@@ -2338,6 +2538,7 @@
+@@ -2338,6 +2545,7 @@
      {
          this.field_72985_G = p_72891_1_;
          this.field_72992_H = p_72891_2_;
@@ -709,7 +723,7 @@
      }
  
      public void func_72835_b()
-@@ -2347,6 +2548,11 @@
+@@ -2347,6 +2555,11 @@
  
      protected void func_72947_a()
      {
@@ -721,7 +735,7 @@
          if (this.field_72986_A.func_76059_o())
          {
              this.field_73004_o = 1.0F;
-@@ -2360,6 +2566,11 @@
+@@ -2360,6 +2573,11 @@
  
      protected void func_72979_l()
      {
@@ -733,7 +747,7 @@
          if (this.field_73011_w.func_191066_m())
          {
              if (!this.field_72995_K)
-@@ -2484,6 +2695,11 @@
+@@ -2484,6 +2702,11 @@
  
      public boolean func_175670_e(BlockPos p_175670_1_, boolean p_175670_2_)
      {
@@ -745,7 +759,7 @@
          Biome biome = this.func_180494_b(p_175670_1_);
          float f = biome.func_180626_a(p_175670_1_);
  
-@@ -2525,6 +2741,11 @@
+@@ -2525,6 +2748,11 @@
  
      public boolean func_175708_f(BlockPos p_175708_1_, boolean p_175708_2_)
      {
@@ -757,7 +771,7 @@
          Biome biome = this.func_180494_b(p_175708_1_);
          float f = biome.func_180626_a(p_175708_1_);
  
-@@ -2542,7 +2763,7 @@
+@@ -2542,7 +2770,7 @@
              {
                  IBlockState iblockstate1 = this.func_180495_p(p_175708_1_);
  
@@ -766,7 +780,7 @@
                  {
                      return true;
                  }
-@@ -2574,10 +2795,11 @@
+@@ -2574,10 +2802,11 @@
          else
          {
              IBlockState iblockstate1 = this.func_180495_p(p_175638_1_);
@@ -781,7 +795,7 @@
              {
                  k2 = 1;
              }
-@@ -2630,12 +2852,13 @@
+@@ -2630,12 +2859,13 @@
  
      public boolean func_180500_c(EnumSkyBlock p_180500_1_, BlockPos p_180500_2_)
      {
@@ -796,7 +810,7 @@
              int j2 = 0;
              int k2 = 0;
              this.field_72984_F.func_76320_a("getBrightness");
-@@ -2673,7 +2896,7 @@
+@@ -2673,7 +2903,7 @@
                              int l5 = MathHelper.func_76130_a(k4 - k3);
                              int i6 = MathHelper.func_76130_a(l4 - l3);
  
@@ -805,7 +819,7 @@
                              {
                                  BlockPos.PooledMutableBlockPos blockpos$pooledmutableblockpos = BlockPos.PooledMutableBlockPos.func_185346_s();
  
-@@ -2683,7 +2906,8 @@
+@@ -2683,7 +2913,8 @@
                                      int k6 = k4 + enumfacing.func_96559_d();
                                      int l6 = l4 + enumfacing.func_82599_e();
                                      blockpos$pooledmutableblockpos.func_181079_c(j6, k6, l6);
@@ -815,7 +829,7 @@
                                      j5 = this.func_175642_b(p_180500_1_, blockpos$pooledmutableblockpos);
  
                                      if (j5 == i5 - i7 && k2 < this.field_72994_J.length)
-@@ -2725,7 +2949,7 @@
+@@ -2725,7 +2956,7 @@
                          int j9 = Math.abs(i8 - l3);
                          boolean flag = k2 < this.field_72994_J.length - 6;
  
@@ -824,7 +838,7 @@
                          {
                              if (this.func_175642_b(p_180500_1_, blockpos2.func_177976_e()) < k8)
                              {
-@@ -2791,10 +3015,10 @@
+@@ -2791,10 +3022,10 @@
      public List<Entity> func_175674_a(@Nullable Entity p_175674_1_, AxisAlignedBB p_175674_2_, @Nullable Predicate <? super Entity > p_175674_3_)
      {
          List<Entity> list = Lists.<Entity>newArrayList();
@@ -839,7 +853,7 @@
  
          for (int j3 = j2; j3 <= k2; ++j3)
          {
-@@ -2847,10 +3071,10 @@
+@@ -2847,10 +3078,10 @@
  
      public <T extends Entity> List<T> func_175647_a(Class <? extends T > p_175647_1_, AxisAlignedBB p_175647_2_, @Nullable Predicate <? super T > p_175647_3_)
      {
@@ -854,7 +868,7 @@
          List<T> list = Lists.<T>newArrayList();
  
          for (int j3 = j2; j3 < k2; ++j3)
-@@ -2930,11 +3154,13 @@
+@@ -2930,11 +3161,13 @@
  
      public void func_175650_b(Collection<Entity> p_175650_1_)
      {
@@ -871,7 +885,7 @@
          }
      }
  
-@@ -2958,7 +3184,7 @@
+@@ -2958,7 +3191,7 @@
          }
          else
          {
@@ -880,7 +894,7 @@
          }
      }
  
-@@ -3042,7 +3268,7 @@
+@@ -3042,7 +3275,7 @@
      public int func_175651_c(BlockPos p_175651_1_, EnumFacing p_175651_2_)
      {
          IBlockState iblockstate1 = this.func_180495_p(p_175651_1_);
@@ -889,7 +903,7 @@
      }
  
      public boolean func_175640_z(BlockPos p_175640_1_)
-@@ -3208,6 +3434,8 @@
+@@ -3208,6 +3441,8 @@
                      d2 *= ((Double)MoreObjects.firstNonNull(p_184150_11_.apply(entityplayer1), Double.valueOf(1.0D))).doubleValue();
                  }
  
@@ -898,7 +912,7 @@
                  if ((p_184150_9_ < 0.0D || Math.abs(entityplayer1.field_70163_u - p_184150_3_) < p_184150_9_ * p_184150_9_) && (p_184150_7_ < 0.0D || d1 < d2 * d2) && (d0 == -1.0D || d1 < d0))
                  {
                      d0 = d1;
-@@ -3269,7 +3497,7 @@
+@@ -3269,7 +3504,7 @@
  
      public long func_72905_C()
      {
@@ -907,7 +921,7 @@
      }
  
      public long func_82737_E()
-@@ -3279,17 +3507,17 @@
+@@ -3279,17 +3514,17 @@
  
      public long func_72820_D()
      {
@@ -928,7 +942,7 @@
  
          if (!this.func_175723_af().func_177746_a(blockpos1))
          {
-@@ -3301,7 +3529,7 @@
+@@ -3301,7 +3536,7 @@
  
      public void func_175652_B(BlockPos p_175652_1_)
      {
@@ -937,7 +951,7 @@
      }
  
      @SideOnly(Side.CLIENT)
-@@ -3321,12 +3549,18 @@
+@@ -3321,12 +3556,18 @@
  
          if (!this.field_72996_f.contains(p_72897_1_))
          {
@@ -956,7 +970,7 @@
          return true;
      }
  
-@@ -3428,8 +3662,7 @@
+@@ -3428,8 +3669,7 @@
  
      public boolean func_180502_D(BlockPos p_180502_1_)
      {
@@ -966,7 +980,7 @@
      }
  
      @Nullable
-@@ -3490,12 +3723,12 @@
+@@ -3490,12 +3730,12 @@
  
      public int func_72800_K()
      {
@@ -981,7 +995,7 @@
      }
  
      public Random func_72843_D(int p_72843_1_, int p_72843_2_, int p_72843_3_)
-@@ -3539,7 +3772,7 @@
+@@ -3539,7 +3779,7 @@
      @SideOnly(Side.CLIENT)
      public double func_72919_O()
      {
@@ -990,7 +1004,7 @@
      }
  
      public void func_175715_c(int p_175715_1_, BlockPos p_175715_2_, int p_175715_3_)
-@@ -3573,7 +3806,7 @@
+@@ -3573,7 +3813,7 @@
  
      public void func_175666_e(BlockPos p_175666_1_, Block p_175666_2_)
      {
@@ -999,7 +1013,7 @@
          {
              BlockPos blockpos1 = p_175666_1_.func_177972_a(enumfacing);
  
-@@ -3581,18 +3814,15 @@
+@@ -3581,18 +3821,15 @@
              {
                  IBlockState iblockstate1 = this.func_180495_p(blockpos1);
  
@@ -1022,7 +1036,7 @@
                      }
                  }
              }
-@@ -3658,6 +3888,124 @@
+@@ -3658,6 +3895,124 @@
          return j2 >= -128 && j2 <= 128 && k2 >= -128 && k2 <= 128;
      }
  


### PR DESCRIPTION
Created these patches for fun, so why not make a PR out of it :P

Currently, slabs, stairs and some other blocks appear bright when there is some bright block beneath them, resulting in pictures like these (there is a sea lantern below):

Flat lighting:
![2018-05-03_21 49 40](https://user-images.githubusercontent.com/11480245/39599837-3e32a2f0-4f1d-11e8-908f-387bfc9f8a3d.png)
Smooth lighting:
![2018-05-03_21 49 54](https://user-images.githubusercontent.com/11480245/39599847-43160802-4f1d-11e8-89a7-8c18f83a7bcc.png)

This bug originates from a bugfix to an earlier issue: https://bugs.mojang.com/browse/MC-123117

The underlying problem of the original bug was that there can only be one light value per position. However, slabs, stairs, etc. should visibly behave like 2 blocks in one: something solid on the bottom and air on top. Because they are solid, light won't pass into them and so they would appear dark (as in the linked issue) which certainly is not the desired effect.
The most intuitive solution would have been to change the lighting engine, so that light could only pass through certain faces, but not others. Then light could pass into those blocks from above, but from no other side.
Unfortunately, Mojang didn't implement it this way. So I won't either because I'm quite sure that there are parts of the rendering code that expect these blocks to be dark. Messing with this would probably result in more bugs. Also, the patches would be a bit more invasive.

The route Mojang took is to modify the light values just for rendering, instead of modifiying the lighting engine overall. The issue was "fixed" by just inheriting the light from neighbors, which can be controlled via `useNeighborBrightness`. However, this mechanism considers all 6 neighbors, so even light sources from below lighten up the block visually.
My fix basically adds some direction awareness to `useNeighborBrightness()`, so it can be configured to only include light from above (or below when slabs, stairs are flipped).

The result looks as follow:

Flat light
![2018-05-03_21 55 01](https://user-images.githubusercontent.com/11480245/39600305-a47bbcd0-4f1e-11e8-89fa-13d2b176f27d.png)
Smooth light
![2018-05-03_21 55 09](https://user-images.githubusercontent.com/11480245/39600313-a8d7bec8-4f1e-11e8-8aba-9ceacc521165.png)

As you can see, the issue is solved for flat lighting. Smooth lighting is still not perfect, but a lot better, at least. This requires another fix somewhere in VertexLighterSmooth, but I'm not familiar with that code, at all.

Remark: Slabs, stairs, etc. won't take into account light sources from the side. Not sure what should be the correct behavior for that. Light sources from above you certainly want and those from below certainly not. Not sure about the horizontal neighbors.

There is also a variant of the original bug for liquids: https://bugs.mojang.com/browse/MC-104532

I have also fixed this, by enabling `useNeighborBrightness`  for liquids:
![2018-05-03_21 55 42](https://user-images.githubusercontent.com/11480245/39600428-009fb836-4f1f-11e8-9a86-907bc101bee8.png)


