### PR TITLE
[1.14] Fix MC-162953 bounds checks in `NativeImage`

### DIFF
--- a/patches/minecraft/net/minecraft/client/renderer/texture/NativeImage.java.patch
+++ b/patches/minecraft/net/minecraft/client/renderer/texture/NativeImage.java.patch
@@ -1,0 +1,38 @@
+--- a/net/minecraft/client/renderer/texture/NativeImage.java
++++ b/net/minecraft/client/renderer/texture/NativeImage.java
+@@ -172,7 +172,7 @@
+    public int func_195709_a(int p_195709_1_, int p_195709_2_) {
+       if (this.field_211680_b != NativeImage.PixelFormat.RGBA) {
+          throw new IllegalArgumentException(String.format("getPixelRGBA only works on RGBA images; have %s", this.field_211680_b));
+-      } else if (p_195709_1_ <= this.field_195719_a && p_195709_2_ <= this.field_195720_b) {
++      } else if (p_195709_1_ >= 0 && p_195709_2_ >= 0 && p_195709_1_ < this.field_195719_a && p_195709_2_ < this.field_195720_b) {
+          this.func_195696_g();
+          return MemoryUtil.memIntBuffer(this.field_195722_d, this.field_195723_e).get(p_195709_1_ + p_195709_2_ * this.field_195719_a);
+       } else {
+@@ -183,7 +183,7 @@
+    public void func_195700_a(int p_195700_1_, int p_195700_2_, int p_195700_3_) {
+       if (this.field_211680_b != NativeImage.PixelFormat.RGBA) {
+          throw new IllegalArgumentException(String.format("getPixelRGBA only works on RGBA images; have %s", this.field_211680_b));
+-      } else if (p_195700_1_ <= this.field_195719_a && p_195700_2_ <= this.field_195720_b) {
++      } else if (p_195700_1_ >= 0 && p_195700_2_ >= 0 && p_195700_1_ < this.field_195719_a && p_195700_2_ < this.field_195720_b) {
+          this.func_195696_g();
+          MemoryUtil.memIntBuffer(this.field_195722_d, this.field_195723_e).put(p_195700_1_ + p_195700_2_ * this.field_195719_a, p_195700_3_);
+       } else {
+@@ -194,7 +194,7 @@
+    public byte func_211675_e(int p_211675_1_, int p_211675_2_) {
+       if (!this.field_211680_b.func_211653_r()) {
+          throw new IllegalArgumentException(String.format("no luminance or alpha in %s", this.field_211680_b));
+-      } else if (p_211675_1_ <= this.field_195719_a && p_211675_2_ <= this.field_195720_b) {
++      } else if (p_211675_1_ >= 0 && p_211675_2_ >= 0 && p_211675_1_ < this.field_195719_a && p_211675_2_ < this.field_195720_b) {
+          return MemoryUtil.memByteBuffer(this.field_195722_d, this.field_195723_e).get((p_211675_1_ + p_211675_2_ * this.field_195719_a) * this.field_211680_b.func_211651_a() + this.field_211680_b.func_211647_v() / 8);
+       } else {
+          throw new IllegalArgumentException(String.format("(%s, %s) outside of image bounds (%s, %s)", p_211675_1_, p_211675_2_, this.field_195719_a, this.field_195720_b));
+@@ -328,7 +328,7 @@
+    }
+ 
+    public void func_211676_a(STBTTFontinfo p_211676_1_, int p_211676_2_, int p_211676_3_, int p_211676_4_, float p_211676_5_, float p_211676_6_, float p_211676_7_, float p_211676_8_, int p_211676_9_, int p_211676_10_) {
+-      if (p_211676_9_ >= 0 && p_211676_9_ + p_211676_3_ <= this.func_195702_a() && p_211676_10_ >= 0 && p_211676_10_ + p_211676_4_ <= this.func_195714_b()) {
++      if (p_211676_9_ >= 0 && p_211676_9_ + p_211676_3_ < this.func_195702_a() && p_211676_10_ >= 0 && p_211676_10_ + p_211676_4_ < this.func_195714_b()) {
+          if (this.field_211680_b.func_211651_a() != 1) {
+             throw new IllegalArgumentException("Can only write fonts into 1-component images.");
+          } else {

--- a/patches/minecraft/net/minecraft/client/renderer/texture/NativeImage.java.patch
+++ b/patches/minecraft/net/minecraft/client/renderer/texture/NativeImage.java.patch
@@ -5,7 +5,7 @@
        if (this.field_211680_b != NativeImage.PixelFormat.RGBA) {
           throw new IllegalArgumentException(String.format("getPixelRGBA only works on RGBA images; have %s", this.field_211680_b));
 -      } else if (p_195709_1_ <= this.field_195719_a && p_195709_2_ <= this.field_195720_b) {
-+      } else if (p_195709_1_ >= 0 && p_195709_2_ >= 0 && p_195709_1_ < this.field_195719_a && p_195709_2_ < this.field_195720_b) {
++      } else if (p_195709_1_ >= 0 && p_195709_2_ >= 0 && p_195709_1_ < this.field_195719_a && p_195709_2_ < this.field_195720_b) { //Fix MC-162953 bounds checks in `NativeImage`
           this.func_195696_g();
           return MemoryUtil.memIntBuffer(this.field_195722_d, this.field_195723_e).get(p_195709_1_ + p_195709_2_ * this.field_195719_a);
        } else {
@@ -14,7 +14,7 @@
        if (this.field_211680_b != NativeImage.PixelFormat.RGBA) {
           throw new IllegalArgumentException(String.format("getPixelRGBA only works on RGBA images; have %s", this.field_211680_b));
 -      } else if (p_195700_1_ <= this.field_195719_a && p_195700_2_ <= this.field_195720_b) {
-+      } else if (p_195700_1_ >= 0 && p_195700_2_ >= 0 && p_195700_1_ < this.field_195719_a && p_195700_2_ < this.field_195720_b) {
++      } else if (p_195700_1_ >= 0 && p_195700_2_ >= 0 && p_195700_1_ < this.field_195719_a && p_195700_2_ < this.field_195720_b) { //Fix MC-162953 bounds checks in `NativeImage`
           this.func_195696_g();
           MemoryUtil.memIntBuffer(this.field_195722_d, this.field_195723_e).put(p_195700_1_ + p_195700_2_ * this.field_195719_a, p_195700_3_);
        } else {
@@ -23,7 +23,7 @@
        if (!this.field_211680_b.func_211653_r()) {
           throw new IllegalArgumentException(String.format("no luminance or alpha in %s", this.field_211680_b));
 -      } else if (p_211675_1_ <= this.field_195719_a && p_211675_2_ <= this.field_195720_b) {
-+      } else if (p_211675_1_ >= 0 && p_211675_2_ >= 0 && p_211675_1_ < this.field_195719_a && p_211675_2_ < this.field_195720_b) {
++      } else if (p_211675_1_ >= 0 && p_211675_2_ >= 0 && p_211675_1_ < this.field_195719_a && p_211675_2_ < this.field_195720_b) { //Fix MC-162953 bounds checks in `NativeImage`
           return MemoryUtil.memByteBuffer(this.field_195722_d, this.field_195723_e).get((p_211675_1_ + p_211675_2_ * this.field_195719_a) * this.field_211680_b.func_211651_a() + this.field_211680_b.func_211647_v() / 8);
        } else {
           throw new IllegalArgumentException(String.format("(%s, %s) outside of image bounds (%s, %s)", p_211675_1_, p_211675_2_, this.field_195719_a, this.field_195720_b));
@@ -32,7 +32,7 @@
  
     public void func_211676_a(STBTTFontinfo p_211676_1_, int p_211676_2_, int p_211676_3_, int p_211676_4_, float p_211676_5_, float p_211676_6_, float p_211676_7_, float p_211676_8_, int p_211676_9_, int p_211676_10_) {
 -      if (p_211676_9_ >= 0 && p_211676_9_ + p_211676_3_ <= this.func_195702_a() && p_211676_10_ >= 0 && p_211676_10_ + p_211676_4_ <= this.func_195714_b()) {
-+      if (p_211676_9_ >= 0 && p_211676_9_ + p_211676_3_ < this.func_195702_a() && p_211676_10_ >= 0 && p_211676_10_ + p_211676_4_ < this.func_195714_b()) {
++      if (p_211676_9_ >= 0 && p_211676_9_ + p_211676_3_ < this.func_195702_a() && p_211676_10_ >= 0 && p_211676_10_ + p_211676_4_ < this.func_195714_b()) { //Fix MC-162953 bounds checks in `NativeImage`
           if (this.field_211680_b.func_211651_a() != 1) {
              throw new IllegalArgumentException("Can only write fonts into 1-component images.");
           } else {


### PR DESCRIPTION
Bounds checks in `NativeImage` are a bit wrong, and it uses `UNSAFE` to directly access memory, so misusing it can cause the JRE to completely crash instead of throwing an exception.

This can be tough to debug because `hs_err_pid` error logs tend to be from bugs in the JRE itself or low-level libraries, and it shouldn't be possible for mod bugs to cause them directly.
(see https://github.com/mezz/JustEnoughItems/issues/1698)

This PR updates adds lower bounds checks (`>= 0`), and fixes the upper bounds checks to exclude the width and height.

https://bugs.mojang.com/browse/MC-162953