### PR TITLE
Fix MC-12269

### DIFF
--- a/patches/minecraft/net/minecraft/client/particle/Particle.java.patch
+++ b/patches/minecraft/net/minecraft/client/particle/Particle.java.patch
@@ -1,19 +1,17 @@
 --- ../src-base/minecraft/net/minecraft/client/particle/Particle.java
 +++ ../src-work/minecraft/net/minecraft/client/particle/Particle.java
-@@ -265,8 +265,12 @@
+@@ -265,8 +265,8 @@
          {
              this.field_187134_n = p_187115_1_;
              this.field_187135_o = p_187115_2_;
+-            AxisAlignedBB axisalignedbb = this.func_187116_l();
+-            this.func_187108_a(new AxisAlignedBB(axisalignedbb.field_72340_a, axisalignedbb.field_72338_b, axisalignedbb.field_72339_c, axisalignedbb.field_72340_a + (double)this.field_187134_n, axisalignedbb.field_72338_b + (double)this.field_187135_o, axisalignedbb.field_72339_c + (double)this.field_187134_n));
 +            // FORGE: Fix MC-12269 - Glitchy movement when setSize is called without setPosition
 +            func_187109_b(field_187126_f, field_187127_g, field_187128_h);
-+            if (false) {
-             AxisAlignedBB axisalignedbb = this.func_187116_l();
-             this.func_187108_a(new AxisAlignedBB(axisalignedbb.field_72340_a, axisalignedbb.field_72338_b, axisalignedbb.field_72339_c, axisalignedbb.field_72340_a + (double)this.field_187134_n, axisalignedbb.field_72338_b + (double)this.field_187135_o, axisalignedbb.field_72339_c + (double)this.field_187134_n));
-+            }
          }
      }
  
-@@ -283,6 +287,8 @@
+@@ -283,6 +283,8 @@
      public void func_187110_a(double p_187110_1_, double p_187110_3_, double p_187110_5_)
      {
          double d0 = p_187110_3_;
@@ -22,7 +20,7 @@
  
          if (this.field_190017_n)
          {
-@@ -315,14 +321,14 @@
+@@ -315,14 +317,14 @@
          }
  
          this.func_187118_j();

--- a/patches/minecraft/net/minecraft/client/particle/Particle.java.patch
+++ b/patches/minecraft/net/minecraft/client/particle/Particle.java.patch
@@ -1,6 +1,19 @@
 --- ../src-base/minecraft/net/minecraft/client/particle/Particle.java
 +++ ../src-work/minecraft/net/minecraft/client/particle/Particle.java
-@@ -283,6 +283,8 @@
+@@ -265,8 +265,12 @@
+         {
+             this.field_187134_n = p_187115_1_;
+             this.field_187135_o = p_187115_2_;
++            // FORGE: Fix MC-12269 - Glitchy movement when setSize is called without setPosition
++            func_187109_b(field_187126_f, field_187127_g, field_187128_h);
++            if (false) {
+             AxisAlignedBB axisalignedbb = this.func_187116_l();
+             this.func_187108_a(new AxisAlignedBB(axisalignedbb.field_72340_a, axisalignedbb.field_72338_b, axisalignedbb.field_72339_c, axisalignedbb.field_72340_a + (double)this.field_187134_n, axisalignedbb.field_72338_b + (double)this.field_187135_o, axisalignedbb.field_72339_c + (double)this.field_187134_n));
++            }
+         }
+     }
+ 
+@@ -283,6 +287,8 @@
      public void func_187110_a(double p_187110_1_, double p_187110_3_, double p_187110_5_)
      {
          double d0 = p_187110_3_;
@@ -9,7 +22,7 @@
  
          if (this.field_190017_n)
          {
-@@ -315,14 +317,14 @@
+@@ -315,14 +321,14 @@
          }
  
          this.func_187118_j();


### PR DESCRIPTION
This patches the vanilla bug that causes certain particles to "jump" after being spawned. [See my breakdown of the issue on JIRA.](https://bugs.mojang.com/browse/MC-12269?focusedCommentId=427159&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-427159)

Before:
![buggyparticles](https://user-images.githubusercontent.com/3751664/39694959-f8b8b466-51b6-11e8-9f77-6a152f4934ed.gif)

After:
![buggyparticlesfixed](https://user-images.githubusercontent.com/3751664/39694964-fe06d768-51b6-11e8-93ca-d482be4ab7d0.gif)

~~I'm not sure if this was the best way to do the patch, I wanted to leave the old vanilla code in for easier un-fixing once this is patched by Mojang, so I added the `if (false)`. If you'd rather I just delete it, I will do so.~~