### PR TITLE
Re-implement custom atlas sprites

### DIFF
--- a/patches/minecraft/net/minecraft/client/renderer/texture/AtlasTexture.java.patch
+++ b/patches/minecraft/net/minecraft/client/renderer/texture/AtlasTexture.java.patch
@@ -1,22 +1,32 @@
 --- a/net/minecraft/client/renderer/texture/AtlasTexture.java
 +++ b/net/minecraft/client/renderer/texture/AtlasTexture.java
+@@ -33,7 +33,7 @@
+ import org.apache.logging.log4j.Logger;
+ 
+ @OnlyIn(Dist.CLIENT)
+-public class AtlasTexture extends Texture implements ITickableTextureObject {
++public class AtlasTexture extends Texture implements ITickableTextureObject, net.minecraftforge.client.extensions.IForgeAtlasTexture {
+    private static final Logger field_147635_d = LogManager.getLogger();
+    public static final ResourceLocation field_110575_b = new ResourceLocation("textures/atlas/blocks.png");
+    public static final ResourceLocation field_215262_g = new ResourceLocation("textures/atlas/particles.png");
 @@ -80,6 +80,7 @@
           }
        }
  
-+      net.minecraftforge.client.ForgeHooksClient.onTextureStitchedPost(this);
++      onTextureStitchedPost();
     }
  
     public AtlasTexture.SheetData func_215254_a(IResourceManager p_215254_1_, Iterable<ResourceLocation> p_215254_2_, IProfiler p_215254_3_) {
-@@ -92,6 +93,7 @@
-             set.add(p_215253_1_);
-          }
-       });
-+      net.minecraftforge.client.ForgeHooksClient.onTextureStitchedPre(this, set);
-       int i = this.field_215265_o;
-       Stitcher stitcher = new Stitcher(i, i, this.field_147636_j);
-       int j = Integer.MAX_VALUE;
-@@ -111,6 +113,7 @@
+@@ -98,7 +99,7 @@
+       int k = 1 << this.field_147636_j;
+       p_215254_3_.func_219895_b("extracting_frames");
+ 
+-      for(TextureAtlasSprite textureatlassprite : this.func_215256_a(p_215254_1_, set)) {
++      for(TextureAtlasSprite textureatlassprite : collectSprites(p_215254_1_, set, this::func_215256_a)) {
+          j = Math.min(j, Math.min(textureatlassprite.func_94211_a(), textureatlassprite.func_94216_b()));
+          int l = Math.min(Integer.lowestOneBit(textureatlassprite.func_94211_a()), Integer.lowestOneBit(textureatlassprite.func_94216_b()));
+          if (l < k) {
+@@ -111,6 +112,7 @@
  
        int i1 = Math.min(j, k);
        int j1 = MathHelper.func_151239_c(i1);
@@ -24,24 +34,37 @@
        if (j1 < this.field_147636_j) {
           field_147635_d.warn("{}: dropping miplevel from {} to {}, because of minimum power of two: {}", this.field_94254_c, this.field_147636_j, j1, i1);
           this.field_147636_j = j1;
-@@ -198,6 +201,7 @@
+@@ -135,7 +137,7 @@
+       }
  
-       label62: {
-          boolean flag;
-+         if (p_195422_2_.hasCustomLoader(p_195422_1_, resourcelocation)) break label62;
-          try {
-             iresource = p_195422_1_.func_199002_a(resourcelocation);
-             p_195422_2_.func_195664_a(iresource, this.field_147636_j + 1);
-@@ -275,6 +279,93 @@
-       this.field_94258_i.clear();
+       p_215254_3_.func_219895_b("loading");
+-      List<TextureAtlasSprite> list = this.func_215259_a(p_215254_1_, stitcher);
++      List<TextureAtlasSprite> list = processTextures(p_215254_1_, stitcher.func_94309_g());
+       p_215254_3_.func_76319_b();
+       return new AtlasTexture.SheetData(set, stitcher.func_110935_a(), stitcher.func_110936_b(), list);
     }
+@@ -215,10 +217,13 @@
  
+          return flag;
+       }
++      generateMipmaps(p_195422_2_);
++      return true;
++   }
+ 
++   public void generateMipmaps(TextureAtlasSprite p_195422_2_) {
+       try {
+          p_195422_2_.func_147963_d(this.field_147636_j);
+-         return true;
+       } catch (Throwable throwable) {
+          CrashReport crashreport = CrashReport.func_85055_a(throwable, "Applying mipmap");
+          CrashReportCategory crashreportcategory = crashreport.func_85058_a("Sprite being mipmapped");
+@@ -289,4 +294,24 @@
+          this.field_217808_d = p_i49874_4_;
+       }
+    }
 +   //===================================================================================================
 +   //                                           Forge Start
 +   //===================================================================================================
-+
-+   private final java.util.Deque<ResourceLocation> loadingSprites = new java.util.ArrayDeque<>();
-+   private final java.util.Set<ResourceLocation> loadedSprites = new java.util.HashSet<>();
 +
 +   public String getBasePath()
 +   {
@@ -53,76 +76,10 @@
 +       return field_147636_j;
 +   }
 +
-+   private int loadTexture(Stitcher stitcher, IResourceManager manager, ResourceLocation resourcelocation, int j, int k)
++   @Override
++   public TextureAtlasSprite getMissingTexture()
 +   {
-+      if (loadedSprites.contains(resourcelocation))
-+      {
-+         return j;
-+      }
-+      TextureAtlasSprite textureatlassprite;
-+      ResourceLocation resourcelocation1 = this.func_195420_b(resourcelocation);
-+      for (ResourceLocation loading : loadingSprites)
-+      {
-+         if (resourcelocation1.equals(loading))
-+         {
-+            final String error = "circular model dependencies, stack: [" + com.google.common.base.Joiner.on(", ").join(loadingSprites) + "]";
-+            net.minecraftforge.fml.client.ClientHooks.trackBrokenTexture(resourcelocation, error);
-+         }
-+      }
-+      loadingSprites.addLast(resourcelocation1);
-+      try (IResource iresource = manager.func_199002_a(resourcelocation1))
-+      {
-+         PngSizeInfo pngsizeinfo = new PngSizeInfo(iresource.toString(), iresource.func_199027_b());
-+         AnimationMetadataSection animationmetadatasection = iresource.func_199028_a(AnimationMetadataSection.field_195817_a);
-+         textureatlassprite = new TextureAtlasSprite(resourcelocation, pngsizeinfo, animationmetadatasection);
-+
-+         for (ResourceLocation dependency : textureatlassprite.getDependencies())
-+         {
-+            if (!field_195427_i.contains(dependency))
-+            {
-+               this.field_195427_i.add(dependency);
-+            }
-+            j = loadTexture(stitcher, manager, dependency, j, k);
-+         }
-+         if (textureatlassprite.hasCustomLoader(manager, resourcelocation))
-+         {
-+            if (textureatlassprite.load(manager, resourcelocation, field_94252_e::get))
-+            {
-+               return j;
-+            }
-+         }
-+         j = Math.min(j, Math.min(textureatlassprite.func_94211_a(), textureatlassprite.func_94216_b()));
-+         int j1 = Math.min(Integer.lowestOneBit(textureatlassprite.func_94211_a()), Integer.lowestOneBit(textureatlassprite.func_94216_b()));
-+         if (j1 < k)
-+         {
-+            // FORGE: do not lower the mipmap level, just log the problematic textures
-+            field_147635_d.warn("Texture {} with size {}x{} will have visual artifacts at mip level {}, it can only support level {}." +
-+                    "Please report to the mod author that the texture should be some multiple of 16x16.",
-+                    resourcelocation1, textureatlassprite.func_94211_a(), textureatlassprite.func_94216_b(), MathHelper.func_151239_c(k), MathHelper.func_151239_c(j1));
-+         }
-+         if (func_195422_a(manager, textureatlassprite))
-+         {
-+            stitcher.func_110934_a(textureatlassprite);
-+         }
-+         return j;
-+      }
-+      catch (RuntimeException runtimeexception)
-+      {
-+         net.minecraftforge.fml.client.ClientHooks.trackBrokenTexture(resourcelocation, runtimeexception.getMessage());
-+         return j;
-+      }
-+      catch (IOException ioexception)
-+      {
-+         net.minecraftforge.fml.client.ClientHooks.trackMissingTexture(resourcelocation);
-+         return j;
-+      }
-+      finally
-+      {
-+         loadingSprites.removeLast();
-+         field_195427_i.add(resourcelocation1);
-+      }
++      return field_94249_f;
 +   }
 +
-    @OnlyIn(Dist.CLIENT)
-    public static class SheetData {
-       final Set<ResourceLocation> field_217805_a;
+ }

--- a/patches/minecraft/net/minecraft/client/renderer/texture/TextureAtlasSprite.java.patch
+++ b/patches/minecraft/net/minecraft/client/renderer/texture/TextureAtlasSprite.java.patch
@@ -42,7 +42,7 @@
           p_195667_3_[i].func_195706_a(i, this.field_110975_c >> i, this.field_110974_d >> i, p_195667_1_ >> i, p_195667_2_ >> i, this.field_130223_c >> i, this.field_130224_d >> i, this.field_195670_c.length > 1);
        }
  
-@@ -464,4 +471,10 @@
+@@ -464,4 +471,14 @@
     public void func_195663_q() {
        this.func_195659_d(0);
     }
@@ -51,5 +51,9 @@
 +   
 +   public int getPixelRGBA(int frameIndex, int x, int y) {
 +       return this.field_195670_c[frameIndex].func_195709_a(x + this.field_195671_d[frameIndex] * this.field_130223_c, y + this.field_195672_e[frameIndex] * this.field_130224_d);
++   }
++
++   public NativeImage getImage(int frameIndex) {
++      return field_195670_c[frameIndex];
 +   }
  }

