### PR TITLE
[1.13.2] Migrate SeedEntry to LootTable

### DIFF
--- a/patches/minecraft/net/minecraft/block/BlockTallGrass.java.patch
+++ b/patches/minecraft/net/minecraft/block/BlockTallGrass.java.patch
@@ -18,7 +18,7 @@
     }
  
     public int func_196251_a(IBlockState p_196251_1_, int p_196251_2_, World p_196251_3_, BlockPos p_196251_4_, Random p_196251_5_) {
-@@ -64,4 +64,18 @@
+@@ -64,4 +64,24 @@
     public Block.EnumOffsetType func_176218_Q() {
        return Block.EnumOffsetType.XYZ;
     }
@@ -31,9 +31,15 @@
 +
 +   @Override
 +   public void getDrops(IBlockState state, net.minecraft.util.NonNullList<ItemStack> drops, World world, BlockPos pos, int fortune) {
-+      if (world.field_73012_v.nextInt(8) != 0) return;
-+      ItemStack seed = net.minecraftforge.common.ForgeHooks.getGrassSeed(world.field_73012_v, fortune);
-+      if (!seed.func_190926_b())
-+         drops.add(seed);
++      if (world instanceof net.minecraft.world.WorldServer) {
++         net.minecraft.world.storage.loot.LootContext context = new net.minecraft.world.storage.loot.LootContext.Builder((net.minecraft.world.WorldServer) world).func_186470_a(harvesters.get()).func_186471_a();
++         java.util.List<ItemStack> poll = world.func_73046_m().func_200249_aQ().func_186521_a(GRASS_SEEDS).func_186462_a(world.field_73012_v, context);
++         if (!poll.isEmpty()) {
++            java.util.Collections.shuffle(poll, world.field_73012_v);
++            drops.add(poll.get(0));
++         }
++      }
 +   }
++
++   private static final net.minecraft.util.ResourceLocation GRASS_SEEDS = new net.minecraft.util.ResourceLocation("forge", "grass_seeds");
  }

--- a/src/main/java/net/minecraftforge/common/ForgeHooks.java
+++ b/src/main/java/net/minecraftforge/common/ForgeHooks.java
@@ -22,13 +22,10 @@ package net.minecraftforge.common;
 import java.lang.reflect.Field;
 import java.net.URI;
 import java.net.URISyntaxException;
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Deque;
 import java.util.HashSet;
-import java.util.List;
-import java.util.Random;
 import java.util.Set;
 import java.util.function.Function;
 import java.util.function.Predicate;
