### PR TITLE
Don't log FML signature errors in dev environment

### DIFF
--- a/src/main/java/net/minecraftforge/fml/common/asm/FMLSanityChecker.java
+++ b/src/main/java/net/minecraftforge/fml/common/asm/FMLSanityChecker.java
@@ -56,7 +56,7 @@ public class FMLSanityChecker implements IFMLCallHook
     public Void call() throws Exception
     {
         CodeSource codeSource = getClass().getProtectionDomain().getCodeSource();
-        boolean goodFML = false;
+        boolean goodFML = !liveEnv;
         boolean fmlIsJar = false;
         if (codeSource.getLocation().getProtocol().equals("jar"))
         {


### PR DESCRIPTION
Prevents the following error from showing up when running a mod from a development environment:
```
[main/ERROR] [FML]: FML appears to be missing any signature data. This is not a good thing
```
