### PR TITLE
New round of fluid system fixes:

### DIFF
--- a/patches/minecraft/net/minecraft/block/FlowingFluidBlock.java.patch
+++ b/patches/minecraft/net/minecraft/block/FlowingFluidBlock.java.patch
@@ -72,7 +72,7 @@
 +
 +   private boolean fluidStateCacheInitialized = false;
 +   protected synchronized void initFluidStateCache() {
-+      if (fluidStateCacheInitialized = false)
++      if (fluidStateCacheInitialized == false)
 +      {
 +         this.field_212565_c.add(getFluid().func_207204_a(false));
 +

--- a/patches/minecraft/net/minecraft/block/FlowingFluidBlock.java.patch
+++ b/patches/minecraft/net/minecraft/block/FlowingFluidBlock.java.patch
@@ -59,7 +59,7 @@
                 this.func_180688_d(p_204515_1_, p_204515_2_);
                 return false;
              }
-@@ -160,4 +176,22 @@
+@@ -160,4 +176,27 @@
        }
  
     }
@@ -70,15 +70,20 @@
 +      return (FlowingFluid)supplier.get();
 +   }
 +
-+   private boolean fluidStateCacheInitialized;
-+   protected void initFluidStateCache() {
-+      this.field_212565_c.add(getFluid().func_207204_a(false));
++   private boolean fluidStateCacheInitialized = false;
++   protected synchronized void initFluidStateCache() {
++      if (fluidStateCacheInitialized = false)
++      {
++         this.field_212565_c.add(getFluid().func_207204_a(false));
 +
-+      for(int i = 1; i < 8; ++i) {
-+         this.field_212565_c.add(getFluid().func_207207_a(8 - i, false));
++         for (int i = 1; i < 8; ++i)
++         {
++            this.field_212565_c.add(getFluid().func_207207_a(8 - i, false));
++         }
++
++         this.field_212565_c.add(getFluid().func_207207_a(8, true));
++
++         fluidStateCacheInitialized = true;
 +      }
-+
-+      this.field_212565_c.add(getFluid().func_207207_a(8, true));
-+      fluidStateCacheInitialized = true;
 +   }
  }

--- a/src/main/java/net/minecraftforge/client/model/ItemTextureQuadConverter.java
+++ b/src/main/java/net/minecraftforge/client/model/ItemTextureQuadConverter.java
@@ -150,7 +150,7 @@ public final class ItemTextureQuadConverter
             for (int y = 0; y < h; y++)
             {
                 // current pixel
-                boolean isVisible = !sprite.isPixelTransparent(0, x, y);
+                boolean isVisible = !template.isPixelTransparent(0, x, y);
 
                 // no current quad but found a new one
                 if (start < 0 && isVisible)
@@ -168,7 +168,7 @@ public final class ItemTextureQuadConverter
                     {
                         for (int i = 0; i < h; i++)
                         {
-                            if (sprite.isPixelTransparent(0, x, i) != sprite.isPixelTransparent(0, endX, i))
+                            if (template.isPixelTransparent(0, x, i) != template.isPixelTransparent(0, endX, i))
                             {
                                 sameColumn = false;
                                 break;

--- a/src/main/java/net/minecraftforge/fluids/FluidUtil.java
+++ b/src/main/java/net/minecraftforge/fluids/FluidUtil.java
@@ -178,31 +178,20 @@ public class FluidUtil
         ItemStack containerCopy = ItemHandlerHelper.copyStackWithSize(container, 1); // do not modify the input
         return getFluidHandler(containerCopy)
                 .map(containerFluidHandler -> {
-                    if (doDrain)
+
+                    // We are acting on a COPY of the stack, so performing changes is acceptable even if we are simulating.
+                    FluidStack transfer = tryFluidTransfer(fluidDestination, containerFluidHandler, maxAmount, true);
+                    if (transfer.isEmpty())
+                        return FluidActionResult.FAILURE;
+
+                    if (doDrain && player != null)
                     {
-                        FluidStack transfer = tryFluidTransfer(fluidDestination, containerFluidHandler, maxAmount, true);
-                        if (!transfer.isEmpty())
-                        {
-                            if (player != null)
-                            {
-                                SoundEvent soundevent = transfer.getFluid().getAttributes().getEmptySound(transfer);
-                                player.world.playSound(null, player.posX, player.posY + 0.5, player.posZ, soundevent, SoundCategory.BLOCKS, 1.0F, 1.0F);
-                            }
-                            ItemStack resultContainer = containerFluidHandler.getContainer();
-                            return new FluidActionResult(resultContainer);
-                        }
+                        SoundEvent soundevent = transfer.getFluid().getAttributes().getEmptySound(transfer);
+                        player.world.playSound(null, player.posX, player.posY + 0.5, player.posZ, soundevent, SoundCategory.BLOCKS, 1.0F, 1.0F);
                     }
-                    else
-                    {
-                        FluidStack simulatedTransfer = tryFluidTransfer(fluidDestination, containerFluidHandler, maxAmount, false);
-                        if (!simulatedTransfer.isEmpty())
-                        {
-                            containerFluidHandler.drain(simulatedTransfer, IFluidHandler.FluidAction.SIMULATE);
-                            ItemStack resultContainer = containerFluidHandler.getContainer();
-                            return new FluidActionResult(resultContainer);
-                        }
-                    }
-                    return FluidActionResult.FAILURE;
+
+                    ItemStack resultContainer = containerFluidHandler.getContainer();
+                    return new FluidActionResult(resultContainer);
                 })
                 .orElse(FluidActionResult.FAILURE);
     }

--- a/src/main/java/net/minecraftforge/fluids/capability/templates/EmptyFluidHandler.java
+++ b/src/main/java/net/minecraftforge/fluids/capability/templates/EmptyFluidHandler.java
@@ -47,7 +47,7 @@ public class EmptyFluidHandler implements IFluidHandler
     @Override
     public int fill(FluidStack resource, FluidAction action)
     {
-        return resource.getAmount();
+        return 0;
     }
 
     @Nonnull

--- a/src/main/java/net/minecraftforge/fluids/capability/templates/FluidTank.java
+++ b/src/main/java/net/minecraftforge/fluids/capability/templates/FluidTank.java
@@ -147,8 +147,8 @@ public class FluidTank implements IFluidHandler, IFluidTank {
         }
         if (fluid.isEmpty())
         {
-            onContentsChanged();
             fluid = new FluidStack(resource, Math.min(capacity, resource.getAmount()));
+            onContentsChanged();
             return fluid.getAmount();
         }
         if (!fluid.isFluidEqual(resource))
@@ -166,6 +166,8 @@ public class FluidTank implements IFluidHandler, IFluidTank {
         {
             fluid.setAmount(capacity);
         }
+        if (filled > 0)
+            onContentsChanged();
         return filled;
     }
 
@@ -194,6 +196,8 @@ public class FluidTank implements IFluidHandler, IFluidTank {
         {
             fluid.shrink(drained);
         }
+        if (drained > 0)
+            onContentsChanged();
         return stack;
     }
 


### PR DESCRIPTION
- Fix race condition lazy-initializing flowing fluid block data.
- Fix typo in ItemTextureQuadConverter that prevents certain animated textures from being used in the fluid bucket.

Any other issues I learn of within the next day or 2, will be added here.