### PR TITLE
[1.12.x] Add piston hooks with test

### DIFF
--- a/patches/minecraft/net/minecraft/block/BlockPistonBase.java.patch
+++ b/patches/minecraft/net/minecraft/block/BlockPistonBase.java.patch
@@ -4,7 +4,7 @@
  
          if (p_189539_4_ == 0)
          {
-+            if(net.minecraftforge.event.ForgeEventFactory.onPistonExtend(p_189539_2_, p_189539_3_, enumfacing)) return false;
++            if(net.minecraftforge.event.ForgeEventFactory.onPistonMovePre(p_189539_2_, p_189539_3_, enumfacing, true)) return false;
              if (!this.func_176319_a(p_189539_2_, p_189539_3_, enumfacing, true))
              {
                  return false;
@@ -12,7 +12,7 @@
          }
          else if (p_189539_4_ == 1)
          {
-+            if(net.minecraftforge.event.ForgeEventFactory.onPistonRetract(p_189539_2_, p_189539_3_, enumfacing)) return false;
++            if(net.minecraftforge.event.ForgeEventFactory.onPistonMovePre(p_189539_2_, p_189539_3_, enumfacing, false)) return false;
              TileEntity tileentity1 = p_189539_2_.func_175625_s(p_189539_3_.func_177972_a(enumfacing));
  
              if (tileentity1 instanceof TileEntityPiston)
@@ -45,6 +45,15 @@
                  p_176319_1_.func_180501_a(blockpos1, Blocks.field_150350_a.func_176223_P(), 4);
                  --k;
                  aiblockstate[k] = iblockstate;
+@@ -396,7 +400,7 @@
+             {
+                 p_176319_1_.func_175685_c(blockpos2, Blocks.field_150332_K, false);
+             }
+-
++            net.minecraftforge.event.ForgeEventFactory.onPistonMovePost(p_176319_1_, p_176319_2_, p_176319_3_, p_176319_4_);
+             return true;
+         }
+     }
 @@ -434,6 +438,13 @@
          return new BlockStateContainer(this, new IProperty[] {field_176387_N, field_176320_b});
      }

--- a/patches/minecraft/net/minecraft/block/BlockPistonBase.java.patch
+++ b/patches/minecraft/net/minecraft/block/BlockPistonBase.java.patch
@@ -1,6 +1,22 @@
 --- ../src-base/minecraft/net/minecraft/block/BlockPistonBase.java
 +++ ../src-work/minecraft/net/minecraft/block/BlockPistonBase.java
-@@ -241,7 +241,7 @@
+@@ -198,6 +198,7 @@
+ 
+         if (p_189539_4_ == 0)
+         {
++            if(net.minecraftforge.event.ForgeEventFactory.onPistonExtend(p_189539_2_, p_189539_3_, enumfacing)) return false;
+             if (!this.func_176319_a(p_189539_2_, p_189539_3_, enumfacing, true))
+             {
+                 return false;
+@@ -208,6 +209,7 @@
+         }
+         else if (p_189539_4_ == 1)
+         {
++            if(net.minecraftforge.event.ForgeEventFactory.onPistonRetract(p_189539_2_, p_189539_3_, enumfacing)) return false;
+             TileEntity tileentity1 = p_189539_2_.func_175625_s(p_189539_3_.func_177972_a(enumfacing));
+ 
+             if (tileentity1 instanceof TileEntityPiston)
+@@ -241,7 +243,7 @@
                      }
                  }
  
@@ -9,7 +25,7 @@
                  {
                      this.func_176319_a(p_189539_2_, p_189539_3_, enumfacing, false);
                  }
-@@ -307,7 +307,7 @@
+@@ -307,7 +309,7 @@
                      return false;
                  }
  
@@ -18,7 +34,7 @@
              }
              else
              {
-@@ -353,7 +353,9 @@
+@@ -353,7 +355,9 @@
              {
                  BlockPos blockpos1 = list2.get(j);
                  IBlockState iblockstate = p_176319_1_.func_180495_p(blockpos1);
@@ -29,7 +45,7 @@
                  p_176319_1_.func_180501_a(blockpos1, Blocks.field_150350_a.func_176223_P(), 4);
                  --k;
                  aiblockstate[k] = iblockstate;
-@@ -434,6 +436,13 @@
+@@ -434,6 +438,13 @@
          return new BlockStateContainer(this, new IProperty[] {field_176387_N, field_176320_b});
      }
  

--- a/src/main/java/net/minecraftforge/event/ForgeEventFactory.java
+++ b/src/main/java/net/minecraftforge/event/ForgeEventFactory.java
@@ -836,15 +836,15 @@ public class ForgeEventFactory
         MinecraftForge.EVENT_BUS.post(event);
         return event.getList();
     }
