### PR TITLE
[1.13] Fix #5365: Some chat messages lose their formatting

### DIFF
--- a/src/main/java/net/minecraftforge/fml/TextComponentMessageFormatHandler.java
+++ b/src/main/java/net/minecraftforge/fml/TextComponentMessageFormatHandler.java
@@ -28,7 +28,9 @@ import java.util.List;
 public class TextComponentMessageFormatHandler {
     public static int handle(final TextComponentTranslation parent, final List<ITextComponent> children, final Object[] formatArgs, final String format) {
         try {
-            children.add(new TextComponentString(ForgeI18n.parseFormat(format, formatArgs)));
+            TextComponentString component = new TextComponentString(ForgeI18n.parseFormat(format, formatArgs));
+            component.getStyle().setParentStyle(parent.getStyle());
+            children.add(component);
             return format.length();
         } catch (IllegalArgumentException ex) {
             return 0;


### PR DESCRIPTION
Properly apply the parent styling when handling message format.