### PR TITLE
Fixed overworld spawn point reset when respawning in another dimension

### DIFF
--- a/patches/minecraft/net/minecraft/entity/player/EntityPlayer.java.patch
+++ b/patches/minecraft/net/minecraft/entity/player/EntityPlayer.java.patch
@@ -13,6 +13,17 @@
      private static final DataParameter<Float> field_184829_a = EntityDataManager.<Float>func_187226_a(EntityPlayer.class, DataSerializers.field_187193_c);
      private static final DataParameter<Integer> field_184830_b = EntityDataManager.<Integer>func_187226_a(EntityPlayer.class, DataSerializers.field_187192_b);
      protected static final DataParameter<Byte> field_184827_bp = EntityDataManager.<Byte>func_187226_a(EntityPlayer.class, DataSerializers.field_187191_a);
+@@ -124,8 +130,8 @@
+     @SideOnly(Side.CLIENT)
+     public float field_71082_cx;
+     public float field_71089_bV;
+-    private BlockPos field_71077_c;
+-    private boolean field_82248_d;
++    protected BlockPos field_71077_c;
++    protected boolean field_82248_d;
+     public PlayerCapabilities field_71075_bZ = new PlayerCapabilities();
+     public int field_71068_ca;
+     public int field_71067_cb;
 @@ -165,6 +171,7 @@
          this.func_110148_a(SharedMonsterAttributes.field_111263_d).func_111128_a(0.10000000149011612D);
          this.func_110140_aT().func_111150_b(SharedMonsterAttributes.field_188790_f);

--- a/patches/minecraft/net/minecraft/entity/player/EntityPlayer.java.patch
+++ b/patches/minecraft/net/minecraft/entity/player/EntityPlayer.java.patch
@@ -13,17 +13,6 @@
      private static final DataParameter<Float> field_184829_a = EntityDataManager.<Float>func_187226_a(EntityPlayer.class, DataSerializers.field_187193_c);
      private static final DataParameter<Integer> field_184830_b = EntityDataManager.<Integer>func_187226_a(EntityPlayer.class, DataSerializers.field_187192_b);
      protected static final DataParameter<Byte> field_184827_bp = EntityDataManager.<Byte>func_187226_a(EntityPlayer.class, DataSerializers.field_187191_a);
-@@ -124,8 +130,8 @@
-     @SideOnly(Side.CLIENT)
-     public float field_71082_cx;
-     public float field_71089_bV;
--    private BlockPos field_71077_c;
--    private boolean field_82248_d;
-+    protected BlockPos field_71077_c;
-+    protected boolean field_82248_d;
-     public PlayerCapabilities field_71075_bZ = new PlayerCapabilities();
-     public int field_71068_ca;
-     public int field_71067_cb;
 @@ -165,6 +171,7 @@
          this.func_110148_a(SharedMonsterAttributes.field_111263_d).func_111128_a(0.10000000149011612D);
          this.func_110140_aT().func_111150_b(SharedMonsterAttributes.field_188790_f);

--- a/patches/minecraft/net/minecraft/entity/player/EntityPlayerMP.java.patch
+++ b/patches/minecraft/net/minecraft/entity/player/EntityPlayerMP.java.patch
@@ -120,13 +120,18 @@
          this.field_71070_bA = this.field_71069_bz;
      }
  
-@@ -1144,6 +1162,18 @@
+@@ -1144,6 +1162,23 @@
          this.field_193110_cw = p_193104_1_.field_193110_cw;
          this.func_192029_h(p_193104_1_.func_192023_dk());
          this.func_192031_i(p_193104_1_.func_192025_dl());
 +
 +        this.spawnChunkMap = p_193104_1_.spawnChunkMap;
 +        this.spawnForcedMap = p_193104_1_.spawnForcedMap;
++        if(p_193104_1_.field_71093_bK != 0)
++        {
++            this.field_71077_c = p_193104_1_.field_71077_c;
++            this.field_82248_d = p_193104_1_.field_82248_d;
++        }
 +
 +        //Copy over a section of the Entity Data from the old player.
 +        //Allows mods to specify data that persists after players respawn.

--- a/src/main/resources/forge_at.cfg
+++ b/src/main/resources/forge_at.cfg
@@ -167,6 +167,8 @@ public net.minecraft.client.renderer.EntityRenderer func_175069_a(Lnet/minecraft
 public net.minecraft.util.WeightedRandom$Item field_76292_a #probability
 # EntityPlayer
 public net.minecraft.entity.player.EntityPlayer func_184816_a(Lnet/minecraft/entity/item/EntityItem;)Lnet/minecraft/item/ItemStack; # dropItemAndGetStack
+protected net.minecraft.entity.player.EntityPlayer field_71077_c # spawnPos
+protected net.minecraft.entity.player.EntityPlayer field_82248_d # spawnForced
 # EntityPlayerSP
 public net.minecraft.client.entity.EntityPlayerSP func_184816_a(Lnet/minecraft/entity/item/EntityItem;)Lnet/minecraft/item/ItemStack; # dropItemAndGetStack
 ## EntityPlayerMP getNextWindowId


### PR DESCRIPTION
A player reported that after dying in the Betweenlands dimension the overworld spawn point would reset (https://github.com/Angry-Pixel/The-Betweenlands/issues/607). After some digging I found that
`EntityPlayerMP#copyFrom` does not copy over the overworld spawn point, only the spawn points in other dimensions.

This PR fixes this problem by copying over `EntityPlayer#spawnPos` and `EntityPlayer#spawnForced` in `EntityPlayerMP#copyFrom` if a player respawns in any dimension other than the overworld.