### PR TITLE
[1.12] Team Events

### DIFF
--- a/patches/minecraft/net/minecraft/scoreboard/Scoreboard.java.patch
+++ b/patches/minecraft/net/minecraft/scoreboard/Scoreboard.java.patch
@@ -1,0 +1,42 @@
+--- ../src-base/minecraft/net/minecraft/scoreboard/Scoreboard.java
++++ ../src-work/minecraft/net/minecraft/scoreboard/Scoreboard.java
+@@ -272,6 +272,7 @@
+         for (String s : p_96511_1_.func_96670_d())
+         {
+             this.field_96540_f.remove(s);
++            net.minecraftforge.common.MinecraftForge.EVENT_BUS.post(new net.minecraftforge.event.entity.TeamEvent.LeaveTeamEvent(p_96511_1_, s));
+         }
+ 
+         this.func_96513_c(p_96511_1_);
+@@ -298,6 +299,7 @@
+ 
+             this.field_96540_f.put(p_151392_1_, scoreplayerteam);
+             scoreplayerteam.func_96670_d().add(p_151392_1_);
++            net.minecraftforge.common.MinecraftForge.EVENT_BUS.post(new net.minecraftforge.event.entity.TeamEvent.JoinTeamEvent(scoreplayerteam, p_151392_1_));
+             return true;
+         }
+     }
+@@ -327,6 +329,7 @@
+         {
+             this.field_96540_f.remove(p_96512_1_);
+             p_96512_2_.func_96670_d().remove(p_96512_1_);
++            net.minecraftforge.common.MinecraftForge.EVENT_BUS.post(new net.minecraftforge.event.entity.TeamEvent.LeaveTeamEvent(p_96512_2_, p_96512_1_));
+         }
+     }
+ 
+@@ -372,6 +375,7 @@
+ 
+     public void func_96523_a(ScorePlayerTeam p_96523_1_)
+     {
++        net.minecraftforge.common.MinecraftForge.EVENT_BUS.post(new net.minecraftforge.event.entity.TeamEvent.CreateTeamEvent(p_96523_1_));
+     }
+ 
+     public void func_96538_b(ScorePlayerTeam p_96538_1_)
+@@ -380,6 +384,7 @@
+ 
+     public void func_96513_c(ScorePlayerTeam p_96513_1_)
+     {
++        net.minecraftforge.common.MinecraftForge.EVENT_BUS.post(new net.minecraftforge.event.entity.TeamEvent.RemoveTeamEvent(p_96513_1_));
+     }
+ 
+     public static String func_96517_b(int p_96517_0_)

--- a/src/main/java/net/minecraftforge/event/entity/TeamEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/TeamEvent.java
@@ -1,0 +1,86 @@
+/*
+ * Minecraft Forge
+ * Copyright (c) 2016-2018.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation version 2.1
+ * of the License.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+package net.minecraftforge.event.entity;
+
+import net.minecraft.scoreboard.Team;
+import net.minecraftforge.fml.common.eventhandler.Event;
+
+public class TeamEvent extends Event
+{
+    private final Team team;
+
+    public TeamEvent(Team team)
+    {
+        this.team = team;
+    }
+
+    public Team getTeam()
+    {
+        return this.team;
+    }
+
+    public static class CreateTeamEvent extends TeamEvent
+    {
+        public CreateTeamEvent(Team team)
+        {
+            super(team);
+        }
+    }
+
+    public static class RemoveTeamEvent extends TeamEvent
+    {
+        public RemoveTeamEvent(Team team)
+        {
+            super(team);
+        }
+    }
+
+    public static class EntityTeamEvent extends TeamEvent
+    {
+        private final String entityName;
+
+        public EntityTeamEvent(Team team, String entityName)
+        {
+            super(team);
+            this.entityName = entityName;
+        }
+
+        public String getEntityName()
+        {
+            return this.entityName;
+        }
+    }
+
+    public static class JoinTeamEvent extends EntityTeamEvent
+    {
+        public JoinTeamEvent(Team team, String entity)
+        {
+            super(team, entity);
+        }
+    }
+
+    public static class LeaveTeamEvent extends EntityTeamEvent
+    {
+        public LeaveTeamEvent(Team team, String entity)
+        {
+            super(team, entity);
+        }
+    }
+}

--- a/src/test/java/net/minecraftforge/debug/entity/TeamEventTest.java
+++ b/src/test/java/net/minecraftforge/debug/entity/TeamEventTest.java
@@ -1,0 +1,51 @@
+package net.minecraftforge.debug.entity;
+
+import net.minecraftforge.common.MinecraftForge;
+import net.minecraftforge.event.entity.ProjectileImpactEvent;
+import net.minecraftforge.event.entity.TeamEvent;
+import net.minecraftforge.fml.common.Mod;
+import net.minecraftforge.fml.common.event.FMLPreInitializationEvent;
+import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
+import org.apache.logging.log4j.Logger;
+
+@Mod(modid = "team_event_test", name = "TeamEvent Test Mod", version = "1.0", acceptableRemoteVersions = "*")
+public class TeamEventTest
+{
+    private static final boolean ENABLED = false;
+    private static Logger logger;
+
+    @Mod.EventHandler
+    public void preInit(FMLPreInitializationEvent event)
+    {
+        logger = event.getModLog();
+
+        if (ENABLED)
+        {
+            MinecraftForge.EVENT_BUS.register(TeamEventTest.class);
+        }
+    }
+
+    @SubscribeEvent
+    public static void onTeamCreated(TeamEvent.CreateTeamEvent event)
+    {
+        logger.info("Team Created: {}", event.getTeam().getName());
+    }
+
+    @SubscribeEvent
+    public static void onTeamRemoved(TeamEvent.RemoveTeamEvent event)
+    {
+        logger.info("Team Removed: {}", event.getTeam().getName());
+    }
+
+    @SubscribeEvent
+    public static void onTeamEntityLeave(TeamEvent.LeaveTeamEvent event)
+    {
+        logger.info("Entity {} left Team {}", event.getEntityName(), event.getTeam().getName());
+    }
+
+    @SubscribeEvent
+    public static void onTeamEntityJoin(TeamEvent.JoinTeamEvent event)
+    {
+        logger.info("Entity {} joined Team {}", event.getEntityName(), event.getTeam().getName());
+    }
+}

--- a/src/test/java/net/minecraftforge/debug/entity/TeamEventTest.java
+++ b/src/test/java/net/minecraftforge/debug/entity/TeamEventTest.java
@@ -1,7 +1,25 @@
+/*
+ * Minecraft Forge
+ * Copyright (c) 2016-2018.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation version 2.1
+ * of the License.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
 package net.minecraftforge.debug.entity;
 
 import net.minecraftforge.common.MinecraftForge;
-import net.minecraftforge.event.entity.ProjectileImpactEvent;
 import net.minecraftforge.event.entity.TeamEvent;
 import net.minecraftforge.fml.common.Mod;
 import net.minecraftforge.fml.common.event.FMLPreInitializationEvent;


### PR DESCRIPTION
Add a few new events for notifying changes in Teams (Team Creation/Removal, Join/Leaving), which should make it a bit easier to integration into Vanilla Teams.