### PR TITLE
Add support for custom Smelting-Recipes

### DIFF
--- a/patches/minecraft/net/minecraft/item/crafting/FurnaceRecipes.java.patch
+++ b/patches/minecraft/net/minecraft/item/crafting/FurnaceRecipes.java.patch
@@ -5,7 +5,7 @@
      public static FurnaceRecipes func_77602_a()
      {
 -        return field_77606_a;
-+        return net.minecraftforge.common.smelting.SmeltingHandler.INSTANCE;
++        return net.minecraftforge.common.smelting.SmeltingHandler.instance();
      }
  
      protected FurnaceRecipes()

--- a/patches/minecraft/net/minecraft/item/crafting/FurnaceRecipes.java.patch
+++ b/patches/minecraft/net/minecraft/item/crafting/FurnaceRecipes.java.patch
@@ -1,20 +1,11 @@
 --- ../src-base/minecraft/net/minecraft/item/crafting/FurnaceRecipes.java
 +++ ../src-work/minecraft/net/minecraft/item/crafting/FurnaceRecipes.java
-@@ -113,6 +113,7 @@
+@@ -20,7 +20,7 @@
  
-     public void func_151394_a(ItemStack p_151394_1_, ItemStack p_151394_2_, float p_151394_3_)
+     public static FurnaceRecipes func_77602_a()
      {
-+        if (func_151395_a(p_151394_1_) != ItemStack.field_190927_a) { net.minecraftforge.fml.common.FMLLog.log.info("Ignored smelting recipe with conflicting input: {} = {}", p_151394_1_, p_151394_2_); return; }
-         this.field_77604_b.put(p_151394_1_, p_151394_2_);
-         this.field_77605_c.put(p_151394_2_, Float.valueOf(p_151394_3_));
+-        return field_77606_a;
++        return net.minecraftforge.common.smelting.SmeltingHandler.INSTANCE;
      }
-@@ -142,6 +143,9 @@
  
