### PR TITLE
Made functional interface IChunkGeneratorFactory public

### DIFF
--- a/src/main/resources/META-INF/accesstransformer.cfg
+++ b/src/main/resources/META-INF/accesstransformer.cfg
@@ -396,3 +396,6 @@ public net.minecraft.block.Block$Builder func_200943_b(F)Lnet/minecraft/block/Bl
 
 #ChunkGeneratorType
 public net.minecraft.world.gen.ChunkGeneratorType$Settings
+
+#IChunkGeneratorFactory
+public net.minecraft.world.gen.IChunkGeneratorFactory


### PR DESCRIPTION
This one is needed if ChunkGeneratorType#register is used.

It wants a `IChunkGeneratorFactory<C, T>`, but this package default, so it can not be used with a lamda of type `ChunkGenerator::new`.

This PR fixes this by making the Interface public.