### PR TITLE
Add possibility to modify CreateWorldScreen values from mod WorldType

### DIFF
--- a/patches/minecraft/net/minecraft/client/gui/screen/CreateWorldScreen.java.patch
+++ b/patches/minecraft/net/minecraft/client/gui/screen/CreateWorldScreen.java.patch
@@ -24,11 +24,11 @@
  
           WorldSettings worldsettings = new WorldSettings(i, GameType.func_77142_a(this.field_146342_r), this.field_146341_s, this.field_146337_w, WorldType.field_77139_a[this.field_146331_K]);
           worldsettings.func_205390_a(Dynamic.convert(NBTDynamicOps.field_210820_a, JsonOps.INSTANCE, this.field_146334_a));
-@@ -253,6 +247,7 @@
- 
-    private void func_146316_a(boolean p_146316_1_) {
-       this.field_146344_y = p_146316_1_;
+@@ -280,6 +274,7 @@
+          this.field_146321_E.visible = this.field_146344_y;
+          this.field_146322_F.visible = this.field_146344_y && WorldType.field_77139_a[this.field_146331_K].func_205393_e();
+       }
 +      WorldType.field_77139_a[this.field_146331_K].onGUIUpdateMoreWorldOptions(this);
-       if (WorldType.field_77139_a[this.field_146331_K] == WorldType.field_180272_g) {
-          this.field_146343_z.visible = !this.field_146344_y;
-          this.field_146343_z.active = false;
+ 
+       this.func_146319_h();
+       this.field_146335_h.func_146189_e(this.field_146344_y);

--- a/patches/minecraft/net/minecraft/client/gui/screen/CreateWorldScreen.java.patch
+++ b/patches/minecraft/net/minecraft/client/gui/screen/CreateWorldScreen.java.patch
@@ -1,6 +1,14 @@
 --- a/net/minecraft/client/gui/screen/CreateWorldScreen.java
 +++ b/net/minecraft/client/gui/screen/CreateWorldScreen.java
-@@ -137,14 +137,7 @@
+@@ -58,6 +58,7 @@
+    public void tick() {
+       this.field_146333_g.func_146178_a();
+       this.field_146335_h.func_146178_a();
++      WorldType.field_77139_a[this.field_146331_K].onCreateWorldScreenTick(this);
+    }
+ 
+    protected void init() {
+@@ -137,14 +138,7 @@
        }));
        this.field_146320_D.visible = false;
        this.field_146322_F = this.addButton(new Button(this.width / 2 + 5, 120, 150, 20, I18n.func_135052_a("selectWorld.customizeType"), (p_214314_1_) -> {
@@ -16,7 +24,7 @@
        }));
        this.field_146322_F.visible = false;
        this.field_146321_E = this.addButton(new Button(this.width / 2 - 155, 151, 150, 20, I18n.func_135052_a("selectWorld.allowCommands"), (p_214315_1_) -> {
-@@ -223,6 +216,7 @@
+@@ -223,6 +217,7 @@
                 i = (long)s.hashCode();
              }
           }

--- a/patches/minecraft/net/minecraft/client/gui/screen/CreateWorldScreen.java.patch
+++ b/patches/minecraft/net/minecraft/client/gui/screen/CreateWorldScreen.java.patch
@@ -1,14 +1,6 @@
 --- a/net/minecraft/client/gui/screen/CreateWorldScreen.java
 +++ b/net/minecraft/client/gui/screen/CreateWorldScreen.java
-@@ -58,6 +58,7 @@
-    public void tick() {
-       this.field_146333_g.func_146178_a();
-       this.field_146335_h.func_146178_a();
-+      WorldType.field_77139_a[this.field_146331_K].onCreateWorldScreenTick(this);
-    }
- 
-    protected void init() {
-@@ -137,14 +138,7 @@
+@@ -137,14 +137,7 @@
        }));
        this.field_146320_D.visible = false;
        this.field_146322_F = this.addButton(new Button(this.width / 2 + 5, 120, 150, 20, I18n.func_135052_a("selectWorld.customizeType"), (p_214314_1_) -> {
@@ -24,7 +16,7 @@
        }));
        this.field_146322_F.visible = false;
        this.field_146321_E = this.addButton(new Button(this.width / 2 - 155, 151, 150, 20, I18n.func_135052_a("selectWorld.allowCommands"), (p_214315_1_) -> {
-@@ -223,6 +217,7 @@
+@@ -223,6 +216,7 @@
                 i = (long)s.hashCode();
              }
           }
@@ -32,3 +24,11 @@
  
           WorldSettings worldsettings = new WorldSettings(i, GameType.func_77142_a(this.field_146342_r), this.field_146341_s, this.field_146337_w, WorldType.field_77139_a[this.field_146331_K]);
           worldsettings.func_205390_a(Dynamic.convert(NBTDynamicOps.field_210820_a, JsonOps.INSTANCE, this.field_146334_a));
+@@ -253,6 +247,7 @@
+ 
+    private void func_146316_a(boolean p_146316_1_) {
+       this.field_146344_y = p_146316_1_;
++      WorldType.field_77139_a[this.field_146331_K].onGUIUpdateMoreWorldOptions(this);
+       if (WorldType.field_77139_a[this.field_146331_K] == WorldType.field_180272_g) {
+          this.field_146343_z.visible = !this.field_146344_y;
+          this.field_146343_z.active = false;

--- a/src/main/java/net/minecraftforge/common/extensions/IForgeWorldType.java
+++ b/src/main/java/net/minecraftforge/common/extensions/IForgeWorldType.java
@@ -56,6 +56,16 @@ public interface IForgeWorldType
     }
 
     /**
+     * Called when CreateWorldScreen ticks, use to modify button values etc.
+     * 
+     * @param gui the createworld GUI
+     */
+    @OnlyIn(Dist.CLIENT)
+    default void onCreateWorldScreenTick(CreateWorldScreen gui)
+    {
+    }
+
+    /**
      * Called when the 'Customize' button is pressed on world creation GUI
      *
      * @param mc  The Minecraft instance

--- a/src/main/java/net/minecraftforge/common/extensions/IForgeWorldType.java
+++ b/src/main/java/net/minecraftforge/common/extensions/IForgeWorldType.java
@@ -56,12 +56,14 @@ public interface IForgeWorldType
     }
 
     /**
-     * Called when CreateWorldScreen ticks, use to modify button values etc.
+     * Called when CreateWorldScreen is initialized, worldType/moreWorldOptions button is pressed.
+     * Can be used to modify button, state values etc.
+     * Backup gametype as vanilla code do.
      * 
      * @param gui the createworld GUI
      */
     @OnlyIn(Dist.CLIENT)
-    default void onCreateWorldScreenTick(CreateWorldScreen gui)
+    default void onGUIUpdateMoreWorldOptions(CreateWorldScreen gui)
     {
     }
 


### PR DESCRIPTION
Allow mod world types to do things like shown in the attached picture
Mod needs to AT specific fields (buttons) which are private and not static

![image](https://user-images.githubusercontent.com/17338378/65161534-034e5600-da38-11e9-898d-bffc349756f9.png)
