### PR TITLE
Wrap ModClassVisitor in FMLRemappingAdapter

### DIFF
--- a/src/main/java/net/minecraftforge/fml/common/discovery/asm/ASMModParser.java
+++ b/src/main/java/net/minecraftforge/fml/common/discovery/asm/ASMModParser.java
@@ -26,6 +26,7 @@ import java.util.Set;
 
 import net.minecraftforge.fml.common.FMLLog;
 import net.minecraftforge.fml.common.LoaderException;
+import net.minecraftforge.fml.common.asm.transformers.deobf.FMLRemappingAdapter;
 import net.minecraftforge.fml.common.discovery.ASMDataTable;
 import net.minecraftforge.fml.common.discovery.ModCandidate;
 
@@ -55,7 +56,8 @@ public class ASMModParser
         try
         {
             ClassReader reader = new ClassReader(stream);
-            reader.accept(new ModClassVisitor(this), 0);
+            // EXPAND_FRAMES is needed because ASM's RemappingMethodAdapter requires it
+            reader.accept(new FMLRemappingAdapter(new ModClassVisitor(this)), ClassReader.EXPAND_FRAMES);
         }
         catch (Exception ex)
         {


### PR DESCRIPTION
When mod classes are loaded, they are run through
DeobfuscationTransformer. This allows reobfuscated mod jars (with SRG
names) to be used in a development environment (with MCP names).

However, Forge constructs its ASMDataTable using the bytecode directly
from the mod's jarfile or directory. This means that ASMDataTable will
contain references to obfuscated names (e.g. overriden methods in a
subclass of a Minecraft class) even though the corresponding mod class
will be deobfuscated when it is actually classloaded.

This mismatch between ASMDataTable and the runtime mod classes can lead
to issues when using things like @Optional in a development environment.
If a mod class method is stored under its obfuscated name in its ASMData
entry for an annotation, it will not be properly stripped from the
deobfuscated bytecode that ModAPITransformer deals with.

This commit wraps the ModClassVisitor used to populate ASMDataTable in a
FMLRemappingAdapter. This ensures that the information in ASMDataTable
will always match the runtime methods and fields of the mod classes that
will later be classloaded.