### PR TITLE
Add result itemstack to PlayerDestroyItemEvent

### DIFF
--- a/patches/minecraft/net/minecraft/client/multiplayer/PlayerControllerMP.java.patch
+++ b/patches/minecraft/net/minecraft/client/multiplayer/PlayerControllerMP.java.patch
@@ -43,8 +43,9 @@
  
                          if (itemstack1.func_190926_b())
                          {
-+                            net.minecraftforge.event.ForgeEventFactory.onPlayerDestroyItem(this.field_78776_a.field_71439_g, copyBeforeUse, EnumHand.MAIN_HAND);
-                             this.field_78776_a.field_71439_g.func_184611_a(EnumHand.MAIN_HAND, ItemStack.field_190927_a);
+-                            this.field_78776_a.field_71439_g.func_184611_a(EnumHand.MAIN_HAND, ItemStack.field_190927_a);
++                        	ItemStack resultStack = net.minecraftforge.event.ForgeEventFactory.onPlayerDestroyItem(this.field_78776_a.field_71439_g, copyBeforeUse, EnumHand.MAIN_HAND);
++                            this.field_78776_a.field_71439_g.func_184611_a(EnumHand.MAIN_HAND, resultStack);
                          }
                      }
                  }
@@ -160,7 +161,7 @@
              {
                  if (itemstack.func_190926_b())
                  {
-@@ -430,14 +463,20 @@
+@@ -430,14 +463,24 @@
                      {
                          int i = itemstack.func_77960_j();
                          int j = itemstack.func_190916_E();
@@ -177,12 +178,16 @@
 +                        ItemStack copyForUse = itemstack.func_77946_l();
 +                        if (event.getUseItem() != net.minecraftforge.fml.common.eventhandler.Event.Result.DENY)
 +                        result = itemstack.func_179546_a(p_187099_1_, p_187099_2_, p_187099_3_, p_187099_6_, p_187099_4_, f, f1, f2);
-+                        if (itemstack.func_190926_b()) net.minecraftforge.event.ForgeEventFactory.onPlayerDestroyItem(p_187099_1_, copyForUse, p_187099_6_);
++                        if (itemstack.func_190926_b())
++                        {
++                        	ItemStack resultStack = net.minecraftforge.event.ForgeEventFactory.onPlayerDestroyItem(p_187099_1_, copyForUse, p_187099_6_);
++                        	p_187099_1_.func_184611_a(p_187099_6_, resultStack);
++                        }
 +                        return result;
                      }
                  }
              }
