### PR TITLE
[1.14.x] Replace dye items in Forge tags.

### DIFF
--- a/src/generated/resources/data/forge/tags/items/dyes/black.json
+++ b/src/generated/resources/data/forge/tags/items/dyes/black.json
@@ -1,6 +1,7 @@
 {
   "replace": false,
   "values": [
-    "minecraft:ink_sac"
+    "minecraft:ink_sac",
+    "minecraft:black_dye"
   ]
 }

--- a/src/generated/resources/data/forge/tags/items/dyes/black.json
+++ b/src/generated/resources/data/forge/tags/items/dyes/black.json
@@ -1,7 +1,6 @@
 {
   "replace": false,
   "values": [
-    "minecraft:ink_sac",
     "minecraft:black_dye"
   ]
 }

--- a/src/generated/resources/data/forge/tags/items/dyes/blue.json
+++ b/src/generated/resources/data/forge/tags/items/dyes/blue.json
@@ -1,6 +1,7 @@
 {
   "replace": false,
   "values": [
-    "minecraft:lapis_lazuli"
+    "minecraft:lapis_lazuli",
+    "minecraft:blue_dye"
   ]
 }

--- a/src/generated/resources/data/forge/tags/items/dyes/blue.json
+++ b/src/generated/resources/data/forge/tags/items/dyes/blue.json
@@ -1,7 +1,6 @@
 {
   "replace": false,
   "values": [
-    "minecraft:lapis_lazuli",
     "minecraft:blue_dye"
   ]
 }

--- a/src/generated/resources/data/forge/tags/items/dyes/brown.json
+++ b/src/generated/resources/data/forge/tags/items/dyes/brown.json
@@ -1,7 +1,6 @@
 {
   "replace": false,
   "values": [
-    "minecraft:cocoa_beans",
     "minecraft:brown_dye"
   ]
 }

--- a/src/generated/resources/data/forge/tags/items/dyes/brown.json
+++ b/src/generated/resources/data/forge/tags/items/dyes/brown.json
@@ -1,6 +1,7 @@
 {
   "replace": false,
   "values": [
-    "minecraft:cocoa_beans"
+    "minecraft:cocoa_beans",
+    "minecraft:brown_dye"
   ]
 }

--- a/src/generated/resources/data/forge/tags/items/dyes/white.json
+++ b/src/generated/resources/data/forge/tags/items/dyes/white.json
@@ -1,6 +1,7 @@
 {
   "replace": false,
   "values": [
-    "minecraft:bone_meal"
+    "minecraft:bone_meal",
+    "minecraft:white_dye"
   ]
 }

--- a/src/generated/resources/data/forge/tags/items/dyes/white.json
+++ b/src/generated/resources/data/forge/tags/items/dyes/white.json
@@ -1,7 +1,6 @@
 {
   "replace": false,
   "values": [
-    "minecraft:bone_meal",
     "minecraft:white_dye"
   ]
 }

--- a/src/main/java/net/minecraftforge/common/data/ForgeItemTagsProvider.java
+++ b/src/main/java/net/minecraftforge/common/data/ForgeItemTagsProvider.java
@@ -44,9 +44,9 @@ public class ForgeItemTagsProvider extends ItemTagsProvider
         getBuilder(Tags.Items.DUSTS_PRISMARINE).add(Items.PRISMARINE_SHARD);
         getBuilder(Tags.Items.DUSTS_REDSTONE).add(Items.REDSTONE);
         getBuilder(Tags.Items.DYES).add(Tags.Items.DYES_BLACK, Tags.Items.DYES_RED, Tags.Items.DYES_GREEN, Tags.Items.DYES_BROWN, Tags.Items.DYES_BLUE, Tags.Items.DYES_PURPLE, Tags.Items.DYES_CYAN, Tags.Items.DYES_LIGHT_GRAY, Tags.Items.DYES_GRAY, Tags.Items.DYES_PINK, Tags.Items.DYES_LIME, Tags.Items.DYES_YELLOW, Tags.Items.DYES_LIGHT_BLUE, Tags.Items.DYES_MAGENTA, Tags.Items.DYES_ORANGE, Tags.Items.DYES_WHITE);
