### PR TITLE
Remove OnlyIn Client Distribution from Effect and EffectType methods.

### DIFF
--- a/patches/minecraft/net/minecraft/potion/Effect.java.patch
+++ b/patches/minecraft/net/minecraft/potion/Effect.java.patch
@@ -9,11 +9,27 @@
     private final Map<IAttribute, AttributeModifier> field_111188_I = Maps.newHashMap();
     private final EffectType field_220305_b;
     private final int field_76414_N;
-@@ -149,7 +149,6 @@
+@@ -134,7 +134,6 @@
+       return new TranslationTextComponent(this.func_76393_a());
+    }
+ 
+-   @OnlyIn(Dist.CLIENT)
+    public EffectType func_220303_e() {
+       return this.field_220305_b;
+    }
+@@ -149,7 +148,6 @@
        return this;
     }
  
 -   @OnlyIn(Dist.CLIENT)
     public Map<IAttribute, AttributeModifier> func_111186_k() {
        return this.field_111188_I;
+    }
+@@ -180,7 +178,6 @@
+       return p_111183_2_.func_111164_d() * (double)(p_111183_1_ + 1);
+    }
+ 
+-   @OnlyIn(Dist.CLIENT)
+    public boolean func_188408_i() {
+       return this.field_220305_b == EffectType.BENEFICIAL;
     }

--- a/patches/minecraft/net/minecraft/potion/EffectType.java.patch
+++ b/patches/minecraft/net/minecraft/potion/EffectType.java.patch
@@ -1,0 +1,10 @@
+--- a/net/minecraft/potion/EffectType.java
++++ b/net/minecraft/potion/EffectType.java
+@@ -15,7 +15,6 @@
+       this.field_220307_d = p_i50390_3_;
+    }
+ 
+-   @OnlyIn(Dist.CLIENT)
+    public TextFormatting func_220306_a() {
+       return this.field_220307_d;
+    }


### PR DESCRIPTION
Fix for #5920 

These methods do not use any client only distribution resources. By making them available on both sides the server can now make decisions based on EffectType of an Effect.

For example remove all Beneficial potion effects from a player. 