### PR TITLE
Add ModelRotationEvent

### DIFF
--- a/patches/minecraft/net/minecraft/client/renderer/entity/RenderLivingBase.java.patch
+++ b/patches/minecraft/net/minecraft/client/renderer/entity/RenderLivingBase.java.patch
@@ -33,7 +33,7 @@
              {
                  EntityLivingBase entitylivingbase = (EntityLivingBase)p_76986_1_.func_184187_bx();
                  f = this.func_77034_a(entitylivingbase.field_70760_ar, entitylivingbase.field_70761_aq, p_76986_9_);
-@@ -133,6 +138,7 @@
+@@ -133,12 +138,13 @@
                  {
                      f5 = 1.0F;
                  }
@@ -41,6 +41,13 @@
              }
  
              GlStateManager.func_179141_d();
+             this.field_77045_g.func_78086_a(p_76986_1_, f6, f5, p_76986_9_);
+             this.field_77045_g.func_78087_a(f6, f5, f8, f2, f7, f4, p_76986_1_);
+-
++            net.minecraftforge.common.MinecraftForge.EVENT_BUS.post(new net.minecraftforge.client.event.ModelRotationEvent(this, f6, f5, f8, f2, f7, f4, p_76986_1_));
+             if (this.field_188301_f)
+             {
+                 boolean flag1 = this.func_177088_c(p_76986_1_);
 @@ -194,6 +200,7 @@
          GlStateManager.func_179089_o();
          GlStateManager.func_179121_F();

--- a/src/main/java/net/minecraftforge/client/event/ModelRotationEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/ModelRotationEvent.java
@@ -1,0 +1,60 @@
+package net.minecraftforge.client.event;
+
+import net.minecraft.client.renderer.entity.RenderLivingBase;
+import net.minecraft.entity.Entity;
+import net.minecraftforge.fml.common.eventhandler.Event;
+
+/**
+ * Allows modification to the entity model before being rendered.
+ */
+public class ModelRotationEvent extends Event{
+
+	private final RenderLivingBase<?> render;
+	private final float limbSwing, limbSwingAmount, ageInTicks, netHeadYaw, headPitch;
+	private final Entity entity;
+	public ModelRotationEvent(RenderLivingBase<?> render, float limbSwing, float limbSwingAmount, float ageInTicks, float netHeadYaw, float headPitch,
+			float scaleFactor, Entity entity) {
+		this.render=render;
+		this.limbSwing=limbSwing;
+		this.limbSwingAmount=limbSwingAmount;
+		this.ageInTicks=ageInTicks;
+		this.netHeadYaw=netHeadYaw;
+		this.headPitch=headPitch;
+		this.entity=entity;
+	}
+	
+	public RenderLivingBase<?> getRender()
+	{
+		return this.render;
+	}
+	
+	public float getLimbSwing()
+	{
+		return this.limbSwing;
+	}
+	
+	public float getLimbSwingAmount()
+	{
+		return this.limbSwingAmount;
+	}
+	
+	public float getAgeInTicks()
+	{
+		return this.ageInTicks;
+	}
+	
+	public float getNetHeadYaw()
+	{
+		return this.netHeadYaw;
+	}
+	
+	public float getHeadPitch()
+	{
+		return this.headPitch;
+	}
+	
+	public Entity getEntity()
+	{
+		return this.entity;
+	}
+}

--- a/src/main/java/net/minecraftforge/client/event/ModelRotationEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/ModelRotationEvent.java
@@ -7,13 +7,14 @@ import net.minecraftforge.fml.common.eventhandler.Event;
 /**
  * Allows modification to the entity model before being rendered.
  */
-public class ModelRotationEvent extends Event{
-
+public class ModelRotationEvent extends Event
+{
 	private final RenderLivingBase<?> render;
 	private final float limbSwing, limbSwingAmount, ageInTicks, netHeadYaw, headPitch;
 	private final Entity entity;
-	public ModelRotationEvent(RenderLivingBase<?> render, float limbSwing, float limbSwingAmount, float ageInTicks, float netHeadYaw, float headPitch,
-			float scaleFactor, Entity entity) {
+	
+	public ModelRotationEvent(RenderLivingBase<?> render, float limbSwing, float limbSwingAmount, float ageInTicks, float netHeadYaw, float headPitch, float scaleFactor, Entity entity) 
+	{
 		this.render=render;
 		this.limbSwing=limbSwing;
 		this.limbSwingAmount=limbSwingAmount;

--- a/src/test/java/net/minecraftforge/debug/client/ModelRotationEventTest.java
+++ b/src/test/java/net/minecraftforge/debug/client/ModelRotationEventTest.java
@@ -1,0 +1,56 @@
+/*
+ * Minecraft Forge
+ * Copyright (c) 2016-2018.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation version 2.1
+ * of the License.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+package net.minecraftforge.debug.client;
+
+import net.minecraft.client.model.ModelBiped;
+import net.minecraftforge.client.event.ModelRotationEvent;
+import net.minecraftforge.common.MinecraftForge;
+import net.minecraftforge.fml.common.Mod;
+import net.minecraftforge.fml.common.Mod.EventHandler;
+import net.minecraftforge.fml.common.event.FMLInitializationEvent;
+import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
+
+/**
+ * Example mod to test ModelRotationEvent.
+ */
+@Mod(modid = "modelrotationtest", name = "Model Rotation Test", version = "0.0.0", clientSideOnly = true)
+public class ModelRotationEventTest
+{
+    static final boolean ENABLED = true;
+
+    @EventHandler
+    public void init(FMLInitializationEvent event)
+    {
+        if (ENABLED)
+        {
+            MinecraftForge.EVENT_BUS.register(this);
+        }
+    }
+
+    @SubscribeEvent
+    public void modelEvent(ModelRotationEvent event)
+    {
+		if(event.getRender().getMainModel() instanceof ModelBiped)
+		{
+			ModelBiped model = (ModelBiped) event.getRender().getMainModel();
+			model.bipedHead.showModel=false;	
+		}
+    }
+}

--- a/src/test/java/net/minecraftforge/debug/client/ModelRotationEventTest.java
+++ b/src/test/java/net/minecraftforge/debug/client/ModelRotationEventTest.java
@@ -33,7 +33,7 @@ import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
 @Mod(modid = "modelrotationtest", name = "Model Rotation Test", version = "0.0.0", clientSideOnly = true)
 public class ModelRotationEventTest
 {
-    static final boolean ENABLED = true;
+    static final boolean ENABLED = false;
 
     @EventHandler
     public void init(FMLInitializationEvent event)


### PR DESCRIPTION
Adds an event in RenderLivingBase.doRender just before the actual model is rendered. This allows to modify the models rotation etc. (including the players). 