### PR TITLE
Fixed Server GUI being blank

### DIFF
--- a/src/main/resources/log4j2_server.xml
+++ b/src/main/resources/log4j2_server.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<Configuration status="warn" packages="net.minecraftforge.server.terminalconsole">
+<Configuration status="warn" packages="net.minecraftforge.server.terminalconsole,com.mojang.util">
     <Appenders>
         <TerminalConsole name="Console">
             <PatternLayout>


### PR DESCRIPTION
Added location of Queue type appender class (com.mojang.util) to the packages attribute of the log4j2_server logging configuration

(This is so small I'm not sure if it's worth it's own PR, if not then take it as a small note)