### PR TITLE
Fix long type config value was always reset if that's integer range

### DIFF
--- a/src/main/java/net/minecraftforge/common/ForgeConfigSpec.java
+++ b/src/main/java/net/minecraftforge/common/ForgeConfigSpec.java
@@ -563,6 +563,12 @@ public class ForgeConfigSpec extends UnmodifiableConfigWrapper<Config>
         @Override
         public boolean test(Object t)
         {
+            // Even if use Long type, the value obtained from the config file may be Integer type
+            if (clazz.equals(Long.class) && t instanceof Integer)
+            {
+                V c = clazz.cast(((Integer) t).longValue());
+                return c.compareTo(min) >= 0 && c.compareTo(max) <= 0;
+            }
             if (!clazz.isInstance(t)) return false;
             V c = clazz.cast(t);
             return c.compareTo(min) >= 0 && c.compareTo(max) <= 0;


### PR DESCRIPTION
```java
long defaultValue = Integer.MAX_VALUE;
long min = Long.MIN_VALUE;
long max = Long.MAX_VALUE;

ForgeConfigSpec.Builder builder = new ForgeConfigSpec.Builder();
```
```java
builder
    .defineInRange("long.value", defaultValue, min, max);
```

```
[22:29:59.322] [Client thread/WARN] [ne.mi.co.ForgeConfigSpec/CORE]: Incorrect key long.value was corrected from 2147483647 to 2147483647
```