### PR TITLE
Ensure slave maps are cleaned up when handling registry overrides

### DIFF
--- a/src/main/java/net/minecraftforge/registries/GameData.java
+++ b/src/main/java/net/minecraftforge/registries/GameData.java
@@ -292,7 +292,10 @@ public class GameData
         void remove(I key)
         {
             Integer prev = this.identityMap.remove(key);
-            if (prev != null) this.objectList.set(prev, null);
+            if (prev != null)
+            {
+                this.objectList.set(prev, null);
+            }
         }
     }
 
@@ -311,7 +314,9 @@ public class GameData
             if (oldBlock != null)
             {
                 for (IBlockState state : oldBlock.getBlockState().getValidStates())
+                {
                     blockstateMap.remove(state);
+                }
             }
 
             if ("minecraft:tripwire".equals(block.getRegistryName().toString())) //Tripwire is crap so we have to special case whee!
@@ -495,7 +500,10 @@ public class GameData
             }
             @SuppressWarnings("unchecked")
             Map<Class<? extends Entity>, EntityEntry> map = owner.getSlaveMap(ENTITY_CLASS_TO_ENTRY, Map.class);
-            if (oldEntry != null) map.remove(oldEntry.getEntityClass());
+            if (oldEntry != null)
+            {
+                map.remove(oldEntry.getEntityClass());
+            }
             map.put(entry.getEntityClass(), entry);
         }
 

--- a/src/main/java/net/minecraftforge/registries/GameData.java
+++ b/src/main/java/net/minecraftforge/registries/GameData.java
@@ -288,6 +288,12 @@ public class GameData
             this.identityMap.clear();
             this.objectList.clear();
         }
+
+        void remove(I key)
+        {
+            Integer prev = this.identityMap.remove(key);
+            if (prev != null) this.objectList.set(prev, null);
+        }
     }
 
 
@@ -301,6 +307,12 @@ public class GameData
         {
             @SuppressWarnings("unchecked")
             ClearableObjectIntIdentityMap<IBlockState> blockstateMap = owner.getSlaveMap(BLOCKSTATE_TO_ID, ClearableObjectIntIdentityMap.class);
+
+            if (oldBlock != null)
+            {
+                for (IBlockState state : oldBlock.getBlockState().getValidStates())
+                    blockstateMap.remove(state);
+            }
 
             if ("minecraft:tripwire".equals(block.getRegistryName().toString())) //Tripwire is crap so we have to special case whee!
             {
@@ -387,6 +399,12 @@ public class GameData
         @Override
         public void onAdd(IForgeRegistryInternal<Item> owner, RegistryManager stage, int id, Item item, @Nullable Item oldItem)
         {
+            if (oldItem instanceof ItemBlock)
+            {
+                @SuppressWarnings("unchecked")
+                BiMap<Block, Item> blockToItem = owner.getSlaveMap(BLOCK_TO_ITEM, BiMap.class);
+                blockToItem.remove(((ItemBlock)oldItem).getBlock());
+            }
             if (item instanceof ItemBlock)
             {
                 @SuppressWarnings("unchecked")
@@ -477,6 +495,7 @@ public class GameData
             }
             @SuppressWarnings("unchecked")
             Map<Class<? extends Entity>, EntityEntry> map = owner.getSlaveMap(ENTITY_CLASS_TO_ENTRY, Map.class);
+            if (oldEntry != null) map.remove(oldEntry.getEntityClass());
             map.put(entry.getEntityClass(), entry);
         }
 


### PR DESCRIPTION
As per title, adds code to the various `onAdd` callbacks to remove any entries in slave maps relating to the old value, prior to adding the new value.

This is to ensure the maps don't end up with "orphan" entries that waste space and may cause issues if they show up in queries.