### PR TITLE
[1.13] Allow GuiContainer and ItemGroup to specify slot hover colors

### DIFF
--- a/patches/minecraft/net/minecraft/client/gui/inventory/GuiContainer.java.patch
+++ b/patches/minecraft/net/minecraft/client/gui/inventory/GuiContainer.java.patch
@@ -5,7 +5,7 @@
              int k1 = slot.field_75221_f;
              GlStateManager.func_179135_a(true, true, true, false);
 -            this.func_73733_a(j1, k1, j1 + 16, k1 + 16, -2130706433, -2130706433);
-+            int hoverColor = this.field_147002_h.getHoverColor(i1);
++            int hoverColor = this.getSlotHoverColor(i1);
 +            this.func_73733_a(j1, k1, j1 + 16, k1 + 16, hoverColor, hoverColor);
              GlStateManager.func_179135_a(true, true, true, true);
              GlStateManager.func_179145_e();
@@ -141,7 +141,7 @@
                 this.func_184098_a(this.field_147006_u, this.field_147006_u.field_75222_d, i, ClickType.SWAP);
                 return true;
              }
-@@ -556,4 +564,11 @@
+@@ -556,4 +564,16 @@
        }
  
     }
@@ -152,4 +152,9 @@
 +   public int getGuiTop() { return field_147009_r; }
 +   public int getXSize() { return field_146999_f; }
 +   public int getYSize() { return field_147000_g; }
++
++   public int slotHoverColor = -2130706433;
++   public int getSlotHoverColor(int index) {
++      return slotHoverColor;
++   }
  }

--- a/patches/minecraft/net/minecraft/client/gui/inventory/GuiContainer.java.patch
+++ b/patches/minecraft/net/minecraft/client/gui/inventory/GuiContainer.java.patch
@@ -1,16 +1,24 @@
 --- a/net/minecraft/client/gui/inventory/GuiContainer.java
 +++ b/net/minecraft/client/gui/inventory/GuiContainer.java
-@@ -97,7 +97,8 @@
+@@ -7,7 +7,6 @@
+ import net.minecraft.client.renderer.OpenGlHelper;
+ import net.minecraft.client.renderer.RenderHelper;
+ import net.minecraft.client.renderer.texture.TextureAtlasSprite;
+-import net.minecraft.client.renderer.texture.TextureMap;
+ import net.minecraft.client.util.InputMappings;
+ import net.minecraft.entity.player.InventoryPlayer;
+ import net.minecraft.inventory.ClickType;
+@@ -97,7 +96,8 @@
              int j1 = slot.field_75223_e;
              int k1 = slot.field_75221_f;
              GlStateManager.func_179135_a(true, true, true, false);
 -            this.func_73733_a(j1, k1, j1 + 16, k1 + 16, -2130706433, -2130706433);
-+            int hoverColor = this.getSlotHoverColor(i1);
-+            this.func_73733_a(j1, k1, j1 + 16, k1 + 16, hoverColor, hoverColor);
++            int slotColor = this.getSlotColor(i1);
++            this.func_73733_a(j1, k1, j1 + 16, k1 + 16, slotColor, slotColor);
              GlStateManager.func_179135_a(true, true, true, true);
              GlStateManager.func_179145_e();
              GlStateManager.func_179126_j();
-@@ -107,6 +108,7 @@
+@@ -107,6 +107,7 @@
        RenderHelper.func_74518_a();
        this.func_146979_b(p_73863_1_, p_73863_2_);
        RenderHelper.func_74520_c();
@@ -18,7 +26,7 @@
        InventoryPlayer inventoryplayer = this.field_146297_k.field_71439_g.field_71071_by;
        ItemStack itemstack = this.field_147012_x.func_190926_b() ? inventoryplayer.func_70445_o() : this.field_147012_x;
        if (!itemstack.func_190926_b()) {
-@@ -158,8 +160,10 @@
+@@ -158,8 +159,10 @@
        GlStateManager.func_179109_b(0.0F, 0.0F, 32.0F);
        this.field_73735_i = 200.0F;
        this.field_146296_j.field_77023_b = 200.0F;
@@ -30,7 +38,7 @@
        this.field_73735_i = 0.0F;
        this.field_146296_j.field_77023_b = 0.0F;
     }
