### PR TITLE
Add player size and pose event

### DIFF
--- a/patches/minecraft/net/minecraft/entity/Entity.java.patch
+++ b/patches/minecraft/net/minecraft/entity/Entity.java.patch
@@ -271,16 +271,18 @@
        return this.field_181018_ap;
     }
  
-@@ -2274,7 +2299,7 @@
+@@ -2273,8 +2298,9 @@
+       EntitySize entitysize = this.field_213325_aI;
        Pose pose = this.func_213283_Z();
        EntitySize entitysize1 = this.func_213305_a(pose);
++      if(this instanceof net.minecraft.entity.player.PlayerEntity) entitysize1 = net.minecraftforge.event.ForgeEventFactory.getPlayerSize((net.minecraft.entity.player.PlayerEntity)this,pose,entitysize1);
        this.field_213325_aI = entitysize1;
 -      this.field_213326_aJ = this.func_213316_a(pose, entitysize1);
 +      this.field_213326_aJ = getEyeHeightForge(pose, entitysize1);
        if (entitysize1.field_220315_a < entitysize.field_220315_a) {
           double d0 = (double)entitysize1.field_220315_a / 2.0D;
           this.func_174826_a(new AxisAlignedBB(this.field_70165_t - d0, this.field_70163_u, this.field_70161_v - d0, this.field_70165_t + d0, this.field_70163_u + (double)entitysize1.field_220316_b, this.field_70161_v + d0));
-@@ -2641,6 +2666,7 @@
+@@ -2641,6 +2667,7 @@
        return this.field_211517_W;
     }
  
@@ -288,7 +290,7 @@
     public final float func_213311_cf() {
        return this.field_213325_aI.field_220315_a;
     }
-@@ -2670,4 +2696,69 @@
+@@ -2670,4 +2697,69 @@
     public void func_213293_j(double p_213293_1_, double p_213293_3_, double p_213293_5_) {
        this.func_213317_d(new Vec3d(p_213293_1_, p_213293_3_, p_213293_5_));
     }

--- a/patches/minecraft/net/minecraft/entity/player/PlayerEntity.java.patch
+++ b/patches/minecraft/net/minecraft/entity/player/PlayerEntity.java.patch
@@ -54,7 +54,16 @@
     }
  
     protected boolean func_204229_de() {
-@@ -441,10 +451,10 @@
+@@ -330,6 +340,8 @@
+    }
+ 
+    protected void func_213832_dB() {
++      @Nullable Pose forcedPose = net.minecraftforge.event.ForgeEventFactory.getForcedPlayerPose(this);
++      if(forcedPose!=null) { this.func_213301_b(forcedPose); return; }
+       if (this.func_213298_c(Pose.SWIMMING)) {
+          Pose pose;
+          if (this.func_184613_cA()) {
+@@ -441,10 +453,10 @@
           this.field_71107_bF = this.field_71109_bG;
           this.field_71109_bG = 0.0F;
           this.func_71015_k(this.field_70165_t - d0, this.field_70163_u - d1, this.field_70161_v - d2);
@@ -67,7 +76,7 @@
           }
  
        }
-@@ -557,6 +567,7 @@
+@@ -557,6 +569,7 @@
     }
  
     public void func_70645_a(DamageSource p_70645_1_) {
@@ -75,7 +84,7 @@
        super.func_70645_a(p_70645_1_);
        this.func_70107_b(this.field_70165_t, this.field_70163_u, this.field_70161_v);
        if (!this.func_175149_v()) {
-@@ -611,12 +622,14 @@
+@@ -611,12 +624,14 @@
  
     @Nullable
     public ItemEntity func_71040_bB(boolean p_71040_1_) {
@@ -92,7 +101,7 @@
     }
  
     @Nullable
-@@ -650,7 +663,12 @@
+@@ -650,7 +665,12 @@
        }
     }
  
