### PR TITLE
Allow config GUI cycling button elements generated from enums to display toString return values, rather than actual values.

### DIFF
--- a/src/main/java/net/minecraftforge/common/config/ConfigElement.java
+++ b/src/main/java/net/minecraftforge/common/config/ConfigElement.java
@@ -208,6 +208,12 @@ public class ConfigElement implements IConfigElement
     }
 
     @Override
+    public String[] getValidValuesDisplay()
+    {
+        return isProperty ? prop.getValidValuesDisplay() : null;
+    }
+
+    @Override
     public String getLanguageKey()
     {
         return isProperty ? prop.getLanguageKey() : category.getLanguagekey();

--- a/src/main/java/net/minecraftforge/common/config/Configuration.java
+++ b/src/main/java/net/minecraftforge/common/config/Configuration.java
@@ -1610,16 +1610,16 @@ public class Configuration
     }
 
     private String setPropertyAndGetString(String name, String category, String defaultValue, String comment, String[] validValues, String[] validValuesDisplay, String langKey)
-	{
-		Property prop = this.get(category, name, defaultValue);
+    {
+        Property prop = this.get(category, name, defaultValue);
         prop.setValidValues(validValues);
         if (validValuesDisplay != null)
-        	prop.setValidValuesDisplay(validValuesDisplay);
+            prop.setValidValuesDisplay(validValuesDisplay);
 
         prop.setLanguageKey(langKey);
         prop.setComment(comment + " [default: " + defaultValue + "]");
-		return prop.getString();
-	}
+        return prop.getString();
+    }
 
     /**
      * Creates a string list property.
@@ -1699,16 +1699,16 @@ public class Configuration
     }
 
     private String[] setPropertyAndGetStringList(String name, String category, String[] defaultValue, String comment, String[] validValues, String[] validValuesDisplay, String langKey)
-	{
-		Property prop = this.get(category, name, defaultValue);
+    {
+        Property prop = this.get(category, name, defaultValue);
         prop.setValidValues(validValues);
         if (validValuesDisplay != null)
-        	prop.setValidValuesDisplay(validValuesDisplay);
+            prop.setValidValuesDisplay(validValuesDisplay);
 
         prop.setLanguageKey(langKey);
         prop.setComment(comment + " [default: " + defaultValue + "]");
-		return prop.getStringList();
-	}
+        return prop.getStringList();
+    }
 
     /**
      * Creates a boolean property.

--- a/src/main/java/net/minecraftforge/common/config/Configuration.java
+++ b/src/main/java/net/minecraftforge/common/config/Configuration.java
@@ -629,6 +629,25 @@ public class Configuration
     }
 
     /**
+     * Gets a string Property with a comment using the defined validValues array and otherwise default settings.
+     *
+     * @param category the config category
+     * @param key the Property key value
+     * @param defaultValue the default value
+     * @param comment a String comment
+     * @param validValues an array of valid values that this Property can be set to. If an array is provided the Config GUI control will be
+     *            a value cycle button.
+     * @param validValuesDisplay an array of the config GUI display versions of the valid values that this Property can be set to.
+     * @return a string Property with the defined validValues array, validationPattern = null
+     */
+    public Property get(String category, String key, String defaultValue, String comment, String[] validValues, String[] validValuesDisplay)
+    {
+        Property prop = get(category, key, defaultValue, comment, validValues);
+        prop.setValidValuesDisplay(validValuesDisplay);
+        return prop;
+    }
+
+    /**
      * Gets a string array Property without a comment using the default settings.
      *
      * @param category the config category
@@ -1549,17 +1568,58 @@ public class Configuration
      * @param defaultValue Default value of the property.
      * @param comment A brief description what the property does.
      * @param validValues A list of valid values that this property can be set to.
+     * @param validValuesDisplay an array of the config GUI display versions of the valid values that this Property can be set to.
+     * @return The value of the new string property.
+     */
+    public String getString(String name, String category, String defaultValue, String comment, String[] validValues, String[] validValuesDisplay)
+    {
+        return setPropertyAndGetString(name, category, defaultValue, comment, validValues, validValuesDisplay, name);
+    }
+
+    /**
+     * Creates a string property.
+     *
+     * @param name Name of the property.
+     * @param category Category of the property.
+     * @param defaultValue Default value of the property.
+     * @param comment A brief description what the property does.
+     * @param validValues A list of valid values that this property can be set to.
      * @param langKey A language key used for localization of GUIs
      * @return The value of the new string property.
      */
     public String getString(String name, String category, String defaultValue, String comment, String[] validValues, String langKey)
     {
-        Property prop = this.get(category, name, defaultValue);
+        return setPropertyAndGetString(name, category, defaultValue, comment, validValues, null, langKey);
+    }
+
+    /**
+     * Creates a string property.
+     *
+     * @param name Name of the property.
+     * @param category Category of the property.
+     * @param defaultValue Default value of the property.
+     * @param comment A brief description what the property does.
+     * @param validValues A list of valid values that this property can be set to.
+     * @param validValuesDisplay an array of the config GUI display versions of the valid values that this Property can be set to.
+     * @param langKey A language key used for localization of GUIs
+     * @return The value of the new string property.
+     */
+    public String getString(String name, String category, String defaultValue, String comment, String[] validValues, String[] validValuesDisplay, String langKey)
+    {
+        return setPropertyAndGetString(name, category, defaultValue, comment, validValues, validValuesDisplay, langKey);
+    }
+
+    private String setPropertyAndGetString(String name, String category, String defaultValue, String comment, String[] validValues, String[] validValuesDisplay, String langKey)
+	{
+		Property prop = this.get(category, name, defaultValue);
         prop.setValidValues(validValues);
+        if (validValuesDisplay != null)
+        	prop.setValidValuesDisplay(validValuesDisplay);
+
         prop.setLanguageKey(langKey);
         prop.setComment(comment + " [default: " + defaultValue + "]");
-        return prop.getString();
-    }
+		return prop.getString();
+	}
 
     /**
      * Creates a string list property.
@@ -1596,16 +1656,59 @@ public class Configuration
      * @param category Category of the property.
      * @param defaultValue Default value of the property.
      * @param comment A brief description what the property does.
+     * @param validValues A list of valid values that this property can be set to.
+     * @param validValuesDisplay an array of the config GUI display versions of the valid values that this Property can be set to.
+     * @return The value of the new string property.
+     */
+    public String[] getStringList(String name, String category, String[] defaultValue, String comment, String[] validValues, String[] validValuesDisplay)
+    {
+        return setPropertyAndGetStringList(name, category, defaultValue, comment, validValues, validValuesDisplay, name);
+    }
+
+    /**
+     * Creates a string list property.
+     *
+     * @param name Name of the property.
+     * @param category Category of the property.
+     * @param defaultValue Default value of the property.
+     * @param comment A brief description what the property does.
+     * @param validValues A list of valid values that this property can be set to.
+     * @param langKey A language key used for localization of GUIs
      * @return The value of the new string property.
      */
     public String[] getStringList(String name, String category, String[] defaultValue, String comment, String[] validValues, String langKey)
     {
-        Property prop = this.get(category, name, defaultValue);
-        prop.setLanguageKey(langKey);
-        prop.setValidValues(validValues);
-        prop.setComment(comment + " [default: " + prop.getDefault() + "]");
-        return prop.getStringList();
+        return setPropertyAndGetStringList(name, category, defaultValue, comment, validValues, null, langKey);
     }
