### PR TITLE
Fix loading error/warning screen not showing

### DIFF
--- a/patches/minecraft/net/minecraft/client/Minecraft.java.patch
+++ b/patches/minecraft/net/minecraft/client/Minecraft.java.patch
@@ -81,7 +81,7 @@
              this.func_213256_aB();
           }
 -
-+         if (net.minecraftforge.fml.client.ClientModLoader.complete()) return; // Do not overwrite the error sceen
++         if (net.minecraftforge.fml.client.ClientModLoader.completeModLoading()) return; // Do not overwrite the error sceen
 +         // FORGE: Move opening initial screen to after startup and events are enabled.
 +         // Also Fixes MC-145102
 +         if (this.field_71475_ae != null) {

--- a/patches/minecraft/net/minecraft/client/Minecraft.java.patch
+++ b/patches/minecraft/net/minecraft/client/Minecraft.java.patch
@@ -81,7 +81,7 @@
              this.func_213256_aB();
           }
 -
-+         net.minecraftforge.fml.client.ClientModLoader.complete();
++         if (net.minecraftforge.fml.client.ClientModLoader.complete()) return; // Do not overwrite the error sceen
 +         // FORGE: Move opening initial screen to after startup and events are enabled.
 +         // Also Fixes MC-145102
 +         if (this.field_71475_ae != null) {

--- a/src/main/java/net/minecraftforge/fml/client/ClientModLoader.java
+++ b/src/main/java/net/minecraftforge/fml/client/ClientModLoader.java
@@ -142,7 +142,12 @@ public class ClientModLoader
         return VersionChecker.Status.UP_TO_DATE;
     }
 
-    public static boolean complete()
+    public static void complete()
+    {
+        completeModLoading();
+    }
+
+    public static boolean completeModLoading()
     {
         GlStateManager.disableTexture();
         GlStateManager.enableTexture();

--- a/src/main/java/net/minecraftforge/fml/client/ClientModLoader.java
+++ b/src/main/java/net/minecraftforge/fml/client/ClientModLoader.java
@@ -142,7 +142,7 @@ public class ClientModLoader
         return VersionChecker.Status.UP_TO_DATE;
     }
 
-    public static void complete()
+    public static boolean complete()
     {
         GlStateManager.disableTexture();
         GlStateManager.enableTexture();
@@ -161,14 +161,16 @@ public class ClientModLoader
             }
             warnings = Collections.emptyList(); //Clear warnings, as the user does not want to see them
         }
-        if (error != null || !warnings.isEmpty()) {
-            mc.displayGuiScreen(new LoadingErrorScreen(error, warnings));
-        } else {
-            ClientHooks.logMissingTextureErrors();
-        }
         if (error == null) {
             // We can finally start the forge eventbus up
             MinecraftForge.EVENT_BUS.start();
+        }
+        if (error != null || !warnings.isEmpty()) {
+            mc.displayGuiScreen(new LoadingErrorScreen(error, warnings));
+            return true;
+        } else {
+            ClientHooks.logMissingTextureErrors();
+            return false;
         }
     }
 

--- a/src/main/java/net/minecraftforge/fml/client/ClientModLoader.java
+++ b/src/main/java/net/minecraftforge/fml/client/ClientModLoader.java
@@ -142,6 +142,7 @@ public class ClientModLoader
         return VersionChecker.Status.UP_TO_DATE;
     }
 
+    @Deprecated // TODO: remove in 1.15
     public static void complete()
     {
         completeModLoading();


### PR DESCRIPTION
Fixes an error introduced by #6139
Currently, forge logs the error and stops firing any events, but does show the main menu, leaving the game in a half-initialized state