### PR TITLE
Fix missing string interpolation parameters in log messages

### DIFF
--- a/src/main/java/net/minecraftforge/common/config/ConfigManager.java
+++ b/src/main/java/net/minecraftforge/common/config/ConfigManager.java
@@ -187,7 +187,7 @@ public class ConfigManager
             }
             catch (Exception e)
             {
-                FMLLog.log.error("An error occurred trying to load a config for {} into {}", targ.getClassName(), e);
+                FMLLog.log.error("An error occurred trying to load a config for {} into {}", modid, targ.getClassName(), e);
                 throw new LoaderException(e);
             }
         }

--- a/src/main/java/net/minecraftforge/fml/common/FMLCommonHandler.java
+++ b/src/main/java/net/minecraftforge/fml/common/FMLCommonHandler.java
@@ -216,7 +216,7 @@ public class FMLCommonHandler
      */
     public void raiseException(Throwable exception, String message, boolean stopGame)
     {
-        FMLLog.log.error("Something raised an exception. The message was '{}'. 'stopGame' is {}", stopGame, exception);
+        FMLLog.log.error("Something raised an exception. The message was '{}'. 'stopGame' is {}", message, stopGame, exception);
         if (stopGame)
         {
             getSidedDelegate().haltGame(message,exception);

--- a/src/main/java/net/minecraftforge/fml/common/FMLModContainer.java
+++ b/src/main/java/net/minecraftforge/fml/common/FMLModContainer.java
@@ -155,7 +155,7 @@ public class FMLModContainer implements ModContainer
             }
             catch (Exception ex)
             {
-                FMLLog.log.error("Error constructing custom mod language adapter referenced by {} (modid: {})", getModId(), ex);
+                FMLLog.log.error("Error constructing custom mod language adapter referenced by {} (modid: {})", this.className, getModId(), ex);
                 throw new RuntimeException(ex);
             }
         }

--- a/src/main/java/net/minecraftforge/fml/common/ILanguageAdapter.java
+++ b/src/main/java/net/minecraftforge/fml/common/ILanguageAdapter.java
@@ -25,8 +25,6 @@ import java.lang.reflect.Method;
 
 import net.minecraftforge.fml.relauncher.Side;
 
-import org.apache.logging.log4j.Level;
-
 public interface ILanguageAdapter {
     Object getNewInstance(FMLModContainer container, Class<?> objectClass, ClassLoader classLoader, Method factoryMarkedAnnotation) throws Exception;
     boolean supportsStatics();
@@ -110,7 +108,7 @@ public interface ILanguageAdapter {
             }
             catch (InvocationTargetException e)
             {
-                FMLLog.log.error("An error occurred trying to load a proxy into {}.{}", target.getName(), e);
+                FMLLog.log.error("An error occurred trying to load a proxy into {}.{}", proxyTarget.getSimpleName(), target.getName(), e);
                 throw new LoaderException(e);
             }
 
@@ -167,7 +165,7 @@ public interface ILanguageAdapter {
                             setProxy(target, proxyTarget, proxy);
                         }
                         catch (Exception e) {
-                            FMLLog.log.error("An error occurred trying to load a proxy into {}.{}", target.getName(), e);
+                            FMLLog.log.error("An error occurred trying to load a proxy into {}.{}", proxyTarget.getSimpleName(), target.getName(), e);
                             throw new LoaderException(e);
                         }
                     }

--- a/src/main/java/net/minecraftforge/fml/common/ObfuscationReflectionHelper.java
+++ b/src/main/java/net/minecraftforge/fml/common/ObfuscationReflectionHelper.java
@@ -44,7 +44,7 @@ public class ObfuscationReflectionHelper
         }
         catch (UnableToAccessFieldException e)
         {
-            FMLLog.log.error("There was a problem getting field index {} from {}", classToAccess.getName(), e);
+            FMLLog.log.error("There was a problem getting field index {} from {}", fieldIndex, classToAccess.getName(), e);
             throw e;
         }
     }
@@ -74,7 +74,7 @@ public class ObfuscationReflectionHelper
         }
         catch (UnableToAccessFieldException e)
         {
-            FMLLog.log.error("Unable to access any field {} on type {}", classToAccess.getName(), e);
+            FMLLog.log.error("Unable to access any field {} on type {}", Arrays.toString(fieldNames), classToAccess.getName(), e);
             throw e;
         }
     }
@@ -87,7 +87,7 @@ public class ObfuscationReflectionHelper
         }
         catch (UnableToAccessFieldException e)
         {
-            FMLLog.log.error("There was a problem setting field index {} on type {}", classToAccess.getName(), e);
+            FMLLog.log.error("There was a problem setting field index {} on type {}", fieldIndex, classToAccess.getName(), e);
             throw e;
         }
     }
