### PR TITLE
Add hook for user connections at the stage of ban/whitelist: 

### DIFF
--- a/patches/minecraft/net/minecraft/server/network/NetHandlerLoginServer.java.patch
+++ b/patches/minecraft/net/minecraft/server/network/NetHandlerLoginServer.java.patch
@@ -9,7 +9,16 @@
                  this.field_181025_l = null;
              }
          }
-@@ -132,7 +132,7 @@
+@@ -103,6 +103,8 @@
+ 
+         String s = this.field_147327_f.func_184103_al().func_148542_a(this.field_147333_a.func_74430_c(), this.field_147337_i);
+ 
++        s = net.minecraftforge.event.ForgeEventFactory.canUserConnect(this.field_147327_f,this.field_147333_a,this.field_147337_i,s);
++
+         if (s != null)
+         {
+             this.func_194026_b(new TextComponentTranslation(s, new Object[0]));
+@@ -132,7 +134,7 @@
              }
              else
              {
@@ -18,7 +27,7 @@
              }
          }
      }
-@@ -177,7 +177,7 @@
+@@ -177,7 +179,7 @@
              this.field_147335_k = p_147315_1_.func_149300_a(privatekey);
              this.field_147328_g = NetHandlerLoginServer.LoginState.AUTHENTICATING;
              this.field_147333_a.func_150727_a(this.field_147335_k);

--- a/src/main/java/net/minecraftforge/event/ForgeEventFactory.java
+++ b/src/main/java/net/minecraftforge/event/ForgeEventFactory.java
@@ -44,6 +44,7 @@ import net.minecraft.entity.projectile.EntityThrowable;
 import net.minecraft.init.Blocks;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
+import net.minecraft.network.NetworkManager;
 import net.minecraft.server.MinecraftServer;
 import net.minecraft.tileentity.MobSpawnerBaseLogic;
 import net.minecraft.tileentity.TileEntity;
@@ -140,6 +141,8 @@ import net.minecraftforge.fml.common.registry.GameRegistry;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
+
+import com.mojang.authlib.GameProfile;
 
 public class ForgeEventFactory
 {
@@ -834,5 +837,13 @@ public class ForgeEventFactory
         MerchantTradeOffersEvent event = new MerchantTradeOffersEvent(merchant, player, dupeList);
         MinecraftForge.EVENT_BUS.post(event);
         return event.getList();
+    }
+
+    @Nullable
+    public static String canUserConnect(MinecraftServer server, NetworkManager networkManager, GameProfile loginGameProfile, @Nullable String original)
+    {
+        ServerTryConnectEvent event = new ServerTryConnectEvent(server, networkManager, loginGameProfile, original);
+        MinecraftForge.EVENT_BUS.post(event);
+        return event.getRejectionMessage();
     }
 }

--- a/src/main/java/net/minecraftforge/event/ServerTryConnectEvent.java
+++ b/src/main/java/net/minecraftforge/event/ServerTryConnectEvent.java
@@ -1,0 +1,95 @@
+package net.minecraftforge.event;
+
+import javax.annotation.Nullable;
+
+import org.apache.commons.lang3.Validate;
+
+import com.mojang.authlib.GameProfile;
+
+import net.minecraft.network.NetworkManager;
+import net.minecraft.server.MinecraftServer;
+import net.minecraftforge.fml.common.eventhandler.Event;
+import net.minecraftforge.fml.common.eventhandler.Event.HasResult;
+
+/**
+ * ServerTryConnectEvent is fired as part of checking if a user is permitted to connect to the server. <br>
+ * This event is fired via {@link ForgeEventFactory#canUserConnect(NetworkManager, GameProfile, String)},
+ * which is executed by the {@link NetHandlerLoginServer#tryAcceptPlayer()}<br>
+ * <br>
+ * This event does not have a result. {@link HasResult}<br>
+ * <br>
+ * This event is fired on the {@link MinecraftForge#EVENT_BUS}.
+ **/
+
+public class ServerTryConnectEvent extends Event {
+
+    private final MinecraftServer server;
+    private final NetworkManager networkManager;
+    private final GameProfile profile;
+    @Nullable
+    private final String originalMessage;
+    @Nullable
+    private String rejectionMessage;
+
+    public ServerTryConnectEvent(MinecraftServer server, NetworkManager networkManager, GameProfile profile, @Nullable String original)
+    {
+        this.server = server;
+        this.networkManager = networkManager;
+        this.profile = profile;
+        this.originalMessage = original;
+        this.setRejectionMessage(original);
+    }
+
+    public NetworkManager getNetworkManager()
+    {
+        return networkManager;
+    }
+
+    public GameProfile getProfile()
+    {
+        return profile;
+    }
+
+    @Nullable
+    public String getOriginalMessage()
+    {
+        return originalMessage;
+    }
+
+    @Nullable
+    public String getRejectionMessage()
+    {
+        return rejectionMessage;
+    }
+
+    public boolean isRejected()
+    {
+        return this.rejectionMessage != null;
+    }
+
+    public boolean isAccepted()
+    {
+        return this.rejectionMessage == null;
+    }
+
+    public void reject(String message)
+    {
+        Validate.notNull(message, "Rejection message cannot be null");
+        this.rejectionMessage = message;
+    }
+
+    public void accept()
+    {
+        this.rejectionMessage = null;
+    }
+
+    public void setRejectionMessage(@Nullable String rejectionMessage)
+    {
+        this.rejectionMessage = rejectionMessage;
+    }
+
+    public MinecraftServer getServer()
+    {
+        return server;
+    }
+}

