### PR TITLE
Set Context's getNetworkManger() to public to allow for grabbing of a…

### DIFF
--- a/src/main/java/net/minecraftforge/fml/network/NetworkEvent.java
+++ b/src/main/java/net/minecraftforge/fml/network/NetworkEvent.java
@@ -170,7 +170,7 @@ public class NetworkEvent extends Event
             return (ListenableFuture<V>)LogicalSidedProvider.WORKQUEUE.<IThreadListener>get(getDirection().getLogicalSide()).addScheduledTask(runnable);
         }
 
-        NetworkManager getNetworkManager() {
+        public NetworkManager getNetworkManager() {
             return networkManager;
         }
     }


### PR DESCRIPTION
… player object via NetworkManager.