-@@ -203,11 +207,10 @@
+@@ -203,11 +206,10 @@
        this.field_73735_i = 100.0F;
        this.field_146296_j.field_77023_b = 100.0F;
        if (itemstack.func_190926_b() && p_146977_1_.func_111238_b()) {
@@ -45,7 +53,7 @@
              this.func_175175_a(i, j, textureatlassprite, 16, 16);
              GlStateManager.func_179145_e();
              flag1 = true;
-@@ -268,7 +271,8 @@
+@@ -268,7 +270,8 @@
        if (super.mouseClicked(p_mouseClicked_1_, p_mouseClicked_3_, p_mouseClicked_5_)) {
           return true;
        } else {
@@ -55,7 +63,7 @@
           Slot slot = this.func_195360_a(p_mouseClicked_1_, p_mouseClicked_3_);
           long i = Util.func_211177_b();
           this.field_146993_M = this.field_146998_K == slot && i - this.field_146997_J < 250L && this.field_146992_L == p_mouseClicked_5_;
-@@ -277,6 +281,7 @@
+@@ -277,6 +280,7 @@
              int j = this.field_147003_i;
              int k = this.field_147009_r;
              boolean flag1 = this.func_195361_a(p_mouseClicked_1_, p_mouseClicked_3_, j, k, p_mouseClicked_5_);
@@ -63,7 +71,7 @@
              int l = -1;
              if (slot != null) {
                 l = slot.field_75222_d;
-@@ -302,7 +307,7 @@
+@@ -302,7 +306,7 @@
                    }
                 } else if (!this.field_147007_t) {
                    if (this.field_146297_k.field_71439_g.field_71071_by.func_70445_o().func_190926_b()) {
@@ -72,7 +80,7 @@
                          this.func_184098_a(slot, l, p_mouseClicked_5_, ClickType.CLONE);
                       } else {
                          boolean flag2 = l != -999 && (InputMappings.func_197956_a(340) || InputMappings.func_197956_a(344));
-@@ -326,7 +331,7 @@
+@@ -326,7 +330,7 @@
                          this.field_146987_F = 0;
                       } else if (p_mouseClicked_5_ == 1) {
                          this.field_146987_F = 1;
@@ -81,7 +89,7 @@
                          this.field_146987_F = 2;
                       }
                    }
-@@ -379,10 +384,13 @@
+@@ -379,10 +383,13 @@
     }
  
     public boolean mouseReleased(double p_mouseReleased_1_, double p_mouseReleased_3_, int p_mouseReleased_5_) {
@@ -95,7 +103,7 @@
        int k = -1;
        if (slot != null) {
           k = slot.field_75222_d;
-@@ -396,7 +404,7 @@
+@@ -396,7 +403,7 @@
           if (func_146272_n()) {
              if (!this.field_146994_N.func_190926_b()) {
                 for(Slot slot2 : this.field_147002_h.field_75151_b) {
@@ -104,7 +112,7 @@
                       this.func_184098_a(slot2, slot2.field_75222_d, p_mouseReleased_5_, ClickType.QUICK_MOVE);
                    }
                 }
-@@ -460,7 +468,7 @@
+@@ -460,7 +467,7 @@
  
              this.func_184098_a((Slot)null, -999, Container.func_94534_d(2, this.field_146987_F), ClickType.QUICK_CRAFT);
           } else if (!this.field_146297_k.field_71439_g.field_71071_by.func_70445_o().func_190926_b()) {
@@ -113,7 +121,7 @@
                 this.func_184098_a(slot, k, p_mouseReleased_5_, ClickType.CLONE);
              } else {
                 boolean flag1 = k != -999 && (InputMappings.func_197956_a(340) || InputMappings.func_197956_a(344));
-@@ -509,15 +517,15 @@
+@@ -509,15 +516,15 @@
        if (super.keyPressed(p_keyPressed_1_, p_keyPressed_2_, p_keyPressed_3_)) {
           return true;
        } else {
@@ -132,7 +140,7 @@
                 this.func_184098_a(this.field_147006_u, this.field_147006_u.field_75222_d, func_146271_m() ? 1 : 0, ClickType.THROW);
              }
           }
-@@ -529,7 +537,7 @@
+@@ -529,7 +536,7 @@
     protected boolean func_195363_d(int p_195363_1_, int p_195363_2_) {
        if (this.field_146297_k.field_71439_g.field_71071_by.func_70445_o().func_190926_b() && this.field_147006_u != null) {
           for(int i = 0; i < 9; ++i) {
@@ -141,7 +149,7 @@
                 this.func_184098_a(this.field_147006_u, this.field_147006_u.field_75222_d, i, ClickType.SWAP);
                 return true;
              }
-@@ -556,4 +564,16 @@
+@@ -556,4 +563,16 @@
        }
  
     }
@@ -153,8 +161,8 @@
 +   public int getXSize() { return field_146999_f; }
 +   public int getYSize() { return field_147000_g; }
 +
-+   public int slotHoverColor = -2130706433;
-+   public int getSlotHoverColor(int index) {
-+      return slotHoverColor;
++   public int slotColor = -2130706433;
++   public int getSlotColor(int index) {
++      return slotColor;
 +   }
  }

--- a/patches/minecraft/net/minecraft/client/gui/inventory/GuiContainer.java.patch
+++ b/patches/minecraft/net/minecraft/client/gui/inventory/GuiContainer.java.patch
@@ -1,6 +1,16 @@
 --- a/net/minecraft/client/gui/inventory/GuiContainer.java
 +++ b/net/minecraft/client/gui/inventory/GuiContainer.java
-@@ -107,6 +107,7 @@
+@@ -97,7 +97,8 @@
+             int j1 = slot.field_75223_e;
+             int k1 = slot.field_75221_f;
+             GlStateManager.func_179135_a(true, true, true, false);
+-            this.func_73733_a(j1, k1, j1 + 16, k1 + 16, -2130706433, -2130706433);
++            int hoverColor = this.field_147002_h.getHoverColor(i1);
++            this.func_73733_a(j1, k1, j1 + 16, k1 + 16, hoverColor, hoverColor);
+             GlStateManager.func_179135_a(true, true, true, true);
+             GlStateManager.func_179145_e();
+             GlStateManager.func_179126_j();
+@@ -107,6 +108,7 @@
        RenderHelper.func_74518_a();
        this.func_146979_b(p_73863_1_, p_73863_2_);
        RenderHelper.func_74520_c();
@@ -8,7 +18,7 @@
        InventoryPlayer inventoryplayer = this.field_146297_k.field_71439_g.field_71071_by;
        ItemStack itemstack = this.field_147012_x.func_190926_b() ? inventoryplayer.func_70445_o() : this.field_147012_x;
        if (!itemstack.func_190926_b()) {
-@@ -158,8 +159,10 @@
+@@ -158,8 +160,10 @@
        GlStateManager.func_179109_b(0.0F, 0.0F, 32.0F);
        this.field_73735_i = 200.0F;
        this.field_146296_j.field_77023_b = 200.0F;
@@ -20,7 +30,7 @@
        this.field_73735_i = 0.0F;
        this.field_146296_j.field_77023_b = 0.0F;
     }
-@@ -203,11 +206,10 @@
+@@ -203,11 +207,10 @@
        this.field_73735_i = 100.0F;
        this.field_146296_j.field_77023_b = 100.0F;
        if (itemstack.func_190926_b() && p_146977_1_.func_111238_b()) {
@@ -35,7 +45,7 @@
              this.func_175175_a(i, j, textureatlassprite, 16, 16);
              GlStateManager.func_179145_e();
              flag1 = true;
-@@ -268,7 +270,8 @@
+@@ -268,7 +271,8 @@
        if (super.mouseClicked(p_mouseClicked_1_, p_mouseClicked_3_, p_mouseClicked_5_)) {
           return true;
        } else {
@@ -45,7 +55,7 @@
           Slot slot = this.func_195360_a(p_mouseClicked_1_, p_mouseClicked_3_);
           long i = Util.func_211177_b();
           this.field_146993_M = this.field_146998_K == slot && i - this.field_146997_J < 250L && this.field_146992_L == p_mouseClicked_5_;
-@@ -277,6 +280,7 @@
+@@ -277,6 +281,7 @@
              int j = this.field_147003_i;
              int k = this.field_147009_r;
              boolean flag1 = this.func_195361_a(p_mouseClicked_1_, p_mouseClicked_3_, j, k, p_mouseClicked_5_);
@@ -53,7 +63,7 @@
              int l = -1;
              if (slot != null) {
                 l = slot.field_75222_d;
-@@ -302,7 +306,7 @@
+@@ -302,7 +307,7 @@
                    }
                 } else if (!this.field_147007_t) {
                    if (this.field_146297_k.field_71439_g.field_71071_by.func_70445_o().func_190926_b()) {
@@ -62,7 +72,7 @@
                          this.func_184098_a(slot, l, p_mouseClicked_5_, ClickType.CLONE);
                       } else {
                          boolean flag2 = l != -999 && (InputMappings.func_197956_a(340) || InputMappings.func_197956_a(344));
-@@ -326,7 +330,7 @@
+@@ -326,7 +331,7 @@
                          this.field_146987_F = 0;
                       } else if (p_mouseClicked_5_ == 1) {
                          this.field_146987_F = 1;
@@ -71,7 +81,7 @@
                          this.field_146987_F = 2;
                       }
                    }
-@@ -379,10 +383,13 @@
+@@ -379,10 +384,13 @@
     }
  
     public boolean mouseReleased(double p_mouseReleased_1_, double p_mouseReleased_3_, int p_mouseReleased_5_) {
@@ -85,7 +95,7 @@
        int k = -1;
        if (slot != null) {
           k = slot.field_75222_d;
-@@ -396,7 +403,7 @@
+@@ -396,7 +404,7 @@
           if (func_146272_n()) {
              if (!this.field_146994_N.func_190926_b()) {
                 for(Slot slot2 : this.field_147002_h.field_75151_b) {
@@ -94,7 +104,7 @@
                       this.func_184098_a(slot2, slot2.field_75222_d, p_mouseReleased_5_, ClickType.QUICK_MOVE);
                    }
                 }
-@@ -460,7 +467,7 @@
+@@ -460,7 +468,7 @@
  
              this.func_184098_a((Slot)null, -999, Container.func_94534_d(2, this.field_146987_F), ClickType.QUICK_CRAFT);
           } else if (!this.field_146297_k.field_71439_g.field_71071_by.func_70445_o().func_190926_b()) {
@@ -103,7 +113,7 @@
                 this.func_184098_a(slot, k, p_mouseReleased_5_, ClickType.CLONE);
              } else {
                 boolean flag1 = k != -999 && (InputMappings.func_197956_a(340) || InputMappings.func_197956_a(344));
-@@ -509,15 +516,15 @@
+@@ -509,15 +517,15 @@
        if (super.keyPressed(p_keyPressed_1_, p_keyPressed_2_, p_keyPressed_3_)) {
           return true;
        } else {
@@ -122,7 +132,7 @@
                 this.func_184098_a(this.field_147006_u, this.field_147006_u.field_75222_d, func_146271_m() ? 1 : 0, ClickType.THROW);
              }
           }
-@@ -529,7 +536,7 @@
+@@ -529,7 +537,7 @@
     protected boolean func_195363_d(int p_195363_1_, int p_195363_2_) {
        if (this.field_146297_k.field_71439_g.field_71071_by.func_70445_o().func_190926_b() && this.field_147006_u != null) {
           for(int i = 0; i < 9; ++i) {
@@ -131,7 +141,7 @@
                 this.func_184098_a(this.field_147006_u, this.field_147006_u.field_75222_d, i, ClickType.SWAP);
                 return true;
              }
-@@ -556,4 +563,11 @@
+@@ -556,4 +564,11 @@
        }
  
     }

--- a/patches/minecraft/net/minecraft/client/gui/inventory/GuiContainerCreative.java.patch
+++ b/patches/minecraft/net/minecraft/client/gui/inventory/GuiContainerCreative.java.patch
@@ -104,7 +104,7 @@
                 this.func_147050_b(itemgroup);
                 return true;
              }
-@@ -368,10 +412,12 @@
+@@ -368,15 +412,18 @@
     }
  
     private boolean func_147055_p() {
@@ -117,7 +117,13 @@
        int i = field_147058_w;
        field_147058_w = p_147050_1_.func_78021_a();
        GuiContainerCreative.ContainerCreative guicontainercreative$containercreative = (GuiContainerCreative.ContainerCreative)this.field_147002_h;
-@@ -447,13 +493,15 @@
+       this.field_147008_s.clear();
+       guicontainercreative$containercreative.field_148330_a.clear();
++      guicontainercreative$containercreative.tabHoverColor = p_147050_1_.getHoverColor();
+       if (p_147050_1_ == ItemGroup.field_192395_m) {
+          CreativeSettings creativesettings = this.field_146297_k.func_199403_al();
+ 
+@@ -447,13 +494,15 @@
        }
  
        if (this.field_147062_A != null) {
@@ -134,7 +140,7 @@
  
              this.func_147053_i();
           } else {
-@@ -512,16 +560,36 @@
+@@ -512,16 +561,36 @@
        this.func_146276_q_();
        super.func_73863_a(p_73863_1_, p_73863_2_, p_73863_3_);
  
@@ -172,7 +178,7 @@
        GlStateManager.func_179131_c(1.0F, 1.0F, 1.0F, 1.0F);
        GlStateManager.func_179140_f();
        this.func_191948_b(p_73863_1_, p_73863_2_);
-@@ -563,7 +631,10 @@
+@@ -563,7 +632,10 @@
              }
           }
  
@@ -184,7 +190,7 @@
        } else {
           super.func_146285_a(p_146285_1_, p_146285_2_, p_146285_3_);
        }
-@@ -575,14 +646,30 @@
+@@ -575,14 +647,30 @@
        RenderHelper.func_74520_c();
        ItemGroup itemgroup = ItemGroup.field_78032_a[field_147058_w];
  
@@ -217,7 +223,7 @@
        this.func_73729_b(this.field_147003_i, this.field_147009_r, 0, 0, this.field_146999_f, this.field_147000_g);
        this.field_147062_A.func_195608_a(p_146976_2_, p_146976_3_, p_146976_1_);
        GlStateManager.func_179131_c(1.0F, 1.0F, 1.0F, 1.0F);
-@@ -594,6 +681,9 @@
+@@ -594,6 +682,9 @@
           this.func_73729_b(i, j + (int)((float)(k - j - 17) * this.field_147067_x), 232 + (this.func_147055_p() ? 0 : 12), 0, 12, 15);
        }
  
