### PR TITLE
Adding long support to configuration

### DIFF
--- a/src/main/java/net/minecraftforge/common/config/ConfigElement.java
+++ b/src/main/java/net/minecraftforge/common/config/ConfigElement.java
@@ -142,7 +142,7 @@ public class ConfigElement implements IConfigElement
     public static ConfigGuiType getType(Property prop)
     {
         return prop.getType() == Property.Type.BOOLEAN ? ConfigGuiType.BOOLEAN : prop.getType() == Property.Type.DOUBLE ? ConfigGuiType.DOUBLE :
-            prop.getType() == Property.Type.INTEGER ? ConfigGuiType.INTEGER :  prop.getType() == Property.Type.COLOR ? ConfigGuiType.COLOR :
+            prop.getType() == Property.Type.INTEGER ? ConfigGuiType.INTEGER : prop.getType() == Property.Type.COLOR ? ConfigGuiType.COLOR :
             prop.getType() == Property.Type.MOD_ID ? ConfigGuiType.MOD_ID : ConfigGuiType.STRING;
     }
 

--- a/src/main/java/net/minecraftforge/common/config/ConfigElement.java
+++ b/src/main/java/net/minecraftforge/common/config/ConfigElement.java
@@ -355,6 +355,13 @@ public class ConfigElement implements IConfigElement
                     ia[i] = Integer.valueOf(aVal[i].toString());
                 prop.set(ia);
             }
+            else if (type == Property.Type.LONG)
+            {
+                long[] la = new long[aVal.length];
+                for(int i = 0; i < aVal.length; i++)
+                    la[i] = Long.valueOf(aVal[i].toString());
+                prop.set(la);
+            }
             else
             {
                 String[] is = new String[aVal.length];

--- a/src/main/java/net/minecraftforge/common/config/ConfigElement.java
+++ b/src/main/java/net/minecraftforge/common/config/ConfigElement.java
@@ -142,7 +142,7 @@ public class ConfigElement implements IConfigElement
     public static ConfigGuiType getType(Property prop)
     {
         return prop.getType() == Property.Type.BOOLEAN ? ConfigGuiType.BOOLEAN : prop.getType() == Property.Type.DOUBLE ? ConfigGuiType.DOUBLE :
-            prop.getType() == Property.Type.INTEGER ? ConfigGuiType.INTEGER : prop.getType() == Property.Type.COLOR ? ConfigGuiType.COLOR :
+            prop.getType() == Property.Type.INTEGER ? ConfigGuiType.INTEGER :  prop.getType() == Property.Type.COLOR ? ConfigGuiType.COLOR :
             prop.getType() == Property.Type.MOD_ID ? ConfigGuiType.MOD_ID : ConfigGuiType.STRING;
     }
 
@@ -246,6 +246,13 @@ public class ConfigElement implements IConfigElement
                     ia[i] = Integer.valueOf(aVal[i].toString());
                 return ia;
             }
+            else if (type == Property.Type.LONG)
+            {
+                Long[] ia = new Long[aVal.length];
+                for(int i = 0; i < aVal.length; i++)
+                    ia[i] = Long.valueOf(aVal[i].toString());
+                return ia;
+            }
             else
                 return aVal;
         }
@@ -291,6 +298,13 @@ public class ConfigElement implements IConfigElement
                     ia[i] = Integer.valueOf(aVal[i].toString());
                 return ia;
             }
+            else if (type == Property.Type.LONG)
+            {
+                Long[] ia = new Long[aVal.length];
+                for(int i = 0; i < aVal.length; i++)
+                    ia[i] = Long.valueOf(aVal[i].toString());
+                return ia;
+            }
             else
                 return aVal;
         }
@@ -308,6 +322,8 @@ public class ConfigElement implements IConfigElement
                 prop.set(Double.parseDouble(value.toString()));
             else if (type == Property.Type.INTEGER)
                 prop.set(Integer.parseInt(value.toString()));
+            else if (type == Property.Type.LONG)
+                prop.set(Long.parseLong(value.toString()));
             else
                 prop.set(value.toString());
         }

