### PR TITLE
Add function to lookup model location for an ItemStack

### DIFF
--- a/src/main/java/net/minecraftforge/client/ItemModelMesherForge.java
+++ b/src/main/java/net/minecraftforge/client/ItemModelMesherForge.java
@@ -26,12 +26,18 @@ import com.google.common.collect.Maps;
 import it.unimi.dsi.fastutil.ints.Int2ObjectMap;
 import it.unimi.dsi.fastutil.ints.Int2ObjectOpenHashMap;
 
+import net.minecraft.client.renderer.ItemMeshDefinition;
 import net.minecraft.client.renderer.ItemModelMesher;
 import net.minecraft.client.renderer.block.model.IBakedModel;
+import net.minecraft.client.renderer.block.model.ModelBakery;
 import net.minecraft.client.renderer.block.model.ModelManager;
 import net.minecraft.client.renderer.block.model.ModelResourceLocation;
 import net.minecraft.item.Item;
+import net.minecraft.item.ItemStack;
 import net.minecraftforge.registries.IRegistryDelegate;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 
 /**
  * Wrapper around ItemModeMesher that cleans up the internal maps to respect ID remapping.
@@ -47,6 +53,7 @@ public class ItemModelMesherForge extends ItemModelMesher
     }
 
     @Override
+    @Nullable
     protected IBakedModel getItemModel(Item item, int meta)
     {
         Int2ObjectMap<IBakedModel> map = models.get(item.delegate);
@@ -94,5 +101,33 @@ public class ItemModelMesherForge extends ItemModelMesher
                 map.put(entry.getIntKey(), manager.getModel(entry.getValue()))
             );
         }
+    }
+
+    public ModelResourceLocation getLocation(@Nonnull ItemStack stack)
+    {
+        Item item = stack.getItem();
+        ModelResourceLocation location = null;
+
+        Int2ObjectMap<ModelResourceLocation> map = locations.get(item.delegate);
+        if (map != null)
+        {
+            location = map.get(getMetadata(stack));
+        }
+
+        if (location == null)
+        {
+            ItemMeshDefinition definition = shapers.get(item);
+            if (definition != null)
+            {
+                location = definition.getModelLocation(stack);
+            }
+        }
+
+        if (location == null)
+        {
+            location = ModelBakery.MODEL_MISSING;
+        }
+
+        return location;
     }
 }

--- a/src/main/resources/forge_at.cfg
+++ b/src/main/resources/forge_at.cfg
@@ -107,6 +107,9 @@ public net.minecraft.client.renderer.block.model.ModelBlock field_178318_c # tex
 public net.minecraft.client.renderer.block.model.ModelBlock field_178315_d # parent
 public net.minecraft.client.renderer.block.model.ModelBlock field_178322_i # ambientOcclusion
 public net.minecraft.client.renderer.block.model.ModelBlock func_187966_f()Ljava/util/List; # getOverrides
+
+# ModelBakery
+public net.minecraft.client.renderer.block.model.ModelBakery field_177604_a # MODEL_MISSING
 protected net.minecraft.client.renderer.block.model.ModelBakery field_177602_b # LOCATIONS_BUILTIN_TEXTURES
 protected net.minecraft.client.renderer.block.model.ModelBakery field_177598_f # resourceManager
 protected net.minecraft.client.renderer.block.model.ModelBakery field_177599_g # sprites
@@ -136,6 +139,10 @@ protected net.minecraft.client.renderer.block.model.ModelBakery func_177595_c()V
 protected net.minecraft.client.renderer.block.model.ModelBakery func_188637_e()V # loadMultipartVariantModels
 protected net.minecraft.client.renderer.block.model.ModelBakery func_188638_a(Lnet/minecraft/client/renderer/block/model/ModelResourceLocation;Lnet/minecraft/client/renderer/block/model/VariantList;)V # loadVariantList
 #public net.minecraft.client.renderer.block.model.WeightedBakedModel field_177565_b # models
+
+# ItemModelMesher
+protected net.minecraft.client.renderer.ItemModelMesher field_178092_c # shapers
+
 # EnumFacing
 public net.minecraft.util.EnumFacing field_82609_l # VALUES
 public net.minecraft.util.EnumFacing field_176754_o # HORIZONTALS


### PR DESCRIPTION
Aims to provide a 'proper' way to lookup the `ModelResourceLocation` for an `ItemStack`, which can be used to get the associated `IModel`. At the moment, mods have taken to reflecting into internal Forge classes, causing issues such as https://github.com/Chisel-Team/ConnectedTexturesMod/issues/63, which is obviously not ideal.

