### PR TITLE
Add functionality in IItemHandler to test if a slot can accept an item

### DIFF
--- a/src/main/java/net/minecraftforge/items/IItemHandler.java
+++ b/src/main/java/net/minecraftforge/items/IItemHandler.java
@@ -19,7 +19,10 @@
 
 package net.minecraftforge.items;
 
+import net.minecraft.inventory.IInventory;
 import net.minecraft.item.ItemStack;
+import net.minecraftforge.fluids.FluidStack;
+import net.minecraftforge.fluids.capability.IFluidHandler;
 
 import javax.annotation.Nonnull;
 
@@ -35,16 +38,18 @@ public interface IItemHandler
     /**
      * Returns the ItemStack in a given slot.
      *
-     * The result's stack size may be greater than the itemstacks max size.
+     * The result's stack size may be greater than the itemstack's max size.
      *
      * If the result is empty, then the slot is empty.
      *
-     * <p/>
-     * IMPORTANT: This ItemStack MUST NOT be modified. This method is not for
-     * altering an inventories contents. Any implementers who are able to detect
+     * <p>
+     * <strong>IMPORTANT:</strong> This ItemStack <em>MUST NOT</em> be modified. This method is not for
+     * altering an inventory's contents. Any implementers who are able to detect
      * modification through this method should throw an exception.
-     * <p/>
-     * SERIOUSLY: DO NOT MODIFY THE RETURNED ITEMSTACK
+     * </p>
+     * <p>
+     * <strong><em>SERIOUSLY: DO NOT MODIFY THE RETURNED ITEMSTACK</em></strong>
+     * </p>
      *
      * @param slot Slot to query
      * @return ItemStack in given slot. Empty Itemstack if the slot is empty.
@@ -53,9 +58,11 @@ public interface IItemHandler
     ItemStack getStackInSlot(int slot);
 
     /**
+     * <p>
      * Inserts an ItemStack into the given slot and return the remainder.
-     * The ItemStack should not be modified in this function!
-     * Note: This behaviour is subtly different from IFluidHandlers.fill()
+     * The ItemStack <em>should not</em> be modified in this function!
+     * </p>
+     * Note: This behaviour is subtly different from {@link IFluidHandler#fill(FluidStack, boolean)}
      *
      * @param slot     Slot to insert into.
      * @param stack    ItemStack to insert. This must not be modified by the item handler.
@@ -69,11 +76,13 @@ public interface IItemHandler
 
     /**
      * Extracts an ItemStack from the given slot.
+     * <p>
      * The returned value must be empty if nothing is extracted,
-     * otherwise it's stack size must less than than amount and {@link ItemStack#getMaxStackSize()}.
+     * otherwise its stack size must be less than or equal to {@code amount} and {@link ItemStack#getMaxStackSize()}.
+     * </p>
      *
      * @param slot     Slot to extract from.
-     * @param amount   Amount to extract (may be greater than the current stacks max limit)
+     * @param amount   Amount to extract (may be greater than the current stack's max limit)
      * @param simulate If true, the extraction is only simulated
      * @return ItemStack extracted from the slot, must be empty if nothing can be extracted.
      *         The returned ItemStack can be safely modified after, so item handlers should return a new or copied stack.
@@ -90,12 +99,24 @@ public interface IItemHandler
     int getSlotLimit(int slot);
 
     /**
-     * Tests if a slot can accept an ItemStack.
-     * Use instead of simulated insertions for cases where current contents should be ignored.
+     * <p>
+     * This function re-implements the vanilla function {@link IInventory#isItemValidForSlot(int, ItemStack)}.
+     * It should be used instead of simulated insertions in cases where the contents and state of the inventory are
+     * irrelevant, mainly for the purpose of automation and logic (for instance, testing if a minecart can wait
+     * to deposit its items into a full inventory, or if the items in the minecart can never be placed into the
+     * inventory and should move on).
+     * </p>
+     * <ul>
+     * <li>isItemValid is false when insertion of the item is never valid.</li>
+     * <li>When isItemValid is true, no assumptions can be made and insertion must be simulated case-by-case.</li>
+     * <li>The actual items in the inventory, its fullness, or any other state are <strong>not</strong> considered by isItemValid.</li>
+     * </ul>
+     * @param slot    Slot to query for validity
+     * @param stack   Stack to test with for validity
      *
-     * @param slot  Slot to query.
-     * @param stack ItemStack to test with
-     * @return True if automation is allowed to insert the given stack into the slot in the inventory, ignoring current contents.
+     * @return true if the slot can insert the ItemStack, not considering the current state of the inventory.
+     *         false if the slot can never insert the ItemStack in any situation.
      */
+    //todo Make non-default and/or replace in 1.13
     default boolean isItemValid(int slot, @Nonnull ItemStack stack) { return true; }
 }

