### PR TITLE
[1.13] Fix vanilla trying to load the constants json as an recipe.

### DIFF
--- a/patches/minecraft/net/minecraft/item/crafting/RecipeManager.java.patch
+++ b/patches/minecraft/net/minecraft/item/crafting/RecipeManager.java.patch
@@ -8,7 +8,7 @@
 +
        for(ResourceLocation resourcelocation : p_195410_1_.func_199003_a("recipes", (p_199516_0_) -> {
 -         return p_199516_0_.endsWith(".json");
-+         return p_199516_0_.endsWith(".json") && !p_199516_0_.equals("_constants.json");
++         return p_199516_0_.endsWith(".json") && !p_199516_0_.startsWith("_");
        })) {
           String s = resourcelocation.func_110623_a();
           ResourceLocation resourcelocation1 = new ResourceLocation(resourcelocation.func_110624_b(), s.substring(field_199519_a, s.length() - field_199520_b));

--- a/patches/minecraft/net/minecraft/item/crafting/RecipeManager.java.patch
+++ b/patches/minecraft/net/minecraft/item/crafting/RecipeManager.java.patch
@@ -1,6 +1,6 @@
 --- a/net/minecraft/item/crafting/RecipeManager.java
 +++ b/net/minecraft/item/crafting/RecipeManager.java
-@@ -37,6 +37,8 @@
+@@ -37,16 +37,21 @@
        this.field_199523_e = false;
        this.field_199522_d.clear();
  
@@ -9,7 +9,11 @@
        for(ResourceLocation resourcelocation : p_195410_1_.func_199003_a("recipes", (p_199516_0_) -> {
           return p_199516_0_.endsWith(".json");
        })) {
-@@ -47,6 +49,8 @@
+          String s = resourcelocation.func_110623_a();
++         if (s.equals("recipes/_constants.json")) continue;
+          ResourceLocation resourcelocation1 = new ResourceLocation(resourcelocation.func_110624_b(), s.substring(field_199519_a, s.length() - field_199520_b));
+ 
+          try (IResource iresource = p_195410_1_.func_199002_a(resourcelocation)) {
              JsonObject jsonobject = (JsonObject)JsonUtils.func_188178_a(gson, IOUtils.toString(iresource.func_199027_b(), StandardCharsets.UTF_8), JsonObject.class);
              if (jsonobject == null) {
                 field_199521_c.error("Couldn't load recipe {} as it's null or empty", (Object)resourcelocation1);

--- a/patches/minecraft/net/minecraft/item/crafting/RecipeManager.java.patch
+++ b/patches/minecraft/net/minecraft/item/crafting/RecipeManager.java.patch
@@ -1,19 +1,18 @@
 --- a/net/minecraft/item/crafting/RecipeManager.java
 +++ b/net/minecraft/item/crafting/RecipeManager.java
-@@ -37,16 +37,21 @@
+@@ -37,8 +37,10 @@
        this.field_199523_e = false;
        this.field_199522_d.clear();
  
 +      net.minecraftforge.common.crafting.CraftingHelper.reloadConstants(p_195410_1_);
 +
        for(ResourceLocation resourcelocation : p_195410_1_.func_199003_a("recipes", (p_199516_0_) -> {
-          return p_199516_0_.endsWith(".json");
+-         return p_199516_0_.endsWith(".json");
++         return p_199516_0_.endsWith(".json") && !p_199516_0_.equals("_constants.json");
        })) {
           String s = resourcelocation.func_110623_a();
-+         if (s.equals("recipes/_constants.json")) continue;
           ResourceLocation resourcelocation1 = new ResourceLocation(resourcelocation.func_110624_b(), s.substring(field_199519_a, s.length() - field_199520_b));
- 
-          try (IResource iresource = p_195410_1_.func_199002_a(resourcelocation)) {
+@@ -47,6 +49,8 @@
              JsonObject jsonobject = (JsonObject)JsonUtils.func_188178_a(gson, IOUtils.toString(iresource.func_199027_b(), StandardCharsets.UTF_8), JsonObject.class);
              if (jsonobject == null) {
                 field_199521_c.error("Couldn't load recipe {} as it's null or empty", (Object)resourcelocation1);


### PR DESCRIPTION
Currently Vanilla tries to load the constants file as an actual recipe which causes a JSON error as the constants file uses an JsonArray instead of JsonObject.