### PR TITLE
Apply access-level changes to inner class attributes

### DIFF
--- a/src/main/java/net/minecraftforge/fml/common/asm/transformers/AccessTransformer.java
+++ b/src/main/java/net/minecraftforge/fml/common/asm/transformers/AccessTransformer.java
@@ -52,6 +52,7 @@ import org.objectweb.asm.ClassWriter;
 import org.objectweb.asm.tree.AbstractInsnNode;
 import org.objectweb.asm.tree.ClassNode;
 import org.objectweb.asm.tree.FieldNode;
+import org.objectweb.asm.tree.InnerClassNode;
 import org.objectweb.asm.tree.MethodInsnNode;
 import org.objectweb.asm.tree.MethodNode;
 
@@ -204,6 +205,15 @@ public class AccessTransformer implements IClassTransformer
                 {
                     FMLLog.log.debug("Class: {} {} -> {}", name, toBinary(m.oldAccess), toBinary(m.newAccess));
                 }
+                // if this is an inner class, also modify the access flags on the corresponding InnerClasses attribute
+                for (InnerClassNode innerClass : classNode.innerClasses)
+                {
+                    if (innerClass.name.replace('/', '.').equals(transformedName))
+                    {
+                        innerClass.access = getFixedAccess(innerClass.access, m);
+                        break;
+                    }
+                }
                 continue;
             }
             if (m.desc.isEmpty())
@@ -261,7 +271,10 @@ public class AccessTransformer implements IClassTransformer
                     }
                 }
 
-                replaceInvokeSpecial(classNode, nowOverrideable);
+                if (!nowOverrideable.isEmpty())
+                {
+                    replaceInvokeSpecial(classNode, nowOverrideable);
+                }
             }
         }
 

--- a/src/main/java/net/minecraftforge/fml/common/asm/transformers/AccessTransformer.java
+++ b/src/main/java/net/minecraftforge/fml/common/asm/transformers/AccessTransformer.java
@@ -208,7 +208,7 @@ public class AccessTransformer implements IClassTransformer
                 // if this is an inner class, also modify the access flags on the corresponding InnerClasses attribute
                 for (InnerClassNode innerClass : classNode.innerClasses)
                 {
-                    if (innerClass.name.replace('/', '.').equals(transformedName))
+                    if (innerClass.name.equals(classNode.name))
                     {
                         innerClass.access = getFixedAccess(innerClass.access, m);
                         break;


### PR DESCRIPTION
Should fix #5254.

For access-transformed classes that are also inner (not top-level) classes, this will update the access flags on the corresponding `InnerClasses` attribute ([JVMS 4.7.6](https://docs.oracle.com/javase/specs/jvms/se8/html/jvms-4.html#jvms-4.7.6)).

Note that not all `InnerClasses` attributes that refer to access-transformed classes are changed by this, only those within the classes themselves, however this was sufficient to fix the crash example in the issue.

As fixing all attributes would require visiting more classes, I think doing the minimum here is okay.

Also, in what is admittedly a minor deviation, this also skips the `replaceInvokeSpecial` call when it's not required, as it iterates over the instructions of every method in the class.