-
-    public static boolean onPistonExtend(World world, BlockPos pos, EnumFacing facing)
+    
+    public static boolean onPistonMovePre(World world, BlockPos pos, EnumFacing facing, boolean extending)
     {
-        return MinecraftForge.EVENT_BUS.post(new PistonEvent.Extend(world, pos, facing));
+        return MinecraftForge.EVENT_BUS.post(new PistonEvent.Pre(world, pos, facing, extending ? PistonEvent.PistonMoveDirection.EXTEND : PistonEvent.PistonMoveDirection.RETRACT));
     }
     
-    public static boolean onPistonRetract(World world, BlockPos pos, EnumFacing facing)
+    public static boolean onPistonMovePost(World world, BlockPos pos, EnumFacing facing, boolean extending)
     {
-        return MinecraftForge.EVENT_BUS.post(new PistonEvent.Retract(world, pos, facing));
+        return MinecraftForge.EVENT_BUS.post(new PistonEvent.Post(world, pos, facing, extending ? PistonEvent.PistonMoveDirection.EXTEND : PistonEvent.PistonMoveDirection.RETRACT));
     }
     
 }

--- a/src/main/java/net/minecraftforge/event/ForgeEventFactory.java
+++ b/src/main/java/net/minecraftforge/event/ForgeEventFactory.java
@@ -132,6 +132,7 @@ import net.minecraftforge.event.world.BlockEvent.NeighborNotifyEvent;
 import net.minecraftforge.event.world.BlockEvent.PlaceEvent;
 import net.minecraftforge.event.world.ExplosionEvent;
 import net.minecraftforge.event.world.GetCollisionBoxesEvent;
+import net.minecraftforge.event.world.PistonEvent;
 import net.minecraftforge.event.world.WorldEvent;
 import net.minecraftforge.fml.common.ObfuscationReflectionHelper;
 import net.minecraftforge.fml.common.eventhandler.Event;
@@ -835,4 +836,13 @@ public class ForgeEventFactory
         MinecraftForge.EVENT_BUS.post(event);
         return event.getList();
     }
+
+    public static boolean onPistonExtend(World world, BlockPos pos, EnumFacing facing) {
+        return MinecraftForge.EVENT_BUS.post(new PistonEvent.Extend(world, pos, facing));
+    }
+    
+    public static boolean onPistonRetract(World world, BlockPos pos, EnumFacing facing) {
+        return MinecraftForge.EVENT_BUS.post(new PistonEvent.Retract(world, pos, facing));
+    }
+    
 }

--- a/src/main/java/net/minecraftforge/event/ForgeEventFactory.java
+++ b/src/main/java/net/minecraftforge/event/ForgeEventFactory.java
@@ -836,15 +836,15 @@ public class ForgeEventFactory
         MinecraftForge.EVENT_BUS.post(event);
         return event.getList();
     }
-    
+
     public static boolean onPistonMovePre(World world, BlockPos pos, EnumFacing facing, boolean extending)
     {
         return MinecraftForge.EVENT_BUS.post(new PistonEvent.Pre(world, pos, facing, extending ? PistonEvent.PistonMoveDirection.EXTEND : PistonEvent.PistonMoveDirection.RETRACT));
     }
-    
+
     public static boolean onPistonMovePost(World world, BlockPos pos, EnumFacing facing, boolean extending)
     {
         return MinecraftForge.EVENT_BUS.post(new PistonEvent.Post(world, pos, facing, extending ? PistonEvent.PistonMoveDirection.EXTEND : PistonEvent.PistonMoveDirection.RETRACT));
     }
-    
+
 }

--- a/src/main/java/net/minecraftforge/event/ForgeEventFactory.java
+++ b/src/main/java/net/minecraftforge/event/ForgeEventFactory.java
@@ -837,11 +837,13 @@ public class ForgeEventFactory
         return event.getList();
     }
 
