### PR TITLE
[1.13.x] Tags for several old oredicts and some extra

### DIFF
--- a/src/main/resources/data/forge/tags/blocks/bookshelves.json
+++ b/src/main/resources/data/forge/tags/blocks/bookshelves.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "minecraft:bookshelf"
+  ]
+}

--- a/src/main/resources/data/forge/tags/blocks/end_stone.json
+++ b/src/main/resources/data/forge/tags/blocks/end_stone.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "minecraft:end_stone"
+  ]
+}

--- a/src/main/resources/data/forge/tags/blocks/gravel.json
+++ b/src/main/resources/data/forge/tags/blocks/gravel.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "minecraft:gravel"
+  ]
+}

--- a/src/main/resources/data/forge/tags/blocks/heads.json
+++ b/src/main/resources/data/forge/tags/blocks/heads.json
@@ -1,0 +1,17 @@
+{
+  "replace": false,
+  "values": [
+    "minecraft:creeper_head",
+    "minecraft:creeper_wall_head",
+    "minecraft:dragon_head",
+    "minecraft:dragon_wall_head",
+    "minecraft:player_head",
+    "minecraft:player_wall_head",
+    "minecraft:skeleton_skull",
+    "minecraft:skeleton_wall_skull",
+    "minecraft:wither_skeleton_skull",
+    "minecraft:wither_skeleton_wall_skull",
+    "minecraft:zombie_head",
+    "minecraft:zombie_wall_head"
+  ]
+}

--- a/src/main/resources/data/forge/tags/blocks/netherrack.json
+++ b/src/main/resources/data/forge/tags/blocks/netherrack.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "minecraft:netherrack"
+  ]
+}

--- a/src/main/resources/data/forge/tags/blocks/obsidian.json
+++ b/src/main/resources/data/forge/tags/blocks/obsidian.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "minecraft:obsidian"
+  ]
+}

--- a/src/main/resources/data/forge/tags/blocks/sandstone.json
+++ b/src/main/resources/data/forge/tags/blocks/sandstone.json
@@ -1,0 +1,13 @@
+{
+  "replace": false,
+  "values": [
+    "minecraft:sandstone",
+    "minecraft:cut_sandstone",
+    "minecraft:chiseled_sandstone",
+    "minecraft:smooth_sandstone",
+    "minecraft:red_sandstone",
+    "minecraft:cut_red_sandstone",
+    "minecraft:chiseled_red_sandstone",
+    "minecraft:smooth_red_sandstone"
+  ]
+}

--- a/src/main/resources/data/forge/tags/items/arrows.json
+++ b/src/main/resources/data/forge/tags/items/arrows.json
@@ -1,0 +1,8 @@
+{
+  "replace": false,
+  "values": [
+    "minecraft:arrow",
+    "minecraft:tipped_arrow",
+    "minecraft:spectral_arrow"
+  ]
+}

--- a/src/main/resources/data/forge/tags/items/bone.json
+++ b/src/main/resources/data/forge/tags/items/bone.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "minecraft:bone"
+  ]
+}

--- a/src/main/resources/data/forge/tags/items/bookshelves.json
+++ b/src/main/resources/data/forge/tags/items/bookshelves.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "minecraft:bookshelf"
+  ]
+}

--- a/src/main/resources/data/forge/tags/items/crops.json
+++ b/src/main/resources/data/forge/tags/items/crops.json
@@ -1,0 +1,10 @@
+{
+  "replace": false,
+  "values": [
+    "#forge:crops/beetroot",
+    "#forge:crops/carrot",
+    "#forge:crops/nether_wart",
+    "#forge:crops/potato",
+    "#forge:crops/wheat"
+  ]
+}

--- a/src/main/resources/data/forge/tags/items/crops/beetroot.json
+++ b/src/main/resources/data/forge/tags/items/crops/beetroot.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "minecraft:beetroot"
+  ]
+}

--- a/src/main/resources/data/forge/tags/items/crops/carrot.json
+++ b/src/main/resources/data/forge/tags/items/crops/carrot.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "minecraft:carrot"
+  ]
+}

--- a/src/main/resources/data/forge/tags/items/crops/nether_wart.json
+++ b/src/main/resources/data/forge/tags/items/crops/nether_wart.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "minecraft:nether_wart"
+  ]
+}

--- a/src/main/resources/data/forge/tags/items/crops/potato.json
+++ b/src/main/resources/data/forge/tags/items/crops/potato.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "minecraft:potato"
+  ]
+}

--- a/src/main/resources/data/forge/tags/items/crops/wheat.json
+++ b/src/main/resources/data/forge/tags/items/crops/wheat.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "minecraft:wheat"
+  ]
+}

--- a/src/main/resources/data/forge/tags/items/egg.json
+++ b/src/main/resources/data/forge/tags/items/egg.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "minecraft:egg"
+  ]
+}

--- a/src/main/resources/data/forge/tags/items/end_stone.json
+++ b/src/main/resources/data/forge/tags/items/end_stone.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "minecraft:end_stone"
+  ]
+}

--- a/src/main/resources/data/forge/tags/items/ender_pearl.json
+++ b/src/main/resources/data/forge/tags/items/ender_pearl.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "minecraft:ender_pearl"
+  ]
+}

