### PR TITLE
Readd redirecting of stdout and stderr

### DIFF
--- a/src/fmllauncher/java/net/minecraftforge/fml/loading/FMLServiceProvider.java
+++ b/src/fmllauncher/java/net/minecraftforge/fml/loading/FMLServiceProvider.java
@@ -93,6 +93,9 @@ public class FMLServiceProvider implements ITransformationService
     @Override
     public void onLoad(IEnvironment environment, Set<String> otherServices) throws IncompatibleEnvironmentException
     {
+        LOGGER.debug("Injecting tracing printstreams for STDOUT/STDERR.");
+        System.setOut(new TracingPrintStream(LogManager.getLogger("STDOUT"), System.out));
+        System.setErr(new TracingPrintStream(LogManager.getLogger("STDERR"), System.err));
         FMLLoader.onInitialLoad(environment, otherServices);
     }
 

--- a/src/fmllauncher/java/net/minecraftforge/fml/loading/TracingPrintStream.java
+++ b/src/fmllauncher/java/net/minecraftforge/fml/loading/TracingPrintStream.java
@@ -30,7 +30,7 @@ import java.io.PrintStream;
 public class TracingPrintStream extends PrintStream
 {
 
-    private static final int BASE_DEPTH = 3;
+    private static final int BASE_DEPTH = 4;
     private final Logger logger;
 
     public TracingPrintStream(Logger logger, PrintStream original)

--- a/src/fmllauncher/java/net/minecraftforge/fml/loading/TracingPrintStream.java
+++ b/src/fmllauncher/java/net/minecraftforge/fml/loading/TracingPrintStream.java
@@ -1,0 +1,115 @@
+/*
+ * Minecraft Forge
+ * Copyright (c) 2016-2019.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation version 2.1
+ * of the License.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+package net.minecraftforge.fml.loading;
+
+import org.apache.logging.log4j.Logger;
+
+import java.io.PrintStream;
+
+/**
+ * PrintStream which redirects it's output to a given logger.
+ *
+ */
+public class TracingPrintStream extends PrintStream
+{
+
+    private static final int BASE_DEPTH = 3;
+    private final Logger logger;
+
+    public TracingPrintStream(Logger logger, PrintStream original)
+    {
+        super(original);
+        this.logger = logger;
+    }
+
+    private void log(String s)
+    {
+        logger.info("{}{}", getPrefix(), s);
+    }
+
+    private static String getPrefix()
+    {
+        StackTraceElement[] elems = Thread.currentThread().getStackTrace();
+        StackTraceElement elem = elems[BASE_DEPTH]; // The caller is always at BASE_DEPTH, including this call.
+        if (elem.getClassName().startsWith("kotlin.io."))
+        {
+            elem = elems[BASE_DEPTH + 2]; // Kotlins IoPackage masks origins 2 deeper in the stack.
+        }
+        else if (elem.getClassName().startsWith("java.lang.Throwable"))
+        {
+            elem = elems[BASE_DEPTH + 4];
+        }
+        return "[" + elem.getClassName() + ":" + elem.getMethodName() + ":" + elem.getLineNumber() + "]: ";
+    }
+
+    @Override
+    public void println(Object o)
+    {
+        log(String.valueOf(o));
+    }
+
+    @Override
+    public void println(String s)
+    {
+        log(s);
+    }
+
+    @Override
+    public void println(boolean x)
+    {
+        log(String.valueOf(x));
+    }
+
+    @Override
+    public void println(char x)
+    {
+        log(String.valueOf(x));
+    }
+
+    @Override
+    public void println(int x)
+    {
+        log(String.valueOf(x));
+    }
+
+    @Override
+    public void println(long x)
+    {
+        log(String.valueOf(x));
+    }
+
+    @Override
+    public void println(float x)
+    {
+        log(String.valueOf(x));
+    }
+
+    @Override
+    public void println(double x)
+    {
+        log(String.valueOf(x));
+    }
+
+    @Override
+    public void println(char[] x)
+    {
+        log(String.valueOf(x));
+    }
+}

--- a/src/fmllauncher/java/net/minecraftforge/fml/loading/TracingPrintStream.java
+++ b/src/fmllauncher/java/net/minecraftforge/fml/loading/TracingPrintStream.java
@@ -47,14 +47,14 @@ public class TracingPrintStream extends PrintStream
     private static String getPrefix()
     {
         StackTraceElement[] elems = Thread.currentThread().getStackTrace();
-        StackTraceElement elem = elems[BASE_DEPTH]; // The caller is always at BASE_DEPTH, including this call.
+        StackTraceElement elem = elems[Math.min(BASE_DEPTH, elems.length - 1)]; // The caller is always at BASE_DEPTH, including this call.
         if (elem.getClassName().startsWith("kotlin.io."))
         {
-            elem = elems[BASE_DEPTH + 2]; // Kotlins IoPackage masks origins 2 deeper in the stack.
+            elem = elems[Math.min(BASE_DEPTH + 2, elems.length - 1)]; // Kotlins IoPackage masks origins 2 deeper in the stack.
         }
         else if (elem.getClassName().startsWith("java.lang.Throwable"))
         {
-            elem = elems[BASE_DEPTH + 4];
+            elem = elems[Math.min(BASE_DEPTH + 4, elems.length - 1)];
         }
         return "[" + elem.getClassName() + ":" + elem.getMethodName() + ":" + elem.getLineNumber() + "]: ";
     }


### PR DESCRIPTION
This fixes #5507
This is a modified copy of [the original TracingPrintStream](https://github.com/MinecraftForge/MinecraftForge/blob/1.12.x/src/main/java/net/minecraftforge/fml/common/TracingPrintStream.java), but cleaned up and expanded to also work for primitives that are logged.