### PR TITLE
Make DimensionManager.SavedEntry save sky light consistently

### DIFF
--- a/src/main/java/net/minecraftforge/common/DimensionManager.java
+++ b/src/main/java/net/minecraftforge/common/DimensionManager.java
@@ -450,7 +450,7 @@ public class DimensionManager
             this.name = new ResourceLocation(data.getString("name"));
             this.type = data.contains("type", 8) ? new ResourceLocation(data.getString("type")) : null;
             this.data = data.contains("data", 7) ? data.getByteArray("data") : null;
-            this.skyLight = data.contains("sky_light", 99) ? data.getByte("sky_light") == 0 : true;
+            this.skyLight = data.contains("sky_light", 99) ? data.getBoolean("sky_light") : true;
         }
 
         private SavedEntry(DimensionType data)
@@ -473,7 +473,7 @@ public class DimensionManager
                 ret.putString("type", type.toString());
             if (data != null)
                 ret.putByteArray("data", data);
-            ret.putByte("sky_light", (byte)(skyLight ? 1 : 0));
+            ret.putBoolean("sky_light", skyLight);
             return ret;
         }
     }


### PR DESCRIPTION
The sky light field in `DimensionManager.SavedEntry` is currently being read as the inverted value of what it is saved as. This problem causes mod dimensions to switch between having and not having sky light each time the world is reloaded.

This pull request solves that problem while also changing relevant function calls to `getBoolean` and `putBoolean` for added clarity.