### PR TITLE
Fix more unclosed resources

### DIFF
--- a/src/main/java/net/minecraftforge/client/MinecraftForgeClient.java
+++ b/src/main/java/net/minecraftforge/client/MinecraftForgeClient.java
@@ -148,7 +148,9 @@ public class MinecraftForgeClient
         if (supplier != null)
             return supplier.get();
 
-        IResource iresource1 = resourceManager.getResource(resourceLocation);
-        return TextureUtil.readBufferedImage(iresource1.getInputStream());
+        try (IResource iresource1 = resourceManager.getResource(resourceLocation))
+        {
+            return TextureUtil.readBufferedImage(iresource1.getInputStream());
+        }
     }
 }

--- a/src/main/java/net/minecraftforge/client/model/ModelDynBucket.java
+++ b/src/main/java/net/minecraftforge/client/model/ModelDynBucket.java
@@ -273,19 +273,26 @@ public final class ModelDynBucket implements IModel
         public void register(TextureMap map)
         {
             // only create these textures if they are not added by a resource pack
-
-            if (getResource(new ResourceLocation(ForgeVersion.MOD_ID, "textures/items/bucket_cover.png")) == null)
+            try (IResource cover = getResource(new ResourceLocation(ForgeVersion.MOD_ID, "textures/items/bucket_cover.png"));
+                 IResource base = getResource(new ResourceLocation(ForgeVersion.MOD_ID, "textures/items/bucket_base.png")))
             {
-                ResourceLocation bucketCover = new ResourceLocation(ForgeVersion.MOD_ID, "items/bucket_cover");
-                BucketCoverSprite bucketCoverSprite = new BucketCoverSprite(bucketCover);
-                map.setTextureEntry(bucketCoverSprite);
+                if (cover == null)
+                {
+                    ResourceLocation bucketCover = new ResourceLocation(ForgeVersion.MOD_ID, "items/bucket_cover");
+                    BucketCoverSprite bucketCoverSprite = new BucketCoverSprite(bucketCover);
+                    map.setTextureEntry(bucketCoverSprite);
+                }
+
+                if (base == null)
+                {
+                    ResourceLocation bucketBase = new ResourceLocation(ForgeVersion.MOD_ID, "items/bucket_base");
+                    BucketBaseSprite bucketBaseSprite = new BucketBaseSprite(bucketBase);
+                    map.setTextureEntry(bucketBaseSprite);
+                }
             }
-
-            if (getResource(new ResourceLocation(ForgeVersion.MOD_ID, "textures/items/bucket_base.png")) == null)
+            catch (IOException e)
             {
-                ResourceLocation bucketBase = new ResourceLocation(ForgeVersion.MOD_ID, "items/bucket_base");
-                BucketBaseSprite bucketBaseSprite = new BucketBaseSprite(bucketBase);
-                map.setTextureEntry(bucketBaseSprite);
+                FMLLog.log.error("Failed to close resource", e);
             }
         }
 


### PR DESCRIPTION
Followup to #4806, fixes the remaining uses of `IResourceManager.getResource` where the returned `IResource` is not subsequently closed.

Also fixes a couple of tiny bugs in the OBJ model handling code - discarded string operations and incorrect floating-point/integer mixing.