### PR TITLE
[1.13.2/1.14.2] Fire Loading event for default server config

### DIFF
--- a/src/main/java/net/minecraftforge/fml/config/ConfigTracker.java
+++ b/src/main/java/net/minecraftforge/fml/config/ConfigTracker.java
@@ -112,6 +112,7 @@ public class ConfigTracker {
             final CommentedConfig commentedConfig = CommentedConfig.inMemory();
             modConfig.getSpec().correct(commentedConfig);
             modConfig.setConfigData(commentedConfig);
+            modConfig.fireEvent(new ModConfig.Loading(modConfig));
         });
     }
 }


### PR DESCRIPTION
The default server configs weren't loaded/baked, resulting in values being null.