### PR TITLE
Allow mods actually to have their own usable config gui

### DIFF
--- a/src/fmllauncher/java/net/minecraftforge/fml/loading/moddiscovery/ModInfo.java
+++ b/src/fmllauncher/java/net/minecraftforge/fml/loading/moddiscovery/ModInfo.java
@@ -151,6 +151,10 @@ public class ModInfo implements IModInfo
         return this.logoFile;
     }
 
+    /**
+     * This is no longer used. The Mods List GUI currently directly checks whether there is an EntryPoint registered.
+     */
+    @Deprecated
     public boolean hasConfigUI()
     {
         return false;

--- a/src/main/java/net/minecraftforge/fml/client/gui/GuiModList.java
+++ b/src/main/java/net/minecraftforge/fml/client/gui/GuiModList.java
@@ -405,8 +405,7 @@ public class GuiModList extends Screen
             return;
         }
         ModInfo selectedMod = selected.getInfo();
-
-        this.configButton.active = selectedMod.hasConfigUI();
+        this.configButton.active = ConfigGuiHandler.getGuiFactoryFor(selectedMod).isPresent();
         List<String> lines = new ArrayList<>();
         VersionChecker.CheckResult vercheck = VersionChecker.getResult(selectedMod);
 


### PR DESCRIPTION
Currently mods can register config guis but they can't be opened since the "has config gui" setting is hardcoded to false. This PR would change that.