### PR TITLE
Fix FluidTank with empty contents throwing error if drained

### DIFF
--- a/src/main/java/net/minecraftforge/fluids/capability/templates/FluidTank.java
+++ b/src/main/java/net/minecraftforge/fluids/capability/templates/FluidTank.java
@@ -190,7 +190,7 @@ public class FluidTank implements IFluidHandler, IFluidTank {
             drained = fluid.getAmount();
         }
         FluidStack stack = new FluidStack(fluid, drained);
-        if (action.execute())
+        if (action.execute() && drained > 0)
         {
             fluid.shrink(drained);
         }


### PR DESCRIPTION
If a FluidTank is empty, and you attempt to drain it in execution-mode,
it will throw a "Can't modify the empty stack." exception.
This PR fixes that.