### PR TITLE
Protect against concurrent modification in World#setTileEntity

### DIFF
--- a/patches/minecraft/net/minecraft/world/World.java.patch
+++ b/patches/minecraft/net/minecraft/world/World.java.patch
@@ -676,16 +676,29 @@
          if (!this.func_189509_E(p_175690_1_))
          {
              if (p_175690_2_ != null && !p_175690_2_.func_145837_r())
-@@ -2245,6 +2434,8 @@
+@@ -2245,7 +2434,10 @@
                  if (this.field_147481_N)
                  {
                      p_175690_2_.func_174878_a(p_175690_1_);
 +                    if (p_175690_2_.func_145831_w() != this)
 +                        p_175690_2_.func_145834_a(this); // Forge - set the world early as vanilla doesn't set it until next tick
                      Iterator<TileEntity> iterator1 = this.field_147484_a.iterator();
++                    List<TileEntity> toInvalidate = Lists.newArrayList();
  
                      while (iterator1.hasNext())
-@@ -2262,7 +2453,8 @@
+                     {
+@@ -2253,16 +2445,18 @@
+ 
+                         if (tileentity2.func_174877_v().equals(p_175690_1_))
+                         {
+-                            tileentity2.func_145843_s();
++                            toInvalidate.add(tileentity2); // Forge - don't call invalidate while iterating
+                             iterator1.remove();
+                         }
+                     }
+ 
++                    toInvalidate.forEach(TileEntity::func_145843_s);
+                     this.field_147484_a.add(p_175690_2_);
                  }
                  else
                  {
@@ -695,7 +708,7 @@
                      this.func_175700_a(p_175690_2_);
                  }
              }
-@@ -2277,6 +2469,8 @@
+@@ -2277,6 +2471,8 @@
          {
              tileentity2.func_145843_s();
              this.field_147484_a.remove(tileentity2);
@@ -704,7 +717,7 @@
          }
          else
          {
-@@ -2289,6 +2483,7 @@
+@@ -2289,6 +2485,7 @@
  
              this.func_175726_f(p_175713_1_).func_177425_e(p_175713_1_);
          }
@@ -712,7 +725,7 @@
      }
  
      public void func_147457_a(TileEntity p_147457_1_)