--- a/src/main/java/net/minecraftforge/common/config/ConfigManager.java
+++ b/src/main/java/net/minecraftforge/common/config/ConfigManager.java
@@ -84,6 +84,10 @@ public class ConfigManager
         register(int[].class,       TypeAdapters.intA);
         register(Integer.class,     TypeAdapters.Int);
         register(Integer[].class,   TypeAdapters.IntA);
+        register(long.class,        TypeAdapters.long_);
+        register(long[].class,      TypeAdapters.longA);
+        register(Long.class,        TypeAdapters.Long);
+        register(Long[].class,      TypeAdapters.LongA);
         register(String.class,      TypeAdapters.Str);
         register(String[].class,    TypeAdapters.StrA);
 
@@ -95,6 +99,7 @@ public class ConfigManager
         ARRAY_REMAP.put(Character.class, Character[].class);
         ARRAY_REMAP.put(Short.class,     Short[].class    );
         ARRAY_REMAP.put(Integer.class,   Integer[].class  );
+        ARRAY_REMAP.put(Long.class,      Long[].class     );
         ARRAY_REMAP.put(String.class,    String[].class   );
     }
     private static void register(Class<?> cls, ITypeAdapter adpt)

--- a/src/main/java/net/minecraftforge/common/config/Configuration.java
+++ b/src/main/java/net/minecraftforge/common/config/Configuration.java
@@ -19,11 +19,6 @@
 
 package net.minecraftforge.common.config;
 
-import static net.minecraftforge.common.config.Property.Type.BOOLEAN;
-import static net.minecraftforge.common.config.Property.Type.DOUBLE;
-import static net.minecraftforge.common.config.Property.Type.INTEGER;
-import static net.minecraftforge.common.config.Property.Type.STRING;
-
 import java.io.BufferedReader;
 import java.io.BufferedWriter;
 import java.io.File;
@@ -59,6 +54,8 @@ import net.minecraftforge.fml.common.FMLLog;
 import net.minecraftforge.fml.common.Loader;
 import net.minecraftforge.fml.relauncher.FMLInjectionData;
 import org.apache.commons.io.IOUtils;
