### PR TITLE
CreativeTabs#getBackgroundImage

### DIFF
--- a/patches/minecraft/net/minecraft/client/gui/inventory/GuiContainerCreative.java.patch
+++ b/patches/minecraft/net/minecraft/client/gui/inventory/GuiContainerCreative.java.patch
@@ -172,7 +172,7 @@
          }
          else
          {
-@@ -676,16 +744,35 @@
+@@ -676,17 +744,36 @@
          RenderHelper.func_74520_c();
          CreativeTabs creativetabs = CreativeTabs.field_78032_a[field_147058_w];
  
@@ -192,6 +192,7 @@
              }
          }
  
+-        this.field_146297_k.func_110434_K().func_110577_a(new ResourceLocation("textures/gui/container/creative_inventory/tab_" + creativetabs.func_78015_f()));
 +        if (tabPage != 0)
 +        {
 +            if (creativetabs != CreativeTabs.field_78027_g)
@@ -206,9 +207,10 @@
 +            }
 +        }
 +
-         this.field_146297_k.func_110434_K().func_110577_a(new ResourceLocation("textures/gui/container/creative_inventory/tab_" + creativetabs.func_78015_f()));
++        this.field_146297_k.func_110434_K().func_110577_a(creativetabs.getBackgroundImageLocation());
          this.func_73729_b(this.field_147003_i, this.field_147009_r, 0, 0, this.field_146999_f, this.field_147000_g);
          this.field_147062_A.func_146194_f();
+         GlStateManager.func_179131_c(1.0F, 1.0F, 1.0F, 1.0F);
 @@ -700,6 +787,14 @@
              this.func_73729_b(i, j + (int)((float)(k - j - 17) * this.field_147067_x), 232 + (this.func_147055_p() ? 0 : 12), 0, 12, 15);
          }

--- a/patches/minecraft/net/minecraft/client/gui/inventory/GuiContainerCreative.java.patch
+++ b/patches/minecraft/net/minecraft/client/gui/inventory/GuiContainerCreative.java.patch
@@ -207,7 +207,7 @@
 +            }
 +        }
 +
-+        this.field_146297_k.func_110434_K().func_110577_a(creativetabs.getBackgroundImageLocation());
++        this.field_146297_k.func_110434_K().func_110577_a(creativetabs.getBackgroundImage());
          this.func_73729_b(this.field_147003_i, this.field_147009_r, 0, 0, this.field_146999_f, this.field_147000_g);
          this.field_147062_A.func_146194_f();
          GlStateManager.func_179131_c(1.0F, 1.0F, 1.0F, 1.0F);

--- a/patches/minecraft/net/minecraft/creativetab/CreativeTabs.java.patch
+++ b/patches/minecraft/net/minecraft/creativetab/CreativeTabs.java.patch
@@ -44,7 +44,7 @@
          return this.field_78033_n < 6;
      }
  
-@@ -260,4 +282,39 @@
+@@ -260,4 +282,44 @@
              item.func_150895_a(this, p_78018_1_);
          }
      }
@@ -82,5 +82,10 @@
 +    public int getSearchbarWidth()
 +    {
 +        return 89;
++    }
++
++    public net.minecraft.util.ResourceLocation getBackgroundImageLocation()
++    {
++        return new net.minecraft.util.ResourceLocation("textures/gui/container/creative_inventory/tab_" + this.func_78015_f());
 +    }
  }

--- a/patches/minecraft/net/minecraft/creativetab/CreativeTabs.java.patch
+++ b/patches/minecraft/net/minecraft/creativetab/CreativeTabs.java.patch
@@ -84,7 +84,7 @@
 +        return 89;
 +    }
 +
-+    public net.minecraft.util.ResourceLocation getBackgroundImageLocation()
++    public net.minecraft.util.ResourceLocation getBackgroundImage()
 +    {
 +        return new net.minecraft.util.ResourceLocation("textures/gui/container/creative_inventory/tab_" + this.func_78015_f());
 +    }

--- a/patches/minecraft/net/minecraft/creativetab/CreativeTabs.java.patch
+++ b/patches/minecraft/net/minecraft/creativetab/CreativeTabs.java.patch
@@ -23,15 +23,7 @@
          this.field_78033_n = p_i1853_1_;
          this.field_78034_o = p_i1853_2_;
          this.field_151245_t = ItemStack.field_190927_a;
-@@ -177,7 +191,6 @@
-     @SideOnly(Side.CLIENT)
-     public abstract ItemStack func_78016_d();
- 
--    @SideOnly(Side.CLIENT)
-     public String func_78015_f()
-     {
-         return this.field_78043_p;
-@@ -210,12 +223,20 @@
+@@ -210,12 +224,20 @@
      @SideOnly(Side.CLIENT)
      public int func_78020_k()
      {
@@ -52,7 +44,7 @@
          return this.field_78033_n < 6;
      }
  
-@@ -260,4 +281,44 @@
+@@ -260,4 +282,45 @@
              item.func_150895_a(this, p_78018_1_);
          }
      }
@@ -92,6 +84,7 @@
 +        return 89;
 +    }
 +
++    @SideOnly(Side.CLIENT)
 +    public net.minecraft.util.ResourceLocation getBackgroundImage()
 +    {
 +        return new net.minecraft.util.ResourceLocation("textures/gui/container/creative_inventory/tab_" + this.func_78015_f());

--- a/patches/minecraft/net/minecraft/creativetab/CreativeTabs.java.patch
+++ b/patches/minecraft/net/minecraft/creativetab/CreativeTabs.java.patch
@@ -23,7 +23,15 @@
          this.field_78033_n = p_i1853_1_;
          this.field_78034_o = p_i1853_2_;
          this.field_151245_t = ItemStack.field_190927_a;
-@@ -210,12 +224,20 @@
+@@ -177,7 +191,6 @@
+     @SideOnly(Side.CLIENT)
+     public abstract ItemStack func_78016_d();
+ 
+-    @SideOnly(Side.CLIENT)
+     public String func_78015_f()
+     {
+         return this.field_78043_p;
+@@ -210,12 +223,20 @@
      @SideOnly(Side.CLIENT)
      public int func_78020_k()
      {
@@ -44,7 +52,7 @@
          return this.field_78033_n < 6;
      }
  
-@@ -260,4 +282,44 @@
+@@ -260,4 +281,44 @@
              item.func_150895_a(this, p_78018_1_);
          }
      }


### PR DESCRIPTION
This patch adds a getter to `CreativeTabs` to allow overriding the `ResourceLocation` created in `GuiContainerCreative#drawGuiContainerBackgroundLayer`, which in turn allows for modders to defer the background texture to another domain and path. Ideal usage would be overriding the method to declare the location of the background texture under their domain, i.e `modid:textures/gui/creative_tab.png`. If anyone has a better suggestion for the getter name, I'm happy to update the pull request.

Example code making use of this method:
```java
public static final CreativeTabs TAB = new CreativeTabs(MyFirstMod.ID) {
    @Override
    @SideOnly(Side.CLIENT)
    public ItemStack getTabIconItem() {
        return new ItemStack(Items.APPLE);
    }

    @Override
    @SideOnly(Side.CLIENT)
    public ResourceLocation getBackgroundImage() {
        return new ResourceLocation(MyFirstMod.ID, "textures/gui/creative_tab.png");
    }
};
```