### PR TITLE
Change ModLoadingException to display ModID

### DIFF
--- a/src/main/java/net/minecraftforge/fml/ModLoadingException.java
+++ b/src/main/java/net/minecraftforge/fml/ModLoadingException.java
@@ -53,7 +53,7 @@ public class ModLoadingException extends RuntimeException
     private final List<Object> context;
 
     public ModLoadingException(final IModInfo modInfo, final ModLoadingStage errorStage, final String i18nMessage, final Throwable originalException, Object... context) {
-        super("Mod Loading Exception : " + i18nMessage + " " + Arrays.toString(Streams.concat(Stream.of(modInfo, errorStage, originalException), Stream.of(context)).toArray()), originalException);
+        super("Mod Loading Exception : " + i18nMessage + " " + Arrays.toString(Streams.concat(Stream.of(modInfo.getModId(), errorStage, originalException), Stream.of(context)).toArray()), originalException);
         this.modInfo = modInfo;
         this.errorStage = errorStage;
         this.i18nMessage = i18nMessage;
@@ -73,6 +73,6 @@ public class ModLoadingException extends RuntimeException
     }
 
     public String formatToString() {
-        return ForgeI18n.parseMessage(i18nMessage, Streams.concat(Stream.of(modInfo, errorStage, getCause()), context.stream()).toArray());
+        return ForgeI18n.parseMessage(i18nMessage, Streams.concat(Stream.of(modInfo.getModId(), errorStage, getCause()), context.stream()).toArray());
     }
 }


### PR DESCRIPTION
Change ModLoadingException to display ModID instead of ModInfo instance identifier.