--- a/src/main/java/net/minecraftforge/items/IItemHandler.java
+++ b/src/main/java/net/minecraftforge/items/IItemHandler.java
@@ -88,4 +88,14 @@ public interface IItemHandler
      * @return     The maximum stack size allowed in the slot.
      */
     int getSlotLimit(int slot);
+
+    /**
+     * Tests if a slot can accept an ItemStack.
+     * Use instead of simulated insertions for cases where current stack size should be ignored.
+     *
+     * @param slot  Slot to query.
+     * @param stack ItemStack to test with
+     * @return True if automation is allowed to insert the given stack (ignoring stack size) into the given slot.
+     */
+    default boolean isItemValid(int slot, @Nonnull ItemStack stack) { return true; }
 }

--- a/src/main/java/net/minecraftforge/items/IItemHandler.java
+++ b/src/main/java/net/minecraftforge/items/IItemHandler.java
@@ -91,11 +91,11 @@ public interface IItemHandler
 
     /**
      * Tests if a slot can accept an ItemStack.
-     * Use instead of simulated insertions for cases where current stack size should be ignored.
+     * Use instead of simulated insertions for cases where current contents should be ignored.
      *
      * @param slot  Slot to query.
      * @param stack ItemStack to test with
-     * @return True if automation is allowed to insert the given stack (ignoring stack size) into the given slot.
+     * @return True if automation is allowed to insert the given stack into the slot in the inventory, ignoring current contents.
      */
     default boolean isItemValid(int slot, @Nonnull ItemStack stack) { return true; }
 }

--- a/src/main/java/net/minecraftforge/items/ItemStackHandler.java
+++ b/src/main/java/net/minecraftforge/items/ItemStackHandler.java
@@ -165,6 +165,12 @@ public class ItemStackHandler implements IItemHandler, IItemHandlerModifiable, I
     }
 
     @Override
+    public boolean isItemValid(int slot, @Nonnull ItemStack stack)
+    {
+        return true;
+    }
+
+    @Override
     public NBTTagCompound serializeNBT()
     {
         NBTTagList nbtTagList = new NBTTagList();

--- a/src/main/java/net/minecraftforge/items/SlotItemHandler.java
+++ b/src/main/java/net/minecraftforge/items/SlotItemHandler.java
@@ -46,24 +46,7 @@ public class SlotItemHandler extends Slot
         if (stack.isEmpty())
             return false;
 
-        IItemHandler handler = this.getItemHandler();
-        ItemStack remainder;
-        if (handler instanceof IItemHandlerModifiable)
-        {
-            IItemHandlerModifiable handlerModifiable = (IItemHandlerModifiable) handler;
-            ItemStack currentStack = handlerModifiable.getStackInSlot(index);
-
-            handlerModifiable.setStackInSlot(index, ItemStack.EMPTY);
-
-            remainder = handlerModifiable.insertItem(index, stack, true);
-
-            handlerModifiable.setStackInSlot(index, currentStack);
-        }
-        else
-        {
-            remainder = handler.insertItem(index, stack, true);
-        }
-        return remainder.isEmpty() || remainder.getCount() < stack.getCount();
+        return itemHandler.isItemValid(index, stack);
     }
 
     @Override

--- a/src/main/java/net/minecraftforge/items/VanillaDoubleChestItemHandler.java
+++ b/src/main/java/net/minecraftforge/items/VanillaDoubleChestItemHandler.java
@@ -188,6 +188,19 @@ public class VanillaDoubleChestItemHandler extends WeakReference<TileEntityChest
     }
 
     @Override
+    public boolean isItemValid(int slot, @Nonnull ItemStack stack)
+    {
+        boolean accessingUpperChest = slot < 27;
+        int targetSlot = accessingUpperChest ? slot : slot - 27;
+        TileEntityChest chest = getChest(accessingUpperChest);
+        if (chest != null)
+        {
+            return chest.getSingleChestHandler().isItemValid(targetSlot, stack);
+        }
+        return true;
+    }
+
+    @Override
     public boolean equals(Object o)
     {
         if (this == o)

--- a/src/main/java/net/minecraftforge/items/wrapper/CombinedInvWrapper.java
+++ b/src/main/java/net/minecraftforge/items/wrapper/CombinedInvWrapper.java
@@ -132,4 +132,13 @@ public class CombinedInvWrapper implements IItemHandlerModifiable
         int localSlot = getSlotFromIndex(slot, index);
         return handler.getSlotLimit(localSlot);
     }
+
+    @Override
+    public boolean isItemValid(int slot, @Nonnull ItemStack stack)
+    {
+        int index = getIndexForSlot(slot);
+        IItemHandlerModifiable handler = getHandlerFromIndex(index);
+        int localSlot = getSlotFromIndex(slot, index);
+        return handler.isItemValid(localSlot, stack);
+    }
 }

--- a/src/main/java/net/minecraftforge/items/wrapper/EmptyHandler.java
+++ b/src/main/java/net/minecraftforge/items/wrapper/EmptyHandler.java
@@ -67,4 +67,10 @@ public class EmptyHandler implements IItemHandlerModifiable
     {
         return 0;
     }
