### PR TITLE
Clean up logged mod states

### DIFF
--- a/src/main/java/net/minecraftforge/fml/common/LoadController.java
+++ b/src/main/java/net/minecraftforge/fml/common/LoadController.java
@@ -53,6 +53,7 @@ import com.google.common.collect.ListMultimap;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Multimap;
+import com.google.common.collect.MultimapBuilder;
 import com.google.common.eventbus.EventBus;
 import com.google.common.eventbus.Subscribe;
 
@@ -64,7 +65,7 @@ public class LoadController
     private EventBus masterChannel;
     private ImmutableMap<String, EventBus> eventChannels;
     private LoaderState state;
-    private Multimap<String, ModState> modStates = ArrayListMultimap.create();
+    private Multimap<String, ModState> modStates = MultimapBuilder.hashKeys().enumSetValues(ModState.class).build();
     private List<ModContainer> activeModList = Lists.newArrayList();
     private ModContainer activeContainer;
     private BiMap<ModContainer, Object> modObjectList;
@@ -113,7 +114,7 @@ public class LoadController
             if (isActive)
             {
                 activeModList.add(mod);
-                modStates.put(mod.getModId(), ModState.UNLOADED);
+                modStates.put(mod.getModId(), ModState.LOADED);
                 eventBus.put(mod.getModId(), bus);
                 FMLCommonHandler.instance().addModToResourcePack(mod);
             }


### PR DESCRIPTION
Changes the `Multimap` used to track mod states, so you don't get mod state entries like `UCHIJAAAAAAAAAAAAAAAAAAAA`, instead just `LCHIJA`.

Can be a `LinkedHashMultimap` if preferred, but `ModState` should be ordered 'correctly' as-is:
https://github.com/MinecraftForge/MinecraftForge/blob/f9c2f715fd63bed9d4bd78b332ed348ad7383a30/src/main/java/net/minecraftforge/fml/common/LoaderState.java#L108-L116

Also marks active mods in `buildModList` as `LOADED` rather than `UNLOADED`, as otherwise that state is never set, and it'd seem to make more sense to have initialised mods not be marked as unloaded.