### PR TITLE
[1.13.x] Implement Ingredient.getSerializer for custom ingredients

### DIFF
--- a/src/main/java/net/minecraftforge/common/crafting/CompoundIngredient.java
+++ b/src/main/java/net/minecraftforge/common/crafting/CompoundIngredient.java
@@ -107,6 +107,12 @@ public class CompoundIngredient extends Ingredient
         return isSimple;
     }
 
+    @Override
+    public IIngredientSerializer<? extends Ingredient> getSerializer()
+    {
+        return CraftingHelper.INGREDIENT_COMPOUND;
+    }
+
     @Nonnull
     public Collection<Ingredient> getChildren()
     {

--- a/src/main/java/net/minecraftforge/common/crafting/IngredientNBT.java
+++ b/src/main/java/net/minecraftforge/common/crafting/IngredientNBT.java
@@ -53,6 +53,12 @@ public class IngredientNBT extends Ingredient
         return false;
     }
 
+    @Override
+    public IIngredientSerializer<? extends Ingredient> getSerializer()
+    {
+        return CraftingHelper.INGREDIENT_NBT;
+    }
+
     public static class Serializer implements IIngredientSerializer<IngredientNBT>
     {
         @Override


### PR DESCRIPTION
As per https://github.com/MinecraftForge/MinecraftForge/blob/1.13.x/patches/minecraft/net/minecraft/item/crafting/Ingredient.java.patch#L67-L70 custom ingredients have to implement Ingredient.getSerializer. This is not the case for Forge's custom ingredients, which leads to e.g. [players not being able to connect to servers when recipes using those ingredients are present](https://paste.ubuntu.com/p/SNghDqpNM2/). This pull requests simply implements that method for `net.minecraftforge.common.crafting.CompoundIngredient` and `net.minecraftforge.common.crafting.IngredientNBT`.