### PR TITLE
Allow network leak detection level to be specified

### DIFF
--- a/patches/minecraft/net/minecraft/util/ChatAllowedCharacters.java.patch
+++ b/patches/minecraft/net/minecraft/util/ChatAllowedCharacters.java.patch
@@ -1,0 +1,10 @@
+--- ../src-base/minecraft/net/minecraft/util/ChatAllowedCharacters.java
++++ ../src-work/minecraft/net/minecraft/util/ChatAllowedCharacters.java
+@@ -31,6 +31,7 @@
+ 
+     static
+     {
++        if (System.getProperty("io.netty.leakDetection.level") == null) // Forge: allow level to be manually specified
+         ResourceLeakDetector.setLevel(field_184877_a);
+     }
+ }


### PR DESCRIPTION
This allows the network leak detection level to be configured by the `io.netty.leakDetection.level` system property. While this property can be specified at present, it will be forcibly set to `DISABLED` by the static initialiser of `ChatAllowedCharacters`.

This PR makes that logic conditional on the property being undefined, so any explicitly set values will not be overridden.

An alternative approach would be to disable the vanilla overriding of the property entirely, which would allow it to be set manually and otherwise keep the normal default value of `SIMPLE`.