### PR TITLE
Make the peer's mod list queryable

### DIFF
--- a/src/main/java/net/minecraftforge/fml/network/FMLHandshakeHandler.java
+++ b/src/main/java/net/minecraftforge/fml/network/FMLHandshakeHandler.java
@@ -184,6 +184,7 @@ public class FMLHandshakeHandler {
         LOGGER.debug(FMLHSMARKER, "Accepted server connection");
         // Set the modded marker on the channel so we know we got packets
         c.get().getNetworkManager().channel().attr(FMLNetworkConstants.FML_NETVERSION).set(FMLNetworkConstants.NETVERSION);
+        c.get().getNetworkManager().channel().attr(FMLNetworkConstants.FML_MOD_DATA).set(new PeerModInformation(serverModList.getModList(), serverModList.getChannels()));
 
         this.registriesToReceive = new HashSet<>(serverModList.getRegistries());
         this.registrySnapshots = Maps.newHashMap();
@@ -210,6 +211,8 @@ public class FMLHandshakeHandler {
             return;
         }
         LOGGER.debug(FMLHSMARKER, "Accepted client connection mod list");
+
+        c.get().getNetworkManager().channel().attr(FMLNetworkConstants.FML_MOD_DATA).set(new PeerModInformation(clientModList.getModList(), clientModList.getChannels()));
     }
 
     void handleRegistryMessage(final FMLHandshakeMessages.S2CRegistry registryPacket, final Supplier<NetworkEvent.Context> contextSupplier){

--- a/src/main/java/net/minecraftforge/fml/network/FMLNetworkConstants.java
+++ b/src/main/java/net/minecraftforge/fml/network/FMLNetworkConstants.java
@@ -40,6 +40,7 @@ public class FMLNetworkConstants
     static final Marker NETWORK = MarkerManager.getMarker("FMLNETWORK");
     static final AttributeKey<String> FML_NETVERSION = AttributeKey.valueOf("fml:netversion");
     static final AttributeKey<FMLHandshakeHandler> FML_HANDSHAKE_HANDLER = AttributeKey.valueOf("fml:handshake");
+    static final AttributeKey<PeerModInformation> FML_MOD_DATA = AttributeKey.valueOf("fml:moddata");
     static final AttributeKey<FMLMCRegisterPacketHandler.ChannelList> FML_MC_REGISTRY = AttributeKey.valueOf("minecraft:netregistry");
     static final ResourceLocation FML_HANDSHAKE_RESOURCE = new ResourceLocation("fml:handshake");
     static final ResourceLocation FML_PLAY_RESOURCE = new ResourceLocation("fml:play");

--- a/src/main/java/net/minecraftforge/fml/network/NetworkHooks.java
+++ b/src/main/java/net/minecraftforge/fml/network/NetworkHooks.java
@@ -77,12 +77,16 @@ public class NetworkHooks
     public static void registerServerLoginChannel(NetworkManager manager, CHandshakePacket packet)
     {
         manager.channel().attr(FMLNetworkConstants.FML_NETVERSION).set(packet.getFMLVersion());
+        if(ConnectionType.forVersionFlag(packet.getFMLVersion()) == ConnectionType.VANILLA)
+            manager.channel().attr(FMLNetworkConstants.FML_MOD_DATA).set(new PeerModInformation());
+        //else we set it in FMLHandshakeHandler#handleClientModListOnServer once we've got the mod list
         FMLHandshakeHandler.registerHandshake(manager, NetworkDirection.LOGIN_TO_CLIENT);
     }
 
     public synchronized static void registerClientLoginChannel(NetworkManager manager)
     {
         manager.channel().attr(FMLNetworkConstants.FML_NETVERSION).set(FMLNetworkConstants.NOVERSION);
+        manager.channel().attr(FMLNetworkConstants.FML_MOD_DATA).set(new PeerModInformation());
         FMLHandshakeHandler.registerHandshake(manager, NetworkDirection.LOGIN_TO_SERVER);
     }
 
@@ -205,5 +209,10 @@ public class NetworkHooks
         trackingMap.put(dimensionType.getId(), dimensionType);
         final ClearableRegistry<DimensionType> dimtypereg = (ClearableRegistry<DimensionType>) Registry.DIMENSION_TYPE;
         dimtypereg.register(dimensionType.getId(), dimName, dimensionType);
+    }
+
+    public static PeerModInformation getModInformation(NetworkManager connection)
+    {
+        return connection.channel().attr(FMLNetworkConstants.FML_MOD_DATA).get();
     }
 }

--- a/src/main/java/net/minecraftforge/fml/network/PeerModInformation.java
+++ b/src/main/java/net/minecraftforge/fml/network/PeerModInformation.java
@@ -1,0 +1,39 @@
+package net.minecraftforge.fml.network;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import net.minecraft.util.ResourceLocation;
+
+import java.util.List;
+import java.util.Map;
+
+public class PeerModInformation {
+
+    private final List<String> mods;
+    private final Map<ResourceLocation, String> channelVersions;
+    private final boolean isVanilla;
+
+    public PeerModInformation(List<String> mods, Map<ResourceLocation, String> channelVersions) {
+        this.mods = ImmutableList.copyOf(mods);
+        this.channelVersions = ImmutableMap.copyOf(channelVersions);
+        this.isVanilla = false;
+    }
+
+    public PeerModInformation() {
+        this.isVanilla = true;
+        this.mods = ImmutableList.of();
+        this.channelVersions = ImmutableMap.of();
+    }
+
+    public List<String> getMods() {
+        return mods;
+    }
+
+    public Map<ResourceLocation, String> getChannelVersions() {
+        return channelVersions;
+    }
+
+    public boolean isVanilla() {
+        return isVanilla;
+    }
+}


### PR DESCRIPTION
So that mods can see whether they or any other mod is present on the other side.

Note that this list can be faked. It is intended for mods that can optionally be installed on the other side and allow extended features (ie a minimap that allows you to share waypoints with other players via a server mod).