### PR TITLE
Add grindstone event, use ItemStack-sensitive getMaxDamage

### DIFF
--- a/patches/minecraft/net/minecraft/inventory/container/GrindstoneContainer.java.patch
+++ b/patches/minecraft/net/minecraft/inventory/container/GrindstoneContainer.java.patch
@@ -1,0 +1,26 @@
+--- a/net/minecraft/inventory/container/GrindstoneContainer.java
++++ b/net/minecraft/inventory/container/GrindstoneContainer.java
+@@ -123,6 +123,7 @@
+       if (!flag) {
+          this.field_217013_c.func_70299_a(0, ItemStack.field_190927_a);
+       } else {
++         if (!net.minecraftforge.common.ForgeHooks.onGrindstoneChange(itemstack, itemstack1, field_217013_c)) return;
+          boolean flag2 = !itemstack.func_190926_b() && itemstack.func_77973_b() != Items.field_151134_bR && !itemstack.func_77948_v() || !itemstack1.func_190926_b() && itemstack1.func_77973_b() != Items.field_151134_bR && !itemstack1.func_77948_v();
+          if (itemstack.func_190916_E() > 1 || itemstack1.func_190916_E() > 1 || !flag1 && flag2) {
+             this.field_217013_c.func_70299_a(0, ItemStack.field_190927_a);
+@@ -140,11 +141,10 @@
+                return;
+             }
+ 
+-            Item item = itemstack.func_77973_b();
+-            int k = item.func_77612_l() - itemstack.func_77952_i();
+-            int l = item.func_77612_l() - itemstack1.func_77952_i();
+-            int i1 = k + l + item.func_77612_l() * 5 / 100;
+-            i = Math.max(item.func_77612_l() - i1, 0);
++            int k = itemstack.func_77958_k() - itemstack.func_77952_i();
++            int l = itemstack1.func_77958_k() - itemstack1.func_77952_i();
++            int i1 = k + l + itemstack.func_77958_k() * 5 / 100;
++            i = Math.max(itemstack.func_77958_k() - i1, 0);
+             itemstack2 = this.func_217011_b(itemstack, itemstack1);
+             if (!itemstack2.func_77984_f()) {
+                if (!ItemStack.func_77989_b(itemstack, itemstack1)) {

--- a/patches/minecraft/net/minecraft/inventory/container/GrindstoneContainer.java.patch
+++ b/patches/minecraft/net/minecraft/inventory/container/GrindstoneContainer.java.patch
@@ -1,18 +1,41 @@
 --- a/net/minecraft/inventory/container/GrindstoneContainer.java
 +++ b/net/minecraft/inventory/container/GrindstoneContainer.java
-@@ -123,6 +123,7 @@
+@@ -27,6 +27,7 @@
+       }
+    };
+    private final IWorldPosCallable field_217015_e;
++   public int xpOnCraft = -1;
+ 
+    public GrindstoneContainer(int p_i50080_1_, PlayerInventory p_i50080_2_) {
+       this(p_i50080_1_, p_i50080_2_, IWorldPosCallable.field_221489_a);
+@@ -53,6 +54,7 @@
+          public ItemStack func_190901_a(PlayerEntity p_190901_1_, ItemStack p_190901_2_) {
+             p_i50081_3_.func_221486_a((p_216944_1_, p_216944_2_) -> {
+                int l = this.func_216942_a(p_216944_1_);
++               xpOnCraft = -1;
+ 
+                while(l > 0) {
+                   int i1 = ExperienceOrbEntity.func_70527_a(l);
+@@ -68,6 +70,7 @@
+          }
+ 
+          private int func_216942_a(World p_216942_1_) {
++            if (xpOnCraft >= 0) return xpOnCraft;
+             int l = 0;
+             l = l + this.func_216943_e(GrindstoneContainer.this.field_217014_d.func_70301_a(0));
+             l = l + this.func_216943_e(GrindstoneContainer.this.field_217014_d.func_70301_a(1));
+@@ -123,6 +126,7 @@
        if (!flag) {
           this.field_217013_c.func_70299_a(0, ItemStack.field_190927_a);
        } else {
-+         if (!net.minecraftforge.common.ForgeHooks.onGrindstoneChange(itemstack, itemstack1, field_217013_c)) return;
++         if (!net.minecraftforge.common.ForgeHooks.onGrindstoneChangePre(itemstack, itemstack1, field_217013_c, this)) return;
           boolean flag2 = !itemstack.func_190926_b() && itemstack.func_77973_b() != Items.field_151134_bR && !itemstack.func_77948_v() || !itemstack1.func_190926_b() && itemstack1.func_77973_b() != Items.field_151134_bR && !itemstack1.func_77948_v();
           if (itemstack.func_190916_E() > 1 || itemstack1.func_190916_E() > 1 || !flag1 && flag2) {
              this.field_217013_c.func_70299_a(0, ItemStack.field_190927_a);
-@@ -140,11 +141,10 @@
-                return;
+@@ -141,10 +145,10 @@
              }
  
--            Item item = itemstack.func_77973_b();
+             Item item = itemstack.func_77973_b();
 -            int k = item.func_77612_l() - itemstack.func_77952_i();
 -            int l = item.func_77612_l() - itemstack1.func_77952_i();
 -            int i1 = k + l + item.func_77612_l() * 5 / 100;
@@ -24,3 +47,12 @@
              itemstack2 = this.func_217011_b(itemstack, itemstack1);
              if (!itemstack2.func_77984_f()) {
                 if (!ItemStack.func_77989_b(itemstack, itemstack1)) {
+@@ -161,7 +165,7 @@
+             itemstack2 = flag3 ? itemstack : itemstack1;
+          }
+ 
+-         this.field_217013_c.func_70299_a(0, this.func_217007_a(itemstack2, i, j));
++         net.minecraftforge.common.ForgeHooks.onGrindstoneChangePost(itemstack, itemstack1, this.func_217007_a(itemstack2, i, j), field_217013_c, this);
+       }
+ 
+       this.func_75142_b();

--- a/src/main/java/net/minecraftforge/common/ForgeHooks.java
+++ b/src/main/java/net/minecraftforge/common/ForgeHooks.java
@@ -45,6 +45,7 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import net.minecraft.advancements.Advancement;
 import net.minecraft.block.Block;
+import net.minecraft.inventory.container.GrindstoneContainer;
 import net.minecraft.util.CachedBlockInfo;
 import net.minecraft.block.BlockState;
 import net.minecraft.client.Minecraft;
@@ -693,17 +694,29 @@ public class ForgeHooks
         return e.getBreakChance();
     }
 
-    public static boolean onGrindstoneChange(@Nonnull ItemStack first, @Nonnull ItemStack second, IInventory outputSlot)
+    public static boolean onGrindstoneChangePre(ItemStack first, ItemStack second, IInventory outputSlot, GrindstoneContainer container)
     {
-        GrindstoneUpdateEvent e = new GrindstoneUpdateEvent(first, second);
-        if (MinecraftForge.EVENT_BUS.post(e))
+        GrindstoneUpdateEvent event = new GrindstoneUpdateEvent.Pre(first, second);
+        return onGrindstoneChange(event, outputSlot, container);
+    }
+
+    public static void onGrindstoneChangePost(ItemStack first, ItemStack second, ItemStack output, IInventory outputSlot, GrindstoneContainer container)
+    {
+        GrindstoneUpdateEvent event = new GrindstoneUpdateEvent.Post(first, second, output);
+        onGrindstoneChange(event, outputSlot, container);
+    }
+
+    public static boolean onGrindstoneChange(GrindstoneUpdateEvent event, IInventory outputSlot, GrindstoneContainer container)
+    {
+        if (MinecraftForge.EVENT_BUS.post(event))
         {
             outputSlot.setInventorySlotContents(0, ItemStack.EMPTY);
             return false;
         }
-        if (e.getOutput().isEmpty()) return true;
+        if (event.getOutput().isEmpty()) return true;
 
-        outputSlot.setInventorySlotContents(0, e.getOutput());
+        outputSlot.setInventorySlotContents(0, event.getOutput());
+        container.xpOnCraft = event.getXp();
         return false;
     }
 

--- a/src/main/java/net/minecraftforge/common/ForgeHooks.java
+++ b/src/main/java/net/minecraftforge/common/ForgeHooks.java
@@ -137,6 +137,7 @@ import net.minecraftforge.event.entity.player.AttackEntityEvent;
 import net.minecraftforge.event.entity.player.CriticalHitEvent;
 import net.minecraftforge.event.entity.player.PlayerEvent;
 import net.minecraftforge.event.entity.player.PlayerInteractEvent;
+import net.minecraftforge.event.grindstone.GrindstoneUpdateEvent;
 import net.minecraftforge.event.world.BlockEvent;
 import net.minecraftforge.event.world.NoteBlockEvent;
 import net.minecraftforge.eventbus.api.Event.Result;
@@ -690,6 +691,20 @@ public class ForgeHooks
         AnvilRepairEvent e = new AnvilRepairEvent(player, left, right, output);
         MinecraftForge.EVENT_BUS.post(e);
         return e.getBreakChance();
+    }
+
+    public static boolean onGrindstoneChange(@Nonnull ItemStack first, @Nonnull ItemStack second, IInventory outputSlot)
+    {
+        GrindstoneUpdateEvent e = new GrindstoneUpdateEvent(first, second);
+        if (MinecraftForge.EVENT_BUS.post(e))
+        {
+            outputSlot.setInventorySlotContents(0, ItemStack.EMPTY);
+            return false;
+        }
+        if (e.getOutput().isEmpty()) return true;
+
+        outputSlot.setInventorySlotContents(0, e.getOutput());
+        return false;
     }
 
     private static ThreadLocal<PlayerEntity> craftingPlayer = new ThreadLocal<PlayerEntity>();

--- a/src/main/java/net/minecraftforge/event/grindstone/GrindstoneUpdateEvent.java
+++ b/src/main/java/net/minecraftforge/event/grindstone/GrindstoneUpdateEvent.java
@@ -1,0 +1,59 @@
+package net.minecraftforge.event.grindstone;
+
+import net.minecraft.item.ItemStack;
+import net.minecraftforge.eventbus.api.Cancelable;
+import net.minecraftforge.eventbus.api.Event;
+
+import javax.annotation.Nonnull;
+
+/**
+ * Fired when a player places items in both the top and bottom slots of the grindstone. Very similar
+ * to AnvilUpdateEvent.
+ * If the event is canceled, vanilla behavior will not run and the output slot will be cleared.
+ * If the event is not canceled and the output is not empty, it will set the output and not run vanilla behavior.
+ * If the event is not canceled and the output is empty, normal vanilla behavior will run.
+ */
+@Cancelable
+public class GrindstoneUpdateEvent extends Event
+{
+    @Nonnull private final ItemStack first;
+    @Nonnull private final ItemStack second;
+    @Nonnull private ItemStack output;
+
+    public GrindstoneUpdateEvent(@Nonnull ItemStack first, @Nonnull ItemStack second)
+    {
+        this.first = first;
+        this.second = second;
+        this.output = ItemStack.EMPTY;
+    }
+
+    /**
+     * Gets the item in the top slot. In vanilla, most of the first item's NBT is copied to the
+     * output item.
+     */
+    @Nonnull
+    public ItemStack getFirst()
+    {
+        return first;
+    }
+
+    /**
+     * Gets the item in the bottom slot.
+     */
+    @Nonnull
+    public ItemStack getSecond()
+    {
+        return second;
+    }
+
+    @Nonnull
+    public ItemStack getOutput()
+    {
+        return output;
+    }
+
+    public void setOutput(@Nonnull ItemStack output)
+    {
+        this.output = output;
+    }
+}

--- a/src/main/java/net/minecraftforge/event/grindstone/GrindstoneUpdateEvent.java
+++ b/src/main/java/net/minecraftforge/event/grindstone/GrindstoneUpdateEvent.java
@@ -7,24 +7,53 @@ import net.minecraftforge.eventbus.api.Event;
 import javax.annotation.Nonnull;
 
 /**
- * Fired when a player places items in both the top and bottom slots of the grindstone. Very similar
- * to AnvilUpdateEvent.
- * If the event is canceled, vanilla behavior will not run and the output slot will be cleared.
- * If the event is not canceled and the output is not empty, it will set the output and not run vanilla behavior.
- * If the event is not canceled and the output is empty, normal vanilla behavior will run.
+ * Fired when a player places items in both the top and bottom slots of the grindstone.
+ * <p>
+ * The {@link Pre} event fires before most vanilla logic, while the {@link Post} event fires after
+ * vanilla calculates the normal output. {@code Post} is the better choice for making simple
+ * changes, while {@code Pre} allows different behavior, such as combining different types of
+ * items.
+ * <p>
+ * Canceling the event will clear the output slot.
+ * <p>
+ * If {@code xp} is less than zero, vanilla logic is used to calculate XP.
  */
 @Cancelable
 public class GrindstoneUpdateEvent extends Event
 {
+    /**
+     * Fired before most of the grindstone's checks. This does <em>not</em> provide the vanilla
+     * output. If the output is left empty, vanilla logic will continue.
+     */
+    public static class Pre extends GrindstoneUpdateEvent
+    {
+        public Pre(@Nonnull ItemStack first, @Nonnull ItemStack second)
+        {
+            super(first, second, ItemStack.EMPTY);
+        }
+    }
+
+    /**
+     * Fired after all vanilla checks. This provides the vanilla output.
+     */
+    public static class Post extends GrindstoneUpdateEvent
+    {
+        public Post(@Nonnull ItemStack first, @Nonnull ItemStack second, @Nonnull ItemStack output)
+        {
+            super(first, second, output);
+        }
+    }
+
     @Nonnull private final ItemStack first;
     @Nonnull private final ItemStack second;
     @Nonnull private ItemStack output;
+    private int xp = -1;
 
-    public GrindstoneUpdateEvent(@Nonnull ItemStack first, @Nonnull ItemStack second)
+    public GrindstoneUpdateEvent(@Nonnull ItemStack first, @Nonnull ItemStack second, @Nonnull ItemStack output)
     {
         this.first = first;
         this.second = second;
-        this.output = ItemStack.EMPTY;
+        this.output = output;
     }
 
     /**
@@ -55,5 +84,15 @@ public class GrindstoneUpdateEvent extends Event
     public void setOutput(@Nonnull ItemStack output)
     {
         this.output = output;
+    }
+
+    public int getXp()
+    {
+        return xp;
+    }
+
+    public void setXp(int xp)
+    {
+        this.xp = xp;
     }
 }


### PR DESCRIPTION
This makes a change to `GrindstoneContainer` so it uses `ItemStack.getMaxDamage` instead of `Item.getMaxDamage`, which makes the results more accurate for some items. I also added an event for mods which need more control over the output. The event is very similar to `AnvilUpdateEvent`. It can also be canceled, which will clear the grindstone's output slot.

**A simple example mod can be found here**: https://gist.github.com/SilentChaos512/74a31a24e348fbe5c752b184fa394d9c  
This shows both overriding the output and canceling the event.