### PR TITLE
Fix small logic error in ItemTextureQuadConverter

### DIFF
--- a/src/main/java/net/minecraftforge/client/model/ItemTextureQuadConverter.java
+++ b/src/main/java/net/minecraftforge/client/model/ItemTextureQuadConverter.java
@@ -63,7 +63,7 @@ public final class ItemTextureQuadConverter
         List<UnpackedBakedQuad> horizontal = convertTextureHorizontal(format, transform, template, sprite, z, facing, color, tint);
         List<UnpackedBakedQuad> vertical = convertTextureVertical(format, transform, template, sprite, z, facing, color, tint);
 
-        return horizontal.size() >= vertical.size() ? horizontal : vertical;
+        return horizontal.size() <= vertical.size() ? horizontal : vertical;
     }
 
     /** @deprecated use {@link #convertTextureHorizontal(VertexFormat, TRSRTransformation, TextureAtlasSprite, TextureAtlasSprite, float, EnumFacing, int, int)} */


### PR DESCRIPTION
Very simple fix for `ItemTextureQuadConverter.convertTexture` to make it match the intended behaviour specified in the javadoc:
https://github.com/MinecraftForge/MinecraftForge/blob/41a098e2f789a507d8d56f4aa3facfe9c8088164/src/main/java/net/minecraftforge/client/model/ItemTextureQuadConverter.java#L53-L54

Currently the logic incorrectly prefers the less efficient representation here.