### PR TITLE
Use itemstack in LivingEntityUseItemEvent.Finish before it was used

### DIFF
--- a/patches/minecraft/net/minecraft/entity/EntityLivingBase.java.patch
+++ b/patches/minecraft/net/minecraft/entity/EntityLivingBase.java.patch
@@ -367,18 +367,19 @@
  
              if (!this.field_70170_p.field_72995_K)
              {
-@@ -2700,7 +2775,9 @@
+@@ -2700,7 +2775,10 @@
          if (!this.field_184627_bm.func_190926_b() && this.func_184587_cr())
          {
              this.func_184584_a(this.field_184627_bm, 16);
 -            this.func_184611_a(this.func_184600_cs(), this.field_184627_bm.func_77950_b(this.field_70170_p, this));
++            ItemStack activeItemStackCopy = this.field_184627_bm.func_77946_l();
 +            ItemStack itemstack = this.field_184627_bm.func_77950_b(this.field_70170_p, this);
-+            itemstack = net.minecraftforge.event.ForgeEventFactory.onItemUseFinish(this, field_184627_bm, func_184605_cv(), itemstack);
++            itemstack = net.minecraftforge.event.ForgeEventFactory.onItemUseFinish(this, activeItemStackCopy, func_184605_cv(), itemstack);
 +            this.func_184611_a(this.func_184600_cs(), itemstack);
              this.func_184602_cy();
          }
      }
-@@ -2724,7 +2801,8 @@
+@@ -2724,7 +2802,8 @@
      {
          if (!this.field_184627_bm.func_190926_b())
          {
@@ -388,7 +389,7 @@
          }
  
          this.func_184602_cy();
-@@ -2852,6 +2930,31 @@
+@@ -2852,6 +2931,31 @@
          return true;
      }
  

--- a/src/main/java/net/minecraftforge/event/entity/living/LivingEntityUseItemEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/living/LivingEntityUseItemEvent.java
@@ -113,6 +113,8 @@ public class LivingEntityUseItemEvent extends LivingEvent
      * Fired after an item has fully finished being used.
      * The item has been notified that it was used, and the item/result stacks reflect after that state.
      * This means that when this is fired for a Potion, the potion effect has already been applied.
+     * 
+     * {@link LivingEntityUseItemEvent#item} is a copy of the item BEFORE it was used.
      *
      * If you wish to cancel those effects, you should cancel one of the above events.
      *


### PR DESCRIPTION
`LivingEntityUseItemEvent.Finish#getItem` doesn't return the item before it was used.
That means that if you eat the last piece of food `#getItem` is empty as well as `#getResultStack`.
So you don't know what the player ate.
For non-stackable items like milk bucket or potion `#getItem` is always empty.
Basically `#getItem` is useless since it returns the same as `#getResultStack` or is empty.
I changed so that it uses a copy of the stack before it was used.
