### PR TITLE
[1.13] Remove EnumFacing internal ID maps from AT file

### DIFF
--- a/src/main/resources/META-INF/accesstransformer.cfg
+++ b/src/main/resources/META-INF/accesstransformer.cfg
@@ -162,9 +162,7 @@ private net.minecraft.client.renderer.ItemModelMesher field_199313_a
 # ItemOverrideList
 protected net.minecraft.client.renderer.model.ItemOverrideList <init>()V
 
-# EnumFacing
-public net.minecraft.util.EnumFacing field_82609_l # VALUES
-public net.minecraft.util.EnumFacing field_176754_o # HORIZONTALS
+# BufferBuilder
 public net.minecraft.client.renderer.BufferBuilder func_78909_a(I)I # getColorIndex
 public net.minecraft.client.renderer.BufferBuilder func_178972_a(IIII)V # putColorRGB -- Add A?
 


### PR DESCRIPTION
These were always for internal ID lookups and not intended for external use, as can be seen by the changed implementation in 1.13.

A local copy of the `values()` array (or any other arrangement of constants) can be taken wherever it is appropriate to do so, as is done in various places in the 1.13 vanilla codebase.

There isn't really any need to be changing vanilla classes for something that can be so trivially reproduced without creating an artificial dependence on shared state.