### PR TITLE
Fix RuntimeEnumExtender creating new enums with incorrect ordinal value

### DIFF
--- a/src/fmllauncher/java/net/minecraftforge/common/asm/RuntimeEnumExtender.java
+++ b/src/fmllauncher/java/net/minecraftforge/common/asm/RuntimeEnumExtender.java
@@ -157,14 +157,12 @@ public class RuntimeEnumExtender implements ILaunchPluginService {
 
             {
                 vars += 1; //enum ret;
-                //ret = new ThisType(name, VALUES.length + 1, args..)
+                //ret = new ThisType(name, VALUES.length, args..)
                 ins.anew(classType);
                 ins.dup();
                 ins.load(0, STRING);
                 ins.getstatic(classType.getInternalName(), values.name, values.desc);
                 ins.arraylength();
-                ins.iconst(1);
-                ins.add(Type.INT_TYPE);
                 int idx = 1;
                 for (int x = 1; x < args.length; x++)
                 {

--- a/src/test/java/net/minecraftforge/debug/misc/EnumPlantTypeTest.java
+++ b/src/test/java/net/minecraftforge/debug/misc/EnumPlantTypeTest.java
@@ -21,56 +21,41 @@ package net.minecraftforge.debug.misc;
 
 import net.minecraftforge.common.BiomeManager.BiomeType;
 import net.minecraftforge.common.EnumPlantType;
+import net.minecraftforge.eventbus.api.SubscribeEvent;
+import net.minecraftforge.fml.DeferredWorkQueue;
 import net.minecraftforge.fml.common.Mod;
-import net.minecraftforge.fml.event.FMLInitializationEvent;
-import net.minecraftforge.fml.event.FMLPreInitializationEvent;
+import net.minecraftforge.fml.event.lifecycle.FMLCommonSetupEvent;
+import net.minecraftforge.fml.javafmlmod.FMLModLoadingContext;
+import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
-@Mod(modid = "enumplanttypetest", name = "EnumPlantTypeTest", version = "1.0", acceptableRemoteVersions = "*")
+@Mod("enumplanttypetest")
 public class EnumPlantTypeTest
 {
-    private static Logger logger;
+    private static final Logger LOGGER = LogManager.getLogger();
 
-    @Mod.EventHandler
-    public void onPreInit(FMLPreInitializationEvent event)
+    public EnumPlantTypeTest()
     {
-        logger = event.getModLog();
+        FMLModLoadingContext.get().getModEventBus().addListener(this::setup);
     }
 
-    @Mod.EventHandler
-    public void onInit(FMLInitializationEvent event)
+    @SubscribeEvent
+    public void setup(final FMLCommonSetupEvent event)
     {
-        BiomeType biomeType = null;
-        try
+        DeferredWorkQueue.runLater(() ->
         {
-            biomeType = BiomeType.getType("FAKE");
-        }
-        catch (NullPointerException npe)
-        {
-            logger.warn("EnumHelper in BiomeType is working incorrectly!", npe);
-        }
-        finally
-        {
-            if (biomeType == null || !biomeType.name().equals("FAKE"))
+            int index = BiomeType.values().length;
+            BiomeType biomeType = BiomeType.create("FAKE");
+            if (biomeType == null || !biomeType.name().equals("FAKE") || biomeType.ordinal() != index)
             {
-                logger.warn("EnumHelper in BiomeType is working incorrectly!");
+                LOGGER.warn("RuntimeEnumExtender is working incorrectly for BiomeType!");
             }
-        }
-        EnumPlantType plantType = null;
-        try
-        {
-            plantType = EnumPlantType.getPlantType("FAKE");
-        }
-        catch (NullPointerException npe)
-        {
-            logger.warn("EnumHelper in EnumPlantType is working incorrectly!", npe);
-        }
-        finally
-        {
-            if (plantType == null || !plantType.name().equals("FAKE"))
+
+            EnumPlantType plantType = EnumPlantType.create("FAKE");
+            if (plantType == null || !plantType.name().equals("FAKE") || plantType != EnumPlantType.create("FAKE"))
             {
-                logger.warn("EnumHelper in EnumPlantType is working incorrectly!");
+                LOGGER.warn("RuntimeEnumExtender is working incorrectly for EnumPlantType!");
             }
-        }
+        });
     }
 }

--- a/src/test/resources/META-INF/mods.toml
+++ b/src/test/resources/META-INF/mods.toml
@@ -69,3 +69,8 @@ key="value"
 [[mods]]
     # A minimal mod
     modId="minimalmod"
+# debug/misc
+[[mods]]
+    modId="enumplanttypetest"
+    version="1.0"
+    displayName="EnumPlantTypeTest"


### PR DESCRIPTION
This fixes a bug where the ordinal value for enums add by mods is one greater than what is expected. The incorrect ordinal value can cause a mess of issues further down the line like an `ArrayIndexOutOfBoundsException` in the constructor of `GenLayerBiome`.

Also updated the debug mod that test enum creation.