### PR TITLE
1.13 API change proposal: Generification of the capability providers' context parameters.

### DIFF
--- a/patches/minecraft/net/minecraft/entity/Entity.java.patch
+++ b/patches/minecraft/net/minecraft/entity/Entity.java.patch
@@ -5,7 +5,7 @@
  import org.apache.logging.log4j.Logger;
  
 -public abstract class Entity implements ICommandSender
-+public abstract class Entity implements ICommandSender, net.minecraftforge.common.capabilities.ICapabilitySerializable<NBTTagCompound>
++public abstract class Entity implements ICommandSender, net.minecraftforge.common.capabilities.ICapabilitySerializable<net.minecraftforge.common.capabilities.context.EntityPart, NBTTagCompound>
  {
      private static final Logger field_184243_a = LogManager.getLogger();
      private static final List<ItemStack> field_190535_b = Collections.<ItemStack>emptyList();
@@ -41,7 +41,7 @@
 +    private NBTTagCompound customEntityData;
 +    public boolean captureDrops = false;
 +    public java.util.ArrayList<EntityItem> capturedDrops = new java.util.ArrayList<EntityItem>();
-+    private net.minecraftforge.common.capabilities.CapabilityDispatcher capabilities;
++    private net.minecraftforge.common.capabilities.CapabilityDispatcher<net.minecraftforge.common.capabilities.context.EntityPart> capabilities;
 +
      public int func_145782_y()
      {
@@ -368,14 +368,14 @@
 +    }
 +
 +    @Override
-+    public boolean hasCapability(net.minecraftforge.common.capabilities.Capability<?> capability, @Nullable net.minecraft.util.EnumFacing facing)
++    public boolean hasCapability(net.minecraftforge.common.capabilities.Capability<?> capability, @Nullable net.minecraftforge.common.capabilities.context.EntityPart facing)
 +    {
 +        return capabilities != null && capabilities.hasCapability(capability, facing);
 +    }
 +
 +    @Override
 +    @Nullable
-+    public <T> T getCapability(net.minecraftforge.common.capabilities.Capability<T> capability, @Nullable net.minecraft.util.EnumFacing facing)
++    public <T> T getCapability(net.minecraftforge.common.capabilities.Capability<T> capability, @Nullable net.minecraftforge.common.capabilities.context.EntityPart facing)
 +    {
 +        return capabilities == null ? null : capabilities.getCapability(capability, facing);
 +    }

--- a/patches/minecraft/net/minecraft/entity/EntityLivingBase.java.patch
+++ b/patches/minecraft/net/minecraft/entity/EntityLivingBase.java.patch
@@ -401,19 +401,19 @@
 +    @SuppressWarnings("unchecked")
 +    @Override
 +    @Nullable
-+    public <T> T getCapability(net.minecraftforge.common.capabilities.Capability<T> capability, @Nullable net.minecraft.util.EnumFacing facing)
++    public <T> T getCapability(net.minecraftforge.common.capabilities.Capability<T> capability, @Nullable net.minecraftforge.common.capabilities.context.EntityPart facing)
 +    {
 +        if (capability == net.minecraftforge.items.CapabilityItemHandler.ITEM_HANDLER_CAPABILITY)
 +        {
 +            if (facing == null) return (T) joinedHandler;
-+            else if (facing.func_176740_k().func_176720_b()) return (T) handHandler;
-+            else if (facing.func_176740_k().func_176722_c()) return (T) armorHandler;
++            else if (facing.isHands()) return (T) handHandler;
++            else if (facing.isArmor()) return (T) armorHandler;
 +        }
 +        return super.getCapability(capability, facing);
 +    }
 +
 +    @Override
-+    public boolean hasCapability(net.minecraftforge.common.capabilities.Capability<?> capability, @Nullable net.minecraft.util.EnumFacing facing)
++    public boolean hasCapability(net.minecraftforge.common.capabilities.Capability<?> capability, @Nullable net.minecraftforge.common.capabilities.context.EntityPart facing)
 +    {
 +        return capability == net.minecraftforge.items.CapabilityItemHandler.ITEM_HANDLER_CAPABILITY || super.hasCapability(capability, facing);
 +    }

--- a/patches/minecraft/net/minecraft/entity/item/EntityMinecartContainer.java.patch
+++ b/patches/minecraft/net/minecraft/entity/item/EntityMinecartContainer.java.patch
@@ -43,7 +43,7 @@
 +    @SuppressWarnings("unchecked")
 +    @Override
 +    @Nullable
-+    public <T> T getCapability(net.minecraftforge.common.capabilities.Capability<T> capability, @Nullable net.minecraft.util.EnumFacing facing)
++    public <T> T getCapability(net.minecraftforge.common.capabilities.Capability<T> capability, @Nullable net.minecraftforge.common.capabilities.context.EntityPart facing)
 +    {
 +        if (capability == net.minecraftforge.items.CapabilityItemHandler.ITEM_HANDLER_CAPABILITY)
 +        {
@@ -53,7 +53,7 @@
 +    }
 +
 +    @Override
-+    public boolean hasCapability(net.minecraftforge.common.capabilities.Capability<?> capability, @Nullable net.minecraft.util.EnumFacing facing)
++    public boolean hasCapability(net.minecraftforge.common.capabilities.Capability<?> capability, @Nullable net.minecraftforge.common.capabilities.context.EntityPart facing)
 +    {
 +        return capability == net.minecraftforge.items.CapabilityItemHandler.ITEM_HANDLER_CAPABILITY || super.hasCapability(capability, facing);
 +    }

--- a/patches/minecraft/net/minecraft/entity/passive/AbstractHorse.java.patch
+++ b/patches/minecraft/net/minecraft/entity/passive/AbstractHorse.java.patch
@@ -19,14 +19,14 @@
 +    @SuppressWarnings("unchecked")
 +    @Override
 +    @Nullable
-+    public <T> T getCapability(net.minecraftforge.common.capabilities.Capability<T> capability, @Nullable net.minecraft.util.EnumFacing facing)
++    public <T> T getCapability(net.minecraftforge.common.capabilities.Capability<T> capability, @Nullable net.minecraftforge.common.capabilities.context.EntityPart facing)
 +    {
 +        if (capability == net.minecraftforge.items.CapabilityItemHandler.ITEM_HANDLER_CAPABILITY) return (T) itemHandler;
 +        return super.getCapability(capability, facing);
 +    }
 +
 +    @Override
-+    public boolean hasCapability(net.minecraftforge.common.capabilities.Capability<?> capability, @Nullable net.minecraft.util.EnumFacing facing)
++    public boolean hasCapability(net.minecraftforge.common.capabilities.Capability<?> capability, @Nullable net.minecraftforge.common.capabilities.context.EntityPart facing)
 +    {
 +        return capability == net.minecraftforge.items.CapabilityItemHandler.ITEM_HANDLER_CAPABILITY || super.hasCapability(capability, facing);
 +    }

--- a/patches/minecraft/net/minecraft/entity/player/EntityPlayer.java.patch
+++ b/patches/minecraft/net/minecraft/entity/player/EntityPlayer.java.patch
@@ -624,19 +624,19 @@
 +    @SuppressWarnings("unchecked")
 +    @Override
 +    @Nullable
-+    public <T> T getCapability(net.minecraftforge.common.capabilities.Capability<T> capability, @Nullable net.minecraft.util.EnumFacing facing)
++    public <T> T getCapability(net.minecraftforge.common.capabilities.Capability<T> capability, @Nullable net.minecraftforge.common.capabilities.context.EntityPart facing)
 +    {
 +        if (capability == net.minecraftforge.items.CapabilityItemHandler.ITEM_HANDLER_CAPABILITY)
 +        {
 +            if (facing == null) return (T) playerJoinedHandler;
-+            else if (facing.func_176740_k().func_176720_b()) return (T) playerMainHandler;
-+            else if (facing.func_176740_k().func_176722_c()) return (T) playerEquipmentHandler;
++            else if (facing.isHands()) return (T) playerMainHandler;
++            else if (facing.isArmor()) return (T) playerEquipmentHandler;
 +        }
 +        return super.getCapability(capability, facing);
 +    }
 +
 +    @Override
-+    public boolean hasCapability(net.minecraftforge.common.capabilities.Capability<?> capability, @Nullable net.minecraft.util.EnumFacing facing)
++    public boolean hasCapability(net.minecraftforge.common.capabilities.Capability<?> capability, @Nullable net.minecraftforge.common.capabilities.context.EntityPart facing)
 +    {
 +        return capability == net.minecraftforge.items.CapabilityItemHandler.ITEM_HANDLER_CAPABILITY || super.hasCapability(capability, facing);
 +    }

--- a/patches/minecraft/net/minecraft/item/Item.java.patch
+++ b/patches/minecraft/net/minecraft/item/Item.java.patch
@@ -722,7 +722,7 @@
 +     * @return A holder instance associated with this ItemStack where you can hold capabilities for the life of this item.
 +     */
 +    @Nullable
-+    public net.minecraftforge.common.capabilities.ICapabilityProvider initCapabilities(ItemStack stack, @Nullable NBTTagCompound nbt)
++    public net.minecraftforge.common.capabilities.ICapabilityProvider<EntityEquipmentSlot> initCapabilities(ItemStack stack, @Nullable NBTTagCompound nbt)
 +    {
 +        return null;
 +    }

--- a/patches/minecraft/net/minecraft/item/ItemBucket.java.patch
+++ b/patches/minecraft/net/minecraft/item/ItemBucket.java.patch
@@ -15,7 +15,7 @@
      }
 +
 +    @Override
-+    public net.minecraftforge.common.capabilities.ICapabilityProvider initCapabilities(ItemStack stack, @Nullable net.minecraft.nbt.NBTTagCompound nbt) {
++    public net.minecraftforge.common.capabilities.ICapabilityProvider<net.minecraft.inventory.EntityEquipmentSlot> initCapabilities(ItemStack stack, @Nullable net.minecraft.nbt.NBTTagCompound nbt) {
 +        if (this.getClass() == ItemBucket.class)
 +        {
 +            return new net.minecraftforge.fluids.capability.wrappers.FluidBucketWrapper(stack);

--- a/patches/minecraft/net/minecraft/item/ItemBucketMilk.java.patch
+++ b/patches/minecraft/net/minecraft/item/ItemBucketMilk.java.patch
@@ -25,7 +25,7 @@
      }
  
 +    @Override
-+    public net.minecraftforge.common.capabilities.ICapabilityProvider initCapabilities(ItemStack stack, net.minecraft.nbt.NBTTagCompound nbt) {
++    public net.minecraftforge.common.capabilities.ICapabilityProvider<net.minecraft.inventory.EntityEquipmentSlot> initCapabilities(ItemStack stack, net.minecraft.nbt.NBTTagCompound nbt) {
 +        return new net.minecraftforge.fluids.capability.wrappers.FluidBucketWrapper(stack);
 +    }
 +

--- a/patches/minecraft/net/minecraft/item/ItemStack.java.patch
+++ b/patches/minecraft/net/minecraft/item/ItemStack.java.patch
@@ -5,7 +5,7 @@
  import net.minecraftforge.fml.relauncher.SideOnly;
  
 -public final class ItemStack
-+public final class ItemStack implements net.minecraftforge.common.capabilities.ICapabilitySerializable<NBTTagCompound>
++public final class ItemStack implements net.minecraftforge.common.capabilities.ICapabilitySerializable<EntityEquipmentSlot, NBTTagCompound>
  {
      public static final ItemStack field_190927_a = new ItemStack((Item)null);
      public static final DecimalFormat field_111284_a = new DecimalFormat("#.##");
@@ -14,7 +14,7 @@
      private boolean field_179551_k;
  
 +    private net.minecraftforge.registries.IRegistryDelegate<Item> delegate;
-+    private net.minecraftforge.common.capabilities.CapabilityDispatcher capabilities;
++    private net.minecraftforge.common.capabilities.CapabilityDispatcher<EntityEquipmentSlot> capabilities;
 +    private NBTTagCompound capNBT;
 +
      public ItemStack(Block p_i1876_1_)
@@ -238,14 +238,14 @@
      }
 +
 +    @Override
-+    public boolean hasCapability(net.minecraftforge.common.capabilities.Capability<?> capability, @Nullable net.minecraft.util.EnumFacing facing)
++    public boolean hasCapability(net.minecraftforge.common.capabilities.Capability<?> capability, @Nullable EntityEquipmentSlot facing)
 +    {
 +        return this.field_190928_g  || this.capabilities == null ? false : this.capabilities.hasCapability(capability, facing);
 +    }
 +
 +    @Override
 +    @Nullable
-+    public <T> T getCapability(net.minecraftforge.common.capabilities.Capability<T> capability, @Nullable net.minecraft.util.EnumFacing facing)
++    public <T> T getCapability(net.minecraftforge.common.capabilities.Capability<T> capability, @Nullable EntityEquipmentSlot facing)
 +    {
 +        return this.field_190928_g  || this.capabilities == null ? null : this.capabilities.getCapability(capability, facing);
 +    }
@@ -293,7 +293,7 @@
 +        if (item != null)
 +        {
 +            this.delegate = item.delegate;
-+            net.minecraftforge.common.capabilities.ICapabilityProvider provider = item.initCapabilities(this, this.capNBT);
++            net.minecraftforge.common.capabilities.ICapabilityProvider<EntityEquipmentSlot> provider = item.initCapabilities(this, this.capNBT);
 +            this.capabilities = net.minecraftforge.event.ForgeEventFactory.gatherCapabilities(this, provider);
 +            if (this.capNBT != null && this.capabilities != null) this.capabilities.deserializeNBT(this.capNBT);
 +        }

--- a/patches/minecraft/net/minecraft/tileentity/TileEntity.java.patch
+++ b/patches/minecraft/net/minecraft/tileentity/TileEntity.java.patch
@@ -5,7 +5,7 @@
  import org.apache.logging.log4j.Logger;
  
 -public abstract class TileEntity
-+public abstract class TileEntity implements net.minecraftforge.common.capabilities.ICapabilitySerializable<NBTTagCompound>
++public abstract class TileEntity implements net.minecraftforge.common.capabilities.ICapabilitySerializable<net.minecraft.util.EnumFacing, NBTTagCompound>
  {
      private static final Logger field_145852_a = LogManager.getLogger();
      private static final RegistryNamespaced < ResourceLocation, Class <? extends TileEntity >> field_190562_f = new RegistryNamespaced < ResourceLocation, Class <? extends TileEntity >> ();
@@ -237,7 +237,7 @@
 +        return false;
 +    }
 +
-+    private net.minecraftforge.common.capabilities.CapabilityDispatcher capabilities;
++    private net.minecraftforge.common.capabilities.CapabilityDispatcher<net.minecraft.util.EnumFacing> capabilities;
 +    public TileEntity()
 +    {
 +        capabilities = net.minecraftforge.event.ForgeEventFactory.gatherCapabilities(this);

--- a/patches/minecraft/net/minecraft/village/Village.java.patch
+++ b/patches/minecraft/net/minecraft/village/Village.java.patch
@@ -5,7 +5,7 @@
  import net.minecraft.world.World;
  
 -public class Village
-+public class Village implements net.minecraftforge.common.capabilities.ICapabilitySerializable<NBTTagCompound>
++public class Village implements net.minecraftforge.common.capabilities.ICapabilitySerializable<Void, NBTTagCompound>
  {
      private World field_75586_a;
      private final List<VillageDoorInfo> field_75584_b = Lists.<VillageDoorInfo>newArrayList();
@@ -181,14 +181,14 @@
      }
 +
 +    /* ======================================== FORGE START =====================================*/
-+    private net.minecraftforge.common.capabilities.CapabilityDispatcher capabilities;
-+    public boolean hasCapability(net.minecraftforge.common.capabilities.Capability<?> capability, @Nullable net.minecraft.util.EnumFacing facing)
++    private net.minecraftforge.common.capabilities.CapabilityDispatcher<Void> capabilities;
++    public boolean hasCapability(net.minecraftforge.common.capabilities.Capability<?> capability, @Nullable Void facing)
 +    {
 +        return capabilities == null ? false : capabilities.hasCapability(capability, facing);
 +    }
 +
 +    @Nullable
-+    public <T> T getCapability(net.minecraftforge.common.capabilities.Capability<T> capability, @Nullable net.minecraft.util.EnumFacing facing)
++    public <T> T getCapability(net.minecraftforge.common.capabilities.Capability<T> capability, @Nullable Void facing)
 +    {
 +        return capabilities == null ? null : capabilities.getCapability(capability, facing);
 +    }

--- a/patches/minecraft/net/minecraft/world/World.java.patch
+++ b/patches/minecraft/net/minecraft/world/World.java.patch
@@ -5,7 +5,7 @@
  import net.minecraftforge.fml.relauncher.SideOnly;
  
 -public abstract class World implements IBlockAccess
-+public abstract class World implements IBlockAccess, net.minecraftforge.common.capabilities.ICapabilityProvider
++public abstract class World implements IBlockAccess, net.minecraftforge.common.capabilities.ICapabilityProvider<Void>
  {
 +    /**
 +     * Used in the getEntitiesWithinAABB functions to expand the search area for entities.
@@ -24,7 +24,7 @@
 +    public boolean restoringBlockSnapshots = false;
 +    public boolean captureBlockSnapshots = false;
 +    public java.util.ArrayList<net.minecraftforge.common.util.BlockSnapshot> capturedBlockSnapshots = new java.util.ArrayList<net.minecraftforge.common.util.BlockSnapshot>();
-+    private net.minecraftforge.common.capabilities.CapabilityDispatcher capabilities;
++    private net.minecraftforge.common.capabilities.CapabilityDispatcher<Void> capabilities;
 +    private net.minecraftforge.common.util.WorldCapabilityData capabilityData;
 +
      protected World(ISaveHandler p_i45749_1_, WorldInfo p_i45749_2_, WorldProvider p_i45749_3_, Profiler p_i45749_4_, boolean p_i45749_5_)
@@ -1098,7 +1098,7 @@
 +
 +    protected void initCapabilities()
 +    {
-+        net.minecraftforge.common.capabilities.ICapabilityProvider parent = field_73011_w.initCapabilities();
++        net.minecraftforge.common.capabilities.ICapabilityProvider<Void> parent = field_73011_w.initCapabilities();
 +        capabilities = net.minecraftforge.event.ForgeEventFactory.gatherCapabilities(this, parent);
 +        net.minecraftforge.common.util.WorldCapabilityData data = (net.minecraftforge.common.util.WorldCapabilityData)perWorldStorage.func_75742_a(net.minecraftforge.common.util.WorldCapabilityData.class, net.minecraftforge.common.util.WorldCapabilityData.ID);
 +        if (data == null)
@@ -1113,13 +1113,13 @@
 +        }
 +    }
 +    @Override
-+    public boolean hasCapability(net.minecraftforge.common.capabilities.Capability<?> capability, @Nullable EnumFacing facing)
++    public boolean hasCapability(net.minecraftforge.common.capabilities.Capability<?> capability, @Nullable Void facing)
 +    {
 +        return capabilities == null ? false : capabilities.hasCapability(capability, facing);
 +    }
 +    @Override
 +    @Nullable
-+    public <T> T getCapability(net.minecraftforge.common.capabilities.Capability<T> capability, @Nullable EnumFacing facing)
++    public <T> T getCapability(net.minecraftforge.common.capabilities.Capability<T> capability, @Nullable Void facing)
 +    {
 +        return capabilities == null ? null : capabilities.getCapability(capability, facing);
 +    }

--- a/patches/minecraft/net/minecraft/world/WorldProvider.java.patch
+++ b/patches/minecraft/net/minecraft/world/WorldProvider.java.patch
@@ -240,7 +240,7 @@
 +     * @return initial holder for capabilities on the world
 +     */
 +    @Nullable
-+    public net.minecraftforge.common.capabilities.ICapabilityProvider initCapabilities() {
++    public net.minecraftforge.common.capabilities.ICapabilityProvider<Void> initCapabilities() {
 +        return null;
 +    }
 +

--- a/patches/minecraft/net/minecraft/world/chunk/Chunk.java.patch
+++ b/patches/minecraft/net/minecraft/world/chunk/Chunk.java.patch
@@ -5,7 +5,7 @@
  import org.apache.logging.log4j.Logger;
  
 -public class Chunk
-+public class Chunk implements net.minecraftforge.common.capabilities.ICapabilityProvider
++public class Chunk implements net.minecraftforge.common.capabilities.ICapabilityProvider<Void>
  {
      private static final Logger field_150817_t = LogManager.getLogger();
      public static final ExtendedBlockStorage field_186036_a = null;
@@ -352,20 +352,20 @@
 +        }
 +    }
 +
-+    private final net.minecraftforge.common.capabilities.CapabilityDispatcher capabilities;
++    private final net.minecraftforge.common.capabilities.CapabilityDispatcher<Void> capabilities;
 +    @Nullable
-+    public net.minecraftforge.common.capabilities.CapabilityDispatcher getCapabilities()
++    public net.minecraftforge.common.capabilities.CapabilityDispatcher<Void> getCapabilities()
 +    {
 +        return capabilities;
 +    }
 +    @Override
-+    public boolean hasCapability(net.minecraftforge.common.capabilities.Capability<?> capability, @Nullable EnumFacing facing)
++    public boolean hasCapability(net.minecraftforge.common.capabilities.Capability<?> capability, @Nullable Void facing)
 +    {
 +        return capabilities == null ? false : capabilities.hasCapability(capability, facing);
 +    }
 +    @Override
 +    @Nullable
-+    public <T> T getCapability(net.minecraftforge.common.capabilities.Capability<T> capability, @Nullable EnumFacing facing)
++    public <T> T getCapability(net.minecraftforge.common.capabilities.Capability<T> capability, @Nullable Void facing)
 +    {
 +        return capabilities == null ? null : capabilities.getCapability(capability, facing);
 +    }

--- a/src/main/java/net/minecraftforge/common/capabilities/CapabilityDispatcher.java
+++ b/src/main/java/net/minecraftforge/common/capabilities/CapabilityDispatcher.java
@@ -42,21 +42,21 @@ import net.minecraftforge.common.util.INBTSerializable;
  * Internally the handlers are baked into arrays for fast iteration.
  * The ResourceLocations will be used for the NBT Key when serializing.
  */
-public final class CapabilityDispatcher implements INBTSerializable<NBTTagCompound>, ICapabilityProvider
+public final class CapabilityDispatcher<TContext> implements INBTSerializable<NBTTagCompound>, ICapabilityProvider<TContext>
 {
-    private ICapabilityProvider[] caps;
+    private ICapabilityProvider<TContext>[] caps;
     private INBTSerializable<NBTBase>[] writers;
     private String[] names;
 
-    public CapabilityDispatcher(Map<ResourceLocation, ICapabilityProvider> list)
+    public CapabilityDispatcher(Map<ResourceLocation, ICapabilityProvider<TContext>> list)
     {
         this(list, null);
     }
 
     @SuppressWarnings("unchecked")
-    public CapabilityDispatcher(Map<ResourceLocation, ICapabilityProvider> list, @Nullable ICapabilityProvider parent)
+    public CapabilityDispatcher(Map<ResourceLocation, ICapabilityProvider<TContext>> list, @Nullable ICapabilityProvider<TContext> parent)
     {
-        List<ICapabilityProvider> lstCaps = Lists.newArrayList();
+        List<ICapabilityProvider<TContext>> lstCaps = Lists.newArrayList();
         List<INBTSerializable<NBTBase>> lstWriters = Lists.newArrayList();
         List<String> lstNames = Lists.newArrayList();
 
@@ -70,9 +70,9 @@ public final class CapabilityDispatcher implements INBTSerializable<NBTTagCompou
             }
         }
 
-        for (Map.Entry<ResourceLocation, ICapabilityProvider> entry : list.entrySet())
+        for (Map.Entry<ResourceLocation, ICapabilityProvider<TContext>> entry : list.entrySet())
         {
-            ICapabilityProvider prov = entry.getValue();
+            ICapabilityProvider<TContext> prov = entry.getValue();
             lstCaps.add(prov);
             if (prov instanceof INBTSerializable)
             {
@@ -87,11 +87,11 @@ public final class CapabilityDispatcher implements INBTSerializable<NBTTagCompou
     }
 
     @Override
-    public boolean hasCapability(@Nonnull Capability<?> capability, @Nullable EnumFacing facing)
+    public boolean hasCapability(@Nonnull Capability<?> capability, @Nullable TContext context)
     {
-        for (ICapabilityProvider cap : caps)
+        for (ICapabilityProvider<TContext> cap : caps)
         {
-            if (cap.hasCapability(capability, facing))
+            if (cap.hasCapability(capability, context))
             {
                 return true;
             }
@@ -101,11 +101,11 @@ public final class CapabilityDispatcher implements INBTSerializable<NBTTagCompou
 
     @Override
     @Nullable
-    public <T> T getCapability(@Nonnull Capability<T> capability, @Nullable EnumFacing facing)
+    public <T> T getCapability(@Nonnull Capability<T> capability, @Nullable TContext context)
     {
-        for (ICapabilityProvider cap : caps)
+        for (ICapabilityProvider<TContext> cap : caps)
         {
-            T ret = cap.getCapability(capability, facing);
+            T ret = cap.getCapability(capability, context);
             if (ret != null)
             {
                 return ret;
@@ -137,7 +137,7 @@ public final class CapabilityDispatcher implements INBTSerializable<NBTTagCompou
         }
     }
 
-    public boolean areCompatible(CapabilityDispatcher other) //Called from ItemStack to compare equality.
+    public boolean areCompatible(CapabilityDispatcher<TContext> other) //Called from ItemStack to compare equality.
     {                                                        // Only compares serializeable caps.
         if (other == null) return this.writers.length == 0;  // Done this way so we can do some pre-checks before doing the costly NBT serialization and compare
         if (this.writers.length == 0) return other.writers.length == 0;

--- a/src/main/java/net/minecraftforge/common/capabilities/ICapabilityProvider.java
+++ b/src/main/java/net/minecraftforge/common/capabilities/ICapabilityProvider.java
@@ -26,7 +26,11 @@ import javax.annotation.Nullable;
 
 import net.minecraft.util.EnumFacing;
 
-public interface ICapabilityProvider
+/**
+ * @param <TContext> The type that provides a context for the capability.
+ *                  In TileEntities, this will be an EnumFacing for the side that is being interacted with.
+ */
+public interface ICapabilityProvider<TContext>
 {
     /**
      * Determines if this object has support for the capability in question on the specific side.
@@ -47,7 +51,7 @@ public interface ICapabilityProvider
      * @return True if this object supports the capability. If true, then {@link #getCapability(Capability, EnumFacing)} 
      * must not return null.
      */
-    boolean hasCapability(@Nonnull Capability<?> capability, @Nullable EnumFacing facing);
+    boolean hasCapability(@Nonnull Capability<?> capability, @Nullable TContext facing);
 
     /**
      * Retrieves the handler for the capability requested on the specific side.
@@ -61,9 +65,9 @@ public interface ICapabilityProvider
      * @param capability The capability to check
      * @param facing The Side to check from, 
      *   <strong>CAN BE NULL</strong>. Null is defined to represent 'internal' or 'self'
-     * @return The requested capability. Must <strong>NOT</strong> be null when {@link #hasCapability(Capability, EnumFacing)} 
+     * @return The requested capability. Must <strong>NOT</strong> be null when {@link #hasCapability(Capability, TContext)} 
      * would return true. 
      */
     @Nullable
-    <T> T getCapability(@Nonnull Capability<T> capability, @Nullable EnumFacing facing);
+    <T> T getCapability(@Nonnull Capability<T> capability, @Nullable TContext facing);
 }

--- a/src/main/java/net/minecraftforge/common/capabilities/ICapabilitySerializable.java
+++ b/src/main/java/net/minecraftforge/common/capabilities/ICapabilitySerializable.java
@@ -23,4 +23,4 @@ import net.minecraft.nbt.NBTBase;
 import net.minecraftforge.common.util.INBTSerializable;
 
 //Just a mix of the two, useful in patches to lower the size.
-public interface ICapabilitySerializable<T extends NBTBase> extends ICapabilityProvider, INBTSerializable<T>{}
+public interface ICapabilitySerializable<TContext, T extends NBTBase> extends ICapabilityProvider<TContext>, INBTSerializable<T>{}

--- a/src/main/java/net/minecraftforge/common/capabilities/context/EntityPart.java
+++ b/src/main/java/net/minecraftforge/common/capabilities/context/EntityPart.java
@@ -1,0 +1,74 @@
+/*
+ * Minecraft Forge
+ * Copyright (c) 2016-2018.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation version 2.1
+ * of the License.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+package net.minecraftforge.common.capabilities.context;
+
+// Not an enum to allow mods to add more possible body parts
+public class EntityPart
+{
+    // Generic parts
+    public static final EntityPart HEAD = new EntityPart("head");
+    public static final EntityPart CHEST = new EntityPart("chest");
+    public static final EntityPart FEET = new EntityPart("feet");
+
+    // Biped parts
+    public static final EntityPart ARMS = new EntityPart("arms");
+    public static final EntityPart LEGS = new EntityPart("legs");
+
+    // Quadruped parts
+    public static final EntityPart FRONT_LEGS = new EntityPart("front_legs");
+    public static final EntityPart HIND_LEGS = new EntityPart("hind_legs");
+
+    // Other parts
+    public static final EntityPart TAIL = new EntityPart("tail");
+
+    public final String name;
+
+    public EntityPart(String name)
+    {
+        this.name = name;
+    }
+
+    @Override
+    public boolean equals(Object obj)
+    {
+        return obj instanceof EntityPart && equals((EntityPart)obj);
+    }
+
+    public boolean equals(EntityPart other)
+    {
+        return (name== null && other.name == null) || (name != null && name.equals(other.name));
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return name.hashCode();
+    }
+
+    public boolean isHands()
+    {
+        return equals(ARMS);
+    }
+
+    public boolean isArmor()
+    {
+        return equals(HEAD) || equals(CHEST) || equals(LEGS) || equals(FEET);
+    }
+}

--- a/src/main/java/net/minecraftforge/common/model/animation/CapabilityAnimation.java
+++ b/src/main/java/net/minecraftforge/common/model/animation/CapabilityAnimation.java
@@ -51,7 +51,7 @@ public class CapabilityAnimation
         }, AnimationStateMachine::getMissing);
     }
 
-    public static class DefaultItemAnimationCapabilityProvider implements ICapabilityProvider
+    public static class DefaultItemAnimationCapabilityProvider<TContext> implements ICapabilityProvider<TContext>
     {
         private final IAnimationStateMachine asm;
 
@@ -61,14 +61,14 @@ public class CapabilityAnimation
         }
 
         @Override
-        public boolean hasCapability(@Nonnull Capability<?> capability, @Nullable EnumFacing facing)
+        public boolean hasCapability(@Nonnull Capability<?> capability, @Nullable TContext facing)
         {
             return capability == ANIMATION_CAPABILITY;
         }
 
         @Override
         @Nullable
-        public <T> T getCapability(@Nonnull Capability<T> capability, @Nullable EnumFacing facing)
+        public <T> T getCapability(@Nonnull Capability<T> capability, @Nullable TContext facing)
         {
             if(capability == ANIMATION_CAPABILITY)
             {

--- a/src/main/java/net/minecraftforge/event/AttachCapabilitiesEvent.java
+++ b/src/main/java/net/minecraftforge/event/AttachCapabilitiesEvent.java
@@ -35,11 +35,11 @@ import net.minecraftforge.fml.common.eventhandler.GenericEvent;
  * Please note that as this is fired for ALL object creations efficient code is recommended.
  * And if possible use one of the sub-classes to filter your intended objects.
  */
-public class AttachCapabilitiesEvent<T> extends GenericEvent<T>
+public class AttachCapabilitiesEvent<T extends ICapabilityProvider<TContext>, TContext> extends GenericEvent<T>
 {
     private final T obj;
-    private final Map<ResourceLocation, ICapabilityProvider> caps = Maps.newLinkedHashMap();
-    private final Map<ResourceLocation, ICapabilityProvider> view = Collections.unmodifiableMap(caps);
+    private final Map<ResourceLocation, ICapabilityProvider<TContext>> caps = Maps.newLinkedHashMap();
+    private final Map<ResourceLocation, ICapabilityProvider<TContext>> view = Collections.unmodifiableMap(caps);
 
     public AttachCapabilitiesEvent(Class<T> type, T obj)
     {
@@ -63,7 +63,7 @@ public class AttachCapabilitiesEvent<T> extends GenericEvent<T>
      * @param key The name of owner of this capability provider.
      * @param cap The capability provider
      */
-    public void addCapability(ResourceLocation key, ICapabilityProvider cap)
+    public void addCapability(ResourceLocation key, ICapabilityProvider<TContext> cap)
     {
         if (caps.containsKey(key))
             throw new IllegalStateException("Duplicate Capability Key: " + key  + " " + cap);
@@ -73,7 +73,7 @@ public class AttachCapabilitiesEvent<T> extends GenericEvent<T>
     /**
      * A unmodifiable view of the capabilities that will be attached to this object.
      */
-    public Map<ResourceLocation, ICapabilityProvider> getCapabilities()
+    public Map<ResourceLocation, ICapabilityProvider<TContext>> getCapabilities()
     {
         return view;
     }

--- a/src/main/java/net/minecraftforge/event/ForgeEventFactory.java
+++ b/src/main/java/net/minecraftforge/event/ForgeEventFactory.java
@@ -42,6 +42,7 @@ import net.minecraft.entity.projectile.EntityArrow;
 import net.minecraft.entity.projectile.EntityFireball;
 import net.minecraft.entity.projectile.EntityThrowable;
 import net.minecraft.init.Blocks;
+import net.minecraft.inventory.EntityEquipmentSlot;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraft.tileentity.MobSpawnerBaseLogic;
@@ -80,6 +81,7 @@ import net.minecraftforge.client.event.RenderBlockOverlayEvent.OverlayType;
 import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.common.capabilities.CapabilityDispatcher;
 import net.minecraftforge.common.capabilities.ICapabilityProvider;
+import net.minecraftforge.common.capabilities.context.EntityPart;
 import net.minecraftforge.common.util.BlockSnapshot;
 import net.minecraftforge.event.brewing.PlayerBrewedPotionEvent;
 import net.minecraftforge.event.brewing.PotionBrewEvent;
@@ -625,46 +627,46 @@ public class ForgeEventFactory
     }
 
     @Nullable
-    public static CapabilityDispatcher gatherCapabilities(TileEntity tileEntity)
+    public static CapabilityDispatcher<EnumFacing> gatherCapabilities(TileEntity tileEntity)
     {
-        return gatherCapabilities(new AttachCapabilitiesEvent<TileEntity>(TileEntity.class, tileEntity), null);
+        return gatherCapabilities(new AttachCapabilitiesEvent<>(TileEntity.class, tileEntity), null);
     }
 
     @Nullable
-    public static CapabilityDispatcher gatherCapabilities(Entity entity)
+    public static CapabilityDispatcher<EntityPart> gatherCapabilities(Entity entity)
     {
-        return gatherCapabilities(new AttachCapabilitiesEvent<Entity>(Entity.class, entity), null);
+        return gatherCapabilities(new AttachCapabilitiesEvent<>(Entity.class, entity), null);
     }
 
     @Nullable
-    public static CapabilityDispatcher gatherCapabilities(Village village)
+    public static CapabilityDispatcher<Void> gatherCapabilities(Village village)
     {
-        return gatherCapabilities(new AttachCapabilitiesEvent<Village>(Village.class, village), null);
+        return gatherCapabilities(new AttachCapabilitiesEvent<>(Village.class, village), null);
     }
 
     @Nullable
-    public static CapabilityDispatcher gatherCapabilities(ItemStack stack, ICapabilityProvider parent)
+    public static CapabilityDispatcher<EntityEquipmentSlot> gatherCapabilities(ItemStack stack, ICapabilityProvider<EntityEquipmentSlot> parent)
     {
-        return gatherCapabilities(new AttachCapabilitiesEvent<ItemStack>(ItemStack.class, stack), parent);
+        return gatherCapabilities(new AttachCapabilitiesEvent<>(ItemStack.class, stack), parent);
     }
 
     @Nullable
-    public static CapabilityDispatcher gatherCapabilities(World world, ICapabilityProvider parent)
+    public static CapabilityDispatcher<Void> gatherCapabilities(World world, ICapabilityProvider<Void> parent)
     {
-        return gatherCapabilities(new AttachCapabilitiesEvent<World>(World.class, world), parent);
+        return gatherCapabilities(new AttachCapabilitiesEvent<>(World.class, world), parent);
     }
 
     @Nullable
-    public static CapabilityDispatcher gatherCapabilities(Chunk chunk)
+    public static CapabilityDispatcher<Void> gatherCapabilities(Chunk chunk)
     {
-        return gatherCapabilities(new AttachCapabilitiesEvent<Chunk>(Chunk.class, chunk), null);
+        return gatherCapabilities(new AttachCapabilitiesEvent<>(Chunk.class, chunk), null);
     }
 
     @Nullable
-    private static CapabilityDispatcher gatherCapabilities(AttachCapabilitiesEvent<?> event, @Nullable ICapabilityProvider parent)
+    private static <TContext> CapabilityDispatcher<TContext> gatherCapabilities(AttachCapabilitiesEvent<? extends ICapabilityProvider<TContext>, TContext> event, @Nullable ICapabilityProvider<TContext> parent)
     {
         MinecraftForge.EVENT_BUS.post(event);
-        return event.getCapabilities().size() > 0 || parent != null ? new CapabilityDispatcher(event.getCapabilities(), parent) : null;
+        return event.getCapabilities().size() > 0 || parent != null ? new CapabilityDispatcher<>(event.getCapabilities(), parent) : null;
     }
 
     public static boolean fireSleepingLocationCheck(EntityPlayer player, BlockPos sleepingLocation)

--- a/src/main/java/net/minecraftforge/fluids/UniversalBucket.java
+++ b/src/main/java/net/minecraftforge/fluids/UniversalBucket.java
@@ -23,6 +23,7 @@ import net.minecraft.block.BlockDispenser;
 import net.minecraft.creativetab.CreativeTabs;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.init.Items;
+import net.minecraft.inventory.EntityEquipmentSlot;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
@@ -296,7 +297,7 @@ public class UniversalBucket extends Item
     }
 
     @Override
-    public ICapabilityProvider initCapabilities(@Nonnull ItemStack stack, NBTTagCompound nbt)
+    public ICapabilityProvider<EntityEquipmentSlot> initCapabilities(@Nonnull ItemStack stack, NBTTagCompound nbt)
     {
         return new FluidBucketWrapper(stack);
     }

--- a/src/main/java/net/minecraftforge/fluids/capability/ItemFluidContainer.java
+++ b/src/main/java/net/minecraftforge/fluids/capability/ItemFluidContainer.java
@@ -19,6 +19,7 @@
 
 package net.minecraftforge.fluids.capability;
 
+import net.minecraft.inventory.EntityEquipmentSlot;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
@@ -46,7 +47,7 @@ public class ItemFluidContainer extends Item
     }
 
     @Override
-    public ICapabilityProvider initCapabilities(@Nonnull ItemStack stack, @Nullable NBTTagCompound nbt)
+    public ICapabilityProvider<EntityEquipmentSlot> initCapabilities(@Nonnull ItemStack stack, @Nullable NBTTagCompound nbt)
     {
         return new FluidHandlerItemStack(stack, capacity);
     }

--- a/src/main/java/net/minecraftforge/fluids/capability/templates/FluidHandlerItemStack.java
+++ b/src/main/java/net/minecraftforge/fluids/capability/templates/FluidHandlerItemStack.java
@@ -22,6 +22,7 @@ package net.minecraftforge.fluids.capability.templates;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
+import net.minecraft.inventory.EntityEquipmentSlot;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.util.EnumFacing;
@@ -42,7 +43,7 @@ import net.minecraftforge.fluids.capability.IFluidTankProperties;
  * Additional examples are provided to enable consumable fluid containers (see {@link Consumable}),
  * fluid containers with different empty and full items (see {@link SwapEmpty},
  */
-public class FluidHandlerItemStack implements IFluidHandlerItem, ICapabilityProvider
+public class FluidHandlerItemStack implements IFluidHandlerItem, ICapabilityProvider<EntityEquipmentSlot>
 {
     public static final String FLUID_NBT_KEY = "Fluid";
 
@@ -201,7 +202,7 @@ public class FluidHandlerItemStack implements IFluidHandlerItem, ICapabilityProv
     }
 
     @Override
-    public boolean hasCapability(@Nonnull Capability<?> capability, @Nullable EnumFacing facing)
+    public boolean hasCapability(@Nonnull Capability<?> capability, @Nullable EntityEquipmentSlot equipmentSlot)
     {
         return capability == CapabilityFluidHandler.FLUID_HANDLER_ITEM_CAPABILITY;
     }
@@ -209,7 +210,7 @@ public class FluidHandlerItemStack implements IFluidHandlerItem, ICapabilityProv
     @SuppressWarnings("unchecked")
     @Override
     @Nullable
-    public <T> T getCapability(@Nonnull Capability<T> capability, @Nullable EnumFacing facing)
+    public <T> T getCapability(@Nonnull Capability<T> capability, @Nullable EntityEquipmentSlot equipmentSlot)
     {
         return capability == CapabilityFluidHandler.FLUID_HANDLER_ITEM_CAPABILITY ? (T) this : null;
     }

--- a/src/main/java/net/minecraftforge/fluids/capability/templates/FluidHandlerItemStackSimple.java
+++ b/src/main/java/net/minecraftforge/fluids/capability/templates/FluidHandlerItemStackSimple.java
@@ -22,6 +22,7 @@ package net.minecraftforge.fluids.capability.templates;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
+import net.minecraft.inventory.EntityEquipmentSlot;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.util.EnumFacing;
@@ -39,7 +40,7 @@ import net.minecraftforge.fluids.capability.CapabilityFluidHandler;
  *
  * This implementation only allows item containers to be fully filled or emptied, similar to vanilla buckets.
  */
-public class FluidHandlerItemStackSimple implements IFluidHandlerItem, ICapabilityProvider
+public class FluidHandlerItemStackSimple implements IFluidHandlerItem, ICapabilityProvider<EntityEquipmentSlot>
 {
     public static final String FLUID_NBT_KEY = "Fluid";
 
@@ -178,7 +179,7 @@ public class FluidHandlerItemStackSimple implements IFluidHandlerItem, ICapabili
     }
 
     @Override
-    public boolean hasCapability(@Nonnull Capability<?> capability, @Nullable EnumFacing facing)
+    public boolean hasCapability(@Nonnull Capability<?> capability, @Nullable EntityEquipmentSlot equipmentSlot)
     {
         return capability == CapabilityFluidHandler.FLUID_HANDLER_ITEM_CAPABILITY;
     }
@@ -186,7 +187,7 @@ public class FluidHandlerItemStackSimple implements IFluidHandlerItem, ICapabili
     @SuppressWarnings("unchecked")
     @Override
     @Nullable
-    public <T> T getCapability(@Nonnull Capability<T> capability, @Nullable EnumFacing facing)
+    public <T> T getCapability(@Nonnull Capability<T> capability, @Nullable EntityEquipmentSlot equipmentSlot)
     {
         return capability == CapabilityFluidHandler.FLUID_HANDLER_ITEM_CAPABILITY ? (T) this : null;
     }

--- a/src/main/java/net/minecraftforge/fluids/capability/wrappers/FluidBucketWrapper.java
+++ b/src/main/java/net/minecraftforge/fluids/capability/wrappers/FluidBucketWrapper.java
@@ -23,6 +23,7 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
 import net.minecraft.init.Items;
+import net.minecraft.inventory.EntityEquipmentSlot;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemBucketMilk;
 import net.minecraft.item.ItemStack;
@@ -43,7 +44,7 @@ import net.minecraftforge.fluids.capability.CapabilityFluidHandler;
  * Wrapper for vanilla and forge buckets.
  * Swaps between empty bucket and filled bucket of the correct type.
  */
-public class FluidBucketWrapper implements IFluidHandlerItem, ICapabilityProvider
+public class FluidBucketWrapper implements IFluidHandlerItem, ICapabilityProvider<EntityEquipmentSlot>
 {
     @Nonnull
     protected ItemStack container;
@@ -178,14 +179,14 @@ public class FluidBucketWrapper implements IFluidHandlerItem, ICapabilityProvide
     }
 
     @Override
-    public boolean hasCapability(@Nonnull Capability<?> capability, @Nullable EnumFacing facing)
+    public boolean hasCapability(@Nonnull Capability<?> capability, @Nullable EntityEquipmentSlot equipmentSlot)
     {
         return capability == CapabilityFluidHandler.FLUID_HANDLER_ITEM_CAPABILITY;
     }
 
     @Override
     @Nullable
-    public <T> T getCapability(@Nonnull Capability<T> capability, @Nullable EnumFacing facing)
+    public <T> T getCapability(@Nonnull Capability<T> capability, @Nullable EntityEquipmentSlot equipmentSlot)
     {
         if (capability == CapabilityFluidHandler.FLUID_HANDLER_ITEM_CAPABILITY)
         {

--- a/src/test/java/net/minecraftforge/debug/client/model/AnimatedModelTest.java
+++ b/src/test/java/net/minecraftforge/debug/client/model/AnimatedModelTest.java
@@ -36,6 +36,7 @@ import net.minecraft.entity.EntityLiving;
 import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.entity.SharedMonsterAttributes;
 import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.inventory.EntityEquipmentSlot;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemBlock;
 import net.minecraft.item.ItemStack;
@@ -57,6 +58,7 @@ import net.minecraftforge.common.animation.ITimeValue;
 import net.minecraftforge.common.animation.TimeValues.VariableValue;
 import net.minecraftforge.common.capabilities.Capability;
 import net.minecraftforge.common.capabilities.ICapabilityProvider;
+import net.minecraftforge.common.capabilities.context.EntityPart;
 import net.minecraftforge.common.model.animation.CapabilityAnimation;
 import net.minecraftforge.common.model.animation.IAnimationStateMachine;
 import net.minecraftforge.common.property.ExtendedBlockState;
@@ -263,7 +265,7 @@ public class AnimatedModelTest
             new ItemBlock(TEST_BLOCK)
             {
                 @Override
-                public ICapabilityProvider initCapabilities(ItemStack stack, @Nullable NBTTagCompound nbt)
+                public ICapabilityProvider<EntityEquipmentSlot> initCapabilities(ItemStack stack, @Nullable NBTTagCompound nbt)
                 {
                     return new ItemAnimationHolder();
                 }
@@ -346,7 +348,7 @@ public class AnimatedModelTest
         }
     }
 
-    private static class ItemAnimationHolder implements ICapabilityProvider
+    private static class ItemAnimationHolder implements ICapabilityProvider<EntityEquipmentSlot>
     {
         private final VariableValue cycleLength = new VariableValue(4);
 
@@ -355,14 +357,14 @@ public class AnimatedModelTest
         ));
 
         @Override
-        public boolean hasCapability(@Nonnull Capability<?> capability, @Nullable EnumFacing facing)
+        public boolean hasCapability(@Nonnull Capability<?> capability, @Nullable EntityEquipmentSlot equipmentSlot)
         {
             return capability == CapabilityAnimation.ANIMATION_CAPABILITY;
         }
 
         @Override
         @Nullable
-        public <T> T getCapability(@Nonnull Capability<T> capability, @Nullable EnumFacing facing)
+        public <T> T getCapability(@Nonnull Capability<T> capability, @Nullable EntityEquipmentSlot equipmentSlot)
         {
             if (capability == CapabilityAnimation.ANIMATION_CAPABILITY)
             {
@@ -543,24 +545,24 @@ public class AnimatedModelTest
         }
 
         @Override
-        public boolean hasCapability(@Nonnull Capability<?> capability, @Nullable EnumFacing side)
+        public boolean hasCapability(@Nonnull Capability<?> capability, @Nullable EntityPart entityPart)
         {
             if (capability == CapabilityAnimation.ANIMATION_CAPABILITY)
             {
                 return true;
             }
-            return super.hasCapability(capability, side);
+            return super.hasCapability(capability, entityPart);
         }
 
         @Override
         @Nullable
-        public <T> T getCapability(@Nonnull Capability<T> capability, @Nullable EnumFacing side)
+        public <T> T getCapability(@Nonnull Capability<T> capability, @Nullable EntityPart entityPart)
         {
             if (capability == CapabilityAnimation.ANIMATION_CAPABILITY)
             {
                 return CapabilityAnimation.ANIMATION_CAPABILITY.cast(asm);
             }
-            return super.getCapability(capability, side);
+            return super.getCapability(capability, entityPart);
         }
     }
 }

--- a/src/test/java/net/minecraftforge/debug/fluid/FluidPlacementTest.java
+++ b/src/test/java/net/minecraftforge/debug/fluid/FluidPlacementTest.java
@@ -28,6 +28,7 @@ import net.minecraft.client.renderer.block.statemap.StateMapperBase;
 import net.minecraft.client.util.ITooltipFlag;
 import net.minecraft.creativetab.CreativeTabs;
 import net.minecraft.init.Blocks;
+import net.minecraft.inventory.EntityEquipmentSlot;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemBlock;
 import net.minecraft.item.ItemBucket;
@@ -197,7 +198,7 @@ public class FluidPlacementTest
         }
 
         @Override
-        public ICapabilityProvider initCapabilities(ItemStack stack, @Nullable NBTTagCompound nbt)
+        public ICapabilityProvider<EntityEquipmentSlot> initCapabilities(ItemStack stack, @Nullable NBTTagCompound nbt)
         {
             return new EmptyContainerHandler(stack);
         }
@@ -312,7 +313,7 @@ public class FluidPlacementTest
         }
 
         @Override
-        public ICapabilityProvider initCapabilities(ItemStack stack, NBTTagCompound nbt)
+        public ICapabilityProvider<EntityEquipmentSlot> initCapabilities(ItemStack stack, NBTTagCompound nbt)
         {
             return new FluidHandlerItemStack.SwapEmpty(stack, new ItemStack(EmptyFluidContainer.instance), 1000);
         }

--- a/src/test/java/net/minecraftforge/debug/gameplay/NoBedSleepingTest.java
+++ b/src/test/java/net/minecraftforge/debug/gameplay/NoBedSleepingTest.java
@@ -43,6 +43,7 @@ import net.minecraftforge.common.capabilities.Capability.IStorage;
 import net.minecraftforge.common.capabilities.CapabilityInject;
 import net.minecraftforge.common.capabilities.CapabilityManager;
 import net.minecraftforge.common.capabilities.ICapabilitySerializable;
+import net.minecraftforge.common.capabilities.context.EntityPart;
 import net.minecraftforge.event.AttachCapabilitiesEvent;
 import net.minecraftforge.event.RegistryEvent;
 import net.minecraftforge.event.entity.player.PlayerWakeUpEvent;
@@ -92,26 +93,26 @@ public class NoBedSleepingTest
     public static class EventHandler
     {
         @SubscribeEvent
-        public void onEntityConstruct(AttachCapabilitiesEvent<Entity> evt)
+        public void onEntityConstruct(AttachCapabilitiesEvent<Entity, EntityPart> evt)
         {
             if (!(evt.getObject() instanceof EntityPlayer))
             {
                 return;
             }
 
-            evt.addCapability(new ResourceLocation(MODID, "IExtraSleeping"), new ICapabilitySerializable<NBTPrimitive>()
+            evt.addCapability(new ResourceLocation(MODID, "IExtraSleeping"), new ICapabilitySerializable<EntityPart, NBTPrimitive>()
             {
                 IExtraSleeping inst = SLEEP_CAP.getDefaultInstance();
 
                 @Override
-                public boolean hasCapability(@Nonnull Capability<?> capability, @Nullable EnumFacing facing)
+                public boolean hasCapability(@Nonnull Capability<?> capability, @Nullable EntityPart entityPart)
                 {
                     return capability == SLEEP_CAP;
                 }
 
                 @Override
                 @Nullable
-                public <T> T getCapability(@Nonnull Capability<T> capability, @Nullable EnumFacing facing)
+                public <T> T getCapability(@Nonnull Capability<T> capability, @Nullable EntityPart entityPart)
                 {
                     return capability == SLEEP_CAP ? SLEEP_CAP.<T>cast(inst) : null;
                 }

--- a/src/test/java/net/minecraftforge/debug/world/ChunkCapabilityTest.java
+++ b/src/test/java/net/minecraftforge/debug/world/ChunkCapabilityTest.java
@@ -115,7 +115,7 @@ public class ChunkCapabilityTest
         }
     }
 
-    public static class PollutionProvider implements ICapabilitySerializable<NBTBase>
+    public static class PollutionProvider implements ICapabilitySerializable<Void, NBTBase>
     {
         private final IPollution pollution;
 
@@ -135,13 +135,13 @@ public class ChunkCapabilityTest
         }
 
         @Override
-        public boolean hasCapability(@Nonnull Capability<?> capability, @Nullable EnumFacing facing) {
+        public boolean hasCapability(@Nonnull Capability<?> capability, @Nullable Void nothing) {
             return capability == POLLUTION_CAPABILITY;
         }
 
         @Nullable
         @Override
-        public <T> T getCapability(@Nonnull Capability<T> capability, @Nullable EnumFacing facing) {
+        public <T> T getCapability(@Nonnull Capability<T> capability, @Nullable Void nothing) {
             return capability == POLLUTION_CAPABILITY ? POLLUTION_CAPABILITY.cast(pollution) : null;
         }
     }
@@ -149,7 +149,7 @@ public class ChunkCapabilityTest
     public static class EventBusHandler
     {
         @SubscribeEvent
-        public void onAttachChunkCapabilities(AttachCapabilitiesEvent<Chunk> event)
+        public void onAttachChunkCapabilities(AttachCapabilitiesEvent<Chunk, Void> event)
         {
             event.addCapability(new ResourceLocation(MODID, "pollution"), new PollutionProvider(event.getObject()));
         }

--- a/src/test/java/net/minecraftforge/debug/world/WorldCapabilityTest.java
+++ b/src/test/java/net/minecraftforge/debug/world/WorldCapabilityTest.java
@@ -62,7 +62,7 @@ public class WorldCapabilityTest
     public static class NormalEventHandler
     {
         @SubscribeEvent
-        public void attatchTimer(AttachCapabilitiesEvent<World> event)
+        public void attatchTimer(AttachCapabilitiesEvent<World, Void> event)
         {
             if (!event.getObject().isRemote && !event.getObject().provider.isNether())
             {
@@ -190,19 +190,19 @@ public class WorldCapabilityTest
         }
     }
 
-    public static class RainTimerProvider implements ICapabilitySerializable<NBTTagCompound>
+    public static class RainTimerProvider implements ICapabilitySerializable<Void, NBTTagCompound>
     {
         private IRainTimer timer = TIMER_CAP.getDefaultInstance();
 
         @Override
-        public boolean hasCapability(@Nonnull Capability<?> capability, @Nullable EnumFacing facing)
+        public boolean hasCapability(@Nonnull Capability<?> capability, @Nullable Void nothing)
         {
             return capability == TIMER_CAP;
         }
 
         @Override
         @Nullable
-        public <T> T getCapability(@Nonnull Capability<T> capability, @Nullable EnumFacing facing)
+        public <T> T getCapability(@Nonnull Capability<T> capability, @Nullable Void nothing)
         {
             return capability == TIMER_CAP ? TIMER_CAP.<T>cast(this.timer) : null;
         }


### PR DESCRIPTION
This 1.12 PR is for review and comments. It will be recreated on 1.13 when available, unless it is rejected before then.

## Rationale

Currently ICapabilityProviders all use an EnumFacing value as context. This makes no sense outside TEs. IMO, all attempts to explain this making sense sound like excuses.

Other context values would make more sense in other capabilities, so why not make the API allow that?

## Implementation details

So far, these are the context types I have come up with. They are open to change, based on feedback.

| Capability container | Context type        |
|----------------------|---------------------|
| Entity               | `EntityPart` *1         |
| ItemStack            | `EntityEquipmentSlot` *2 |
| TileEntity           | `EnumFacing`          |
| Village              | `Void` *3                |
| World                | `Void` *3                |
| Chunk                | `Void` *3                |

***1** Regarding EntityPart: This is a custom class I created as a test. It allows returning different capabilities for arms, legs, etc. such as you would for a block that auto-equips. An alternative to this would be EntityEquipmentSlot, but that's an enum, which isn't friendly to mods declaring new places.

***2** Regarding ItemStacks: I see 3 possible choices for this:

1. Use the equipment slot (only works for vanilla equipment slots, and says nothing about inventory items' positions)
2. Use an Integer value representing the slot in the vanilla inventory and equipment (works for all vanilla slots, but doesn't support mod extension slots)
3. Use a custom class that represents a slot, which could include an API to get/set the contents of that slot, so that mod-added slots can provide their own accessor objects.
    * This might look like `SlotAccessot {getContents() setContents(stack)}` for which forge provides `VanillaInventorySlot` and `VanillaEquipmentSlot` which would have a number and a EntityEquipmentSlot property respectively.

***3** Regarding other capability containers: I used Void as a placeholder, because I couldn't come up with any context data useful for capabilitites. Feel free to suggest something!

## TODO

- [ ] Write tests and documentation (will do when I know that this is wanted and won't be rejected after making that effort)