### PR TITLE
Fix mod info rendering incorrectly on some systems with HiDPI displays

### DIFF
--- a/src/main/java/net/minecraftforge/client/gui/ScrollPanel.java
+++ b/src/main/java/net/minecraftforge/client/gui/ScrollPanel.java
@@ -191,7 +191,7 @@ public abstract class ScrollPanel extends FocusableGui implements IRenderable
 
         double scale = client.mainWindow.getGuiScaleFactor();
         GL11.glEnable(GL11.GL_SCISSOR_TEST);
-        GL11.glScissor((int)(left      * scale), (int)(client.mainWindow.getHeight() - (bottom * scale)),
+        GL11.glScissor((int)(left  * scale), (int)(client.mainWindow.getFramebufferHeight() - (bottom * scale)),
                        (int)(width * scale), (int)(height * scale));
 
         if (this.client.world != null)

--- a/src/main/java/net/minecraftforge/fml/client/gui/GuiModList.java
+++ b/src/main/java/net/minecraftforge/fml/client/gui/GuiModList.java
@@ -275,7 +275,7 @@ public class GuiModList extends Screen
         this.modList.setLeftPos(6);
 
         int modInfoWidth = this.width - this.listWidth - 20;
-        this.modInfo = new InfoPanel(this.minecraft, modInfoWidth, this.height - 30, 10);
+        this.modInfo = new InfoPanel(this.minecraft, modInfoWidth, this.height - 40, 10);
 
         int doneButtonWidth = Math.min(modInfoWidth, 200);
         this.addButton(new Button(((modList.getWidth() + 8 + this.width - doneButtonWidth) / 2), this.height - 24, doneButtonWidth, 20,


### PR DESCRIPTION
Fixes #6162. Gigaherz was correct about the way HiDPI displays are handled on mac. The size of the actual frame buffer for the window is larger than the requested window size. This caused the y value for the `glScissor` operation in the info panel's rendering code to be incorrect. This value is now calculated using the actual height of the frame buffer instead.

I also adjusted the height of the info panel to fix it overlapping with the done button.

After on a retina display mac:
<img width="857" alt="Screen Shot 2019-09-18 at 7 24 09 PM" src="https://user-images.githubusercontent.com/6103327/65209455-0bfd5700-da4d-11e9-8c65-7fc1c69f75cc.png">