### PR TITLE
Fix Forge bucket not declaring all texture dependencies

### DIFF
--- a/src/main/java/net/minecraftforge/client/model/ModelDynBucket.java
+++ b/src/main/java/net/minecraftforge/client/model/ModelDynBucket.java
@@ -104,12 +104,15 @@ public final class ModelDynBucket implements IModel
     public Collection<ResourceLocation> getTextures()
     {
         ImmutableSet.Builder<ResourceLocation> builder = ImmutableSet.builder();
+
         if (baseLocation != null)
             builder.add(baseLocation);
         if (liquidLocation != null)
             builder.add(liquidLocation);
         if (coverLocation != null)
             builder.add(coverLocation);
+        if (fluid != null)
+            builder.add(fluid.getStill());
 
         return builder.build();
     }


### PR DESCRIPTION
Fixes the Forge bucket model not declaring the still fluid texture location in `getTextures`, when it may try to lookup the corresponding `TextureAtlasSprite` in `bake`.

See:
https://github.com/MinecraftForge/MinecraftForge/blob/e7cd3d4df6206bc6366f026e3933edf15963d4d9/src/main/java/net/minecraftforge/client/model/ModelDynBucket.java#L135-L137