### PR TITLE
Fix FillBucketEvent having incorrect Nonnull on a nullable

### DIFF
--- a/src/main/java/net/minecraftforge/event/entity/player/FillBucketEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/player/FillBucketEvent.java
@@ -48,7 +48,7 @@ public class FillBucketEvent extends PlayerEvent
     @Nullable
     private final RayTraceResult target;
 
-    private ItemStack result = ItemStack.EMPTY;
+    private ItemStack result;
 
     public FillBucketEvent(EntityPlayer player, @Nonnull ItemStack current, World world, @Nullable RayTraceResult target)
     {

--- a/src/main/java/net/minecraftforge/event/entity/player/FillBucketEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/player/FillBucketEvent.java
@@ -47,7 +47,7 @@ public class FillBucketEvent extends PlayerEvent
     private final World world;
     @Nullable
     private final RayTraceResult target;
-
+    @Nullable
     private ItemStack result;
 
     public FillBucketEvent(EntityPlayer player, @Nonnull ItemStack current, World world, @Nullable RayTraceResult target)
@@ -63,7 +63,7 @@ public class FillBucketEvent extends PlayerEvent
     public World getWorld(){ return this.world; }
     @Nullable
     public RayTraceResult getTarget() { return this.target; }
-    @Nonnull
+    @Nullable
     public ItemStack getFilledBucket() { return this.result; }
     public void setFilledBucket(@Nonnull ItemStack bucket) { this.result = bucket; }
 }

--- a/src/main/java/net/minecraftforge/event/entity/player/FillBucketEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/player/FillBucketEvent.java
@@ -48,7 +48,7 @@ public class FillBucketEvent extends PlayerEvent
     @Nullable
     private final RayTraceResult target;
 
-    private ItemStack result;
+    private ItemStack result = ItemStack.EMPTY;
 
     public FillBucketEvent(EntityPlayer player, @Nonnull ItemStack current, World world, @Nullable RayTraceResult target)
     {


### PR DESCRIPTION
The result ItemStack in this event was not initialize as empty and thus could be null.
This is a partial fix for #4994