### PR TITLE
Add CreativeTabs#getLabelColor

### DIFF
--- a/patches/minecraft/net/minecraft/client/gui/inventory/GuiContainerCreative.java.patch
+++ b/patches/minecraft/net/minecraft/client/gui/inventory/GuiContainerCreative.java.patch
@@ -67,7 +67,7 @@
          if (this.field_147062_A.func_146179_b().isEmpty())
          {
              for (Item item : Item.field_150901_e)
-@@ -366,7 +403,7 @@
+@@ -366,10 +403,10 @@
      {
          CreativeTabs creativetabs = CreativeTabs.field_78032_a[field_147058_w];
  
@@ -75,7 +75,11 @@
 +        if (creativetabs != null && creativetabs.func_78019_g())
          {
              GlStateManager.func_179084_k();
-             this.field_146289_q.func_78276_b(I18n.func_135052_a(creativetabs.func_78024_c()), 8, 6, 4210752);
+-            this.field_146289_q.func_78276_b(I18n.func_135052_a(creativetabs.func_78024_c()), 8, 6, 4210752);
++            this.field_146289_q.func_78276_b(I18n.func_135052_a(creativetabs.func_78024_c()), 8, 6, creativetabs.getLabelColor());
+         }
+     }
+ 
 @@ -401,7 +438,7 @@
  
              for (CreativeTabs creativetabs : CreativeTabs.field_78032_a)

--- a/patches/minecraft/net/minecraft/creativetab/CreativeTabs.java.patch
+++ b/patches/minecraft/net/minecraft/creativetab/CreativeTabs.java.patch
@@ -44,7 +44,7 @@
          return this.field_78033_n < 6;
      }
  
-@@ -260,4 +282,45 @@
+@@ -260,4 +282,50 @@
              item.func_150895_a(this, p_78018_1_);
          }
      }
@@ -88,5 +88,10 @@
 +    public net.minecraft.util.ResourceLocation getBackgroundImage()
 +    {
 +        return new net.minecraft.util.ResourceLocation("textures/gui/container/creative_inventory/tab_" + this.func_78015_f());
++    }
++
++    public int getLabelColor()
++    {
++        return 4210752;
 +    }
  }


### PR DESCRIPTION
Allows for custom creative tabs to determine the color of the drawn label String in the GUI. Useful for custom backgrounds that result in the default color being unreadable against the background.