### PR TITLE
1.7.10

### DIFF
--- a/fml/src/main/resources/log4j2.xml
+++ b/fml/src/main/resources/log4j2.xml
@@ -7,7 +7,7 @@
         <Console name="SysOut" target="SYSTEM_OUT">
             <PatternLayout pattern="[%d{HH:mm:ss}] [%t/%level]: %msg%n" />
         </Console>
-        <Queue name="ServerGuiConsole">
+        <Queue name="ServerGuiConsole" ignoreExceptions="true">
             <PatternLayout pattern="[%d{HH:mm:ss}] [%t/%level] [%logger]: %msg%n" />
         </Queue>
         <RollingRandomAccessFile name="File" fileName="logs/latest.log" filePattern="logs/%d{yyyy-MM-dd}-%i.log.gz">

--- a/patches/minecraft/net/minecraft/item/ItemArmor.java.patch
+++ b/patches/minecraft/net/minecraft/item/ItemArmor.java.patch
@@ -1,5 +1,14 @@
 --- ../src-base/minecraft/net/minecraft/item/ItemArmor.java
 +++ ../src-work/minecraft/net/minecraft/item/ItemArmor.java
+@@ -40,7 +40,7 @@
+             if (list.size() > 0)
+             {
+                 EntityLivingBase entitylivingbase = (EntityLivingBase)list.get(0);
+-                int l = entitylivingbase instanceof EntityPlayer ? 1 : 0;
++                int l = 0;// Forge: We fix the indexes. Mojang Stop hard coding this!
+                 int i1 = EntityLiving.func_82159_b(p_82487_2_);
+                 ItemStack itemstack1 = p_82487_2_.func_77946_l();
+                 itemstack1.field_77994_a = 1;
 @@ -221,7 +221,7 @@
  
          if (itemstack1 == null)

--- a/patches/minecraft/net/minecraft/item/ItemSkull.java.patch
+++ b/patches/minecraft/net/minecraft/item/ItemSkull.java.patch
@@ -14,7 +14,7 @@
              return false;
          }
 -        else if (!p_77648_3_.func_147439_a(p_77648_4_, p_77648_5_, p_77648_6_).func_149688_o().func_76220_a())
-+        else if (!p_77648_3_.isSideSolid(p_77648_4_, p_77648_5_, p_77648_6_, net.minecraftforge.common.util.ForgeDirection.getOrientation(p_77648_7_)))
++        else if (!p_77648_3_.func_147439_a(p_77648_4_, p_77648_5_, p_77648_6_).func_149688_o().func_76220_a() && !p_77648_3_.isSideSolid(p_77648_4_, p_77648_5_, p_77648_6_, net.minecraftforge.common.util.ForgeDirection.getOrientation(p_77648_7_)))
          {
              return false;
          }

--- a/patches/minecraft/net/minecraft/tileentity/TileEntityFurnace.java.patch
+++ b/patches/minecraft/net/minecraft/tileentity/TileEntityFurnace.java.patch
@@ -32,3 +32,13 @@
              }
  
              --this.field_145957_n[0].field_77994_a;
+@@ -301,6 +304,9 @@
+         }
+         else
+         {
++        	int moddedBurnTime = net.minecraftforge.event.ForgeEventFactory.getFuelBurnTime(p_145952_0_);
++        	if (moddedBurnTime >= 0) return moddedBurnTime;
++        	
+             Item item = p_145952_0_.func_77973_b();
+ 
+             if (item instanceof ItemBlock && Block.func_149634_a(item) != Blocks.field_150350_a)

--- a/src/main/java/net/minecraftforge/event/ForgeEventFactory.java
+++ b/src/main/java/net/minecraftforge/event/ForgeEventFactory.java
@@ -135,6 +135,13 @@ public class ForgeEventFactory
         return event.list;
     }
 
