### PR TITLE
[1.13] Add support to use the AutomaticEventSubscriber for the mod loading bus

### DIFF
--- a/src/main/java/net/minecraftforge/fml/ModContainer.java
+++ b/src/main/java/net/minecraftforge/fml/ModContainer.java
@@ -19,6 +19,7 @@
 
 package net.minecraftforge.fml;
 
+import net.minecraftforge.eventbus.api.IEventBus;
 import net.minecraftforge.forgespi.language.IModInfo;
 
 import java.util.Collections;
@@ -133,4 +134,13 @@ public abstract class ModContainer
      * @return the mod object instance
      */
     public abstract Object getMod();
+
+    /**
+     * @return the event bus used for loading events. Used by the automatic event bus subscriber.
+     * @throws UnsupportedOperationException If the mod container has no loading event buses
+     */
+    public IEventBus getLoadingEventBus() throws UnsupportedOperationException
+    {
+        throw new UnsupportedOperationException("ModContainer for mod " + modId + " has no mod loading bus!");
+    }
 }

--- a/src/main/java/net/minecraftforge/fml/common/Mod.java
+++ b/src/main/java/net/minecraftforge/fml/common/Mod.java
@@ -22,7 +22,6 @@ package net.minecraftforge.fml.common;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
-import java.lang.annotation.Target;
 
 import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.fml.event.lifecycle.FMLFingerprintViolationEvent;
@@ -45,7 +44,7 @@ import net.minecraftforge.fml.common.registry.GameRegistry;
  * annotation.
  */
 @Retention(RetentionPolicy.RUNTIME)
-@Target(ElementType.TYPE)
+@java.lang.annotation.Target(ElementType.TYPE)
 public @interface Mod
 {
     /**
@@ -97,16 +96,18 @@ public @interface Mod
      */
     @Deprecated
     @Retention(RetentionPolicy.RUNTIME)
-    @Target(ElementType.METHOD)
+    @java.lang.annotation.Target(ElementType.METHOD)
     @interface EventHandler{}
 
     /**
-     * A class which will be subscribed to {@link net.minecraftforge.common.MinecraftForge.EVENT_BUS} at mod construction time.
+     * A class which will be subscribed to {@link net.minecraftforge.common.MinecraftForge#EVENT_BUS} at mod construction time.
      */
     @Retention(RetentionPolicy.RUNTIME)
-    @Target(ElementType.TYPE)
+    @java.lang.annotation.Target(ElementType.TYPE)
     @interface EventBusSubscriber {
         Dist[] value() default { Dist.CLIENT, Dist.DEDICATED_SERVER };
+
+        Target[] bus() default { Target.MAIN_BUS };
 
         /**
          * Optional value, only nessasary if tis annotation is not on the same class that has a @Mod annotation.
@@ -114,5 +115,9 @@ public @interface Mod
          * @return
          */
         String modid() default "";
+
+        enum Target {
+            MAIN_BUS, MOD_LOADING_BUS
+        }
     }
 }

--- a/src/main/java/net/minecraftforge/fml/javafmlmod/FMLModContainer.java
+++ b/src/main/java/net/minecraftforge/fml/javafmlmod/FMLModContainer.java
@@ -152,7 +152,8 @@ public class FMLModContainer extends ModContainer
         return modInstance;
     }
 
-    public IEventBus getEventBus()
+    @Override
+    public IEventBus getLoadingEventBus()
     {
         return this.eventBus;
     }

--- a/src/main/java/net/minecraftforge/fml/javafmlmod/FMLModLoadingContext.java
+++ b/src/main/java/net/minecraftforge/fml/javafmlmod/FMLModLoadingContext.java
@@ -38,7 +38,7 @@ public class FMLModLoadingContext
 
     public IEventBus getModEventBus()
     {
-        return getActiveContainer().getEventBus();
+        return getActiveContainer().getLoadingEventBus();
     }
 
     public FMLModContainer getActiveContainer()


### PR DESCRIPTION
Basically the title.
Adds support to specify something like `@EventBusSubscriber(bus = Target.MOD_LOADING_BUS)`.
The bus defaults to the forge event bus, so there is no difference.