### PR TITLE
Add way to change player pose and size

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -253,7 +253,7 @@ project(':forge') {
                 parent runs.forge_client
                 taskName 'forge_test_client'
 
-                environment 'MOD_CLASSES', "${project.file("build/resources/test").canonicalPath}:${project.file("build/classes/java/test").canonicalPath}"
+                environment 'MOD_CLASSES', 'dummy' // Needed to work around FG limitation, FG will replace this!
 
                 mods {
                     TestMods { sources sourceSets.test }

--- a/build.gradle
+++ b/build.gradle
@@ -253,7 +253,7 @@ project(':forge') {
                 parent runs.forge_client
                 taskName 'forge_test_client'
 
-                environment 'MOD_CLASSES', 'dummy' // Needed to work around FG limitation, FG will replace this!
+                environment 'MOD_CLASSES', "${project.file("build/resources/test").canonicalPath}:${project.file("build/classes/java/test").canonicalPath}"
 
                 mods {
                     TestMods { sources sourceSets.test }

--- a/patches/minecraft/net/minecraft/entity/Pose.java.patch
+++ b/patches/minecraft/net/minecraft/entity/Pose.java.patch
@@ -1,0 +1,19 @@
+--- a/net/minecraft/entity/Pose.java
++++ b/net/minecraft/entity/Pose.java
+@@ -1,6 +1,6 @@
+ package net.minecraft.entity;
+ 
+-public enum Pose {
++public enum Pose implements net.minecraftforge.common.IExtensibleEnum {
+    STANDING,
+    FALL_FLYING,
+    SLEEPING,
+@@ -8,4 +8,8 @@
+    SPIN_ATTACK,
+    SNEAKING,
+    DYING;
++
++   public static Pose create(String name) {
++      throw new IllegalStateException("Enum not extended");
++   }
+ }

--- a/patches/minecraft/net/minecraft/entity/player/PlayerEntity.java.patch
+++ b/patches/minecraft/net/minecraft/entity/player/PlayerEntity.java.patch
@@ -54,6 +54,15 @@
     }
  
     protected boolean func_204229_de() {
+@@ -345,7 +355,7 @@
+          } else {
+             pose = Pose.STANDING;
+          }
+-
++         pose = net.minecraftforge.event.ForgeEventFactory.getPlayerPose(this,pose);
+          Pose pose1;
+          if (!this.func_175149_v() && !this.func_184218_aH() && !this.func_213298_c(pose)) {
+             if (this.func_213298_c(Pose.SNEAKING)) {
 @@ -441,10 +451,10 @@
           this.field_71107_bF = this.field_71109_bG;
           this.field_71109_bG = 0.0F;
@@ -440,6 +449,15 @@
        return this.func_208016_c(itextcomponent);
     }
  
+@@ -1878,7 +1997,7 @@
+    }
+ 
+    public EntitySize func_213305_a(Pose p_213305_1_) {
+-      return field_213836_b.getOrDefault(p_213305_1_, field_213835_bs);
++      return field_213836_b.getOrDefault(p_213305_1_, net.minecraftforge.common.PlayerSize.getOrDefault(p_213305_1_,field_213835_bs));
+    }
+ 
+    public ItemStack func_213356_f(ItemStack p_213356_1_) {
 @@ -1939,4 +2058,44 @@
           return this.field_221260_g;
        }

--- a/src/main/java/net/minecraftforge/common/PlayerSize.java
+++ b/src/main/java/net/minecraftforge/common/PlayerSize.java
@@ -1,0 +1,47 @@
+/*
+ * Minecraft Forge
+ * Copyright (c) 2016-2019.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation version 2.1
+ * of the License.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+package net.minecraftforge.common;
+
+
+import com.google.common.base.Preconditions;
+import net.minecraft.entity.EntitySize;
+import net.minecraft.entity.Pose;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class PlayerSize
+{
+    private final static Map<Pose, EntitySize> SIZE_BY_POSE = new HashMap<>();
+
+    /**
+     * Specify the entity size a player has in the given pose.
+     * Does not affect vanilla poses
+     */
+    public static void specifySize(Pose pose, EntitySize size){
+        Preconditions.checkNotNull(pose);
+        Preconditions.checkNotNull(size);
+        SIZE_BY_POSE.put(pose,size);
+    }
+
+    public static EntitySize getOrDefault(Pose pose, EntitySize defaultSize){
+        return SIZE_BY_POSE.getOrDefault(pose,defaultSize);
+    }
+}

--- a/src/main/java/net/minecraftforge/event/ForgeEventFactory.java
+++ b/src/main/java/net/minecraftforge/event/ForgeEventFactory.java
@@ -33,6 +33,7 @@ import net.minecraft.entity.MobEntity;
 import net.minecraft.entity.SpawnReason;
 import net.minecraft.entity.LivingEntity;
 import net.minecraft.entity.EntityClassification;
+import net.minecraft.entity.Pose;
 import net.minecraft.entity.merchant.IMerchant;
 import net.minecraft.entity.effect.LightningBoltEntity;
 import net.minecraft.entity.item.ItemEntity;
@@ -698,5 +699,11 @@ public class ForgeEventFactory
     public static boolean onPistonMovePost(World world, BlockPos pos, Direction direction, boolean extending)
     {
         return MinecraftForge.EVENT_BUS.post(new PistonEvent.Post(world, pos, direction, extending ? PistonEvent.PistonMoveType.EXTEND : PistonEvent.PistonMoveType.RETRACT));
+    }
+
+    public static Pose getPlayerPose(PlayerEntity player, Pose pose)
+    {
+        PlayerEvent.PlayerUpdatePoseEvent event = new PlayerEvent.PlayerUpdatePoseEvent(player,pose);
+        return MinecraftForge.EVENT_BUS.post(event) ? event.getOverriddenPose() : event.getOriginalPose();
     }
 }

--- a/src/main/java/net/minecraftforge/event/entity/player/PlayerEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/player/PlayerEvent.java
@@ -21,6 +21,8 @@ package net.minecraftforge.event.entity.player;
 
 import java.io.File;
 
+import com.google.common.base.Preconditions;
+import net.minecraft.entity.Pose;
 import net.minecraft.entity.item.ItemEntity;
 import net.minecraft.inventory.IInventory;
 import net.minecraft.item.ItemStack;
@@ -516,6 +518,42 @@ public class PlayerEvent extends LivingEvent
         public DimensionType getTo()
         {
             return this.toDim;
+        }
+    }
+
+    /**
+     * Can be used to change the pose of the player.
+     * Set a pose to override and cancel the event.
+     *
+     * Can be used together with {@link net.minecraftforge.common.PlayerSize} to modify the size of a player
+     */
+    @Cancelable
+    public static class PlayerUpdatePoseEvent extends PlayerEvent {
+        private final Pose originalPose;
+        private Pose overriddenPose;
+
+        public PlayerUpdatePoseEvent(PlayerEntity player, Pose pose){
+            super(player);
+            this.originalPose=pose;
+            this.overriddenPose=pose;
+        }
+
+        /**
+         * @return The pose vanilla has chosen for the player
+         */
+        public Pose getOriginalPose() {
+            return originalPose;
+        }
+
+        public Pose getOverriddenPose()
+        {
+            return overriddenPose;
+        }
+
+        public void setOverriddenPose(Pose overriddenPose)
+        {
+            Preconditions.checkNotNull(overriddenPose);
+            this.overriddenPose = overriddenPose;
         }
     }
 }

