### PR TITLE
Allow sleeping at any time

### DIFF
--- a/patches/minecraft/net/minecraft/entity/player/EntityPlayer.java.patch
+++ b/patches/minecraft/net/minecraft/entity/player/EntityPlayer.java.patch
@@ -29,6 +29,15 @@
          this.field_70145_X = this.func_175149_v();
  
          if (this.func_175149_v())
+@@ -207,7 +215,7 @@
+                 {
+                     this.func_70999_a(true, true, false);
+                 }
+-                else if (this.field_70170_p.func_72935_r())
++                else if (!net.minecraftforge.event.ForgeEventFactory.fireSleepingTimeCheck(this, this.field_71081_bT))
+                 {
+                     this.func_70999_a(false, true, true);
+                 }
 @@ -367,6 +375,7 @@
                  this.func_70105_a(f, f1);
              }
@@ -335,6 +344,15 @@
  
          if (!this.field_70170_p.field_72995_K)
          {
+@@ -1456,7 +1547,7 @@
+                 return EntityPlayer.SleepResult.NOT_POSSIBLE_HERE;
+             }
+ 
+-            if (this.field_70170_p.func_72935_r())
++            if (!net.minecraftforge.event.ForgeEventFactory.fireSleepingTimeCheck(this, this.field_71081_bT))
+             {
+                 return EntityPlayer.SleepResult.NOT_POSSIBLE_NOW;
+             }
 @@ -1484,8 +1575,7 @@
          this.func_192030_dh();
          this.func_70105_a(0.2F, 0.2F);

--- a/src/main/java/net/minecraftforge/event/ForgeEventFactory.java
+++ b/src/main/java/net/minecraftforge/event/ForgeEventFactory.java
@@ -114,6 +114,7 @@ import net.minecraftforge.event.entity.player.PlayerSetSpawnEvent;
 import net.minecraftforge.event.entity.player.PlayerSleepInBedEvent;
 import net.minecraftforge.event.entity.player.PlayerWakeUpEvent;
 import net.minecraftforge.event.entity.player.SleepingLocationCheckEvent;
+import net.minecraftforge.event.entity.player.SleepingTimeCheckEvent;
 import net.minecraftforge.event.entity.player.UseHoeEvent;
 import net.minecraftforge.event.furnace.FurnaceFuelBurnTimeEvent;
 import net.minecraftforge.event.terraingen.ChunkGeneratorEvent;
@@ -678,6 +679,18 @@ public class ForgeEventFactory
             IBlockState state = player.world.getBlockState(player.bedLocation);
             return state.getBlock().isBed(state, player.world, player.bedLocation, player);
         }
+        else
+            return canContinueSleep == Result.ALLOW;
+    }
+
+    public static boolean fireSleepingTimeCheck(EntityPlayer player, BlockPos sleepingLocation)
+    {
+        SleepingTimeCheckEvent evt = new SleepingTimeCheckEvent(player, sleepingLocation);
+        MinecraftForge.EVENT_BUS.post(evt);
+
+        Result canContinueSleep = evt.getResult();
+        if (canContinueSleep == Result.DEFAULT)
+            return !player.world.isDaytime();
         else
             return canContinueSleep == Result.ALLOW;
     }

--- a/src/main/java/net/minecraftforge/event/entity/player/SleepingTimeCheckEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/player/SleepingTimeCheckEvent.java
@@ -44,6 +44,10 @@ public class SleepingTimeCheckEvent extends PlayerEvent
         this.sleepingLocation = sleepingLocation;
     }
 
