### PR TITLE
[1.12] Trimmed Server start parameters

### DIFF
--- a/src/main/java/net/minecraftforge/fml/relauncher/ServerLaunchWrapper.java
+++ b/src/main/java/net/minecraftforge/fml/relauncher/ServerLaunchWrapper.java
@@ -67,6 +67,11 @@ public class ServerLaunchWrapper {
             allArgs[0] = "--tweakClass";
             allArgs[1] = "net.minecraftforge.fml.common.launcher.FMLServerTweaker";
             System.arraycopy(args, 0, allArgs, 2, args.length);
+
+            if (allArgs[allArgs.length - 1].endsWith("\r")) {
+                allArgs[allArgs.length - 1] = allArgs[allArgs.length - 1].substring(0, allArgs[allArgs.length - 1].length() - 1);
+            }
+
             main.invoke(null,(Object)allArgs);
         }
         catch (Exception e)


### PR DESCRIPTION
Added in extra check for server start parameters to strip any trailing \r characters
When starting a server from a script on the Linux terminal, but the script is in dos format the extra \r is passed into the parameter when starting the server causing it to ignore the arguments

Basically i was trying to start a server from the terminal, and up popped the GUI (well, firstly it failed because it was trying to lunch the GUI on my server), and then using X forwarding, the UI popped up

I experimented a bit, seems that on Linux if the script is dos format the trailing \r is send as past of the last argument making forge (and the server) ignore the "nogui\r" option

This PR just cleans up the last argument removing a trailing \r if its there (only on server)