### PR TITLE
Speed up runtime deobfuscation

### DIFF
--- a/src/main/java/net/minecraftforge/fml/common/asm/transformers/DeobfuscationTransformer.java
+++ b/src/main/java/net/minecraftforge/fml/common/asm/transformers/DeobfuscationTransformer.java
@@ -21,6 +21,7 @@ package net.minecraftforge.fml.common.asm.transformers;
 
 import java.util.Arrays;
 
+import com.google.common.base.Stopwatch;
 import net.minecraft.launchwrapper.IClassNameTransformer;
 import net.minecraft.launchwrapper.IClassTransformer;
 import net.minecraft.launchwrapper.Launch;
@@ -30,6 +31,7 @@ import net.minecraftforge.fml.common.asm.transformers.deobf.FMLRemappingAdapter;
 
 import org.objectweb.asm.ClassReader;
 import org.objectweb.asm.ClassWriter;
+import org.objectweb.asm.commons.ClassRemapper;
 import org.objectweb.asm.commons.RemappingClassAdapter;
 
 public class DeobfuscationTransformer implements IClassTransformer, IClassNameTransformer {
@@ -52,7 +54,7 @@ public class DeobfuscationTransformer implements IClassTransformer, IClassNameTr
 
     private static final boolean RECALC_FRAMES = Boolean.parseBoolean(System.getProperty("FORGE_FORCE_FRAME_RECALC", "false"));
     private static final int WRITER_FLAGS = ClassWriter.COMPUTE_MAXS | (RECALC_FRAMES ? ClassWriter.COMPUTE_FRAMES : 0);
-    private static final int READER_FLAGS = RECALC_FRAMES ? ClassReader.SKIP_FRAMES : ClassReader.EXPAND_FRAMES;
+    private static final int READER_FLAGS = RECALC_FRAMES ? ClassReader.SKIP_FRAMES : 0;
     // COMPUTE_FRAMES causes classes to be loaded, which could cause issues if the classes do not exist.
     // However in testing this has not happened. {As we run post SideTransformer}
     // If reported we need to add a custom implementation of ClassWriter.getCommonSuperClass
@@ -72,7 +74,7 @@ public class DeobfuscationTransformer implements IClassTransformer, IClassNameTr
 
         ClassReader classReader = new ClassReader(bytes);
         ClassWriter classWriter = new ClassWriter(WRITER_FLAGS);
-        RemappingClassAdapter remapAdapter = new FMLRemappingAdapter(classWriter);
+        ClassRemapper remapAdapter = new FMLRemappingAdapter(classWriter);
         classReader.accept(remapAdapter, READER_FLAGS);
         return classWriter.toByteArray();
     }

--- a/src/main/java/net/minecraftforge/fml/common/asm/transformers/DeobfuscationTransformer.java
+++ b/src/main/java/net/minecraftforge/fml/common/asm/transformers/DeobfuscationTransformer.java
@@ -21,7 +21,6 @@ package net.minecraftforge.fml.common.asm.transformers;
 
 import java.util.Arrays;
 
-import com.google.common.base.Stopwatch;
 import net.minecraft.launchwrapper.IClassNameTransformer;
 import net.minecraft.launchwrapper.IClassTransformer;
 import net.minecraft.launchwrapper.Launch;
@@ -32,7 +31,6 @@ import net.minecraftforge.fml.common.asm.transformers.deobf.FMLRemappingAdapter;
 import org.objectweb.asm.ClassReader;
 import org.objectweb.asm.ClassWriter;
 import org.objectweb.asm.commons.ClassRemapper;
-import org.objectweb.asm.commons.RemappingClassAdapter;
 
 public class DeobfuscationTransformer implements IClassTransformer, IClassNameTransformer {
     private static final String[] EXEMPT_LIBS = new String[] {

--- a/src/main/java/net/minecraftforge/fml/common/asm/transformers/SideTransformer.java
+++ b/src/main/java/net/minecraftforge/fml/common/asm/transformers/SideTransformer.java
@@ -62,6 +62,7 @@ public class SideTransformer implements IClassTransformer
             throw new RuntimeException(String.format("Attempted to load class %s for invalid side %s", classNode.name, SIDE));
         }
 
+        boolean changed = false;
         Iterator<FieldNode> fields = classNode.fields.iterator();
         while(fields.hasNext())
         {
@@ -73,6 +74,7 @@ public class SideTransformer implements IClassTransformer
                     System.out.println(String.format("Removing Field: %s.%s", classNode.name, field.name));
                 }
                 fields.remove();
+                changed = true;
             }
         }
 
