### PR TITLE
Fixed `shouldCauseReequipAnimation `

### DIFF
--- a/patches/minecraft/net/minecraft/client/renderer/FirstPersonRenderer.java.patch
+++ b/patches/minecraft/net/minecraft/client/renderer/FirstPersonRenderer.java.patch
@@ -97,10 +97,12 @@
        GlStateManager.popMatrix();
        GlStateManager.color4f(1.0F, 1.0F, 1.0F, 1.0F);
        GlStateManager.disableBlend();
-@@ -600,6 +608,15 @@
+@@ -600,8 +608,17 @@
           this.field_187471_h = MathHelper.func_76131_a(this.field_187471_h - 0.4F, 0.0F, 1.0F);
        } else {
           float f = clientplayerentity.func_184825_o(1.0F);
+-         this.field_187469_f += MathHelper.func_76131_a((Objects.equals(this.field_187467_d, itemstack) ? f * f * f : 0.0F) - this.field_187469_f, -0.4F, 0.4F);
+-         this.field_187471_h += MathHelper.func_76131_a((float)(Objects.equals(this.field_187468_e, itemstack1) ? 1 : 0) - this.field_187471_h, -0.4F, 0.4F);
 +
 +         boolean requipM = net.minecraftforge.client.ForgeHooksClient.shouldCauseReequipAnimation(this.field_187467_d, itemstack, clientplayerentity.field_71071_by.field_70461_c);
 +         boolean requipO = net.minecraftforge.client.ForgeHooksClient.shouldCauseReequipAnimation(this.field_187468_e, itemstack1, -1);
@@ -110,6 +112,8 @@
 +         if (!requipO && !Objects.equals(this.field_187468_e, itemstack1))
 +             this.field_187468_e = itemstack1;
 +
-          this.field_187469_f += MathHelper.func_76131_a((Objects.equals(this.field_187467_d, itemstack) ? f * f * f : 0.0F) - this.field_187469_f, -0.4F, 0.4F);
-          this.field_187471_h += MathHelper.func_76131_a((float)(Objects.equals(this.field_187468_e, itemstack1) ? 1 : 0) - this.field_187471_h, -0.4F, 0.4F);
++         this.field_187469_f += MathHelper.func_76131_a((!requipM ? f * f * f : 0.0F) - this.field_187469_f, -0.4F, 0.4F);
++         this.field_187471_h += MathHelper.func_76131_a((float)(!requipO ? 1 : 0) - this.field_187471_h, -0.4F, 0.4F);
        }
+ 
+       if (this.field_187469_f < 0.1F) {


### PR DESCRIPTION
Currently, returning false on `IForgeItem#shouldCauseReequipAnimation` doesn't block the item requip animation. This patch re-adds the code that handles the result of `shouldCauseReequipAnimation`. This is to match the previous 1.12 patch.

1.12:
![image](https://user-images.githubusercontent.com/15876682/67128655-3f6e0580-f1f4-11e9-85c4-761d00f75081.png)

Current 1.14:
![image](https://user-images.githubusercontent.com/15876682/67128671-47c64080-f1f4-11e9-93b5-f7f1af6842b4.png)
