### PR TITLE
Added WatcherPotionEffect and LastHealth

### DIFF
--- a/patches/minecraft/net/minecraft/entity/EntityLivingBase.java.patch
+++ b/patches/minecraft/net/minecraft/entity/EntityLivingBase.java.patch
@@ -1,6 +1,6 @@
 --- ../src-base/minecraft/net/minecraft/entity/EntityLivingBase.java
 +++ ../src-work/minecraft/net/minecraft/entity/EntityLivingBase.java
-@@ -82,6 +82,7 @@
+@@ -82,11 +82,14 @@
      private static final Logger field_190632_a = LogManager.getLogger();
      private static final UUID field_110156_b = UUID.fromString("662A6B8D-DA3E-4C1C-8813-96EA6097278D");
      private static final AttributeModifier field_110157_c = (new AttributeModifier(field_110156_b, "Sprinting speed boost", 0.30000001192092896D, 2)).func_111168_a(false);
@@ -8,7 +8,23 @@
      protected static final DataParameter<Byte> field_184621_as = EntityDataManager.<Byte>func_187226_a(EntityLivingBase.class, DataSerializers.field_187191_a);
      private static final DataParameter<Float> field_184632_c = EntityDataManager.<Float>func_187226_a(EntityLivingBase.class, DataSerializers.field_187193_c);
      private static final DataParameter<Integer> field_184633_f = EntityDataManager.<Integer>func_187226_a(EntityLivingBase.class, DataSerializers.field_187192_b);
-@@ -188,6 +189,7 @@
+     private static final DataParameter<Boolean> field_184634_g = EntityDataManager.<Boolean>func_187226_a(EntityLivingBase.class, DataSerializers.field_187198_h);
+     private static final DataParameter<Integer> field_184635_h = EntityDataManager.<Integer>func_187226_a(EntityLivingBase.class, DataSerializers.field_187192_b);
++    private static final DataParameter<Float> LAST_HEALTH = EntityDataManager.func_187226_a(EntityLivingBase.class, DataSerializers.field_187193_c);
++    private static final DataParameter<NBTTagCompound> WATCHER_POTION_EFFECTS = EntityDataManager.func_187226_a(EntityLivingBase.class, DataSerializers.field_192734_n);
+     private AbstractAttributeMap field_110155_d;
+     private final CombatTracker field_94063_bt = new CombatTracker(this);
+     private final Map<Potion, PotionEffect> field_70713_bf = Maps.<Potion, PotionEffect>newHashMap();
+@@ -179,6 +182,8 @@
+         this.field_70180_af.func_187214_a(field_184634_g, Boolean.valueOf(false));
+         this.field_70180_af.func_187214_a(field_184635_h, Integer.valueOf(0));
+         this.field_70180_af.func_187214_a(field_184632_c, Float.valueOf(1.0F));
++        this.field_70180_af.func_187214_a(LAST_HEALTH, Float.valueOf(1.0F));
++        this.field_70180_af.func_187214_a(WATCHER_POTION_EFFECTS, new NBTTagCompound());
+     }
+ 
+     protected void func_110147_ax()
+@@ -188,6 +193,7 @@
          this.func_110140_aT().func_111150_b(SharedMonsterAttributes.field_111263_d);
          this.func_110140_aT().func_111150_b(SharedMonsterAttributes.field_188791_g);
          this.func_110140_aT().func_111150_b(SharedMonsterAttributes.field_189429_h);
@@ -16,7 +32,7 @@
      }
  
      protected void func_184231_a(double p_184231_1_, boolean p_184231_3_, IBlockState p_184231_4_, BlockPos p_184231_5_)
-@@ -201,10 +203,11 @@
+@@ -201,10 +207,11 @@
          {
              float f = (float)MathHelper.func_76123_f(this.field_70143_R - 3.0F);
  
@@ -29,7 +45,7 @@
                  ((WorldServer)this.field_70170_p).func_175739_a(EnumParticleTypes.BLOCK_DUST, this.field_70165_t, this.field_70163_u, this.field_70161_v, i, 0.0D, 0.0D, 0.0D, 0.15000000596046448D, Block.func_176210_f(p_184231_4_));
              }
          }
-@@ -281,7 +284,7 @@
+@@ -281,7 +288,7 @@
                      }
                  }
  
@@ -38,7 +54,7 @@
                  {
                      this.func_184210_p();
                  }
