### PR TITLE
Porting capability patches (and everything else that comes with them)

### DIFF
--- a/patches/minecraft/net/minecraft/client/multiplayer/WorldClient.java.patch
+++ b/patches/minecraft/net/minecraft/client/multiplayer/WorldClient.java.patch
@@ -1,0 +1,10 @@
+--- a/net/minecraft/client/multiplayer/WorldClient.java
++++ b/net/minecraft/client/multiplayer/WorldClient.java
+@@ -81,6 +81,7 @@
+       this.mapStorage = new SaveDataMemoryStorage();
+       this.calculateInitialSkylight();
+       this.calculateInitialWeather();
++      this.initCapabilities();
+    }
+ 
+    public void tick() {

--- a/patches/minecraft/net/minecraft/client/renderer/BufferBuilder.java.patch
+++ b/patches/minecraft/net/minecraft/client/renderer/BufferBuilder.java.patch
@@ -46,7 +46,7 @@
  }
 +   
 +   public boolean isColorDisabled() {
-+	   return noColor;
++       return noColor;
 +   }
 +   
 +   public void putBulkData(ByteBuffer buffer) {

--- a/patches/minecraft/net/minecraft/client/renderer/block/model/IBakedModel.java.patch
+++ b/patches/minecraft/net/minecraft/client/renderer/block/model/IBakedModel.java.patch
@@ -17,6 +17,6 @@
 +    * that should be applied to the GL state before rendering it (matrix may be null).
 +    */
 +   default org.apache.commons.lang3.tuple.Pair<? extends IBakedModel, javax.vecmath.Matrix4f> handlePerspective(ItemCameraTransforms.TransformType cameraTransformType) {
-+	   return net.minecraftforge.client.ForgeHooksClient.handlePerspective(this, cameraTransformType);
++       return net.minecraftforge.client.ForgeHooksClient.handlePerspective(this, cameraTransformType);
  }
 +}

--- a/patches/minecraft/net/minecraft/client/renderer/block/model/ModelBlock.java.patch
+++ b/patches/minecraft/net/minecraft/client/renderer/block/model/ModelBlock.java.patch
@@ -73,7 +73,7 @@
  
     private static BakedQuad func_209567_a(BlockPart p_209567_0_, BlockPartFace p_209567_1_, TextureAtlasSprite p_209567_2_, EnumFacing p_209567_3_, ModelRotation p_209567_4_, boolean p_209567_5_) {
 -      return field_209572_h.func_199332_a(p_209567_0_.positionFrom, p_209567_0_.positionTo, p_209567_1_, p_209567_2_, p_209567_3_, p_209567_4_, p_209567_0_.partRotation, p_209567_5_, p_209567_0_.shade);
-+	  return makeBakedQuad(p_209567_0_, p_209567_1_, p_209567_2_, p_209567_3_, (net.minecraftforge.common.model.IModelState) p_209567_4_, p_209567_5_);
++      return makeBakedQuad(p_209567_0_, p_209567_1_, p_209567_2_, p_209567_3_, (net.minecraftforge.common.model.IModelState) p_209567_4_, p_209567_5_);
     }
  
 +   public static BakedQuad makeBakedQuad(BlockPart p_209567_0_, BlockPartFace p_209567_1_, TextureAtlasSprite p_209567_2_, EnumFacing p_209567_3_, net.minecraftforge.common.model.IModelState p_209567_4_, boolean p_209567_5_) {

--- a/patches/minecraft/net/minecraft/client/renderer/texture/TextureAtlasSprite.java.patch
+++ b/patches/minecraft/net/minecraft/client/renderer/texture/TextureAtlasSprite.java.patch
@@ -8,6 +8,6 @@
 +   // Forge Start
 +   
 +   public int getPixelRGBA(int frameIndex, int x, int y) {
-+   	return this.field_195670_c[frameIndex].func_195709_a(x + this.field_195671_d[frameIndex] * this.width, y + this.field_195672_e[frameIndex] * this.height);
++       return this.field_195670_c[frameIndex].func_195709_a(x + this.field_195671_d[frameIndex] * this.width, y + this.field_195672_e[frameIndex] * this.height);
  }
 +}

--- a/patches/minecraft/net/minecraft/client/renderer/vertex/VertexFormatElement.java.patch
+++ b/patches/minecraft/net/minecraft/client/renderer/vertex/VertexFormatElement.java.patch
@@ -1,0 +1,21 @@
+--- a/net/minecraft/client/renderer/vertex/VertexFormatElement.java
++++ b/net/minecraft/client/renderer/vertex/VertexFormatElement.java
+@@ -124,10 +124,17 @@
+       NORMAL("Normal"),
+       COLOR("Vertex Color"),
+       UV("UV"),
++      // As of 1.8.8 - unused in vanilla; use GENERIC for now
++      @Deprecated
+       MATRIX("Bone Matrix"),
++      @Deprecated
+       BLEND_WEIGHT("Blend Weight"),
+-      PADDING("Padding");
++      PADDING("Padding"),
++      GENERIC("Generic");
+ 
++      public void preDraw(VertexFormat format, int element, int stride, java.nio.ByteBuffer buffer) { net.minecraftforge.client.ForgeHooksClient.preDraw(this, format, element, stride, buffer); }
++      public void postDraw(VertexFormat format, int element, int stride, java.nio.ByteBuffer buffer) { net.minecraftforge.client.ForgeHooksClient.postDraw(this, format, element, stride, buffer); }
++
+       private final String displayName;
+ 
+       private EnumUsage(String displayNameIn) {

--- a/patches/minecraft/net/minecraft/client/resources/Language.java.patch
+++ b/patches/minecraft/net/minecraft/client/resources/Language.java.patch
@@ -1,0 +1,25 @@
+--- a/net/minecraft/client/resources/Language.java
++++ b/net/minecraft/client/resources/Language.java
+@@ -15,7 +15,13 @@
+       this.region = regionIn;
+       this.name = nameIn;
+       this.bidirectional = bidirectionalIn;
++      String[] splitLangCode = name.split("_", 2);
++      if (splitLangCode.length == 1) { // Vanilla has some languages without underscores
++    	  this.javaLocale = new java.util.Locale(languageCode);
++      } else {
++    	  this.javaLocale = new java.util.Locale(splitLangCode[0], splitLangCode[1]);
+    }
++   }
+ 
+    public String getLanguageCode() {
+       return this.languageCode;
+@@ -44,4 +50,8 @@
+    public int compareTo(Language p_compareTo_1_) {
+       return this.languageCode.compareTo(p_compareTo_1_.languageCode);
+    }
++   
++   // Forge: add access to Locale so modders can create correct string and number formatters
++   private final java.util.Locale javaLocale;
++   public java.util.Locale getJavaLocale() { return javaLocale; }
+ }

--- a/patches/minecraft/net/minecraft/client/resources/Language.java.patch
+++ b/patches/minecraft/net/minecraft/client/resources/Language.java.patch
@@ -6,9 +6,9 @@
        this.bidirectional = bidirectionalIn;
 +      String[] splitLangCode = name.split("_", 2);
 +      if (splitLangCode.length == 1) { // Vanilla has some languages without underscores
-+    	  this.javaLocale = new java.util.Locale(languageCode);
++          this.javaLocale = new java.util.Locale(languageCode);
 +      } else {
-+    	  this.javaLocale = new java.util.Locale(splitLangCode[0], splitLangCode[1]);
++          this.javaLocale = new java.util.Locale(splitLangCode[0], splitLangCode[1]);
     }
 +   }
  

--- a/patches/minecraft/net/minecraft/entity/Entity.java.patch
+++ b/patches/minecraft/net/minecraft/entity/Entity.java.patch
@@ -1,0 +1,55 @@
+--- a/net/minecraft/entity/Entity.java
++++ b/net/minecraft/entity/Entity.java
+@@ -12,6 +12,8 @@
+ import java.util.Random;
+ import java.util.Set;
+ import java.util.UUID;
++
++import javax.annotation.Nonnull;
+ import javax.annotation.Nullable;
+ import net.minecraft.advancements.CriteriaTriggers;
+ import net.minecraft.block.Block;
+@@ -97,7 +99,7 @@
+ import org.apache.logging.log4j.LogManager;
+ import org.apache.logging.log4j.Logger;
+ 
+-public abstract class Entity implements INameable, ICommandSource {
++public abstract class Entity implements INameable, ICommandSource, net.minecraftforge.common.extensions.IForgeEntity {
+    protected static final Logger LOGGER = LogManager.getLogger();
+    private static final List<ItemStack> EMPTY_EQUIPMENT = Collections.<ItemStack>emptyList();
+    private static final AxisAlignedBB ZERO_AABB = new AxisAlignedBB(0.0D, 0.0D, 0.0D, 0.0D, 0.0D, 0.0D);
+@@ -190,6 +192,11 @@
+    private boolean isPositionDirty;
+    private final double[] pistonDeltas;
+    private long pistonDeltasGameTime;
++   /**
++    * Setting this to true will prevent the world from calling {@link #onUpdate()} for this entity.
++    */
++   public boolean updateBlocked;
++   private net.minecraftforge.common.capabilities.CapabilityDispatcher capabilities;
+ 
+    public Entity(EntityType<?> p_i48580_1_, World p_i48580_2_) {
+       this.entityId = nextEntityID++;
+@@ -221,6 +228,8 @@
+       this.dataManager.register(SILENT, false);
+       this.dataManager.register(NO_GRAVITY, false);
+       this.entityInit();
++      net.minecraftforge.common.MinecraftForge.EVENT_BUS.post(new net.minecraftforge.event.entity.EntityEvent.EntityConstructing(this));
++      capabilities = net.minecraftforge.event.ForgeEventFactory.gatherCapabilities(this);
+    }
+ 
+    public EntityType<?> func_200600_R() {
+@@ -2591,4 +2600,13 @@
+    public double func_212107_bY() {
+       return this.field_211517_W;
+    }
++   
++   /* ================================== Forge Start =====================================*/
++
++   @Override
++   @Nonnull
++   public <T> net.minecraftforge.common.capabilities.OptionalCapabilityInstance<T> getCapability(net.minecraftforge.common.capabilities.Capability<T> capability, @Nullable net.minecraft.util.EnumFacing facing)
++   {
++       return capabilities == null ? net.minecraftforge.common.capabilities.OptionalCapabilityInstance.empty() : capabilities.getCapability(capability, facing);
+ }
++}

--- a/patches/minecraft/net/minecraft/entity/Entity.java.patch
+++ b/patches/minecraft/net/minecraft/entity/Entity.java.patch
@@ -1,15 +1,14 @@
 --- a/net/minecraft/entity/Entity.java
 +++ b/net/minecraft/entity/Entity.java
-@@ -12,6 +12,8 @@
+@@ -12,6 +12,7 @@
  import java.util.Random;
  import java.util.Set;
  import java.util.UUID;
 +
-+import javax.annotation.Nonnull;
  import javax.annotation.Nullable;
  import net.minecraft.advancements.CriteriaTriggers;
  import net.minecraft.block.Block;
-@@ -97,7 +99,7 @@
+@@ -97,7 +98,7 @@
  import org.apache.logging.log4j.LogManager;
  import org.apache.logging.log4j.Logger;
  
@@ -18,19 +17,7 @@
     protected static final Logger LOGGER = LogManager.getLogger();
     private static final List<ItemStack> EMPTY_EQUIPMENT = Collections.<ItemStack>emptyList();
     private static final AxisAlignedBB ZERO_AABB = new AxisAlignedBB(0.0D, 0.0D, 0.0D, 0.0D, 0.0D, 0.0D);
-@@ -190,6 +192,11 @@
-    private boolean isPositionDirty;
-    private final double[] pistonDeltas;
-    private long pistonDeltasGameTime;
-+   /**
-+    * Setting this to true will prevent the world from calling {@link #onUpdate()} for this entity.
-+    */
-+   public boolean updateBlocked;
-+   private net.minecraftforge.common.capabilities.CapabilityDispatcher capabilities;
- 
-    public Entity(EntityType<?> p_i48580_1_, World p_i48580_2_) {
-       this.entityId = nextEntityID++;
-@@ -221,6 +228,8 @@
+@@ -221,6 +222,8 @@
        this.dataManager.register(SILENT, false);
        this.dataManager.register(NO_GRAVITY, false);
        this.entityInit();
@@ -39,15 +26,17 @@
     }
  
     public EntityType<?> func_200600_R() {
-@@ -2591,4 +2600,13 @@
+@@ -2591,4 +2594,15 @@
     public double func_212107_bY() {
        return this.field_211517_W;
     }
 +   
 +   /* ================================== Forge Start =====================================*/
 +
++   private net.minecraftforge.common.capabilities.CapabilityDispatcher capabilities;
++
 +   @Override
-+   @Nonnull
++   @javax.annotation.Nonnull
 +   public <T> net.minecraftforge.common.capabilities.OptionalCapabilityInstance<T> getCapability(net.minecraftforge.common.capabilities.Capability<T> capability, @Nullable net.minecraft.util.EnumFacing facing)
 +   {
 +       return capabilities == null ? net.minecraftforge.common.capabilities.OptionalCapabilityInstance.empty() : capabilities.getCapability(capability, facing);

--- a/patches/minecraft/net/minecraft/entity/Entity.java.patch
+++ b/patches/minecraft/net/minecraft/entity/Entity.java.patch
@@ -26,7 +26,7 @@
     }
  
     public EntityType<?> func_200600_R() {
-@@ -2591,4 +2594,15 @@
+@@ -2591,4 +2594,14 @@
     public double func_212107_bY() {
        return this.field_211517_W;
     }
@@ -36,7 +36,6 @@
 +   private net.minecraftforge.common.capabilities.CapabilityDispatcher capabilities;
 +
 +   @Override
-+   @javax.annotation.Nonnull
 +   public <T> net.minecraftforge.common.capabilities.OptionalCapabilityInstance<T> getCapability(net.minecraftforge.common.capabilities.Capability<T> capability, @Nullable net.minecraft.util.EnumFacing facing)
 +   {
 +       return capabilities == null ? net.minecraftforge.common.capabilities.OptionalCapabilityInstance.empty() : capabilities.getCapability(capability, facing);

--- a/patches/minecraft/net/minecraft/entity/Entity.java.patch
+++ b/patches/minecraft/net/minecraft/entity/Entity.java.patch
@@ -13,7 +13,7 @@
  import org.apache.logging.log4j.Logger;
  
 -public abstract class Entity implements INameable, ICommandSource {
-+public abstract class Entity implements INameable, ICommandSource, net.minecraftforge.common.extensions.IForgeEntity {
++public abstract class Entity extends net.minecraftforge.common.capabilities.CapabilityProvider implements INameable, ICommandSource, net.minecraftforge.common.extensions.IForgeEntity {
     protected static final Logger LOGGER = LogManager.getLogger();
     private static final List<ItemStack> EMPTY_EQUIPMENT = Collections.<ItemStack>emptyList();
     private static final AxisAlignedBB ZERO_AABB = new AxisAlignedBB(0.0D, 0.0D, 0.0D, 0.0D, 0.0D, 0.0D);
@@ -22,22 +22,7 @@
        this.dataManager.register(NO_GRAVITY, false);
        this.entityInit();
 +      net.minecraftforge.common.MinecraftForge.EVENT_BUS.post(new net.minecraftforge.event.entity.EntityEvent.EntityConstructing(this));
-+      capabilities = net.minecraftforge.event.ForgeEventFactory.gatherCapabilities(this);
++      this.gatherCapabilities();
     }
  
     public EntityType<?> func_200600_R() {
-@@ -2591,4 +2594,14 @@
-    public double func_212107_bY() {
-       return this.field_211517_W;
-    }
-+   
-+   /* ================================== Forge Start =====================================*/
-+
-+   private net.minecraftforge.common.capabilities.CapabilityDispatcher capabilities;
-+
-+   @Override
-+   public <T> net.minecraftforge.common.capabilities.OptionalCapabilityInstance<T> getCapability(net.minecraftforge.common.capabilities.Capability<T> capability, @Nullable net.minecraft.util.EnumFacing facing)
-+   {
-+       return capabilities == null ? net.minecraftforge.common.capabilities.OptionalCapabilityInstance.empty() : capabilities.getCapability(capability, facing);
- }
-+}

--- a/patches/minecraft/net/minecraft/item/Item.java.patch
+++ b/patches/minecraft/net/minecraft/item/Item.java.patch
@@ -13,7 +13,15 @@
     private static final IItemPropertyGetter DAMAGED_GETTER = (p_210306_0_, p_210306_1_, p_210306_2_) -> {
        return p_210306_0_.isItemDamaged() ? 1.0F : 0.0F;
     };
-@@ -149,10 +149,12 @@
+@@ -126,6 +126,7 @@
+       this.containerItem = p_i48487_1_.field_200922_c;
+       this.maxDamage = p_i48487_1_.field_200921_b;
+       this.maxStackSize = p_i48487_1_.field_200920_a;
++      this.canRepair = p_i48487_1_.canRepair;
+       if (this.maxDamage > 0) {
+          this.addPropertyOverride(new ResourceLocation("damaged"), DAMAGED_GETTER);
+          this.addPropertyOverride(new ResourceLocation("damage"), DAMAGE_GETTER);
+@@ -149,10 +150,12 @@
        return stack;
     }
  
@@ -26,7 +34,7 @@
     public final int getMaxDamage() {
        return this.maxDamage;
     }
-@@ -207,6 +209,7 @@
+@@ -207,6 +210,7 @@
        return this.containerItem;
     }
  
@@ -34,7 +42,7 @@
     public boolean hasContainerItem() {
        return this.containerItem != null;
     }
-@@ -263,7 +266,7 @@
+@@ -263,7 +267,7 @@
     }
  
     public boolean isEnchantable(ItemStack stack) {
@@ -43,7 +51,7 @@
     }
  
     @Nullable
-@@ -280,8 +283,8 @@
+@@ -280,8 +284,8 @@
        float f5 = MathHelper.sin(-f * ((float)Math.PI / 180F));
        float f6 = f3 * f4;
        float f7 = f2 * f4;
@@ -54,7 +62,7 @@
        return worldIn.func_200259_a(vec3d, vec3d1, useLiquids ? RayTraceFluidMode.SOURCE_ONLY : RayTraceFluidMode.NEVER, false, false);
     }
  
-@@ -297,6 +300,7 @@
+@@ -297,6 +301,7 @@
     }
  
     protected boolean isInCreativeTab(ItemGroup targetTab) {
@@ -62,7 +70,7 @@
        ItemGroup itemgroup = this.getCreativeTab();
        return itemgroup != null && (targetTab == ItemGroup.SEARCH || targetTab == itemgroup);
     }
-@@ -310,10 +314,72 @@
+@@ -310,10 +315,65 @@
        return false;
     }
  
@@ -79,7 +87,7 @@
 +   
 +   private java.util.Map<String, Integer> toolClasses = new java.util.HashMap<String, Integer>();
 +
-+   protected boolean canRepair = true;
++   protected final boolean canRepair;
 +
 +   @Override
 +   public boolean isRepairable()
@@ -87,13 +95,6 @@
 +       return canRepair && isDamageable();
 +   }
 +
-+   @Override
-+   public Item setNoRepair()
-+   {
-+       canRepair = false;
-+       return this;
-+   }
-+   
 +   @Override
 +   public void setHarvestLevel(String toolClass, int level)
 +   {
@@ -135,3 +136,22 @@
     public static void registerItems() {
        registerItemBlock(Blocks.AIR, new ItemAir(Blocks.AIR, new Item.Builder()));
        func_200879_a(Blocks.STONE, ItemGroup.BUILDING_BLOCKS);
+@@ -1147,6 +1207,7 @@
+       private Item field_200922_c;
+       private ItemGroup field_200923_d;
+       private EnumRarity field_208104_e = EnumRarity.COMMON;
++      private boolean canRepair = true;
+ 
+       public Item.Builder func_200917_a(int p_200917_1_) {
+          if (this.field_200921_b > 0) {
+@@ -1181,5 +1242,10 @@
+          this.field_208104_e = p_208103_1_;
+          return this;
+       }
++      
++      public Item.Builder setNoRepair() {
++          canRepair = false;
++          return this;
+    }
+ }
++}

--- a/patches/minecraft/net/minecraft/item/Item.java.patch
+++ b/patches/minecraft/net/minecraft/item/Item.java.patch
@@ -13,17 +13,18 @@
     private static final IItemPropertyGetter DAMAGED_GETTER = (p_210306_0_, p_210306_1_, p_210306_2_) -> {
        return p_210306_0_.isItemDamaged() ? 1.0F : 0.0F;
     };
-@@ -126,6 +126,9 @@
+@@ -126,6 +126,10 @@
        this.containerItem = p_i48487_1_.field_200922_c;
        this.maxDamage = p_i48487_1_.field_200921_b;
        this.maxStackSize = p_i48487_1_.field_200920_a;
 +      this.canRepair = p_i48487_1_.canRepair;
 +      this.toolClasses.putAll(p_i48487_1_.toolClasses);
-+      this.teisr = net.minecraftforge.fml.DistExecutor.callWhenOn(Dist.CLIENT, p_i48487_1_.teisr);
++      Object tmp = net.minecraftforge.fml.DistExecutor.callWhenOn(Dist.CLIENT, p_i48487_1_.teisr);
++      this.teisr = tmp == null ? null : () -> (net.minecraft.client.renderer.tileentity.TileEntityItemStackRenderer) tmp;
        if (this.maxDamage > 0) {
           this.addPropertyOverride(new ResourceLocation("damaged"), DAMAGED_GETTER);
           this.addPropertyOverride(new ResourceLocation("damage"), DAMAGE_GETTER);
-@@ -149,10 +152,12 @@
+@@ -149,10 +153,12 @@
        return stack;
     }
  
@@ -36,7 +37,7 @@
     public final int getMaxDamage() {
        return this.maxDamage;
     }
-@@ -207,6 +212,7 @@
+@@ -207,6 +213,7 @@
        return this.containerItem;
     }
  
@@ -44,7 +45,7 @@
     public boolean hasContainerItem() {
        return this.containerItem != null;
     }
-@@ -263,7 +269,7 @@
+@@ -263,7 +270,7 @@
     }
  
     public boolean isEnchantable(ItemStack stack) {
@@ -53,7 +54,7 @@
     }
  
     @Nullable
-@@ -280,8 +286,8 @@
+@@ -280,8 +287,8 @@
        float f5 = MathHelper.sin(-f * ((float)Math.PI / 180F));
        float f6 = f3 * f4;
        float f7 = f2 * f4;
@@ -64,7 +65,7 @@
        return worldIn.func_200259_a(vec3d, vec3d1, useLiquids ? RayTraceFluidMode.SOURCE_ONLY : RayTraceFluidMode.NEVER, false, false);
     }
  
-@@ -297,6 +303,7 @@
+@@ -297,6 +304,7 @@
     }
  
     protected boolean isInCreativeTab(ItemGroup targetTab) {
@@ -72,7 +73,7 @@
        ItemGroup itemgroup = this.getCreativeTab();
        return itemgroup != null && (targetTab == ItemGroup.SEARCH || targetTab == itemgroup);
     }
-@@ -310,10 +317,49 @@
+@@ -310,10 +318,49 @@
        return false;
     }
  
@@ -83,9 +84,8 @@
  
 +   /* ======================================== FORGE START =====================================*/
 +
-+   @OnlyIn(Dist.CLIENT)
 +   @Nullable
-+   private final net.minecraft.client.renderer.tileentity.TileEntityItemStackRenderer teisr;
++   private final java.util.function.Supplier<net.minecraft.client.renderer.tileentity.TileEntityItemStackRenderer> teisr;
 +   
 +   private final java.util.Map<String, Integer> toolClasses = new java.util.HashMap<String, Integer>();
 +
@@ -114,7 +114,8 @@
 +   @Override
 +   public final net.minecraft.client.renderer.tileentity.TileEntityItemStackRenderer getTileEntityItemStackRenderer()
 +   {
-+       return teisr != null ? teisr : net.minecraft.client.renderer.tileentity.TileEntityItemStackRenderer.instance;
++       net.minecraft.client.renderer.tileentity.TileEntityItemStackRenderer renderer = teisr != null ? teisr.get() : null;
++       return renderer != null ? renderer : net.minecraft.client.renderer.tileentity.TileEntityItemStackRenderer.instance;
 +   }
 +
 +   /* ======================================== FORGE END   =====================================*/
