### PR TITLE
Fail fast when null is used with setTag instead of crashing in writeEntry

### DIFF
--- a/patches/minecraft/net/minecraft/nbt/NBTTagCompound.java.patch
+++ b/patches/minecraft/net/minecraft/nbt/NBTTagCompound.java.patch
@@ -1,6 +1,14 @@
 --- ../src-base/minecraft/net/minecraft/nbt/NBTTagCompound.java
 +++ ../src-work/minecraft/net/minecraft/nbt/NBTTagCompound.java
-@@ -477,6 +477,7 @@
+@@ -82,6 +82,7 @@
+ 
+     public void func_74782_a(String p_74782_1_, NBTBase p_74782_2_)
+     {
++        if (p_74782_2_ == null) throw new IllegalArgumentException("Invalid null NBT value with key " + p_74782_1_);
+         this.field_74784_a.put(p_74782_1_, p_74782_2_);
+     }
+ 
+@@ -477,6 +478,7 @@
  
      private static byte func_152447_a(DataInput p_152447_0_, NBTSizeTracker p_152447_1_) throws IOException
      {
@@ -8,7 +16,7 @@
          return p_152447_0_.readByte();
      }
  
-@@ -487,6 +488,7 @@
+@@ -487,6 +489,7 @@
  
      static NBTBase func_152449_a(byte p_152449_0_, String p_152449_1_, DataInput p_152449_2_, int p_152449_3_, NBTSizeTracker p_152449_4_) throws IOException
      {


### PR DESCRIPTION
This attempts to make issues like #5197 easier to debug, by immediately throwing an exception in `setTag` (`put(String, INBTBase)` in later mappings) instead of having it eventually crash with an NPE in `writeEntry` (that doesn't include the tag that was being written).  With this change, the example mod from #5197 still throws an exception, but it doesn't reject saving the chunk and instead the entity is skipped (whether this behavior is correct or not still is a question for that issue, though).

Here's an example of the new log:

```
[09:19:06] [Server thread/ERROR] [FML]: An Entity type net.minecraft.entity.passive.EntityCow has thrown an exception trying to write state. It will not persist. Report this to the mod author
net.minecraft.util.ReportedException: Saving entity NBT
	at net.minecraft.entity.Entity.writeToNBT(Entity.java:1772) ~[Entity.class:?]
	at net.minecraft.entity.Entity.writeToNBTOptional(Entity.java:1654) ~[Entity.class:?]
	at net.minecraft.world.chunk.storage.AnvilChunkLoader.writeChunkToNBT(AnvilChunkLoader.java:361) [AnvilChunkLoader.class:?]
	at net.minecraft.world.chunk.storage.AnvilChunkLoader.saveChunk(AnvilChunkLoader.java:173) [AnvilChunkLoader.class:?]
	at net.minecraft.world.gen.ChunkProviderServer.saveChunkData(ChunkProviderServer.java:202) [ChunkProviderServer.class:?]
	at net.minecraft.world.gen.ChunkProviderServer.saveChunks(ChunkProviderServer.java:230) [ChunkProviderServer.class:?]
	at net.minecraft.world.WorldServer.saveAllChunks(WorldServer.java:1007) [WorldServer.class:?]
	at net.minecraft.server.MinecraftServer.saveAllWorlds(MinecraftServer.java:408) [MinecraftServer.class:?]
	at net.minecraft.server.integrated.IntegratedServer.saveAllWorlds(IntegratedServer.java:252) [IntegratedServer.class:?]
	at net.minecraft.server.integrated.IntegratedServer.tick(IntegratedServer.java:170) [IntegratedServer.class:?]
	at net.minecraft.server.MinecraftServer.run(MinecraftServer.java:526) [MinecraftServer.class:?]
	at java.lang.Thread.run(Thread.java:745) [?:1.8.0_72]
Caused by: java.lang.IllegalArgumentException: Invalid null NBT value with key issuereport:testcapability
	at net.minecraft.nbt.NBTTagCompound.setTag(NBTTagCompound.java:85) ~[NBTTagCompound.class:?]
	at net.minecraftforge.common.capabilities.CapabilityDispatcher.serializeNBT(CapabilityDispatcher.java:123) ~[CapabilityDispatcher.class:?]
	at net.minecraft.entity.Entity.writeToNBT(Entity.java:1741) ~[Entity.class:?]
	... 11 more
```

One thing to note is that I'm only adding a check to that one method, and many of the other methods could also have this issue (e.g. `putString`/`putByteArray`/`putIntArray`/`putLongArray` for the value, and all of them for the key).  Those ones also could have the same issue, but I don't know how beneficial it is to null-check all of them (and I feel like it's harder to accidentally pass null to them by accident).