### PR TITLE
Fix player movement status not syncing across dimensions (MC-10657)

### DIFF
--- a/patches/minecraft/net/minecraft/client/Minecraft.java.patch
+++ b/patches/minecraft/net/minecraft/client/Minecraft.java.patch
@@ -342,7 +342,15 @@
  
          if (p_71353_1_ != null)
          {
-@@ -2535,159 +2598,8 @@
+@@ -2488,6 +2551,7 @@
+         EntityPlayerSP entityplayersp = this.field_71439_g;
+         this.field_71439_g = this.field_71442_b.func_192830_a(this.field_71441_e, this.field_71439_g == null ? new StatisticsManager() : this.field_71439_g.func_146107_m(), this.field_71439_g == null ? new RecipeBook() : this.field_71439_g.func_192035_E());
+         this.field_71439_g.func_184212_Q().func_187218_a(entityplayersp.func_184212_Q().func_187231_c());
++        this.field_71439_g.updateSyncFields(entityplayersp); // Forge: fix MC-10657
+         this.field_71439_g.field_71093_bK = p_71354_1_;
+         this.field_175622_Z = this.field_71439_g;
+         this.field_71439_g.func_70065_x();
+@@ -2535,159 +2599,8 @@
      {
          if (this.field_71476_x != null && this.field_71476_x.field_72313_a != RayTraceResult.Type.MISS)
          {
@@ -504,7 +512,7 @@
          }
      }
  
-@@ -3009,18 +2921,8 @@
+@@ -3009,18 +2922,8 @@
  
      public static int func_71369_N()
      {
@@ -525,7 +533,7 @@
      }
  
      public boolean func_70002_Q()
-@@ -3152,6 +3054,9 @@
+@@ -3152,6 +3055,9 @@
          }
          else if (this.field_71439_g != null)
          {
@@ -535,7 +543,7 @@
              if (this.field_71439_g.field_70170_p.field_73011_w instanceof WorldProviderHell)
              {
                  return MusicTicker.MusicType.NETHER;
-@@ -3181,11 +3086,11 @@
+@@ -3181,11 +3087,11 @@
              {
                  if (Keyboard.getEventKeyState())
                  {
@@ -549,7 +557,7 @@
                      {
                          this.field_71456_v.func_146158_b().func_146227_a(ScreenShotHelper.func_148260_a(this.field_71412_D, this.field_71443_c, this.field_71440_d, this.field_147124_at));
                      }
-@@ -3199,6 +3104,7 @@
+@@ -3199,6 +3105,7 @@
                          }
                      }
                  }
@@ -557,7 +565,7 @@
              }
          }
      }
-@@ -3328,6 +3234,12 @@
+@@ -3328,6 +3235,12 @@
          return this.field_184127_aH;
      }
  
@@ -570,7 +578,7 @@
      public boolean func_189648_am()
      {
          return this.field_71439_g != null && this.field_71439_g.func_175140_cp() || this.field_71474_y.field_178879_v;
-@@ -3342,4 +3254,9 @@
+@@ -3342,4 +3255,9 @@
      {
          return this.field_193035_aW;
      }

--- a/patches/minecraft/net/minecraft/client/entity/EntityPlayerSP.java.patch
+++ b/patches/minecraft/net/minecraft/client/entity/EntityPlayerSP.java.patch
@@ -111,3 +111,21 @@
          boolean flag4 = (float)this.func_71024_bL().func_75116_a() > 6.0F || this.field_71075_bZ.field_75101_c;
  
          if (this.field_70122_E && !flag1 && !flag2 && this.field_71158_b.field_192832_b >= 0.8F && !this.func_70051_ag() && flag4 && !this.func_184587_cr() && !this.func_70644_a(MobEffects.field_76440_q))
+@@ -1178,4 +1203,17 @@
+             }
+         }
+     }
++
++    public void updateSyncFields(EntityPlayerSP old)
++    {
++        this.field_175172_bI = old.field_175172_bI;
++        this.field_175166_bJ = old.field_175166_bJ;
++        this.field_175167_bK = old.field_175167_bK;
++        this.field_175164_bL = old.field_175164_bL;
++        this.field_175165_bM = old.field_175165_bM;
++        this.field_184841_cd = old.field_184841_cd;
++        this.field_175170_bN = old.field_175170_bN;
++        this.field_175171_bO = old.field_175171_bO;
++        this.field_175168_bP = old.field_175168_bP;
++    }
+ }


### PR DESCRIPTION
Fixes vanilla bug [MC-10657](https://bugs.mojang.com/browse/MC-10657).

`Minecraft.setDimensionAndSpawnPlayer` creates a new player entity, mostly losing the field values from the old one.
This causes the client to "forget" that the player was previously sneaking, and so it will not send a status update packet to the server as it believes that the sneak status is unchanged, causing the linked issue.

This PR fixes the issue by patching `setDimensionAndSpawnPlayer` to copy the values used to determine when status update packets are sent (inside `EntityPlayerSP.onUpdateWalkingPlayer`) across to the newly-created player.