@@ -122,7 +123,7 @@
     public static void registerItems() {
        registerItemBlock(Blocks.AIR, new ItemAir(Blocks.AIR, new Item.Builder()));
        func_200879_a(Blocks.STONE, ItemGroup.BUILDING_BLOCKS);
-@@ -1147,6 +1193,9 @@
+@@ -1147,6 +1194,9 @@
        private Item field_200922_c;
        private ItemGroup field_200923_d;
        private EnumRarity field_208104_e = EnumRarity.COMMON;
@@ -132,7 +133,7 @@
  
        public Item.Builder func_200917_a(int p_200917_1_) {
           if (this.field_200921_b > 0) {
-@@ -1181,5 +1230,27 @@
+@@ -1181,5 +1231,27 @@
           this.field_208104_e = p_208103_1_;
           return this;
        }

--- a/patches/minecraft/net/minecraft/item/Item.java.patch
+++ b/patches/minecraft/net/minecraft/item/Item.java.patch
@@ -7,7 +7,7 @@
 -public class Item implements IItemProvider {
 -   public static final RegistryNamespaced<ResourceLocation, Item> REGISTRY = new RegistryNamespaced<ResourceLocation, Item>();
 -   public static final Map<Block, Item> BLOCK_TO_ITEM = Maps.<Block, Item>newHashMap();
-+public class Item extends net.minecraftforge.registries.ForgeRegistryEntry<Item> implements IItemProvider {
++public class Item extends net.minecraftforge.registries.ForgeRegistryEntry<Item> implements IItemProvider, net.minecraftforge.common.extensions.IForgeItem {
 +   public static final RegistryNamespaced<ResourceLocation, Item> REGISTRY = net.minecraftforge.registries.GameData.getWrapper(Item.class);
 +   public static final Map<Block, Item> BLOCK_TO_ITEM = net.minecraftforge.registries.GameData.getBlockItemMap();
     private static final IItemPropertyGetter DAMAGED_GETTER = (p_210306_0_, p_210306_1_, p_210306_2_) -> {
@@ -17,12 +17,12 @@
        return stack;
     }
  
-+   @Deprecated // Use ItemStack sensitive version below.
++   @Deprecated // Use ItemStack sensitive version.
     public final int getItemStackLimit() {
        return this.maxStackSize;
     }
  
-+   @Deprecated // Use ItemStack sensitive version below.
++   @Deprecated // Use ItemStack sensitive version.
     public final int getMaxDamage() {
        return this.maxDamage;
     }
@@ -30,7 +30,7 @@
        return this.containerItem;
     }
  
-+   @Deprecated // Use ItemStack sensitive version below.
++   @Deprecated // Use ItemStack sensitive version.
     public boolean hasContainerItem() {
        return this.containerItem != null;
     }
@@ -39,7 +39,7 @@
  
     public boolean isEnchantable(ItemStack stack) {
 -      return this.getItemStackLimit() == 1 && this.isDamageable();
-+	  return this.getItemStackLimit(stack) == 1 && this.isDamageable();
++      return this.getItemStackLimit(stack) == 1 && this.isDamageable();
     }
  
     @Nullable
@@ -54,526 +54,47 @@
        return worldIn.func_200259_a(vec3d, vec3d1, useLiquids ? RayTraceFluidMode.SOURCE_ONLY : RayTraceFluidMode.NEVER, false, false);
     }
  
-@@ -297,6 +300,9 @@
+@@ -297,6 +300,7 @@
     }
  
     protected boolean isInCreativeTab(ItemGroup targetTab) {
-+	  for (ItemGroup tab : this.getCreativeTabs())
-+		  if (tab == targetTab)
-+			  return true;
++      if (getCreativeTabs().stream().anyMatch(tab -> tab == targetTab)) return true;
        ItemGroup itemgroup = this.getCreativeTab();
        return itemgroup != null && (targetTab == ItemGroup.SEARCH || targetTab == itemgroup);
     }
-@@ -310,10 +316,736 @@
+@@ -310,10 +314,72 @@
        return false;
     }
  
-+   @Deprecated // Use ItemStack sensitive version below.
++   @Deprecated // Use ItemStack sensitive version.
     public Multimap<String, AttributeModifier> getItemAttributeModifiers(EntityEquipmentSlot equipmentSlot) {
        return HashMultimap.<String, AttributeModifier>create();
     }
  
 +   /* ======================================== FORGE START =====================================*/
-+   /**
-+    * ItemStack sensitive version of getItemAttributeModifiers
-+    */
-+   public Multimap<String, AttributeModifier> getAttributeModifiers(EntityEquipmentSlot slot, ItemStack stack)
-+   {
-+       return this.getItemAttributeModifiers(slot);
-+   }
 +
-+   /**
-+    * Called when a player drops the item into the world,
-+    * returning false from this will prevent the item from
-+    * being removed from the players inventory and spawning
-+    * in the world
-+    *
-+    * @param player The player that dropped the item
-+    * @param item The item stack, before the item is removed.
-+    */
-+   public boolean onDroppedByPlayer(ItemStack item, EntityPlayer player)
-+   {
-+       return true;
-+   }
-+
-+   /**
-+    * Allow the item one last chance to modify its name used for the
-+    * tool highlight useful for adding something extra that can't be removed
-+    * by a user in the displayed name, such as a mode of operation.
-+    *
-+    * @param item the ItemStack for the item.
-+    * @param displayName the name that will be displayed unless it is changed in this method.
-+    */
-+   public String getHighlightTip( ItemStack item, String displayName )
-+   {
-+       return displayName;
-+   }
-+
-+   /**
-+    * This is called when the item is used, before the block is activated.
-+	*
-+    * @return Return PASS to allow vanilla handling, any other to skip normal code.
-+    */
-+   public EnumActionResult onItemUseFirst(ItemUseContext context)
-+   {
-+       return EnumActionResult.PASS;
-+   }
++   @OnlyIn(Dist.CLIENT)
++   @Nullable
++   private net.minecraft.client.renderer.tileentity.TileEntityItemStackRenderer teisr;
++   
++   private java.util.Map<String, Integer> toolClasses = new java.util.HashMap<String, Integer>();
 +
 +   protected boolean canRepair = true;
-+   /**
-+    * Called by CraftingManager to determine if an item is reparable.
-+    * @return True if reparable
-+    */
++
++   @Override
 +   public boolean isRepairable()
 +   {
 +       return canRepair && isDamageable();
 +   }
 +
-+   /**
-+    * Call to disable repair recipes.
-+    * @return The current Item instance
-+    */
++   @Override
 +   public Item setNoRepair()
 +   {
 +       canRepair = false;
 +       return this;
 +   }
-+
-+   /**
-+    * Override this method to change the NBT data being sent to the client.
-+    * You should ONLY override this when you have no other choice, as this might change behavior client side!
-+    *
-+    * Note that this will sometimes be applied multiple times, the following MUST be supported:
-+    * Item item = stack.getItem();
-+    * NBTTagCompound nbtShare1 = item.getNBTShareTag(stack);
-+    * stack.setTagCompound(nbtShare1);
-+    * NBTTagCompound nbtShare2 = item.getNBTShareTag(stack);
-+    * assert nbtShare1.equals(nbtShare2);
-+    *
-+    * @param stack The stack to send the NBT tag for
-+    * @return The NBT tag
-+    */
-+   @Nullable
-+   public NBTTagCompound getNBTShareTag(ItemStack stack)
-+   {
-+       return stack.getTagCompound();
-+   }
-+
-+   /**
-+    * Override this method to decide what to do with the NBT data received from getNBTShareTag().
-+    * 
-+    * @param stack The stack that received NBT
-+    * @param nbt Received NBT, can be null
-+    */
-+   public void readNBTShareTag(ItemStack stack, @Nullable NBTTagCompound nbt)
-+   {
-+       stack.setTagCompound(nbt);
-+   }
-+
-+   /**
-+    * Called before a block is broken.  Return true to prevent default block harvesting.
-+    *
-+    * Note: In SMP, this is called on both client and server sides!
-+    *
-+    * @param itemstack The current ItemStack
-+    * @param pos Block's position in world
-+    * @param player The Player that is wielding the item
-+    * @return True to prevent harvesting, false to continue as normal
-+    */
-+   public boolean onBlockStartBreak(ItemStack itemstack, BlockPos pos, EntityPlayer player)
-+   {
-+       return false;
-+   }
-+
-+   /**
-+    * Called each tick while using an item.
-+    * @param stack The Item being used
-+    * @param player The Player using the item
-+    * @param count The amount of time in tick the item has been used for continuously
-+    */
-+   public void onUsingTick(ItemStack stack, EntityLivingBase player, int count)
-+   {
-+   }
-+
-+   /**
-+    * Called when the player Left Clicks (attacks) an entity.
-+    * Processed before damage is done, if return value is true further processing is canceled
-+    * and the entity is not attacked.
-+    *
-+    * @param stack The Item being used
-+    * @param player The player that is attacking
-+    * @param entity The entity being attacked
-+    * @return True to cancel the rest of the interaction.
-+    */
-+   public boolean onLeftClickEntity(ItemStack stack, EntityPlayer player, Entity entity)
-+   {
-+       return false;
-+   }
-+
-+   /**
-+    * ItemStack sensitive version of getContainerItem.
-+    * Returns a full ItemStack instance of the result.
-+    *
-+    * @param itemStack The current ItemStack
-+    * @return The resulting ItemStack
-+    */
-+   public ItemStack getContainerItem(ItemStack itemStack)
-+   {
-+       if (!hasContainerItem(itemStack))
-+       {
-+           return ItemStack.EMPTY;
-+       }
-+       return new ItemStack(getContainerItem());
-+   }
-+
-+   /**
-+    * ItemStack sensitive version of hasContainerItem
-+    * @param stack The current item stack
-+    * @return True if this item has a 'container'
-+    */
-+   public boolean hasContainerItem(ItemStack stack)
-+   {
-+       return hasContainerItem();
-+   }
-+
-+   /**
-+    * Retrieves the normal 'lifespan' of this item when it is dropped on the ground as a EntityItem.
-+    * This is in ticks, standard result is 6000, or 5 mins.
-+    *
-+    * @param itemStack The current ItemStack
-+    * @param world The world the entity is in
-+    * @return The normal lifespan in ticks.
-+    */
-+   public int getEntityLifespan(ItemStack itemStack, World world)
-+   {
-+       return 6000;
-+   }
-+
-+   /**
-+    * Determines if this Item has a special entity for when they are in the world.
-+    * Is called when a EntityItem is spawned in the world, if true and Item#createCustomEntity
-+    * returns non null, the EntityItem will be destroyed and the new Entity will be added to the world.
-+    *
-+    * @param stack The current item stack
-+    * @return True of the item has a custom entity, If true, Item#createCustomEntity will be called
-+    */
-+   public boolean hasCustomEntity(ItemStack stack)
-+   {
-+       return false;
-+   }
-+
-+   /**
-+    * This function should return a new entity to replace the dropped item.
-+    * Returning null here will not kill the EntityItem and will leave it to function normally.
-+    * Called when the item it placed in a world.
-+    *
-+    * @param world The world object
-+    * @param location The EntityItem object, useful for getting the position of the entity
-+    * @param itemstack The current item stack
-+    * @return A new Entity object to spawn or null
-+    */
-+   @Nullable
-+   public Entity createEntity(World world, Entity location, ItemStack itemstack)
-+   {
-+       return null;
-+   }
-+
-+   /**
-+    * Called by the default implemetation of EntityItem's onUpdate method, allowing for cleaner
-+    * control over the update of the item without having to write a subclass.
-+    *
-+    * @param entityItem The entity Item
-+    * @return Return true to skip any further update code.
-+    */
-+   public boolean onEntityItemUpdate(net.minecraft.entity.item.EntityItem entityItem)
-+   {
-+       return false;
-+   }
-+
-+   /**
-+    * Gets a list of tabs that items belonging to this class can display on,
-+    * combined properly with getSubItems allows for a single item to span
-+    * many sub-items across many tabs.
-+    *
-+    * @return A list of all tabs that this item could possibly be one.
-+    */
-+   public ItemGroup[] getCreativeTabs()
-+   {
-+       return new ItemGroup[]{ getCreativeTab() };
-+   }
-+
-+   /**
-+    * Determines the base experience for a player when they remove this item from a furnace slot.
-+    * This number must be between 0 and 1 for it to be valid.
-+    * This number will be multiplied by the stack size to get the total experience.
-+    *
-+    * @param item The item stack the player is picking up.
-+    * @return The amount to award for each item.
-+    */
-+   public float getSmeltingExperience(ItemStack item)
-+   {
-+       return -1; //-1 will default to the old lookups.
-+   }
-+
-+   /**
-+    *
-+    * Should this item, when held, allow sneak-clicks to pass through to the underlying block?
-+    *
-+    * @param world The world
-+    * @param pos Block position in world
-+    * @param player The Player that is wielding the item
-+    * @return
-+    */
-+   public boolean doesSneakBypassUse(ItemStack stack, net.minecraft.world.IWorldReader world, BlockPos pos, EntityPlayer player)
-+   {
-+       return false;
-+   }
-+
-+   /**
-+    * Called to tick armor in the armor slot. Override to do something
-+    */
-+   public void onArmorTick(World world, EntityPlayer player, ItemStack itemStack){}
-+
-+   /**
-+    * Determines if the specific ItemStack can be placed in the specified armor slot, for the entity.
-+    *
-+    * TODO: Change name to canEquip in 1.13?
-+    *
-+    * @param stack The ItemStack
-+    * @param armorType Armor slot to be verified.
-+    * @param entity The entity trying to equip the armor
-+    * @return True if the given ItemStack can be inserted in the slot
-+    */
-+   public boolean isValidArmor(ItemStack stack, EntityEquipmentSlot armorType, Entity entity)
-+   {
-+       return net.minecraft.entity.EntityLiving.getSlotForItemStack(stack) == armorType;
-+   }
-+
-+   /**
-+    * Override this to set a non-default armor slot for an ItemStack, but
-+    * <em>do not use this to get the armor slot of said stack; for that, use
-+    * {@link net.minecraft.entity.EntityLiving#getSlotForItemStack(ItemStack)}.</em>
-+    *
-+    * @param stack the ItemStack
-+    * @return the armor slot of the ItemStack, or {@code null} to let the default
-+    * vanilla logic as per {@code EntityLiving.getSlotForItemStack(stack)} decide
-+    */
-+   @Nullable
-+   public EntityEquipmentSlot getEquipmentSlot(ItemStack stack)
-+   {
-+       return null;
-+   }
-+
-+   /**
-+    * Allow or forbid the specific book/item combination as an anvil enchant
-+    *
-+    * @param stack The item
-+    * @param book The book
-+    * @return if the enchantment is allowed
-+    */
-+   public boolean isBookEnchantable(ItemStack stack, ItemStack book)
-+   {
-+       return true;
-+   }
-+
-+   /**
-+    * Called by RenderBiped and RenderPlayer to determine the armor texture that
-+    * should be use for the currently equipped item.
-+    * This will only be called on instances of ItemArmor.
-+    *
-+    * Returning null from this function will use the default value.
-+    *
-+    * @param stack ItemStack for the equipped armor
-+    * @param entity The entity wearing the armor
-+    * @param slot The slot the armor is in
-+    * @param type The subtype, can be null or "overlay"
-+    * @return Path of texture to bind, or null to use default
-+    */
-+   @Nullable
-+   public String getArmorTexture(ItemStack stack, Entity entity, EntityEquipmentSlot slot, String type)
-+   {
-+       return null;
-+   }
-+
-+   /**
-+    * Returns the font renderer used to render tooltips and overlays for this item.
-+    * Returning null will use the standard font renderer.
-+    *
-+    * @param stack The current item stack
-+    * @return A instance of FontRenderer or null to use default
-+    */
-+   @OnlyIn(Dist.CLIENT)
-+   @Nullable
-+   public net.minecraft.client.gui.FontRenderer getFontRenderer(ItemStack stack)
-+   {
-+       return null;
-+   }
-+
-+   /**
-+    * Override this method to have an item handle its own armor rendering.
-+    *
-+    * @param  entityLiving  The entity wearing the armor
-+    * @param  itemStack  The itemStack to render the model of
-+    * @param  armorSlot  The slot the armor is in
-+    * @param _default Original armor model. Will have attributes set.
-+    * @return  A ModelBiped to render instead of the default
-+    */
-+   @OnlyIn(Dist.CLIENT)
-+   @Nullable
-+   public net.minecraft.client.renderer.entity.model.ModelBiped getArmorModel(EntityLivingBase entityLiving, ItemStack itemStack, EntityEquipmentSlot armorSlot, net.minecraft.client.renderer.entity.model.ModelBiped _default)
-+   {
-+       return null;
-+   }
-+
-+   /**
-+    * Called when a entity tries to play the 'swing' animation.
-+    *
-+    * @param entityLiving The entity swinging the item.
-+    * @param stack The Item stack
-+    * @return True to cancel any further processing by EntityLiving
-+    */
-+   public boolean onEntitySwing(EntityLivingBase entityLiving, ItemStack stack)
-+   {
-+       return false;
-+   }
-+
-+   /**
-+    * Called when the client starts rendering the HUD, for whatever item the player currently has as a helmet.
-+    * This is where pumpkins would render there overlay.
-+    *
-+    * @param stack The ItemStack that is equipped
-+    * @param player Reference to the current client entity
-+    * @param resolution Resolution information about the current viewport and configured GUI Scale
-+    * @param partialTicks Partial ticks for the renderer, useful for interpolation
-+    */
-+   @OnlyIn(Dist.CLIENT)
-+   public void renderHelmetOverlay(ItemStack stack, EntityPlayer player, int width, int height, float partialTicks){}
-+
-+   /**
-+    * Return the itemDamage represented by this ItemStack. Defaults to the Damage entry in the stack NBT, but can be overridden here for other sources.
-+    *
-+    * @param stack The itemstack that is damaged
-+    * @return the damage value
-+    */
-+   public int getDamage(ItemStack stack)
-+   {
-+	   return !stack.hasTagCompound() ? 0 : stack.getTagCompound().getInteger("Damage");
-+   }
-+
-+   /**
-+    * Determines if the durability bar should be rendered for this item.
-+    * Defaults to vanilla stack.isDamaged behavior.
-+    * But modders can use this for any data they wish.
-+    *
-+    * @param stack The current Item Stack
-+    * @return True if it should render the 'durability' bar.
-+    */
-+   public boolean showDurabilityBar(ItemStack stack)
-+   {
-+       return stack.isItemDamaged();
-+   }
-+
-+   /**
-+    * Queries the percentage of the 'Durability' bar that should be drawn.
-+    *
-+    * @param stack The current ItemStack
-+    * @return 0.0 for 100% (no damage / full bar), 1.0 for 0% (fully damaged / empty bar)
-+    */
-+   public double getDurabilityForDisplay(ItemStack stack)
-+   {
-+       return (double)stack.getItemDamage() / (double)stack.getMaxDamage();
-+   }
-+
-+   /**
-+    * Returns the packed int RGB value used to render the durability bar in the GUI.
-+    * Defaults to a value based on the hue scaled based on {@link #getDurabilityForDisplay}, but can be overriden.
-+    *
-+    * @param stack Stack to get durability from
-+    * @return A packed RGB value for the durability colour (0x00RRGGBB)
-+    */
-+   public int getRGBDurabilityForDisplay(ItemStack stack)
-+   {
-+       return MathHelper.hsvToRGB(Math.max(0.0F, (float) (1.0F - getDurabilityForDisplay(stack))) / 3.0F, 1.0F, 1.0F);
-+   }
-+   /**
-+    * Return the maxDamage for this ItemStack. Defaults to the maxDamage field in this item,
-+    * but can be overridden here for other sources such as NBT.
-+    *
-+    * @param stack The itemstack that is damaged
-+    * @return the damage value
-+    */
-+   public int getMaxDamage(ItemStack stack)
-+   {
-+       return getMaxDamage();
-+   }
-+
-+   /**
-+    * Return if this itemstack is damaged. Note only called if {@link #isDamageable()} is true.
-+    * @param stack the stack
-+    * @return if the stack is damaged
-+    */
-+   public boolean isDamaged(ItemStack stack)
-+   {
-+       return stack.getItemDamage() > 0;
-+   }
-+
-+   /**
-+    * Set the damage for this itemstack. Note, this method is responsible for zero checking.
-+    * @param stack the stack
-+    * @param damage the new damage value
-+    */
-+   public void setDamage(ItemStack stack, int damage)
-+   {
-+       stack.func_196082_o().setInteger("Damage", Math.max(0, damage));
-+   }
-+
-+   /**
-+    * Checked from {@link net.minecraft.client.multiplayer.PlayerControllerMP#onPlayerDestroyBlock(BlockPos pos) PlayerControllerMP.onPlayerDestroyBlock()}
-+    * when a creative player left-clicks a block with this item.
-+    * Also checked from {@link net.minecraftforge.common.ForgeHooks#onBlockBreakEvent(World, GameType, EntityPlayerMP, BlockPos)  ForgeHooks.onBlockBreakEvent()}
-+    * to prevent sending an event.
-+    * @return true if the given player can destroy specified block in creative mode with this item
-+    */
-+   public boolean canDestroyBlockInCreative(World world, BlockPos pos, ItemStack stack, EntityPlayer player)
-+   {
-+       return !(this instanceof ItemSword);
-+   }
-+
-+   /**
-+    * ItemStack sensitive version of {@link #canHarvestBlock(IBlockState)}
-+    * @param state The block trying to harvest
-+    * @param stack The itemstack used to harvest the block
-+    * @return true if can harvest the block
-+    */
-+   public boolean canHarvestBlock(IBlockState state, ItemStack stack)
-+   {
-+       return canHarvestBlock(state);
-+   }
-+
-+   /**
-+    * Gets the maximum number of items that this stack should be able to hold.
-+    * This is a ItemStack (and thus NBT) sensitive version of Item.getItemStackLimit()
-+    *
-+    * @param stack The ItemStack
-+    * @return The maximum number this item can be stacked to
-+    */
-+   public int getItemStackLimit(ItemStack stack)
-+   {
-+       return this.getItemStackLimit();
-+   }
-+
-+   private java.util.Map<String, Integer> toolClasses = new java.util.HashMap<String, Integer>();
-+   /**
-+    * Sets or removes the harvest level for the specified tool class.
-+    *
-+    * @param toolClass Class
-+    * @param level Harvest level:
-+    *     Wood:    0
-+    *     Stone:   1
-+    *     Iron:    2
-+    *     Diamond: 3
-+    *     Gold:    0
-+    */
++   
++   @Override
 +   public void setHarvestLevel(String toolClass, int level)
 +   {
 +       if (level < 0)
@@ -582,222 +103,35 @@
 +           toolClasses.put(toolClass, level);
 +   }
 +
++   @Override
 +   public java.util.Set<String> getToolClasses(ItemStack stack)
 +   {
 +       return toolClasses.keySet();
 +   }
 +
-+   /**
-+    * Queries the harvest level of this item stack for the specified tool class,
-+    * Returns -1 if this tool is not of the specified type
-+    *
-+    * @param stack This item stack instance
-+    * @param toolClass Tool Class
-+    * @param player The player trying to harvest the given blockstate
-+    * @param blockState The block to harvest
-+    * @return Harvest level, or -1 if not the specified tool type.
-+    */
++   @Override
 +   public int getHarvestLevel(ItemStack stack, String toolClass, @Nullable EntityPlayer player, @Nullable IBlockState blockState)
 +   {
 +       Integer ret = toolClasses.get(toolClass);
 +       return ret == null ? -1 : ret;
 +   }
 +
-+   /**
-+    * ItemStack sensitive version of getItemEnchantability
-+    *
-+    * @param stack The ItemStack
-+    * @return the item echantability value
-+    */
-+   public int getItemEnchantability(ItemStack stack)
-+   {
-+       return getItemEnchantability();
-+   }
-+
-+   /**
-+    * Checks whether an item can be enchanted with a certain enchantment. This applies specifically to enchanting an item in the enchanting table and is called when retrieving the list of possible enchantments for an item.
-+    * Enchantments may additionally (or exclusively) be doing their own checks in {@link net.minecraft.enchantment.Enchantment#canApplyAtEnchantingTable(ItemStack)}; check the individual implementation for reference.
-+    * By default this will check if the enchantment type is valid for this item type.
-+    * @param stack the item stack to be enchanted
-+    * @param enchantment the enchantment to be applied
-+    * @return true if the enchantment can be applied to this item
-+    */
-+   public boolean canApplyAtEnchantingTable(ItemStack stack, net.minecraft.enchantment.Enchantment enchantment)
-+   {
-+       return enchantment.type.canEnchantItem(stack.getItem());
-+   }
-+
-+   /**
-+    * Whether this Item can be used as a payment to activate the vanilla beacon.
-+    * @param stack the ItemStack
-+    * @return true if this Item can be used
-+    */
-+   public boolean isBeaconPayment(ItemStack stack)
-+   {
-+       return this == Items.EMERALD || this == Items.DIAMOND || this == Items.GOLD_INGOT || this == Items.IRON_INGOT;
-+   }
-+
-+   /**
-+    * Determine if the player switching between these two item stacks
-+    * @param oldStack The old stack that was equipped
-+    * @param newStack The new stack
-+    * @param slotChanged If the current equipped slot was changed,
-+    *                    Vanilla does not play the animation if you switch between two
-+    *                    slots that hold the exact same item.
-+    * @return True to play the item change animation
-+    */
-+   public boolean shouldCauseReequipAnimation(ItemStack oldStack, ItemStack newStack, boolean slotChanged)
-+   {
-+       return !oldStack.equals(newStack); //!ItemStack.areItemStacksEqual(oldStack, newStack);
-+   }
-+
-+   /**
-+    * Called when the player is mining a block and the item in his hand changes.
-+    * Allows to not reset blockbreaking if only NBT or similar changes.
-+    * @param oldStack The old stack that was used for mining. Item in players main hand
-+    * @param newStack The new stack
-+    * @return True to reset block break progress
-+    */
-+   public boolean shouldCauseBlockBreakReset(ItemStack oldStack, ItemStack newStack)
-+   {
-+       return !(newStack.getItem() == oldStack.getItem() && ItemStack.areItemStackTagsEqual(newStack, oldStack) && (newStack.isItemStackDamageable() || newStack.getItemDamage() == oldStack.getItemDamage()));
-+   }
-+
-+   /**
-+    * Called to get the Mod ID of the mod that *created* the ItemStack,
-+    * instead of the real Mod ID that *registered* it.
-+    *
-+    * For example the Forge Universal Bucket creates a subitem for each modded fluid,
-+    * and it returns the modded fluid's Mod ID here.
-+    *
-+    * Mods that register subitems for other mods can override this.
-+    * Informational mods can call it to show the mod that created the item.
-+    *
-+    * @param itemStack the ItemStack to check
-+    * @return the Mod ID for the ItemStack, or
-+    *         null when there is no specially associated mod and {@link #getRegistryName()} would return null.
-+    */
-+   @Nullable
-+   public String getCreatorModId(ItemStack itemStack)
-+   {
-+       return net.minecraftforge.common.ForgeHooks.getDefaultCreatorModId(itemStack);
-+   }
-+
-+   /**
-+    * Called from ItemStack.setItem, will hold extra data for the life of this ItemStack.
-+    * Can be retrieved from stack.getCapabilities()
-+    * The NBT can be null if this is not called from readNBT or if the item the stack is
-+    * changing FROM is different then this item, or the previous item had no capabilities.
-+    *
-+    * This is called BEFORE the stacks item is set so you can use stack.getItem() to see the OLD item.
-+    * Remember that getItem CAN return null.
-+    *
-+    * @param stack The ItemStack
-+    * @param nbt NBT of this item serialized, or null.
-+    * @return A holder instance associated with this ItemStack where you can hold capabilities for the life of this item.
-+    */
-+   @Nullable
-+   public net.minecraftforge.common.capabilities.ICapabilityProvider initCapabilities(ItemStack stack, @Nullable NBTTagCompound nbt)
-+   {
-+       return null;
-+   }
-+
-+   public com.google.common.collect.ImmutableMap<String, net.minecraftforge.common.animation.ITimeValue> getAnimationParameters(final ItemStack stack, final World world, final EntityLivingBase entity)
-+   {
-+       com.google.common.collect.ImmutableMap.Builder<String, net.minecraftforge.common.animation.ITimeValue> builder = com.google.common.collect.ImmutableMap.builder();
-+       for(ResourceLocation location : ((RegistrySimple<ResourceLocation, IItemPropertyGetter>)properties).getKeys())
-+       {
-+           final IItemPropertyGetter parameter = properties.getObject(location);
-+           builder.put(location.toString(), new net.minecraftforge.common.animation.ITimeValue()
-+           {
-+               public float apply(float input)
-+               {
-+                   return parameter.call(stack, world, entity);
-+               }
-+           });
-+       }
-+       return builder.build();
-+   }
-+
-+   /**
-+    * Can this Item disable a shield
-+    * @param stack The ItemStack
-+    * @param shield The shield in question
-+    * @param entity The EntityLivingBase holding the shield
-+    * @param attacker The EntityLivingBase holding the ItemStack
-+    * @retrun True if this ItemStack can disable the shield in question.
-+    */
-+   public boolean canDisableShield(ItemStack stack, ItemStack shield, EntityLivingBase entity, EntityLivingBase attacker)
-+   {
-+       return this instanceof ItemAxe;
-+   }
-+
-+   /**
-+    * Is this Item a shield
-+    * @param stack The ItemStack
-+    * @param entity The Entity holding the ItemStack
-+    * @return True if the ItemStack is considered a shield
-+    */
-+   public boolean isShield(ItemStack stack, @Nullable EntityLivingBase entity)
-+   {
-+       return stack.getItem() == Items.SHIELD;
-+   }
-+
-+   /**
-+    * @return the fuel burn time for this itemStack in a furnace.
-+    * Return 0 to make it not act as a fuel.
-+    * Return -1 to let the default vanilla logic decide.
-+    */
-+   public int getItemBurnTime(ItemStack itemStack)
-+   {
-+       return -1;
-+   }
-+
-+   /** 
-+    * Returns an enum constant of type {@code HorseArmorType}.
-+    * The returned enum constant will be used to determine the armor value and texture of this item when equipped.
-+    * @param stack the armor stack
-+    * @return an enum constant of type {@code HorseArmorType}. Return HorseArmorType.NONE if this is not horse armor
-+    */
-+   public net.minecraft.entity.passive.HorseArmorType getHorseArmorType(ItemStack stack)
-+   {
-+       return net.minecraft.entity.passive.HorseArmorType.getByItem(stack.getItem());
-+   }
-+
-+   public String getHorseArmorTexture(net.minecraft.entity.EntityLiving wearer, ItemStack stack)
-+   {
-+       return getHorseArmorType(stack).getTextureName();
-+   }
-+
-+   /**
-+    * Called every tick from {@link EntityHorse#onUpdate()} on the item in the armor slot.
-+    * @param world the world the horse is in
-+    * @param horse the horse wearing this armor
-+    * @param armor the armor itemstack
-+    */
-+   public void onHorseArmorTick(World world, net.minecraft.entity.EntityLiving horse, ItemStack armor) {}
-+
 +   @OnlyIn(Dist.CLIENT)
-+   @Nullable
-+   private net.minecraft.client.renderer.tileentity.TileEntityItemStackRenderer teisr;
-+
-+   /**
-+    * @return This Item's renderer, or the default instance if it does not have one.
-+    */
-+   @OnlyIn(Dist.CLIENT)
++   @Override
 +   public final net.minecraft.client.renderer.tileentity.TileEntityItemStackRenderer getTileEntityItemStackRenderer()
 +   {
-+    return teisr != null ? teisr : net.minecraft.client.renderer.tileentity.TileEntityItemStackRenderer.instance;
++       return teisr != null ? teisr : net.minecraft.client.renderer.tileentity.TileEntityItemStackRenderer.instance;
 +   }
 +
 +   @OnlyIn(Dist.CLIENT)
++   @Override
 +   public void setTileEntityItemStackRenderer(@Nullable net.minecraft.client.renderer.tileentity.TileEntityItemStackRenderer teisr)
 +   {
-+   	this.teisr = teisr;
-+   }  
-+
++       this.teisr = teisr;
++   }
++   
 +   /* ======================================== FORGE END   =====================================*/
