### PR TITLE
Fix server watchdog thread occasionally crashing on first run

### DIFF
--- a/patches/minecraft/net/minecraft/server/dedicated/DedicatedServer.java.patch
+++ b/patches/minecraft/net/minecraft/server/dedicated/DedicatedServer.java.patch
@@ -33,7 +33,7 @@
                  this.func_184105_a(new DedicatedPlayerList(this));
                  long j = System.nanoTime();
  
-@@ -260,6 +265,7 @@
+@@ -260,11 +265,13 @@
                  TileEntitySkull.func_184293_a(this.func_152358_ax());
                  TileEntitySkull.func_184294_a(this.func_147130_as());
                  PlayerProfileCache.func_187320_a(this.func_71266_T());
@@ -41,7 +41,13 @@
                  field_155771_h.info("Preparing level \"{}\"", (Object)this.func_71270_I());
                  this.func_71247_a(this.func_71270_I(), this.func_71270_I(), k, worldtype, s2);
                  long i1 = System.nanoTime() - j;
-@@ -296,7 +302,8 @@
+                 String s3 = String.format("%.3fs", (double)i1 / 1.0E9D);
+                 field_155771_h.info("Done ({})! For help, type \"help\" or \"?\"", (Object)s3);
++                this.field_175591_ab = func_130071_aq();
+ 
+                 if (this.field_71340_o.func_187239_a("announce-player-achievements"))
+                 {
+@@ -296,7 +303,8 @@
                  }
  
                  Items.field_190931_a.func_150895_a(CreativeTabs.field_78027_g, NonNullList.func_191196_a());
@@ -51,7 +57,7 @@
              }
          }
      }
-@@ -515,7 +522,7 @@
+@@ -515,7 +523,7 @@
  
      public boolean func_175579_a(World p_175579_1_, BlockPos p_175579_2_, EntityPlayer p_175579_3_)
      {
@@ -60,7 +66,7 @@
          {
              return false;
          }
-@@ -584,6 +591,9 @@
+@@ -584,6 +592,9 @@
          return this.field_71340_o.func_73669_a("network-compression-threshold", super.func_175577_aI());
      }
  

--- a/patches/minecraft/net/minecraft/server/dedicated/ServerHangWatchdog.java.patch
+++ b/patches/minecraft/net/minecraft/server/dedicated/ServerHangWatchdog.java.patch
@@ -25,11 +25,12 @@
  
                  for (ThreadInfo threadinfo : athreadinfo)
                  {
-@@ -75,6 +76,8 @@
+@@ -75,6 +76,9 @@
                  this.func_180248_a();
              }
  
 +            this.firstRun = false;
++            if (k > this.field_180250_c) continue;
 +
              try
              {

--- a/patches/minecraft/net/minecraft/server/dedicated/ServerHangWatchdog.java.patch
+++ b/patches/minecraft/net/minecraft/server/dedicated/ServerHangWatchdog.java.patch
@@ -1,22 +1,6 @@
 --- ../src-base/minecraft/net/minecraft/server/dedicated/ServerHangWatchdog.java
 +++ ../src-work/minecraft/net/minecraft/server/dedicated/ServerHangWatchdog.java
-@@ -22,6 +22,7 @@
-     private static final Logger field_180251_a = LogManager.getLogger();
-     private final DedicatedServer field_180249_b;
-     private final long field_180250_c;
-+    private boolean firstRun = true;
- 
-     public ServerHangWatchdog(DedicatedServer p_i46310_1_)
-     {
-@@ -37,14 +38,14 @@
-             long j = MinecraftServer.func_130071_aq();
-             long k = j - i;
- 
--            if (k > this.field_180250_c)
-+            if (k > this.field_180250_c && !this.firstRun)
-             {
-                 field_180251_a.fatal("A single server tick took {} seconds (should be max {})", String.format("%.2f", (float)k / 1000.0F), String.format("%.2f", 0.05F));
-                 field_180251_a.fatal("Considering it to be crashed, server will forcibly shutdown.");
+@@ -44,7 +44,7 @@
                  ThreadMXBean threadmxbean = ManagementFactory.getThreadMXBean();
                  ThreadInfo[] athreadinfo = threadmxbean.dumpAllThreads(true, true);
                  StringBuilder stringbuilder = new StringBuilder();
@@ -25,13 +9,3 @@
  
                  for (ThreadInfo threadinfo : athreadinfo)
                  {
-@@ -75,6 +76,9 @@
-                 this.func_180248_a();
-             }
- 
-+            this.firstRun = false;
-+            if (k > this.field_180250_c) continue;
-+
-             try
-             {
-                 Thread.sleep(i + this.field_180250_c - j);

--- a/src/main/resources/forge_at.cfg
+++ b/src/main/resources/forge_at.cfg
@@ -187,6 +187,8 @@ public net.minecraft.client.Minecraft field_110450_ap # mcDefaultResourcePack
 public net.minecraft.client.Minecraft func_71370_a(II)V # resize
 public net.minecraft.client.Minecraft func_180510_a(Lnet/minecraft/client/renderer/texture/TextureManager;)V # drawSplashScreen
 public net.minecraft.client.Minecraft func_184119_a(Lnet/minecraft/item/ItemStack;Lnet/minecraft/tileentity/TileEntity;)Lnet/minecraft/item/ItemStack; # storeTEInStack
+# MinecraftServer
+protected net.minecraft.server.MinecraftServer field_175591_ab # currentTime
 ## DedicatedServer
 public net.minecraft.server.dedicated.DedicatedServer field_71341_l # pendingCommandList
 ## SaveFormatOld


### PR DESCRIPTION
Fixes #5018.

Forge patches the `if (k > this.maxTickTime)` condition to include a check for `!this.firstRun` (#2367). This means that it is possible for `k > this.maxTickTime` to be true, but for that block of code to not execute (due to `firstRun` being true).

As a consequence, the code will attempt to sleep for a negative amount of time and crash.

This is fixed here by skipping the call to `sleep` in that specific case.