### PR TITLE
Fix Digging particle using the wrong block pos for ModelData

### DIFF
--- a/patches/minecraft/net/minecraft/client/particle/DiggingParticle.java.patch
+++ b/patches/minecraft/net/minecraft/client/particle/DiggingParticle.java.patch
@@ -1,11 +1,25 @@
 --- a/net/minecraft/client/particle/DiggingParticle.java
 +++ b/net/minecraft/client/particle/DiggingParticle.java
-@@ -21,7 +21,7 @@
-    public DiggingParticle(World p_i46280_1_, double p_i46280_2_, double p_i46280_4_, double p_i46280_6_, double p_i46280_8_, double p_i46280_10_, double p_i46280_12_, BlockState p_i46280_14_) {
-       super(p_i46280_1_, p_i46280_2_, p_i46280_4_, p_i46280_6_, p_i46280_8_, p_i46280_10_, p_i46280_12_);
-       this.field_174847_a = p_i46280_14_;
--      this.func_217567_a(Minecraft.func_71410_x().func_175602_ab().func_175023_a().func_178122_a(p_i46280_14_));
-+      this.func_217567_a(Minecraft.func_71410_x().func_175602_ab().func_175023_a().getTexture(p_i46280_14_, p_i46280_1_, new BlockPos(field_187126_f, field_187127_g, field_187128_h)));
-       this.field_70545_g = 1.0F;
-       this.field_70552_h = 0.6F;
-       this.field_70553_i = 0.6F;
+@@ -36,6 +36,7 @@
+    }
+ 
+    public DiggingParticle func_174846_a(BlockPos p_174846_1_) {
++      updateSprite(p_174846_1_);
+       this.field_181019_az = p_174846_1_;
+       if (this.field_174847_a.func_177230_c() == Blocks.field_196658_i) {
+          return this;
+@@ -93,7 +94,13 @@
+    public static class Factory implements IParticleFactory<BlockParticleData> {
+       public Particle func_199234_a(BlockParticleData p_199234_1_, World p_199234_2_, double p_199234_3_, double p_199234_5_, double p_199234_7_, double p_199234_9_, double p_199234_11_, double p_199234_13_) {
+          BlockState blockstate = p_199234_1_.func_197584_c();
+-         return !blockstate.func_196958_f() && blockstate.func_177230_c() != Blocks.field_196603_bb ? (new DiggingParticle(p_199234_2_, p_199234_3_, p_199234_5_, p_199234_7_, p_199234_9_, p_199234_11_, p_199234_13_, blockstate)).func_174845_l() : null;
++         return !blockstate.func_196958_f() && blockstate.func_177230_c() != Blocks.field_196603_bb ? (new DiggingParticle(p_199234_2_, p_199234_3_, p_199234_5_, p_199234_7_, p_199234_9_, p_199234_11_, p_199234_13_, blockstate)).func_174845_l().updateSprite(p_199234_1_.getPos()) : null;
+       }
+    }
++
++   private Particle updateSprite(BlockPos pos) { //FORGE: we cannot assume that the x y z of the particles match the block pos of the block.
++      if (pos != null) // There are cases where we are not able to obtain the correct source pos, and need to fallback to the non-model data version
++         this.func_217567_a(Minecraft.func_71410_x().func_175602_ab().func_175023_a().getTexture(field_174847_a, field_187122_b, pos));
++      return this;
++   }
+ }

--- a/patches/minecraft/net/minecraft/entity/Entity.java.patch
+++ b/patches/minecraft/net/minecraft/entity/Entity.java.patch
@@ -108,14 +108,18 @@
           this.func_184185_a(soundtype.func_185844_d(), soundtype.func_185843_a() * 0.15F, soundtype.func_185847_b());
        }
     }