--- a/src/main/java/net/minecraftforge/client/ForgeHooksClient.java
+++ b/src/main/java/net/minecraftforge/client/ForgeHooksClient.java
@@ -91,9 +91,7 @@ import net.minecraftforge.client.event.RenderHandEvent;
 import net.minecraftforge.client.event.RenderSpecificHandEvent;
 import net.minecraftforge.client.event.RenderWorldLastEvent;
 import net.minecraftforge.client.event.ScreenshotEvent;
-import net.minecraftforge.client.event.TextureStitchEvent;
 import net.minecraftforge.client.event.sound.PlaySoundEvent;
-import net.minecraftforge.client.model.ModelDynBucket;
 import net.minecraftforge.client.model.ModelLoader;
 import net.minecraftforge.client.model.animation.Animation;
 import net.minecraftforge.client.model.pipeline.QuadGatheringTransformer;
@@ -165,18 +163,6 @@ public class ForgeHooksClient
     public static boolean renderSpecificFirstPersonHand(Hand hand, float partialTicks, float interpPitch, float swingProgress, float equipProgress, ItemStack stack)
     {
         return MinecraftForge.EVENT_BUS.post(new RenderSpecificHandEvent(hand, partialTicks, interpPitch, swingProgress, equipProgress, stack));
-    }
-
-    public static void onTextureStitchedPre(AtlasTexture map, Set<ResourceLocation> resourceLocations)
-    {
-        ModLoader.get().postEvent(new TextureStitchEvent.Pre(map, resourceLocations));
-//        ModelLoader.White.INSTANCE.register(map); // TODO Custom TAS
-        ModelDynBucket.LoaderDynBucket.INSTANCE.register(map);
-    }
-
-    public static void onTextureStitchedPost(AtlasTexture map)
-    {
-        ModLoader.get().postEvent(new TextureStitchEvent.Post(map));
     }
 
     public static void onBlockColorsInit(BlockColors blockColors)

