### PR TITLE
[1.14] Allow mods to specify recipe book categories

### DIFF
--- a/patches/minecraft/net/minecraft/client/gui/recipebook/RecipeBookGui.java.patch
+++ b/patches/minecraft/net/minecraft/client/gui/recipebook/RecipeBookGui.java.patch
@@ -1,5 +1,14 @@
 --- a/net/minecraft/client/gui/recipebook/RecipeBookGui.java
 +++ b/net/minecraft/client/gui/recipebook/RecipeBookGui.java
+@@ -89,7 +89,7 @@
+       this.func_205702_a();
+       this.field_193018_j.clear();
+ 
+-      for(RecipeBookCategories recipebookcategories : ClientRecipeBook.func_216769_b(this.field_201522_g)) {
++      for(RecipeBookCategories recipebookcategories : this.field_201522_g.getRecipeBookCategories()) {
+          this.field_193018_j.add(new RecipeTabToggleWidget(recipebookcategories));
+       }
+ 
 @@ -421,7 +421,7 @@
  
           languagemanager.func_135045_a(language);

--- a/patches/minecraft/net/minecraft/inventory/container/RecipeBookContainer.java.patch
+++ b/patches/minecraft/net/minecraft/inventory/container/RecipeBookContainer.java.patch
@@ -1,0 +1,11 @@
+--- a/net/minecraft/inventory/container/RecipeBookContainer.java
++++ b/net/minecraft/inventory/container/RecipeBookContainer.java
+@@ -31,4 +31,8 @@
+ 
+    @OnlyIn(Dist.CLIENT)
+    public abstract int func_203721_h();
++
++   public java.util.List<net.minecraft.client.util.RecipeBookCategories> getRecipeBookCategories() {
++      return net.minecraft.client.util.ClientRecipeBook.func_216769_b(this);
++   }
+ }


### PR DESCRIPTION
In order to implement a recipe book button on a custom GUI screen, it is necessary to call `RecipeBookGui#func_201518_a` in order to initialize the contents of the recipe GUI panel. This method calls `ClientRecipeBook.func_216769_b` to retrieve the list of recipe categories that apply to the container. However, this method hardcodes the list of categories, based on the type of the container, and for any container that doesn't extend one of the vanilla containers, the method returns an empty list, triggering a crash later in the function. On top of that, this method is static and can't be easily overriden, and overriding `func_201518_a` would be impractical since it's a rather extensive initialization process.

This PR adds a method in RecipeBookContainer, which CAN be overriden by containers to return a custom list.