### PR TITLE
Make customClientFactory optional again

### DIFF
--- a/patches/minecraft/net/minecraft/entity/EntityType.java.patch
+++ b/patches/minecraft/net/minecraft/entity/EntityType.java.patch
@@ -85,7 +85,7 @@
     }
  
 +   public T customClientSpawn(net.minecraftforge.fml.network.FMLPlayMessages.SpawnEntity packet, World world) {
-+      if (customClientFactory == null) throw new RuntimeException("Missing custom spawn data for entity type "+this);
++      if (customClientFactory == null) return this.func_200721_a(world);
 +      return customClientFactory.apply(packet, world);
 +   }
 +
@@ -111,7 +111,7 @@
        private boolean field_225436_f;
        private EntitySize field_220326_f = EntitySize.func_220314_b(0.6F, 1.8F);
  
-@@ -553,11 +591,31 @@
+@@ -553,11 +591,35 @@
           return this;
        }
  
@@ -130,6 +130,10 @@
 +         return this;
 +      }
 +
++      /**
++       * By default, entities are spawned clientside via {@link EntityType#create(World)}.
++       * If you need finer control over the spawning process, use this to get read access to the spawn packet.
++       */
 +      public EntityType.Builder<T> setCustomClientFactory(java.util.function.BiFunction<net.minecraftforge.fml.network.FMLPlayMessages.SpawnEntity, World, T> customClientFactory) {
 +         this.customClientFactory = customClientFactory;
 +         return this;
@@ -144,7 +148,7 @@
                 if (SharedConstants.field_206244_b) {
                    throw illegalstateexception;
                 }
-@@ -566,7 +624,7 @@
+@@ -566,7 +628,7 @@
              }
           }
  

--- a/src/main/java/net/minecraftforge/fml/network/FMLPlayMessages.java
+++ b/src/main/java/net/minecraftforge/fml/network/FMLPlayMessages.java
@@ -50,9 +50,6 @@ public class FMLPlayMessages
     /**
      * Used to spawn a custom entity without the same restrictions as
      * {@link net.minecraft.network.play.server.SSpawnObjectPacket} or {@link net.minecraft.network.play.server.SSpawnMobPacket}
-     *
-     * Ensure your {@link EntityType} registration supplies a {@link EntityType.Builder#customClientFactory} or the
-     * mob won't actually spawn on the client.
      */
     public static class SpawnEntity
     {

--- a/src/main/java/net/minecraftforge/fml/network/FMLPlayMessages.java
+++ b/src/main/java/net/minecraftforge/fml/network/FMLPlayMessages.java
@@ -50,6 +50,9 @@ public class FMLPlayMessages
     /**
      * Used to spawn a custom entity without the same restrictions as
      * {@link net.minecraft.network.play.server.SSpawnObjectPacket} or {@link net.minecraft.network.play.server.SSpawnMobPacket}
+     *
+     * To customize how your entity is created clientside (instead of using the default factory provided to the {@link EntityType})
+     * see {@link EntityType.Builder#setCustomClientFactory}.
      */
     public static class SpawnEntity
     {


### PR DESCRIPTION
The custom spawn callback (the function from packet -> entity) was always optional in 1.12 and when I restored it in 1.13 (#5353).

In 1.14.2 it was (inadvertently?) changed to be required, which was a bit confusing since it has the word "custom" in it, which to me implies it's optional and you fall back to the normal `factory` if not present.

Anecdotally I've seen tons of modders in the 1.14 Discord channel (including myself) run into this as well and get confused that they need to pass *two* factories to the EntityType builder when they're not doing anything special. It was always just `(packet, world) -> new MyEntity(world)`, which is exactly what the default factory does. It just becomes extra "forge boilerplate" you have to type in for each entitytype you have.

Therefore, change the clientside spawning back so that it uses the regular factory of the `EntityType` if `customClientFactory` is not present. This matches the old behaviour in 1.12/1.13. Those who need the flexibility can have it, but let's keep it ergonomic for the common case.

There is no backward compat concern with the RB because those who called `customClientFactory` will continue to do so.