### PR TITLE
[1.12.x] Fix client sometimes generating biomes, causing incorrect biome generation on integrated server

### DIFF
--- a/patches/minecraft/net/minecraft/world/chunk/Chunk.java.patch
+++ b/patches/minecraft/net/minecraft/world/chunk/Chunk.java.patch
@@ -295,7 +295,21 @@
      }
  
      public Biome func_177411_a(BlockPos p_177411_1_, BiomeProvider p_177411_2_)
-@@ -1244,13 +1268,13 @@
+@@ -1190,7 +1214,12 @@
+ 
+         if (k == 255)
+         {
+-            Biome biome = p_177411_2_.func_180300_a(p_177411_1_, Biomes.field_76772_c);
++            // Forge: checking for client ensures that biomes are only generated on integrated server
++            // in singleplayer. Generating biomes on the client may corrupt the biome ID arrays on
++            // the server while they are being generated because IntCache can't be thread safe,
++            // so client and server may end up filling the same array.
++            // This is not necessary in 1.13 and newer versions.
++            Biome biome = field_76637_e.field_72995_K ? Biomes.field_76772_c : p_177411_2_.func_180300_a(p_177411_1_, Biomes.field_76772_c);
+             k = Biome.func_185362_a(biome);
+             this.field_76651_r[j << 4 | i] = (byte)(k & 255);
+         }
+@@ -1244,13 +1273,13 @@
                      BlockPos blockpos1 = blockpos.func_177982_a(k, (j << 4) + i1, l);
                      boolean flag = i1 == 0 || i1 == 15 || k == 0 || k == 15 || l == 0 || l == 15;
  
@@ -311,7 +325,7 @@
                              {
                                  this.field_76637_e.func_175664_x(blockpos2);
                              }
-@@ -1381,7 +1405,7 @@
+@@ -1381,7 +1410,7 @@
          {
              blockpos$mutableblockpos.func_181079_c(blockpos$mutableblockpos.func_177958_n(), l, blockpos$mutableblockpos.func_177952_p());
  
@@ -320,7 +334,7 @@
              {
                  this.field_76637_e.func_175664_x(blockpos$mutableblockpos);
              }
-@@ -1420,6 +1444,7 @@
+@@ -1420,6 +1449,7 @@
          else
          {
              System.arraycopy(p_177420_1_, 0, this.field_76634_f, 0, this.field_76634_f.length);
@@ -328,7 +342,7 @@
          }
      }
  
-@@ -1489,4 +1514,55 @@
+@@ -1489,4 +1519,55 @@
          QUEUED,
          CHECK;
      }


### PR DESCRIPTION
This is a vanilla issue (fixed in 1.13) that has never been properly reported to mojang because there is a different issue with similar-looking symptoms, that appears to be experienced by more players - [MC-34303](https://bugs.mojang.com/browse/MC-34303).

It doesn't happen frequently (I was only able to intentionally reproduce it once without any code changes that make it more common), but in some modded environments it appears to be more common. And it can cause crashes with mods that add custom biome layers (for example old versions of buildcraft have been affected: https://github.com/BuildCraft/BuildCraft/issues/3640).

The biome array is initially filled with -1 in EmptyChunk clientside. Player going into unloaded chunks (or close to it with fancy graphics) will call getBiome and cause the biome to be generated. If that happens at the same time as server generating biomes, the server will generate wrong biome IDs, that don't match with surrounding area. A way to manually trigger it by code change, is to change `if (k == 255)` to `if (world.isRemote)` (it just makes it much more common, so that it doesn't take forever to intentionally reproduce it). The effects look like this:
![2019-05-01_04 13 27](https://user-images.githubusercontent.com/1349112/57003008-d81bb500-6bc3-11e9-9a6f-fb62b0041701.png)

A few other ways to fix the issue:
 * Fill EmptyChunk biome array with something other than 255
 * Give EmptyChunk (or all client chunks) a dummy biome provider
 * isRemote check in BiomeProvider
 * (potentially slower): ThreadLocal lists in IntCache?