### PR TITLE
Fix wrong path for the access transformer in the MDK build.gradle

### DIFF
--- a/mdk/build.gradle
+++ b/mdk/build.gradle
@@ -28,7 +28,7 @@ minecraft {
     mappings channel: '@MAPPING_CHANNEL@', version: '@MAPPING_VERSION@'
     // makeObfSourceJar = false // an Srg named sources jar is made by default. uncomment this to disable.
     
-    // accessTransformer = file('build/resources/main/META-INF/accesstransformer.cfg')
+    // accessTransformer = file('src/main/resources/META-INF/accesstransformer.cfg')
 
     // Default run configurations.
     // These can be tweaked, removed, or duplicated as needed.


### PR DESCRIPTION
Currently, `build.gradle` in the default MDK references the access transformer out of `build.resources/main`. However, the access transformer does not get placed into that directory until after a build, which happens after access transformers run so the AT is missing on that first build.

When I asked about it on Discord, I was told `src/main` makes more sense, especially given that Forge's base `build.gradle` uses src/main, so this commit just corrects the path so future developers downloading the MDK use the more proper path.