### PR TITLE
Fix invalid placeholder entity attributes (MC-150405)

### DIFF
--- a/patches/minecraft/net/minecraft/client/network/NetHandlerPlayClient.java.patch
+++ b/patches/minecraft/net/minecraft/client/network/NetHandlerPlayClient.java.patch
@@ -99,3 +99,12 @@
                  packetbuffer.release();
              }
          }
+@@ -2087,7 +2099,7 @@
+ 
+                     if (iattributeinstance == null)
+                     {
+-                        iattributeinstance = abstractattributemap.func_111150_b(new RangedAttribute((IAttribute)null, spacketentityproperties$snapshot.func_151409_a(), 0.0D, 2.2250738585072014E-308D, Double.MAX_VALUE));
++                        iattributeinstance = abstractattributemap.func_111150_b(new RangedAttribute((IAttribute)null, spacketentityproperties$snapshot.func_151409_a(), 0.0D, -Double.MAX_VALUE, Double.MAX_VALUE)); // Forge: fix invalid value range (MC-150405)
+                     }
+ 
+                     iattributeinstance.func_111128_a(spacketentityproperties$snapshot.func_151410_b());


### PR DESCRIPTION
Filed as vanilla bug [MC-150405](https://bugs.mojang.com/browse/MC-150405).

Clients register a placeholder attribute for any unknown attribute data received from the server, as described by https://github.com/MinecraftForge/MinecraftForge/pull/4331#issuecomment-324446421. However, currently the placeholder attribute is created with invalid values, causing the constructor to throw an `IllegalArgumentException`. This is caught by `Util.runTask`, however it prevents any following attributes from being processed.

This PR patches the minimum attribute value specified to be `-Double.MAX_VALUE` instead of the currently specified `Double.MIN_NORMAL`. This matches the maximum value of `Double.MAX_VALUE`, accepting any finite double value, which would seem to be the intended behaviour given negative attribute values are allowed. As the default value now falls into the accepted value range, no exception will be thrown and all attributes will be processed normally.