### PR TITLE
Expose ParticleManager.registerFactory in AT

### DIFF
--- a/src/main/resources/META-INF/accesstransformer.cfg
+++ b/src/main/resources/META-INF/accesstransformer.cfg
@@ -417,3 +417,7 @@ public net.minecraft.world.gen.IChunkGeneratorFactory
 #ParticleType ctors
 public net.minecraft.particles.ParticleType <init>(ZLnet/minecraft/particles/IParticleData$IDeserializer;)V
 public net.minecraft.particles.BasicParticleType <init>(Z)V
+
+# ParticleManager
+public net.minecraft.client.particle.ParticleManager func_199283_a(Lnet/minecraft/particles/ParticleType;Lnet/minecraft/client/particle/IParticleFactory;)V # registerFactory
+public net.minecraft.client.particle.ParticleManager func_215234_a(Lnet/minecraft/particles/ParticleType;Lnet/minecraft/client/particle/ParticleManager$IParticleMetaFactory;)V # registerFactory


### PR DESCRIPTION
Allows for mods to actually register particle factories since these methods are private.
On another note, that `factories` map probably needs to be patched to use registry delegates since it uses particle int ids as keys