### PR TITLE
Fix DimensionArgument not working

### DIFF
--- a/src/main/java/net/minecraftforge/registries/ClearableRegistry.java
+++ b/src/main/java/net/minecraftforge/registries/ClearableRegistry.java
@@ -167,7 +167,6 @@ public class ClearableRegistry<T> extends MutableRegistry<T>
 
     @Override
     public Optional<T> func_218349_b(ResourceLocation p_218349_1_) {
-        // TODO Auto-generated method stub
-        return null;
+        return Optional.ofNullable(map.get(p_218349_1_));
     }
 }


### PR DESCRIPTION
The DimensionArgument use the 
``` java 
Registry.DIMENSION_TYPE.getValue(param); 
``` 
method to parse the string of this command argument. This method was not implemented in Clearable Registry which resulted always in a failure of the command.
This pull implements the method so the commands will work