--- a/src/test/java/net/minecraftforge/debug/entity/player/PlayerPoseTest.java
+++ b/src/test/java/net/minecraftforge/debug/entity/player/PlayerPoseTest.java
@@ -1,0 +1,59 @@
+/*
+ * Minecraft Forge
+ * Copyright (c) 2016-2019.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation version 2.1
+ * of the License.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+
+package net.minecraftforge.debug.entity.player;
+
+import net.minecraft.entity.EntitySize;
+import net.minecraft.entity.Pose;
+import net.minecraftforge.common.PlayerSize;
+import net.minecraftforge.event.entity.player.PlayerEvent;
+import net.minecraftforge.eventbus.api.SubscribeEvent;
+import net.minecraftforge.fml.common.Mod;
+
+/**
+ * This test mod verifies that the player pose/size can be changed.
+ * How to check:
+ * 1) Make sure that ENABLED is true
+ * 2) Spawn in a world, set your gamemode to creative and verify that you do not fit through a door.
+ * 3) Change your gamemode to survival and verify that you can walk though doors again
+ */
+@Mod.EventBusSubscriber(modid = PlayerPoseTest.MODID)
+@Mod(value = PlayerPoseTest.MODID)
+public class PlayerPoseTest
+{
+    public static final String MODID = "player_pose_test";
+    public static final boolean ENABLED = false;
+    private static final Pose widePose = Pose.create("wide");
+
+    public PlayerPoseTest()
+    {
+        PlayerSize.specifySize(widePose, EntitySize.flexible(2f,1.8f));
+    }
+
+    @SubscribeEvent
+    public static void onUpdatePlayerPose(PlayerEvent.PlayerUpdatePoseEvent event)
+    {
+        if(ENABLED&& event.getPlayer().isCreative()){
+            event.setOverriddenPose(widePose);
+            event.setCanceled(true);
+        }
+    }
+
+}

--- a/src/test/resources/META-INF/mods.toml
+++ b/src/test/resources/META-INF/mods.toml
@@ -43,3 +43,7 @@ loaderVersion="[28,)"
     modId="command_event_test"
 [[mods]]
     modId="entity_selector_test"
+[[mods]]
+    modId="pistoneventtest"
+[[mods]]
+    modId="player_pose_test"


### PR DESCRIPTION
## Why
For a mod of mine I would like to transform the player into a bat. Therefore I need to modify the size of the player, so the collision boxes match the size of a bat.

## Issue
With MC 1.13/1.14 the system of determining the size of an entity has been changed to use different poses (`net.minecraft.entity.Pose` enum). For modded entities and probably even vanilla mobs this can be worked around. But the PlayerEntity class determines it's size by looking up the current pose in an immutable map. 

## Proposed solution
This PR makes the Pose enum extensible (`IExtensibleEnum`), adds a way to specify the size a player should have in a added pose and introduces an event allowing to set the pose a player is currently in.

There is a (disabled) test that makes the player 2 blocks wide in creative mode.

### Notes
- The entities pose is stored in the datamanager using a enum parameter. However that should not be an issue as the enum is just serialized using it's ordinal.
- It is not possible to override the size associated with vanilla poses (could be changed)
- If an overridden pose isn't clear (there is a collision in the world), the vanilla falls back to the SWIMMING pose, so it's not possible to force a pose even though there is no space (could be changed)
- I have created a new class PlayerSize to store the pose->size map. If there is a better place for this, I will move it.

### Alternatives
A simpler alternative would be to just add a hook and event in the `PlayerEntity#getSize` method and skip/ignore the entire pose concept. However, I think the pose system might be useful for other things as well and might be extended in future MC versions.