### PR TITLE
[1.14.4] Added synchronized modifier to RegionFileCache.loadFile, RegionFileCache.close and RegionFile.func_222662_b to allow safe world save access from any thread, not just server thread, like it used to be in older Minecraft versions.

### DIFF
--- a/patches/minecraft/net/minecraft/world/chunk/storage/RegionFile.java.patch
+++ b/patches/minecraft/net/minecraft/world/chunk/storage/RegionFile.java.patch
@@ -65,6 +65,15 @@
                 return null;
              } else {
                 byte b0 = this.field_76719_c.readByte();
+@@ -101,7 +123,7 @@
+       }
+    }
+ 
+-   public boolean func_222662_b(ChunkPos p_222662_1_) {
++   public synchronized boolean func_222662_b(ChunkPos p_222662_1_) {
+       int i = this.func_222660_e(p_222662_1_);
+       if (i == 0) {
+          return false;
 @@ -134,10 +156,16 @@
        int i = this.func_222660_e(p_222664_1_);
        int j = i >> 8;

--- a/patches/minecraft/net/minecraft/world/chunk/storage/RegionFileCache.java.patch
+++ b/patches/minecraft/net/minecraft/world/chunk/storage/RegionFileCache.java.patch
@@ -1,0 +1,20 @@
+--- a/net/minecraft/world/chunk/storage/RegionFileCache.java
++++ b/net/minecraft/world/chunk/storage/RegionFileCache.java
+@@ -18,7 +18,7 @@
+       this.field_219101_a = p_i49938_1_;
+    }
+ 
+-   private RegionFile func_219098_a(ChunkPos p_219098_1_) throws IOException {
++   private synchronized RegionFile func_219098_a(ChunkPos p_219098_1_) throws IOException {
+       long i = ChunkPos.func_77272_a(p_219098_1_.func_222241_h(), p_219098_1_.func_222242_i());
+       RegionFile regionfile = this.field_219102_c.getAndMoveToFirst(i);
+       if (regionfile != null) {
+@@ -65,7 +65,7 @@
+ 
+    }
+ 
+-   public void close() throws IOException {
++   public synchronized void close() throws IOException {
+       for(RegionFile regionfile : this.field_219102_c.values()) {
+          regionfile.close();
+       }


### PR DESCRIPTION
I really need this back for my map mod. I have temporarily (hopefully) moved some of the work to the server thread to avoid race condition issues but it affects the game performance way too much, especially when the server thread is already loaded.