### PR TITLE
Make Forge blockstate variants correctly inherit AO setting from vanilla models

### DIFF
--- a/src/main/java/net/minecraftforge/client/model/BlockStateLoader.java
+++ b/src/main/java/net/minecraftforge/client/model/BlockStateLoader.java
@@ -28,6 +28,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Optional;
 
 import net.minecraft.client.renderer.block.model.ModelBlockDefinition;
 import net.minecraft.client.renderer.block.model.ModelRotation;
@@ -90,14 +91,12 @@ public class BlockStateLoader
                         for (ForgeBlockStateV1.Variant var : entry.getValue())
                         {
                             boolean uvLock = var.getUvLock().orElse(false);
-                            boolean smooth = var.getSmooth().orElse(true);
-                            boolean gui3d = var.getGui3d().orElse(true);
                             int weight = var.getWeight().orElse(1);
 
-                            if (var.getModel() != null && var.getSubmodels().size() == 0 && var.getTextures().size() == 0 && var.getCustomData().size() == 0 && var.getState().orElse(ModelRotation.X0_Y0) instanceof ModelRotation)
+                            if (var.getModel() != null && var.getSubmodels().isEmpty() && var.getTextures().isEmpty() && var.getCustomData().isEmpty() && var.getState().orElse(ModelRotation.X0_Y0) instanceof ModelRotation)
                                 mcVars.add(new Variant(var.getModel(), (ModelRotation)var.getState().orElse(ModelRotation.X0_Y0), uvLock, weight));
                             else
-                                mcVars.add(new ForgeVariant(location, var.getModel(), var.getState().orElse(TRSRTransformation.identity()), uvLock, smooth, gui3d, weight, var.getTextures(), var.getOnlyPartsVariant(), var.getCustomData()));
+                                mcVars.add(new ForgeVariant(location, var.getModel(), var.getState().orElse(TRSRTransformation.identity()), uvLock, var.getSmooth(), var.getGui3d(), weight, var.getTextures(), var.getOnlyPartsVariant(), var.getCustomData()));
                         }
                         variants.put(entry.getKey(), new VariantList(mcVars));
                     }
@@ -156,11 +155,11 @@ public class BlockStateLoader
         private final ImmutableMap<String, String> textures;
         private final ImmutableMap<String, SubModel> parts;
         private final ImmutableMap<String, String> customData;
-        private final boolean smooth;
-        private final boolean gui3d;
+        private final Optional<Boolean> smooth;
+        private final Optional<Boolean> gui3d;
         private final IModelState state;
 
-        public ForgeVariant(ResourceLocation blockstateLocation, @Nullable ResourceLocation model, IModelState state, boolean uvLock, boolean smooth, boolean gui3d, int weight, ImmutableMap<String, String> textures, ImmutableMap<String, SubModel> parts, ImmutableMap<String, String> customData)
+        ForgeVariant(ResourceLocation blockstateLocation, @Nullable ResourceLocation model, IModelState state, boolean uvLock, Optional<Boolean> smooth, Optional<Boolean> gui3d, int weight, ImmutableMap<String, String> textures, ImmutableMap<String, SubModel> parts, ImmutableMap<String, String> customData)
         {
             super(model == null ? new ResourceLocation("builtin/missing") : model, state instanceof ModelRotation ? (ModelRotation)state : ModelRotation.X0_Y0, uvLock, weight);
             this.blockstateLocation = blockstateLocation;
@@ -172,12 +171,12 @@ public class BlockStateLoader
             this.gui3d = gui3d;
         }
 
-        private IModel runModelHooks(IModel base, boolean smooth, boolean gui3d, boolean uvlock, ImmutableMap<String, String> textureMap, ImmutableMap<String, String> customData)
+        private IModel runModelHooks(IModel base, Optional<Boolean> smooth, Optional<Boolean> gui3d, boolean uvlock, ImmutableMap<String, String> textureMap, ImmutableMap<String, String> customData)
         {
             base = base.process(customData);
             base = base.retexture(textureMap);
-            base = base.smoothLighting(smooth);
-            base = base.gui3d(gui3d);
+            base = smooth.isPresent() ? base.smoothLighting(smooth.get()) : base;
+            base = gui3d.isPresent() ? base.gui3d(gui3d.get()) : base;
             base = base.uvlock(uvlock);
             return base;
         }
@@ -217,7 +216,7 @@ public class BlockStateLoader
                     model = ModelLoaderRegistry.getModelOrLogError(modelLocation, "Unable to load block sub-model: \'" + modelLocation);
                 }
 
