### PR TITLE
Added option for mods to enable the config button in the mods list gui screen

### DIFF
--- a/src/fmllauncher/java/net/minecraftforge/fml/loading/moddiscovery/ModInfo.java
+++ b/src/fmllauncher/java/net/minecraftforge/fml/loading/moddiscovery/ModInfo.java
@@ -51,9 +51,11 @@ public class ModInfo implements IModInfo
     private final String displayName;
     private final String description;
     private final URL updateJSONURL;
+    private final boolean configUI;
     private final List<IModInfo.ModVersion> dependencies;
     private final Map<String,Object> properties;
     private final UnmodifiableConfig modConfig;
+
 
     public ModInfo(final ModFileInfo owningFile, final UnmodifiableConfig modConfig)
     {
@@ -75,6 +77,7 @@ public class ModInfo implements IModInfo
         this.displayName = modConfig.<String>getOptional("displayName").orElse(null);
         this.description = modConfig.get("description");
         this.updateJSONURL = modConfig.<String>getOptional("updateJSONURL").map(StringUtils::toURL).orElse(null);
+        this.configUI = modConfig.<Boolean>getOptional("configUI").orElse(false);
         if (owningFile != null) {
             this.dependencies = owningFile.getConfig().<List<UnmodifiableConfig>>getOptional(Arrays.asList("dependencies", this.modId)).
                     orElse(Collections.emptyList()).stream().map(dep -> new ModVersion(this, dep)).collect(Collectors.toList());
@@ -145,6 +148,6 @@ public class ModInfo implements IModInfo
 
     public boolean hasConfigUI()
     {
-        return false;
+        return configUI;
     }
 }


### PR DESCRIPTION
This option is enabled via the mods toml file.
Not sure if this is the right way to go about adding this functionality, but as of now the hasConfigUI method always returns false and it needs to be able to return false to enable the Config button when looking at a mod in the Mods list gui screen.