### PR TITLE
Fix #5455 and a NPE during mod discovery

### DIFF
--- a/src/fmllauncher/java/net/minecraftforge/fml/loading/moddiscovery/ModsFolderLocator.java
+++ b/src/fmllauncher/java/net/minecraftforge/fml/loading/moddiscovery/ModsFolderLocator.java
@@ -58,7 +58,7 @@ public class ModsFolderLocator extends AbstractJarFileLocator implements IModLoc
                 sorted(Comparator.comparing(path-> StringUtils.toLowerCase(path.getFileName().toString()))).
                 filter(p->StringUtils.toLowerCase(p.getFileName().toString()).endsWith(SUFFIX)).
                 map(p->new ModFile(p, this)).
-                peek(f->modJars.compute(f, (mf, fs)->createFileSystem(mf))).
+                filter(f->modJars.compute(f, (mf, fs)->createFileSystem(mf))!=null).
                 collect(Collectors.toList());
     }
 

--- a/src/fmllauncher/java/net/minecraftforge/fml/loading/moddiscovery/ModsFolderLocator.java
+++ b/src/fmllauncher/java/net/minecraftforge/fml/loading/moddiscovery/ModsFolderLocator.java
@@ -58,7 +58,7 @@ public class ModsFolderLocator extends AbstractJarFileLocator implements IModLoc
                 sorted(Comparator.comparing(path-> StringUtils.toLowerCase(path.getFileName().toString()))).
                 filter(p->StringUtils.toLowerCase(p.getFileName().toString()).endsWith(SUFFIX)).
                 map(p->new ModFile(p, this)).
-                filter(f->modJars.compute(f, (mf, fs)->createFileSystem(mf))!=null).
+                peek(f->modJars.compute(f, (mf, fs)->createFileSystem(mf))).
                 collect(Collectors.toList());
     }
 

--- a/src/main/java/net/minecraftforge/fml/ForgeI18n.java
+++ b/src/main/java/net/minecraftforge/fml/ForgeI18n.java
@@ -88,10 +88,18 @@ public class ForgeI18n {
 
     public static String parseMessage(final String i18nMessage, Object... args) {
         final String pattern = getPattern(i18nMessage);
-        return parseFormat(pattern, args);
+        try
+        {
+            return parseFormat(pattern, args);
+        }
+        catch (IllegalArgumentException e)
+        {
+            LOGGER.warn(CORE, "Invalid translation pattern for key {}!", i18nMessage);
+            return i18nMessage+" - invalid pattern";
+        }
     }
 
-    public static String parseFormat(final String format, final Object... args) {
+    public static String parseFormat(final String format, final Object... args) throws IllegalArgumentException{
         final ExtendedMessageFormat extendedMessageFormat = new ExtendedMessageFormat(format, customFactories);
         return extendedMessageFormat.format(args);
     }

--- a/src/main/java/net/minecraftforge/fml/ForgeI18n.java
+++ b/src/main/java/net/minecraftforge/fml/ForgeI18n.java
@@ -94,12 +94,12 @@ public class ForgeI18n {
         }
         catch (IllegalArgumentException e)
         {
-            LOGGER.warn(CORE, "Invalid translation pattern for key {}!", i18nMessage);
-            return i18nMessage+" - invalid pattern";
+            LOGGER.warn(CORE, "Invalid translation pattern for key {}: {}!", i18nMessage, e.getLocalizedMessage());
+            return i18nMessage;
         }
     }
 
-    public static String parseFormat(final String format, final Object... args) throws IllegalArgumentException{
+    public static String parseFormat(final String format, final Object... args) throws IllegalArgumentException {
         final ExtendedMessageFormat extendedMessageFormat = new ExtendedMessageFormat(format, customFactories);
         return extendedMessageFormat.format(args);
     }


### PR DESCRIPTION
Fixes error happening with invalid translation keys by instead returning an error default message as well as a log entry

The other bug was caused by nothing (or null) being put into the modJars hashmap and then later used at [AbstractJarFileLocator](https://github.com/MinecraftForge/MinecraftForge/blob/1.13-pre/src/fmllauncher/java/net/minecraftforge/fml/loading/moddiscovery/AbstractJarFileLocator.java#L63).