### PR TITLE
[1.14] Added functionality to IForgeItem#getHighlightTip

### DIFF
--- a/patches/minecraft/net/minecraft/client/gui/IngameGui.java.patch
+++ b/patches/minecraft/net/minecraft/client/gui/IngameGui.java.patch
@@ -24,7 +24,15 @@
              }
           }
  
-@@ -588,7 +593,13 @@
+@@ -572,6 +577,7 @@
+          }
+ 
+          String s = itextcomponent.func_150254_d();
++         s = this.field_92016_l.func_77973_b().getHighlightTip(this.field_92016_l, s);
+          int i = (this.field_194811_H - this.func_175179_f().func_78256_a(s)) / 2;
+          int j = this.field_194812_I - 59;
+          if (!this.field_73839_d.field_71442_b.func_78755_b()) {
+@@ -588,7 +594,13 @@
              GlStateManager.enableBlend();
              GlStateManager.blendFuncSeparate(GlStateManager.SourceFactor.SRC_ALPHA, GlStateManager.DestFactor.ONE_MINUS_SRC_ALPHA, GlStateManager.SourceFactor.ONE, GlStateManager.DestFactor.ZERO);
              fill(i - 2, j - 2, i + this.func_175179_f().func_78256_a(s) + 2, j + 9 + 2, this.field_73839_d.field_71474_y.func_216839_a(0));

--- a/src/main/java/net/minecraftforge/client/ForgeIngameGui.java
+++ b/src/main/java/net/minecraftforge/client/ForgeIngameGui.java
@@ -50,8 +50,6 @@ import net.minecraft.util.StringUtils;
 import net.minecraft.util.Util;
 import net.minecraft.util.math.MathHelper;
 import net.minecraft.util.text.ITextComponent;
-import net.minecraft.util.text.StringTextComponent;
-import net.minecraft.util.text.TextFormatting;
 import net.minecraft.world.GameType;
 import net.minecraftforge.client.event.RenderGameOverlayEvent;
 import net.minecraftforge.client.event.RenderGameOverlayEvent.ElementType;
@@ -362,49 +360,6 @@ public class ForgeIngameGui extends IngameGui
         }
 
         post(HOTBAR);
-    }
-
-    @Override
-    public void renderSelectedItem()
-    {
-        mc.getProfiler().startSection("selectedItemName");
-        if (this.remainingHighlightTicks > 0 && !this.highlightingItemStack.isEmpty()) {
-            ITextComponent itextcomponent = (new StringTextComponent("")).appendSibling(this.highlightingItemStack.getDisplayName()).applyTextStyle(this.highlightingItemStack.getRarity().color);
-            if (this.highlightingItemStack.hasDisplayName()) {
-                itextcomponent.applyTextStyle(TextFormatting.ITALIC);
-            }
-
-            // Apply highlight tip to display string
-            String s = this.highlightingItemStack.getItem().getHighlightTip(this.highlightingItemStack, itextcomponent.getFormattedText());
-            int i = (this.scaledWidth - this.getFontRenderer().getStringWidth(s)) / 2;
-            int j = this.scaledHeight - 59;
-            if (!this.mc.playerController.shouldDrawHUD()) {
-                j += 14;
-            }
-
-            int k = (int)((float)this.remainingHighlightTicks * 256.0F / 10.0F);
-            if (k > 255) {
-                k = 255;
-            }
-
-            if (k > 0) {
-                GlStateManager.pushMatrix();
-                GlStateManager.enableBlend();
-                GlStateManager.blendFuncSeparate(GlStateManager.SourceFactor.SRC_ALPHA, GlStateManager.DestFactor.ONE_MINUS_SRC_ALPHA, GlStateManager.SourceFactor.ONE, GlStateManager.DestFactor.ZERO);
-                fill(i - 2, j - 2, i + this.getFontRenderer().getStringWidth(s) + 2, j + 9 + 2, this.mc.gameSettings.func_216839_a(0));
-                FontRenderer font = highlightingItemStack.getItem().getFontRenderer(highlightingItemStack);
-                if (font == null) {
-                    this.getFontRenderer().drawStringWithShadow(s, (float)i, (float)j, 16777215 + (k << 24));
-                } else {
-                    i = (this.scaledWidth - font.getStringWidth(s)) / 2;
-                    font.drawStringWithShadow(s, (float)i, (float)j, 16777215 + (k << 24));
-                }
-                GlStateManager.disableBlend();
-                GlStateManager.popMatrix();
-            }
-        }
-
-        mc.getProfiler().endSection();
     }
 
     @Override