-    public static boolean onPistonExtend(World world, BlockPos pos, EnumFacing facing) {
+    public static boolean onPistonExtend(World world, BlockPos pos, EnumFacing facing)
+    {
         return MinecraftForge.EVENT_BUS.post(new PistonEvent.Extend(world, pos, facing));
     }
     
-    public static boolean onPistonRetract(World world, BlockPos pos, EnumFacing facing) {
+    public static boolean onPistonRetract(World world, BlockPos pos, EnumFacing facing)
+    {
         return MinecraftForge.EVENT_BUS.post(new PistonEvent.Retract(world, pos, facing));
     }
     

--- a/src/main/java/net/minecraftforge/event/world/PistonEvent.java
+++ b/src/main/java/net/minecraftforge/event/world/PistonEvent.java
@@ -28,7 +28,7 @@ import net.minecraftforge.fml.common.eventhandler.Cancelable;
 /**
  * Base piston event, use {@link PistonEvent.Post} and {@link PistonEvent.Pre}
  */
-public class PistonEvent extends BlockEvent
+public abstract class PistonEvent extends BlockEvent
 {
 
     private final EnumFacing facing;

--- a/src/main/java/net/minecraftforge/event/world/PistonEvent.java
+++ b/src/main/java/net/minecraftforge/event/world/PistonEvent.java
@@ -1,3 +1,22 @@
+/*
+ * Minecraft Forge
+ * Copyright (c) 2016-2018.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation version 2.1
+ * of the License.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
 package net.minecraftforge.event.world;
 
 import net.minecraft.util.EnumFacing;

--- a/src/main/java/net/minecraftforge/event/world/PistonEvent.java
+++ b/src/main/java/net/minecraftforge/event/world/PistonEvent.java
@@ -19,6 +19,7 @@
 
 package net.minecraftforge.event.world;
 
+import net.minecraft.block.state.BlockPistonStructureHelper;
 import net.minecraft.util.EnumFacing;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.World;
@@ -71,6 +72,15 @@ public class PistonEvent extends BlockEvent
         {
             super(world, pos, facing);
         }
+        
+        /**
+         * @return A piston structure helper for this extension. This is equivalent to <code>new BlockPistonStructureHelper(this.getWorld(), this.getPos(), this.getFacing(), true)</code>
+         */
+        public BlockPistonStructureHelper getStructureHelper()
+        {
+            return new BlockPistonStructureHelper(this.getWorld(), this.getPos(), this.getFacing(), true);
+        }
+        
     }
 
     /**
@@ -83,6 +93,14 @@ public class PistonEvent extends BlockEvent
         public Retract(World world, BlockPos pos, EnumFacing facing)
         {
             super(world, pos, facing);
+        }
+        
+        /**
+         * @return A piston structure helper for this retraction. This is equivalent to <code>new BlockPistonStructureHelper(this.getWorld(), this.getPos(), this.getFacing(), false)</code>
+         */
+        public BlockPistonStructureHelper getStructureHelper()
+        {
+            return new BlockPistonStructureHelper(this.getWorld(), this.getPos(), this.getFacing(), false);
         }
     }
 }

--- a/src/main/java/net/minecraftforge/event/world/PistonEvent.java
+++ b/src/main/java/net/minecraftforge/event/world/PistonEvent.java
@@ -7,7 +7,6 @@ import net.minecraftforge.fml.common.eventhandler.Cancelable;
 
 /**
  * Base piston event, use {@link PistonEvent.Extend} and {@link PistonEvent.Retract} for specific movement types
- * @author its_meow
  */
 public class PistonEvent extends BlockEvent
 {
@@ -43,8 +42,8 @@ public class PistonEvent extends BlockEvent
     }
 
     /**
-     * Fired when a piston extends. Canceling prevents extension
-     * @author its_meow
+     * Fired when a piston extends at any point, only once per extension.
+     * Canceling prevents extension.
      */
     @Cancelable
     public static class Extend extends PistonEvent
@@ -56,8 +55,8 @@ public class PistonEvent extends BlockEvent
     }
 
     /**
-     * Fired when a piston retracts. Canceling prevents retraction.
-     * @author its_meow
+     * Fired when a piston retracts at any point, only once retraction.
+     * Canceling prevents retraction.
      */
     @Cancelable
     public static class Retract extends PistonEvent

--- a/src/main/java/net/minecraftforge/event/world/PistonEvent.java
+++ b/src/main/java/net/minecraftforge/event/world/PistonEvent.java
@@ -1,0 +1,70 @@
+package net.minecraftforge.event.world;
+
+import net.minecraft.util.EnumFacing;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.World;
+import net.minecraftforge.fml.common.eventhandler.Cancelable;
+
+/**
+ * Base piston event, use {@link PistonEvent.Extend} and {@link PistonEvent.Retract} for specific movement types
+ * @author its_meow
+ */
+public class PistonEvent extends BlockEvent
+{
+
+    private final EnumFacing facing;
+    
+    /**
+     * @param world
+     * @param pos - The position of the piston
+     * @param facing - The facing of the piston
+     */
+    public PistonEvent(World world, BlockPos pos, EnumFacing facing)
+    {
+        super(world, pos, world.getBlockState(pos));
+
+        this.facing = facing;
+    }
+    
+    /**
+     * @return The facing of the piston block
+     */
+    public EnumFacing getFacing()
+    {
+        return this.facing;
+    }
+    
+    /**
+     * Helper method that gets the piston position offset by its facing
+     */
+    public BlockPos getFaceOffsetPos()
+    {
+        return this.getPos().offset(facing);
+    }
+
+    /**
+     * Fired when a piston extends. Canceling prevents extension
+     * @author its_meow
+     */
+    @Cancelable
+    public static class Extend extends PistonEvent
+    {
+        public Extend(World world, BlockPos pos, EnumFacing facing)
+        {
+            super(world, pos, facing);
+        }
+    }
+
+    /**
+     * Fired when a piston retracts. Canceling prevents retraction.
+     * @author its_meow
+     */
+    @Cancelable
+    public static class Retract extends PistonEvent
+    {
+        public Retract(World world, BlockPos pos, EnumFacing facing)
+        {
+            super(world, pos, facing);
+        }
+    }
+}

