### PR TITLE
Place Event (Implements #5054)

### DIFF
--- a/patches/minecraft/net/minecraft/entity/item/EntityFallingBlock.java.patch
+++ b/patches/minecraft/net/minecraft/entity/item/EntityFallingBlock.java.patch
@@ -8,7 +8,15 @@
                      if (!flag1 && BlockFalling.func_185759_i(this.field_70170_p.func_180495_p(new BlockPos(this.field_70165_t, this.field_70163_u - 0.009999999776482582D, this.field_70161_v))))
                      {
                          this.field_70122_E = false;
-@@ -189,7 +190,7 @@
+@@ -182,14 +183,14 @@
+ 
+                         if (!this.field_145808_f)
+                         {
+-                            if (this.field_70170_p.func_190527_a(block, blockpos1, true, EnumFacing.UP, (Entity)null) && (flag1 || !BlockFalling.func_185759_i(this.field_70170_p.func_180495_p(blockpos1.func_177977_b()))) && this.field_70170_p.func_180501_a(blockpos1, this.field_175132_d, 3))
++                            if (this.field_70170_p.func_190527_a(block, blockpos1, true, EnumFacing.UP, this) && (flag1 || !BlockFalling.func_185759_i(this.field_70170_p.func_180495_p(blockpos1.func_177977_b()))) && this.field_70170_p.func_180501_a(blockpos1, this.field_175132_d, 3))
+                             {
+                                 if (block instanceof BlockFalling)
+                                 {
                                      ((BlockFalling)block).func_176502_a_(this.field_70170_p, blockpos1, this.field_175132_d, iblockstate);
                                  }
  

--- a/patches/minecraft/net/minecraft/entity/monster/EntityEnderman.java.patch
+++ b/patches/minecraft/net/minecraft/entity/monster/EntityEnderman.java.patch
@@ -39,6 +39,15 @@
                  {
                      return false;
                  }
+@@ -508,7 +522,7 @@
+                 IBlockState iblockstate1 = world.func_180495_p(blockpos.func_177977_b());
+                 IBlockState iblockstate2 = this.field_179475_a.func_175489_ck();
+ 
+-                if (iblockstate2 != null && this.func_188518_a(world, blockpos, iblockstate2.func_177230_c(), iblockstate, iblockstate1))
++                if (iblockstate2 != null && this.func_188518_a(world, blockpos, iblockstate2.func_177230_c(), iblockstate, iblockstate1) && net.minecraftforge.event.ForgeEventFactory.onBlockPlace(field_179475_a, new net.minecraftforge.common.util.BlockSnapshot(world, blockpos, iblockstate2), net.minecraft.util.EnumFacing.UP).isCanceled())
+                 {
+                     world.func_180501_a(blockpos, iblockstate2, 3);
+                     this.field_179475_a.func_175490_a((IBlockState)null);
 @@ -551,7 +565,7 @@
                  {
                      return false;

--- a/patches/minecraft/net/minecraft/item/ItemBlock.java.patch
+++ b/patches/minecraft/net/minecraft/item/ItemBlock.java.patch
@@ -1,7 +1,11 @@
 --- ../src-base/minecraft/net/minecraft/item/ItemBlock.java
 +++ ../src-work/minecraft/net/minecraft/item/ItemBlock.java
-@@ -49,24 +49,12 @@
-         if (!itemstack.func_190926_b() && p_180614_1_.func_175151_a(p_180614_3_, p_180614_5_, itemstack) && p_180614_2_.func_190527_a(this.field_150939_a, p_180614_3_, false, p_180614_5_, (Entity)null))
+@@ -46,27 +46,15 @@
+ 
+         ItemStack itemstack = p_180614_1_.func_184586_b(p_180614_4_);
+ 
+-        if (!itemstack.func_190926_b() && p_180614_1_.func_175151_a(p_180614_3_, p_180614_5_, itemstack) && p_180614_2_.func_190527_a(this.field_150939_a, p_180614_3_, false, p_180614_5_, (Entity)null))
++        if (!itemstack.func_190926_b() && p_180614_1_.func_175151_a(p_180614_3_, p_180614_5_, itemstack) && p_180614_2_.func_190527_a(this.field_150939_a, p_180614_3_, false, p_180614_5_, p_180614_1_))
          {
              int i = this.func_77647_b(itemstack.func_77960_j());
 -            IBlockState iblockstate1 = this.field_150939_a.func_180642_a(p_180614_2_, p_180614_3_, p_180614_5_, p_180614_6_, p_180614_7_, p_180614_8_, i, p_180614_1_);
@@ -37,6 +41,15 @@
          {
              p_179222_3_ = EnumFacing.UP;
          }
+@@ -136,7 +124,7 @@
+             p_179222_2_ = p_179222_2_.func_177972_a(p_179222_3_);
+         }
+ 
+-        return p_179222_1_.func_190527_a(this.field_150939_a, p_179222_2_, false, p_179222_3_, (Entity)null);
++        return p_179222_1_.func_190527_a(this.field_150939_a, p_179222_2_, false, p_179222_3_, p_179222_4_);
+     }
+ 
+     public String func_77667_c(ItemStack p_77667_1_)
 @@ -171,6 +159,36 @@
  
      public Block func_179223_d()

--- a/patches/minecraft/net/minecraft/item/ItemBlockSpecial.java.patch
+++ b/patches/minecraft/net/minecraft/item/ItemBlockSpecial.java.patch
@@ -1,8 +1,11 @@
 --- ../src-base/minecraft/net/minecraft/item/ItemBlockSpecial.java
 +++ ../src-work/minecraft/net/minecraft/item/ItemBlockSpecial.java
-@@ -43,7 +43,7 @@
+@@ -41,9 +41,9 @@
  
-         if (!itemstack.func_190926_b() && p_180614_1_.func_175151_a(p_180614_3_, p_180614_5_, itemstack) && p_180614_2_.func_190527_a(this.field_150935_a, p_180614_3_, false, p_180614_5_, (Entity)null))
+         ItemStack itemstack = p_180614_1_.func_184586_b(p_180614_4_);
+ 
+-        if (!itemstack.func_190926_b() && p_180614_1_.func_175151_a(p_180614_3_, p_180614_5_, itemstack) && p_180614_2_.func_190527_a(this.field_150935_a, p_180614_3_, false, p_180614_5_, (Entity)null))
++        if (!itemstack.func_190926_b() && p_180614_1_.func_175151_a(p_180614_3_, p_180614_5_, itemstack) && p_180614_2_.func_190527_a(this.field_150935_a, p_180614_3_, false, p_180614_5_, p_180614_1_))
          {
 -            IBlockState iblockstate1 = this.field_150935_a.func_180642_a(p_180614_2_, p_180614_3_, p_180614_5_, p_180614_6_, p_180614_7_, p_180614_8_, 0, p_180614_1_);
 +            IBlockState iblockstate1 = this.field_150935_a.getStateForPlacement(p_180614_2_, p_180614_3_, p_180614_5_, p_180614_6_, p_180614_7_, p_180614_8_, 0, p_180614_1_, p_180614_4_);

--- a/patches/minecraft/net/minecraft/item/ItemRedstone.java.patch
+++ b/patches/minecraft/net/minecraft/item/ItemRedstone.java.patch
@@ -1,0 +1,11 @@
+--- ../src-base/minecraft/net/minecraft/item/ItemRedstone.java
++++ ../src-work/minecraft/net/minecraft/item/ItemRedstone.java
+@@ -25,7 +25,7 @@
+         BlockPos blockpos = flag ? p_180614_3_ : p_180614_3_.func_177972_a(p_180614_5_);
+         ItemStack itemstack = p_180614_1_.func_184586_b(p_180614_4_);
+ 
+-        if (p_180614_1_.func_175151_a(blockpos, p_180614_5_, itemstack) && p_180614_2_.func_190527_a(p_180614_2_.func_180495_p(blockpos).func_177230_c(), blockpos, false, p_180614_5_, (Entity)null) && Blocks.field_150488_af.func_176196_c(p_180614_2_, blockpos))
++        if (p_180614_1_.func_175151_a(blockpos, p_180614_5_, itemstack) && p_180614_2_.func_190527_a(p_180614_2_.func_180495_p(blockpos).func_177230_c(), blockpos, false, p_180614_5_, p_180614_1_) && Blocks.field_150488_af.func_176196_c(p_180614_2_, blockpos))
+         {
+             p_180614_2_.func_175656_a(blockpos, Blocks.field_150488_af.func_176223_P());
+ 

--- a/patches/minecraft/net/minecraft/world/World.java.patch
+++ b/patches/minecraft/net/minecraft/world/World.java.patch
@@ -899,16 +899,24 @@
          }
      }
  
-@@ -2958,7 +3178,7 @@
+@@ -2948,6 +3168,7 @@
+         IBlockState iblockstate1 = this.func_180495_p(p_190527_2_);
+         AxisAlignedBB axisalignedbb = p_190527_3_ ? null : p_190527_1_.func_176223_P().func_185890_d(this, p_190527_2_);
+ 
++        if (!((p_190527_5_ instanceof EntityPlayer) || !net.minecraftforge.event.ForgeEventFactory.onBlockPlace(p_190527_5_, new net.minecraftforge.common.util.BlockSnapshot(this, p_190527_2_, p_190527_1_.func_176223_P()), p_190527_4_).isCanceled())) return false;
+         if (axisalignedbb != Block.field_185506_k && !this.func_72917_a(axisalignedbb.func_186670_a(p_190527_2_), p_190527_5_))
+         {
+             return false;
+@@ -2958,7 +3179,7 @@
          }
          else
          {
 -            return iblockstate1.func_185904_a().func_76222_j() && p_190527_1_.func_176198_a(this, p_190527_2_, p_190527_4_);
-+            return iblockstate1.func_177230_c().func_176200_f(this, p_190527_2_) && p_190527_1_.func_176198_a(this, p_190527_2_, p_190527_4_);
++            return iblockstate1.func_177230_c().func_176200_f(this, p_190527_2_);
          }
      }
  
-@@ -3042,7 +3262,7 @@
+@@ -3042,7 +3263,7 @@
      public int func_175651_c(BlockPos p_175651_1_, EnumFacing p_175651_2_)
      {
          IBlockState iblockstate1 = this.func_180495_p(p_175651_1_);
@@ -917,7 +925,7 @@
      }
  
      public boolean func_175640_z(BlockPos p_175640_1_)
-@@ -3208,6 +3428,8 @@
+@@ -3208,6 +3429,8 @@
                      d2 *= ((Double)MoreObjects.firstNonNull(p_184150_11_.apply(entityplayer1), Double.valueOf(1.0D))).doubleValue();
                  }
  
@@ -926,7 +934,7 @@
                  if ((p_184150_9_ < 0.0D || Math.abs(entityplayer1.field_70163_u - p_184150_3_) < p_184150_9_ * p_184150_9_) && (p_184150_7_ < 0.0D || d1 < d2 * d2) && (d0 == -1.0D || d1 < d0))
                  {
                      d0 = d1;
-@@ -3269,7 +3491,7 @@
+@@ -3269,7 +3492,7 @@
  
      public long func_72905_C()
      {
@@ -935,7 +943,7 @@
      }
  
      public long func_82737_E()
-@@ -3279,17 +3501,17 @@
+@@ -3279,17 +3502,17 @@
  
      public long func_72820_D()
      {
@@ -956,7 +964,7 @@
  
          if (!this.func_175723_af().func_177746_a(blockpos1))
          {
-@@ -3301,7 +3523,7 @@
+@@ -3301,7 +3524,7 @@
  
      public void func_175652_B(BlockPos p_175652_1_)
      {
@@ -965,7 +973,7 @@
      }
  
      @SideOnly(Side.CLIENT)
-@@ -3321,12 +3543,18 @@
+@@ -3321,12 +3544,18 @@
  
          if (!this.field_72996_f.contains(p_72897_1_))
          {
@@ -984,7 +992,7 @@
          return true;
      }
  
-@@ -3428,8 +3656,7 @@
+@@ -3428,8 +3657,7 @@
  
      public boolean func_180502_D(BlockPos p_180502_1_)
      {
@@ -994,7 +1002,7 @@
      }
  
      @Nullable
-@@ -3490,12 +3717,12 @@
+@@ -3490,12 +3718,12 @@
  
      public int func_72800_K()
      {
@@ -1009,7 +1017,7 @@
      }
  
      public Random func_72843_D(int p_72843_1_, int p_72843_2_, int p_72843_3_)
-@@ -3539,7 +3766,7 @@
+@@ -3539,7 +3767,7 @@
      @SideOnly(Side.CLIENT)
      public double func_72919_O()
      {
@@ -1018,7 +1026,7 @@
      }
  
      public void func_175715_c(int p_175715_1_, BlockPos p_175715_2_, int p_175715_3_)
-@@ -3573,7 +3800,7 @@
+@@ -3573,7 +3801,7 @@
  
      public void func_175666_e(BlockPos p_175666_1_, Block p_175666_2_)
      {
@@ -1027,7 +1035,7 @@
          {
              BlockPos blockpos1 = p_175666_1_.func_177972_a(enumfacing);
  
-@@ -3581,18 +3808,15 @@
+@@ -3581,18 +3809,15 @@
              {
                  IBlockState iblockstate1 = this.func_180495_p(blockpos1);
  
@@ -1050,7 +1058,7 @@
                      }
                  }
              }
-@@ -3658,6 +3882,124 @@
+@@ -3658,6 +3883,124 @@
          return j2 >= -128 && j2 <= 128 && k2 >= -128 && k2 <= 128;
      }
  

--- a/src/main/java/net/minecraftforge/event/ForgeEventFactory.java
+++ b/src/main/java/net/minecraftforge/event/ForgeEventFactory.java
@@ -121,8 +121,8 @@ import net.minecraftforge.event.furnace.FurnaceFuelBurnTimeEvent;
 import net.minecraftforge.event.terraingen.ChunkGeneratorEvent;
 import net.minecraftforge.event.terraingen.PopulateChunkEvent;
 import net.minecraftforge.event.world.BlockEvent;
-import net.minecraftforge.event.world.BlockEvent.BaseMultiPlaceEvent;
-import net.minecraftforge.event.world.BlockEvent.BasePlaceEvent;
+import net.minecraftforge.event.world.BlockEvent.EntityMultiPlaceEvent;
+import net.minecraftforge.event.world.BlockEvent.EntityPlaceEvent;
 import net.minecraftforge.event.world.BlockEvent.CreateFluidSourceEvent;
 import net.minecraftforge.event.world.BlockEvent.MultiPlaceEvent;
 import net.minecraftforge.event.world.BlockEvent.NeighborNotifyEvent;
@@ -141,11 +141,11 @@ import javax.annotation.Nullable;
 public class ForgeEventFactory
 {
 
-    public static BaseMultiPlaceEvent onMultiBlockPlace(@Nullable Entity entity, List<BlockSnapshot> blockSnapshots, EnumFacing direction)
+    public static EntityMultiPlaceEvent onMultiBlockPlace(@Nullable Entity entity, List<BlockSnapshot> blockSnapshots, EnumFacing direction)
     {
         BlockSnapshot snap = blockSnapshots.get(0);
         IBlockState placedAgainst = snap.getWorld().getBlockState(snap.getPos().offset(direction.getOpposite()));
-        BaseMultiPlaceEvent event = new BaseMultiPlaceEvent(blockSnapshots, placedAgainst, entity);
+        EntityMultiPlaceEvent event = new EntityMultiPlaceEvent(blockSnapshots, placedAgainst, entity);
         MinecraftForge.EVENT_BUS.post(event);
         return event;
     }
@@ -159,10 +159,10 @@ public class ForgeEventFactory
         return event;
     }
 
-    public static BasePlaceEvent onBlockPlace(@Nullable Entity entity, @Nonnull BlockSnapshot blockSnapshot, @Nonnull EnumFacing direction)
+    public static EntityPlaceEvent onBlockPlace(@Nullable Entity entity, @Nonnull BlockSnapshot blockSnapshot, @Nonnull EnumFacing direction)
     {
         IBlockState placedAgainst = blockSnapshot.getWorld().getBlockState(blockSnapshot.getPos().offset(direction.getOpposite()));
-        BasePlaceEvent event = new BasePlaceEvent(blockSnapshot, placedAgainst, entity);
+        EntityPlaceEvent event = new BlockEvent.EntityPlaceEvent(blockSnapshot, placedAgainst, entity);
         MinecraftForge.EVENT_BUS.post(event);
         return event;
     }

--- a/src/main/java/net/minecraftforge/event/ForgeEventFactory.java
+++ b/src/main/java/net/minecraftforge/event/ForgeEventFactory.java
@@ -121,6 +121,8 @@ import net.minecraftforge.event.furnace.FurnaceFuelBurnTimeEvent;
 import net.minecraftforge.event.terraingen.ChunkGeneratorEvent;
 import net.minecraftforge.event.terraingen.PopulateChunkEvent;
 import net.minecraftforge.event.world.BlockEvent;
+import net.minecraftforge.event.world.BlockEvent.BaseMultiPlaceEvent;
+import net.minecraftforge.event.world.BlockEvent.BasePlaceEvent;
 import net.minecraftforge.event.world.BlockEvent.CreateFluidSourceEvent;
 import net.minecraftforge.event.world.BlockEvent.MultiPlaceEvent;
 import net.minecraftforge.event.world.BlockEvent.NeighborNotifyEvent;
@@ -139,6 +141,15 @@ import javax.annotation.Nullable;
 public class ForgeEventFactory
 {
 
+    public static BaseMultiPlaceEvent onMultiBlockPlace(@Nullable Entity entity, List<BlockSnapshot> blockSnapshots, EnumFacing direction)
+    {
+        BlockSnapshot snap = blockSnapshots.get(0);
+        IBlockState placedAgainst = snap.getWorld().getBlockState(snap.getPos().offset(direction.getOpposite()));
+        BaseMultiPlaceEvent event = new BaseMultiPlaceEvent(blockSnapshots, placedAgainst, entity);
+        MinecraftForge.EVENT_BUS.post(event);
+        return event;
+    }
+
     public static MultiPlaceEvent onPlayerMultiBlockPlace(EntityPlayer player, List<BlockSnapshot> blockSnapshots, EnumFacing direction, EnumHand hand)
     {
         BlockSnapshot snap = blockSnapshots.get(0);
@@ -147,6 +158,15 @@ public class ForgeEventFactory
         MinecraftForge.EVENT_BUS.post(event);
         return event;
     }
+
+    public static BasePlaceEvent onBlockPlace(@Nullable Entity entity, @Nonnull BlockSnapshot blockSnapshot, @Nonnull EnumFacing direction)
+    {
+        IBlockState placedAgainst = blockSnapshot.getWorld().getBlockState(blockSnapshot.getPos().offset(direction.getOpposite()));
+        BasePlaceEvent event = new BasePlaceEvent(blockSnapshot, placedAgainst, entity);
+        MinecraftForge.EVENT_BUS.post(event);
+        return event;
+    }
+
 
     public static PlaceEvent onPlayerBlockPlace(@Nonnull EntityPlayer player, @Nonnull BlockSnapshot blockSnapshot, @Nonnull EnumFacing direction, @Nonnull EnumHand hand)
     {

--- a/src/main/java/net/minecraftforge/event/world/BlockEvent.java
+++ b/src/main/java/net/minecraftforge/event/world/BlockEvent.java
@@ -22,14 +22,10 @@ package net.minecraftforge.event.world;
 import java.util.EnumSet;
 import java.util.List;
 
-import net.minecraft.block.Block;
 import net.minecraft.block.BlockPortal;
-import net.minecraft.block.material.Material;
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.enchantment.EnchantmentHelper;
 import net.minecraft.entity.Entity;
-import net.minecraft.entity.EntityLivingBase;
-import net.minecraft.entity.item.EntityFallingBlock;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.init.Enchantments;
 import net.minecraft.item.ItemStack;
@@ -173,14 +169,14 @@ public class BlockEvent extends Event
      * If a Block Place event is cancelled, the block will not be placed.
      */
     @Cancelable
-    public static class BasePlaceEvent extends BlockEvent
+    public static class EntityPlaceEvent extends BlockEvent
     {
         private final Entity entity;
         private final BlockSnapshot blockSnapshot;
         private final IBlockState placedBlock;
         private final IBlockState placedAgainst;
 
-        public BasePlaceEvent(@Nonnull BlockSnapshot blockSnapshot, @Nonnull IBlockState placedAgainst, @Nullable Entity entity)
+        public EntityPlaceEvent(@Nonnull BlockSnapshot blockSnapshot, @Nonnull IBlockState placedAgainst, @Nullable Entity entity)
         {
             super(blockSnapshot.getWorld(), blockSnapshot.getPos(), !(entity instanceof EntityPlayer) ? blockSnapshot.getReplacedBlock() : blockSnapshot.getCurrentBlock());
             this.entity = entity;
@@ -190,7 +186,7 @@ public class BlockEvent extends Event
 
             if (DEBUG)
             {
-                System.out.printf("Created BasePlaceEvent - [PlacedBlock: %s ][PlacedAgainst: %s ][Entity: %s ]\n", getPlacedBlock(), placedAgainst, entity);
+                System.out.printf("Created EntityPlaceEvent - [PlacedBlock: %s ][PlacedAgainst: %s ][Entity: %s ]\n", getPlacedBlock(), placedAgainst, entity);
             }
         }
 
@@ -207,7 +203,7 @@ public class BlockEvent extends Event
      * If a Block Place event is cancelled, the block will not be placed.
      */
     @Cancelable
-    public static class PlaceEvent extends BasePlaceEvent
+    public static class PlaceEvent extends EntityPlaceEvent
     {
         private final EntityPlayer player;
         private final EnumHand hand;
@@ -237,16 +233,16 @@ public class BlockEvent extends Event
      * block.
      */
     @Cancelable
-    public static class BaseMultiPlaceEvent extends BasePlaceEvent
+    public static class EntityMultiPlaceEvent extends EntityPlaceEvent
     {
         private final List<BlockSnapshot> blockSnapshots;
 
-        public BaseMultiPlaceEvent(@Nonnull List<BlockSnapshot> blockSnapshots, @Nonnull IBlockState placedAgainst, @Nullable Entity entity) {
+        public EntityMultiPlaceEvent(@Nonnull List<BlockSnapshot> blockSnapshots, @Nonnull IBlockState placedAgainst, @Nullable Entity entity) {
             super(blockSnapshots.get(0), placedAgainst, entity);
             this.blockSnapshots = ImmutableList.copyOf(blockSnapshots);
             if (DEBUG)
             {
-                System.out.printf("Created BaseMultiPlaceEvent - [PlacedAgainst: %s ][Entity: %s ]\n", placedAgainst, entity);
+                System.out.printf("Created EntityMultiPlaceEvent - [PlacedAgainst: %s ][Entity: %s ]\n", placedAgainst, entity);
             }
         }
 

--- a/src/main/java/net/minecraftforge/event/world/BlockEvent.java
+++ b/src/main/java/net/minecraftforge/event/world/BlockEvent.java
@@ -203,6 +203,7 @@ public class BlockEvent extends Event
      * If a Block Place event is cancelled, the block will not be placed.
      */
     @Cancelable
+    @Deprecated // Remove in 1.13
     public static class PlaceEvent extends EntityPlaceEvent
     {
         private final EntityPlayer player;

--- a/src/test/java/net/minecraftforge/debug/block/BasePlaceEventTest.java
+++ b/src/test/java/net/minecraftforge/debug/block/BasePlaceEventTest.java
@@ -1,0 +1,47 @@
+/*
+ * Minecraft Forge
+ * Copyright (c) 2016-2018.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation version 2.1
+ * of the License.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+package net.minecraftforge.debug.block;
+
+import net.minecraft.entity.item.EntityFallingBlock;
+import net.minecraft.init.Blocks;
+import net.minecraftforge.event.world.BlockEvent;
+import net.minecraftforge.fml.common.Mod;
+import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
+
+@Mod(modid = BasePlaceEventTest.MOD_ID, name = "BaseBlockPlaceEvent test mod", version = "1.0", acceptableRemoteVersions = "*")
+@Mod.EventBusSubscriber
+public class BasePlaceEventTest
+{
+    static final String MOD_ID = "base_block_place_event_test";
+    static final boolean ENABLED = true;
+
+    @SubscribeEvent
+    public static void onBlockPlaced(BlockEvent.BasePlaceEvent event)
+    {
+        if (!ENABLED)
+        {
+            return;
+        }
+
+        if (event.getEntity() instanceof EntityFallingBlock) {
+            event.setCanceled(true);
+        }
+    }
+}

--- a/src/test/java/net/minecraftforge/debug/block/BasePlaceEventTest.java
+++ b/src/test/java/net/minecraftforge/debug/block/BasePlaceEventTest.java
@@ -20,7 +20,6 @@
 package net.minecraftforge.debug.block;
 
 import net.minecraft.entity.item.EntityFallingBlock;
-import net.minecraft.init.Blocks;
 import net.minecraftforge.event.world.BlockEvent;
 import net.minecraftforge.fml.common.Mod;
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
@@ -33,7 +32,7 @@ public class BasePlaceEventTest
     static final boolean ENABLED = true;
 
     @SubscribeEvent
-    public static void onBlockPlaced(BlockEvent.BasePlaceEvent event)
+    public static void onBlockPlaced(BlockEvent.EntityPlaceEvent event)
     {
         if (!ENABLED)
         {


### PR DESCRIPTION
Pull request changes the BlockPlace event to allow more use cases in modding. It adds the ability to change the default behavior of block placement for actions such Falling block being placed, Endermen Block Placement, and any other areas which call the world's placement check method.

Changes have been made in various locations that call the world's placement check method due to missing data when the method was called. All calls that have been edited were edited to add data to the final parameter of the call. An entity parameter that states what entity placed the block always had null passed to it for an unknown reason. It has been updated to pass known entity data.

The locations of these changes includes:
- EntityFallingBlock
- ItemBlock
- ItemBlockSpecial
- ItemRedstone

Additionally, changes have been made to the ForgeEventFactory to keep method naming as well as documentation consistent with the new BlockPlace event behavior. The old methods have been redirected to the new methods and deprecated. All references within the existing code have been updated to use the new method. A deprecation note has been added, stating to use the new method.

--------------

The PlaceEvent test mod code has been updated to show EntityFallingBlock placements. The test mod continues to remain disabled by default due to performance reasons. The performance hit of the test does increase with these changes due to the effect applied upon block placement for falling blocks.

--------------
EDIT:
> 
> Unfortunately the changes introduces the possibility for null pointer exceptions to occur within mods if they use the event's `getPlayer()` method without any checks. For this reason, it has been deprecated and marked with `@Nullable`.
> 
> In addition to the deprecation of `getPlayer()`, the `getHand()` method has been updated with the `@Nullable` annotation due to the possibility returning null.

This is no longer the case.

