### PR TITLE
AccessTransformer Cleanup

### DIFF
--- a/src/main/resources/META-INF/accesstransformer.cfg
+++ b/src/main/resources/META-INF/accesstransformer.cfg
@@ -1,98 +1,60 @@
 #Main Forge Access Transformer configuration file
 # SoundEngine
-public net.minecraft.client.audio.SoundEngine field_148622_c #sndHandler
+public net.minecraft.client.audio.SoundEngine field_148622_c # sndHandler
 # Block
 public net.minecraft.block.Block <init>(Lnet/minecraft/block/material/Material;)V
-public net.minecraft.block.Block func_149752_b(F)Lnet.minecraft.block.Block; #setResistance
-public net.minecraft.block.Block func_149711_c(F)Lnet.minecraft.block.Block; #setHardness
-public net.minecraft.block.Block func_149713_g(I)Lnet.minecraft.block.Block; #setLightOpacity
-public net.minecraft.block.Block func_149715_a(F)Lnet.minecraft.block.Block; #setLightValue
-public net.minecraft.block.Block func_149722_s()Lnet.minecraft.block.Block; #setBlockUnbreakable
-public net.minecraft.block.Block func_149675_a(Z)Lnet.minecraft.block.Block; #setTickRandomly
 public net.minecraft.block.Block func_180637_b(Lnet/minecraft/world/World;Lnet/minecraft/util/math/BlockPos;I)V # dropXpOnBlockBreak
-public net.minecraft.block.Block func_193384_b(Lnet/minecraft/block/Block;)Z # isExceptionBlockForAttaching
-# FireBlock
-public net.minecraft.block.FireBlock func_176532_c(Lnet/minecraft/block/Block;)I # getFireSpreadSpeed
-public net.minecraft.block.FireBlock func_176534_d(Lnet/minecraft/block/Block;)I # getFireSpreadSpeed
 # Item
-public net.minecraft.item.Item func_77656_e(I)Lnet.minecraft.item.Item; #setMaxDamage
-public net.minecraft.item.Item func_77627_a(Z)Lnet.minecraft.item.Item; #setHasSubtypes
 public net.minecraft.item.Item field_185051_m # properties
-public-f net.minecraft.item.ItemGroup field_78032_a # group array
-# BowItem
-protected net.minecraft.item.BowItem func_185060_a(Lnet/minecraft/entity/player/PlayerEntity;)Lnet/minecraft/item/ItemStack; # findAmmo
-# Fluid
-public net.minecraft.fluid.Fluid func_180664_k()Lnet/minecraft/util/BlockRenderLayer; # getRenderLayer
+public-f net.minecraft.item.ItemGroup field_78032_a # GROUPS
 # Entity
 public net.minecraft.entity.Entity func_70022_Q()Ljava/lang/String; # getEntityString
 # PlayerEntity
-public net.minecraft.entity.player.PlayerEntity func_71053_j()V #closeScreen
-# EntityTrackerEntry
-public net.minecraft.entity.EntityTrackerEntry field_73134_o # trackingPlayers
+public net.minecraft.entity.player.PlayerEntity func_71053_j()V # closeScreen
 # Save Location
-public net.minecraft.world.chunk.storage.AnvilChunkLoader field_75825_d # chunkSaveLocation
-public net.minecraft.world.chunk.ServerChunkProvider field_73247_e # currentChunkLoader
-private-f net.minecraft.world.chunk.ChunkHolder field_219320_o # block update location
-# World
-public-f net.minecraft.world.World field_72982_D #villageCollectionObj
-# Map Gen Biome Lists
-public+f net.minecraft.world.gen.structure.MapGenStronghold field_151546_e
-# MapGenVillage
-public-f net.minecraft.world.gen.structure.MapGenVillage field_75055_e #villageSpawnBiomes
+private-f net.minecraft.world.chunk.ChunkHolder field_219320_o # changedBlockPositions
 # LayerUtil
 public net.minecraft.world.gen.layer.LayerUtil func_202829_a(JLnet/minecraft/world/gen/layer/traits/IAreaTransformer1;Lnet/minecraft/world/gen/area/IAreaFactory;ILjava/util/function/LongFunction;)Lnet/minecraft/world/gen/area/IAreaFactory; # repeat
-# ShapedRecipes
-public+f net.minecraft.item.crafting.ShapedRecipes field_77574_d #recipeItems
-public+f net.minecraft.item.crafting.ShapedRecipes field_77576_b #recipeWidth
-public+f net.minecraft.item.crafting.ShapedRecipes field_77577_c #recipeHeight
-# ShapelessRecipes
-public net.minecraft.item.crafting.ShapelessRecipes field_77579_b #recipeItems
+# ShapedRecipe
+public+f net.minecraft.item.crafting.ShapedRecipe field_77574_d # recipeItems
+public+f net.minecraft.item.crafting.ShapedRecipe field_77576_b # recipeWidth
+public+f net.minecraft.item.crafting.ShapedRecipe field_77577_c # recipeHeight
+# ShapelessRecipe
+public net.minecraft.item.crafting.ShapelessRecipe field_77579_b # recipeItems
+# Other recipes
+public net.minecraft.item.crafting.TippedArrowRecipe
 # ContainerType
 public net.minecraft.inventory.container.ContainerType <init>(Lnet/minecraft/inventory/container/ContainerType$IFactory;)V
 public net.minecraft.inventory.container.ContainerType$IFactory
 # RepairContainer
