### PR TITLE
[Bug] fml|ModInfo.java: `logoFile` wrong order of priority

### DIFF
--- a/src/fmllauncher/java/net/minecraftforge/fml/loading/moddiscovery/ModInfo.java
+++ b/src/fmllauncher/java/net/minecraftforge/fml/loading/moddiscovery/ModInfo.java
@@ -50,6 +50,7 @@ public class ModInfo implements IModInfo
     private final ArtifactVersion version;
     private final String displayName;
     private final String description;
+    private final Optional<String> logoFile;
     private final URL updateJSONURL;
     private final List<IModInfo.ModVersion> dependencies;
     private final Map<String,Object> properties;
@@ -74,6 +75,13 @@ public class ModInfo implements IModInfo
                 map(DefaultArtifactVersion::new).orElse(DEFAULT_VERSION);
         this.displayName = modConfig.<String>getOptional("displayName").orElse(null);
         this.description = modConfig.get("description");
+
+        Optional<String> tmp = modConfig.<String>getOptional("logoFile");
+        if (!tmp.isPresent() && this.owningFile != null) {
+            tmp = this.owningFile.getConfig().getOptional("logoFile");
+        }
+        this.logoFile = tmp;
+
         this.updateJSONURL = modConfig.<String>getOptional("updateJSONURL").map(StringUtils::toURL).orElse(null);
         if (owningFile != null) {
             this.dependencies = owningFile.getConfig().<List<UnmodifiableConfig>>getOptional(Arrays.asList("dependencies", this.modId)).
@@ -140,7 +148,7 @@ public class ModInfo implements IModInfo
 
     public Optional<String> getLogoFile()
     {
-        return this.owningFile != null ? this.owningFile.getConfig().getOptional("logoFile") : this.modConfig.getOptional("logoFile");
+        return this.logoFile;
     }
 
     public boolean hasConfigUI()


### PR DESCRIPTION
The "logoFile" of the `mods.toml` template in MDK does not work.

It seems that there are 3 cases from where to take it's value. The case `!logoFile.isPresent()` was the second and `modConfig.getOptional("logoFile")` had the lowest priority (the case of MDK template).

Now `modConfig.getOptional("logoFile")` has highest priority and overrides all. `!logoFile.isPresent()` has lowest priority now.