### PR TITLE
Fix worlds being queued twice to unload

### DIFF
--- a/patches/minecraft/net/minecraft/world/server/ChunkManager.java.patch
+++ b/patches/minecraft/net/minecraft/world/server/ChunkManager.java.patch
@@ -1,13 +1,13 @@
 --- a/net/minecraft/world/server/ChunkManager.java
 +++ b/net/minecraft/world/server/ChunkManager.java
-@@ -385,6 +385,7 @@
-       while((p_223155_1_.getAsBoolean() || this.field_223181_A.size() > 2000) && (runnable = this.field_223181_A.poll()) != null) {
-          runnable.run();
+@@ -362,6 +362,7 @@
+       iprofiler.func_219895_b("chunk_unload");
+       if (!this.field_219255_i.func_217402_u()) {
+          this.func_223155_b(p_219204_1_);
++         if (this.field_219251_e.isEmpty()) net.minecraftforge.common.DimensionManager.unloadWorld(this.field_219255_i);
        }
-+      if (this.field_219251_e.isEmpty()) net.minecraftforge.common.DimensionManager.unloadWorld(this.field_219255_i);
  
-    }
- 
+       iprofiler.func_76319_b();
 @@ -398,6 +399,7 @@
              if (this.field_219253_g.remove(p_219212_1_, p_219212_3_) && p_219185_5_ != null) {
                 if (p_219185_5_ instanceof Chunk) {

--- a/src/main/java/net/minecraftforge/common/DimensionManager.java
+++ b/src/main/java/net/minecraftforge/common/DimensionManager.java
@@ -227,7 +227,7 @@ public class DimensionManager
 
     /**
      * Queues a dimension to unload, if it can be unloaded.
-     * @param id The id of the dimension
+     * @param world The world to unload
      */
     public static void unloadWorld(ServerWorld world)
     {
@@ -370,7 +370,7 @@ public class DimensionManager
                 ModDimension mod = ForgeRegistries.MOD_DIMENSIONS.getValue(entry.type);
                 if (mod == null)
                 {
-                    LOGGER.error(DIMMGR, "Modded dimension entry '{}' id {} in save file missing ModDimension.", entry.name.toString(), entry.id, entry.type.toString());
+                    LOGGER.error(DIMMGR, "Modded dimension entry '{}' id {} type {} in save file missing ModDimension.", entry.name.toString(), entry.id, entry.type.toString());
                     savedEntries.put(entry.name, entry);
                     continue;
                 }


### PR DESCRIPTION
Currently, the unload check is in the scheduleUnloads method. The problem is that this is also called on close, which is called by unloadWorlds, so it tries a second time which gets filtered out by https://github.com/ichttt/MinecraftForge/blob/96c421db5e5a04be4fb594ed4a10f9ee7abe87e4/src/main/java/net/minecraftforge/common/DimensionManager.java#L271, but logs a confusing log message. The "fix" is to move the unloadWorld check to the tick method, right after scheduleUnloads has been run.
Also fixes a javadoc and log arg error in DimManager