### PR TITLE
[1.13] Fix statistics gui crashing when handling input events

### DIFF
--- a/patches/minecraft/net/minecraft/client/gui/achievement/GuiStats.java.patch
+++ b/patches/minecraft/net/minecraft/client/gui/achievement/GuiStats.java.patch
@@ -1,0 +1,12 @@
+--- a/net/minecraft/client/gui/achievement/GuiStats.java
++++ b/net/minecraft/client/gui/achievement/GuiStats.java
+@@ -118,8 +118,8 @@
+    public void func_193026_g() {
+       if (this.field_146543_v) {
+          this.func_193028_a();
+-         this.func_193029_f();
+          this.field_146545_u = this.field_146550_h;
++         this.func_193029_f();
+          this.field_146543_v = false;
+       }
+ 

--- a/patches/minecraft/net/minecraft/client/gui/achievement/GuiStats.java.patch
+++ b/patches/minecraft/net/minecraft/client/gui/achievement/GuiStats.java.patch
@@ -6,7 +6,7 @@
           this.func_193028_a();
 -         this.func_193029_f();
           this.field_146545_u = this.field_146550_h;
-+         this.func_193029_f(); //Forge: Bugfix, initButtons adds displaySlot to children, so se it first.
++         this.func_193029_f(); //Forge: Bugfix, initButtons adds displaySlot to children, so set it first to prevent NPE
           this.field_146543_v = false;
        }
  

--- a/patches/minecraft/net/minecraft/client/gui/achievement/GuiStats.java.patch
+++ b/patches/minecraft/net/minecraft/client/gui/achievement/GuiStats.java.patch
@@ -6,7 +6,7 @@
           this.func_193028_a();
 -         this.func_193029_f();
           this.field_146545_u = this.field_146550_h;
-+         this.func_193029_f();
++         this.func_193029_f(); //Forge: Bugfix, initButtons adds displaySlot to children, so se it first.
           this.field_146543_v = false;
        }
  


### PR DESCRIPTION
This fixes a NullPointerException that is thrown when clicking anywhere in the statistics gui. The problem was that displaySlot was being added to the event listeners collection before it was assigned a value.