-public net.minecraft.inventory.container.RepairContainer field_82856_l #RepairContainer/stackSizeToBeUsedInRepair
-# BiomeDecorator
-public net.minecraft.world.biome.BiomeDecorator *
-# CreativeTabs
-public-f net.minecraft.creativetab.CreativeTabs field_78032_a # creativeTabArray non-final
+public net.minecraft.inventory.container.RepairContainer field_82856_l # materialCost
 # World stuff
-public net.minecraft.world.World field_73003_n #prevRainingStrength
-public net.minecraft.world.World field_73004_o #rainingStrength
-public net.minecraft.world.World field_73017_q #thunderingStrength
-public net.minecraft.world.World field_73018_p #prevThunderingStrength
-public net.minecraft.world.World func_72923_a(Lnet/minecraft/entity/Entity;)V #onEntityAdded
-public net.minecraft.world.World func_72847_b(Lnet/minecraft/entity/Entity;)V #onEntityRemoved
-public net.minecraft.world.ServerWorld func_72923_a(Lnet/minecraft/entity/Entity;)V #onEntityAdded
-public net.minecraft.world.ServerWorld func_72847_b(Lnet/minecraft/entity/Entity;)V #onEntityRemoved
-public net.minecraft.client.world.ClientWorld func_72923_a(Lnet/minecraft/entity/Entity;)V #onEntityAdded
-public net.minecraft.client.world.ClientWorld func_72847_b(Lnet/minecraft/entity/Entity;)V #onEntityRemoved
+public net.minecraft.world.World field_73003_n # prevRainingStrength
+public net.minecraft.world.World field_73004_o # rainingStrength
+public net.minecraft.world.World field_73017_q # thunderingStrength
+public net.minecraft.world.World field_73018_p # prevThunderingStrengt
+public net.minecraft.world.ServerWorld func_217465_m(Lnet/minecraft/entity/Entity;)V # onEntityAdded
+public net.minecraft.world.ServerWorld func_217484_g(Lnet/minecraft/entity/Entity;)V # onEntityRemoved
 public net.minecraft.world.World func_175701_a(Lnet/minecraft/util/math/BlockPos;)Z # isValid
 public net.minecraft.world.World func_189509_E(Lnet/minecraft/util/math/BlockPos;)Z # isOutsideBuildHeight
 # IngameGui
 protected net.minecraft.client.gui.IngameGui *
 protected net.minecraft.client.gui.IngameGui func_194798_c()V # renderAttackIndicator
-protected net.minecraft.client.gui.IngameGui func_194800_d(F)V
-protected net.minecraft.client.gui.IngameGui func_194805_e(F)V
+protected net.minecraft.client.gui.IngameGui func_212303_b(Lnet/minecraft/entity/Entity;)V # renderVignette
+protected net.minecraft.client.gui.IngameGui func_194805_e(F)V # renderPortal
 protected net.minecraft.client.gui.IngameGui func_212303_b(Lnet/minecraft/entity/Entity;)V
-protected net.minecraft.client.gui.IngameGui func_194808_p()V
-protected net.minecraft.client.gui.IngameGui func_194802_a(Lnet/minecraft/scoreboard/ScoreObjective;)V
-# ItemStack
-default net.minecraft.item.ItemStack field_77991_e
-# MapGenStructureIO
-public net.minecraft.world.gen.structure.MapGenStructureIO func_143034_b(Ljava/lang/Class;Ljava/lang/String;)V # registerStart
-public net.minecraft.world.gen.structure.MapGenStructureIO func_143031_a(Ljava/lang/Class;Ljava/lang/String;)V # registerPiece
+protected net.minecraft.client.gui.IngameGui func_194808_p()V # renderPumpkinOverlay
+protected net.minecraft.client.gui.IngameGui func_194802_a(Lnet/minecraft/scoreboard/ScoreObjective;)V # renderScoreboard
 # Stronghold
-public net.minecraft.world.gen.structure.StructureStrongholdPieces$Stronghold
+public net.minecraft.world.gen.feature.structure.StrongholdPieces$Stronghold
 # Packets
-public net.minecraft.network.play.server.SChangeBlockPacket field_148883_d # blockState
+public net.minecraft.network.play.server.SChangeBlockPacket field_197686_b # state
 # WorldType
-public-f net.minecraft.world.WorldType field_77139_a #worldTypes
+public-f net.minecraft.world.WorldType field_77139_a # WORLD_TYPES
 # DamageSource
 public net.minecraft.util.DamageSource *() #All methods public, most are already
 # GoalSelector
-public net.minecraft.entity.ai.goal.GoalSelector field_75782_a # taskEntries
-public net.minecraft.entity.ai.goal.GoalSelector$EntityAITaskEntry
+public net.minecraft.entity.ai.goal.GoalSelector field_220892_d # goals
 # MemoryModuleType
 public net.minecraft.entity.ai.brain.memory.MemoryModuleType <init>(Ljava/util/Optional;)V
 # SensorType
