### PR TITLE
[1.13] Reintroduce a container-opening system

### DIFF
--- a/patches/minecraft/net/minecraft/entity/player/EntityPlayer.java.patch
+++ b/patches/minecraft/net/minecraft/entity/player/EntityPlayer.java.patch
@@ -500,7 +500,7 @@
        if (this.func_70608_bn()) {
           f = 0.2F;
        } else if (!this.func_203007_ba() && !this.func_184613_cA() && this.field_70131_O != 0.6F) {
-@@ -1967,6 +2096,30 @@
+@@ -1967,6 +2096,41 @@
        return this.field_71075_bZ.field_75098_d && this.func_184840_I() >= 2;
     }
  
@@ -526,6 +526,17 @@
 +
 +   public Collection<ITextComponent> getSuffixes() {
 +       return this.suffixes;
++   }
++
++   /**
++    * Opens a modded container, based on {@code container.getGuiID}
++    * Container.getGuiID must return a valid ResourceLocation in String form. Vanilla follows this, but does not enforce it.
++    * @param container The container provider. The container will be obtained using {@link IInteractionObject#createContainer}.
++    * @param extraData Any extra data to communicate to the client
++    */
++   public void openGui(IInteractionObject container, @Nullable io.netty.buffer.ByteBuf extraData)
++   {
++      if (!field_70170_p.field_72995_K) net.minecraftforge.fml.network.NetworkHooks.openGui((EntityPlayerMP) this, container, extraData);
 +   }
 +
     public static enum EnumChatVisibility {

--- a/src/main/java/net/minecraftforge/fml/network/FMLPlayHandler.java
+++ b/src/main/java/net/minecraftforge/fml/network/FMLPlayHandler.java
@@ -33,5 +33,6 @@ public class FMLPlayHandler
     static
     {
         channel.registerMessage(0, FMLPlayMessages.SpawnEntity.class, FMLPlayMessages.SpawnEntity::encode, FMLPlayMessages.SpawnEntity::decode, FMLPlayMessages.SpawnEntity::handle);
+        channel.registerMessage(1, FMLPlayMessages.OpenContainer.class, FMLPlayMessages.OpenContainer::encode, FMLPlayMessages.OpenContainer::decode, FMLPlayMessages.OpenContainer::handle);
     }
 }

--- a/src/main/java/net/minecraftforge/fml/network/NetworkRegistry.java
+++ b/src/main/java/net/minecraftforge/fml/network/NetworkRegistry.java
@@ -19,6 +19,8 @@
 
 package net.minecraftforge.fml.network;
 
+import io.netty.buffer.ByteBuf;
+import net.minecraft.client.gui.GuiScreen;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.nbt.NBTTagList;
 import net.minecraft.network.NetworkManager;
@@ -33,7 +35,9 @@ import org.apache.logging.log4j.Marker;
 import org.apache.logging.log4j.MarkerManager;
 
 import java.util.*;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.BiFunction;
+import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
@@ -47,6 +51,21 @@ public class NetworkRegistry
     private static final Marker NETREGISTRY = MarkerManager.getMarker("NETREGISTRY");
 
     private static Map<ResourceLocation, NetworkInstance> instances = new HashMap<>();
+    static final Map<ResourceLocation, Supplier<Function<ByteBuf, GuiScreen>>> guiHandlers = new ConcurrentHashMap<>();
+
+    /**
+     * Registers a client-side GUI handler for the given ID.
+     * The function takes any extra data provided to {@link net.minecraft.entity.player.EntityPlayer#openGui}
+     * and returns a {@link GuiScreen} to display.
+     * Call this during {@link net.minecraftforge.fml.event.lifecycle.FMLClientSetupEvent}.
+     * This method is safe to call in parallel mod loading
+     * @param id
+     * @param handler
+     */
+    public static void registerGui(ResourceLocation id, Supplier<Function<ByteBuf, GuiScreen>> handler)
+    {
+        guiHandlers.put(id, handler);
+    }
 
     /**
      * Special value for clientAcceptedVersions and serverAcceptedVersions predicates indicating the other side lacks


### PR DESCRIPTION
Major points:
* This system only deals with containers, the guis that need syncing to open. Client-only guis formerly opened with `player.openGui` are now relegated to mods to do themselves, using `DistExecutor`
* Modeled after `SPacketOpenWindow`, but with two changes. 1: Don't send the window title by default, I don't think it's that useful and modders can send it on their own if they want it. 2: Allow modders to send additional data by passing a bytebuf. This replaces people stuffing random stuff into the `x/y/z` fields of the old `IGuiHandler` (yes, people did this, including me).

This is a rough sketch for review since no one has done anything and it's the last piece I need for ProjectE. The bytebuf parts for extra data seems a bit weird but idk what to put otherwise