-@@ -466,6 +505,8 @@
+@@ -466,6 +509,8 @@
              }
              else
              {
@@ -191,18 +196,19 @@
                  int i = itemstack.func_190916_E();
                  ActionResult<ItemStack> actionresult = itemstack.func_77957_a(p_187101_2_, p_187101_1_, p_187101_3_);
                  ItemStack itemstack1 = actionresult.func_188398_b();
-@@ -473,6 +514,10 @@
+@@ -473,6 +518,11 @@
                  if (itemstack1 != itemstack || itemstack1.func_190916_E() != i)
                  {
                      p_187101_1_.func_184611_a(p_187101_3_, itemstack1);
 +                    if (itemstack1.func_190926_b())
 +                    {
-+                        net.minecraftforge.event.ForgeEventFactory.onPlayerDestroyItem(p_187101_1_, itemstack, p_187101_3_);
++                    	ItemStack resultStack = net.minecraftforge.event.ForgeEventFactory.onPlayerDestroyItem(p_187101_1_, itemstack, p_187101_3_);
++                    	p_187101_1_.func_184611_a(p_187101_3_, resultStack);
 +                    }
                  }
  
                  return actionresult.func_188397_a();
-@@ -509,6 +554,9 @@
+@@ -509,6 +559,9 @@
          this.func_78750_j();
          Vec3d vec3d = new Vec3d(p_187102_3_.field_72307_f.field_72450_a - p_187102_2_.field_70165_t, p_187102_3_.field_72307_f.field_72448_b - p_187102_2_.field_70163_u, p_187102_3_.field_72307_f.field_72449_c - p_187102_2_.field_70161_v);
          this.field_78774_b.func_147297_a(new CPacketUseEntity(p_187102_2_, p_187102_4_, vec3d));

--- a/patches/minecraft/net/minecraft/entity/player/EntityPlayer.java.patch
+++ b/patches/minecraft/net/minecraft/entity/player/EntityPlayer.java.patch
@@ -215,7 +215,7 @@
          {
              this.func_190777_m(true);
          }
-@@ -1002,14 +1072,16 @@
+@@ -1002,25 +1072,27 @@
  
      protected void func_184590_k(float p_184590_1_)
      {
@@ -229,10 +229,24 @@
              if (this.field_184627_bm.func_190926_b())
              {
                  EnumHand enumhand = this.func_184600_cs();
-+                net.minecraftforge.event.ForgeEventFactory.onPlayerDestroyItem(this, copyBeforeUse, enumhand);
++                ItemStack resultStack = net.minecraftforge.event.ForgeEventFactory.onPlayerDestroyItem(this, copyBeforeUse, enumhand);
  
                  if (enumhand == EnumHand.MAIN_HAND)
                  {
+-                    this.func_184201_a(EntityEquipmentSlot.MAINHAND, ItemStack.field_190927_a);
++                    this.func_184201_a(EntityEquipmentSlot.MAINHAND, resultStack);
+                 }
+                 else
+                 {
+-                    this.func_184201_a(EntityEquipmentSlot.OFFHAND, ItemStack.field_190927_a);
++                    this.func_184201_a(EntityEquipmentSlot.OFFHAND, resultStack);
+                 }
+ 
+-                this.field_184627_bm = ItemStack.field_190927_a;
++                this.field_184627_bm = resultStack;
+                 this.func_184185_a(SoundEvents.field_187769_eM, 0.8F, 0.8F + this.field_70170_p.field_73012_v.nextFloat() * 0.4F);
+             }
+         }
 @@ -1045,11 +1117,15 @@
      {
          if (!this.func_180431_b(p_70665_1_))
@@ -259,27 +273,30 @@
              ItemStack itemstack = this.func_184586_b(p_190775_2_);
              ItemStack itemstack1 = itemstack.func_190926_b() ? ItemStack.field_190927_a : itemstack.func_77946_l();
  
-@@ -1124,7 +1202,10 @@
+@@ -1124,7 +1202,11 @@
                  {
                      itemstack.func_190920_e(itemstack1.func_190916_E());
                  }
 -
 +                if (!this.field_71075_bZ.field_75098_d && itemstack.func_190926_b())
 +                {
-+                    net.minecraftforge.event.ForgeEventFactory.onPlayerDestroyItem(this, itemstack1, p_190775_2_);
++                	ItemStack resultStack = net.minecraftforge.event.ForgeEventFactory.onPlayerDestroyItem(this, itemstack1, p_190775_2_);
++                	this.func_184611_a(p_190775_2_, resultStack);
 +                }
                  return EnumActionResult.SUCCESS;
              }
              else
-@@ -1140,6 +1221,7 @@
+@@ -1140,7 +1222,8 @@
                      {
                          if (itemstack.func_190926_b() && !this.field_71075_bZ.field_75098_d)
                          {
-+                            net.minecraftforge.event.ForgeEventFactory.onPlayerDestroyItem(this, itemstack1, p_190775_2_);
-                             this.func_184611_a(p_190775_2_, ItemStack.field_190927_a);
+-                            this.func_184611_a(p_190775_2_, ItemStack.field_190927_a);
++                        	ItemStack resultStack = net.minecraftforge.event.ForgeEventFactory.onPlayerDestroyItem(this, itemstack1, p_190775_2_);
++                            this.func_184611_a(p_190775_2_, resultStack);
                          }
  
-@@ -1165,6 +1247,7 @@
+                         return EnumActionResult.SUCCESS;
+@@ -1165,6 +1248,7 @@
  
      public void func_71059_n(Entity p_71059_1_)
      {
@@ -287,7 +304,7 @@
          if (p_71059_1_.func_70075_an())
          {
              if (!p_71059_1_.func_85031_j(this))
-@@ -1203,9 +1286,11 @@
+@@ -1203,9 +1287,11 @@
                      boolean flag2 = flag && this.field_70143_R > 0.0F && !this.field_70122_E && !this.func_70617_f_() && !this.func_70090_H() && !this.func_70644_a(MobEffects.field_76440_q) && !this.func_184218_aH() && p_71059_1_ instanceof EntityLivingBase;
                      flag2 = flag2 && !this.func_70051_ag();
  
@@ -300,7 +317,7 @@
                      }
  
                      f = f + f1;
-@@ -1332,10 +1417,12 @@
+@@ -1332,11 +1418,13 @@
  
                          if (!itemstack1.func_190926_b() && entity instanceof EntityLivingBase)
                          {
@@ -309,11 +326,13 @@
  
                              if (itemstack1.func_190926_b())
                              {
-+                                net.minecraftforge.event.ForgeEventFactory.onPlayerDestroyItem(this, beforeHitCopy, EnumHand.MAIN_HAND);
-                                 this.func_184611_a(EnumHand.MAIN_HAND, ItemStack.field_190927_a);
+-                                this.func_184611_a(EnumHand.MAIN_HAND, ItemStack.field_190927_a);
++                            	ItemStack resultStack = net.minecraftforge.event.ForgeEventFactory.onPlayerDestroyItem(this, beforeHitCopy, EnumHand.MAIN_HAND);
++                                this.func_184611_a(EnumHand.MAIN_HAND, resultStack);
                              }
                          }
-@@ -1384,7 +1471,7 @@
+ 
+@@ -1384,7 +1472,7 @@
  
          if (this.field_70146_Z.nextFloat() < f)
          {
@@ -322,7 +341,7 @@
              this.func_184602_cy();
              this.field_70170_p.func_72960_a(this, (byte)30);
          }
-@@ -1442,7 +1529,11 @@
+@@ -1442,7 +1530,11 @@
  
      public EntityPlayer.SleepResult func_180469_a(BlockPos p_180469_1_)
      {
@@ -335,7 +354,7 @@
  
          if (!this.field_70170_p.field_72995_K)
          {
-@@ -1484,8 +1575,7 @@
+@@ -1484,8 +1576,7 @@
          this.func_192030_dh();
          this.func_70105_a(0.2F, 0.2F);
  
@@ -345,7 +364,7 @@
              float f1 = 0.5F + (float)enumfacing.func_82601_c() * 0.4F;
              float f = 0.5F + (float)enumfacing.func_82599_e() * 0.4F;
              this.func_175139_a(enumfacing);
-@@ -1517,6 +1607,7 @@
+@@ -1517,6 +1608,7 @@
          {
              return true;
          }
@@ -353,7 +372,7 @@
          else
          {
              BlockPos blockpos = p_190774_1_.func_177972_a(p_190774_2_.func_176734_d());
-@@ -1532,13 +1623,14 @@
+@@ -1532,13 +1624,14 @@
  
      public void func_70999_a(boolean p_70999_1_, boolean p_70999_2_, boolean p_70999_3_)
      {
@@ -372,7 +391,7 @@
  
              if (blockpos == null)
              {
-@@ -1547,6 +1639,10 @@
+@@ -1547,6 +1640,10 @@
  
              this.func_70107_b((double)((float)blockpos.func_177958_n() + 0.5F), (double)((float)blockpos.func_177956_o() + 0.1F), (double)((float)blockpos.func_177952_p() + 0.5F));
          }
@@ -383,7 +402,7 @@
  
          this.field_71083_bS = false;
  
-@@ -1565,15 +1661,16 @@
+@@ -1565,15 +1662,16 @@
  
      private boolean func_175143_p()
      {
@@ -403,7 +422,7 @@
          {
              if (!p_180467_2_)
              {
-@@ -1588,16 +1685,17 @@
+@@ -1588,16 +1686,17 @@
          }
          else
          {
@@ -424,7 +443,7 @@
  
              switch (enumfacing)
              {
-@@ -1637,16 +1735,24 @@
+@@ -1637,16 +1736,24 @@
  
      public BlockPos func_180470_cg()
      {
@@ -451,7 +470,7 @@
          if (p_180473_1_ != null)
          {
              this.field_71077_c = p_180473_1_;
-@@ -1839,6 +1945,10 @@
+@@ -1839,6 +1946,10 @@
  
              super.func_180430_e(p_180430_1_, p_180430_2_);
          }
@@ -462,7 +481,7 @@
      }
  
      protected void func_71061_d_()
-@@ -2176,7 +2286,10 @@
+@@ -2176,7 +2287,10 @@
  
      public ITextComponent func_145748_c_()
      {
@@ -474,7 +493,7 @@
          itextcomponent.func_150256_b().func_150241_a(new ClickEvent(ClickEvent.Action.SUGGEST_COMMAND, "/msg " + this.func_70005_c_() + " "));
          itextcomponent.func_150256_b().func_150209_a(this.func_174823_aP());
          itextcomponent.func_150256_b().func_179989_a(this.func_70005_c_());
-@@ -2185,7 +2298,7 @@
+@@ -2185,7 +2299,7 @@
  
      public float func_70047_e()
      {
@@ -483,7 +502,7 @@
  
          if (this.func_70608_bn())
          {
-@@ -2421,6 +2534,168 @@
+@@ -2421,6 +2535,168 @@
          return this.field_71075_bZ.field_75098_d && this.func_70003_b(2, "");
      }
  

--- a/patches/minecraft/net/minecraft/server/management/PlayerInteractionManager.java.patch
+++ b/patches/minecraft/net/minecraft/server/management/PlayerInteractionManager.java.patch
@@ -126,7 +126,7 @@
          {
              return false;
          }
-@@ -264,53 +298,41 @@
+@@ -264,53 +298,45 @@
              }
              else
              {
@@ -174,7 +174,11 @@
                      if (!itemstack1.func_190926_b())
                      {
                          itemstack1.func_179548_a(this.field_73092_a, iblockstate, p_180237_1_, this.field_73090_b);
-+                        if (itemstack1.func_190926_b()) net.minecraftforge.event.ForgeEventFactory.onPlayerDestroyItem(this.field_73090_b, itemstack2, EnumHand.MAIN_HAND);
++                        if (itemstack1.func_190926_b())
++                        {
++                        	ItemStack resultStack = net.minecraftforge.event.ForgeEventFactory.onPlayerDestroyItem(this.field_73090_b, itemstack2, EnumHand.MAIN_HAND);
++                        	this.field_73090_b.func_184611_a(EnumHand.MAIN_HAND, resultStack);
++                        }
                      }
  
 +                    flag1 = this.removeBlock(p_180237_1_, flag);
@@ -192,7 +196,7 @@
                  return flag1;
              }
          }
-@@ -328,8 +350,11 @@
+@@ -328,8 +354,11 @@
          }
          else
          {
@@ -204,15 +208,17 @@
              ActionResult<ItemStack> actionresult = p_187250_3_.func_77957_a(p_187250_2_, p_187250_1_, p_187250_4_);
              ItemStack itemstack = actionresult.func_188398_b();
  
-@@ -357,6 +382,7 @@
+@@ -357,7 +386,8 @@
  
                  if (itemstack.func_190926_b())
                  {
-+                    net.minecraftforge.event.ForgeEventFactory.onPlayerDestroyItem(p_187250_1_, copyBeforeUse, p_187250_4_);
-                     p_187250_1_.func_184611_a(p_187250_4_, ItemStack.field_190927_a);
+-                    p_187250_1_.func_184611_a(p_187250_4_, ItemStack.field_190927_a);
++                	ItemStack resultStack = net.minecraftforge.event.ForgeEventFactory.onPlayerDestroyItem(p_187250_1_, copyBeforeUse, p_187250_4_);
++                    p_187250_1_.func_184611_a(p_187250_4_, resultStack);
                  }
  
-@@ -402,13 +428,27 @@
+                 if (!p_187250_1_.func_184587_cr())
+@@ -402,13 +432,27 @@
          }
          else
          {
@@ -243,7 +249,7 @@
                  }
              }
  
-@@ -436,14 +476,22 @@
+@@ -436,14 +480,26 @@
                  {
                      int j = p_187251_3_.func_77960_j();
                      int i = p_187251_3_.func_190916_E();
@@ -262,12 +268,16 @@
 +                            || result == EnumActionResult.SUCCESS && event.getUseItem() == net.minecraftforge.fml.common.eventhandler.Event.Result.ALLOW) {
 +                        ItemStack copyBeforeUse = p_187251_3_.func_77946_l();
 +                        result = p_187251_3_.func_179546_a(p_187251_1_, p_187251_2_, p_187251_5_, p_187251_4_, p_187251_6_, p_187251_7_, p_187251_8_, p_187251_9_);
-+                        if (p_187251_3_.func_190926_b()) net.minecraftforge.event.ForgeEventFactory.onPlayerDestroyItem(p_187251_1_, copyBeforeUse, p_187251_4_);
++                        if (p_187251_3_.func_190926_b())
++                        {
++                        	ItemStack resultStack = net.minecraftforge.event.ForgeEventFactory.onPlayerDestroyItem(p_187251_1_, copyBeforeUse, p_187251_4_);
++                        	p_187251_1_.func_184611_a(p_187251_4_, resultStack);
++                        }
 +                    } return result;
                  }
              }
          }
-@@ -453,4 +501,16 @@
+@@ -453,4 +509,16 @@
      {
          this.field_73092_a = p_73080_1_;
      }

--- a/src/main/java/net/minecraftforge/event/ForgeEventFactory.java
+++ b/src/main/java/net/minecraftforge/event/ForgeEventFactory.java
@@ -174,9 +174,11 @@ public class ForgeEventFactory
         return (MinecraftForge.EVENT_BUS.post(event) ? -1 : event.getNewSpeed());
     }
 
-    public static void onPlayerDestroyItem(EntityPlayer player, @Nonnull ItemStack stack, @Nullable EnumHand hand)
+    public static ItemStack onPlayerDestroyItem(EntityPlayer player, @Nonnull ItemStack stack, @Nullable EnumHand hand)
     {
-        MinecraftForge.EVENT_BUS.post(new PlayerDestroyItemEvent(player, stack, hand));
+    	PlayerDestroyItemEvent event = new PlayerDestroyItemEvent(player, stack, hand);
+        MinecraftForge.EVENT_BUS.post(event);
+        return event.getResultStack();
     }
 
     /**

--- a/src/main/java/net/minecraftforge/event/entity/player/PlayerDestroyItemEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/player/PlayerDestroyItemEvent.java
@@ -54,7 +54,8 @@ import javax.annotation.Nullable;
  * and {@link PlayerInteractionManager#tryHarvestBlock(BlockPos)}.<br>
  * <br>
  * {@link #original} contains the original ItemStack before the item was destroyed. <br>
- * (@link #hand) contains the hand that the current item was held in.<br>
+ * {@link #resultStack} contains the result ItemStack that is placed in the active hand of the player (if {@link #hand} is not null). <br>
+ * {@link #hand} contains the hand that the current item was held in.<br>
  * <br>
  * This event is not {@link Cancelable}.<br>
  * <br>
@@ -67,6 +68,8 @@ public class PlayerDestroyItemEvent extends PlayerEvent
 {
     @Nonnull
     private final ItemStack original;
+    @Nonnull
+    private ItemStack resultStack = ItemStack.EMPTY;
     @Nullable
     private final EnumHand hand; // May be null if this player destroys the item by any use besides holding it.
     public PlayerDestroyItemEvent(EntityPlayer player, @Nonnull ItemStack original, @Nullable EnumHand hand)
@@ -80,5 +83,8 @@ public class PlayerDestroyItemEvent extends PlayerEvent
     public ItemStack getOriginal() { return this.original; }
     @Nullable
     public EnumHand getHand() { return this.hand; }
+    @Nonnull
+    public ItemStack getResultStack() { return this.resultStack; }
+    public void setResultStack(ItemStack stack) { this.resultStack = stack; }
 
 }


### PR DESCRIPTION
It's not always possible to replace an item in the player's hand, after it was broken.
[Here](https://github.com/MinecraftForge/MinecraftForge/blob/1.12.x/patches/minecraft/net/minecraft/server/management/PlayerInteractionManager.java.patch#L212) the item is removed after `PlayerDestroyItemEvent` was fired.
That's why I added a result itemstack that is placed in the players's hand.
I'm not sure if the result stack should be returned [here](https://github.com/MinecraftForge/MinecraftForge/blob/1.12.x/src/main/java/net/minecraftforge/common/ForgeHooks.java#L1017) as well.

Tell me if a test mod is necessary.