### PR TITLE
Add collisionExtendsVertically

### DIFF
--- a/patches/minecraft/net/minecraft/entity/Entity.java.patch
+++ b/patches/minecraft/net/minecraft/entity/Entity.java.patch
@@ -64,7 +64,7 @@
        float f = this.field_213325_aI.field_220315_a / 2.0F;
        float f1 = this.field_213325_aI.field_220316_b;
        this.func_174826_a(new AxisAlignedBB(p_70107_1_ - (double)f, p_70107_3_, p_70107_5_ - (double)f, p_70107_1_ + (double)f, p_70107_3_ + (double)f1, p_70107_5_ + (double)f));
-@@ -496,7 +508,7 @@
+@@ -496,11 +508,11 @@
           int k = MathHelper.func_76128_c(this.field_70161_v);
           BlockPos blockpos = new BlockPos(i, j, k);
           BlockState blockstate = this.field_70170_p.func_180495_p(blockpos);
@@ -73,6 +73,11 @@
              BlockPos blockpos1 = blockpos.func_177977_b();
              BlockState blockstate1 = this.field_70170_p.func_180495_p(blockpos1);
              Block block = blockstate1.func_177230_c();
+-            if (block.func_203417_a(BlockTags.field_219748_G) || block.func_203417_a(BlockTags.field_219757_z) || block instanceof FenceGateBlock) {
++            if (block.func_203417_a(BlockTags.field_219748_G) || block.func_203417_a(BlockTags.field_219757_z) || block instanceof FenceGateBlock || blockstate.collisionExtendsVertically(this.field_70170_p, blockpos, this)) {
+                blockstate = blockstate1;
+                blockpos = blockpos1;
+             }
 @@ -535,7 +547,7 @@
  
              this.field_70140_Q = (float)((double)this.field_70140_Q + (double)MathHelper.func_76133_a(func_213296_b(vec3d)) * 0.6D);

--- a/patches/minecraft/net/minecraft/entity/Entity.java.patch
+++ b/patches/minecraft/net/minecraft/entity/Entity.java.patch
@@ -74,7 +74,7 @@
              BlockState blockstate1 = this.field_70170_p.func_180495_p(blockpos1);
              Block block = blockstate1.func_177230_c();
 -            if (block.func_203417_a(BlockTags.field_219748_G) || block.func_203417_a(BlockTags.field_219757_z) || block instanceof FenceGateBlock) {
-+            if (block.func_203417_a(BlockTags.field_219748_G) || block.func_203417_a(BlockTags.field_219757_z) || block instanceof FenceGateBlock || blockstate.collisionExtendsVertically(this.field_70170_p, blockpos, this)) {
++            if (blockstate.collisionExtendsVertically(this.field_70170_p, blockpos, this)) {
                 blockstate = blockstate1;
                 blockpos = blockpos1;
              }

--- a/patches/minecraft/net/minecraft/entity/player/ServerPlayerEntity.java.patch
+++ b/patches/minecraft/net/minecraft/entity/player/ServerPlayerEntity.java.patch
@@ -64,7 +64,7 @@
           return this;
        }
     }
-@@ -776,7 +778,7 @@
+@@ -776,11 +778,11 @@
        BlockPos blockpos = new BlockPos(i, j, k);
        if (this.field_70170_p.func_175667_e(blockpos)) {
           BlockState blockstate = this.field_70170_p.func_180495_p(blockpos);
@@ -73,6 +73,11 @@
              BlockPos blockpos1 = blockpos.func_177977_b();
              BlockState blockstate1 = this.field_70170_p.func_180495_p(blockpos1);
              Block block = blockstate1.func_177230_c();
+-            if (block.func_203417_a(BlockTags.field_219748_G) || block.func_203417_a(BlockTags.field_219757_z) || block instanceof FenceGateBlock) {
++            if (block.func_203417_a(BlockTags.field_219748_G) || block.func_203417_a(BlockTags.field_219757_z) || block instanceof FenceGateBlock || blockstate.collisionExtendsVertically(this.field_70170_p, blockpos, this)) {
+                blockpos = blockpos1;
+                blockstate = blockstate1;
+             }
 @@ -819,6 +821,7 @@
              this.field_71135_a.func_147359_a(new SOpenWindowPacket(container.field_75152_c, container.func_216957_a(), p_213829_1_.func_145748_c_()));
              container.func_75132_a(this);

--- a/patches/minecraft/net/minecraft/entity/player/ServerPlayerEntity.java.patch
+++ b/patches/minecraft/net/minecraft/entity/player/ServerPlayerEntity.java.patch
@@ -74,7 +74,7 @@
              BlockState blockstate1 = this.field_70170_p.func_180495_p(blockpos1);
              Block block = blockstate1.func_177230_c();
 -            if (block.func_203417_a(BlockTags.field_219748_G) || block.func_203417_a(BlockTags.field_219757_z) || block instanceof FenceGateBlock) {
-+            if (block.func_203417_a(BlockTags.field_219748_G) || block.func_203417_a(BlockTags.field_219757_z) || block instanceof FenceGateBlock || blockstate.collisionExtendsVertically(this.field_70170_p, blockpos, this)) {
++            if (blockstate.collisionExtendsVertically(this.field_70170_p, blockpos, this)) {
                 blockpos = blockpos1;
                 blockstate = blockstate1;
              }

--- a/patches/minecraft/net/minecraft/pathfinding/WalkNodeProcessor.java.patch
+++ b/patches/minecraft/net/minecraft/pathfinding/WalkNodeProcessor.java.patch
@@ -58,3 +58,12 @@
           return PathNodeType.OPEN;
        } else if (!block.func_203417_a(BlockTags.field_212185_E) && block != Blocks.field_196651_dG) {
           if (block == Blocks.field_150480_ab) {
+@@ -412,7 +420,7 @@
+             return PathNodeType.RAIL;
+          } else if (block instanceof LeavesBlock) {
+             return PathNodeType.LEAVES;
+-         } else if (!block.func_203417_a(BlockTags.field_219748_G) && !block.func_203417_a(BlockTags.field_219757_z) && (!(block instanceof FenceGateBlock) || blockstate.func_177229_b(FenceGateBlock.field_176466_a))) {
++         } else if (!block.func_203417_a(BlockTags.field_219748_G) && !block.func_203417_a(BlockTags.field_219757_z) && (!(block instanceof FenceGateBlock) || blockstate.func_177229_b(FenceGateBlock.field_176466_a)) && !blockstate.collisionExtendsVertically(p_189553_1_, blockpos, currentEntity)) {
+             IFluidState ifluidstate = p_189553_1_.func_204610_c(blockpos);
+             if (ifluidstate.func_206884_a(FluidTags.field_206959_a)) {
+                return PathNodeType.WATER;

--- a/patches/minecraft/net/minecraft/pathfinding/WalkNodeProcessor.java.patch
+++ b/patches/minecraft/net/minecraft/pathfinding/WalkNodeProcessor.java.patch
@@ -58,12 +58,3 @@
           return PathNodeType.OPEN;
        } else if (!block.func_203417_a(BlockTags.field_212185_E) && block != Blocks.field_196651_dG) {
           if (block == Blocks.field_150480_ab) {
-@@ -412,7 +420,7 @@
-             return PathNodeType.RAIL;
-          } else if (block instanceof LeavesBlock) {
-             return PathNodeType.LEAVES;
--         } else if (!block.func_203417_a(BlockTags.field_219748_G) && !block.func_203417_a(BlockTags.field_219757_z) && (!(block instanceof FenceGateBlock) || blockstate.func_177229_b(FenceGateBlock.field_176466_a))) {
-+         } else if (!block.func_203417_a(BlockTags.field_219748_G) && !block.func_203417_a(BlockTags.field_219757_z) && (!(block instanceof FenceGateBlock) || blockstate.func_177229_b(FenceGateBlock.field_176466_a)) && !blockstate.collisionExtendsVertically(p_189553_1_, blockpos, currentEntity)) {
-             IFluidState ifluidstate = p_189553_1_.func_204610_c(blockpos);
-             if (ifluidstate.func_206884_a(FluidTags.field_206959_a)) {
-                return PathNodeType.WATER;

--- a/src/main/java/net/minecraftforge/common/extensions/IForgeBlock.java
+++ b/src/main/java/net/minecraftforge/common/extensions/IForgeBlock.java
@@ -1024,4 +1024,13 @@ public interface IForgeBlock
         world.setBlockState(pos, Blocks.AIR.getDefaultState(), 3);
         getBlock().onExplosionDestroy(world, pos, explosion);
     }
+
+    /**
+     * Determines if this block's collision box should be treated as though it can extend above its block space.
+     * Use this to replicate fence and wall behavior.
+     */
+    default boolean collisionExtendsVertically(BlockState state, IBlockReader world, BlockPos pos, Entity collidingEntity)
+    {
+        return false;
+    }
 }

--- a/src/main/java/net/minecraftforge/common/extensions/IForgeBlock.java
+++ b/src/main/java/net/minecraftforge/common/extensions/IForgeBlock.java
@@ -29,6 +29,7 @@ import javax.annotation.Nullable;
 import net.minecraft.block.Block;
 import net.minecraft.block.BedBlock;
 import net.minecraft.block.FarmlandBlock;
+import net.minecraft.block.FenceGateBlock;
 import net.minecraft.block.FireBlock;
 import net.minecraft.block.HorizontalBlock;
 import net.minecraft.block.IBeaconBeamColorProvider;
@@ -1031,6 +1032,6 @@ public interface IForgeBlock
      */
     default boolean collisionExtendsVertically(BlockState state, IBlockReader world, BlockPos pos, Entity collidingEntity)
     {
-        return false;
+        return getBlock().isIn(BlockTags.FENCES) || getBlock().isIn(BlockTags.WALLS) || getBlock() instanceof FenceGateBlock;
     }
 }

--- a/src/main/java/net/minecraftforge/common/extensions/IForgeBlockState.java
+++ b/src/main/java/net/minecraftforge/common/extensions/IForgeBlockState.java
@@ -867,4 +867,13 @@ public interface IForgeBlockState
     {
         getBlockState().getBlock().onBlockExploded(getBlockState(), world, pos, explosion);
     }
+
+    /**
+     * Determines if this block's collision box should be treated as though it can extend above its block space.
+     * This can be used to replicate fence and wall behavior.
+     */
+    default boolean collisionExtendsVertically(IBlockReader world, BlockPos pos, Entity collidingEntity)
+    {
+        return getBlockState().getBlock().collisionExtendsVertically(getBlockState(), world, pos, collidingEntity);
+    }
 }


### PR DESCRIPTION
Example implementation: https://gist.github.com/yrsegal/927e018abb33505fda2d98c05907ce3f

In prior versions (1.12-), entities checked the blockspace below them unconditionally for collision with hitboxes that extend above the block space.
In 1.13, this was changed by Mojang to only collide when the block below is a fence, fence gate, or wall. This breaks the collision of any modded block whose collision box extends above its block space.
This PR allows blocks to opt back in to that behaviour.