### PR TITLE
Throw when a mod returns null from a capability provider

### DIFF
--- a/src/main/java/net/minecraftforge/common/capabilities/CapabilityDispatcher.java
+++ b/src/main/java/net/minecraftforge/common/capabilities/CapabilityDispatcher.java
@@ -105,7 +105,7 @@ public final class CapabilityDispatcher implements INBTSerializable<NBTTagCompou
             {
                 throw new RuntimeException(
                         String.format(
-                                "Provider %s.getCapability() returned null; this is not allowed!",
+                                "Provider %s.getCapability() returned null; return LazyOptional.empty() instead!",
                                 c.getClass().getTypeName()
                         )
                 );

--- a/src/main/java/net/minecraftforge/common/capabilities/CapabilityDispatcher.java
+++ b/src/main/java/net/minecraftforge/common/capabilities/CapabilityDispatcher.java
@@ -100,6 +100,15 @@ public final class CapabilityDispatcher implements INBTSerializable<NBTTagCompou
         for (ICapabilityProvider c : caps)
         {
             LazyOptional<T> ret = c.getCapability(cap, side);
+            //noinspection ConstantConditions
+            if (ret == null) {
+                throw new RuntimeException(
+                        String.format(
+                                "Provider %s.getCapability() returned null; this is not allowed!",
+                                c.getClass().getTypeName()
+                        )
+                );
+            }
             if (ret.isPresent()) {
                 return ret;
             }

--- a/src/main/java/net/minecraftforge/common/capabilities/CapabilityDispatcher.java
+++ b/src/main/java/net/minecraftforge/common/capabilities/CapabilityDispatcher.java
@@ -101,7 +101,8 @@ public final class CapabilityDispatcher implements INBTSerializable<NBTTagCompou
         {
             LazyOptional<T> ret = c.getCapability(cap, side);
             //noinspection ConstantConditions
-            if (ret == null) {
+            if (ret == null)
+            {
                 throw new RuntimeException(
                         String.format(
                                 "Provider %s.getCapability() returned null; this is not allowed!",
@@ -109,7 +110,8 @@ public final class CapabilityDispatcher implements INBTSerializable<NBTTagCompou
                         )
                 );
             }
-            if (ret.isPresent()) {
+            if (ret.isPresent())
+            {
                 return ret;
             }
         }


### PR DESCRIPTION
Currently, if MC1.13 mods return null in `getProvider` like they used to in MC1.12, the stack trace of the NPE leads users to report the bug to the mod checking for capabilities, not the mod that erroneously returned null. This `throw` will report the offending mod's provider, making it clear(er) which mod actually contains the bug.

This fixes #5645 (see that issue for context)