### PR TITLE
[1.14] Context aware capability access system

### DIFF
--- a/src/main/java/net/minecraftforge/client/model/animation/AnimationItemOverrideList.java
+++ b/src/main/java/net/minecraftforge/client/model/animation/AnimationItemOverrideList.java
@@ -19,8 +19,6 @@
 
 package net.minecraftforge.client.model.animation;
 
-import java.util.List;
-
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.renderer.model.IBakedModel;
 import net.minecraft.client.renderer.model.IUnbakedModel;
@@ -34,15 +32,14 @@ import net.minecraft.item.ItemStack;
 import net.minecraft.util.ResourceLocation;
 import net.minecraft.world.World;
 import net.minecraftforge.client.model.ModelLoader;
-import net.minecraftforge.client.model.ModelLoaderRegistry;
 import net.minecraftforge.client.model.ModelStateComposition;
+import net.minecraftforge.common.capabilities.accessor.ICapabilityAccessor;
 import net.minecraftforge.common.model.IModelState;
 import net.minecraftforge.common.model.animation.CapabilityAnimation;
-import net.minecraftforge.common.model.animation.IAnimationStateMachine;
-
-import java.util.function.Function;
 
 import javax.annotation.Nullable;
+import java.util.List;
+import java.util.function.Function;
 
 public final class AnimationItemOverrideList extends ItemOverrideList
 {
@@ -70,7 +67,7 @@ public final class AnimationItemOverrideList extends ItemOverrideList
     @Override
     public IBakedModel getModelWithOverrides(IBakedModel originalModel, ItemStack stack, @Nullable World world, @Nullable LivingEntity entity)
     {
-        return stack.getCapability(CapabilityAnimation.ANIMATION_CAPABILITY, null)
+        return stack.getCapability(CapabilityAnimation.ANIMATION_CAPABILITY, (ICapabilityAccessor)null)
             .map(asm ->
             {
                 World w = world;

--- a/src/main/java/net/minecraftforge/common/capabilities/CapabilityDispatcher.java
+++ b/src/main/java/net/minecraftforge/common/capabilities/CapabilityDispatcher.java
@@ -19,21 +19,22 @@
 
 package net.minecraftforge.common.capabilities;
 
-import javax.annotation.Nullable;
-import javax.annotation.ParametersAreNonnullByDefault;
-
-import java.util.List;
-import java.util.Map;
-
 import com.google.common.collect.Lists;
-
 import mcp.MethodsReturnNonnullByDefault;
-import net.minecraft.nbt.INBT;
 import net.minecraft.nbt.CompoundNBT;
+import net.minecraft.nbt.INBT;
 import net.minecraft.util.Direction;
 import net.minecraft.util.ResourceLocation;
+import net.minecraftforge.common.capabilities.accessor.CapabilityAccessor;
+import net.minecraftforge.common.capabilities.accessor.ICapabilityAccessor;
 import net.minecraftforge.common.util.INBTSerializable;
 import net.minecraftforge.common.util.LazyOptional;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import javax.annotation.ParametersAreNonnullByDefault;
+import java.util.List;
+import java.util.Map;
 
 /**
  * A high-speed implementation of a capability delegator.
@@ -94,12 +95,19 @@ public final class CapabilityDispatcher implements INBTSerializable<CompoundNBT>
     }
 
 
+    @Nonnull
     @Override
-    public <T> LazyOptional<T> getCapability(Capability<T> cap, @Nullable Direction side)
+    public <T> LazyOptional<T> getCapability(@Nonnull Capability<T> cap, @Nullable Direction side)
+    {
+        return getCapability(cap, CapabilityAccessor.getSide(side));
+    }
+
+    @Override
+    public <T> LazyOptional<T> getCapability(Capability<T> cap, @Nullable ICapabilityAccessor accessor)
     {
         for (ICapabilityProvider c : caps)
         {
-            LazyOptional<T> ret = c.getCapability(cap, side);
+            LazyOptional<T> ret = c.getCapability(cap, accessor);
             //noinspection ConstantConditions
             if (ret == null)
             {

--- a/src/main/java/net/minecraftforge/common/capabilities/CapabilityProvider.java
+++ b/src/main/java/net/minecraftforge/common/capabilities/CapabilityProvider.java
@@ -19,14 +19,17 @@
 
 package net.minecraftforge.common.capabilities;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
-import javax.annotation.ParametersAreNonnullByDefault;
 import mcp.MethodsReturnNonnullByDefault;
 import net.minecraft.nbt.CompoundNBT;
 import net.minecraft.util.Direction;
+import net.minecraftforge.common.capabilities.accessor.CapabilityAccessor;
+import net.minecraftforge.common.capabilities.accessor.ICapabilityAccessor;
 import net.minecraftforge.common.util.LazyOptional;
 import net.minecraftforge.event.ForgeEventFactory;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import javax.annotation.ParametersAreNonnullByDefault;
 
 @MethodsReturnNonnullByDefault
 @ParametersAreNonnullByDefault
@@ -112,9 +115,17 @@ public abstract class CapabilityProvider<B extends CapabilityProvider<B>> implem
 
     @Override
     @Nonnull
+    @Deprecated
     public <T> LazyOptional<T> getCapability(@Nonnull Capability<T> cap, @Nullable Direction side)
     {
+        return getCapability(cap, CapabilityAccessor.getSide(side));
+    }
+
+    @Override
+    @Nonnull
+    public <T> LazyOptional<T> getCapability(@Nonnull Capability<T> cap, @Nullable ICapabilityAccessor accessor)
+    {
         final CapabilityDispatcher disp = getCapabilities();
-        return !valid || disp == null ? LazyOptional.empty() : disp.getCapability(cap, side);
+        return !valid || disp == null ? LazyOptional.empty() : disp.getCapability(cap, accessor);
     }
 }

--- a/src/main/java/net/minecraftforge/common/capabilities/ICapabilityProvider.java
+++ b/src/main/java/net/minecraftforge/common/capabilities/ICapabilityProvider.java
@@ -19,32 +19,54 @@
 
 package net.minecraftforge.common.capabilities;
 
+import net.minecraft.util.Direction;
+import net.minecraftforge.common.capabilities.accessor.CapabilityAccessor;
+import net.minecraftforge.common.capabilities.accessor.ICapabilityAccessor;
+import net.minecraftforge.common.util.LazyOptional;
+
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
-
-import net.minecraft.util.Direction;
-import net.minecraftforge.common.util.LazyOptional;
 
 public interface ICapabilityProvider
 {
     /**
      * Retrieves the Optional handler for the capability requested on the specific side.
      * The return value <strong>CAN</strong> be the same for multiple faces.
+     *
      * Modders are encouraged to cache this value, using the listener capabilities of the Optional to
      * be notified if the requested capability get lost.
      *
-     * @param capability The capability to check
-     * @param facing The Side to check from,
+     * @param cap -  The capability to check
+     * @param side - The Side to check from,
      *   <strong>CAN BE NULL</strong>. Null is defined to represent 'internal' or 'self'
      * @return The requested an optional holding the requested capability.
      */
+    @Deprecated //Remove in 1.15, switch to accessor version
     @Nonnull <T> LazyOptional<T> getCapability(@Nonnull final Capability<T> cap, final @Nullable Direction side);
+
+    /**
+     * Retrieves the Optional handler for the capability requested on the specific side.
+     * The return value <strong>CAN</strong> be the same for multiple faces.
+     *
+     * Modders are encouraged to cache this value, using the listener capabilities of the Optional to
+     * be notified if the requested capability get lost.
+     *
+     * @param cap -  The capability to check
+     * @param accessor - system/style of access of the capability
+     * @return The requested an optional holding the requested capability.
+     */
+    @Nonnull default <T> LazyOptional<T> getCapability(@Nonnull final Capability<T> cap, final @Nullable ICapabilityAccessor accessor) {
+        if(accessor != null) {
+            return getCapability(cap, accessor.getAccessSide());
+        }
+        return getCapability(cap, (Direction)null);
+    }
 
     /*
      * Purely added as a bouncer to sided version, to make modders stop complaining about calling with a null value.
      * This should never be OVERRIDDEN, modders should only ever implement the sided version.
      */
     @Nonnull default <T> LazyOptional<T> getCapability(@Nonnull final Capability<T> cap) {
-        return getCapability(cap, null);
+        return getCapability(cap, CapabilityAccessor.SELF);
     }
 }

--- a/src/main/java/net/minecraftforge/common/capabilities/accessor/CapabilityAccessor.java
+++ b/src/main/java/net/minecraftforge/common/capabilities/accessor/CapabilityAccessor.java
@@ -1,0 +1,81 @@
+package net.minecraftforge.common.capabilities.accessor;
+
+import net.minecraft.util.Direction;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.util.function.Supplier;
+
+/**
+ * Simplified sided accessor for generic retrieval of capabilities per side.
+ * <p>
+ * For those that only care about the side use the constants.
+ *
+ * For those that want to reference the accessor create a new instance
+ * and cache it in the accessing object. For a TileEntity this should be
+ * done to reduce memory churn of repeat access calls.
+ */
+public class CapabilityAccessor<A> implements ICapabilityAccessor<A>
+{
+    //Static versions to reduce churn usage of access that doesn't care about context beyond side
+    public static final CapabilityAccessor SELF = new CapabilityAccessor(null, () -> null);
+    public static final CapabilityAccessor NORTH = new CapabilityAccessor(Direction.NORTH, () -> null);
+    public static final CapabilityAccessor SOUTH = new CapabilityAccessor(Direction.SOUTH, () -> null);
+    public static final CapabilityAccessor EAST = new CapabilityAccessor(Direction.EAST, () -> null);
+    public static final CapabilityAccessor WEST = new CapabilityAccessor(Direction.WEST, () -> null);
+    public static final CapabilityAccessor UP = new CapabilityAccessor(Direction.UP, () -> null);
+    public static final CapabilityAccessor DOWN = new CapabilityAccessor(Direction.DOWN, () -> null);
+
+    //Array to provide looping
+    public static final CapabilityAccessor[] SIDES = new CapabilityAccessor[]{
+            DOWN,
+            UP,
+            NORTH,
+            SOUTH,
+            EAST,
+            WEST
+    };
+
+    /** Side being accessed, can be null to indicate internal access */
+    protected final Direction side;
+    /** Object that is accessing the capability, can be null */
+    protected final Supplier<A> accessor;
+
+    public CapabilityAccessor(@Nullable Direction side, @Nullable Supplier<A> accessor)
+    {
+        this.side = side;
+        this.accessor = accessor;
+    }
+
+    @Nullable
+    @Override
+    public Direction getAccessSide()
+    {
+        return side;
+    }
+
+    @Nullable
+    @Override
+    public A getAccessor()
+    {
+        return accessor.get();
+    }
+
+    /**
+     * Helper to map from a direction to an accessor.
+     * <p>
+     * This works well for anything that may need to
+     * dynamically get the accessor based on a side. As
+     * well a simple solution for iterators.
+     *
+     * @param direction - direction to access
+     * @return accessor instance for the side
+     */
+    public static CapabilityAccessor getSide(@Nonnull Direction direction)
+    {
+        if(direction == null) {
+            return SELF;
+        }
+        return SIDES[direction.ordinal()];
+    }
+}

--- a/src/main/java/net/minecraftforge/common/capabilities/accessor/FlowCapabilityAccessor.java
+++ b/src/main/java/net/minecraftforge/common/capabilities/accessor/FlowCapabilityAccessor.java
@@ -1,0 +1,142 @@
+package net.minecraftforge.common.capabilities.accessor;
+
+import net.minecraft.util.Direction;
+
+import javax.annotation.Nullable;
+import java.util.function.Supplier;
+
+/**
+ * Accessor for capabilities that allow flow of content between two systems.
+ * <p>
+ * Examples: Energy, Fluid, and Items
+ * <p>
+ * Created by Dark(DarkGuardsman, Robert) on 8/4/2019.
+ */
+public class FlowCapabilityAccessor<A> extends CapabilityAccessor<A> implements IFlowCapabilityAccessor<A>
+{
+    //Static cache of common values for normal access
+    public static final FlowCapabilityAccessor[] FLOW_SIDES = new FlowCapabilityAccessor[]{
+            new FlowCapabilityAccessor(Direction.DOWN, null).lock(),
+            new FlowCapabilityAccessor(Direction.UP, null).lock(),
+            new FlowCapabilityAccessor(Direction.NORTH, null).lock(),
+            new FlowCapabilityAccessor(Direction.SOUTH, null).lock(),
+            new FlowCapabilityAccessor(Direction.EAST, null).lock(),
+            new FlowCapabilityAccessor(Direction.WEST, null).lock()
+    };
+
+    //Static cache of common values for simulated access
+    public static final FlowCapabilityAccessor[] FLOW_SIDES_SIM = new FlowCapabilityAccessor[]{
+            new FlowCapabilityAccessor(Direction.DOWN, null).setSimulate(true).lock(),
+            new FlowCapabilityAccessor(Direction.UP, null).setSimulate(true).lock(),
+            new FlowCapabilityAccessor(Direction.NORTH, null).setSimulate(true).lock(),
+            new FlowCapabilityAccessor(Direction.SOUTH, null).setSimulate(true).lock(),
+            new FlowCapabilityAccessor(Direction.EAST, null).setSimulate(true).lock(),
+            new FlowCapabilityAccessor(Direction.WEST, null).setSimulate(true).lock()
+    };
+
+    public static final FlowCapabilityAccessor FLOW = new FlowCapabilityAccessor(null, null).lock();
+    public static final FlowCapabilityAccessor FLOW_BYPASS = new FlowCapabilityAccessor(null, null).setBypassLimits(true).lock();
+    public static final FlowCapabilityAccessor FLOW_SIM = new FlowCapabilityAccessor(null, null).setSimulate(true).lock();
+
+    protected boolean simulate = false;
+    protected boolean bypassLimits = false;
+    protected boolean requireFull = false;
+    protected boolean _lock = false;
+
+    public FlowCapabilityAccessor(@Nullable Direction side, @Nullable Supplier<A> accessor)
+    {
+        super(side, accessor);
+    }
+
+    /**
+     * Allows setting this accessor to require full
+     *
+     * @param value - true to require full, false to not
+     */
+    public FlowCapabilityAccessor setRequireFull(boolean value)
+    {
+        //Should not be called once locked
+        if (_lock)
+        {
+            throw new UnsupportedOperationException();
+        }
+        this.requireFull = value;
+        return this;
+    }
+
+    /**
+     * Allows setting ths accessor to simulate actions
+     *
+     * @param value - true to simulate, false to complete action
+     */
+    public FlowCapabilityAccessor setSimulate(boolean value)
+    {
+        //Should not be called once locked
+        if (_lock)
+        {
+            throw new UnsupportedOperationException();
+        }
+        this.simulate = value;
+        return this;
+    }
+
+    /**
+     * Allows setting this accessor to bypass limits
+     *
+     * @param value - true to bypass limits, false to complete action
+     */
+    public FlowCapabilityAccessor setBypassLimits(boolean value)
+    {
+        //Should not be called once locked
+        if (_lock)
+        {
+            throw new UnsupportedOperationException();
+        }
+        this.bypassLimits = value;
+        return this;
+    }
+
+    /**
+     * Called to lock settings to prevent then from being
+     * changed. Useful for creating immutable accessors.
+     */
+    public FlowCapabilityAccessor lock()
+    {
+        this._lock = true;
+        return this;
+    }
+
+    @Override
+    public boolean requireFull()
+    {
+        return requireFull;
+    }
+
+    @Override
+    public boolean simulate()
+    {
+        return simulate;
+    }
+
+    @Override
+    public boolean bypassLimits()
+    {
+        return bypassLimits;
+    }
+
+    /**
+     * Helper to quickly get the static cache values per side and simulated status
+     *
+     * @param direction - side to access
+     * @param simulate  - true to simulate
+     * @return flow accessor cache value
+     */
+    public static FlowCapabilityAccessor getSide(@Nullable Direction direction, boolean simulate)
+    {
+        if (direction == null)
+        {
+            return simulate ? FLOW_SIM : FLOW;
+        }
+        return simulate ? FLOW_SIDES_SIM[direction.ordinal()] : FLOW_SIDES[direction.ordinal()];
+    }
+}

--- a/src/main/java/net/minecraftforge/common/capabilities/accessor/ICapabilityAccessor.java
+++ b/src/main/java/net/minecraftforge/common/capabilities/accessor/ICapabilityAccessor.java
@@ -1,0 +1,51 @@
+package net.minecraftforge.common.capabilities.accessor;
+
+
+import net.minecraft.util.Direction;
+
+import javax.annotation.Nullable;
+
+/**
+ * Wrapper to provide context into how the capability is being accessed. Use the data
+ * provided to better supply capabilities customized to handle the data.
+ * <p>
+ * Example of usage of this accessor is to provided a sided capability or a non-sided
+ * capability based on the {@link #getAccessSide()} direction.
+ * <p>
+ * Instances of {@link net.minecraftforge.common.capabilities.ICapabilityProvider} should
+ * not cache this value. As it may be shared over several machines or recycled to help
+ * with memory churn.
+ * <p>
+ * Created by Dark(DarkGuardsman, Robert) on 8/4/2019.
+ */
+public interface ICapabilityAccessor<A>
+{
+    /**
+     * Side that will be accessed
+     *
+     * @return sided access, can be null to indicate internal access
+     */
+    @Nullable
+    Direction getAccessSide();
+
+    /**
+     * System or object accessing the capability.
+     * <p>
+     * Do not use this to filter access to capabilities.
+     * Instead use the accessor to provided feedback of actions,
+     * debug of how the capability is being handled, or solutions
+     * of edge cases such as infinite loops.
+     * <p>
+     * Example of usage: Pipe that can only have 1 input
+     * and 1 output. In which instead of providing its own
+     * capabilities it wrappers the target's capabilities
+     * for return. In doing so it may return the sender's
+     * capability due to also being the target. This can
+     * cause an infinite loop if handled wrong. To avoid
+     * this the target could check if accessor is itself.
+     *
+     * @return accessor, or null for generic access
+     */
+    @Nullable
+    A getAccessor();
+}

--- a/src/main/java/net/minecraftforge/common/capabilities/accessor/IFlowCapabilityAccessor.java
+++ b/src/main/java/net/minecraftforge/common/capabilities/accessor/IFlowCapabilityAccessor.java
@@ -1,0 +1,63 @@
+package net.minecraftforge.common.capabilities.accessor;
+
+/**
+ * Accessor for capabilities that allow flow of content between two systems.
+ * <p>
+ * Examples: Energy, Fluid, and Items.
+ * <p>
+ * Created by Dark(DarkGuardsman, Robert) on 8/4/2019.
+ */
+public interface IFlowCapabilityAccessor<A> extends ICapabilityAccessor<A>
+{
+    /**
+     * Allows setting the access to be simulated.
+     * <p>
+     * Example: Machine wants to predict how much to send would
+     * return true to get a check value back.
+     * <p>
+     * Example 2: Machine wants to apply the changes would return
+     * false to have the action go through.
+     *
+     * @return true to simulate, false to complete the action
+     */
+    boolean simulate();
+
+    /**
+     * Allows setting the access to input/output the
+     * full amount provided. If this can't be provided
+     * then it will reject the full amount.
+     * <p>
+     * Example: Machine wants to send fluid but doesn't care how much
+     * is taken. This machine would return false.
+     * <p>
+     * Example 2: Machine is sending a packet of fluid. It wants to
+     * pathfind to the first machine possible to take the packet. This
+     * machine would return true and would also run a simulate check
+     * to predict the path needed.
+     *
+     * @return true to require full input, false to take as much
+     * as possible into the capability
+     */
+    default boolean requireFull()
+    {
+        return false;
+    }
+
+    /**
+     * Allows bypassing any input/output limit on the capability.
+     * <p>
+     * Should only be used as needed. Most cases this should return false.
+     * <p>
+     * Example: Wires/Pipes/Belts should return false as they need to be
+     * driven by the limits of the connection.
+     * <p>
+     * Example 2: Admin command to set or update the state would return true
+     * as it needs to bypass the limit to quickly handle the action.
+     *
+     * @return true to bypass limits
+     */
+    default boolean bypassLimits()
+    {
+        return false;
+    }
+}

--- a/src/main/java/net/minecraftforge/energy/CapabilityEnergy.java
+++ b/src/main/java/net/minecraftforge/energy/CapabilityEnergy.java
@@ -19,13 +19,13 @@
 
 package net.minecraftforge.energy;
 
-import java.util.concurrent.Callable;
-
 import net.minecraft.nbt.INBT;
 import net.minecraft.nbt.IntNBT;
 import net.minecraft.util.Direction;
-import net.minecraftforge.common.capabilities.*;
+import net.minecraftforge.common.capabilities.Capability;
 import net.minecraftforge.common.capabilities.Capability.IStorage;
+import net.minecraftforge.common.capabilities.CapabilityInject;
+import net.minecraftforge.common.capabilities.CapabilityManager;
 
 public class CapabilityEnergy
 {

--- a/src/main/java/net/minecraftforge/energy/EnergyStorage.java
+++ b/src/main/java/net/minecraftforge/energy/EnergyStorage.java
@@ -63,7 +63,8 @@ public class EnergyStorage implements IEnergyStorage
 
         int energyReceived = Math.min(capacity - energy, Math.min(this.maxReceive, maxReceive));
         if (!simulate)
-            energy += energyReceived;
+            setEnergyStored(energy + energyReceived);
+
         return energyReceived;
     }
 
@@ -75,14 +76,41 @@ public class EnergyStorage implements IEnergyStorage
 
         int energyExtracted = Math.min(energy, Math.min(this.maxExtract, maxExtract));
         if (!simulate)
-            energy -= energyExtracted;
+            setEnergyStored(energy - energyExtracted);
+
         return energyExtracted;
+    }
+
+    /**
+     * Triggered any time the energy state changes.
+     *
+     * @param prevValue - value before changes were applied
+     * @param newValue - new value after changes were applied
+     */
+    protected void onEnergyChanged(int prevValue, int newValue)
+    {
+        //Override this to implement update/sync logic
     }
 
     @Override
     public int getEnergyStored()
     {
         return energy;
+    }
+
+    /**
+     * Allows setting the energy directly
+     *
+     * @param value - value to set
+     */
+    public void setEnergyStored(int value)
+    {
+        final int prevEnergy = this.energy;
+        this.energy = Math.max(0, Math.min(value, getMaxEnergyStored()));
+        if (prevEnergy != this.energy)
+        {
+            onEnergyChanged(prevEnergy, value);
+        }
     }
 
     @Override

--- a/src/main/java/net/minecraftforge/energy/IEnergyStorage.java
+++ b/src/main/java/net/minecraftforge/energy/IEnergyStorage.java
@@ -19,6 +19,8 @@
 
 package net.minecraftforge.energy;
 
+import net.minecraftforge.common.capabilities.accessor.IFlowCapabilityAccessor;
+
 /**
  * An energy storage is the unit of interaction with Energy inventories.
  * <p>
@@ -39,7 +41,22 @@ public interface IEnergyStorage
     *            If TRUE, the insertion will only be simulated.
     * @return Amount of energy that was (or would have been, if simulated) accepted by the storage.
     */
+    @Deprecated //Remove in 1.15, use accessor version instead
     int receiveEnergy(int maxReceive, boolean simulate);
+
+    /**
+     * Adds energy to the storage. Returns quantity of energy that was accepted.
+     *
+     * @param maxReceive
+     *            Maximum amount of energy to be inserted.
+     * @param accessor
+     *            Data input to control how the receive is processed
+     * @return Amount of energy that was (or would have been, if simulated) accepted by the storage.
+     */
+    default int receiveEnergy(int maxReceive, IFlowCapabilityAccessor accessor)
+    {
+        return receiveEnergy(maxReceive, accessor.simulate());
+    }
 
     /**
     * Removes energy from the storage. Returns quantity of energy that was removed.
@@ -50,7 +67,22 @@ public interface IEnergyStorage
     *            If TRUE, the extraction will only be simulated.
     * @return Amount of energy that was (or would have been, if simulated) extracted from the storage.
     */
+    @Deprecated //Remove in 1.15, use accessor version instead
     int extractEnergy(int maxExtract, boolean simulate);
+
+    /**
+     * Removes energy from the storage. Returns quantity of energy that was removed.
+     *
+     * @param maxExtract
+     *            Maximum amount of energy to be extracted.
+     * @param accessor
+     *            Data input to control how the extract is processed
+     * @return Amount of energy that was (or would have been, if simulated) extracted from the storage.
+     */
+    default int extractEnergy(int maxExtract, IFlowCapabilityAccessor accessor)
+    {
+        return extractEnergy(maxExtract, accessor.simulate());
+    }
 
     /**
     * Returns the amount of energy currently stored.

--- a/src/main/java/net/minecraftforge/fluids/capability/IFluidHandler.java
+++ b/src/main/java/net/minecraftforge/fluids/capability/IFluidHandler.java
@@ -19,9 +19,11 @@
 
 package net.minecraftforge.fluids.capability;
 
-import javax.annotation.Nullable;
+import net.minecraftforge.common.capabilities.accessor.IFlowCapabilityAccessor;
+import net.minecraftforge.fluids.FluidStack;
+import net.minecraftforge.fluids.IFluidTank;
 
-import net.minecraftforge.fluids.*;
+import javax.annotation.Nullable;
 
 /**
  * Implement this interface as a capability which should handle fluids, generally storing them in
@@ -46,7 +48,19 @@ public interface IFluidHandler
      * @param doFill   If false, fill will only be simulated.
      * @return Amount of resource that was (or would have been, if simulated) filled.
      */
+    @Deprecated // Remove in 1.15, use accessor version
     int fill(FluidStack resource, boolean doFill);
+
+    /**
+     * Fills fluid into internal tanks, distribution is left entirely to the IFluidHandler.
+     *
+     * @param resource FluidStack representing the Fluid and maximum amount of fluid to be filled.
+     * @param accessor System/Object data for accessing this capability
+     * @return Amount of resource that was (or would have been, if simulated) filled.
+     */
+    default int fill(FluidStack resource, IFlowCapabilityAccessor accessor) {
+        return fill(resource, !accessor.simulate());
+    }
 
     /**
      * Drains fluid out of internal tanks, distribution is left entirely to the IFluidHandler.
@@ -56,8 +70,22 @@ public interface IFluidHandler
      * @return FluidStack representing the Fluid and amount that was (or would have been, if
      * simulated) drained.
      */
-    @Nullable
+    @Nullable // Remove in 1.15, use accessor version
     FluidStack drain(FluidStack resource, boolean doDrain);
+
+
+    /**
+     * Drains fluid out of internal tanks, distribution is left entirely to the IFluidHandler.
+     *
+     * @param resource FluidStack representing the Fluid and maximum amount of fluid to be drained.
+     * @param accessor System/Object data for accessing this capability
+     * @return FluidStack representing the Fluid and amount that was (or would have been, if
+     * simulated) drained.
+     */
+    @Nullable
+    default FluidStack drain(FluidStack resource, IFlowCapabilityAccessor accessor) {
+        return drain(resource, !accessor.simulate());
+    }
 
     /**
      * Drains fluid out of internal tanks, distribution is left entirely to the IFluidHandler.
@@ -69,6 +97,21 @@ public interface IFluidHandler
      * @return FluidStack representing the Fluid and amount that was (or would have been, if
      * simulated) drained.
      */
-    @Nullable
+    @Nullable // Remove in 1.15, use accessor version
     FluidStack drain(int maxDrain, boolean doDrain);
+
+    /**
+     * Drains fluid out of internal tanks, distribution is left entirely to the IFluidHandler.
+     * <p/>
+     * This method is not Fluid-sensitive.
+     *
+     * @param maxDrain Maximum amount of fluid to drain.
+     * @param accessor System/Object data for accessing this capability
+     * @return FluidStack representing the Fluid and amount that was (or would have been, if
+     * simulated) drained.
+     */
+    @Nullable // Remove in 1.15, use accessor version
+    default FluidStack drain(int maxDrain, IFlowCapabilityAccessor accessor) {
+        return drain(maxDrain, !accessor.simulate());
+    }
 }

--- a/src/main/java/net/minecraftforge/items/IItemHandler.java
+++ b/src/main/java/net/minecraftforge/items/IItemHandler.java
@@ -21,10 +21,9 @@ package net.minecraftforge.items;
 
 import net.minecraft.inventory.IInventory;
 import net.minecraft.item.ItemStack;
+import net.minecraftforge.common.capabilities.accessor.IFlowCapabilityAccessor;
 import net.minecraftforge.fluids.FluidStack;
 import net.minecraftforge.fluids.capability.IFluidHandler;
-import javax.annotation.Nonnull;
-
 
 import javax.annotation.Nonnull;
 
@@ -74,7 +73,26 @@ public interface IItemHandler
      *         The returned ItemStack can be safely modified after.
      **/
     @Nonnull
+    @Deprecated //Remove in 1.15, use accessor version
     ItemStack insertItem(int slot, @Nonnull ItemStack stack, boolean simulate);
+
+    /**
+     * <p>
+     * Inserts an ItemStack into the given slot and return the remainder.
+     * The ItemStack <em>should not</em> be modified in this function!
+     * </p>
+     * Note: This behaviour is subtly different from {@link IFluidHandler#fill(FluidStack, boolean)}
+     *
+     * @param slot     Slot to insert into.
+     * @param stack    ItemStack to insert. This must not be modified by the item handler.
+     * @param accessor - System/Object data for working with the capability
+     * @return The remaining ItemStack that was not inserted (if the entire stack is accepted, then return an empty ItemStack).
+     *         May be the same as the input ItemStack if unchanged, otherwise a new ItemStack.
+     *         The returned ItemStack can be safely modified after.
+     **/
+    default ItemStack insertItem(int slot, @Nonnull ItemStack stack, IFlowCapabilityAccessor accessor) {
+        return insertItem(slot, stack, accessor.simulate());
+    }
 
     /**
      * Extracts an ItemStack from the given slot.
@@ -90,7 +108,26 @@ public interface IItemHandler
      *         The returned ItemStack can be safely modified after, so item handlers should return a new or copied stack.
      **/
     @Nonnull
+    @Deprecated //Remove in 1.15, use accessor version
     ItemStack extractItem(int slot, int amount, boolean simulate);
+
+    /**
+     * Extracts an ItemStack from the given slot.
+     * <p>
+     * The returned value must be empty if nothing is extracted,
+     * otherwise its stack size must be less than or equal to {@code amount} and {@link ItemStack#getMaxStackSize()}.
+     * </p>
+     *
+     * @param slot     Slot to extract from.
+     * @param amount   Amount to extract (may be greater than the current stack's max limit)
+     * @param accessor - System/Object data for working with the capability
+     * @return ItemStack extracted from the slot, must be empty if nothing can be extracted.
+     *         The returned ItemStack can be safely modified after, so item handlers should return a new or copied stack.
+     **/
+    @Nonnull
+    default ItemStack extractItem(int slot, int amount, IFlowCapabilityAccessor accessor) {
+        return extractItem(slot, amount, accessor.simulate());
+    }
 
     /**
      * Retrieves the maximum stack size allowed to exist in the given slot.

--- a/src/main/java/net/minecraftforge/items/wrapper/CombinedInvWrapper.java
+++ b/src/main/java/net/minecraftforge/items/wrapper/CombinedInvWrapper.java
@@ -20,6 +20,7 @@
 package net.minecraftforge.items.wrapper;
 
 import net.minecraft.item.ItemStack;
+import net.minecraftforge.common.capabilities.accessor.IFlowCapabilityAccessor;
 import net.minecraftforge.items.IItemHandlerModifiable;
 
 import javax.annotation.Nonnull;
@@ -122,6 +123,26 @@ public class CombinedInvWrapper implements IItemHandlerModifiable
         IItemHandlerModifiable handler = getHandlerFromIndex(index);
         slot = getSlotFromIndex(slot, index);
         return handler.extractItem(slot, amount, simulate);
+    }
+
+    @Override
+    @Nonnull
+    public ItemStack insertItem(int slot, @Nonnull ItemStack stack, IFlowCapabilityAccessor accessor)
+    {
+        int index = getIndexForSlot(slot);
+        IItemHandlerModifiable handler = getHandlerFromIndex(index);
+        slot = getSlotFromIndex(slot, index);
+        return handler.insertItem(slot, stack, accessor);
+    }
+
+    @Override
+    @Nonnull
+    public ItemStack extractItem(int slot, int amount, IFlowCapabilityAccessor accessor)
+    {
+        int index = getIndexForSlot(slot);
+        IItemHandlerModifiable handler = getHandlerFromIndex(index);
+        slot = getSlotFromIndex(slot, index);
+        return handler.extractItem(slot, amount, accessor);
     }
 
     @Override

--- a/src/main/java/net/minecraftforge/items/wrapper/RangedWrapper.java
+++ b/src/main/java/net/minecraftforge/items/wrapper/RangedWrapper.java
@@ -21,6 +21,7 @@ package net.minecraftforge.items.wrapper;
 
 import com.google.common.base.Preconditions;
 import net.minecraft.item.ItemStack;
+import net.minecraftforge.common.capabilities.accessor.IFlowCapabilityAccessor;
 import net.minecraftforge.items.IItemHandlerModifiable;
 
 import javax.annotation.Nonnull;
@@ -80,6 +81,30 @@ public class RangedWrapper implements IItemHandlerModifiable {
         if (checkSlot(slot))
         {
             return compose.extractItem(slot + minSlot, amount, simulate);
+        }
+
+        return ItemStack.EMPTY;
+    }
+
+    @Override
+    @Nonnull
+    public ItemStack insertItem(int slot, @Nonnull ItemStack stack, IFlowCapabilityAccessor accessor)
+    {
+        if (checkSlot(slot))
+        {
+            return compose.insertItem(slot + minSlot, stack, accessor);
+        }
+
+        return stack;
+    }
+
+    @Override
+    @Nonnull
+    public ItemStack extractItem(int slot, int amount, IFlowCapabilityAccessor accessor)
+    {
+        if (checkSlot(slot))
+        {
+            return compose.extractItem(slot + minSlot, amount, accessor);
         }
 
         return ItemStack.EMPTY;

--- a/src/test/java/net/minecraftforge/test/capabilities/CapAccessorTest.java
+++ b/src/test/java/net/minecraftforge/test/capabilities/CapAccessorTest.java
@@ -1,0 +1,8 @@
+package net.minecraftforge.test.capabilities;
+
+/**
+ * Created by Dark(DarkGuardsman, Robert) on 8/10/2019.
+ */
+public class CapAccessorTest
+{
+}

--- a/src/test/java/net/minecraftforge/test/capabilities/EnergyCapTest.java
+++ b/src/test/java/net/minecraftforge/test/capabilities/EnergyCapTest.java
@@ -1,0 +1,193 @@
+package net.minecraftforge.test.capabilities;
+
+import net.minecraft.util.Direction;
+import net.minecraftforge.common.capabilities.accessor.FlowCapabilityAccessor;
+import net.minecraftforge.energy.EnergyStorage;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Created by Dark(DarkGuardsman, Robert) on 8/10/2019.
+ */
+public class EnergyCapTest
+{
+    @Test
+    public void basicEnergyAdd() {
+        final EnergyStorage storage = new EnergyStorage(1000, 10, 10, 0);
+
+        //Create a basic accessor
+        final FlowCapabilityAccessor accessor = new FlowCapabilityAccessor(Direction.NORTH, () -> this);
+
+        //Test the limits are still enforced
+        final int received = storage.receiveEnergy(100, accessor);
+
+        //Test we received only 10
+        Assertions.assertEquals(10, received);
+        Assertions.assertEquals(10, storage.getEnergyStored());
+    }
+
+    @Test
+    public void basicEnergyRemove() {
+        final EnergyStorage storage = new EnergyStorage(1000, 10, 10, 1000);
+
+        //Create a basic accessor
+        final FlowCapabilityAccessor accessor = new FlowCapabilityAccessor(Direction.NORTH, () -> this);
+
+        //Test the limits are still enforced
+        final int extract = storage.extractEnergy(100, accessor);
+
+        //Test we removed only 10
+        Assertions.assertEquals(10, extract);
+        Assertions.assertEquals(990, storage.getEnergyStored());
+    }
+
+    @Test
+    public void basicEnergyAddSimulate() {
+        final EnergyStorage storage = new EnergyStorage(1000, 10, 10, 0);
+
+        //Create a basic accessor
+        final FlowCapabilityAccessor accessor = new FlowCapabilityAccessor(Direction.NORTH, () -> this).setSimulate(true);
+
+        //Test the limits are still enforced
+        final int received = storage.receiveEnergy(100, accessor);
+
+        //Test we received only 10
+        Assertions.assertEquals(10, received);
+        Assertions.assertEquals(0, storage.getEnergyStored());
+    }
+
+    @Test
+    public void basicEnergyRemoveSimulate() {
+        final EnergyStorage storage = new EnergyStorage(1000, 10, 10, 1000);
+
+        //Create a basic accessor
+        final FlowCapabilityAccessor accessor = new FlowCapabilityAccessor(Direction.NORTH, () -> this).setSimulate(true);
+
+        //Test the limits are still enforced
+        final int extract = storage.extractEnergy(100, accessor);
+
+        //Test we removed only 10
+        Assertions.assertEquals(10, extract);
+        Assertions.assertEquals(1000, storage.getEnergyStored());
+    }
+
+    @Test
+    public void energyAddBypass() {
+        final EnergyStorage storage = new EnergyStorage(1000, 10, 10, 0);
+
+        //Create a basic accessor
+        final FlowCapabilityAccessor accessor = new FlowCapabilityAccessor(Direction.NORTH, () -> this).setBypassLimits(true);
+
+        //Test the limits are still enforced
+        final int received = storage.receiveEnergy(100, accessor);
+
+        //Test we received only 10
+        Assertions.assertEquals(100, received);
+        Assertions.assertEquals(100, storage.getEnergyStored());
+    }
+
+    @Test
+    public void energyRemoveBypass() {
+        final EnergyStorage storage = new EnergyStorage(1000, 10, 10, 1000);
+
+        //Create a basic accessor
+        final FlowCapabilityAccessor accessor = new FlowCapabilityAccessor(Direction.NORTH, () -> this).setBypassLimits(true);
+
+        //Test the limits are still enforced
+        final int extract = storage.extractEnergy(100, accessor);
+
+        //Test we removed only 10
+        Assertions.assertEquals(100, extract);
+        Assertions.assertEquals(900, storage.getEnergyStored());
+    }
+
+    @Test //Tests normal reaction
+    public void energyAddTakeAll() {
+        final EnergyStorage storage = new EnergyStorage(1000, 10, 10, 0);
+
+        //Create a basic accessor
+        final FlowCapabilityAccessor accessor = new FlowCapabilityAccessor(Direction.NORTH, () -> this).setRequireFull(true);
+
+        //Test the limits are still enforced
+        final int received = storage.receiveEnergy(10, accessor);
+
+        //Test we received only 10
+        Assertions.assertEquals(10, received);
+        Assertions.assertEquals(10, storage.getEnergyStored());
+    }
+
+    @Test //Tests normal reaction
+    public void energyRemoveTakeAll() {
+        final EnergyStorage storage = new EnergyStorage(1000, 10, 10, 100);
+
+        //Create a basic accessor
+        final FlowCapabilityAccessor accessor = new FlowCapabilityAccessor(Direction.NORTH, () -> this).setRequireFull(true);
+
+        //Test the limits are still enforced
+        final int extract = storage.extractEnergy(10, accessor);
+
+        //Test we removed only 10
+        Assertions.assertEquals(10, extract);
+        Assertions.assertEquals(90, storage.getEnergyStored());
+    }
+
+    @Test //Tests the limit fail check
+    public void energyAddTakeAllFailLimit() {
+        final EnergyStorage storage = new EnergyStorage(1000, 10, 10, 0);
+
+        //Create a basic accessor
+        final FlowCapabilityAccessor accessor = new FlowCapabilityAccessor(Direction.NORTH, () -> this).setRequireFull(true);
+
+        //Test the limits are still enforced
+        final int received = storage.receiveEnergy(100, accessor);
+
+        //Test we received only 10
+        Assertions.assertEquals(0, received);
+        Assertions.assertEquals(0, storage.getEnergyStored());
+    }
+
+    @Test //Tests the limit fail check
+    public void energyRemoveTakeAllFailLimit() {
+        final EnergyStorage storage = new EnergyStorage(1000, 10, 10, 100);
+
+        //Create a basic accessor
+        final FlowCapabilityAccessor accessor = new FlowCapabilityAccessor(Direction.NORTH, () -> this).setRequireFull(true);
+
+        //Test the limits are still enforced
+        final int extract = storage.extractEnergy(100, accessor);
+
+        //Test we removed only 10
+        Assertions.assertEquals(0, extract);
+        Assertions.assertEquals(100, storage.getEnergyStored());
+    }
+
+    @Test //Tests the fail condition for no room left
+    public void energyAddTakeAllFailNoRoom() {
+        final EnergyStorage storage = new EnergyStorage(1000, 10, 10, 999);
+
+        //Create a basic accessor
+        final FlowCapabilityAccessor accessor = new FlowCapabilityAccessor(Direction.NORTH, () -> this).setRequireFull(true);
+
+        //Test the limits are still enforced
+        final int received = storage.receiveEnergy(10, accessor);
+
+        //Test we received only 10
+        Assertions.assertEquals(0, received);
+        Assertions.assertEquals(999, storage.getEnergyStored());
+    }
+
+    @Test //Tests the fail condition for not enough energy left
+    public void energyRemoveTakeAllFailNoEnergy() {
+        final EnergyStorage storage = new EnergyStorage(1000, 10, 10, 3);
+
+        //Create a basic accessor
+        final FlowCapabilityAccessor accessor = new FlowCapabilityAccessor(Direction.NORTH, () -> this).setRequireFull(true);
+
+        //Test the limits are still enforced
+        final int extract = storage.extractEnergy(10, accessor);
+
+        //Test we removed only 10
+        Assertions.assertEquals(0, extract);
+        Assertions.assertEquals(3, storage.getEnergyStored());
+    }
+}

--- a/src/test/java/net/minecraftforge/test/capabilities/FlowAccessorCapTest.java
+++ b/src/test/java/net/minecraftforge/test/capabilities/FlowAccessorCapTest.java
@@ -1,0 +1,8 @@
+package net.minecraftforge.test.capabilities;
+
+/**
+ * Created by Dark(DarkGuardsman, Robert) on 8/10/2019.
+ */
+public class FlowAccessorCapTest
+{
+}


### PR DESCRIPTION
**Note:** This is a work in progress pull request and is open to suggestions for improvements/modifications. The pull request is meant to create a debate around this change so to better match the needs of the community. 

The system present will not be the final system unless all parties are happy with the structure and usage. As well we will need to talk over how to integrate it and if it should wait for 1.15MC so we can do a more complete overhaul. 

This is an additional PR to go with this https://github.com/MinecraftForge/MinecraftForge/pull/5993

**Pull itself**
This change to the capability system exists to provide a context into how something is being accessed. So rather than providing a direction and getting a capability, we can tailor the capability to match the needs of the requesting system. Such as providing ways to simulate and bypass limits on the machines.

The core change for this is targeted at the energy system. As it needs a way to handle bypass limits and allow pulling the full amount vs amount present. While still ensuring the target capability has complete control to allow this behavior or not.

Fluid and inventory systems were partially implemented as neither system needs the full power at this moment. As well the fluid system has active pull requests that could conflict. So we can make addition pull requests to cover this side of the code later.

**How the system works**
Capabilities will now be accessed via an accessor data object. This accessor will provide the side to access, what is accessing, and in the case of energy how to access. Using this information the capability provider will return the correct capability to use. It will then pass in the accessor for other information bits to be accessed.

AccessorMachine -> TargetMachine#capabilitySet(capType, accessorData) -> capability
AccessorMachine -> capability.doThing(rawData, accessorData)

**Additional Changes to consider**
* Returning both the value of a capability and a context. Such as providing a response to say not enough energy exists or limits where hit.
* Could add in the capability to access to the accessor so that only 1 input is needed for capability providers. Not sure how this would work with generics so left it out for this PR.