--- a/src/main/java/net/minecraftforge/client/event/TextureStitchEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/TextureStitchEvent.java
@@ -18,8 +18,10 @@
  */
 
 package net.minecraftforge.client.event;
-
+import java.util.List;
+import net.minecraft.resources.IResourceManager;
 import net.minecraft.util.ResourceLocation;
+import net.minecraftforge.client.extensions.IForgeAtlasTexture;
 import net.minecraftforge.eventbus.api.Event;
 import net.minecraft.client.renderer.texture.AtlasTexture;
 
@@ -43,22 +45,36 @@ public class TextureStitchEvent extends Event
     /**
      * Fired when the TextureMap is told to refresh it's stitched texture.
      * Called before the {@link net.minecraft.client.renderer.texture.TextureAtlasSprite} are loaded.
+     * Custom sprites added here will be evaluated in parallel with normal sprites.
+     * In case of id conflict custom sprites will have priority.
      */
     public static class Pre extends TextureStitchEvent
     {
+        private final IResourceManager resourceManager;
         private final Set<ResourceLocation> sprites;
+        private final List<IForgeAtlasTexture.SpriteProvider> customSprites;
 
-        public Pre(AtlasTexture map, Set<ResourceLocation> sprites)
+        public Pre(AtlasTexture map, IResourceManager resourceManager, Set<ResourceLocation> sprites, List<IForgeAtlasTexture.SpriteProvider> customSprites)
         {
             super(map);
+            this.resourceManager = resourceManager;
             this.sprites = sprites;
+            this.customSprites = customSprites;
         }
 
-        /**
-         * Add a sprite to be stitched into the Texture Atlas.
-         */
-        public boolean addSprite(ResourceLocation sprite) {
-            return this.sprites.add(sprite);
+        public boolean addSprite(ResourceLocation sprite)
+        {
+            return sprites.add(sprite);
+        }
+
+        public void addSprite(final IForgeAtlasTexture.SpriteProvider sprite)
+        {
+            customSprites.add(sprite);
+        }
+
+        public IResourceManager getResourceManager()
+        {
+            return resourceManager;
         }
     }
 

--- a/src/main/java/net/minecraftforge/client/extensions/IForgeAtlasTexture.java
+++ b/src/main/java/net/minecraftforge/client/extensions/IForgeAtlasTexture.java
@@ -1,0 +1,197 @@
+/*
+ * Minecraft Forge
+ * Copyright (c) 2016-2019.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation version 2.1
+ * of the License.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+package net.minecraftforge.client.extensions;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+import com.google.common.graph.GraphBuilder;
+import com.google.common.graph.MutableGraph;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+import java.util.function.BiFunction;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.renderer.texture.AtlasTexture;
+import net.minecraft.client.renderer.texture.TextureAtlasSprite;
+import net.minecraft.resources.IResourceManager;
+import net.minecraft.util.ResourceLocation;
+import net.minecraft.util.Util;
+import net.minecraftforge.client.event.TextureStitchEvent;
+import net.minecraftforge.client.model.ModelDynBucket;
+import net.minecraftforge.client.model.ModelLoader;
+import net.minecraftforge.fml.ModLoader;
+import net.minecraftforge.fml.client.ClientHooks;
+import net.minecraftforge.fml.loading.toposort.CyclePresentException;
+import net.minecraftforge.fml.loading.toposort.TopologicalSort;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+public interface IForgeAtlasTexture
+{
+    Logger LOGGER = LogManager.getLogger();
+
+    default AtlasTexture getAtlasTexture()
+    {
+        return (AtlasTexture)this;
+    }
+
+    @FunctionalInterface
+    interface SpriteProvider
+    {
+        TextureAtlasSprite create(IResourceManager manager) throws Exception;
+    }
+
+    default List<TextureAtlasSprite> resolveSpriteDependencies(Collection<TextureAtlasSprite> sprites)
+    {
+        Map<ResourceLocation, TextureAtlasSprite> idToSprite = Maps.newHashMap();
+        MutableGraph<TextureAtlasSprite> graph = GraphBuilder.directed().allowsSelfLoops(false).build();
+        sprites.forEach(node -> {
+            graph.addNode(node);
+            idToSprite.put(node.getName(), node);
+        });
+        sprites.forEach(s -> s.getDependencies().forEach(dep -> {
+            final TextureAtlasSprite dependency = idToSprite.get(dep);
+            if (dependency == null)
+            {
+                ClientHooks.trackBrokenTexture(dep, "Missing dependency requested from sprite " + s.getName());
+            }
+            else
+            {
+                graph.putEdge(dependency, s);
+            }
+        }));
+
+        try
+        {
+            return TopologicalSort.topologicalSort(graph, null);
+        }
+        catch (CyclePresentException e)
+        {
+            Set<Set<TextureAtlasSprite>> cycles = e.getCycles();
+            cycles.stream().flatMap(Set::stream).distinct().forEach(sprite -> {
+                ClientHooks.trackBrokenTexture(sprite.getName(), "Texture is part of dependency cycle");
+                idToSprite.remove(sprite.getName());
+            });
+            return ImmutableList.copyOf(idToSprite.values());
+        }
+    }
+
+    default Collection<TextureAtlasSprite> collectSprites(IResourceManager resourceManager, Set<ResourceLocation> spritesToLoad, BiFunction<IResourceManager, Set<ResourceLocation>, Collection<TextureAtlasSprite>> vanillaResolver)
+    {
+        List<SpriteProvider> customSpriteProviders = Lists.newArrayList();
+        if (getAtlasTexture() == Minecraft.getInstance().getTextureMap())
+        {
+            customSpriteProviders.add(manager -> new ModelLoader.White());
+            ModelDynBucket.LoaderDynBucket.INSTANCE.register(getAtlasTexture(), resourceManager, customSpriteProviders);
+        }
+        ModLoader.get().postEvent(new TextureStitchEvent.Pre(getAtlasTexture(), resourceManager, spritesToLoad, customSpriteProviders));
+
+        List<CompletableFuture<TextureAtlasSprite>> customSprites = customSpriteProviders.stream()
+                .map(spriteProvider ->
+                        CompletableFuture.supplyAsync(() -> {
+                            try
+                            {
+                                return spriteProvider.create(resourceManager);
+                            }
+                            catch (Exception ex)
+                            {
+                                throw new CompletionException(ex);
+                            }
+                        }, Util.getServerExecutor())
+                ).collect(Collectors.toList());
+
+        Map<ResourceLocation, TextureAtlasSprite> resolvedSprites = customSprites.stream()
+                .flatMap(future -> {
+                    try
+                    {
+                        return Stream.of(future.get());
+                    }
+                    catch (final Exception e)
+                    {
+                        LOGGER.error("Failed to create custom sprite", e);
+                        return Stream.empty();
+                    }
+                })
+                .peek(sprite -> spritesToLoad.addAll(sprite.getDependencies()))
+                .collect(Collectors.toMap(TextureAtlasSprite::getName, Function.identity()));
+
+        spritesToLoad.removeAll(resolvedSprites.keySet());
+        vanillaResolver.apply(resourceManager, spritesToLoad).forEach(sprite -> resolvedSprites.putIfAbsent(sprite.getName(), sprite));
+        return ImmutableList.copyOf(resolvedSprites.values());
+    }
+
+    default void onTextureStitchedPost()
+    {
+        ModLoader.get().postEvent(new TextureStitchEvent.Post(getAtlasTexture()));
+    }
+
+    default List<TextureAtlasSprite> processTextures(IResourceManager resourceManager, Collection<TextureAtlasSprite> sprites)
+    {
+        Map<ResourceLocation, CompletableFuture<TextureAtlasSprite>> results = Maps.newConcurrentMap();
+
+        AtlasTexture map = getAtlasTexture();
+        for (TextureAtlasSprite sprite : resolveSpriteDependencies(sprites))
+        {
+            if (sprite == getMissingTexture())
+            {
+                results.put(sprite.getName(), CompletableFuture.completedFuture(sprite));
+            }
+            else
+            {
+                results.put(sprite.getName(), CompletableFuture.supplyAsync(() -> {
+                    try
+                    {
+                        ResourceLocation resourcelocation = map.getSpritePath(sprite.getName());
+                        sprite.load(resourceManager, resourcelocation, map.getMipmapLevels() + 1, results::get);
+                        map.generateMipmaps(sprite);
+                        return sprite;
+                    }
+                    catch (Exception e)
+                    {
+                        throw new CompletionException(e);
+                    }
+                }, Util.getServerExecutor()));
+            }
+        }
+
+        List<TextureAtlasSprite> result = Lists.newArrayList();
+        results.forEach((location, spriteFuture) -> {
+            try
+            {
+                result.add(spriteFuture.get());
+            }
+            catch (final Exception e)
+            {
+                ClientHooks.trackBrokenTexture(location, e.getMessage());
+            }
+        });
+        return result;
+    }
+
+    TextureAtlasSprite getMissingTexture();
+}

--- a/src/main/java/net/minecraftforge/client/model/ModelLoader.java
+++ b/src/main/java/net/minecraftforge/client/model/ModelLoader.java
@@ -31,6 +31,7 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.NoSuchElementException;
 import java.util.Set;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 
 import net.minecraft.block.Block;
@@ -66,6 +67,7 @@ import net.minecraft.client.renderer.model.multipart.Multipart;
 import net.minecraft.client.renderer.model.multipart.Selector;
 import net.minecraft.client.renderer.texture.ISprite;
 import net.minecraft.client.renderer.texture.MissingTextureSprite;
+import net.minecraft.client.renderer.texture.NativeImage;
 import net.minecraft.client.renderer.texture.TextureAtlasSprite;
 import net.minecraft.client.renderer.texture.AtlasTexture;
 import net.minecraft.client.renderer.vertex.DefaultVertexFormats;
@@ -713,54 +715,30 @@ public final class ModelLoader extends ModelBakery
         }
     }
 
-    // Temporary to compile things
-    public static final class White {
-        public static final ResourceLocation LOCATION = new ResourceLocation("white");
-        public static final TextureAtlasSprite INSTANCE = MissingTextureSprite.func_217790_a();
-    }
-
     /**
      * 16x16 pure white sprite.
      */
-    /*/ TODO Custom TAS
     public static final class White extends TextureAtlasSprite
     {
         public static final ResourceLocation LOCATION = new ResourceLocation("white");
-        public static final White INSTANCE = new White();
+        public static White INSTANCE = new White();
 
-        private White()
+        public White()
         {
-            super(LOCATION.toString());
-            this.width = this.height = 16;
+            super(LOCATION, 16, 16);
         }
 
         @Override
-        public boolean hasCustomLoader(IResourceManager manager, ResourceLocation location)
+        public void load(IResourceManager manager, ResourceLocation location, int mipmapLevels, Function<ResourceLocation, CompletableFuture<TextureAtlasSprite>> textureGetter)
         {
-            return true;
-        }
-
-        @Override
-        public boolean load(IResourceManager manager, ResourceLocation location, Function<ResourceLocation, TextureAtlasSprite> textureGetter)
-        {
-            BufferedImage image = new BufferedImage(this.getIconWidth(), this.getIconHeight(), BufferedImage.TYPE_INT_ARGB);
-            Graphics2D graphics = image.createGraphics();
-            graphics.setBackground(Color.WHITE);
-            graphics.clearRect(0, 0, this.getIconWidth(), this.getIconHeight());
-            int[][] pixels = new int[Minecraft.getMinecraft().gameSettings.mipmapLevels + 1][];
-            pixels[0] = new int[image.getWidth() * image.getHeight()];
-            image.getRGB(0, 0, image.getWidth(), image.getHeight(), pixels[0], 0, image.getWidth());
-            this.clearFramesTextureData();
-            this.framesTextureData.add(pixels);
-            return false;
-        }
-
-        public void register(TextureMap map)
-        {
-            map.setTextureEntry(White.INSTANCE);
+            NativeImage img = new NativeImage(width, height, false);
+            img.fillAreaRGBA(0, 0, width, height, 0xFFFFFFFF);
+            frames = new NativeImage[mipmapLevels];
+            frames[0] = img;
+            INSTANCE = this;
         }
     }
-*/
+
     @SuppressWarnings("serial")
     public static class ItemLoadingException extends ModelLoaderRegistry.LoaderException
     {

--- a/src/main/resources/META-INF/accesstransformer.cfg
+++ b/src/main/resources/META-INF/accesstransformer.cfg
@@ -50,6 +50,7 @@ protected net.minecraft.client.renderer.model.ModelBakery field_177609_j # textu
 protected net.minecraft.client.renderer.model.ModelBakery field_177616_r # MODEL_ENTITY
 private-f net.minecraft.client.renderer.model.ModelBakery field_217853_J # field_217853_J - need to un-finalize so that we can delay initialization to after calling super() in ModelLoader
 protected net.minecraft.client.renderer.model.ModelBakery func_177594_c(Lnet/minecraft/util/ResourceLocation;)Lnet/minecraft/client/renderer/model/BlockModel; # loadModel
+public net.minecraft.client.renderer.texture.AtlasTexture func_195420_b(Lnet/minecraft/util/ResourceLocation;)Lnet/minecraft/util/ResourceLocation; # getSpritePath
 private-f net.minecraft.client.renderer.tileentity.PistonTileEntityRenderer field_178462_c # blockRenderer - it's static so we need to un-finalize in case this class loads to early.
 public net.minecraft.client.renderer.tileentity.TileEntityRendererDispatcher field_147557_n # fontRenderer - needed for rendering text in TESR items before entering world
 public net.minecraft.command.arguments.EntityOptions func_202024_a(Ljava/lang/String;Lnet/minecraft/command/arguments/EntityOptions$IFilter;Ljava/util/function/Predicate;Lnet/minecraft/util/text/ITextComponent;)V # register

--- a/src/test/resources/META-INF/mods.toml
+++ b/src/test/resources/META-INF/mods.toml
@@ -57,3 +57,5 @@ loaderVersion="[28,)"
     modId="player_xp_event_test"
 [[mods]]
     modId="forgeblockstatesloader"
+[[mods]]
+    modId="custom_sprite_test"

--- a/src/test/resources/assets/custom_sprite_test/blockstates/custom_sprite_block.json
+++ b/src/test/resources/assets/custom_sprite_test/blockstates/custom_sprite_block.json
@@ -1,5 +1,5 @@
 {
   "variants": {
-    "normal": { "model": "custom_sprite_test:custom_sprite_block" }
+    "": { "model": "custom_sprite_test:block/custom_sprite_block" }
   }
 }

--- a/src/test/resources/assets/custom_sprite_test/models/item/custom_sprite_block.json
+++ b/src/test/resources/assets/custom_sprite_test/models/item/custom_sprite_block.json
@@ -1,0 +1,3 @@
+{
+  "parent": "custom_sprite_test:block/custom_sprite_block"
+}


### PR DESCRIPTION
Previous `TextureAtlasSprite` interface couldn't be adapter to vanilla changes (`final width, height` and parallel loading), so it had to be changed. Probably fixes #5555, if new interface is enough for their needs.