+
+import static net.minecraftforge.common.config.Property.Type.*;
 
 /**
  * This class offers advanced configurations capabilities, allowing to provide
@@ -410,6 +407,148 @@ public class Configuration
         prop.setMaxListLength(maxListLength);
 
         if (!prop.isIntList())
+        {
+            prop.setValues(values);
+        }
+
+        return prop;
+    }
+
+    /* ****************************************************************************************************************
+     *
+     * LONG gets
+     *
+     *****************************************************************************************************************/
+
+    /**
+     * Gets a long Property object without a comment using default settings.
+     *
+     * @param category the config category
+     * @param key the Property key value
+     * @param defaultValue the default value
+     * @return an integer Property object with default bounds of Long.MIN_VALUE and Long.MAX_VALUE
+     */
+    public Property get(String category, String key, long defaultValue)
+    {
+        return get(category, key, defaultValue, null, Long.MIN_VALUE, Long.MAX_VALUE);
+    }
+
+    /**
+     * Gets a long Property object with a comment using default settings.
+     *
+     * @param category the config category
+     * @param key the Property key value
+     * @param defaultValue the default value
+     * @param comment a String comment
+     * @return an long Property object with default bounds of Long.MIN_VALUE and Long.MAX_VALUE
+     */
+    public Property get(String category, String key, long defaultValue, String comment)
+    {
+        return get(category, key, defaultValue, comment, Long.MIN_VALUE, Long.MAX_VALUE);
+    }
+
+    /**
+     * Gets a long Property object with the defined comment, minimum and maximum bounds.
+     *
+     * @param category the config category
+     * @param key the Property key value
+     * @param defaultValue the default value
+     * @param comment a String comment
+     * @param minValue minimum boundary
+     * @param maxValue maximum boundary
+     * @return an integer Property object with the defined comment, minimum and maximum bounds
+     */
+    public Property get(String category, String key, long defaultValue, String comment, long minValue, long maxValue)
+    {
+        Property prop = get(category, key, Long.toString(defaultValue), comment, LONG);
+        prop.setDefaultValue(Long.toString(defaultValue));
+        prop.setMinValue(minValue);
+        prop.setMaxValue(maxValue);
+
+        if (!prop.isLongValue())
+        {
+            prop.setValue(defaultValue);
+        }
+        return prop;
+    }
+
+    /**
+     * Gets a long array Property object without a comment using default settings.
+     *
+     * @param category the config category
+     * @param key the Property key value
+     * @param defaultValues an array containing the default values
+     * @return a long array Property object with default bounds of Long.MIN_VALUE and Long.MAX_VALUE, isListLengthFixed = false,
+     *         maxListLength = -1
+     */
+    public Property get(String category, String key, long[] defaultValues)
+    {
+        return get(category, key, defaultValues, null);
+    }
+
+    /**
+     * Gets a long array Property object with a comment using default settings.
+     *
+     * @param category the config category
+     * @param key the Property key value
+     * @param defaultValues an array containing the default values
+     * @param comment a String comment
+     * @return a long array Property object with default bounds of Long.MIN_VALUE and Long.MAX_VALUE, isListLengthFixed = false,
+     *         maxListLength = -1
+     */
+    public Property get(String category, String key, long[] defaultValues, String comment)
+    {
+        return get(category, key, defaultValues, comment, Long.MIN_VALUE, Long.MAX_VALUE, false, -1);
+    }
+
+    /**
+     * Gets a long array Property object with the defined comment, minimum and maximum bounds.
+     *
+     * @param category the config category
+     * @param key the Property key value
+     * @param defaultValues an array containing the default values
+     * @param comment a String comment
+     * @param minValue minimum boundary
+     * @param maxValue maximum boundary
+     * @return a long array Property object with the defined comment, minimum and maximum bounds, isListLengthFixed
+     *         = false, maxListLength = -1
+     */
+    public Property get(String category, String key, long[] defaultValues, String comment, long minValue, long maxValue)
+    {
+        return get(category, key, defaultValues, comment, minValue, maxValue, false, -1);
+    }
+
+    /**
+     * Gets a long array Property object with all settings defined.
+     *
+     * @param category the config category
+     * @param key the Property key value
+     * @param defaultValues an array containing the default values
+     * @param comment a String comment
+     * @param minValue minimum boundary
+     * @param maxValue maximum boundary
+     * @param isListLengthFixed boolean for whether this array is required to be a specific length (defined by the default value array
+     *            length or maxListLength)
+     * @param maxListLength the maximum length of this array, use -1 for no max length
+     * @return a long array Property object with all settings defined
+     */
+    public Property get(String category, String key, long[] defaultValues, String comment, long minValue, long maxValue,
+        boolean isListLengthFixed, int maxListLength)
+    {
+        String[] values = new String[defaultValues.length];
+        for (int i = 0; i < defaultValues.length; i++)
+        {
+            values[i] = Long.toString(defaultValues[i]);
+        }
+
+        Property prop = get(category, key, values, comment, LONG);
+        prop.setDefaultValues(values);
+        prop.setMinValue(minValue);
+        prop.setMaxValue(maxValue);
+        prop.setIsListLengthFixed(isListLengthFixed);
+        prop.setMaxListLength(maxListLength);
+
+        if (!prop.isLongList())
         {
             prop.setValues(values);
         }

--- a/src/main/java/net/minecraftforge/common/config/Property.java
+++ b/src/main/java/net/minecraftforge/common/config/Property.java
@@ -50,7 +50,8 @@ public class Property
         BOOLEAN,
         DOUBLE,
         COLOR,
-        MOD_ID;
+        MOD_ID,
+        LONG;
 
         public static Type tryParse(char id)
         {
@@ -554,6 +555,21 @@ public class Property
     }
 
     /**
+     * Sets the default long[] values of this Property.
+     *
+     * @param defaultValues an array of long values
+     */
+    public Property setDefaultValues(long[] defaultValues)
+    {
+        String[] temp = new String[defaultValues.length];
+        for(int i = 0; i < defaultValues.length; i++)
+            temp[i] = Long.toString(defaultValues[i]);
+
+        setDefaultValues(temp);
+        return this;
+    }
+
+    /**
      * Sets the default double value of this Property.
      *
      * @param defaultValue a double value
@@ -954,6 +970,56 @@ public class Property
     }
 
     /**
+     * Returns the long value of all values that can
+     * be parsed in the list.
+     *
+     * @return Array of length 0 if none of the values could be parsed.
+     */
+    public long[] getLongList()
+    {
+        ArrayList<Long> nums = new ArrayList<>();
+
+        for(String value : values)
+        {
+            try
+            {
+                nums.add(Long.parseLong(value));
+            }
+            catch (NumberFormatException e){}
+        }
+
+        long[] primitives = new long[nums.size()];
+
+        for(int i = 0; i < nums.size(); i++)
+        {
+            primitives[i] = nums.get(i);
+        }
+
+        return primitives;
+    }
+
+    /**
+     * Checks if all of the current values stored in this property can be converted to a long.
+     * @return True if the type of the Property is a Long List
+     */
+    public boolean isLongList()
+    {
+        if(isList && type == Type.LONG)
+            for(String value : values)
+            {
+                try
+                {
+                    Long.parseLong(value);
+                }
+                catch(NumberFormatException e)
+                {
+                    return false;
+                }
+            }
+        return isList && type == Type.LONG;
+    }
+
+    /**
      * Returns the boolean value of all values that can
      * be parsed in the list.
      *
@@ -1196,6 +1262,23 @@ public class Property
     }
 
     public void set(int[] values)
+    {
+        this.setValues(values);
+    }
+
+    /**
+     * Sets the values of this Property to the provided int[] values.
+     */
+    public Property setValues(long[] values)
+    {
+        this.values = new String[values.length];
+        for (int i = 0; i < values.length; i++)
+            this.values[i] = String.valueOf(values[i]);
+        changed = true;
+        return this;
+    }
+
+    public void set(long[] values)
     {
         this.setValues(values);
     }

--- a/src/main/java/net/minecraftforge/common/config/Property.java
+++ b/src/main/java/net/minecraftforge/common/config/Property.java
@@ -257,6 +257,9 @@ public class Property
         if (this.type == Type.INTEGER && this.isIntValue())
             return Integer.parseInt(value) == Integer.parseInt(defaultValue);
 
+        if (this.type == Type.LONG && this.isLongValue())
+            return Long.parseLong(value) == Long.parseLong(defaultValue);
+
         if (this.type == Type.DOUBLE && this.isDoubleValue())
             return Double.parseDouble(value) == Double.parseDouble(defaultValue);
 

--- a/src/main/java/net/minecraftforge/common/config/TypeAdapters.java
+++ b/src/main/java/net/minecraftforge/common/config/TypeAdapters.java
@@ -29,6 +29,7 @@ import com.google.common.primitives.Bytes;
 import com.google.common.primitives.Doubles;
 import com.google.common.primitives.Floats;
 import com.google.common.primitives.Ints;
+import com.google.common.primitives.Longs;
 import com.google.common.primitives.Shorts;
 
 import net.minecraftforge.common.config.Property.Type;
@@ -43,6 +44,7 @@ class TypeAdapters
     *    char, char[], Character, Character[]
     *    short, short[], Short, Short[]
     *    int, int[], Integer, Integer[]
+    *    long, long[], Long, Long[]
     *    String, String[]
     */
     static ITypeAdapter bool = new ITypeAdapter() {
@@ -814,6 +816,113 @@ class TypeAdapters
             return true;
         }
     };
