### PR TITLE
[1.13.2] Uncommenting lines to re-add Custom Entities for Items 

### DIFF
--- a/src/main/java/net/minecraftforge/common/ForgeInternalHandler.java
+++ b/src/main/java/net/minecraftforge/common/ForgeInternalHandler.java
@@ -37,6 +37,7 @@ import net.minecraftforge.fml.common.gameevent.TickEvent.ServerTickEvent;
 
 public class ForgeInternalHandler
 {
+    
     @SubscribeEvent(priority = EventPriority.HIGHEST)
     public void onEntityJoinWorld(EntityJoinWorldEvent event)
     {
@@ -45,7 +46,6 @@ public class ForgeInternalHandler
         {
             ItemStack stack = ((EntityItem)entity).getItem();
             Item item = stack.getItem();
-/*
             if (item.hasCustomEntity(stack))
             {
                 Entity newEntity = item.createEntity(event.getWorld(), entity, stack);
@@ -56,7 +56,6 @@ public class ForgeInternalHandler
                     event.getWorld().spawnEntity(newEntity);
                 }
             }
-*/
         }
     }
 

--- a/src/main/java/net/minecraftforge/common/ForgeInternalHandler.java
+++ b/src/main/java/net/minecraftforge/common/ForgeInternalHandler.java
@@ -51,7 +51,7 @@ public class ForgeInternalHandler
                 Entity newEntity = item.createEntity(event.getWorld(), entity, stack);
                 if (newEntity != null)
                 {
-                    entity.setDead();
+                    entity.remove();
                     event.setCanceled(true);
                     event.getWorld().spawnEntity(newEntity);
                 }

--- a/src/main/java/net/minecraftforge/common/ForgeInternalHandler.java
+++ b/src/main/java/net/minecraftforge/common/ForgeInternalHandler.java
@@ -37,7 +37,6 @@ import net.minecraftforge.fml.common.gameevent.TickEvent.ServerTickEvent;
 
 public class ForgeInternalHandler
 {
-    
     @SubscribeEvent(priority = EventPriority.HIGHEST)
     public void onEntityJoinWorld(EntityJoinWorldEvent event)
     {


### PR DESCRIPTION
Uncommented lines in ForgeInternalHandler to re-add support for Items that have custom entities, for them to actually use the custom entity instead of the items EntityItem. 

It was apparently commented out early on in Forge 1.13 Dev by Cpw because it made the server fail to start due to missing patches. This is no longer the case and this now works as expected. 