-@@ -380,7 +383,7 @@
+@@ -380,7 +387,7 @@
              if (!this.field_70170_p.field_72995_K && (this.func_70684_aJ() || this.field_70718_bc > 0 && this.func_146066_aG() && this.field_70170_p.func_82736_K().func_82766_b("doMobLoot")))
              {
                  int i = this.func_70693_a(this.field_70717_bb);
@@ -47,7 +63,7 @@
                  while (i > 0)
                  {
                      int j = EntityXPOrb.func_70527_a(i);
-@@ -442,6 +445,7 @@
+@@ -442,6 +449,7 @@
      {
          this.field_70755_b = p_70604_1_;
          this.field_70756_c = this.field_70173_aa;
@@ -55,7 +71,27 @@
      }
  
      public EntityLivingBase func_110144_aD()
-@@ -670,8 +674,10 @@
+@@ -496,6 +504,7 @@
+     public void func_70014_b(NBTTagCompound p_70014_1_)
+     {
+         p_70014_1_.func_74776_a("Health", this.func_110143_aJ());
++        p_70014_1_.func_74776_a("LastHealth", this.getLastHealth());
+         p_70014_1_.func_74777_a("HurtTime", (short)this.field_70737_aN);
+         p_70014_1_.func_74768_a("HurtByTimestamp", this.field_70756_c);
+         p_70014_1_.func_74777_a("DeathTime", (short)this.field_70725_aQ);
+@@ -567,6 +576,11 @@
+         {
+             this.func_70606_j(p_70037_1_.func_74760_g("Health"));
+         }
++        
++        if (p_70037_1_.func_150297_b("LastHealth", 99))
++        {
++            this.setLastHealth(p_70037_1_.func_74760_g("LastHealth"));
++        }
+ 
+         this.field_70737_aN = p_70037_1_.func_74765_d("HurtTime");
+         this.field_70725_aQ = p_70037_1_.func_74765_d("DeathTime");
+@@ -670,9 +684,24 @@
          else
          {
              Collection<PotionEffect> collection = this.field_70713_bf.values();
@@ -66,9 +102,31 @@
 +            this.field_70180_af.func_187227_b(field_184634_g, event.areParticlesHidden());
 +            this.field_70180_af.func_187227_b(field_184633_f, event.getColor());
              this.func_82142_c(this.func_70644_a(MobEffects.field_76441_p));
++            
++            if(!field_70170_p.field_72995_K)
++            {
++                NBTTagList nbttaglist = new NBTTagList();
++                for (PotionEffect potioneffect : collection)
++                {
++            		nbttaglist.func_74742_a(potioneffect.func_82719_a(new NBTTagCompound()));
++            	}
++                NBTTagCompound compound = new NBTTagCompound();
++            	compound.func_74782_a("ActiveEffects", nbttaglist);
++
++            	this.field_70180_af.func_187227_b(WATCHER_POTION_EFFECTS, compound);
++            }
          }
      }
-@@ -819,6 +825,8 @@
+ 
+@@ -693,6 +722,7 @@
+     {
+         this.field_70180_af.func_187227_b(field_184634_g, Boolean.valueOf(false));
+         this.field_70180_af.func_187227_b(field_184633_f, Integer.valueOf(0));
++        this.field_70180_af.func_187227_b(WATCHER_POTION_EFFECTS, new NBTTagCompound());
+     }
+ 
+     public void func_70674_bp()
+@@ -819,6 +849,8 @@
  
      public void func_70691_i(float p_70691_1_)
      {
@@ -77,15 +135,34 @@
          float f = this.func_110143_aJ();
  
          if (f > 0.0F)
-@@ -839,6 +847,7 @@
+@@ -831,14 +863,26 @@
+     {
+         return ((Float)this.field_70180_af.func_187225_a(field_184632_c)).floatValue();
+     }
++    
  
+     public void func_70606_j(float p_70606_1_)
+     {
++    	setLastHealth(func_110143_aJ());
+         this.field_70180_af.func_187227_b(field_184632_c, Float.valueOf(MathHelper.func_76131_a(p_70606_1_, 0.0F, this.func_110138_aP())));
+     }
++    
++    public float getLastHealth() {
++        return ((Float)this.field_70180_af.func_187225_a(LAST_HEALTH)).floatValue();
++    }
+ 
++    public void setLastHealth(float lastHealth)
++    {
++    	this.field_70180_af.func_187227_b(LAST_HEALTH, lastHealth);
++    }
++    
      public boolean func_70097_a(DamageSource p_70097_1_, float p_70097_2_)
      {
 +        if (!net.minecraftforge.common.ForgeHooks.onLivingAttack(this, p_70097_1_, p_70097_2_)) return false;
          if (this.func_180431_b(p_70097_1_))
          {
              return false;
-@@ -927,9 +936,9 @@
+@@ -927,9 +971,9 @@
                          this.field_70718_bc = 100;
                          this.field_70717_bb = (EntityPlayer)entity1;
                      }
@@ -97,7 +174,7 @@
  
                          if (entitywolf.func_70909_n())
                          {
-@@ -1127,7 +1136,7 @@
+@@ -1127,7 +1171,7 @@
  
      public void func_70669_a(ItemStack p_70669_1_)
      {
@@ -106,7 +183,7 @@
  
          for (int i = 0; i < 5; ++i)
          {
-@@ -1139,12 +1148,17 @@
+@@ -1139,12 +1183,17 @@
              vec3d1 = vec3d1.func_178789_a(-this.field_70125_A * 0.017453292F);
              vec3d1 = vec3d1.func_178785_b(-this.field_70177_z * 0.017453292F);
              vec3d1 = vec3d1.func_72441_c(this.field_70165_t, this.field_70163_u + (double)this.func_70047_e(), this.field_70161_v);
@@ -125,7 +202,7 @@
          if (!this.field_70729_aU)
          {
              Entity entity = p_70645_1_.func_76346_g();
-@@ -1165,18 +1179,26 @@
+@@ -1165,18 +1214,26 @@
  
              if (!this.field_70170_p.field_72995_K)
              {
@@ -157,7 +234,7 @@
              }
  
              this.field_70170_p.func_72960_a(this, (byte)3);
-@@ -1195,6 +1217,9 @@
+@@ -1195,6 +1252,9 @@
  
      public void func_70653_a(Entity p_70653_1_, float p_70653_2_, double p_70653_3_, double p_70653_5_)
      {
@@ -167,7 +244,7 @@
          if (this.field_70146_Z.nextDouble() >= this.func_110148_a(SharedMonsterAttributes.field_111266_c).func_111126_e())
          {
              this.field_70160_al = true;
-@@ -1253,15 +1278,7 @@
+@@ -1253,15 +1313,7 @@
              BlockPos blockpos = new BlockPos(i, j, k);
              IBlockState iblockstate = this.field_70170_p.func_180495_p(blockpos);
              Block block = iblockstate.func_177230_c();
@@ -184,7 +261,7 @@
          }
      }
  
-@@ -1287,6 +1304,9 @@
+@@ -1287,6 +1339,9 @@
  
      public void func_180430_e(float p_180430_1_, float p_180430_2_)
      {
@@ -194,7 +271,7 @@
          super.func_180430_e(p_180430_1_, p_180430_2_);
          PotionEffect potioneffect = this.func_70660_b(MobEffects.field_76430_j);
          float f = potioneffect == null ? 0.0F : (float)(potioneffect.func_76458_c() + 1);
-@@ -1303,7 +1323,7 @@
+@@ -1303,7 +1358,7 @@
  
              if (iblockstate.func_185904_a() != Material.field_151579_a)
              {
@@ -203,7 +280,7 @@
                  this.func_184185_a(soundtype.func_185842_g(), soundtype.func_185843_a() * 0.5F, soundtype.func_185847_b() * 0.75F);
              }
          }
-@@ -1380,17 +1400,20 @@
+@@ -1380,17 +1435,20 @@
      {
          if (!this.func_180431_b(p_70665_1_))
          {
@@ -225,7 +302,7 @@
                  this.func_110149_m(this.func_110139_bj() - p_70665_2_);
              }
          }
-@@ -1447,6 +1470,11 @@
+@@ -1447,6 +1505,11 @@
  
      public void func_184609_a(EnumHand p_184609_1_)
      {
@@ -237,7 +314,7 @@
          if (!this.field_82175_bq || this.field_110158_av >= this.func_82166_i() / 2 || this.field_110158_av < 0)
          {
              this.field_110158_av = -1;
-@@ -1694,7 +1722,7 @@
+@@ -1694,7 +1757,7 @@
  
                      if (!this.field_70170_p.func_184143_b(axisalignedbb1))
                      {
@@ -246,7 +323,7 @@
                          {
                              this.func_70634_a(d11, this.field_70163_u + 1.0D, d12);
                              return;
-@@ -1702,14 +1730,14 @@
+@@ -1702,14 +1765,14 @@
  
                          BlockPos blockpos = new BlockPos(d11, this.field_70163_u - 1.0D, d12);
  
@@ -263,7 +340,7 @@
                      {
                          d1 = d11;
                          d13 = this.field_70163_u + 2.0D;
-@@ -1781,16 +1809,17 @@
+@@ -1781,16 +1844,17 @@
          }
  
          this.field_70160_al = true;
@@ -283,7 +360,7 @@
      }
  
      protected float func_189749_co()
-@@ -1874,7 +1903,8 @@
+@@ -1874,7 +1938,8 @@
  
                          if (this.field_70122_E)
                          {
@@ -293,7 +370,7 @@
                          }
  
                          float f7 = 0.16277136F / (f6 * f6 * f6);
-@@ -1894,7 +1924,8 @@
+@@ -1894,7 +1959,8 @@
  
                          if (this.field_70122_E)
                          {
@@ -303,7 +380,7 @@
                          }
  
                          if (this.func_70617_f_())
-@@ -2054,6 +2085,7 @@
+@@ -2054,6 +2120,7 @@
  
      public void func_70071_h_()
      {
@@ -311,7 +388,7 @@
          super.func_70071_h_();
          this.func_184608_ct();
  
-@@ -2096,7 +2128,9 @@
+@@ -2096,7 +2163,9 @@
  
                  if (!ItemStack.func_77989_b(itemstack1, itemstack))
                  {
@@ -321,7 +398,7 @@
  
                      if (!itemstack.func_190926_b())
                      {
-@@ -2575,6 +2609,40 @@
+@@ -2575,6 +2644,40 @@
          this.field_70752_e = true;
      }
  
@@ -362,7 +439,7 @@
      public abstract EnumHandSide func_184591_cq();
  
      public boolean func_184587_cr()
-@@ -2595,12 +2663,19 @@
+@@ -2595,12 +2698,19 @@
  
              if (itemstack == this.field_184627_bm)
              {
@@ -383,7 +460,7 @@
                  {
                      this.func_71036_o();
                  }
-@@ -2618,8 +2693,10 @@
+@@ -2618,8 +2728,10 @@
  
          if (!itemstack.func_190926_b() && !this.func_184587_cr())
          {
@@ -395,7 +472,29 @@
  
              if (!this.field_70170_p.field_72995_K)
              {
-@@ -2700,7 +2777,10 @@
+@@ -2656,6 +2768,21 @@
+                 this.field_184628_bn = 0;
+             }
+         }
++        
++        if (WATCHER_POTION_EFFECTS.equals(p_184206_1_) && field_70170_p.field_72995_K)
++        {
++    		NBTTagList nbttaglist = this.field_70180_af.func_187225_a(WATCHER_POTION_EFFECTS).func_150295_c("ActiveEffects", 10);
++    		field_70713_bf.clear();
++    		for (int i = 0; i < nbttaglist.func_74745_c(); ++i)
++    		{
++    			NBTTagCompound nbttagcompound = nbttaglist.func_150305_b(i);
++    			PotionEffect potioneffect = PotionEffect.func_82722_b(nbttagcompound);
++    			if (potioneffect != null)
++    			{
++    				func_70690_d(potioneffect);
++    			}
++    		}
++        }
+     }
+ 
+     protected void func_184584_a(ItemStack p_184584_1_, int p_184584_2_)
+@@ -2700,7 +2827,10 @@
          if (!this.field_184627_bm.func_190926_b() && this.func_184587_cr())
          {
              this.func_184584_a(this.field_184627_bm, 16);
@@ -407,7 +506,7 @@
              this.func_184602_cy();
          }
      }
-@@ -2724,7 +2804,8 @@
+@@ -2724,7 +2854,8 @@
      {
          if (!this.field_184627_bm.func_190926_b())
          {
@@ -417,7 +516,7 @@
          }
  
          this.func_184602_cy();
-@@ -2852,6 +2933,31 @@
+@@ -2852,6 +2983,31 @@
          return true;
      }
  
@@ -449,7 +548,7 @@
      public boolean func_190631_cK()
      {
          return true;
-@@ -2861,4 +2967,30 @@
+@@ -2861,4 +3017,30 @@
      public void func_191987_a(BlockPos p_191987_1_, boolean p_191987_2_)
      {
      }


### PR DESCRIPTION
WatcherPotionEffect is a watcher added to make sure that the client and
server are always in agreement with which potion effects are active. The
client does **not** influence what potion effects the server has on any given
LivingEntity.

LastHealth acts similarly to Heath as it is always one step behind what
health was. This data is persistent and written to the nbt and a getter and setter were added.

I have created mod that uses both of these features called [Damage Indicator](https://github.com/Z-Doctor/DamageIndicator) that uses these values to draw the entities health above its head as it would look for the player, including potion effects.

LastHealth is needed so that a ghostly heart can be drawn where the health was at before the previous injury.

I have tested as well as I am able and have not found any problems.

Here is a [forum post](http://www.minecraftforge.net/forum/topic/66408-suggestion-for-a-few-small-changes/?do=findComment&comment=318367) as to why I felt that these additions were necessary as well as some pictures of the mod. **Note:** I have changed some of the code given in that post to better integrate it into the forge code and required fewer changes than I originally thought.