--- a/src/main/java/net/minecraftforge/event/world/PistonEvent.java
+++ b/src/main/java/net/minecraftforge/event/world/PistonEvent.java
@@ -72,7 +72,8 @@ public class PistonEvent extends BlockEvent
     }
 
     /**
-     * @return A piston structure helper for this movement. This is equivalent to <code>new BlockPistonStructureHelper(this.getWorld(), this.getPos(), this.getFacing(), this.getDirection().isExtend)</code>
+     * @return A piston structure helper for this movement. This is equivalent to
+     *         <code>new BlockPistonStructureHelper(this.getWorld(), this.getPos(), this.getFacing(), this.getDirection().isExtend)</code>
      */
     public BlockPistonStructureHelper getStructureHelper()
     {
@@ -108,12 +109,12 @@ public class PistonEvent extends BlockEvent
 
     public static enum PistonMoveDirection
     {
-        EXTEND(true),
-        RETRACT(false);
+        EXTEND(true), RETRACT(false);
 
         public final boolean isExtend;
 
-        PistonMoveDirection(boolean isExtend) {
+        PistonMoveDirection(boolean isExtend)
+        {
             this.isExtend = isExtend;
         }
     }

--- a/src/main/java/net/minecraftforge/event/world/PistonEvent.java
+++ b/src/main/java/net/minecraftforge/event/world/PistonEvent.java
@@ -26,25 +26,27 @@ import net.minecraft.world.World;
 import net.minecraftforge.fml.common.eventhandler.Cancelable;
 
 /**
- * Base piston event, use {@link PistonEvent.Extend} and {@link PistonEvent.Retract} for specific movement types
+ * Base piston event, use {@link PistonEvent.Post} and {@link PistonEvent.Pre}
  */
 public class PistonEvent extends BlockEvent
 {
 
     private final EnumFacing facing;
-    
+    private final PistonMoveDirection direction;
+
     /**
      * @param world
      * @param pos - The position of the piston
      * @param facing - The facing of the piston
+     * @param direction - The move direction of the piston
      */
-    public PistonEvent(World world, BlockPos pos, EnumFacing facing)
+    public PistonEvent(World world, BlockPos pos, EnumFacing facing, PistonMoveDirection direction)
     {
         super(world, pos, world.getBlockState(pos));
-
         this.facing = facing;
+        this.direction = direction;
     }
-    
+
     /**
      * @return The facing of the piston block
      */
@@ -52,7 +54,7 @@ public class PistonEvent extends BlockEvent
     {
         return this.facing;
     }
-    
+
     /**
      * Helper method that gets the piston position offset by its facing
      */
@@ -62,45 +64,58 @@ public class PistonEvent extends BlockEvent
     }
 
     /**
-     * Fired when a piston extends at any point, only once per extension. (This includes indirect extension movement, it still fires once)
-     * Canceling prevents extension.
+     * @return The movement direction of the piston
      */
-    @Cancelable
-    public static class Extend extends PistonEvent
+    public PistonMoveDirection getDirection()
     {
-        public Extend(World world, BlockPos pos, EnumFacing facing)
-        {
-            super(world, pos, facing);
-        }
-        
-        /**
-         * @return A piston structure helper for this extension. This is equivalent to <code>new BlockPistonStructureHelper(this.getWorld(), this.getPos(), this.getFacing(), true)</code>
-         */
-        public BlockPistonStructureHelper getStructureHelper()
-        {
-            return new BlockPistonStructureHelper(this.getWorld(), this.getPos(), this.getFacing(), true);
-        }
-        
+        return direction;
     }
 
     /**
-     * Fired when a piston retracts at any point, only once per retraction. (This includes indirect retraction movement, it still fires once)
-     * Canceling prevents retraction.
+     * @return A piston structure helper for this movement. This is equivalent to <code>new BlockPistonStructureHelper(this.getWorld(), this.getPos(), this.getFacing(), this.getDirection().isExtend)</code>
+     */
+    public BlockPistonStructureHelper getStructureHelper()
+    {
+        return new BlockPistonStructureHelper(this.getWorld(), this.getPos(), this.getFacing(), this.getDirection().isExtend);
+    }
+
+    /**
+     * Fires after the piston has moved and set surrounding states. This will not fire if {@link PistonEvent.Pre} is cancelled.
+     */
+    public static class Post extends PistonEvent
+    {
+
+        public Post(World world, BlockPos pos, EnumFacing facing, PistonMoveDirection direction)
+        {
+            super(world, pos, facing, direction);
+        }
+
+    }
+
+    /**
+     * Fires before the piston has updated block states. Cancellation prevents movement.
      */
     @Cancelable
-    public static class Retract extends PistonEvent
+    public static class Pre extends PistonEvent
     {
-        public Retract(World world, BlockPos pos, EnumFacing facing)
+
+        public Pre(World world, BlockPos pos, EnumFacing facing, PistonMoveDirection direction)
         {
-            super(world, pos, facing);
+            super(world, pos, facing, direction);
         }
-        
-        /**
-         * @return A piston structure helper for this retraction. This is equivalent to <code>new BlockPistonStructureHelper(this.getWorld(), this.getPos(), this.getFacing(), false)</code>
-         */
-        public BlockPistonStructureHelper getStructureHelper()
-        {
-            return new BlockPistonStructureHelper(this.getWorld(), this.getPos(), this.getFacing(), false);
+
+    }
+
+    public static enum PistonMoveDirection
+    {
+        EXTEND(true),
+        RETRACT(false);
+
+        public final boolean isExtend;
+
+        PistonMoveDirection(boolean isExtend) {
+            this.isExtend = isExtend;
         }
     }
+
 }

--- a/src/main/java/net/minecraftforge/event/world/PistonEvent.java
+++ b/src/main/java/net/minecraftforge/event/world/PistonEvent.java
@@ -42,7 +42,7 @@ public class PistonEvent extends BlockEvent
     }
 
     /**
-     * Fired when a piston extends at any point, only once per extension.
+     * Fired when a piston extends at any point, only once per extension. (This includes indirect extension movement, it still fires once)
      * Canceling prevents extension.
      */
     @Cancelable
@@ -55,7 +55,7 @@ public class PistonEvent extends BlockEvent
     }
 
     /**
-     * Fired when a piston retracts at any point, only once retraction.
+     * Fired when a piston retracts at any point, only once per retraction. (This includes indirect retraction movement, it still fires once)
      * Canceling prevents retraction.
      */
     @Cancelable

