### PR TITLE
Fix errors caused by fancy missing model being non-vanilla parent

### DIFF
--- a/src/main/java/net/minecraftforge/client/model/FancyMissingModel.java
+++ b/src/main/java/net/minecraftforge/client/model/FancyMissingModel.java
@@ -32,6 +32,7 @@ import net.minecraft.client.renderer.block.model.BakedQuad;
 import net.minecraft.client.renderer.block.model.IBakedModel;
 import net.minecraft.client.renderer.block.model.ItemCameraTransforms;
 import net.minecraft.client.renderer.block.model.ItemOverrideList;
+import net.minecraft.client.renderer.block.model.ModelBlock;
 import net.minecraft.client.renderer.texture.TextureAtlasSprite;
 import net.minecraft.client.renderer.vertex.VertexFormat;
 import net.minecraft.util.EnumFacing;
@@ -93,6 +94,12 @@ final class FancyMissingModel implements IModel
     public Collection<ResourceLocation> getTextures()
     {
         return ImmutableList.of(font2);
+    }
+
+    @Override
+    public Optional<ModelBlock> asVanillaModel()
+    {
+        return missingModel.asVanillaModel();
     }
 
     @Override

--- a/src/main/java/net/minecraftforge/client/model/IModel.java
+++ b/src/main/java/net/minecraftforge/client/model/IModel.java
@@ -25,6 +25,7 @@ import java.util.Optional;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import net.minecraft.client.renderer.block.model.IBakedModel;
+import net.minecraft.client.renderer.block.model.ModelBlock;
 import net.minecraft.client.renderer.texture.TextureAtlasSprite;
 import net.minecraft.client.renderer.vertex.VertexFormat;
 import net.minecraft.util.ResourceLocation;
@@ -120,5 +121,9 @@ public interface IModel
      */
     default IModel retexture(ImmutableMap<String, String> textures) {
         return this;
+    }
+
+    default Optional<ModelBlock> asVanillaModel() {
+        return Optional.empty();
     }
 }

--- a/src/main/java/net/minecraftforge/client/model/ModelLoader.java
+++ b/src/main/java/net/minecraftforge/client/model/ModelLoader.java
@@ -375,23 +375,17 @@ public final class ModelLoader extends ModelBakery
         public Collection<ResourceLocation> getTextures()
         {
             // setting parent here to make textures resolve properly
-            if(model.getParentLocation() != null && model.parent == null)
+            ResourceLocation parentLocation = model.getParentLocation();
+            if(parentLocation != null && model.parent == null)
             {
-                if(model.getParentLocation().getResourcePath().equals("builtin/generated"))
+                if(parentLocation.getResourcePath().equals("builtin/generated"))
                 {
                     model.parent = MODEL_GENERATED;
                 }
                 else
                 {
-                    Optional<ModelBlock> vanillaParent = ModelLoaderRegistry.getModelOrLogError(model.getParentLocation(), "Could not load vanilla model parent '" + model.getParentLocation() + "' for '" + model).asVanillaModel();
-                    if(vanillaParent.isPresent())
-                    {
-                        model.parent = vanillaParent.get();
-                    }
-                    else
-                    {
-                        throw new IllegalStateException("vanilla model '" + model + "' can't have non-vanilla parent");
-                    }
+                    model.parent = ModelLoaderRegistry.getModelOrLogError(parentLocation, "Could not load vanilla model parent '" + parentLocation + "' for '" + model + "'")
+                            .asVanillaModel().orElseThrow(() -> new IllegalStateException("vanilla model '" + model + "' can't have non-vanilla parent"));
                 }
             }
 

--- a/src/main/java/net/minecraftforge/client/model/ModelLoader.java
+++ b/src/main/java/net/minecraftforge/client/model/ModelLoader.java
@@ -383,14 +383,10 @@ public final class ModelLoader extends ModelBakery
                 }
                 else
                 {
-                    IModel parent = ModelLoaderRegistry.getModelOrLogError(model.getParentLocation(), "Could not load vanilla model parent '" + model.getParentLocation() + "' for '" + model);
-                    if (parent instanceof FancyMissingModel)
+                    Optional<ModelBlock> vanillaParent = ModelLoaderRegistry.getModelOrLogError(model.getParentLocation(), "Could not load vanilla model parent '" + model.getParentLocation() + "' for '" + model).asVanillaModel();
+                    if(vanillaParent.isPresent())
                     {
-                        parent = getMissingModel();
-                    }
-                    if(parent instanceof VanillaModelWrapper)
-                    {
-                        model.parent = ((VanillaModelWrapper) parent).model;
+                        model.parent = vanillaParent.get();
                     }
                     else
                     {
@@ -624,6 +620,12 @@ public final class ModelLoader extends ModelBakery
                 return this;
             }
             return new VanillaModelWrapper(location, model, value, animation);
+        }
+
+        @Override
+        public Optional<ModelBlock> asVanillaModel()
+        {
+            return Optional.of(model);
         }
     }
 

--- a/src/main/java/net/minecraftforge/client/model/ModelLoader.java
+++ b/src/main/java/net/minecraftforge/client/model/ModelLoader.java
@@ -375,7 +375,7 @@ public final class ModelLoader extends ModelBakery
         public Collection<ResourceLocation> getTextures()
         {
             // setting parent here to make textures resolve properly
-            if(model.getParentLocation() != null)
+            if(model.getParentLocation() != null && model.parent == null)
             {
                 if(model.getParentLocation().getResourcePath().equals("builtin/generated"))
                 {
@@ -384,6 +384,10 @@ public final class ModelLoader extends ModelBakery
                 else
                 {
                     IModel parent = ModelLoaderRegistry.getModelOrLogError(model.getParentLocation(), "Could not load vanilla model parent '" + model.getParentLocation() + "' for '" + model);
+                    if (parent instanceof FancyMissingModel)
+                    {
+                        parent = getMissingModel();
+                    }
                     if(parent instanceof VanillaModelWrapper)
                     {
                         model.parent = ((VanillaModelWrapper) parent).model;


### PR DESCRIPTION
Since #3328, the call to `ModelLoaderRegistry.getModelOrLogError` here may return a `FancyMissingModel`, which fails the check for `VanillaModelWrapper` and causes an `IllegalStateException` to be thrown:

https://github.com/MinecraftForge/MinecraftForge/blob/1ba084f131975e1e38181c21f8b9f1e9cab6f9ba/src/main/java/net/minecraftforge/client/model/ModelLoader.java#L386-L394

This PR adds a check for fancy missing models, replacing them with the vanilla version to address this case.

As a minor additional fix, it also changes the logic here to only resolve parent models when needed, rather than with every call to `getTextures`.