### PR TITLE
Use Objects.equals() checks for UUIDs in ItemStack#getTooltip, not == checks

### DIFF
--- a/patches/minecraft/net/minecraft/item/ItemStack.java.patch
+++ b/patches/minecraft/net/minecraft/item/ItemStack.java.patch
@@ -215,7 +215,24 @@
          }
      }
  
-@@ -862,6 +886,7 @@
+@@ -751,13 +775,14 @@
+ 
+                     if (p_82840_1_ != null)
+                     {
+-                        if (attributemodifier.func_111167_a() == Item.field_111210_e)
++                        //Forge: Changed to java.util.Objects.equals check to support deserialised attributes
++                        if (java.util.Objects.equals(attributemodifier.func_111167_a(), Item.field_111210_e))
+                         {
+                             d0 = d0 + p_82840_1_.func_110148_a(SharedMonsterAttributes.field_111264_e).func_111125_b();
+                             d0 = d0 + (double)EnchantmentHelper.func_152377_a(this, EnumCreatureAttribute.UNDEFINED);
+                             flag = true;
+                         }
+-                        else if (attributemodifier.func_111167_a() == Item.field_185050_h)
++                        else if (java.util.Objects.equals(attributemodifier.func_111167_a(), Item.field_185050_h))
+                         {
+                             d0 += p_82840_1_.func_110148_a(SharedMonsterAttributes.field_188790_f).func_111125_b();
+                             flag = true;
+@@ -862,6 +887,7 @@
              }
          }
  
@@ -223,7 +240,7 @@
          return list;
      }
  
-@@ -987,7 +1012,7 @@
+@@ -987,7 +1013,7 @@
          }
          else
          {
@@ -232,7 +249,7 @@
          }
  
          return multimap;
-@@ -1130,4 +1155,128 @@
+@@ -1130,4 +1156,128 @@
      {
          this.func_190917_f(-p_190918_1_);
      }


### PR DESCRIPTION
`ItemStack#getTooltip()` currently uses reference equality to hard code an equals style modifier tooltip 
 for modifiers with either `Item.ATTACK_DAMAGE_MODIFIER` or `Item.ATTACK_DAMAGE_MODIFIER` as their UUID. However this currently doesn't work if the UUID is deserialised from NBT.
![2018-11-20_12 34 47](https://user-images.githubusercontent.com/10936237/48742746-159b1e80-ecc5-11e8-8d07-6a24a813668f.png)
This iron sword has the same stats as the default iron sword, but given by modifiers. The command for it is `/give @p iron_sword 1 0 {AttributeModifiers: [{Slot: "mainhand",AttributeName: "generic.attackDamage",Name: "generic.attackDamage",Amount: 5,Operation: 0,UUIDMost: -3801225194067177672L,UUIDLeast: -6586624321849018929L},{Slot: "mainhand",AttributeName: "generic.attackSpeed",Name: "generic.attackSpeed",Amount: -2.4,Operation: 0,UUIDMost: -422425648963762075L,UUIDLeast: -5756800103171642205L}]}`, it needs a command block as it is quite long. This tooltip could easily be interpreted as the sword having an attack speed of -2.4 and an attack damage of 5, since players expect the equals style for swords.  
By using Object.equals() checks, the tooltip becomes
![2018-11-20_12 37 18](https://user-images.githubusercontent.com/10936237/48742953-f2bd3a00-ecc5-11e8-8fad-d121c4271d69.png)
as players expect, but only if the NBT attribute modifiers use the UUIDs of either `Item.ATTACK_DAMAGE_MODIFIER` or `Item.ATTACK_DAMAGE_MODIFIER`.

I ran into this issue with [this recipe](https://github.com/Polar-Team/Polar/blob/1.12/src/main/java/leviathan143/polar/common/recipes/RecipeAddAttributeModifier.java). When using it to add to the existing attribute modifiers of a sword the tooltip becomes similar to the one in the first picture, which initially made me think the sword had a negative attack speed. I suspect players might think the same, so I have made this PR.