--- a/src/test/java/net/minecraftforge/debug/block/PistonEventTest.java
+++ b/src/test/java/net/minecraftforge/debug/block/PistonEventTest.java
@@ -1,0 +1,118 @@
+package net.minecraftforge.debug.block;
+
+import net.minecraft.block.Block;
+import net.minecraft.block.BlockPistonBase;
+import net.minecraft.block.material.Material;
+import net.minecraft.block.state.BlockPistonStructureHelper;
+import net.minecraft.client.Minecraft;
+import net.minecraft.creativetab.CreativeTabs;
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.init.Blocks;
+import net.minecraft.item.Item;
+import net.minecraft.item.ItemBlock;
+import net.minecraft.util.EnumFacing;
+import net.minecraft.util.ResourceLocation;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.text.TextComponentString;
+import net.minecraft.world.World;
+import net.minecraftforge.event.RegistryEvent;
+import net.minecraftforge.event.world.PistonEvent;
+import net.minecraftforge.fml.common.Mod;
+import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
+
+/**
+ * This test mod blocks pistons from moving cobblestone at all except indirectly
+ * This test mod adds a block that moves upwards when pushed by a piston
+ * This test mod informs the user what will happen the piston and affected blocks when changes are made
+ * @author its_meow
+ */
+@Mod.EventBusSubscriber(modid = PistonEventTest.MODID)
+@Mod(modid = PistonEventTest.MODID)
+public class PistonEventTest {
+
+    public static final String MODID = "pistoneventtest";
+
+    private static Block shiftOnMove = new BlockShiftOnMove();
+
+    @SubscribeEvent
+    public static void regItem(RegistryEvent.Register<Item> event)
+    {
+        event.getRegistry().register(new ItemBlock(shiftOnMove).setRegistryName(shiftOnMove.getRegistryName()));
+    }
+
+    @SubscribeEvent
+    public static void regBlock(RegistryEvent.Register<Block> event)
+    {
+        event.getRegistry().register(shiftOnMove);
+    }
+
+    @SubscribeEvent
+    public static void onPistonExtend(PistonEvent.Extend event)
+    {
+        if (event.getWorld().isRemote)
+        {
+            BlockPistonStructureHelper pistonHelper = new BlockPistonStructureHelper(event.getWorld(), event.getPos(), event.getFacing(), true);
+            EntityPlayer player = Minecraft.getMinecraft().player;
+            if (pistonHelper.canMove()) 
+            {
+                player.sendMessage(new TextComponentString(String.format("Piston will extend moving %d blocks and destroy %d blocks", pistonHelper.getBlocksToMove().size(), pistonHelper.getBlocksToDestroy().size())));
+            }
+            else
+            {
+                player.sendMessage(new TextComponentString("Piston won't extend"));
+            }
+        }
+
+        // Make the block move up and out of the way so long as it won't replace the piston
+        World world = event.getWorld();
+        BlockPos pushedBlockPos = event.getFaceOffsetPos();
+        if (world.getBlockState(pushedBlockPos).getBlock() == shiftOnMove && event.getFacing() != EnumFacing.DOWN)
+        {
+            world.setBlockToAir(pushedBlockPos);
+            world.setBlockState(pushedBlockPos.up(), shiftOnMove.getDefaultState());
+        }
+        
+        // Block pushing cobblestone (directly, indirectly works)
+        event.setCanceled(event.getWorld().getBlockState(event.getFaceOffsetPos()).getBlock() == Blocks.COBBLESTONE);
+    }
+
+    @SubscribeEvent
+    public static void onPistonRetract(PistonEvent.Retract event)
+    {
+        boolean isSticky = event.getWorld().getBlockState(event.getPos()).getBlock() == Blocks.STICKY_PISTON;
+        if (event.getWorld().isRemote)
+        {
+            EntityPlayer player = Minecraft.getMinecraft().player;
+            if (isSticky)
+            {
+                BlockPos targetPos = event.getFaceOffsetPos().offset(event.getFacing());
+                boolean canPush = BlockPistonBase.canPush(event.getWorld().getBlockState(targetPos), event.getWorld(), event.getFaceOffsetPos(), event.getFacing().getOpposite(), false, event.getFacing());
+                boolean isAir = event.getWorld().isAirBlock(targetPos);
+                player.sendMessage(new TextComponentString(String.format("Piston will retract moving %d blocks", !isAir && canPush ? 1 : 0)));
+            }
+            else
+            {
+                player.sendMessage(new TextComponentString("Piston will retract"));
+            }
+        }
+        // Offset twice to see if retraction will pull cobblestone
+        event.setCanceled(event.getWorld().getBlockState(event.getFaceOffsetPos().offset(event.getFacing())).getBlock() == Blocks.COBBLESTONE && isSticky);
+    }
+
+    public static class BlockShiftOnMove extends Block
+    {
+        public static String blockName = "shiftonmove";
+        public static ResourceLocation blockId = new ResourceLocation(MODID, blockName);
+
+        public BlockShiftOnMove()
+        {
+            super(Material.ROCK);
+            setCreativeTab(CreativeTabs.BUILDING_BLOCKS);
+            setUnlocalizedName(MODID + "." + blockName);
+            setRegistryName(blockId);
+            setCreativeTab(CreativeTabs.BUILDING_BLOCKS);
+        }
+
+    }
+
+}

