### PR TITLE
Fix lazy ModContainer evaluation skipping thrown loadingExceptions

### DIFF
--- a/src/main/java/net/minecraftforge/fml/ModLoader.java
+++ b/src/main/java/net/minecraftforge/fml/ModLoader.java
@@ -119,8 +119,8 @@ public class ModLoader
         final List<ModContainer> modContainers = loadingModList.getModFiles().stream().
                 map(ModFileInfo::getFile).
                 map(mf -> buildMods(mf, launchClassLoader)).
-                flatMap(Collection::stream)
-                .collect(Collectors.toList());
+                flatMap(Collection::stream).
+                collect(Collectors.toList());
         if (!loadingExceptions.isEmpty()) {
             LOGGER.fatal(CORE, "Failed to initialize mod containers");
             throw new LoadingFailedException(loadingExceptions);

--- a/src/main/java/net/minecraftforge/fml/ModLoader.java
+++ b/src/main/java/net/minecraftforge/fml/ModLoader.java
@@ -26,16 +26,15 @@ import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.common.capabilities.CapabilityManager;
 import net.minecraftforge.fml.config.ConfigTracker;
 import net.minecraftforge.fml.config.ModConfig;
-import net.minecraftforge.fml.loading.FMLPaths;
-import net.minecraftforge.forgespi.language.IModInfo;
 import net.minecraftforge.fml.loading.FMLLoader;
+import net.minecraftforge.fml.loading.FMLPaths;
 import net.minecraftforge.fml.loading.LoadingModList;
 import net.minecraftforge.fml.loading.moddiscovery.ModFile;
 import net.minecraftforge.fml.loading.moddiscovery.ModFileInfo;
+import net.minecraftforge.forgespi.language.IModInfo;
 import net.minecraftforge.forgespi.language.IModLanguageProvider;
 import net.minecraftforge.registries.GameData;
 import net.minecraftforge.registries.ObjectHolderRegistry;
-
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -45,7 +44,6 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.function.Function;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 import static net.minecraftforge.fml.Logging.CORE;
 import static net.minecraftforge.fml.Logging.LOADING;
@@ -118,15 +116,16 @@ public class ModLoader
         if (!this.loadingExceptions.isEmpty()) {
             throw new LoadingFailedException(loadingExceptions);
         }
-        final Stream<ModContainer> modContainerStream = loadingModList.getModFiles().stream().
+        final List<ModContainer> modContainers = loadingModList.getModFiles().stream().
                 map(ModFileInfo::getFile).
                 map(mf -> buildMods(mf, launchClassLoader)).
-                flatMap(Collection::stream);
+                flatMap(Collection::stream)
+                .collect(Collectors.toList());
         if (!loadingExceptions.isEmpty()) {
             LOGGER.fatal(CORE, "Failed to initialize mod containers");
             throw new LoadingFailedException(loadingExceptions);
         }
-        modList.setLoadedMods(modContainerStream.collect(Collectors.toList()));
+        modList.setLoadedMods(modContainers);
         dispatchAndHandleError(LifecycleEventProvider.CONSTRUCT);
         GameData.fireCreateRegistryEvents(LifecycleEventProvider.CREATE_REGISTRIES, this::dispatchAndHandleError);
         ObjectHolderRegistry.findObjectHolders();


### PR DESCRIPTION
With `modContainerStream` formerly only being evaluated in the call to `setLoadedMods`, any exceptions added to `loadingExceptions` would be ignored due to the list only being checked beforehand.

The end result was unclear error messages: a NPE would be thrown in `setLoadedMods` from `null` being returned on exception within `buildModContainerFromTOML`.