### PR TITLE
Some minor improvements to early loading screen

### DIFF
--- a/src/fmllauncher/java/net/minecraftforge/fml/loading/progress/ClientVisualization.java
+++ b/src/fmllauncher/java/net/minecraftforge/fml/loading/progress/ClientVisualization.java
@@ -65,7 +65,7 @@ class ClientVisualization implements EarlyProgressVisualization.Visualization {
 
         window = glfwCreateWindow(screenWidth, screenHeight, "FML early loading progress", NULL, NULL);
         if (window == NULL) {
-            throw new RuntimeException("Failed to create the GLFW window"); // ignore it and make the GUI optional?
+            throw new RuntimeException("Failed to create the GLFW window");
         }
 
         try (MemoryStack stack = stackPush()) {
@@ -98,15 +98,6 @@ class ClientVisualization implements EarlyProgressVisualization.Visualization {
         glOrtho(0.0D, screenWidth, screenHeight, 0.0D, -1000.0D, 1000.0D);
         glMatrixMode(GL_MODELVIEW);
         glLoadIdentity();
-
-//            // replace with more modern opengl?
-//            glBegin(GL_QUADS);
-//            glColor3f(0.1f, 0.1f, 0.9f);
-//            glVertex2f(0, 0);
-//            glVertex2f(0, screenHeight);
-//            glVertex2f(screenWidth * progress, screenHeight);
-//            glVertex2f(screenWidth * progress, 0);
-//            glEnd();
 
         glEnableClientState(GL11.GL_VERTEX_ARRAY);
         glEnable(GL_BLEND);
@@ -260,10 +251,6 @@ class ClientVisualization implements EarlyProgressVisualization.Visualization {
 
     @Override
     public void join() {
-//        try {
-//            Thread.sleep(10000);
-//        } catch (InterruptedException e) {
-//        }
         LOGGER.debug("Asking early loading window to destroy");
         running = false;
         try {

--- a/src/main/java/net/minecraftforge/fml/StartupMessageManager.java
+++ b/src/main/java/net/minecraftforge/fml/StartupMessageManager.java
@@ -19,7 +19,12 @@
 
 package net.minecraftforge.fml;
 
+@Deprecated
 public class StartupMessageManager {
+    /**
+     * @deprecated Use {@link net.minecraftforge.fml.loading.progress.StartupMessageManager#addModMessage(String)} instead
+     */
+    @Deprecated
     public static void addModMessage(final String message) {
         net.minecraftforge.fml.loading.progress.StartupMessageManager.addModMessage(message);
     }


### PR DESCRIPTION
- Fix memory leak due to GLCapabilities not being freed after the window has been destroyed
- Interrupt the early render thread for faster shutdown of the window
- Log thread crashes of the render thread
- Make running variable volatile, as it is set from off-thread
- Make sure to always destroy the window after creating it, even if the thread crashes
- Deprecate the old API