### PR TITLE
[1.14.x] Add RegisterReloadListenersEvent

### DIFF
--- a/patches/minecraft/net/minecraft/client/Minecraft.java.patch
+++ b/patches/minecraft/net/minecraft/client/Minecraft.java.patch
@@ -42,7 +42,12 @@
        this.field_184132_p = new DebugRenderer(this);
        GLX.setGlfwErrorCallback(this::func_195545_a);
        if (this.field_71474_y.field_74353_u && !this.field_195558_d.func_198113_j()) {
-@@ -542,7 +543,7 @@
+@@ -538,11 +539,12 @@
+       }
+ 
+       ResourceLoadProgressGui.func_212970_a(this);
++      net.minecraftforge.client.ForgeHooksClient.registerReloadListeners(this.field_110451_am);
+       this.func_213268_a(new ResourceLoadProgressGui(this, this.field_110451_am.func_219535_a(Util.func_215072_e(), this, CompletableFuture.completedFuture(Unit.INSTANCE)), () -> {
           if (SharedConstants.field_206244_b) {
              this.func_213256_aB();
           }
@@ -51,7 +56,7 @@
        }, false));
     }
  
-@@ -557,7 +558,7 @@
+@@ -557,7 +559,7 @@
           return Stream.of(Registry.field_212630_s.func_177774_c(p_213251_0_.func_77973_b()));
        });
        SearchTreeReloadable<ItemStack> searchtreereloadable = new SearchTreeReloadable<>((p_213235_0_) -> {
@@ -60,7 +65,7 @@
        });
        NonNullList<ItemStack> nonnulllist = NonNullList.func_191196_a();
  
-@@ -646,7 +647,7 @@
+@@ -646,7 +648,7 @@
        Bootstrap.func_179870_a(p_71377_1_.func_71502_e());
        if (p_71377_1_.func_71497_f() != null) {
           Bootstrap.func_179870_a("#@!@# Game crashed! Crash report saved to: #@!@# " + p_71377_1_.func_71497_f());
@@ -69,7 +74,7 @@
        } else if (p_71377_1_.func_147149_a(file2)) {
           Bootstrap.func_179870_a("#@!@# Game crashed! Crash report saved to: #@!@# " + file2.getAbsolutePath());
           System.exit(-1);
-@@ -661,6 +662,7 @@
+@@ -661,6 +663,7 @@
        return this.field_71474_y.field_211842_aO;
     }
  
@@ -77,7 +82,7 @@
     public CompletableFuture<Void> func_213237_g() {
        if (this.field_213276_aV != null) {
           return this.field_213276_aV;
-@@ -740,16 +742,20 @@
+@@ -740,16 +743,20 @@
     }
  
     public void func_147108_a(@Nullable Screen p_147108_1_) {
@@ -102,7 +107,7 @@
        if (p_147108_1_ instanceof MainMenuScreen || p_147108_1_ instanceof MultiplayerScreen) {
           this.field_71474_y.field_74330_P = false;
           this.field_71456_v.func_146158_b().func_146231_a(true);
-@@ -874,11 +880,13 @@
+@@ -874,11 +881,13 @@
        GlStateManager.enableTexture();
        this.field_71424_I.func_76319_b();
        if (!this.field_71454_w) {
@@ -116,7 +121,7 @@
        }
  
        this.field_71424_I.func_219897_b();
-@@ -1146,10 +1154,10 @@
+@@ -1146,10 +1155,10 @@
           if (p_147115_1_ && this.field_71476_x != null && this.field_71476_x.func_216346_c() == RayTraceResult.Type.BLOCK) {
              BlockRayTraceResult blockraytraceresult = (BlockRayTraceResult)this.field_71476_x;
              BlockPos blockpos = blockraytraceresult.func_216350_a();
@@ -129,7 +134,7 @@
                    this.field_71439_g.func_184609_a(Hand.MAIN_HAND);
                 }
              }
-@@ -1176,7 +1184,7 @@
+@@ -1176,7 +1185,7 @@
              case BLOCK:
                 BlockRayTraceResult blockraytraceresult = (BlockRayTraceResult)this.field_71476_x;
                 BlockPos blockpos = blockraytraceresult.func_216350_a();
@@ -138,7 +143,7 @@
                    this.field_71442_b.func_180511_b(blockpos, blockraytraceresult.func_216354_b());
                    break;
                 }
-@@ -1186,6 +1194,7 @@
+@@ -1186,6 +1195,7 @@
                 }
  
                 this.field_71439_g.func_184821_cY();
