### PR TITLE
Transform vertex normals as well as positions when generating quads

### DIFF
--- a/src/main/java/net/minecraftforge/client/ForgeHooksClient.java
+++ b/src/main/java/net/minecraftforge/client/ForgeHooksClient.java
@@ -476,6 +476,7 @@ public class ForgeHooksClient
             case GENERIC:
                 GL20.glEnableVertexAttribArray(attr.getIndex());
                 GL20.glVertexAttribPointer(attr.getIndex(), count, constant, false, stride, buffer);
+                break;
             default:
                 FMLLog.log.fatal("Unimplemented vanilla attribute upload: {}", attrType.getDisplayName());
         }
@@ -506,6 +507,7 @@ public class ForgeHooksClient
                 break;
             case GENERIC:
                 GL20.glDisableVertexAttribArray(attr.getIndex());
+                break;
             default:
                 FMLLog.log.fatal("Unimplemented vanilla attribute upload: {}", attrType.getDisplayName());
         }

--- a/src/main/java/net/minecraftforge/client/model/ItemLayerModel.java
+++ b/src/main/java/net/minecraftforge/client/model/ItemLayerModel.java
@@ -429,12 +429,6 @@ public final class ItemLayerModel implements IModel
             case COLOR:
                 builder.put(e, 1f, 1f, 1f, 1f);
                 break;
-            case UV:
-                if(format.getElement(e).getIndex() == 0)
-                {
-                    builder.put(e, u, v, 0f, 1f);
-                }
-                break;
             case NORMAL:
                 float offX = (float) side.getFrontOffsetX();
                 float offY = (float) side.getFrontOffsetY();
@@ -450,6 +444,13 @@ public final class ItemLayerModel implements IModel
                     builder.put(e, offX, offY, offZ, 0f);
                 }
                 break;
+            case UV:
+                if(format.getElement(e).getIndex() == 0)
+                {
+                    builder.put(e, u, v, 0f, 1f);
+                    break;
+                }
+                // else fallthrough to default
             default:
                 builder.put(e);
                 break;

--- a/src/main/java/net/minecraftforge/client/model/ItemLayerModel.java
+++ b/src/main/java/net/minecraftforge/client/model/ItemLayerModel.java
@@ -19,9 +19,6 @@
 
 package net.minecraftforge.client.model;
 
-import javax.vecmath.Vector3f;
-import javax.vecmath.Vector4f;
-
 import net.minecraftforge.common.ForgeVersion;
 
 import net.minecraft.client.renderer.block.model.BakedQuad;
@@ -34,6 +31,8 @@ import net.minecraft.client.renderer.vertex.VertexFormat;
 import net.minecraft.client.resources.IResourceManager;
 import net.minecraft.util.EnumFacing;
 import net.minecraft.util.ResourceLocation;
+import net.minecraftforge.client.model.pipeline.IVertexConsumer;
+import net.minecraftforge.client.model.pipeline.TRSRTransformer;
 import net.minecraftforge.client.model.pipeline.UnpackedBakedQuad;
 import net.minecraftforge.common.model.IModelState;
 import net.minecraftforge.common.model.TRSRTransformation;
@@ -396,63 +395,49 @@ public final class ItemLayerModel implements IModel
         float x3, float y3, float z3, float u3, float v3)
     {
         UnpackedBakedQuad.Builder builder = new UnpackedBakedQuad.Builder(format);
+
         builder.setQuadTint(tint);
         builder.setQuadOrientation(side);
         builder.setTexture(sprite);
-        putVertex(builder, format, transform, side, x0, y0, z0, u0, v0);
-        putVertex(builder, format, transform, side, x1, y1, z1, u1, v1);
-        putVertex(builder, format, transform, side, x2, y2, z2, u2, v2);
-        putVertex(builder, format, transform, side, x3, y3, z3, u3, v3);
+
+        boolean hasTransform = transform.isPresent() && !transform.get().isIdentity();
+        IVertexConsumer consumer = hasTransform ? new TRSRTransformer(builder, transform.get()) : builder;
+
+        putVertex(consumer, format, side, x0, y0, z0, u0, v0);
+        putVertex(consumer, format, side, x1, y1, z1, u1, v1);
+        putVertex(consumer, format, side, x2, y2, z2, u2, v2);
+        putVertex(consumer, format, side, x3, y3, z3, u3, v3);
+
         return builder.build();
     }
 
