### PR TITLE
[1.13.2/1.14.2] Add logging for exceptions during mod loading

### DIFF
--- a/src/main/java/net/minecraftforge/fml/client/ClientModLoader.java
+++ b/src/main/java/net/minecraftforge/fml/client/ClientModLoader.java
@@ -63,6 +63,7 @@ public class ClientModLoader
         try {
             ModLoader.get().loadMods();
         } catch (LoadingFailedException e) {
+            e.printStackTrace();
             MinecraftForge.EVENT_BUS.shutdown();
             error = e;
         }
@@ -74,6 +75,7 @@ public class ClientModLoader
         try {
             ModLoader.get().finishMods();
         } catch (LoadingFailedException e) {
+            e.printStackTrace();
             MinecraftForge.EVENT_BUS.shutdown();
             if (error == null) error = e;
         }


### PR DESCRIPTION
Logging these exceptions is pretty vital, because the game can crash from errors related to these exceptions before it gets a chance to display the GUI about them.