### PR TITLE
Filter duplicate mod files in mod file scan data

### DIFF
--- a/src/main/java/net/minecraftforge/fml/ModList.java
+++ b/src/main/java/net/minecraftforge/fml/ModList.java
@@ -197,6 +197,7 @@ public class ModList
                     map(ModInfo::getOwningFile).
                     filter(Objects::nonNull).
                     map(ModFileInfo::getFile).
+                    distinct().
                     map(ModFile::getScanResult).
                     collect(Collectors.toList());
         }


### PR DESCRIPTION
Forge allows having two (or more) mods in one mod file.

When `ModList#getAllScanData` is called to get annotations (for ObjectHolder etc.), it retrieves the defining mod file for each mod. Because the two mods can be in the same file, this can lead to duplicate scan data.

For ObjectHolder and Capability Injects this means, that all fields of defined in the mod file are injected twice.

Furthermore, other mods like JEI use this as well. For JEI this means that any @JeiPlugin is loaded twice (causing an error).


This PR simply adds a .distinct call in the stream to filter duplicate mod files.
