### PR TITLE
Clear out stored errors after model loading finishes

### DIFF
--- a/src/main/java/net/minecraftforge/client/model/ModelLoader.java
+++ b/src/main/java/net/minecraftforge/client/model/ModelLoader.java
@@ -1062,6 +1062,8 @@ public final class ModelLoader extends ModelBakery
                 FMLLog.log.fatal("Suppressed additional {} model loading errors for domain {}", e.getValue() - verboseMissingInfoCount, e.getKey());
             }
         }
+        loadingExceptions.clear();
+        missingVariants.clear();
         isLoading = false;
     }
 


### PR DESCRIPTION
Small change to clear out any stored exceptions from the model loader when they're no longer needed.

Ideally, there wouldn't really be a large number of stored errors, but when testing #4791 with a modpack this used close to 20MB.

As the collections here are private and only queried from `onPostBakeEvent`, clearing them after use should be fine.

`missingVariants` is currently unused, but I felt it should be covered here for "good practice" reasons, just in case someone finds a use for it.