### PR TITLE
Allow items to specify speed and sprinting restrictions while in use

### DIFF
--- a/patches/minecraft/net/minecraft/client/entity/EntityPlayerSP.java.patch
+++ b/patches/minecraft/net/minecraft/client/entity/EntityPlayerSP.java.patch
@@ -89,7 +89,7 @@
      }
  
      public boolean func_70613_aW()
-@@ -840,6 +861,7 @@
+@@ -840,13 +861,14 @@
          float f = 0.8F;
          boolean flag2 = this.field_71158_b.field_192832_b >= 0.8F;
          this.field_71158_b.func_78898_a();
@@ -97,7 +97,17 @@
          this.field_71159_c.func_193032_ao().func_193293_a(this.field_71158_b);
  
          if (this.func_184587_cr() && !this.func_184218_aH())
-@@ -859,10 +881,13 @@
+         {
+-            this.field_71158_b.field_78902_a *= 0.2F;
+-            this.field_71158_b.field_192832_b *= 0.2F;
+-            this.field_71156_d = 0;
++            this.field_71158_b.field_78902_a *= this.func_184607_cu().func_77973_b().getMovementSpeedMultiplier(this.func_184607_cu(), this);
++            this.field_71158_b.field_192832_b *= this.func_184607_cu().func_77973_b().getMovementSpeedMultiplier(this.func_184607_cu(), this);
++            if(this.func_184607_cu().func_77973_b().shouldPreventSprinting(this.func_184607_cu(), this)) this.field_71156_d = 0;
+         }
+ 
+         boolean flag3 = false;
+@@ -859,13 +881,16 @@
          }
  
          AxisAlignedBB axisalignedbb = this.func_174813_aQ();
@@ -110,7 +120,20 @@
 +        }
          boolean flag4 = (float)this.func_71024_bL().func_75116_a() > 6.0F || this.field_71075_bZ.field_75101_c;
  
-         if (this.field_70122_E && !flag1 && !flag2 && this.field_71158_b.field_192832_b >= 0.8F && !this.func_70051_ag() && flag4 && !this.func_184587_cr() && !this.func_70644_a(MobEffects.field_76440_q))
+-        if (this.field_70122_E && !flag1 && !flag2 && this.field_71158_b.field_192832_b >= 0.8F && !this.func_70051_ag() && flag4 && !this.func_184587_cr() && !this.func_70644_a(MobEffects.field_76440_q))
++        if (this.field_70122_E && !flag1 && !flag2 && this.field_71158_b.field_192832_b >= 0.8F && !this.func_70051_ag() && flag4 && !(this.func_184587_cr() && this.func_184607_cu().func_77973_b().shouldPreventSprinting(this.func_184607_cu(), this)) && !this.func_70644_a(MobEffects.field_76440_q))
+         {
+             if (this.field_71156_d <= 0 && !this.field_71159_c.field_71474_y.field_151444_V.func_151470_d())
+             {
+@@ -877,7 +902,7 @@
+             }
+         }
+ 
+-        if (!this.func_70051_ag() && this.field_71158_b.field_192832_b >= 0.8F && flag4 && !this.func_184587_cr() && !this.func_70644_a(MobEffects.field_76440_q) && this.field_71159_c.field_71474_y.field_151444_V.func_151470_d())
++        if (!this.func_70051_ag() && this.field_71158_b.field_192832_b >= 0.8F && flag4 && !(this.func_184587_cr() && this.func_184607_cu().func_77973_b().shouldPreventSprinting(this.func_184607_cu(), this)) && !this.func_70644_a(MobEffects.field_76440_q) && this.field_71159_c.field_71474_y.field_151444_V.func_151470_d())
+         {
+             this.func_70031_b(true);
+         }
 @@ -1178,4 +1203,17 @@
              }
          }

--- a/patches/minecraft/net/minecraft/client/entity/EntityPlayerSP.java.patch
+++ b/patches/minecraft/net/minecraft/client/entity/EntityPlayerSP.java.patch
@@ -101,8 +101,8 @@
 -            this.field_71158_b.field_78902_a *= 0.2F;
 -            this.field_71158_b.field_192832_b *= 0.2F;
 -            this.field_71156_d = 0;
-+            this.field_71158_b.field_78902_a *= this.func_184607_cu().func_77973_b().getMovementSpeedMultiplier(this.func_184607_cu(), this);
-+            this.field_71158_b.field_192832_b *= this.func_184607_cu().func_77973_b().getMovementSpeedMultiplier(this.func_184607_cu(), this);
++            this.field_71158_b.field_78902_a *= this.func_184607_cu().func_77973_b().getSpeedModifier(this.func_184607_cu(), this);
++            this.field_71158_b.field_192832_b *= this.func_184607_cu().func_77973_b().getSpeedModifier(this.func_184607_cu(), this);
 +            if(this.func_184607_cu().func_77973_b().shouldPreventSprinting(this.func_184607_cu(), this)) this.field_71156_d = 0;
          }
  

