### PR TITLE
[1.13.2] Add forge:tag_exists condition

### DIFF
--- a/src/main/java/net/minecraftforge/common/crafting/CraftingHelper.java
+++ b/src/main/java/net/minecraftforge/common/crafting/CraftingHelper.java
@@ -30,8 +30,6 @@ import java.util.stream.Stream;
 
 import javax.annotation.Nullable;
 
-import net.minecraft.block.Block;
-import net.minecraft.tags.BlockTags;
 import net.minecraft.tags.ItemTags;
 import net.minecraft.tags.Tag;
 import net.minecraftforge.fml.ModList;
@@ -86,10 +84,9 @@ public class CraftingHelper
     public static final IConditionSerializer CONDITION_TAG_EXISTS = condition("tag_exists", json -> {
                                                                         String tagName = JsonUtils.getString(json, "tag");
                                                                         Tag<Item> itemTag = ItemTags.getCollection().get(new ResourceLocation(tagName));
-                                                                        Tag<Block> blockTag = BlockTags.getCollection().get(new ResourceLocation(tagName));
-                                                                        if (itemTag == null || blockTag == null)
+                                                                        if (itemTag == null)
                                                                             return () -> false;
-                                                                        return () -> !itemTag.getAllElements().isEmpty() || !blockTag.getAllElements().isEmpty();
+                                                                        return () -> !itemTag.getAllElements().isEmpty();
                                                                     });
     public static final IConditionSerializer CONDITION_NOT = condition("not", json -> {
                                                                 BooleanSupplier child = CraftingHelper.getCondition(JsonUtils.getJsonObject(json, "value"));

--- a/src/main/java/net/minecraftforge/common/crafting/CraftingHelper.java
+++ b/src/main/java/net/minecraftforge/common/crafting/CraftingHelper.java
@@ -30,6 +30,10 @@ import java.util.stream.Stream;
 
 import javax.annotation.Nullable;
 
+import net.minecraft.block.Block;
+import net.minecraft.tags.BlockTags;
+import net.minecraft.tags.ItemTags;
+import net.minecraft.tags.Tag;
 import net.minecraftforge.fml.ModList;
 import com.google.common.collect.BiMap;
 import com.google.common.collect.HashBiMap;
@@ -78,6 +82,14 @@ public class CraftingHelper
     public static final IConditionSerializer CONDITION_ITEM_EXISTS = condition("item_exists", json -> {
                                                                         String itemName = JsonUtils.getString(json, "item");
                                                                         return () -> ForgeRegistries.ITEMS.containsKey(new ResourceLocation(itemName));
+                                                                    });
+    public static final IConditionSerializer CONDITION_TAG_EXISTS = condition("tag_exists", json -> {
+                                                                        String tagName = JsonUtils.getString(json, "tag");
+                                                                        Tag<Item> itemTag = ItemTags.getCollection().get(new ResourceLocation(tagName));
+                                                                        Tag<Block> blockTag = BlockTags.getCollection().get(new ResourceLocation(tagName));
+                                                                        if (itemTag == null || blockTag == null)
+                                                                            return () -> false;
+                                                                        return () -> !itemTag.getAllElements().isEmpty() || !blockTag.getAllElements().isEmpty();
                                                                     });
     public static final IConditionSerializer CONDITION_NOT = condition("not", json -> {
                                                                 BooleanSupplier child = CraftingHelper.getCondition(JsonUtils.getJsonObject(json, "value"));


### PR DESCRIPTION
Without this Minecraft outputs error:
`com.google.gson.JsonSyntaxException: Unknown item tag 'forge:ingots/aluminum'`
With this we can check if tag exists and we can avoid errors