### PR TITLE
[1.13] Improves topological sort

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -112,6 +112,17 @@ project(':forge') {
                 srcDir "$rootDir/src/main/resources"
             }
         }
+        test {
+            compileClasspath += sourceSets.fmllauncher.runtimeClasspath
+            runtimeClasspath += sourceSets.fmllauncher.runtimeClasspath
+            java {
+                // srcDir "$rootDir/src/test/java" TODO fix later
+                srcDir "$rootDir/src/fmllaunchertest/java"
+            }
+            resources {
+                srcDir "$rootDir/src/test/resources"
+            }
+        }
         userdev {
             compileClasspath += sourceSets.main.runtimeClasspath
             runtimeClasspath += sourceSets.main.runtimeClasspath
@@ -273,6 +284,9 @@ project(':forge') {
         installer 'org.apache.logging.log4j:log4j-core:2.11.1'
         fmllauncherImplementation 'com.google.guava:guava:21.0'
         fmllauncherImplementation 'com.google.code.gson:gson:2.8.0'
+        testImplementation "org.junit.jupiter:junit-jupiter-api:5.0.0"
+        testImplementation "org.opentest4j:opentest4j:1.0.0" // needed for junit 5
+        testImplementation "org.hamcrest:hamcrest-all:1.3" // needs advanced matching for list order
     }
 
     task runclient(type: JavaExec, dependsOn: [":forge:downloadAssets", ":forge:extractNatives"]) {

--- a/src/fmllauncher/java/net/minecraftforge/fml/loading/toposort/CyclePresentException.java
+++ b/src/fmllauncher/java/net/minecraftforge/fml/loading/toposort/CyclePresentException.java
@@ -1,0 +1,52 @@
+/*
+ * Minecraft Forge
+ * Copyright (c) 2016-2018.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation version 2.1
+ * of the License.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+package net.minecraftforge.fml.loading.toposort;
+
+import java.util.Set;
+
+/**
+ * An exception thrown for graphs with cycles as an argument for topological sort.
+ */
+public final class CyclePresentException extends IllegalArgumentException {
+    private final Set<Set<?>> cycles;
+
+    /**
+     * Creates the exception.
+     *
+     * @param cycles the cycles present
+     */
+    CyclePresentException(Set<Set<?>> cycles) {
+        this.cycles = cycles;
+    }
+
+    /**
+     * Accesses the cycles present in the sorted graph.
+     *
+     * <p>Each element in the outer set represents a cycle; each cycle, or the inner set,
+     * forms a strongly connected component with two or more elements.
+     *
+     * @param <T> the type of node sorted
+     * @return the cycles identified
+     */
+    @SuppressWarnings("unchecked")
+    public <T> Set<Set<T>> getCycles() {
+        return (Set<Set<T>>) (Set<?>) cycles;
+    }
+}

--- a/src/fmllauncher/java/net/minecraftforge/fml/loading/toposort/StronglyConnectedComponentDetector.java
+++ b/src/fmllauncher/java/net/minecraftforge/fml/loading/toposort/StronglyConnectedComponentDetector.java
@@ -1,0 +1,123 @@
+/*
+ * Minecraft Forge
+ * Copyright (c) 2016-2018.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation version 2.1
+ * of the License.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+package net.minecraftforge.fml.loading.toposort;
+
+import com.google.common.graph.Graph;
+
+import java.util.BitSet;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * An object that splits a graph into strongly connected components lazily with
+ * Tarjan's Strongly Connected Components Algorithm.
+ *
+ * <p>This algorithm allows to detect all cycles in dependencies that prevent topological
+ * sorting.
+ *
+ * <p>This detector evaluates the graph lazily and won't reflect the modifications in the
+ * graph after initial evaluation.
+ */
+public class StronglyConnectedComponentDetector<T> {
+    private final Graph<T> graph;
+    private Map<T, Integer> ids;
+    private T[] elements;
+    private int[] dfn;
+    private int[] low;
+    private int[] stack;
+    private int top;
+    private BitSet onStack;
+    private Set<Set<T>> components;
+
+    public StronglyConnectedComponentDetector(Graph<T> graph) {
+        this.graph = graph;
+    }
+
+    public Set<Set<T>> getComponents() {
+        if (components == null) {
+            calculate();
+        }
+        return components;
+    }
+
+    @SuppressWarnings("unchecked")
+    private void calculate() {
+        components = new HashSet<>();
+        int t = 0;
+        ids = new HashMap<>();
+        Set<T> nodes = graph.nodes();
+        elements = (T[]) new Object[nodes.size()];
+        for (T node : nodes) {
+            ids.put(node, t);
+            elements[t] = node;
+            t++;
+        }
+
+        final int n = nodes.size();
+        dfn = new int[n];
+        low = new int[n];
+        stack = new int[n];
+        onStack = new BitSet(n);
+        top = -1;
+        for (int i = 0; i < n; i++) {
+            if (dfn[i] == 0) {
+                dfs(i, 1);
+            }
+        }
+    }
+
+    private void dfs(int now, int depth) {
+        dfn[now] = depth;
+        low[now] = depth;
+        top++;
+        stack[top] = now;
+        onStack.set(now);
+        for (T each : graph.successors(elements[now])) {
+            int to = ids.get(each);
+            if (dfn[to] != 0) {
+                if (low[now] > dfn[to]) {
+                    low[now] = dfn[to];
+                }
+            } else {
+                dfs(to, depth + 1);
+                if (low[now] > low[to]) {
+                    low[now] = low[to];
+                }
+            }
+        }
+
+        if (dfn[now] == low[now]) {
+            Set<T> component = new HashSet<>();
+            while (top >= 0) {
+                final int t = stack[top];
+                component.add(elements[t]);
+                onStack.clear(t);
+                top--;
+                if (t == now) {
+                    break;
+                }
+            }
+            components.add(component);
+        }
+    }
+
+}

--- a/src/fmllaunchertest/java/net/minecraftforge/fml/test/TopologicalSortTests.java
+++ b/src/fmllaunchertest/java/net/minecraftforge/fml/test/TopologicalSortTests.java
@@ -1,0 +1,140 @@
+/*
+ * Minecraft Forge
+ * Copyright (c) 2016-2018.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation version 2.1
+ * of the License.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+package net.minecraftforge.fml.test;
+
+import com.google.common.graph.GraphBuilder;
+import com.google.common.graph.MutableGraph;
+import net.minecraftforge.fml.loading.toposort.CyclePresentException;
+import net.minecraftforge.fml.loading.toposort.StronglyConnectedComponentDetector;
+import net.minecraftforge.fml.loading.toposort.TopologicalSort;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Set;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+
+/**
+ * Tests for topological sort.
+ */
+public class TopologicalSortTests {
+
+    @Test
+    @DisplayName("strongly connected components")
+    @SuppressWarnings("unchecked")
+    void testScc() {
+        MutableGraph<Integer> graph = GraphBuilder.directed().build();
+        graph.putEdge(2, 4);
+        graph.putEdge(4, 7);
+        graph.putEdge(4, 6);
+        graph.putEdge(6, 1);
+        graph.putEdge(3, 4);
+        graph.putEdge(1, 4);
+        graph.putEdge(3, 1);
+        Set<Set<Integer>> components = new StronglyConnectedComponentDetector<>(graph).getComponents();
+        assertThat(components, containsInAnyOrder(contains(2), contains(3), contains(7), containsInAnyOrder(1, 4, 6)));
+    }
+
+    @Test
+    @DisplayName("strongly connected components 2")
+    @SuppressWarnings("unchecked")
+    void testScc2() {
+        MutableGraph<Integer> graph = GraphBuilder.directed().build();
+        graph.putEdge(2, 4);
+        graph.putEdge(4, 8);
+        graph.putEdge(8, 2);
+        graph.putEdge(2, 1);
+        graph.putEdge(2, 3);
+        graph.putEdge(1, 9);
+        graph.putEdge(9, 7);
+        graph.putEdge(7, 5);
+        graph.putEdge(5, 1);
+        graph.putEdge(5, 3);
+        graph.putEdge(3, 6);
+        graph.putEdge(6, 5);
+        graph.putEdge(9, 3);
+        Set<Set<Integer>> components = new StronglyConnectedComponentDetector<>(graph).getComponents();
+        assertThat(components, containsInAnyOrder(containsInAnyOrder(1, 3, 5, 6, 7, 9), containsInAnyOrder(2, 4, 8)));
+    }
+
+    @Test
+    @DisplayName("basic sort")
+    void testBasicSort() {
+        MutableGraph<Integer> graph = GraphBuilder.directed().build();
+        graph.putEdge(2, 4);
+        graph.putEdge(4, 7);
+        graph.putEdge(4, 6);
+        graph.putEdge(3, 4);
+        graph.putEdge(1, 4);
+        graph.putEdge(3, 1);
+        List<Integer> list = TopologicalSort.topologicalSort(graph, Comparator.naturalOrder());
+        assertThat(list, contains(2, 3, 1, 4, 6, 7));
+    }
+
+    @Test
+    @DisplayName("basic sort 2")
+    void testBasicSort2() {
+        MutableGraph<Integer> graph = GraphBuilder.directed().build();
+        graph.putEdge(7, 6);
+        graph.putEdge(8, 6);
+        graph.putEdge(8, 2);
+        graph.putEdge(12, 2);
+        graph.putEdge(2, 6);
+        graph.putEdge(6, 1);
+        graph.putEdge(2, 4);
+        graph.putEdge(2, 1);
+        graph.putEdge(1, 4);
+        graph.putEdge(1, 3);
+        graph.putEdge(4, 5);
+        graph.putEdge(1, 5);
+        graph.putEdge(5, 3);
+        graph.putEdge(1, 10);
+        graph.putEdge(3, 11);
+        graph.putEdge(5, 9);
+        graph.putEdge(11, 9);
+        graph.putEdge(11, 13);
+        graph.putEdge(10, 13);
+        List<Integer> list = TopologicalSort.topologicalSort(graph, Collections.reverseOrder());
+        assertThat(list, contains(12, 8, 7, 2, 6, 1, 10, 4, 5, 3, 11, 13, 9));
+    }
+
+    @Test
+    @DisplayName("loop sort")
+    void testLoopSort() {
+        MutableGraph<Integer> graph = GraphBuilder.directed().build();
+        graph.putEdge(2, 4);
+        graph.putEdge(4, 7);
+        graph.putEdge(4, 6);
+        graph.putEdge(6, 1);
+        graph.putEdge(3, 4);
+        graph.putEdge(1, 4);
+        graph.putEdge(3, 1);
+        CyclePresentException ex = Assertions.assertThrows(CyclePresentException.class, () -> {
+            TopologicalSort.topologicalSort(graph, Comparator.naturalOrder());
+        });
+        assertThat(ex.getCycles(), contains(containsInAnyOrder(1, 4, 6)));
+    }
+}

--- a/src/main/resources/assets/forge/lang/en_us.json
+++ b/src/main/resources/assets/forge/lang/en_us.json
@@ -25,6 +25,7 @@
   "fml.modloading.errorduringevent":"{0,modinfo,name} ({0,modinfo,id}) encountered an error during the {1,lower} event phase\n\u00a77{2,exc,msg}",
   "fml.modloading.failedtoloadforge": "Failed to load forge",
   "fml.modloading.missingdependency": "Mod \u00a7e{4}\u00a7r requires \u00a76{3}\u00a7r \u00a7o{5,vr}\u00a7r\n\u00a77Currently, \u00a76{3}\u00a7r\u00a77 is \u00a7o{6,i18n,fml.messages.artifactversion.ornotinstalled}",
+  "fml.modloading.cycle": "Detected a mod dependency cycle: {0}",
   "fml.modloading.failedtoprocesswork":"{0,modinfo,name} ({0,modinfo,id}) encountered an error processing deferred work\n\u00a77{2,exc,msg}",
 
   "fml.messages.artifactversion.ornotinstalled":"{0,ornull,fml.messages.artifactversion.notinstalled}",


### PR DESCRIPTION
This can be used for mod sorting, dependencies between registries, etc.
e.g. https://github.com/MinecraftForge/MinecraftForge/pull/4694#issuecomment-412520302

New features:
Now accepts guava graph
Performance improvement: no longer reverse the graph; changed dfs to bfs
Accepets a comparator for secondary order, e.g. natural order, index by map
Now properly reports all cycles in a graph with Tarjan's strongly connected component algorithm
Adds a test to prove the validity of the sort and cycle detection
Modified build.gradle for test source directory and dependencies

Mod loading changes:
Sort mod file info instead of suppliers (we don't have previously created suppliers instances for identity comparison)
Moves cycle error reporting out of topological sort and into mod sorter
Prevent mod file dependencies between mods that share the same file

Signed-off-by: liach <liach@users.noreply.github.com>