### PR TITLE
Fixes #5499 - World crashing on load

### DIFF
--- a/patches/minecraft/net/minecraft/world/dimension/DimensionType.java.patch
+++ b/patches/minecraft/net/minecraft/world/dimension/DimensionType.java.patch
@@ -52,7 +52,7 @@
     }
  
     public File func_212679_a(File p_212679_1_) {
-@@ -47,7 +59,7 @@
+@@ -47,11 +59,11 @@
     }
  
     public Dimension func_186070_d() {
@@ -61,6 +61,11 @@
     }
  
     public String toString() {
+-      return func_212678_a(this).toString();
++      return "DimensionType{" + func_212678_a(this) + "}";
+    }
+ 
+    @Nullable
 @@ -59,7 +71,21 @@
        return IRegistry.field_212622_k.func_148754_a(p_186069_0_ - -1);
     }


### PR DESCRIPTION
Super simple fix. `DimensionManager#REGISTRY` is cleared before re-registering dimensions in `DimensionManager#readRegistry`. Due to this, `DimensionType#toString` is being called before registering the dimension, for logging purposes; `DimensionType#toString` works by searching for itself in the `DimensionManager#REGISTRY` which has just been cleared, hence NPE