@@ -100,12 +100,12 @@ public class ObfuscationReflectionHelper
         }
         catch (UnableToFindFieldException e)
         {
-            FMLLog.log.error("Unable to locate any field {} on type {}", classToAccess.getName(), e);
+            FMLLog.log.error("Unable to locate any field {} on type {}", Arrays.toString(fieldNames), classToAccess.getName(), e);
             throw e;
         }
         catch (UnableToAccessFieldException e)
         {
-            FMLLog.log.error("Unable to set any field {} on type {}", classToAccess.getName(), e);
+            FMLLog.log.error("Unable to set any field {} on type {}", Arrays.toString(fieldNames), classToAccess.getName(), e);
             throw e;
         }
     }

--- a/src/main/java/net/minecraftforge/fml/common/ProxyInjector.java
+++ b/src/main/java/net/minecraftforge/fml/common/ProxyInjector.java
@@ -98,7 +98,7 @@ public class ProxyInjector
             }
             catch (Exception e)
             {
-                FMLLog.log.error("An error occurred trying to load a proxy into {}.{}", targ.getObjectName(), e);
+                FMLLog.log.error("An error occurred trying to load a proxy into {}.{}", targ.getClassName(), targ.getObjectName(), e);
                 throw new LoaderException(e);
             }
         }

--- a/src/main/java/net/minecraftforge/fml/common/discovery/JarDiscoverer.java
+++ b/src/main/java/net/minecraftforge/fml/common/discovery/JarDiscoverer.java
@@ -105,7 +105,7 @@ public class JarDiscoverer implements ITypeDiscoverer
                 }
                 catch (LoaderException e)
                 {
-                    FMLLog.log.error("There was a problem reading the entry {} in the jar {} - probably a corrupt zip", candidate.getModContainer().getPath(), e);
+                    FMLLog.log.error("There was a problem reading the entry {} in the jar {} - probably a corrupt zip", ze.getName(), candidate.getModContainer().getPath(), e);
                     jar.close();
                     throw e;
                 }

--- a/src/main/java/net/minecraftforge/fml/common/network/internal/NetworkModHolder.java
+++ b/src/main/java/net/minecraftforge/fml/common/network/internal/NetworkModHolder.java
@@ -160,8 +160,8 @@ public class NetworkModHolder
             }
             catch (Exception e)
             {
-                FMLLog.log.error("Error occurred invoking NetworkCheckHandler {} at {}", container, e);
-                return String.format("Error occurred invoking NetworkCheckHandler %s", container);
+                FMLLog.log.error("Error occurred invoking NetworkCheckHandler {} at {}", checkHandler.getName(), container, e);
+                return String.format("Error occurred invoking NetworkCheckHandler %s at %s", checkHandler.getName(), container);
             }
         }
 

--- a/src/main/java/net/minecraftforge/fml/relauncher/CoreModManager.java
+++ b/src/main/java/net/minecraftforge/fml/relauncher/CoreModManager.java
@@ -605,21 +605,21 @@ public class CoreModManager {
         catch (ClassNotFoundException cnfe)
         {
             if (!Lists.newArrayList(rootPlugins).contains(coreModClass))
-                FMLLog.log.error("Coremod {}: Unable to class load the plugin {}", coreModClass, cnfe);
+                FMLLog.log.error("Coremod {}: Unable to class load the plugin {}", coreModName, coreModClass, cnfe);
             else
                 FMLLog.log.debug("Skipping root plugin {}", coreModClass);
         }
         catch (ClassCastException cce)
         {
-            FMLLog.log.error("Coremod {}: The plugin {} is not an implementor of IFMLLoadingPlugin", coreModClass, cce);
+            FMLLog.log.error("Coremod {}: The plugin {} is not an implementor of IFMLLoadingPlugin", coreModName, coreModClass, cce);
         }
         catch (InstantiationException ie)
         {
-            FMLLog.log.error("Coremod {}: The plugin class {} was not instantiable", coreModClass, ie);
+            FMLLog.log.error("Coremod {}: The plugin class {} was not instantiable", coreModName, coreModClass, ie);
         }
         catch (IllegalAccessException iae)
         {
-            FMLLog.log.error("Coremod {}: The plugin class {} was not accessible", coreModClass, iae);
+            FMLLog.log.error("Coremod {}: The plugin class {} was not accessible", coreModName, coreModClass, iae);
         }
         return null;
     }


### PR DESCRIPTION
Extension of #4986, fixes more log messages that lost parameters after #3953.