### PR TITLE
Fix leaking unclosed InputStream in Scanner.fileVisitor

### DIFF
--- a/src/fmllauncher/java/net/minecraftforge/fml/loading/moddiscovery/Scanner.java
+++ b/src/fmllauncher/java/net/minecraftforge/fml/loading/moddiscovery/Scanner.java
@@ -26,6 +26,7 @@ import org.apache.logging.log4j.Logger;
 import org.objectweb.asm.ClassReader;
 
 import java.io.IOException;
+import java.io.InputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 
@@ -50,10 +51,10 @@ public class Scanner {
     }
 
     private void fileVisitor(final Path path, final ModFileScanData result) {
-        try {
-            LOGGER.debug(SCAN,"Scanning {} path {}", fileToScan, path);
+        LOGGER.debug(SCAN,"Scanning {} path {}", fileToScan, path);
+        try (InputStream in = Files.newInputStream(path)){
             ModClassVisitor mcv = new ModClassVisitor();
-            ClassReader cr = new ClassReader(Files.newInputStream(path));
+            ClassReader cr = new ClassReader(in);
             cr.accept(mcv, 0);
             mcv.buildData(result.getClasses(), result.getAnnotations());
         } catch (IOException e) {


### PR DESCRIPTION
Issue the same as the one fixed in https://github.com/cpw/modlauncher/pull/14:

> While ASM ClassReader takes an InputStream as a constructor argument, it doesn't actually close the input stream.
> 
> As modlauncher doesn't close the input stream, this causes Forge to leave many thousands of open files, and on some systems even running into the limit of open files (this doesn't appear to be an issue in newer versions of java, where these files end up being closed anyway).
> 
> There will also be a corresponding PR into forge, ad it has a similar issue.
> 
> I don't have much evidence for it, and it's 
> 
> probably just a coincidence, but on my system it also appears to fix JVM crashes that cpw and a few other people have been experiencing on linux.