### PR TITLE
Pass tick counter to custom render handlers

### DIFF
--- a/patches/minecraft/net/minecraft/client/renderer/GameRenderer.java.patch
+++ b/patches/minecraft/net/minecraft/client/renderer/GameRenderer.java.patch
@@ -138,7 +138,7 @@
     protected void func_78474_d(float p_78474_1_) {
 +      net.minecraftforge.client.IRenderHandler renderer = this.field_78531_r.field_71441_e.func_201675_m().getWeatherRenderer();
 +      if (renderer != null) {
-+         renderer.render(p_78474_1_, this.field_78531_r.field_71441_e, field_78531_r);
++         renderer.render(this.field_78529_t, p_78474_1_, this.field_78531_r.field_71441_e, this.field_78531_r);
 +         return;
 +      }
        float f = this.field_78531_r.field_71441_e.func_72867_j(p_78474_1_);

--- a/patches/minecraft/net/minecraft/client/renderer/WorldRenderer.java.patch
+++ b/patches/minecraft/net/minecraft/client/renderer/WorldRenderer.java.patch
@@ -110,7 +110,7 @@
     public void func_195465_a(float p_195465_1_) {
 +      net.minecraftforge.client.IRenderHandler renderer = this.field_72769_h.func_201675_m().getSkyRenderer();
 +      if (renderer != null) {
-+         renderer.render(p_195465_1_, field_72769_h, field_72777_q);
++         renderer.render(this.field_72773_u, p_195465_1_, this.field_72769_h, this.field_72777_q);
 +         return;
 +      }
        if (this.field_72777_q.field_71441_e.field_73011_w.func_186058_p() == DimensionType.THE_END) {

--- a/src/main/java/net/minecraftforge/client/CloudRenderer.java
+++ b/src/main/java/net/minecraftforge/client/CloudRenderer.java
@@ -483,7 +483,7 @@ public class CloudRenderer implements ISelectiveResourceReloadListener
         IRenderHandler renderer = world.dimension.getCloudRenderer();
         if (renderer != null)
         {
-            renderer.render(partialTicks, world, client);
+            renderer.render(cloudTicks, partialTicks, world, client);
             return true;
         }
         return getCloudRenderer().render(cloudTicks, partialTicks);

--- a/src/main/java/net/minecraftforge/client/IRenderHandler.java
+++ b/src/main/java/net/minecraftforge/client/IRenderHandler.java
@@ -28,5 +28,5 @@ import net.minecraftforge.api.distmarker.OnlyIn;
 public interface IRenderHandler
 {
     @OnlyIn(Dist.CLIENT)
-    public abstract void render(float partialTicks, WorldClient world, Minecraft mc);
+    void render(int ticks, float partialTicks, WorldClient world, Minecraft mc);
 }


### PR DESCRIPTION
Updates `IRenderHandler.render` to also pass the relevant tick count, which is used by the vanilla weather/cloud render implementations and, due to being conditionally updated, is awkward to emulate correctly otherwise.