### PR TITLE
Fix tab completion of coordinates for client-side commands

### DIFF
--- a/patches/minecraft/net/minecraft/util/TabCompleter.java.patch
+++ b/patches/minecraft/net/minecraft/util/TabCompleter.java.patch
@@ -12,7 +12,7 @@
      {
          if (p_186838_1_.length() >= 1)
          {
-+            net.minecraftforge.client.ClientCommandHandler.instance.autoComplete(p_186838_1_);
++            net.minecraftforge.client.ClientCommandHandler.instance.autoComplete(p_186838_1_, this.func_186839_b());
              Minecraft.func_71410_x().field_71439_g.field_71174_a.func_147297_a(new CPacketTabComplete(p_186838_1_, this.func_186839_b(), this.field_186845_b));
              this.field_186847_d = true;
          }

--- a/src/main/java/net/minecraftforge/client/ClientCommandHandler.java
+++ b/src/main/java/net/minecraftforge/client/ClientCommandHandler.java
@@ -21,6 +21,7 @@ package net.minecraftforge.client;
 
 import java.util.List;
 
+import javax.annotation.Nullable;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.GuiChat;
 import net.minecraft.command.CommandException;
@@ -32,6 +33,7 @@ import net.minecraft.server.MinecraftServer;
 import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.event.CommandEvent;
 import net.minecraftforge.fml.client.FMLClientHandler;
+import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.text.TextComponentTranslation;
 import net.minecraft.util.text.TextFormatting;
 import net.minecraftforge.fml.common.FMLLog;
@@ -125,7 +127,16 @@ public class ClientCommandHandler extends CommandHandler
         return ret;
     }
 
+    /**
+     * @deprecated use {@link #autoComplete(String, BlockPos)}
+     */
+    @Deprecated
     public void autoComplete(String leftOfCursor)
+    {
+        autoComplete(leftOfCursor, FMLClientHandler.instance().getClient().player.getPosition());
+    }
+
+    public void autoComplete(String leftOfCursor, @Nullable BlockPos targetBlockPos)
     {
         latestAutoComplete = null;
 
@@ -136,7 +147,7 @@ public class ClientCommandHandler extends CommandHandler
             Minecraft mc = FMLClientHandler.instance().getClient();
             if (mc.currentScreen instanceof GuiChat)
             {
-                List<String> commands = getTabCompletions(mc.player, leftOfCursor, mc.player.getPosition());
+                List<String> commands = getTabCompletions(mc.player, leftOfCursor, targetBlockPos);
                 if (!commands.isEmpty())
                 {
                     if (leftOfCursor.indexOf(' ') == -1)


### PR DESCRIPTION
When a command was registered with the ClientCommandHandler, the command's getTabCompletions method would be given a BlockPos for the player's position. It should have been given the position of the block being looked at by the player, or null if the player wasn't looking at a block.