@@ -105,7 +114,7 @@
        float f = this.field_71071_by.func_184438_a(p_184813_1_);
        if (f > 1.0F) {
           int i = EnchantmentHelper.func_185293_e(this);
-@@ -692,11 +710,12 @@
+@@ -692,11 +712,12 @@
           f /= 5.0F;
        }
  
@@ -119,7 +128,7 @@
     }
  
     public void func_70037_a(CompoundNBT p_70037_1_) {
-@@ -720,6 +739,17 @@
+@@ -720,6 +741,17 @@
           this.field_82248_d = p_70037_1_.func_74767_n("SpawnForced");
        }
  
@@ -137,7 +146,7 @@
        this.field_71100_bB.func_75112_a(p_70037_1_);
        this.field_71075_bZ.func_75095_b(p_70037_1_);
        if (p_70037_1_.func_150297_b("EnderItems", 9)) {
-@@ -765,9 +795,26 @@
+@@ -765,9 +797,26 @@
           p_213281_1_.func_218657_a("ShoulderEntityRight", this.func_192025_dl());
        }
  
@@ -164,7 +173,7 @@
        if (this.func_180431_b(p_70097_1_)) {
           return false;
        } else if (this.field_71075_bZ.field_75102_a && !p_70097_1_.func_76357_e()) {
-@@ -799,7 +846,7 @@
+@@ -799,7 +848,7 @@
  
     protected void func_190629_c(LivingEntity p_190629_1_) {
        super.func_190629_c(p_190629_1_);
@@ -173,7 +182,7 @@
           this.func_190777_m(true);
        }
  
-@@ -820,11 +867,12 @@
+@@ -820,11 +869,12 @@
     }
  
     protected void func_184590_k(float p_184590_1_) {
@@ -187,7 +196,7 @@
           });
           if (this.field_184627_bm.func_190926_b()) {
              if (hand == Hand.MAIN_HAND) {
-@@ -842,11 +890,14 @@
+@@ -842,11 +892,14 @@
  
     protected void func_70665_d(DamageSource p_70665_1_, float p_70665_2_) {
        if (!this.func_180431_b(p_70665_1_)) {
@@ -202,7 +211,7 @@
           float f1 = f - p_70665_2_;
           if (f1 > 0.0F && f1 < 3.4028235E37F) {
              this.func_195067_a(Stats.field_212738_J, Math.round(f1 * 10.0F));
-@@ -901,6 +952,8 @@
+@@ -901,6 +954,8 @@
  
           return ActionResultType.PASS;
        } else {
@@ -211,7 +220,7 @@
           ItemStack itemstack = this.func_184586_b(p_190775_2_);
           ItemStack itemstack1 = itemstack.func_190926_b() ? ItemStack.field_190927_a : itemstack.func_77946_l();
           if (p_190775_1_.func_184230_a(this, p_190775_2_)) {
-@@ -908,6 +961,9 @@
+@@ -908,6 +963,9 @@
                 itemstack.func_190920_e(itemstack1.func_190916_E());
              }
  
@@ -221,7 +230,7 @@
              return ActionResultType.SUCCESS;
           } else {
              if (!itemstack.func_190926_b() && p_190775_1_ instanceof LivingEntity) {
-@@ -917,6 +973,7 @@
+@@ -917,6 +975,7 @@
  
                 if (itemstack.func_111282_a(this, (LivingEntity)p_190775_1_, p_190775_2_)) {
                    if (itemstack.func_190926_b() && !this.field_71075_bZ.field_75098_d) {
@@ -229,7 +238,7 @@
                       this.func_184611_a(p_190775_2_, ItemStack.field_190927_a);
                    }
  
-@@ -943,6 +1000,7 @@
+@@ -943,6 +1002,7 @@
     }
  
     public void func_71059_n(Entity p_71059_1_) {
@@ -237,7 +246,7 @@
        if (p_71059_1_.func_70075_an()) {
           if (!p_71059_1_.func_85031_j(this)) {
              float f = (float)this.func_110148_a(SharedMonsterAttributes.field_111264_e).func_111126_e();
-@@ -970,8 +1028,10 @@
+@@ -970,8 +1030,10 @@
  
                 boolean flag2 = flag && this.field_70143_R > 0.0F && !this.field_70122_E && !this.func_70617_f_() && !this.func_70090_H() && !this.func_70644_a(Effects.field_76440_q) && !this.func_184218_aH() && p_71059_1_ instanceof LivingEntity;
                 flag2 = flag2 && !this.func_70051_ag();
@@ -249,7 +258,7 @@
                 }
  
                 f = f + f1;
-@@ -1059,8 +1119,10 @@
+@@ -1059,8 +1121,10 @@
                    }
  
                    if (!this.field_70170_p.field_72995_K && !itemstack1.func_190926_b() && entity instanceof LivingEntity) {
@@ -260,7 +269,7 @@
                          this.func_184611_a(Hand.MAIN_HAND, ItemStack.field_190927_a);
                       }
                    }
-@@ -1102,7 +1164,7 @@
+@@ -1102,7 +1166,7 @@
        }
  
        if (this.field_70146_Z.nextFloat() < f) {
@@ -269,7 +278,7 @@
           this.func_184602_cy();
           this.field_70170_p.func_72960_a(this, (byte)30);
        }
-@@ -1128,8 +1190,9 @@
+@@ -1128,8 +1192,9 @@
     public void func_71004_bE() {
     }
  
@@ -281,7 +290,7 @@
        this.field_71069_bz.func_75134_a(this);
        if (this.field_71070_bA != null) {
           this.field_71070_bA.func_75134_a(this);
-@@ -1146,6 +1209,9 @@
+@@ -1146,6 +1211,9 @@
     }
  
     public Either<PlayerEntity.SleepResult, Unit> func_213819_a(BlockPos p_213819_1_) {
@@ -291,7 +300,7 @@
        Direction direction = this.field_70170_p.func_180495_p(p_213819_1_).func_177229_b(HorizontalBlock.field_185512_D);
        if (!this.field_70170_p.field_72995_K) {
           if (this.func_70608_bn() || !this.func_70089_S()) {
-@@ -1156,7 +1222,7 @@
+@@ -1156,7 +1224,7 @@
              return Either.left(PlayerEntity.SleepResult.NOT_POSSIBLE_HERE);
           }
  
@@ -300,7 +309,7 @@
              return Either.left(PlayerEntity.SleepResult.NOT_POSSIBLE_NOW);
           }
  
-@@ -1197,6 +1263,8 @@
+@@ -1197,6 +1265,8 @@
     private boolean func_190774_a(BlockPos p_190774_1_, Direction p_190774_2_) {
        if (Math.abs(this.field_70165_t - (double)p_190774_1_.func_177958_n()) <= 3.0D && Math.abs(this.field_70163_u - (double)p_190774_1_.func_177956_o()) <= 2.0D && Math.abs(this.field_70161_v - (double)p_190774_1_.func_177952_p()) <= 3.0D) {
           return true;
@@ -309,7 +318,7 @@
        } else {
           BlockPos blockpos = p_190774_1_.func_177972_a(p_190774_2_.func_176734_d());
           return Math.abs(this.field_70165_t - (double)blockpos.func_177958_n()) <= 3.0D && Math.abs(this.field_70163_u - (double)blockpos.func_177956_o()) <= 2.0D && Math.abs(this.field_70161_v - (double)blockpos.func_177952_p()) <= 3.0D;
-@@ -1209,6 +1277,7 @@
+@@ -1209,6 +1279,7 @@
     }
  
     public void func_70999_a(boolean p_70999_1_, boolean p_70999_2_, boolean p_70999_3_) {
@@ -317,7 +326,7 @@
        Optional<BlockPos> optional = this.func_213374_dv();
        super.func_213366_dy();
        if (this.field_70170_p instanceof ServerWorld && p_70999_2_) {
-@@ -1229,17 +1298,17 @@
+@@ -1229,17 +1300,17 @@
     }
  
     public static Optional<Vec3d> func_213822_a(IWorldReader p_213822_0_, BlockPos p_213822_1_, boolean p_213822_2_) {
@@ -339,7 +348,7 @@
        }
     }
  
-@@ -1254,23 +1323,67 @@
+@@ -1254,23 +1325,67 @@
     public void func_146105_b(ITextComponent p_146105_1_, boolean p_146105_2_) {
     }
  
@@ -416,7 +425,7 @@
     }
  
     public void func_195066_a(ResourceLocation p_195066_1_) {
-@@ -1436,6 +1549,8 @@
+@@ -1436,6 +1551,8 @@
           }
  
           super.func_180430_e(p_180430_1_, p_180430_2_);
@@ -425,7 +434,7 @@
        }
     }
  
-@@ -1462,6 +1577,10 @@
+@@ -1462,6 +1579,10 @@
     }
  
     public void func_195068_e(int p_195068_1_) {
@@ -436,7 +445,7 @@
        this.func_85039_t(p_195068_1_);
        this.field_71106_cc += (float)p_195068_1_ / (float)this.func_71050_bK();
        this.field_71067_cb = MathHelper.func_76125_a(this.field_71067_cb + p_195068_1_, 0, Integer.MAX_VALUE);
-@@ -1501,6 +1620,10 @@
+@@ -1501,6 +1622,10 @@
     }
  
     public void func_82242_a(int p_82242_1_) {
@@ -447,7 +456,7 @@
        this.field_71068_ca += p_82242_1_;
        if (this.field_71068_ca < 0) {
           this.field_71068_ca = 0;
-@@ -1703,7 +1826,10 @@
+@@ -1703,7 +1828,10 @@
     }
  
     public ITextComponent func_145748_c_() {
@@ -459,7 +468,7 @@
        return this.func_208016_c(itextcomponent);
     }
  
-@@ -1939,4 +2065,44 @@
+@@ -1939,4 +2067,44 @@
           return this.field_221260_g;
        }
     }

--- a/src/main/java/net/minecraftforge/event/ForgeEventFactory.java
+++ b/src/main/java/net/minecraftforge/event/ForgeEventFactory.java
@@ -712,4 +712,14 @@ public class ForgeEventFactory
         MinecraftForge.EVENT_BUS.post(event);
         return event.getSize();
     }
+
+    @Nullable
+    public static Pose getForcedPlayerPose(PlayerEntity player)
+    {
+        PlayerEvent.PlayerPoseEvent event = new PlayerEvent.PlayerPoseEvent(player);
+        if(MinecraftForge.EVENT_BUS.post(event)){
+            return event.getForcedPose();
+        }
+        return null;
+    }
 }

