### PR TITLE
Maintain default behaviour for Item#canPlayerBreakBlockWhileHolding()

### DIFF
--- a/src/main/java/net/minecraftforge/common/ForgeHooks.java
+++ b/src/main/java/net/minecraftforge/common/ForgeHooks.java
@@ -531,9 +531,10 @@ public class ForgeHooks
         // Logic from tryHarvestBlock for pre-canceling the event
         boolean preCancelEvent = false;
         ItemStack itemstack = entityPlayer.getHeldItemMainhand();
-        if (gameType.isCreative() && !itemstack.isEmpty()
-                && !itemstack.getItem().canPlayerBreakBlockWhileHolding(world.getBlockState(pos), world, pos, entityPlayer))
+        if (!itemstack.isEmpty() && !itemstack.getItem().canPlayerBreakBlockWhileHolding(world.getBlockState(pos), world, pos, entityPlayer))
+        {
             preCancelEvent = true;
+        }
 
         if (gameType.hasLimitedInteractions())
         {


### PR DESCRIPTION
This PR fix missing default behaviour for [this forge hook](https://github.com/MinecraftForge/MinecraftForge/blob/4dc34b7d5b945b9d4fa86223771fcfecea7de293/src/main/java/net/minecraftforge/common/ForgeHooks.java#L529) ([patch](https://github.com/MinecraftForge/MinecraftForge/blob/68524ddde93eb404a5fd42b6beb6b8c92426b7e4/patches/minecraft/net/minecraft/server/management/PlayerInteractionManager.java.patch#L58)) which was preserved only for `gameType.isCreative()`