### PR TITLE
Allow custom DataSerializers to be registered safely

### DIFF
--- a/patches/minecraft/net/minecraft/network/datasync/DataSerializers.java.patch
+++ b/patches/minecraft/net/minecraft/network/datasync/DataSerializers.java.patch
@@ -1,14 +1,16 @@
 --- ../src-base/minecraft/net/minecraft/network/datasync/DataSerializers.java
 +++ ../src-work/minecraft/net/minecraft/network/datasync/DataSerializers.java
-@@ -305,6 +305,7 @@
+@@ -305,20 +305,21 @@
          }
      };
  
 +    @Deprecated // Forge: ONLY FOR VANILLA - mods should use the Forge registry
      public static void func_187189_a(DataSerializer<?> p_187189_0_)
      {
-         field_187204_n.func_186808_c(p_187189_0_);
-@@ -313,12 +314,12 @@
+-        field_187204_n.func_186808_c(p_187189_0_);
++        if (field_187204_n.func_186808_c(p_187189_0_) >= 256) throw new RuntimeException("Vanilla DataSerializer ID limit exceeded");
+     }
+ 
      @Nullable
      public static DataSerializer<?> func_187190_a(int p_187190_0_)
      {

--- a/patches/minecraft/net/minecraft/network/datasync/DataSerializers.java.patch
+++ b/patches/minecraft/net/minecraft/network/datasync/DataSerializers.java.patch
@@ -1,0 +1,25 @@
+--- ../src-base/minecraft/net/minecraft/network/datasync/DataSerializers.java
++++ ../src-work/minecraft/net/minecraft/network/datasync/DataSerializers.java
+@@ -305,6 +305,7 @@
+         }
+     };
+ 
++    @Deprecated // Forge: ONLY FOR VANILLA - mods should use the Forge registry
+     public static void func_187189_a(DataSerializer<?> p_187189_0_)
+     {
+         field_187204_n.func_186808_c(p_187189_0_);
+@@ -313,12 +314,12 @@
+     @Nullable
+     public static DataSerializer<?> func_187190_a(int p_187190_0_)
+     {
+-        return (DataSerializer)field_187204_n.func_186813_a(p_187190_0_);
++        return net.minecraftforge.common.ForgeHooks.getSerializer(p_187190_0_, field_187204_n);
+     }
+ 
+     public static int func_187188_b(DataSerializer<?> p_187188_0_)
+     {
+-        return field_187204_n.func_186815_a(p_187188_0_);
++        return net.minecraftforge.common.ForgeHooks.getSerializerId(p_187188_0_, field_187204_n);
+     }
+ 
+     static

--- a/src/main/java/net/minecraftforge/common/ForgeHooks.java
+++ b/src/main/java/net/minecraftforge/common/ForgeHooks.java
@@ -81,6 +81,7 @@ import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.nbt.NBTTagList;
 import net.minecraft.network.NetHandlerPlayServer;
 import net.minecraft.network.Packet;
+import net.minecraft.network.datasync.DataSerializer;
 import net.minecraft.network.play.server.SPacketBlockChange;
 import net.minecraft.network.play.server.SPacketRecipeBook;
 import net.minecraft.network.play.server.SPacketRecipeBook.State;
@@ -93,6 +94,7 @@ import net.minecraft.util.DamageSource;
 import net.minecraft.util.EnumActionResult;
 import net.minecraft.util.EnumFacing;
 import net.minecraft.util.EnumHand;
+import net.minecraft.util.IntIdentityHashBiMap;
 import net.minecraft.util.JsonUtils;
 import net.minecraft.util.NonNullList;
 import net.minecraft.util.ResourceLocation;
@@ -151,6 +153,9 @@ import net.minecraftforge.fml.common.network.handshake.NetworkDispatcher;
 import net.minecraftforge.fml.common.network.handshake.NetworkDispatcher.ConnectionType;
 import net.minecraftforge.fml.common.registry.ForgeRegistries;
 import net.minecraftforge.fml.relauncher.ReflectionHelper;
+import net.minecraftforge.registries.DataSerializerEntry;
+import net.minecraftforge.registries.ForgeRegistry;
+import net.minecraftforge.registries.GameData;
 import net.minecraftforge.registries.IForgeRegistry;
 import net.minecraftforge.registries.RegistryManager;
 
@@ -1462,4 +1467,29 @@ public class ForgeHooks
         return false;
     }
 
