### PR TITLE
Fix flickering leaves when mods break the blurMipmap settings

### DIFF
--- a/patches/minecraft/net/minecraft/client/renderer/EntityRenderer.java.patch
+++ b/patches/minecraft/net/minecraft/client/renderer/EntityRenderer.java.patch
@@ -141,7 +141,17 @@
          this.field_78531_r.field_71424_I.func_76318_c("frustum");
          ClippingHelperImpl.func_78558_a();
          this.field_78531_r.field_71424_I.func_76318_c("culling");
-@@ -1329,7 +1341,9 @@
+@@ -1315,7 +1327,9 @@
+         GlStateManager.func_179118_c();
+         renderglobal.func_174977_a(BlockRenderLayer.SOLID, (double)p_175068_2_, p_175068_1_, entity);
+         GlStateManager.func_179141_d();
++        this.field_78531_r.func_110434_K().func_110581_b(TextureMap.field_110575_b).func_174936_b(false, this.field_78531_r.field_71474_y.field_151442_I > 0); // FORGE: fix flickering leaves when mods mess up the blurMipmap settings
+         renderglobal.func_174977_a(BlockRenderLayer.CUTOUT_MIPPED, (double)p_175068_2_, p_175068_1_, entity);
++        this.field_78531_r.func_110434_K().func_110581_b(TextureMap.field_110575_b).func_174935_a();
+         this.field_78531_r.func_110434_K().func_110581_b(TextureMap.field_110575_b).func_174936_b(false, false);
+         renderglobal.func_174977_a(BlockRenderLayer.CUTOUT, (double)p_175068_2_, p_175068_1_, entity);
+         this.field_78531_r.func_110434_K().func_110581_b(TextureMap.field_110575_b).func_174935_a();
+@@ -1329,7 +1343,9 @@
              GlStateManager.func_179094_E();
              RenderHelper.func_74519_b();
              this.field_78531_r.field_71424_I.func_76318_c("entities");
@@ -151,7 +161,7 @@
              RenderHelper.func_74518_a();
              this.func_175072_h();
          }
-@@ -1342,6 +1356,7 @@
+@@ -1342,6 +1358,7 @@
              EntityPlayer entityplayer = (EntityPlayer)entity;
              GlStateManager.func_179118_c();
              this.field_78531_r.field_71424_I.func_76318_c("outline");
@@ -159,7 +169,7 @@
              renderglobal.func_72731_b(entityplayer, this.field_78531_r.field_71476_x, 0, p_175068_2_);
              GlStateManager.func_179141_d();
          }
-@@ -1388,6 +1403,17 @@
+@@ -1388,6 +1405,17 @@
          GlStateManager.func_179103_j(7425);
          this.field_78531_r.field_71424_I.func_76318_c("translucent");
          renderglobal.func_174977_a(BlockRenderLayer.TRANSLUCENT, (double)p_175068_2_, p_175068_1_, entity);
@@ -177,7 +187,7 @@
          GlStateManager.func_179103_j(7424);
          GlStateManager.func_179132_a(true);
          GlStateManager.func_179089_o();
-@@ -1400,6 +1426,9 @@
+@@ -1400,6 +1428,9 @@
              this.func_180437_a(renderglobal, p_175068_2_, p_175068_1_, d0, d1, d2);
          }
  
@@ -187,7 +197,7 @@
          this.field_78531_r.field_71424_I.func_76318_c("hand");
  
          if (this.field_175074_C)
-@@ -1515,6 +1544,13 @@
+@@ -1515,6 +1546,13 @@
  
      protected void func_78474_d(float p_78474_1_)
      {
@@ -201,7 +211,7 @@
          float f = this.field_78531_r.field_71441_e.func_72867_j(p_78474_1_);
  
          if (f > 0.0F)
-@@ -1749,30 +1785,17 @@
+@@ -1749,30 +1787,17 @@
              this.field_175082_R = (float)vec3d3.field_72448_b;
              this.field_175081_S = (float)vec3d3.field_72449_c;
          }
@@ -241,7 +251,7 @@
  
          float f13 = this.field_78535_ad + (this.field_78539_ae - this.field_78535_ad) * p_78466_1_;
          this.field_175080_Q *= f13;
-@@ -1830,6 +1853,9 @@
+@@ -1830,6 +1855,9 @@
                  f6 = 1.0F / this.field_175081_S;
              }
  
@@ -251,7 +261,7 @@
              this.field_175080_Q = this.field_175080_Q * (1.0F - f15) + this.field_175080_Q * f6 * f15;
              this.field_175082_R = this.field_175082_R * (1.0F - f15) + this.field_175082_R * f6 * f15;
              this.field_175081_S = this.field_175081_S * (1.0F - f15) + this.field_175081_S * f6 * f15;
-@@ -1845,6 +1871,13 @@
+@@ -1845,6 +1873,13 @@
              this.field_175081_S = f7;
          }
  
@@ -265,7 +275,7 @@
          GlStateManager.func_179082_a(this.field_175080_Q, this.field_175082_R, this.field_175081_S, 0.0F);
      }
  
-@@ -1855,7 +1888,9 @@
+@@ -1855,7 +1890,9 @@
          GlStateManager.func_187432_a(0.0F, -1.0F, 0.0F);
          GlStateManager.func_179131_c(1.0F, 1.0F, 1.0F, 1.0F);
          IBlockState iblockstate = ActiveRenderInfo.func_186703_a(this.field_78531_r.field_71441_e, entity, p_78468_2_);
@@ -276,7 +286,7 @@
          if (entity instanceof EntityLivingBase && ((EntityLivingBase)entity).func_70644_a(MobEffects.field_76440_q))
          {
              float f1 = 5.0F;
-@@ -1940,6 +1975,7 @@
+@@ -1940,6 +1977,7 @@
                  GlStateManager.func_179102_b(f * 0.05F);
                  GlStateManager.func_179153_c(Math.min(f, 192.0F) * 0.5F);
              }


### PR DESCRIPTION
I found that a lot of packs have flickering leaves when mipmap is enabled.

Investigation eventually led to finding the cause: mods are calling `ITextureObject#setBlurMipmap` but not calling `ITextureObject#restoreLastBlurMipmap` after. It's sort of the same issue as doing an OpenGL `push` without doing `pop`. The end result is that the settings are wrong when leaves are getting rendered and they flicker annoyingly.

I found and reported these issues to a couple mods, but there are many mods that have done this and it's extremely hard to track down, so I'd like to fix it in Forge. 

This PR defends against this problem by setting the blur mipmap settings to the "default" before drawing `BlockRenderLayer.CUTOUT_MIPPED` (which includes leaves) and then restoring it after.
A very similar thing is done just below by vanilla for `BlockRenderLayer.CUTOUT` where they force the blur mipmap settings to "false" and then restore the settings after.