### PR TITLE
[1.13] Modernize blocksnapshot

### DIFF
--- a/src/main/java/net/minecraftforge/common/util/BlockSnapshot.java
+++ b/src/main/java/net/minecraftforge/common/util/BlockSnapshot.java
@@ -183,9 +183,10 @@ public class BlockSnapshot
             {
                 return false;
             }
+        } else
+        {
+            world.setBlockState(pos, replaced, notifyNeighbors ? 3 : 2);
         }
-
-        world.setBlockState(pos, replaced, notifyNeighbors ? 3 : 2);
 
         TileEntity te = null;
         if (getNbt() != null)


### PR DESCRIPTION
Instead of storing string ID + meta, store the NBT serialized form using vanilla's `NBTUtil`, which stores the string ID and all prop-val pairs.

Also modernize the logging.