### PR TITLE
Fix concurrent modification when loading chunk tickets

### DIFF
--- a/src/main/java/net/minecraftforge/common/ForgeChunkManager.java
+++ b/src/main/java/net/minecraftforge/common/ForgeChunkManager.java
@@ -585,8 +585,8 @@ public class ForgeChunkManager
                 }
                 if (tickets.size() > maxTicketLength)
                 {
-                    FMLLog.log.warn("The mod {} has too many open chunkloading tickets {}. Excess will be dropped", modId, tickets.size());
-                    tickets.subList(maxTicketLength, tickets.size()).clear();
+                    FMLLog.log.warn("The mod {} has too many open chunkloading tickets: {} (max: {}). Excess will be dropped.", modId, tickets.size(), maxTicketLength);
+                    tickets = tickets.subList(0, maxTicketLength);
                 }
                 ForgeChunkManager.tickets.get(world).putAll(modId, tickets);
                 loadingCallback.ticketsLoaded(ImmutableList.copyOf(tickets), world);


### PR DESCRIPTION
See https://github.com/SpongePowered/SpongeForge/issues/2119 (incl. [crash report](https://gist.github.com/ProsperCraft/cb2dd354c10032fea336b46e1ee0eb62)).

The relevant part of the stacktrace is as follows:
```
Caused by: java.util.ConcurrentModificationException
	at java.util.HashMap$HashIterator.nextNode(HashMap.java:1442)
	at java.util.HashMap$EntryIterator.next(HashMap.java:1476)
	at java.util.HashMap$EntryIterator.next(HashMap.java:1474)
	at com.google.common.collect.AbstractMapBasedMultimap$KeySet$1.next(AbstractMapBasedMultimap.java:960)
	at net.minecraftforge.common.ForgeChunkManager.loadWorld(ForgeChunkManager.java:572)
	at net.minecraftforge.common.ForgeInternalHandler.onDimensionLoad(ForgeInternalHandler.java:70)
	at net.minecraftforge.fml.common.eventhandler.ASMEventHandler_371_ForgeInternalHandler_onDimensionLoad_Load.invoke(.dynamic)
	at net.minecraftforge.fml.common.eventhandler.ASMEventHandler.invoke(ASMEventHandler.java:90)
	at net.minecraftforge.fml.common.eventhandler.EventBus.post(EventBus.java:651)
	... 12 more
```

The exception comes from this part of the code in `ForgeChunkManager.loadWorld()`:
https://github.com/MinecraftForge/MinecraftForge/blob/9a636e3c76f9da868b4167e877e57885bdb2a643/src/main/java/net/minecraftforge/common/ForgeChunkManager.java#L572-L593

and is caused by the `tickets.subList(maxTicketLength, tickets.size()).clear();` call modifing the write-though collection view returned by `loadedTickets.get(modId)`.

This will affect `loadedTickets` itself - as stated in the [javadoc](https://guava.dev/releases/snapshot/api/docs/com/google/common/collect/Multimap.html) for `Multimap`:
> A key is contained in the multimap if and only if it maps to at least one value. Any operation that causes a key to have zero associated values has the effect of removing that key from the multimap.

which will be the case in the event that `maxTicketLength` is 0 here, causing the iteration over `loadedTickets.keySet()` to throw a CME, leading to the crash described.

The fix is simple - rather than actively removing the excess, just expose only the view of tickets to be kept. As the resulting list is simply read into another collection, the values in the source collection do not need to be modified.