-                models.put(entry.getKey(), Pair.of(runModelHooks(model, part.smooth, part.gui3d, part.uvLock, part.getTextures(), part.getCustomData()), part.getState()));
+                models.put(entry.getKey(), Pair.of(runModelHooks(model, Optional.of(part.smooth), Optional.of(part.gui3d), part.uvLock, part.getTextures(), part.getCustomData()), part.getState()));
             }
 
             return new MultiModel(getModelLocation(), hasBase ? base : null, models.build());

--- a/src/main/java/net/minecraftforge/client/model/BlockStateLoader.java
+++ b/src/main/java/net/minecraftforge/client/model/BlockStateLoader.java
@@ -93,7 +93,7 @@ public class BlockStateLoader
                             boolean uvLock = var.getUvLock().orElse(false);
                             int weight = var.getWeight().orElse(1);
 
-                            if (var.getModel() != null && var.getSubmodels().isEmpty() && var.getTextures().isEmpty() && var.getCustomData().isEmpty() && var.getState().orElse(ModelRotation.X0_Y0) instanceof ModelRotation)
+                            if (var.isVanillaCompatible())
                                 mcVars.add(new Variant(var.getModel(), (ModelRotation)var.getState().orElse(ModelRotation.X0_Y0), uvLock, weight));
                             else
                                 mcVars.add(new ForgeVariant(location, var.getModel(), var.getState().orElse(TRSRTransformation.identity()), uvLock, var.getSmooth(), var.getGui3d(), weight, var.getTextures(), var.getOnlyPartsVariant(), var.getCustomData()));

--- a/src/main/java/net/minecraftforge/client/model/BlockStateLoader.java
+++ b/src/main/java/net/minecraftforge/client/model/BlockStateLoader.java
@@ -175,8 +175,8 @@ public class BlockStateLoader
         {
             base = base.process(customData);
             base = base.retexture(textureMap);
-            base = smooth.isPresent() ? base.smoothLighting(smooth.get()) : base;
-            base = gui3d.isPresent() ? base.gui3d(gui3d.get()) : base;
+            base = smooth.map(base::smoothLighting).orElse(base);
+            base = gui3d.map(base::gui3d).orElse(base);
             base = base.uvlock(uvlock);
             return base;
         }

--- a/src/main/java/net/minecraftforge/client/model/ForgeBlockStateV1.java
+++ b/src/main/java/net/minecraftforge/client/model/ForgeBlockStateV1.java
@@ -385,6 +385,11 @@ public class ForgeBlockStateV1 extends Marker
             return output;
         }
 
+        boolean isVanillaCompatible()
+        {
+            return model != null && submodels.isEmpty() && textures.isEmpty() && customData.isEmpty() && !smooth.isPresent() && !gui3d.isPresent() && state.orElse(ModelRotation.X0_Y0) instanceof ModelRotation;
+        }
+
         protected SubModel asGenericSubModel()
         {
             return new SubModel(state.orElse(TRSRTransformation.identity()), uvLock.orElse(false), smooth.orElse(true), gui3d.orElse(true), getTextures(), model, getCustomData());


### PR DESCRIPTION
This alters the loading of Forge-format blockstate variants to change how Forge-added (3bdc75ad4922405bab18d2289d93ee0201af8b45) variant properties are applied.

In particular, vanilla models have the `ambientocclusion` property already defined as part of the model file. At present, a Forge variant will always override this property, even if it does not specify a `smooth_lighting` value.

However, as `ModelBlock.isAmbientOcclusion` defers to the parent model if it exists, this is only apparent for models without parents.

This is addressed here by changing `ForgeVariant.runModelHooks` to only override the base model properties which are explicitly defined in the variant. (The `uvlock` and `weight` tags are part of the vanilla variant spec, and so are always applied.)

Some screenshots using the following blockstate, with vanilla grass for comparison:
```json
{
	"forge_marker": 1,
	"defaults": {
		"textures": { "cross": "blocks/vine" }
	},
	"variants": {
		"normal": [{ "model": "tinted_cross" }]
	}
}
```

Before:
![2018-10-15_11 27 46](https://user-images.githubusercontent.com/1447117/46946070-8324b100-d06e-11e8-8371-476eb710e9e8.png)

After:
![2018-10-15_11 28 47](https://user-images.githubusercontent.com/1447117/46946080-8ae45580-d06e-11e8-80b0-a1056f56ae59.png)
