### PR TITLE
Clean up and improve ICapabilityProvider javadocs

### DIFF
--- a/src/main/java/net/minecraftforge/common/capabilities/ICapabilityProvider.java
+++ b/src/main/java/net/minecraftforge/common/capabilities/ICapabilityProvider.java
@@ -28,30 +28,36 @@ public interface ICapabilityProvider
 {
     /**
      * Determines if this object has support for the capability in question on the specific side.
-     * The return value of this MIGHT change during runtime if this object gains or looses support
-     * for a capability.
+     * The return value of this MIGHT change during runtime if this object gains or loses support
+     * for a capability. It is not required to call this function before calling 
+     * {@link #getCapability(Capability, EnumFacing)}.
      *
-     * Example:
-     *   A Pipe getting a cover placed on one side causing it loose the Inventory attachment function for that side.
-     *
+     * <p>
+     * <em>Example:</em>
+     *   A Pipe getting a cover placed on one side causing it lose the Inventory attachment function for that side.
+     * </p><p>
      * This is a light weight version of getCapability, intended for metadata uses.
-     *
+     * </p>
      * @param capability The capability to check
      * @param facing The Side to check from:
      *   CAN BE NULL. Null is defined to represent 'internal' or 'self'
-     * @return True if this object supports the capability.
+     * @return True if this object supports the capability. If true, then {@link #getCapability(Capability, EnumFacing)} 
+     * must not return null.
      */
     boolean hasCapability(@Nonnull Capability<?> capability, @Nullable EnumFacing facing);
 
     /**
      * Retrieves the handler for the capability requested on the specific side.
-     * The return value CAN be null if the object does not support the capability.
-     * The return value CAN be the same for multiple faces.
+     * <ul>
+     * <li>The return value <strong>CAN</strong> be null if the object does not support the capability.</il>
+     * <li>The return value <strong>CAN</strong> be the same for multiple faces.</li>
+     * </ul>
      *
      * @param capability The capability to check
-     * @param facing The Side to check from:
-     *   CAN BE NULL. Null is defined to represent 'internal' or 'self'
-     * @return The requested capability. Returns null when {@link #hasCapability(Capability, EnumFacing)} would return false.
+     * @param facing The Side to check from, 
+     *   <strong>CAN BE NULL</strong>. Null is defined to represent 'internal' or 'self'
+     * @return The requested capability. Must <strong>NOT</strong> be null when {@link #hasCapability(Capability, EnumFacing)} 
+     * would return true. 
      */
     @Nullable
     <T> T getCapability(@Nonnull Capability<T> capability, @Nullable EnumFacing facing);

--- a/src/main/java/net/minecraftforge/common/capabilities/ICapabilityProvider.java
+++ b/src/main/java/net/minecraftforge/common/capabilities/ICapabilityProvider.java
@@ -19,6 +19,8 @@
 
 package net.minecraftforge.common.capabilities;
 
+import java.util.Map;
+
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
@@ -31,7 +33,8 @@ public interface ICapabilityProvider
      * The return value of this MIGHT change during runtime if this object gains or loses support
      * for a capability. It is not required to call this function before calling 
      * {@link #getCapability(Capability, EnumFacing)}.
-     *
+     * <p>
+     * Basically, this method functions analogously to {@link Map#containsKey(Object)}.
      * <p>
      * <em>Example:</em>
      *   A Pipe getting a cover placed on one side causing it lose the Inventory attachment function for that side.
@@ -52,6 +55,8 @@ public interface ICapabilityProvider
      * <li>The return value <strong>CAN</strong> be null if the object does not support the capability.</il>
      * <li>The return value <strong>CAN</strong> be the same for multiple faces.</li>
      * </ul>
+     * <p>
+     * Basically, this method functions analogously to {@link Map#get(Object)}.
      *
      * @param capability The capability to check
      * @param facing The Side to check from, 


### PR DESCRIPTION
This PR aims to improve the contract definitions of the ICapabilityProvider interface. Previously there were some uncertainties when it came to how the two methods, `hasCapability` and `getCapability`, were related. Hopefully with these additions it is clearer to all. Due to the formatting changes and addition of HTML tags, here is the post-formatting before/after of the javadocs:

### `hasCapability` before:

<div class="block">Determines if this object has support for the capability in question on the specific side.
 The return value of this MIGHT change during runtime if this object gains or looses support
 for a capability.

 Example:
   A Pipe getting a cover placed on one side causing it loose the Inventory attachment function for that side.

 This is a light weight version of getCapability, intended for metadata uses.</div>
<dl>
<dt><span class="paramLabel">Parameters:</span></dt>
<dd><code>capability</code> - The capability to check</dd>
<dd><code>facing</code> - The Side to check from:
   CAN BE NULL. Null is defined to represent 'internal' or 'self'</dd>
<dt><span class="returnLabel">Returns:</span></dt>
<dd>True if this object supports the capability.</dd>
</dl>

___

### `hasCapability` after:

<div class="block">Determines if this object has support for the capability in question on the specific side.
 The return value of this MIGHT change during runtime if this object gains or loses support
 for a capability. It is not required to call this function before calling 
 <a href="#"><code>getCapability(Capability, EnumFacing)</code></a>.

 <p>
 <em>Example:</em>
   A Pipe getting a cover placed on one side causing it lose the Inventory attachment function for that side.
 </p><p>
 This is a light weight version of getCapability, intended for metadata uses.
 </p></div>
<dl>
<dt><span class="paramLabel">Parameters:</span></dt>
<dd><code>capability</code> - The capability to check</dd>
<dd><code>facing</code> - The Side to check from:
   CAN BE NULL. Null is defined to represent 'internal' or 'self'</dd>
<dt><span class="returnLabel">Returns:</span></dt>
<dd>True if this object supports the capability. If true, then <a href="#"><code>getCapability(Capability, EnumFacing)</code></a> 
 must not return null.</dd>
</dl>

___

### `getCapability` before:

<div class="block">Retrieves the handler for the capability requested on the specific side.
 The return value CAN be null if the object does not support the capability.
 The return value CAN be the same for multiple faces.</div>
<dl>
<dt><span class="paramLabel">Parameters:</span></dt>
<dd><code>capability</code> - The capability to check</dd>
<dd><code>facing</code> - The Side to check from:
   CAN BE NULL. Null is defined to represent 'internal' or 'self'</dd>
<dt><span class="returnLabel">Returns:</span></dt>
<dd>The requested capability. Returns null when <a href="#"><code>hasCapability(Capability, EnumFacing)</code></a> would return false.</dd>
</dl>

___

### `getCapability` after:

<div class="block">Retrieves the handler for the capability requested on the specific side.
 <ul>
 <li>The return value <strong>CAN</strong> be null if the object does not support the capability.</il>
 <li>The return value <strong>CAN</strong> be the same for multiple faces.</li>
 </ul></div>
<dl>
<dt><span class="paramLabel">Parameters:</span></dt>
<dd><code>capability</code> - The capability to check</dd>
<dd><code>facing</code> - The Side to check from, 
   <strong>CAN BE NULL</strong>. Null is defined to represent 'internal' or 'self'</dd>
<dt><span class="returnLabel">Returns:</span></dt>
<dd>The requested capability. Must <strong>NOT</strong> be null when <a href="#"><code>hasCapability(Capability, EnumFacing)</code></a> 
 would return true.</dd>
</dl>

___