### PR TITLE
Reduce Network usage by post-poning flush

### DIFF
--- a/patches/minecraft/net/minecraft/network/NetworkManager.java.patch
+++ b/patches/minecraft/net/minecraft/network/NetworkManager.java.patch
@@ -21,7 +21,7 @@
          {
              field_150735_g.debug("Disabled auto read");
              this.field_150746_k.config().setAutoRead(false);
-@@ -212,7 +217,7 @@
+@@ -212,12 +217,12 @@
  
          if (this.field_150746_k.eventLoop().inEventLoop())
          {
@@ -30,7 +30,13 @@
              {
                  this.func_150723_a(enumconnectionstate);
              }
-@@ -232,7 +237,7 @@
+ 
+-            ChannelFuture channelfuture = this.field_150746_k.writeAndFlush(p_150732_1_);
++            ChannelFuture channelfuture = net.minecraftforge.common.network.NetworkChannelHelper.writeAndFlush(this.field_150746_k, p_150732_1_);
+ 
+             if (p_150732_2_ != null)
+             {
+@@ -232,12 +237,12 @@
              {
                  public void run()
                  {
@@ -39,6 +45,12 @@
                      {
                          NetworkManager.this.func_150723_a(enumconnectionstate);
                      }
+ 
+-                    ChannelFuture channelfuture1 = NetworkManager.this.field_150746_k.writeAndFlush(p_150732_1_);
++                    ChannelFuture channelfuture1 = net.minecraftforge.common.network.NetworkChannelHelper.writeAndFlush(NetworkManager.this.field_150746_k, p_150732_1_);
+ 
+                     if (p_150732_2_ != null)
+                     {
 @@ -308,6 +313,7 @@
      @SideOnly(Side.CLIENT)
      public static NetworkManager func_181124_a(InetAddress p_181124_0_, int p_181124_1_, boolean p_181124_2_)

--- a/patches/minecraft/net/minecraft/network/NetworkManager.java.patch
+++ b/patches/minecraft/net/minecraft/network/NetworkManager.java.patch
@@ -32,7 +32,7 @@
              }
  
 -            ChannelFuture channelfuture = this.field_150746_k.writeAndFlush(p_150732_1_);
-+            ChannelFuture channelfuture = net.minecraftforge.common.network.NetworkChannelHelper.writeAndFlush(this.field_150746_k, p_150732_1_);
++            ChannelFuture channelfuture = net.minecraftforge.common.network.NetworkChannelHelper.writeAndFlush(this.field_150746_k, p_150732_1_, field_150744_m);
  
              if (p_150732_2_ != null)
              {
@@ -47,7 +47,7 @@
                      }
  
 -                    ChannelFuture channelfuture1 = NetworkManager.this.field_150746_k.writeAndFlush(p_150732_1_);
-+                    ChannelFuture channelfuture1 = net.minecraftforge.common.network.NetworkChannelHelper.writeAndFlush(NetworkManager.this.field_150746_k, p_150732_1_);
++                    ChannelFuture channelfuture1 = net.minecraftforge.common.network.NetworkChannelHelper.writeAndFlush(NetworkManager.this.field_150746_k, p_150732_1_, field_150744_m);
  
                      if (p_150732_2_ != null)
                      {

--- a/src/main/java/net/minecraftforge/common/ForgeModContainer.java
+++ b/src/main/java/net/minecraftforge/common/ForgeModContainer.java
@@ -126,7 +126,7 @@ public class ForgeModContainer extends DummyModContainer implements WorldAccessC
     public static boolean logCascadingWorldGeneration = true; // see Chunk#logCascadingWorldGeneration()
     public static boolean fixVanillaCascading = false; // There are various places in vanilla that cause cascading worldgen. Enabling this WILL change where blocks are placed to prevent this.
                                                        // DO NOT contact Forge about worldgen not 'matching' vanilla if this flag is set.
-    public static boolean flushNetworkOnTick = false; //because vanilla spamms TCP packets
+    public static boolean flushNetworkOnTick = false; //because vanilla spmms TCP packets
 
     static final Logger log = LogManager.getLogger(ForgeVersion.MOD_ID);
 
@@ -313,7 +313,7 @@ public class ForgeModContainer extends DummyModContainer implements WorldAccessC
         propOrder.add(prop.getName());
         
         prop = config.get(Configuration.CATEGORY_GENERAL, "flushNetworkOnTick", true,
-        		"When enabled, packets are send once per tick, which greatly reduces network traffic but might increase latency (<50ms). When disabled packets are send immediatly.");
+        		"When enabled, packets are send once per tick, which greatly reduces network traffic but might increase latency (<50ms). When disabled packets are sent immediately.");
         flushNetworkOnTick = prop.getBoolean();
         prop.setLanguageKey("forge.configgui.flushNetworkOnTick");
         propOrder.add(prop.getName());

--- a/src/main/java/net/minecraftforge/common/ForgeModContainer.java
+++ b/src/main/java/net/minecraftforge/common/ForgeModContainer.java
@@ -126,7 +126,7 @@ public class ForgeModContainer extends DummyModContainer implements WorldAccessC
     public static boolean logCascadingWorldGeneration = true; // see Chunk#logCascadingWorldGeneration()
     public static boolean fixVanillaCascading = false; // There are various places in vanilla that cause cascading worldgen. Enabling this WILL change where blocks are placed to prevent this.
                                                        // DO NOT contact Forge about worldgen not 'matching' vanilla if this flag is set.
-    public static boolean instantNetworkFlushing = true; //because vanilla spamms TCP packets
+    public static boolean flushNetworkOnTick = false; //because vanilla spamms TCP packets
 
     static final Logger log = LogManager.getLogger(ForgeVersion.MOD_ID);
 
@@ -312,10 +312,10 @@ public class ForgeModContainer extends DummyModContainer implements WorldAccessC
         prop.setLanguageKey("forge.configgui.dimensionUnloadQueueDelay");
         propOrder.add(prop.getName());
         
-        prop = config.get(Configuration.CATEGORY_GENERAL, "instantNetworkFlushing", true,
-        		"This is enabled by default as this is vanilla behaivuer, by disabling this packets will only get send after each tick to reduce alot of tiny packets (wich have a very large TCP header)");
-        instantNetworkFlushing = prop.getBoolean();
-        prop.setLanguageKey("forge.configgui.instantNetworkFlushing");
+        prop = config.get(Configuration.CATEGORY_GENERAL, "flushNetworkOnTick", true,
+        		"When enabled, packets are send once per tick, which greatly reduces network traffic but might increase latency (<50ms). When disabled packets are send immediatly.");
+        flushNetworkOnTick = prop.getBoolean();
+        prop.setLanguageKey("forge.configgui.flushNetworkOnTick");
         propOrder.add(prop.getName());
 
         config.setCategoryPropertyOrder(CATEGORY_GENERAL, propOrder);

--- a/src/main/java/net/minecraftforge/common/ForgeModContainer.java
+++ b/src/main/java/net/minecraftforge/common/ForgeModContainer.java
@@ -126,6 +126,7 @@ public class ForgeModContainer extends DummyModContainer implements WorldAccessC
     public static boolean logCascadingWorldGeneration = true; // see Chunk#logCascadingWorldGeneration()
     public static boolean fixVanillaCascading = false; // There are various places in vanilla that cause cascading worldgen. Enabling this WILL change where blocks are placed to prevent this.
                                                        // DO NOT contact Forge about worldgen not 'matching' vanilla if this flag is set.
+    public static boolean instantNetworkFlushing = true; //because vanilla spamms TCP packets
 
     static final Logger log = LogManager.getLogger(ForgeVersion.MOD_ID);
 
@@ -309,6 +310,12 @@ public class ForgeModContainer extends DummyModContainer implements WorldAccessC
                         "This can be useful when rapidly loading and unloading dimensions, like e.g. throwing items through a nether portal a few time per second.");
         dimensionUnloadQueueDelay = prop.getInt(0);
         prop.setLanguageKey("forge.configgui.dimensionUnloadQueueDelay");
+        propOrder.add(prop.getName());
+        
+        prop = config.get(Configuration.CATEGORY_GENERAL, "instantNetworkFlushing", true,
+        		"This is enabled by default as this is vanilla behaivuer, by disabling this packets will only get send after each tick to reduce alot of tiny packets (wich have a very large TCP header)");
+        instantNetworkFlushing = prop.getBoolean();
+        prop.setLanguageKey("forge.configgui.instantNetworkFlushing");
         propOrder.add(prop.getName());
 
         config.setCategoryPropertyOrder(CATEGORY_GENERAL, propOrder);

--- a/src/main/java/net/minecraftforge/common/network/NetworkChannelHelper.java
+++ b/src/main/java/net/minecraftforge/common/network/NetworkChannelHelper.java
@@ -29,10 +29,6 @@ import net.minecraft.network.INetHandler;
 import net.minecraft.network.play.INetHandlerPlayClient;
 import net.minecraft.network.play.INetHandlerPlayServer;
 import net.minecraftforge.common.ForgeModContainer;
-import net.minecraftforge.fml.common.Mod;
-import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
-import net.minecraftforge.fml.common.gameevent.TickEvent;
-import net.minecraftforge.fml.common.gameevent.TickEvent.Phase;
 
 public class NetworkChannelHelper
 {

--- a/src/main/java/net/minecraftforge/common/network/NetworkChannelHelper.java
+++ b/src/main/java/net/minecraftforge/common/network/NetworkChannelHelper.java
@@ -1,3 +1,22 @@
+/*
+ * Minecraft Forge
+ * Copyright (c) 2016-2018.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation version 2.1
+ * of the License.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
 package net.minecraftforge.common.network;
 
 import java.util.HashSet;

--- a/src/main/java/net/minecraftforge/common/network/NetworkChannelHelper.java
+++ b/src/main/java/net/minecraftforge/common/network/NetworkChannelHelper.java
@@ -20,7 +20,6 @@
 package net.minecraftforge.common.network;
 
 import java.util.HashSet;
-import java.util.Properties;
 import java.util.Set;
 
 import io.netty.channel.ChannelFuture;

--- a/src/main/java/net/minecraftforge/common/network/NetworkChannelHelper.java
+++ b/src/main/java/net/minecraftforge/common/network/NetworkChannelHelper.java
@@ -15,7 +15,6 @@ import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
 import net.minecraftforge.fml.common.gameevent.TickEvent;
 import net.minecraftforge.fml.common.gameevent.TickEvent.Phase;
 
-@Mod.EventBusSubscriber(modid = "forge")
 public class NetworkChannelHelper
 {
     private static Set<ChannelOutboundInvoker> markedChannels;

--- a/src/main/java/net/minecraftforge/common/network/NetworkChannelHelper.java
+++ b/src/main/java/net/minecraftforge/common/network/NetworkChannelHelper.java
@@ -20,6 +20,7 @@
 package net.minecraftforge.common.network;
 
 import java.util.HashSet;
+import java.util.Properties;
 import java.util.Set;
 
 import io.netty.channel.ChannelFuture;
@@ -34,12 +35,15 @@ public class NetworkChannelHelper
 {
     private static Set<ChannelOutboundInvoker> markedChannels;
     
+    public static int flushDelay;
+    
     static
     {
         markedChannels = new HashSet<ChannelOutboundInvoker>();
         Thread t = new Thread(NetworkChannelHelper::run, "NetworkChannelFlush");
         t.setDaemon(true);
         t.start();
+        flushDelay = Integer.getInteger("fml.network.flushDelay", 50);
     }
     
     
@@ -105,7 +109,7 @@ public class NetworkChannelHelper
     
     private static boolean isInstantFlushEnabled()
     {
-        return ForgeModContainer.instantNetworkFlushing;
+        return !ForgeModContainer.flushNetworkOnTick;
     }
     
     public static void run()
@@ -115,7 +119,7 @@ public class NetworkChannelHelper
             while(true)
             {
                 flushAllChannels();
-                Thread.sleep(50);
+                Thread.sleep(flushDelay);
             }
         }
         catch(InterruptedException e) {

--- a/src/main/java/net/minecraftforge/common/network/NetworkChannelHelper.java
+++ b/src/main/java/net/minecraftforge/common/network/NetworkChannelHelper.java
@@ -1,0 +1,86 @@
+package net.minecraftforge.common.network;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import io.netty.channel.ChannelFuture;
+import io.netty.channel.ChannelOutboundInvoker;
+import io.netty.channel.ChannelPromise;
+import net.minecraftforge.common.ForgeModContainer;
+import net.minecraftforge.fml.common.Mod;
+import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
+import net.minecraftforge.fml.common.gameevent.TickEvent;
+
+@Mod.EventBusSubscriber(modid = "forge")
+public class NetworkChannelHelper
+{
+    private static Set<ChannelOutboundInvoker> markedChannels;
+    
+    static
+    {
+        markedChannels = new HashSet<ChannelOutboundInvoker>();
+    }
+    
+    
+    public static ChannelFuture writeAndFlush(ChannelOutboundInvoker channel, Object msg)
+    {
+        if(isInstantFlushEnabled())
+        {
+            return channel.writeAndFlush(msg);
+        }
+        else
+        {
+            markForFlush(channel);
+            return channel.write(msg);
+        }
+    }
+    
+    public static ChannelFuture writeAndFlush(ChannelOutboundInvoker channel, Object msg, ChannelPromise promise)
+    {
+        if(isInstantFlushEnabled())
+        {
+            return channel.writeAndFlush(msg, promise);
+        }
+        else
+        {
+            markForFlush(channel);
+            return channel.write(msg, promise);
+        }
+    }
+    
+    
+    public static void markForFlush(ChannelOutboundInvoker channel)
+    {
+        synchronized (markedChannels)
+        {
+            markedChannels.add(channel);
+        }
+    }
+    
+    @SubscribeEvent
+    public static void tickServer(TickEvent.ServerTickEvent event)
+    {
+        synchronized (markedChannels)
+        {
+            markedChannels.forEach(ChannelOutboundInvoker::flush);
+            markedChannels.clear();
+        }
+        
+    }
+    
+    @SubscribeEvent
+    public static void tickClient(TickEvent.ClientTickEvent event)
+    {
+        synchronized (markedChannels)
+        {
+            markedChannels.forEach(ChannelOutboundInvoker::flush);
+            markedChannels.clear();
+        }
+        
+    }
+    
+    private static boolean isInstantFlushEnabled()
+    {
+        return ForgeModContainer.instantNetworkFlushing;
+    }
+}

--- a/src/main/java/net/minecraftforge/fml/common/network/FMLEventChannel.java
+++ b/src/main/java/net/minecraftforge/fml/common/network/FMLEventChannel.java
@@ -28,6 +28,7 @@ import net.minecraft.client.network.NetHandlerPlayClient;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraft.network.NetHandlerPlayServer;
+import net.minecraftforge.common.network.NetworkChannelHelper;
 import net.minecraftforge.fml.common.FMLCommonHandler;
 import net.minecraftforge.fml.common.eventhandler.EventBus;
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
@@ -131,7 +132,7 @@ public class FMLEventChannel {
             if (event.getReply() != null)
             {
                 ctx.channel().attr(FMLOutboundHandler.FML_MESSAGETARGET).set(FMLOutboundHandler.OutboundTarget.REPLY);
-                ctx.writeAndFlush(event.getReply()).addListener(ChannelFutureListener.FIRE_EXCEPTION_ON_FAILURE);
+                NetworkChannelHelper.writeAndFlush(ctx, event.getReply()).addListener(ChannelFutureListener.FIRE_EXCEPTION_ON_FAILURE);
             }
         }
     }
@@ -150,7 +151,7 @@ public class FMLEventChannel {
     public void sendToAll(FMLProxyPacket pkt)
     {
         channels.get(Side.SERVER).attr(FMLOutboundHandler.FML_MESSAGETARGET).set(FMLOutboundHandler.OutboundTarget.ALL);
-        channels.get(Side.SERVER).writeAndFlush(pkt).addListener(ChannelFutureListener.FIRE_EXCEPTION_ON_FAILURE);
+        NetworkChannelHelper.writeAndFlush(channels.get(Side.SERVER), pkt).addListener(ChannelFutureListener.FIRE_EXCEPTION_ON_FAILURE);
     }
 
     /**
@@ -163,7 +164,7 @@ public class FMLEventChannel {
     {
         channels.get(Side.SERVER).attr(FMLOutboundHandler.FML_MESSAGETARGET).set(FMLOutboundHandler.OutboundTarget.PLAYER);
         channels.get(Side.SERVER).attr(FMLOutboundHandler.FML_MESSAGETARGETARGS).set(player);
-        channels.get(Side.SERVER).writeAndFlush(pkt).addListener(ChannelFutureListener.FIRE_EXCEPTION_ON_FAILURE);
+        NetworkChannelHelper.writeAndFlush(channels.get(Side.SERVER), pkt).addListener(ChannelFutureListener.FIRE_EXCEPTION_ON_FAILURE);
     }
 
     /**
@@ -175,7 +176,7 @@ public class FMLEventChannel {
     {
         channels.get(Side.SERVER).attr(FMLOutboundHandler.FML_MESSAGETARGET).set(FMLOutboundHandler.OutboundTarget.ALLAROUNDPOINT);
         channels.get(Side.SERVER).attr(FMLOutboundHandler.FML_MESSAGETARGETARGS).set(point);
-        channels.get(Side.SERVER).writeAndFlush(pkt).addListener(ChannelFutureListener.FIRE_EXCEPTION_ON_FAILURE);
+        NetworkChannelHelper.writeAndFlush(channels.get(Side.SERVER), pkt).addListener(ChannelFutureListener.FIRE_EXCEPTION_ON_FAILURE);
     }
 
     /**
@@ -188,7 +189,7 @@ public class FMLEventChannel {
     {
         channels.get(Side.SERVER).attr(FMLOutboundHandler.FML_MESSAGETARGET).set(FMLOutboundHandler.OutboundTarget.TRACKING_POINT);
         channels.get(Side.SERVER).attr(FMLOutboundHandler.FML_MESSAGETARGETARGS).set(point);
-        channels.get(Side.SERVER).writeAndFlush(pkt).addListener(ChannelFutureListener.FIRE_EXCEPTION_ON_FAILURE);
+        NetworkChannelHelper.writeAndFlush(channels.get(Side.SERVER), pkt).addListener(ChannelFutureListener.FIRE_EXCEPTION_ON_FAILURE);
     }
 
     /**
@@ -202,7 +203,7 @@ public class FMLEventChannel {
     {
         channels.get(Side.SERVER).attr(FMLOutboundHandler.FML_MESSAGETARGET).set(FMLOutboundHandler.OutboundTarget.TRACKING_ENTITY);
         channels.get(Side.SERVER).attr(FMLOutboundHandler.FML_MESSAGETARGETARGS).set(entity);
-        channels.get(Side.SERVER).writeAndFlush(pkt).addListener(ChannelFutureListener.FIRE_EXCEPTION_ON_FAILURE);
+        NetworkChannelHelper.writeAndFlush(channels.get(Side.SERVER), pkt).addListener(ChannelFutureListener.FIRE_EXCEPTION_ON_FAILURE);
     }
 
     /**
@@ -214,7 +215,7 @@ public class FMLEventChannel {
     {
         channels.get(Side.SERVER).attr(FMLOutboundHandler.FML_MESSAGETARGET).set(FMLOutboundHandler.OutboundTarget.DIMENSION);
         channels.get(Side.SERVER).attr(FMLOutboundHandler.FML_MESSAGETARGETARGS).set(dimensionId);
-        channels.get(Side.SERVER).writeAndFlush(pkt).addListener(ChannelFutureListener.FIRE_EXCEPTION_ON_FAILURE);
+        NetworkChannelHelper.writeAndFlush(channels.get(Side.SERVER), pkt).addListener(ChannelFutureListener.FIRE_EXCEPTION_ON_FAILURE);
     }
 
     /**
@@ -224,6 +225,6 @@ public class FMLEventChannel {
     public void sendToServer(FMLProxyPacket pkt)
     {
         channels.get(Side.CLIENT).attr(FMLOutboundHandler.FML_MESSAGETARGET).set(FMLOutboundHandler.OutboundTarget.TOSERVER);
-        channels.get(Side.CLIENT).writeAndFlush(pkt).addListener(ChannelFutureListener.FIRE_EXCEPTION_ON_FAILURE);
+        NetworkChannelHelper.writeAndFlush(channels.get(Side.CLIENT), pkt).addListener(ChannelFutureListener.FIRE_EXCEPTION_ON_FAILURE);
     }
 }

--- a/src/main/java/net/minecraftforge/fml/common/network/simpleimpl/SimpleChannelHandlerWrapper.java
+++ b/src/main/java/net/minecraftforge/fml/common/network/simpleimpl/SimpleChannelHandlerWrapper.java
@@ -22,6 +22,7 @@ package net.minecraftforge.fml.common.network.simpleimpl;
 import org.apache.logging.log4j.Level;
 
 import net.minecraft.network.INetHandler;
+import net.minecraftforge.common.network.NetworkChannelHelper;
 import net.minecraftforge.fml.common.FMLLog;
 import net.minecraftforge.fml.common.network.FMLOutboundHandler;
 import net.minecraftforge.fml.common.network.NetworkRegistry;
@@ -57,7 +58,7 @@ public class SimpleChannelHandlerWrapper<REQ extends IMessage, REPLY extends IMe
         if (result != null)
         {
             ctx.channel().attr(FMLOutboundHandler.FML_MESSAGETARGET).set(FMLOutboundHandler.OutboundTarget.REPLY);
-            ctx.writeAndFlush(result).addListener(ChannelFutureListener.FIRE_EXCEPTION_ON_FAILURE);
+            NetworkChannelHelper.writeAndFlush(ctx, result).addListener(ChannelFutureListener.FIRE_EXCEPTION_ON_FAILURE);
         }
     }
 

--- a/src/main/java/net/minecraftforge/fml/common/network/simpleimpl/SimpleNetworkWrapper.java
+++ b/src/main/java/net/minecraftforge/fml/common/network/simpleimpl/SimpleNetworkWrapper.java
@@ -33,6 +33,7 @@ import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraft.network.INetHandler;
 import net.minecraft.network.Packet;
 import net.minecraft.tileentity.TileEntity;
+import net.minecraftforge.common.network.NetworkChannelHelper;
 import net.minecraftforge.fml.common.event.FMLInitializationEvent;
 import net.minecraftforge.fml.common.event.FMLPreInitializationEvent;
 import net.minecraftforge.fml.common.network.FMLEmbeddedChannel;
@@ -233,7 +234,7 @@ public class SimpleNetworkWrapper {
     public void sendToAll(IMessage message)
     {
         channels.get(Side.SERVER).attr(FMLOutboundHandler.FML_MESSAGETARGET).set(FMLOutboundHandler.OutboundTarget.ALL);
-        channels.get(Side.SERVER).writeAndFlush(message).addListener(ChannelFutureListener.FIRE_EXCEPTION_ON_FAILURE);
+        NetworkChannelHelper.writeAndFlush(channels.get(Side.SERVER), message).addListener(ChannelFutureListener.FIRE_EXCEPTION_ON_FAILURE);
     }
 
     /**
@@ -247,7 +248,7 @@ public class SimpleNetworkWrapper {
     {
         channels.get(Side.SERVER).attr(FMLOutboundHandler.FML_MESSAGETARGET).set(FMLOutboundHandler.OutboundTarget.PLAYER);
         channels.get(Side.SERVER).attr(FMLOutboundHandler.FML_MESSAGETARGETARGS).set(player);
-        channels.get(Side.SERVER).writeAndFlush(message).addListener(ChannelFutureListener.FIRE_EXCEPTION_ON_FAILURE);
+        NetworkChannelHelper.writeAndFlush(channels.get(Side.SERVER), message).addListener(ChannelFutureListener.FIRE_EXCEPTION_ON_FAILURE);
     }
 
     /**
@@ -261,7 +262,7 @@ public class SimpleNetworkWrapper {
     {
         channels.get(Side.SERVER).attr(FMLOutboundHandler.FML_MESSAGETARGET).set(FMLOutboundHandler.OutboundTarget.ALLAROUNDPOINT);
         channels.get(Side.SERVER).attr(FMLOutboundHandler.FML_MESSAGETARGETARGS).set(point);
-        channels.get(Side.SERVER).writeAndFlush(message).addListener(ChannelFutureListener.FIRE_EXCEPTION_ON_FAILURE);
+        NetworkChannelHelper.writeAndFlush(channels.get(Side.SERVER), message).addListener(ChannelFutureListener.FIRE_EXCEPTION_ON_FAILURE);
     }
 
     /**
@@ -276,7 +277,7 @@ public class SimpleNetworkWrapper {
     {
         channels.get(Side.SERVER).attr(FMLOutboundHandler.FML_MESSAGETARGET).set(FMLOutboundHandler.OutboundTarget.TRACKING_POINT);
         channels.get(Side.SERVER).attr(FMLOutboundHandler.FML_MESSAGETARGETARGS).set(point);
-        channels.get(Side.SERVER).writeAndFlush(message).addListener(ChannelFutureListener.FIRE_EXCEPTION_ON_FAILURE);
+        NetworkChannelHelper.writeAndFlush(channels.get(Side.SERVER), message).addListener(ChannelFutureListener.FIRE_EXCEPTION_ON_FAILURE);
     }
 
     /**
@@ -292,7 +293,7 @@ public class SimpleNetworkWrapper {
     {
         channels.get(Side.SERVER).attr(FMLOutboundHandler.FML_MESSAGETARGET).set(FMLOutboundHandler.OutboundTarget.TRACKING_ENTITY);
         channels.get(Side.SERVER).attr(FMLOutboundHandler.FML_MESSAGETARGETARGS).set(entity);
-        channels.get(Side.SERVER).writeAndFlush(message).addListener(ChannelFutureListener.FIRE_EXCEPTION_ON_FAILURE);
+        NetworkChannelHelper.writeAndFlush(channels.get(Side.SERVER), message).addListener(ChannelFutureListener.FIRE_EXCEPTION_ON_FAILURE);
     }
 
     /**
@@ -306,7 +307,7 @@ public class SimpleNetworkWrapper {
     {
         channels.get(Side.SERVER).attr(FMLOutboundHandler.FML_MESSAGETARGET).set(FMLOutboundHandler.OutboundTarget.DIMENSION);
         channels.get(Side.SERVER).attr(FMLOutboundHandler.FML_MESSAGETARGETARGS).set(dimensionId);
-        channels.get(Side.SERVER).writeAndFlush(message).addListener(ChannelFutureListener.FIRE_EXCEPTION_ON_FAILURE);
+        NetworkChannelHelper.writeAndFlush(channels.get(Side.SERVER), message).addListener(ChannelFutureListener.FIRE_EXCEPTION_ON_FAILURE);
     }
 
     /**
@@ -318,6 +319,6 @@ public class SimpleNetworkWrapper {
     public void sendToServer(IMessage message)
     {
         channels.get(Side.CLIENT).attr(FMLOutboundHandler.FML_MESSAGETARGET).set(FMLOutboundHandler.OutboundTarget.TOSERVER);
-        channels.get(Side.CLIENT).writeAndFlush(message).addListener(ChannelFutureListener.FIRE_EXCEPTION_ON_FAILURE);
+        NetworkChannelHelper.writeAndFlush(channels.get(Side.CLIENT), message).addListener(ChannelFutureListener.FIRE_EXCEPTION_ON_FAILURE);
     }
 }


### PR DESCRIPTION
As mentioned in #4564 after each packet the channel is flushed and thus, alot of tiny packets are send, because the TCP header is so large this increases network usage a lot. This PR attempts to reduce the flush calls and instead flush after each tick, which is done by vanilla itself.

This has not been tested on many systems so to find any issue help is recommended. 

Statistics will follow.

Also I have never made large patches, so please tell me if something is made wrong.