### PR TITLE
Fix datapack walking not working for mod datapacks. Closes #5334

### DIFF
--- a/src/main/java/net/minecraftforge/fml/packs/ModFileResourcePack.java
+++ b/src/main/java/net/minecraftforge/fml/packs/ModFileResourcePack.java
@@ -79,7 +79,7 @@ public class ModFileResourcePack extends AbstractResourcePack
         try
         {
             Path root = modFile.getLocator().findPath(modFile, type.getDirectoryName()).toAbsolutePath();
-            Path inputPath = root.resolve(pathIn);
+            Path inputPath = Paths.get(pathIn);
             return Files.walk(root).
                     map(path -> root.relativize(path.toAbsolutePath())).
                     filter(path -> path.getNameCount() > 1 && path.getNameCount() - 1 <= maxDepth). // Make sure the depth is within bounds, ignoring domain

--- a/src/main/java/net/minecraftforge/fml/packs/ModFileResourcePack.java
+++ b/src/main/java/net/minecraftforge/fml/packs/ModFileResourcePack.java
@@ -79,7 +79,8 @@ public class ModFileResourcePack extends AbstractResourcePack
         try
         {
             Path root = modFile.getLocator().findPath(modFile, type.getDirectoryName()).toAbsolutePath();
-            Path inputPath = Paths.get(pathIn);
+            Path inputPath = root.getFileSystem().getPath(pathIn);
+
             return Files.walk(root).
                     map(path -> root.relativize(path.toAbsolutePath())).
                     filter(path -> path.getNameCount() > 1 && path.getNameCount() - 1 <= maxDepth). // Make sure the depth is within bounds, ignoring domain


### PR DESCRIPTION
See comment below for main problem and solution description

This can be seen to work as the Forge defined block tags actually are loaded now.

Before (there's nothing above minecraft:acacia_logs):
![2019-01-09_15 24 29](https://user-images.githubusercontent.com/2015032/50929783-c4392100-1423-11e9-9542-bd9e544f6ef1.png)

After:
![2019-01-09_15 29 12](https://user-images.githubusercontent.com/2015032/50929799-cbf8c580-1423-11e9-8f2b-abdc756c10ef.png)
