### PR TITLE
Fix small logic error in emissive item rendering code

### DIFF
--- a/src/main/java/net/minecraftforge/client/ForgeHooksClient.java
+++ b/src/main/java/net/minecraftforge/client/ForgeHooksClient.java
@@ -662,6 +662,9 @@ public class ForgeHooksClient
         int segmentSkyLight = -1;
         // Coloring of the current segment
         int segmentColorMultiplier = color;
+        // State changed by the current segment
+        boolean segmentLightingDirty = false;
+        boolean segmentColorDirty = false;
         // If the current segment contains lighting data
         boolean hasLighting = false;
 
@@ -714,18 +717,20 @@ public class ForgeHooksClient
             {
                 if (i > 0) // Make sure this isn't the first quad being processed
                 {
-                    drawSegment(ri, color, stack, segment, segmentBlockLight, segmentSkyLight, segmentColorMultiplier, lightingDirty && (hasLighting || segment.size() < i), colorDirty);
+                    drawSegment(ri, color, stack, segment, segmentBlockLight, segmentSkyLight, segmentColorMultiplier, segmentLightingDirty && (hasLighting || segment.size() < i), segmentColorDirty);
                 }
                 segmentBlockLight = bl;
                 segmentSkyLight = sl;
                 segmentColorMultiplier = colorMultiplier;
+                segmentLightingDirty = lightingDirty;
+                segmentColorDirty = colorDirty;
                 hasLighting = segmentBlockLight > 0 || segmentSkyLight > 0;
             }
 
             segment.add(q);
         }
 
-        drawSegment(ri, color, stack, segment, segmentBlockLight, segmentSkyLight, segmentColorMultiplier, hasLighting || segment.size() < allquads.size(), false);
+        drawSegment(ri, color, stack, segment, segmentBlockLight, segmentSkyLight, segmentColorMultiplier, segmentLightingDirty && (hasLighting || segment.size() < allquads.size()), segmentColorDirty);
 
         // Clean up render state if necessary
         if (hasLighting)


### PR DESCRIPTION
This fixes a small error in the `renderLitItem` logic for the case where multiple quads share the same light level, but have a different colour multiplier, as can be seen in the following example:

Before:
![2019-01-02_07 09 19](https://user-images.githubusercontent.com/1447117/50583508-85bec780-0e61-11e9-9335-7722057fe2c3.png)

After:
![2019-01-02_07 14 16](https://user-images.githubusercontent.com/1447117/50583509-89524e80-0e61-11e9-8512-a9265e95cd94.png)