@@ -146,7 +151,7 @@
              }
  
              this.field_71439_g.func_184609_a(Hand.MAIN_HAND);
-@@ -1235,6 +1244,9 @@
+@@ -1235,6 +1245,9 @@
                    }
                 }
  
@@ -156,7 +161,7 @@
                 if (!itemstack.func_190926_b() && this.field_71442_b.func_187101_a(this.field_71439_g, this.field_71441_e, hand) == ActionResultType.SUCCESS) {
                    this.field_71460_t.field_78516_c.func_187460_a(hand);
                    return;
-@@ -1254,6 +1266,8 @@
+@@ -1254,6 +1267,8 @@
           --this.field_71467_ac;
        }
  
@@ -165,7 +170,7 @@
        this.field_71424_I.func_76320_a("gui");
        if (!this.field_71445_n) {
           this.field_71456_v.func_73831_a();
-@@ -1372,6 +1386,8 @@
+@@ -1372,6 +1387,8 @@
        this.field_71424_I.func_219895_b("keyboard");
        this.field_195559_v.func_204870_b();
        this.field_71424_I.func_76319_b();
@@ -174,7 +179,7 @@
     }
  
     private void func_184117_aA() {
-@@ -1430,6 +1446,7 @@
+@@ -1430,6 +1447,7 @@
              this.field_71439_g.func_71040_bB(Screen.hasControlDown());
           }
        }
@@ -182,7 +187,7 @@
  
        boolean flag2 = this.field_71474_y.field_74343_n != ChatVisibility.HIDDEN;
        if (flag2) {
-@@ -1526,6 +1543,12 @@
+@@ -1526,6 +1544,12 @@
        this.func_147108_a(worldloadprogressscreen);
  
        while(!this.field_71437_Z.func_71200_ad()) {
@@ -195,7 +200,7 @@
           worldloadprogressscreen.tick();
           this.func_195542_b(false);
  
-@@ -1546,11 +1569,17 @@
+@@ -1546,11 +1570,17 @@
        networkmanager.func_150719_a(new ClientLoginNetHandler(networkmanager, this, (Screen)null, (p_213261_0_) -> {
        }));
        networkmanager.func_179290_a(new CHandshakePacket(socketaddress.toString(), 0, ProtocolType.LOGIN));
@@ -214,7 +219,7 @@
        WorkingScreen workingscreen = new WorkingScreen();
        workingscreen.func_200210_a(new TranslationTextComponent("connect.joining"));
        this.func_213241_c(workingscreen);
-@@ -1623,6 +1652,7 @@
+@@ -1623,6 +1653,7 @@
        }
  
        TileEntityRendererDispatcher.field_147556_a.func_147543_a(p_213257_1_);
@@ -222,7 +227,7 @@
     }
  
     public final boolean func_71355_q() {
-@@ -1648,112 +1678,8 @@
+@@ -1648,112 +1679,8 @@
  
     private void func_147112_ai() {
        if (this.field_71476_x != null && this.field_71476_x.func_216346_c() != RayTraceResult.Type.MISS) {
@@ -337,7 +342,7 @@
        }
     }
  
-@@ -1825,6 +1751,7 @@
+@@ -1825,6 +1752,7 @@
        return field_71432_P;
     }
  
