### PR TITLE
[1.14] Made OreFeatureConfig.FillerBlockType extensible

### DIFF
--- a/patches/minecraft/net/minecraft/world/gen/feature/OreFeatureConfig.java.patch
+++ b/patches/minecraft/net/minecraft/world/gen/feature/OreFeatureConfig.java.patch
@@ -1,0 +1,22 @@
+--- a/net/minecraft/world/gen/feature/OreFeatureConfig.java
++++ b/net/minecraft/world/gen/feature/OreFeatureConfig.java
+@@ -34,7 +34,7 @@
+       return new OreFeatureConfig(orefeatureconfig$fillerblocktype, blockstate, i);
+    }
+ 
+-   public static enum FillerBlockType {
++   public static enum FillerBlockType implements net.minecraftforge.common.IExtensibleEnum {
+       NATURAL_STONE("natural_stone", (p_214739_0_) -> {
+          if (p_214739_0_ == null) {
+             return false;
+@@ -56,6 +56,10 @@
+          this.field_214743_e = p_i50618_4_;
+       }
+ 
++      public static FillerBlockType create(String name, String p_i50618_3_, Predicate<BlockState> p_i50618_4_) {
++          throw new IllegalStateException("Enum not extended");
++      }
++
+       public String func_214737_a() {
+          return this.field_214742_d;
+       }


### PR DESCRIPTION
This PR makes OreFeatureConfig.FillerBlockType extensible. This is needed to allow mods to specify different target blocks that an ore should generate in. 

For example, a mod that adds ores to The End would need to create a custom Feature and IFeatureConfig. With this PR, the mod would only have to create a new OreFeatureConfig.FillerBlockType and use vanilla's OreFeature and OreFeatureConfig.