-+
++   
     public static void registerItems() {
        registerItemBlock(Blocks.AIR, new ItemAir(Blocks.AIR, new Item.Builder()));
        func_200879_a(Blocks.STONE, ItemGroup.BUILDING_BLOCKS);

--- a/patches/minecraft/net/minecraft/item/Item.java.patch
+++ b/patches/minecraft/net/minecraft/item/Item.java.patch
@@ -1,11 +1,803 @@
 --- a/net/minecraft/item/Item.java
 +++ b/net/minecraft/item/Item.java
-@@ -50,7 +50,7 @@
+@@ -50,9 +50,9 @@
  import net.minecraftforge.api.distmarker.Dist;
  import net.minecraftforge.api.distmarker.OnlyIn;
  
 -public class Item implements IItemProvider {
+-   public static final RegistryNamespaced<ResourceLocation, Item> REGISTRY = new RegistryNamespaced<ResourceLocation, Item>();
+-   public static final Map<Block, Item> BLOCK_TO_ITEM = Maps.<Block, Item>newHashMap();
 +public class Item extends net.minecraftforge.registries.ForgeRegistryEntry<Item> implements IItemProvider {
-    public static final RegistryNamespaced<ResourceLocation, Item> REGISTRY = new RegistryNamespaced<ResourceLocation, Item>();
-    public static final Map<Block, Item> BLOCK_TO_ITEM = Maps.<Block, Item>newHashMap();
++   public static final RegistryNamespaced<ResourceLocation, Item> REGISTRY = net.minecraftforge.registries.GameData.getWrapper(Item.class);
++   public static final Map<Block, Item> BLOCK_TO_ITEM = net.minecraftforge.registries.GameData.getBlockItemMap();
     private static final IItemPropertyGetter DAMAGED_GETTER = (p_210306_0_, p_210306_1_, p_210306_2_) -> {
+       return p_210306_0_.isItemDamaged() ? 1.0F : 0.0F;
+    };
+@@ -149,10 +149,12 @@
+       return stack;
+    }
+ 
++   @Deprecated // Use ItemStack sensitive version below.
+    public final int getItemStackLimit() {
+       return this.maxStackSize;
+    }
+ 
++   @Deprecated // Use ItemStack sensitive version below.
+    public final int getMaxDamage() {
+       return this.maxDamage;
+    }
+@@ -207,6 +209,7 @@
+       return this.containerItem;
+    }
+ 
++   @Deprecated // Use ItemStack sensitive version below.
+    public boolean hasContainerItem() {
+       return this.containerItem != null;
+    }
+@@ -263,7 +266,7 @@
+    }
+ 
+    public boolean isEnchantable(ItemStack stack) {
+-      return this.getItemStackLimit() == 1 && this.isDamageable();
++	  return this.getItemStackLimit(stack) == 1 && this.isDamageable();
+    }
+ 
+    @Nullable
+@@ -280,8 +283,8 @@
+       float f5 = MathHelper.sin(-f * ((float)Math.PI / 180F));
+       float f6 = f3 * f4;
+       float f7 = f2 * f4;
+-      double d3 = 5.0D;
+-      Vec3d vec3d1 = vec3d.add((double)f6 * 5.0D, (double)f5 * 5.0D, (double)f7 * 5.0D);
++      double d3 = playerIn.getEntityAttribute(EntityPlayer.REACH_DISTANCE).getAttributeValue();
++      Vec3d vec3d1 = vec3d.add((double)f6 * d3, (double)f5 * d3, (double)f7 * d3);
+       return worldIn.func_200259_a(vec3d, vec3d1, useLiquids ? RayTraceFluidMode.SOURCE_ONLY : RayTraceFluidMode.NEVER, false, false);
+    }
+ 
+@@ -297,6 +300,9 @@
+    }
+ 
+    protected boolean isInCreativeTab(ItemGroup targetTab) {
++	  for (ItemGroup tab : this.getCreativeTabs())
++		  if (tab == targetTab)
++			  return true;
+       ItemGroup itemgroup = this.getCreativeTab();
+       return itemgroup != null && (targetTab == ItemGroup.SEARCH || targetTab == itemgroup);
+    }
+@@ -310,10 +316,736 @@
+       return false;
+    }
+ 
++   @Deprecated // Use ItemStack sensitive version below.
+    public Multimap<String, AttributeModifier> getItemAttributeModifiers(EntityEquipmentSlot equipmentSlot) {
+       return HashMultimap.<String, AttributeModifier>create();
+    }
+ 
++   /* ======================================== FORGE START =====================================*/
++   /**
++    * ItemStack sensitive version of getItemAttributeModifiers
++    */
++   public Multimap<String, AttributeModifier> getAttributeModifiers(EntityEquipmentSlot slot, ItemStack stack)
++   {
++       return this.getItemAttributeModifiers(slot);
++   }
++
++   /**
++    * Called when a player drops the item into the world,
++    * returning false from this will prevent the item from
++    * being removed from the players inventory and spawning
++    * in the world
++    *
++    * @param player The player that dropped the item
++    * @param item The item stack, before the item is removed.
++    */
++   public boolean onDroppedByPlayer(ItemStack item, EntityPlayer player)
++   {
++       return true;
++   }
++
++   /**
++    * Allow the item one last chance to modify its name used for the
++    * tool highlight useful for adding something extra that can't be removed
++    * by a user in the displayed name, such as a mode of operation.
++    *
++    * @param item the ItemStack for the item.
++    * @param displayName the name that will be displayed unless it is changed in this method.
++    */
++   public String getHighlightTip( ItemStack item, String displayName )
++   {
++       return displayName;
++   }
++
++   /**
++    * This is called when the item is used, before the block is activated.
++	*
++    * @return Return PASS to allow vanilla handling, any other to skip normal code.
++    */
++   public EnumActionResult onItemUseFirst(ItemUseContext context)
++   {
++       return EnumActionResult.PASS;
++   }
++
++   protected boolean canRepair = true;
++   /**
++    * Called by CraftingManager to determine if an item is reparable.
++    * @return True if reparable
++    */
++   public boolean isRepairable()
++   {
++       return canRepair && isDamageable();
++   }
++
++   /**
++    * Call to disable repair recipes.
++    * @return The current Item instance
++    */
++   public Item setNoRepair()
++   {
++       canRepair = false;
++       return this;
++   }
++
++   /**
++    * Override this method to change the NBT data being sent to the client.
++    * You should ONLY override this when you have no other choice, as this might change behavior client side!
++    *
++    * Note that this will sometimes be applied multiple times, the following MUST be supported:
++    * Item item = stack.getItem();
++    * NBTTagCompound nbtShare1 = item.getNBTShareTag(stack);
++    * stack.setTagCompound(nbtShare1);
++    * NBTTagCompound nbtShare2 = item.getNBTShareTag(stack);
++    * assert nbtShare1.equals(nbtShare2);
++    *
++    * @param stack The stack to send the NBT tag for
++    * @return The NBT tag
++    */
++   @Nullable
++   public NBTTagCompound getNBTShareTag(ItemStack stack)
++   {
++       return stack.getTagCompound();
++   }
++
++   /**
++    * Override this method to decide what to do with the NBT data received from getNBTShareTag().
++    * 
++    * @param stack The stack that received NBT
++    * @param nbt Received NBT, can be null
++    */
++   public void readNBTShareTag(ItemStack stack, @Nullable NBTTagCompound nbt)
++   {
++       stack.setTagCompound(nbt);
++   }
++
++   /**
++    * Called before a block is broken.  Return true to prevent default block harvesting.
++    *
++    * Note: In SMP, this is called on both client and server sides!
++    *
++    * @param itemstack The current ItemStack
++    * @param pos Block's position in world
++    * @param player The Player that is wielding the item
++    * @return True to prevent harvesting, false to continue as normal
++    */
++   public boolean onBlockStartBreak(ItemStack itemstack, BlockPos pos, EntityPlayer player)
++   {
++       return false;
++   }
++
++   /**
++    * Called each tick while using an item.
++    * @param stack The Item being used
++    * @param player The Player using the item
++    * @param count The amount of time in tick the item has been used for continuously
++    */
++   public void onUsingTick(ItemStack stack, EntityLivingBase player, int count)
++   {
++   }
++
++   /**
++    * Called when the player Left Clicks (attacks) an entity.
++    * Processed before damage is done, if return value is true further processing is canceled
++    * and the entity is not attacked.
++    *
++    * @param stack The Item being used
++    * @param player The player that is attacking
++    * @param entity The entity being attacked
++    * @return True to cancel the rest of the interaction.
++    */
++   public boolean onLeftClickEntity(ItemStack stack, EntityPlayer player, Entity entity)
++   {
++       return false;
++   }
++
++   /**
++    * ItemStack sensitive version of getContainerItem.
++    * Returns a full ItemStack instance of the result.
++    *
++    * @param itemStack The current ItemStack
++    * @return The resulting ItemStack
++    */
++   public ItemStack getContainerItem(ItemStack itemStack)
++   {
++       if (!hasContainerItem(itemStack))
++       {
++           return ItemStack.EMPTY;
++       }
++       return new ItemStack(getContainerItem());
++   }
++
++   /**
++    * ItemStack sensitive version of hasContainerItem
++    * @param stack The current item stack
++    * @return True if this item has a 'container'
++    */
++   public boolean hasContainerItem(ItemStack stack)
++   {
++       return hasContainerItem();
++   }
++
++   /**
++    * Retrieves the normal 'lifespan' of this item when it is dropped on the ground as a EntityItem.
++    * This is in ticks, standard result is 6000, or 5 mins.
++    *
++    * @param itemStack The current ItemStack
++    * @param world The world the entity is in
++    * @return The normal lifespan in ticks.
++    */
++   public int getEntityLifespan(ItemStack itemStack, World world)
++   {
++       return 6000;
++   }
++
++   /**
++    * Determines if this Item has a special entity for when they are in the world.
++    * Is called when a EntityItem is spawned in the world, if true and Item#createCustomEntity
++    * returns non null, the EntityItem will be destroyed and the new Entity will be added to the world.
++    *
++    * @param stack The current item stack
++    * @return True of the item has a custom entity, If true, Item#createCustomEntity will be called
++    */
++   public boolean hasCustomEntity(ItemStack stack)
++   {
++       return false;
++   }
++
++   /**
++    * This function should return a new entity to replace the dropped item.
++    * Returning null here will not kill the EntityItem and will leave it to function normally.
++    * Called when the item it placed in a world.
++    *
++    * @param world The world object
++    * @param location The EntityItem object, useful for getting the position of the entity
++    * @param itemstack The current item stack
++    * @return A new Entity object to spawn or null
++    */
++   @Nullable
++   public Entity createEntity(World world, Entity location, ItemStack itemstack)
++   {
++       return null;
++   }
++
++   /**
++    * Called by the default implemetation of EntityItem's onUpdate method, allowing for cleaner
++    * control over the update of the item without having to write a subclass.
++    *
++    * @param entityItem The entity Item
++    * @return Return true to skip any further update code.
++    */
++   public boolean onEntityItemUpdate(net.minecraft.entity.item.EntityItem entityItem)
++   {
++       return false;
++   }
++
++   /**
++    * Gets a list of tabs that items belonging to this class can display on,
++    * combined properly with getSubItems allows for a single item to span
++    * many sub-items across many tabs.
++    *
++    * @return A list of all tabs that this item could possibly be one.
++    */
++   public ItemGroup[] getCreativeTabs()
++   {
++       return new ItemGroup[]{ getCreativeTab() };
++   }
++
++   /**
++    * Determines the base experience for a player when they remove this item from a furnace slot.
++    * This number must be between 0 and 1 for it to be valid.
++    * This number will be multiplied by the stack size to get the total experience.
++    *
++    * @param item The item stack the player is picking up.
++    * @return The amount to award for each item.
++    */
++   public float getSmeltingExperience(ItemStack item)
++   {
++       return -1; //-1 will default to the old lookups.
++   }
++
++   /**
++    *
++    * Should this item, when held, allow sneak-clicks to pass through to the underlying block?
++    *
++    * @param world The world
++    * @param pos Block position in world
++    * @param player The Player that is wielding the item
++    * @return
++    */
++   public boolean doesSneakBypassUse(ItemStack stack, net.minecraft.world.IWorldReader world, BlockPos pos, EntityPlayer player)
++   {
++       return false;
++   }
++
++   /**
++    * Called to tick armor in the armor slot. Override to do something
++    */
++   public void onArmorTick(World world, EntityPlayer player, ItemStack itemStack){}
++
++   /**
++    * Determines if the specific ItemStack can be placed in the specified armor slot, for the entity.
++    *
++    * TODO: Change name to canEquip in 1.13?
++    *
++    * @param stack The ItemStack
++    * @param armorType Armor slot to be verified.
++    * @param entity The entity trying to equip the armor
++    * @return True if the given ItemStack can be inserted in the slot
++    */
++   public boolean isValidArmor(ItemStack stack, EntityEquipmentSlot armorType, Entity entity)
++   {
++       return net.minecraft.entity.EntityLiving.getSlotForItemStack(stack) == armorType;
++   }
++
++   /**
++    * Override this to set a non-default armor slot for an ItemStack, but
++    * <em>do not use this to get the armor slot of said stack; for that, use
++    * {@link net.minecraft.entity.EntityLiving#getSlotForItemStack(ItemStack)}.</em>
++    *
++    * @param stack the ItemStack
++    * @return the armor slot of the ItemStack, or {@code null} to let the default
++    * vanilla logic as per {@code EntityLiving.getSlotForItemStack(stack)} decide
++    */
++   @Nullable
++   public EntityEquipmentSlot getEquipmentSlot(ItemStack stack)
++   {
++       return null;
++   }
++
++   /**
++    * Allow or forbid the specific book/item combination as an anvil enchant
++    *
++    * @param stack The item
++    * @param book The book
++    * @return if the enchantment is allowed
++    */
++   public boolean isBookEnchantable(ItemStack stack, ItemStack book)
++   {
++       return true;
++   }
++
++   /**
++    * Called by RenderBiped and RenderPlayer to determine the armor texture that
++    * should be use for the currently equipped item.
++    * This will only be called on instances of ItemArmor.
++    *
++    * Returning null from this function will use the default value.
++    *
++    * @param stack ItemStack for the equipped armor
++    * @param entity The entity wearing the armor
++    * @param slot The slot the armor is in
++    * @param type The subtype, can be null or "overlay"
++    * @return Path of texture to bind, or null to use default
++    */
++   @Nullable
++   public String getArmorTexture(ItemStack stack, Entity entity, EntityEquipmentSlot slot, String type)
++   {
++       return null;
++   }
++
++   /**
++    * Returns the font renderer used to render tooltips and overlays for this item.
++    * Returning null will use the standard font renderer.
++    *
++    * @param stack The current item stack
++    * @return A instance of FontRenderer or null to use default
++    */
++   @OnlyIn(Dist.CLIENT)
++   @Nullable
++   public net.minecraft.client.gui.FontRenderer getFontRenderer(ItemStack stack)
++   {
++       return null;
++   }
++
++   /**
++    * Override this method to have an item handle its own armor rendering.
++    *
++    * @param  entityLiving  The entity wearing the armor
++    * @param  itemStack  The itemStack to render the model of
++    * @param  armorSlot  The slot the armor is in
++    * @param _default Original armor model. Will have attributes set.
++    * @return  A ModelBiped to render instead of the default
++    */
++   @OnlyIn(Dist.CLIENT)
++   @Nullable
++   public net.minecraft.client.renderer.entity.model.ModelBiped getArmorModel(EntityLivingBase entityLiving, ItemStack itemStack, EntityEquipmentSlot armorSlot, net.minecraft.client.renderer.entity.model.ModelBiped _default)
++   {
++       return null;
++   }
++
++   /**
++    * Called when a entity tries to play the 'swing' animation.
++    *
++    * @param entityLiving The entity swinging the item.
++    * @param stack The Item stack
++    * @return True to cancel any further processing by EntityLiving
++    */
++   public boolean onEntitySwing(EntityLivingBase entityLiving, ItemStack stack)
++   {
++       return false;
++   }
++
++   /**
++    * Called when the client starts rendering the HUD, for whatever item the player currently has as a helmet.
++    * This is where pumpkins would render there overlay.
++    *
++    * @param stack The ItemStack that is equipped
++    * @param player Reference to the current client entity
++    * @param resolution Resolution information about the current viewport and configured GUI Scale
++    * @param partialTicks Partial ticks for the renderer, useful for interpolation
++    */
++   @OnlyIn(Dist.CLIENT)
++   public void renderHelmetOverlay(ItemStack stack, EntityPlayer player, int width, int height, float partialTicks){}
++
++   /**
++    * Return the itemDamage represented by this ItemStack. Defaults to the Damage entry in the stack NBT, but can be overridden here for other sources.
++    *
++    * @param stack The itemstack that is damaged
++    * @return the damage value
++    */
++   public int getDamage(ItemStack stack)
++   {
++	   return !stack.hasTagCompound() ? 0 : stack.getTagCompound().getInteger("Damage");
++   }
++
++   /**
++    * Determines if the durability bar should be rendered for this item.
++    * Defaults to vanilla stack.isDamaged behavior.
++    * But modders can use this for any data they wish.
++    *
++    * @param stack The current Item Stack
++    * @return True if it should render the 'durability' bar.
++    */
++   public boolean showDurabilityBar(ItemStack stack)
++   {
++       return stack.isItemDamaged();
++   }
++
++   /**
++    * Queries the percentage of the 'Durability' bar that should be drawn.
++    *
++    * @param stack The current ItemStack
++    * @return 0.0 for 100% (no damage / full bar), 1.0 for 0% (fully damaged / empty bar)
++    */
++   public double getDurabilityForDisplay(ItemStack stack)
++   {
++       return (double)stack.getItemDamage() / (double)stack.getMaxDamage();
++   }
++
++   /**
++    * Returns the packed int RGB value used to render the durability bar in the GUI.
++    * Defaults to a value based on the hue scaled based on {@link #getDurabilityForDisplay}, but can be overriden.
++    *
++    * @param stack Stack to get durability from
++    * @return A packed RGB value for the durability colour (0x00RRGGBB)
++    */
++   public int getRGBDurabilityForDisplay(ItemStack stack)
++   {
++       return MathHelper.hsvToRGB(Math.max(0.0F, (float) (1.0F - getDurabilityForDisplay(stack))) / 3.0F, 1.0F, 1.0F);
++   }
++   /**
++    * Return the maxDamage for this ItemStack. Defaults to the maxDamage field in this item,
++    * but can be overridden here for other sources such as NBT.
++    *
++    * @param stack The itemstack that is damaged
++    * @return the damage value
++    */
++   public int getMaxDamage(ItemStack stack)
++   {
++       return getMaxDamage();
++   }
++
++   /**
++    * Return if this itemstack is damaged. Note only called if {@link #isDamageable()} is true.
++    * @param stack the stack
++    * @return if the stack is damaged
++    */
++   public boolean isDamaged(ItemStack stack)
++   {
++       return stack.getItemDamage() > 0;
++   }
++
++   /**
++    * Set the damage for this itemstack. Note, this method is responsible for zero checking.
++    * @param stack the stack
++    * @param damage the new damage value
++    */
++   public void setDamage(ItemStack stack, int damage)
++   {
++       stack.func_196082_o().setInteger("Damage", Math.max(0, damage));
++   }
++
++   /**
++    * Checked from {@link net.minecraft.client.multiplayer.PlayerControllerMP#onPlayerDestroyBlock(BlockPos pos) PlayerControllerMP.onPlayerDestroyBlock()}
++    * when a creative player left-clicks a block with this item.
++    * Also checked from {@link net.minecraftforge.common.ForgeHooks#onBlockBreakEvent(World, GameType, EntityPlayerMP, BlockPos)  ForgeHooks.onBlockBreakEvent()}
++    * to prevent sending an event.
++    * @return true if the given player can destroy specified block in creative mode with this item
++    */
++   public boolean canDestroyBlockInCreative(World world, BlockPos pos, ItemStack stack, EntityPlayer player)
++   {
++       return !(this instanceof ItemSword);
++   }
++
++   /**
++    * ItemStack sensitive version of {@link #canHarvestBlock(IBlockState)}
++    * @param state The block trying to harvest
++    * @param stack The itemstack used to harvest the block
++    * @return true if can harvest the block
++    */
++   public boolean canHarvestBlock(IBlockState state, ItemStack stack)
++   {
++       return canHarvestBlock(state);
++   }
++
++   /**
++    * Gets the maximum number of items that this stack should be able to hold.
++    * This is a ItemStack (and thus NBT) sensitive version of Item.getItemStackLimit()
++    *
++    * @param stack The ItemStack
++    * @return The maximum number this item can be stacked to
++    */
++   public int getItemStackLimit(ItemStack stack)
++   {
++       return this.getItemStackLimit();
++   }
++
++   private java.util.Map<String, Integer> toolClasses = new java.util.HashMap<String, Integer>();
++   /**
++    * Sets or removes the harvest level for the specified tool class.
++    *
++    * @param toolClass Class
++    * @param level Harvest level:
++    *     Wood:    0
++    *     Stone:   1
++    *     Iron:    2
++    *     Diamond: 3
++    *     Gold:    0
++    */
++   public void setHarvestLevel(String toolClass, int level)
++   {
++       if (level < 0)
++           toolClasses.remove(toolClass);
++       else
++           toolClasses.put(toolClass, level);
++   }
++
++   public java.util.Set<String> getToolClasses(ItemStack stack)
++   {
++       return toolClasses.keySet();
++   }
++
++   /**
++    * Queries the harvest level of this item stack for the specified tool class,
++    * Returns -1 if this tool is not of the specified type
++    *
++    * @param stack This item stack instance
++    * @param toolClass Tool Class
++    * @param player The player trying to harvest the given blockstate
++    * @param blockState The block to harvest
++    * @return Harvest level, or -1 if not the specified tool type.
++    */
++   public int getHarvestLevel(ItemStack stack, String toolClass, @Nullable EntityPlayer player, @Nullable IBlockState blockState)
++   {
++       Integer ret = toolClasses.get(toolClass);
++       return ret == null ? -1 : ret;
++   }
++
++   /**
++    * ItemStack sensitive version of getItemEnchantability
++    *
++    * @param stack The ItemStack
++    * @return the item echantability value
++    */
++   public int getItemEnchantability(ItemStack stack)
++   {
++       return getItemEnchantability();
++   }
++
++   /**
++    * Checks whether an item can be enchanted with a certain enchantment. This applies specifically to enchanting an item in the enchanting table and is called when retrieving the list of possible enchantments for an item.
++    * Enchantments may additionally (or exclusively) be doing their own checks in {@link net.minecraft.enchantment.Enchantment#canApplyAtEnchantingTable(ItemStack)}; check the individual implementation for reference.
++    * By default this will check if the enchantment type is valid for this item type.
++    * @param stack the item stack to be enchanted
++    * @param enchantment the enchantment to be applied
++    * @return true if the enchantment can be applied to this item
++    */
++   public boolean canApplyAtEnchantingTable(ItemStack stack, net.minecraft.enchantment.Enchantment enchantment)
++   {
++       return enchantment.type.canEnchantItem(stack.getItem());
++   }
++
++   /**
++    * Whether this Item can be used as a payment to activate the vanilla beacon.
++    * @param stack the ItemStack
++    * @return true if this Item can be used
++    */
++   public boolean isBeaconPayment(ItemStack stack)
++   {
++       return this == Items.EMERALD || this == Items.DIAMOND || this == Items.GOLD_INGOT || this == Items.IRON_INGOT;
++   }
++
++   /**
++    * Determine if the player switching between these two item stacks
++    * @param oldStack The old stack that was equipped
++    * @param newStack The new stack
++    * @param slotChanged If the current equipped slot was changed,
++    *                    Vanilla does not play the animation if you switch between two
++    *                    slots that hold the exact same item.
++    * @return True to play the item change animation
++    */
++   public boolean shouldCauseReequipAnimation(ItemStack oldStack, ItemStack newStack, boolean slotChanged)
++   {
++       return !oldStack.equals(newStack); //!ItemStack.areItemStacksEqual(oldStack, newStack);
++   }
++
++   /**
++    * Called when the player is mining a block and the item in his hand changes.
++    * Allows to not reset blockbreaking if only NBT or similar changes.
++    * @param oldStack The old stack that was used for mining. Item in players main hand
++    * @param newStack The new stack
++    * @return True to reset block break progress
++    */
++   public boolean shouldCauseBlockBreakReset(ItemStack oldStack, ItemStack newStack)
++   {
++       return !(newStack.getItem() == oldStack.getItem() && ItemStack.areItemStackTagsEqual(newStack, oldStack) && (newStack.isItemStackDamageable() || newStack.getItemDamage() == oldStack.getItemDamage()));
++   }
++
++   /**
++    * Called to get the Mod ID of the mod that *created* the ItemStack,
++    * instead of the real Mod ID that *registered* it.
++    *
++    * For example the Forge Universal Bucket creates a subitem for each modded fluid,
++    * and it returns the modded fluid's Mod ID here.
++    *
++    * Mods that register subitems for other mods can override this.
++    * Informational mods can call it to show the mod that created the item.
++    *
++    * @param itemStack the ItemStack to check
++    * @return the Mod ID for the ItemStack, or
++    *         null when there is no specially associated mod and {@link #getRegistryName()} would return null.
++    */
++   @Nullable
++   public String getCreatorModId(ItemStack itemStack)
++   {
++       return net.minecraftforge.common.ForgeHooks.getDefaultCreatorModId(itemStack);
++   }
++
++   /**
++    * Called from ItemStack.setItem, will hold extra data for the life of this ItemStack.
++    * Can be retrieved from stack.getCapabilities()
++    * The NBT can be null if this is not called from readNBT or if the item the stack is
++    * changing FROM is different then this item, or the previous item had no capabilities.
++    *
++    * This is called BEFORE the stacks item is set so you can use stack.getItem() to see the OLD item.
++    * Remember that getItem CAN return null.
++    *
++    * @param stack The ItemStack
++    * @param nbt NBT of this item serialized, or null.
++    * @return A holder instance associated with this ItemStack where you can hold capabilities for the life of this item.
++    */
++   @Nullable
++   public net.minecraftforge.common.capabilities.ICapabilityProvider initCapabilities(ItemStack stack, @Nullable NBTTagCompound nbt)
++   {
++       return null;
++   }
++
++   public com.google.common.collect.ImmutableMap<String, net.minecraftforge.common.animation.ITimeValue> getAnimationParameters(final ItemStack stack, final World world, final EntityLivingBase entity)
++   {
++       com.google.common.collect.ImmutableMap.Builder<String, net.minecraftforge.common.animation.ITimeValue> builder = com.google.common.collect.ImmutableMap.builder();
++       for(ResourceLocation location : ((RegistrySimple<ResourceLocation, IItemPropertyGetter>)properties).getKeys())
++       {
++           final IItemPropertyGetter parameter = properties.getObject(location);
++           builder.put(location.toString(), new net.minecraftforge.common.animation.ITimeValue()
++           {
++               public float apply(float input)
++               {
++                   return parameter.call(stack, world, entity);
++               }
++           });
++       }
++       return builder.build();
++   }
++
++   /**
++    * Can this Item disable a shield
++    * @param stack The ItemStack
++    * @param shield The shield in question
++    * @param entity The EntityLivingBase holding the shield
++    * @param attacker The EntityLivingBase holding the ItemStack
++    * @retrun True if this ItemStack can disable the shield in question.
++    */
++   public boolean canDisableShield(ItemStack stack, ItemStack shield, EntityLivingBase entity, EntityLivingBase attacker)
++   {
++       return this instanceof ItemAxe;
++   }
++
++   /**
++    * Is this Item a shield
++    * @param stack The ItemStack
++    * @param entity The Entity holding the ItemStack
++    * @return True if the ItemStack is considered a shield
++    */
++   public boolean isShield(ItemStack stack, @Nullable EntityLivingBase entity)
++   {
++       return stack.getItem() == Items.SHIELD;
++   }
++
++   /**
++    * @return the fuel burn time for this itemStack in a furnace.
++    * Return 0 to make it not act as a fuel.
++    * Return -1 to let the default vanilla logic decide.
++    */
++   public int getItemBurnTime(ItemStack itemStack)
++   {
++       return -1;
++   }
++
++   /** 
++    * Returns an enum constant of type {@code HorseArmorType}.
++    * The returned enum constant will be used to determine the armor value and texture of this item when equipped.
++    * @param stack the armor stack
++    * @return an enum constant of type {@code HorseArmorType}. Return HorseArmorType.NONE if this is not horse armor
++    */
++   public net.minecraft.entity.passive.HorseArmorType getHorseArmorType(ItemStack stack)
++   {
++       return net.minecraft.entity.passive.HorseArmorType.getByItem(stack.getItem());
++   }
++
++   public String getHorseArmorTexture(net.minecraft.entity.EntityLiving wearer, ItemStack stack)
++   {
++       return getHorseArmorType(stack).getTextureName();
++   }
++
++   /**
++    * Called every tick from {@link EntityHorse#onUpdate()} on the item in the armor slot.
++    * @param world the world the horse is in
++    * @param horse the horse wearing this armor
++    * @param armor the armor itemstack
++    */
++   public void onHorseArmorTick(World world, net.minecraft.entity.EntityLiving horse, ItemStack armor) {}
++
++   @OnlyIn(Dist.CLIENT)
++   @Nullable
++   private net.minecraft.client.renderer.tileentity.TileEntityItemStackRenderer teisr;
++
++   /**
++    * @return This Item's renderer, or the default instance if it does not have one.
++    */
++   @OnlyIn(Dist.CLIENT)
++   public final net.minecraft.client.renderer.tileentity.TileEntityItemStackRenderer getTileEntityItemStackRenderer()
++   {
++    return teisr != null ? teisr : net.minecraft.client.renderer.tileentity.TileEntityItemStackRenderer.instance;
++   }
++
++   @OnlyIn(Dist.CLIENT)
++   public void setTileEntityItemStackRenderer(@Nullable net.minecraft.client.renderer.tileentity.TileEntityItemStackRenderer teisr)
++   {
++   	this.teisr = teisr;
++   }  
++
++   /* ======================================== FORGE END   =====================================*/
++
+    public static void registerItems() {
+       registerItemBlock(Blocks.AIR, new ItemAir(Blocks.AIR, new Item.Builder()));
+       func_200879_a(Blocks.STONE, ItemGroup.BUILDING_BLOCKS);

--- a/patches/minecraft/net/minecraft/item/Item.java.patch
+++ b/patches/minecraft/net/minecraft/item/Item.java.patch
@@ -13,15 +13,17 @@
     private static final IItemPropertyGetter DAMAGED_GETTER = (p_210306_0_, p_210306_1_, p_210306_2_) -> {
        return p_210306_0_.isItemDamaged() ? 1.0F : 0.0F;
     };
-@@ -126,6 +126,7 @@
+@@ -126,6 +126,9 @@
        this.containerItem = p_i48487_1_.field_200922_c;
        this.maxDamage = p_i48487_1_.field_200921_b;
        this.maxStackSize = p_i48487_1_.field_200920_a;
 +      this.canRepair = p_i48487_1_.canRepair;
++      this.toolClasses.putAll(p_i48487_1_.toolClasses);
++      this.teisr = net.minecraftforge.fml.DistExecutor.callWhenOn(Dist.CLIENT, p_i48487_1_.teisr);
        if (this.maxDamage > 0) {
           this.addPropertyOverride(new ResourceLocation("damaged"), DAMAGED_GETTER);
           this.addPropertyOverride(new ResourceLocation("damage"), DAMAGE_GETTER);
-@@ -149,10 +150,12 @@
+@@ -149,10 +152,12 @@
        return stack;
     }
  
@@ -34,7 +36,7 @@
     public final int getMaxDamage() {
        return this.maxDamage;
     }
-@@ -207,6 +210,7 @@
+@@ -207,6 +212,7 @@
        return this.containerItem;
     }
  
