### PR TITLE
[1.14.X] Reimplemented MouseEvent (from 1.12) as RawMouseEvent

### DIFF
--- a/patches/minecraft/net/minecraft/client/MouseHelper.java.patch
+++ b/patches/minecraft/net/minecraft/client/MouseHelper.java.patch
@@ -1,6 +1,13 @@
 --- a/net/minecraft/client/MouseHelper.java
 +++ b/net/minecraft/client/MouseHelper.java
-@@ -77,11 +77,15 @@
+@@ -71,17 +71,22 @@
+                if (!this.field_198051_p && flag) {
+                   this.func_198034_i();
+                }
++               if (net.minecraftforge.client.ForgeHooksClient.onRawMouseClicked(p_198023_3_, p_198023_4_, p_198023_5_)) return;
+             } else {
+                double d0 = this.field_198040_e * (double)this.field_198036_a.field_195558_d.func_198107_o() / (double)this.field_198036_a.field_195558_d.func_198105_m();
+                double d1 = this.field_198041_f * (double)this.field_198036_a.field_195558_d.func_198087_p() / (double)this.field_198036_a.field_195558_d.func_198083_n();
                 int p_198023_3_f = p_198023_3_;
                 if (flag) {
                    Screen.wrapScreenError(() -> {
@@ -18,7 +25,7 @@
                    }, "mouseReleased event handler", this.field_198036_a.field_71462_r.getClass().getCanonicalName());
                 }
              }
-@@ -105,7 +109,7 @@
+@@ -105,7 +110,7 @@
                 }
              }
           }
@@ -27,7 +34,7 @@
        }
     }
  
-@@ -116,7 +120,9 @@
+@@ -116,7 +121,9 @@
              if (this.field_198036_a.field_71462_r != null) {
                 double d1 = this.field_198040_e * (double)this.field_198036_a.field_195558_d.func_198107_o() / (double)this.field_198036_a.field_195558_d.func_198105_m();
                 double d2 = this.field_198041_f * (double)this.field_198036_a.field_195558_d.func_198087_p() / (double)this.field_198036_a.field_195558_d.func_198083_n();
@@ -38,7 +45,7 @@
              } else if (this.field_198036_a.field_71439_g != null) {
                 if (this.field_200542_o != 0.0D && Math.signum(d0) != Math.signum(this.field_200542_o)) {
                    this.field_200542_o = 0.0D;
-@@ -129,6 +135,7 @@
+@@ -129,6 +136,7 @@
                 }
  
                 this.field_200542_o -= (double)f1;
@@ -46,7 +53,7 @@
                 if (this.field_198036_a.field_71439_g.func_175149_v()) {
                    if (this.field_198036_a.field_71456_v.func_175187_g().func_175262_a()) {
                       this.field_198036_a.field_71456_v.func_175187_g().func_195621_a((double)(-f1));
-@@ -168,7 +175,9 @@
+@@ -168,7 +176,9 @@
                 double d2 = (p_198022_3_ - this.field_198040_e) * (double)this.field_198036_a.field_195558_d.func_198107_o() / (double)this.field_198036_a.field_195558_d.func_198105_m();
                 double d3 = (p_198022_5_ - this.field_198041_f) * (double)this.field_198036_a.field_195558_d.func_198087_p() / (double)this.field_198036_a.field_195558_d.func_198083_n();
                 Screen.wrapScreenError(() -> {
@@ -57,7 +64,7 @@
                 }, "mouseDragged event handler", iguieventlistener.getClass().getCanonicalName());
              }
           }
-@@ -233,6 +242,10 @@
+@@ -233,6 +243,10 @@
        return this.field_198039_d;
     }
  
@@ -68,7 +75,7 @@
     public double func_198024_e() {
        return this.field_198040_e;
     }
-@@ -241,6 +254,14 @@
+@@ -241,6 +255,14 @@
        return this.field_198041_f;
     }
  

--- a/src/main/java/net/minecraftforge/client/ForgeHooksClient.java
+++ b/src/main/java/net/minecraftforge/client/ForgeHooksClient.java
@@ -1043,4 +1043,9 @@ public class ForgeHooksClient
         Event event = new InputEvent.MouseScrollEvent(scrollDelta, mouseHelper.isLeftDown(), mouseHelper.isMiddleDown(), mouseHelper.isRightDown(), mouseHelper.getMouseX(), mouseHelper.getMouseY());
         return MinecraftForge.EVENT_BUS.post(event);
     }
+
+    public static boolean onRawMouseClicked(int button, int action, int mods)
+    {
+        return MinecraftForge.EVENT_BUS.post(new InputEvent.RawMouseEvent(button, action, mods));
+    }
 }

--- a/src/main/java/net/minecraftforge/client/event/InputEvent.java
+++ b/src/main/java/net/minecraftforge/client/event/InputEvent.java
@@ -28,6 +28,59 @@ import org.lwjgl.glfw.GLFW;
 public class InputEvent extends Event
 {
     /**
+     * A cancellable mouse event fired before key bindings are updated
+     */
+    public static class RawMouseEvent extends InputEvent
+    {
+        private final int button;
+        private final int action;
+        private final int mods;
+
+        public RawMouseEvent(int button, int action, int mods)
+        {
+            this.button = button;
+            this.action = action;
+            this.mods = mods;
+        }
+
+        /**
+         * The mouse button that triggered this event.
+         * https://www.glfw.org/docs/latest/group__buttons.html
+         *
+         * @see GLFW mouse constants starting with "GLFW_MOUSE_BUTTON_"
+         */
+        public int getButton()
+        {
+            return this.button;
+        }
+
+        /**
+         * Integer representing the mouse button's action.
+         *
+         * @see GLFW#GLFW_PRESS
+         * @see GLFW#GLFW_RELEASE
+         */
+        public int getAction()
+        {
+            return this.action;
+        }
+
+        /**
+         * Bit field representing the modifier keys pressed.
+         * https://www.glfw.org/docs/latest/group__mods.html
+         *
+         * @see GLFW#GLFW_MOD_SHIFT
+         * @see GLFW#GLFW_MOD_CONTROL
+         * @see GLFW#GLFW_MOD_ALT
+         * @see GLFW#GLFW_MOD_SUPER
+         */
+        public int getMods()
+        {
+            return this.mods;
+        }
+    }
+
+    /**
      * This event fires when a mouse input is detected.
      */
     public static class MouseInputEvent extends InputEvent


### PR DESCRIPTION
During the port to 1.13 and subsequently 1.14, MouseEvent was removed. I'm not sure if this was a decision by the team or just never re-added. MouseInputEvent doesn't provide enough control as it's fired after KeyBindings are updated and is not cancellable. This PR reimplements the original event "MouseEvent" as RawMouseEvent.

MouseEvent is something I use in 1.12 for the handling of custom guns and using left click to make them shoot. The ability to cancel the event before keybindings were updated prevented Minecraft's handling of input. E.g. cancelling left/right click prevents the arm from swinging.

Here is an example of how it might be used in 1.14: https://pastebin.com/WgTbtDYx