-    private static void putVertex(UnpackedBakedQuad.Builder builder, VertexFormat format, Optional<TRSRTransformation> transform, EnumFacing side, float x, float y, float z, float u, float v)
+    private static void putVertex(IVertexConsumer consumer, VertexFormat format, EnumFacing side, float x, float y, float z, float u, float v)
     {
-        boolean hasTransform = transform.isPresent() && !transform.get().isIdentity();
-
         for(int e = 0; e < format.getElementCount(); e++)
         {
             switch(format.getElement(e).getUsage())
             {
             case POSITION:
-                if(hasTransform)
-                {
-                    Vector4f vec = new Vector4f(x, y, z, 1);
-                    transform.get().transformPosition(vec);
-                    builder.put(e, vec.x, vec.y, vec.z, vec.w);
-                }
-                else
-                {
-                    builder.put(e, x, y, z, 1);
-                }
+                consumer.put(e, x, y, z, 1f);
                 break;
             case COLOR:
-                builder.put(e, 1f, 1f, 1f, 1f);
+                consumer.put(e, 1f, 1f, 1f, 1f);
                 break;
             case NORMAL:
                 float offX = (float) side.getFrontOffsetX();
                 float offY = (float) side.getFrontOffsetY();
                 float offZ = (float) side.getFrontOffsetZ();
-                if(hasTransform)
-                {
-                    Vector3f vec = new Vector3f(offX, offY, offZ);
-                    transform.get().transformNormal(vec);
-                    builder.put(e, vec.x, vec.y, vec.z, 0f);
-                }
-                else
-                {
-                    builder.put(e, offX, offY, offZ, 0f);
-                }
+                consumer.put(e, offX, offY, offZ, 0f);
                 break;
             case UV:
                 if(format.getElement(e).getIndex() == 0)
                 {
-                    builder.put(e, u, v, 0f, 1f);
+                    consumer.put(e, u, v, 0f, 1f);
                     break;
                 }
                 // else fallthrough to default
             default:
-                builder.put(e);
+                consumer.put(e);
                 break;
             }
         }

--- a/src/main/java/net/minecraftforge/client/model/ItemLayerModel.java
+++ b/src/main/java/net/minecraftforge/client/model/ItemLayerModel.java
@@ -19,6 +19,7 @@
 
 package net.minecraftforge.client.model;
 
+import javax.vecmath.Vector3f;
 import javax.vecmath.Vector4f;
 
 import net.minecraftforge.common.ForgeVersion;
@@ -406,7 +407,6 @@ public final class ItemLayerModel implements IModel
 
     private static void putVertex(UnpackedBakedQuad.Builder builder, VertexFormat format, Optional<TRSRTransformation> transform, EnumFacing side, float x, float y, float z, float u, float v)
     {
-        Vector4f vec = new Vector4f();
         boolean hasTransform = transform.isPresent() && !transform.get().isIdentity();
 
         for(int e = 0; e < format.getElementCount(); e++)
@@ -416,11 +416,8 @@ public final class ItemLayerModel implements IModel
             case POSITION:
                 if(hasTransform)
                 {
-                    vec.x = x;
-                    vec.y = y;
-                    vec.z = z;
-                    vec.w = 1;
-                    transform.get().getMatrix().transform(vec);
+                    Vector4f vec = new Vector4f(x, y, z, 1);
+                    transform.get().transformPosition(vec);
                     builder.put(e, vec.x, vec.y, vec.z, vec.w);
                 }
                 else
@@ -438,18 +435,18 @@ public final class ItemLayerModel implements IModel
                 }
                 break;
             case NORMAL:
+                float offX = (float) side.getFrontOffsetX();
+                float offY = (float) side.getFrontOffsetY();
+                float offZ = (float) side.getFrontOffsetZ();
                 if(hasTransform)
                 {
-                    vec.x = (float)side.getFrontOffsetX();
-                    vec.y = (float)side.getFrontOffsetY();
-                    vec.z = (float)side.getFrontOffsetZ();
-                    vec.w = 1f;
-                    transform.get().getMatrix().transform(vec);
-                    builder.put(e, vec.x / vec.w, vec.y / vec.w, vec.z / vec.w, 0f);
+                    Vector3f vec = new Vector3f(offX, offY, offZ);
+                    transform.get().transformNormal(vec);
+                    builder.put(e, vec.x, vec.y, vec.z, 0f);
                 }
                 else
                 {
-                    builder.put(e, (float)side.getFrontOffsetX(), (float)side.getFrontOffsetY(), (float)side.getFrontOffsetZ(), 0f);
+                    builder.put(e, offX, offY, offZ, 0f);
                 }
                 break;
             default:

--- a/src/main/java/net/minecraftforge/client/model/ItemTextureQuadConverter.java
+++ b/src/main/java/net/minecraftforge/client/model/ItemTextureQuadConverter.java
@@ -320,12 +320,6 @@ public final class ItemTextureQuadConverter
                     float a = ((color >> 24) & 0xFF) / 255f; // alpha
                     builder.put(e, r, g, b, a);
                     break;
-                case UV:
-                    if (format.getElement(e).getIndex() == 0)
-                    {
-                        builder.put(e, u, v, 0f, 1f);
-                    }
-                    break;
                 case NORMAL:
                     float offX = (float) side.getFrontOffsetX();
                     float offY = (float) side.getFrontOffsetY();
@@ -341,6 +335,13 @@ public final class ItemTextureQuadConverter
                         builder.put(e, offX, offY, offZ, 0f);
                     }
                     break;
