### PR TITLE
Add redirects to PotionEffect to respect registry replacement

### DIFF
--- a/patches/minecraft/net/minecraft/potion/PotionEffect.java.patch
+++ b/patches/minecraft/net/minecraft/potion/PotionEffect.java.patch
@@ -17,7 +17,19 @@
      }
  
      public void func_76452_a(PotionEffect p_76452_1_)
-@@ -195,12 +198,13 @@
+@@ -79,6 +82,11 @@
+ 
+     public Potion func_188419_a()
+     {
++        return this.getPotionRaw() == null ? null : this.getPotionRaw().delegate.get();
++    }
++
++    private Potion getPotionRaw()
++    {
+         return this.field_188420_b;
+     }
+ 
+@@ -195,12 +203,13 @@
          p_82719_1_.func_74768_a("Duration", this.func_76459_b());
          p_82719_1_.func_74757_a("Ambient", this.func_82720_e());
          p_82719_1_.func_74757_a("ShowParticles", this.func_188418_e());
@@ -32,7 +44,7 @@
          Potion potion = Potion.func_188412_a(i);
  
          if (potion == null)
-@@ -219,7 +223,7 @@
+@@ -219,7 +228,7 @@
                  flag1 = p_82722_0_.func_74767_n("ShowParticles");
              }
  
@@ -41,7 +53,7 @@
          }
      }
  
-@@ -232,7 +236,7 @@
+@@ -232,7 +241,7 @@
      public int compareTo(PotionEffect p_compareTo_1_)
      {
          int i = 32147;
@@ -50,7 +62,7 @@
      }
  
      @SideOnly(Side.CLIENT)
-@@ -240,4 +244,85 @@
+@@ -240,4 +249,85 @@
      {
          return this.field_100013_f;
      }

--- a/src/main/java/net/minecraftforge/fml/common/asm/transformers/PotionEffectTransformer.java
+++ b/src/main/java/net/minecraftforge/fml/common/asm/transformers/PotionEffectTransformer.java
@@ -1,0 +1,28 @@
+/*
+ * Minecraft Forge
+ * Copyright (c) 2016-2018.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation version 2.1
+ * of the License.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+package net.minecraftforge.fml.common.asm.transformers;
+
+public class PotionEffectTransformer extends FieldRedirectTransformer
+{
+    public PotionEffectTransformer()
+    {
+        super("net.minecraft.potion.PotionEffect", "Lnet/minecraft/potion/Potion;", "getPotionRaw");
+    }
+}

--- a/src/main/java/net/minecraftforge/fml/common/launcher/FMLDeobfTweaker.java
+++ b/src/main/java/net/minecraftforge/fml/common/launcher/FMLDeobfTweaker.java
@@ -49,6 +49,7 @@ public class FMLDeobfTweaker implements ITweaker {
         classLoader.registerTransformer("net.minecraftforge.fml.common.asm.transformers.ItemStackTransformer");
         classLoader.registerTransformer("net.minecraftforge.fml.common.asm.transformers.ItemBlockTransformer");
         classLoader.registerTransformer("net.minecraftforge.fml.common.asm.transformers.ItemBlockSpecialTransformer");
+        classLoader.registerTransformer("net.minecraftforge.fml.common.asm.transformers.PotionEffectTransformer");
         try
         {
             FMLLog.log.debug("Validating minecraft");

--- a/src/test/java/net/minecraftforge/debug/mod/RegistryOverrideTest.java
+++ b/src/test/java/net/minecraftforge/debug/mod/RegistryOverrideTest.java
@@ -26,6 +26,7 @@ import net.minecraft.block.state.IBlockState;
 import net.minecraft.creativetab.CreativeTabs;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.Item;
+import net.minecraft.potion.Potion;
 import net.minecraft.potion.PotionType;
 import net.minecraft.util.EnumFacing;
 import net.minecraft.util.EnumHand;
@@ -73,6 +74,22 @@ public class RegistryOverrideTest
         if (ENABLED)
         {
             event.getRegistry().register(new PotionType().setRegistryName("minecraft:awkward"));
+        }
+    }
+
+    @SubscribeEvent
+    public static void registerPotions(RegistryEvent.Register<Potion> event)
+    {
+        if (ENABLED)
+        {
+            event.getRegistry().register(new Potion(true, 0x00ffff)
+            {
+                {
+                    setPotionName("effect.poison");
+                    setIconIndex(6, 0);
+                    setEffectiveness(0.25D);
+                }
+            }.setRegistryName("minecraft:poison"));
         }
     }
 


### PR DESCRIPTION
This makes the stored `Potion` in `PotionEffect` respect registry replacement, in the same way as the existing handling for `ItemStack`/`ItemBlock`.

A test case is added to the `RegistryOverrideTest` mod which recolours the poison effect.