### PR TITLE
Send extra data to client upon opening a ContainerScreen

### DIFF
--- a/patches/minecraft/net/minecraft/client/network/play/ClientPlayNetHandler.java.patch
+++ b/patches/minecraft/net/minecraft/client/network/play/ClientPlayNetHandler.java.patch
@@ -28,6 +28,15 @@
        clientplayerentity1.func_70065_x();
        clientplayerentity1.func_175158_f(s);
        this.field_147300_g.func_217408_a(i, clientplayerentity1);
+@@ -993,7 +996,7 @@
+ 
+    public void func_217272_a(SOpenWindowPacket p_217272_1_) {
+       PacketThreadUtil.func_218797_a(p_217272_1_, this, this.field_147299_f);
+-      ScreenManager.func_216909_a(p_217272_1_.func_218749_c(), this.field_147299_f, p_217272_1_.func_218750_b(), p_217272_1_.func_218748_d());
++      net.minecraftforge.common.ForgeHooks.openScreen(p_217272_1_.func_218749_c(), this.field_147299_f, p_217272_1_.func_218750_b(), p_217272_1_.func_218748_d(), p_217272_1_.getExtraData());
+    }
+ 
+    public void func_147266_a(SSetSlotPacket p_147266_1_) {
 @@ -1078,6 +1081,12 @@
           boolean flag = i == 2 && tileentity instanceof CommandBlockTileEntity;
           if (i == 1 && tileentity instanceof MobSpawnerTileEntity || flag || i == 3 && tileentity instanceof BeaconTileEntity || i == 4 && tileentity instanceof SkullTileEntity || i == 6 && tileentity instanceof BannerTileEntity || i == 7 && tileentity instanceof StructureBlockTileEntity || i == 8 && tileentity instanceof EndGatewayTileEntity || i == 9 && tileentity instanceof SignTileEntity || i == 11 && tileentity instanceof BedTileEntity || i == 5 && tileentity instanceof ConduitTileEntity || i == 12 && tileentity instanceof JigsawTileEntity || i == 13 && tileentity instanceof CampfireTileEntity) {

--- a/patches/minecraft/net/minecraft/entity/player/PlayerEntity.java.patch
+++ b/patches/minecraft/net/minecraft/entity/player/PlayerEntity.java.patch
@@ -213,7 +213,18 @@
           float f1 = f - p_70665_2_;
           if (f1 > 0.0F && f1 < 3.4028235E37F) {
              this.func_195067_a(Stats.field_212738_J, Math.round(f1 * 10.0F));
-@@ -886,6 +939,8 @@
+@@ -869,6 +922,10 @@
+    }
+ 
+    public OptionalInt func_213829_a(@Nullable INamedContainerProvider p_213829_1_) {
++	   return openContainer(p_213829_1_, null);
++   }
++   
++   public OptionalInt openContainer(@Nullable INamedContainerProvider p_213829_1_, @Nullable net.minecraftforge.common.ContainerExtraData extraData) {
+       return OptionalInt.empty();
+    }
+ 
+@@ -886,6 +943,8 @@
  
           return ActionResultType.PASS;
        } else {
@@ -222,7 +233,7 @@
           ItemStack itemstack = this.func_184586_b(p_190775_2_);
           ItemStack itemstack1 = itemstack.func_190926_b() ? ItemStack.field_190927_a : itemstack.func_77946_l();
           if (p_190775_1_.func_184230_a(this, p_190775_2_)) {
-@@ -893,6 +948,9 @@
+@@ -893,6 +952,9 @@
                 itemstack.func_190920_e(itemstack1.func_190916_E());
              }
  
@@ -232,7 +243,7 @@
              return ActionResultType.SUCCESS;
           } else {
              if (!itemstack.func_190926_b() && p_190775_1_ instanceof LivingEntity) {
-@@ -902,6 +960,7 @@
+@@ -902,6 +964,7 @@
  
                 if (itemstack.func_111282_a(this, (LivingEntity)p_190775_1_, p_190775_2_)) {
                    if (itemstack.func_190926_b() && !this.field_71075_bZ.field_75098_d) {
@@ -240,7 +251,7 @@
                       this.func_184611_a(p_190775_2_, ItemStack.field_190927_a);
                    }
  
-@@ -928,6 +987,7 @@
+@@ -928,6 +991,7 @@
     }
  
     public void func_71059_n(Entity p_71059_1_) {
@@ -248,7 +259,7 @@
        if (p_71059_1_.func_70075_an()) {
           if (!p_71059_1_.func_85031_j(this)) {
              float f = (float)this.func_110148_a(SharedMonsterAttributes.field_111264_e).func_111126_e();
-@@ -955,8 +1015,10 @@
+@@ -955,8 +1019,10 @@
  
                 boolean flag2 = flag && this.field_70143_R > 0.0F && !this.field_70122_E && !this.func_70617_f_() && !this.func_70090_H() && !this.func_70644_a(Effects.field_76440_q) && !this.func_184218_aH() && p_71059_1_ instanceof LivingEntity;
                 flag2 = flag2 && !this.func_70051_ag();
@@ -260,7 +271,7 @@
                 }
  
                 f = f + f1;
-@@ -1044,8 +1106,10 @@
+@@ -1044,8 +1110,10 @@
                    }
  
                    if (!this.field_70170_p.field_72995_K && !itemstack1.func_190926_b() && entity instanceof LivingEntity) {
@@ -271,7 +282,7 @@
                          this.func_184611_a(Hand.MAIN_HAND, ItemStack.field_190927_a);
                       }
                    }
-@@ -1087,7 +1151,7 @@
+@@ -1087,7 +1155,7 @@
        }
  
        if (this.field_70146_Z.nextFloat() < f) {
@@ -280,7 +291,7 @@
           this.func_184602_cy();
           this.field_70170_p.func_72960_a(this, (byte)30);
        }
-@@ -1131,6 +1195,8 @@
+@@ -1131,6 +1199,8 @@
     }
  
     public Either<PlayerEntity.SleepResult, Unit> func_213819_a(BlockPos p_213819_1_) {
@@ -289,7 +300,7 @@
        Direction direction = this.field_70170_p.func_180495_p(p_213819_1_).func_177229_b(HorizontalBlock.field_185512_D);
        if (!this.field_70170_p.field_72995_K) {
           if (this.func_70608_bn() || !this.func_70089_S()) {
-@@ -1141,7 +1207,7 @@
+@@ -1141,7 +1211,7 @@
              return Either.left(PlayerEntity.SleepResult.NOT_POSSIBLE_HERE);
           }
  
@@ -298,7 +309,7 @@
              return Either.left(PlayerEntity.SleepResult.NOT_POSSIBLE_NOW);
           }
  
-@@ -1183,6 +1249,8 @@
+@@ -1183,6 +1253,8 @@
     private boolean func_190774_a(BlockPos p_190774_1_, Direction p_190774_2_) {
        if (Math.abs(this.field_70165_t - (double)p_190774_1_.func_177958_n()) <= 3.0D && Math.abs(this.field_70163_u - (double)p_190774_1_.func_177956_o()) <= 2.0D && Math.abs(this.field_70161_v - (double)p_190774_1_.func_177952_p()) <= 3.0D) {
           return true;
@@ -307,7 +318,7 @@
        } else {
           BlockPos blockpos = p_190774_1_.func_177972_a(p_190774_2_.func_176734_d());
           return Math.abs(this.field_70165_t - (double)blockpos.func_177958_n()) <= 3.0D && Math.abs(this.field_70163_u - (double)blockpos.func_177956_o()) <= 2.0D && Math.abs(this.field_70161_v - (double)blockpos.func_177952_p()) <= 3.0D;
-@@ -1195,6 +1263,7 @@
+@@ -1195,6 +1267,7 @@
     }
  
     public void func_70999_a(boolean p_70999_1_, boolean p_70999_2_, boolean p_70999_3_) {
@@ -315,7 +326,7 @@
        Optional<BlockPos> optional = this.func_213374_dv();
        super.func_213366_dy();
        if (this.field_70170_p instanceof ServerWorld && p_70999_2_) {
-@@ -1215,17 +1284,17 @@
+@@ -1215,17 +1288,17 @@
     }
  
     public static Optional<Vec3d> func_213822_a(IWorldReader p_213822_0_, BlockPos p_213822_1_, boolean p_213822_2_) {
@@ -337,7 +348,7 @@
        }
     }
  
-@@ -1240,23 +1309,67 @@
+@@ -1240,23 +1313,67 @@
     public void func_146105_b(ITextComponent p_146105_1_, boolean p_146105_2_) {
     }
  
@@ -414,7 +425,7 @@
     }
  
     public void func_195066_a(ResourceLocation p_195066_1_) {
-@@ -1422,6 +1535,8 @@
+@@ -1422,6 +1539,8 @@
           }
  
           super.func_180430_e(p_180430_1_, p_180430_2_);
@@ -423,7 +434,7 @@
        }
     }
  
