### PR TITLE
Changed all calls of `BlockState#getSoundType` to use the sensitive version. 

### DIFF
--- a/patches/minecraft/net/minecraft/client/renderer/WorldRenderer.java.patch
+++ b/patches/minecraft/net/minecraft/client/renderer/WorldRenderer.java.patch
@@ -107,8 +107,9 @@
        case 2001:
           BlockState blockstate = Block.func_196257_b(p_180439_4_);
 -         if (!blockstate.func_196958_f()) {
+-            SoundType soundtype = blockstate.func_215695_r();
 +         if (!blockstate.isAir(this.field_72769_h, p_180439_3_)) {
-             SoundType soundtype = blockstate.func_215695_r();
++            SoundType soundtype = blockstate.getSoundType(field_72769_h, p_180439_3_, null);
              this.field_72769_h.func_184156_a(p_180439_3_, soundtype.func_185845_c(), SoundCategory.BLOCKS, (soundtype.func_185843_a() + 1.0F) / 2.0F, soundtype.func_185847_b() * 0.8F, false);
           }
 @@ -2118,6 +2132,11 @@

--- a/patches/minecraft/net/minecraft/entity/Entity.java.patch
+++ b/patches/minecraft/net/minecraft/entity/Entity.java.patch
@@ -104,7 +104,7 @@
        if (!p_180429_2_.func_185904_a().func_76224_d()) {
           BlockState blockstate = this.field_70170_p.func_180495_p(p_180429_1_.func_177984_a());
 -         SoundType soundtype = blockstate.func_177230_c() == Blocks.field_150433_aE ? blockstate.func_215695_r() : p_180429_2_.func_215695_r();
-+         SoundType soundtype = blockstate.func_177230_c() == Blocks.field_150433_aE ? blockstate.func_215695_r() : p_180429_2_.getSoundType(field_70170_p, p_180429_1_, this);
++         SoundType soundtype = blockstate.func_177230_c() == Blocks.field_150433_aE ? blockstate.getSoundType(field_70170_p, p_180429_1_, this) : p_180429_2_.getSoundType(field_70170_p, p_180429_1_, this);
           this.func_184185_a(soundtype.func_185844_d(), soundtype.func_185843_a() * 0.15F, soundtype.func_185847_b());
        }
     }

--- a/patches/minecraft/net/minecraft/entity/passive/horse/AbstractHorseEntity.java.patch
+++ b/patches/minecraft/net/minecraft/entity/passive/horse/AbstractHorseEntity.java.patch
@@ -1,6 +1,19 @@
 --- a/net/minecraft/entity/passive/horse/AbstractHorseEntity.java
 +++ b/net/minecraft/entity/passive/horse/AbstractHorseEntity.java
-@@ -260,6 +260,7 @@
+@@ -230,9 +230,10 @@
+             }
+          }
+ 
+-         BlockState blockstate = this.field_70170_p.func_180495_p(new BlockPos(this.field_70165_t, this.field_70163_u - 0.2D - (double)this.field_70126_B, this.field_70161_v));
++         BlockPos pos = new BlockPos(this.field_70165_t, this.field_70163_u - 0.2D - (double) this.field_70126_B, this.field_70161_v);
++         BlockState blockstate = this.field_70170_p.func_180495_p(pos);
+          if (!blockstate.func_196958_f() && !this.func_174814_R()) {
+-            SoundType soundtype = blockstate.func_215695_r();
++            SoundType soundtype = blockstate.getSoundType(field_70170_p, pos, this);
+             this.field_70170_p.func_184148_a((PlayerEntity)null, this.field_70165_t, this.field_70163_u, this.field_70161_v, soundtype.func_185844_d(), this.func_184176_by(), soundtype.func_185843_a() * 0.5F, soundtype.func_185847_b() * 0.75F);
+          }
+ 
+@@ -260,6 +261,7 @@
  
        this.field_110296_bG.func_110134_a(this);
        this.func_110232_cE();
