### PR TITLE
Add validation to recipe registry

### DIFF
--- a/src/main/java/net/minecraftforge/registries/ForgeRegistry.java
+++ b/src/main/java/net/minecraftforge/registries/ForgeRegistry.java
@@ -70,6 +70,7 @@ public class ForgeRegistry<V extends IForgeRegistryEntry<V>> implements IForgeRe
     private final CreateCallback<V> create;
     private final AddCallback<V> add;
     private final ClearCallback<V> clear;
+    private final ValidateCallback<V> validate;
     private final MissingFactory<V> missing;
     private final BitSet availabilityMap;
     private final Set<ResourceLocation> dummies = Sets.newHashSet();
@@ -86,7 +87,7 @@ public class ForgeRegistry<V extends IForgeRegistryEntry<V>> implements IForgeRe
     private V defaultValue = null;
     boolean isFrozen = false;
 
-    ForgeRegistry(Class<V> superType, ResourceLocation defaultKey, int min, int max, @Nullable CreateCallback<V> create, @Nullable AddCallback<V> add, @Nullable ClearCallback<V> clear, RegistryManager stage, boolean allowOverrides, boolean isModifiable, @Nullable DummyFactory<V> dummyFactory, @Nullable MissingFactory<V> missing)
+    ForgeRegistry(Class<V> superType, ResourceLocation defaultKey, int min, int max, @Nullable CreateCallback<V> create, @Nullable AddCallback<V> add, @Nullable ClearCallback<V> clear, @Nullable ValidateCallback<V> validate, RegistryManager stage, boolean allowOverrides, boolean isModifiable, @Nullable DummyFactory<V> dummyFactory, @Nullable MissingFactory<V> missing)
     {
         this.stage = stage;
         this.superType = superType;
@@ -97,6 +98,7 @@ public class ForgeRegistry<V extends IForgeRegistryEntry<V>> implements IForgeRe
         this.create = create;
         this.add = add;
         this.clear = clear;
+        this.validate = validate;
         this.missing = missing;
         this.isDelegated = IForgeRegistryEntry.Impl.class.isAssignableFrom(superType); //TODO: Make this IDelegatedRegistryEntry?
         this.allowOverrides = allowOverrides;
@@ -269,7 +271,7 @@ public class ForgeRegistry<V extends IForgeRegistryEntry<V>> implements IForgeRe
 
     ForgeRegistry<V> copy(RegistryManager stage)
     {
-        return new ForgeRegistry<V>(superType, defaultKey, min, max, create, add, clear, stage, allowOverrides, isModifiable, dummyFactory, missing);
+        return new ForgeRegistry<V>(superType, defaultKey, min, max, create, add, clear, validate, stage, allowOverrides, isModifiable, dummyFactory, missing);
     }
 
     int add(int id, V value)
@@ -464,6 +466,10 @@ public class ForgeRegistry<V extends IForgeRegistryEntry<V>> implements IForgeRe
             if (blockedIds.contains(id))
                 throw new IllegalStateException(String.format("Registry entry for %s %s, id %d, name %s, marked as dangling.", registryName, obj, id, name));
              */
+
+            // registry-specific validation
+            if (this.validate != null)
+                this.validate.onValidate(this, this.stage, id, name, obj);
         }
     }
 

--- a/src/main/java/net/minecraftforge/registries/GameData.java
+++ b/src/main/java/net/minecraftforge/registries/GameData.java
@@ -402,9 +402,20 @@ public class GameData
         }
     }
 
