### PR TITLE
Add a notification event for handling game rule changes

### DIFF
--- a/patches/minecraft/net/minecraft/command/CommandGameRule.java.patch
+++ b/patches/minecraft/net/minecraft/command/CommandGameRule.java.patch
@@ -1,0 +1,10 @@
+--- ../src-base/minecraft/net/minecraft/command/CommandGameRule.java
++++ ../src-work/minecraft/net/minecraft/command/CommandGameRule.java
+@@ -73,6 +73,7 @@
+                 entityplayermp.field_71135_a.func_147359_a(new SPacketEntityStatus(entityplayermp, b0));
+             }
+         }
++        net.minecraftforge.event.ForgeEventFactory.onGameRuleChange(p_184898_0_, p_184898_1_, p_184898_2_);
+     }
+ 
+     public List<String> func_184883_a(MinecraftServer p_184883_1_, ICommandSender p_184883_2_, String[] p_184883_3_, @Nullable BlockPos p_184883_4_)

--- a/src/main/java/net/minecraftforge/event/ForgeEventFactory.java
+++ b/src/main/java/net/minecraftforge/event/ForgeEventFactory.java
@@ -25,7 +25,6 @@ import java.util.List;
 import java.util.Random;
 
 import net.minecraft.block.BlockPortal;
-import net.minecraft.block.material.Material;
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.client.util.ITooltipFlag;
 import net.minecraft.entity.Entity;
@@ -44,6 +43,7 @@ import net.minecraft.entity.projectile.EntityThrowable;
 import net.minecraft.init.Blocks;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
+import net.minecraft.server.MinecraftServer;
 import net.minecraft.tileentity.MobSpawnerBaseLogic;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.ActionResult;
@@ -62,6 +62,7 @@ import net.minecraft.util.text.ChatType;
 import net.minecraft.util.text.ITextComponent;
 import net.minecraft.village.Village;
 import net.minecraft.world.Explosion;
+import net.minecraft.world.GameRules;
 import net.minecraft.world.World;
 import net.minecraft.world.WorldServer;
 import net.minecraft.world.WorldSettings;
@@ -792,5 +793,10 @@ public class ForgeEventFactory
 
         Result result = event.getResult();
         return result == Result.DEFAULT ? world.getGameRules().getBoolean("mobGriefing") : result == Result.ALLOW;
+    }
+
+    public static void onGameRuleChange(GameRules rules, String ruleName, MinecraftServer server)
+    {
+        MinecraftForge.EVENT_BUS.post(new GameRuleChangeEvent(rules, ruleName, server));
     }
 }

--- a/src/main/java/net/minecraftforge/event/GameRuleChangeEvent.java
+++ b/src/main/java/net/minecraftforge/event/GameRuleChangeEvent.java
@@ -1,0 +1,59 @@
+/*
+ * Minecraft Forge
+ * Copyright (c) 2016-2018.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation version 2.1
+ * of the License.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+package net.minecraftforge.event;
+
+import net.minecraft.server.MinecraftServer;
+import net.minecraft.world.GameRules;
+import net.minecraftforge.fml.common.eventhandler.Event;
+
+/**
+ * Fired when a game rule is changed,
+ * via {@link net.minecraft.command.CommandGameRule#notifyGameRuleChange(GameRules, String, MinecraftServer)}.
+ *
+ * This allows updating clients with the effects of server rule changes.
+ */
+public class GameRuleChangeEvent extends Event
+{
+    private final GameRules rules;
+    private final String ruleName;
+    private final MinecraftServer server;
+
+    public GameRuleChangeEvent(GameRules rules, String ruleName, MinecraftServer server)
+    {
+        this.rules = rules;
+        this.ruleName = ruleName;
+        this.server = server;
+    }
+
+    public GameRules getRules()
+    {
+        return rules;
+    }
+
+    public String getRuleName()
+    {
+        return ruleName;
+    }
+
+    public MinecraftServer getServer()
+    {
+        return server;
+    }
+}


### PR DESCRIPTION
This adds a new `GameRuleChangeEvent`, which is fired from `CommandGameRule.notifyGameRuleChange` when a game rule is changed.

This allows mods to react to game rule changes and send updates to clients without requiring continous polling.

As an example, the vanilla game uses `notifyGameRuleChange` to handle changes to the `reducedDebugInfo` game rule.