### PR TITLE
Improve context provided by potion icon rendering hooks

### DIFF
--- a/patches/minecraft/net/minecraft/client/gui/GuiIngame.java.patch
+++ b/patches/minecraft/net/minecraft/client/gui/GuiIngame.java.patch
@@ -29,7 +29,7 @@
 +                    // FORGE - Move status icon check down from above so renderHUDEffect will still be called without a status icon
 +                    if (potion.func_76400_d())
                      this.func_73729_b(k + 3, l + 3, i1 % 8 * 18, 198 + i1 / 8 * 18, 18, 18);
-+                    potion.renderHUDEffect(k, l, potioneffect, field_73839_d, f);
++                    potion.renderHUDEffect(potioneffect, this, k, l, this.field_73735_i, f);
                  }
              }
          }

--- a/patches/minecraft/net/minecraft/client/renderer/InventoryEffectRenderer.java.patch
+++ b/patches/minecraft/net/minecraft/client/renderer/InventoryEffectRenderer.java.patch
@@ -33,7 +33,7 @@
                      this.func_73729_b(i + 6, j + 7, 0 + i1 % 8 * 18, 198 + i1 / 8 * 18, 18, 18);
                  }
  
-+                potion.renderInventoryEffect(i, j, potioneffect, field_146297_k);
++                potion.renderInventoryEffect(potioneffect, this, i, j, this.field_73735_i);
 +                if (!potion.shouldRenderInvText(potioneffect)) { j += l; continue; }
                  String s1 = I18n.func_135052_a(potion.func_76393_a());
  

--- a/patches/minecraft/net/minecraft/potion/Potion.java.patch
+++ b/patches/minecraft/net/minecraft/potion/Potion.java.patch
@@ -20,7 +20,7 @@
      public boolean func_76398_f()
      {
          return this.field_76418_K;
-@@ -293,7 +292,85 @@
+@@ -293,7 +292,122 @@
          return p_111183_2_.func_111164_d() * (double)(p_111183_1_ + 1);
      }
  
@@ -60,9 +60,27 @@
 +     * @param y the y coordinate
 +     * @param effect the active PotionEffect
 +     * @param mc the Minecraft instance, for convenience