@@ -227,7 +233,7 @@
        this.func_147051_a(itemgroup);
        if (itemgroup == ItemGroup.field_78036_m) {
           GuiInventory.func_147046_a(this.field_147003_i + 88, this.field_147009_r + 45, 20, (float)(this.field_147003_i + 88 - p_146976_2_), (float)(this.field_147009_r + 45 - 30 - p_146976_3_), this.field_146297_k.field_71439_g);
-@@ -602,6 +692,7 @@
+@@ -602,6 +693,7 @@
     }
  
     protected boolean func_195375_a(ItemGroup p_195375_1_, double p_195375_2_, double p_195375_4_) {
@@ -235,7 +241,7 @@
        int i = p_195375_1_.func_78020_k();
        int j = 28 * i;
        int k = 0;
-@@ -671,6 +762,8 @@
+@@ -671,6 +763,8 @@
        }
  
        GlStateManager.func_179140_f();
@@ -244,7 +250,27 @@
        this.func_73729_b(l, i1, j, k, 28, 32);
        this.field_73735_i = 100.0F;
        this.field_146296_j.field_77023_b = 100.0F;
-@@ -845,6 +938,31 @@
+@@ -718,6 +812,7 @@
+    @OnlyIn(Dist.CLIENT)
+    public static class ContainerCreative extends Container {
+       public NonNullList<ItemStack> field_148330_a = NonNullList.<ItemStack>func_191196_a();
++      private int tabHoverColor = 0;
+ 
+       public ContainerCreative(EntityPlayer p_i1086_1_) {
+          InventoryPlayer inventoryplayer = p_i1086_1_.field_71071_by;
+@@ -781,6 +876,11 @@
+       public boolean func_94531_b(Slot p_94531_1_) {
+          return p_94531_1_.field_75224_c instanceof InventoryPlayer || p_94531_1_.field_75221_f > 90 && p_94531_1_.field_75223_e <= 162;
+       }
++
++      @Override
++      public int getHoverColor(int index) {
++         return index > 44 ? super.getHoverColor(index) : tabHoverColor;
++      }
+    }
+ 
+    @OnlyIn(Dist.CLIENT)
+@@ -845,6 +945,31 @@
        public boolean func_82869_a(EntityPlayer p_82869_1_) {
           return this.field_148332_b.func_82869_a(p_82869_1_);
        }

--- a/patches/minecraft/net/minecraft/client/gui/inventory/GuiContainerCreative.java.patch
+++ b/patches/minecraft/net/minecraft/client/gui/inventory/GuiContainerCreative.java.patch
@@ -104,7 +104,7 @@
                 this.func_147050_b(itemgroup);
                 return true;
              }
