### PR TITLE
1.12.x [Bugfix] Trigger SpecialSpawnEvent consistently by Command, MonsterSpawner, SpawnEgg etc

### DIFF
--- a/patches/minecraft/net/minecraft/command/server/CommandSummon.java.patch
+++ b/patches/minecraft/net/minecraft/command/server/CommandSummon.java.patch
@@ -1,0 +1,37 @@
+--- ../src-base/minecraft/net/minecraft/command/server/CommandSummon.java
++++ ../src-work/minecraft/net/minecraft/command/server/CommandSummon.java
+@@ -94,7 +94,7 @@
+                 }
+ 
+                 nbttagcompound.func_74778_a("id", s);
+-                Entity entity = AnvilChunkLoader.func_186054_a(nbttagcompound, world, d0, d1, d2, true);
++                Entity entity = AnvilChunkLoader.func_186054_a(nbttagcompound, world, d0, d1, d2, false);
+ 
+                 if (entity == null)
+                 {
+@@ -102,14 +102,22 @@
+                 }
+                 else
+                 {
++                    boolean success = true;
+                     entity.func_70012_b(d0, d1, d2, entity.field_70177_z, entity.field_70125_A);
+ 
+-                    if (!flag && entity instanceof EntityLiving)
++                    if (entity instanceof EntityLiving)
+                     {
+                         ((EntityLiving)entity).func_180482_a(world.func_175649_E(new BlockPos(entity)), (IEntityLivingData)null);
++                        if (net.minecraftforge.event.ForgeEventFactory.doSpecialSpawn((EntityLiving) entity, world, (float)blockpos.func_177958_n(), (float)blockpos.func_177956_o(), (float)blockpos.func_177952_p(), null))
++                            success = false;
+                     }
+-
+-                    func_152373_a(p_184881_2_, this, "commands.summon.success", new Object[0]);
++                    if (success)
++                    {
++                        AnvilChunkLoader.func_186052_a(entity, world);
++                        func_152373_a(p_184881_2_, this, "commands.summon.success", new Object[0]);
++                    }
++                    else
++                        func_152373_a(p_184881_2_, this, "commands.summon.failed", new Object[] {"Command cancelled"});
+                 }
+             }
+         }

--- a/patches/minecraft/net/minecraft/init/Bootstrap.java.patch
+++ b/patches/minecraft/net/minecraft/init/Bootstrap.java.patch
@@ -1,6 +1,25 @@
 --- ../src-base/minecraft/net/minecraft/init/Bootstrap.java
 +++ ../src-work/minecraft/net/minecraft/init/Bootstrap.java
-@@ -264,6 +264,9 @@
+@@ -193,15 +193,11 @@
+                 double d0 = p_82487_1_.func_82615_a() + (double)enumfacing.func_82601_c();
+                 double d1 = (double)((float)(p_82487_1_.func_180699_d().func_177956_o() + enumfacing.func_96559_d()) + 0.2F);
+                 double d2 = p_82487_1_.func_82616_c() + (double)enumfacing.func_82599_e();
+-                Entity entity = ItemMonsterPlacer.func_77840_a(p_82487_1_.func_82618_k(), ItemMonsterPlacer.func_190908_h(p_82487_2_), d0, d1, d2);
++                Entity entity = ItemMonsterPlacer.spawnCreature(p_82487_1_.func_82618_k(), p_82487_2_, d0, d1, d2, null);
+ 
+-                if (entity instanceof EntityLivingBase && p_82487_2_.func_82837_s())
+-                {
+-                    entity.func_96094_a(p_82487_2_.func_82833_r());
+-                }
++                if (entity != null)
++                    p_82487_2_.func_190918_g(1);
+ 
+-                ItemMonsterPlacer.func_185079_a(p_82487_1_.func_82618_k(), (EntityPlayer)null, p_82487_2_, entity);
+-                p_82487_2_.func_190918_g(1);
+                 return p_82487_2_;
+             }
+         });
+@@ -264,6 +260,9 @@
          };
          BlockDispenser.field_149943_a.func_82595_a(Items.field_151129_at, ibehaviordispenseitem);
          BlockDispenser.field_149943_a.func_82595_a(Items.field_151131_as, ibehaviordispenseitem);
