### PR TITLE
Fix race condition causing the FML handshake to hang

### DIFF
--- a/src/main/java/net/minecraftforge/fml/network/FMLHandshakeHandler.java
+++ b/src/main/java/net/minecraftforge/fml/network/FMLHandshakeHandler.java
@@ -242,8 +242,8 @@ public class FMLHandshakeHandler {
             NetworkRegistry.LoginPayload message = messageList.get(packetPosition);
 
             LOGGER.debug(FMLHSMARKER, "Sending ticking packet info '{}' to '{}' sequence {}", message.getMessageContext(), message.getChannelName(), packetPosition);
-            loginWrapper.sendServerToClientLoginPacket(message.getChannelName(), message.getData(), packetPosition, this.manager);
             sentMessages.add(packetPosition);
+            loginWrapper.sendServerToClientLoginPacket(message.getChannelName(), message.getData(), packetPosition, this.manager);
             packetPosition++;
         }
 


### PR DESCRIPTION
I had this happen a couple of times while playing around with 1.13, sometimes the world loading would just hang with a message like `Received unexpected index 10 in client reply` in the log. This seems to have been caused by the reply coming in between lines 245 and 246; swapping the lines (adding the expected reply before sending the packet) should fix it.