### PR TITLE
Allow mods to use other vertex formats with FastTESR 

### DIFF
--- a/patches/minecraft/net/minecraft/client/renderer/RenderGlobal.java.patch
+++ b/patches/minecraft/net/minecraft/client/renderer/RenderGlobal.java.patch
@@ -60,7 +60,7 @@
              this.field_72769_h.field_72984_F.func_76318_c("blockentities");
              RenderHelper.func_74519_b();
  
-+            TileEntityRendererDispatcher.field_147556_a.preDrawBatch();
++            net.minecraftforge.client.render.BatchedTileEntityRenderer.preDrawBatch();
              for (RenderGlobal.ContainerLocalRenderInformation renderglobal$containerlocalrenderinformation1 : this.field_72755_R)
              {
                  List<TileEntity> list3 = renderglobal$containerlocalrenderinformation1.field_178036_a.func_178571_g().func_178485_b();
@@ -80,7 +80,7 @@
                      TileEntityRendererDispatcher.field_147556_a.func_180546_a(tileentity, p_180446_3_, -1);
                  }
              }
-+            TileEntityRendererDispatcher.field_147556_a.drawBatch(pass);
++            net.minecraftforge.client.render.BatchedTileEntityRenderer.drawBatch(pass);
  
              this.func_180443_s();
  

