### PR TITLE
Support for mcmod.info file when starting client from IDE

### DIFF
--- a/mdk/build.gradle
+++ b/mdk/build.gradle
@@ -75,3 +75,33 @@ processResources {
         exclude 'mcmod.info'
     }
 }
+
+task deleteMcmodInfoFile(type: Delete) {
+    doLast {
+        // We need to delete the duplicate mcmod.info file, which is
+        // created when the Gradle task 'copyMcmodInfoFile' (see below)
+        // executes, for when we run the client from inside of the
+        // IDE, before the jar file is created, or else Gradle will
+        // throw a ZipException ('duplicate entry: mcmod.info').
+        //
+        // delete "$buildDir/classes/main/mcmod.info" <-- DOES NOT WORK!
+        file("$buildDir/classes/main/mcmod.info").delete()
+    }
+}
+task copyMcmodInfoFile() {
+    doLast {
+        // Copy the in-memory/modified mcmod.info file (see above Gradle
+        // task 'processResources') into the root folder that the
+        // net.minecraftforge.fml.common.discovery.DirectoryDiscoverer
+        // class will search in, when running the client from the IDE.
+        copy { // A 'type: Copy' task will not run its 'doLast' block!
+            from("$buildDir/resources/main") {
+                include 'mcmod.info'
+            }
+            into "$buildDir/classes/main"
+        }
+    }
+}
+// Need to hook our before/after tasks up to the 'jar' task ...
+jar.dependsOn deleteMcmodInfoFile
+jar.finalizedBy copyMcmodInfoFile


### PR DESCRIPTION
When you run the Minecraft client from inside the IDE (IntelliJ, etc.), the client does not see the 'src/main/resources/mcmod.info' file (assuming the mod dev created one).  This is because net.minecraftforge.fml.common.discovery.DirectoryDiscoverer looks in the '$buildDir/classes/main' folder for it.

This change will copy over the mcmod.info file into the '$buildDir/classes/main' folder, after the Jar task completes.  This change will also temporarily delete the mcmod.info copied into '$buildDir/classes/main' before the Jar task is called (via the reobfJar task), so that no ZipExceptions are thrown (if the deletion did not happen, there would be two mcmod.info files).

This way, you have just one point of modification file, and the Gradle process automagically makes the latest changes visible to the IDE-running Minecraft client.  This should also make it allot easier for new mod devs, when first starting out, and not understanding why the changes they make to mcmod.info file does not show when the client is started from within the IDE.

Note that this change has only been tested with IntelliJ, and not Eclipse!  I've used the Gradle $buildDir variable, so it should also work correctly across all IDEs/Eclipse.  Having said that, please do test this in Eclipse IDE.