### PR TITLE
Made the slash optional in fml confirm/cancel.

### DIFF
--- a/src/main/java/net/minecraftforge/fml/StartupQuery.java
+++ b/src/main/java/net/minecraftforge/fml/StartupQuery.java
@@ -280,22 +280,23 @@ public class StartupQuery {
                             for (Iterator<PendingCommand> it = dedServer.pendingCommandList.iterator(); it.hasNext(); )
                             {
                                 String cmd = it.next().command.trim().toLowerCase();
+                                cmd = cmd.charAt(0) == '/' ? cmd.substring(1) : cmd; // strip the forward slash to make it optional
 
-                                if (cmd.equals("/fml confirm"))
+                                if (cmd.equals("fml confirm"))
                                 {
                                     LOGGER.info(SQ, "confirmed");
                                     query.setResult(true);
                                     done = true;
                                     it.remove();
                                 }
-                                else if (cmd.equals("/fml cancel"))
+                                else if (cmd.equals("fml cancel"))
                                 {
                                     LOGGER.info(SQ, "cancelled");
                                     query.setResult(false);
                                     done = true;
                                     it.remove();
                                 }
-                                else if (cmd.equals("/stop"))
+                                else if (cmd.equals("stop"))
                                 {
                                     StartupQuery.abort();
                                 }

--- a/src/main/java/net/minecraftforge/registries/RegistryManager.java
+++ b/src/main/java/net/minecraftforge/registries/RegistryManager.java
@@ -87,12 +87,13 @@ public class RegistryManager
 
     public <V extends IForgeRegistryEntry<V>> ResourceLocation updateLegacyName(ResourceLocation legacyName)
     {
+        ResourceLocation originalName = legacyName;
         while (getRegistry(legacyName) == null)
         {
             legacyName = legacyNames.get(legacyName);
             if (legacyName == null)
             {
-                return null;
+                return originalName;
             }
         }
         return legacyName;

--- a/src/main/java/net/minecraftforge/registries/RegistryManager.java
+++ b/src/main/java/net/minecraftforge/registries/RegistryManager.java
@@ -87,13 +87,12 @@ public class RegistryManager
 
     public <V extends IForgeRegistryEntry<V>> ResourceLocation updateLegacyName(ResourceLocation legacyName)
     {
-        ResourceLocation originalName = legacyName;
         while (getRegistry(legacyName) == null)
         {
             legacyName = legacyNames.get(legacyName);
             if (legacyName == null)
             {
-                return originalName;
+                return null;
             }
         }
         return legacyName;


### PR DESCRIPTION
Missing registries in this case being registries renamed without proper remapping or created by mods that were removed.