### PR TITLE
Allow configuring log levels using system properties.

### DIFF
--- a/src/main/resources/log4j2.xml
+++ b/src/main/resources/log4j2.xml
@@ -37,16 +37,16 @@
     </Appenders>
     <Loggers>
         <!-- make sure mojang's logging is set to 'info' so that their LOGGER.isDebugEnabled() behavior isn't active -->
-        <Logger level="info" name="com.mojang"/>
-        <Logger level="info" name="net.minecraft"/>
+        <Logger level="${sys:forge.mojangLogLevel:-info}" name="com.mojang"/>
+        <Logger level="${sys:forge.mojangLogLevel:-info}" name="net.minecraft"/>
         <Root level="all">
             <filters>
                 <MarkerFilter marker="NETWORK_PACKETS" onMatch="DENY" onMismatch="NEUTRAL"/>
             </filters>
-            <AppenderRef ref="SysOut" level="info"/>
-            <AppenderRef ref="ServerGuiConsole" level="info"/>
-            <AppenderRef ref="File" level="info"/>
-            <AppenderRef ref="DebugFile"/>
+            <AppenderRef ref="SysOut" level="${sys:forge.consoleLogLevel:-info}"/>
+            <AppenderRef ref="ServerGuiConsole" level="${sys:forge.consoleLogLevel:-info}"/>
+            <AppenderRef ref="File" level="${sys:forge.fileLogLevel:-info}"/>
+            <AppenderRef ref="DebugFile" level="${sys:forge.debugFileLogLevel:-trace}"/>
         </Root>
     </Loggers>
 </Configuration>

--- a/src/main/resources/log4j2.xml
+++ b/src/main/resources/log4j2.xml
@@ -37,16 +37,16 @@
     </Appenders>
     <Loggers>
         <!-- make sure mojang's logging is set to 'info' so that their LOGGER.isDebugEnabled() behavior isn't active -->
-        <Logger level="${sys:forge.mojangLogLevel:-info}" name="com.mojang"/>
-        <Logger level="${sys:forge.mojangLogLevel:-info}" name="net.minecraft"/>
+        <Logger level="${sys:forge.logging.mojang.level:-info}" name="com.mojang"/>
+        <Logger level="${sys:forge.logging.mojang.level:-info}" name="net.minecraft"/>
         <Root level="all">
             <filters>
                 <MarkerFilter marker="NETWORK_PACKETS" onMatch="DENY" onMismatch="NEUTRAL"/>
             </filters>
-            <AppenderRef ref="SysOut" level="${sys:forge.consoleLogLevel:-info}"/>
-            <AppenderRef ref="ServerGuiConsole" level="${sys:forge.consoleLogLevel:-info}"/>
-            <AppenderRef ref="File" level="${sys:forge.fileLogLevel:-info}"/>
-            <AppenderRef ref="DebugFile" level="${sys:forge.debugFileLogLevel:-trace}"/>
+            <AppenderRef ref="SysOut" level="${sys:forge.logging.console.level:-info}"/>
+            <AppenderRef ref="ServerGuiConsole" level="${sys:forge.logging.console.level:-info}"/>
+            <AppenderRef ref="File" level="${sys:forge.logging.file.level:-info}"/>
+            <AppenderRef ref="DebugFile" level="${sys:forge.logging.debug.level:-trace}"/>
         </Root>
     </Loggers>
 </Configuration>

--- a/src/main/resources/log4j2.xml
+++ b/src/main/resources/log4j2.xml
@@ -46,7 +46,7 @@
             <AppenderRef ref="SysOut" level="${sys:forge.logging.console.level:-info}"/>
             <AppenderRef ref="ServerGuiConsole" level="${sys:forge.logging.console.level:-info}"/>
             <AppenderRef ref="File" level="${sys:forge.logging.file.level:-info}"/>
-            <AppenderRef ref="DebugFile" level="${sys:forge.logging.debug.level:-trace}"/>
+            <AppenderRef ref="DebugFile" level="${sys:forge.logging.debugFile.level:-trace}"/>
         </Root>
     </Loggers>
 </Configuration>

--- a/src/main/resources/log4j2_server.xml
+++ b/src/main/resources/log4j2_server.xml
@@ -37,16 +37,16 @@
     </Appenders>
     <Loggers>
         <!-- make sure mojang's logging is set to 'info' so that their LOGGER.isDebugEnabled() behavior isn't active -->