-@@ -1040,6 +1053,7 @@
+@@ -1040,9 +1053,10 @@
        int k = MathHelper.func_76128_c(this.field_70161_v);
        BlockPos blockpos = new BlockPos(i, j, k);
        BlockState blockstate = this.field_70170_p.func_180495_p(blockpos);
 +      if (!blockstate.addRunningEffects(field_70170_p, blockpos, this))
        if (blockstate.func_185901_i() != BlockRenderType.INVISIBLE) {
           Vec3d vec3d = this.func_213322_ci();
-          this.field_70170_p.func_195594_a(new BlockParticleData(ParticleTypes.field_197611_d, blockstate), this.field_70165_t + ((double)this.field_70146_Z.nextFloat() - 0.5D) * (double)this.field_213325_aI.field_220315_a, this.field_70163_u + 0.1D, this.field_70161_v + ((double)this.field_70146_Z.nextFloat() - 0.5D) * (double)this.field_213325_aI.field_220315_a, vec3d.field_72450_a * -4.0D, 1.5D, vec3d.field_72449_c * -4.0D);
+-         this.field_70170_p.func_195594_a(new BlockParticleData(ParticleTypes.field_197611_d, blockstate), this.field_70165_t + ((double)this.field_70146_Z.nextFloat() - 0.5D) * (double)this.field_213325_aI.field_220315_a, this.field_70163_u + 0.1D, this.field_70161_v + ((double)this.field_70146_Z.nextFloat() - 0.5D) * (double)this.field_213325_aI.field_220315_a, vec3d.field_72450_a * -4.0D, 1.5D, vec3d.field_72449_c * -4.0D);
++         this.field_70170_p.func_195594_a(new BlockParticleData(ParticleTypes.field_197611_d, blockstate).setPos(blockpos), this.field_70165_t + ((double)this.field_70146_Z.nextFloat() - 0.5D) * (double)this.field_213325_aI.field_220315_a, this.field_70163_u + 0.1D, this.field_70161_v + ((double)this.field_70146_Z.nextFloat() - 0.5D) * (double)this.field_213325_aI.field_220315_a, vec3d.field_72450_a * -4.0D, 1.5D, vec3d.field_72449_c * -4.0D);
+       }
+ 
+    }
 @@ -1061,7 +1075,7 @@
              return false;
           } else {

--- a/patches/minecraft/net/minecraft/entity/passive/IronGolemEntity.java.patch
+++ b/patches/minecraft/net/minecraft/entity/passive/IronGolemEntity.java.patch
@@ -1,0 +1,11 @@
+--- a/net/minecraft/entity/passive/IronGolemEntity.java
++++ b/net/minecraft/entity/passive/IronGolemEntity.java
+@@ -106,7 +106,7 @@
+          int k = MathHelper.func_76128_c(this.field_70161_v);
+          BlockState blockstate = this.field_70170_p.func_180495_p(new BlockPos(i, j, k));
+          if (!blockstate.func_196958_f()) {
+-            this.field_70170_p.func_195594_a(new BlockParticleData(ParticleTypes.field_197611_d, blockstate), this.field_70165_t + ((double)this.field_70146_Z.nextFloat() - 0.5D) * (double)this.func_213311_cf(), this.func_174813_aQ().field_72338_b + 0.1D, this.field_70161_v + ((double)this.field_70146_Z.nextFloat() - 0.5D) * (double)this.func_213311_cf(), 4.0D * ((double)this.field_70146_Z.nextFloat() - 0.5D), 0.5D, ((double)this.field_70146_Z.nextFloat() - 0.5D) * 4.0D);
++            this.field_70170_p.func_195594_a(new BlockParticleData(ParticleTypes.field_197611_d, blockstate).setPos(new BlockPos(i, j, k)), this.field_70165_t + ((double)this.field_70146_Z.nextFloat() - 0.5D) * (double)this.func_213311_cf(), this.func_174813_aQ().field_72338_b + 0.1D, this.field_70161_v + ((double)this.field_70146_Z.nextFloat() - 0.5D) * (double)this.func_213311_cf(), 4.0D * ((double)this.field_70146_Z.nextFloat() - 0.5D), 0.5D, ((double)this.field_70146_Z.nextFloat() - 0.5D) * 4.0D);
+          }
+       }
+ 

--- a/patches/minecraft/net/minecraft/particles/BlockParticleData.java.patch
+++ b/patches/minecraft/net/minecraft/particles/BlockParticleData.java.patch
@@ -1,0 +1,18 @@
+--- a/net/minecraft/particles/BlockParticleData.java
++++ b/net/minecraft/particles/BlockParticleData.java
+@@ -45,4 +45,15 @@
+    public BlockState func_197584_c() {
+       return this.field_197587_c;
+    }
++
++   //FORGE: Add a source pos property, so we can provide models with additional model data
++   private net.minecraft.util.math.BlockPos pos;
++   public BlockParticleData setPos(net.minecraft.util.math.BlockPos pos) {
++      this.pos = pos;
++      return this;
++   }
++
++   public net.minecraft.util.math.BlockPos getPos() {
++      return pos;
++   }
+ }


### PR DESCRIPTION
This PR fixes up a mistake I made in #5756
The assumption that the xyz of the particle matches the pos of the block that the particle originates from is dangerous and wrong. The new aproach is to pass the block pos directly when the data is available.
In most cases, this is now able to deliver the correct data to the system, but in some cases the block pos cannot be determined without large effort, so this just falls back to getting the particles without additional model data.

Fixes #6020