-@@ -2315,7 +2510,7 @@
+@@ -2315,7 +2512,7 @@
              if (chunk1 != null && !chunk1.func_76621_g())
              {
                  IBlockState iblockstate1 = this.func_180495_p(p_175677_1_);
@@ -721,7 +734,7 @@
              }
              else
              {
-@@ -2338,6 +2533,7 @@
+@@ -2338,6 +2535,7 @@
      {
          this.field_72985_G = p_72891_1_;
          this.field_72992_H = p_72891_2_;
@@ -729,7 +742,7 @@
      }
  
      public void func_72835_b()
-@@ -2347,6 +2543,11 @@
+@@ -2347,6 +2545,11 @@
  
      protected void func_72947_a()
      {
@@ -741,7 +754,7 @@
          if (this.field_72986_A.func_76059_o())
          {
              this.field_73004_o = 1.0F;
-@@ -2360,6 +2561,11 @@
+@@ -2360,6 +2563,11 @@
  
      protected void func_72979_l()
      {
@@ -753,7 +766,7 @@
          if (this.field_73011_w.func_191066_m())
          {
              if (!this.field_72995_K)
-@@ -2484,6 +2690,11 @@
+@@ -2484,6 +2692,11 @@
  
      public boolean func_175670_e(BlockPos p_175670_1_, boolean p_175670_2_)
      {
@@ -765,7 +778,7 @@
          Biome biome = this.func_180494_b(p_175670_1_);
          float f = biome.func_180626_a(p_175670_1_);
  
-@@ -2525,6 +2736,11 @@
+@@ -2525,6 +2738,11 @@
  
      public boolean func_175708_f(BlockPos p_175708_1_, boolean p_175708_2_)
      {
@@ -777,7 +790,7 @@
          Biome biome = this.func_180494_b(p_175708_1_);
          float f = biome.func_180626_a(p_175708_1_);
  
-@@ -2542,7 +2758,7 @@
+@@ -2542,7 +2760,7 @@
              {
                  IBlockState iblockstate1 = this.func_180495_p(p_175708_1_);
  
@@ -786,7 +799,7 @@
                  {
                      return true;
                  }
-@@ -2574,10 +2790,10 @@
+@@ -2574,10 +2792,10 @@
          else
          {
              IBlockState iblockstate1 = this.func_180495_p(p_175638_1_);
@@ -800,7 +813,7 @@
              {
                  k2 = 1;
              }
-@@ -2589,7 +2805,7 @@
+@@ -2589,7 +2807,7 @@
  
              if (k2 >= 15)
              {
@@ -809,7 +822,7 @@
              }
              else if (j2 >= 14)
              {
-@@ -2630,12 +2846,13 @@
+@@ -2630,12 +2848,13 @@
  
      public boolean func_180500_c(EnumSkyBlock p_180500_1_, BlockPos p_180500_2_)
      {
@@ -824,7 +837,7 @@
              int j2 = 0;
              int k2 = 0;
              this.field_72984_F.func_76320_a("getBrightness");
-@@ -2673,7 +2890,7 @@
+@@ -2673,7 +2892,7 @@
                              int l5 = MathHelper.func_76130_a(k4 - k3);
                              int i6 = MathHelper.func_76130_a(l4 - l3);
  
@@ -833,7 +846,7 @@
                              {
                                  BlockPos.PooledMutableBlockPos blockpos$pooledmutableblockpos = BlockPos.PooledMutableBlockPos.func_185346_s();
  
-@@ -2683,7 +2900,8 @@
+@@ -2683,7 +2902,8 @@
                                      int k6 = k4 + enumfacing.func_96559_d();
                                      int l6 = l4 + enumfacing.func_82599_e();
                                      blockpos$pooledmutableblockpos.func_181079_c(j6, k6, l6);
@@ -843,7 +856,7 @@
                                      j5 = this.func_175642_b(p_180500_1_, blockpos$pooledmutableblockpos);
  
                                      if (j5 == i5 - i7 && k2 < this.field_72994_J.length)
-@@ -2725,7 +2943,7 @@
+@@ -2725,7 +2945,7 @@
                          int j9 = Math.abs(i8 - l3);
                          boolean flag = k2 < this.field_72994_J.length - 6;
  
@@ -852,7 +865,7 @@
                          {
                              if (this.func_175642_b(p_180500_1_, blockpos2.func_177976_e()) < k8)
                              {
-@@ -2791,10 +3009,10 @@
+@@ -2791,10 +3011,10 @@
      public List<Entity> func_175674_a(@Nullable Entity p_175674_1_, AxisAlignedBB p_175674_2_, @Nullable Predicate <? super Entity > p_175674_3_)
      {
          List<Entity> list = Lists.<Entity>newArrayList();
@@ -867,7 +880,7 @@
  
          for (int j3 = j2; j3 <= k2; ++j3)
          {
-@@ -2847,10 +3065,10 @@
+@@ -2847,10 +3067,10 @@
  
      public <T extends Entity> List<T> func_175647_a(Class <? extends T > p_175647_1_, AxisAlignedBB p_175647_2_, @Nullable Predicate <? super T > p_175647_3_)
      {
@@ -882,7 +895,7 @@
          List<T> list = Lists.<T>newArrayList();
  
          for (int j3 = j2; j3 < k2; ++j3)
-@@ -2930,11 +3148,13 @@
+@@ -2930,11 +3150,13 @@
  
      public void func_175650_b(Collection<Entity> p_175650_1_)
      {
@@ -899,7 +912,7 @@
          }
      }
  
-@@ -2948,7 +3168,8 @@
+@@ -2948,7 +3170,8 @@
          IBlockState iblockstate1 = this.func_180495_p(p_190527_2_);
          AxisAlignedBB axisalignedbb = p_190527_3_ ? null : p_190527_1_.func_176223_P().func_185890_d(this, p_190527_2_);
  
@@ -909,7 +922,7 @@
          {
              return false;
          }
-@@ -2958,7 +3179,7 @@
+@@ -2958,7 +3181,7 @@
          }
          else
          {
@@ -918,7 +931,7 @@
          }
      }
  
-@@ -3042,7 +3263,7 @@
+@@ -3042,7 +3265,7 @@
      public int func_175651_c(BlockPos p_175651_1_, EnumFacing p_175651_2_)
      {
          IBlockState iblockstate1 = this.func_180495_p(p_175651_1_);
@@ -927,7 +940,7 @@
      }
  
      public boolean func_175640_z(BlockPos p_175640_1_)
-@@ -3208,6 +3429,8 @@
+@@ -3208,6 +3431,8 @@
                      d2 *= ((Double)MoreObjects.firstNonNull(p_184150_11_.apply(entityplayer1), Double.valueOf(1.0D))).doubleValue();
                  }
  
@@ -936,7 +949,7 @@
                  if ((p_184150_9_ < 0.0D || Math.abs(entityplayer1.field_70163_u - p_184150_3_) < p_184150_9_ * p_184150_9_) && (p_184150_7_ < 0.0D || d1 < d2 * d2) && (d0 == -1.0D || d1 < d0))
                  {
                      d0 = d1;
-@@ -3269,7 +3492,7 @@
+@@ -3269,7 +3494,7 @@
  
      public long func_72905_C()
      {
@@ -945,7 +958,7 @@
      }
  
      public long func_82737_E()
-@@ -3279,17 +3502,17 @@
+@@ -3279,17 +3504,17 @@
  
      public long func_72820_D()
      {
@@ -966,7 +979,7 @@
  
          if (!this.func_175723_af().func_177746_a(blockpos1))
          {
-@@ -3301,7 +3524,7 @@
+@@ -3301,7 +3526,7 @@
  
      public void func_175652_B(BlockPos p_175652_1_)
      {
@@ -975,7 +988,7 @@
      }
  
      @SideOnly(Side.CLIENT)
-@@ -3321,12 +3544,18 @@
+@@ -3321,12 +3546,18 @@
  
          if (!this.field_72996_f.contains(p_72897_1_))
          {
@@ -994,7 +1007,7 @@
          return true;
      }
  
-@@ -3428,8 +3657,7 @@
+@@ -3428,8 +3659,7 @@
  
      public boolean func_180502_D(BlockPos p_180502_1_)
      {
@@ -1004,7 +1017,7 @@
      }
  
      @Nullable
-@@ -3490,12 +3718,12 @@
+@@ -3490,12 +3720,12 @@
  
      public int func_72800_K()
      {
@@ -1019,7 +1032,7 @@
      }
  
      public Random func_72843_D(int p_72843_1_, int p_72843_2_, int p_72843_3_)
-@@ -3539,7 +3767,7 @@
+@@ -3539,7 +3769,7 @@
      @SideOnly(Side.CLIENT)
      public double func_72919_O()
      {
@@ -1028,7 +1041,7 @@
      }
  
      public void func_175715_c(int p_175715_1_, BlockPos p_175715_2_, int p_175715_3_)
-@@ -3573,7 +3801,7 @@
+@@ -3573,7 +3803,7 @@
  
      public void func_175666_e(BlockPos p_175666_1_, Block p_175666_2_)
      {
@@ -1037,7 +1050,7 @@
          {
              BlockPos blockpos1 = p_175666_1_.func_177972_a(enumfacing);
  
-@@ -3581,18 +3809,15 @@
+@@ -3581,18 +3811,15 @@
              {
                  IBlockState iblockstate1 = this.func_180495_p(blockpos1);
  
@@ -1060,7 +1073,7 @@
                      }
                  }
              }
-@@ -3658,6 +3883,124 @@
+@@ -3658,6 +3885,124 @@
          return j2 >= -128 && j2 <= 128 && k2 >= -128 && k2 <= 128;
      }
  


### PR DESCRIPTION
This changes `World.setTileEntity()` to not call `TileEntity.invalidate()` while iterating over `addedTileEntityList`. Instead any TEs to be invalidated are added to a separate list, and then handled after iteration is complete.

Similar handling can be found in `Chunk.read()` as seen here:
https://github.com/MinecraftForge/MinecraftForge/blob/9a636e3c76f9da868b4167e877e57885bdb2a643/patches/minecraft/net/minecraft/world/chunk/Chunk.java.patch#L281-L297

This is because some TEs, including vanilla chests, can cause changes to this state from `invalidate()` (e.g. the issues involving #5512).

This came up while investigating https://github.com/TeamTwilight/twilightforest/issues/740, and the deobfed head of the stacktrace from that issue can be seen here:
```
Description: Ticking block entity

java.util.ConcurrentModificationException
	at java.util.ArrayList$Itr.checkForComodification(ArrayList.java:909)
	at java.util.ArrayList$Itr.remove(ArrayList.java:873)
	at net.minecraft.world.World.setTileEntity(World.java:2448)
	at net.minecraft.world.chunk.Chunk.setBlockState(Chunk.java:624)
	at net.minecraft.world.World.setBlockState(World.java:343)
	at net.minecraft.block.BlockChest.checkForSurroundingChests(BlockChest.java:261)
	at net.minecraft.block.BlockChest.onBlockAdded(BlockChest.java:107)
	at net.minecraft.world.chunk.Chunk.setBlockState(Chunk.java:614)
	at net.minecraft.world.World.setBlockState(World.java:343)
	at twilightforest.loot.TFTreasure.generateChest(TFTreasure.java:106)
```

The crash originates from a concurrent modification of `World#addedTileEntityList` as detected by the iterator used in `setTileEntity`. Note also that as the crash occurs while ticking TEs, `World.processingLoadedTiles` will be true for the duration.

In particular, the following problematic sequence of method calls:
1. `World.setTileEntity()`
2. `TileEntityChest.invalidate()`
3. `TileEntityChest.checkForAdjacentChests()`
4. `TileEntityChest.getAdjacentChest()`
5. `World.getTileEntity()`
6. `Chunk.getTileEntity()`
7. `World.setTileEntity()`

can occur due to double-chest handling with the conditions observed here.

In this case, the second `setTileEntity` call will modify `addedTileEntityList` during the first call's iteration, causing a CME.
