### PR TITLE
[1.13] Reimplemented IForgeBlock hasTileEntity and createTileEntity replacements in patches

### DIFF
--- a/patches/minecraft/net/minecraft/client/renderer/RenderGlobal.java.patch
+++ b/patches/minecraft/net/minecraft/client/renderer/RenderGlobal.java.patch
@@ -65,7 +65,7 @@
                    TileEntityRendererDispatcher.field_147556_a.func_180546_a(tileentity1, p_180446_3_, -1);
                 }
              }
-@@ -622,10 +632,12 @@
+@@ -622,16 +632,18 @@
  
           synchronized(this.field_181024_n) {
              for(TileEntity tileentity : this.field_181024_n) {
@@ -79,6 +79,13 @@
           this.func_180443_s();
  
           for(DestroyBlockProgress destroyblockprogress : this.field_72738_E.values()) {
+             BlockPos blockpos = destroyblockprogress.func_180246_b();
+             IBlockState iblockstate = this.field_72769_h.func_180495_p(blockpos);
+-            if (iblockstate.func_177230_c().func_149716_u()) {
++            if (iblockstate.hasTileEntity()) {
+                TileEntity tileentity2 = this.field_72769_h.func_175625_s(blockpos);
+                if (tileentity2 instanceof TileEntityChest && iblockstate.func_177229_b(BlockChest.field_196314_b) == ChestType.LEFT) {
+                   blockpos = blockpos.func_177972_a(((EnumFacing)iblockstate.func_177229_b(BlockChest.field_176459_a)).func_176746_e());
 @@ -767,7 +779,7 @@
              for(int j = -this.field_72739_F; j <= this.field_72739_F; ++j) {
                 for(int k = -this.field_72739_F; k <= this.field_72739_F; ++k) {

--- a/patches/minecraft/net/minecraft/command/arguments/BlockStateParser.java.patch
+++ b/patches/minecraft/net/minecraft/command/arguments/BlockStateParser.java.patch
@@ -1,0 +1,20 @@
+--- a/net/minecraft/command/arguments/BlockStateParser.java
++++ b/net/minecraft/command/arguments/BlockStateParser.java
+@@ -167,7 +167,7 @@
+    }
+ 
+    private CompletableFuture<Suggestions> func_197244_d(SuggestionsBuilder p_197244_1_) {
+-      if (p_197244_1_.getRemaining().isEmpty() && (this.field_197270_l == null || this.field_197270_l.func_177230_c().func_149716_u())) {
++      if (p_197244_1_.getRemaining().isEmpty() && (this.field_197270_l == null || this.field_197270_l.hasTileEntity())) {
+          p_197244_1_.suggest(String.valueOf('{'));
+       }
+ 
+@@ -252,7 +252,7 @@
+             p_197255_1_.suggest(String.valueOf('['));
+          }
+ 
+-         if (this.field_197270_l.func_177230_c().func_149716_u()) {
++         if (this.field_197270_l.hasTileEntity()) {
+             p_197255_1_.suggest(String.valueOf('{'));
+          }
+       }

--- a/patches/minecraft/net/minecraft/world/chunk/Chunk.java.patch
+++ b/patches/minecraft/net/minecraft/world/chunk/Chunk.java.patch
@@ -17,6 +17,37 @@
     }
  
     public Chunk(World p_i48703_1_, ChunkPrimer p_i48703_2_, int p_i48703_3_, int p_i48703_4_) {
+@@ -441,7 +442,7 @@
+          ((Heightmap)this.field_76634_f.get(Heightmap.Type.WORLD_SURFACE)).func_202270_a(i, j, k, p_177436_2_);
+          if (!this.field_76637_e.field_72995_K) {
+             iblockstate.func_196947_b(this.field_76637_e, p_177436_1_, p_177436_2_, p_177436_3_);
+-         } else if (block1 != block && block1 instanceof ITileEntityProvider) {
++         } else if (block1 != block && iblockstate.hasTileEntity()) {
+             this.field_76637_e.func_175713_t(p_177436_1_);
+          }
+ 
+@@ -459,7 +460,7 @@
+                }
+             }
+ 
+-            if (block1 instanceof ITileEntityProvider) {
++            if (iblockstate.hasTileEntity()) {
+                TileEntity tileentity = this.func_177424_a(p_177436_1_, Chunk.EnumCreateEntityType.CHECK);
+                if (tileentity != null) {
+                   tileentity.func_145836_u();
+@@ -470,10 +471,10 @@
+                p_177436_2_.func_196945_a(this.field_76637_e, p_177436_1_, iblockstate);
+             }
+ 
+-            if (block instanceof ITileEntityProvider) {
++            if (p_177436_2_.hasTileEntity()) {
+                TileEntity tileentity1 = this.func_177424_a(p_177436_1_, Chunk.EnumCreateEntityType.CHECK);
+                if (tileentity1 == null) {
+-                  tileentity1 = ((ITileEntityProvider)block).func_196283_a_(this.field_76637_e);
++                  tileentity1 = p_177436_2_.createTileEntity(this.field_76637_e);
+                   this.field_76637_e.func_175690_a(p_177436_1_, tileentity1);
+                } else {
+                   tileentity1.func_145836_u();
 @@ -593,6 +594,7 @@
        p_76612_1_.field_70162_ai = k;
        p_76612_1_.field_70164_aj = this.field_76647_h;
@@ -33,6 +64,47 @@
     }
  
     public boolean func_177444_d(BlockPos p_177444_1_) {
+@@ -629,8 +632,7 @@
+    @Nullable
+    private TileEntity func_177422_i(BlockPos p_177422_1_) {
+       IBlockState iblockstate = this.func_180495_p(p_177422_1_);
+-      Block block = iblockstate.func_177230_c();
+-      return !block.func_149716_u() ? null : ((ITileEntityProvider)block).func_196283_a_(this.field_76637_e);
++      return !iblockstate.hasTileEntity() ? null : iblockstate.createTileEntity(this.field_76637_e);
+    }
+ 
+    @Nullable
+@@ -667,7 +669,7 @@
+    public void func_177426_a(BlockPos p_177426_1_, TileEntity p_177426_2_) {
+       p_177426_2_.func_145834_a(this.field_76637_e);
+       p_177426_2_.func_174878_a(p_177426_1_);
+-      if (this.func_180495_p(p_177426_1_).func_177230_c() instanceof ITileEntityProvider) {
++      if (this.func_180495_p(p_177426_1_).hasTileEntity()) {
+          if (this.field_150816_i.containsKey(p_177426_1_)) {
+             ((TileEntity)this.field_150816_i.get(p_177426_1_)).func_145843_s();
+          }
+@@ -788,7 +790,7 @@
+ 
+       while(!this.field_177447_w.isEmpty()) {
+          BlockPos blockpos = this.field_177447_w.poll();
+-         if (this.func_177424_a(blockpos, Chunk.EnumCreateEntityType.CHECK) == null && this.func_180495_p(blockpos).func_177230_c().func_149716_u()) {
++         if (this.func_177424_a(blockpos, Chunk.EnumCreateEntityType.CHECK) == null && this.func_180495_p(blockpos).hasTileEntity()) {
+             TileEntity tileentity = this.func_177422_i(blockpos);
+             this.field_76637_e.func_175690_a(blockpos, tileentity);
+             this.field_76637_e.func_175704_b(blockpos, blockpos);
+@@ -1087,9 +1089,10 @@
+             if (this.func_175625_s(blockpos1) == null) {
+                TileEntity tileentity;
+                if ("DUMMY".equals(nbttagcompound.func_74779_i("id"))) {
++                  IBlockState iblockstate = this.func_180495_p(blockpos1);
+                   Block block = this.func_180495_p(blockpos1).func_177230_c();
+-                  if (block instanceof ITileEntityProvider) {
+-                     tileentity = ((ITileEntityProvider)block).func_196283_a_(this.field_76637_e);
++                  if (iblockstate.hasTileEntity()) {
++                     tileentity = iblockstate.createTileEntity(this.field_76637_e);
+                   } else {
+                      tileentity = null;
+                      field_150817_t.warn("Tried to load a DUMMY block entity @ {} but found not tile entity block {} at location", blockpos1, this.func_180495_p(blockpos1));
 @@ -1164,4 +1167,30 @@
        QUEUED,
        CHECK;

--- a/patches/minecraft/net/minecraft/world/gen/WorldGenRegion.java.patch
+++ b/patches/minecraft/net/minecraft/world/gen/WorldGenRegion.java.patch
@@ -9,3 +9,42 @@
     }
  
     public Biome func_180494_b(BlockPos p_180494_1_) {
+@@ -180,7 +180,7 @@
+          NBTTagCompound nbttagcompound = ichunk.func_201579_g(p_175625_1_);
+          if (nbttagcompound != null) {
+             if ("DUMMY".equals(nbttagcompound.func_74779_i("id"))) {
+-               tileentity = ((ITileEntityProvider)this.func_180495_p(p_175625_1_).func_177230_c()).func_196283_a_(this.field_201689_f);
++               tileentity = this.func_180495_p(p_175625_1_).createTileEntity(this.field_201689_f);
+             } else {
+                tileentity = TileEntity.func_203403_c(nbttagcompound);
+             }
+@@ -191,7 +191,7 @@
+             }
+          }
+ 
+-         if (ichunk.func_180495_p(p_175625_1_).func_177230_c() instanceof ITileEntityProvider) {
++         if (ichunk.func_180495_p(p_175625_1_).hasTileEntity()) {
+             field_208303_a.warn("Tried to access a block entity before it was created. {}", (Object)p_175625_1_);
+          }
+ 
+@@ -203,9 +203,9 @@
+       IChunk ichunk = this.func_205771_y(p_180501_1_);
+       IBlockState iblockstate = ichunk.func_177436_a(p_180501_1_, p_180501_2_, false);
+       Block block = p_180501_2_.func_177230_c();
+-      if (block.func_149716_u()) {
++      if (p_180501_2_.hasTileEntity()) {
+          if (ichunk.func_201589_g().func_202129_d() == ChunkStatus.Type.LEVELCHUNK) {
+-            ichunk.func_177426_a(p_180501_1_, ((ITileEntityProvider)block).func_196283_a_(this));
++            ichunk.func_177426_a(p_180501_1_, p_180501_2_.createTileEntity(this.field_201689_f));
+          } else {
+             NBTTagCompound nbttagcompound = new NBTTagCompound();
+             nbttagcompound.func_74768_a("x", p_180501_1_.func_177958_n());
+@@ -214,7 +214,7 @@
+             nbttagcompound.func_74778_a("id", "DUMMY");
+             ichunk.func_201591_a(nbttagcompound);
+          }
+-      } else if (iblockstate != null && iblockstate.func_177230_c().func_149716_u()) {
++      } else if (iblockstate != null && iblockstate.hasTileEntity()) {
+          ichunk.func_177425_e(p_180501_1_);
+       }
+ 

--- a/src/main/java/net/minecraftforge/items/VanillaInventoryCodeHooks.java
+++ b/src/main/java/net/minecraftforge/items/VanillaInventoryCodeHooks.java
@@ -253,9 +253,8 @@ public class VanillaInventoryCodeHooks
         int k = MathHelper.floor(z);
         BlockPos blockpos = new BlockPos(i, j, k);
         net.minecraft.block.state.IBlockState state = worldIn.getBlockState(blockpos);
-        Block block = state.getBlock();
 
-        if (block.hasTileEntity(/* TODO Block patches // state */))
+        if (state.hasTileEntity())
         {
             TileEntity tileentity = worldIn.getTileEntity(blockpos);
             if (tileentity != null)


### PR DESCRIPTION
These methods have worked in previous versions of Forge, but hadn't been implemented yet in 1.13. They were useful for conditional tile entities or overriding when extending vanilla blocks.