### PR TITLE
Remove FluidStack amount from hashcode calculation

### DIFF
--- a/src/main/java/net/minecraftforge/fluids/FluidStack.java
+++ b/src/main/java/net/minecraftforge/fluids/FluidStack.java
@@ -208,7 +208,6 @@ public class FluidStack
     {
         int code = 1;
         code = 31*code + getFluid().hashCode();
-        code = 31*code + amount;
         if (tag != null)
             code = 31*code + tag.hashCode();
         return code;


### PR DESCRIPTION
The current implementation of FluidStack#hashcode and FluidStack#equals breaks the implementation contract for these methods.

Specifically, this is not true:
>If two objects are equal according to the equals(Object) method, then calling the hashCode method on each of the two objects must produce the same integer result.


Alternatively, this could be solved by directing FluidStack#equals to the FluidStack#isFluidStackIdentical function. Though this is probably more likely to break existing code than the proposed solution of removing the amount from the hashcode calc.

I'm not specifically aware of what effects this bug has, I only discovered it via code inspection rather that debugging. So I'm not particularly fussed about the outcome of this PR, but I felt it at least deserved a discussion.