+
+    static ITypeAdapter long_ = new ITypeAdapter() {
+        @Override
+        public Object getValue(Property prop) {
+            return prop.getLong();
+        }
+        @Override
+        public void setDefaultValue(Property property, Object value)
+        {
+            property.setDefaultValue((Long)value);
+        }
+        @Override
+        public void setValue(Property property, Object value)
+        {
+            property.setValue((Long)value);
+        }
+        @Override
+        public Type getType()
+        {
+            return Type.LONG;
+        }
+        @Override
+        public boolean isArrayAdapter()
+        {
+            return false;
+        }
+    };
+    static ITypeAdapter longA = new ITypeAdapter() {
+        @Override
+        public Object getValue(Property prop) {
+            return prop.getLongList();
+        }
+        @Override
+        public void setDefaultValue(Property property, Object value)
+        {
+            property.setDefaultValues((long[])value);
+        }
+        @Override
+        public void setValue(Property property, Object value)
+        {
+            property.setValues((long[])value);
+        }
+        @Override
+        public Type getType()
+        {
+            return Type.LONG;
+        }
+        @Override
+        public boolean isArrayAdapter()
+        {
+            return true;
+        }
+    };
+    static ITypeAdapter Long = new ITypeAdapter() {
+        @Override
+        public Object getValue(Property prop) {
+            return (Long)prop.getLong();
+        }
+        @Override
+        public void setDefaultValue(Property property, Object value)
+        {
+            property.setDefaultValue((Long)value);
+        }
+        @Override
+        public void setValue(Property property, Object value)
+        {
+            property.setValue((Long)value);
+        }
+        @Override
+        public Type getType()
+        {
+            return Type.LONG;
+        }
+        @Override
+        public boolean isArrayAdapter()
+        {
+            return false;
+        }
+    };
+    static ITypeAdapter LongA = new ITypeAdapter() {
+        @Override
+        public Object getValue(Property prop) {
+            return Longs.asList(prop.getLongList()).toArray(new Long[prop.getLongList().length]);
+        }
+        @Override
+        public void setDefaultValue(Property property, Object value)
+        {
+            property.setDefaultValues(Longs.toArray(Arrays.asList((Long[])value)));
+        }
+        @Override
+        public void setValue(Property property, Object value)
+        {
+            property.setValues(Longs.toArray(Arrays.asList((Long[])value)));
+        }
+        @Override
+        public Type getType()
+        {
+            return Type.LONG;
+        }
+        @Override
+        public boolean isArrayAdapter()
+        {
+            return true;
+        }
+    };
+
+
     static ITypeAdapter Str = new ITypeAdapter() {
         @Override
         public Object getValue(Property prop) {

--- a/src/test/java/net/minecraftforge/test/ConfigurationTest.java
+++ b/src/test/java/net/minecraftforge/test/ConfigurationTest.java
@@ -56,10 +56,14 @@ public class ConfigurationTest {
         Property backgroundProperty = new Property("background", "0xFFFFFF", Property.Type.COLOR);
         backgroundProperty.setComment("background property comment");
 
+        Property longProperty = new Property("longProp", Long.toString((long)1e10), Property.Type.LONG);
+        longProperty.setComment("long value comment");
+
         config = new Configuration();
         category = config.getCategory("defaults");
         category.put(enabledProperty.getName(), enabledProperty);
         category.put(backgroundProperty.getName(), backgroundProperty);
+        category.put(longProperty.getName(), longProperty);
     }
 
     @Test
@@ -94,5 +98,17 @@ public class ConfigurationTest {
         assertEquals("The property's value changed", "true", backgroundProperty.getString());
         assertEquals("The property's type was changed", Property.Type.BOOLEAN, backgroundProperty.getType());
         assertEquals("The property's comment was changed", "enabled property comment", backgroundProperty.getComment());
+    }
+
+    @Test
+    public void testSavingLongValue()
+    {
+        Property longProperty = category.get("longProp");
+
+        assertEquals("The property's name was not changed", "longProp", longProperty.getName());
+        assertEquals("The property's value was not changed", (long)1e10, longProperty.getLong());
+        assertEquals("The property's type was not changed", Property.Type.LONG, longProperty.getType());
+        assertEquals("The property's comment was not changed", "long value comment", longProperty.getComment());
+
     }
 }


### PR DESCRIPTION
I was writing a mod and I tried to save longs into the config, but it told me that longs weren't a primitive, which is obviously incorrect.

I saw 
```
public enum Type
    {
        STRING,
        INTEGER,
        BOOLEAN,
        DOUBLE,
        COLOR,
        MOD_ID;
```

I thought at first it was because `com.google.common.primitives.Longs` didn't exist, but it does, so I added the code to handle longs.

I wrote a test to make sure it saved and loaded properly. I didn't really need to actually write much original code, since there are so many other types already in there, I just copied the existing functionality and changed the names and types.