### PR TITLE
Add method for getting rotation of a block

### DIFF
--- a/patches/minecraft/net/minecraft/block/Block.java.patch
+++ b/patches/minecraft/net/minecraft/block/Block.java.patch
@@ -1180,14 +1180,14 @@
 +
 +    /**
 +     * Get current rotation of the block at the specified coordinates. Null means block doesn't support rotating.
-+     * @param world The world
++     * @param state The current state
++     * @param blockAccess The blockAccess
 +     * @param pos Block position in world
 +     * @return EnumFacing representing rotation, or null for unknown
 +     */
 +    @Nullable
-+    public EnumFacing getRotation(World world, BlockPos pos)
++    public EnumFacing getRotation(IBlockState state, IBlockAccess blockAccess, BlockPos pos)
 +    {
-+        IBlockState state = world.func_180495_p(pos);
 +        for (IProperty<?> prop : state.func_177228_b().keySet())
 +        {
 +            if ((prop.func_177701_a().equals("facing") || prop.func_177701_a().equals("rotation")) && prop.func_177699_b() == EnumFacing.class)

--- a/patches/minecraft/net/minecraft/block/Block.java.patch
+++ b/patches/minecraft/net/minecraft/block/Block.java.patch
@@ -1192,7 +1192,7 @@
 +        {
 +            if ((prop.func_177701_a().equals("facing") || prop.func_177701_a().equals("rotation")) && prop.func_177699_b() == EnumFacing.class)
 +            {
-+                return (EnumFacing) world.func_180495_p(pos).func_177229_b(prop);
++                return (EnumFacing) state.func_177229_b(prop);
 +            }
 +        }
 +        return null;

--- a/patches/minecraft/net/minecraft/block/Block.java.patch
+++ b/patches/minecraft/net/minecraft/block/Block.java.patch
@@ -221,7 +221,7 @@
      public SoundType func_185467_w()
      {
          return this.field_149762_H;
-@@ -934,6 +952,1361 @@
+@@ -934,6 +952,1381 @@
      {
      }
  
@@ -1179,6 +1179,26 @@
 +    }
 +
 +    /**
++     * Get current rotation of the block at the specified coordinates. Null means block doesn't support rotating.
++     * @param world The world
++     * @param pos Block position in world
++     * @return EnumFacing representing rotation, or null for unknown
++     */
++    @Nullable
++    public EnumFacing getRotation(World world, BlockPos pos)
++    {
++        IBlockState state = world.func_180495_p(pos);
++        for (IProperty<?> prop : state.func_177228_b().keySet())
++        {
++            if ((prop.func_177701_a().equals("facing") || prop.func_177701_a().equals("rotation")) && prop.func_177699_b() == EnumFacing.class)
++            {
++                return (EnumFacing) world.func_180495_p(pos).func_177229_b(prop);
++            }
++        }
++        return null;
++    }
++
++    /**
 +     * Determines the amount of enchanting power this block can provide to an enchanting table.
 +     * @param world The World
 +     * @param pos Block position in world
@@ -1583,7 +1603,7 @@
      public static void func_149671_p()
      {
          func_176215_a(0, field_176230_a, (new BlockAir()).func_149663_c("air"));
-@@ -1105,7 +2478,7 @@
+@@ -1105,7 +2498,7 @@
          Block block11 = (new BlockQuartz()).func_149672_a(SoundType.field_185851_d).func_149711_c(0.8F).func_149663_c("quartzBlock");
          func_176219_a(155, "quartz_block", block11);
          func_176219_a(156, "quartz_stairs", (new BlockStairs(block11.func_176223_P().func_177226_a(BlockQuartz.field_176335_a, BlockQuartz.EnumType.DEFAULT))).func_149663_c("stairsQuartz"));
@@ -1592,7 +1612,7 @@
          func_176219_a(158, "dropper", (new BlockDropper()).func_149711_c(3.5F).func_149672_a(SoundType.field_185851_d).func_149663_c("dropper"));
          func_176219_a(159, "stained_hardened_clay", (new BlockStainedHardenedClay()).func_149711_c(1.25F).func_149752_b(7.0F).func_149672_a(SoundType.field_185851_d).func_149663_c("clayHardenedStained"));
          func_176219_a(160, "stained_glass_pane", (new BlockStainedGlassPane()).func_149711_c(0.3F).func_149672_a(SoundType.field_185853_f).func_149663_c("thinStainedGlass"));
-@@ -1230,31 +2603,6 @@
+@@ -1230,31 +2623,6 @@
                  block15.field_149783_u = flag;
              }
          }

--- a/src/test/java/net/minecraftforge/debug/util/RotatingWrench.java
+++ b/src/test/java/net/minecraftforge/debug/util/RotatingWrench.java
@@ -32,6 +32,7 @@ import net.minecraft.util.EnumFacing;
 import net.minecraft.util.EnumHand;
 import net.minecraft.util.ResourceLocation;
 import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.text.TextComponentString;
 import net.minecraft.world.World;
 import net.minecraftforge.client.event.ModelRegistryEvent;
 import net.minecraftforge.client.model.ModelLoader;
@@ -79,6 +80,11 @@ public class RotatingWrench
         @Override
         public EnumActionResult onItemUse(EntityPlayer player, World worldIn, BlockPos pos, EnumHand hand, EnumFacing facing, float hitX, float hitY, float hitZ)
         {
+            if (!player.world.isRemote)
+            {
+                player.sendStatusMessage(new TextComponentString("Facing before rotation: " + worldIn.getBlockState(pos).getBlock().getRotation(worldIn, pos)), false);
+            }
+
             ItemStack wrench = player.getHeldItem(hand);
             if (player.canPlayerEdit(pos, facing, wrench) && worldIn.isBlockModifiable(player, pos))
             {

--- a/src/test/java/net/minecraftforge/debug/util/RotatingWrench.java
+++ b/src/test/java/net/minecraftforge/debug/util/RotatingWrench.java
@@ -82,7 +82,8 @@ public class RotatingWrench
         {
             if (!player.world.isRemote)
             {
-                player.sendStatusMessage(new TextComponentString("Facing before rotation: " + worldIn.getBlockState(pos).getBlock().getRotation(worldIn, pos)), false);
+                IBlockState state = worldIn.getBlockState(pos);
+                player.sendStatusMessage(new TextComponentString("Facing before rotation: " + state.getBlock().getRotation(state, worldIn, pos)), false);
             }
 
             ItemStack wrench = player.getHeldItem(hand);


### PR DESCRIPTION
There are already `rotateBlock` and `getValidRotations` methods but there is no method to actually get the rotation of the block. This PR adds it.

This method should allow various rotation dependent behaviors. In my case I need it to display current rotation of the block in an overlay when hover over the block itself while holding wrench.