@@ -89,6 +91,7 @@ public class SideTransformer implements IClassTransformer
                 }
                 methods.remove();
                 lambdaGatherer.accept(method);
+                changed = true;
             }
         }
 
@@ -112,14 +115,20 @@ public class SideTransformer implements IClassTransformer
                         }
                         methods.remove();
                         lambdaGatherer.accept(method);
+                        changed = true;
                     }
                 }
             }
         }
 
-        ClassWriter writer = new ClassWriter(ClassWriter.COMPUTE_MAXS);
-        classNode.accept(writer);
-        return writer.toByteArray();
+        //No need to waste time on rewriting an unchanged class
+        if (changed)
+        {
+            ClassWriter writer = new ClassWriter(ClassWriter.COMPUTE_MAXS);
+            classNode.accept(writer);
+            return writer.toByteArray();
+        }
+        return bytes;
     }
 
     private boolean remove(List<AnnotationNode> anns, String side)

--- a/src/main/java/net/minecraftforge/fml/common/asm/transformers/deobf/FMLRemappingAdapter.java
+++ b/src/main/java/net/minecraftforge/fml/common/asm/transformers/deobf/FMLRemappingAdapter.java
@@ -25,14 +25,13 @@ import org.objectweb.asm.Handle;
 import org.objectweb.asm.MethodVisitor;
 import org.objectweb.asm.Opcodes;
 import org.objectweb.asm.Type;
-import org.objectweb.asm.commons.Remapper;
-import org.objectweb.asm.commons.RemappingClassAdapter;
-import org.objectweb.asm.commons.RemappingMethodAdapter;
+import org.objectweb.asm.commons.*;
 
 import java.util.Arrays;
 import java.util.List;
 
-public class FMLRemappingAdapter extends RemappingClassAdapter {
+public class FMLRemappingAdapter extends ClassRemapper
+{
     public FMLRemappingAdapter(ClassVisitor cv)
     {
         super(cv, FMLDeobfuscatingRemapper.INSTANCE);
@@ -65,21 +64,21 @@ public class FMLRemappingAdapter extends RemappingClassAdapter {
             remapper.mapMemberFieldName(className, name, desc),
             remapper.mapDesc(desc), remapper.mapSignature(signature, true),
             remapper.mapValue(value));
-        return createRemappingFieldAdapter(fv);
+        return createFieldRemapper(fv);
     }
 
     @Override
-    protected MethodVisitor createRemappingMethodAdapter(int access, String newDesc, MethodVisitor mv)
+    protected MethodVisitor createMethodRemapper(MethodVisitor mv)
     {
-        return new StaticFixingMethodVisitor(access, newDesc, mv, remapper);
+        return new StaticFixingMethodVisitor(mv, remapper);
     }
 
-    private static class StaticFixingMethodVisitor extends RemappingMethodAdapter
+    private static class StaticFixingMethodVisitor extends MethodRemapper
     {
 
-        public StaticFixingMethodVisitor(int access, String desc, MethodVisitor mv, Remapper remapper)
+        public StaticFixingMethodVisitor(MethodVisitor mv, Remapper remapper)
         {
-            super(access, desc, mv, remapper);
+            super(mv, remapper);
         }
 
         @Override


### PR DESCRIPTION
This PR aims to improve startup time, esp on large modpacks. This is done by changing the deobf transformer to not expand frames, which, as the javadoc says, is slow. This works for a simple renaming transformer as well, but we need to change it to a ´ClassRemapper´ instead of a ´RemappingClassAdapter´, as the ´RemappingClassAdapter´ class requires ´EXPAND_FRAMES´.
See https://gitlab.ow2.org/asm/asm/issues/317576 for some background information.