### PR TITLE
Fix giveItemToPlayer creating item entities with incorrect contents

### DIFF
--- a/src/main/java/net/minecraftforge/items/ItemHandlerHelper.java
+++ b/src/main/java/net/minecraftforge/items/ItemHandlerHelper.java
@@ -162,18 +162,20 @@ public class ItemHandlerHelper
      */
     public static void giveItemToPlayer(EntityPlayer player, @Nonnull ItemStack stack, int preferredSlot)
     {
+        if (stack.isEmpty()) return;
+
         IItemHandler inventory = new PlayerMainInvWrapper(player.inventory);
         World world = player.world;
 
         // try adding it into the inventory
         ItemStack remainder = stack;
         // insert into preferred slot first
-        if(preferredSlot >= 0)
+        if (preferredSlot >= 0 && preferredSlot < inventory.getSlots())
         {
             remainder = inventory.insertItem(preferredSlot, stack, false);
         }
         // then into the inventory in general
-        if(!remainder.isEmpty())
+        if (!remainder.isEmpty())
         {
             remainder = insertItemStacked(inventory, remainder, false);
         }
@@ -188,7 +190,7 @@ public class ItemHandlerHelper
         // drop remaining itemstack into the world
         if (!remainder.isEmpty() && !world.isRemote)
         {
-            EntityItem entityitem = new EntityItem(world, player.posX, player.posY + 0.5, player.posZ, stack);
+            EntityItem entityitem = new EntityItem(world, player.posX, player.posY + 0.5, player.posZ, remainder);
             entityitem.setPickupDelay(40);
             entityitem.motionX = 0;
             entityitem.motionZ = 0;


### PR DESCRIPTION
Fixes `ItemHandlerHelper.giveItemToPlayer` creating an `EntityItem` with the original contents, instead of only the remainder. Also adds a couple of extra "just in case" checks for edge cases.