### PR TITLE
Preserve player capabilities when returning from the End

### DIFF
--- a/patches/minecraft/net/minecraft/entity/Entity.java.patch
+++ b/patches/minecraft/net/minecraft/entity/Entity.java.patch
@@ -441,7 +441,7 @@
 +
 +    protected void copyForgeCapabilities(Entity other)
 +    {
-+        this.capabilities = other.capabilities;
++        this.capabilities.deserializeNBT(other.capabilities.serializeNBT());
 +    }
 +
 +    public void deserializeNBT(NBTTagCompound nbt)

--- a/patches/minecraft/net/minecraft/entity/Entity.java.patch
+++ b/patches/minecraft/net/minecraft/entity/Entity.java.patch
@@ -253,7 +253,7 @@
      }
  
      public boolean func_174816_a(Explosion p_174816_1_, World p_174816_2_, BlockPos p_174816_3_, IBlockState p_174816_4_, float p_174816_5_)
-@@ -2901,6 +2939,218 @@
+@@ -2901,6 +2939,223 @@
          EnchantmentHelper.func_151385_b(p_174815_1_, p_174815_2_);
      }
  
@@ -437,6 +437,11 @@
 +    public <T> T getCapability(net.minecraftforge.common.capabilities.Capability<T> capability, @Nullable net.minecraft.util.EnumFacing facing)
 +    {
 +        return capabilities == null ? null : capabilities.getCapability(capability, facing);
++    }
++
++    protected void copyForgeCapabilities(Entity other)
++    {
++        this.capabilities = other.capabilities;
 +    }
 +
 +    public void deserializeNBT(NBTTagCompound nbt)

--- a/patches/minecraft/net/minecraft/entity/player/EntityPlayerMP.java.patch
+++ b/patches/minecraft/net/minecraft/entity/player/EntityPlayerMP.java.patch
@@ -120,7 +120,7 @@
          this.field_71070_bA = this.field_71069_bz;
      }
  
-@@ -1144,6 +1162,23 @@
+@@ -1144,6 +1162,25 @@
          this.field_193110_cw = p_193104_1_.field_193110_cw;
          this.func_192029_h(p_193104_1_.func_192023_dk());
          this.func_192031_i(p_193104_1_.func_192025_dl());
@@ -132,6 +132,8 @@
 +            this.field_71077_c = p_193104_1_.field_71077_c;
 +            this.field_82248_d = p_193104_1_.field_82248_d;
 +        }
++
++        if (p_193104_2_) this.copyForgeCapabilities(p_193104_1_);
 +
 +        //Copy over a section of the Entity Data from the old player.
 +        //Allows mods to specify data that persists after players respawn.


### PR DESCRIPTION
This reloads data for the player's capabilities when they are respawning due to using the End exit portal.

Although the [docs](https://mcforge.readthedocs.io/en/latest/datastorage/capabilities/#persisting-across-player-deaths) suggest this is a thing already, this appears to have only been implemented for the old `IExtendedEntityProperties` system (c8abc41aa06a790887a9b84041ee7413c2e36ed0).

Currently implemented in this way due to `Entity.capabilities` being private, but it can be changed if preferable.