### PR TITLE
Fix structure template processors causing cascading world generation

### DIFF
--- a/patches/minecraft/net/minecraft/world/gen/structure/template/Template.java.patch
+++ b/patches/minecraft/net/minecraft/world/gen/structure/template/Template.java.patch
@@ -1,6 +1,15 @@
 --- ../src-base/minecraft/net/minecraft/world/gen/structure/template/Template.java
 +++ ../src-work/minecraft/net/minecraft/world/gen/structure/template/Template.java
-@@ -514,6 +514,7 @@
+@@ -211,6 +211,8 @@
+             for (Template.BlockInfo template$blockinfo : this.field_186270_a)
+             {
+                 BlockPos blockpos = func_186266_a(p_189960_4_, template$blockinfo.field_186242_a).func_177971_a(p_189960_2_);
++                // Forge: skip processing blocks outside BB to prevent cascading worldgen issues
++                if (structureboundingbox != null && !structureboundingbox.func_175898_b(blockpos)) continue;
+                 Template.BlockInfo template$blockinfo1 = p_189960_3_ != null ? p_189960_3_.func_189943_a(p_189960_1_, blockpos, template$blockinfo) : template$blockinfo;
+ 
+                 if (template$blockinfo1 != null)
+@@ -514,6 +516,7 @@
              nbttaglist2.func_74742_a(NBTUtil.func_190009_a(new NBTTagCompound(), iblockstate));
          }
  


### PR DESCRIPTION
This patches `Template.addBlocksToWorld` to not call `ITemplateProcessor.processBlock` for block positions that are outside of the specified bounding box.

This check is performed later, before any blocks are set, but because `processBlock` is called first, it can attempt to access unloaded chunks, causing cascading worldgen issues.