### PR TITLE
Invalidate tile entities that are queued for removal

### DIFF
--- a/patches/minecraft/net/minecraft/world/World.java.patch
+++ b/patches/minecraft/net/minecraft/world/World.java.patch
@@ -704,7 +704,7 @@
          }
          else
          {
-@@ -2289,6 +2483,7 @@
+@@ -2289,11 +2483,13 @@
  
              this.func_175726_f(p_175713_1_).func_177425_e(p_175713_1_);
          }
@@ -712,7 +712,13 @@
      }
  
      public void func_147457_a(TileEntity p_147457_1_)
-@@ -2315,7 +2510,7 @@
+     {
+         this.field_147483_b.add(p_147457_1_);
++        p_147457_1_.func_145843_s(); // Forge: invalidate TE promptly as removal happens later
+     }
+ 
+     public boolean func_175665_u(BlockPos p_175665_1_)
+@@ -2315,7 +2511,7 @@
              if (chunk1 != null && !chunk1.func_76621_g())
              {
                  IBlockState iblockstate1 = this.func_180495_p(p_175677_1_);
@@ -721,7 +727,7 @@
              }
              else
              {
-@@ -2338,6 +2533,7 @@
+@@ -2338,6 +2534,7 @@
      {
          this.field_72985_G = p_72891_1_;
          this.field_72992_H = p_72891_2_;
@@ -729,7 +735,7 @@
      }
  
      public void func_72835_b()
-@@ -2347,6 +2543,11 @@
+@@ -2347,6 +2544,11 @@
  
      protected void func_72947_a()
      {
@@ -741,7 +747,7 @@
          if (this.field_72986_A.func_76059_o())
          {
              this.field_73004_o = 1.0F;
-@@ -2360,6 +2561,11 @@
+@@ -2360,6 +2562,11 @@
  
      protected void func_72979_l()
      {
@@ -753,7 +759,7 @@
          if (this.field_73011_w.func_191066_m())
          {
              if (!this.field_72995_K)
-@@ -2484,6 +2690,11 @@
+@@ -2484,6 +2691,11 @@
  
      public boolean func_175670_e(BlockPos p_175670_1_, boolean p_175670_2_)
      {
@@ -765,7 +771,7 @@
          Biome biome = this.func_180494_b(p_175670_1_);
          float f = biome.func_180626_a(p_175670_1_);
  
-@@ -2525,6 +2736,11 @@
+@@ -2525,6 +2737,11 @@
  
      public boolean func_175708_f(BlockPos p_175708_1_, boolean p_175708_2_)
      {
@@ -777,7 +783,7 @@
          Biome biome = this.func_180494_b(p_175708_1_);
          float f = biome.func_180626_a(p_175708_1_);
  
-@@ -2542,7 +2758,7 @@
+@@ -2542,7 +2759,7 @@
              {
                  IBlockState iblockstate1 = this.func_180495_p(p_175708_1_);
  
@@ -786,7 +792,7 @@
                  {
                      return true;
                  }
-@@ -2574,10 +2790,10 @@
+@@ -2574,10 +2791,10 @@
          else
          {
              IBlockState iblockstate1 = this.func_180495_p(p_175638_1_);
@@ -800,7 +806,7 @@
              {
                  k2 = 1;
              }
-@@ -2589,7 +2805,7 @@
+@@ -2589,7 +2806,7 @@
  
              if (k2 >= 15)
              {
@@ -809,7 +815,7 @@
              }
              else if (j2 >= 14)
              {
-@@ -2630,12 +2846,13 @@
+@@ -2630,12 +2847,13 @@
  
      public boolean func_180500_c(EnumSkyBlock p_180500_1_, BlockPos p_180500_2_)
      {
@@ -824,7 +830,7 @@
              int j2 = 0;
              int k2 = 0;
              this.field_72984_F.func_76320_a("getBrightness");
-@@ -2673,7 +2890,7 @@
+@@ -2673,7 +2891,7 @@
                              int l5 = MathHelper.func_76130_a(k4 - k3);
                              int i6 = MathHelper.func_76130_a(l4 - l3);
  
@@ -833,7 +839,7 @@
                              {
                                  BlockPos.PooledMutableBlockPos blockpos$pooledmutableblockpos = BlockPos.PooledMutableBlockPos.func_185346_s();
  
-@@ -2683,7 +2900,8 @@
+@@ -2683,7 +2901,8 @@
                                      int k6 = k4 + enumfacing.func_96559_d();
                                      int l6 = l4 + enumfacing.func_82599_e();
                                      blockpos$pooledmutableblockpos.func_181079_c(j6, k6, l6);
@@ -843,7 +849,7 @@
                                      j5 = this.func_175642_b(p_180500_1_, blockpos$pooledmutableblockpos);
  
                                      if (j5 == i5 - i7 && k2 < this.field_72994_J.length)
-@@ -2725,7 +2943,7 @@
+@@ -2725,7 +2944,7 @@
                          int j9 = Math.abs(i8 - l3);
                          boolean flag = k2 < this.field_72994_J.length - 6;
  
@@ -852,7 +858,7 @@
                          {
                              if (this.func_175642_b(p_180500_1_, blockpos2.func_177976_e()) < k8)
                              {
-@@ -2791,10 +3009,10 @@
+@@ -2791,10 +3010,10 @@
      public List<Entity> func_175674_a(@Nullable Entity p_175674_1_, AxisAlignedBB p_175674_2_, @Nullable Predicate <? super Entity > p_175674_3_)
      {
          List<Entity> list = Lists.<Entity>newArrayList();
@@ -867,7 +873,7 @@
  
          for (int j3 = j2; j3 <= k2; ++j3)
          {
-@@ -2847,10 +3065,10 @@
+@@ -2847,10 +3066,10 @@
  
      public <T extends Entity> List<T> func_175647_a(Class <? extends T > p_175647_1_, AxisAlignedBB p_175647_2_, @Nullable Predicate <? super T > p_175647_3_)
      {
@@ -882,7 +888,7 @@
          List<T> list = Lists.<T>newArrayList();
  
          for (int j3 = j2; j3 < k2; ++j3)
-@@ -2930,11 +3148,13 @@
+@@ -2930,11 +3149,13 @@
  
      public void func_175650_b(Collection<Entity> p_175650_1_)
      {
@@ -899,7 +905,7 @@
          }
      }
  
-@@ -2958,7 +3178,7 @@
+@@ -2958,7 +3179,7 @@
          }
          else
          {
@@ -908,7 +914,7 @@
          }
      }
  
-@@ -3042,7 +3262,7 @@
+@@ -3042,7 +3263,7 @@
      public int func_175651_c(BlockPos p_175651_1_, EnumFacing p_175651_2_)
      {
          IBlockState iblockstate1 = this.func_180495_p(p_175651_1_);
@@ -917,7 +923,7 @@
      }
  
      public boolean func_175640_z(BlockPos p_175640_1_)
-@@ -3208,6 +3428,8 @@
+@@ -3208,6 +3429,8 @@
                      d2 *= ((Double)MoreObjects.firstNonNull(p_184150_11_.apply(entityplayer1), Double.valueOf(1.0D))).doubleValue();
                  }
  
@@ -926,7 +932,7 @@
                  if ((p_184150_9_ < 0.0D || Math.abs(entityplayer1.field_70163_u - p_184150_3_) < p_184150_9_ * p_184150_9_) && (p_184150_7_ < 0.0D || d1 < d2 * d2) && (d0 == -1.0D || d1 < d0))
                  {
                      d0 = d1;
-@@ -3269,7 +3491,7 @@
+@@ -3269,7 +3492,7 @@
  
      public long func_72905_C()
      {
@@ -935,7 +941,7 @@
      }
  
      public long func_82737_E()
-@@ -3279,17 +3501,17 @@
+@@ -3279,17 +3502,17 @@
  
      public long func_72820_D()
      {
@@ -956,7 +962,7 @@
  
          if (!this.func_175723_af().func_177746_a(blockpos1))
          {
-@@ -3301,7 +3523,7 @@
+@@ -3301,7 +3524,7 @@
  
      public void func_175652_B(BlockPos p_175652_1_)
      {
@@ -965,7 +971,7 @@
      }
  
      @SideOnly(Side.CLIENT)
-@@ -3321,12 +3543,18 @@
+@@ -3321,12 +3544,18 @@
  
          if (!this.field_72996_f.contains(p_72897_1_))
          {
@@ -984,7 +990,7 @@
          return true;
      }
  
-@@ -3428,8 +3656,7 @@
+@@ -3428,8 +3657,7 @@
  
      public boolean func_180502_D(BlockPos p_180502_1_)
      {
@@ -994,7 +1000,7 @@
      }
  
      @Nullable
-@@ -3490,12 +3717,12 @@
+@@ -3490,12 +3718,12 @@
  
      public int func_72800_K()
      {
@@ -1009,7 +1015,7 @@
      }
  
      public Random func_72843_D(int p_72843_1_, int p_72843_2_, int p_72843_3_)
-@@ -3539,7 +3766,7 @@
+@@ -3539,7 +3767,7 @@
      @SideOnly(Side.CLIENT)
      public double func_72919_O()
      {
@@ -1018,7 +1024,7 @@
      }
  
      public void func_175715_c(int p_175715_1_, BlockPos p_175715_2_, int p_175715_3_)
-@@ -3573,7 +3800,7 @@
+@@ -3573,7 +3801,7 @@
  
      public void func_175666_e(BlockPos p_175666_1_, Block p_175666_2_)
      {
@@ -1027,7 +1033,7 @@
          {
              BlockPos blockpos1 = p_175666_1_.func_177972_a(enumfacing);
  
-@@ -3581,18 +3808,15 @@
+@@ -3581,18 +3809,15 @@
              {
                  IBlockState iblockstate1 = this.func_180495_p(blockpos1);
  
@@ -1050,7 +1056,7 @@
                      }
                  }
              }
-@@ -3658,6 +3882,124 @@
+@@ -3658,6 +3883,124 @@
          return j2 >= -128 && j2 <= 128 && k2 >= -128 && k2 <= 128;
      }
  


### PR DESCRIPTION
Somewhat of a followup to #4811.

Generally, when tile entities are removed, they are invalidated. However, this is not currently the case for tile entities that are removed by a chunk unloading. In that case, the tile entities are just added to a queue, and are removed directly from the worlds TE lists later during ticking.

While this removal is now done prior to ticking the affected TEs, it still causes issues as, as mentioned in the linked PR, the tile entity lists used for rendering are not perfectly synchronised with the world's. This results in the tile entity being accessed while not being in a loaded chunk, which can cause client-side crashes due to the associated block missing. In particular, this can be seen in the chunk unload/load cycle which occurs when respawning. This can be consistently reproduced with a seperated client/server setup using the test example given for #4811 [here](https://gist.github.com/InsomniaKitten/2cef6b0a15bf4f1a86b4a6dd79da8c4b).

This PR adds a call to `TileEntity.invalidate()` to `World.markTileEntityForRemoval()` to resolve this issue.