-    private static class RecipeCallbacks implements IForgeRegistry.MissingFactory<IRecipe>
+    private static class RecipeCallbacks implements IForgeRegistry.ValidateCallback<IRecipe>, IForgeRegistry.MissingFactory<IRecipe>
     {
         static final RecipeCallbacks INSTANCE = new RecipeCallbacks();
+
+        @Override
+        public void onValidate(IForgeRegistryInternal<IRecipe> owner, RegistryManager stage, int id, ResourceLocation key, IRecipe obj)
+        {
+            // verify the recipe output yields a registered item
+            Item item = obj.getRecipeOutput().getItem();
+            if (!stage.getRegistry(Item.class).containsValue(item))
+            {
+                throw new IllegalStateException(String.format("Recipe %s (%s) produces unregistered item %s (%s)", key, obj, item.getRegistryName(), item));
+            }
+        }
 
         @Override
         public IRecipe createMissing(ResourceLocation key, boolean isNetwork)

--- a/src/main/java/net/minecraftforge/registries/GameData.java
+++ b/src/main/java/net/minecraftforge/registries/GameData.java
@@ -409,6 +409,7 @@ public class GameData
         @Override
         public void onValidate(IForgeRegistryInternal<IRecipe> owner, RegistryManager stage, int id, ResourceLocation key, IRecipe obj)
         {
+            if (stage != RegistryManager.ACTIVE) return;
             // verify the recipe output yields a registered item
             Item item = obj.getRecipeOutput().getItem();
             if (!stage.getRegistry(Item.class).containsValue(item))

--- a/src/main/java/net/minecraftforge/registries/IForgeRegistry.java
+++ b/src/main/java/net/minecraftforge/registries/IForgeRegistry.java
@@ -95,6 +95,14 @@ public interface IForgeRegistry<V extends IForgeRegistryEntry<V>> extends Iterab
     }
 
     /**
+     * Callback fired when the registry contents are validated.
+     */
+    interface ValidateCallback<V extends IForgeRegistryEntry<V>>
+    {
+        void onValidate(IForgeRegistryInternal<V> owner, RegistryManager stage, int id, ResourceLocation key, V obj);
+    }
+
+    /**
      * Factory for creating dummy entries, allowing worlds to be loaded and keep the missing block references.
      */
     interface DummyFactory<V extends IForgeRegistryEntry<V>>

--- a/src/main/java/net/minecraftforge/registries/RegistryBuilder.java
+++ b/src/main/java/net/minecraftforge/registries/RegistryBuilder.java
@@ -38,6 +38,7 @@ public class RegistryBuilder<T extends IForgeRegistryEntry<T>>
     private List<AddCallback<T>> addCallback = Lists.newArrayList();
     private List<ClearCallback<T>> clearCallback = Lists.newArrayList();
     private List<CreateCallback<T>> createCallback = Lists.newArrayList();
+    private List<ValidateCallback<T>> validateCallback = Lists.newArrayList();
     private boolean saveToDisc = true;
     private boolean allowOverrides = true;
     private boolean allowModifications = false;
@@ -83,6 +84,8 @@ public class RegistryBuilder<T extends IForgeRegistryEntry<T>>
             this.add((ClearCallback<T>)inst);
         if (inst instanceof CreateCallback)
             this.add((CreateCallback<T>)inst);
+        if (inst instanceof ValidateCallback)
+            this.add((ValidateCallback<T>)inst);
         if (inst instanceof DummyFactory)
             this.set((DummyFactory<T>)inst);
         if (inst instanceof MissingFactory)
@@ -105,6 +108,12 @@ public class RegistryBuilder<T extends IForgeRegistryEntry<T>>
     public RegistryBuilder<T> add(CreateCallback<T> create)
     {
         this.createCallback.add(create);
+        return this;
+    }
+
+    public RegistryBuilder<T> add(ValidateCallback<T> validate)
+    {
+        this.validateCallback.add(validate);
         return this;
     }
 
@@ -141,7 +150,7 @@ public class RegistryBuilder<T extends IForgeRegistryEntry<T>>
     public IForgeRegistry<T> create()
     {
         return RegistryManager.ACTIVE.createRegistry(registryName, registryType, optionalDefaultKey, minId, maxId,
-                getAdd(), getClear(), getCreate(), saveToDisc, allowOverrides, allowModifications, dummyFactory, missingFactory);
+                getAdd(), getClear(), getCreate(), getValidate(), saveToDisc, allowOverrides, allowModifications, dummyFactory, missingFactory);
     }
 
     @Nullable
