### PR TITLE
[1.13] Use the reply logical side when enqueing work

### DIFF
--- a/src/main/java/net/minecraftforge/fml/network/NetworkEvent.java
+++ b/src/main/java/net/minecraftforge/fml/network/NetworkEvent.java
@@ -173,7 +173,7 @@ public class NetworkEvent extends Event
 
         @SuppressWarnings("unchecked")
         public <V> ListenableFuture<V> enqueueWork(Runnable runnable) {
-            return (ListenableFuture<V>)LogicalSidedProvider.WORKQUEUE.<IThreadListener>get(getDirection().getLogicalSide()).addScheduledTask(runnable);
+            return (ListenableFuture<V>)LogicalSidedProvider.WORKQUEUE.<IThreadListener>get(getDirection().reply().getLogicalSide()).addScheduledTask(runnable);
         }
 
         /**


### PR DESCRIPTION
`NetworkEvent.Context.enqueueWork` was using the incorrect work queue, running client tasks on the server, and vice versa.

When receiving a packet, `NetworkDirection.getLogicalSide` details where the packet was the packet was sent from. Therefore, on the client it'll be `SERVER`, and so the server work queue was being used, rather than the `Minecraft` instance. I'm not 100% sure this is the nicest solution, this just seemed the most obvious one.