### PR TITLE
Fix received data for last vertex format element not being recorded

### DIFF
--- a/src/main/java/net/minecraftforge/client/model/pipeline/QuadGatheringTransformer.java
+++ b/src/main/java/net/minecraftforge/client/model/pipeline/QuadGatheringTransformer.java
@@ -52,12 +52,15 @@ public abstract class QuadGatheringTransformer implements IVertexConsumer
     public void put(int element, float... data)
     {
         System.arraycopy(data, 0, quadData[element][vertices], 0, data.length);
-        if(element == getVertexFormat().getElementCount() - 1) vertices++;
-        if(vertices == 0)
+        if (vertices == 0)
         {
             dataLength[element] = (byte)data.length;
         }
-        else if(vertices == 4)
+        if (element == getVertexFormat().getElementCount() - 1)
+        {
+            vertices++;
+        }
+        if (vertices == 4)
         {
             vertices = 0;
             processQuad();


### PR DESCRIPTION
Fixes #5073.

Relocates the vertex counter increment to the correct position (after `dataLength` is recorded).