--- a/patches/minecraft/net/minecraft/item/Item.java.patch
+++ b/patches/minecraft/net/minecraft/item/Item.java.patch
@@ -68,7 +68,7 @@
          CreativeTabs creativetabs = this.func_77640_w();
          return creativetabs != null && (p_194125_1_ == CreativeTabs.field_78027_g || p_194125_1_ == creativetabs);
      }
-@@ -435,11 +441,757 @@
+@@ -435,11 +441,779 @@
          return false;
      }
  
@@ -802,6 +802,28 @@
 +     */
 +    public void onHorseArmorTick(World world, net.minecraft.entity.EntityLiving horse, ItemStack armor) {}
 +    
++    /**
++     * Returns the movement speed multiplier which is applied to an entity using this item.
++     * @param stack the item stack being used
++     * @param entity the entity using the item
++     * @return a float between 0F and 1F
++     */
++    public float getMovementSpeedMultiplier(ItemStack stack, EntityLivingBase entity)
++    {
++    	return 0.2F;
++    }
++    
++    /**
++     * Whether an entity is prevented from sprinting while using this item.
++     * @param stack the item stack being used
++     * @param entity the entity using the item
++     * @return true if an entity is prevented from sprinting while using this item
++     */
++    public boolean shouldPreventSprinting(ItemStack stack, EntityLivingBase entity)
++    {
++    	return true;
++    }
++    
 +    @SideOnly(Side.CLIENT)
 +    @Nullable
 +    private net.minecraft.client.renderer.tileentity.TileEntityItemStackRenderer teisr;
@@ -826,7 +848,7 @@
      public static void func_150900_l()
      {
          func_179214_a(Blocks.field_150350_a, new ItemAir(Blocks.field_150350_a));
-@@ -999,6 +1751,8 @@
+@@ -999,6 +1773,8 @@
          private final float field_78010_h;
          private final float field_78011_i;
          private final int field_78008_j;
@@ -835,7 +857,7 @@
  
          private ToolMaterial(int p_i1874_3_, int p_i1874_4_, float p_i1874_5_, float p_i1874_6_, int p_i1874_7_)
          {
-@@ -1034,6 +1788,7 @@
+@@ -1034,6 +1810,7 @@
              return this.field_78008_j;
          }
  
@@ -843,7 +865,7 @@
          public Item func_150995_f()
          {
              if (this == WOOD)
-@@ -1057,5 +1812,21 @@
+@@ -1057,5 +1834,21 @@
                  return this == DIAMOND ? Items.field_151045_i : null;
              }
          }

--- a/patches/minecraft/net/minecraft/item/Item.java.patch
+++ b/patches/minecraft/net/minecraft/item/Item.java.patch
@@ -808,7 +808,7 @@
 +     * @param entity the entity using the item
 +     * @return a float between 0F and 1F
 +     */
-+    public float getMovementSpeedMultiplier(ItemStack stack, EntityLivingBase entity)
++    public float getSpeedModifier(ItemStack stack, EntityLivingBase entity)
 +    {
 +    	return 0.2F;
 +    }

--- a/patches/minecraft/net/minecraft/item/Item.java.patch
+++ b/patches/minecraft/net/minecraft/item/Item.java.patch
@@ -810,7 +810,7 @@
 +     */
 +    public float getSpeedModifier(ItemStack stack, EntityLivingBase entity)
 +    {
-+    	return 0.2F;
++        return 0.2F;
 +    }
 +    
 +    /**
@@ -821,7 +821,7 @@
 +     */
 +    public boolean shouldPreventSprinting(ItemStack stack, EntityLivingBase entity)
 +    {
-+    	return true;
++        return true;
 +    }
 +    
 +    @SideOnly(Side.CLIENT)

