### PR TITLE
Fix ModList cache never being updated

### DIFF
--- a/src/main/java/net/minecraftforge/fml/relauncher/libraries/LibraryManager.java
+++ b/src/main/java/net/minecraftforge/fml/relauncher/libraries/LibraryManager.java
@@ -99,8 +99,11 @@ public class LibraryManager
         for (ModList list : ModList.getKnownLists(minecraftHome))
         {
             Repository repo = list.getRepository() == null ? libraries_dir : list.getRepository();
-            for (Artifact artifact : list.getArtifacts())
+            List<Artifact> artifacts = list.getArtifacts();
+            // extractPacked adds artifacts to the list. As such, we can't use an Iterator to traverse it.
+            for (int i = 0; i < artifacts.size(); i++)
             {
+                Artifact artifact = artifacts.get(i);
                 Artifact resolved = repo.resolve(artifact);
                 if (resolved != null)
                 {

--- a/src/main/java/net/minecraftforge/fml/relauncher/libraries/ModList.java
+++ b/src/main/java/net/minecraftforge/fml/relauncher/libraries/ModList.java
@@ -50,8 +50,7 @@ public class ModList
         try
         {
             String key = json.getCanonicalFile().getAbsolutePath();
-            if (cache.containsKey(key))
-                return cache.get(key);
+            return cache.computeIfAbsent(key, k -> new ModList(json, mcdir));
         }
         catch (IOException e)
         {


### PR DESCRIPTION
So I played around with the possibility of managing mods through json mod lists, and most things work perfectly. However, when using mods that have contained dependencies, those dependencies are never extracted. I looked at the code a bit, and it seems that the dependency extraction mechanism depends on the ModList cache being updated, which never happens. 

I assume that a cache never being updated is not intended behaviour, so here is a very short PR to fix it.