### PR TITLE
Stub additional fake player methods

### DIFF
--- a/src/main/java/net/minecraftforge/common/util/FakePlayer.java
+++ b/src/main/java/net/minecraftforge/common/util/FakePlayer.java
@@ -24,18 +24,28 @@ import javax.annotation.Nullable;
 import com.mojang.authlib.GameProfile;
 
 import net.minecraft.entity.Entity;
+import net.minecraft.entity.passive.horse.AbstractHorseEntity;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.entity.player.ServerPlayerEntity;
+import net.minecraft.inventory.IInventory;
+import net.minecraft.inventory.container.INamedContainerProvider;
+import net.minecraft.item.ItemStack;
 import net.minecraft.network.play.client.CClientSettingsPacket;
+import net.minecraft.potion.EffectInstance;
 import net.minecraft.server.MinecraftServer;
 import net.minecraft.server.management.PlayerInteractionManager;
 import net.minecraft.stats.Stat;
+import net.minecraft.tileentity.SignTileEntity;
 import net.minecraft.util.DamageSource;
+import net.minecraft.util.Hand;
+import net.minecraft.util.SoundCategory;
+import net.minecraft.util.SoundEvent;
 import net.minecraft.util.text.ITextComponent;
 import net.minecraft.util.math.Vec3d;
 import net.minecraft.world.server.ServerWorld;
-import net.minecraft.world.dimension.DimensionType;
 import net.minecraftforge.fml.server.ServerLifecycleHooks;
+
+import java.util.OptionalInt;
 
 //Preliminary, simple Fake Player class
 public class FakePlayer extends ServerPlayerEntity
@@ -49,11 +59,24 @@ public class FakePlayer extends ServerPlayerEntity
     @Override public void sendStatusMessage(ITextComponent chatComponent, boolean actionBar){}
     @Override public void sendMessage(ITextComponent component) {}
     @Override public void addStat(Stat par1StatBase, int par2){}
-    //@Override public void openGui(Object mod, int modGuiId, World world, int x, int y, int z){}
+    @Override public OptionalInt openContainer(@Nullable INamedContainerProvider prover) { return OptionalInt.empty(); }
     @Override public boolean isInvulnerableTo(DamageSource source){ return true; }
     @Override public boolean canAttackPlayer(PlayerEntity player){ return false; }
     @Override public void onDeath(DamageSource source){ return; }
     @Override public void tick(){ return; }
     @Override public void handleClientSettings(CClientSettingsPacket pkt){ return; }
     @Override @Nullable public MinecraftServer getServer() { return ServerLifecycleHooks.getCurrentServer(); }
+    @Override public void sendEnterCombat() {}
+    @Override public void sendEndCombat() {}
+    @Override public boolean startRiding(Entity entityIn, boolean force) { return false; }
+    @Override public void stopRiding() {}
+    @Override public void openSignEditor(SignTileEntity signTile) {}
+    @Override public void openHorseInventory(AbstractHorseEntity horse, IInventory inventory) {}
+    @Override public void openBook(ItemStack stack, Hand hand) { }
+    @Override public void closeScreen() {}
+    @Override public void updateHeldItem() {}
+    @Override protected void onNewPotionEffect(EffectInstance id) {}
+    @Override protected void onChangedPotionEffect(EffectInstance id, boolean apply) {}
+    @Override protected void onFinishedPotionEffect(EffectInstance effect) {}
+    @Override public void func_213823_a(SoundEvent sound, SoundCategory category, float volume, float pitch) { }
 }


### PR DESCRIPTION
This stubs out several additional methods in the `FakePlayer` class which use the player's connection. Calling the unstubbed methods results in an NPE, as fake players do not have a connection.

This approach is definitely not foolproof - there's definitely some methods I've missed.

An alternative way would be to do something like [CoFHCore does](https://github.com/CoFH/CoFHCore/blob/1.12/src/main/java/cofh/core/entity/FakePlayerCore.java), and have a fake connection object. I'm not sure of the downsides of that though.