@@ -10,7 +29,7 @@
          BlockDispenser.field_149943_a.func_82595_a(Items.field_151133_ar, new BehaviorDefaultDispenseItem()
          {
              private final BehaviorDefaultDispenseItem field_150840_b = new BehaviorDefaultDispenseItem();
-@@ -489,6 +492,7 @@
+@@ -489,6 +488,7 @@
          if (!field_151355_a)
          {
              field_151355_a = true;
@@ -18,7 +37,7 @@
              func_179868_d();
              SoundEvent.func_187504_b();
              Block.func_149671_p();
-@@ -524,6 +528,8 @@
+@@ -524,6 +524,8 @@
                      field_179871_c.error("Errors with built-in loot tables");
                  }
              }

--- a/patches/minecraft/net/minecraft/item/ItemMonsterPlacer.java.patch
+++ b/patches/minecraft/net/minecraft/item/ItemMonsterPlacer.java.patch
@@ -1,10 +1,86 @@
 --- ../src-base/minecraft/net/minecraft/item/ItemMonsterPlacer.java
 +++ ../src-work/minecraft/net/minecraft/item/ItemMonsterPlacer.java
-@@ -234,6 +234,7 @@
-                     entity.func_70012_b(p_77840_2_, p_77840_4_, p_77840_6_, MathHelper.func_76142_g(p_77840_0_.field_73012_v.nextFloat() * 360.0F), 0.0F);
-                     entityliving.field_70759_as = entityliving.field_70177_z;
-                     entityliving.field_70761_aq = entityliving.field_70177_z;
-+                    if (net.minecraftforge.event.ForgeEventFactory.doSpecialSpawn(entityliving, p_77840_0_, (float) p_77840_2_, (float) p_77840_4_, (float) p_77840_6_, null)) return null;
-                     entityliving.func_180482_a(p_77840_0_.func_175649_E(new BlockPos(entityliving)), (IEntityLivingData)null);
-                     p_77840_0_.func_72838_d(entity);
-                     entityliving.func_70642_aH();
+@@ -218,36 +218,65 @@
+     }
+ 
+     @Nullable
+-    public static Entity func_77840_a(World p_77840_0_, @Nullable ResourceLocation p_77840_1_, double p_77840_2_, double p_77840_4_, double p_77840_6_)
++    public static Entity spawnCreature(World worldIn, ResourceLocation entityID, @Nullable String displayName, @Nullable NBTTagCompound nbtTagCompound,
++                                       @Nullable EntityPlayer player, double x, double y, double z)
+     {
+-        if (p_77840_1_ != null && EntityList.field_75627_a.containsKey(p_77840_1_))
++        if (entityID != null && EntityList.field_75627_a.containsKey(entityID))
+         {
+-            Entity entity = null;
++            Entity entity = EntityList.func_188429_b(entityID, worldIn);
+ 
+-            for (int i = 0; i < 1; ++i)
++            if (entity instanceof EntityLiving)
+             {
+-                entity = EntityList.func_188429_b(p_77840_1_, p_77840_0_);
++                EntityLiving entityLiving = (EntityLiving) entity;
++                entityLiving.func_70012_b(x, y, z, MathHelper.func_76142_g(worldIn.field_73012_v.nextFloat() * 360.0F), 0.0F);
++                entityLiving.field_70759_as = entityLiving.field_70177_z;
++                entityLiving.field_70761_aq = entityLiving.field_70177_z;
++                entityLiving.func_180482_a(worldIn.func_175649_E(new BlockPos(entityLiving)), (IEntityLivingData)null);
+ 
+-                if (entity instanceof EntityLiving)
++                if (displayName != null)
+                 {
+-                    EntityLiving entityliving = (EntityLiving)entity;
+-                    entity.func_70012_b(p_77840_2_, p_77840_4_, p_77840_6_, MathHelper.func_76142_g(p_77840_0_.field_73012_v.nextFloat() * 360.0F), 0.0F);
+-                    entityliving.field_70759_as = entityliving.field_70177_z;
+-                    entityliving.field_70761_aq = entityliving.field_70177_z;
+-                    entityliving.func_180482_a(p_77840_0_.func_175649_E(new BlockPos(entityliving)), (IEntityLivingData)null);
+-                    p_77840_0_.func_72838_d(entity);
+-                    entityliving.func_70642_aH();
++                    entityLiving.func_96094_a(displayName);
+                 }
+-            }
+ 
++                MinecraftServer minecraftserver = worldIn.func_73046_m();
++
++                if (nbtTagCompound != null && nbtTagCompound.func_150297_b("EntityTag", 10))
++                {
++                    if (worldIn.field_72995_K || !entity.func_184213_bq() || (player != null && minecraftserver.func_184103_al().func_152596_g(player.func_146103_bH())))
++                    {
++                        NBTTagCompound nbttagcompound1 = entity.func_189511_e(new NBTTagCompound());
++                        UUID uuid = entity.func_110124_au();
++                        nbttagcompound1.func_179237_a(nbtTagCompound.func_74775_l("EntityTag"));
++                        entity.func_184221_a(uuid);
++                        entity.func_70020_e(nbttagcompound1);
++                    }
++                }
++
++                if (net.minecraftforge.event.ForgeEventFactory.doSpecialSpawn((EntityLiving) entity, worldIn, (float) x, (float) y, (float) z, null))
++                {
++                    return null;
++                }
++
++                worldIn.func_72838_d(entity);
++                entityLiving.func_70642_aH();
++            }
+             return entity;
+         }
+-        else
+-        {
+-            return null;
+-        }
++        return null;
+     }
+ 
++    @Nullable
++    public static Entity spawnCreature(World worldIn, ItemStack stack, double x, double y, double z, @Nullable EntityPlayer player)
++    {
++        return spawnCreature(worldIn, func_190908_h(stack), stack.func_82837_s() ? stack.func_82833_r() : null, stack.func_77978_p(), player, x, y, z);
++    }
++
++    @Nullable
++    public static Entity func_77840_a(World p_77840_0_, @Nullable ResourceLocation p_77840_1_, double p_77840_2_, double p_77840_4_, double p_77840_6_)
++    {
++        return spawnCreature(p_77840_0_, p_77840_1_, null, null, null, p_77840_2_, p_77840_4_, p_77840_6_);
++    }
++
+     public void func_150895_a(CreativeTabs p_150895_1_, NonNullList<ItemStack> p_150895_2_)
+     {
+         if (this.func_194125_a(p_150895_1_))

--- a/patches/minecraft/net/minecraft/tileentity/MobSpawnerBaseLogic.java.patch
+++ b/patches/minecraft/net/minecraft/tileentity/MobSpawnerBaseLogic.java.patch
@@ -1,19 +1,44 @@
 --- ../src-base/minecraft/net/minecraft/tileentity/MobSpawnerBaseLogic.java
 +++ ../src-work/minecraft/net/minecraft/tileentity/MobSpawnerBaseLogic.java
-@@ -124,10 +124,11 @@
+@@ -124,22 +124,26 @@
                      EntityLiving entityliving = entity instanceof EntityLiving ? (EntityLiving)entity : null;
                      entity.func_70012_b(entity.field_70165_t, entity.field_70163_u, entity.field_70161_v, world.field_73012_v.nextFloat() * 360.0F, 0.0F);
  
 -                    if (entityliving == null || entityliving.func_70601_bi() && entityliving.func_70058_J())
 +                    if (entityliving == null || net.minecraftforge.event.ForgeEventFactory.canEntitySpawnSpawner(entityliving, func_98271_a(), (float)entity.field_70165_t, (float)entity.field_70163_u, (float)entity.field_70161_v, this))
                      {
-                         if (this.field_98282_f.func_185277_b().func_186856_d() == 1 && this.field_98282_f.func_185277_b().func_150297_b("id", 8) && entity instanceof EntityLiving)
+-                        if (this.field_98282_f.func_185277_b().func_186856_d() == 1 && this.field_98282_f.func_185277_b().func_150297_b("id", 8) && entity instanceof EntityLiving)
++                        if (entityliving != null)
                          {
-+                            if (!net.minecraftforge.event.ForgeEventFactory.doSpecialSpawn(entityliving, this.func_98271_a(), (float)entity.field_70165_t, (float)entity.field_70163_u, (float)entity.field_70161_v, this))
-                             ((EntityLiving)entity).func_180482_a(world.func_175649_E(new BlockPos(entity)), (IEntityLivingData)null);
-                         }
+-                            ((EntityLiving)entity).func_180482_a(world.func_175649_E(new BlockPos(entity)), (IEntityLivingData)null);
+-                        }
++                            entityliving.func_180482_a(world.func_175649_E(new BlockPos(entity)), (IEntityLivingData)null);
  
-@@ -307,4 +308,7 @@
+-                        AnvilChunkLoader.func_186052_a(entity, world);
+-                        world.func_175718_b(2004, blockpos, 0);
+-
+-                        if (entityliving != null)
++                            if (!net.minecraftforge.event.ForgeEventFactory.doSpecialSpawn(entityliving, this.func_98271_a(), (float)entity.field_70165_t, (float)entity.field_70163_u, (float)entity.field_70161_v, this))
++                            {
++                                AnvilChunkLoader.func_186052_a(entity, world);
++                                world.func_175718_b(2004, blockpos, 0);
++                                entityliving.func_70656_aK();
++                                flag = true;
++                            }
++                        }
++                        else
+                         {
+-                            entityliving.func_70656_aK();
++                            AnvilChunkLoader.func_186052_a(entity, world);
++                            world.func_175718_b(2004, blockpos, 0);
++                            flag = true;
+                         }
+-
+-                        flag = true;
+                     }
+                 }
+ 
+@@ -307,4 +311,7 @@
      {
          return this.field_98284_d;
      }

