### PR TITLE
[1.13] Small comment typo fixes for ObfuscationReflectionHelper

### DIFF
--- a/src/main/java/net/minecraftforge/fml/common/ObfuscationReflectionHelper.java
+++ b/src/main/java/net/minecraftforge/fml/common/ObfuscationReflectionHelper.java
@@ -40,7 +40,7 @@ import com.google.common.base.Preconditions;
 
 /**
  * Some reflection helper code.
- * This may not work properly in Java 9 with it's new, more restrictive, reflection management.
+ * This may not work properly in Java 9 with its new, more restrictive, reflection management.
  * As such, if issues are encountered, please report them and we can see what we can do to expand
  * the compatibility.
  *

--- a/src/main/java/net/minecraftforge/fml/common/ObfuscationReflectionHelper.java
+++ b/src/main/java/net/minecraftforge/fml/common/ObfuscationReflectionHelper.java
@@ -240,7 +240,7 @@ public class ObfuscationReflectionHelper
                 return;
             for (String file  : new String[]{"fields.csv", "methods.csv"})
             {
-                URL path = ClassLoader.getSystemResource(file); //We EXPLICITLY go throught the SystemClassLoader here because this is dev-time only. And will be on the root classpath.
+                URL path = ClassLoader.getSystemResource(file); //We EXPLICITLY go through the SystemClassLoader here because this is dev-time only. And will be on the root classpath.
                 if (path == null)
                     continue;
 

--- a/src/main/java/net/minecraftforge/fml/common/ObfuscationReflectionHelper.java
+++ b/src/main/java/net/minecraftforge/fml/common/ObfuscationReflectionHelper.java
@@ -153,7 +153,7 @@ public class ObfuscationReflectionHelper
      * Throws an exception if the method is not found.
      *
      * @param clazz          The class to find the method on.
-     * @param methodName     The SRG (obfuscated) name of the method to find(e.g. "func_72820_D").
+     * @param methodName     The SRG (obfuscated) name of the method to find(e.g. "func_12820_D").
      * @param parameterTypes The parameter types of the method to find.
      * @return The method with the specified name and parameters in the given class.
      */

--- a/src/main/java/net/minecraftforge/fml/common/ObfuscationReflectionHelper.java
+++ b/src/main/java/net/minecraftforge/fml/common/ObfuscationReflectionHelper.java
@@ -40,7 +40,7 @@ import com.google.common.base.Preconditions;
 
 /**
  * Some reflection helper code.
- * This may not work properly in Java9 with their new more restrictive reflection management.
+ * This may not work properly in Java 9 with it's new, more restrictive, reflection management.
  * As such, if issues are encountered, please report them and we can see what we can do to expand
  * the compatibility.
  *
@@ -148,7 +148,7 @@ public class ObfuscationReflectionHelper
 
     /**
      * Finds a method with the specified name and parameters in the given class and makes it accessible.
-     * Note: for performance, store the returned value and avoid calling this repeatedly.
+     * Note: For performance, store the returned value and avoid calling this repeatedly.
      * <p>
      * Throws an exception if the method is not found.
      *
@@ -240,7 +240,7 @@ public class ObfuscationReflectionHelper
                 return;
             for (String file  : new String[]{"fields.csv", "methods.csv"})
             {
-                URL path = ClassLoader.getSystemResource(file); //We EXPLICITLY go through the SystemClassLoader here because this is dev-time only. And will be on the root classpath.
+                URL path = ClassLoader.getSystemResource(file); //We EXPLICITLY go through the SystemClassLoader here because this is dev-time only. Therefore we will be on the root classpath.
                 if (path == null)
                     continue;
 


### PR DESCRIPTION
Change a SRG method name in the `findMethod` Javadoc (`func_72820_D`) to a non-existent SRG name (`func_12820_D`) so that MCP doesn't convert it to "World#getDayTime" when it sets up userdev