### PR TITLE
Fix small logic omissions in BlockFluidBase

### DIFF
--- a/src/main/java/net/minecraftforge/fluids/BlockFluidBase.java
+++ b/src/main/java/net/minecraftforge/fluids/BlockFluidBase.java
@@ -714,8 +714,13 @@ public abstract class BlockFluidBase extends Block implements IFluidBlock
 
     private int getFlowDecay(IBlockAccess world, BlockPos pos)
     {
+        return quantaPerBlock - getEffectiveQuanta(world, pos);
+    }
+
+    private int getEffectiveQuanta(IBlockAccess world, BlockPos pos)
+    {
         int quantaValue = getQuantaValue(world, pos);
-        return quantaValue > 0 && hasVerticalFlow(world, pos) ? 0 : quantaPerBlock - quantaValue;
+        return quantaValue > 0 && quantaValue < quantaPerBlock && hasVerticalFlow(world, pos) ? quantaPerBlock : quantaValue;
     }
 
     private boolean hasVerticalFlow(IBlockAccess world, BlockPos pos)
@@ -751,7 +756,7 @@ public abstract class BlockFluidBase extends Block implements IFluidBlock
 
     public float getFilledPercentage(IBlockAccess world, BlockPos pos)
     {
-        int quantaRemaining = getQuantaValue(world, pos);
+        int quantaRemaining = getEffectiveQuanta(world, pos);
         float remaining = (quantaRemaining + 1f) / (quantaPerBlockFloat + 1f);
         return remaining * (density > 0 ? 1 : -1);
     }

--- a/src/main/java/net/minecraftforge/fluids/BlockFluidBase.java
+++ b/src/main/java/net/minecraftforge/fluids/BlockFluidBase.java
@@ -717,13 +717,13 @@ public abstract class BlockFluidBase extends Block implements IFluidBlock
         return quantaPerBlock - getEffectiveQuanta(world, pos);
     }
 
-    private int getEffectiveQuanta(IBlockAccess world, BlockPos pos)
+    final int getEffectiveQuanta(IBlockAccess world, BlockPos pos)
     {
         int quantaValue = getQuantaValue(world, pos);
         return quantaValue > 0 && quantaValue < quantaPerBlock && hasVerticalFlow(world, pos) ? quantaPerBlock : quantaValue;
     }
 
-    private boolean hasVerticalFlow(IBlockAccess world, BlockPos pos)
+    final boolean hasVerticalFlow(IBlockAccess world, BlockPos pos)
     {
         return world.getBlockState(pos.down(densityDir)).getBlock() == this;
     }

--- a/src/main/java/net/minecraftforge/fluids/BlockFluidBase.java
+++ b/src/main/java/net/minecraftforge/fluids/BlockFluidBase.java
@@ -399,7 +399,7 @@ public abstract class BlockFluidBase extends Block implements IFluidBlock
     public int getPackedLightmapCoords(@Nonnull IBlockState state, @Nonnull IBlockAccess world, @Nonnull BlockPos pos)
     {
         int lightThis     = world.getCombinedLight(pos, 0);
-        int lightUp       = world.getCombinedLight(pos.up(), 0);
+        int lightUp       = world.getCombinedLight(pos.down(densityDir), 0);
         int lightThisBase = lightThis & 255;
         int lightUpBase   = lightUp & 255;
         int lightThisExt  = lightThis >> 16 & 255;

--- a/src/main/java/net/minecraftforge/fluids/BlockFluidClassic.java
+++ b/src/main/java/net/minecraftforge/fluids/BlockFluidClassic.java
@@ -126,12 +126,8 @@ public class BlockFluidClassic extends BlockFluidBase
             {
                 expQuanta = quantaPerBlock;
             }
-            // unobstructed flow from 'above'
-            else if (world.getBlockState(pos.down(densityDir)).getBlock() == this
-                    || hasDownhillFlow(world, pos, EnumFacing.EAST)
-                    || hasDownhillFlow(world, pos, EnumFacing.WEST)
-                    || hasDownhillFlow(world, pos, EnumFacing.NORTH)
-                    || hasDownhillFlow(world, pos, EnumFacing.SOUTH))
+            // vertical flow into block
+            else if (hasVerticalFlow(world, pos))
             {
                 expQuanta = quantaPerBlock - 1;
             }
@@ -179,7 +175,7 @@ public class BlockFluidClassic extends BlockFluidBase
 
         if (isSourceBlock(world, pos) || !isFlowingVertically(world, pos))
         {
-            if (world.getBlockState(pos.down(densityDir)).getBlock() == this)
+            if (hasVerticalFlow(world, pos))
             {
                 flowMeta = 1;
             }
@@ -289,7 +285,7 @@ public class BlockFluidClassic extends BlockFluidBase
 
     protected int getLargerQuanta(IBlockAccess world, BlockPos pos, int compare)
     {
-        int quantaRemaining = getQuantaValue(world, pos);
+        int quantaRemaining = getEffectiveQuanta(world, pos);
         if (quantaRemaining <= 0)
         {
             return compare;


### PR DESCRIPTION
Small fix for the missed case of non-source fluid blocks under other fluid blocks in the `getFilledPercentage` logic.

Apologies for missing this as part of #4763.