### PR TITLE
Greatly improve DeferredWorkQueue API

### DIFF
--- a/src/main/java/net/minecraftforge/fml/DeferredWorkQueue.java
+++ b/src/main/java/net/minecraftforge/fml/DeferredWorkQueue.java
@@ -72,7 +72,8 @@ public class DeferredWorkQueue
      * Is to {@link Runnable} as {@link Callable} is to {@link Supplier}.
      */
     @FunctionalInterface
-    public interface CheckedRunnable {
+    public interface CheckedRunnable 
+    {
         void run() throws Exception;
     }
     
@@ -131,8 +132,8 @@ public class DeferredWorkQueue
         return runLater(() -> {
             try {
                 workToEnqueue.run();
-            } catch (Exception e) {
-                throw new CompletionException(e);
+            } catch (Throwable t) {
+                throw new CompletionException(t);
             }
         });
     }
@@ -177,8 +178,8 @@ public class DeferredWorkQueue
         return getLater(() -> {
             try {
                 return workToEnqueue.call();
-            } catch (Exception e) {
-                throw new CompletionException(e);
+            } catch (Throwable t) {
+                throw new CompletionException(t);
             }
         });
     }
@@ -197,8 +198,8 @@ public class DeferredWorkQueue
             Stopwatch timer = Stopwatch.createStarted();
             taskinfo.task.run();
             timer.stop();
-            if (timer.elapsed(TimeUnit.SECONDS) > 5) {
-                LOGGER.warn(LOADING, "Mod '{}' took {} to run a deferred task.", taskinfo.owner.getDisplayName(), timer);
+            if (timer.elapsed(TimeUnit.SECONDS) > 1) {
+                LOGGER.warn(LOADING, "Mod '{}' took {} to run a deferred task.", taskinfo.owner.getModId(), timer);
             }
         }
         LOGGER.info(LOADING, "Synchronous work queue completed in {}", globalTimer);

--- a/src/main/java/net/minecraftforge/fml/DeferredWorkQueue.java
+++ b/src/main/java/net/minecraftforge/fml/DeferredWorkQueue.java
@@ -19,26 +19,189 @@
 
 package net.minecraftforge.fml;
 
