### PR TITLE
Hardcore worlds can now be deleted upon death, and they now close properly when deleted

### DIFF
--- a/patches/minecraft/net/minecraft/client/gui/GuiGameOver.java.patch
+++ b/patches/minecraft/net/minecraft/client/gui/GuiGameOver.java.patch
@@ -1,0 +1,10 @@
+--- a/net/minecraft/client/gui/GuiGameOver.java
++++ b/net/minecraft/client/gui/GuiGameOver.java
+@@ -40,6 +40,7 @@
+       GuiButton guibutton = this.func_189646_b(new GuiButton(1, this.field_146294_l / 2 - 100, this.field_146295_m / 4 + 96, s1) {
+          public void func_194829_a(double p_194829_1_, double p_194829_3_) {
+             if (GuiGameOver.this.field_146297_k.field_71441_e.func_72912_H().func_76093_s()) {
++               net.minecraftforge.client.ForgeHooksClient.fixHardcore();
+                GuiGameOver.this.field_146297_k.func_147108_a(new GuiMainMenu());
+             } else {
+                GuiYesNo guiyesno = new GuiYesNo(GuiGameOver.this, I18n.func_135052_a("deathScreen.quit.confirm"), "", I18n.func_135052_a("deathScreen.titleScreen"), I18n.func_135052_a("deathScreen.respawn"), 0);

--- a/patches/minecraft/net/minecraft/client/gui/GuiListWorldSelection.java.patch
+++ b/patches/minecraft/net/minecraft/client/gui/GuiListWorldSelection.java.patch
@@ -1,0 +1,10 @@
+--- a/net/minecraft/client/gui/GuiListWorldSelection.java
++++ b/net/minecraft/client/gui/GuiListWorldSelection.java
+@@ -51,6 +51,7 @@
+       String s = p_212330_1_.get().toLowerCase(Locale.ROOT);
+ 
+       for(WorldSummary worldsummary : this.field_212331_y) {
++         if (net.minecraftforge.client.ForgeHooksClient.deleteMarkedHardcoreWorld(worldsummary)) {continue;}
+          if (worldsummary.func_75788_b().toLowerCase(Locale.ROOT).contains(s) || worldsummary.func_75786_a().toLowerCase(Locale.ROOT).contains(s)) {
+             this.func_195085_a(new GuiListWorldSelectionEntry(this, worldsummary, this.field_148161_k.func_71359_d()));
+          }

--- a/src/main/java/net/minecraftforge/client/ForgeHooksClient.java
+++ b/src/main/java/net/minecraftforge/client/ForgeHooksClient.java
@@ -108,6 +108,7 @@ import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.MathHelper;
 import net.minecraft.util.math.RayTraceResult;
 import net.minecraft.util.registry.IRegistry;
+import net.minecraft.util.text.TextComponentTranslation;
 import net.minecraft.util.text.TextFormatting;
 import net.minecraft.world.GameType;
 import net.minecraft.world.IWorldReader;
@@ -1052,7 +1053,7 @@ public class ForgeHooksClient
 	            String ownerName = server.getServerOwner();
 	            EntityPlayerMP owner = server.getPlayerList().getPlayerByUsername(ownerName);
 	            owner.setGameType(GameType.NOT_SET);
-	            mc.world.sendQuittingDisconnectingPacket();
+	            owner.connection.disconnect(new TextComponentTranslation("deathScreen.title.hardcore"));
 	        });
         }
         else {
@@ -1074,7 +1075,7 @@ public class ForgeHooksClient
      * 
      * @param world the WorldSummary to delete
      * 
-     * @see #fixHardcore
+     * @see #fixHardcore()
      * @see net.minecraft.client.gui.GuiListWorldSelection#func_212330_a
      * 
      * @return true if the world was just deleted, or the world has already been deleted


### PR DESCRIPTION
This is a redo of #5693 

Hardcore worlds can now be deleted upon death, and they now close properly when deleted.

Fixes #5689, #5690, [MC-30646](https://bugs.mojang.com/browse/MC-30646), and [MC-96521](https://bugs.mojang.com/browse/MC-96521)

I closed the previous PR due to race conditions when deleting the world (sometimes the world files would still be locked, and deletion would fail, or sometimes the server thread hadn't stopped).

To prevent race conditions, instead of deleting the world right after the player leaves, the world is instead marked for deletion. When the player enters the world selection menu, all worlds marked for deletion are then deleted.

The world is marked for deletion by setting the player's game mode to GameType.NOT_SET (the player is already dead, and the world is going to be deleted, so this has no adverse effects). I chose to mark the world for deletion in this way because I already have to check the player's NBT to see if their health is below zero, and so forge doesn't modify the normal nbt/data structure of worlds. Though, if you would rather mark the world for deletion in a different way (such as creating a file in the world's directory), just let me know and I'll alter the PR accordingly.

