### PR TITLE
[1.13.x] Refactor run configs based on my FG pr: MinecraftForge/ForgeGradle#546

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -64,20 +64,35 @@ project(':clean') {
     repositories {
         mavenCentral()
     }
+
     patcher {
         parent = project(':mcp')
-        patchedSrc = file('src/main/java')
-        mappings channel: MAPPING_CHANNEL, version: MAPPING_VERSION
         mcVersion = MC_VERSION
-    }
-    task runclient(type: JavaExec) {
-        doFirst {
-            mkdir 'runclient'
+        patchedSrc = file('src/main/java')
+
+        mappings channel: MAPPING_CHANNEL, version: MAPPING_VERSION
+
+        runs {
+            clean_client {
+                taskName 'clean_client'
+
+                main 'net.minecraft.client.main.Main'
+                workingDirectory project.file('run')
+
+                args '--gameDir', '.'
+                args '--version', MC_VERSION
+                args '--assetsDir', downloadAssets.output
+                args '--assetIndex', '{asset_index}'
+                args '--accessToken', '0'
+            }
+
+            clean_server {
+                taskName 'clean_server'
+
+                main 'net.minecraft.server.MinecraftServer'
+                workingDirectory project.file('run')
+            }
         }
-        classpath sourceSets.main.runtimeClasspath
-        args = ['--accessToken', '0', '--version', MC_VERSION]
-        main 'net.minecraft.client.main.Main'
-        workingDir 'runclient'
     }
 }
 
@@ -166,46 +181,49 @@ project(':forge') {
     version = getVersion()
 
     patcher {
+        exc = file("$rootDir/src/main/resources/forge.exc")
         parent = project(':clean')
         patches = file("$rootDir/patches/minecraft")
         patchedSrc = file('src/main/java')
-        accessTransformer = file("$rootDir/src/main/resources/META-INF/accesstransformer.cfg")
-        exc = file("$rootDir/src/main/resources/forge.exc")
         srgPatches = true
+        accessTransformer = file("$rootDir/src/main/resources/META-INF/accesstransformer.cfg")
+
         runs {
-            forge_client = {
+            forge_client {
+                taskName 'forge_client'
+
                 main 'net.minecraftforge.fml.LaunchTesting'
-                environment = [
-                    target: 'fmldevclient',
-                    assetDirectory: downloadAssets.output,
-                    nativesDirectory: extractNatives.output
-                ]
-                properties = [
-//                    'org.lwjgl.util.Debug': 'true',
-//                    'org.lwjgl.util.DebugLoader': 'true',
-                    'org.lwjgl.system.SharedLibraryExtractDirectory': 'lwjgl_dll',
-                    'mc.version': MC_VERSION,
-                    'mcp.version': MCP_VERSION,
-                    'forge.version': project.version.substring(MC_VERSION.length() + 1),
-                    'forge.spec': SPEC_VERSION,
-                    'forge.group': project.group, 
-                    'fmllauncher.version': SPEC_VERSION,
-                    'terminal.ansi': 'true'
-                ]
+                workingDirectory project.file('run')
+
+                environment 'target', 'fmldevclient'
+                environment 'assetIndex', '{asset_index}'
+                environment 'assetDirectory', downloadAssets.output
+                environment 'nativesDirectory', extractNatives.output
+
+                property 'mc.version', MC_VERSION
+                property 'forge.spec', SPEC_VERSION
+                property 'mcp.version', MCP_VERSION
+                property 'forge.group', project.group
+                property 'forge.version', project.version.substring(MC_VERSION.length() + 1).toString()
+                property 'terminal.ansi', 'true'
+                property 'fmllauncher.version', SPEC_VERSION
+                property 'org.lwjgl.system.SharedLibraryExtractDirectory', 'lwjgl_dll'
             }
-            forge_server = {
+
+            forge_server {
+                taskName 'forge_server'
+
                 main 'net.minecraftforge.fml.LaunchTesting'
-                environment = [
-                    target: 'fmldevserver'
-                ]
-                properties = [
-                    'mc.version': MC_VERSION,
-                    'mcp.version': MCP_VERSION,
-                    'forge.version': "${project.version.substring(MC_VERSION.length() + 1)}".toString(),
-                    'forge.spec': SPEC_VERSION,
-                    'forge.group': project.group, 
-                    'fmllauncher.version': SPEC_VERSION
-                ]
+                workingDirectory project.file('run')
+
+                environment 'target', 'fmldevserver'
+
+                property 'mc.version', MC_VERSION
+                property 'forge.spec', SPEC_VERSION
+                property 'mcp.version', MCP_VERSION
+                property 'forge.group', project.group
+                property 'forge.version', project.version.substring(MC_VERSION.length() + 1).toString()
+                property 'fmllauncher.version', SPEC_VERSION
             }
         }
     }
@@ -289,43 +307,6 @@ project(':forge') {
         testImplementation "org.junit.jupiter:junit-jupiter-api:5.0.0"
         testImplementation "org.opentest4j:opentest4j:1.0.0" // needed for junit 5
         testImplementation "org.hamcrest:hamcrest-all:1.3" // needs advanced matching for list order
-    }
-
-    task runclient(type: JavaExec, dependsOn: [":forge:downloadAssets", ":forge:extractNatives"]) {
-        doFirst {
-            mkdir 'runclient'
-        }
-        doFirst {
-            copy {
-                from sourceSets.main.resources
-                into "$buildDir/classes/java/main"
-            }
-        }
-        //jvmArgs = ['-verbose:class']
-        classpath sourceSets.main.runtimeClasspath
-        main patcher.runs.forge_client.main
-        systemProperties = patcher.runs.forge_client.properties
-        environment += patcher.runs.forge_client.environment
-        workingDir 'runclient'
-    }
-
-    task runserver(type: JavaExec) {
-        doFirst {
-            mkdir 'runserver'
-        }
-        doFirst {
-            copy {
-                from sourceSets.main.resources
-                into "$buildDir/classes/java/main"
-            }
-        }
-        classpath sourceSets.main.runtimeClasspath
-        main patcher.runs.forge_server.main
-        args 'nogui'
-        systemProperties = patcher.runs.forge_server.properties
-        environment += patcher.runs.forge_server.environment
-        workingDir 'runserver'
-        standardInput = System.in
     }
     
     def extraTxts = [
@@ -836,27 +817,33 @@ project(':forge') {
         }
         addLibrary("${project.group}:${project.name}:${project.version}:launcher")
         runs {
-            client = {
+            client {
                 main 'net.minecraftforge.userdev.UserdevLauncher'
+
                 environment 'target', 'fmluserdevclient'
+                environment 'assetIndex', '{asset_index}'
                 environment 'assetDirectory', '{assets_root}'
                 environment 'nativesDirectory', '{natives}'
-                environment 'FORGE_VERSION', project.version.substring(MC_VERSION.length() + 1)
-                environment 'FORGE_GROUP', project.group
-                environment 'MCP_VERSION', MCP_VERSION
-                environment 'MC_VERSION', MC_VERSION
+
+                environment 'MC_VERSION', "${MC_VERSION}"
+                environment 'FORGE_GROUP', "${project.group}"
+                environment 'MCP_VERSION', "${MCP_VERSION}"
                 environment 'MOD_CLASSES', '{source_roots}'
                 environment 'MCP_MAPPINGS', '{mcp_mappings}'
+                environment 'FORGE_VERSION', "${project.version.substring(MC_VERSION.length() + 1)}"
             }
-            server = {
+
+            server {
                 main 'net.minecraftforge.userdev.UserdevLauncher'
+
                 environment 'target', 'fmluserdevserver'
-                environment 'FORGE_VERSION', project.version.substring(MC_VERSION.length() + 1)
-                environment 'FORGE_GROUP', project.group
-                environment 'MCP_VERSION', MCP_VERSION
-                environment 'MC_VERSION', MC_VERSION
+
+                environment 'MC_VERSION', "${MC_VERSION}"
+                environment 'FORGE_GROUP', "${project.group}"
+                environment 'MCP_VERSION', "${MCP_VERSION}"
                 environment 'MOD_CLASSES', '{source_roots}'
                 environment 'MCP_MAPPINGS', '{mcp_mappings}'
+                environment 'FORGE_VERSION', "${project.version.substring(MC_VERSION.length() + 1)}"
             }
         }
     }

--- a/mdk/build.gradle
+++ b/mdk/build.gradle
@@ -9,7 +9,7 @@ buildscript {
     }
 }
 apply plugin: 'net.minecraftforge.gradle'
-//Only edit below this line, the above code adds and enables the necessary things for Forge to be setup.
+// Only edit below this line, the above code adds and enables the necessary things for Forge to be setup.
 apply plugin: 'eclipse'
 
 version = '1.0'
@@ -19,34 +19,49 @@ archivesBaseName = 'modid'
 sourceCompatibility = targetCompatibility = compileJava.sourceCompatibility = compileJava.targetCompatibility = '1.8' // Need this here so eclipse task generates correctly.
 
 minecraft {
-    // the mappings can be changed at any time, and must be in the following format.
-    // snapshot_YYYYMMDD   snapshot are built nightly.
-    // stable_#            stables are built at the discretion of the MCP team.
+    // The mappings can be changed at any time, and must be in the following format.
+    // snapshot_YYYYMMDD   Snapshot are built nightly.
+    // stable_#            Stables are built at the discretion of the MCP team.
     // Use non-default mappings at your own risk. they may not always work.
-    // simply re-run your setup task after changing the mappings to update your workspace.
+    // Simply re-run your setup task after changing the mappings to update your workspace.
     mappings channel: '@MAPPING_CHANNEL@', version: '@MAPPING_VERSION@'
     // makeObfSourceJar = false // an Srg named sources jar is made by default. uncomment this to disable.
     
-    //accessTransformer = file('my_at.cfg')
+    // accessTransformer = file('build/resources/main/META-INF/accesstransformer.cfg')
 
-    // default run configurations.
-    // these can be tweaked, removed, or duplicated as needed.
+    // Default run configurations.
+    // These can be tweaked, removed, or duplicated as needed.
     runs {
-        client = {
-            // recommended logging data for a userdev environment
-            properties 'forge.logging.markers': 'SCAN,REGISTRIES,REGISTRYDUMP'
-            // recommended logging level for the console
-            properties 'forge.logging.console.level': 'debug'
-            workingDirectory project.file('run').canonicalPath
-            source sourceSets.main
+        client {
+            workingDirectory project.file('run')
+
+            // Recommended logging data for a userdev environment
+            property 'forge.logging.markers', 'SCAN,REGISTRIES,REGISTRYDUMP'
+
+            // Recommended logging level for the console
+            property 'forge.logging.console.level', 'debug'
+
+            mods {
+                examplemod {
+                    source sourceSets.main
+                }
+            }
         }
-        server = {
-            // recommended logging data for a userdev environment
-            properties 'forge.logging.markers': 'SCAN,REGISTRIES,REGISTRYDUMP'
-            // recommended logging level for the console
-            properties 'forge.logging.console.level': 'debug'
-            workingDirectory project.file('run').canonicalPath
-            source sourceSets.main
+
+        server {
+            workingDirectory project.file('run')
+
+            // Recommended logging data for a userdev environment
+            property 'forge.logging.markers', 'SCAN,REGISTRIES,REGISTRYDUMP'
+
+            // Recommended logging level for the console
+            property 'forge.logging.console.level', 'debug'
+
+            mods {
+                examplemod {
+                    source sourceSets.main
+                }
+            }
         }
     }
 }
@@ -57,22 +72,21 @@ dependencies {
     // The userdev artifact is a special name and will get all sorts of transformations applied to it.
     minecraft '@FORGE_GROUP@:@FORGE_NAME@:@FORGE_VERSION@'
 
-    // you may put jars on which you depend on in ./libs
-    // or you may define them like so..
-    //compile "some.group:artifact:version:classifier"
-    //compile "some.group:artifact:version"
+    // You may put jars on which you depend on in ./libs or you may define them like so..
+    // compile "some.group:artifact:version:classifier"
+    // compile "some.group:artifact:version"
 
-    // real examples
-    //compile 'com.mod-buildcraft:buildcraft:6.0.8:dev'  // adds buildcraft to the dev env
-    //compile 'com.googlecode.efficient-java-matrix-library:ejml:0.24' // adds ejml to the dev env
+    // Real examples
+    // compile 'com.mod-buildcraft:buildcraft:6.0.8:dev'  // adds buildcraft to the dev env
+    // compile 'com.googlecode.efficient-java-matrix-library:ejml:0.24' // adds ejml to the dev env
 
-    // the 'provided' configuration is for optional dependencies that exist at compile-time but might not at runtime.
-    //provided 'com.mod-buildcraft:buildcraft:6.0.8:dev'
+    // The 'provided' configuration is for optional dependencies that exist at compile-time but might not at runtime.
+    // provided 'com.mod-buildcraft:buildcraft:6.0.8:dev'
 
     // These dependencies get remapped to your current MCP mappings
-    //deobf 'com.mod-buildcraft:buildcraft:6.0.8:dev'
+    // deobf 'com.mod-buildcraft:buildcraft:6.0.8:dev'
 
-    // for more info...
+    // For more info...
     // http://www.gradle.org/docs/current/userguide/artifact_dependencies_tutorial.html
     // http://www.gradle.org/docs/current/userguide/dependency_management.html
 
@@ -81,12 +95,14 @@ dependencies {
 // Example for how to get properties into the manifest for reading by the runtime..
 jar {
     manifest {
-        attributes(["Specification-Title": "examplemod",
-                    "Specification-Vendor": "examplemodsareus",
-                    "Specification-Version": "1", // We are version 1 of ourselves
-                    "Implementation-Title": project.name,
-                    "Implementation-Version": "${version}",
-                    "Implementation-Vendor" :"examplemodsareus",
-                    "Implementation-Timestamp": new Date().format("yyyy-MM-dd'T'HH:mm:ssZ")],)
+        attributes([
+            "Specification-Title": "examplemod",
+            "Specification-Vendor": "examplemodsareus",
+            "Specification-Version": "1", // We are version 1 of ourselves
+            "Implementation-Title": project.name,
+            "Implementation-Version": "${version}",
+            "Implementation-Vendor" :"examplemodsareus",
+            "Implementation-Timestamp": new Date().format("yyyy-MM-dd'T'HH:mm:ssZ")
+        ])
     }
 }

--- a/src/main/java/net/minecraftforge/fml/LaunchTesting.java
+++ b/src/main/java/net/minecraftforge/fml/LaunchTesting.java
@@ -61,11 +61,11 @@ public class LaunchTesting
         if (Objects.equals(target,"fmldevclient")) {
             hackNatives();
             launchArgs = ObjectArrays.concat(launchArgs, new String[] {
-                            "--accessToken", "blah",
-                            "--version", "FMLDev",
-                            "--assetIndex", "1.13.1",
-                            "--assetsDir", assets,
-                            "--userProperties", "{}"
+                    "--accessToken", "blah",
+                    "--version", "FMLDev",
+                    "--assetIndex", System.getenv("assetIndex"),
+                    "--assetsDir", assets,
+                    "--userProperties", "{}"
             }, String.class);
         } else {
             launchArgs = ObjectArrays.concat(launchArgs, args, String.class);

--- a/src/userdev/java/net/minecraftforge/userdev/UserdevLauncher.java
+++ b/src/userdev/java/net/minecraftforge/userdev/UserdevLauncher.java
@@ -65,7 +65,7 @@ public class UserdevLauncher
             launchArgs = ObjectArrays.concat(launchArgs, new String[] {
                     "--accessToken", "blah",
                     "--version", "FMLDev",
-                    "--assetIndex", "1.13.1",
+                    "--assetIndex", System.getenv("assetIndex"),
                     "--assetsDir", assets,
                     "--userProperties", "{}"
             }, String.class);


### PR DESCRIPTION
This PR is the result of the combination of two of my other PR's: MinecraftForge/MinecraftForge#5333 and MinecraftForge/MinecraftForge#5471. I have closed those two PR's to centralize them into this.

This updates Forge's `build.gradle` file to better use the run config setup I have created in my FG pr: MinecraftForge/ForgeGradle#546. It also fixes the current issue of using the wrong asset index and now sets it based on the downloaded version meta from FG.

I have also updated parts of the MDK to show, and describe, what can be done with the new run config setup. It also adds a test mod, using the MDK's test source set, to show the ability of multiple mods in a single project. Run configs _should_ also be backwards compatible