### PR TITLE
Make EntityRenderer#orientCamera use the EntityRenderer#thirdPersonDistance variable

### DIFF
--- a/patches/minecraft/net/minecraft/client/renderer/EntityRenderer.java.patch
+++ b/patches/minecraft/net/minecraft/client/renderer/EntityRenderer.java.patch
@@ -8,6 +8,15 @@
          }
      }
  
+@@ -265,7 +266,7 @@
+         this.func_78477_e();
+         this.func_78470_f();
+         this.field_78535_ad = this.field_78539_ae;
+-        this.field_78491_C = 4.0F;
++        this.field_78491_C = field_78490_B;
+ 
+         if (this.field_78531_r.field_71474_y.field_74326_T)
+         {
 @@ -290,7 +291,7 @@
              this.field_78531_r.func_175607_a(this.field_78531_r.field_71439_g);
          }
@@ -35,7 +44,7 @@
          }
      }
  
-@@ -569,14 +570,8 @@
+@@ -569,21 +570,15 @@
              {
                  BlockPos blockpos = new BlockPos(entity);
                  IBlockState iblockstate = this.field_78531_r.field_71441_e.func_180495_p(blockpos);
@@ -51,6 +60,14 @@
                  GlStateManager.func_179114_b(entity.field_70126_B + (entity.field_70177_z - entity.field_70126_B) * p_78467_1_ + 180.0F, 0.0F, -1.0F, 0.0F);
                  GlStateManager.func_179114_b(entity.field_70127_C + (entity.field_70125_A - entity.field_70127_C) * p_78467_1_, -1.0F, 0.0F, 0.0F);
              }
+         }
+         else if (this.field_78531_r.field_71474_y.field_74320_O > 0)
+         {
+-            double d3 = (double)(this.field_78491_C + (4.0F - this.field_78491_C) * p_78467_1_);
++            double d3 = (double)(this.field_78491_C + (field_78490_B - this.field_78491_C) * p_78467_1_);
+ 
+             if (this.field_78531_r.field_71474_y.field_74325_U)
+             {
 @@ -643,17 +638,20 @@
  
          if (!this.field_78531_r.field_71474_y.field_74325_U)


### PR DESCRIPTION
EntityRenderer#orientCamera line 581 used to use the EntityRenderer#thirdPersonDistance variable to control the 3d person distance. This was changed to a hardcoded value of 4.0F. However, the variable still existed but wasn't used anywhere.

This was reported on the forums (http://www.minecraftforge.net/forum/topic/64894-112-how-do-i-make-the-third-person-zoom-farther-when-riding-my-custom-entity-my-dragon-is-kind-of-big/)

This PR makes the method use the variable again. It also sets EntityRenderer#thirdPersonDistancePrev to EntityRender#thirdPersonDistance to prevent flickering when changing the variable with Reflection.