### PR TITLE
Allow registries to be handled before BLOCKS and ITEMS (fixes #4987)

### DIFF
--- a/src/main/java/net/minecraftforge/registries/ForgeRegistry.java
+++ b/src/main/java/net/minecraftforge/registries/ForgeRegistry.java
@@ -82,11 +82,12 @@ public class ForgeRegistry<V extends IForgeRegistryEntry<V>> implements IForgeRe
     private final int max;
     private final boolean allowOverrides;
     private final boolean isModifiable;
+    final boolean isPreBlocks;
 
     private V defaultValue = null;
     boolean isFrozen = false;
 
-    ForgeRegistry(Class<V> superType, ResourceLocation defaultKey, int min, int max, @Nullable CreateCallback<V> create, @Nullable AddCallback<V> add, @Nullable ClearCallback<V> clear, RegistryManager stage, boolean allowOverrides, boolean isModifiable, @Nullable DummyFactory<V> dummyFactory, @Nullable MissingFactory<V> missing)
+    ForgeRegistry(Class<V> superType, ResourceLocation defaultKey, int min, int max, @Nullable CreateCallback<V> create, @Nullable AddCallback<V> add, @Nullable ClearCallback<V> clear, RegistryManager stage, boolean allowOverrides, boolean isModifiable, boolean isPreBlocks, @Nullable DummyFactory<V> dummyFactory, @Nullable MissingFactory<V> missing)
     {
         this.stage = stage;
         this.superType = superType;
@@ -101,6 +102,7 @@ public class ForgeRegistry<V extends IForgeRegistryEntry<V>> implements IForgeRe
         this.isDelegated = IForgeRegistryEntry.Impl.class.isAssignableFrom(superType); //TODO: Make this IDelegatedRegistryEntry?
         this.allowOverrides = allowOverrides;
         this.isModifiable = isModifiable;
+        this.isPreBlocks = isPreBlocks;
         this.dummyFactory = dummyFactory;
         if (this.create != null)
             this.create.onCreate(this, stage);
@@ -269,7 +271,7 @@ public class ForgeRegistry<V extends IForgeRegistryEntry<V>> implements IForgeRe
 
     ForgeRegistry<V> copy(RegistryManager stage)
     {
-        return new ForgeRegistry<V>(superType, defaultKey, min, max, create, add, clear, stage, allowOverrides, isModifiable, dummyFactory, missing);
+        return new ForgeRegistry<V>(superType, defaultKey, min, max, create, add, clear, stage, allowOverrides, isModifiable, isPreBlocks, dummyFactory, missing);
     }
 
     int add(int id, V value)

--- a/src/main/java/net/minecraftforge/registries/GameData.java
+++ b/src/main/java/net/minecraftforge/registries/GameData.java
@@ -733,6 +733,15 @@ public class GameData
         });
         */
 
+        for (ResourceLocation rl : keys)
+        {
+            if (!filter.test(rl)) continue;
+            if (rl == BLOCKS || rl == ITEMS) continue;
+            ForgeRegistry<?> reg = RegistryManager.ACTIVE.getRegistry(rl);
+            if (!reg.isPreBlocks) continue;
+            MinecraftForge.EVENT_BUS.post(reg.getRegisterEvent(rl));
+        }
+        ObjectHolderRegistry.INSTANCE.applyObjectHolders(); // inject the preBlocks registries
         if (filter.test(BLOCKS))
         {
             MinecraftForge.EVENT_BUS.post(RegistryManager.ACTIVE.getRegistry(BLOCKS).getRegisterEvent(BLOCKS));
@@ -747,7 +756,9 @@ public class GameData
         {
             if (!filter.test(rl)) continue;
             if (rl == BLOCKS || rl == ITEMS) continue;
-            MinecraftForge.EVENT_BUS.post(RegistryManager.ACTIVE.getRegistry(rl).getRegisterEvent(rl));
+            ForgeRegistry<?> reg = RegistryManager.ACTIVE.getRegistry(rl);
+            if (reg.isPreBlocks) continue;
+            MinecraftForge.EVENT_BUS.post(reg.getRegisterEvent(rl));
         }
         ObjectHolderRegistry.INSTANCE.applyObjectHolders(); // inject everything else
 

--- a/src/main/java/net/minecraftforge/registries/RegistryBuilder.java
+++ b/src/main/java/net/minecraftforge/registries/RegistryBuilder.java
@@ -41,6 +41,7 @@ public class RegistryBuilder<T extends IForgeRegistryEntry<T>>
     private boolean saveToDisc = true;
     private boolean allowOverrides = true;
     private boolean allowModifications = false;
+    private boolean isPreBlocks = false;
     private DummyFactory<T> dummyFactory;
     private MissingFactory<T> missingFactory;
 
@@ -138,10 +139,16 @@ public class RegistryBuilder<T extends IForgeRegistryEntry<T>>
         return this;
     }
 
+    public RegistryBuilder<T> setPreBlocks()
+    {
+        this.isPreBlocks = true;
+        return this;
+    }
+
     public IForgeRegistry<T> create()
     {
         return RegistryManager.ACTIVE.createRegistry(registryName, registryType, optionalDefaultKey, minId, maxId,
-                getAdd(), getClear(), getCreate(), saveToDisc, allowOverrides, allowModifications, dummyFactory, missingFactory);
+                getAdd(), getClear(), getCreate(), saveToDisc, allowOverrides, allowModifications, isPreBlocks, dummyFactory, missingFactory);
     }
 
     @Nullable

--- a/src/main/java/net/minecraftforge/registries/RegistryManager.java
+++ b/src/main/java/net/minecraftforge/registries/RegistryManager.java
@@ -76,7 +76,7 @@ public class RegistryManager
 
     <V extends IForgeRegistryEntry<V>> ForgeRegistry<V> createRegistry(ResourceLocation name, Class<V> type, ResourceLocation defaultKey, int min, int max,
             @Nullable AddCallback<V> add, @Nullable ClearCallback<V> clear, @Nullable CreateCallback<V> create,
-            boolean persisted, boolean allowOverrides, boolean isModifiable, @Nullable DummyFactory<V> dummyFactory, @Nullable MissingFactory<V> missing)
+            boolean persisted, boolean allowOverrides, boolean isModifiable, boolean isPreBlocks, @Nullable DummyFactory<V> dummyFactory, @Nullable MissingFactory<V> missing)
     {
         Set<Class<?>> parents = Sets.newHashSet();
         findSuperTypes(type, parents);
@@ -87,7 +87,7 @@ public class RegistryManager
             FMLLog.log.error("Found existing registry of type {} named {}, you cannot create a new registry ({}) with type {}, as {} has a parent of that type", foundType, superTypes.get(foundType), name, type, type);
             throw new IllegalArgumentException("Duplicate registry parent type found - you can only have one registry for a particular super type");
         }
-        ForgeRegistry<V> reg = new ForgeRegistry<V>(type, defaultKey, min, max, create, add, clear, this, allowOverrides, isModifiable, dummyFactory, missing);
+        ForgeRegistry<V> reg = new ForgeRegistry<V>(type, defaultKey, min, max, create, add, clear, this, allowOverrides, isModifiable, isPreBlocks, dummyFactory, missing);
         registries.put(name, reg);
         superTypes.put(type, name);
         if (persisted)


### PR DESCRIPTION
See issue #4987 for more details.
The change was so small I decided to make a PR so if approved, it could be merged immediately.
