### PR TITLE
[1.13] Fix redstone power calculations

### DIFF
--- a/src/main/java/net/minecraftforge/common/extensions/IForgeBlock.java
+++ b/src/main/java/net/minecraftforge/common/extensions/IForgeBlock.java
@@ -743,7 +743,7 @@ public interface IForgeBlock
     */
     default boolean shouldCheckWeakPower(IBlockState state, IWorldReader world, BlockPos pos, EnumFacing side)
     {
-        return state.isTopSolid();
+        return state.isNormalCube(world, pos);
     }
 
     /**


### PR DESCRIPTION
This resolves the problem where redstone blocks fail to update surrounding redstone related blocks, as seen in https://github.com/MinecraftForge/MinecraftForge/issues/5428. It also fixes a similar issue where observer blocks did not update redstone wire when triggered.