### PR TITLE
Allow items to control the rate of repair from mending

### DIFF
--- a/patches/minecraft/net/minecraft/entity/item/EntityXPOrb.java.patch
+++ b/patches/minecraft/net/minecraft/entity/item/EntityXPOrb.java.patch
@@ -19,7 +19,7 @@
          if (this.func_180431_b(p_70097_1_))
          {
              return false;
-@@ -208,6 +211,7 @@
+@@ -208,14 +211,16 @@
          {
              if (this.field_70532_c == 0 && p_70100_1_.field_71090_bL == 0)
              {
@@ -27,3 +27,25 @@
                  p_70100_1_.field_71090_bL = 2;
                  p_70100_1_.func_71001_a(this, 1);
                  ItemStack itemstack = EnchantmentHelper.func_92099_a(Enchantments.field_185296_A, p_70100_1_);
+ 
+                 if (!itemstack.func_190926_b() && itemstack.func_77951_h())
+                 {
+-                    int i = Math.min(this.func_184514_c(this.field_70530_e), itemstack.func_77952_i());
+-                    this.field_70530_e -= this.func_184515_b(i);
++                    float ratio = itemstack.func_77973_b().getXpRepairRatio(itemstack);
++                    int i = Math.min(roundAverage(this.field_70530_e * ratio), itemstack.func_77952_i());
++                    this.field_70530_e -= roundAverage(i / ratio);
+                     itemstack.func_77964_b(itemstack.func_77952_i() - i);
+                 }
+ 
+@@ -337,4 +342,10 @@
+     {
+         return false;
+     }
++
++    private static int roundAverage(float value)
++    {
++        double floor = Math.floor(value);
++        return (int) floor + (Math.random() < value - floor ? 1 : 0);
++    }
+ }

--- a/patches/minecraft/net/minecraft/item/Item.java.patch
+++ b/patches/minecraft/net/minecraft/item/Item.java.patch
@@ -68,7 +68,7 @@
          CreativeTabs creativetabs = this.func_77640_w();
          return creativetabs != null && (p_194125_1_ == CreativeTabs.field_78027_g || p_194125_1_ == creativetabs);
      }
-@@ -435,11 +441,757 @@
+@@ -435,11 +441,766 @@
          return false;
      }
  
