### PR TITLE
[1.13] Avoid HeadlessException and add modid validation

### DIFF
--- a/src/main/java/net/minecraftforge/fml/ModContainer.java
+++ b/src/main/java/net/minecraftforge/fml/ModContainer.java
@@ -29,6 +29,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
+import java.util.regex.Pattern;
 
 /**
  * The container that wraps around mods in the system.
@@ -45,13 +46,17 @@ import java.util.function.Supplier;
 
 public abstract class ModContainer
 {
+    private static final Pattern VALID_MODIDS = Pattern.compile("^[a-z0-9_-]{3,64}$");
     protected final String modId;
     protected final IModInfo modInfo;
     protected ModLoadingStage modLoadingStage;
     protected final Map<ModLoadingStage, Consumer<LifecycleEventProvider.LifecycleEvent>> triggerMap;
     protected final Map<ExtensionPoint, Supplier<?>> extensionPoints = new IdentityHashMap<>();
+
     public ModContainer(IModInfo info)
     {
+        if (!VALID_MODIDS.matcher(info.getModId()).matches())
+            throw new IllegalArgumentException("Invalid modid " + info.getModId() + "! Mod ids need to be lowercase alphanumeric characters or '-'/'_' and need to be between 3 and 64 chars long.");
         this.modId = info.getModId();
         this.modInfo = info;
         this.triggerMap = new HashMap<>();

--- a/src/main/java/net/minecraftforge/fml/client/gui/LoadingErrorScreen.java
+++ b/src/main/java/net/minecraftforge/fml/client/gui/LoadingErrorScreen.java
@@ -25,6 +25,7 @@ import net.minecraft.client.gui.GuiButton;
 import net.minecraft.client.gui.GuiErrorScreen;
 import net.minecraft.client.gui.GuiListExtended;
 import net.minecraft.client.renderer.Tessellator;
+import net.minecraft.util.Util;
 import net.minecraftforge.fml.ForgeI18n;
 import net.minecraftforge.fml.LoadingFailedException;
 import net.minecraftforge.fml.ModLoadingException;
@@ -33,7 +34,6 @@ import net.minecraftforge.fml.loading.FMLPaths;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
-import java.awt.*;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.List;
@@ -56,27 +56,13 @@ public class LoadingErrorScreen extends GuiErrorScreen {
 
     private double openModsDir(double mouseX, double mouseY)
     {
-        try
-        {
-            Desktop.getDesktop().open(modsDir.toFile());
-        }
-        catch (Exception e)
-        {
-            LOGGER.error("Problem opening mods folder", e);
-        }
+        Util.getOSType().openFile(modsDir.toFile());
         return 0.0;
     }
 
     private double openLogFile(double mouseX, double mouseY)
     {
-        try
-        {
-            Desktop.getDesktop().open(logFile.toFile());
-        }
-        catch (Exception e)
-        {
-            LOGGER.error("Problem opening log file {}", logFile, e);
-        }
+        Util.getOSType().openFile(logFile.toFile());
         return 0.0;
     }
 


### PR DESCRIPTION
1. Remove any usages of java.awt that do no longer work as 1.13 set headless to true.
2. Add validation to mod ids. As far as I can tell they are currently not being checked, but they still need to be lowercase, as resource locations enforce this.

I also added some more conditions, so modids need to be between 3 and 64 chars long, and may only contain alphanumeric characters and the chars `_` and `-`
I think this restriction is fair, as modids are a technical detail, and there is a huge possibility that they might overlap if they have less than 3 characters, and they should be easy, so special characters as $ should not exist IMO.