--- a/patches/minecraft/net/minecraft/client/renderer/tileentity/TileEntityRendererDispatcher.java.patch
+++ b/patches/minecraft/net/minecraft/client/renderer/tileentity/TileEntityRendererDispatcher.java.patch
@@ -13,7 +13,7 @@
      {
          if (p_180546_1_.func_145835_a(this.field_147560_j, this.field_147561_k, this.field_147558_l) < p_180546_1_.func_145833_n())
          {
-+            if(!drawingBatch || !p_180546_1_.hasFastRenderer())
++            if(!net.minecraftforge.client.render.BatchedTileEntityRenderer.isDrawingBatch() || !p_180546_1_.hasFastRenderer())
 +            {
              RenderHelper.func_74519_b();
              int i = this.field_147550_f.func_175626_b(p_180546_1_.func_174877_v(), 0);
@@ -25,67 +25,15 @@
              BlockPos blockpos = p_180546_1_.func_174877_v();
              this.func_192854_a(p_180546_1_, (double)blockpos.func_177958_n() - field_147554_b, (double)blockpos.func_177956_o() - field_147555_c, (double)blockpos.func_177952_p() - field_147552_d, p_180546_2_, p_180546_3_, 1.0F);
          }
-@@ -146,6 +149,9 @@
+@@ -146,7 +149,10 @@
          {
              try
              {
-+                if(drawingBatch && p_192854_1_.hasFastRenderer())
-+                    tileentityspecialrenderer.renderTileEntityFast(p_192854_1_, p_192854_2_, p_192854_4_, p_192854_6_, p_192854_8_, p_192854_9_, p_192854_10_, batchBuffer.func_178180_c());
+-                tileentityspecialrenderer.func_192841_a(p_192854_1_, p_192854_2_, p_192854_4_, p_192854_6_, p_192854_8_, p_192854_9_, p_192854_10_);
++                if(net.minecraftforge.client.render.BatchedTileEntityRenderer.isDrawingBatch() && p_192854_1_.hasFastRenderer())
++                    tileentityspecialrenderer.renderTileEntityFast(p_192854_1_, p_192854_2_, p_192854_4_, p_192854_6_, p_192854_8_, p_192854_9_, p_192854_10_, net.minecraftforge.client.render.BatchedTileEntityRenderer.getAll());
 +                else
-                 tileentityspecialrenderer.func_192841_a(p_192854_1_, p_192854_2_, p_192854_4_, p_192854_6_, p_192854_8_, p_192854_9_, p_192854_10_);
++                    tileentityspecialrenderer.func_192841_a(p_192854_1_, p_192854_2_, p_192854_4_, p_192854_6_, p_192854_8_, p_192854_9_, p_192854_10_);
              }
              catch (Throwable throwable)
-@@ -172,4 +178,53 @@
-     {
-         return this.field_147557_n;
-     }
-+
-+    /* ======================================== FORGE START =====================================*/
-+    /**
-+     * Buffer used for batched TESRs
-+     */
-+    private net.minecraft.client.renderer.Tessellator batchBuffer = new net.minecraft.client.renderer.Tessellator(0x200000);
-+    private boolean drawingBatch = false;
-+
-+    /**
-+     * Prepare for a batched TESR rendering.
-+     * You probably shouldn't call this manually.
-+     */
-+    public void preDrawBatch()
-+    {
-+        batchBuffer.func_178180_c().func_181668_a(org.lwjgl.opengl.GL11.GL_QUADS, net.minecraft.client.renderer.vertex.DefaultVertexFormats.field_176600_a);
-+        drawingBatch = true;
-+    }
-+
-+    /**
-+     * Render all TESRs batched so far.
-+     * You probably shouldn't call this manually.
-+     */
-+    public void drawBatch(int pass)
-+    {
-+        field_147553_e.func_110577_a(net.minecraft.client.renderer.texture.TextureMap.field_110575_b);
-+        net.minecraft.client.renderer.RenderHelper.func_74518_a();
-+        GlStateManager.func_179112_b(org.lwjgl.opengl.GL11.GL_SRC_ALPHA, org.lwjgl.opengl.GL11.GL_ONE_MINUS_SRC_ALPHA);
-+        GlStateManager.func_179147_l();
-+        GlStateManager.func_179129_p();
-+
-+        if (net.minecraft.client.Minecraft.func_71379_u())
-+        {
-+            GlStateManager.func_179103_j(org.lwjgl.opengl.GL11.GL_SMOOTH);
-+        }
-+        else
-+        {
-+            GlStateManager.func_179103_j(org.lwjgl.opengl.GL11.GL_FLAT);
-+        }
-+
-+        if(pass > 0)
-+        {
-+            net.minecraft.util.math.Vec3d cameraPos = net.minecraft.client.renderer.ActiveRenderInfo.getCameraPosition();
-+            batchBuffer.func_178180_c().func_181674_a((float)cameraPos.field_72450_a, (float)cameraPos.field_72448_b, (float)cameraPos.field_72449_c);
-+        }
-+        batchBuffer.func_78381_a();
-+
-+        net.minecraft.client.renderer.RenderHelper.func_74519_b();
-+        drawingBatch = false;
-+    }
- }
+             {

--- a/patches/minecraft/net/minecraft/client/renderer/tileentity/TileEntityRendererDispatcher.java.patch
+++ b/patches/minecraft/net/minecraft/client/renderer/tileentity/TileEntityRendererDispatcher.java.patch
@@ -25,15 +25,13 @@
              BlockPos blockpos = p_180546_1_.func_174877_v();
              this.func_192854_a(p_180546_1_, (double)blockpos.func_177958_n() - field_147554_b, (double)blockpos.func_177956_o() - field_147555_c, (double)blockpos.func_177952_p() - field_147552_d, p_180546_2_, p_180546_3_, 1.0F);
          }
-@@ -146,7 +149,10 @@
+@@ -146,6 +149,9 @@
          {
              try
              {
--                tileentityspecialrenderer.func_192841_a(p_192854_1_, p_192854_2_, p_192854_4_, p_192854_6_, p_192854_8_, p_192854_9_, p_192854_10_);
 +                if(net.minecraftforge.client.render.BatchedTileEntityRenderer.isDrawingBatch() && p_192854_1_.hasFastRenderer())
 +                    tileentityspecialrenderer.renderTileEntityFast(p_192854_1_, p_192854_2_, p_192854_4_, p_192854_6_, p_192854_8_, p_192854_9_, p_192854_10_, net.minecraftforge.client.render.BatchedTileEntityRenderer.getAll());
 +                else
-+                    tileentityspecialrenderer.func_192841_a(p_192854_1_, p_192854_2_, p_192854_4_, p_192854_6_, p_192854_8_, p_192854_9_, p_192854_10_);
+                 tileentityspecialrenderer.func_192841_a(p_192854_1_, p_192854_2_, p_192854_4_, p_192854_6_, p_192854_8_, p_192854_9_, p_192854_10_);
              }
              catch (Throwable throwable)
-             {

--- a/patches/minecraft/net/minecraft/client/renderer/tileentity/TileEntitySpecialRenderer.java.patch
+++ b/patches/minecraft/net/minecraft/client/renderer/tileentity/TileEntitySpecialRenderer.java.patch
@@ -1,10 +1,17 @@
 --- ../src-base/minecraft/net/minecraft/client/renderer/tileentity/TileEntitySpecialRenderer.java
 +++ ../src-work/minecraft/net/minecraft/client/renderer/tileentity/TileEntitySpecialRenderer.java
-@@ -77,6 +77,8 @@
+@@ -77,6 +77,15 @@
          return false;
      }
  
-+    public void renderTileEntityFast(T te, double x, double y, double z, float partialTicks, int destroyStage, float partial, net.minecraft.client.renderer.BufferBuilder buffer) {}
++    /**
++     * @deprecated Use {@link #renderTileEntityFast(TileEntity, double, double, double, float, int, float, java.util.Map)}
++     * */
++    @Deprecated
++    public void renderTileEntityFast(T te, double x, double y, double z, float partialTicks, int destroyStage, float partial, net.minecraft.client.renderer.BufferBuilder blockFormatBuffer) {}
++    @SuppressWarnings("deprecation")
++    public void renderTileEntityFast(T te, double x, double y, double z, float partialTicks, int destroyStage, float partial, java.util.Map<net.minecraftforge.client.render.BatchedBufferConfig, net.minecraft.client.renderer.Tessellator> tessellatorMap) { renderTileEntityFast(te, x, y, z, partialTicks, destroyStage, partial, tessellatorMap.get(net.minecraftforge.client.render.BatchedBufferConfig.BLOCK).func_178180_c()); }
++
 +
      protected void func_190052_a(T p_190052_1_, String p_190052_2_, double p_190052_3_, double p_190052_5_, double p_190052_7_, int p_190052_9_)
      {

--- a/src/main/java/net/minecraftforge/client/MinecraftForgeClient.java
+++ b/src/main/java/net/minecraftforge/client/MinecraftForgeClient.java
@@ -24,11 +24,15 @@ import java.util.Locale;
 import java.util.concurrent.TimeUnit;
 
 import net.minecraft.client.Minecraft;
+import net.minecraft.client.renderer.vertex.VertexFormat;
 import net.minecraft.util.BlockRenderLayer;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.ChunkCache;
 import net.minecraft.world.World;
 
+import net.minecraftforge.client.render.BatchedBufferConfig;
+import net.minecraftforge.client.render.BatchedTileEntityRenderer;
+import net.minecraftforge.client.render.IBufferDrawer;
 import org.apache.commons.lang3.tuple.Pair;
 
 import com.google.common.cache.CacheBuilder;
@@ -123,5 +127,12 @@ public class MinecraftForgeClient
     {
         regionCache.invalidateAll();
         regionCache.cleanUp();
+    }
+
+    public static BatchedBufferConfig createCustomFastTESR(int glMode, VertexFormat format, IBufferDrawer drawer)
+    {
+        BatchedBufferConfig config = new BatchedBufferConfig(format, glMode, drawer);
+        BatchedTileEntityRenderer.registerBatchedVertexFormat(config);
+        return config;
     }
 }

--- a/src/main/java/net/minecraftforge/client/model/animation/AnimationTESR.java
+++ b/src/main/java/net/minecraftforge/client/model/animation/AnimationTESR.java
@@ -23,11 +23,14 @@ import net.minecraft.block.state.IBlockState;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.renderer.BlockRendererDispatcher;
 import net.minecraft.client.renderer.BufferBuilder;
+import net.minecraft.client.renderer.Tessellator;
 import net.minecraft.client.renderer.block.model.IBakedModel;
+import net.minecraft.client.renderer.tileentity.TileEntitySpecialRenderer;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.IBlockAccess;
 import net.minecraftforge.client.MinecraftForgeClient;
+import net.minecraftforge.client.render.BatchedBufferConfig;
 import net.minecraftforge.common.animation.Event;
 import net.minecraftforge.common.animation.IEventHandler;
 import net.minecraftforge.common.model.IModelState;
@@ -38,16 +41,22 @@ import net.minecraftforge.common.property.Properties;
 
 import org.apache.commons.lang3.tuple.Pair;
 
+import java.util.Map;
+
 /**
  * Generic TileEntitySpecialRenderer that works with the Forge model system and animations.
  */
 public class AnimationTESR<T extends TileEntity> extends FastTESR<T> implements IEventHandler<T>
 {
     protected static BlockRendererDispatcher blockRenderer;
+    public AnimationTESR()
+    {
+        super(BatchedBufferConfig.BLOCK);
+    }
 
     @Override
-    public void renderTileEntityFast(T te, double x, double y, double z, float partialTick, int breakStage, float partial, BufferBuilder renderer)
-   {
+    public void renderTileEntityFast(T te, double x, double y, double z, float partialTick, int breakStage, float partial, Map<BatchedBufferConfig, Tessellator> map)
+    {
         if(!te.hasCapability(CapabilityAnimation.ANIMATION_CAPABILITY, null))
         {
             return;
@@ -75,6 +84,7 @@ public class AnimationTESR<T extends TileEntity> extends FastTESR<T> implements 
                     // TODO: caching?
                     IBakedModel model = blockRenderer.getBlockModelShapes().getModelForState(exState.getClean());
                     exState = exState.withProperty(Properties.AnimationProperty, pair.getLeft());
+                    BufferBuilder renderer = map.get(BatchedBufferConfig.BLOCK).getBuffer();
 
                     renderer.setTranslation(x - pos.getX(), y - pos.getY(), z - pos.getZ());
 

--- a/src/main/java/net/minecraftforge/client/render/BatchedBufferConfig.java
+++ b/src/main/java/net/minecraftforge/client/render/BatchedBufferConfig.java
@@ -1,0 +1,40 @@
+/*
+ * Minecraft Forge
+ * Copyright (c) 2016-2018.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation version 2.1
+ * of the License.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+package net.minecraftforge.client.render;
+
+import net.minecraft.client.renderer.vertex.DefaultVertexFormats;
+import net.minecraft.client.renderer.vertex.VertexFormat;
+import org.lwjgl.opengl.GL11;
+
+public class BatchedBufferConfig
+{
+    public static final BatchedBufferConfig BLOCK = new BatchedBufferConfig(DefaultVertexFormats.BLOCK, GL11.GL_QUADS, BlockBufferDrawer.INSTANCE);
+
+    public final VertexFormat vertexFormat;
+    public final int glMode;
+    public final IBufferDrawer drawer;
+
+    public BatchedBufferConfig(VertexFormat vertexFormat, int glMode, IBufferDrawer drawer)
+    {
+        this.vertexFormat = vertexFormat;
+        this.glMode = glMode;
+        this.drawer = drawer;
+    }
+}

--- a/src/main/java/net/minecraftforge/client/render/BatchedTileEntityRenderer.java
+++ b/src/main/java/net/minecraftforge/client/render/BatchedTileEntityRenderer.java
@@ -1,0 +1,84 @@
+/*
+ * Minecraft Forge
+ * Copyright (c) 2016-2018.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation version 2.1
+ * of the License.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+package net.minecraftforge.client.render;
+
+import net.minecraft.client.renderer.Tessellator;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+public class BatchedTileEntityRenderer
+{
+
+    private static final Map<BatchedBufferConfig, Tessellator> BATCHED_BUFFERS = new LinkedHashMap<>();
+    private static boolean drawingBatch = false;
+
+    static
+    {
+        registerBatchedVertexFormat(BatchedBufferConfig.BLOCK);
+    }
+
+    public static void registerBatchedVertexFormat(BatchedBufferConfig config)
+    {
+        BATCHED_BUFFERS.put(config, new Tessellator(0x20000));
+    }
+
+    /**
+     * Prepare for a batched TESR rendering.
+     * You probably shouldn't call this manually.
+     */
+    public static void preDrawBatch()
+    {
+        for (Map.Entry<BatchedBufferConfig, Tessellator> entry : BATCHED_BUFFERS.entrySet())
+        {
+            BatchedBufferConfig config = entry.getKey();
+            entry.getValue().getBuffer().begin(config.glMode, config.vertexFormat);
+        }
+        drawingBatch = true;
+    }
+
+    /**
+     * Render all TESRs batched so far.
+     * You probably shouldn't call this manually.
+     */
+    public static void drawBatch(int pass)
+    {
+        for (Map.Entry<BatchedBufferConfig, Tessellator> entry : BATCHED_BUFFERS.entrySet())
+        {
+            BatchedBufferConfig config = entry.getKey();
+            Tessellator tessellator = entry.getValue();
+            config.drawer.preDraw(pass, tessellator.getBuffer());
+            tessellator.draw();
+            config.drawer.postDraw(pass);
+        }
+
+        drawingBatch = false;
+    }
+
+    public static boolean isDrawingBatch()
+    {
+        return drawingBatch;
+    }
+
+    public static Map<BatchedBufferConfig, Tessellator> getAll()
+    {
+        return BATCHED_BUFFERS;
+    }
+}

--- a/src/main/java/net/minecraftforge/client/render/BlockBufferDrawer.java
+++ b/src/main/java/net/minecraftforge/client/render/BlockBufferDrawer.java
@@ -1,0 +1,66 @@
+/*
+ * Minecraft Forge
+ * Copyright (c) 2016-2018.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation version 2.1
+ * of the License.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+package net.minecraftforge.client.render;
+
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.renderer.*;
+import net.minecraft.client.renderer.texture.TextureManager;
+import net.minecraft.client.renderer.texture.TextureMap;
+import net.minecraft.util.math.Vec3d;
+import org.lwjgl.opengl.GL11;
+
+public class BlockBufferDrawer implements IBufferDrawer
+{
+    public static final BlockBufferDrawer INSTANCE = new BlockBufferDrawer();
+
+    private BlockBufferDrawer() {}
+
+    @Override
+    public void preDraw(int renderPass, BufferBuilder builder)
+    {
+        TextureManager renderEngine = Minecraft.getMinecraft().renderEngine;
+        renderEngine.bindTexture(TextureMap.LOCATION_BLOCKS_TEXTURE);
+        RenderHelper.disableStandardItemLighting();
+        GlStateManager.blendFunc(GL11.GL_SRC_ALPHA, GL11.GL_ONE_MINUS_SRC_ALPHA);
+        GlStateManager.enableBlend();
+        GlStateManager.disableCull();
+
+        if (net.minecraft.client.Minecraft.isAmbientOcclusionEnabled())
+        {
+            GlStateManager.shadeModel(GL11.GL_SMOOTH);
+        }
+        else
+        {
+            GlStateManager.shadeModel(GL11.GL_FLAT);
+        }
+
+        if(renderPass > 0)
+        {
+            Vec3d cameraPos = ActiveRenderInfo.getCameraPosition();
+            builder.sortVertexData((float)cameraPos.x, (float)cameraPos.y, (float)cameraPos.z);
+        }
+    }
+
+    @Override
+    public void postDraw(int renderPass)
+    {
+        RenderHelper.enableStandardItemLighting();
+    }
+}

--- a/src/main/java/net/minecraftforge/client/render/IBufferDrawer.java
+++ b/src/main/java/net/minecraftforge/client/render/IBufferDrawer.java
@@ -1,0 +1,29 @@
+/*
+ * Minecraft Forge
+ * Copyright (c) 2016-2018.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation version 2.1
+ * of the License.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+package net.minecraftforge.client.render;
+
+import net.minecraft.client.renderer.BufferBuilder;
+
+public interface IBufferDrawer
+{
+    void preDraw(int renderPass, BufferBuilder builder);
+
+    void postDraw(int renderPass);
+}

--- a/src/test/java/net/minecraftforge/debug/client/rendering/FastTESRCustomFormatTest.java
+++ b/src/test/java/net/minecraftforge/debug/client/rendering/FastTESRCustomFormatTest.java
@@ -1,0 +1,202 @@
+/*
+ * Minecraft Forge
+ * Copyright (c) 2016-2018.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation version 2.1
+ * of the License.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+package net.minecraftforge.debug.client.rendering;
+
+import java.util.Map;
+
+import net.minecraft.block.Block;
+import net.minecraft.block.BlockContainer;
+import net.minecraft.block.material.Material;
+import net.minecraft.block.state.IBlockState;
+import net.minecraft.client.renderer.*;
+import net.minecraft.client.renderer.block.model.ModelBakery;
+import net.minecraft.client.renderer.tileentity.TileEntitySpecialRenderer;
+import net.minecraft.client.renderer.vertex.DefaultVertexFormats;
+import net.minecraft.creativetab.CreativeTabs;
+import net.minecraft.item.Item;
+import net.minecraft.item.ItemBlock;
+import net.minecraft.tileentity.TileEntity;
+import net.minecraft.util.*;
+import net.minecraft.world.World;
+import net.minecraftforge.client.model.animation.FastTESR;
+import net.minecraftforge.client.render.BatchedBufferConfig;
+import net.minecraftforge.client.render.BatchedTileEntityRenderer;
+import net.minecraftforge.client.event.ModelRegistryEvent;
+import net.minecraftforge.client.render.IBufferDrawer;
+import net.minecraftforge.event.RegistryEvent;
+import net.minecraftforge.fml.client.registry.ClientRegistry;
+import net.minecraftforge.fml.common.Mod;
+import net.minecraftforge.fml.common.event.FMLPreInitializationEvent;
+import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
+import net.minecraftforge.fml.common.registry.GameRegistry;
+import net.minecraftforge.fml.relauncher.Side;
+import org.lwjgl.opengl.GL11;
+
+@Mod(modid = FastTESRCustomFormatTest.MODID, name = "CustomVertexFormatFastTESR", version = "1.0", acceptableRemoteVersions = "*")
+@Mod.EventBusSubscriber
+public class FastTESRCustomFormatTest
+{
+
+    static final String MODID = "custom_vertex_format_fast_tesr";
+
+    private static class CustomFormatFastTESR extends FastTESR<CustomFormatTE> implements IBufferDrawer
+    {
+        public static final CustomFormatFastTESR INSTANCE = new CustomFormatFastTESR();
+        public static final BatchedBufferConfig CONFIG = new BatchedBufferConfig(DefaultVertexFormats.POSITION_COLOR, GL11.GL_QUADS, INSTANCE);
+
+        private CustomFormatFastTESR()
+        {
+            super(CONFIG);
+        }
+
+        @Override
+        public void renderTileEntityFast(CustomFormatTE te, double x, double y, double z, float partialTicks, int destroyStage, float partial, Map<BatchedBufferConfig, Tessellator> map)
+        {
+            BufferBuilder builder = map.get(CONFIG).getBuffer();
+            builder.pos(x + 1, y + 1, z).color(255, 255, 255, 255).endVertex();
+            builder.pos(x, y + 1, z).color(255, 255, 255, 255).endVertex();
+            builder.pos(x, y, z).color(255, 0, 0, 255).endVertex();
+            builder.pos(x + 1, y, z).color(255, 0, 0, 255).endVertex();
+
+            builder.pos(x, y, z).color(255, 255, 255, 255).endVertex();
+            builder.pos(x + 1D, y, z).color(255, 255, 255, 255).endVertex();
+            builder.pos(x + 1D, y, z + 0.5D).color(255, 0, 0, 255).endVertex();
+            builder.pos(x, y, z + 0.5D).color(255, 0, 0, 255).endVertex();
+
+            z += 0.5D;
+            builder.pos(x + 1D, y, z + 0.5D).color(255, 255, 255, 255).endVertex();
+            builder.pos(x, y, z + 0.5D).color(255, 255, 255, 255).endVertex();
+            builder.pos(x, y, z).color(255, 0, 0, 255).endVertex();
+            builder.pos(x + 1D, y, z).color(255, 0, 0, 255).endVertex();
+            z -= 0.5D;
+
+            builder.pos(x, y + 1, z + 1).color(255, 255, 255, 255).endVertex();
+            builder.pos(x, y + 1, z).color(255, 255, 255, 255).endVertex();
+            builder.pos(x, y, z).color(255, 0, 0, 255).endVertex();
+            builder.pos(x, y, z + 1).color(255, 0, 0, 255).endVertex();
+
+            z++;
+            builder.pos(x + 1, y + 1, z).color(255, 255, 255, 255).endVertex();
+            builder.pos(x, y + 1, z).color(255, 255, 255, 255).endVertex();
+            builder.pos(x, y, z).color(255, 0, 0, 255).endVertex();
+            builder.pos(x + 1, y, z).color(255, 0, 0, 255).endVertex();
+
+            z--;
+            y++;
+            builder.pos(x, y, z).color(255, 255, 255, 255).endVertex();
+            builder.pos(x + 1D, y, z).color(255, 255, 255, 255).endVertex();
+            builder.pos(x + 1D, y, z + 0.5D).color(255, 0, 0, 255).endVertex();
+            builder.pos(x, y, z + 0.5D).color(255, 0, 0, 255).endVertex();
+
+            z += 0.5D;
+            builder.pos(x + 1D, y, z + 0.5D).color(255, 255, 255, 255).endVertex();
+            builder.pos(x, y, z + 0.5D).color(255, 255, 255, 255).endVertex();
+            builder.pos(x, y, z).color(255, 0, 0, 255).endVertex();
+            builder.pos(x + 1D, y, z).color(255, 0, 0, 255).endVertex();
+            z -= 0.5D;
+
+            y--;
+            x++;
+            builder.pos(x, y + 1, z + 1).color(255, 255, 255, 255).endVertex();
+            builder.pos(x, y + 1, z).color(255, 255, 255, 255).endVertex();
+            builder.pos(x, y, z).color(255, 0, 0, 255).endVertex();
+            builder.pos(x, y, z + 1).color(255, 0, 0, 255).endVertex();
+            x--;
+        }
+
+        @Override
+        public void preDraw(int renderPass, BufferBuilder builder)
+        {
+            RenderHelper.disableStandardItemLighting();
+            GlStateManager.disableTexture2D();
+            GlStateManager.shadeModel(GL11.GL_SMOOTH);
+            OpenGlHelper.setLightmapTextureCoords(OpenGlHelper.lightmapTexUnit, 0, 240);
+        }
+
+        @Override
+        public void postDraw(int renderPass)
+        {
+            RenderHelper.enableStandardItemLighting();
+            GlStateManager.shadeModel(GL11.GL_FLAT);
+            GlStateManager.enableTexture2D();
+        }
+    }
+
+    public static class CustomFormatTE extends TileEntity
+    {
+
+        public CustomFormatTE()
+        {
+        }
+
+        @Override
+        public boolean hasFastRenderer()
+        {
+            return true;
+        }
+    }
+
+
+    private static final Block testBlock = new BlockContainer(Material.ROCK)
+    {
+
+        @Override
+        public TileEntity createNewTileEntity(World worldIn, int meta)
+        {
+            return new CustomFormatTE();
+        }
+
+        @Override
+        public EnumBlockRenderType getRenderType(IBlockState state)
+        {
+            return EnumBlockRenderType.ENTITYBLOCK_ANIMATED;
+        }
+    };
+
+    @Mod.EventHandler
+    public void preInit(FMLPreInitializationEvent evt)
+    {
+        GameRegistry.registerTileEntity(CustomFormatTE.class, new ResourceLocation(MODID, "fast-tesr-te"));
+    }
+
+    @SubscribeEvent
+    public static void onBlockRegister(RegistryEvent.Register<Block> evt)
+    {
+        evt.getRegistry().register(testBlock.setCreativeTab(CreativeTabs.DECORATIONS).setRegistryName(MODID, "fluid-tesr-block"));
+    }
+
+    @SubscribeEvent
+    public static void onItemRegister(RegistryEvent.Register<Item> evt)
+    {
+        evt.getRegistry().register(new ItemBlock(testBlock).setRegistryName(MODID, "tesr-test"));
+    }
+
+    @Mod.EventBusSubscriber(value = Side.CLIENT, modid = MODID)
+    public static class ClientLoader
+    {
+        @SubscribeEvent
+        public static void registerModels(ModelRegistryEvent event)
+        {
+            ModelBakery.registerItemVariants(Item.getItemFromBlock(testBlock));
+            ClientRegistry.bindTileEntitySpecialRenderer(CustomFormatTE.class, new CustomFormatFastTESR());
+            BatchedTileEntityRenderer.registerBatchedVertexFormat(CustomFormatFastTESR.CONFIG);
+        }
+    }
+}


### PR DESCRIPTION
This PR aims to allow custom vertex formats for renderers that do not need to change the GL state while rendering the block to use the FastTESR.
Modders should be able to use the FastTESR for many more things now, as the GL state can be changed before all batched together tesrs with this format are rendered, and thus speed up rendering quite a lot when many blocks that use this feature are being rendered.
An example is provided with a mod that uses a FastTESR with the POSITION_COLOR format and a few GL calls before the batched buffer gets rendered.