### PR TITLE
Fix unnecessary WorldEvent.Unload continue to be dispatched

### DIFF
--- a/patches/minecraft/net/minecraft/client/Minecraft.java.patch
+++ b/patches/minecraft/net/minecraft/client/Minecraft.java.patch
@@ -174,15 +174,7 @@
     }
  
     private void func_184117_aA() {
-@@ -1430,6 +1446,7 @@
-             this.field_71439_g.func_71040_bB(Screen.hasControlDown());
-          }
-       }
-+      if (field_71441_e != null) net.minecraftforge.common.MinecraftForge.EVENT_BUS.post(new net.minecraftforge.event.world.WorldEvent.Unload(field_71441_e));
- 
-       boolean flag2 = this.field_71474_y.field_74343_n != ChatVisibility.HIDDEN;
-       if (flag2) {
-@@ -1526,6 +1543,12 @@
+@@ -1526,6 +1542,12 @@
        this.func_147108_a(worldloadprogressscreen);
  
        while(!this.field_71437_Z.func_71200_ad()) {
@@ -195,7 +187,7 @@
           worldloadprogressscreen.tick();
           this.func_195542_b(false);
  
-@@ -1546,11 +1569,17 @@
+@@ -1546,11 +1568,17 @@
        networkmanager.func_150719_a(new ClientLoginNetHandler(networkmanager, this, (Screen)null, (p_213261_0_) -> {
        }));
        networkmanager.func_179290_a(new CHandshakePacket(socketaddress.toString(), 0, ProtocolType.LOGIN));
@@ -214,7 +206,7 @@
        WorkingScreen workingscreen = new WorkingScreen();
        workingscreen.func_200210_a(new TranslationTextComponent("connect.joining"));
        this.func_213241_c(workingscreen);
-@@ -1623,6 +1652,7 @@
+@@ -1623,6 +1651,7 @@
        }
  
        TileEntityRendererDispatcher.field_147556_a.func_147543_a(p_213257_1_);
@@ -222,7 +214,7 @@
     }
  
     public final boolean func_71355_q() {
-@@ -1648,112 +1678,8 @@
+@@ -1648,112 +1677,8 @@
  
     private void func_147112_ai() {
        if (this.field_71476_x != null && this.field_71476_x.func_216346_c() != RayTraceResult.Type.MISS) {
@@ -337,7 +329,7 @@
        }
     }
  
-@@ -1825,6 +1751,7 @@
+@@ -1825,6 +1750,7 @@
        return field_71432_P;
     }
  
@@ -345,7 +337,7 @@
     public CompletableFuture<Void> func_213245_w() {
        return this.func_213169_a(this::func_213237_g).thenCompose((p_213240_0_) -> {
           return p_213240_0_;
-@@ -1968,6 +1895,8 @@
+@@ -1968,6 +1894,8 @@
     }
  
     public MusicTicker.MusicType func_147109_W() {
@@ -354,7 +346,7 @@
        if (this.field_71462_r instanceof WinGameScreen) {
           return MusicTicker.MusicType.CREDITS;
        } else if (this.field_71439_g == null) {
-@@ -2124,4 +2053,12 @@
+@@ -2124,4 +2052,12 @@
     public LoadingGui func_213250_au() {
        return this.field_213279_p;
     }


### PR DESCRIPTION
This PR is removed an unnecessary `WorldEvent.Unload` dispatch from a `Minecraft#processKeyBinds` method.