### PR TITLE
Change universal bucket support to use fluid names instead of instances

### DIFF
--- a/src/main/java/net/minecraftforge/fluids/FluidRegistry.java
+++ b/src/main/java/net/minecraftforge/fluids/FluidRegistry.java
@@ -19,6 +19,7 @@
 
 package net.minecraftforge.fluids;
 
+import java.util.Collections;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
@@ -37,7 +38,6 @@ import net.minecraftforge.common.MinecraftForge;
 import com.google.common.base.Strings;
 import com.google.common.collect.BiMap;
 import com.google.common.collect.HashBiMap;
-import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 
@@ -68,6 +68,7 @@ public abstract class FluidRegistry
 
     static boolean universalBucketEnabled = false;
     static Set<String> bucketFluids = Sets.newHashSet();
+    static Set<Fluid> currentBucketFluids;
 
     public static final Fluid WATER = new Fluid("water", new ResourceLocation("blocks/water_still"), new ResourceLocation("blocks/water_flow")) {
         @Override
@@ -140,6 +141,7 @@ public abstract class FluidRegistry
         fluids = localFluids;
         fluidNames = localFluidNames;
         fluidBlocks = null;
+        currentBucketFluids = null;
         for (FluidDelegate fd : delegates.values())
         {
             fd.rebind();
@@ -234,7 +236,7 @@ public abstract class FluidRegistry
      */
     public static Map<String, Fluid> getRegisteredFluids()
     {
-        return ImmutableMap.copyOf(fluids);
+        return Maps.unmodifiableBiMap(fluids);
     }
 
     /**
@@ -244,7 +246,7 @@ public abstract class FluidRegistry
     @Deprecated
     public static Map<Fluid, Integer> getRegisteredFluidIDs()
     {
-        return ImmutableMap.copyOf(fluidIDs);
+        return Maps.unmodifiableBiMap(fluidIDs);
     }
 
     /**
@@ -292,16 +294,20 @@ public abstract class FluidRegistry
 
     /**
      * All fluids registered with the universal bucket
-     * @return A new set containing the fluids
+     * @return A read-only set containing the fluids
      */
     public static Set<Fluid> getBucketFluids()
     {
-        Set<Fluid> fluids = Sets.newHashSet();
-        for (String fluidName : bucketFluids)
+        if (currentBucketFluids == null)
         {
-            fluids.add(getFluid(fluidName));
+            Set<Fluid> tmp = Sets.newHashSet();
+            for (String fluidName : bucketFluids)
+            {
+                tmp.add(getFluid(fluidName));
+            }
+            currentBucketFluids = Collections.unmodifiableSet(tmp);
         }
-        return fluids;
+        return currentBucketFluids;
     }
 
     public static boolean hasBucket(Fluid fluid)

--- a/src/main/java/net/minecraftforge/fluids/FluidRegistry.java
+++ b/src/main/java/net/minecraftforge/fluids/FluidRegistry.java
@@ -24,7 +24,6 @@ import java.util.Map.Entry;
 import java.util.Set;
 
 import net.minecraftforge.fml.common.LoaderState;
-import org.apache.logging.log4j.Level;
 
 import net.minecraft.block.Block;
 import net.minecraft.init.Blocks;
@@ -39,7 +38,6 @@ import com.google.common.base.Strings;
 import com.google.common.collect.BiMap;
 import com.google.common.collect.HashBiMap;
 import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 
@@ -69,7 +67,7 @@ public abstract class FluidRegistry
     static Map<Fluid,FluidDelegate> delegates = Maps.newHashMap();
 
     static boolean universalBucketEnabled = false;
-    static Set<Fluid> bucketFluids = Sets.newHashSet();
+    static Set<String> bucketFluids = Sets.newHashSet();
 
     public static final Fluid WATER = new Fluid("water", new ResourceLocation("blocks/water_still"), new ResourceLocation("blocks/water_flow")) {
         @Override
@@ -289,18 +287,27 @@ public abstract class FluidRegistry
         {
             registerFluid(fluid);
         }
-        return bucketFluids.add(fluid);
+        return bucketFluids.add(fluid.getName());
     }
 
     /**
      * All fluids registered with the universal bucket
-     * @return An immutable set containing the fluids
+     * @return A new set containing the fluids
      */
     public static Set<Fluid> getBucketFluids()
     {
-        return ImmutableSet.copyOf(bucketFluids);
+        Set<Fluid> fluids = Sets.newHashSet();
+        for (String fluidName : bucketFluids)
+        {
+            fluids.add(getFluid(fluidName));
+        }
+        return fluids;
     }
 
+    public static boolean hasBucket(Fluid fluid)
+    {
+        return bucketFluids.contains(fluid.getName());
+    }
 
     public static Fluid lookupFluidForBlock(Block block)
     {

--- a/src/main/java/net/minecraftforge/fluids/FluidUtil.java
+++ b/src/main/java/net/minecraftforge/fluids/FluidUtil.java
@@ -740,7 +740,7 @@ public class FluidUtil
             }
         }
 
-        if (FluidRegistry.isUniversalBucketEnabled() && FluidRegistry.getBucketFluids().contains(fluid))
+        if (FluidRegistry.isUniversalBucketEnabled() && FluidRegistry.hasBucket(fluid))
         {
             UniversalBucket bucket = ForgeModContainer.getInstance().universalBucket;
             ItemStack filledBucket = new ItemStack(bucket);

--- a/src/main/java/net/minecraftforge/fluids/capability/wrappers/FluidBucketWrapper.java
+++ b/src/main/java/net/minecraftforge/fluids/capability/wrappers/FluidBucketWrapper.java
@@ -60,13 +60,14 @@ public class FluidBucketWrapper implements IFluidHandlerItem, ICapabilityProvide
         return container;
     }
 
-    public boolean canFillFluidType(FluidStack fluid)
+    public boolean canFillFluidType(FluidStack fluidStack)
     {
-        if (fluid.getFluid() == FluidRegistry.WATER || fluid.getFluid() == FluidRegistry.LAVA || fluid.getFluid().getName().equals("milk"))
+        Fluid fluid = fluidStack.getFluid();
+        if (fluid == FluidRegistry.WATER || fluid == FluidRegistry.LAVA || fluid.getName().equals("milk"))
         {
             return true;
         }
-        return FluidRegistry.isUniversalBucketEnabled() && FluidRegistry.getBucketFluids().contains(fluid.getFluid());
+        return FluidRegistry.isUniversalBucketEnabled() && FluidRegistry.hasBucket(fluid);
     }
 
     @Nullable


### PR DESCRIPTION
Resolves #4863.

Any thoughts on what to do with `getBucketFluids` - should it be deprecated to be removed/replaced, or left as-is?