### PR TITLE
[1.13] Fixed missed OptionalCapabilityInstance to LazyOptional refactors in patches

### DIFF
--- a/patches/minecraft/net/minecraft/entity/EntityLivingBase.java.patch
+++ b/patches/minecraft/net/minecraft/entity/EntityLivingBase.java.patch
@@ -411,10 +411,10 @@
 +      }
 +   }
 +
-+   private final net.minecraftforge.common.capabilities.OptionalCapabilityInstance<?>[] handlers = net.minecraftforge.items.wrapper.EntityEquipmentInvWrapper.create(this);
++   private final net.minecraftforge.common.util.LazyOptional<?>[] handlers = net.minecraftforge.items.wrapper.EntityEquipmentInvWrapper.create(this);
 +
 +   @Override
-+   public <T> net.minecraftforge.common.capabilities.OptionalCapabilityInstance<T> getCapability(net.minecraftforge.common.capabilities.Capability<T> capability, @Nullable EnumFacing facing) {
++   public <T> net.minecraftforge.common.util.LazyOptional<T> getCapability(net.minecraftforge.common.capabilities.Capability<T> capability, @Nullable EnumFacing facing) {
 +      if (capability == net.minecraftforge.items.CapabilityItemHandler.ITEM_HANDLER_CAPABILITY) {
 +         if (facing == null) return handlers[2].cast();
 +         else if (facing.func_176740_k().func_200128_b()) return handlers[0].cast();

--- a/patches/minecraft/net/minecraft/entity/item/EntityMinecartContainer.java.patch
+++ b/patches/minecraft/net/minecraft/entity/item/EntityMinecartContainer.java.patch
@@ -39,10 +39,10 @@
        return this.field_184290_c;
     }
 +
-+   private net.minecraftforge.common.capabilities.OptionalCapabilityInstance<?> itemHandler = net.minecraftforge.common.capabilities.OptionalCapabilityInstance.of(() -> new net.minecraftforge.items.wrapper.InvWrapper(this));
++   private net.minecraftforge.common.util.LazyOptional<?> itemHandler = net.minecraftforge.common.util.LazyOptional.of(() -> new net.minecraftforge.items.wrapper.InvWrapper(this));
 +
 +   @Override
-+   public <T> net.minecraftforge.common.capabilities.OptionalCapabilityInstance<T> getCapability(net.minecraftforge.common.capabilities.Capability<T> capability, @Nullable net.minecraft.util.EnumFacing facing) {
++   public <T> net.minecraftforge.common.util.LazyOptional<T> getCapability(net.minecraftforge.common.capabilities.Capability<T> capability, @Nullable net.minecraft.util.EnumFacing facing) {
 +      if (capability == net.minecraftforge.items.CapabilityItemHandler.ITEM_HANDLER_CAPABILITY)
 +         return itemHandler.cast();
 +      return super.getCapability(capability, facing);

--- a/patches/minecraft/net/minecraft/entity/passive/AbstractHorse.java.patch
+++ b/patches/minecraft/net/minecraft/entity/passive/AbstractHorse.java.patch
@@ -4,7 +4,7 @@
  
        this.field_110296_bG.func_110134_a(this);
        this.func_110232_cE();
-+      this.itemHandler = net.minecraftforge.common.capabilities.OptionalCapabilityInstance.of(() -> new net.minecraftforge.items.wrapper.InvWrapper(this.field_110296_bG));
++      this.itemHandler = net.minecraftforge.common.util.LazyOptional.of(() -> new net.minecraftforge.items.wrapper.InvWrapper(this.field_110296_bG));
     }
  
     protected void func_110232_cE() {
@@ -13,10 +13,10 @@
        return p_204210_2_;
     }
 +
-+   private net.minecraftforge.common.capabilities.OptionalCapabilityInstance<?> itemHandler = null;
++   private net.minecraftforge.common.util.LazyOptional<?> itemHandler = null;
 +
 +   @Override
-+   public <T> net.minecraftforge.common.capabilities.OptionalCapabilityInstance<T> getCapability(net.minecraftforge.common.capabilities.Capability<T> capability, @Nullable net.minecraft.util.EnumFacing facing) {
++   public <T> net.minecraftforge.common.util.LazyOptional<T> getCapability(net.minecraftforge.common.capabilities.Capability<T> capability, @Nullable net.minecraft.util.EnumFacing facing) {
 +      if (capability == net.minecraftforge.items.CapabilityItemHandler.ITEM_HANDLER_CAPABILITY && itemHandler != null)
 +         return itemHandler.cast();
 +      return super.getCapability(capability, facing);

--- a/patches/minecraft/net/minecraft/tileentity/TileEntityBrewingStand.java.patch
+++ b/patches/minecraft/net/minecraft/tileentity/TileEntityBrewingStand.java.patch
@@ -58,11 +58,11 @@
        this.field_145945_j.clear();
     }
 +
-+   net.minecraftforge.common.capabilities.OptionalCapabilityInstance<? extends net.minecraftforge.items.IItemHandler>[] handlers =
++   net.minecraftforge.common.util.LazyOptional<? extends net.minecraftforge.items.IItemHandler>[] handlers =
 +           net.minecraftforge.items.wrapper.SidedInvWrapper.create(this, EnumFacing.UP, EnumFacing.DOWN, EnumFacing.NORTH);
 +
 +   @Override
-+   public <T> net.minecraftforge.common.capabilities.OptionalCapabilityInstance<T> getCapability(net.minecraftforge.common.capabilities.Capability<T> capability, @Nullable EnumFacing facing) {
++   public <T> net.minecraftforge.common.util.LazyOptional<T> getCapability(net.minecraftforge.common.capabilities.Capability<T> capability, @Nullable EnumFacing facing) {
 +      if (facing != null && capability == net.minecraftforge.items.CapabilityItemHandler.ITEM_HANDLER_CAPABILITY) {
 +         if (facing == EnumFacing.UP)
 +            return handlers[0].cast();

--- a/patches/minecraft/net/minecraft/tileentity/TileEntityChest.java.patch
+++ b/patches/minecraft/net/minecraft/tileentity/TileEntityChest.java.patch
@@ -4,7 +4,7 @@
     protected float field_145986_n;
     protected int field_145987_o;
     private int field_145983_q;
-+   private net.minecraftforge.common.capabilities.OptionalCapabilityInstance<net.minecraftforge.items.IItemHandlerModifiable> chestHandler;
++   private net.minecraftforge.common.util.LazyOptional<net.minecraftforge.items.IItemHandlerModifiable> chestHandler;
  
     protected TileEntityChest(TileEntityType<?> p_i48287_1_) {
        super(p_i48287_1_);
@@ -32,10 +32,10 @@
 +   }
 +
 +   @Override
-+   public <T> net.minecraftforge.common.capabilities.OptionalCapabilityInstance<T> getCapability(net.minecraftforge.common.capabilities.Capability<T> cap, EnumFacing side) {
++   public <T> net.minecraftforge.common.util.LazyOptional<T> getCapability(net.minecraftforge.common.capabilities.Capability<T> cap, EnumFacing side) {
 +       if (cap == net.minecraftforge.items.CapabilityItemHandler.ITEM_HANDLER_CAPABILITY) {
 +          if (this.chestHandler == null) {
-+             this.chestHandler = net.minecraftforge.common.capabilities.OptionalCapabilityInstance.of(this::createHandler);
++             this.chestHandler = net.minecraftforge.common.util.LazyOptional.of(this::createHandler);
 +          }
 +          return this.chestHandler.cast();
 +       }

--- a/patches/minecraft/net/minecraft/tileentity/TileEntityFurnace.java.patch
+++ b/patches/minecraft/net/minecraft/tileentity/TileEntityFurnace.java.patch
@@ -96,11 +96,11 @@
        this.field_203901_m.clear();
     }
 +
-+   net.minecraftforge.common.capabilities.OptionalCapabilityInstance<? extends net.minecraftforge.items.IItemHandler>[] handlers =
++   net.minecraftforge.common.util.LazyOptional<? extends net.minecraftforge.items.IItemHandler>[] handlers =
 +           net.minecraftforge.items.wrapper.SidedInvWrapper.create(this, EnumFacing.UP, EnumFacing.DOWN, EnumFacing.NORTH);
 +
 +   @Override
-+   public <T> net.minecraftforge.common.capabilities.OptionalCapabilityInstance<T> getCapability(net.minecraftforge.common.capabilities.Capability<T> capability, @Nullable EnumFacing facing) {
++   public <T> net.minecraftforge.common.util.LazyOptional<T> getCapability(net.minecraftforge.common.capabilities.Capability<T> capability, @Nullable EnumFacing facing) {
 +      if (facing != null && capability == net.minecraftforge.items.CapabilityItemHandler.ITEM_HANDLER_CAPABILITY) {
 +         if (facing == EnumFacing.UP)
 +            return handlers[0].cast();

--- a/patches/minecraft/net/minecraft/tileentity/TileEntityLockable.java.patch
+++ b/patches/minecraft/net/minecraft/tileentity/TileEntityLockable.java.patch
@@ -5,13 +5,13 @@
        this.field_174901_a = p_174892_1_;
     }
 +
-+   private net.minecraftforge.common.capabilities.OptionalCapabilityInstance<?> itemHandler = net.minecraftforge.common.capabilities.OptionalCapabilityInstance.of(() -> createUnSidedHandler());
++   private net.minecraftforge.common.util.LazyOptional<?> itemHandler = net.minecraftforge.common.util.LazyOptional.of(() -> createUnSidedHandler());
 +   protected net.minecraftforge.items.IItemHandler createUnSidedHandler() {
 +      return new net.minecraftforge.items.wrapper.InvWrapper(this);
 +   }
 +
 +   @javax.annotation.Nullable
-+   public <T> net.minecraftforge.common.capabilities.OptionalCapabilityInstance<T> getCapability(net.minecraftforge.common.capabilities.Capability<T> cap, @javax.annotation.Nullable net.minecraft.util.EnumFacing side) {
++   public <T> net.minecraftforge.common.util.LazyOptional<T> getCapability(net.minecraftforge.common.capabilities.Capability<T> cap, @javax.annotation.Nullable net.minecraft.util.EnumFacing side) {
 +      if (cap == net.minecraftforge.items.CapabilityItemHandler.ITEM_HANDLER_CAPABILITY ) {
 +         return itemHandler.cast();
 +      }


### PR DESCRIPTION
Refactored the patches that were missed in 8e43dfa7a626387556e642f21aeb632e8e96cdba with the `OptionalCapabilityInstance` -> `LazyOptional` change.