### PR TITLE
Modify issue template for better clarity.

### DIFF
--- a/.github/ISSUE_TEMPLATE/issue_report.md
+++ b/.github/ISSUE_TEMPLATE/issue_report.md
@@ -1,8 +1,8 @@
 ---
-name: Bug report
+name: Issue report
 about: Visit the forum first for issues with crashes.
 title: ''
-labels: Bug
+labels: Triage
 assignees: ''
 
 ---
@@ -23,4 +23,4 @@ assignees: ''
  2. Then do that
  3. ...
 
-**Description of bug:**
+**Description of issue:**

--- a/.github/ISSUE_TEMPLATE/issue_report.md
+++ b/.github/ISSUE_TEMPLATE/issue_report.md
@@ -16,7 +16,7 @@ assignees: ''
 
 **Forge Version:** {Forge version. *Version number, not latest/rb*}
 
-**Full Log:** {Link to GitHub Gist with full latest.log}
+**Logs:** {Link(s) to GitHub Gist with full latest.log and/or crash report}
 
 **Steps to Reproduce:**
  1. Do this

--- a/docs/README.md
+++ b/docs/README.md
@@ -7,8 +7,8 @@ Forge is a free, open-source modding API all of your favourite mods use!
 
 | Version  | Support |
 | ------------- | ------------- |
-| 1.14.2  | Active (latest)  |
-| 1.12.2  | Active (stable)  |
+| 1.14.x  | Active (latest)  |
+| 1.12.x  | Active (stable)  |
 
 * [Download]
 * [Forum]


### PR DESCRIPTION
Since merging https://github.com/MinecraftForge/MinecraftForge/pull/5773 and seeing the new template in use, I feel like the auto-assigning of the Bug label isn't a great idea since that's typically assigned by a member and could incorrectly describe the issue.

Now that there is a preliminary check by a Triage team, my suggestion is to create a Triage label that will be auto-assigned to reflect that a team member has yet to view it.

I'd also like to discuss any changes people want in the templates, maybe even to create more. We can also auto-assign members to templates if wanted/needed.

(Please note, there is *not* currently a Triage label for this repo, a member would have to create it)