### PR TITLE
Better support for custom bows

### DIFF
--- a/patches/minecraft/net/minecraft/client/entity/AbstractClientPlayer.java.patch
+++ b/patches/minecraft/net/minecraft/client/entity/AbstractClientPlayer.java.patch
@@ -1,5 +1,14 @@
 --- ../src-base/minecraft/net/minecraft/client/entity/AbstractClientPlayer.java
 +++ ../src-work/minecraft/net/minecraft/client/entity/AbstractClientPlayer.java
+@@ -135,7 +135,7 @@
+             f = 1.0F;
+         }
+ 
+-        if (this.func_184587_cr() && this.func_184607_cu().func_77973_b() == Items.field_151031_f)
++        if (this.func_184587_cr() && this.func_184607_cu().func_77973_b() instanceof net.minecraft.item.ItemBow)
+         {
+             int i = this.func_184612_cw();
+             float f1 = (float)i / 20.0F;
 @@ -152,6 +152,6 @@
              f *= 1.0F - f1 * 0.15F;
          }

--- a/patches/minecraft/net/minecraft/client/model/ModelSkeleton.java.patch
+++ b/patches/minecraft/net/minecraft/client/model/ModelSkeleton.java.patch
@@ -1,0 +1,20 @@
+--- ../src-base/minecraft/net/minecraft/client/model/ModelSkeleton.java
++++ ../src-work/minecraft/net/minecraft/client/model/ModelSkeleton.java
+@@ -48,7 +48,7 @@
+         this.field_187075_l = ModelBiped.ArmPose.EMPTY;
+         ItemStack itemstack = p_78086_1_.func_184586_b(EnumHand.MAIN_HAND);
+ 
+-        if (itemstack.func_77973_b() == Items.field_151031_f && ((AbstractSkeleton)p_78086_1_).func_184725_db())
++        if (itemstack.func_77973_b() instanceof net.minecraft.item.ItemBow && ((AbstractSkeleton)p_78086_1_).func_184725_db())
+         {
+             if (p_78086_1_.func_184591_cq() == EnumHandSide.RIGHT)
+             {
+@@ -69,7 +69,7 @@
+         ItemStack itemstack = ((EntityLivingBase)p_78087_7_).func_184614_ca();
+         AbstractSkeleton abstractskeleton = (AbstractSkeleton)p_78087_7_;
+ 
+-        if (abstractskeleton.func_184725_db() && (itemstack.func_190926_b() || itemstack.func_77973_b() != Items.field_151031_f))
++        if (abstractskeleton.func_184725_db() && (itemstack.func_190926_b() || !(itemstack.func_77973_b() instanceof net.minecraft.item.ItemBow)))
+         {
+             float f = MathHelper.func_76126_a(this.field_78095_p * (float)Math.PI);
+             float f1 = MathHelper.func_76126_a((1.0F - (1.0F - this.field_78095_p) * (1.0F - this.field_78095_p)) * (float)Math.PI);

--- a/patches/minecraft/net/minecraft/client/renderer/ItemRenderer.java.patch
+++ b/patches/minecraft/net/minecraft/client/renderer/ItemRenderer.java.patch
@@ -14,7 +14,7 @@
              ItemStack itemstack = abstractclientplayer.func_184607_cu();
  
 -            if (itemstack.func_77973_b() == Items.field_151031_f)
-+            if (!itemstack.func_190926_b() && itemstack.func_77973_b() == Items.field_151031_f) //Forge: Data watcher can desync and cause this to NPE...
++            if (itemstack.func_77973_b() instanceof net.minecraft.item.ItemBow)
              {
                  EnumHand enumhand1 = abstractclientplayer.func_184600_cs();
                  flag = enumhand1 == EnumHand.MAIN_HAND;

--- a/patches/minecraft/net/minecraft/client/renderer/entity/layers/LayerHeldItemWitch.java.patch
+++ b/patches/minecraft/net/minecraft/client/renderer/entity/layers/LayerHeldItemWitch.java.patch
@@ -1,0 +1,11 @@
+--- ../src-base/minecraft/net/minecraft/client/renderer/entity/layers/LayerHeldItemWitch.java
++++ ../src-work/minecraft/net/minecraft/client/renderer/entity/layers/LayerHeldItemWitch.java
+@@ -53,7 +53,7 @@
+                 float f1 = 0.375F;
+                 GlStateManager.func_179152_a(0.375F, -0.375F, 0.375F);
+             }
+-            else if (item == Items.field_151031_f)
++            else if (item instanceof net.minecraft.item.ItemBow)
+             {
+                 GlStateManager.func_179109_b(0.0F, 0.125F, -0.125F);
+                 GlStateManager.func_179114_b(-45.0F, 0.0F, 1.0F, 0.0F);

--- a/patches/minecraft/net/minecraft/entity/ai/EntityAIAttackRangedBow.java.patch
+++ b/patches/minecraft/net/minecraft/entity/ai/EntityAIAttackRangedBow.java.patch
@@ -1,0 +1,11 @@
+--- ../src-base/minecraft/net/minecraft/entity/ai/EntityAIAttackRangedBow.java
++++ ../src-work/minecraft/net/minecraft/entity/ai/EntityAIAttackRangedBow.java
+@@ -40,7 +40,7 @@
+ 
+     protected boolean func_188498_f()
+     {
+-        return !this.field_188499_a.func_184614_ca().func_190926_b() && this.field_188499_a.func_184614_ca().func_77973_b() == Items.field_151031_f;
++        return !this.field_188499_a.func_184614_ca().func_190926_b() && this.field_188499_a.func_184614_ca().func_77973_b() instanceof ItemBow;
+     }
+ 
+     public boolean func_75253_b()

--- a/patches/minecraft/net/minecraft/entity/monster/AbstractSkeleton.java.patch
+++ b/patches/minecraft/net/minecraft/entity/monster/AbstractSkeleton.java.patch
@@ -1,0 +1,20 @@
+--- ../src-base/minecraft/net/minecraft/entity/monster/AbstractSkeleton.java
++++ ../src-work/minecraft/net/minecraft/entity/monster/AbstractSkeleton.java
+@@ -192,7 +192,7 @@
+             this.field_70714_bg.func_85156_a(this.field_85037_d);
+             ItemStack itemstack = this.func_184614_ca();
+ 
+-            if (itemstack.func_77973_b() == Items.field_151031_f)
++            if (itemstack.func_77973_b() instanceof net.minecraft.item.ItemBow)
+             {
+                 int i = 20;
+ 
+@@ -214,6 +214,8 @@
+     public void func_82196_d(EntityLivingBase p_82196_1_, float p_82196_2_)
+     {
+         EntityArrow entityarrow = this.func_190726_a(p_82196_2_);
++        if (this.func_184614_ca().func_77973_b() instanceof net.minecraft.item.ItemBow)
++            entityarrow = ((net.minecraft.item.ItemBow) this.func_184614_ca().func_77973_b()).customizeArrow(entityarrow);
+         double d0 = p_82196_1_.field_70165_t - this.field_70165_t;
+         double d1 = p_82196_1_.func_174813_aQ().field_72338_b + (double)(p_82196_1_.field_70131_O / 3.0F) - entityarrow.field_70163_u;
+         double d2 = p_82196_1_.field_70161_v - this.field_70161_v;

--- a/patches/minecraft/net/minecraft/entity/monster/EntityIllusionIllager.java.patch
+++ b/patches/minecraft/net/minecraft/entity/monster/EntityIllusionIllager.java.patch
@@ -1,0 +1,11 @@
+--- ../src-base/minecraft/net/minecraft/entity/monster/EntityIllusionIllager.java
++++ ../src-work/minecraft/net/minecraft/entity/monster/EntityIllusionIllager.java
+@@ -214,6 +214,8 @@
+     public void func_82196_d(EntityLivingBase p_82196_1_, float p_82196_2_)
+     {
+         EntityArrow entityarrow = this.func_193097_t(p_82196_2_);
++        if (this.func_184614_ca().func_77973_b() instanceof net.minecraft.item.ItemBow)
++            entityarrow = ((net.minecraft.item.ItemBow) this.func_184614_ca().func_77973_b()).customizeArrow(entityarrow);
+         double d0 = p_82196_1_.field_70165_t - this.field_70165_t;
+         double d1 = p_82196_1_.func_174813_aQ().field_72338_b + (double)(p_82196_1_.field_70131_O / 3.0F) - entityarrow.field_70163_u;
+         double d2 = p_82196_1_.field_70161_v - this.field_70161_v;

--- a/patches/minecraft/net/minecraft/item/ItemBow.java.patch
+++ b/patches/minecraft/net/minecraft/item/ItemBow.java.patch
@@ -1,5 +1,14 @@
 --- ../src-base/minecraft/net/minecraft/item/ItemBow.java
 +++ ../src-work/minecraft/net/minecraft/item/ItemBow.java
+@@ -37,7 +37,7 @@
+                 }
+                 else
+                 {
+-                    return p_185085_3_.func_184607_cu().func_77973_b() != Items.field_151031_f ? 0.0F : (float)(p_185085_1_.func_77988_m() - p_185085_3_.func_184605_cv()) / 20.0F;
++                    return !(p_185085_3_.func_184607_cu().func_77973_b() instanceof ItemBow) ? 0.0F : (float)(p_185085_1_.func_77988_m() - p_185085_3_.func_184605_cv()) / 20.0F;
+                 }
+             }
+         });
 @@ -90,6 +90,10 @@
              boolean flag = entityplayer.field_71075_bZ.field_75098_d || EnchantmentHelper.func_77506_a(Enchantments.field_185312_x, p_77615_1_) > 0;
              ItemStack itemstack = this.func_185060_a(entityplayer);
@@ -11,7 +20,7 @@
              if (!itemstack.func_190926_b() || flag)
              {
                  if (itemstack.func_190926_b())
-@@ -97,12 +101,11 @@
+@@ -97,17 +101,17 @@
                      itemstack = new ItemStack(Items.field_151032_g);
                  }
  
@@ -25,7 +34,13 @@
  
                      if (!p_77615_2_.field_72995_K)
                      {
-@@ -190,6 +193,9 @@
+                         ItemArrow itemarrow = (ItemArrow)(itemstack.func_77973_b() instanceof ItemArrow ? itemstack.func_77973_b() : Items.field_151032_g);
+                         EntityArrow entityarrow = itemarrow.func_185052_a(p_77615_2_, itemstack, entityplayer);
++                        entityarrow = this.customizeArrow(entityarrow);
+                         entityarrow.func_184547_a(entityplayer, entityplayer.field_70125_A, entityplayer.field_70177_z, 0.0F, f * 3.0F, 1.0F);
+ 
+                         if (f == 1.0F)
+@@ -190,6 +194,9 @@
          ItemStack itemstack = p_77659_2_.func_184586_b(p_77659_3_);
          boolean flag = !this.func_185060_a(p_77659_2_).func_190926_b();
  
@@ -35,3 +50,13 @@
          if (!p_77659_2_.field_71075_bZ.field_75098_d && !flag)
          {
              return flag ? new ActionResult(EnumActionResult.PASS, itemstack) : new ActionResult(EnumActionResult.FAIL, itemstack);
+@@ -205,4 +212,9 @@
+     {
+         return 1;
+     }
++
++    public EntityArrow customizeArrow(EntityArrow arrow)
++    {
++        return arrow;
++    }
+ }

--- a/src/main/resources/forge_at.cfg
+++ b/src/main/resources/forge_at.cfg
@@ -16,6 +16,8 @@ public net.minecraft.block.BlockFire func_176534_d(Lnet/minecraft/block/Block;)I
 # Item
 public net.minecraft.item.Item func_77656_e(I)Lnet.minecraft.item.Item; #setMaxDamage
 public net.minecraft.item.Item func_77627_a(Z)Lnet.minecraft.item.Item; #setHasSubtypes
+# ItemBow
+protected net.minecraft.item.ItemBow func_185060_a(Lnet/minecraft/entity/player/EntityPlayer;)Lnet/minecraft/item/ItemStack; # findAmmo
 # EntityPlayer
 public net.minecraft.entity.player.EntityPlayer func_71053_j()V #closeScreen
 # EntityTrackerEntry


### PR DESCRIPTION
Aims to make it easier to have custom bow implementations by replacing various checks for `item == Items.BOW` with `item instanceof ItemBow`, and allowing for more bow behaviour to be overriden without needing to copy/paste all the other vanilla logic by providing a new `customizeArrow` method and making `findAmmo` overrideable.
The vanilla users of `EntityAIAttackRangedBow` have also had `attackEntityWithRangedAttack` patched to call `customizeArrow` as well.