### PR TITLE
Bake item models with correct default state

### DIFF
--- a/src/main/java/net/minecraftforge/client/model/BakedItemModel.java
+++ b/src/main/java/net/minecraftforge/client/model/BakedItemModel.java
@@ -44,13 +44,20 @@ public class BakedItemModel implements IBakedModel
     protected final ItemOverrideList overrides;
     protected final IBakedModel guiModel;
 
+    /** @deprecated use {@link #BakedItemModel(ImmutableList, TextureAtlasSprite, ImmutableMap, ItemOverrideList, boolean)} */
+    @Deprecated // TODO: remove
     public BakedItemModel(ImmutableList<BakedQuad> quads, TextureAtlasSprite particle, ImmutableMap<TransformType, TRSRTransformation> transforms, ItemOverrideList overrides)
+    {
+        this(quads, particle, transforms, overrides, true);
+    }
+
+    public BakedItemModel(ImmutableList<BakedQuad> quads, TextureAtlasSprite particle, ImmutableMap<TransformType, TRSRTransformation> transforms, ItemOverrideList overrides, boolean untransformed)
     {
         this.quads = quads;
         this.particle = particle;
         this.transforms = transforms;
         this.overrides = overrides;
-        this.guiModel = hasGuiIdentity(transforms) ? new BakedGuiItemModel<>(this) : null;
+        this.guiModel = untransformed && hasGuiIdentity(transforms) ? new BakedGuiItemModel<>(this) : null;
     }
 
     private static boolean hasGuiIdentity(ImmutableMap<TransformType, TRSRTransformation> transforms)

--- a/src/main/java/net/minecraftforge/client/model/ItemLayerModel.java
+++ b/src/main/java/net/minecraftforge/client/model/ItemLayerModel.java
@@ -110,6 +110,7 @@ public final class ItemLayerModel implements IModel
     {
         ImmutableList.Builder<BakedQuad> builder = ImmutableList.builder();
         Optional<TRSRTransformation> transform = state.apply(Optional.empty());
+        boolean identity = !transform.isPresent() || transform.get().isIdentity();
         for(int i = 0; i < textures.size(); i++)
         {
             TextureAtlasSprite sprite = bakedTextureGetter.apply(textures.get(i));
@@ -117,7 +118,7 @@ public final class ItemLayerModel implements IModel
         }
         TextureAtlasSprite particle = bakedTextureGetter.apply(textures.isEmpty() ? new ResourceLocation("missingno") : textures.get(0));
         ImmutableMap<TransformType, TRSRTransformation> map = PerspectiveMapWrapper.getTransforms(state);
-        return new BakedItemModel(builder.build(), particle, map, overrides);
+        return new BakedItemModel(builder.build(), particle, map, overrides, identity);
     }
 
     public static ImmutableList<BakedQuad> getQuadsForSprite(int tint, TextureAtlasSprite sprite, VertexFormat format, Optional<TRSRTransformation> transform)
@@ -407,12 +408,14 @@ public final class ItemLayerModel implements IModel
     private static void putVertex(UnpackedBakedQuad.Builder builder, VertexFormat format, Optional<TRSRTransformation> transform, EnumFacing side, float x, float y, float z, float u, float v)
     {
         Vector4f vec = new Vector4f();
+        boolean hasTransform = transform.isPresent() && !transform.get().isIdentity();
+
         for(int e = 0; e < format.getElementCount(); e++)
         {
             switch(format.getElement(e).getUsage())
             {
             case POSITION:
-                if(transform.isPresent())
+                if(hasTransform)
                 {
                     vec.x = x;
                     vec.y = y;

--- a/src/main/java/net/minecraftforge/client/model/ModelDynBucket.java
+++ b/src/main/java/net/minecraftforge/client/model/ModelDynBucket.java
@@ -176,7 +176,7 @@ public final class ModelDynBucket implements IModel
             }
         }
 
-        return new BakedDynBucket(this, builder.build(), particleSprite, format, Maps.immutableEnumMap(transformMap), Maps.newHashMap());
+        return new BakedDynBucket(this, builder.build(), particleSprite, format, Maps.immutableEnumMap(transformMap), Maps.newHashMap(), transform.isIdentity());
     }
 
     /**
@@ -453,14 +453,15 @@ public final class ModelDynBucket implements IModel
         private final Map<String, IBakedModel> cache; // contains all the baked models since they'll never change
         private final VertexFormat format;
 
-        public BakedDynBucket(ModelDynBucket parent,
-                              ImmutableList<BakedQuad> quads,
-                              TextureAtlasSprite particle,
-                              VertexFormat format,
-                              ImmutableMap<TransformType, TRSRTransformation> transforms,
-                              Map<String, IBakedModel> cache)
+        BakedDynBucket(ModelDynBucket parent,
+                       ImmutableList<BakedQuad> quads,
+                       TextureAtlasSprite particle,
+                       VertexFormat format,
+                       ImmutableMap<TransformType, TRSRTransformation> transforms,
+                       Map<String, IBakedModel> cache,
+                       boolean untransformed)
         {
-            super(quads, particle, transforms, BakedDynBucketOverrideHandler.INSTANCE);
+            super(quads, particle, transforms, BakedDynBucketOverrideHandler.INSTANCE, untransformed);
             this.format = format;
             this.parent = parent;
             this.cache = cache;

--- a/src/main/java/net/minecraftforge/client/model/ModelLoader.java
+++ b/src/main/java/net/minecraftforge/client/model/ModelLoader.java
@@ -439,7 +439,7 @@ public final class ModelLoader extends ModelBakery
             Map<TransformType, TRSRTransformation> tMap = Maps.newEnumMap(TransformType.class);
             tMap.putAll(PerspectiveMapWrapper.getTransforms(transforms));
             tMap.putAll(PerspectiveMapWrapper.getTransforms(state));
-            IModelState perState = new SimpleModelState(ImmutableMap.copyOf(tMap));
+            IModelState perState = new SimpleModelState(ImmutableMap.copyOf(tMap), state.apply(Optional.empty()));
 
             if(hasItemModel(model))
             {


### PR DESCRIPTION
Changes `VanillaModelWrapper.bakeImpl` to pass through the default transform from the provided `IModelState`.

Note that as `bakeNormal` already queries this information, it's just item models that are affected:
https://github.com/MinecraftForge/MinecraftForge/blob/c040a8865ffb7e204919da9a62bb521b5b46ad61/src/main/java/net/minecraftforge/client/model/ModelLoader.java#L454

The additional changes here are to make the item model culling logic not apply if a non-identity transform is applied to the quads during baking.

---

**Example:**

Blockstate:
```json
{
  "forge_marker": 1,
  "variants": {
    "inventory": {
      "model": "item_model_generation_test:pattern_test", "x": 90
    }
  }
}
```

Model:
```json
{
  "parent": "item/generated",
  "textures": {
    "layer0": "item_model_generation_test:items/pattern_test"
  }
}
```

Before:
![2018-11-18_23 20 00](https://user-images.githubusercontent.com/1447117/48679483-b33d0380-eb88-11e8-8f74-5ae7b1b3a5da.png)

After:
![2018-11-18_23 21 07](https://user-images.githubusercontent.com/1447117/48679486-b6d08a80-eb88-11e8-8784-a1f9626c605a.png)