### PR TITLE
Fix CME when unloading tickets as of chunk unload in FarmlandWaterManager 

### DIFF
--- a/src/main/java/net/minecraftforge/common/ticket/ITicketGetter.java
+++ b/src/main/java/net/minecraftforge/common/ticket/ITicketGetter.java
@@ -24,4 +24,10 @@ import java.util.Collection;
 public interface ITicketGetter<T> extends ITicketManager<T>
 {
     Collection<SimpleTicket<T>> getTickets();
+
+    /**
+     * This is only for the managing system to completely invalidate a ticket manager from the system.
+     * Don't call this from tickets
+     */
+    void destroy();
 }

--- a/src/main/java/net/minecraftforge/common/ticket/ITicketManager.java
+++ b/src/main/java/net/minecraftforge/common/ticket/ITicketManager.java
@@ -24,4 +24,6 @@ public interface ITicketManager<T>
     void add(SimpleTicket<T> ticket);
 
     void remove(SimpleTicket<T> ticket);
+
+    boolean isDestroyed();
 }


### PR DESCRIPTION
Also adds support to remove the entire ChunkTicketManager when the chunk is unloaded. For this, we need a new flag to tell the ticket to refetch the manager, and need to switch to suppliers so the ticket can refresh it's local cache when needed.