### PR TITLE
Clean up and unify most top-surface placement code

### DIFF
--- a/patches/minecraft/net/minecraft/block/Block.java.patch
+++ b/patches/minecraft/net/minecraft/block/Block.java.patch
@@ -221,7 +221,7 @@
      public SoundType func_185467_w()
      {
          return this.field_149762_H;
-@@ -934,6 +952,1374 @@
+@@ -934,6 +952,1382 @@
      {
      }
  
@@ -324,6 +324,14 @@
 +    }
 +
 +    /**
++     * Position-aware version of {@link #isTopSolid(IBlockState)}.
++     */
++    public boolean isTopSolid(IBlockState state, IBlockAccess world, BlockPos pos)
++    {
++        return state.func_185896_q() || state.func_193401_d(world, pos, EnumFacing.UP) == BlockFaceShape.SOLID && !func_193384_b(state.func_177230_c());
++    }
++
++    /**
 +     * Checks if the block is a solid face on the given side, used by placement logic.
 +     *
 +     * @param base_state The base state, getActualState should be called first
@@ -332,7 +340,7 @@
 +     * @param side The side to check
 +     * @return True if the block is solid on the specified side.
 +     */
-+    @Deprecated //Use IBlockState.getBlockFaceShape
++    @Deprecated // Use IBlockState.getBlockFaceShape or the extended Block.isTopSolid
 +    public boolean isSideSolid(IBlockState base_state, IBlockAccess world, BlockPos pos, EnumFacing side)
 +    {
 +        if (base_state.func_185896_q() && side == EnumFacing.UP) // Short circuit to vanilla function if its true
@@ -1596,7 +1604,7 @@
      public static void func_149671_p()
      {
          func_176215_a(0, field_176230_a, (new BlockAir()).func_149663_c("air"));
-@@ -1105,7 +2491,7 @@
+@@ -1105,7 +2499,7 @@
          Block block11 = (new BlockQuartz()).func_149672_a(SoundType.field_185851_d).func_149711_c(0.8F).func_149663_c("quartzBlock");
          func_176219_a(155, "quartz_block", block11);
          func_176219_a(156, "quartz_stairs", (new BlockStairs(block11.func_176223_P().func_177226_a(BlockQuartz.field_176335_a, BlockQuartz.EnumType.DEFAULT))).func_149663_c("stairsQuartz"));
@@ -1605,7 +1613,7 @@
          func_176219_a(158, "dropper", (new BlockDropper()).func_149711_c(3.5F).func_149672_a(SoundType.field_185851_d).func_149663_c("dropper"));
          func_176219_a(159, "stained_hardened_clay", (new BlockStainedHardenedClay()).func_149711_c(1.25F).func_149752_b(7.0F).func_149672_a(SoundType.field_185851_d).func_149663_c("clayHardenedStained"));
          func_176219_a(160, "stained_glass_pane", (new BlockStainedGlassPane()).func_149711_c(0.3F).func_149672_a(SoundType.field_185853_f).func_149663_c("thinStainedGlass"));
-@@ -1230,31 +2616,6 @@
+@@ -1230,31 +2624,6 @@
                  block15.field_149783_u = flag;
              }
          }

--- a/patches/minecraft/net/minecraft/block/BlockDoor.java.patch
+++ b/patches/minecraft/net/minecraft/block/BlockDoor.java.patch
@@ -5,11 +5,11 @@
              }
  
 -            if (!p_189540_2_.func_180495_p(p_189540_3_.func_177977_b()).func_185896_q())
