### PR TITLE
Improve crash report details

### DIFF
--- a/patches/minecraft/net/minecraft/client/renderer/RenderItem.java.patch
+++ b/patches/minecraft/net/minecraft/client/renderer/RenderItem.java.patch
@@ -72,16 +72,15 @@
          this.func_180454_a(p_191962_1_, p_191962_4_);
          GlStateManager.func_179118_c();
          GlStateManager.func_179101_C();
-@@ -364,7 +349,7 @@
-                 {
-                     public String call() throws Exception
-                     {
--                        return String.valueOf((Object)p_184391_2_.func_77973_b());
-+                        return p_184391_2_.func_77973_b().getRegistryName().toString();
+@@ -367,6 +352,7 @@
+                         return String.valueOf((Object)p_184391_2_.func_77973_b());
                      }
                  });
++                crashreportcategory.func_189529_a("Registry Name", () -> p_184391_2_.func_77973_b().getRegistryName().toString());
                  crashreportcategory.func_189529_a("Item Aux", new ICrashReportDetail<String>()
-@@ -413,9 +398,12 @@
+                 {
+                     public String call() throws Exception
+@@ -413,9 +399,12 @@
                  p_180453_1_.func_175063_a(s, (float)(p_180453_3_ + 19 - 2 - p_180453_1_.func_78256_a(s)), (float)(p_180453_4_ + 6 + 3), 16777215);
                  GlStateManager.func_179145_e();
                  GlStateManager.func_179126_j();
@@ -95,7 +94,7 @@
              {
                  GlStateManager.func_179140_f();
                  GlStateManager.func_179097_i();
-@@ -424,11 +412,10 @@
+@@ -424,11 +413,10 @@
                  GlStateManager.func_179084_k();
                  Tessellator tessellator = Tessellator.func_178181_a();
                  BufferBuilder bufferbuilder = tessellator.func_178180_c();
@@ -111,7 +110,7 @@
                  this.func_181565_a(bufferbuilder, p_180453_3_ + 2, p_180453_4_ + 13, 13, 2, 0, 0, 0, 255);
                  this.func_181565_a(bufferbuilder, p_180453_3_ + 2, p_180453_4_ + 13, i, 1, j >> 16 & 255, j >> 8 & 255, j & 255, 255);
                  GlStateManager.func_179147_l();
-@@ -1099,6 +1086,7 @@
+@@ -1099,6 +1087,7 @@
          this.func_175029_a(Blocks.field_185779_df, TileEntityStructure.Mode.LOAD.func_185110_a(), "structure_block");
          this.func_175029_a(Blocks.field_185779_df, TileEntityStructure.Mode.CORNER.func_185110_a(), "structure_block");
          this.func_175029_a(Blocks.field_185779_df, TileEntityStructure.Mode.DATA.func_185110_a(), "structure_block");

--- a/patches/minecraft/net/minecraft/client/renderer/RenderItem.java.patch
+++ b/patches/minecraft/net/minecraft/client/renderer/RenderItem.java.patch
@@ -72,6 +72,15 @@
          this.func_180454_a(p_191962_1_, p_191962_4_);
          GlStateManager.func_179118_c();
          GlStateManager.func_179101_C();
+@@ -364,7 +349,7 @@
+                 {
+                     public String call() throws Exception
+                     {
+-                        return String.valueOf((Object)p_184391_2_.func_77973_b());
++                        return p_184391_2_.func_77973_b().getRegistryName().toString();
+                     }
+                 });
+                 crashreportcategory.func_189529_a("Item Aux", new ICrashReportDetail<String>()
 @@ -413,9 +398,12 @@
                  p_180453_1_.func_175063_a(s, (float)(p_180453_3_ + 19 - 2 - p_180453_1_.func_78256_a(s)), (float)(p_180453_4_ + 6 + 3), 16777215);
                  GlStateManager.func_179145_e();

--- a/patches/minecraft/net/minecraft/client/renderer/RenderItem.java.patch
+++ b/patches/minecraft/net/minecraft/client/renderer/RenderItem.java.patch
@@ -76,7 +76,7 @@
                          return String.valueOf((Object)p_184391_2_.func_77973_b());
                      }
                  });
