### PR TITLE
Fix vertex lighter using stale normal data

### DIFF
--- a/src/main/java/net/minecraftforge/client/model/pipeline/VertexLighterFlat.java
+++ b/src/main/java/net/minecraftforge/client/model/pipeline/VertexLighterFlat.java
@@ -121,7 +121,10 @@ public class VertexLighterFlat extends QuadGatheringTransformer
         float[][] lightmap = quadData[lightmapIndex];
         float[][] color = quadData[colorIndex];
 
-        if (dataLength[normalIndex] >= 3)
+        if (dataLength[normalIndex] >= 3
+            && (quadData[normalIndex][0][0] != -1
+            ||  quadData[normalIndex][0][1] != -1
+            ||  quadData[normalIndex][0][2] != -1))
         {
             normal = quadData[normalIndex];
         }

--- a/src/main/java/net/minecraftforge/client/model/pipeline/VertexLighterFlat.java
+++ b/src/main/java/net/minecraftforge/client/model/pipeline/VertexLighterFlat.java
@@ -121,14 +121,11 @@ public class VertexLighterFlat extends QuadGatheringTransformer
         float[][] lightmap = quadData[lightmapIndex];
         float[][] color = quadData[colorIndex];
 
-        // If all three normal values are either -1 or 0, normals must be generated
-        if(quadData[normalIndex][0][0] != quadData[normalIndex][0][1] ||
-            quadData[normalIndex][0][1] != quadData[normalIndex][0][2] ||
-           (quadData[normalIndex][0][0] != -1 && quadData[normalIndex][0][0] != 0))
+        if (dataLength[normalIndex] >= 3)
         {
             normal = quadData[normalIndex];
         }
-        else
+        else // normals must be generated
         {
             normal = new float[4][4];
             Vector3f v1 = new Vector3f(position[3]);


### PR DESCRIPTION
Should fix #4916.

Rather than checking the values of `quadData`, this changes the code to check the amount of normal data received. If less than 3 values have been `put` into the lighter (see `VertexLighter.putBakedQuad`), normals should be generated for the quad. This prevents re-use of stale normal data for quads which don't provide their own.

Example screenshots (model in question is from [here](https://github.com/MinecraftForge/MinecraftForge/blob/1.12.x/src/test/java/net/minecraftforge/debug/client/model/ModelBakeEventTest.java)):

Before:
![2018-05-09_04 57 08](https://user-images.githubusercontent.com/1447117/39795231-a81e6cbc-5346-11e8-941d-d13b10af9c54.png)

After:
![2018-05-09_04 59 09](https://user-images.githubusercontent.com/1447117/39795234-aae17b38-5346-11e8-8aaf-63cd109e2037.png)