--- a/src/main/java/net/minecraftforge/event/ForgeEventFactory.java
+++ b/src/main/java/net/minecraftforge/event/ForgeEventFactory.java
@@ -33,6 +33,8 @@ import net.minecraft.entity.MobEntity;
 import net.minecraft.entity.SpawnReason;
 import net.minecraft.entity.LivingEntity;
 import net.minecraft.entity.EntityClassification;
+import net.minecraft.entity.Pose;
+import net.minecraft.entity.EntitySize;
 import net.minecraft.entity.effect.LightningBoltEntity;
 import net.minecraft.entity.item.ItemEntity;
 import net.minecraft.entity.monster.ZombieEntity;
@@ -702,5 +704,12 @@ public class ForgeEventFactory
         SleepFinishedTimeEvent event = new SleepFinishedTimeEvent(world, newTime, minTime);
         MinecraftForge.EVENT_BUS.post(event);
         return event.getNewTime();
+    }
+
+    public static EntitySize getPlayerSize(PlayerEntity player, Pose pose, EntitySize originalSize)
+    {
+        PlayerEvent.PlayerSizeEvent event = new PlayerEvent.PlayerSizeEvent(player, pose, originalSize);
+        MinecraftForge.EVENT_BUS.post(event);
+        return event.getSize();
     }
 }

