### PR TITLE
Add a way for attached capabilitites to be included in sync.

### DIFF
--- a/patches/minecraft/net/minecraft/item/ItemStack.java.patch
+++ b/patches/minecraft/net/minecraft/item/ItemStack.java.patch
@@ -232,7 +232,7 @@
          }
  
          return multimap;
-@@ -1130,4 +1155,128 @@
+@@ -1130,4 +1155,165 @@
      {
          this.func_190917_f(-p_190918_1_);
      }
@@ -263,6 +263,43 @@
 +        NBTTagCompound ret = new NBTTagCompound();
 +        this.func_77955_b(ret);
 +        return ret;
++    }
++
++    public NBTTagCompound getShareTag()
++    {
++        NBTTagCompound nbttagcompound = null;
++
++        if (func_77973_b().func_77645_m() || func_77973_b().func_77651_p())
++        {
++            nbttagcompound = func_77973_b().getNBTShareTag(this);
++        }
++
++        NBTTagCompound capabilityShareTags = capabilities.serializeShareTag();
++        if (capabilityShareTags != null)
++        {
++            if (nbttagcompound == null)
++            {
++                nbttagcompound = new NBTTagCompound();
++            }
++            nbttagcompound.func_74782_a("ForgeCaps", capabilityShareTags);
++        }
++
++        return nbttagcompound;
++    }
++
++    public void readShareTag(@Nullable NBTTagCompound tag)
++    {
++        if (tag != null && tag.func_150297_b("ForgeCaps", net.minecraftforge.common.util.Constants.NBT.TAG_COMPOUND))
++        {
++            capabilities.deserializeShareTag(tag.func_74775_l("ForgeCaps"));
++            tag.func_82580_o("ForgeCaps");
++            if (tag.func_186856_d() == 0)
++            {
++                return;
++            }
++        }
++
++        func_77973_b().readNBTShareTag(this, tag);
 +    }
 +
 +    public boolean areCapsCompatible(ItemStack other)

--- a/patches/minecraft/net/minecraft/network/PacketBuffer.java.patch
+++ b/patches/minecraft/net/minecraft/network/PacketBuffer.java.patch
@@ -1,20 +1,23 @@
 --- ../src-base/minecraft/net/minecraft/network/PacketBuffer.java
 +++ ../src-work/minecraft/net/minecraft/network/PacketBuffer.java
-@@ -336,7 +336,7 @@
+@@ -334,10 +334,7 @@
+             this.writeShort(p_150788_1_.func_77960_j());
+             NBTTagCompound nbttagcompound = null;
  
-             if (p_150788_1_.func_77973_b().func_77645_m() || p_150788_1_.func_77973_b().func_77651_p())
-             {
+-            if (p_150788_1_.func_77973_b().func_77645_m() || p_150788_1_.func_77973_b().func_77651_p())
+-            {
 -                nbttagcompound = p_150788_1_.func_77978_p();
-+                nbttagcompound = p_150788_1_.func_77973_b().getNBTShareTag(p_150788_1_);
-             }
+-            }
++            nbttagcompound = p_150788_1_.getShareTag();
  
              this.func_150786_a(nbttagcompound);
-@@ -358,7 +358,7 @@
+         }
+@@ -358,7 +355,7 @@
              int j = this.readByte();
              int k = this.readShort();
              ItemStack itemstack = new ItemStack(Item.func_150899_d(i), j, k);
 -            itemstack.func_77982_d(this.func_150793_b());
-+            itemstack.func_77973_b().readNBTShareTag(itemstack, this.func_150793_b());
++            itemstack.readShareTag(this.func_150793_b());
              return itemstack;
          }
      }

--- a/patches/minecraft/net/minecraft/network/play/client/CPacketClickWindow.java.patch
+++ b/patches/minecraft/net/minecraft/network/play/client/CPacketClickWindow.java.patch
@@ -1,5 +1,14 @@
 --- ../src-base/minecraft/net/minecraft/network/play/client/CPacketClickWindow.java
 +++ ../src-work/minecraft/net/minecraft/network/play/client/CPacketClickWindow.java
+@@ -45,7 +45,7 @@
+         this.field_149553_c = p_148837_1_.readByte();
+         this.field_149550_d = p_148837_1_.readShort();
+         this.field_149549_f = (ClickType)p_148837_1_.func_179257_a(ClickType.class);
+-        this.field_149551_e = p_148837_1_.func_150791_c();
++        this.field_149551_e = net.minecraftforge.common.util.PacketUtil.readItemStackFromClientToServer(p_148837_1_);
+     }
+ 
+     public void func_148840_b(PacketBuffer p_148840_1_) throws IOException
 @@ -55,7 +55,7 @@
          p_148840_1_.writeByte(this.field_149553_c);
          p_148840_1_.writeShort(this.field_149550_d);