-@@ -368,15 +412,18 @@
+@@ -368,12 +412,15 @@
     }
  
     private boolean func_147055_p() {
@@ -116,13 +116,10 @@
 +      if (p_147050_1_ == null) return;
        int i = field_147058_w;
        field_147058_w = p_147050_1_.func_78021_a();
++      slotHoverColor = p_147050_1_.getHoverColor();
        GuiContainerCreative.ContainerCreative guicontainercreative$containercreative = (GuiContainerCreative.ContainerCreative)this.field_147002_h;
        this.field_147008_s.clear();
        guicontainercreative$containercreative.field_148330_a.clear();
-+      guicontainercreative$containercreative.tabHoverColor = p_147050_1_.getHoverColor();
-       if (p_147050_1_ == ItemGroup.field_192395_m) {
-          CreativeSettings creativesettings = this.field_146297_k.func_199403_al();
- 
 @@ -447,13 +494,15 @@
        }
  
@@ -250,27 +247,7 @@
        this.func_73729_b(l, i1, j, k, 28, 32);
        this.field_73735_i = 100.0F;
        this.field_146296_j.field_77023_b = 100.0F;
-@@ -718,6 +812,7 @@
-    @OnlyIn(Dist.CLIENT)
-    public static class ContainerCreative extends Container {
-       public NonNullList<ItemStack> field_148330_a = NonNullList.<ItemStack>func_191196_a();
-+      private int tabHoverColor = 0;
- 
-       public ContainerCreative(EntityPlayer p_i1086_1_) {
-          InventoryPlayer inventoryplayer = p_i1086_1_.field_71071_by;
-@@ -781,6 +876,11 @@
-       public boolean func_94531_b(Slot p_94531_1_) {
-          return p_94531_1_.field_75224_c instanceof InventoryPlayer || p_94531_1_.field_75221_f > 90 && p_94531_1_.field_75223_e <= 162;
-       }
-+
-+      @Override
-+      public int getHoverColor(int index) {
-+         return tabHoverColor;
-+      }
-    }
- 
-    @OnlyIn(Dist.CLIENT)
-@@ -845,6 +945,31 @@
+@@ -845,6 +939,31 @@
        public boolean func_82869_a(EntityPlayer p_82869_1_) {
           return this.field_148332_b.func_82869_a(p_82869_1_);
        }

--- a/patches/minecraft/net/minecraft/client/gui/inventory/GuiContainerCreative.java.patch
+++ b/patches/minecraft/net/minecraft/client/gui/inventory/GuiContainerCreative.java.patch
@@ -265,7 +265,7 @@
 +
 +      @Override
 +      public int getHoverColor(int index) {
-+         return index > 44 ? super.getHoverColor(index) : tabHoverColor;
++         return tabHoverColor;
 +      }
     }
  

--- a/patches/minecraft/net/minecraft/client/gui/inventory/GuiContainerCreative.java.patch
+++ b/patches/minecraft/net/minecraft/client/gui/inventory/GuiContainerCreative.java.patch
@@ -116,7 +116,7 @@
 +      if (p_147050_1_ == null) return;
        int i = field_147058_w;
        field_147058_w = p_147050_1_.func_78021_a();
-+      slotHoverColor = p_147050_1_.getHoverColor();
++      slotColor = p_147050_1_.getSlotColor();
        GuiContainerCreative.ContainerCreative guicontainercreative$containercreative = (GuiContainerCreative.ContainerCreative)this.field_147002_h;
        this.field_147008_s.clear();
        guicontainercreative$containercreative.field_148330_a.clear();

--- a/patches/minecraft/net/minecraft/item/ItemGroup.java.patch
+++ b/patches/minecraft/net/minecraft/item/ItemGroup.java.patch
@@ -40,7 +40,7 @@
        return this.field_78033_n < 6;
     }
  