@@ -42,7 +44,7 @@
     public boolean hasContainerItem() {
        return this.containerItem != null;
     }
-@@ -263,7 +267,7 @@
+@@ -263,7 +269,7 @@
     }
  
     public boolean isEnchantable(ItemStack stack) {
@@ -51,7 +53,7 @@
     }
  
     @Nullable
-@@ -280,8 +284,8 @@
+@@ -280,8 +286,8 @@
        float f5 = MathHelper.sin(-f * ((float)Math.PI / 180F));
        float f6 = f3 * f4;
        float f7 = f2 * f4;
@@ -62,7 +64,7 @@
        return worldIn.func_200259_a(vec3d, vec3d1, useLiquids ? RayTraceFluidMode.SOURCE_ONLY : RayTraceFluidMode.NEVER, false, false);
     }
  
-@@ -297,6 +301,7 @@
+@@ -297,6 +303,7 @@
     }
  
     protected boolean isInCreativeTab(ItemGroup targetTab) {
@@ -70,7 +72,7 @@
        ItemGroup itemgroup = this.getCreativeTab();
        return itemgroup != null && (targetTab == ItemGroup.SEARCH || targetTab == itemgroup);
     }
-@@ -310,10 +315,65 @@
+@@ -310,10 +317,49 @@
        return false;
     }
  
@@ -83,9 +85,9 @@
 +
 +   @OnlyIn(Dist.CLIENT)
 +   @Nullable
-+   private net.minecraft.client.renderer.tileentity.TileEntityItemStackRenderer teisr;
++   private final net.minecraft.client.renderer.tileentity.TileEntityItemStackRenderer teisr;
 +   
-+   private java.util.Map<String, Integer> toolClasses = new java.util.HashMap<String, Integer>();
++   private final java.util.Map<String, Integer> toolClasses = new java.util.HashMap<String, Integer>();
 +
 +   protected final boolean canRepair;
 +
@@ -93,15 +95,6 @@
 +   public boolean isRepairable()
 +   {
 +       return canRepair && isDamageable();
-+   }
-+
-+   @Override
-+   public void setHarvestLevel(String toolClass, int level)
-+   {
-+       if (level < 0)
-+           toolClasses.remove(toolClass);
-+       else
-+           toolClasses.put(toolClass, level);
 +   }
 +
 +   @Override
@@ -124,27 +117,22 @@
 +       return teisr != null ? teisr : net.minecraft.client.renderer.tileentity.TileEntityItemStackRenderer.instance;
 +   }
 +
-+   @OnlyIn(Dist.CLIENT)
-+   @Override
-+   public void setTileEntityItemStackRenderer(@Nullable net.minecraft.client.renderer.tileentity.TileEntityItemStackRenderer teisr)
-+   {
-+       this.teisr = teisr;
-+   }
-+   
 +   /* ======================================== FORGE END   =====================================*/
 +   
     public static void registerItems() {
        registerItemBlock(Blocks.AIR, new ItemAir(Blocks.AIR, new Item.Builder()));
        func_200879_a(Blocks.STONE, ItemGroup.BUILDING_BLOCKS);
-@@ -1147,6 +1207,7 @@
+@@ -1147,6 +1193,9 @@
        private Item field_200922_c;
        private ItemGroup field_200923_d;
        private EnumRarity field_208104_e = EnumRarity.COMMON;
 +      private boolean canRepair = true;
++      private java.util.Map<String, Integer> toolClasses = new java.util.HashMap<String, Integer>();
++      private java.util.function.Supplier<java.util.concurrent.Callable<net.minecraft.client.renderer.tileentity.TileEntityItemStackRenderer>> teisr;
  
        public Item.Builder func_200917_a(int p_200917_1_) {
           if (this.field_200921_b > 0) {
-@@ -1181,5 +1242,10 @@
+@@ -1181,5 +1230,27 @@
           this.field_208104_e = p_208103_1_;
           return this;
        }
@@ -153,5 +141,22 @@
 +          canRepair = false;
 +          return this;
     }
++
++      /**
++       * Sets or removes the harvest level for the specified tool class.
++       *
++       * @param toolClass Class
++       * @param level     Harvest level: Wood: 0 Stone: 1 Iron: 2 Diamond: 3 Gold: 0
++       */
++      public void setHarvestLevel(String toolClass, int level) {
++          if (level < 0)
++              toolClasses.remove(toolClass);
++          else
++              toolClasses.put(toolClass, level);
  }
++
++      public void setTileEntityItemStackRenderer(java.util.function.Supplier<java.util.concurrent.Callable<net.minecraft.client.renderer.tileentity.TileEntityItemStackRenderer>> teisrSupplier) {
++          this.teisr = teisrSupplier;
++      }
++   }
 +}

--- a/patches/minecraft/net/minecraft/item/ItemStack.java.patch
+++ b/patches/minecraft/net/minecraft/item/ItemStack.java.patch
@@ -5,22 +5,21 @@
  import org.apache.logging.log4j.Logger;
  
 -public final class ItemStack {
-+public final class ItemStack implements net.minecraftforge.common.capabilities.ICapabilitySerializable<NBTTagCompound> {
++public final class ItemStack extends net.minecraftforge.common.capabilities.CapabilityProvider implements net.minecraftforge.common.capabilities.ICapabilitySerializable<NBTTagCompound> {
     private static final Logger field_199558_c = LogManager.getLogger();
     public static final ItemStack EMPTY = new ItemStack((Item)null);
     public static final DecimalFormat DECIMALFORMAT = func_208306_D();
-@@ -79,6 +79,10 @@
+@@ -79,6 +79,9 @@
     private BlockWorldState canPlaceOnCacheBlock;
     private boolean canPlaceOnCacheResult;
  
 +   private net.minecraftforge.registries.IRegistryDelegate<Item> delegate;
-+   private net.minecraftforge.common.capabilities.CapabilityDispatcher capabilities;
 +   private NBTTagCompound capNBT;
 +
     private static DecimalFormat func_208306_D() {
        DecimalFormat decimalformat = new DecimalFormat("#.##");
        decimalformat.setDecimalFormatSymbols(DecimalFormatSymbols.getInstance(Locale.ROOT));
-@@ -89,10 +93,13 @@
+@@ -89,10 +92,13 @@
        this(p_i48203_1_, 1);
     }
  
@@ -35,7 +34,7 @@
     }
  
     private void updateEmptyState() {
-@@ -101,6 +108,7 @@
+@@ -101,6 +107,7 @@
     }
  
     private ItemStack(NBTTagCompound compound) {
@@ -43,7 +42,7 @@
        Item item = Item.REGISTRY.getObject(new ResourceLocation(compound.getString("id")));
        this.item = item == null ? Items.AIR : item;
        this.stackSize = compound.getByte("Count");
-@@ -114,6 +122,7 @@
+@@ -114,6 +121,7 @@
        }
  
        this.updateEmptyState();
@@ -51,7 +50,7 @@
     }
  
     public static ItemStack func_199557_a(NBTTagCompound p_199557_0_) {
-@@ -128,7 +137,7 @@
+@@ -128,7 +136,7 @@
     public boolean isEmpty() {
        if (this == EMPTY) {
           return true;
@@ -60,7 +59,7 @@
           return this.stackSize <= 0;
        } else {
           return true;
-@@ -144,10 +153,11 @@
+@@ -144,10 +152,11 @@
     }
  
     public Item getItem() {
@@ -73,7 +72,7 @@
        EntityPlayer entityplayer = p_196084_1_.func_195999_j();
        BlockPos blockpos = p_196084_1_.func_195995_a();
        BlockWorldState blockworldstate = new BlockWorldState(p_196084_1_.func_195991_k(), blockpos, false);
-@@ -164,6 +174,23 @@
+@@ -164,6 +173,23 @@
        }
     }
  
@@ -97,14 +96,14 @@
     public float getDestroySpeed(IBlockState blockIn) {
        return this.getItem().getDestroySpeed(this, blockIn);
     }
-@@ -183,12 +210,15 @@
+@@ -183,12 +209,15 @@
        if (this.stackTagCompound != null) {
           nbt.setTag("tag", this.stackTagCompound);
        }
 -
-+      if (this.capabilities != null) {
-+         NBTTagCompound cnbt = this.capabilities.serializeNBT();
-+         if (cnbt.getSize() > 0) nbt.setTag("ForgeCaps", cnbt);
++      NBTTagCompound cnbt = this.serializeCaps();
++      if (cnbt != null && !cnbt.isEmpty()) {
++         nbt.setTag("ForgeCaps", cnbt);
 +      }
        return nbt;
     }
@@ -115,7 +114,7 @@
     }
  
     public boolean isStackable() {
-@@ -196,7 +226,7 @@
+@@ -196,7 +225,7 @@
     }
  
     public boolean isItemStackDamageable() {
@@ -124,7 +123,7 @@
           NBTTagCompound nbttagcompound = this.getTagCompound();
           return nbttagcompound == null || !nbttagcompound.getBoolean("Unbreakable");
        } else {
-@@ -205,19 +235,19 @@
+@@ -205,19 +234,19 @@
     }
  
     public boolean isItemDamaged() {
@@ -149,7 +148,7 @@
     }
  
     public boolean attemptDamageItem(int amount, Random rand, @Nullable EntityPlayerMP damager) {
-@@ -285,7 +315,7 @@
+@@ -285,7 +314,7 @@
     }
  
     public boolean canHarvestBlock(IBlockState blockIn) {
@@ -158,16 +157,16 @@
     }
  
     public boolean interactWithEntity(EntityPlayer playerIn, EntityLivingBase entityIn, EnumHand hand) {
-@@ -293,7 +323,7 @@
+@@ -293,7 +322,7 @@
     }
  
     public ItemStack copy() {
 -      ItemStack itemstack = new ItemStack(this.getItem(), this.stackSize);
-+      ItemStack itemstack = new ItemStack(this.getItem(), this.stackSize, this.capabilities != null ? this.capabilities.serializeNBT() : null);
++      ItemStack itemstack = new ItemStack(this.getItem(), this.stackSize, this.serializeCaps());
        itemstack.setAnimationsToGo(this.getAnimationsToGo());
        if (this.stackTagCompound != null) {
           itemstack.stackTagCompound = this.stackTagCompound.copy();
-@@ -309,7 +339,7 @@
+@@ -309,7 +338,7 @@
           if (stackA.stackTagCompound == null && stackB.stackTagCompound != null) {
              return false;
           } else {
@@ -176,7 +175,7 @@
           }
        } else {
           return false;
-@@ -332,7 +362,7 @@
+@@ -332,7 +361,7 @@
        } else if (this.stackTagCompound == null && other.stackTagCompound != null) {
           return false;
        } else {
@@ -185,7 +184,7 @@
        }
     }
  
-@@ -633,6 +663,7 @@
+@@ -633,6 +662,7 @@
           }
        }
  
@@ -193,7 +192,7 @@
        return list;
     }
  
-@@ -743,7 +774,7 @@
+@@ -743,7 +773,7 @@
              }
           }
        } else {
@@ -202,18 +201,12 @@
        }
  
        return multimap;
-@@ -874,4 +905,123 @@
+@@ -874,4 +904,98 @@
     public void shrink(int quantity) {
        this.grow(-quantity);
     }
 +
 +   // FORGE START
