### PR TITLE
[1.13] Fixed Configuration not setting config file

### DIFF
--- a/src/main/java/net/minecraftforge/common/config/Configuration.java
+++ b/src/main/java/net/minecraftforge/common/config/Configuration.java
@@ -139,11 +139,13 @@ public class Configuration
 */
     public Configuration(File file, String configVersion)
     {
+		this.file = file;
 //        runConfiguration(file, configVersion);
     }
 
     public Configuration(File file, String configVersion, boolean caseSensitiveCustomCategories)
     {
+    	this.file = file;
         this.caseSensitiveCustomCategories = caseSensitiveCustomCategories;
 //        runConfiguration(file, configVersion);
     }


### PR DESCRIPTION
I noticed this when working on the port of my mod.
If I set the field via reflection, everything works, so this should be a valid, simple fix.