### PR TITLE
Redstone now checks for solid side BlockFaceShape

### DIFF
--- a/patches/minecraft/net/minecraft/block/BlockRedstoneDiode.java.patch
+++ b/patches/minecraft/net/minecraft/block/BlockRedstoneDiode.java.patch
@@ -1,6 +1,6 @@
 --- ../src-base/minecraft/net/minecraft/block/BlockRedstoneDiode.java
 +++ ../src-work/minecraft/net/minecraft/block/BlockRedstoneDiode.java
-@@ -39,7 +39,8 @@
+@@ -39,12 +39,14 @@
  
      public boolean func_176196_c(World p_176196_1_, BlockPos p_176196_2_)
      {
@@ -10,7 +10,14 @@
      }
  
      public boolean func_176409_d(World p_176409_1_, BlockPos p_176409_2_)
-@@ -227,6 +228,8 @@
+     {
+-        return p_176409_1_.func_180495_p(p_176409_2_.func_177977_b()).func_185896_q();
++        IBlockState downState = p_176409_1_.func_180495_p(p_176409_2_.func_177977_b());
++        return downState.func_185896_q() || downState.func_193401_d(p_176409_1_, p_176409_2_.func_177977_b(), EnumFacing.UP) == BlockFaceShape.SOLID;
+     }
+ 
+     public void func_180645_a(World p_180645_1_, BlockPos p_180645_2_, IBlockState p_180645_3_, Random p_180645_4_)
+@@ -227,6 +229,8 @@
      {
          EnumFacing enumfacing = (EnumFacing)p_176400_3_.func_177229_b(field_185512_D);
          BlockPos blockpos = p_176400_2_.func_177972_a(enumfacing.func_176734_d());
@@ -19,7 +26,7 @@
          p_176400_1_.func_190524_a(blockpos, this, p_176400_2_);
          p_176400_1_.func_175695_a(blockpos, this, enumfacing);
      }
-@@ -307,6 +310,25 @@
+@@ -307,6 +311,25 @@
          return BlockRenderLayer.CUTOUT;
      }
  

--- a/patches/minecraft/net/minecraft/block/BlockRedstoneDiode.java.patch
+++ b/patches/minecraft/net/minecraft/block/BlockRedstoneDiode.java.patch
@@ -1,6 +1,16 @@
 --- ../src-base/minecraft/net/minecraft/block/BlockRedstoneDiode.java
 +++ ../src-work/minecraft/net/minecraft/block/BlockRedstoneDiode.java
-@@ -227,6 +227,8 @@
+@@ -39,7 +39,8 @@
+ 
+     public boolean func_176196_c(World p_176196_1_, BlockPos p_176196_2_)
+     {
+-        return p_176196_1_.func_180495_p(p_176196_2_.func_177977_b()).func_185896_q() ? super.func_176196_c(p_176196_1_, p_176196_2_) : false;
++        IBlockState downState = p_176196_1_.func_180495_p(p_176196_2_.func_177977_b());
++        return (downState.func_185896_q() || downState.func_193401_d(p_176196_1_, p_176196_2_.func_177977_b(), EnumFacing.UP) == BlockFaceShape.SOLID) ? super.func_176196_c(p_176196_1_, p_176196_2_) : false;
+     }
+ 
+     public boolean func_176409_d(World p_176409_1_, BlockPos p_176409_2_)
+@@ -227,6 +228,8 @@
      {
          EnumFacing enumfacing = (EnumFacing)p_176400_3_.func_177229_b(field_185512_D);
          BlockPos blockpos = p_176400_2_.func_177972_a(enumfacing.func_176734_d());
@@ -9,7 +19,7 @@
          p_176400_1_.func_190524_a(blockpos, this, p_176400_2_);
          p_176400_1_.func_175695_a(blockpos, this, enumfacing);
      }
-@@ -307,6 +309,25 @@
+@@ -307,6 +310,25 @@
          return BlockRenderLayer.CUTOUT;
      }
  

--- a/patches/minecraft/net/minecraft/block/BlockRedstoneWire.java.patch
+++ b/patches/minecraft/net/minecraft/block/BlockRedstoneWire.java.patch
@@ -19,7 +19,17 @@
                  {
                      if (iblockstate.func_185898_k())
                      {
-@@ -414,7 +414,7 @@
+@@ -144,7 +144,8 @@
+ 
+     public boolean func_176196_c(World p_176196_1_, BlockPos p_176196_2_)
+     {
+-        return p_176196_1_.func_180495_p(p_176196_2_.func_177977_b()).func_185896_q() || p_176196_1_.func_180495_p(p_176196_2_.func_177977_b()).func_177230_c() == Blocks.field_150426_aN;
++        IBlockState downState = p_176196_1_.func_180495_p(p_176196_2_.func_177977_b());
++        return downState.func_185896_q() || downState.func_193401_d(p_176196_1_, p_176196_2_.func_177977_b(), EnumFacing.UP) == BlockFaceShape.SOLID || p_176196_1_.func_180495_p(p_176196_2_.func_177977_b()).func_177230_c() == Blocks.field_150426_aN;
+     }
+ 
+     private IBlockState func_176338_e(World p_176338_1_, BlockPos p_176338_2_, IBlockState p_176338_3_)
+@@ -414,7 +415,7 @@
          {
              return true;
          }
@@ -28,7 +38,7 @@
          {
              return true;
          }
-@@ -430,16 +430,11 @@
+@@ -430,16 +431,11 @@
  
      protected static boolean func_176340_e(IBlockAccess p_176340_0_, BlockPos p_176340_1_)
      {
@@ -47,7 +57,7 @@
          Block block = p_176343_0_.func_177230_c();
  
          if (block == Blocks.field_150488_af)
-@@ -457,7 +452,7 @@
+@@ -457,7 +453,7 @@
          }
          else
          {


### PR DESCRIPTION
This fixes redstone, comparators and repeaters check on placement, to also check the `getBlockFaceShape` instead of only the old `isSideSolid` in a similar way as #4571.