### PR TITLE
Add missing license header

### DIFF
--- a/src/fmllauncher/java/net/minecraftforge/fml/loading/ModDirTransformerDiscoverer.java
+++ b/src/fmllauncher/java/net/minecraftforge/fml/loading/ModDirTransformerDiscoverer.java
@@ -1,3 +1,22 @@
+/*
+ * Minecraft Forge
+ * Copyright (c) 2016-2019.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation version 2.1
+ * of the License.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
 package net.minecraftforge.fml.loading;
 
 import cpw.mods.modlauncher.api.LamdbaExceptionUtils;


### PR DESCRIPTION
The missing license header is causing some builds to fail.


```
> Task :forge:checkLicenseFmllauncher FAILED

FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':forge:checkLicenseFmllauncher'.
> License violations were found: C:\Users\G\Desktop\Forge\MinecraftForge\src\fmllauncher\java\net\minecraftforge\fml\loading\ModDirTransformerDiscoverer.java
```