### PR TITLE
Fix lang file loading on dedicated server

### DIFF
--- a/src/main/java/net/minecraftforge/fml/packs/ModFileResourcePack.java
+++ b/src/main/java/net/minecraftforge/fml/packs/ModFileResourcePack.java
@@ -126,7 +126,14 @@ public class ModFileResourcePack extends DelegatableResourcePack
         }
         catch (IOException e)
         {
-            return Collections.emptySet();
+            if (type == ResourcePackType.SERVER_DATA) //We still have to add the resource namespace if client resources exist, as we load langs (which are in assets) on server
+            {
+                return this.getResourceNamespaces(ResourcePackType.CLIENT_RESOURCES);
+            }
+            else
+            {
+                return Collections.emptySet();
+            }
         }
     }
 


### PR DESCRIPTION
Add the mod to the resource manager used on the server even if the data folder does no exist.
This fixes the server localisation loading if the data/[modid] folder does not exist
Closes #6223