### PR TITLE
 [1.14.x] Fix text positioning issues caused by scaling loading screen 

### DIFF
--- a/src/main/java/net/minecraftforge/fml/client/EarlyLoaderGUI.java
+++ b/src/main/java/net/minecraftforge/fml/client/EarlyLoaderGUI.java
@@ -79,7 +79,7 @@ public class EarlyLoaderGUI {
             final float fade = MathHelper.clamp((4000.0f - (float) pair.getLeft() - ( i - 4 ) * 1000.0f) / 5000.0f, 0.0f, 1.0f);
             if (fade <0.01f) continue;
             StartupMessageManager.Message msg = pair.getRight();
-            renderMessage(msg.getText(), msg.getTypeColour(), ((window.getScaledHeight() - 15) / 10) - i, fade);
+            renderMessage(msg.getText(), msg.getTypeColour(), ((window.getScaledHeight() - 15) / 10) - i + 1, fade);
         }
         renderMemoryInfo();
     }

--- a/src/main/java/net/minecraftforge/fml/client/EarlyLoaderGUI.java
+++ b/src/main/java/net/minecraftforge/fml/client/EarlyLoaderGUI.java
@@ -79,7 +79,7 @@ public class EarlyLoaderGUI {
             final float fade = MathHelper.clamp((4000.0f - (float) pair.getLeft() - ( i - 4 ) * 1000.0f) / 5000.0f, 0.0f, 1.0f);
             if (fade <0.01f) continue;
             StartupMessageManager.Message msg = pair.getRight();
-            renderMessage(msg.getText(), msg.getTypeColour(), i, fade);
+            renderMessage(msg.getText(), msg.getTypeColour(), ((window.getScaledHeight() - 15) / 10) - i, fade);
         }
         renderMemoryInfo();
     }
@@ -96,7 +96,7 @@ public class EarlyLoaderGUI {
         memorycolour[2] = ((i) & 0xFF) / 255.0f;
         memorycolour[1] = ((i >> 8 ) & 0xFF) / 255.0f;
         memorycolour[0] = ((i >> 16 ) & 0xFF) / 255.0f;
-        renderMessage(memory, memorycolour, 21, 1.0f);
+        renderMessage(memory, memorycolour, 1, 1.0f);
     }
 
     void renderMessage(final String message, final float[] colour, int line, float alpha) {
@@ -110,7 +110,7 @@ public class EarlyLoaderGUI {
         GlStateManager.blendFunc(GlStateManager.SourceFactor.CONSTANT_ALPHA, GlStateManager.DestFactor.ONE_MINUS_CONSTANT_ALPHA);
         GlStateManager.color3f(colour[0],colour[1],colour[2]);
         GlStateManager.pushMatrix();
-        GlStateManager.translatef(10, window.getScaledHeight() - 15 - line * 10, 0);
+        GlStateManager.translatef(10, line * 10, 0);
         GlStateManager.scalef(1, 1, 0);
         GlStateManager.drawArrays(GL11.GL_QUADS, 0, quads * 4);
         GlStateManager.popMatrix();


### PR DESCRIPTION
Scaling the loading screen would cause the memory heap info to float in the middle of the screen at its original distance. Now the "reversing" for the mod loading status is not automatic and the math is in the loop for the status messages, while the memory info is at line 1 as would make sense (since it's at the top of the screen).

Original issue (after maximizing window):
![image](https://user-images.githubusercontent.com/10366817/61168424-06026b80-a51c-11e9-8d04-6b3a2aae2b97.png)

Now (after maximizing window):
![image](https://user-images.githubusercontent.com/10366817/61168462-8de87580-a51c-11e9-99d1-b41010a31e01.png)

Of course, this still works fine on the window when not scaled:
![image](https://user-images.githubusercontent.com/10366817/61168471-b07a8e80-a51c-11e9-83f7-ce868f818190.png)