### PR TITLE
Fix MC-234: Z-fighting when viewing break animation side-on

### DIFF
--- a/patches/minecraft/net/minecraft/client/renderer/RenderGlobal.java.patch
+++ b/patches/minecraft/net/minecraft/client/renderer/RenderGlobal.java.patch
@@ -124,6 +124,15 @@
          if (this.field_72777_q.field_71441_e.field_73011_w.func_76569_d())
          {
              if (this.field_72777_q.field_71474_y.func_181147_e() == 2)
+@@ -1852,7 +1875,7 @@
+         GlStateManager.func_187428_a(GlStateManager.SourceFactor.DST_COLOR, GlStateManager.DestFactor.SRC_COLOR, GlStateManager.SourceFactor.ONE, GlStateManager.DestFactor.ZERO);
+         GlStateManager.func_179147_l();
+         GlStateManager.func_179131_c(1.0F, 1.0F, 1.0F, 0.5F);
+-        GlStateManager.func_179136_a(-3.0F, -3.0F);
++        GlStateManager.func_179136_a(-1.0F, -10.0F);
+         GlStateManager.func_179088_q();
+         GlStateManager.func_179092_a(516, 0.1F);
+         GlStateManager.func_179141_d();
 @@ -1892,8 +1915,11 @@
                  double d7 = (double)blockpos.func_177956_o() - d4;
                  double d8 = (double)blockpos.func_177952_p() - d5;

--- a/patches/minecraft/net/minecraft/client/renderer/RenderGlobal.java.patch
+++ b/patches/minecraft/net/minecraft/client/renderer/RenderGlobal.java.patch
@@ -124,16 +124,17 @@
          if (this.field_72777_q.field_71441_e.field_73011_w.func_76569_d())
          {
              if (this.field_72777_q.field_71474_y.func_181147_e() == 2)
-@@ -1852,7 +1875,7 @@
+@@ -1852,7 +1875,8 @@
          GlStateManager.func_187428_a(GlStateManager.SourceFactor.DST_COLOR, GlStateManager.DestFactor.SRC_COLOR, GlStateManager.SourceFactor.ONE, GlStateManager.DestFactor.ZERO);
          GlStateManager.func_179147_l();
          GlStateManager.func_179131_c(1.0F, 1.0F, 1.0F, 0.5F);
 -        GlStateManager.func_179136_a(-3.0F, -3.0F);
++        // FORGE: Fix MC-234
 +        GlStateManager.func_179136_a(-1.0F, -10.0F);
          GlStateManager.func_179088_q();
          GlStateManager.func_179092_a(516, 0.1F);
          GlStateManager.func_179141_d();
-@@ -1892,8 +1915,11 @@
+@@ -1892,8 +1916,11 @@
                  double d7 = (double)blockpos.func_177956_o() - d4;
                  double d8 = (double)blockpos.func_177952_p() - d5;
                  Block block = this.field_72769_h.func_180495_p(blockpos).func_177230_c();
@@ -146,7 +147,7 @@
                  {
                      if (d6 * d6 + d7 * d7 + d8 * d8 > 1024.0D)
                      {
-@@ -2388,7 +2414,7 @@
+@@ -2388,7 +2415,7 @@
  
                  if (block.func_176223_P().func_185904_a() != Material.field_151579_a)
                  {


### PR DESCRIPTION
See: https://bugs.mojang.com/browse/MC-234?focusedCommentId=452332&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-452332

I'll admit to not *100%* understanding the intricacies of `glPolygonOffset`, but here's the best technical explanation I can give:

- The first parameter is a factor based on the depth slope (view angle) of the polygon
- The second parameter is a constant value to adjust the polygon depth

Knowing this data, I first attempted to just set the first argument to zero, and found that the breaking animation *always* had z-fighting, regardless of angle. This led me to believe that the issue was simply that the constant value (the second parameter) was too low, and adjusting this to a higher value (10) seemed to solve the issue. I added the -1.0 to the first argument as I noticed z-fighting at some *very* steep viewing angles, and after changing it to -1 I have not noticed this.

No images because I think everyone knows what z-fighting is, and there are plenty of pics on the Jira report.