### PR TITLE
Fix up torch placement logic to handle more vanilla special-casing

### DIFF
--- a/patches/minecraft/net/minecraft/block/Block.java.patch
+++ b/patches/minecraft/net/minecraft/block/Block.java.patch
@@ -221,7 +221,7 @@
      public SoundType func_185467_w()
      {
          return this.field_149762_H;
-@@ -934,6 +952,1369 @@
+@@ -934,6 +952,1374 @@
      {
      }
  
@@ -837,13 +837,18 @@
 +     */
 +    public boolean canPlaceTorchOnTop(IBlockState state, IBlockAccess world, BlockPos pos)
 +    {
-+        if (state.func_185896_q() || state.func_193401_d(world, pos, EnumFacing.UP) == BlockFaceShape.SOLID)
++        if (this == Blocks.field_185775_db || this == Blocks.field_150428_aP)
 +        {
-+            return this != Blocks.field_185775_db && this != Blocks.field_150428_aP;
++            return false;
++        }
++        else if (state.func_185896_q() || this instanceof BlockFence || this == Blocks.field_150359_w || this == Blocks.field_150463_bK || this == Blocks.field_150399_cn)
++        {
++            return true;
 +        }
 +        else
 +        {
-+            return this instanceof BlockFence || this == Blocks.field_150359_w || this == Blocks.field_150463_bK || this == Blocks.field_150399_cn;
++            BlockFaceShape shape = state.func_193401_d(world, pos, EnumFacing.UP);
++            return (shape == BlockFaceShape.SOLID || shape == BlockFaceShape.CENTER || shape == BlockFaceShape.CENTER_BIG) && !func_193384_b(this);
 +        }
 +    }
 +
@@ -1591,7 +1596,7 @@
      public static void func_149671_p()
      {
          func_176215_a(0, field_176230_a, (new BlockAir()).func_149663_c("air"));
-@@ -1105,7 +2486,7 @@
+@@ -1105,7 +2491,7 @@
          Block block11 = (new BlockQuartz()).func_149672_a(SoundType.field_185851_d).func_149711_c(0.8F).func_149663_c("quartzBlock");
          func_176219_a(155, "quartz_block", block11);
          func_176219_a(156, "quartz_stairs", (new BlockStairs(block11.func_176223_P().func_177226_a(BlockQuartz.field_176335_a, BlockQuartz.EnumType.DEFAULT))).func_149663_c("stairsQuartz"));
@@ -1600,7 +1605,7 @@
          func_176219_a(158, "dropper", (new BlockDropper()).func_149711_c(3.5F).func_149672_a(SoundType.field_185851_d).func_149663_c("dropper"));
          func_176219_a(159, "stained_hardened_clay", (new BlockStainedHardenedClay()).func_149711_c(1.25F).func_149752_b(7.0F).func_149672_a(SoundType.field_185851_d).func_149663_c("clayHardenedStained"));
          func_176219_a(160, "stained_glass_pane", (new BlockStainedGlassPane()).func_149711_c(0.3F).func_149672_a(SoundType.field_185853_f).func_149663_c("thinStainedGlass"));
-@@ -1230,31 +2611,6 @@
+@@ -1230,31 +2616,6 @@
                  block15.field_149783_u = flag;
              }
          }


### PR DESCRIPTION
Fixes #5423.

Should better match the vanilla logic while still providing a good default for modded blocks. The fallthrough logic is similar to the logic in `BlockButton.canPlaceBlock`, but also accepting fence/wall shapes.

For reference, the vanilla `BlockTorch.canPlaceOn`:
```java
private boolean canPlaceOn(World worldIn, BlockPos pos)
{
    Block block = worldIn.getBlockState(pos).getBlock();
    boolean flag = block == Blocks.END_GATEWAY || block == Blocks.LIT_PUMPKIN;
    if (worldIn.getBlockState(pos).isTopSolid())
    {
        return !flag;
    }
    else
    {
        boolean flag1 = block instanceof BlockFence || block == Blocks.GLASS || block == Blocks.COBBLESTONE_WALL || block == Blocks.STAINED_GLASS;
        return flag1 && !flag;
    }
}
```

The following cases are all consistent with vanilla now:
![2019-02-03_06 28 49](https://user-images.githubusercontent.com/1447117/52173491-7642df00-277d-11e9-9c12-32533d945f3c.png)

Currently, a torch can be placed on all the blocks there with Forge.