-        getBuilder(Tags.Items.DYES_BLACK).add(Items.INK_SAC);
-        getBuilder(Tags.Items.DYES_BLUE).add(Items.LAPIS_LAZULI);
-        getBuilder(Tags.Items.DYES_BROWN).add(Items.COCOA_BEANS);
+        getBuilder(Tags.Items.DYES_BLACK).add(Items.field_222086_lz);
+        getBuilder(Tags.Items.DYES_BLUE).add(Items.field_222083_lx);
+        getBuilder(Tags.Items.DYES_BROWN).add(Items.field_222085_ly);
         getBuilder(Tags.Items.DYES_CYAN).add(Items.CYAN_DYE);
         getBuilder(Tags.Items.DYES_GRAY).add(Items.GRAY_DYE);
         getBuilder(Tags.Items.DYES_GREEN).add(Items.GREEN_DYE);

--- a/src/main/java/net/minecraftforge/common/data/ForgeItemTagsProvider.java
+++ b/src/main/java/net/minecraftforge/common/data/ForgeItemTagsProvider.java
@@ -44,9 +44,9 @@ public class ForgeItemTagsProvider extends ItemTagsProvider
         getBuilder(Tags.Items.DUSTS_PRISMARINE).add(Items.PRISMARINE_SHARD);
         getBuilder(Tags.Items.DUSTS_REDSTONE).add(Items.REDSTONE);
         getBuilder(Tags.Items.DYES).add(Tags.Items.DYES_BLACK, Tags.Items.DYES_RED, Tags.Items.DYES_GREEN, Tags.Items.DYES_BROWN, Tags.Items.DYES_BLUE, Tags.Items.DYES_PURPLE, Tags.Items.DYES_CYAN, Tags.Items.DYES_LIGHT_GRAY, Tags.Items.DYES_GRAY, Tags.Items.DYES_PINK, Tags.Items.DYES_LIME, Tags.Items.DYES_YELLOW, Tags.Items.DYES_LIGHT_BLUE, Tags.Items.DYES_MAGENTA, Tags.Items.DYES_ORANGE, Tags.Items.DYES_WHITE);
-        getBuilder(Tags.Items.DYES_BLACK).add(Items.field_222086_lz);
-        getBuilder(Tags.Items.DYES_BLUE).add(Items.field_222083_lx);
-        getBuilder(Tags.Items.DYES_BROWN).add(Items.field_222085_ly);
+        getBuilder(Tags.Items.DYES_BLACK).add(Items.BLACK_DYE);
+        getBuilder(Tags.Items.DYES_BLUE).add(Items.BLUE_DYE);
+        getBuilder(Tags.Items.DYES_BROWN).add(Items.BROWN_DYE);
         getBuilder(Tags.Items.DYES_CYAN).add(Items.CYAN_DYE);
         getBuilder(Tags.Items.DYES_GRAY).add(Items.GRAY_DYE);
         getBuilder(Tags.Items.DYES_GREEN).add(Items.GREEN_DYE);
@@ -58,7 +58,7 @@ public class ForgeItemTagsProvider extends ItemTagsProvider
         getBuilder(Tags.Items.DYES_PINK).add(Items.PINK_DYE);
         getBuilder(Tags.Items.DYES_PURPLE).add(Items.PURPLE_DYE);
         getBuilder(Tags.Items.DYES_RED).add(Items.RED_DYE);
-        getBuilder(Tags.Items.DYES_WHITE).add(Items.BONE_MEAL);
+        getBuilder(Tags.Items.DYES_WHITE).add(Items.WHITE_DYE);
         getBuilder(Tags.Items.DYES_YELLOW).add(Items.YELLOW_DYE);
         copy(Tags.Blocks.FENCE_GATES, Tags.Items.FENCE_GATES);
         copy(Tags.Blocks.FENCE_GATES_WOODEN, Tags.Items.FENCE_GATES_WOODEN);


### PR DESCRIPTION
This PR adds the new dye items to the Forge item tags for colored dyes.

* `minecraft:blue_dye` -> `Tags.Items.DYES_BLUE`
* `minecraft:black_dye` -> `Tags.Items.DYES_BLACK`
* `minecraft:brown_dye` -> `Tags.Items.DYES_BROWN`
* `minecraft:white_dye` -> `Tags.Items.DYES_WHITE`

This fixes the potential for recipes using the Forge dye tags to refuse the new vanilla dyes added in 1.14.