--- a/src/test/java/net/minecraftforge/debug/item/ItemUseMovementTest.java
+++ b/src/test/java/net/minecraftforge/debug/item/ItemUseMovementTest.java
@@ -1,3 +1,22 @@
+/*
+ * Minecraft Forge
+ * Copyright (c) 2016-2018.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation version 2.1
+ * of the License.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
 package net.minecraftforge.debug.item;
 
 import net.minecraft.client.renderer.block.model.ModelResourceLocation;
@@ -15,39 +34,39 @@ import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
 @Mod.EventBusSubscriber(modid = ItemUseMovementTest.MODID)
 public class ItemUseMovementTest
 {
-	public static  final String MODID = "iumtest";
-	private static final boolean ENABLED = false;
-	public static final Item LIGHTSTEAK = new ItemLightFood(3, false).setAlwaysEdible().setRegistryName("light_steak");
+    public static  final String MODID = "iumtest";
+    private static final boolean ENABLED = false;
+    public static final Item LIGHTSTEAK = new ItemLightFood(3, false).setAlwaysEdible().setRegistryName("light_steak");
 
-	@SubscribeEvent
-	public static void registerItems(RegistryEvent.Register<Item> event)
-	{
-		if(ENABLED) event.getRegistry().registerAll(LIGHTSTEAK);
-	}
+    @SubscribeEvent
+    public static void registerItems(RegistryEvent.Register<Item> event)
+    {
+        if(ENABLED) event.getRegistry().registerAll(LIGHTSTEAK);
+    }
 
-	@SubscribeEvent
-	public static void registerModels(ModelRegistryEvent event)
-	{
-		if(ENABLED) ModelLoader.setCustomModelResourceLocation(LIGHTSTEAK, 0, new ModelResourceLocation("minecraft:cooked_beef"));
-	}
+    @SubscribeEvent
+    public static void registerModels(ModelRegistryEvent event)
+    {
+        if(ENABLED) ModelLoader.setCustomModelResourceLocation(LIGHTSTEAK, 0, new ModelResourceLocation("minecraft:cooked_beef"));
+    }
 
-	private static class ItemLightFood extends ItemFood
-	{
-		public ItemLightFood(int amount, boolean isWolfFood)
-		{
-			super(amount, isWolfFood);
-		}
+    private static class ItemLightFood extends ItemFood
+    {
+        public ItemLightFood(int amount, boolean isWolfFood)
+        {
+            super(amount, isWolfFood);
+        }
 
-		@Override
-		public float getMovementSpeedMultiplier(ItemStack stack, EntityLivingBase entity)
-		{
-			return 1F;
-		}
+        @Override
+        public float getSpeedModifier(ItemStack stack, EntityLivingBase entity)
+        {
+            return 1F;
+        }
 
-		@Override
-		public boolean shouldPreventSprinting(ItemStack stack, EntityLivingBase entity)
-		{
-			return false;
-		}
-	}
+        @Override
+        public boolean shouldPreventSprinting(ItemStack stack, EntityLivingBase entity)
+        {
+            return false;
+        }
+    }
 }

--- a/src/test/java/net/minecraftforge/debug/item/ItemUseMovementTest.java
+++ b/src/test/java/net/minecraftforge/debug/item/ItemUseMovementTest.java
@@ -1,0 +1,53 @@
+package net.minecraftforge.debug.item;
+
+import net.minecraft.client.renderer.block.model.ModelResourceLocation;
+import net.minecraft.entity.EntityLivingBase;
+import net.minecraft.item.Item;
+import net.minecraft.item.ItemFood;
+import net.minecraft.item.ItemStack;
+import net.minecraftforge.client.event.ModelRegistryEvent;
+import net.minecraftforge.client.model.ModelLoader;
+import net.minecraftforge.event.RegistryEvent;
+import net.minecraftforge.fml.common.Mod;
+import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
+
+@Mod(modid = ItemUseMovementTest.MODID, name = "Item Use Movement Test", version = "1.0", acceptableRemoteVersions = "*")
+@Mod.EventBusSubscriber(modid = ItemUseMovementTest.MODID)
+public class ItemUseMovementTest
+{
+	public static  final String MODID = "iumtest";
+	private static final boolean ENABLED = false;
+	public static final Item LIGHTSTEAK = new ItemLightFood(3, false).setAlwaysEdible().setRegistryName("light_steak");
+
+	@SubscribeEvent
+	public static void registerItems(RegistryEvent.Register<Item> event)
+	{
+		if(ENABLED) event.getRegistry().registerAll(LIGHTSTEAK);
+	}
+
+	@SubscribeEvent
+	public static void registerModels(ModelRegistryEvent event)
+	{
+		if(ENABLED) ModelLoader.setCustomModelResourceLocation(LIGHTSTEAK, 0, new ModelResourceLocation("minecraft:cooked_beef"));
+	}
+
+	private static class ItemLightFood extends ItemFood
+	{
+		public ItemLightFood(int amount, boolean isWolfFood)
+		{
+			super(amount, isWolfFood);
+		}
+
+		@Override
+		public float getMovementSpeedMultiplier(ItemStack stack, EntityLivingBase entity)
+		{
+			return 1F;
+		}
+
+		@Override
+		public boolean shouldPreventSprinting(ItemStack stack, EntityLivingBase entity)
+		{
+			return false;
+		}
+	}
+}


### PR DESCRIPTION
## **Changes**
Modified _EntityPlayerSP_, added _getSpeedModifier_ and _shouldPreventSprinting_ to _Item_, added _ItemUseMovementTest_.
## **Why?**
These tweaks fix the problems with hard-coded vanilla sprinting restrictions and movement slow when using an item. It is now possible to specify exactly how much slowness will be applied and allow sprinting while the item is being used. I've seen multiple requests for this feature and I need it myself.
## **How does it work?**
It adds two new methods to the Item class allowing modders to achieve the desired effect by overriding them. Some logic has been changed in the EntityPlayerSP class to include these new methods. I've also added a test mod for anyone curious.