### PR TITLE
[1.13.x] Concat main args when launching via 'UserdevLauncher' or 'LaunchTesting'

### DIFF
--- a/src/main/java/net/minecraftforge/fml/LaunchTesting.java
+++ b/src/main/java/net/minecraftforge/fml/LaunchTesting.java
@@ -44,15 +44,14 @@ public class LaunchTesting
 
         String assets = System.getenv().getOrDefault("assetDirectory", "assets");
         String target = System.getenv().get("target");
-        String[] launchArgs = new String[]{
+        String[] launchArgs = ObjectArrays.concat(args, new String[]{
                 "--gameDir", ".",
                 "--launchTarget", target,
                 "--fml.forgeVersion", System.getProperty("forge.version"),
                 "--fml.mcpVersion", System.getProperty("mcp.version"),
                 "--fml.mcVersion", System.getProperty("mc.version"),
                 "--fml.forgeGroup", System.getProperty("forge.group")
-        };
-
+        }, String.class);
 
         if (target == null) {
             throw new IllegalArgumentException("Environment variable target must be set.");
@@ -67,9 +66,8 @@ public class LaunchTesting
                     "--assetsDir", assets,
                     "--userProperties", "{}"
             }, String.class);
-        } else {
-            launchArgs = ObjectArrays.concat(launchArgs, args, String.class);
         }
+
         Launcher.main(launchArgs);
         Thread.sleep(10000);
     }

--- a/src/userdev/java/net/minecraftforge/userdev/UserdevLauncher.java
+++ b/src/userdev/java/net/minecraftforge/userdev/UserdevLauncher.java
@@ -46,7 +46,7 @@ public class UserdevLauncher
             throw new IllegalArgumentException("Environment variable 'target' must be set to 'fmluserdevclient' or 'fmluserdevserver'.");
         }
 
-        String[] launchArgs = new String[]{
+        String[] launchArgs = ObjectArrays.concat(args, new String[]{
                 "--gameDir", ".",
                 "--launchTarget", target,
                 "--fml.forgeVersion", System.getenv("FORGE_VERSION"),
@@ -54,7 +54,7 @@ public class UserdevLauncher
                 "--fml.mcpMappings", System.getenv("MCP_MAPPINGS"),
                 "--fml.mcVersion", System.getenv("MC_VERSION"),
                 "--fml.forgeGroup", System.getenv("FORGE_GROUP")
-        };
+        }, String.class);
 
         if (Objects.equals(target,"fmluserdevclient")) {
             if (assets == null || !new File(assets).exists()) {


### PR DESCRIPTION
The **UserdevLauncher** and **LaunchTesting** entry point classes are currently not utilizing the **args** parameter in their entry point `main(String... args)` method.

This is fixed by the following changes made in this PR:
- Concatting the `args` parameter with the initial, explicitly defined, launch args 