### PR TITLE
Fix droppers not spawning items in world

### DIFF
--- a/src/main/java/net/minecraftforge/items/VanillaInventoryCodeHooks.java
+++ b/src/main/java/net/minecraftforge/items/VanillaInventoryCodeHooks.java
@@ -109,7 +109,7 @@ public class VanillaInventoryCodeHooks
                     dropper.setInventorySlotContents(slot, remainder);
                     return false;
                 })
-                .orElse(false);
+                .orElse(true);
     }
 
     /**


### PR DESCRIPTION
Fixes [this issue](http://www.minecraftforge.net/forum/topic/69051-113-dropper-wont-drop-items/) from the forums.

The return value of `VanillaInventoryCodeHooks.dropperInsertHook` determines if the vanilla logic should run, as seen here:
https://github.com/MinecraftForge/MinecraftForge/blob/bbdf52e038a06dd8b34901eac92c027f517161fd/patches/minecraft/net/minecraft/block/BlockDropper.java.patch#L8

Currently, the code for `dropperInsertHook` returns `false` always, skipping the needed behaviour here.

