### PR TITLE
[1.13]  Update MDK based on MinecraftForge/ForgeGradle#546

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -12,19 +12,13 @@ buildscript {
 import groovy.json.JsonSlurper
 import groovy.json.JsonBuilder
 import java.text.SimpleDateFormat
-import java.util.Date
-import java.util.LinkedHashMap
 import java.security.MessageDigest
-import java.net.URL
 import net.minecraftforge.gradle.common.task.ArchiveChecksum
 import net.minecraftforge.gradle.common.task.DownloadMavenArtifact
 import net.minecraftforge.gradle.common.task.SignJar
 import net.minecraftforge.gradle.patcher.task.ApplyBinPatches
 import org.apache.tools.ant.filters.ReplaceTokens
-import de.undercouch.gradle.tasks.download.Download
 import net.minecraftforge.gradle.patcher.task.TaskReobfuscateJar
-
-import java.util.stream.Collectors
 
 plugins {
     id 'net.minecrell.licenser' version '0.4'
@@ -69,6 +63,19 @@ project(':clean') {
         patchedSrc = file('src/main/java')
         mappings channel: MAPPING_CHANNEL, version: MAPPING_VERSION
         mcVersion = MC_VERSION
+
+        runs {
+            clean_client {
+                taskName 'clean_client'
+                main 'mcp.client.Start'
+                environment 'assetDirectory', downloadAssets.output
+            }
+
+            clean_server {
+                taskName 'clean_server'
+                main 'net.minecraft.server.MinecraftServer'
+            }
+        }
     }
     task runclient(type: JavaExec) {
         doFirst {
@@ -173,7 +180,8 @@ project(':forge') {
         exc = file("$rootDir/src/main/resources/forge.exc")
         srgPatches = true
         runs {
-            forge_client = {
+            forge_client {
+                taskName 'forge_client'
                 main 'net.minecraftforge.fml.LaunchTesting'
                 environment = [
                     target: 'fmldevclient',
@@ -192,7 +200,8 @@ project(':forge') {
                     'fmllauncher.version': SPEC_VERSION
                 ]
             }
-            forge_server = {
+            forge_server {
+                taskName 'forge_server'
                 main 'net.minecraftforge.fml.LaunchTesting'
                 environment = [
                     target: 'fmldevserver'
@@ -810,7 +819,7 @@ project(':forge') {
         }
         addLibrary("${project.group}:${project.name}:${project.version}:launcher")
         runs {
-            client = {
+            client {
                 main 'net.minecraftforge.userdev.UserdevLauncher'
                 environment 'target', 'fmluserdevclient'
                 environment 'assetDirectory', '{assets_root}'
@@ -822,7 +831,7 @@ project(':forge') {
                 environment 'MOD_CLASSES', '{source_roots}'
                 environment 'MCP_MAPPINGS', '{mcp_mappings}'
             }
-            server = {
+            server {
                 main 'net.minecraftforge.userdev.UserdevLauncher'
                 environment 'target', 'fmluserdevserver'
                 environment 'FORGE_VERSION', project.version.substring(MC_VERSION.length() + 1)

--- a/mdk/build.gradle
+++ b/mdk/build.gradle
@@ -1,15 +1,27 @@
 buildscript {
     repositories {
-        maven { url = 'https://files.minecraftforge.net/maven' }
+        // Try to resolve locally first
+        mavenLocal()
+
+        // Then from Forge's maven
+        maven {
+            name = 'Forge'
+            url = 'https://files.minecraftforge.net/maven'
+        }
+
         jcenter()
         mavenCentral()
     }
+
     dependencies {
         classpath group: 'net.minecraftforge.gradle', name: 'ForgeGradle', version: '3.+', changing: true
     }
 }
+
 apply plugin: 'net.minecraftforge.gradle'
+
 //Only edit below this line, the above code adds and enables the necessary things for Forge to be setup.
+
 apply plugin: 'eclipse'
 
 version = '1.0'
@@ -32,21 +44,83 @@ minecraft {
     // default run configurations.
     // these can be tweaked, removed, or duplicated as needed.
     runs {
-        client = {
-            // recommended logging data for a userdev environment
-            properties 'forge.logging.markers': 'SCAN,REGISTRIES,REGISTRYDUMP'
-            // recommended logging level for the console
-            properties 'forge.logging.console.level': 'debug'
+        // Specifies the name of the run config. 'client' will extend from the userdevConfig's 'client' run config
+        client {
             workingDirectory project.file('run').canonicalPath
-            source sourceSets.main
+
+            // Recommended logging data for a userdev environment
+            properties 'forge.logging.markers': 'SCAN,REGISTRIES,REGISTRYDUMP'
+            // Recommended logging level for the console
+            properties 'forge.logging.console.level': 'debug'
+
+            // Here you can specify a number of mods that are contained
+            // within your project. This allows for having multiple mods,
+            // from multiple source sets, loaded at runtime
+            mods {
+                // The name of the mod
+                ExampleMod {
+                    // The source set for the mod
+                    source sourceSets.main
+
+                    // You can specify multiple source sets per mod
+                    // NOTE: the first source set _MUST_ be the source set that contains the 'META-INF/mods.toml' file
+                    // sources sourceSets.main, sourceSets.api
+                    
+                    // You can also specify arbitrary classes directories, for this given mod
+                    // NOTE: only 'classes' can be used and not 'class' due to it being a reserved keyword
+                    // classes project.file('some/classes/dir')
+                    
+                    // You can also overwrite the existing resource directory specified
+                    // resource = project.file('only/this/resources/dir')
+                    
+                    // The same goes for classes
+                    // classes = project.file('only/this/classes/dir')
+                }
+            }
         }
-        server = {
-            // recommended logging data for a userdev environment
-            properties 'forge.logging.markers': 'SCAN,REGISTRIES,REGISTRYDUMP'
-            // recommended logging level for the console
-            properties 'forge.logging.console.level': 'debug'
+
+        // You can specify any number of run configs
+        // NOTE: only the run configs named 'client' and 'server' will extend from their userdevConfig's counterparts
+        testClient {
+            // You can specify a parent run to be merged into this run config
+            // NOTE: it will not override anything set within this run config
+            parent runs.client
+
+            mods {
+                // Because we are including the parent 'runs.client' config into this run config,
+                // the mod 'ExampleMod' will be added
+
+                // You can specify any number of mods
+                ExampleModTest {
+                    source sourceSets.test
+                }
+            }
+        }
+        
+        server {
             workingDirectory project.file('run').canonicalPath
-            source sourceSets.main
+            
+            properties 'forge.logging.markers': 'SCAN,REGISTRIES,REGISTRYDUMP'
+            properties 'forge.logging.console.level': 'debug'
+
+            // You can specify any arguments you wish to pass to the launcher
+            arg 'nogui'
+
+            mods {
+                ExampleMod {
+                    source sourceSets.main
+                }
+            }
+        }
+
+        testServer {
+            parent runs.server
+
+            mods {
+                ExampleModTest {
+                    source sourceSets.test
+                }
+            }
         }
     }
 }
@@ -88,5 +162,39 @@ jar {
                     "Implementation-Version": "${version}",
                     "Implementation-Vendor" :"examplemodsareus",
                     "Implementation-Timestamp": new Date().format("yyyy-MM-dd'T'HH:mm:ssZ")],)
+    }
+}
+
+processResources {
+    // this will ensure that this task is redone when the versions change.
+    inputs.property 'version', project.version
+    inputs.property 'mcversion', '@MC_VERSION@'
+
+    // replace stuff in mcmod.info, nothing else
+    from(sourceSets.main.resources.srcDirs) {
+        include 'META_INF/mods.toml'
+                
+        // replace version and mcversion
+        expand 'version':project.version, 'mcversion': '@MC_VERSION@'
+    }
+
+    // copy everything else except the mods.toml
+    from(sourceSets.main.resources.srcDirs) {
+        exclude 'META_INF/mods.toml'
+    }
+}
+
+processTestResources {
+    inputs.property 'version', project.version
+    inputs.property 'mcversion', '@MC_VERSION@'
+
+    from(sourceSets.test.resources.srcDirs) {
+        include 'META_INF/mods.toml'
+
+        expand 'version':project.version, 'mcversion': '@MC_VERSION@'
+    }
+
+    from(sourceSets.test.resources.srcDirs) {
+        exclude 'META_INF/mods.toml'
     }
 }

--- a/mdk/src/main/java/com/example/examplemod/ExampleMod.java
+++ b/mdk/src/main/java/com/example/examplemod/ExampleMod.java
@@ -2,6 +2,7 @@ package com.example.examplemod;
 
 import net.minecraft.block.Block;
 import net.minecraft.init.Blocks;
+import net.minecraft.item.Item;
 import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.event.RegistryEvent;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
@@ -11,6 +12,7 @@ import net.minecraftforge.fml.event.lifecycle.FMLClientSetupEvent;
 import net.minecraftforge.fml.event.lifecycle.FMLCommonSetupEvent;
 import net.minecraftforge.fml.event.lifecycle.InterModEnqueueEvent;
 import net.minecraftforge.fml.event.lifecycle.InterModProcessEvent;
+import net.minecraftforge.fml.event.server.FMLServerAboutToStartEvent;
 import net.minecraftforge.fml.event.server.FMLServerStartingEvent;
 import net.minecraftforge.fml.javafmlmod.FMLModLoadingContext;
 import org.apache.logging.log4j.LogManager;
@@ -20,12 +22,17 @@ import java.util.stream.Collectors;
 
 // The value here should match an entry in the META-INF/mods.toml file
 @Mod("examplemod")
-public class ExampleMod
-{
+public class ExampleMod {
+
     // Directly reference a log4j logger.
     private static final Logger LOGGER = LogManager.getLogger();
 
     public ExampleMod() {
+        // Register the registerBlocks method for registry
+        FMLModLoadingContext.get().getModEventBus().addGenericListener(Block.class, this::registerBlocks);
+        // Register the registerItems method for registry
+        FMLModLoadingContext.get().getModEventBus().addGenericListener(Item.class, this::registerItems);
+
         // Register the setup method for modloading
         FMLModLoadingContext.get().getModEventBus().addListener(this::setup);
         // Register the enqueueIMC method for modloading
@@ -39,45 +46,60 @@ public class ExampleMod
         MinecraftForge.EVENT_BUS.register(this);
     }
 
-    private void setup(final FMLCommonSetupEvent event)
-    {
-        // some preinit code
-        LOGGER.info("HELLO FROM PREINIT");
+    private void registerBlocks(final RegistryEvent.Register<Block> event) {
+        // Register a new block here
+        LOGGER.info("HELLO from Register Block");
+    }
+
+    private void registerItems(final RegistryEvent.Register<Item> event) {
+        // Register a new item here
+        LOGGER.info("HELLO from Register Item");
+    }
+
+    private void setup(final FMLCommonSetupEvent event) {
+        // Some setup code
+        LOGGER.info("HELLO FROM SETUP");
         LOGGER.info("DIRT BLOCK >> {}", Blocks.DIRT.getRegistryName());
     }
 
     private void doClientStuff(final FMLClientSetupEvent event) {
-        // do something that can only be done on the client
+        // Do something that can only be done on the client
         LOGGER.info("Got game settings {}", event.getMinecraftSupplier().get().gameSettings);
     }
 
-    private void enqueueIMC(final InterModEnqueueEvent event)
-    {
-        // some example code to dispatch IMC to another mod
-        InterModComms.sendTo("forge", "helloworld", () -> { LOGGER.info("Hello world"); return "Hello world";});
+    private void enqueueIMC(final InterModEnqueueEvent event) {
+        // Some example code to dispatch IMC to another mod
+        InterModComms.sendTo("forge", "helloworld", () -> {
+            LOGGER.info("Hello world");
+
+            return "Hello world";
+        });
     }
 
-    private void processIMC(final InterModProcessEvent event)
-    {
-        // some example code to receive and process InterModComms from other mods
-        LOGGER.info("Got IMC", event.getIMCStream().
-                map(m->m.getMessageSupplier().get()).
-                collect(Collectors.toList()));
+    private void processIMC(final InterModProcessEvent event) {
+        // Some example code to receive and process InterModComms from other mods
+        LOGGER.info("Got IMC {}", event.getIMCStream()
+                .map(m -> m.getMessageSupplier().get())
+                .collect(Collectors.toList()));
     }
+
     // You can use SubscribeEvent and let the Event Bus discover methods to call
     @SubscribeEvent
-    public void onBlocksRegistry(final RegistryEvent.Register<Block> blockRegistryEvent) {
-        // register a new block here
-        LOGGER.info("HELLO from Register Block");
+    public final void serverAboutToStart(final FMLServerAboutToStartEvent event) {
+        // Do something when the server is about to start
+        LOGGER.info("HELLO from server about to start");
     }
 
     // You can use EventBusSubscriber to automatically subscribe events on the contained class
     @Mod.EventBusSubscriber
     public static class ServerEvents {
+
         @SubscribeEvent
         public static void onServerStarting(FMLServerStartingEvent event) {
-            // do something when the server starts
+            // Do something when the server starts
             LOGGER.info("HELLO from server starting");
         }
+
     }
+
 }

--- a/mdk/src/test/java/com/example/examplemod/test/ExampleModTest.java
+++ b/mdk/src/test/java/com/example/examplemod/test/ExampleModTest.java
@@ -1,0 +1,21 @@
+package com.example.examplemod.test;
+
+import net.minecraftforge.fml.InterModComms;
+import net.minecraftforge.fml.common.Mod;
+import net.minecraftforge.fml.event.lifecycle.InterModEnqueueEvent;
+import net.minecraftforge.fml.javafmlmod.FMLModLoadingContext;
+
+@Mod("examplemodtest")
+public class ExampleModTest {
+
+    public ExampleModTest() {
+        // Register the enqueueIMC method for modloading
+        FMLModLoadingContext.get().getModEventBus().addListener(this::enqueueIMC);
+    }
+
+    private void enqueueIMC(final InterModEnqueueEvent event) {
+        // Dispatch IMC to ExampleMod
+        InterModComms.sendTo("examplemod", "helloworld", (() -> "HELLO from ExampleModTest"));
+    }
+
+}

--- a/mdk/src/test/resources/META-INF/mods.toml
+++ b/mdk/src/test/resources/META-INF/mods.toml
@@ -1,0 +1,29 @@
+modLoader = 'javafml'
+loaderVersion = '[24,)'
+
+[[mods]]
+    modId = 'examplemodtest'
+    version = '1.0'
+    displayName = 'Example Mod Test'
+    description = 'A test mod to test Example Mod'
+
+[[dependencies.examplemodtest]]
+    modId = 'examplemod'
+    mandatory = true
+    versionRange = '[1.0]'
+    ordering = 'AFTER'
+    side = 'BOTH'
+
+[[dependencies.examplemodtest]]
+    modId = 'forge'
+    mandatory = true
+    versionRange = '[24,)'
+    ordering = 'NONE'
+    side = 'BOTH'
+
+[[dependencies.examplemodtest]]
+    modId = 'minecraft'
+    mandatory = true
+    versionRange = '[1.13]'
+    ordering = 'NONE'
+    side = 'BOTH'

--- a/mdk/src/test/resources/pack.mcmeta
+++ b/mdk/src/test/resources/pack.mcmeta
@@ -1,0 +1,7 @@
+{
+    "pack": {
+        "description": "examplemodtest resources",
+        "pack_format": 4,
+        "_comment": "A pack_format of 4 requires json lang files. Note: we require v4 pack meta for all mods."
+    }
+}

--- a/src/main/java/net/minecraftforge/registries/GameData.java
+++ b/src/main/java/net/minecraftforge/registries/GameData.java
@@ -811,8 +811,7 @@ public class GameData
             if (!filter.test(rl)) continue;
             ForgeRegistry<?> reg = RegistryManager.ACTIVE.getRegistry(rl);
             reg.unfreeze();
-            final RegistryEvent.Register<?> registerEvent = reg.getRegisterEvent(rl);
-            lifecycleEventProvider.setCustomEventSupplier(() -> registerEvent);
+            lifecycleEventProvider.setCustomEventSupplier(() -> reg.getRegisterEvent(rl));
             lifecycleEventProvider.changeProgression(LifecycleEventProvider.LifecycleEvent.Progression.STAY);
             if (i==keysSize-1) lifecycleEventProvider.changeProgression(LifecycleEventProvider.LifecycleEvent.Progression.NEXT);
             eventDispatcher.accept(lifecycleEventProvider);


### PR DESCRIPTION
Currently the way that **ExplodedDirectoryLocator** works is assuming that there is only a single resource directory, because of this the first path in the **MOD_CLASSES** environment variable is considered as the resources directory. A result of this is that, if you have different mods in different sourcesets, they are not loaded. If you specify the first source as a sourceset that has no _**mods.toml**_, in its resources directory, then it just kills the locator. Alternatively, if any of the specified paths in the **MOD_CLASSES** environment variable don't exist, it also kills the locator. Essentially, if you don't order things right or have any empty resources or classes in any sourceset it will fail at said point.

The provided solution for not existent paths is to just filter them out.

The provided solution for the locating would is to scan all of the directories in the **MOD_CLASSES** environment variable, however, there is one issue: because it tries to separate the resources and classes, if two files exist in two sourcesets, e.g: _**test/resources/META-INF/mods.toml**_ & _**main/resources/META-INF/mods.toml**_ then whichever is in the sourceset that is referenced first will be the one that is loaded.

This fix essentially just allows it to find the mod, independent of the ordering, however the above issue still applies. Any feedback or suggestions are definitely appreciated.