### PR TITLE
[1.14] Added Energy limit bypass overload

### DIFF
--- a/src/main/java/net/minecraftforge/energy/EnergyStorage.java
+++ b/src/main/java/net/minecraftforge/energy/EnergyStorage.java
@@ -63,7 +63,8 @@ public class EnergyStorage implements IEnergyStorage
 
         int energyReceived = Math.min(capacity - energy, Math.min(this.maxReceive, maxReceive));
         if (!simulate)
-            energy += energyReceived;
+            setEnergyStored(energy + energyReceived);
+
         return energyReceived;
     }
 
@@ -75,14 +76,41 @@ public class EnergyStorage implements IEnergyStorage
 
         int energyExtracted = Math.min(energy, Math.min(this.maxExtract, maxExtract));
         if (!simulate)
-            energy -= energyExtracted;
+            setEnergyStored(energy - energyExtracted);
+
         return energyExtracted;
+    }
+
+    /**
+     * Triggered any time the energy state changes.
+     *
+     * @param prevValue - value before changes were applied
+     * @param newValue - new value after changes were applied
+     */
+    protected void onEnergyChanged(int prevValue, int newValue)
+    {
+        //Override this to implement update/sync logic
     }
 
     @Override
     public int getEnergyStored()
     {
         return energy;
+    }
+
+    /**
+     * Allows setting the energy directly
+     *
+     * @param value - value to set
+     */
+    public void setEnergyStored(int value)
+    {
+        final int prevEnergy = this.energy;
+        this.energy = Math.max(0, Math.min(value, getMaxEnergyStored()));
+        if (prevEnergy != this.energy)
+        {
+            onEnergyChanged(prevEnergy, value);
+        }
     }
 
     @Override

--- a/src/main/java/net/minecraftforge/energy/EnergyStorage.java
+++ b/src/main/java/net/minecraftforge/energy/EnergyStorage.java
@@ -69,6 +69,29 @@ public class EnergyStorage implements IEnergyStorage
     }
 
     @Override
+    public int receiveEnergy(int maxReceive, boolean simulate, boolean bypassLimits, boolean matchExact)
+    {
+        //Enforce take all, not enough storage space
+        if(matchExact && (getEnergyStored() + maxReceive > getMaxEnergyStored())) {
+            return 0;
+        }
+        //Bypass
+        else if(bypassLimits)
+        {
+            int energyReceived = Math.min(capacity - energy, maxReceive);
+            if (!simulate)
+                setEnergyStored(energy + energyReceived);
+
+            return energyReceived;
+        }
+        //Enforce take all, breaks max limit check
+        else if(matchExact && maxReceive > this.maxReceive) {
+            return 0;
+        }
+        return receiveEnergy(maxReceive, simulate);
+    }
+
+    @Override
     public int extractEnergy(int maxExtract, boolean simulate)
     {
         if (!canExtract())
@@ -79,6 +102,29 @@ public class EnergyStorage implements IEnergyStorage
             setEnergyStored(energy - energyExtracted);
 
         return energyExtracted;
+    }
+
+    @Override
+    public int extractEnergy(int maxExtract, boolean simulate, boolean bypassLimits, boolean matchExact)
+    {
+        //Enforce remove all, don't have enough energy check
+        if(matchExact && maxExtract > energy) {
+            return 0;
+        }
+        //Bypass
+        else if(bypassLimits)
+        {
+            int energyExtracted = Math.min(energy, maxExtract);
+            if (!simulate)
+                setEnergyStored(energy - energyExtracted);
+
+            return energyExtracted;
+        }
+        //Enforce remove all, breaks max limit check
+        else if(matchExact && (maxExtract > this.maxExtract)) {
+            return 0;
+        }
+        return extractEnergy(maxExtract, simulate);
     }
 
     /**

--- a/src/main/java/net/minecraftforge/energy/IEnergyStorage.java
+++ b/src/main/java/net/minecraftforge/energy/IEnergyStorage.java
@@ -39,7 +39,24 @@ public interface IEnergyStorage
     *            If TRUE, the insertion will only be simulated.
     * @return Amount of energy that was (or would have been, if simulated) accepted by the storage.
     */
