### PR TITLE
Add method to IResourcePack to hide it entirely from the UI

### DIFF
--- a/patches/minecraft/net/minecraft/client/Minecraft.java.patch
+++ b/patches/minecraft/net/minecraft/client/Minecraft.java.patch
@@ -1,5 +1,14 @@
 --- a/net/minecraft/client/Minecraft.java
 +++ b/net/minecraft/client/Minecraft.java
+@@ -314,7 +314,7 @@
+             supplier = p_211818_2_;
+          }
+ 
+-         return new ResourcePackInfoClient(p_211818_0_, p_211818_1_, supplier, p_211818_3_, p_211818_4_, p_211818_5_);
++         return new ResourcePackInfoClient(p_211818_0_, p_211818_1_, supplier, p_211818_3_, p_211818_4_, p_211818_5_, p_211818_3_.isHidden());
+       });
+       this.field_110448_aq.func_198982_a(this.field_195554_ax);
+       this.field_110448_aq.func_198982_a(new FolderPackFinder(this.field_130070_K));
 @@ -322,7 +322,6 @@
        this.field_152355_az = (new YggdrasilAuthenticationService(this.field_110453_aa, UUID.randomUUID().toString())).createMinecraftSessionService();
        this.field_71449_j = p_i45547_1_.field_178745_a.field_178752_a;

--- a/patches/minecraft/net/minecraft/client/gui/GuiScreenResourcePacks.java.patch
+++ b/patches/minecraft/net/minecraft/client/gui/GuiScreenResourcePacks.java.patch
@@ -1,0 +1,19 @@
+--- a/net/minecraft/client/gui/GuiScreenResourcePacks.java
++++ b/net/minecraft/client/gui/GuiScreenResourcePacks.java
+@@ -84,12 +84,15 @@
+          resourcepacklist.func_198983_a();
+          List<ResourcePackInfoClient> list = Lists.newArrayList(resourcepacklist.func_198978_b());
+          list.removeAll(resourcepacklist.func_198980_d());
++         list.removeIf(net.minecraft.resources.ResourcePackInfo::isHidden); // Forge: Hide some resource packs from the UI entirely
+ 
+          for(ResourcePackInfoClient resourcepackinfoclient : list) {
+             this.field_146970_i.func_195095_a(new ResourcePackListEntryFound(this, resourcepackinfoclient));
+          }
+ 
+-         for(ResourcePackInfoClient resourcepackinfoclient1 : Lists.reverse(Lists.newArrayList(resourcepacklist.func_198980_d()))) {
++         java.util.Collection<ResourcePackInfoClient> enabledList = resourcepacklist.func_198980_d();
++         enabledList.removeIf(net.minecraft.resources.ResourcePackInfo::isHidden); // Forge: Hide some resource packs from the UI entirely
++         for(ResourcePackInfoClient resourcepackinfoclient1 : Lists.reverse(Lists.newArrayList(enabledList))) {
+             this.field_146967_r.func_195095_a(new ResourcePackListEntryFound(this, resourcepackinfoclient1));
+          }
+       }