--- a/src/test/java/net/minecraftforge/debug/entity/living/ExtendedSpecialSpawnTest.java
+++ b/src/test/java/net/minecraftforge/debug/entity/living/ExtendedSpecialSpawnTest.java
@@ -1,5 +1,7 @@
 package net.minecraftforge.debug.entity.living;
 
+import net.minecraft.entity.Entity;
+import net.minecraft.entity.EntityLiving;
 import net.minecraft.entity.monster.EntityCreeper;
 import net.minecraft.entity.monster.EntitySkeleton;
 import net.minecraft.entity.monster.EntityZombie;
@@ -9,6 +11,8 @@ import net.minecraft.util.EnumHand;
 import net.minecraftforge.event.entity.living.LivingSpawnEvent;
 import net.minecraftforge.fml.common.Mod;
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
+
+import java.util.List;
 
 @Mod(
         modid = ExtendedSpecialSpawnTest.MOD_ID,
@@ -29,24 +33,43 @@ public class ExtendedSpecialSpawnTest
             return;
         }
 
+        if (event.getEntity() != null)
+            if (cancelEventRec(event.getEntity()))
+                event.setCanceled(true);
+    }
+
+    /** Handles the entity and all it's passengers recursively
+     *
+     * @param entity
+     * @return true, if the event should be cancelled, false otherwise
+     */
+    public static boolean cancelEventRec(Entity entity)
+    {
         // Rename all skeletons
-        if (event.getEntity() instanceof EntitySkeleton)
+        if (entity instanceof EntitySkeleton)
         {
-            event.getEntity().setCustomNameTag("Dinnerbone");
+            entity.setCustomNameTag("Dinnerbone");
         }
 
         // Prevents Creepers from spawning
-        if (event.getEntity() instanceof EntityCreeper)
+        if (entity instanceof EntityCreeper)
         {
-            event.setCanceled(true);
+            return true;
         }
 
         // Give Zombies a diamond sword
-        if (event.getEntity() instanceof EntityZombie)
+        if (entity instanceof EntityZombie)
         {
-            EntityZombie zombie = (EntityZombie) event.getEntity();
+            EntityZombie zombie = (EntityZombie) entity;
 
             zombie.setHeldItem(EnumHand.MAIN_HAND, new ItemStack(Item.getByNameOrId("minecraft:diamond_sword")));
         }
+
+        for(Entity passenger : entity.getPassengers())
+        {
+            if (cancelEventRec(passenger))
+                return true;
+        }
+        return false;
     }
 }

