### PR TITLE
Fix NPE on clientside entities constructed with null world

### DIFF
--- a/patches/minecraft/net/minecraft/entity/Entity.java.patch
+++ b/patches/minecraft/net/minecraft/entity/Entity.java.patch
@@ -50,7 +50,7 @@
          this.field_70165_t = p_70107_1_;
          this.field_70163_u = p_70107_3_;
          this.field_70161_v = p_70107_5_;
-+        if (!this.field_70170_p.field_72995_K && this.isAddedToWorld()) this.field_70170_p.func_72866_a(this, false); // Forge - Process chunk registration after moving.
++        if (this.isAddedToWorld() && !this.field_70170_p.field_72995_K) this.field_70170_p.func_72866_a(this, false); // Forge - Process chunk registration after moving.
          float f = this.field_70130_N / 2.0F;
          float f1 = this.field_70131_O;
          this.func_174826_a(new AxisAlignedBB(p_70107_1_ - (double)f, p_70107_3_, p_70107_5_ - (double)f, p_70107_1_ + (double)f, p_70107_3_ + (double)f1, p_70107_5_ + (double)f));
@@ -58,7 +58,7 @@
          this.field_70165_t = (axisalignedbb.field_72340_a + axisalignedbb.field_72336_d) / 2.0D;
          this.field_70163_u = axisalignedbb.field_72338_b;
          this.field_70161_v = (axisalignedbb.field_72339_c + axisalignedbb.field_72334_f) / 2.0D;
-+        if (!this.field_70170_p.field_72995_K && this.isAddedToWorld()) this.field_70170_p.func_72866_a(this, false); // Forge - Process chunk registration after moving.
++        if (this.isAddedToWorld() && !this.field_70170_p.field_72995_K) this.field_70170_p.func_72866_a(this, false); // Forge - Process chunk registration after moving.
      }
  
      protected SoundEvent func_184184_Z()

--- a/patches/minecraft/net/minecraft/entity/EntityLeashKnot.java.patch
+++ b/patches/minecraft/net/minecraft/entity/EntityLeashKnot.java.patch
@@ -4,7 +4,7 @@
          this.field_70165_t = (double)this.field_174861_a.func_177958_n() + 0.5D;
          this.field_70163_u = (double)this.field_174861_a.func_177956_o() + 0.5D;
          this.field_70161_v = (double)this.field_174861_a.func_177952_p() + 0.5D;
-+        if (!this.field_70170_p.field_72995_K && this.isAddedToWorld()) this.field_70170_p.func_72866_a(this, false); // Forge - Process chunk registration after moving.
++        if (this.isAddedToWorld() && !this.field_70170_p.field_72995_K) this.field_70170_p.func_72866_a(this, false); // Forge - Process chunk registration after moving.
      }
  
      public void func_174859_a(EnumFacing p_174859_1_)

--- a/patches/minecraft/net/minecraft/entity/monster/EntityShulker.java.patch
+++ b/patches/minecraft/net/minecraft/entity/monster/EntityShulker.java.patch
@@ -4,7 +4,7 @@
              this.field_70165_t = (double)blockpos.func_177958_n() + 0.5D;
              this.field_70163_u = (double)blockpos.func_177956_o();
              this.field_70161_v = (double)blockpos.func_177952_p() + 0.5D;
-+            if (!this.field_70170_p.field_72995_K && this.isAddedToWorld()) this.field_70170_p.func_72866_a(this, false); // Forge - Process chunk registration after moving.
++            if (this.isAddedToWorld() && !this.field_70170_p.field_72995_K) this.field_70170_p.func_72866_a(this, false); // Forge - Process chunk registration after moving.
              this.field_70169_q = this.field_70165_t;
              this.field_70167_r = this.field_70163_u;
              this.field_70166_s = this.field_70161_v;


### PR DESCRIPTION
This simply reverses the order of operations of the changes made in #5168, since the world can never be null if `isAddedToWorld()` returns true.