-+                crashreportcategory.func_189529_a("Registry Name", () -> p_184391_2_.func_77973_b().getRegistryName().toString());
++                crashreportcategory.func_189529_a("Registry Name", () -> String.valueOf(p_184391_2_.func_77973_b().getRegistryName()));
                  crashreportcategory.func_189529_a("Item Aux", new ICrashReportDetail<String>()
                  {
                      public String call() throws Exception

--- a/patches/minecraft/net/minecraft/crash/CrashReportCategory.java.patch
+++ b/patches/minecraft/net/minecraft/crash/CrashReportCategory.java.patch
@@ -14,3 +14,12 @@
              return this.field_85075_d.length;
          }
      }
+@@ -206,7 +209,7 @@
+             {
+                 try
+                 {
+-                    return String.format("ID #%d (%s // %s)", i, p_180523_2_.func_149739_a(), p_180523_2_.getClass().getCanonicalName());
++                    return String.format("ID #%d (%s // %s)", i, p_180523_2_.getRegistryName(), p_180523_2_.getClass().getCanonicalName());
+                 }
+                 catch (Throwable var2)
+                 {

--- a/patches/minecraft/net/minecraft/crash/CrashReportCategory.java.patch
+++ b/patches/minecraft/net/minecraft/crash/CrashReportCategory.java.patch
@@ -19,7 +19,7 @@
                  try
                  {
 -                    return String.format("ID #%d (%s // %s)", i, p_180523_2_.func_149739_a(), p_180523_2_.getClass().getCanonicalName());
-+                    return String.format("ID #%d (%s // %s)", i, p_180523_2_.getRegistryName(), p_180523_2_.getClass().getCanonicalName());
++                    return String.format("ID #%d (%s // %s // %s)", i, p_180523_2_.func_149739_a(), p_180523_2_.getClass().getCanonicalName(), p_180523_2_.getRegistryName());
                  }
                  catch (Throwable var2)
                  {

--- a/patches/minecraft/net/minecraft/crash/CrashReportCategory.java.patch
+++ b/patches/minecraft/net/minecraft/crash/CrashReportCategory.java.patch
@@ -19,7 +19,7 @@
                  try
                  {
 -                    return String.format("ID #%d (%s // %s)", i, p_180523_2_.func_149739_a(), p_180523_2_.getClass().getCanonicalName());
-+                    return String.format("ID #%d (%s // %s // %s)", i, p_180523_2_.func_149739_a(), p_180523_2_.getClass().getCanonicalName(), p_180523_2_.getRegistryName());
++                    return String.format("ID #%d (%s // %s // %s)", i, p_180523_2_.func_149739_a(), p_180523_2_.getClass().getName(), p_180523_2_.getRegistryName());
                  }
                  catch (Throwable var2)
                  {

--- a/patches/minecraft/net/minecraft/entity/player/InventoryPlayer.java.patch
+++ b/patches/minecraft/net/minecraft/entity/player/InventoryPlayer.java.patch
@@ -29,7 +29,7 @@
                  crashreportcategory.func_71507_a("Item ID", Integer.valueOf(Item.func_150891_b(p_191971_2_.func_77973_b())));
                  crashreportcategory.func_71507_a("Item data", Integer.valueOf(p_191971_2_.func_77960_j()));
 +                crashreportcategory.func_189529_a("Registry Name", () -> p_191971_2_.func_77973_b().getRegistryName().toString());
-+                crashreportcategory.func_189529_a("Item Class", () -> p_191971_2_.func_77973_b().getClass().getCanonicalName());
++                crashreportcategory.func_189529_a("Item Class", () -> p_191971_2_.func_77973_b().getClass().getName());
                  crashreportcategory.func_189529_a("Item name", new ICrashReportDetail<String>()
                  {
                      public String call() throws Exception

--- a/patches/minecraft/net/minecraft/entity/player/InventoryPlayer.java.patch
+++ b/patches/minecraft/net/minecraft/entity/player/InventoryPlayer.java.patch
@@ -24,3 +24,12 @@
      }
  
      public boolean func_70441_a(ItemStack p_70441_1_)
+@@ -442,7 +450,7 @@
+             {
+                 CrashReport crashreport = CrashReport.func_85055_a(throwable, "Adding item to inventory");
+                 CrashReportCategory crashreportcategory = crashreport.func_85058_a("Item being added");
+-                crashreportcategory.func_71507_a("Item ID", Integer.valueOf(Item.func_150891_b(p_191971_2_.func_77973_b())));
++                crashreportcategory.func_71507_a("Item ID", p_191971_2_.func_77973_b().getRegistryName());
+                 crashreportcategory.func_71507_a("Item data", Integer.valueOf(p_191971_2_.func_77960_j()));
+                 crashreportcategory.func_189529_a("Item name", new ICrashReportDetail<String>()
+                 {

--- a/patches/minecraft/net/minecraft/entity/player/InventoryPlayer.java.patch
+++ b/patches/minecraft/net/minecraft/entity/player/InventoryPlayer.java.patch
@@ -28,7 +28,7 @@
                  CrashReportCategory crashreportcategory = crashreport.func_85058_a("Item being added");
                  crashreportcategory.func_71507_a("Item ID", Integer.valueOf(Item.func_150891_b(p_191971_2_.func_77973_b())));
                  crashreportcategory.func_71507_a("Item data", Integer.valueOf(p_191971_2_.func_77960_j()));
-+                crashreportcategory.func_189529_a("Registry Name", () -> p_191971_2_.func_77973_b().getRegistryName().toString());
++                crashreportcategory.func_189529_a("Registry Name", () -> String.valueOf(p_191971_2_.func_77973_b().getRegistryName()));
 +                crashreportcategory.func_189529_a("Item Class", () -> p_191971_2_.func_77973_b().getClass().getName());
                  crashreportcategory.func_189529_a("Item name", new ICrashReportDetail<String>()
                  {

--- a/patches/minecraft/net/minecraft/entity/player/InventoryPlayer.java.patch
+++ b/patches/minecraft/net/minecraft/entity/player/InventoryPlayer.java.patch
@@ -24,12 +24,12 @@
      }
  
      public boolean func_70441_a(ItemStack p_70441_1_)
-@@ -442,7 +450,7 @@
-             {
-                 CrashReport crashreport = CrashReport.func_85055_a(throwable, "Adding item to inventory");
+@@ -444,6 +452,8 @@
                  CrashReportCategory crashreportcategory = crashreport.func_85058_a("Item being added");
--                crashreportcategory.func_71507_a("Item ID", Integer.valueOf(Item.func_150891_b(p_191971_2_.func_77973_b())));
-+                crashreportcategory.func_71507_a("Item ID", p_191971_2_.func_77973_b().getRegistryName());
+                 crashreportcategory.func_71507_a("Item ID", Integer.valueOf(Item.func_150891_b(p_191971_2_.func_77973_b())));
                  crashreportcategory.func_71507_a("Item data", Integer.valueOf(p_191971_2_.func_77960_j()));
++                crashreportcategory.func_189529_a("Registry Name", () -> p_191971_2_.func_77973_b().getRegistryName().toString());
++                crashreportcategory.func_189529_a("Item Class", () -> p_191971_2_.func_77973_b().getClass().getCanonicalName());
                  crashreportcategory.func_189529_a("Item name", new ICrashReportDetail<String>()
                  {
+                     public String call() throws Exception

--- a/patches/minecraft/net/minecraft/tileentity/TileEntity.java.patch
+++ b/patches/minecraft/net/minecraft/tileentity/TileEntity.java.patch
@@ -71,7 +71,7 @@
                      try
                      {
 -                        return String.format("ID #%d (%s // %s)", i, Block.func_149729_e(i).func_149739_a(), Block.func_149729_e(i).getClass().getCanonicalName());
-+                    	return String.format("ID #%d (%s // %s // %s)", i, Block.func_149729_e(i).func_149739_a(), Block.func_149729_e(i).getClass().getCanonicalName(), Block.func_149729_e(i).getRegistryName());
++                    	return String.format("ID #%d (%s // %s // %s)", i, Block.func_149729_e(i).func_149739_a(), Block.func_149729_e(i).getClass().getName(), Block.func_149729_e(i).getRegistryName());
                      }
                      catch (Throwable var3)
                      {

--- a/patches/minecraft/net/minecraft/tileentity/TileEntity.java.patch
+++ b/patches/minecraft/net/minecraft/tileentity/TileEntity.java.patch
@@ -66,6 +66,15 @@
      public double func_145835_a(double p_145835_1_, double p_145835_3_, double p_145835_5_)
      {
          double d0 = (double)this.field_174879_c.func_177958_n() + 0.5D - p_145835_1_;
+@@ -244,7 +252,7 @@
+ 
+                     try
+                     {
+-                        return String.format("ID #%d (%s // %s)", i, Block.func_149729_e(i).func_149739_a(), Block.func_149729_e(i).getClass().getCanonicalName());
++                        return String.format("ID #%d (%s // %s)", i, Block.func_149729_e(i).getRegistryName(), Block.func_149729_e(i).getClass().getCanonicalName());
+                     }
+                     catch (Throwable var3)
+                     {
 @@ -297,6 +305,204 @@
      {
      }

--- a/patches/minecraft/net/minecraft/tileentity/TileEntity.java.patch
+++ b/patches/minecraft/net/minecraft/tileentity/TileEntity.java.patch
@@ -71,7 +71,7 @@
                      try
                      {
 -                        return String.format("ID #%d (%s // %s)", i, Block.func_149729_e(i).func_149739_a(), Block.func_149729_e(i).getClass().getCanonicalName());
-+                    	return String.format("ID #%d (%s // %s // %s)", i, Block.func_149729_e(i).func_149739_a(), Block.func_149729_e(i).getClass().getName(), Block.func_149729_e(i).getRegistryName());
++                        return String.format("ID #%d (%s // %s // %s)", i, Block.func_149729_e(i).func_149739_a(), Block.func_149729_e(i).getClass().getName(), Block.func_149729_e(i).getRegistryName());
                      }
                      catch (Throwable var3)
                      {

--- a/patches/minecraft/net/minecraft/tileentity/TileEntity.java.patch
+++ b/patches/minecraft/net/minecraft/tileentity/TileEntity.java.patch
@@ -71,7 +71,7 @@
                      try
                      {
 -                        return String.format("ID #%d (%s // %s)", i, Block.func_149729_e(i).func_149739_a(), Block.func_149729_e(i).getClass().getCanonicalName());
-+                        return String.format("ID #%d (%s // %s)", i, Block.func_149729_e(i).getRegistryName(), Block.func_149729_e(i).getClass().getCanonicalName());
++                    	return String.format("ID #%d (%s // %s // %s)", i, Block.func_149729_e(i).func_149739_a(), Block.func_149729_e(i).getClass().getCanonicalName(), Block.func_149729_e(i).getRegistryName());
                      }
                      catch (Throwable var3)
                      {

--- a/patches/minecraft/net/minecraft/world/World.java.patch
+++ b/patches/minecraft/net/minecraft/world/World.java.patch
@@ -159,7 +159,7 @@
                          try
                          {
 -                            return String.format("ID #%d (%s // %s)", Block.func_149682_b(p_190524_2_), p_190524_2_.func_149739_a(), p_190524_2_.getClass().getCanonicalName());
-+                            return String.format("ID #%d (%s // %s // %s)", Block.func_149682_b(p_190524_2_), p_190524_2_.func_149739_a(), p_190524_2_.getClass().getCanonicalName(), p_190524_2_.getRegistryName());
++                            return String.format("ID #%d (%s // %s // %s)", Block.func_149682_b(p_190524_2_), p_190524_2_.func_149739_a(), p_190524_2_.getClass().getName(), p_190524_2_.getRegistryName());
                          }
                          catch (Throwable var2)
                          {
@@ -182,7 +182,7 @@
                              try
                              {
 -                                return String.format("ID #%d (%s // %s)", Block.func_149682_b(p_190529_2_), p_190529_2_.func_149739_a(), p_190529_2_.getClass().getCanonicalName());
-+                                return String.format("ID #%d (%s // %s // %s)", Block.func_149682_b(p_190529_2_), p_190529_2_.func_149739_a(), p_190529_2_.getClass().getCanonicalName(), p_190529_2_.getRegistryName());
++                                return String.format("ID #%d (%s // %s // %s)", Block.func_149682_b(p_190529_2_), p_190529_2_.func_149739_a(), p_190529_2_.getClass().getName(), p_190529_2_.getRegistryName());
                              }
                              catch (Throwable var2)
                              {

--- a/patches/minecraft/net/minecraft/world/World.java.patch
+++ b/patches/minecraft/net/minecraft/world/World.java.patch
@@ -159,7 +159,7 @@
                          try
                          {
 -                            return String.format("ID #%d (%s // %s)", Block.func_149682_b(p_190524_2_), p_190524_2_.func_149739_a(), p_190524_2_.getClass().getCanonicalName());
-+                            return String.format("ID #%d (%s // %s)", Block.func_149682_b(p_190524_2_), p_190524_2_.getRegistryName(), p_190524_2_.getClass().getCanonicalName());
++                            return String.format("ID #%d (%s // %s // %s)", Block.func_149682_b(p_190524_2_), p_190524_2_.func_149739_a(), p_190524_2_.getClass().getCanonicalName(), p_190524_2_.getRegistryName());
                          }
                          catch (Throwable var2)
                          {
@@ -182,7 +182,7 @@
                              try
                              {
 -                                return String.format("ID #%d (%s // %s)", Block.func_149682_b(p_190529_2_), p_190529_2_.func_149739_a(), p_190529_2_.getClass().getCanonicalName());
-+                                return String.format("ID #%d (%s // %s)", Block.func_149682_b(p_190529_2_), p_190529_2_.getRegistryName(), p_190529_2_.getClass().getCanonicalName());
++                                return String.format("ID #%d (%s // %s // %s)", Block.func_149682_b(p_190529_2_), p_190529_2_.func_149739_a(), p_190529_2_.getClass().getCanonicalName(), p_190529_2_.getRegistryName());
                              }
                              catch (Throwable var2)
                              {

--- a/patches/minecraft/net/minecraft/world/World.java.patch
+++ b/patches/minecraft/net/minecraft/world/World.java.patch
@@ -154,6 +154,15 @@
          if (p_175695_3_ != EnumFacing.WEST)
          {
              this.func_190524_a(p_175695_1_.func_177976_e(), p_175695_2_, p_175695_1_);
+@@ -507,7 +559,7 @@
+                     {
+                         try
+                         {
+-                            return String.format("ID #%d (%s // %s)", Block.func_149682_b(p_190524_2_), p_190524_2_.func_149739_a(), p_190524_2_.getClass().getCanonicalName());
++                            return String.format("ID #%d (%s // %s)", Block.func_149682_b(p_190524_2_), p_190524_2_.getRegistryName(), p_190524_2_.getClass().getCanonicalName());
+                         }
+                         catch (Throwable var2)
+                         {
 @@ -527,11 +579,11 @@
          {
              IBlockState iblockstate = this.func_180495_p(p_190529_1_);
@@ -168,6 +177,15 @@
                  }
                  catch (Throwable throwable)
                  {
+@@ -543,7 +595,7 @@
+                         {
+                             try
+                             {
+-                                return String.format("ID #%d (%s // %s)", Block.func_149682_b(p_190529_2_), p_190529_2_.func_149739_a(), p_190529_2_.getClass().getCanonicalName());
++                                return String.format("ID #%d (%s // %s)", Block.func_149682_b(p_190529_2_), p_190529_2_.getRegistryName(), p_190529_2_.getClass().getCanonicalName());
+                             }
+                             catch (Throwable var2)
+                             {
 @@ -588,7 +640,7 @@
                  {
                      IBlockState iblockstate = this.func_180495_p(blockpos1);


### PR DESCRIPTION
This PR seeks to make a few crash reports easier to read.  I've updated most ICrashReportDetails to use getRegistryName where necessary (referencing blocks/items).  Before, details were scattered - either using unlocalized name, numerical ID, or just item.toString.  This will make crash reports much easier to diagnose in the future.