--- a/src/main/java/net/minecraftforge/event/entity/player/PlayerEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/player/PlayerEvent.java
@@ -38,6 +38,7 @@ import net.minecraftforge.event.entity.living.LivingEvent;
 import net.minecraftforge.eventbus.api.Event;
 
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 
 /**
  * PlayerEvent is fired whenever an event involving Living entities occurs. <br>
@@ -530,7 +531,7 @@ public class PlayerEvent extends LivingEvent
         public PlayerSizeEvent(PlayerEntity player, @Nonnull Pose pose, @Nonnull EntitySize size)
         {
             super(player);
-            this.pose=pose;
+            this.pose = pose;
             this.originalSize = size;
             this.size = size;
         }
@@ -554,6 +555,27 @@ public class PlayerEvent extends LivingEvent
         public EntitySize getSize()
         {
             return size;
+        }
+    }
+
+    @Cancelable
+    public static class PlayerPoseEvent extends PlayerEvent {
+        private Pose pose;
+
+        public PlayerPoseEvent(PlayerEntity player)
+        {
+            super(player);
+        }
+
+        public void setForcedPose(Pose pose)
+        {
+            this.pose = pose;
+        }
+
+        @Nullable
+        public Pose getForcedPose()
+        {
+            return this.pose;
         }
     }
 }

--- a/src/main/java/net/minecraftforge/event/entity/player/PlayerEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/player/PlayerEvent.java
@@ -21,6 +21,8 @@ package net.minecraftforge.event.entity.player;
 
 import java.io.File;
 
+import net.minecraft.entity.EntitySize;
+import net.minecraft.entity.Pose;
 import net.minecraft.entity.item.ItemEntity;
 import net.minecraft.inventory.IInventory;
 import net.minecraft.item.ItemStack;
@@ -516,6 +518,42 @@ public class PlayerEvent extends LivingEvent
         public DimensionType getTo()
         {
             return this.toDim;
+        }
+    }
+
+    public static class PlayerSizeEvent extends PlayerEvent {
+        private final EntitySize originalSize;
+        private final Pose pose;
+        @Nonnull
+        private EntitySize size;
+
+        public PlayerSizeEvent(PlayerEntity player, @Nonnull Pose pose, @Nonnull EntitySize size)
+        {
+            super(player);
+            this.pose=pose;
+            this.originalSize = size;
+            this.size = size;
+        }
+
+        public EntitySize getOriginalSize()
+        {
+            return originalSize;
+        }
+
+        public Pose getPose()
+        {
+            return pose;
+        }
+
+        public void setSize(@Nonnull EntitySize size)
+        {
+            this.size = size;
+        }
+
+        @Nonnull
+        public EntitySize getSize()
+        {
+            return size;
         }
     }
 }


### PR DESCRIPTION
For original intention see https://github.com/MinecraftForge/MinecraftForge/pull/6059

<s>
Because the vanilla pose system is rather difficult to modify, this PR simply introduces a way to modify the player's size regardless of their pose. 

This is done by adding override size field to PlayerEntity. If this is set (and the current pose isn't dying), it will be used as the player size in Entity#getSize.</s>

This PR adds two things:
- A player size event which is fired when the player pose changes and allows mods to specify their own size.
- A player pose event which is fired once per tick and allows mods to bypass vanilla logic and enforce a certain vanilla pose.

An example why the latter event is required:
A mod want's to shrink a player to just one block height. For this it can use the first event and shrink the player's bounding box. Thereby a player can move into a 1x1 hole.

However, `PlayerEntity` updates the players pose every tick. Therefore it checks if the theoretical size of the `STANDING` pose (1.8x0.6)  is clear, which is not the case in said hole. Therefore, it falls back to the `SWIMMING` pose. This does not only affect the renderer but the game logic as well.

Therefore, the second event has to be used to enforce the standing pose.
This has to be done every tick as vanilla will update the pose every tick and always switch back to swimming.

## Cons
- Pose event fired once per tick per player
- Does not allow non vanilla poses, but this would require a much larger patch since the pose is synced with a DataParameter<enum>,