### PR TITLE
Fix forge 1.14.4 startup in obfed enviroment

### DIFF
--- a/src/fmllauncher/java/net/minecraftforge/fml/loading/FMLClientLaunchProvider.java
+++ b/src/fmllauncher/java/net/minecraftforge/fml/loading/FMLClientLaunchProvider.java
@@ -62,10 +62,9 @@ public class FMLClientLaunchProvider extends FMLCommonLaunchHandler implements I
     public void configureTransformationClassLoader(final ITransformingClassLoaderBuilder builder)
     {
         super.configureTransformationClassLoader(builder);
-        Path patchy = LibraryFinder.findJarPathFor("com/mojang/patch/LegacyXMLLayout.class", "patchy");
-        Path mapped = Paths.get(patchy.toString().substring(0, patchy.toString().length() - 4) + '-' + FMLLoader.getMcpVersion() + ".jar");
-        LOGGER.debug(CORE, "Found patchy library at {}", Files.exists(mapped) ? mapped : patchy);
-        builder.addTransformationPath(Files.exists(mapped) ? mapped : patchy);
+        Path patchy = LibraryFinder.findJarPathFor("com/mojang/patchy/LegacyXMLLayout.class", "patchy");
+        LOGGER.debug(CORE, "Found patchy library at {}", patchy);
+        builder.addTransformationPath(patchy);
     }
 
     @SuppressWarnings("unchecked")


### PR DESCRIPTION
Forge searched in the wrong package.
I also removed the mapped search, as it was only needed for realms.