### PR TITLE
[1.12.2] Update EnumHelper to be compatible with OpenJ9

### DIFF
--- a/src/main/java/net/minecraftforge/common/util/EnumHelper.java
+++ b/src/main/java/net/minecraftforge/common/util/EnumHelper.java
@@ -250,6 +250,8 @@ public class EnumHelper
     {
         blankField(enumClass, "enumConstantDirectory");
         blankField(enumClass, "enumConstants");
+        //Open J9
+        blankField(enumClass, "enumVars");
     }
 
     @Nullable


### PR DESCRIPTION
OpenJ9 Implementation moves the enumConstantDirectory and enumConstants to a enumVars field.
Without this change, once the cache is built the first time the enum is modified, it will throw up a 
``` java.lang.IllegalArgumentException: No enum constant```