### PR TITLE
Don't catch exceptions from server starting events

### DIFF
--- a/patches/minecraft/net/minecraft/client/Minecraft.java.patch
+++ b/patches/minecraft/net/minecraft/client/Minecraft.java.patch
@@ -273,14 +273,11 @@
          this.func_71403_a((WorldClient)null);
          System.gc();
          ISaveHandler isavehandler = this.field_71469_aa.func_75804_a(p_71371_1_, false);
-@@ -2344,8 +2380,14 @@
+@@ -2346,6 +2382,12 @@
  
-         this.field_71461_s.func_73720_a(I18n.func_135052_a("menu.loadingLevel"));
- 
--        while (!this.field_71437_Z.func_71200_ad())
-+        while (!this.field_71437_Z.func_71200_ad() && !this.field_71437_Z.func_71241_aa())
+         while (!this.field_71437_Z.func_71200_ad())
          {
-+            if (!net.minecraftforge.fml.common.StartupQuery.check())
++            if (!net.minecraftforge.fml.common.StartupQuery.check() || this.field_71437_Z.func_71241_aa())
 +            {
 +                func_71403_a(null);
 +                func_147108_a(null);

--- a/src/main/java/net/minecraftforge/fml/common/Loader.java
+++ b/src/main/java/net/minecraftforge/fml/common/Loader.java
@@ -789,16 +789,8 @@ public class Loader
 
     public boolean serverStarting(Object server)
     {
-        try
-        {
-            modController.distributeStateMessage(LoaderState.SERVER_STARTING, server);
-            modController.transition(LoaderState.SERVER_STARTING, false);
-        }
-        catch (Throwable t)
-        {
-            FMLLog.log.error("A fatal exception occurred during the server starting event", t);
-            return false;
-        }
+        modController.distributeStateMessage(LoaderState.SERVER_STARTING, server);
+        modController.transition(LoaderState.SERVER_STARTING, false);
         return true;
     }
 
@@ -859,16 +851,8 @@ public class Loader
 
     public boolean serverAboutToStart(Object server)
     {
-        try
-        {
-            modController.distributeStateMessage(LoaderState.SERVER_ABOUT_TO_START, server);
-            modController.transition(LoaderState.SERVER_ABOUT_TO_START, false);
-        }
-        catch (Throwable t)
-        {
-            FMLLog.log.error("A fatal exception occurred during the server about to start event", t);
-            return false;
-        }
+        modController.distributeStateMessage(LoaderState.SERVER_ABOUT_TO_START, server);
+        modController.transition(LoaderState.SERVER_ABOUT_TO_START, false);
         return true;
     }
 


### PR DESCRIPTION
Follow up to #4796, this removes the catching of exceptions thrown in `serverAboutToStart` and `serverStarting`, allowing them to be handled by `MinecraftServer.run` instead.

This is necessary to prevent client hangs - currently, returning `false` from `MinecraftServer.init` will only correctly shut down the dedicated server jar. For a client, it fails to stop the client thread, as it does not produce a crash report, which prevents `Minecraft.run` from exiting the run loop.

---

Quick code overview:

```java
if (this.init())
{
    /* ... */
}
else
{
    net.minecraftforge.fml.common.FMLCommonHandler.instance().expectServerStopped();
    this.finalTick((CrashReport)null);
}
```

```java
public void finalTick(CrashReport report)
{
    this.mc.crashed(report);
}
```

```java
public void crashed(CrashReport crash)
{
    this.hasCrashed = true;
    this.crashReporter = crash;
}
```

```java
while (this.running)
{
    if (!this.hasCrashed || this.crashReporter == null)
    {
        try
        {
            this.runGameLoop();
        }
        catch (OutOfMemoryError var10)
        {
            this.freeMemory();
            this.displayGuiScreen(new GuiMemoryErrorScreen());
            System.gc();
        }
    }
    else
    {
        this.displayCrashReport(this.crashReporter);
    }
}
```

---

As an update, this also improves the original patch - this alternative format (as in the original issue) is better as it ensures there's no race between the server shutdown and the query check.
Apologies for not using that implementation originally, IIRC I'd already written the patches before that suggestion was made and the difference wasn't very apparent.