### PR TITLE
Bring back the ITeleporter interface

### DIFF
--- a/patches/minecraft/net/minecraft/entity/Entity.java.patch
+++ b/patches/minecraft/net/minecraft/entity/Entity.java.patch
@@ -212,16 +212,35 @@
        }
     }
  
-@@ -2063,6 +2092,7 @@
+@@ -2063,33 +2092,32 @@
  
     @Nullable
     public Entity func_212321_a(DimensionType p_212321_1_) {
-+      if (!net.minecraftforge.common.ForgeHooks.onTravelToDimension(this, p_212321_1_)) return null;
++      return changeDimension(p_212321_1_, func_184102_h().func_71218_a(p_212321_1_).func_85176_s());
++   }
++
++   @Nullable
++   public Entity changeDimension(DimensionType destination, net.minecraftforge.common.util.ITeleporter teleporter) {
++      if (!net.minecraftforge.common.ForgeHooks.onTravelToDimension(this, destination)) return null;
        if (!this.field_70170_p.field_72995_K && !this.field_70128_L) {
           this.field_70170_p.func_217381_Z().func_76320_a("changeDimension");
           MinecraftServer minecraftserver = this.func_184102_h();
-@@ -2080,16 +2110,9 @@
-          } else if (p_212321_1_ == DimensionType.field_223229_c_) {
+          DimensionType dimensiontype = this.field_71093_bK;
+          ServerWorld serverworld = minecraftserver.func_71218_a(dimensiontype);
+-         ServerWorld serverworld1 = minecraftserver.func_71218_a(p_212321_1_);
+-         this.field_71093_bK = p_212321_1_;
++         ServerWorld serverworld1 = minecraftserver.func_71218_a(destination);
++         this.field_71093_bK = destination;
+          this.func_213319_R();
+          this.field_70170_p.func_217381_Z().func_76320_a("reposition");
+          Vec3d vec3d = this.func_213322_ci();
+          float f = 0.0F;
+          BlockPos blockpos;
+-         if (dimensiontype == DimensionType.field_223229_c_ && p_212321_1_ == DimensionType.field_223227_a_) {
++         if (dimensiontype == DimensionType.field_223229_c_ && destination == DimensionType.field_223227_a_) {
+             blockpos = serverworld1.func_205770_a(Heightmap.Type.MOTION_BLOCKING_NO_LEAVES, serverworld1.func_175694_M());
+-         } else if (p_212321_1_ == DimensionType.field_223229_c_) {
++         } else if (destination == DimensionType.field_223229_c_) {
              blockpos = serverworld1.func_180504_m();
           } else {
 -            double d0 = this.field_70165_t;
@@ -240,7 +259,41 @@
  
              double d3 = Math.min(-2.9999872E7D, serverworld1.func_175723_af().func_177726_b() + 16.0D);
              double d4 = Math.min(-2.9999872E7D, serverworld1.func_175723_af().func_177736_c() + 16.0D);
-@@ -2118,7 +2141,7 @@
+@@ -2099,26 +2127,32 @@
+             d1 = MathHelper.func_151237_a(d1, d4, d6);
+             Vec3d vec3d1 = this.func_181014_aG();
+             blockpos = new BlockPos(d0, this.field_70163_u, d1);
+-            BlockPattern.PortalInfo blockpattern$portalinfo = serverworld1.func_85176_s().func_222272_a(blockpos, vec3d, this.func_181012_aH(), vec3d1.field_72450_a, vec3d1.field_72448_b, this instanceof PlayerEntity);
+-            if (blockpattern$portalinfo == null) {
+-               return null;
+-            }
++            if (teleporter.isVanilla()) {
++               BlockPattern.PortalInfo blockpattern$portalinfo = ((net.minecraft.world.Teleporter) teleporter).func_222272_a(blockpos, vec3d, this.func_181012_aH(), vec3d1.field_72450_a, vec3d1.field_72448_b, this instanceof PlayerEntity);
++               if (blockpattern$portalinfo == null) {
++                  return null;
++               }
+ 
+-            blockpos = new BlockPos(blockpattern$portalinfo.field_222505_a);
+-            vec3d = blockpattern$portalinfo.field_222506_b;
+-            f = (float)blockpattern$portalinfo.field_222507_c;
++               blockpos = new BlockPos(blockpattern$portalinfo.field_222505_a);
++               vec3d = blockpattern$portalinfo.field_222506_b;
++               f = (float) blockpattern$portalinfo.field_222507_c;
++            } else {
++               teleporter.placeEntity(this, serverworld, serverworld1, this.field_70177_z);
++            }
+          }
+ 
+          this.field_70170_p.func_217381_Z().func_219895_b("reloading");
+          Entity entity = this.func_200600_R().func_200721_a(serverworld1);
+          if (entity != null) {
+             entity.func_180432_n(this);
+-            entity.func_174828_a(blockpos, entity.field_70177_z + f, entity.field_70125_A);
+-            entity.func_213317_d(vec3d);
++            if (teleporter.isVanilla()) {
++               entity.func_174828_a(blockpos, entity.field_70177_z + f, entity.field_70125_A);
++               entity.func_213317_d(vec3d);
++            }
              serverworld1.func_217460_e(entity);
           }
  
@@ -249,7 +302,7 @@
           this.field_70170_p.func_217381_Z().func_76319_b();
           serverworld.func_82742_i();
           serverworld1.func_82742_i();
-@@ -2146,10 +2169,12 @@
+@@ -2146,10 +2180,12 @@
     }
  
     public Vec3d func_181014_aG() {
@@ -262,7 +315,7 @@
        return this.field_181018_ap;
     }
  
-@@ -2274,7 +2299,7 @@
+@@ -2274,7 +2310,7 @@
        Pose pose = this.func_213283_Z();
        EntitySize entitysize1 = this.func_213305_a(pose);
        this.field_213325_aI = entitysize1;
@@ -271,7 +324,7 @@
        if (entitysize1.field_220315_a < entitysize.field_220315_a) {
           double d0 = (double)entitysize1.field_220315_a / 2.0D;
           this.func_174826_a(new AxisAlignedBB(this.field_70165_t - d0, this.field_70163_u, this.field_70161_v - d0, this.field_70165_t + d0, this.field_70163_u + (double)entitysize1.field_220316_b, this.field_70161_v + d0));
-@@ -2641,6 +2666,7 @@
+@@ -2641,6 +2677,7 @@
        return this.field_211517_W;
     }
  
@@ -279,7 +332,7 @@
     public final float func_213311_cf() {
        return this.field_213325_aI.field_220315_a;
     }
-@@ -2670,4 +2696,69 @@
+@@ -2670,4 +2707,69 @@
     public void func_213293_j(double p_213293_1_, double p_213293_3_, double p_213293_5_) {
        this.func_213317_d(new Vec3d(p_213293_1_, p_213293_3_, p_213293_5_));
     }

--- a/patches/minecraft/net/minecraft/entity/Entity.java.patch
+++ b/patches/minecraft/net/minecraft/entity/Entity.java.patch
@@ -212,7 +212,7 @@
        }
     }
  
