### PR TITLE
Config: Add a comment that lists the available constants of enums

### DIFF
--- a/src/main/java/net/minecraftforge/common/ForgeConfigSpec.java
+++ b/src/main/java/net/minecraftforge/common/ForgeConfigSpec.java
@@ -38,6 +38,7 @@ import java.util.Objects;
 import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.function.Supplier;
+import java.util.stream.Collectors;
 
 import javax.annotation.Nonnull;
 
@@ -388,6 +389,8 @@ public class ForgeConfigSpec extends UnmodifiableConfigWrapper<Config>
         }
         public <V extends Enum<V>> EnumValue<V> defineEnum(List<String> path, Supplier<V> defaultSupplier, EnumGetMethod converter, Predicate<Object> validator, Class<V> clazz) {
             context.setClazz(clazz);
+            V[] allowedValues = clazz.getEnumConstants();
+            context.setComment(ObjectArrays.concat(context.getComment(), "Allowed Values: " + Arrays.stream(allowedValues).map(Enum::name).collect(Collectors.joining(", "))));
             return new EnumValue<V>(this, define(path, new ValueSpec(defaultSupplier, validator, context), defaultSupplier).getPath(), defaultSupplier, converter, clazz);
         }
 


### PR DESCRIPTION
Currently, users can not see what enum values are actually allowed.
Example how this looks like now:
```
#Just a test!
#Allowed Values: TEST1, TEST2, TEST3, NOTEST
testEnumVal = "TEST2"
```