### PR TITLE
Extend Potion ID limit from 255 to Integer.MAX_VALUE - 1

### DIFF
--- a/patches/minecraft/net/minecraft/client/network/NetHandlerPlayClient.java.patch
+++ b/patches/minecraft/net/minecraft/client/network/NetHandlerPlayClient.java.patch
@@ -87,7 +87,7 @@
          if (entity instanceof EntityLivingBase)
          {
 -            Potion potion = Potion.func_188412_a(p_147260_1_.func_149427_e());
-+            Potion potion = Potion.func_188412_a(p_147260_1_.func_149427_e() & 0xFF);
++            Potion potion = Potion.func_188412_a(p_147260_1_.getEffectId());
  
              if (potion != null)
              {

--- a/patches/minecraft/net/minecraft/network/play/server/SPacketEntityEffect.java.patch
+++ b/patches/minecraft/net/minecraft/network/play/server/SPacketEntityEffect.java.patch
@@ -1,0 +1,47 @@
+--- ../src-base/minecraft/net/minecraft/network/play/server/SPacketEntityEffect.java
++++ ../src-work/minecraft/net/minecraft/network/play/server/SPacketEntityEffect.java
+@@ -12,7 +12,7 @@
+ public class SPacketEntityEffect implements Packet<INetHandlerPlayClient>
+ {
+     private int field_149434_a;
+-    private byte field_149432_b;
++    private int field_149432_b;
+     private byte field_149433_c;
+     private int field_149431_d;
+     private byte field_186985_e;
+@@ -24,7 +24,7 @@
+     public SPacketEntityEffect(int p_i46891_1_, PotionEffect p_i46891_2_)
+     {
+         this.field_149434_a = p_i46891_1_;
+-        this.field_149432_b = (byte)(Potion.func_188409_a(p_i46891_2_.func_188419_a()) & 255);
++        this.field_149432_b = Potion.func_188409_a(p_i46891_2_.func_188419_a());
+         this.field_149433_c = (byte)(p_i46891_2_.func_76458_c() & 255);
+ 
+         if (p_i46891_2_.func_76459_b() > 32767)
+@@ -52,7 +52,7 @@
+     public void func_148837_a(PacketBuffer p_148837_1_) throws IOException
+     {
+         this.field_149434_a = p_148837_1_.func_150792_a();
+-        this.field_149432_b = p_148837_1_.readByte();
++        this.field_149432_b = p_148837_1_.func_150792_a();
+         this.field_149433_c = p_148837_1_.readByte();
+         this.field_149431_d = p_148837_1_.func_150792_a();
+         this.field_186985_e = p_148837_1_.readByte();
+@@ -61,7 +61,7 @@
+     public void func_148840_b(PacketBuffer p_148840_1_) throws IOException
+     {
+         p_148840_1_.func_150787_b(this.field_149434_a);
+-        p_148840_1_.writeByte(this.field_149432_b);
++        p_148840_1_.func_150787_b(this.field_149432_b);
+         p_148840_1_.writeByte(this.field_149433_c);
+         p_148840_1_.func_150787_b(this.field_149431_d);
+         p_148840_1_.writeByte(this.field_186985_e);
+@@ -85,7 +85,7 @@
+     }
+ 
+     @SideOnly(Side.CLIENT)
+-    public byte func_149427_e()
++    public int getEffectId()
+     {
+         return this.field_149432_b;
+     }

--- a/patches/minecraft/net/minecraft/network/play/server/SPacketRemoveEntityEffect.java.patch
+++ b/patches/minecraft/net/minecraft/network/play/server/SPacketRemoveEntityEffect.java.patch
@@ -1,0 +1,18 @@
+--- ../src-base/minecraft/net/minecraft/network/play/server/SPacketRemoveEntityEffect.java
++++ ../src-work/minecraft/net/minecraft/network/play/server/SPacketRemoveEntityEffect.java
+@@ -29,13 +29,13 @@
+     public void func_148837_a(PacketBuffer p_148837_1_) throws IOException
+     {
+         this.field_149079_a = p_148837_1_.func_150792_a();
+-        this.field_149078_b = Potion.func_188412_a(p_148837_1_.readUnsignedByte());
++        this.field_149078_b = Potion.func_188412_a(p_148837_1_.func_150792_a());
+     }
+ 
+     public void func_148840_b(PacketBuffer p_148840_1_) throws IOException
+     {
+         p_148840_1_.func_150787_b(this.field_149079_a);
+-        p_148840_1_.writeByte(Potion.func_188409_a(this.field_149078_b));
++        p_148840_1_.func_150787_b(Potion.func_188409_a(this.field_149078_b));
+     }
+ 
+     public void func_148833_a(INetHandlerPlayClient p_148833_1_)

--- a/patches/minecraft/net/minecraft/potion/PotionEffect.java.patch
+++ b/patches/minecraft/net/minecraft/potion/PotionEffect.java.patch
@@ -17,7 +17,13 @@
      }
  
      public void func_76452_a(PotionEffect p_76452_1_)
-@@ -195,12 +198,13 @@
+@@ -190,17 +193,18 @@
+ 
+     public NBTTagCompound func_82719_a(NBTTagCompound p_82719_1_)
+     {
+-        p_82719_1_.func_74774_a("Id", (byte)Potion.func_188409_a(this.func_188419_a()));
++        p_82719_1_.func_74768_a("Id", Potion.func_188409_a(this.func_188419_a()));
+         p_82719_1_.func_74774_a("Amplifier", (byte)this.func_76458_c());
          p_82719_1_.func_74768_a("Duration", this.func_76459_b());
          p_82719_1_.func_74757_a("Ambient", this.func_82720_e());
          p_82719_1_.func_74757_a("ShowParticles", this.func_188418_e());
@@ -28,7 +34,7 @@
      public static PotionEffect func_82722_b(NBTTagCompound p_82722_0_)
      {
 -        int i = p_82722_0_.func_74771_c("Id");
-+        int i = p_82722_0_.func_74771_c("Id") & 0xFF;
++        int i = p_82722_0_.func_74762_e("Id");
          Potion potion = Potion.func_188412_a(i);
  
          if (potion == null)

--- a/src/main/java/net/minecraftforge/registries/GameData.java
+++ b/src/main/java/net/minecraftforge/registries/GameData.java
@@ -102,7 +102,7 @@ public class GameData
     private static final int MAX_BLOCK_ID = 4095;
     private static final int MIN_ITEM_ID = MAX_BLOCK_ID + 1;
     private static final int MAX_ITEM_ID = 31999;
-    private static final int MAX_POTION_ID = 255; // SPacketEntityEffect sends bytes, we can only use 255
+    private static final int MAX_POTION_ID = Integer.MAX_VALUE - 1; // Int (SPacketEntityEffect)
     private static final int MAX_BIOME_ID = 255; // Maximum number in a byte in the chunk
     private static final int MAX_SOUND_ID = Integer.MAX_VALUE >> 5; // Varint (SPacketSoundEffect)
     private static final int MAX_POTIONTYPE_ID = Integer.MAX_VALUE >> 5; // Int (SPacketEffect)


### PR DESCRIPTION
Most of the times the id was already an integer. It was cast into byte in the packet and in a couple instances, after getting the value, it was `AND`ed with `0xFF` for some reason.
With the increasing number of mods using potion effects, many modpacks are running out of IDs, and I feel like this is a change that belongs to forge.
It's been a while since I actually contributed to forge, **I'm not sure I generated my patches properly**, some functions use names like `func_149427_e()`, while in the lines I changed in patch files the names are the human readable, as in `getEffectId()`