### PR TITLE
[1.14] Added new InputEvent.MouseScrollEvent, fixes #5811

### DIFF
--- a/patches/minecraft/net/minecraft/client/MouseHelper.java.patch
+++ b/patches/minecraft/net/minecraft/client/MouseHelper.java.patch
@@ -38,7 +38,15 @@
              } else if (this.field_198036_a.field_71439_g != null) {
                 if (this.field_200542_o != 0.0D && Math.signum(d0) != Math.signum(this.field_200542_o)) {
                    this.field_200542_o = 0.0D;
-@@ -168,7 +174,9 @@
+@@ -129,6 +135,7 @@
+                }
+ 
+                this.field_200542_o -= (double)f1;
++               if (net.minecraftforge.client.ForgeHooksClient.onMouseScroll(this, d0)) return;
+                if (this.field_198036_a.field_71439_g.func_175149_v()) {
+                   if (this.field_198036_a.field_71456_v.func_175187_g().func_175262_a()) {
+                      this.field_198036_a.field_71456_v.func_175187_g().func_195621_a((double)(-f1));
+@@ -168,7 +175,9 @@
                 double d2 = (p_198022_3_ - this.field_198040_e) * (double)this.field_198036_a.field_195558_d.func_198107_o() / (double)this.field_198036_a.field_195558_d.func_198105_m();
                 double d3 = (p_198022_5_ - this.field_198041_f) * (double)this.field_198036_a.field_195558_d.func_198087_p() / (double)this.field_198036_a.field_195558_d.func_198083_n();
                 Screen.wrapScreenError(() -> {
@@ -49,7 +57,7 @@
                 }, "mouseDragged event handler", iguieventlistener.getClass().getCanonicalName());
              }
           }
-@@ -233,6 +241,10 @@
+@@ -233,6 +242,10 @@
        return this.field_198039_d;
     }
  
@@ -60,7 +68,7 @@
     public double func_198024_e() {
        return this.field_198040_e;
     }
-@@ -241,6 +253,14 @@
+@@ -241,6 +254,14 @@
        return this.field_198041_f;
     }
  

--- a/src/main/java/net/minecraftforge/client/ForgeHooksClient.java
+++ b/src/main/java/net/minecraftforge/client/ForgeHooksClient.java
@@ -1028,4 +1028,10 @@ public class ForgeHooksClient
     {
         MinecraftForge.EVENT_BUS.post(new InputEvent.KeyInputEvent(key, scanCode, action, modifiers));
     }
+
+    public static boolean onMouseScroll(MouseHelper mouseHelper, double scrollDelta)
+    {
+        Event event = new InputEvent.MouseScrollEvent(scrollDelta, mouseHelper.isLeftDown(), mouseHelper.isMiddleDown(), mouseHelper.isRightDown(), mouseHelper.getMouseX(), mouseHelper.getMouseY());
+        return MinecraftForge.EVENT_BUS.post(event);
+    }
 }

--- a/src/main/java/net/minecraftforge/client/event/InputEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/InputEvent.java
@@ -20,6 +20,7 @@
 package net.minecraftforge.client.event;
 
 import net.minecraft.client.util.InputMappings;
+import net.minecraftforge.eventbus.api.Cancelable;
 import net.minecraftforge.eventbus.api.Event;
 
 import org.lwjgl.glfw.GLFW;
@@ -75,6 +76,59 @@ public class InputEvent extends Event
         public int getMods()
         {
             return this.mods;
+        }
+    }
+
+    /**
+     * This event fires when the mouse scroll wheel is used outside of a gui.
+     */
+    @Cancelable
+    public static class MouseScrollEvent extends InputEvent
+    {
+        private final double scrollDelta;
+        private final double mouseX;
+        private final double mouseY;
+        private final boolean leftDown;
+        private final boolean middleDown;
+        private final boolean rightDown;
+        public MouseScrollEvent(double scrollDelta, boolean leftDown, boolean middleDown, boolean rightDown, double mouseX, double mouseY)
+        {
+            this.scrollDelta = scrollDelta;
+            this.leftDown = leftDown;
+            this.middleDown = middleDown;
+            this.rightDown = rightDown;
+            this.mouseX = mouseX;
+            this.mouseY = mouseY;
+        }
+
+        public double getScrollDelta()
+        {
+            return this.scrollDelta;
+        }
+
+        public boolean isLeftDown()
+        {
+            return this.leftDown;
+        }
+
+        public boolean isRightDown()
+        {
+            return this.rightDown;
+        }
+
+        public boolean isMiddleDown()
+        {
+            return this.middleDown;
+        }
+
+        public double getMouseX()
+        {
+            return this.mouseX;
+        }
+
+        public double getMouseY()
+        {
+            return this.mouseY;
         }
     }
 


### PR DESCRIPTION
Here's an example implementation for this method where every time you scroll the durability of the held item is decreased: https://pastebin.com/dqHkJEgk (just an example not why I needed it personally)

This event already existed in 1.12 as part of MouseEvent and I'm porting/rewriting a mod which used that event so I needed a replacement. More specifically I've got an item with mutiple modes and I'm using the scroll wheel to switch between those modes, the event also needed to be cancellable to stop the selected item from going to the next.

Also, issue #5811 requested this event so it can be closed if this PR is allowed.