### PR TITLE
Move displaying the main menu during init to after launch

### DIFF
--- a/patches/minecraft/net/minecraft/client/Minecraft.java.patch
+++ b/patches/minecraft/net/minecraft/client/Minecraft.java.patch
@@ -57,16 +57,34 @@
        this.field_184132_p = new DebugRenderer(this);
        GLX.setGlfwErrorCallback(this::func_195545_a);
        if (this.field_71474_y.field_74353_u && !this.field_195558_d.func_198113_j()) {
-@@ -543,7 +545,7 @@
+@@ -532,18 +534,20 @@
+       this.field_195558_d.func_216523_b(this.field_71474_y.field_74352_v);
+       this.field_195558_d.func_224798_d(this.field_71474_y.field_225307_E);
+       this.field_195558_d.func_198112_b();
+-      if (this.field_71475_ae != null) {
+-         this.func_147108_a(new ConnectingScreen(new MainMenuScreen(), this, this.field_71475_ae, this.field_71477_af));
+-      } else {
+-         this.func_147108_a(new MainMenuScreen(true));
+-      }
+ 
+       ResourceLoadProgressGui.func_212970_a(this);
+       this.func_213268_a(new ResourceLoadProgressGui(this, this.field_110451_am.func_219535_a(Util.func_215072_e(), this, field_223714_G), () -> {
           if (SharedConstants.field_206244_b) {
              this.func_213256_aB();
           }
 -
 +         net.minecraftforge.fml.client.ClientModLoader.complete();
++         // FORGE: Move opening initial screen to after startup and events are enabled.
++         // Also Fixes MC-145102
++         if (this.field_71475_ae != null) {
++            this.func_147108_a(new ConnectingScreen(new MainMenuScreen(), this, this.field_71475_ae, this.field_71477_af));
++         } else {
++            this.func_147108_a(new MainMenuScreen(true));
++         }
        }, false));
     }
  
-@@ -558,7 +560,7 @@
+@@ -558,7 +562,7 @@
           return Stream.of(Registry.field_212630_s.func_177774_c(p_213251_0_.func_77973_b()));
        });
        SearchTreeReloadable<ItemStack> searchtreereloadable = new SearchTreeReloadable<>((p_213235_0_) -> {
@@ -75,7 +93,7 @@
        });
        NonNullList<ItemStack> nonnulllist = NonNullList.func_191196_a();
  
-@@ -647,7 +649,7 @@
+@@ -647,7 +651,7 @@
        Bootstrap.func_179870_a(p_71377_1_.func_71502_e());
        if (p_71377_1_.func_71497_f() != null) {
           Bootstrap.func_179870_a("#@!@# Game crashed! Crash report saved to: #@!@# " + p_71377_1_.func_71497_f());
@@ -84,7 +102,7 @@
        } else if (p_71377_1_.func_147149_a(file2)) {
           Bootstrap.func_179870_a("#@!@# Game crashed! Crash report saved to: #@!@# " + file2.getAbsolutePath());
           System.exit(-1);
-@@ -662,6 +664,7 @@
+@@ -662,6 +666,7 @@
        return this.field_71474_y.field_211842_aO;
     }
  
@@ -92,7 +110,7 @@
     public CompletableFuture<Void> func_213237_g() {
        if (this.field_213276_aV != null) {
           return this.field_213276_aV;
-@@ -741,16 +744,20 @@
+@@ -741,16 +746,20 @@
     }
  
     public void func_147108_a(@Nullable Screen p_147108_1_) {
@@ -117,7 +135,7 @@
        if (p_147108_1_ instanceof MainMenuScreen || p_147108_1_ instanceof MultiplayerScreen) {
           this.field_71474_y.field_74330_P = false;
           this.field_71456_v.func_146158_b().func_146231_a(true);
-@@ -875,11 +882,13 @@
+@@ -875,11 +884,13 @@
        GlStateManager.enableTexture();
        this.field_71424_I.func_76319_b();
        if (!this.field_71454_w) {
@@ -131,7 +149,7 @@
        }
  
        this.field_71424_I.func_219897_b();
-@@ -1147,10 +1156,10 @@
+@@ -1147,10 +1158,10 @@
           if (p_147115_1_ && this.field_71476_x != null && this.field_71476_x.func_216346_c() == RayTraceResult.Type.BLOCK) {
              BlockRayTraceResult blockraytraceresult = (BlockRayTraceResult)this.field_71476_x;
              BlockPos blockpos = blockraytraceresult.func_216350_a();
@@ -144,7 +162,7 @@
                    this.field_71439_g.func_184609_a(Hand.MAIN_HAND);
                 }
              }
-@@ -1177,7 +1186,7 @@
+@@ -1177,7 +1188,7 @@
              case BLOCK:
                 BlockRayTraceResult blockraytraceresult = (BlockRayTraceResult)this.field_71476_x;
                 BlockPos blockpos = blockraytraceresult.func_216350_a();
@@ -153,7 +171,7 @@
                    this.field_71442_b.func_180511_b(blockpos, blockraytraceresult.func_216354_b());
                    break;
                 }
-@@ -1187,6 +1196,7 @@
+@@ -1187,6 +1198,7 @@
                 }
  
                 this.field_71439_g.func_184821_cY();
