### PR TITLE
Fix incorrect indexing in mipmap generation code

### DIFF
--- a/patches/minecraft/net/minecraft/client/renderer/texture/TextureUtil.java.patch
+++ b/patches/minecraft/net/minecraft/client/renderer/texture/TextureUtil.java.patch
@@ -1,5 +1,14 @@
 --- ../src-base/minecraft/net/minecraft/client/renderer/texture/TextureUtil.java
 +++ ../src-work/minecraft/net/minecraft/client/renderer/texture/TextureUtil.java
+@@ -63,7 +63,7 @@
+         {
+             boolean flag = false;
+ 
+-            for (int i = 0; i < p_147949_2_.length; ++i)
++            for (int i = 0; i < p_147949_2_[0].length; ++i)
+             {
+                 if (p_147949_2_[0][i] >> 24 == 0)
+                 {
 @@ -83,6 +83,7 @@
                      int[] aint1 = aint[l1 - 1];
                      int[] aint2 = new int[aint1.length >> 2];


### PR DESCRIPTION
Fixes [this crash](http://www.minecraftforge.net/forum/topic/67012-i-cant-launch-forge/) from the forums, as well as the logic being wrong at present.

Since #3087 makes it that mipmap levels aren't reduced by undersized textures, this causes crashes with Forge, although the vanilla game code is still affected by this error - it just never indexes out of the image as a result.

The loop here (inside `TextureUtil.generateMipmapData`) is supposed to iterate over the pixels in the unmipped image data, however the current bounds check incorrectly checks the top-level array length (which depends on the number of miplevels) instead. This both means it can run out-of-bounds if the number of miplevels exceeds the image size and also that it fails to check more than a token number of pixels otherwise.

I did a quick search, but didn't find any existing vanilla ticket that seemed to cover this. It seems to have been fixed for 1.13, probably during the change of image handling library.