### PR TITLE
Update 'build.gradle' to fix run configs for launching forge

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -208,6 +208,11 @@ project(':forge') {
                 environment 'LAUNCHER_VERSION', SPEC_VERSION
                 property 'terminal.ansi', 'true'
                 property 'org.lwjgl.system.SharedLibraryExtractDirectory', 'lwjgl_dll'
+
+                ideaModule "${rootProject.name}.${project.name}.userdev"
+
+                source sourceSets.main
+                source sourceSets.userdev
             }
 
             forge_server {
@@ -224,6 +229,11 @@ project(':forge') {
                 environment 'FORGE_SPEC', SPEC_VERSION
                 environment 'FORGE_VERSION', project.version.substring(MC_VERSION.length() + 1).toString()
                 environment 'LAUNCHER_VERSION', SPEC_VERSION
+
+                ideaModule "${rootProject.name}.${project.name}.userdev"
+
+                source sourceSets.main
+                source sourceSets.userdev
             }
         }
     }


### PR DESCRIPTION
This allows the `forge_client` and `forge_server` run configs to work via gradle and also sets the appropriate idea module when using `:forge:genIntellijRuns`