### PR TITLE
Annotation Config Expansion

### DIFF
--- a/src/main/java/net/minecraftforge/common/config/FieldWrapper.java
+++ b/src/main/java/net/minecraftforge/common/config/FieldWrapper.java
@@ -508,7 +508,7 @@ public abstract class FieldWrapper implements IFieldWrapper
         @Override
         public ITypeAdapter getTypeAdapter()
         {
-            return TypeAdapters.Str;
+            return TypeAdapters.StrA;
         }
 
         @Override

--- a/src/main/java/net/minecraftforge/common/config/IConfigValue.java
+++ b/src/main/java/net/minecraftforge/common/config/IConfigValue.java
@@ -1,0 +1,10 @@
+package net.minecraftforge.common.config;
+
+public interface IConfigValue {
+	
+	public IConfigValue readFromString(String s);
+	
+	public String writeToString();
+
+	public String usage();
+}

--- a/src/main/java/net/minecraftforge/common/config/IConfigValue.java
+++ b/src/main/java/net/minecraftforge/common/config/IConfigValue.java
@@ -1,6 +1,26 @@
+/*
+ * Minecraft Forge
+ * Copyright (c) 2016-2018.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation version 2.1
+ * of the License.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
 package net.minecraftforge.common.config;
 
-public interface IConfigValue {
+public interface IConfigValue 
+{
 	
 	public IConfigValue readFromString(String s);
 	

--- a/src/main/java/net/minecraftforge/common/config/IConfigValueArray.java
+++ b/src/main/java/net/minecraftforge/common/config/IConfigValueArray.java
@@ -1,6 +1,26 @@
+/*
+ * Minecraft Forge
+ * Copyright (c) 2016-2018.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation version 2.1
+ * of the License.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
 package net.minecraftforge.common.config;
 
-public interface IConfigValueArray {
+public interface IConfigValueArray 
+{
 	
 	public IConfigValueArray readFromString(String[] s);
 	

--- a/src/main/java/net/minecraftforge/common/config/IConfigValueArray.java
+++ b/src/main/java/net/minecraftforge/common/config/IConfigValueArray.java
@@ -1,0 +1,10 @@
+package net.minecraftforge.common.config;
+
+public interface IConfigValueArray {
+	
+	public IConfigValueArray readFromString(String[] s);
+	
+	public String[] writeToString();
+
+	public String usage();
+}

--- a/src/test/java/net/minecraftforge/debug/mod/ConfigAnnotationTest.java
+++ b/src/test/java/net/minecraftforge/debug/mod/ConfigAnnotationTest.java
@@ -135,7 +135,7 @@ public class ConfigAnnotationTest
         public static String[]    StrA = {"STR", "ING!"};
         public static TEST        enu = TEST.BIG;
         public static NestedType  Inner = new NestedType();
-        public static IConfigValue aValue = new IConfigValue() {
+        public static IConfigValue IConfigValue = new IConfigValue() {
         	private String insideString = "defaultValue";
 			@Override
 			public IConfigValue readFromString(String s) {
@@ -150,7 +150,7 @@ public class ConfigAnnotationTest
 			public String usage() {
 				return "Saves a string";
 			}};
-		public static IConfigValueArray aValueArray = new IConfigValueArray() {
+		public static IConfigValueArray IConfigValueArray = new IConfigValueArray() {
 			private String[] array = new String[] {"defaultA","defaultB"};
 			@Override
 			public IConfigValueArray readFromString(String[] s) {

--- a/src/test/java/net/minecraftforge/debug/mod/ConfigAnnotationTest.java
+++ b/src/test/java/net/minecraftforge/debug/mod/ConfigAnnotationTest.java
@@ -19,7 +19,14 @@
 
 package net.minecraftforge.debug.mod;
 
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.apache.logging.log4j.Logger;
+
 import com.google.common.collect.Maps;
+
 import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.common.config.Config;
 import net.minecraftforge.common.config.Config.Comment;
@@ -30,16 +37,13 @@ import net.minecraftforge.common.config.Config.RangeInt;
 import net.minecraftforge.common.config.Config.RequiresMcRestart;
 import net.minecraftforge.common.config.Config.Type;
 import net.minecraftforge.common.config.ConfigManager;
+import net.minecraftforge.common.config.IConfigValue;
+import net.minecraftforge.common.config.IConfigValueArray;
 import net.minecraftforge.fml.client.event.ConfigChangedEvent.OnConfigChangedEvent;
 import net.minecraftforge.fml.common.Mod;
 import net.minecraftforge.fml.common.event.FMLInitializationEvent;
 import net.minecraftforge.fml.common.event.FMLPreInitializationEvent;
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
-import org.apache.logging.log4j.Logger;
-
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.Map;
 
 @Mod(modid = ConfigAnnotationTest.MODID, name = "ConfigTest", version = "1.0", acceptableRemoteVersions = "*")
 public class ConfigAnnotationTest
@@ -131,7 +135,37 @@ public class ConfigAnnotationTest
         public static String[]    StrA = {"STR", "ING!"};
         public static TEST        enu = TEST.BIG;
         public static NestedType  Inner = new NestedType();
-
+        public static IConfigValue aValue = new IConfigValue() {
+        	private String insideString = "defaultValue";
+			@Override
+			public IConfigValue readFromString(String s) {
+				this.insideString=s;
+				return this;
+			}
+			@Override
+			public String writeToString() {
+				return this.insideString;
+			}
+			@Override
+			public String usage() {
+				return "Saves a string";
+			}};
+		public static IConfigValueArray aValueArray = new IConfigValueArray() {
+			private String[] array = new String[] {"defaultA","defaultB"};
+			@Override
+			public IConfigValueArray readFromString(String[] s) {
+				this.array=s;
+				return this;
+			}
+			@Override
+			public String[] writeToString() {
+				return this.array;
+			}
+			@Override
+			public String usage() {
+				return "Saves an array of strings";
+			}};	
+			
         public enum TEST { BIG, BAD, WOLF; }
         public static class NestedType
         {


### PR DESCRIPTION
Adds an interface IConfigValue and IConfigValueArray to the annotation based config system. It reads a string/string-array value from the config to do stuff. E.g. get an itemstack from the string. (See a non released mod of mine: https://github.com/Flemmli97/TenshiLib/blob/master/src/main/java/com/flemmli97/tenshilib/api/config/ItemWrapper.java).
This can save the user the hassle of manually updating values during a config change event. 