### PR TITLE
Add isItemValid check for ItemStackHandler

### DIFF
--- a/src/main/java/net/minecraftforge/items/ItemStackHandler.java
+++ b/src/main/java/net/minecraftforge/items/ItemStackHandler.java
@@ -80,6 +80,9 @@ public class ItemStackHandler implements IItemHandler, IItemHandlerModifiable, I
     {
         if (stack.isEmpty())
             return ItemStack.EMPTY;
+            
+        if (!isItemValid(slot, stack))
+            return stack;
 
         validateSlotIndex(slot);
 
@@ -89,7 +92,7 @@ public class ItemStackHandler implements IItemHandler, IItemHandlerModifiable, I
 
         if (!existing.isEmpty())
         {
-            if (!ItemHandlerHelper.canItemStacksStack(stack, existing) || !isItemValid(slot, stack))
+            if (!ItemHandlerHelper.canItemStacksStack(stack, existing))
                 return stack;
 
             limit -= existing.getCount();

--- a/src/main/java/net/minecraftforge/items/ItemStackHandler.java
+++ b/src/main/java/net/minecraftforge/items/ItemStackHandler.java
@@ -89,7 +89,7 @@ public class ItemStackHandler implements IItemHandler, IItemHandlerModifiable, I
 
         if (!existing.isEmpty())
         {
-            if (!ItemHandlerHelper.canItemStacksStack(stack, existing))
+            if (!ItemHandlerHelper.canItemStacksStack(stack, existing) || !isItemValid(slot, stack))
                 return stack;
 
             limit -= existing.getCount();


### PR DESCRIPTION
ItemStackHandler will now no longer proceed to insert an item if isItemValid returns false.

This fixes #5849.

This handler will now no longer accept anything other than diamonds:
```java
ItemStackHandler handler = new ItemStackHandler(5) {
    @Override
    public boolean isItemValid(int slot, ItemStack stack) {
        return stack.getItem() == Items.DIAMOND;
    }
}
```