### PR TITLE
Re-add some missing villager profession patches

### DIFF
--- a/patches/minecraft/net/minecraft/entity/monster/EntityZombieVillager.java.patch
+++ b/patches/minecraft/net/minecraft/entity/monster/EntityZombieVillager.java.patch
@@ -37,6 +37,15 @@
  
          if (p_70037_1_.func_150297_b("ConversionTime", 99) && p_70037_1_.func_74762_e("ConversionTime") > -1)
          {
+@@ -91,7 +101,7 @@
+     @Nullable
+     public IEntityLivingData func_180482_a(DifficultyInstance p_180482_1_, @Nullable IEntityLivingData p_180482_2_)
+     {
+-        this.func_190733_a(this.field_70170_p.field_73012_v.nextInt(6));
++        net.minecraftforge.fml.common.registry.VillagerRegistry.setRandomProfession(this, this.field_70170_p.field_73012_v);
+         return super.func_180482_a(p_180482_1_, p_180482_2_);
+     }
+ 
 @@ -175,7 +185,7 @@
      {
          EntityVillager entityvillager = new EntityVillager(this.field_70170_p);

--- a/patches/minecraft/net/minecraft/world/gen/structure/StructureVillagePieces.java.patch
+++ b/patches/minecraft/net/minecraft/world/gen/structure/StructureVillagePieces.java.patch
@@ -52,24 +52,26 @@
                  }
              }
  
-@@ -1770,7 +1780,6 @@
+@@ -1770,7 +1780,7 @@
                              EntityZombieVillager entityzombievillager = new EntityZombieVillager(p_74893_1_);
                              entityzombievillager.func_70012_b((double)j + 0.5D, (double)k, (double)l + 0.5D, 0.0F, 0.0F);
                              entityzombievillager.func_180482_a(p_74893_1_.func_175649_E(new BlockPos(entityzombievillager)), (IEntityLivingData)null);
 -                            entityzombievillager.func_190733_a(this.func_180779_c(i, 0));
++                            entityzombievillager.setForgeProfession(this.chooseForgeProfession(i, net.minecraftforge.fml.common.registry.VillagerRegistry.FARMER));
                              entityzombievillager.func_110163_bv();
                              p_74893_1_.func_72838_d(entityzombievillager);
                          }
-@@ -1778,7 +1787,7 @@
+@@ -1778,7 +1788,8 @@
                          {
                              EntityVillager entityvillager = new EntityVillager(p_74893_1_);
                              entityvillager.func_70012_b((double)j + 0.5D, (double)k, (double)l + 0.5D, 0.0F, 0.0F);
 -                            entityvillager.func_70938_b(this.func_180779_c(i, p_74893_1_.field_73012_v.nextInt(6)));
++                            net.minecraftforge.fml.common.registry.VillagerRegistry.setRandomProfession(entityvillager, p_74893_1_.field_73012_v);
 +                            entityvillager.setProfession(this.chooseForgeProfession(i, entityvillager.getProfessionForge()));
                              entityvillager.func_190672_a(p_74893_1_.func_175649_E(new BlockPos(entityvillager)), (IEntityLivingData)null, false);
                              p_74893_1_.func_72838_d(entityvillager);
                          }
-@@ -1786,13 +1795,21 @@
+@@ -1786,13 +1797,21 @@
                  }
              }
  

--- a/src/main/java/net/minecraftforge/fml/common/registry/VillagerRegistry.java
+++ b/src/main/java/net/minecraftforge/fml/common/registry/VillagerRegistry.java
@@ -318,12 +318,10 @@ public class VillagerRegistry
         entity.setProfession(INSTANCE.REGISTRY.getRandomObject(rand));
     }
 
-
-
-
-
-
-
+    public static void setRandomProfession(EntityZombieVillager entity, Random rand)
+    {
+        entity.setForgeProfession(INSTANCE.REGISTRY.getRandomObject(rand));
+    }
 
     //Below this is INTERNAL USE ONLY DO NOT USE MODDERS
     public static void onSetProfession(EntityVillager entity, int network)


### PR DESCRIPTION
Fixes #5198.

There used to be a Forge patch for this, but it was lost with the 1.11 update (see the `VillagerRegistry` changes in 4e6a7740750f4ef98b4f24e2b51da340b3d32b37 and 85a2a2e6612eba61a15b57434b5480c888276e18).

It's reimplemented here in a similar way as the existing `EntityVillager` hook.