### PR TITLE
[1.14.x] Another attempt to fix the ArgumentTypes added by Forge

### DIFF
--- a/src/main/java/net/minecraftforge/server/command/ConfigCommand.java
+++ b/src/main/java/net/minecraftforge/server/command/ConfigCommand.java
@@ -46,7 +46,7 @@ public class ConfigCommand {
             return Commands.literal("showfile").
                     requires(cs->cs.hasPermissionLevel(0)).
                     then(Commands.argument("mod", ModIdArgument.modIdArgument()).
-                        then(Commands.argument("type", EnumArgument.enumArgument(ModConfig.Type.class)).
+                        then(Commands.argument("type", ConfigTypeArgument.configTypeArgument()).
                             executes(ShowFile::showFile)
                         )
                     );

--- a/src/main/java/net/minecraftforge/server/command/ConfigTypeArgument.java
+++ b/src/main/java/net/minecraftforge/server/command/ConfigTypeArgument.java
@@ -19,14 +19,14 @@
 
 package net.minecraftforge.server.command;
 
-import net.minecraft.command.arguments.ArgumentSerializer;
-import net.minecraft.command.arguments.ArgumentTypes;
+import net.minecraftforge.fml.config.ModConfig;
 
-public class ForgeArguments
-{
-    public static void register()
-    {
-        ArgumentTypes.register("forge:modid", ModIdArgument.class, new ArgumentSerializer<>(ModIdArgument::modIdArgument));
-        ArgumentTypes.register("forge:config_type", ConfigTypeArgument.class, new ArgumentSerializer<>(ConfigTypeArgument::configTypeArgument));
+public class ConfigTypeArgument extends EnumArgument<ModConfig.Type> {
+    public ConfigTypeArgument() {
+        super(ModConfig.Type.class);
+    }
+
+    public static ConfigTypeArgument configTypeArgument() {
+        return new ConfigTypeArgument();
     }
 }

--- a/src/main/java/net/minecraftforge/server/command/EnumArgument.java
+++ b/src/main/java/net/minecraftforge/server/command/EnumArgument.java
@@ -31,13 +31,14 @@ import java.util.concurrent.CompletableFuture;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+/**
+ * Because {@link ArgumentType}s are registered by class, and we can't use a custom serializer (breaks vanilla clients),
+ * a subclass of this class must be created for each enum. Example: {@link ConfigTypeArgument}
+ */
 public class EnumArgument<T extends Enum<T>> implements ArgumentType<T> {
     private final Class<T> enumClass;
 
-    public static <R extends Enum<R>> EnumArgument<R> enumArgument(Class<R> enumClass) {
-        return new EnumArgument<>(enumClass);
-    }
-    private EnumArgument(final Class<T> enumClass) {
+    protected EnumArgument(final Class<T> enumClass) {
         this.enumClass = enumClass;
     }
 
@@ -55,29 +56,4 @@ public class EnumArgument<T extends Enum<T>> implements ArgumentType<T> {
     public Collection<String> getExamples() {
         return Stream.of(enumClass.getEnumConstants()).map(Object::toString).collect(Collectors.toList());
     }
-
-    /* JAVAC HATES RAW TYPES!
-    @SuppressWarnings({"rawtypes", "unchecked"})
-    public static class Serialzier implements IArgumentSerializer<EnumArgument> {
-        @Override
-        public void write(EnumArgument argument, PacketBuffer buffer) {
-            buffer.writeString(argument.enumClass.getName());
-        }
-
-        @Override
-        public EnumArgument<?> read(PacketBuffer buffer) {
-            try {
-                String name = buffer.readString();
-                return new EnumArgument(Class.forName(name));
-            } catch (ClassNotFoundException e) {
-                return null;
-            }
-        }
-
-        @Override
-        public void write(EnumArgument argument, JsonObject json) {
-            json.addProperty("enum", argument.enumClass.getName());
-        }
-    }
-    */
 }


### PR DESCRIPTION
This has been a problem for a while now, and the errors that are printed into the logs because of it are really annoying.

This PR turns the config type argument into it's own subclass of `EnumArgument`, so it can be registered without a custom serializer, and doesn't break vanilla clients.