### PR TITLE
Add logging for data manager key registration

### DIFF
--- a/patches/minecraft/net/minecraft/network/datasync/EntityDataManager.java.patch
+++ b/patches/minecraft/net/minecraft/network/datasync/EntityDataManager.java.patch
@@ -1,0 +1,21 @@
+--- ../src-base/minecraft/net/minecraft/network/datasync/EntityDataManager.java
++++ ../src-work/minecraft/net/minecraft/network/datasync/EntityDataManager.java
+@@ -38,7 +38,7 @@
+ 
+     public static <T> DataParameter<T> func_187226_a(Class <? extends Entity > p_187226_0_, DataSerializer<T> p_187226_1_)
+     {
+-        if (field_190303_a.isDebugEnabled())
++        if (true || field_190303_a.isDebugEnabled()) //Forge: This is very useful for mods that register keys on classes that are not their own
+         {
+             try
+             {
+@@ -46,7 +46,8 @@
+ 
+                 if (!oclass.equals(p_187226_0_))
+                 {
+-                    field_190303_a.debug("defineId called for: {} from {}", p_187226_0_, oclass, new RuntimeException());
++                    field_190303_a.warn("defineId called for: {} from {}", p_187226_0_, oclass); //Forge: log at warn, mods should not add to classes that they don't own
++                    field_190303_a.debug("Calling stacktrace: ", new RuntimeException()); //Forge: move stacktrace to debug, not needed at warn
+                 }
+             }
+             catch (ClassNotFoundException var5)

--- a/patches/minecraft/net/minecraft/network/datasync/EntityDataManager.java.patch
+++ b/patches/minecraft/net/minecraft/network/datasync/EntityDataManager.java.patch
@@ -15,7 +15,7 @@
                  {
 -                    field_190303_a.debug("defineId called for: {} from {}", p_187226_0_, oclass, new RuntimeException());
 +                    field_190303_a.warn("defineId called for: {} from {}", p_187226_0_, oclass); //Forge: log at warn, mods should not add to classes that they don't own
-+                    field_190303_a.debug("Calling stacktrace: ", new RuntimeException()); //Forge: move stacktrace to debug, not needed at warn
++                    if (field_190303_a.isDebugEnabled()) field_190303_a.debug("Calling stacktrace: ", new RuntimeException()); //Forge: move stacktrace to debug, not needed at warn
                  }
              }
              catch (ClassNotFoundException var5)

--- a/patches/minecraft/net/minecraft/network/datasync/EntityDataManager.java.patch
+++ b/patches/minecraft/net/minecraft/network/datasync/EntityDataManager.java.patch
@@ -9,13 +9,15 @@
          {
              try
              {
-@@ -46,7 +46,8 @@
+@@ -46,7 +46,10 @@
  
                  if (!oclass.equals(p_187226_0_))
                  {
 -                    field_190303_a.debug("defineId called for: {} from {}", p_187226_0_, oclass, new RuntimeException());
-+                    field_190303_a.warn("defineId called for: {} from {}", p_187226_0_, oclass); //Forge: log at warn, mods should not add to classes that they don't own
-+                    if (field_190303_a.isDebugEnabled()) field_190303_a.debug("Calling stacktrace: ", new RuntimeException()); //Forge: move stacktrace to debug, not needed at warn
++                    //Forge: log at warn, mods should not add to classes that they don't own
++                    if (!field_190303_a.isDebugEnabled()) field_190303_a.warn("defineId called for: {} from {}", p_187226_0_, oclass, new RuntimeException());
++                    else //Forge: only log stacktrace with debug enabled, normally not needed
++                    field_190303_a.warn("defineId called for: {} from {}", p_187226_0_, oclass);
                  }
              }
              catch (ClassNotFoundException var5)

--- a/patches/minecraft/net/minecraft/network/datasync/EntityDataManager.java.patch
+++ b/patches/minecraft/net/minecraft/network/datasync/EntityDataManager.java.patch
@@ -9,15 +9,14 @@
          {
              try
              {
-@@ -46,7 +46,10 @@
+@@ -46,7 +46,9 @@
  
                  if (!oclass.equals(p_187226_0_))
                  {
 -                    field_190303_a.debug("defineId called for: {} from {}", p_187226_0_, oclass, new RuntimeException());
-+                    //Forge: log at warn, mods should not add to classes that they don't own
-+                    if (!field_190303_a.isDebugEnabled()) field_190303_a.warn("defineId called for: {} from {}", p_187226_0_, oclass, new RuntimeException());
-+                    else //Forge: only log stacktrace with debug enabled, normally not needed
-+                    field_190303_a.warn("defineId called for: {} from {}", p_187226_0_, oclass);
++                    //Forge: log at warn, mods should not add to classes that they don't own, and only add stacktrace when in debug is enabled as it is mostly not needed and consumes time
++                    if (field_190303_a.isDebugEnabled()) field_190303_a.warn("defineId called for: {} from {}", p_187226_0_, oclass, new RuntimeException());
++                    else field_190303_a.warn("defineId called for: {} from {}", p_187226_0_, oclass);
                  }
              }
              catch (ClassNotFoundException var5)


### PR DESCRIPTION
Some mods add entries to the datamanager of entities that are owned by minecraft or other mods. Because the EntityDataManager keeps track of a static ID, if things are registered in the wrong order, there is a client/server mismatch in the IDs, and it causes a ClassCastException that is hard to track down. These log entries should help to track down these errors