### PR TITLE
Fix hashCode when side is null

### DIFF
--- a/src/main/java/net/minecraftforge/items/wrapper/SidedInvWrapper.java
+++ b/src/main/java/net/minecraftforge/items/wrapper/SidedInvWrapper.java
@@ -25,6 +25,8 @@ import net.minecraft.util.EnumFacing;
 import net.minecraftforge.items.IItemHandlerModifiable;
 import net.minecraftforge.items.ItemHandlerHelper;
 
+import java.util.Objects;
+
 import javax.annotation.Nonnull;
 
 public class SidedInvWrapper implements IItemHandlerModifiable
@@ -63,7 +65,7 @@ public class SidedInvWrapper implements IItemHandlerModifiable
     public int hashCode()
     {
         int result = inv.hashCode();
-        result = 31 * result + side.hashCode();
+        result = 31 * result + Objects.hashCode(side);
         return result;
     }
 


### PR DESCRIPTION
SidedInvWrapper supports the null (internal) side in all but one place: when it's used in something that calls hashCode(), it crashes. Fix this by testing side for null before calling its hashCode().

Fixes McJtyMods/RFTools#1958.