### PR TITLE
Add player size event

### DIFF
--- a/patches/minecraft/net/minecraft/entity/player/PlayerEntity.java.patch
+++ b/patches/minecraft/net/minecraft/entity/player/PlayerEntity.java.patch
@@ -437,6 +437,15 @@
        return this.func_208016_c(itextcomponent);
     }
  
+@@ -1878,7 +1996,7 @@
+    }
+ 
+    public EntitySize func_213305_a(Pose p_213305_1_) {
+-      return field_213836_b.getOrDefault(p_213305_1_, field_213835_bs);
++      return net.minecraftforge.event.ForgeEventFactory.getPlayerSize(this, field_213836_b.getOrDefault(p_213305_1_, field_213835_bs));
+    }
+ 
+    public ItemStack func_213356_f(ItemStack p_213356_1_) {
 @@ -1939,4 +2057,44 @@
           return this.field_221260_g;
        }

--- a/src/main/java/net/minecraftforge/event/ForgeEventFactory.java
+++ b/src/main/java/net/minecraftforge/event/ForgeEventFactory.java
@@ -33,6 +33,7 @@ import net.minecraft.entity.MobEntity;
 import net.minecraft.entity.SpawnReason;
 import net.minecraft.entity.LivingEntity;
 import net.minecraft.entity.EntityClassification;
+import net.minecraft.entity.EntitySize;
 import net.minecraft.entity.merchant.IMerchant;
 import net.minecraft.entity.effect.LightningBoltEntity;
 import net.minecraft.entity.item.ItemEntity;
@@ -698,5 +699,12 @@ public class ForgeEventFactory
     public static boolean onPistonMovePost(World world, BlockPos pos, Direction direction, boolean extending)
     {
         return MinecraftForge.EVENT_BUS.post(new PistonEvent.Post(world, pos, direction, extending ? PistonEvent.PistonMoveType.EXTEND : PistonEvent.PistonMoveType.RETRACT));
+    }
+
+    public static EntitySize getPlayerSize(PlayerEntity player, EntitySize originalSize)
+    {
+        PlayerEvent.PlayerSizeEvent event = new PlayerEvent.PlayerSizeEvent(player, originalSize);
+        MinecraftForge.EVENT_BUS.post(event);
+        return event.getSize();
     }
 }

--- a/src/main/java/net/minecraftforge/event/entity/player/PlayerEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/player/PlayerEvent.java
@@ -21,6 +21,7 @@ package net.minecraftforge.event.entity.player;
 
 import java.io.File;
 
+import net.minecraft.entity.EntitySize;
 import net.minecraft.entity.item.ItemEntity;
 import net.minecraft.inventory.IInventory;
 import net.minecraft.item.ItemStack;
@@ -33,7 +34,6 @@ import net.minecraft.entity.Entity;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.util.math.BlockPos;
 import net.minecraftforge.event.entity.living.LivingEvent;
-import net.minecraftforge.eventbus.api.Event;
 
 import javax.annotation.Nonnull;
 
@@ -516,6 +516,35 @@ public class PlayerEvent extends LivingEvent
         public DimensionType getTo()
         {
             return this.toDim;
+        }
+    }
+
+    public static class PlayerSizeEvent extends PlayerEvent {
+        private final EntitySize originalSize;
+        @Nonnull
+        private EntitySize size;
+
+        public PlayerSizeEvent(PlayerEntity player, @Nonnull EntitySize size)
+        {
+            super(player);
+            this.originalSize = size;
+            this.size = size;
+        }
+
+        public EntitySize getOriginalSize()
+        {
+            return originalSize;
+        }
+
+        public void setSize(@Nonnull EntitySize size)
+        {
+            this.size = size;
+        }
+
+        @Nonnull
+        public EntitySize getSize()
+        {
+            return size;
         }
     }
 }


### PR DESCRIPTION
Alternative to https://github.com/MinecraftForge/MinecraftForge/pull/6166

For original intention see https://github.com/MinecraftForge/MinecraftForge/pull/6059
Because the vanilla pose system is rather difficult to modify, this PR simply introduces a way to modify the player's size regardless of their pose.

This is done by adding an event hook in the PlayerEntity#getSize method.

Note: If a mod decides to return a different size (e.g the player transformed)  for the same pose, it has to call Entity#recalculateSize

#### Pro
- Straightforward
- Small patch size
- Can adapt to pose
#### Con
- getSize is called several times per tick