### PR TITLE
Added field to make "Looking at" debug info maximum distance configurable

### DIFF
--- a/src/main/java/net/minecraftforge/client/GuiIngameForge.java
+++ b/src/main/java/net/minecraftforge/client/GuiIngameForge.java
@@ -89,6 +89,11 @@ public class GuiIngameForge extends GuiIngame
     public static int left_height = 39;
     public static int right_height = 39;
 
+    /*
+     * If the Euclidian distance to the moused-over block in meters is less than this value, the "Looking at" text will appear on the debug overlay.
+     */
+    public static double ray_trace_distance = 20.0D;
+
     private FontRenderer fontrenderer = null;
     private RenderGameOverlayEvent eventParent;
     //private static final String MC_VERSION = MinecraftForge.MC_VERSION;
@@ -836,8 +841,8 @@ public class GuiIngameForge extends GuiIngame
         public void update()
         {
             Entity entity = this.mc.getRenderViewEntity();
-            this.rayTraceBlock = entity.rayTrace(20.0D, 0.0F, RayTraceFluidMode.NEVER);
-            this.rayTraceFluid = entity.rayTrace(20.0D, 0.0F, RayTraceFluidMode.ALWAYS);
+            this.rayTraceBlock = entity.rayTrace(ray_trace_distance, 0.0F, RayTraceFluidMode.NEVER);
+            this.rayTraceFluid = entity.rayTrace(ray_trace_distance, 0.0F, RayTraceFluidMode.ALWAYS);
         }
         @Override protected void renderDebugInfoLeft(){}
         @Override protected void renderDebugInfoRight(){}

--- a/src/main/java/net/minecraftforge/client/GuiIngameForge.java
+++ b/src/main/java/net/minecraftforge/client/GuiIngameForge.java
@@ -92,7 +92,7 @@ public class GuiIngameForge extends GuiIngame
     /*
      * If the Euclidian distance to the moused-over block in meters is less than this value, the "Looking at" text will appear on the debug overlay.
      */
-    public static double ray_trace_distance = 20.0D;
+    public static double rayTraceDistance = 20.0D;
 
     private FontRenderer fontrenderer = null;
     private RenderGameOverlayEvent eventParent;
@@ -841,8 +841,8 @@ public class GuiIngameForge extends GuiIngame
         public void update()
         {
             Entity entity = this.mc.getRenderViewEntity();
-            this.rayTraceBlock = entity.rayTrace(ray_trace_distance, 0.0F, RayTraceFluidMode.NEVER);
-            this.rayTraceFluid = entity.rayTrace(ray_trace_distance, 0.0F, RayTraceFluidMode.ALWAYS);
+            this.rayTraceBlock = entity.rayTrace(rayTraceDistance, 0.0F, RayTraceFluidMode.NEVER);
+            this.rayTraceFluid = entity.rayTrace(rayTraceDistance, 0.0F, RayTraceFluidMode.ALWAYS);
         }
         @Override protected void renderDebugInfoLeft(){}
         @Override protected void renderDebugInfoRight(){}

--- a/src/test/java/net/minecraftforge/debug/client/LookingAtDistanceTest.java
+++ b/src/test/java/net/minecraftforge/debug/client/LookingAtDistanceTest.java
@@ -39,6 +39,6 @@ public class LookingAtDistanceTest
             return;
         }
 
-        GuiIngameForge.ray_trace_distance *= 10;
+        GuiIngameForge.rayTraceDistance *= 10;
     }
 }

--- a/src/test/java/net/minecraftforge/debug/client/LookingAtDistanceTest.java
+++ b/src/test/java/net/minecraftforge/debug/client/LookingAtDistanceTest.java
@@ -1,0 +1,44 @@
+/*
+ * Minecraft Forge
+ * Copyright (c) 2016-2018.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation version 2.1
+ * of the License.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+package net.minecraftforge.debug.client;
+
+import net.minecraftforge.client.GuiIngameForge;
+
+@Mod(LookingAtDistanceTest.MODID)
+@Mod.EventBusSubscriber
+public class LookingAtDistanceTest
+{
+    public static final String MODID = "lookingatdistancetest";
+    /*
+     * Enabling this mod should increase tenfold the maximum distance at which the "Looking at" block/fluid info appears on the Debug overlay.
+     */
+    private static final boolean ENABLED = false;
+
+    @SubscribeEvent
+    public void init(FMLServerStartedEvent event) throws IOException
+    {
+        if (!ENABLED)
+        {
+            return;
+        }
+
+        GuiIngameForge.ray_trace_distance *= 10;
+    }
+}


### PR DESCRIPTION
A simple modification that simply allows a modder to modify the maximum distance at which the "Looking at" block/fluid info appears on the Debug overlay.

Achieving this without a change to Forge would require a modder to jump through hoops and duplicate code related to the debug overlay. See attempt here that only implements part of it: https://github.com/hypehuman/LookingFar/commit/2b289a636798f2c69ea01182acd88210baae33c2 and the related discussion thread: http://www.minecraftforge.net/forum/topic/70191-1132-correct-way-to-change-a-hard-coded-value/?tab=comments#comment-339934

My apologies if the test mod doesn't work, as I am unable to get the test environment to run. Details here if you'd like to help me with that: https://gist.github.com/mcenderdragon/6c7af2daf6f72b0cadf0c63169a87583#gistcomment-2895146