### PR TITLE
Fix crash when placing furnaces or brewing stands in 1.13

### DIFF
--- a/patches/minecraft/net/minecraft/tileentity/TileEntityBrewingStand.java.patch
+++ b/patches/minecraft/net/minecraft/tileentity/TileEntityBrewingStand.java.patch
@@ -66,7 +66,7 @@
 +      if (facing != null && capability == net.minecraftforge.items.CapabilityItemHandler.ITEM_HANDLER_CAPABILITY) {
 +         if (facing == EnumFacing.UP)
 +            return handlers[0].cast();
-+         else if (facing == EnumFacing.UP)
++         else if (facing == EnumFacing.DOWN)
 +            return handlers[1].cast();
 +         else
 +            return handlers[2].cast();

--- a/patches/minecraft/net/minecraft/tileentity/TileEntityFurnace.java.patch
+++ b/patches/minecraft/net/minecraft/tileentity/TileEntityFurnace.java.patch
@@ -88,7 +88,7 @@
 +      if (facing != null && capability == net.minecraftforge.items.CapabilityItemHandler.ITEM_HANDLER_CAPABILITY) {
 +         if (facing == EnumFacing.UP)
 +            return handlers[0].cast();
-+         else if (facing == EnumFacing.UP)
++         else if (facing == EnumFacing.DOWN)
 +            return handlers[1].cast();
 +         else
 +            return handlers[2].cast();

--- a/src/main/java/net/minecraftforge/items/wrapper/SidedInvWrapper.java
+++ b/src/main/java/net/minecraftforge/items/wrapper/SidedInvWrapper.java
@@ -34,11 +34,11 @@ public class SidedInvWrapper implements IItemHandlerModifiable
     protected final EnumFacing side;
 
     @SuppressWarnings("unchecked")
-    public static <T extends IItemHandlerModifiable> OptionalCapabilityInstance<T>[] create(ISidedInventory inv, EnumFacing... sides) {
-        OptionalCapabilityInstance<T>[] ret = new OptionalCapabilityInstance[sides.length];
+    public static OptionalCapabilityInstance<IItemHandlerModifiable>[] create(ISidedInventory inv, EnumFacing... sides) {
+        OptionalCapabilityInstance<IItemHandlerModifiable>[] ret = new OptionalCapabilityInstance[sides.length];
         for (int x = 0; x < sides.length; x++) {
             final EnumFacing side = sides[x];
-            ret[x] = OptionalCapabilityInstance.of(() -> (T)new SidedInvWrapper(inv, side));
+            ret[x] = OptionalCapabilityInstance.of(() -> new SidedInvWrapper(inv, side));
         }
         return ret;
     }

--- a/src/main/java/net/minecraftforge/items/wrapper/SidedInvWrapper.java
+++ b/src/main/java/net/minecraftforge/items/wrapper/SidedInvWrapper.java
@@ -34,11 +34,11 @@ public class SidedInvWrapper implements IItemHandlerModifiable
     protected final EnumFacing side;
 
     @SuppressWarnings("unchecked")
-    public static <T extends OptionalCapabilityInstance<IItemHandlerModifiable>> T[] create(ISidedInventory inv, EnumFacing... sides) {
-        T[] ret = (T[])new Object[sides.length];
+    public static <T extends IItemHandlerModifiable> OptionalCapabilityInstance<T>[] create(ISidedInventory inv, EnumFacing... sides) {
+        OptionalCapabilityInstance<T>[] ret = new OptionalCapabilityInstance[sides.length];
         for (int x = 0; x < sides.length; x++) {
             final EnumFacing side = sides[x];
-            ret[x] = (T)OptionalCapabilityInstance.of(() -> (IItemHandlerModifiable)new SidedInvWrapper(inv, side));
+            ret[x] = OptionalCapabilityInstance.of(() -> (T)new SidedInvWrapper(inv, side));
         }
         return ret;
     }


### PR DESCRIPTION
The old code tried to cast an `Object[]` into an `OptionalCapabilityInstance<IItemHandlerModifiable>[]`and potentially into something else on return, causing a `ClassCastException`. It works just as well without generics since the only places where it is used assign the return value to a `OptionalCapabilityInstance<? extends IItemHandler>[]`.