### PR TITLE
Fix squid:S2696 Instance methods should not write to "static" fields

### DIFF
--- a/mdk/src/main/java/com/example/examplemod/ExampleMod.java
+++ b/mdk/src/main/java/com/example/examplemod/ExampleMod.java
@@ -19,7 +19,7 @@ public class ExampleMod
     @EventHandler
     public void preInit(FMLPreInitializationEvent event)
     {
-        logger = event.getModLog();
+        setLogger(event.getModLog());
     }
 
     @EventHandler
@@ -27,5 +27,9 @@ public class ExampleMod
     {
         // some example code
         logger.info("DIRT BLOCK >> {}", Blocks.DIRT.getRegistryName());
+    }
+
+    private static synchronized void setLogger(Logger logger) {
+        ExampleMod.logger = logger;
     }
 }


### PR DESCRIPTION
Sample code should do its best to be as close as possible to pristine legal.
Current `ExampleMod` writes into a static class member from an instance method.
I propose this minor change to show a legal way to set the `logger` instead. 

[`squid:S2696`: Instance methods should not write to "static" fields](https://next.sonarqube.com/sonarqube/coding_rules?open=squid%3AS2696&rule_key=squid%3AS2696)