### PR TITLE
Change biome spawn list entries to use factory method where possible

### DIFF
--- a/patches/minecraft/net/minecraft/world/biome/Biome.java.patch
+++ b/patches/minecraft/net/minecraft/world/biome/Biome.java.patch
@@ -164,22 +164,23 @@
      public static void func_185358_q()
      {
          func_185354_a(0, "ocean", new BiomeOcean((new Biome.BiomeProperties("Ocean")).func_185398_c(-1.0F).func_185400_d(0.1F)));
-@@ -552,6 +635,7 @@
+@@ -552,6 +635,8 @@
              public Class <? extends EntityLiving > field_76300_b;
              public int field_76301_c;
              public int field_76299_d;
 +            private final java.lang.reflect.Constructor<? extends EntityLiving> ctr;
++            private final net.minecraftforge.fml.common.registry.EntityEntry entry;
  
              public SpawnListEntry(Class <? extends EntityLiving > p_i1970_1_, int p_i1970_2_, int p_i1970_3_, int p_i1970_4_)
              {
-@@ -559,12 +643,26 @@
+@@ -559,12 +644,26 @@
                  this.field_76300_b = p_i1970_1_;
                  this.field_76301_c = p_i1970_3_;
                  this.field_76299_d = p_i1970_4_;
-+
++                this.entry = net.minecraftforge.fml.common.registry.EntityRegistry.getEntry(p_i1970_1_);
 +                try
 +                {
-+                    ctr = p_i1970_1_.getConstructor(World.class);
++                    this.ctr = this.entry != null ? null : p_i1970_1_.getConstructor(World.class);
 +                }
 +                catch (NoSuchMethodException e)
 +                {
@@ -194,7 +195,7 @@
 +
 +            public EntityLiving newInstance(World world) throws Exception
 +            {
-+                return ctr.newInstance(world);
++                return this.entry != null ? (EntityLiving) this.entry.newInstance(world) : this.ctr.newInstance(world);
 +            }
          }
  

--- a/patches/minecraft/net/minecraft/world/biome/Biome.java.patch
+++ b/patches/minecraft/net/minecraft/world/biome/Biome.java.patch
@@ -164,38 +164,16 @@
      public static void func_185358_q()
      {
          func_185354_a(0, "ocean", new BiomeOcean((new Biome.BiomeProperties("Ocean")).func_185398_c(-1.0F).func_185400_d(0.1F)));
-@@ -552,6 +635,8 @@
-             public Class <? extends EntityLiving > field_76300_b;
-             public int field_76301_c;
-             public int field_76299_d;
-+            private final java.lang.reflect.Constructor<? extends EntityLiving> ctr;
-+            private final net.minecraftforge.fml.common.registry.EntityEntry entry;
- 
-             public SpawnListEntry(Class <? extends EntityLiving > p_i1970_1_, int p_i1970_2_, int p_i1970_3_, int p_i1970_4_)
-             {
-@@ -559,12 +644,26 @@
-                 this.field_76300_b = p_i1970_1_;
-                 this.field_76301_c = p_i1970_3_;
-                 this.field_76299_d = p_i1970_4_;
-+                this.entry = net.minecraftforge.fml.common.registry.EntityRegistry.getEntry(p_i1970_1_);
-+                try
-+                {
-+                    this.ctr = this.entry != null ? null : p_i1970_1_.getConstructor(World.class);
-+                }
-+                catch (NoSuchMethodException e)
-+                {
-+                    throw new RuntimeException(e);
-+                }
-             }
- 
-             public String toString()
+@@ -565,6 +648,13 @@
              {
                  return this.field_76300_b.getSimpleName() + "*(" + this.field_76301_c + "-" + this.field_76299_d + "):" + this.field_76292_a;
              }
 +
 +            public EntityLiving newInstance(World world) throws Exception
 +            {
-+                return this.entry != null ? (EntityLiving) this.entry.newInstance(world) : this.ctr.newInstance(world);
++                net.minecraftforge.fml.common.registry.EntityEntry entry = net.minecraftforge.fml.common.registry.EntityRegistry.getEntry(this.field_76300_b);
++                if (entry != null) return (EntityLiving) entry.newInstance(world);
++                return this.field_76300_b.getConstructor(World.class).newInstance(world);
 +            }
          }
  

--- a/src/main/java/net/minecraftforge/fml/common/registry/EntityRegistry.java
+++ b/src/main/java/net/minecraftforge/fml/common/registry/EntityRegistry.java
@@ -19,10 +19,6 @@
 
 package net.minecraftforge.fml.common.registry;
 
-import java.util.Iterator;
-import java.util.List;
-import org.apache.logging.log4j.Level;
-
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.EntityList.EntityEggInfo;
 import net.minecraft.entity.EntityLiving;
@@ -36,7 +32,10 @@ import net.minecraftforge.fml.common.FMLCommonHandler;
 import net.minecraftforge.fml.common.FMLLog;
 import net.minecraftforge.fml.common.ModContainer;
 import net.minecraftforge.fml.common.network.internal.FMLMessage.EntitySpawnMessage;
+import net.minecraftforge.registries.GameData;
 
+import java.util.List;
+import java.util.Map;
 import java.util.function.Function;
 import com.google.common.collect.ArrayListMultimap;
 import com.google.common.collect.BiMap;
@@ -145,8 +144,9 @@ public class EntityRegistry
 
     private static final EntityRegistry INSTANCE = new EntityRegistry();
 
-    private ListMultimap<ModContainer, EntityRegistration> entityRegistrations = ArrayListMultimap.create();
-    private BiMap<Class<? extends Entity>, EntityRegistration> entityClassRegistrations = HashBiMap.create();
+    private final ListMultimap<ModContainer, EntityRegistration> entityRegistrations = ArrayListMultimap.create();
+    private final BiMap<Class<? extends Entity>, EntityRegistration> entityClassRegistrations = HashBiMap.create();
+    private final Map<Class<? extends Entity>, EntityEntry> entityClassEntries = GameData.getEntityClassMap();
 
     public static EntityRegistry instance()
     {
@@ -374,15 +374,9 @@ public class EntityRegistry
 
     //Helper function
     @Nullable
-    public static EntityEntry getEntry(Class<? extends Entity> entry)
+    public static EntityEntry getEntry(Class<? extends Entity> entityClass)
     {
-        //TODO: Slave map for faster lookup?
-        for (EntityEntry e : ForgeRegistries.ENTITIES)
-        {
-            if (e.getEntityClass() == entry)
-                return e;
-        }
-        return null;
+        return instance().entityClassEntries.get(entityClass);
     }
 
     // This is an internal method - do not touch.

--- a/src/main/java/net/minecraftforge/registries/GameData.java
+++ b/src/main/java/net/minecraftforge/registries/GameData.java
@@ -70,6 +70,7 @@ import java.io.IOException;
 import java.lang.reflect.Field;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.IdentityHashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
@@ -111,8 +112,9 @@ public class GameData
     private static final int MAX_RECIPE_ID = Integer.MAX_VALUE >> 5; // Varint CPacketRecipeInfo/SPacketRecipeBook
     private static final int MAX_PROFESSION_ID = 1024; //TODO: Is this serialized anywhere anymore?
 
-    private static final ResourceLocation BLOCK_TO_ITEM    = new ResourceLocation("minecraft:blocktoitemmap");
-    private static final ResourceLocation BLOCKSTATE_TO_ID = new ResourceLocation("minecraft:blockstatetoid");
+    private static final ResourceLocation BLOCK_TO_ITEM         = new ResourceLocation("minecraft:blocktoitemmap");
+    private static final ResourceLocation BLOCKSTATE_TO_ID      = new ResourceLocation("minecraft:blockstatetoid");
+    private static final ResourceLocation ENTITY_CLASS_TO_ENTRY = new ResourceLocation("forge:entity_class_to_entry");
     private static boolean hasInit = false;
     private static final boolean DISABLE_VANILLA_REGISTRIES = Boolean.parseBoolean(System.getProperty("forge.disableVanillaGameData", "false")); // Use for unit tests/debugging
     private static final BiConsumer<ResourceLocation, ForgeRegistry<?>> LOCK_VANILLA = (name, reg) -> reg.slaves.values().stream().filter(o -> o instanceof ILockableRegistry).forEach(o -> ((ILockableRegistry)o).lock());
@@ -186,6 +188,12 @@ public class GameData
     public static ObjectIntIdentityMap<IBlockState> getBlockStateIDMap()
     {
         return GameRegistry.findRegistry(Block.class).getSlaveMap(BLOCKSTATE_TO_ID, ObjectIntIdentityMap.class);
+    }
+
+    @SuppressWarnings("unchecked")
+    public static Map<Class<? extends Entity>, EntityEntry> getEntityClassMap()
+    {
+        return GameRegistry.findRegistry(EntityEntry.class).getSlaveMap(ENTITY_CLASS_TO_ENTRY, Map.class);
     }
 
     public static <K extends IForgeRegistryEntry<K>> K register_impl(K value)
@@ -452,7 +460,7 @@ public class GameData
         reg.register(id, key, new EntityEntry(clazz, oldName));
     }
 
-    private static class EntityCallbacks implements IForgeRegistry.AddCallback<EntityEntry>
+    private static class EntityCallbacks implements IForgeRegistry.AddCallback<EntityEntry>, IForgeRegistry.ClearCallback<EntityEntry>, IForgeRegistry.CreateCallback<EntityEntry>
     {
         static final EntityCallbacks INSTANCE = new EntityCallbacks();
 
@@ -464,7 +472,24 @@ public class GameData
                 ((EntityEntryBuilder.BuiltEntityEntry) entry).addedToRegistry();
             }
             if (entry.getEgg() != null)
+            {
                 EntityList.ENTITY_EGGS.put(entry.getRegistryName(), entry.getEgg());
+            }
+            @SuppressWarnings("unchecked")
+            Map<Class<? extends Entity>, EntityEntry> map = owner.getSlaveMap(ENTITY_CLASS_TO_ENTRY, Map.class);
+            map.put(entry.getEntityClass(), entry);
+        }
+
+        @Override
+        public void onClear(IForgeRegistryInternal<EntityEntry> owner, RegistryManager stage)
+        {
+            owner.getSlaveMap(ENTITY_CLASS_TO_ENTRY, Map.class).clear();
+        }
+
+        @Override
+        public void onCreate(IForgeRegistryInternal<EntityEntry> owner, RegistryManager stage)
+        {
+            owner.setSlaveMap(ENTITY_CLASS_TO_ENTRY, new IdentityHashMap<>());
         }
     }
 


