### PR TITLE
[1.13.2] Fix MathHelper.clamp not working for NaN values.

### DIFF
--- a/patches/minecraft/net/minecraft/util/math/MathHelper.java.patch
+++ b/patches/minecraft/net/minecraft/util/math/MathHelper.java.patch
@@ -1,0 +1,25 @@
+--- a/net/minecraft/util/math/MathHelper.java
++++ b/net/minecraft/util/math/MathHelper.java
+@@ -90,18 +90,18 @@
+    }
+ 
+    public static float func_76131_a(float p_76131_0_, float p_76131_1_, float p_76131_2_) {
+-      if (p_76131_0_ < p_76131_1_) {
++      if (!(p_76131_0_ >= p_76131_1_)) {
+          return p_76131_1_;
+       } else {
+-         return p_76131_0_ > p_76131_2_ ? p_76131_2_ : p_76131_0_;
++         return !(p_76131_0_ <= p_76131_2_) ? p_76131_2_ : p_76131_0_;
+       }
+    }
+ 
+    public static double func_151237_a(double p_151237_0_, double p_151237_2_, double p_151237_4_) {
+-      if (p_151237_0_ < p_151237_2_) {
++      if (!(p_151237_0_ >= p_151237_2_)) {
+          return p_151237_2_;
+       } else {
+-         return p_151237_0_ > p_151237_4_ ? p_151237_4_ : p_151237_0_;
++         return !(p_151237_0_ <= p_151237_4_) ? p_151237_4_ : p_151237_0_;
+       }
+    }
+ 


### PR DESCRIPTION
Probably not the proper solution to this, and maybe not a directly Forge issue (decompiling issue)

It fixes ender dragon going NaN when spawned in the overworld.
The rise velocity calculation passes a NaN to MathHelper.clamp, where vanilla correctly clamps, Forge just seems to return a NaN value.