### PR TITLE
[1.14] Fix RightClickBlock#getUseBlock and #getUseItem being ignored. Fixes #6244

### DIFF
--- a/patches/minecraft/net/minecraft/client/multiplayer/PlayerController.java.patch
+++ b/patches/minecraft/net/minecraft/client/multiplayer/PlayerController.java.patch
@@ -72,7 +72,7 @@
        }
  
        return p_178893_1_.equals(this.field_178895_c) && flag;
-@@ -257,6 +264,12 @@
+@@ -257,17 +264,25 @@
           return ActionResultType.FAIL;
        } else {
           ItemStack itemstack = p_217292_1_.func_184586_b(p_217292_3_);
@@ -85,7 +85,20 @@
           if (this.field_78779_k == GameType.SPECTATOR) {
              this.field_78774_b.func_147297_a(new CPlayerTryUseItemOnBlockPacket(p_217292_3_, p_217292_4_));
              return ActionResultType.SUCCESS;
-@@ -298,11 +311,14 @@
+          } else {
+             boolean flag = !p_217292_1_.func_184614_ca().func_190926_b() || !p_217292_1_.func_184592_cb().func_190926_b();
+             boolean flag1 = p_217292_1_.func_70093_af() && flag;
++            if (event.getUseBlock() == net.minecraftforge.eventbus.api.Event.Result.DENY) flag1 = true;
+             if (!flag1 && p_217292_2_.func_180495_p(blockpos).func_215687_a(p_217292_2_, p_217292_1_, p_217292_3_, p_217292_4_)) {
+                this.field_78774_b.func_147297_a(new CPlayerTryUseItemOnBlockPacket(p_217292_3_, p_217292_4_));
+                return ActionResultType.SUCCESS;
+             } else {
+                this.field_78774_b.func_147297_a(new CPlayerTryUseItemOnBlockPacket(p_217292_3_, p_217292_4_));
++               if (event.getUseItem() == net.minecraftforge.eventbus.api.Event.Result.DENY) return ActionResultType.PASS;
+                if (!itemstack.func_190926_b() && !p_217292_1_.func_184811_cZ().func_185141_a(itemstack.func_77973_b())) {
+                   ItemUseContext itemusecontext = new ItemUseContext(p_217292_1_, p_217292_3_, p_217292_4_);
+                   ActionResultType actionresulttype;
+@@ -298,11 +313,14 @@
           if (p_187101_1_.func_184811_cZ().func_185141_a(itemstack.func_77973_b())) {
              return ActionResultType.PASS;
           } else {
@@ -100,7 +113,7 @@
              }
  
              return actionresult.func_188397_a();
-@@ -327,6 +343,9 @@
+@@ -327,6 +345,9 @@
     public ActionResultType func_187097_a(PlayerEntity p_187097_1_, Entity p_187097_2_, Hand p_187097_3_) {
        this.func_78750_j();
        this.field_78774_b.func_147297_a(new CUseEntityPacket(p_187097_2_, p_187097_3_));
@@ -110,7 +123,7 @@
        return this.field_78779_k == GameType.SPECTATOR ? ActionResultType.PASS : p_187097_1_.func_190775_a(p_187097_2_, p_187097_3_);
     }
  
-@@ -334,6 +353,9 @@
+@@ -334,6 +355,9 @@
        this.func_78750_j();
        Vec3d vec3d = p_187102_3_.func_216347_e().func_178786_a(p_187102_2_.field_70165_t, p_187102_2_.field_70163_u, p_187102_2_.field_70161_v);
        this.field_78774_b.func_147297_a(new CUseEntityPacket(p_187102_2_, p_187102_4_, vec3d));

--- a/patches/minecraft/net/minecraft/server/management/PlayerInteractionManager.java.patch
+++ b/patches/minecraft/net/minecraft/server/management/PlayerInteractionManager.java.patch
@@ -122,7 +122,7 @@
           int i = p_187250_3_.func_190916_E();
           int j = p_187250_3_.func_77952_i();
           ActionResult<ItemStack> actionresult = p_187250_3_.func_77957_a(p_187250_2_, p_187250_1_, p_187250_4_);
-@@ -285,12 +310,18 @@
+@@ -285,12 +310,20 @@
              return ActionResultType.PASS;
           }
        } else {
@@ -135,10 +135,12 @@
 +         }
           boolean flag = !p_219441_1_.func_184614_ca().func_190926_b() || !p_219441_1_.func_184592_cb().func_190926_b();
           boolean flag1 = p_219441_1_.func_70093_af() && flag;
++         if (event.getUseBlock() == net.minecraftforge.eventbus.api.Event.Result.DENY) flag1 = true;
           if (!flag1 && blockstate.func_215687_a(p_219441_2_, p_219441_1_, p_219441_4_, p_219441_5_)) {
              return ActionResultType.SUCCESS;
           } else if (!p_219441_3_.func_190926_b() && !p_219441_1_.func_184811_cZ().func_185141_a(p_219441_3_.func_77973_b())) {
 -            ItemUseContext itemusecontext = new ItemUseContext(p_219441_1_, p_219441_4_, p_219441_5_);
++            if (event.getUseItem() == net.minecraftforge.eventbus.api.Event.Result.DENY) return ActionResultType.PASS;
              if (this.func_73083_d()) {
                 int i = p_219441_3_.func_190916_E();
                 ActionResultType actionresulttype = p_219441_3_.func_196084_a(itemusecontext);


### PR DESCRIPTION
As reported in #6244 the PlayerInteractEvent.RightClickBlock has methods called #getUseBlock and #getUseItem but neither method has any code to handle a Result.DENY as of 1.13/1.14. This PR restores the functionality exactly as it was in 1.12 and exactly as the documentation suggests.