### PR TITLE
Added an additional constructor to every implementation of IFluidBlock..

### DIFF
--- a/src/main/java/net/minecraftforge/fluids/BlockFluidBase.java
+++ b/src/main/java/net/minecraftforge/fluids/BlockFluidBase.java
@@ -31,6 +31,7 @@ import com.google.common.collect.Maps;
 import net.minecraft.block.Block;
 import net.minecraft.block.BlockLiquid;
 import net.minecraft.block.BlockStairs;
+import net.minecraft.block.material.MapColor;
 import net.minecraft.block.material.Material;
 import net.minecraft.block.properties.PropertyBool;
 import net.minecraft.block.properties.PropertyInteger;
@@ -162,9 +163,9 @@ public abstract class BlockFluidBase extends Block implements IFluidBlock
      */
     protected final Fluid definedFluid;
 
-    public BlockFluidBase(Fluid fluid, Material material)
+    public BlockFluidBase(Fluid fluid, Material material, MapColor mapColor)
     {
-        super(material);
+        super(material, mapColor);
         this.setTickRandomly(true);
         this.disableStats();
 
@@ -179,6 +180,11 @@ public abstract class BlockFluidBase extends Block implements IFluidBlock
         this.definedFluid = fluid;
         displacements.putAll(defaultDisplacements);
         this.setDefaultState(blockState.getBaseState().withProperty(LEVEL, getMaxRenderHeightMeta()));
+    }
+
+    public BlockFluidBase(Fluid fluid, Material material)
+    {
+        this(fluid, material, material.getMaterialMapColor());
     }
 
     @Override

--- a/src/main/java/net/minecraftforge/fluids/BlockFluidClassic.java
+++ b/src/main/java/net/minecraftforge/fluids/BlockFluidClassic.java
@@ -26,6 +26,7 @@ import java.util.Random;
 
 import com.google.common.primitives.Ints;
 
+import net.minecraft.block.material.MapColor;
 import net.minecraft.block.material.Material;
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.util.EnumFacing;
@@ -55,10 +56,15 @@ public class BlockFluidClassic extends BlockFluidBase
 
     protected FluidStack stack;
 
+    public BlockFluidClassic(Fluid fluid, Material material, MapColor mapColor)
+    {
+        super(fluid, material, mapColor);
+        stack = new FluidStack(fluid, Fluid.BUCKET_VOLUME);
+    }
+
     public BlockFluidClassic(Fluid fluid, Material material)
     {
-        super(fluid, material);
-        stack = new FluidStack(fluid, Fluid.BUCKET_VOLUME);
+        this(fluid, material, material.getMaterialMapColor());
     }
 
     public BlockFluidClassic setFluidStack(FluidStack stack)

--- a/src/main/java/net/minecraftforge/fluids/BlockFluidFinite.java
+++ b/src/main/java/net/minecraftforge/fluids/BlockFluidFinite.java
@@ -21,6 +21,7 @@ package net.minecraftforge.fluids;
 
 import java.util.Random;
 
+import net.minecraft.block.material.MapColor;
 import net.minecraft.block.material.Material;
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.util.math.BlockPos;
@@ -39,9 +40,14 @@ import javax.annotation.Nonnull;
  */
 public class BlockFluidFinite extends BlockFluidBase
 {
+    public BlockFluidFinite(Fluid fluid, Material material, MapColor mapColor)
+    {
+        super(fluid, material, mapColor);
+    }
+
     public BlockFluidFinite(Fluid fluid, Material material)
     {
-        super(fluid, material);
+        this(fluid, material, material.getMaterialMapColor());
     }
 
     @Override


### PR DESCRIPTION
It is now possible to create a fluid block with a Fluid, Material and MapColor, so that the Material's MapColor isn't used for the blocks MapColor.
This should be useful for many mods, which add new fluids and use Material.WATER, so that they don't have to add events for many of the hardcoded Material.WATER checks, but their new fluid block has a different color than the water color and they want it to be shown on maps.