### PR TITLE
Fix ParticleFactoryRegisterEvent not firing

### DIFF
--- a/patches/minecraft/net/minecraft/client/Minecraft.java.patch
+++ b/patches/minecraft/net/minecraft/client/Minecraft.java.patch
@@ -41,7 +41,13 @@
        this.field_110448_aq.func_198983_a();
        List<IResourcePack> list = this.field_110448_aq.func_198980_d().stream().map(ResourcePackInfo::func_195796_e).collect(Collectors.toList());
  
-@@ -521,7 +521,8 @@
+@@ -516,12 +516,14 @@
+       this.field_110451_am.func_219534_a(this.field_193995_ae);
+       GlStateManager.viewport(0, 0, this.field_195558_d.func_198109_k(), this.field_195558_d.func_198091_l());
+       this.field_71452_i = new ParticleManager(this.field_71441_e, this.field_71446_o);
++      net.minecraftforge.fml.ModLoader.get().postEvent(new net.minecraftforge.client.event.ParticleFactoryRegisterEvent());
+       this.field_110451_am.func_219534_a(this.field_71452_i);
+       this.field_213272_aL = new PaintingSpriteUploader(this.field_71446_o);
        this.field_110451_am.func_219534_a(this.field_213272_aL);
        this.field_213273_aM = new PotionSpriteUploader(this.field_71446_o);
        this.field_110451_am.func_219534_a(this.field_213273_aM);
@@ -51,7 +57,7 @@
        this.field_184132_p = new DebugRenderer(this);
        GLX.setGlfwErrorCallback(this::func_195545_a);
        if (this.field_71474_y.field_74353_u && !this.field_195558_d.func_198113_j()) {
-@@ -543,7 +544,7 @@
+@@ -543,7 +545,7 @@
           if (SharedConstants.field_206244_b) {
              this.func_213256_aB();
           }
@@ -60,7 +66,7 @@
        }, false));
     }
  
-@@ -558,7 +559,7 @@
+@@ -558,7 +560,7 @@
           return Stream.of(Registry.field_212630_s.func_177774_c(p_213251_0_.func_77973_b()));
        });
        SearchTreeReloadable<ItemStack> searchtreereloadable = new SearchTreeReloadable<>((p_213235_0_) -> {
@@ -69,7 +75,7 @@
        });
        NonNullList<ItemStack> nonnulllist = NonNullList.func_191196_a();
  
-@@ -647,7 +648,7 @@
+@@ -647,7 +649,7 @@
        Bootstrap.func_179870_a(p_71377_1_.func_71502_e());
        if (p_71377_1_.func_71497_f() != null) {
           Bootstrap.func_179870_a("#@!@# Game crashed! Crash report saved to: #@!@# " + p_71377_1_.func_71497_f());
@@ -78,7 +84,7 @@
        } else if (p_71377_1_.func_147149_a(file2)) {
           Bootstrap.func_179870_a("#@!@# Game crashed! Crash report saved to: #@!@# " + file2.getAbsolutePath());
           System.exit(-1);
-@@ -662,6 +663,7 @@
+@@ -662,6 +664,7 @@
        return this.field_71474_y.field_211842_aO;
     }
  
