### PR TITLE
Add Tools, Weapons, and Armor Tags the correct way.

### DIFF
--- a/patches/minecraft/net/minecraft/block/PumpkinBlock.java.patch
+++ b/patches/minecraft/net/minecraft/block/PumpkinBlock.java.patch
@@ -1,0 +1,11 @@
+--- a/net/minecraft/block/PumpkinBlock.java
++++ b/net/minecraft/block/PumpkinBlock.java
+@@ -19,7 +19,7 @@
+ 
+    public boolean func_220051_a(BlockState p_220051_1_, World p_220051_2_, BlockPos p_220051_3_, PlayerEntity p_220051_4_, Hand p_220051_5_, BlockRayTraceResult p_220051_6_) {
+       ItemStack itemstack = p_220051_4_.func_184586_b(p_220051_5_);
+-      if (itemstack.func_77973_b() == Items.field_151097_aZ) {
++      if (itemstack.func_77973_b().func_206844_a(net.minecraftforge.common.Tags.Items.SHEARS)) {
+          if (!p_220051_2_.field_72995_K) {
+             Direction direction = p_220051_6_.func_216354_b();
+             Direction direction1 = direction.func_176740_k() == Direction.Axis.Y ? p_220051_4_.func_174811_aO().func_176734_d() : direction;

--- a/patches/minecraft/net/minecraft/block/TripWireBlock.java.patch
+++ b/patches/minecraft/net/minecraft/block/TripWireBlock.java.patch
@@ -1,0 +1,11 @@
+--- a/net/minecraft/block/TripWireBlock.java
++++ b/net/minecraft/block/TripWireBlock.java
+@@ -71,7 +71,7 @@
+    }
+ 
+    public void func_176208_a(World p_176208_1_, BlockPos p_176208_2_, BlockState p_176208_3_, PlayerEntity p_176208_4_) {
+-      if (!p_176208_1_.field_72995_K && !p_176208_4_.func_184614_ca().func_190926_b() && p_176208_4_.func_184614_ca().func_77973_b() == Items.field_151097_aZ) {
++      if (!p_176208_1_.field_72995_K && !p_176208_4_.func_184614_ca().func_190926_b() && p_176208_4_.func_184614_ca().func_77973_b().func_206844_a(net.minecraftforge.common.Tags.Items.SHEARS)) {
+          p_176208_1_.func_180501_a(p_176208_2_, p_176208_3_.func_206870_a(field_176295_N, Boolean.valueOf(true)), 4);
+       }
+ 

--- a/src/generated/resources/data/forge/tags/items/armor.json
+++ b/src/generated/resources/data/forge/tags/items/armor.json
@@ -1,0 +1,9 @@
+{
+  "replace": false,
+  "values": [
+    "#forge:armor/helmets",
+    "#forge:armor/chestplates",
+    "#forge:armor/leggings",
+    "#forge:armor/boots"
+  ]
+}

--- a/src/generated/resources/data/forge/tags/items/armor/boots.json
+++ b/src/generated/resources/data/forge/tags/items/armor/boots.json
@@ -1,0 +1,10 @@
+{
+  "replace": false,
+  "values": [
+    "minecraft:leather_boots",
+    "minecraft:chainmail_boots",
+    "minecraft:iron_boots",
+    "minecraft:golden_boots",
+    "minecraft:diamond_boots"
+  ]
+}

--- a/src/generated/resources/data/forge/tags/items/armor/chestplates.json
+++ b/src/generated/resources/data/forge/tags/items/armor/chestplates.json
@@ -1,0 +1,10 @@
+{
+  "replace": false,
+  "values": [
+    "minecraft:leather_chestplate",
+    "minecraft:chainmail_chestplate",
+    "minecraft:iron_chestplate",
+    "minecraft:golden_chestplate",
+    "minecraft:diamond_chestplate"
+  ]
+}

--- a/src/generated/resources/data/forge/tags/items/armor/helmets.json
+++ b/src/generated/resources/data/forge/tags/items/armor/helmets.json
@@ -1,0 +1,10 @@
+{
+  "replace": false,
+  "values": [
+    "minecraft:leather_helmet",
+    "minecraft:chainmail_helmet",
+    "minecraft:iron_helmet",
+    "minecraft:golden_helmet",
+    "minecraft:diamond_helmet"
+  ]
+}

--- a/src/generated/resources/data/forge/tags/items/armor/leggings.json
+++ b/src/generated/resources/data/forge/tags/items/armor/leggings.json
@@ -1,0 +1,10 @@
+{
+  "replace": false,
+  "values": [
+    "minecraft:leather_leggings",
+    "minecraft:chainmail_leggings",
+    "minecraft:iron_leggings",
+    "minecraft:golden_leggings",
+    "minecraft:diamond_leggings"
+  ]
+}

--- a/src/generated/resources/data/forge/tags/items/elytra.json
+++ b/src/generated/resources/data/forge/tags/items/elytra.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "minecraft:elytra"
+  ]
+}

--- a/src/generated/resources/data/forge/tags/items/tools.json
+++ b/src/generated/resources/data/forge/tags/items/tools.json
@@ -1,0 +1,10 @@
+{
+  "replace": false,
+  "values": [
+    "#forge:tools/axes",
+    "#forge:tools/pickaxes",
+    "#forge:tools/shovels",
+    "#forge:tools/hoes",
+    "#forge:tools/shears"
+  ]
+}

--- a/src/generated/resources/data/forge/tags/items/tools/axes.json
+++ b/src/generated/resources/data/forge/tags/items/tools/axes.json
@@ -1,0 +1,10 @@
+{
+  "replace": false,
+  "values": [
+    "minecraft:wooden_axe",
+    "minecraft:stone_axe",
+    "minecraft:iron_axe",
+    "minecraft:golden_axe",
+    "minecraft:diamond_axe"
+  ]
+}

--- a/src/generated/resources/data/forge/tags/items/tools/hoes.json
+++ b/src/generated/resources/data/forge/tags/items/tools/hoes.json
@@ -1,0 +1,10 @@
+{
+  "replace": false,
+  "values": [
+    "minecraft:wooden_hoe",
+    "minecraft:stone_hoe",
+    "minecraft:iron_hoe",
+    "minecraft:golden_hoe",
+    "minecraft:diamond_hoe"
+  ]
+}

--- a/src/generated/resources/data/forge/tags/items/tools/pickaxes.json
+++ b/src/generated/resources/data/forge/tags/items/tools/pickaxes.json
@@ -1,0 +1,10 @@
+{
+  "replace": false,
+  "values": [
+    "minecraft:wooden_pickaxe",
+    "minecraft:stone_pickaxe",
+    "minecraft:iron_pickaxe",
+    "minecraft:golden_pickaxe",
+    "minecraft:diamond_pickaxe"
+  ]
+}

--- a/src/generated/resources/data/forge/tags/items/tools/shears.json
+++ b/src/generated/resources/data/forge/tags/items/tools/shears.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "minecraft:shears"
+  ]
+}

--- a/src/generated/resources/data/forge/tags/items/tools/shovels.json
+++ b/src/generated/resources/data/forge/tags/items/tools/shovels.json
@@ -1,0 +1,10 @@
+{
+  "replace": false,
+  "values": [
+    "minecraft:wooden_shovel",
+    "minecraft:stone_shovel",
+    "minecraft:iron_shovel",
+    "minecraft:golden_shovel",
+    "minecraft:diamond_shovel"
+  ]
+}

--- a/src/generated/resources/data/forge/tags/items/weapons.json
+++ b/src/generated/resources/data/forge/tags/items/weapons.json
@@ -1,0 +1,7 @@
+{
+  "replace": false,
+  "values": [
+    "#forge:weapons/swords",
+    "#forge:weapons/ranged"
+  ]
+}

--- a/src/generated/resources/data/forge/tags/items/weapons/bows.json
+++ b/src/generated/resources/data/forge/tags/items/weapons/bows.json
@@ -1,0 +1,7 @@
+{
+  "replace": false,
+  "values": [
+    "minecraft:bow",
+    "minecraft:crossbow"
+  ]
+}

--- a/src/generated/resources/data/forge/tags/items/weapons/ranged.json
+++ b/src/generated/resources/data/forge/tags/items/weapons/ranged.json
@@ -1,0 +1,7 @@
+{
+  "replace": false,
+  "values": [
+    "minecraft:trident",
+    "#forge:weapons/bows"
+  ]
+}

--- a/src/generated/resources/data/forge/tags/items/weapons/swords.json
+++ b/src/generated/resources/data/forge/tags/items/weapons/swords.json
@@ -1,0 +1,10 @@
+{
+  "replace": false,
+  "values": [
+    "minecraft:wooden_sword",
+    "minecraft:stone_sword",
+    "minecraft:iron_sword",
+    "minecraft:golden_sword",
+    "minecraft:diamond_sword"
+  ]
+}

--- a/src/main/java/net/minecraftforge/common/Tags.java
+++ b/src/main/java/net/minecraftforge/common/Tags.java
@@ -266,6 +266,26 @@ public class Tags
         public static final Tag<Item> STORAGE_BLOCKS_REDSTONE = tag("storage_blocks/redstone");
         public static final Tag<Item> STRING = tag("string");
 
+        public static final Tag<Item> TOOLS = tag("tools");
+        public static final Tag<Item> PICKAXES = tag("tools/pickaxes");
+        public static final Tag<Item> AXES = tag("tools/axes");
+        public static final Tag<Item> SHOVELS = tag("tools/shovels");
+        public static final Tag<Item> HOES = tag("tools/hoes");
+        public static final Tag<Item> SHEARS = tag("tools/shears");
+
+        public static final Tag<Item> WEAPONS = tag("weapons");
+        public static final Tag<Item> SWORDS = tag("weapons/swords");
+        public static final Tag<Item> RANGED_WEAPONS = tag("weapons/ranged");
+        public static final Tag<Item> BOWS = tag("weapons/bows");
+
+        public static final Tag<Item> ARMOR = tag("armor");
+        public static final Tag<Item> HELMETS = tag("armor/helmets");
+        public static final Tag<Item> CHESTPLATES = tag("armor/chestplates");
+        public static final Tag<Item> LEGGINGS = tag("armor/leggings");
+        public static final Tag<Item> BOOTS = tag("armor/boots");
+
+        public static final Tag<Item> ELYTRA = tag("elytra");
+
         private static Tag<Item> tag(String name)
         {
             return new ItemTags.Wrapper(new ResourceLocation("forge", name));

--- a/src/main/java/net/minecraftforge/common/data/ForgeItemTagsProvider.java
+++ b/src/main/java/net/minecraftforge/common/data/ForgeItemTagsProvider.java
@@ -141,6 +141,22 @@ public class ForgeItemTagsProvider extends ItemTagsProvider
         copy(Tags.Blocks.STORAGE_BLOCKS_QUARTZ, Tags.Items.STORAGE_BLOCKS_QUARTZ);
         copy(Tags.Blocks.STORAGE_BLOCKS_REDSTONE, Tags.Items.STORAGE_BLOCKS_REDSTONE);
         getBuilder(Tags.Items.STRING).add(Items.STRING);
+        getBuilder(Tags.Items.AXES).add(Items.WOODEN_AXE,Items.STONE_AXE,Items.IRON_AXE,Items.GOLDEN_AXE,Items.DIAMOND_AXE);
+        getBuilder(Tags.Items.PICKAXES).add(Items.WOODEN_PICKAXE,Items.STONE_PICKAXE,Items.IRON_PICKAXE,Items.GOLDEN_PICKAXE,Items.DIAMOND_PICKAXE);
+        getBuilder(Tags.Items.SHOVELS).add(Items.WOODEN_SHOVEL,Items.STONE_SHOVEL,Items.IRON_SHOVEL,Items.GOLDEN_SHOVEL,Items.DIAMOND_SHOVEL);
+        getBuilder(Tags.Items.HOES).add(Items.WOODEN_HOE,Items.STONE_HOE,Items.IRON_HOE,Items.GOLDEN_HOE,Items.DIAMOND_HOE);
+        getBuilder(Tags.Items.SHEARS).add(Items.SHEARS);
+        getBuilder(Tags.Items.TOOLS).add(Tags.Items.AXES,Tags.Items.PICKAXES,Tags.Items.SHOVELS,Tags.Items.HOES,Tags.Items.SHEARS);
+        getBuilder(Tags.Items.HELMETS).add(Items.LEATHER_HELMET,Items.CHAINMAIL_HELMET,Items.IRON_HELMET,Items.GOLDEN_HELMET,Items.DIAMOND_HELMET);
+        getBuilder(Tags.Items.CHESTPLATES).add(Items.LEATHER_CHESTPLATE,Items.CHAINMAIL_CHESTPLATE,Items.IRON_CHESTPLATE,Items.GOLDEN_CHESTPLATE,Items.DIAMOND_CHESTPLATE);
+        getBuilder(Tags.Items.LEGGINGS).add(Items.LEATHER_LEGGINGS,Items.CHAINMAIL_LEGGINGS,Items.IRON_LEGGINGS,Items.GOLDEN_LEGGINGS,Items.DIAMOND_LEGGINGS);
+        getBuilder(Tags.Items.BOOTS).add(Items.LEATHER_BOOTS,Items.CHAINMAIL_BOOTS,Items.IRON_BOOTS,Items.GOLDEN_BOOTS,Items.DIAMOND_BOOTS);
+        getBuilder(Tags.Items.ARMOR).add(Tags.Items.HELMETS,Tags.Items.CHESTPLATES,Tags.Items.LEGGINGS,Tags.Items.BOOTS);
+        getBuilder(Tags.Items.SWORDS).add(Items.WOODEN_SWORD,Items.STONE_SWORD,Items.IRON_SWORD,Items.GOLDEN_SWORD,Items.DIAMOND_SWORD);
+        getBuilder(Tags.Items.BOWS).add(Items.BOW,Items.CROSSBOW);
+        getBuilder(Tags.Items.RANGED_WEAPONS).add(Items.TRIDENT).add(Tags.Items.BOWS);
+        getBuilder(Tags.Items.WEAPONS).add(Tags.Items.SWORDS,Tags.Items.RANGED_WEAPONS);
+        getBuilder(Tags.Items.ELYTRA).add(Items.ELYTRA);
     }
 
     private void addColored(Consumer<Item> consumer, Tag<Item> group, String pattern)


### PR DESCRIPTION
Fixes previous PR, which added the tags manually, to now generate them automatically, with advice from reviewers.