### PR TITLE
Small cleanup of handshake state handling

### DIFF
--- a/src/main/java/net/minecraftforge/fml/common/network/handshake/FMLHandshakeClientState.java
+++ b/src/main/java/net/minecraftforge/fml/common/network/handshake/FMLHandshakeClientState.java
@@ -129,7 +129,7 @@ enum FMLHandshakeClientState implements IHandshakeState<FMLHandshakeClientState>
     WAITINGSERVERCOMPLETE
     {
         @Override
-        public void accept(final ChannelHandlerContext ctx, final FMLHandshakeMessage msg, final Consumer<? super FMLHandshakeClientState> cons)
+        public void accept(ChannelHandlerContext ctx, FMLHandshakeMessage msg, Consumer<? super FMLHandshakeClientState> cons)
         {
             FMLHandshakeMessage.RegistryData pkt = (FMLHandshakeMessage.RegistryData)msg;
             Map<ResourceLocation, ForgeRegistry.Snapshot> snap = ctx.channel().attr(NetworkDispatcher.FML_GAMEDATA_SNAPSHOT).get();
@@ -156,21 +156,18 @@ enum FMLHandshakeClientState implements IHandshakeState<FMLHandshakeClientState>
 
             //Do the remapping on the Client's thread in case things are reset while the client is running. We stall the network thread until this is finished which can cause the IO thread to time out... Not sure if we can do anything about that.
             final Map<ResourceLocation, ForgeRegistry.Snapshot> snap_f = snap;
-            Futures.getUnchecked(Minecraft.getMinecraft().addScheduledTask(() ->
+            Multimap<ResourceLocation, ResourceLocation> locallyMissing = Futures.getUnchecked(Minecraft.getMinecraft().addScheduledTask(() -> GameData.injectSnapshot(snap_f, false, false)));
+            if (!locallyMissing.isEmpty())
             {
-                Multimap<ResourceLocation, ResourceLocation> locallyMissing = GameData.injectSnapshot(snap_f, false, false);
-                if (!locallyMissing.isEmpty())
-                {
-                    cons.accept(ERROR);
-                    NetworkDispatcher dispatcher = ctx.channel().attr(NetworkDispatcher.FML_DISPATCHER).get();
-                    dispatcher.rejectHandshake("Fatally missing registry entries");
-                    FMLLog.log.fatal("Failed to connect to server: there are {} missing registry items", locallyMissing.size());
-                    locallyMissing.asMap().forEach((key, value) ->  FMLLog.log.debug("Missing {} Entries: {}", key, value));
-                    return;
-                }
-                cons.accept(PENDINGCOMPLETE);
-                ctx.writeAndFlush(new FMLHandshakeMessage.HandshakeAck(ordinal())).addListener(ChannelFutureListener.FIRE_EXCEPTION_ON_FAILURE);
-            }));
+                cons.accept(ERROR);
+                NetworkDispatcher dispatcher = ctx.channel().attr(NetworkDispatcher.FML_DISPATCHER).get();
+                dispatcher.rejectHandshake("Fatally missing registry entries");
+                FMLLog.log.fatal("Failed to connect to server: there are {} missing registry items", locallyMissing.size());
+                locallyMissing.asMap().forEach((key, value) ->  FMLLog.log.debug("Missing {} Entries: {}", key, value));
+                return;
+            }
+            cons.accept(PENDINGCOMPLETE);
+            ctx.writeAndFlush(new FMLHandshakeMessage.HandshakeAck(ordinal())).addListener(ChannelFutureListener.FIRE_EXCEPTION_ON_FAILURE);
         }
     },
     PENDINGCOMPLETE

--- a/src/main/java/net/minecraftforge/fml/common/network/handshake/HandshakeMessageHandler.java
+++ b/src/main/java/net/minecraftforge/fml/common/network/handshake/HandshakeMessageHandler.java
@@ -28,14 +28,16 @@ import io.netty.util.AttributeKey;
 public class HandshakeMessageHandler<S extends Enum<S> & IHandshakeState<S>> extends SimpleChannelInboundHandler<FMLHandshakeMessage> {
     private static final AttributeKey<IHandshakeState<?>> STATE = AttributeKey.valueOf("fml:handshake-state");
     private final AttributeKey<S> fmlHandshakeState;
-    private S initialState;
-    private Class<S> stateType;
+    private final S initialState;
+    private final S errorState;
+    private final Class<S> stateType;
 
     @SuppressWarnings("unchecked")
     public HandshakeMessageHandler(Class<S> stateType)
     {
         fmlHandshakeState = (AttributeKey<S>) ((Object)STATE);
         initialState = Enum.valueOf(stateType, "START");
+        errorState = Enum.valueOf(stateType, "ERROR");
         this.stateType = stateType;
     }
     @Override
@@ -71,6 +73,7 @@ public class HandshakeMessageHandler<S extends Enum<S> & IHandshakeState<S>> ext
     public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) throws Exception
     {
         FMLLog.log.error("HandshakeMessageHandler exception", cause);
+        ctx.channel().attr(fmlHandshakeState).set(errorState);
         super.exceptionCaught(ctx, cause);
     }
 }


### PR DESCRIPTION
This should prevent spurious `ClassCastException`s from ending up in the logs if some other error occurs during the handshake, which should help with people getting confused about the cause of problems (e.g. #4969).
It also cleans up the code slightly to just run `GameData.injectSnapshot` on the client thread, passing the result back in the `Future`, rather than scheduling the full remainder of the method.