### PR TITLE
[1.12] Improve performance of persistent chunk checks

### DIFF
--- a/patches/minecraft/net/minecraft/world/World.java.patch
+++ b/patches/minecraft/net/minecraft/world/World.java.patch
@@ -576,7 +576,7 @@
 -            int l2 = 32;
  
 -            if (p_72866_2_ && !this.func_175663_a(j2 - 32, 0, k2 - 32, j2 + 32, 0, k2 + 32, true))
-+            boolean isForced = getPersistentChunks().containsKey(new net.minecraft.util.math.ChunkPos(j2 >> 4, k2 >> 4));
++            boolean isForced = !this.field_72995_K && getPersistentChunks().containsKey(new net.minecraft.util.math.ChunkPos(j2 >> 4, k2 >> 4));
 +            int range = isForced ? 0 : 32;
 +            boolean canUpdate = !p_72866_2_ || this.func_175663_a(j2 - range, 0, k2 - range, j2 + range, 0, k2 + range, true);
 +            if (!canUpdate) canUpdate = net.minecraftforge.event.ForgeEventFactory.canEntityUpdate(p_72866_1_);


### PR DESCRIPTION
Some recent profiling showed a noticable amount of time in `World.updateEntityWithOptionalForce` is spent on `ForgeChunkManager.getPersistentChunksFor`.

Example overview:
![overview-pre](https://user-images.githubusercontent.com/1447117/56459847-930cad00-6391-11e9-8aa9-f35c63aa93df.png)

In addition to the `getPersistentChunks` call at the top level, looking into each of the `onUpdate` calls shows a large propertion of time spent calling `getPersistentChunks` via `move`/`resetPositionToBB`, which now calls `updateEntityWithOptionalForce` since #5160:
![chunk-checks-pre](https://user-images.githubusercontent.com/1447117/56459874-ed0d7280-6391-11e9-9252-0b367afdacdb.png)

This PR aims to improve the performance here, both by removing the redundant `containsKey` call in favour of a null-checked `get` as well as moving from the Guava `MapMaker` implementation to a simpler `WeakHashMap`. The patched `updateEntityWithOptionalForce` is also changed to skip the check entirely in the case of `world.isRemote` being true.

Access to the map is synchronised for thread-safety/correctness (equivalent to the existing map impl, see the points below), but as this should only really be accessed from a single thread there should be very little contention as a result.

Example overview with changes:
![overview-post](https://user-images.githubusercontent.com/1447117/56460227-5479f100-6397-11e9-84a9-4da0d2b26ea3.png)

This no longer shows up as a large part of `onUpdate`:
![chunk-checks-post](https://user-images.githubusercontent.com/1447117/56460241-88551680-6397-11e9-9256-fe2d23767752.png)

Regarding the existing code, there are some points I would like input on here:

* Why was the particular `new MapMaker().weakKeys().makeMap()` implementation chosen?
Is this intended for thread-safety/concurrency reasons, or just for the weak references? Only `World`-keyed collections use this, the other collections are plain hash-based non-concurrent versions, so it's hard to tell.

* Are any of the `ForgeChunkManager` functions intended to be used on the logical client? There are  `instanceof WorldServer` checks performed in some places, but not others, and even when the checks are performed, some actions are taken before them in some places (the `forcedChunks.remove(world)` call is relocated here for this reason, to make the behaviour symmetric). In particular, `loadWorld`/`unloadWorld` are called from `ForgeInternalHandler` unconditionally, so they will be called on client worlds at present. This is one of the things making thread-safety here an issue currently.