@@ -345,7 +350,7 @@
     public CompletableFuture<Void> func_213245_w() {
        return this.func_213169_a(this::func_213237_g).thenCompose((p_213240_0_) -> {
           return p_213240_0_;
-@@ -1968,6 +1895,8 @@
+@@ -1968,6 +1896,8 @@
     }
  
     public MusicTicker.MusicType func_147109_W() {
@@ -354,7 +359,7 @@
        if (this.field_71462_r instanceof WinGameScreen) {
           return MusicTicker.MusicType.CREDITS;
        } else if (this.field_71439_g == null) {
-@@ -2124,4 +2053,12 @@
+@@ -2124,4 +2054,12 @@
     public LoadingGui func_213250_au() {
        return this.field_213279_p;
     }

--- a/src/main/java/net/minecraftforge/client/ForgeHooksClient.java
+++ b/src/main/java/net/minecraftforge/client/ForgeHooksClient.java
@@ -101,6 +101,7 @@ import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.fluid.IFluidState;
 import net.minecraft.inventory.EquipmentSlotType;
 import net.minecraft.item.ItemStack;
+import net.minecraft.resources.IReloadableResourceManager;
 import net.minecraft.util.BlockRenderLayer;
 import net.minecraft.util.Direction;
 import net.minecraft.util.Hand;
@@ -139,6 +140,7 @@ import net.minecraftforge.common.model.IModelPart;
 import net.minecraftforge.common.model.ITransformation;
 import net.minecraftforge.common.model.TRSRTransformation;
 import net.minecraftforge.fml.VersionChecker;
+import net.minecraftforge.fml.client.event.RegisterReloadListeners;
 import net.minecraftforge.fml.client.registry.ClientRegistry;
 import net.minecraftforge.eventbus.api.Event;
 import net.minecraftforge.resource.ReloadRequirements;
@@ -198,6 +200,11 @@ public class ForgeHooksClient
     public static void onItemColorsInit(ItemColors itemColors, BlockColors blockColors)
     {
         ModLoader.get().postEvent(new ColorHandlerEvent.Item(itemColors, blockColors));
+    }
+
+    public static void registerReloadListeners(IReloadableResourceManager resourceManager)
+    {
+        ModLoader.get().postEvent(new RegisterReloadListeners(resourceManager));
     }
 
     static final ThreadLocal<BlockRenderLayer> renderLayer = new ThreadLocal<BlockRenderLayer>();

--- a/src/main/java/net/minecraftforge/client/ForgeHooksClient.java
+++ b/src/main/java/net/minecraftforge/client/ForgeHooksClient.java
@@ -34,8 +34,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Random;
-import java.util.function.Consumer;
-import java.util.function.Function;
 
 import javax.annotation.Nonnull;
 import javax.vecmath.Matrix3f;
@@ -72,7 +70,6 @@ import net.minecraft.client.renderer.BufferBuilder;
 import net.minecraft.client.renderer.GameRenderer;
 import net.minecraft.client.renderer.FogRenderer;
 import net.minecraft.client.renderer.ItemRenderer;
-import net.minecraft.client.renderer.RenderHelper;
 import net.minecraft.client.renderer.Tessellator;
 import net.minecraft.client.renderer.WorldRenderer;
 import net.minecraft.client.renderer.model.BakedQuad;
@@ -81,7 +78,6 @@ import net.minecraft.client.renderer.model.IBakedModel;
 import net.minecraft.client.renderer.model.ItemCameraTransforms;
 import net.minecraft.client.renderer.model.ItemTransformVec3f;
 import net.minecraft.client.renderer.model.ModelManager;
-import net.minecraft.client.renderer.model.ModelResourceLocation;
 import net.minecraft.client.renderer.model.ModelRotation;
 import net.minecraft.client.renderer.model.SimpleBakedModel;
 import net.minecraft.client.renderer.color.BlockColors;
@@ -98,7 +94,6 @@ import net.minecraft.client.resources.I18n;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.LivingEntity;
 import net.minecraft.entity.player.PlayerEntity;
-import net.minecraft.fluid.IFluidState;
 import net.minecraft.inventory.EquipmentSlotType;
 import net.minecraft.item.ItemStack;
 import net.minecraft.resources.IReloadableResourceManager;
@@ -112,7 +107,6 @@ import net.minecraft.util.math.MathHelper;
 import net.minecraft.util.math.RayTraceResult;
 import net.minecraft.util.text.TextFormatting;
 import net.minecraft.world.IEnviromentBlockReader;
-import net.minecraft.world.IWorldReader;
 import net.minecraft.world.World;
 import net.minecraft.world.biome.Biome;
 import net.minecraftforge.client.event.ColorHandlerEvent;
@@ -140,7 +134,7 @@ import net.minecraftforge.common.model.IModelPart;
 import net.minecraftforge.common.model.ITransformation;
 import net.minecraftforge.common.model.TRSRTransformation;
 import net.minecraftforge.fml.VersionChecker;
-import net.minecraftforge.fml.client.event.RegisterReloadListeners;
+import net.minecraftforge.fml.client.event.RegisterReloadListenersEvent;
 import net.minecraftforge.fml.client.registry.ClientRegistry;
 import net.minecraftforge.eventbus.api.Event;
 import net.minecraftforge.resource.ReloadRequirements;
@@ -204,7 +198,7 @@ public class ForgeHooksClient
 
     public static void registerReloadListeners(IReloadableResourceManager resourceManager)
     {
-        ModLoader.get().postEvent(new RegisterReloadListeners(resourceManager));
+        ModLoader.get().postEvent(new RegisterReloadListenersEvent(resourceManager));
     }
 
     static final ThreadLocal<BlockRenderLayer> renderLayer = new ThreadLocal<BlockRenderLayer>();

--- a/src/main/java/net/minecraftforge/client/event/ColorHandlerEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/ColorHandlerEvent.java
@@ -26,6 +26,8 @@ import net.minecraftforge.eventbus.api.Event;
 /**
  * Use these events to register block/item
  * color handlers at the appropriate time.
+ *
+ * Fired on the mod event bus.
  */
 public abstract class ColorHandlerEvent extends Event
 {

--- a/src/main/java/net/minecraftforge/fml/client/event/RegisterReloadListeners.java
+++ b/src/main/java/net/minecraftforge/fml/client/event/RegisterReloadListeners.java
@@ -1,0 +1,27 @@
+package net.minecraftforge.fml.client.event;
+
+import net.minecraftforge.api.distmarker.Dist;
+import net.minecraftforge.eventbus.api.Event;
+import net.minecraft.resources.IFutureReloadListener;
+import net.minecraft.resources.IReloadableResourceManager;
+
+/**
+ * Fired just before {@link IReloadableResourceManager#initialReload} so mods can register listeners.
+ * Fired on the mod event bus.
+ *
+ * Called on {@link Dist#CLIENT} - the game client.
+ */
+public class RegisterReloadListeners extends Event
+{
+	private final IReloadableResourceManager resourceManager;
+
+	public RegisterReloadListeners(IReloadableResourceManager resourceManager)
+	{
+		this.resourceManager = resourceManager;
+	}
+
+	public void addReloadListener(IFutureReloadListener listener)
+	{
+		resourceManager.addReloadListener(listener);
+	}
+}

--- a/src/main/java/net/minecraftforge/fml/client/event/RegisterReloadListenersEvent.java
+++ b/src/main/java/net/minecraftforge/fml/client/event/RegisterReloadListenersEvent.java
@@ -11,11 +11,11 @@ import net.minecraft.resources.IReloadableResourceManager;
  *
  * Called on {@link Dist#CLIENT} - the game client.
  */
-public class RegisterReloadListeners extends Event
+public class RegisterReloadListenersEvent extends Event
 {
 	private final IReloadableResourceManager resourceManager;
 
-	public RegisterReloadListeners(IReloadableResourceManager resourceManager)
+	public RegisterReloadListenersEvent(IReloadableResourceManager resourceManager)
 	{
 		this.resourceManager = resourceManager;
 	}


### PR DESCRIPTION
This adds a new event that allows mods to register reload listeners just before the call to `net.minecraft.resources.IReloadableResourceManager#initialReload`.
This is in the same general location that a lot of the vanilla reload listeners are registered.

It is important to add the listeners before that call so that they are part of the progress bar used by the initial reload.
The only events we could find that are fired early enough right now for this purpose are the `ColorHandlerEvent`s, and using those to do this is pretty hacky and likely to break.

I need something like this so that I can create a Atlas Texture for JEI's GUI icons.