### PR TITLE
[1.13] Fix vanilla exception mismatch

### DIFF
--- a/patches/minecraft/net/minecraft/tileentity/TileEntityType.java.patch
+++ b/patches/minecraft/net/minecraft/tileentity/TileEntityType.java.patch
@@ -12,3 +12,12 @@
     public static final TileEntityType<TileEntityFurnace> field_200971_b = func_200966_a("furnace", TileEntityType.Builder.func_200963_a(TileEntityFurnace::new));
     public static final TileEntityType<TileEntityChest> field_200972_c = func_200966_a("chest", TileEntityType.Builder.func_200963_a(TileEntityChest::new));
     public static final TileEntityType<TileEntityTrappedChest> field_200973_d = func_200966_a("trapped_chest", TileEntityType.Builder.func_200963_a(TileEntityTrappedChest::new));
+@@ -53,7 +53,7 @@
+ 
+       try {
+          type = DataFixesManager.func_210901_a().getSchema(DataFixUtils.makeKey(1519)).getChoiceType(TypeReferences.field_211294_j, p_200966_0_);
+-      } catch (IllegalStateException illegalstateexception) {
++      } catch (IllegalArgumentException illegalstateexception) {
+          if (SharedConstants.field_206244_b) {
+             throw illegalstateexception;
+          }


### PR DESCRIPTION
DataFixerUpper throws IllegalArgumentException but Minecraft tries to catch IllegalStateException instead, causing a hard crash instead of a soft one, if a DataFixer isn't registered.