+    private static final Map<DataSerializer<?>, DataSerializerEntry> serializerEntries = GameData.getSerializerMap();
+    private static final ForgeRegistry<DataSerializerEntry> serializerRegistry = (ForgeRegistry<DataSerializerEntry>) ForgeRegistries.DATA_SERIALIZERS;
+
+    @Nullable
+    public static DataSerializer<?> getSerializer(int id, IntIdentityHashBiMap<DataSerializer<?>> vanilla)
+    {
+        DataSerializer<?> serializer = vanilla.get(id);
+        if (serializer == null)
+        {
+            DataSerializerEntry entry = serializerRegistry.getValue(id);
+            if (entry != null) serializer = entry.getSerializer();
+        }
+        return serializer;
+    }
+
+    public static int getSerializerId(DataSerializer<?> serializer, IntIdentityHashBiMap<DataSerializer<?>> vanilla)
+    {
+        int id = vanilla.getId(serializer);
+        if (id < 0)
+        {
+            DataSerializerEntry entry = serializerEntries.get(serializer);
+            if (entry != null) id = serializerRegistry.getID(entry);
+        }
+        return id;
+    }
 }

--- a/src/main/java/net/minecraftforge/fml/common/registry/ForgeRegistries.java
+++ b/src/main/java/net/minecraftforge/fml/common/registry/ForgeRegistries.java
@@ -29,6 +29,7 @@ import net.minecraft.potion.PotionType;
 import net.minecraft.util.SoundEvent;
 import net.minecraft.world.biome.Biome;
 import net.minecraftforge.fml.common.registry.VillagerRegistry.VillagerProfession;
+import net.minecraftforge.registries.DataSerializerEntry;
 import net.minecraftforge.registries.GameData;
 import net.minecraftforge.registries.IForgeRegistry;
 
@@ -51,6 +52,7 @@ public class ForgeRegistries
     public static final IForgeRegistry<VillagerProfession> VILLAGER_PROFESSIONS = GameRegistry.findRegistry(VillagerProfession.class);
     public static final IForgeRegistry<EntityEntry>  ENTITIES     = GameRegistry.findRegistry(EntityEntry.class);
     public static final IForgeRegistry<IRecipe>      RECIPES      = GameRegistry.findRegistry(IRecipe.class);
