### PR TITLE
Switch from trove to fastutil collections

### DIFF
--- a/src/main/java/net/minecraftforge/advancements/critereon/ItemPredicates.java
+++ b/src/main/java/net/minecraftforge/advancements/critereon/ItemPredicates.java
@@ -20,17 +20,18 @@
 package net.minecraftforge.advancements.critereon;
 
 import com.google.gson.JsonObject;
-import gnu.trove.map.hash.THashMap;
+
 import net.minecraft.advancements.critereon.ItemPredicate;
 import net.minecraft.util.ResourceLocation;
 
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.function.Function;
 
 public class ItemPredicates
 {
-    private static final Map<ResourceLocation, Function<JsonObject, ItemPredicate>> predicates = new THashMap<>();
+    private static final Map<ResourceLocation, Function<JsonObject, ItemPredicate>> predicates = new HashMap<>();
 
     static
     {

--- a/src/main/java/net/minecraftforge/fml/common/network/FMLIndexedMessageToMessageCodec.java
+++ b/src/main/java/net/minecraftforge/fml/common/network/FMLIndexedMessageToMessageCodec.java
@@ -19,8 +19,6 @@
 
 package net.minecraftforge.fml.common.network;
 
-import gnu.trove.map.hash.TByteObjectHashMap;
-import gnu.trove.map.hash.TObjectByteHashMap;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 import io.netty.channel.ChannelHandler.Sharable;
@@ -31,14 +29,20 @@ import io.netty.util.AttributeKey;
 import java.lang.ref.WeakReference;
 import java.util.List;
 
+import it.unimi.dsi.fastutil.bytes.Byte2ObjectMap;
+import it.unimi.dsi.fastutil.bytes.Byte2ObjectOpenHashMap;
+import it.unimi.dsi.fastutil.objects.Object2ByteMap;
+import it.unimi.dsi.fastutil.objects.Object2ByteOpenHashMap;
+
 import net.minecraft.network.PacketBuffer;
 import net.minecraftforge.fml.common.FMLLog;
 import net.minecraftforge.fml.common.network.internal.FMLProxyPacket;
 
 @Sharable
-public abstract class FMLIndexedMessageToMessageCodec<A> extends MessageToMessageCodec<FMLProxyPacket, A> {
-    private TByteObjectHashMap<Class<? extends A>> discriminators = new TByteObjectHashMap<Class<? extends A>>();
-    private TObjectByteHashMap<Class<? extends A>> types = new TObjectByteHashMap<Class<? extends A>>();
+public abstract class FMLIndexedMessageToMessageCodec<A> extends MessageToMessageCodec<FMLProxyPacket, A>
+{
+    private final Byte2ObjectMap<Class<? extends A>> discriminators = new Byte2ObjectOpenHashMap<>();
+    private final Object2ByteMap<Class<? extends A>> types = new Object2ByteOpenHashMap<>();
 
     /**
      * Make this accessible to subclasses
@@ -71,7 +75,7 @@ public abstract class FMLIndexedMessageToMessageCodec<A> extends MessageToMessag
         {
             throw new RuntimeException("Undefined discriminator for message type " + clazz.getSimpleName() + " in channel " + channel);
         }
-        byte discriminator = types.get(clazz);
+        byte discriminator = types.getByte(clazz);
         PacketBuffer buffer = new PacketBuffer(Unpooled.buffer());
         buffer.writeByte(discriminator);
         encodeInto(ctx, msg, buffer);


### PR DESCRIPTION
With the release of 1.12, Mojang started providing a full version of fastutil. As a result, it's not really necessary for Forge to also ship Trove, as it doesn't really provide any extra functionality.

As per #4029, we should consider dropping Trove for 1.13 if it isn't needed.

This PR would be the first part of that, converting Forge's uses of Trove collections over to the fastutil equivalent.