### PR TITLE
Fix regular arrows giving off particles after a world reload (MC-107941)

### DIFF
--- a/patches/minecraft/net/minecraft/entity/projectile/ArrowEntity.java.patch
+++ b/patches/minecraft/net/minecraft/entity/projectile/ArrowEntity.java.patch
@@ -1,0 +1,11 @@
+--- a/net/minecraft/entity/projectile/ArrowEntity.java
++++ b/net/minecraft/entity/projectile/ArrowEntity.java
+@@ -59,7 +59,7 @@
+       } else if (p_184555_1_.func_77973_b() == Items.field_151032_g) {
+          this.field_184560_g = Potions.field_185229_a;
+          this.field_184561_h.clear();
+-         this.field_70180_af.func_187227_b(field_184559_f, -1);
++         this.func_191507_d(-1); // Forge: fix MC-107941
+       }
+ 
+    }


### PR DESCRIPTION
Fixes [MC-107941](https://bugs.mojang.com/browse/MC-107941).

The `ArrowEntity.COLOR` value was not being written to NBT and on reloading, because the value was not present, it would retrieve the color from `PotionUtils.getPotionColorFromEffectList`.

This patches `ArrowEntity.setPotionEffect` to set a fixed color for regular arrows, which will be written to NBT and in turn load properly on the next reload.