--- a/patches/minecraft/net/minecraft/network/play/client/CPacketCreativeInventoryAction.java.patch
+++ b/patches/minecraft/net/minecraft/network/play/client/CPacketCreativeInventoryAction.java.patch
@@ -1,6 +1,13 @@
 --- ../src-base/minecraft/net/minecraft/network/play/client/CPacketCreativeInventoryAction.java
 +++ ../src-work/minecraft/net/minecraft/network/play/client/CPacketCreativeInventoryAction.java
-@@ -38,7 +38,7 @@
+@@ -32,13 +32,13 @@
+     public void func_148837_a(PacketBuffer p_148837_1_) throws IOException
+     {
+         this.field_149629_a = p_148837_1_.readShort();
+-        this.field_149628_b = p_148837_1_.func_150791_c();
++        this.field_149628_b = net.minecraftforge.common.util.PacketUtil.readItemStackFromClientToServer(p_148837_1_);
+     }
+ 
      public void func_148840_b(PacketBuffer p_148840_1_) throws IOException
      {
          p_148840_1_.writeShort(this.field_149629_a);

--- a/src/main/java/net/minecraftforge/common/capabilities/CapabilityDispatcher.java
+++ b/src/main/java/net/minecraftforge/common/capabilities/CapabilityDispatcher.java
@@ -91,11 +91,18 @@ public final class CapabilityDispatcher implements INBTSerializable<NBTTagCompou
         }
 
         caps = lstCaps.toArray(new ICapabilityProvider[lstCaps.size()]);
-        writers = lstWriters.toArray(new INBTSerializable[lstWriters.size()]);
-        writerNames = lstNames.toArray(new String[lstNames.size()]);
 
-        shareTags = lstShareTags.toArray(new ICapabilityShareTag[lstShareTags.size()]);
-        shareTagNames = lstShareTagNames.toArray(new String[lstShareTagNames.size()]);
+        if (lstShareTags.size() > 0)
+        {
+            writers = lstWriters.toArray(new INBTSerializable[lstWriters.size()]);
+            writerNames = lstNames.toArray(new String[lstNames.size()]);
+        }
+
+        if (lstShareTags.size() > 0)
+        {
+            shareTags = lstShareTags.toArray(new ICapabilityShareTag[lstShareTags.size()]);
+            shareTagNames = lstShareTagNames.toArray(new String[lstShareTagNames.size()]);
+        }
     }
 
     @Override
