### PR TITLE
Further support for custom block path types

### DIFF
--- a/patches/minecraft/net/minecraft/block/Block.java.patch
+++ b/patches/minecraft/net/minecraft/block/Block.java.patch
@@ -221,7 +221,7 @@
      public SoundType func_185467_w()
      {
          return this.field_149762_H;
-@@ -934,6 +952,1361 @@
+@@ -934,6 +952,1369 @@
      {
      }
  
@@ -1540,15 +1540,23 @@
 +        return false;
 +    }
 +
++    /** @deprecated use {@link #getAiPathNodeType(IBlockState, IBlockAccess, BlockPos, net.minecraft.entity.EntityLiving)} */
++    @Nullable
++    @Deprecated // TODO: remove
++    public net.minecraft.pathfinding.PathNodeType getAiPathNodeType(IBlockState state, IBlockAccess world, BlockPos pos)
++    {
++        return isBurning(world, pos) ? net.minecraft.pathfinding.PathNodeType.DAMAGE_FIRE : null;
++    }
++
 +    /**
 +     * Get the {@code PathNodeType} for this block. Return {@code null} for vanilla behavior.
 +     *
 +     * @return the PathNodeType
 +     */
 +    @Nullable
-+    public net.minecraft.pathfinding.PathNodeType getAiPathNodeType(IBlockState state, IBlockAccess world, BlockPos pos)
++    public net.minecraft.pathfinding.PathNodeType getAiPathNodeType(IBlockState state, IBlockAccess world, BlockPos pos, @Nullable net.minecraft.entity.EntityLiving entity)
 +    {
-+        return isBurning(world, pos) ? net.minecraft.pathfinding.PathNodeType.DAMAGE_FIRE : null;
++        return getAiPathNodeType(state, world, pos);
 +    }
 +
 +    /**
@@ -1583,7 +1591,7 @@
      public static void func_149671_p()
      {
          func_176215_a(0, field_176230_a, (new BlockAir()).func_149663_c("air"));
-@@ -1105,7 +2478,7 @@
+@@ -1105,7 +2486,7 @@
          Block block11 = (new BlockQuartz()).func_149672_a(SoundType.field_185851_d).func_149711_c(0.8F).func_149663_c("quartzBlock");
          func_176219_a(155, "quartz_block", block11);
          func_176219_a(156, "quartz_stairs", (new BlockStairs(block11.func_176223_P().func_177226_a(BlockQuartz.field_176335_a, BlockQuartz.EnumType.DEFAULT))).func_149663_c("stairsQuartz"));
@@ -1592,7 +1600,7 @@
          func_176219_a(158, "dropper", (new BlockDropper()).func_149711_c(3.5F).func_149672_a(SoundType.field_185851_d).func_149663_c("dropper"));
          func_176219_a(159, "stained_hardened_clay", (new BlockStainedHardenedClay()).func_149711_c(1.25F).func_149752_b(7.0F).func_149672_a(SoundType.field_185851_d).func_149663_c("clayHardenedStained"));
          func_176219_a(160, "stained_glass_pane", (new BlockStainedGlassPane()).func_149711_c(0.3F).func_149672_a(SoundType.field_185853_f).func_149663_c("thinStainedGlass"));
-@@ -1230,31 +2603,6 @@
+@@ -1230,31 +2611,6 @@
                  block15.field_149783_u = flag;
              }
          }

--- a/patches/minecraft/net/minecraft/pathfinding/FlyingNodeProcessor.java.patch
+++ b/patches/minecraft/net/minecraft/pathfinding/FlyingNodeProcessor.java.patch
@@ -1,0 +1,20 @@
+--- ../src-base/minecraft/net/minecraft/pathfinding/FlyingNodeProcessor.java
++++ ../src-work/minecraft/net/minecraft/pathfinding/FlyingNodeProcessor.java
+@@ -272,7 +272,9 @@
+         EnumSet<PathNodeType> enumset = EnumSet.<PathNodeType>noneOf(PathNodeType.class);
+         PathNodeType pathnodetype = PathNodeType.BLOCKED;
+         BlockPos blockpos = new BlockPos(p_186319_5_);
++        this.currentEntity = p_186319_5_;
+         pathnodetype = this.func_193577_a(p_186319_1_, p_186319_2_, p_186319_3_, p_186319_4_, p_186319_6_, p_186319_7_, p_186319_8_, p_186319_9_, p_186319_10_, enumset, pathnodetype, blockpos);
++        this.currentEntity = null;
+ 
+         if (enumset.contains(PathNodeType.FENCE))
+         {
+@@ -321,6 +323,7 @@
+                 {
+                     pathnodetype = PathNodeType.DAMAGE_CACTUS;
+                 }
++                else if (pathnodetype1 == PathNodeType.DAMAGE_OTHER) pathnodetype = PathNodeType.DAMAGE_OTHER;
+                 else
+                 {
+                     pathnodetype = pathnodetype1 != PathNodeType.WALKABLE && pathnodetype1 != PathNodeType.OPEN && pathnodetype1 != PathNodeType.WATER ? PathNodeType.WALKABLE : PathNodeType.OPEN;

--- a/patches/minecraft/net/minecraft/pathfinding/WalkNodeProcessor.java.patch
+++ b/patches/minecraft/net/minecraft/pathfinding/WalkNodeProcessor.java.patch
@@ -1,14 +1,32 @@
 --- ../src-base/minecraft/net/minecraft/pathfinding/WalkNodeProcessor.java
 +++ ../src-work/minecraft/net/minecraft/pathfinding/WalkNodeProcessor.java
-@@ -427,6 +427,7 @@
+@@ -417,16 +417,22 @@
+                 {
+                     if (i != 0 || j != 0)
+                     {
+-                        Block block = p_193578_1_.func_180495_p(blockpos$pooledmutableblockpos.func_181079_c(i + p_193578_2_, p_193578_3_, j + p_193578_4_)).func_177230_c();
++                        IBlockState state = p_193578_1_.func_180495_p(blockpos$pooledmutableblockpos.func_181079_c(i + p_193578_2_, p_193578_3_, j + p_193578_4_));
++                        Block block = state.func_177230_c();
++                        PathNodeType type = block.getAiPathNodeType(state, p_193578_1_, blockpos$pooledmutableblockpos);
+ 
+-                        if (block == Blocks.field_150434_aF)
++                        if (block == Blocks.field_150434_aF || type == PathNodeType.DAMAGE_CACTUS)
+                         {
+                             p_193578_5_ = PathNodeType.DANGER_CACTUS;
+                         }
+-                        else if (block == Blocks.field_150480_ab)
++                        else if (block == Blocks.field_150480_ab || type == PathNodeType.DAMAGE_FIRE)
                          {
                              p_193578_5_ = PathNodeType.DANGER_FIRE;
                          }
-+                        else if(block.isBurning(p_193578_1_,blockpos$pooledmutableblockpos)) p_193578_5_ = PathNodeType.DAMAGE_FIRE;
++                        else if (type == PathNodeType.DAMAGE_OTHER)
++                        {
++                            p_193578_5_ = PathNodeType.DANGER_OTHER;
++                        }
                      }
                  }
              }
-@@ -443,6 +444,9 @@
+@@ -443,6 +449,9 @@
          Block block = iblockstate.func_177230_c();
          Material material = iblockstate.func_185904_a();
  

--- a/patches/minecraft/net/minecraft/pathfinding/WalkNodeProcessor.java.patch
+++ b/patches/minecraft/net/minecraft/pathfinding/WalkNodeProcessor.java.patch
@@ -1,13 +1,40 @@
 --- ../src-base/minecraft/net/minecraft/pathfinding/WalkNodeProcessor.java
 +++ ../src-work/minecraft/net/minecraft/pathfinding/WalkNodeProcessor.java
-@@ -417,16 +417,22 @@
+@@ -23,6 +23,7 @@
+ public class WalkNodeProcessor extends NodeProcessor
+ {
+     protected float field_176183_h;
++    protected EntityLiving currentEntity;
+ 
+     public void func_186315_a(IBlockAccess p_186315_1_, EntityLiving p_186315_2_)
+     {
+@@ -295,7 +296,9 @@
+         PathNodeType pathnodetype = PathNodeType.BLOCKED;
+         double d0 = (double)p_186319_5_.field_70130_N / 2.0D;
+         BlockPos blockpos = new BlockPos(p_186319_5_);
++        this.currentEntity = p_186319_5_;
+         pathnodetype = this.func_193577_a(p_186319_1_, p_186319_2_, p_186319_3_, p_186319_4_, p_186319_6_, p_186319_7_, p_186319_8_, p_186319_9_, p_186319_10_, enumset, pathnodetype, blockpos);
++        this.currentEntity = null;
+ 
+         if (enumset.contains(PathNodeType.FENCE))
+         {
+@@ -399,6 +402,8 @@
+             {
+                 pathnodetype = PathNodeType.DAMAGE_CACTUS;
+             }
++
++            if (pathnodetype1 == PathNodeType.DAMAGE_OTHER) pathnodetype = PathNodeType.DAMAGE_OTHER;
+         }
+ 
+         pathnodetype = this.func_193578_a(p_186330_1_, p_186330_2_, p_186330_3_, p_186330_4_, pathnodetype);
+@@ -417,16 +422,19 @@
                  {
                      if (i != 0 || j != 0)
                      {
 -                        Block block = p_193578_1_.func_180495_p(blockpos$pooledmutableblockpos.func_181079_c(i + p_193578_2_, p_193578_3_, j + p_193578_4_)).func_177230_c();
 +                        IBlockState state = p_193578_1_.func_180495_p(blockpos$pooledmutableblockpos.func_181079_c(i + p_193578_2_, p_193578_3_, j + p_193578_4_));
 +                        Block block = state.func_177230_c();
-+                        PathNodeType type = block.getAiPathNodeType(state, p_193578_1_, blockpos$pooledmutableblockpos);
++                        PathNodeType type = block.getAiPathNodeType(state, p_193578_1_, blockpos$pooledmutableblockpos, this.currentEntity);
  
 -                        if (block == Blocks.field_150434_aF)
 +                        if (block == Blocks.field_150434_aF || type == PathNodeType.DAMAGE_CACTUS)
@@ -19,18 +46,15 @@
                          {
                              p_193578_5_ = PathNodeType.DANGER_FIRE;
                          }
-+                        else if (type == PathNodeType.DAMAGE_OTHER)
-+                        {
-+                            p_193578_5_ = PathNodeType.DANGER_OTHER;
-+                        }
++                        else if (type == PathNodeType.DAMAGE_OTHER) p_193578_5_ = PathNodeType.DANGER_OTHER;
                      }
                  }
              }
-@@ -443,6 +449,9 @@
+@@ -443,6 +451,9 @@
          Block block = iblockstate.func_177230_c();
          Material material = iblockstate.func_185904_a();
  
-+        PathNodeType type = block.getAiPathNodeType(iblockstate, p_189553_1_, blockpos);
++        PathNodeType type = block.getAiPathNodeType(iblockstate, p_189553_1_, blockpos, this.currentEntity);
 +        if (type != null) return type;
 +
          if (material == Material.field_151579_a)


### PR DESCRIPTION
Partial replacement of #4598, this just patches `WalkNodeProcessor.checkNeighborBlocks` to use the existing `getAiPathNodeType` function in addition to the current hardcoded block checks.

This means that blocks which return a "damage" path type will have surrounding blocks with the corresponding "danger" path type, as is currently the case for vanilla fire and cactus blocks.

This also replaces the need for the `isBurning` check here, as that's covered by the default `getAiPathNodeType` implementation.