### PR TITLE
[1.13] Reimplemented the ObjectHolder discovery

### DIFF
--- a/patches/minecraft/net/minecraft/fluid/Fluid.java.patch
+++ b/patches/minecraft/net/minecraft/fluid/Fluid.java.patch
@@ -1,11 +1,14 @@
 --- a/net/minecraft/fluid/Fluid.java
 +++ b/net/minecraft/fluid/Fluid.java
-@@ -19,7 +19,7 @@
+@@ -19,9 +19,9 @@
  import net.minecraftforge.api.distmarker.Dist;
  import net.minecraftforge.api.distmarker.OnlyIn;
  
 -public abstract class Fluid {
-+public abstract class Fluid implements net.minecraftforge.common.extensions.IForgeFluid {
++public abstract class Fluid extends net.minecraftforge.registries.ForgeRegistryEntry<Fluid> implements net.minecraftforge.common.extensions.IForgeFluid {
     private static final ResourceLocation field_207199_a = new ResourceLocation("empty");
-    public static final RegistryNamespacedDefaultedByKey<ResourceLocation, Fluid> field_205588_a = new RegistryNamespacedDefaultedByKey<ResourceLocation, Fluid>(field_207199_a);
+-   public static final RegistryNamespacedDefaultedByKey<ResourceLocation, Fluid> field_205588_a = new RegistryNamespacedDefaultedByKey<ResourceLocation, Fluid>(field_207199_a);
++   public static final RegistryNamespacedDefaultedByKey<ResourceLocation, Fluid> field_205588_a = net.minecraftforge.registries.GameData.getWrapperDefaulted(Fluid.class);
     public static final ObjectIntIdentityMap<IFluidState> field_207201_d = new ObjectIntIdentityMap<IFluidState>();
+    protected final StateContainer<Fluid, IFluidState> field_207202_e;
+    private IFluidState field_207200_b;

--- a/patches/minecraft/net/minecraft/particles/ParticleType.java.patch
+++ b/patches/minecraft/net/minecraft/particles/ParticleType.java.patch
@@ -1,0 +1,13 @@
+--- a/net/minecraft/particles/ParticleType.java
++++ b/net/minecraft/particles/ParticleType.java
+@@ -3,8 +3,8 @@
+ import net.minecraft.util.ResourceLocation;
+ import net.minecraft.util.registry.RegistryNamespaced;
+ 
+-public class ParticleType<T extends IParticleData> {
+-   public static final RegistryNamespaced<ResourceLocation, ParticleType<? extends IParticleData>> field_197577_a = new RegistryNamespaced<ResourceLocation, ParticleType<? extends IParticleData>>();
++public class ParticleType<T extends IParticleData> extends net.minecraftforge.registries.ForgeRegistryEntry<ParticleType<?>> {
++   public static final RegistryNamespaced<ResourceLocation, ParticleType<? extends IParticleData>> field_197577_a = (RegistryNamespaced)net.minecraftforge.registries.GameData.getWrapper(ParticleType.class);
+    private final ResourceLocation field_197579_c;
+    private final boolean field_197581_e;
+    private final IParticleData.IDeserializer<T> field_197582_f;

--- a/src/main/java/net/minecraftforge/fml/ModLoader.java
+++ b/src/main/java/net/minecraftforge/fml/ModLoader.java
@@ -30,6 +30,7 @@ import net.minecraftforge.fml.loading.LoadingModList;
 import net.minecraftforge.fml.loading.moddiscovery.ModFile;
 import net.minecraftforge.fml.loading.moddiscovery.ModFileInfo;
 import net.minecraftforge.registries.GameData;
+import net.minecraftforge.registries.ObjectHolderRegistry;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -86,6 +87,7 @@ public class ModLoader
         modList.setLoadedMods(modContainerStream.collect(Collectors.toList()));
         dispatchAndHandleError(LifecycleEventProvider.CONSTRUCT);
         GameData.fireCreateRegistryEvents();
+        ObjectHolderRegistry.INSTANCE.findObjectHolders(modList.getAllScanData());
         CapabilityManager.INSTANCE.injectCapabilities(modList.getAllScanData());
         GameData.fireRegistryEvents();
         dispatchAndHandleError(LifecycleEventProvider.PREINIT);

--- a/src/main/java/net/minecraftforge/registries/ForgeRegistries.java
+++ b/src/main/java/net/minecraftforge/registries/ForgeRegistries.java
@@ -22,9 +22,11 @@ package net.minecraftforge.registries;
 import net.minecraft.block.Block;
 import net.minecraft.enchantment.Enchantment;
 import net.minecraft.entity.EntityType;
+import net.minecraft.fluid.Fluid;
 import net.minecraft.init.Bootstrap;
 import net.minecraft.item.Item;
 import net.minecraft.item.crafting.IRecipe;
+import net.minecraft.particles.ParticleType;
 import net.minecraft.potion.Potion;
 import net.minecraft.potion.PotionType;
 import net.minecraft.tileentity.TileEntityType;
@@ -54,6 +56,8 @@ public class ForgeRegistries
     public static final IForgeRegistry<VillagerProfession>  VILLAGER_PROFESSIONS = RegistryManager.ACTIVE.getRegistry(VillagerProfession.class);
     public static final IForgeRegistry<EntityType<?>>       ENTITIES     = (IForgeRegistry)RegistryManager.ACTIVE.getRegistry(EntityType.class);
     public static final IForgeRegistry<TileEntityType<?>>   TILE_ENTITIES = (IForgeRegistry)RegistryManager.ACTIVE.getRegistry(TileEntityType.class);
+    public static final IForgeRegistry<ParticleType<?>>     PARTICLES    = (IForgeRegistry)RegistryManager.ACTIVE.getRegistry(ParticleType.class);
+    public static final IForgeRegistry<Fluid>               FLUIDS       = RegistryManager.ACTIVE.getRegistry(Fluid.class);
     /**
      * This function is just to make sure static inializers in other classes have run and setup their registries before we query them.
      */

--- a/src/main/java/net/minecraftforge/registries/GameData.java
+++ b/src/main/java/net/minecraftforge/registries/GameData.java
@@ -29,8 +29,10 @@ import net.minecraft.block.material.Material;
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.enchantment.Enchantment;
 import net.minecraft.entity.EntityType;
+import net.minecraft.fluid.Fluid;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemBlock;
+import net.minecraft.particles.ParticleType;
 import net.minecraft.potion.Potion;
 import net.minecraft.potion.PotionType;
 import net.minecraft.tileentity.TileEntityType;
@@ -92,6 +94,8 @@ public class GameData
     public static final ResourceLocation ENTITIES     = new ResourceLocation("minecraft:entities");
     public static final ResourceLocation TILEENTITIES = new ResourceLocation("minecraft:tileentities");
     public static final ResourceLocation PROFESSIONS  = new ResourceLocation("minecraft:villagerprofessions");
+    public static final ResourceLocation PARTICLES    = new ResourceLocation("minecraft:particles");
+    public static final ResourceLocation FLUIDS       = new ResourceLocation("minecraft:fluids");
     private static final int MAX_BLOCK_ID = 4095;
     private static final int MIN_ITEM_ID = MAX_BLOCK_ID + 1;
     private static final int MAX_ITEM_ID = 31999;
@@ -102,6 +106,8 @@ public class GameData
     private static final int MAX_ENCHANTMENT_ID = Short.MAX_VALUE - 1; // Short - serialized as a short in ItemStack NBTs.
     private static final int MAX_ENTITY_ID = Integer.MAX_VALUE >> 5; // Varint (SPacketSpawnMob)
     private static final int MAX_TILE_ENTITY_ID = Integer.MAX_VALUE; //Doesnt seem to be serialized anywhere, so no max.
+    private static final int MAX_PARTICLE_ID = Integer.MAX_VALUE;
+    private static final int MAX_FLUID_ID = Integer.MAX_VALUE;
     private static final int MAX_PROFESSION_ID = 1024; //TODO: Is this serialized anywhere anymore?
 
     private static final ResourceLocation BLOCK_TO_ITEM    = new ResourceLocation("minecraft:blocktoitemmap");
@@ -136,6 +142,8 @@ public class GameData
         // TODO do we need the callback and the static field anymore?
         makeRegistry(ENTITIES,     EntityType.class, MAX_ENTITY_ID).create();
         makeRegistry(TILEENTITIES, TileEntityType.class, MAX_TILE_ENTITY_ID).disableSaving().create();
+        makeRegistry(PARTICLES,    ParticleType.class, MAX_PARTICLE_ID).disableSaving().create();
+        makeRegistry(FLUIDS,       Fluid.class,       MAX_FLUID_ID, new ResourceLocation("empty")).create();
     }
 
     private static <T extends IForgeRegistryEntry<T>> RegistryBuilder<T> makeRegistry(ResourceLocation name, Class<T> type, int min, int max)

--- a/src/main/java/net/minecraftforge/registries/ObjectHolderRef.java
+++ b/src/main/java/net/minecraftforge/registries/ObjectHolderRef.java
@@ -103,9 +103,9 @@ class ObjectHolderRef
         {
             Class<?> type = typesToExamine.remove();
             Collections.addAll(typesToExamine, type.getInterfaces());
-            if (ForgeRegistryEntry.class.isAssignableFrom(type))
+            if (IForgeRegistryEntry.class.isAssignableFrom(type))
             {
-                registry = (ForgeRegistry<?>)RegistryManager.ACTIVE.getRegistry((Class<ForgeRegistryEntry>)type);
+                registry = (ForgeRegistry<?>)RegistryManager.ACTIVE.getRegistry((Class<IForgeRegistryEntry>)type);
                 final Class<?> parentType = type.getSuperclass();
                 if (parentType != null)
                 {

--- a/src/test/java/net/minecraftforge/debug/mod/ObjectHolderAnnotationTest.java
+++ b/src/test/java/net/minecraftforge/debug/mod/ObjectHolderAnnotationTest.java
@@ -23,20 +23,26 @@ import net.minecraft.block.Block;
 import net.minecraft.potion.Potion;
 import net.minecraft.util.ResourceLocation;
 import net.minecraft.util.SoundEvent;
+import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.event.RegistryEvent;
 import net.minecraftforge.fml.common.Mod;
 import net.minecraftforge.fml.common.event.FMLInitializationEvent;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
 import net.minecraftforge.fml.common.registry.GameRegistry;
 import net.minecraftforge.registries.IForgeRegistryEntry;
+import net.minecraftforge.registries.ObjectHolder;
 import net.minecraftforge.registries.RegistryBuilder;
 
-@Mod(modid = ObjectHolderAnnotationTest.MODID, name = "ObjectHolderTests", version = "1.0", acceptableRemoteVersions = "*")
+@Mod(ObjectHolderAnnotationTest.MODID)
 public class ObjectHolderAnnotationTest
 {
     public static final String MODID = "objectholdertest";
 
-    @Mod.EventHandler
+    public ObjectHolderAnnotationTest() {
+        FMLModLoadingContext.get().getModEventBus().addListener(this::init);
+        MinecraftForge.EVENT_BUS.register(Registration.class);
+    }
+
     public void init(FMLInitializationEvent event)
     {
         //verifies @ObjectHolder with custom id
@@ -46,7 +52,7 @@ public class ObjectHolderAnnotationTest
         //verifies minecraft:air is now resolvable
         assert VanillaObjectHolder.air != null;
         //verifies unexpected name should not have defaulted to AIR.
-        assert VanillaObjectHolder.nonExistentBlock == null;
+        assert VanillaObjectHolder.non_existent_block == null;
         //verifies custom registries
         assert CustomRegistryObjectHolder.custom_entry != null;
         //verifies interfaces are supported
@@ -59,25 +65,23 @@ public class ObjectHolderAnnotationTest
         protected PotionForge(ResourceLocation location, boolean badEffect, int potionColor)
         {
             super(badEffect, potionColor);
-            setPotionName("potion." + location.getResourcePath());
             setRegistryName(location);
         }
     }
 
-    @Mod.EventBusSubscriber(modid = MODID)
     public static class Registration
     {
-        @net.minecraftforge.eventbus.api.SubscribeEvent
+        @SubscribeEvent
         public static void newRegistry(RegistryEvent.NewRegistry event)
         {
             new RegistryBuilder<ICustomRegistryEntry>()
                     .setType(ICustomRegistryEntry.class)
-                    .setName(new ResourceLocation("object_holder_test_custom_registry"))
+                    .setName(new ResourceLocation(MODID, "object_holder_test_custom_registry"))
                     .setIDRange(0, 255)
                     .create();
         }
 
-        @net.minecraftforge.eventbus.api.SubscribeEvent
+        @SubscribeEvent
         public static void registerPotions(RegistryEvent.Register<Potion> event)
         {
             event.getRegistry().register(
@@ -124,24 +128,24 @@ public class ObjectHolderAnnotationTest
         }
     }
 
-    @GameRegistry.ObjectHolder("minecraft")
+    @ObjectHolder("minecraft")
     static class VanillaObjectHolder
     {
         //Tests importing vanilla objects that need the @ObjectHolder annotation to get a valid ResourceLocation
-        @GameRegistry.ObjectHolder("ui.button.click")
+        @ObjectHolder("ui.button.click")
         public static final SoundEvent uiButtonClick = null;
         public static final Block air = null;
-        public static final Block nonExistentBlock = null;
+        public static final Block non_existent_block = null;
     }
 
-    @GameRegistry.ObjectHolder(ObjectHolderAnnotationTest.MODID)
+    @ObjectHolder(ObjectHolderAnnotationTest.MODID)
     static class ForgeObjectHolder
     {
         //Tests using subclasses for injections
         public static final ObjectHolderAnnotationTest.PotionForge forge_potion = null;
     }
 
-    @GameRegistry.ObjectHolder(ObjectHolderAnnotationTest.MODID)
+    @ObjectHolder(ObjectHolderAnnotationTest.MODID)
     static class CustomRegistryObjectHolder
     {
         //Tests whether custom registries can be used


### PR DESCRIPTION
Reimplemented the ObjectHolder discovery for the new mod loading.
Added Fluid and ParticleType registries because Fluids and Particles lists in `net.minecraft.init` have the @ObjectHolder annotation and need a registry for those to not crash on startup.

Updated the test for this, did run it in another folder temporary to not need to update all test for now.
