### PR TITLE
Fix loading languages with no underscore in the name

### DIFF
--- a/patches/minecraft/net/minecraft/client/resources/Language.java.patch
+++ b/patches/minecraft/net/minecraft/client/resources/Language.java.patch
@@ -1,15 +1,19 @@
 --- ../src-base/minecraft/net/minecraft/client/resources/Language.java
 +++ ../src-work/minecraft/net/minecraft/client/resources/Language.java
-@@ -17,6 +17,8 @@
+@@ -17,6 +17,12 @@
          this.field_135037_b = p_i1303_2_;
          this.field_135038_c = p_i1303_3_;
          this.field_135036_d = p_i1303_4_;
 +        String[] splitLangCode = field_135039_a.split("_", 2);
-+        this.javaLocale = new java.util.Locale(splitLangCode[0], splitLangCode[1]);
++        if (splitLangCode.length == 1) { // Vanilla has some languages without underscores
++            this.javaLocale = new java.util.Locale(field_135039_a);
++        } else {
++            this.javaLocale = new java.util.Locale(splitLangCode[0], splitLangCode[1]);
++        }
      }
  
      public String func_135034_a()
-@@ -55,4 +57,8 @@
+@@ -55,4 +61,8 @@
      {
          return this.field_135039_a.compareTo(p_compareTo_1_.field_135039_a);
      }


### PR DESCRIPTION
This fixes a bug elucidated by the latest Mojang asset index, where they added some languages such as "brb.lang" and "enp.lang" that do not have an underscore in the name. This resulted in the code that assumes an [a-z]+_[a-z]+ pattern for all languages crashing.

Vanilla swallows this exception here in `DefaultResourcePack#getPackMetadata`:

```java
    @Nullable
    public <T extends IMetadataSection> T getPackMetadata(MetadataSerializer metadataSerializer, String metadataSectionName) throws IOException
    {
        try
        {
            InputStream inputstream = new FileInputStream(this.resourceIndex.getPackMcmeta());
            return (T)AbstractResourcePack.readMetadata(metadataSerializer, inputstream, metadataSectionName);
        }
        catch (RuntimeException var4)
        {
            return (T)null;
        }
        catch (FileNotFoundException var5)
        {
            return (T)null;
        }
    }
```

Which results in no languages being loaded as the game thinks there is no pack.mcmeta for the vanilla resources.

The fix is simply to detect and handle these new language codes.

See: https://github.com/bdew/gendustry/issues/277