### PR TITLE
Catch json parsing errors from constants/factories files

### DIFF
--- a/src/main/java/net/minecraftforge/common/crafting/CraftingHelper.java
+++ b/src/main/java/net/minecraftforge/common/crafting/CraftingHelper.java
@@ -367,6 +367,11 @@ public class CraftingHelper {
         return ret;
     }
 
+    public static boolean processConditions(JsonObject json, JsonContext context)
+    {
+        return !json.has("conditions") || processConditions(JsonUtils.getJsonArray(json, "conditions"), context);
+    }
+
     public static boolean processConditions(JsonArray conditions, JsonContext context)
     {
         for (int x = 0; x < conditions.size(); x++)
@@ -706,7 +711,7 @@ public class CraftingHelper {
                 {
                     reader = Files.newBufferedReader(file);
                     JsonObject json = JsonUtils.fromJson(GSON, reader, JsonObject.class);
-                    if (json.has("conditions") && !CraftingHelper.processConditions(JsonUtils.getJsonArray(json, "conditions"), ctx))
+                    if (!processConditions(json, ctx))
                         return true;
                     IRecipe recipe = CraftingHelper.getRecipe(json, ctx);
                     ForgeRegistries.RECIPES.register(recipe.setRegistryName(key));

--- a/src/main/java/net/minecraftforge/common/crafting/CraftingHelper.java
+++ b/src/main/java/net/minecraftforge/common/crafting/CraftingHelper.java
@@ -650,9 +650,9 @@ public class CraftingHelper {
                 loadFactories(json, ctx);
             }
         }
-        catch (IOException e)
+        catch (JsonParseException | IOException e)
         {
-            e.printStackTrace();
+            FMLLog.log.error("Error loading _factories.json: ", e);
         }
         finally
         {
@@ -678,7 +678,7 @@ public class CraftingHelper {
                         JsonObject[] json = JsonUtils.fromJson(GSON, reader, JsonObject[].class);
                         ctx.loadConstants(json);
                     }
-                    catch (IOException e)
+                    catch (JsonParseException | IOException e)
                     {
                         FMLLog.log.error("Error loading _constants.json: ", e);
                         return false;

--- a/src/main/java/net/minecraftforge/common/crafting/CraftingHelper.java
+++ b/src/main/java/net/minecraftforge/common/crafting/CraftingHelper.java
@@ -224,7 +224,7 @@ public class CraftingHelper {
                 if(element.isJsonObject())
                     nbt = JsonToNBT.getTagFromJson(GSON.toJson(element));
                 else
-                    nbt = JsonToNBT.getTagFromJson(element.getAsString());
+                    nbt = JsonToNBT.getTagFromJson(JsonUtils.getString(element, "nbt"));
 
                 NBTTagCompound tmp = new NBTTagCompound();
                 if (nbt.hasKey("ForgeCaps"))

--- a/src/main/java/net/minecraftforge/common/crafting/CraftingHelper.java
+++ b/src/main/java/net/minecraftforge/common/crafting/CraftingHelper.java
@@ -367,9 +367,9 @@ public class CraftingHelper {
         return ret;
     }
 
-    public static boolean processConditions(JsonObject json, JsonContext context)
+    public static boolean processConditions(JsonObject json, String memberName, JsonContext context)
     {
-        return !json.has("conditions") || processConditions(JsonUtils.getJsonArray(json, "conditions"), context);
+        return !json.has(memberName) || processConditions(JsonUtils.getJsonArray(json, memberName), context);
     }
 
     public static boolean processConditions(JsonArray conditions, JsonContext context)
@@ -711,7 +711,7 @@ public class CraftingHelper {
                 {
                     reader = Files.newBufferedReader(file);
                     JsonObject json = JsonUtils.fromJson(GSON, reader, JsonObject.class);
-                    if (!processConditions(json, ctx))
+                    if (!processConditions(json, "conditions", ctx))
                         return true;
                     IRecipe recipe = CraftingHelper.getRecipe(json, ctx);
                     ForgeRegistries.RECIPES.register(recipe.setRegistryName(key));

--- a/src/main/java/net/minecraftforge/common/crafting/JsonContext.java
+++ b/src/main/java/net/minecraftforge/common/crafting/JsonContext.java
@@ -62,7 +62,7 @@ public class JsonContext
     {
         for (JsonObject json : jsons)
         {
-            if (json.has("conditions") && !CraftingHelper.processConditions(JsonUtils.getJsonArray(json, "conditions"), this))
+            if (!CraftingHelper.processConditions(json, this))
                 continue;
             if (!json.has("ingredient"))
                 throw new JsonSyntaxException("Constant entry must contain 'ingredient' value");

--- a/src/main/java/net/minecraftforge/common/crafting/JsonContext.java
+++ b/src/main/java/net/minecraftforge/common/crafting/JsonContext.java
@@ -62,7 +62,7 @@ public class JsonContext
     {
         for (JsonObject json : jsons)
         {
-            if (!CraftingHelper.processConditions(json, this))
+            if (!CraftingHelper.processConditions(json, "conditions", this))
                 continue;
             if (!json.has("ingredient"))
                 throw new JsonSyntaxException("Constant entry must contain 'ingredient' value");

--- a/src/main/java/net/minecraftforge/common/crafting/JsonContext.java
+++ b/src/main/java/net/minecraftforge/common/crafting/JsonContext.java
@@ -62,7 +62,7 @@ public class JsonContext
     {
         for (JsonObject json : jsons)
         {
-            if (json.has("conditions") && !CraftingHelper.processConditions(json.getAsJsonArray("conditions"), this))
+            if (json.has("conditions") && !CraftingHelper.processConditions(JsonUtils.getJsonArray(json, "conditions"), this))
                 continue;
             if (!json.has("ingredient"))
                 throw new JsonSyntaxException("Constant entry must contain 'ingredient' value");


### PR DESCRIPTION
Updates some `CraftingHelper` code to also catch `JsonParseException` in addition to `IOException`, similarly to other code in that class. Currently, syntax errors in `_constants.json` or `_factories.json` files will crash the game on load.

Also fixes a couple of similar issues to the issue previously fixed by #4043.