### PR TITLE
Improvements to #6010

### DIFF
--- a/patches/minecraft/net/minecraft/client/renderer/model/ModelBakery.java.patch
+++ b/patches/minecraft/net/minecraft/client/renderer/model/ModelBakery.java.patch
@@ -9,20 +9,22 @@
     private final Map<ResourceLocation, IUnbakedModel> field_217851_H = Maps.newHashMap();
     private final Map<ResourceLocation, IBakedModel> field_217852_I = Maps.newHashMap();
     private final AtlasTexture.SheetData field_217853_J;
-@@ -142,6 +142,12 @@
+@@ -142,6 +142,14 @@
  
        p_i51735_4_.func_219895_b("special");
        this.func_217843_a(new ModelResourceLocation("minecraft:trident_in_hand#inventory"));
++      this.setLoaders(); // Do this now so special models can use custom loaders
 +      for (ResourceLocation rl : getSpecialModels()) {
-+          // Same as func_217843_a but without restricting to MRL's
-+          IUnbakedModel iunbakedmodel = this.func_209597_a(rl);
++          // Same as func_217843_a but go through custom loaders
++          IUnbakedModel iunbakedmodel = net.minecraftforge.client.model.ModelLoaderRegistry
++                  .getModelOrLogError(rl, "Error loading special model " + rl.toString());
 +          this.field_217849_F.put(rl, iunbakedmodel);
 +          this.field_217851_H.put(rl, iunbakedmodel);
 +      }
        p_i51735_4_.func_219895_b("textures");
        Set<String> set = Sets.newLinkedHashSet();
        Set<ResourceLocation> set1 = this.field_217851_H.values().stream().flatMap((p_217838_2_) -> {
-@@ -288,7 +294,7 @@
+@@ -288,7 +296,7 @@
                       {
                          lvt_13_5_ = this.field_177598_f.func_199004_b(resourcelocation1).stream().map((p_217839_1_) -> {
                             try (InputStream inputstream = p_217839_1_.func_199027_b()) {
@@ -31,7 +33,7 @@
                                return pair2;
                             } catch (Exception exception1) {
                                throw new ModelBakery.BlockStateDefinitionException(String.format("Exception loading blockstate definition: '%s' in resourcepack: '%s': %s", p_217839_1_.func_199029_a(), p_217839_1_.func_199026_d(), exception1.getMessage()));
-@@ -404,7 +410,12 @@
+@@ -404,7 +412,12 @@
  
     @Nullable
     public IBakedModel func_217845_a(ResourceLocation p_217845_1_, ISprite p_217845_2_) {
@@ -45,7 +47,7 @@
        if (this.field_217850_G.containsKey(triple)) {
           return this.field_217850_G.get(triple);
        } else {
-@@ -412,11 +423,11 @@
+@@ -412,11 +425,11 @@
           if (iunbakedmodel instanceof BlockModel) {
              BlockModel blockmodel = (BlockModel)iunbakedmodel;
              if (blockmodel.func_178310_f() == field_177606_o) {
@@ -59,13 +61,15 @@
           this.field_217850_G.put(triple, ibakedmodel);
           return ibakedmodel;
        }
-@@ -471,6 +482,10 @@
+@@ -471,6 +484,12 @@
        return this.field_225367_M;
     }
  
 +   public Set<ResourceLocation> getSpecialModels() {
 +      return java.util.Collections.emptySet();
 +   }
++
++   public void setLoaders() {}
 +
     @OnlyIn(Dist.CLIENT)
     static class BlockStateDefinitionException extends RuntimeException {

--- a/patches/minecraft/net/minecraft/client/renderer/model/ModelBakery.java.patch
+++ b/patches/minecraft/net/minecraft/client/renderer/model/ModelBakery.java.patch
@@ -9,11 +9,18 @@
     private final Map<ResourceLocation, IUnbakedModel> field_217851_H = Maps.newHashMap();
     private final Map<ResourceLocation, IBakedModel> field_217852_I = Maps.newHashMap();
     private final AtlasTexture.SheetData field_217853_J;
-@@ -142,6 +142,14 @@
+@@ -107,6 +107,7 @@
+    });
+ 
+    public ModelBakery(IResourceManager p_i51735_1_, AtlasTexture p_i51735_2_, BlockColors p_i51735_3_, IProfiler p_i51735_4_) {
++      this.setLoaders(); // Do this early so we can use custom loaders
+       this.field_177598_f = p_i51735_1_;
+       this.field_177609_j = p_i51735_2_;
+       this.field_225365_D = p_i51735_3_;
+@@ -142,6 +143,13 @@
  
        p_i51735_4_.func_219895_b("special");
        this.func_217843_a(new ModelResourceLocation("minecraft:trident_in_hand#inventory"));
-+      this.setLoaders(); // Do this now so special models can use custom loaders
 +      for (ResourceLocation rl : getSpecialModels()) {
 +          // Same as func_217843_a but go through custom loaders
 +          IUnbakedModel iunbakedmodel = net.minecraftforge.client.model.ModelLoaderRegistry

--- a/src/main/java/net/minecraftforge/client/model/ModelLoader.java
+++ b/src/main/java/net/minecraftforge/client/model/ModelLoader.java
@@ -140,9 +140,6 @@ public final class ModelLoader extends ModelBakery
     public ModelLoader(IResourceManager manager, AtlasTexture map, BlockColors colours, IProfiler profiler)
     {
         super(manager, map, colours, profiler);
-        VanillaLoader.INSTANCE.setLoader(this);
-        VariantLoader.INSTANCE.setLoader(this);
-        ModelLoaderRegistry.clearModelCache(manager);
     }
 
     private static Set<ResourceLocation> specialModels = new HashSet<>();
@@ -151,8 +148,7 @@ public final class ModelLoader extends ModelBakery
      * Indicate to vanilla that it should load and bake the given model, even if no blocks or
      * items use it. This is useful if e.g. you have baked models only for entity renderers.
      * Call during {@link net.minecraftforge.client.event.ModelRegistryEvent}
-     * @param rl The model, either {@link ModelResourceLocation} to point to a blockstate variant,
-     *           or plain {@link ResourceLocation} to point directly to a json in the models folder.
+     * @param rl Model path to load, same as in {@link ModelLoaderRegistry#getModel}.
      */
     public static void addSpecialModel(ResourceLocation rl) {
         specialModels.add(rl);
@@ -161,6 +157,13 @@ public final class ModelLoader extends ModelBakery
     @Override
     public Set<ResourceLocation> getSpecialModels() {
         return specialModels;
+    }
+
+    @Override
+    public void setLoaders() {
+        VanillaLoader.INSTANCE.setLoader(this);
+        VariantLoader.INSTANCE.setLoader(this);
+        ModelLoaderRegistry.clearModelCache(resourceManager);
     }
 
     /**


### PR DESCRIPTION
Minor improvements to #6010. It allowed you to specify MRL's/RL's not attached to a block or item to be loaded by vanilla, but had the oversight where I called `ModelBakery.func_209597_a` which only supports the vanilla model format, and doesn't do other nice things like wrapping vanilla models into forge's `VanillaModelWrapper`, etc.

This patch changes it so that any special models are loaded through the custom loader system, so you can use alternate formats, the resulting model is a `VanillaModelWrapper` if applicable, etc.

Since `ModelBakery` stupidly does all the loading/baking work in its constructor (why), I had to do some tricks to set the `ModelLoader` instances earlier than they were set before.