--- a/src/test/java/net/minecraftforge/debug/block/PistonEventTest.java
+++ b/src/test/java/net/minecraftforge/debug/block/PistonEventTest.java
@@ -24,7 +24,6 @@ import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
  * This test mod blocks pistons from moving cobblestone at all except indirectly
  * This test mod adds a block that moves upwards when pushed by a piston
  * This test mod informs the user what will happen the piston and affected blocks when changes are made
- * @author its_meow
  */
 @Mod.EventBusSubscriber(modid = PistonEventTest.MODID)
 @Mod(modid = PistonEventTest.MODID)

--- a/src/test/java/net/minecraftforge/debug/block/PistonEventTest.java
+++ b/src/test/java/net/minecraftforge/debug/block/PistonEventTest.java
@@ -1,3 +1,22 @@
+/*
+ * Minecraft Forge
+ * Copyright (c) 2016-2018.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation version 2.1
+ * of the License.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
 package net.minecraftforge.debug.block;
 
 import net.minecraft.block.Block;

--- a/src/test/java/net/minecraftforge/debug/block/PistonEventTest.java
+++ b/src/test/java/net/minecraftforge/debug/block/PistonEventTest.java
@@ -51,7 +51,8 @@ import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
  */
 @Mod.EventBusSubscriber(modid = PistonEventTest.MODID)
 @Mod(modid = PistonEventTest.MODID)
