### PR TITLE
Update MDK to use plugins block

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,14 +1,3 @@
-buildscript {
-    repositories {
-        mavenLocal()
-        maven { url = 'https://files.minecraftforge.net/maven' }
-        jcenter()
-        mavenCentral()
-    }
-    dependencies {
-        classpath 'net.minecraftforge.gradle:ForgeGradle:3.+'
-    }
-}
 import groovy.json.JsonSlurper
 import groovy.json.JsonBuilder
 import java.text.SimpleDateFormat
@@ -32,6 +21,7 @@ plugins {
     id 'org.ajoberstar.grgit' version '2.3.0'
     id 'de.undercouch.download' version '3.3.0'
     id 'com.github.ben-manes.versions' version '0.20.0'
+    id 'net.minecraftforge.gradle' version '3.0.128' apply false
 }
 apply plugin: 'eclipse'
 
@@ -48,6 +38,7 @@ ext {
     MAPPING_VERSION = '20190621-1.14.2'
     MC_VERSION = '1.14.3'
     MCP_VERSION = '20190624.152911'
+    FG_VERSION = '3.0.128'
 }
 
 project(':mcp') {
@@ -843,6 +834,7 @@ project(':forge') {
                 FORGE_GROUP: project.group,
                 FORGE_NAME: project.name,
                 MC_VERSION: MC_VERSION,
+                FG_VERSION: FG_VERSION,
                 MAPPING_CHANNEL: MAPPING_CHANNEL,
                 MAPPING_VERSION: MAPPING_VERSION
             ])

--- a/mdk/build.gradle
+++ b/mdk/build.gradle
@@ -1,17 +1,11 @@
-buildscript {
-    repositories {
-        maven { url = 'https://files.minecraftforge.net/maven' }
-        jcenter()
-        mavenCentral()
-    }
-    dependencies {
-        classpath group: 'net.minecraftforge.gradle', name: 'ForgeGradle', version: '3.+', changing: true
-    }
+plugins {
+    // check for updates at forge files
+    // https://files.minecraftforge.net/maven/net/minecraftforge/gradle/ForgeGradle
+    id 'net.minecraftforge.gradle' version '@FG_VERSION@'
+    // Only edit below this line, the above code adds and enables the necessary things for Forge to be setup.
+    id 'eclipse'
+    id 'maven-publish'
 }
-apply plugin: 'net.minecraftforge.gradle'
-// Only edit below this line, the above code adds and enables the necessary things for Forge to be setup.
-apply plugin: 'eclipse'
-apply plugin: 'maven-publish'
 
 version = '1.0'
 group = 'com.yourname.modid' // http://maven.apache.org/guides/mini/guide-naming-conventions.html

--- a/mdk/settings.gradle
+++ b/mdk/settings.gradle
@@ -1,7 +1,9 @@
 pluginManagement {
     repositories {
-        mavenLocal()
-        maven { url = 'https://files.minecraftforge.net/maven' }
+        maven {
+            url = 'https://files.minecraftforge.net/maven'
+            name = 'Forge'
+        }
         jcenter()
         mavenCentral()
         gradlePluginPortal()
@@ -15,12 +17,4 @@ pluginManagement {
     }
 
 }
-rootProject.name = 'Forge'
-
-include ':mcp'
-include ':clean'
-include ':forge'
-
-project(":mcp").projectDir = file("projects/mcp")
-project(":clean").projectDir = file("projects/clean")
-project(":forge").projectDir = file("projects/forge")
+rootProject.name = 'Example'


### PR DESCRIPTION
[Reasons for not using dynamic versions](https://blog.danlew.net/2015/09/09/dont-use-dynamic-versions-for-your-dependencies/)

Also because gradle plugins don't support dynamic versions (but do support SNAPSHOT).

The MDK will use the value of the `FG_VERSION` variable. I was originally going to set it to be `3.0.+`, but I think this way is a better idea.