-import java.util.concurrent.Callable;
-import java.util.concurrent.ConcurrentLinkedDeque;
-import java.util.concurrent.Future;
-import java.util.concurrent.FutureTask;
+import static net.minecraftforge.fml.Logging.LOADING;
 
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.ConcurrentLinkedDeque;
+import java.util.concurrent.Executor;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Consumer;
+import java.util.function.Supplier;
+
+import org.apache.commons.lang3.time.StopWatch;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import com.google.common.base.Function;
+import com.google.common.base.Stopwatch;
+
+import net.minecraft.util.IThreadListener;
+import net.minecraftforge.forgespi.language.IModInfo;
+
+/**
+ * Utility for running code on the main launch thread at the next available
+ * opportunity. There is no guaranteed order that work from various mods will be
+ * run, but your own work will be run sequentially.
+ * <p>
+ * <strong>Use of this class after startup is not possible.</strong> At that
+ * point, {@link IThreadListener} should be used instead.
+ * <p>
+ * Exceptions from tasks will be handled gracefully, causing a mod loading
+ * error. Tasks that take egregiously long times to run will be logged.
+ */
 public class DeferredWorkQueue
 {
-    public static ConcurrentLinkedDeque<FutureWorkTask<?>> deferredWorkQueue = new ConcurrentLinkedDeque<>();
-
-    public static <T> Future<T> enqueueWork(Callable<T> workToEnqueue) {
-        final FutureWorkTask<T> workTask = new FutureWorkTask<>(workToEnqueue);
-        DeferredWorkQueue.deferredWorkQueue.add(workTask);
-        return workTask;
+    private static class TaskInfo
+    {
+        public final IModInfo owner;
+        public final Runnable task;
+        
+        TaskInfo(IModInfo owner, Runnable task) {
+            this.owner = owner;
+            this.task = task;
+        }
     }
 
-    public static class FutureWorkTask<T> extends FutureTask<T>
-    {
-        FutureWorkTask(Callable<T> callable)
-        {
-            super(callable);
+    /**
+     * {@link Runnable} except it allows throwing checked exceptions.
+     * 
+     * Is to {@link Runnable} as {@link Callable} is to {@link Supplier}.
+     */
+    @FunctionalInterface
+    public interface CheckedRunnable {
+        void run() throws Exception;
+    }
+    
+    private static final Logger LOGGER = LogManager.getLogger();
+
+    private static ThreadLocal<ModContainer> currentOwner = new ThreadLocal<>();
+    private static List<ModLoadingException> raisedExceptions = new ArrayList<>();
+
+    private static final ConcurrentLinkedDeque<TaskInfo> taskQueue = new ConcurrentLinkedDeque<>();
+    private static final Executor deferredExecutor = r -> taskQueue.add(new TaskInfo(currentOwner.get().getModInfo(), r));
+    
+    private static <T> Function<Throwable, T> handleException() {
+        final ModContainer owner = currentOwner.get();
+        return t -> {
+            LogManager.getLogger(DeferredWorkQueue.class).error("Encountered exception executing deferred work", t);
+            raisedExceptions.add(new ModLoadingException(owner.getModInfo(), owner.getCurrentState(), "fml.modloading.failedtoprocesswork", t));
+            return null;
+        };
+    }
+
+    /**
+     * Run a task on the loading thread at the next available opportunity, i.e.
+     * after the current lifecycle event has completed.
+     * <p>
+     * If the task must throw a checked exception, use
+     * {@link #runLaterChecked(CheckedRunnable)}.
+     * <p>
+     * If the task has a result, use {@link #getLater(Supplier)} or
+     * {@link #getLaterChecked(Callable)}.
+     * 
+     * @param workToEnqueue A {@link Runnable} to execute later, on the loading
+     *                      thread
+     * @return A {@link CompletableFuture} that completes at said time
+     */
+    public static CompletableFuture<Void> runLater(Runnable workToEnqueue) {
+        currentOwner.set(ModThreadContext.get().getActiveContainer());
+        return CompletableFuture.runAsync(workToEnqueue, deferredExecutor).exceptionally(DeferredWorkQueue.handleException());
+    }
+
+    /**
+     * Run a task on the loading thread at the next available opportunity, i.e.
+     * after the current lifecycle event has completed. This variant allows the task
+     * to throw a checked exception.
+     * <p>
+     * If the task does not throw a checked exception, use
+     * {@link #runLater(Runnable)}.
+     * <p>
+     * If the task has a result, use {@link #getLater(Supplier)} or
+     * {@link #getLaterChecked(Callable)}.
+     * 
+     * @param workToEnqueue A {@link CheckedRunnable} to execute later, on the
+     *                      loading thread
+     * @return A {@link CompletableFuture} that completes at said time
+     */
+    public static CompletableFuture<Void> runLaterChecked(CheckedRunnable workToEnqueue) {
+        return runLater(() -> {
+            try {
+                workToEnqueue.run();
+            } catch (Exception e) {
+                throw new CompletionException(e);
+            }
+        });
+    }
+
+    /**
+     * Run a task computing a result on the loading thread at the next available
+     * opportunity, i.e. after the current lifecycle event has completed.
+     * <p>
+     * If the task throws a checked exception, use
+     * {@link #getLaterChecked(Callable)}.
+     * <p>
+     * If the task does not have a result, use {@link #runLater(Runnable)} or
+     * {@link #runLaterChecked(CheckedRunnable)}.
+     * 
+     * @param               <T> The result type of the task
+     * @param workToEnqueue A {@link Supplier} to execute later, on the loading
+     *                      thread
+     * @return A {@link CompletableFuture} that completes at said time
+     */
+    public static <T> CompletableFuture<T> getLater(Supplier<T> workToEnqueue) {
+        currentOwner.set(ModThreadContext.get().getActiveContainer());
+        return CompletableFuture.supplyAsync(workToEnqueue, deferredExecutor).exceptionally(DeferredWorkQueue.handleException());
+    }
+
+    /**
+     * Run a task computing a result on the loading thread at the next available
+     * opportunity, i.e. after the current lifecycle event has completed. This
+     * variant allows the task to throw a checked exception.
+     * <p>
+     * If the task does not throw a checked exception, use
+     * {@link #getLater(Callable)}.
+     * <p>
+     * If the task does not have a result, use {@link #runLater(Runnable)} or
+     * {@link #runLaterChecked(CheckedRunnable)}.
+     * 
+     * @param               <T> The result type of the task
+     * @param workToEnqueue A {@link Supplier} to execute later, on the loading
+     *                      thread
+     * @return A {@link CompletableFuture} that completes at said time
+     */
+    public static <T> CompletableFuture<T> getLaterChecked(Callable<T> workToEnqueue) {
+        return getLater(() -> {
+            try {
+                return workToEnqueue.call();
+            } catch (Exception e) {
+                throw new CompletionException(e);
+            }
+        });
+    }
+    
+    static void clear() {
+        taskQueue.clear();
+    }
+
+    static void runTasks(ModLoadingStage fromStage, Consumer<List<ModLoadingException>> errorHandler) {
+        raisedExceptions.clear();
+        if (taskQueue.isEmpty()) return; // Don't log unnecessarily
+        LOGGER.info(LOADING, "Dispatching synchronous work after {}: {} jobs", fromStage, taskQueue.size());
+        StopWatch globalTimer = StopWatch.createStarted();
+        while (!taskQueue.isEmpty()) {
+            TaskInfo taskinfo = taskQueue.poll();
+            Stopwatch timer = Stopwatch.createStarted();
+            taskinfo.task.run();
+            timer.stop();
+            if (timer.elapsed(TimeUnit.SECONDS) > 5) {
+                LOGGER.warn(LOADING, "Mod '{}' took {} to run a deferred task.", taskinfo.owner.getDisplayName(), timer);
+            }
         }
+        LOGGER.info(LOADING, "Synchronous work queue completed in {}", globalTimer);
+        errorHandler.accept(raisedExceptions);
     }
 }

--- a/src/main/java/net/minecraftforge/fml/DeferredWorkQueue.java
+++ b/src/main/java/net/minecraftforge/fml/DeferredWorkQueue.java
@@ -198,7 +198,7 @@ public class DeferredWorkQueue
             Stopwatch timer = Stopwatch.createStarted();
             taskinfo.task.run();
             timer.stop();
-            if (timer.elapsed(TimeUnit.SECONDS) > 1) {
+            if (timer.elapsed(TimeUnit.SECONDS) >= 1) {
                 LOGGER.warn(LOADING, "Mod '{}' took {} to run a deferred task.", taskinfo.owner.getModId(), timer);
             }
         }

--- a/src/main/java/net/minecraftforge/fml/ModList.java
+++ b/src/main/java/net/minecraftforge/fml/ModList.java
@@ -91,7 +91,7 @@ public class ModList
 
     public void dispatchLifeCycleEvent(LifecycleEventProvider.LifecycleEvent lifecycleEvent, final Consumer<List<ModLoadingException>> errorHandler) {
         FMLLoader.getLanguageLoadingProvider().forEach(lp->lp.consumeLifecycleEvent(()->lifecycleEvent));
-        DeferredWorkQueue.deferredWorkQueue.clear();
+        DeferredWorkQueue.clear();
         try
         {
             modLoadingThreadPool.submit(()->this.mods.parallelStream().forEach(m->m.transitionState(lifecycleEvent, errorHandler))).get();
@@ -100,9 +100,7 @@ public class ModList
         {
             LOGGER.error(LOADING, "Encountered an exception during parallel processing", e);
         }
-        LOGGER.debug(LOADING, "Dispatching synchronous work, {} jobs", DeferredWorkQueue.deferredWorkQueue.size());
-        DeferredWorkQueue.deferredWorkQueue.forEach(FutureTask::run);
-        LOGGER.debug(LOADING, "Synchronous work queue complete");
+        DeferredWorkQueue.runTasks(lifecycleEvent.fromStage(), errorHandler);
         FMLLoader.getLanguageLoadingProvider().forEach(lp->lp.consumeLifecycleEvent(()->lifecycleEvent));
     }
 

--- a/src/main/resources/assets/forge/lang/en_us.json
+++ b/src/main/resources/assets/forge/lang/en_us.json
@@ -25,6 +25,8 @@
   "fml.modloading.errorduringevent":"{0,modinfo,name} ({0,modinfo,id}) encountered an error during the {1,lower} event phase\n\u00a77{2,exc,msg}",
   "fml.modloading.failedtoloadforge": "Failed to load forge",
   "fml.modloading.missingdependency": "Mod \u00a7e{4}\u00a7r requires \u00a76{3}\u00a7r \u00a7o{5,vr}\u00a7r\n\u00a77Currently, \u00a76{3}\u00a7r\u00a77 is \u00a7o{6,i18n,fml.messages.artifactversion.ornotinstalled}",
+  "fml.modloading.failedtoprocesswork":"{0,modinfo,name} ({0,modinfo,id}) encountered an error processing deferred work\n\u00a77{2,exc,msg}",
+  
 
   "fml.messages.artifactversion.ornotinstalled":"{0,ornull,fml.messages.artifactversion.notinstalled}",
   "fml.messages.artifactversion":"{0,ornull,fml.messages.artifactversion.none}",

--- a/src/main/resources/assets/forge/lang/en_us.json
+++ b/src/main/resources/assets/forge/lang/en_us.json
@@ -26,7 +26,6 @@
   "fml.modloading.failedtoloadforge": "Failed to load forge",
   "fml.modloading.missingdependency": "Mod \u00a7e{4}\u00a7r requires \u00a76{3}\u00a7r \u00a7o{5,vr}\u00a7r\n\u00a77Currently, \u00a76{3}\u00a7r\u00a77 is \u00a7o{6,i18n,fml.messages.artifactversion.ornotinstalled}",
   "fml.modloading.failedtoprocesswork":"{0,modinfo,name} ({0,modinfo,id}) encountered an error processing deferred work\n\u00a77{2,exc,msg}",
-  
 
   "fml.messages.artifactversion.ornotinstalled":"{0,ornull,fml.messages.artifactversion.notinstalled}",
   "fml.messages.artifactversion":"{0,ornull,fml.messages.artifactversion.none}",


### PR DESCRIPTION
The current `DeferredWorkQueue` implementation leaves much to be desired. There is no way to do any async chaining on results, and absolutely zero error handling or blame. With that in mind I've designed this much improved version.

- All methods return `CompletableFuture` instead of `Future` for added functionality like async chaining and exception handling.
- More methods for more use cases, 2 for `Runnable` and 2 for `Callable` (unchecked/checked for each)
- Automatic error handling via `CompletableFuture#exceptionally`, will handle attributing blame to erroring mods via `ModLoadingException`.
- Run time checking, tasks that take too long (currently over 5 seconds, maybe should be a config or sysprop?) will be logged at the WARN level with attribution
- Infinity% more documentation