### PR TITLE
Write full class name in undefined packet error messages

### DIFF
--- a/src/main/java/net/minecraftforge/fml/common/network/FMLIndexedMessageToMessageCodec.java
+++ b/src/main/java/net/minecraftforge/fml/common/network/FMLIndexedMessageToMessageCodec.java
@@ -69,7 +69,7 @@ public abstract class FMLIndexedMessageToMessageCodec<A> extends MessageToMessag
         Class<?> clazz = msg.getClass();
         if (!types.containsKey(clazz))
         {
-            throw new RuntimeException("Undefined discriminator for message type " + clazz.getSimpleName() + " in channel " + channel);
+            throw new RuntimeException("Undefined discriminator for message type " + clazz.getName() + " in channel " + channel);
         }
         byte discriminator = types.get(clazz);
         PacketBuffer buffer = new PacketBuffer(Unpooled.buffer());


### PR DESCRIPTION
This could have saved me much time with a dumb mistake I made in my mods. I had a second old class in a different package with the same name still referenced in a new class.