++     * @deprecated use {@link #renderInventoryEffect(PotionEffect, net.minecraft.client.gui.Gui, int, int, float)}
 +     */
      @SideOnly(Side.CLIENT)
++    @Deprecated // TODO: remove
 +    public void renderInventoryEffect(int x, int y, PotionEffect effect, net.minecraft.client.Minecraft mc) { }
++
++    /**
++     * Called to draw the this Potion onto the player's inventory when it's active.
++     * This can be used to e.g. render Potion icons from your own texture.
++     *
++     * @param effect the active PotionEffect
++     * @param gui the gui instance
++     * @param x the x coordinate
++     * @param y the y coordinate
++     * @param z the z level
++     */
++    @SideOnly(Side.CLIENT)
++    public void renderInventoryEffect(PotionEffect effect, net.minecraft.client.gui.Gui gui, int x, int y, float z)
++    {
++        renderInventoryEffect(x, y, effect, net.minecraft.client.Minecraft.func_71410_x());
++    }
 +
 +    /**
 +     * Called to draw the this Potion onto the player's ingame HUD when it's active.
@@ -72,9 +90,28 @@
 +     * @param effect the active PotionEffect
 +     * @param mc the Minecraft instance, for convenience
 +     * @param alpha the alpha value, blinks when the potion is about to run out
++     * @deprecated use {@link #renderHUDEffect(PotionEffect, net.minecraft.client.gui.Gui, int, int, float, float)}
 +     */
 +    @SideOnly(Side.CLIENT)
++    @Deprecated // TODO: remove
 +    public void renderHUDEffect(int x, int y, PotionEffect effect, net.minecraft.client.Minecraft mc, float alpha) { }
++
++    /**
++     * Called to draw the this Potion onto the player's ingame HUD when it's active.
++     * This can be used to e.g. render Potion icons from your own texture.
++     *
++     * @param effect the active PotionEffect
++     * @param gui the gui instance
++     * @param x the x coordinate
++     * @param y the y coordinate
++     * @param z the z level
++     * @param alpha the alpha value, blinks when the potion is about to run out
++     */
++    @SideOnly(Side.CLIENT)
++    public void renderHUDEffect(PotionEffect effect, net.minecraft.client.gui.Gui gui, int x, int y, float z, float alpha)
++    {
++        renderHUDEffect(x, y, effect, net.minecraft.client.Minecraft.func_71410_x(), alpha);
++    }
 +
 +    /**
 +     * Get a fresh list of items that can cure this Potion.

--- a/src/test/java/net/minecraftforge/debug/gameplay/PotionRegistryTest.java
+++ b/src/test/java/net/minecraftforge/debug/gameplay/PotionRegistryTest.java
@@ -19,9 +19,8 @@
 
 package net.minecraftforge.debug.gameplay;
 
-import gnu.trove.set.TIntSet;
-import gnu.trove.set.hash.TIntHashSet;
 import net.minecraft.client.Minecraft;
+import net.minecraft.client.gui.Gui;
 import net.minecraft.client.renderer.BufferBuilder;
 import net.minecraft.client.renderer.GlStateManager;
 import net.minecraft.client.renderer.Tessellator;
@@ -30,63 +29,44 @@ import net.minecraft.client.renderer.texture.TextureMap;
 import net.minecraft.client.renderer.vertex.DefaultVertexFormats;
 import net.minecraft.potion.Potion;
 import net.minecraft.potion.PotionEffect;
-import net.minecraft.util.ResourceLocation;
-import net.minecraftforge.common.ForgeVersion;
+import net.minecraftforge.event.RegistryEvent;
 import net.minecraftforge.fml.common.Mod;
-import net.minecraftforge.fml.common.event.FMLPreInitializationEvent;
-import net.minecraftforge.fml.common.registry.ForgeRegistries;
+import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
+import net.minecraftforge.fml.relauncher.Side;
+import net.minecraftforge.fml.relauncher.SideOnly;
+import org.lwjgl.opengl.GL11;
 
-import java.util.Random;
-
-@Mod(modid = PotionRegistryTest.MODID, name = "ForgePotionRegistry", version = "1.0", acceptableRemoteVersions = "*")
+@Mod.EventBusSubscriber
+@Mod(modid = PotionRegistryTest.MOD_ID, name = "ForgePotionRegistry", version = "1.0", acceptableRemoteVersions = "*")
 public class PotionRegistryTest
 {
-    public static final String MODID = "forgepotionregistry";
+    public static final String MOD_ID = "forge_potion_registry";
 
-    @Mod.EventHandler
-    public void preInit(FMLPreInitializationEvent event)
+    @SubscribeEvent
+    public static void registerPotions(RegistryEvent.Register<Potion> event)
     {
-        Potion forge = new PotionForge(new ResourceLocation(ForgeVersion.MOD_ID, "forge"), false, 0xff00ff).setRegistryName(new ResourceLocation(MODID, "forge")); // test automatic id distribution
-        Potion forgy = new PotionForge(new ResourceLocation(ForgeVersion.MOD_ID, "forgy"), true, 0x00ff00).setRegistryName(new ResourceLocation(MODID, "forgy")); // test that ids above 127 work
-        ForgeRegistries.POTIONS.register(forge);
-        //((ForgeRegistry)ForgeRegistries.POTIONS).register(200, forgy.getRegistryName(), forgy);
-
-        Random rand = new Random();
-        TIntSet taken = new TIntHashSet(100);
-        int ra = rand.nextInt(100) + 100;
-        taken.add(ra);
-
-        // a new potion with a random id so that forge has to remap it
-        //new PotionForge(ra, new ResourceLocation(ForgeModContainer.MOD_ID, "realRandomPotion"), false, 0x0000ff);
-
-        for (int i = 0; i < 20; i++)
-        {
-            int r = rand.nextInt(200) + 35;
-            while (taken.contains(r))
-                r = rand.nextInt(200) + 35;
-            //r = 32+i;
-            taken.add(r);
-            // this potions will most likely not have the same IDs between server and client.
-            // The forge handshake on connect should fix this.
-            //new PotionForge(new ResourceLocation(ForgeModContainer.MOD_ID, "randomPotion" + r), false, 0xff00ff);
-        }
+        event.getRegistry().register(
+                new PotionForge(false, 0xff00ff)
+                        .setRegistryName(MOD_ID, "forge")
+                        .setPotionName("potion." + MOD_ID + ".forge")
+        );
     }
 
-    protected class PotionForge extends Potion
+    private static class PotionForge extends Potion
     {
-        protected PotionForge(ResourceLocation location, boolean badEffect, int potionColor)
+        PotionForge(boolean badEffect, int potionColor)
         {
             super(badEffect, potionColor);
-            setPotionName("potion." + location.getResourcePath());
         }
 
         @Override
-        public void renderInventoryEffect(int x, int y, PotionEffect effect, Minecraft mc)
+        @SideOnly(Side.CLIENT)
+        public void renderInventoryEffect(PotionEffect effect, Gui gui, int x, int y, float z)
         {
             Potion potion = effect.getPotion();
 
-            mc.getTextureManager().bindTexture(TextureMap.LOCATION_BLOCKS_TEXTURE);
-            TextureAtlasSprite sprite = mc.getTextureMapBlocks().getAtlasSprite("minecraft:blocks/fire_layer_0");
+            Minecraft.getMinecraft().getTextureManager().bindTexture(TextureMap.LOCATION_BLOCKS_TEXTURE);
+            TextureAtlasSprite sprite = Minecraft.getMinecraft().getTextureMapBlocks().getAtlasSprite("minecraft:blocks/fire_layer_0");
 
             x += 6;
             y += 7;
@@ -101,22 +81,25 @@ public class PotionRegistryTest
 
             Tessellator tessellator = Tessellator.getInstance();
             BufferBuilder buf = tessellator.getBuffer();
-            buf.begin(7, DefaultVertexFormats.POSITION_TEX);
+            buf.begin(GL11.GL_QUADS, DefaultVertexFormats.POSITION_TEX);
             GlStateManager.color(r, g, b, a);
-            buf.pos((double) x, (double) (y + height), 0.0D).tex(sprite.getMinU(), sprite.getMaxV()).endVertex();
-            buf.pos((double) (x + width), (double) (y + height), 0.0D).tex(sprite.getMaxU(), sprite.getMaxV()).endVertex();
-            buf.pos((double) (x + width), (double) y, 0.0D).tex(sprite.getMaxU(), sprite.getMinV()).endVertex();
-            buf.pos((double) x, (double) y, 0.0D).tex(sprite.getMinU(), sprite.getMinV()).endVertex();
+
+            buf.pos((double) x, (double) (y + height), z).tex(sprite.getMinU(), sprite.getMaxV()).endVertex();
+            buf.pos((double) (x + width), (double) (y + height), z).tex(sprite.getMaxU(), sprite.getMaxV()).endVertex();
+            buf.pos((double) (x + width), (double) y, z).tex(sprite.getMaxU(), sprite.getMinV()).endVertex();
+            buf.pos((double) x, (double) y, z).tex(sprite.getMinU(), sprite.getMinV()).endVertex();
+
             tessellator.draw();
         }
 
         @Override
-        public void renderHUDEffect(int x, int y, PotionEffect effect, Minecraft mc, float alpha)
+        @SideOnly(Side.CLIENT)
+        public void renderHUDEffect(PotionEffect effect, Gui gui, int x, int y, float z, float alpha)
         {
             Potion potion = effect.getPotion();
 
-            mc.getTextureManager().bindTexture(TextureMap.LOCATION_BLOCKS_TEXTURE);
-            TextureAtlasSprite sprite = mc.getTextureMapBlocks().getAtlasSprite("minecraft:blocks/tnt_side");
+            Minecraft.getMinecraft().getTextureManager().bindTexture(TextureMap.LOCATION_BLOCKS_TEXTURE);
+            TextureAtlasSprite sprite = Minecraft.getMinecraft().getTextureMapBlocks().getAtlasSprite("minecraft:blocks/tnt_side");
 
             x += 3;
             y += 3;
@@ -130,12 +113,12 @@ public class PotionRegistryTest
 
             Tessellator tessellator = Tessellator.getInstance();
             BufferBuilder buf = tessellator.getBuffer();
-            buf.begin(7, DefaultVertexFormats.POSITION_TEX);
+            buf.begin(GL11.GL_QUADS, DefaultVertexFormats.POSITION_TEX);
             GlStateManager.color(r, g, b, alpha);
-            buf.pos((double) x, (double) (y + height), 0.0D).tex(sprite.getMinU(), sprite.getMaxV()).endVertex();
-            buf.pos((double) (x + width), (double) (y + height), 0.0D).tex(sprite.getMaxU(), sprite.getMaxV()).endVertex();
-            buf.pos((double) (x + width), (double) y, 0.0D).tex(sprite.getMaxU(), sprite.getMinV()).endVertex();
-            buf.pos((double) x, (double) y, 0.0D).tex(sprite.getMinU(), sprite.getMinV()).endVertex();
+            buf.pos((double) x, (double) (y + height), z).tex(sprite.getMinU(), sprite.getMaxV()).endVertex();
+            buf.pos((double) (x + width), (double) (y + height), z).tex(sprite.getMaxU(), sprite.getMaxV()).endVertex();
+            buf.pos((double) (x + width), (double) y, z).tex(sprite.getMaxU(), sprite.getMinV()).endVertex();
+            buf.pos((double) x, (double) y, z).tex(sprite.getMinU(), sprite.getMinV()).endVertex();
             tessellator.draw();
         }
     }


### PR DESCRIPTION
Small update of the hooks provided by #1194 and #2798 to provide some additional context - the GUI instance and the z-level used for rendering. The new methods currently forward to the existing ones, which are deprecated and marked for removal.

The aim here is to make it easier to render at the correct z-level, either by using an applicable `Gui` instance method, or by specifying the value manually. Currently this information isn't readily available, and using a level of 0 doesn't give correct results (as can be seen in https://github.com/TeamTwilight/twilightforest/issues/602 and also the current test code).

The existing test mod is updated to use the new methods, and is also cleaned up to remove some old, no longer applicable, code.