### PR TITLE
Allow DamageSource modification (LivingAttackEvent)

### DIFF
--- a/src/main/java/net/minecraftforge/event/entity/living/LivingAttackEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/living/LivingAttackEvent.java
@@ -47,7 +47,7 @@ import net.minecraft.entity.EntityLivingBase;
 @Cancelable
 public class LivingAttackEvent extends LivingEvent
 {
-    private final DamageSource source;
+    private DamageSource source;
     private final float amount;
     public LivingAttackEvent(EntityLivingBase entity, DamageSource source, float amount)
     {

--- a/src/main/java/net/minecraftforge/event/entity/living/LivingAttackEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/living/LivingAttackEvent.java
@@ -57,5 +57,6 @@ public class LivingAttackEvent extends LivingEvent
     }
 
     public DamageSource getSource() { return source; }
+    public void setDamageSource(DamageSource source) { this.source = source; }
     public float getAmount() { return amount; }
 }


### PR DESCRIPTION
Add a setDamageSource method to the LivingAttackEvent to allow the modification of the DamageSource which is useful for creating swords with a custom DamageSource. The only other way i found to make a sword with a custom DamageSource is to cancel the event and call the attackEntityFrom method. But then the attackEntityFrom method and the event is called twice which is unnecessary.