### PR TITLE
[1.14.x] [Bug] Fix old entity not being removed in Entity#changeDimension

### DIFF
--- a/patches/minecraft/net/minecraft/entity/Entity.java.patch
+++ b/patches/minecraft/net/minecraft/entity/Entity.java.patch
@@ -240,15 +240,16 @@
  
              double d3 = Math.min(-2.9999872E7D, serverworld1.func_175723_af().func_177726_b() + 16.0D);
              double d4 = Math.min(-2.9999872E7D, serverworld1.func_175723_af().func_177736_c() + 16.0D);
-@@ -2118,7 +2141,6 @@
+@@ -2118,7 +2141,7 @@
              serverworld1.func_217460_e(entity);
           }
  
 -         this.field_70128_L = true;
++         this.remove(false);
           this.field_70170_p.func_217381_Z().func_76319_b();
           serverworld.func_82742_i();
           serverworld1.func_82742_i();
-@@ -2274,7 +2296,7 @@
+@@ -2274,7 +2297,7 @@
        Pose pose = this.func_213283_Z();
        EntitySize entitysize1 = this.func_213305_a(pose);
        this.field_213325_aI = entitysize1;
@@ -257,7 +258,7 @@
        if (entitysize1.field_220315_a < entitysize.field_220315_a) {
           double d0 = (double)entitysize1.field_220315_a / 2.0D;
           this.func_174826_a(new AxisAlignedBB(this.field_70165_t - d0, this.field_70163_u, this.field_70161_v - d0, this.field_70165_t + d0, this.field_70163_u + (double)entitysize1.field_220316_b, this.field_70161_v + d0));
-@@ -2641,6 +2663,7 @@
+@@ -2641,6 +2664,7 @@
        return this.field_211517_W;
     }
  
@@ -265,7 +266,7 @@
     public final float func_213311_cf() {
        return this.field_213325_aI.field_220315_a;
     }
-@@ -2670,4 +2693,69 @@
+@@ -2670,4 +2694,69 @@
     public void func_213293_j(double p_213293_1_, double p_213293_3_, double p_213293_5_) {
        this.func_213317_d(new Vec3d(p_213293_1_, p_213293_3_, p_213293_5_));
     }


### PR DESCRIPTION
In Forge 1.14.x, when an entity is teleported from one dimension to another (for example, when an item is tossed into a portal), it is copied to the new world, but never removed from the old world.

This obviously causes some poblems, for example:

**When an item is tossed into a nether portal**
Item duplication. (see https://youtu.be/PSPbKPkPQHo)

**When an entity is dropped into the end portal**
Because the old entity is not removed, the server will attempt to transfer it to the new dimension again on the next tick. But because the entity.dimension field is now inconsistent with the entity.world field, the game will just crash with an NPE in this case. (see https://pastebin.com/NfWiSb7k)
This happens, for example, when the enderdragon is killed and the torches on the portal thingy drop into the portal.

This PR adds the call to Entity#remove that is present in 1.13.x, but was probably accidentally removed in the 1.13 -> 1.14 patch update.