-@@ -2063,33 +2092,32 @@
+@@ -2063,6 +2092,12 @@
  
     @Nullable
     public Entity func_212321_a(DimensionType p_212321_1_) {
@@ -220,27 +220,13 @@
 +   }
 +
 +   @Nullable
-+   public Entity changeDimension(DimensionType destination, net.minecraftforge.common.util.ITeleporter teleporter) {
-+      if (!net.minecraftforge.common.ForgeHooks.onTravelToDimension(this, destination)) return null;
++   public Entity changeDimension(DimensionType p_212321_1_, net.minecraftforge.common.util.ITeleporter teleporter) {
++      if (!net.minecraftforge.common.ForgeHooks.onTravelToDimension(this, p_212321_1_)) return null;
        if (!this.field_70170_p.field_72995_K && !this.field_70128_L) {
           this.field_70170_p.func_217381_Z().func_76320_a("changeDimension");
           MinecraftServer minecraftserver = this.func_184102_h();
-          DimensionType dimensiontype = this.field_71093_bK;
-          ServerWorld serverworld = minecraftserver.func_71218_a(dimensiontype);
--         ServerWorld serverworld1 = minecraftserver.func_71218_a(p_212321_1_);
--         this.field_71093_bK = p_212321_1_;
-+         ServerWorld serverworld1 = minecraftserver.func_71218_a(destination);
-+         this.field_71093_bK = destination;
-          this.func_213319_R();
-          this.field_70170_p.func_217381_Z().func_76320_a("reposition");
-          Vec3d vec3d = this.func_213322_ci();
-          float f = 0.0F;
-          BlockPos blockpos;
--         if (dimensiontype == DimensionType.field_223229_c_ && p_212321_1_ == DimensionType.field_223227_a_) {
-+         if (dimensiontype == DimensionType.field_223229_c_ && destination == DimensionType.field_223227_a_) {
-             blockpos = serverworld1.func_205770_a(Heightmap.Type.MOTION_BLOCKING_NO_LEAVES, serverworld1.func_175694_M());
--         } else if (p_212321_1_ == DimensionType.field_223229_c_) {
-+         } else if (destination == DimensionType.field_223229_c_) {
+@@ -2080,16 +2115,9 @@
+          } else if (p_212321_1_ == DimensionType.field_223229_c_) {
              blockpos = serverworld1.func_180504_m();
           } else {
 -            double d0 = this.field_70165_t;

--- a/patches/minecraft/net/minecraft/entity/player/ServerPlayerEntity.java.patch
+++ b/patches/minecraft/net/minecraft/entity/player/ServerPlayerEntity.java.patch
@@ -17,18 +17,33 @@
                 BlockPos blockpos = new BlockPos(this.field_70165_t, this.field_70163_u, this.field_70161_v);
                 BlockState blockstate = Blocks.field_222388_bz.func_176223_P();
                 if (this.field_70170_p.func_180495_p(blockpos).func_196958_f() && blockstate.func_196955_c(this.field_70170_p, blockpos)) {
-@@ -568,8 +569,10 @@
+@@ -568,11 +569,13 @@
        return this.field_71133_b.func_71219_W();
     }
  
 +   @Override
     @Nullable
-    public Entity func_212321_a(DimensionType p_212321_1_) {
-+      if (!net.minecraftforge.common.ForgeHooks.onTravelToDimension(this, p_212321_1_)) return null;
+-   public Entity func_212321_a(DimensionType p_212321_1_) {
++   public Entity changeDimension(DimensionType destination, net.minecraftforge.common.util.ITeleporter teleporter) {
++      if (!net.minecraftforge.common.ForgeHooks.onTravelToDimension(this, destination)) return null;
        this.field_184851_cj = true;
        DimensionType dimensiontype = this.field_71093_bK;
-       if (dimensiontype == DimensionType.field_223229_c_ && p_212321_1_ == DimensionType.field_223227_a_) {
-@@ -591,8 +594,8 @@
+-      if (dimensiontype == DimensionType.field_223229_c_ && p_212321_1_ == DimensionType.field_223227_a_) {
++      if (dimensiontype == DimensionType.field_223229_c_ && destination == DimensionType.field_223227_a_) {
+          this.func_213319_R();
+          this.func_71121_q().func_217434_e(this);
+          if (!this.field_71136_j) {
+@@ -584,15 +587,15 @@
+          return this;
+       } else {
+          ServerWorld serverworld = this.field_71133_b.func_71218_a(dimensiontype);
+-         this.field_71093_bK = p_212321_1_;
+-         ServerWorld serverworld1 = this.field_71133_b.func_71218_a(p_212321_1_);
++         this.field_71093_bK = destination;
++         ServerWorld serverworld1 = this.field_71133_b.func_71218_a(destination);
+          WorldInfo worldinfo = this.field_70170_p.func_72912_H();
+-         this.field_71135_a.func_147359_a(new SRespawnPacket(p_212321_1_, worldinfo.func_76067_t(), this.field_71134_c.func_73081_b()));
++         this.field_71135_a.func_147359_a(new SRespawnPacket(destination, worldinfo.func_76067_t(), this.field_71134_c.func_73081_b()));
           this.field_71135_a.func_147359_a(new SServerDifficultyPacket(worldinfo.func_176130_y(), worldinfo.func_176123_z()));
           PlayerList playerlist = this.field_71133_b.func_184103_al();
           playerlist.func_187243_f(this);
@@ -39,28 +54,53 @@
           double d0 = this.field_70165_t;
           double d1 = this.field_70163_u;
           double d2 = this.field_70161_v;
-@@ -601,13 +604,11 @@
+@@ -601,14 +604,12 @@
           double d3 = 8.0D;
           float f2 = f1;
           serverworld.func_217381_Z().func_76320_a("moving");
+-         if (dimensiontype == DimensionType.field_223227_a_ && p_212321_1_ == DimensionType.field_223228_b_) {
 +         double moveFactor = serverworld.func_201675_m().getMovementFactor() / serverworld1.func_201675_m().getMovementFactor();
 +         d0 *= moveFactor;
 +         d2 *= moveFactor;
-          if (dimensiontype == DimensionType.field_223227_a_ && p_212321_1_ == DimensionType.field_223228_b_) {
++         if (dimensiontype == DimensionType.field_223227_a_ && destination == DimensionType.field_223228_b_) {
              this.field_193110_cw = new Vec3d(this.field_70165_t, this.field_70163_u, this.field_70161_v);
 -            d0 /= 8.0D;
 -            d2 /= 8.0D;
 -         } else if (dimensiontype == DimensionType.field_223228_b_ && p_212321_1_ == DimensionType.field_223227_a_) {
 -            d0 *= 8.0D;
 -            d2 *= 8.0D;
-          } else if (dimensiontype == DimensionType.field_223227_a_ && p_212321_1_ == DimensionType.field_223229_c_) {
+-         } else if (dimensiontype == DimensionType.field_223227_a_ && p_212321_1_ == DimensionType.field_223229_c_) {
++         } else if (dimensiontype == DimensionType.field_223227_a_ && destination == DimensionType.field_223229_c_) {
              BlockPos blockpos = serverworld1.func_180504_m();
              d0 = (double)blockpos.func_177958_n();
+             d1 = (double)blockpos.func_177956_o();
+@@ -627,7 +628,7 @@
+          d0 = MathHelper.func_151237_a(d0, d7, d5);
+          d2 = MathHelper.func_151237_a(d2, d4, d6);
+          this.func_70012_b(d0, d1, d2, f1, f);
+-         if (p_212321_1_ == DimensionType.field_223229_c_) {
++         if (destination == DimensionType.field_223229_c_) {
+             int i = MathHelper.func_76128_c(this.field_70165_t);
+             int j = MathHelper.func_76128_c(this.field_70163_u) - 1;
+             int k = MathHelper.func_76128_c(this.field_70161_v);
+@@ -648,9 +649,9 @@
+ 
+             this.func_70012_b((double)i, (double)j, (double)k, f1, 0.0F);
+             this.func_213317_d(Vec3d.field_186680_a);
+-         } else if (!serverworld1.func_85176_s().func_222268_a(this, f2)) {
+-            serverworld1.func_85176_s().func_85188_a(this);
+-            serverworld1.func_85176_s().func_222268_a(this, f2);
++         } else if (!teleporter.placeEntity(this, serverworld, serverworld1, f2) && teleporter.isVanilla()) {
++            ((net.minecraft.world.Teleporter) teleporter).func_85188_a(this);
++            teleporter.placeEntity(this, serverworld, serverworld1, f2);
+          }
+ 
+          serverworld.func_217381_Z().func_76319_b();
 @@ -671,6 +672,7 @@
           this.field_71144_ck = -1;
           this.field_71149_ch = -1.0F;
           this.field_71146_ci = -1;
-+         net.minecraftforge.fml.hooks.BasicEventHooks.firePlayerChangedDimensionEvent(this, dimensiontype, p_212321_1_);
++         net.minecraftforge.fml.hooks.BasicEventHooks.firePlayerChangedDimensionEvent(this, dimensiontype, destination);
           return this;
        }
     }

--- a/patches/minecraft/net/minecraft/entity/player/ServerPlayerEntity.java.patch
+++ b/patches/minecraft/net/minecraft/entity/player/ServerPlayerEntity.java.patch
@@ -17,33 +17,19 @@
                 BlockPos blockpos = new BlockPos(this.field_70165_t, this.field_70163_u, this.field_70161_v);
                 BlockState blockstate = Blocks.field_222388_bz.func_176223_P();
                 if (this.field_70170_p.func_180495_p(blockpos).func_196958_f() && blockstate.func_196955_c(this.field_70170_p, blockpos)) {
-@@ -568,11 +569,13 @@
+@@ -568,8 +569,10 @@
        return this.field_71133_b.func_71219_W();
     }
  
 +   @Override
     @Nullable
 -   public Entity func_212321_a(DimensionType p_212321_1_) {
-+   public Entity changeDimension(DimensionType destination, net.minecraftforge.common.util.ITeleporter teleporter) {
-+      if (!net.minecraftforge.common.ForgeHooks.onTravelToDimension(this, destination)) return null;
++   public Entity changeDimension(DimensionType p_212321_1_, net.minecraftforge.common.util.ITeleporter teleporter) {
++      if (!net.minecraftforge.common.ForgeHooks.onTravelToDimension(this, p_212321_1_)) return null;
        this.field_184851_cj = true;
        DimensionType dimensiontype = this.field_71093_bK;
--      if (dimensiontype == DimensionType.field_223229_c_ && p_212321_1_ == DimensionType.field_223227_a_) {
-+      if (dimensiontype == DimensionType.field_223229_c_ && destination == DimensionType.field_223227_a_) {
-          this.func_213319_R();
-          this.func_71121_q().func_217434_e(this);
-          if (!this.field_71136_j) {
-@@ -584,15 +587,15 @@
-          return this;
-       } else {
-          ServerWorld serverworld = this.field_71133_b.func_71218_a(dimensiontype);
--         this.field_71093_bK = p_212321_1_;
--         ServerWorld serverworld1 = this.field_71133_b.func_71218_a(p_212321_1_);
-+         this.field_71093_bK = destination;
-+         ServerWorld serverworld1 = this.field_71133_b.func_71218_a(destination);
-          WorldInfo worldinfo = this.field_70170_p.func_72912_H();
--         this.field_71135_a.func_147359_a(new SRespawnPacket(p_212321_1_, worldinfo.func_76067_t(), this.field_71134_c.func_73081_b()));
-+         this.field_71135_a.func_147359_a(new SRespawnPacket(destination, worldinfo.func_76067_t(), this.field_71134_c.func_73081_b()));
+       if (dimensiontype == DimensionType.field_223229_c_ && p_212321_1_ == DimensionType.field_223227_a_) {
+@@ -591,8 +594,8 @@
           this.field_71135_a.func_147359_a(new SServerDifficultyPacket(worldinfo.func_176130_y(), worldinfo.func_176123_z()));
           PlayerList playerlist = this.field_71133_b.func_184103_al();
           playerlist.func_187243_f(this);
@@ -54,35 +40,23 @@
           double d0 = this.field_70165_t;
           double d1 = this.field_70163_u;
           double d2 = this.field_70161_v;
-@@ -601,14 +604,12 @@
+@@ -601,13 +604,11 @@
           double d3 = 8.0D;
           float f2 = f1;
           serverworld.func_217381_Z().func_76320_a("moving");
--         if (dimensiontype == DimensionType.field_223227_a_ && p_212321_1_ == DimensionType.field_223228_b_) {
 +         double moveFactor = serverworld.func_201675_m().getMovementFactor() / serverworld1.func_201675_m().getMovementFactor();
 +         d0 *= moveFactor;
 +         d2 *= moveFactor;
-+         if (dimensiontype == DimensionType.field_223227_a_ && destination == DimensionType.field_223228_b_) {
+          if (dimensiontype == DimensionType.field_223227_a_ && p_212321_1_ == DimensionType.field_223228_b_) {
              this.field_193110_cw = new Vec3d(this.field_70165_t, this.field_70163_u, this.field_70161_v);
 -            d0 /= 8.0D;
 -            d2 /= 8.0D;
 -         } else if (dimensiontype == DimensionType.field_223228_b_ && p_212321_1_ == DimensionType.field_223227_a_) {
 -            d0 *= 8.0D;
 -            d2 *= 8.0D;
--         } else if (dimensiontype == DimensionType.field_223227_a_ && p_212321_1_ == DimensionType.field_223229_c_) {
-+         } else if (dimensiontype == DimensionType.field_223227_a_ && destination == DimensionType.field_223229_c_) {
+          } else if (dimensiontype == DimensionType.field_223227_a_ && p_212321_1_ == DimensionType.field_223229_c_) {
              BlockPos blockpos = serverworld1.func_180504_m();
              d0 = (double)blockpos.func_177958_n();
-             d1 = (double)blockpos.func_177956_o();
-@@ -627,7 +628,7 @@
-          d0 = MathHelper.func_151237_a(d0, d7, d5);
-          d2 = MathHelper.func_151237_a(d2, d4, d6);
-          this.func_70012_b(d0, d1, d2, f1, f);
--         if (p_212321_1_ == DimensionType.field_223229_c_) {
-+         if (destination == DimensionType.field_223229_c_) {
-             int i = MathHelper.func_76128_c(this.field_70165_t);
-             int j = MathHelper.func_76128_c(this.field_70163_u) - 1;
-             int k = MathHelper.func_76128_c(this.field_70161_v);
 @@ -648,9 +649,9 @@
  
              this.func_70012_b((double)i, (double)j, (double)k, f1, 0.0F);
@@ -100,7 +74,7 @@
           this.field_71144_ck = -1;
           this.field_71149_ch = -1.0F;
           this.field_71146_ci = -1;
-+         net.minecraftforge.fml.hooks.BasicEventHooks.firePlayerChangedDimensionEvent(this, dimensiontype, destination);
++         net.minecraftforge.fml.hooks.BasicEventHooks.firePlayerChangedDimensionEvent(this, dimensiontype, p_212321_1_);
           return this;
        }
     }

--- a/patches/minecraft/net/minecraft/world/Teleporter.java.patch
+++ b/patches/minecraft/net/minecraft/world/Teleporter.java.patch
@@ -1,0 +1,28 @@
+--- a/net/minecraft/world/Teleporter.java
++++ b/net/minecraft/world/Teleporter.java
+@@ -25,11 +25,12 @@
+ import net.minecraft.world.dimension.Dimension;
+ import net.minecraft.world.server.ServerWorld;
+ import net.minecraft.world.server.TicketType;
++import net.minecraftforge.common.util.ITeleporter;
+ import org.apache.logging.log4j.LogManager;
+ import org.apache.logging.log4j.Logger;
+ import org.apache.logging.log4j.util.Supplier;
+ 
+-public class Teleporter {
++public class Teleporter implements ITeleporter {
+    private static final Logger field_222274_a = LogManager.getLogger();
+    private static final NetherPortalBlock field_196236_a = (NetherPortalBlock)Blocks.field_150427_aO;
+    protected final ServerWorld field_85192_a;
+@@ -42,6 +43,11 @@
+       this.field_77187_a = new Random(p_i1963_1_.func_72905_C());
+    }
+ 
++   @Override
++   public boolean placeEntity(Entity entity, ServerWorld currentWorld, ServerWorld destWorld, float yaw) {
++      return func_222268_a(entity, yaw);
++   }
++
+    public boolean func_222268_a(Entity p_222268_1_, float p_222268_2_) {
+       Vec3d vec3d = p_222268_1_.func_181014_aG();
+       Direction direction = p_222268_1_.func_181012_aH();

--- a/src/main/java/net/minecraftforge/common/util/ITeleporter.java
+++ b/src/main/java/net/minecraftforge/common/util/ITeleporter.java
@@ -1,0 +1,61 @@
+/*
+ * Minecraft Forge
+ * Copyright (c) 2016-2019.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation version 2.1
+ * of the License.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+package net.minecraftforge.common.util;
+
+import net.minecraft.entity.Entity;
+import net.minecraft.world.Teleporter;
+import net.minecraft.world.dimension.Dimension;
+import net.minecraft.world.server.ServerWorld;
+
+/**
+ * Interface for handling the placement of entities during dimension change.
+ *
+ * An implementation of this interface can be used to place the entity
+ * in a safe location, or generate a return portal, for instance.
+ *
+ * See the {@link net.minecraft.world.Teleporter} class, which has
+ * been patched to implement this interface, for a vanilla example.
+ */
+public interface ITeleporter {
+
+    /**
+     * Called to handle placing the entity in the new world.
+     *
+     * The initial position of the entity will be its
+     * position in the origin world, multiplied horizontally
+     * by the computed cross-dimensional movement factor
+     * (see {@link Dimension#getMovementFactor()}).
+     *
+     * Note that the supplied entity has not yet been spawned
+     * in the destination world at the time.
+     *
+     * @param entity       the entity to be placed
+     * @param currentWorld the entity's origin
+     * @param destWorld    the entity's destination
+     * @param yaw          the suggested yaw value to apply
+     */
+    boolean placeEntity(Entity entity, ServerWorld currentWorld, ServerWorld destWorld, float yaw);
+
+    // used internally to handle vanilla hardcoding
+    default boolean isVanilla()
+    {
+        return this instanceof Teleporter;
+    }
+}

--- a/src/main/resources/forge.exc
+++ b/src/main/resources/forge.exc
@@ -31,6 +31,8 @@ net/minecraft/client/resources/ClientResourcePackInfo.<init>(Ljava/lang/String;Z
 net/minecraft/client/gui/ScreenManager.getScreenFactory(Lnet/minecraft/inventory/container/ContainerType;Lnet/minecraft/client/Minecraft;ILnet/minecraft/util/text/ITextComponent;)Ljava/util/Optional;=|p_216909_0_,p_216909_1_,p_216909_2_,p_216909_3_
 net/minecraft/entity/EntityClassification.create(Ljava/lang/String;Ljava/lang/String;IZZ)Lnet/minecraft/entity/EntityClassification;=|name,p_i50381_3_,p_i50381_4_,p_i50381_5_,p_i50381_6_
 
+net/minecraft/entity/Entity.changeDimension(Lnet/minecraft/world/dimension/DimensionType;Lnet.minecraftforge.common.util.ITeleporter;)Lnet/minecraft/entity/Entity;=|p_212321_1_,teleporter
+
 net/minecraft/entity/player/PlayerEntity.getDigSpeed(Lnet/minecraft/block/BlockState;Lnet/minecraft/util/math/BlockPos;)F=|p_184813_1_,pos
 
 net/minecraft/item/Rarity.create(Ljava/lang/String;Lnet/minecraft/util/text/TextFormatting;)Lnet/minecraft/item/EnumRarity;=|name,p_i48837_3_


### PR DESCRIPTION
The implementation is very similar to the implementation on 1.12.x. The only change is that the placeEntity method has two new parameters: the ServerWorld objects of the origin and destination dimensions. This makes it easier to build exit portals and break entry portals if the modder needs to do so. 

All the code is backwards-compatible:
 * Mods that were extending Teleporter will still work as expected (Teleporter instances are treated as vanilla ITeleporters)
 * Mods that copied the changeDimension method to modify it will still work as expected (Their code stays unchanged)

In both cases migrating to the ITeleporter approach should be easy and straightforward.

If I any change is required let me know it and I will solve it as soon as possible.

Resolves #5990