### PR TITLE
Fix some of minecraft's resources loading twice

### DIFF
--- a/src/main/java/net/minecraftforge/fml/packs/ModFileResourcePack.java
+++ b/src/main/java/net/minecraftforge/fml/packs/ModFileResourcePack.java
@@ -108,6 +108,7 @@ public class ModFileResourcePack extends AbstractResourcePack
                     .map(path -> root.relativize(path.toAbsolutePath()))
                     .filter(path -> path.getNameCount() > 0) // skip the root entry
                     .map(p->p.toString().replaceAll("/$","")) // remove the trailing slash, if present
+                    .filter(s -> !s.isEmpty()) //filter empty strings, otherwise empty strings default to minecraft in ResourceLocations
                     .collect(Collectors.toSet());
         }
         catch (IOException e)


### PR DESCRIPTION
This method sometimes returns an empty string, causing certain elements of minecraft to be loaded twice (as an empty string defaults to minecraft in resourcelocation).
This can be observed in the log by e.g. the underwater_ambience sound being preloaded twice