### PR TITLE
Patch GuiRecipeBook to handle other empty ingredients

### DIFF
--- a/patches/minecraft/net/minecraft/client/gui/recipebook/GuiRecipeBook.java.patch
+++ b/patches/minecraft/net/minecraft/client/gui/recipebook/GuiRecipeBook.java.patch
@@ -18,3 +18,12 @@
          int l = 1;
          Iterator<Ingredient> iterator = p_193951_1_.func_192400_c().iterator();
  
+@@ -500,7 +500,7 @@
+ 
+                 Ingredient ingredient = iterator.next();
+ 
+-                if (ingredient != Ingredient.field_193370_a)
++                if (ingredient.func_193365_a().length > 0)
+                 {
+                     Slot slot = p_193951_2_.get(l);
+                     this.field_191915_z.func_194187_a(ingredient, slot.field_75223_e, slot.field_75221_f);


### PR DESCRIPTION
Fixes #4359, as it doesn't show any signs of being fixed otherwise.

Changes `GuiRecipeBook.setupGhostRecipe` to skip ingredients which return an empty array from `getMatchingStacks`, instead of only checking for `Ingredient.EMPTY`.