@@ -8,7 +21,19 @@
     }
  
     protected void func_110232_cE() {
-@@ -944,4 +945,22 @@
+@@ -321,9 +323,9 @@
+    protected void func_180429_a(BlockPos p_180429_1_, BlockState p_180429_2_) {
+       if (!p_180429_2_.func_185904_a().func_76224_d()) {
+          BlockState blockstate = this.field_70170_p.func_180495_p(p_180429_1_.func_177984_a());
+-         SoundType soundtype = p_180429_2_.func_215695_r();
++         SoundType soundtype = p_180429_2_.getSoundType(field_70170_p, p_180429_1_, this);
+          if (blockstate.func_177230_c() == Blocks.field_150433_aE) {
+-            soundtype = blockstate.func_215695_r();
++            soundtype = blockstate.getSoundType(field_70170_p, p_180429_1_, this);
+          }
+ 
+          if (this.func_184207_aI() && this.field_190688_bE) {
+@@ -944,4 +946,22 @@
  
        return p_213386_4_;
     }

--- a/patches/minecraft/net/minecraft/entity/passive/horse/LlamaEntity.java.patch
+++ b/patches/minecraft/net/minecraft/entity/passive/horse/LlamaEntity.java.patch
@@ -1,6 +1,6 @@
---- a/net/minecraft/entity/passive/FoxEntity.java
-+++ b/net/minecraft/entity/passive/FoxEntity.java
-@@ -573,9 +573,10 @@
+--- a/net/minecraft/entity/passive/horse/LlamaEntity.java
++++ b/net/minecraft/entity/passive/horse/LlamaEntity.java
+@@ -364,9 +364,10 @@
              }
           }
  
@@ -13,12 +13,3 @@
              this.field_70170_p.func_184148_a((PlayerEntity)null, this.field_70165_t, this.field_70163_u, this.field_70161_v, soundtype.func_185844_d(), this.func_184176_by(), soundtype.func_185843_a() * 0.5F, soundtype.func_185847_b() * 0.75F);
           }
  
-@@ -767,7 +768,7 @@
-       }
- 
-       protected void func_220730_m() {
--         if (FoxEntity.this.field_70170_p.func_82736_K().func_223586_b(GameRules.field_223599_b)) {
-+         if (net.minecraftforge.event.ForgeEventFactory.getMobGriefingEvent(FoxEntity.this.field_70170_p, FoxEntity.this)) {
-             BlockState blockstate = FoxEntity.this.field_70170_p.func_180495_p(this.field_179494_b);
-             if (blockstate.func_177230_c() == Blocks.field_222434_lW) {
-                int i = blockstate.func_177229_b(SweetBerryBushBlock.field_220125_a);

--- a/patches/minecraft/net/minecraft/item/BlockItem.java.patch
+++ b/patches/minecraft/net/minecraft/item/BlockItem.java.patch
@@ -1,15 +1,34 @@
 --- a/net/minecraft/item/BlockItem.java
 +++ b/net/minecraft/item/BlockItem.java
-@@ -69,7 +69,7 @@
+@@ -69,8 +69,8 @@
                    }
                 }
  
 -               SoundType soundtype = blockstate1.func_215695_r();
+-               world.func_184133_a(playerentity, blockpos, this.func_219983_a(blockstate1), SoundCategory.BLOCKS, (soundtype.func_185843_a() + 1.0F) / 2.0F, soundtype.func_185847_b() * 0.8F);
 +               SoundType soundtype = blockstate1.getSoundType(world, blockpos, p_195942_1_.func_195999_j());
-                world.func_184133_a(playerentity, blockpos, this.func_219983_a(blockstate1), SoundCategory.BLOCKS, (soundtype.func_185843_a() + 1.0F) / 2.0F, soundtype.func_185847_b() * 0.8F);
++               world.func_184133_a(playerentity, blockpos, this.getPlaceSound(blockstate1, world, blockpos, p_195942_1_.func_195999_j()), SoundCategory.BLOCKS, (soundtype.func_185843_a() + 1.0F) / 2.0F, soundtype.func_185847_b() * 0.8F);
                 itemstack.func_190918_g(1);
                 return ActionResultType.SUCCESS;
-@@ -189,10 +189,18 @@
+             }
+@@ -78,10 +78,16 @@
+       }
+    }
+ 
++   @Deprecated //Forge: Use more sensitive version {@link BlockItem#getPlaceSound(BlockState, IBlockReader, BlockPos, Entity) }
+    protected SoundEvent func_219983_a(BlockState p_219983_1_) {
+       return p_219983_1_.func_215695_r().func_185841_e();
+    }
+ 
++   //Forge: Sensitive version of BlockItem#getPlaceSound
++   protected SoundEvent getPlaceSound(BlockState state, World world, BlockPos pos, PlayerEntity entity) {
++      return state.getSoundType(world, pos, entity).func_185841_e();
++   }
++
+    @Nullable
+    public BlockItemUseContext func_219984_b(BlockItemUseContext p_219984_1_) {
+       return p_219984_1_;
+@@ -189,10 +195,18 @@
     }
  
     public Block func_179223_d() {


### PR DESCRIPTION
Changed all the calls of `BlockState#getSoundType()` to use `BlockState#getSoundType(IWorldReader, BlockPos, Entity)`.

I don't believe I've missed any, but if I have please point them out. 

Also, if wanted, I could search for all missing sensitive calls to Blocks/Items/Whatever and add them to this PR 