### PR TITLE
[1.12] Fix special spawn event not firing in many cases.

### DIFF
--- a/patches/minecraft/net/minecraft/item/ItemMonsterPlacer.java.patch
+++ b/patches/minecraft/net/minecraft/item/ItemMonsterPlacer.java.patch
@@ -1,0 +1,10 @@
+--- ../src-base/minecraft/net/minecraft/item/ItemMonsterPlacer.java
++++ ../src-work/minecraft/net/minecraft/item/ItemMonsterPlacer.java
+@@ -234,6 +234,7 @@
+                     entity.func_70012_b(p_77840_2_, p_77840_4_, p_77840_6_, MathHelper.func_76142_g(p_77840_0_.field_73012_v.nextFloat() * 360.0F), 0.0F);
+                     entityliving.field_70759_as = entityliving.field_70177_z;
+                     entityliving.field_70761_aq = entityliving.field_70177_z;
++                    if (net.minecraftforge.event.ForgeEventFactory.doSpecialSpawn(entityliving, p_77840_0_, (float) p_77840_2_, (float) p_77840_4_, (float)p_77840_6_, null)) return null;
+                     entityliving.func_180482_a(p_77840_0_.func_175649_E(new BlockPos(entityliving)), (IEntityLivingData)null);
+                     p_77840_0_.func_72838_d(entity);
+                     entityliving.func_70642_aH();

--- a/patches/minecraft/net/minecraft/item/ItemMonsterPlacer.java.patch
+++ b/patches/minecraft/net/minecraft/item/ItemMonsterPlacer.java.patch
@@ -4,7 +4,7 @@
                      entity.func_70012_b(p_77840_2_, p_77840_4_, p_77840_6_, MathHelper.func_76142_g(p_77840_0_.field_73012_v.nextFloat() * 360.0F), 0.0F);
                      entityliving.field_70759_as = entityliving.field_70177_z;
                      entityliving.field_70761_aq = entityliving.field_70177_z;
-+                    if (net.minecraftforge.event.ForgeEventFactory.doSpecialSpawn(entityliving, p_77840_0_, (float) p_77840_2_, (float) p_77840_4_, (float)p_77840_6_, null)) return null;
++                    if (net.minecraftforge.event.ForgeEventFactory.doSpecialSpawn(entityliving, p_77840_0_, (float) p_77840_2_, (float) p_77840_4_, (float) p_77840_6_, null)) return null;
                      entityliving.func_180482_a(p_77840_0_.func_175649_E(new BlockPos(entityliving)), (IEntityLivingData)null);
                      p_77840_0_.func_72838_d(entity);
                      entityliving.func_70642_aH();

--- a/src/test/java/net/minecraftforge/debug/entity/living/SpecialSpawnTest.java
+++ b/src/test/java/net/minecraftforge/debug/entity/living/SpecialSpawnTest.java
@@ -1,0 +1,47 @@
+/*
+ * Minecraft Forge
+ * Copyright (c) 2016-2018.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation version 2.1
+ * of the License.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+package net.minecraftforge.debug.entity.living;
+
+import net.minecraft.entity.monster.EntityPigZombie;
+import net.minecraftforge.event.entity.living.LivingSpawnEvent;
+import net.minecraftforge.fml.common.Mod;
+import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
+
+@Mod(modid = SpecialSpawnTest.MOD_ID, name = "Special Spawn Test", version = "1.0", acceptableRemoteVersions = "*")
+@Mod.EventBusSubscriber(modid = SpecialSpawnTest.MOD_ID)
+public class SpecialSpawnTest
+{
+    static final String MOD_ID = "special_spawn_test";
+    static final boolean ENABLED = false;
+
+    @SubscribeEvent
+    public static void onAnimalTame(LivingSpawnEvent.SpecialSpawn event)
+    {
+        if (!ENABLED)
+        {
+            return;
+        }
+
+        if (event.getEntity() instanceof EntityPigZombie)
+        {
+        	event.getEntity().setCustomNameTag("Called SpecialSpawn");
+        }
+    }
+}

--- a/src/test/java/net/minecraftforge/debug/entity/living/SpecialSpawnTest.java
+++ b/src/test/java/net/minecraftforge/debug/entity/living/SpecialSpawnTest.java
@@ -41,7 +41,7 @@ public class SpecialSpawnTest
 
         if (event.getEntity() instanceof EntityPigZombie)
         {
-        	event.getEntity().setCustomNameTag("Called SpecialSpawn");
+            event.getEntity().setCustomNameTag("Called SpecialSpawn");
         }
     }
 }

--- a/src/test/java/net/minecraftforge/debug/entity/living/SpecialSpawnTest.java
+++ b/src/test/java/net/minecraftforge/debug/entity/living/SpecialSpawnTest.java
@@ -32,7 +32,7 @@ public class SpecialSpawnTest
     static final boolean ENABLED = false;
 
     @SubscribeEvent
-    public static void onAnimalTame(LivingSpawnEvent.SpecialSpawn event)
+    public static void onSpecialSpawn(LivingSpawnEvent.SpecialSpawn event)
     {
         if (!ENABLED)
         {


### PR DESCRIPTION
This PR fixes the SpecialSpawn event not being fired in many situations. Specifically, it patches a static spawn helper method in ItemMonsterPlacer to include the trigger. This fixes the following situations.
- Mobs spawned by spawn eggs.
- Mobs spawned by dispensers.
- Mobs spawned by nether portal update tick.
- Mods that use this static method when spawning mobs.

I've included a test mod which will set the name tag of a Zombie PigMan if it spawns in a way that triggers this event.