### PR TITLE
Modified Minecraft and IntegratedServer to crash to the title screen instead of just stopping the game

### DIFF
--- a/patches/minecraft/net/minecraft/client/Minecraft.java.patch
+++ b/patches/minecraft/net/minecraft/client/Minecraft.java.patch
@@ -26,6 +26,7 @@
 +                                if(this.integratedServerCrash == null) {
 +                                    this.func_71403_a((WorldClient) null);
 +                                    this.field_152351_aB.clear();
++                                    net.minecraftforge.fml.client.ClientStateReset.resetAllClientState();
 +                                    CrashReport worldcrash;
 +                                    if (t instanceof ReportedException) {
 +                                        worldcrash = ((ReportedException) t).func_71575_a();
@@ -361,7 +362,15 @@
          if (p_71353_1_ == null)
          {
              NetHandlerPlayClient nethandlerplayclient = this.func_147114_u();
-@@ -2395,6 +2445,18 @@
+ 
+             if (nethandlerplayclient != null)
+             {
++                if(nethandlerplayclient.func_147298_b().func_150724_d()) {
++                    nethandlerplayclient.func_147298_b().func_150718_a(new TextComponentString("World is being unloaded")); //MC-128953
++                }
+                 nethandlerplayclient.func_147296_c();
+             }
+ 
              if (this.field_71437_Z != null && this.field_71437_Z.func_175578_N())
              {
                  this.field_71437_Z.func_71263_m();

--- a/patches/minecraft/net/minecraft/client/Minecraft.java.patch
+++ b/patches/minecraft/net/minecraft/client/Minecraft.java.patch
@@ -1,6 +1,14 @@
 --- ../src-base/minecraft/net/minecraft/client/Minecraft.java
 +++ ../src-work/minecraft/net/minecraft/client/Minecraft.java
-@@ -344,7 +344,6 @@
+@@ -328,6 +328,7 @@
+     private final Tutorial field_193035_aW;
+     long field_71421_N = -1L;
+     private String field_71465_an = "root";
++    public CrashReport integratedServerCrash = null;
+ 
+     public Minecraft(GameConfiguration p_i45547_1_)
+     {
+@@ -344,7 +345,6 @@
          this.field_152355_az = (new YggdrasilAuthenticationService(this.field_110453_aa, UUID.randomUUID().toString())).createMinecraftSessionService();
          this.field_71449_j = p_i45547_1_.field_178745_a.field_178752_a;
          field_147123_G.info("Setting user: {}", (Object)this.field_71449_j.func_111285_a());
@@ -8,7 +16,55 @@
          this.field_71459_aj = p_i45547_1_.field_178741_d.field_178756_a;
          this.field_71443_c = p_i45547_1_.field_178743_b.field_178764_a > 0 ? p_i45547_1_.field_178743_b.field_178764_a : 1;
          this.field_71440_d = p_i45547_1_.field_178743_b.field_178762_b > 0 ? p_i45547_1_.field_178743_b.field_178762_b : 1;
-@@ -464,10 +463,10 @@
+@@ -395,6 +395,8 @@
+                     {
+                         try
+                         {
++                        try
++                        {
+                             this.func_71411_J();
+                         }
+                         catch (OutOfMemoryError var10)
+@@ -403,6 +405,38 @@
+                             this.func_147108_a(new GuiMemoryErrorScreen());
+                             System.gc();
+                         }
++                        }
++                        catch(Throwable t) // Forge: catch exceptions in the game loop, then display an error screen instead of System.exit
++                        {
++                            if (this.field_71441_e != null) { //only if a world is loaded
++                                if(this.integratedServerCrash != null)
++                                {
++                                    this.field_71441_e.func_72882_A();
++                                    this.func_71403_a((WorldClient) null);
++                                }
++                                this.field_152351_aB.clear();
++                                CrashReport worldcrash;
++                                if (t instanceof ReportedException) {
++                                    worldcrash = ((ReportedException) t).func_71575_a();
++                                } else {
++                                    worldcrash = new CrashReport("Unexpected error", t);
++                                }
++                                this.func_71396_d(worldcrash);
++                                field_147123_G.fatal("Exception thrown client world tick!", t);
++                                Bootstrap.func_179870_a(worldcrash.func_71502_e());
++                                this.field_71417_B.func_74373_b();
++                                this.func_147108_a(new net.minecraftforge.fml.client.GuiWorldTickException(worldcrash, false));
++                            } else {
++                                throw t; //throw it normally otherwise
++                            }
++                    	}
++                    	
++                    	if(this.integratedServerCrash != null) //display the integrated server's crash, if any, see IntegratedServer:237
++                    	{
++                		    this.func_147108_a(new net.minecraftforge.fml.client.GuiWorldTickException(this.integratedServerCrash, true));
++                		    this.integratedServerCrash = null;
++                    	} //forge end
++                    	
+                     }
+                     else
+                     {
+@@ -464,10 +498,10 @@
          this.field_110451_am = new SimpleReloadableResourceManager(this.field_110452_an);
          this.field_135017_as = new LanguageManager(this.field_110452_an, this.field_71474_y.field_74363_ab);
          this.field_110451_am.func_110542_a(this.field_135017_as);

--- a/patches/minecraft/net/minecraft/client/Minecraft.java.patch
+++ b/patches/minecraft/net/minecraft/client/Minecraft.java.patch
@@ -221,7 +221,15 @@
          }
  
          this.field_71424_I.func_76319_b();
-@@ -1455,9 +1476,9 @@
+@@ -1237,6 +1291,7 @@
+         {
+             System.gc();
+             this.func_71403_a((WorldClient)null);
++            net.minecraftforge.fml.client.ClientStateReset.resetAllClientState();
+         }
+         catch (Throwable var2)
+         {
+@@ -1455,9 +1510,9 @@
              {
                  BlockPos blockpos = this.field_71476_x.func_178782_a();
  

--- a/patches/minecraft/net/minecraft/client/Minecraft.java.patch
+++ b/patches/minecraft/net/minecraft/client/Minecraft.java.patch
@@ -23,23 +23,21 @@
 +                        catch(Throwable t) // Forge: catch exceptions in the game loop, then display an error screen instead of System.exit
 +                        {
 +                            if (this.field_71441_e != null) { //only if a world is loaded
-+                                if(this.integratedServerCrash != null)
-+                                {
-+                                    this.field_71441_e.func_72882_A();
++                                if(this.integratedServerCrash == null) {
 +                                    this.func_71403_a((WorldClient) null);
++                                    this.field_152351_aB.clear();
++                                    CrashReport worldcrash;
++                                    if (t instanceof ReportedException) {
++                                        worldcrash = ((ReportedException) t).func_71575_a();
++                                    } else {
++                                        worldcrash = new CrashReport("Unexpected error", t);
++                                    }
++                                    this.func_71396_d(worldcrash);
++                                    field_147123_G.fatal("Exception thrown client world tick!", t);
++                                    Bootstrap.func_179870_a(worldcrash.func_71502_e());
++                                    this.field_71417_B.func_74373_b();
++                                    this.func_147108_a(new net.minecraftforge.fml.client.GuiWorldTickException(worldcrash, false));
 +                                }
-+                                this.field_152351_aB.clear();
-+                                CrashReport worldcrash;
-+                                if (t instanceof ReportedException) {
-+                                    worldcrash = ((ReportedException) t).func_71575_a();
-+                                } else {
-+                                    worldcrash = new CrashReport("Unexpected error", t);
-+                                }
-+                                this.func_71396_d(worldcrash);
-+                                field_147123_G.fatal("Exception thrown client world tick!", t);
-+                                Bootstrap.func_179870_a(worldcrash.func_71502_e());
-+                                this.field_71417_B.func_74373_b();
-+                                this.func_147108_a(new net.minecraftforge.fml.client.GuiWorldTickException(worldcrash, false));
 +                            } else {
 +                                throw t; //throw it normally otherwise
 +                            }
@@ -47,6 +45,8 @@
 +                    	
 +                        if(this.integratedServerCrash != null) //display the integrated server's crash, if any, see IntegratedServer:237
 +                        {
++                            this.func_71403_a((WorldClient) null);
++                            this.field_152351_aB.clear();
 +                            this.func_147108_a(new net.minecraftforge.fml.client.GuiWorldTickException(this.integratedServerCrash, true));
 +                            this.integratedServerCrash = null;
 +                        } //forge end

--- a/patches/minecraft/net/minecraft/client/Minecraft.java.patch
+++ b/patches/minecraft/net/minecraft/client/Minecraft.java.patch
@@ -16,20 +16,10 @@
          this.field_71459_aj = p_i45547_1_.field_178741_d.field_178756_a;
          this.field_71443_c = p_i45547_1_.field_178743_b.field_178764_a > 0 ? p_i45547_1_.field_178743_b.field_178764_a : 1;
          this.field_71440_d = p_i45547_1_.field_178743_b.field_178762_b > 0 ? p_i45547_1_.field_178743_b.field_178762_b : 1;
-@@ -395,6 +395,8 @@
-                     {
-                         try
-                         {
-+                        try
-+                        {
-                             this.func_71411_J();
-                         }
-                         catch (OutOfMemoryError var10)
-@@ -403,6 +405,38 @@
+@@ -403,6 +403,37 @@
                              this.func_147108_a(new GuiMemoryErrorScreen());
                              System.gc();
                          }
-+                        }
 +                        catch(Throwable t) // Forge: catch exceptions in the game loop, then display an error screen instead of System.exit
 +                        {
 +                            if (this.field_71441_e != null) { //only if a world is loaded
@@ -55,16 +45,16 @@
 +                            }
 +                    	}
 +                    	
-+                    	if(this.integratedServerCrash != null) //display the integrated server's crash, if any, see IntegratedServer:237
-+                    	{
-+                		    this.func_147108_a(new net.minecraftforge.fml.client.GuiWorldTickException(this.integratedServerCrash, true));
-+                		    this.integratedServerCrash = null;
-+                    	} //forge end
++                        if(this.integratedServerCrash != null) //display the integrated server's crash, if any, see IntegratedServer:237
++                        {
++                            this.func_147108_a(new net.minecraftforge.fml.client.GuiWorldTickException(this.integratedServerCrash, true));
++                            this.integratedServerCrash = null;
++                        } //forge end
 +                    	
                      }
                      else
                      {
-@@ -464,10 +498,10 @@
+@@ -464,10 +495,10 @@
          this.field_110451_am = new SimpleReloadableResourceManager(this.field_110452_an);
          this.field_135017_as = new LanguageManager(this.field_110452_an, this.field_71474_y.field_74363_ab);
          this.field_110451_am.func_110542_a(this.field_135017_as);

--- a/patches/minecraft/net/minecraft/client/renderer/BufferBuilder.java.patch
+++ b/patches/minecraft/net/minecraft/client/renderer/BufferBuilder.java.patch
@@ -1,6 +1,32 @@
 --- ../src-base/minecraft/net/minecraft/client/renderer/BufferBuilder.java
 +++ ../src-work/minecraft/net/minecraft/client/renderer/BufferBuilder.java
-@@ -123,6 +123,8 @@
+@@ -18,7 +18,7 @@
+ import org.apache.logging.log4j.Logger;
+ 
+ @SideOnly(Side.CLIENT)
+-public class BufferBuilder
++public class BufferBuilder implements net.minecraftforge.fml.client.ClientStateReset.IStateResettable
+ {
+     private static final Logger field_187316_a = LogManager.getLogger();
+     private ByteBuffer field_179001_a;
+@@ -38,11 +38,16 @@
+ 
+     public BufferBuilder(int p_i46275_1_)
+     {
++        net.minecraftforge.fml.client.ClientStateReset.addResettable(this);
+         this.field_179001_a = GLAllocation.func_74524_c(p_i46275_1_ * 4);
+         this.field_178999_b = this.field_179001_a.asIntBuffer();
+         this.field_181676_c = this.field_179001_a.asShortBuffer();
+         this.field_179000_c = this.field_179001_a.asFloatBuffer();
+     }
++    
++    public void resetState() {
++        if (field_179010_r) func_178977_d();
++    }
+ 
+     private void func_181670_b(int p_181670_1_)
+     {
+@@ -123,6 +128,8 @@
  
              bitset.set(i1);
          }

--- a/patches/minecraft/net/minecraft/client/renderer/tileentity/TileEntityRendererDispatcher.java.patch
+++ b/patches/minecraft/net/minecraft/client/renderer/tileentity/TileEntityRendererDispatcher.java.patch
@@ -1,6 +1,34 @@
 --- ../src-base/minecraft/net/minecraft/client/renderer/tileentity/TileEntityRendererDispatcher.java
 +++ ../src-work/minecraft/net/minecraft/client/renderer/tileentity/TileEntityRendererDispatcher.java
-@@ -92,7 +92,7 @@
+@@ -35,7 +35,7 @@
+ import net.minecraftforge.fml.relauncher.SideOnly;
+ 
+ @SideOnly(Side.CLIENT)
+-public class TileEntityRendererDispatcher
++public class TileEntityRendererDispatcher implements net.minecraftforge.fml.client.ClientStateReset.IStateResettable
+ {
+     public final Map < Class <? extends TileEntity > , TileEntitySpecialRenderer <? extends TileEntity >> field_147559_m = Maps. < Class <? extends TileEntity > , TileEntitySpecialRenderer <? extends TileEntity >> newHashMap();
+     public static TileEntityRendererDispatcher field_147556_a = new TileEntityRendererDispatcher();
+@@ -55,6 +55,7 @@
+ 
+     private TileEntityRendererDispatcher()
+     {
++        net.minecraftforge.fml.client.ClientStateReset.addResettable(this);
+         this.field_147559_m.put(TileEntitySign.class, new TileEntitySignRenderer());
+         this.field_147559_m.put(TileEntityMobSpawner.class, new TileEntityMobSpawnerRenderer());
+         this.field_147559_m.put(TileEntityPiston.class, new TileEntityPistonRenderer());
+@@ -75,6 +76,10 @@
+             tileentityspecialrenderer.func_147497_a(this);
+         }
+     }
++    
++    public void resetState() {
++        if (drawingBatch) drawingBatch = false;
++    }
+ 
+     public <T extends TileEntity> TileEntitySpecialRenderer<T> func_147546_a(Class <? extends TileEntity > p_147546_1_)
+     {
+@@ -92,7 +97,7 @@
      @Nullable
      public <T extends TileEntity> TileEntitySpecialRenderer<T> func_147547_b(@Nullable TileEntity p_147547_1_)
      {

--- a/patches/minecraft/net/minecraft/server/integrated/IntegratedServer.java.patch
+++ b/patches/minecraft/net/minecraft/server/integrated/IntegratedServer.java.patch
@@ -58,55 +58,55 @@
  
      public void func_71217_p()
      {
-+        if(this.field_71349_l.integratedServerCrash != null) return;
++        try
++        {
          boolean flag = this.field_71348_o;
          this.field_71348_o = Minecraft.func_71410_x().func_147114_u() != null && Minecraft.func_71410_x().func_147113_T();
  
-@@ -167,37 +187,56 @@
+@@ -155,13 +172,19 @@
+             this.func_71267_a(false);
          }
-         else
-         {
-+            try
-+            {
-             super.func_71217_p();
  
-             if (this.field_71349_l.field_71474_y.field_151451_c != this.func_184103_al().func_72395_o())
-@@ -198,6 +216,34 @@
-                     }
+-        if (this.field_71348_o)
++        if (this.field_71348_o || this.field_71349_l.integratedServerCrash != null) //to be shut down correctly the server needs this to process the client's messages, ugly but effective
+         {
+             synchronized (this.field_175589_i)
+             {
+                 while (!this.field_175589_i.isEmpty())
+                 {
++                    try {
+                     Util.func_181617_a(this.field_175589_i.poll(), field_147148_h);
++                    }catch(Throwable t) {
++                        if(this.field_71349_l.integratedServerCrash == null) {
++                            throw t;
++                        }
++                    }
                  }
              }
-+            }
-+            catch(Throwable t) //Forge: just close the world instead of stopping the whole game
-+            {
-+                CrashReport worldcrash;
-+                if(t instanceof net.minecraft.util.ReportedException) {
-+                    worldcrash = ((net.minecraft.util.ReportedException)t).func_71575_a();
-+                }else {
-+                    worldcrash = new CrashReport("Unexpected error", t);
-+                }
-+                this.func_71230_b(worldcrash);
-+                field_147148_h.fatal("Exception thrown in server world tick!", t);
-+                net.minecraft.init.Bootstrap.func_179870_a(worldcrash.func_71502_e());
-+                
-+                for (EntityPlayerMP entityplayermp : Lists.newArrayList(IntegratedServer.this.func_184103_al().func_181057_v()))
-+                {
-+                    IntegratedServer.this.func_184103_al().func_72367_e(entityplayermp);
-+                }
-+                
-+                super.func_71263_m();
-+                
-+                try {
-+                    Thread.sleep(100L);
-+                }catch(InterruptedException e){
-+                    ;
-+                }
-+
-+                this.field_71349_l.integratedServerCrash = worldcrash;
-+            }
          }
+@@ -199,6 +222,21 @@
+                 }
+             }
+         }
++        }
++        catch(Throwable t) //Forge: just close the world instead of stopping the whole game
++        {
++            CrashReport worldcrash;
++            if(t instanceof net.minecraft.util.ReportedException) {
++                worldcrash = ((net.minecraft.util.ReportedException)t).func_71575_a();
++            }else {
++                worldcrash = new CrashReport("Unexpected error", t);
++            }
++            this.func_71230_b(worldcrash);
++            field_147148_h.fatal("Exception thrown in server world tick!", t);
++            net.minecraft.init.Bootstrap.func_179870_a(worldcrash.func_71502_e());
++
++            this.field_71349_l.integratedServerCrash = worldcrash;
++        }
      }
  
-@@ -213,6 +259,7 @@
+     public boolean func_71225_e()
+@@ -213,6 +251,7 @@
  
      public EnumDifficulty func_147135_j()
      {

--- a/patches/minecraft/net/minecraft/server/integrated/IntegratedServer.java.patch
+++ b/patches/minecraft/net/minecraft/server/integrated/IntegratedServer.java.patch
@@ -57,7 +57,56 @@
      }
  
      public void func_71217_p()
-@@ -213,6 +228,7 @@
+     {
++        if(this.field_71349_l.integratedServerCrash != null) return;
+         boolean flag = this.field_71348_o;
+         this.field_71348_o = Minecraft.func_71410_x().func_147114_u() != null && Minecraft.func_71410_x().func_147113_T();
+ 
+@@ -167,37 +187,56 @@
+         }
+         else
+         {
++            try
++            {
+             super.func_71217_p();
+ 
+             if (this.field_71349_l.field_71474_y.field_151451_c != this.func_184103_al().func_72395_o())
+@@ -198,6 +216,34 @@
+                     }
+                 }
+             }
++            }
++            catch(Throwable t) //Forge: just close the world instead of stopping the whole game
++            {
++                CrashReport worldcrash;
++                if(t instanceof net.minecraft.util.ReportedException) {
++                    worldcrash = ((net.minecraft.util.ReportedException)t).func_71575_a();
++                }else {
++                    worldcrash = new CrashReport("Unexpected error", t);
++                }
++                this.func_71230_b(worldcrash);
++                field_147148_h.fatal("Exception thrown in server world tick!", t);
++                net.minecraft.init.Bootstrap.func_179870_a(worldcrash.func_71502_e());
++                
++                for (EntityPlayerMP entityplayermp : Lists.newArrayList(IntegratedServer.this.func_184103_al().func_181057_v()))
++                {
++                    IntegratedServer.this.func_184103_al().func_72367_e(entityplayermp);
++                }
++                
++                super.func_71263_m();
++                
++                try {
++                    Thread.sleep(100L);
++                }catch(InterruptedException e){
++                    ;
++                }
++
++                this.field_71349_l.integratedServerCrash = worldcrash;
++            }
+         }
+     }
+ 
+@@ -213,6 +259,7 @@
  
      public EnumDifficulty func_147135_j()
      {

--- a/src/main/java/net/minecraftforge/fml/client/ClientStateReset.java
+++ b/src/main/java/net/minecraftforge/fml/client/ClientStateReset.java
@@ -1,0 +1,208 @@
+/*
+ * Minecraft Forge
+ * Copyright (c) 2016-2018.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation version 2.1
+ * of the License.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+package net.minecraftforge.fml.client;
+
+import org.lwjgl.opengl.GL11;
+import org.lwjgl.opengl.GL12;
+import org.lwjgl.opengl.GL13;
+import org.lwjgl.opengl.GL14;
+import org.lwjgl.opengl.GL15;
+import org.lwjgl.opengl.GLContext;
+import org.lwjgl.util.glu.GLU;
+
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.renderer.GlStateManager;
+import net.minecraft.client.renderer.OpenGlHelper;
+import net.minecraft.client.renderer.RenderHelper;
+
+public class ClientStateReset {
+    
+    /**
+     * Resets all opengl and network state on the client side, during a crash
+     */
+    public static void resetAllClientState() {
+        Minecraft mc = Minecraft.getMinecraft();
+        
+        int j;
+        while ((j = GlStateManager.glGetError()) != 0) //clear existing gl errors
+        {
+            String s = GLU.gluErrorString(j);
+            System.out.printf("########## GL ERROR ##########");
+            System.out.printf("@ {}", s);
+            System.out.printf("{}: {}", Integer.valueOf(j), s);
+        }
+        
+        //This was made by Runemoro for their VanillaFix mod, original available at https://github.com/DimensionalDevelopment/VanillaFix/blob/master/src/main/java/org/dimdev/utils/GlUtil.java
+        //I modified it a lot tho
+        
+        if (mc.entityRenderer.isShaderActive()) mc.entityRenderer.stopUseShader();
+        
+        //reset opengl matrix stacks
+        GlStateManager.matrixMode(GL11.GL_MODELVIEW);
+        try {
+            do GL11.glPopMatrix(); while (GlStateManager.glGetError() == 0);
+        } catch (Throwable ignored) {}
+        GlStateManager.loadIdentity();
+        GlStateManager.matrixMode(GL11.GL_PROJECTION);
+        try {
+            do GL11.glPopMatrix(); while (GlStateManager.glGetError() == 0);
+        } catch (Throwable ignored) {}
+        GlStateManager.loadIdentity();
+        GlStateManager.matrixMode(GL11.GL_TEXTURE);
+        try {
+            do GL11.glPopMatrix(); while (GlStateManager.glGetError() == 0);
+        } catch (Throwable ignored) {}
+        GlStateManager.loadIdentity();
+        GlStateManager.matrixMode(GL11.GL_COLOR);
+        try {
+            do GL11.glPopMatrix(); while (GlStateManager.glGetError() == 0);
+        } catch (Throwable ignored) {}
+        GlStateManager.loadIdentity();
+        
+        //TODO: add these lines in 1.13 where lwjgl should be fixed
+        
+        /*
+        try {
+             do GL11.glPopAttrib(); while (GlStateManager.glGetError() == 0);
+        } catch (Throwable ignored) {}
+        try {
+            do GL11.glPopClientAttrib(); while (GlStateManager.glGetError() == 0);
+        } catch (Throwable ignored) {}
+        */
+        
+        GlStateManager.bindTexture(0);
+        GlStateManager.disableTexture2D();
+        
+        GlStateManager.disableLighting();
+        GlStateManager.glLightModel(GL11.GL_LIGHT_MODEL_AMBIENT, RenderHelper.setColorBuffer(0.2F, 0.2F, 0.2F, 1.0F));
+        for (int i = 0; i < 8; ++i) {
+            GlStateManager.disableLight(i);
+            GlStateManager.glLight(GL11.GL_LIGHT0 + i, GL11.GL_AMBIENT, RenderHelper.setColorBuffer(0.0F, 0.0F, 0.0F, 1.0F));
+            GlStateManager.glLight(GL11.GL_LIGHT0 + i, GL11.GL_POSITION, RenderHelper.setColorBuffer(0.0F, 0.0F, 1.0F, 0.0F));
+
+            if (i == 0) {
+                GlStateManager.glLight(GL11.GL_LIGHT0 + i, GL11.GL_DIFFUSE, RenderHelper.setColorBuffer(1.0F, 1.0F, 1.0F, 1.0F));
+                GlStateManager.glLight(GL11.GL_LIGHT0 + i, GL11.GL_SPECULAR, RenderHelper.setColorBuffer(1.0F, 1.0F, 1.0F, 1.0F));
+            } else {
+                GlStateManager.glLight(GL11.GL_LIGHT0 + i, GL11.GL_DIFFUSE, RenderHelper.setColorBuffer(0.0F, 0.0F, 0.0F, 1.0F));
+                GlStateManager.glLight(GL11.GL_LIGHT0 + i, GL11.GL_SPECULAR, RenderHelper.setColorBuffer(0.0F, 0.0F, 0.0F, 1.0F));
+            }
+        }
+        
+        GlStateManager.disableColorMaterial();
+        GlStateManager.colorMaterial(GL11.GL_FRONT_AND_BACK, GL11.GL_AMBIENT_AND_DIFFUSE);
+        
+        GlStateManager.disableDepth();
+        GlStateManager.depthFunc(GL11.GL_LESS);
+        GlStateManager.depthMask(true);
+        
+        GlStateManager.disableBlend();
+        GlStateManager.blendFunc(GlStateManager.SourceFactor.ONE, GlStateManager.DestFactor.ZERO);
+        GlStateManager.tryBlendFuncSeparate(GlStateManager.SourceFactor.ONE, GlStateManager.DestFactor.ZERO, GlStateManager.SourceFactor.ONE, GlStateManager.DestFactor.ZERO);
+        GlStateManager.glBlendEquation(GL14.GL_FUNC_ADD);
+        
+        GlStateManager.disableFog();
+        GlStateManager.setFog(GlStateManager.FogMode.LINEAR);
+        GlStateManager.setFogDensity(1.0F);
+        GlStateManager.setFogStart(0.0F);
+        GlStateManager.setFogEnd(1.0F);
+        GlStateManager.glFog(GL11.GL_FOG_COLOR, RenderHelper.setColorBuffer(0.0F, 0.0F, 0.0F, 0.0F));
+        if (GLContext.getCapabilities().GL_NV_fog_distance) GlStateManager.glFogi(GL11.GL_FOG_MODE, 34140);
+        
+        GlStateManager.doPolygonOffset(0.0F, 0.0F);
+        GlStateManager.disablePolygonOffset();
+        
+        GlStateManager.disableColorLogic();
+        GlStateManager.colorLogicOp(5379);
+        
+        GlStateManager.disableTexGenCoord(GlStateManager.TexGen.S);
+        GlStateManager.disableTexGenCoord(GlStateManager.TexGen.T);
+        GlStateManager.disableTexGenCoord(GlStateManager.TexGen.R);
+        GlStateManager.disableTexGenCoord(GlStateManager.TexGen.Q);
+        GlStateManager.texGen(GlStateManager.TexGen.S, 9216);
+        GlStateManager.texGen(GlStateManager.TexGen.T, 9216);
+        GlStateManager.texGen(GlStateManager.TexGen.R, 9216);
+        GlStateManager.texGen(GlStateManager.TexGen.Q, 9216);
+        GlStateManager.texGen(GlStateManager.TexGen.S, 9474, RenderHelper.setColorBuffer(1.0F, 0.0F, 0.0F, 0.0F));
+        GlStateManager.texGen(GlStateManager.TexGen.T, 9474, RenderHelper.setColorBuffer(0.0F, 1.0F, 0.0F, 0.0F));
+        GlStateManager.texGen(GlStateManager.TexGen.R, 9474, RenderHelper.setColorBuffer(0.0F, 0.0F, 1.0F, 0.0F));
+        GlStateManager.texGen(GlStateManager.TexGen.Q, 9474, RenderHelper.setColorBuffer(0.0F, 0.0F, 0.0F, 1.0F));
+        GlStateManager.texGen(GlStateManager.TexGen.S, 9217, RenderHelper.setColorBuffer(1.0F, 0.0F, 0.0F, 0.0F));
+        GlStateManager.texGen(GlStateManager.TexGen.T, 9217, RenderHelper.setColorBuffer(0.0F, 1.0F, 0.0F, 0.0F));
+        GlStateManager.texGen(GlStateManager.TexGen.R, 9217, RenderHelper.setColorBuffer(0.0F, 0.0F, 1.0F, 0.0F));
+        GlStateManager.texGen(GlStateManager.TexGen.Q, 9217, RenderHelper.setColorBuffer(0.0F, 0.0F, 0.0F, 1.0F));
+        
+        GlStateManager.setActiveTexture(OpenGlHelper.lightmapTexUnit);
+        GlStateManager.disableTexture2D();
+        
+        GlStateManager.setActiveTexture(OpenGlHelper.defaultTexUnit);
+        
+        GlStateManager.glTexParameteri(GL11.GL_TEXTURE_2D, GL11.GL_TEXTURE_MAG_FILTER, GL11.GL_LINEAR);
+        GlStateManager.glTexParameteri(GL11.GL_TEXTURE_2D, GL11.GL_TEXTURE_MIN_FILTER, GL11.GL_NEAREST_MIPMAP_LINEAR);
+        GlStateManager.glTexParameteri(GL11.GL_TEXTURE_2D, GL11.GL_TEXTURE_WRAP_S, GL11.GL_REPEAT);
+        GlStateManager.glTexParameteri(GL11.GL_TEXTURE_2D, GL11.GL_TEXTURE_WRAP_T, GL11.GL_REPEAT);
+        GlStateManager.glTexParameteri(GL11.GL_TEXTURE_2D, GL12.GL_TEXTURE_MAX_LEVEL, 1000);
+        GlStateManager.glTexParameteri(GL11.GL_TEXTURE_2D, GL12.GL_TEXTURE_MAX_LOD, 1000);
+        GlStateManager.glTexParameteri(GL11.GL_TEXTURE_2D, GL12.GL_TEXTURE_MIN_LOD, -1000);
+        GlStateManager.glTexParameterf(GL11.GL_TEXTURE_2D, GL14.GL_TEXTURE_LOD_BIAS, 0.0F);
+        
+        GlStateManager.glTexEnvi(GL11.GL_TEXTURE_ENV, GL11.GL_TEXTURE_ENV_MODE, GL11.GL_MODULATE);
+        GlStateManager.glTexEnv(GL11.GL_TEXTURE_ENV, GL11.GL_TEXTURE_ENV_COLOR, RenderHelper.setColorBuffer(0.0F, 0.0F, 0.0F, 0.0F));
+        GlStateManager.glTexEnvi(GL11.GL_TEXTURE_ENV, GL13.GL_COMBINE_RGB, GL11.GL_MODULATE);
+        GlStateManager.glTexEnvi(GL11.GL_TEXTURE_ENV, GL13.GL_COMBINE_ALPHA, GL11.GL_MODULATE);
+        GlStateManager.glTexEnvi(GL11.GL_TEXTURE_ENV, GL15.GL_SRC0_RGB, GL11.GL_TEXTURE);
+        GlStateManager.glTexEnvi(GL11.GL_TEXTURE_ENV, GL15.GL_SRC1_RGB, GL13.GL_PREVIOUS);
+        GlStateManager.glTexEnvi(GL11.GL_TEXTURE_ENV, GL15.GL_SRC2_RGB, GL13.GL_CONSTANT);
+        GlStateManager.glTexEnvi(GL11.GL_TEXTURE_ENV, GL15.GL_SRC0_ALPHA, GL11.GL_TEXTURE);
+        GlStateManager.glTexEnvi(GL11.GL_TEXTURE_ENV, GL15.GL_SRC1_ALPHA, GL13.GL_PREVIOUS);
+        GlStateManager.glTexEnvi(GL11.GL_TEXTURE_ENV, GL15.GL_SRC2_ALPHA, GL13.GL_CONSTANT);
+        GlStateManager.glTexEnvi(GL11.GL_TEXTURE_ENV, GL13.GL_OPERAND0_RGB, GL11.GL_SRC_COLOR);
+        GlStateManager.glTexEnvi(GL11.GL_TEXTURE_ENV, GL13.GL_OPERAND1_RGB, GL11.GL_SRC_COLOR);
+        GlStateManager.glTexEnvi(GL11.GL_TEXTURE_ENV, GL13.GL_OPERAND2_RGB, GL11.GL_SRC_ALPHA);
+        GlStateManager.glTexEnvi(GL11.GL_TEXTURE_ENV, GL13.GL_OPERAND0_ALPHA, GL11.GL_SRC_ALPHA);
+        GlStateManager.glTexEnvi(GL11.GL_TEXTURE_ENV, GL13.GL_OPERAND1_ALPHA, GL11.GL_SRC_ALPHA);
+        GlStateManager.glTexEnvi(GL11.GL_TEXTURE_ENV, GL13.GL_OPERAND2_ALPHA, GL11.GL_SRC_ALPHA);
+        GlStateManager.glTexEnvf(GL11.GL_TEXTURE_ENV, GL13.GL_RGB_SCALE, 1.0F);
+        GlStateManager.glTexEnvf(GL11.GL_TEXTURE_ENV, GL11.GL_ALPHA_SCALE, 1.0F);
+        
+        GlStateManager.disableNormalize();
+        GlStateManager.shadeModel(7425);
+        GlStateManager.disableRescaleNormal();
+        GlStateManager.colorMask(true, true, true, true);
+        GlStateManager.clearDepth(1.0D);
+        GlStateManager.glLineWidth(1.0F);
+        GlStateManager.glNormal3f(0.0F, 0.0F, 1.0F);
+        GlStateManager.glPolygonMode(GL11.GL_FRONT, GL11.GL_FILL);
+        GlStateManager.glPolygonMode(GL11.GL_BACK, GL11.GL_FILL);
+
+        GlStateManager.enableTexture2D();
+        GlStateManager.shadeModel(7425);
+        GlStateManager.clearDepth(1.0D);
+        GlStateManager.enableDepth();
+        GlStateManager.depthFunc(515);
+        GlStateManager.enableAlpha();
+        GlStateManager.alphaFunc(516, 0.1F);
+        GlStateManager.cullFace(GlStateManager.CullFace.BACK);
+        GlStateManager.matrixMode(5889);
+        GlStateManager.loadIdentity();
+        GlStateManager.matrixMode(5888);
+    }
+    
+}

--- a/src/main/java/net/minecraftforge/fml/client/ClientStateReset.java
+++ b/src/main/java/net/minecraftforge/fml/client/ClientStateReset.java
@@ -89,7 +89,7 @@ public class ClientStateReset {
         }
         
         //This was made by Runemoro for their VanillaFix mod, original available at https://github.com/DimensionalDevelopment/VanillaFix/blob/master/src/main/java/org/dimdev/utils/GlUtil.java
-        //I modified it a lot tho
+        //I modified it a lot though
         
         if (mc.entityRenderer.isShaderActive()) mc.entityRenderer.stopUseShader();
         

--- a/src/main/java/net/minecraftforge/fml/client/GuiWorldTickException.java
+++ b/src/main/java/net/minecraftforge/fml/client/GuiWorldTickException.java
@@ -1,0 +1,118 @@
+/*
+ * Minecraft Forge
+ * Copyright (c) 2016-2018.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation version 2.1
+ * of the License.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+package net.minecraftforge.fml.client;
+
+import java.io.IOException;
+
+import org.apache.commons.lang3.text.WordUtils;
+
+import net.minecraft.client.gui.GuiButton;
+import net.minecraft.client.gui.GuiMainMenu;
+import net.minecraft.client.gui.GuiOptionButton;
+import net.minecraft.client.gui.GuiScreen;
+import net.minecraft.client.resources.I18n;
+import net.minecraft.crash.CrashReport;
+import net.minecraftforge.fml.common.FMLCommonHandler;
+import net.minecraftforge.fml.common.ICrashCallable;
+
+public class GuiWorldTickException extends GuiScreen
+{
+    
+    private final CrashReport theCrashReport;
+    private final boolean hasShown;
+    private final boolean serverSide;
+    
+    public static boolean hasShownThisScreenBeforeNow = false;
+    
+    public GuiWorldTickException(CrashReport crash, boolean serverside)
+    {
+        this.theCrashReport = crash;
+        this.hasShown = hasShownThisScreenBeforeNow;
+        this.serverSide = serverside;
+        
+        if(!this.hasShown) {
+            FMLCommonHandler.instance().registerCrashCallable(new ICrashCallable() { //makes sure ignorant people don't post tainted crash reports
+
+                @Override
+                public String call() throws Exception {
+                    
+                    return "NO! The game has already crashed before but the user chose not to restart minecraft. This is not a clean enviroment!";
+                }
+
+                @Override
+                public String getLabel() {
+                    return "Is this the first crash";
+                }
+                
+            });
+        }
+        
+        hasShownThisScreenBeforeNow = true;
+    }
+
+    public void initGui()
+    {
+        this.buttonList.clear();
+        this.buttonList.add(new GuiOptionButton(0, this.width / 2 - 155, this.height / 4 + 120 + 12, I18n.format("gui.toTitle")));
+        this.buttonList.add(new GuiOptionButton(1, this.width / 2 - 155 + 160, this.height / 4 + 120 + 12, I18n.format("menu.quit")));
+    }
+    
+    protected void actionPerformed(GuiButton button) throws IOException
+    {
+        if (button.id == 0)
+        {
+            this.mc.displayGuiScreen(new GuiMainMenu());
+        }
+        else if (button.id == 1)
+        {
+            this.mc.shutdown();
+        }
+    }
+
+    public void drawScreen(int mouseX, int mouseY, float partialTicks)
+    {
+        this.drawDefaultBackground();
+        this.drawCenteredString(this.fontRenderer, "World Tick Exception!", this.width / 2, this.height / 4 - 60 + 20, 16777215);
+        
+        String eagler = this.serverSide ? "A fatal exception has been caught during world ticking:" : "A fatal exception has been caught during clientside ticking:";
+        this.drawString(this.fontRenderer, eagler, this.width / 2 - 140, this.height / 4 - 70 + 60 + 0, 10526880);
+        
+        int offset = this.height / 4 - 70 + 60 + 18;
+        String[] wrappedException = WordUtils.wrap(this.theCrashReport.getCrashCause().toString(), 55, "\n", true).split("\n");
+        for(String s : wrappedException)
+        {
+            this.drawCenteredString(this.fontRenderer, s, this.width / 2, offset, 0xFFAAAA);
+            offset += 9;
+        }
+        
+        String remark = this.hasShown ? "(you have)" : "(you haven't)";
+
+        this.drawString(this.fontRenderer, "The full stack traces and crash report has been printed to", this.width / 2 - 140, offset + 18, 10526880);
+        this.drawString(this.fontRenderer, "your minecraft log. Please do not post them on the forums", this.width / 2 - 140, offset + 27, 10526880);
+        this.drawString(this.fontRenderer, "if you've already seen this screen once before "+remark, this.width / 2 - 140, offset + 36, 10526880);
+        
+        this.drawString(this.fontRenderer, "It should be safe to return to the title screen and continue", this.width / 2 - 140, offset + 54, 10526880);
+        this.drawString(this.fontRenderer, "playing with you legos but there's the possibility things", this.width / 2 - 140, offset + 63, 10526880);
+        this.drawString(this.fontRenderer, "might still be messed up somewhere deep within minceraft.", this.width / 2 - 140, offset + 72, 10526880);
+        this.drawString(this.fontRenderer, "If that's case then you should please restart your game.", this.width / 2 - 140, offset + 81, 10526880);
+        super.drawScreen(mouseX, mouseY, partialTicks);
+    }
+
+}


### PR DESCRIPTION
you guys probably aren't going to like this but hear me out

so lately loading forge has been taking longer and longer, and when you have 50+ mods installed it gets really annoying when you accidentally crash the game and need to wait 10 minutes for the whole thing to load again

What I've done is changed the exception handling for the integrated server and the minecraft client side so when there's an exception, instead of saving the world and System.exiting, it just saves the world. It displays a message like this: https://gyazo.com/94d3490b5b1b1194ec289c09c28ef69c with the options to quit the game or return to the title screen, and it hasn't failed me a single time. The game remains stable no matter where I throw an exception, and considering I'm doing the exact same world save procedure as the game does when it crashes normally I don't think there's any increased risk of world corruption.

As you can see the screenshot does instruct you not to post the crash report if you've already had the screen happen multiple times that game launch though so in the rare situation where not shutting down after an exception does actually cause instability, you won't get any tainted crash reports.

It adds a notice to the crash report if there has already been multiple crashes that game launch, so if some ignorant nine year old doesn't read what it says and posts a crash report anyway despite it saying they shouldn't, developers will be able to tell.

Please keep an open mind and try it yourself before vetoing it unsafe. I'd like to see someone actually successfully corrupt a world using this or an explanation over something I didn't understand first.

This is my first time contributing to this repo so feel free to request the correction of any formatting or coding style I got wrong