### PR TITLE
Fix leather armor dye recipe (unnecessary patch)

### DIFF
--- a/patches/minecraft/net/minecraft/item/crafting/ArmorDyeRecipe.java.patch
+++ b/patches/minecraft/net/minecraft/item/crafting/ArmorDyeRecipe.java.patch
@@ -1,14 +1,5 @@
 --- a/net/minecraft/item/crafting/ArmorDyeRecipe.java
 +++ b/net/minecraft/item/crafting/ArmorDyeRecipe.java
-@@ -31,7 +31,7 @@
- 
-                itemstack = itemstack1;
-             } else {
--               if (!(itemstack1.func_77973_b() instanceof DyeItem)) {
-+               if (!(itemstack.func_77973_b() instanceof DyeItem)) {
-                   return false;
-                }
- 
 @@ -74,7 +74,6 @@
        }
     }


### PR DESCRIPTION
Remove patch that broke the leather armor dye recipe.

**Before**
![grafik](https://user-images.githubusercontent.com/7681220/59723998-a4a2f180-9228-11e9-94f4-c21369db81a7.png)
**With this commit**
![grafik](https://user-images.githubusercontent.com/7681220/59724056-d451f980-9228-11e9-8bcd-3de26ab3ad58.png)
