### PR TITLE
Fix & Improve state comparison when checking vanilla block replacements

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -385,6 +385,7 @@ project(':forge') {
         fmllauncherImplementation 'com.google.guava:guava:21.0'
         fmllauncherImplementation 'com.google.code.gson:gson:2.8.0'
         testImplementation 'org.junit.jupiter:junit-jupiter-api:5.0.0'
+        testImplementation 'org.junit.vintage:junit-vintage-engine:5.+'
         testImplementation 'org.opentest4j:opentest4j:1.0.0' // needed for junit 5
         testImplementation 'org.hamcrest:hamcrest-all:1.3' // needs advanced matching for list order
     }

--- a/patches/minecraft/net/minecraft/item/BlockItem.java.patch
+++ b/patches/minecraft/net/minecraft/item/BlockItem.java.patch
@@ -9,7 +9,7 @@
                 world.func_184133_a(playerentity, blockpos, this.func_219983_a(blockstate1), SoundCategory.BLOCKS, (soundtype.func_185843_a() + 1.0F) / 2.0F, soundtype.func_185847_b() * 0.8F);
                 itemstack.func_190918_g(1);
                 return ActionResultType.SUCCESS;
-@@ -189,6 +189,10 @@
+@@ -189,10 +189,18 @@
     }
  
     public Block func_179223_d() {
@@ -20,3 +20,11 @@
        return this.field_150939_a;
     }
  
+    public void func_195946_a(Map<Block, Item> p_195946_1_, Item p_195946_2_) {
+       p_195946_1_.put(this.func_179223_d(), p_195946_2_);
+    }
++
++   public void removeFromBlockToItemMap(Map<Block, Item> blockToItemMap, Item itemIn) {
++      blockToItemMap.remove(this.func_179223_d());
++   }
+ }

--- a/patches/minecraft/net/minecraft/item/WallOrFloorItem.java.patch
+++ b/patches/minecraft/net/minecraft/item/WallOrFloorItem.java.patch
@@ -1,0 +1,12 @@
+--- a/net/minecraft/item/WallOrFloorItem.java
++++ b/net/minecraft/item/WallOrFloorItem.java
+@@ -41,4 +41,9 @@
+       super.func_195946_a(p_195946_1_, p_195946_2_);
+       p_195946_1_.put(this.field_195947_b, p_195946_2_);
+    }
++
++   public void removeFromBlockToItemMap(Map<Block, Item> blockToItemMap, Item itemIn) {
++      super.removeFromBlockToItemMap(blockToItemMap, itemIn);
++      blockToItemMap.remove(this.field_195947_b);
++   }
+ }

--- a/src/main/java/net/minecraftforge/registries/GameData.java
+++ b/src/main/java/net/minecraftforge/registries/GameData.java
@@ -41,6 +41,7 @@ import net.minecraft.network.datasync.IDataSerializer;
 import net.minecraft.particles.ParticleType;
 import net.minecraft.potion.Effect;
 import net.minecraft.potion.Potion;
+import net.minecraft.state.IProperty;
 import net.minecraft.state.StateContainer;
 import net.minecraft.stats.StatType;
 import net.minecraft.tileentity.TileEntityType;
