### PR TITLE
Make vanilla particle system usable by mods

### DIFF
--- a/patches/minecraft/net/minecraft/client/particle/ParticleManager.java.patch
+++ b/patches/minecraft/net/minecraft/client/particle/ParticleManager.java.patch
@@ -1,6 +1,37 @@
 --- a/net/minecraft/client/particle/ParticleManager.java
 +++ b/net/minecraft/client/particle/ParticleManager.java
-@@ -235,6 +235,7 @@
+@@ -63,7 +63,7 @@
+    private final Queue<EmitterParticle> field_178933_d = Queues.newArrayDeque();
+    private final TextureManager field_78877_c;
+    private final Random field_78875_d = new Random();
+-   private final Int2ObjectMap<IParticleFactory<?>> field_178932_g = new Int2ObjectOpenHashMap<>();
++   private final Map<ResourceLocation, IParticleFactory<?>> field_178932_g = new java.util.HashMap<>();
+    private final Queue<Particle> field_187241_h = Queues.newArrayDeque();
+    private final Map<ResourceLocation, ParticleManager.AnimatedSpriteImpl> field_215242_i = Maps.newHashMap();
+    private final AtlasTexture field_215243_j = new AtlasTexture("textures/particle");
+@@ -137,13 +137,13 @@
+    }
+ 
+    public <T extends IParticleData> void func_199283_a(ParticleType<T> p_199283_1_, IParticleFactory<T> p_199283_2_) {
+-      this.field_178932_g.put(Registry.field_212632_u.func_148757_b(p_199283_1_), p_199283_2_);
++      this.field_178932_g.put(Registry.field_212632_u.func_177774_c(p_199283_1_), p_199283_2_);
+    }
+ 
+    public <T extends IParticleData> void func_215234_a(ParticleType<T> p_215234_1_, ParticleManager.IParticleMetaFactory<T> p_215234_2_) {
+       ParticleManager.AnimatedSpriteImpl particlemanager$animatedspriteimpl = new ParticleManager.AnimatedSpriteImpl();
+       this.field_215242_i.put(Registry.field_212632_u.func_177774_c(p_215234_1_), particlemanager$animatedspriteimpl);
+-      this.field_178932_g.put(Registry.field_212632_u.func_148757_b(p_215234_1_), p_215234_2_.create(particlemanager$animatedspriteimpl));
++      this.field_178932_g.put(Registry.field_212632_u.func_177774_c(p_215234_1_), p_215234_2_.create(particlemanager$animatedspriteimpl));
+    }
+ 
+    public CompletableFuture<Void> func_215226_a(IFutureReloadListener.IStage p_215226_1_, IResourceManager p_215226_2_, IProfiler p_215226_3_, IProfiler p_215226_4_, Executor p_215226_5_, Executor p_215226_6_) {
+@@ -230,11 +230,12 @@
+ 
+    @Nullable
+    private <T extends IParticleData> Particle func_199927_b(T p_199927_1_, double p_199927_2_, double p_199927_4_, double p_199927_6_, double p_199927_8_, double p_199927_10_, double p_199927_12_) {
+-      IParticleFactory<T> iparticlefactory = (IParticleFactory<T>) this.field_178932_g.get(Registry.field_212632_u.func_148757_b(p_199927_1_.func_197554_b()));
++      IParticleFactory<T> iparticlefactory = (IParticleFactory<T>) this.field_178932_g.get(Registry.field_212632_u.func_177774_c(p_199927_1_.func_197554_b()));
+       return iparticlefactory == null ? null : iparticlefactory.func_199234_a(p_199927_1_, this.field_78878_a, p_199927_2_, p_199927_4_, p_199927_6_, p_199927_8_, p_199927_10_, p_199927_12_);
     }
  
     public void func_78873_a(Particle p_78873_1_) {

--- a/patches/minecraft/net/minecraft/client/particle/ParticleManager.java.patch
+++ b/patches/minecraft/net/minecraft/client/particle/ParticleManager.java.patch
@@ -13,7 +13,7 @@
        this.func_215234_a(ParticleTypes.field_197605_P, UnderwaterParticle.Factory::new);
        this.func_215234_a(ParticleTypes.field_218422_X, SplashParticle.Factory::new);
        this.func_215234_a(ParticleTypes.field_197607_R, SpellParticle.WitchFactory::new);
-+      net.minecraftforge.common.MinecraftForge.EVENT_BUS.post(new net.minecraftforge.client.event.ParticleRegistryEvent());
++      net.minecraftforge.common.MinecraftForge.EVENT_BUS.post(new net.minecraftforge.client.event.ParticleFactoryRegisterEvent());
     }
  
     public <T extends IParticleData> void func_199283_a(ParticleType<T> p_199283_1_, IParticleFactory<T> p_199283_2_) {

--- a/patches/minecraft/net/minecraft/client/particle/ParticleManager.java.patch
+++ b/patches/minecraft/net/minecraft/client/particle/ParticleManager.java.patch
@@ -9,7 +9,11 @@
     private final Queue<Particle> field_187241_h = Queues.newArrayDeque();
     private final Map<ResourceLocation, ParticleManager.AnimatedSpriteImpl> field_215242_i = Maps.newHashMap();
     private final AtlasTexture field_215243_j = new AtlasTexture("textures/particle");
-@@ -137,13 +137,13 @@
+@@ -134,16 +134,17 @@
+       this.func_215234_a(ParticleTypes.field_197605_P, UnderwaterParticle.Factory::new);
+       this.func_215234_a(ParticleTypes.field_218422_X, SplashParticle.Factory::new);
+       this.func_215234_a(ParticleTypes.field_197607_R, SpellParticle.WitchFactory::new);
++      net.minecraftforge.common.MinecraftForge.EVENT_BUS.post(new net.minecraftforge.client.event.ParticleRegistryEvent());
     }
  
     public <T extends IParticleData> void func_199283_a(ParticleType<T> p_199283_1_, IParticleFactory<T> p_199283_2_) {
@@ -25,7 +29,7 @@
     }
  
     public CompletableFuture<Void> func_215226_a(IFutureReloadListener.IStage p_215226_1_, IResourceManager p_215226_2_, IProfiler p_215226_3_, IProfiler p_215226_4_, Executor p_215226_5_, Executor p_215226_6_) {
-@@ -230,11 +230,12 @@
+@@ -230,11 +231,12 @@
  
     @Nullable
     private <T extends IParticleData> Particle func_199927_b(T p_199927_1_, double p_199927_2_, double p_199927_4_, double p_199927_6_, double p_199927_8_, double p_199927_10_, double p_199927_12_) {
@@ -39,7 +43,7 @@
        this.field_187241_h.add(p_78873_1_);
     }
  
-@@ -342,7 +343,7 @@
+@@ -342,7 +344,7 @@
     }
  
     public void func_180533_a(BlockPos p_180533_1_, BlockState p_180533_2_) {
@@ -48,7 +52,7 @@
           VoxelShape voxelshape = p_180533_2_.func_196954_c(this.field_78878_a, p_180533_1_);
           double d0 = 0.25D;
           voxelshape.func_197755_b((p_199284_3_, p_199284_5_, p_199284_7_, p_199284_9_, p_199284_11_, p_199284_13_) -> {
-@@ -414,6 +415,12 @@
+@@ -414,6 +416,12 @@
        return String.valueOf(this.field_78876_b.values().stream().mapToInt(Collection::size).sum());
     }
  

--- a/src/main/java/net/minecraftforge/client/event/ParticleFactoryRegisterEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/ParticleFactoryRegisterEvent.java
@@ -7,5 +7,4 @@ import net.minecraftforge.eventbus.api.Event;
  * Note that your {@code ParticleType}s should still be registered during the usual registry events, this
  * is only for the factories.
  */
-public class ParticleRegistryEvent extends Event {
-}
+public class ParticleFactoryRegisterEvent extends Event {}

--- a/src/main/java/net/minecraftforge/client/event/ParticleRegistryEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/ParticleRegistryEvent.java
@@ -1,0 +1,11 @@
+package net.minecraftforge.client.event;
+
+import net.minecraftforge.eventbus.api.Event;
+
+/**
+ * Fired when you should call {@link net.minecraft.client.particle.ParticleManager#registerFactory}.
+ * Note that your {@code ParticleType}s should still be registered during the usual registry events, this
+ * is only for the factories.
+ */
+public class ParticleRegistryEvent extends Event {
+}


### PR DESCRIPTION
1. Closes #5605, makes the factories map keyed by RL instead of integer IDs
Right now the particle types are synced from the server so the integer ID's can shift.
I couldve stored delegates as the key but using RL matches the sprite map and makes for a smaller patch (getId -> getKey in 3 places)

2. Adds an event for registerFactories to be called.
Why? Vanilla expects this to be called at a very specific time, basically between when it calls it and the final resource reload. If you have a particle json (yes, they exist), but the `sprites` field doesn't have a corresponding entry, then you crash. An entry is inserted by calling registerFactories. But calling registerFactories at load complete event is too late because the check/crash happens during resource reload which is before load complete. Any earlier event and the particlemanager doesn't exist yet.