### PR TITLE
Fix saved toolbars not working with non-vanilla items

### DIFF
--- a/src/main/java/net/minecraftforge/common/ForgeModContainer.java
+++ b/src/main/java/net/minecraftforge/common/ForgeModContainer.java
@@ -572,6 +572,7 @@ public class ForgeModContainer extends DummyModContainer implements WorldAccessC
         Ingredient.invalidateAll();
         FMLCommonHandler.instance().resetClientRecipeBook();
         FMLCommonHandler.instance().reloadSearchTrees();
+        FMLCommonHandler.instance().reloadCreativeSettings();
     }
 
 

--- a/src/main/java/net/minecraftforge/fml/client/FMLClientHandler.java
+++ b/src/main/java/net/minecraftforge/fml/client/FMLClientHandler.java
@@ -1087,6 +1087,12 @@ public class FMLClientHandler implements IFMLSidedHandler
         this.client.getSearchTreeManager().onResourceManagerReload(this.client.getResourceManager());
     }
 
+    @Override
+    public void reloadCreativeSettings()
+    {
+        this.client.creativeSettings.read();
+    }
+
     private CloudRenderer getCloudRenderer()
     {
         if (cloudRenderer == null)

--- a/src/main/java/net/minecraftforge/fml/common/FMLCommonHandler.java
+++ b/src/main/java/net/minecraftforge/fml/common/FMLCommonHandler.java
@@ -771,4 +771,9 @@ public class FMLCommonHandler
     public void reloadSearchTrees() {
         this.sidedDelegate.reloadSearchTrees();
     }
+
+    public void reloadCreativeSettings()
+    {
+        this.sidedDelegate.reloadCreativeSettings();
+    }
 }

--- a/src/main/java/net/minecraftforge/fml/common/IFMLSidedHandler.java
+++ b/src/main/java/net/minecraftforge/fml/common/IFMLSidedHandler.java
@@ -88,4 +88,6 @@ public interface IFMLSidedHandler
     default void resetClientRecipeBook(){}
 
     default void reloadSearchTrees(){}
+
+    default void reloadCreativeSettings(){}
 }


### PR DESCRIPTION
Saved toolbars are loaded via `CreativeSettings.read`, which is currently only called on construction. As this happens very early in `Minecraft.init`, this means that only the bootstrapped vanilla items exist in the registry, which results in modded items not being loaded.

This adds a call to `read` from `ForgeModContainer.mappingChanged`, ensuring that this is kept up-to-date with the item registry, fixing the issue.