### PR TITLE
[1.13] Update multiple classes to use correct grass block

### DIFF
--- a/patches/minecraft/net/minecraft/block/Block.java.patch
+++ b/patches/minecraft/net/minecraft/block/Block.java.patch
@@ -261,10 +261,10 @@
 +           case Nether: return this.getBlock() == Blocks.field_150425_aM;
 +           case Crop: return this.getBlock() == Blocks.field_150458_ak;
 +           case Cave: return state.func_185896_q();
-+           case Plains: return this.getBlock() == Blocks.field_150349_c || Block.func_196245_f(this) || this.getBlock() == Blocks.field_150458_ak;
++           case Plains: return this.getBlock() == Blocks.field_196658_i || Block.func_196245_f(this) || this.getBlock() == Blocks.field_150458_ak;
 +           case Water: return state.func_185904_a() == Material.field_151586_h; //&& state.getValue(BlockLiquidWrapper)
 +           case Beach:
-+               boolean isBeach = this.getBlock() == Blocks.field_150349_c || Block.func_196245_f(this) || this.getBlock() == Blocks.field_150354_m;
++               boolean isBeach = this.getBlock() == Blocks.field_196658_i || Block.func_196245_f(this) || this.getBlock() == Blocks.field_150354_m;
 +               boolean hasWater = (world.func_180495_p(pos.func_177974_f()).func_185904_a() == Material.field_151586_h ||
 +                       world.func_180495_p(pos.func_177976_e()).func_185904_a() == Material.field_151586_h ||
 +                       world.func_180495_p(pos.func_177978_c()).func_185904_a() == Material.field_151586_h ||

--- a/patches/minecraft/net/minecraft/entity/passive/EntityParrot.java.patch
+++ b/patches/minecraft/net/minecraft/entity/passive/EntityParrot.java.patch
@@ -9,3 +9,12 @@
                 this.func_193101_c(p_184645_1_);
                 this.func_70908_e(true);
                 this.field_70170_p.func_72960_a(this, (byte)7);
+@@ -260,7 +260,7 @@
+       int k = MathHelper.func_76128_c(this.field_70161_v);
+       BlockPos blockpos = new BlockPos(i, j, k);
+       Block block = p_205020_1_.func_180495_p(blockpos.func_177977_b()).func_177230_c();
+-      return block instanceof BlockLeaves || block == Blocks.field_150349_c || block instanceof BlockLog || block == Blocks.field_150350_a && super.func_205020_a(p_205020_1_);
++      return block instanceof BlockLeaves || block == Blocks.field_196658_i || block instanceof BlockLog || block == Blocks.field_150350_a && super.func_205020_a(p_205020_1_);
+    }
+ 
+    public void func_180430_e(float p_180430_1_, float p_180430_2_) {

--- a/patches/minecraft/net/minecraft/entity/passive/EntityRabbit.java.patch
+++ b/patches/minecraft/net/minecraft/entity/passive/EntityRabbit.java.patch
@@ -1,5 +1,14 @@
 --- a/net/minecraft/entity/passive/EntityRabbit.java
 +++ b/net/minecraft/entity/passive/EntityRabbit.java
+@@ -370,7 +370,7 @@
+       int k = MathHelper.func_76128_c(this.field_70161_v);
+       BlockPos blockpos = new BlockPos(i, j, k);
+       Block block = p_205020_1_.func_180495_p(blockpos.func_177977_b()).func_177230_c();
+-      return block != Blocks.field_150349_c && block != Blocks.field_150433_aE && block != Blocks.field_150354_m ? super.func_205020_a(p_205020_1_) : true;
++      return block != Blocks.field_196658_i && block != Blocks.field_150433_aE && block != Blocks.field_150354_m ? super.func_205020_a(p_205020_1_) : true;
+    }
+ 
+    private boolean func_175534_cv() {
 @@ -438,7 +438,7 @@
  
        public boolean func_75250_a() {

--- a/src/main/java/net/minecraftforge/common/extensions/IForgeBlock.java
+++ b/src/main/java/net/minecraftforge/common/extensions/IForgeBlock.java
@@ -599,7 +599,7 @@ public interface IForgeBlock
      */
     default void onPlantGrow(IBlockState state, IWorld world, BlockPos pos, BlockPos source)
     {
-        if (this.getBlock() == Blocks.GRASS || this.getBlock() == Blocks.FARMLAND || this.getBlock() == Blocks.AIR)
+        if (this.getBlock() == Blocks.GRASS_BLOCK || this.getBlock() == Blocks.MYCELIUM || this.getBlock() == Blocks.FARMLAND || this.getBlock() == Blocks.AIR)
             world.setBlockState(pos, Blocks.DIRT.getDefaultState(), 2);
     }
 


### PR DESCRIPTION
This fixes the issue where grass incorrectly generates in stacks, as seen in https://github.com/MinecraftForge/MinecraftForge/issues/5422. It also updates EntityParrot and EntityRabbit to use the correct grass block for spawning conditions.

I also added Mycelium to the onPlantGrow method so that it changes back to dirt when a tree or mushroom is grown or generated on it. This behaviour already exists in vanilla.