@@ -368,6 +369,13 @@ public class GameData
     {
         static final BlockCallbacks INSTANCE = new BlockCallbacks();
 
+        private boolean compareProperty(IProperty<?> a, IProperty<?> b)
+        {
+            if (!a.getName().equals(b.getName()))
+                return false;
+            return Streams.zip(a.getAllowedValues().stream(), b.getAllowedValues().stream(), Object::equals).allMatch(v -> v);
+        }
+
         @Override
         public void onAdd(IForgeRegistryInternal<Block> owner, RegistryManager stage, int id, Block block, @Nullable Block oldBlock)
         {
@@ -381,9 +389,7 @@ public class GameData
                 // Test vanilla blockstates, if the number matches, make sure they also match in their string representations
                 if (block.getRegistryName().getNamespace().equals("minecraft") && (
                         oldValidStates.size() != newValidStates.size() ||
-                        !Streams.zip(oldValidStates.stream().map(Object::toString),
-                                    newValidStates.stream().map(Object::toString),
-                                    String::equals).allMatch(v -> v)))
+                        !Streams.zip(oldContainer.getProperties().stream(), newContainer.getProperties().stream(), this::compareProperty).allMatch(v -> v)))
                 {
                     String oldSequence = oldContainer.getProperties().stream()
                             .map(s -> String.format("%s={%s}", s.getName(),

--- a/src/main/java/net/minecraftforge/registries/GameData.java
+++ b/src/main/java/net/minecraftforge/registries/GameData.java
@@ -373,13 +373,9 @@ public class GameData
             {
                 StateContainer<Block, BlockState> oldContainer = oldBlock.getStateContainer();
                 StateContainer<Block, BlockState> newContainer = block.getStateContainer();
-                ImmutableList<BlockState> oldValidStates = oldContainer.getValidStates();
-                ImmutableList<BlockState> newValidStates = newContainer.getValidStates();
 
                 // Test vanilla blockstates, if the number matches, make sure they also match in their string representations
-                if (block.getRegistryName().getNamespace().equals("minecraft") && (
-                        oldValidStates.size() != newValidStates.size() ||
-                        !Streams.zip(oldContainer.getProperties().stream(), newContainer.getProperties().stream(), Object::equals).allMatch(v -> v)))
+                if (block.getRegistryName().getNamespace().equals("minecraft") && !oldContainer.getProperties().equals(newContainer.getProperties()))
                 {
                     String oldSequence = oldContainer.getProperties().stream()
                             .map(s -> String.format("%s={%s}", s.getName(),

--- a/src/main/java/net/minecraftforge/registries/GameData.java
+++ b/src/main/java/net/minecraftforge/registries/GameData.java
@@ -41,7 +41,6 @@ import net.minecraft.network.datasync.IDataSerializer;
 import net.minecraft.particles.ParticleType;
 import net.minecraft.potion.Effect;
 import net.minecraft.potion.Potion;
-import net.minecraft.state.IProperty;
 import net.minecraft.state.StateContainer;
 import net.minecraft.stats.StatType;
 import net.minecraft.tileentity.TileEntityType;
@@ -88,8 +87,6 @@ import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
 import static net.minecraftforge.registries.ForgeRegistry.REGISTRIES;
-
-import net.minecraftforge.fml.common.EnhancedRuntimeException.WrappedPrintStream;
 
 /**
  * INTERNAL ONLY
@@ -369,13 +366,6 @@ public class GameData
     {
         static final BlockCallbacks INSTANCE = new BlockCallbacks();
 
-        private boolean compareProperty(IProperty<?> a, IProperty<?> b)
-        {
-            if (!a.getName().equals(b.getName()))
-                return false;
-            return Streams.zip(a.getAllowedValues().stream(), b.getAllowedValues().stream(), Object::equals).allMatch(v -> v);
-        }
-
         @Override
         public void onAdd(IForgeRegistryInternal<Block> owner, RegistryManager stage, int id, Block block, @Nullable Block oldBlock)
         {
@@ -389,7 +379,7 @@ public class GameData
                 // Test vanilla blockstates, if the number matches, make sure they also match in their string representations
                 if (block.getRegistryName().getNamespace().equals("minecraft") && (
                         oldValidStates.size() != newValidStates.size() ||
-                        !Streams.zip(oldContainer.getProperties().stream(), newContainer.getProperties().stream(), this::compareProperty).allMatch(v -> v)))
+                        !Streams.zip(oldContainer.getProperties().stream(), newContainer.getProperties().stream(), Object::equals).allMatch(v -> v)))
                 {
                     String oldSequence = oldContainer.getProperties().stream()
                             .map(s -> String.format("%s={%s}", s.getName(),

--- a/src/main/java/net/minecraftforge/registries/GameData.java
+++ b/src/main/java/net/minecraftforge/registries/GameData.java
@@ -475,7 +475,7 @@ public class GameData
             {
                 @SuppressWarnings("unchecked")
                 Map<Block, Item> blockToItem = owner.getSlaveMap(BLOCK_TO_ITEM, Map.class);
-                blockToItem.remove(((BlockItem)oldItem).getBlock());
+                ((BlockItem)oldItem).removeFromBlockToItemMap(blockToItem, item);
             }
             if (item instanceof BlockItem)
             {

--- a/src/main/java/net/minecraftforge/registries/GameData.java
+++ b/src/main/java/net/minecraftforge/registries/GameData.java
@@ -474,7 +474,7 @@ public class GameData
             if (oldItem instanceof BlockItem)
             {
                 @SuppressWarnings("unchecked")
-                BiMap<Block, Item> blockToItem = owner.getSlaveMap(BLOCK_TO_ITEM, BiMap.class);
+                Map<Block, Item> blockToItem = owner.getSlaveMap(BLOCK_TO_ITEM, Map.class);
                 blockToItem.remove(((BlockItem)oldItem).getBlock());
             }
             if (item instanceof BlockItem)


### PR DESCRIPTION
Back in 1.13, I wrote this piece of code, but I'm ashamed to admit I was too hasty and lazy, so I resorted to a rather crappy and finicky way to perform the check of whether a replacement block is a correct replacement for a vanilla block.

Currently in 1.14, some of the assumptions that supported that code don't apply correctly anymore, so the code breaks in some situations.

This PR replaces that piece of code with a more robust and faster version.