@@ -186,6 +195,21 @@ public class RegistryBuilder<T extends IForgeRegistryEntry<T>>
         {
             for (CreateCallback<T> cb : this.createCallback)
                 cb.onCreate(owner, stage);
+        };
+    }
+
+    @Nullable
+    private ValidateCallback<T> getValidate()
+    {
+        if (validateCallback.isEmpty())
+            return null;
+        if (validateCallback.size() == 1)
+            return validateCallback.get(0);
+
+        return (owner, stage, id, key, obj) ->
+        {
+            for (ValidateCallback<T> cb : this.validateCallback)
+                cb.onValidate(owner, stage, id, key, obj);
         };
     }
 }

--- a/src/main/java/net/minecraftforge/registries/RegistryManager.java
+++ b/src/main/java/net/minecraftforge/registries/RegistryManager.java
@@ -75,7 +75,7 @@ public class RegistryManager
     }
 
     <V extends IForgeRegistryEntry<V>> ForgeRegistry<V> createRegistry(ResourceLocation name, Class<V> type, ResourceLocation defaultKey, int min, int max,
-            @Nullable AddCallback<V> add, @Nullable ClearCallback<V> clear, @Nullable CreateCallback<V> create,
+            @Nullable AddCallback<V> add, @Nullable ClearCallback<V> clear, @Nullable CreateCallback<V> create, @Nullable ValidateCallback<V> validate,
             boolean persisted, boolean allowOverrides, boolean isModifiable, @Nullable DummyFactory<V> dummyFactory, @Nullable MissingFactory<V> missing)
     {
         Set<Class<?>> parents = Sets.newHashSet();
@@ -87,7 +87,7 @@ public class RegistryManager
             FMLLog.log.error("Found existing registry of type {} named {}, you cannot create a new registry ({}) with type {}, as {} has a parent of that type", foundType, superTypes.get(foundType), name, type, type);
             throw new IllegalArgumentException("Duplicate registry parent type found - you can only have one registry for a particular super type");
         }
-        ForgeRegistry<V> reg = new ForgeRegistry<V>(type, defaultKey, min, max, create, add, clear, this, allowOverrides, isModifiable, dummyFactory, missing);
+        ForgeRegistry<V> reg = new ForgeRegistry<V>(type, defaultKey, min, max, create, add, clear, validate, this, allowOverrides, isModifiable, dummyFactory, missing);
         registries.put(name, reg);
         superTypes.put(type, name);
         if (persisted)

--- a/src/test/java/net/minecraftforge/debug/mod/RegistryOverrideTest.java
+++ b/src/test/java/net/minecraftforge/debug/mod/RegistryOverrideTest.java
@@ -24,6 +24,7 @@ import net.minecraft.block.material.Material;
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.creativetab.CreativeTabs;
 import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.item.Item;
 import net.minecraft.util.EnumFacing;
 import net.minecraft.util.EnumHand;
 import net.minecraft.util.math.AxisAlignedBB;
@@ -48,6 +49,20 @@ public class RegistryOverrideTest
         {
             event.getRegistry().register(new BlockReplacement());
         }
+    }
+
+    @SubscribeEvent
+    public static void registerItems(RegistryEvent.Register<Item> event)
+    {
+        if (!ENABLED) return;
+
+        event.getRegistry().register(
+                new Item()
+                        .setFull3D()
+                        .setUnlocalizedName("stick")
+                        .setCreativeTab(CreativeTabs.MATERIALS)
+                        .setRegistryName("minecraft:stick")
+        );
     }
 
     private static class BlockReplacement extends Block


### PR DESCRIPTION
Following on from #4942, as there may still be people experiencing problems (https://github.com/MinecraftForge/MinecraftForge/pull/4942#issuecomment-392904067).

This aims to catch any registered recipes that would cause a crash when populating the search trees, which enables giving more detailed error messages than just an NPE.

The implementation is based on the existing registry callbacks. The only signature changes don't affect any public methods, so this should be fine for compatibility.