### PR TITLE
Fix defaulted registries returning null keys

### DIFF
--- a/src/main/java/net/minecraftforge/registries/ForgeRegistry.java
+++ b/src/main/java/net/minecraftforge/registries/ForgeRegistry.java
@@ -190,7 +190,8 @@ public class ForgeRegistry<V extends IForgeRegistryEntry<V>> implements IForgeRe
     @Override
     public ResourceLocation getKey(V value)
     {
-        return this.names.inverse().get(value);
+        ResourceLocation ret = this.names.inverse().get(value);
+        return ret == null ? this.defaultKey : ret;
     }
 
     @Override

--- a/src/main/java/net/minecraftforge/registries/NamespacedDefaultedWrapper.java
+++ b/src/main/java/net/minecraftforge/registries/NamespacedDefaultedWrapper.java
@@ -125,7 +125,7 @@ class NamespacedDefaultedWrapper<V extends IForgeRegistryEntry<V>> extends Regis
     public V getRandomObject(Random random)
     {
         Collection<V> values = this.delegate.getValuesCollection();
-        return values.stream().skip(random.nextInt(values.size())).findFirst().orElse(null);
+        return values.stream().skip(random.nextInt(values.size())).findFirst().orElse(this.delegate.getDefault());
     }
 
     //internal


### PR DESCRIPTION
Aims to better match the behaviour of `NamespacedDefaultedWrapper` to the vanilla `RegistryNamespacedDefaultedByKey` it is replacing.

In particular, the implementation of `getNameForObject` is not consistent with the original:
```java
@Nonnull
public K getNameForObject(V value)
{
    K k = (K)super.getNameForObject(value);
    return (K)(k == null ? this.defaultValueKey : k);
}
```

The default key should be returned for a failed lookup if available, not null.

(`getRandomObject` shouldn't overrun, so that change is mostly just for clarity and matching the parent class)