+
+    /**
+     * Creates a string list property.
+     *
+     * @param name Name of the property.
+     * @param category Category of the property.
+     * @param defaultValue Default value of the property.
+     * @param comment A brief description what the property does.
+     * @param validValues A list of valid values that this property can be set to.
+     * @param validValuesDisplay an array of the config GUI display versions of the valid values that this Property can be set to.
+     * @param langKey A language key used for localization of GUIs
+     * @return The value of the new string property.
+     */
+    public String[] getStringList(String name, String category, String[] defaultValue, String comment, String[] validValues, String[] validValuesDisplay, String langKey)
+    {
+        return setPropertyAndGetStringList(name, category, defaultValue, comment, validValues, validValuesDisplay, langKey);
+    }
+
+    private String[] setPropertyAndGetStringList(String name, String category, String[] defaultValue, String comment, String[] validValues, String[] validValuesDisplay, String langKey)
+	{
+		Property prop = this.get(category, name, defaultValue);
+        prop.setValidValues(validValues);
+        if (validValuesDisplay != null)
+        	prop.setValidValuesDisplay(validValuesDisplay);
+
+        prop.setLanguageKey(langKey);
+        prop.setComment(comment + " [default: " + defaultValue + "]");
+		return prop.getStringList();
+	}
 
     /**
      * Creates a boolean property.

--- a/src/main/java/net/minecraftforge/common/config/Configuration.java
+++ b/src/main/java/net/minecraftforge/common/config/Configuration.java
@@ -1613,9 +1613,7 @@ public class Configuration
     {
         Property prop = this.get(category, name, defaultValue);
         prop.setValidValues(validValues);
-        if (validValuesDisplay != null)
-            prop.setValidValuesDisplay(validValuesDisplay);
-
+        prop.setValidValuesDisplay(validValuesDisplay);
         prop.setLanguageKey(langKey);
         prop.setComment(comment + " [default: " + defaultValue + "]");
         return prop.getString();
@@ -1702,9 +1700,7 @@ public class Configuration
     {
         Property prop = this.get(category, name, defaultValue);
         prop.setValidValues(validValues);
-        if (validValuesDisplay != null)
-            prop.setValidValuesDisplay(validValuesDisplay);
-
+        prop.setValidValuesDisplay(validValuesDisplay);
         prop.setLanguageKey(langKey);
         prop.setComment(comment + " [default: " + defaultValue + "]");
         return prop.getStringList();

--- a/src/main/java/net/minecraftforge/common/config/FieldWrapper.java
+++ b/src/main/java/net/minecraftforge/common/config/FieldWrapper.java
@@ -259,14 +259,19 @@ public abstract class FieldWrapper implements IFieldWrapper
 
             Property prop = cfg.getCategory(this.category).get(this.name); // Will be setup in general by ConfigManager
 
-            List<String> lst = Lists.newArrayList();
+            List<String> listValidValues = Lists.newArrayList();
+            List<String> listValidValuesDisplay = Lists.newArrayList();
             for (Enum e : ((Class<? extends Enum>) field.getType()).getEnumConstants())
-                lst.add(e.name());
+            {
+            	listValidValues.add(e.name());
+            	listValidValuesDisplay.add(e.toString());
+            }
 
-            prop.setValidationPattern(Pattern.compile(PIPE.join(lst)));
-            prop.setValidValues(lst.toArray(new String[0]));
+            prop.setValidationPattern(Pattern.compile(PIPE.join(listValidValues)));
+            prop.setValidValues(listValidValues.toArray(new String[0]));
+            prop.setValidValuesDisplay(listValidValuesDisplay.toArray(new String[0]));
 
-            String validValues = NEW_LINE.join(lst);
+            String validValues = NEW_LINE.join(listValidValues);
 
             if (desc != null)
                 prop.setComment(NEW_LINE.join(new String[] { desc, "Valid values:" }) + "\n" + validValues);

--- a/src/main/java/net/minecraftforge/common/config/FieldWrapper.java
+++ b/src/main/java/net/minecraftforge/common/config/FieldWrapper.java
@@ -263,8 +263,8 @@ public abstract class FieldWrapper implements IFieldWrapper
             List<String> listValidValuesDisplay = Lists.newArrayList();
             for (Enum e : ((Class<? extends Enum>) field.getType()).getEnumConstants())
             {
-            	listValidValues.add(e.name());
-            	listValidValuesDisplay.add(e.toString());
+                listValidValues.add(e.name());
+                listValidValuesDisplay.add(e.toString());
             }
 
             prop.setValidationPattern(Pattern.compile(PIPE.join(listValidValues)));

--- a/src/main/java/net/minecraftforge/common/config/Property.java
+++ b/src/main/java/net/minecraftforge/common/config/Property.java
@@ -179,7 +179,7 @@ public class Property
 
     Property(String name, String[] values, Type type, boolean read, String[] validValues, String langKey)
     {
-    	this(name, values, type, read, validValues, new String[0], langKey);
+        this(name, values, type, read, validValues, new String[0], langKey);
     }
 
     Property(String name, String[] values, Type type, boolean read, String[] validValues, String[] validValuesDisplay, String langKey)

--- a/src/main/java/net/minecraftforge/common/config/Property.java
+++ b/src/main/java/net/minecraftforge/common/config/Property.java
@@ -111,7 +111,7 @@ public class Property
     {
         this(name, value, type, false, validValues, new String[0], name);
     }
-    
+
     public Property(String name, String value, Type type, String[] validValues, String[] validValuesDisplay)
     {
         this(name, value, type, false, validValues, validValuesDisplay, name);

--- a/src/main/java/net/minecraftforge/common/config/Property.java
+++ b/src/main/java/net/minecraftforge/common/config/Property.java
@@ -99,35 +99,45 @@ public class Property
 
     public Property(String name, String value, Type type)
     {
-        this(name, value, type, false, new String[0], name);
+        this(name, value, type, false, new String[0], new String[0], name);
     }
 
     public Property(String name, String value, Type type, boolean read)
     {
-        this(name, value, type, read, new String[0], name);
+        this(name, value, type, read, new String[0], new String[0], name);
     }
 
     public Property(String name, String value, Type type, String[] validValues)
     {
-        this(name, value, type, false, validValues, name);
+        this(name, value, type, false, validValues, new String[0], name);
+    }
+    
+    public Property(String name, String value, Type type, String[] validValues, String[] validValuesDisplay)
+    {
+        this(name, value, type, false, validValues, validValuesDisplay, name);
     }
 
     public Property(String name, String value, Type type, String langKey)
     {
-        this(name, value, type, false, new String[0], langKey);
+        this(name, value, type, false, new String[0], new String[0], langKey);
     }
 
     public Property(String name, String value, Type type, boolean read, String langKey)
     {
-        this(name, value, type, read, new String[0], langKey);
+        this(name, value, type, read, new String[0], new String[0], langKey);
     }
 
     public Property(String name, String value, Type type, String[] validValues, String langKey)
     {
-        this(name, value, type, false, validValues, langKey);
+        this(name, value, type, false, validValues, new String[0], langKey);
     }
 
-    Property(String name, String value, Type type, boolean read, String[] validValues, String langKey)
+    public Property(String name, String value, Type type, String[] validValues, String[] validValuesDisplay, String langKey)
+    {
+        this(name, value, type, false, validValues, validValuesDisplay, langKey);
+    }
+
+    Property(String name, String value, Type type, boolean read, String[] validValues, String[] validValuesDisplay, String langKey)
     {
         setName(name);
         this.value = value;
@@ -138,6 +148,7 @@ public class Property
         this.defaultValue = value;
         this.defaultValues = new String[0];
         this.validValues = validValues;
+        this.validValuesDisplay = validValues;
         this.isListLengthFixed = false;
         this.maxListLength = -1;
         this.minValue = String.valueOf(Integer.MIN_VALUE);
@@ -168,6 +179,11 @@ public class Property
 
     Property(String name, String[] values, Type type, boolean read, String[] validValues, String langKey)
     {
+    	this(name, values, type, read, validValues, new String[0], langKey);
+    }
+
+    Property(String name, String[] values, Type type, boolean read, String[] validValues, String[] validValuesDisplay, String langKey)
+    {
         setName(name);
         this.type   = type;
         this.values = Arrays.copyOf(values, values.length);
@@ -180,6 +196,7 @@ public class Property
         this.defaultValue = this.defaultValue.replaceFirst(", ", "");
         this.defaultValues = Arrays.copyOf(values, values.length);
         this.validValues = validValues;
+        this.validValuesDisplay = validValues;
         this.isListLengthFixed = false;
         this.maxListLength = -1;
         this.minValue = String.valueOf(Integer.MIN_VALUE);

--- a/src/main/java/net/minecraftforge/common/config/Property.java
+++ b/src/main/java/net/minecraftforge/common/config/Property.java
@@ -78,6 +78,7 @@ public class Property
     private String[] values;
     private String[] defaultValues;
     private String[] validValues;
+    private String[] validValuesDisplay;
     private String langKey;
     private String minValue;
     private String maxValue;
@@ -699,6 +700,28 @@ public class Property
     public String[] getValidValues()
     {
         return this.validValues;
+    }
+
+    /**
+     * Sets the array of the config GUI display versions of the valid values that this String Property can be set to.
+     * When an array of valid values is defined for a Property the GUI control for that property will be a value cycle button.
+     *
+     * @param validValueAliases a String array of the aliases of valid values
+     */
+    public Property setValidValuesDisplay(String[] validValuesDisplay)
+    {
+        this.validValuesDisplay = validValuesDisplay;
+        return this;
+    }
+
+    /**
+     * Gets the array of the config GUI display versions of the valid values that this String Property can be set to, or null if not defined.
+     *
+     * @return a String array of the aliases of the valid values
+     */
+    public String[] getValidValuesDisplay()
+    {
+        return this.validValuesDisplay;
     }
 
     /**

--- a/src/main/java/net/minecraftforge/common/config/Property.java
+++ b/src/main/java/net/minecraftforge/common/config/Property.java
@@ -710,7 +710,7 @@ public class Property
     }
 
     /**
-     * Gets the array of valid values that this String Property can be set to, or null if not defined.
+     * Gets the array of valid values that this String Property can be set to, or null or empty if not defined.
      *
      * @return a String array of valid values
      */
