### PR TITLE
[1.13.x] Added tags for small mushrooms and mushroom blocks

### DIFF
--- a/src/main/resources/data/forge/tags/blocks/huge_mushrooms.json
+++ b/src/main/resources/data/forge/tags/blocks/huge_mushrooms.json
@@ -3,6 +3,6 @@
   "values": [
     "#forge:huge_mushrooms/red",
     "#forge:huge_mushrooms/brown",
-	"#forge:huge_mushrooms/stem"
+    "#forge:huge_mushrooms/stem"
   ]
 }

--- a/src/main/resources/data/forge/tags/blocks/huge_mushrooms.json
+++ b/src/main/resources/data/forge/tags/blocks/huge_mushrooms.json
@@ -1,0 +1,8 @@
+{
+  "replace": false,
+  "values": [
+    "#forge:huge_mushrooms/red",
+    "#forge:huge_mushrooms/brown",
+	"#forge:huge_mushrooms/stem"
+  ]
+}

--- a/src/main/resources/data/forge/tags/blocks/huge_mushrooms/brown.json
+++ b/src/main/resources/data/forge/tags/blocks/huge_mushrooms/brown.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "minecraft:brown_mushroom_block"
+  ]
+}

--- a/src/main/resources/data/forge/tags/blocks/huge_mushrooms/red.json
+++ b/src/main/resources/data/forge/tags/blocks/huge_mushrooms/red.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "minecraft:red_mushroom_block"
+  ]
+}

--- a/src/main/resources/data/forge/tags/blocks/huge_mushrooms/stem.json
+++ b/src/main/resources/data/forge/tags/blocks/huge_mushrooms/stem.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "minecraft:mushroom_stem"
+  ]
+}

--- a/src/main/resources/data/forge/tags/blocks/mushrooms.json
+++ b/src/main/resources/data/forge/tags/blocks/mushrooms.json
@@ -1,0 +1,7 @@
+{
+  "replace": false,
+  "values": [
+    "#forge:small_mushrooms",
+    "#forge:huge_mushrooms"
+  ]
+}

--- a/src/main/resources/data/forge/tags/blocks/small_mushrooms.json
+++ b/src/main/resources/data/forge/tags/blocks/small_mushrooms.json
@@ -1,0 +1,7 @@
+{
+  "replace": false,
+  "values": [
+    "#forge:small_mushrooms/red",
+    "#forge:small_mushrooms/brown"
+  ]
+}

--- a/src/main/resources/data/forge/tags/blocks/small_mushrooms/brown.json
+++ b/src/main/resources/data/forge/tags/blocks/small_mushrooms/brown.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "minecraft:brown_mushroom"
+  ]
+}

--- a/src/main/resources/data/forge/tags/blocks/small_mushrooms/red.json
+++ b/src/main/resources/data/forge/tags/blocks/small_mushrooms/red.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "minecraft:red_mushroom"
+  ]
+}


### PR DESCRIPTION
I did not edit the recipes by intension, as the mushroom soup is designed to accept only red and brown mushrooms.