### PR TITLE
Make BannerPattern extensible

### DIFF
--- a/patches/minecraft/net/minecraft/tileentity/BannerPattern.java.patch
+++ b/patches/minecraft/net/minecraft/tileentity/BannerPattern.java.patch
@@ -1,0 +1,24 @@
+--- a/net/minecraft/tileentity/BannerPattern.java
++++ b/net/minecraft/tileentity/BannerPattern.java
+@@ -7,7 +7,7 @@
+ import net.minecraftforge.api.distmarker.Dist;
+ import net.minecraftforge.api.distmarker.OnlyIn;
+ 
+-public enum BannerPattern {
++public enum BannerPattern implements net.minecraftforge.common.IExtensibleEnum {
+    BASE("base", "b"),
+    SQUARE_BOTTOM_LEFT("square_bottom_left", "bl", "   ", "   ", "#  "),
+    SQUARE_BOTTOM_RIGHT("square_bottom_right", "br", "   ", "   ", "  #"),
+@@ -108,4 +108,12 @@
+ 
+       return null;
+    }
++   
++   public static BannerPattern create(String enumName, String p_i47246_3_, String p_i47246_4_, ItemStack p_i47246_5_) {
++	   throw new IllegalStateException("Enum not extended");
++   }
++   
++   public static BannerPattern create(String enumName, String p_i47247_3_, String p_i47247_4_, String p_i47247_5_, String p_i47247_6_, String p_i47247_7_) {
++	   throw new IllegalStateException("Enum not extended");
++   }
+ }

--- a/src/main/resources/forge.exc
+++ b/src/main/resources/forge.exc
@@ -31,6 +31,9 @@ net/minecraft/network/PacketBuffer.writeItemStack(Lnet/minecraft/item/ItemStack;
 net/minecraft/server/management/PlayerList.changePlayerDimension(Lnet/minecraft/entity/player/EntityPlayerMP;Lnet/minecraft/world/dimension/DimensionType;Lnet/minecraftforge/common/util/ITeleporter;)V=|p_187242_1_,p_187242_2_,teleporter
 net/minecraft/server/management/PlayerList.transferEntityToWorld(Lnet/minecraft/entity/Entity;Lnet/minecraft/world/dimension/DimensionType;Lnet/minecraft/world/WorldServer;Lnet/minecraft/world/WorldServer;Lnet/minecraftforge/common/util/ITeleporter;)V=|p_82448_1_,p_82448_2_,p_82448_3_,p_82448_4_,teleporter
 
+net/minecraft/tileentity/BannerPattern.create(Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lnet/minecraft/item/ItemStack;)Lnet/minecraft/tileentity/BannerPattern;=|enumName,p_i47246_3_,p_i47246_4_,p_i47246_5_
+net/minecraft/tileentity/BannerPattern.create(Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lnet/minecraft/tileentity/BannerPattern;=|enumName,p_i47247_3_,p_i47247_4_,p_i47247_5_,p_i47247_6_,p_i47247_7_
+
 net/minecraft/village/Village.getPlayerReputation(Ljava/util/UUID;)I=|p_82684_1_
 net/minecraft/village/Village.modifyPlayerReputation(Ljava/util/UUID;I)I=|p_82688_1_,p_82688_2_
 


### PR DESCRIPTION
Added two factory methods to `BannerPattern` matching the two used constructors, one for ItemStack based, and one using pattern strings. New impl of `RuntimeEnumExtender` handles this case fine :smile:.

Will wait to merge this until after 1.13.2 update is complete, then rebase on top of that. I doubt there will be conflicts.

This closes #5447