### PR TITLE
Add Multipart API

### DIFF
--- a/patches/minecraft/net/minecraft/item/BlockItem.java.patch
+++ b/patches/minecraft/net/minecraft/item/BlockItem.java.patch
@@ -22,6 +22,15 @@
           BlockItemUseContext blockitemusecontext = this.func_219984_b(p_195942_1_);
           if (blockitemusecontext == null) {
              return ActionResultType.FAIL;
+@@ -51,7 +54,7 @@
+             BlockState blockstate = this.func_195945_b(blockitemusecontext);
+             if (blockstate == null) {
+                return ActionResultType.FAIL;
+-            } else if (!this.func_195941_b(blockitemusecontext, blockstate)) {
++            } else if (!this.tryPlaceBlock(blockitemusecontext, blockstate)) {
+                return ActionResultType.FAIL;
+             } else {
+                BlockPos blockpos = blockitemusecontext.func_195995_a();
 @@ -69,7 +72,7 @@
                    }
                 }
@@ -31,17 +40,7 @@
                 world.func_184133_a(playerentity, blockpos, this.func_219983_a(blockstate1), SoundCategory.BLOCKS, (soundtype.func_185843_a() + 1.0F) / 2.0F, soundtype.func_185847_b() * 0.8F);
                 itemstack.func_190918_g(1);
                 return ActionResultType.SUCCESS;
-@@ -137,6 +140,9 @@
-    }
- 
-    protected boolean func_195941_b(BlockItemUseContext p_195941_1_, BlockState p_195941_2_) {
-+      if (p_195941_1_.func_195991_k().canAddBlockState(p_195941_1_.func_195995_a(), p_195941_2_) && p_195941_1_.func_195991_k().addBlockState(p_195941_1_.func_195995_a(), p_195941_2_, 11)) return true;
-+      if (p_195941_1_ instanceof net.minecraftforge.common.util.SameBlockPlaceContext) return false;
-+      if (!p_195941_1_.func_196012_c() && !p_195941_1_.func_195991_k().func_180495_p(p_195941_1_.func_195995_a()).func_196953_a(p_195941_1_)) return false;
-       return p_195941_1_.func_195991_k().func_180501_a(p_195941_1_.func_195995_a(), p_195941_2_, 11);
-    }
- 
-@@ -189,10 +195,18 @@
+@@ -189,10 +192,25 @@
     }
  
     public Block func_179223_d() {
@@ -58,5 +57,12 @@
 +
 +   public void removeFromBlockToItemMap(Map<Block, Item> blockToItemMap, Item itemIn) {
 +      blockToItemMap.remove(this.func_179223_d());
++   }
++
++   protected boolean tryPlaceBlock(BlockItemUseContext context, BlockState state) {
++      if (context.func_195991_k().canAddBlockState(context.func_195995_a(), state) && context.func_195991_k().addBlockState(context.func_195995_a(), state, 11)) return true;
++      if (context instanceof net.minecraftforge.common.util.SameBlockPlaceContext) return false;
++      if (!context.func_196012_c() && !context.func_195991_k().func_180495_p(context.func_195995_a()).func_196953_a(context)) return false;
++      return func_195941_b(context, state);
 +   }
  }

--- a/patches/minecraft/net/minecraft/item/BlockItem.java.patch
+++ b/patches/minecraft/net/minecraft/item/BlockItem.java.patch
@@ -1,6 +1,28 @@
 --- a/net/minecraft/item/BlockItem.java
 +++ b/net/minecraft/item/BlockItem.java
-@@ -69,7 +69,7 @@
+@@ -36,14 +36,17 @@
+    }
+ 
+    public ActionResultType func_195939_a(ItemUseContext p_195939_1_) {
+-      ActionResultType actionresulttype = this.func_195942_a(new BlockItemUseContext(p_195939_1_));
++      BlockItemUseContext ctx = new BlockItemUseContext(p_195939_1_);
++      ActionResultType actionresulttype = ActionResultType.FAIL;
++      if (!ctx.func_196012_c())
++         actionresulttype = this.func_195942_a(new net.minecraftforge.common.util.SameBlockPlaceContext(ctx));
++      if (actionresulttype != ActionResultType.SUCCESS)
++         actionresulttype = this.func_195942_a(ctx);
+       return actionresulttype != ActionResultType.SUCCESS && this.func_219971_r() ? this.func_77659_a(p_195939_1_.field_196006_g, p_195939_1_.field_196001_b, p_195939_1_.field_221534_c).func_188397_a() : actionresulttype;
+    }
+ 
+    public ActionResultType func_195942_a(BlockItemUseContext p_195942_1_) {
+-      if (!p_195942_1_.func_196011_b()) {
+-         return ActionResultType.FAIL;
+-      } else {
++      {
+          BlockItemUseContext blockitemusecontext = this.func_219984_b(p_195942_1_);
+          if (blockitemusecontext == null) {
+             return ActionResultType.FAIL;
+@@ -69,7 +72,7 @@
                    }
                 }
  
@@ -9,7 +31,17 @@
                 world.func_184133_a(playerentity, blockpos, this.func_219983_a(blockstate1), SoundCategory.BLOCKS, (soundtype.func_185843_a() + 1.0F) / 2.0F, soundtype.func_185847_b() * 0.8F);
                 itemstack.func_190918_g(1);
                 return ActionResultType.SUCCESS;
-@@ -189,10 +189,18 @@
+@@ -137,6 +140,9 @@
+    }
+ 
+    protected boolean func_195941_b(BlockItemUseContext p_195941_1_, BlockState p_195941_2_) {
++      if (p_195941_1_.func_195991_k().canAddBlockState(p_195941_1_.func_195995_a(), p_195941_2_) && p_195941_1_.func_195991_k().addBlockState(p_195941_1_.func_195995_a(), p_195941_2_, 11)) return true;
++      if (p_195941_1_ instanceof net.minecraftforge.common.util.SameBlockPlaceContext) return false;
++      if (!p_195941_1_.func_196012_c() && !p_195941_1_.func_195991_k().func_180495_p(p_195941_1_.func_195995_a()).func_196953_a(p_195941_1_)) return false;
+       return p_195941_1_.func_195991_k().func_180501_a(p_195941_1_.func_195995_a(), p_195941_2_, 11);
+    }
+ 
+@@ -189,10 +195,18 @@
     }
  
     public Block func_179223_d() {

--- a/patches/minecraft/net/minecraft/tileentity/TileEntity.java.patch
+++ b/patches/minecraft/net/minecraft/tileentity/TileEntity.java.patch
@@ -40,9 +40,12 @@
           return p_189516_1_;
        }
     }
