### PR TITLE
[1.13] Change vanilla block constructors to public

### DIFF
--- a/patches/minecraft/net/minecraft/block/BlockButtonStone.java.patch
+++ b/patches/minecraft/net/minecraft/block/BlockButtonStone.java.patch
@@ -1,0 +1,11 @@
+--- a/net/minecraft/block/BlockButtonStone.java
++++ b/net/minecraft/block/BlockButtonStone.java
+@@ -4,7 +4,7 @@
+ import net.minecraft.util.SoundEvent;
+ 
+ public class BlockButtonStone extends BlockButton {
+-   protected BlockButtonStone(Block.Builder p_i48315_1_) {
++   public BlockButtonStone(Block.Builder p_i48315_1_) {
+       super(false, p_i48315_1_);
+    }
+ 

--- a/patches/minecraft/net/minecraft/block/BlockButtonWood.java.patch
+++ b/patches/minecraft/net/minecraft/block/BlockButtonWood.java.patch
@@ -1,0 +1,11 @@
+--- a/net/minecraft/block/BlockButtonWood.java
++++ b/net/minecraft/block/BlockButtonWood.java
+@@ -4,7 +4,7 @@
+ import net.minecraft.util.SoundEvent;
+ 
+ public class BlockButtonWood extends BlockButton {
+-   protected BlockButtonWood(Block.Builder p_i48291_1_) {
++   public BlockButtonWood(Block.Builder p_i48291_1_) {
+       super(true, p_i48291_1_);
+    }
+ 

--- a/patches/minecraft/net/minecraft/block/BlockCarpet.java.patch
+++ b/patches/minecraft/net/minecraft/block/BlockCarpet.java.patch
@@ -1,0 +1,11 @@
+--- a/net/minecraft/block/BlockCarpet.java
++++ b/net/minecraft/block/BlockCarpet.java
+@@ -15,7 +15,7 @@
+    protected static final VoxelShape field_196548_a = Block.func_208617_a(0.0D, 0.0D, 0.0D, 16.0D, 1.0D, 16.0D);
+    private final EnumDyeColor field_196549_b;
+ 
+-   protected BlockCarpet(EnumDyeColor p_i48290_1_, Block.Builder p_i48290_2_) {
++   public BlockCarpet(EnumDyeColor p_i48290_1_, Block.Builder p_i48290_2_) {
+       super(p_i48290_2_);
+       this.field_196549_b = p_i48290_1_;
+    }

--- a/patches/minecraft/net/minecraft/block/BlockChest.java.patch
+++ b/patches/minecraft/net/minecraft/block/BlockChest.java.patch
@@ -1,5 +1,14 @@
 --- a/net/minecraft/block/BlockChest.java
 +++ b/net/minecraft/block/BlockChest.java
+@@ -54,7 +54,7 @@
+    protected static final VoxelShape field_196313_A = Block.func_208617_a(1.0D, 0.0D, 1.0D, 16.0D, 14.0D, 15.0D);
+    protected static final VoxelShape field_196315_B = Block.func_208617_a(1.0D, 0.0D, 1.0D, 15.0D, 14.0D, 15.0D);
+ 
+-   protected BlockChest(Block.Builder p_i48430_1_) {
++   public BlockChest(Block.Builder p_i48430_1_) {
+       super(p_i48430_1_);
+       this.func_180632_j((IBlockState)((IBlockState)((IBlockState)(this.field_176227_L.func_177621_b()).func_206870_a(field_176459_a, EnumFacing.NORTH)).func_206870_a(field_196314_b, ChestType.SINGLE)).func_206870_a(field_204511_c, Boolean.valueOf(false)));
+    }
 @@ -258,7 +258,7 @@
     }
  

--- a/patches/minecraft/net/minecraft/block/BlockDoor.java.patch
+++ b/patches/minecraft/net/minecraft/block/BlockDoor.java.patch
@@ -1,0 +1,11 @@
+--- a/net/minecraft/block/BlockDoor.java
++++ b/net/minecraft/block/BlockDoor.java
+@@ -47,7 +47,7 @@
+    protected static final VoxelShape field_185656_B = Block.func_208617_a(13.0D, 0.0D, 0.0D, 16.0D, 16.0D, 16.0D);
+    protected static final VoxelShape field_185657_C = Block.func_208617_a(0.0D, 0.0D, 0.0D, 3.0D, 16.0D, 16.0D);
+ 
+-   protected BlockDoor(Block.Builder p_i48413_1_) {
++   public BlockDoor(Block.Builder p_i48413_1_) {
+       super(p_i48413_1_);
+       this.func_180632_j((IBlockState)((IBlockState)((IBlockState)((IBlockState)((IBlockState)(this.field_176227_L.func_177621_b()).func_206870_a(field_176520_a, EnumFacing.NORTH)).func_206870_a(field_176519_b, Boolean.valueOf(false))).func_206870_a(field_176521_M, DoorHingeSide.LEFT)).func_206870_a(field_176522_N, Boolean.valueOf(false))).func_206870_a(field_176523_O, DoubleBlockHalf.LOWER));
+    }

--- a/patches/minecraft/net/minecraft/block/BlockIronBars.java.patch
+++ b/patches/minecraft/net/minecraft/block/BlockIronBars.java.patch
@@ -1,5 +1,14 @@
 --- a/net/minecraft/block/BlockIronBars.java
 +++ b/net/minecraft/block/BlockIronBars.java
+@@ -16,7 +16,7 @@
+ import net.minecraftforge.api.distmarker.OnlyIn;
+ 
+ public class BlockIronBars extends BlockFourWay {
+-   protected BlockIronBars(Block.Builder p_i48373_1_) {
++   public BlockIronBars(Block.Builder p_i48373_1_) {
+       super(1.0F, 1.0F, 16.0F, 16.0F, 16.0F, p_i48373_1_);
+       this.func_180632_j((IBlockState)((IBlockState)((IBlockState)((IBlockState)((IBlockState)(this.field_176227_L.func_177621_b()).func_206870_a(field_196409_a, Boolean.valueOf(false))).func_206870_a(field_196411_b, Boolean.valueOf(false))).func_206870_a(field_196413_c, Boolean.valueOf(false))).func_206870_a(field_196414_y, Boolean.valueOf(false))).func_206870_a(field_204514_u, Boolean.valueOf(false)));
+    }
 @@ -25,15 +25,12 @@
        IBlockReader iblockreader = p_196258_1_.func_195991_k();
        BlockPos blockpos = p_196258_1_.func_195995_a();

--- a/patches/minecraft/net/minecraft/block/BlockLadder.java.patch
+++ b/patches/minecraft/net/minecraft/block/BlockLadder.java.patch
@@ -1,5 +1,14 @@
 --- a/net/minecraft/block/BlockLadder.java
 +++ b/net/minecraft/block/BlockLadder.java
+@@ -30,7 +30,7 @@
+    protected static final VoxelShape field_185689_d = Block.func_208617_a(0.0D, 0.0D, 0.0D, 16.0D, 16.0D, 3.0D);
+    protected static final VoxelShape field_185690_e = Block.func_208617_a(0.0D, 0.0D, 13.0D, 16.0D, 16.0D, 16.0D);
+ 
+-   protected BlockLadder(Block.Builder p_i48371_1_) {
++   public BlockLadder(Block.Builder p_i48371_1_) {
+       super(p_i48371_1_);
+       this.func_180632_j((IBlockState)((IBlockState)(this.field_176227_L.func_177621_b()).func_206870_a(field_176382_a, EnumFacing.NORTH)).func_206870_a(field_204612_b, Boolean.valueOf(false)));
+    }
 @@ -151,4 +151,9 @@
           return false;
        }

--- a/patches/minecraft/net/minecraft/block/BlockLever.java.patch
+++ b/patches/minecraft/net/minecraft/block/BlockLever.java.patch
@@ -1,0 +1,11 @@
+--- a/net/minecraft/block/BlockLever.java
++++ b/net/minecraft/block/BlockLever.java
+@@ -32,7 +32,7 @@
+    protected static final VoxelShape field_209350_t = Block.func_208617_a(5.0D, 10.0D, 4.0D, 11.0D, 16.0D, 12.0D);
+    protected static final VoxelShape field_209351_u = Block.func_208617_a(4.0D, 10.0D, 5.0D, 12.0D, 16.0D, 11.0D);
+ 
+-   protected BlockLever(Block.Builder p_i48369_1_) {
++   public BlockLever(Block.Builder p_i48369_1_) {
+       super(p_i48369_1_);
+       this.func_180632_j((IBlockState)((IBlockState)((IBlockState)(this.field_176227_L.func_177621_b()).func_206870_a(field_185512_D, EnumFacing.NORTH)).func_206870_a(field_176359_b, Boolean.valueOf(false))).func_206870_a(field_196366_M, AttachFace.WALL));
+    }

--- a/patches/minecraft/net/minecraft/block/BlockPressurePlate.java.patch
+++ b/patches/minecraft/net/minecraft/block/BlockPressurePlate.java.patch
@@ -1,0 +1,11 @@
+--- a/net/minecraft/block/BlockPressurePlate.java
++++ b/net/minecraft/block/BlockPressurePlate.java
+@@ -20,7 +20,7 @@
+    public static final BooleanProperty field_176580_a = BlockStateProperties.field_208194_u;
+    private final BlockPressurePlate.Sensitivity field_150069_a;
+ 
+-   protected BlockPressurePlate(BlockPressurePlate.Sensitivity p_i48348_1_, Block.Builder p_i48348_2_) {
++   public BlockPressurePlate(BlockPressurePlate.Sensitivity p_i48348_1_, Block.Builder p_i48348_2_) {
+       super(p_i48348_2_);
+       this.func_180632_j((IBlockState)(this.field_176227_L.func_177621_b()).func_206870_a(field_176580_a, Boolean.valueOf(false)));
+       this.field_150069_a = p_i48348_1_;

--- a/patches/minecraft/net/minecraft/block/BlockPressurePlateWeighted.java.patch
+++ b/patches/minecraft/net/minecraft/block/BlockPressurePlateWeighted.java.patch
@@ -1,0 +1,11 @@
+--- a/net/minecraft/block/BlockPressurePlateWeighted.java
++++ b/net/minecraft/block/BlockPressurePlateWeighted.java
+@@ -18,7 +18,7 @@
+    public static final IntegerProperty field_176579_a = BlockStateProperties.field_208136_ak;
+    private final int field_150068_a;
+ 
+-   protected BlockPressurePlateWeighted(int p_i48295_1_, Block.Builder p_i48295_2_) {
++   public BlockPressurePlateWeighted(int p_i48295_1_, Block.Builder p_i48295_2_) {
+       super(p_i48295_2_);
+       this.func_180632_j((IBlockState)(this.field_176227_L.func_177621_b()).func_206870_a(field_176579_a, Integer.valueOf(0)));
+       this.field_150068_a = p_i48295_1_;

--- a/patches/minecraft/net/minecraft/block/BlockStairs.java.patch
+++ b/patches/minecraft/net/minecraft/block/BlockStairs.java.patch
@@ -1,0 +1,11 @@
+--- a/net/minecraft/block/BlockStairs.java
++++ b/net/minecraft/block/BlockStairs.java
+@@ -86,7 +86,7 @@
+       return voxelshape;
+    }
+ 
+-   protected BlockStairs(IBlockState p_i48321_1_, Block.Builder p_i48321_2_) {
++   public BlockStairs(IBlockState p_i48321_1_, Block.Builder p_i48321_2_) {
+       super(p_i48321_2_);
+       this.func_180632_j((IBlockState)((IBlockState)((IBlockState)((IBlockState)(this.field_176227_L.func_177621_b()).func_206870_a(field_176309_a, EnumFacing.NORTH)).func_206870_a(field_176308_b, Half.BOTTOM)).func_206870_a(field_176310_M, StairsShape.STRAIGHT)).func_206870_a(field_204513_t, Boolean.valueOf(false)));
+       this.field_150149_b = p_i48321_1_.func_177230_c();

--- a/patches/minecraft/net/minecraft/block/BlockTrapDoor.java.patch
+++ b/patches/minecraft/net/minecraft/block/BlockTrapDoor.java.patch
@@ -1,5 +1,14 @@
 --- a/net/minecraft/block/BlockTrapDoor.java
 +++ b/net/minecraft/block/BlockTrapDoor.java
+@@ -36,7 +36,7 @@
+    protected static final VoxelShape field_185732_B = Block.func_208617_a(0.0D, 0.0D, 0.0D, 16.0D, 3.0D, 16.0D);
+    protected static final VoxelShape field_185733_C = Block.func_208617_a(0.0D, 13.0D, 0.0D, 16.0D, 16.0D, 16.0D);
+ 
+-   protected BlockTrapDoor(Block.Builder p_i48307_1_) {
++   public BlockTrapDoor(Block.Builder p_i48307_1_) {
+       super(p_i48307_1_);
+       this.func_180632_j((IBlockState)((IBlockState)((IBlockState)((IBlockState)((IBlockState)(this.field_176227_L.func_177621_b()).func_206870_a(field_185512_D, EnumFacing.NORTH)).func_206870_a(field_176283_b, Boolean.valueOf(false))).func_206870_a(field_176285_M, Half.BOTTOM)).func_206870_a(field_196381_c, Boolean.valueOf(false))).func_206870_a(field_204614_t, Boolean.valueOf(false)));
+    }
 @@ -186,4 +186,14 @@
  
        return super.func_196271_a(p_196271_1_, p_196271_2_, p_196271_3_, p_196271_4_, p_196271_5_, p_196271_6_);


### PR DESCRIPTION
This changes several of the vanilla block constructors from protected to public, making it easier for similar custom blocks with no additional behaviours or properties to be registered.

Changed Blocks:
- BlockButtonStone
- BlockButtonWood
- BlockCarpet
- BlockChest
- BlockDoor
- BlockIronBars
- BlockLadder
- BlockLever
- BlockPressurePlate
- BlockPressurePlateWeighted
- BlockStairs
- BlockTrapDoor