-+
-+   @Override
-+   public <T> net.minecraftforge.common.capabilities.OptionalCapabilityInstance<T> getCapability(net.minecraftforge.common.capabilities.Capability<T> capability, @Nullable net.minecraft.util.EnumFacing facing)
-+   {
-+       return this.isEmpty || this.capabilities == null ? null : this.capabilities.getCapability(capability, facing);
- }
 +
 +   public void deserializeNBT(NBTTagCompound nbt)
 +   {
@@ -221,32 +214,13 @@
 +       final ItemStack itemStack = new ItemStack(nbt);
 +       this.stackTagCompound = itemStack.stackTagCompound;
 +       this.capNBT = itemStack.capNBT;
-+   }
+ }
 +
 +   public NBTTagCompound serializeNBT()
 +   {
 +       NBTTagCompound ret = new NBTTagCompound();
 +       this.writeToNBT(ret);
 +       return ret;
-+   }
-+
-+   public boolean areCapsCompatible(ItemStack other)
-+   {
-+       if (this.capabilities == null)
-+       {
-+           if (other.capabilities == null)
-+           {
-+               return true;
-+           }
-+           else
-+           {
-+               return other.capabilities.areCompatible(null);
-+           }
-+       }
-+       else
-+       {
-+           return this.capabilities.areCompatible(other.capabilities);
-+       }
 +   }
 +
 +   /**
@@ -259,8 +233,8 @@
 +       {
 +           this.delegate = item.delegate;
 +           net.minecraftforge.common.capabilities.ICapabilityProvider provider = item.initCapabilities(this, this.capNBT);
-+           this.capabilities = net.minecraftforge.event.ForgeEventFactory.gatherCapabilities(this, provider);
-+           if (this.capNBT != null && this.capabilities != null) this.capabilities.deserializeNBT(this.capNBT);
++           this.gatherCapabilities(provider);
++           if (this.capNBT != null) deserializeCaps(this.capNBT);
 +       }
 +   }
 +

--- a/patches/minecraft/net/minecraft/item/ItemStack.java.patch
+++ b/patches/minecraft/net/minecraft/item/ItemStack.java.patch
@@ -27,7 +27,7 @@
 -   public ItemStack(IItemProvider p_i48204_1_, int p_i48204_2_) {
 +   public ItemStack(IItemProvider p_i48204_1_, int p_i48204_2_){ this(p_i48204_1_, p_i48204_2_, null); }
 +   public ItemStack(IItemProvider p_i48204_1_, int p_i48204_2_, @Nullable NBTTagCompound capNBT) {
-+	  this.capNBT = capNBT;
++      this.capNBT = capNBT;
        this.item = p_i48204_1_ == null ? null : p_i48204_1_.func_199767_j();
        this.stackSize = p_i48204_2_;
        this.updateEmptyState();
@@ -39,7 +39,7 @@
     }
  
     private ItemStack(NBTTagCompound compound) {
-+	  this.capNBT = compound.hasKey("ForgeCaps") ? compound.getCompoundTag("ForgeCaps") : null;
++      this.capNBT = compound.hasKey("ForgeCaps") ? compound.getCompoundTag("ForgeCaps") : null;
        Item item = Item.REGISTRY.getObject(new ResourceLocation(compound.getString("id")));
        this.item = item == null ? Items.AIR : item;
        this.stackSize = compound.getByte("Count");
@@ -69,7 +69,7 @@
     }
  
     public EnumActionResult func_196084_a(ItemUseContext p_196084_1_) {
-+	  if (!p_196084_1_.field_196006_g.isRemote) return net.minecraftforge.common.ForgeHooks.onPlaceItemIntoWorld(p_196084_1_);
++      if (!p_196084_1_.field_196006_g.isRemote) return net.minecraftforge.common.ForgeHooks.onPlaceItemIntoWorld(p_196084_1_);
        EntityPlayer entityplayer = p_196084_1_.func_195999_j();
        BlockPos blockpos = p_196084_1_.func_195995_a();
        BlockWorldState blockworldstate = new BlockWorldState(p_196084_1_.func_195991_k(), blockpos, false);
@@ -103,8 +103,8 @@
        }
 -
 +      if (this.capabilities != null) {
-+    	 NBTTagCompound cnbt = this.capabilities.serializeNBT();
-+    	 if (cnbt.getSize() > 0) nbt.setTag("ForgeCaps", cnbt);
++         NBTTagCompound cnbt = this.capabilities.serializeNBT();
++         if (cnbt.getSize() > 0) nbt.setTag("ForgeCaps", cnbt);
 +      }
        return nbt;
     }
@@ -135,12 +135,12 @@
 -   public int getItemDamage() {
 -      return this.stackTagCompound == null ? 0 : this.stackTagCompound.getInteger("Damage");
 +   public int getItemDamage() { // TODO evaluate the necessity of this patch
-+	  return this.getItem().getDamage(this);
++      return this.getItem().getDamage(this);
     }
  
     public void func_196085_b(int p_196085_1_) {
 -      this.func_196082_o().setInteger("Damage", Math.max(0, p_196085_1_));
-+	  getItem().setDamage(this, p_196085_1_);
++      getItem().setDamage(this, p_196085_1_);
     }
  
     public int getMaxDamage() {
@@ -198,7 +198,7 @@
           }
        } else {
 -         multimap = this.getItem().getItemAttributeModifiers(equipmentSlot);
-+    	  multimap = this.getItem().getAttributeModifiers(equipmentSlot, this);
++          multimap = this.getItem().getAttributeModifiers(equipmentSlot, this);
        }
  
        return multimap;
@@ -212,7 +212,7 @@
 +   @Override
 +   public <T> net.minecraftforge.common.capabilities.OptionalCapabilityInstance<T> getCapability(net.minecraftforge.common.capabilities.Capability<T> capability, @Nullable net.minecraft.util.EnumFacing facing)
 +   {
-+	   return this.isEmpty || this.capabilities == null ? null : this.capabilities.getCapability(capability, facing);
++       return this.isEmpty || this.capabilities == null ? null : this.capabilities.getCapability(capability, facing);
  }
 +
 +   public void deserializeNBT(NBTTagCompound nbt)

--- a/patches/minecraft/net/minecraft/item/ItemStack.java.patch
+++ b/patches/minecraft/net/minecraft/item/ItemStack.java.patch
@@ -1,0 +1,329 @@
+--- a/net/minecraft/item/ItemStack.java
++++ b/net/minecraft/item/ItemStack.java
+@@ -63,7 +63,7 @@
+ import org.apache.logging.log4j.LogManager;
+ import org.apache.logging.log4j.Logger;
+ 
+-public final class ItemStack {
++public final class ItemStack implements net.minecraftforge.common.capabilities.ICapabilitySerializable<NBTTagCompound> {
+    private static final Logger field_199558_c = LogManager.getLogger();
+    public static final ItemStack EMPTY = new ItemStack((Item)null);
+    public static final DecimalFormat DECIMALFORMAT = func_208306_D();
+@@ -79,6 +79,10 @@
+    private BlockWorldState canPlaceOnCacheBlock;
+    private boolean canPlaceOnCacheResult;
+ 
++   private net.minecraftforge.registries.IRegistryDelegate<Item> delegate;
++   private net.minecraftforge.common.capabilities.CapabilityDispatcher capabilities;
++   private NBTTagCompound capNBT;
++
+    private static DecimalFormat func_208306_D() {
+       DecimalFormat decimalformat = new DecimalFormat("#.##");
+       decimalformat.setDecimalFormatSymbols(DecimalFormatSymbols.getInstance(Locale.ROOT));
+@@ -89,10 +93,13 @@
+       this(p_i48203_1_, 1);
+    }
+ 
+-   public ItemStack(IItemProvider p_i48204_1_, int p_i48204_2_) {
++   public ItemStack(IItemProvider p_i48204_1_, int p_i48204_2_){ this(p_i48204_1_, p_i48204_2_, null); }
++   public ItemStack(IItemProvider p_i48204_1_, int p_i48204_2_, @Nullable NBTTagCompound capNBT) {
++	  this.capNBT = capNBT;
+       this.item = p_i48204_1_ == null ? null : p_i48204_1_.func_199767_j();
+       this.stackSize = p_i48204_2_;
+       this.updateEmptyState();
++      this.forgeInit();
+    }
+ 
+    private void updateEmptyState() {
+@@ -101,6 +108,7 @@
+    }
+ 
+    private ItemStack(NBTTagCompound compound) {
++	  this.capNBT = compound.hasKey("ForgeCaps") ? compound.getCompoundTag("ForgeCaps") : null;
+       Item item = Item.REGISTRY.getObject(new ResourceLocation(compound.getString("id")));
+       this.item = item == null ? Items.AIR : item;
+       this.stackSize = compound.getByte("Count");
+@@ -114,6 +122,7 @@
+       }
+ 
+       this.updateEmptyState();
++      this.forgeInit();
+    }
+ 
+    public static ItemStack func_199557_a(NBTTagCompound p_199557_0_) {
+@@ -128,7 +137,7 @@
+    public boolean isEmpty() {
+       if (this == EMPTY) {
+          return true;
+-      } else if (this.getItem() != null && this.getItem() != Items.AIR) {
++      } else if (this.getItemRaw() != null && this.getItemRaw() != Items.AIR) {
+          return this.stackSize <= 0;
+       } else {
+          return true;
+@@ -144,10 +153,11 @@
+    }
+ 
+    public Item getItem() {
+-      return this.isEmpty ? Items.AIR : this.item;
++      return this.isEmpty || this.delegate == null ? Items.AIR : this.delegate.get();
+    }
+ 
+    public EnumActionResult func_196084_a(ItemUseContext p_196084_1_) {
++	  if (!p_196084_1_.field_196006_g.isRemote) return net.minecraftforge.common.ForgeHooks.onPlaceItemIntoWorld(p_196084_1_);
+       EntityPlayer entityplayer = p_196084_1_.func_195999_j();
+       BlockPos blockpos = p_196084_1_.func_195995_a();
+       BlockWorldState blockworldstate = new BlockWorldState(p_196084_1_.func_195991_k(), blockpos, false);
+@@ -164,6 +174,23 @@
+       }
+    }
+ 
++   public EnumActionResult onItemUseFirst(ItemUseContext p_196084_1_) {
++      EntityPlayer entityplayer = p_196084_1_.func_195999_j();
++      BlockPos blockpos = p_196084_1_.func_195995_a();
++      BlockWorldState blockworldstate = new BlockWorldState(p_196084_1_.func_195991_k(), blockpos, false);
++      if (entityplayer != null && !entityplayer.capabilities.allowEdit && !this.func_206847_b(p_196084_1_.func_195991_k().func_205772_D(), blockworldstate)) {
++         return EnumActionResult.PASS;
++      } else {
++         Item item = this.getItem();
++         EnumActionResult enumactionresult = item.onItemUseFirst(p_196084_1_);
++         if (entityplayer != null && enumactionresult == EnumActionResult.SUCCESS) {
++            entityplayer.addStat(StatList.OBJECT_USE_STATS.func_199076_b(item));
++         }
++
++         return enumactionresult;
++      }
++   }
++
+    public float getDestroySpeed(IBlockState blockIn) {
+       return this.getItem().getDestroySpeed(this, blockIn);
+    }
+@@ -183,12 +210,15 @@
+       if (this.stackTagCompound != null) {
+          nbt.setTag("tag", this.stackTagCompound);
+       }
+-
++      if (this.capabilities != null) {
++    	 NBTTagCompound cnbt = this.capabilities.serializeNBT();
++    	 if (cnbt.getSize() > 0) nbt.setTag("ForgeCaps", cnbt);
++      }
+       return nbt;
+    }
+ 
+    public int getMaxStackSize() {
+-      return this.getItem().getItemStackLimit();
++      return this.getItem().getItemStackLimit(this);
+    }
+ 
+    public boolean isStackable() {
+@@ -196,7 +226,7 @@
+    }
+ 
+    public boolean isItemStackDamageable() {
+-      if (!this.isEmpty && this.getItem().getMaxDamage() > 0) {
++      if (!this.isEmpty && this.getItem().getMaxDamage(this) > 0) {
+          NBTTagCompound nbttagcompound = this.getTagCompound();
+          return nbttagcompound == null || !nbttagcompound.getBoolean("Unbreakable");
+       } else {
+@@ -205,19 +235,19 @@
+    }
+ 
+    public boolean isItemDamaged() {
+-      return this.isItemStackDamageable() && this.getItemDamage() > 0;
++      return this.isItemStackDamageable() && getItem().isDamaged(this);
+    }
+ 
+-   public int getItemDamage() {
+-      return this.stackTagCompound == null ? 0 : this.stackTagCompound.getInteger("Damage");
++   public int getItemDamage() { // TODO evaluate the necessity of this patch
++	  return this.getItem().getDamage(this);
+    }
+ 
+    public void func_196085_b(int p_196085_1_) {
+-      this.func_196082_o().setInteger("Damage", Math.max(0, p_196085_1_));
++	  getItem().setDamage(this, p_196085_1_);
+    }
+ 
+    public int getMaxDamage() {
+-      return this.getItem().getMaxDamage();
++      return this.getItem().getMaxDamage(this);
+    }
+ 
+    public boolean attemptDamageItem(int amount, Random rand, @Nullable EntityPlayerMP damager) {
+@@ -285,7 +315,7 @@
+    }
+ 
+    public boolean canHarvestBlock(IBlockState blockIn) {
+-      return this.getItem().canHarvestBlock(blockIn);
++      return this.getItem().canHarvestBlock(blockIn, this);
+    }
+ 
+    public boolean interactWithEntity(EntityPlayer playerIn, EntityLivingBase entityIn, EnumHand hand) {
+@@ -293,7 +323,7 @@
+    }
+ 
+    public ItemStack copy() {
+-      ItemStack itemstack = new ItemStack(this.getItem(), this.stackSize);
++      ItemStack itemstack = new ItemStack(this.getItem(), this.stackSize, this.capabilities != null ? this.capabilities.serializeNBT() : null);
+       itemstack.setAnimationsToGo(this.getAnimationsToGo());
+       if (this.stackTagCompound != null) {
+          itemstack.stackTagCompound = this.stackTagCompound.copy();
+@@ -309,7 +339,7 @@
+          if (stackA.stackTagCompound == null && stackB.stackTagCompound != null) {
+             return false;
+          } else {
+-            return stackA.stackTagCompound == null || stackA.stackTagCompound.equals(stackB.stackTagCompound);
++            return stackA.stackTagCompound == null || stackA.stackTagCompound.equals(stackB.stackTagCompound) && stackA.areCapsCompatible(stackB);
+          }
+       } else {
+          return false;
+@@ -332,7 +362,7 @@
+       } else if (this.stackTagCompound == null && other.stackTagCompound != null) {
+          return false;
+       } else {
+-         return this.stackTagCompound == null || this.stackTagCompound.equals(other.stackTagCompound);
++         return this.stackTagCompound == null || this.stackTagCompound.equals(other.stackTagCompound) && this.areCapsCompatible(other);
+       }
+    }
+ 
+@@ -633,6 +663,7 @@
+          }
+       }
+ 
++      net.minecraftforge.event.ForgeEventFactory.onItemTooltip(this, playerIn, list, advanced);
+       return list;
+    }
+ 
+@@ -743,7 +774,7 @@
+             }
+          }
+       } else {
+-         multimap = this.getItem().getItemAttributeModifiers(equipmentSlot);
++    	  multimap = this.getItem().getAttributeModifiers(equipmentSlot, this);
+       }
+ 
+       return multimap;
+@@ -874,4 +905,124 @@
+    public void shrink(int quantity) {
+       this.grow(-quantity);
+    }
++
++   // FORGE START
++
++   @Override
++   @Nullable
++   public <T> net.minecraftforge.common.capabilities.OptionalCapabilityInstance<T> getCapability(net.minecraftforge.common.capabilities.Capability<T> capability, @Nullable net.minecraft.util.EnumFacing facing)
++   {
++	   return this.isEmpty || this.capabilities == null ? null : this.capabilities.getCapability(capability, facing);
+ }
++
++   public void deserializeNBT(NBTTagCompound nbt)
++   {
++       // TODO do this better while respecting new rules
++       final ItemStack itemStack = new ItemStack(nbt);
++       this.stackTagCompound = itemStack.stackTagCompound;
++       this.capNBT = itemStack.capNBT;
++   }
++
++   public NBTTagCompound serializeNBT()
++   {
++       NBTTagCompound ret = new NBTTagCompound();
++       this.writeToNBT(ret);
++       return ret;
++   }
++
++   public boolean areCapsCompatible(ItemStack other)
++   {
++       if (this.capabilities == null)
++       {
++           if (other.capabilities == null)
++           {
++               return true;
++           }
++           else
++           {
++               return other.capabilities.areCompatible(null);
++           }
++       }
++       else
++       {
++           return this.capabilities.areCompatible(other.capabilities);
++       }
++   }
++
++   /**
++    * Set up forge's ItemStack additions.
++    */
++   private void forgeInit()
++   {
++       Item item = getItemRaw();
++       if (item != null)
++       {
++           this.delegate = item.delegate;
++           net.minecraftforge.common.capabilities.ICapabilityProvider provider = item.initCapabilities(this, this.capNBT);
++           this.capabilities = net.minecraftforge.event.ForgeEventFactory.gatherCapabilities(this, provider);
++           if (this.capNBT != null && this.capabilities != null) this.capabilities.deserializeNBT(this.capNBT);
++       }
++   }
++
++   /**
++    * Internal call to get the actual item, not the delegate.
++    * In all other methods, FML replaces calls to this.item with the item delegate.
++    */
++   @Nullable
++   private Item getItemRaw()
++   {
++       return this.item;
++   }
++
++   /**
++    * Modeled after ItemStack.areItemStacksEqual
++    * Uses Item.getNBTShareTag for comparison instead of NBT and capabilities.
++    * Only used for comparing itemStacks that were transferred from server to client using Item.getNBTShareTag.
++    */
++   public static boolean areItemStacksEqualUsingNBTShareTag(ItemStack stackA, ItemStack stackB)
++   {
++       if (stackA.isEmpty())
++           return stackB.isEmpty();
++       else
++           return !stackB.isEmpty() && stackA.isItemStackEqualUsingNBTShareTag(stackB);
++   }
++
++   /**
++    * Modeled after ItemStack.isItemStackEqual
++    * Uses Item.getNBTShareTag for comparison instead of NBT and capabilities.
++    * Only used for comparing itemStacks that were transferred from server to client using Item.getNBTShareTag.
++    */
++   private boolean isItemStackEqualUsingNBTShareTag(ItemStack other)
++   {
++       return this.stackSize == other.stackSize && this.getItem() == other.getItem() && areItemStackShareTagsEqual(this, other);
++   }
++
++   /**
++    * Modeled after ItemStack.areItemStackTagsEqual
++    * Uses Item.getNBTShareTag for comparison instead of NBT and capabilities.
++    * Only used for comparing itemStacks that were transferred from server to client using Item.getNBTShareTag.
++    */
++   public static boolean areItemStackShareTagsEqual(ItemStack stackA, ItemStack stackB)
++   {
++       NBTTagCompound shareTagA = stackA.getItem().getNBTShareTag(stackA);
++       NBTTagCompound shareTagB = stackB.getItem().getNBTShareTag(stackB);
++       if (shareTagA == null)
++           return shareTagB == null;
++       else
++           return shareTagB != null && shareTagA.equals(shareTagB);
++   }
++
++   /**
++    *
++    * Should this item, when held, allow sneak-clicks to pass through to the underlying block?
++    *
++    * @param world The world
++    * @param pos Block position in world
++    * @param player The Player that is wielding the item
++    * @return
++    */
++   public boolean doesSneakBypassUse(net.minecraft.world.IWorldReader world, BlockPos pos, EntityPlayer player)
++   {
++       return this.isEmpty() || this.getItem().doesSneakBypassUse(this, world, pos, player);
++   }
++}

--- a/patches/minecraft/net/minecraft/item/ItemStack.java.patch
+++ b/patches/minecraft/net/minecraft/item/ItemStack.java.patch
@@ -202,7 +202,7 @@
        }
  
        return multimap;
-@@ -874,4 +905,124 @@
+@@ -874,4 +905,123 @@
     public void shrink(int quantity) {
        this.grow(-quantity);
     }
@@ -210,7 +210,6 @@
 +   // FORGE START
 +
 +   @Override
