### PR TITLE
[1.13] Fix recipe constants being overridden by a blank map. Closes #5380

### DIFF
--- a/src/main/java/net/minecraftforge/common/crafting/CraftingHelper.java
+++ b/src/main/java/net/minecraftforge/common/crafting/CraftingHelper.java
@@ -325,12 +325,12 @@ public class CraftingHelper
                             }
                         }
                         if (!items.isEmpty())
-                            constants.put(new ResourceLocation(JsonUtils.getString(json, "name")), new StackList(items));
+                            ret.put(new ResourceLocation(JsonUtils.getString(json, "name")), new StackList(items));
                     }
                     else if (json.has("tag"))
-                        constants.put(new ResourceLocation(JsonUtils.getString(json, "name")), Ingredient.deserializeItemList(json));
+                        ret.put(new ResourceLocation(JsonUtils.getString(json, "name")), Ingredient.deserializeItemList(json));
                     else if (json.has("item"))
-                        constants.put(new ResourceLocation(JsonUtils.getString(json, "name")), new StackList(Lists.newArrayList(getItemStack(JsonUtils.getJsonObject(json, "item"), true))));
+                        ret.put(new ResourceLocation(JsonUtils.getString(json, "name")), new StackList(Lists.newArrayList(getItemStack(JsonUtils.getJsonObject(json, "item"), true))));
                     else
                         LOGGER.error(CRAFTHELPER, "Couldn't load constant #{} from {} as it's missing `item` or `items` element", x, key);
                 }


### PR DESCRIPTION
Fixes issue report #5380 by adding the constants to the blank map that overrides constants at the end of reloadConstants.