### PR TITLE
Skip background for hidden effect instances

### DIFF
--- a/patches/minecraft/net/minecraft/client/gui/DisplayEffectsScreen.java.patch
+++ b/patches/minecraft/net/minecraft/client/gui/DisplayEffectsScreen.java.patch
@@ -8,7 +8,15 @@
           this.field_147003_i = 160 + (this.width - this.field_146999_f - 200) / 2;
           this.field_147045_u = true;
        }
-@@ -84,6 +85,7 @@
+@@ -71,6 +72,7 @@
+       int i = this.field_147009_r;
+ 
+       for(EffectInstance effectinstance : p_214079_3_) {
++         if (!effectinstance.func_188419_a().shouldRender(effectinstance)) continue;
+          GlStateManager.color4f(1.0F, 1.0F, 1.0F, 1.0F);
+          this.blit(p_214079_1_, i, 0, 166, 140, 32);
+          i += p_214079_2_;
+@@ -84,6 +86,7 @@
        int i = this.field_147009_r;
  
        for(EffectInstance effectinstance : p_214077_3_) {
@@ -16,7 +24,7 @@
           Effect effect = effectinstance.func_188419_a();
           blit(p_214077_1_ + 6, i + 7, this.blitOffset, 18, 18, potionspriteuploader.func_215288_a(effect));
           i += p_214077_2_;
-@@ -95,6 +97,9 @@
+@@ -95,6 +98,9 @@
        int i = this.field_147009_r;
  
        for(EffectInstance effectinstance : p_214078_3_) {

--- a/patches/minecraft/net/minecraft/client/gui/DisplayEffectsScreen.java.patch
+++ b/patches/minecraft/net/minecraft/client/gui/DisplayEffectsScreen.java.patch
@@ -8,27 +8,19 @@
           this.field_147003_i = 160 + (this.width - this.field_146999_f - 200) / 2;
           this.field_147045_u = true;
        }
-@@ -71,6 +72,7 @@
-       int i = this.field_147009_r;
+@@ -59,7 +60,7 @@
+             j = 132 / (collection.size() - 1);
+          }
  
-       for(EffectInstance effectinstance : p_214079_3_) {
-+         if (!effectinstance.func_188419_a().shouldRender(effectinstance)) continue;
-          GlStateManager.color4f(1.0F, 1.0F, 1.0F, 1.0F);
-          this.blit(p_214079_1_, i, 0, 166, 140, 32);
-          i += p_214079_2_;
-@@ -84,6 +86,7 @@
-       int i = this.field_147009_r;
- 
-       for(EffectInstance effectinstance : p_214077_3_) {
-+         if (!effectinstance.func_188419_a().shouldRender(effectinstance)) continue;
-          Effect effect = effectinstance.func_188419_a();
-          blit(p_214077_1_ + 6, i + 7, this.blitOffset, 18, 18, potionspriteuploader.func_215288_a(effect));
-          i += p_214077_2_;
-@@ -95,6 +98,9 @@
+-         Iterable<EffectInstance> iterable = Ordering.<EffectInstance>natural().sortedCopy(collection);
++         Iterable<EffectInstance> iterable = collection.stream().filter( effectInstance -> effectInstance.func_188419_a().shouldRender(effectInstance)).sorted().collect(java.util.stream.Collectors.toList());
+          this.func_214079_a(i, j, iterable);
+          this.func_214077_b(i, j, iterable);
+          this.func_214078_c(i, j, iterable);
+@@ -95,6 +96,8 @@
        int i = this.field_147009_r;
  
        for(EffectInstance effectinstance : p_214078_3_) {
-+         if (!effectinstance.func_188419_a().shouldRender(effectinstance)) continue;
 +         effectinstance.func_188419_a().renderInventoryEffect(effectinstance, this, p_214078_1_, i, this.blitOffset);
 +         if (!effectinstance.func_188419_a().shouldRenderInvText(effectinstance)) { i += p_214078_2_; continue; }
           String s = I18n.func_135052_a(effectinstance.func_188419_a().func_76393_a());


### PR DESCRIPTION
`IForgeEffect`s can be prevented from being displayed in effect display next to the players inventory using `IForgeEffect#shouldRender`.
However, in 1.14 only text and icon are skipped. The (empty) background (the gray square) is still rendered.

This PR adds the missing check to `drawActivePotionEffectsBackground`.


**Alternative**:
There are three separate methods `drawActivePotionEffectsBackground`, `drawActivePotionEffectIcons` and `drawActivePotionEffectsName` which are called at the same position with the same copy of the active potion effect list. Therefore it could be reasonable to remove the patches from the individual methods and just filter the potion effect list beforehand to minimize patch size.
E.g. with 
`Ordering.<EffectInstance>natural().sortedCopy(collection).stream().filter( effectInstance -> effectInstance.getPotion().shouldRender(effectInstance)).collect(Collectors.toList())`
But this probably creates another List instance. 
