### PR TITLE
Allow specifying different block states with vanilla tree generators

### DIFF
--- a/patches/minecraft/net/minecraft/world/gen/feature/WorldGenAbstractTree.java.patch
+++ b/patches/minecraft/net/minecraft/world/gen/feature/WorldGenAbstractTree.java.patch
@@ -5,7 +5,7 @@
          }
      }
 +
-+    protected net.minecraft.block.state.IBlockState trunk; // for big trees, should have log axis property
++    protected net.minecraft.block.state.IBlockState trunk; // should have log axis property if used for WorldGenBigTree
 +    protected net.minecraft.block.state.IBlockState leaf;
 +    protected net.minecraftforge.common.IPlantable sapling = (net.minecraft.block.BlockSapling) Blocks.field_150345_g;
 +

--- a/patches/minecraft/net/minecraft/world/gen/feature/WorldGenAbstractTree.java.patch
+++ b/patches/minecraft/net/minecraft/world/gen/feature/WorldGenAbstractTree.java.patch
@@ -1,9 +1,13 @@
 --- ../src-base/minecraft/net/minecraft/world/gen/feature/WorldGenAbstractTree.java
 +++ ../src-work/minecraft/net/minecraft/world/gen/feature/WorldGenAbstractTree.java
-@@ -31,4 +31,10 @@
+@@ -31,4 +31,14 @@
              this.func_175903_a(p_175921_1_, p_175921_2_, Blocks.field_150346_d.func_176223_P());
          }
      }