+    public static final IForgeRegistry<DataSerializerEntry> DATA_SERIALIZERS = GameRegistry.findRegistry(DataSerializerEntry.class);
 
 
     /**

--- a/src/main/java/net/minecraftforge/registries/DataSerializerEntry.java
+++ b/src/main/java/net/minecraftforge/registries/DataSerializerEntry.java
@@ -1,0 +1,37 @@
+/*
+ * Minecraft Forge
+ * Copyright (c) 2016-2018.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation version 2.1
+ * of the License.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+package net.minecraftforge.registries;
+
+import net.minecraft.network.datasync.DataSerializer;
+
+public final class DataSerializerEntry extends IForgeRegistryEntry.Impl<DataSerializerEntry>
+{
+    private final DataSerializer<?> serializer;
+
+    public DataSerializerEntry(DataSerializer<?> serializer)
+    {
+        this.serializer = serializer;
+    }
+
+    public DataSerializer<?> getSerializer()
+    {
+        return serializer;
+    }
+}

--- a/src/main/java/net/minecraftforge/registries/GameData.java
+++ b/src/main/java/net/minecraftforge/registries/GameData.java
@@ -512,11 +512,12 @@ public class GameData
         static final SerializerCallbacks INSTANCE = new SerializerCallbacks();
 
         @Override
-        public void onAdd(IForgeRegistryInternal<DataSerializerEntry> owner, RegistryManager stage, int id, DataSerializerEntry obj, @Nullable DataSerializerEntry oldObj)
+        public void onAdd(IForgeRegistryInternal<DataSerializerEntry> owner, RegistryManager stage, int id, DataSerializerEntry entry, @Nullable DataSerializerEntry oldEntry)
         {
             @SuppressWarnings("unchecked")
             Map<DataSerializer<?>, DataSerializerEntry> map = owner.getSlaveMap(SERIALIZER_TO_ENTRY, Map.class);
-            map.put(obj.getSerializer(), obj);
+            if (oldEntry != null) map.remove(oldEntry.getSerializer());
+            map.put(entry.getSerializer(), entry);
         }
 
         @Override

--- a/src/main/java/net/minecraftforge/registries/GameData.java
+++ b/src/main/java/net/minecraftforge/registries/GameData.java
@@ -37,6 +37,7 @@ import net.minecraft.item.Item;
 import net.minecraft.item.ItemBlock;
 import net.minecraft.item.ItemStack;
 import net.minecraft.item.crafting.IRecipe;
+import net.minecraft.network.datasync.DataSerializer;
 import net.minecraft.potion.Potion;
 import net.minecraft.potion.PotionType;
 import net.minecraft.util.ObjectIntIdentityMap;
@@ -100,6 +101,8 @@ public class GameData
     public static final ResourceLocation ENTITIES     = new ResourceLocation("minecraft:entities");
     public static final ResourceLocation RECIPES      = new ResourceLocation("minecraft:recipes");
     public static final ResourceLocation PROFESSIONS  = new ResourceLocation("minecraft:villagerprofessions");
+    public static final ResourceLocation SERIALIZERS  = new ResourceLocation("minecraft:dataserializers");
+
     private static final int MAX_BLOCK_ID = 4095;
     private static final int MIN_ITEM_ID = MAX_BLOCK_ID + 1;
     private static final int MAX_ITEM_ID = 31999;
@@ -111,10 +114,14 @@ public class GameData
     private static final int MAX_ENTITY_ID = Integer.MAX_VALUE >> 5; // Varint (SPacketSpawnMob)
     private static final int MAX_RECIPE_ID = Integer.MAX_VALUE >> 5; // Varint CPacketRecipeInfo/SPacketRecipeBook
     private static final int MAX_PROFESSION_ID = 1024; //TODO: Is this serialized anywhere anymore?
+    private static final int MIN_SERIALIZER_ID = 256; // Leave room for vanilla entries
+    private static final int MAX_SERIALIZER_ID = Integer.MAX_VALUE >> 5; // Varint (EntityDataManager)
 
     private static final ResourceLocation BLOCK_TO_ITEM         = new ResourceLocation("minecraft:blocktoitemmap");
     private static final ResourceLocation BLOCKSTATE_TO_ID      = new ResourceLocation("minecraft:blockstatetoid");
     private static final ResourceLocation ENTITY_CLASS_TO_ENTRY = new ResourceLocation("forge:entity_class_to_entry");
+    private static final ResourceLocation SERIALISER_TO_ENTRY   = new ResourceLocation("forge:serializer_to_entry");
+
     private static boolean hasInit = false;
     private static final boolean DISABLE_VANILLA_REGISTRIES = Boolean.parseBoolean(System.getProperty("forge.disableVanillaGameData", "false")); // Use for unit tests/debugging
     private static final BiConsumer<ResourceLocation, ForgeRegistry<?>> LOCK_VANILLA = (name, reg) -> reg.slaves.values().stream().filter(o -> o instanceof ILockableRegistry).forEach(o -> ((ILockableRegistry)o).lock());
@@ -142,6 +149,7 @@ public class GameData
         makeRegistry(ENCHANTMENTS, Enchantment.class, MAX_ENCHANTMENT_ID).create();
         makeRegistry(RECIPES,      IRecipe.class,     MAX_RECIPE_ID).disableSaving().allowModification().addCallback(RecipeCallbacks.INSTANCE).create();
         makeRegistry(PROFESSIONS,  VillagerProfession.class, MAX_PROFESSION_ID).create();
+        makeRegistry(SERIALIZERS,  DataSerializerEntry.class, MIN_SERIALIZER_ID, MAX_SERIALIZER_ID).disableSaving().disableOverrides().addCallback(SerializerCallbacks.INSTANCE).create();
         entityRegistry = (ForgeRegistry<EntityEntry>)makeRegistry(ENTITIES, EntityEntry.class, MAX_ENTITY_ID).addCallback(EntityCallbacks.INSTANCE).create();
     }
 
@@ -194,6 +202,12 @@ public class GameData
     public static Map<Class<? extends Entity>, EntityEntry> getEntityClassMap()
     {
         return GameRegistry.findRegistry(EntityEntry.class).getSlaveMap(ENTITY_CLASS_TO_ENTRY, Map.class);
+    }
+
+    @SuppressWarnings("unchecked")
+    public static Map<DataSerializer<?>, DataSerializerEntry> getSerializerMap()
+    {
+        return GameRegistry.findRegistry(DataSerializerEntry.class).getSlaveMap(SERIALISER_TO_ENTRY, Map.class);
     }
 
     public static <K extends IForgeRegistryEntry<K>> K register_impl(K value)
@@ -490,6 +504,31 @@ public class GameData
         public void onCreate(IForgeRegistryInternal<EntityEntry> owner, RegistryManager stage)
         {
             owner.setSlaveMap(ENTITY_CLASS_TO_ENTRY, new IdentityHashMap<>());
+        }
+    }
+
+    private static class SerializerCallbacks implements IForgeRegistry.AddCallback<DataSerializerEntry>, IForgeRegistry.ClearCallback<DataSerializerEntry>, IForgeRegistry.CreateCallback<DataSerializerEntry>
+    {
+        static final SerializerCallbacks INSTANCE = new SerializerCallbacks();
+
+        @Override
+        public void onAdd(IForgeRegistryInternal<DataSerializerEntry> owner, RegistryManager stage, int id, DataSerializerEntry obj, @Nullable DataSerializerEntry oldObj)
+        {
+            @SuppressWarnings("unchecked")
+            Map<DataSerializer<?>, DataSerializerEntry> map = owner.getSlaveMap(SERIALISER_TO_ENTRY, Map.class);
+            map.put(obj.getSerializer(), obj);
+        }
+
+        @Override
+        public void onClear(IForgeRegistryInternal<DataSerializerEntry> owner, RegistryManager stage)
+        {
+            owner.getSlaveMap(SERIALISER_TO_ENTRY, Map.class).clear();
+        }
+
+        @Override
+        public void onCreate(IForgeRegistryInternal<DataSerializerEntry> owner, RegistryManager stage)
+        {
+            owner.setSlaveMap(SERIALISER_TO_ENTRY, new IdentityHashMap<>());
         }
     }
 

--- a/src/main/java/net/minecraftforge/registries/GameData.java
+++ b/src/main/java/net/minecraftforge/registries/GameData.java
@@ -120,7 +120,7 @@ public class GameData
     private static final ResourceLocation BLOCK_TO_ITEM         = new ResourceLocation("minecraft:blocktoitemmap");
     private static final ResourceLocation BLOCKSTATE_TO_ID      = new ResourceLocation("minecraft:blockstatetoid");
     private static final ResourceLocation ENTITY_CLASS_TO_ENTRY = new ResourceLocation("forge:entity_class_to_entry");
-    private static final ResourceLocation SERIALISER_TO_ENTRY   = new ResourceLocation("forge:serializer_to_entry");
+    private static final ResourceLocation SERIALIZER_TO_ENTRY   = new ResourceLocation("forge:serializer_to_entry");
 
     private static boolean hasInit = false;
     private static final boolean DISABLE_VANILLA_REGISTRIES = Boolean.parseBoolean(System.getProperty("forge.disableVanillaGameData", "false")); // Use for unit tests/debugging
@@ -207,7 +207,7 @@ public class GameData
     @SuppressWarnings("unchecked")
     public static Map<DataSerializer<?>, DataSerializerEntry> getSerializerMap()
     {
-        return GameRegistry.findRegistry(DataSerializerEntry.class).getSlaveMap(SERIALISER_TO_ENTRY, Map.class);
+        return GameRegistry.findRegistry(DataSerializerEntry.class).getSlaveMap(SERIALIZER_TO_ENTRY, Map.class);
     }
 
     public static <K extends IForgeRegistryEntry<K>> K register_impl(K value)
@@ -515,20 +515,20 @@ public class GameData
         public void onAdd(IForgeRegistryInternal<DataSerializerEntry> owner, RegistryManager stage, int id, DataSerializerEntry obj, @Nullable DataSerializerEntry oldObj)
         {
             @SuppressWarnings("unchecked")
-            Map<DataSerializer<?>, DataSerializerEntry> map = owner.getSlaveMap(SERIALISER_TO_ENTRY, Map.class);
+            Map<DataSerializer<?>, DataSerializerEntry> map = owner.getSlaveMap(SERIALIZER_TO_ENTRY, Map.class);
             map.put(obj.getSerializer(), obj);
         }
 
         @Override
         public void onClear(IForgeRegistryInternal<DataSerializerEntry> owner, RegistryManager stage)
         {
-            owner.getSlaveMap(SERIALISER_TO_ENTRY, Map.class).clear();
+            owner.getSlaveMap(SERIALIZER_TO_ENTRY, Map.class).clear();
         }
 
         @Override
         public void onCreate(IForgeRegistryInternal<DataSerializerEntry> owner, RegistryManager stage)
         {
-            owner.setSlaveMap(SERIALISER_TO_ENTRY, new IdentityHashMap<>());
+            owner.setSlaveMap(SERIALIZER_TO_ENTRY, new IdentityHashMap<>());
         }
     }
 


### PR DESCRIPTION
This PR is intended to allow mods to register custom `DataSerializer` implementations.

Currently, the vanilla implementations are statically defined in `DataSerializers`. While a `registerSerializer` method is available to register additional `DataSerializer` implementations, it cannot actually be used safely.

As the IDs are used for networking, there must be client/server agreement on the ID of every entry, and as the backing `IntIdentityHashBiMap` will assign IDs in registration order, this requires the exact same entries to be registered in the exact same order for the server and all clients, which can only be reasonably ensured for vanilla's serialisers.

This adds a non-persistent `ForgeRegistry` for data serialisers (using a `DataSerializerEntry` wrapper class), using the existing registry mechanisms to ensure IDs are matched. The existing vanilla map lookups are patched to fallthrough to checking the Forge registry and a deprecation note is added to the vanilla registration method warning against its use.