--- a/src/main/resources/data/forge/tags/items/feather.json
+++ b/src/main/resources/data/forge/tags/items/feather.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "minecraft:feather"
+  ]
+}

--- a/src/main/resources/data/forge/tags/items/gravel.json
+++ b/src/main/resources/data/forge/tags/items/gravel.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "minecraft:gravel"
+  ]
+}

--- a/src/main/resources/data/forge/tags/items/gunpowder.json
+++ b/src/main/resources/data/forge/tags/items/gunpowder.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "minecraft:gunpowder"
+  ]
+}

--- a/src/main/resources/data/forge/tags/items/heads.json
+++ b/src/main/resources/data/forge/tags/items/heads.json
@@ -1,0 +1,11 @@
+{
+  "replace": false,
+  "values": [
+    "minecraft:creeper_head",
+    "minecraft:dragon_head",
+    "minecraft:player_head",
+    "minecraft:skeleton_skull",
+    "minecraft:wither_skeleton_skull",
+    "minecraft:zombie_head"
+  ]
+}

--- a/src/main/resources/data/forge/tags/items/leather.json
+++ b/src/main/resources/data/forge/tags/items/leather.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "minecraft:leather"
+  ]
+}

--- a/src/main/resources/data/forge/tags/items/nether_star.json
+++ b/src/main/resources/data/forge/tags/items/nether_star.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "minecraft:nether_star"
+  ]
+}

--- a/src/main/resources/data/forge/tags/items/netherrack.json
+++ b/src/main/resources/data/forge/tags/items/netherrack.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "minecraft:netherrack"
+  ]
+}

--- a/src/main/resources/data/forge/tags/items/obsidian.json
+++ b/src/main/resources/data/forge/tags/items/obsidian.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "minecraft:obsidian"
+  ]
+}

--- a/src/main/resources/data/forge/tags/items/sandstone.json
+++ b/src/main/resources/data/forge/tags/items/sandstone.json
@@ -1,0 +1,13 @@
+{
+  "replace": false,
+  "values": [
+    "minecraft:sandstone",
+    "minecraft:cut_sandstone",
+    "minecraft:chiseled_sandstone",
+    "minecraft:smooth_sandstone",
+    "minecraft:red_sandstone",
+    "minecraft:cut_red_sandstone",
+    "minecraft:chiseled_red_sandstone",
+    "minecraft:smooth_red_sandstone"
+  ]
+}

--- a/src/main/resources/data/forge/tags/items/seeds.json
+++ b/src/main/resources/data/forge/tags/items/seeds.json
@@ -1,0 +1,9 @@
+{
+  "replace": false,
+  "values": [
+    "#forge:seeds/beetroot",
+    "#forge:seeds/melon",
+    "#forge:seeds/pumpkin",
+    "#forge:seeds/wheat"
+  ]
+}

--- a/src/main/resources/data/forge/tags/items/seeds/beetroot.json
+++ b/src/main/resources/data/forge/tags/items/seeds/beetroot.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "minecraft:beetroot_seeds"
+  ]
+}

--- a/src/main/resources/data/forge/tags/items/seeds/melon.json
+++ b/src/main/resources/data/forge/tags/items/seeds/melon.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "minecraft:melon_seeds"
+  ]
+}

--- a/src/main/resources/data/forge/tags/items/seeds/pumpkin.json
+++ b/src/main/resources/data/forge/tags/items/seeds/pumpkin.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "minecraft:pumpkin_seeds"
+  ]
+}

--- a/src/main/resources/data/forge/tags/items/seeds/wheat.json
+++ b/src/main/resources/data/forge/tags/items/seeds/wheat.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "minecraft:wheat_seeds"
+  ]
+}

--- a/src/main/resources/data/forge/tags/items/slime_ball.json
+++ b/src/main/resources/data/forge/tags/items/slime_ball.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "minecraft:slime_ball"
+  ]
+}

--- a/src/main/resources/data/forge/tags/items/string.json
+++ b/src/main/resources/data/forge/tags/items/string.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "minecraft:string"
+  ]
+}


### PR DESCRIPTION
This adds tags equivalent for several old oredicts, and a few others that were used by certain mods or requested [here](https://github.com/MinecraftForge/MinecraftForge/pull/5609#issuecomment-491081669) by @darkhax.

Anything that's unmarked is an old oredict tag.

Item and block:

* `bookshelves` (requested by the Darkhax post)
* `end_stone`
* `gravel`
* `heads` (was "used" (when the item had metadata) in some mods; named heads because more of the variants were named head than skull)
* `netherrack`
* `obsidian`
* `sandstone`

Item:
* `arrows` (requested)
* `bone`
* `crops` (general tag, didn't make a block tag because of some ambiguity on some blocks (like is the crop the pumpkin block or the stem?))
  * `beetroot` (only new crop, didn't add others because of ambiguity with melons, chorus fruits and such)
  * `carrot`
  * `nether_wart`
  * `potato`
  * `wheat`
* `egg` (no turtle egg because it isn't used in the same recipes)
* `ender_pearl`
* `feather`
* `gunpowder`
* `leather`
* `nether_star`
* `seeds` (used by several mods and requested, only kept ones explicitely referred as seeds)
  * `beetroot`
  * `melon`
  * `pumpkin`
  * `wheat`
* `slime_ball`
* `string`

_Footnote for the linked post: beds and rails are already tagged by vanilla according to the wiki._