### PR TITLE
Remove synthetic lambda methods only in method body of SideOnly methods

### DIFF
--- a/src/main/java/net/minecraftforge/fml/common/asm/transformers/SideTransformer.java
+++ b/src/main/java/net/minecraftforge/fml/common/asm/transformers/SideTransformer.java
@@ -92,7 +92,7 @@ public class SideTransformer implements IClassTransformer
             }
         }
 
-        // remove dynamic lambda methods that are inside of removed methods
+        // remove dynamic synthetic lambda methods that are inside of removed methods
         List<Handle> dynamicLambdaHandles = lambdaGatherer.getDynamicLambdaHandles();
         if (!dynamicLambdaHandles.isEmpty())
         {
@@ -100,6 +100,7 @@ public class SideTransformer implements IClassTransformer
             while (methods.hasNext())
             {
                 MethodNode method = methods.next();
+                if ((method.access & Opcodes.ACC_SYNTHETIC) == 0) continue;
                 for (Handle dynamicLambdaHandle : dynamicLambdaHandles)
                 {
                     if (method.name.equals(dynamicLambdaHandle.getName()) && method.desc.equals(dynamicLambdaHandle.getDesc()))

--- a/src/main/java/net/minecraftforge/fml/common/asm/transformers/SideTransformer.java
+++ b/src/main/java/net/minecraftforge/fml/common/asm/transformers/SideTransformer.java
@@ -93,9 +93,10 @@ public class SideTransformer implements IClassTransformer
         }
 
         // remove dynamic synthetic lambda methods that are inside of removed methods
-        List<Handle> dynamicLambdaHandles = lambdaGatherer.getDynamicLambdaHandles();
-        if (!dynamicLambdaHandles.isEmpty())
+        for (List<Handle> dynamicLambdaHandles = lambdaGatherer.getDynamicLambdaHandles();
+             !dynamicLambdaHandles.isEmpty(); dynamicLambdaHandles = lambdaGatherer.getDynamicLambdaHandles())
         {
+            lambdaGatherer = new LambdaGatherer();
             methods = classNode.methods.iterator();
             while (methods.hasNext())
             {
@@ -110,6 +111,7 @@ public class SideTransformer implements IClassTransformer
                             System.out.println(String.format("Removing Method: %s.%s%s", classNode.name, method.name, method.desc));
                         }
                         methods.remove();
+                        lambdaGatherer.accept(method);
                     }
                 }
             }


### PR DESCRIPTION
The corresponding methods referred by `invokedynamic` in a method marked `@SideOnly` will be removed in the current implementation for SideOnly lambdas, and it means that even those methods written by modders themselves will also be removed.

Here is an example of referring a method declared by hand in a SideOnly method: [SideOnlyLambda.java](https://gist.github.com/ustc-zzzz/0ea3d29ff29b21fc2ed4811b58df173f). A `java.lang.NoSuchMethodError` will be thrown while the mod is being initialized.

The root of the problem is that only synthetic lambda methods generated by compilers should be removed. The methods that should be removed needs to satisfy two conditions:

* It is a synthetic method (which could be known by access modifier).
* It is referred by `invokedynamic` in a method marked `@SideOnly` of wrong side.

This is exactly what this pull request does.