++
++    protected net.minecraft.block.state.IBlockState trunk; // for big trees, should have log axis property
++    protected net.minecraft.block.state.IBlockState leaf;
++    protected net.minecraftforge.common.IPlantable sapling = (net.minecraft.block.BlockSapling) Blocks.field_150345_g;
 +
 +    public boolean isReplaceable(World world, BlockPos pos)
 +    {

--- a/patches/minecraft/net/minecraft/world/gen/feature/WorldGenBigTree.java.patch
+++ b/patches/minecraft/net/minecraft/world/gen/feature/WorldGenBigTree.java.patch
@@ -1,6 +1,15 @@
 --- ../src-base/minecraft/net/minecraft/world/gen/feature/WorldGenBigTree.java
 +++ ../src-work/minecraft/net/minecraft/world/gen/feature/WorldGenBigTree.java
-@@ -99,9 +99,9 @@
+@@ -32,6 +32,8 @@
+     public WorldGenBigTree(boolean p_i2008_1_)
+     {
+         super(p_i2008_1_);
++        this.trunk = Blocks.field_150364_r.func_176223_P();
++        this.leaf = Blocks.field_150362_t.func_176223_P().func_177226_a(BlockLeaves.field_176236_b, Boolean.valueOf(false));
+     }
+ 
+     void func_76489_a()
+@@ -99,9 +101,9 @@
                  if (Math.pow((double)Math.abs(j) + 0.5D, 2.0D) + Math.pow((double)Math.abs(k) + 0.5D, 2.0D) <= (double)(p_181631_2_ * p_181631_2_))
                  {
                      BlockPos blockpos = p_181631_1_.func_177982_a(j, 0, k);
@@ -12,7 +21,62 @@
                      {
                          this.func_175903_a(this.field_175946_l, blockpos, p_181631_3_);
                      }
-@@ -269,7 +269,7 @@
+@@ -151,12 +153,17 @@
+     {
+         for (int i = 0; i < this.field_76508_n; ++i)
+         {
+-            this.func_181631_a(p_175940_1_.func_177981_b(i), this.func_76495_b(i), Blocks.field_150362_t.func_176223_P().func_177226_a(BlockLeaves.field_176236_b, Boolean.valueOf(false)));
++            this.func_181631_a(p_175940_1_.func_177981_b(i), this.func_76495_b(i), this.leaf);
+         }
+     }
+ 
+     void func_175937_a(BlockPos p_175937_1_, BlockPos p_175937_2_, Block p_175937_3_)
+     {
++        limb(p_175937_1_, p_175937_2_, p_175937_3_.func_176223_P());
++    }
++
++    void limb(BlockPos p_175937_1_, BlockPos p_175937_2_, IBlockState p_175937_3_)
++    {
+         BlockPos blockpos = p_175937_2_.func_177982_a(-p_175937_1_.func_177958_n(), -p_175937_1_.func_177956_o(), -p_175937_1_.func_177952_p());
+         int i = this.func_175935_b(blockpos);
+         float f = (float)blockpos.func_177958_n() / (float)i;
+@@ -167,7 +174,7 @@
+         {
+             BlockPos blockpos1 = p_175937_1_.func_177963_a((double)(0.5F + (float)j * f), (double)(0.5F + (float)j * f1), (double)(0.5F + (float)j * f2));
+             BlockLog.EnumAxis blocklog$enumaxis = this.func_175938_b(p_175937_1_, blockpos1);
+-            this.func_175903_a(this.field_175946_l, blockpos1, p_175937_3_.func_176223_P().func_177226_a(BlockLog.field_176299_a, blocklog$enumaxis));
++            this.func_175903_a(this.field_175946_l, blockpos1, p_175937_3_.func_177226_a(BlockLog.field_176299_a, blocklog$enumaxis));
+         }
+     }
+ 
+@@ -227,13 +234,13 @@
+         BlockPos blockpos = this.field_175947_m;
+         BlockPos blockpos1 = this.field_175947_m.func_177981_b(this.field_76501_f);
+         Block block = Blocks.field_150364_r;
+-        this.func_175937_a(blockpos, blockpos1, block);
++        this.limb(blockpos, blockpos1, this.trunk);
+ 
+         if (this.field_175943_g == 2)
+         {
+-            this.func_175937_a(blockpos.func_177974_f(), blockpos1.func_177974_f(), block);
+-            this.func_175937_a(blockpos.func_177974_f().func_177968_d(), blockpos1.func_177974_f().func_177968_d(), block);
+-            this.func_175937_a(blockpos.func_177968_d(), blockpos1.func_177968_d(), block);
++            this.limb(blockpos.func_177974_f(), blockpos1.func_177974_f(), this.trunk);
++            this.limb(blockpos.func_177974_f().func_177968_d(), blockpos1.func_177974_f().func_177968_d(), this.trunk);
++            this.limb(blockpos.func_177968_d(), blockpos1.func_177968_d(), this.trunk);
+         }
+     }
+ 
+@@ -246,7 +253,7 @@
+ 
+             if (!blockpos.equals(worldgenbigtree$foliagecoordinates) && this.func_76493_c(i - this.field_175947_m.func_177956_o()))
+             {
+-                this.func_175937_a(blockpos, worldgenbigtree$foliagecoordinates, Blocks.field_150364_r);
++                this.limb(blockpos, worldgenbigtree$foliagecoordinates, this.trunk);
+             }
+         }
+     }
+@@ -269,7 +276,7 @@
              {
                  BlockPos blockpos1 = p_175936_1_.func_177963_a((double)(0.5F + (float)j * f), (double)(0.5F + (float)j * f1), (double)(0.5F + (float)j * f2));
  
@@ -21,7 +85,7 @@
                  {
                      return j;
                  }
-@@ -297,6 +297,7 @@
+@@ -297,6 +304,7 @@
  
          if (!this.func_76497_e())
          {
@@ -29,7 +93,7 @@
              return false;
          }
          else
-@@ -305,15 +306,18 @@
+@@ -305,15 +313,18 @@
              this.func_175941_b();
              this.func_175942_c();
              this.func_175939_d();
@@ -43,7 +107,7 @@
 -        Block block = this.field_175946_l.func_180495_p(this.field_175947_m.func_177977_b()).func_177230_c();
 +        BlockPos down = this.field_175947_m.func_177977_b();
 +        net.minecraft.block.state.IBlockState state = this.field_175946_l.func_180495_p(down);
-+        boolean isSoil = state.func_177230_c().canSustainPlant(state, this.field_175946_l, down, net.minecraft.util.EnumFacing.UP, ((net.minecraft.block.BlockSapling)Blocks.field_150345_g));
++        boolean isSoil = state.func_177230_c().canSustainPlant(state, this.field_175946_l, down, net.minecraft.util.EnumFacing.UP, this.sapling);
  
 -        if (block != Blocks.field_150346_d && block != Blocks.field_150349_c && block != Blocks.field_150458_ak)
 +        if (!isSoil)

--- a/patches/minecraft/net/minecraft/world/gen/feature/WorldGenBirchTree.java.patch
+++ b/patches/minecraft/net/minecraft/world/gen/feature/WorldGenBirchTree.java.patch
@@ -1,6 +1,15 @@
 --- ../src-base/minecraft/net/minecraft/world/gen/feature/WorldGenBirchTree.java
 +++ ../src-work/minecraft/net/minecraft/world/gen/feature/WorldGenBirchTree.java
-@@ -56,9 +56,9 @@
+@@ -21,6 +21,8 @@
+     {
+         super(p_i45449_1_);
+         this.field_150531_a = p_i45449_2_;
++        this.trunk = field_181629_a;
++        this.leaf = field_181630_b;
+     }
+ 
+     public boolean func_180709_b(World p_180709_1_, Random p_180709_2_, BlockPos p_180709_3_)
+@@ -56,9 +58,9 @@
                  {
                      for (int i1 = p_180709_3_.func_177952_p() - k; i1 <= p_180709_3_.func_177952_p() + k && flag; ++i1)
                      {
@@ -12,14 +21,14 @@
                              {
                                  flag = false;
                              }
-@@ -77,11 +77,13 @@
+@@ -77,11 +79,13 @@
              }
              else
              {
 -                Block block = p_180709_1_.func_180495_p(p_180709_3_.func_177977_b()).func_177230_c();
 +                BlockPos down = p_180709_3_.func_177977_b();
 +                IBlockState state = p_180709_1_.func_180495_p(down);
-+                boolean isSoil = state.func_177230_c().canSustainPlant(state, p_180709_1_, down, net.minecraft.util.EnumFacing.UP, (net.minecraft.block.BlockSapling)Blocks.field_150345_g);
++                boolean isSoil = state.func_177230_c().canSustainPlant(state, p_180709_1_, down, net.minecraft.util.EnumFacing.UP, this.sapling);
  
 -                if ((block == Blocks.field_150349_c || block == Blocks.field_150346_d || block == Blocks.field_150458_ak) && p_180709_3_.func_177956_o() < 256 - i - 1)
 +                if (isSoil && p_180709_3_.func_177956_o() < p_180709_1_.func_72800_K() - i - 1)
@@ -29,7 +38,7 @@
  
                      for (int i2 = p_180709_3_.func_177956_o() - 3 + i; i2 <= p_180709_3_.func_177956_o() + i; ++i2)
                      {
-@@ -99,9 +101,9 @@
+@@ -99,11 +103,11 @@
                                  if (Math.abs(j1) != l2 || Math.abs(l1) != l2 || p_180709_2_.nextInt(2) != 0 && k2 != 0)
                                  {
                                      BlockPos blockpos = new BlockPos(i3, i2, k1);
@@ -39,9 +48,12 @@
 -                                    if (material == Material.field_151579_a || material == Material.field_151584_j)
 +                                    if (state2.func_177230_c().isAir(state2, p_180709_1_, blockpos) || state2.func_177230_c().isAir(state2, p_180709_1_, blockpos))
                                      {
-                                         this.func_175903_a(p_180709_1_, blockpos, field_181630_b);
+-                                        this.func_175903_a(p_180709_1_, blockpos, field_181630_b);
++                                        this.func_175903_a(p_180709_1_, blockpos, this.leaf);
                                      }
-@@ -112,9 +114,10 @@
+                                 }
+                             }
+@@ -112,11 +116,12 @@
  
                      for (int j2 = 0; j2 < i; ++j2)
                      {
@@ -52,5 +64,8 @@
 -                        if (material1 == Material.field_151579_a || material1 == Material.field_151584_j)
 +                        if (state2.func_177230_c().isAir(state2, p_180709_1_, upN) || state2.func_177230_c().isLeaves(state2, p_180709_1_, upN))
                          {
-                             this.func_175903_a(p_180709_1_, p_180709_3_.func_177981_b(j2), field_181629_a);
+-                            this.func_175903_a(p_180709_1_, p_180709_3_.func_177981_b(j2), field_181629_a);
++                            this.func_175903_a(p_180709_1_, p_180709_3_.func_177981_b(j2), this.trunk);
                          }
+                     }
+ 

--- a/patches/minecraft/net/minecraft/world/gen/feature/WorldGenCanopyTree.java.patch
+++ b/patches/minecraft/net/minecraft/world/gen/feature/WorldGenCanopyTree.java.patch
@@ -1,19 +1,28 @@
 --- ../src-base/minecraft/net/minecraft/world/gen/feature/WorldGenCanopyTree.java
 +++ ../src-work/minecraft/net/minecraft/world/gen/feature/WorldGenCanopyTree.java
-@@ -33,9 +33,10 @@
+@@ -21,6 +21,8 @@
+     public WorldGenCanopyTree(boolean p_i45461_1_)
+     {
+         super(p_i45461_1_);
++        this.trunk = field_181640_a;
++        this.leaf = field_181641_b;
+     }
+ 
+     public boolean func_180709_b(World p_180709_1_, Random p_180709_2_, BlockPos p_180709_3_)
+@@ -33,9 +35,10 @@
          if (k >= 1 && k + i + 1 < 256)
          {
              BlockPos blockpos = p_180709_3_.func_177977_b();
 -            Block block = p_180709_1_.func_180495_p(blockpos).func_177230_c();
 +            IBlockState state = p_180709_1_.func_180495_p(blockpos);
-+            boolean isSoil = state.func_177230_c().canSustainPlant(state, p_180709_1_, blockpos, net.minecraft.util.EnumFacing.UP, ((net.minecraft.block.BlockSapling)Blocks.field_150345_g));
++            boolean isSoil = state.func_177230_c().canSustainPlant(state, p_180709_1_, blockpos, net.minecraft.util.EnumFacing.UP, this.sapling);
  
 -            if (block != Blocks.field_150349_c && block != Blocks.field_150346_d)
 +            if (!(isSoil && p_180709_3_.func_177956_o() < p_180709_1_.func_72800_K() - i - 1))
              {
                  return false;
              }
-@@ -45,10 +46,10 @@
+@@ -45,10 +48,10 @@
              }
              else
              {
@@ -28,7 +37,7 @@
                  EnumFacing enumfacing = EnumFacing.Plane.HORIZONTAL.func_179518_a(p_180709_2_);
                  int i1 = i - p_180709_2_.nextInt(4);
                  int j1 = 2 - p_180709_2_.nextInt(3);
-@@ -67,9 +68,9 @@
+@@ -67,9 +70,9 @@
  
                      int k2 = k + j2;
                      BlockPos blockpos1 = new BlockPos(k1, k2, l1);
@@ -40,7 +49,7 @@
                      {
                          this.func_181639_b(p_180709_1_, blockpos1);
                          this.func_181639_b(p_180709_1_, blockpos1.func_177974_f());
-@@ -187,7 +188,7 @@
+@@ -187,7 +190,7 @@
              {
                  for (int k1 = -i1; k1 <= i1; ++k1)
                  {
@@ -49,7 +58,15 @@
                      {
                          return false;
                      }
-@@ -209,11 +210,18 @@
+@@ -202,18 +205,25 @@
+     {
+         if (this.func_150523_a(p_181639_1_.func_180495_p(p_181639_2_).func_177230_c()))
+         {
+-            this.func_175903_a(p_181639_1_, p_181639_2_, field_181640_a);
++            this.func_175903_a(p_181639_1_, p_181639_2_, this.trunk);
+         }
+     }
+ 
      private void func_150526_a(World p_150526_1_, int p_150526_2_, int p_150526_3_, int p_150526_4_)
      {
          BlockPos blockpos = new BlockPos(p_150526_2_, p_150526_3_, p_150526_4_);
@@ -59,7 +76,8 @@
 -        if (material == Material.field_151579_a)
 +        if (state.func_177230_c().isAir(state, p_150526_1_, blockpos))
          {
-             this.func_175903_a(p_150526_1_, blockpos, field_181641_b);
+-            this.func_175903_a(p_150526_1_, blockpos, field_181641_b);
++            this.func_175903_a(p_150526_1_, blockpos, this.leaf);
          }
      }
 +

--- a/patches/minecraft/net/minecraft/world/gen/feature/WorldGenCanopyTree.java.patch
+++ b/patches/minecraft/net/minecraft/world/gen/feature/WorldGenCanopyTree.java.patch
@@ -58,9 +58,12 @@
                      {
                          return false;
                      }
-@@ -202,18 +205,25 @@
+@@ -200,20 +203,27 @@
+ 
+     private void func_181639_b(World p_181639_1_, BlockPos p_181639_2_)
      {
-         if (this.func_150523_a(p_181639_1_.func_180495_p(p_181639_2_).func_177230_c()))
+-        if (this.func_150523_a(p_181639_1_.func_180495_p(p_181639_2_).func_177230_c()))
++        if (this.isReplaceable(p_181639_1_, p_181639_2_))
          {
 -            this.func_175903_a(p_181639_1_, p_181639_2_, field_181640_a);
 +            this.func_175903_a(p_181639_1_, p_181639_2_, this.trunk);

--- a/patches/minecraft/net/minecraft/world/gen/feature/WorldGenHugeTrees.java.patch
+++ b/patches/minecraft/net/minecraft/world/gen/feature/WorldGenHugeTrees.java.patch
@@ -15,7 +15,7 @@
          BlockPos blockpos = p_175927_1_.func_177977_b();
 -        Block block = p_175927_2_.func_180495_p(blockpos).func_177230_c();
 +        IBlockState state = p_175927_2_.func_180495_p(blockpos);
-+        boolean isSoil = state.func_177230_c().canSustainPlant(state, p_175927_2_, blockpos, net.minecraft.util.EnumFacing.UP, ((net.minecraft.block.BlockSapling)Blocks.field_150345_g));
++        boolean isSoil = state.func_177230_c().canSustainPlant(state, p_175927_2_, blockpos, net.minecraft.util.EnumFacing.UP, this.sapling);
  
 -        if ((block == Blocks.field_150349_c || block == Blocks.field_150346_d) && p_175927_1_.func_177956_o() >= 2)
 +        if (isSoil && p_175927_1_.func_177956_o() >= 2)

--- a/patches/minecraft/net/minecraft/world/gen/feature/WorldGenMegaPineTree.java.patch
+++ b/patches/minecraft/net/minecraft/world/gen/feature/WorldGenMegaPineTree.java.patch
@@ -37,7 +37,7 @@
                      {
                          this.func_175903_a(p_180709_1_, p_180709_3_.func_177982_a(0, j, 1), this.field_76520_b);
                      }
-@@ -133,7 +126,7 @@
+@@ -133,16 +126,23 @@
              IBlockState iblockstate = p_175934_1_.func_180495_p(blockpos);
              Block block = iblockstate.func_177230_c();
  
@@ -46,7 +46,12 @@
              {
                  this.func_175903_a(p_175934_1_, blockpos, field_181635_g);
                  break;
-@@ -145,4 +138,11 @@
+             }
+ 
+-            if (iblockstate.func_185904_a() != Material.field_151579_a && i < 0)
++            if (!block.isAir(iblockstate, p_175934_1_, blockpos) && i < 0)
+             {
+                 break;
              }
          }
      }

--- a/patches/minecraft/net/minecraft/world/gen/feature/WorldGenMegaPineTree.java.patch
+++ b/patches/minecraft/net/minecraft/world/gen/feature/WorldGenMegaPineTree.java.patch
@@ -42,7 +42,7 @@
              Block block = iblockstate.func_177230_c();
  
 -            if (block == Blocks.field_150349_c || block == Blocks.field_150346_d)
-+            if (block.canSustainPlant(iblockstate, p_175934_1_, blockpos, net.minecraft.util.EnumFacing.UP, ((net.minecraft.block.BlockSapling)Blocks.field_150345_g)))
++            if (block.canSustainPlant(iblockstate, p_175934_1_, blockpos, net.minecraft.util.EnumFacing.UP, this.sapling))
              {
                  this.func_175903_a(p_175934_1_, blockpos, field_181635_g);
                  break;

--- a/patches/minecraft/net/minecraft/world/gen/feature/WorldGenSavannaTree.java.patch
+++ b/patches/minecraft/net/minecraft/world/gen/feature/WorldGenSavannaTree.java.patch
@@ -1,6 +1,15 @@
 --- ../src-base/minecraft/net/minecraft/world/gen/feature/WorldGenSavannaTree.java
 +++ ../src-work/minecraft/net/minecraft/world/gen/feature/WorldGenSavannaTree.java
-@@ -52,7 +52,7 @@
+@@ -21,6 +21,8 @@
+     public WorldGenSavannaTree(boolean p_i45463_1_)
+     {
+         super(p_i45463_1_);
++        this.trunk = field_181643_a;
++        this.leaf = field_181644_b;
+     }
+ 
+     public boolean func_180709_b(World p_180709_1_, Random p_180709_2_, BlockPos p_180709_3_)
+@@ -52,7 +54,7 @@
                      {
                          if (j >= 0 && j < 256)
                          {
@@ -9,14 +18,14 @@
                              {
                                  flag = false;
                              }
-@@ -71,11 +71,13 @@
+@@ -71,11 +73,13 @@
              }
              else
              {
 -                Block block = p_180709_1_.func_180495_p(p_180709_3_.func_177977_b()).func_177230_c();
 +                BlockPos down = p_180709_3_.func_177977_b();
 +                IBlockState state = p_180709_1_.func_180495_p(down);
-+                boolean isSoil = state.func_177230_c().canSustainPlant(state, p_180709_1_, down, net.minecraft.util.EnumFacing.UP, ((net.minecraft.block.BlockSapling)Blocks.field_150345_g));
++                boolean isSoil = state.func_177230_c().canSustainPlant(state, p_180709_1_, down, net.minecraft.util.EnumFacing.UP, this.sapling);
  
 -                if ((block == Blocks.field_150349_c || block == Blocks.field_150346_d) && p_180709_3_.func_177956_o() < 256 - i - 1)
 +                if (isSoil && p_180709_3_.func_177956_o() < p_180709_1_.func_72800_K() - i - 1)
@@ -26,7 +35,7 @@
                      EnumFacing enumfacing = EnumFacing.Plane.HORIZONTAL.func_179518_a(p_180709_2_);
                      int k2 = i - p_180709_2_.nextInt(4) - 1;
                      int l2 = 3 - p_180709_2_.nextInt(3);
-@@ -95,9 +97,9 @@
+@@ -95,9 +99,9 @@
                          }
  
                          BlockPos blockpos = new BlockPos(i3, i2, j1);
@@ -38,7 +47,7 @@
                          {
                              this.func_181642_b(p_180709_1_, blockpos);
                              k1 = i2;
-@@ -149,9 +151,9 @@
+@@ -149,9 +153,9 @@
                                  i3 += enumfacing1.func_82601_c();
                                  j1 += enumfacing1.func_82599_e();
                                  BlockPos blockpos1 = new BlockPos(i3, j2, j1);
@@ -50,7 +59,13 @@
                                  {
                                      this.func_181642_b(p_180709_1_, blockpos1);
                                      k1 = j2;
-@@ -209,9 +211,9 @@
+@@ -204,16 +208,16 @@
+ 
+     private void func_181642_b(World p_181642_1_, BlockPos p_181642_2_)
+     {
+-        this.func_175903_a(p_181642_1_, p_181642_2_, field_181643_a);
++        this.func_175903_a(p_181642_1_, p_181642_2_, this.trunk);
+     }
  
      private void func_175924_b(World p_175924_1_, BlockPos p_175924_2_)
      {
@@ -60,5 +75,8 @@
 -        if (material == Material.field_151579_a || material == Material.field_151584_j)
 +        if (state.func_177230_c().isAir(state, p_175924_1_, p_175924_2_) || state.func_177230_c().isLeaves(state, p_175924_1_, p_175924_2_))
          {
-             this.func_175903_a(p_175924_1_, p_175924_2_, field_181644_b);
+-            this.func_175903_a(p_175924_1_, p_175924_2_, field_181644_b);
++            this.func_175903_a(p_175924_1_, p_175924_2_, this.leaf);
          }
+     }
+ }

--- a/patches/minecraft/net/minecraft/world/gen/feature/WorldGenShrub.java.patch
+++ b/patches/minecraft/net/minecraft/world/gen/feature/WorldGenShrub.java.patch
@@ -14,7 +14,7 @@
 +        IBlockState state = p_180709_1_.func_180495_p(p_180709_3_);
  
 -        if (block == Blocks.field_150346_d || block == Blocks.field_150349_c)
-+        if (state.func_177230_c().canSustainPlant(state, p_180709_1_, p_180709_3_, net.minecraft.util.EnumFacing.UP, ((net.minecraft.block.BlockSapling)Blocks.field_150345_g)))
++        if (state.func_177230_c().canSustainPlant(state, p_180709_1_, p_180709_3_, net.minecraft.util.EnumFacing.UP, this.sapling))
          {
              p_180709_3_ = p_180709_3_.func_177984_a();
              this.func_175903_a(p_180709_1_, p_180709_3_, this.field_150527_b);

--- a/patches/minecraft/net/minecraft/world/gen/feature/WorldGenSwamp.java.patch
+++ b/patches/minecraft/net/minecraft/world/gen/feature/WorldGenSwamp.java.patch
@@ -1,6 +1,15 @@
 --- ../src-base/minecraft/net/minecraft/world/gen/feature/WorldGenSwamp.java
 +++ ../src-work/minecraft/net/minecraft/world/gen/feature/WorldGenSwamp.java
-@@ -61,7 +61,7 @@
+@@ -21,6 +21,8 @@
+     public WorldGenSwamp()
+     {
+         super(false);
++        this.trunk = field_181648_a;
++        this.leaf = field_181649_b;
+     }
+ 
+     public boolean func_180709_b(World p_180709_1_, Random p_180709_2_, BlockPos p_180709_3_)
+@@ -61,7 +63,7 @@
                              IBlockState iblockstate = p_180709_1_.func_180495_p(blockpos$mutableblockpos.func_181079_c(l, j, i1));
                              Block block = iblockstate.func_177230_c();
  
@@ -9,14 +18,14 @@
                              {
                                  if (block != Blocks.field_150355_j && block != Blocks.field_150358_i)
                                  {
-@@ -87,11 +87,13 @@
+@@ -87,11 +89,13 @@
              }
              else
              {
 -                Block block1 = p_180709_1_.func_180495_p(p_180709_3_.func_177977_b()).func_177230_c();
 +                BlockPos down = p_180709_3_.func_177977_b();
 +                IBlockState state = p_180709_1_.func_180495_p(down);
-+                boolean isSoil = state.func_177230_c().canSustainPlant(state, p_180709_1_, down, net.minecraft.util.EnumFacing.UP, ((net.minecraft.block.BlockSapling)Blocks.field_150345_g));
++                boolean isSoil = state.func_177230_c().canSustainPlant(state, p_180709_1_, down, net.minecraft.util.EnumFacing.UP, this.sapling);
  
 -                if ((block1 == Blocks.field_150349_c || block1 == Blocks.field_150346_d) && p_180709_3_.func_177956_o() < 256 - i - 1)
 +                if (isSoil && p_180709_3_.func_177956_o() < p_180709_1_.func_72800_K() - i - 1)
@@ -26,7 +35,7 @@
  
                      for (int k1 = p_180709_3_.func_177956_o() - 3 + i; k1 <= p_180709_3_.func_177956_o() + i; ++k1)
                      {
-@@ -109,8 +111,9 @@
+@@ -109,10 +113,11 @@
                                  if (Math.abs(k3) != l2 || Math.abs(j1) != l2 || p_180709_2_.nextInt(2) != 0 && j2 != 0)
                                  {
                                      BlockPos blockpos = new BlockPos(j3, k1, i4);
@@ -35,9 +44,12 @@
 -                                    if (!p_180709_1_.func_180495_p(blockpos).func_185913_b())
 +                                    if (state.func_177230_c().canBeReplacedByLeaves(state, p_180709_1_, blockpos))
                                      {
-                                         this.func_175903_a(p_180709_1_, blockpos, field_181649_b);
+-                                        this.func_175903_a(p_180709_1_, blockpos, field_181649_b);
++                                        this.func_175903_a(p_180709_1_, blockpos, this.leaf);
                                      }
-@@ -121,10 +124,11 @@
+                                 }
+                             }
+@@ -121,12 +126,13 @@
  
                      for (int l1 = 0; l1 < i; ++l1)
                      {
@@ -49,9 +61,12 @@
 -                        if (iblockstate1.func_185904_a() == Material.field_151579_a || iblockstate1.func_185904_a() == Material.field_151584_j || block2 == Blocks.field_150358_i || block2 == Blocks.field_150355_j)
 +                        if (block2.isAir(iblockstate1, p_180709_1_, upN) || block2.isLeaves(iblockstate1, p_180709_1_, upN) || block2 == Blocks.field_150358_i || block2 == Blocks.field_150355_j)
                          {
-                             this.func_175903_a(p_180709_1_, p_180709_3_.func_177981_b(l1), field_181648_a);
+-                            this.func_175903_a(p_180709_1_, p_180709_3_.func_177981_b(l1), field_181648_a);
++                            this.func_175903_a(p_180709_1_, p_180709_3_.func_177981_b(l1), this.trunk);
                          }
-@@ -149,22 +153,22 @@
+                     }
+ 
+@@ -149,22 +155,22 @@
                                      BlockPos blockpos1 = blockpos$mutableblockpos1.func_177978_c();
                                      BlockPos blockpos2 = blockpos$mutableblockpos1.func_177968_d();
  
@@ -78,7 +93,7 @@
                                      {
                                          this.func_181647_a(p_180709_1_, blockpos2, BlockVine.field_176273_b);
                                      }
-@@ -193,7 +197,7 @@
+@@ -193,7 +199,7 @@
          this.func_175903_a(p_181647_1_, p_181647_2_, iblockstate);
          int i = 4;
  

--- a/patches/minecraft/net/minecraft/world/gen/feature/WorldGenSwamp.java.patch
+++ b/patches/minecraft/net/minecraft/world/gen/feature/WorldGenSwamp.java.patch
@@ -66,7 +66,16 @@
                          }
                      }
  
-@@ -149,22 +155,22 @@
+@@ -142,29 +148,30 @@
+                             {
+                                 blockpos$mutableblockpos1.func_181079_c(l3, i2, j4);
+ 
+-                                if (p_180709_1_.func_180495_p(blockpos$mutableblockpos1).func_185904_a() == Material.field_151584_j)
++                                IBlockState state1 = p_180709_1_.func_180495_p(blockpos$mutableblockpos1);
++                                if (state1.func_177230_c().isLeaves(state1, p_180709_1_, blockpos$mutableblockpos1))
+                                 {
+                                     BlockPos blockpos3 = blockpos$mutableblockpos1.func_177976_e();
+                                     BlockPos blockpos4 = blockpos$mutableblockpos1.func_177974_f();
                                      BlockPos blockpos1 = blockpos$mutableblockpos1.func_177978_c();
                                      BlockPos blockpos2 = blockpos$mutableblockpos1.func_177968_d();
  
@@ -93,7 +102,7 @@
                                      {
                                          this.func_181647_a(p_180709_1_, blockpos2, BlockVine.field_176273_b);
                                      }
-@@ -193,7 +199,7 @@
+@@ -193,7 +200,7 @@
          this.func_175903_a(p_181647_1_, p_181647_2_, iblockstate);
          int i = 4;
  

--- a/patches/minecraft/net/minecraft/world/gen/feature/WorldGenTaiga1.java.patch
+++ b/patches/minecraft/net/minecraft/world/gen/feature/WorldGenTaiga1.java.patch
@@ -1,6 +1,15 @@
 --- ../src-base/minecraft/net/minecraft/world/gen/feature/WorldGenTaiga1.java
 +++ ../src-work/minecraft/net/minecraft/world/gen/feature/WorldGenTaiga1.java
-@@ -54,7 +54,7 @@
+@@ -20,6 +20,8 @@
+     public WorldGenTaiga1()
+     {
+         super(false);
++        this.trunk = field_181636_a;
++        this.leaf = field_181637_b;
+     }
+ 
+     public boolean func_180709_b(World p_180709_1_, Random p_180709_2_, BlockPos p_180709_3_)
+@@ -54,7 +56,7 @@
                      {
                          if (i1 >= 0 && i1 < 256)
                          {
@@ -9,14 +18,14 @@
                              {
                                  flag = false;
                              }
-@@ -73,11 +73,13 @@
+@@ -73,11 +75,13 @@
              }
              else
              {
 -                Block block = p_180709_1_.func_180495_p(p_180709_3_.func_177977_b()).func_177230_c();
 +                BlockPos down = p_180709_3_.func_177977_b();
 +                IBlockState state = p_180709_1_.func_180495_p(down);
-+                boolean isSoil = state.func_177230_c().canSustainPlant(state, p_180709_1_, down, net.minecraft.util.EnumFacing.UP, (net.minecraft.block.BlockSapling)Blocks.field_150345_g);
++                boolean isSoil = state.func_177230_c().canSustainPlant(state, p_180709_1_, down, net.minecraft.util.EnumFacing.UP, this.sapling);
  
 -                if ((block == Blocks.field_150349_c || block == Blocks.field_150346_d) && p_180709_3_.func_177956_o() < 256 - i - 1)
 +                if (isSoil && p_180709_3_.func_177956_o() < 256 - i - 1)
@@ -26,7 +35,7 @@
                      int k2 = 0;
  
                      for (int l2 = p_180709_3_.func_177956_o() + i; l2 >= p_180709_3_.func_177956_o() + j; --l2)
-@@ -93,8 +95,9 @@
+@@ -93,10 +97,11 @@
                                  if (Math.abs(k3) != k2 || Math.abs(j2) != k2 || k2 <= 0)
                                  {
                                      BlockPos blockpos = new BlockPos(j3, l2, i2);
@@ -35,9 +44,12 @@
 -                                    if (!p_180709_1_.func_180495_p(blockpos).func_185913_b())
 +                                    if (state.func_177230_c().canBeReplacedByLeaves(state, p_180709_1_, blockpos))
                                      {
-                                         this.func_175903_a(p_180709_1_, blockpos, field_181637_b);
+-                                        this.func_175903_a(p_180709_1_, blockpos, field_181637_b);
++                                        this.func_175903_a(p_180709_1_, blockpos, this.leaf);
                                      }
-@@ -114,9 +117,10 @@
+                                 }
+                             }
+@@ -114,11 +119,12 @@
  
                      for (int i3 = 0; i3 < i - 1; ++i3)
                      {
@@ -48,5 +60,8 @@
 -                        if (material == Material.field_151579_a || material == Material.field_151584_j)
 +                        if (state.func_177230_c().isAir(state, p_180709_1_, upN) || state.func_177230_c().isLeaves(state, p_180709_1_, upN))
                          {
-                             this.func_175903_a(p_180709_1_, p_180709_3_.func_177981_b(i3), field_181636_a);
+-                            this.func_175903_a(p_180709_1_, p_180709_3_.func_177981_b(i3), field_181636_a);
++                            this.func_175903_a(p_180709_1_, p_180709_3_.func_177981_b(i3), this.trunk);
                          }
+                     }
+ 

--- a/patches/minecraft/net/minecraft/world/gen/feature/WorldGenTaiga2.java.patch
+++ b/patches/minecraft/net/minecraft/world/gen/feature/WorldGenTaiga2.java.patch
@@ -1,6 +1,15 @@
 --- ../src-base/minecraft/net/minecraft/world/gen/feature/WorldGenTaiga2.java
 +++ ../src-work/minecraft/net/minecraft/world/gen/feature/WorldGenTaiga2.java
-@@ -30,7 +30,7 @@
+@@ -20,6 +20,8 @@
+     public WorldGenTaiga2(boolean p_i2025_1_)
+     {
+         super(p_i2025_1_);
++        this.trunk = field_181645_a;
++        this.leaf = field_181646_b;
+     }
+ 
+     public boolean func_180709_b(World p_180709_1_, Random p_180709_2_, BlockPos p_180709_3_)
+@@ -30,7 +32,7 @@
          int l = 2 + p_180709_2_.nextInt(2);
          boolean flag = true;
  
@@ -9,7 +18,7 @@
          {
              for (int i1 = p_180709_3_.func_177956_o(); i1 <= p_180709_3_.func_177956_o() + 1 + i && flag; ++i1)
              {
-@@ -51,11 +51,11 @@
+@@ -51,11 +53,11 @@
                  {
                      for (int l1 = p_180709_3_.func_177952_p() - j1; l1 <= p_180709_3_.func_177952_p() + j1 && flag; ++l1)
                      {
@@ -24,7 +33,7 @@
                              {
                                  flag = false;
                              }
-@@ -74,11 +74,12 @@
+@@ -74,11 +76,12 @@
              }
              else
              {
@@ -33,14 +42,14 @@
 +                IBlockState state = p_180709_1_.func_180495_p(down);
  
 -                if ((block == Blocks.field_150349_c || block == Blocks.field_150346_d || block == Blocks.field_150458_ak) && p_180709_3_.func_177956_o() < 256 - i - 1)
-+                if (state.func_177230_c().canSustainPlant(state, p_180709_1_, down, net.minecraft.util.EnumFacing.UP, (net.minecraft.block.BlockSapling)Blocks.field_150345_g) && p_180709_3_.func_177956_o() < p_180709_1_.func_72800_K() - i - 1)
++                if (state.func_177230_c().canSustainPlant(state, p_180709_1_, down, net.minecraft.util.EnumFacing.UP, this.sapling) && p_180709_3_.func_177956_o() < p_180709_1_.func_72800_K() - i - 1)
                  {
 -                    this.func_175921_a(p_180709_1_, p_180709_3_.func_177977_b());
 +                    state.func_177230_c().onPlantGrow(state, p_180709_1_, down, p_180709_3_);
                      int i3 = p_180709_2_.nextInt(2);
                      int j3 = 1;
                      int k3 = 0;
-@@ -98,8 +99,9 @@
+@@ -98,10 +101,11 @@
                                  if (Math.abs(j2) != i3 || Math.abs(l2) != i3 || i3 <= 0)
                                  {
                                      BlockPos blockpos = new BlockPos(i2, j4, k2);
@@ -49,9 +58,12 @@
 -                                    if (!p_180709_1_.func_180495_p(blockpos).func_185913_b())
 +                                    if (state.func_177230_c().canBeReplacedByLeaves(state, p_180709_1_, blockpos))
                                      {
-                                         this.func_175903_a(p_180709_1_, blockpos, field_181646_b);
+-                                        this.func_175903_a(p_180709_1_, blockpos, field_181646_b);
++                                        this.func_175903_a(p_180709_1_, blockpos, this.leaf);
                                      }
-@@ -128,9 +130,10 @@
+                                 }
+                             }
+@@ -128,11 +132,12 @@
  
                      for (int k4 = 0; k4 < i - i4; ++k4)
                      {
@@ -62,5 +74,8 @@
 -                        if (material1 == Material.field_151579_a || material1 == Material.field_151584_j)
 +                        if (state.func_177230_c().isAir(state, p_180709_1_, upN) || state.func_177230_c().isLeaves(state, p_180709_1_, upN))
                          {
-                             this.func_175903_a(p_180709_1_, p_180709_3_.func_177981_b(k4), field_181645_a);
+-                            this.func_175903_a(p_180709_1_, p_180709_3_.func_177981_b(k4), field_181645_a);
++                            this.func_175903_a(p_180709_1_, p_180709_3_.func_177981_b(k4), this.trunk);
                          }
+                     }
+ 

--- a/patches/minecraft/net/minecraft/world/gen/feature/WorldGenTrees.java.patch
+++ b/patches/minecraft/net/minecraft/world/gen/feature/WorldGenTrees.java.patch
@@ -29,7 +29,7 @@
 +                IBlockState state = p_180709_1_.func_180495_p(p_180709_3_.func_177977_b());
  
 -                if ((block == Blocks.field_150349_c || block == Blocks.field_150346_d || block == Blocks.field_150458_ak) && p_180709_3_.func_177956_o() < 256 - i - 1)
-+                if (state.func_177230_c().canSustainPlant(state, p_180709_1_, p_180709_3_.func_177977_b(), net.minecraft.util.EnumFacing.UP, (net.minecraft.block.BlockSapling)Blocks.field_150345_g) && p_180709_3_.func_177956_o() < p_180709_1_.func_72800_K() - i - 1)
++                if (state.func_177230_c().canSustainPlant(state, p_180709_1_, p_180709_3_.func_177977_b(), net.minecraft.util.EnumFacing.UP, this.sapling) && p_180709_3_.func_177956_o() < p_180709_1_.func_72800_K() - i - 1)
                  {
 -                    this.func_175921_a(p_180709_1_, p_180709_3_.func_177977_b());
 +                    state.func_177230_c().onPlantGrow(state, p_180709_1_, p_180709_3_.func_177977_b(), p_180709_3_);

--- a/src/main/resources/forge.exc
+++ b/src/main/resources/forge.exc
@@ -80,3 +80,5 @@ net/minecraft/command/EntitySelector.isSelectorDefault(Ljava/lang/String;)Z=|p_8
 net/minecraft/client/util/RecipeItemHelper.accountStack(Lnet/minecraft/item/ItemStack;I)V=|p_194112_1_,forceCount
 net/minecraft/client/renderer/ActiveRenderInfo.updateRenderInfo(Lnet/minecraft/entity/Entity;Z)V=|p_74583_0_,p_74583_1_
 net/minecraft/client/audio/SoundManager.setListener(Lnet/minecraft/entity/Entity;F)V=|p_148615_1_,p_148615_2_
+
+net/minecraft/world/gen/feature/WorldGenBigTree.limb(Lnet/minecraft/util/math/BlockPos;Lnet/minecraft/util/math/BlockPos;Lnet/minecraft/block/state/IBlockState;)V=|p_175937_1_,p_175937_2_,p_175937_3_


### PR DESCRIPTION
This replaces the hardcoded `IBlockState` references in various vanilla tree generator classes with protected field references, allowing mods to use these to place "vanilla-like" trees without having to copy/paste code.

Currently does not affect the tree gen classes that can already take `IBlockState` parameters (`WorldGenHugeTrees`/`WorldGenTrees` + subclasses), but these can also be changed to be consistent if wanted.