-@@ -93,7 +100,7 @@
+@@ -91,9 +98,9 @@
+ 
+    public void func_70296_d() {
        if (this.field_145850_b != null) {
-          this.field_195045_e = this.field_145850_b.func_180495_p(this.field_174879_c);
+-         this.field_195045_e = this.field_145850_b.func_180495_p(this.field_174879_c);
++         this.field_195045_e = this.field_195045_e != null ? this.field_145850_b.getBlockState(this.field_174879_c, this.field_195045_e.getSlot()) : this.field_145850_b.func_180495_p(this.field_174879_c);
           this.field_145850_b.func_175646_b(this.field_174879_c, this);
 -         if (!this.field_195045_e.func_196958_f()) {
 +         if (!this.field_195045_e.isAir(this.field_145850_b, this.field_174879_c)) {

--- a/patches/minecraft/net/minecraft/world/IBlockReader.java.patch
+++ b/patches/minecraft/net/minecraft/world/IBlockReader.java.patch
@@ -1,0 +1,11 @@
+--- a/net/minecraft/world/IBlockReader.java
++++ b/net/minecraft/world/IBlockReader.java
+@@ -14,7 +14,7 @@
+ import net.minecraft.util.math.Vec3d;
+ import net.minecraft.util.math.shapes.VoxelShape;
+ 
+-public interface IBlockReader {
++public interface IBlockReader extends net.minecraftforge.common.extensions.IForgeBlockReader {
+    @Nullable
+    TileEntity func_175625_s(BlockPos p_175625_1_);
+ 

--- a/patches/minecraft/net/minecraft/world/IWorldWriter.java.patch
+++ b/patches/minecraft/net/minecraft/world/IWorldWriter.java.patch
@@ -1,0 +1,11 @@
+--- a/net/minecraft/world/IWorldWriter.java
++++ b/net/minecraft/world/IWorldWriter.java
+@@ -4,7 +4,7 @@
+ import net.minecraft.entity.Entity;
+ import net.minecraft.util.math.BlockPos;
+ 
+-public interface IWorldWriter {
++public interface IWorldWriter extends net.minecraftforge.common.extensions.IForgeWorldWriter {
+    boolean func_180501_a(BlockPos p_180501_1_, BlockState p_180501_2_, int p_180501_3_);
+ 
+    boolean func_217377_a(BlockPos p_217377_1_, boolean p_217377_2_);

--- a/src/main/java/net/minecraftforge/common/ForgeConfig.java
+++ b/src/main/java/net/minecraftforge/common/ForgeConfig.java
@@ -28,6 +28,7 @@ import org.apache.commons.lang3.tuple.Pair;
 import org.apache.logging.log4j.LogManager;
 
 import net.minecraftforge.common.ForgeConfigSpec.BooleanValue;
+import net.minecraftforge.common.ForgeConfigSpec.ConfigValue;
 import net.minecraftforge.common.ForgeConfigSpec.DoubleValue;
 import net.minecraftforge.common.ForgeConfigSpec.IntValue;
 
@@ -48,6 +49,8 @@ public class ForgeConfig
         public final IntValue dimensionUnloadQueueDelay;
 
         public final IntValue clumpingThreshold;
+
+        public final ConfigValue<String> multipartHandler;
 
         Server(ForgeConfigSpec.Builder builder) {
             builder.comment("Server configuration settings")
@@ -103,6 +106,12 @@ public class ForgeConfig
                     .translation("forge.configgui.clumpingThreshold")
                     .worldRestart()
                     .defineInRange("clumpingThreshold", 64, 64, 1024);
+
+            multipartHandler = builder
+                    .comment("Determines the handler for all multipart behavior in the instance. If empty (default), will be populated with the first mod-supplied handler available, or default to the vanilla one if none are present.")
+                    .translation("forge.configgui.multipartHandler")
+                    .worldRestart()
+                    .define("multipartHandler", "");
 
             builder.pop();
         }

--- a/src/main/java/net/minecraftforge/common/ForgeConfig.java
+++ b/src/main/java/net/minecraftforge/common/ForgeConfig.java
@@ -22,6 +22,7 @@ package net.minecraftforge.common;
 import static net.minecraftforge.fml.Logging.CORE;
 import static net.minecraftforge.fml.loading.LogMarkers.FORGEMOD;
 
+import net.minecraftforge.common.multipart.MultipartManager;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
 import net.minecraftforge.fml.config.ModConfig;
 import org.apache.commons.lang3.tuple.Pair;
@@ -207,6 +208,10 @@ public class ForgeConfig
     @SubscribeEvent
     public static void onLoad(final ModConfig.Loading configEvent) {
         LogManager.getLogger().debug(FORGEMOD, "Loaded forge config file {}", configEvent.getConfig().getFileName());
+        if (configEvent.getConfig().getSpec() == serverSpec)
+        {
+            MultipartManager.INSTANCE.updateActiveHandler();
+        }
     }
 
     @SubscribeEvent

--- a/src/main/java/net/minecraftforge/common/ForgeMod.java
+++ b/src/main/java/net/minecraftforge/common/ForgeMod.java
@@ -19,6 +19,7 @@
 
 package net.minecraftforge.common;
 
+import net.minecraftforge.common.multipart.MultipartManager;
 import net.minecraftforge.eventbus.api.IEventBus;
 import net.minecraftforge.fml.*;
 import net.minecraftforge.fml.config.ModConfig;
@@ -94,6 +95,7 @@ public class ForgeMod implements WorldPersistenceHooks.WorldPersistenceHook
         ModLoadingContext.get().registerConfig(ModConfig.Type.CLIENT, ForgeConfig.clientSpec);
         ModLoadingContext.get().registerConfig(ModConfig.Type.SERVER, ForgeConfig.serverSpec);
         modEventBus.register(ForgeConfig.class);
+        modEventBus.register(MultipartManager.INSTANCE);
         // Forge does not display problems when the remote is not matching.
         ModLoadingContext.get().registerExtensionPoint(ExtensionPoint.DISPLAYTEST, ()-> Pair.of(()->"ANY", (remote, isServer)-> true));
         StartupMessageManager.addModMessage("Forge version "+ForgeVersion.getVersion());

--- a/src/main/java/net/minecraftforge/common/extensions/IForgeBlock.java
+++ b/src/main/java/net/minecraftforge/common/extensions/IForgeBlock.java
@@ -1060,9 +1060,12 @@ public interface IForgeBlock
      *
      * Returning {@link ActionResultType#SUCCESS} indicates that the blocks do not intersect with each other.<br/>
      * Returning {@link ActionResultType#FAIL} indicates that the blocks intersect with each other.<br/>
-     * Returning {@link ActionResultType#PASS} indicates that this block does not perform special occlusion testing, and
-     * the other block should also be tested. If both return {@link ActionResultType#PASS}, a default occlusion test is
-     * to be performed by the caller.
+     * Returning {@link ActionResultType#PASS} indicates that this block does not perform special occlusion testing.<br/>
+     *
+     * When testing two blocks against each other:<br/>
+     * If either block returns {@link ActionResultType#FAIL}, they intersect.<br/>
+     * If neither fail and either block returns {@link ActionResultType#SUCCESS}, they don't intersect.<br/>
+     * If both return {@link ActionResultType#PASS}, a default occlusion test is to be performed by the caller.
      *
      * @param state The current state
      * @param world The current world

--- a/src/main/java/net/minecraftforge/common/extensions/IForgeBlock.java
+++ b/src/main/java/net/minecraftforge/common/extensions/IForgeBlock.java
@@ -1043,6 +1043,7 @@ public interface IForgeBlock
 
     /**
      * Gets the shape for a given state of this block when performing an occlusion test.<br/>
+     * The state may not yet be in the world, so perform any necessary checks.<br/>
      *
      * This is the part of the block that cannot and will not be intersected by other parts in the same block space.<br/>
      * In the case of a pipe or tube, this should only return the center of said block, since the sides can be covered to
@@ -1054,7 +1055,8 @@ public interface IForgeBlock
     }
 
     /**
-     * Performs an occlusion test between a state of this block and another state that may or may not be in the world.<br/>
+     * Performs an occlusion test between a state of this block and another state.<br/>
+     * One (either) of them may not be in the world, so perform any necessary checks.<br/>
      *
      * Returning {@link ActionResultType#SUCCESS} indicates that the blocks do not intersect with each other.<br/>
      * Returning {@link ActionResultType#FAIL} indicates that the blocks intersect with each other.<br/>

--- a/src/main/java/net/minecraftforge/common/extensions/IForgeBlock.java
+++ b/src/main/java/net/minecraftforge/common/extensions/IForgeBlock.java
@@ -85,8 +85,8 @@ import net.minecraftforge.api.distmarker.OnlyIn;
 import net.minecraftforge.common.ForgeHooks;
 import net.minecraftforge.common.IPlantable;
 import net.minecraftforge.common.ToolType;
-import net.minecraftforge.common.multipart.IMultipartSlot;
-import net.minecraftforge.common.multipart.MultipartSlot;
+import net.minecraftforge.common.multipart.IBlockSlot;
+import net.minecraftforge.common.multipart.BlockSlot;
 
 @SuppressWarnings("deprecation")
 public interface IForgeBlock
@@ -1033,12 +1033,12 @@ public interface IForgeBlock
     /**
      * Gets the slot that the given state takes up when placed in the same block space as other blocks.<br/>
      *
-     * Returning {@link MultipartSlot#FULL_BLOCK} signifies that the given state does not support multipart behavior and
+     * Returning {@link BlockSlot#FULL_BLOCK} signifies that the given state does not support multipart behavior and
      * is the value returned by default.
      */
-    default IMultipartSlot getMultipartSlot(BlockState state)
+    default IBlockSlot getSlot(BlockState state)
     {
-        return MultipartSlot.FULL_BLOCK;
+        return BlockSlot.FULL_BLOCK;
     }
 
     /**

--- a/src/main/java/net/minecraftforge/common/extensions/IForgeBlockReader.java
+++ b/src/main/java/net/minecraftforge/common/extensions/IForgeBlockReader.java
@@ -23,7 +23,7 @@ import net.minecraft.block.BlockState;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.IBlockReader;
-import net.minecraftforge.common.multipart.IMultipartSlot;
+import net.minecraftforge.common.multipart.IBlockSlot;
 import net.minecraftforge.common.multipart.MultipartManager;
 
 import javax.annotation.Nullable;
@@ -40,7 +40,7 @@ public interface IForgeBlockReader
      *
      * If there isn't a part in the given slot, air is returned.
      */
-    default BlockState getBlockState(BlockPos pos, IMultipartSlot slot)
+    default BlockState getBlockState(BlockPos pos, IBlockSlot slot)
     {
         return MultipartManager.INSTANCE.getHandler().getBlockState(getBlockReader(), pos, slot);
     }

--- a/src/main/java/net/minecraftforge/common/extensions/IForgeBlockReader.java
+++ b/src/main/java/net/minecraftforge/common/extensions/IForgeBlockReader.java
@@ -1,0 +1,59 @@
+/*
+ * Minecraft Forge
+ * Copyright (c) 2016-2019.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation version 2.1
+ * of the License.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+package net.minecraftforge.common.extensions;
+
+import net.minecraft.block.BlockState;
+import net.minecraft.tileentity.TileEntity;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.IBlockReader;
+import net.minecraftforge.common.multipart.IMultipartSlot;
+import net.minecraftforge.common.multipart.MultipartManager;
+
+import javax.annotation.Nullable;
+
+public interface IForgeBlockReader
+{
+    default IBlockReader getBlockReader()
+    {
+        return (IBlockReader)this;
+    }
+
+    /**
+     * Gets the {@link BlockState} at the specified slot in a block.<br/>
+     *
+     * If there isn't a part in the given slot, air is returned.
+     */
+    default BlockState getBlockState(BlockPos pos, IMultipartSlot slot)
+    {
+        return MultipartManager.INSTANCE.getHandler().getBlockState(getBlockReader(), pos, slot);
+    }
+
+    /**
+     * Gets the {@link TileEntity} for the specified state in a block.<br/>
+     *
+     * If the state matches that of the block or a part in the block space, returns that TileEntity, if present.
+     * If the state does not match anything in the block, returns {@code null}.
+     */
+    @Nullable
+    default TileEntity getTileEntity(BlockPos pos, BlockState state)
+    {
+        return MultipartManager.INSTANCE.getHandler().getTileEntity(getBlockReader(), pos, state);
+    }
+}

--- a/src/main/java/net/minecraftforge/common/extensions/IForgeBlockReader.java
+++ b/src/main/java/net/minecraftforge/common/extensions/IForgeBlockReader.java
@@ -27,12 +27,23 @@ import net.minecraftforge.common.multipart.IBlockSlot;
 import net.minecraftforge.common.multipart.MultipartManager;
 
 import javax.annotation.Nullable;
+import java.util.Set;
 
 public interface IForgeBlockReader
 {
     default IBlockReader getBlockReader()
     {
         return (IBlockReader)this;
+    }
+
+    /**
+     * Gets all the {@link IBlockSlot}s occupied by blocks in the given block space.<br/>
+     *
+     * If the current state is air, returns an empty set.
+     */
+    default Set<IBlockSlot> getOccupiedSlots(BlockPos pos)
+    {
+        return MultipartManager.INSTANCE.getHandler().getOccupiedSlots(getBlockReader(), pos);
     }
 
     /**
@@ -43,6 +54,18 @@ public interface IForgeBlockReader
     default BlockState getBlockState(BlockPos pos, IBlockSlot slot)
     {
         return MultipartManager.INSTANCE.getHandler().getBlockState(getBlockReader(), pos, slot);
+    }
+
+    /**
+     * Gets the {@link TileEntity} at the specified slot in a block.<br/>
+     *
+     * If the slot matches that of a part in this block space, returns that TileEntity, if present.<br/>
+     * If there isn't a part in the given slot, returns {@code null}.
+     */
+    @Nullable
+    default TileEntity getTileEntity(BlockPos pos, IBlockSlot slot)
+    {
+        return MultipartManager.INSTANCE.getHandler().getTileEntity(getBlockReader(), pos, slot);
     }
 
     /**

--- a/src/main/java/net/minecraftforge/common/extensions/IForgeBlockState.java
+++ b/src/main/java/net/minecraftforge/common/extensions/IForgeBlockState.java
@@ -884,6 +884,7 @@ public interface IForgeBlockState
 
     /**
      * Gets the shape for this state when performing an occlusion test.<br/>
+     * The state may not yet be in the world, so perform any necessary checks.<br/>
      *
      * This is the part of the block that cannot and will not be intersected by other parts in the same block space.<br/>
      * In the case of a pipe or tube, this should only return the center of said block, since the sides can be covered to
@@ -895,7 +896,8 @@ public interface IForgeBlockState
     }
 
     /**
-     * Performs an occlusion test between this state and another state that may or may not be in the world.<br/>
+     * Performs an occlusion test between this state and another state.<br/>
+     * One (either) of them may not be in the world, so perform any necessary checks.<br/>
      *
      * Returning {@link ActionResultType#SUCCESS} indicates that the blocks do not intersect with each other.<br/>
      * Returning {@link ActionResultType#FAIL} indicates that the blocks intersect with each other.<br/>

--- a/src/main/java/net/minecraftforge/common/extensions/IForgeBlockState.java
+++ b/src/main/java/net/minecraftforge/common/extensions/IForgeBlockState.java
@@ -55,8 +55,8 @@ import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.api.distmarker.OnlyIn;
 import net.minecraftforge.common.IPlantable;
 import net.minecraftforge.common.ToolType;
-import net.minecraftforge.common.multipart.IMultipartSlot;
-import net.minecraftforge.common.multipart.MultipartSlot;
+import net.minecraftforge.common.multipart.IBlockSlot;
+import net.minecraftforge.common.multipart.BlockSlot;
 
 public interface IForgeBlockState
 {
@@ -874,12 +874,12 @@ public interface IForgeBlockState
     /**
      * Gets the slot that this state takes up when placed in the same block space as other blocks.<br/>
      *
-     * Returning {@link MultipartSlot#FULL_BLOCK} signifies that this state does not support multipart behavior and is
+     * Returning {@link BlockSlot#FULL_BLOCK} signifies that this state does not support multipart behavior and is
      * the value returned by default.
      */
-    default IMultipartSlot getMultipartSlot()
+    default IBlockSlot getSlot()
     {
-        return getBlockState().getBlock().getMultipartSlot(getBlockState());
+        return getBlockState().getBlock().getSlot(getBlockState());
     }
 
     /**

--- a/src/main/java/net/minecraftforge/common/extensions/IForgeBlockState.java
+++ b/src/main/java/net/minecraftforge/common/extensions/IForgeBlockState.java
@@ -43,6 +43,7 @@ import net.minecraft.util.*;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.RayTraceResult;
 import net.minecraft.util.math.Vec3d;
+import net.minecraft.util.math.shapes.VoxelShape;
 import net.minecraft.world.Explosion;
 import net.minecraft.world.IBlockReader;
 import net.minecraft.world.IEnviromentBlockReader;
@@ -54,6 +55,8 @@ import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.api.distmarker.OnlyIn;
 import net.minecraftforge.common.IPlantable;
 import net.minecraftforge.common.ToolType;
+import net.minecraftforge.common.multipart.IMultipartSlot;
+import net.minecraftforge.common.multipart.MultipartSlot;
 
 public interface IForgeBlockState
 {
@@ -866,5 +869,47 @@ public interface IForgeBlockState
     default void onBlockExploded(World world, BlockPos pos, Explosion explosion)
     {
         getBlockState().getBlock().onBlockExploded(getBlockState(), world, pos, explosion);
+    }
+
+    /**
+     * Gets the slot that this state takes up when placed in the same block space as other blocks.<br/>
+     *
+     * Returning {@link MultipartSlot#FULL_BLOCK} signifies that this state does not support multipart behavior and is
+     * the value returned by default.
+     */
+    default IMultipartSlot getMultipartSlot()
+    {
+        return getBlockState().getBlock().getMultipartSlot(getBlockState());
+    }
+
+    /**
+     * Gets the shape for this state when performing an occlusion test.<br/>
+     *
+     * This is the part of the block that cannot and will not be intersected by other parts in the same block space.<br/>
+     * In the case of a pipe or tube, this should only return the center of said block, since the sides can be covered to
+     * block the connection.<br/>
+     */
+    default VoxelShape getOcclusionShape(IBlockReader world, BlockPos pos)
+    {
+        return getBlockState().getBlock().getOcclusionShape(getBlockState(), world, pos);
+    }
+
+    /**
+     * Performs an occlusion test between this state and another state that may or may not be in the world.<br/>
+     *
+     * Returning {@link ActionResultType#SUCCESS} indicates that the blocks do not intersect with each other.<br/>
+     * Returning {@link ActionResultType#FAIL} indicates that the blocks intersect with each other.<br/>
+     * Returning {@link ActionResultType#PASS} indicates that this block does not perform special occlusion testing, and
+     * the other block should also be tested. If both return {@link ActionResultType#PASS}, a default occlusion test is
+     * to be performed by the caller.
+     *
+     * @param world The current world
+     * @param pos The current position
+     * @param otherState The other state (may or may not be in the world already)
+     * @return Whether the occlusion test succeeded or failed, or is not handled in any special way
+     */
+    default ActionResultType testOcclusion(IBlockReader world, BlockPos pos, BlockState otherState)
+    {
+        return getBlockState().getBlock().testOcclusion(getBlockState(), world, pos, otherState);
     }
 }

--- a/src/main/java/net/minecraftforge/common/extensions/IForgeBlockState.java
+++ b/src/main/java/net/minecraftforge/common/extensions/IForgeBlockState.java
@@ -901,9 +901,12 @@ public interface IForgeBlockState
      *
      * Returning {@link ActionResultType#SUCCESS} indicates that the blocks do not intersect with each other.<br/>
      * Returning {@link ActionResultType#FAIL} indicates that the blocks intersect with each other.<br/>
-     * Returning {@link ActionResultType#PASS} indicates that this block does not perform special occlusion testing, and
-     * the other block should also be tested. If both return {@link ActionResultType#PASS}, a default occlusion test is
-     * to be performed by the caller.
+     * Returning {@link ActionResultType#PASS} indicates that this block does not perform special occlusion testing.<br/>
+     *
+     * When testing two blocks against each other:<br/>
+     * If either block returns {@link ActionResultType#FAIL}, they intersect.<br/>
+     * If neither fail and either block returns {@link ActionResultType#SUCCESS}, they don't intersect.<br/>
+     * If both return {@link ActionResultType#PASS}, a default occlusion test is to be performed by the caller.
      *
      * @param world The current world
      * @param pos The current position

--- a/src/main/java/net/minecraftforge/common/extensions/IForgeWorldWriter.java
+++ b/src/main/java/net/minecraftforge/common/extensions/IForgeWorldWriter.java
@@ -47,11 +47,27 @@ public interface IForgeWorldWriter
     /**
      * Attempts to add the given {@link BlockState} to the world at the given position.
      */
+    default boolean addBlockState(BlockPos pos, BlockState state)
+    {
+        return addBlockState(pos, state, 3);
+    }
+
+    /**
+     * Attempts to add the given {@link BlockState} to the world at the given position.
+     */
     default boolean addBlockState(BlockPos pos, BlockState state, int flags)
     {
         IWorld world = getWorldWriterAsIWorld();
         if (world == null) return false;
         return MultipartManager.INSTANCE.getHandler().addBlockState(world, pos, state, flags);
+    }
+
+    /**
+     * Replaces the given {@link BlockState}, if present, with another.
+     */
+    default boolean replaceBlockState(BlockPos pos, BlockState originalState, BlockState newState)
+    {
+        return replaceBlockState(pos, originalState, newState, 3);
     }
 
     /**

--- a/src/main/java/net/minecraftforge/common/extensions/IForgeWorldWriter.java
+++ b/src/main/java/net/minecraftforge/common/extensions/IForgeWorldWriter.java
@@ -1,0 +1,86 @@
+/*
+ * Minecraft Forge
+ * Copyright (c) 2016-2019.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation version 2.1
+ * of the License.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+package net.minecraftforge.common.extensions;
+
+import net.minecraft.block.BlockState;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.IWorld;
+import net.minecraftforge.common.multipart.MultipartManager;
+
+import javax.annotation.Nullable;
+
+public interface IForgeWorldWriter
+{
+    @Nullable
+    default IWorld getWorldWriterAsIWorld()
+    {
+        return this instanceof IWorld ? (IWorld) this : null;
+    }
+
+    /**
+     * Checks if the given {@link BlockState} can be added to the world at the given position.
+     */
+    default boolean canAddBlockState(BlockPos pos, BlockState state)
+    {
+        IWorld world = getWorldWriterAsIWorld();
+        if (world == null) return false;
+        return MultipartManager.INSTANCE.getHandler().canAddBlockState(world, pos, state);
+    }
+
+    /**
+     * Attempts to add the given {@link BlockState} to the world at the given position.
+     */
+    default boolean addBlockState(BlockPos pos, BlockState state, int flags)
+    {
+        IWorld world = getWorldWriterAsIWorld();
+        if (world == null) return false;
+        return MultipartManager.INSTANCE.getHandler().addBlockState(world, pos, state, flags);
+    }
+
+    /**
+     * Replaces the given {@link BlockState}, if present, with another.
+     */
+    default boolean replaceBlockState(BlockPos pos, BlockState originalState, BlockState newState, int flags)
+    {
+        IWorld world = getWorldWriterAsIWorld();
+        if (world == null) return false;
+        return MultipartManager.INSTANCE.getHandler().replaceBlockState(world, pos, originalState, newState, flags);
+    }
+
+    /**
+     * Removes the given {@link BlockState} from the world, if present.
+     */
+    default boolean removeBlockState(BlockPos pos, BlockState state, boolean isMoving)
+    {
+        IWorld world = getWorldWriterAsIWorld();
+        if (world == null) return false;
+        return MultipartManager.INSTANCE.getHandler().removeBlockState(world, pos, state, isMoving);
+    }
+
+    /**
+     * Destroys the given {@link BlockState}, if present.
+     */
+    default boolean destroyBlockState(BlockPos pos, BlockState state, boolean dropBlock)
+    {
+        IWorld world = getWorldWriterAsIWorld();
+        if (world == null) return false;
+        return MultipartManager.INSTANCE.getHandler().destroyBlockState(world, pos, state, dropBlock);
+    }
+}

--- a/src/main/java/net/minecraftforge/common/multipart/BlockSlot.java
+++ b/src/main/java/net/minecraftforge/common/multipart/BlockSlot.java
@@ -19,20 +19,26 @@
 
 package net.minecraftforge.common.multipart;
 
-import net.minecraftforge.registries.IForgeRegistryEntry;
+import net.minecraftforge.registries.ForgeRegistryEntry;
 
 /**
- * Represents a slot inside a block space.<br/>
- * In most cases, you will want to extend {@link MultipartSlot} instead of implementing this interface directly.<br/>
+ * Default implementation of {@link IBlockSlot} to reduce redundant code.<br/>
  *
- * Default implementations are provided for face, edge, corner and center slots, as well as a general-purpose full-block
- * slot.
- *
- * @see MultipartSlot
+ * @see IBlockSlot
  * @see FaceSlot
  * @see EdgeSlot
  * @see CornerSlot
  */
-public interface IMultipartSlot extends IForgeRegistryEntry<IMultipartSlot>
+public class BlockSlot extends ForgeRegistryEntry<IBlockSlot> implements IBlockSlot
 {
+    /**
+     * A slot that takes up the whole block.<br/>
+     * This slot is not meant to be used in practice and all implementations should treat blocks returning this as not
+     * supporting multipart behavior.
+     */
+    public static final IBlockSlot FULL_BLOCK = new BlockSlot().setRegistryName("forge", "full_block");
+    /**
+     * A generic slot located in the center of the block.
+     */
+    public static final IBlockSlot CENTER = new BlockSlot().setRegistryName("forge", "center");
 }

--- a/src/main/java/net/minecraftforge/common/multipart/CornerSlot.java
+++ b/src/main/java/net/minecraftforge/common/multipart/CornerSlot.java
@@ -27,9 +27,9 @@ import javax.annotation.Nullable;
 /**
  * A slot on the corner of a block.
  *
- * @see IMultipartSlot
+ * @see IBlockSlot
  */
-public enum CornerSlot implements IMultipartSlot
+public enum CornerSlot implements IBlockSlot
 {
     DOWN_NORTH_WEST(Direction.AxisDirection.NEGATIVE, Direction.AxisDirection.NEGATIVE, Direction.AxisDirection.NEGATIVE),
     DOWN_NORTH_EAST(Direction.AxisDirection.NEGATIVE, Direction.AxisDirection.NEGATIVE, Direction.AxisDirection.POSITIVE),
@@ -69,7 +69,7 @@ public enum CornerSlot implements IMultipartSlot
     }
 
     @Override
-    public IMultipartSlot setRegistryName(ResourceLocation name)
+    public IBlockSlot setRegistryName(ResourceLocation name)
     {
         throw new IllegalStateException("Attempted to override registry name of: " + getRegistryName());
     }
@@ -81,9 +81,9 @@ public enum CornerSlot implements IMultipartSlot
     }
 
     @Override
-    public Class<IMultipartSlot> getRegistryType()
+    public Class<IBlockSlot> getRegistryType()
     {
-        return IMultipartSlot.class;
+        return IBlockSlot.class;
     }
 
     private static final CornerSlot[] SLOTS = values();

--- a/src/main/java/net/minecraftforge/common/multipart/CornerSlot.java
+++ b/src/main/java/net/minecraftforge/common/multipart/CornerSlot.java
@@ -50,7 +50,7 @@ public enum CornerSlot implements IMultipartSlot
         this.dirX = dirX;
         this.dirY = dirY;
         this.dirZ = dirZ;
-        this.name = new ResourceLocation("forge", "corner_" + getDirectionString(dirY) + getDirectionString(dirY) + getDirectionString(dirZ));
+        this.name = new ResourceLocation("forge", "corner_" + getDirectionString(dirY) + getDirectionString(dirZ) + getDirectionString(dirX));
     }
 
     public Direction.AxisDirection getXDirection()

--- a/src/main/java/net/minecraftforge/common/multipart/CornerSlot.java
+++ b/src/main/java/net/minecraftforge/common/multipart/CornerSlot.java
@@ -1,0 +1,113 @@
+/*
+ * Minecraft Forge
+ * Copyright (c) 2016-2019.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation version 2.1
+ * of the License.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+package net.minecraftforge.common.multipart;
+
+import net.minecraft.util.Direction;
+import net.minecraft.util.ResourceLocation;
+
+import javax.annotation.Nullable;
+
+/**
+ * A slot on the corner of a block.
+ *
+ * @see IMultipartSlot
+ */
+public enum CornerSlot implements IMultipartSlot
+{
+    DOWN_NORTH_WEST(Direction.AxisDirection.NEGATIVE, Direction.AxisDirection.NEGATIVE, Direction.AxisDirection.NEGATIVE),
+    DOWN_NORTH_EAST(Direction.AxisDirection.NEGATIVE, Direction.AxisDirection.NEGATIVE, Direction.AxisDirection.POSITIVE),
+    DOWN_SOUTH_WEST(Direction.AxisDirection.NEGATIVE, Direction.AxisDirection.POSITIVE, Direction.AxisDirection.NEGATIVE),
+    DOWN_SOUTH_EAST(Direction.AxisDirection.NEGATIVE, Direction.AxisDirection.POSITIVE, Direction.AxisDirection.POSITIVE),
+    UP_NORTH_WEST(Direction.AxisDirection.POSITIVE, Direction.AxisDirection.NEGATIVE, Direction.AxisDirection.NEGATIVE),
+    UP_NORTH_EAST(Direction.AxisDirection.POSITIVE, Direction.AxisDirection.NEGATIVE, Direction.AxisDirection.POSITIVE),
+    UP_SOUTH_WEST(Direction.AxisDirection.POSITIVE, Direction.AxisDirection.POSITIVE, Direction.AxisDirection.NEGATIVE),
+    UP_SOUTH_EAST(Direction.AxisDirection.POSITIVE, Direction.AxisDirection.POSITIVE, Direction.AxisDirection.POSITIVE);
+
+    private final Direction.AxisDirection dirX, dirY, dirZ;
+    private final ResourceLocation name;
+
+    // The permutations are ordered based on Direction, and so are the arguments (DOWN/UP, NORTH/SOUTH, WEST/EAST)
+    // Read: these arguments are correct and not shuffled. Please don't try to "fix" them.
+    CornerSlot(Direction.AxisDirection dirY, Direction.AxisDirection dirZ, Direction.AxisDirection dirX)
+    {
+        this.dirX = dirX;
+        this.dirY = dirY;
+        this.dirZ = dirZ;
+        this.name = new ResourceLocation("forge", "corner_" + getDirectionString(dirY) + getDirectionString(dirY) + getDirectionString(dirZ));
+    }
+
+    public Direction.AxisDirection getXDirection()
+    {
+        return dirX;
+    }
+
+    public Direction.AxisDirection getYDirection()
+    {
+        return dirY;
+    }
+
+    public Direction.AxisDirection getZDirection()
+    {
+        return dirZ;
+    }
+
+    @Override
+    public IMultipartSlot setRegistryName(ResourceLocation name)
+    {
+        throw new IllegalStateException("Attempted to override registry name of: " + getRegistryName());
+    }
+
+    @Override
+    public ResourceLocation getRegistryName()
+    {
+        return name;
+    }
+
+    @Override
+    public Class<IMultipartSlot> getRegistryType()
+    {
+        return IMultipartSlot.class;
+    }
+
+    private static final CornerSlot[] SLOTS = values();
+
+    @Nullable
+    public static CornerSlot on(Direction dir1, Direction dir2, Direction dir3)
+    {
+        Direction.Axis axis1 = dir1.getAxis(), axis2 = dir2.getAxis(), axis3 = dir3.getAxis();
+        if (axis1 == axis2 || axis1 == axis3 || axis2 == axis3)
+            return null;
+
+        Direction.AxisDirection dirX = axis1 == Direction.Axis.X ? dir1.getAxisDirection() : axis2 == Direction.Axis.X ? dir2.getAxisDirection() : dir3.getAxisDirection();
+        Direction.AxisDirection dirY = axis1 == Direction.Axis.Y ? dir1.getAxisDirection() : axis2 == Direction.Axis.Y ? dir2.getAxisDirection() : dir3.getAxisDirection();
+        Direction.AxisDirection dirZ = axis1 == Direction.Axis.Z ? dir1.getAxisDirection() : axis2 == Direction.Axis.Z ? dir2.getAxisDirection() : dir3.getAxisDirection();
+        return on(dirX, dirY, dirZ);
+    }
+
+    public static CornerSlot on(Direction.AxisDirection dirX, Direction.AxisDirection dirY, Direction.AxisDirection dirZ)
+    {
+        return SLOTS[(dirY.ordinal() << 2) | (dirZ.ordinal() << 1) | dirX.ordinal()];
+    }
+
+    private static String getDirectionString(Direction.AxisDirection direction)
+    {
+        return direction == Direction.AxisDirection.POSITIVE ? "p" : "n";
+    }
+}

--- a/src/main/java/net/minecraftforge/common/multipart/EdgeSlot.java
+++ b/src/main/java/net/minecraftforge/common/multipart/EdgeSlot.java
@@ -1,0 +1,101 @@
+/*
+ * Minecraft Forge
+ * Copyright (c) 2016-2019.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation version 2.1
+ * of the License.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+package net.minecraftforge.common.multipart;
+
+import net.minecraft.util.Direction;
+import net.minecraft.util.ResourceLocation;
+
+import javax.annotation.Nullable;
+
+/**
+ * A slot on the edge of a block.
+ *
+ * @see IMultipartSlot
+ */
+public enum EdgeSlot implements IMultipartSlot
+{
+    DOWN_NORTH(Direction.DOWN, Direction.NORTH, Direction.Axis.X),
+    DOWN_SOUTH(Direction.DOWN, Direction.SOUTH, Direction.Axis.X),
+    DOWN_WEST(Direction.DOWN, Direction.WEST, Direction.Axis.Z),
+    DOWN_EAST(Direction.DOWN, Direction.EAST, Direction.Axis.Z),
+    UP_NORTH(Direction.UP, Direction.NORTH, Direction.Axis.X),
+    UP_SOUTH(Direction.UP, Direction.SOUTH, Direction.Axis.X),
+    UP_WEST(Direction.UP, Direction.WEST, Direction.Axis.Z),
+    UP_EAST(Direction.UP, Direction.EAST, Direction.Axis.Z),
+    NORTH_WEST(Direction.NORTH, Direction.WEST, Direction.Axis.Y),
+    NORTH_EAST(Direction.NORTH, Direction.EAST, Direction.Axis.Y),
+    SOUTH_WEST(Direction.SOUTH, Direction.WEST, Direction.Axis.Y),
+    SOUTH_EAST(Direction.SOUTH, Direction.EAST, Direction.Axis.Y);
+
+    private final Direction direction1, direction2;
+    private final Direction.Axis axis;
+    private final ResourceLocation name;
+
+    EdgeSlot(Direction direction1, Direction direction2, Direction.Axis axis)
+    {
+        this.direction1 = direction1;
+        this.direction2 = direction2;
+        this.axis = axis;
+        this.name = new ResourceLocation("forge", "edge_" + direction1.getName() + "_" + direction2.getName());
+    }
+
+    public Direction getFirstDirection()
+    {
+        return direction1;
+    }
+
+    public Direction getSecondDirection()
+    {
+        return direction2;
+    }
+
+    @Override
+    public IMultipartSlot setRegistryName(ResourceLocation name)
+    {
+        throw new IllegalStateException("Attempted to override registry name of: " + getRegistryName());
+    }
+
+    @Override
+    public ResourceLocation getRegistryName()
+    {
+        return name;
+    }
+
+    @Override
+    public Class<IMultipartSlot> getRegistryType()
+    {
+        return IMultipartSlot.class;
+    }
+
+    private static final EdgeSlot[][] SLOTS = {
+        { null, null, DOWN_NORTH, DOWN_SOUTH, DOWN_WEST, DOWN_EAST },
+        { null, null, UP_NORTH, UP_SOUTH, UP_WEST, DOWN_EAST },
+        { DOWN_NORTH, UP_NORTH, null, null, NORTH_WEST, NORTH_EAST },
+        { DOWN_SOUTH, UP_SOUTH, null, null, SOUTH_WEST, SOUTH_EAST },
+        { DOWN_WEST, UP_WEST, NORTH_WEST, SOUTH_WEST, null, null },
+        { DOWN_EAST, UP_EAST, NORTH_EAST, SOUTH_EAST, null, null }
+    };
+
+    @Nullable
+    public static EdgeSlot between(Direction first, Direction second)
+    {
+        return SLOTS[first.ordinal()][second.ordinal()];
+    }
+}

--- a/src/main/java/net/minecraftforge/common/multipart/EdgeSlot.java
+++ b/src/main/java/net/minecraftforge/common/multipart/EdgeSlot.java
@@ -27,9 +27,9 @@ import javax.annotation.Nullable;
 /**
  * A slot on the edge of a block.
  *
- * @see IMultipartSlot
+ * @see IBlockSlot
  */
-public enum EdgeSlot implements IMultipartSlot
+public enum EdgeSlot implements IBlockSlot
 {
     DOWN_NORTH(Direction.DOWN, Direction.NORTH, Direction.Axis.X),
     DOWN_SOUTH(Direction.DOWN, Direction.SOUTH, Direction.Axis.X),
@@ -67,7 +67,7 @@ public enum EdgeSlot implements IMultipartSlot
     }
 
     @Override
-    public IMultipartSlot setRegistryName(ResourceLocation name)
+    public IBlockSlot setRegistryName(ResourceLocation name)
     {
         throw new IllegalStateException("Attempted to override registry name of: " + getRegistryName());
     }
@@ -79,9 +79,9 @@ public enum EdgeSlot implements IMultipartSlot
     }
 
     @Override
-    public Class<IMultipartSlot> getRegistryType()
+    public Class<IBlockSlot> getRegistryType()
     {
-        return IMultipartSlot.class;
+        return IBlockSlot.class;
     }
 
     private static final EdgeSlot[][] SLOTS = {

--- a/src/main/java/net/minecraftforge/common/multipart/FaceSlot.java
+++ b/src/main/java/net/minecraftforge/common/multipart/FaceSlot.java
@@ -1,0 +1,77 @@
+/*
+ * Minecraft Forge
+ * Copyright (c) 2016-2019.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation version 2.1
+ * of the License.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+package net.minecraftforge.common.multipart;
+
+import net.minecraft.util.Direction;
+import net.minecraft.util.ResourceLocation;
+
+/**
+ * A slot on the face of a block.
+ *
+ * @see IMultipartSlot
+ */
+public enum FaceSlot implements IMultipartSlot
+{
+    DOWN(Direction.DOWN),
+    UP(Direction.UP),
+    NORTH(Direction.NORTH),
+    SOUTH(Direction.SOUTH),
+    WEST(Direction.WEST),
+    EAST(Direction.EAST);
+
+    private final Direction direction;
+    private final ResourceLocation name;
+
+    FaceSlot(Direction direction)
+    {
+        this.direction = direction;
+        this.name = new ResourceLocation("forge", direction.getName());
+    }
+
+    public Direction getDirection()
+    {
+        return direction;
+    }
+
+    @Override
+    public IMultipartSlot setRegistryName(ResourceLocation name)
+    {
+        throw new IllegalStateException("Attempted to override registry name of: " + getRegistryName());
+    }
+
+    @Override
+    public ResourceLocation getRegistryName()
+    {
+        return name;
+    }
+
+    @Override
+    public Class<IMultipartSlot> getRegistryType()
+    {
+        return IMultipartSlot.class;
+    }
+
+    private static final FaceSlot[] SLOTS = values();
+
+    public static FaceSlot facing(Direction direction)
+    {
+        return SLOTS[direction.ordinal()];
+    }
+}

--- a/src/main/java/net/minecraftforge/common/multipart/FaceSlot.java
+++ b/src/main/java/net/minecraftforge/common/multipart/FaceSlot.java
@@ -25,9 +25,9 @@ import net.minecraft.util.ResourceLocation;
 /**
  * A slot on the face of a block.
  *
- * @see IMultipartSlot
+ * @see IBlockSlot
  */
-public enum FaceSlot implements IMultipartSlot
+public enum FaceSlot implements IBlockSlot
 {
     DOWN(Direction.DOWN),
     UP(Direction.UP),
@@ -51,7 +51,7 @@ public enum FaceSlot implements IMultipartSlot
     }
 
     @Override
-    public IMultipartSlot setRegistryName(ResourceLocation name)
+    public IBlockSlot setRegistryName(ResourceLocation name)
     {
         throw new IllegalStateException("Attempted to override registry name of: " + getRegistryName());
     }
@@ -63,9 +63,9 @@ public enum FaceSlot implements IMultipartSlot
     }
 
     @Override
-    public Class<IMultipartSlot> getRegistryType()
+    public Class<IBlockSlot> getRegistryType()
     {
-        return IMultipartSlot.class;
+        return IBlockSlot.class;
     }
 
     private static final FaceSlot[] SLOTS = values();

--- a/src/main/java/net/minecraftforge/common/multipart/IBlockSlot.java
+++ b/src/main/java/net/minecraftforge/common/multipart/IBlockSlot.java
@@ -19,26 +19,20 @@
 
 package net.minecraftforge.common.multipart;
 
-import net.minecraftforge.registries.ForgeRegistryEntry;
+import net.minecraftforge.registries.IForgeRegistryEntry;
 
 /**
- * Default implementation of {@link IMultipartSlot} to reduce redundant code.<br/>
+ * Represents a slot inside a block space.<br/>
+ * In most cases, you will want to extend {@link BlockSlot} instead of implementing this interface directly.<br/>
  *
- * @see IMultipartSlot
+ * Default implementations are provided for face, edge, corner and center slots, as well as a general-purpose full-block
+ * slot.
+ *
+ * @see BlockSlot
  * @see FaceSlot
  * @see EdgeSlot
  * @see CornerSlot
  */
-public class MultipartSlot extends ForgeRegistryEntry<IMultipartSlot> implements IMultipartSlot
+public interface IBlockSlot extends IForgeRegistryEntry<IBlockSlot>
 {
-    /**
-     * A slot that takes up the whole block.<br/>
-     * This slot is not meant to be used in practice and all implementations should treat blocks returning this as not
-     * supporting multipart behavior.
-     */
-    public static final IMultipartSlot FULL_BLOCK = new MultipartSlot().setRegistryName("forge", "full_block");
-    /**
-     * A generic slot located in the center of the block.
-     */
-    public static final IMultipartSlot CENTER = new MultipartSlot().setRegistryName("forge", "center");
 }

--- a/src/main/java/net/minecraftforge/common/multipart/IMultipartSlot.java
+++ b/src/main/java/net/minecraftforge/common/multipart/IMultipartSlot.java
@@ -1,0 +1,38 @@
+/*
+ * Minecraft Forge
+ * Copyright (c) 2016-2019.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation version 2.1
+ * of the License.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+package net.minecraftforge.common.multipart;
+
+import net.minecraftforge.registries.IForgeRegistryEntry;
+
+/**
+ * Represents a slot inside a block space.<br/>
+ * In most cases, you will want to extend {@link MultipartSlot} instead of implementing this interface directly.<br/>
+ *
+ * Default implementations are provided for face, edge, corner and center slots, as well as a general-purpose full-block
+ * slot.
+ *
+ * @see MultipartSlot
+ * @see FaceSlot
+ * @see EdgeSlot
+ * @see CornerSlot
+ */
+public interface IMultipartSlot extends IForgeRegistryEntry<IMultipartSlot>
+{
+}

--- a/src/main/java/net/minecraftforge/common/multipart/MultipartHandler.java
+++ b/src/main/java/net/minecraftforge/common/multipart/MultipartHandler.java
@@ -1,0 +1,110 @@
+/*
+ * Minecraft Forge
+ * Copyright (c) 2016-2019.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation version 2.1
+ * of the License.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+package net.minecraftforge.common.multipart;
+
+import net.minecraft.block.BlockState;
+import net.minecraft.tileentity.TileEntity;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.IBlockReader;
+import net.minecraft.world.IWorld;
+import net.minecraftforge.common.extensions.IForgeBlockState;
+import net.minecraftforge.registries.ForgeRegistryEntry;
+
+import javax.annotation.Nullable;
+
+/**
+ * Exposes the methods needed for placement, removal and retrieval of parts within a single block space.<br/>
+ * Implementations <b>must</b> respect vanilla behavior for blocks they cannot handle.<br/>
+ *
+ * Forge provides a default implementation that replicates vanilla behavior.
+ *
+ * @see NoOpMultipartHandler
+ */
+public abstract class MultipartHandler extends ForgeRegistryEntry<MultipartHandler>
+{
+    /**
+     * Gets the {@link BlockState} at the specified slot in a block.<br/>
+     *
+     * If the slot is {@link MultipartSlot#FULL_BLOCK}, this method must return {@code world.getBlockState(pos)}.<br/>
+     * If there isn't a part in the given slot, the returned state must return true when {@link BlockState#isAir(IBlockReader, BlockPos)} is called.
+     */
+    public abstract BlockState getBlockState(IBlockReader world, BlockPos pos, IMultipartSlot slot);
+
+    /**
+     * Gets the {@link TileEntity} for the specified state in a block.<br/>
+     *
+     * If the state matches that of the block (as returned by {@code world.getBlockState(pos)}), this method must return
+     * {@code world.getTileEntity(pos)}.<br/>
+     * If the state matches that of a part in this block space, this method must return that TileEntity, if present.
+     * If the state does not match either of the above cases, this method must return {@code null}.
+     */
+    @Nullable
+    public abstract TileEntity getTileEntity(IBlockReader world, BlockPos pos, BlockState state);
+
+    /**
+     * Checks if the given {@link BlockState} can be added to the world at the given position.<br/>
+     *
+     * If the current state at that position returns true in {@link BlockState#isAir(IBlockReader, BlockPos)}, this method
+     * must return {@code true}.<br/>
+     * If a block is already present, behavior will depend on the specific implementation, but should generally check for
+     * multipart compatibility (see {@link IForgeBlockState#getMultipartSlot()}) and perform an occlusion test.
+     */
+    public abstract boolean canAddBlockState(IWorld world, BlockPos pos, BlockState state);
+
+    /**
+     * Attempts to add the given {@link BlockState} to the world at the given position.<br/>
+     *
+     * If the current state at that position returns true in {@link BlockState#isAir(IBlockReader, BlockPos)}, this method
+     * can directly set the state at that position, ignoring any multipart behavior.<br/>
+     *
+     * {@link #canAddBlockState(IWorld, BlockPos, BlockState)} is assumed to have been called before this method.
+     */
+    public abstract boolean addBlockState(IWorld world, BlockPos pos, BlockState state, int flags);
+
+    /**
+     * Replaces the given {@link BlockState} with another.<br/>
+     *
+     * If the original state matches that of the block (as returned by {@code world.getBlockState(pos)}), this method
+     * must replace the state by calling {@code world.getBlockState(pos)} directly and return its result.<br/>
+     * If the original state matches that of a part in this block space, that part is to be replaced.<br/>
+     * If the original state does not match either of the above cases, this method must return {@code false}.
+     */
+    public abstract boolean replaceBlockState(IWorld world, BlockPos pos, BlockState originalState, BlockState newState, int flags);
+
+    /**
+     * Removes the given {@link BlockState} from the world.<br/>
+     *
+     * If the state matches that of the block (as returned by {@code world.getBlockState(pos)}), this method must call
+     * {@code world.removeBlock(pos, isMoving)} directly and return its result.<br/>
+     * If the state matches that of a part in this block space, that part is to be removed.<br/>
+     * If the state does not match either of the above cases, this method must return {@code false}.
+     */
+    public abstract boolean removeBlockState(IWorld world, BlockPos pos, BlockState state, boolean isMoving);
+
+    /**
+     * Destroys the given {@link BlockState}.<br/>
+     *
+     * If the state matches that of the block (as returned by {@code world.getBlockState(pos)}), this method must call
+     * {@code world.destroyBlock(pos, dropBlock)} directly and return its result.<br/>
+     * If the state matches that of a part in this block space, that part is to be destroyed.<br/>
+     * If the state does not match either of the above cases, this method must return {@code false}.
+     */
+    public abstract boolean destroyBlockState(IWorld world, BlockPos pos, BlockState state, boolean dropBlock);
+}

--- a/src/main/java/net/minecraftforge/common/multipart/MultipartHandler.java
+++ b/src/main/java/net/minecraftforge/common/multipart/MultipartHandler.java
@@ -42,10 +42,11 @@ public abstract class MultipartHandler extends ForgeRegistryEntry<MultipartHandl
     /**
      * Gets the {@link BlockState} at the specified slot in a block.<br/>
      *
-     * If the slot is {@link MultipartSlot#FULL_BLOCK}, this method must return {@code world.getBlockState(pos)}.<br/>
-     * If there isn't a part in the given slot, the returned state must return true when {@link BlockState#isAir(IBlockReader, BlockPos)} is called.
+     * If the slot is {@link BlockSlot#FULL_BLOCK}, this method must return {@code world.getBlockState(pos)}.<br/>
+     * If the slot matches that of a part in this block space, this method must return that BlockState.<br/>
+     * If there isn't a part in the given slot, the returned state must return {@code true} when {@link BlockState#isAir(IBlockReader, BlockPos)} is called.
      */
-    public abstract BlockState getBlockState(IBlockReader world, BlockPos pos, IMultipartSlot slot);
+    public abstract BlockState getBlockState(IBlockReader world, BlockPos pos, IBlockSlot slot);
 
     /**
      * Gets the {@link TileEntity} for the specified state in a block.<br/>

--- a/src/main/java/net/minecraftforge/common/multipart/MultipartHandler.java
+++ b/src/main/java/net/minecraftforge/common/multipart/MultipartHandler.java
@@ -28,6 +28,7 @@ import net.minecraftforge.common.extensions.IForgeBlockState;
 import net.minecraftforge.registries.ForgeRegistryEntry;
 
 import javax.annotation.Nullable;
+import java.util.Set;
 
 /**
  * Exposes the methods needed for placement, removal and retrieval of parts within a single block space.<br/>
@@ -40,6 +41,15 @@ import javax.annotation.Nullable;
 public abstract class MultipartHandler extends ForgeRegistryEntry<MultipartHandler>
 {
     /**
+     * Gets all the {@link IBlockSlot}s occupied by blocks in the given block space.<br/>
+     *
+     * If the current state is air, this method must return an empty set.<br/>
+     * If the given block space contains a single block, this method must return a set with its state's slot as its sole element.<br/>
+     * If the given block space contains multiple blocks, this method must return a set of all the slots they take up.
+     */
+    public abstract Set<IBlockSlot> getOccupiedSlots(IBlockReader world, BlockPos pos);
+
+    /**
      * Gets the {@link BlockState} at the specified slot in a block.<br/>
      *
      * If the slot is {@link BlockSlot#FULL_BLOCK}, this method must return {@code world.getBlockState(pos)}.<br/>
@@ -49,11 +59,21 @@ public abstract class MultipartHandler extends ForgeRegistryEntry<MultipartHandl
     public abstract BlockState getBlockState(IBlockReader world, BlockPos pos, IBlockSlot slot);
 
     /**
+     * Gets the {@link TileEntity} at the specified slot in a block.<br/>
+     *
+     * If the slot is {@link BlockSlot#FULL_BLOCK}, this method must return {@code world.getTileEntity(pos)}.<br/>
+     * If the slot matches that of a part in this block space, this method must return that TileEntity, if present.<br/>
+     * If there isn't a part in the given slot, this method must return {@code null}.
+     */
+    @Nullable
+    public abstract TileEntity getTileEntity(IBlockReader world, BlockPos pos, IBlockSlot slot);
+
+    /**
      * Gets the {@link TileEntity} for the specified state in a block.<br/>
      *
      * If the state matches that of the block (as returned by {@code world.getBlockState(pos)}), this method must return
      * {@code world.getTileEntity(pos)}.<br/>
-     * If the state matches that of a part in this block space, this method must return that TileEntity, if present.
+     * If the state matches that of a part in this block space, this method must return that TileEntity, if present.<br/>
      * If the state does not match either of the above cases, this method must return {@code null}.
      */
     @Nullable
@@ -65,7 +85,7 @@ public abstract class MultipartHandler extends ForgeRegistryEntry<MultipartHandl
      * If the current state at that position returns true in {@link BlockState#isAir(IBlockReader, BlockPos)}, this method
      * must return {@code true}.<br/>
      * If a block is already present, behavior will depend on the specific implementation, but should generally check for
-     * multipart compatibility (see {@link IForgeBlockState#getMultipartSlot()}) and perform an occlusion test.
+     * multipart compatibility (see {@link IForgeBlockState#getSlot()}) and perform an occlusion test.
      */
     public abstract boolean canAddBlockState(IWorld world, BlockPos pos, BlockState state);
 

--- a/src/main/java/net/minecraftforge/common/multipart/MultipartManager.java
+++ b/src/main/java/net/minecraftforge/common/multipart/MultipartManager.java
@@ -1,0 +1,96 @@
+/*
+ * Minecraft Forge
+ * Copyright (c) 2016-2019.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation version 2.1
+ * of the License.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+package net.minecraftforge.common.multipart;
+
+import net.minecraft.util.ResourceLocation;
+import net.minecraftforge.common.ForgeConfig;
+import net.minecraftforge.common.ForgeConfigSpec;
+import net.minecraftforge.event.RegistryEvent;
+import net.minecraftforge.eventbus.api.SubscribeEvent;
+import net.minecraftforge.registries.ForgeRegistries;
+import net.minecraftforge.registries.IForgeRegistry;
+
+import java.util.Arrays;
+
+/**
+ * Manages the current instance of {@link MultipartHandler} in use by the system and handles registration of Forge's
+ * built-in {@link IMultipartSlot multipart slots} and {@link NoOpMultipartHandler handler}.
+ *
+ * @see MultipartHandler
+ */
+public enum MultipartManager
+{
+    INSTANCE;
+
+    private MultipartHandler handler;
+
+    public MultipartHandler getHandler()
+    {
+        if (handler == null) updateActiveHandler();
+        return handler;
+    }
+
+    private void updateActiveHandler()
+    {
+        ForgeConfigSpec.ConfigValue<String> cfg = ForgeConfig.SERVER.multipartHandler;
+        String cfgValue = cfg.get().trim();
+
+        // Try to find the specified multipart handler
+        if(!cfgValue.isEmpty())
+        {
+            ResourceLocation handlerName = new ResourceLocation(cfgValue);
+            handler = ForgeRegistries.MULTIPART_HANDLERS.getValue(handlerName);
+            if (handler != null) return;
+            cfg.set(""); // We couldn't find it, so for now we'll leave the config value empty
+        }
+
+        // Default to the no-op handler for now
+        handler = NoOpMultipartHandler.INSTANCE;
+
+        // If we find a handler that is not the no-op one, use that one instead
+        for (MultipartHandler h : ForgeRegistries.MULTIPART_HANDLERS.getValues())
+        {
+            if (h == NoOpMultipartHandler.INSTANCE) continue;
+            handler = h;
+            cfg.set(h.getRegistryName().toString());
+            break;
+        }
+
+        // Update the config value so we use this handler from now on
+        cfg.save();
+    }
+
+    @SubscribeEvent
+    public void registerMultipartSlots(RegistryEvent.Register<IMultipartSlot> event)
+    {
+        IForgeRegistry<IMultipartSlot> registry = event.getRegistry();
+        registry.register(MultipartSlot.FULL_BLOCK);
+        registry.register(MultipartSlot.CENTER);
+        Arrays.stream(FaceSlot.values()).forEach(registry::register);
+        Arrays.stream(EdgeSlot.values()).forEach(registry::register);
+        Arrays.stream(CornerSlot.values()).forEach(registry::register);
+    }
+
+    @SubscribeEvent
+    public void registerMultipartHandlers(RegistryEvent.Register<MultipartHandler> event)
+    {
+        event.getRegistry().register(NoOpMultipartHandler.INSTANCE);
+    }
+}

--- a/src/main/java/net/minecraftforge/common/multipart/MultipartManager.java
+++ b/src/main/java/net/minecraftforge/common/multipart/MultipartManager.java
@@ -47,7 +47,7 @@ public enum MultipartManager
         return handler;
     }
 
-    private void updateActiveHandler()
+    public void updateActiveHandler()
     {
         ForgeConfigSpec.ConfigValue<String> cfg = ForgeConfig.SERVER.multipartHandler;
         String cfgValue = cfg.get().trim();

--- a/src/main/java/net/minecraftforge/common/multipart/MultipartManager.java
+++ b/src/main/java/net/minecraftforge/common/multipart/MultipartManager.java
@@ -31,7 +31,7 @@ import java.util.Arrays;
 
 /**
  * Manages the current instance of {@link MultipartHandler} in use by the system and handles registration of Forge's
- * built-in {@link IMultipartSlot multipart slots} and {@link NoOpMultipartHandler handler}.
+ * built-in {@link IBlockSlot block slots} and {@link NoOpMultipartHandler handler}.
  *
  * @see MultipartHandler
  */
@@ -78,11 +78,11 @@ public enum MultipartManager
     }
 
     @SubscribeEvent
-    public void registerMultipartSlots(RegistryEvent.Register<IMultipartSlot> event)
+    public void registerMultipartSlots(RegistryEvent.Register<IBlockSlot> event)
     {
-        IForgeRegistry<IMultipartSlot> registry = event.getRegistry();
-        registry.register(MultipartSlot.FULL_BLOCK);
-        registry.register(MultipartSlot.CENTER);
+        IForgeRegistry<IBlockSlot> registry = event.getRegistry();
+        registry.register(BlockSlot.FULL_BLOCK);
+        registry.register(BlockSlot.CENTER);
         Arrays.stream(FaceSlot.values()).forEach(registry::register);
         Arrays.stream(EdgeSlot.values()).forEach(registry::register);
         Arrays.stream(CornerSlot.values()).forEach(registry::register);

--- a/src/main/java/net/minecraftforge/common/multipart/MultipartSlot.java
+++ b/src/main/java/net/minecraftforge/common/multipart/MultipartSlot.java
@@ -1,0 +1,44 @@
+/*
+ * Minecraft Forge
+ * Copyright (c) 2016-2019.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation version 2.1
+ * of the License.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+package net.minecraftforge.common.multipart;
+
+import net.minecraftforge.registries.ForgeRegistryEntry;
+
+/**
+ * Default implementation of {@link IMultipartSlot} to reduce redundant code.<br/>
+ *
+ * @see IMultipartSlot
+ * @see FaceSlot
+ * @see EdgeSlot
+ * @see CornerSlot
+ */
+public class MultipartSlot extends ForgeRegistryEntry<IMultipartSlot> implements IMultipartSlot
+{
+    /**
+     * A slot that takes up the whole block.<br/>
+     * This slot is not meant to be used in practice and all implementations should treat blocks returning this as not
+     * supporting multipart behavior.
+     */
+    public static final IMultipartSlot FULL_BLOCK = new MultipartSlot().setRegistryName("forge", "full_block");
+    /**
+     * A generic slot located in the center of the block.
+     */
+    public static final IMultipartSlot CENTER = new MultipartSlot().setRegistryName("forge", "center");
+}

--- a/src/main/java/net/minecraftforge/common/multipart/NoOpMultipartHandler.java
+++ b/src/main/java/net/minecraftforge/common/multipart/NoOpMultipartHandler.java
@@ -45,10 +45,10 @@ public final class NoOpMultipartHandler extends MultipartHandler
     }
 
     @Override
-    public BlockState getBlockState(IBlockReader world, BlockPos pos, IMultipartSlot slot)
+    public BlockState getBlockState(IBlockReader world, BlockPos pos, IBlockSlot slot)
     {
         BlockState currentState = world.getBlockState(pos);
-        if (slot == MultipartSlot.FULL_BLOCK || slot == currentState.getMultipartSlot())
+        if (slot == BlockSlot.FULL_BLOCK || slot == currentState.getSlot())
         {
             return currentState;
         }

--- a/src/main/java/net/minecraftforge/common/multipart/NoOpMultipartHandler.java
+++ b/src/main/java/net/minecraftforge/common/multipart/NoOpMultipartHandler.java
@@ -1,0 +1,99 @@
+/*
+ * Minecraft Forge
+ * Copyright (c) 2016-2019.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation version 2.1
+ * of the License.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+package net.minecraftforge.common.multipart;
+
+import net.minecraft.block.BlockState;
+import net.minecraft.block.Blocks;
+import net.minecraft.tileentity.TileEntity;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.IBlockReader;
+import net.minecraft.world.IWorld;
+
+import javax.annotation.Nullable;
+
+/**
+ * The default implementation of {@link MultipartHandler} shipped with Forge.<br/>
+ * Placement, removal and retrieval logic is the same as vanilla.<br/>
+ *
+ * This is what will be used if there are no mod-provided implementations, or if the user forces this handler to be used.
+ *
+ * @see MultipartHandler
+ */
+public final class NoOpMultipartHandler extends MultipartHandler
+{
+    public static final MultipartHandler INSTANCE = new NoOpMultipartHandler().setRegistryName("forge", "noop");
+
+    private NoOpMultipartHandler()
+    {
+    }
+
+    @Override
+    public BlockState getBlockState(IBlockReader world, BlockPos pos, IMultipartSlot slot)
+    {
+        BlockState currentState = world.getBlockState(pos);
+        if (slot == MultipartSlot.FULL_BLOCK || slot == currentState.getMultipartSlot())
+        {
+            return currentState;
+        }
+        return Blocks.AIR.getDefaultState();
+    }
+
+    @Nullable
+    @Override
+    public TileEntity getTileEntity(IBlockReader world, BlockPos pos, BlockState state)
+    {
+        BlockState currentState = world.getBlockState(pos);
+        return state == currentState ? world.getTileEntity(pos) : null;
+    }
+
+    @Override
+    public boolean canAddBlockState(IWorld world, BlockPos pos, BlockState state)
+    {
+        return world.getBlockState(pos).isAir(world, pos);
+    }
+
+    @Override
+    public boolean addBlockState(IWorld world, BlockPos pos, BlockState state, int flags)
+    {
+        BlockState currentState = world.getBlockState(pos);
+        return currentState.isAir(world, pos) && world.setBlockState(pos, state, flags);
+    }
+
+    @Override
+    public boolean replaceBlockState(IWorld world, BlockPos pos, BlockState originalState, BlockState newState, int flags)
+    {
+        BlockState currentState = world.getBlockState(pos);
+        return originalState == currentState && world.setBlockState(pos, newState, flags);
+    }
+
+    @Override
+    public boolean removeBlockState(IWorld world, BlockPos pos, BlockState state, boolean isMoving)
+    {
+        BlockState currentState = world.getBlockState(pos);
+        return currentState == state && world.removeBlock(pos, isMoving);
+    }
+
+    @Override
+    public boolean destroyBlockState(IWorld world, BlockPos pos, BlockState state, boolean dropBlock)
+    {
+        BlockState currentState = world.getBlockState(pos);
+        return currentState == state && world.destroyBlock(pos, dropBlock);
+    }
+}

--- a/src/main/java/net/minecraftforge/common/multipart/NoOpMultipartHandler.java
+++ b/src/main/java/net/minecraftforge/common/multipart/NoOpMultipartHandler.java
@@ -27,6 +27,8 @@ import net.minecraft.world.IBlockReader;
 import net.minecraft.world.IWorld;
 
 import javax.annotation.Nullable;
+import java.util.Collections;
+import java.util.Set;
 
 /**
  * The default implementation of {@link MultipartHandler} shipped with Forge.<br/>
@@ -45,6 +47,17 @@ public final class NoOpMultipartHandler extends MultipartHandler
     }
 
     @Override
+    public Set<IBlockSlot> getOccupiedSlots(IBlockReader world, BlockPos pos)
+    {
+        BlockState currentState = world.getBlockState(pos);
+        if (currentState.isAir(world, pos))
+        {
+            return Collections.emptySet();
+        }
+        return Collections.singleton(currentState.getSlot());
+    }
+
+    @Override
     public BlockState getBlockState(IBlockReader world, BlockPos pos, IBlockSlot slot)
     {
         BlockState currentState = world.getBlockState(pos);
@@ -53,6 +66,18 @@ public final class NoOpMultipartHandler extends MultipartHandler
             return currentState;
         }
         return Blocks.AIR.getDefaultState();
+    }
+
+    @Nullable
+    @Override
+    public TileEntity getTileEntity(IBlockReader world, BlockPos pos, IBlockSlot slot)
+    {
+        BlockState currentState = world.getBlockState(pos);
+        if (slot == BlockSlot.FULL_BLOCK || slot == currentState.getSlot())
+        {
+            return world.getTileEntity(pos);
+        }
+        return null;
     }
 
     @Nullable

--- a/src/main/java/net/minecraftforge/common/util/SameBlockPlaceContext.java
+++ b/src/main/java/net/minecraftforge/common/util/SameBlockPlaceContext.java
@@ -1,3 +1,22 @@
+/*
+ * Minecraft Forge
+ * Copyright (c) 2016-2019.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation version 2.1
+ * of the License.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
 package net.minecraftforge.common.util;
 
 import net.minecraft.item.BlockItemUseContext;

--- a/src/main/java/net/minecraftforge/common/util/SameBlockPlaceContext.java
+++ b/src/main/java/net/minecraftforge/common/util/SameBlockPlaceContext.java
@@ -1,0 +1,12 @@
+package net.minecraftforge.common.util;
+
+import net.minecraft.item.BlockItemUseContext;
+
+public class SameBlockPlaceContext extends BlockItemUseContext {
+
+    public SameBlockPlaceContext(BlockItemUseContext context) {
+        super(context);
+        this.replaceClicked = true;
+    }
+
+}

--- a/src/main/java/net/minecraftforge/registries/ForgeRegistries.java
+++ b/src/main/java/net/minecraftforge/registries/ForgeRegistries.java
@@ -49,6 +49,8 @@ import net.minecraft.world.gen.feature.Feature;
 import net.minecraft.world.gen.placement.Placement;
 import net.minecraft.world.gen.surfacebuilders.SurfaceBuilder;
 import net.minecraftforge.common.ModDimension;
+import net.minecraftforge.common.multipart.IMultipartSlot;
+import net.minecraftforge.common.multipart.MultipartHandler;
 import net.minecraftforge.fml.common.registry.GameRegistry;
 
 /**
@@ -97,6 +99,8 @@ public class ForgeRegistries
     // Custom forge registries
     public static final IForgeRegistry<ModDimension> MOD_DIMENSIONS = RegistryManager.ACTIVE.getRegistry(ModDimension.class);
     public static final IForgeRegistry<DataSerializerEntry> DATA_SERIALIZERS = RegistryManager.ACTIVE.getRegistry(DataSerializerEntry.class);
+    public static final IForgeRegistry<IMultipartSlot> MULTIPART_SLOTS = RegistryManager.ACTIVE.getRegistry(IMultipartSlot.class);
+    public static final IForgeRegistry<MultipartHandler> MULTIPART_HANDLERS = RegistryManager.ACTIVE.getRegistry(MultipartHandler.class);
 
     /**
      * This function is just to make sure static inializers in other classes have run and setup their registries before we query them.

--- a/src/main/java/net/minecraftforge/registries/ForgeRegistries.java
+++ b/src/main/java/net/minecraftforge/registries/ForgeRegistries.java
@@ -49,7 +49,7 @@ import net.minecraft.world.gen.feature.Feature;
 import net.minecraft.world.gen.placement.Placement;
 import net.minecraft.world.gen.surfacebuilders.SurfaceBuilder;
 import net.minecraftforge.common.ModDimension;
-import net.minecraftforge.common.multipart.IMultipartSlot;
+import net.minecraftforge.common.multipart.IBlockSlot;
 import net.minecraftforge.common.multipart.MultipartHandler;
 import net.minecraftforge.fml.common.registry.GameRegistry;
 
@@ -99,7 +99,7 @@ public class ForgeRegistries
     // Custom forge registries
     public static final IForgeRegistry<ModDimension> MOD_DIMENSIONS = RegistryManager.ACTIVE.getRegistry(ModDimension.class);
     public static final IForgeRegistry<DataSerializerEntry> DATA_SERIALIZERS = RegistryManager.ACTIVE.getRegistry(DataSerializerEntry.class);
-    public static final IForgeRegistry<IMultipartSlot> MULTIPART_SLOTS = RegistryManager.ACTIVE.getRegistry(IMultipartSlot.class);
+    public static final IForgeRegistry<IBlockSlot> BLOCK_SLOTS = RegistryManager.ACTIVE.getRegistry(IBlockSlot.class);
     public static final IForgeRegistry<MultipartHandler> MULTIPART_HANDLERS = RegistryManager.ACTIVE.getRegistry(MultipartHandler.class);
 
     /**

--- a/src/main/java/net/minecraftforge/registries/GameData.java
+++ b/src/main/java/net/minecraftforge/registries/GameData.java
@@ -60,6 +60,8 @@ import net.minecraft.world.gen.placement.Placement;
 import net.minecraft.world.gen.surfacebuilders.SurfaceBuilder;
 import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.common.ModDimension;
+import net.minecraftforge.common.multipart.IMultipartSlot;
+import net.minecraftforge.common.multipart.MultipartHandler;
 import net.minecraftforge.event.RegistryEvent;
 import net.minecraftforge.event.RegistryEvent.MissingMappings;
 import net.minecraftforge.fml.LifecycleEventProvider;
@@ -136,6 +138,8 @@ public class GameData
     // Custom forge registries
     public static final ResourceLocation MODDIMENSIONS = new ResourceLocation("forge:moddimensions");
     public static final ResourceLocation SERIALIZERS = new ResourceLocation("minecraft:dataserializers");
+    public static final ResourceLocation MULTIPART_SLOTS = new ResourceLocation("forge:multipart_slots");
+    public static final ResourceLocation MULTIPART_HANDLERS = new ResourceLocation("forge:multipart_handlers");
 
     private static final int MAX_VARINT = Integer.MAX_VALUE - 1; //We were told it is their intention to have everything in a reg be unlimited, so assume that until we find cases where it isnt.
 
@@ -200,6 +204,8 @@ public class GameData
         // Custom forge registries
         makeRegistry(MODDIMENSIONS, ModDimension.class ).disableSaving().create();
         makeRegistry(SERIALIZERS, DataSerializerEntry.class, 256 /*vanilla space*/, MAX_VARINT).disableSaving().disableOverrides().addCallback(SerializerCallbacks.INSTANCE).create();
+        makeRegistry(MULTIPART_SLOTS, IMultipartSlot.class).disableSaving().disableOverrides().create();
+        makeRegistry(MULTIPART_HANDLERS, MultipartHandler.class).disableSaving().disableOverrides().create();
     }
 
     private static <T extends IForgeRegistryEntry<T>> RegistryBuilder<T> makeRegistry(ResourceLocation name, Class<T> type)

--- a/src/main/java/net/minecraftforge/registries/GameData.java
+++ b/src/main/java/net/minecraftforge/registries/GameData.java
@@ -60,7 +60,7 @@ import net.minecraft.world.gen.placement.Placement;
 import net.minecraft.world.gen.surfacebuilders.SurfaceBuilder;
 import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.common.ModDimension;
-import net.minecraftforge.common.multipart.IMultipartSlot;
+import net.minecraftforge.common.multipart.IBlockSlot;
 import net.minecraftforge.common.multipart.MultipartHandler;
 import net.minecraftforge.event.RegistryEvent;
 import net.minecraftforge.event.RegistryEvent.MissingMappings;
@@ -138,7 +138,7 @@ public class GameData
     // Custom forge registries
     public static final ResourceLocation MODDIMENSIONS = new ResourceLocation("forge:moddimensions");
     public static final ResourceLocation SERIALIZERS = new ResourceLocation("minecraft:dataserializers");
-    public static final ResourceLocation MULTIPART_SLOTS = new ResourceLocation("forge:multipart_slots");
+    public static final ResourceLocation BLOCK_SLOTS = new ResourceLocation("forge:block_slots");
     public static final ResourceLocation MULTIPART_HANDLERS = new ResourceLocation("forge:multipart_handlers");
 
     private static final int MAX_VARINT = Integer.MAX_VALUE - 1; //We were told it is their intention to have everything in a reg be unlimited, so assume that until we find cases where it isnt.
@@ -204,7 +204,7 @@ public class GameData
         // Custom forge registries
         makeRegistry(MODDIMENSIONS, ModDimension.class ).disableSaving().create();
         makeRegistry(SERIALIZERS, DataSerializerEntry.class, 256 /*vanilla space*/, MAX_VARINT).disableSaving().disableOverrides().addCallback(SerializerCallbacks.INSTANCE).create();
-        makeRegistry(MULTIPART_SLOTS, IMultipartSlot.class).disableSaving().disableOverrides().create();
+        makeRegistry(BLOCK_SLOTS, IBlockSlot.class).disableSaving().disableOverrides().create();
         makeRegistry(MULTIPART_HANDLERS, MultipartHandler.class).disableSaving().disableOverrides().create();
     }
 

--- a/src/main/resources/assets/forge/lang/en_us.json
+++ b/src/main/resources/assets/forge/lang/en_us.json
@@ -137,6 +137,8 @@
   "forge.configgui.forgeLightPipelineEnabled": "Forge Light Pipeline Enabled",
   "forge.configgui.selectiveResourceReloadEnabled.tooltip": "When enabled, makes specific reload tasks such as language changing quicker to run.",
   "forge.configgui.selectiveResourceReloadEnabled": "Enable Selective Resource Loading",
+  "forge.configgui.multipartHandler.tooltip": "Determines the handler for all multipart behavior in the instance. If empty (default), will be populated with the first mod-supplied handler available, or default to the vanilla one if none are present.",
+  "forge.configgui.multipartHandler": "Active Multipart Handler",
 
   "forge.controlsgui.shift": "SHIFT + %s",
   "forge.controlsgui.control": "CTRL + %s",


### PR DESCRIPTION
It's been a long while since the last one of these, and since the changes introduced in 1.13 and 1.14 (both in Minecraft and in Forge) have considerably improved the simplicity of adding a native multipart API to Forge, I thought I would have another go.

## The Problem

As it stands right now, there is no universal way to talk about multiple blocks coexisting in the same block space in Minecraft, and this is a type of behavior that a lot of developers seek.

In most cases, the solution tends to be to make a custom implementation for each mod's blocks.  
This solution generally works well enough when the mod is isolated, but players expect to be able to place things from multiple mods in the same block space, in much of the same way that the ones from the same mod can be.

Enter: the multipart API.

## The Objective

This PR intends to:
 * Add a universal implementation-agnostic multipart API
 * Add default multipart behavior that replicates that of vanilla when no 3rd party mods are installed
 * Replace several calls to vanilla's methods with calls to the new ones to support multipart behavior

It does however **not** intend to:
 * Add a multipart implementation to Forge
 * Add any kind of new block or item to the game
 * Extend vanilla blocks with multipart functionality
 * Handle the specifics of multipart behavior
 * Provide microblocks in any way

## The Solution

The implementation as of the first commit is extremely barebones, but defines all basic methods that need to exist for multiparts to be possible.

The multiparts in this system follow a very simple set of rules, and result in easily predictable outcomes:
 * Only one part can exist at a time in any given slot
 * Each BlockState has exactly one slot assigned
   * These two conditions imply that a two way lookup of slot->state and state->slot is possible within any block space (except for air)
   * This also implies that there can be at most one part with a given BlockState in any block space
 * Lookups for TileEntity data use the BlockState as an extra key
   * Given that for any given block space, there is a 1:1 mapping between slots and states, the state acts as a unique key to address its respective TileEntity
 * Two BlockStates in different slots can co-exist in the same block space so long as their occlusion tests against one another succeed

The API does not specify how multiparts should be internally handled, saved, synchronized, or interacted with. Specific behavior like that is left to be handled by the implementors of `MultipartHandler`s.  
It only specifies the basic logic that all implementations must follow for multipart systems to behave properly.

## The Code

I want to do quick dive into some of the things I've added and the sort of changes you would need to make to your codebase to support multiparts.

### Block Slots:
Let's talk about `BlockState#getSlot()` and its `Block` counterpart.
By default, this method returns `BlockSlot#FULL_BLOCK`, which is a special-cased slot that indicates that the state does not support multipart behavior.
Returning anything other than that indicates that your block opts into multipart behavior, if available, and determines which slot it will take up in the block.

### Working with TileEntities:
Normally, you would query your TileEntity by calling `world.getTileEntity(pos)`.
For multipart compatibility, you just need one extra argument: `world.getTileEntity(pos, state)`.
This is needed so that your block can be provided with its specific TileEntity, and not another part's or the container's. Calls to `Block` generally include the state as an argument, and that is what you will need to pass.

Alternatively, you can call `world.getTileEntity(pos, slot)` if you know the slot and don't care about the state (useful when querying capabilities).

### Working with BlockStates:
Normally, you would query a BlockState by calling `world.getBlockState(pos)`.
If you want to access a specific part in the block, you will need to call `world.getBlockState(pos, slot)`.

To update a state, you would usually call `world.setBlockState(pos, state)`, optionally passing in some flags.
If you want to replace a part, be it with another state of itself or with another state entirely, you will need to call `world.replaceBlockState(pos, oldState, newState, flags)`.

If you want to add a part at a given position, you will need to call `world.canAddBlockState(pos, state)`, and if the test succeeds, you can call `world.addBlockState(pos, state, flags)`.

For completion sake, `world.removeBlockState(...)` and `world.destroyBlockState(...)` have also been given a new variant that takes in the state to be targeted.

### Slots:
A slot in itself doesn't represent anything. It is exclusively a way for mods to address the same part of a block in a consistent way, and in most cases will not be relevant to developers.

By default, 4 kinds of slots are provided (`FaceSlot`, `EdgeSlot`, `CornerSlot` and `BlockSlot#CENTER`), however more can be added to fit any mod's needs and avoid clashing with other blocks.

To query the slots currently taken up in a block, you can call `world.getOccupiedSlots(pos)`.

### Block(State) x Block(State) Occlusion Testing:
When two blocks want to coexist in the same block space, they are first tested to ensure they don't take up the same slot, and afterwards, that they don't intersect each other. That last one is the occlusion test.

`BlockState#testOcclusion(world, pos otherState)` and its `Block` counterpart handle the occlusion test for any given state. By default they return `ActionResultType#PASS`.

When testing occlusion, both states are checked.
If one of them returns `ActionResultType#FAIL`, the two blocks intersect.
If neither fail, but one returns `ActionResultType#SUCCESS`, the blocks do not intersect.
If both return `ActionResultType#PASS`, it is down to the caller to handle the default occlusion test.

The default occlusion test is done by calculating the intersection of the `VoxelShape` returned by each of the states in `BlockState#getOcclusionShape(world, pos)` (and its `Block` counterpart). By default this method returns `BlockState#getShape(...)` and will in most cases be overridden.

### Block(State) x VoxelShape Occlusion Testing:
Some blocks need to test that nothing is in the way before they can do specific things. In the case of a pipe for example, this would happen when trying to connect to a neighboring pipe or to an inventory/tank.
In this case, since there is no other state to test occlusion against, it'd have to be against a `VoxelShape`.

The procedure in this case is the same as the default occlusion test for states.

**Note:** Multipart containers should wrap as many methods as they can, including `Block#getOcclusionShape(...)`, meaning that if you want to test against the whole block instead of going part by part, you can test against the container directly.

## Request For Comments

I would like to hear the community's ideas and comments on this proposal to try to improve it before it gets merged.
I've tried to keep it minimal since it really doesn't need to be much more complex than this to work, but there are probably quality of life features you could want.

**If there is anything that jumps out to you, that you miss, or that you think should be changed, by all means let me know and we can talk about it! :)**