### PR TITLE
Added getter for children of CompoundIngredient

### DIFF
--- a/src/main/java/net/minecraftforge/common/crafting/CompoundIngredient.java
+++ b/src/main/java/net/minecraftforge/common/crafting/CompoundIngredient.java
@@ -109,4 +109,10 @@ public class CompoundIngredient extends Ingredient
     {
         return isSimple;
     }
+    
+    @Nonnull
+    public Collection<Ingredient> getChilds()
+    {
+        return this.children
+    }
 }

--- a/src/main/java/net/minecraftforge/common/crafting/CompoundIngredient.java
+++ b/src/main/java/net/minecraftforge/common/crafting/CompoundIngredient.java
@@ -113,6 +113,6 @@ public class CompoundIngredient extends Ingredient
     @Nonnull
     public Collection<Ingredient> getChildren()
     {
-        return this.children;
+        return Collections.unmodifiableCollection(this.children);
     }
 }

--- a/src/main/java/net/minecraftforge/common/crafting/CompoundIngredient.java
+++ b/src/main/java/net/minecraftforge/common/crafting/CompoundIngredient.java
@@ -111,7 +111,7 @@ public class CompoundIngredient extends Ingredient
     }
     
     @Nonnull
-    public Collection<Ingredient> getChilds()
+    public Collection<Ingredient> getChildren()
     {
         return this.children;
     }

--- a/src/main/java/net/minecraftforge/common/crafting/CompoundIngredient.java
+++ b/src/main/java/net/minecraftforge/common/crafting/CompoundIngredient.java
@@ -113,6 +113,6 @@ public class CompoundIngredient extends Ingredient
     @Nonnull
     public Collection<Ingredient> getChilds()
     {
-        return this.children
+        return this.children;
     }
 }


### PR DESCRIPTION
This PR adds a getter to CompoundIngredient to access the collection of sub ingredients. ~~I am not sure if we should make this collection readonly or not.~~ The collection is readonly because otherwise someone could break cashing.