### PR TITLE
Added Item#readNBTShareTag(ItemStack, NBTTagCompound)

### DIFF
--- a/patches/minecraft/net/minecraft/item/Item.java.patch
+++ b/patches/minecraft/net/minecraft/item/Item.java.patch
@@ -68,7 +68,7 @@
          CreativeTabs creativetabs = this.func_77640_w();
          return creativetabs != null && (p_194125_1_ == CreativeTabs.field_78027_g || p_194125_1_ == creativetabs);
      }
-@@ -435,11 +441,746 @@
+@@ -435,11 +441,757 @@
          return false;
      }
  
@@ -167,6 +167,17 @@
 +    public NBTTagCompound getNBTShareTag(ItemStack stack)
 +    {
 +        return stack.func_77978_p();
++    }
++
++    /**
++     * Override this method to decide what to do with the NBT data received from getNBTShareTag().
++     * 
++     * @param stack The stack that received NBT
++     * @param nbt Received NBT, can be null
++     */
++    public void readNBTShareTag(ItemStack stack, @Nullable NBTTagCompound nbt)
++    {
++        stack.func_77982_d(nbt);
 +    }
 +
 +    /**
@@ -815,7 +826,7 @@
      public static void func_150900_l()
      {
          func_179214_a(Blocks.field_150350_a, new ItemAir(Blocks.field_150350_a));
-@@ -999,6 +1740,8 @@
+@@ -999,6 +1751,8 @@
          private final float field_78010_h;
          private final float field_78011_i;
          private final int field_78008_j;
@@ -824,7 +835,7 @@
  
          private ToolMaterial(int p_i1874_3_, int p_i1874_4_, float p_i1874_5_, float p_i1874_6_, int p_i1874_7_)
          {
-@@ -1034,6 +1777,7 @@
+@@ -1034,6 +1788,7 @@
              return this.field_78008_j;
          }
  
@@ -832,7 +843,7 @@
          public Item func_150995_f()
          {
              if (this == WOOD)
-@@ -1057,5 +1801,21 @@
+@@ -1057,5 +1812,21 @@
                  return this == DIAMOND ? Items.field_151045_i : null;
              }
          }

--- a/patches/minecraft/net/minecraft/network/PacketBuffer.java.patch
+++ b/patches/minecraft/net/minecraft/network/PacketBuffer.java.patch
@@ -9,3 +9,12 @@
              }
  
              this.func_150786_a(nbttagcompound);
+@@ -358,7 +358,7 @@
+             int j = this.readByte();
+             int k = this.readShort();
+             ItemStack itemstack = new ItemStack(Item.func_150899_d(i), j, k);
+-            itemstack.func_77982_d(this.func_150793_b());
++            itemstack.func_77973_b().readNBTShareTag(itemstack, this.func_150793_b());
+             return itemstack;
+         }
+     }


### PR DESCRIPTION
Adds complementary method to Item#getNBTShareTag(ItemStack) that can be used to process received tag, instead of just setting ItemStack tag compound to it (Though, that is the default behavior, just like default getNBTShareTag returns stack tag compound)