### PR TITLE
Fix BlockRailState inverting flexibility flag.

### DIFF
--- a/patches/minecraft/net/minecraft/block/BlockRailState.java.patch
+++ b/patches/minecraft/net/minecraft/block/BlockRailState.java.patch
@@ -14,7 +14,7 @@
 -      RailShape railshape = p_i47755_3_.func_177229_b(this.field_196922_c.func_176560_l());
 -      this.field_208513_e = this.field_196922_c.func_208490_b();
 +      RailShape railshape = this.field_196922_c.getRailDirection(field_196923_d, p_i47755_1_, p_i47755_2_, null);
-+      this.field_208513_e = this.field_196922_c.isFlexibleRail(field_196923_d, p_i47755_1_, p_i47755_2_);
++      this.field_208513_e = !this.field_196922_c.isFlexibleRail(field_196923_d, p_i47755_1_, p_i47755_2_);
 +      this.canMakeSlopes = this.field_196922_c.canMakeSlopes(field_196923_d, p_i47755_1_, p_i47755_2_);
        this.func_208509_a(railshape);
     }


### PR DESCRIPTION
Originally the method was if cornering was disabled, forge patched it and made it if cornering is not disabled, which ended up meaning rails can no longer turn corners.