### PR TITLE
Fix for SidedInvWrapper isItemValid using wrong slot

### DIFF
--- a/src/main/java/net/minecraftforge/items/wrapper/SidedInvWrapper.java
+++ b/src/main/java/net/minecraftforge/items/wrapper/SidedInvWrapper.java
@@ -235,6 +235,6 @@ public class SidedInvWrapper implements IItemHandlerModifiable
     public boolean isItemValid(int slot, @Nonnull ItemStack stack)
     {
         int slot1 = getSlot(inv, slot, side);
-        return slot1 == -1 ? false : inv.isItemValidForSlot(slot, stack);
+        return slot1 == -1 ? false : inv.isItemValidForSlot(slot1, stack);
     }
 }

--- a/src/main/java/net/minecraftforge/items/wrapper/SidedInvWrapper.java
+++ b/src/main/java/net/minecraftforge/items/wrapper/SidedInvWrapper.java
@@ -234,6 +234,7 @@ public class SidedInvWrapper implements IItemHandlerModifiable
     @Override
     public boolean isItemValid(int slot, @Nonnull ItemStack stack)
     {
-        return inv.isItemValidForSlot(slot, stack);
+        int slot1 = getSlot(inv, slot, side);
+        return slot1 == -1 ? false : inv.isItemValidForSlot(slot, stack);
     }
 }


### PR DESCRIPTION
isItemValid is passing in the slot directly instead of mapping it back to the internals slot ID. This results in slot 0 being used instead of say slot 20. This means anything trying to use isItemValid will break if the slot IDs do not match 1:1.