### PR TITLE
[1.12.2] Add a few events pertaining to villages

### DIFF
--- a/patches/minecraft/net/minecraft/entity/NpcMerchant.java.patch
+++ b/patches/minecraft/net/minecraft/entity/NpcMerchant.java.patch
@@ -1,0 +1,11 @@
+--- ../src-base/minecraft/net/minecraft/entity/NpcMerchant.java
++++ ../src-work/minecraft/net/minecraft/entity/NpcMerchant.java
+@@ -41,7 +41,7 @@
+     @Nullable
+     public MerchantRecipeList func_70934_b(EntityPlayer p_70934_1_)
+     {
+-        return this.field_70936_c;
++        return net.minecraftforge.event.ForgeEventFactory.listTradeOffers(this, p_70934_1_, this.field_70936_c);
+     }
+ 
+     public void func_70930_a(@Nullable MerchantRecipeList p_70930_1_)

--- a/patches/minecraft/net/minecraft/entity/passive/EntityVillager.java.patch
+++ b/patches/minecraft/net/minecraft/entity/passive/EntityVillager.java.patch
@@ -122,7 +122,13 @@
              }
              else
              {
-@@ -617,15 +656,13 @@
+@@ -612,20 +651,18 @@
+             this.func_175554_cu();
+         }
+ 
+-        return this.field_70963_i;
++        return net.minecraftforge.event.ForgeEventFactory.listTradeOffers(this, p_70934_1_, field_70963_i);
+     }
  
      private void func_175554_cu()
      {

--- a/patches/minecraft/net/minecraft/village/VillageSiege.java.patch
+++ b/patches/minecraft/net/minecraft/village/VillageSiege.java.patch
@@ -1,0 +1,10 @@
+--- ../src-base/minecraft/net/minecraft/village/VillageSiege.java
++++ ../src-work/minecraft/net/minecraft/village/VillageSiege.java
+@@ -146,6 +146,7 @@
+ 
+                     if (vec3d != null)
+                     {
++                        if (net.minecraftforge.common.MinecraftForge.EVENT_BUS.post(new net.minecraftforge.event.village.VillageSiegeEvent(this, field_75537_a, entityplayer, field_75531_f, vec3d))) return false;
+                         break;
+                     }
+                 }

--- a/src/main/java/net/minecraftforge/event/ForgeEventFactory.java
+++ b/src/main/java/net/minecraftforge/event/ForgeEventFactory.java
@@ -31,6 +31,7 @@ import net.minecraft.entity.Entity;
 import net.minecraft.entity.EntityLiving;
 import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.entity.EnumCreatureType;
+import net.minecraft.entity.IMerchant;
 import net.minecraft.entity.effect.EntityLightningBolt;
 import net.minecraft.entity.item.EntityItem;
 import net.minecraft.entity.monster.EntityZombie;
@@ -60,6 +61,7 @@ import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.RayTraceResult;
 import net.minecraft.util.text.ChatType;
 import net.minecraft.util.text.ITextComponent;
+import net.minecraft.village.MerchantRecipeList;
 import net.minecraft.village.Village;
 import net.minecraft.world.Explosion;
 import net.minecraft.world.GameRules;
@@ -120,6 +122,7 @@ import net.minecraftforge.event.entity.player.UseHoeEvent;
 import net.minecraftforge.event.furnace.FurnaceFuelBurnTimeEvent;
 import net.minecraftforge.event.terraingen.ChunkGeneratorEvent;
 import net.minecraftforge.event.terraingen.PopulateChunkEvent;
+import net.minecraftforge.event.village.MerchantTradeOffersEvent;
 import net.minecraftforge.event.world.BlockEvent;
 import net.minecraftforge.event.world.BlockEvent.CreateFluidSourceEvent;
 import net.minecraftforge.event.world.BlockEvent.MultiPlaceEvent;