-@@ -1684,7 +1799,10 @@
+@@ -1684,7 +1803,10 @@
     }
  
     public ITextComponent func_145748_c_() {
@@ -435,7 +446,7 @@
        return this.func_208016_c(itextcomponent);
     }
  
-@@ -1920,4 +2038,44 @@
+@@ -1920,4 +2042,44 @@
           return this.field_221260_g;
        }
     }

--- a/patches/minecraft/net/minecraft/entity/player/ServerPlayerEntity.java.patch
+++ b/patches/minecraft/net/minecraft/entity/player/ServerPlayerEntity.java.patch
@@ -64,8 +64,23 @@
              BlockPos blockpos1 = blockpos.func_177977_b();
              BlockState blockstate1 = this.field_70170_p.func_180495_p(blockpos1);
              Block block = blockstate1.func_177230_c();
-@@ -816,6 +818,7 @@
-             this.field_71135_a.func_147359_a(new SOpenWindowPacket(container.field_75152_c, container.func_216957_a(), p_213829_1_.func_145748_c_()));
+@@ -795,8 +797,8 @@
+    public void func_71117_bO() {
+       this.field_71139_cq = this.field_71139_cq % 100 + 1;
+    }
+-
+-   public OptionalInt func_213829_a(@Nullable INamedContainerProvider p_213829_1_) {
++   
++   public OptionalInt openContainer(@Nullable INamedContainerProvider p_213829_1_, @Nullable net.minecraftforge.common.ContainerExtraData extraData) {
+       if (p_213829_1_ == null) {
+          return OptionalInt.empty();
+       } else {
+@@ -813,9 +815,10 @@
+ 
+             return OptionalInt.empty();
+          } else {
+-            this.field_71135_a.func_147359_a(new SOpenWindowPacket(container.field_75152_c, container.func_216957_a(), p_213829_1_.func_145748_c_()));
++            this.field_71135_a.func_147359_a(new SOpenWindowPacket(container.field_75152_c, container.func_216957_a(), p_213829_1_.func_145748_c_(), extraData));
              container.func_75132_a(this);
              this.field_71070_bA = container;
 +            net.minecraftforge.common.MinecraftForge.EVENT_BUS.post(new net.minecraftforge.event.entity.player.PlayerContainerEvent.Open(this, this.field_71070_bA));

--- a/patches/minecraft/net/minecraft/inventory/container/ContainerType.java.patch
+++ b/patches/minecraft/net/minecraft/inventory/container/ContainerType.java.patch
@@ -9,3 +9,21 @@
     public static final ContainerType<ChestContainer> field_221507_a = func_221505_a("generic_9x1", ChestContainer::func_216986_a);
     public static final ContainerType<ChestContainer> field_221508_b = func_221505_a("generic_9x2", ChestContainer::func_216987_b);
     public static final ContainerType<ChestContainer> field_221509_c = func_221505_a("generic_9x3", ChestContainer::func_216988_c);
+@@ -50,4 +50,17 @@
+       @OnlyIn(Dist.CLIENT)
+       T create(int p_create_1_, PlayerInventory p_create_2_);
+    }
++   
++   /* ================================== Forge Start =====================================*/
++   
++   private java.util.function.Supplier<net.minecraftforge.common.ContainerExtraData> extraData = () -> null;
++   
++   public ContainerType<T> setExtraData(java.util.function.Supplier<net.minecraftforge.common.ContainerExtraData> extraData) {
++	   this.extraData = extraData;
++	   return this;
++   }
++   
++   public net.minecraftforge.common.ContainerExtraData getExtraData() {
++ 	  return this.extraData.get();
++   }
+ }

--- a/patches/minecraft/net/minecraft/network/play/server/SOpenWindowPacket.java.patch
+++ b/patches/minecraft/net/minecraft/network/play/server/SOpenWindowPacket.java.patch
@@ -1,0 +1,38 @@
+--- a/net/minecraft/network/play/server/SOpenWindowPacket.java
++++ b/net/minecraft/network/play/server/SOpenWindowPacket.java
+@@ -29,12 +29,14 @@
+       this.field_218751_a = p_148837_1_.func_150792_a();
+       this.field_218752_b = p_148837_1_.func_150792_a();
+       this.field_218753_c = p_148837_1_.func_179258_d();
++      net.minecraftforge.common.ForgeHooks.readContainerExtra(this, p_148837_1_); //FORGE
+    }
+ 
+    public void func_148840_b(PacketBuffer p_148840_1_) throws IOException {
+       p_148840_1_.func_150787_b(this.field_218751_a);
+       p_148840_1_.func_150787_b(this.field_218752_b);
+       p_148840_1_.func_179256_a(this.field_218753_c);
++      net.minecraftforge.common.ForgeHooks.writeContainerExtra(this, p_148840_1_); //FORGE
+    }
+ 
+    public void func_148833_a(IClientPlayNetHandler p_148833_1_) {
+@@ -56,4 +58,20 @@
+    public ITextComponent func_218748_d() {
+       return this.field_218753_c;
+    }
++   
++   /* ================================== Forge Start =====================================*/
++   public net.minecraftforge.common.ContainerExtraData extras;
++   
++   @Nullable
++   @OnlyIn(Dist.CLIENT)
++   public net.minecraftforge.common.ContainerExtraData getExtraData() {
++      return this.extras;
++   }
++   
++   public SOpenWindowPacket(int windowIdIn, ContainerType<?> typeIn, ITextComponent titleIn, net.minecraftforge.common.ContainerExtraData extras) {
++	   this.field_218751_a = windowIdIn;
++	   this.field_218752_b = Registry.field_218366_G.func_148757_b(typeIn);
++	   this.field_218753_c = titleIn;
++	   this.extras = extras;
++   }
+ }

