### PR TITLE
Added JVM argument so dll extraction works, closes #5282

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -140,7 +140,7 @@ project(':forge') {
             properties = [
                 'org.lwjgl.util.Debug': 'true',
                 'org.lwjgl.util.DebugLoader': 'true',
-                'org.lwjgl.system.SharedLibraryExtractDirectory': 'lwjgl_dll',
+                'org.lwjgl.system.SharedLibraryExtractDirectory': "lwjgl_dll",
                 'mc.version': MC_VERSION,
                 'mcp.version': MCP_VERSION,
                 'forge.version': "${project.version.substring(MC_VERSION.length() + 1)}".toString(),

--- a/build.gradle
+++ b/build.gradle
@@ -140,6 +140,7 @@ project(':forge') {
             properties = [
                 'org.lwjgl.util.Debug': 'true',
                 'org.lwjgl.util.DebugLoader': 'true',
+                'org.lwjgl.system.SharedLibraryExtractDirectory': 'lwjgl_dll',
                 'mc.version': MC_VERSION,
                 'mcp.version': MCP_VERSION,
                 'forge.version': "${project.version.substring(MC_VERSION.length() + 1)}".toString(),

--- a/build.gradle
+++ b/build.gradle
@@ -140,7 +140,7 @@ project(':forge') {
             properties = [
                 'org.lwjgl.util.Debug': 'true',
                 'org.lwjgl.util.DebugLoader': 'true',
-                'org.lwjgl.system.SharedLibraryExtractDirectory': "lwjgl_dll",
+                'org.lwjgl.system.SharedLibraryExtractDirectory': 'lwjgl_dll',
                 'mc.version': MC_VERSION,
                 'mcp.version': MCP_VERSION,
                 'forge.version': "${project.version.substring(MC_VERSION.length() + 1)}".toString(),


### PR DESCRIPTION
This fixes #5282 by adding a needed JVM argument. 

**Issue:**
the library extractor uses the local temp directory and and as subdir "<lib name>+<user name>". Username is fetched from the system property "user.name". This name can apprently be wrong (which happened to me) so the directy gets wrongly created and the extracted dlls get not found.
**This Solution:**
By specifing another extracting directory we can make sure this directory will always works, even if the username is wrong in the JVM.

[Log output without fix](https://gist.github.com/mcenderdragon/8fce947b13323246f73332209436110f)
L[og output with fix](https://gist.github.com/mcenderdragon/f74d788f9192f33803e94b759bc76750)