@@ -130,6 +137,8 @@ public final class CapabilityDispatcher implements INBTSerializable<NBTTagCompou
     public NBTTagCompound serializeNBT()
     {
         NBTTagCompound nbt = new NBTTagCompound();
+        if (writers == null)
+            return nbt;
         for (int x = 0; x < writers.length; x++)
         {
             nbt.setTag(writerNames[x], writers[x].serializeNBT());
@@ -140,6 +149,8 @@ public final class CapabilityDispatcher implements INBTSerializable<NBTTagCompou
     @Override
     public void deserializeNBT(NBTTagCompound nbt)
     {
+        if (writers == null)
+            return;
         for (int x = 0; x < writers.length; x++)
         {
             if (nbt.hasKey(writerNames[x]))
@@ -149,10 +160,17 @@ public final class CapabilityDispatcher implements INBTSerializable<NBTTagCompou
         }
     }
 
-    public boolean areCompatible(CapabilityDispatcher other) //Called from ItemStack to compare equality.
-    {                                                        // Only compares serializeable caps.
-        if (other == null) return this.writers.length == 0;  // Done this way so we can do some pre-checks before doing the costly NBT serialization and compare
-        if (this.writers.length == 0) return other.writers.length == 0;
+    /**
+     *  Called from ItemStack to compare equality.
+     *  Only compares serializeable caps.
+     *  Done this way so we can do some pre-checks before doing the costly NBT serialization and compare
+     * @param other The other dispatcher
+     * @return True if they are serialization-compatible
+     */
+    public boolean areCompatible(CapabilityDispatcher other)
+    {
+        if (other == null) return writers == null || this.writers.length == 0;
+        if (writers == null || this.writers.length == 0) return other.writers == null || other.writers.length == 0;
         return this.serializeNBT().equals(other.serializeNBT());
     }
 
@@ -160,7 +178,7 @@ public final class CapabilityDispatcher implements INBTSerializable<NBTTagCompou
     @Nullable
     public NBTTagCompound serializeShareTag()
     {
-        if (shareTags.length == 0)
+        if (shareTags == null || shareTags.length == 0)
             return null;
         NBTTagCompound nbt = new NBTTagCompound();
         for (int x = 0; x < shareTags.length; x++)
@@ -173,11 +191,11 @@ public final class CapabilityDispatcher implements INBTSerializable<NBTTagCompou
     @Override
     public void deserializeShareTag(NBTTagCompound nbt)
     {
-        for (int x = 0; x < writers.length; x++)
+        for (int x = 0; x < shareTags.length; x++)
         {
-            if (nbt.hasKey(writerNames[x]))
+            if (nbt.hasKey(shareTagNames[x]))
             {
-                writers[x].deserializeNBT(nbt.getTag(writerNames[x]));
+                shareTags[x].deserializeShareTag(nbt.getTag(shareTagNames[x]));
             }
         }
     }

--- a/src/main/java/net/minecraftforge/common/capabilities/CapabilityDispatcher.java
+++ b/src/main/java/net/minecraftforge/common/capabilities/CapabilityDispatcher.java
@@ -92,7 +92,7 @@ public final class CapabilityDispatcher implements INBTSerializable<NBTTagCompou
 
         caps = lstCaps.toArray(new ICapabilityProvider[lstCaps.size()]);
 
-        if (lstShareTags.size() > 0)
+        if (lstWriters.size() > 0)
         {
             writers = lstWriters.toArray(new INBTSerializable[lstWriters.size()]);
             writerNames = lstNames.toArray(new String[lstNames.size()]);

--- a/src/main/java/net/minecraftforge/common/capabilities/CapabilityDispatcher.java
+++ b/src/main/java/net/minecraftforge/common/capabilities/CapabilityDispatcher.java
@@ -95,7 +95,7 @@ public final class CapabilityDispatcher implements INBTSerializable<NBTTagCompou
         writerNames = lstNames.toArray(new String[lstNames.size()]);
 
         shareTags = lstShareTags.toArray(new ICapabilityShareTag[lstShareTags.size()]);
-        shareTagNames = lstShareTagNames.toArray(new String[lstNames.size()]);
+        shareTagNames = lstShareTagNames.toArray(new String[lstShareTagNames.size()]);
     }
 
     @Override
@@ -160,12 +160,14 @@ public final class CapabilityDispatcher implements INBTSerializable<NBTTagCompou
     @Nullable
     public NBTTagCompound serializeShareTag()
     {
+        if (shareTags.length == 0)
+            return null;
         NBTTagCompound nbt = new NBTTagCompound();
         for (int x = 0; x < shareTags.length; x++)
         {
             nbt.setTag(shareTagNames[x], shareTags[x].serializeShareTag());
         }
-        return nbt.getSize() > 0 ? nbt : null;
+        return nbt;
     }
 
     @Override

--- a/src/main/java/net/minecraftforge/common/capabilities/ICapabilityShareTag.java
+++ b/src/main/java/net/minecraftforge/common/capabilities/ICapabilityShareTag.java
@@ -1,0 +1,28 @@
+/*
+ * Minecraft Forge
+ * Copyright (c) 2016-2018.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation version 2.1
+ * of the License.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+package net.minecraftforge.common.capabilities;
+
+import net.minecraft.nbt.NBTBase;
+
+public interface ICapabilityShareTag<T extends NBTBase>
+{
+    T serializeShareTag();
+    void deserializeShareTag(T nbt);
+}

--- a/src/main/java/net/minecraftforge/common/util/PacketUtil.java
+++ b/src/main/java/net/minecraftforge/common/util/PacketUtil.java
@@ -24,6 +24,8 @@ import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.network.PacketBuffer;
 
+import java.io.IOException;
+
 public class PacketUtil
 {
     private PacketUtil() {}
@@ -54,6 +56,24 @@ public class PacketUtil
             }
 
             buffer.writeCompoundTag(nbttagcompound);
+        }
+    }
+
+    public static ItemStack readItemStackFromClientToServer(PacketBuffer buffer) throws IOException
+    {
+        int i = buffer.readShort();
+
+        if (i < 0)
+        {
+            return ItemStack.EMPTY;
+        }
+        else
+        {
+            int j = buffer.readByte();
+            int k = buffer.readShort();
+            ItemStack itemstack = new ItemStack(Item.getItemById(i), j, k);
+            itemstack.setTagCompound(buffer.readCompoundTag());
+            return itemstack;
         }
     }
 }


### PR DESCRIPTION
Implemented for ItemStacks only for now. Might do the rest if people agree with this approach.

## Reasoning
Currently, synchronizing capability data of 3rdparty items with the client is extremely annoying (own item capabilitites are doable now, after #4932 was merged). It requires custom packets, which are not guaranteed to reach the client at the right time compared with vanilla interactions.

This PR adds logic to allow capabilitites to provide extra data to include in share tags, which are then deserialized on the client. The majority of the logic is agnostic to the type of object, and could be used to add sync support to TileEntity

## Notes
- I moved a couple bits of code from PacketBuffer to ItemStack, to avoid adding more accessors that are just used for that one task, but I would be happy to move it back and create those accessors, if it's wanted.
- I had to add a new function to PacketUtil, because the existing assumption wouldn't work anymore, for ItemStacks sent from the client to the server (creative menu).
- I added a new set of arrays to the CapabilityDispatcher so that capabilitites with share tag don't need to be serializable, and vice versa. If it is a concern to have so many allocations, the class could be reshuffled to use less overall arrays, at a potential cost in performance.

## TODO

- [ ] Sync share tags for TileEntities (~~should be easily doable~~ maybe not THAT easy >_<)
- [ ] Sync share tags for other things (maybe, I didn't look if it's feasible)
- [ ] Tests