+                case UV:
+                    if (format.getElement(e).getIndex() == 0)
+                    {
+                        builder.put(e, u, v, 0f, 1f);
+                        break;
+                    }
+                    // else fallthrough to default
                 default:
                     builder.put(e);
                     break;

--- a/src/main/java/net/minecraftforge/client/model/ItemTextureQuadConverter.java
+++ b/src/main/java/net/minecraftforge/client/model/ItemTextureQuadConverter.java
@@ -294,17 +294,15 @@ public final class ItemTextureQuadConverter
                                   float x, float y, float z, float u, float v, int color)
     {
         Vector4f vec = new Vector4f();
+        // only apply the transform if it's not identity
+        boolean hasTransform = !transform.isIdentity();
+
         for (int e = 0; e < format.getElementCount(); e++)
         {
             switch (format.getElement(e).getUsage())
             {
                 case POSITION:
-                    if (transform.isIdentity())
-                    {
-                        builder.put(e, x, y, z, 1);
-                    }
-                    // only apply the transform if it's not identity
-                    else
+                    if (hasTransform)
                     {
                         vec.x = x;
                         vec.y = y;
@@ -312,6 +310,10 @@ public final class ItemTextureQuadConverter
                         vec.w = 1;
                         transform.getMatrix().transform(vec);
                         builder.put(e, vec.x, vec.y, vec.z, vec.w);
+                    }
+                    else
+                    {
+                        builder.put(e, x, y, z, 1);
                     }
                     break;
                 case COLOR:
@@ -325,10 +327,22 @@ public final class ItemTextureQuadConverter
                     if (format.getElement(e).getIndex() == 0)
                     {
                         builder.put(e, u, v, 0f, 1f);
-                        break;
                     }
+                    break;
                 case NORMAL:
-                    builder.put(e, (float) side.getFrontOffsetX(), (float) side.getFrontOffsetY(), (float) side.getFrontOffsetZ(), 0f);
+                    if (hasTransform)
+                    {
+                        vec.x = (float) side.getFrontOffsetX();
+                        vec.y = (float) side.getFrontOffsetY();
+                        vec.z = (float) side.getFrontOffsetZ();
+                        vec.w = 1f;
+                        transform.getMatrix().transform(vec);
+                        builder.put(e, vec.x / vec.w, vec.y / vec.w, vec.z / vec.w, 0f);
+                    }
+                    else
+                    {
+                        builder.put(e, (float) side.getFrontOffsetX(), (float) side.getFrontOffsetY(), (float) side.getFrontOffsetZ(), 0f);
+                    }
                     break;
                 default:
                     builder.put(e);

--- a/src/main/java/net/minecraftforge/client/model/ItemTextureQuadConverter.java
+++ b/src/main/java/net/minecraftforge/client/model/ItemTextureQuadConverter.java
@@ -27,6 +27,7 @@ import net.minecraft.util.EnumFacing;
 import net.minecraftforge.client.model.pipeline.UnpackedBakedQuad;
 import net.minecraftforge.common.model.TRSRTransformation;
 
+import javax.vecmath.Vector3f;
 import javax.vecmath.Vector4f;
 
 import java.util.List;
@@ -293,7 +294,6 @@ public final class ItemTextureQuadConverter
     private static void putVertex(UnpackedBakedQuad.Builder builder, VertexFormat format, TRSRTransformation transform, EnumFacing side,
                                   float x, float y, float z, float u, float v, int color)
     {
-        Vector4f vec = new Vector4f();
         // only apply the transform if it's not identity
         boolean hasTransform = !transform.isIdentity();
 
@@ -304,11 +304,8 @@ public final class ItemTextureQuadConverter
                 case POSITION:
                     if (hasTransform)
                     {
-                        vec.x = x;
-                        vec.y = y;
-                        vec.z = z;
-                        vec.w = 1;
-                        transform.getMatrix().transform(vec);
+                        Vector4f vec = new Vector4f(x, y, z, 1f);
+                        transform.transformPosition(vec);
                         builder.put(e, vec.x, vec.y, vec.z, vec.w);
                     }
                     else
@@ -330,18 +327,18 @@ public final class ItemTextureQuadConverter
                     }
                     break;
                 case NORMAL:
+                    float offX = (float) side.getFrontOffsetX();
+                    float offY = (float) side.getFrontOffsetY();
+                    float offZ = (float) side.getFrontOffsetZ();
                     if (hasTransform)
                     {
-                        vec.x = (float) side.getFrontOffsetX();
-                        vec.y = (float) side.getFrontOffsetY();
-                        vec.z = (float) side.getFrontOffsetZ();
-                        vec.w = 1f;
-                        transform.getMatrix().transform(vec);
-                        builder.put(e, vec.x / vec.w, vec.y / vec.w, vec.z / vec.w, 0f);
+                        Vector3f vec = new Vector3f(offX, offY, offZ);
+                        transform.transformNormal(vec);
+                        builder.put(e, vec.x, vec.y, vec.z, 0f);
                     }
                     else
                     {
-                        builder.put(e, (float) side.getFrontOffsetX(), (float) side.getFrontOffsetY(), (float) side.getFrontOffsetZ(), 0f);
+                        builder.put(e, offX, offY, offZ, 0f);
                     }
                     break;
                 default:

--- a/src/main/java/net/minecraftforge/client/model/ModelFluid.java
+++ b/src/main/java/net/minecraftforge/client/model/ModelFluid.java
@@ -437,12 +437,6 @@ public final class ModelFluid implements IModel
                         (color & 0xFF) / 255f,
                         ((color >> 24) & 0xFF) / 255f);
                     break;
-                case UV:
-                    if(format.getElement(e).getIndex() == 0)
-                    {
-                        builder.put(e, u, v, 0f, 1f);
-                    }
-                    break;
                 case NORMAL:
                     float offX = (float) side.getFrontOffsetX();
                     float offY = (float) side.getFrontOffsetY();
@@ -458,6 +452,13 @@ public final class ModelFluid implements IModel
                         builder.put(e, offX, offY, offZ, 0f);
                     }
                     break;
+                case UV:
+                    if(format.getElement(e).getIndex() == 0)
+                    {
+                        builder.put(e, u, v, 0f, 1f);
+                        break;
+                    }
+                    // else fallthrough to default
                 default:
                     builder.put(e);
                     break;

--- a/src/main/java/net/minecraftforge/client/model/ModelFluid.java
+++ b/src/main/java/net/minecraftforge/client/model/ModelFluid.java
@@ -27,8 +27,6 @@ import java.util.Optional;
 
 import javax.annotation.Nullable;
 import javax.vecmath.Matrix4f;
-import javax.vecmath.Vector3f;
-import javax.vecmath.Vector4f;
 
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.client.renderer.block.model.BakedQuad;
@@ -41,6 +39,8 @@ import net.minecraft.client.resources.IResourceManager;
 import net.minecraft.util.EnumFacing;
 import net.minecraft.util.ResourceLocation;
 import net.minecraft.util.math.MathHelper;
+import net.minecraftforge.client.model.pipeline.IVertexConsumer;
+import net.minecraftforge.client.model.pipeline.TRSRTransformer;
 import net.minecraftforge.client.model.pipeline.UnpackedBakedQuad;
 import net.minecraftforge.common.ForgeVersion;
 import net.minecraftforge.common.model.IModelState;
@@ -391,15 +391,19 @@ public final class ModelFluid implements IModel
         private BakedQuad buildQuad(EnumFacing side, TextureAtlasSprite texture, boolean flip, boolean offset, VertexParameter x, VertexParameter y, VertexParameter z, VertexParameter u, VertexParameter v)
         {
             UnpackedBakedQuad.Builder builder = new UnpackedBakedQuad.Builder(format);
+
             builder.setQuadOrientation(side);
             builder.setTexture(texture);
             builder.setQuadTint(0);
+
+            boolean hasTransform = transformation.isPresent() && !transformation.get().isIdentity();
+            IVertexConsumer consumer = hasTransform ? new TRSRTransformer(builder, transformation.get()) : builder;
 
             for (int i = 0; i < 4; i++)
             {
                 int vertex = flip ? 3 - i : i;
                 putVertex(
-                    builder, side, offset,
+                    consumer, side, offset,
                     x.get(vertex), y.get(vertex), z.get(vertex),
                     texture.getInterpolatedU(u.get(vertex)),
                     texture.getInterpolatedV(v.get(vertex))
@@ -409,10 +413,8 @@ public final class ModelFluid implements IModel
             return builder.build();
         }
 
-        private void putVertex(UnpackedBakedQuad.Builder builder, EnumFacing side, boolean offset, float x, float y, float z, float u, float v)
+        private void putVertex(IVertexConsumer consumer, EnumFacing side, boolean offset, float x, float y, float z, float u, float v)
         {
-            boolean hasTransform = transformation.isPresent() && !transformation.get().isIdentity();
-
             for(int e = 0; e < format.getElementCount(); e++)
             {
                 switch(format.getElement(e).getUsage())
@@ -421,46 +423,30 @@ public final class ModelFluid implements IModel
                     float dx = offset ? side.getDirectionVec().getX() * eps : 0f;
                     float dy = offset ? side.getDirectionVec().getY() * eps : 0f;
                     float dz = offset ? side.getDirectionVec().getZ() * eps : 0f;
-                    float[] data = { x - dx, y - dy, z - dz, 1f };
-                    if(hasTransform)
-                    {
-                        Vector4f vec = new Vector4f(data);
-                        transformation.get().transformPosition(vec);
-                        vec.get(data);
-                    }
-                    builder.put(e, data);
+                    consumer.put(e, x - dx, y - dy, z - dz, 1f);
                     break;
                 case COLOR:
-                    builder.put(e,
-                        ((color >> 16) & 0xFF) / 255f,
-                        ((color >> 8) & 0xFF) / 255f,
-                        (color & 0xFF) / 255f,
-                        ((color >> 24) & 0xFF) / 255f);
+                    float r = ((color >> 16) & 0xFF) / 255f;
+                    float g = ((color >>  8) & 0xFF) / 255f;
+                    float b = ( color        & 0xFF) / 255f;
+                    float a = ((color >> 24) & 0xFF) / 255f;
+                    consumer.put(e, r, g, b, a);
                     break;
                 case NORMAL:
                     float offX = (float) side.getFrontOffsetX();
                     float offY = (float) side.getFrontOffsetY();
                     float offZ = (float) side.getFrontOffsetZ();
-                    if(hasTransform)
-                    {
-                        Vector3f vec = new Vector3f(offX, offY, offZ);
-                        transformation.get().transformNormal(vec);
-                        builder.put(e, vec.x, vec.y, vec.z, 0f);
-                    }
-                    else
-                    {
-                        builder.put(e, offX, offY, offZ, 0f);
-                    }
+                    consumer.put(e, offX, offY, offZ, 0f);
                     break;
                 case UV:
                     if(format.getElement(e).getIndex() == 0)
                     {
-                        builder.put(e, u, v, 0f, 1f);
+                        consumer.put(e, u, v, 0f, 1f);
                         break;
                     }
                     // else fallthrough to default
                 default:
-                    builder.put(e);
+                    consumer.put(e);
                     break;
                 }
             }

--- a/src/main/java/net/minecraftforge/client/model/ModelFluid.java
+++ b/src/main/java/net/minecraftforge/client/model/ModelFluid.java
@@ -27,6 +27,7 @@ import java.util.Optional;
 
 import javax.annotation.Nullable;
 import javax.vecmath.Matrix4f;
+import javax.vecmath.Vector3f;
 import javax.vecmath.Vector4f;
 
 import net.minecraft.block.state.IBlockState;
@@ -424,7 +425,7 @@ public final class ModelFluid implements IModel
                     if(hasTransform)
                     {
                         Vector4f vec = new Vector4f(data);
-                        transformation.get().getMatrix().transform(vec);
+                        transformation.get().transformPosition(vec);
                         vec.get(data);
                     }
                     builder.put(e, data);
@@ -443,19 +444,18 @@ public final class ModelFluid implements IModel
                     }
                     break;
                 case NORMAL:
+                    float offX = (float) side.getFrontOffsetX();
+                    float offY = (float) side.getFrontOffsetY();
+                    float offZ = (float) side.getFrontOffsetZ();
                     if(hasTransform)
                     {
-                        Vector4f vec = new Vector4f();
-                        vec.x = (float)side.getFrontOffsetX();
-                        vec.y = (float)side.getFrontOffsetY();
-                        vec.z = (float)side.getFrontOffsetZ();
-                        vec.w = 1f;
-                        transformation.get().getMatrix().transform(vec);
-                        builder.put(e, vec.x / vec.w, vec.y / vec.w, vec.z / vec.w, 0f);
+                        Vector3f vec = new Vector3f(offX, offY, offZ);
+                        transformation.get().transformNormal(vec);
+                        builder.put(e, vec.x, vec.y, vec.z, 0f);
                     }
                     else
                     {
-                        builder.put(e, (float)side.getFrontOffsetX(), (float)side.getFrontOffsetY(), (float)side.getFrontOffsetZ(), 0f);
+                        builder.put(e, offX, offY, offZ, 0f);
                     }
                     break;
                 default:

--- a/src/main/java/net/minecraftforge/client/model/SimpleModelFontRenderer.java
+++ b/src/main/java/net/minecraftforge/client/model/SimpleModelFontRenderer.java
@@ -141,7 +141,8 @@ public abstract class SimpleModelFontRenderer extends FontRenderer {
                     quadBuilder.put(e, vec.x, vec.y, vec.z, vec.w);
                     break;
                 case UV:
-                    quadBuilder.put(e, sprite.getInterpolatedU(u * 16), sprite.getInterpolatedV(v * 16), 0, 1);
+                    if(format.getElement(e).getIndex() == 0)
+                        quadBuilder.put(e, sprite.getInterpolatedU(u * 16), sprite.getInterpolatedV(v * 16), 0, 1);
                     break;
                 case COLOR:
                     quadBuilder.put(e, r, g, b, a);

--- a/src/main/java/net/minecraftforge/client/model/SimpleModelFontRenderer.java
+++ b/src/main/java/net/minecraftforge/client/model/SimpleModelFontRenderer.java
@@ -19,12 +19,12 @@
 
 package net.minecraftforge.client.model;
 
-import javax.vecmath.Matrix3f;
 import javax.vecmath.Matrix4f;
 import javax.vecmath.Vector3f;
 import javax.vecmath.Vector4f;
 
 import net.minecraftforge.client.model.pipeline.UnpackedBakedQuad;
+import net.minecraftforge.common.model.TRSRTransformation;
 
 import com.google.common.collect.ImmutableList;
 
@@ -42,7 +42,7 @@ import net.minecraft.util.ResourceLocation;
 public abstract class SimpleModelFontRenderer extends FontRenderer {
 
     private float r, g, b, a;
-    private final Matrix4f matrix;
+    private final TRSRTransformation transform;
     private ImmutableList.Builder<BakedQuad> builder = ImmutableList.builder();
     private final VertexFormat format;
     private final Vector3f normal = new Vector3f(0, 0, 1);
@@ -54,14 +54,9 @@ public abstract class SimpleModelFontRenderer extends FontRenderer {
     public SimpleModelFontRenderer(GameSettings settings, ResourceLocation font, TextureManager manager, boolean isUnicode, Matrix4f matrix, VertexFormat format)
     {
         super(settings, font, manager, isUnicode);
-        this.matrix = new Matrix4f(matrix);
-        Matrix3f nm = new Matrix3f();
-        this.matrix.getRotationScale(nm);
-        nm.invert();
-        nm.transpose();
+        this.transform = new TRSRTransformation(matrix);
         this.format = format;
-        nm.transform(normal);
-        normal.normalize();
+        transform.transformNormal(normal);
         orientation = EnumFacing.getFacingFromVector(normal.x, normal.y, normal.z);
     }
 
@@ -128,16 +123,13 @@ public abstract class SimpleModelFontRenderer extends FontRenderer {
 
     private void addVertex(UnpackedBakedQuad.Builder quadBuilder, float x, float y, float u, float v)
     {
-        vec.x = x;
-        vec.y = y;
-        vec.z = 0;
-        vec.w = 1;
-        matrix.transform(vec);
         for(int e = 0; e < format.getElementCount(); e++)
         {
             switch(format.getElement(e).getUsage())
             {
                 case POSITION:
+                    vec.set(x, y, 0f, 1f);
+                    transform.transformPosition(vec);
                     quadBuilder.put(e, vec.x, vec.y, vec.z, vec.w);
                     break;
                 case COLOR:

--- a/src/main/java/net/minecraftforge/client/model/SimpleModelFontRenderer.java
+++ b/src/main/java/net/minecraftforge/client/model/SimpleModelFontRenderer.java
@@ -140,12 +140,6 @@ public abstract class SimpleModelFontRenderer extends FontRenderer {
                 case POSITION:
                     quadBuilder.put(e, vec.x, vec.y, vec.z, vec.w);
                     break;
-                case UV:
-                    if(format.getElement(e).getIndex() == 0)
-                    {
-                        quadBuilder.put(e, sprite.getInterpolatedU(u * 16), sprite.getInterpolatedV(v * 16), 0, 1);
-                    }
-                    break;
                 case COLOR:
                     quadBuilder.put(e, r, g, b, a);
                     break;
@@ -153,6 +147,13 @@ public abstract class SimpleModelFontRenderer extends FontRenderer {
                     //quadBuilder.put(e, normal.x, normal.y, normal.z, 1);
                     quadBuilder.put(e, 0, 0, 1, 1);
                     break;
+                case UV:
+                    if(format.getElement(e).getIndex() == 0)
+                    {
+                        quadBuilder.put(e, sprite.getInterpolatedU(u * 16), sprite.getInterpolatedV(v * 16), 0, 1);
+                        break;
+                    }
+                    // else fallthrough to default
                 default:
                     quadBuilder.put(e);
                     break;

--- a/src/main/java/net/minecraftforge/client/model/SimpleModelFontRenderer.java
+++ b/src/main/java/net/minecraftforge/client/model/SimpleModelFontRenderer.java
@@ -142,7 +142,9 @@ public abstract class SimpleModelFontRenderer extends FontRenderer {
                     break;
                 case UV:
                     if(format.getElement(e).getIndex() == 0)
+                    {
                         quadBuilder.put(e, sprite.getInterpolatedU(u * 16), sprite.getInterpolatedV(v * 16), 0, 1);
+                    }
                     break;
                 case COLOR:
                     quadBuilder.put(e, r, g, b, a);

--- a/src/main/java/net/minecraftforge/client/model/b3d/B3DModel.java
+++ b/src/main/java/net/minecraftforge/client/model/b3d/B3DModel.java
@@ -37,7 +37,6 @@ import java.util.Map;
 import java.util.Set;
 
 import javax.annotation.Nullable;
-import javax.vecmath.Matrix3f;
 import javax.vecmath.Matrix4f;
 import javax.vecmath.Quat4f;
 import javax.vecmath.Vector2f;
@@ -45,6 +44,7 @@ import javax.vecmath.Vector3f;
 import javax.vecmath.Vector4f;
 
 import net.minecraftforge.common.ForgeVersion;
+import net.minecraftforge.common.model.TRSRTransformation;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.commons.lang3.tuple.Triple;
@@ -681,25 +681,21 @@ public class B3DModel
                 else t.setIdentity();
             }
 
+            TRSRTransformation trsr = new TRSRTransformation(t);
+
             // pos
-            Vector4f pos = new Vector4f(this.pos), newPos = new Vector4f();
+            Vector4f pos = new Vector4f(this.pos);
             pos.w = 1;
-            t.transform(pos, newPos);
-            Vector3f rPos = new Vector3f(newPos.x / newPos.w, newPos.y / newPos.w, newPos.z / newPos.w);
+            trsr.transformPosition(pos);
+            Vector3f rPos = new Vector3f(pos.x / pos.w, pos.y / pos.w, pos.z / pos.w);
 
             // normal
             Vector3f rNormal = null;
 
             if(this.normal != null)
             {
-                Matrix3f tm = new Matrix3f();
-                t.getRotationScale(tm);
-                tm.invert();
-                tm.transpose();
-                Vector3f normal = new Vector3f(this.normal);
-                rNormal = new Vector3f();
-                tm.transform(normal, rNormal);
-                rNormal.normalize();
+                rNormal = new Vector3f(this.normal);
+                trsr.transformNormal(rNormal);
             }
 
             // texCoords TODO

--- a/src/main/java/net/minecraftforge/client/model/obj/OBJModel.java
+++ b/src/main/java/net/minecraftforge/client/model/obj/OBJModel.java
@@ -35,7 +35,6 @@ import java.util.Set;
 import java.util.regex.Pattern;
 
 import javax.annotation.Nullable;
-import javax.vecmath.Matrix3f;
 import javax.vecmath.Matrix4f;
 import javax.vecmath.Vector2f;
 import javax.vecmath.Vector3f;
@@ -845,8 +844,6 @@ public class OBJModel implements IModel
 
         public Face bake(TRSRTransformation transform)
         {
-            Matrix4f m = transform.getMatrix();
-            Matrix3f mn = null;
             Vertex[] vertices = new Vertex[verts.length];
 //            Normal[] normals = norms != null ? new Normal[norms.length] : null;
 //            TextureCoordinate[] textureCoords = texCoords != null ? new TextureCoordinate[texCoords.length] : null;
@@ -857,24 +854,16 @@ public class OBJModel implements IModel
 //                Normal n = norms != null ? norms[i] : null;
 //                TextureCoordinate t = texCoords != null ? texCoords[i] : null;
 
-                Vector4f pos = new Vector4f(v.getPos()), newPos = new Vector4f();
+                Vector4f pos = new Vector4f(v.getPos());
                 pos.w = 1;
-                m.transform(pos, newPos);
-                vertices[i] = new Vertex(newPos, v.getMaterial());
+                transform.transformPosition(pos);
+                vertices[i] = new Vertex(pos, v.getMaterial());
 
                 if (v.hasNormal())
                 {
-                    if(mn == null)
-                    {
-                        mn = new Matrix3f();
-                        m.getRotationScale(mn);
-                        mn.invert();
-                        mn.transpose();
-                    }
-                    Vector3f normal = new Vector3f(v.getNormal().getData()), newNormal = new Vector3f();
-                    mn.transform(normal, newNormal);
-                    newNormal.normalize();
-                    vertices[i].setNormal(new Normal(newNormal));
+                    Vector3f normal = new Vector3f(v.getNormal().getData());
+                    transform.transformNormal(normal);
+                    vertices[i].setNormal(new Normal(normal));
                 }
 
                 if (v.hasTextureCoordinate()) vertices[i].setTextureCoordinate(v.getTextureCoordinate());

--- a/src/main/java/net/minecraftforge/client/model/pipeline/TRSRTransformer.java
+++ b/src/main/java/net/minecraftforge/client/model/pipeline/TRSRTransformer.java
@@ -1,0 +1,55 @@
+/*
+ * Minecraft Forge
+ * Copyright (c) 2016-2018.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation version 2.1
+ * of the License.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+package net.minecraftforge.client.model.pipeline;
+
+import net.minecraftforge.common.model.TRSRTransformation;
+
+import javax.vecmath.Vector3f;
+import javax.vecmath.Vector4f;
+
+public class TRSRTransformer extends VertexTransformer
+{
+    private final TRSRTransformation transform;
+
+    public TRSRTransformer(IVertexConsumer parent, TRSRTransformation transform)
+    {
+        super(parent);
+        this.transform = transform;
+    }
+
+    @Override
+    public void put(int element, float... data)
+    {
+        switch (getVertexFormat().getElement(element).getUsage())
+        {
+            case POSITION:
+                Vector4f pos = new Vector4f(data);
+                transform.transformPosition(pos);
+                pos.get(data);
+                break;
+            case NORMAL:
+                Vector3f normal = new Vector3f(data);
+                transform.transformNormal(normal);
+                normal.get(data);
+                break;
+        }
+        super.put(element, data);
+    }
+}

--- a/src/main/java/net/minecraftforge/client/model/pipeline/VertexLighterFlat.java
+++ b/src/main/java/net/minecraftforge/client/model/pipeline/VertexLighterFlat.java
@@ -211,10 +211,7 @@ public class VertexLighterFlat extends QuadGatheringTransformer
                         parent.put(e, position[v]);
                         break;
                     case NORMAL:
-                        if(normalIndex != -1)
-                        {
-                            parent.put(e, normal[v]);
-                        }
+                        parent.put(e, normal[v]);
                         break;
                     case COLOR:
                         parent.put(e, color[v]);
@@ -223,8 +220,8 @@ public class VertexLighterFlat extends QuadGatheringTransformer
                         if(element.getIndex() == 1)
                         {
                             parent.put(e, lightmap[v]);
+                            break;
                         }
-                        break;
                     default:
                         parent.put(e, quadData[e][v]);
                 }

--- a/src/main/java/net/minecraftforge/client/model/pipeline/VertexLighterFlat.java
+++ b/src/main/java/net/minecraftforge/client/model/pipeline/VertexLighterFlat.java
@@ -222,6 +222,7 @@ public class VertexLighterFlat extends QuadGatheringTransformer
                             parent.put(e, lightmap[v]);
                             break;
                         }
+                        // else fallthrough to default
                     default:
                         parent.put(e, quadData[e][v]);
                 }

--- a/src/main/java/net/minecraftforge/client/model/pipeline/VertexLighterFlat.java
+++ b/src/main/java/net/minecraftforge/client/model/pipeline/VertexLighterFlat.java
@@ -210,19 +210,21 @@ public class VertexLighterFlat extends QuadGatheringTransformer
                         pos[2] += blockInfo.getBlockPos().getZ();*/
                         parent.put(e, position[v]);
                         break;
-                    case NORMAL: if(normalIndex != -1)
-                    {
-                        parent.put(e, normal[v]);
+                    case NORMAL:
+                        if(normalIndex != -1)
+                        {
+                            parent.put(e, normal[v]);
+                        }
                         break;
-                    }
                     case COLOR:
                         parent.put(e, color[v]);
                         break;
-                    case UV: if(element.getIndex() == 1)
-                    {
-                        parent.put(e, lightmap[v]);
+                    case UV:
+                        if(element.getIndex() == 1)
+                        {
+                            parent.put(e, lightmap[v]);
+                        }
                         break;
-                    }
                     default:
                         parent.put(e, quadData[e][v]);
                 }

--- a/src/main/java/net/minecraftforge/common/model/TRSRTransformation.java
+++ b/src/main/java/net/minecraftforge/common/model/TRSRTransformation.java
@@ -71,7 +71,7 @@ public final class TRSRTransformation implements IModelState, ITransformation
     private Vector3f scale;
     private Quat4f rightRot;
 
-    private Matrix4f normalTransform;
+    private Matrix3f normalTransform;
 
     public TRSRTransformation(@Nullable Matrix4f matrix)
     {
@@ -666,10 +666,10 @@ public final class TRSRTransformation implements IModelState, ITransformation
     {
         if (normalTransform == null)
         {
-            Matrix4f matrix = getMatrix();
-            matrix.invert();
-            matrix.transpose();
-            normalTransform = matrix;
+            normalTransform = new Matrix3f();
+            matrix.getRotationScale(normalTransform);
+            normalTransform.invert();
+            normalTransform.transpose();
         }
     }
 

--- a/src/main/java/net/minecraftforge/common/model/TRSRTransformation.java
+++ b/src/main/java/net/minecraftforge/common/model/TRSRTransformation.java
@@ -71,6 +71,8 @@ public final class TRSRTransformation implements IModelState, ITransformation
     private Vector3f scale;
     private Quat4f rightRot;
 
+    private Matrix4f normalTransform;
+
     public TRSRTransformation(@Nullable Matrix4f matrix)
     {
         if(matrix == null)
@@ -646,6 +648,29 @@ public final class TRSRTransformation implements IModelState, ITransformation
     {
         // FIXME check if this is good enough
         return vertexIndex;
+    }
+
+    public void transformPosition(Vector4f position)
+    {
+        matrix.transform(position);
+    }
+
+    public void transformNormal(Vector3f normal)
+    {
+        checkNormalTransform();
+        normalTransform.transform(normal);
+        normal.normalize();
+    }
+
+    private void checkNormalTransform()
+    {
+        if (normalTransform == null)
+        {
+            Matrix4f matrix = getMatrix();
+            matrix.invert();
+            matrix.transpose();
+            normalTransform = matrix;
+        }
     }
 
     @Override


### PR DESCRIPTION
This PR aims to address the issue that various quad generation methods in the model handling code currently apply transforms to the vertex positions, but not the normals.

As the normals for quads generated by vanilla code are computed by Forge based on the vertex positions (`ForgeHooksClient.fillNormal` called from `FaceBakery.makeBakedQuad`), they _will_ take the transform into account.

This leaves the Forge-generated quads with incorrect normals, as can been seen with the test case from #5241 - the "upwards" face is still shaded as if it were horizontal.

Also fixes a bonus bug where the `UV` switch case didn't correctly break for any element index other than 0, causing any format that accepted lightmap values to be supplied normal values instead.

Would appreciate review to make sure the logic is correct.