@@ -161,7 +179,7 @@
              }
  
              this.field_71439_g.func_184609_a(Hand.MAIN_HAND);
-@@ -1236,6 +1246,9 @@
+@@ -1236,6 +1248,9 @@
                    }
                 }
  
@@ -171,7 +189,7 @@
                 if (!itemstack.func_190926_b() && this.field_71442_b.func_187101_a(this.field_71439_g, this.field_71441_e, hand) == ActionResultType.SUCCESS) {
                    this.field_71460_t.field_78516_c.func_187460_a(hand);
                    return;
-@@ -1255,6 +1268,8 @@
+@@ -1255,6 +1270,8 @@
           --this.field_71467_ac;
        }
  
@@ -180,7 +198,7 @@
        this.field_71424_I.func_76320_a("gui");
        if (!this.field_71445_n) {
           this.field_71456_v.func_73831_a();
-@@ -1373,6 +1388,8 @@
+@@ -1373,6 +1390,8 @@
        this.field_71424_I.func_219895_b("keyboard");
        this.field_195559_v.func_204870_b();
        this.field_71424_I.func_76319_b();
@@ -189,7 +207,7 @@
     }
  
     private void func_184117_aA() {
-@@ -1527,6 +1544,12 @@
+@@ -1527,6 +1546,12 @@
        this.func_147108_a(worldloadprogressscreen);
  
        while(!this.field_71437_Z.func_71200_ad()) {
@@ -202,7 +220,7 @@
           worldloadprogressscreen.tick();
           this.func_195542_b(false);
  
-@@ -1547,11 +1570,17 @@
+@@ -1547,11 +1572,17 @@
        networkmanager.func_150719_a(new ClientLoginNetHandler(networkmanager, this, (Screen)null, (p_213261_0_) -> {
        }));
        networkmanager.func_179290_a(new CHandshakePacket(socketaddress.toString(), 0, ProtocolType.LOGIN));
@@ -221,7 +239,7 @@
        WorkingScreen workingscreen = new WorkingScreen();
        workingscreen.func_200210_a(new TranslationTextComponent("connect.joining"));
        this.func_213241_c(workingscreen);
-@@ -1583,10 +1612,12 @@
+@@ -1583,10 +1614,12 @@
        IntegratedServer integratedserver = this.field_71437_Z;
        this.field_71437_Z = null;
        this.field_71460_t.func_190564_k();
@@ -234,7 +252,7 @@
           if (integratedserver != null) {
              while(!integratedserver.func_213201_w()) {
                 this.func_195542_b(false);
-@@ -1624,6 +1655,7 @@
+@@ -1624,6 +1657,7 @@
        }
  
        TileEntityRendererDispatcher.field_147556_a.func_147543_a(p_213257_1_);
@@ -242,7 +260,7 @@
     }
  
     public final boolean func_71355_q() {
-@@ -1649,112 +1681,8 @@
+@@ -1649,112 +1683,8 @@
  
     private void func_147112_ai() {
        if (this.field_71476_x != null && this.field_71476_x.func_216346_c() != RayTraceResult.Type.MISS) {
@@ -357,7 +375,7 @@
        }
     }
  
-@@ -1826,6 +1754,7 @@
+@@ -1826,6 +1756,7 @@
        return field_71432_P;
     }
  
@@ -365,7 +383,7 @@
     public CompletableFuture<Void> func_213245_w() {
        return this.func_213169_a(this::func_213237_g).thenCompose((p_213240_0_) -> {
           return p_213240_0_;
-@@ -1972,6 +1901,8 @@
+@@ -1972,6 +1903,8 @@
     }
  
     public MusicTicker.MusicType func_147109_W() {
@@ -374,7 +392,7 @@
        if (this.field_71462_r instanceof WinGameScreen) {
           return MusicTicker.MusicType.CREDITS;
        } else if (this.field_71439_g == null) {
-@@ -2128,4 +2059,12 @@
+@@ -2128,4 +2061,12 @@
     public LoadingGui func_213250_au() {
        return this.field_213279_p;
     }


### PR DESCRIPTION
Fixes #6062 

This moves opening the initial screen to after startup and events are enabled. This allows events to be fired for the initial opening of the main menu.
Also fixes [MC-145102](https://bugs.mojang.com/browse/MC-145102)

Ideally, this patch would only be 4 lines, 3 for saving the logic for `displayGuiScreen`, and one that calls it after startup is complete. Unfortunately, the multiplayer session starts to connect as soon as `ConnectingScreen` is initialized, so I had to move that along with the screen.

That wouldn't strictly be necessary for just making sure events are passed, but I also wanted to fix a vanilla bug while I was in there. Additionally, I'm afraid it might cause a race condition which causes the `ConnectingScreen` to be displayed after the connection completed.