-public class PistonEventTest {
+public class PistonEventTest
+{
 
     public static final String MODID = "pistoneventtest";
 
@@ -71,15 +72,15 @@ public class PistonEventTest {
 
     @SubscribeEvent
     public static void pistonPre(PistonEvent.Pre event)
-    {   
-        if(event.getDirection() == PistonMoveDirection.EXTEND)
+    {
+        if (event.getDirection() == PistonMoveDirection.EXTEND)
         {
             World world = event.getWorld();
             BlockPistonStructureHelper pistonHelper = event.getStructureHelper();
             if (world.isRemote)
             {
                 EntityPlayer player = Minecraft.getMinecraft().player;
-                if (pistonHelper.canMove()) 
+                if (pistonHelper.canMove())
                 {
                     player.sendMessage(new TextComponentString(String.format("Piston will extend moving %d blocks and destroy %d blocks", pistonHelper.getBlocksToMove().size(), pistonHelper.getBlocksToDestroy().size())));
                 }
@@ -89,13 +90,13 @@ public class PistonEventTest {
                 }
             }
 
-            if(pistonHelper.canMove())
+            if (pistonHelper.canMove())
             {
                 List<BlockPos> posList = pistonHelper.getBlocksToMove();
-                for(BlockPos newPos : posList)
+                for (BlockPos newPos : posList)
                 {
                     IBlockState state = event.getWorld().getBlockState(newPos);
-                    if(state.getBlock() == Blocks.WOOL)
+                    if (state.getBlock() == Blocks.WOOL)
                     {
                         state.getBlock().dropBlockAsItem(world, newPos, state, 0);
                         world.setBlockToAir(newPos);
@@ -110,7 +111,7 @@ public class PistonEventTest {
                 world.setBlockToAir(pushedBlockPos);
                 world.setBlockState(pushedBlockPos.up(), shiftOnMove.getDefaultState());
             }
-            
+
             // Block pushing cobblestone (directly, indirectly works)
             event.setCanceled(event.getWorld().getBlockState(event.getFaceOffsetPos()).getBlock() == Blocks.COBBLESTONE);
         }

--- a/src/test/java/net/minecraftforge/debug/block/PistonEventTest.java
+++ b/src/test/java/net/minecraftforge/debug/block/PistonEventTest.java
@@ -19,10 +19,13 @@
 
 package net.minecraftforge.debug.block;
 
+import java.util.List;
+
 import net.minecraft.block.Block;
 import net.minecraft.block.BlockPistonBase;
 import net.minecraft.block.material.Material;
 import net.minecraft.block.state.BlockPistonStructureHelper;
+import net.minecraft.block.state.IBlockState;
 import net.minecraft.client.Minecraft;
 import net.minecraft.creativetab.CreativeTabs;
 import net.minecraft.entity.player.EntityPlayer;
@@ -36,6 +39,7 @@ import net.minecraft.util.text.TextComponentString;
 import net.minecraft.world.World;
 import net.minecraftforge.event.RegistryEvent;
 import net.minecraftforge.event.world.PistonEvent;
+import net.minecraftforge.event.world.PistonEvent.PistonMoveDirection;
 import net.minecraftforge.fml.common.Mod;
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
 
@@ -43,6 +47,7 @@ import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
  * This test mod blocks pistons from moving cobblestone at all except indirectly
  * This test mod adds a block that moves upwards when pushed by a piston
  * This test mod informs the user what will happen the piston and affected blocks when changes are made
+ * This test mod makes any wool pushed by a piston drop after being pushed.
  */
 @Mod.EventBusSubscriber(modid = PistonEventTest.MODID)
 @Mod(modid = PistonEventTest.MODID)
@@ -65,56 +70,71 @@ public class PistonEventTest {
     }
 
     @SubscribeEvent
-    public static void onPistonExtend(PistonEvent.Extend event)
-    {
-        if (event.getWorld().isRemote)
+    public static void pistonPre(PistonEvent.Pre event)
+    {   
+        if(event.getDirection() == PistonMoveDirection.EXTEND)
         {
-            BlockPistonStructureHelper pistonHelper = new BlockPistonStructureHelper(event.getWorld(), event.getPos(), event.getFacing(), true);
-            EntityPlayer player = Minecraft.getMinecraft().player;
-            if (pistonHelper.canMove()) 
+            World world = event.getWorld();
+            BlockPistonStructureHelper pistonHelper = event.getStructureHelper();
+            if (world.isRemote)
             {
-                player.sendMessage(new TextComponentString(String.format("Piston will extend moving %d blocks and destroy %d blocks", pistonHelper.getBlocksToMove().size(), pistonHelper.getBlocksToDestroy().size())));
+                EntityPlayer player = Minecraft.getMinecraft().player;
+                if (pistonHelper.canMove()) 
+                {
+                    player.sendMessage(new TextComponentString(String.format("Piston will extend moving %d blocks and destroy %d blocks", pistonHelper.getBlocksToMove().size(), pistonHelper.getBlocksToDestroy().size())));
+                }
+                else
+                {
+                    player.sendMessage(new TextComponentString("Piston won't extend"));
+                }
             }
-            else
-            {
-                player.sendMessage(new TextComponentString("Piston won't extend"));
-            }
-        }
 
-        // Make the block move up and out of the way so long as it won't replace the piston
-        World world = event.getWorld();
-        BlockPos pushedBlockPos = event.getFaceOffsetPos();
-        if (world.getBlockState(pushedBlockPos).getBlock() == shiftOnMove && event.getFacing() != EnumFacing.DOWN)
-        {
-            world.setBlockToAir(pushedBlockPos);
-            world.setBlockState(pushedBlockPos.up(), shiftOnMove.getDefaultState());
-        }
-        
-        // Block pushing cobblestone (directly, indirectly works)
-        event.setCanceled(event.getWorld().getBlockState(event.getFaceOffsetPos()).getBlock() == Blocks.COBBLESTONE);
-    }
+            if(pistonHelper.canMove())
+            {
+                List<BlockPos> posList = pistonHelper.getBlocksToMove();
+                for(BlockPos newPos : posList)
+                {
+                    IBlockState state = event.getWorld().getBlockState(newPos);
+                    if(state.getBlock() == Blocks.WOOL)
+                    {
+                        state.getBlock().dropBlockAsItem(world, newPos, state, 0);
+                        world.setBlockToAir(newPos);
+                    }
+                }
+            }
 
-    @SubscribeEvent
-    public static void onPistonRetract(PistonEvent.Retract event)
-    {
-        boolean isSticky = event.getWorld().getBlockState(event.getPos()).getBlock() == Blocks.STICKY_PISTON;
-        if (event.getWorld().isRemote)
-        {
-            EntityPlayer player = Minecraft.getMinecraft().player;
-            if (isSticky)
+            // Make the block move up and out of the way so long as it won't replace the piston
+            BlockPos pushedBlockPos = event.getFaceOffsetPos();
+            if (world.getBlockState(pushedBlockPos).getBlock() == shiftOnMove && event.getFacing() != EnumFacing.DOWN)
             {
-                BlockPos targetPos = event.getFaceOffsetPos().offset(event.getFacing());
-                boolean canPush = BlockPistonBase.canPush(event.getWorld().getBlockState(targetPos), event.getWorld(), event.getFaceOffsetPos(), event.getFacing().getOpposite(), false, event.getFacing());
-                boolean isAir = event.getWorld().isAirBlock(targetPos);
-                player.sendMessage(new TextComponentString(String.format("Piston will retract moving %d blocks", !isAir && canPush ? 1 : 0)));
+                world.setBlockToAir(pushedBlockPos);
+                world.setBlockState(pushedBlockPos.up(), shiftOnMove.getDefaultState());
             }
-            else
-            {
-                player.sendMessage(new TextComponentString("Piston will retract"));
-            }
+            
+            // Block pushing cobblestone (directly, indirectly works)
+            event.setCanceled(event.getWorld().getBlockState(event.getFaceOffsetPos()).getBlock() == Blocks.COBBLESTONE);
         }
-        // Offset twice to see if retraction will pull cobblestone
-        event.setCanceled(event.getWorld().getBlockState(event.getFaceOffsetPos().offset(event.getFacing())).getBlock() == Blocks.COBBLESTONE && isSticky);
+        else
+        {
+            boolean isSticky = event.getWorld().getBlockState(event.getPos()).getBlock() == Blocks.STICKY_PISTON;
+            if (event.getWorld().isRemote)
+            {
+                EntityPlayer player = Minecraft.getMinecraft().player;
+                if (isSticky)
+                {
+                    BlockPos targetPos = event.getFaceOffsetPos().offset(event.getFacing());
+                    boolean canPush = BlockPistonBase.canPush(event.getWorld().getBlockState(targetPos), event.getWorld(), event.getFaceOffsetPos(), event.getFacing().getOpposite(), false, event.getFacing());
+                    boolean isAir = event.getWorld().isAirBlock(targetPos);
+                    player.sendMessage(new TextComponentString(String.format("Piston will retract moving %d blocks", !isAir && canPush ? 1 : 0)));
+                }
+                else
+                {
+                    player.sendMessage(new TextComponentString("Piston will retract"));
+                }
+            }
+            // Offset twice to see if retraction will pull cobblestone
+            event.setCanceled(event.getWorld().getBlockState(event.getFaceOffsetPos().offset(event.getFacing())).getBlock() == Blocks.COBBLESTONE && isSticky);
+        }
     }
 
     public static class BlockShiftOnMove extends Block


### PR DESCRIPTION
Resolves #5722 when merged. Provides two events, PistonEvent.Retract and PistonEvent.Extend. Read the test mod class javadoc for info on what it does. Testing the test mod showed no out of the ordinary results, everything seemed functional (including cancellation). Most of the test mod is from a modified version of #3481 