--- a/src/test/java/net/minecraftforge/debug/network/ServerModifyConnectTest.java
+++ b/src/test/java/net/minecraftforge/debug/network/ServerModifyConnectTest.java
@@ -1,0 +1,100 @@
+package net.minecraftforge.debug.network;
+
+import org.apache.logging.log4j.Logger;
+
+import net.minecraft.entity.player.EntityPlayerMP;
+import net.minecraft.item.ItemStack;
+import net.minecraft.server.MinecraftServer;
+import net.minecraftforge.common.MinecraftForge;
+import net.minecraftforge.event.ServerTryConnectEvent;
+import net.minecraftforge.fml.common.Mod;
+import net.minecraftforge.fml.common.Mod.EventHandler;
+import net.minecraftforge.fml.common.event.FMLPreInitializationEvent;
+import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
+
+/*
+ * When this mod is enabled the behavior should be as follows:
+ * - If a player is banned and no online players are holding sticks, it modifies the message informing them they are banned to mention the lack of stick
+ * - If a player is banned and an online player is holding a stick, they can get in
+ * - If a player would be able to get in normally, but a player is holding a stick, they are rejected informing them that a player is holding a stick
+ * 
+ * This covers all the main checks:
+ * - That behavior can change at any time
+ * - That the message can be modified
+ * - That an acceptance can be turned into a rejection
+ * - That a rejection can be turned into an acceptance
+ * 
+ * Sticks form an easy test criteria
+ */
+
+@Mod(modid = ServerModifyConnectTest.MODID, name = ServerModifyConnectTest.NAME, version = "1.0.0", acceptedMinecraftVersions = "*", acceptableRemoteVersions = "*")
+public class ServerModifyConnectTest
+{
+
+    static final boolean ENABLED = false;      // <-- enable mod
+
+    static final String MODID = "servermodifyconnecttest";
+    static final String NAME = "Server Modify Connect Test";
+
+    private static Logger logger;
+
+
+    @EventHandler
+    public void preInit(FMLPreInitializationEvent event)
+    {
+        if (ENABLED)
+        {
+            logger = event.getModLog();
+            logger.info("Started up stick based access filtering");
+            MinecraftForge.EVENT_BUS.register(ServerModifyConnectTest.class);
+        }
+    }
+
+    private static boolean isPlayerHoldingStick(MinecraftServer server)
+    {
+        for(EntityPlayerMP player : server.getPlayerList().getPlayers())
+        {
+            ItemStack stack = player.getHeldItemMainhand();
+            if(stack != null && stack.getItem().getUnlocalizedName().equals("item.stick"))
+                return true;
+        }
+        return false;
+    }
+
+    @SubscribeEvent
+    public static void onTryConnect(final ServerTryConnectEvent event)
+    {
+        logger.info("A player is trying to connect");
+        if(event.isAccepted())
+        {
+            logger.info("That player would normally be accepted");
+            if(isPlayerHoldingStick(event.getServer()))
+            {
+                logger.info("...except someone is holding a stick");
+                event.reject("A player is holding a stick");
+            }
+            else
+            {
+                logger.info("and no one is holding a stick!");
+            }
+        }
+        else if(event.getRejectionMessage().startsWith("You are banned from this server!"))
+        {
+            logger.info("That player is banned");
+            if(isPlayerHoldingStick(event.getServer()))
+            {
+                logger.info("but someone is holding a stick!");
+                event.accept();
+            }
+            else
+            {
+                logger.info("...and no one is holding a stick");
+                event.reject("You are banned and no player is holding a stick");
+            }
+        }
+        else
+        {
+            logger.info("That player wouldn't be accepted, but isn't banned");
+        }
+    }
+}


### PR DESCRIPTION
The hook consists of an event fired during the stage of ban/whitelist which can control if the connecting user is rejected and the message they are rejected with if they are, enabling custom access control mods to work properly.
  - Add a new event ServerTryConnectEvent to fire at this stage
  - Patch NetHandlerLoginServer to call the event and modify its behavior according to the result
  - Add canUserConnect to the ForgeEventFactory
  - Add tests for the hook as ServerModifyConnectTest
This resolves #4300.