@@ -147,6 +147,15 @@
 +    {
 +        canRepair = false;
 +        return this;
++    }
++
++    /**
++     * Determines the amount of durability the mending enchantment
++     * will repair, on average, per point of experience.
++     */
++    public float getXpRepairRatio(ItemStack stack)
++    {
++        return 2f;
 +    }
 +
 +    /**
@@ -826,7 +835,7 @@
      public static void func_150900_l()
      {
          func_179214_a(Blocks.field_150350_a, new ItemAir(Blocks.field_150350_a));
-@@ -999,6 +1751,8 @@
+@@ -999,6 +1760,8 @@
          private final float field_78010_h;
          private final float field_78011_i;
          private final int field_78008_j;
@@ -835,7 +844,7 @@
  
          private ToolMaterial(int p_i1874_3_, int p_i1874_4_, float p_i1874_5_, float p_i1874_6_, int p_i1874_7_)
          {
-@@ -1034,6 +1788,7 @@
+@@ -1034,6 +1797,7 @@
              return this.field_78008_j;
          }
  
@@ -843,7 +852,7 @@
          public Item func_150995_f()
          {
              if (this == WOOD)
-@@ -1057,5 +1812,21 @@
+@@ -1057,5 +1821,21 @@
                  return this == DIAMOND ? Items.field_151045_i : null;
              }
          }

--- a/src/test/java/net/minecraftforge/debug/item/MendingRepairTest.java
+++ b/src/test/java/net/minecraftforge/debug/item/MendingRepairTest.java
@@ -1,3 +1,22 @@
+/*
+ * Minecraft Forge
+ * Copyright (c) 2016-2018.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation version 2.1
+ * of the License.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
 package net.minecraftforge.debug.item;
 
 import net.minecraft.client.renderer.block.model.ModelResourceLocation;

--- a/src/test/java/net/minecraftforge/debug/item/MendingRepairTest.java
+++ b/src/test/java/net/minecraftforge/debug/item/MendingRepairTest.java
@@ -1,0 +1,76 @@
+package net.minecraftforge.debug.item;
+
+import net.minecraft.client.renderer.block.model.ModelResourceLocation;
+import net.minecraft.creativetab.CreativeTabs;
+import net.minecraft.init.Enchantments;
+import net.minecraft.item.Item;
+import net.minecraft.item.ItemStack;
+import net.minecraft.util.NonNullList;
+import net.minecraftforge.client.event.ModelRegistryEvent;
+import net.minecraftforge.client.model.ModelLoader;
+import net.minecraftforge.event.RegistryEvent;
+import net.minecraftforge.fml.common.Mod;
+import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
+import net.minecraftforge.fml.common.registry.GameRegistry;
+import net.minecraftforge.fml.relauncher.Side;
+
+@Mod.EventBusSubscriber
+@Mod(modid = MendingRepairTest.MOD_ID, name = "Mending repair amount test mod", version = "1.0")
+public class MendingRepairTest
+{
+    static final boolean ENABLED = true;
+    static final String MOD_ID = "mending_repair_test";
+
+    @GameRegistry.ObjectHolder(MOD_ID + ":test_item")
+    public static final Item TEST_ITEM = null;
+
+    @SubscribeEvent
+    public static void registerItems(RegistryEvent.Register<Item> event)
+    {
+        if (!ENABLED) return;
+        event.getRegistry().register(
+                new TestItem()
+                        .setRegistryName(MOD_ID, "test_item")
+                        .setUnlocalizedName(MOD_ID + ".test_item")
+        );
+    }
+
+    @Mod.EventBusSubscriber(modid = MOD_ID, value = Side.CLIENT)
+    public static final class ClientEventHandler
+    {
+        @SubscribeEvent
+        public static void registerModels(ModelRegistryEvent event)
+        {
+            if (!ENABLED) return;
+            ModelLoader.setCustomModelResourceLocation(TEST_ITEM, 0, new ModelResourceLocation("minecraft:blaze_rod", "inventory"));
+        }
+    }
+
+    private static final class TestItem extends Item
+    {
+        TestItem()
+        {
+            maxStackSize = 1;
+            setMaxDamage(10);
+            setCreativeTab(CreativeTabs.TOOLS);
+        }
+
+        @Override
+        public void getSubItems(CreativeTabs tab, NonNullList<ItemStack> items)
+        {
+            if (this.isInCreativeTab(tab))
+            {
+                ItemStack stack = new ItemStack(this);
+                stack.addEnchantment(Enchantments.MENDING, 1);
+                stack.setItemDamage(stack.getMaxDamage());
+                items.add(stack);
+            }
+        }
+
+        @Override
+        public float getXpRepairRatio(ItemStack stack)
+        {
+            return 0.1f;
+        }
+    }
+}


### PR DESCRIPTION
This PR allows items to specify the "exchange rate" to be used when repaired through the Mending enchantment. This is done by providing a new method (`getXpRepairRatio`), which is called from the repair logic in `EntityXPOrb.onCollideWithPlayer`.

At present, there is a fixed conversion rate of 1 experience -> 2 durability repaired:
```java
private int durabilityToXp(int durability) // func_184515_b
{
    return durability / 2;
}

private int xpToDurability(int xp) // func_184514_c
{
    return xp * 2;
}
```

This means that "powerful" items with limited uses generally have to blacklist Mending as an applicable enchant as otherwise usage of the item becomes trivial.

The additional logic in the implementation here is to allow fractional rates to be specified - durability "fractions" are converted using probabalistic rounding, so 1.8 becomes 2 80% of the time, and 1 the remaining 20%.

A test mod example is provided.