--- a/src/test/java/net/minecraftforge/debug/entity/living/ExtendedSpecialSpawnTest.java
+++ b/src/test/java/net/minecraftforge/debug/entity/living/ExtendedSpecialSpawnTest.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2018.
+ * Copyright (c) 2016-2019.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -16,6 +16,7 @@
  * License along with this library; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
  */
+
 package net.minecraftforge.debug.entity.living;
 
 import net.minecraft.entity.Entity;

--- a/src/test/java/net/minecraftforge/debug/entity/living/ExtendedSpecialSpawnTest.java
+++ b/src/test/java/net/minecraftforge/debug/entity/living/ExtendedSpecialSpawnTest.java
@@ -1,6 +1,6 @@
 /*
  * Minecraft Forge
- * Copyright (c) 2016-2019.
+ * Copyright (c) 2016-2018.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/test/java/net/minecraftforge/debug/entity/living/ExtendedSpecialSpawnTest.java
+++ b/src/test/java/net/minecraftforge/debug/entity/living/ExtendedSpecialSpawnTest.java
@@ -1,0 +1,52 @@
+package net.minecraftforge.debug.entity.living;
+
+import net.minecraft.entity.monster.EntityCreeper;
+import net.minecraft.entity.monster.EntitySkeleton;
+import net.minecraft.entity.monster.EntityZombie;
+import net.minecraft.item.Item;
+import net.minecraft.item.ItemStack;
+import net.minecraft.util.EnumHand;
+import net.minecraftforge.event.entity.living.LivingSpawnEvent;
+import net.minecraftforge.fml.common.Mod;
+import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
+
+@Mod(
+        modid = ExtendedSpecialSpawnTest.MOD_ID,
+        name = "Extended SpecialSpawn Test",
+        version = "1.0",
+        acceptableRemoteVersions = "*")
+@Mod.EventBusSubscriber(modid = ExtendedSpecialSpawnTest.MOD_ID)
+public class ExtendedSpecialSpawnTest
+{
+    static final String MOD_ID = "extended_special_spawn_test";
+    static final boolean ENABLED = false;
+
+    @SubscribeEvent
+    public static void onSpecialSpawn(LivingSpawnEvent.SpecialSpawn event)
+    {
+        if (!ENABLED)
+        {
+            return;
+        }
+
+        // Rename all skeletons
+        if (event.getEntity() instanceof EntitySkeleton)
+        {
+            event.getEntity().setCustomNameTag("Dinnerbone");
+        }
+
+        // Prevents Creepers from spawning
+        if (event.getEntity() instanceof EntityCreeper)
+        {
+            event.setCanceled(true);
+        }
+
+        // Give Zombies a diamond sword
+        if (event.getEntity() instanceof EntityZombie)
+        {
+            EntityZombie zombie = (EntityZombie) event.getEntity();
+
+            zombie.setHeldItem(EnumHand.MAIN_HAND, new ItemStack(Item.getByNameOrId("minecraft:diamond_sword")));
+        }
+    }
+}

--- a/src/test/java/net/minecraftforge/debug/entity/living/ExtendedSpecialSpawnTest.java
+++ b/src/test/java/net/minecraftforge/debug/entity/living/ExtendedSpecialSpawnTest.java
@@ -1,3 +1,21 @@
+/*
+ * Minecraft Forge
+ * Copyright (c) 2016-2018.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation version 2.1
+ * of the License.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
 package net.minecraftforge.debug.entity.living;
 
 import net.minecraft.entity.Entity;


### PR DESCRIPTION
The changes to SpawnEggs, MonsterSpawner and /summon Command fix the bugs I pointed out #5694

- SpawnEggs used by both players and dispensers along with portal blocks have their functionality forwarded to a common function. 
- The /summon command now triggers a SpecialSpawn event
- Monster spawner now trigger a SpecialSpawn event with and without NBT data present

All these cases follow the same order: 
- Create the entity
- Apply NBT data, custom names etc
- Trigger SpecialSpawn event
- If the event wasn't cancelled
         Spawn the Entity

The supplied mod listens (when turned on) for special spawn events and acts based on different entity types. Creeper spawns are cancelled, skeletons renamed and zombies get a diamond sword. 

Using this mod without the fixes would show the inconsitent trigger of the event, e.g.
- Spawning creepers using the /summon command would still summon a creeper, because the command never triggered an event
- Spawns from a monster spawner would pass unnoticed, if the spawner summoned the entities with additional nbt data, e.g. higher health, custom tags. 

This does not fix the inherent minecraft bug, that spawn eggs do not spawn their content recursively. A completely unified spawn mechanic would be feasible, if desired, 

I tested these changes in client and server mode, with the forge test mods, with additional common mods. 

As far as I can tell these changes should also be implemented in 1.13