### PR TITLE
Added formatting support for status messages

### DIFF
--- a/patches/minecraft/net/minecraft/client/gui/GuiIngame.java.patch
+++ b/patches/minecraft/net/minecraft/client/gui/GuiIngame.java.patch
@@ -33,3 +33,12 @@
                  }
              }
          }
+@@ -1260,7 +1267,7 @@
+ 
+     public void func_175188_a(ITextComponent p_175188_1_, boolean p_175188_2_)
+     {
+-        this.func_110326_a(p_175188_1_.func_150260_c(), p_175188_2_);
++        this.func_110326_a(p_175188_1_.func_150254_d(), p_175188_2_);
+     }
+ 
+     public void func_191742_a(ChatType p_191742_1_, ITextComponent p_191742_2_)

--- a/patches/minecraft/net/minecraft/client/gui/GuiIngame.java.patch
+++ b/patches/minecraft/net/minecraft/client/gui/GuiIngame.java.patch
@@ -33,12 +33,3 @@
                  }
              }
          }
-@@ -1260,7 +1267,7 @@
- 
-     public void func_175188_a(ITextComponent p_175188_1_, boolean p_175188_2_)
-     {
--        this.func_110326_a(p_175188_1_.func_150260_c(), p_175188_2_);
-+        this.func_110326_a(p_175188_1_.func_150254_d(), p_175188_2_);
-     }
- 
-     public void func_191742_a(ChatType p_191742_1_, ITextComponent p_191742_2_)

--- a/src/main/java/net/minecraftforge/client/GuiIngameForge.java
+++ b/src/main/java/net/minecraftforge/client/GuiIngameForge.java
@@ -52,6 +52,7 @@ import net.minecraft.util.FoodStats;
 import net.minecraft.util.ResourceLocation;
 import net.minecraft.util.StringUtils;
 import net.minecraft.util.math.MathHelper;
+import net.minecraft.util.text.ITextComponent;
 import net.minecraft.util.text.TextFormatting;
 import net.minecraftforge.client.event.RenderGameOverlayEvent;
 import net.minecraftforge.client.event.RenderGameOverlayEvent.ElementType;
@@ -346,6 +347,12 @@ public class GuiIngameForge extends GuiIngame
         }
 
         post(HOTBAR);
+    }
+
+    @Override
+    public void setOverlayMessage(ITextComponent component, boolean animateColor)
+    {
+        this.setOverlayMessage(component.getFormattedText(), animateColor);
     }
 
     protected void renderAir(int width, int height)


### PR DESCRIPTION
For some reason vanilla uses getUnformattedText() in status messages, which removes all formatting. This PR uses formatted version and allows to use colors, bold, italic, etc.

Code for test:

```java
ITextComponent component = new TextComponentTranslation("ftbutilities.lang.chunks.wilderness");
component.getStyle().setColor(TextFormatting.DARK_GREEN);
component.getStyle().setBold(true);
player.sendStatusMessage(component, true);
```

Result without patch:
![image](https://ss.latmod.com/mc/2018-05-14_03.16.14.png)
Result with patch:
![image](https://ss.latmod.com/mc/2018-05-14_03.14.50.png)