+    public static int getFuelBurnTime(ItemStack fuel)
+    {
+        FuelBurnTimeEvent event = new FuelBurnTimeEvent(fuel);
+        MinecraftForge.EVENT_BUS.post(event);
+        return event.getResult() == Result.DEFAULT ? -1 : event.burnTime;
+    }
+
     public static int getMaxSpawnPackSize(EntityLiving entity)
     {
         LivingPackSizeEvent maxCanSpawnEvent = new LivingPackSizeEvent(entity);

--- a/src/main/java/net/minecraftforge/event/FuelBurnTimeEvent.java
+++ b/src/main/java/net/minecraftforge/event/FuelBurnTimeEvent.java
@@ -1,0 +1,32 @@
+package net.minecraftforge.event;
+
+import net.minecraft.item.ItemStack;
+import cpw.mods.fml.common.eventhandler.Event;
+import cpw.mods.fml.common.eventhandler.Event.HasResult;
+
+/**
+ * FuelBurnTimeEvent is fired whenever a furnace needs the burn time of a fuel. <br>
+ * Normally, a registered {@link cpw.mods.fml.common.IFuelHandler} is preferred, but
+ * this is useful in the rare situation where IFuelHandler is not effective.<br>
+ * <br>
+ * {@link Result#DEFAULT} allows the normal fuel handling code to proceed.
+ * {@link Result#ALLOW} or {@link Result#DENY} uses the value of {@link #burnTime}
+ * for the given {@link fuel}, bypassing both vanilla and IFuelHandler determinations.
+ * <br>
+ * {@link #fuel} contains the potential fuel.<br>
+ * {@link #burnTime} the results if set by an event handler.<br>
+ * <br>
+ * This event are fired on the {@link MinecraftForge#EVENT_BUS}.
+ **/
+@HasResult
+@Deprecated //Remove in 1.8
+public class FuelBurnTimeEvent extends Event
+{
+    public final ItemStack fuel;
+    public int burnTime;
+    
+    public FuelBurnTimeEvent(ItemStack fuel)
+    {
+        this.fuel = fuel;
+    }
+}


### PR DESCRIPTION
``---- Minecraft Crash Report ----
// Don't be sad, have a hug! <3

Time: 24.01.2019 11:13
Description: Initializing game

java.lang.IllegalArgumentException: Tried to create a genome for 'rootBees' from an invalid chromosome template. Missing chromosome 'effect'.
species: {magicbees.speciesAMLightning, magicbees.speciesAMLightning}
speed: {magicbees.bees.AlleleFloat@3ee88c4f, magicbees.bees.AlleleFloat@3ee88c4f}
lifespan: {forestry.lifespanShortest, forestry.lifespanShortest}
fertility: {forestry.fertilityNormal, forestry.fertilityNormal}
temperature_tolerance: {forestry.toleranceNone, forestry.toleranceNone}
nocturnal: {forestry.boolTrue, forestry.boolTrue}
humidity_tolerance: {forestry.toleranceNone, forestry.toleranceNone}
tolerant_flyer: {forestry.boolFalse, forestry.boolFalse}
cave_dwelling: {forestry.boolFalse, forestry.boolFalse}
flower_provider: {magicbees.bees.AlleleFlower@273f3e89, magicbees.bees.AlleleFlower@273f3e89}
flowering: {forestry.floweringSlowest, forestry.floweringSlowest}
territory: {forestry.territoryLargest, forestry.territoryLargest}
effect: null

	at forestry.core.genetics.Genome.checkChromosomes(Genome.java:73)
	at forestry.core.genetics.Genome.<init>(Genome.java:52)
	at forestry.apiculture.genetics.BeeGenome.<init>(BeeGenome.java:84)
	at forestry.apiculture.genetics.BeeHelper.templateAsGenome(BeeHelper.java:200)
	at forestry.apiculture.genetics.BeeHelper.registerTemplate(BeeHelper.java:228)
	at magicbees.bees.BeeSpecies.registerGenomeTemplate(BeeSpecies.java:645)
	at magicbees.bees.BeeSpecies.setupBeeSpecies(BeeSpecies.java:421)
	at magicbees.bees.BeeManager.setupAlleles(BeeManager.java:35)
	at magicbees.main.MagicBees.init(MagicBees.java:64)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(Unknown Source)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(Unknown Source)
	at java.lang.reflect.Method.invoke(Unknown Source)
	at cpw.mods.fml.common.FMLModContainer.handleModStateEvent(FMLModContainer.java:532)
	at sun.reflect.GeneratedMethodAccessor4.invoke(Unknown Source)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(Unknown Source)
	at java.lang.reflect.Method.invoke(Unknown Source)
	at com.google.common.eventbus.EventSubscriber.handleEvent(EventSubscriber.java:74)
	at com.google.common.eventbus.SynchronizedEventSubscriber.handleEvent(SynchronizedEventSubscriber.java:47)
	at com.google.common.eventbus.EventBus.dispatch(EventBus.java:322)
	at com.google.common.eventbus.EventBus.dispatchQueuedEvents(EventBus.java:304)
	at com.google.common.eventbus.EventBus.post(EventBus.java:275)
	at cpw.mods.fml.common.LoadController.sendEventToModContainer(LoadController.java:212)
	at cpw.mods.fml.common.LoadController.propogateStateMessage(LoadController.java:190)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(Unknown Source)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(Unknown Source)
	at java.lang.reflect.Method.invoke(Unknown Source)
	at com.google.common.eventbus.EventSubscriber.handleEvent(EventSubscriber.java:74)
	at com.google.common.eventbus.SynchronizedEventSubscriber.handleEvent(SynchronizedEventSubscriber.java:47)
	at com.google.common.eventbus.EventBus.dispatch(EventBus.java:322)
	at com.google.common.eventbus.EventBus.dispatchQueuedEvents(EventBus.java:304)
	at com.google.common.eventbus.EventBus.post(EventBus.java:275)
	at cpw.mods.fml.common.LoadController.distributeStateMessage(LoadController.java:119)
	at cpw.mods.fml.common.Loader.initializeMods(Loader.java:737)
	at cpw.mods.fml.client.FMLClientHandler.finishMinecraftLoading(FMLClientHandler.java:311)
	at net.minecraft.client.Minecraft.func_71384_a(Minecraft.java:552)
	at net.minecraft.client.Minecraft.func_99999_d(Minecraft.java:878)
	at net.minecraft.client.main.Main.main(SourceFile:148)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(Unknown Source)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(Unknown Source)
	at java.lang.reflect.Method.invoke(Unknown Source)
	at net.minecraft.launchwrapper.Launch.launch(Launch.java:135)
	at net.minecraft.launchwrapper.Launch.main(Launch.java:28)


A detailed walkthrough of the error, its code path and all known details is as follows:
---------------------------------------------------------------------------------------

-- Head --
Stacktrace:
	at forestry.core.genetics.Genome.checkChromosomes(Genome.java:73)
	at forestry.core.genetics.Genome.<init>(Genome.java:52)
	at forestry.apiculture.genetics.BeeGenome.<init>(BeeGenome.java:84)
	at forestry.apiculture.genetics.BeeHelper.templateAsGenome(BeeHelper.java:200)
	at forestry.apiculture.genetics.BeeHelper.registerTemplate(BeeHelper.java:228)
	at magicbees.bees.BeeSpecies.registerGenomeTemplate(BeeSpecies.java:645)
	at magicbees.bees.BeeSpecies.setupBeeSpecies(BeeSpecies.java:421)
	at magicbees.bees.BeeManager.setupAlleles(BeeManager.java:35)
	at magicbees.main.MagicBees.init(MagicBees.java:64)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(Unknown Source)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(Unknown Source)
	at java.lang.reflect.Method.invoke(Unknown Source)
	at cpw.mods.fml.common.FMLModContainer.handleModStateEvent(FMLModContainer.java:532)
	at sun.reflect.GeneratedMethodAccessor4.invoke(Unknown Source)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(Unknown Source)
	at java.lang.reflect.Method.invoke(Unknown Source)
	at com.google.common.eventbus.EventSubscriber.handleEvent(EventSubscriber.java:74)
	at com.google.common.eventbus.SynchronizedEventSubscriber.handleEvent(SynchronizedEventSubscriber.java:47)
	at com.google.common.eventbus.EventBus.dispatch(EventBus.java:322)
	at com.google.common.eventbus.EventBus.dispatchQueuedEvents(EventBus.java:304)
	at com.google.common.eventbus.EventBus.post(EventBus.java:275)
	at cpw.mods.fml.common.LoadController.sendEventToModContainer(LoadController.java:212)
	at cpw.mods.fml.common.LoadController.propogateStateMessage(LoadController.java:190)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(Unknown Source)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(Unknown Source)
	at java.lang.reflect.Method.invoke(Unknown Source)
	at com.google.common.eventbus.EventSubscriber.handleEvent(EventSubscriber.java:74)
	at com.google.common.eventbus.SynchronizedEventSubscriber.handleEvent(SynchronizedEventSubscriber.java:47)
	at com.google.common.eventbus.EventBus.dispatch(EventBus.java:322)
	at com.google.common.eventbus.EventBus.dispatchQueuedEvents(EventBus.java:304)
	at com.google.common.eventbus.EventBus.post(EventBus.java:275)
	at cpw.mods.fml.common.LoadController.distributeStateMessage(LoadController.java:119)
	at cpw.mods.fml.common.Loader.initializeMods(Loader.java:737)
	at cpw.mods.fml.client.FMLClientHandler.finishMinecraftLoading(FMLClientHandler.java:311)
	at net.minecraft.client.Minecraft.func_71384_a(Minecraft.java:552)
	at net.minecraft.client.Minecraft.func_99999_d(Minecraft.java:878)

-- Initialization --
Details:
Stacktrace:
	at net.minecraft.client.main.Main.main(SourceFile:148)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(Unknown Source)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(Unknown Source)
	at java.lang.reflect.Method.invoke(Unknown Source)
	at net.minecraft.launchwrapper.Launch.launch(Launch.java:135)
	at net.minecraft.launchwrapper.Launch.main(Launch.java:28)

-- System Details --
Details:
	Minecraft Version: 1.7.10
	Operating System: Windows 10 (amd64) version 10.0
	Java Version: 1.8.0_201, Oracle Corporation
	Java VM Version: Java HotSpot(TM) 64-Bit Server VM (mixed mode), Oracle Corporation
	Memory: 448463920 bytes (427 MB) / 1054433280 bytes (1005 MB) up to 1060372480 bytes (1011 MB)
	JVM Flags: 6 total; -XX:HeapDumpPath=MojangTricksIntelDriversForPerformance_javaw.exe_minecraft.exe.heapdump -Xmx1G -XX:+UseConcMarkSweepGC -XX:+CMSIncrementalMode -XX:-UseAdaptiveSizePolicy -Xmn128M
	AABB Pool Size: 0 (0 bytes; 0 MB) allocated, 0 (0 bytes; 0 MB) used
	IntCache: cache: 0, tcache: 0, allocated: 0, tallocated: 0
	FML: MCP v9.05 FML v7.10.99.99 Minecraft Forge 10.13.4.1614 146 mods loaded, 141 mods active
	States: 'U' = Unloaded 'L' = Loaded 'C' = Constructed 'H' = Pre-initialized 'I' = Initialized 'J' = Post-initialized 'A' = Available 'D' = Disabled 'E' = Errored
	UCHI	mcp{9.05} [Minecraft Coder Pack] (minecraft.jar) 
	UCHI	FML{7.10.99.99} [Forge Mod Loader] (forge-1.7.10-10.13.4.1614-1.7.10.jar) 
	UCHI	Forge{10.13.4.1614} [Minecraft Forge] (forge-1.7.10-10.13.4.1614-1.7.10.jar) 
	UCHI	appliedenergistics2-core{rv2-stable-10} [AppliedEnergistics2 Core] (minecraft.jar) 
	UCHI	CodeChickenCore{1.0.7.47} [CodeChicken Core] (minecraft.jar) 
	UCHI	NotEnoughItems{1.0.5.120} [Not Enough Items] (NotEnoughItems-1.7.10-1.0.5.120-universal.jar) 
	UCHI	ThaumicTinkerer-preloader{0.1} [Thaumic Tinkerer Core] (minecraft.jar) 
	UCHI	OpenModsCore{0.10} [OpenModsCore] (minecraft.jar) 
	UCHI	<CoFH ASM>{000} [CoFH ASM] (minecraft.jar) 
	UCHI	FastCraft{1.25} [FastCraft] (fastcraft-1.25.jar) 
	UCHI	debug{1.0} [debug] (denseores-1.6.2.jar) 
	UCHI	act{0.0.2a_1.7.10} [AdminCommandsToolbox] (AdminCommandsToolbox-0.0.2a_1.7.10.jar) 
	UCHI	appliedenergistics2{rv2-stable-10} [Applied Energistics 2] (appliedenergistics2-rv2-stable-10.jar) 
	UCHI	bdlib{1.9.4.109} [BD Lib] (bdlib-1.9.4.109-mc1.7.10.jar) 
	UCHI	BetterTitleScreen{1.7.10-1.1} [Better Title Screen] (BetterTitleScreen-1.7.10-1.1.jar) 
	UCHI	BiblioCraft{1.11.7} [BiblioCraft] (BiblioCraft[v1.11.7][MC1.7.10].jar) 
	UCHI	Mantle{1.7.10-0.3.2.jenkins191} [Mantle] (Mantle-1.7.10-0.3.2b.jar) 
	UCHI	Natura{2.2.0} [Natura] (natura-1.7.10-2.2.0.1.jar) 
	UCHI	BiomesOPlenty{2.1.0} [Biomes O' Plenty] (BiomesOPlenty-1.7.10-2.1.0.1889-universal.jar) 
	UCHI	BiblioWoodsBoP{1.9} [BiblioWoods Biomes O'Plenty Edition] (BiblioWoods[BiomesOPlenty][v1.9].jar) 
	UCHI	IC2{2.2.827-experimental} [IndustrialCraft 2] (industrialcraft-2-2.2.827-experimental.jar) 
	UCHI	CoFHCore{1.7.10R3.1.4} [CoFH Core] (CoFHCore-[1.7.10]3.1.4-329.jar) 
	UCHI	Forestry{4.2.16.64} [Forestry for Minecraft] (forestry_1.7.10-4.2.16.64.jar) 
	UCHI	BiblioWoodsForestry{1.7} [BiblioWoods Forestry Edition] (BiblioWoods[Forestry][v1.7].jar) 
	UCHI	BiblioWoodsNatura{1.5} [BiblioWoods Natura Edition] (BiblioWoods[Natura][v1.5].jar) 
	UCHI	Baubles{1.0.1.10} [Baubles] (Baubles-1.7.10-1.0.1.10.jar) 
	UCHI	ThermalFoundation{1.7.10R1.2.6} [Thermal Foundation] (ThermalFoundation-[1.7.10]1.2.6-118.jar) 
	UCHI	ThermalExpansion{1.7.10R4.1.5} [Thermal Expansion] (ThermalExpansion-[1.7.10]4.1.5-248.jar) 
	UCHI	BigReactors{0.4.3A} [Big Reactors] (BigReactors-0.4.3A.jar) 
	UCHI	BinnieCore{2.0.22.7} [Binnie Core] (binnie-mods-1.7.10-2.0.22.7.jar) 
	UCHI	Botany{2.0.22.7} [Botany] (binnie-mods-1.7.10-2.0.22.7.jar) 
	UCHI	ExtraTrees{2.0.22.7} [Extra Trees] (binnie-mods-1.7.10-2.0.22.7.jar) 
	UCHI	Genetics{2.0.22.7} [Genetics] (binnie-mods-1.7.10-2.0.22.7.jar) 
	UCHI	ExtraBees{2.0.22.7} [Extra Bees] (binnie-mods-1.7.10-2.0.22.7.jar) 
	UCHI	AWWayofTime{v1.3.3} [Blood Magic: Alchemical Wizardry] (BloodMagic-1.7.10-1.3.3-17.jar) 
	UCHI	Thaumcraft{4.2.3.5} [Thaumcraft] (Thaumcraft-1.7.10-4.2.3.5.jar) 
	UCHI	Botania{r1.8-249} [Botania] (Botania+r1.8-249.jar) 
	UCHI	BuildCraft|Core{7.1.23} [BuildCraft] (buildcraft-7.1.23.jar) 
	UCHI	BuildCraft|Transport{7.1.23} [BC Transport] (buildcraft-7.1.23.jar) 
	UCHI	BuildCraft|Factory{7.1.23} [BC Factory] (buildcraft-7.1.23.jar) 
	UCHI	BuildCraft|Silicon{7.1.23} [BC Silicon] (buildcraft-7.1.23.jar) 
	UCHI	BuildCraft|Robotics{7.1.23} [BC Robotics] (buildcraft-7.1.23.jar) 
	UCHI	BuildCraft|Energy{7.1.23} [BC Energy] (buildcraft-7.1.23.jar) 
	UCHI	BuildCraft|Builders{7.1.23} [BC Builders] (buildcraft-7.1.23.jar) 
	UCHI	BuildCraft|Compat{7.1.7} [BuildCraft Compat] (buildcraft-compat-7.1.7.jar) 
	UCHI	Railcraft{9.12.2.0} [Railcraft] (Railcraft_1.7.10-9.12.2.0.jar) 
	UCHI	TwilightForest{2.3.7} [The Twilight Forest] (twilightforest-1.7.10-2.3.7.jar) 
	UCHI	ForgeMultipart{1.2.0.345} [Forge Multipart] (ForgeMultipart-1.7.10-1.2.0.345-universal.jar) 
	UCHI	chisel{2.9.5.11} [Chisel] (Chisel-2.9.5.11.jar) 
	UCHI	CarpentersBlocks{3.3.8.1} [Carpenter's Blocks] (Carpenter'sBlocksv3.3.8.1-MC1.7.10.jar) 
	UCHI	ChickenChunks{1.3.4.19} [ChickenChunks] (ChickenChunks-1.7.10-1.3.4.19-universal.jar) 
	UCHI	CompactSolars{4.4.39.315} [Compact Solar Arrays] (CompactSolars-1.7.10-4.4.39.315-universal.jar) 
	UCHI	ComputerCraft{1.75} [ComputerCraft] (ComputerCraft1.75.jar) 
	UCHI	CustomMainMenu{1.9.2} [Custom Main Menu] (CustomMainMenu-MC1.7.10-1.9.2.jar) 
	UCHI	endercore{1.7.10-0.2.0.39_beta} [EnderCore] (EnderCore-1.7.10-0.2.0.39_beta.jar) 
	UCHI	MineFactoryReloaded{1.7.10R2.8.1} [MineFactory Reloaded] (MineFactoryReloaded-[1.7.10]2.8.1-174.jar) 
	UCHI	Waila{1.5.10} [Waila] (Waila-1.5.10_1.7.10.jar) 
	UCHI	EnderIO{1.7.10-2.3.0.429_beta} [Ender IO] (EnderIO-1.7.10-2.3.0.429_beta.jar) 
	UCHI	EnderStorage{1.4.7.37} [EnderStorage] (EnderStorage-1.7.10-1.4.7.37-universal.jar) 
	UCHI	EnderTech{1.7.10-0.3.2.405} [EnderTech] (EnderTech-1.7.10-0.3.2.405.jar) 
	UCHI	EnderZoo{1.7.10-1.0.15.32} [Ender Zoo] (EnderZoo-1.7.10-1.0.15.32.jar) 
	UCHI	ExtraUtilities{1.2.12} [Extra Utilities] (extrautilities-1.2.12.jar) 
	UCHI	FlatSigns{2.1.0.19} [Flat Signs] (FlatSigns-1.7.10-universal-2.1.0.19.jar) 
	UCHI	MineTweaker3{3.0.10} [MineTweaker 3] (MineTweaker3-1.7.10-3.0.10B.jar) 
	UCHI	FTBL{1.0.18.2} [FTBLib] (FTBLib-1.7.10-1.0.18.3.jar) 
	UCHI	FTBU{1.0.18.2} [FTBUtilities] (FTBUtilities-1.7.10-1.0.18.3.jar) 
	UCHI	funkylocomotion{1.0} [Funky Locomotion] (funky-locomotion-1.7.10-beta-7.jar) 
	UCHI	RedstoneArsenal{1.7.10R1.1.2} [Redstone Arsenal] (RedstoneArsenal-[1.7.10]1.1.2-92.jar) 
	UCHI	TConstruct{1.7.10-1.8.8.build988} [Tinkers' Construct] (TConstruct-1.7.10-1.8.8.jar) 
	UCHI	ThaumicTinkerer{unspecified} [Thaumic Tinkerer] (ThaumicTinkerer-2.5-1.7.10-164.jar) 
	UCHE	MagicBees{2.4.4} [Magic Bees] (magicbees-1.7.10-2.4.4.jar) 
	UCHI	gendustry{1.6.3.132} [GenDustry] (gendustry-1.6.3.132-mc1.7.10.jar) 
	UCHI	guideapi{1.7.10-1.0.1-20} [Guide-API] (Guide-API-1.7.10-1.0.1-20.jar) 
	UCHI	iChunUtil{4.2.3} [iChunUtil] (iChunUtil-4.2.3.jar) 
	UCHI	Hats{4.0.1} [Hats] (Hats-4.0.1.jar) 
	UCHI	HatStand{4.0.0} [HatStand] (HatStand-4.0.0.jar) 
	UCHI	HelpFixer{1.0.7} [HelpFixer] (HelpFixer-1.0.7.jar) 
	UCHI	IC2NuclearControl{2.4.3a} [Nuclear Control 2] (IC2NuclearControl-2.4.3a.jar) 
	UCHI	inpure|core{1.7.10R1.0.0B9} [INpureCore] (INpureCore-[1.7.10]1.0.0B9-62.jar) 
	UCHI	inventorytweaks{1.59-dev-152-cf6e263} [Inventory Tweaks] (InventoryTweaks-1.59-dev-152.jar) 
	UCHI	IronChest{6.0.62.742} [Iron Chest] (ironchest-1.7.10-6.0.62.742-universal.jar) 
	UCHI	JABBA{1.2.2} [JABBA] (Jabba-1.2.2_1.7.10.jar) 
	UCHI	journeymap{5.1.4p2} [JourneyMap] (journeymap-1.7.10-5.1.4p2-unlimited.jar) 
	UCHI	MineFactoryReloaded|CompatAppliedEnergistics{1.7.10R2.8.1} [MFR Compat: Applied Energistics] (MineFactoryReloaded-[1.7.10]2.8.1-174.jar) 
	UCHI	MineFactoryReloaded|CompatBuildCraft{1.7.10R2.8.1} [MFR Compat: BuildCraft] (MineFactoryReloaded-[1.7.10]2.8.1-174.jar) 
	UCHI	MineFactoryReloaded|CompatForestry{1.7.10R2.8.1} [MFR Compat: Forestry] (MineFactoryReloaded-[1.7.10]2.8.1-174.jar) 
	UCHI	MineFactoryReloaded|CompatForgeMicroblock{1.7.10R2.8.1} [MFR Compat: ForgeMicroblock] (MineFactoryReloaded-[1.7.10]2.8.1-174.jar) 
	UCHI	MineFactoryReloaded|CompatIC2{1.7.10R2.8.1} [MFR Compat: IC2] (MineFactoryReloaded-[1.7.10]2.8.1-174.jar) 
	UCHI	MrTJPCoreMod{1.1.0.33} [MrTJPCore] (MrTJPCore-1.7.10-1.1.0.33-universal.jar) 
	UCHI	ProjRed|Core{4.7.0pre12.95} [ProjectRed Core] (ProjectRed-1.7.10-4.7.0pre12.95-Base.jar) 
	UCHI	ProjRed|Exploration{4.7.0pre12.95} [ProjectRed Exploration] (ProjectRed-1.7.10-4.7.0pre12.95-World.jar) 
	UCHI	MineFactoryReloaded|CompatProjRed{1.7.10R2.8.1} [MFR Compat ProjectRed] (MineFactoryReloaded-[1.7.10]2.8.1-174.jar) 
	UCHI	MineFactoryReloaded|CompatRailcraft{1.7.10R2.8.1} [MFR Compat: Railcraft] (MineFactoryReloaded-[1.7.10]2.8.1-174.jar) 
	UCHI	MineFactoryReloaded|CompatThaumcraft{1.7.10R2.8.1} [MFR Compat: Thaumcraft] (MineFactoryReloaded-[1.7.10]2.8.1-174.jar) 
	UCHI	MineFactoryReloaded|CompatThermalExpansion{1.7.10R2.8.1} [MFR Compat: Thermal Expansion] (MineFactoryReloaded-[1.7.10]2.8.1-174.jar) 
	UCHI	MineFactoryReloaded|CompatTConstruct{1.7.10R2.8.1} [MFR Compat: Tinkers' Construct] (MineFactoryReloaded-[1.7.10]2.8.1-174.jar) 
	UCHI	MineFactoryReloaded|CompatTwilightForest{1.7.10R2.8.1} [MFR Compat: TwilightForest] (MineFactoryReloaded-[1.7.10]2.8.1-174.jar) 
	UCHI	MineFactoryReloaded|CompatVanilla{1.7.10R2.8.1} [MFR Compat: Vanilla] (MineFactoryReloaded-[1.7.10]2.8.1-174.jar) 
	UCHI	numina{1.7.10} [Numina] (Numina-0.4.1.105.jar) 
	UCHI	powersuits{1.7.10-0.11.1.116} [MachineMuse's Modular Powersuits] (ModularPowersuits-1.7.10-0.11.1.116.jar) 
	UCHI	Morph{0.9.3} [Morph] (Morph-Beta-0.9.3.jar) 
	UCHI	Morpheus{1.7.10-1.6.21} [Morpheus] (Morpheus-1.7.10-1.6.21.jar) 
	UCHI	Mystcraft{0.12.3.04} [Mystcraft] (mystcraft-1.7.10-0.12.3.04.jar) 
	UCHI	NEIAddons{1.12.14.40} [NEI Addons] (neiaddons-1.12.14.40-mc1.7.10.jar) 
	UCHI	NEIAddons|Developer{1.12.14.40} [NEI Addons: Developer Tools] (neiaddons-1.12.14.40-mc1.7.10.jar) 
	UCHI	NEIAddons|AppEng{1.12.14.40} [NEI Addons: Applied Energistics 2] (neiaddons-1.12.14.40-mc1.7.10.jar) 
	UCHI	NEIAddons|Botany{1.12.14.40} [NEI Addons: Botany] (neiaddons-1.12.14.40-mc1.7.10.jar) 
	UCHI	NEIAddons|Forestry{1.12.14.40} [NEI Addons: Forestry] (neiaddons-1.12.14.40-mc1.7.10.jar) 
	UCHI	NEIAddons|CraftingTables{1.12.14.40} [NEI Addons: Crafting Tables] (neiaddons-1.12.14.40-mc1.7.10.jar) 
	UCHI	NEIAddons|ExNihilo{1.12.14.40} [NEI Addons: Ex Nihilo] (neiaddons-1.12.14.40-mc1.7.10.jar) 
	UCHI	neiintegration{1.1.2} [NEI Integration] (NEIIntegration-MC1.7.10-1.1.2.jar) 
	UCHI	notenoughkeys{@MOD_VERSION@} [NotEnoughKeys] (NotEnoughKeys-1.7.10-3.0.0b45-dev-universal.jar) 
	UCHI	ObsidiPlates{3.0.0.18} [ObsidiPlates] (ObsidiPlates-1.7.10-universal-3.0.0.18.jar) 
	UCHI	OpenMods{0.10} [OpenMods] (OpenModsLib-1.7.10-0.10.jar) 
	UCHI	OpenBlocks{1.6} [OpenBlocks] (OpenBlocks-1.7.10-1.6.jar) 
	UCHI	OpenPeripheralCore{1.4} [OpenPeripheralCore] (OpenPeripheralCore-1.7.10-1.4.jar) 
	UCHI	OpenPeripheral{0.6} [OpenPeripheralAddons] (OpenPeripheralAddons-1.7.10-0.6.jar) 
	UCHI	OpenPeripheralIntegration{0.6} [OpenPeripheralIntegration] (OpenPeripheralIntegration-1.7.10-0.6.jar) 
	UCHI	PneumaticCraft{1.12.7-152} [PneumaticCraft] (PneumaticCraft-1.7.10-1.12.7-152-universal.jar) 
	UCHI	PortalGun{4.0.0-beta-6} [PortalGun] (PortalGun-4.0.0-beta-6-fix-1.jar) 
	UCHI	ProjRed|Transmission{4.7.0pre12.95} [ProjectRed Transmission] (ProjectRed-1.7.10-4.7.0pre12.95-Integration.jar) 
	UCHI	ProjRed|Compatibility{4.7.0pre12.95} [ProjectRed Compatibility] (ProjectRed-1.7.10-4.7.0pre12.95-Compat.jar) 
	UCHI	ProjRed|Integration{4.7.0pre12.95} [ProjectRed Integration] (ProjectRed-1.7.10-4.7.0pre12.95-Integration.jar) 
	UCHI	ProjRed|Illumination{4.7.0pre12.95} [ProjectRed Illumination] (ProjectRed-1.7.10-4.7.0pre12.95-Lighting.jar) 
	UCHI	ResourceLoader{1.3} [Resource Loader] (ResourceLoader-MC1.7.10-1.3.jar) 
	UCHI	rftools{4.23} [RFTools] (rftools-4.23.jar) 
	UCHI	StevesFactoryManager{A93} [Steve's Factory Manager] (StevesFactoryManagerA93.jar) 
	UCHI	ThaumicExploration{0.6.0} [Thaumic Exploration] (ThaumicExploration-1.7.10-1.1-53.jar) 
	UCHI	ThermalDynamics{1.7.10R1.2.1} [Thermal Dynamics] (ThermalDynamics-[1.7.10]1.2.1-172.jar) 
	UCHI	TiCTooltips{1.2.5} [TiC Tooltips] (TiCTooltips-mc1.7.10-1.2.5.jar) 
	UCHI	TMechworks{0.2.15.106} [Tinkers' Mechworks] (TMechworks-1.7.10-0.2.15.106.jar) 
	UCHI	Translocator{1.1.2.16} [Translocator] (Translocator-1.7.10-1.1.2.16-universal.jar) 
	UCHI	WailaHarvestability{1.1.6} [Waila Harvestability] (WailaHarvestability-mc1.7.10-1.1.6.jar) 
	UCHI	witchery{0.24.1} [Witchery] (witchery-1.7.10-0.24.1.jar) 
	UCHI	WR-CBE|Core{1.4.1.9} [WR-CBE Core] (WR-CBE-1.7.10-1.4.1.9-universal.jar) 
	UCHI	WR-CBE|Addons{1.4.1.9} [WR-CBE Addons] (WR-CBE-1.7.10-1.4.1.9-universal.jar) 
	UCHI	WR-CBE|Logic{1.4.1.9} [WR-CBE Logic] (WR-CBE-1.7.10-1.4.1.9-universal.jar) 
	UCHI	McMultipart{1.2.0.345} [Minecraft Multipart Plugin] (ForgeMultipart-1.7.10-1.2.0.345-universal.jar) 
	UCHI	aobd{2.9.2} [Another One Bites The Dust] (AOBD-2.9.2.jar) 
	UCHI	denseores{1.0} [Dense Ores] (denseores-1.6.2.jar) 
	UCHI	ForgeMicroblock{1.2.0.345} [Forge Microblocks] (ForgeMultipart-1.7.10-1.2.0.345-universal.jar) 
	UD	MineFactoryReloaded|CompatAtum{1.7.10R2.8.1} [MFR Compat: Atum] (MineFactoryReloaded-[1.7.10]2.8.1-174.jar) 
	UD	MineFactoryReloaded|CompatBackTools{1.7.10R2.8.1} [MFR Compat: BackTools] (MineFactoryReloaded-[1.7.10]2.8.1-174.jar) 
	UD	MineFactoryReloaded|CompatChococraft{1.7.10R2.8.1} [MFR Compat: Chococraft] (MineFactoryReloaded-[1.7.10]2.8.1-174.jar) 
	UD	MineFactoryReloaded|CompatExtraBiomes{1.7.10R2.8.1} [MFR Compat: ExtraBiomes] (MineFactoryReloaded-[1.7.10]2.8.1-174.jar) 
	UD	MineFactoryReloaded|CompatSufficientBiomes{1.7.10R2.8.1} [MFR Compat: Sufficient Biomes] (MineFactoryReloaded-[1.7.10]2.8.1-174.jar) 
	GL info: ' Vendor: 'NVIDIA Corporation' Version: '4.6.0 NVIDIA 416.94' Renderer: 'GeForce GTX 1050 Ti/PCIe/SSE2'
	OpenModsLib class transformers: [stencil_patches:FINISHED],[movement_callback:FINISHED],[player_damage_hook:FINISHED],[map_gen_fix:FINISHED],[gl_capabilities_hook:FINISHED],[player_render_hook:FINISHED]
	Class transformer null safety: all safe
	AE2 Version: stable rv2-stable-10 for Forge 10.13.2.1291
	Mantle Environment: Environment healthy.
	CoFHCore: -[1.7.10]3.1.4-329
	ThermalFoundation: -[1.7.10]1.2.6-118
	ThermalExpansion: -[1.7.10]4.1.5-248
	MineFactoryReloaded: -[1.7.10]2.8.1-174
	RedstoneArsenal: -[1.7.10]1.1.2-92
	TConstruct Environment: Environment healthy.
	ThermalDynamics: -[1.7.10]1.2.1-172
	List of loaded APIs: 
		* API_NEK (1.2.0) from NotEnoughKeys-1.7.10-3.0.0b45-dev-universal.jar
		* appliedenergistics2|API (rv2) from appliedenergistics2-rv2-stable-10.jar
		* Baubles|API (1.0.1.10) from ThermalFoundation-[1.7.10]1.2.6-118.jar
		* BiomesOPlentyAPI (1.0.0) from BiomesOPlenty-1.7.10-2.1.0.1889-universal.jar
		* BloodMagicAPI (1.3.3-13) from BloodMagic-1.7.10-1.3.3-17.jar
		* BotaniaAPI (76) from Botania+r1.8-249.jar
		* BuildCraftAPI|blocks (1.0) from Railcraft_1.7.10-9.12.2.0.jar
		* BuildCraftAPI|blueprints (1.5) from buildcraft-7.1.23.jar
		* BuildCraftAPI|boards (2.0) from buildcraft-7.1.23.jar
		* BuildCraftAPI|core (2.0) from Railcraft_1.7.10-9.12.2.0.jar
		* BuildCraftAPI|crops (1.1) from Railcraft_1.7.10-9.12.2.0.jar
		* BuildCraftAPI|events (2.0) from buildcraft-7.1.23.jar
		* BuildCraftAPI|facades (1.1) from buildcraft-7.1.23.jar
		* BuildCraftAPI|filler (4.0) from buildcraft-7.1.23.jar
		* BuildCraftAPI|fuels (2.0) from buildcraft-7.1.23.jar
		* BuildCraftAPI|gates (4.1) from buildcraft-7.1.23.jar
		* BuildCraftAPI|items (1.1) from Railcraft_1.7.10-9.12.2.0.jar
		* BuildCraftAPI|library (2.0) from buildcraft-7.1.23.jar
		* BuildCraftAPI|lists (1.0) from Railcraft_1.7.10-9.12.2.0.jar
		* BuildCraftAPI|power (1.3) from buildcraft-7.1.23.jar
		* BuildCraftAPI|recipes (3.1) from buildcraft-7.1.23.jar
		* BuildCraftAPI|robotics (3.0) from buildcraft-7.1.23.jar
		* BuildCraftAPI|statements (1.1) from buildcraft-7.1.23.jar
		* BuildCraftAPI|tablet (1.0) from Railcraft_1.7.10-9.12.2.0.jar
		* BuildCraftAPI|tiles (1.2) from buildcraft-7.1.23.jar
		* BuildCraftAPI|tools (1.0) from buildcraft-7.1.23.jar
		* BuildCraftAPI|transport (4.1) from buildcraft-7.1.23.jar
		* CarpentersBlocks|API (3.3.7) from Carpenter'sBlocksv3.3.8.1-MC1.7.10.jar
		* ChiselAPI (0.1.1) from Chisel-2.9.5.11.jar
		* ChiselAPI|Carving (0.1.1) from Chisel-2.9.5.11.jar
		* ChiselAPI|Rendering (0.1.1) from Chisel-2.9.5.11.jar
		* CoFHAPI (1.7.10R1.0.2) from Railcraft_1.7.10-9.12.2.0.jar
		* CoFHAPI|block (1.7.10R1.1.0) from EnderTech-1.7.10-0.3.2.405.jar
		* CoFHAPI|core (1.7.10R1.3.1) from CoFHCore-[1.7.10]3.1.4-329.jar
		* CoFHAPI|energy (1.7.10R1.0.2) from Railcraft_1.7.10-9.12.2.0.jar
		* CoFHAPI|fluid (1.7.10R1.1.0) from EnderTech-1.7.10-0.3.2.405.jar
		* CoFHAPI|inventory (1.7.10R1.0.1) from buildcraft-compat-7.1.7.jar
		* CoFHAPI|item (1.7.10R1.0.13B1) from extrautilities-1.2.12.jar
		* CoFHAPI|modhelpers (1.7.10R1.1.0) from EnderTech-1.7.10-0.3.2.405.jar
		* CoFHAPI|tileentity (1.7.10R1.0.13) from EnderIO-1.7.10-2.3.0.429_beta.jar
		* CoFHAPI|transport (1.7.10R1.1.0) from EnderTech-1.7.10-0.3.2.405.jar
		* CoFHAPI|world (1.7.10R1.1.0) from EnderTech-1.7.10-0.3.2.405.jar
		* CoFHLib (1.7.10R1.0.4B1) from EnderTech-1.7.10-0.3.2.405.jar
		* CoFHLib|audio (1.7.10R1.2.1) from CoFHCore-[1.7.10]3.1.4-329.jar
		* CoFHLib|gui (1.7.10R1.0.4B1) from EnderTech-1.7.10-0.3.2.405.jar
		* CoFHLib|gui|container (1.7.10R1.0.4B1) from EnderTech-1.7.10-0.3.2.405.jar
		* CoFHLib|gui|element (1.7.10R1.0.4B1) from EnderTech-1.7.10-0.3.2.405.jar
		* CoFHLib|gui|element|listbox (1.7.10R1.0.4B1) from EnderTech-1.7.10-0.3.2.405.jar
		* CoFHLib|gui|slot (1.7.10R1.0.4B1) from EnderTech-1.7.10-0.3.2.405.jar
		* CoFHLib|inventory (1.7.10R1.0.4B1) from EnderTech-1.7.10-0.3.2.405.jar
		* CoFHLib|render (1.7.10R1.2.1) from CoFHCore-[1.7.10]3.1.4-329.jar
		* CoFHLib|render|particle (1.7.10R1.0.4B1) from EnderTech-1.7.10-0.3.2.405.jar
		* CoFHLib|util (1.7.10R1.0.4B1) from EnderTech-1.7.10-0.3.2.405.jar
		* CoFHLib|util|helpers (1.7.10R1.2.1) from CoFHCore-[1.7.10]3.1.4-329.jar
		* CoFHLib|util|position (1.7.10R1.2.1) from CoFHCore-[1.7.10]3.1.4-329.jar
		* CoFHLib|world (1.7.10R1.2.1) from CoFHCore-[1.7.10]3.1.4-329.jar
		* CoFHLib|world|feature (1.7.10R1.0.4B1) from EnderTech-1.7.10-0.3.2.405.jar
		* ComputerCraft|API (1.75) from ComputerCraft1.75.jar
		* ComputerCraft|API|FileSystem (1.75) from ComputerCraft1.75.jar
		* ComputerCraft|API|Lua (1.75) from ComputerCraft1.75.jar
		* ComputerCraft|API|Media (1.75) from ComputerCraft1.75.jar
		* ComputerCraft|API|Peripheral (1.75) from ComputerCraft1.75.jar
		* ComputerCraft|API|Permissions (1.75) from ComputerCraft1.75.jar
		* ComputerCraft|API|Redstone (1.75) from ComputerCraft1.75.jar
		* ComputerCraft|API|Turtle (1.75) from ComputerCraft1.75.jar
		* EnderIOAPI (0.0.2) from EnderIO-1.7.10-2.3.0.429_beta.jar
		* EnderIOAPI|Redstone (0.0.2) from EnderIO-1.7.10-2.3.0.429_beta.jar
		* EnderIOAPI|Teleport (0.0.2) from EnderIO-1.7.10-2.3.0.429_beta.jar
		* EnderIOAPI|Tools (0.0.2) from EnderIO-1.7.10-2.3.0.429_beta.jar
		* ForestryAPI|apiculture (4.8.0) from forestry_1.7.10-4.2.16.64.jar
		* ForestryAPI|arboriculture (4.2.1) from forestry_1.7.10-4.2.16.64.jar
		* ForestryAPI|circuits (3.1.0) from forestry_1.7.10-4.2.16.64.jar
		* ForestryAPI|core (5.0.0) from forestry_1.7.10-4.2.16.64.jar
		* ForestryAPI|farming (2.1.0) from forestry_1.7.10-4.2.16.64.jar
		* ForestryAPI|food (1.1.0) from forestry_1.7.10-4.2.16.64.jar
		* ForestryAPI|fuels (2.0.1) from forestry_1.7.10-4.2.16.64.jar
		* ForestryAPI|genetics (4.7.1) from forestry_1.7.10-4.2.16.64.jar
		* ForestryAPI|hives (4.1.0) from forestry_1.7.10-4.2.16.64.jar
		* ForestryAPI|lepidopterology (1.3.0) from forestry_1.7.10-4.2.16.64.jar
		* ForestryAPI|mail (3.0.0) from forestry_1.7.10-4.2.16.64.jar
		* ForestryAPI|multiblock (3.0.0) from forestry_1.7.10-4.2.16.64.jar
		* ForestryAPI|recipes (5.4.0) from forestry_1.7.10-4.2.16.64.jar
		* ForestryAPI|storage (3.0.0) from forestry_1.7.10-4.2.16.64.jar
		* ForestryAPI|world (2.1.0) from forestry_1.7.10-4.2.16.64.jar
		* gendustryAPI (2.3.0) from gendustry-1.6.3.132-mc1.7.10.jar
		* Guide-API|API (1.7.10-1.0.1-20) from Guide-API-1.7.10-1.0.1-20.jar
		* IC2API (1.0) from Railcraft_1.7.10-9.12.2.0.jar
		* inpure|api (1.7) from INpureCore-[1.7.10]1.0.0B9-62.jar
		* McJtyLib (1.8.1) from mcjtylib-1.8.1.jar
		* Mystcraft|API (0.1) from mystcraft-1.7.10-0.12.3.04.jar
		* NuclearControlAPI (v1.0.5) from IC2NuclearControl-2.4.3a.jar
		* OpenBlocks|API (1.1) from OpenBlocks-1.7.10-1.6.jar
		* OpenPeripheralAddonsApi (1.0) from OpenPeripheralAddons-1.7.10-0.6.jar
		* OpenPeripheralApi (3.4.2) from OpenPeripheralCore-1.7.10-1.4.jar
		* PneumaticCraftApi (1.0) from PneumaticCraft-1.7.10-1.12.7-152-universal.jar
		* RailcraftAPI|bore (1.0.0) from Railcraft_1.7.10-9.12.2.0.jar
		* RailcraftAPI|carts (1.6.0) from Railcraft_1.7.10-9.12.2.0.jar
		* RailcraftAPI|core (1.5.0) from Railcraft_1.7.10-9.12.2.0.jar
		* RailcraftAPI|crafting (1.0.0) from Railcraft_1.7.10-9.12.2.0.jar
		* RailcraftAPI|electricity (2.0.0) from Railcraft_1.7.10-9.12.2.0.jar
		* RailcraftAPI|events (1.0.0) from Railcraft_1.7.10-9.12.2.0.jar
		* RailcraftAPI|fuel (1.0.0) from Railcraft_1.7.10-9.12.2.0.jar
		* RailcraftAPI|helpers (1.1.0) from Railcraft_1.7.10-9.12.2.0.jar
		* RailcraftAPI|items (1.0.0) from Railcraft_1.7.10-9.12.2.0.jar
		* RailcraftAPI|locomotive (1.1.0) from Railcraft_1.7.10-9.12.2.0.jar
		* RailcraftAPI|signals (2.3.0) from Railcraft_1.7.10-9.12.2.0.jar
		* RailcraftAPI|tracks (2.3.0) from Railcraft_1.7.10-9.12.2.0.jar
		* Thaumcraft|API (4.2.2.0) from Railcraft_1.7.10-9.12.2.0.jar
		* WailaAPI (1.2) from Waila-1.5.10_1.7.10.jar
	Chisel: Errors like "[FML]: Unable to lookup ..." are NOT the cause of this crash. You can safely ignore these errors. And update forge while you're at it.
	EnderIO: Found the following problem(s) with your installation:
                  * The RF API that is being used (1.7.10R1.3.1 from <unknown>) differes from that that is reported as being loaded (1.7.10R1.0.2 from Railcraft_1.7.10-9.12.2.0.jar).

                    It is a supported version, but that difference may lead to problems.
                 This may have caused the error. Try reproducing the crash WITHOUT this/these mod(s) before reporting it.
	Stencil buffer state: Function set: GL30, pool: forge, bits: 8
	Launched Version: 1.7.10-Forge10.13.4.1614-1.7.10
	LWJGL: 2.9.1
	OpenGL: GeForce GTX 1050 Ti/PCIe/SSE2 GL version 4.6.0 NVIDIA 416.94, NVIDIA Corporation
	GL Caps: Using GL 1.3 multitexturing.
Using framebuffer objects because OpenGL 3.0 is supported and separate blending is supported.
Anisotropic filtering is supported and maximum anisotropy is 16.
Shaders are available because OpenGL 2.1 is supported.

	Is Modded: Definitely; Client brand changed to 'fml,forge'
	Type: Client (map_client.txt)
	Resource Packs: []
	Current Language: English (US)
	Profiler Position: N/A (disabled)
	Vec3 Pool Size: 0 (0 bytes; 0 MB) allocated, 0 (0 bytes; 0 MB) used
	Anisotropic Filtering: Off (1)`
The game is giving error. Can you help me?