-+            if (!p_189540_2_.func_180495_p(p_189540_3_.func_177977_b()).isSideSolid(p_189540_2_,  p_189540_3_.func_177977_b(), EnumFacing.UP))
++            if (!net.minecraftforge.common.ForgeHooks.isTopSolid(p_189540_2_, p_189540_3_.func_177977_b()))
              {
                  p_189540_2_.func_175698_g(p_189540_3_);
                  flag1 = true;
-@@ -247,13 +247,14 @@
+@@ -247,13 +247,13 @@
  
      public boolean func_176196_c(World p_176196_1_, BlockPos p_176196_2_)
      {
@@ -21,8 +21,7 @@
          else
          {
 -            return p_176196_1_.func_180495_p(p_176196_2_.func_177977_b()).func_185896_q() && super.func_176196_c(p_176196_1_, p_176196_2_) && super.func_176196_c(p_176196_1_, p_176196_2_.func_177984_a());
-+            IBlockState state = p_176196_1_.func_180495_p(p_176196_2_.func_177977_b());
-+            return (state.func_185896_q() || state.func_193401_d(p_176196_1_, p_176196_2_.func_177977_b(), EnumFacing.UP) == BlockFaceShape.SOLID) && super.func_176196_c(p_176196_1_, p_176196_2_) && super.func_176196_c(p_176196_1_, p_176196_2_.func_177984_a());
++            return net.minecraftforge.common.ForgeHooks.isTopSolid(p_176196_1_, p_176196_2_.func_177977_b()) && super.func_176196_c(p_176196_1_, p_176196_2_) && super.func_176196_c(p_176196_1_, p_176196_2_.func_177984_a());
          }
      }
  

--- a/patches/minecraft/net/minecraft/block/BlockFire.java.patch
+++ b/patches/minecraft/net/minecraft/block/BlockFire.java.patch
@@ -5,7 +5,7 @@
      public IBlockState func_176221_a(IBlockState p_176221_1_, IBlockAccess p_176221_2_, BlockPos p_176221_3_)
      {
 -        return !p_176221_2_.func_180495_p(p_176221_3_.func_177977_b()).func_185896_q() && !Blocks.field_150480_ab.func_176535_e(p_176221_2_, p_176221_3_.func_177977_b()) ? p_176221_1_.func_177226_a(field_176545_N, Boolean.valueOf(this.func_176535_e(p_176221_2_, p_176221_3_.func_177978_c()))).func_177226_a(field_176546_O, Boolean.valueOf(this.func_176535_e(p_176221_2_, p_176221_3_.func_177974_f()))).func_177226_a(field_176541_P, Boolean.valueOf(this.func_176535_e(p_176221_2_, p_176221_3_.func_177968_d()))).func_177226_a(field_176539_Q, Boolean.valueOf(this.func_176535_e(p_176221_2_, p_176221_3_.func_177976_e()))).func_177226_a(field_176542_R, Boolean.valueOf(this.func_176535_e(p_176221_2_, p_176221_3_.func_177984_a()))) : this.func_176223_P();
-+        if (!p_176221_2_.func_180495_p(p_176221_3_.func_177977_b()).isSideSolid(p_176221_2_, p_176221_3_.func_177977_b(), EnumFacing.UP) && !Blocks.field_150480_ab.canCatchFire(p_176221_2_, p_176221_3_.func_177977_b(), EnumFacing.UP))
++        if (!net.minecraftforge.common.ForgeHooks.isTopSolid(p_176221_2_, p_176221_3_.func_177977_b()) && !Blocks.field_150480_ab.canCatchFire(p_176221_2_, p_176221_3_.func_177977_b(), EnumFacing.UP))
 +        {
 +            return p_176221_1_.func_177226_a(field_176545_N, this.canCatchFire(p_176221_2_, p_176221_3_.func_177978_c(), EnumFacing.SOUTH))
 +                        .func_177226_a(field_176546_O,  this.canCatchFire(p_176221_2_, p_176221_3_.func_177974_f(), EnumFacing.WEST))
@@ -52,7 +52,7 @@
                      if (!this.func_176533_e(p_180650_1_, p_180650_2_))
                      {
 -                        if (!p_180650_1_.func_180495_p(p_180650_2_.func_177977_b()).func_185896_q() || i > 3)
-+                        if (!p_180650_1_.func_180495_p(p_180650_2_.func_177977_b()).isSideSolid(p_180650_1_, p_180650_2_.func_177977_b(), EnumFacing.UP) || i > 3)
++                        if (!net.minecraftforge.common.ForgeHooks.isTopSolid(p_180650_1_, p_180650_2_.func_177977_b()) || i > 3)
                          {
                              p_180650_1_.func_175698_g(p_180650_2_);
                          }
@@ -151,7 +151,7 @@
          }
  
 -        if (!p_180655_2_.func_180495_p(p_180655_3_.func_177977_b()).func_185896_q() && !Blocks.field_150480_ab.func_176535_e(p_180655_2_, p_180655_3_.func_177977_b()))
-+        if (!p_180655_2_.func_180495_p(p_180655_3_.func_177977_b()).isSideSolid(p_180655_2_, p_180655_3_.func_177977_b(), EnumFacing.UP) && !Blocks.field_150480_ab.canCatchFire(p_180655_2_, p_180655_3_.func_177977_b(), EnumFacing.UP))
++        if (!net.minecraftforge.common.ForgeHooks.isTopSolid(p_180655_2_, p_180655_3_.func_177977_b()) && !Blocks.field_150480_ab.canCatchFire(p_180655_2_, p_180655_3_.func_177977_b(), EnumFacing.UP))
          {
 -            if (Blocks.field_150480_ab.func_176535_e(p_180655_2_, p_180655_3_.func_177976_e()))
 +            if (Blocks.field_150480_ab.canCatchFire(p_180655_2_, p_180655_3_.func_177976_e(), EnumFacing.EAST))

--- a/patches/minecraft/net/minecraft/block/BlockFlowerPot.java.patch
+++ b/patches/minecraft/net/minecraft/block/BlockFlowerPot.java.patch
@@ -1,23 +1,21 @@
 --- ../src-base/minecraft/net/minecraft/block/BlockFlowerPot.java
 +++ ../src-work/minecraft/net/minecraft/block/BlockFlowerPot.java
-@@ -152,12 +152,14 @@
+@@ -152,12 +152,12 @@
  
      public boolean func_176196_c(World p_176196_1_, BlockPos p_176196_2_)
      {
 -        return super.func_176196_c(p_176196_1_, p_176196_2_) && p_176196_1_.func_180495_p(p_176196_2_.func_177977_b()).func_185896_q();
-+        IBlockState downState = p_176196_1_.func_180495_p(p_176196_2_.func_177977_b());
-+        return super.func_176196_c(p_176196_1_, p_176196_2_) && (downState.func_185896_q() || downState.func_193401_d(p_176196_1_, p_176196_2_.func_177977_b(), EnumFacing.UP) == BlockFaceShape.SOLID);
++        return super.func_176196_c(p_176196_1_, p_176196_2_) && net.minecraftforge.common.ForgeHooks.isTopSolid(p_176196_1_, p_176196_2_.func_177977_b());
      }
  
      public void func_189540_a(IBlockState p_189540_1_, World p_189540_2_, BlockPos p_189540_3_, Block p_189540_4_, BlockPos p_189540_5_)
      {
 -        if (!p_189540_2_.func_180495_p(p_189540_3_.func_177977_b()).func_185896_q())
-+        IBlockState downState = p_189540_2_.func_180495_p(p_189540_3_.func_177977_b());
-+        if (!downState.func_185896_q() && downState.func_193401_d(p_189540_2_, p_189540_3_.func_177977_b(), EnumFacing.UP) != BlockFaceShape.SOLID)
++        if (!net.minecraftforge.common.ForgeHooks.isTopSolid(p_189540_2_, p_189540_3_.func_177977_b()))
          {
              this.func_176226_b(p_189540_2_, p_189540_3_, p_189540_1_, 0);
              p_189540_2_.func_175698_g(p_189540_3_);
-@@ -166,13 +168,6 @@
+@@ -166,13 +166,6 @@
  
      public void func_180663_b(World p_180663_1_, BlockPos p_180663_2_, IBlockState p_180663_3_)
      {
@@ -31,7 +29,7 @@
          super.func_180663_b(p_180663_1_, p_180663_2_, p_180663_3_);
      }
  
-@@ -398,6 +393,30 @@
+@@ -398,6 +391,30 @@
          return BlockFaceShape.UNDEFINED;
      }
  

--- a/patches/minecraft/net/minecraft/block/BlockPumpkin.java.patch
+++ b/patches/minecraft/net/minecraft/block/BlockPumpkin.java.patch
@@ -5,7 +5,7 @@
      public boolean func_176196_c(World p_176196_1_, BlockPos p_176196_2_)
      {
 -        return p_176196_1_.func_180495_p(p_176196_2_).func_177230_c().field_149764_J.func_76222_j() && p_176196_1_.func_180495_p(p_176196_2_.func_177977_b()).func_185896_q();
-+        return p_176196_1_.func_180495_p(p_176196_2_).func_177230_c().func_176200_f(p_176196_1_, p_176196_2_) && p_176196_1_.isSideSolid(p_176196_2_.func_177977_b(), EnumFacing.UP);
++        return p_176196_1_.func_180495_p(p_176196_2_).func_177230_c().func_176200_f(p_176196_1_, p_176196_2_) && net.minecraftforge.common.ForgeHooks.isTopSolid(p_176196_1_, p_176196_2_.func_177977_b());
      }
  
      public IBlockState func_185499_a(IBlockState p_185499_1_, Rotation p_185499_2_)

--- a/patches/minecraft/net/minecraft/block/BlockRailBase.java.patch
+++ b/patches/minecraft/net/minecraft/block/BlockRailBase.java.patch
@@ -23,7 +23,7 @@
      public boolean func_176196_c(World p_176196_1_, BlockPos p_176196_2_)
      {
 -        return p_176196_1_.func_180495_p(p_176196_2_.func_177977_b()).func_185896_q();
-+        return p_176196_1_.func_180495_p(p_176196_2_.func_177977_b()).isSideSolid(p_176196_1_, p_176196_2_.func_177977_b(), EnumFacing.UP);
++        return net.minecraftforge.common.ForgeHooks.isTopSolid(p_176196_1_, p_176196_2_.func_177977_b());
      }
  
      public void func_176213_c(World p_176213_1_, BlockPos p_176213_2_, IBlockState p_176213_3_)
@@ -36,28 +36,28 @@
              boolean flag = false;
  
 -            if (!p_189540_2_.func_180495_p(p_189540_3_.func_177977_b()).func_185896_q())
-+            if (!p_189540_2_.func_180495_p(p_189540_3_.func_177977_b()).isSideSolid(p_189540_2_, p_189540_3_.func_177977_b(), EnumFacing.UP))
++            if (!net.minecraftforge.common.ForgeHooks.isTopSolid(p_189540_2_, p_189540_3_.func_177977_b()))
              {
                  flag = true;
              }
  
 -            if (blockrailbase$enumraildirection == BlockRailBase.EnumRailDirection.ASCENDING_EAST && !p_189540_2_.func_180495_p(p_189540_3_.func_177974_f()).func_185896_q())
-+            if (blockrailbase$enumraildirection == BlockRailBase.EnumRailDirection.ASCENDING_EAST && !p_189540_2_.func_180495_p(p_189540_3_.func_177974_f()).isSideSolid(p_189540_2_, p_189540_3_.func_177974_f(), EnumFacing.UP))
++            if (blockrailbase$enumraildirection == BlockRailBase.EnumRailDirection.ASCENDING_EAST && !net.minecraftforge.common.ForgeHooks.isTopSolid(p_189540_2_, p_189540_3_.func_177974_f()))
              {
                  flag = true;
              }
 -            else if (blockrailbase$enumraildirection == BlockRailBase.EnumRailDirection.ASCENDING_WEST && !p_189540_2_.func_180495_p(p_189540_3_.func_177976_e()).func_185896_q())
-+            else if (blockrailbase$enumraildirection == BlockRailBase.EnumRailDirection.ASCENDING_WEST && !p_189540_2_.func_180495_p(p_189540_3_.func_177976_e()).isSideSolid(p_189540_2_, p_189540_3_.func_177976_e(), EnumFacing.UP))
++            else if (blockrailbase$enumraildirection == BlockRailBase.EnumRailDirection.ASCENDING_WEST && !net.minecraftforge.common.ForgeHooks.isTopSolid(p_189540_2_, p_189540_3_.func_177976_e()))
              {
                  flag = true;
              }
 -            else if (blockrailbase$enumraildirection == BlockRailBase.EnumRailDirection.ASCENDING_NORTH && !p_189540_2_.func_180495_p(p_189540_3_.func_177978_c()).func_185896_q())
-+            else if (blockrailbase$enumraildirection == BlockRailBase.EnumRailDirection.ASCENDING_NORTH && !p_189540_2_.func_180495_p(p_189540_3_.func_177978_c()).isSideSolid(p_189540_2_, p_189540_3_.func_177978_c(), EnumFacing.UP))
++            else if (blockrailbase$enumraildirection == BlockRailBase.EnumRailDirection.ASCENDING_NORTH && !net.minecraftforge.common.ForgeHooks.isTopSolid(p_189540_2_, p_189540_3_.func_177978_c()))
              {
                  flag = true;
              }
 -            else if (blockrailbase$enumraildirection == BlockRailBase.EnumRailDirection.ASCENDING_SOUTH && !p_189540_2_.func_180495_p(p_189540_3_.func_177968_d()).func_185896_q())
-+            else if (blockrailbase$enumraildirection == BlockRailBase.EnumRailDirection.ASCENDING_SOUTH && !p_189540_2_.func_180495_p(p_189540_3_.func_177968_d()).isSideSolid(p_189540_2_, p_189540_3_.func_177968_d(), EnumFacing.UP))
++            else if (blockrailbase$enumraildirection == BlockRailBase.EnumRailDirection.ASCENDING_SOUTH && !net.minecraftforge.common.ForgeHooks.isTopSolid(p_189540_2_, p_189540_3_.func_177968_d()))
              {
                  flag = true;
              }

--- a/patches/minecraft/net/minecraft/block/BlockRedstoneDiode.java.patch
+++ b/patches/minecraft/net/minecraft/block/BlockRedstoneDiode.java.patch
@@ -1,23 +1,21 @@
 --- ../src-base/minecraft/net/minecraft/block/BlockRedstoneDiode.java
 +++ ../src-work/minecraft/net/minecraft/block/BlockRedstoneDiode.java
-@@ -39,12 +39,14 @@
+@@ -39,12 +39,12 @@
  
      public boolean func_176196_c(World p_176196_1_, BlockPos p_176196_2_)
      {
 -        return p_176196_1_.func_180495_p(p_176196_2_.func_177977_b()).func_185896_q() ? super.func_176196_c(p_176196_1_, p_176196_2_) : false;
-+        IBlockState downState = p_176196_1_.func_180495_p(p_176196_2_.func_177977_b());
-+        return (downState.func_185896_q() || downState.func_193401_d(p_176196_1_, p_176196_2_.func_177977_b(), EnumFacing.UP) == BlockFaceShape.SOLID) ? super.func_176196_c(p_176196_1_, p_176196_2_) : false;
++        return net.minecraftforge.common.ForgeHooks.isTopSolid(p_176196_1_, p_176196_2_.func_177977_b()) ? super.func_176196_c(p_176196_1_, p_176196_2_) : false;
      }
  
      public boolean func_176409_d(World p_176409_1_, BlockPos p_176409_2_)
      {
 -        return p_176409_1_.func_180495_p(p_176409_2_.func_177977_b()).func_185896_q();
-+        IBlockState downState = p_176409_1_.func_180495_p(p_176409_2_.func_177977_b());
-+        return downState.func_185896_q() || downState.func_193401_d(p_176409_1_, p_176409_2_.func_177977_b(), EnumFacing.UP) == BlockFaceShape.SOLID;
++        return net.minecraftforge.common.ForgeHooks.isTopSolid(p_176409_1_, p_176409_2_.func_177977_b());
      }
  
      public void func_180645_a(World p_180645_1_, BlockPos p_180645_2_, IBlockState p_180645_3_, Random p_180645_4_)
-@@ -227,6 +229,8 @@
+@@ -227,6 +227,8 @@
      {
          EnumFacing enumfacing = (EnumFacing)p_176400_3_.func_177229_b(field_185512_D);
          BlockPos blockpos = p_176400_2_.func_177972_a(enumfacing.func_176734_d());
@@ -26,7 +24,7 @@
          p_176400_1_.func_190524_a(blockpos, this, p_176400_2_);
          p_176400_1_.func_175695_a(blockpos, this, enumfacing);
      }
-@@ -307,6 +311,25 @@
+@@ -307,6 +309,25 @@
          return BlockRenderLayer.CUTOUT;
      }
  

--- a/patches/minecraft/net/minecraft/block/BlockRedstoneWire.java.patch
+++ b/patches/minecraft/net/minecraft/block/BlockRedstoneWire.java.patch
@@ -12,7 +12,7 @@
              if (!iblockstate1.func_185915_l())
              {
 -                boolean flag = p_176341_1_.func_180495_p(blockpos).func_185896_q() || p_176341_1_.func_180495_p(blockpos).func_177230_c() == Blocks.field_150426_aN;
-+                boolean flag = p_176341_1_.func_180495_p(blockpos).isSideSolid(p_176341_1_, blockpos, EnumFacing.UP) || p_176341_1_.func_180495_p(blockpos).func_177230_c() == Blocks.field_150426_aN;
++                boolean flag = iblockstate.func_177230_c().isTopSolid(iblockstate, p_176341_1_, blockpos) || iblockstate.func_177230_c() == Blocks.field_150426_aN;
  
 -                if (flag && func_176346_d(p_176341_1_.func_180495_p(blockpos.func_177984_a())))
 +                if (flag && func_176340_e(p_176341_1_, blockpos.func_177984_a()))
@@ -25,7 +25,7 @@
      {
 -        return p_176196_1_.func_180495_p(p_176196_2_.func_177977_b()).func_185896_q() || p_176196_1_.func_180495_p(p_176196_2_.func_177977_b()).func_177230_c() == Blocks.field_150426_aN;
 +        IBlockState downState = p_176196_1_.func_180495_p(p_176196_2_.func_177977_b());
-+        return downState.func_185896_q() || downState.func_193401_d(p_176196_1_, p_176196_2_.func_177977_b(), EnumFacing.UP) == BlockFaceShape.SOLID || p_176196_1_.func_180495_p(p_176196_2_.func_177977_b()).func_177230_c() == Blocks.field_150426_aN;
++        return downState.func_177230_c().isTopSolid(downState, p_176196_1_, p_176196_2_.func_177977_b()) || downState.func_177230_c() == Blocks.field_150426_aN;
      }
  
      private IBlockState func_176338_e(World p_176338_1_, BlockPos p_176338_2_, IBlockState p_176338_3_)

--- a/patches/minecraft/net/minecraft/block/state/IBlockProperties.java.patch
+++ b/patches/minecraft/net/minecraft/block/state/IBlockProperties.java.patch
@@ -18,7 +18,7 @@
  
      RayTraceResult func_185910_a(World p_185910_1_, BlockPos p_185910_2_, Vec3d p_185910_3_, Vec3d p_185910_4_);
  
-+    @Deprecated // Forge: Use isSideSolid(IBlockAccess, BlockPos, EnumFacing.UP) instead
++    @Deprecated // Forge: Use Block#isTopSolid(IBlockState, IBlockAccess, BlockPos) instead
      boolean func_185896_q();
  
 +    //Forge added functions

--- a/patches/minecraft/net/minecraft/entity/EntityLivingBase.java.patch
+++ b/patches/minecraft/net/minecraft/entity/EntityLivingBase.java.patch
@@ -281,7 +281,7 @@
                      if (!this.field_70170_p.func_184143_b(axisalignedbb1))
                      {
 -                        if (this.field_70170_p.func_180495_p(new BlockPos(d11, this.field_70163_u, d12)).func_185896_q())
-+                        if (this.field_70170_p.func_180495_p(new BlockPos(d11, this.field_70163_u, d12)).isSideSolid(field_70170_p, new BlockPos(d11, this.field_70163_u, d12), EnumFacing.UP))
++                        if (net.minecraftforge.common.ForgeHooks.isTopSolid(this.field_70170_p, new BlockPos(d11, this.field_70163_u, d12)))
                          {
                              this.func_70634_a(d11, this.field_70163_u + 1.0D, d12);
                              return;
@@ -290,7 +290,7 @@
                          BlockPos blockpos = new BlockPos(d11, this.field_70163_u - 1.0D, d12);
  
 -                        if (this.field_70170_p.func_180495_p(blockpos).func_185896_q() || this.field_70170_p.func_180495_p(blockpos).func_185904_a() == Material.field_151586_h)
-+                        if (this.field_70170_p.func_180495_p(blockpos).isSideSolid(field_70170_p, blockpos, EnumFacing.UP) || this.field_70170_p.func_180495_p(blockpos).func_185904_a() == Material.field_151586_h)
++                        if (net.minecraftforge.common.ForgeHooks.isTopSolid(this.field_70170_p, blockpos) || this.field_70170_p.func_180495_p(blockpos).func_185904_a() == Material.field_151586_h)
                          {
                              d1 = d11;
                              d13 = this.field_70163_u + 1.0D;
@@ -298,7 +298,7 @@
                          }
                      }
 -                    else if (!this.field_70170_p.func_184143_b(axisalignedbb1.func_72317_d(0.0D, 1.0D, 0.0D)) && this.field_70170_p.func_180495_p(new BlockPos(d11, this.field_70163_u + 1.0D, d12)).func_185896_q())
-+                    else if (!this.field_70170_p.func_184143_b(axisalignedbb1.func_72317_d(0.0D, 1.0D, 0.0D)) && this.field_70170_p.func_180495_p(new BlockPos(d11, this.field_70163_u + 1.0D, d12)).isSideSolid(field_70170_p, new BlockPos(d11, this.field_70163_u + 1.0D, d12), EnumFacing.UP))
++                    else if (!this.field_70170_p.func_184143_b(axisalignedbb1.func_72317_d(0.0D, 1.0D, 0.0D)) && net.minecraftforge.common.ForgeHooks.isTopSolid(this.field_70170_p, new BlockPos(d11, this.field_70163_u + 1.0D, d12)))
                      {
                          d1 = d11;
                          d13 = this.field_70163_u + 2.0D;

--- a/patches/minecraft/net/minecraft/entity/monster/EntityZombie.java.patch
+++ b/patches/minecraft/net/minecraft/entity/monster/EntityZombie.java.patch
@@ -44,7 +44,7 @@
                      int k1 = k + MathHelper.func_76136_a(this.field_70146_Z, 7, 40) * MathHelper.func_76136_a(this.field_70146_Z, -1, 1);
  
 -                    if (this.field_70170_p.func_180495_p(new BlockPos(i1, j1 - 1, k1)).func_185896_q() && this.field_70170_p.func_175671_l(new BlockPos(i1, j1, k1)) < 10)
-+                    if (this.field_70170_p.func_180495_p(new BlockPos(i1, j1 - 1, k1)).isSideSolid(this.field_70170_p, new BlockPos(i1, j1 - 1, k1), net.minecraft.util.EnumFacing.UP) && this.field_70170_p.func_175671_l(new BlockPos(i1, j1, k1)) < 10)
++                    if (net.minecraftforge.common.ForgeHooks.isTopSolid(this.field_70170_p, new BlockPos(i1, j1 - 1, k1)) && this.field_70170_p.func_175671_l(new BlockPos(i1, j1, k1)) < 10)
                      {
                          entityzombie.func_70107_b((double)i1, (double)j1, (double)k1);
  

--- a/patches/minecraft/net/minecraft/world/gen/feature/WorldGeneratorBonusChest.java.patch
+++ b/patches/minecraft/net/minecraft/world/gen/feature/WorldGeneratorBonusChest.java.patch
@@ -9,39 +9,40 @@
          {
              p_180709_3_ = p_180709_3_.func_177977_b();
          }
-@@ -31,7 +31,7 @@
+@@ -31,7 +31,8 @@
              {
                  BlockPos blockpos = p_180709_3_.func_177982_a(p_180709_2_.nextInt(4) - p_180709_2_.nextInt(4), p_180709_2_.nextInt(3) - p_180709_2_.nextInt(3), p_180709_2_.nextInt(4) - p_180709_2_.nextInt(4));
  
 -                if (p_180709_1_.func_175623_d(blockpos) && p_180709_1_.func_180495_p(blockpos.func_177977_b()).func_185896_q())
-+                if (p_180709_1_.func_175623_d(blockpos) && p_180709_1_.func_180495_p(blockpos.func_177977_b()).isSideSolid(p_180709_1_, blockpos.func_177977_b(), net.minecraft.util.EnumFacing.UP))
++
++                if (p_180709_1_.func_175623_d(blockpos) && net.minecraftforge.common.ForgeHooks.isTopSolid(p_180709_1_, blockpos.func_177977_b()))
                  {
                      p_180709_1_.func_180501_a(blockpos, Blocks.field_150486_ae.func_176223_P(), 2);
                      TileEntity tileentity = p_180709_1_.func_175625_s(blockpos);
-@@ -46,22 +46,22 @@
+@@ -46,22 +47,22 @@
                      BlockPos blockpos3 = blockpos.func_177978_c();
                      BlockPos blockpos4 = blockpos.func_177968_d();
  
 -                    if (p_180709_1_.func_175623_d(blockpos2) && p_180709_1_.func_180495_p(blockpos2.func_177977_b()).func_185896_q())
-+                    if (p_180709_1_.func_175623_d(blockpos2) && p_180709_1_.func_180495_p(blockpos2.func_177977_b()).isSideSolid(p_180709_1_, blockpos2.func_177977_b(), net.minecraft.util.EnumFacing.UP))
++                    if (p_180709_1_.func_175623_d(blockpos2) && net.minecraftforge.common.ForgeHooks.isTopSolid(p_180709_1_, blockpos2.func_177977_b()))
                      {
                          p_180709_1_.func_180501_a(blockpos2, Blocks.field_150478_aa.func_176223_P(), 2);
                      }
  
 -                    if (p_180709_1_.func_175623_d(blockpos1) && p_180709_1_.func_180495_p(blockpos1.func_177977_b()).func_185896_q())
-+                    if (p_180709_1_.func_175623_d(blockpos1) && p_180709_1_.func_180495_p(blockpos1.func_177977_b()).isSideSolid(p_180709_1_, blockpos1.func_177977_b(), net.minecraft.util.EnumFacing.UP))
++                    if (p_180709_1_.func_175623_d(blockpos1) && net.minecraftforge.common.ForgeHooks.isTopSolid(p_180709_1_, blockpos1.func_177977_b()))
                      {
                          p_180709_1_.func_180501_a(blockpos1, Blocks.field_150478_aa.func_176223_P(), 2);
                      }
  
 -                    if (p_180709_1_.func_175623_d(blockpos3) && p_180709_1_.func_180495_p(blockpos3.func_177977_b()).func_185896_q())
-+                    if (p_180709_1_.func_175623_d(blockpos3) && p_180709_1_.func_180495_p(blockpos3.func_177977_b()).isSideSolid(p_180709_1_, blockpos3.func_177977_b(), net.minecraft.util.EnumFacing.UP))
++                    if (p_180709_1_.func_175623_d(blockpos3) && net.minecraftforge.common.ForgeHooks.isTopSolid(p_180709_1_, blockpos3.func_177977_b()))
                      {
                          p_180709_1_.func_180501_a(blockpos3, Blocks.field_150478_aa.func_176223_P(), 2);
                      }
  
 -                    if (p_180709_1_.func_175623_d(blockpos4) && p_180709_1_.func_180495_p(blockpos4.func_177977_b()).func_185896_q())
-+                    if (p_180709_1_.func_175623_d(blockpos4) && p_180709_1_.func_180495_p(blockpos4.func_177977_b()).isSideSolid(p_180709_1_, blockpos4.func_177977_b(), net.minecraft.util.EnumFacing.UP))
++                    if (p_180709_1_.func_175623_d(blockpos4) && net.minecraftforge.common.ForgeHooks.isTopSolid(p_180709_1_, blockpos4.func_177977_b()))
                      {
                          p_180709_1_.func_180501_a(blockpos4, Blocks.field_150478_aa.func_176223_P(), 2);
                      }

--- a/patches/minecraft/net/minecraft/world/gen/feature/WorldGeneratorBonusChest.java.patch
+++ b/patches/minecraft/net/minecraft/world/gen/feature/WorldGeneratorBonusChest.java.patch
@@ -9,17 +9,16 @@
          {
              p_180709_3_ = p_180709_3_.func_177977_b();
          }
-@@ -31,7 +31,8 @@
+@@ -31,7 +31,7 @@
              {
                  BlockPos blockpos = p_180709_3_.func_177982_a(p_180709_2_.nextInt(4) - p_180709_2_.nextInt(4), p_180709_2_.nextInt(3) - p_180709_2_.nextInt(3), p_180709_2_.nextInt(4) - p_180709_2_.nextInt(4));
  
 -                if (p_180709_1_.func_175623_d(blockpos) && p_180709_1_.func_180495_p(blockpos.func_177977_b()).func_185896_q())
-+
 +                if (p_180709_1_.func_175623_d(blockpos) && net.minecraftforge.common.ForgeHooks.isTopSolid(p_180709_1_, blockpos.func_177977_b()))
                  {
                      p_180709_1_.func_180501_a(blockpos, Blocks.field_150486_ae.func_176223_P(), 2);
                      TileEntity tileentity = p_180709_1_.func_175625_s(blockpos);
-@@ -46,22 +47,22 @@
+@@ -46,22 +46,22 @@
                      BlockPos blockpos3 = blockpos.func_177978_c();
                      BlockPos blockpos4 = blockpos.func_177968_d();
  

--- a/src/main/java/net/minecraftforge/common/ForgeHooks.java
+++ b/src/main/java/net/minecraftforge/common/ForgeHooks.java
@@ -1470,4 +1470,10 @@ public class ForgeHooks
         return false;
     }
 
+    // helper function to reduce patches
+    public static boolean isTopSolid(IBlockAccess world, BlockPos pos)
+    {
+        IBlockState state = world.getBlockState(pos);
+        return state.getBlock().isTopSolid(state, world, pos);
+    }
 }


### PR DESCRIPTION
This aims to clean up and unify the code where the various uses of `IBlockState.isTopSolid` have been patched to provide additional context.

The intent here is to cleanly migrate away from the old `Block.isSideSolid` method while still keeping compatibility with vanilla behaviour.