### PR TITLE
Avoid unnecessary calls to Mouse.setGrabbed

### DIFF
--- a/patches/minecraft/net/minecraft/client/renderer/EntityRenderer.java.patch
+++ b/patches/minecraft/net/minecraft/client/renderer/EntityRenderer.java.patch
@@ -103,6 +103,15 @@
                      if (this.field_78531_r.field_71439_g.func_70644_a(MobEffects.field_76439_r))
                      {
                          float f15 = this.func_180438_a(this.field_78531_r.field_71439_g, p_78472_1_);
+@@ -994,7 +1002,7 @@
+ 
+         if (flag && Minecraft.field_142025_a && this.field_78531_r.field_71415_G && !Mouse.isInsideWindow())
+         {
+-            Mouse.setGrabbed(false);
++            if (Mouse.isGrabbed()) Mouse.setGrabbed(false);
+             Mouse.setCursorPosition(Display.getWidth() / 2, Display.getHeight() / 2 - 20);
+             Mouse.setGrabbed(true);
+         }
 @@ -1101,6 +1109,10 @@
                  GlStateManager.func_179096_D();
                  this.func_78478_c();

--- a/patches/minecraft/net/minecraft/util/MouseHelper.java.patch
+++ b/patches/minecraft/net/minecraft/util/MouseHelper.java.patch
@@ -1,10 +1,21 @@
 --- ../src-base/minecraft/net/minecraft/util/MouseHelper.java
 +++ ../src-work/minecraft/net/minecraft/util/MouseHelper.java
-@@ -13,6 +13,7 @@
+@@ -13,7 +13,8 @@
  
      public void func_74372_a()
      {
+-        Mouse.setGrabbed(true);
 +        if (Boolean.parseBoolean(System.getProperty("fml.noGrab","false"))) return;
-         Mouse.setGrabbed(true);
++        if (!Mouse.isGrabbed()) Mouse.setGrabbed(true);
          this.field_74377_a = 0;
          this.field_74375_b = 0;
+     }
+@@ -21,7 +22,7 @@
+     public void func_74373_b()
+     {
+         Mouse.setCursorPosition(Display.getWidth() / 2, Display.getHeight() / 2);
+-        Mouse.setGrabbed(false);
++        if (Mouse.isGrabbed()) Mouse.setGrabbed(false);
+     }
+ 
+     public void func_74374_c()


### PR DESCRIPTION
Workaround for a bug in LWJGL on macOS where calling `Mouse.setGrabbed` unnecessarily can cause the cursor to permanently disappear.

Fixes https://github.com/HellFirePvP/AstralSorcery/issues/12 amongst other things.