### PR TITLE
Added a key to @EventBusSubscriber allowing for the selection of a EventBus

### DIFF
--- a/src/main/java/net/minecraftforge/fml/common/AutomaticEventSubscriber.java
+++ b/src/main/java/net/minecraftforge/fml/common/AutomaticEventSubscriber.java
@@ -26,7 +26,6 @@ import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.fml.common.discovery.ASMDataTable;
 import net.minecraftforge.fml.common.discovery.ASMDataTable.ASMData;
 import net.minecraftforge.fml.common.discovery.asm.ModAnnotation;
-import net.minecraftforge.fml.common.eventhandler.EventBus;
 import net.minecraftforge.fml.relauncher.Side;
 import org.apache.logging.log4j.Level;
 
@@ -81,7 +80,7 @@ public class AutomaticEventSubscriber
                     FMLLog.log.debug("Registering @EventBusSubscriber for {} for mod {}", targ.getClassName(), mod.getModId());
                     Class<?> subscriptionTarget = Class.forName(targ.getClassName(), false, mcl);
                     ModAnnotation.EnumHolder bus = (ModAnnotation.EnumHolder)targ.getAnnotationInfo().get("bus");
-                    if(bus != null) ForgeBusType.valueOf(bus.getValue()).getBus().register(subscriptionTarget);
+                    if (bus != null) ForgeBusType.valueOf(bus.getValue()).getBus().register(subscriptionTarget);
                     else MinecraftForge.EVENT_BUS.register(subscriptionTarget);
                     FMLLog.log.debug("Injected @EventBusSubscriber class {}", targ.getClassName());
                 }
@@ -115,7 +114,7 @@ public class AutomaticEventSubscriber
         /**
          * @return The EventBus calling the function
          */
-        public EventBus getBus() {
+        public net.minecraftforge.fml.common.eventhandler.EventBus getBus() {
             switch (this) {
                 case EVENT:
                 default:

--- a/src/main/java/net/minecraftforge/fml/common/Mod.java
+++ b/src/main/java/net/minecraftforge/fml/common/Mod.java
@@ -24,6 +24,7 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
+import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.fml.client.IModGuiFactory;
 import net.minecraftforge.fml.common.event.FMLEvent;
 import net.minecraftforge.fml.common.event.FMLFingerprintViolationEvent;
@@ -37,6 +38,7 @@ import net.minecraftforge.fml.common.event.FMLServerStartingEvent;
 import net.minecraftforge.fml.common.event.FMLServerStoppedEvent;
 import net.minecraftforge.fml.common.event.FMLServerStoppingEvent;
 import net.minecraftforge.fml.common.event.FMLInterModComms.IMCEvent;
+import net.minecraftforge.fml.common.eventhandler.EventBus;
 import net.minecraftforge.fml.common.network.NetworkCheckHandler;
 import net.minecraftforge.fml.common.registry.GameRegistry;
 import net.minecraftforge.fml.common.versioning.VersionRange;
@@ -367,7 +369,7 @@ public @interface Mod
     }
 
     /**
-     * A class which will be subscribed to {@link net.minecraftforge.common.MinecraftForge.EVENT_BUS} at mod construction time.
+     * A class which will be subscribed to one of the three {@link net.minecraftforge.common.MinecraftForge} EventBusses at mod construction time.
      */
     @Retention(RetentionPolicy.RUNTIME)
     @Target(ElementType.TYPE)
@@ -375,10 +377,15 @@ public @interface Mod
         Side[] value() default { Side.CLIENT, Side.SERVER };
 
         /**
-         * Optional value, only nessasary if tis annotation is not on the same class that has a @Mod annotation.
+         * Optional value, only necessary if this annotation is not on the same class that has a @Mod annotation.
          * Needed to prevent early classloading of classes not owned by your mod.
          * @return
          */
         String modid() default "";
+
+        /**
+         * Optional value, only necessary if the event being used is for Ore or Terrain Generation.
+         */
+        AutomaticEventSubscriber.ForgeBusType bus() default AutomaticEventSubscriber.ForgeBusType.EVENT;
     }
 }


### PR DESCRIPTION
This PR adds an additional key to @EventBusSubscriber called "bus," which allows the modder to set the EventBus the mod's event handler is being subscribed to.  If the "bus" key isn't used, then it will default back to MinecraftForge.EVENT_BUS.