### PR TITLE
Fixed IModelData not able to be removed once the tile entity is removed

### DIFF
--- a/patches/minecraft/net/minecraft/tileentity/TileEntity.java.patch
+++ b/patches/minecraft/net/minecraft/tileentity/TileEntity.java.patch
@@ -49,15 +49,16 @@
              this.field_145850_b.func_175666_e(this.field_174879_c, this.field_195045_e.func_177230_c());
           }
        }
-@@ -139,6 +146,7 @@
+@@ -139,6 +146,8 @@
  
     public void func_145843_s() {
        this.field_145846_f = true;
 +      this.invalidateCaps();
++      requestModelDataUpdate();
     }
  
     public void func_145829_t() {
-@@ -181,6 +189,13 @@
+@@ -181,6 +190,13 @@
        return this.field_200663_e;
     }
  

--- a/src/main/java/net/minecraftforge/client/model/ModelDataManager.java
+++ b/src/main/java/net/minecraftforge/client/model/ModelDataManager.java
@@ -83,7 +83,7 @@ public class ModelDataManager
             for (BlockPos pos : needUpdate)
             {
                 TileEntity toUpdate = world.getTileEntity(pos);
-                if (toUpdate != null)
+                if (toUpdate != null && !toUpdate.isRemoved())
                 {
                     data.put(pos, toUpdate.getModelData());
                 }

--- a/src/main/java/net/minecraftforge/client/model/ModelDataManager.java
+++ b/src/main/java/net/minecraftforge/client/model/ModelDataManager.java
@@ -87,6 +87,10 @@ public class ModelDataManager
                 {
                     data.put(pos, toUpdate.getModelData());
                 }
+                else
+                {
+                    data.remove(pos);
+                }
             }
         }
     }


### PR DESCRIPTION
When using `IModelData`, the data can persist after the tile entity is removed, even if `#requestModelDataUpdate` has been called. This simply just makes it so if there is no tile entity at a position, then the model data is removed from the `modelDataCache`   

One thing that could be done, is when a tile entitiy is removed, `TileEntity#remove`, it requests a model data update, so that the data will be removed when the cache is next updated.

A fix for anyone currently facing this problem with be to use a `ModelProperty<Supplier<Boolean>>`, which should be set to `() -> tileentity.isRemoved`