### PR TITLE
Update RayTrace Overide Patch to 1.14

### DIFF
--- a/patches/minecraft/net/minecraft/world/IBlockReader.java.patch
+++ b/patches/minecraft/net/minecraft/world/IBlockReader.java.patch
@@ -1,0 +1,16 @@
+--- a/net/minecraft/world/IBlockReader.java
++++ b/net/minecraft/world/IBlockReader.java
+@@ -59,11 +59,11 @@
+       if (blockraytraceresult != null) {
+          BlockRayTraceResult blockraytraceresult1 = p_217296_5_.func_199611_f(this, p_217296_3_).func_212433_a(p_217296_1_, p_217296_2_, p_217296_3_);
+          if (blockraytraceresult1 != null && blockraytraceresult1.func_216347_e().func_178788_d(p_217296_1_).func_189985_c() < blockraytraceresult.func_216347_e().func_178788_d(p_217296_1_).func_189985_c()) {
+-            return blockraytraceresult.func_216351_a(blockraytraceresult1.func_216354_b());
++            blockraytraceresult = blockraytraceresult.func_216351_a(blockraytraceresult1.func_216354_b());
+          }
+       }
+ 
+-      return blockraytraceresult;
++      return p_217296_5_.func_177230_c().getRayTraceResult(p_217296_5_, this, p_217296_3_, p_217296_1_, p_217296_2_, blockraytraceresult);
+    }
+ 
+    static <T> T func_217300_a(RayTraceContext p_217300_0_, BiFunction<RayTraceContext, BlockPos, T> p_217300_1_, Function<RayTraceContext, T> p_217300_2_) {

--- a/src/main/java/net/minecraftforge/common/extensions/IForgeBlock.java
+++ b/src/main/java/net/minecraftforge/common/extensions/IForgeBlock.java
@@ -983,6 +983,17 @@ public interface IForgeBlock
     }
 
     /**
+     * This is the 1.13 version and is now dead, use the new version bellow
+     * TODO: Remove in 1.15
+     */
+    @Deprecated
+    @Nullable
+    default RayTraceResult getRayTraceResult(BlockState state, World world, BlockPos pos, Vec3d start, Vec3d end, RayTraceResult original)
+    {
+        return original;
+    }
+
+    /**
      * Ray traces through the blocks collision from start vector to end vector returning a ray trace hit.
      *
      * @param state The current state

--- a/src/main/java/net/minecraftforge/common/extensions/IForgeBlock.java
+++ b/src/main/java/net/minecraftforge/common/extensions/IForgeBlock.java
@@ -67,8 +67,10 @@ import net.minecraft.util.Hand;
 import net.minecraft.util.ResourceLocation;
 import net.minecraft.util.Rotation;
 import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.math.BlockRayTraceResult;
 import net.minecraft.util.math.RayTraceResult;
 import net.minecraft.util.math.Vec3d;
+import net.minecraft.util.math.shapes.VoxelShape;
 import net.minecraft.world.Explosion;
 import net.minecraft.world.IBlockReader;
 import net.minecraft.world.IEnviromentBlockReader;
@@ -988,11 +990,11 @@ public interface IForgeBlock
      * @param pos Block position in world
      * @param start The start vector
      * @param end The end vector
-     * @param original The original result from {@link Block#collisionRayTrace(IBlockState, World, BlockPos, Vec3d, Vec3d)}
+     * @param original The original result from {@link IBlockReader#func_217296_a(Vec3d, Vec3d, BlockPos, VoxelShape, BlockState)}
      * @return A result that suits your block
      */
     @Nullable
-    default RayTraceResult getRayTraceResult(BlockState state, World world, BlockPos pos, Vec3d start, Vec3d end, RayTraceResult original)
+    default BlockRayTraceResult getRayTraceResult(BlockState state, IBlockReader world, BlockPos pos, Vec3d start, Vec3d end, BlockRayTraceResult original)
     {
         return original;
     }


### PR DESCRIPTION
1.14 Update for Patch: https://github.com/MinecraftForge/MinecraftForge/pull/5354

Short Function Summery:
Enables sub segment block outlines, and assignment of the 'subHit' variable