### PR TITLE
[1.13] Fix some minor patch regressions

### DIFF
--- a/patches/minecraft/net/minecraft/block/BlockCrops.java.patch
+++ b/patches/minecraft/net/minecraft/block/BlockCrops.java.patch
@@ -28,7 +28,7 @@
                    f1 = 3.0F;
                 }
              }
-@@ -135,15 +137,19 @@
+@@ -135,15 +137,20 @@
     }
  
     public void func_196255_a(IBlockState p_196255_1_, World p_196255_2_, BlockPos p_196255_3_, float p_196255_4_, int p_196255_5_) {
@@ -40,6 +40,7 @@
 +
 +   @Override
 +   public void getDrops(IBlockState state, net.minecraft.util.NonNullList<ItemStack> drops, World world, BlockPos pos, int fortune) {
++      super.getDrops(state, drops, world, pos, 0);
 +      {
 +         int i = this.func_185527_x(state);
           if (i >= this.func_185526_g()) {

--- a/patches/minecraft/net/minecraft/client/gui/inventory/GuiContainerCreative.java.patch
+++ b/patches/minecraft/net/minecraft/client/gui/inventory/GuiContainerCreative.java.patch
@@ -148,7 +148,7 @@
 +      boolean rendered = false;
 +
 +      for(ItemGroup itemgroup : java.util.Arrays.copyOfRange(ItemGroup.field_78032_a, start, end)) {
-+         if (itemgroup != null) continue;
++         if (itemgroup == null) continue;
           if (this.func_147052_b(itemgroup, p_73863_1_, p_73863_2_)) {
 +            rendered = true;
              break;

--- a/patches/minecraft/net/minecraft/tileentity/TileEntityBeacon.java.patch
+++ b/patches/minecraft/net/minecraft/tileentity/TileEntityBeacon.java.patch
@@ -32,7 +32,7 @@
                 for(int j1 = k - k1; j1 <= k + k1; ++j1) {
 -                  Block block1 = this.field_145850_b.func_180495_p(new BlockPos(i2, l1, j1)).func_177230_c();
 -                  if (block1 != Blocks.field_150475_bE && block1 != Blocks.field_150340_R && block1 != Blocks.field_150484_ah && block1 != Blocks.field_150339_S) {
-+                  if (this.field_145850_b.func_180495_p(new BlockPos(i2, l1, j1)).isBeaconBase(this.field_145850_b, new BlockPos(i2, l1, j1), this.func_174877_v())) {
++                  if (!this.field_145850_b.func_180495_p(new BlockPos(i2, l1, j1)).isBeaconBase(this.field_145850_b, new BlockPos(i2, l1, j1), this.func_174877_v())) {
                       flag1 = false;
                       break;
                    }

--- a/patches/minecraft/net/minecraft/world/WorldEntitySpawner.java.patch
+++ b/patches/minecraft/net/minecraft/world/WorldEntitySpawner.java.patch
@@ -56,7 +56,7 @@
           default:
              IBlockState iblockstate1 = p_209382_1_.func_180495_p(p_209382_2_.func_177977_b());
 -            if (iblockstate1.func_185896_q() || p_209382_3_ != null && EntitySpawnPlacementRegistry.func_209345_a(p_209382_3_, iblockstate1)) {
-+            if (iblockstate.canCreatureSpawn(p_209382_1_, p_209382_2_, p_209382_0_, p_209382_3_)) {
++            if (iblockstate1.canCreatureSpawn(p_209382_1_, p_209382_2_, p_209382_0_, p_209382_3_)) {
                 Block block = iblockstate1.func_177230_c();
                 boolean flag = block != Blocks.field_150357_h && block != Blocks.field_180401_cv;
                 return flag && func_206851_a(iblockstate, ifluidstate) && func_206851_a(p_209382_1_.func_180495_p(p_209382_2_.func_177984_a()), p_209382_1_.func_204610_c(p_209382_2_.func_177984_a()));

--- a/patches/minecraft/net/minecraft/world/WorldEntitySpawner.java.patch
+++ b/patches/minecraft/net/minecraft/world/WorldEntitySpawner.java.patch
@@ -56,7 +56,7 @@
           default:
              IBlockState iblockstate1 = p_209382_1_.func_180495_p(p_209382_2_.func_177977_b());
 -            if (iblockstate1.func_185896_q() || p_209382_3_ != null && EntitySpawnPlacementRegistry.func_209345_a(p_209382_3_, iblockstate1)) {
-+            if (iblockstate1.canCreatureSpawn(p_209382_1_, p_209382_2_, p_209382_0_, p_209382_3_)) {
++            if (iblockstate1.canCreatureSpawn(p_209382_1_, p_209382_2_.func_177977_b(), p_209382_0_, p_209382_3_)) {
                 Block block = iblockstate1.func_177230_c();
                 boolean flag = block != Blocks.field_150357_h && block != Blocks.field_180401_cv;
                 return flag && func_206851_a(iblockstate, ifluidstate) && func_206851_a(p_209382_1_.func_180495_p(p_209382_2_.func_177984_a()), p_209382_1_.func_204610_c(p_209382_2_.func_177984_a()));


### PR DESCRIPTION
See #5485 and #5486 .

Fixes missing drops from partially-grown crops, ground-based mob spawning not working and creative tab tooltips not displaying.

Can be updated with more minor fixes if there's anything else that needs looking into.

---

**Updates:**
* Fixes beacon base check being inverted