### PR TITLE
[1.12] Fix incorrect block checks in terrain gen patches

### DIFF
--- a/patches/minecraft/net/minecraft/world/gen/MapGenCaves.java.patch
+++ b/patches/minecraft/net/minecraft/world/gen/MapGenCaves.java.patch
@@ -67,7 +67,7 @@
 +    {
 +        net.minecraft.world.biome.Biome biome = field_75039_c.func_180494_b(new BlockPos(x + chunkX * 16, 0, z + chunkZ * 16));
 +        IBlockState state = data.func_177856_a(x, y, z);
-+        return (isExceptionBiome(biome) ? state.func_177230_c() == Blocks.field_150349_c : state.func_177230_c() == biome.field_76752_A);
++        return (isExceptionBiome(biome) ? state.func_177230_c() == Blocks.field_150349_c : state == biome.field_76752_A);
 +    }
 +
 +    /**

--- a/patches/minecraft/net/minecraft/world/gen/MapGenRavine.java.patch
+++ b/patches/minecraft/net/minecraft/world/gen/MapGenRavine.java.patch
@@ -79,7 +79,7 @@
 +    {
 +        net.minecraft.world.biome.Biome biome = field_75039_c.func_180494_b(new BlockPos(x + chunkX * 16, 0, z + chunkZ * 16));
 +        IBlockState state = data.func_177856_a(x, y, z);
-+        return (isExceptionBiome(biome) ? state.func_177230_c() == Blocks.field_150349_c : state.func_177230_c() == biome.field_76752_A);
++        return (isExceptionBiome(biome) ? state.func_177230_c() == Blocks.field_150349_c : state == biome.field_76752_A);
 +    }
 +
 +    /**


### PR DESCRIPTION
Small PR to fix the `isTopBlock` checks in `MapGenCaves`/`MapGenRavine`, which currently incorrectly compare a `Block` to an `IBlockState`.