-        <Logger level="info" name="com.mojang"/>
-        <Logger level="info" name="net.minecraft"/>
+        <Logger level="${sys:forge.mojangLogLevel:-info}" name="com.mojang"/>
+        <Logger level="${sys:forge.mojangLogLevel:-info}" name="net.minecraft"/>
         <Root level="all">
             <filters>
                 <MarkerFilter marker="NETWORK_PACKETS" onMatch="DENY" onMismatch="NEUTRAL"/>
             </filters>
-            <AppenderRef ref="Console" level="info"/>
-            <AppenderRef ref="ServerGuiConsole" level="info"/>
-            <AppenderRef ref="File" level="info"/>
-            <AppenderRef ref="DebugFile"/>
+            <AppenderRef ref="Console" level="${sys:forge.consoleLogLevel:-info}"/>
+            <AppenderRef ref="ServerGuiConsole" level="${sys:forge.consoleLogLevel:-info}"/>
+            <AppenderRef ref="File" level="${sys:forge.fileLogLevel:-info}"/>
+            <AppenderRef ref="DebugFile" level="${sys:forge.debugFileLogLevel:-trace}"/>
         </Root>
     </Loggers>
 </Configuration>

--- a/src/main/resources/log4j2_server.xml
+++ b/src/main/resources/log4j2_server.xml
@@ -37,16 +37,16 @@
     </Appenders>
     <Loggers>
         <!-- make sure mojang's logging is set to 'info' so that their LOGGER.isDebugEnabled() behavior isn't active -->
-        <Logger level="${sys:forge.mojangLogLevel:-info}" name="com.mojang"/>
-        <Logger level="${sys:forge.mojangLogLevel:-info}" name="net.minecraft"/>
+        <Logger level="${sys:forge.logging.mojang.level:-info}" name="com.mojang"/>
+        <Logger level="${sys:forge.logging.mojang.level:-info}" name="net.minecraft"/>
         <Root level="all">
             <filters>
                 <MarkerFilter marker="NETWORK_PACKETS" onMatch="DENY" onMismatch="NEUTRAL"/>
             </filters>
-            <AppenderRef ref="Console" level="${sys:forge.consoleLogLevel:-info}"/>
-            <AppenderRef ref="ServerGuiConsole" level="${sys:forge.consoleLogLevel:-info}"/>
-            <AppenderRef ref="File" level="${sys:forge.fileLogLevel:-info}"/>
-            <AppenderRef ref="DebugFile" level="${sys:forge.debugFileLogLevel:-trace}"/>
+            <AppenderRef ref="Console" level="${sys:forge.logging.console.level:-info}"/>
+            <AppenderRef ref="ServerGuiConsole" level="${sys:forge.logging.console.level:-info}"/>
+            <AppenderRef ref="File" level="${sys:forge.logging.file.level:-info}"/>
+            <AppenderRef ref="DebugFile" level="${sys:forge.logging.debug.level:-trace}"/>
         </Root>
     </Loggers>
 </Configuration>

--- a/src/main/resources/log4j2_server.xml
+++ b/src/main/resources/log4j2_server.xml
@@ -46,7 +46,7 @@
             <AppenderRef ref="Console" level="${sys:forge.logging.console.level:-info}"/>
             <AppenderRef ref="ServerGuiConsole" level="${sys:forge.logging.console.level:-info}"/>
             <AppenderRef ref="File" level="${sys:forge.logging.file.level:-info}"/>
-            <AppenderRef ref="DebugFile" level="${sys:forge.logging.debug.level:-trace}"/>
+            <AppenderRef ref="DebugFile" level="${sys:forge.logging.debugFile.level:-trace}"/>
         </Root>
     </Loggers>
 </Configuration>


### PR DESCRIPTION
Defaults are:
`-Dforge.mojangLogLevel=info` (note that setting this to debug or trace will enable extra debug behavior)
`-Dforge.consoleLogLevel=info`
`-Dforge.fileLogLevel=info`
`-Dforge.debugFileLogLevel=trace`

Edit: the final keys are:
```
-Dforge.logging.mojang.level=info
-Dforge.logging.console.level=info
-Dforge.logging.file.level=info
-Dforge.logging.debugFile.level=trace
```