### PR TITLE
[1.12.x] Fix issue with --modListFile. (#5315)

### DIFF
--- a/src/main/java/net/minecraftforge/fml/relauncher/libraries/ModList.java
+++ b/src/main/java/net/minecraftforge/fml/relauncher/libraries/ModList.java
@@ -63,7 +63,7 @@ public class ModList
     @SuppressWarnings("unchecked")
     public static List<ModList> getKnownLists(File mcdir)
     {
-        for (String list : new String[] {"mods/mod_list.json", "mods/" + ForgeVersion.mcVersion + "/mod_list.json", ((Map<String, String>)Launch.blackboard.get("launchArgs")).get("--modListFile")})
+        for (String list : new String[] {"mods/mod_list.json", "mods/" + ForgeVersion.mcVersion + "/mod_list.json", ((Map<String, String>)Launch.blackboard.get("forgeLaunchArgs")).get("--modListFile")})
         {
             if (list != null)
             {
@@ -84,7 +84,7 @@ public class ModList
         if (memory != null)
             lst.add(memory);
 
-        for (String list : new String[] {"mods/mod_list.json", "mods/" + ForgeVersion.mcVersion + "/mod_list.json", ((Map<String, String>)Launch.blackboard.get("launchArgs")).get("--modListFile")})
+        for (String list : new String[] {"mods/mod_list.json", "mods/" + ForgeVersion.mcVersion + "/mod_list.json", ((Map<String, String>)Launch.blackboard.get("forgeLaunchArgs")).get("--modListFile")})
         {
             if (list != null)
             {


### PR DESCRIPTION
This commit fixes --modListFile (#5315). The argument is stored in `forgeLaunchArgs` as of https://github.com/MinecraftForge/MinecraftForge/commit/10dbbf9c1915b7f5b2fc879a630b199aedbd192.