### PR TITLE
Allow mod dimensions to have completely separate world info

### DIFF
--- a/patches/minecraft/net/minecraft/command/impl/GameRuleCommand.java.patch
+++ b/patches/minecraft/net/minecraft/command/impl/GameRuleCommand.java.patch
@@ -1,0 +1,19 @@
+--- a/net/minecraft/command/impl/GameRuleCommand.java
++++ b/net/minecraft/command/impl/GameRuleCommand.java
+@@ -27,14 +27,14 @@
+ 
+    private static <T extends GameRules.RuleValue<T>> int func_223485_b(CommandContext<CommandSource> p_223485_0_, GameRules.RuleKey<T> p_223485_1_) {
+       CommandSource commandsource = p_223485_0_.getSource();
+-      T t = commandsource.func_197028_i().func_200252_aR().func_223585_a(p_223485_1_);
++      T t = commandsource.func_197023_e().func_82736_K().func_223585_a(p_223485_1_); // FORGE: Modify only the current world's gamerules
+       t.func_223554_b(p_223485_0_, "value");
+       commandsource.func_197030_a(new TranslationTextComponent("commands.gamerule.set", p_223485_1_.func_223576_a(), t.toString()), true);
+       return t.func_223557_c();
+    }
+ 
+    private static <T extends GameRules.RuleValue<T>> int func_223486_b(CommandSource p_223486_0_, GameRules.RuleKey<T> p_223486_1_) {
+-      T t = p_223486_0_.func_197028_i().func_200252_aR().func_223585_a(p_223486_1_);
++      T t = p_223486_0_.func_197023_e().func_82736_K().func_223585_a(p_223486_1_); // FORGE: Modify only the current world's gamerules
+       p_223486_0_.func_197030_a(new TranslationTextComponent("commands.gamerule.query", p_223486_1_.func_223576_a(), t.toString()), false);
+       return t.func_223557_c();
+    }

