### PR TITLE
Fix GuiContainer#keyPressed to return the correct key handled boolean

### DIFF
--- a/patches/minecraft/net/minecraft/client/gui/inventory/GuiContainer.java.patch
+++ b/patches/minecraft/net/minecraft/client/gui/inventory/GuiContainer.java.patch
@@ -129,26 +129,36 @@
                 this.func_184098_a(slot, k, p_mouseReleased_5_, ClickType.CLONE);
              } else {
                 boolean flag1 = k != -999 && (InputMappings.func_197956_a(340) || InputMappings.func_197956_a(344));
-@@ -509,15 +517,15 @@
+@@ -509,27 +517,31 @@
        if (super.keyPressed(p_keyPressed_1_, p_keyPressed_2_, p_keyPressed_3_)) {
           return true;
        } else {
 -         if (p_keyPressed_1_ == 256 || this.field_146297_k.field_71474_y.field_151445_Q.func_197976_a(p_keyPressed_1_, p_keyPressed_2_)) {
 +         if (p_keyPressed_1_ == 256 || this.field_146297_k.field_71474_y.field_151445_Q.isActiveAndMatches(InputMappings.func_197954_a(p_keyPressed_1_, p_keyPressed_2_))) {
              this.field_146297_k.field_71439_g.func_71053_j();
++            return true; // Forge MC-146650: Needs to return true when the key is handled.
           }
  
-          this.func_195363_d(p_keyPressed_1_, p_keyPressed_2_);
+-         this.func_195363_d(p_keyPressed_1_, p_keyPressed_2_);
++         if (this.func_195363_d(p_keyPressed_1_, p_keyPressed_2_))
++            return true; // Forge MC-146650: Needs to return true when the key is handled.
           if (this.field_147006_u != null && this.field_147006_u.func_75216_d()) {
 -            if (this.field_146297_k.field_71474_y.field_74322_I.func_197976_a(p_keyPressed_1_, p_keyPressed_2_)) {
 +            if (this.field_146297_k.field_71474_y.field_74322_I.isActiveAndMatches(InputMappings.func_197954_a(p_keyPressed_1_, p_keyPressed_2_))) {
                 this.func_184098_a(this.field_147006_u, this.field_147006_u.field_75222_d, 0, ClickType.CLONE);
 -            } else if (this.field_146297_k.field_71474_y.field_74316_C.func_197976_a(p_keyPressed_1_, p_keyPressed_2_)) {
++               return true; // Forge MC-146650: Needs to return true when the key is handled.
 +            } else if (this.field_146297_k.field_71474_y.field_74316_C.isActiveAndMatches(InputMappings.func_197954_a(p_keyPressed_1_, p_keyPressed_2_))) {
                 this.func_184098_a(this.field_147006_u, this.field_147006_u.field_75222_d, func_146271_m() ? 1 : 0, ClickType.THROW);
++               return true; // Forge MC-146650: Needs to return true when the key is handled.
              }
           }
-@@ -529,7 +537,7 @@
+ 
+-         return true;
++         return false; // Forge MC-146650: Needs to return false when the key is not handled.
+       }
+    }
+ 
     protected boolean func_195363_d(int p_195363_1_, int p_195363_2_) {
        if (this.field_146297_k.field_71439_g.field_71071_by.func_70445_o().func_190926_b() && this.field_147006_u != null) {
           for(int i = 0; i < 9; ++i) {
@@ -157,7 +167,7 @@
                 this.func_184098_a(this.field_147006_u, this.field_147006_u.field_75222_d, i, ClickType.SWAP);
                 return true;
              }
-@@ -556,4 +564,16 @@
+@@ -556,4 +568,16 @@
        }
  
     }


### PR DESCRIPTION
The return value here is incorrect, and it is preventing `GuiScreenEvent.KeyboardKeyPressedEvent.Post` from firing when a `GuiContainer` is open.
Basically it should return `true` when the key is handled, and `false` otherwise. Currently it always returns `true`.

Vanilla bug: https://bugs.mojang.com/browse/MC-146650