### PR TITLE
Removed getTypes invocation from ensureHasTypes to prevent infinite recursion.

### DIFF
--- a/src/main/java/net/minecraftforge/common/BiomeDictionary.java
+++ b/src/main/java/net/minecraftforge/common/BiomeDictionary.java
@@ -338,7 +338,7 @@ public class BiomeDictionary
         if (!hasAnyType(biome))
         {
             makeBestGuess(biome);
-            LOGGER.warn("No types have been added to Biome {}, types have been assigned on a best-effort guess: {}", biome.getRegistryName(), getTypes(biome));
+            LOGGER.warn("No types have been added to Biome {}, types have been assigned on a best-effort guess: {}", biome.getRegistryName(), !getBiomeInfo(biome).types.isEmpty() ? getBiomeInfo(biome).types : "could not guess types");
         }
     }
 


### PR DESCRIPTION
The getTypes invocation has been replaced with a getBiomeInfo.types reference that is checked via ternary and reports if the set is empty.

This is likely to result in log spam if modders don't assign types to their biomes.

Infinite recursion went as follows:

1. `getTypes` is called
2. `getTypes` runs `ensureHasTypes`  to make sure it has something to return
3. `ensureHasTypes` checks if the biome has any types, it does not
4. `ensureHasTypes` calls `makeBestGuess`
5. `makeBestGuess` comes up dry (no types added)
6. `ensureHasTypes` attempts to write a log message listing the types added by `makeBestGuess`, utilizing `getTypes` to do so
7. Rinse and repeat

This should Fix #6283 