### PR TITLE
Fixed forge rendering pipeline and shape based light occulsion.

### DIFF
--- a/src/main/java/net/minecraftforge/client/model/pipeline/BlockInfo.java
+++ b/src/main/java/net/minecraftforge/client/model/pipeline/BlockInfo.java
@@ -21,6 +21,7 @@ package net.minecraftforge.client.model.pipeline;
 
 import net.minecraft.block.Block;
 import net.minecraft.block.BlockState;
+import net.minecraft.block.Blocks;
 import net.minecraft.client.renderer.color.BlockColors;
 import net.minecraft.util.Direction;
 import net.minecraft.util.math.BlockPos;
@@ -138,7 +139,10 @@ public class BlockInfo
             BlockPos pos = blockPos.offset(side);
             BlockState state = world.getBlockState(pos);
 
-            if(!VoxelShapes.func_223416_b(this.state.func_215702_a(world, blockPos, side), state.func_215702_a(world, pos, side.getOpposite())))
+            BlockState thisStateShape = this.state.isSolid() && this.state.func_215691_g() ? this.state : Blocks.AIR.getDefaultState();
+            BlockState otherStateShape = state.isSolid() && state.func_215691_g() ? state : Blocks.AIR.getDefaultState();
+
+            if(state.getOpacity(world, blockPos) == 15 || VoxelShapes.func_223416_b(thisStateShape.func_215702_a(world, blockPos, side), otherStateShape.func_215702_a(world, pos, side.getOpposite())))
             {
                 int x = side.getXOffset() + 1;
                 int y = side.getYOffset() + 1;

--- a/src/main/java/net/minecraftforge/client/model/pipeline/BlockInfo.java
+++ b/src/main/java/net/minecraftforge/client/model/pipeline/BlockInfo.java
@@ -25,6 +25,7 @@ import net.minecraft.client.renderer.color.BlockColors;
 import net.minecraft.util.Direction;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.Vec3d;
+import net.minecraft.util.math.shapes.VoxelShapes;
 import net.minecraft.world.IEnviromentBlockReader;
 
 public class BlockInfo
@@ -134,7 +135,10 @@ public class BlockInfo
         }
         for(Direction side : SIDES)
         {
-            if(!state.doesSideBlockRendering(world, blockPos, side))
+            BlockPos pos = blockPos.offset(side);
+            BlockState state = world.getBlockState(pos);
+
+            if(!VoxelShapes.func_223416_b(this.state.func_215702_a(world, blockPos, side), state.func_215702_a(world, pos, side.getOpposite())))
             {
                 int x = side.getXOffset() + 1;
                 int y = side.getYOffset() + 1;

--- a/src/main/java/net/minecraftforge/common/extensions/IForgeBlock.java
+++ b/src/main/java/net/minecraftforge/common/extensions/IForgeBlock.java
@@ -136,6 +136,7 @@ public interface IForgeBlock
         return false;
     }
 
+    //TODO: remove in 1.15
     /**
      * Check if the face of a block should block rendering.
      *
@@ -147,7 +148,7 @@ public interface IForgeBlock
      * @param pos Block position in world
      * @param face The side to check
      * @return True if the block is opaque on the specified side.
-     * @deprecated This is no longer used for rendering logic. //TODO: remove in 1.15
+     * @deprecated This is no longer used for rendering logic.
      */
     @Deprecated
     default boolean doesSideBlockRendering(BlockState state, IEnviromentBlockReader world, BlockPos pos, Direction face)

--- a/src/main/java/net/minecraftforge/common/extensions/IForgeBlock.java
+++ b/src/main/java/net/minecraftforge/common/extensions/IForgeBlock.java
@@ -147,7 +147,9 @@ public interface IForgeBlock
      * @param pos Block position in world
      * @param face The side to check
      * @return True if the block is opaque on the specified side.
+     * @deprecated This is no longer used for rendering logic. //TODO: remove in 1.15
      */
+    @Deprecated
     default boolean doesSideBlockRendering(BlockState state, IEnviromentBlockReader world, BlockPos pos, Direction face)
     {
        return state.isOpaqueCube(world, pos);

--- a/src/main/java/net/minecraftforge/common/extensions/IForgeBlockState.java
+++ b/src/main/java/net/minecraftforge/common/extensions/IForgeBlockState.java
@@ -102,6 +102,7 @@ public interface IForgeBlockState
         return getBlockState().getBlock().isLadder(getBlockState(), world, pos, entity);
     }
 
+    //TODO: remove in 1.15
     /**
      * Check if the face of a block should block rendering.
      *
@@ -112,7 +113,7 @@ public interface IForgeBlockState
      * @param pos Block position in world
      * @param face The side to check
      * @return True if the block is opaque on the specified side.
-     * @deprecated This is no longer used for rendering logic. //TODO: remove in 1.15
+     * @deprecated This is no longer used for rendering logic.
      */
     @Deprecated
     default boolean doesSideBlockRendering(IEnviromentBlockReader world, BlockPos pos, Direction face)

--- a/src/main/java/net/minecraftforge/common/extensions/IForgeBlockState.java
+++ b/src/main/java/net/minecraftforge/common/extensions/IForgeBlockState.java
@@ -112,6 +112,7 @@ public interface IForgeBlockState
      * @param pos Block position in world
      * @param face The side to check
      * @return True if the block is opaque on the specified side.
+     * @deprecated This is no longer used for rendering logic. //TODO: remove in 1.15
      */
     @Deprecated
     default boolean doesSideBlockRendering(IEnviromentBlockReader world, BlockPos pos, Direction face)

--- a/src/main/java/net/minecraftforge/common/extensions/IForgeBlockState.java
+++ b/src/main/java/net/minecraftforge/common/extensions/IForgeBlockState.java
@@ -113,6 +113,7 @@ public interface IForgeBlockState
      * @param face The side to check
      * @return True if the block is opaque on the specified side.
      */
+    @Deprecated
     default boolean doesSideBlockRendering(IEnviromentBlockReader world, BlockPos pos, Direction face)
     {
         return getBlockState().getBlock().doesSideBlockRendering(getBlockState(), world, pos, face);


### PR DESCRIPTION
Fixes #6174

The logic behind `doesSideBlockRendering` doesn't really work with shape based light occlusion. It currently just returns whether the block is an opaque cube, which now doesn't necessarily mean it blocks light. A stone slab isn't an opaque cube, but may not block, depending on what shapes are around it. 

The new logic is esssentially what the light engines use for checking whether a side lets light through or not. 

`doesSideBlockRendering` isn't actually used anymore, so I've put a `@Deprecated` on it.