### PR TITLE
Fix caps not being visible on old player during clone event

### DIFF
--- a/patches/minecraft/net/minecraft/server/management/PlayerList.java.patch
+++ b/patches/minecraft/net/minecraft/server/management/PlayerList.java.patch
@@ -82,23 +82,25 @@
        p_72368_1_.func_71121_q().func_73039_n().func_72790_b(p_72368_1_);
        p_72368_1_.func_71121_q().func_184164_w().func_72695_c(p_72368_1_);
        this.field_72404_b.remove(p_72368_1_);
-       this.field_72400_f.func_71218_a(p_72368_1_.field_71093_bK).func_72973_f(p_72368_1_);
+-      this.field_72400_f.func_71218_a(p_72368_1_.field_71093_bK).func_72973_f(p_72368_1_);
 -      BlockPos blockpos = p_72368_1_.func_180470_cg();
 -      boolean flag = p_72368_1_.func_82245_bX();
++      this.field_72400_f.func_71218_a(p_72368_1_.field_71093_bK).removeEntityDangerously(p_72368_1_, true); // Forge: keep data until copyFrom called
 +      BlockPos blockpos = p_72368_1_.getBedLocation(p_72368_2_);
 +      boolean flag = p_72368_1_.isSpawnForced(p_72368_2_);
        p_72368_1_.field_71093_bK = p_72368_2_;
        PlayerInteractionManager playerinteractionmanager;
        if (this.field_72400_f.func_71242_L()) {
-@@ -409,6 +432,7 @@
+@@ -409,6 +432,8 @@
        EntityPlayerMP entityplayermp = new EntityPlayerMP(this.field_72400_f, this.field_72400_f.func_71218_a(p_72368_1_.field_71093_bK), p_72368_1_.func_146103_bH(), playerinteractionmanager);
        entityplayermp.field_71135_a = p_72368_1_.field_71135_a;
        entityplayermp.func_193104_a(p_72368_1_, p_72368_3_);
++      p_72368_1_.remove(false); // Forge: clone event had a chance to see old data, now discard it
 +      entityplayermp.field_71093_bK = p_72368_2_;
        entityplayermp.func_145769_d(p_72368_1_.func_145782_y());
        entityplayermp.func_184819_a(p_72368_1_.func_184591_cq());
  
-@@ -422,7 +446,7 @@
+@@ -422,7 +447,7 @@
           BlockPos blockpos1 = EntityPlayer.func_180467_a(this.field_72400_f.func_71218_a(p_72368_1_.field_71093_bK), blockpos, flag);
           if (blockpos1 != null) {
              entityplayermp.func_70012_b((double)((float)blockpos1.func_177958_n() + 0.5F), (double)((float)blockpos1.func_177956_o() + 0.1F), (double)((float)blockpos1.func_177952_p() + 0.5F), 0.0F, 0.0F);
@@ -107,7 +109,7 @@
           } else {
              entityplayermp.field_71135_a.func_147359_a(new SPacketChangeGameState(0, 0.0F));
           }
-@@ -434,7 +458,7 @@
+@@ -434,7 +459,7 @@
           entityplayermp.func_70107_b(entityplayermp.field_70165_t, entityplayermp.field_70163_u + 1.0D, entityplayermp.field_70161_v);
        }
  
@@ -116,7 +118,7 @@
        BlockPos blockpos2 = worldserver.func_175694_M();
        entityplayermp.field_71135_a.func_147364_a(entityplayermp.field_70165_t, entityplayermp.field_70163_u, entityplayermp.field_70161_v, entityplayermp.field_70177_z, entityplayermp.field_70125_A);
        entityplayermp.field_71135_a.func_147359_a(new SPacketSpawnPosition(blockpos2));
-@@ -447,6 +471,7 @@
+@@ -447,6 +472,7 @@
        this.field_177454_f.put(entityplayermp.func_110124_au(), entityplayermp);
        entityplayermp.func_71116_b();
        entityplayermp.func_70606_j(entityplayermp.func_110143_aJ());
@@ -124,7 +126,7 @@
        return entityplayermp;
     }
  
-@@ -457,15 +482,19 @@
+@@ -457,15 +483,19 @@
     }
  
     public void func_187242_a(EntityPlayerMP p_187242_1_, DimensionType p_187242_2_) {
@@ -148,7 +150,7 @@
        this.func_72375_a(p_187242_1_, worldserver);
        p_187242_1_.field_71135_a.func_147364_a(p_187242_1_.field_70165_t, p_187242_1_.field_70163_u, p_187242_1_.field_70161_v, p_187242_1_.field_70177_z, p_187242_1_.field_70125_A);
        p_187242_1_.field_71134_c.func_73080_a(worldserver1);
-@@ -477,29 +506,25 @@
+@@ -477,29 +507,25 @@
           p_187242_1_.field_71135_a.func_147359_a(new SPacketEntityEffect(p_187242_1_.func_145782_y(), potioneffect));
        }
  
@@ -191,7 +193,7 @@
           BlockPos blockpos;
           if (p_82448_2_ == DimensionType.THE_END) {
              blockpos = p_82448_4_.func_175694_M();
-@@ -517,13 +542,14 @@
+@@ -517,13 +543,14 @@
        }
  
        p_82448_3_.field_72984_F.func_76319_b();


### PR DESCRIPTION
Fixes the situation described in this comment and following ones: https://github.com/MinecraftForge/MinecraftForge/issues/5500#issuecomment-474703823

In various places, forge patches in "keep data" params until the player's data can be copied, then invalidates it. This is one case that got missed, and prevents the Player clone event from seeing old caps. This happens for end returns and death respawns.

With this PR, we should have the 1.12 behaviour back for all cases w.r.t. caps visibility across all types dimensional teleports.