-    int receiveEnergy(int maxReceive, boolean simulate);
+    default int receiveEnergy(int maxReceive, boolean simulate){
+        return receiveEnergy(maxReceive, simulate, false, false);
+    }
+
+    /**
+     * Adds energy to the storage. Returns quantity of energy that was accepted.
+     *
+     * @param maxReceive
+     *            Maximum amount of energy to be inserted.
+     * @param simulate
+     *            If TRUE, the extraction will only be simulated.
+     * @param bypassLimits
+     *            If TRUE, the input limit should be ignored
+     * @param matchExact
+     *            If TRUE, the receive should be exact instead of partial (take all or none)
+     * @return Amount of energy that was (or would have been, if simulated) accepted by the storage.
+     */
+    int receiveEnergy(int maxReceive, boolean simulate, boolean bypassLimits, boolean matchExact);
 
     /**
     * Removes energy from the storage. Returns quantity of energy that was removed.
@@ -50,7 +67,24 @@ public interface IEnergyStorage
     *            If TRUE, the extraction will only be simulated.
     * @return Amount of energy that was (or would have been, if simulated) extracted from the storage.
     */
-    int extractEnergy(int maxExtract, boolean simulate);
+    default int extractEnergy(int maxExtract, boolean simulate){
+        return extractEnergy(maxExtract, simulate, false, false);
+    }
+
+    /**
+     * Removes energy from the storage. Returns quantity of energy that was removed.
+     *
+     * @param maxExtract
+     *            Maximum amount of energy to be extracted.
+     * @param simulate
+     *            If TRUE, the extraction will only be simulated.
+     * @param bypassLimits
+     *            If TRUE, the input limit should be ignored
+     * @param matchExact
+     *            If TRUE, the extract should be exact instead of partial (take all or none)
+     * @return Amount of energy that was (or would have been, if simulated) extracted from the storage.
+     */
+    int extractEnergy(int maxExtract, boolean simulate, boolean bypassLimits, boolean matchExact);
 
     /**
     * Returns the amount of energy currently stored.

--- a/src/test/java/net/minecraftforge/test/capabilities/EnergyCapTest.java
+++ b/src/test/java/net/minecraftforge/test/capabilities/EnergyCapTest.java
@@ -1,0 +1,187 @@
+package net.minecraftforge.test.capabilities;
+
+import net.minecraftforge.energy.EnergyStorage;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Created by Dark(DarkGuardsman, Robert) on 8/10/2019.
+ */
+public class EnergyCapTest
+{
+    @Test //Test that old saves will not load beyond the limit of the buffer
+    public void basicEnergyInitBeyondLimit() {
+        final EnergyStorage storage = new EnergyStorage(1000, 10, 10, 5000);
+
+        //Test we received only 1000
+        Assertions.assertEquals(1000, storage.getEnergyStored());
+    }
+
+    @Test
+    public void basicEnergyAdd() {
+        final EnergyStorage storage = new EnergyStorage(1000, 10, 10, 0);
+
+        //Test the limits are still enforced
+        final int received = storage.receiveEnergy(100, false, false, false);
+
+        //Test we received only 10
+        Assertions.assertEquals(10, received);
+        Assertions.assertEquals(10, storage.getEnergyStored());
+    }
+
+    @Test
+    public void basicEnergyAddBeyondLimit() {
+        final EnergyStorage storage = new EnergyStorage(1000, 1000, 1000, 0);
+
+        //Test the limits are still enforced
+        final int received = storage.receiveEnergy(5000, false, false, false);
+
+        //Test we received only 10
+        Assertions.assertEquals(1000, received);
+        Assertions.assertEquals(1000, storage.getEnergyStored());
+    }
+
+    @Test
+    public void basicEnergyRemove() {
+        final EnergyStorage storage = new EnergyStorage(1000, 10, 10, 1000);
+
+        //Test the limits are still enforced
+        final int extract = storage.extractEnergy(100, false, false, false);
+
+        //Test we removed only 10
+        Assertions.assertEquals(10, extract);
+        Assertions.assertEquals(990, storage.getEnergyStored());
+    }
+
+    @Test
+    public void basicEnergyRemoveBeyondLimit() {
+        final EnergyStorage storage = new EnergyStorage(1000, 1000, 1000, 1000);
+
+        //Test the limits are still enforced
+        final int extract = storage.extractEnergy(5000, false, false, false);
+
+        //Test we removed only 10
+        Assertions.assertEquals(1000, extract);
+        Assertions.assertEquals(0, storage.getEnergyStored());
+    }
+
+    @Test
+    public void basicEnergyAddSimulate() {
+        final EnergyStorage storage = new EnergyStorage(1000, 10, 10, 0);
+
+        //Test the limits are still enforced
+        final int received = storage.receiveEnergy(100, true, false, false);
+
+        //Test we received only 10
+        Assertions.assertEquals(10, received);
+        Assertions.assertEquals(0, storage.getEnergyStored());
+    }
+
+    @Test
+    public void basicEnergyRemoveSimulate() {
+        final EnergyStorage storage = new EnergyStorage(1000, 10, 10, 1000);
+
+        //Test the limits are still enforced
+        final int extract = storage.extractEnergy(100, true, false, false);
+
+        //Test we removed only 10
+        Assertions.assertEquals(10, extract);
+        Assertions.assertEquals(1000, storage.getEnergyStored());
+    }
+
+    @Test
+    public void energyAddBypass() {
+        final EnergyStorage storage = new EnergyStorage(1000, 10, 10, 0);
+
+        //Test the limits are still enforced
+        final int received = storage.receiveEnergy(100, false, true, false);
+
+        //Test we received only 10
+        Assertions.assertEquals(100, received);
+        Assertions.assertEquals(100, storage.getEnergyStored());
+    }
+
+    @Test
+    public void energyRemoveBypass() {
+        final EnergyStorage storage = new EnergyStorage(1000, 10, 10, 1000);
+
+        //Test the limits are still enforced
+        final int extract = storage.extractEnergy(100, false, true, false);
+
+        //Test we removed only 10
+        Assertions.assertEquals(100, extract);
+        Assertions.assertEquals(900, storage.getEnergyStored());
+    }
+
+    @Test //Tests normal reaction
+    public void energyAddTakeAll() {
+        final EnergyStorage storage = new EnergyStorage(1000, 10, 10, 0);
+
+        //Test the limits are still enforced
+        final int received = storage.receiveEnergy(10, false, false, true);
+
+        //Test we received only 10
+        Assertions.assertEquals(10, received);
+        Assertions.assertEquals(10, storage.getEnergyStored());
+    }
+
+    @Test //Tests normal reaction
+    public void energyRemoveTakeAll() {
+        final EnergyStorage storage = new EnergyStorage(1000, 10, 10, 100);
+
+        //Test the limits are still enforced
+        final int extract = storage.extractEnergy(10, false, false, true);
+
+        //Test we removed only 10
+        Assertions.assertEquals(10, extract);
+        Assertions.assertEquals(90, storage.getEnergyStored());
+    }
+
+    @Test //Tests the limit fail check
+    public void energyAddTakeAllFailLimit() {
+        final EnergyStorage storage = new EnergyStorage(1000, 10, 10, 0);
+
+        //Test the limits are still enforced
+        final int received = storage.receiveEnergy(100, false, false, true);
+
+        //Test we received only 10
+        Assertions.assertEquals(0, received);
+        Assertions.assertEquals(0, storage.getEnergyStored());
+    }
+
+    @Test //Tests the limit fail check
+    public void energyRemoveTakeAllFailLimit() {
+        final EnergyStorage storage = new EnergyStorage(1000, 10, 10, 100);
+
+        //Test the limits are still enforced
+        final int extract = storage.extractEnergy(100, false, false, true);
+
+        //Test we removed only 10
+        Assertions.assertEquals(0, extract);
+        Assertions.assertEquals(100, storage.getEnergyStored());
+    }
+
+    @Test //Tests the fail condition for no room left
+    public void energyAddTakeAllFailNoRoom() {
+        final EnergyStorage storage = new EnergyStorage(1000, 10, 10, 999);
+
+        //Test the limits are still enforced
+        final int received = storage.receiveEnergy(10,false, false, true);
+
+        //Test we received only 10
+        Assertions.assertEquals(0, received);
+        Assertions.assertEquals(999, storage.getEnergyStored());
+    }
+
+    @Test //Tests the fail condition for not enough energy left
+    public void energyRemoveTakeAllFailNoEnergy() {
+        final EnergyStorage storage = new EnergyStorage(1000, 10, 10, 3);
+
+        //Test the limits are still enforced
+        final int extract = storage.extractEnergy(10,false, false, true);
+
+        //Test we removed only 10
+        Assertions.assertEquals(0, extract);
+        Assertions.assertEquals(3, storage.getEnergyStored());
+    }
+}


### PR DESCRIPTION
Try 3: Again this is open to discussion and I'm willing to make changes as needed.

Additional Pull to previous https://github.com/MinecraftForge/MinecraftForge/pull/5993

**Pull Itself**
The idea behind this change is to make it possible to bypass limit checks during energy receive and extract calls. While allowing the capability implementation to decide when and how this happens. See the previous pull request for reasons why. 

**Aditional Change**
Provided with this is also the ability to request that the energy capability return an exact match for the request. The goal with this change is for packet driven energy systems that only send or receive set amounts of energy. 

**Unit tests** 
All changes are provided with unit tests. I an add more as needed to bring up the class to 100% coverage. 