### PR TITLE
Fix findJarPathFor when path of the jar contains whitespace, fix #5236

### DIFF
--- a/src/main/java/net/minecraftforge/fml/loading/FMLCommonLaunchHandler.java
+++ b/src/main/java/net/minecraftforge/fml/loading/FMLCommonLaunchHandler.java
@@ -72,10 +72,10 @@ public abstract class FMLCommonLaunchHandler
         try {
             Path path;
             final URI uri = resource.toURI();
-            if (uri.getSchemeSpecificPart().contains("!")) {
-                path = Paths.get(new URI(uri.getSchemeSpecificPart().split("!")[0]));
+            if (uri.getRawSchemeSpecificPart().contains("!")) {
+                path = Paths.get(new URI(uri.getRawSchemeSpecificPart().split("!")[0]));
             } else {
-                path = Paths.get(new URI("file://"+uri.getSchemeSpecificPart().substring(0, uri.getSchemeSpecificPart().length()-className.length())));
+                path = Paths.get(new URI("file://"+uri.getRawSchemeSpecificPart().substring(0, uri.getRawSchemeSpecificPart().length()-className.length())));
             }
             LOGGER.debug(CORE, "Found JAR {} at path {}", jarName, path.toString());
             return path;


### PR DESCRIPTION
getRawSchemeSpecificPart don't unescape precent encoding like getSchemeSpecificPart so we always have a vaild uri.