@@ -101,78 +63,46 @@ public net.minecraft.entity.ai.brain.sensor.SensorType <init>(Ljava/util/functio
 public net.minecraft.entity.ai.brain.schedule.Activity <init>(Ljava/lang/String;)V
 # ExperienceOrbEntity
 public net.minecraft.entity.item.ExperienceOrbEntity field_70530_e # xpValue
-# Village
-public net.minecraft.world.gen.structure.StructureVillagePieces$Village
 # RenderItem
 public net.minecraft.client.renderer.ItemRenderer func_191970_a(Lnet/minecraft/client/renderer/BufferBuilder;Ljava/util/List;ILnet/minecraft/item/ItemStack;)V # renderQuads
 # ServerChunkProvider
-public net.minecraft.world.chunk.ServerChunkProvider field_186029_c # chunkGenerator
-public net.minecraft.world.chunk.ServerChunkProvider field_73244_f # loadedChunkHashMap
-#public net.minecraft.world.chunk.ServerChunkProvider field_73245_g # loadedChunks
-public net.minecraft.world.chunk.ServerChunkProvider field_73251_h # worldObj
+public net.minecraft.world.chunk.ServerChunkProvider field_186029_c # generator
+public net.minecraft.world.chunk.ServerChunkProvider field_73251_h # world
 # ChunkStatus
 public net.minecraft.world.chunk.ChunkStatus <init>(Ljava/lang/String;Lnet/minecraft/world/chunk/ChunkStatus;ILjava/util/EnumSet;Lnet/minecraft/world/chunk/ChunkStatus$Type;Lnet/minecraft/world/chunk/ChunkStatus$IGenerationWorker;Lnet/minecraft/world/chunk/ChunkStatus$ILoadingWorker;)V
 
 # ItemRenderer
-protected net.minecraft.client.renderer.entity.ItemRenderer func_177078_a(Lnet/minecraft/item/ItemStack;)I # getMiniItemCount
+protected net.minecraft.client.renderer.entity.ItemRenderer func_177078_a(Lnet/minecraft/item/ItemStack;)I # getModelCount
 
-public net.minecraft.client.renderer.entity.EntityRendererManager func_217782_a(Ljava/lang/Class;Lnet/minecraft/client/renderer/entity/EntityRenderer;)V # addRenderer
-
-public net.minecraft.item.crafting.TippedArrowRecipe
-public net.minecraft.item.crafting.ShieldRecipes$Decoration
-public net.minecraft.item.crafting.RecipesBanners$RecipeAddPattern
-public net.minecraft.item.crafting.RecipesBanners$RecipeDuplicatePattern
-public net.minecraft.block.state.BlockStateContainer$StateImplementation
-protected net.minecraft.block.state.BlockStateContainer$StateImplementation <init>(Lnet/minecraft/block/Block;Lcom/google/common/collect/ImmutableMap;)V
-protected net.minecraft.block.state.BlockStateContainer$StateImplementation field_177238_c # propertyValueTable
+public net.minecraft.client.renderer.entity.EntityRendererManager func_217782_a(Ljava/lang/Class;Lnet/minecraft/client/renderer/entity/EntityRenderer;)V # register
 
 # BlockModel
 public net.minecraft.client.renderer.model.BlockModel field_178318_c # textures
 public net.minecraft.client.renderer.model.BlockModel field_178315_d # parent
 public net.minecraft.client.renderer.model.BlockModel field_178322_i # ambientOcclusion
-public net.minecraft.client.renderer.model.BlockModel func_209568_a(Lnet/minecraft/client/renderer/model/BlockModel;Ljava/util/function/Function;Ljava/util/function/Function;)Lnet/minecraft/client/renderer/model/ItemOverrideList; # getOverrides
 public net.minecraft.client.renderer.model.BlockModel func_187966_f()Ljava/util/List; # getOverrides
 
 # ModelBakery
 public net.minecraft.client.renderer.model.ModelBakery field_177604_a # MODEL_MISSING
 protected net.minecraft.client.renderer.model.ModelBakery field_177602_b # LOCATIONS_BUILTIN_TEXTURES
 protected net.minecraft.client.renderer.model.ModelBakery field_177598_f # resourceManager
-protected net.minecraft.client.renderer.model.ModelBakery field_177599_g # sprites
 protected net.minecraft.client.renderer.model.ModelBakery field_177609_j # textureMap
-protected net.minecraft.client.renderer.model.ModelBakery field_177610_k # blockModelShapes
-protected net.minecraft.client.renderer.model.ModelBakery field_177605_n # bakedRegistry
 protected net.minecraft.client.renderer.model.ModelBakery field_177606_o # MODEL_GENERATED
 protected net.minecraft.client.renderer.model.ModelBakery field_177616_r # MODEL_ENTITY
-protected net.minecraft.client.renderer.model.ModelBakery func_177569_a(Lnet/minecraft/client/renderer/model/BlockModelDefinition;Lnet/minecraft/client/renderer/model/ModelResourceLocation;)V # registerVariant
-protected net.minecraft.client.renderer.model.ModelBakery func_177586_a(Lnet/minecraft/util/ResourceLocation;)Lnet/minecraft/client/renderer/model/BlockModelDefinition; # getBlockModelDefinition
 protected net.minecraft.client.renderer.model.ModelBakery func_177594_c(Lnet/minecraft/util/ResourceLocation;)Lnet/minecraft/client/renderer/model/BlockModel; # loadModel
-protected net.minecraft.client.renderer.model.ModelBakery func_177592_e()V # registerVariantNames
-protected net.minecraft.client.renderer.model.ModelBakery func_177596_a(Lnet/minecraft/item/Item;)Ljava/util/List; # getVariantNames
-protected net.minecraft.client.renderer.model.ModelBakery func_177583_a(Ljava/lang/String;)Lnet/minecraft/util/ResourceLocation; # getItemLocation
-protected net.minecraft.client.renderer.model.ModelBakery func_177585_a(Lnet/minecraft/client/renderer/model/BlockModel;)Ljava/util/Set; # getTextureLocations
-protected net.minecraft.client.renderer.model.ModelBakery func_177581_b(Lnet/minecraft/client/renderer/model/BlockModel;)Z # hasItemModel
-protected net.minecraft.client.renderer.model.ModelBakery func_177587_c(Lnet/minecraft/client/renderer/model/BlockModel;)Z # isCustomRenderer
-protected net.minecraft.client.renderer.model.ModelBakery func_177582_d(Lnet/minecraft/client/renderer/model/BlockModel;)Lnet/minecraft/client/renderer/model/BlockModel; # makeItemModel
-protected net.minecraft.client.renderer.model.ModelBakery func_177580_d(Lnet/minecraft/util/ResourceLocation;)Lnet/minecraft/util/ResourceLocation; # getModelLocation
-protected net.minecraft.client.renderer.model.ModelBakery func_188640_b()V # loadBlocks
-protected net.minecraft.client.renderer.model.ModelBakery func_177577_b()V # loadVariantItemModels
-protected net.minecraft.client.renderer.model.ModelBakery func_177590_d()V # loadItemModels
-protected net.minecraft.client.renderer.model.ModelBakery func_177595_c()V # loadVariantModels
-protected net.minecraft.client.renderer.model.ModelBakery func_188637_e()V # loadMultipartVariantModels
-protected net.minecraft.client.renderer.model.ModelBakery func_188638_a(Lnet/minecraft/client/renderer/model/ModelResourceLocation;Lnet/minecraft/client/renderer/model/VariantList;)V # loadVariantList
 
 # ItemModelMesher
 # This field is public and uses int IDs, so we hide it and expose ItemModelMesherForge methods instead
-private net.minecraft.client.renderer.ItemModelMesher field_199313_a
+private net.minecraft.client.renderer.ItemModelMesher field_199313_a # modelLocations
 
 # ItemOverrideList
 protected net.minecraft.client.renderer.model.ItemOverrideList <init>()V
 
 # BufferBuilder
 public net.minecraft.client.renderer.BufferBuilder func_78909_a(I)I # getColorIndex
-public net.minecraft.client.renderer.BufferBuilder func_178972_a(IIII)V # putColorRGB -- Add A?
+public net.minecraft.client.renderer.BufferBuilder func_178972_a(IIII)V # putColorRGBA
 
-# S00PacketServerInfo
+# SServerInfoPacket
 public net.minecraft.network.status.server.SServerInfoPacket field_149297_a # GSON
 
 # Resource Packs
@@ -181,66 +111,54 @@ public net.minecraft.resources.ResourcePack field_195771_a # file
 
 #Main FML Access Transformer configuration file
 # EntityRendererManager
-public net.minecraft.client.renderer.entity.EntityRendererManager field_78729_o #renderers
+public net.minecraft.client.renderer.entity.EntityRendererManager field_78729_o # renderers
 # TileEntityRendererDispatcher
 public net.minecraft.client.renderer.tileentity.TileEntityRendererDispatcher field_147557_n # fontRenderer - needed for rendering text in TESR items before entering world
 private-f net.minecraft.client.renderer.tileentity.PistonTileEntityRenderer field_178462_c # blockRenderer - it's static so we need to un-finalize in case this class loads to early.
 # GameRenderer
-public net.minecraft.client.renderer.GameRenderer func_175069_a(Lnet/minecraft/util/ResourceLocation;)V #loadShader
+public net.minecraft.client.renderer.GameRenderer func_175069_a(Lnet/minecraft/util/ResourceLocation;)V # loadShader
 # WeightedRandomItem
-public net.minecraft.util.WeightedRandom$Item field_76292_a #probability
+public net.minecraft.util.WeightedRandom$Item field_76292_a # itemWeight
 # PlayerEntity
-public net.minecraft.entity.player.PlayerEntity func_184816_a(Lnet/minecraft/entity/item/ItemEntity;)Lnet/minecraft/item/ItemStack; # dropItemAndGetStack
 protected net.minecraft.entity.player.PlayerEntity field_71077_c # spawnPos
 protected net.minecraft.entity.player.PlayerEntity field_82248_d # spawnForced
-# ClientPlayerEntity
-public net.minecraft.client.entity.ClientPlayerEntity func_184816_a(Lnet/minecraft/entity/item/ItemEntity;)Lnet/minecraft/item/ItemStack; # dropItemAndGetStack
-# ServerPlayerEntity getNextWindowId
-public net.minecraft.entity.player.ServerPlayerEntity func_71117_bO()V
-public net.minecraft.entity.player.ServerPlayerEntity field_71139_cq
+# ServerPlayerEntity
+public net.minecraft.entity.player.ServerPlayerEntity func_71117_bO()V # getNextWindowId
+public net.minecraft.entity.player.ServerPlayerEntity field_71139_cq # currentWindowId
 # MobEntity
-public net.minecraft.entity.MobEntity field_70714_bg #tasks
-public net.minecraft.entity.MobEntity field_70715_bh #targetTasks
+public net.minecraft.entity.MobEntity field_70714_bg # goalSelector
+public net.minecraft.entity.MobEntity field_70715_bh # targetSelector
 # ContainerMinecartEntity
-public net.minecraft.entity.item.ContainerMinecartEntity field_94112_b #dropContentsWhenDead
+public net.minecraft.entity.item.minecart.ContainerMinecartEntity field_94112_b # dropContentsWhenDead
 # ScreenManager
 public net.minecraft.client.gui.ScreenManager func_216911_a(Lnet/minecraft/inventory/container/ContainerType;Lnet/minecraft/client/gui/ScreenManager$IScreenFactory;)V # registerFactory
 public net.minecraft.client.gui.ScreenManager$IScreenFactory
 # Screen
-public net.minecraft.client.gui.screen.Screen field_146297_k # minecraft instance - public because gui's outside access it
+public net.minecraft.client.gui.screen.Screen minecraft # minecraft - public because gui's outside access it
 # Minecraft
 public net.minecraft.client.Minecraft field_71446_o # textureManager
-public net.minecraft.client.Minecraft field_110450_ap # mcDefaultResourcePack
-public net.minecraft.client.Minecraft func_71370_a(II)V # resize
-public net.minecraft.client.Minecraft func_180510_a(Lnet/minecraft/client/renderer/texture/TextureManager;)V # drawSplashScreen
 public net.minecraft.client.Minecraft func_184119_a(Lnet/minecraft/item/ItemStack;Lnet/minecraft/tileentity/TileEntity;)Lnet/minecraft/item/ItemStack; # storeTEInStack
 # MinecraftServer
 protected net.minecraft.server.MinecraftServer field_211151_aa # serverTime
 # DedicatedServer
 public net.minecraft.server.dedicated.DedicatedServer field_71341_l # pendingCommandList
-# SaveFormatOld
-public net.minecraft.world.storage.SaveFormatOld field_75808_a # savesDirectory
-
-protected net.minecraft.util.ObjectIntIdentityMap field_148749_a # internal map
-protected net.minecraft.util.ObjectIntIdentityMap field_148748_b # internal index list
+# ObjectIntIdentityMap
+protected net.minecraft.util.ObjectIntIdentityMap field_148749_a # identityMap
+protected net.minecraft.util.ObjectIntIdentityMap field_148748_b # objectList
 protected net.minecraft.util.ObjectIntIdentityMap field_195868_a # nextId
-
+# Widget
+public net.minecraft.client.gui.widget.Widget width # width - needed for config GUI stuff
+public net.minecraft.client.gui.widget.Widget height # height - needed for config GUI stuff
 protected net.minecraft.client.gui.widget.list.AbstractList$AbstractListEntry list # list
-# Button
-public net.minecraft.client.gui.widget.button.Button field_146120_f # width - needed for config GUI stuff
-public net.minecraft.client.gui.widget.button.Button field_146121_g # height - needed for config GUI stuff
-# TextFieldWidget
-public-f net.minecraft.client.gui.widget.TextFieldWidget field_146218_h # width - needed for config GUI stuff
-public-f net.minecraft.client.gui.widget.TextFieldWidget field_146219_i # height - needed for config GUI stuff
 # SlotGui
-public net.minecraft.client.gui.SlotGui field_148149_f # slotHeight - needed for config GUI stuff
-public net.minecraft.client.gui.SlotGui field_148151_d # right - needed for config GUI stuff
-public net.minecraft.client.gui.SlotGui field_148152_e # left - needed for config GUI stuff
-public net.minecraft.client.gui.SlotGui field_148153_b # top - needed for config GUI stuff
-public net.minecraft.client.gui.SlotGui field_148154_c # bottom - needed for config GUI stuff
-public net.minecraft.client.gui.SlotGui field_148155_a # width - needed for config GUI stuff
-public net.minecraft.client.gui.SlotGui field_148158_l # height - needed for config GUI stuff
-public net.minecraft.client.gui.SlotGui field_148160_j # headerPadding - needed for config GUI stuff
+public net.minecraft.client.gui.SlotGui itemHeight # itemHeight - needed for config GUI stuff
+public net.minecraft.client.gui.SlotGui x1 # x1 - needed for config GUI stuff
+public net.minecraft.client.gui.SlotGui x0 # x0 - needed for config GUI stuff
+public net.minecraft.client.gui.SlotGui y0 # y0 - needed for config GUI stuff
+public net.minecraft.client.gui.SlotGui y1 # y1 - needed for config GUI stuff
+public net.minecraft.client.gui.SlotGui width # width- needed for config GUI stuff
+public net.minecraft.client.gui.SlotGui height # height- needed for config GUI stuff
+public net.minecraft.client.gui.SlotGui headerHeight # headerHeight - needed for config GUI stuff
 
 # VillagerProfession
 public net.minecraft.entity.merchant.villager.VillagerProfession <init>(Ljava/lang/String;Lnet/minecraft/village/PointOfInterestType;Lcom/google/common/collect/ImmutableSet;Lcom/google/common/collect/ImmutableSet;)V
@@ -248,94 +166,44 @@ public net.minecraft.entity.merchant.villager.VillagerProfession <init>(Ljava/la
 public net.minecraft.village.PointOfInterestType <init>(Ljava/lang/String;Ljava/util/Set;ILnet/minecraft/util/SoundEvent;Ljava/util/function/Predicate;)V
 public net.minecraft.village.PointOfInterestType <init>(Ljava/lang/String;Ljava/util/Set;ILnet/minecraft/util/SoundEvent;)V
 
-# Villager Traid Classes
-public net.minecraft.entity.passive.VillagerEntity$EmeraldForItems
-public net.minecraft.entity.passive.VillagerEntity$ITradeList
-public net.minecraft.entity.passive.VillagerEntity$ItemAndEmeraldToItem
-public net.minecraft.entity.passive.VillagerEntity$ListEnchantedBookForEmeralds
-public net.minecraft.entity.passive.VillagerEntity$ListEnchantedItemForEmeralds
-public net.minecraft.entity.passive.VillagerEntity$ListItemForEmeralds
-public net.minecraft.entity.passive.VillagerEntity$PriceInfo
+# VillagerTrades
+public net.minecraft.entity.merchant.villager.VillagerTrades$DyedArmorForEmeraldsTrade
+public net.minecraft.entity.merchant.villager.VillagerTrades$EmeraldForItemsTrade
+public net.minecraft.entity.merchant.villager.VillagerTrades$EmeraldForMapTrade
+public net.minecraft.entity.merchant.villager.VillagerTrades$EmeraldForVillageTypeItemTrade
+public net.minecraft.entity.merchant.villager.VillagerTrades$EnchantedBookForEmeraldsTrade
+public net.minecraft.entity.merchant.villager.VillagerTrades$EnchantedItemForEmeraldsTrade
+public net.minecraft.entity.merchant.villager.VillagerTrades$ItemWithPotionForEmeraldsAndItemsTrade
+public net.minecraft.entity.merchant.villager.VillagerTrades$ItemsForEmeraldsAndItemsTrade
+public net.minecraft.entity.merchant.villager.VillagerTrades$ItemsForEmeraldsTrade
+public net.minecraft.entity.merchant.villager.VillagerTrades$SuspiciousStewForEmeraldTrade
 
-# Font renderer
-protected net.minecraft.client.gui.FontRenderer field_78286_d # charWidth
-protected net.minecraft.client.gui.FontRenderer field_78287_e # glyphWidth
-protected net.minecraft.client.gui.FontRenderer field_111273_g # locationFontTexture
-protected net.minecraft.client.gui.FontRenderer field_78295_j # posX
-protected net.minecraft.client.gui.FontRenderer field_78296_k # posY
-protected net.minecraft.client.gui.FontRenderer func_78266_a(IZ)F # renderDefaultChar
-protected net.minecraft.client.gui.FontRenderer func_78277_a(CZ)F # renderUnicodeChar
-
-# EndChunkGenerator
-private-f net.minecraft.world.gen.EndChunkGenerator field_185969_i #lperlin1
-private-f net.minecraft.world.gen.EndChunkGenerator field_185970_j #lperlin2
-private-f net.minecraft.world.gen.EndChunkGenerator field_185971_k #perlin
-private-f net.minecraft.world.gen.EndChunkGenerator field_185973_o #island
-private-f net.minecraft.world.gen.EndChunkGenerator field_185972_n #endCityGen
-
-# OverworldChunkGenerator
-private-f net.minecraft.world.gen.OverworldChunkGenerator field_185991_j #lperlin1
-private-f net.minecraft.world.gen.OverworldChunkGenerator field_185992_k #lperlin2
-private-f net.minecraft.world.gen.OverworldChunkGenerator field_185993_l #perlin
-private-f net.minecraft.world.gen.OverworldChunkGenerator field_185994_m #surface
-private-f net.minecraft.world.gen.OverworldChunkGenerator field_185979_A #ravineGenerator
-private-f net.minecraft.world.gen.OverworldChunkGenerator field_185980_B #oceanMonumentGenerator
-private-f net.minecraft.world.gen.OverworldChunkGenerator field_186003_v #caveGenerator
-private-f net.minecraft.world.gen.OverworldChunkGenerator field_186004_w #strongholdGenerator
-private-f net.minecraft.world.gen.OverworldChunkGenerator field_186005_x #villageGenerator
-private-f net.minecraft.world.gen.OverworldChunkGenerator field_186006_y #mineshaftGenerator
-private-f net.minecraft.world.gen.OverworldChunkGenerator field_186007_z #scatteredFeatureGenerator
-private-f net.minecraft.world.gen.OverworldChunkGenerator field_191060_C #woodlandMansionGenerator
-
-# NetherChunkGenerator
-private-f net.minecraft.world.gen.NetherChunkGenerator field_185957_u #lperlin1
-private-f net.minecraft.world.gen.NetherChunkGenerator field_185958_v #lperlin2
-private-f net.minecraft.world.gen.NetherChunkGenerator field_185959_w #perlin
-private-f net.minecraft.world.gen.NetherChunkGenerator field_73177_m #perlin2
-private-f net.minecraft.world.gen.NetherChunkGenerator field_73174_n #perlin3
-public-f net.minecraft.world.gen.NetherChunkGenerator field_185946_g #scale
-public-f net.minecraft.world.gen.NetherChunkGenerator field_185947_h #depth
-private-f net.minecraft.world.gen.NetherChunkGenerator field_185939_I #netherCaveGenerator
-private-f net.minecraft.world.gen.NetherChunkGenerator field_73172_c #netherBridgeGenerator
-
-# PlayerManager
-private-f net.minecraft.server.management.PlayerChunkMapEntry field_187285_e # field_187285_e
+# NoiseChunkGenerator
+private-f net.minecraft.world.gen.NoiseChunkGenerator field_222568_o
+private-f net.minecraft.world.gen.NoiseChunkGenerator field_222569_p
+private-f net.minecraft.world.gen.NoiseChunkGenerator field_222570_q
+private-f net.minecraft.world.gen.NoiseChunkGenerator field_222571_r
 
 # LivingRenderer
 public net.minecraft.client.renderer.entity.LivingRenderer func_177094_a(Lnet/minecraft/client/renderer/entity/layers/LayerRenderer;)Z # addLayer
-#public net.minecraft.client.renderer.entity.LivingRenderer func_177089_b(Lnet/minecraft/client/renderer/entity/layers/LayerRenderer;)Z # removeLayer
 
 # LootTable Stuff
 private-f net.minecraft.world.storage.loot.LootPool field_186455_c # rolls
 private-f net.minecraft.world.storage.loot.LootPool field_186456_d # bonusRolls
+public net.minecraft.world.storage.loot.LootTables func_186375_a(Lnet/minecraft/util/ResourceLocation;)Lnet/minecraft/util/ResourceLocation; # register
 
-#NumberNBT
-public net.minecraft.nbt.NumberNBT
-
-#overlay.DebugOverlayGui
-public net.minecraft.client.gui.overlay.DebugOverlayGui func_181554_e()V # renderLagometer
+# DebugOverlayGui
+public net.minecraft.client.gui.overlay.DebugOverlayGui func_212920_a(Lnet/minecraft/util/FrameTimer;IIZ)V # renderLagometer
 protected net.minecraft.client.gui.overlay.DebugOverlayGui field_211537_g # rayTraceBlock
 protected net.minecraft.client.gui.overlay.DebugOverlayGui field_211538_h # rayTraceFluid
-
-# Expose vanilla brewing recipe system
-public net.minecraft.potion.PotionHelper func_193355_a(Lnet/minecraft/item/PotionItem;Lnet/minecraft/item/Item;Lnet/minecraft/item/PotionItem;)V # registerPotionItemConversion
-public net.minecraft.potion.PotionHelper func_193354_a(Lnet/minecraft/item/PotionItem;)V # registerPotionItem
-public net.minecraft.potion.PotionHelper func_193357_a(Lnet/minecraft/potion/PotionType;Lnet/minecraft/item/Item;Lnet/minecraft/potion/PotionType;)V # registerPotionTypeConversion
-public net.minecraft.potion.PotionHelper func_193356_a(Lnet/minecraft/potion/PotionType;Lnet/minecraft/item/crafting/Ingredient;Lnet/minecraft/potion/PotionType;)V # registerPotionTypeConversion
-
-# TileEntity
-public net.minecraft.tileentity.TileEntity func_190560_a(Ljava/lang/String;Ljava/lang/Class;)V # register
 
 # HopperTileEntity
 public net.minecraft.tileentity.HopperTileEntity func_174914_o()Z # mayTransfer
 public net.minecraft.tileentity.HopperTileEntity func_145896_c(I)V # setTransferCooldown
-protected net.minecraft.tileentity.HopperTileEntity func_145887_i()Z # updateHopper
-
-# DataFixer
-public net.minecraft.util.datafix.DataFixer field_188262_d # version
+protected net.minecraft.tileentity.HopperTileEntity func_200109_a(Ljava/util/function/Supplier;)Z # updateHopper
 
 # ThreadTaskExecutor
-public net.minecraft.util.concurrent.ThreadTaskExecutor func_213165_a(Ljava/lang/Runnable;)Ljava/util/concurrent/CompletableFuture; # func_213165_a
+public net.minecraft.util.concurrent.ThreadTaskExecutor func_213165_a(Ljava/lang/Runnable;)Ljava/util/concurrent/CompletableFuture; # deferTask
 
 # AbstractSkeletonEntity
 protected net.minecraft.entity.monster.AbstractSkeletonEntity func_190727_o()Lnet/minecraft/util/SoundEvent; # getStepSound - make AbstractSkeletonEntity implementable
@@ -361,13 +229,13 @@ protected net.minecraft.world.Teleporter field_85192_a # world
 protected net.minecraft.world.Teleporter field_77187_a # random
 protected net.minecraft.world.Teleporter field_85191_c # destinationCoordinateCache
 
-public net.minecraft.util.ResourceLocation func_177516_a(Ljava/lang/String;)[Ljava/lang/String; # splitObjectName
+public net.minecraft.util.ResourceLocation func_195823_b(Ljava/lang/String;C)[Ljava/lang/String; # decompose
 
 # Ingredient
 public-f net.minecraft.item.crafting.Ingredient
 protected net.minecraft.item.crafting.Ingredient <init>(Ljava/util/stream/Stream;)V
-public net.minecraft.item.crafting.Ingredient func_209357_a(Ljava/util/stream/Stream;)Lnet/minecraft/item/crafting/Ingredient;
-public+f net.minecraft.item.crafting.Ingredient func_199564_a(Lnet/minecraft/network/PacketBuffer;)V
+public net.minecraft.item.crafting.Ingredient func_209357_a(Ljava/util/stream/Stream;)Lnet/minecraft/item/crafting/Ingredient; # fromItemListStream
+public+f net.minecraft.item.crafting.Ingredient func_199564_a(Lnet/minecraft/network/PacketBuffer;)V # write
 public net.minecraft.item.crafting.Ingredient$IItemList
 public net.minecraft.item.crafting.Ingredient$SingleItemList
 public net.minecraft.item.crafting.Ingredient$SingleItemList <init>(Lnet/minecraft/item/ItemStack;)V
@@ -388,10 +256,10 @@ public net.minecraft.world.biome.provider.BiomeProvider field_201540_a # BIOMES_
 public net.minecraft.tags.BlockTags$Wrapper
 
 #SaveHandler
-public net.minecraft.world.storage.SaveHandler field_75771_c # playersDirectory
+public net.minecraft.world.storage.SaveHandler field_215775_d # playersDirectory
 
 #BlockItemUseContext
-public net.minecraft.item.BlockItemUseContext <init>(Lnet/minecraft/world/World;Lnet/minecraft/entity/player/PlayerEntity;Lnet/minecraft/item/ItemStack;Lnet/minecraft/util/math/BlockPos;Lnet/minecraft/util/EnumFacing;FFF)V
+public net.minecraft.item.BlockItemUseContext <init>(Lnet/minecraft/world/World;Lnet/minecraft/entity/player/PlayerEntity;Lnet/minecraft/util/Hand;Lnet/minecraft/item/ItemStack;Lnet/minecraft/util/math/BlockRayTraceResult;)V
 
 #EntitySpawnPlacementRegistry
 public net.minecraft.entity.EntitySpawnPlacementRegistry func_209343_a(Lnet/minecraft/entity/EntityType;Lnet/minecraft/entity/EntitySpawnPlacementRegistry$PlacementType;Lnet/minecraft/world/gen/Heightmap$Type;)V # register
@@ -399,12 +267,10 @@ public net.minecraft.entity.EntitySpawnPlacementRegistry func_209343_a(Lnet/mine
 # Block$Properties
 public net.minecraft.block.Block$Properties func_200947_a(Lnet/minecraft/block/SoundType;)Lnet/minecraft/block/Block$Properties; # sound
 public net.minecraft.block.Block$Properties func_200951_a(I)Lnet/minecraft/block/Block$Properties; # lightValue
-public net.minecraft.block.Block$Properties func_200944_c()Lnet/minecraft/block/Block$Properties; # needsRandomTick
+public net.minecraft.block.Block$Properties func_200944_c()Lnet/minecraft/block/Block$Properties; # tickRandomly
 public net.minecraft.block.Block$Properties func_208770_d()Lnet/minecraft/block/Block$Properties; # variableOpacity
 public net.minecraft.block.Block$Properties func_200943_b(F)Lnet/minecraft/block/Block$Properties; # hardnessAndResistance
-
-#ChunkGeneratorType
-public net.minecraft.world.gen.ChunkGeneratorType$Settings
+public net.minecraft.block.Block$Properties func_222380_e()Lnet/minecraft/block/Block$Properties; # noDrops
 
 #IChunkGeneratorFactory
 public net.minecraft.world.gen.IChunkGeneratorFactory

--- a/src/main/resources/META-INF/accesstransformer.cfg
+++ b/src/main/resources/META-INF/accesstransformer.cfg
@@ -264,7 +264,7 @@ public net.minecraft.world.storage.SaveHandler field_215775_d # playersDirectory
 public net.minecraft.item.BlockItemUseContext <init>(Lnet/minecraft/world/World;Lnet/minecraft/entity/player/PlayerEntity;Lnet/minecraft/util/Hand;Lnet/minecraft/item/ItemStack;Lnet/minecraft/util/math/BlockRayTraceResult;)V
 
 #EntitySpawnPlacementRegistry
-public net.minecraft.entity.EntitySpawnPlacementRegistry func_209343_a(Lnet/minecraft/entity/EntityType;Lnet/minecraft/entity/EntitySpawnPlacementRegistry$PlacementType;Lnet/minecraft/world/gen/Heightmap$Type;)V # register
+public net.minecraft.entity.EntitySpawnPlacementRegistry func_209343_a(Lnet/minecraft/entity/EntityType;Lnet/minecraft/entity/EntitySpawnPlacementRegistry$PlacementType;Lnet/minecraft/world/gen/Heightmap$Type;Lnet/minecraft/entity/EntitySpawnPlacementRegistry$IPlacementPredicate;)V # register
 
 # Block$Properties
 public net.minecraft.block.Block$Properties func_200947_a(Lnet/minecraft/block/SoundType;)Lnet/minecraft/block/Block$Properties; # sound

--- a/src/main/resources/META-INF/accesstransformer.cfg
+++ b/src/main/resources/META-INF/accesstransformer.cfg
@@ -7,6 +7,8 @@ public net.minecraft.block.Block func_180637_b(Lnet/minecraft/world/World;Lnet/m
 # Item
 public net.minecraft.item.Item field_185051_m # properties
 public-f net.minecraft.item.ItemGroup field_78032_a # GROUPS
+# Fluid
+public net.minecraft.fluid.Fluid func_180664_k()Lnet/minecraft/util/BlockRenderLayer; # getRenderLayer
 # Entity
 public net.minecraft.entity.Entity func_70022_Q()Ljava/lang/String; # getEntityString
 # PlayerEntity


### PR DESCRIPTION
Figured it would be a good time to do a bit of cleanup of Forge's Access Transformers, while 1.14 is still in beta. The PR is mostly removals of now-unnecessary ATs, and updating of broken ATs.

[List of all additions/removals](https://gist.github.com/GirafiStudios/282bf2dfed4c303884e1329c702bdb80)
_Any change not listed in the list above is simply just a fix of the AT_ 

Feedback is very welcome.