@@ -150,38 +147,6 @@ public class ForgeHooks
 {
     private static final Logger LOGGER = LogManager.getLogger();
     private static final Marker FORGEHOOKS = MarkerManager.getMarker("FORGEHOOKS");
-    //TODO: Loot tables?
-    static class SeedEntry extends WeightedRandom.Item
-    {
-        @Nonnull
-        public final ItemStack seed;
-        public SeedEntry(@Nonnull ItemStack seed, int weight)
-        {
-            super(weight);
-            this.seed = seed;
-        }
-        @Nonnull
-        public ItemStack getStack(Random rand, int fortune)
-        {
-            return seed.copy();
-        }
-    }
-    static final List<SeedEntry> seedList = new ArrayList<SeedEntry>();
-
-    @Nonnull
-    public static ItemStack getGrassSeed(Random rand, int fortune)
-    {
-        if (seedList.size() == 0)
-        {
-            return ItemStack.EMPTY; //Some bad mods hack in and empty our list, so lets not hard crash -.-
-        }
-        SeedEntry entry = WeightedRandom.getRandomItem(rand, seedList);
-        if (entry == null || entry.seed.isEmpty())
-        {
-            return ItemStack.EMPTY;
-        }
-        return entry.getStack(rand, fortune);
-    }
 
     public static boolean canHarvestBlock(@Nonnull IBlockState state, @Nonnull EntityPlayer player, @Nonnull IBlockReader world, @Nonnull BlockPos pos)
     {

--- a/src/main/java/net/minecraftforge/common/ForgeMod.java
+++ b/src/main/java/net/minecraftforge/common/ForgeMod.java
@@ -40,8 +40,10 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import net.minecraft.nbt.NBTTagCompound;
+import net.minecraft.world.storage.loot.functions.LootFunctionManager;
 import net.minecraft.world.storage.SaveHandler;
 import net.minecraft.world.storage.WorldInfo;
+import net.minecraftforge.common.loot.functions.FortuneEnchantBonus;
 import net.minecraftforge.common.model.animation.CapabilityAnimation;
 import net.minecraftforge.energy.CapabilityEnergy;
 import net.minecraftforge.fluids.capability.CapabilityFluidHandler;
@@ -122,6 +124,7 @@ public class ForgeMod implements WorldPersistenceHooks.WorldPersistenceHook
         CapabilityEnergy.register();
         MinecraftForge.EVENT_BUS.register(MinecraftForge.INTERNAL_HANDLER);
         MinecraftForge.EVENT_BUS.register(this);
+        LootFunctionManager.registerFunction(new FortuneEnchantBonus.Serializer());
 
         if (!ForgeMod.disableVersionCheck)
         {

--- a/src/main/java/net/minecraftforge/common/MinecraftForge.java
+++ b/src/main/java/net/minecraftforge/common/MinecraftForge.java
@@ -22,15 +22,11 @@ package net.minecraftforge.common;
 import net.minecraftforge.eventbus.api.IEventBus;
 
 import net.minecraft.crash.CrashReport;
-import net.minecraft.item.ItemStack;
-import net.minecraftforge.common.ForgeHooks.SeedEntry;
 import net.minecraftforge.versions.forge.ForgeVersion;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.Marker;
 import org.apache.logging.log4j.MarkerManager;
-
-import javax.annotation.Nonnull;
 
 public class MinecraftForge
 {
@@ -47,24 +43,6 @@ public class MinecraftForge
     static final ForgeInternalHandler INTERNAL_HANDLER = new ForgeInternalHandler();
     private static final Logger LOGGER = LogManager.getLogger();
     private static final Marker FORGE = MarkerManager.getMarker("FORGE");
-
-    /**
-     * Register a new seed to be dropped when breaking tall grass.
-     *
-     * @param seed The item to drop as a seed.
-     * @param weight The relative probability of the seeds,
-     *               where wheat seeds are 10.
-     *
-     * Note: These functions may be going away soon, we're looking into loot tables....
-     */
-    public static void addGrassSeed(@Nonnull ItemStack seed, int weight)
-    {
-        addGrassSeed(new SeedEntry(seed, weight));
-    }
-    public static void addGrassSeed(SeedEntry seed)
-    {
-        ForgeHooks.seedList.add(seed);
-    }
 
    /**
     * Method invoked by FML before any other mods are loaded.

--- a/src/main/java/net/minecraftforge/common/loot/functions/FortuneEnchantBonus.java
+++ b/src/main/java/net/minecraftforge/common/loot/functions/FortuneEnchantBonus.java
@@ -1,3 +1,22 @@
+/*
+ * Minecraft Forge
+ * Copyright (c) 2016-2019.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation version 2.1
+ * of the License.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
 package net.minecraftforge.common.loot.functions;
 
 import com.google.gson.JsonDeserializationContext;

--- a/src/main/java/net/minecraftforge/common/loot/functions/FortuneEnchantBonus.java
+++ b/src/main/java/net/minecraftforge/common/loot/functions/FortuneEnchantBonus.java
@@ -1,0 +1,65 @@
+package net.minecraftforge.common.loot.functions;
+
+import com.google.gson.JsonDeserializationContext;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonSerializationContext;
+import net.minecraft.enchantment.EnchantmentHelper;
+import net.minecraft.entity.Entity;
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.init.Enchantments;
+import net.minecraft.item.ItemStack;
+import net.minecraft.util.ResourceLocation;
+import net.minecraft.world.storage.loot.LootContext;
+import net.minecraft.world.storage.loot.conditions.LootCondition;
+import net.minecraft.world.storage.loot.functions.LootFunction;
+
+import java.util.Random;
+
+public class FortuneEnchantBonus extends LootFunction
+{
+    private final int multiplier, offset;
+
+    protected FortuneEnchantBonus(LootCondition[] conditions, int multiplier, int offset)
+    {
+        super(conditions);
+        this.multiplier = multiplier;
+        this.offset = offset;
+    }
+
+    @Override
+    public ItemStack apply(ItemStack stack, Random rand, LootContext context)
+    {
+        Entity player = context.getKillerPlayer();
+        if (player instanceof EntityPlayer)
+        {
+            int fortune = EnchantmentHelper.getEnchantmentLevel(Enchantments.FORTUNE, ((EntityPlayer) player).getHeldItemMainhand());
+            if (fortune > 0 && this.multiplier > 0 && this.offset > 0)
+            {
+                stack.grow(rand.nextInt(fortune * this.multiplier + this.offset));
+            }
+        }
+        return stack;
+    }
+
+    public static class Serializer extends LootFunction.Serializer<FortuneEnchantBonus>
+    {
+
+        public Serializer()
+        {
+            super(new ResourceLocation("forge", "fortune_enchant"), FortuneEnchantBonus.class);
+        }
+
+        @Override
+        public void serialize(JsonObject object, FortuneEnchantBonus theFunction, JsonSerializationContext context)
+        {
+            object.addProperty("multiplier", theFunction.multiplier);
+            object.addProperty("offset", theFunction.offset);
+        }
+
+        @Override
+        public FortuneEnchantBonus deserialize(JsonObject object, JsonDeserializationContext context, LootCondition[] conditions)
+        {
+            return new FortuneEnchantBonus(conditions, object.get("multiplier").getAsInt(), object.get("offset").getAsInt());
+        }
+    }
+}

--- a/src/main/resources/data/forge/loot_tables/grass_seeds.json
+++ b/src/main/resources/data/forge/loot_tables/grass_seeds.json
@@ -1,0 +1,27 @@
+{
+  "pools": [
+    {
+      "name": "default_grass_drop",
+      "conditions": [
+        {
+          "condition": "random_chance",
+          "chance": 0.125
+        }
+      ],
+      "rolls": 1,
+      "entries": [
+        {
+          "type": "item",
+          "name": "minecraft:wheat_seeds",
+          "functions": [
+            {
+              "function": "forge:fortune_enchant",
+              "multiplier": 2,
+              "offset": 1
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
1.13.2 version of #5496 but without backward compatibilities.  
Rationale is stated below (copied from #5496):
> Given the fact that, in 1.14 snapshots, all block drops will use loot table, it would be a good start to deprecate the old `SeedEntry` system and migrate to LootTable (which seems to be the plan according to the comments left in related classes) ahead of time right now. Hence here is a PR.

Summary:
  * `getGrassSeed` is no more; `BlockTallGrass.getDrops` now draws `ItemStack` from LootTable `forge:grass_seeds`.
  * Two `MinecraftForge.addGrassSeed` are completely purged.
  * `ForgeHooks.SeedEntry` is completely removed.
  * As a bonus, in order to correctly implement the behavior of fortune bonus, a new `LootFunction` is provided - `net.minecraftforge.common.loot.functions.FortuneEnchantBonus`.
    * It is registered in `ForgeMod.preInit`.
    * Has two parameters: `multiplier` and `offset`.
    * Behavior: if the harvest player exists, and fortune level, `multiplier` and `offset` are all larger than zero, then the final `ItemStack` size will increase by `Random.nextInt(fortuneLevel * multiplier + offset)`.

Both issues mentioned in #5496 are still applicable here. Specifically:
  * Should we just add all `ItemStack`s generated from loot table to the drop list, instead of adding a single `ItemStack` instance?
  * As mentioned above, in order to correctly implement the fortune bonus, a new `LootFunction` is implemented, but the harvester's instance is still acquired from that `ThreadLocal<EntityPlayer> harvesters`. Is there still space for further improvements?