-@@ -220,4 +225,48 @@
+@@ -220,4 +225,52 @@
        }
  
     }
@@ -70,6 +70,10 @@
 +
 +   public int getLabelColor() {
 +      return 4210752;
++   }
++
++   public int getSlotColor() {
++      return -2130706433;
 +   }
 +   
 +   public static synchronized int getGroupCountSafe() {

--- a/patches/minecraft/net/minecraft/item/ItemGroup.java.patch
+++ b/patches/minecraft/net/minecraft/item/ItemGroup.java.patch
@@ -68,10 +68,6 @@
 +      return new net.minecraft.util.ResourceLocation("textures/gui/container/creative_inventory/tab_" + this.func_78015_f());
 +   }
 +
-+   public int getHoverColor() {
-+      return -2130706433;
-+   }
-+
 +   public int getLabelColor() {
 +      return 4210752;
 +   }

--- a/patches/minecraft/net/minecraft/item/ItemGroup.java.patch
+++ b/patches/minecraft/net/minecraft/item/ItemGroup.java.patch
@@ -68,6 +68,10 @@
 +      return new net.minecraft.util.ResourceLocation("textures/gui/container/creative_inventory/tab_" + this.func_78015_f());
 +   }
 +
++   public int getHoverColor() {
++      return -2130706433;
++   }
++
 +   public int getLabelColor() {
 +      return 4210752;
 +   }


### PR DESCRIPTION
This adds getSlotColor(slotIndex) to the GuiContainer class, which is used for rendering the highlight when the mouse is hovering over a slot in the container. It can be overriden by custom GuiContainers to better suit their background images.

The ItemGroup class also has getSlotColor() which can be overriden when registering a new group, similar to how createIcon() is. This goes together with ItemGroups being able to specify their background image.

Examples were temporarily implemented in the Minecraft source code for screenshots, as I'm unable to get test mods running in the Forge environment.

**GuiContainer Example:**
![container_code](https://user-images.githubusercontent.com/23238153/51787848-adf2cb00-216e-11e9-93a3-8ff369670813.PNG)
![container_gif](https://i.gyazo.com/023b867f81ba3e789c5942240ae872c5.gif)

**ItemGroup Example**
![group_code](https://user-images.githubusercontent.com/23238153/51787968-ffe82080-216f-11e9-849f-a4a894a782b6.PNG)
![group_gif](https://i.gyazo.com/19d9141494eb5a0f6548a471f1057ba7.gif)
