### PR TITLE
Modified despawnEntity() in EntityLiving to allow forge event to be called in all ticks

### DIFF
--- a/patches/minecraft/net/minecraft/entity/EntityLiving.java.patch
+++ b/patches/minecraft/net/minecraft/entity/EntityLiving.java.patch
@@ -26,7 +26,7 @@
          {
              this.field_70708_bq = 0;
          }
-+        else if ((this.field_70708_bq & 0x1F) == 0x1F && (result = net.minecraftforge.event.ForgeEventFactory.canEntityDespawn(this)) != net.minecraftforge.fml.common.eventhandler.Event.Result.DEFAULT)
++        else if ((result = net.minecraftforge.event.ForgeEventFactory.canEntityDespawn(this)) != net.minecraftforge.fml.common.eventhandler.Event.Result.DEFAULT)
 +        {
 +            if (result == net.minecraftforge.fml.common.eventhandler.Event.Result.DENY)
 +            {


### PR DESCRIPTION
Modified despawnEntity() to allow forge AllowDespawn event to be called every tick, not just every 32nd one.

This is a fix to issues #4485 (closed)  and #5148 