### PR TITLE
Fix coremod not redirecting to the correct method

### DIFF
--- a/patches/minecraft/net/minecraft/potion/EffectInstance.java.patch
+++ b/patches/minecraft/net/minecraft/potion/EffectInstance.java.patch
@@ -17,18 +17,16 @@
     }
  
     public boolean func_199308_a(EffectInstance p_199308_1_) {
-@@ -88,6 +89,10 @@
+@@ -88,7 +89,7 @@
     }
  
     public Effect func_188419_a() {
-+      return this.getPotionRaw() == null ? null : this.getPotionRaw().delegate.get();
-+   }
-+
-+   private Effect getPotionRaw() {
-       return this.field_188420_b;
+-      return this.field_188420_b;
++      return this.field_188420_b == null ? null : this.field_188420_b.delegate.get();
     }
  
-@@ -188,11 +193,12 @@
+    public int func_76459_b() {
+@@ -188,11 +189,12 @@
        p_82719_1_.func_74757_a("Ambient", this.func_82720_e());
        p_82719_1_.func_74757_a("ShowParticles", this.func_188418_e());
        p_82719_1_.func_74757_a("ShowIcon", this.func_205348_f());
@@ -42,7 +40,7 @@
        Effect effect = Effect.func_188412_a(i);
        if (effect == null) {
           return null;
-@@ -210,7 +216,7 @@
+@@ -210,7 +212,7 @@
              flag2 = p_82722_0_.func_74767_n("ShowIcon");
           }
  
@@ -51,7 +49,7 @@
        }
     }
  
-@@ -226,6 +232,32 @@
+@@ -226,6 +228,32 @@
  
     public int compareTo(EffectInstance p_compareTo_1_) {
        int i = 32147;

--- a/src/main/resources/META-INF/fieldtomethodtransformers.js
+++ b/src/main/resources/META-INF/fieldtomethodtransformers.js
@@ -8,7 +8,7 @@ function initializeCoreMod() {
             'transformer': function(classNode) {
                 var asmapi=Java.type('net.minecraftforge.coremod.api.ASMAPI')
                 var fn = asmapi.mapField('field_188420_b') // potion field - remap to mcp if necessary
-                asmapi.redirectFieldToMethod(classNode, fn, 'getPotionRaw')
+                asmapi.redirectFieldToMethod(classNode, fn, asmapi.mapMethod('func_188419_a'))
                 return classNode;
             }
         }


### PR DESCRIPTION
Redirects to the getPotion method instead of the getPotionRaw method now.
Also, remove the getPotionRaw method entirely, as the getPotion method is excluded from field transforms now directly.
Fixes #6052
