### PR TITLE
Add button to open mods folder

### DIFF
--- a/src/main/java/net/minecraftforge/fml/client/gui/GuiModList.java
+++ b/src/main/java/net/minecraftforge/fml/client/gui/GuiModList.java
@@ -32,6 +32,8 @@ import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
+import net.minecraft.util.Util;
+import net.minecraftforge.fml.loading.FMLPaths;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -102,7 +104,7 @@ public class GuiModList extends Screen
     private int listWidth;
     private List<ModInfo> mods;
     private final List<ModInfo> unsortedMods;
-    private Button configButton;
+    private Button configButton, openModsFolderButton;
 
     private int buttonMargin = 1;
     private int numButtons = SortType.values().length;
@@ -279,7 +281,9 @@ public class GuiModList extends Screen
         int doneButtonWidth = Math.min(modInfoWidth, 200);
         this.addButton(new Button(((modList.getWidth() + 8 + this.width - doneButtonWidth) / 2), this.height - 24, doneButtonWidth, 20,
                 I18n.format("gui.done"), b -> GuiModList.this.minecraft.displayGuiScreen(GuiModList.this.mainMenu)));
-        this.addButton(this.configButton = new Button(6, this.height - 24, this.listWidth, 20,
+        this.addButton(this.openModsFolderButton = new Button(6, this.height - 24, this.listWidth, 20,
+                I18n.format("fml.menu.mods.openmodsfolder"), b -> Util.getOSType().openFile(FMLPaths.MODSDIR.get().toFile())));
+        this.addButton(this.configButton = new Button(6, this.height - 48, this.listWidth, 20,
                 I18n.format("fml.menu.mods.config"), b -> GuiModList.this.displayModConfig()));
         this.configButton.active = false;
 

--- a/src/main/java/net/minecraftforge/fml/client/gui/GuiSlotModList.java
+++ b/src/main/java/net/minecraftforge/fml/client/gui/GuiSlotModList.java
@@ -42,7 +42,7 @@ public class GuiSlotModList extends ExtendedList<GuiSlotModList.ModEntry>
 
     public GuiSlotModList(GuiModList parent, int listWidth)
     {
-        super(parent.getMinecraftInstance(), listWidth, parent.height, 32, parent.height - 67 + 4, parent.getFontRenderer().FONT_HEIGHT * 2 + 8);
+        super(parent.getMinecraftInstance(), listWidth, parent.height, 32, parent.height - 91 + 4, parent.getFontRenderer().FONT_HEIGHT * 2 + 8);
         this.parent = parent;
         this.listWidth = listWidth;
         this.refreshList();

--- a/src/main/resources/assets/forge/lang/en_us.json
+++ b/src/main/resources/assets/forge/lang/en_us.json
@@ -6,6 +6,7 @@
   "fml.menu.mods.a_to_z": "A-Z",
   "fml.menu.mods.z_to_a": "Z-A",
   "fml.menu.mods.config": "Config",
+  "fml.menu.mods.openmodsfolder": "Open mods folder",
   "fml.menu.modoptions": "Mod Options...",
   "fml.menu.mods.info.version":"Version: {0}",
   "fml.menu.mods.info.idstate":"ModID: {0} State:{1,lower}",


### PR DESCRIPTION
Simple cosmetic fix
I think this button existed in a previous version of forge, if it was removed for a reason I apologize
I though it was fitting since there also is a button to open the resourcepacks folder..

![Before](https://imgur.com/m9MxB2j.png)
![After](https://imgur.com/VSqVcYF.png)