@@ -86,7 +92,7 @@
     public CompletableFuture<Void> func_213237_g() {
        if (this.field_213276_aV != null) {
           return this.field_213276_aV;
-@@ -741,16 +743,20 @@
+@@ -741,16 +744,20 @@
     }
  
     public void func_147108_a(@Nullable Screen p_147108_1_) {
@@ -111,7 +117,7 @@
        if (p_147108_1_ instanceof MainMenuScreen || p_147108_1_ instanceof MultiplayerScreen) {
           this.field_71474_y.field_74330_P = false;
           this.field_71456_v.func_146158_b().func_146231_a(true);
-@@ -875,11 +881,13 @@
+@@ -875,11 +882,13 @@
        GlStateManager.enableTexture();
        this.field_71424_I.func_76319_b();
        if (!this.field_71454_w) {
@@ -125,7 +131,7 @@
        }
  
        this.field_71424_I.func_219897_b();
-@@ -1147,10 +1155,10 @@
+@@ -1147,10 +1156,10 @@
           if (p_147115_1_ && this.field_71476_x != null && this.field_71476_x.func_216346_c() == RayTraceResult.Type.BLOCK) {
              BlockRayTraceResult blockraytraceresult = (BlockRayTraceResult)this.field_71476_x;
              BlockPos blockpos = blockraytraceresult.func_216350_a();
@@ -138,7 +144,7 @@
                    this.field_71439_g.func_184609_a(Hand.MAIN_HAND);
                 }
              }
-@@ -1177,7 +1185,7 @@
+@@ -1177,7 +1186,7 @@
              case BLOCK:
                 BlockRayTraceResult blockraytraceresult = (BlockRayTraceResult)this.field_71476_x;
                 BlockPos blockpos = blockraytraceresult.func_216350_a();
@@ -147,7 +153,7 @@
                    this.field_71442_b.func_180511_b(blockpos, blockraytraceresult.func_216354_b());
                    break;
                 }
-@@ -1187,6 +1195,7 @@
+@@ -1187,6 +1196,7 @@
                 }
  
                 this.field_71439_g.func_184821_cY();
@@ -155,7 +161,7 @@
              }
  
              this.field_71439_g.func_184609_a(Hand.MAIN_HAND);
-@@ -1236,6 +1245,9 @@
+@@ -1236,6 +1246,9 @@
                    }
                 }
  
@@ -165,7 +171,7 @@
                 if (!itemstack.func_190926_b() && this.field_71442_b.func_187101_a(this.field_71439_g, this.field_71441_e, hand) == ActionResultType.SUCCESS) {
                    this.field_71460_t.field_78516_c.func_187460_a(hand);
                    return;
-@@ -1255,6 +1267,8 @@
+@@ -1255,6 +1268,8 @@
           --this.field_71467_ac;
        }
  
