### PR TITLE
Fix link applying to whole component in chat if component starts with link (1.12.2)

### DIFF
--- a/src/main/java/net/minecraftforge/common/ForgeHooks.java
+++ b/src/main/java/net/minecraftforge/common/ForgeHooks.java
@@ -801,9 +801,8 @@ public class ForgeHooks
             link.getStyle().setUnderlined(true);
             link.getStyle().setColor(TextFormatting.BLUE);
             if (ichat == null)
-                ichat = link;
-            else
-                ichat.appendSibling(link);
+                ichat = new TextComponentString("");
+            ichat.appendSibling(link);
         }
 
         // Append the rest of the message.


### PR DESCRIPTION
If a chat line starts with a link, the entire line becomes the link.

Example:

![image](https://user-images.githubusercontent.com/1624192/60763103-3f8f2e80-a065-11e9-9b33-3eb48bfb0a4f.png)

This pull resolves this - it will now look like this:

![image](https://user-images.githubusercontent.com/1624192/60763121-9ac12100-a065-11e9-8e64-94d6a9512f55.png)