--- a/patches/minecraft/net/minecraft/client/resources/ResourcePackInfoClient.java.patch
+++ b/patches/minecraft/net/minecraft/client/resources/ResourcePackInfoClient.java.patch
@@ -1,0 +1,28 @@
+--- a/net/minecraft/client/resources/ResourcePackInfoClient.java
++++ b/net/minecraft/client/resources/ResourcePackInfoClient.java
+@@ -24,7 +24,11 @@
+    private ResourceLocation field_195810_b;
+ 
+    public ResourcePackInfoClient(String p_i48113_1_, boolean p_i48113_2_, Supplier<IResourcePack> p_i48113_3_, IResourcePack p_i48113_4_, PackMetadataSection p_i48113_5_, ResourcePackInfo.Priority p_i48113_6_) {
+-      super(p_i48113_1_, p_i48113_2_, p_i48113_3_, p_i48113_4_, p_i48113_5_, p_i48113_6_);
++	  this(p_i48113_1_, p_i48113_2_, p_i48113_3_, p_i48113_4_, p_i48113_5_, p_i48113_6_, false);
++   }
++
++   public ResourcePackInfoClient(String p_i48113_1_, boolean p_i48113_2_, Supplier<IResourcePack> p_i48113_3_, IResourcePack p_i48113_4_, PackMetadataSection p_i48113_5_, ResourcePackInfo.Priority p_i48113_6_, boolean hidden) {
++      super(p_i48113_1_, p_i48113_2_, p_i48113_3_, p_i48113_4_, p_i48113_5_, p_i48113_6_, hidden);
+       NativeImage nativeimage = null;
+ 
+       try (InputStream inputstream = p_i48113_4_.func_195763_b("pack.png")) {
+@@ -37,7 +41,11 @@
+    }
+ 
+    public ResourcePackInfoClient(String p_i48114_1_, boolean p_i48114_2_, Supplier<IResourcePack> p_i48114_3_, ITextComponent p_i48114_4_, ITextComponent p_i48114_5_, PackCompatibility p_i48114_6_, ResourcePackInfo.Priority p_i48114_7_, boolean p_i48114_8_, @Nullable NativeImage p_i48114_9_) {
+-      super(p_i48114_1_, p_i48114_2_, p_i48114_3_, p_i48114_4_, p_i48114_5_, p_i48114_6_, p_i48114_7_, p_i48114_8_);
++      this(p_i48114_1_, p_i48114_2_, p_i48114_3_, p_i48114_4_, p_i48114_5_, p_i48114_6_, p_i48114_7_, p_i48114_8_, p_i48114_9_, false);
++   }
++
++   public ResourcePackInfoClient(String p_i48114_1_, boolean p_i48114_2_, Supplier<IResourcePack> p_i48114_3_, ITextComponent p_i48114_4_, ITextComponent p_i48114_5_, PackCompatibility p_i48114_6_, ResourcePackInfo.Priority p_i48114_7_, boolean p_i48114_8_, @Nullable NativeImage p_i48114_9_, boolean hidden) {
++      super(p_i48114_1_, p_i48114_2_, p_i48114_3_, p_i48114_4_, p_i48114_5_, p_i48114_6_, p_i48114_7_, p_i48114_8_, hidden);
+       this.field_195809_a = p_i48114_9_;
+    }
+ 

--- a/patches/minecraft/net/minecraft/client/resources/ResourcePackInfoClient.java.patch
+++ b/patches/minecraft/net/minecraft/client/resources/ResourcePackInfoClient.java.patch
@@ -1,8 +1,10 @@
 --- a/net/minecraft/client/resources/ResourcePackInfoClient.java
 +++ b/net/minecraft/client/resources/ResourcePackInfoClient.java
-@@ -24,7 +24,11 @@
+@@ -23,8 +23,13 @@
+    @Nullable
     private ResourceLocation field_195810_b;
  
++   @Deprecated
     public ResourcePackInfoClient(String p_i48113_1_, boolean p_i48113_2_, Supplier<IResourcePack> p_i48113_3_, IResourcePack p_i48113_4_, PackMetadataSection p_i48113_5_, ResourcePackInfo.Priority p_i48113_6_) {
 -      super(p_i48113_1_, p_i48113_2_, p_i48113_3_, p_i48113_4_, p_i48113_5_, p_i48113_6_);
 +	  this(p_i48113_1_, p_i48113_2_, p_i48113_3_, p_i48113_4_, p_i48113_5_, p_i48113_6_, false);
@@ -13,9 +15,11 @@
        NativeImage nativeimage = null;
  
        try (InputStream inputstream = p_i48113_4_.func_195763_b("pack.png")) {
-@@ -37,7 +41,11 @@
+@@ -36,8 +41,13 @@
+       this.field_195809_a = nativeimage;
     }
  
++   @Deprecated
     public ResourcePackInfoClient(String p_i48114_1_, boolean p_i48114_2_, Supplier<IResourcePack> p_i48114_3_, ITextComponent p_i48114_4_, ITextComponent p_i48114_5_, PackCompatibility p_i48114_6_, ResourcePackInfo.Priority p_i48114_7_, boolean p_i48114_8_, @Nullable NativeImage p_i48114_9_) {
 -      super(p_i48114_1_, p_i48114_2_, p_i48114_3_, p_i48114_4_, p_i48114_5_, p_i48114_6_, p_i48114_7_, p_i48114_8_);
 +      this(p_i48114_1_, p_i48114_2_, p_i48114_3_, p_i48114_4_, p_i48114_5_, p_i48114_6_, p_i48114_7_, p_i48114_8_, p_i48114_9_, false);

--- a/patches/minecraft/net/minecraft/resources/IResourcePack.java.patch
+++ b/patches/minecraft/net/minecraft/resources/IResourcePack.java.patch
@@ -1,0 +1,11 @@
+--- a/net/minecraft/resources/IResourcePack.java
++++ b/net/minecraft/resources/IResourcePack.java
+@@ -12,7 +12,7 @@
+ import net.minecraftforge.api.distmarker.Dist;
+ import net.minecraftforge.api.distmarker.OnlyIn;
+ 
+-public interface IResourcePack extends Closeable {
++public interface IResourcePack extends Closeable, net.minecraftforge.client.extensions.IForgeResourcePack {
+    @OnlyIn(Dist.CLIENT)
+    InputStream func_195763_b(String p_195763_1_) throws IOException;
+ 

--- a/patches/minecraft/net/minecraft/resources/ResourcePackInfo.java.patch
+++ b/patches/minecraft/net/minecraft/resources/ResourcePackInfo.java.patch
@@ -8,7 +8,7 @@
  
     @Nullable
     public static <T extends ResourcePackInfo> T func_195793_a(String p_195793_0_, boolean p_195793_1_, Supplier<IResourcePack> p_195793_2_, ResourcePackInfo.IFactory<T> p_195793_3_, ResourcePackInfo.Priority p_195793_4_) {
-@@ -51,22 +52,33 @@
+@@ -51,9 +52,14 @@
  
        return (T)null;
     }
@@ -17,16 +17,15 @@
 +   @Deprecated
     public ResourcePackInfo(String p_i47907_1_, boolean p_i47907_2_, Supplier<IResourcePack> p_i47907_3_, ITextComponent p_i47907_4_, ITextComponent p_i47907_5_, PackCompatibility p_i47907_6_, ResourcePackInfo.Priority p_i47907_7_, boolean p_i47907_8_) {
 -      this.field_195800_b = p_i47907_1_;
--      this.field_195801_c = p_i47907_3_;
 +      this(p_i47907_1_, p_i47907_2_, p_i47907_3_, p_i47907_4_, p_i47907_5_, p_i47907_6_, p_i47907_7_, p_i47907_8_, false);
 +   }
 +
-+   public ResourcePackInfo(String nameIn, boolean p_i47907_2_, Supplier<IResourcePack> resourcePackSupplierIn, ITextComponent p_i47907_4_, ITextComponent p_i47907_5_, PackCompatibility p_i47907_6_, ResourcePackInfo.Priority p_i47907_7_, boolean p_i47907_8_, boolean hidden) {
-+      this.field_195800_b = nameIn;
-+      this.field_195801_c = resourcePackSupplierIn;
++   public ResourcePackInfo(String namp_i47907_1_, boolean p_i47907_2_, Supplier<IResourcePack> p_i47907_3_, ITextComponent p_i47907_4_, ITextComponent p_i47907_5_, PackCompatibility p_i47907_6_, ResourcePackInfo.Priority p_i47907_7_, boolean p_i47907_8_, boolean hidden) {
++      this.field_195800_b = namp_i47907_1_;
+       this.field_195801_c = p_i47907_3_;
        this.field_195802_d = p_i47907_4_;
        this.field_195803_e = p_i47907_5_;
-       this.field_195804_f = p_i47907_6_;
+@@ -61,12 +67,18 @@
        this.field_195806_h = p_i47907_2_;
        this.field_195805_g = p_i47907_7_;
        this.field_195807_i = p_i47907_8_;

--- a/patches/minecraft/net/minecraft/resources/ResourcePackInfo.java.patch
+++ b/patches/minecraft/net/minecraft/resources/ResourcePackInfo.java.patch
@@ -1,0 +1,57 @@
+--- a/net/minecraft/resources/ResourcePackInfo.java
++++ b/net/minecraft/resources/ResourcePackInfo.java
+@@ -29,6 +29,7 @@
+    private final ResourcePackInfo.Priority field_195805_g;
+    private final boolean field_195806_h;
+    private final boolean field_195807_i;
++   public final boolean hidden; // Forge: Allow packs to be hidden from the UI entirely
+ 
+    @Nullable
+    public static <T extends ResourcePackInfo> T func_195793_a(String p_195793_0_, boolean p_195793_1_, Supplier<IResourcePack> p_195793_2_, ResourcePackInfo.IFactory<T> p_195793_3_, ResourcePackInfo.Priority p_195793_4_) {
+@@ -51,22 +52,33 @@
+ 
+       return (T)null;
+    }
+-
++   
++   @Deprecated
+    public ResourcePackInfo(String p_i47907_1_, boolean p_i47907_2_, Supplier<IResourcePack> p_i47907_3_, ITextComponent p_i47907_4_, ITextComponent p_i47907_5_, PackCompatibility p_i47907_6_, ResourcePackInfo.Priority p_i47907_7_, boolean p_i47907_8_) {
+-      this.field_195800_b = p_i47907_1_;
+-      this.field_195801_c = p_i47907_3_;
++      this(p_i47907_1_, p_i47907_2_, p_i47907_3_, p_i47907_4_, p_i47907_5_, p_i47907_6_, p_i47907_7_, p_i47907_8_, false);
++   }
++
++   public ResourcePackInfo(String nameIn, boolean p_i47907_2_, Supplier<IResourcePack> resourcePackSupplierIn, ITextComponent p_i47907_4_, ITextComponent p_i47907_5_, PackCompatibility p_i47907_6_, ResourcePackInfo.Priority p_i47907_7_, boolean p_i47907_8_, boolean hidden) {
++      this.field_195800_b = nameIn;
++      this.field_195801_c = resourcePackSupplierIn;
+       this.field_195802_d = p_i47907_4_;
+       this.field_195803_e = p_i47907_5_;
+       this.field_195804_f = p_i47907_6_;
+       this.field_195806_h = p_i47907_2_;
+       this.field_195805_g = p_i47907_7_;
+       this.field_195807_i = p_i47907_8_;
++      this.hidden = hidden;
+    }
+ 
++   @Deprecated
+    public ResourcePackInfo(String p_i47908_1_, boolean p_i47908_2_, Supplier<IResourcePack> p_i47908_3_, IResourcePack p_i47908_4_, PackMetadataSection p_i47908_5_, ResourcePackInfo.Priority p_i47908_6_) {
+-      this(p_i47908_1_, p_i47908_2_, p_i47908_3_, new TextComponentString(p_i47908_4_.func_195762_a()), p_i47908_5_.func_198963_a(), PackCompatibility.func_198969_a(p_i47908_5_.func_198962_b()), p_i47908_6_, false);
++      this(p_i47908_1_, p_i47908_2_, p_i47908_3_, p_i47908_4_, p_i47908_5_, p_i47908_6_, false);
+    }
+ 
++   public ResourcePackInfo(String p_i47908_1_, boolean p_i47908_2_, Supplier<IResourcePack> p_i47908_3_, IResourcePack p_i47908_4_, PackMetadataSection p_i47908_5_, ResourcePackInfo.Priority p_i47908_6_, boolean hidden) {
++      this(p_i47908_1_, p_i47908_2_, p_i47908_3_, new TextComponentString(p_i47908_4_.func_195762_a()), p_i47908_5_.func_198963_a(), PackCompatibility.func_198969_a(p_i47908_5_.func_198962_b()), p_i47908_6_, false, hidden);
++   }
++
+    @OnlyIn(Dist.CLIENT)
+    public ITextComponent func_195789_b() {
+       return this.field_195802_d;
+@@ -106,6 +118,8 @@
+    public ResourcePackInfo.Priority func_195792_i() {
+       return this.field_195805_g;
+    }
++   
++   public boolean isHidden() { return hidden; }
+ 
+    public boolean equals(Object p_equals_1_) {
+       if (this == p_equals_1_) {

--- a/patches/minecraft/net/minecraft/resources/ResourcePackInfo.java.patch
+++ b/patches/minecraft/net/minecraft/resources/ResourcePackInfo.java.patch
@@ -40,7 +40,7 @@
     }
  
 +   public ResourcePackInfo(String p_i47908_1_, boolean p_i47908_2_, Supplier<IResourcePack> p_i47908_3_, IResourcePack p_i47908_4_, PackMetadataSection p_i47908_5_, ResourcePackInfo.Priority p_i47908_6_, boolean hidden) {
-+      this(p_i47908_1_, p_i47908_2_, p_i47908_3_, new TextComponentString(p_i47908_4_.func_195762_a()), p_i47908_5_.func_198963_a(), PackCompatibility.func_198969_a(p_i47908_5_.func_198962_b()), p_i47908_6_, false, hidden);
++      this(p_i47908_1_, p_i47908_2_, p_i47908_3_, new TextComponentString(p_i47908_4_.func_195762_a()), p_i47908_5_.func_198963_a(), PackCompatibility.func_198969_a(p_i47908_5_.func_198962_b()), p_i47908_6_, hidden, hidden);
 +   }
 +
     @OnlyIn(Dist.CLIENT)

--- a/patches/minecraft/net/minecraft/resources/ResourcePackInfo.java.patch
+++ b/patches/minecraft/net/minecraft/resources/ResourcePackInfo.java.patch
@@ -8,21 +8,19 @@
  
     @Nullable
     public static <T extends ResourcePackInfo> T func_195793_a(String p_195793_0_, boolean p_195793_1_, Supplier<IResourcePack> p_195793_2_, ResourcePackInfo.IFactory<T> p_195793_3_, ResourcePackInfo.Priority p_195793_4_) {
-@@ -52,8 +53,13 @@
+@@ -52,7 +53,12 @@
        return (T)null;
     }
  
 +   @Deprecated
     public ResourcePackInfo(String p_i47907_1_, boolean p_i47907_2_, Supplier<IResourcePack> p_i47907_3_, ITextComponent p_i47907_4_, ITextComponent p_i47907_5_, PackCompatibility p_i47907_6_, ResourcePackInfo.Priority p_i47907_7_, boolean p_i47907_8_) {
--      this.field_195800_b = p_i47907_1_;
 +      this(p_i47907_1_, p_i47907_2_, p_i47907_3_, p_i47907_4_, p_i47907_5_, p_i47907_6_, p_i47907_7_, p_i47907_8_, false);
 +   }
 +
-+   public ResourcePackInfo(String namp_i47907_1_, boolean p_i47907_2_, Supplier<IResourcePack> p_i47907_3_, ITextComponent p_i47907_4_, ITextComponent p_i47907_5_, PackCompatibility p_i47907_6_, ResourcePackInfo.Priority p_i47907_7_, boolean p_i47907_8_, boolean hidden) {
-+      this.field_195800_b = namp_i47907_1_;
++   public ResourcePackInfo(String p_i47907_1_, boolean p_i47907_2_, Supplier<IResourcePack> p_i47907_3_, ITextComponent p_i47907_4_, ITextComponent p_i47907_5_, PackCompatibility p_i47907_6_, ResourcePackInfo.Priority p_i47907_7_, boolean p_i47907_8_, boolean hidden) {
+       this.field_195800_b = p_i47907_1_;
        this.field_195801_c = p_i47907_3_;
        this.field_195802_d = p_i47907_4_;
-       this.field_195803_e = p_i47907_5_;
 @@ -61,12 +67,18 @@
        this.field_195806_h = p_i47907_2_;
        this.field_195805_g = p_i47907_7_;

--- a/patches/minecraft/net/minecraft/resources/ResourcePackInfo.java.patch
+++ b/patches/minecraft/net/minecraft/resources/ResourcePackInfo.java.patch
@@ -4,7 +4,7 @@
     private final ResourcePackInfo.Priority field_195805_g;
     private final boolean field_195806_h;
     private final boolean field_195807_i;
-+   public final boolean hidden; // Forge: Allow packs to be hidden from the UI entirely
++   private final boolean hidden; // Forge: Allow packs to be hidden from the UI entirely
  
     @Nullable
     public static <T extends ResourcePackInfo> T func_195793_a(String p_195793_0_, boolean p_195793_1_, Supplier<IResourcePack> p_195793_2_, ResourcePackInfo.IFactory<T> p_195793_3_, ResourcePackInfo.Priority p_195793_4_) {

--- a/patches/minecraft/net/minecraft/resources/ResourcePackInfo.java.patch
+++ b/patches/minecraft/net/minecraft/resources/ResourcePackInfo.java.patch
@@ -8,12 +8,10 @@
  
     @Nullable
     public static <T extends ResourcePackInfo> T func_195793_a(String p_195793_0_, boolean p_195793_1_, Supplier<IResourcePack> p_195793_2_, ResourcePackInfo.IFactory<T> p_195793_3_, ResourcePackInfo.Priority p_195793_4_) {
-@@ -51,9 +52,14 @@
- 
+@@ -52,8 +53,13 @@
        return (T)null;
     }
--
-+   
+ 
 +   @Deprecated
     public ResourcePackInfo(String p_i47907_1_, boolean p_i47907_2_, Supplier<IResourcePack> p_i47907_3_, ITextComponent p_i47907_4_, ITextComponent p_i47907_5_, PackCompatibility p_i47907_6_, ResourcePackInfo.Priority p_i47907_7_, boolean p_i47907_8_) {
 -      this.field_195800_b = p_i47907_1_;

--- a/src/fmllauncher/java/net/minecraftforge/fml/loading/moddiscovery/ModFileInfo.java
+++ b/src/fmllauncher/java/net/minecraftforge/fml/loading/moddiscovery/ModFileInfo.java
@@ -38,6 +38,7 @@ public class ModFileInfo implements IModFileInfo
     private final URL issueURL;
     private final String modLoader;
     private final VersionRange modLoaderVersion;
+    private final boolean showAsResourcePack;
     private final List<IModInfo> mods;
     private final Map<String,Object> properties;
 
@@ -50,6 +51,7 @@ public class ModFileInfo implements IModFileInfo
         this.modLoaderVersion = config.<String>getOptional("loaderVersion").
                 map(MavenVersionAdapter::createFromVersionSpec).
                 orElseThrow(()->new InvalidModFileException("Missing ModLoader version in file", this));
+        this.showAsResourcePack = config.<Boolean>getOrElse("showAsResourcePack", false);
         this.properties = config.<UnmodifiableConfig>getOptional("properties").
                 map(UnmodifiableConfig::valueMap).orElse(Collections.emptyMap());
         this.modFile.setFileProperties(this.properties);
@@ -88,6 +90,12 @@ public class ModFileInfo implements IModFileInfo
     public VersionRange getModLoaderVersion()
     {
         return modLoaderVersion;
+    }
+
+    @Override
+    public boolean showAsResourcePack()
+    {
+        return this.showAsResourcePack;
     }
 
     @Override

--- a/src/fmllauncher/java/net/minecraftforge/fml/loading/moddiscovery/ModFileInfo.java
+++ b/src/fmllauncher/java/net/minecraftforge/fml/loading/moddiscovery/ModFileInfo.java
@@ -93,12 +93,6 @@ public class ModFileInfo implements IModFileInfo
     }
 
     @Override
-    public boolean showAsResourcePack()
-    {
-        return this.showAsResourcePack;
-    }
-
-    @Override
     public Map<String, Object> getFileProperties() {
         return this.properties;
     }
@@ -109,6 +103,6 @@ public class ModFileInfo implements IModFileInfo
 
     @Override
     public boolean showAsResourcePack() {
-        return false; // noop right now
+        return this.showAsResourcePack;
     }
 }

--- a/src/main/java/net/minecraftforge/client/extensions/IForgeResourcePack.java
+++ b/src/main/java/net/minecraftforge/client/extensions/IForgeResourcePack.java
@@ -1,3 +1,22 @@
+/*
+ * Minecraft Forge
+ * Copyright (c) 2016-2019.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation version 2.1
+ * of the License.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
 package net.minecraftforge.client.extensions;
 
 public interface IForgeResourcePack

--- a/src/main/java/net/minecraftforge/client/extensions/IForgeResourcePack.java
+++ b/src/main/java/net/minecraftforge/client/extensions/IForgeResourcePack.java
@@ -1,0 +1,9 @@
+package net.minecraftforge.client.extensions;
+
+public interface IForgeResourcePack
+{
+    default boolean isHidden()
+    {
+        return false;
+    }
+}

--- a/src/main/java/net/minecraftforge/fml/packs/ModFileResourcePack.java
+++ b/src/main/java/net/minecraftforge/fml/packs/ModFileResourcePack.java
@@ -221,6 +221,6 @@ public class ModFileResourcePack extends AbstractResourcePack
     
     @Override
     public boolean isHidden() {
-    	return true;
+    	return (Boolean) modFile.getModFileInfo().getFileProperties().getOrDefault("hiddenResources", true);
     }
 }

--- a/src/main/java/net/minecraftforge/fml/packs/ModFileResourcePack.java
+++ b/src/main/java/net/minecraftforge/fml/packs/ModFileResourcePack.java
@@ -218,4 +218,9 @@ public class ModFileResourcePack extends AbstractResourcePack
     <T extends ResourcePackInfo> T getPackInfo() {
         return (T)this.packInfo;
     }
+    
+    @Override
+    public boolean isHidden() {
+    	return true;
+    }
 }

--- a/src/main/java/net/minecraftforge/fml/packs/ModFileResourcePack.java
+++ b/src/main/java/net/minecraftforge/fml/packs/ModFileResourcePack.java
@@ -221,6 +221,6 @@ public class ModFileResourcePack extends AbstractResourcePack
     
     @Override
     public boolean isHidden() {
-    	return (Boolean) modFile.getModFileInfo().getFileProperties().getOrDefault("hiddenResources", true);
+    	return !modFile.getModFileInfo().showAsResourcePack();
     }
 }

--- a/src/main/resources/forge.exc
+++ b/src/main/resources/forge.exc
@@ -15,6 +15,9 @@ net/minecraft/client/renderer/model/ModelBlock.makeBakedQuad(Lnet/minecraft/clie
 net/minecraft/client/renderer/model/VariantList.bake(Ljava/util/function/Function;Ljava/util/function/Function;Lnet/minecraftforge/common/model/IModelState;ZLnet/minecraft/client/renderer/vertex/VertexFormat;)Lnet/minecraft/client/renderer/model/IBakedModel;=|p_209558_1_,p_209558_2_,p_209558_3_,p_209558_4_,format
 net/minecraft/client/renderer/model/multipart/Multipart.bake(Ljava/util/function/Function;Ljava/util/function/Function;Lnet/minecraftforge/common/model/IModelState;ZLnet/minecraft/client/renderer/vertex/VertexFormat;)Lnet/minecraft/client/renderer/model/IBakedModel;=|p_209558_1_,p_209558_2_,p_209558_3_,p_209558_4_,format
 
+net/minecraft/client/resources/ResourcePackInfoClient.<init>(Ljava/lang/String;ZLjava/util/function/Supplier;Lnet/minecraft/resources/IResourcePack;Lnet/minecraft/resources/data/PackMetadataSection;Lnet/minecraft/resources/ResourcePackInfo$Priority;Z)V=|p_i48113_1_,p_i48113_2_,p_i48113_3_,p_i48113_4_,p_i48113_5_,p_i48113_6_,hidden
+net/minecraft/client/resources/ResourcePackInfoClient.<init>(Ljava/lang/String;ZLjava/util/function/Supplier;Lnet/minecraft/util/text/ITextComponent;Lnet/minecraft/util/text/ITextComponent;Lnet/minecraft/resources/PackCompatibility;Lnet/minecraft/resources/ResourcePackInfo$Priority;ZLnet/minecraft/client/renderer/texture/NativeImage;Z)V=|p_i48114_1_,p_i48114_2_,p_i48114_3_,p_i48114_4_,p_i48114_5_,p_i48114_6_,p_i48114_7_,p_i48114_8_,p_i48114_9_,hidden
+
 net/minecraft/entity/Entity.changeDimension(Lnet/minecraft/world/dimension/DimensionType;Lnet/minecraftforge/common/util/ITeleporter;)Lnet/minecraft/entity/Entity;=|p_212321_1_,teleporter
 net/minecraft/entity/EnumCreatureType.create(Ljava/lang/String;Ljava/lang/Class;IZZ)Lnet/minecraft/entity/EnumCreatureType;=|name,p_i47849_3_,p_i47849_4_,p_i47849_5_,p_i47849_6_
 net/minecraft/entity/item/EntityEnderPearl.changeDimension(Lnet/minecraft/world/dimension/DimensionType;Lnet/minecraftforge/common/util/ITeleporter;)Lnet/minecraft/entity/Entity;=|p_212321_1_,teleporter
@@ -27,6 +30,9 @@ net/minecraft/item/ArmorMaterial.create(Ljava/lang/String;Ljava/lang/String;I[II
 net/minecraft/item/ItemStack.<init>(Lnet/minecraft/util/IItemProvider;ILnet/minecraft/nbt/NBTTagCompound;)V=|p_i48204_1_,p_i48204_2_,capNBT
 
 net/minecraft/network/PacketBuffer.writeItemStack(Lnet/minecraft/item/ItemStack;Z)Lnet/minecraft/network/PacketBuffer;=|p_150788_1_,limitedTag
+
+net/minecraft/resources/ResourcePackInfo.<init>(Ljava/lang/String;ZLjava/util/function/Supplier;Lnet/minecraft/util/text/ITextComponent;Lnet/minecraft/util/text/ITextComponent;Lnet/minecraft/resources/PackCompatibility;Lnet/minecraft/resources/ResourcePackInfo$Priority;ZZ)V=|namp_i47907_1_,p_i47907_2_,p_i47907_3_,p_i47907_4_,p_i47907_5_,p_i47907_6_,p_i47907_7_,p_i47907_8_,hidden
+net/minecraft/resources/ResourcePackInfo.<init>(Ljava/lang/String;ZLjava/util/function/Supplier;Lnet/minecraft/resources/IResourcePack;Lnet/minecraft/resources/data/PackMetadataSection;Lnet/minecraft/resources/ResourcePackInfo$Priority;Z)V=|p_i47908_1_,p_i47908_2_,p_i47908_3_,p_i47908_4_,p_i47908_5_,p_i47908_6_,hidden
 
 net/minecraft/server/management/PlayerList.changePlayerDimension(Lnet/minecraft/entity/player/EntityPlayerMP;Lnet/minecraft/world/dimension/DimensionType;Lnet/minecraftforge/common/util/ITeleporter;)V=|p_187242_1_,p_187242_2_,teleporter
 net/minecraft/server/management/PlayerList.transferEntityToWorld(Lnet/minecraft/entity/Entity;Lnet/minecraft/world/dimension/DimensionType;Lnet/minecraft/world/WorldServer;Lnet/minecraft/world/WorldServer;Lnet/minecraftforge/common/util/ITeleporter;)V=|p_82448_1_,p_82448_2_,p_82448_3_,p_82448_4_,teleporter

--- a/src/main/resources/forge.exc
+++ b/src/main/resources/forge.exc
@@ -31,7 +31,7 @@ net/minecraft/item/ItemStack.<init>(Lnet/minecraft/util/IItemProvider;ILnet/mine
 
 net/minecraft/network/PacketBuffer.writeItemStack(Lnet/minecraft/item/ItemStack;Z)Lnet/minecraft/network/PacketBuffer;=|p_150788_1_,limitedTag
 
-net/minecraft/resources/ResourcePackInfo.<init>(Ljava/lang/String;ZLjava/util/function/Supplier;Lnet/minecraft/util/text/ITextComponent;Lnet/minecraft/util/text/ITextComponent;Lnet/minecraft/resources/PackCompatibility;Lnet/minecraft/resources/ResourcePackInfo$Priority;ZZ)V=|namp_i47907_1_,p_i47907_2_,p_i47907_3_,p_i47907_4_,p_i47907_5_,p_i47907_6_,p_i47907_7_,p_i47907_8_,hidden
+net/minecraft/resources/ResourcePackInfo.<init>(Ljava/lang/String;ZLjava/util/function/Supplier;Lnet/minecraft/util/text/ITextComponent;Lnet/minecraft/util/text/ITextComponent;Lnet/minecraft/resources/PackCompatibility;Lnet/minecraft/resources/ResourcePackInfo$Priority;ZZ)V=|p_i47907_1_,p_i47907_2_,p_i47907_3_,p_i47907_4_,p_i47907_5_,p_i47907_6_,p_i47907_7_,p_i47907_8_,hidden
 net/minecraft/resources/ResourcePackInfo.<init>(Ljava/lang/String;ZLjava/util/function/Supplier;Lnet/minecraft/resources/IResourcePack;Lnet/minecraft/resources/data/PackMetadataSection;Lnet/minecraft/resources/ResourcePackInfo$Priority;Z)V=|p_i47908_1_,p_i47908_2_,p_i47908_3_,p_i47908_4_,p_i47908_5_,p_i47908_6_,hidden
 
 net/minecraft/server/management/PlayerList.changePlayerDimension(Lnet/minecraft/entity/player/EntityPlayerMP;Lnet/minecraft/world/dimension/DimensionType;Lnet/minecraftforge/common/util/ITeleporter;)V=|p_187242_1_,p_187242_2_,teleporter


### PR DESCRIPTION
Currently every mod RP will show in the UI (even though it can't be disabled). Because this is a useful feature, not just to hide mod RPs, but also modder-created RPs (think ResourceLoader), I made it public API on IResourcePack.

The method of patching is a bit ugly (I have to add overloads to 4 constructors), so I'm open to alternative solutions. However it's as minimal as it can be with this method.

## Before ![](https://i.imgur.com/2zI5czz.png)

## After ![](https://i.imgur.com/1jrwcNQ.png)