### PR TITLE
Fix mods with no dependencies not being loaded

### DIFF
--- a/src/fmllauncher/java/net/minecraftforge/fml/loading/ModSorter.java
+++ b/src/fmllauncher/java/net/minecraftforge/fml/loading/ModSorter.java
@@ -86,6 +86,7 @@ public class ModSorter
         final MutableGraph<ModFileInfo> graph = GraphBuilder.directed().build();
         AtomicInteger counter = new AtomicInteger();
         Map<IModFileInfo, Integer> infos = modFiles.stream().map(ModFile::getModFileInfo).collect(Collectors.toMap(Function.identity(), (e) -> counter.incrementAndGet()));
+        modFiles.stream().map(ModFile::getModFileInfo).map(ModFileInfo.class::cast).forEach(graph::addNode);
         modFiles.stream().map(ModFile::getModInfos).flatMap(Collection::stream).
                 map(IModInfo::getDependencies).flatMap(Collection::stream).
                 forEach(dep -> addDependency(graph, dep));


### PR DESCRIPTION
c01b336095e3d443b5a61eaaedacd60cc4cf5544 converted mod sorting to use Guava's graph, but removed the line which added all mods to the graph. As a result, mods with no dependencies (such as Forge) weren't actually loaded.