### PR TITLE
Added RenderLayer getter

### DIFF
--- a/patches/minecraft/net/minecraft/client/renderer/entity/RenderLivingBase.java.patch
+++ b/patches/minecraft/net/minecraft/client/renderer/entity/RenderLivingBase.java.patch
@@ -70,3 +70,13 @@
      }
  
      protected boolean func_177070_b(T p_177070_1_)
+@@ -512,4 +521,9 @@
+ 
+         field_177096_e.func_110564_a();
+     }
++    
++    //Forge: A way to retrieve a list of Renderers Render-layers
++    public List<LayerRenderer<T>> getLayerRenders(){
++    	return field_177097_h;
++    }
+ }


### PR DESCRIPTION
This PR adds a getter method to RenderLivingBase in order to return a list of RenderLayers in use in that renderer to allow modders to access a list of them more easily without Reflection.

This is my first time making a PR for forge, so if I've done anything wrong, let me know and I'll sort it