-     public float func_151398_b(ItemStack p_151398_1_)
-     {
-+        float ret = p_151398_1_.func_77973_b().getSmeltingExperience(p_151398_1_);
-+        if (ret != -1) return ret;
-+
-         for (Entry<ItemStack, Float> entry : this.field_77605_c.entrySet())
-         {
-             if (this.func_151397_a(p_151398_1_, entry.getKey()))
+     protected FurnaceRecipes()

--- a/src/main/java/net/minecraftforge/common/crafting/CompoundIngredient.java
+++ b/src/main/java/net/minecraftforge/common/crafting/CompoundIngredient.java
@@ -41,10 +41,17 @@ public class CompoundIngredient extends Ingredient
     private IntList itemIds;
     private final boolean isSimple;
 
-    protected CompoundIngredient(Collection<Ingredient> children)
+    public CompoundIngredient(Iterable<Ingredient> children)
     {
         super(0);
-        this.children = children;
+        this.children = Lists.newArrayList();
+        for (Ingredient part : children)
+        {
+            if (part instanceof CompoundIngredient)
+                this.children.addAll(((CompoundIngredient) part).children);
+            else
+                this.children.add(part);
+        }
 
         boolean simple = true;
         for (Ingredient child : children)

--- a/src/main/java/net/minecraftforge/common/smelting/BasicSmeltingRecipe.java
+++ b/src/main/java/net/minecraftforge/common/smelting/BasicSmeltingRecipe.java
@@ -1,3 +1,22 @@
+/*
+ * Minecraft Forge
+ * Copyright (c) 2016-2018.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation version 2.1
+ * of the License.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
 package net.minecraftforge.common.smelting;
 
 import net.minecraft.item.ItemStack;

--- a/src/main/java/net/minecraftforge/common/smelting/BasicSmeltingRecipe.java
+++ b/src/main/java/net/minecraftforge/common/smelting/BasicSmeltingRecipe.java
@@ -1,0 +1,35 @@
+package net.minecraftforge.common.smelting;
+
+import net.minecraft.item.ItemStack;
+
+public class BasicSmeltingRecipe implements ISmeltingRecipe
+{
+    private final ItemStack output;
+    private final float experience;
+
+    public BasicSmeltingRecipe(ItemStack output, float experience)
+    {
+        this.output = output;
+        this.experience = experience;
+    }
+
+    @Override
+    public ItemStack getSmeltingResult(ItemStack input)
+    {
+        return output;
+    }
+
+    @Override
+    public float getExperience(ItemStack input)
+    {
+        float ret = input.getItem().getSmeltingExperience(input);
+        if (ret != -1) return ret;
+        return experience;
+    }
+
+    @Override
+    public ItemStack getGenericOutput()
+    {
+        return output;
+    }
+}

--- a/src/main/java/net/minecraftforge/common/smelting/BasicSmeltingRecipe.java
+++ b/src/main/java/net/minecraftforge/common/smelting/BasicSmeltingRecipe.java
@@ -19,19 +19,37 @@
 
 package net.minecraftforge.common.smelting;
 
-import net.minecraft.item.ItemStack;
+import javax.annotation.Nonnull;
 
-public class BasicSmeltingRecipe implements ISmeltingRecipe
+import net.minecraft.item.ItemStack;
+import net.minecraft.item.crafting.Ingredient;
+
+public final class BasicSmeltingRecipe implements ISmeltingRecipe
 {
+    private final Ingredient input;
     private final ItemStack output;
     private final float experience;
 
-    public BasicSmeltingRecipe(ItemStack output, float experience)
+    public BasicSmeltingRecipe(Ingredient input, ItemStack output, float experience)
     {
         this.output = output;
         this.experience = experience;
+        this.input = input;
     }
 
+    public BasicSmeltingRecipe(ItemStack input, ItemStack output, float experience)
+    {
+        this(Ingredient.fromStacks(input), output, experience);
+    }
+
+    @Nonnull
+    @Override
+    public Ingredient getInput()
+    {
+        return input;
+    }
+
+    @Nonnull
     @Override
     public ItemStack getSmeltingResult(ItemStack input)
     {
@@ -47,8 +65,8 @@ public class BasicSmeltingRecipe implements ISmeltingRecipe
     }
 
     @Override
-    public ItemStack getGenericOutput()
+    public boolean isBasic()
     {
-        return output;
+        return true;
     }
 }

--- a/src/main/java/net/minecraftforge/common/smelting/ISmeltingRecipe.java
+++ b/src/main/java/net/minecraftforge/common/smelting/ISmeltingRecipe.java
@@ -1,3 +1,22 @@
+/*
+ * Minecraft Forge
+ * Copyright (c) 2016-2018.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation version 2.1
+ * of the License.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
 package net.minecraftforge.common.smelting;
 
 import net.minecraft.item.ItemStack;

--- a/src/main/java/net/minecraftforge/common/smelting/ISmeltingRecipe.java
+++ b/src/main/java/net/minecraftforge/common/smelting/ISmeltingRecipe.java
@@ -1,0 +1,17 @@
+package net.minecraftforge.common.smelting;
+
+import net.minecraft.item.ItemStack;
+import net.minecraft.item.crafting.FurnaceRecipes;
+
+public interface ISmeltingRecipe
+{
+    ItemStack getSmeltingResult(ItemStack input);
+
+    float getExperience(ItemStack input);
+
+    /**
+     * @return a static representation of the ItemStack return by {@link ISmeltingRecipe#getSmeltingResult(ItemStack)}
+     * to be used in {@link FurnaceRecipes#getSmeltingList()}
+     */
+    ItemStack getGenericOutput();
+}

--- a/src/main/java/net/minecraftforge/common/smelting/ISmeltingRecipe.java
+++ b/src/main/java/net/minecraftforge/common/smelting/ISmeltingRecipe.java
@@ -19,18 +19,45 @@
 
 package net.minecraftforge.common.smelting;
 
+import javax.annotation.Nonnull;
+
 import net.minecraft.item.ItemStack;
-import net.minecraft.item.crafting.FurnaceRecipes;
+import net.minecraft.item.crafting.Ingredient;
 
 public interface ISmeltingRecipe
 {
-    ItemStack getSmeltingResult(ItemStack input);
-
-    float getExperience(ItemStack input);
+    /**
+     * @return a static {@link Ingredient} to be used as input
+     */
+    @Nonnull
+    Ingredient getInput();
 
     /**
-     * @return a static representation of the ItemStack return by {@link ISmeltingRecipe#getSmeltingResult(ItemStack)}
-     * to be used in {@link FurnaceRecipes#getSmeltingList()}
+     * @return a {@link ItemStack} to be used as output <b>which has to be copied by the caller</b><br>
+     * <br>
+     * In case the passed input is {@link ItemStack#isEmpty()} a static default representation of the output has to be returned.<br>
+     * The default state is used to keep binary compatibility with the vanilla system<br>
      */
-    ItemStack getGenericOutput();
+    @Nonnull
+    ItemStack getSmeltingResult(ItemStack input);
+
+    default float getExperience(ItemStack input)
+    {
+        return input.getItem().getSmeltingExperience(input);
+    }
+
+    default ItemStack getDefaultResult()
+    {
+        return getSmeltingResult(ItemStack.EMPTY);
+    }
+
+    /**
+     * @return if this recipe can be safely merged with another one if the inputs collide.
+     * This typically means the output doesn't depend on the input<br>
+     * Clarification on merging: {A,B}>R + {A,C}>R = {A,B,C}>R<br>
+     */
+    default boolean isBasic()
+    {
+        return false;
+    }
 }

--- a/src/main/java/net/minecraftforge/common/smelting/SmeltingHandler.java
+++ b/src/main/java/net/minecraftforge/common/smelting/SmeltingHandler.java
@@ -29,15 +29,19 @@ import java.util.Map;
 
 public class SmeltingHandler extends FurnaceRecipes
 {
-    public static final SmeltingHandler INSTANCE = new SmeltingHandler();
+    private static final SmeltingHandler INSTANCE = new SmeltingHandler();
 
-    private final Map<ItemStack, ISmeltingRecipe> recipes = Maps.newHashMap();
-    private final Map<ItemStack, ItemStack> staticView;
+    private Map<ItemStack, ISmeltingRecipe> recipes;
+    private Map<ItemStack, ItemStack> staticView;
 
     private SmeltingHandler()
     {
         super();
-        staticView = Maps.transformValues(recipes, ISmeltingRecipe::getGenericOutput);
+    }
+
+    public static SmeltingHandler instance()
+    {
+        return SmeltingHandler.INSTANCE;
     }
 
     @Override
@@ -53,7 +57,7 @@ public class SmeltingHandler extends FurnaceRecipes
             FMLLog.log.info("Ignored smelting recipe with conflicting input: {} = {}", input, recipe.getGenericOutput());
             return;
         }
-        recipes.put(input, recipe);
+        getRecipes().put(input, recipe);
     }
 
     @Override
@@ -72,6 +76,15 @@ public class SmeltingHandler extends FurnaceRecipes
         return staticView;
     }
 
