### PR TITLE
[1.12][Event]: LivingTotemEvent - Totem Handling and Intersection between DamageEvent and DeathEvents

### DIFF
--- a/patches/minecraft/net/minecraft/entity/EntityLivingBase.java.patch
+++ b/patches/minecraft/net/minecraft/entity/EntityLivingBase.java.patch
@@ -136,7 +136,17 @@
  
                          if (entitywolf.func_70909_n())
                          {
-@@ -1127,7 +1143,7 @@
+@@ -1048,6 +1063,9 @@
+         }
+         else
+         {
++            net.minecraftforge.fml.common.eventhandler.Event.Result result = net.minecraftforge.event.ForgeEventFactory.checkTotemProtection(this, p_190628_1_);
++            if (result != net.minecraftforge.fml.common.eventhandler.Event.Result.DEFAULT) return result == net.minecraftforge.fml.common.eventhandler.Event.Result.ALLOW;
++
+             ItemStack itemstack = null;
+ 
+             for (EnumHand enumhand : EnumHand.values())
+@@ -1127,7 +1145,7 @@
  
      public void func_70669_a(ItemStack p_70669_1_)
      {

--- a/src/main/java/net/minecraftforge/event/ForgeEventFactory.java
+++ b/src/main/java/net/minecraftforge/event/ForgeEventFactory.java
@@ -838,7 +838,11 @@ public class ForgeEventFactory
         Result result = event.getResult();
         if (result == Result.ALLOW)
         {
-            livingBase.world.setEntityState(livingBase, (byte)35);
+            livingBase.world.setEntityState(livingBase, (byte) 35);
+            if (event.doesClearEffects())
+            {
+                livingBase.clearActivePotions();
+            }
             if (event.getHealth() <= 0)
             {
                 livingBase.setHealth(1.0F);
@@ -850,6 +854,13 @@ public class ForgeEventFactory
             else
             {
                 livingBase.setHealth(event.getHealth());
+            }
+            if (!event.getEffects().isEmpty())
+            {
+                for (PotionEffect instance : event.getEffects())
+                {
+                    livingBase.addPotionEffect(instance);
+                }
             }
         }
         return event.getResult();

--- a/src/main/java/net/minecraftforge/event/ForgeEventFactory.java
+++ b/src/main/java/net/minecraftforge/event/ForgeEventFactory.java
@@ -843,6 +843,10 @@ public class ForgeEventFactory
             {
                 livingBase.setHealth(1.0F);
             }
+            else if (event.getHealth() > livingBase.getMaxHealth())
+            {
+                livingBase.setHealth(livingBase.getMaxHealth());
+            }
             else
             {
                 livingBase.setHealth(event.getHealth());

--- a/src/main/java/net/minecraftforge/event/ForgeEventFactory.java
+++ b/src/main/java/net/minecraftforge/event/ForgeEventFactory.java
@@ -836,15 +836,14 @@ public class ForgeEventFactory
         LivingTotemEvent event = new LivingTotemEvent(livingBase, source);
         MinecraftForge.EVENT_BUS.post(event);
         Result result = event.getResult();
-        if (result == Result.ALLOW)
-        {
-            livingBase.setHealth(1.0F);
-            livingBase.clearActivePotions();
-            livingBase.addPotionEffect(new PotionEffect(MobEffects.REGENERATION, 900, 1));
-            livingBase.addPotionEffect(new PotionEffect(MobEffects.ABSORPTION, 100, 1));
+        if (result == Result.ALLOW) {
             livingBase.world.setEntityState(livingBase, (byte)35);
+            if (!(livingBase.getHealth() > 0)) {
+                livingBase.setHealth(1.0F);
+            }
         }
-
-        return result;
+        return event.getResult();
     }
+
+
 }

--- a/src/main/java/net/minecraftforge/event/ForgeEventFactory.java
+++ b/src/main/java/net/minecraftforge/event/ForgeEventFactory.java
@@ -42,8 +42,10 @@ import net.minecraft.entity.projectile.EntityArrow;
 import net.minecraft.entity.projectile.EntityFireball;
 import net.minecraft.entity.projectile.EntityThrowable;
 import net.minecraft.init.Blocks;
+import net.minecraft.init.MobEffects;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
+import net.minecraft.potion.PotionEffect;
 import net.minecraft.server.MinecraftServer;
 import net.minecraft.tileentity.MobSpawnerBaseLogic;
 import net.minecraft.tileentity.TileEntity;
@@ -94,13 +96,7 @@ import net.minecraftforge.event.entity.PlaySoundAtEntityEvent;
 import net.minecraftforge.event.entity.ProjectileImpactEvent;
 import net.minecraftforge.event.entity.ThrowableImpactEvent;
 import net.minecraftforge.event.entity.item.ItemExpireEvent;
-import net.minecraftforge.event.entity.living.AnimalTameEvent;
-import net.minecraftforge.event.entity.living.LivingDestroyBlockEvent;
-import net.minecraftforge.event.entity.living.LivingEntityUseItemEvent;
-import net.minecraftforge.event.entity.living.LivingExperienceDropEvent;
-import net.minecraftforge.event.entity.living.LivingHealEvent;
-import net.minecraftforge.event.entity.living.LivingPackSizeEvent;
-import net.minecraftforge.event.entity.living.LivingSpawnEvent;
+import net.minecraftforge.event.entity.living.*;
 import net.minecraftforge.event.entity.living.LivingSpawnEvent.AllowDespawn;
 import net.minecraftforge.event.entity.living.ZombieEvent.SummonAidEvent;
 import net.minecraftforge.event.entity.player.ArrowLooseEvent;
@@ -834,5 +830,20 @@ public class ForgeEventFactory
         MerchantTradeOffersEvent event = new MerchantTradeOffersEvent(merchant, player, dupeList);
         MinecraftForge.EVENT_BUS.post(event);
         return event.getList();
+    }
+
+    public static Result checkTotemProtection(EntityLivingBase livingBase, DamageSource source) {
+        LivingTotemEvent event = new LivingTotemEvent(livingBase, source);
+        MinecraftForge.EVENT_BUS.post(event);
+        Result result = event.getResult();
+        if (result == Result.ALLOW) {
+            livingBase.setHealth(1.0F);
+            livingBase.clearActivePotions();
+            livingBase.addPotionEffect(new PotionEffect(MobEffects.REGENERATION, 900, 1));
+            livingBase.addPotionEffect(new PotionEffect(MobEffects.ABSORPTION, 100, 1));
+            livingBase.world.setEntityState(livingBase, (byte)35);
+        }
+
+        return result;
     }
 }

--- a/src/main/java/net/minecraftforge/event/ForgeEventFactory.java
+++ b/src/main/java/net/minecraftforge/event/ForgeEventFactory.java
@@ -836,7 +836,8 @@ public class ForgeEventFactory
         LivingTotemEvent event = new LivingTotemEvent(livingBase, source);
         MinecraftForge.EVENT_BUS.post(event);
         Result result = event.getResult();
-        if (result == Result.ALLOW) {
+        if (result == Result.ALLOW)
+        {
             livingBase.setHealth(1.0F);
             livingBase.clearActivePotions();
             livingBase.addPotionEffect(new PotionEffect(MobEffects.REGENERATION, 900, 1));

--- a/src/main/java/net/minecraftforge/event/ForgeEventFactory.java
+++ b/src/main/java/net/minecraftforge/event/ForgeEventFactory.java
@@ -836,10 +836,16 @@ public class ForgeEventFactory
         LivingTotemEvent event = new LivingTotemEvent(livingBase, source);
         MinecraftForge.EVENT_BUS.post(event);
         Result result = event.getResult();
-        if (result == Result.ALLOW) {
+        if (result == Result.ALLOW)
+        {
             livingBase.world.setEntityState(livingBase, (byte)35);
-            if (!(livingBase.getHealth() > 0)) {
+            if (event.getHealth() <= 0)
+            {
                 livingBase.setHealth(1.0F);
+            }
+            else
+            {
+                livingBase.setHealth(event.getHealth());
             }
         }
         return event.getResult();

--- a/src/main/java/net/minecraftforge/event/entity/living/LivingTotemEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/living/LivingTotemEvent.java
@@ -1,0 +1,38 @@
+package net.minecraftforge.event.entity.living;
+
+import net.minecraft.entity.EntityLivingBase;
+import net.minecraft.util.DamageSource;
+import net.minecraftforge.fml.common.eventhandler.Cancelable;
+import net.minecraftforge.common.MinecraftForge;
+import net.minecraftforge.fml.common.eventhandler.Event;
+
+/**
+ * LivingTotemEvent is fired when a player is about to die but are holding a Totem of Undying.
+ * <br>
+ * This event is fired whenever a player's death is prevented by a Totem of Undying.
+ * <br>
+ * This event isn't {@link Cancelable}
+ * <br>
+ * This event has a result. {@link HasResult}
+ *  Result.Allow = Respawns the Player regardless of them having a Totem.
+ *  Result.Default = Runs the default Totem of Undying checks and balances.
+ *  Result.Deny = Don't save the player regardless of them holding the Totem.
+ * <br>
+ * This event is fired on the {@link MinecraftForge#EVENT_BUS}
+ */
+@Event.HasResult
+public class LivingTotemEvent extends LivingEvent
+{
+    private final DamageSource source;
+
+    public LivingTotemEvent(EntityLivingBase livingBase, DamageSource source)
+    {
+        super(livingBase);
+        this.source = source;
+    }
+
+    public DamageSource getSource() {
+        return source;
+    }
+
+}

--- a/src/main/java/net/minecraftforge/event/entity/living/LivingTotemEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/living/LivingTotemEvent.java
@@ -7,9 +7,9 @@ import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.fml.common.eventhandler.Event;
 
 /**
- * LivingTotemEvent is fired when a player is about to die but are holding a Totem of Undying.
+ * LivingTotemEvent is fired when a player is about to die.
  * <br>
- * This event is fired whenever a player's death is prevented by a Totem of Undying.
+ * This event is fired whenever a player is about to die.
  * <br>
  * This event isn't {@link Cancelable}
  * <br>
@@ -31,7 +31,8 @@ public class LivingTotemEvent extends LivingEvent
         this.source = source;
     }
 
-    public DamageSource getSource() {
+    public DamageSource getSource()
+    {
         return source;
     }
 

--- a/src/main/java/net/minecraftforge/event/entity/living/LivingTotemEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/living/LivingTotemEvent.java
@@ -72,13 +72,6 @@ public class LivingTotemEvent extends LivingEvent
 
     public void setHealth(int health)
     {
-        if (health > getEntityLiving().getMaxHealth())
-        {
-            this.health = getEntityLiving().getMaxHealth();
-        }
-        else
-        {
-            this.health = health;
-        }
+        this.health = health;
     }
 }

--- a/src/main/java/net/minecraftforge/event/entity/living/LivingTotemEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/living/LivingTotemEvent.java
@@ -20,10 +20,14 @@
 package net.minecraftforge.event.entity.living;
 
 import net.minecraft.entity.EntityLivingBase;
+import net.minecraft.potion.PotionEffect;
 import net.minecraft.util.DamageSource;
 import net.minecraftforge.fml.common.eventhandler.Cancelable;
 import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.fml.common.eventhandler.Event;
+
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * LivingTotemEvent is fired when a player is about to die.
@@ -48,30 +52,77 @@ import net.minecraftforge.fml.common.eventhandler.Event;
 public class LivingTotemEvent extends LivingEvent
 {
     /**
-     * If the event returns Result.Allow, the value of health will be used to decide the health of the player is set to when "protected".
+     * If the event returns Result.Allow, the value of health will be used to decide the health the player is set to when "protected".
      * By default, the player's health will be set to 1.
      */
     private float health;
+
+    /**
+     * If the event returns Result.Allow, the value of clearEffects will be used to decide if the built-in behavior clears all active potion effects.
+     * By default, the player's effects are cleared.
+     */
+    private boolean clearEffects = true;
+
+    /**
+     * If the event returns Result.Allow, the value of effects allows for people to add effects that gets added to the player;
+     * By default, the player gets no extra effects.
+     */
+    private List<PotionEffect> effects;
+
     private final DamageSource source;
 
     public LivingTotemEvent(EntityLivingBase livingBase, DamageSource source)
     {
         super(livingBase);
         this.source = source;
+        effects = new ArrayList<>();
     }
 
+
+    /**
+     * Returns the DamageSource that inflicted the lethal damage.
+     */
     public DamageSource getSource()
     {
         return source;
     }
 
+    /**
+     * Returns the health float for the event.
+     */
     public float getHealth()
     {
         return health;
     }
 
-    public void setHealth(int health)
+    /**
+     * @param health - Sets the float value for how much life the player should get returned to if the Event.Result is Allow.
+     */
+    public void setHealth(float health)
     {
         this.health = health;
+    }
+
+    /**
+     * Returns the boolean for if the event should clear all active potion effects.
+     */
+    public boolean doesClearEffects()
+    {
+        return clearEffects;
+    }
+
+    /**
+     * @param clearEffects - If the event should clear effects, True By Default.
+     */
+    public void setClearEffects(boolean clearEffects)
+    {
+        this.clearEffects = clearEffects;
+    }
+
+    /**
+     * Returns the list of effects that will get added after effects are cleared by the event.
+     */
+    public List<PotionEffect> getEffects() {
+        return effects;
     }
 }

--- a/src/main/java/net/minecraftforge/event/entity/living/LivingTotemEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/living/LivingTotemEvent.java
@@ -14,6 +14,11 @@ import net.minecraftforge.fml.common.eventhandler.Event;
  * This event isn't {@link Cancelable}
  * <br>
  * This event has a result. {@link HasResult}
+ * <br>
+ * If you pass Result.Allow, you need to do any resulting handling such as setting effects and such.
+ * Result.Allow does only handle Life-Setting and Entity State handling by default.
+ * This is done to allow mod-authors to create their own "set of effects" for their own totems.
+ * <br>
  *  Result.Allow = Respawns the Player regardless of them having a Totem.
  *  Result.Default = Runs the default Totem of Undying checks and balances.
  *  Result.Deny = Do not save the player regardless of them holding the Totem.
@@ -23,6 +28,12 @@ import net.minecraftforge.fml.common.eventhandler.Event;
 @Event.HasResult
 public class LivingTotemEvent extends LivingEvent
 {
+    /**
+     * If the event returns Result.Allow, the value of health will be used to chose the health the player is "revived" with.
+     * By default it's not set and thus returns 0.
+     * This is checked against in ForgeEventFactory#checkTotemProtection and returns a value of 1 if a value is not set.
+     */
+    private int health;
     private final DamageSource source;
 
     public LivingTotemEvent(EntityLivingBase livingBase, DamageSource source)
@@ -36,4 +47,13 @@ public class LivingTotemEvent extends LivingEvent
         return source;
     }
 
+    public int getHealth()
+    {
+        return health;
+    }
+
+    public void setHealth(int health)
+    {
+        this.health = health;
+    }
 }

--- a/src/main/java/net/minecraftforge/event/entity/living/LivingTotemEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/living/LivingTotemEvent.java
@@ -16,7 +16,7 @@ import net.minecraftforge.fml.common.eventhandler.Event;
  * This event has a result. {@link HasResult}
  *  Result.Allow = Respawns the Player regardless of them having a Totem.
  *  Result.Default = Runs the default Totem of Undying checks and balances.
- *  Result.Deny = Don't save the player regardless of them holding the Totem.
+ *  Result.Deny = Do not save the player regardless of them holding the Totem.
  * <br>
  * This event is fired on the {@link MinecraftForge#EVENT_BUS}
  */

--- a/src/main/java/net/minecraftforge/event/entity/living/LivingTotemEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/living/LivingTotemEvent.java
@@ -1,3 +1,22 @@
+/*
+ * Minecraft Forge
+ * Copyright (c) 2016-2018.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation version 2.1
+ * of the License.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
 package net.minecraftforge.event.entity.living;
 
 import net.minecraft.entity.EntityLivingBase;

--- a/src/main/java/net/minecraftforge/event/entity/living/LivingTotemEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/living/LivingTotemEvent.java
@@ -19,7 +19,7 @@ import net.minecraftforge.fml.common.eventhandler.Event;
  * Result.Allow does only handle Life-Setting and Entity State handling by default.
  * This is done to allow mod-authors to create their own "set of effects" for their own totems.
  * <br>
- *  Result.Allow = Respawns the Player regardless of them having a Totem.
+ *  Result.Allow = Protects the player, setting their health to the value set in getHealth or 1F.
  *  Result.Default = Runs the default Totem of Undying checks and balances.
  *  Result.Deny = Do not save the player regardless of them holding the Totem.
  * <br>
@@ -29,11 +29,10 @@ import net.minecraftforge.fml.common.eventhandler.Event;
 public class LivingTotemEvent extends LivingEvent
 {
     /**
-     * If the event returns Result.Allow, the value of health will be used to chose the health the player is "revived" with.
-     * By default it's not set and thus returns 0.
-     * This is checked against in ForgeEventFactory#checkTotemProtection and returns a value of 1 if a value is not set.
+     * If the event returns Result.Allow, the value of health will be used to decide the health of the player is set to when "protected".
+     * By default, the player's health will be set to 1.
      */
-    private int health;
+    private float health;
     private final DamageSource source;
 
     public LivingTotemEvent(EntityLivingBase livingBase, DamageSource source)
@@ -47,13 +46,20 @@ public class LivingTotemEvent extends LivingEvent
         return source;
     }
 
-    public int getHealth()
+    public float getHealth()
     {
         return health;
     }
 
     public void setHealth(int health)
     {
-        this.health = health;
+        if (health > getEntityLiving().getMaxHealth())
+        {
+            this.health = getEntityLiving().getMaxHealth();
+        }
+        else
+        {
+            this.health = health;
+        }
     }
 }


### PR DESCRIPTION
**What classes/methods does this event add?:**  
This event currently adds 1 event class, 1 method and 2 lines of patches.

**What purpose does this event fill?:**  
This event is created to not only allow handling of the Totem of Protection but also to help intersect the event chain between Damage Taken events and Death Events. This event similarly to the Totem Of Protection itself occurs in the state between the player taking lethal damage, and the player being handled as dead.

Essentially the place this occurs is:
Lethal Damage Taken > Totem Protection Check > Death Handled

And thusly allows people to intervene before the player is handled as dead but after the damage is taken.

**So what does this event provide in terms of capabilities?:**  
Well, it does a few things, let's start by establishing that this event is Result-based and such has 3 states it can inhabit. 

**Allow** = Provides a "hook-in" point for mods to provide event-based custom behavior for the totem event, for example, one can subscribe to the event, check if a player has their "totem" item or whatever you'd not want to check for. And then you'd do the handling and pass Result.Allow.

**Default** = Defaults to the vanilla totem of protection checking behavior, this means you don't insert any overwriting behavior and instead lets the vanilla method run its course. 

**Deny** = Denies all behavior and passes the event forward so the player just dies.

A lot of the functionality of this event is documented using JavaDocs with links.

**THIS IS WHERE THE IFFY OCCURS**  
For whatever reason I haven't been able to get test mods working on my dev environment, what so ever.
Neither on my 1.12 nor my 1.14 branches, so I haven't been able to validate the code myself.
Nothing I've done seems to have worked thus far, I've reached out to a few colleagues for validation.

However, I've had several members of the community chime in on the implementation, documentation, etc to make sure it's all compliant with forge contributing guidelines (outside of testing) and implemented in a way that the community would like for an event like this to work.
