### PR TITLE
Make EntityRenderer#orientCamera use EntityRenderer#thirdPersonDistance field

### DIFF
--- a/patches/minecraft/net/minecraft/client/renderer/EntityRenderer.java.patch
+++ b/patches/minecraft/net/minecraft/client/renderer/EntityRenderer.java.patch
@@ -8,6 +8,15 @@
          }
      }
  
+@@ -265,7 +266,7 @@
+         this.func_78477_e();
+         this.func_78470_f();
+         this.field_78535_ad = this.field_78539_ae;
+-        this.field_78491_C = 4.0F;
++        this.field_78491_C = field_78490_B;
+ 
+         if (this.field_78531_r.field_71474_y.field_74326_T)
+         {
 @@ -290,7 +291,7 @@
              this.field_78531_r.func_175607_a(this.field_78531_r.field_71439_g);
          }
@@ -35,7 +44,7 @@
          }
      }
  
-@@ -569,14 +570,8 @@
+@@ -569,21 +570,15 @@
              {
                  BlockPos blockpos = new BlockPos(entity);
                  IBlockState iblockstate = this.field_78531_r.field_71441_e.func_180495_p(blockpos);
@@ -51,6 +60,14 @@
                  GlStateManager.func_179114_b(entity.field_70126_B + (entity.field_70177_z - entity.field_70126_B) * p_78467_1_ + 180.0F, 0.0F, -1.0F, 0.0F);
                  GlStateManager.func_179114_b(entity.field_70127_C + (entity.field_70125_A - entity.field_70127_C) * p_78467_1_, -1.0F, 0.0F, 0.0F);
              }
+         }
+         else if (this.field_78531_r.field_71474_y.field_74320_O > 0)
+         {
+-            double d3 = (double)(this.field_78491_C + (4.0F - this.field_78491_C) * p_78467_1_);
++            double d3 = (double)(this.field_78491_C + (field_78490_B - this.field_78491_C) * p_78467_1_);
+ 
+             if (this.field_78531_r.field_71474_y.field_74325_U)
+             {
 @@ -643,17 +638,20 @@
  
          if (!this.field_78531_r.field_71474_y.field_74325_U)

--- a/patches/minecraft/net/minecraft/client/renderer/EntityRenderer.java.patch
+++ b/patches/minecraft/net/minecraft/client/renderer/EntityRenderer.java.patch
@@ -13,7 +13,7 @@
          this.func_78470_f();
          this.field_78535_ad = this.field_78539_ae;
 -        this.field_78491_C = 4.0F;
-+        this.field_78491_C = field_78490_B;
++        this.field_78491_C = field_78490_B; //FORGE: set thirdPersonDistancePrev to thirdPersonDistance field instead of hardcoded 4.0F, prevents flickering when using a different thirdPersonDistance value
  
          if (this.field_78531_r.field_71474_y.field_74326_T)
          {
@@ -64,7 +64,7 @@
          else if (this.field_78531_r.field_71474_y.field_74320_O > 0)
          {
 -            double d3 = (double)(this.field_78491_C + (4.0F - this.field_78491_C) * p_78467_1_);
-+            double d3 = (double)(this.field_78491_C + (field_78490_B - this.field_78491_C) * p_78467_1_);
++            double d3 = (double)(this.field_78491_C + (field_78490_B - this.field_78491_C) * p_78467_1_); //FORGE: use thirdPersonDistance instead of hardcoded 4.0F, allows for variable third person zoom
  
              if (this.field_78531_r.field_71474_y.field_74325_U)
              {


### PR DESCRIPTION
In previous versions, the `EntityRenderer#orientCamera` method used the `EntityRenderer#thirdPersonDistance` field in its calculations. That was changed, and now uses a hardcoded value of `4.0F`, the same as the field.

You used to be able to change the field with Reflection to change the 3rd person camera distance from the player. With it using the hardcoded value, you couldn't.

This was reported at the forums (http://www.minecraftforge.net/forum/topic/64894-112-how-do-i-make-the-third-person-zoom-farther-when-riding-my-custom-entity-my-dragon-is-kind-of-big/)

This PR fixes that by replacing the hardcoded values with the `EntityRenderer#thirdPersonDistance` field.