@@ -798,5 +801,18 @@ public class ForgeEventFactory
     public static void onGameRuleChange(GameRules rules, String ruleName, MinecraftServer server)
     {
         MinecraftForge.EVENT_BUS.post(new GameRuleChangeEvent(rules, ruleName, server));
+    }
+    
+    public static MerchantRecipeList listTradeOffers(IMerchant merchant, EntityPlayer player, @Nullable MerchantRecipeList list)
+    {
+        MerchantRecipeList dupeList = null;
+        if (list != null)
+        {
+            dupeList = new MerchantRecipeList();
+            dupeList.addAll(list);
+        }
+        MerchantTradeOffersEvent event = new MerchantTradeOffersEvent(merchant, player, dupeList);
+        MinecraftForge.EVENT_BUS.post(event);
+        return event.getList();
     }
 }

--- a/src/main/java/net/minecraftforge/event/village/MerchantTradeOffersEvent.java
+++ b/src/main/java/net/minecraftforge/event/village/MerchantTradeOffersEvent.java
@@ -1,3 +1,22 @@
+/*
+ * Minecraft Forge
+ * Copyright (c) 2016-2018.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation version 2.1
+ * of the License.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
 package net.minecraftforge.event.village;
 
 import javax.annotation.Nullable;

--- a/src/main/java/net/minecraftforge/event/village/MerchantTradeOffersEvent.java
+++ b/src/main/java/net/minecraftforge/event/village/MerchantTradeOffersEvent.java
@@ -1,0 +1,61 @@
+package net.minecraftforge.event.village;
+
+import javax.annotation.Nullable;
+
+import net.minecraft.entity.IMerchant;
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.village.MerchantRecipeList;
+import net.minecraftforge.common.MinecraftForge;
+import net.minecraftforge.fml.common.eventhandler.Cancelable;
+import net.minecraftforge.fml.common.eventhandler.Event;
+import net.minecraftforge.fml.common.eventhandler.Event.HasResult;
+
+/**
+ * MerchantTradeOffersEvent is fired when a list of villager trade offers is presented in
+ * {@link IMerchant#getRecipes(EntityPlayer)}, allowing mods to modify trade offers depending
+ * on the player.<br>
+ * <br>
+ * This event is not {@link Cancelable}.<br>
+ * <br>
+ * This event does not have a result. {@link HasResult}<br>
+ * <br>
+ * This event is fired on the {@link MinecraftForge#EVENT_BUS}.
+ */
+public class MerchantTradeOffersEvent extends Event
+{
+    private final IMerchant merchant;
+    private final EntityPlayer player;
+    private @Nullable MerchantRecipeList list;
+    
+    public MerchantTradeOffersEvent(IMerchant merchant, EntityPlayer player, @Nullable MerchantRecipeList list)
+    {
+        this.merchant = merchant;
+        this.player = player;
+        this.list = list;
+    }
+
+    /**
+     * The recipe list (if not {@code null}) returned from this function may be modified.
+     * @return the recipe list
+     */
+    public @Nullable MerchantRecipeList getList()
+    {
+        return list;
+    }
+
+    public void setList(@Nullable MerchantRecipeList list)
+    {
+        this.list = list;
+    }
+
+    public IMerchant getMerchant()
+    {
+        return merchant;
+    }
+
+    public EntityPlayer getPlayer()
+    {
+        return player;
+    }
+
+}