--- a/src/main/java/net/minecraftforge/client/ForgeIngameGui.java
+++ b/src/main/java/net/minecraftforge/client/ForgeIngameGui.java
@@ -50,6 +50,8 @@ import net.minecraft.util.StringUtils;
 import net.minecraft.util.Util;
 import net.minecraft.util.math.MathHelper;
 import net.minecraft.util.text.ITextComponent;
+import net.minecraft.util.text.StringTextComponent;
+import net.minecraft.util.text.TextFormatting;
 import net.minecraft.world.GameType;
 import net.minecraftforge.client.event.RenderGameOverlayEvent;
 import net.minecraftforge.client.event.RenderGameOverlayEvent.ElementType;
@@ -360,6 +362,49 @@ public class ForgeIngameGui extends IngameGui
         }
 
         post(HOTBAR);
+    }
+
+    @Override
+    public void renderSelectedItem()
+    {
+        mc.getProfiler().startSection("selectedItemName");
+        if (this.remainingHighlightTicks > 0 && !this.highlightingItemStack.isEmpty()) {
+            ITextComponent itextcomponent = (new StringTextComponent("")).appendSibling(this.highlightingItemStack.getDisplayName()).applyTextStyle(this.highlightingItemStack.getRarity().color);
+            if (this.highlightingItemStack.hasDisplayName()) {
+                itextcomponent.applyTextStyle(TextFormatting.ITALIC);
+            }
+
+            // Apply highlight tip to display string
+            String s = this.highlightingItemStack.getItem().getHighlightTip(this.highlightingItemStack, itextcomponent.getFormattedText());
+            int i = (this.scaledWidth - this.getFontRenderer().getStringWidth(s)) / 2;
+            int j = this.scaledHeight - 59;
+            if (!this.mc.playerController.shouldDrawHUD()) {
+                j += 14;
+            }
+
+            int k = (int)((float)this.remainingHighlightTicks * 256.0F / 10.0F);
+            if (k > 255) {
+                k = 255;
+            }
+
+            if (k > 0) {
+                GlStateManager.pushMatrix();
+                GlStateManager.enableBlend();
+                GlStateManager.blendFuncSeparate(GlStateManager.SourceFactor.SRC_ALPHA, GlStateManager.DestFactor.ONE_MINUS_SRC_ALPHA, GlStateManager.SourceFactor.ONE, GlStateManager.DestFactor.ZERO);
+                fill(i - 2, j - 2, i + this.getFontRenderer().getStringWidth(s) + 2, j + 9 + 2, this.mc.gameSettings.func_216839_a(0));
+                FontRenderer font = highlightingItemStack.getItem().getFontRenderer(highlightingItemStack);
+                if (font == null) {
+                    this.getFontRenderer().drawStringWithShadow(s, (float)i, (float)j, 16777215 + (k << 24));
+                } else {
+                    i = (this.scaledWidth - font.getStringWidth(s)) / 2;
+                    font.drawStringWithShadow(s, (float)i, (float)j, 16777215 + (k << 24));
+                }
+                GlStateManager.disableBlend();
+                GlStateManager.popMatrix();
+            }
+        }
+
+        mc.getProfiler().endSection();
     }
 
     @Override


### PR DESCRIPTION
In 1.14 (or 1.13) the code got removed where IForgeItem#getHighlightTip got implemented. I've re-added it in the exact same way it used to work by simply copying the method from IngameGui to ForgeIngameGui and parsing the string about to be displayed through getHighlightTip to allow mods to modify it.