### PR TITLE
Class transformer optimization

### DIFF
--- a/src/main/java/net/minecraftforge/fml/common/asm/transformers/DeobfuscationTransformer.java
+++ b/src/main/java/net/minecraftforge/fml/common/asm/transformers/DeobfuscationTransformer.java
@@ -19,8 +19,12 @@
 
 package net.minecraftforge.fml.common.asm.transformers;
 
+import java.util.Arrays;
+
 import net.minecraft.launchwrapper.IClassNameTransformer;
 import net.minecraft.launchwrapper.IClassTransformer;
+import net.minecraft.launchwrapper.Launch;
+
 import net.minecraftforge.fml.common.asm.transformers.deobf.FMLDeobfuscatingRemapper;
 import net.minecraftforge.fml.common.asm.transformers.deobf.FMLRemappingAdapter;
 
@@ -29,6 +33,22 @@ import org.objectweb.asm.ClassWriter;
 import org.objectweb.asm.commons.RemappingClassAdapter;
 
 public class DeobfuscationTransformer implements IClassTransformer, IClassNameTransformer {
+    private static final String[] EXEMPT_LIBS = new String[] {
+            "com.google.",
+            "com.mojang.",
+            "joptsimple.",
+            "io.netty.",
+            "it.unimi.dsi.fastutil.",
+            "oshi.",
+            "com.sun.",
+            "com.ibm.",
+            "paulscode.",
+            "com.jcraft"
+    };
+    private static final String[] EXEMPT_DEV = new String[] {
+            "net.minecraft.",
+            "net.minecraftforge."
+    };
 
     private static final boolean RECALC_FRAMES = Boolean.parseBoolean(System.getProperty("FORGE_FORCE_FRAME_RECALC", "false"));
     private static final int WRITER_FLAGS = ClassWriter.COMPUTE_MAXS | (RECALC_FRAMES ? ClassWriter.COMPUTE_FRAMES : 0);
@@ -38,6 +58,8 @@ public class DeobfuscationTransformer implements IClassTransformer, IClassNameTr
     // If reported we need to add a custom implementation of ClassWriter.getCommonSuperClass
     // that does not cause class loading.
 
+    private boolean deobfuscatedEnvironment = (Boolean) Launch.blackboard.get("fml.deobfuscatedEnvironment");
+
     @Override
     public byte[] transform(String name, String transformedName, byte[] bytes)
     {
@@ -45,11 +67,28 @@ public class DeobfuscationTransformer implements IClassTransformer, IClassNameTr
         {
             return null;
         }
+
+        if (!shouldTransform(name)) return bytes;
+
         ClassReader classReader = new ClassReader(bytes);
         ClassWriter classWriter = new ClassWriter(WRITER_FLAGS);
         RemappingClassAdapter remapAdapter = new FMLRemappingAdapter(classWriter);
         classReader.accept(remapAdapter, READER_FLAGS);
         return classWriter.toByteArray();
+    }
+
+    private boolean shouldTransform(String name)
+    {
+        boolean transformLib = Arrays.stream(EXEMPT_LIBS).noneMatch(name::startsWith);
+
+        if (deobfuscatedEnvironment)
+        {
+            return transformLib && Arrays.stream(EXEMPT_DEV).noneMatch(name::startsWith);
+        }
+        else
+        {
+            return transformLib;
+        }
     }
 
     @Override


### PR DESCRIPTION
### What?

This PR optimizes some Forge class transformers, greatly reducing startup time in a dev environment.
 - `DeobfuscationTransformer`: This is run on external libraries, which should never contain references to anything in the MC source, they can be skipped. Additionally, in a dev environment, vanilla class names are already all deobfuscated, so these can be skipped too.
 - `TerminalTransformer`: Minor optimization; currently serializes classes even if they were not modified at all. It has been changed here to skip serialization if nothing changed.

### Performance
This can have a large impact on performance on slower CPUs, as can be seen here in profiler results during startup:
![Before](https://i.imgur.com/ovaSJgE.png)
->
![After](https://i.imgur.com/L6eKbjU.png)