--- a/patches/minecraft/net/minecraft/command/impl/TimeCommand.java.patch
+++ b/patches/minecraft/net/minecraft/command/impl/TimeCommand.java.patch
@@ -1,0 +1,20 @@
+--- a/net/minecraft/command/impl/TimeCommand.java
++++ b/net/minecraft/command/impl/TimeCommand.java
+@@ -43,6 +43,8 @@
+    }
+ 
+    public static int func_198829_a(CommandSource p_198829_0_, int p_198829_1_) {
++      p_198829_0_.func_197023_e().func_72877_b(p_198829_1_); // FORGE: Don't change time of modded dimensions
++      if (false)
+       for(ServerWorld serverworld : p_198829_0_.func_197028_i().func_212370_w()) {
+          serverworld.func_72877_b((long)p_198829_1_);
+       }
+@@ -52,6 +54,8 @@
+    }
+ 
+    public static int func_198826_b(CommandSource p_198826_0_, int p_198826_1_) {
++      p_198826_0_.func_197023_e().func_72877_b(p_198826_0_.func_197023_e().func_72820_D() + p_198826_1_); // FORGE: Don't change time of modded dimensions
++      if (false)
+       for(ServerWorld serverworld : p_198826_0_.func_197028_i().func_212370_w()) {
+          serverworld.func_72877_b(serverworld.func_72820_D() + (long)p_198826_1_);
+       }

--- a/patches/minecraft/net/minecraft/world/ServerMultiWorld.java.patch
+++ b/patches/minecraft/net/minecraft/world/ServerMultiWorld.java.patch
@@ -1,14 +1,16 @@
 --- a/net/minecraft/world/ServerMultiWorld.java
 +++ b/net/minecraft/world/ServerMultiWorld.java
-@@ -11,11 +11,18 @@
+@@ -11,11 +11,19 @@
  import net.minecraft.world.storage.SaveHandler;
  
  public class ServerMultiWorld extends ServerWorld {
 +   private final ServerWorld delegate;
 +   private final IBorderListener borderListener;
     public ServerMultiWorld(ServerWorld p_i50708_1_, MinecraftServer p_i50708_2_, Executor p_i50708_3_, SaveHandler p_i50708_4_, DimensionType p_i50708_5_, IProfiler p_i50708_6_, IChunkStatusListener p_i50708_7_) {
-       super(p_i50708_2_, p_i50708_3_, p_i50708_4_, new DerivedWorldInfo(p_i50708_1_.func_72912_H()), p_i50708_5_, p_i50708_6_, p_i50708_7_);
+-      super(p_i50708_2_, p_i50708_3_, p_i50708_4_, new DerivedWorldInfo(p_i50708_1_.func_72912_H()), p_i50708_5_, p_i50708_6_, p_i50708_7_);
 -      p_i50708_1_.func_175723_af().func_177737_a(new IBorderListener.Impl(this.func_175723_af()));
++      // FORGE: Allow mod dimensions to control WorldInfo creation
++      super(p_i50708_2_, p_i50708_3_, p_i50708_4_, p_i50708_5_.createWorldInfo(p_i50708_1_.func_72912_H()), p_i50708_5_, p_i50708_6_, p_i50708_7_);
 +      this.delegate = p_i50708_1_;
 +      this.borderListener = new IBorderListener.Impl(this.func_175723_af());
 +      p_i50708_1_.func_175723_af().func_177737_a(this.borderListener);

--- a/patches/minecraft/net/minecraft/world/dimension/DimensionType.java.patch
+++ b/patches/minecraft/net/minecraft/world/dimension/DimensionType.java.patch
@@ -61,12 +61,17 @@
     }
  
     @Nullable
-@@ -65,7 +80,21 @@
+@@ -65,7 +80,26 @@
        return Registry.field_212622_k.func_148745_a(p_186069_0_ - -1);
     }
  
 +   public boolean isVanilla() {
 +      return this.isVanilla;
++   }
++   
++   public net.minecraft.world.storage.WorldInfo createWorldInfo(net.minecraft.world.storage.WorldInfo parent) {
++      net.minecraftforge.common.ModDimension modType = getModType();
++      return modType == null ? new net.minecraft.world.storage.DerivedWorldInfo(parent) : modType.createWorldInfo(parent);
 +   }
 +
     @Nullable

--- a/src/main/java/net/minecraftforge/common/ModDimension.java
+++ b/src/main/java/net/minecraftforge/common/ModDimension.java
@@ -19,13 +19,16 @@
 
 package net.minecraftforge.common;
 
-import java.util.function.BiFunction;
-
 import net.minecraft.network.PacketBuffer;
 import net.minecraft.world.World;
+import net.minecraft.world.WorldSettings;
 import net.minecraft.world.dimension.Dimension;
 import net.minecraft.world.dimension.DimensionType;
+import net.minecraft.world.storage.DerivedWorldInfo;
+import net.minecraft.world.storage.WorldInfo;
 import net.minecraftforge.registries.ForgeRegistryEntry;
+
+import java.util.function.BiFunction;
 
 /**
  * In 1.13.2, Mojang made DimensionType as the unique holder/identifier for each Dimension.
@@ -36,6 +39,22 @@ import net.minecraftforge.registries.ForgeRegistryEntry;
 public abstract class ModDimension extends ForgeRegistryEntry<ModDimension>
 {
     public abstract BiFunction<World, DimensionType, ? extends Dimension> getFactory();
+
+    /**
+     * Allow mods to control the WorldInfo used for the dimension. In vanilla, all
+     * dimensions use a {@link DerivedWorldInfo} except the overworld, which ties
+     * weather and other data to the overworld. Instead, the default implementation
+     * here creates a new {@link WorldInfo}, but can be overriden for more
+     * advanced behavior.
+     * 
+     * @param parent   The parent {@link WorldInfo}, mostly likely from the
+     *                 overworld.
+     * @return A {@link WorldInfo} for the dimension world being created.
+     */
+    public WorldInfo createWorldInfo(WorldInfo parent)
+    {
+        return new WorldInfo(new WorldSettings(parent), parent.getWorldName());
+    }
 
     /**
      * Serialize any necessary data, this is called both when saving the world on the server.


### PR DESCRIPTION
Fixes:
- Mod dimensions always using DerivedWorldInfo (which delegates to the overworld, and prevents modifying anything)
- Mod dimensions' weather not being affected by /weather
- Mod dimensions having their time modified when /time is run in a different dimension
- Game rules being tied completely to the overworld

I am interested in review because:
- Not sure if I missed any spots that need to be separated (I tested as much as I could, but there's a LOT of stuff using this data)
- Need opinions on how gamerules should be handled - currently the nether and end will remain linked to the overworld but modded dimensions will have separate gamerules. This behavior is confusing but the most flexible.