@@ -732,7 +732,7 @@ public class Property
     }
 
     /**
-     * Gets the array of the config GUI display versions of the valid values that this String Property can be set to, or null if not defined.
+     * Gets the array of the config GUI display versions of the valid values that this String Property can be set to, or null or empty if not defined.
      *
      * @return a String array of the aliases of the valid values
      */

--- a/src/main/java/net/minecraftforge/fml/client/config/DummyConfigElement.java
+++ b/src/main/java/net/minecraftforge/fml/client/config/DummyConfigElement.java
@@ -212,6 +212,11 @@ public class DummyConfigElement implements IConfigElement
         this(name, defaultValue, type, langKey, validValues, null, null, null);
     }
     
+    public DummyConfigElement(String name, Object defaultValue, ConfigGuiType type, String langKey, String[] validValues, String[] validValuesDisplay)
+    {
+    	this(name, defaultValue, type, langKey, validValues, validValuesDisplay, null, null, null);
+    }
+    
     public DummyConfigElement(String name, Object defaultValue, ConfigGuiType type, String langKey)
     {
         this(name, defaultValue, type, langKey, null, null, null, null);

--- a/src/main/java/net/minecraftforge/fml/client/config/DummyConfigElement.java
+++ b/src/main/java/net/minecraftforge/fml/client/config/DummyConfigElement.java
@@ -62,7 +62,7 @@ public class DummyConfigElement implements IConfigElement
     @Nullable
     protected Class<? extends IConfigEntry> configEntryClass;
     protected Class<? extends IArrayEntry> arrayEntryClass;
-    
+
     /**
      * This class provides a Dummy Category IConfigElement. It can be used to define a custom list of GUI entries that will 
      * appear on the child screen or to specify a custom IGuiConfigListEntry for a special category.
@@ -73,12 +73,12 @@ public class DummyConfigElement implements IConfigElement
         {
             this(name, langKey, childElements, null);
         }
-        
+
         public DummyCategoryElement(String name, String langKey, Class<? extends IConfigEntry> customListEntryClass)
         {
             this(name, langKey, new ArrayList<IConfigElement>(), customListEntryClass);
         }
-        
+
         public DummyCategoryElement(String name, String langKey, List<IConfigElement> childElements, @Nullable Class<? extends IConfigEntry> customListEntryClass)
         {
             super(name, null, ConfigGuiType.CONFIG_CATEGORY, langKey);
@@ -87,7 +87,7 @@ public class DummyConfigElement implements IConfigElement
             isProperty = false;
         }
     }
-    
+
     /**
      * This class provides a dummy array-type IConfigElement. 
      */
@@ -113,7 +113,7 @@ public class DummyConfigElement implements IConfigElement
         {
             this(name, defaultValues, type, langKey, isListFixedLength, -1, null, null, null);
         }
-        
+
         public DummyListElement(String name, Object[] defaultValues, ConfigGuiType type, String langKey, int maxListLength)
         {
             this(name, defaultValues, type, langKey, false, maxListLength, null, null, null);
@@ -128,7 +128,7 @@ public class DummyConfigElement implements IConfigElement
         {
             this(name, defaultValues, type, langKey, isListFixedLength, -1, null, minValue, maxValue);
         }
-        
+
         public DummyListElement(String name, Object[] defaultValues, ConfigGuiType type, String langKey, int maxListLength, Object minValue, Object maxValue)
         {
             this(name, defaultValues, type, langKey, false, maxListLength, null, minValue, maxValue);
@@ -148,12 +148,12 @@ public class DummyConfigElement implements IConfigElement
         {
             this(name, defaultValues, type, langKey, isListFixedLength, -1, validStringPattern, null, null);
         }
-        
+
         public DummyListElement(String name, Object[] defaultValues, ConfigGuiType type, String langKey, int maxListLength, Pattern validStringPattern)
         {
             this(name, defaultValues, type, langKey, false, maxListLength, validStringPattern, null, null);
         }
-        
+
         public DummyListElement setCustomEditListEntryClass(Class<? extends IArrayEntry> clazz)
         {
             this.arrayEntryClass = clazz;
@@ -166,7 +166,7 @@ public class DummyConfigElement implements IConfigElement
             return Arrays.toString(this.defaultValues);
         }
     }
-    
+
     public DummyConfigElement(String name, Object defaultValue, ConfigGuiType type, String langKey, String[] validValues, String[] validValuesDisplay, Pattern validStringPattern, Object minValue, Object maxValue)
     {
         this.name = name;
@@ -196,49 +196,49 @@ public class DummyConfigElement implements IConfigElement
         else
             this.maxValue = maxValue;
     }
-    
+
     public DummyConfigElement(String name, Object defaultValue, ConfigGuiType type, String langKey, String[] validValues, Pattern validStringPattern, Object minValue, Object maxValue)
     {
         this(name, defaultValue, type, langKey, validValues, null, validStringPattern, minValue, maxValue);
     }
-    
+
     public DummyConfigElement(String name, Object defaultValue, ConfigGuiType type, String langKey, Pattern validStringPattern)
     {
         this(name, defaultValue, type, langKey, null, validStringPattern, null, null);
     }
-    
+
     public DummyConfigElement(String name, Object defaultValue, ConfigGuiType type, String langKey, String[] validValues)
     {
         this(name, defaultValue, type, langKey, validValues, null, null, null);
     }
-    
+
     public DummyConfigElement(String name, Object defaultValue, ConfigGuiType type, String langKey, String[] validValues, String[] validValuesDisplay)
     {
         this(name, defaultValue, type, langKey, validValues, validValuesDisplay, null, null, null);
     }
-    
+
     public DummyConfigElement(String name, Object defaultValue, ConfigGuiType type, String langKey)
     {
         this(name, defaultValue, type, langKey, null, null, null, null);
     }
-    
+
     public DummyConfigElement(String name, Object defaultValue, ConfigGuiType type, String langKey, Object minValue, Object maxValue)
     {
         this(name, defaultValue, type, langKey, null, null, minValue, maxValue);
     }
-    
+
     public DummyConfigElement setCustomListEntryClass(Class<? extends IConfigEntry> clazz)
     {
         this.configEntryClass = clazz;
         return this;
     }
-    
+
     @Override
     public boolean isProperty()
     {
         return isProperty;
     }
-    
+
     public IConfigElement setConfigEntryClass(Class<? extends IConfigEntry> clazz)
     {
         this.configEntryClass = clazz;
@@ -250,7 +250,7 @@ public class DummyConfigElement implements IConfigElement
     {
         return configEntryClass;
     }
-    
+
     public IConfigElement setArrayEntryClass(Class<? extends IArrayEntry> clazz)
     {
         this.arrayEntryClass = clazz;

--- a/src/main/java/net/minecraftforge/fml/client/config/DummyConfigElement.java
+++ b/src/main/java/net/minecraftforge/fml/client/config/DummyConfigElement.java
@@ -62,7 +62,7 @@ public class DummyConfigElement implements IConfigElement
     @Nullable
     protected Class<? extends IConfigEntry> configEntryClass;
     protected Class<? extends IArrayEntry> arrayEntryClass;
-
+    
     /**
      * This class provides a Dummy Category IConfigElement. It can be used to define a custom list of GUI entries that will 
      * appear on the child screen or to specify a custom IGuiConfigListEntry for a special category.
@@ -73,12 +73,12 @@ public class DummyConfigElement implements IConfigElement
         {
             this(name, langKey, childElements, null);
         }
-
+        
         public DummyCategoryElement(String name, String langKey, Class<? extends IConfigEntry> customListEntryClass)
         {
             this(name, langKey, new ArrayList<IConfigElement>(), customListEntryClass);
         }
-
+        
         public DummyCategoryElement(String name, String langKey, List<IConfigElement> childElements, @Nullable Class<? extends IConfigEntry> customListEntryClass)
         {
             super(name, null, ConfigGuiType.CONFIG_CATEGORY, langKey);
@@ -87,7 +87,7 @@ public class DummyConfigElement implements IConfigElement
             isProperty = false;
         }
     }
-
+    
     /**
      * This class provides a dummy array-type IConfigElement. 
      */
@@ -113,7 +113,7 @@ public class DummyConfigElement implements IConfigElement
         {
             this(name, defaultValues, type, langKey, isListFixedLength, -1, null, null, null);
         }
-
+        
         public DummyListElement(String name, Object[] defaultValues, ConfigGuiType type, String langKey, int maxListLength)
         {
             this(name, defaultValues, type, langKey, false, maxListLength, null, null, null);
@@ -128,7 +128,7 @@ public class DummyConfigElement implements IConfigElement
         {
             this(name, defaultValues, type, langKey, isListFixedLength, -1, null, minValue, maxValue);
         }
-
+        
         public DummyListElement(String name, Object[] defaultValues, ConfigGuiType type, String langKey, int maxListLength, Object minValue, Object maxValue)
         {
             this(name, defaultValues, type, langKey, false, maxListLength, null, minValue, maxValue);
@@ -148,12 +148,12 @@ public class DummyConfigElement implements IConfigElement
         {
             this(name, defaultValues, type, langKey, isListFixedLength, -1, validStringPattern, null, null);
         }
-
+        
         public DummyListElement(String name, Object[] defaultValues, ConfigGuiType type, String langKey, int maxListLength, Pattern validStringPattern)
         {
             this(name, defaultValues, type, langKey, false, maxListLength, validStringPattern, null, null);
         }
-
+        
         public DummyListElement setCustomEditListEntryClass(Class<? extends IArrayEntry> clazz)
         {
             this.arrayEntryClass = clazz;
@@ -206,7 +206,7 @@ public class DummyConfigElement implements IConfigElement
     {
         this(name, defaultValue, type, langKey, null, validStringPattern, null, null);
     }
-
+    
     public DummyConfigElement(String name, Object defaultValue, ConfigGuiType type, String langKey, String[] validValues)
     {
         this(name, defaultValue, type, langKey, validValues, null, null, null);
@@ -221,24 +221,24 @@ public class DummyConfigElement implements IConfigElement
     {
         this(name, defaultValue, type, langKey, null, null, null, null);
     }
-
+    
     public DummyConfigElement(String name, Object defaultValue, ConfigGuiType type, String langKey, Object minValue, Object maxValue)
     {
         this(name, defaultValue, type, langKey, null, null, minValue, maxValue);
     }
-
+    
     public DummyConfigElement setCustomListEntryClass(Class<? extends IConfigEntry> clazz)
     {
         this.configEntryClass = clazz;
         return this;
     }
-
+    
     @Override
     public boolean isProperty()
     {
         return isProperty;
     }
-
+    
     public IConfigElement setConfigEntryClass(Class<? extends IConfigEntry> clazz)
     {
         this.configEntryClass = clazz;
@@ -250,7 +250,7 @@ public class DummyConfigElement implements IConfigElement
     {
         return configEntryClass;
     }
-
+    
     public IConfigElement setArrayEntryClass(Class<? extends IArrayEntry> clazz)
     {
         this.arrayEntryClass = clazz;

--- a/src/main/java/net/minecraftforge/fml/client/config/DummyConfigElement.java
+++ b/src/main/java/net/minecraftforge/fml/client/config/DummyConfigElement.java
@@ -214,7 +214,7 @@ public class DummyConfigElement implements IConfigElement
     
     public DummyConfigElement(String name, Object defaultValue, ConfigGuiType type, String langKey, String[] validValues, String[] validValuesDisplay)
     {
-    	this(name, defaultValue, type, langKey, validValues, validValuesDisplay, null, null, null);
+        this(name, defaultValue, type, langKey, validValues, validValuesDisplay, null, null, null);
     }
     
     public DummyConfigElement(String name, Object defaultValue, ConfigGuiType type, String langKey)

--- a/src/main/java/net/minecraftforge/fml/client/config/DummyConfigElement.java
+++ b/src/main/java/net/minecraftforge/fml/client/config/DummyConfigElement.java
@@ -50,6 +50,7 @@ public class DummyConfigElement implements IConfigElement
     protected Object[] values;
     protected Object[] defaultValues;
     protected String[] validValues;
+    protected String[] validValuesDisplay;
     protected Pattern validStringPattern;
     protected Object minValue;
     protected Object maxValue;
@@ -166,7 +167,7 @@ public class DummyConfigElement implements IConfigElement
         }
     }
     
-    public DummyConfigElement(String name, Object defaultValue, ConfigGuiType type, String langKey, String[] validValues, Pattern validStringPattern, Object minValue, Object maxValue)
+    public DummyConfigElement(String name, Object defaultValue, ConfigGuiType type, String langKey, String[] validValues, String[] validValuesDisplay, Pattern validStringPattern, Object minValue, Object maxValue)
     {
         this.name = name;
         this.defaultValue = defaultValue;
@@ -174,6 +175,7 @@ public class DummyConfigElement implements IConfigElement
         this.type = type;
         this.langKey = langKey;
         this.validValues = validValues;
+        this.validValuesDisplay = validValuesDisplay;
         this.validStringPattern = validStringPattern;
         if (minValue == null)
         {
@@ -193,6 +195,11 @@ public class DummyConfigElement implements IConfigElement
         }
         else
             this.maxValue = maxValue;
+    }
+    
+    public DummyConfigElement(String name, Object defaultValue, ConfigGuiType type, String langKey, String[] validValues, Pattern validStringPattern, Object minValue, Object maxValue)
+    {
+        this(name, defaultValue, type, langKey, validValues, null, validStringPattern, minValue, maxValue);
     }
     
     public DummyConfigElement(String name, Object defaultValue, ConfigGuiType type, String langKey, Pattern validStringPattern)
@@ -381,6 +388,12 @@ public class DummyConfigElement implements IConfigElement
     public String[] getValidValues()
     {
         return validValues;
+    }
+ 
+    @Override
+    public String[] getValidValuesDisplay()
+    {
+        return validValuesDisplay;
     }
 
     @Override

--- a/src/main/java/net/minecraftforge/fml/client/config/GuiConfigEntries.java
+++ b/src/main/java/net/minecraftforge/fml/client/config/GuiConfigEntries.java
@@ -481,8 +481,8 @@ public class GuiConfigEntries extends GuiListExtended
 
         protected String getValidValueDisplay()
         {
-        	String[] validValuesDisplay = configElement.getValidValuesDisplay();
-        	return validValuesDisplay != null && validValuesDisplay.length > 0 ? validValuesDisplay[currentIndex] : configElement.getValidValues()[currentIndex];
+            String[] validValuesDisplay = configElement.getValidValuesDisplay();
+            return validValuesDisplay != null && validValuesDisplay.length > 0 ? validValuesDisplay[currentIndex] : configElement.getValidValues()[currentIndex];
         }
 
         @Override

--- a/src/main/java/net/minecraftforge/fml/client/config/GuiConfigEntries.java
+++ b/src/main/java/net/minecraftforge/fml/client/config/GuiConfigEntries.java
@@ -476,7 +476,13 @@ public class GuiConfigEntries extends GuiListExtended
         @Override
         public void updateValueButtonText()
         {
-            this.btnValue.displayString = I18n.format(configElement.getValidValues()[currentIndex]);
+            this.btnValue.displayString = I18n.format(getValidValueDisplay());
+        }
+
+        protected String getValidValueDisplay()
+        {
+        	String[] validValuesDisplay = configElement.getValidValuesDisplay();
+        	return validValuesDisplay != null && validValuesDisplay.length > 0 ? validValuesDisplay[currentIndex] : configElement.getValidValues()[currentIndex];
         }
 
         @Override
@@ -564,14 +570,14 @@ public class GuiConfigEntries extends GuiListExtended
         @Override
         public void drawEntry(int slotIndex, int x, int y, int listWidth, int slotHeight, int mouseX, int mouseY, boolean isSelected, float partial)
         {
-            this.btnValue.packedFGColour = GuiUtils.getColorCode(this.configElement.getValidValues()[currentIndex].charAt(0), true);
+            this.btnValue.packedFGColour = GuiUtils.getColorCode(getValidValueDisplay().charAt(0), true);
             super.drawEntry(slotIndex, x, y, listWidth, slotHeight, mouseX, mouseY, isSelected, partial);
         }
 
         @Override
         public void updateValueButtonText()
         {
-            this.btnValue.displayString = I18n.format(configElement.getValidValues()[currentIndex]) + " - " + I18n.format("fml.configgui.sampletext");
+            this.btnValue.displayString = I18n.format(getValidValueDisplay()) + " - " + I18n.format("fml.configgui.sampletext");
         }
     }
 

--- a/src/main/java/net/minecraftforge/fml/client/config/IConfigElement.java
+++ b/src/main/java/net/minecraftforge/fml/client/config/IConfigElement.java
@@ -36,7 +36,7 @@ public interface IConfigElement
      * [Property, Category] Is this object a property object?
      */
     boolean isProperty();
-    
+
     /**
      * This method returns a class that implements {@link IConfigEntry} or null. This class MUST
      * provide a constructor with the following parameter types: {@link GuiConfig}, {@link GuiConfigEntries}, {@link IConfigElement}
@@ -48,7 +48,7 @@ public interface IConfigElement
      * @see GuiConfigEntries.IntegerEntry
      */
     Class<? extends IConfigEntry> getConfigEntryClass();
-    
+
     /**
      * This method returns a class that implements {@link IArrayEntry}. This class MUST provide a constructor with the
      * following parameter types: {@link GuiEditArray}, {@link GuiEditArrayEntries}, {@link IConfigElement}, {@link Object}
@@ -60,134 +60,134 @@ public interface IConfigElement
      * @see GuiEditArrayEntries.IntegerEntry
      */
     Class<? extends IArrayEntry> getArrayEntryClass();
-    
+
     /**
      * [Property, Category] Gets the name of this object.
      */
     String getName();
-    
+
     /**
      * [Category] Gets the qualified name of this object. This is typically only used for category objects.
      */
     String getQualifiedName();
-    
+
     /**
      * [Property, Category] Gets a language key for localization of config GUI entry names. If the same key is specified with .tooltip
      * appended to the end, that key will return a localized tooltip when the mouse hovers over the property label/category button.
      */
     String getLanguageKey();
-    
+
     /**
      * [Property, Category] Gets the comment for this object. Used for the tooltip if getLanguageKey() + ".tooltip" is not defined in the
      * .lang file.
      */
     String getComment();
-    
+
     /**
      * [Category] Gets this category's child categories/properties.
      */
     List<IConfigElement> getChildElements();
-    
+
     /**
      * [Property, Category] Gets the ConfigGuiType value corresponding to the type of this property object, or CONFIG_CATEGORY if this is a
      * category object.
      */
     ConfigGuiType getType();
-    
+
     /**
      * [Property] Is this property object a list?
      */
     boolean isList();
-    
+
     /**
      * [Property] Does this list property have to remain a fixed length?
      */
     boolean isListLengthFixed();
-    
+
     /**
      * [Property] Gets the max length of this list property, or -1 if the length is unlimited.
      */
     int getMaxListLength();
-    
+
     /**
      * [Property] Is this property value equal to the default value?
      */
     boolean isDefault();
-    
+
     /**
      * [Property] Gets this property's default value. If this element is an array, this method should return a String
      * representation of that array using Arrays.toString()
      */
     Object getDefault();
-    
+
     /**
      * [Property] Gets this property's default values.
      */
     Object[] getDefaults();
-    
+
     /**
      * [Property] Sets this property's value to the default value.
      */
     void setToDefault();
-    
+
     /**
      * [Property, Category] Whether or not this element is safe to modify while a world is running. For Categories return false if ANY properties
      * in the category are modifiable while a world is running, true if all are not.
      */
     boolean requiresWorldRestart();
-    
+
     /**
      * [Property, Category] Whether or not this element should be allowed to show on config GUIs.
      */
     boolean showInGui();
-    
+
     /**
      * [Property, Category] Whether or not this element requires Minecraft to be restarted when changed.
      */
     boolean requiresMcRestart();
-    
+
     /**
      * [Property] Gets this property value.
      */
     Object get();
-    
+
     /**
      * [Property] Gets this property value as a list. Generally you should be sure of whether the property is a list before calling this.
      */
     Object[] getList();
-    
+
     /**
      * [Property] Sets this property's value.
      */
     void set(Object value);
-    
+
     /**
      * [Property] Sets this property's value to the specified array.
      */
     void set(Object[] aVal);
-    
+
     /**
      * [Property] Gets a String array of valid values for this property. This is generally used for String properties to allow the user to
      * select a value from a list of valid values.
      */
     String[] getValidValues();
-    
+
     /**
      * [Property] Gets a String array of the versions of this property's valid values that will display in the config GUI.
      * This is generally used for String properties to allow the user to select a value from a list of valid values.
      */
     String[] getValidValuesDisplay();
-    
+
     /**
      * [Property] Gets this property's minimum value.
      */
     Object getMinValue();
-    
+
     /**
      * [Property] Gets this property's maximum value.
      */
     Object getMaxValue();
-    
+
     /**
      * [Property] Gets a Pattern object used in String property input validation.
      */

--- a/src/main/java/net/minecraftforge/fml/client/config/IConfigElement.java
+++ b/src/main/java/net/minecraftforge/fml/client/config/IConfigElement.java
@@ -36,7 +36,7 @@ public interface IConfigElement
      * [Property, Category] Is this object a property object?
      */
     boolean isProperty();
-
+    
     /**
      * This method returns a class that implements {@link IConfigEntry} or null. This class MUST
      * provide a constructor with the following parameter types: {@link GuiConfig}, {@link GuiConfigEntries}, {@link IConfigElement}
@@ -48,7 +48,7 @@ public interface IConfigElement
      * @see GuiConfigEntries.IntegerEntry
      */
     Class<? extends IConfigEntry> getConfigEntryClass();
-
+    
     /**
      * This method returns a class that implements {@link IArrayEntry}. This class MUST provide a constructor with the
      * following parameter types: {@link GuiEditArray}, {@link GuiEditArrayEntries}, {@link IConfigElement}, {@link Object}
@@ -60,112 +60,112 @@ public interface IConfigElement
      * @see GuiEditArrayEntries.IntegerEntry
      */
     Class<? extends IArrayEntry> getArrayEntryClass();
-
+    
     /**
      * [Property, Category] Gets the name of this object.
      */
     String getName();
-
+    
     /**
      * [Category] Gets the qualified name of this object. This is typically only used for category objects.
      */
     String getQualifiedName();
-
+    
     /**
      * [Property, Category] Gets a language key for localization of config GUI entry names. If the same key is specified with .tooltip
      * appended to the end, that key will return a localized tooltip when the mouse hovers over the property label/category button.
      */
     String getLanguageKey();
-
+    
     /**
      * [Property, Category] Gets the comment for this object. Used for the tooltip if getLanguageKey() + ".tooltip" is not defined in the
      * .lang file.
      */
     String getComment();
-
+    
     /**
      * [Category] Gets this category's child categories/properties.
      */
     List<IConfigElement> getChildElements();
-
+    
     /**
      * [Property, Category] Gets the ConfigGuiType value corresponding to the type of this property object, or CONFIG_CATEGORY if this is a
      * category object.
      */
     ConfigGuiType getType();
-
+    
     /**
      * [Property] Is this property object a list?
      */
     boolean isList();
-
+    
     /**
      * [Property] Does this list property have to remain a fixed length?
      */
     boolean isListLengthFixed();
-
+    
     /**
      * [Property] Gets the max length of this list property, or -1 if the length is unlimited.
      */
     int getMaxListLength();
-
+    
     /**
      * [Property] Is this property value equal to the default value?
      */
     boolean isDefault();
-
+    
     /**
      * [Property] Gets this property's default value. If this element is an array, this method should return a String
      * representation of that array using Arrays.toString()
      */
     Object getDefault();
-
+    
     /**
      * [Property] Gets this property's default values.
      */
     Object[] getDefaults();
-
+    
     /**
      * [Property] Sets this property's value to the default value.
      */
     void setToDefault();
-
+    
     /**
      * [Property, Category] Whether or not this element is safe to modify while a world is running. For Categories return false if ANY properties
      * in the category are modifiable while a world is running, true if all are not.
      */
     boolean requiresWorldRestart();
-
+    
     /**
      * [Property, Category] Whether or not this element should be allowed to show on config GUIs.
      */
     boolean showInGui();
-
+    
     /**
      * [Property, Category] Whether or not this element requires Minecraft to be restarted when changed.
      */
     boolean requiresMcRestart();
-
+    
     /**
      * [Property] Gets this property value.
      */
     Object get();
-
+    
     /**
      * [Property] Gets this property value as a list. Generally you should be sure of whether the property is a list before calling this.
      */
     Object[] getList();
-
+    
     /**
      * [Property] Sets this property's value.
      */
     void set(Object value);
-
+    
     /**
      * [Property] Sets this property's value to the specified array.
      */
     void set(Object[] aVal);
-
+    
     /**
      * [Property] Gets a String array of valid values for this property. This is generally used for String properties to allow the user to
      * select a value from a list of valid values.
@@ -182,12 +182,12 @@ public interface IConfigElement
      * [Property] Gets this property's minimum value.
      */
     Object getMinValue();
-
+    
     /**
      * [Property] Gets this property's maximum value.
      */
     Object getMaxValue();
-
+    
     /**
      * [Property] Gets a Pattern object used in String property input validation.
      */

--- a/src/main/java/net/minecraftforge/fml/client/config/IConfigElement.java
+++ b/src/main/java/net/minecraftforge/fml/client/config/IConfigElement.java
@@ -173,6 +173,12 @@ public interface IConfigElement
     String[] getValidValues();
     
     /**
+     * [Property] Gets a String array of the versions of this property's valid values that will display in the config GUI.
+     * This is generally used for String properties to allow the user to select a value from a list of valid values.
+     */
+    String[] getValidValuesDisplay();
+    
+    /**
      * [Property] Gets this property's minimum value.
      */
     Object getMinValue();

--- a/src/test/java/net/minecraftforge/debug/mod/ConfigAnnotationTest.java
+++ b/src/test/java/net/minecraftforge/debug/mod/ConfigAnnotationTest.java
@@ -132,7 +132,25 @@ public class ConfigAnnotationTest
         public static TEST        enu = TEST.BIG;
         public static NestedType  Inner = new NestedType();
 
-        public enum TEST { BIG, BAD, WOLF; }
+        public enum TEST
+        {
+        	BIG("Big"),
+        	BAD("Bad"),
+        	WOLF("Wolf");
+
+        	private String name;
+
+        	private TEST(String name)
+        	{
+        		this.name = name;
+        	}
+
+        	@Override
+        	public String toString()
+        	{
+        		return name;
+        	}
+        }
         public static class NestedType
         {
             public String HeyLook = "I'm Inside!";

--- a/src/test/java/net/minecraftforge/debug/mod/ConfigAnnotationTest.java
+++ b/src/test/java/net/minecraftforge/debug/mod/ConfigAnnotationTest.java
@@ -134,22 +134,22 @@ public class ConfigAnnotationTest
 
         public enum TEST
         {
-        	BIG("Big"),
-        	BAD("Bad"),
-        	WOLF("Wolf");
+            BIG("Big"),
+            BAD("Bad"),
+            WOLF("Wolf");
 
-        	private String name;
+            private String name;
 
-        	private TEST(String name)
-        	{
-        		this.name = name;
-        	}
+            private TEST(String name)
+            {
+                this.name = name;
+            }
 
-        	@Override
-        	public String toString()
-        	{
-        		return name;
-        	}
+            @Override
+            public String toString()
+            {
+                return name;
+            }
         }
         public static class NestedType
         {


### PR DESCRIPTION
Currently, they only display the actual values. I implemented [a workaround](http://www.minecraftforge.net/forum/topic/65048-solved-config-enum-value-text/?tab=comments#comment-317086) using `EnumHelper`, but was [informed of it's unreliability](http://www.minecraftforge.net/forum/topic/65048-solved-config-enum-value-text/?tab=comments#comment-317110).

With this PR, config files themselves remain completely unchanged, as the actual values (the return values of `Enum#name`) are still used for generating them, but the display strings for the cycling button elements in the config GUIs render the return values of `Enum#toString`. It's merely a visual improvement afforded only to those using the config GUI, rather than directly modifying the config file.

Also, everything I added here emulates what was already there, and in doing so, I noticed an inconsistency: The documentation for `Propery#getValidValues` states that the returned array will be "null if not defined," yet all its constructors that don't define it initialize it with an empty array. `ConfigElement#getValidValues` returns `Propery#getValidValues` if it's a property element, but null, if not. And all the constructors of `DummyConfigElement` initialize its `validValues` field as null if not defined. Finally, the `GuiConfigEntries` constructor, where the config element's `getValidValues` methods are called, checks if the return value is null or empty.

So, it seems that `ConfigElement`and `DummyConfigElement` follow `Propery#getValidValues`'s documentation by returning null, yet `Propery` itself doesn't. So should I change `Propery`'s constructors to initialize them as null, and remove the length checks from `GuiConfigEntries`? Or should I just change the documentation of `Propery#getValidValues` to indicate that the returned array will be null or empty if not defined?