### PR TITLE
Fix exception mismatch for EntityType

### DIFF
--- a/patches/minecraft/net/minecraft/entity/EntityType.java.patch
+++ b/patches/minecraft/net/minecraft/entity/EntityType.java.patch
@@ -20,3 +20,12 @@
     public static final EntityType<EntityAreaEffectCloud> field_200788_b = func_200712_a("area_effect_cloud", EntityType.Builder.func_201757_a(EntityAreaEffectCloud.class, EntityAreaEffectCloud::new));
     public static final EntityType<EntityArmorStand> field_200789_c = func_200712_a("armor_stand", EntityType.Builder.func_201757_a(EntityArmorStand.class, EntityArmorStand::new));
     public static final EntityType<EntityTippedArrow> field_200790_d = func_200712_a("arrow", EntityType.Builder.func_201757_a(EntityTippedArrow.class, EntityTippedArrow::new));
+@@ -411,7 +412,7 @@
+          if (this.field_200710_b) {
+             try {
+                type = DataFixesManager.func_210901_a().getSchema(DataFixUtils.makeKey(1519)).getChoiceType(TypeReferences.field_211298_n, p_206830_1_);
+-            } catch (IllegalStateException illegalstateexception) {
++            } catch (IllegalArgumentException illegalstateexception) {
+                if (SharedConstants.field_206244_b) {
+                   throw illegalstateexception;
+                }


### PR DESCRIPTION
Exact same as #5229, but for Entities as well (5229 only handles TE's)
Vanilla throws IllegalArgumentException, but catches IllegalStateException, causing a game crash if you have no datafixer.