--- a/src/main/java/net/minecraftforge/event/village/MerchantTradeOffersEvent.java
+++ b/src/main/java/net/minecraftforge/event/village/MerchantTradeOffersEvent.java
@@ -13,7 +13,8 @@ import net.minecraftforge.fml.common.eventhandler.Event.HasResult;
 /**
  * MerchantTradeOffersEvent is fired when a list of villager trade offers is presented in
  * {@link IMerchant#getRecipes(EntityPlayer)}, allowing mods to modify trade offers depending
- * on the player.<br>
+ * on the player. Be warned that this event is fired on both server and client; thus, modders
+ * should ensure that they sync the needed data for this event themselves.<br>
  * <br>
  * This event is not {@link Cancelable}.<br>
  * <br>

--- a/src/main/java/net/minecraftforge/event/village/VillageSiegeEvent.java
+++ b/src/main/java/net/minecraftforge/event/village/VillageSiegeEvent.java
@@ -1,3 +1,22 @@
+/*
+ * Minecraft Forge
+ * Copyright (c) 2016-2018.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation version 2.1
+ * of the License.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
 package net.minecraftforge.event.village;
 
 import net.minecraft.entity.player.EntityPlayer;

--- a/src/main/java/net/minecraftforge/event/village/VillageSiegeEvent.java
+++ b/src/main/java/net/minecraftforge/event/village/VillageSiegeEvent.java
@@ -1,0 +1,65 @@
+package net.minecraftforge.event.village;
+
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.util.math.Vec3d;
+import net.minecraft.village.Village;
+import net.minecraft.village.VillageSiege;
+import net.minecraft.world.World;
+import net.minecraftforge.common.MinecraftForge;
+import net.minecraftforge.fml.common.eventhandler.Cancelable;
+import net.minecraftforge.fml.common.eventhandler.Event;
+import net.minecraftforge.fml.common.eventhandler.Event.HasResult;
+
+/**
+ * VillageSiegeEvent is fired just before a zombie siege finds a successful location in
+ * {@link VillageSiege#trySetupSiege}, to give mods the chance to stop the siege.<br>
+ * <br>
+ * This event is {@link Cancelable}; canceling stops the siege.<br>
+ * <br>
+ * This event does not have a result. {@link HasResult}<br>
+ * <br>
+ * This event is fired on the {@link MinecraftForge#EVENT_BUS}.
+ */
+@Cancelable
+public class VillageSiegeEvent extends Event
+{
+    private final VillageSiege siege;
+    private final World world;
+    private final EntityPlayer player;
+    private final Village village;
+    private final Vec3d attemptedSpawnPos;
+
+    public VillageSiegeEvent(VillageSiege siege, World world, EntityPlayer player, Village village, Vec3d attemptedSpawnPos)
+    {
+       this.siege = siege;
+       this.world = world;
+       this.player = player;
+       this.village = village;
+       this.attemptedSpawnPos = attemptedSpawnPos;
+    }
+
+    public VillageSiege getSiege()
+    {
+        return siege;
+    }
+
+    public World getWorld()
+    {
+        return world;
+    }
+
+    public EntityPlayer getPlayer()
+    {
+        return player;
+    }
+
+    public Village getVillage()
+    {
+        return village;
+    }
+
+    public Vec3d getAttemptedSpawnPos()
+    {
+        return attemptedSpawnPos;
+    }
+}

--- a/src/test/java/net/minecraftforge/debug/village/MerchantTradeOffersEventTest.java
+++ b/src/test/java/net/minecraftforge/debug/village/MerchantTradeOffersEventTest.java
@@ -1,3 +1,22 @@
+/*
+ * Minecraft Forge
+ * Copyright (c) 2016-2018.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation version 2.1
+ * of the License.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
 package net.minecraftforge.debug.village;
 
 import java.util.ListIterator;

--- a/src/test/java/net/minecraftforge/debug/village/MerchantTradeOffersEventTest.java
+++ b/src/test/java/net/minecraftforge/debug/village/MerchantTradeOffersEventTest.java
@@ -1,0 +1,47 @@
+package net.minecraftforge.debug.village;
+
+import java.util.ListIterator;
+
+import net.minecraft.village.MerchantRecipe;
+import net.minecraft.village.MerchantRecipeList;
+import net.minecraftforge.common.MinecraftForge;
+import net.minecraftforge.event.village.MerchantTradeOffersEvent;
+import net.minecraftforge.fml.common.Mod;
+import net.minecraftforge.fml.common.event.FMLPreInitializationEvent;
+import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
+
+/**
+ * Tests {@link MerchantTradeOffersEvent}. When enabled, the item that the villager sells to
+ * the player will be maxed out in stack size.
+ */
+@Mod(modid = MerchantTradeOffersEventTest.MODID, name = MerchantTradeOffersEventTest.NAME, version = "0.0.0", acceptableRemoteVersions = "*")
+public class MerchantTradeOffersEventTest
+{
+    public static final String MODID = "merchanttradeofferseventtest";
+    public static final String NAME = "Merchant Trade Offers Event Test";
+    public static final boolean ENABLED = false;
+    
+    @Mod.EventHandler
+    public void preInit(FMLPreInitializationEvent event)
+    {
+        if (ENABLED)
+        {
+            MinecraftForge.EVENT_BUS.register(MerchantTradeOffersEventTest.class);
+        }
+    }
+    
+    @SubscribeEvent
+    public static void onGetRecipes(MerchantTradeOffersEvent event)
+    {
+        MerchantRecipeList list = event.getList();
+        if (list != null)
+        {
+            ListIterator<MerchantRecipe> it = list.listIterator();
+            while (it.hasNext())
+            {
+                MerchantRecipe recipe = it.next();
+                recipe.getItemToSell().setCount(recipe.getItemToSell().getMaxStackSize());
+            }
+        }
+    }
+}

