### PR TITLE
Add back missing ItemColors patch

### DIFF
--- a/patches/minecraft/net/minecraft/client/renderer/color/ItemColors.java.patch
+++ b/patches/minecraft/net/minecraft/client/renderer/color/ItemColors.java.patch
@@ -1,0 +1,10 @@
+--- a/net/minecraft/client/renderer/color/ItemColors.java
++++ b/net/minecraft/client/renderer/color/ItemColors.java
+@@ -80,6 +80,7 @@
+       itemcolors.func_199877_a((p_210237_0_, p_210237_1_) -> {
+          return p_210237_1_ == 0 ? -1 : ItemMap.func_190907_h(p_210237_0_);
+       }, Items.field_151098_aY);
++      net.minecraftforge.client.ForgeHooksClient.onItemColorsInit(itemcolors, p_186729_0_);
+       return itemcolors;
+    }
+ 

--- a/patches/minecraft/net/minecraft/client/renderer/color/ItemColors.java.patch
+++ b/patches/minecraft/net/minecraft/client/renderer/color/ItemColors.java.patch
@@ -1,6 +1,16 @@
 --- a/net/minecraft/client/renderer/color/ItemColors.java
 +++ b/net/minecraft/client/renderer/color/ItemColors.java
-@@ -80,6 +80,7 @@
+@@ -22,7 +22,8 @@
+ 
+ @OnlyIn(Dist.CLIENT)
+ public class ItemColors {
+-   private final ObjectIntIdentityMap<IItemColor> field_186732_a = new ObjectIntIdentityMap<>(32);
++   // FORGE: Use RegistryDelegates as non-Vanilla item ids are not constant
++   private final java.util.Map<net.minecraftforge.registries.IRegistryDelegate<Item>, IItemColor> field_186732_a = new java.util.HashMap<>();
+ 
+    public static ItemColors func_186729_a(BlockColors p_186729_0_) {
+       ItemColors itemcolors = new ItemColors();
+@@ -80,17 +81,18 @@
        itemcolors.func_199877_a((p_210237_0_, p_210237_1_) -> {
           return p_210237_1_ == 0 ? -1 : ItemMap.func_190907_h(p_210237_0_);
        }, Items.field_151098_aY);
@@ -8,3 +18,16 @@
        return itemcolors;
     }
  
+    public int func_186728_a(ItemStack p_186728_1_, int p_186728_2_) {
+-      IItemColor iitemcolor = this.field_186732_a.func_148745_a(IRegistry.field_212630_s.func_148757_b(p_186728_1_.func_77973_b()));
++      IItemColor iitemcolor = this.field_186732_a.get(p_186728_1_.func_77973_b().delegate);
+       return iitemcolor == null ? -1 : iitemcolor.getColor(p_186728_1_, p_186728_2_);
+    }
+ 
+    public void func_199877_a(IItemColor p_199877_1_, IItemProvider... p_199877_2_) {
+       for(IItemProvider iitemprovider : p_199877_2_) {
+-         this.field_186732_a.func_148746_a(p_199877_1_, Item.func_150891_b(iitemprovider.func_199767_j()));
++         this.field_186732_a.put(iitemprovider.func_199767_j().delegate, p_199877_1_);
+       }
+ 
+    }


### PR DESCRIPTION
This was causing the appropriate `ColorHandlerEvent` event not to be fired.