### PR TITLE
Make Forge-provided default transforms accessible to custom models

### DIFF
--- a/src/main/java/net/minecraftforge/client/model/ForgeBlockStateV1.java
+++ b/src/main/java/net/minecraftforge/client/model/ForgeBlockStateV1.java
@@ -451,77 +451,6 @@ public class ForgeBlockStateV1 extends Marker
                     throw new UnsupportedOperationException("Forge BlockStateLoader V1 does not support nested submodels.");
             }
 
-            private static TRSRTransformation get(float tx, float ty, float tz, float ax, float ay, float az, float s)
-            {
-                return TRSRTransformation.blockCenterToCorner(new TRSRTransformation(
-                    new Vector3f(tx / 16, ty / 16, tz / 16),
-                    TRSRTransformation.quatFromXYZDegrees(new Vector3f(ax, ay, az)),
-                    new Vector3f(s, s, s),
-                    null));
-            }
-
-            private static final TRSRTransformation flipX = new TRSRTransformation(null, null, new Vector3f(-1, 1, 1), null);
-
-            private static TRSRTransformation leftify(TRSRTransformation transform)
-            {
-                return TRSRTransformation.blockCenterToCorner(flipX.compose(TRSRTransformation.blockCornerToCenter(transform)).compose(flipX));
-            }
-
-            // Note: these strings might change to a full-blown resource locations in the future, and move from here to some json somewhere
-            // TODO: vanilla now includes from parent, deprecate?
-            private static final ImmutableMap<String, IModelState> transforms;
-
-            static
-            {
-                ImmutableMap.Builder<String, IModelState> builder = ImmutableMap.builder();
-
-                builder.put("identity", TRSRTransformation.identity());
-
-                // block/block
-                {
-                    EnumMap<TransformType, TRSRTransformation> map = new EnumMap<>(TransformType.class);
-                    TRSRTransformation thirdperson = get(0, 2.5f, 0, 75, 45, 0, 0.375f);
-                    map.put(TransformType.GUI,                     get(0, 0, 0, 30, 225, 0, 0.625f));
-                    map.put(TransformType.GROUND,                  get(0, 3, 0, 0, 0, 0, 0.25f));
-                    map.put(TransformType.FIXED,                   get(0, 0, 0, 0, 0, 0, 0.5f));
-                    map.put(TransformType.THIRD_PERSON_RIGHT_HAND, thirdperson);
-                    map.put(TransformType.THIRD_PERSON_LEFT_HAND,  leftify(thirdperson));
-                    map.put(TransformType.FIRST_PERSON_RIGHT_HAND, get(0, 0, 0, 0, 45, 0, 0.4f));
-                    map.put(TransformType.FIRST_PERSON_LEFT_HAND,  get(0, 0, 0, 0, 225, 0, 0.4f));
-                    builder.put("forge:default-block", new SimpleModelState(ImmutableMap.copyOf(map)));
-                }
-
-                // item/generated
-                {
-                    EnumMap<TransformType, TRSRTransformation> map = new EnumMap<>(TransformType.class);
-                    TRSRTransformation thirdperson = get(0, 3, 1, 0, 0, 0, 0.55f);
-                    TRSRTransformation firstperson = get(1.13f, 3.2f, 1.13f, 0, -90, 25, 0.68f);
-                    map.put(TransformType.GROUND,                  get(0, 2, 0, 0, 0, 0, 0.5f));
-                    map.put(TransformType.HEAD,                    get(0, 13, 7, 0, 180, 0, 1));
-                    map.put(TransformType.THIRD_PERSON_RIGHT_HAND, thirdperson);
-                    map.put(TransformType.THIRD_PERSON_LEFT_HAND,  leftify(thirdperson));
-                    map.put(TransformType.FIRST_PERSON_RIGHT_HAND, firstperson);
-                    map.put(TransformType.FIRST_PERSON_LEFT_HAND,  leftify(firstperson));
-                    map.put(TransformType.FIXED,                   get(0, 0, 0, 0, 180, 0, 1));
-                    builder.put("forge:default-item", new SimpleModelState(ImmutableMap.copyOf(map)));
-                }
-
-                // item/handheld
-                {
-                    EnumMap<TransformType, TRSRTransformation> map = new EnumMap<>(TransformType.class);
-                    map.put(TransformType.GROUND,                  get(0, 2, 0, 0, 0, 0, 0.5f));
-                    map.put(TransformType.HEAD,                    get(0, 13, 7, 0, 180, 0, 1));
-                    map.put(TransformType.THIRD_PERSON_RIGHT_HAND, get(0, 4, 0.5f,         0, -90, 55, 0.85f));
-                    map.put(TransformType.THIRD_PERSON_LEFT_HAND,  get(0, 4, 0.5f,         0, 90, -55, 0.85f));
-                    map.put(TransformType.FIRST_PERSON_RIGHT_HAND, get(1.13f, 3.2f, 1.13f, 0, -90, 25, 0.68f));
-                    map.put(TransformType.FIRST_PERSON_LEFT_HAND,  get(1.13f, 3.2f, 1.13f, 0, 90, -25, 0.68f));
-                    map.put(TransformType.FIXED,                   get(0, 0, 0, 0, 180, 0, 1));
-                    builder.put("forge:default-tool", new SimpleModelState(ImmutableMap.copyOf(map)));
-                }
-
-                transforms = builder.build();
-            }
-
             @Override
             public ForgeBlockStateV1.Variant deserialize(JsonElement element, Type typeOfT, JsonDeserializationContext context) throws JsonParseException
             {
@@ -562,7 +491,7 @@ public class ForgeBlockStateV1 extends Marker
                     if (json.get("transform").isJsonPrimitive() && json.get("transform").getAsJsonPrimitive().isString())
                     {
                         String transform = json.get("transform").getAsString();
-                        ret.state = Optional.ofNullable(transforms.get(transform));
+                        ret.state = Transforms.get(transform);
                         if (!ret.state.isPresent())
                         {
                             throw new JsonParseException("transform: unknown default string: " + transform);
@@ -960,6 +889,83 @@ public class ForgeBlockStateV1 extends Marker
                 return parseAxisRotation(e);
             }
             else throw new JsonParseException("Rotation: expected array or object, got: " + e);
+        }
+    }
+
+    public static class Transforms
+    {
+        public static TRSRTransformation convert(float tx, float ty, float tz, float ax, float ay, float az, float s)
+        {
+            return convert(tx, ty, tz, ax, ay, az, s, s, s);
+        }
+
+        public static TRSRTransformation convert(float tx, float ty, float tz, float ax, float ay, float az, float sx, float sy, float sz)
+        {
+            return TRSRTransformation.blockCenterToCorner(new TRSRTransformation(
+                    new Vector3f(tx / 16, ty / 16, tz / 16),
+                    TRSRTransformation.quatFromXYZDegrees(new Vector3f(ax, ay, az)),
+                    new Vector3f(sx, sy, sz),
+                    null
+            ));
+        }
+
+        private static final TRSRTransformation flipX = new TRSRTransformation(null, null, new Vector3f(-1, 1, 1), null);
+
+        public static TRSRTransformation leftify(TRSRTransformation transform)
+        {
+            return TRSRTransformation.blockCenterToCorner(flipX.compose(TRSRTransformation.blockCornerToCenter(transform)).compose(flipX));
+        }
+
+        public static Optional<IModelState> get(String name)
+        {
+            return Optional.ofNullable(transforms.get(name));
+        }
+
+        // Note: these strings might change to a full-blown resource locations in the future, and move from here to some json somewhere
+        // TODO: vanilla now includes from parent, deprecate?
+        private static final ImmutableMap<String, IModelState> transforms;
+
+        static
+        {
+            ImmutableMap.Builder<String, IModelState> builder = ImmutableMap.builder();
+
+            builder.put("identity", TRSRTransformation.identity());
+
+            // block/block
+            EnumMap<TransformType, TRSRTransformation> block = new EnumMap<>(TransformType.class);
+            TRSRTransformation thirdPersonBlock = convert(0, 2.5f, 0, 75, 45, 0, 0.375f);
+            block.put(TransformType.GUI,                     convert(0, 0, 0, 30, 225, 0, 0.625f));
+            block.put(TransformType.GROUND,                  convert(0, 3, 0, 0, 0, 0, 0.25f));
+            block.put(TransformType.FIXED,                   convert(0, 0, 0, 0, 0, 0, 0.5f));
+            block.put(TransformType.THIRD_PERSON_RIGHT_HAND, thirdPersonBlock);
+            block.put(TransformType.THIRD_PERSON_LEFT_HAND,  leftify(thirdPersonBlock));
+            block.put(TransformType.FIRST_PERSON_RIGHT_HAND, convert(0, 0, 0, 0, 45, 0, 0.4f));
+            block.put(TransformType.FIRST_PERSON_LEFT_HAND,  convert(0, 0, 0, 0, 225, 0, 0.4f));
+            builder.put("forge:default-block", new SimpleModelState(ImmutableMap.copyOf(block)));
+
+            // item/generated
+            EnumMap<TransformType, TRSRTransformation> item = new EnumMap<>(TransformType.class);
+            TRSRTransformation thirdPersonItem = convert(0, 3, 1, 0, 0, 0, 0.55f);
+            TRSRTransformation firstPersonItem = convert(1.13f, 3.2f, 1.13f, 0, -90, 25, 0.68f);
+            item.put(TransformType.GROUND,                  convert(0, 2, 0, 0, 0, 0, 0.5f));
+            item.put(TransformType.HEAD,                    convert(0, 13, 7, 0, 180, 0, 1));
+            item.put(TransformType.THIRD_PERSON_RIGHT_HAND, thirdPersonItem);
+            item.put(TransformType.THIRD_PERSON_LEFT_HAND,  leftify(thirdPersonItem));
+            item.put(TransformType.FIRST_PERSON_RIGHT_HAND, firstPersonItem);
+            item.put(TransformType.FIRST_PERSON_LEFT_HAND,  leftify(firstPersonItem));
+            item.put(TransformType.FIXED,                   convert(0, 0, 0, 0, 180, 0, 1));
+            builder.put("forge:default-item", new SimpleModelState(ImmutableMap.copyOf(item)));
+
+            // item/handheld
+            EnumMap<TransformType, TRSRTransformation> tool = new EnumMap<>(TransformType.class);
+            tool.putAll(item);
+            tool.put(TransformType.THIRD_PERSON_RIGHT_HAND, convert(0, 4, 0.5f,         0, -90, 55, 0.85f));
+            tool.put(TransformType.THIRD_PERSON_LEFT_HAND,  convert(0, 4, 0.5f,         0, 90, -55, 0.85f));
+            tool.put(TransformType.FIRST_PERSON_RIGHT_HAND, convert(1.13f, 3.2f, 1.13f, 0, -90, 25, 0.68f));
+            tool.put(TransformType.FIRST_PERSON_LEFT_HAND,  convert(1.13f, 3.2f, 1.13f, 0, 90, -25, 0.68f));
+            builder.put("forge:default-tool", new SimpleModelState(ImmutableMap.copyOf(tool)));
+
+            transforms = builder.build();
         }
     }
 }


### PR DESCRIPTION
This moves the code for the Forge-provided [default transforms](https://gist.github.com/RainWarrior/0618131f51b8d37b80a6#file-forge-blockstate-v1-specs-L40-L46) from the `Variant.Deserializer` into a seperate `Transforms` class and makes them accessible for custom model implementations (e.g. can be supplied to a `PerspectiveMapWrapper`).