+    /**
+     * Note that the sleeping location may be an approximated one.
+     * @return The player's sleeping location.
+     */
     public BlockPos getSleepingLocation()
     {
         return sleepingLocation;

--- a/src/main/java/net/minecraftforge/event/entity/player/SleepingTimeCheckEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/player/SleepingTimeCheckEvent.java
@@ -1,0 +1,51 @@
+/*
+ * Minecraft Forge
+ * Copyright (c) 2016-2018.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation version 2.1
+ * of the License.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+package net.minecraftforge.event.entity.player;
+
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.World;
+import net.minecraftforge.fml.common.eventhandler.Event.HasResult;
+
+/**
+ * This event is fired when the game checks if players can sleep at this time.<br>
+ * Failing this check will cause sleeping players to wake up and prevent awake players from sleeping.<br>
+ *
+ * This event has a result. {@link HasResult}<br>
+ *
+ * setResult(ALLOW) informs game that player can sleep at this time.<br>
+ * setResult(DEFAULT) causes game to check !{@link World#isDaytime()} instead.
+ */
+@HasResult
+public class SleepingTimeCheckEvent extends PlayerEvent
+{
+    private final BlockPos sleepingLocation;
+
+    public SleepingTimeCheckEvent(EntityPlayer player, BlockPos sleepingLocation)
+    {
+        super(player);
+        this.sleepingLocation = sleepingLocation;
+    }
+
+    public BlockPos getSleepingLocation()
+    {
+        return sleepingLocation;
+    }
+}

--- a/src/test/java/net/minecraftforge/debug/gameplay/AnytimeSleepingTest.java
+++ b/src/test/java/net/minecraftforge/debug/gameplay/AnytimeSleepingTest.java
@@ -1,0 +1,88 @@
+/*
+ * Minecraft Forge
+ * Copyright (c) 2016-2018.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation version 2.1
+ * of the License.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+package net.minecraftforge.debug.gameplay;
+
+import net.minecraft.client.renderer.block.model.ModelResourceLocation;
+import net.minecraft.creativetab.CreativeTabs;
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.item.Item;
+import net.minecraft.util.ResourceLocation;
+import net.minecraftforge.client.event.ModelRegistryEvent;
+import net.minecraftforge.client.model.ModelLoader;
+import net.minecraftforge.common.MinecraftForge;
+import net.minecraftforge.event.RegistryEvent;
+import net.minecraftforge.event.entity.player.SleepingTimeCheckEvent;
+import net.minecraftforge.fml.common.Mod;
+import net.minecraftforge.fml.common.event.FMLPreInitializationEvent;
+import net.minecraftforge.fml.common.eventhandler.Event;
+import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
+import net.minecraftforge.fml.common.registry.GameRegistry;
+
+@Mod(modid = AnytimeSleepingTest.MODID, name = "Anytime Sleeping Test", version = "0.0", acceptableRemoteVersions = "*")
+public class AnytimeSleepingTest
+{
+    public static final String MODID = "anytimesleepingtest";
+    @GameRegistry.ObjectHolder(ItemSleepCharm.NAME)
+    public static final Item SLEEP_CHARM = null;
+
+    @Mod.EventHandler
+    public void preInit(FMLPreInitializationEvent evt)
+    {
+        MinecraftForge.EVENT_BUS.register(this);
+    }
+
+    @SubscribeEvent
+    public void onCheckSleepTime(SleepingTimeCheckEvent evt)
+    {
+        EntityPlayer player = evt.getEntityPlayer();
+        if (player.getHeldItemMainhand().getItem() instanceof ItemSleepCharm)
+        {
+            evt.setResult(Event.Result.ALLOW);
+        }
+    }
+
+    @Mod.EventBusSubscriber(modid = MODID)
+    public static class Registration
+    {
+        @SubscribeEvent
+        public static void registerItems(RegistryEvent.Register<Item> evt)
+        {
+            evt.getRegistry().register(new ItemSleepCharm());
+        }
+
+        @SubscribeEvent
+        public static void registerModels(ModelRegistryEvent evt)
+        {
+            ModelLoader.setCustomModelResourceLocation(SLEEP_CHARM, 0, new ModelResourceLocation("minecraft:totem", "inventory"));
+        }
+    }
+
+    public static class ItemSleepCharm extends Item
+    {
+        static final String NAME = "sleep_charm";
+
+        private ItemSleepCharm()
+        {
+            this.setCreativeTab(CreativeTabs.MISC);
+            this.setUnlocalizedName(MODID + ":" + NAME);
+            this.setRegistryName(new ResourceLocation(MODID, NAME));
+        }
+    }
+}


### PR DESCRIPTION
Currently, Minecraft forces players awake if the time is daytime. This makes it impossible to implement anything that allows sleeping during the day as far as I know. A concrete example of such a feature is in my mod, Comforts, which adds hammocks that allow players to sleep during the day to skip to nighttime.

This PR adds a SleepingTimeCheckEvent event, which serves as a counterpart to the already implemented SleepingLocationCheckEvent. Calls to this event replace the two checks in EntityPlayer for sleep time, allowing modders to override the result as needed. The default behavior is set to the vanilla check for `World#isDaytime`.

The included test mod adds a sleeping charm item that, when held in the mainhand, allows the player to sleep in a bed at any time of the day.