@@ -174,7 +180,7 @@
        this.field_71424_I.func_76320_a("gui");
        if (!this.field_71445_n) {
           this.field_71456_v.func_73831_a();
-@@ -1373,6 +1387,8 @@
+@@ -1373,6 +1388,8 @@
        this.field_71424_I.func_219895_b("keyboard");
        this.field_195559_v.func_204870_b();
        this.field_71424_I.func_76319_b();
@@ -183,7 +189,7 @@
     }
  
     private void func_184117_aA() {
-@@ -1527,6 +1543,12 @@
+@@ -1527,6 +1544,12 @@
        this.func_147108_a(worldloadprogressscreen);
  
        while(!this.field_71437_Z.func_71200_ad()) {
@@ -196,7 +202,7 @@
           worldloadprogressscreen.tick();
           this.func_195542_b(false);
  
-@@ -1547,11 +1569,17 @@
+@@ -1547,11 +1570,17 @@
        networkmanager.func_150719_a(new ClientLoginNetHandler(networkmanager, this, (Screen)null, (p_213261_0_) -> {
        }));
        networkmanager.func_179290_a(new CHandshakePacket(socketaddress.toString(), 0, ProtocolType.LOGIN));
@@ -215,7 +221,7 @@
        WorkingScreen workingscreen = new WorkingScreen();
        workingscreen.func_200210_a(new TranslationTextComponent("connect.joining"));
        this.func_213241_c(workingscreen);
-@@ -1583,10 +1611,12 @@
+@@ -1583,10 +1612,12 @@
        IntegratedServer integratedserver = this.field_71437_Z;
        this.field_71437_Z = null;
        this.field_71460_t.func_190564_k();
@@ -228,7 +234,7 @@
           if (integratedserver != null) {
              while(!integratedserver.func_213201_w()) {
                 this.func_195542_b(false);
-@@ -1624,6 +1654,7 @@
+@@ -1624,6 +1655,7 @@
        }
  
        TileEntityRendererDispatcher.field_147556_a.func_147543_a(p_213257_1_);
@@ -236,7 +242,7 @@
     }
  
     public final boolean func_71355_q() {
-@@ -1649,112 +1680,8 @@
+@@ -1649,112 +1681,8 @@
  
     private void func_147112_ai() {
        if (this.field_71476_x != null && this.field_71476_x.func_216346_c() != RayTraceResult.Type.MISS) {
@@ -351,7 +357,7 @@
        }
     }
  
-@@ -1826,6 +1753,7 @@
+@@ -1826,6 +1754,7 @@
        return field_71432_P;
     }
  
@@ -359,7 +365,7 @@
     public CompletableFuture<Void> func_213245_w() {
        return this.func_213169_a(this::func_213237_g).thenCompose((p_213240_0_) -> {
           return p_213240_0_;
-@@ -1972,6 +1900,8 @@
+@@ -1972,6 +1901,8 @@
     }
  
     public MusicTicker.MusicType func_147109_W() {
@@ -368,7 +374,7 @@
        if (this.field_71462_r instanceof WinGameScreen) {
           return MusicTicker.MusicType.CREDITS;
        } else if (this.field_71439_g == null) {
-@@ -2128,4 +2058,12 @@
+@@ -2128,4 +2059,12 @@
     public LoadingGui func_213250_au() {
        return this.field_213279_p;
     }

--- a/patches/minecraft/net/minecraft/client/particle/ParticleManager.java.patch
+++ b/patches/minecraft/net/minecraft/client/particle/ParticleManager.java.patch
@@ -9,11 +9,7 @@
     private final Queue<Particle> field_187241_h = Queues.newArrayDeque();
     private final Map<ResourceLocation, ParticleManager.AnimatedSpriteImpl> field_215242_i = Maps.newHashMap();
     private final AtlasTexture field_215243_j = new AtlasTexture("textures/particle");
-@@ -134,16 +134,17 @@
-       this.func_215234_a(ParticleTypes.field_197605_P, UnderwaterParticle.Factory::new);
-       this.func_215234_a(ParticleTypes.field_218422_X, SplashParticle.Factory::new);
-       this.func_215234_a(ParticleTypes.field_197607_R, SpellParticle.WitchFactory::new);
-+      net.minecraftforge.common.MinecraftForge.EVENT_BUS.post(new net.minecraftforge.client.event.ParticleFactoryRegisterEvent());
+@@ -137,13 +137,13 @@
     }
  
     public <T extends IParticleData> void func_199283_a(ParticleType<T> p_199283_1_, IParticleFactory<T> p_199283_2_) {
@@ -29,7 +25,7 @@
     }
  
     public CompletableFuture<Void> func_215226_a(IFutureReloadListener.IStage p_215226_1_, IResourceManager p_215226_2_, IProfiler p_215226_3_, IProfiler p_215226_4_, Executor p_215226_5_, Executor p_215226_6_) {
-@@ -230,11 +231,12 @@
+@@ -230,11 +230,12 @@
  
     @Nullable
     private <T extends IParticleData> Particle func_199927_b(T p_199927_1_, double p_199927_2_, double p_199927_4_, double p_199927_6_, double p_199927_8_, double p_199927_10_, double p_199927_12_) {
@@ -43,7 +39,7 @@
        this.field_187241_h.add(p_78873_1_);
     }
  
-@@ -342,7 +344,7 @@
+@@ -342,7 +343,7 @@
     }
  
     public void func_180533_a(BlockPos p_180533_1_, BlockState p_180533_2_) {
@@ -52,7 +48,7 @@
           VoxelShape voxelshape = p_180533_2_.func_196954_c(this.field_78878_a, p_180533_1_);
           double d0 = 0.25D;
           voxelshape.func_197755_b((p_199284_3_, p_199284_5_, p_199284_7_, p_199284_9_, p_199284_11_, p_199284_13_) -> {
-@@ -414,6 +416,12 @@
+@@ -414,6 +415,12 @@
        return String.valueOf(this.field_78876_b.values().stream().mapToInt(Collection::size).sum());
     }
  


### PR DESCRIPTION
This event happens before the forge event bus is started, so it was moved to the mod bus. Also, the event is now posted after the particle manager is finished constructing so mods can access it.