### PR TITLE
 Add back several missing patches for FML events 

### DIFF
--- a/patches/minecraft/net/minecraft/entity/item/EntityItem.java.patch
+++ b/patches/minecraft/net/minecraft/entity/item/EntityItem.java.patch
@@ -86,7 +86,7 @@
  
        if (p_70037_1_.func_150297_b("Owner", 10)) {
           this.field_145802_g = NBTUtil.func_186860_b(p_70037_1_.func_74775_l("Owner"));
-@@ -262,12 +281,17 @@
+@@ -262,12 +281,20 @@
  
     public void func_70100_b_(EntityPlayer p_70100_1_) {
        if (!this.field_70170_p.field_72995_K) {
@@ -100,13 +100,16 @@
 +         int hook = net.minecraftforge.event.ForgeEventFactory.onItemPickup(this, p_70100_1_);
 +         if (hook < 0) return;
 +
++         ItemStack copy = itemstack.func_77946_l();
 +         if (this.field_145804_b == 0 && (this.field_145802_g == null || lifespan - this.field_70292_b <= 200 || this.field_145802_g.equals(p_70100_1_.func_110124_au())) && (hook == 1 || i <= 0 || p_70100_1_.field_71071_by.func_70441_a(itemstack))) {
++            copy.func_190920_e(copy.func_190916_E() - func_92059_d().func_190916_E());
++            net.minecraftforge.fml.hooks.BasicEventHooks.firePlayerItemPickupEvent(p_70100_1_, this, copy);
              if (itemstack.func_190926_b()) {
 +               p_70100_1_.func_71001_a(this, i);
                 this.func_70106_y();
                 itemstack.func_190920_e(i);
              }
-@@ -287,9 +311,10 @@
+@@ -287,9 +314,10 @@
        return false;
     }
  
@@ -119,7 +122,7 @@
        if (!this.field_70170_p.field_72995_K && entity instanceof EntityItem) {
           ((EntityItem)entity).func_85054_d();
        }
-@@ -354,6 +379,6 @@
+@@ -354,6 +382,6 @@
  
     public void func_174870_v() {
        this.func_174871_r();

--- a/patches/minecraft/net/minecraft/entity/player/EntityPlayer.java.patch
+++ b/patches/minecraft/net/minecraft/entity/player/EntityPlayer.java.patch
@@ -31,7 +31,15 @@
     }
  
     protected void func_70088_a() {
-@@ -192,7 +202,7 @@
+@@ -174,6 +184,7 @@
+    }
+ 
+    public void func_70071_h_() {
++      net.minecraftforge.fml.hooks.BasicEventHooks.onPlayerPreTick(this);
+       this.field_70145_X = this.func_175149_v();
+       if (this.func_175149_v()) {
+          this.field_70122_E = false;
+@@ -192,7 +203,7 @@
           if (!this.field_70170_p.field_72995_K) {
              if (!this.func_175143_p()) {
                 this.func_70999_a(true, true, false);
@@ -40,7 +48,15 @@
                 this.func_70999_a(false, true, true);
              }
           }
-@@ -433,10 +443,10 @@
+@@ -252,6 +263,7 @@
+       this.func_203041_m();
+       this.field_184832_bU.func_185144_a();
+       this.func_184808_cD();
++      net.minecraftforge.fml.hooks.BasicEventHooks.onPlayerPostTick(this);
+    }
+ 
+    protected boolean func_204229_de() {
+@@ -433,10 +445,10 @@
           this.field_71107_bF = this.field_71109_bG;
           this.field_71109_bG = 0.0F;
           this.func_71015_k(this.field_70165_t - d0, this.field_70163_u - d1, this.field_70161_v - d2);
@@ -53,7 +69,7 @@
           }
  
        }
-@@ -555,10 +565,12 @@
+@@ -555,10 +567,12 @@
     }
  
     public void func_70645_a(DamageSource p_70645_1_) {
@@ -66,7 +82,7 @@
        if ("Notch".equals(this.func_200200_C_().getString())) {
           this.func_146097_a(new ItemStack(Items.field_151034_e), true, false);
        }
-@@ -568,6 +580,8 @@
+@@ -568,6 +582,8 @@
           this.field_71071_by.func_70436_m();
        }
  
@@ -75,7 +91,7 @@
        if (p_70645_1_ != null) {
           this.field_70159_w = (double)(-MathHelper.func_76134_b((this.field_70739_aP + this.field_70177_z) * ((float)Math.PI / 180F)) * 0.1F);
           this.field_70179_y = (double)(-MathHelper.func_76126_a((this.field_70739_aP + this.field_70177_z) * ((float)Math.PI / 180F)) * 0.1F);
-@@ -607,12 +621,14 @@
+@@ -607,12 +623,14 @@
  
     @Nullable
     public EntityItem func_71040_bB(boolean p_71040_1_) {
@@ -92,7 +108,7 @@
     }
  
     @Nullable
-@@ -659,11 +675,18 @@
+@@ -659,11 +677,18 @@
     }
  
     public ItemStack func_184816_a(EntityItem p_184816_1_) {
@@ -111,7 +127,7 @@
        float f = this.field_71071_by.func_184438_a(p_184813_1_);
        if (f > 1.0F) {
           int i = EnchantmentHelper.func_185293_e(this);
-@@ -705,11 +728,12 @@
+@@ -705,11 +730,12 @@
           f /= 5.0F;
        }
  
@@ -125,7 +141,7 @@
     }
  
     public void func_70037_a(NBTTagCompound p_70037_1_) {
-@@ -739,6 +763,14 @@
+@@ -739,6 +765,14 @@
           this.field_82248_d = p_70037_1_.func_74767_n("SpawnForced");
        }
  
@@ -140,7 +156,7 @@
        this.field_71100_bB.func_75112_a(p_70037_1_);
        this.field_71075_bZ.func_75095_b(p_70037_1_);
        if (p_70037_1_.func_150297_b("EnderItems", 9)) {
-@@ -785,9 +817,26 @@
+@@ -785,9 +819,26 @@
           p_70014_1_.func_74782_a("ShoulderEntityRight", this.func_192025_dl());
        }
  
@@ -167,7 +183,7 @@
        if (this.func_180431_b(p_70097_1_)) {
           return false;
        } else if (this.field_71075_bZ.field_75102_a && !p_70097_1_.func_76357_e()) {
-@@ -823,7 +872,7 @@
+@@ -823,7 +874,7 @@
  
     protected void func_190629_c(EntityLivingBase p_190629_1_) {
        super.func_190629_c(p_190629_1_);
@@ -176,7 +192,7 @@
           this.func_190777_m(true);
        }
  
-@@ -844,11 +893,13 @@
+@@ -844,11 +895,13 @@
     }
  
     protected void func_184590_k(float p_184590_1_) {
@@ -191,7 +207,7 @@
              if (enumhand == EnumHand.MAIN_HAND) {
                 this.func_184201_a(EntityEquipmentSlot.MAINHAND, ItemStack.field_190927_a);
              } else {
-@@ -876,11 +927,14 @@
+@@ -876,11 +929,14 @@
  
     protected void func_70665_d(DamageSource p_70665_1_, float p_70665_2_) {
        if (!this.func_180431_b(p_70665_1_)) {
@@ -206,7 +222,7 @@
           if (p_70665_2_ != 0.0F) {
              this.func_71020_j(p_70665_1_.func_76345_d());
              float f1 = this.func_110143_aJ();
-@@ -929,6 +983,8 @@
+@@ -929,6 +985,8 @@
  
           return EnumActionResult.PASS;
        } else {
@@ -215,7 +231,7 @@
           ItemStack itemstack = this.func_184586_b(p_190775_2_);
           ItemStack itemstack1 = itemstack.func_190926_b() ? ItemStack.field_190927_a : itemstack.func_77946_l();
           if (p_190775_1_.func_184230_a(this, p_190775_2_)) {
-@@ -936,6 +992,10 @@
+@@ -936,6 +994,10 @@
                 itemstack.func_190920_e(itemstack1.func_190916_E());
              }
  
@@ -226,7 +242,7 @@
              return EnumActionResult.SUCCESS;
           } else {
              if (!itemstack.func_190926_b() && p_190775_1_ instanceof EntityLivingBase) {
-@@ -945,6 +1005,7 @@
+@@ -945,6 +1007,7 @@
  
                 if (itemstack.func_111282_a(this, (EntityLivingBase)p_190775_1_, p_190775_2_)) {
                    if (itemstack.func_190926_b() && !this.field_71075_bZ.field_75098_d) {
@@ -234,7 +250,7 @@
                       this.func_184611_a(p_190775_2_, ItemStack.field_190927_a);
                    }
  
-@@ -967,6 +1028,7 @@
+@@ -967,6 +1030,7 @@
     }
  
     public void func_71059_n(Entity p_71059_1_) {
@@ -242,7 +258,7 @@
        if (p_71059_1_.func_70075_an()) {
           if (!p_71059_1_.func_85031_j(this)) {
              float f = (float)this.func_110148_a(SharedMonsterAttributes.field_111264_e).func_111126_e();
-@@ -994,8 +1056,11 @@
+@@ -994,8 +1058,11 @@
  
                 boolean flag2 = flag && this.field_70143_R > 0.0F && !this.field_70122_E && !this.func_70617_f_() && !this.func_70090_H() && !this.func_70644_a(MobEffects.field_76440_q) && !this.func_184218_aH() && p_71059_1_ instanceof EntityLivingBase;
                 flag2 = flag2 && !this.func_70051_ag();
@@ -255,7 +271,7 @@
                 }
  
                 f = f + f1;
-@@ -1091,8 +1156,10 @@
+@@ -1091,8 +1158,10 @@
                    }
  
                    if (!itemstack1.func_190926_b() && entity instanceof EntityLivingBase) {
@@ -266,7 +282,7 @@
                          this.func_184611_a(EnumHand.MAIN_HAND, ItemStack.field_190927_a);
                       }
                    }
-@@ -1134,7 +1201,7 @@
+@@ -1134,7 +1203,7 @@
        }
  
        if (this.field_70146_Z.nextFloat() < f) {
@@ -275,7 +291,7 @@
           this.func_184602_cy();
           this.field_70170_p.func_72960_a(this, (byte)30);
        }
-@@ -1182,7 +1249,12 @@
+@@ -1182,7 +1251,12 @@
     }
  
     public EntityPlayer.SleepResult func_180469_a(BlockPos p_180469_1_) {
@@ -289,7 +305,7 @@
        if (!this.field_70170_p.field_72995_K) {
           if (this.func_70608_bn() || !this.func_70089_S()) {
              return EntityPlayer.SleepResult.OTHER_PROBLEM;
-@@ -1192,7 +1264,7 @@
+@@ -1192,7 +1266,7 @@
              return EntityPlayer.SleepResult.NOT_POSSIBLE_HERE;
           }
  
@@ -298,7 +314,7 @@
              return EntityPlayer.SleepResult.NOT_POSSIBLE_NOW;
           }
  
-@@ -1217,7 +1289,7 @@
+@@ -1217,7 +1291,7 @@
        this.func_192030_dh();
        this.func_175145_a(StatList.field_199092_j.func_199076_b(StatList.field_203284_n));
        this.func_70105_a(0.2F, 0.2F);
@@ -307,7 +323,7 @@
           float f1 = 0.5F + (float)enumfacing.func_82601_c() * 0.4F;
           float f = 0.5F + (float)enumfacing.func_82599_e() * 0.4F;
           this.func_175139_a(enumfacing);
-@@ -1242,6 +1314,8 @@
+@@ -1242,6 +1316,8 @@
     private boolean func_190774_a(BlockPos p_190774_1_, EnumFacing p_190774_2_) {
        if (Math.abs(this.field_70165_t - (double)p_190774_1_.func_177958_n()) <= 3.0D && Math.abs(this.field_70163_u - (double)p_190774_1_.func_177956_o()) <= 2.0D && Math.abs(this.field_70161_v - (double)p_190774_1_.func_177952_p()) <= 3.0D) {
           return true;
@@ -316,7 +332,7 @@
        } else {
           BlockPos blockpos = p_190774_1_.func_177972_a(p_190774_2_.func_176734_d());
           return Math.abs(this.field_70165_t - (double)blockpos.func_177958_n()) <= 3.0D && Math.abs(this.field_70163_u - (double)blockpos.func_177956_o()) <= 2.0D && Math.abs(this.field_70161_v - (double)blockpos.func_177952_p()) <= 3.0D;
-@@ -1254,16 +1328,19 @@
+@@ -1254,16 +1330,19 @@
     }
  
     public void func_70999_a(boolean p_70999_1_, boolean p_70999_2_, boolean p_70999_3_) {
@@ -340,7 +356,7 @@
        }
  
        this.field_71083_bS = false;
-@@ -1279,29 +1356,30 @@
+@@ -1279,29 +1358,30 @@
     }
  
     private boolean func_175143_p() {
@@ -377,7 +393,7 @@
           switch(enumfacing) {
           case SOUTH:
              return 90.0F;
-@@ -1333,23 +1411,67 @@
+@@ -1333,23 +1413,67 @@
     public void func_146105_b(ITextComponent p_146105_1_, boolean p_146105_2_) {
     }
  
@@ -454,7 +470,7 @@
     }
  
     public void func_195066_a(ResourceLocation p_195066_1_) {
-@@ -1519,6 +1641,8 @@
+@@ -1519,6 +1643,8 @@
           }
  
           super.func_180430_e(p_180430_1_, p_180430_2_);
@@ -463,7 +479,7 @@
        }
     }
  
-@@ -1780,7 +1904,10 @@
+@@ -1780,7 +1906,10 @@
     }
  
     public ITextComponent func_145748_c_() {
@@ -475,7 +491,7 @@
        return this.func_208016_c(itextcomponent);
     }
  
-@@ -1800,7 +1927,7 @@
+@@ -1800,7 +1929,7 @@
     }
  
     public float func_70047_e() {
@@ -484,7 +500,7 @@
        if (this.func_70608_bn()) {
           f = 0.2F;
        } else if (!this.func_203007_ba() && !this.func_184613_cA() && this.field_70131_O != 0.6F) {
-@@ -1967,6 +2094,30 @@
+@@ -1967,6 +2096,30 @@
        return this.field_71075_bZ.field_75098_d && this.func_184840_I() >= 2;
     }
  

--- a/patches/minecraft/net/minecraft/server/MinecraftServer.java.patch
+++ b/patches/minecraft/net/minecraft/server/MinecraftServer.java.patch
@@ -96,7 +96,15 @@
              this.func_71240_o();
           }
  
-@@ -648,6 +669,7 @@
+@@ -628,6 +649,7 @@
+ 
+    public void func_71217_p() {
+       long i = Util.func_211178_c();
++      net.minecraftforge.fml.hooks.BasicEventHooks.onPreServerTick();
+       ++this.field_71315_w;
+       if (this.field_71295_T) {
+          this.field_71295_T = false;
+@@ -648,6 +670,7 @@
  
           Collections.shuffle(Arrays.asList(agameprofile));
           this.field_147147_p.func_151318_b().func_151330_a(agameprofile);
@@ -104,7 +112,15 @@
        }
  
        if (this.field_71315_w % 900 == 0) {
-@@ -686,16 +708,18 @@
+@@ -672,6 +695,7 @@
+       this.field_211152_ao = this.field_211152_ao * 0.8F + (float)l / 1000000.0F * 0.19999999F;
+       this.field_71304_b.func_76319_b();
+       this.field_71304_b.func_76319_b();
++      net.minecraftforge.fml.hooks.BasicEventHooks.onPostServerTick();
+    }
+ 
+    public void func_71190_q() {
+@@ -686,20 +710,23 @@
        this.func_193030_aL().func_73660_a();
        this.field_71304_b.func_76318_c("levels");
  
@@ -127,7 +143,20 @@
                 this.field_71304_b.func_76319_b();
              }
  
-@@ -724,9 +748,11 @@
+             this.field_71304_b.func_76320_a("tick");
++            net.minecraftforge.fml.hooks.BasicEventHooks.onPreWorldTick(worldserver);
+ 
+             try {
+                worldserver.func_72835_b();
+@@ -717,6 +744,7 @@
+                throw new ReportedException(crashreport1);
+             }
+ 
++            net.minecraftforge.fml.hooks.BasicEventHooks.onPostWorldTick(worldserver);
+             this.field_71304_b.func_76319_b();
+             this.field_71304_b.func_76320_a("tracker");
+             worldserver.func_73039_n().func_72788_a();
+@@ -724,9 +752,11 @@
              this.field_71304_b.func_76319_b();
           }
  
@@ -140,7 +169,7 @@
        this.field_71304_b.func_76318_c("connection");
        this.func_147137_ag().func_151269_c();
        this.field_71304_b.func_76318_c("players");
-@@ -749,6 +775,14 @@
+@@ -749,6 +779,14 @@
     }
  
     public static void main(String[] p_main_0_) {
@@ -155,7 +184,7 @@
        Bootstrap.func_151354_b();
  
        try {
-@@ -851,7 +885,7 @@
+@@ -851,7 +889,7 @@
     }
  
     public void func_71256_s() {
@@ -164,7 +193,7 @@
        this.field_175590_aa.setUncaughtExceptionHandler((p_195574_0_, p_195574_1_) -> {
           field_147145_h.error(p_195574_1_);
        });
-@@ -871,11 +905,7 @@
+@@ -871,11 +909,7 @@
     }
  
     public WorldServer func_71218_a(int p_71218_1_) {
@@ -177,7 +206,7 @@
     }
  
     public WorldServer func_200667_a(DimensionType p_200667_1_) {
-@@ -918,7 +948,7 @@
+@@ -918,7 +952,7 @@
     }
  
     public String getServerModName() {

--- a/patches/minecraft/net/minecraft/server/management/PlayerList.java.patch
+++ b/patches/minecraft/net/minecraft/server/management/PlayerList.java.patch
@@ -1,0 +1,35 @@
+--- a/net/minecraft/server/management/PlayerList.java
++++ b/net/minecraft/server/management/PlayerList.java
+@@ -184,6 +184,7 @@
+       }
+ 
+       p_72355_2_.func_71116_b();
++      net.minecraftforge.fml.hooks.BasicEventHooks.firePlayerLoggedIn( p_72355_2_ );
+    }
+ 
+    protected void func_96456_a(ServerScoreboard p_96456_1_, EntityPlayerMP p_96456_2_) {
+@@ -307,6 +308,7 @@
+    }
+ 
+    public void func_72367_e(EntityPlayerMP p_72367_1_) {
++      net.minecraftforge.fml.hooks.BasicEventHooks.firePlayerLoggedOut( p_72367_1_ );
+       WorldServer worldserver = p_72367_1_.func_71121_q();
+       p_72367_1_.func_195066_a(StatList.field_75947_j);
+       this.func_72391_b(p_72367_1_);
+@@ -453,6 +455,7 @@
+       this.field_177454_f.put(entityplayermp.func_110124_au(), entityplayermp);
+       entityplayermp.func_71116_b();
+       entityplayermp.func_70606_j(entityplayermp.func_110143_aJ());
++      net.minecraftforge.fml.hooks.BasicEventHooks.firePlayerRespawnEvent( p_72368_1_, p_72368_3_ );
+       return entityplayermp;
+    }
+ 
+@@ -482,7 +485,7 @@
+       for(PotionEffect potioneffect : p_187242_1_.func_70651_bq()) {
+          p_187242_1_.field_71135_a.func_147359_a(new SPacketEntityEffect(p_187242_1_.func_145782_y(), potioneffect));
+       }
+-
++      net.minecraftforge.fml.hooks.BasicEventHooks.firePlayerChangedDimensionEvent( p_187242_1_, i, p_187242_2_ );
+    }
+ 
+    public void func_82448_a(Entity p_82448_1_, int p_82448_2_, WorldServer p_82448_3_, WorldServer p_82448_4_) {


### PR DESCRIPTION
Adds back patches for the following FML events:

 - Player login, logout, respawn and change dimension
 - Item pickup
 - Player tick
 - World and server tick

This should cover all events in `BasicEventHooks` aside from those fired in `Minecraft`.