+    public Map<ItemStack, ISmeltingRecipe> getRecipes()
+    {
+        if (recipes != null)
+            return recipes;
+        recipes = Maps.newHashMap();
+        staticView = Maps.transformValues(recipes, ISmeltingRecipe::getGenericOutput);
+        return recipes;
+    }
+
     @Override
     public float getSmeltingExperience(ItemStack stack)
     {
@@ -84,7 +97,7 @@ public class SmeltingHandler extends FurnaceRecipes
 
     public ISmeltingRecipe findRecipe(ItemStack input)
     {
-        for (Map.Entry<ItemStack, ISmeltingRecipe> entry : this.recipes.entrySet())
+        for (Map.Entry<ItemStack, ISmeltingRecipe> entry : getRecipes().entrySet())
         {
             if (OreDictionary.itemMatches(entry.getKey(), input, false))
             {

--- a/src/main/java/net/minecraftforge/common/smelting/SmeltingHandler.java
+++ b/src/main/java/net/minecraftforge/common/smelting/SmeltingHandler.java
@@ -1,0 +1,96 @@
+/*
+ * Minecraft Forge
+ * Copyright (c) 2016-2018.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation version 2.1
+ * of the License.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+package net.minecraftforge.common.smelting;
+
+import com.google.common.collect.Maps;
+import net.minecraft.item.ItemStack;
+import net.minecraft.item.crafting.FurnaceRecipes;
+import net.minecraftforge.fml.common.FMLLog;
+import net.minecraftforge.oredict.OreDictionary;
+
+import java.util.Map;
+
+public class SmeltingHandler extends FurnaceRecipes
+{
+    public static final SmeltingHandler INSTANCE = new SmeltingHandler();
+
+    private final Map<ItemStack, ISmeltingRecipe> recipes = Maps.newHashMap();
+    private final Map<ItemStack, ItemStack> staticView;
+
+    private SmeltingHandler()
+    {
+        super();
+        staticView = Maps.transformValues(recipes, ISmeltingRecipe::getGenericOutput);
+    }
+
+    @Override
+    public void addSmeltingRecipe(ItemStack input, ItemStack stack, float experience)
+    {
+        addSmeltingRecipe(input, new BasicSmeltingRecipe(stack, experience));
+    }
+
+    public void addSmeltingRecipe(ItemStack input, ISmeltingRecipe recipe)
+    {
+        if (findRecipe(input) != null)
+        {
+            FMLLog.log.info("Ignored smelting recipe with conflicting input: {} = {}", input, recipe.getGenericOutput());
+            return;
+        }
+        recipes.put(input, recipe);
+    }
+
+    @Override
+    public ItemStack getSmeltingResult(ItemStack stack)
+    {
+        ISmeltingRecipe recipe = findRecipe(stack);
+        if (recipe != null)
+            return recipe.getSmeltingResult(stack);
+        else
+            return ItemStack.EMPTY;
+    }
+
+    @Override
+    public Map<ItemStack, ItemStack> getSmeltingList()
+    {
+        return staticView;
+    }
+
+    @Override
+    public float getSmeltingExperience(ItemStack stack)
+    {
+        ISmeltingRecipe recipe = findRecipe(stack);
+        if (recipe != null)
+            return recipe.getExperience(stack);
+        else
+            return 0;
+    }
+
+    public ISmeltingRecipe findRecipe(ItemStack input)
+    {
+        for (Map.Entry<ItemStack, ISmeltingRecipe> entry : this.recipes.entrySet())
+        {
+            if (OreDictionary.itemMatches(entry.getKey(), input, false))
+            {
+                return entry.getValue();
+            }
+        }
+        return null;
+    }
+}

--- a/src/main/java/net/minecraftforge/common/smelting/SmeltingHandler.java
+++ b/src/main/java/net/minecraftforge/common/smelting/SmeltingHandler.java
@@ -19,24 +19,36 @@
 
 package net.minecraftforge.common.smelting;
 
-import com.google.common.collect.Maps;
+import com.google.common.collect.Iterators;
+import com.google.common.collect.Lists;
 import net.minecraft.item.ItemStack;
 import net.minecraft.item.crafting.FurnaceRecipes;
+import net.minecraft.item.crafting.Ingredient;
+import net.minecraftforge.common.crafting.CompoundIngredient;
 import net.minecraftforge.fml.common.FMLLog;
 import net.minecraftforge.oredict.OreDictionary;
 
+import java.util.AbstractMap;
+import java.util.AbstractSet;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.List;
 import java.util.Map;
+import java.util.Set;
+
 
 public class SmeltingHandler extends FurnaceRecipes
 {
     private static final SmeltingHandler INSTANCE = new SmeltingHandler();
 
-    private Map<ItemStack, ISmeltingRecipe> recipes;
+    private List<ISmeltingRecipe> recipes;
     private Map<ItemStack, ItemStack> staticView;
 
     private SmeltingHandler()
     {
         super();
+        // super adds recipes an therefore indirectly initializes above fields
     }
 
     public static SmeltingHandler instance()
@@ -45,19 +57,58 @@ public class SmeltingHandler extends FurnaceRecipes
     }
 
     @Override
-    public void addSmeltingRecipe(ItemStack input, ItemStack stack, float experience)
+    public void addSmeltingRecipe(ItemStack input, ItemStack output, float experience)
     {
-        addSmeltingRecipe(input, new BasicSmeltingRecipe(stack, experience));
+        addSmeltingRecipe(new BasicSmeltingRecipe(input, output, experience));
     }
 
-    public void addSmeltingRecipe(ItemStack input, ISmeltingRecipe recipe)
+    /**
+     * Add an arbitrary Recipe to the furnace<br>
+     * <b>You will be required to move to json 1.13</b>
+     */
+    public void addSmeltingRecipe(ISmeltingRecipe recipe)
     {
-        if (findRecipe(input) != null)
+        ItemStack[] inputs = recipe.getInput().getMatchingStacks();
+        List<ISmeltingRecipe> collisions = Lists.newArrayList();
+        for (ItemStack in : inputs)
         {
-            FMLLog.log.info("Ignored smelting recipe with conflicting input: {} = {}", input, recipe.getGenericOutput());
-            return;
+            ISmeltingRecipe isr = findRecipe(in);
+            if (isr != null)
+                collisions.add(isr);
         }
-        getRecipes().put(input, recipe);
+        if (collisions.size() > 0)
+        {
+            collisions.add(recipe);
+            if (collisions.stream().allMatch(ISmeltingRecipe::isBasic))
+            {
+                if (collisions.stream().allMatch(isr -> OreDictionary.itemMatches(isr.getDefaultResult(), recipe.getDefaultResult(), false)))
+                {
+                    getRecipes().removeAll(collisions);
+
+                    List<Ingredient> ingredients = Lists.newArrayList();
+                    collisions.forEach(isr -> ingredients.add(isr.getInput()));
+                    Ingredient merged = new CompoundIngredient(ingredients);
+
+                    float exp = 0;
+                    for (ISmeltingRecipe isr : collisions)
+                        exp = Math.max(isr.getExperience(ItemStack.EMPTY), exp);
+
+                    getRecipes().add(new BasicSmeltingRecipe(merged, recipe.getDefaultResult(), exp));
+                    FMLLog.log.debug("Merged {} smelting recipes to {} => {}", collisions.size(), Arrays.toString(merged.getMatchingStacks()), recipe.getDefaultResult());
+                }
+            }
+            else
+            {
+                FMLLog.log.info("Ignored smelting recipe with conflicting input: {} = {}", Arrays.toString(recipe.getInput().getMatchingStacks()), recipe.getDefaultResult());
+            }
+        }
+        else
+        {
+            if (recipe.getInput().getMatchingStacks().length > 0)
+                getRecipes().add(recipe);
+            else
+                FMLLog.log.info("Ignored smelting recipe due to empty matchingStacks in Ingredient: [] = {}", recipe.getDefaultResult());
+        }
     }
 
     @Override
@@ -71,17 +122,21 @@ public class SmeltingHandler extends FurnaceRecipes
     }
 
     @Override
+    @Deprecated
     public Map<ItemStack, ItemStack> getSmeltingList()
     {
         return staticView;
     }
 
-    public Map<ItemStack, ISmeltingRecipe> getRecipes()
+    /**
+     * this method is required to be able to set {@link SmeltingHandler#recipes} before the super-constructor returns
+     */
+    public List<ISmeltingRecipe> getRecipes()
     {
         if (recipes != null)
             return recipes;
-        recipes = Maps.newHashMap();
-        staticView = Maps.transformValues(recipes, ISmeltingRecipe::getGenericOutput);
+        recipes = Lists.newArrayList();
+        staticView = new VanillaView();
         return recipes;
     }
 
@@ -97,13 +152,72 @@ public class SmeltingHandler extends FurnaceRecipes
 
     public ISmeltingRecipe findRecipe(ItemStack input)
     {
-        for (Map.Entry<ItemStack, ISmeltingRecipe> entry : getRecipes().entrySet())
-        {
-            if (OreDictionary.itemMatches(entry.getKey(), input, false))
-            {
-                return entry.getValue();
-            }
-        }
+        for (ISmeltingRecipe recipe : getRecipes())
+            if (recipe.getInput().apply(input))
+                return recipe;
         return null;
+    }
+
+    /**
+     * Map is used for binary compatibility reasons<br>
+     * <br>
+     * The map is a transformed live view of the new recipe list where:<br>
+     * The keys correspond to the first ItemStack returned in {@link net.minecraft.item.crafting.Ingredient#getMatchingStacks()}<br>
+     * The values correspond to the static representation of the Recipe Outputs as described in {@link ISmeltingRecipe#getDefaultResult()}<br>
+     * <br>
+     * {@link VanillaView#remove(Object)} removes the first recipe where the passed ItemStack matches the recipes Ingredient<br>
+     * {@link VanillaView#put(ItemStack, ItemStack)} tries to add a basic recipe to the list with an experience value of 0.1
+     */
+    private class VanillaView extends AbstractMap<ItemStack, ItemStack>
+    {
+        @Override
+        public Set<Map.Entry<ItemStack, ItemStack>> entrySet()
+        {
+            return new AbstractSet<Entry<ItemStack, ItemStack>>()
+            {
+                @Override
+                public Iterator<Entry<ItemStack, ItemStack>> iterator()
+                {
+                    return Iterators.transform(recipes.iterator(), recipe ->
+                            new SimpleImmutableEntry<>(recipe.getInput().getMatchingStacks()[0], recipe.getDefaultResult()));
+                }
+
+                @Override
+                public int size()
+                {
+                    return recipes.size();
+                }
+            };
+        }
+
+        @Override
+        public Collection<ItemStack> values()
+        {
+            return Lists.transform(recipes, ISmeltingRecipe::getDefaultResult);
+        }
+
+        @Override
+        public ItemStack remove(Object key)
+        {
+            if (!(key instanceof ItemStack))
+                return null;
+            Iterator<ISmeltingRecipe> it = recipes.iterator();
+            for (ISmeltingRecipe recipe = it.next(); it.hasNext(); )
+            {
+                if (recipe.getInput().apply((ItemStack) key))
+                {
+                    it.remove();
+                    return recipe.getDefaultResult();
+                }
+            }
+            return null;
+        }
+
+        @Override
+        public ItemStack put(ItemStack key, ItemStack value)
+        {
+            addSmeltingRecipe(key, value, 0.1f);
+            return null;
+        }
     }
 }

--- a/src/main/resources/forge_at.cfg
+++ b/src/main/resources/forge_at.cfg
@@ -325,6 +325,9 @@ protected net.minecraft.item.crafting.Ingredient <init>([Lnet/minecraft/item/Ite
 # Crafting
 public net.minecraft.client.Minecraft func_193986_ar()V # populateSearchTreeManager
 
+# Smelting
+protected net.minecraft.item.crafting.FurnaceRecipes <init>()V
+
 # Advancements
 public net.minecraft.advancements.AdvancementManager field_192783_b # GSON
 public net.minecraft.advancements.CriteriaTriggers func_192118_a(Lnet/minecraft/advancements/ICriterionTrigger;)Lnet/minecraft/advancements/ICriterionTrigger; # register

--- a/src/test/java/net/minecraftforge/debug/gameplay/CustomSmeltingTest.java
+++ b/src/test/java/net/minecraftforge/debug/gameplay/CustomSmeltingTest.java
@@ -19,13 +19,21 @@
 
 package net.minecraftforge.debug.gameplay;
 
+import net.minecraft.init.Blocks;
 import net.minecraft.init.Items;
 import net.minecraft.item.ItemStack;
+import net.minecraft.item.crafting.Ingredient;
 import net.minecraft.potion.PotionUtils;
+import net.minecraft.util.NonNullList;
+import net.minecraftforge.common.smelting.BasicSmeltingRecipe;
 import net.minecraftforge.common.smelting.ISmeltingRecipe;
 import net.minecraftforge.common.smelting.SmeltingHandler;
 import net.minecraftforge.fml.common.Mod;
 import net.minecraftforge.fml.common.event.FMLPreInitializationEvent;
+import net.minecraftforge.oredict.OreDictionary;
+import net.minecraftforge.oredict.OreIngredient;
+
+import javax.annotation.Nonnull;
 
 @Mod(modid = CustomSmeltingTest.MODID, version = "1.0", acceptableRemoteVersions = "*")
 public class CustomSmeltingTest
@@ -38,17 +46,42 @@ public class CustomSmeltingTest
     public void preInit(FMLPreInitializationEvent event)
     {
         if (ENABLED)
-            SmeltingHandler.instance().addSmeltingRecipe(new ItemStack(Items.POTIONITEM), new PotionSmeltingRecipe());
+        {
+            SmeltingHandler handler = SmeltingHandler.instance();
+            handler.addSmeltingRecipe(new ItemStack(Blocks.COBBLESTONE), new ItemStack(Items.SKULL), 1); // ignored+warn(conflict)
+
+            Ingredient cobbleNglass = Ingredient.fromStacks(new ItemStack(Blocks.COBBLESTONE), new ItemStack(Items.GLASS_BOTTLE));
+            handler.addSmeltingRecipe(new BasicSmeltingRecipe(cobbleNglass, new ItemStack(Blocks.STONE), 1)); // merged
+
+            NonNullList<ItemStack> IIron = OreDictionary.getOres("ingotIron", false);
+            if (IIron.size() > 0)
+                handler.addSmeltingRecipe(new BasicSmeltingRecipe(new OreIngredient("oreIron"), IIron.get(0), 1)); // merged
+
+            handler.addSmeltingRecipe(new BasicSmeltingRecipe(new OreIngredient("oreBanana"), new ItemStack(Blocks.SAPLING), 1)); // ignored+warn(emtpy input)
+
+            SmeltingHandler.instance().addSmeltingRecipe(new PotionSmeltingRecipe()); // added
+        }
     }
 
     private static class PotionSmeltingRecipe implements ISmeltingRecipe
     {
 
         private static final ItemStack generic = new ItemStack(Items.LINGERING_POTION);
+        private static final Ingredient input = Ingredient.fromItem(Items.POTIONITEM);
 
+        @Nonnull
+        @Override
+        public Ingredient getInput()
+        {
+            return input;
+        }
+
+        @Nonnull
         @Override
         public ItemStack getSmeltingResult(ItemStack input)
         {
+            if (input.isEmpty())
+                return generic;
             // set the output item to be a lingering potion with the same effects as the input potion
             ItemStack out = new ItemStack(Items.LINGERING_POTION);
             PotionUtils.addPotionToItemStack(out, PotionUtils.getPotionFromItem(input));
@@ -60,12 +93,6 @@ public class CustomSmeltingTest
         public float getExperience(ItemStack input)
         {
             return input.getItem().getSmeltingExperience(input);
-        }
-
-        @Override
-        public ItemStack getGenericOutput()
-        {
-            return generic;
         }
     }
 }

--- a/src/test/java/net/minecraftforge/debug/gameplay/CustomSmeltingTest.java
+++ b/src/test/java/net/minecraftforge/debug/gameplay/CustomSmeltingTest.java
@@ -1,0 +1,71 @@
+/*
+ * Minecraft Forge
+ * Copyright (c) 2016-2018.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation version 2.1
+ * of the License.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+package net.minecraftforge.debug.gameplay;
+
+import net.minecraft.init.Items;
+import net.minecraft.item.ItemStack;
+import net.minecraft.potion.PotionUtils;
+import net.minecraftforge.common.smelting.ISmeltingRecipe;
+import net.minecraftforge.common.smelting.SmeltingHandler;
+import net.minecraftforge.fml.common.Mod;
+import net.minecraftforge.fml.common.event.FMLPreInitializationEvent;
+
+@Mod(modid = CustomSmeltingTest.MODID, version = "1.0", acceptableRemoteVersions = "*")
+public class CustomSmeltingTest
+{
+    public static final String MODID = "furnace_customsmelt_test";
+
+    private static final boolean ENABLED = false;
+
+    @Mod.EventHandler
+    public void preInit(FMLPreInitializationEvent event)
+    {
+        if (ENABLED)
+            SmeltingHandler.instance().addSmeltingRecipe(new ItemStack(Items.POTIONITEM), new PotionSmeltingRecipe());
+    }
+
+    private static class PotionSmeltingRecipe implements ISmeltingRecipe
+    {
+
+        private static final ItemStack generic = new ItemStack(Items.LINGERING_POTION);
+
+        @Override
+        public ItemStack getSmeltingResult(ItemStack input)
+        {
+            // set the output item to be a lingering potion with the same effects as the input potion
+            ItemStack out = new ItemStack(Items.LINGERING_POTION);
+            PotionUtils.addPotionToItemStack(out, PotionUtils.getPotionFromItem(input));
+            PotionUtils.appendEffects(out, PotionUtils.getEffectsFromStack(input));
+            return out;
+        }
+
+        @Override
+        public float getExperience(ItemStack input)
+        {
+            return input.getItem().getSmeltingExperience(input);
+        }
+
+        @Override
+        public ItemStack getGenericOutput()
+        {
+            return generic;
+        }
+    }
+}


### PR DESCRIPTION
Alternative implementation to #5038 without an event
Adds a way to have the output/experience of a SmeltingRecipe to be dependant on the Input

I removed the now unneccessary patches from the FurnaceRecipes class

Test Mod modified from #5038; it is somewhat broken as potions (sometimes) get applied twice yet it shows the feature working

Slight binary incompatibility if someone were to directly use `FurnaceRecipes.instance().getSmeltingList().add()` to register their recipes as the now return map doesnt support the put operation (clear/remove should work though)

@mezz something else required for jei to work with this?