-+   @Nullable
 +   public <T> net.minecraftforge.common.capabilities.OptionalCapabilityInstance<T> getCapability(net.minecraftforge.common.capabilities.Capability<T> capability, @Nullable net.minecraft.util.EnumFacing facing)
 +   {
 +	   return this.isEmpty || this.capabilities == null ? null : this.capabilities.getCapability(capability, facing);

--- a/patches/minecraft/net/minecraft/tileentity/TileEntity.java.patch
+++ b/patches/minecraft/net/minecraft/tileentity/TileEntity.java.patch
@@ -21,7 +21,7 @@
     private static final Logger LOGGER = LogManager.getLogger();
     private final TileEntityType<?> field_200663_e;
     protected World world;
-@@ -179,4 +182,15 @@
+@@ -179,4 +182,14 @@
     public TileEntityType<?> func_200662_C() {
        return this.field_200663_e;
     }
@@ -31,7 +31,6 @@
 +   private net.minecraftforge.common.capabilities.CapabilityDispatcher capabilities;
 +
 +   @Override
-+   @Nonnull
 +   public <T> net.minecraftforge.common.capabilities.OptionalCapabilityInstance<T> getCapability(net.minecraftforge.common.capabilities.Capability<T> capability, @Nullable net.minecraft.util.EnumFacing facing)
 +   {
 +       return capabilities == null ? OptionalCapabilityInstance.empty() : capabilities.getCapability(capability, facing);

--- a/patches/minecraft/net/minecraft/tileentity/TileEntity.java.patch
+++ b/patches/minecraft/net/minecraft/tileentity/TileEntity.java.patch
@@ -1,0 +1,39 @@
+--- a/net/minecraft/tileentity/TileEntity.java
++++ b/net/minecraft/tileentity/TileEntity.java
+@@ -1,5 +1,6 @@
+ package net.minecraft.tileentity;
+ 
++import javax.annotation.Nonnull;
+ import javax.annotation.Nullable;
+ import net.minecraft.block.state.IBlockState;
+ import net.minecraft.crash.CrashReportCategory;
+@@ -12,10 +13,12 @@
+ import net.minecraft.world.World;
+ import net.minecraftforge.api.distmarker.Dist;
+ import net.minecraftforge.api.distmarker.OnlyIn;
++import net.minecraftforge.common.capabilities.OptionalCapabilityInstance;
++
+ import org.apache.logging.log4j.LogManager;
+ import org.apache.logging.log4j.Logger;
+ 
+-public abstract class TileEntity {
++public abstract class TileEntity implements net.minecraftforge.common.extensions.IForgeTileEntity {
+    private static final Logger LOGGER = LogManager.getLogger();
+    private final TileEntityType<?> field_200663_e;
+    protected World world;
+@@ -179,4 +182,15 @@
+    public TileEntityType<?> func_200662_C() {
+       return this.field_200663_e;
+    }
++   
++   // -- BEGIN FORGE PATCHES --
++
++   private net.minecraftforge.common.capabilities.CapabilityDispatcher capabilities;
++
++   @Override
++   @Nonnull
++   public <T> net.minecraftforge.common.capabilities.OptionalCapabilityInstance<T> getCapability(net.minecraftforge.common.capabilities.Capability<T> capability, @Nullable net.minecraft.util.EnumFacing facing)
++   {
++       return capabilities == null ? OptionalCapabilityInstance.empty() : capabilities.getCapability(capability, facing);
+ }
++}

--- a/patches/minecraft/net/minecraft/tileentity/TileEntity.java.patch
+++ b/patches/minecraft/net/minecraft/tileentity/TileEntity.java.patch
@@ -9,22 +9,15 @@
  import org.apache.logging.log4j.Logger;
  
 -public abstract class TileEntity {
-+public abstract class TileEntity implements net.minecraftforge.common.extensions.IForgeTileEntity {
++public abstract class TileEntity extends net.minecraftforge.common.capabilities.CapabilityProvider implements net.minecraftforge.common.extensions.IForgeTileEntity {
     private static final Logger LOGGER = LogManager.getLogger();
     private final TileEntityType<?> field_200663_e;
     protected World world;
-@@ -179,4 +180,14 @@
-    public TileEntityType<?> func_200662_C() {
-       return this.field_200663_e;
+@@ -26,6 +27,7 @@
+ 
+    public TileEntity(TileEntityType<?> p_i48289_1_) {
+       this.field_200663_e = p_i48289_1_;
++      this.gatherCapabilities();
     }
-+   
-+   // -- BEGIN FORGE PATCHES --
-+
-+   private net.minecraftforge.common.capabilities.CapabilityDispatcher capabilities;
-+
-+   @Override
-+   public <T> net.minecraftforge.common.capabilities.OptionalCapabilityInstance<T> getCapability(net.minecraftforge.common.capabilities.Capability<T> capability, @Nullable net.minecraft.util.EnumFacing facing)
-+   {
-+       return capabilities == null ? net.minecraftforge.common.capabilities.OptionalCapabilityInstance.empty() : capabilities.getCapability(capability, facing);
- }
-+}
+ 
+    @Nullable

--- a/patches/minecraft/net/minecraft/tileentity/TileEntity.java.patch
+++ b/patches/minecraft/net/minecraft/tileentity/TileEntity.java.patch
@@ -1,17 +1,9 @@
 --- a/net/minecraft/tileentity/TileEntity.java
 +++ b/net/minecraft/tileentity/TileEntity.java
-@@ -1,5 +1,6 @@
- package net.minecraft.tileentity;
- 
-+import javax.annotation.Nonnull;
- import javax.annotation.Nullable;
- import net.minecraft.block.state.IBlockState;
- import net.minecraft.crash.CrashReportCategory;
-@@ -12,10 +13,12 @@
+@@ -12,10 +12,11 @@
  import net.minecraft.world.World;
  import net.minecraftforge.api.distmarker.Dist;
  import net.minecraftforge.api.distmarker.OnlyIn;
-+import net.minecraftforge.common.capabilities.OptionalCapabilityInstance;
 +
  import org.apache.logging.log4j.LogManager;
  import org.apache.logging.log4j.Logger;
@@ -21,7 +13,7 @@
     private static final Logger LOGGER = LogManager.getLogger();
     private final TileEntityType<?> field_200663_e;
     protected World world;
-@@ -179,4 +182,14 @@
+@@ -179,4 +180,14 @@
     public TileEntityType<?> func_200662_C() {
        return this.field_200663_e;
     }
@@ -33,6 +25,6 @@
 +   @Override
 +   public <T> net.minecraftforge.common.capabilities.OptionalCapabilityInstance<T> getCapability(net.minecraftforge.common.capabilities.Capability<T> capability, @Nullable net.minecraft.util.EnumFacing facing)
 +   {
-+       return capabilities == null ? OptionalCapabilityInstance.empty() : capabilities.getCapability(capability, facing);
++       return capabilities == null ? net.minecraftforge.common.capabilities.OptionalCapabilityInstance.empty() : capabilities.getCapability(capability, facing);
  }
 +}

--- a/patches/minecraft/net/minecraft/village/Village.java.patch
+++ b/patches/minecraft/net/minecraft/village/Village.java.patch
@@ -1,0 +1,42 @@
+--- a/net/minecraft/village/Village.java
++++ b/net/minecraft/village/Village.java
+@@ -30,7 +30,7 @@
+ import net.minecraft.util.text.ITextComponent;
+ import net.minecraft.world.World;
+ 
+-public class Village {
++public class Village extends net.minecraftforge.common.capabilities.CapabilityProvider implements net.minecraftforge.common.extensions.IForgeVillage {
+    private World world;
+    private final List<VillageDoorInfo> villageDoorInfoList = Lists.<VillageDoorInfo>newArrayList();
+    private BlockPos centerHelper = BlockPos.ORIGIN;
+@@ -45,10 +45,12 @@
+    private int numIronGolems;
+ 
+    public Village() {
++       this.gatherCapabilities();
+    }
+ 
+    public Village(World worldIn) {
+       this.world = worldIn;
++      this.gatherCapabilities();
+    }
+ 
+    public void setWorld(World worldIn) {
+@@ -364,7 +366,7 @@
+             this.playerReputation.put(nbttagcompound1.getString("Name"), nbttagcompound1.getInteger("S"));
+          }
+       }
+-
++      if (compound.hasKey("ForgeCaps")) this.deserializeCaps(compound.getCompoundTag("ForgeCaps"));
+    }
+ 
+    public void writeVillageDataToNBT(NBTTagCompound compound) {
+@@ -413,6 +415,8 @@
+       }
+ 
+       compound.setTag("Players", nbttaglist1);
++      NBTTagCompound capTag = this.serializeCaps();
++      if (capTag != null) compound.setTag("ForgeCaps", capTag);
+    }
+ 
+    public void endMatingSeason() {

--- a/patches/minecraft/net/minecraft/world/World.java.patch
+++ b/patches/minecraft/net/minecraft/world/World.java.patch
@@ -9,7 +9,7 @@
  import org.apache.logging.log4j.Logger;
  
 -public abstract class World implements IWorld, IWorldReader, AutoCloseable {
-+public abstract class World implements IWorld, IWorldReader, AutoCloseable, net.minecraftforge.common.extensions.IForgeWorld {
++public abstract class World extends net.minecraftforge.common.capabilities.CapabilityProvider implements IWorld, IWorldReader, AutoCloseable, net.minecraftforge.common.extensions.IForgeWorld {
     protected static final Logger field_195596_d = LogManager.getLogger();
     private static final EnumFacing[] field_200007_a = EnumFacing.values();
     private int seaLevel = 63;
@@ -21,37 +21,30 @@
     }
  
     public IWorld init() {
-@@ -2397,4 +2399,38 @@
+@@ -2397,4 +2399,31 @@
     public abstract RecipeManager func_199532_z();
  
     public abstract NetworkTagManager func_205772_D();
 +
 +   /* ======================================== FORGE START =====================================*/
 +
-+   private net.minecraftforge.common.capabilities.CapabilityDispatcher capabilities;
 +   private net.minecraftforge.common.util.WorldCapabilityData capabilityData;
 +   
 +   protected void initCapabilities()
 +   {
 +       net.minecraftforge.common.capabilities.ICapabilityProvider parent = provider.initCapabilities();
-+       capabilities = net.minecraftforge.event.ForgeEventFactory.gatherCapabilities(this, parent);
++       this.gatherCapabilities(parent);
 +       net.minecraftforge.common.util.WorldCapabilityData data = (net.minecraftforge.common.util.WorldCapabilityData)perWorldStorage.func_201067_a(net.minecraftforge.common.util.WorldCapabilityData::new, net.minecraftforge.common.util.WorldCapabilityData.ID);
 +       if (data == null)
 +       {
-+           capabilityData = new net.minecraftforge.common.util.WorldCapabilityData(capabilities);
++           capabilityData = new net.minecraftforge.common.util.WorldCapabilityData(getCapabilities());
 +           perWorldStorage.setData(capabilityData.func_195925_e(), capabilityData);
  }
 +       else
 +       {
 +           capabilityData = data;
-+           capabilityData.setCapabilities(provider, capabilities);
++           capabilityData.setCapabilities(provider, getCapabilities());
 +       }
-+   }
-+   
-+   @Override
-+   public <T> net.minecraftforge.common.capabilities.OptionalCapabilityInstance<T> getCapability(net.minecraftforge.common.capabilities.Capability<T> capability, @Nullable EnumFacing facing)
-+   {
-+       return capabilities == null ? net.minecraftforge.common.capabilities.OptionalCapabilityInstance.empty() : capabilities.getCapability(capability, facing);
 +   }
 +   
 +   protected WorldSavedDataStorage perWorldStorage; //Moved to a getter to simulate final without being final so we can load in subclasses.

--- a/patches/minecraft/net/minecraft/world/World.java.patch
+++ b/patches/minecraft/net/minecraft/world/World.java.patch
@@ -1,0 +1,62 @@
+--- a/net/minecraft/world/World.java
++++ b/net/minecraft/world/World.java
+@@ -68,10 +68,11 @@
+ import net.minecraft.world.storage.WorldSavedDataStorage;
+ import net.minecraftforge.api.distmarker.Dist;
+ import net.minecraftforge.api.distmarker.OnlyIn;
++
+ import org.apache.logging.log4j.LogManager;
+ import org.apache.logging.log4j.Logger;
+ 
+-public abstract class World implements IWorld, IWorldReader, AutoCloseable {
++public abstract class World implements IWorld, IWorldReader, AutoCloseable, net.minecraftforge.common.extensions.IForgeWorld {
+    protected static final Logger field_195596_d = LogManager.getLogger();
+    private static final EnumFacing[] field_200007_a = EnumFacing.values();
+    private int seaLevel = 63;
+@@ -121,6 +122,7 @@
+       this.provider = providerIn;
+       this.isRemote = client;
+       this.worldBorder = providerIn.createWorldBorder();
++      perWorldStorage = new WorldSavedDataStorage((ISaveHandler)null);
+    }
+ 
+    public IWorld init() {
+@@ -2397,4 +2399,38 @@
+    public abstract RecipeManager func_199532_z();
+ 
+    public abstract NetworkTagManager func_205772_D();
++
++   /* ======================================== FORGE START =====================================*/
++
++   private net.minecraftforge.common.capabilities.CapabilityDispatcher capabilities;
++   private net.minecraftforge.common.util.WorldCapabilityData capabilityData;
++   
++   protected void initCapabilities()
++   {
++       net.minecraftforge.common.capabilities.ICapabilityProvider parent = provider.initCapabilities();
++       capabilities = net.minecraftforge.event.ForgeEventFactory.gatherCapabilities(this, parent);
++       net.minecraftforge.common.util.WorldCapabilityData data = (net.minecraftforge.common.util.WorldCapabilityData)perWorldStorage.func_201067_a(net.minecraftforge.common.util.WorldCapabilityData::new, net.minecraftforge.common.util.WorldCapabilityData.ID);
++       if (data == null)
++       {
++           capabilityData = new net.minecraftforge.common.util.WorldCapabilityData(capabilities);
++           perWorldStorage.setData(capabilityData.func_195925_e(), capabilityData);
+ }
++       else
++       {
++           capabilityData = data;
++           capabilityData.setCapabilities(provider, capabilities);
++       }
++   }
++   
++   @Override
++   public <T> net.minecraftforge.common.capabilities.OptionalCapabilityInstance<T> getCapability(net.minecraftforge.common.capabilities.Capability<T> capability, @Nullable EnumFacing facing)
++   {
++       return capabilities == null ? net.minecraftforge.common.capabilities.OptionalCapabilityInstance.empty() : capabilities.getCapability(capability, facing);
++   }
++   
++   protected WorldSavedDataStorage perWorldStorage; //Moved to a getter to simulate final without being final so we can load in subclasses.
++   public WorldSavedDataStorage getPerWorldStorage()
++   {
++       return perWorldStorage;
++   }
++}

--- a/patches/minecraft/net/minecraft/world/WorldServer.java.patch
+++ b/patches/minecraft/net/minecraft/world/WorldServer.java.patch
@@ -1,0 +1,10 @@
+--- a/net/minecraft/world/WorldServer.java
++++ b/net/minecraft/world/WorldServer.java
+@@ -150,6 +150,7 @@
+          this.getWorldBorder().setTransition(this.worldInfo.getBorderSize());
+       }
+ 
++      this.initCapabilities();
+       return this;
+    }
+ 

--- a/patches/minecraft/net/minecraft/world/WorldServerMulti.java.patch
+++ b/patches/minecraft/net/minecraft/world/WorldServerMulti.java.patch
@@ -1,0 +1,10 @@
+--- a/net/minecraft/world/WorldServerMulti.java
++++ b/net/minecraft/world/WorldServerMulti.java
+@@ -60,6 +60,7 @@
+          this.villageCollection.setWorldsForAll(this);
+       }
+ 
++      this.initCapabilities();
+       return this;
+    }
+ 

--- a/patches/minecraft/net/minecraft/world/chunk/Chunk.java.patch
+++ b/patches/minecraft/net/minecraft/world/chunk/Chunk.java.patch
@@ -5,7 +5,7 @@
  import org.apache.logging.log4j.Logger;
  
 -public class Chunk implements IChunk {
-+public class Chunk implements IChunk, net.minecraftforge.common.extensions.IForgeChunk {
++public class Chunk extends net.minecraftforge.common.capabilities.CapabilityProvider implements IChunk, net.minecraftforge.common.extensions.IForgeChunk {
     private static final Logger LOGGER = LogManager.getLogger();
     public static final ChunkSection NULL_BLOCK_STORAGE = null;
     private final ChunkSection[] storageArrays;
@@ -13,28 +13,7 @@
        this.field_201621_s = p_i49379_6_;
        this.field_205325_u = p_i49379_7_;
        this.inhabitedTime = p_i49379_8_;
-+      capabilities = net.minecraftforge.event.ForgeEventFactory.gatherCapabilities(this);
++      this.gatherCapabilities();
     }
  
     public Chunk(World p_i48703_1_, ChunkPrimer p_i48703_2_, int p_i48703_3_, int p_i48703_4_) {
-@@ -1164,4 +1165,20 @@
-       QUEUED,
-       CHECK;
-    }
-+   
-+   /* ======================================== FORGE START =====================================*/
-+   
-+   private final net.minecraftforge.common.capabilities.CapabilityDispatcher capabilities;
-+   
-+   @Nullable
-+   public net.minecraftforge.common.capabilities.CapabilityDispatcher getCapabilities()
-+   {
-+       return capabilities;
- }
-+
-+   @Override
-+   public <T> net.minecraftforge.common.capabilities.OptionalCapabilityInstance<T> getCapability(net.minecraftforge.common.capabilities.Capability<T> capability, @Nullable EnumFacing facing)
-+   {
-+       return capabilities == null ? net.minecraftforge.common.capabilities.OptionalCapabilityInstance.empty() : capabilities.getCapability(capability, facing);
-+   }
-+}

--- a/patches/minecraft/net/minecraft/world/chunk/Chunk.java.patch
+++ b/patches/minecraft/net/minecraft/world/chunk/Chunk.java.patch
@@ -1,0 +1,40 @@
+--- a/net/minecraft/world/chunk/Chunk.java
++++ b/net/minecraft/world/chunk/Chunk.java
+@@ -53,7 +53,7 @@
+ import org.apache.logging.log4j.LogManager;
+ import org.apache.logging.log4j.Logger;
+ 
+-public class Chunk implements IChunk {
++public class Chunk implements IChunk, net.minecraftforge.common.extensions.IForgeChunk {
+    private static final Logger LOGGER = LogManager.getLogger();
+    public static final ChunkSection NULL_BLOCK_STORAGE = null;
+    private final ChunkSection[] storageArrays;
+@@ -125,6 +125,7 @@
+       this.field_201621_s = p_i49379_6_;
+       this.field_205325_u = p_i49379_7_;
+       this.inhabitedTime = p_i49379_8_;
++      capabilities = net.minecraftforge.event.ForgeEventFactory.gatherCapabilities(this);
+    }
+ 
+    public Chunk(World p_i48703_1_, ChunkPrimer p_i48703_2_, int p_i48703_3_, int p_i48703_4_) {
+@@ -1164,4 +1165,20 @@
+       QUEUED,
+       CHECK;
+    }
++   
++   /* ======================================== FORGE START =====================================*/
++   
++   private final net.minecraftforge.common.capabilities.CapabilityDispatcher capabilities;
++   
++   @Nullable
++   public net.minecraftforge.common.capabilities.CapabilityDispatcher getCapabilities()
++   {
++       return capabilities;
+ }
++
++   @Override
++   public <T> net.minecraftforge.common.capabilities.OptionalCapabilityInstance<T> getCapability(net.minecraftforge.common.capabilities.Capability<T> capability, @Nullable EnumFacing facing)
++   {
++       return capabilities == null ? net.minecraftforge.common.capabilities.OptionalCapabilityInstance.empty() : capabilities.getCapability(capability, facing);
++   }
++}

--- a/patches/minecraft/net/minecraft/world/chunk/storage/AnvilChunkLoader.java.patch
+++ b/patches/minecraft/net/minecraft/world/chunk/storage/AnvilChunkLoader.java.patch
@@ -1,0 +1,33 @@
+--- a/net/minecraft/world/chunk/storage/AnvilChunkLoader.java
++++ b/net/minecraft/world/chunk/storage/AnvilChunkLoader.java
+@@ -445,7 +445,19 @@
+ 
+       compound.setTag("Heightmaps", nbttagcompound2);
+       compound.setTag("Structures", this.func_202160_a(chunkIn.x, chunkIn.z, chunkIn.func_201609_c(), chunkIn.func_201604_d()));
++      
++      if (chunkIn.getCapabilities() != null)
++      {
++          try
++          {
++              compound.setTag("ForgeCaps", chunkIn.getCapabilities().serializeNBT());
+    }
++          catch (Exception exception)
++          {
++              org.apache.logging.log4j.LogManager.getLogger().error("A capability provider has thrown an exception trying to write state. It will not persist. Report this to the mod author", exception);
++          }
++      }
++   }
+ 
+    private Chunk readChunkFromNBT(IWorld worldIn, NBTTagCompound compound) {
+       int i = compound.getInteger("xPos");
+@@ -511,6 +523,10 @@
+          chunk.setModified(true);
+       }
+ 
++      if (chunk.getCapabilities() != null && compound.hasKey("ForgeCaps")) {
++          chunk.getCapabilities().deserializeNBT(compound.getCompoundTag("ForgeCaps"));
++      }
++
+       return chunk;
+    }
+ 

--- a/patches/minecraft/net/minecraft/world/dimension/Dimension.java.patch
+++ b/patches/minecraft/net/minecraft/world/dimension/Dimension.java.patch
@@ -1,0 +1,11 @@
+--- a/net/minecraft/world/dimension/Dimension.java
++++ b/net/minecraft/world/dimension/Dimension.java
+@@ -13,7 +13,7 @@
+ import net.minecraftforge.api.distmarker.Dist;
+ import net.minecraftforge.api.distmarker.OnlyIn;
+ 
+-public abstract class Dimension {
++public abstract class Dimension implements net.minecraftforge.common.extensions.IForgeDimension {
+    public static final float[] MOON_PHASE_FACTORS = new float[]{1.0F, 0.75F, 0.5F, 0.25F, 0.0F, 0.25F, 0.5F, 0.75F};
+    protected World world;
+    protected boolean doesWaterVaporize;

--- a/src/main/java/net/minecraftforge/client/CloudRenderer.java
+++ b/src/main/java/net/minecraftforge/client/CloudRenderer.java
@@ -41,6 +41,7 @@ import net.minecraft.client.renderer.vertex.VertexBuffer;
 import net.minecraft.client.renderer.vertex.VertexFormat;
 import net.minecraft.entity.Entity;
 import net.minecraft.resources.IReloadableResourceManager;
+import net.minecraft.resources.IResourceManager;
 import net.minecraft.util.ResourceLocation;
 import net.minecraft.util.math.MathHelper;
 import net.minecraft.util.math.Vec3d;

--- a/src/main/java/net/minecraftforge/client/ForgeClientHandler.java
+++ b/src/main/java/net/minecraftforge/client/ForgeClientHandler.java
@@ -35,7 +35,8 @@ public class ForgeClientHandler
         // register model for the universal bucket, if it exists
         if (FluidRegistry.isUniversalBucketEnabled())
         {
-            ModelLoader.setBucketModelDefinition(ForgeMod.getInstance().universalBucket);
+        	// TODO no more mesh definitions, this should be implemented with overrides
+//            ModelLoader.setBucketModelDefinition(ForgeMod.getInstance().universalBucket);
         }
     }
 
@@ -44,7 +45,7 @@ public class ForgeClientHandler
     {
         if (FluidRegistry.isUniversalBucketEnabled())
         {
-            event.getItemColors().registerItemColorHandler(new FluidContainerColorer(), ForgeMod.getInstance().universalBucket);
+            event.getItemColors().func_199877_a(new FluidContainerColorer(), ForgeMod.getInstance().universalBucket);
         }
     }
 }

--- a/src/main/java/net/minecraftforge/client/model/animation/AnimationItemOverrideList.java
+++ b/src/main/java/net/minecraftforge/client/model/animation/AnimationItemOverrideList.java
@@ -67,22 +67,23 @@ public final class AnimationItemOverrideList extends ItemOverrideList
     @Override
     public IBakedModel func_209581_a(IBakedModel originalModel, ItemStack stack, @Nullable World world, @Nullable EntityLivingBase entity)
     {
-        IAnimationStateMachine asm = stack.getCapability(CapabilityAnimation.ANIMATION_CAPABILITY, null);
-        if (asm != null)
-        {
-            // TODO: caching?
-            if(world == null && entity != null)
+        return stack.getCapability(CapabilityAnimation.ANIMATION_CAPABILITY, null)
+            .map(asm -> 
             {
-                world = entity.world;
-            }
-            if(world == null)
-            {
-                world = Minecraft.getMinecraft().world;
-            }
-            IModelState state = asm.apply(Animation.getWorldTime(world, Animation.getPartialTickTime())).getLeft();
+                World w = world;
+                // TODO caching?
+                if(w == null && entity != null)
+                {
+                    w = entity.world;
+                }
+                if(world == null)
+                {
+                    w = Minecraft.getMinecraft().world;
+                }
+                return asm.apply(Animation.getWorldTime(world, Animation.getPartialTickTime())).getLeft();
+            })
             // TODO where should uvlock data come from?
-            return model.bake(ModelLoader.defaultModelGetter(), bakedTextureGetter, new ModelStateComposition(state, this.state), false, format);
-        }
-        return super.func_209581_a(originalModel, stack, world, entity);
+            .map(state -> model.bake(ModelLoader.defaultModelGetter(), bakedTextureGetter, new ModelStateComposition(state, this.state), false, format))
+            .orElseGet(() -> super.func_209581_a(originalModel, stack, world, entity));
     }
 }

--- a/src/main/java/net/minecraftforge/client/model/animation/AnimationTESR.java
+++ b/src/main/java/net/minecraftforge/client/model/animation/AnimationTESR.java
@@ -30,6 +30,7 @@ import net.minecraft.world.IWorldReader;
 import net.minecraftforge.client.MinecraftForgeClient;
 import net.minecraftforge.common.animation.Event;
 import net.minecraftforge.common.animation.IEventHandler;
+import net.minecraftforge.common.capabilities.OptionalCapabilityInstance;
 import net.minecraftforge.common.model.IModelState;
 import net.minecraftforge.common.model.animation.CapabilityAnimation;
 import net.minecraftforge.common.model.animation.IAnimationStateMachine;
@@ -50,7 +51,8 @@ public class AnimationTESR<T extends TileEntity> extends FastTESR<T> implements 
     @Override
     public void renderTileEntityFast(T te, double x, double y, double z, float partialTick, int breakStage, BufferBuilder renderer)
    {
-        if(!te.getCapability(CapabilityAnimation.ANIMATION_CAPABILITY).isPresent())
+        OptionalCapabilityInstance<IAnimationStateMachine> cap = te.getCapability(CapabilityAnimation.ANIMATION_CAPABILITY);
+        if(!cap.isPresent())
         {
             return;
         }
@@ -68,8 +70,8 @@ public class AnimationTESR<T extends TileEntity> extends FastTESR<T> implements 
             if(exState.getUnlistedNames().contains(Properties.AnimationProperty))
             {
                 float time = Animation.getWorldTime(getWorld(), partialTick);
-                te.getCapability(CapabilityAnimation.ANIMATION_CAPABILITY, null)
-                    .map(cap -> cap.apply(time))
+                cap
+                    .map(asm -> asm.apply(time))
                     .ifPresent(pair -> {
                         handleEvents(te, time, pair.getRight());
 

--- a/src/main/java/net/minecraftforge/client/resource/IResourceType.java
+++ b/src/main/java/net/minecraftforge/client/resource/IResourceType.java
@@ -19,13 +19,13 @@
 
 package net.minecraftforge.client.resource;
 
-import net.minecraftforge.fml.relauncher.Side;
-import net.minecraftforge.fml.relauncher.SideOnly;
+import net.minecraftforge.api.distmarker.Dist;
+import net.minecraftforge.api.distmarker.OnlyIn;
 
 /**
  * Represents a generic type of reloadable resource. Used for resource reload filtering.
  */
-@SideOnly(Side.CLIENT)
+@OnlyIn(Dist.CLIENT)
 public interface IResourceType
 {
 }

--- a/src/main/java/net/minecraftforge/client/resource/ReloadRequirements.java
+++ b/src/main/java/net/minecraftforge/client/resource/ReloadRequirements.java
@@ -22,15 +22,15 @@ package net.minecraftforge.client.resource;
 import java.util.Set;
 import java.util.function.Predicate;
 
-import net.minecraftforge.fml.relauncher.Side;
-import net.minecraftforge.fml.relauncher.SideOnly;
-
 import com.google.common.collect.Sets;
+
+import net.minecraftforge.api.distmarker.Dist;
+import net.minecraftforge.api.distmarker.OnlyIn;
 
 /**
  * Holds methods to create standard predicates to select {@link IResourceType}s that should be reloaded.
  */
-@SideOnly(Side.CLIENT)
+@OnlyIn(Dist.CLIENT)
 public final class ReloadRequirements
 {
     /**

--- a/src/main/java/net/minecraftforge/common/ForgeHooks.java
+++ b/src/main/java/net/minecraftforge/common/ForgeHooks.java
@@ -79,6 +79,7 @@ import net.minecraft.item.ItemPotion;
 import net.minecraft.item.ItemSpade;
 import net.minecraft.item.ItemStack;
 import net.minecraft.item.ItemTippedArrow;
+import net.minecraft.item.ItemUseContext;
 import net.minecraft.item.crafting.IRecipe;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.nbt.NBTTagList;
@@ -867,8 +868,11 @@ public class ForgeHooks
         return event.isCanceled() ? -1 : event.getExpToDrop();
     }
 
-    public static EnumActionResult onPlaceItemIntoWorld(@Nonnull ItemStack itemstack, @Nonnull EntityPlayer player, @Nonnull World world, @Nonnull BlockPos pos, @Nonnull EnumFacing side, float hitX, float hitY, float hitZ, @Nonnull EnumHand hand)
+    public static EnumActionResult onPlaceItemIntoWorld(@Nonnull ItemUseContext context)
     {
+    	ItemStack itemstack = context.func_195996_i();
+    	World world = context.func_195991_k();
+    	
         // handle all placement events here
         int meta = itemstack.getItemDamage();
         int size = itemstack.getCount();
@@ -883,7 +887,7 @@ public class ForgeHooks
             world.captureBlockSnapshots = true;
         }
 
-        EnumActionResult ret = itemstack.getItem().onItemUse(player, world, pos, hand, side, hitX, hitY, hitZ);
+        EnumActionResult ret = itemstack.getItem().func_195939_a(context);
         world.captureBlockSnapshots = false;
 
         if (ret == EnumActionResult.SUCCESS)
@@ -902,12 +906,16 @@ public class ForgeHooks
             world.capturedBlockSnapshots.clear();
 
             // make sure to set pre-placement item data for event
-            itemstack.setItemDamage(meta);
+            itemstack.func_196085_b(meta);
             itemstack.setCount(size);
             if (nbt != null)
             {
                 itemstack.setTagCompound(nbt);
             }
+            
+            EntityPlayer player = context.func_195999_j();
+            EnumFacing side = context.func_196000_l();
+            
             if (blockSnapshots.size() > 1)
             {
                 placeEvent = ForgeEventFactory.onPlayerMultiBlockPlace(player, blockSnapshots, side, hand);
@@ -931,7 +939,7 @@ public class ForgeHooks
             else
             {
                 // Change the stack to its new content
-                itemstack.setItemDamage(newMeta);
+                itemstack.func_196085_b(newMeta);
                 itemstack.setCount(newSize);
                 if (nbt != null)
                 {

--- a/src/main/java/net/minecraftforge/common/capabilities/Capability.java
+++ b/src/main/java/net/minecraftforge/common/capabilities/Capability.java
@@ -135,17 +135,6 @@ public class Capability<T>
         }
     }
 
-    /**
-     * Use this inside ICapabilityProvider.getCapability to avoid unchecked cast warnings.
-     * Example: return SOME_CAPABILITY.cast(instance);
-     * Use with caution;
-     */
-    @SuppressWarnings("unchecked")
-    public <R> R cast(T instance)
-    {
-        return (R)instance;
-    }
-
     // INTERNAL
     private final String name;
     private final IStorage<T> storage;

--- a/src/main/java/net/minecraftforge/common/capabilities/CapabilityDispatcher.java
+++ b/src/main/java/net/minecraftforge/common/capabilities/CapabilityDispatcher.java
@@ -20,11 +20,14 @@
 package net.minecraftforge.common.capabilities;
 
 import javax.annotation.Nullable;
+import javax.annotation.ParametersAreNonnullByDefault;
+
 import java.util.List;
 import java.util.Map;
 
 import com.google.common.collect.Lists;
 
+import mcp.MethodsReturnNonnullByDefault;
 import net.minecraft.nbt.INBTBase;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.util.EnumFacing;
@@ -41,6 +44,8 @@ import net.minecraftforge.common.util.INBTSerializable;
  * Internally the handlers are baked into arrays for fast iteration.
  * The ResourceLocations will be used for the NBT Key when serializing.
  */
+@ParametersAreNonnullByDefault
+@MethodsReturnNonnullByDefault
 public final class CapabilityDispatcher implements INBTSerializable<NBTTagCompound>, ICapabilityProvider
 {
     private ICapabilityProvider[] caps;
@@ -87,7 +92,7 @@ public final class CapabilityDispatcher implements INBTSerializable<NBTTagCompou
 
 
     @Override
-    public <T> OptionalCapabilityInstance<T> getCapability(Capability<T> cap, EnumFacing side)
+    public <T> OptionalCapabilityInstance<T> getCapability(Capability<T> cap, @Nullable EnumFacing side)
     {
         for (ICapabilityProvider c : caps)
         {

--- a/src/main/java/net/minecraftforge/common/capabilities/CapabilityDispatcher.java
+++ b/src/main/java/net/minecraftforge/common/capabilities/CapabilityDispatcher.java
@@ -127,7 +127,7 @@ public final class CapabilityDispatcher implements INBTSerializable<NBTTagCompou
         }
     }
 
-    public boolean areCompatible(CapabilityDispatcher other) //Called from ItemStack to compare equality.
+    public boolean areCompatible(@Nullable CapabilityDispatcher other) //Called from ItemStack to compare equality.
     {                                                        // Only compares serializeable caps.
         if (other == null) return this.writers.length == 0;  // Done this way so we can do some pre-checks before doing the costly NBT serialization and compare
         if (this.writers.length == 0) return other.writers.length == 0;

--- a/src/main/java/net/minecraftforge/common/capabilities/CapabilityProvider.java
+++ b/src/main/java/net/minecraftforge/common/capabilities/CapabilityProvider.java
@@ -1,0 +1,100 @@
+/*
+ * Minecraft Forge
+ * Copyright (c) 2016-2018.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation version 2.1
+ * of the License.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+package net.minecraftforge.common.capabilities;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import javax.annotation.ParametersAreNonnullByDefault;
+
+import mcp.MethodsReturnNonnullByDefault;
+import net.minecraft.nbt.NBTTagCompound;
+import net.minecraft.util.EnumFacing;
+import net.minecraftforge.event.ForgeEventFactory;
+
+@MethodsReturnNonnullByDefault
+@ParametersAreNonnullByDefault
+public abstract class CapabilityProvider implements ICapabilityProvider
+{
+    private @Nullable CapabilityDispatcher capabilities;
+    
+    protected final void gatherCapabilities() { gatherCapabilities(null); }
+    
+    protected final void gatherCapabilities(@Nullable ICapabilityProvider parent)
+    {
+        this.capabilities = ForgeEventFactory.gatherCapabilities(getClass(), this, parent);
+    }
+    
+    protected final @Nullable CapabilityDispatcher getCapabilities()
+    {
+        return this.capabilities;
+    }
+    
+    public final boolean areCapsCompatible(CapabilityProvider other)
+    {
+        return areCapsCompatible(other.getCapabilities());
+    }
+
+    public final boolean areCapsCompatible(@Nullable CapabilityDispatcher other)
+    {
+        final CapabilityDispatcher disp = getCapabilities();
+        if (disp == null)
+        {
+            if (other == null)
+            {
+                return true;
+            }
+            else
+            {
+                return other.areCompatible(null);
+            }
+        } 
+        else
+        {
+            return disp.areCompatible(other);
+        }
+    }
+    
+    protected final @Nullable NBTTagCompound serializeCaps()
+    {
+        final CapabilityDispatcher disp = getCapabilities();
+        if (disp != null) 
+        {
+            return disp.serializeNBT();
+        }
+        return null;
+    }
+    
+    protected final void deserializeCaps(NBTTagCompound tag)
+    {
+        final CapabilityDispatcher disp = getCapabilities();
+        if (disp != null)
+        {
+            disp.deserializeNBT(tag);
+        }
+    }
+
+    @Override
+    @Nonnull
+    public <T> OptionalCapabilityInstance<T> getCapability(@Nonnull Capability<T> cap, @Nullable EnumFacing side)
+    {
+        final CapabilityDispatcher disp = getCapabilities();
+        return disp == null ? OptionalCapabilityInstance.empty() : disp.getCapability(cap, side);
+    }
+}

--- a/src/main/java/net/minecraftforge/common/capabilities/NonNullConsumer.java
+++ b/src/main/java/net/minecraftforge/common/capabilities/NonNullConsumer.java
@@ -1,0 +1,29 @@
+/*
+ * Minecraft Forge
+ * Copyright (c) 2016-2018.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation version 2.1
+ * of the License.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+package net.minecraftforge.common.capabilities;
+
+import javax.annotation.Nonnull;
+
+//Exactly like Consumer, except there IS a contract that the parameter must not be null.
+@FunctionalInterface
+public interface NonNullConsumer<T>
+{
+    void accept(@Nonnull T t);
+}

--- a/src/main/java/net/minecraftforge/common/capabilities/OptionalCapabilityInstance.java
+++ b/src/main/java/net/minecraftforge/common/capabilities/OptionalCapabilityInstance.java
@@ -111,10 +111,11 @@ public class OptionalCapabilityInstance<T>
      * @throws NullPointerException if mod object is present and {@code consumer} is
      * null
      */
-    public void ifPresent(Consumer<? super T> consumer)
+    public void ifPresent(NonNullConsumer<? super T> consumer)
     {
-        if (isValid && getValue() != null)
-            consumer.accept(getValue());
+        T val = getValue();
+        if (isValid && val != null)
+            consumer.accept(val);
     }
 
     /**
@@ -154,30 +155,6 @@ public class OptionalCapabilityInstance<T>
     {
         Objects.requireNonNull(mapper);
         return isPresent() ? OptionalCapabilityInstance.of(()->mapper.apply(getValue())) : empty();
-    }
-
-    /**
-     * If a value is present, apply the provided {@code Optional}-bearing
-     * mapping function to it, return that result, otherwise return an empty
-     * {@code Optional}.  This method is similar to {@link #map(Function)},
-     * but the provided mapper is one whose result is already an {@code Optional},
-     * and if invoked, {@code flatMap} does not wrap it with an additional
-     * {@code Optional}.
-     *
-     * @param <U> The type parameter to the {@code Optional} returned by
-     * @param mapper a mapping function to apply to the mod object, if present
-     *           the mapping function
-     * @return the result of applying an {@code Optional}-bearing mapping
-     * function to the value of this {@code Optional}, if a value is present,
-     * otherwise an empty {@code Optional}
-     * @throws NullPointerException if the mapping function is null or returns
-     * a null result
-     */
-    public<U> OptionalCapabilityInstance<U> flatMap(Function<? super T, Optional<U>> mapper)
-    {//I am not sure this is valid, or how to handle this, it's just a copy pasta from Optional. I dont think its needed. Returning a null supplier is bad
-        Objects.requireNonNull(mapper);
-        final U value = map(mapper).orElse(Optional.empty()).orElse(null); // To keep the non-null contract we have to evaluate right now. Should we allow this function at all?
-        return value != null ? OptionalCapabilityInstance.of(() -> value) : OptionalCapabilityInstance.empty();
     }
 
     /**

--- a/src/main/java/net/minecraftforge/common/capabilities/OptionalCapabilityInstance.java
+++ b/src/main/java/net/minecraftforge/common/capabilities/OptionalCapabilityInstance.java
@@ -28,6 +28,14 @@ import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.function.Supplier;
 
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import javax.annotation.ParametersAreNonnullByDefault;
+
+import mcp.MethodsReturnNonnullByDefault;
+
+@ParametersAreNonnullByDefault
+@MethodsReturnNonnullByDefault
 public class OptionalCapabilityInstance<T>
 {
     private final NonNullSupplier<T> supplier;
@@ -35,7 +43,7 @@ public class OptionalCapabilityInstance<T>
     private Set<Consumer<OptionalCapabilityInstance<T>>> listeners = new HashSet<>();
     private boolean isValid = true;
 
-    private static final OptionalCapabilityInstance<Void> EMPTY = new OptionalCapabilityInstance<>(null);
+    private static final @Nonnull OptionalCapabilityInstance<Void> EMPTY = new OptionalCapabilityInstance<>(null);
 
     @SuppressWarnings("unchecked")
     public static <T> OptionalCapabilityInstance<T> empty()
@@ -49,17 +57,17 @@ public class OptionalCapabilityInstance<T>
         return (OptionalCapabilityInstance<X>)this;
     }
 
-    private OptionalCapabilityInstance(NonNullSupplier<T> instanceSupplier)
+    private OptionalCapabilityInstance(@Nullable NonNullSupplier<T> instanceSupplier)
     {
         this.supplier = instanceSupplier;
     }
 
-    public static <T> OptionalCapabilityInstance<T> of(final NonNullSupplier<T> instanceSupplier)
+    public static <T> OptionalCapabilityInstance<T> of(final @Nullable NonNullSupplier<T> instanceSupplier)
     {
         return new OptionalCapabilityInstance<>(instanceSupplier);
     }
 
-    private T getValue()
+    private @Nullable T getValue()
     {
         if (!isValid)
             return null;
@@ -181,7 +189,8 @@ public class OptionalCapabilityInstance<T>
      */
     public T orElse(T other)
     {
-        return getValue() != null ? getValue() : other;
+        T val = getValue();
+        return val != null ? val : other;
     }
 
     /**
@@ -194,9 +203,10 @@ public class OptionalCapabilityInstance<T>
      * @throws NullPointerException if mod object is not present and {@code other} is
      * null
      */
-    public T orElseGet(Supplier<? extends T> other)
+    public T orElseGet(NonNullSupplier<? extends T> other)
     {
-        return getValue() != null ? getValue() : other.get();
+        T val = getValue();
+        return val != null ? val : other.get();
     }
 
     /**
@@ -217,8 +227,9 @@ public class OptionalCapabilityInstance<T>
      */
     public <X extends Throwable> T orElseThrow(Supplier<? extends X> exceptionSupplier) throws X
     {
-        if (getValue() != null)
-            return getValue();
+        T val = getValue();
+        if (val != null)
+            return val;
         throw exceptionSupplier.get();
     }
 

--- a/src/main/java/net/minecraftforge/common/capabilities/OptionalCapabilityInstance.java
+++ b/src/main/java/net/minecraftforge/common/capabilities/OptionalCapabilityInstance.java
@@ -64,7 +64,7 @@ public class OptionalCapabilityInstance<T>
 
     public static <T> OptionalCapabilityInstance<T> of(final @Nullable NonNullSupplier<T> instanceSupplier)
     {
-        return new OptionalCapabilityInstance<>(instanceSupplier);
+        return instanceSupplier == null ? EMPTY.cast() : new OptionalCapabilityInstance<>(instanceSupplier);
     }
 
     private @Nullable T getValue()

--- a/src/main/java/net/minecraftforge/common/extensions/IForgeChunk.java
+++ b/src/main/java/net/minecraftforge/common/extensions/IForgeChunk.java
@@ -1,0 +1,8 @@
+package net.minecraftforge.common.extensions;
+
+import net.minecraftforge.common.capabilities.ICapabilityProvider;
+
+public interface IForgeChunk extends ICapabilityProvider
+{
+
+}

--- a/src/main/java/net/minecraftforge/common/extensions/IForgeDimension.java
+++ b/src/main/java/net/minecraftforge/common/extensions/IForgeDimension.java
@@ -1,0 +1,21 @@
+package net.minecraftforge.common.extensions;
+
+public interface IForgeDimension
+{
+    /**
+     * Called from {@link World#initCapabilities()}, to gather capabilities for this
+     * world. It's safe to access world here since this is called after world is
+     * registered.
+     *
+     * On server, called directly after mapStorage and world data such as Scoreboard
+     * and VillageCollection are initialized. On client, called when world is
+     * constructed, just before world load event is called. Note that this method is
+     * always called before the world load event.
+     * 
+     * @return initial holder for capabilities on the world
+     */
+    default net.minecraftforge.common.capabilities.ICapabilityProvider initCapabilities()
+    {
+        return null;
+    }
+}

--- a/src/main/java/net/minecraftforge/common/extensions/IForgeEntity.java
+++ b/src/main/java/net/minecraftforge/common/extensions/IForgeEntity.java
@@ -1,0 +1,9 @@
+package net.minecraftforge.common.extensions;
+
+import net.minecraft.nbt.NBTTagCompound;
+import net.minecraftforge.common.capabilities.ICapabilitySerializable;
+
+public interface IForgeEntity extends ICapabilitySerializable<NBTTagCompound>
+{
+
+}

--- a/src/main/java/net/minecraftforge/common/extensions/IForgeEntity.java
+++ b/src/main/java/net/minecraftforge/common/extensions/IForgeEntity.java
@@ -1,9 +1,26 @@
 package net.minecraftforge.common.extensions;
 
+import net.minecraft.entity.Entity;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraftforge.common.capabilities.ICapabilitySerializable;
 
 public interface IForgeEntity extends ICapabilitySerializable<NBTTagCompound>
 {
+    default Entity getEntity() { return (Entity) this; }
 
+    default void deserializeNBT(NBTTagCompound nbt)
+    {
+        getEntity().readFromNBT(nbt);
+    }
+
+    default NBTTagCompound serializeNBT()
+    {
+        NBTTagCompound ret = new NBTTagCompound();
+        String id = getEntity().getEntityString();
+        if (id != null)
+        {
+            ret.setString("id", getEntity().getEntityString());
+        }
+        return getEntity().writeToNBT(ret);
+    }
 }

--- a/src/main/java/net/minecraftforge/common/extensions/IForgeItem.java
+++ b/src/main/java/net/minecraftforge/common/extensions/IForgeItem.java
@@ -545,14 +545,6 @@ public interface IForgeItem
         return getItem().getItemStackLimit();
     }
 
-    /**
-     * Sets or removes the harvest level for the specified tool class.
-     *
-     * @param toolClass Class
-     * @param level     Harvest level: Wood: 0 Stone: 1 Iron: 2 Diamond: 3 Gold: 0
-     */
-    void setHarvestLevel(String toolClass, int level);
-
     java.util.Set<String> getToolClasses(ItemStack stack);
 
     /**
@@ -763,7 +755,4 @@ public interface IForgeItem
      */
     @OnlyIn(Dist.CLIENT)
     net.minecraft.client.renderer.tileentity.TileEntityItemStackRenderer getTileEntityItemStackRenderer();
-
-    @OnlyIn(Dist.CLIENT)
-    void setTileEntityItemStackRenderer(@Nullable net.minecraft.client.renderer.tileentity.TileEntityItemStackRenderer teisr);
 }

--- a/src/main/java/net/minecraftforge/common/extensions/IForgeItem.java
+++ b/src/main/java/net/minecraftforge/common/extensions/IForgeItem.java
@@ -31,6 +31,7 @@ import net.minecraft.world.World;
 import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.api.distmarker.OnlyIn;
 
+// TODO review most of the methods in this "patch"
 public interface IForgeItem
 {
     // Helpers for accessing Item data

--- a/src/main/java/net/minecraftforge/common/extensions/IForgeItem.java
+++ b/src/main/java/net/minecraftforge/common/extensions/IForgeItem.java
@@ -92,13 +92,6 @@ public interface IForgeItem
     boolean isRepairable();
 
     /**
-     * Call to disable repair recipes.
-     * 
-     * @return The current Item instance
-     */
-    Item setNoRepair();
-
-    /**
      * Override this method to change the NBT data being sent to the client. You
      * should ONLY override this when you have no other choice, as this might change
      * behavior client side!

--- a/src/main/java/net/minecraftforge/common/extensions/IForgeItem.java
+++ b/src/main/java/net/minecraftforge/common/extensions/IForgeItem.java
@@ -1,0 +1,775 @@
+package net.minecraftforge.common.extensions;
+
+import javax.annotation.Nullable;
+
+import com.google.common.collect.Multimap;
+
+import net.minecraft.block.state.IBlockState;
+import net.minecraft.entity.Entity;
+import net.minecraft.entity.EntityLivingBase;
+import net.minecraft.entity.ai.attributes.AttributeModifier;
+import net.minecraft.entity.passive.EntityHorse;
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.entity.player.EntityPlayerMP;
+import net.minecraft.init.Items;
+import net.minecraft.inventory.EntityEquipmentSlot;
+import net.minecraft.item.IItemPropertyGetter;
+import net.minecraft.item.Item;
+import net.minecraft.item.ItemAxe;
+import net.minecraft.item.ItemGroup;
+import net.minecraft.item.ItemStack;
+import net.minecraft.item.ItemSword;
+import net.minecraft.item.ItemUseContext;
+import net.minecraft.nbt.NBTTagCompound;
+import net.minecraft.util.EnumActionResult;
+import net.minecraft.util.ResourceLocation;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.math.MathHelper;
+import net.minecraft.util.registry.RegistrySimple;
+import net.minecraft.world.GameType;
+import net.minecraft.world.World;
+import net.minecraftforge.api.distmarker.Dist;
+import net.minecraftforge.api.distmarker.OnlyIn;
+
+public interface IForgeItem
+{
+    // Helpers for accessing Item data
+    default Item getItem()
+    {
+        return (Item) this;
+    }
+
+    /**
+     * ItemStack sensitive version of getItemAttributeModifiers
+     */
+    default Multimap<String, AttributeModifier> getAttributeModifiers(EntityEquipmentSlot slot, ItemStack stack)
+    {
+        return getItem().getItemAttributeModifiers(slot);
+    }
+
+    /**
+     * Called when a player drops the item into the world, returning false from this
+     * will prevent the item from being removed from the players inventory and
+     * spawning in the world
+     *
+     * @param player The player that dropped the item
+     * @param item   The item stack, before the item is removed.
+     */
+    default boolean onDroppedByPlayer(ItemStack item, EntityPlayer player)
+    {
+        return true;
+    }
+
+    /**
+     * Allow the item one last chance to modify its name used for the tool highlight
+     * useful for adding something extra that can't be removed by a user in the
+     * displayed name, such as a mode of operation.
+     *
+     * @param item        the ItemStack for the item.
+     * @param displayName the name that will be displayed unless it is changed in
+     *                    this method.
+     */
+    default String getHighlightTip(ItemStack item, String displayName)
+    {
+        return displayName;
+    }
+
+    /**
+     * This is called when the item is used, before the block is activated.
+     *
+     * @return Return PASS to allow vanilla handling, any other to skip normal code.
+     */
+    default EnumActionResult onItemUseFirst(ItemUseContext context)
+    {
+        return EnumActionResult.PASS;
+    }
+
+    /**
+     * Called by CraftingManager to determine if an item is reparable.
+     * 
+     * @return True if reparable
+     */
+    boolean isRepairable();
+
+    /**
+     * Call to disable repair recipes.
+     * 
+     * @return The current Item instance
+     */
+    Item setNoRepair();
+
+    /**
+     * Override this method to change the NBT data being sent to the client. You
+     * should ONLY override this when you have no other choice, as this might change
+     * behavior client side!
+     *
+     * Note that this will sometimes be applied multiple times, the following MUST
+     * be supported: Item item = stack.getItem(); NBTTagCompound nbtShare1 =
+     * item.getNBTShareTag(stack); stack.setTagCompound(nbtShare1); NBTTagCompound
+     * nbtShare2 = item.getNBTShareTag(stack); assert nbtShare1.equals(nbtShare2);
+     *
+     * @param stack The stack to send the NBT tag for
+     * @return The NBT tag
+     */
+    @Nullable
+    default NBTTagCompound getNBTShareTag(ItemStack stack)
+    {
+        return stack.getTagCompound();
+    }
+
+    /**
+     * Override this method to decide what to do with the NBT data received from
+     * getNBTShareTag().
+     * 
+     * @param stack The stack that received NBT
+     * @param nbt   Received NBT, can be null
+     */
+    default void readNBTShareTag(ItemStack stack, @Nullable NBTTagCompound nbt)
+    {
+        stack.setTagCompound(nbt);
+    }
+
+    /**
+     * Called before a block is broken. Return true to prevent default block
+     * harvesting.
+     *
+     * Note: In SMP, this is called on both client and server sides!
+     *
+     * @param itemstack The current ItemStack
+     * @param pos       Block's position in world
+     * @param player    The Player that is wielding the item
+     * @return True to prevent harvesting, false to continue as normal
+     */
+    default boolean onBlockStartBreak(ItemStack itemstack, BlockPos pos, EntityPlayer player)
+    {
+        return false;
+    }
+
+    /**
+     * Called each tick while using an item.
+     * 
+     * @param stack  The Item being used
+     * @param player The Player using the item
+     * @param count  The amount of time in tick the item has been used for
+     *               continuously
+     */
+    default void onUsingTick(ItemStack stack, EntityLivingBase player, int count)
+    {
+    }
+
+    /**
+     * Called when the player Left Clicks (attacks) an entity. Processed before
+     * damage is done, if return value is true further processing is canceled and
+     * the entity is not attacked.
+     *
+     * @param stack  The Item being used
+     * @param player The player that is attacking
+     * @param entity The entity being attacked
+     * @return True to cancel the rest of the interaction.
+     */
+    default boolean onLeftClickEntity(ItemStack stack, EntityPlayer player, Entity entity)
+    {
+        return false;
+    }
+
+    /**
+     * ItemStack sensitive version of getContainerItem. Returns a full ItemStack
+     * instance of the result.
+     *
+     * @param itemStack The current ItemStack
+     * @return The resulting ItemStack
+     */
+    default ItemStack getContainerItem(ItemStack itemStack)
+    {
+        if (!hasContainerItem(itemStack))
+        {
+            return ItemStack.EMPTY;
+        }
+        return new ItemStack(getItem().getContainerItem());
+    }
+
+    /**
+     * ItemStack sensitive version of hasContainerItem
+     * 
+     * @param stack The current item stack
+     * @return True if this item has a 'container'
+     */
+    default boolean hasContainerItem(ItemStack stack)
+    {
+        return getItem().hasContainerItem();
+    }
+
+    /**
+     * Retrieves the normal 'lifespan' of this item when it is dropped on the ground
+     * as a EntityItem. This is in ticks, standard result is 6000, or 5 mins.
+     *
+     * @param itemStack The current ItemStack
+     * @param world     The world the entity is in
+     * @return The normal lifespan in ticks.
+     */
+    default int getEntityLifespan(ItemStack itemStack, World world)
+    {
+        return 6000;
+    }
+
+    /**
+     * Determines if this Item has a special entity for when they are in the world.
+     * Is called when a EntityItem is spawned in the world, if true and
+     * Item#createCustomEntity returns non null, the EntityItem will be destroyed
+     * and the new Entity will be added to the world.
+     *
+     * @param stack The current item stack
+     * @return True of the item has a custom entity, If true,
+     *         Item#createCustomEntity will be called
+     */
+    default boolean hasCustomEntity(ItemStack stack)
+    {
+        return false;
+    }
+    
+    /**
+     * This function should return a new entity to replace the dropped item.
+     * Returning null here will not kill the EntityItem and will leave it to
+     * function normally. Called when the item it placed in a world.
+     *
+     * @param world     The world object
+     * @param location  The EntityItem object, useful for getting the position of
+     *                  the entity
+     * @param itemstack The current item stack
+     * @return A new Entity object to spawn or null
+     */
+    @Nullable
+    default Entity createEntity(World world, Entity location, ItemStack itemstack)
+    {
+        return null;
+    }
+
+    /**
+     * Called by the default implemetation of EntityItem's onUpdate method, allowing
+     * for cleaner control over the update of the item without having to write a
+     * subclass.
+     *
+     * @param entityItem The entity Item
+     * @return Return true to skip any further update code.
+     */
+    default boolean onEntityItemUpdate(net.minecraft.entity.item.EntityItem entityItem)
+    {
+        return false;
+    }
+
+    /**
+     * Gets a list of tabs that items belonging to this class can display on,
+     * combined properly with getSubItems allows for a single item to span many
+     * sub-items across many tabs.
+     *
+     * @return A list of all tabs that this item could possibly be one.
+     */
+    default java.util.Collection<ItemGroup> getCreativeTabs()
+    {
+        return java.util.Collections.singletonList(getItem().getCreativeTab());
+    }
+
+    /**
+     * Determines the base experience for a player when they remove this item from a
+     * furnace slot. This number must be between 0 and 1 for it to be valid. This
+     * number will be multiplied by the stack size to get the total experience.
+     *
+     * @param item The item stack the player is picking up.
+     * @return The amount to award for each item.
+     */
+    default float getSmeltingExperience(ItemStack item)
+    {
+        return -1; // -1 will default to the old lookups.
+    }
+
+    /**
+     *
+     * Should this item, when held, allow sneak-clicks to pass through to the
+     * underlying block?
+     *
+     * @param world  The world
+     * @param pos    Block position in world
+     * @param player The Player that is wielding the item
+     * @return
+     */
+    default boolean doesSneakBypassUse(ItemStack stack, net.minecraft.world.IWorldReader world, BlockPos pos, EntityPlayer player)
+    {
+        return false;
+    }
+
+    /**
+     * Called to tick armor in the armor slot. Override to do something
+     */
+    default void onArmorTick(World world, EntityPlayer player, ItemStack itemStack)
+    {
+    }
+
+    /**
+     * Determines if the specific ItemStack can be placed in the specified armor
+     * slot, for the entity.
+     *
+     * TODO: Change name to canEquip in 1.13?
+     *
+     * @param stack     The ItemStack
+     * @param armorType Armor slot to be verified.
+     * @param entity    The entity trying to equip the armor
+     * @return True if the given ItemStack can be inserted in the slot
+     */
+    default boolean isValidArmor(ItemStack stack, EntityEquipmentSlot armorType, Entity entity)
+    {
+        return net.minecraft.entity.EntityLiving.getSlotForItemStack(stack) == armorType;
+    }
+
+    /**
+     * Override this to set a non-default armor slot for an ItemStack, but <em>do
+     * not use this to get the armor slot of said stack; for that, use
+     * {@link net.minecraft.entity.EntityLiving#getSlotForItemStack(ItemStack)}.</em>
+     *
+     * @param stack the ItemStack
+     * @return the armor slot of the ItemStack, or {@code null} to let the default
+     *         vanilla logic as per {@code EntityLiving.getSlotForItemStack(stack)}
+     *         decide
+     */
+    @Nullable
+    default EntityEquipmentSlot getEquipmentSlot(ItemStack stack)
+    {
+        return null;
+    }
+
+    /**
+     * Allow or forbid the specific book/item combination as an anvil enchant
+     *
+     * @param stack The item
+     * @param book  The book
+     * @return if the enchantment is allowed
+     */
+    default boolean isBookEnchantable(ItemStack stack, ItemStack book)
+    {
+        return true;
+    }
+
+    /**
+     * Called by RenderBiped and RenderPlayer to determine the armor texture that
+     * should be use for the currently equipped item. This will only be called on
+     * instances of ItemArmor.
+     *
+     * Returning null from this function will use the default value.
+     *
+     * @param stack  ItemStack for the equipped armor
+     * @param entity The entity wearing the armor
+     * @param slot   The slot the armor is in
+     * @param type   The subtype, can be null or "overlay"
+     * @return Path of texture to bind, or null to use default
+     */
+    @Nullable
+    default String getArmorTexture(ItemStack stack, Entity entity, EntityEquipmentSlot slot, String type)
+    {
+        return null;
+    }
+
+    /**
+     * Returns the font renderer used to render tooltips and overlays for this item.
+     * Returning null will use the standard font renderer.
+     *
+     * @param stack The current item stack
+     * @return A instance of FontRenderer or null to use default
+     */
+    @OnlyIn(Dist.CLIENT)
+    @Nullable
+    default net.minecraft.client.gui.FontRenderer getFontRenderer(ItemStack stack)
+    {
+        return null;
+    }
+
+    /**
+     * Override this method to have an item handle its own armor rendering.
+     *
+     * @param entityLiving The entity wearing the armor
+     * @param itemStack    The itemStack to render the model of
+     * @param armorSlot    The slot the armor is in
+     * @param _default     Original armor model. Will have attributes set.
+     * @return A ModelBiped to render instead of the default
+     */
+    @OnlyIn(Dist.CLIENT)
+    @Nullable
+    default net.minecraft.client.renderer.entity.model.ModelBiped getArmorModel(EntityLivingBase entityLiving, ItemStack itemStack,
+            EntityEquipmentSlot armorSlot, net.minecraft.client.renderer.entity.model.ModelBiped _default)
+    {
+        return null;
+    }
+
+    /**
+     * Called when a entity tries to play the 'swing' animation.
+     *
+     * @param entityLiving The entity swinging the item.
+     * @param stack        The Item stack
+     * @return True to cancel any further processing by EntityLiving
+     */
+    default boolean onEntitySwing(EntityLivingBase entityLiving, ItemStack stack)
+    {
+        return false;
+    }
+
+    /**
+     * Called when the client starts rendering the HUD, for whatever item the player
+     * currently has as a helmet. This is where pumpkins would render there overlay.
+     *
+     * @param stack        The ItemStack that is equipped
+     * @param player       Reference to the current client entity
+     * @param resolution   Resolution information about the current viewport and
+     *                     configured GUI Scale
+     * @param partialTicks Partial ticks for the renderer, useful for interpolation
+     */
+    @OnlyIn(Dist.CLIENT)
+    default void renderHelmetOverlay(ItemStack stack, EntityPlayer player, int width, int height, float partialTicks)
+    {
+    }
+
+    /**
+     * Return the itemDamage represented by this ItemStack. Defaults to the Damage
+     * entry in the stack NBT, but can be overridden here for other sources.
+     *
+     * @param stack The itemstack that is damaged
+     * @return the damage value
+     */
+    default int getDamage(ItemStack stack)
+    {
+        return !stack.hasTagCompound() ? 0 : stack.getTagCompound().getInteger("Damage");
+    }
+
+    /**
+     * Determines if the durability bar should be rendered for this item. Defaults
+     * to vanilla stack.isDamaged behavior. But modders can use this for any data
+     * they wish.
+     *
+     * @param stack The current Item Stack
+     * @return True if it should render the 'durability' bar.
+     */
+    default boolean showDurabilityBar(ItemStack stack)
+    {
+        return stack.isItemDamaged();
+    }
+
+    /**
+     * Queries the percentage of the 'Durability' bar that should be drawn.
+     *
+     * @param stack The current ItemStack
+     * @return 0.0 for 100% (no damage / full bar), 1.0 for 0% (fully damaged /
+     *         empty bar)
+     */
+    default double getDurabilityForDisplay(ItemStack stack)
+    {
+        return (double) stack.getItemDamage() / (double) stack.getMaxDamage();
+    }
+
+    /**
+     * Returns the packed int RGB value used to render the durability bar in the
+     * GUI. Defaults to a value based on the hue scaled based on
+     * {@link #getDurabilityForDisplay}, but can be overriden.
+     *
+     * @param stack Stack to get durability from
+     * @return A packed RGB value for the durability colour (0x00RRGGBB)
+     */
+    default int getRGBDurabilityForDisplay(ItemStack stack)
+    {
+        return MathHelper.hsvToRGB(Math.max(0.0F, (float) (1.0F - getDurabilityForDisplay(stack))) / 3.0F, 1.0F, 1.0F);
+    }
+
+    /**
+     * Return the maxDamage for this ItemStack. Defaults to the maxDamage field in
+     * this item, but can be overridden here for other sources such as NBT.
+     *
+     * @param stack The itemstack that is damaged
+     * @return the damage value
+     */
+    default int getMaxDamage(ItemStack stack)
+    {
+        return getItem().getMaxDamage();
+    }
+
+    /**
+     * Return if this itemstack is damaged. Note only called if
+     * {@link #isDamageable()} is true.
+     * 
+     * @param stack the stack
+     * @return if the stack is damaged
+     */
+    default boolean isDamaged(ItemStack stack)
+    {
+        return stack.getItemDamage() > 0;
+    }
+
+    /**
+     * Set the damage for this itemstack. Note, this method is responsible for zero
+     * checking.
+     * 
+     * @param stack  the stack
+     * @param damage the new damage value
+     */
+    default void setDamage(ItemStack stack, int damage)
+    {
+        stack.func_196082_o().setInteger("Damage", Math.max(0, damage));
+    }
+
+    /**
+     * Checked from
+     * {@link net.minecraft.client.multiplayer.PlayerControllerMP#onPlayerDestroyBlock(BlockPos pos)
+     * PlayerControllerMP.onPlayerDestroyBlock()} when a creative player left-clicks
+     * a block with this item. Also checked from
+     * {@link net.minecraftforge.common.ForgeHooks#onBlockBreakEvent(World, GameType, EntityPlayerMP, BlockPos)
+     * ForgeHooks.onBlockBreakEvent()} to prevent sending an event.
+     * 
+     * @return true if the given player can destroy specified block in creative mode
+     *         with this item
+     */
+    default boolean canDestroyBlockInCreative(World world, BlockPos pos, ItemStack stack, EntityPlayer player)
+    {
+        return !(this instanceof ItemSword);
+    }
+
+    /**
+     * ItemStack sensitive version of {@link #canHarvestBlock(IBlockState)}
+     * 
+     * @param state The block trying to harvest
+     * @param stack The itemstack used to harvest the block
+     * @return true if can harvest the block
+     */
+    default boolean canHarvestBlock(IBlockState state, ItemStack stack)
+    {
+        return getItem().canHarvestBlock(state);
+    }
+
+    /**
+     * Gets the maximum number of items that this stack should be able to hold. This
+     * is a ItemStack (and thus NBT) sensitive version of Item.getItemStackLimit()
+     *
+     * @param stack The ItemStack
+     * @return The maximum number this item can be stacked to
+     */
+    default int getItemStackLimit(ItemStack stack)
+    {
+        return getItem().getItemStackLimit();
+    }
+
+    /**
+     * Sets or removes the harvest level for the specified tool class.
+     *
+     * @param toolClass Class
+     * @param level     Harvest level: Wood: 0 Stone: 1 Iron: 2 Diamond: 3 Gold: 0
+     */
+    void setHarvestLevel(String toolClass, int level);
+
+    java.util.Set<String> getToolClasses(ItemStack stack);
+
+    /**
+     * Queries the harvest level of this item stack for the specified tool class,
+     * Returns -1 if this tool is not of the specified type
+     *
+     * @param stack      This item stack instance
+     * @param toolClass  Tool Class
+     * @param player     The player trying to harvest the given blockstate
+     * @param blockState The block to harvest
+     * @return Harvest level, or -1 if not the specified tool type.
+     */
+    int getHarvestLevel(ItemStack stack, String toolClass, @Nullable EntityPlayer player, @Nullable IBlockState blockState);
+
+    /**
+     * ItemStack sensitive version of getItemEnchantability
+     *
+     * @param stack The ItemStack
+     * @return the item echantability value
+     */
+    default int getItemEnchantability(ItemStack stack)
+    {
+        return getItem().getItemEnchantability();
+    }
+
+    /**
+     * Checks whether an item can be enchanted with a certain enchantment. This
+     * applies specifically to enchanting an item in the enchanting table and is
+     * called when retrieving the list of possible enchantments for an item.
+     * Enchantments may additionally (or exclusively) be doing their own checks in
+     * {@link net.minecraft.enchantment.Enchantment#canApplyAtEnchantingTable(ItemStack)};
+     * check the individual implementation for reference. By default this will check
+     * if the enchantment type is valid for this item type.
+     * 
+     * @param stack       the item stack to be enchanted
+     * @param enchantment the enchantment to be applied
+     * @return true if the enchantment can be applied to this item
+     */
+    default boolean canApplyAtEnchantingTable(ItemStack stack, net.minecraft.enchantment.Enchantment enchantment)
+    {
+        return enchantment.type.canEnchantItem(stack.getItem());
+    }
+
+    /**
+     * Whether this Item can be used as a payment to activate the vanilla beacon.
+     * 
+     * @param stack the ItemStack
+     * @return true if this Item can be used
+     */
+    default boolean isBeaconPayment(ItemStack stack)
+    {
+        return this == Items.EMERALD || this == Items.DIAMOND || this == Items.GOLD_INGOT || this == Items.IRON_INGOT;
+    }
+
+    /**
+     * Determine if the player switching between these two item stacks
+     * 
+     * @param oldStack    The old stack that was equipped
+     * @param newStack    The new stack
+     * @param slotChanged If the current equipped slot was changed, Vanilla does not
+     *                    play the animation if you switch between two slots that
+     *                    hold the exact same item.
+     * @return True to play the item change animation
+     */
+    default boolean shouldCauseReequipAnimation(ItemStack oldStack, ItemStack newStack, boolean slotChanged)
+    {
+        return !oldStack.equals(newStack); // !ItemStack.areItemStacksEqual(oldStack, newStack);
+    }
+
+    /**
+     * Called when the player is mining a block and the item in his hand changes.
+     * Allows to not reset blockbreaking if only NBT or similar changes.
+     * 
+     * @param oldStack The old stack that was used for mining. Item in players main
+     *                 hand
+     * @param newStack The new stack
+     * @return True to reset block break progress
+     */
+    default boolean shouldCauseBlockBreakReset(ItemStack oldStack, ItemStack newStack)
+    {
+        return !(newStack.getItem() == oldStack.getItem() && ItemStack.areItemStackTagsEqual(newStack, oldStack)
+                && (newStack.isItemStackDamageable() || newStack.getItemDamage() == oldStack.getItemDamage()));
+    }
+
+    /**
+     * Called to get the Mod ID of the mod that *created* the ItemStack, instead of
+     * the real Mod ID that *registered* it.
+     *
+     * For example the Forge Universal Bucket creates a subitem for each modded
+     * fluid, and it returns the modded fluid's Mod ID here.
+     *
+     * Mods that register subitems for other mods can override this. Informational
+     * mods can call it to show the mod that created the item.
+     *
+     * @param itemStack the ItemStack to check
+     * @return the Mod ID for the ItemStack, or null when there is no specially
+     *         associated mod and {@link #getRegistryName()} would return null.
+     */
+    @Nullable
+    default String getCreatorModId(ItemStack itemStack)
+    {
+        return net.minecraftforge.common.ForgeHooks.getDefaultCreatorModId(itemStack);
+    }
+
+    /**
+     * Called from ItemStack.setItem, will hold extra data for the life of this
+     * ItemStack. Can be retrieved from stack.getCapabilities() The NBT can be null
+     * if this is not called from readNBT or if the item the stack is changing FROM
+     * is different then this item, or the previous item had no capabilities.
+     *
+     * This is called BEFORE the stacks item is set so you can use stack.getItem()
+     * to see the OLD item. Remember that getItem CAN return null.
+     *
+     * @param stack The ItemStack
+     * @param nbt   NBT of this item serialized, or null.
+     * @return A holder instance associated with this ItemStack where you can hold
+     *         capabilities for the life of this item.
+     */
+    @Nullable
+    default net.minecraftforge.common.capabilities.ICapabilityProvider initCapabilities(ItemStack stack, @Nullable NBTTagCompound nbt)
+    {
+        return null;
+    }
+
+    default com.google.common.collect.ImmutableMap<String, net.minecraftforge.common.animation.ITimeValue> getAnimationParameters(final ItemStack stack,
+            final World world, final EntityLivingBase entity)
+    {
+        com.google.common.collect.ImmutableMap.Builder<String, net.minecraftforge.common.animation.ITimeValue> builder = com.google.common.collect.ImmutableMap
+                .builder();
+        for (ResourceLocation location : ((RegistrySimple<ResourceLocation, IItemPropertyGetter>) getItem().properties).getKeys())
+        {
+            final IItemPropertyGetter parameter = getItem().properties.getObject(location);
+            builder.put(location.toString(), input -> parameter.call(stack, world, entity));
+        }
+        return builder.build();
+    }
+
+    /**
+     * Can this Item disable a shield
+     * 
+     * @param stack    The ItemStack
+     * @param shield   The shield in question
+     * @param entity   The EntityLivingBase holding the shield
+     * @param attacker The EntityLivingBase holding the ItemStack
+     * @retrun True if this ItemStack can disable the shield in question.
+     */
+    default boolean canDisableShield(ItemStack stack, ItemStack shield, EntityLivingBase entity, EntityLivingBase attacker)
+    {
+        return this instanceof ItemAxe;
+    }
+
+    /**
+     * Is this Item a shield
+     * 
+     * @param stack  The ItemStack
+     * @param entity The Entity holding the ItemStack
+     * @return True if the ItemStack is considered a shield
+     */
+    default boolean isShield(ItemStack stack, @Nullable EntityLivingBase entity)
+    {
+        return stack.getItem() == Items.SHIELD;
+    }
+
+    /**
+     * @return the fuel burn time for this itemStack in a furnace. Return 0 to make
+     *         it not act as a fuel. Return -1 to let the default vanilla logic
+     *         decide.
+     */
+    default int getItemBurnTime(ItemStack itemStack)
+    {
+        return -1;
+    }
+
+    /**
+     * Returns an enum constant of type {@code HorseArmorType}. The returned enum
+     * constant will be used to determine the armor value and texture of this item
+     * when equipped.
+     * 
+     * @param stack the armor stack
+     * @return an enum constant of type {@code HorseArmorType}. Return
+     *         HorseArmorType.NONE if this is not horse armor
+     */
+    default net.minecraft.entity.passive.HorseArmorType getHorseArmorType(ItemStack stack)
+    {
+        return net.minecraft.entity.passive.HorseArmorType.getByItem(stack.getItem());
+    }
+
+    default String getHorseArmorTexture(net.minecraft.entity.EntityLiving wearer, ItemStack stack)
+    {
+        return getHorseArmorType(stack).getTextureName();
+    }
+
+    /**
+     * Called every tick from {@link EntityHorse#onUpdate()} on the item in the
+     * armor slot.
+     * 
+     * @param world the world the horse is in
+     * @param horse the horse wearing this armor
+     * @param armor the armor itemstack
+     */
+    default void onHorseArmorTick(World world, net.minecraft.entity.EntityLiving horse, ItemStack armor)
+    {
+    }
+
+    /**
+     * @return This Item's renderer, or the default instance if it does not have
+     *         one.
+     */
+    @OnlyIn(Dist.CLIENT)
+    net.minecraft.client.renderer.tileentity.TileEntityItemStackRenderer getTileEntityItemStackRenderer();
+
+    @OnlyIn(Dist.CLIENT)
+    void setTileEntityItemStackRenderer(@Nullable net.minecraft.client.renderer.tileentity.TileEntityItemStackRenderer teisr);
+}

--- a/src/main/java/net/minecraftforge/common/extensions/IForgeTileEntity.java
+++ b/src/main/java/net/minecraftforge/common/extensions/IForgeTileEntity.java
@@ -1,0 +1,24 @@
+package net.minecraftforge.common.extensions;
+
+import net.minecraft.nbt.NBTTagCompound;
+import net.minecraft.tileentity.TileEntity;
+import net.minecraftforge.common.capabilities.ICapabilitySerializable;
+
+public interface IForgeTileEntity extends ICapabilitySerializable<NBTTagCompound>
+{
+    default TileEntity getTileEntity() { return (TileEntity) this; }
+    
+    @Override
+    default void deserializeNBT(NBTTagCompound nbt)
+    {
+        getTileEntity().readFromNBT(nbt);
+    }
+
+    @Override
+    default NBTTagCompound serializeNBT()
+    {
+        NBTTagCompound ret = new NBTTagCompound();
+        getTileEntity().writeToNBT(ret);
+        return ret;
+    }
+}

--- a/src/main/java/net/minecraftforge/common/extensions/IForgeVillage.java
+++ b/src/main/java/net/minecraftforge/common/extensions/IForgeVillage.java
@@ -1,0 +1,27 @@
+package net.minecraftforge.common.extensions;
+
+import net.minecraft.nbt.NBTTagCompound;
+import net.minecraft.village.Village;
+import net.minecraftforge.common.capabilities.ICapabilitySerializable;
+
+public interface IForgeVillage extends ICapabilitySerializable<NBTTagCompound>
+{
+    default Village getVillage()
+    {
+        return (Village) this;
+    }
+    
+    @Override
+    default void deserializeNBT(NBTTagCompound nbt)
+    {
+        getVillage().readVillageDataFromNBT(nbt);
+    }
+
+    @Override
+    default NBTTagCompound serializeNBT()
+    {
+        NBTTagCompound ret = new NBTTagCompound();
+        getVillage().writeVillageDataToNBT(ret);
+        return ret;
+    }
+}

--- a/src/main/java/net/minecraftforge/common/extensions/IForgeWorld.java
+++ b/src/main/java/net/minecraftforge/common/extensions/IForgeWorld.java
@@ -1,0 +1,8 @@
+package net.minecraftforge.common.extensions;
+
+import net.minecraftforge.common.capabilities.ICapabilityProvider;
+
+public interface IForgeWorld extends ICapabilityProvider
+{
+    
+}

--- a/src/main/java/net/minecraftforge/common/model/animation/CapabilityAnimation.java
+++ b/src/main/java/net/minecraftforge/common/model/animation/CapabilityAnimation.java
@@ -60,14 +60,14 @@ public class CapabilityAnimation
         }
 
         @Override
-        @Nullable
+        @Nonnull
         public <T> OptionalCapabilityInstance<T> getCapability(@Nonnull Capability<T> capability, @Nullable EnumFacing facing)
         {
             if(capability == ANIMATION_CAPABILITY)
             {
-                return ANIMATION_CAPABILITY.cast(asm);
+                return OptionalCapabilityInstance.of(() -> asm).cast();
             }
-            return null;
+            return OptionalCapabilityInstance.empty();
         }
     }
 }

--- a/src/main/java/net/minecraftforge/common/property/Properties.java
+++ b/src/main/java/net/minecraftforge/common/property/Properties.java
@@ -19,8 +19,8 @@
 
 package net.minecraftforge.common.property;
 
-import net.minecraft.block.properties.IProperty;
-import net.minecraft.block.properties.PropertyBool;
+import net.minecraft.state.BooleanProperty;
+import net.minecraft.state.IProperty;
 import net.minecraftforge.common.model.IModelState;
 
 public class Properties
@@ -28,7 +28,7 @@ public class Properties
     /**
      * Property indicating if the model should be rendered in the static renderer or in the TESR. AnimationTESR sets it to false.
      */
-    public static final PropertyBool StaticProperty = PropertyBool.create("static");
+    public static final BooleanProperty StaticProperty = BooleanProperty.create("static");
 
     /**
      * Property holding the IModelState used for animating the model in the TESR.

--- a/src/main/java/net/minecraftforge/common/util/WorldCapabilityData.java
+++ b/src/main/java/net/minecraftforge/common/util/WorldCapabilityData.java
@@ -19,6 +19,8 @@
 
 package net.minecraftforge.common.util;
 
+import javax.annotation.Nullable;
+
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.world.dimension.Dimension;
 import net.minecraft.world.storage.WorldSavedData;
@@ -35,7 +37,7 @@ public class WorldCapabilityData extends WorldSavedData
         super(name);
     }
 
-    public WorldCapabilityData(INBTSerializable<NBTTagCompound> serializable)
+    public WorldCapabilityData(@Nullable INBTSerializable<NBTTagCompound> serializable)
     {
         super(ID);
         this.serializable = serializable;

--- a/src/main/java/net/minecraftforge/common/util/WorldCapabilityData.java
+++ b/src/main/java/net/minecraftforge/common/util/WorldCapabilityData.java
@@ -20,7 +20,7 @@
 package net.minecraftforge.common.util;
 
 import net.minecraft.nbt.NBTTagCompound;
-import net.minecraft.world.WorldProvider;
+import net.minecraft.world.dimension.Dimension;
 import net.minecraft.world.storage.WorldSavedData;
 
 public class WorldCapabilityData extends WorldSavedData
@@ -66,7 +66,7 @@ public class WorldCapabilityData extends WorldSavedData
         return true;
     }
 
-    public void setCapabilities(WorldProvider provider, INBTSerializable<NBTTagCompound> capabilities)
+    public void setCapabilities(Dimension provider, INBTSerializable<NBTTagCompound> capabilities)
     {
         this.serializable = capabilities;
         if (this.capNBT != null && serializable != null)

--- a/src/main/java/net/minecraftforge/event/ForgeEventFactory.java
+++ b/src/main/java/net/minecraftforge/event/ForgeEventFactory.java
@@ -624,41 +624,18 @@ public class ForgeEventFactory
     {
         return MinecraftForge.EVENT_BUS.post(new RenderBlockOverlayEvent(player, renderPartialTicks, type, block, pos));
     }
-
+    
     @Nullable
-    public static CapabilityDispatcher gatherCapabilities(TileEntity tileEntity)
+    public static <T extends ICapabilityProvider> CapabilityDispatcher gatherCapabilities(Class<? extends T> type, T provider)
     {
-        return gatherCapabilities(new AttachCapabilitiesEvent<TileEntity>(TileEntity.class, tileEntity), null);
+        return gatherCapabilities(type, provider, null);
     }
-
+    
+    @SuppressWarnings("unchecked")
     @Nullable
-    public static CapabilityDispatcher gatherCapabilities(Entity entity)
+    public static <T extends ICapabilityProvider> CapabilityDispatcher gatherCapabilities(Class<? extends T> type, T provider, @Nullable ICapabilityProvider parent)
     {
-        return gatherCapabilities(new AttachCapabilitiesEvent<Entity>(Entity.class, entity), null);
-    }
-
-    @Nullable
-    public static CapabilityDispatcher gatherCapabilities(Village village)
-    {
-        return gatherCapabilities(new AttachCapabilitiesEvent<Village>(Village.class, village), null);
-    }
-
-    @Nullable
-    public static CapabilityDispatcher gatherCapabilities(ItemStack stack, ICapabilityProvider parent)
-    {
-        return gatherCapabilities(new AttachCapabilitiesEvent<ItemStack>(ItemStack.class, stack), parent);
-    }
-
-    @Nullable
-    public static CapabilityDispatcher gatherCapabilities(World world, ICapabilityProvider parent)
-    {
-        return gatherCapabilities(new AttachCapabilitiesEvent<World>(World.class, world), parent);
-    }
-
-    @Nullable
-    public static CapabilityDispatcher gatherCapabilities(Chunk chunk)
-    {
-        return gatherCapabilities(new AttachCapabilitiesEvent<Chunk>(Chunk.class, chunk), null);
+        return gatherCapabilities(new AttachCapabilitiesEvent<T>((Class<T>) type, provider), parent);
     }
 
     @Nullable

--- a/src/main/java/net/minecraftforge/event/ForgeEventFactory.java
+++ b/src/main/java/net/minecraftforge/event/ForgeEventFactory.java
@@ -328,9 +328,9 @@ public class ForgeEventFactory
         return event.getNewState();
     }
 
-    public static ItemTooltipEvent onItemTooltip(ItemStack itemStack, @Nullable EntityPlayer entityPlayer, List<String> toolTip, ITooltipFlag flags)
+    public static ItemTooltipEvent onItemTooltip(ItemStack itemStack, @Nullable EntityPlayer entityPlayer, List<ITextComponent> list, ITooltipFlag flags)
     {
-        ItemTooltipEvent event = new ItemTooltipEvent(itemStack, entityPlayer, toolTip, flags);
+        ItemTooltipEvent event = new ItemTooltipEvent(itemStack, entityPlayer, list, flags);
         MinecraftForge.EVENT_BUS.post(event);
         return event;
     }

--- a/src/main/java/net/minecraftforge/event/entity/player/ItemTooltipEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/player/ItemTooltipEvent.java
@@ -25,6 +25,7 @@ import net.minecraft.client.Minecraft;
 import net.minecraft.client.util.ITooltipFlag;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemStack;
+import net.minecraft.util.text.ITextComponent;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -34,17 +35,17 @@ public class ItemTooltipEvent extends PlayerEvent
     private final ITooltipFlag flags;
     @Nonnull
     private final ItemStack itemStack;
-    private final List<String> toolTip;
+    private final List<ITextComponent> toolTip;
 
     /**
      * This event is fired in {@link ItemStack#getTooltip(EntityPlayer, ITooltipFlag)}, which in turn is called from it's respective GUIContainer.
      * Tooltips are also gathered with a null entityPlayer during startup by {@link Minecraft#populateSearchTreeManager()}.
      */
-    public ItemTooltipEvent(@Nonnull ItemStack itemStack, @Nullable EntityPlayer entityPlayer, List<String> toolTip, ITooltipFlag flags)
+    public ItemTooltipEvent(@Nonnull ItemStack itemStack, @Nullable EntityPlayer entityPlayer, List<ITextComponent> list, ITooltipFlag flags)
     {
         super(entityPlayer);
         this.itemStack = itemStack;
-        this.toolTip = toolTip;
+        this.toolTip = list;
         this.flags = flags;
     }
 
@@ -68,7 +69,7 @@ public class ItemTooltipEvent extends PlayerEvent
     /**
      * The {@link ItemStack} tooltip.
      */
-    public List<String> getToolTip()
+    public List<ITextComponent> getToolTip()
     {
         return toolTip;
     }

--- a/src/main/resources/forge_at.cfg
+++ b/src/main/resources/forge_at.cfg
@@ -17,6 +17,8 @@ public net.minecraft.block.BlockFire func_176534_d(Lnet/minecraft/block/Block;)I
 public net.minecraft.item.Item func_77656_e(I)Lnet.minecraft.item.Item; #setMaxDamage
 public net.minecraft.item.Item func_77627_a(Z)Lnet.minecraft.item.Item; #setHasSubtypes
 public net.minecraft.item.Item field_185051_m # properties
+# Entity
+public net.minecraft.entity.Entity func_70022_Q()Ljava/lang/String; # getEntityString
 # EntityPlayer
 public net.minecraft.entity.player.EntityPlayer func_71053_j()V #closeScreen
 # EntityTrackerEntry

--- a/src/main/resources/forge_at.cfg
+++ b/src/main/resources/forge_at.cfg
@@ -16,6 +16,7 @@ public net.minecraft.block.BlockFire func_176534_d(Lnet/minecraft/block/Block;)I
 # Item
 public net.minecraft.item.Item func_77656_e(I)Lnet.minecraft.item.Item; #setMaxDamage
 public net.minecraft.item.Item func_77627_a(Z)Lnet.minecraft.item.Item; #setHasSubtypes
+public net.minecraft.item.Item field_185051_m # properties
 # EntityPlayer
 public net.minecraft.entity.player.EntityPlayer func_71053_j()V #closeScreen
 # EntityTrackerEntry


### PR DESCRIPTION
Skipped things:

- `EntityPlayer.REACH_DISTANCE` won't exist until `EntityPlayer` patch is done.
- `Entity` patches (except for ICapabilityProvider) were skipped, since they are very interdependent and need reviewing.
- Same treatment for TE/World/Chunk (only ended up porting the entire patch for Item/ItemStack)

TODO List:
- [x] ItemStack caps
- [x] Entity caps
- [x] TileEntity caps
- [x] World caps
- [x] Chunk caps
- [x] Village caps