### PR TITLE
Update Forge registries with new ID limits

### DIFF
--- a/src/main/java/net/minecraftforge/registries/ForgeRegistry.java
+++ b/src/main/java/net/minecraftforge/registries/ForgeRegistry.java
@@ -102,7 +102,7 @@ public class ForgeRegistry<V extends IForgeRegistryEntry<V>> implements IForgeRe
         this.defaultKey = builder.getDefault();
         this.min = builder.getMinId();
         this.max = builder.getMaxId();
-        this.availabilityMap = new BitSet(Math.min(max + 1, 0x0FFF));
+        this.availabilityMap = new BitSet(Math.min(max, 0x0FFF) + 1);
         this.create = builder.getCreate();
         this.add = builder.getAdd();
         this.clear = builder.getClear();

--- a/src/main/java/net/minecraftforge/registries/GameData.java
+++ b/src/main/java/net/minecraftforge/registries/GameData.java
@@ -87,7 +87,15 @@ public class GameData
     public static final ResourceLocation PROFESSIONS  = new ResourceLocation("minecraft:villagerprofessions");
     public static final ResourceLocation MODDIMENSIONS = new ResourceLocation("forge:moddimensions");
 
-    private static final int MAX_POTION_ID = 255; // SPacketEntityEffect sends bytes, we can only use 255
+    /**
+     * Limited to an unsigned byte by SPacketEntityEffect/SPacketRemoveEntityEffect,
+     * as well as NBT serialization in PotionEffect.
+     * Otherwise, limited to a short by SPacketWindowProperty for the beacon.
+     */
+    private static final int MAX_POTION_ID = 255;
+
+    /** Limited to a short by SPacketWindowProperty for the enchantment table. */
+    private static final int MAX_ENCHANTMENT_ID = Short.MAX_VALUE;
 
     private static final ResourceLocation BLOCK_TO_ITEM    = new ResourceLocation("minecraft:blocktoitemmap");
     private static final ResourceLocation BLOCKSTATE_TO_ID = new ResourceLocation("minecraft:blockstatetoid");
@@ -116,7 +124,7 @@ public class GameData
         makeRegistry(BIOMES,        Biome.class).create();
         makeRegistry(SOUNDEVENTS,   SoundEvent.class).create();
         makeRegistry(POTIONTYPES,   PotionType.class, new ResourceLocation("empty")).create();
-        makeRegistry(ENCHANTMENTS,  Enchantment.class).create();
+        makeRegistry(ENCHANTMENTS,  Enchantment.class).setMaxID(MAX_ENCHANTMENT_ID).create();
         makeRegistry(PROFESSIONS,   VillagerProfession.class).create();
         // TODO do we need the callback and the static field anymore?
         makeRegistry(ENTITIES,      EntityType.class).create();

--- a/src/main/java/net/minecraftforge/registries/RegistryBuilder.java
+++ b/src/main/java/net/minecraftforge/registries/RegistryBuilder.java
@@ -21,6 +21,7 @@ package net.minecraftforge.registries;
 
 import java.util.List;
 
+import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
 
 import net.minecraft.util.ResourceLocation;
@@ -30,13 +31,11 @@ import javax.annotation.Nullable;
 
 public class RegistryBuilder<T extends IForgeRegistryEntry<T>>
 {
-    private static final int MAX_ID = Integer.MAX_VALUE - 1;
-
     private ResourceLocation registryName;
     private Class<T> registryType;
     private ResourceLocation optionalDefaultKey;
     private int minId = 0;
-    private int maxId = MAX_ID;
+    private int maxId = Integer.MAX_VALUE;
     private List<AddCallback<T>> addCallback = Lists.newArrayList();
     private List<ClearCallback<T>> clearCallback = Lists.newArrayList();
     private List<CreateCallback<T>> createCallback = Lists.newArrayList();
@@ -62,8 +61,10 @@ public class RegistryBuilder<T extends IForgeRegistryEntry<T>>
 
     public RegistryBuilder<T> setIDRange(int min, int max)
     {
-        this.minId = Math.max(min, 0);
-        this.maxId = Math.min(max, MAX_ID);
+        Preconditions.checkArgument(min >= 0, "min ID must be at least zero");
+        Preconditions.checkArgument(max >= min, "max ID must be at least min ID");
+        this.minId = min;
+        this.maxId = max;
         return this;
     }
 


### PR DESCRIPTION
This PR updates `GameData` to account for most ID limits being removed as of 1.13.2, as well as removing some commented out code for dealing with block metadata that is no longer relevant.

In particular, there is no longer an ID limit on blocks, items, and biomes now.

As unlimited IDs are the norm, max IDs are only specified where they apply, and the registry simply defaults to `Integer.MAX_VALUE` otherwise.

For reference, the original max IDs imposed here come from c44ed8fbdeb867b35f04fb5a74899c5a3f965fc4.
This is no longer required due to the initial availability map being size-limited since b203468cde953bbd35b4043fa8ebff4364f1f8d9 - the integer overflow can be dealt with simply by performing the addition after capping the value here.

Note that as `BitSet`s can only be sized as a multiple of the word size used, an odd size is not meaningful here - this does not change the logic at all.

Double-checking would of course be appreciated, the vanilla protocol is well documented here: https://wiki.vg/Protocol.