### PR TITLE
Move EntityEnderman.setAttackTarget super call to give LSAT full context

### DIFF
--- a/patches/minecraft/net/minecraft/entity/monster/EntityEnderman.java.patch
+++ b/patches/minecraft/net/minecraft/entity/monster/EntityEnderman.java.patch
@@ -1,5 +1,23 @@
 --- a/net/minecraft/entity/monster/EntityEnderman.java
 +++ b/net/minecraft/entity/monster/EntityEnderman.java
+@@ -84,7 +84,6 @@
+    }
+ 
+    public void func_70624_b(@Nullable EntityLivingBase p_70624_1_) {
+-      super.func_70624_b(p_70624_1_);
+       IAttributeInstance iattributeinstance = this.func_110148_a(SharedMonsterAttributes.field_111263_d);
+       if (p_70624_1_ == null) {
+          this.field_184721_by = 0;
+@@ -97,7 +96,8 @@
+             iattributeinstance.func_111121_a(field_110193_bq);
+          }
+       }
+-
++      //Forge: Moved to give {@link net.minecraftforge.event.entity.living.LivingSetAttackTargetEvent} full context
++      super.func_70624_b(p_70624_1_);
+    }
+ 
+    protected void func_70088_a() {
 @@ -209,7 +209,9 @@
     }
  


### PR DESCRIPTION
This is an updated version of a PR I previously put in for 1.12 (#5106).

`EntityEnderman.setAttackTarget` overrides `Entity.setAttackTarget` and makes changes to the attributes of the entity after calling the super method.
This makes it so the LivingSetAttackTarget event in the `Entity.setAttackTarget` does not get the full context of the enderman.

To solve this, the super.setAttackTarget is simply moved to after the enderman specific code, so the LSAT event can change those attributes properly.

Use cases:
Allowing an LSAT event to stop an enderman from screaming at a player if should not aggro.

Let me know if anything needs to change.