### PR TITLE
Fix incorrect string representation of string list config property default values in their comments.

### DIFF
--- a/src/main/java/net/minecraftforge/common/config/Configuration.java
+++ b/src/main/java/net/minecraftforge/common/config/Configuration.java
@@ -1702,7 +1702,7 @@ public class Configuration
         prop.setValidValues(validValues);
         prop.setValidValuesDisplay(validValuesDisplay);
         prop.setLanguageKey(langKey);
-        prop.setComment(comment + " [default: " + defaultValue + "]");
+        prop.setComment(comment + " [default: " + prop.getDefault() + "]");
         return prop.getStringList();
     }
 


### PR DESCRIPTION
Fixes #5363, as pointed out by @bs2609. Bug introduced by myself in #5125.