+
+    @Override
+    public boolean isItemValid(int slot, @Nonnull ItemStack stack)
+    {
+        return false;
+    }
 }

--- a/src/main/java/net/minecraftforge/items/wrapper/EntityEquipmentInvWrapper.java
+++ b/src/main/java/net/minecraftforge/items/wrapper/EntityEquipmentInvWrapper.java
@@ -179,6 +179,12 @@ public abstract class EntityEquipmentInvWrapper implements IItemHandlerModifiabl
         entity.setItemStackToSlot(equipmentSlot, stack);
     }
 
+    @Override
+    public boolean isItemValid(int slot, @Nonnull ItemStack stack)
+    {
+        return isItemValid(slot, stack);
+    }
+
     protected EntityEquipmentSlot validateSlotIndex(final int slot)
     {
         if (slot < 0 || slot >= slots.size())

--- a/src/main/java/net/minecraftforge/items/wrapper/EntityEquipmentInvWrapper.java
+++ b/src/main/java/net/minecraftforge/items/wrapper/EntityEquipmentInvWrapper.java
@@ -182,7 +182,7 @@ public abstract class EntityEquipmentInvWrapper implements IItemHandlerModifiabl
     @Override
     public boolean isItemValid(int slot, @Nonnull ItemStack stack)
     {
-        return isItemValid(slot, stack);
+        return IItemHandlerModifiable.super.isItemValid(slot, stack);
     }
 
     protected EntityEquipmentSlot validateSlotIndex(final int slot)

--- a/src/main/java/net/minecraftforge/items/wrapper/InvWrapper.java
+++ b/src/main/java/net/minecraftforge/items/wrapper/InvWrapper.java
@@ -204,6 +204,12 @@ public class InvWrapper implements IItemHandlerModifiable
         return getInv().getInventoryStackLimit();
     }
 
+    @Override
+    public boolean isItemValid(int slot, @Nonnull ItemStack stack)
+    {
+        return getInv().isItemValidForSlot(slot, stack);
+    }
+
     public IInventory getInv()
     {
         return inv;

--- a/src/main/java/net/minecraftforge/items/wrapper/RangedWrapper.java
+++ b/src/main/java/net/minecraftforge/items/wrapper/RangedWrapper.java
@@ -110,7 +110,7 @@ public class RangedWrapper implements IItemHandlerModifiable {
     {
         if (checkSlot(slot))
         {
-            return isItemValid(slot, stack);
+            return compose.isItemValid(slot, stack);
         }
 
         return false;

--- a/src/main/java/net/minecraftforge/items/wrapper/RangedWrapper.java
+++ b/src/main/java/net/minecraftforge/items/wrapper/RangedWrapper.java
@@ -110,7 +110,7 @@ public class RangedWrapper implements IItemHandlerModifiable {
     {
         if (checkSlot(slot))
         {
-            return compose.isItemValid(slot, stack);
+            return compose.isItemValid(slot + minSlot, stack);
         }
 
         return false;

--- a/src/main/java/net/minecraftforge/items/wrapper/RangedWrapper.java
+++ b/src/main/java/net/minecraftforge/items/wrapper/RangedWrapper.java
@@ -105,6 +105,17 @@ public class RangedWrapper implements IItemHandlerModifiable {
         return 0;
     }
 
+    @Override
+    public boolean isItemValid(int slot, @Nonnull ItemStack stack)
+    {
+        if (checkSlot(slot))
+        {
+            return isItemValid(slot, stack);
+        }
+
+        return false;
+    }
+
     private boolean checkSlot(int localSlot)
     {
         return localSlot + minSlot < maxSlot;

--- a/src/main/java/net/minecraftforge/items/wrapper/SidedInvWrapper.java
+++ b/src/main/java/net/minecraftforge/items/wrapper/SidedInvWrapper.java
@@ -230,4 +230,10 @@ public class SidedInvWrapper implements IItemHandlerModifiable
     {
         return inv.getInventoryStackLimit();
     }
+
+    @Override
+    public boolean isItemValid(int slot, @Nonnull ItemStack stack)
+    {
+        return inv.isItemValidForSlot(slot, stack);
+    }
 }


### PR DESCRIPTION
This pull request exists to resolve a loss of functionality with IItemHandler compared to the vanilla IInventory (see #3344). Other PRs have been proposed into the past, but they have all went stale. This isn't the best implementation, but it is non-breaking. It is unlikely we will be able to have a full rework to the scale as proposed in the comments of #3344 until 1.13 is well underway, which could take a long time based on the plans Forge has.

This function in Vanilla exists mainly for automation to test whether an inventory can accept an ItemStack. Without this PR, there is only a function to test whether an inventory will accept an ItemStack, which is similar but distinct in a few key manners. If the Inventory fills up, it can no longer test for acceptance due to the reliance on simulated insertions. This function exists to handle acceptance in a case where the Inventory is already full.