--- a/src/main/java/net/minecraftforge/common/ContainerExtraData.java
+++ b/src/main/java/net/minecraftforge/common/ContainerExtraData.java
@@ -1,0 +1,43 @@
+/*
+ * Minecraft Forge
+ * Copyright (c) 2016-2019.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation version 2.1
+ * of the License.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+package net.minecraftforge.common;
+
+import net.minecraft.network.PacketBuffer;
+
+public abstract class ContainerExtraData {
+
+	/**
+	 * @param buf The PacketBuffer to read from
+	 */
+	public abstract void read(PacketBuffer buf);
+	
+	/**
+	 * @param buf The PacketBuffer to write to
+	 */
+	public abstract void write(PacketBuffer buf);
+	
+	public interface Accept<T extends ContainerExtraData> {
+		
+		/**
+		 * Called immediately after Container constructor
+		 */
+		public void set(T extraData);
+	}
+}

--- a/src/test/java/net/minecraftforge/debug/client/gui/ExtraContainerDataTest.java
+++ b/src/test/java/net/minecraftforge/debug/client/gui/ExtraContainerDataTest.java
@@ -1,0 +1,182 @@
+/*
+ * Minecraft Forge
+ * Copyright (c) 2016-2019.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation version 2.1
+ * of the License.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+package net.minecraftforge.debug.client.gui;
+
+import java.util.UUID;
+import net.minecraft.block.Block;
+import net.minecraft.block.BlockState;
+import net.minecraft.block.material.Material;
+import net.minecraft.client.gui.ScreenManager;
+import net.minecraft.client.gui.screen.inventory.ContainerScreen;
+import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.entity.player.PlayerInventory;
+import net.minecraft.inventory.container.Container;
+import net.minecraft.inventory.container.ContainerType;
+import net.minecraft.inventory.container.INamedContainerProvider;
+import net.minecraft.item.BlockItem;
+import net.minecraft.item.Item;
+import net.minecraft.item.ItemGroup;
+import net.minecraft.network.PacketBuffer;
+import net.minecraft.util.Hand;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.math.BlockRayTraceResult;
+import net.minecraft.util.text.ITextComponent;
+import net.minecraft.util.text.StringTextComponent;
+import net.minecraft.world.World;
+import net.minecraftforge.common.ContainerExtraData;
+import net.minecraftforge.event.RegistryEvent;
+import net.minecraftforge.fml.common.Mod;
+import net.minecraftforge.fml.event.lifecycle.FMLClientSetupEvent;
+import net.minecraftforge.fml.javafmlmod.FMLJavaModLoadingContext;
+import net.minecraftforge.registries.ObjectHolder;
+
+@Mod("extracontainerdatatest")
+public class ExtraContainerDataTest {
+
+    @ObjectHolder("extracontainerdatatest:test")
+    public static final Block TEST_BLOCK = null;
+    
+    @ObjectHolder("extracontainerdatatest:test")
+    public static final ContainerType<ContainerTest> TEST_CONTAINER = null;
+
+    public ExtraContainerDataTest() {
+    	FMLJavaModLoadingContext.get().getModEventBus().addListener(this::clientSetup);
+    	FMLJavaModLoadingContext.get().getModEventBus().addGenericListener(ContainerType.class, this::registerContainer);
+    	FMLJavaModLoadingContext.get().getModEventBus().addGenericListener(Block.class, this::registerBlock);
+    	FMLJavaModLoadingContext.get().getModEventBus().addGenericListener(Item.class, this::registerItem);
+    }
+    
+    private void clientSetup(FMLClientSetupEvent event) {
+        ScreenManager.registerFactory(TEST_CONTAINER, ScreenTest::new);
+    }
+    
+    public void registerContainer(RegistryEvent.Register<ContainerType<?>> event) {
+    	event.getRegistry().register(new ContainerType<ContainerTest>(ContainerTest::new).setRegistryName("extracontainerdatatest:test").setExtraData(TestDataHandler::new));
+    }
+    
+    public void registerBlock(RegistryEvent.Register<Block> event) {
+    	event.getRegistry().register(new BlockTest(Block.Properties.create(Material.IRON)).setRegistryName("extracontainerdatatest:test"));
+    }
+    
+    
+    public void registerItem(RegistryEvent.Register<Item> event) {
+    	event.getRegistry().register(new BlockItem(TEST_BLOCK, new Item.Properties().group(ItemGroup.BUILDING_BLOCKS)).setRegistryName("extracontainerdatatest:test"));
+    }
+    
+    public static class BlockTest extends Block {
+    	
+    	public BlockTest(Properties properties) {
+			super(properties);
+		}
+
+		@Override
+		public boolean onBlockActivated(BlockState p_220051_1_, World p_220051_2_, BlockPos p_220051_3_, PlayerEntity p_220051_4_, Hand p_220051_5_, BlockRayTraceResult p_220051_6_) {
+            if (p_220051_2_.isRemote) {
+		         return true;
+            } else {
+                INamedContainerProvider inamedcontainerprovider = new INamedContainerProvider() {
+
+                    @Override
+                    public Container createMenu(int p_createMenu_1_, PlayerInventory p_createMenu_2_, PlayerEntity p_createMenu_3_) {
+                        return new ContainerTest(p_createMenu_1_, p_createMenu_2_);
+                    }
+
+					@Override
+		            public ITextComponent getDisplayName() {
+			            return new StringTextComponent("extracontainerdatatest");
+			        } 
+		         };
+		         
+		         p_220051_4_.openContainer(inamedcontainerprovider, new TestDataHandler(p_220051_3_, p_220051_4_.getUniqueID()));
+		         return true;
+		      }
+        }
+ 
+    }
+    
+    public static class TestDataHandler extends ContainerExtraData {
+    	public BlockPos pos;
+    	public UUID entityId;
+		
+		public TestDataHandler() {}
+		public TestDataHandler(BlockPos posIn, UUID entityId) {
+			this.pos = posIn;
+			this.entityId = entityId;
+		}
+		
+		@Override
+		public void read(PacketBuffer buf) {
+			buf.writeBlockPos(this.pos);
+			buf.writeUniqueId(this.entityId);
+		}
+		
+		@Override
+		public void write(PacketBuffer buf) {
+			this.pos = buf.readBlockPos();
+			this.entityId = buf.readUniqueId();
+		}
+    }
+    
+    public static class ContainerTest extends Container implements ContainerExtraData.Accept<TestDataHandler>  {
+    	public TestDataHandler extraData;
+    	
+		protected ContainerTest(int windowId, PlayerInventory playerInventory) {
+			super(ExtraContainerDataTest.TEST_CONTAINER, windowId);
+		}
+
+		@Override
+		public boolean canInteractWith(PlayerEntity playerIn) {
+			return true;
+		}
+
+		@Override
+		public void set(TestDataHandler extraData) {
+			this.extraData = extraData;
+		}
+    	
+    }
+    
+    public static class ScreenTest extends ContainerScreen<ContainerTest> {
+        
+		public ScreenTest(ContainerTest p_i51105_1_, PlayerInventory p_i51105_2_, ITextComponent p_i51105_3_) {
+            super(p_i51105_1_, p_i51105_2_, p_i51105_3_);
+		}
+        
+		@Override
+		public void render(int p_render_1_, int p_render_2_, float p_render_3_) {
+            this.renderBackground();
+            super.render(p_render_1_, p_render_2_, p_render_3_);
+            this.renderHoveredToolTip(p_render_1_, p_render_2_);
+		}
+		
+		@Override
+		protected void drawGuiContainerForegroundLayer(int mouseX, int mouseY) {
+			this.font.drawString(this.getContainer().extraData.pos.toString(), 8.0F, 6.0F, -1);
+			this.font.drawString(this.getContainer().extraData.entityId.toString(), 8.0F, 25.0F, -1);
+		}
+		
+		@Override
+		protected void drawGuiContainerBackgroundLayer(float partialTicks, int mouseX, int mouseY) {
+            
+		}
+    	
+    }
+
+}


### PR DESCRIPTION
This allows extra data to be send to the client in the new ContainerType system when opening a ContainerScreen.

To do create an instance of `net.minecraftforge.common.ContainerExtraData` and populate it will fields of data you wish to send. E.g BlockPos for a TileEntity and complete the read and write methods as appropriate. On creation of the ContainerType call setExtraData(ContainerExtraData::new) - this is used to create the ContainerExtraData object when the packet is received on the client end. Now implement 'net.minecraftforge.common.ContainerExtraData.Accept' in the container and override the `set` method will be called when the extra data is received. To send extra data in the first place use ServerPlayerEntity#openContainer(INamedContainerProvider, ContainerExtraData). The example mod probably explains it better.