### PR DESCRIPTION
Resolves #5046.

This adds a slave `Class` -> `EntityEntry` map to the entity registry for fast lookups.
As mentioned in the issue, an alternative would be a cached, lazily-initialised registry delegate stored in the `SpawnListEntry` instance.

Here's the `SpawnListEntry` versions for comparision:
```java
public static class SpawnListEntry extends WeightedRandom.Item
{
    public Class <? extends EntityLiving > entityClass;
    public int minGroupCount;
    public int maxGroupCount;

    /* ... */

    public EntityLiving newInstance(World world) throws Exception
    {
        net.minecraftforge.fml.common.registry.EntityEntry entry = net.minecraftforge.fml.common.registry.EntityRegistry.getEntry(this.entityClass);
        if (entry != null) return (EntityLiving) entry.newInstance(world);
        return this.entityClass.getConstructor(World.class).newInstance(world);
    }
}
```

```java
public static class SpawnListEntry extends WeightedRandom.Item
{
    public Class <? extends EntityLiving > entityClass;
    public int minGroupCount;
    public int maxGroupCount;
    private net.minecraftforge.registries.IRegistryDelegate<net.minecraftforge.fml.common.registry.EntityEntry> delegate;
    private Class<? extends EntityLiving> cachedEntryClass;

    /* ... */

    public EntityLiving newInstance(World world) throws Exception
    {
        if (this.cachedEntryClass != this.entityClass)
        {
            net.minecraftforge.fml.common.registry.EntityEntry entry = net.minecraftforge.fml.common.registry.EntityRegistry.getEntry(this.entityClass);
            if (entry != null) this.delegate = entry.delegate;
            this.cachedEntryClass = this.entityClass;
        }
        if (this.delegate != null) return (EntityLiving) this.delegate.get().newInstance(world);
        return this.entityClass.getConstructor(World.class).newInstance(world);
    }
}
```

Note the options here aren't mutually exclusive, but there is likely a need for at least one of them as otherwise mob spawning performance would be an issue, especially with a large number of registered entities.