### PR TITLE
[1.13.2] Add getters for mouse x/y velocity and if the middle-mouse button is being held down

### DIFF
--- a/patches/minecraft/net/minecraft/client/MouseHelper.java.patch
+++ b/patches/minecraft/net/minecraft/client/MouseHelper.java.patch
@@ -49,3 +49,22 @@
              }, "mouseDragged event handler", iguieventlistener.getClass().getCanonicalName());
           }
  
+@@ -267,4 +275,18 @@
+          GLFW.glfwSetCursorPos(this.field_198036_a.field_195558_d.func_198092_i(), this.field_198040_e, this.field_198041_f);
+       }
+    }
++
++   /* ======================================== FORGE START =====================================*/
++   public double getXVelocity() {
++      return this.field_198048_m;
++   }
++
++   public double getYVelocity() {
++      return this.field_198049_n;
++   }
++
++   public boolean isMiddleDown() {
++      return this.field_198038_c;
++   }
++   /* ======================================== FORGE END =====================================*/
+ }


### PR DESCRIPTION
The current MouseHelper class has getters for leftDown and rightDown, which are booleans that return true if the player is holding down their left or right mouse buttons respectively. However, for some reason, MouseHelper doesn't have a getter method for middleDown, which is a boolean that checks whether or not the player's middle mouse button is being held down. This could be a useful method for mods that want to utilize middle-mouse to perform some function (including one of mine).

An AccessTransformer or Reflection could also allow us access to this private value, but that's fairly impractical to have to set up an AT or deal with the performance issues of Reflection (if you're referencing this boolean a lot) when there's already getters for the other two mouse buttons. 

This commit simply adds a getter for this value, as well as getters for the X and Y velocity of the mouse.
(this is a duplicate pull request that I made after messing up my original one.)