### PR TITLE
Clamp max diffuse lighting multiplier to 1.0

### DIFF
--- a/src/main/java/net/minecraftforge/client/model/pipeline/LightUtil.java
+++ b/src/main/java/net/minecraftforge/client/model/pipeline/LightUtil.java
@@ -37,7 +37,7 @@ public class LightUtil
 {
     public static float diffuseLight(float x, float y, float z)
     {
-        return x * x * 0.6f + y * y * ((3f + y) / 4f) + z * z * 0.8f;
+        return Math.min(x * x * 0.6f + y * y * ((3f + y) / 4f) + z * z * 0.8f, 1f);
     }
 
     public static float diffuseLight(EnumFacing side)


### PR DESCRIPTION
Fixes #4960.

The issue here is caused by models with normals close to, but not exactly, vertical.

Within `ForgeHooksClient.fillNormal`, the y value will still be rounded to 127/127, but there will be non-zero x/z values in addition (this rounding is why the problem started becoming visible when it did).

The issue with these normal vectors is that the vertical direction combined with the slight extra length causes the value produced by `LightUtil.diffuseLight` to be greater than 1.

This value is applied here:
https://github.com/MinecraftForge/MinecraftForge/blob/bea02348e2845ef6b1f49b0692f79dbc097d2706/src/main/java/net/minecraftforge/client/model/pipeline/VertexLighterFlat.java#L185-L192

In these cases, if the value is large enough, it can cause the colour component values to overflow to 256 from 255. Without the low order bits, the colour is effectively black, causing the visual 'flicker'.

Clamping the output of `diffuseLight` to a maximum value of 1 fixes the issue.