### PR TITLE
Fix some vertex format changes not being handled correctly

### DIFF
--- a/src/main/java/net/minecraftforge/client/ForgeHooksClient.java
+++ b/src/main/java/net/minecraftforge/client/ForgeHooksClient.java
@@ -555,9 +555,10 @@ public class ForgeHooksClient
         VertexFormat format = quad.getFormat();
         int size = format.getIntegerSize();
         int offset = format.getColorOffset() / 4; // assumes that color is aligned
+        boolean hasColor = format.hasColor();
         for(int i = 0; i < 4; i++)
         {
-            int vc = quad.getVertexData()[offset + size * i];
+            int vc = hasColor ? quad.getVertexData()[offset + size * i] : 0xFFFFFFFF;
             float vcr = vc & 0xFF;
             float vcg = (vc >>> 8) & 0xFF;
             float vcb = (vc >>> 16) & 0xFF;

--- a/src/main/java/net/minecraftforge/client/model/pipeline/ForgeBlockModelRenderer.java
+++ b/src/main/java/net/minecraftforge/client/model/pipeline/ForgeBlockModelRenderer.java
@@ -36,10 +36,10 @@ public class ForgeBlockModelRenderer extends BlockModelRenderer
 {
     private final ThreadLocal<VertexLighterFlat> lighterFlat;
     private final ThreadLocal<VertexLighterSmoothAo> lighterSmooth;
-    private final ThreadLocal<VertexBufferConsumer> wrFlat = new ThreadLocal<>();
-    private final ThreadLocal<VertexBufferConsumer> wrSmooth = new ThreadLocal<>();
-    private final ThreadLocal<BufferBuilder> lastRendererFlat = new ThreadLocal<>();
-    private final ThreadLocal<BufferBuilder> lastRendererSmooth = new ThreadLocal<>();
+    private final ThreadLocal<VertexBufferConsumer> consumerFlat = new ThreadLocal<>();
+    private final ThreadLocal<VertexBufferConsumer> consumerSmooth = new ThreadLocal<>();
+    private final ThreadLocal<BufferBuilder> lastBufferFlat = new ThreadLocal<>();
+    private final ThreadLocal<BufferBuilder> lastBufferSmooth = new ThreadLocal<>();
 
     public ForgeBlockModelRenderer(BlockColors colors)
     {
@@ -53,15 +53,19 @@ public class ForgeBlockModelRenderer extends BlockModelRenderer
     {
         if(ForgeModContainer.forgeLightPipelineEnabled)
         {
-            if(buffer != lastRendererFlat.get())
+            if (buffer != lastBufferFlat.get())
             {
-                lastRendererFlat.set(buffer);
-                VertexBufferConsumer newCons = new VertexBufferConsumer(buffer);
-                wrFlat.set(newCons);
-                lighterFlat.get().setParent(newCons);
+                lastBufferFlat.set(buffer);
+                consumerFlat.set(new VertexBufferConsumer(buffer));
             }
-            wrFlat.get().setOffset(pos);
-            return render(lighterFlat.get(), world, model, state, pos, buffer, checkSides, rand);
+            VertexBufferConsumer consumer = consumerFlat.get();
+            consumer.checkVertexFormat();
+            consumer.setOffset(pos);
+
+            VertexLighterFlat lighter = lighterFlat.get();
+            lighter.setParent(consumer);
+
+            return render(lighter, world, model, state, pos, buffer, checkSides, rand);
         }
         else
         {
@@ -74,15 +78,19 @@ public class ForgeBlockModelRenderer extends BlockModelRenderer
     {
         if(ForgeModContainer.forgeLightPipelineEnabled)
         {
-            if(buffer != lastRendererSmooth.get())
+            if (buffer != lastBufferSmooth.get())
             {
-                lastRendererSmooth.set(buffer);
-                VertexBufferConsumer newCons = new VertexBufferConsumer(buffer);
-                wrSmooth.set(newCons);
-                lighterSmooth.get().setParent(newCons);
+                lastBufferSmooth.set(buffer);
+                consumerSmooth.set(new VertexBufferConsumer(buffer));
             }
-            wrSmooth.get().setOffset(pos);
-            return render(lighterSmooth.get(), world, model, state, pos, buffer, checkSides, rand);
+            VertexBufferConsumer consumer = consumerSmooth.get();
+            consumer.checkVertexFormat();
+            consumer.setOffset(pos);
+
+            VertexLighterSmoothAo lighter = lighterSmooth.get();
+            lighter.setParent(consumer);
+
+            return render(lighter, world, model, state, pos, buffer, checkSides, rand);
         }
         else
         {

--- a/src/main/java/net/minecraftforge/client/model/pipeline/ForgeBlockModelRenderer.java
+++ b/src/main/java/net/minecraftforge/client/model/pipeline/ForgeBlockModelRenderer.java
@@ -36,10 +36,8 @@ public class ForgeBlockModelRenderer extends BlockModelRenderer
 {
     private final ThreadLocal<VertexLighterFlat> lighterFlat;
     private final ThreadLocal<VertexLighterSmoothAo> lighterSmooth;
-    private final ThreadLocal<VertexBufferConsumer> consumerFlat = new ThreadLocal<>();
-    private final ThreadLocal<VertexBufferConsumer> consumerSmooth = new ThreadLocal<>();
-    private final ThreadLocal<BufferBuilder> lastBufferFlat = new ThreadLocal<>();
-    private final ThreadLocal<BufferBuilder> lastBufferSmooth = new ThreadLocal<>();
+    private final ThreadLocal<VertexBufferConsumer> consumerFlat = ThreadLocal.withInitial(VertexBufferConsumer::new);
+    private final ThreadLocal<VertexBufferConsumer> consumerSmooth = ThreadLocal.withInitial(VertexBufferConsumer::new);
 
     public ForgeBlockModelRenderer(BlockColors colors)
     {
@@ -53,13 +51,8 @@ public class ForgeBlockModelRenderer extends BlockModelRenderer
     {
         if(ForgeModContainer.forgeLightPipelineEnabled)
         {
-            if (buffer != lastBufferFlat.get())
-            {
-                lastBufferFlat.set(buffer);
-                consumerFlat.set(new VertexBufferConsumer(buffer));
-            }
             VertexBufferConsumer consumer = consumerFlat.get();
-            consumer.checkVertexFormat();
+            consumer.setBuffer(buffer);
             consumer.setOffset(pos);
 
             VertexLighterFlat lighter = lighterFlat.get();
@@ -78,13 +71,8 @@ public class ForgeBlockModelRenderer extends BlockModelRenderer
     {
         if(ForgeModContainer.forgeLightPipelineEnabled)
         {
-            if (buffer != lastBufferSmooth.get())
-            {
-                lastBufferSmooth.set(buffer);
-                consumerSmooth.set(new VertexBufferConsumer(buffer));
-            }
             VertexBufferConsumer consumer = consumerSmooth.get();
-            consumer.checkVertexFormat();
+            consumer.setBuffer(buffer);
             consumer.setOffset(pos);
 
             VertexLighterSmoothAo lighter = lighterSmooth.get();

--- a/src/main/java/net/minecraftforge/client/model/pipeline/LightUtil.java
+++ b/src/main/java/net/minecraftforge/client/model/pipeline/LightUtil.java
@@ -297,16 +297,19 @@ public class LightUtil
         quad.pipe(cons);
     }
 
-    public static void renderQuadColor(BufferBuilder wr, BakedQuad quad, int auxColor)
+    public static void renderQuadColor(BufferBuilder buffer, BakedQuad quad, int auxColor)
     {
-        if (quad.getFormat().equals(wr.getVertexFormat())) 
+        if (quad.getFormat().equals(buffer.getVertexFormat()))
         {
-            wr.addVertexData(quad.getVertexData());
-            ForgeHooksClient.putQuadColor(wr, quad, auxColor);
+            buffer.addVertexData(quad.getVertexData());
+            if (buffer.getVertexFormat().hasColor())
+            {
+                ForgeHooksClient.putQuadColor(buffer, quad, auxColor);
+            }
         }
         else
         {
-            renderQuadColorSlow(wr, quad, auxColor);
+            renderQuadColorSlow(buffer, quad, auxColor);
         }
     }
 
@@ -333,7 +336,8 @@ public class LightUtil
             if(getVertexFormat().getElement(element).getUsage() == EnumUsage.COLOR)
             {
                 System.arraycopy(auxColor, 0, buf, 0, buf.length);
-                for(int i = 0; i < 4; i++)
+                int n = Math.min(4, data.length);
+                for(int i = 0; i < n; i++)
                 {
                     buf[i] *= data[i];
                 }

--- a/src/main/java/net/minecraftforge/client/model/pipeline/LightUtil.java
+++ b/src/main/java/net/minecraftforge/client/model/pipeline/LightUtil.java
@@ -269,33 +269,23 @@ public class LightUtil
 
     private static final class ItemPipeline
     {
-        final BufferBuilder buffer;
         final VertexBufferConsumer bufferConsumer;
         final ItemConsumer itemConsumer;
 
-        ItemPipeline(BufferBuilder buffer)
+        ItemPipeline()
         {
-            this.buffer = buffer;
-            this.bufferConsumer = new VertexBufferConsumer(buffer);
+            this.bufferConsumer = new VertexBufferConsumer();
             this.itemConsumer = new ItemConsumer(bufferConsumer);
         }
     }
 
-    private static final ThreadLocal<ItemPipeline> itemPipeline = new ThreadLocal<>();
+    private static final ThreadLocal<ItemPipeline> itemPipeline = ThreadLocal.withInitial(ItemPipeline::new);
 
     // renders quad in any Vertex Format, but is slower
     public static void renderQuadColorSlow(BufferBuilder buffer, BakedQuad quad, int auxColor)
     {
         ItemPipeline pipeline = itemPipeline.get();
-        if (pipeline == null || buffer != pipeline.buffer)
-        {
-            pipeline = new ItemPipeline(buffer);
-            itemPipeline.set(pipeline);
-        }
-        else
-        {
-            pipeline.bufferConsumer.checkVertexFormat();
-        }
+        pipeline.bufferConsumer.setBuffer(buffer);
         ItemConsumer cons = pipeline.itemConsumer;
 
         float b = (float)( auxColor         & 0xFF) / 0xFF;

--- a/src/main/java/net/minecraftforge/client/model/pipeline/VertexBufferConsumer.java
+++ b/src/main/java/net/minecraftforge/client/model/pipeline/VertexBufferConsumer.java
@@ -32,16 +32,17 @@ import net.minecraft.util.EnumFacing;
 public class VertexBufferConsumer implements IVertexConsumer
 {
     private static final float[] dummyColor = new float[]{ 1, 1, 1, 1 };
-    private final BufferBuilder renderer;
+
+    private BufferBuilder renderer;
     private int[] quadData;
     private int v = 0;
     private BlockPos offset = BlockPos.ORIGIN;
 
-    public VertexBufferConsumer(BufferBuilder renderer)
+    public VertexBufferConsumer() {}
+
+    public VertexBufferConsumer(BufferBuilder buffer)
     {
-        super();
-        this.renderer = renderer;
-        quadData = new int[renderer.getVertexFormat().getNextOffset()/* / 4 * 4 */];
+        setBuffer(buffer);
     }
 
     @Override
@@ -72,12 +73,18 @@ public class VertexBufferConsumer implements IVertexConsumer
         }
     }
 
-    public void checkVertexFormat()
+    private void checkVertexFormat()
     {
-        if (renderer.getVertexFormat().getNextOffset() != quadData.length)
+        if (quadData == null || renderer.getVertexFormat().getNextOffset() != quadData.length)
         {
             quadData = new int[renderer.getVertexFormat().getNextOffset()];
         }
+    }
+
+    public void setBuffer(BufferBuilder buffer)
+    {
+        this.renderer = buffer;
+        checkVertexFormat();
     }
 
     public void setOffset(BlockPos offset)

--- a/src/main/java/net/minecraftforge/client/model/pipeline/VertexBufferConsumer.java
+++ b/src/main/java/net/minecraftforge/client/model/pipeline/VertexBufferConsumer.java
@@ -33,7 +33,7 @@ public class VertexBufferConsumer implements IVertexConsumer
 {
     private static final float[] dummyColor = new float[]{ 1, 1, 1, 1 };
     private final BufferBuilder renderer;
-    private final int[] quadData;
+    private int[] quadData;
     private int v = 0;
     private BlockPos offset = BlockPos.ORIGIN;
 
@@ -69,6 +69,14 @@ public class VertexBufferConsumer implements IVertexConsumer
                 //Arrays.fill(quadData, 0);
                 v = 0;
             }
+        }
+    }
+
+    public void checkVertexFormat()
+    {
+        if (renderer.getVertexFormat().getNextOffset() != quadData.length)
+        {
+            quadData = new int[renderer.getVertexFormat().getNextOffset()];
         }
     }
 


### PR DESCRIPTION
Fixes some cases where vertex format changes aren't handled by the vertex pipeline.

Note that the vertex format used by a `BufferBuilder` isn't fixed, it's set with each call to `begin`.

This means that `VertexBufferConsumer` needs to handle potential format changes here. Currently, the `quadData` array is sized only for the format used at the time of creation, causing problems if a different format is later used.

This PR adds a call to ensure the format is correct in places where `VertexBufferConsumer` instances are reused. Additionally, as the return value of `VertexBufferConsumer#getVertexFormat` may change, it needs to be checked each time by the vertex lighter when rendering block models.

The `getTessellator` and `getItemConsumer` methods in `LightUtil` are deprecated for compatibility reasons - they can be removed otherwise.