### PR TITLE
[1,13] Make ChunkGeneratorType.Settings accessible for modders

### DIFF
--- a/src/main/resources/META-INF/accesstransformer.cfg
+++ b/src/main/resources/META-INF/accesstransformer.cfg
@@ -393,3 +393,6 @@ public net.minecraft.block.Block$Builder func_200951_a(I)Lnet/minecraft/block/Bl
 public net.minecraft.block.Block$Builder func_200944_c()Lnet/minecraft/block/Block$Builder; # needsRandomTick
 public net.minecraft.block.Block$Builder func_208770_d()Lnet/minecraft/block/Block$Builder; # variableOpacity
 public net.minecraft.block.Block$Builder func_200943_b(F)Lnet/minecraft/block/Block$Builder; # hardnessAndResistance
+
+#ChunkGeneratorType
+public net.minecraft.world.gen.ChunkGeneratorType$Settings


### PR DESCRIPTION
I am currently trying to add my own dimension and I will use this PR to collect all things I came across that need fixing to make modders live more easy.

Changes:
- make ChunkGeneratorType.Settings accessible so custom ChunkGeneratorType can get registered.