--- a/src/test/java/net/minecraftforge/debug/village/VillageSiegeEventTest.java
+++ b/src/test/java/net/minecraftforge/debug/village/VillageSiegeEventTest.java
@@ -1,0 +1,46 @@
+package net.minecraftforge.debug.village;
+
+import java.util.Locale;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import net.minecraft.init.Items;
+import net.minecraftforge.common.MinecraftForge;
+import net.minecraftforge.event.village.VillageSiegeEvent;
+import net.minecraftforge.fml.common.Mod;
+import net.minecraftforge.fml.common.event.FMLPreInitializationEvent;
+import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
+
+/**
+ * Tests {@link VillageSiegeEvent}. When enabled, players holding a diamond sword in the mainhand
+ * slot are not counted in determining where the zombie siege occurs.
+ */
+@Mod(modid = VillageSiegeEventTest.MODID, name = VillageSiegeEventTest.NAME, version = "0.0.0", acceptableRemoteVersions = "*")
+public class VillageSiegeEventTest
+{
+    public static final String MODID = "villagesiegeeventtest";
+    public static final String NAME = "Village Siege Event Test";
+    public static final boolean ENABLED = false;
+    
+    public static final Logger LOG = LogManager.getLogger(MODID.toUpperCase(Locale.US));
+    
+    @Mod.EventHandler
+    public void preInit(FMLPreInitializationEvent event)
+    {
+        if (ENABLED)
+        {
+            MinecraftForge.EVENT_BUS.register(VillageSiegeEventTest.class);
+        }
+    }
+    
+    @SubscribeEvent
+    public static void onVillageSiege(VillageSiegeEvent event)
+    {
+        if (!event.getWorld().isRemote && event.getPlayer().getHeldItemMainhand().getItem() == Items.DIAMOND_SWORD)
+        {
+            LOG.info("Village siege event for player "+event.getPlayer().getName()+" canceled");
+            event.setCanceled(true);
+        }
+    }
+}

--- a/src/test/java/net/minecraftforge/debug/village/VillageSiegeEventTest.java
+++ b/src/test/java/net/minecraftforge/debug/village/VillageSiegeEventTest.java
@@ -1,3 +1,22 @@
+/*
+ * Minecraft Forge
+ * Copyright (c) 2016-2018.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation version 2.1
+ * of the License.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
 package net.minecraftforge.debug.village;
 
 import java.util.Locale;


### PR DESCRIPTION
This PR adds a few events pertaining to villages not covered by Forge currently:
- `MerchantTradeOffersEvent` is triggered in `IMerchant.getRecipes(EntityPlayer)` and allows mods to change merchant recipes depending on the player interacting with the villager; currently, there is no way to return a different set of trade offers for each player. For example, this event allows a player wearing a certain type of helmet (such as one signifying a village in-group) to gain small trade advantages with villagers (e.g. 10% less emeralds per item).
- `VillageSiegeEvent` allows mods to fail a siege attempt upon certain conditions (such as when the player has a talisman to ward off them); currently, Forge does not yet provide an interface to work with zombie sieges.