### PR TITLE
Move registry events to after preinit

### DIFF
--- a/src/main/java/net/minecraftforge/fml/ModLoader.java
+++ b/src/main/java/net/minecraftforge/fml/ModLoader.java
@@ -90,8 +90,8 @@ public class ModLoader
         GameData.fireCreateRegistryEvents();
         ObjectHolderRegistry.findObjectHolders();
         CapabilityManager.INSTANCE.injectCapabilities(modList.getAllScanData());
-        GameData.fireRegistryEvents();
         dispatchAndHandleError(LifecycleEventProvider.PREINIT);
+        GameData.fireRegistryEvents();
         DistExecutor.runWhenOn(Dist.CLIENT, ModLoader::fireClientEvents);
         dispatchAndHandleError(LifecycleEventProvider.SIDEDINIT);
     }


### PR DESCRIPTION
Registry events should remain in the same place they were in 1.12.2 to avoid confusion.  While there is no benefit to either position, modders expect to be able to use @EventBusSubscriber and/or register handlers for registry events to the bus in preinit.  The confusion that would be created as a side effect of leaving the registry events before preinit is unnecessary.