### PR TITLE
Fix AT for EntitySpawnPlacementRegistry.register

### DIFF
--- a/src/main/resources/META-INF/accesstransformer.cfg
+++ b/src/main/resources/META-INF/accesstransformer.cfg
@@ -388,7 +388,7 @@ public net.minecraft.world.storage.SaveHandler field_75771_c # playersDirectory
 public net.minecraft.item.BlockItemUseContext <init>(Lnet/minecraft/world/World;Lnet/minecraft/entity/player/PlayerEntity;Lnet/minecraft/item/ItemStack;Lnet/minecraft/util/math/BlockPos;Lnet/minecraft/util/EnumFacing;FFF)V
 
 #EntitySpawnPlacementRegistry
-public net.minecraft.entity.EntitySpawnPlacementRegistry func_209346_a(Lnet/minecraft/entity/EntityType;Lnet/minecraft/entity/EntitySpawnPlacementRegistry$PlacementType;Lnet/minecraft/world/gen/Heightmap$Type;Lnet/minecraft/tags/Tag;)V # register
+public net.minecraft.entity.EntitySpawnPlacementRegistry func_209343_a(Lnet/minecraft/entity/EntityType;Lnet/minecraft/entity/EntitySpawnPlacementRegistry$PlacementType;Lnet/minecraft/world/gen/Heightmap$Type;)V # register
 
 # Block$Properties
 public net.minecraft.block.Block$Properties func_200947_a(Lnet/minecraft/block/SoundType;)Lnet/minecraft/block/Block$Properties; # sound


### PR DESCRIPTION
The method sig changed which broke the AT, removing the ability to register to the placement registry. This should fix it.